### PR TITLE
drivers: timer: fix disable systick function

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -145,5 +145,5 @@ void z_clock_idle_exit(void)
 
 void sys_clock_disable(void)
 {
-	SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
+	SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
 }


### PR DESCRIPTION
This patch fixes a bug in System timer driver where
the sys_clock_disable() function was enabling the
timer instead of disabling it.

Signed-off-by: David Vincze <david.vincze@arm.com>