### PR TITLE
net/icmpv4: A checksum value of 0 is valid

### DIFF
--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -338,7 +338,7 @@ enum net_verdict net_icmpv4_input(struct net_pkt *pkt, bool bcast)
 		return NET_DROP;
 	}
 
-	if (!icmp_hdr.chksum || net_calc_chksum_icmpv4(pkt) != 0) {
+	if (net_calc_chksum_icmpv4(pkt) != 0) {
 		NET_DBG("DROP: Invalid checksum");
 		goto drop;
 	}


### PR DESCRIPTION
Introduced by commit id de78a7af28.
If the sum is 0xffff, a ~sum will give 0.

Fixes #12164

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>