### PR TITLE
ci: bump number of builders to 7

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -7,14 +7,16 @@ env:
         - SDK=0.9.5
         - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.9.5
         - ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-        - MATRIX_BUILDS="5"
-        - MATRIX_BUILDS_EXTRA="5"
+        - MATRIX_BUILDS="7"
+        - MATRIX_BUILDS_EXTRA="7"
     matrix:
         - MATRIX_BUILD="1"
         - MATRIX_BUILD="2"
         - MATRIX_BUILD="3"
         - MATRIX_BUILD="4"
         - MATRIX_BUILD="5"
+        - MATRIX_BUILD="6"
+        - MATRIX_BUILD="7"
 
 build:
     cache: false


### PR DESCRIPTION
Temp bump number of builders to 7 since we getting a lot of timeout
issues with normal PRs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>