### PR TITLE
Timer fixes

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -207,17 +207,6 @@ static struct k_thread *next_up(void)
 static int slice_time;
 static int slice_max_prio;
 
-/* Subtle note on locking here: in theory we're subject to a race
- * where _get_next_timeout_expiry() returns a value that changes
- * between the return and the z_clock_set_timeout() of the adjusted
- * time: another context can add a new timeout that should expire
- * sooner, and we'll miss it.  But that's OK, because (1) we're inside
- * the scheduler lock, so cannot be interrupted on uniprocessor
- * systems, and (2) it's an interrupt time for our local CPU -- in
- * SMP, it's safe to miss a timeout as long as another CPU (i.e. the
- * one we're racing against) is available to wake up at the
- * appropriate time.
- */
 static void reset_time_slice(void)
 {
 	/* Add the elapsed time since the last announced tick to the

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -46,11 +46,14 @@ static struct _timeout *next(struct _timeout *t)
 
 static void remove_timeout(struct _timeout *t)
 {
-	if (next(t) != NULL) {
-		next(t)->dticks += t->dticks;
-	}
+	if (t->node.next != NULL && t->node.prev != NULL) {
+		if (next(t) != NULL) {
+			next(t)->dticks += t->dticks;
+		}
 
-	sys_dlist_remove(&t->node);
+		sys_dlist_remove(&t->node);
+	}
+	t->node.next = t->node.prev = NULL;
 	t->dticks = _INACTIVE;
 }
 

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -151,8 +151,16 @@ void z_set_timeout_expiry(s32_t ticks, bool idle)
 {
 	LOCKED(&timeout_lock) {
 		int next = _get_next_timeout_expiry();
+		bool sooner = (next == K_FOREVER) || (ticks < next);
+		bool imminent = next <= 1;
 
-		if ((next == K_FOREVER) || (ticks < next)) {
+		/* Only set new timeouts when they are sooner than
+		 * what we have.  Also don't try to set a timeout when
+		 * one is about to expire: drivers have internal logic
+		 * that will bump the timeout to the "next" tick if
+		 * it's not considered to be settable as directed.
+		 */
+		if (sooner && !imminent) {
 			z_clock_set_timeout(ticks, idle);
 		}
 	}

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -196,6 +196,19 @@ void test_timer_expirefn_null(void)
 	k_timer_stop(&timer);
 }
 
+/* Wait for the next expiration of an OS timer tick, to synchronize
+ * test start
+ */
+static void tick_sync(void)
+{
+	static struct k_timer sync_timer;
+
+	k_timer_init(&sync_timer, NULL, NULL);
+	k_timer_start(&sync_timer, 0, 1);
+	k_timer_status_sync(&sync_timer);
+	k_timer_stop(&sync_timer);
+}
+
 /**
  * @brief Test to check timer periodicity
  *
@@ -216,6 +229,12 @@ void test_timer_expirefn_null(void)
 void test_timer_periodicity(void)
 {
 	s64_t delta;
+
+	/* Start at a tick boundary, otherwise a tick expiring between
+	 * the unlocked (and unlockable) start/uptime/sync steps below
+	 * will throw off the math.
+	 */
+	tick_sync();
 
 	init_timer_data();
 	/** TESTPOINT: set duration 0 */


### PR DESCRIPTION
Two bugs discovered since the timer rewrite: one that would produce incorrect expiration times for timeouts set within timeout handlers in the case where multiple timeouts were expiring in the same tick.  Another was a potential timeout list corruption issue if the timeout handler (or under SMP, simultaneous code racing against it) tries to remove a timeout (for example by aborting a thread).

This doesn't fix the API confusion about "what is 'current time' to a timeout handler when the interrupt was delayed" detailed in #11722.  I'm going to think a little more on that one and see if an API option makes sense, or at least update the docs.

Relevant to #11722, this works for me over 30 iterations of the timer_api test, so I'm reasonably confident the bug is fixed even if I was never able to reproduce it.