### PR TITLE
net: shell: Update info to enable allocs

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1160,8 +1160,8 @@ static int cmd_net_allocs(const struct shell *shell, size_t argc, char *argv[])
 	PR("memory\t\tStatus\tPool\tFunction alloc -> freed\n");
 	net_pkt_allocs_foreach(allocs_cb, &user_data);
 #else
-	PR_INFO("Enable CONFIG_NET_DEBUG_NET_PKT to see allocations.\n");
-#endif /* CONFIG_NET_DEBUG_NET_PKT */
+	PR_INFO("Enable CONFIG_NET_PKT_LOG_LEVEL_DBG to see allocations.\n");
+#endif /* CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG */
 
 	return 0;
 }


### PR DESCRIPTION
If relevant configs are not enabled shell allocs command would print
wrong info:

"Enable CONFIG_NET_DEBUG_NET_PKT to see allocations"

CONFIG_NET_DEBUG_NET_PKT is obsolete and an undefined symbol, setting it
causes cmake to fail. This patch fixes this issue by printing up-to-date
information on how to enable allocs command

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>