### PR TITLE
dts: nrf: Fix device tree warnings

### DIFF
--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -93,9 +93,9 @@
 			label = "I2C_0";
 		};
 
-		pwm0: pwm@4001C000 {
+		pwm0: pwm@4001c000 {
 			compatible = "nordic,nrf-pwm";
-			reg = <0x4001C000 0x1000>;
+			reg = <0x4001c000 0x1000>;
 			interrupts = <28 1>;
 			status = "disabled";
 			label = "PWM_0";

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -111,9 +111,9 @@
 			label = "I2C_1";
 		};
 
-		pwm0: pwm@4001C000 {
+		pwm0: pwm@4001c000 {
 			compatible = "nordic,nrf-pwm";
-			reg = <0x4001C000 0x1000>;
+			reg = <0x4001c000 0x1000>;
 			interrupts = <28 1>;
 			status = "disabled";
 			label = "PWM_0";

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -136,9 +136,9 @@
 			label = "I2C_1";
 		};
 
-		pwm0: pwm@4001C000 {
+		pwm0: pwm@4001c000 {
 			compatible = "nordic,nrf-pwm";
-			reg = <0x4001C000 0x1000>;
+			reg = <0x4001c000 0x1000>;
 			interrupts = <28 1>;
 			status = "disabled";
 			label = "PWM_0";


### PR DESCRIPTION
Fix the following warning that shows up in some NRF device tree files:

	Warning (simple_bus_reg): /soc/pwm@4001C000: simple-bus unit
	address format error, expected "4001c000"

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>