### PR TITLE
arch: arc: Remove priv_stack_size field form _thread_arch

### DIFF
--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -86,8 +86,6 @@ void _new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	if (options & K_USER) {
 		thread->arch.priv_stack_start =
 			(u32_t)(stackEnd + STACK_GUARD_SIZE);
-		thread->arch.priv_stack_size =
-			(u32_t)(CONFIG_PRIVILEGED_STACK_SIZE);
 
 		stackAdjEnd = (char *)STACK_ROUND_DOWN(stackEnd + STACK_GUARD_SIZE +
 					CONFIG_PRIVILEGED_STACK_SIZE);
@@ -121,7 +119,6 @@ void _new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 		stackEnd += CONFIG_PRIVILEGED_STACK_SIZE + STACK_GUARD_SIZE;
 
 		thread->arch.priv_stack_start = 0;
-		thread->arch.priv_stack_size = 0;
 
 #ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
 		/* reserve stack space for the userspace local data struct */
@@ -249,13 +246,11 @@ FUNC_NORETURN void _arch_user_mode_enter(k_thread_entry_t user_entry,
 	_current->arch.priv_stack_start =
 			(u32_t)(_current->stack_info.start +
 				_current->stack_info.size + STACK_GUARD_SIZE);
-	_current->arch.priv_stack_size =
-			(u32_t)CONFIG_PRIVILEGED_STACK_SIZE;
 
 #ifdef CONFIG_ARC_STACK_CHECKING
 	_current->arch.k_stack_top = _current->arch.priv_stack_start;
 	_current->arch.k_stack_base = _current->arch.priv_stack_start +
-				_current->arch.priv_stack_size;
+				CONFIG_PRIVILEGED_STACK_SIZE;
 	_current->arch.u_stack_top = _current->stack_info.start;
 	_current->arch.u_stack_base = _current->stack_info.start +
 				_current->stack_info.size;

--- a/arch/arc/include/kernel_arch_thread.h
+++ b/arch/arc/include/kernel_arch_thread.h
@@ -71,7 +71,6 @@ struct _thread_arch {
 
 #ifdef CONFIG_USERSPACE
 	u32_t priv_stack_start;
-	u32_t priv_stack_size;
 #endif
 };
 

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -99,7 +99,6 @@ void _new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #if CONFIG_USERSPACE
 	thread->arch.mode = 0;
 	thread->arch.priv_stack_start = 0;
-	thread->arch.priv_stack_size = 0;
 #endif
 
 	/* swap_return_value can contain garbage */
@@ -119,8 +118,6 @@ FUNC_NORETURN void _arch_user_mode_enter(k_thread_entry_t user_entry,
 	/* Set up privileged stack before entering user mode */
 	_current->arch.priv_stack_start =
 		(u32_t)_k_priv_stack_find(_current->stack_obj);
-	_current->arch.priv_stack_size =
-		(u32_t)CONFIG_PRIVILEGED_STACK_SIZE;
 
 	/* Truncate the stack size with the MPU region granularity. */
 	_current->stack_info.size &=

--- a/arch/arm/include/kernel_arch_thread.h
+++ b/arch/arm/include/kernel_arch_thread.h
@@ -98,7 +98,6 @@ struct _thread_arch {
 #ifdef CONFIG_USERSPACE
 	u32_t mode;
 	u32_t priv_stack_start;
-	u32_t priv_stack_size;
 #endif
 };
 


### PR DESCRIPTION
This PR removes the priv_stack_size field from the _thread_arch           
on arc architecture as there is no code using value stored in this variable.  
                                                                                  