### PR TITLE
net: pkt: Show buffer allocations only when needed

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -745,7 +745,8 @@ static inline void net_pkt_set_src_ipv6_addr(struct net_pkt *pkt)
 	NET_BUF_POOL_DEFINE(name, count, CONFIG_NET_BUF_DATA_SIZE,	\
 			    CONFIG_NET_BUF_USER_DATA_SIZE, NULL)
 
-#if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
+#if defined(CONFIG_NET_DEBUG_NET_PKT_ALLOC) || \
+	(CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG)
 
 /* Debug versions of the net_pkt functions that are used when tracking
  * buffer usage.
@@ -1891,7 +1892,7 @@ int net_pkt_get_dst_addr(struct net_pkt *pkt,
 			 struct sockaddr *addr,
 			 socklen_t addrlen);
 
-#if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
+#if defined(CONFIG_NET_DEBUG_NET_PKT_ALLOC)
 /**
  * @brief Debug helper to print out the buffer allocations
  */

--- a/subsys/net/ip/Kconfig.debug
+++ b/subsys/net/ip/Kconfig.debug
@@ -50,9 +50,9 @@ module-str = Log level for network packet and buffer allocation
 module-help = Enables debug of network packet and buffer allocations and frees.
 source "subsys/net/Kconfig.template.log_config.net"
 
-if NET_PKT_LOG_LEVEL >= 4
-config NET_DEBUG_NET_PKT_ALL
+config NET_DEBUG_NET_PKT_ALLOC
 	bool "Debug network packet and buffer individual allocation"
+	default y if NET_PKT_LOG_LEVEL_DBG
 	help
 	  Enables printing of network packet and buffer allocations and frees for
 	  each allocation. This can produce lot of output so it is disabled by
@@ -65,7 +65,6 @@ config NET_DEBUG_NET_PKT_EXTERNALS
 	  How many external net_pkt objects are there in user specific pools.
 	  This value is used when allocating space for tracking the
 	  memory allocations.
-endif
 
 module = NET_CONN
 module-dep = NET_LOG

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1080,7 +1080,7 @@ static void ipv6_frag_cb(struct net_ipv6_reassembly *reass,
 }
 #endif /* CONFIG_NET_IPV6_FRAGMENT */
 
-#if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
+#if defined(CONFIG_NET_DEBUG_NET_PKT_ALLOC)
 static void allocs_cb(struct net_pkt *pkt,
 		      struct net_buf *buf,
 		      const char *func_alloc,
@@ -1140,28 +1140,28 @@ buf:
 		}
 	}
 }
-#endif /* CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG */
+#endif /* CONFIG_NET_DEBUG_NET_PKT_ALLOC */
 
 /* Put the actual shell commands after this */
 
 static int cmd_net_allocs(const struct shell *shell, size_t argc, char *argv[])
 {
-#if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
+#if defined(CONFIG_NET_DEBUG_NET_PKT_ALLOC)
 	struct net_shell_user_data user_data;
 #endif
 
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-#if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
+#if defined(CONFIG_NET_DEBUG_NET_PKT_ALLOC)
 	user_data.shell = shell;
 
 	PR("Network memory allocations\n\n");
 	PR("memory\t\tStatus\tPool\tFunction alloc -> freed\n");
 	net_pkt_allocs_foreach(allocs_cb, &user_data);
 #else
-	PR_INFO("Enable CONFIG_NET_PKT_LOG_LEVEL_DBG to see allocations.\n");
-#endif /* CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG */
+	PR_INFO("Enable CONFIG_NET_DEBUG_NET_PKT_ALLOC to see allocations.\n");
+#endif /* CONFIG_NET_DEBUG_NET_PKT_ALLOC */
 
 	return 0;
 }


### PR DESCRIPTION
The net-shell "net allocs" command should print network buffer
allocations even if network packet debugging is not enabled.
This is how it used to work earlier but the behaviour got lost
at some point. So user needs to set CONFIG_NET_DEBUG_NET_PKT_ALLOC
in order to see the buffer allocations. The option will be enabled
by default if network packet log level is set to DBG.
The reason for a separate option is that the network packet debug
logging prints just too much data and it is very difficult to
track allocations when that happens.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>