### PR TITLE
examples: disco: Using generic board configuration.

### DIFF
--- a/samples/basic/disco/README.rst
+++ b/samples/basic/disco/README.rst
@@ -9,51 +9,28 @@ Overview
 A simple 'disco' demo. The demo assumes that 2 LEDs are connected to
 GPIO outputs of the MCU/board.
 
+Requirements
+************
 
-Wiring
-******
+This demo assumes there are two LEDs connected to two GPIO lines. These two
+LEDs should be given aliases as 'led0' and 'led1' in the board dts file so the
+configure process will automatically create these four define macros in generated
+board head file
+:file:`samples/basic/disco/build/zephyr/include/generated/generated_dts_board.h`.
 
-The code may need some work before running on another board: set PORT,
-LED1 and LED2 according to the board's GPIO configuration.
-
-Nucleo-64 F103RB/F401RE boards
-==============================
-
-Connect two LEDs to PB5 and PB8 pins. PB5 is mapped to the
-Arduino's D4 pin and PB8 to Arduino's D15. For more details about
-these boards see:
-
-- https://developer.mbed.org/platforms/ST-Nucleo-F103RB/
-- https://developer.mbed.org/platforms/ST-Nucleo-F401RE/
-
-Arduino 101 (x86)
-=================
-
-Connect two LEDs to D4 (IO4) and D7 (IO7) pins. The schematics for the Arduino
-101 board is available at:
-
-https://www.arduino.cc/en/uploads/Main/Arduino101-REV4Schematic.pdf
-
-For Arduino 101's pinmux mapping in Zephyr, see: :file:`boards/x86/arduino_101/pinmux.c`
-
-Modify the src/main.c file and set:
-
-.. code-block:: c
-
-   #define PORT	CONFIG_GPIO_QMSI_0_NAME
-   /* GPIO_19 is Arduino's D4 */
-   #define LED1	19
-   /* GPIO_20 is Arduino's D7 */
-   #define LED2	20
+ - LED0_GPIO_CONTROLLER
+ - LED0_GPIO_PIN
+ - LED1_GPIO_CONTROLLER
+ - LED1_GPIO_PIN
 
 Building and Running
 *********************
 
-After startup, the program looks up a predefined GPIO device defined by 'PORT',
-and configures pins 'LED1' and 'LED2' in output mode.  During each iteration of
-the main loop, the state of GPIO lines will be changed so that one of the lines
-is in high state, while the other is in low, thus switching the LEDs on and off
-in an alternating pattern.
+After startup, the program looks up two predefined GPIO line defined in
+devicetree, and configures them in output mode. During each  iteration of the
+main loop, the state of GPIO lines will be changed so that one of the lines is
+in high state, while the other is in low, thus switching the LEDs on and off in
+an alternating pattern.
 
 This project does not output to the serial console, but instead causes two LEDs
 connected to the GPIO device to blink in an alternating pattern.

--- a/samples/basic/disco/src/main.c
+++ b/samples/basic/disco/src/main.c
@@ -8,33 +8,28 @@
 #include <device.h>
 #include <gpio.h>
 
-/**
- * the demo assumes use of nucleo_f103rb board, adjust defines below
- * to fit your board
- */
+#define LED0_PORT LED0_GPIO_CONTROLLER
+#define LED1_PORT LED1_GPIO_CONTROLLER
 
-/* we're going to use PB8 and PB5 */
-#define PORT "GPIOB"
-/* PB5 */
-#define LED1 5
-/* PB8 */
-#define LED2 8
+#define LED0 LED0_GPIO_PIN
+#define LED1 LED1_GPIO_PIN
 
 #define SLEEP_TIME	500
 
 void main(void)
 {
 	int cnt = 0;
-	struct device *gpiob;
+	struct device *gpio0, *gpio1;
 
-	gpiob = device_get_binding(PORT);
+	gpio0 = device_get_binding(LED0_PORT);
+	gpio1 = device_get_binding(LED1_PORT);
 
-	gpio_pin_configure(gpiob, LED1, GPIO_DIR_OUT);
-	gpio_pin_configure(gpiob, LED2, GPIO_DIR_OUT);
+	gpio_pin_configure(gpio0, LED0, GPIO_DIR_OUT);
+	gpio_pin_configure(gpio1, LED1, GPIO_DIR_OUT);
 
 	while (1) {
-		gpio_pin_write(gpiob, LED1, cnt % 2);
-		gpio_pin_write(gpiob, LED2, (cnt + 1) % 2);
+		gpio_pin_write(gpio0, LED0, cnt % 2);
+		gpio_pin_write(gpio1, LED1, (cnt + 1) % 2);
 		k_sleep(SLEEP_TIME);
 		cnt++;
 	}


### PR DESCRIPTION
This example used to use some board-related stuff.
Replace them with some generic definitions.

Signed-off-by: Song Qiang <songqiang1304521@gmail.com>