### PR TITLE
net: logs: Enable logging for NET_RAW

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -49,8 +49,6 @@ config NET_INIT_PRIO
 	  Network initialization priority level. This number tells how
 	  early in the boot the network stack is initialized.
 
-source "subsys/net/ip/Kconfig.debug"
-
 source "subsys/net/ip/Kconfig.ipv6"
 
 source "subsys/net/ip/Kconfig.ipv4"
@@ -536,5 +534,7 @@ module-str = Log level for offload layer
 module-help = Enables offload layer to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 endif # NET_OFFLOAD
+
+source "subsys/net/ip/Kconfig.debug"
 
 endmenu

--- a/subsys/net/ip/Kconfig.debug
+++ b/subsys/net/ip/Kconfig.debug
@@ -14,6 +14,30 @@ menuconfig NET_LOG
 	  Specific debugging options to other sub-menus will be unlocked
 	  as well (IPv6, IPv4, ...).
 
+module = NET_PKT
+module-dep = NET_LOG
+module-str = Log level for network packet and buffer allocation
+module-help = Enables debug of network packet and buffer allocations and frees.
+source "subsys/net/Kconfig.template.log_config.net"
+
+config NET_DEBUG_NET_PKT_ALLOC
+	bool "Debug network packet and buffer individual allocation"
+	default y if NET_PKT_LOG_LEVEL_DBG
+	help
+	  Enables printing of network packet and buffer allocations and frees for
+	  each allocation. This can produce lot of output so it is disabled by
+	  default.
+
+config NET_DEBUG_NET_PKT_EXTERNALS
+	int "How many external network packet allocations"
+	default 0
+	help
+	  How many external net_pkt objects are there in user specific pools.
+	  This value is used when allocating space for tracking the
+	  memory allocations.
+
+if !NET_RAW_MODE
+
 module = NET_CORE
 module-dep = NET_LOG
 module-str = Log level for core IP stack
@@ -44,28 +68,6 @@ module-str = Log level for network context allocation
 module-help = Enables printing of network context allocations and frees.
 source "subsys/net/Kconfig.template.log_config.net"
 
-module = NET_PKT
-module-dep = NET_LOG
-module-str = Log level for network packet and buffer allocation
-module-help = Enables debug of network packet and buffer allocations and frees.
-source "subsys/net/Kconfig.template.log_config.net"
-
-config NET_DEBUG_NET_PKT_ALLOC
-	bool "Debug network packet and buffer individual allocation"
-	default y if NET_PKT_LOG_LEVEL_DBG
-	help
-	  Enables printing of network packet and buffer allocations and frees for
-	  each allocation. This can produce lot of output so it is disabled by
-	  default.
-
-config NET_DEBUG_NET_PKT_EXTERNALS
-	int "How many external network packet allocations"
-	default 0
-	help
-	  How many external net_pkt objects are there in user specific pools.
-	  This value is used when allocating space for tracking the
-	  memory allocations.
-
 module = NET_CONN
 module-dep = NET_LOG
 module-str = Log level for UDP/TCP connection handling
@@ -77,3 +79,5 @@ module-dep = NET_LOG
 module-str = Log level for route management
 module-help = Enables routing engine debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
+
+endif # NET_RAW_MODE


### PR DESCRIPTION
The patch allows to enable logs for NET_RAW configuration.
For example using wpanusb currently breaks build with logging enabled.