### PR TITLE
tests: crypto: tinycrypt: Limit to boards with more than 128K flash

### DIFF
--- a/tests/crypto/tinycrypt/testcase.yaml
+++ b/tests/crypto/tinycrypt/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   crypto.tinycrypt:
     tags: tinycrypt crypto aes ccm
     min_ram: 48
+    min_flash: 129


### PR DESCRIPTION
This test can be on the boarder line with systems that only have 128K of
flash.  Limit it systems with more for now.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>