### PR TITLE
soc: arm: nordic_nrf: Remove duplicates from Kconfig.soc

### DIFF
--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -154,6 +154,7 @@ config NRF_RTC_TIMER
 	default y
 	depends on CLOCK_CONTROL_NRF
 	select TICKLESS_CAPABLE
+	select COUNTER_RTC1
 	help
 	  This module implements a kernel device driver for the nRF Real Time
 	  Counter NRF_RTC1 and provides the standard "system clock driver"

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.soc
@@ -45,11 +45,6 @@ config SOC_NRF52810
 
 config SOC_NRF52832
 	depends on SOC_SERIES_NRF52X
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TIMER3
-	select HAS_HW_NRF_TIMER4
 	bool
 	select SOC_COMPATIBLE_NRF52832
 	select CPU_HAS_FPU
@@ -116,11 +111,6 @@ config SOC_NRF52832
 config SOC_NRF52840
 	depends on SOC_SERIES_NRF52X
 	bool
-	select HAS_HW_NRF_TIMER0
-	select HAS_HW_NRF_TIMER1
-	select HAS_HW_NRF_TIMER2
-	select HAS_HW_NRF_TIMER3
-	select HAS_HW_NRF_TIMER4
 	select CPU_HAS_FPU
 	select HAS_HW_NRF_ACL
 	select HAS_HW_NRF_CC310


### PR DESCRIPTION
Removing duplicates in selects for config SOC_NRF52832 and
SOC_NRF52840. Duplicates were unexpected merge artifacts.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>