### PR TITLE
dts: nxp: Add sram_l node to k64 dtsi

### DIFF
--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -15,6 +15,21 @@
 		};
 	};
 
+	/* The on-chip SRAM is split into SRAM_L and SRAM_U regions that form a
+	 * contiguous block in the memory map, however misaligned accesses
+	 * across the 0x2000_0000 boundary are not supported in the Arm
+	 * Cortex-M4 architecture. For clarity and to avoid the temptation for
+	 * someone to extend sram0 without solving this issue, we define two
+	 * separate memory nodes here and only use the upper one for now. A
+	 * potential solution has been proposed in binutils:
+	 * https://sourceware.org/ml/binutils/2017-02/msg00250.html
+	 */
+	sram_l: memory@1fff0000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
+		reg = <0x1fff0000 0x10000>;
+	};
+
 	sram0: memory@20000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";


### PR DESCRIPTION
Adds a second sram node to the k64 device tree to acknowledge that the
additional sram is present in hardware, but deliberately not used in
zephyr until an outstanding issue is solved. The upper and lower sram
nodes are contiguous in the memory map, however the Cortex-M4
architecture does not support misaligned accesses across the boundary
between the two nodes.

Fixes #2984

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>