### PR TITLE
test: code_relocation: Fixed CI failure

### DIFF
--- a/samples/application_development/code_relocation/sample.yaml
+++ b/samples/application_development/code_relocation/sample.yaml
@@ -10,3 +10,4 @@ tests:
       - "Hello World! (.*)"
     platform_whitelist: qemu_cortex_m3 mps2_an385 sam_e70_xplained
     tags: linker
+    extra_sections: _SRAM2_RODATA_SECTION_NAME _SRAM_TEXT_SECTION_NAME _SRAM_RODATA_SECTION_NAME _SRAM_DATA_SECTION_NAME _CUSTOM_SECTION_NAME2


### PR DESCRIPTION
The test 'samples/application_development/code_relocation' was failing
in master because it was not declaring that it was defining additional
sections.

The CI error is attached below.

This patch fixes the CI failure by declaring in 'sample.yaml' that
these additional sections are expected.

FAILED:
qemu_cortex_m3/samples/application_development/code_relocation/test
has unrecognized binary sections: ['_SRAM2_RODATA_SECTION_NAME',
'_SRAM_TEXT_SECTION_NAME', '_SRAM_RODATA_SECTION_NAME',
'_SRAM_DATA_SECTION_NAME', '_CUSTOM_SECTION_NAME2']

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>