### PR TITLE
Revert "interrupts: use weak linkage instead ..."

### DIFF
--- a/arch/common/isr_tables.c
+++ b/arch/common/isr_tables.c
@@ -48,7 +48,7 @@ u32_t __irq_vector_table _irq_vector_table[IRQ_TABLE_SIZE] = {
  * type and bypass the _sw_isr_table, then do not generate one.
  */
 #ifdef CONFIG_GEN_SW_ISR_TABLE
-struct _isr_table_entry __weak __sw_isr_table _sw_isr_table[IRQ_TABLE_SIZE] = {
+struct _isr_table_entry __sw_isr_table _sw_isr_table[IRQ_TABLE_SIZE] = {
 	[0 ...(IRQ_TABLE_SIZE - 1)] = {(void *)0x42, (void *)&_irq_spurious},
 };
 #endif

--- a/include/linker/sections.h
+++ b/include/linker/sections.h
@@ -46,7 +46,7 @@
 
 /* Interrupts */
 #define IRQ_VECTOR_TABLE	.gnu.linkonce.irq_vector_table
-#define SW_ISR_TABLE		.sw_isr_table
+#define SW_ISR_TABLE		.gnu.linkonce.sw_isr_table
 
 /* Architecture-specific sections */
 #if defined(CONFIG_ARM)


### PR DESCRIPTION
This reverts commit 140863f6a753f3ab169e0faee79463e977c1364f.

This was found to be causing problems with certain linkers which
generate different code depending on whether a symbol is weak or
not.

Fixes #11916

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>