### PR TITLE
drivers: usb_dc_stm32: add support for SoF event

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -185,6 +185,13 @@ static void usb_dc_stm32_isr(void *arg)
 	HAL_PCD_IRQHandler(&usb_dc_stm32_state.pcd);
 }
 
+#ifdef CONFIG_USB_DEVICE_SOF
+void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd)
+{
+	usb_dc_stm32_state.status_cb(USB_DC_SOF, NULL);
+}
+#endif
+
 static int usb_dc_stm32_clock_enable(void)
 {
 	struct device *clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
@@ -344,6 +351,10 @@ static int usb_dc_stm32_init(void)
 #endif
 
 #endif /* USB */
+
+#ifdef CONFIG_USB_DEVICE_SOF
+	usb_dc_stm32_state.pcd.Init.Sof_enable = 1;
+#endif /* CONFIG_USB_DEVICE_SOF */
 
 	LOG_DBG("HAL_PCD_Init");
 	status = HAL_PCD_Init(&usb_dc_stm32_state.pcd);


### PR DESCRIPTION
Add support for SoF events to the USB STM32 device driver. When
CONFIG_USB_DEVICE_SOF is enabled, enable the corresponding interrupt
and provide a non-weak callback function calling status_cb.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>