### PR TITLE
net/pkt: Fix debug logs checking

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -353,7 +353,7 @@ struct net_pkt *net_pkt_get_reserve(struct k_mem_slab *slab,
 
 	net_pkt_alloc_add(pkt, true, caller, line);
 
-#if NET_LOG_LEVEL == LOG_LEVEL_DBG
+#if NET_LOG_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
 	NET_DBG("%s [%u] pkt %p ref %d (%s():%d)",
 		slab2str(slab), k_mem_slab_num_free_get(slab),
 		pkt, pkt->ref, caller, line);
@@ -394,7 +394,7 @@ struct net_buf *net_pkt_get_reserve_data(struct net_buf_pool *pool,
 
 	net_pkt_alloc_add(frag, false, caller, line);
 
-#if NET_LOG_LEVEL >= LOG_LEVEL_DBG
+#if NET_LOG_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
 	NET_DBG("%s (%s) [%d] frag %p ref %d (%s():%d)",
 		pool2str(pool), get_name(pool), get_frees(pool),
 		frag, frag->ref, caller, line);


### PR DESCRIPTION
The slab2str function which is used in the debug log call is not defined
unless NET_LOG_PKT_LOG_LEVEL >= LOG_LEVEL_DEBUG.

It looks like this change was accidentally introduced in #11374.

Easiest way to reproduce:
Use the `net/sockets/echo` sample with `NET_DEBUG_NET_PKT_ALLOC` enabled.

Compilation renders:

```
In file included from /path/zephyr/include/logging/log.h:11:0,
                 from /path/zephyr/subsys/net/ip/net_pkt.c:13:                   
/path/zephyr/subsys/net/ip/net_pkt.c: In function ‘net_pkt_get_reserve_data_debug’:
/path/zephyr/subsys/net/ip/net_pkt.c:399:3: warning: implicit declaration of function ‘pool2str’ [-Wimplicit-function-declaration]
   pool2str(pool), get_name(pool), get_frees(pool), 
(...)
```