### PR TITLE
boards: arm: stm32: Fix openocd warning

### DIFF
--- a/boards/arm/96b_stm32_sensor_mez/support/openocd.cfg
+++ b/boards/arm/96b_stm32_sensor_mez/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2-1.cfg]
+source [find interface/stlink.cfg]
 
 transport select hla_swd
 

--- a/boards/arm/b_l072z_lrwan1/support/openocd.cfg
+++ b/boards/arm/b_l072z_lrwan1/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2-1.cfg]
+source [find interface/stlink.cfg]
 
 transport select hla_swd
 

--- a/boards/arm/disco_l475_iot1/support/openocd.cfg
+++ b/boards/arm/disco_l475_iot1/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2-1.cfg]
+source [find interface/stlink.cfg]
 
 transport select hla_swd
 

--- a/boards/arm/nucleo_f207zg/support/openocd.cfg
+++ b/boards/arm/nucleo_f207zg/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2-1.cfg]
+source [find interface/stlink.cfg]
 source [find target/stm32f2x.cfg]
 
 $_TARGETNAME configure -event gdb-attach {

--- a/boards/arm/nucleo_l053r8/support/openocd.cfg
+++ b/boards/arm/nucleo_l053r8/support/openocd.cfg
@@ -1,6 +1,6 @@
 # This is an ST NUCLEO-L053R8 board with single STM32L053R8 chip.
 # http://www.st.com/en/evaluation-tools/nucleo-l053r8.html
-source [find interface/stlink-v2-1.cfg]
+source [find interface/stlink.cfg]
 
 transport select hla_swd
 

--- a/boards/arm/nucleo_l073rz/support/openocd.cfg
+++ b/boards/arm/nucleo_l073rz/support/openocd.cfg
@@ -1,6 +1,6 @@
 # This is an ST NUCLEO-L073RZ board with single STM32L073RZ chip.
 # http://www.st.com/en/evaluation-tools/nucleo-l073rz.html
-source [find interface/stlink-v2-1.cfg]
+source [find interface/stlink.cfg]
 
 transport select hla_swd
 

--- a/boards/arm/nucleo_l432kc/support/openocd.cfg
+++ b/boards/arm/nucleo_l432kc/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2-1.cfg]
+source [find interface/stlink.cfg]
 
 transport select hla_swd
 

--- a/boards/arm/olimex_stm32_e407/support/openocd.cfg
+++ b/boards/arm/olimex_stm32_e407/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 
 set WORKAREASIZE 0x10000
 

--- a/boards/arm/olimex_stm32_p405/support/openocd.cfg
+++ b/boards/arm/olimex_stm32_p405/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 
 set WORKAREASIZE 0x10000
 

--- a/boards/arm/stm32_min_dev/support/openocd.cfg
+++ b/boards/arm/stm32_min_dev/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 
 # Work-area size (RAM size) = 20kB
 set WORKAREASIZE 0x5000


### PR DESCRIPTION
    boards: arm: stm32: Fix openocd warning
    
    interface/stlink-v2-1.cfg and interface/stlink-v2.cfg are wrappers
    around interface/stlink.cfg, their inclusion trigger warning which
    this change addresses. Besides the warning there is nothing there
    except sourcing iterface/stlink.cfg directly.
    
    Signed-off-by: Vasili Slapik <vslapik@gmail.com>

    Warnings are below:
    "WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg"
    "WARNING: interface/stlink-v2.cfg is deprecated, please switch to interface/stlink.cfg"

