### PR TITLE
libc: riscv: Fix the RISC-V ifdef

### DIFF
--- a/lib/libc/minimal/include/sys/types.h
+++ b/lib/libc/minimal/include/sys/types.h
@@ -28,7 +28,7 @@ typedef int off_t;
 typedef int off_t;
 #elif defined(__NIOS2__)
 typedef int off_t;
-#elif defined(__riscv__)
+#elif defined(__riscv)
 typedef int off_t;
 #elif defined(__XTENSA__)
 typedef int off_t;


### PR DESCRIPTION
Following the standard GCC RISC-V convetion use __riscv for the RISC-V
specific define:
https://github.com/gcc-mirror/gcc/blob/41d6b10e96a1de98e90a7c0378437c3255814b16/gcc/config/riscv/riscv-c.c#L37

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>