### PR TITLE
Issue8758 migrate nRF sensor temp config to dts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -137,6 +137,7 @@
 /dts/arm/nordic/                          @ioannisg @carlescufi
 /dts/arm/nxp/                             @MaureenHelm
 /dts/bindings/can/                        @alexanderwachter
+/dts/bindings/*/nordic*                   @anangl
 /dts/bindings/*/nxp*                      @MaureenHelm
 /ext/fs/                                  @nashif @ramakrishnapallala
 /ext/hal/cmsis/                           @MaureenHelm @galak

--- a/drivers/sensor/nrf5/Kconfig
+++ b/drivers/sensor/nrf5/Kconfig
@@ -20,12 +20,4 @@ config TEMP_NRF5_NAME
 	help
 	  Device name with which the nRF5 temperature sensor is identified.
 
-config TEMP_NRF5_PRI
-	int "TEMP interrupt priority"
-	range 0 1 if SOC_SERIES_NRF51X
-	range 0 5 if SOC_SERIES_NRF52X
-	default 1
-	help
-	  nRF5X TEMP IRQ priority.
-
 endif # TEMP_NRF5

--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -13,7 +13,6 @@
 LOG_MODULE_REGISTER(TEMPNRF5);
 
 #include "nrf.h"
-#include "nrf_common.h"
 
 
 /* The nRF5 temperature device returns measurements in 0.25C
@@ -30,7 +29,6 @@ struct temp_nrf5_data {
 
 static int temp_nrf5_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
-	volatile NRF_TEMP_Type *temp = NRF_TEMP;
 	struct temp_nrf5_data *data = dev->driver_data;
 	int r;
 
@@ -47,15 +45,15 @@ static int temp_nrf5_sample_fetch(struct device *dev, enum sensor_channel chan)
 	r = clock_control_on(data->clk_m16_dev, (void *)1);
 	__ASSERT_NO_MSG(!r);
 
-	temp->TASKS_START = 1;
+	NRF_TEMP->TASKS_START = 1;
 	k_sem_take(&data->device_sync_sem, K_FOREVER);
 
 	r = clock_control_off(data->clk_m16_dev, (void *)1);
 	__ASSERT_NO_MSG(!r || r == -EBUSY);
 
-	data->sample = temp->TEMP;
+	data->sample = NRF_TEMP->TEMP;
 
-	temp->TASKS_STOP = 1;
+	NRF_TEMP->TASKS_STOP = 1;
 
 	return 0;
 }
@@ -82,11 +80,10 @@ static int temp_nrf5_channel_get(struct device *dev,
 
 static void temp_nrf5_isr(void *arg)
 {
-	volatile NRF_TEMP_Type *temp = NRF_TEMP;
 	struct device *dev = (struct device *)arg;
 	struct temp_nrf5_data *data = dev->driver_data;
 
-	temp->EVENTS_DATARDY = 0;
+	NRF_TEMP->EVENTS_DATARDY = 0;
 	k_sem_give(&data->device_sync_sem);
 }
 
@@ -95,18 +92,10 @@ static const struct sensor_driver_api temp_nrf5_driver_api = {
 	.channel_get = temp_nrf5_channel_get,
 };
 
-static int temp_nrf5_init(struct device *dev);
-
-static struct temp_nrf5_data temp_nrf5_driver;
-
-DEVICE_AND_API_INIT(temp_nrf5, CONFIG_TEMP_NRF5_NAME, temp_nrf5_init,
-		    &temp_nrf5_driver, NULL,
-		    POST_KERNEL,
-		    CONFIG_SENSOR_INIT_PRIORITY, &temp_nrf5_driver_api);
+DEVICE_DECLARE(temp_nrf5);
 
 static int temp_nrf5_init(struct device *dev)
 {
-	volatile NRF_TEMP_Type *temp = NRF_TEMP;
 	struct temp_nrf5_data *data = dev->driver_data;
 
 	LOG_DBG("");
@@ -124,7 +113,18 @@ static int temp_nrf5_init(struct device *dev)
 		0);
 	irq_enable(DT_NORDIC_NRF_TEMP_0_IRQ_0);
 
-	temp->INTENSET = TEMP_INTENSET_DATARDY_Set;
+	NRF_TEMP->INTENSET = TEMP_INTENSET_DATARDY_Set;
 
 	return 0;
 }
+
+static struct temp_nrf5_data temp_nrf5_driver;
+
+DEVICE_AND_API_INIT(temp_nrf5,
+		    CONFIG_TEMP_NRF5_NAME,
+		    temp_nrf5_init,
+		    &temp_nrf5_driver,
+		    NULL,
+		    POST_KERNEL,
+		    CONFIG_SENSOR_INIT_PRIORITY,
+		    &temp_nrf5_driver_api);

--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -116,9 +116,13 @@ static int temp_nrf5_init(struct device *dev)
 	__ASSERT_NO_MSG(data->clk_m16_dev);
 
 	k_sem_init(&data->device_sync_sem, 0, UINT_MAX);
-	IRQ_CONNECT(NRF5_IRQ_TEMP_IRQn, CONFIG_TEMP_NRF5_PRI,
-		    temp_nrf5_isr, DEVICE_GET(temp_nrf5), 0);
-	irq_enable(NRF5_IRQ_TEMP_IRQn);
+	IRQ_CONNECT(
+		DT_NORDIC_NRF_TEMP_0_IRQ_0,
+		DT_NORDIC_NRF_TEMP_0_IRQ_0_PRIORITY,
+		temp_nrf5_isr,
+		DEVICE_GET(temp_nrf5),
+		0);
+	irq_enable(DT_NORDIC_NRF_TEMP_0_IRQ_0);
 
 	temp->INTENSET = TEMP_INTENSET_DATARDY_Set;
 

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -186,6 +186,14 @@
 			label = "TIMER_2";
 		};
 
+		temp: temp@4000c000 {
+			compatible = "nordic,nrf-temp";
+			reg = <0x4000c000 0x1000>;
+			interrupts = <12 1>;
+			status = "ok";
+			label = "TEMP_0";
+		};
+
 		wdt: watchdog@40010000 {
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -173,6 +173,14 @@
 			label = "TIMER_2";
 		};
 
+		temp: temp@4000c000 {
+			compatible = "nordic,nrf-temp";
+			reg = <0x4000c000 0x1000>;
+			interrupts = <12 1>;
+			status = "ok";
+			label = "TEMP_0";
+		};
+
 		wdt: watchdog@40010000 {
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -253,6 +253,14 @@
 			label = "TIMER_4";
 		};
 
+		temp: temp@4000c000 {
+			compatible = "nordic,nrf-temp";
+			reg = <0x4000c000 0x1000>;
+			interrupts = <12 1>;
+			status = "ok";
+			label = "TEMP_0";
+		};
+
 		wdt: watchdog@40010000 {
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -296,6 +296,14 @@
 			label = "TIMER_4";
 		};
 
+		temp: temp@4000c000 {
+			compatible = "nordic,nrf-temp";
+			reg = <0x4000c000 0x1000>;
+			interrupts = <12 1>;
+			status = "ok";
+			label = "TEMP_0";
+		};
+
 		usbd: usbd@40027000 {
 			compatible = "nordic,nrf-usbd";
 			reg = <0x40027000 0x1000>;

--- a/dts/bindings/sensor/nordic,nrf-temp.yaml
+++ b/dts/bindings/sensor/nordic,nrf-temp.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2018, Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: Nordic nRF Family TEMP node
+version: 0.1
+
+description: >
+    This is a representation of the Nordic nRF TEMP node
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "nordic,nrf-temp"
+
+    reg:
+      type: array
+      category: required
+      description: mmio register space
+      generation: define
+
+    interrupts:
+      type: array
+      category: required
+      description: required interrupts
+      generation: define
+...


### PR DESCRIPTION
1. Added Temp device node to nRF5 devices with yaml binding.
2. Removed Kconfig Temp priority setting, modified temp_nrf5.c driver to use DT defines.
3. Modified temp_nrf5.c driver to use DT base address define.
4. Added new nrf52 board temperature sensor sample.

Related to #8758. 