### PR TITLE
samples: usb: hid-mouse: remove get_report_cb

### DIFF
--- a/samples/subsys/usb/hid-mouse/src/main.c
+++ b/samples/subsys/usb/hid-mouse/src/main.c
@@ -134,19 +134,6 @@ static const u8_t hid_report_desc[] = {
 		/* END_COLLECTION				C0    */
 };
 
-static int get_report_cb(struct usb_setup_packet *setup, s32_t *len,
-			 u8_t **data)
-{
-	*len = sizeof(hid_report_desc);
-	*data = (u8_t *)hid_report_desc;
-
-	return 0;
-}
-
-static struct hid_ops ops = {
-	.get_report = get_report_cb,
-};
-
 static u32_t def_val[4];
 static volatile u8_t status[4];
 static K_SEM_DEFINE(sem, 0, 1);	/* starts off "not available" */
@@ -296,7 +283,7 @@ void main(void)
 	}
 #endif
 
-	usb_hid_register_device(hid_report_desc, sizeof(hid_report_desc), &ops);
+	usb_hid_register_device(hid_report_desc, sizeof(hid_report_desc), NULL);
 	usb_hid_init();
 
 	while (true) {


### PR DESCRIPTION
Removed get_report_cb as it was an incorrect implementation
of Get_Report request. Correct response would be returning
current report value, not report descriptor.

Signed-off-by: Marcin Szymczyk <Marcin.Szymczyk@nordicsemi.no>

This is a follow-up to [this discussion](https://github.com/zephyrproject-rtos/zephyr/pull/11864#discussion_r238992308).
Rationale: Chapter 7.2.1 of Device Class Definition for Human Interface Devices (HID) Version 1.11