### PR TITLE
Make options depend on their features

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -410,11 +410,9 @@ config MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 	  and size for MPU regions.
 
 
-menu "Floating Point Options"
-depends on CPU_HAS_FPU
-
-config FLOAT
-	bool "Floating point registers"
+menuconfig FLOAT
+	bool "Floating point"
+	depends on CPU_HAS_FPU
 	help
 	  This option allows threads to use the floating point registers.
 	  By default, only a single thread may use the registers.
@@ -422,14 +420,15 @@ config FLOAT
 	  Disabling this option means that any thread that uses a
 	  floating point register will get a fatal exception.
 
+if FLOAT
+
 config FP_SHARING
 	bool "Floating point register sharing"
-	depends on FLOAT
 	help
 	  This option allows multiple threads to use the floating point
 	  registers.
 
-endmenu
+endif # FLOAT
 
 #
 # End hidden PM feature configs

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -34,6 +34,7 @@ config XTENSA_OMIT_HIGH_INTERRUPTS
 config XTENSA_ASM2
 	bool "New-style Xtensa context switch & interrupt layer"
 	select USE_SWITCH
+	select USE_SWITCH_SUPPORTED
 	help
 	  This selects a new implementation of context switching and
 	  interrupt handling.  Advantages are a much lower interrupt

--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -7,18 +7,16 @@
 #
 
 menu "Ethernet Drivers"
+	depends on NET_L2_ETHERNET
 
-if NET_L2_ETHERNET
 module = ETHERNET
 module-dep = LOG
 module-str = Log level for Ethernet driver
 module-help = Sets log level for Ethernet Device Drivers.
 source "subsys/net/Kconfig.template.log_config.net"
-endif # NET_L2_ETHERNET
 
 config ETH_INIT_PRIORITY
 	int "Ethernet driver init priority"
-	depends on NET_L2_ETHERNET
 	default 80
 	help
 	  Ethernet device driver initialization priority.
@@ -35,4 +33,4 @@ source "drivers/ethernet/Kconfig.stm32_hal"
 source "drivers/ethernet/Kconfig.native_posix"
 source "drivers/ethernet/Kconfig.stellaris"
 
-endmenu
+endmenu # "Ethernet Drivers"

--- a/drivers/ethernet/Kconfig.dw
+++ b/drivers/ethernet/Kconfig.dw
@@ -8,7 +8,6 @@
 
 menuconfig ETH_DW
 	bool "Synopsys DesignWare Ethernet driver"
-	depends on NET_L2_ETHERNET
 	help
 	  Enable Synopsys DesignWare Ethernet driver.
 

--- a/drivers/ethernet/Kconfig.enc28j60
+++ b/drivers/ethernet/Kconfig.enc28j60
@@ -8,7 +8,6 @@
 
 menuconfig ETH_ENC28J60
 	bool "ENC28J60C Ethernet Controller"
-	depends on NET_L2_ETHERNET
 	depends on SPI
 	help
 	  ENC28J60C Stand-Alone Ethernet Controller

--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -6,7 +6,7 @@
 
 menuconfig ETH_MCUX
 	bool "MCUX Ethernet driver"
-	depends on NET_L2_ETHERNET && HAS_MCUX
+	depends on HAS_MCUX
 	help
 	  Enable MCUX Ethernet driver.  Note, this driver performs one shot PHY
 	  setup.  There is no support for PHY disconnect, reconnect or

--- a/drivers/ethernet/Kconfig.native_posix
+++ b/drivers/ethernet/Kconfig.native_posix
@@ -108,4 +108,4 @@ config	ETH_NATIVE_POSIX_MAC_ADDR
 
 endif
 
-endif
+endif # ETH_NATIVE_POSIX

--- a/drivers/ethernet/Kconfig.native_posix
+++ b/drivers/ethernet/Kconfig.native_posix
@@ -6,7 +6,7 @@
 
 menuconfig ETH_NATIVE_POSIX
 	bool "Native Posix Ethernet driver"
-	depends on ARCH_POSIX && NET_L2_ETHERNET
+	depends on ARCH_POSIX
 	help
 	  Enable native posix ethernet driver. Note, this driver is run inside
 	  a process in your host system.

--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -6,7 +6,7 @@
 
 menuconfig ETH_SAM_GMAC
 	bool "Atmel SAM Ethernet driver"
-	depends on SOC_FAMILY_SAM && NET_L2_ETHERNET
+	depends on SOC_FAMILY_SAM
 	help
 	  Enable Atmel SAM MCU Family Ethernet driver.
 

--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -6,7 +6,7 @@
 
 menuconfig ETH_SAM_GMAC
 	bool "Atmel SAM Ethernet driver"
-	depends on SOC_FAMILY_SAM
+	depends on SOC_FAMILY_SAM && NET_L2_ETHERNET
 	help
 	  Enable Atmel SAM MCU Family Ethernet driver.
 

--- a/drivers/ethernet/Kconfig.stellaris
+++ b/drivers/ethernet/Kconfig.stellaris
@@ -8,6 +8,5 @@
 
 menuconfig ETH_STELLARIS
 	bool "Enable TI Stellaris MCU family ethernet driver."
-	depends on NET_L2_ETHERNET
 	help
 	  Stellaris on-board Ethernet Controller

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -8,7 +8,6 @@
 
 menuconfig ETH_STM32_HAL
 	bool "STM32 HAL Ethernet driver"
-	depends on NET_L2_ETHERNET
 	select USE_STM32_HAL_ETH
 	help
 	  Enable STM32 HAL based Ethernet driver. It is available for

--- a/drivers/serial/Kconfig.stellaris
+++ b/drivers/serial/Kconfig.stellaris
@@ -1,5 +1,6 @@
 menuconfig UART_STELLARIS
 	bool "Stellaris serial driver"
+	depends on SOC_TI_LM3S6965 || SOC_CC2650
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
@@ -7,11 +8,12 @@ menuconfig UART_STELLARIS
 	  This specific driver can be used for the serial hardware
 	  available at the Texas Instrument LM3S6965 board.
 
+if UART_STELLARIS
+
 # ---------- Port 0 ----------
 
 menuconfig UART_STELLARIS_PORT_0
 	bool "Enable Stellaris UART Port 0"
-	depends on UART_STELLARIS
 	help
 	  This tells the driver to configure the UART port at boot, depending on
 	  the additional configure options below.
@@ -20,7 +22,6 @@ menuconfig UART_STELLARIS_PORT_0
 
 menuconfig UART_STELLARIS_PORT_1
 	bool "Enable Stellaris UART Port 1"
-	depends on UART_STELLARIS
 	help
 	  This tells the driver to configure the UART port at boot, depending on
 	  the additional configure options below.
@@ -29,7 +30,8 @@ menuconfig UART_STELLARIS_PORT_1
 
 menuconfig UART_STELLARIS_PORT_2
 	bool "Enable Stellaris UART Port 2"
-	depends on UART_STELLARIS
 	help
 	  This tells the driver to configure the UART port at boot, depending on
 	  the additional configure options below.
+
+endif # UART_STELLARIS

--- a/ext/hal/libmetal/Kconfig
+++ b/ext/hal/libmetal/Kconfig
@@ -4,13 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-config LIBMETAL
+menuconfig LIBMETAL
 	bool "libmetal Support"
 	help
 	  This option enables the libmetal HAL abstraction layer
+
+if LIBMETAL
 
 config LIBMETAL_SRC_PATH
 	string "libmetal library source path"
 	default "libmetal"
 	help
 	  This option specifies the path to the source for the libmetal library
+
+endif # LIBMETAL

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -686,6 +686,8 @@ config MP_NUM_CPUS
 endmenu
 
 config TICKLESS_IDLE
+	# NB: This option is deprecated, see TICKLESS_KERNEL and
+	# https://github.com/zephyrproject-rtos/zephyr/pull/12234
 	bool "Tickless idle"
 	default y if SYS_POWER_MANAGEMENT || TICKLESS_CAPABLE
 	help
@@ -709,8 +711,7 @@ config TICKLESS_KERNEL
 	default y if TICKLESS_CAPABLE
 	help
 	  This option enables a fully event driven kernel. Periodic system
-	  clock interrupt generation would be stopped at all times. This option
-	  requires Tickless Idle option to be enabled.
+	  clock interrupt generation would be stopped at all times.
 
 source "kernel/Kconfig.power_mgmt"
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -650,8 +650,10 @@ config MAX_DOMAIN_PARTITIONS
 	  Configure the maximum number of partitions per memory domain.
 
 menu "SMP Options"
+
 config USE_SWITCH
 	bool "Use new-style _arch_switch instead of __swap"
+	depends on USE_SWITCH_SUPPORTED
 	help
 	  The _arch_switch() API is a lower level context switching
 	  primitive than the original __swap mechanism.  It is required
@@ -659,6 +661,13 @@ config USE_SWITCH
 	  provide __swap.  In uniprocess situations where the
 	  architecture provides both, _arch_switch incurs more somewhat
 	  overhead and may be slower.
+
+config USE_SWITCH_SUPPORTED
+	bool
+	help
+	  Indicates whether _arch_switch() API is supported by the
+	  currently enabled platform. This option should be selected by
+	  platforms that implement it.
 
 config SMP
 	bool "Enable symmetric multithreading support"

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -662,6 +662,7 @@ config USE_SWITCH
 
 config SMP
 	bool "Enable symmetric multithreading support"
+	depends on USE_SWITCH
 	help
 	  When true, kernel will be built with SMP support, allowing
 	  more than one CPU to schedule Zephyr tasks at a time.

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -582,12 +582,12 @@ menu "Security Options"
 config RETPOLINE
 	bool "Build with retpolines enabled"
 	default y if !X86_NO_SPECTRE_V2
+	# Currently only implemented for x86
+	depends on X86
 	help
 	  This is recommended on platforms with speculative executions, to protect
 	  against branch target injection (AKA Spectre-V2).  Full description of
 	  how retpolines work can be found here[1].
-
-	  Currently only the x86 port
 
 	  [1] https://support.google.com/faqs/answer/7625886
 

--- a/subsys/fb/Kconfig
+++ b/subsys/fb/Kconfig
@@ -6,9 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-menu "Framebuffer"
-
-config CHARACTER_FRAMEBUFFER
+menuconfig CHARACTER_FRAMEBUFFER
 	bool "Character framebuffer for dot matrix displays"
 	help
 	  Character framebuffer for dot matrix displays.
@@ -42,6 +40,4 @@ module = CFB
 module-str = cfb
 source "subsys/logging/Kconfig.template.log_config"
 
-endif
-
-endmenu
+endif # CHARACTER_FRAMEBUFFER


### PR DESCRIPTION
This PR contains misc. Kconfig cleanups.

Including;

- Hiding features from users that are working on platforms where the feature is unsupported.
- Reducing copy-paste between Kconfig options, e.g. using 'if' instead of many 'depends on' statements.
- Adding checkboxes to menus to visualize whether anything within the menu category is enabled.
- Hiding empty menus

Overall, it makes the Kconfig menu more navigatable and prevents invalid configurations.