### PR TITLE
Fix gpio samples

### DIFF
--- a/samples/basic/disco/sample.yaml
+++ b/samples/basic/disco/sample.yaml
@@ -3,5 +3,5 @@ sample:
 tests:
   test:
     # The filters below are from DTS
-    filter: LED0_GPIO_CONTROLLER and LED1_GPIO_PIN and LED0_GPIO_PIN
+    filter: LED0_GPIO_CONTROLLER and LED1_GPIO_CONTROLLER
     tags: LED gpio

--- a/samples/basic/disco/src/main.c
+++ b/samples/basic/disco/src/main.c
@@ -8,7 +8,8 @@
 #include <device.h>
 #include <gpio.h>
 
-#define PORT  LED0_GPIO_CONTROLLER
+#define PORT0  LED0_GPIO_CONTROLLER
+#define PORT1  LED1_GPIO_CONTROLLER
 
 #define LED0 LED0_GPIO_PIN
 #define LED1 LED1_GPIO_PIN
@@ -18,16 +19,17 @@
 void main(void)
 {
 	int cnt = 0;
-	struct device *gpiob;
+	struct device *gpio0, *gpio1;
 
-	gpiob = device_get_binding(PORT);
+	gpio0 = device_get_binding(PORT0);
+	gpio1 = device_get_binding(PORT1);
 
-	gpio_pin_configure(gpiob, LED0, GPIO_DIR_OUT);
-	gpio_pin_configure(gpiob, LED1, GPIO_DIR_OUT);
+	gpio_pin_configure(gpio0, LED0, GPIO_DIR_OUT);
+	gpio_pin_configure(gpio1, LED1, GPIO_DIR_OUT);
 
 	while (1) {
-		gpio_pin_write(gpiob, LED0, cnt % 2);
-		gpio_pin_write(gpiob, LED1, (cnt + 1) % 2);
+		gpio_pin_write(gpio0, LED0, cnt % 2);
+		gpio_pin_write(gpio1, LED1, (cnt + 1) % 2);
 		k_sleep(SLEEP_TIME);
 		cnt++;
 	}

--- a/samples/drivers/gpio/sample.yaml
+++ b/samples/drivers/gpio/sample.yaml
@@ -4,7 +4,7 @@ tests:
   test:
     tags: drivers
     # The filters below are from DTS
-    filter: LED0_GPIO_CONTROLLER and LED0_GPIO_PIN and SW0_GPIO_PIN
+    filter: LED0_GPIO_CONTROLLER and SW0_GPIO_CONTROLLER
     harness: console
     harness_config:
         type: one_line

--- a/samples/drivers/gpio/src/main.c
+++ b/samples/drivers/gpio/src/main.c
@@ -21,8 +21,9 @@
 #include <misc/util.h>
 
 #if defined(SW0_GPIO_CONTROLLER) && defined(LED0_GPIO_CONTROLLER)
-#define GPIO_DRV_NAME LED0_GPIO_CONTROLLER
+#define GPIO_OUT_DRV_NAME LED0_GPIO_CONTROLLER
 #define GPIO_OUT_PIN  LED0_GPIO_PIN
+#define GPIO_IN_DRV_NAME SW0_GPIO_CONTROLLER
 #define GPIO_INT_PIN  SW0_GPIO_PIN
 #else
 #error Change the pins based on your configuration. This sample \
@@ -39,30 +40,36 @@ static struct gpio_callback gpio_cb;
 
 void main(void)
 {
-	struct device *gpio_dev;
+	struct device *gpio_out_dev, *gpio_in_dev;
 	int ret;
 	int toggle = 1;
 
-	gpio_dev = device_get_binding(GPIO_DRV_NAME);
-	if (!gpio_dev) {
-		printk("Cannot find %s!\n", GPIO_DRV_NAME);
+	gpio_out_dev = device_get_binding(GPIO_OUT_DRV_NAME);
+	if (!gpio_out_dev) {
+		printk("Cannot find %s!\n", GPIO_OUT_DRV_NAME);
+		return;
+	}
+
+	gpio_in_dev = device_get_binding(GPIO_IN_DRV_NAME);
+	if (!gpio_in_dev) {
+		printk("Cannot find %s!\n", GPIO_IN_DRV_NAME);
 		return;
 	}
 
 	/* Setup GPIO output */
-	ret = gpio_pin_configure(gpio_dev, GPIO_OUT_PIN, (GPIO_DIR_OUT));
+	ret = gpio_pin_configure(gpio_out_dev, GPIO_OUT_PIN, (GPIO_DIR_OUT));
 	if (ret) {
 		printk("Error configuring pin %d!\n", GPIO_OUT_PIN);
 	}
 
 	/* Setup GPIO input, and triggers on rising edge. */
 #ifdef CONFIG_SOC_CC2650
-	ret = gpio_pin_configure(gpio_dev, GPIO_INT_PIN,
+	ret = gpio_pin_configure(gpio_in_dev, GPIO_INT_PIN,
 				 (GPIO_DIR_IN | GPIO_INT |
 				  GPIO_INT_EDGE | GPIO_INT_ACTIVE_HIGH |
 				  GPIO_INT_DEBOUNCE | GPIO_PUD_PULL_UP));
 #else
-	ret = gpio_pin_configure(gpio_dev, GPIO_INT_PIN,
+	ret = gpio_pin_configure(gpio_in_dev, GPIO_INT_PIN,
 				 (GPIO_DIR_IN | GPIO_INT |
 				  GPIO_INT_EDGE | GPIO_INT_ACTIVE_HIGH |
 				  GPIO_INT_DEBOUNCE));
@@ -73,12 +80,12 @@ void main(void)
 
 	gpio_init_callback(&gpio_cb, gpio_callback, BIT(GPIO_INT_PIN));
 
-	ret = gpio_add_callback(gpio_dev, &gpio_cb);
+	ret = gpio_add_callback(gpio_in_dev, &gpio_cb);
 	if (ret) {
 		printk("Cannot setup callback!\n");
 	}
 
-	ret = gpio_pin_enable_callback(gpio_dev, GPIO_INT_PIN);
+	ret = gpio_pin_enable_callback(gpio_in_dev, GPIO_INT_PIN);
 	if (ret) {
 		printk("Error enabling callback!\n");
 	}
@@ -86,7 +93,7 @@ void main(void)
 	while (1) {
 		printk("Toggling pin %d\n", GPIO_OUT_PIN);
 
-		ret = gpio_pin_write(gpio_dev, GPIO_OUT_PIN, toggle);
+		ret = gpio_pin_write(gpio_out_dev, GPIO_OUT_PIN, toggle);
 		if (ret) {
 			printk("Error set pin %d!\n", GPIO_OUT_PIN);
 		}


### PR DESCRIPTION
`samples/basic/disco` and `samples/drivers/gpio` were implemented with the assumption
one single GPIO controller was used for 2 different pins.
This is actually a particular case. Update the code to take into account the general case in which
different gpio controllers might have to be considered.

Additionally, simplify yaml filter for these samples 
