### PR TITLE
arch: arm: Remove priv_stack_size field form _thread_arch

### DIFF
--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -99,7 +99,6 @@ void _new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #if CONFIG_USERSPACE
 	thread->arch.mode = 0;
 	thread->arch.priv_stack_start = 0;
-	thread->arch.priv_stack_size = 0;
 #endif
 
 	/* swap_return_value can contain garbage */
@@ -119,8 +118,6 @@ FUNC_NORETURN void _arch_user_mode_enter(k_thread_entry_t user_entry,
 	/* Set up privileged stack before entering user mode */
 	_current->arch.priv_stack_start =
 		(u32_t)_k_priv_stack_find(_current->stack_obj);
-	_current->arch.priv_stack_size =
-		(u32_t)CONFIG_PRIVILEGED_STACK_SIZE;
 
 	/* Truncate the stack size with the MPU region granularity. */
 	_current->stack_info.size &=

--- a/arch/arm/include/kernel_arch_thread.h
+++ b/arch/arm/include/kernel_arch_thread.h
@@ -98,7 +98,6 @@ struct _thread_arch {
 #ifdef CONFIG_USERSPACE
 	u32_t mode;
 	u32_t priv_stack_start;
-	u32_t priv_stack_size;
 #endif
 };
 


### PR DESCRIPTION
This PR removes the priv_stack_size field from the _thread_arch on arm architecture as there is no code using value stored in this variable.
