### PR TITLE
doc: regular misspelling scan

### DIFF
--- a/arch/arm/core/cortex_m/mpu/Kconfig
+++ b/arch/arm/core/cortex_m/mpu/Kconfig
@@ -25,7 +25,7 @@ config ARM_MPU_REGION_MIN_ALIGN_AND_SIZE
 	help
 	  Minimum size (and alignment) of an ARM MPU region. Use this
 	  symbol to guarantee minimum size and alignment of MPU regions.
-	  A minimum 4-byte alignmnent is enforced in ARM builds without
+	  A minimum 4-byte alignment is enforced in ARM builds without
 	  support for Memory Protection.
 
 config MPU_STACK_GUARD

--- a/boards/arm/efr32mg_sltb004a/doc/efr32mg_sltb004a.rst
+++ b/boards/arm/efr32mg_sltb004a/doc/efr32mg_sltb004a.rst
@@ -38,7 +38,7 @@ Hardware
   network debugging
 - Breakout pads for GPIO access and connection to external hardware
 - Reset button
-- Automatic switchover between USB and battery power
+- Automatic switch-over between USB and battery power
 - CR2032 coin cell holder and external battery connector
 
 For more information about the EFR32MG SoC and Thunderboard Sense 2

--- a/boards/arm/stm32f769i_disco/doc/stm32f769i_disco.rst
+++ b/boards/arm/stm32f769i_disco/doc/stm32f769i_disco.rst
@@ -85,7 +85,7 @@ The STM32F769I Discovery kit provides the following hardware components:
 - 8- to 14-bit camera interface up to 54 Mbyte/s
 - True random number generator
 - CRC calculation unit
-- RTC: subsecond accuracy, hardware calendar
+- RTC: sub-second accuracy, hardware calendar
 - 96-bit unique ID
 
 More information about STM32F769NIH6 can be found here:

--- a/doc/subsystems/networking/secure-sockets.rst
+++ b/doc/subsystems/networking/secure-sockets.rst
@@ -33,7 +33,7 @@ The following TLS credential types can be registered in the system:
 - ``TLS_CREDENTIAL_PSK``
 - ``TLS_CREDENTIAL_PSK_ID``
 
-An example registeration of CA certificate (provided in ``ca_certificate``
+An example registration of CA certificate (provided in ``ca_certificate``
 array) looks like this:
 
 .. code-block:: c
@@ -71,7 +71,7 @@ CA certificate and hostname can be set:
 
    ret = setsockopt(sock, SOL_TLS, TLS_HOSTNAME, host, sizeof(host));
 
-Once configured, socket can be used just like a regualar TCP socket.
+Once configured, socket can be used just like a regular TCP socket.
 
 Several samples in Zephyr use secure sockets for communication. For a sample use
 see e.g. :ref:`sockets-echo-server-sample` or :ref:`sockets-http-get`.

--- a/include/atomic.h
+++ b/include/atomic.h
@@ -342,7 +342,7 @@ static inline bool atomic_test_bit(const atomic_t *target, int bit)
  * @param target Address of atomic variable or array.
  * @param bit Bit number (starting from 0).
  *
- * @return true if the bit was set, fale if it wasn't.
+ * @return true if the bit was set, false if it wasn't.
  */
 static inline bool atomic_test_and_clear_bit(atomic_t *target, int bit)
 {

--- a/include/console.h
+++ b/include/console.h
@@ -63,7 +63,7 @@ ssize_t console_write(void *dummy, const void *buf, size_t size);
  *  or console_getline().
  *
  *  @return 0-255: a character read, including control characters.
- *          <0: error occured.
+ *          <0: error occurred.
  */
 int console_getchar(void);
 

--- a/include/gna.h
+++ b/include/gna.h
@@ -133,7 +133,7 @@ struct gna_driver_api {
  * @param cfg Device configuration information
  *
  * @retval 0 If the configuration is successful
- * @retval A negative erro code in case of a failure.
+ * @retval A negative error code in case of a failure.
  */
 static inline int gna_configure(struct device *dev, struct gna_config *cfg)
 {
@@ -153,7 +153,7 @@ static inline int gna_configure(struct device *dev, struct gna_config *cfg)
  * @param model_handle Handle to the registered model if registration succeeds
  *
  * @retval 0 If registration of the model is successful.
- * @retval A negative erro code in case of a failure.
+ * @retval A negative error code in case of a failure.
  */
 static inline int gna_register_model(struct device *dev,
 		struct gna_model_info *model, void **model_handle)
@@ -174,7 +174,7 @@ static inline int gna_register_model(struct device *dev,
  * @param model Model handle output by gna_register_model API
  *
  * @retval 0 If de-registration of the model is successful.
- * @retval A negative erro code in case of a failure.
+ * @retval A negative error code in case of a failure.
  */
 static inline int gna_deregister_model(struct device *dev, void *model)
 {
@@ -195,7 +195,7 @@ static inline int gna_deregister_model(struct device *dev, void *model)
  * @param callback A callback function to notify inference completion
  *
  * @retval 0 If the request is accepted
- * @retval A negative erro code in case of a failure.
+ * @retval A negative error code in case of a failure.
  */
 static inline int gna_infer(struct device *dev, struct gna_inference_req *req,
 	gna_callback callback)

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2560,7 +2560,7 @@ static inline void k_work_submit_to_queue(struct k_work_q *work_q,
 /**
  * @brief Submit a work item to a user mode workqueue
  *
- * Sumbits a work item to a workqueue that runs in user mode. A temporary
+ * Submits a work item to a workqueue that runs in user mode. A temporary
  * memory allocation is made from the caller's resource pool which is freed
  * once the worker thread consumes the k_work item. The workqueue
  * thread must have memory access to the k_work item being submitted. The caller

--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -582,7 +582,7 @@ int mqtt_subscribe(struct mqtt_client *client,
 		   const struct mqtt_subscription_list *param);
 
 /**
- * @brief API to request unsubscribtion of one or more topics on the connection.
+ * @brief API to request unsubscription of one or more topics on the connection.
  *
  * @param[in] client Identifies client instance for which the procedure is
  *                   requested. Shall not be NULL.

--- a/include/settings/settings.h
+++ b/include/settings/settings.h
@@ -63,7 +63,7 @@ struct settings_handler {
 	 * Parameters:
 	 *  - argc - count of item in argv, argv - array of pointers to keyword
 	 *   names.
-	 *  - value_ctx - pointer to the value contex which is used paramiter
+	 *  - value_ctx - pointer to the value context which is used parameter
 	 *   for data extracting routine (@ref settings_val_read_cb).
 	 */
 
@@ -196,16 +196,16 @@ int settings_commit(char *name);
 /**
  * Persistent data extracting routine.
  *
- * This function read and decode data from non volatile storage to user buffer
+ * This function read and decode data from non-volatile storage to user buffer
  * This function should be used inside set handler in order to read the settings
  * data from backend storage.
  *
- * @param[in] value_ctx Data contex provided by the <p>h_set</p> handler.
+ * @param[in] value_ctx Data context provided by the h_set handler.
  * @param[out] buf Buffer for data read.
- * @param[in] len Length of <p>buf</p>.
+ * @param[in] len Length of @p buf.
  *
  * @retval Negative value on failure. 0 and positive: Length of data loaded to
- * the <p>buf</p>.
+ * the @p buf.
  */
 int settings_val_read_cb(void *value_ctx, void *buf, size_t len);
 
@@ -214,7 +214,7 @@ int settings_val_read_cb(void *value_ctx, void *buf, size_t len);
  * This function should be used inside set handler in order to detect the
  * settings data length.
  *
- * @param[in] value_ctx Data contex provided by the <p>h_set</p> handler.
+ * @param[in] value_ctx Data context provided by the h_set handler.
  *
  * @retval length of data.
  */

--- a/include/tty.h
+++ b/include/tty.h
@@ -86,7 +86,7 @@ static inline void tty_set_tx_timeout(struct tty_serial *tty, s32_t timeout)
  * @param buf buffer to read data to
  * @param size maximum number of bytes to read
  * @return >0, number of actually read bytes (can be less than size param)
- *         =0, for EOF-like condition (e.g., break signalled)
+ *         =0, for EOF-like condition (e.g., break signaled)
  *         <0, in case of error (e.g. -EAGAIN if timeout expired). errno
  *             variable is also set.
  */
@@ -96,7 +96,7 @@ ssize_t tty_read(struct tty_serial *tty, void *buf, size_t size);
  * @brief Write data to tty device.
  *
  * @param tty tty device structure
- * @param buf buffer containg data
+ * @param buf buffer containing data
  * @param size maximum number of bytes to write
  * @return =>0, number of actually written bytes (can be less than size param)
  *         <0, in case of error (e.g. -EAGAIN if timeout expired). errno

--- a/samples/net/gptp/README.rst
+++ b/samples/net/gptp/README.rst
@@ -58,9 +58,9 @@ the ``net-setup.sh`` will create VLAN setup automatically with this command:
 
 The OpenAVNU repository at https://github.com/AVnu contains gPTP
 daemon that can be run in Linux host and which can act as a grandmaster for
-the IEEE 801.1AS network. Note that OpenAvnu will not work with
+the IEEE 801.1AS network. Note that OpenAVNU will not work with
 native_posix board as that board only supports software timestamping and
-OpenAvnu only supports hardware timestamping. See instructions at the end
+OpenAVNU only supports hardware timestamping. See instructions at the end
 of this chapter how to run linuxptp daemon with native_posix board.
 
 Get OpenAvnu/gPTP project sources

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -239,7 +239,7 @@ config TRACING_CPU_STATS
 	  Module provides information about percent of CPU usage based on
 	  tracing hooks for threads switching in and out, interrupts enters
 	  and exits (only distinguishes between idle thread, non idle thread
-	  and scheduler). Use provided API or enable automatical logging to
+	  and scheduler). Use provided API or enable automatic logging to
 	  get values.
 
 config TRACING_CPU_STATS_LOG

--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -18,8 +18,8 @@ choice COAP_CHOICE
 	prompt "CoAP Implementation"
 	default COAP_SOCK
 	help
-	  Select the CoAP implmentation. CoAP based on net_pkt is deprecated.
-	  Please use the socket based implmenetation for new applications.
+	  Select the CoAP implementation. CoAP based on net_pkt is deprecated.
+	  Please use the socket based implementation for new applications.
 
 config COAP_SOCK
 	bool "CoAP based on Sockets"


### PR DESCRIPTION
Fix misspellings in documentation (.rst, Kconfig help text, and .h doxygen
API comments), missed during regular reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>