### PR TITLE
Bluetooth: nordic ECB hal: Bugfix for simulation

### DIFF
--- a/subsys/bluetooth/controller/hal/nrf5/ecb.c
+++ b/subsys/bluetooth/controller/hal/nrf5/ecb.c
@@ -37,7 +37,7 @@ static void do_ecb(struct ecb_param *ecb)
 		       (NRF_ECB->EVENTS_ERRORECB == 0) &&
 		       (NRF_ECB->ECBDATAPTR != 0)) {
 #if defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
-			__WFE();
+			k_busy_wait(10);
 #else
 			/*__WFE();*/
 #endif


### PR DESCRIPTION
Fix in the do_ecb() function
In real HW this function busy waits for the ECB to be done.
In simulation with the POSIX arch a WFE was added to avoid that infinite loop.
But this function is called with the ECB interrupts disabled.
In normal builds other interrupts will awake the CPU very soon after entering into that WFE, and the problem was not discovered.

But, in controller only builds, during some conformance tests, the loop will hang as no other interrupts are coming.

=> Replace the WFE() with a k_busy_wait (only for simulation)

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>