### PR TITLE
log: Explicitly ignoring return of memcpy

### DIFF
--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -50,7 +50,7 @@ void __weak relocate_vector_table(void)
 #if defined(CONFIG_XIP) && (CONFIG_FLASH_BASE_ADDRESS != 0) || \
     !defined(CONFIG_XIP) && (CONFIG_SRAM_BASE_ADDRESS != 0)
 	size_t vector_size = (size_t)_vector_end - (size_t)_vector_start;
-	memcpy(VECTOR_ADDRESS, _vector_start, vector_size);
+	(void)memcpy(VECTOR_ADDRESS, _vector_start, vector_size);
 #elif defined(CONFIG_SW_VECTOR_RELAY)
 	_vector_table_pointer = _vector_start;
 #endif

--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -250,7 +250,7 @@ struct dirent *readdir(DIR *dirp)
 
 	rc = strlen(fdirent.name);
 	rc = (rc < PATH_MAX) ? rc : (PATH_MAX - 1);
-	memcpy(pdirent.d_name, fdirent.name, rc);
+	(void)memcpy(pdirent.d_name, fdirent.name, rc);
 
 	/* Make sure the name is NULL terminated */
 	pdirent.d_name[rc] = '\0';

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -283,7 +283,7 @@ int pthread_attr_init(pthread_attr_t *attr)
 		return ENOMEM;
 	}
 
-	memcpy(attr, &init_pthread_attrs, sizeof(pthread_attr_t));
+	(void)memcpy(attr, &init_pthread_attrs, sizeof(pthread_attr_t));
 
 	return 0;
 }

--- a/scripts/coccinelle/ignore_return.cocci
+++ b/scripts/coccinelle/ignore_return.cocci
@@ -1,7 +1,7 @@
 /// Cast void to memset to ignore its return value
 ///
-//# The return of memset is never checked and therefore cast
-//# it to void to explicitly ignore while adhering to MISRA-C.
+//# The return of memset and memcpy is never checked and therefore
+//# cast it to void to explicitly ignore while adhering to MISRA-C.
 //
 // Confidence: High
 // Copyright (c) 2017 Intel Corporation
@@ -13,7 +13,10 @@ virtual patch
 @depends on patch && !(file in "ext")@
 expression e1,e2,e3;
 @@
-
+(
 + (void)
 memset(e1,e2,e3);
-
+|
++ (void)
+memcpy(e1,e2,e3);
+)

--- a/subsys/logging/log_backend_net.c
+++ b/subsys/logging/log_backend_net.c
@@ -126,7 +126,7 @@ static int do_net_init(void)
 	}
 
 	if (IS_ENABLED(CONFIG_NET_HOSTNAME_ENABLE)) {
-		memcpy(hostname, net_hostname_get(), MAX_HOSTNAME_LEN);
+		(void)memcpy(hostname, net_hostname_get(), MAX_HOSTNAME_LEN);
 
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		   server_addr.sa_family == AF_INET6) {

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -105,7 +105,7 @@ static int log_backend_rtt_write_drop(void)
 	if (drop_cnt > 0 && !drop_warn) {
 		memmove(line_buf + DROP_MSG_LEN, line_buf,
 			line_pos - line_buf);
-		memcpy(line_buf, drop_msg, DROP_MSG_LEN);
+		(void)memcpy(line_buf, drop_msg, DROP_MSG_LEN);
 		line_pos += DROP_MSG_LEN;
 		drop_warn = 1;
 	}

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -184,19 +184,21 @@ static void copy_args_to_msg(struct  log_msg *msg, u32_t *args, u32_t nargs)
 	struct log_msg_cont *cont = msg->payload.ext.next;
 
 	if (nargs > LOG_MSG_NARGS_SINGLE_CHUNK) {
-		memcpy(msg->payload.ext.data.args, args,
+		(void)memcpy(msg->payload.ext.data.args, args,
 		       LOG_MSG_NARGS_HEAD_CHUNK * sizeof(u32_t));
 		nargs -= LOG_MSG_NARGS_HEAD_CHUNK;
 		args += LOG_MSG_NARGS_HEAD_CHUNK;
 	} else {
-		memcpy(msg->payload.single.args, args, nargs * sizeof(u32_t));
+		(void)memcpy(msg->payload.single.args, args,
+			     nargs * sizeof(u32_t));
 		nargs  = 0U;
 	}
 
 	while (nargs) {
 		u32_t cpy_args = min(nargs, ARGS_CONT_MSG);
 
-		memcpy(cont->payload.args, args, cpy_args * sizeof(u32_t));
+		(void)memcpy(cont->payload.args, args,
+			     cpy_args * sizeof(u32_t));
 		nargs -= cpy_args;
 		args += cpy_args;
 		cont = cont->next;
@@ -247,7 +249,7 @@ struct log_msg *log_msg_hexdump_create(const char *str,
 
 
 	if (length > LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK) {
-		memcpy(msg->payload.ext.data.bytes,
+		(void)memcpy(msg->payload.ext.data.bytes,
 		       data,
 		       LOG_MSG_HEXDUMP_BYTES_HEAD_CHUNK);
 		msg->payload.ext.next = NULL;
@@ -256,7 +258,7 @@ struct log_msg *log_msg_hexdump_create(const char *str,
 		data += LOG_MSG_HEXDUMP_BYTES_HEAD_CHUNK;
 		length -= LOG_MSG_HEXDUMP_BYTES_HEAD_CHUNK;
 	} else {
-		memcpy(msg->payload.single.bytes, data, length);
+		(void)memcpy(msg->payload.single.bytes, data, length);
 		msg->hdr.params.generic.ext = 0;
 		length = 0U;
 	}
@@ -277,7 +279,7 @@ struct log_msg *log_msg_hexdump_create(const char *str,
 		chunk_length = (length > HEXDUMP_BYTES_CONT_MSG) ?
 			       HEXDUMP_BYTES_CONT_MSG : length;
 
-		memcpy(cont->payload.bytes, data, chunk_length);
+		(void)memcpy(cont->payload.bytes, data, chunk_length);
 		data += chunk_length;
 		length -= chunk_length;
 	}
@@ -323,9 +325,9 @@ static void log_msg_hexdump_data_op(struct log_msg *msg,
 		cpy_len = req_len > chunk_len ? chunk_len : req_len;
 
 		if (put_op) {
-			memcpy(&head_data[offset], data, cpy_len);
+			(void)memcpy(&head_data[offset], data, cpy_len);
 		} else {
-			memcpy(data, &head_data[offset], cpy_len);
+			(void)memcpy(data, &head_data[offset], cpy_len);
 		}
 
 		req_len -= cpy_len;
@@ -348,9 +350,11 @@ static void log_msg_hexdump_data_op(struct log_msg *msg,
 		cpy_len = req_len > chunk_len ? chunk_len : req_len;
 
 		if (put_op) {
-			memcpy(&cont->payload.bytes[offset], data, cpy_len);
+			(void)memcpy(&cont->payload.bytes[offset],
+				     data, cpy_len);
 		} else {
-			memcpy(data, &cont->payload.bytes[offset], cpy_len);
+			(void)memcpy(data, &cont->payload.bytes[offset],
+				     cpy_len);
 		}
 
 		offset = 0;

--- a/subsys/logging/sys_log_net.c
+++ b/subsys/logging/sys_log_net.c
@@ -169,7 +169,7 @@ void syslog_net_hook_install(void)
 	}
 
 #if CONFIG_NET_HOSTNAME_ENABLE
-	memcpy(hostname, net_hostname_get(), MAX_HOSTNAME_LEN);
+	(void)memcpy(hostname, net_hostname_get(), MAX_HOSTNAME_LEN);
 #else /* CONFIG_NET_HOSTNAME_ENABLE */
 	if (server_addr.sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)


### PR DESCRIPTION
According with MISRA-C the value returned by a non-void function has
to be used. As memcpy return is almost useless, we are explicitly
ignoring it.

MISRA-C rule 17.7

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>