### PR TITLE
cmake: Remove dead code LTO references

### DIFF
--- a/arch/arc/CMakeLists.txt
+++ b/arch/arc/CMakeLists.txt
@@ -8,6 +8,4 @@ zephyr_cc_option(-g3 -gdwarf-2)
 # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63691
 zephyr_cc_option(-fno-delete-null-pointer-checks)
 
-zephyr_cc_option_ifdef (CONFIG_LTO         -flto)
-
 add_subdirectory(core)

--- a/arch/arm/CMakeLists.txt
+++ b/arch/arm/CMakeLists.txt
@@ -1,5 +1,3 @@
-zephyr_cc_option_ifdef(CONFIG_LTO -flto)
-
 set(ARCH_FOR_cortex-m0        armv6s-m        )
 set(ARCH_FOR_cortex-m0plus    armv6s-m        )
 set(ARCH_FOR_cortex-m3        armv7-m         )

--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -1,5 +1,3 @@
-zephyr_cc_option_ifdef(CONFIG_LTO -flto)
-
 zephyr_compile_options(
   -fno-freestanding
   -m32

--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -31,7 +31,6 @@ if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
     )
 endif()
 
-zephyr_cc_option_ifdef (CONFIG_LTO         -flto)
 zephyr_cc_option_ifndef(CONFIG_SSE_FP_MATH -mno-sse)
 
 if(CMAKE_VERBOSE_MAKEFILE)


### PR DESCRIPTION
LTO is not supported yet, but there are a handful of references to the
flag '-flto' and the non-existent Kconfig option 'LTO'. To not confuse
users about whether LTO is supported or not, we should remove this
dead code.

As an aside, prototyping has shown that supporting LTO will give
signicant (10%) code size improvments, but will not be trivial to
support due to how we process object files with python.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>