### PR TITLE
Obtain SoC part number from the device tree and not Kconfig

### DIFF
--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -18,6 +18,8 @@
 	};
 
 	soc {
+		compatible = "soc,silabs";
+
 		flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";
 			label = "FLASH_CTRL";

--- a/dts/arm/silabs/efr32fg1p133f256gm48.dtsi
+++ b/dts/arm/silabs/efr32fg1p133f256gm48.dtsi
@@ -13,6 +13,8 @@
 	};
 
 	soc {
+		part-number = "EFR32FG1P133F256GM48";
+
 		flash-controller@400e0000 {
 			flash0: flash@0 {
 				reg = <0 DT_SIZE_K(256)>;

--- a/dts/bindings/soc/soc,silabs.yaml
+++ b/dts/bindings/soc/soc,silabs.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2018, Piotr Mienkowski
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: SiLabs SoC
+version: 0.1
+
+description: >
+    This binding gives a base representation of the SiLabs SoC
+
+inherits:
+    !include soc.yaml
+
+properties:
+    compatible:
+      constraint: "soc,silabs"
+...

--- a/dts/bindings/soc/soc.yaml
+++ b/dts/bindings/soc/soc.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2018, Piotr Mienkowski
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: SoC binding
+version: 0.1
+
+description: >
+    Binding for the SoC node.
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
+
+    part-number:
+      type: string
+      category: required
+      description: SoC part number
+      generation: define
+...

--- a/ext/hal/silabs/gecko/CMakeLists.txt
+++ b/ext/hal/silabs/gecko/CMakeLists.txt
@@ -9,7 +9,7 @@
 # respectively.
 string(TOUPPER ${CONFIG_SOC_SERIES} SILABS_GECKO_DEVICE)
 
-set(SILABS_GECKO_PART_NUMBER ${CONFIG_SOC_PART_NUMBER})
+set(SILABS_GECKO_PART_NUMBER ${DT_SOC_SILABS_SOC_PART_NUMBER})
 
 zephyr_include_directories(
   Device/SiliconLabs/${SILABS_GECKO_DEVICE}/Include


### PR DESCRIPTION
Virtually all of the SoCs require part number information to compile the code. Originally this information was provided by a Kconfig option. After introduction of the DT some part number dependent configuration settings such as RAM and flash size were moved to DT. Consequently we need to maintain and set part number information twice, once in Kconfig and once in DT.

This PR adds DT bindings to allow to obtain SoC part number from the device tree. The corresponding Kconfig options can be removed.

Zephyr DT is supposed to be compatible with Linux DT, however Linux DT does not seem to contain part number information. Following proposal is Zephyr specific.

Since the DT root node is supposed to represent the board I propose to attach the part-number property to the soc node. The proposal needs to be carefully reviewed.