### PR TITLE
soc: arm: Don't touch interrupts in kinetis watchdog init

### DIFF
--- a/soc/arm/nxp_kinetis/k6x/wdog.S
+++ b/soc/arm/nxp_kinetis/k6x/wdog.S
@@ -50,8 +50,6 @@ SECTION_FUNC(TEXT,_WdogInit)
      * interrupts to keep the code atomic and ensure the timing.
      */
 
-    cpsid i
-
     ldr r0, =PERIPH_ADDR_BASE_WDOG
 
     movw r1, #WDOG_UNLOCK_1_CMD
@@ -71,8 +69,6 @@ SECTION_FUNC(TEXT,_WdogInit)
     mov  r2, #1
     bics r1, r2
     strh r1, [r0, #WDOG_SCTRL_HI_OFFSET]
-
-    cpsie i
 
     bx lr
 

--- a/soc/arm/nxp_kinetis/kwx/wdog.S
+++ b/soc/arm/nxp_kinetis/kwx/wdog.S
@@ -50,8 +50,6 @@ SECTION_FUNC(TEXT,_WdogInit)
      * interrupts to keep the code atomic and ensure the timing.
      */
 
-    cpsid i
-
     ldr r0, =PERIPH_ADDR_BASE_WDOG
 
     movw r1, #WDOG_UNLOCK_1_CMD
@@ -71,8 +69,6 @@ SECTION_FUNC(TEXT,_WdogInit)
     mov  r2, #1
     bics r1, r2
     strh r1, [r0, #WDOG_SCTRL_HI_OFFSET]
-
-    cpsie i
 
     bx lr
 


### PR DESCRIPTION
The early boot watchdog init for kinetis was incorrectly disabling and
reenabling interrupts to preserve timing during the unlock sequence.
However, interrupts are already disabled before this routine executes
and the kernel is not yet ready to enable them when this routine exits.

Fixes #11815

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>