### PR TITLE
arch: arm: fix initial value of _image_ram_start

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -292,6 +292,7 @@ SECTIONS
 
     GROUP_START(RAMABLE_REGION)
 
+	. = RAM_ADDR;
 	/* Align the start of image SRAM with the
 	 * minimum granularity required by MPU.
 	 */


### PR DESCRIPTION
For all builds, _image_ram_start is initially set to RAM_ADDR,
before it is (possibly) aligned for MPU.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>