### PR TITLE
samples/basic: Update readme for blinky/button/disco

### DIFF
--- a/samples/basic/blinky/README.rst
+++ b/samples/basic/blinky/README.rst
@@ -14,12 +14,11 @@ Requirements
 ************
 
 The demo assumes that an LED is connected to one of GPIO lines. The
-sample code is configured to work on boards with user defined buttons and that
-have defined the LED0\_* variables in :file:`board.h`.
+sample code is configured to work on boards that have defined the led0
+alias in their board device tree description file. Doing so will generate
+these variables:
 
-The :file:`board.h` must define the following variables:
-
-- LED0_GPIO_NAME (or LED0_GPIO_CONTROLLER)
+- LED0_GPIO_CONTROLLER
 - LED0_GPIO_PIN
 
 

--- a/samples/basic/button/README.rst
+++ b/samples/basic/button/README.rst
@@ -13,7 +13,7 @@ Requirements
 
 The demo assumes that a push button is connected to one of GPIO lines. The
 sample code is configured to work on boards with user defined buttons and that
-have defined the SW0_* variable in board.h
+have defined the SW0_* variables.
 
 To use this sample, you will require a board that defines the user switch in its
 header file. The :file:`board.h` must define the following variables:
@@ -21,18 +21,8 @@ header file. The :file:`board.h` must define the following variables:
 - SW0_GPIO_NAME (or SW0_GPIO_CONTROLLER)
 - SW0_GPIO_PIN
 
-The following boards currently define the above variables:
-
-- bbc_microbit
-- cc3220sf_launchxl
-- frdm_k64f
-- nrf51_pca10028
-- nrf52840_pca10056
-- nrf52_pca10040
-- nucleo_f103rb
-- :ref:`quark_d2000_devboard`
-- quark_se_c1000_devboard
-- quark_se_c1000_ss_devboard
+Alternatively, this could also be done by defining 'sw0' alias in the board
+device tree description file.
 
 
 Building and Running

--- a/samples/basic/disco/README.rst
+++ b/samples/basic/disco/README.rst
@@ -17,20 +17,6 @@ This sample should work on board with multiple built-in LEDs without any
 changes, otherwise, the code may need some changes before running on various
 board: set PORT, LED0 and LED1 according to the board's GPIO configuration.
 
-For example, on the following boards with additional LEDs, follow the
-instructions below:
-
-Nucleo-64 F103RB/F401RE boards
-==============================
-
-Connect two LEDs to PB5 and PB8 pins. PB5 is mapped to the
-Arduino's D4 pin and PB8 to Arduino's D15. For more details about
-these boards see:
-
-- https://developer.mbed.org/platforms/ST-Nucleo-F103RB/
-- https://developer.mbed.org/platforms/ST-Nucleo-F401RE/
-
-
 Building and Running
 *********************
 
@@ -44,30 +30,3 @@ This project does not output to the serial console, but instead causes two LEDs
 connected to the GPIO device to blink in an alternating pattern.
 
 The sample can be found here: :file:`samples/basic/disco`.
-
-Nucleo F103RB
-=============
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/disco
-   :board: nucleo_f103rb
-   :goals: build
-   :compact:
-
-Nucleo F401RE
-=============
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/disco
-   :board: nucleo_f401re
-   :goals: build
-   :compact:
-
-reel Board
-==========
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/disco
-   :board: reel_board
-   :goals: build
-   :compact:


### PR DESCRIPTION
blinky/button and disco samples are now using definitions
generated from  boards dts files.
Update smaples README files accordingly.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>