### PR TITLE
samples: reel board: correct timeout condition

### DIFF
--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -519,7 +519,7 @@ static void led_timeout(struct k_work *work)
 	}
 
 	/* Stop after 5 iterations */
-	if (led_cntr > (ARRAY_SIZE(leds) * 5)) {
+	if (led_cntr >= (ARRAY_SIZE(leds) * 5)) {
 		led_cntr = 0;
 		return;
 	}


### PR DESCRIPTION
After this fix each LED will blink 5 times. Previously
LED_0 has been blining 6 times while others 5 times.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>