### PR TITLE
ci: update docker image to 0.5-rc4 to get sdk-ng

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -22,7 +22,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.5-rc3
+        image_tag: v0.5-rc4
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
The 0.5-rc4 ci docker image adds the beta2 of sdk-ng so we can use that
for testing.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>