### PR TITLE
boards: Add counter capability to nordic boards

### DIFF
--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.yaml
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.yaml
@@ -11,6 +11,7 @@ supported:
   - adc
   - ble
   - nvs
+  - counter
 testing:
   default: true
   ignore_tags:

--- a/boards/arm/nrf52810_pca10040/nrf52810_pca10040.yaml
+++ b/boards/arm/nrf52810_pca10040/nrf52810_pca10040.yaml
@@ -8,3 +8,5 @@ toolchain:
   - xtools
 ram: 24
 flash: 192
+supported:
+  - counter

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.yaml
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.yaml
@@ -11,3 +11,4 @@ supported:
   - usb_device
   - ble
   - ieee802154
+  - counter

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
@@ -11,3 +11,4 @@ flash: 512
 supported:
   - adc
   - nvs
+  - counter


### PR DESCRIPTION
Added counter capability to pca10028, pca10040 and pca10056

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>