### PR TITLE
lib: fdtable: fsync() should not result in fd closure.

### DIFF
--- a/lib/fdtable.c
+++ b/lib/fdtable.c
@@ -188,7 +188,6 @@ int fsync(int fd)
 	}
 
 	res = fdtable[fd].vtable->ioctl(fdtable[fd].obj, ZFD_IOCTL_FSYNC);
-	z_free_fd(fd);
 
 	return res;
 }


### PR DESCRIPTION
Was a copy-paste mistake from close() implementatiion.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>