### PR TITLE
userspace: eliminate warning in process_gperf.py

### DIFF
--- a/scripts/process_gperf.py
+++ b/scripts/process_gperf.py
@@ -101,7 +101,7 @@ def process_line(line, fp):
 
     # Replace length lookups with constant len of 4 since we're always
     # looking at pointers
-    line = re.sub(r'lengthtable[[]key[]]', r'4', line)
+    line = re.sub(r'lengthtable\[key\]', r'4', line)
 
     # Empty wordlist entries to have NULLs instead of ""
     line = re.sub(r'[{]["]["][}]', r'{}', line)


### PR DESCRIPTION
Python 3.7 throws a FutureWarning when it thinks it
has found a nested set in a regular expression.

We weren't actually; just trying to match some brackets.
Escape them instead. No functional difference.

Fixes: #11961

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>