### PR TITLE
drivers: Modified drivers to use DEVICE_AND_API_INIT()

### DIFF
--- a/drivers/display/grove_lcd_rgb.c
+++ b/drivers/display/grove_lcd_rgb.c
@@ -267,16 +267,6 @@ int glcd_initialize(struct device *port)
 		return -EPERM;
 	}
 
-	/* Since device_get_binding() will not return any
-	 * reference to a driver instance if port->driver_api
-	 * is NULL and grove_lcd does not have any API struct,
-	 * just populate it with some magic number
-	 * so grove_lcd can be referenced.
-	 *
-	 * Since dev is probably still in registers.
-	 * use that to minimize code addition.
-	 */
-	port->driver_api = (void *)dev;
 
 	/*
 	 * Initialization sequence from the data sheet:
@@ -344,6 +334,14 @@ static struct glcd_data grove_lcd_driver = {
 	.function = 0,
 };
 
-DEVICE_INIT(grove_lcd, GROVE_LCD_NAME, glcd_initialize,
+	/* Since device_get_binding() will not return any
+	 * reference to a driver instance if driver_api
+	 * is NULL and grove_lcd does not have any API struct,
+	 * just populate it with some magic number
+	 * so grove_lcd can be referenced.
+	 * since grove_lcd_driver struct is available, populating with it
+	 */
+DEVICE_AND_API_INIT(grove_lcd, GROVE_LCD_NAME, glcd_initialize,
 			&grove_lcd_driver, &grove_lcd_config,
-			POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);
+			POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
+			(void *)&grove_lcd_driver);

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -254,8 +254,6 @@ static const struct flash_driver_api flash_nrf_api = {
 
 static int nrf_flash_init(struct device *dev)
 {
-	dev->driver_api = &flash_nrf_api;
-
 	SYNC_INIT();
 
 #if defined(CONFIG_SOC_FLASH_NRF_RADIO_SYNC)
@@ -270,8 +268,9 @@ static int nrf_flash_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_INIT(nrf_flash, DT_FLASH_DEV_NAME, nrf_flash_init,
-	     NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+DEVICE_AND_API_INIT(nrf_flash, DT_FLASH_DEV_NAME, nrf_flash_init,
+		NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		&flash_nrf_api);
 
 #if defined(CONFIG_SOC_FLASH_NRF_RADIO_SYNC)
 

--- a/drivers/flash/spi_flash_w25qxxdv.c
+++ b/drivers/flash/spi_flash_w25qxxdv.c
@@ -367,9 +367,6 @@ static int spi_flash_init(struct device *dev)
 	SYNC_INIT();
 
 	ret = spi_flash_wb_configure(dev);
-	if (!ret) {
-		dev->driver_api = &spi_flash_api;
-	}
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 	/*
@@ -386,6 +383,6 @@ static int spi_flash_init(struct device *dev)
 
 static struct spi_flash_data spi_flash_memory_data;
 
-DEVICE_INIT(spi_flash_memory, CONFIG_SPI_FLASH_W25QXXDV_DRV_NAME,
+DEVICE_AND_API_INIT(spi_flash_memory, CONFIG_SPI_FLASH_W25QXXDV_DRV_NAME,
 	    spi_flash_init, &spi_flash_memory_data, NULL, POST_KERNEL,
-	    CONFIG_SPI_FLASH_W25QXXDV_INIT_PRIORITY);
+	    CONFIG_SPI_FLASH_W25QXXDV_INIT_PRIORITY, &spi_flash_api);

--- a/drivers/gpio/gpio_pcal9535a.c
+++ b/drivers/gpio/gpio_pcal9535a.c
@@ -549,8 +549,6 @@ static int gpio_pcal9535a_init(struct device *dev)
 	}
 	drv_data->i2c_master = i2c_master;
 
-	dev->driver_api = &gpio_pcal9535a_drv_api_funcs;
-
 	return 0;
 }
 
@@ -571,10 +569,11 @@ static struct gpio_pcal9535a_drv_data gpio_pcal9535a_0_drvdata = {
 };
 
 /* This has to init after I2C master */
-DEVICE_INIT(gpio_pcal9535a_0, CONFIG_GPIO_PCAL9535A_0_DEV_NAME,
+DEVICE_AND_API_INIT(gpio_pcal9535a_0, CONFIG_GPIO_PCAL9535A_0_DEV_NAME,
 	    gpio_pcal9535a_init,
 	    &gpio_pcal9535a_0_drvdata, &gpio_pcal9535a_0_cfg,
-	    POST_KERNEL, CONFIG_GPIO_PCAL9535A_INIT_PRIORITY);
+	    POST_KERNEL, CONFIG_GPIO_PCAL9535A_INIT_PRIORITY,
+	    &gpio_pcal9535a_drv_api_funcs);
 
 #endif /* CONFIG_GPIO_PCAL9535A_0 */
 
@@ -595,10 +594,11 @@ static struct gpio_pcal9535a_drv_data gpio_pcal9535a_1_drvdata = {
 };
 
 /* This has to init after I2C master */
-DEVICE_INIT(gpio_pcal9535a_1, CONFIG_GPIO_PCAL9535A_1_DEV_NAME,
+DEVICE_AND_API_INIT(gpio_pcal9535a_1, CONFIG_GPIO_PCAL9535A_1_DEV_NAME,
 	    gpio_pcal9535a_init,
 	    &gpio_pcal9535a_1_drvdata, &gpio_pcal9535a_1_cfg,
-	    POST_KERNEL, CONFIG_GPIO_PCAL9535A_INIT_PRIORITY);
+	    POST_KERNEL, CONFIG_GPIO_PCAL9535A_INIT_PRIORITY,
+	    &gpio_pcal9535a_drv_api_funcs);
 
 #endif /* CONFIG_GPIO_PCAL9535A_1 */
 
@@ -619,10 +619,11 @@ static struct gpio_pcal9535a_drv_data gpio_pcal9535a_2_drvdata = {
 };
 
 /* This has to init after I2C master */
-DEVICE_INIT(gpio_pcal9535a_2, CONFIG_GPIO_PCAL9535A_2_DEV_NAME,
+DEVICE_AND_API_INIT(gpio_pcal9535a_2, CONFIG_GPIO_PCAL9535A_2_DEV_NAME,
 	    gpio_pcal9535a_init,
 	    &gpio_pcal9535a_2_drvdata, &gpio_pcal9535a_2_cfg,
-	    POST_KERNEL, CONFIG_GPIO_PCAL9535A_INIT_PRIORITY);
+	    POST_KERNEL, CONFIG_GPIO_PCAL9535A_INIT_PRIORITY,
+	    &gpio_pcal9535a_drv_api_funcs);
 
 #endif /* CONFIG_GPIO_PCAL9535A_2 */
 
@@ -643,9 +644,10 @@ static struct gpio_pcal9535a_drv_data gpio_pcal9535a_3_drvdata = {
 };
 
 /* This has to init after I2C master */
-DEVICE_INIT(gpio_pcal9535a_3, CONFIG_GPIO_PCAL9535A_3_DEV_NAME,
+DEVICE_AND_API_INIT(gpio_pcal9535a_3, CONFIG_GPIO_PCAL9535A_3_DEV_NAME,
 	    gpio_pcal9535a_init,
 	    &gpio_pcal9535a_3_drvdata, &gpio_pcal9535a_3_cfg,
-	    POST_KERNEL, CONFIG_GPIO_PCAL9535A_INIT_PRIORITY);
+	    POST_KERNEL, CONFIG_GPIO_PCAL9535A_INIT_PRIORITY,
+	    &gpio_pcal9535a_drv_api_funcs);
 
 #endif /* CONFIG_GPIO_PCAL9535A_3 */

--- a/drivers/gpio/gpio_sch.c
+++ b/drivers/gpio/gpio_sch.c
@@ -311,8 +311,6 @@ static int gpio_sch_init(struct device *dev)
 {
 	struct gpio_sch_data *gpio = dev->driver_data;
 
-	dev->driver_api = &gpio_sch_api;
-
 	k_timer_init(&gpio->poll_timer, NULL, NULL);
 
 	LOG_DBG("SCH GPIO Intel Driver initialized on device: %p", dev);
@@ -329,9 +327,9 @@ static const struct gpio_sch_config gpio_sch_0_config = {
 
 static struct gpio_sch_data gpio_data_0;
 
-DEVICE_INIT(gpio_0, CONFIG_GPIO_SCH_0_DEV_NAME, gpio_sch_init,
+DEVICE_AND_API_INIT(gpio_0, CONFIG_GPIO_SCH_0_DEV_NAME, gpio_sch_init,
 	    &gpio_data_0, &gpio_sch_0_config,
-	    POST_KERNEL, CONFIG_GPIO_SCH_INIT_PRIORITY);
+	    POST_KERNEL, CONFIG_GPIO_SCH_INIT_PRIORITY, &gpio_sch_api);
 
 #endif /* CONFIG_GPIO_SCH_0 */
 #if CONFIG_GPIO_SCH_1
@@ -343,8 +341,8 @@ static const struct gpio_sch_config gpio_sch_1_config = {
 
 static struct gpio_sch_data gpio_data_1;
 
-DEVICE_INIT(gpio_1, CONFIG_GPIO_SCH_1_DEV_NAME, gpio_sch_init,
+DEVICE_AND_API_INIT(gpio_1, CONFIG_GPIO_SCH_1_DEV_NAME, gpio_sch_init,
 	    &gpio_data_1, &gpio_sch_1_config,
-	    POST_KERNEL, CONFIG_GPIO_SCH_INIT_PRIORITY);
+	    POST_KERNEL, CONFIG_GPIO_SCH_INIT_PRIORITY, &gpio_sch_api);
 
 #endif /* CONFIG_GPIO_SCH_1 */

--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -105,8 +105,6 @@ static int i2c_gpio_init(struct device *dev)
 
 	i2c_bitbang_init(&context->bitbang, &io_fns, context);
 
-	dev->driver_api = &api;
-
 	return 0;
 }
 
@@ -120,11 +118,11 @@ static const struct i2c_gpio_config i2c_gpio_dev_cfg_##_num = {		\
 	.sda_pin	= CONFIG_I2C_GPIO_##_num##_SDA_PIN,		\
 };									\
 									\
-DEVICE_INIT(i2c_gpio_##_num, CONFIG_I2C_GPIO_##_num##_NAME,		\
+DEVICE_AND_API_INIT(i2c_gpio_##_num, CONFIG_I2C_GPIO_##_num##_NAME,	\
 	    i2c_gpio_init,						\
 	    &i2c_gpio_dev_data_##_num,					\
 	    &i2c_gpio_dev_cfg_##_num,					\
-	    PRE_KERNEL_2, CONFIG_I2C_INIT_PRIORITY)
+	    PRE_KERNEL_2, CONFIG_I2C_INIT_PRIORITY, &api)
 
 #ifdef CONFIG_I2C_GPIO_0
 DEFINE_I2C_GPIO(0);

--- a/drivers/i2c/i2c_sbcon.c
+++ b/drivers/i2c/i2c_sbcon.c
@@ -103,8 +103,6 @@ static int i2c_sbcon_init(struct device *dev)
 
 	i2c_bitbang_init(&context->bitbang, &io_fns, config->sbcon);
 
-	dev->driver_api = &api;
-
 	return 0;
 }
 
@@ -116,11 +114,11 @@ static const struct i2c_sbcon_config i2c_sbcon_dev_cfg_##_num = {	\
 	.sbcon		= (void *)DT_I2C_SBCON_##_num##_BASE_ADDR,		\
 };									\
 									\
-DEVICE_INIT(i2c_sbcon_##_num, CONFIG_I2C_SBCON_##_num##_NAME,		\
+DEVICE_AND_API_INIT(i2c_sbcon_##_num, CONFIG_I2C_SBCON_##_num##_NAME,	\
 	    i2c_sbcon_init,						\
 	    &i2c_sbcon_dev_data_##_num,					\
 	    &i2c_sbcon_dev_cfg_##_num,					\
-	    PRE_KERNEL_2, CONFIG_I2C_INIT_PRIORITY)
+	    PRE_KERNEL_2, CONFIG_I2C_INIT_PRIORITY, &api)
 
 #ifdef CONFIG_I2C_SBCON_0
 DEFINE_I2C_SBCON(0);

--- a/drivers/interrupt_controller/shared_irq.c
+++ b/drivers/interrupt_controller/shared_irq.c
@@ -117,10 +117,7 @@ static const struct shared_irq_driver_api api_funcs = {
 int shared_irq_initialize(struct device *dev)
 {
 	const struct shared_irq_config *config = dev->config->config_info;
-
-	dev->driver_api = &api_funcs;
 	config->config();
-
 	return 0;
 }
 
@@ -135,9 +132,10 @@ const struct shared_irq_config shared_irq_config_0 = {
 
 struct shared_irq_runtime shared_irq_0_runtime;
 
-DEVICE_INIT(shared_irq_0, CONFIG_SHARED_IRQ_0_NAME, shared_irq_initialize,
-				&shared_irq_0_runtime, &shared_irq_config_0,
-				POST_KERNEL, CONFIG_SHARED_IRQ_INIT_PRIORITY);
+DEVICE_AND_API_INIT(shared_irq_0, CONFIG_SHARED_IRQ_0_NAME,
+		shared_irq_initialize, &shared_irq_0_runtime,
+		&shared_irq_config_0, POST_KERNEL,
+		CONFIG_SHARED_IRQ_INIT_PRIORITY, &api_funcs);
 
 #if defined(CONFIG_IOAPIC)
 #if defined(CONFIG_SHARED_IRQ_0_FALLING_EDGE)
@@ -173,9 +171,10 @@ const struct shared_irq_config shared_irq_config_1 = {
 
 struct shared_irq_runtime shared_irq_1_runtime;
 
-DEVICE_INIT(shared_irq_1, CONFIG_SHARED_IRQ_1_NAME, shared_irq_initialize,
-				&shared_irq_1_runtime, &shared_irq_config_1,
-				POST_KERNEL, CONFIG_SHARED_IRQ_INIT_PRIORITY);
+DEVICE_AND_API_INIT(shared_irq_1, CONFIG_SHARED_IRQ_1_NAME,
+		shared_irq_initialize, &shared_irq_1_runtime,
+		&shared_irq_config_1, POST_KERNEL,
+		CONFIG_SHARED_IRQ_INIT_PRIORITY, &api_funcs);
 
 #if defined(CONFIG_IOAPIC)
 #if defined(CONFIG_SHARED_IRQ_1_FALLING_EDGE)

--- a/drivers/pwm/pwm_pca9685.c
+++ b/drivers/pwm/pwm_pca9685.c
@@ -145,8 +145,6 @@ int pwm_pca9685_init(struct device *dev)
 		return -EPERM;
 	}
 
-	dev->driver_api = &pwm_pca9685_drv_api_funcs;
-
 	return 0;
 }
 
@@ -163,9 +161,10 @@ static const struct pwm_pca9685_config pwm_pca9685_0_cfg = {
 static struct pwm_pca9685_drv_data pwm_pca9685_0_drvdata;
 
 /* This has to init after I2C master */
-DEVICE_INIT(pwm_pca9685_0, CONFIG_PWM_PCA9685_0_DEV_NAME,
+DEVICE_AND_API_INIT(pwm_pca9685_0, CONFIG_PWM_PCA9685_0_DEV_NAME,
 			pwm_pca9685_init,
 			&pwm_pca9685_0_drvdata, &pwm_pca9685_0_cfg,
-			POST_KERNEL, CONFIG_PWM_PCA9685_INIT_PRIORITY);
+			POST_KERNEL, CONFIG_PWM_PCA9685_INIT_PRIORITY,
+			&pwm_pca9685_drv_api_funcs);
 
 #endif /* CONFIG_PWM_PCA9685_0 */

--- a/drivers/sensor/bmi160/bmi160.c
+++ b/drivers/sensor/bmi160/bmi160.c
@@ -895,8 +895,6 @@ int bmi160_init(struct device *dev)
 	}
 #endif
 
-	dev->driver_api = &bmi160_api;
-
 	return 0;
 }
 
@@ -909,5 +907,6 @@ const struct bmi160_device_config bmi160_config = {
 
 
 
-DEVICE_INIT(bmi160, DT_BMI160_NAME, bmi160_init, &bmi160_data,
-	    &bmi160_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY);
+DEVICE_AND_API_INIT(bmi160, DT_BMI160_NAME, bmi160_init, &bmi160_data,
+		&bmi160_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
+		&bmi160_api);

--- a/drivers/sensor/grove/light_sensor.c
+++ b/drivers/sensor/grove/light_sensor.c
@@ -94,12 +94,11 @@ static int gls_init(struct device *dev)
 
 	adc_channel_setup(drv_data->adc, &drv_data->ch10_cfg);
 
-	dev->driver_api = &gls_api;
-
 	return 0;
 }
 
 static struct gls_data gls_data;
 
-DEVICE_INIT(gls_dev, CONFIG_GROVE_LIGHT_SENSOR_NAME, &gls_init, &gls_data,
-	    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY);
+DEVICE_AND_API_INIT(gls_dev, CONFIG_GROVE_LIGHT_SENSOR_NAME, &gls_init,
+		&gls_data, NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
+		&gls_api);

--- a/drivers/sensor/grove/temperature_sensor.c
+++ b/drivers/sensor/grove/temperature_sensor.c
@@ -101,12 +101,11 @@ static int gts_init(struct device *dev)
 
 	adc_channel_setup(drv_data->adc, &drv_data->ch10_cfg);
 
-	dev->driver_api = &gts_api;
-
 	return 0;
 }
 
 static struct gts_data gts_data;
 
-DEVICE_INIT(gts_dev, CONFIG_GROVE_TEMPERATURE_SENSOR_NAME, &gts_init, &gts_data,
-	    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY);
+DEVICE_AND_API_INIT(gts_dev, CONFIG_GROVE_TEMPERATURE_SENSOR_NAME, &gts_init,
+		&gts_data, NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
+		&gts_api);

--- a/drivers/sensor/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/lis3mdl/lis3mdl.c
@@ -160,12 +160,11 @@ int lis3mdl_init(struct device *dev)
 	}
 #endif
 
-	dev->driver_api = &lis3mdl_driver_api;
-
 	return 0;
 }
 
 struct lis3mdl_data lis3mdl_driver;
 
-DEVICE_INIT(lis3mdl, DT_LIS3MDL_NAME, lis3mdl_init, &lis3mdl_driver,
-	    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY);
+DEVICE_AND_API_INIT(lis3mdl, DT_LIS3MDL_NAME, lis3mdl_init, &lis3mdl_driver,
+		NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
+		&lis3mdl_driver_api);

--- a/drivers/sensor/max44009/max44009.c
+++ b/drivers/sensor/max44009/max44009.c
@@ -179,13 +179,11 @@ int max44009_init(struct device *dev)
 		return -EINVAL;
 	}
 
-	dev->driver_api = &max44009_driver_api;
-
 	return 0;
 }
 
 static struct max44009_data max44009_drv_data;
 
-DEVICE_INIT(max44009, CONFIG_MAX44009_DRV_NAME, max44009_init,
+DEVICE_AND_API_INIT(max44009, CONFIG_MAX44009_DRV_NAME, max44009_init,
 	    &max44009_drv_data, NULL, POST_KERNEL,
-	    CONFIG_SENSOR_INIT_PRIORITY);
+	    CONFIG_SENSOR_INIT_PRIORITY, &max44009_driver_api);

--- a/drivers/sensor/tmp112/tmp112.c
+++ b/drivers/sensor/tmp112/tmp112.c
@@ -203,12 +203,10 @@ int tmp112_init(struct device *dev)
 		return -EINVAL;
 	}
 
-	dev->driver_api = &tmp112_driver_api;
-
 	return 0;
 }
 
 static struct tmp112_data tmp112_driver;
 
-DEVICE_INIT(tmp112, CONFIG_TMP112_NAME, tmp112_init, &tmp112_driver,
-	    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY);
+DEVICE_AND_API_INIT(tmp112, CONFIG_TMP112_NAME, tmp112_init, &tmp112_driver,
+	    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &tmp112_driver_api);

--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -189,8 +189,6 @@ static int np_uart_init(struct device *dev)
 		}
 	}
 
-	dev->driver_api = &np_uart_driver_api;
-
 	return 0;
 }
 
@@ -285,10 +283,11 @@ static int np_uart_tty_poll_in(struct device *dev, unsigned char *p_char)
 
 static struct native_uart_status native_uart_status_0;
 
-DEVICE_INIT(uart_native_posix0,
+DEVICE_AND_API_INIT(uart_native_posix0,
 	    CONFIG_UART_NATIVE_POSIX_PORT_0_NAME, &np_uart_init,
 	    (void *)&native_uart_status_0, NULL,
-	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+	    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+	    &np_uart_driver_api);
 
 static void np_add_uart_options(void)
 {

--- a/drivers/serial/uart_nsim.c
+++ b/drivers/serial/uart_nsim.c
@@ -76,8 +76,6 @@ static int uart_nsim_init(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	dev->driver_api = &uart_nsim_driver_api;
-
 	return 0;
 }
 
@@ -113,6 +111,7 @@ static struct uart_device_config uart_nsim_dev_cfg_0 = {
 	.regs = CONFIG_UART_NSIM_PORT_0_BASE_ADDR,
 };
 
-DEVICE_INIT(uart_nsim0, CONFIG_UART_NSIM_PORT_0_NAME, &uart_nsim_init,
+DEVICE_AND_API_INIT(uart_nsim0, CONFIG_UART_NSIM_PORT_0_NAME, &uart_nsim_init,
 			NULL, &uart_nsim_dev_cfg_0,
-			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+			&uart_nsim_driver_api);

--- a/include/device.h
+++ b/include/device.h
@@ -83,8 +83,8 @@ extern "C" {
  * (e.g. CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5).
  */
 #define DEVICE_INIT(dev_name, drv_name, init_fn, data, cfg_info, level, prio) \
-	DEVICE_AND_API_INIT(dev_name, drv_name, init_fn, data, cfg_info,      \
-			    level, prio, NULL)
+	DEVICE_AND_API_INIT(dev_name, drv_name, init_fn,\
+	data, cfg_info, level, prio, NULL)
 
 
 /**

--- a/include/init.h
+++ b/include/init.h
@@ -41,13 +41,14 @@ extern "C" {
  *
  * @param init_fn Pointer to the boot function to run
  *
- * @param level The initialization level, See DEVICE_INIT for details.
+ * @param level The initialization level, See DEVICE_AND_API_INIT for details.
  *
  * @param prio Priority within the selected initialization level. See
- * DEVICE_INIT for details.
+ * DEVICE_AND_API_INIT for details.
  */
 #define SYS_INIT(init_fn, level, prio) \
-	DEVICE_INIT(_SYS_NAME(init_fn), "", init_fn, NULL, NULL, level, prio)
+	DEVICE_AND_API_INIT(_SYS_NAME(init_fn), "", init_fn, NULL, NULL, level,\
+	prio, NULL)
 
 /**
  * @def SYS_DEVICE_DEFINE

--- a/tests/drivers/ipm/src/ipm_dummy.c
+++ b/tests/drivers/ipm/src/ipm_dummy.c
@@ -128,7 +128,6 @@ int ipm_dummy_init(struct device *d)
 	struct ipm_dummy_driver_data *driver_data;
 
 	driver_data = d->driver_data;
-	d->driver_api = &ipm_dummy_api;
 
 	return 0;
 }

--- a/tests/drivers/ipm/src/main.c
+++ b/tests/drivers/ipm/src/main.c
@@ -26,11 +26,13 @@
 
 #define INIT_PRIO_IPM_SEND 50
 
+extern struct ipm_driver_api ipm_dummy_api;
+
 /* Set up the dummy IPM driver */
 struct ipm_dummy_driver_data ipm_dummy0_driver_data;
-DEVICE_INIT(ipm_dummy0, "ipm_dummy0", ipm_dummy_init,
+DEVICE_AND_API_INIT(ipm_dummy0, "ipm_dummy0", ipm_dummy_init,
 	    &ipm_dummy0_driver_data, NULL,
-	    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+	    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &ipm_dummy_api);
 
 /* Sending side of the console IPM driver, will forward anything sent
  * to printf() since we selected IPM_CONSOLE_STDOUT


### PR DESCRIPTION
Modified drivers to use DEVICE_AND_API_INIT() instead of DEVICE_INIT()

This will make sure driver_api, is populated at build time and is exposed
to user space

Signed-off-by: Varun Sharma <varun.sharma@intel.com>