### PR TITLE
[RFC] net: openthread: update to latest master

### DIFF
--- a/include/net/openthread.h
+++ b/include/net/openthread.h
@@ -11,7 +11,8 @@
 
 #include <net/net_if.h>
 
-#include <openthread/openthread.h>
+#include <openthread/instance.h>
+#include <openthread/thread.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -11,8 +11,6 @@ LOG_MODULE_DECLARE(net_l2_openthread, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 #include <net/net_pkt.h>
 #include <net/openthread.h>
 
-#include <openthread/openthread.h>
-
 #include "openthread_utils.h"
 
 int pkt_list_add(struct openthread_context *context, struct net_pkt *pkt)

--- a/subsys/net/lib/openthread/CMakeLists.txt
+++ b/subsys/net/lib/openthread/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT EXTERNAL_PROJECT_PATH_OPENTHREAD)
   # TODO: Point to a Zephyr fork
   # Nov. 7
   set_ifndef(ot_GIT_REPOSITORY "https://github.com/openthread/openthread.git")
-  set_ifndef(ot_GIT_TAG db4759cc41257d0572ddedbeead1e02c52033620)
+  set_ifndef(ot_GIT_TAG ff0b30db5551bc6b87d10752363bdb1707ff72c8)
   set_ifndef(ot_GIT_PROGRESS 1)
 
   list(APPEND cmd
@@ -128,6 +128,7 @@ set(ZEPHYR_MBEDTLS_CPPFLAGS "${ZEPHYR_MBEDTLS_CPPFLAGS} ")
 set(ZEPHYR_MBEDTLS_CPPFLAGS "-DMBEDTLS_CONFIG_FILE='\"mbedtls-config.h\"'")
 set(ZEPHYR_MBEDTLS_CPPFLAGS "${ZEPHYR_MBEDTLS_CPPFLAGS} -DMBEDTLS_USER_CONFIG_FILE='\"${CMAKE_CURRENT_SOURCE_DIR}/zephyr-mbedtls-config.h\"'")
 set(ZEPHYR_MBEDTLS_CPPFLAGS "${ZEPHYR_MBEDTLS_CPPFLAGS} -I${ot_SOURCE_DIR}/third_party/mbedtls")
+set(ZEPHYR_MBEDTLS_CPPFLAGS "${ZEPHYR_MBEDTLS_CPPFLAGS} -I${ot_SOURCE_DIR}/third_party/mbedtls/repo/include")
 set(ZEPHYR_MBEDTLS_CPPFLAGS "${ZEPHYR_MBEDTLS_CPPFLAGS} -I${ot_SOURCE_DIR}/third_party/mbedtls/repo.patched/include")
 set(ZEPHYR_MBEDTLS_CPPFLAGS "${ZEPHYR_MBEDTLS_CPPFLAGS} -I${ot_SOURCE_DIR}/third_party/mbedtls/repo.patched/include/mbedtls")
 
@@ -155,13 +156,25 @@ endif()
 
 if(CONFIG_OPENTHREAD_SHELL)
   list(APPEND configure_flags
-    --enable-cli-app=all
+    --enable-cli
     )
 endif()
 
 if(CONFIG_OPENTHREAD_DIAG)
   list(APPEND configure_flags
     --enable-diag
+    )
+endif()
+
+if(CONFIG_OPENTHREAD_FTD)
+  list(APPEND configure_flags
+    --enable-ftd
+    )
+endif()
+
+if(CONFIG_OPENTHREAD_MTD)
+  list(APPEND configure_flags
+    --enable-mtd
     )
 endif()
 

--- a/subsys/net/lib/openthread/platform/alarm.c
+++ b/subsys/net/lib/openthread/platform/alarm.c
@@ -15,7 +15,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <inttypes.h>
 
 #include <openthread/platform/alarm-milli.h>
-#include <platform.h>
 
 #include <stdio.h>
 

--- a/subsys/net/lib/openthread/platform/misc.c
+++ b/subsys/net/lib/openthread/platform/misc.c
@@ -6,7 +6,7 @@
 
 #include <kernel.h>
 #include <misc/reboot.h>
-#include <openthread/types.h>
+#include <openthread/instance.h>
 #include <openthread/platform/misc.h>
 
 #include "platform-zephyr.h"

--- a/subsys/net/lib/openthread/platform/platform-zephyr.h
+++ b/subsys/net/lib/openthread/platform/platform-zephyr.h
@@ -15,7 +15,9 @@
 
 #include <stdint.h>
 
-#include <openthread/openthread.h>
+#include <openthread/instance.h>
+#include <openthread/tasklet.h>
+#include <openthread/thread.h>
 
 /**
  * This function initializes the alarm service used by OpenThread.
@@ -66,5 +68,9 @@ void platformRandomInit(void);
  *  Initialize platform Shell driver.
  */
 void platformShellInit(otInstance *aInstance);
+
+void PlatformProcessDrivers(otInstance *aInstance);
+void PlatformInit(int argc, char *argv[]);
+void PlatformEventSignalPending(void);
 
 #endif  /* PLATFORM_POSIX_H_ */

--- a/subsys/net/lib/openthread/platform/platform.c
+++ b/subsys/net/lib/openthread/platform/platform.c
@@ -11,7 +11,7 @@
  */
 
 #include <kernel.h>
-#include <openthread/openthread.h>
+#include <openthread/instance.h>
 #include <openthread/tasklet.h>
 
 #include "platform-zephyr.h"

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -30,9 +30,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <openthread/platform/radio.h>
 #include <openthread/platform/diag.h>
-#include <platform.h>
-
-#include <openthread/types.h>
 
 #include "platform-zephyr.h"
 
@@ -98,7 +95,7 @@ void platformRadioProcess(otInstance *aInstance)
 		radio_api->set_channel(radio_dev, sTransmitFrame.mChannel);
 		radio_api->set_txpower(radio_dev, tx_power);
 
-		if (sTransmitFrame.mIsCcaEnabled) {
+		if (sTransmitFrame.mInfo.mTxInfo.mCsmaCaEnabled) {
 			if (radio_api->cca(radio_dev) ||
 			    radio_api->tx(radio_dev, tx_pkt, tx_payload)) {
 				result = OT_ERROR_CHANNEL_ACCESS_FAILURE;
@@ -129,8 +126,8 @@ void platformRadioProcess(otInstance *aInstance)
 
 				ackPsdu[2] = sTransmitFrame.mPsdu[2];
 				ackFrame.mPsdu = ackPsdu;
-				ackFrame.mLqi = 80;
-				ackFrame.mRssi = -40;
+				ackFrame.mInfo.mRxInfo.mLqi = 80;
+				ackFrame.mInfo.mRxInfo.mRssi = -40;
 				ackFrame.mLength = 5;
 
 				otPlatRadioTxDone(aInstance, &sTransmitFrame,

--- a/subsys/net/lib/openthread/platform/random.c
+++ b/subsys/net/lib/openthread/platform/random.c
@@ -6,7 +6,7 @@
 
 #include <kernel.h>
 #include <string.h>
-#include <openthread/types.h>
+
 #include <openthread/platform/random.h>
 
 #include "platform-zephyr.h"

--- a/subsys/net/lib/openthread/platform/shell.c
+++ b/subsys/net/lib/openthread/platform/shell.c
@@ -10,7 +10,6 @@
 #include <shell/shell.h>
 #include <shell/shell_uart.h>
 #include <openthread/cli.h>
-#include <platform.h>
 
 #include "platform-zephyr.h"
 


### PR DESCRIPTION
This patch enables compiling the Zephyr OpenThread platform integration
with a more current version of:
https://github.com/openthread/openthread/

The commit used was:
commit ff0b30db5551: "[mle] limit number of child-router links a REED /
FED maintains (#3358)" (Dec 6, 2018)

Signed-off-by: Michael Scott <mike@foundries.io>