### PR TITLE
drivers: i2c: nrfx: Prevent transfer overlapping

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -15,7 +15,8 @@
 LOG_MODULE_REGISTER(i2c_nrfx_twim);
 
 struct i2c_nrfx_twim_data {
-	struct k_sem sync;
+	struct k_sem transfer_sync;
+	struct k_sem completion_sync;
 	volatile nrfx_err_t res;
 };
 
@@ -39,6 +40,7 @@ static int i2c_nrfx_twim_transfer(struct device *dev, struct i2c_msg *msgs,
 {
 	int ret = 0;
 
+	k_sem_take(&(get_dev_data(dev)->transfer_sync), K_FOREVER);
 	nrfx_twim_enable(&get_dev_config(dev)->twim);
 
 	for (size_t i = 0; i < num_msgs; i++) {
@@ -69,7 +71,7 @@ static int i2c_nrfx_twim_transfer(struct device *dev, struct i2c_msg *msgs,
 			}
 		}
 
-		k_sem_take(&(get_dev_data(dev)->sync), K_FOREVER);
+		k_sem_take(&(get_dev_data(dev)->completion_sync), K_FOREVER);
 		res = get_dev_data(dev)->res;
 		if (res != NRFX_SUCCESS) {
 			LOG_ERR("Error %d occurred for message %d", res, i);
@@ -79,6 +81,7 @@ static int i2c_nrfx_twim_transfer(struct device *dev, struct i2c_msg *msgs,
 	}
 
 	nrfx_twim_disable(&get_dev_config(dev)->twim);
+	k_sem_give(&(get_dev_data(dev)->transfer_sync));
 
 	return ret;
 }
@@ -103,7 +106,7 @@ static void event_handler(nrfx_twim_evt_t const *p_event, void *p_context)
 		break;
 	}
 
-	k_sem_give(&dev_data->sync);
+	k_sem_give(&dev_data->completion_sync);
 }
 
 static int i2c_nrfx_twim_configure(struct device *dev, u32_t dev_config)
@@ -175,7 +178,10 @@ static int init_twim(struct device *dev, const nrfx_twim_config_t *config)
 		return init_twim(dev, &config);				       \
 	}								       \
 	static struct i2c_nrfx_twim_data twim_##idx##_data = {		       \
-		.sync = _K_SEM_INITIALIZER(twim_##idx##_data.sync, 0, 1)       \
+		.transfer_sync = _K_SEM_INITIALIZER(                           \
+			twim_##idx##_data.transfer_sync, 1, 1),                \
+		.completion_sync = _K_SEM_INITIALIZER(                         \
+			twim_##idx##_data.completion_sync, 0, 1)               \
 	};								       \
 	static const struct i2c_nrfx_twim_config twim_##idx##_config = {       \
 		.twim = NRFX_TWIM_INSTANCE(idx)				       \


### PR DESCRIPTION
I2C transfers could simultaneous be called that would cause an inconsistent state in NRFX I2C state (and HW).
The NRFX TWI driver would expect to be in state `NRFX_DRV_STATE_INITIALIZED` while being in state `NRFX_DRV_STATE_POWERED_ON`.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>