### PR TITLE
dts: binding: Add mmio-sram binding

### DIFF
--- a/dts/bindings/sram/mmio-sram.yaml
+++ b/dts/bindings/sram/mmio-sram.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2018, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: Generic on-chip SRAM
+version: 0.1
+
+description: >
+    This binding gives a generic on-chip SRAM description
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "mmio-sram"
+      generation: define
+
+    reg:
+      type: array
+      description: mmio register space
+      generation: define
+      category: required
+
+    label:
+      type: string
+      category: optional
+      description: Human readable string describing the device (used by Zephyr for API name)
+      generation: define
+
+...


### PR DESCRIPTION
Add mmio-sram binding so we generate defines for on-chip SRAMs

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>