### PR TITLE
RFC: Renaming PM APIs

### DIFF
--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -90,7 +90,7 @@ done_cache_invalidate:
 
 #if defined(CONFIG_SYS_POWER_DEEP_SLEEP) && \
 	!defined(CONFIG_BOOTLOADER_CONTEXT_RESTORE)
-        jl @sys_soc_resume_from_deep_sleep
+        jl @sys_resume_from_deep_sleep
 #endif
 
 #ifdef CONFIG_INIT_STACKS

--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -90,7 +90,7 @@ done_cache_invalidate:
 
 #if defined(CONFIG_SYS_POWER_DEEP_SLEEP) && \
 	!defined(CONFIG_BOOTLOADER_CONTEXT_RESTORE)
-        jl @_sys_soc_resume_from_deep_sleep
+        jl @sys_soc_resume_from_deep_sleep
 #endif
 
 #ifdef CONFIG_INIT_STACKS

--- a/arch/x86/core/crt0.S
+++ b/arch/x86/core/crt0.S
@@ -39,7 +39,7 @@
 #endif
 
 #ifdef CONFIG_SYS_POWER_DEEP_SLEEP
-	GTEXT(_sys_soc_resume_from_deep_sleep)
+	GTEXT(sys_soc_resume_from_deep_sleep)
 #endif
 
 #ifdef CONFIG_REALMODE
@@ -255,13 +255,13 @@ __csSet:
 	 * the ISR stack size are some multiple of STACK_ALIGN, which
 	 * is at least 4.
 	 *
-	 * This is also used to call the _sys_soc_resume_from_deep_sleep()
+	 * This is also used to call the sys_soc_resume_from_deep_sleep()
 	 * routine to avoid memory corruption if the system is resuming from
-	 * deep sleep. It is important that _sys_soc_resume_from_deep_sleep()
+	 * deep sleep. It is important that sys_soc_resume_from_deep_sleep()
 	 * restores the stack pointer to what it was at deep sleep before
          * enabling interrupts.  This is necessary to avoid
 	 * interfering with interrupt handler use of this stack.
-	 * If it is a cold boot then _sys_soc_resume_from_deep_sleep() should
+	 * If it is a cold boot then sys_soc_resume_from_deep_sleep() should
 	 * not do anything and must return immediately.
 	 */
 #ifdef CONFIG_INIT_STACKS
@@ -287,7 +287,7 @@ __csSet:
 #if defined(CONFIG_SYS_POWER_DEEP_SLEEP) && \
              !defined(CONFIG_BOOTLOADER_CONTEXT_RESTORE)
 	/*
-	 * Invoke _sys_soc_resume_from_deep_sleep() hook to handle resume from
+	 * Invoke sys_soc_resume_from_deep_sleep() hook to handle resume from
 	 * deep sleep. It should first check whether system is recovering from
 	 * deep sleep state. If it is, then this function should restore
 	 * states and resume at the point system went to deep sleep.
@@ -298,7 +298,7 @@ __csSet:
 	 * return and execution falls through to cold boot path.
 	 */
 
-	call _sys_soc_resume_from_deep_sleep
+	call sys_soc_resume_from_deep_sleep
 
 #endif
 

--- a/arch/x86/core/crt0.S
+++ b/arch/x86/core/crt0.S
@@ -39,7 +39,7 @@
 #endif
 
 #ifdef CONFIG_SYS_POWER_DEEP_SLEEP
-	GTEXT(sys_soc_resume_from_deep_sleep)
+	GTEXT(sys_resume_from_deep_sleep)
 #endif
 
 #ifdef CONFIG_REALMODE
@@ -255,13 +255,13 @@ __csSet:
 	 * the ISR stack size are some multiple of STACK_ALIGN, which
 	 * is at least 4.
 	 *
-	 * This is also used to call the sys_soc_resume_from_deep_sleep()
+	 * This is also used to call the sys_resume_from_deep_sleep()
 	 * routine to avoid memory corruption if the system is resuming from
-	 * deep sleep. It is important that sys_soc_resume_from_deep_sleep()
+	 * deep sleep. It is important that sys_resume_from_deep_sleep()
 	 * restores the stack pointer to what it was at deep sleep before
          * enabling interrupts.  This is necessary to avoid
 	 * interfering with interrupt handler use of this stack.
-	 * If it is a cold boot then sys_soc_resume_from_deep_sleep() should
+	 * If it is a cold boot then sys_resume_from_deep_sleep() should
 	 * not do anything and must return immediately.
 	 */
 #ifdef CONFIG_INIT_STACKS
@@ -287,7 +287,7 @@ __csSet:
 #if defined(CONFIG_SYS_POWER_DEEP_SLEEP) && \
              !defined(CONFIG_BOOTLOADER_CONTEXT_RESTORE)
 	/*
-	 * Invoke sys_soc_resume_from_deep_sleep() hook to handle resume from
+	 * Invoke sys_resume_from_deep_sleep() hook to handle resume from
 	 * deep sleep. It should first check whether system is recovering from
 	 * deep sleep state. If it is, then this function should restore
 	 * states and resume at the point system went to deep sleep.
@@ -298,7 +298,7 @@ __csSet:
 	 * return and execution falls through to cold boot path.
 	 */
 
-	call sys_soc_resume_from_deep_sleep
+	call sys_resume_from_deep_sleep
 
 #endif
 

--- a/doc/subsystems/power_management.rst
+++ b/doc/subsystems/power_management.rst
@@ -103,10 +103,10 @@ Suspend Hook function
 
 .. code-block:: c
 
-   int _sys_soc_suspend(s32_t ticks);
+   int sys_soc_suspend(s32_t ticks);
 
 When the kernel is about to go idle, the power management subsystem calls the
-:code:`_sys_soc_suspend()` function, notifying the SOC interface that the kernel
+:code:`sys_soc_suspend()` function, notifying the SOC interface that the kernel
 is ready to enter the idle state.
 
 At this point, the kernel has disabled interrupts and computed the maximum
@@ -116,7 +116,7 @@ can be done in the available time. The power management operation must halt
 execution on a CPU or SOC low power state. Before entering the low power state,
 the SOC interface must setup a wake event.
 
-The power management subsystem expects the :code:`_sys_soc_suspend()` to
+The power management subsystem expects the :code:`sys_soc_suspend()` to
 return one of the following values based on the power management operations
 the SOC interface executed:
 
@@ -137,22 +137,22 @@ Resume Hook function
 
 .. code-block:: c
 
-   void _sys_soc_resume(void);
+   void sys_soc_resume(void);
 
 The power management subsystem optionally calls this hook function when exiting
 kernel idling if power management operations were performed in
-:code:`_sys_soc_suspend()`. Any necessary recovery operations can be performed
+:code:`sys_soc_suspend()`. Any necessary recovery operations can be performed
 in this function before the kernel scheduler schedules another thread. Some
 power states may not need this notification. It can be disabled by calling
-:code:`_sys_soc_pm_idle_exit_notification_disable()` from
-:code:`_sys_soc_suspend()`.
+:code:`sys_soc_pm_idle_exit_notification_disable()` from
+:code:`sys_soc_suspend()`.
 
 Resume From Deep Sleep Hook function
 ====================================
 
 .. code-block:: c
 
-   void _sys_soc_resume_from_deep_sleep(void);
+   void sys_soc_resume_from_deep_sleep(void);
 
 This function is optionally called when exiting from deep sleep if the SOC
 interface does not have bootloader support to handle resume from deep sleep.
@@ -231,7 +231,7 @@ in power saving mode. This method allows saving power even when the CPU is
 active. The components that use the devices need to be power aware and should
 be able to make decisions related to managing device power. In this method, the
 SOC interface can enter CPU or SOC low power states quickly when
-:code:`_sys_soc_suspend()` gets called. This is because it does not need to
+:code:`sys_soc_suspend()` gets called. This is because it does not need to
 spend time doing device power management if the devices are already put in
 the appropriate low power state by the application or component managing the
 devices.
@@ -240,7 +240,7 @@ Central method
 ==============
 
 In this method device power management is mostly done inside
-:code:`_sys_soc_suspend()` along with entering a CPU or SOC low power state.
+:code:`sys_soc_suspend()` along with entering a CPU or SOC low power state.
 
 If a decision to enter deep sleep is made, the implementation would enter it
 only after checking if the devices are not in the middle of a hardware
@@ -380,21 +380,21 @@ off, then such transactions would be left in an inconsistent state. This
 infrastructure guards such transactions by indicating to the SOC interface that
 the device is in the middle of a hardware transaction.
 
-When the :code:`_sys_soc_suspend()` is called, the SOC interface checks if any device
+When the :code:`sys_soc_suspend()` is called, the SOC interface checks if any device
 is busy. The SOC interface can then decide to execute a power management scheme other than deep sleep or
 to defer power management operations until the next call of
-:code:`_sys_soc_suspend()`.
+:code:`sys_soc_suspend()`.
 
 An alternative to using the busy status mechanism is to use the
 `distributed method`_ of device power management. In such a method where the
 device power management is handled in a distributed manner rather than centrally in
-:code:`_sys_soc_suspend()`, the decision to enter deep sleep can be made based
+:code:`sys_soc_suspend()`, the decision to enter deep sleep can be made based
 on whether all devices are already turned off.
 
 This feature can be also used to emulate a hardware feature found in some SOCs
 that causes the system to automatically enter deep sleep when all devices are idle.
 In such an usage, the busy status can be set by default and cleared as each
-device becomes idle. When :code:`_sys_soc_suspend()` is called, deep sleep can
+device becomes idle. When :code:`sys_soc_suspend()` is called, deep sleep can
 be entered if no device is found to be busy.
 
 Here are the APIs used to set, clear, and check the busy status of devices.

--- a/doc/subsystems/power_management.rst
+++ b/doc/subsystems/power_management.rst
@@ -103,10 +103,10 @@ Suspend Hook function
 
 .. code-block:: c
 
-   int sys_soc_suspend(s32_t ticks);
+   int sys_suspend(s32_t ticks);
 
 When the kernel is about to go idle, the power management subsystem calls the
-:code:`sys_soc_suspend()` function, notifying the SOC interface that the kernel
+:code:`sys_suspend()` function, notifying the SOC interface that the kernel
 is ready to enter the idle state.
 
 At this point, the kernel has disabled interrupts and computed the maximum
@@ -116,7 +116,7 @@ can be done in the available time. The power management operation must halt
 execution on a CPU or SOC low power state. Before entering the low power state,
 the SOC interface must setup a wake event.
 
-The power management subsystem expects the :code:`sys_soc_suspend()` to
+The power management subsystem expects the :code:`sys_suspend()` to
 return one of the following values based on the power management operations
 the SOC interface executed:
 
@@ -137,22 +137,22 @@ Resume Hook function
 
 .. code-block:: c
 
-   void sys_soc_resume(void);
+   void sys_resume(void);
 
 The power management subsystem optionally calls this hook function when exiting
 kernel idling if power management operations were performed in
-:code:`sys_soc_suspend()`. Any necessary recovery operations can be performed
+:code:`sys_suspend()`. Any necessary recovery operations can be performed
 in this function before the kernel scheduler schedules another thread. Some
 power states may not need this notification. It can be disabled by calling
-:code:`sys_soc_pm_idle_exit_notification_disable()` from
-:code:`sys_soc_suspend()`.
+:code:`sys_pm_idle_exit_notification_disable()` from
+:code:`sys_suspend()`.
 
 Resume From Deep Sleep Hook function
 ====================================
 
 .. code-block:: c
 
-   void sys_soc_resume_from_deep_sleep(void);
+   void sys_resume_from_deep_sleep(void);
 
 This function is optionally called when exiting from deep sleep if the SOC
 interface does not have bootloader support to handle resume from deep sleep.
@@ -231,7 +231,7 @@ in power saving mode. This method allows saving power even when the CPU is
 active. The components that use the devices need to be power aware and should
 be able to make decisions related to managing device power. In this method, the
 SOC interface can enter CPU or SOC low power states quickly when
-:code:`sys_soc_suspend()` gets called. This is because it does not need to
+:code:`sys_suspend()` gets called. This is because it does not need to
 spend time doing device power management if the devices are already put in
 the appropriate low power state by the application or component managing the
 devices.
@@ -240,7 +240,7 @@ Central method
 ==============
 
 In this method device power management is mostly done inside
-:code:`sys_soc_suspend()` along with entering a CPU or SOC low power state.
+:code:`sys_suspend()` along with entering a CPU or SOC low power state.
 
 If a decision to enter deep sleep is made, the implementation would enter it
 only after checking if the devices are not in the middle of a hardware
@@ -380,21 +380,21 @@ off, then such transactions would be left in an inconsistent state. This
 infrastructure guards such transactions by indicating to the SOC interface that
 the device is in the middle of a hardware transaction.
 
-When the :code:`sys_soc_suspend()` is called, the SOC interface checks if any device
+When the :code:`sys_suspend()` is called, the SOC interface checks if any device
 is busy. The SOC interface can then decide to execute a power management scheme other than deep sleep or
 to defer power management operations until the next call of
-:code:`sys_soc_suspend()`.
+:code:`sys_suspend()`.
 
 An alternative to using the busy status mechanism is to use the
 `distributed method`_ of device power management. In such a method where the
 device power management is handled in a distributed manner rather than centrally in
-:code:`sys_soc_suspend()`, the decision to enter deep sleep can be made based
+:code:`sys_suspend()`, the decision to enter deep sleep can be made based
 on whether all devices are already turned off.
 
 This feature can be also used to emulate a hardware feature found in some SOCs
 that causes the system to automatically enter deep sleep when all devices are idle.
 In such an usage, the busy status can be set by default and cleared as each
-device becomes idle. When :code:`sys_soc_suspend()` is called, deep sleep can
+device becomes idle. When :code:`sys_suspend()` is called, deep sleep can
 be entered if no device is found to be busy.
 
 Here are the APIs used to set, clear, and check the busy status of devices.

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -433,7 +433,7 @@ static int i2c_dw_transfer(struct device *dev,
 
 	/*
 	 * While waiting at device_sync_sem, kernel can switch to idle
-	 * task which in turn can call _sys_soc_suspend() hook of Power
+	 * task which in turn can call sys_soc_suspend() hook of Power
 	 * Management App (PMA).
 	 * device_busy_set() call here, would indicate to PMA that it should not
 	 * execute PM policies that would turn off this ip block, causing an

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -433,7 +433,7 @@ static int i2c_dw_transfer(struct device *dev,
 
 	/*
 	 * While waiting at device_sync_sem, kernel can switch to idle
-	 * task which in turn can call sys_soc_suspend() hook of Power
+	 * task which in turn can call sys_suspend() hook of Power
 	 * Management App (PMA).
 	 * device_busy_set() call here, would indicate to PMA that it should not
 	 * execute PM policies that would turn off this ip block, causing an

--- a/include/power.h
+++ b/include/power.h
@@ -20,7 +20,7 @@ extern "C" {
 
 #define SYS_PM_NOT_HANDLED		SYS_PM_ACTIVE_STATE
 
-extern unsigned char _sys_pm_idle_exit_notify;
+extern unsigned char sys_pm_idle_exit_notify;
 
 /**
  * @brief Power Management Hook Interface
@@ -33,15 +33,15 @@ extern unsigned char _sys_pm_idle_exit_notify;
 /**
  * @brief Function to disable power management idle exit notification
  *
- * _sys_soc_resume() would be called from the ISR of the event that caused
+ * sys_soc_resume() would be called from the ISR of the event that caused
  * exit from kernel idling after PM operations. For some power operations,
  * this notification may not be necessary. This function can be called in
- * _sys_soc_suspend to disable the corresponding _sys_soc_resume notification.
+ * sys_soc_suspend to disable the corresponding sys_soc_resume notification.
  *
  */
-static inline void _sys_soc_pm_idle_exit_notification_disable(void)
+static inline void sys_soc_pm_idle_exit_notification_disable(void)
 {
-	_sys_pm_idle_exit_notify = 0;
+	sys_pm_idle_exit_notify = 0;
 }
 
 /**
@@ -59,13 +59,13 @@ static inline void _sys_soc_pm_idle_exit_notification_disable(void)
  * function should return immediately.
  *
  */
-void _sys_soc_resume_from_deep_sleep(void);
+void sys_soc_resume_from_deep_sleep(void);
 
 /**
  * @brief Hook function to notify exit from kernel idling after PM operations
  *
  * This function would notify exit from kernel idling if a corresponding
- * _sys_soc_suspend() notification was handled and did not return
+ * sys_soc_suspend() notification was handled and did not return
  * SYS_PM_NOT_HANDLED.
  *
  * This function would be called from the ISR context of the event
@@ -77,11 +77,11 @@ void _sys_soc_resume_from_deep_sleep(void);
  * those cases, the ISR would be invoked immediately after the event wakes up
  * the CPU, before code following the CPU wait, gets a chance to execute. This
  * can be ignored if no operation needs to be done at the wake event
- * notification. Alternatively _sys_soc_pm_idle_exit_notification_disable() can
- * be called in _sys_soc_suspend to disable this notification.
+ * notification. Alternatively sys_soc_pm_idle_exit_notification_disable() can
+ * be called in sys_soc_suspend to disable this notification.
  *
  */
-void _sys_soc_resume(void);
+void sys_soc_resume(void);
 
 /**
  * @brief Hook function to allow entry to low power state
@@ -109,7 +109,7 @@ void _sys_soc_resume(void);
  * @retval SYS_PM_LOW_POWER_STATE If CPU low power state was entered.
  * @retval SYS_PM_DEEP_SLEEP If SOC low power state was entered.
  */
-extern int _sys_soc_suspend(s32_t ticks);
+extern int sys_soc_suspend(s32_t ticks);
 
 #ifdef CONFIG_PM_CONTROL_OS_DEBUG
 /**

--- a/include/power.h
+++ b/include/power.h
@@ -33,13 +33,13 @@ extern unsigned char sys_pm_idle_exit_notify;
 /**
  * @brief Function to disable power management idle exit notification
  *
- * sys_soc_resume() would be called from the ISR of the event that caused
+ * sys_resume() would be called from the ISR of the event that caused
  * exit from kernel idling after PM operations. For some power operations,
  * this notification may not be necessary. This function can be called in
- * sys_soc_suspend to disable the corresponding sys_soc_resume notification.
+ * sys_suspend to disable the corresponding sys_resume notification.
  *
  */
-static inline void sys_soc_pm_idle_exit_notification_disable(void)
+static inline void sys_pm_idle_exit_notification_disable(void)
 {
 	sys_pm_idle_exit_notify = 0;
 }
@@ -59,13 +59,13 @@ static inline void sys_soc_pm_idle_exit_notification_disable(void)
  * function should return immediately.
  *
  */
-void sys_soc_resume_from_deep_sleep(void);
+void sys_resume_from_deep_sleep(void);
 
 /**
  * @brief Hook function to notify exit from kernel idling after PM operations
  *
  * This function would notify exit from kernel idling if a corresponding
- * sys_soc_suspend() notification was handled and did not return
+ * sys_suspend() notification was handled and did not return
  * SYS_PM_NOT_HANDLED.
  *
  * This function would be called from the ISR context of the event
@@ -77,11 +77,11 @@ void sys_soc_resume_from_deep_sleep(void);
  * those cases, the ISR would be invoked immediately after the event wakes up
  * the CPU, before code following the CPU wait, gets a chance to execute. This
  * can be ignored if no operation needs to be done at the wake event
- * notification. Alternatively sys_soc_pm_idle_exit_notification_disable() can
- * be called in sys_soc_suspend to disable this notification.
+ * notification. Alternatively sys_pm_idle_exit_notification_disable() can
+ * be called in sys_suspend to disable this notification.
  *
  */
-void sys_soc_resume(void);
+void sys_resume(void);
 
 /**
  * @brief Hook function to allow entry to low power state
@@ -109,7 +109,7 @@ void sys_soc_resume(void);
  * @retval SYS_PM_LOW_POWER_STATE If CPU low power state was entered.
  * @retval SYS_PM_DEEP_SLEEP If SOC low power state was entered.
  */
-extern int sys_soc_suspend(s32_t ticks);
+extern int sys_suspend(s32_t ticks);
 
 #ifdef CONFIG_PM_CONTROL_OS_DEBUG
 /**

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -21,19 +21,19 @@
 
 #ifdef CONFIG_SYS_POWER_MANAGEMENT
 /*
- * Used to allow sys_soc_suspend() implementation to control notification
+ * Used to allow sys_suspend() implementation to control notification
  * of the event that caused exit from kernel idling after pm operations.
  */
 unsigned char sys_pm_idle_exit_notify;
 
 #if defined(CONFIG_SYS_POWER_LOW_POWER_STATE)
-void __attribute__((weak)) sys_soc_resume(void)
+void __attribute__((weak)) sys_resume(void)
 {
 }
 #endif
 
 #if defined(CONFIG_SYS_POWER_DEEP_SLEEP)
-void __attribute__((weak)) sys_soc_resume_from_deep_sleep(void)
+void __attribute__((weak)) sys_resume_from_deep_sleep(void)
 {
 }
 #endif
@@ -92,7 +92,7 @@ static void sys_power_save_idle(void)
 	 * idle processing re-enables interrupts which is essential for
 	 * the kernel's scheduling logic.
 	 */
-	if (sys_soc_suspend(ticks) == SYS_PM_NOT_HANDLED) {
+	if (sys_suspend(ticks) == SYS_PM_NOT_HANDLED) {
 		sys_pm_idle_exit_notify = 0U;
 		k_cpu_idle();
 	}
@@ -108,11 +108,11 @@ void _sys_power_save_idle_exit(s32_t ticks)
 	/* Some CPU low power states require notification at the ISR
 	 * to allow any operations that needs to be done before kernel
 	 * switches task or processes nested interrupts. This can be
-	 * disabled by calling sys_soc_pm_idle_exit_notification_disable().
+	 * disabled by calling sys_pm_idle_exit_notification_disable().
 	 * Alternatively it can be simply ignored if not required.
 	 */
 	if (sys_pm_idle_exit_notify) {
-		sys_soc_resume();
+		sys_resume();
 	}
 #endif
 

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -21,19 +21,19 @@
 
 #ifdef CONFIG_SYS_POWER_MANAGEMENT
 /*
- * Used to allow _sys_soc_suspend() implementation to control notification
+ * Used to allow sys_soc_suspend() implementation to control notification
  * of the event that caused exit from kernel idling after pm operations.
  */
-unsigned char _sys_pm_idle_exit_notify;
+unsigned char sys_pm_idle_exit_notify;
 
 #if defined(CONFIG_SYS_POWER_LOW_POWER_STATE)
-void __attribute__((weak)) _sys_soc_resume(void)
+void __attribute__((weak)) sys_soc_resume(void)
 {
 }
 #endif
 
 #if defined(CONFIG_SYS_POWER_DEEP_SLEEP)
-void __attribute__((weak)) _sys_soc_resume_from_deep_sleep(void)
+void __attribute__((weak)) sys_soc_resume_from_deep_sleep(void)
 {
 }
 #endif
@@ -77,7 +77,7 @@ static void sys_power_save_idle(void)
 #if (defined(CONFIG_SYS_POWER_LOW_POWER_STATE) || \
 	defined(CONFIG_SYS_POWER_DEEP_SLEEP))
 
-	_sys_pm_idle_exit_notify = 1U;
+	sys_pm_idle_exit_notify = 1U;
 
 	/*
 	 * Call the suspend hook function of the soc interface to allow
@@ -92,8 +92,8 @@ static void sys_power_save_idle(void)
 	 * idle processing re-enables interrupts which is essential for
 	 * the kernel's scheduling logic.
 	 */
-	if (_sys_soc_suspend(ticks) == SYS_PM_NOT_HANDLED) {
-		_sys_pm_idle_exit_notify = 0U;
+	if (sys_soc_suspend(ticks) == SYS_PM_NOT_HANDLED) {
+		sys_pm_idle_exit_notify = 0U;
 		k_cpu_idle();
 	}
 #else
@@ -108,11 +108,11 @@ void _sys_power_save_idle_exit(s32_t ticks)
 	/* Some CPU low power states require notification at the ISR
 	 * to allow any operations that needs to be done before kernel
 	 * switches task or processes nested interrupts. This can be
-	 * disabled by calling _sys_soc_pm_idle_exit_notification_disable().
+	 * disabled by calling sys_soc_pm_idle_exit_notification_disable().
 	 * Alternatively it can be simply ignored if not required.
 	 */
-	if (_sys_pm_idle_exit_notify) {
-		_sys_soc_resume();
+	if (sys_pm_idle_exit_notify) {
+		sys_soc_resume();
 	}
 #endif
 

--- a/samples/boards/nrf52/power_mgr/README.rst
+++ b/samples/boards/nrf52/power_mgr/README.rst
@@ -10,7 +10,7 @@ This sample demonstrates a power manager app that uses the Zephyr
 power management infrastructure to enter into Low Power state.
 
 This app will cycle through the following power schemes each time idle thread
-calls sys_soc_suspend() hook function :
+calls sys_suspend() hook function :
 
 1. Low Power State: Low Power State is SOC specific and being in this state is
    transparent to devices. SOC and devices do not lose context in this Mode.

--- a/samples/boards/nrf52/power_mgr/README.rst
+++ b/samples/boards/nrf52/power_mgr/README.rst
@@ -10,7 +10,7 @@ This sample demonstrates a power manager app that uses the Zephyr
 power management infrastructure to enter into Low Power state.
 
 This app will cycle through the following power schemes each time idle thread
-calls _sys_soc_suspend() hook function :
+calls sys_soc_suspend() hook function :
 
 1. Low Power State: Low Power State is SOC specific and being in this state is
    transparent to devices. SOC and devices do not lose context in this Mode.

--- a/samples/boards/nrf52/power_mgr/src/power.c
+++ b/samples/boards/nrf52/power_mgr/src/power.c
@@ -68,7 +68,7 @@ static int low_power_state_entry(void)
 	} else {
 		printk("--> Entering into Low Power State -");
 	}
-	sys_soc_set_power_state(pm_state);
+	sys_set_power_state(pm_state);
 	return SYS_PM_LOW_POWER_STATE;
 }
 
@@ -83,24 +83,24 @@ static int low_power_suspend_entry(void)
 {
 	printk("--> Entering into Deep Sleep State -");
 	/* Don't need pm idle exit event notification */
-	sys_soc_pm_idle_exit_notification_disable();
+	sys_pm_idle_exit_notification_disable();
 	/* Save device states and turn off peripherals as necessary */
 	suspend_devices();
-	sys_soc_set_power_state(SYS_POWER_STATE_DEEP_SLEEP);
+	sys_set_power_state(SYS_POWER_STATE_DEEP_SLEEP);
 	 /* Exiting from Deep Sleep State */
 	low_power_suspend_exit();
 
 	return SYS_PM_DEEP_SLEEP;
 }
 
-/* Function name : sys_soc_suspend
+/* Function name : sys_suspend
  * Return Value : Power Mode Entered Success/Failure
  * Input : Idleness in number of Ticks
  *
  * Description: All request from Idle thread to Enter into
  * Low Power Mode or Deep Sleep State land in this function
  */
-int sys_soc_suspend(s32_t ticks)
+int sys_suspend(s32_t ticks)
 {
 	int ret = SYS_PM_NOT_HANDLED;
 
@@ -142,14 +142,14 @@ int sys_soc_suspend(s32_t ticks)
 				low_power_state_exit();
 			}
 			post_ops_done = 1;
-			sys_soc_power_state_post_ops(pm_state);
+			sys_power_state_post_ops(pm_state);
 		}
 	}
 
 	return ret;
 }
 
-void sys_soc_resume(void)
+void sys_resume(void)
 {
 	/*
 	 * This notification is called from the ISR of the event
@@ -163,7 +163,7 @@ void sys_soc_resume(void)
 	 * The kernel scheduler will get control after the ISR finishes
 	 * and it may schedule another thread.
 	 *
-	 * Call sys_soc_pm_idle_exit_notification_disable() if this
+	 * Call sys_pm_idle_exit_notification_disable() if this
 	 * notification is not required.
 	 */
 	if (!post_ops_done) {
@@ -171,6 +171,6 @@ void sys_soc_resume(void)
 			low_power_state_exit();
 		}
 		post_ops_done = 1;
-		sys_soc_power_state_post_ops(pm_state);
+		sys_power_state_post_ops(pm_state);
 	}
 }

--- a/samples/boards/nrf52/power_mgr/src/power.c
+++ b/samples/boards/nrf52/power_mgr/src/power.c
@@ -68,7 +68,7 @@ static int low_power_state_entry(void)
 	} else {
 		printk("--> Entering into Low Power State -");
 	}
-	_sys_soc_set_power_state(pm_state);
+	sys_soc_set_power_state(pm_state);
 	return SYS_PM_LOW_POWER_STATE;
 }
 
@@ -83,24 +83,24 @@ static int low_power_suspend_entry(void)
 {
 	printk("--> Entering into Deep Sleep State -");
 	/* Don't need pm idle exit event notification */
-	_sys_soc_pm_idle_exit_notification_disable();
+	sys_soc_pm_idle_exit_notification_disable();
 	/* Save device states and turn off peripherals as necessary */
 	suspend_devices();
-	_sys_soc_set_power_state(SYS_POWER_STATE_DEEP_SLEEP);
+	sys_soc_set_power_state(SYS_POWER_STATE_DEEP_SLEEP);
 	 /* Exiting from Deep Sleep State */
 	low_power_suspend_exit();
 
 	return SYS_PM_DEEP_SLEEP;
 }
 
-/* Function name : _sys_soc_suspend
+/* Function name : sys_soc_suspend
  * Return Value : Power Mode Entered Success/Failure
  * Input : Idleness in number of Ticks
  *
  * Description: All request from Idle thread to Enter into
  * Low Power Mode or Deep Sleep State land in this function
  */
-int _sys_soc_suspend(s32_t ticks)
+int sys_soc_suspend(s32_t ticks)
 {
 	int ret = SYS_PM_NOT_HANDLED;
 
@@ -142,14 +142,14 @@ int _sys_soc_suspend(s32_t ticks)
 				low_power_state_exit();
 			}
 			post_ops_done = 1;
-			_sys_soc_power_state_post_ops(pm_state);
+			sys_soc_power_state_post_ops(pm_state);
 		}
 	}
 
 	return ret;
 }
 
-void _sys_soc_resume(void)
+void sys_soc_resume(void)
 {
 	/*
 	 * This notification is called from the ISR of the event
@@ -163,7 +163,7 @@ void _sys_soc_resume(void)
 	 * The kernel scheduler will get control after the ISR finishes
 	 * and it may schedule another thread.
 	 *
-	 * Call _sys_soc_pm_idle_exit_notification_disable() if this
+	 * Call sys_soc_pm_idle_exit_notification_disable() if this
 	 * notification is not required.
 	 */
 	if (!post_ops_done) {
@@ -171,6 +171,6 @@ void _sys_soc_resume(void)
 			low_power_state_exit();
 		}
 		post_ops_done = 1;
-		_sys_soc_power_state_post_ops(pm_state);
+		sys_soc_power_state_post_ops(pm_state);
 	}
 }

--- a/samples/boards/quark_se_c1000/power_mgr/README.rst
+++ b/samples/boards/quark_se_c1000/power_mgr/README.rst
@@ -10,7 +10,7 @@ A sample implementation of a power manager app that uses the Zephyr
 power management infrastructure.
 
 This app will cycle through the various power schemes at every call
-to sys_soc_suspend() hook function.
+to sys_suspend() hook function.
 It will cycle through the following states:
 
 1. CPU Low Power State

--- a/samples/boards/quark_se_c1000/power_mgr/README.rst
+++ b/samples/boards/quark_se_c1000/power_mgr/README.rst
@@ -10,7 +10,7 @@ A sample implementation of a power manager app that uses the Zephyr
 power management infrastructure.
 
 This app will cycle through the various power schemes at every call
-to _sys_soc_suspend() hook function.
+to sys_soc_suspend() hook function.
 It will cycle through the following states:
 
 1. CPU Low Power State

--- a/samples/boards/quark_se_c1000/power_mgr/src/main.c
+++ b/samples/boards/quark_se_c1000/power_mgr/src/main.c
@@ -143,7 +143,7 @@ static int low_power_state_entry(s32_t ticks)
 
 	enable_wake_event();
 
-	_sys_soc_set_power_state(SYS_POWER_STATE_CPU_LPS);
+	sys_soc_set_power_state(SYS_POWER_STATE_CPU_LPS);
 
 	return SYS_PM_LOW_POWER_STATE;
 }
@@ -155,14 +155,14 @@ static int deep_sleep_entry(s32_t ticks)
 	start_time = rtc_read(rtc_dev);
 
 	/* Don't need pm idle exit event notification */
-	_sys_soc_pm_idle_exit_notification_disable();
+	sys_soc_pm_idle_exit_notification_disable();
 
 	/* Save device states and turn off peripherals as necessary */
 	suspend_devices();
 
 	enable_wake_event();
 
-	_sys_soc_set_power_state(SYS_POWER_STATE_DEEP_SLEEP);
+	sys_soc_set_power_state(SYS_POWER_STATE_DEEP_SLEEP);
 
 	/*
 	 * At this point system has woken up from
@@ -174,7 +174,7 @@ static int deep_sleep_entry(s32_t ticks)
 	return SYS_PM_DEEP_SLEEP;
 }
 
-int _sys_soc_suspend(s32_t ticks)
+int sys_soc_suspend(s32_t ticks)
 {
 	int ret = SYS_PM_NOT_HANDLED;
 
@@ -220,7 +220,7 @@ int _sys_soc_suspend(s32_t ticks)
 		 * Some CPU power states would require interrupts to be
 		 * enabled at the time of entering the low power state.
 		 * For such states the post operations need to be done
-		 * at _sys_soc_resume. To avoid doing it twice, check a
+		 * at sys_soc_resume. To avoid doing it twice, check a
 		 * flag.
 		 */
 		if (!post_ops_done) {
@@ -228,14 +228,14 @@ int _sys_soc_suspend(s32_t ticks)
 				low_power_state_exit();
 			}
 			post_ops_done = 1;
-			_sys_soc_power_state_post_ops(pm_state);
+			sys_soc_power_state_post_ops(pm_state);
 		}
 	}
 
 	return ret;
 }
 
-void _sys_soc_resume(void)
+void sys_soc_resume(void)
 {
 	/*
 	 * This notification is called from the ISR of the event
@@ -249,7 +249,7 @@ void _sys_soc_resume(void)
 	 * The kernel scheduler will get control after the ISR finishes
 	 * and it may schedule another thread.
 	 *
-	 * Call _sys_soc_pm_idle_exit_notification_disable() if this
+	 * Call sys_soc_pm_idle_exit_notification_disable() if this
 	 * notification is not required.
 	 */
 	if (!post_ops_done) {
@@ -257,7 +257,7 @@ void _sys_soc_resume(void)
 			low_power_state_exit();
 		}
 		post_ops_done = 1;
-		_sys_soc_power_state_post_ops(pm_state);
+		sys_soc_power_state_post_ops(pm_state);
 	}
 }
 

--- a/samples/boards/quark_se_c1000/power_mgr/src/main.c
+++ b/samples/boards/quark_se_c1000/power_mgr/src/main.c
@@ -143,7 +143,7 @@ static int low_power_state_entry(s32_t ticks)
 
 	enable_wake_event();
 
-	sys_soc_set_power_state(SYS_POWER_STATE_CPU_LPS);
+	sys_set_power_state(SYS_POWER_STATE_CPU_LPS);
 
 	return SYS_PM_LOW_POWER_STATE;
 }
@@ -155,14 +155,14 @@ static int deep_sleep_entry(s32_t ticks)
 	start_time = rtc_read(rtc_dev);
 
 	/* Don't need pm idle exit event notification */
-	sys_soc_pm_idle_exit_notification_disable();
+	sys_pm_idle_exit_notification_disable();
 
 	/* Save device states and turn off peripherals as necessary */
 	suspend_devices();
 
 	enable_wake_event();
 
-	sys_soc_set_power_state(SYS_POWER_STATE_DEEP_SLEEP);
+	sys_set_power_state(SYS_POWER_STATE_DEEP_SLEEP);
 
 	/*
 	 * At this point system has woken up from
@@ -174,7 +174,7 @@ static int deep_sleep_entry(s32_t ticks)
 	return SYS_PM_DEEP_SLEEP;
 }
 
-int sys_soc_suspend(s32_t ticks)
+int sys_suspend(s32_t ticks)
 {
 	int ret = SYS_PM_NOT_HANDLED;
 
@@ -220,7 +220,7 @@ int sys_soc_suspend(s32_t ticks)
 		 * Some CPU power states would require interrupts to be
 		 * enabled at the time of entering the low power state.
 		 * For such states the post operations need to be done
-		 * at sys_soc_resume. To avoid doing it twice, check a
+		 * at sys_resume. To avoid doing it twice, check a
 		 * flag.
 		 */
 		if (!post_ops_done) {
@@ -228,14 +228,14 @@ int sys_soc_suspend(s32_t ticks)
 				low_power_state_exit();
 			}
 			post_ops_done = 1;
-			sys_soc_power_state_post_ops(pm_state);
+			sys_power_state_post_ops(pm_state);
 		}
 	}
 
 	return ret;
 }
 
-void sys_soc_resume(void)
+void sys_resume(void)
 {
 	/*
 	 * This notification is called from the ISR of the event
@@ -249,7 +249,7 @@ void sys_soc_resume(void)
 	 * The kernel scheduler will get control after the ISR finishes
 	 * and it may schedule another thread.
 	 *
-	 * Call sys_soc_pm_idle_exit_notification_disable() if this
+	 * Call sys_pm_idle_exit_notification_disable() if this
 	 * notification is not required.
 	 */
 	if (!post_ops_done) {
@@ -257,7 +257,7 @@ void sys_soc_resume(void)
 			low_power_state_exit();
 		}
 		post_ops_done = 1;
-		sys_soc_power_state_post_ops(pm_state);
+		sys_power_state_post_ops(pm_state);
 	}
 }
 

--- a/samples/subsys/power/power_mgr/README.rst
+++ b/samples/subsys/power/power_mgr/README.rst
@@ -8,7 +8,7 @@ Overview
 
 This sample demonstrates OS managed power saving mechanism through the sample
 application which will periodically go sleep there by invoking the idle thread
-which will call the _sys_soc_suspend() to enter into low power states. The Low
+which will call the sys_soc_suspend() to enter into low power states. The Low
 Power state will be selected based on the next timeout event.
 
 Requirements

--- a/samples/subsys/power/power_mgr/README.rst
+++ b/samples/subsys/power/power_mgr/README.rst
@@ -8,7 +8,7 @@ Overview
 
 This sample demonstrates OS managed power saving mechanism through the sample
 application which will periodically go sleep there by invoking the idle thread
-which will call the sys_soc_suspend() to enter into low power states. The Low
+which will call the sys_suspend() to enter into low power states. The Low
 Power state will be selected based on the next timeout event.
 
 Requirements

--- a/soc/arc/quark_se_c1000_ss/power.c
+++ b/soc/arc/quark_se_c1000_ss/power.c
@@ -39,7 +39,7 @@ static void _deep_sleep(enum power_states state)
 }
 #endif
 
-void _sys_soc_set_power_state(enum power_states state)
+void sys_soc_set_power_state(enum power_states state)
 {
 	switch (state) {
 	case SYS_POWER_STATE_CPU_LPS:
@@ -64,7 +64,7 @@ void _sys_soc_set_power_state(enum power_states state)
 	}
 }
 
-void _sys_soc_power_state_post_ops(enum power_states state)
+void sys_soc_power_state_post_ops(enum power_states state)
 {
 	u32_t limit;
 

--- a/soc/arc/quark_se_c1000_ss/power.c
+++ b/soc/arc/quark_se_c1000_ss/power.c
@@ -39,7 +39,7 @@ static void _deep_sleep(enum power_states state)
 }
 #endif
 
-void sys_soc_set_power_state(enum power_states state)
+void sys_set_power_state(enum power_states state)
 {
 	switch (state) {
 	case SYS_POWER_STATE_CPU_LPS:
@@ -64,7 +64,7 @@ void sys_soc_set_power_state(enum power_states state)
 	}
 }
 
-void sys_soc_power_state_post_ops(enum power_states state)
+void sys_power_state_post_ops(enum power_states state)
 {
 	u32_t limit;
 

--- a/soc/arc/quark_se_c1000_ss/soc_power.S
+++ b/soc/arc/quark_se_c1000_ss/soc_power.S
@@ -11,7 +11,7 @@
 #ifdef CONFIG_SYS_POWER_DEEP_SLEEP
 GDATA(_pm_arc_context)
 
-GTEXT(_sys_soc_resume_from_deep_sleep)
+GTEXT(sys_soc_resume_from_deep_sleep)
 GTEXT(_power_restore_cpu_context)
 GTEXT(_power_soc_sleep)
 GTEXT(_power_soc_deep_sleep)
@@ -24,7 +24,7 @@ GTEXT(_power_soc_lpss_mode)
 #define SLEEP_INTR_ENABLED_BIT 4
 #define SLEEP_MODE_RTC_ENABLED_BIT 5
 
-SECTION_FUNC(TEXT, _sys_soc_resume_from_deep_sleep)
+SECTION_FUNC(TEXT, sys_soc_resume_from_deep_sleep)
         /* Check is this wakeup after sleep event. */
         ld r0,[GPS0_REGISTER]
         bbit1 r0,RESTORE_SS_BIT,restore
@@ -37,7 +37,7 @@ restore:
 	/* Enable I-Cache */
         sr 1, [_ARC_V2_IC_CTRL]
 
-	j @_sys_soc_restore_cpu_context
+	j @sys_soc_restore_cpu_context
 
 SECTION_FUNC(TEXT, save_cpu_context)
 	mov_s r1, _kernel
@@ -114,7 +114,7 @@ SECTION_FUNC(TEXT, _power_soc_lpss_mode)
 	pop_s blink
 	j_s [blink]
 
-SECTION_FUNC(TEXT, _sys_soc_restore_cpu_context)
+SECTION_FUNC(TEXT, sys_soc_restore_cpu_context)
 	mov_s r1, _kernel
 	ld_s r2, [r1, _kernel_offset_to_current]
 

--- a/soc/arc/quark_se_c1000_ss/soc_power.S
+++ b/soc/arc/quark_se_c1000_ss/soc_power.S
@@ -11,7 +11,7 @@
 #ifdef CONFIG_SYS_POWER_DEEP_SLEEP
 GDATA(_pm_arc_context)
 
-GTEXT(sys_soc_resume_from_deep_sleep)
+GTEXT(sys_resume_from_deep_sleep)
 GTEXT(_power_restore_cpu_context)
 GTEXT(_power_soc_sleep)
 GTEXT(_power_soc_deep_sleep)
@@ -24,7 +24,7 @@ GTEXT(_power_soc_lpss_mode)
 #define SLEEP_INTR_ENABLED_BIT 4
 #define SLEEP_MODE_RTC_ENABLED_BIT 5
 
-SECTION_FUNC(TEXT, sys_soc_resume_from_deep_sleep)
+SECTION_FUNC(TEXT, sys_resume_from_deep_sleep)
         /* Check is this wakeup after sleep event. */
         ld r0,[GPS0_REGISTER]
         bbit1 r0,RESTORE_SS_BIT,restore
@@ -37,7 +37,7 @@ restore:
 	/* Enable I-Cache */
         sr 1, [_ARC_V2_IC_CTRL]
 
-	j @sys_soc_restore_cpu_context
+	j @sys_restore_cpu_context
 
 SECTION_FUNC(TEXT, save_cpu_context)
 	mov_s r1, _kernel
@@ -114,7 +114,7 @@ SECTION_FUNC(TEXT, _power_soc_lpss_mode)
 	pop_s blink
 	j_s [blink]
 
-SECTION_FUNC(TEXT, sys_soc_restore_cpu_context)
+SECTION_FUNC(TEXT, sys_restore_cpu_context)
 	mov_s r1, _kernel
 	ld_s r2, [r1, _kernel_offset_to_current]
 

--- a/soc/arc/quark_se_c1000_ss/soc_power.h
+++ b/soc/arc/quark_se_c1000_ss/soc_power.h
@@ -65,7 +65,7 @@ enum power_states {
  * if the ARC wakes up and transitions again to
  * SYS_POWER_STATE_CPU_LPS. This is not required on the x86 side.
  */
-void sys_soc_set_power_state(enum power_states state);
+void sys_set_power_state(enum power_states state);
 
 /**
  * @brief Do any SoC or architecture specific post ops after low power states.
@@ -75,7 +75,7 @@ void sys_soc_set_power_state(enum power_states state);
  * interrupts after resuming from deep sleep. In future, the enabling
  * of interrupts may be moved into the kernel.
  */
-void sys_soc_power_state_post_ops(enum power_states state);
+void sys_power_state_post_ops(enum power_states state);
 
 #ifdef __cplusplus
 }

--- a/soc/arc/quark_se_c1000_ss/soc_power.h
+++ b/soc/arc/quark_se_c1000_ss/soc_power.h
@@ -65,7 +65,7 @@ enum power_states {
  * if the ARC wakes up and transitions again to
  * SYS_POWER_STATE_CPU_LPS. This is not required on the x86 side.
  */
-void _sys_soc_set_power_state(enum power_states state);
+void sys_soc_set_power_state(enum power_states state);
 
 /**
  * @brief Do any SoC or architecture specific post ops after low power states.
@@ -75,7 +75,7 @@ void _sys_soc_set_power_state(enum power_states state);
  * interrupts after resuming from deep sleep. In future, the enabling
  * of interrupts may be moved into the kernel.
  */
-void _sys_soc_power_state_post_ops(enum power_states state);
+void sys_soc_power_state_post_ops(enum power_states state);
 
 #ifdef __cplusplus
 }

--- a/soc/arm/nordic_nrf/nrf52/power.c
+++ b/soc/arm/nordic_nrf/nrf52/power.c
@@ -57,7 +57,7 @@ static void _low_power_mode(enum power_states state)
 }
 
 /* Invoke Low Power/System Off specific Tasks */
-void sys_soc_set_power_state(enum power_states state)
+void sys_set_power_state(enum power_states state)
 {
 	switch (state) {
 	case SYS_POWER_STATE_CPU_LPS:
@@ -79,7 +79,7 @@ void sys_soc_set_power_state(enum power_states state)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void sys_soc_power_state_post_ops(enum power_states state)
+void sys_power_state_post_ops(enum power_states state)
 {
 	switch (state) {
 	case SYS_POWER_STATE_CPU_LPS:
@@ -98,7 +98,7 @@ void sys_soc_power_state_post_ops(enum power_states state)
 	}
 }
 
-bool sys_soc_is_valid_power_state(enum power_states state)
+bool sys_is_valid_power_state(enum power_states state)
 {
 	switch (state) {
 	case SYS_POWER_STATE_CPU_LPS:

--- a/soc/arm/nordic_nrf/nrf52/power.c
+++ b/soc/arm/nordic_nrf/nrf52/power.c
@@ -57,7 +57,7 @@ static void _low_power_mode(enum power_states state)
 }
 
 /* Invoke Low Power/System Off specific Tasks */
-void _sys_soc_set_power_state(enum power_states state)
+void sys_soc_set_power_state(enum power_states state)
 {
 	switch (state) {
 	case SYS_POWER_STATE_CPU_LPS:
@@ -79,7 +79,7 @@ void _sys_soc_set_power_state(enum power_states state)
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */
-void _sys_soc_power_state_post_ops(enum power_states state)
+void sys_soc_power_state_post_ops(enum power_states state)
 {
 	switch (state) {
 	case SYS_POWER_STATE_CPU_LPS:
@@ -98,7 +98,7 @@ void _sys_soc_power_state_post_ops(enum power_states state)
 	}
 }
 
-bool _sys_soc_is_valid_power_state(enum power_states state)
+bool sys_soc_is_valid_power_state(enum power_states state)
 {
 	switch (state) {
 	case SYS_POWER_STATE_CPU_LPS:

--- a/soc/arm/nordic_nrf/nrf52/soc_power.h
+++ b/soc/arm/nordic_nrf/nrf52/soc_power.h
@@ -27,17 +27,17 @@ enum power_states {
 /**
  * @brief Put processor into low power state
  */
-void sys_soc_set_power_state(enum power_states state);
+void sys_set_power_state(enum power_states state);
 
 /**
  * @brief Check a low power state is supported by SoC
  */
-bool sys_soc_is_valid_power_state(enum power_states state);
+bool sys_is_valid_power_state(enum power_states state);
 
 /**
  * @brief Do any SoC or architecture specific post ops after low power states.
  */
-void sys_soc_power_state_post_ops(enum power_states state);
+void sys_power_state_post_ops(enum power_states state);
 
 #ifdef __cplusplus
 }

--- a/soc/arm/nordic_nrf/nrf52/soc_power.h
+++ b/soc/arm/nordic_nrf/nrf52/soc_power.h
@@ -27,17 +27,17 @@ enum power_states {
 /**
  * @brief Put processor into low power state
  */
-void _sys_soc_set_power_state(enum power_states state);
+void sys_soc_set_power_state(enum power_states state);
 
 /**
  * @brief Check a low power state is supported by SoC
  */
-bool _sys_soc_is_valid_power_state(enum power_states state);
+bool sys_soc_is_valid_power_state(enum power_states state);
 
 /**
  * @brief Do any SoC or architecture specific post ops after low power states.
  */
-void _sys_soc_power_state_post_ops(enum power_states state);
+void sys_soc_power_state_post_ops(enum power_states state);
 
 #ifdef __cplusplus
 }

--- a/soc/x86/intel_quark/quark_se/power.c
+++ b/soc/x86/intel_quark/quark_se/power.c
@@ -37,7 +37,7 @@ static void _deep_sleep(enum power_states state)
 	 * is restored. If necessary, it is possible to set the
 	 * resume vector to a location where additional processing
 	 * can be done before cpu context is restored and control
-	 * transferred to sys_soc_suspend.
+	 * transferred to sys_suspend.
 	 */
 	qm_x86_set_resume_vector(_power_restore_cpu_context,
 				 *__x86_restore_info);
@@ -57,7 +57,7 @@ static void _deep_sleep(enum power_states state)
 }
 #endif
 
-void sys_soc_set_power_state(enum power_states state)
+void sys_set_power_state(enum power_states state)
 {
 	switch (state) {
 	case SYS_POWER_STATE_CPU_LPS:
@@ -80,7 +80,7 @@ void sys_soc_set_power_state(enum power_states state)
 	}
 }
 
-void sys_soc_power_state_post_ops(enum power_states state)
+void sys_power_state_post_ops(enum power_states state)
 {
 	switch (state) {
 	case SYS_POWER_STATE_CPU_LPS_2:
@@ -104,7 +104,7 @@ void sys_soc_power_state_post_ops(enum power_states state)
 	}
 }
 
-bool sys_soc_power_state_is_arc_ready(void)
+bool sys_power_state_is_arc_ready(void)
 {
 	return QM_SCSS_GP->gp0 & GP0_BIT_SLEEP_READY ? true : false;
 }

--- a/soc/x86/intel_quark/quark_se/power.c
+++ b/soc/x86/intel_quark/quark_se/power.c
@@ -37,7 +37,7 @@ static void _deep_sleep(enum power_states state)
 	 * is restored. If necessary, it is possible to set the
 	 * resume vector to a location where additional processing
 	 * can be done before cpu context is restored and control
-	 * transferred to _sys_soc_suspend.
+	 * transferred to sys_soc_suspend.
 	 */
 	qm_x86_set_resume_vector(_power_restore_cpu_context,
 				 *__x86_restore_info);
@@ -57,7 +57,7 @@ static void _deep_sleep(enum power_states state)
 }
 #endif
 
-void _sys_soc_set_power_state(enum power_states state)
+void sys_soc_set_power_state(enum power_states state)
 {
 	switch (state) {
 	case SYS_POWER_STATE_CPU_LPS:
@@ -80,7 +80,7 @@ void _sys_soc_set_power_state(enum power_states state)
 	}
 }
 
-void _sys_soc_power_state_post_ops(enum power_states state)
+void sys_soc_power_state_post_ops(enum power_states state)
 {
 	switch (state) {
 	case SYS_POWER_STATE_CPU_LPS_2:
@@ -104,7 +104,7 @@ void _sys_soc_power_state_post_ops(enum power_states state)
 	}
 }
 
-bool _sys_soc_power_state_is_arc_ready(void)
+bool sys_soc_power_state_is_arc_ready(void)
 {
 	return QM_SCSS_GP->gp0 & GP0_BIT_SLEEP_READY ? true : false;
 }

--- a/soc/x86/intel_quark/quark_se/soc_power.S
+++ b/soc/x86/intel_quark/quark_se/soc_power.S
@@ -11,7 +11,7 @@ GDATA(_pm_save_gdtr)
 GDATA(_pm_save_idtr)
 GDATA(_pm_save_esp)
 
-GTEXT(sys_soc_resume_from_deep_sleep)
+GTEXT(sys_resume_from_deep_sleep)
 GTEXT(_power_restore_cpu_context)
 GTEXT(_power_soc_sleep)
 GTEXT(_power_soc_deep_sleep)
@@ -102,7 +102,7 @@ SECTION_FUNC(TEXT, _power_soc_deep_sleep)
  * Disclaimer: This can be used for debug or development purposes. This is not
  * a supported feature in Quark SE boards and to be used at one's own risk.
  */
-SECTION_FUNC(TEXT, sys_soc_resume_from_deep_sleep)
+SECTION_FUNC(TEXT, sys_resume_from_deep_sleep)
 	movl $CONFIG_BSP_SHARED_RESTORE_INFO_RAM_ADDR, %eax
 	cmpl $_power_restore_cpu_context, (%eax)
 	je _power_restore_cpu_context

--- a/soc/x86/intel_quark/quark_se/soc_power.S
+++ b/soc/x86/intel_quark/quark_se/soc_power.S
@@ -11,7 +11,7 @@ GDATA(_pm_save_gdtr)
 GDATA(_pm_save_idtr)
 GDATA(_pm_save_esp)
 
-GTEXT(_sys_soc_resume_from_deep_sleep)
+GTEXT(sys_soc_resume_from_deep_sleep)
 GTEXT(_power_restore_cpu_context)
 GTEXT(_power_soc_sleep)
 GTEXT(_power_soc_deep_sleep)
@@ -102,7 +102,7 @@ SECTION_FUNC(TEXT, _power_soc_deep_sleep)
  * Disclaimer: This can be used for debug or development purposes. This is not
  * a supported feature in Quark SE boards and to be used at one's own risk.
  */
-SECTION_FUNC(TEXT, _sys_soc_resume_from_deep_sleep)
+SECTION_FUNC(TEXT, sys_soc_resume_from_deep_sleep)
 	movl $CONFIG_BSP_SHARED_RESTORE_INFO_RAM_ADDR, %eax
 	cmpl $_power_restore_cpu_context, (%eax)
 	je _power_restore_cpu_context

--- a/soc/x86/intel_quark/quark_se/soc_power.h
+++ b/soc/x86/intel_quark/quark_se/soc_power.h
@@ -53,7 +53,7 @@ enum power_states {
  * SYS_POWER_STATE_DEEP_SLEEP_1: Only Always-On peripherals can wake up
  * the SoC. This consists of the Counter, RTC, GPIO 1 and AIO Comparator.
  */
-void _sys_soc_set_power_state(enum power_states state);
+void sys_soc_set_power_state(enum power_states state);
 
 /**
  * @brief Do any SoC or architecture specific post ops after low power states.
@@ -63,7 +63,7 @@ void _sys_soc_set_power_state(enum power_states state);
  * interrupts after resuming from deep sleep. In future, the enabling
  * of interrupts may be moved into the kernel.
  */
-void _sys_soc_power_state_post_ops(enum power_states state);
+void sys_soc_power_state_post_ops(enum power_states state);
 
 /**
  * @brief Check if ARC core is ready to enter in DEEP_SLEEP states.
@@ -71,7 +71,7 @@ void _sys_soc_power_state_post_ops(enum power_states state);
  * @retval true If ARC is ready.
  * @retval false Otherwise.
  */
-bool _sys_soc_power_state_is_arc_ready(void);
+bool sys_soc_power_state_is_arc_ready(void);
 
 #ifdef __cplusplus
 }

--- a/soc/x86/intel_quark/quark_se/soc_power.h
+++ b/soc/x86/intel_quark/quark_se/soc_power.h
@@ -53,7 +53,7 @@ enum power_states {
  * SYS_POWER_STATE_DEEP_SLEEP_1: Only Always-On peripherals can wake up
  * the SoC. This consists of the Counter, RTC, GPIO 1 and AIO Comparator.
  */
-void sys_soc_set_power_state(enum power_states state);
+void sys_set_power_state(enum power_states state);
 
 /**
  * @brief Do any SoC or architecture specific post ops after low power states.
@@ -63,7 +63,7 @@ void sys_soc_set_power_state(enum power_states state);
  * interrupts after resuming from deep sleep. In future, the enabling
  * of interrupts may be moved into the kernel.
  */
-void sys_soc_power_state_post_ops(enum power_states state);
+void sys_power_state_post_ops(enum power_states state);
 
 /**
  * @brief Check if ARC core is ready to enter in DEEP_SLEEP states.
@@ -71,7 +71,7 @@ void sys_soc_power_state_post_ops(enum power_states state);
  * @retval true If ARC is ready.
  * @retval false Otherwise.
  */
-bool sys_soc_power_state_is_arc_ready(void);
+bool sys_power_state_is_arc_ready(void);
 
 #ifdef __cplusplus
 }

--- a/subsys/power/policy/policy_dummy.c
+++ b/subsys/power/policy/policy_dummy.c
@@ -62,7 +62,7 @@ int sys_pm_policy_next_state(s32_t ticks, enum power_states *pm_state)
 		cur_pm_idx = 0;
 	}
 
-	if (!_sys_soc_is_valid_power_state(pm_policy[cur_pm_idx].pm_state)) {
+	if (!sys_soc_is_valid_power_state(pm_policy[cur_pm_idx].pm_state)) {
 		LOG_ERR("pm_state(%d) not supported by SoC\n",
 						pm_policy[cur_pm_idx].pm_state);
 		return SYS_PM_NOT_HANDLED;

--- a/subsys/power/policy/policy_dummy.c
+++ b/subsys/power/policy/policy_dummy.c
@@ -22,13 +22,13 @@ LOG_MODULE_DECLARE(power);
 #error "Enable Low Power States at SoC Level"
 #endif
 
-struct sys_soc_pm_policy {
+struct sys_pm_policy {
 	enum power_states pm_state;
 	int sys_state;
 };
 
 /* PM Policy based on SoC/Platform residency requirements */
-static struct sys_soc_pm_policy pm_policy[] = {
+static struct sys_pm_policy pm_policy[] = {
 #ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_SUPPORTED
 	{SYS_POWER_STATE_CPU_LPS, SYS_PM_LOW_POWER_STATE},
 #endif
@@ -62,7 +62,7 @@ int sys_pm_policy_next_state(s32_t ticks, enum power_states *pm_state)
 		cur_pm_idx = 0;
 	}
 
-	if (!sys_soc_is_valid_power_state(pm_policy[cur_pm_idx].pm_state)) {
+	if (!sys_is_valid_power_state(pm_policy[cur_pm_idx].pm_state)) {
 		LOG_ERR("pm_state(%d) not supported by SoC\n",
 						pm_policy[cur_pm_idx].pm_state);
 		return SYS_PM_NOT_HANDLED;

--- a/subsys/power/policy/policy_residency.c
+++ b/subsys/power/policy/policy_residency.c
@@ -24,14 +24,14 @@ LOG_MODULE_DECLARE(power);
 #error "Enable Low Power States at SoC Level"
 #endif
 
-struct sys_soc_pm_policy {
+struct sys_pm_policy {
 	enum power_states pm_state;
 	int sys_state;
 	int min_residency;
 };
 
 /* PM Policy based on SoC/Platform residency requirements */
-static struct sys_soc_pm_policy pm_policy[] = {
+static struct sys_pm_policy pm_policy[] = {
 #ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_SUPPORTED
 	{SYS_POWER_STATE_CPU_LPS, SYS_PM_LOW_POWER_STATE,
 			CONFIG_PM_LPS_MIN_RES * SECS_TO_TICKS},
@@ -79,7 +79,7 @@ int sys_pm_policy_next_state(s32_t ticks, enum power_states *pm_state)
 		}
 	}
 
-	if (!sys_soc_is_valid_power_state(pm_policy[i].pm_state)) {
+	if (!sys_is_valid_power_state(pm_policy[i].pm_state)) {
 		LOG_ERR("pm_state(%d) not supported by SoC\n",
 						pm_policy[i].pm_state);
 		return SYS_PM_NOT_HANDLED;

--- a/subsys/power/policy/policy_residency.c
+++ b/subsys/power/policy/policy_residency.c
@@ -79,7 +79,7 @@ int sys_pm_policy_next_state(s32_t ticks, enum power_states *pm_state)
 		}
 	}
 
-	if (!_sys_soc_is_valid_power_state(pm_policy[i].pm_state)) {
+	if (!sys_soc_is_valid_power_state(pm_policy[i].pm_state)) {
 		LOG_ERR("pm_state(%d) not supported by SoC\n",
 						pm_policy[i].pm_state);
 		return SYS_PM_NOT_HANDLED;

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -63,7 +63,7 @@ static void sys_pm_log_debug_info(enum power_states state) { }
 void sys_pm_dump_debug_info(void) { }
 #endif
 
-int sys_soc_suspend(s32_t ticks)
+int sys_suspend(s32_t ticks)
 {
 	int sys_state;
 
@@ -86,12 +86,12 @@ int sys_soc_suspend(s32_t ticks)
 
 		/* Do CPU LPS operations */
 		sys_pm_debug_start_timer();
-		sys_soc_set_power_state(pm_state);
+		sys_set_power_state(pm_state);
 		sys_pm_debug_stop_timer();
 		break;
 	case SYS_PM_DEEP_SLEEP:
 		/* Don't need pm idle exit event notification */
-		sys_soc_pm_idle_exit_notification_disable();
+		sys_pm_idle_exit_notification_disable();
 
 		sys_pm_notify_lps_entry(pm_state);
 
@@ -103,7 +103,7 @@ int sys_soc_suspend(s32_t ticks)
 
 		/* Enter CPU deep sleep state */
 		sys_pm_debug_start_timer();
-		sys_soc_set_power_state(pm_state);
+		sys_set_power_state(pm_state);
 		sys_pm_debug_stop_timer();
 
 		/* Turn on peripherals and restore device states as necessary */
@@ -125,14 +125,14 @@ int sys_soc_suspend(s32_t ticks)
 		if (!post_ops_done) {
 			post_ops_done = 1;
 			sys_pm_notify_lps_exit(pm_state);
-			sys_soc_power_state_post_ops(pm_state);
+			sys_power_state_post_ops(pm_state);
 		}
 	}
 
 	return sys_state;
 }
 
-void sys_soc_resume(void)
+void sys_resume(void)
 {
 	/*
 	 * This notification is called from the ISR of the event
@@ -146,13 +146,13 @@ void sys_soc_resume(void)
 	 * The kernel scheduler will get control after the ISR finishes
 	 * and it may schedule another thread.
 	 *
-	 * Call sys_soc_pm_idle_exit_notification_disable() if this
+	 * Call sys_pm_idle_exit_notification_disable() if this
 	 * notification is not required.
 	 */
 	if (!post_ops_done) {
 		post_ops_done = 1;
 		sys_pm_notify_lps_exit(pm_state);
-		sys_soc_power_state_post_ops(pm_state);
+		sys_power_state_post_ops(pm_state);
 	}
 }
 

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -63,7 +63,7 @@ static void sys_pm_log_debug_info(enum power_states state) { }
 void sys_pm_dump_debug_info(void) { }
 #endif
 
-int _sys_soc_suspend(s32_t ticks)
+int sys_soc_suspend(s32_t ticks)
 {
 	int sys_state;
 
@@ -86,12 +86,12 @@ int _sys_soc_suspend(s32_t ticks)
 
 		/* Do CPU LPS operations */
 		sys_pm_debug_start_timer();
-		_sys_soc_set_power_state(pm_state);
+		sys_soc_set_power_state(pm_state);
 		sys_pm_debug_stop_timer();
 		break;
 	case SYS_PM_DEEP_SLEEP:
 		/* Don't need pm idle exit event notification */
-		_sys_soc_pm_idle_exit_notification_disable();
+		sys_soc_pm_idle_exit_notification_disable();
 
 		sys_pm_notify_lps_entry(pm_state);
 
@@ -103,7 +103,7 @@ int _sys_soc_suspend(s32_t ticks)
 
 		/* Enter CPU deep sleep state */
 		sys_pm_debug_start_timer();
-		_sys_soc_set_power_state(pm_state);
+		sys_soc_set_power_state(pm_state);
 		sys_pm_debug_stop_timer();
 
 		/* Turn on peripherals and restore device states as necessary */
@@ -125,14 +125,14 @@ int _sys_soc_suspend(s32_t ticks)
 		if (!post_ops_done) {
 			post_ops_done = 1;
 			sys_pm_notify_lps_exit(pm_state);
-			_sys_soc_power_state_post_ops(pm_state);
+			sys_soc_power_state_post_ops(pm_state);
 		}
 	}
 
 	return sys_state;
 }
 
-void _sys_soc_resume(void)
+void sys_soc_resume(void)
 {
 	/*
 	 * This notification is called from the ISR of the event
@@ -146,13 +146,13 @@ void _sys_soc_resume(void)
 	 * The kernel scheduler will get control after the ISR finishes
 	 * and it may schedule another thread.
 	 *
-	 * Call _sys_soc_pm_idle_exit_notification_disable() if this
+	 * Call sys_soc_pm_idle_exit_notification_disable() if this
 	 * notification is not required.
 	 */
 	if (!post_ops_done) {
 		post_ops_done = 1;
 		sys_pm_notify_lps_exit(pm_state);
-		_sys_soc_power_state_post_ops(pm_state);
+		sys_soc_power_state_post_ops(pm_state);
 	}
 }
 

--- a/tests/kernel/profiling/profiling_api/src/main.c
+++ b/tests/kernel/profiling/profiling_api/src/main.c
@@ -23,7 +23,7 @@ static void tdata_dump_callback(const struct k_thread *thread, void *user_data)
 }
 
 /*power hook functions*/
-int _sys_soc_suspend(s32_t ticks)
+int sys_soc_suspend(s32_t ticks)
 {
 	static bool test_flag;
 
@@ -38,7 +38,7 @@ int _sys_soc_suspend(s32_t ticks)
 	return 0;
 }
 
-void _sys_soc_resume(void)
+void sys_soc_resume(void)
 {
 }
 
@@ -81,7 +81,7 @@ void test_call_stacks_analyze_main(void)
  *
  * @ingroup kernel_profiling_tests
  *
- * @see k_thread_foreach(), _sys_soc_suspend(), _sys_soc_resume(),
+ * @see k_thread_foreach(), sys_soc_suspend(), sys_soc_resume(),
  * stack_analyze()
  */
 void test_call_stacks_analyze_idle(void)

--- a/tests/kernel/profiling/profiling_api/src/main.c
+++ b/tests/kernel/profiling/profiling_api/src/main.c
@@ -23,7 +23,7 @@ static void tdata_dump_callback(const struct k_thread *thread, void *user_data)
 }
 
 /*power hook functions*/
-int sys_soc_suspend(s32_t ticks)
+int sys_suspend(s32_t ticks)
 {
 	static bool test_flag;
 
@@ -38,7 +38,7 @@ int sys_soc_suspend(s32_t ticks)
 	return 0;
 }
 
-void sys_soc_resume(void)
+void sys_resume(void)
 {
 }
 
@@ -81,7 +81,7 @@ void test_call_stacks_analyze_main(void)
  *
  * @ingroup kernel_profiling_tests
  *
- * @see k_thread_foreach(), sys_soc_suspend(), sys_soc_resume(),
+ * @see k_thread_foreach(), sys_suspend(), sys_resume(),
  * stack_analyze()
  */
 void test_call_stacks_analyze_idle(void)

--- a/tests/power/multicore/arc/src/main.c
+++ b/tests/power/multicore/arc/src/main.c
@@ -42,28 +42,28 @@ static void resume_devices(void)
 	}
 }
 
-int sys_soc_suspend(s32_t ticks)
+int sys_suspend(s32_t ticks)
 {
 	post_ops_done = 0;
 
 	suspend_devices();
 
-	sys_soc_set_power_state(SYS_POWER_STATE_DEEP_SLEEP);
+	sys_set_power_state(SYS_POWER_STATE_DEEP_SLEEP);
 
 	if (!post_ops_done) {
 		post_ops_done = 1;
 		resume_devices();
-		sys_soc_power_state_post_ops(SYS_POWER_STATE_DEEP_SLEEP);
+		sys_power_state_post_ops(SYS_POWER_STATE_DEEP_SLEEP);
 	}
 
 	return SYS_PM_DEEP_SLEEP;
 }
 
-void sys_soc_resume(void)
+void sys_resume(void)
 {
 	if (!post_ops_done) {
 		post_ops_done = 1;
-		sys_soc_power_state_post_ops(SYS_POWER_STATE_DEEP_SLEEP);
+		sys_power_state_post_ops(SYS_POWER_STATE_DEEP_SLEEP);
 		resume_devices();
 	}
 }

--- a/tests/power/multicore/arc/src/main.c
+++ b/tests/power/multicore/arc/src/main.c
@@ -42,28 +42,28 @@ static void resume_devices(void)
 	}
 }
 
-int _sys_soc_suspend(s32_t ticks)
+int sys_soc_suspend(s32_t ticks)
 {
 	post_ops_done = 0;
 
 	suspend_devices();
 
-	_sys_soc_set_power_state(SYS_POWER_STATE_DEEP_SLEEP);
+	sys_soc_set_power_state(SYS_POWER_STATE_DEEP_SLEEP);
 
 	if (!post_ops_done) {
 		post_ops_done = 1;
 		resume_devices();
-		_sys_soc_power_state_post_ops(SYS_POWER_STATE_DEEP_SLEEP);
+		sys_soc_power_state_post_ops(SYS_POWER_STATE_DEEP_SLEEP);
 	}
 
 	return SYS_PM_DEEP_SLEEP;
 }
 
-void _sys_soc_resume(void)
+void sys_soc_resume(void)
 {
 	if (!post_ops_done) {
 		post_ops_done = 1;
-		_sys_soc_power_state_post_ops(SYS_POWER_STATE_DEEP_SLEEP);
+		sys_soc_power_state_post_ops(SYS_POWER_STATE_DEEP_SLEEP);
 		resume_devices();
 	}
 }

--- a/tests/power/multicore/lmt/src/main.c
+++ b/tests/power/multicore/lmt/src/main.c
@@ -49,25 +49,25 @@ static void resume_devices(void)
 	}
 }
 
-int _sys_soc_suspend(s32_t ticks)
+int sys_soc_suspend(s32_t ticks)
 {
 	printk("LMT: Try to put the system in SYS_POWER_STATE_DEEP_SLEEP_2"
 	       " state\n");
 
-	if (!_sys_soc_power_state_is_arc_ready()) {
+	if (!sys_soc_power_state_is_arc_ready()) {
 		printk("LMT: Failed. ARC is busy.\n");
 		return SYS_PM_NOT_HANDLED;
 	}
 
 	suspend_devices();
 
-	_sys_soc_set_power_state(SYS_POWER_STATE_CPU_LPS_2);
+	sys_soc_set_power_state(SYS_POWER_STATE_CPU_LPS_2);
 
 	resume_devices();
 
 	printk("LMT: Succeed.\n");
 
-	_sys_soc_power_state_post_ops(SYS_POWER_STATE_CPU_LPS_2);
+	sys_soc_power_state_post_ops(SYS_POWER_STATE_CPU_LPS_2);
 
 	return SYS_PM_DEEP_SLEEP;
 }

--- a/tests/power/multicore/lmt/src/main.c
+++ b/tests/power/multicore/lmt/src/main.c
@@ -49,25 +49,25 @@ static void resume_devices(void)
 	}
 }
 
-int sys_soc_suspend(s32_t ticks)
+int sys_suspend(s32_t ticks)
 {
 	printk("LMT: Try to put the system in SYS_POWER_STATE_DEEP_SLEEP_2"
 	       " state\n");
 
-	if (!sys_soc_power_state_is_arc_ready()) {
+	if (!sys_power_state_is_arc_ready()) {
 		printk("LMT: Failed. ARC is busy.\n");
 		return SYS_PM_NOT_HANDLED;
 	}
 
 	suspend_devices();
 
-	sys_soc_set_power_state(SYS_POWER_STATE_CPU_LPS_2);
+	sys_set_power_state(SYS_POWER_STATE_CPU_LPS_2);
 
 	resume_devices();
 
 	printk("LMT: Succeed.\n");
 
-	sys_soc_power_state_post_ops(SYS_POWER_STATE_CPU_LPS_2);
+	sys_power_state_post_ops(SYS_POWER_STATE_CPU_LPS_2);
 
 	return SYS_PM_DEEP_SLEEP;
 }

--- a/tests/power/power_states/src/main.c
+++ b/tests/power/power_states/src/main.c
@@ -210,7 +210,7 @@ static void do_soc_sleep(enum power_states state)
 						DEVICE_PM_SUSPEND_STATE);
 	}
 
-	_sys_soc_set_power_state(state);
+	sys_soc_set_power_state(state);
 
 	/*
 	 * Before enabling the interrupts, check the wake source
@@ -242,7 +242,7 @@ static void do_soc_sleep(enum power_states state)
 	}
 }
 
-int _sys_soc_suspend(s32_t ticks)
+int sys_soc_suspend(s32_t ticks)
 {
 	enum power_states state;
 	int pm_operation = SYS_PM_NOT_HANDLED;
@@ -298,12 +298,12 @@ int _sys_soc_suspend(s32_t ticks)
 		 */
 		setup_wake_event();
 		pm_operation = SYS_PM_LOW_POWER_STATE;
-		_sys_soc_set_power_state(state);
+		sys_soc_set_power_state(state);
 		break;
 	case SYS_POWER_STATE_DEEP_SLEEP:
 	case SYS_POWER_STATE_DEEP_SLEEP_1:
 		/* Don't need pm idle exit notification */
-		_sys_soc_pm_idle_exit_notification_disable();
+		sys_soc_pm_idle_exit_notification_disable();
 
 		pm_operation = SYS_PM_DEEP_SLEEP;
 		do_soc_sleep(state);
@@ -317,14 +317,14 @@ int _sys_soc_suspend(s32_t ticks)
 		if (!post_ops_done) {
 			post_ops_done = 1;
 			printk("Exiting %s state\n", state_to_string(state));
-			_sys_soc_power_state_post_ops(state);
+			sys_soc_power_state_post_ops(state);
 		}
 	}
 
 	return pm_operation;
 }
 
-void _sys_soc_resume(void)
+void sys_soc_resume(void)
 {
 	enum power_states state = states_list[current_state];
 
@@ -337,12 +337,12 @@ void _sys_soc_resume(void)
 		if (!post_ops_done) {
 			post_ops_done = 1;
 			printk("Exiting %s state\n", state_to_string(state));
-			_sys_soc_power_state_post_ops(state);
+			sys_soc_power_state_post_ops(state);
 		}
 		break;
 	case SYS_POWER_STATE_DEEP_SLEEP:
 	case SYS_POWER_STATE_DEEP_SLEEP_1:
-		/* Do not perform post_ops in _sys_soc_resume for deep sleep.
+		/* Do not perform post_ops in sys_soc_resume for deep sleep.
 		 * This would make the application task run without the full
 		 * context restored.
 		 */

--- a/tests/power/power_states/src/main.c
+++ b/tests/power/power_states/src/main.c
@@ -210,7 +210,7 @@ static void do_soc_sleep(enum power_states state)
 						DEVICE_PM_SUSPEND_STATE);
 	}
 
-	sys_soc_set_power_state(state);
+	sys_set_power_state(state);
 
 	/*
 	 * Before enabling the interrupts, check the wake source
@@ -242,7 +242,7 @@ static void do_soc_sleep(enum power_states state)
 	}
 }
 
-int sys_soc_suspend(s32_t ticks)
+int sys_suspend(s32_t ticks)
 {
 	enum power_states state;
 	int pm_operation = SYS_PM_NOT_HANDLED;
@@ -298,12 +298,12 @@ int sys_soc_suspend(s32_t ticks)
 		 */
 		setup_wake_event();
 		pm_operation = SYS_PM_LOW_POWER_STATE;
-		sys_soc_set_power_state(state);
+		sys_set_power_state(state);
 		break;
 	case SYS_POWER_STATE_DEEP_SLEEP:
 	case SYS_POWER_STATE_DEEP_SLEEP_1:
 		/* Don't need pm idle exit notification */
-		sys_soc_pm_idle_exit_notification_disable();
+		sys_pm_idle_exit_notification_disable();
 
 		pm_operation = SYS_PM_DEEP_SLEEP;
 		do_soc_sleep(state);
@@ -317,14 +317,14 @@ int sys_soc_suspend(s32_t ticks)
 		if (!post_ops_done) {
 			post_ops_done = 1;
 			printk("Exiting %s state\n", state_to_string(state));
-			sys_soc_power_state_post_ops(state);
+			sys_power_state_post_ops(state);
 		}
 	}
 
 	return pm_operation;
 }
 
-void sys_soc_resume(void)
+void sys_resume(void)
 {
 	enum power_states state = states_list[current_state];
 
@@ -337,12 +337,12 @@ void sys_soc_resume(void)
 		if (!post_ops_done) {
 			post_ops_done = 1;
 			printk("Exiting %s state\n", state_to_string(state));
-			sys_soc_power_state_post_ops(state);
+			sys_power_state_post_ops(state);
 		}
 		break;
 	case SYS_POWER_STATE_DEEP_SLEEP:
 	case SYS_POWER_STATE_DEEP_SLEEP_1:
-		/* Do not perform post_ops in sys_soc_resume for deep sleep.
+		/* Do not perform post_ops in sys_resume for deep sleep.
 		 * This would make the application task run without the full
 		 * context restored.
 		 */


### PR DESCRIPTION
- Rename \_sys to sys\_
- Rename \_sys_soc -> sys\_

Fixes #11047