### PR TITLE
subsys: logging: Enable log only when backend initializes

### DIFF
--- a/include/logging/log_backend.h
+++ b/include/logging/log_backend.h
@@ -8,6 +8,7 @@
 
 #include <logging/log_msg.h>
 #include <assert.h>
+#include <stdbool.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -31,7 +32,7 @@ struct log_backend_api {
 
 	void (*dropped)(const struct log_backend *const backend, u32_t cnt);
 	void (*panic)(const struct log_backend *const backend);
-	void (*init)(void);
+	bool (*init)(void);
 };
 
 /**

--- a/subsys/logging/log_backend_net.c
+++ b/subsys/logging/log_backend_net.c
@@ -208,7 +208,7 @@ static void send_output(const struct log_backend *const backend,
 	log_msg_put(msg);
 }
 
-static void init_net(void)
+static bool init_net(void)
 {
 	int ret;
 
@@ -219,10 +219,12 @@ static void init_net(void)
 			       &server_addr);
 	if (!ret) {
 		LOG_ERR("Cannot configure syslog server address");
-		return;
+		return false;
 	}
 
 	log_backend_deactivate(log_backend_net_get());
+
+	return true;
 }
 
 static void panic(struct log_backend const *const backend)

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <soc.h>
 #include <logging/log_backend.h>
 #include <logging/log_core.h>
 #include <logging/log_msg.h>
@@ -207,14 +208,22 @@ static void log_backend_rtt_cfg(void)
 				  SEGGER_RTT_MODE_NO_BLOCK_SKIP);
 }
 
-static void log_backend_rtt_init(void)
+static bool log_backend_rtt_init(void)
 {
+#if defined(CoreDebug_DHCSR_C_DEBUGEN_Msk)
+	if ((CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) == 0) {
+		return false;
+	}
+#endif
+
 	if (CONFIG_LOG_BACKEND_RTT_BUFFER > 0) {
 		log_backend_rtt_cfg();
 	}
 
 	panic_mode = 0;
 	line_pos = line_buf;
+
+	return true;
 }
 
 static void panic(struct log_backend const *const backend)

--- a/subsys/logging/log_backend_uart.c
+++ b/subsys/logging/log_backend_uart.c
@@ -48,7 +48,7 @@ static void put(const struct log_backend *const backend,
 
 }
 
-static void log_backend_uart_init(void)
+static bool log_backend_uart_init(void)
 {
 	struct device *dev;
 
@@ -56,6 +56,8 @@ static void log_backend_uart_init(void)
 	assert(dev);
 
 	log_output_ctx_set(&log_output, dev);
+
+	return true
 }
 
 static void panic(struct log_backend const *const backend)

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -269,11 +269,16 @@ void log_init(void)
 		const struct log_backend *backend = log_backend_get(i);
 
 		if (backend->autostart) {
+			bool ready = true;
+
 			if (backend->api->init) {
-				backend->api->init();
+				ready = backend->api->init();
 			}
 
-			log_backend_enable(backend, NULL, CONFIG_LOG_MAX_LEVEL);
+			if (ready) {
+				log_backend_enable(backend, NULL,
+						   CONFIG_LOG_MAX_LEVEL);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Do not enable log if backend initialization function fails.
For RTT backend fail initialization function if JLink is not connected.
This is to prevent logger lockout when in panic mode if debugger
was not connected to the system.

Fixes #12051

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>