### PR TITLE
stm32f3_disco: Various fixes around LED and GPIOs

### DIFF
--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -64,6 +64,7 @@
 
 	aliases {
 		led0 = &green_led_6;
+		led1 = &green_led_7;
 		sw0 = &user_button;
 	};
 };

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -37,7 +37,7 @@
 			label = "User LD6";
 		};
 		green_led_7: led_7 {
-			gpios = <&gpiod 11 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioe 11 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD7";
 		};
 		orange_led_8: led_8 {

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -62,7 +62,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000000 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00020000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00020000>;
 				label = "GPIOA";
 			};
 
@@ -71,7 +71,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000400 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00040000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00040000>;
 				label = "GPIOB";
 			};
 
@@ -80,7 +80,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000800 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00080000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00080000>;
 				label = "GPIOC";
 			};
 
@@ -89,7 +89,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00100000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00100000>;
 				label = "GPIOD";
 			};
 
@@ -98,7 +98,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001400 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00400000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00400000>;
 				label = "GPIOF";
 			};
 		};

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -39,7 +39,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00200000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00200000>;
 				label = "GPIOE";
 			};
 		};

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -14,7 +14,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00200000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00200000>;
 				label = "GPIOE";
 			};
 		};


### PR DESCRIPTION
Fix GPIO bus, LED7 GPIO port and a minor addition to board dts file