### PR TITLE
dts: nordic: simplify definition of flash and sram sizes in dts

### DIFF
--- a/dts/arm/nordic/nrf51822_qfaa.dtsi
+++ b/dts/arm/nordic/nrf51822_qfaa.dtsi
@@ -7,14 +7,10 @@
 #include <mem.h>
 #include <nordic/nrf51822.dtsi>
 
-/ {
-	flash-controller@4001E000 {
-		flash0: flash@0 {
-			reg = <0x00000000 DT_SIZE_K(256)>;
-		};
-	};
+&flash0 {
+	reg = <0x00000000 DT_SIZE_K(256)>;
+};
 
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(16)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(16)>;
 };

--- a/dts/arm/nordic/nrf51822_qfab.dtsi
+++ b/dts/arm/nordic/nrf51822_qfab.dtsi
@@ -7,14 +7,10 @@
 #include <mem.h>
 #include <nordic/nrf51822.dtsi>
 
-/ {
-	flash-controller@4001E000 {
-		flash0: flash@0 {
-			reg = <0x00000000 DT_SIZE_K(128)>;
-		};
-	};
+&flash0 {
+	reg = <0x00000000 DT_SIZE_K(128)>;
+};
 
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(16)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(16)>;
 };

--- a/dts/arm/nordic/nrf51822_qfac.dtsi
+++ b/dts/arm/nordic/nrf51822_qfac.dtsi
@@ -7,14 +7,10 @@
 #include <mem.h>
 #include <nordic/nrf51822.dtsi>
 
-/ {
-	flash-controller@4001E000 {
-		flash0: flash@0 {
-			reg = <0x00000000 DT_SIZE_K(256)>;
-		};
-	};
+&flash0 {
+	reg = <0x00000000 DT_SIZE_K(256)>;
+};
 
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(32)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/nordic/nrf52810_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52810_qfaa.dtsi
@@ -7,14 +7,10 @@
 #include <mem.h>
 #include <nordic/nrf52810.dtsi>
 
-/ {
-	flash-controller@4001E000 {
-		flash0: flash@0 {
-			reg = <0x00000000 DT_SIZE_K(192)>;
-		};
-	};
+&flash0 {
+	reg = <0x00000000 DT_SIZE_K(192)>;
+};
 
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(24)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(24)>;
 };

--- a/dts/arm/nordic/nrf52832_ciaa.dtsi
+++ b/dts/arm/nordic/nrf52832_ciaa.dtsi
@@ -7,14 +7,10 @@
 #include <mem.h>
 #include <nordic/nrf52832.dtsi>
 
-/ {
-	flash-controller@4001E000 {
-		flash0: flash@0 {
-			reg = <0x00000000 DT_SIZE_K(512)>;
-		};
-	};
+&flash0 {
+	reg = <0x00000000 DT_SIZE_K(512)>;
+};
 
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(64)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/nordic/nrf52832_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52832_qfaa.dtsi
@@ -7,14 +7,10 @@
 #include <mem.h>
 #include <nordic/nrf52832.dtsi>
 
-/ {
-	flash-controller@4001E000 {
-		flash0: flash@0 {
-			reg = <0x00000000 DT_SIZE_K(512)>;
-		};
-	};
+&flash0 {
+	reg = <0x00000000 DT_SIZE_K(512)>;
+};
 
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(64)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/nordic/nrf52832_qfab.dtsi
+++ b/dts/arm/nordic/nrf52832_qfab.dtsi
@@ -7,14 +7,10 @@
 #include <mem.h>
 #include <nordic/nrf52832.dtsi>
 
-/ {
-	flash-controller@4001E000 {
-		flash0: flash@0 {
-			reg = <0x00000000 DT_SIZE_K(256)>;
-		};
-	};
+&flash0 {
+	reg = <0x00000000 DT_SIZE_K(256)>;
+};
 
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(32)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/nordic/nrf52840_qiaa.dtsi
+++ b/dts/arm/nordic/nrf52840_qiaa.dtsi
@@ -7,14 +7,10 @@
 #include <mem.h>
 #include <nordic/nrf52840.dtsi>
 
-/ {
-	flash-controller@4001E000 {
-		flash0: flash@0 {
-			reg = <0x00000000 DT_SIZE_K(1024)>;
-		};
-	};
+&flash0 {
+	reg = <0x00000000 DT_SIZE_K(1024)>;
+};
 
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(256)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
 };


### PR DESCRIPTION
We only need to add the reg property in flash0 and sram0,
in the different DTS headers for the nRF SOCS. We do not
seem to need to define the nodes again. This commit applies
this simplification for flash and sram sizes definition.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>