### PR TITLE
tests: net: ipv6: Fix reference to stack variable

### DIFF
--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -1001,7 +1001,7 @@ static void test_address_lifetime(void)
  */
 static void test_change_ll_addr(void)
 {
-	u8_t new_mac[] = { 00, 01, 02, 03, 04, 05 };
+	static u8_t new_mac[] = { 00, 01, 02, 03, 04, 05 };
 	struct net_linkaddr_storage *ll;
 	struct net_linkaddr *ll_iface;
 	struct net_pkt *pkt;


### PR DESCRIPTION
Valgrind reported this:

==14823== Invalid read of size 4
==14823==    at 0x113FB9: memcpy (string_fortified.h:34)
==14823==    by 0x113FB9: ethernet_fill_header (ethernet.c:483)
==14823==    by 0x113FB9: ethernet_send (ethernet.c:588)
==14823==    by 0x116720: net_if_tx (net_if.c:173)
==14823==    by 0x116720: process_tx_packet (net_if.c:211)
==14823==    by 0x10FDB6: z_work_q_main (work_q.c:32)
==14823==    by 0x10FD55: _thread_entry (thread_entry.c:29)
==14823==    by 0x111CF7: posix_thread_starter (posix_core.c:301)
==14823==    by 0x49673BC: start_thread (pthread_create.c:463)
==14823==    by 0x4A78E15: clone (clone.S:108)
==14823==  Address 0x87822a6 is in a rw- anonymous segment

The issue is that we had a pointer that pointed to local stack
variable and that pointer was used to access stuff after the
test function had returned.

Fixes #12006

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>