### PR TITLE
kernel: check retval of driver init

### DIFF
--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -105,12 +105,6 @@ static int i2c_gpio_init(struct device *dev)
 
 	i2c_bitbang_init(&context->bitbang, &io_fns, context);
 
-	/*
-	 * Set driver_api at very end of init so if we return early with error
-	 * then the device can't be found later by device_get_binding. This is
-	 * important because driver framework ignores errors from init
-	 * functions.
-	 */
 	dev->driver_api = &api;
 
 	return 0;

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -50,10 +50,18 @@ void _sys_device_do_config_level(s32_t level)
 
 	for (info = config_levels[level]; info < config_levels[level+1];
 								info++) {
+		int retval;
 		struct device_config *device_conf = info->config;
 
-		(void)device_conf->init(info);
-		_k_object_init(info);
+		retval = device_conf->init(info);
+		if (retval != 0) {
+			/* Initialization failed. Clear the API struct so that
+			 * device_get_binding() will not succeed for it.
+			 */
+			info->driver_api = NULL;
+		} else {
+			_k_object_init(info);
+		}
 	}
 }
 


### PR DESCRIPTION
If initialization fails, zero the API struct so that
device_get_binding() can't fetch it, and do not mark
the driver object as initialized to user mode.

Prevents issues where a user thread could crash the kernel
by making driver API calls on a driver which didn't
succeed initialization.

Fixes #3079 

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>