### PR TITLE
debug: SystemView fix

### DIFF
--- a/ext/debug/segger/systemview/SEGGER_SYSVIEW_Conf.h
+++ b/ext/debug/segger/systemview/SEGGER_SYSVIEW_Conf.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <irq.h>
 
 #define SEGGER_SYSVIEW_GET_TIMESTAMP sysview_get_timestamp
 #define SEGGER_SYSVIEW_GET_INTERRUPT_ID sysview_get_interrupt
@@ -8,4 +9,13 @@
 uint32_t sysview_get_timestamp(void);
 uint32_t sysview_get_interrupt(void);
 
-#define SEGGER_SYSVIEW_RTT_BUFFER_SIZE 4096
+#define SEGGER_SYSVIEW_RTT_BUFFER_SIZE CONFIG_SEGGER_SYSVIEW_RTT_BUFFER_SIZE
+
+// Lock SystemView (nestable)
+#define SEGGER_SYSVIEW_LOCK()	{					       \
+					unsigned int __sysview_irq_key =       \
+						irq_lock()
+
+// Unlock SystemView (nestable)
+#define SEGGER_SYSVIEW_UNLOCK()		irq_unlock(__sysview_irq_key);         \
+				}

--- a/subsys/debug/Kconfig.segger
+++ b/subsys/debug/Kconfig.segger
@@ -25,6 +25,16 @@ config SEGGER_SYSTEMVIEW
 	select THREAD_STACK_INFO
 	select TRACING
 
+config SEGGER_SYSTEMVIEW_BOOT_ENABLE
+	bool "Start logging SystemView events on system start"
+	depends on SEGGER_SYSTEMVIEW
+	default n
+
+config SEGGER_SYSVIEW_RTT_BUFFER_SIZE
+	int "Buffer size for SystemView RTT"
+	depends on SEGGER_SYSTEMVIEW
+	default 4096
+
 config SEGGER_RTT_MAX_NUM_UP_BUFFERS
 	int "Maximum number of up-buffers"
 	default 3

--- a/subsys/debug/tracing/sysview.c
+++ b/subsys/debug/tracing/sysview.c
@@ -90,9 +90,11 @@ static int sysview_init(struct device *arg)
 	ARG_UNUSED(arg);
 
 	SEGGER_SYSVIEW_Conf();
-	SEGGER_SYSVIEW_Start();
+	if (IS_ENABLED(CONFIG_SEGGER_SYSTEMVIEW_BOOT_ENABLE)) {
+		SEGGER_SYSVIEW_Start();
+	}
 	return 0;
 }
 
 
-SYS_INIT(sysview_init, PRE_KERNEL_1, 0);
+SYS_INIT(sysview_init, POST_KERNEL, 0);


### PR DESCRIPTION
Change fixes problem with mutexes and initialization for SystemView [#11244](https://github.com/zephyrproject-rtos/zephyr/issues/11244),
adds config options to:
- choose if SystemView should start logging events on system start
- select SystemView RTT buffer size

New config options may help with overflow event - issue:  [#10329](https://github.com/zephyrproject-rtos/zephyr/issues/10329)