### PR TITLE
soc: nordic: default GPIO when SPI enabled

### DIFF
--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -26,4 +26,11 @@ config ENTROPY_NRF5_RNG
 
 endif # ENTROPY_GENERATOR
 
+if SPI
+
+config GPIO
+	default y
+
+endif # SPI
+
 endif # SOC_FAMILY_NRF


### PR DESCRIPTION
SPI devices require chip selects, which are configured through GPIOs.
Ensure the GPIO infrastructure is available when SPI is enabled.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>