### PR TITLE
scripts: extract_dts_includes: Rework get_binding

### DIFF
--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -293,23 +293,20 @@ def add_prop_aliases(node_address,
 
 def get_binding(node_address):
     compat = get_compat(node_address)
+
+    # For just look for the binding in the main dict
+    # if we find it here, return it, otherwise it best
+    # be in the bus specific dict
+    if compat in bindings:
+        return bindings[compat]
+
     parent_addr = get_parent_address(node_address)
     parent_compat = get_compat(parent_addr)
 
-    if parent_compat in get_binding_compats():
-        parent_binding = bindings[parent_compat]
+    parent_binding = bindings[parent_compat]
 
-        if 'child' in parent_binding:
-            bus = parent_binding['child']['bus']
-            try:
-                binding = bus_bindings[bus][compat]
-            except:
-                binding = bindings[compat]
-
-        else:
-            binding = bindings[compat]
-    else:
-        binding = bindings[compat]
+    bus = parent_binding['child']['bus']
+    binding = bus_bindings[bus][compat]
 
     return binding
 


### PR DESCRIPTION
The original version of get_binding didn't handle the case of having a
child node on a SPI or I2C device node.  The example is a SPI flash and
having a partition node under that.

Re-work the binding lookup logic to first look in the master bindings
dict, and if not found there we assume it must be in the bus specific
dictionary, and we can use the parent node to find the bus type.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>