### PR TITLE
cmake: Document CMake system variables

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -25,11 +25,13 @@
 # invocation in every toplevel CMakeLists.txt.
 cmake_minimum_required(VERSION 3.8.2)
 
+# CMP0002: "Logical target names must be globally unique"
 cmake_policy(SET CMP0002 NEW)
 
 if(NOT (${CMAKE_VERSION} VERSION_LESS "3.13.0"))
   # Use the old CMake behaviour until 3.13.x is required and the build
   # scripts have been ported to the new behaviour.
+  # CMP0079: "target_link_libraries() allows use with targets in other directories"
   cmake_policy(SET CMP0079 OLD)
 endif()
 

--- a/cmake/target_toolchain.cmake
+++ b/cmake/target_toolchain.cmake
@@ -1,6 +1,33 @@
-set(CMAKE_SYSTEM_NAME      Generic)
+# No official documentation exists for the "Generic" value, except their wiki.
+#
+# https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/CrossCompiling:
+#   CMAKE_SYSTEM_NAME : this one is mandatory, it is the name of the target
+#   system, i.e. the same as CMAKE_SYSTEM_NAME would have if CMake would run
+#   on the target system.  Typical examples are "Linux" and "Windows". This
+#   variable is used for constructing the file names of the platform files
+#   like Linux.cmake or Windows-gcc.cmake. If your target is an embedded
+#   system without OS set CMAKE_SYSTEM_NAME to "Generic".
+set(CMAKE_SYSTEM_NAME Generic)
+
+# https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_PROCESSOR.html:
+#   The name of the CPU CMake is building for.
+#
+# https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/CrossCompiling:
+#   CMAKE_SYSTEM_PROCESSOR : optional, processor (or hardware) of the
+#   target system. This variable is not used very much except for one
+#   purpose, it is used to load a
+#   CMAKE_SYSTEM_NAME-compiler-CMAKE_SYSTEM_PROCESSOR.cmake file,
+#   which can be used to modify settings like compiler flags etc. for
+#   the target
 set(CMAKE_SYSTEM_PROCESSOR ${ARCH})
 
+# https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_VERSION.html:
+#   When the CMAKE_SYSTEM_NAME variable is set explicitly to enable cross
+#   compiling then the value of CMAKE_SYSTEM_VERSION must also be set
+#   explicitly to specify the target system version.
+set(CMAKE_SYSTEM_VERSION ${PROJECT_VERSION})
+
+# We are not building dynamically loadable libraries
 set(BUILD_SHARED_LIBS OFF)
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
Aid user in understanding what CMake expects of certain variables.

 * Document and add CMAKE_SYSTEM_VERSION
 * Document CMAKE_SYSTEM_NAME
 * Document CMAKE_SYSTEM_PROCESSOR
 * Document BUILD_SHARED_LIBS
 * Document Policies CMP0002, CMP0079

CMAKE_SYSTEM_VERSION is required officially by CMake, but appears
unused -- at least now we are compliant.

Signed-off-by: Mark Ruvald Pedersen <mped@oticon.com>