### PR TITLE
[DNM] sanitycheck: Fail test if the process returns != 0

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -401,7 +401,9 @@ class BinaryHandler(Handler):
 
         subprocess.call(["stty", "sane"])
         self.instance.results = harness.tests
-        if harness.state:
+        if self.returncode != 0:
+            self.set_state(out_state, {})
+        elif harness.state:
             self.set_state(harness.state, {})
         else:
             self.set_state(out_state, {})


### PR DESCRIPTION
If the test process returns an error (return code != 0),
it should be considered a failure, even if the handler considers the test passed.

Otherwise, for example, when running with valgrind, all valgrind errors are missed.