### PR TITLE
net: buf: linearize: Never return -ENOMEM, just do what user asked to

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -1300,21 +1300,22 @@ struct net_buf *net_buf_frag_del(struct net_buf *parent, struct net_buf *frag);
 #endif
 
 /**
- * @brief Copy len bytes from src starting from offset to dst buffer
+ * @brief Copy bytes from net_buf chain starting at offset to linear buffer
  *
- * This routine assumes that dst is large enough to store @a len bytes
- * starting from offset at src.
+ * Copy (extract) @a len bytes from @a src net_buf chain, starting from @a
+ * offset in it, to a linear buffer @a dst. Return number of bytes actually
+ * copied, which may be less than requested, if net_buf chain doesn't have
+ * enough data, or destination buffer is too small.
  *
  * @param dst Destination buffer
- * @param dst_len Destination buffer max length
- * @param src Source buffer that may be fragmented
- * @param offset Starting point to copy from
+ * @param dst_len Destination buffer length
+ * @param src Source net_buf chain
+ * @param offset Starting offset to copy from
  * @param len Number of bytes to copy
- * @return number of bytes copied if everything is ok
- * @return -ENOMEM on error
+ * @return number of bytes actually copied
  */
-int net_buf_linearize(void *dst, size_t dst_len,
-		      struct net_buf *src, size_t offset, size_t len);
+size_t net_buf_linearize(void *dst, size_t dst_len,
+			 struct net_buf *src, size_t offset, size_t len);
 
 /**
  * @typedef net_buf_allocator_cb

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -1122,21 +1122,19 @@ int net_frag_linear_copy(struct net_buf *dst, struct net_buf *src,
 			 u16_t offset, u16_t len);
 
 /**
- * @brief Copy len bytes from src starting from offset to dst buffer
+ * @brief Copy bytes from src packet starting at offset to linear buffer
  *
- * This routine assumes that dst is large enough to store @a len bytes
- * starting from offset at src.
+ * This routine behaves is a convenience wrapper for @ref net_buf_linearize .
  *
  * @param dst Destination buffer
- * @param dst_len Destination buffer max length
- * @param src Source buffer that may be fragmented
- * @param offset Starting point to copy from
+ * @param dst_len Destination buffer length
+ * @param src Source packet with fragmented net_buf chain
+ * @param offset Starting offset to copy from
  * @param len Number of bytes to copy
- * @return number of bytes copied if everything is ok
- * @return -ENOMEM on error
+ * @return number of bytes actually copied
  */
-int net_frag_linearize(u8_t *dst, size_t dst_len,
-		       struct net_pkt *src, u16_t offset, u16_t len);
+size_t net_frag_linearize(void *dst, size_t dst_len,
+			  struct net_pkt *src, size_t offset, size_t len);
 
 /**
  * @brief Compact the fragment list of a packet.

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -674,16 +674,14 @@ struct net_buf *net_buf_frag_del(struct net_buf *parent, struct net_buf *frag)
 	return next_frag;
 }
 
-int net_buf_linearize(void *dst, size_t dst_len, struct net_buf *src,
-		      size_t offset, size_t len)
+size_t net_buf_linearize(void *dst, size_t dst_len, struct net_buf *src,
+			 size_t offset, size_t len)
 {
 	struct net_buf *frag;
 	size_t to_copy;
 	size_t copied;
 
-	if (dst_len < (size_t)len) {
-		return -ENOMEM;
-	}
+	len = min(len, dst_len);
 
 	frag = src;
 
@@ -710,10 +708,6 @@ int net_buf_linearize(void *dst, size_t dst_len, struct net_buf *src,
 
 		/* after the first iteration, this value will be 0 */
 		offset = 0;
-	}
-
-	if (len > 0) {
-		return -ENOMEM;
 	}
 
 	return copied;

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1097,8 +1097,8 @@ int net_frag_linear_copy(struct net_buf *dst, struct net_buf *src,
 	return 0;
 }
 
-int net_frag_linearize(u8_t *dst, size_t dst_len, struct net_pkt *src,
-			 u16_t offset, u16_t len)
+size_t net_frag_linearize(void *dst, size_t dst_len, struct net_pkt *src,
+			  size_t offset, size_t len)
 {
 	return net_buf_linearize(dst, dst_len, src->frags, offset, len);
 }

--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -1698,10 +1698,6 @@ static int tls_sendto(struct net_app_ctx *ctx,
 				 tx_data->pkt,
 				 net_pkt_ip_hdr_len(tx_data->pkt),
 				 len);
-	if (ret < 0) {
-		NET_DBG("Cannot linearize send data (%d)", ret);
-		goto out;
-	}
 
 	if (ret != len) {
 		NET_DBG("Linear copy error (%u vs %d)", len, ret);

--- a/subsys/net/lib/sntp/sntp.c
+++ b/subsys/net/lib/sntp/sntp.c
@@ -113,6 +113,7 @@ static void sntp_recv_cb(struct net_app_ctx *ctx, struct net_pkt *pkt,
 	u64_t epoch_time = 0U;
 	u64_t tmp = 0U;
 	u16_t offset = 0U;
+	size_t out_len;
 
 	if (status < 0) {
 		goto error_exit;
@@ -125,9 +126,9 @@ static void sntp_recv_cb(struct net_app_ctx *ctx, struct net_pkt *pkt,
 
 	/* copy to buf */
 	offset = net_pkt_get_len(pkt) - net_pkt_appdatalen(pkt);
-	status = net_frag_linearize((u8_t *)&buf, sizeof(buf), pkt, offset,
-				    sizeof(buf));
-	if (status < 0) {
+	out_len = net_frag_linearize((u8_t *)&buf, sizeof(buf), pkt, offset,
+				     sizeof(buf));
+	if (out_len != sizeof(buf)) {
 		goto error_exit;
 	}
 


### PR DESCRIPTION
Don't try to find "errors" in the values of dst_len and len params
passed to net_buf_linearize(). Instead, do what entails with the
common sense from the values passed in, specifically:

1. Never read more than dst_len (or it would lead to buffer
overflow).
2. It's absolutely ok to read than specified by "len" param, that's
why this function returns number of bytes read in the first place.

The motivation for this change is that it's not useful with its
current behavior. For example, a number of Ethernet drivers linearize
a packet to send, but each does it with its own duplicated adhoc
routine, because net_buf_linearize() would just return error for the
natural use of:

net_buf_linearize(buf, sizeof(buf), pkt->frags, 0, sizeof(buf));

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>