### PR TITLE
drivers: i2c_ll_stm32_v2: Handle NACK during address tranmsission

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -537,7 +537,9 @@ int stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 	len = msg->len;
 	while (len) {
 		while (!LL_I2C_IsActiveFlag_RXNE(i2c)) {
-			;
+			if (LL_I2C_IsActiveFlag_NACK(i2c)) {
+				goto error;
+			}
 		}
 
 		*buf = LL_I2C_ReceiveData8(i2c);
@@ -548,6 +550,11 @@ int stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 	msg_done(dev, msg->flags);
 
 	return 0;
+error:
+	LL_I2C_ClearFlag_NACK(i2c);
+	LOG_DBG("%s: NACK", __func__);
+
+	return -EIO;
 }
 #endif
 


### PR DESCRIPTION
In polling mode, if a NACK is received during address transmission
stm32_i2c_msg_read() will spin forever because RXNE will never be
set. We need to check NACK flag and stop the transmission if it is
set.

Fixes #9174

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>