### PR TITLE
arch: arm: fix bug in linker symbol definitions for application memory

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -346,15 +346,15 @@ SECTIONS
 	{
 		APP_INPUT_SECTION(.noinit)
 		APP_INPUT_SECTION(".noinit.*")
+
+		__app_last_address_used = .;
+
+		/* Align the end of the application memory
+		 * with MPU alignment requirement.
+		 */
+		MPU_ALIGN(__app_ram_size);
+		__app_ram_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
-
-	__app_last_address_used = .;
-
-	/* Align the end of the application memory
-	 * with MPU alignment requirement.
-	 */
-	MPU_ALIGN(__app_ram_size);
-	__app_ram_end = .;
 	__app_ram_size = __app_ram_end - __app_ram_start;
 #endif /* CONFIG_APPLICATION_MEMORY */
 


### PR DESCRIPTION
The definitions of __app_ram_end and __app_ram_size linker
symbols have been erroneously placed outside the last linker
section of application memory. This commit fixes the problem.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>