### PR TITLE
net: gptp: Update pdelay req lost counter when needed

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_md.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.c
@@ -417,8 +417,10 @@ static void gptp_md_pdelay_req_timeout(struct k_timer *timer)
 		if (timer == &state->pdelay_timer) {
 			state->pdelay_timer_expired = true;
 
-			GPTP_STATS_INC(port,
-				       pdelay_allowed_lost_resp_exceed_count);
+			if (state->rcvd_pdelay_resp == 0) {
+				GPTP_STATS_INC(port,
+					pdelay_allowed_lost_resp_exceed_count);
+			}
 		}
 	}
 }


### PR DESCRIPTION
The pdelay_allowed_lost_resp_exceed_count was updated even if we
had received pdelay response. This affected the state machine
and caused sync failures.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>