### PR TITLE
arch: xtensa: Remove unused field from _thread_arch

### DIFF
--- a/arch/xtensa/core/offsets/offsets.c
+++ b/arch/xtensa/core/offsets/offsets.c
@@ -43,10 +43,6 @@ GEN_OFFSET_SYM(tPreempCoprocReg, cpStack);
 /* Xtensa-specific _thread_arch_t structure member offsets */
 GEN_OFFSET_SYM(_thread_arch_t, flags);
 
-#ifdef CONFIG_THREAD_CUSTOM_DATA
-GEN_OFFSET_SYM(_thread_arch_t, custom_data);
-#endif
-
 /* Xtensa-specific ESF structure member offsets */
 GEN_OFFSET_SYM(__esf_t, sp);
 GEN_OFFSET_SYM(__esf_t, pc);

--- a/arch/xtensa/include/kernel_arch_thread.h
+++ b/arch/xtensa/include/kernel_arch_thread.h
@@ -107,9 +107,6 @@ struct _thread_arch {
 	 * fixed offset to read the 'flags' field.
 	 */
 	u32_t flags;
-#ifdef CONFIG_THREAD_CUSTOM_DATA
-	void *custom_data;     /* available for custom use */
-#endif
 #ifdef CONFIG_ERRNO
 	int errno_var;
 #endif


### PR DESCRIPTION
This PR removes the custom_data field from _thread_arch
for xtensa platform as it is currently unused.
