### PR TITLE
net: gptp: Track memory allocations better

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -141,18 +141,36 @@ out:
 	}
 }
 
+#if defined(CONFIG_NET_DEBUG_NET_PKT_ALLOC)
+static struct net_pkt *setup_gptp_frame_debug(struct net_if *iface,
+					      const char *caller,
+					      int line)
+#define setup_gptp_frame(iface) \
+	setup_gptp_frame_debug(iface, __func__, __LINE__)
+#else
 static struct net_pkt *setup_gptp_frame(struct net_if *iface)
+#endif
 {
 	struct net_pkt *pkt;
 	struct net_buf *frag;
 
+#if defined(CONFIG_NET_DEBUG_NET_PKT_ALLOC)
+	pkt = net_pkt_get_reserve_tx_debug(net_if_get_ll_reserve(iface, NULL),
+					   NET_BUF_TIMEOUT, caller, line);
+#else
 	pkt = net_pkt_get_reserve_tx(net_if_get_ll_reserve(iface, NULL),
 				     NET_BUF_TIMEOUT);
+#endif
 	if (!pkt) {
 		return NULL;
 	}
 
+#if defined(CONFIG_NET_DEBUG_NET_PKT_ALLOC)
+	frag = net_pkt_get_reserve_tx_data_debug(0, NET_BUF_TIMEOUT, caller,
+						 line);
+#else
 	frag = net_pkt_get_reserve_tx_data(0, NET_BUF_TIMEOUT);
+#endif
 	if (!frag) {
 		net_pkt_unref(pkt);
 		return NULL;


### PR DESCRIPTION
Try to catch the original caller of setup_gptp_frame() function
in order to see who is allocating buffers.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>