### PR TITLE
logging: Fix allocation of single chunk log messages

### DIFF
--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -152,7 +152,7 @@ static struct log_msg *msg_alloc(u32_t nargs)
 	struct  log_msg *msg = _log_msg_std_alloc();
 	int n = (int)nargs;
 
-	if (!msg) {
+	if (!msg || nargs <= LOG_MSG_NARGS_SINGLE_CHUNK) {
 		return msg;
 	}
 


### PR DESCRIPTION
Generic log message allocator was wrongly allocating single
chunk messages as initialy it was intended to allocate only
multichunk messages. It resulted in invalid pointer being freed
on log message free. Issue detected by valgrind.

Fixes #12043.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>