### PR TITLE
dts: stm32: Move usb PHY nodes out of SoC to fix warning

### DIFF
--- a/dts/arm/st/f0/stm32f070.dtsi
+++ b/dts/arm/st/f0/stm32f070.dtsi
@@ -19,12 +19,6 @@
 			label = "SPI_2";
 		};
 
-		usb_fs_phy: usbphy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "USB_FS_PHY";
-		};
-
 		usb: usb@40005c00 {
 			compatible = "st,stm32-usb";
 			reg = <0x40005c00 0x400>;
@@ -36,5 +30,11 @@
 			status = "disabled";
 			label= "USB";
 		};
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "USB_FS_PHY";
 	};
 };

--- a/dts/arm/st/f0/stm32f072.dtsi
+++ b/dts/arm/st/f0/stm32f072.dtsi
@@ -47,12 +47,6 @@
 			label = "SPI_2";
 		};
 
-		usb_fs_phy: usbphy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "USB_FS_PHY";
-		};
-
 		usb: usb@40005c00 {
 			compatible = "st,stm32-usb";
 			reg = <0x40005c00 0x400>;
@@ -79,5 +73,11 @@
 			prop_seg_phase_seg1 = <5>;
 			phase_seg2 = <6>;
 		};
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "USB_FS_PHY";
 	};
 };

--- a/dts/arm/st/f1/stm32f103X8.dtsi
+++ b/dts/arm/st/f1/stm32f103X8.dtsi
@@ -31,12 +31,6 @@
 			label = "SPI_2";
 		};
 
-		usb_fs_phy: usbphy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "USB_FS_PHY";
-		};
-
 		usb: usb@40005c00 {
 			compatible = "st,stm32-usb";
 			reg = <0x40005c00 0x400>;
@@ -48,5 +42,11 @@
 			phys = <&usb_fs_phy>;
 			label= "USB";
 		};
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "USB_FS_PHY";
 	};
 };

--- a/dts/arm/st/f1/stm32f103Xb.dtsi
+++ b/dts/arm/st/f1/stm32f103Xb.dtsi
@@ -33,12 +33,6 @@
 			label = "SPI_2";
 		};
 
-		usb_fs_phy: usbphy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "USB_FS_PHY";
-		};
-
 		usb: usb@40005c00 {
 			compatible = "st,stm32-usb";
 			reg = <0x40005c00 0x400>;
@@ -50,5 +44,11 @@
 			status = "disabled";
 			label= "USB";
 		};
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "USB_FS_PHY";
 	};
 };

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -194,12 +194,6 @@
 			label = "UART_5";
 		};
 
-		otgfs_phy: otgfs_phy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "OTGFS_PHY";
-		};
-
 		usbotg_fs: usb@50000000 {
 			compatible = "st,stm32-otgfs";
 			reg = <0x50000000 0x40000>;
@@ -212,6 +206,12 @@
 			status = "disabled";
 			label = "OTGFS";
 		};
+	};
+
+	otgfs_phy: otgfs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "OTGFS_PHY";
 	};
 };
 

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -154,12 +154,6 @@
 			label = "SPI_1";
 		};
 
-		usb_fs_phy: usbphy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "USB_FS_PHY";
-		};
-
 		usb: usb@40005c00 {
 			compatible = "st,stm32-usb";
 			reg = <0x40005c00 0x400>;
@@ -292,6 +286,12 @@
 			status = "disabled";
 			label = "RTC_0";
 		};
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "USB_FS_PHY";
 	};
 };
 

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -210,12 +210,6 @@
 			label = "I2S_1";
 		};
 
-		otgfs_phy: otgfs_phy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "OTGFS_PHY";
-		};
-
 		usbotg_fs: usb@50000000 {
 			compatible = "st,stm32-otgfs";
 			reg = <0x50000000 0x40000>;
@@ -365,6 +359,12 @@
 			status = "disabled";
 			label = "RTC_0";
 		};
+	};
+
+	otgfs_phy: otgfs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "OTGFS_PHY";
 	};
 };
 

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -163,12 +163,6 @@
 			};
 		};
 
-		otghs_fs_phy: otghs_fs_phy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "OTGHS_FS_PHY";
-		};
-
 		usbotg_hs: usb@40040000 {
 			compatible = "st,stm32-otghs", "st,stm32-otgfs";
 			reg = <0x40040000 0x40000>;
@@ -181,5 +175,11 @@
 			status = "disabled";
 			label= "OTGHS";
 		};
+	};
+
+	otghs_fs_phy: otghs_fs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "OTGHS_FS_PHY";
 	};
 };

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -12,12 +12,6 @@
 			num-bidir-endpoints = <6>;
 		};
 
-		otghs_fs_phy: otghs_fs_phy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "OTGHS_FS_PHY";
-		};
-
 		usbotg_hs: usb@40040000 {
 			compatible = "st,stm32-otghs", "st,stm32-otgfs";
 			reg = <0x40040000 0x40000>;
@@ -30,5 +24,11 @@
 			status = "disabled";
 			label= "OTGHS";
 		};
+	};
+
+	otghs_fs_phy: otghs_fs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "OTGHS_FS_PHY";
 	};
 };

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -531,12 +531,6 @@
 			};
 		};
 
-		otgfs_phy: otgfs_phy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "OTGFS_PHY";
-		};
-
 		usbotg_fs: usb@50000000 {
 			compatible = "st,stm32-otgfs";
 			reg = <0x50000000 0x40000>;
@@ -548,12 +542,6 @@
 			phys = <&otgfs_phy>;
 			status = "disabled";
 			label = "OTGFS";
-		};
-
-		otghs_fs_phy: otghs_fs_phy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "OTGHS_FS_PHY";
 		};
 
 		usbotg_hs: usb@40040000 {
@@ -577,6 +565,18 @@
 			status = "disabled";
 			label = "RTC_0";
 		};
+	};
+
+	otghs_fs_phy: otghs_fs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "OTGHS_FS_PHY";
+	};
+
+	otgfs_phy: otgfs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "OTGFS_PHY";
 	};
 };
 

--- a/dts/arm/st/l0/stm32l072.dtsi
+++ b/dts/arm/st/l0/stm32l072.dtsi
@@ -57,12 +57,6 @@
 			label = "SPI_2";
 		};
 
-		otgfs_phy: otgfs_phy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "OTGFS_PHY";
-		};
-
 		usb: usb@40005c00 {
 			compatible = "st,stm32-usb";
 			reg = <0x40005c00 0x400>;
@@ -74,5 +68,11 @@
 			status = "disabled";
 			label= "USB";
 		};
+	};
+
+	otgfs_phy: otgfs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "OTGFS_PHY";
 	};
 };

--- a/dts/arm/st/l0/stm32l073.dtsi
+++ b/dts/arm/st/l0/stm32l073.dtsi
@@ -56,12 +56,6 @@
 			label = "SPI_2";
 		};
 
-		otgfs_phy: otgfs_phy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "OTGFS_PHY";
-		};
-
 		usb: usb@40005c00 {
 			compatible = "st,stm32-usb";
 			reg = <0x40005c00 0x400>;
@@ -73,5 +67,11 @@
 			status = "disabled";
 			label= "USB";
 		};
+	};
+
+	otgfs_phy: otgfs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "OTGFS_PHY";
 	};
 };

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -8,12 +8,6 @@
 
 / {
 	soc {
-		otgfs_phy: otgfs_phy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "OTGFS_PHY";
-		};
-
 		usb: usb@40006800 {
 			compatible = "st,stm32-usb";
 			reg = <0x40006800 0x40000>;
@@ -25,5 +19,11 @@
 			status = "disabled";
 			label = "USB";
 		};
+	};
+
+	otgfs_phy: otgfs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "OTGFS_PHY";
 	};
 };

--- a/dts/arm/st/l4/stm32l475.dtsi
+++ b/dts/arm/st/l4/stm32l475.dtsi
@@ -8,12 +8,6 @@
 
 / {
 	soc {
-		otgfs_phy: otgfs_phy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "OTGFS_PHY";
-		};
-
 		usbotg_fs: otgfs@50000000 {
 			compatible = "st,stm32-otgfs";
 			reg = <0x50000000 0x40000>;
@@ -26,5 +20,11 @@
 			status = "disabled";
 			label= "OTGFS";
 		};
+	};
+
+	otgfs_phy: otgfs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "OTGFS_PHY";
 	};
 };

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -118,12 +118,6 @@
 			label = "SPI_3";
 		};
 
-		otgfs_phy: otgfs_phy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			label = "OTGFS_PHY";
-		};
-
 		usbotg_fs: otgfs@50000000 {
 			compatible = "st,stm32-otgfs";
 			reg = <0x50000000 0x40000>;
@@ -136,5 +130,11 @@
 			status = "disabled";
 			label= "OTGFS";
 		};
+	};
+
+	otgfs_phy: otgfs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "OTGFS_PHY";
 	};
 };


### PR DESCRIPTION
We currently get a number of warnings like:

	Warning (simple_bus_reg): /soc/otgfs_phy: missing or empty
	reg/ranges property

This is due to the usb phy nodes not have a reg property since they
don't have an mmio address associated with them.

Move the phy nodes out of the SoC node so their lack of a reg property
will not cause a warning.  This is similar to how Linux dts files
handle the phy nodes.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>