### PR TITLE
cmake: Fixed a bug in 'cmake -DCONFIG_'

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -166,5 +166,24 @@ endforeach()
 
 add_custom_target(config-sanitycheck DEPENDS ${DOTCONFIG})
 
+# Remove the CLI Kconfig symbols from the namespace and
+# CMakeCache.txt. If the symbols end up in DOTCONFIG they will be
+# re-introduced to the namespace through 'import_kconfig'.
+foreach (name ${cache_variable_names})
+  if("${name}" MATCHES "^CONFIG_")
+	unset(${name})
+	unset(${name} CACHE)
+  endif()
+endforeach()
+
 # Parse the lines prefixed with CONFIG_ in the .config file from Kconfig
 import_kconfig(${DOTCONFIG})
+
+# Re-introduce the CLI Kconfig symbols that survived
+foreach (name ${cache_variable_names})
+  if("${name}" MATCHES "^CONFIG_")
+	if(DEFINED ${name})
+	  set(${name} ${${name}} CACHE STRING "")
+	endif()
+  endif()
+endforeach()


### PR DESCRIPTION
Due to popular demand there exists an experimental feature with
undefined and undocumented semantics that permits Kconfig options to be
specified on the CMake CLI.

Like so:

cmake -DCONFIG_BUILD_OUTPUT_BIN=y

This patch fixes a bug where it was possible to have a mismatch
between the build/zephyr/.config file and the CMake namespace of
'CONFIG_' values.

We now pop all CLI Kconfig symbols from the CMakeCache.txt and then
push only the CLI Kconfig symbols that exist in the active .config
file.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>