### PR TITLE
cmake: PythonInterp: Fixed a bug related to python detection

### DIFF
--- a/cmake/backports/FindPythonInterp.cmake
+++ b/cmake/backports/FindPythonInterp.cmake
@@ -54,7 +54,7 @@ endfunction()
 # and choose it if it does. This gives this executable the highest
 # priority, which is expected behaviour.
 find_program(PYTHON_EXECUTABLE python)
-if(NOT (${PYTHON_EXECUTABLE} STREQUAL FIND_PY-NOTFOUND))
+if(NOT (${PYTHON_EXECUTABLE} STREQUAL PYTHON_EXECUTABLE-NOTFOUND))
   determine_python_version(${PYTHON_EXECUTABLE} ver)
   if(${ver} VERSION_LESS PythonInterp_FIND_VERSION)
 	# We didn't find the correct version on path, so forget about it


### PR DESCRIPTION
Fixed #11980, a bug where a build failure occured when 'python' was
not on path.

There was a bug in the implementation where it failed to detect that
'python' was not on path. This is now fixed.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>