### PR TITLE
boards: arm: Fix and update nordic board doc links

### DIFF
--- a/boards/arm/nrf51_ble400/doc/nrf51_ble400.rst
+++ b/boards/arm/nrf51_ble400/doc/nrf51_ble400.rst
@@ -208,8 +208,8 @@ References
 
 .. target-notes::
 
-.. _nRF51 DK website: http://www.nordicsemi.com/eng/Products/nRF51-DK
-.. _Nordic Semiconductor Infocenter: http://infocenter.nordicsemi.com/
+.. _nRF51 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF51-DK
+.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
 .. _Waveshare Wiki BLE400: https://www.waveshare.com/wiki/BLE400
 .. _User manual: https://www.waveshare.com/w/upload/b/b7/NRF51822-Eval-Kit-UserManual-EN.pdf
 .. _Schematic: https://www.waveshare.com/w/upload/1/1b/BLE400-Schematic.pdf

--- a/boards/arm/nrf51_pca10028/doc/nrf51_pca10028.rst
+++ b/boards/arm/nrf51_pca10028/doc/nrf51_pca10028.rst
@@ -32,7 +32,7 @@ nRF51822 ARM Cortex-M0 CPU and the following devices:
      nRF51 PCA10028 DK (Credit: Nordic Semi)
 
 More information about the board can be found at the
-`nRF51 DK website`_. The `Nordic Semiconductor Infocenter`_
+`nRF51 DK website`_. The `Nordic Semiconductor Documentation library`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -79,7 +79,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
-See `nRF51 DK website`_ and `Nordic Semiconductor Infocenter`_
+See `nRF51 DK website`_ and `Nordic Semiconductor Documentation library`_
 for a complete list of nRF51 Development Kit board hardware features.
 
 Connections and IOs
@@ -158,6 +158,6 @@ References
 
 .. target-notes::
 
-.. _nRF51 DK website: http://www.nordicsemi.com/eng/Products/nRF51-DK
-.. _Nordic Semiconductor Infocenter: http://infocenter.nordicsemi.com/
+.. _nRF51 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF51-DK
+.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
 

--- a/boards/arm/nrf52810_pca10040/doc/nrf52810_pca10040.rst
+++ b/boards/arm/nrf52810_pca10040/doc/nrf52810_pca10040.rst
@@ -20,5 +20,5 @@ References
 
 .. target-notes::
 
-.. _nRF52810 website: http://www.nordicsemi.com/eng/Products/nRF52810
+.. _nRF52810 website: https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52810
 

--- a/boards/arm/nrf52832_mdk/doc/nrf52832_mdk.rst
+++ b/boards/arm/nrf52832_mdk/doc/nrf52832_mdk.rst
@@ -21,7 +21,7 @@ References
 **********
 .. target-notes::
 
-.. _nRF52832 website: http://www.nordicsemi.com/eng/Products/nRF52832
+.. _nRF52832 website: https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52832
 .. _nRF52832-mdk website: https://wiki.makerdiary.com/nrf52832-mdk
 
 

--- a/boards/arm/nrf52840_mdk/doc/nrf52840_mdk.rst
+++ b/boards/arm/nrf52840_mdk/doc/nrf52840_mdk.rst
@@ -26,6 +26,6 @@ References
 **********
 .. target-notes::
 
-.. _nRF52840 website: http://www.nordicsemi.com/eng/Products/nRF52840
+.. _nRF52840 website: https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52840
 .. _nRF52840-mdk website: https://wiki.makerdiary.com/nrf52840-mdk
 

--- a/boards/arm/nrf52840_pca10056/doc/nrf52840_pca10056.rst
+++ b/boards/arm/nrf52840_pca10056/doc/nrf52840_pca10056.rst
@@ -35,7 +35,7 @@ the following devices:
      nRF52840 PCA10056 Preview DK (Credit: Nordic Semi)
 
 More information about the board can be found at the
-`nRF52840 PDK website`_. The `Nordic Semiconductor Infocenter`_
+`nRF52840 PDK website`_. The `Nordic Semiconductor Documentation library`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -87,7 +87,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
-See `nRF52840 PDK website`_ and `Nordic Semiconductor Infocenter`_
+See `nRF52840 PDK website`_ and `Nordic Semiconductor Documentation library`_
 for a complete list of nRF52840 Development Kit board hardware features.
 
 Connections and IOs
@@ -172,7 +172,7 @@ References
 
 .. target-notes::
 
-.. _nRF52840 PDK website: http://www.nordicsemi.com/eng/Products/nRF52840-Preview-DK
-.. _Nordic Semiconductor Infocenter: http://infocenter.nordicsemi.com/
+.. _nRF52840 PDK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK
+.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
 .. _J-Link Software and documentation pack: https://www.segger.com/jlink-software.html
 

--- a/boards/arm/nrf52840_pca10059/doc/nrf52840_pca10059.rst
+++ b/boards/arm/nrf52840_pca10059/doc/nrf52840_pca10059.rst
@@ -34,7 +34,7 @@ the following devices:
      nRF52840 PCA10059
 
 More information about the board can be found at the
-`nRF52840 Dongle website`_. The `Nordic Semiconductor Infocenter`_
+`nRF52840 Dongle website`_. The `Nordic Semiconductor Documentation library`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -84,7 +84,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
-See `nRF52840 Dongle website`_ and `Nordic Semiconductor Infocenter`_
+See `nRF52840 Dongle website`_ and `Nordic Semiconductor Documentation library`_
 for a complete list of nRF52840 PCA10059 Development Kit board hardware features.
 
 Connections and IOs
@@ -159,7 +159,7 @@ References
 
 .. target-notes::
 
-.. _nRF52840 Dongle website: https://www.nordicsemi.com/eng/Products/nRF52840-Dongle
-.. _Nordic Semiconductor Infocenter: http://infocenter.nordicsemi.com/
+.. _nRF52840 Dongle website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-Dongle
+.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
 .. _J-Link Software and documentation pack: https://www.segger.com/jlink-software.html
 

--- a/boards/arm/nrf52_adafruit_feather/doc/nrf52_adafruit_feather.rst
+++ b/boards/arm/nrf52_adafruit_feather/doc/nrf52_adafruit_feather.rst
@@ -27,7 +27,7 @@ the following devices:
      nRF52 Adafruit Feather Board (Credit: Adafruit)
 
 More information about the board and its features can be found at the
-`Adafruit Feather nRF52 Bluefruit Learning Guide`_. The `Nordic Semiconductor Infocenter`_
+`Adafruit Feather nRF52 Bluefruit Learning Guide`_. The `Nordic Semiconductor Documentation library`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -187,7 +187,7 @@ References
 .. _Adafruit Feather nRF52 Bluefruit Learning Guide: https://learn.adafruit.com/bluefruit-nrf52-feather-learning-guide/introduction
 .. _schematic: https://learn.adafruit.com/assets/39913
 .. _pinouts: https://cdn-learn.adafruit.com/assets/assets/000/046/210/original/Feather_NRF52_Pinout_v1.2.pdf?1504807075
-.. _Nordic Semiconductor Infocenter: http://infocenter.nordicsemi.com/
+.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
 .. _J-Link Software and documentation pack: https://www.segger.com/jlink-software.html
 .. _Adafruit Feather nRF52 Bluefruit LE: https://www.adafruit.com/product/3406
 .. _Adafruit Feather nRF52 Pro with myNewt Bootloader: https://www.adafruit.com/product/3574

--- a/boards/arm/nrf52_pca10040/doc/nrf52_pca10040.rst
+++ b/boards/arm/nrf52_pca10040/doc/nrf52_pca10040.rst
@@ -34,7 +34,7 @@ the following devices:
      nRF52 PCA10040 DK (Credit: Nordic Semi)
 
 More information about the board can be found at the
-`nRF52 DK website`_. The `Nordic Semiconductor Infocenter`_
+`nRF52 DK website`_. The `Nordic Semiconductor Documentation library`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -83,7 +83,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
-See `nRF52 DK website`_ and `Nordic Semiconductor Infocenter`_
+See `nRF52 DK website`_ and `Nordic Semiconductor Documentation library`_
 for a complete list of nRF52 Development Kit board hardware features.
 
 Connections and IOs
@@ -402,6 +402,6 @@ References
 
 .. target-notes::
 
-.. _nRF52 DK website: http://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF52-DK
-.. _Nordic Semiconductor Infocenter: http://infocenter.nordicsemi.com/
+.. _nRF52 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52-DK
+.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
 

--- a/boards/arm/nrf52_pca20020/doc/nrf52_pca20020.rst
+++ b/boards/arm/nrf52_pca20020/doc/nrf52_pca20020.rst
@@ -384,6 +384,6 @@ References
 
 .. target-notes::
 
-.. _nRF52 DK website: https://www.nordicsemi.com/eng/Products/Nordic-Thingy-52
+.. _nRF52 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/Nordic-Thingy-52
 .. _Nordic Semiconductor Infocenter: http://infocenter.nordicsemi.com/
 


### PR DESCRIPTION
Fixes old and some broken links to nordic documentation.

Signed-off-by: Florian Gärtner <florian.gaertner@ledcity.ch>