### PR TITLE
drivers: spi: Release driver context for Nordic SoCs 

### DIFF
--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -150,11 +150,10 @@ static void transfer_next_chunk(struct device *dev)
 		xfer.p_rx_buffer = ctx->rx_buf;
 		xfer.rx_length   = spi_context_rx_buf_on(ctx) ? chunk_len : 0;
 		result = nrfx_spi_xfer(&get_dev_config(dev)->spi, &xfer, 0);
-		if (result == NRFX_SUCCESS) {
-			return;
-		}
 
-		error = -EIO;
+		if (result != NRFX_SUCCESS) {
+			error = -EIO;
+		}
 	}
 
 	spi_context_cs_control(ctx, false);

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -179,11 +179,10 @@ static void transfer_next_chunk(struct device *dev)
 		xfer.p_rx_buffer = ctx->rx_buf;
 		xfer.rx_length   = spi_context_rx_buf_on(ctx) ? chunk_len : 0;
 		result = nrfx_spim_xfer(&dev_config->spim, &xfer, 0);
-		if (result == NRFX_SUCCESS) {
-			return;
-		}
 
-		error = -EIO;
+		if (result != NRFX_SUCCESS) {
+			error = -EIO;
+		}
 	}
 
 	spi_context_cs_control(ctx, false);


### PR DESCRIPTION
Do not return immediately in transfer_next_chunk on successful transfer

Fixes #11967