### PR TITLE
usb: fix CDC ACM breakage with CONFIG_USB_DEVICE_SOF

### DIFF
--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -400,7 +400,9 @@ static void cdc_acm_dev_status_cb(enum usb_dc_status_code status,
 	ARG_UNUSED(param);
 
 	/* Store the new status */
-	dev_data->usb_status = status;
+	if (status != USB_DC_SOF) {
+		dev_data->usb_status = status;
+	}
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {


### PR DESCRIPTION
Commit e4c447aac3 ("usb: add SoF event") added support for calling the
status callback with the USB_DC_SOF value for each SoF when
CONFIG_USB_DEVICE_SOF is enabled. The CDC ACM driver saves the latest
received status and compares it USB_DC_CONFIGURED to decide if it can
send data to the host. This therefore doesn't work any more when the
status callback is called regulary with USB_DC_SOF.

Fix that by ignoring USB_DC_SOF when saving the latest received status.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>