### PR TITLE
boards: nucleo_f103rb: enables I2C_1 and I2C_2

### DIFF
--- a/boards/arm/nucleo_f103rb/Kconfig.defconfig
+++ b/boards/arm/nucleo_f103rb/Kconfig.defconfig
@@ -32,6 +32,13 @@ config SPI_1
 config SPI_2
 	default y
 
-endif
+endif # SPI
+
+if I2C
+
+config I2C_1
+	default y
+
+endif # I2C
 
 endif # BOARD_NUCLEO_F103RB

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -77,4 +77,13 @@ arduino_spi: &spi1 {
 
 &idwg {
 	status = "ok";
+
+&i2c1 {
+	status = "ok";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&i2c2 {
+	status = "ok";
+	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -78,7 +78,7 @@ arduino_spi: &spi1 {
 &idwg {
 	status = "ok";
 
-&i2c1 {
+arduino_i2c: &i2c1 {
 	status = "ok";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/arm/nucleo_f103rb/pinmux.c
+++ b/boards/arm/nucleo_f103rb/pinmux.c
@@ -41,6 +41,10 @@ static const struct pin_config pinconf[] = {
 	{STM32_PIN_PB14, STM32F1_PINMUX_FUNC_PB14_SPI2_MASTER_MISO},
 	{STM32_PIN_PB15, STM32F1_PINMUX_FUNC_PB15_SPI2_MASTER_MOSI},
 #endif /* CONFIG_SPI_2 */
+#ifdef CONFIG_I2C_1
+	{STM32_PIN_PB8, STM32F1_PINMUX_FUNC_PB6_I2C1_SCL},
+	{STM32_PIN_PB9, STM32F1_PINMUX_FUNC_PB7_I2C1_SDA},
+#endif /* CONFIG_I2C_1 */
 };
 
 static int pinmux_stm32_init(struct device *port)

--- a/boards/arm/nucleo_f103rb/pinmux.c
+++ b/boards/arm/nucleo_f103rb/pinmux.c
@@ -11,6 +11,8 @@
 #include <sys_io.h>
 
 #include <pinmux/stm32/pinmux_stm32.h>
+#include <stm32f1xx_ll_gpio.h>
+#include <stm32f1xx_ll_bus.h>
 
 /* pin assignments for NUCLEO-F103RB board */
 static const struct pin_config pinconf[] = {
@@ -52,6 +54,11 @@ static int pinmux_stm32_init(struct device *port)
 	ARG_UNUSED(port);
 
 	stm32_setup_pins(pinconf, ARRAY_SIZE(pinconf));
+
+	/* Enablio AFIO clock */
+	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_AFIO);
+	/* Remap I2C1 from PB6/PB7 to PB8/PB9 for Arduino pin compatibility */
+	LL_GPIO_AF_EnableRemap_I2C1();
 
 	return 0;
 }

--- a/boards/arm/nucleo_f103rb/pinmux.c
+++ b/boards/arm/nucleo_f103rb/pinmux.c
@@ -55,10 +55,12 @@ static int pinmux_stm32_init(struct device *port)
 
 	stm32_setup_pins(pinconf, ARRAY_SIZE(pinconf));
 
+#ifdef CONFIG_I2C_1
 	/* Enablio AFIO clock */
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_AFIO);
 	/* Remap I2C1 from PB6/PB7 to PB8/PB9 for Arduino pin compatibility */
 	LL_GPIO_AF_EnableRemap_I2C1();
+#endif /* CONFIG_I2C_1 */
 
 	return 0;
 }

--- a/boards/arm/nucleo_f103rb/pinmux.c
+++ b/boards/arm/nucleo_f103rb/pinmux.c
@@ -44,8 +44,8 @@ static const struct pin_config pinconf[] = {
 	{STM32_PIN_PB15, STM32F1_PINMUX_FUNC_PB15_SPI2_MASTER_MOSI},
 #endif /* CONFIG_SPI_2 */
 #ifdef CONFIG_I2C_1
-	{STM32_PIN_PB8, STM32F1_PINMUX_FUNC_PB6_I2C1_SCL},
-	{STM32_PIN_PB9, STM32F1_PINMUX_FUNC_PB7_I2C1_SDA},
+	{STM32_PIN_PB8, STM32F1_PINMUX_FUNC_PB8_I2C1_SCL},
+	{STM32_PIN_PB9, STM32F1_PINMUX_FUNC_PB9_I2C1_SDA},
 #endif /* CONFIG_I2C_1 */
 };
 
@@ -56,7 +56,7 @@ static int pinmux_stm32_init(struct device *port)
 	stm32_setup_pins(pinconf, ARRAY_SIZE(pinconf));
 
 #ifdef CONFIG_I2C_1
-	/* Enablio AFIO clock */
+	/* AFIO clock needed for AF remap */
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_AFIO);
 	/* Remap I2C1 from PB6/PB7 to PB8/PB9 for Arduino pin compatibility */
 	LL_GPIO_AF_EnableRemap_I2C1();


### PR DESCRIPTION
Resolves #12243

Signed-off-by: Matthias Wientapper <m.wientapper@gmx.de>