### PR TITLE
lib/cmsis_rtos_v2: Fix overflow in osKernelGetInfo()

### DIFF
--- a/lib/cmsis_rtos_v2/kernel.c
+++ b/lib/cmsis_rtos_v2/kernel.c
@@ -17,23 +17,19 @@ extern u32_t z_tick_get_32(void);
  */
 osStatus_t osKernelGetInfo(osVersion_t *version, char *id_buf, uint32_t id_size)
 {
-	char os_str[] = "Zephyr VMM.mm.pp";
-
 	if (version != NULL) {
 		version->api    = sys_kernel_version_get();
 		version->kernel = sys_kernel_version_get();
 	}
 
-	sprintf(os_str, "Zephyr V%2d.%2d.%2d",
-		SYS_KERNEL_VER_MAJOR(version->kernel),
-		SYS_KERNEL_VER_MINOR(version->kernel),
-		SYS_KERNEL_VER_PATCHLEVEL(version->kernel));
-
-	if ((id_buf != NULL) && (id_size > strlen(os_str))) {
-		memcpy(id_buf, os_str, strlen(os_str)+1);
+	if (id_buf != NULL) {
+		snprintf(id_buf, id_size, "Zephyr V%2d.%2d.%2d",
+			 SYS_KERNEL_VER_MAJOR(version->kernel),
+			 SYS_KERNEL_VER_MINOR(version->kernel),
+			 SYS_KERNEL_VER_PATCHLEVEL(version->kernel));
 	}
 
-	return (osOK);
+	return osOK;
 }
 
 /**


### PR DESCRIPTION
If any of the Zephyr version numbers went beyond 99, the "%2d" printf
specifiers would expand to fit and the string would run over the
memory on the stack used for os_str[].

Recent GCC versions (remember native_posix and x86_64 use the host
compiler) were actually detecting this and correctly issuing a warning
(but only if the 3-digit char value would overflow the actual array
size!), which was breaking sanitycheck for me on Fedora 28 and Ubuntu
18.04 build hosts.  Pretty impresive warning.

As it happens this was wasteful anyway; we were spending bytes on the
stack (and in rodata to store the constant which, and the cycles
needed to copy it into place on the stack where it would be
overwritten immediately) when we could just snprintf() directly into
the buffer the user gave us.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>