### PR TITLE
Import dt into cmake namespace

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -193,7 +193,7 @@ if(CONFIG_HAS_DTS)
     message(FATAL_ERROR "command failed with return code: ${ret}")
   endif()
 
-  import_kconfig(${GENERATED_DTS_BOARD_CONF})
+  import_kconfig(CONFIG_ ${GENERATED_DTS_BOARD_CONF})
 
 else()
   file(WRITE ${GENERATED_DTS_BOARD_H} "/* WARNING. THIS FILE IS AUTO-GENERATED. DO NOT MODIFY! */")

--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -194,6 +194,7 @@ if(CONFIG_HAS_DTS)
   endif()
 
   import_kconfig(CONFIG_ ${GENERATED_DTS_BOARD_CONF})
+  import_kconfig(DT_     ${GENERATED_DTS_BOARD_CONF})
 
 else()
   file(WRITE ${GENERATED_DTS_BOARD_H} "/* WARNING. THIS FILE IS AUTO-GENERATED. DO NOT MODIFY! */")

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -745,15 +745,15 @@ endfunction()
 # 2.2 Misc
 #
 # Parse a KConfig fragment (typically with extension .config) and
-# introduce all the symbols that are prefixed with 'CONFIG_' into the
+# introduce all the symbols that are prefixed with 'prefix' into the
 # CMake namespace
-function(import_kconfig kconfig_fragment)
-  # Parse the lines prefixed with 'CONFIG_' in ${kconfig_fragment}
+function(import_kconfig prefix kconfig_fragment)
+  # Parse the lines prefixed with 'prefix' in ${kconfig_fragment}
   file(
     STRINGS
     ${kconfig_fragment}
     DOT_CONFIG_LIST
-    REGEX "^CONFIG_"
+    REGEX "^${prefix}"
     ENCODING "UTF-8"
   )
 

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -744,20 +744,21 @@ endfunction()
 
 # 2.2 Misc
 #
-# Parse a KConfig formatted file (typically named *.config) and
-# introduce all the CONF_ variables into the CMake namespace
-function(import_kconfig config_file)
-  # Parse the lines prefixed with CONFIG_ in ${config_file}
+# Parse a KConfig fragment (typically with extension .config) and
+# introduce all the symbols that are prefixed with 'CONFIG_' into the
+# CMake namespace
+function(import_kconfig kconfig_fragment)
+  # Parse the lines prefixed with 'CONFIG_' in ${kconfig_fragment}
   file(
     STRINGS
-    ${config_file}
+    ${kconfig_fragment}
     DOT_CONFIG_LIST
     REGEX "^CONFIG_"
     ENCODING "UTF-8"
   )
 
   foreach (CONFIG ${DOT_CONFIG_LIST})
-    # CONFIG looks like: CONFIG_NET_BUF=y
+    # CONFIG could look like: CONFIG_NET_BUF=y
 
     # Match the first part, the variable name
     string(REGEX MATCH "[^=]+" CONF_VARIABLE_NAME ${CONFIG})

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -177,7 +177,7 @@ foreach (name ${cache_variable_names})
 endforeach()
 
 # Parse the lines prefixed with CONFIG_ in the .config file from Kconfig
-import_kconfig(${DOTCONFIG})
+import_kconfig(CONFIG_ ${DOTCONFIG})
 
 # Re-introduce the CLI Kconfig symbols that survived
 foreach (name ${cache_variable_names})


### PR DESCRIPTION
CMake parses the Kconfig output for 'CONFIG_*' symbols and adds them
to the CMake namespace.

It does the same for DT, but has only been including 'CONFIG_' symbols
and been ignoring the 'DT_' symbols.

For DeviceTree to be useful, it's information needs to be accessible
from CMake, just like Kconfig is.

To this end we also introduce the 'DT_' symbols into the CMake
namespace.

This resolves #11109