### PR TITLE
doc: samples: Update samples to point to active boards

### DIFF
--- a/samples/basic/blink_led/README.rst
+++ b/samples/basic/blink_led/README.rst
@@ -17,11 +17,6 @@ blinking cycle. This faster-then-slower LED blinking cycle repeats forever.
 Wiring
 ******
 
-Arduino 101 and Quark D2000 CRB
-===============================
-You will need to connect the LED to ground and PWM0 via the shield.
-You may need a current limiting resistor. See your LED datasheet.
-
 Nucleo_F401RE, Nucleo_L476RG, STM32F4_DISCOVERY, Nucleo_F302R8
 ==============================================================
 Connect PWM2(PA0) to LED
@@ -35,9 +30,14 @@ Hexiwear K64
 No special board setup is necessary because there is an on-board RGB LED
 connected to the K64 PWM.
 
-nRF52840_PCA10056
+nrf52840_pca10056
 =================
 No special board setup is necessary because there is an on-board LED connected.
+
+Arduino 101 and Quark D2000 CRB
+===============================
+You will need to connect the LED to ground and PWM0 via the shield.
+You may need a current limiting resistor. See your LED datasheet.
 
 Building and Running
 ********************
@@ -47,7 +47,7 @@ for the arduino_101 board:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blink_led
-   :board: arduino_101
+   :board: nrf52840_pca10056
    :goals: build flash
    :compact:
 

--- a/samples/basic/fade_led/README.rst
+++ b/samples/basic/fade_led/README.rst
@@ -17,12 +17,6 @@ repeat this cycle for ever.
 Wiring
 ******
 
-Arduino 101 and Quark D2000 CRB
-===============================
-You will need to connect the LED to ground and PWM0 via
-the shield. You may need a current limiting resistor. See
-your LED datasheet.
-
 Nucleo_F401RE and Nucleo_L476RG
 ===============================
 Connect PWM2(PA0) to LED
@@ -36,6 +30,17 @@ Hexiwear K64
 No special board setup is necessary because there is an on-board RGB LED
 connected to the K64 PWM.
 
+nrf52840_pca10056
+=================
+No special board setup is necessary because there is an on-board LED connected.
+
+Arduino 101 and Quark D2000 CRB
+===============================
+You will need to connect the LED to ground and PWM0 via
+the shield. You may need a current limiting resistor. See
+your LED datasheet.
+
+
 Building and Running
 ********************
 
@@ -44,6 +49,6 @@ for the arduino_101 board:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/fade_led
-   :board: arduino_101
+   :board: nrf52840_pca10056
    :goals: build flash
    :compact:

--- a/samples/basic/rgb_led/README.rst
+++ b/samples/basic/rgb_led/README.rst
@@ -20,6 +20,11 @@ ever.
 Wiring
 ******
 
+Hexiwear K64
+============
+No special board setup is necessary because there is an on-board RGB LED
+connected to the K64 PWM.
+
 Arduino 101
 ===========
 
@@ -32,11 +37,6 @@ resistor for each of the single color LEDs.
 The sample app requires three PWM ports. So, it can not work
 on Quark D2000 platform.
 
-Hexiwear K64
-============
-No special board setup is necessary because there is an on-board RGB LED
-connected to the K64 PWM.
-
 Building and Running
 ********************
 
@@ -45,6 +45,6 @@ flashed to a board as follows:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/rgb_led
-   :board: arduino_101
+   :board: hexiwear_k64
    :goals: build flash
    :compact:

--- a/samples/basic/servo_motor/README.rst
+++ b/samples/basic/servo_motor/README.rst
@@ -23,6 +23,13 @@ the app if you are using a different servo motor.
 Wiring
 ******
 
+BBC micro:bit
+=============
+
+You will need to connect the motor's red wire to external 5V, the
+black wire to ground and the white wire to pad 0 on the edge
+connector.
+
 Arduino 101 and Quark D2000 CRB
 ===============================
 
@@ -30,12 +37,6 @@ You will need to connect the motor's red wire to 5V,
 the black wire to ground and the white wire to PWM 0 via
 the shield.
 
-BBC micro:bit
-=============
-
-You will need to connect the motor's red wire to external 5V, the
-black wire to ground and the white wire to pad 0 on the edge
-connector.
 
 Building and Running
 ********************
@@ -45,6 +46,6 @@ for the arduino_101 board:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/servo_motor
-   :board: arduino_101
+   :board: bbc_microbit
    :goals: build flash
    :compact:

--- a/samples/bluetooth/hci_usb/README.rst
+++ b/samples/bluetooth/hci_usb/README.rst
@@ -7,8 +7,7 @@ Overview
 ********
 
 Make a USB Bluetooth dongle out of Zephyr. Requires USB device support from the
-board it runs on (e.g. :ref:`arduino_101` has this).
-
+board it runs on (e.g. :ref:`nrf52840_pca10056` supports both BLE and USB).
 
 Requirements
 ************

--- a/samples/net/wifi/README.rst
+++ b/samples/net/wifi/README.rst
@@ -16,12 +16,11 @@ Building and Running
 
 Verify the board and chip you are targeting provide Wi-Fi support.
 
-For instance, Atmel's Winc1500 chip is supported on top of
-quark_se_c1000_devboard board.
+For instance you can use TI's CC3220 by selecting the cc3220sf_launchxl board.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/net/wifi
-   :board: quark_se_c1000_devboard
+   :board: cc3220sf_launchxl
    :goals: build
    :compact:
 


### PR DESCRIPTION
Since the Arduino 101 and the Quark SE C1000 are not actively developed
boards, default to other boards that are maintained and used.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>