### PR TITLE
Document CAN support for stm32f072b_disco and nucleo_l432kc

### DIFF
--- a/boards/arm/nucleo_l432kc/doc/nucleol432kc.rst
+++ b/boards/arm/nucleo_l432kc/doc/nucleol432kc.rst
@@ -116,6 +116,10 @@ The Zephyr nucleo_l432kc board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | PWM       | on-chip    | pwm                                 |
 +-----------+------------+-------------------------------------+
+| CAN       | on-chip    | can                                 |
++-----------+------------+-------------------------------------+
+
+.. note:: CAN feature requires CAN transceiver
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.yaml
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.yaml
@@ -10,3 +10,4 @@ flash: 256
 supported:
   - nvs
   - pwm
+  - can

--- a/boards/arm/stm32f072b_disco/doc/stm32f072b_disco.rst
+++ b/boards/arm/stm32f072b_disco/doc/stm32f072b_disco.rst
@@ -92,6 +92,10 @@ features:
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | SPI controller                      |
 +-----------+------------+-------------------------------------+
+| CAN       | on-chip    | can controller                      |
++-----------+------------+-------------------------------------+
+
+.. note:: CAN feature requires CAN transceiver
 
 Other hardware features are not yet supported in this Zephyr port.
 


### PR DESCRIPTION
CAN support was not correctly documented.

Fixes #12052 