### PR TITLE
drivers: led_strip: Fix typo in APA102 driver causing compile error

### DIFF
--- a/drivers/led_strip/apa102.c
+++ b/drivers/led_strip/apa102.c
@@ -40,7 +40,7 @@ static int apa102_update(struct device *dev, void *buf, size_t size)
 	};
 	const struct spi_buf_set tx = {
 		.buffers = tx_bufs,
-		.count = ARRAY_SIZE(tx)
+		.count = ARRAY_SIZE(tx_bufs)
 	};
 
 	return spi_write(data->spi, &data->cfg, &tx);


### PR DESCRIPTION
This typo was causing a compile error when ever the APA102 led_strip driver was enabled.