### PR TITLE
samples: mesh: additional improvements as per Mesh developer study guide

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -164,7 +164,9 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	}
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -190,7 +192,8 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	k_timer_stop(ptr_timer);
 
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_onoff = onoff;
 
@@ -227,7 +230,9 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	}
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -253,7 +258,8 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	k_timer_stop(ptr_timer);
 
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_onoff = onoff;
 
@@ -350,7 +356,9 @@ static void gen_level_set_unack(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -376,7 +384,8 @@ static void gen_level_set_unack(struct bt_mesh_model *model,
 	k_timer_stop(ptr_timer);
 
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_level = level;
 
@@ -419,7 +428,9 @@ static void gen_level_set(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -445,7 +456,8 @@ static void gen_level_set(struct bt_mesh_model *model,
 	k_timer_stop(ptr_timer);
 
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_level = level;
 
@@ -490,7 +502,9 @@ static void gen_delta_set_unack(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 
 		if (state->last_delta == delta) {
@@ -523,10 +537,11 @@ static void gen_delta_set_unack(struct bt_mesh_model *model,
 	*ptr_counter = 0U;
 	k_timer_stop(ptr_timer);
 
-	state->last_delta = delta;
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
+	state->last_delta = delta;
 
 	if (tmp32 < INT16_MIN) {
 		tmp32 = INT16_MIN;
@@ -576,7 +591,9 @@ static void gen_delta_set(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 
 		if (state->last_delta == delta) {
@@ -609,10 +626,11 @@ static void gen_delta_set(struct bt_mesh_model *model,
 	*ptr_counter = 0U;
 	k_timer_stop(ptr_timer);
 
-	state->last_delta = delta;
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
+	state->last_delta = delta;
 
 	if (tmp32 < INT16_MIN) {
 		tmp32 = INT16_MIN;
@@ -718,7 +736,9 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -743,10 +763,11 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 	*ptr_counter = 0U;
 	k_timer_stop(ptr_timer);
 
-	state->last_delta = delta;
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
+	state->last_delta = delta;
 
 	tmp32 = state->level + delta;
 	if (tmp32 < INT16_MIN) {
@@ -794,7 +815,9 @@ static void gen_move_set(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -819,10 +842,11 @@ static void gen_move_set(struct bt_mesh_model *model,
 	*ptr_counter = 0U;
 	k_timer_stop(ptr_timer);
 
-	state->last_delta = delta;
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
+	state->last_delta = delta;
 
 	tmp32 = state->level + delta;
 	if (tmp32 < INT16_MIN) {
@@ -1082,13 +1106,16 @@ static void vnd_set_unack(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
-	    (now - state->last_msg_timestamp <= 6000)) {
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
+	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
 
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->current = current;
 
@@ -1180,7 +1207,9 @@ static void light_lightness_set_unack(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -1206,7 +1235,8 @@ static void light_lightness_set_unack(struct bt_mesh_model *model,
 	k_timer_stop(ptr_timer);
 
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 
 	if (actual > 0 && actual < state->light_range_min) {
@@ -1247,7 +1277,9 @@ static void light_lightness_set(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -1273,7 +1305,8 @@ static void light_lightness_set(struct bt_mesh_model *model,
 	k_timer_stop(ptr_timer);
 
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 
 	if (actual > 0 && actual < state->light_range_min) {
@@ -1364,7 +1397,9 @@ static void light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -1390,7 +1425,8 @@ static void light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	k_timer_stop(ptr_timer);
 
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_linear = linear;
 
@@ -1424,7 +1460,9 @@ static void light_lightness_linear_set(struct bt_mesh_model *model,
 	tid = net_buf_simple_pull_u8(buf);
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -1450,7 +1488,8 @@ static void light_lightness_linear_set(struct bt_mesh_model *model,
 	k_timer_stop(ptr_timer);
 
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_linear = linear;
 
@@ -1781,7 +1820,9 @@ static void light_ctl_set_unack(struct bt_mesh_model *model,
 	}
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -1807,7 +1848,8 @@ static void light_ctl_set_unack(struct bt_mesh_model *model,
 	k_timer_stop(ptr_timer);
 
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_lightness = lightness;
 
@@ -1861,7 +1903,9 @@ static void light_ctl_set(struct bt_mesh_model *model,
 	}
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -1887,7 +1931,8 @@ static void light_ctl_set(struct bt_mesh_model *model,
 	k_timer_stop(ptr_timer);
 
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_lightness = lightness;
 
@@ -2241,7 +2286,9 @@ static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	}
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -2267,7 +2314,8 @@ static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	k_timer_stop(ptr_timer);
 
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 
 	if (temp < state->temp_range_min) {
@@ -2317,7 +2365,9 @@ static void light_ctl_temp_set(struct bt_mesh_model *model,
 	}
 
 	now = k_uptime_get();
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr &&
+	if (state->last_tid == tid &&
+	    state->last_src_addr == ctx->addr &&
+	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 		return;
 	}
@@ -2343,7 +2393,8 @@ static void light_ctl_temp_set(struct bt_mesh_model *model,
 	k_timer_stop(ptr_timer);
 
 	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	state->last_src_addr = ctx->addr;
+	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 
 	if (temp < state->temp_range_min) {

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -168,7 +168,7 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
-		return;
+		goto ret;
 	}
 
 	switch (buf->len) {
@@ -200,7 +200,7 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	if (state->target_onoff != state->onoff) {
 		onoff_tt_values(state, tt, delay);
 	} else {
-		gen_onoff_publish(model);
+ret:		gen_onoff_publish(model);
 		return;
 	}
 
@@ -234,7 +234,7 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
-		return;
+		goto ret;
 	}
 
 	switch (buf->len) {
@@ -266,7 +266,7 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	if (state->target_onoff != state->onoff) {
 		onoff_tt_values(state, tt, delay);
 	} else {
-		gen_onoff_get(model, ctx, buf);
+ret:		gen_onoff_get(model, ctx, buf);
 		gen_onoff_publish(model);
 		return;
 	}
@@ -360,7 +360,7 @@ static void gen_level_set_unack(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
-		return;
+		goto ret;
 	}
 
 	switch (buf->len) {
@@ -392,7 +392,7 @@ static void gen_level_set_unack(struct bt_mesh_model *model,
 	if (state->target_level != state->level) {
 		level_tt_values(state, tt, delay);
 	} else {
-		gen_level_publish(model);
+ret:		gen_level_publish(model);
 		return;
 	}
 
@@ -432,7 +432,7 @@ static void gen_level_set(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
-		return;
+		goto ret;
 	}
 
 	switch (buf->len) {
@@ -464,7 +464,7 @@ static void gen_level_set(struct bt_mesh_model *model,
 	if (state->target_level != state->level) {
 		level_tt_values(state, tt, delay);
 	} else {
-		gen_level_get(model, ctx, buf);
+ret:		gen_level_get(model, ctx, buf);
 		gen_level_publish(model);
 		return;
 	}
@@ -508,7 +508,7 @@ static void gen_delta_set_unack(struct bt_mesh_model *model,
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 
 		if (state->last_delta == delta) {
-			return;
+			goto ret;
 		}
 		tmp32 = state->last_level + delta;
 
@@ -554,7 +554,7 @@ static void gen_delta_set_unack(struct bt_mesh_model *model,
 	if (state->target_level != state->level) {
 		level_tt_values(state, tt, delay);
 	} else {
-		gen_level_publish(model);
+ret:		gen_level_publish(model);
 		return;
 	}
 
@@ -597,7 +597,7 @@ static void gen_delta_set(struct bt_mesh_model *model,
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
 
 		if (state->last_delta == delta) {
-			return;
+			goto ret;
 		}
 		tmp32 = state->last_level + delta;
 
@@ -643,7 +643,7 @@ static void gen_delta_set(struct bt_mesh_model *model,
 	if (state->target_level != state->level) {
 		level_tt_values(state, tt, delay);
 	} else {
-		gen_level_get(model, ctx, buf);
+ret:		gen_level_get(model, ctx, buf);
 		gen_level_publish(model);
 		return;
 	}
@@ -740,6 +740,7 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
+		gen_level_move_publish(model);
 		return;
 	}
 
@@ -819,6 +820,8 @@ static void gen_move_set(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
+		gen_level_move_get(model, ctx, buf);
+		gen_level_move_publish(model);
 		return;
 	}
 
@@ -1211,6 +1214,7 @@ static void light_lightness_set_unack(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
+		goto ret;
 		return;
 	}
 
@@ -1250,7 +1254,7 @@ static void light_lightness_set_unack(struct bt_mesh_model *model,
 	if (state->target_actual != state->actual) {
 		light_lightness_actual_tt_values(state, tt, delay);
 	} else {
-		light_lightness_publish(model);
+ret:		light_lightness_publish(model);
 		return;
 	}
 
@@ -1281,6 +1285,7 @@ static void light_lightness_set(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
+		goto ret;
 		return;
 	}
 
@@ -1320,7 +1325,7 @@ static void light_lightness_set(struct bt_mesh_model *model,
 	if (state->target_actual != state->actual) {
 		light_lightness_actual_tt_values(state, tt, delay);
 	} else {
-		light_lightness_get(model, ctx, buf);
+ret:		light_lightness_get(model, ctx, buf);
 		light_lightness_publish(model);
 		return;
 	}
@@ -1401,6 +1406,7 @@ static void light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
+		goto ret;
 		return;
 	}
 
@@ -1433,7 +1439,7 @@ static void light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	if (state->target_linear != state->linear) {
 		light_lightness_linear_tt_values(state, tt, delay);
 	} else {
-		light_lightness_linear_publish(model);
+ret:		light_lightness_linear_publish(model);
 		return;
 	}
 
@@ -1464,6 +1470,7 @@ static void light_lightness_linear_set(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
+		goto ret;
 		return;
 	}
 
@@ -1496,7 +1503,7 @@ static void light_lightness_linear_set(struct bt_mesh_model *model,
 	if (state->target_linear != state->linear) {
 		light_lightness_linear_tt_values(state, tt, delay);
 	} else {
-		light_lightness_linear_get(model, ctx, buf);
+ret:		light_lightness_linear_get(model, ctx, buf);
 		light_lightness_linear_publish(model);
 		return;
 	}
@@ -1824,6 +1831,7 @@ static void light_ctl_set_unack(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
+		goto ret;
 		return;
 	}
 
@@ -1867,7 +1875,7 @@ static void light_ctl_set_unack(struct bt_mesh_model *model,
 	    state->target_delta_uv != state->delta_uv) {
 		light_ctl_tt_values(state, tt, delay);
 	} else {
-		light_ctl_publish(model);
+ret:		light_ctl_publish(model);
 		return;
 	}
 
@@ -1907,6 +1915,7 @@ static void light_ctl_set(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
+		goto ret;
 		return;
 	}
 
@@ -1950,7 +1959,7 @@ static void light_ctl_set(struct bt_mesh_model *model,
 	    state->target_delta_uv != state->delta_uv) {
 		light_ctl_tt_values(state, tt, delay);
 	} else {
-		light_ctl_get(model, ctx, buf);
+ret:		light_ctl_get(model, ctx, buf);
 		light_ctl_publish(model);
 		return;
 	}
@@ -2290,6 +2299,7 @@ static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
+		goto ret;
 		return;
 	}
 
@@ -2331,7 +2341,7 @@ static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	    state->target_delta_uv != state->delta_uv) {
 		light_ctl_temp_tt_values(state, tt, delay);
 	} else {
-		light_ctl_temp_publish(model);
+ret:		light_ctl_temp_publish(model);
 		return;
 	}
 
@@ -2369,6 +2379,7 @@ static void light_ctl_temp_set(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
+		goto ret;
 		return;
 	}
 
@@ -2410,7 +2421,7 @@ static void light_ctl_temp_set(struct bt_mesh_model *model,
 	    state->target_delta_uv != state->delta_uv) {
 		light_ctl_temp_tt_values(state, tt, delay);
 	} else {
-		light_ctl_temp_get(model, ctx, buf);
+ret:		light_ctl_temp_get(model, ctx, buf);
 		light_ctl_temp_publish(model);
 		return;
 	}

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
@@ -31,7 +31,8 @@ struct generic_onoff_state {
 	u8_t target_onoff;
 
 	u8_t last_tid;
-	u16_t last_tx_addr;
+	u16_t last_src_addr;
+	u16_t last_dst_addr;
 	s64_t last_msg_timestamp;
 
 	struct transition *transition;
@@ -45,7 +46,8 @@ struct generic_level_state {
 	s32_t last_delta;
 
 	u8_t last_tid;
-	u16_t last_tx_addr;
+	u16_t last_src_addr;
+	u16_t last_dst_addr;
 	s64_t last_msg_timestamp;
 
 	s32_t tt_delta;
@@ -65,7 +67,8 @@ struct vendor_state {
 	int current;
 	u32_t response;
 	u8_t last_tid;
-	u16_t last_tx_addr;
+	u16_t last_src_addr;
+	u16_t last_dst_addr;
 	s64_t last_msg_timestamp;
 };
 
@@ -84,7 +87,8 @@ struct light_lightness_state {
 	u16_t light_range_max;
 
 	u8_t last_tid;
-	u16_t last_tx_addr;
+	u16_t last_src_addr;
+	u16_t last_dst_addr;
 	s64_t last_msg_timestamp;
 
 	s32_t tt_delta_actual;
@@ -115,7 +119,8 @@ struct light_ctl_state {
 	u32_t lightness_temp_last;
 
 	u8_t last_tid;
-	u16_t last_tx_addr;
+	u16_t last_src_addr;
+	u16_t last_dst_addr;
 	s64_t last_msg_timestamp;
 
 	s32_t tt_delta_lightness;


### PR DESCRIPTION
1. As per Mesh Model Specification, when a Server receives a Set message or a Set Unacknowledged message, it shall set the state to the target field of the message, unless the message has the same values for the SRC, DST, and TID fields as the previous message received within the last 6 seconds. This commit take care of this requirement.

2. Now if Server receives re-transmitted messages from client then
it will not get completely ignored but respective GET & Publish
message will get release from Server side.

