### PR TITLE
drivers: ieee802154: nrf5: Prevent log spam

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -121,9 +121,13 @@ static void nrf5_rx_thread(void *arg1, void *arg2, void *arg3)
 			goto out;
 		}
 
-		net_analyze_stack("nRF5 rx stack",
-				  K_THREAD_STACK_BUFFER(nrf5_radio->rx_stack),
-				  K_THREAD_STACK_SIZEOF(nrf5_radio->rx_stack));
+		if (CONFIG_IEEE802154_DRIVER_LOG_LEVEL >= LOG_LEVEL_DBG) {
+			net_analyze_stack(
+				"nRF5 rx stack",
+				K_THREAD_STACK_BUFFER(nrf5_radio->rx_stack),
+				K_THREAD_STACK_SIZEOF(nrf5_radio->rx_stack));
+		}
+
 		continue;
 
 out:


### PR DESCRIPTION
ieee802154_nrf5 uses net_analyze_stack function in a loop, which
prints logs at inf level. As net_core's log level is used in
this function which by default is set to inf, it kept spamming stack
usage logs.

Prevent this behavior by adding additional log level check in the driver
itself, so that this log will only be printed if IEEE802154_DRIVER_LOG_LEVEL is set to debug.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>