### PR TITLE
scripts: extract_dts_includes: Generate defines for chosen props

### DIFF
--- a/doc/devices/dts/device_tree.rst
+++ b/doc/devices/dts/device_tree.rst
@@ -308,6 +308,11 @@ The full set of Zephyr-specific ``chosen`` nodes follows:
    * - ``zephyr,uart-mcumgr``
      - :option:`CONFIG_UART_MCUMGR_ON_DEV_NAME`
 
+As chosen properties tend to be related to software configuration, it can be
+useful for the build system to know if a chosen property was defined. We
+generate a define for each chosen property, for example:
+
+``zephyr,flash`` will generate: ``#define DT_CHOSEN_ZEPHYR_FLASH 1``
 
 Adding support for device tree in drivers
 *****************************************

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -743,6 +743,14 @@ def main():
 
     defs = generate_node_definitions()
 
+    # Add DT_CHOSEN_<X> defines to generated files
+    for c in sorted(chosen.keys()):
+        chosen_def = 'DT_CHOSEN_' + convert_string_to_label(c)
+        load_defs = {
+            chosen_def: "1",
+        }
+        insert_defs('chosen', load_defs, {})
+
      # generate config and include file
     generate_keyvalue_file(args.keyvalue[0])
 


### PR DESCRIPTION
Generate a set of defines that convey if a given chosen property is used
or not.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>