### PR TITLE
drivers: wifi: simplelink: Fix strings used in assertions

### DIFF
--- a/drivers/wifi/simplelink/simplelink_support.c
+++ b/drivers/wifi/simplelink/simplelink_support.c
@@ -27,9 +27,9 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 #undef ASSERT_ON_ERROR
 #define ASSERT_ON_ERROR(ret, e) __ASSERT(ret >= 0, e)
-#define DEVICE_ERROR	 ("See \"DEVICE ERRORS CODES\" in SimpleLink errors.h")
-#define WLAN_ERROR	 ("See \"WLAN ERRORS CODES\" in SimpleLink errors.h")
-#define NETAPP_ERROR	 ("See \"NETAPP ERRORS CODES\" in SimpleLink errors.h")
+#define DEVICE_ERROR	 "See \"DEVICE ERRORS CODES\" in SimpleLink errors.h"
+#define WLAN_ERROR	 "See \"WLAN ERRORS CODES\" in SimpleLink errors.h"
+#define NETAPP_ERROR	 "See \"NETAPP ERRORS CODES\" in SimpleLink errors.h"
 
 #define CHANNEL_MASK_ALL	    (0x1FFF)
 #define RSSI_TH_MAX		    (-95)


### PR DESCRIPTION
Samples for cc3220sf_launchxl where assertions are enabled
(e.g. http_get) fail to build because some of the strings used in the
simplelink wifi driver have parentheses around them. This breaks the
current implementation of the __ASSERT macro. This commit removes
the parentheses, which are unnecessary.

http_get has been verified to build after this change.

Fixes #12192

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>