### PR TITLE
log: Fix switch statement

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -62,22 +62,30 @@ extern void _vprintk(out_func_t out, void *log_output,
  */
 static int level_to_rfc5424_severity(u32_t level)
 {
+	u8_t ret;
+
 	switch (level) {
 	case LOG_LEVEL_NONE:
-		return 7;
+		ret = 7;
+		break;
 	case LOG_LEVEL_ERR:
-		return 3;
+		ret =  3;
+		break;
 	case LOG_LEVEL_WRN:
-		return 4;
+		ret =  4;
+		break;
 	case LOG_LEVEL_INF:
-		return 6;
+		ret =  6;
+		break;
 	case LOG_LEVEL_DBG:
-		return 7;
+		ret = 7;
+		break;
 	default:
+		ret = 7;
 		break;
 	}
 
-	return 7;
+	return ret;
 }
 
 static int out_func(int c, void *ctx)


### PR DESCRIPTION
MISRA-C has several rules about switch statements like each clause
end with an unconditional break. This commit fix these problems to
be in accordance with the standard.

MISRA-C rules 16.1, 16.3 and 16.4

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>