### PR TITLE
dts: stm32f7: move flash0 node below flash-controller

### DIFF
--- a/dts/arm/st/f7/stm32f756Xg.dtsi
+++ b/dts/arm/st/f7/stm32f756Xg.dtsi
@@ -12,7 +12,11 @@
 		reg = <0x20000000 DT_SIZE_K(320)>;
 	};
 
-	flash0: flash@8000000 {
-		reg = <0x08000000 DT_SIZE_K(1024)>;
+	soc {
+		flash-controller@40023c00 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(1024)>;
+			};
+		};
 	};
 };


### PR DESCRIPTION
Due to a bad timing in merging PR #10744 and PR#12083, the flash0 node
in stm32f756Xg.dtsi ended-up at the root of the device tree, while the
flash0 node it is trying to override in stm32f7.dtsi is now under
/soc/flash-controller.

This patch fixes that by moving it at the right location.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>