### PR TITLE
doc: boards: cc3220sf_launchxl: update link to XDS110 firmware update

### DIFF
--- a/boards/arm/cc3220sf_launchxl/doc/cc3220sf_launchxl.rst
+++ b/boards/arm/cc3220sf_launchxl/doc/cc3220sf_launchxl.rst
@@ -143,7 +143,7 @@ Prerequisites:
    Download and install the latest `XDS-110 emulation package`_.
 
    Follow the directions here to update the firmware:
-   http://processors.wiki.ti.com/index.php/XDS110#Updating_the_XDS110_Firmware
+   http://software-dl.ti.com/ccs/esd/documents/xdsdebugprobes/emu_xds110.html#updating-the-xds110-firmware
 
    Note that the emulation package install may place the xdsdfu utility
    in <install_dir>/ccs_base/common/uscif/xds110/.


### PR DESCRIPTION
The link was changed by TI, so we are updating the Zephyr
documentation.

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>