### PR TITLE
docs: include/spi.h removed spi_config doxygen comment for removed variable

### DIFF
--- a/include/spi.h
+++ b/include/spi.h
@@ -139,7 +139,6 @@ struct spi_cs_control {
 /**
  * @brief SPI controller configuration structure
  *
- * @param dev is a valid pointer to an actual SPI device
  * @param frequency is the bus frequency in Hertz
  * @param operation is a bit field with the following parts:
  *


### PR DESCRIPTION
Removed a doxygen comment for a structure variable that has been
removed from spi_config.

Signed-off-by: AJ Palmer <ajpcode@hotmail.com>