### PR TITLE
kernel: fix x86 stack protector with later GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,15 @@ zephyr_cc_option(-fno-pic)
 zephyr_cc_option(-fno-strict-overflow)
 zephyr_cc_option(-Wno-pointer-sign)
 
-zephyr_compile_options_ifdef(CONFIG_STACK_CANARIES -fstack-protector-all)
+if(CONFIG_STACK_CANARIES)
+  zephyr_cc_option(-fstack-protector-all)
+  # Only a valid option with GCC 7.x and above
+  check_c_compiler_flag(-mstack-protector-guard=global MSTACK_PROTECTOR_GUARD)
+
+  if(MSTACK_PROTECTOR_GUARD)
+    zephyr_cc_option(-mstack-protector-guard=global)
+  endif()
+endif()
 
 if(CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT)
   if(CONFIG_OMIT_FRAME_POINTER)


### PR DESCRIPTION
Newer versions of GCC default to using thread-local storage ABI
for the canary value instead of a global. We don't implement TLS
in Zephyr like this (at least for now) so specify that we want
to use the global instead.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>