### PR TITLE
cmake: STACK_CANARIES: Re-write how compatibility is checked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,13 +264,10 @@ zephyr_cc_option(-fno-strict-overflow)
 zephyr_cc_option(-Wno-pointer-sign)
 
 if(CONFIG_STACK_CANARIES)
-  zephyr_cc_option(-fstack-protector-all)
-  # Only a valid option with GCC 7.x and above
-  check_c_compiler_flag(-mstack-protector-guard=global MSTACK_PROTECTOR_GUARD)
+  zephyr_compile_options(-fstack-protector-all)
 
-  if(MSTACK_PROTECTOR_GUARD)
-    zephyr_cc_option(-mstack-protector-guard=global)
-  endif()
+  # Only a valid option with GCC 7.x and above
+  zephyr_cc_option(-mstack-protector-guard=global)
 endif()
 
 if(CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT)

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -608,7 +608,7 @@ config RETPOLINE
 config STACK_CANARIES
 	bool "Compiler stack canaries"
 	help
-	  This option enables compiler stack canaries support kernel functions.
+	  This option enables compiler stack canaries.
 
 	  If stack canaries are supported by the compiler, it will emit
 	  extra code that inserts a canary value into the stack frame when
@@ -618,8 +618,8 @@ config STACK_CANARIES
 	  Enabling this option can result in a significant increase
 	  in footprint and an associated decrease in performance.
 
-	  If stack canaries are not supported by the compiler, enabling this
-	  option has no effect.
+	  If stack canaries are not supported by the compiler an error
+	  will occur at build time.
 
 config EXECUTE_XOR_WRITE
 	bool "Enable W^X for memory partitions"


### PR DESCRIPTION
This re-write fixes several issues with how we were checking for
compatibility with the canary flags:

If a compiler did not support any stack canaries, but a user had still
enabled them, this would silently result in no canaries being added
instead of error-ing out as it should have.

Compatiblity for '-mstack-protector-guard=global' was unnecessarily
being tested twice, once in 'check_c_compiler_flag' and once in
'zephyr_cc_option'.

Compatibility was being tested with 'check_c_compiler_flag' which is
slower than 'zephyr_check_compiler_flag' because it does not cache
it's results.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>