### PR TITLE
scripts: gen_relocate_app: Use linker provided size variable.

### DIFF
--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -68,7 +68,7 @@ SOURCE_CODE_INCLUDES = """
 EXTERN_LINKER_VAR_DECLARATION = """
 extern char __{0}_{1}_start[];
 extern char __{0}_{1}_rom_start[];
-extern char __{0}_{1}_end[];
+extern char __{0}_{1}_size[];
 """
 
 
@@ -88,12 +88,13 @@ void bss_zeroing_relocation(void)
 
 MEMCPY_TEMPLATE = """
 	(void)memcpy(&__{0}_{1}_start, &__{0}_{1}_rom_start,
-		 ((u32_t) &__{0}_{1}_end - (u32_t) &__{0}_{1}_start));
+		     (u32_t) &__{0}_{1}_size);
+
 """
 
 MEMSET_TEMPLATE = """
  	(void)memset(&__{0}_bss_start, 0,
- 		     ((u32_t) &__{0}_bss_end - (u32_t) &__{0}_bss_start));
+		     (u32_t) &__{0}_bss_size);
 """
 
 def find_sections(filename, full_list_of_sections):


### PR DESCRIPTION
This seems to solve the issue with GH-12033. There seems to be
some compiler optimization that was causing this issue. This
occurs only when the build is re-run by invoking cmake without
clearing the previous build.

Fixes:GH-12033

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>