### PR TITLE
Sanitycheck improvements

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -382,7 +382,10 @@ class BinaryHandler(Handler):
 
         if shutil.which("valgrind") and self.valgrind:
             command = ["valgrind", "--error-exitcode=2",
-                       "--leak-check=full"] + command
+                       "--leak-check=full",
+                       "--suppressions="+ZEPHYR_BASE+"/scripts/valgrind.supp",
+                       "--log-file="+self.outdir+"/valgrind.log"
+                       ] + command
 
         with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
             t = threading.Thread(target=self._output_reader, args=(proc, harness, ))

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -343,6 +343,7 @@ class BinaryHandler(Handler):
         super().__init__(instance)
 
         self.valgrind = False
+        self.terminated = False
 
     def _output_reader(self, proc, harness):
         log_out_fp = open(self.log, "wt")
@@ -352,13 +353,18 @@ class BinaryHandler(Handler):
             log_out_fp.flush()
             harness.handle(line.decode('utf-8').rstrip())
             if harness.state:
-                proc.terminate()
+                try:
+                    #POSIX arch based ztests end on their own,
+                    #so let's give it up to 100ms to do so
+                    proc.wait(0.1)
+                except subprocess.TimeoutExpired:
+                    proc.terminate()
+                    self.terminated = True
                 break
 
         log_out_fp.close()
 
     def handle(self):
-        out_state = "failed"
 
         harness_name = self.instance.test.harness.capitalize()
         harness_import = HarnessImporter(harness_name)
@@ -384,13 +390,10 @@ class BinaryHandler(Handler):
             t.join(self.timeout)
             if t.is_alive():
                 proc.terminate()
-                out_state = "timeout"
+                self.terminated = True
                 t.join()
-
             proc.wait()
             self.returncode = proc.returncode
-            if proc.returncode != 0:
-                out_state = "failed"
 
         if options.enable_coverage:
             returncode = subprocess.call(["GCOV_PREFIX=" + self.outdir,
@@ -401,10 +404,14 @@ class BinaryHandler(Handler):
 
         subprocess.call(["stty", "sane"])
         self.instance.results = harness.tests
-        if harness.state:
+        if self.terminated==False and self.returncode != 0:
+            #When a process is killed, the default handler returns 128 + SIGTERM
+            #so in that case the return code itself is not meaningful
+            self.set_state("error", {})
+        elif harness.state:
             self.set_state(harness.state, {})
         else:
-            self.set_state(out_state, {})
+            self.set_state("timeout", {})
 
 class DeviceHandler(Handler):
 

--- a/scripts/valgrind.supp
+++ b/scripts/valgrind.supp
@@ -1,0 +1,26 @@
+{
+   getpwuid() libC issue
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:realloc
+   fun:load_blacklist
+   fun:bindresvport
+}
+{
+   POSIX arch no thread cleanup
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:pthread_create*
+   fun:posix_new_thread
+}
+{
+   POSIX arch no cpu cleanup
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:pthread_create*
+   fun:posix_boot_cpu
+   fun:main
+}


### PR DESCRIPTION
* sanitycheck: Fail test if the process returns != 0:
If the test process returns an error (return code != 0), it should be considered a failure, even if the handler considers the test passed.
One error was hidden due to this: #12043
Also without this, when running with valgrind, all valgrind errors are missed.
* valgrind: Add error suppression file for POSIX arch
* sanitycheck: Use suppression file for valgrind and dump valgrind's log into its own file so it can be inspected afterwards.