### PR TITLE
doc: Missing API documentation

### DIFF
--- a/doc/api/display_api.rst
+++ b/doc/api/display_api.rst
@@ -1,5 +1,9 @@
 .. _display_api:
 
+.. comment
+   not documenting
+   .. doxygengroup:: display_interfaces
+
 Display Interface APIs
 ######################
 

--- a/doc/api/display_api.rst
+++ b/doc/api/display_api.rst
@@ -20,3 +20,9 @@ BBC micro:bit Display
 
 .. doxygengroup:: mb_display
    :project: Zephyr
+
+Monochrome Character Framebuffer
+********************************
+
+.. doxygengroup:: monochrome_character_framebuffer
+   :project: Zephyr

--- a/doc/api/networking.rst
+++ b/doc/api/networking.rst
@@ -78,6 +78,18 @@ BSD Sockets compatible API
 .. doxygengroup:: bsd_sockets
    :project: Zephyr
 
+Network configuration library
+*****************************
+
+.. doxygengroup:: net_config
+   :project: Zephyr
+
+Network long timeout support
+****************************
+
+.. doxygengroup:: net_timeout
+   :project: Zephyr
+
 Network offloading support
 **************************
 
@@ -88,6 +100,18 @@ Network statistics
 ******************
 
 .. doxygengroup:: net_stats
+   :project: Zephyr
+
+Precision Time Protocol time
+****************************
+
+.. doxygengroup:: ptp_time
+   :project: Zephyr
+
+Promiscuous mode support
+************************
+
+.. doxygengroup:: promiscuous
    :project: Zephyr
 
 Trickle timer support

--- a/include/display/cfb.h
+++ b/include/display/cfb.h
@@ -21,7 +21,7 @@ extern "C" {
 
 /**
  * @brief Display Drivers
- * @defgroup display_interfaces Display Drivers
+ * @addtogroup display_interfaces Display Drivers
  * @{
  * @}
  */

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -52,7 +52,8 @@ struct zsock_pollfd {
  */
 #define SOL_TLS 282
 
-/** @defgroup secure_sockets_options Socket options for TLS
+/**
+ *  @defgroup secure_sockets_options Socket options for TLS
  *  @{
  */
 


### PR DESCRIPTION
As mentioned in issue #12265, some APIs aren't included in the generated
API docs because a doxygengroup directive was missing.   This PR adds missing display and networking APIs.
