### PR TITLE
WIP misc: assert: Allow __ASSERT to call k_panic

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4544,6 +4544,7 @@ extern void k_cpu_atomic_idle(unsigned int key);
  */
 extern void _sys_power_save_idle_exit(s32_t ticks);
 
+#if 0
 #ifdef _ARCH_EXCEPT
 /* This archtecture has direct support for triggering a CPU exception */
 #define _k_except_reason(reason)	_ARCH_EXCEPT(reason)
@@ -4588,6 +4589,7 @@ extern void _sys_power_save_idle_exit(s32_t ticks);
  * @req K-MISC-004
  */
 #define k_panic()	_k_except_reason(_NANO_ERR_KERNEL_PANIC)
+#endif
 
 /*
  * private APIs that are utilized by one or more public APIs

--- a/include/kernel_except.h
+++ b/include/kernel_except.h
@@ -1,0 +1,44 @@
+#ifdef _ARCH_EXCEPT
+/* This archtecture has direct support for triggering a CPU exception */
+#define _k_except_reason(reason)	_ARCH_EXCEPT(reason)
+#else
+
+/* NOTE: This is the implementation for arches that do not implement
+ * _ARCH_EXCEPT() to generate a real CPU exception.
+ *
+ * We won't have a real exception frame to determine the PC value when
+ * the oops occurred, so print file and line number before we jump into
+ * the fatal error handler.
+ */
+#define _k_except_reason(reason) do { \
+		printk("@ %s:%d:\n", __FILE__,  __LINE__); \
+		_NanoFatalErrorHandler(reason, &_default_esf); \
+		CODE_UNREACHABLE; \
+	} while (false)
+
+#endif /* _ARCH__EXCEPT */
+
+/**
+ * @brief Fatally terminate a thread
+ *
+ * This should be called when a thread has encountered an unrecoverable
+ * runtime condition and needs to terminate. What this ultimately
+ * means is determined by the _fatal_error_handler() implementation, which
+ * will be called will reason code _NANO_ERR_KERNEL_OOPS.
+ *
+ * If this is called from ISR context, the default system fatal error handler
+ * will treat it as an unrecoverable system error, just like k_panic().
+ * @req K-MISC-003
+ */
+#define k_oops()	_k_except_reason(_NANO_ERR_KERNEL_OOPS)
+
+/**
+ * @brief Fatally terminate the system
+ *
+ * This should be called when the Zephyr kernel has encountered an
+ * unrecoverable runtime condition and needs to terminate. What this ultimately
+ * means is determined by the _fatal_error_handler() implementation, which
+ * will be called will reason code _NANO_ERR_KERNEL_PANIC.
+ * @req K-MISC-004
+ */
+#define k_panic()	_k_except_reason(_NANO_ERR_KERNEL_PANIC)

--- a/include/kernel_includes.h
+++ b/include/kernel_includes.h
@@ -19,11 +19,9 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <atomic.h>
-#include <misc/__assert.h>
 #include <sched_priq.h>
 #include <misc/dlist.h>
 #include <misc/slist.h>
-#include <misc/sflist.h>
 #include <misc/util.h>
 #include <misc/mempool_base.h>
 #include <kernel_version.h>
@@ -34,5 +32,8 @@
 #include <arch/cpu.h>
 #include <misc/rb.h>
 #include <sys_clock.h>
+#include <kernel_except.h>
+#include <misc/__assert.h>
+#include <misc/sflist.h>
 
 #endif /* ZEPHYR_INCLUDE_KERNEL_INCLUDES_H_ */

--- a/include/misc/__assert.h
+++ b/include/misc/__assert.h
@@ -87,6 +87,7 @@ extern void posix_exit(int exit_code);
 #define __ASSERT_POST posix_exit(1)
 #else
 #define __ASSERT_POST             \
+	k_panic(); \
 	for (;;) {                \
 		/* spin thread */ \
 	}


### PR DESCRIPTION
Currently, failed assert leads to infinite loop. This isn't much
useful, there should be at least a possibility to get a backtrace/
crashdump when it happens. However, it's not possible to just
add k_panic() to __ASSERT_POST, as __ASSERT is defined first, then
used by some inline functions, and only then k_panic() is defined.

This patch splits k_panic() and friends declarations from kernel.h
into kernel_except.h, and includes that header before misc/assert.h.
It also reorders kernel includes to get the overall order and
dependencies right.

This patch is mostly proof of concept and RFC. If OKed, more cleanup
would need to be done.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>