### PR TITLE
Make syscall internal implementation visibility consistent

### DIFF
--- a/include/aio_comparator.h
+++ b/include/aio_comparator.h
@@ -48,13 +48,6 @@ struct aio_cmp_driver_api {
  */
 __syscall int aio_cmp_disable(struct device *dev, u8_t index);
 
-static inline int _impl_aio_cmp_disable(struct device *dev, u8_t index)
-{
-	const struct aio_cmp_driver_api *api = dev->driver_api;
-
-	return api->disable(dev, index);
-}
-
 /**
  * @brief Configure and enable a particular comparator.
  *
@@ -94,14 +87,6 @@ static inline int aio_cmp_configure(struct device *dev, u8_t index,
  * @retval 0 if no aio_cmp interrupt is pending.
  */
 __syscall int aio_cmp_get_pending_int(struct device *dev);
-
-static inline int _impl_aio_cmp_get_pending_int(struct device *dev)
-{
-	struct aio_cmp_driver_api *api;
-
-	api = (struct aio_cmp_driver_api *)dev->driver_api;
-	return api->get_pending_int(dev);
-}
 
 #ifdef __cplusplus
 }

--- a/include/can.h
+++ b/include/can.h
@@ -271,14 +271,6 @@ struct can_driver_api {
 __syscall int can_send(struct device *dev, struct can_msg *msg,
 		       s32_t timeout, can_tx_callback_t callback_isr);
 
-static inline int _impl_can_send(struct device *dev, struct can_msg *msg,
-				 s32_t timeout, can_tx_callback_t callback_isr)
-{
-	const struct can_driver_api *api = dev->driver_api;
-
-	return api->send(dev, msg, timeout, callback_isr);
-}
-
 /*
  * Derived can APIs -- all implemented in terms of can_send()
  */
@@ -327,48 +319,13 @@ static inline int can_write(struct device *dev, u8_t *data, u8_t length,
 __syscall int can_attach_msgq(struct device *dev, struct k_msgq *msg_q,
 			      const struct can_filter *filter);
 
-static inline int _impl_can_attach_msgq(struct device *dev,
-					struct k_msgq *msg_q,
-					const struct can_filter *filter)
-{
-	const struct can_driver_api *api = dev->driver_api;
-
-	return api->attach_msgq(dev, msg_q, filter);
-}
-
-
 __syscall int can_attach_isr(struct device *dev, can_rx_callback_t isr,
 			     const struct can_filter *filter);
-static inline int _impl_can_attach_isr(struct device *dev,
-				       can_rx_callback_t isr,
-				       const struct can_filter *filter)
-{
-	const struct can_driver_api *api = dev->driver_api;
-
-	return api->attach_isr(dev, isr, filter);
-}
-
 
 __syscall void can_detach(struct device *dev, int filter_id);
 
-static inline void _impl_can_detach(struct device *dev, int filter_id)
-{
-	const struct can_driver_api *api = dev->driver_api;
-
-	return api->detach(dev, filter_id);
-}
-
-
 __syscall int can_configure(struct device *dev, enum can_mode mode,
 			    u32_t bitrate);
-
-static inline int _impl_can_configure(struct device *dev, enum can_mode mode,
-				      u32_t bitrate)
-{
-	const struct can_driver_api *api = dev->driver_api;
-
-	return api->configure(dev, mode, bitrate);
-}
 
 #ifdef __cplusplus
 }

--- a/include/counter.h
+++ b/include/counter.h
@@ -59,13 +59,6 @@ struct counter_driver_api {
  */
 __syscall int counter_start(struct device *dev);
 
-static inline int _impl_counter_start(struct device *dev)
-{
-	const struct counter_driver_api *api = dev->driver_api;
-
-	return api->start(dev);
-}
-
 /**
  * @brief Stop counter device.
  * @param dev Pointer to the device structure for the driver instance.
@@ -76,13 +69,6 @@ static inline int _impl_counter_start(struct device *dev)
  */
 __syscall int counter_stop(struct device *dev);
 
-static inline int _impl_counter_stop(struct device *dev)
-{
-	const struct counter_driver_api *api = dev->driver_api;
-
-	return api->stop(dev);
-}
-
 /**
  * @brief Read current counter value.
  * @param dev Pointer to the device structure for the driver instance.
@@ -90,13 +76,6 @@ static inline int _impl_counter_stop(struct device *dev)
  * @return  32-bit value
  */
 __syscall u32_t counter_read(struct device *dev);
-
-static inline u32_t _impl_counter_read(struct device *dev)
-{
-	const struct counter_driver_api *api = dev->driver_api;
-
-	return api->read(dev);
-}
 
 /**
  * @brief Set an alarm.
@@ -136,14 +115,6 @@ static inline int counter_set_alarm(struct device *dev,
  * @retval 0 if no counter interrupt is pending.
  */
 __syscall int counter_get_pending_int(struct device *dev);
-
-static inline int _impl_counter_get_pending_int(struct device *dev)
-{
-	struct counter_driver_api *api;
-
-	api = (struct counter_driver_api *)dev->driver_api;
-	return api->get_pending_int(dev);
-}
 
 #ifdef __cplusplus
 }

--- a/include/dma.h
+++ b/include/dma.h
@@ -239,14 +239,6 @@ static inline int dma_reload(struct device *dev, u32_t channel,
  */
 __syscall int dma_start(struct device *dev, u32_t channel);
 
-static inline int _impl_dma_start(struct device *dev, u32_t channel)
-{
-	const struct dma_driver_api *api =
-		(const struct dma_driver_api *)dev->driver_api;
-
-	return api->start(dev, channel);
-}
-
 /**
  * @brief Stops the DMA transfer and disables the channel.
  *
@@ -261,14 +253,6 @@ static inline int _impl_dma_start(struct device *dev, u32_t channel)
  * @retval Negative errno code if failure.
  */
 __syscall int dma_stop(struct device *dev, u32_t channel);
-
-static inline int _impl_dma_stop(struct device *dev, u32_t channel)
-{
-	const struct dma_driver_api *api =
-		(const struct dma_driver_api *)dev->driver_api;
-
-	return api->stop(dev, channel);
-}
 
 /**
  * @brief Look-up generic width index to be used in registers

--- a/include/entropy.h
+++ b/include/entropy.h
@@ -65,17 +65,6 @@ __syscall int entropy_get_entropy(struct device *dev,
 				  u8_t *buffer,
 				  u16_t length);
 
-static inline int _impl_entropy_get_entropy(struct device *dev,
-					    u8_t *buffer,
-					    u16_t length)
-{
-	const struct entropy_driver_api *api = dev->driver_api;
-
-	__ASSERT(api->get_entropy != NULL,
-		"Callback pointer should not be NULL");
-	return api->get_entropy(dev, buffer, length);
-}
-
 /* Busy-wait for random data to be ready */
 #define ENTROPY_BUSYWAIT  BIT(0)
 

--- a/include/flash.h
+++ b/include/flash.h
@@ -94,14 +94,6 @@ struct flash_driver_api {
 __syscall int flash_read(struct device *dev, off_t offset, void *data,
 			 size_t len);
 
-static inline int _impl_flash_read(struct device *dev, off_t offset, void *data,
-			     size_t len)
-{
-	const struct flash_driver_api *api = dev->driver_api;
-
-	return api->read(dev, offset, data, len);
-}
-
 /**
  *  @brief  Write buffer into flash memory.
  *
@@ -117,14 +109,6 @@ static inline int _impl_flash_read(struct device *dev, off_t offset, void *data,
  */
 __syscall int flash_write(struct device *dev, off_t offset, const void *data,
 			  size_t len);
-
-static inline int _impl_flash_write(struct device *dev, off_t offset,
-				    const void *data, size_t len)
-{
-	const struct flash_driver_api *api = dev->driver_api;
-
-	return api->write(dev, offset, data, len);
-}
 
 /**
  *  @brief  Erase part or all of a flash memory
@@ -149,14 +133,6 @@ static inline int _impl_flash_write(struct device *dev, off_t offset,
  */
 __syscall int flash_erase(struct device *dev, off_t offset, size_t size);
 
-static inline int _impl_flash_erase(struct device *dev, off_t offset,
-				    size_t size)
-{
-	const struct flash_driver_api *api = dev->driver_api;
-
-	return api->erase(dev, offset, size);
-}
-
 /**
  *  @brief  Enable or disable write protection for a flash memory
  *
@@ -174,14 +150,6 @@ static inline int _impl_flash_erase(struct device *dev, off_t offset,
  *  @return  0 on success, negative errno code on fail.
  */
 __syscall int flash_write_protection_set(struct device *dev, bool enable);
-
-static inline int _impl_flash_write_protection_set(struct device *dev,
-						   bool enable)
-{
-	const struct flash_driver_api *api = dev->driver_api;
-
-	return api->write_protection(dev, enable);
-}
 
 struct flash_pages_info {
 	off_t start_offset; /* offset from the base of flash address */
@@ -262,13 +230,6 @@ void flash_page_foreach(struct device *dev, flash_page_cb cb, void *data);
  *  @return  write block size in bytes.
  */
 __syscall size_t flash_get_write_block_size(struct device *dev);
-
-static inline size_t _impl_flash_get_write_block_size(struct device *dev)
-{
-	const struct flash_driver_api *api = dev->driver_api;
-
-	return api->write_block_size;
-}
 
 #ifdef __cplusplus
 }

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -127,62 +127,18 @@ struct gpio_driver_api {
 __syscall int gpio_config(struct device *port, int access_op, u32_t pin,
 			  int flags);
 
-static inline int _impl_gpio_config(struct device *port, int access_op,
-				    u32_t pin, int flags)
-{
-	const struct gpio_driver_api *api =
-		(const struct gpio_driver_api *)port->driver_api;
-
-	return api->config(port, access_op, pin, flags);
-}
-
 __syscall int gpio_write(struct device *port, int access_op, u32_t pin,
 			 u32_t value);
-
-static inline int _impl_gpio_write(struct device *port, int access_op,
-				   u32_t pin, u32_t value)
-{
-	const struct gpio_driver_api *api =
-		(const struct gpio_driver_api *)port->driver_api;
-
-	return api->write(port, access_op, pin, value);
-}
 
 __syscall int gpio_read(struct device *port, int access_op, u32_t pin,
 			u32_t *value);
 
-static inline int _impl_gpio_read(struct device *port, int access_op,
-				  u32_t pin, u32_t *value)
-{
-	const struct gpio_driver_api *api =
-		(const struct gpio_driver_api *)port->driver_api;
-
-	return api->read(port, access_op, pin, value);
-}
-
 __syscall int gpio_enable_callback(struct device *port, int access_op,
 				   u32_t pin);
-
-static inline int _impl_gpio_enable_callback(struct device *port,
-					     int access_op, u32_t pin)
-{
-	const struct gpio_driver_api *api =
-		(const struct gpio_driver_api *)port->driver_api;
-
-	return api->enable_callback(port, access_op, pin);
-}
 
 __syscall int gpio_disable_callback(struct device *port, int access_op,
 				    u32_t pin);
 
-static inline int _impl_gpio_disable_callback(struct device *port,
-					      int access_op, u32_t pin)
-{
-	const struct gpio_driver_api *api =
-		(const struct gpio_driver_api *)port->driver_api;
-
-	return api->disable_callback(port, access_op, pin);
-}
 /**
  * @endcond
  */
@@ -399,17 +355,6 @@ static inline int gpio_port_disable_callback(struct device *port)
  * @retval 0 if no gpio interrupt is pending.
  */
 __syscall int gpio_get_pending_int(struct device *dev);
-
-/**
- * @internal
- */
-static inline int _impl_gpio_get_pending_int(struct device *dev)
-{
-	struct gpio_driver_api *api;
-
-	api = (struct gpio_driver_api *)dev->driver_api;
-	return api->get_pending_int(dev);
-}
 
 struct gpio_pin_config {
 	char *gpio_controller;

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -187,14 +187,6 @@ struct i2c_slave_driver_api {
  */
 __syscall int i2c_configure(struct device *dev, u32_t dev_config);
 
-static inline int _impl_i2c_configure(struct device *dev, u32_t dev_config)
-{
-	const struct i2c_driver_api *api =
-		(const struct i2c_driver_api *)dev->driver_api;
-
-	return api->configure(dev, dev_config);
-}
-
 /**
  * @brief Perform data transfer to another I2C device.
  *
@@ -216,16 +208,6 @@ static inline int _impl_i2c_configure(struct device *dev, u32_t dev_config)
 __syscall int i2c_transfer(struct device *dev,
 			   struct i2c_msg *msgs, u8_t num_msgs,
 			   u16_t addr);
-
-static inline int _impl_i2c_transfer(struct device *dev,
-				     struct i2c_msg *msgs, u8_t num_msgs,
-				     u16_t addr)
-{
-	const struct i2c_driver_api *api =
-		(const struct i2c_driver_api *)dev->driver_api;
-
-	return api->transfer(dev, msgs, num_msgs, addr);
-}
 
 /**
  * @brief Registers the provided config as Slave device
@@ -253,19 +235,6 @@ static inline int _impl_i2c_transfer(struct device *dev,
 __syscall int i2c_slave_register(struct device *dev,
 				 struct i2c_slave_config *cfg);
 
-static inline int _impl_i2c_slave_register(struct device *dev,
-					   struct i2c_slave_config *cfg)
-{
-	const struct i2c_driver_api *api =
-		(const struct i2c_driver_api *)dev->driver_api;
-
-	if (!api->slave_register) {
-		return -ENOTSUP;
-	}
-
-	return api->slave_register(dev, cfg);
-}
-
 /**
  * @brief Unregisters the provided config as Slave device
  *
@@ -284,19 +253,6 @@ static inline int _impl_i2c_slave_register(struct device *dev,
 __syscall int i2c_slave_unregister(struct device *dev,
 				   struct i2c_slave_config *cfg);
 
-static inline int _impl_i2c_slave_unregister(struct device *dev,
-					     struct i2c_slave_config *cfg)
-{
-	const struct i2c_driver_api *api =
-		(const struct i2c_driver_api *)dev->driver_api;
-
-	if (!api->slave_unregister) {
-		return -ENOTSUP;
-	}
-
-	return api->slave_unregister(dev, cfg);
-}
-
 /**
  * @brief Instructs the I2C Slave device to register itself to the I2C Controller
  *
@@ -311,14 +267,6 @@ static inline int _impl_i2c_slave_unregister(struct device *dev,
  */
 __syscall int i2c_slave_driver_register(struct device *dev);
 
-static inline int _impl_i2c_slave_driver_register(struct device *dev)
-{
-	const struct i2c_slave_driver_api *api =
-		(const struct i2c_slave_driver_api *)dev->driver_api;
-
-	return api->driver_register(dev);
-}
-
 /**
  * @brief Instructs the I2C Slave device to unregister itself from the I2C
  * Controller
@@ -332,14 +280,6 @@ static inline int _impl_i2c_slave_driver_register(struct device *dev)
  * @retval -EINVAL If parameters are invalid
  */
 __syscall int i2c_slave_driver_unregister(struct device *dev);
-
-static inline int _impl_i2c_slave_driver_unregister(struct device *dev)
-{
-	const struct i2c_slave_driver_api *api =
-		(const struct i2c_slave_driver_api *)dev->driver_api;
-
-	return api->driver_unregister(dev);
-}
 
 /*
  * Derived i2c APIs -- all implemented in terms of i2c_transfer()

--- a/include/i2s.h
+++ b/include/i2s.h
@@ -349,14 +349,6 @@ struct i2s_driver_api {
 __syscall int i2s_configure(struct device *dev, enum i2s_dir dir,
 			    struct i2s_config *cfg);
 
-static inline int _impl_i2s_configure(struct device *dev, enum i2s_dir dir,
-				      struct i2s_config *cfg)
-{
-	const struct i2s_driver_api *api = dev->driver_api;
-
-	return api->configure(dev, dir, cfg);
-}
-
 /**
  * @brief Fetch configuration information of a host I2S controller
  *
@@ -507,14 +499,6 @@ __syscall int i2s_buf_write(struct device *dev, void *buf, size_t size);
  */
 __syscall int i2s_trigger(struct device *dev, enum i2s_dir dir,
 			  enum i2s_trigger_cmd cmd);
-
-static inline int _impl_i2s_trigger(struct device *dev, enum i2s_dir dir,
-				    enum i2s_trigger_cmd cmd)
-{
-	const struct i2s_driver_api *api = dev->driver_api;
-
-	return api->trigger(dev, dir, cmd);
-}
 
 #include <syscalls/i2s.h>
 

--- a/include/ipm.h
+++ b/include/ipm.h
@@ -131,14 +131,6 @@ struct ipm_driver_api {
 __syscall int ipm_send(struct device *ipmdev, int wait, u32_t id,
 		       const void *data, int size);
 
-static inline int _impl_ipm_send(struct device *ipmdev, int wait, u32_t id,
-			   const void *data, int size)
-{
-	const struct ipm_driver_api *api = ipmdev->driver_api;
-
-	return api->send(ipmdev, wait, id, data, size);
-}
-
 /**
  * @brief Register a callback function for incoming messages.
  *
@@ -167,14 +159,6 @@ static inline void ipm_register_callback(struct device *ipmdev,
  */
 __syscall int ipm_max_data_size_get(struct device *ipmdev);
 
-static inline int _impl_ipm_max_data_size_get(struct device *ipmdev)
-{
-	const struct ipm_driver_api *api = ipmdev->driver_api;
-
-	return api->max_data_size_get(ipmdev);
-}
-
-
 /**
  * @brief Return the maximum id value possible in an outbound message.
  *
@@ -187,13 +171,6 @@ static inline int _impl_ipm_max_data_size_get(struct device *ipmdev)
  */
 __syscall u32_t ipm_max_id_val_get(struct device *ipmdev);
 
-static inline u32_t _impl_ipm_max_id_val_get(struct device *ipmdev)
-{
-	const struct ipm_driver_api *api = ipmdev->driver_api;
-
-	return api->max_id_val_get(ipmdev);
-}
-
 /**
  * @brief Enable interrupts and callbacks for inbound channels.
  *
@@ -204,13 +181,6 @@ static inline u32_t _impl_ipm_max_id_val_get(struct device *ipmdev)
  * @retval EINVAL If it isn't an inbound channel.
  */
 __syscall int ipm_set_enabled(struct device *ipmdev, int enable);
-
-static inline int _impl_ipm_set_enabled(struct device *ipmdev, int enable)
-{
-	const struct ipm_driver_api *api = ipmdev->driver_api;
-
-	return api->set_enabled(ipmdev, enable);
-}
 
 #ifdef __cplusplus
 }

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -202,6 +202,38 @@ struct _k_object_assignment {
  * @param obj Address of the kernel object
  */
 void _k_object_init(void *obj);
+
+/**
+ * grant a thread access to a kernel object
+ *
+ * The thread will lose access to the object if the caller is from
+ * supervisor mode, or the caller is from user mode AND has permissions
+ * on both the object and the thread whose access is being revoked.
+ *
+ * @param object Address of kernel object
+ * @param thread Thread to remove access to the object
+ */
+void k_object_access_revoke(void *object, struct k_thread *thread);
+
+/**
+ * grant all present and future threads access to an object
+ *
+ * If the caller is from supervisor mode, or the caller is from user mode and
+ * have sufficient permissions on the object, then that object will have
+ * permissions granted to it for *all* current and future threads running in
+ * the system, effectively becoming a public kernel object.
+ *
+ * Use of this API should be avoided on systems that are running untrusted code
+ * as it is possible for such code to derive the addresses of kernel objects
+ * and perform unwanted operations on them.
+ *
+ * It is not possible to revoke permissions on public objects; once public,
+ * any thread may use it.
+ *
+ * @param object Address of kernel object
+ */
+void k_object_access_all_grant(void *object);
+
 #else
 
 #define K_THREAD_ACCESS_GRANT(thread, ...)
@@ -242,39 +274,8 @@ static inline void k_object_access_all_grant(void *object)
  */
 __syscall void k_object_access_grant(void *object, struct k_thread *thread);
 
-/**
- * grant a thread access to a kernel object
- *
- * The thread will lose access to the object if the caller is from
- * supervisor mode, or the caller is from user mode AND has permissions
- * on both the object and the thread whose access is being revoked.
- *
- * @param object Address of kernel object
- * @param thread Thread to remove access to the object
- */
-void k_object_access_revoke(void *object, struct k_thread *thread);
-
 
 __syscall void k_object_release(void *object);
-
-/**
- * grant all present and future threads access to an object
- *
- * If the caller is from supervisor mode, or the caller is from user mode and
- * have sufficient permissions on the object, then that object will have
- * permissions granted to it for *all* current and future threads running in
- * the system, effectively becoming a public kernel object.
- *
- * Use of this API should be avoided on systems that are running untrusted code
- * as it is possible for such code to derive the addresses of kernel objects
- * and perform unwanted operations on them.
- *
- * It is not possible to revoke permissions on public objects; once public,
- * any thread may use it.
- *
- * @param object Address of kernel object
- */
-void k_object_access_all_grant(void *object);
 
 /**
  * Allocate a kernel object of a designated type

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -204,7 +204,7 @@ struct _k_object_assignment {
 void _k_object_init(void *obj);
 
 /**
- * grant a thread access to a kernel object
+ * revoke a thread access to a kernel object
  *
  * The thread will lose access to the object if the caller is from
  * supervisor mode, or the caller is from user mode AND has permissions

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -217,29 +217,11 @@ static inline void _k_object_init(void *obj)
 /**
  * @internal
  */
-static inline void _impl_k_object_access_grant(void *object,
-					       struct k_thread *thread)
-{
-	ARG_UNUSED(object);
-	ARG_UNUSED(thread);
-}
-
-/**
- * @internal
- */
 static inline void k_object_access_revoke(void *object,
 					  struct k_thread *thread)
 {
 	ARG_UNUSED(object);
 	ARG_UNUSED(thread);
-}
-
-/**
- * @internal
- */
-static inline void _impl_k_object_release(void *object)
-{
-	ARG_UNUSED(object);
 }
 
 static inline void k_object_access_all_grant(void *object)
@@ -322,13 +304,6 @@ __syscall void *k_object_alloc(enum k_objects otype);
  */
 void k_object_free(void *obj);
 #else
-static inline void *_impl_k_object_alloc(enum k_objects otype)
-{
-	ARG_UNUSED(otype);
-
-	return NULL;
-}
-
 static inline void k_obj_free(void *obj)
 {
 	ARG_UNUSED(obj);
@@ -1501,11 +1476,6 @@ extern s32_t z_timeout_remaining(struct _timeout *timeout);
  */
 __syscall u32_t k_timer_remaining_get(struct k_timer *timer);
 
-static inline u32_t _impl_k_timer_remaining_get(struct k_timer *timer)
-{
-	return (u32_t)__ticks_to_ms(z_timeout_remaining(&timer->timeout));
-}
-
 /**
  * @brief Associate user-specific data with a timer.
  *
@@ -1522,14 +1492,6 @@ static inline u32_t _impl_k_timer_remaining_get(struct k_timer *timer)
  */
 __syscall void k_timer_user_data_set(struct k_timer *timer, void *user_data);
 
-/**
- * @internal
- */
-static inline void _impl_k_timer_user_data_set(struct k_timer *timer,
-					       void *user_data)
-{
-	timer->user_data = user_data;
-}
 
 /**
  * @brief Retrieve the user-specific data from a timer.
@@ -1539,11 +1501,6 @@ static inline void _impl_k_timer_user_data_set(struct k_timer *timer,
  * @return The user data.
  */
 __syscall void *k_timer_user_data_get(struct k_timer *timer);
-
-static inline void *_impl_k_timer_user_data_get(struct k_timer *timer)
-{
-	return timer->user_data;
-}
 
 /** @} */
 
@@ -1919,11 +1876,6 @@ static inline bool k_queue_unique_append(struct k_queue *queue, void *data)
  */
 __syscall int k_queue_is_empty(struct k_queue *queue);
 
-static inline int _impl_k_queue_is_empty(struct k_queue *queue)
-{
-	return (int)sys_sflist_is_empty(&queue->data_q);
-}
-
 /**
  * @brief Peek element at the head of queue.
  *
@@ -1935,11 +1887,6 @@ static inline int _impl_k_queue_is_empty(struct k_queue *queue)
  */
 __syscall void *k_queue_peek_head(struct k_queue *queue);
 
-static inline void *_impl_k_queue_peek_head(struct k_queue *queue)
-{
-	return z_queue_node_peek(sys_sflist_peek_head(&queue->data_q), false);
-}
-
 /**
  * @brief Peek element at the tail of queue.
  *
@@ -1950,11 +1897,6 @@ static inline void *_impl_k_queue_peek_head(struct k_queue *queue)
  * @return Tail element, or NULL if queue is empty.
  */
 __syscall void *k_queue_peek_tail(struct k_queue *queue);
-
-static inline void *_impl_k_queue_peek_tail(struct k_queue *queue)
-{
-	return z_queue_node_peek(sys_sflist_peek_tail(&queue->data_q), false);
-}
 
 /**
  * @brief Statically define and initialize a queue.
@@ -3023,14 +2965,6 @@ __syscall void k_sem_give(struct k_sem *sem);
 __syscall void k_sem_reset(struct k_sem *sem);
 
 /**
- * @internal
- */
-static inline void _impl_k_sem_reset(struct k_sem *sem)
-{
-	sem->count = 0;
-}
-
-/**
  * @brief Get a semaphore's count.
  *
  * This routine returns the current count of @a sem.
@@ -3041,14 +2975,6 @@ static inline void _impl_k_sem_reset(struct k_sem *sem)
  * @req K-SEM-001
  */
 __syscall unsigned int k_sem_count_get(struct k_sem *sem);
-
-/**
- * @internal
- */
-static inline unsigned int _impl_k_sem_count_get(struct k_sem *sem)
-{
-	return sem->count;
-}
 
 /**
  * @brief Statically define and initialize a semaphore.
@@ -3445,12 +3371,6 @@ __syscall u32_t k_msgq_num_free_get(struct k_msgq *q);
  */
 __syscall void  k_msgq_get_attrs(struct k_msgq *q, struct k_msgq_attrs *attrs);
 
-
-static inline u32_t _impl_k_msgq_num_free_get(struct k_msgq *q)
-{
-	return q->max_msgs - q->used_msgs;
-}
-
 /**
  * @brief Get the number of messages in a message queue.
  *
@@ -3462,11 +3382,6 @@ static inline u32_t _impl_k_msgq_num_free_get(struct k_msgq *q)
  * @req K-MSGQ-002
  */
 __syscall u32_t k_msgq_num_used_get(struct k_msgq *q);
-
-static inline u32_t _impl_k_msgq_num_used_get(struct k_msgq *q)
-{
-	return q->used_msgs;
-}
 
 /** @} */
 
@@ -4460,11 +4375,6 @@ __syscall void k_poll_signal_init(struct k_poll_signal *signal);
  * @req K-POLL-001
  */
 __syscall void k_poll_signal_reset(struct k_poll_signal *signal);
-
-static inline void _impl_k_poll_signal_reset(struct k_poll_signal *signal)
-{
-	signal->signaled = 0;
-}
 
 /**
  * @brief Fetch the signaled state and result value of a poll signal

--- a/include/led.h
+++ b/include/led.h
@@ -74,14 +74,6 @@ struct led_driver_api {
 __syscall int led_blink(struct device *dev, u32_t led,
 			    u32_t delay_on, u32_t delay_off);
 
-static inline int _impl_led_blink(struct device *dev, u32_t led,
-			    u32_t delay_on, u32_t delay_off)
-{
-	const struct led_driver_api *api = dev->driver_api;
-
-	return api->blink(dev, led, delay_on, delay_off);
-}
-
 /**
  * @brief Set LED brightness
  *
@@ -96,14 +88,6 @@ static inline int _impl_led_blink(struct device *dev, u32_t led,
 __syscall int led_set_brightness(struct device *dev, u32_t led,
 				     u8_t value);
 
-static inline int _impl_led_set_brightness(struct device *dev, u32_t led,
-				     u8_t value)
-{
-	const struct led_driver_api *api = dev->driver_api;
-
-	return api->set_brightness(dev, led, value);
-}
-
 /**
  * @brief Turn on an LED
  *
@@ -115,13 +99,6 @@ static inline int _impl_led_set_brightness(struct device *dev, u32_t led,
  */
 __syscall int led_on(struct device *dev, u32_t led);
 
-static inline int _impl_led_on(struct device *dev, u32_t led)
-{
-	const struct led_driver_api *api = dev->driver_api;
-
-	return api->on(dev, led);
-}
-
 /**
  * @brief Turn off an LED
  *
@@ -132,13 +109,6 @@ static inline int _impl_led_on(struct device *dev, u32_t led)
  * @return 0 on success, negative on error
  */
 __syscall int led_off(struct device *dev, u32_t led);
-
-static inline int _impl_led_off(struct device *dev, u32_t led)
-{
-	const struct led_driver_api *api = dev->driver_api;
-
-	return api->off(dev, led);
-}
 
 #include <syscalls/led.h>
 

--- a/include/pwm.h
+++ b/include/pwm.h
@@ -67,15 +67,6 @@ struct pwm_driver_api {
 __syscall int pwm_pin_set_cycles(struct device *dev, u32_t pwm,
 				 u32_t period, u32_t pulse);
 
-static inline int _impl_pwm_pin_set_cycles(struct device *dev, u32_t pwm,
-					   u32_t period, u32_t pulse)
-{
-	struct pwm_driver_api *api;
-
-	api = (struct pwm_driver_api *)dev->driver_api;
-	return api->pin_set(dev, pwm, period, pulse);
-}
-
 /**
  * @brief Get the clock rate (cycles per second) for a single PWM output.
  *
@@ -90,15 +81,6 @@ static inline int _impl_pwm_pin_set_cycles(struct device *dev, u32_t pwm,
 
 __syscall int pwm_get_cycles_per_sec(struct device *dev, u32_t pwm,
 				     u64_t *cycles);
-
-static inline int _impl_pwm_get_cycles_per_sec(struct device *dev, u32_t pwm,
-					       u64_t *cycles)
-{
-	struct pwm_driver_api *api;
-
-	api = (struct pwm_driver_api *)dev->driver_api;
-	return api->get_cycles_per_sec(dev, pwm, cycles);
-}
 
 /**
  * @brief Set the period and pulse width for a single PWM output.

--- a/include/rtc.h
+++ b/include/rtc.h
@@ -59,30 +59,9 @@ struct rtc_driver_api {
 
 __syscall u32_t rtc_read(struct device *dev);
 
-static inline u32_t _impl_rtc_read(struct device *dev)
-{
-	const struct rtc_driver_api *api = dev->driver_api;
-
-	return api->read(dev);
-}
-
 __syscall void rtc_enable(struct device *dev);
 
-static inline void _impl_rtc_enable(struct device *dev)
-{
-	const struct rtc_driver_api *api = dev->driver_api;
-
-	api->enable(dev);
-}
-
 __syscall void rtc_disable(struct device *dev);
-
-static inline void _impl_rtc_disable(struct device *dev)
-{
-	const struct rtc_driver_api *api = dev->driver_api;
-
-	api->disable(dev);
-}
 
 static inline int rtc_set_config(struct device *dev,
 				 struct rtc_config *cfg)
@@ -93,14 +72,6 @@ static inline int rtc_set_config(struct device *dev,
 }
 
 __syscall int rtc_set_alarm(struct device *dev, const u32_t alarm_val);
-
-static inline int _impl_rtc_set_alarm(struct device *dev,
-				      const u32_t alarm_val)
-{
-	const struct rtc_driver_api *api = dev->driver_api;
-
-	return api->set_alarm(dev, alarm_val);
-}
 
 /**
  * @brief Function to get pending interrupts
@@ -116,14 +87,6 @@ static inline int _impl_rtc_set_alarm(struct device *dev,
  * @retval 0 if no rtc interrupt is pending.
  */
 __syscall int rtc_get_pending_int(struct device *dev);
-
-static inline int _impl_rtc_get_pending_int(struct device *dev)
-{
-	struct rtc_driver_api *api;
-
-	api = (struct rtc_driver_api *)dev->driver_api;
-	return api->get_pending_int(dev);
-}
 
 #ifdef __cplusplus
 }

--- a/include/sensor.h
+++ b/include/sensor.h
@@ -281,20 +281,6 @@ __syscall int sensor_attr_set(struct device *dev,
 			      enum sensor_attribute attr,
 			      const struct sensor_value *val);
 
-static inline int _impl_sensor_attr_set(struct device *dev,
-					enum sensor_channel chan,
-					enum sensor_attribute attr,
-					const struct sensor_value *val)
-{
-	const struct sensor_driver_api *api = dev->driver_api;
-
-	if (!api->attr_set) {
-		return -ENOTSUP;
-	}
-
-	return api->attr_set(dev, chan, attr, val);
-}
-
 /**
  * @brief Activate a sensor's trigger and set the trigger handler
  *
@@ -343,13 +329,6 @@ static inline int sensor_trigger_set(struct device *dev,
  */
 __syscall int sensor_sample_fetch(struct device *dev);
 
-static inline int _impl_sensor_sample_fetch(struct device *dev)
-{
-	const struct sensor_driver_api *api = dev->driver_api;
-
-	return api->sample_fetch(dev, SENSOR_CHAN_ALL);
-}
-
 /**
  * @brief Fetch a sample from the sensor and store it in an internal
  * driver buffer
@@ -371,14 +350,6 @@ static inline int _impl_sensor_sample_fetch(struct device *dev)
  */
 __syscall int sensor_sample_fetch_chan(struct device *dev,
 				       enum sensor_channel type);
-
-static inline int _impl_sensor_sample_fetch_chan(struct device *dev,
-						 enum sensor_channel type)
-{
-	const struct sensor_driver_api *api = dev->driver_api;
-
-	return api->sample_fetch(dev, type);
-}
 
 /**
  * @brief Get a reading from a sensor device
@@ -404,15 +375,6 @@ static inline int _impl_sensor_sample_fetch_chan(struct device *dev,
 __syscall int sensor_channel_get(struct device *dev,
 				 enum sensor_channel chan,
 				 struct sensor_value *val);
-
-static inline int _impl_sensor_channel_get(struct device *dev,
-					   enum sensor_channel chan,
-					   struct sensor_value *val)
-{
-	const struct sensor_driver_api *api = dev->driver_api;
-
-	return api->channel_get(dev, chan, val);
-}
 
 /**
  * @brief The value of gravitational constant in micro m/s^2.

--- a/include/spi.h
+++ b/include/spi.h
@@ -252,17 +252,6 @@ __syscall int spi_transceive(struct device *dev,
 			     const struct spi_buf_set *tx_bufs,
 			     const struct spi_buf_set *rx_bufs);
 
-static inline int _impl_spi_transceive(struct device *dev,
-				       const struct spi_config *config,
-				       const struct spi_buf_set *tx_bufs,
-				       const struct spi_buf_set *rx_bufs)
-{
-	const struct spi_driver_api *api =
-		(const struct spi_driver_api *)dev->driver_api;
-
-	return api->transceive(dev, config, tx_bufs, rx_bufs);
-}
-
 /**
  * @brief Read the specified amount of data from the SPI driver.
  *
@@ -402,15 +391,6 @@ static inline int spi_write_async(struct device *dev,
  */
 __syscall int spi_release(struct device *dev,
 			  const struct spi_config *config);
-
-static inline int _impl_spi_release(struct device *dev,
-				    const struct spi_config *config)
-{
-	const struct spi_driver_api *api =
-		(const struct spi_driver_api *)dev->driver_api;
-
-	return api->release(dev, config);
-}
 
 #ifdef __cplusplus
 }

--- a/include/uart.h
+++ b/include/uart.h
@@ -258,18 +258,6 @@ struct uart_driver_api {
  */
 __syscall int uart_err_check(struct device *dev);
 
-static inline int _impl_uart_err_check(struct device *dev)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	if (api->err_check) {
-		return api->err_check(dev);
-	}
-	return 0;
-}
-
-
 /**
  * @brief Poll the device for input.
  *
@@ -282,14 +270,6 @@ static inline int _impl_uart_err_check(struct device *dev)
  * @retval -ENOTSUP If the operation is not supported.
  */
 __syscall int uart_poll_in(struct device *dev, unsigned char *p_char);
-
-static inline int _impl_uart_poll_in(struct device *dev, unsigned char *p_char)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	return api->poll_in(dev, p_char);
-}
 
 /**
  * @brief Output a character in polled mode.
@@ -307,15 +287,6 @@ static inline int _impl_uart_poll_in(struct device *dev, unsigned char *p_char)
 __syscall void uart_poll_out(struct device *dev,
 				      unsigned char out_char);
 
-static inline void _impl_uart_poll_out(struct device *dev,
-						unsigned char out_char)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	api->poll_out(dev, out_char);
-}
-
 /**
  * @brief Set UART configuration.
  *
@@ -331,19 +302,6 @@ static inline void _impl_uart_poll_out(struct device *dev,
  */
 __syscall int uart_configure(struct device *dev, const struct uart_config *cfg);
 
-static inline int _impl_uart_configure(struct device *dev,
-				       const struct uart_config *cfg)
-{
-	const struct uart_driver_api *api =
-				(const struct uart_driver_api *)dev->driver_api;
-
-	if (api->configure) {
-		return api->configure(dev, cfg);
-	}
-
-	return -ENOTSUP;
-}
-
 /**
  * @brief Get UART configuration.
  *
@@ -357,19 +315,6 @@ static inline int _impl_uart_configure(struct device *dev,
  * @retval 0 If successful, negative errno code otherwise.
  */
 __syscall int uart_config_get(struct device *dev, struct uart_config *cfg);
-
-static inline int _impl_uart_config_get(struct device *dev,
-				     struct uart_config *cfg)
-{
-	const struct uart_driver_api *api =
-				(const struct uart_driver_api *)dev->driver_api;
-
-	if (api->config_get) {
-		return api->config_get(dev, cfg);
-	}
-
-	return -ENOTSUP;
-}
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 
@@ -445,15 +390,6 @@ static inline int uart_fifo_read(struct device *dev, u8_t *rx_data,
  */
 __syscall void uart_irq_tx_enable(struct device *dev);
 
-static inline void _impl_uart_irq_tx_enable(struct device *dev)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	if (api->irq_tx_enable) {
-		api->irq_tx_enable(dev);
-	}
-}
 /**
  * @brief Disable TX interrupt in IER.
  *
@@ -462,16 +398,6 @@ static inline void _impl_uart_irq_tx_enable(struct device *dev)
  * @return N/A
  */
 __syscall void uart_irq_tx_disable(struct device *dev);
-
-static inline void _impl_uart_irq_tx_disable(struct device *dev)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	if (api->irq_tx_disable) {
-		api->irq_tx_disable(dev);
-	}
-}
 
 /**
  * @brief Check if UART TX buffer can accept a new char
@@ -509,16 +435,6 @@ static inline int uart_irq_tx_ready(struct device *dev)
  */
 __syscall void uart_irq_rx_enable(struct device *dev);
 
-static inline void _impl_uart_irq_rx_enable(struct device *dev)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	if (api->irq_rx_enable) {
-		api->irq_rx_enable(dev);
-	}
-}
-
 /**
  * @brief Disable RX interrupt.
  *
@@ -527,16 +443,6 @@ static inline void _impl_uart_irq_rx_enable(struct device *dev)
  * @return N/A
  */
 __syscall void uart_irq_rx_disable(struct device *dev);
-
-static inline void _impl_uart_irq_rx_disable(struct device *dev)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	if (api->irq_rx_disable) {
-		api->irq_rx_disable(dev);
-	}
-}
 
 /**
  * @brief Check if UART TX block finished transmission
@@ -607,16 +513,6 @@ static inline int uart_irq_rx_ready(struct device *dev)
  */
 __syscall void uart_irq_err_enable(struct device *dev);
 
-static inline void _impl_uart_irq_err_enable(struct device *dev)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	if (api->irq_err_enable) {
-		api->irq_err_enable(dev);
-	}
-}
-
 /**
  * @brief Disable error interrupt.
  *
@@ -627,16 +523,6 @@ static inline void _impl_uart_irq_err_enable(struct device *dev)
  */
 __syscall void uart_irq_err_disable(struct device *dev);
 
-static inline void _impl_uart_irq_err_disable(struct device *dev)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	if (api->irq_err_disable) {
-		api->irq_err_disable(dev);
-	}
-}
-
 /**
  * @brief Check if any IRQs is pending.
  *
@@ -646,18 +532,6 @@ static inline void _impl_uart_irq_err_disable(struct device *dev)
  * @retval 0 Otherwise.
  */
 __syscall int uart_irq_is_pending(struct device *dev);
-
-static inline int _impl_uart_irq_is_pending(struct device *dev)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	if (api->irq_is_pending)	{
-		return api->irq_is_pending(dev);
-	}
-
-	return 0;
-}
 
 /**
  * @brief Start processing interrupts in ISR.
@@ -683,18 +557,6 @@ static inline int _impl_uart_irq_is_pending(struct device *dev)
  * @retval 1 Always.
  */
 __syscall int uart_irq_update(struct device *dev);
-
-static inline int _impl_uart_irq_update(struct device *dev)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	if (api->irq_update) {
-		return api->irq_update(dev);
-	}
-
-	return 0;
-}
 
 /**
  * @brief Set the IRQ callback function pointer.
@@ -756,20 +618,6 @@ static inline void uart_irq_callback_set(struct device *dev,
  */
 __syscall int uart_line_ctrl_set(struct device *dev,
 				 u32_t ctrl, u32_t val);
-
-static inline int _impl_uart_line_ctrl_set(struct device *dev,
-					   u32_t ctrl, u32_t val)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	if (api->line_ctrl_set) {
-		return api->line_ctrl_set(dev, ctrl, val);
-	}
-
-	return -ENOTSUP;
-}
-
 /**
  * @brief Retrieve line control for UART.
  *
@@ -781,19 +629,6 @@ static inline int _impl_uart_line_ctrl_set(struct device *dev,
  * @retval failed Otherwise.
  */
 __syscall int uart_line_ctrl_get(struct device *dev, u32_t ctrl, u32_t *val);
-
-static inline int _impl_uart_line_ctrl_get(struct device *dev,
-					   u32_t ctrl, u32_t *val)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	if (api && api->line_ctrl_get) {
-		return api->line_ctrl_get(dev, ctrl, val);
-	}
-
-	return -ENOTSUP;
-}
 
 #endif /* CONFIG_UART_LINE_CTRL */
 
@@ -813,18 +648,6 @@ static inline int _impl_uart_line_ctrl_get(struct device *dev,
  * @retval failed Otherwise.
  */
 __syscall int uart_drv_cmd(struct device *dev, u32_t cmd, u32_t p);
-
-static inline int _impl_uart_drv_cmd(struct device *dev, u32_t cmd, u32_t p)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->driver_api;
-
-	if (api->drv_cmd) {
-		return api->drv_cmd(dev, cmd, p);
-	}
-
-	return -ENOTSUP;
-}
 
 #endif /* CONFIG_UART_DRV_CMD */
 

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,24 +1,39 @@
 # kernel is a normal CMake library and not a zephyr_library because it
 # should not be --whole-archive'd
 add_library(kernel
+  aio_comparator.c
   alert.c
+  can.c
+  counter.c
   device.c
+  dma.c
+  entropy.c
   errno.c
+  flash.c
+  gpio.c
   idle.c
   init.c
+  ipm.c
+  i2c.c
+  i2s.c
+  led.c
   mailbox.c
   mem_slab.c
   mempool.c
   msg_q.c
   mutex.c
   pipes.c
+  pwm.c
   queue.c
   sched.c
   sem.c
+  sensor.c
+  spi.c
   stack.c
   system_work_q.c
   thread.c
   thread_abort.c
+  uart.c
   version.c
   work_q.c
   smp.c

--- a/kernel/aio_comparator.c
+++ b/kernel/aio_comparator.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/types.h>
+#include <device.h>
+#include <aio_comparator.h>
+
+
+int _impl_aio_cmp_disable(struct device *dev, u8_t index)
+{
+	const struct aio_cmp_driver_api *api = dev->driver_api;
+
+	return api->disable(dev, index);
+}
+
+int _impl_aio_cmp_get_pending_int(struct device *dev)
+{
+	struct aio_cmp_driver_api *api;
+
+	api = (struct aio_cmp_driver_api *)dev->driver_api;
+	return api->get_pending_int(dev);
+}

--- a/kernel/can.c
+++ b/kernel/can.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <can.h>
+
+int _impl_can_send(struct device *dev, struct can_msg *msg,
+		   s32_t timeout, can_tx_callback_t callback_isr)
+{
+	const struct can_driver_api *api = dev->driver_api;
+
+	return api->send(dev, msg, timeout, callback_isr);
+}
+
+int _impl_can_attach_msgq(struct device *dev,
+			  struct k_msgq *msg_q,
+			  const struct can_filter *filter)
+{
+	const struct can_driver_api *api = dev->driver_api;
+
+	return api->attach_msgq(dev, msg_q, filter);
+}
+
+int _impl_can_attach_isr(struct device *dev,
+			 can_rx_callback_t isr,
+			 const struct can_filter *filter)
+{
+	const struct can_driver_api *api = dev->driver_api;
+
+	return api->attach_isr(dev, isr, filter);
+}
+
+void _impl_can_detach(struct device *dev, int filter_id)
+{
+	const struct can_driver_api *api = dev->driver_api;
+
+	return api->detach(dev, filter_id);
+}
+
+int _impl_can_configure(struct device *dev, enum can_mode mode,
+			u32_t bitrate)
+{
+	const struct can_driver_api *api = dev->driver_api;
+
+	return api->configure(dev, mode, bitrate);
+}

--- a/kernel/counter.c
+++ b/kernel/counter.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <counter.h>
+
+int _impl_counter_start(struct device *dev)
+{
+	const struct counter_driver_api *api = dev->driver_api;
+
+	return api->start(dev);
+}
+
+int _impl_counter_stop(struct device *dev)
+{
+	const struct counter_driver_api *api = dev->driver_api;
+
+	return api->stop(dev);
+}
+
+u32_t _impl_counter_read(struct device *dev)
+{
+	const struct counter_driver_api *api = dev->driver_api;
+
+	return api->read(dev);
+}
+
+int _impl_counter_get_pending_int(struct device *dev)
+{
+	struct counter_driver_api *api;
+
+	api = (struct counter_driver_api *)dev->driver_api;
+	return api->get_pending_int(dev);
+}

--- a/kernel/dma.c
+++ b/kernel/dma.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dma.h>
+
+int _impl_dma_start(struct device *dev, u32_t channel)
+{
+	const struct dma_driver_api *api =
+		(const struct dma_driver_api *)dev->driver_api;
+
+	return api->start(dev, channel);
+}
+
+int _impl_dma_stop(struct device *dev, u32_t channel)
+{
+	const struct dma_driver_api *api =
+		(const struct dma_driver_api *)dev->driver_api;
+
+	return api->stop(dev, channel);
+}

--- a/kernel/entropy.c
+++ b/kernel/entropy.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel_structs.h>
+#include <syscall_handler.h>
+#include <entropy.h>
+
+int _impl_entropy_get_entropy(struct device *dev,
+			      u8_t *buffer,
+			      u16_t length)
+{
+	const struct entropy_driver_api *api = dev->driver_api;
+
+	__ASSERT(api->get_entropy != NULL,
+		"Callback pointer should not be NULL");
+	return api->get_entropy(dev, buffer, length);
+}

--- a/kernel/flash.c
+++ b/kernel/flash.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel_structs.h>
+#include <syscall_handler.h>
+#include <flash.h>
+
+int _impl_flash_read(struct device *dev, off_t offset, void *data,
+		     size_t len)
+{
+	const struct flash_driver_api *api = dev->driver_api;
+
+	return api->read(dev, offset, data, len);
+}
+
+int _impl_flash_write(struct device *dev, off_t offset,
+		      const void *data, size_t len)
+{
+	const struct flash_driver_api *api = dev->driver_api;
+
+	return api->write(dev, offset, data, len);
+}
+
+int _impl_flash_erase(struct device *dev, off_t offset,
+		      size_t size)
+{
+	const struct flash_driver_api *api = dev->driver_api;
+
+	return api->erase(dev, offset, size);
+}
+
+int _impl_flash_write_protection_set(struct device *dev,
+				     bool enable)
+{
+	const struct flash_driver_api *api = dev->driver_api;
+
+	return api->write_protection(dev, enable);
+}
+
+size_t _impl_flash_get_write_block_size(struct device *dev)
+{
+	const struct flash_driver_api *api = dev->driver_api;
+
+	return api->write_block_size;
+}

--- a/kernel/gpio.c
+++ b/kernel/gpio.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gpio.h>
+
+int _impl_gpio_get_pending_int(struct device *dev)
+{
+	struct gpio_driver_api *api;
+
+	api = (struct gpio_driver_api *)dev->driver_api;
+	return api->get_pending_int(dev);
+}
+
+int _impl_gpio_config(struct device *port, int access_op,
+		      u32_t pin, int flags)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->driver_api;
+
+	return api->config(port, access_op, pin, flags);
+}
+
+int _impl_gpio_write(struct device *port, int access_op,
+		     u32_t pin, u32_t value)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->driver_api;
+
+	return api->write(port, access_op, pin, value);
+}
+
+int _impl_gpio_read(struct device *port, int access_op,
+		    u32_t pin, u32_t *value)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->driver_api;
+
+	return api->read(port, access_op, pin, value);
+}
+
+int _impl_gpio_enable_callback(struct device *port,
+			       int access_op, u32_t pin)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->driver_api;
+
+	return api->enable_callback(port, access_op, pin);
+}
+
+int _impl_gpio_disable_callback(struct device *port,
+				int access_op, u32_t pin)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->driver_api;
+
+	return api->disable_callback(port, access_op, pin);
+}

--- a/kernel/i2c.c
+++ b/kernel/i2c.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <i2c.h>
+
+int _impl_i2c_configure(struct device *dev, u32_t dev_config)
+{
+	const struct i2c_driver_api *api =
+		(const struct i2c_driver_api *)dev->driver_api;
+
+	return api->configure(dev, dev_config);
+}
+
+int _impl_i2c_transfer(struct device *dev,
+		       struct i2c_msg *msgs, u8_t num_msgs,
+		       u16_t addr)
+{
+	const struct i2c_driver_api *api =
+		(const struct i2c_driver_api *)dev->driver_api;
+
+	return api->transfer(dev, msgs, num_msgs, addr);
+}
+
+int _impl_i2c_slave_register(struct device *dev,
+			     struct i2c_slave_config *cfg)
+{
+	const struct i2c_driver_api *api =
+		(const struct i2c_driver_api *)dev->driver_api;
+
+	if (!api->slave_register) {
+		return -ENOTSUP;
+	}
+
+	return api->slave_register(dev, cfg);
+}
+
+int _impl_i2c_slave_unregister(struct device *dev,
+			       struct i2c_slave_config *cfg)
+{
+	const struct i2c_driver_api *api =
+		(const struct i2c_driver_api *)dev->driver_api;
+
+	if (!api->slave_unregister) {
+		return -ENOTSUP;
+	}
+
+	return api->slave_unregister(dev, cfg);
+}
+
+int _impl_i2c_slave_driver_register(struct device *dev)
+{
+	const struct i2c_slave_driver_api *api =
+		(const struct i2c_slave_driver_api *)dev->driver_api;
+
+	return api->driver_register(dev);
+}
+
+int _impl_i2c_slave_driver_unregister(struct device *dev)
+{
+	const struct i2c_slave_driver_api *api =
+		(const struct i2c_slave_driver_api *)dev->driver_api;
+
+	return api->driver_unregister(dev);
+}

--- a/kernel/i2s.c
+++ b/kernel/i2s.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <i2s.h>
+
+int _impl_i2s_configure(struct device *dev, enum i2s_dir dir,
+			struct i2s_config *cfg)
+{
+	const struct i2s_driver_api *api = dev->driver_api;
+
+	return api->configure(dev, dir, cfg);
+}
+
+int _impl_i2s_trigger(struct device *dev, enum i2s_dir dir,
+		      enum i2s_trigger_cmd cmd)
+{
+	const struct i2s_driver_api *api = dev->driver_api;
+
+	return api->trigger(dev, dir, cmd);
+}

--- a/kernel/ipm.c
+++ b/kernel/ipm.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ipm.h>
+
+int _impl_ipm_send(struct device *ipmdev, int wait, u32_t id,
+		   const void *data, int size)
+{
+	const struct ipm_driver_api *api = ipmdev->driver_api;
+
+	return api->send(ipmdev, wait, id, data, size);
+}
+
+int _impl_ipm_max_data_size_get(struct device *ipmdev)
+{
+	const struct ipm_driver_api *api = ipmdev->driver_api;
+
+	return api->max_data_size_get(ipmdev);
+}
+
+u32_t _impl_ipm_max_id_val_get(struct device *ipmdev)
+{
+	const struct ipm_driver_api *api = ipmdev->driver_api;
+
+	return api->max_id_val_get(ipmdev);
+}
+
+int _impl_ipm_set_enabled(struct device *ipmdev, int enable)
+{
+	const struct ipm_driver_api *api = ipmdev->driver_api;
+
+	return api->set_enabled(ipmdev, enable);
+}

--- a/kernel/led.c
+++ b/kernel/led.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <led.h>
+
+int _impl_led_blink(struct device *dev, u32_t led,
+		    u32_t delay_on, u32_t delay_off)
+{
+	const struct led_driver_api *api = dev->driver_api;
+
+	return api->blink(dev, led, delay_on, delay_off);
+}
+
+int _impl_led_set_brightness(struct device *dev, u32_t led,
+			     u8_t value)
+{
+	const struct led_driver_api *api = dev->driver_api;
+
+	return api->set_brightness(dev, led, value);
+}
+
+int _impl_led_on(struct device *dev, u32_t led)
+{
+	const struct led_driver_api *api = dev->driver_api;
+
+	return api->on(dev, led);
+}
+
+int _impl_led_off(struct device *dev, u32_t led)
+{
+	const struct led_driver_api *api = dev->driver_api;
+
+	return api->off(dev, led);
+}

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -88,6 +88,16 @@ int _impl_k_msgq_alloc_init(struct k_msgq *q, size_t msg_size,
 	return ret;
 }
 
+u32_t _impl_k_msgq_num_free_get(struct k_msgq *q)
+{
+	return q->max_msgs - q->used_msgs;
+}
+
+u32_t _impl_k_msgq_num_used_get(struct k_msgq *q)
+{
+	return q->used_msgs;
+}
+
 #ifdef CONFIG_USERSPACE
 Z_SYSCALL_HANDLER(k_msgq_alloc_init, q, msg_size, max_msgs)
 {

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -244,6 +244,11 @@ int _impl_k_poll(struct k_poll_event *events, int num_events, s32_t timeout)
 	return swap_rc;
 }
 
+void _impl_k_poll_signal_reset(struct k_poll_signal *signal)
+{
+	signal->signaled = 0;
+}
+
 #ifdef CONFIG_USERSPACE
 Z_SYSCALL_HANDLER(k_poll, events, num_events, timeout)
 {

--- a/kernel/pwm.c
+++ b/kernel/pwm.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <pwm.h>
+
+int _impl_pwm_pin_set_cycles(struct device *dev, u32_t pwm,
+			     u32_t period, u32_t pulse)
+{
+	struct pwm_driver_api *api;
+
+	api = (struct pwm_driver_api *)dev->driver_api;
+	return api->pin_set(dev, pwm, period, pulse);
+}
+
+int _impl_pwm_get_cycles_per_sec(struct device *dev, u32_t pwm,
+				 u64_t *cycles)
+{
+	struct pwm_driver_api *api;
+
+	api = (struct pwm_driver_api *)dev->driver_api;
+	return api->get_cycles_per_sec(dev, pwm, cycles);
+}

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -351,6 +351,21 @@ void *_impl_k_queue_get(struct k_queue *queue, s32_t timeout)
 #endif /* CONFIG_POLL */
 }
 
+int _impl_k_queue_is_empty(struct k_queue *queue)
+{
+	return (int)sys_sflist_is_empty(&queue->data_q);
+}
+
+void *_impl_k_queue_peek_head(struct k_queue *queue)
+{
+	return z_queue_node_peek(sys_sflist_peek_head(&queue->data_q), false);
+}
+
+void *_impl_k_queue_peek_tail(struct k_queue *queue)
+{
+	return z_queue_node_peek(sys_sflist_peek_tail(&queue->data_q), false);
+}
+
 #ifdef CONFIG_USERSPACE
 Z_SYSCALL_HANDLER(k_queue_get, queue, timeout_p)
 {

--- a/kernel/rtc.c
+++ b/kernel/rtc.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rtc.h>
+
+void _impl_rtc_enable(struct device *dev)
+{
+	const struct rtc_driver_api *api = dev->driver_api;
+
+	api->enable(dev);
+}
+
+void _impl_rtc_disable(struct device *dev)
+{
+	const struct rtc_driver_api *api = dev->driver_api;
+
+	api->disable(dev);
+}
+
+u32_t _impl_rtc_read(struct device *dev)
+{
+	const struct rtc_driver_api *api = dev->driver_api;
+
+	return api->read(dev);
+}
+
+int _impl_rtc_set_alarm(struct device *dev,
+			const u32_t alarm_val)
+{
+	const struct rtc_driver_api *api = dev->driver_api;
+
+	return api->set_alarm(dev, alarm_val);
+}
+
+int _impl_rtc_get_pending_int(struct device *dev)
+{
+	struct rtc_driver_api *api;
+
+	api = (struct rtc_driver_api *)dev->driver_api;
+	return api->get_pending_int(dev);
+}

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -75,6 +75,16 @@ void _impl_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 	sys_trace_end_call(SYS_TRACE_ID_SEMA_INIT);
 }
 
+void _impl_k_sem_reset(struct k_sem *sem)
+{
+	sem->count = 0;
+}
+
+unsigned int _impl_k_sem_count_get(struct k_sem *sem)
+{
+	return sem->count;
+}
+
 #ifdef CONFIG_USERSPACE
 Z_SYSCALL_HANDLER(k_sem_init, sem, initial_count, limit)
 {

--- a/kernel/sensor.c
+++ b/kernel/sensor.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel_structs.h>
+#include <syscall_handler.h>
+#include <sensor.h>
+
+int _impl_sensor_attr_set(struct device *dev,
+			  enum sensor_channel chan,
+			  enum sensor_attribute attr,
+			  const struct sensor_value *val)
+{
+	const struct sensor_driver_api *api = dev->driver_api;
+
+	if (!api->attr_set) {
+		return -ENOTSUP;
+	}
+
+	return api->attr_set(dev, chan, attr, val);
+}
+
+int _impl_sensor_sample_fetch(struct device *dev)
+{
+	const struct sensor_driver_api *api = dev->driver_api;
+
+	return api->sample_fetch(dev, SENSOR_CHAN_ALL);
+}
+
+int _impl_sensor_sample_fetch_chan(struct device *dev,
+				   enum sensor_channel type)
+{
+	const struct sensor_driver_api *api = dev->driver_api;
+
+	return api->sample_fetch(dev, type);
+}
+
+int _impl_sensor_channel_get(struct device *dev,
+			     enum sensor_channel chan,
+			     struct sensor_value *val)
+{
+	const struct sensor_driver_api *api = dev->driver_api;
+
+	return api->channel_get(dev, chan, val);
+}

--- a/kernel/spi.c
+++ b/kernel/spi.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <spi.h>
+
+int _impl_spi_transceive(struct device *dev,
+			 const struct spi_config *config,
+			 const struct spi_buf_set *tx_bufs,
+			 const struct spi_buf_set *rx_bufs)
+{
+	const struct spi_driver_api *api =
+		(const struct spi_driver_api *)dev->driver_api;
+
+	return api->transceive(dev, config, tx_bufs, rx_bufs);
+}
+
+int _impl_spi_release(struct device *dev,
+		      const struct spi_config *config)
+{
+	const struct spi_driver_api *api =
+		(const struct spi_driver_api *)dev->driver_api;
+
+	return api->release(dev, config);
+}

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -109,6 +109,21 @@ void k_timer_init(struct k_timer *timer,
 	_k_object_init(timer);
 }
 
+u32_t _impl_k_timer_remaining_get(struct k_timer *timer)
+{
+	return (u32_t)__ticks_to_ms(z_timeout_remaining(&timer->timeout));
+}
+
+void _impl_k_timer_user_data_set(struct k_timer *timer,
+					       void *user_data)
+{
+	timer->user_data = user_data;
+}
+
+void *_impl_k_timer_user_data_get(struct k_timer *timer)
+{
+	return timer->user_data;
+}
 
 void _impl_k_timer_start(struct k_timer *timer, s32_t duration, s32_t period)
 {

--- a/kernel/uart.c
+++ b/kernel/uart.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/types.h>
+#include <uart.h>
+#include <device.h>
+
+int _impl_uart_err_check(struct device *dev)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	if (api->err_check) {
+		return api->err_check(dev);
+	}
+	return 0;
+}
+
+int _impl_uart_poll_in(struct device *dev, unsigned char *p_char)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	return api->poll_in(dev, p_char);
+}
+
+void _impl_uart_poll_out(struct device *dev,
+			 unsigned char out_char)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	api->poll_out(dev, out_char);
+}
+
+int _impl_uart_configure(struct device *dev,
+			 const struct uart_config *cfg)
+{
+	const struct uart_driver_api *api =
+				(const struct uart_driver_api *)dev->driver_api;
+
+	if (api->configure) {
+		return api->configure(dev, cfg);
+	}
+
+	return -ENOTSUP;
+}
+
+int _impl_uart_config_get(struct device *dev,
+			  struct uart_config *cfg)
+{
+	const struct uart_driver_api *api =
+				(const struct uart_driver_api *)dev->driver_api;
+
+	if (api->config_get) {
+		return api->config_get(dev, cfg);
+	}
+
+	return -ENOTSUP;
+}
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+
+void _impl_uart_irq_tx_enable(struct device *dev)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	if (api->irq_tx_enable) {
+		api->irq_tx_enable(dev);
+	}
+}
+
+void _impl_uart_irq_tx_disable(struct device *dev)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	if (api->irq_tx_disable) {
+		api->irq_tx_disable(dev);
+	}
+}
+
+void _impl_uart_irq_rx_enable(struct device *dev)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	if (api->irq_rx_enable) {
+		api->irq_rx_enable(dev);
+	}
+}
+
+void _impl_uart_irq_rx_disable(struct device *dev)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	if (api->irq_rx_disable) {
+		api->irq_rx_disable(dev);
+	}
+}
+
+void _impl_uart_irq_err_enable(struct device *dev)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	if (api->irq_err_enable) {
+		api->irq_err_enable(dev);
+	}
+}
+
+void _impl_uart_irq_err_disable(struct device *dev)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	if (api->irq_err_disable) {
+		api->irq_err_disable(dev);
+	}
+}
+
+int _impl_uart_irq_is_pending(struct device *dev)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	if (api->irq_is_pending)	{
+		return api->irq_is_pending(dev);
+	}
+
+	return 0;
+}
+
+int _impl_uart_irq_update(struct device *dev)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	if (api->irq_update) {
+		return api->irq_update(dev);
+	}
+
+	return 0;
+}
+
+#endif	/* CONFIG_UART_INTERRUPT_DRIVEN */
+
+#ifdef CONFIG_UART_LINE_CTRL
+int _impl_uart_line_ctrl_set(struct device *dev,
+			     u32_t ctrl, u32_t val)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	if (api->line_ctrl_set) {
+		return api->line_ctrl_set(dev, ctrl, val);
+	}
+
+	return -ENOTSUP;
+}
+
+int _impl_uart_line_ctrl_get(struct device *dev,
+					   u32_t ctrl, u32_t *val)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	if (api && api->line_ctrl_get) {
+		return api->line_ctrl_get(dev, ctrl, val);
+	}
+
+	return -ENOTSUP;
+}
+
+#endif /* CONFIG_UART_LINE_CTRL */
+
+#ifdef CONFIG_UART_DRV_CMD
+
+int _impl_uart_drv_cmd(struct device *dev, u32_t cmd, u32_t p)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->driver_api;
+
+	if (api->drv_cmd) {
+		return api->drv_cmd(dev, cmd, p);
+	}
+
+	return -ENOTSUP;
+}
+
+#endif /* CONFIG_UART_DRV_CMD */

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -315,6 +315,27 @@ void _k_object_wordlist_foreach(_wordlist_cb_func_t func, void *context)
 	}
 	irq_unlock(key);
 }
+#else
+
+void *_impl_k_object_alloc(enum k_objects otype)
+{
+	ARG_UNUSED(otype);
+
+	return NULL;
+}
+
+void _impl_k_object_access_grant(void *object,
+					       struct k_thread *thread)
+{
+	ARG_UNUSED(object);
+	ARG_UNUSED(thread);
+}
+
+void _impl_k_object_release(void *object)
+{
+	ARG_UNUSED(object);
+}
+
 #endif /* CONFIG_DYNAMIC_OBJECTS */
 
 static int thread_index_get(struct k_thread *t)


### PR DESCRIPTION
Syscall internal implementations were spread across headers, as static
inline, and C sources. The generated syscall code was declaring all
internal _impl_ as an extern function because of the ones implemented
in C sources. This was violating MISRA-C rule 8.8 in the cases
internal functions were implemented in the headers.