### PR TITLE
kernel: Change the prototype of k_thread_access_grant.

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -724,21 +724,21 @@ extern FUNC_NORETURN void k_thread_user_mode_enter(k_thread_entry_t entry,
 						   void *p3);
 
 /**
- * @brief Grant a thread access to a NULL-terminated  set of kernel objects
+ * @brief Grant a thread access to a set of kernel objects
  *
  * This is a convenience function. For the provided thread, grant access to
  * the remaining arguments, which must be pointers to kernel objects.
- * The final argument must be a NULL.
  *
  * The thread object must be initialized (i.e. running). The objects don't
  * need to be.
+ * Note that NULL shouldn't be passed as an argument.
  *
  * @param thread Thread to grant access to objects
- * @param ... NULL-terminated list of kernel object pointers
+ * @param ... list of kernel object pointers
  * @req K-THREAD-004
  */
-extern void __attribute__((sentinel))
-	k_thread_access_grant(struct k_thread *thread, ...);
+#define k_thread_access_grant(thread, ...) \
+	FOR_EACH_FIXED_ARG(k_object_access_grant, thread, __VA_ARGS__)
 
 /**
  * @brief Assign a resource memory pool to a thread

--- a/include/misc/util.h
+++ b/include/misc/util.h
@@ -453,4 +453,42 @@ static inline s64_t arithmetic_shift_right(s64_t value, u8_t shift)
 	_for_10, _for_9, _for_8, _for_7, _for_6, _for_5, \
 	_for_4, _for_3, _for_2, _for_1, _for_0)(x, ##__VA_ARGS__)
 
+/* FOR_EACH_FIXED_ARG is used for calling the same function
+ * With one fixed argument and changing 2nd argument.
+ */
+
+#define z_rep_0(_fn, f, ...)
+#define z_rep_1(_fn, f, x) {_fn(x, f); z_rep_0(_fn, f)}
+#define z_rep_2(_fn, f, x, ...) {_fn(x, f); z_rep_1(_fn, f, ##__VA_ARGS__)}
+#define z_rep_3(_fn, f, x, ...) {_fn(x, f); z_rep_2(_fn, f, ##__VA_ARGS__)}
+#define z_rep_4(_fn, f, x, ...) {_fn(x, f); z_rep_3(_fn, f, ##__VA_ARGS__)}
+#define z_rep_5(_fn, f, x, ...) {_fn(x, f); z_rep_4(_fn, f, ##__VA_ARGS__)}
+#define z_rep_6(_fn, f, x, ...) {_fn(x, f); z_rep_5(_fn, f, ##__VA_ARGS__)}
+#define z_rep_7(_fn, f, x, ...) {_fn(x, f); z_rep_6(_fn, f, ##__VA_ARGS__)}
+#define z_rep_8(_fn, f, x, ...) {_fn(x, f); z_rep_7(_fn, f, ##__VA_ARGS__)}
+#define z_rep_9(_fn, f, x, ...) {_fn(x, f); z_rep_8(_fn, f, ##__VA_ARGS__)}
+#define z_rep_10(_fn, f, x, ...) {_fn(x, f); z_rep_9(_fn, f, ##__VA_ARGS__)}
+#define z_rep_11(_fn, f, x, ...) {_fn(x, f); z_rep_10(_fn, f, ##__VA_ARGS__)}
+#define z_rep_12(_fn, f, x, ...) {_fn(x, f); z_rep_11(_fn, f, ##__VA_ARGS__)}
+#define z_rep_13(_fn, f, x, ...) {_fn(x, f); z_rep_12(_fn, f, ##__VA_ARGS__)}
+#define z_rep_14(_fn, f, x, ...) {_fn(x, f); z_rep_13(_fn, f, ##__VA_ARGS__)}
+#define z_rep_15(_fn, f, x, ...) {_fn(x, f); z_rep_14(_fn, f, ##__VA_ARGS__)}
+#define z_rep_16(_fn, f, x, ...) {_fn(x, f); z_rep_15(_fn, f, ##__VA_ARGS__)}
+#define z_rep_17(_fn, f, x, ...) {_fn(x, f); z_rep_16(_fn, f, ##__VA_ARGS__)}
+#define z_rep_18(_fn, f, x, ...) {_fn(x, f); z_rep_17(_fn, f, ##__VA_ARGS__)}
+#define z_rep_19(_fn, f, x, ...) {_fn(x, f); z_rep_18(_fn, f, ##__VA_ARGS__)}
+#define z_rep_20(_fn, f, x, ...) {_fn(x, f); z_rep_19(_fn, f, ##__VA_ARGS__)}
+
+
+#define Z_GET_ARG_2(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, \
+		   _14, _15, _16, _17, _18, _19, _20, N, ...) N
+
+#define FOR_EACH_FIXED_ARG(fixed_arg, x, ...) \
+	{Z_GET_ARG_2(__VA_ARGS__,				\
+		     z_rep_20, z_rep_19, z_rep_18, z_rep_17, z_rep_16,	\
+		     z_rep_15, z_rep_14, z_rep_13, z_rep_12, z_rep_11,	\
+		     z_rep_10, z_rep_9, z_rep_8, z_rep_7, z_rep_6,	\
+		     z_rep_5, z_rep_4, z_rep_3, z_rep_2, z_rep_1, z_rep_0) \
+	 (fixed_arg, x, ##__VA_ARGS__)}
+
 #endif /* ZEPHYR_INCLUDE_MISC_UTIL_H_ */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -682,25 +682,6 @@ void _init_thread_base(struct _thread_base *thread_base, int priority,
 	_init_thread_timeout(thread_base);
 }
 
-void k_thread_access_grant(struct k_thread *thread, ...)
-{
-#ifdef CONFIG_USERSPACE
-	va_list args;
-	va_start(args, thread);
-
-	while (true) {
-		void *object = va_arg(args, void *);
-		if (object == NULL) {
-			break;
-		}
-		k_object_access_grant(object, thread);
-	}
-	va_end(args);
-#else
-	ARG_UNUSED(thread);
-#endif
-}
-
 FUNC_NORETURN void k_thread_user_mode_enter(k_thread_entry_t entry,
 					    void *p1, void *p2, void *p3)
 {

--- a/samples/userspace/shared_mem/src/main.c
+++ b/samples/userspace/shared_mem/src/main.c
@@ -102,7 +102,7 @@ void main(void)
 
 	k_tid_t tPT, tENC, tCT;
 
-	k_thread_access_grant(k_current_get(), &allforone, NULL);
+	k_thread_access_grant(k_current_get(), &allforone);
 	/* initialize the partition structures  */
 	FOR_EACH(appmem_init_part, part0, part1, part2, part3, part4);
 
@@ -117,7 +117,7 @@ void main(void)
 			(k_thread_entry_t)enc, NULL, NULL, NULL,
 			-1, K_USER,
 			K_FOREVER);
-	k_thread_access_grant(tENC, &allforone, NULL);
+	k_thread_access_grant(tENC, &allforone);
 	/* use K_FOREVER followed by k_thread_start*/
 	printk("ENC Thread Created %08X\n", (unsigned int) tENC);
 	appmem_init_domain_dom1(part2);
@@ -133,7 +133,7 @@ void main(void)
 			(k_thread_entry_t)pt, NULL, NULL, NULL,
 			-1, K_USER,
 			K_FOREVER);
-	k_thread_access_grant(tPT, &allforone, NULL);
+	k_thread_access_grant(tPT, &allforone);
 	printk("PT Thread Created %08X\n", (unsigned int) tPT);
 	appmem_init_domain_dom0(part0);
 	appmem_add_part_dom0(part1);
@@ -144,7 +144,7 @@ void main(void)
 			(k_thread_entry_t)ct, NULL, NULL, NULL,
 			-1, K_USER,
 			K_FOREVER);
-	k_thread_access_grant(tCT, &allforone, NULL);
+	k_thread_access_grant(tCT, &allforone);
 	printk("CT Thread Created %08X\n", (unsigned int) tCT);
 	appmem_init_domain_dom2(part4);
 	appmem_add_part_dom2(part3);

--- a/tests/benchmarks/timing_info/src/userspace_bench.c
+++ b/tests/benchmarks/timing_info/src/userspace_bench.c
@@ -236,7 +236,7 @@ void validation_overhead_user_thread(void *p1, void *p2, void *p3)
 void validation_overhead(void)
 {
 
-	k_thread_access_grant(k_current_get(), &test_sema, NULL);
+	k_thread_access_grant(k_current_get(), &test_sema);
 
 
 	k_thread_create(&my_thread_user, my_stack_area, STACK_SIZE,

--- a/tests/drivers/i2s/i2s_api/src/main.c
+++ b/tests/drivers/i2s/i2s_api/src/main.c
@@ -23,8 +23,7 @@ void test_main(void)
 
 	k_thread_access_grant(k_current_get(),
 			      &rx_0_mem_slab, &tx_0_mem_slab,
-			      &rx_1_mem_slab, &tx_1_mem_slab,
-			      NULL);
+			      &rx_1_mem_slab, &tx_1_mem_slab);
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
 	if (dev_i2s != NULL) {
 		k_object_access_grant(dev_i2s, k_current_get());

--- a/tests/kernel/alert/alert_api/src/main.c
+++ b/tests/kernel/alert/alert_api/src/main.c
@@ -492,7 +492,7 @@ void test_main(void)
 			      &thread_alerts[HANDLER_DEFAULT],
 			      &thread_alerts[HANDLER_IGNORE],
 			      &thread_alerts[HANDLER_0],
-			      &thread_alerts[HANDLER_1], NULL);
+			      &thread_alerts[HANDLER_1]);
 
 	k_alert_init(&thread_alerts[HANDLER_DEFAULT], K_ALERT_DEFAULT,
 		     PENDING_MAX);

--- a/tests/kernel/mem_pool/sys_mem_pool/src/main.c
+++ b/tests/kernel/mem_pool/sys_mem_pool/src/main.c
@@ -126,7 +126,7 @@ void test_sys_mem_pool_min_block_size(void)
 /*test case main entry*/
 void test_main(void)
 {
-	k_thread_access_grant(k_current_get(), &pool_mutex, NULL);
+	k_thread_access_grant(k_current_get(), &pool_mutex);
 	sys_mem_pool_init(&pool);
 
 	ztest_test_suite(test_sys_mem_pool_api,

--- a/tests/kernel/mem_protect/mem_protect/src/inherit.c
+++ b/tests/kernel/mem_protect/mem_protect/src/inherit.c
@@ -89,7 +89,7 @@ void test_permission_inheritance(void *p1, void *p2, void *p3)
 			      &inherit_sem,
 			      &inherit_mutex,
 			      &inherit_timer,
-			      &inherit_msgq, &test_1_stack, NULL);
+			      &inherit_msgq, &test_1_stack);
 
 	k_thread_create(&test_1_tid,
 			test_1_stack,

--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -59,7 +59,7 @@ void test_kobject_access_grant(void *p1, void *p2, void *p3)
 	k_thread_access_grant(k_current_get(),
 			      &kobject_sem,
 			      &kobject_mutex,
-			      random_sem_type, NULL);
+			      random_sem_type);
 
 	k_thread_user_mode_enter(kobject_user_tc1, NULL, NULL, NULL);
 
@@ -93,7 +93,7 @@ void test_syscall_invalid_kobject(void *p1, void *p2, void *p3)
 {
 	k_thread_access_grant(k_current_get(),
 			      &kobject_sem,
-			      &kobject_mutex, NULL);
+			      &kobject_mutex);
 
 	k_thread_user_mode_enter(kobject_user_tc2, NULL, NULL, NULL);
 
@@ -118,7 +118,7 @@ void kobject_user_tc3(void *p1, void *p2, void *p3)
 void test_thread_without_kobject_permission(void *p1, void *p2, void *p3)
 {
 	k_thread_access_grant(k_current_get(),
-			      &kobject_mutex, NULL);
+			      &kobject_mutex);
 
 	k_thread_user_mode_enter(kobject_user_tc3, NULL, NULL, NULL);
 
@@ -147,7 +147,7 @@ void kobject_user_test4(void *p1, void *p2, void *p3)
 void test_kobject_revoke_access(void *p1, void *p2, void *p3)
 {
 	k_thread_access_grant(k_current_get(),
-			      &kobject_sem, NULL);
+			      &kobject_sem);
 
 	k_thread_create(&kobject_test_4_tid,
 			kobject_stack_1,
@@ -204,7 +204,7 @@ void kobject_user_2_test5(void *p1, void *p2, void *p3)
 void test_kobject_grant_access_kobj(void *p1, void *p2, void *p3)
 {
 	k_thread_access_grant(k_current_get(),
-			      &kobject_sem, &kobject_test_reuse_2_tid, NULL);
+			      &kobject_sem, &kobject_test_reuse_2_tid);
 
 	k_thread_create(&kobject_test_reuse_1_tid,
 			kobject_stack_1,
@@ -255,7 +255,7 @@ void kobject_user_test6(void *p1, void *p2, void *p3)
 void test_kobject_grant_access_kobj_invalid(void *p1, void *p2, void *p3)
 {
 	k_thread_access_grant(k_current_get(),
-			      &kobject_sem, NULL);
+			      &kobject_sem);
 
 	k_thread_create(&kobject_test_6_tid,
 			kobject_stack_3,
@@ -294,7 +294,7 @@ void kobject_user_test7(void *p1, void *p2, void *p3)
 void test_kobject_release_from_user(void *p1, void *p2, void *p3)
 {
 	k_thread_access_grant(k_current_get(),
-			      &kobject_sem, NULL);
+			      &kobject_sem);
 
 	k_thread_create(&kobject_test_7_tid,
 			kobject_stack_1,
@@ -394,7 +394,7 @@ void test_thread_has_residual_permissions(void *p1, void *p2, void *p3)
 {
 
 	k_thread_access_grant(k_current_get(),
-			      &kobject_sem, NULL);
+			      &kobject_sem);
 
 	k_thread_create(&kobject_test_9_tid,
 			kobject_stack_1,
@@ -503,7 +503,7 @@ void test_access_kobject_without_init_with_access(void *p1,
 						  void *p2, void *p3)
 {
 	k_thread_access_grant(k_current_get(),
-			      &kobject_sem_no_init_access, NULL);
+			      &kobject_sem_no_init_access);
 
 	k_thread_create(&kobject_test_13_tid,
 			kobject_stack_1,
@@ -589,7 +589,7 @@ void test_create_new_thread_from_user(void *p1, void *p2, void *p3)
 
 	k_thread_access_grant(&kobject_test_reuse_3_tid,
 			      &kobject_test_reuse_4_tid,
-			      &kobject_stack_2, NULL);
+			      &kobject_stack_2);
 
 	k_thread_create(&kobject_test_reuse_3_tid,
 			kobject_stack_1,
@@ -639,7 +639,7 @@ void test_create_new_thread_from_user_no_access_stack(void *p1,
 {
 
 	k_thread_access_grant(&kobject_test_reuse_5_tid,
-			      &kobject_test_reuse_6_tid, NULL);
+			      &kobject_test_reuse_6_tid);
 
 	k_thread_create(&kobject_test_reuse_5_tid,
 			kobject_stack_1,
@@ -689,7 +689,7 @@ void test_create_new_thread_from_user_invalid_stacksize(void *p1,
 
 	k_thread_access_grant(&kobject_test_reuse_1_tid,
 			      &kobject_test_reuse_2_tid,
-			      &kobject_stack_3, NULL);
+			      &kobject_stack_3);
 
 	k_thread_create(&kobject_test_reuse_1_tid,
 			kobject_stack_3,
@@ -749,7 +749,7 @@ void test_create_new_thread_from_user_huge_stacksize(void *p1,
 
 	k_thread_access_grant(&kobject_test_reuse_3_tid,
 			      &kobject_test_reuse_4_tid,
-			      &kobject_stack_2, NULL);
+			      &kobject_stack_2);
 
 	k_thread_create(&kobject_test_reuse_3_tid,
 			kobject_stack_1,
@@ -801,7 +801,7 @@ void test_create_new_supervisor_thread_from_user(void *p1, void *p2, void *p3)
 {
 	k_thread_access_grant(&kobject_test_reuse_7_tid,
 			      &kobject_test_reuse_8_tid,
-			      &kobject_stack_2, NULL);
+			      &kobject_stack_2);
 
 	k_thread_create(&kobject_test_reuse_7_tid,
 			kobject_stack_1,
@@ -847,7 +847,7 @@ void test_create_new_essential_thread_from_user(void *p1, void *p2, void *p3)
 {
 	k_thread_access_grant(&kobject_test_reuse_1_tid,
 			      &kobject_test_reuse_2_tid,
-			      &kobject_stack_2, NULL);
+			      &kobject_stack_2);
 
 	k_thread_create(&kobject_test_reuse_1_tid,
 			kobject_stack_1,
@@ -896,7 +896,7 @@ void test_create_new_higher_prio_thread_from_user(void *p1, void *p2, void *p3)
 {
 	k_thread_access_grant(&kobject_test_reuse_3_tid,
 			      &kobject_test_reuse_4_tid,
-			      &kobject_stack_2, NULL);
+			      &kobject_stack_2);
 
 	k_thread_create(&kobject_test_reuse_3_tid,
 			kobject_stack_1,
@@ -945,7 +945,7 @@ void test_create_new_invalid_prio_thread_from_user(void *p1, void *p2, void *p3)
 {
 	k_thread_access_grant(&kobject_test_reuse_5_tid,
 			      &kobject_test_reuse_6_tid,
-			      &kobject_stack_2, NULL);
+			      &kobject_stack_2);
 
 
 	k_thread_create(&kobject_test_reuse_5_tid,

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -721,8 +721,7 @@ void test_main(void)
 			      &kthread_thread, &kthread_stack,
 			      &uthread_thread, &uthread_stack,
 			      &uthread_start_sem, &uthread_end_sem,
-			      &test_revoke_sem, &kpipe, &expect_fault_sem,
-			      NULL);
+			      &test_revoke_sem, &kpipe, &expect_fault_sem);
 	ztest_test_suite(userspace,
 			 ztest_user_unit_test(is_usermode),
 			 ztest_user_unit_test(write_control),

--- a/tests/kernel/msgq/msgq_api/src/main.c
+++ b/tests/kernel/msgq/msgq_api/src/main.c
@@ -55,7 +55,7 @@ K_THREAD_STACK_EXTERN(tstack);
 void test_main(void)
 {
 	k_thread_access_grant(k_current_get(), &kmsgq, &msgq, &end_sema,
-			      &tdata, &tstack, NULL);
+			      &tdata, &tstack);
 
 	k_thread_resource_pool_assign(k_current_get(), &test_pool);
 

--- a/tests/kernel/mutex/mutex/src/main.c
+++ b/tests/kernel/mutex/mutex/src/main.c
@@ -382,8 +382,8 @@ void test_main(void)
 {
 	k_thread_access_grant(k_current_get(), &private_mutex,
 			      &mutex_1, &mutex_2, &mutex_3, &mutex_4,
-			      &thread_12_thread_data, &thread_12_stack_area,
-			      NULL);
+			      &thread_12_thread_data, &thread_12_stack_area);
+
 	ztest_test_suite(mutex_complex, ztest_user_unit_test(test_mutex));
 	ztest_run_test_suite(mutex_complex);
 }

--- a/tests/kernel/pipe/pipe/src/main.c
+++ b/tests/kernel/pipe/pipe/src/main.c
@@ -26,8 +26,7 @@ void test_main(void)
 	k_thread_access_grant(k_current_get(),
 			      &test_pipe, &put_sem, &get_sem,
 			      &sync_sem, &multiple_send_sem,
-			      &get_single_tid, &stack_1,
-			      NULL);
+			      &get_single_tid, &stack_1);
 
 	ztest_test_suite(test_pipe,
 			 ztest_user_unit_test(test_pipe_on_single_elements),

--- a/tests/kernel/pipe/pipe_api/src/main.c
+++ b/tests/kernel/pipe/pipe_api/src/main.c
@@ -56,7 +56,7 @@ void test_main(void)
 {
 	k_thread_access_grant(k_current_get(), &pipe,
 			      &kpipe, &end_sema, &tdata, &tstack,
-			      &khalfpipe, &put_get_pipe, NULL);
+			      &khalfpipe, &put_get_pipe);
 
 	k_thread_resource_pool_assign(k_current_get(), &test_pool);
 

--- a/tests/kernel/poll/src/test_poll.c
+++ b/tests/kernel/poll/src/test_poll.c
@@ -596,6 +596,5 @@ void test_poll_grant_access(void)
 			      &wait_signal, &poll_wait_helper_thread,
 			      &poll_wait_helper_stack, &multi_sem,
 			      &multi_reply, &multi_thread, &multi_stack,
-			      &multi_thread_lowprio, &multi_stack_lowprio,
-			      NULL);
+			      &multi_thread_lowprio, &multi_stack_lowprio);
 }

--- a/tests/kernel/semaphore/sema_api/src/main.c
+++ b/tests/kernel/semaphore/sema_api/src/main.c
@@ -133,8 +133,7 @@ void test_sema_count_get(void)
 /*test case main entry*/
 void test_main(void)
 {
-	k_thread_access_grant(k_current_get(), &ksema, &tdata, &sema, &tstack,
-			      NULL);
+	k_thread_access_grant(k_current_get(), &ksema, &tdata, &sema, &tstack);
 
 	ztest_test_suite(sema_api,
 			 ztest_user_unit_test(test_sema_thread2thread),

--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -764,8 +764,7 @@ void test_main(void)
 			      &simple_sem, &multiple_thread_sem,
 			      &low_prio_sem, &mid_prio_sem, &high_prio_sem,
 			      &stack_1, &stack_2, &stack_3, &timeout_info_pipe,
-			      &sem_tid, &sem_tid_1, &sem_tid_2,
-			      NULL);
+			      &sem_tid, &sem_tid_1, &sem_tid_2);
 
 	ztest_test_suite(test_semaphore,
 			 ztest_unit_test(test_simple_sem_from_isr),

--- a/tests/kernel/stack/stack_api/src/main.c
+++ b/tests/kernel/stack/stack_api/src/main.c
@@ -41,7 +41,7 @@ K_THREAD_STACK_EXTERN(threadstack);
 void test_main(void)
 {
 	k_thread_access_grant(k_current_get(), &kstack, &stack, &thread_data,
-			      &end_sema, &threadstack, NULL);
+			      &end_sema, &threadstack);
 
 	k_thread_resource_pool_assign(k_current_get(), &test_pool);
 

--- a/tests/kernel/stack/stack_usage/src/main.c
+++ b/tests/kernel/stack/stack_usage/src/main.c
@@ -241,7 +241,7 @@ static void test_isr_stack_play(void)
 void test_main(void)
 {
 	k_thread_access_grant(k_current_get(), &stack1, &stack2, &thread_data,
-			      &end_sema, &threadstack, NULL);
+			      &end_sema, &threadstack);
 
 	ztest_test_suite(test_stack_usage,
 			 ztest_user_unit_test(test_single_stack_play),

--- a/tests/kernel/threads/dynamic_thread/src/main.c
+++ b/tests/kernel/threads/dynamic_thread/src/main.c
@@ -26,8 +26,7 @@ static void dyn_thread_entry(void *p1, void *p2, void *p3)
 static void prep(void)
 {
 	k_thread_access_grant(k_current_get(), dyn_thread_stack,
-			      &start_sem, &end_sem,
-			      NULL);
+			      &start_sem, &end_sem);
 }
 
 static void create_dynamic_thread(void)

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -200,8 +200,8 @@ void test_user_mode(void)
 
 void test_main(void)
 {
-	k_thread_access_grant(k_current_get(), &tdata, tstack, NULL);
-	k_thread_access_grant(k_current_get(), &tdata_custom, tstack_custom, NULL);
+	k_thread_access_grant(k_current_get(), &tdata, tstack);
+	k_thread_access_grant(k_current_get(), &tdata_custom, tstack_custom);
 	main_prio = k_thread_priority_get(k_current_get());
 
 	ztest_test_suite(threads_lifecycle,

--- a/tests/kernel/threads/thread_init/src/main.c
+++ b/tests/kernel/threads/thread_init/src/main.c
@@ -206,7 +206,7 @@ void test_kinit_coop_thread(void)
 void test_main(void)
 {
 	k_thread_access_grant(k_current_get(), &thread_preempt, &stack_preempt,
-			      &start_sema, &end_sema, NULL);
+			      &start_sema, &end_sema);
 
 	ztest_test_suite(thread_init,
 			 ztest_user_unit_test(test_kdefine_preempt_thread),

--- a/tests/kernel/workq/work_queue_api/src/main.c
+++ b/tests/kernel/workq/work_queue_api/src/main.c
@@ -509,7 +509,7 @@ void test_main(void)
 	main_thread = k_current_get();
 	k_thread_access_grant(main_thread, &sync_sema, &user_workq.thread,
 			      &user_workq.queue,
-			      &user_tstack, NULL);
+			      &user_tstack);
 	k_sem_init(&sync_sema, 0, NUM_OF_WORK);
 	k_thread_system_pool_assign(k_current_get());
 


### PR DESCRIPTION
This API was using variable number of arguments. Which is not
allowed according to misra c guidelines. Hence making this API
into a macro and using the util macro FOR_EACH_FIXED_ARG to get
the same functionality.

There is one deviation from the old function. The last argument
shouldn't be NULL. If it is NULL the code will fault.