### PR TITLE
dts: Add binding for NXP i.MX RT itcm/dtcm memories

### DIFF
--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -30,14 +30,17 @@
 			#size-cells = <1>;
 
 			itcm0: itcm@0 {
+				compatible = "nxp,imx-rt-itcm";
 				reg = <0x00000000 0x20000>;
 			};
 
 			dtcm0: dtcm@20000000 {
+				compatible = "nxp,imx-rt-dtcm";
 				reg = <0x20000000 0x20000>;
 			};
 
 			ocram0: ocram@20200000 {
+				compatible = "mmio-sram";
 				reg = <0x20200000 0x40000>;
 			};
 		};

--- a/dts/bindings/arm/nxp,imx-rt-dtcm.yaml
+++ b/dts/bindings/arm/nxp,imx-rt-dtcm.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2018, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: i.MX RT DTCM (Data Tightly Coupled Memory)
+version: 0.1
+
+description: >
+  This binding gives a base representation of the i.MX-RT DTCM
+
+properties:
+    compatible:
+      type: string
+      category: required
+      constraint: "nxp,imx-rt-dtcm"
+      generation: define
+
+    reg:
+      type: int
+      description: mmio register space
+      generation: define
+      category: required
+
+...

--- a/dts/bindings/arm/nxp,imx-rt-itcm.yaml
+++ b/dts/bindings/arm/nxp,imx-rt-itcm.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2018, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: i.MX RT ITCM (Instruction Tightly Coupled Memory)
+version: 0.1
+
+description: >
+  This binding gives a base representation of the i.MX-RT ITCM
+
+properties:
+    compatible:
+      type: string
+      category: required
+      constraint: "nxp,imx-rt-itcm"
+      generation: define
+
+    reg:
+      type: int
+      description: mmio register space
+      generation: define
+      category: required
+
+...


### PR DESCRIPTION
Add comptiable into the device tree and associated binding files for NXP
i.MX RT ITCM/DTCM memory regions.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>