### PR TITLE
drivers: eth: gmac: Remove extra variable

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -334,7 +334,6 @@ static struct gptp_hdr *check_gptp_msg(struct net_if *iface,
 	struct ethernet_context *eth_ctx;
 	struct gptp_hdr *gptp_hdr;
 	int eth_hlen;
-	u8_t *msg_start;
 
 #if defined(CONFIG_NET_VLAN)
 	eth_ctx = net_if_l2_data(iface);


### PR DESCRIPTION
The msg_start variable was declared twice.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>