### PR TITLE
nvs: avoid reading multiple times the same area

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -603,7 +603,11 @@ int nvs_reinit(struct nvs_fs *fs)
 	int rc;
 	struct nvs_ate last_ate;
 	size_t ate_size, empty_len;
-	u32_t addr;
+	/* Initialize addr to 0 for the case fs->sector_count == 0. This
+	 * should never happen as this is verified in nvs_init() but both
+	 * Coverity and GCC believe the contrary.
+	 */
+	u32_t addr = 0;
 
 
 	k_mutex_lock(&fs->nvs_lock, K_FOREVER);


### PR DESCRIPTION
The current NVS code checks for an empty or a closed ATE using the
_nvs_flash_cmp_const() function. This function loads the data and
compare them to a value. This means that when executed multiple on
the same area, the data get reloaded multiple time. This might have
a noticeable performance impact with an SPI flash.

Instead define two functions checking if an ATE is empty or closed
on an already read struct nvs_ate. Then replace the calls to
_nvs_flash_cmp_const() on struct nvs_ate by _nvs_flash_ate_rd() plus
those new functions. This also has the advantage of explicitly checking
for errors instead of testing the error and the result of the comparison
at the same time.

Tested on a Nucleo L432KC board. The maximum initialization time (ie
just before running the first garbage collector) goes down to 21ms from
32ms.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>