### PR TITLE
dts: nrf: Fix missed device tree warnings

### DIFF
--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -160,9 +160,9 @@
 			label = "PWM_2";
 		};
 
-		pwm3: pwm@4002D000 {
+		pwm3: pwm@4002d000 {
 			compatible = "nordic,nrf-pwm";
-			reg = <0x4002D000 0x1000>;
+			reg = <0x4002d000 0x1000>;
 			interrupts = <45 1>;
 			status = "disabled";
 			label = "PWM_3";


### PR DESCRIPTION
Fix the following warning that shows up in some NRF device tree files:

	Warning (simple_bus_reg): /soc/pwm@4002D000: simple-bus unit
	address format error, expected "4002d000"

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>