### PR TITLE
doc: usb: Move API documentation to usb_api

### DIFF
--- a/doc/api/usb_api.rst
+++ b/doc/api/usb_api.rst
@@ -8,6 +8,25 @@ USB subsystem API
    :local:
    :backlinks: top
 
+There are two ways to transmit data, using the 'low' level read/write API or
+the 'high' level transfer API.
+
+Low level API
+  To transmit data to the host, the class driver should call usb_write().
+  Upon completion the registered endpoint callback will be called. Before
+  sending another packet the class driver should wait for the completion of
+  the previous write. When data is received, the registered endpoint callback
+  is called. usb_read() should be used for retrieving the received data.
+  For CDC ACM sample driver this happens via the OUT bulk endpoint handler
+  (cdc_acm_bulk_out) mentioned in the endpoint array (cdc_acm_ep_data).
+
+High level API
+  The usb_transfer method can be used to transfer data to/from the host. The
+  transfer API will automatically split the data transmission into one or more
+  USB transaction(s), depending endpoint max packet size. The class driver does
+  not have to implement endpoint callback and should set this callback to the
+  generic usb_transfer_ep_callback.
+
 USB Device Controller API
 *************************
 

--- a/doc/subsystems/usb/usb.rst
+++ b/doc/subsystems/usb/usb.rst
@@ -111,27 +111,6 @@ the vendor requests:
 The class driver waits for the :makevar:`USB_DC_CONFIGURED` device status code
 before transmitting any data.
 
-There are two ways to transmit data, using the 'low' level read/write API or
-the 'high' level transfer API.
-
-low level API:
-
-To transmit data to the host, the class driver should call usb_write().
-Upon completion the registered endpoint callback will be called. Before
-sending another packet the class driver should wait for the completion of
-the previous write. When data is received, the registered endpoint callback
-is called. usb_read() should be used for retrieving the received data.
-For CDC ACM sample driver this happens via the OUT bulk endpoint handler
-(cdc_acm_bulk_out) mentioned in the endpoint array (cdc_acm_ep_data).
-
-high level API:
-
-The usb_transfer method can be used to transfer data to/from the host. The
-transfer API will automatically split the data transmission into one or more
-USB transaction(s), depending endpoint max packet size. The class driver does
-not have to implement endpoint callback and should set this callback to the
-generic usb_transfer_ep_callback.
-
 Further reading
 ***************
 


### PR DESCRIPTION
Move API documentation text to the right place.