### PR TITLE
drivers: sensor: temp_nrf5: update assert condition in nRF temp sensor

### DIFF
--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -51,7 +51,7 @@ static int temp_nrf5_sample_fetch(struct device *dev, enum sensor_channel chan)
 	k_sem_take(&data->device_sync_sem, K_FOREVER);
 
 	r = clock_control_off(data->clk_m16_dev, (void *)1);
-	__ASSERT_NO_MSG(!r);
+	__ASSERT_NO_MSG(!r || r == -EBUSY);
 
 	data->sample = temp->TEMP;
 


### PR DESCRIPTION
nRF 16MHz clock is used by both BLE radio and temperature sensor.
During BLE connection if the temperature sensor is also used then
at some point assert condition is hit in temp_nrf5_sample_fetch().
The error code -EBUSY seen during clock_control_off() is that clock
is no longer needed for the temperature sensor, but it cannot be
just turned off because it is still needed for BLE connection.

Signed-off-by: Dhananjay Gundapu Jayakrishnan <dhananjay.jayakrishnan@proglove.de>