### PR TITLE
arc: cleanup linker scripts to include autoconf.h first

### DIFF
--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -11,7 +11,6 @@
 #define _LINKER
 #define _ASMLANGUAGE
 
-#include <autoconf.h>
 #include <linker/sections.h>
 
 #if defined(CONFIG_UART_NSIM)

--- a/soc/arc/quark_se_c1000_ss/linker.ld
+++ b/soc/arc/quark_se_c1000_ss/linker.ld
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <generated_dts_board.h>
+#include <autoconf.h>
+
 /**
  * @brief Linker script for the Quark SE platform, both standard images and XIP
  * images.
@@ -26,5 +29,4 @@
 #define DCCM_START		DT_DCCM_BASE_ADDRESS
 #define DCCM_SIZE		DT_DCCM_SIZE
 
-#include <generated_dts_board.h>
 #include <arch/arc/v2/linker.ld>

--- a/soc/arc/snps_emsk/linker.ld
+++ b/soc/arc/snps_emsk/linker.ld
@@ -9,6 +9,7 @@
  */
 
 #include <generated_dts_board.h>
+#include <autoconf.h>
 
 /*
  * DRAM base address and size

--- a/soc/arc/snps_nsim/linker.ld
+++ b/soc/arc/snps_nsim/linker.ld
@@ -9,7 +9,7 @@
  */
 
 #include <generated_dts_board.h>
-
+#include <autoconf.h>
 
 /* Instruction Closely Coupled Memory (ICCM) base address and size */
 #if defined(DT_ICCM_BASE_ADDRESS) && (DT_ICCM_SIZE > 0)


### PR DESCRIPTION
The various linker scripts on arc would include autoconf.h in the arch
linker script but might have CONFIG_ symbols referenced in the soc
specific linker script.  Move autoconf.h inclusion to top of the soc
specific linker script out of the arch specific one so we know
autoconf.h is seen before any CONFIG_ references.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>