### PR TITLE
samples: sockets: echo_async: Don't include <sys/fcntl.h>

### DIFF
--- a/samples/net/sockets/echo_async/src/socket_echo.c
+++ b/samples/net/sockets/echo_async/src/socket_echo.c
@@ -21,7 +21,7 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(net_echo_async_sample, LOG_LEVEL_DBG);
 
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <net/socket.h>
 #include <kernel.h>
 #include <net/net_app.h>


### PR DESCRIPTION
POSIX doesn't mandate such a header, only <fcntl.h>. <sys/fnctl.h>
is just an internal implementation detail of Newlib on which we should
not rely.

This makes it possible to build this sample against minimal libc.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>