### PR TITLE
cmake: boilerplate: Move compiler-flag checks into boilerplate

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -102,6 +102,8 @@ set(PythonInterp_FIND_VERSION_EXACT 0)
 set(PythonInterp_FIND_REQUIRED 1)
 include(${ZEPHYR_BASE}/cmake/backports/FindPythonInterp.cmake)
 
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 include(${ZEPHYR_BASE}/cmake/extensions.cmake)
 
 include(${ZEPHYR_BASE}/cmake/ccache.cmake)

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1,6 +1,3 @@
-include(CheckCCompilerFlag)
-include(CheckCXXCompilerFlag)
-
 ########################################################
 # Table of contents
 ########################################################


### PR DESCRIPTION
`CheckCCompilerFlag` and `CheckCXXCompilerFlag` does not belong to `extensions.cmake` since they are standard CMake files. 
Boilerplate seems more appropriate.

No functional change.

Signed-off-by: Mark Ruvald Pedersen <mped@oticon.com>