### PR TITLE
net: coap: return -EPERM for a resource without requested method

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -681,7 +681,7 @@ int coap_handle_request(struct coap_packet *cpkt,
 		code = coap_header_get_code(cpkt);
 		method = method_from_code(resource, code);
 		if (!method) {
-			return 0;
+			return -EPERM;
 		}
 
 		return method(resource, cpkt);

--- a/subsys/net/lib/coap/coap_sock.c
+++ b/subsys/net/lib/coap/coap_sock.c
@@ -824,7 +824,7 @@ int coap_handle_request(struct coap_packet *cpkt,
 		code = coap_header_get_code(cpkt);
 		method = method_from_code(resource, code);
 		if (!method) {
-			return 0;
+			return -EPERM;
 		}
 
 		return method(resource, cpkt, addr, addr_len);


### PR DESCRIPTION
When walking through the coap resources in coap_handle_request, return
-EPERM if a resource exists but does not have the request method. This
allows the caller to catch the error and return a 4.05 message.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>