### PR TITLE
cmake: Use variables for target names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ check_c_compiler_flag("" toolchain_is_ok)
 assert(toolchain_is_ok "The toolchain is unable to build a dummy C file. See CMakeError.log.")
 
 set(CMAKE_EXECUTABLE_SUFFIX .elf)
+set(ZEPHYR_PREBUILT_EXECUTABLE zephyr_prebuilt)
 
 if(NOT PROPERTY_LINKER_SCRIPT_DEFINES)
   set_property(GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__GCC_LINKER_CMD__)
@@ -841,7 +842,7 @@ if(CONFIG_GEN_ISR_TABLES)
     list(APPEND GEN_ISR_TABLE_EXTRA_ARG --vector-table)
   endif()
 
-  # isr_tables.c is generated from zephyr_prebuilt by
+  # isr_tables.c is generated from ${ZEPHYR_PREBUILT_EXECUTABLE} by
   # gen_isr_tables.py
   add_custom_command(
     OUTPUT isr_tables.c
@@ -849,17 +850,17 @@ if(CONFIG_GEN_ISR_TABLES)
     -I ${OUTPUT_FORMAT}
     -O binary
     --only-section=.intList
-    $<TARGET_FILE:zephyr_prebuilt>
+    $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
     isrList.bin
     COMMAND ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/arch/common/gen_isr_tables.py
     --output-source isr_tables.c
-    --kernel $<TARGET_FILE:zephyr_prebuilt>
+    --kernel $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
     --intlist isrList.bin
     $<$<BOOL:${CONFIG_BIG_ENDIAN}>:--big-endian>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--debug>
     ${GEN_ISR_TABLE_EXTRA_ARG}
-    DEPENDS zephyr_prebuilt
+    DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
     )
   set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_SOURCE_FILES isr_tables.c)
 endif()
@@ -921,7 +922,7 @@ if(CONFIG_ARM AND CONFIG_USERSPACE)
   # elf file.
 
   # Use the script GEN_PRIV_STACKS to scan the kernel binary's
-  # (zephyr_prebuilt) DWARF information to produce a table of kernel
+  # (${ZEPHYR_PREBUILT_EXECUTABLE}) DWARF information to produce a table of kernel
   # objects (PRIV_STACKS) which we will then pass to gperf
   add_custom_command(
     OUTPUT ${PRIV_STACKS}
@@ -1040,17 +1041,17 @@ if(CONFIG_USERSPACE)
   # elf file.
 
   # Use the script GEN_KOBJ_LIST to scan the kernel binary's
-  # (zephyr_prebuilt) DWARF information to produce a table of kernel
+  # (${ZEPHYR_PREBUILT_EXECUTABLE}) DWARF information to produce a table of kernel
   # objects (OBJ_LIST) which we will then pass to gperf
   add_custom_command(
     OUTPUT ${OBJ_LIST}
     COMMAND
     ${PYTHON_EXECUTABLE}
     ${GEN_KOBJ_LIST}
-    --kernel $<TARGET_FILE:zephyr_prebuilt>
+    --kernel $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
     --gperf-output ${OBJ_LIST}
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-    DEPENDS zephyr_prebuilt
+    DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   add_custom_target(obj_list DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${OBJ_LIST})
@@ -1262,10 +1263,10 @@ endif()
 endif()
 
 # FIXME: Is there any way to get rid of empty_file.c?
-add_executable(       zephyr_prebuilt misc/empty_file.c)
-target_link_libraries(zephyr_prebuilt ${TOPT} ${PROJECT_BINARY_DIR}/linker.cmd ${PRIV_STACK_LIB} ${zephyr_lnk} ${CODE_RELOCATION_DEP})
-set_property(TARGET   zephyr_prebuilt PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker.cmd)
-add_dependencies(     zephyr_prebuilt ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP} linker_script offsets)
+add_executable(       ${ZEPHYR_PREBUILT_EXECUTABLE} misc/empty_file.c)
+target_link_libraries(${ZEPHYR_PREBUILT_EXECUTABLE} ${TOPT} ${PROJECT_BINARY_DIR}/linker.cmd ${PRIV_STACK_LIB} ${zephyr_lnk} ${CODE_RELOCATION_DEP})
+set_property(TARGET   ${ZEPHYR_PREBUILT_EXECUTABLE} PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker.cmd)
+add_dependencies(     ${ZEPHYR_PREBUILT_EXECUTABLE} ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP} linker_script offsets)
 
 
 if(GKOF OR GKSF)
@@ -1284,7 +1285,7 @@ if(GKOF OR GKSF)
     DEPENDS
     ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP}
     ${CODE_RELOCATION_DEP}
-    zephyr_prebuilt
+    ${ZEPHYR_PREBUILT_EXECUTABLE}
     linker_pass_final.cmd
     offsets_h
     )
@@ -1299,7 +1300,7 @@ if(GKOF OR GKSF)
   set_property(TARGET   kernel_elf PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker_pass_final.cmd)
   add_dependencies(     kernel_elf ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP} linker_pass_final_script)
 else()
-  set(logical_target_for_zephyr_elf zephyr_prebuilt)
+  set(logical_target_for_zephyr_elf ${ZEPHYR_PREBUILT_EXECUTABLE})
   # Use the prebuilt elf as the final elf since we don't have a
   # generation stage.
 endif()
@@ -1410,7 +1411,7 @@ if(CONFIG_OUTPUT_PRINT_MEMORY_USAGE)
   zephyr_check_compiler_flag(C "" ${check})
   set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
 
-  target_link_libraries_ifdef(${check} zephyr_prebuilt ${option})
+  target_link_libraries_ifdef(${check} ${ZEPHYR_PREBUILT_EXECUTABLE} ${option})
 endif()
 
 if(EMU_PLATFORM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,14 @@ assert(toolchain_is_ok "The toolchain is unable to build a dummy C file. See CMa
 set(CMAKE_EXECUTABLE_SUFFIX .elf)
 set(ZEPHYR_PREBUILT_EXECUTABLE zephyr_prebuilt)
 
+set(OFFSETS_H_TARGET           offsets_h)
+set(SYSCALL_MACROS_H_TARGET    syscall_macros_h_target)
+set(SYSCALL_LIST_H_TARGET      syscall_list_h_target)
+set(DRIVER_VALIDATION_H_TARGET driver_validation_h_target)
+set(KOBJ_TYPES_H_TARGET        kobj_types_h_target)
+set(LINKER_SCRIPT_TARGET       linker_script_target)
+
+
 if(NOT PROPERTY_LINKER_SCRIPT_DEFINES)
   set_property(GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__GCC_LINKER_CMD__)
 endif()
@@ -501,7 +509,7 @@ add_subdirectory(tests)
 
 set(syscall_macros_h ${ZEPHYR_BINARY_DIR}/include/generated/syscall_macros.h)
 
-add_custom_target(syscall_macros_h_target DEPENDS ${syscall_macros_h})
+add_custom_target(${SYSCALL_MACROS_H_TARGET} DEPENDS ${syscall_macros_h})
 add_custom_command(                       OUTPUT  ${syscall_macros_h}
   COMMAND
   ${PYTHON_EXECUTABLE}
@@ -604,7 +612,7 @@ add_custom_command(
   DEPENDS ${syscalls_subdirs_trigger} ${PARSE_SYSCALLS_HEADER_DEPENDS}
   )
 
-add_custom_target(syscall_list_h_target DEPENDS                ${syscall_list_h})
+add_custom_target(${SYSCALL_LIST_H_TARGET} DEPENDS             ${syscall_list_h})
 add_custom_command(OUTPUT include/generated/syscall_dispatch.c ${syscall_list_h}
   # Also, some files are written to include/generated/syscalls/
   COMMAND
@@ -628,7 +636,7 @@ add_custom_command(
   $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
-add_custom_target(driver_validation_h_target DEPENDS ${DRV_VALIDATION})
+add_custom_target(${DRIVER_VALIDATION_H_TARGET} DEPENDS ${DRV_VALIDATION})
 
 include($ENV{ZEPHYR_BASE}/cmake/kobj.cmake)
 gen_kobj(KOBJ_INCLUDE_PATH)
@@ -636,17 +644,19 @@ gen_kobj(KOBJ_INCLUDE_PATH)
 # Generate offsets.c.obj from offsets.c
 # Generate offsets.h     from offsets.c.obj
 
+set(OFFSETS_LIB offsets)
+
 set(OFFSETS_C_PATH ${ZEPHYR_BASE}/arch/${ARCH}/core/offsets/offsets.c)
-set(OFFSETS_O_PATH ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/offsets.dir/arch/${ARCH}/core/offsets/offsets.c.obj)
+set(OFFSETS_O_PATH ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${OFFSETS_LIB}.dir/arch/${ARCH}/core/offsets/offsets.c.obj)
 set(OFFSETS_H_PATH ${PROJECT_BINARY_DIR}/include/generated/offsets.h)
 
-add_library(          offsets STATIC ${OFFSETS_C_PATH})
-target_link_libraries(offsets zephyr_interface)
-add_dependencies(     offsets
-  syscall_list_h_target
-  syscall_macros_h_target
-  driver_validation_h_target
-  kobj_types_h_target
+add_library(          ${OFFSETS_LIB} STATIC ${OFFSETS_C_PATH})
+target_link_libraries(${OFFSETS_LIB} zephyr_interface)
+add_dependencies(     ${OFFSETS_LIB}
+  ${SYSCALL_LIST_H_TARGET}
+  ${SYSCALL_MACROS_H_TARGET}
+  ${DRIVER_VALIDATION_H_TARGET}
+  ${KOBJ_TYPES_H_TARGET}
   )
 
 add_custom_command(
@@ -654,9 +664,9 @@ add_custom_command(
   COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/gen_offset_header.py
   -i ${OFFSETS_O_PATH}
   -o ${OFFSETS_H_PATH}
-  DEPENDS offsets
+  DEPENDS ${OFFSETS_LIB}
 )
-add_custom_target(offsets_h DEPENDS ${OFFSETS_H_PATH})
+add_custom_target(${OFFSETS_H_TARGET} DEPENDS ${OFFSETS_H_PATH})
 
 zephyr_include_directories(${TOOLCHAIN_INCLUDES})
 
@@ -669,7 +679,7 @@ get_property(ZEPHYR_LIBS_PROPERTY GLOBAL PROPERTY ZEPHYR_LIBS)
 
 foreach(zephyr_lib ${ZEPHYR_LIBS_PROPERTY})
   # TODO: Could this become an INTERFACE property of zephyr_interface?
-  add_dependencies(${zephyr_lib} offsets_h)
+  add_dependencies(${zephyr_lib} ${OFFSETS_H_TARGET})
 
   # Verify that all (non-imported) libraries have source
   # files. Libraries without source files are not supported because
@@ -797,16 +807,16 @@ add_custom_command(
 )
 
 add_custom_target(
-  linker_script
+  ${LINKER_SCRIPT_TARGET}
   DEPENDS
   ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP}
   ${APP_SMEM_DEP}
   ${CODE_RELOCATION_DEP}
   linker.cmd
-  offsets_h
+  ${OFFSETS_H_TARGET}
   )
 
-# Give the 'linker_script' target all of the include directories so
+# Give the '${LINKER_SCRIPT_TARGET}' target all of the include directories so
 # that cmake can successfully find the linker_script's header
 # dependencies.
 zephyr_get_include_directories_for_lang(C
@@ -814,7 +824,7 @@ zephyr_get_include_directories_for_lang(C
   STRIP_PREFIX # Don't use a -I prefix
   )
 set_property(TARGET
-  linker_script
+  ${LINKER_SCRIPT_TARGET}
   PROPERTY INCLUDE_DIRECTORIES
   ${ZEPHYR_INCLUDE_DIRS}
   )
@@ -1200,7 +1210,7 @@ if(CONFIG_CPU_HAS_MPU AND CONFIG_USERSPACE)
       linker_app_sizing_script
       DEPENDS
       linker_app_sizing.cmd
-      offsets_h
+      ${OFFSETS_H_TARGET}
       ${APP_SMEM_DEP}
       ${CODE_RELOCATION_DEP}
     )
@@ -1219,7 +1229,7 @@ if(CONFIG_CPU_HAS_MPU AND CONFIG_USERSPACE)
     add_executable(       app_sizing_prebuilt misc/empty_file.c)
     target_link_libraries(app_sizing_prebuilt ${TOPT} ${PROJECT_BINARY_DIR}/linker_app_sizing.cmd ${zephyr_lnk} ${CODE_RELOCATION_DEP})
     set_property(TARGET   app_sizing_prebuilt PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker_app_sizing.cmd)
-    add_dependencies(     app_sizing_prebuilt linker_app_sizing_script offsets ${CODE_RELOCATION_DEP} )
+    add_dependencies(     app_sizing_prebuilt linker_app_sizing_script ${OFFSETS_LIB} ${CODE_RELOCATION_DEP} )
 
     add_custom_command(
       TARGET app_sizing_prebuilt
@@ -1244,7 +1254,7 @@ if(CONFIG_ARM)
     ${ALIGN_SIZING_DEP} ${APP_SMEM_DEP}
     ${CODE_RELOCATION_DEP}
     linker_priv_stacks.cmd
-    offsets_h
+    ${OFFSETS_H_TARGET}
     )
 
   set_property(TARGET
@@ -1257,7 +1267,7 @@ if(CONFIG_ARM)
   add_executable(       priv_stacks_prebuilt misc/empty_file.c)
   target_link_libraries(priv_stacks_prebuilt ${TOPT} ${PROJECT_BINARY_DIR}/linker_priv_stacks.cmd ${zephyr_lnk} ${CODE_RELOCATION_DEP})
   set_property(TARGET   priv_stacks_prebuilt PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker_priv_stacks.cmd)
-  add_dependencies(     priv_stacks_prebuilt ${ALIGN_SIZING_DEP} linker_priv_stacks_script offsets)
+  add_dependencies(     priv_stacks_prebuilt ${ALIGN_SIZING_DEP} linker_priv_stacks_script ${OFFSETS_LIB})
 endif()
 
 endif()
@@ -1266,11 +1276,12 @@ endif()
 add_executable(       ${ZEPHYR_PREBUILT_EXECUTABLE} misc/empty_file.c)
 target_link_libraries(${ZEPHYR_PREBUILT_EXECUTABLE} ${TOPT} ${PROJECT_BINARY_DIR}/linker.cmd ${PRIV_STACK_LIB} ${zephyr_lnk} ${CODE_RELOCATION_DEP})
 set_property(TARGET   ${ZEPHYR_PREBUILT_EXECUTABLE} PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker.cmd)
-add_dependencies(     ${ZEPHYR_PREBUILT_EXECUTABLE} ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP} linker_script offsets)
+add_dependencies(     ${ZEPHYR_PREBUILT_EXECUTABLE} ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP} ${LINKER_SCRIPT_TARGET} ${OFFSETS_LIB})
 
 
 if(GKOF OR GKSF)
-  set(logical_target_for_zephyr_elf kernel_elf)
+  set(KERNEL_ELF kernel_elf)
+  set(logical_target_for_zephyr_elf ${KERNEL_ELF})
 
   # The second linker pass uses the same source linker script of the
   # first pass (LINKER_SCRIPT), but this time with a different output
@@ -1280,25 +1291,26 @@ if(GKOF OR GKSF)
     ${custom_command}
     )
 
+  set(LINKER_PASS_FINAL_SCRIPT_TARGET linker_pass_final_script_target)
   add_custom_target(
-    linker_pass_final_script
+    ${LINKER_PASS_FINAL_SCRIPT_TARGET}
     DEPENDS
     ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP}
     ${CODE_RELOCATION_DEP}
     ${ZEPHYR_PREBUILT_EXECUTABLE}
     linker_pass_final.cmd
-    offsets_h
+    ${OFFSETS_H_TARGET}
     )
   set_property(TARGET
-    linker_pass_final_script
+    ${LINKER_PASS_FINAL_SCRIPT_TARGET}
     PROPERTY INCLUDE_DIRECTORIES
     ${ZEPHYR_INCLUDE_DIRS}
   )
 
-  add_executable(       kernel_elf misc/empty_file.c ${GKSF})
-  target_link_libraries(kernel_elf ${GKOF} ${TOPT} ${PROJECT_BINARY_DIR}/linker_pass_final.cmd ${zephyr_lnk} ${CODE_RELOCATION_DEP})
-  set_property(TARGET   kernel_elf PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker_pass_final.cmd)
-  add_dependencies(     kernel_elf ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP} linker_pass_final_script)
+  add_executable(       ${KERNEL_ELF} misc/empty_file.c ${GKSF})
+  target_link_libraries(${KERNEL_ELF} ${GKOF} ${TOPT} ${PROJECT_BINARY_DIR}/linker_pass_final.cmd ${zephyr_lnk} ${CODE_RELOCATION_DEP})
+  set_property(TARGET   ${KERNEL_ELF} PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker_pass_final.cmd)
+  add_dependencies(     ${KERNEL_ELF} ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP} ${LINKER_PASS_FINAL_SCRIPT_TARGET})
 else()
   set(logical_target_for_zephyr_elf ${ZEPHYR_PREBUILT_EXECUTABLE})
   # Use the prebuilt elf as the final elf since we don't have a

--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -44,7 +44,7 @@ set(GENIDT ${ZEPHYR_BASE}/scripts/gen_idt.py)
 define_property(GLOBAL PROPERTY PROPERTY_OUTPUT_ARCH BRIEF_DOCS " " FULL_DOCS " ")
 
 # Use gen_idt.py and objcopy to generate irq_int_vector_map.o,
-# irq_vectors_alloc.o, and staticIdt.o from the elf file zephyr_prebuilt
+# irq_vectors_alloc.o, and staticIdt.o from the elf file ${ZEPHYR_PREBUILT_EXECUTABLE}
 set(gen_idt_output_files
   ${CMAKE_CURRENT_BINARY_DIR}/irq_int_vector_map.bin
   ${CMAKE_CURRENT_BINARY_DIR}/staticIdt.bin
@@ -60,12 +60,12 @@ add_custom_command(
   COMMAND
   ${PYTHON_EXECUTABLE}
   ${GENIDT}
-  --kernel $<TARGET_FILE:zephyr_prebuilt>
+  --kernel $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
   --output-idt staticIdt.bin
   --vector-map irq_int_vector_map.bin
   --output-vectors-alloc irq_vectors_alloc.bin
   ${GENIDT_EXTRA_ARGS}
-  DEPENDS zephyr_prebuilt
+  DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
@@ -137,10 +137,10 @@ set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_OBJECT_FILES irq_vectors_al
 
 if(CONFIG_X86_MMU)
   # Use gen_mmu.py and objcopy to generate mmu_tables.o from from the
-  # elf file zephyr_prebuilt, creating the temp files mmu_tables.bin
+  # elf file ${ZEPHYR_PREBUILT_EXECUTABLE}, creating the temp files mmu_tables.bin
   # and mmulist.bin along the way.
   #
-  # zephyr_prebuilt.elf -> mmulist.bin -> mmu_tables.bin -> mmu_tables.o
+  # ${ZEPHYR_PREBUILT_EXECUTABLE}.elf -> mmulist.bin -> mmu_tables.bin -> mmu_tables.o
   add_custom_command(
     OUTPUT mmulist.bin
     COMMAND
@@ -148,9 +148,9 @@ if(CONFIG_X86_MMU)
     -I ${OUTPUT_FORMAT}
     -O binary
     -j mmulist
-    $<TARGET_FILE:zephyr_prebuilt>
+    $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
     mmulist.bin
-    DEPENDS zephyr_prebuilt
+    DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   add_custom_command(
@@ -159,12 +159,12 @@ if(CONFIG_X86_MMU)
     ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/gen_mmu_x86.py
     -i mmulist.bin
-    -k $<TARGET_FILE:zephyr_prebuilt>
+    -k $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
     -o mmu_tables.bin
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:-v>
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS mmulist.bin
-    DEPENDS zephyr_prebuilt
+    DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
     )
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mmu_tables.o
@@ -189,19 +189,19 @@ endif()
 
 if(CONFIG_GDT_DYNAMIC)
   # Use gen_gdt.py and objcopy to generate gdt.o from from the elf
-  # file zephyr_prebuilt, creating the temp file gdt.bin along the
+  # file ${ZEPHYR_PREBUILT_EXECUTABLE}, creating the temp file gdt.bin along the
   # way.
   #
-  # zephyr_prebuilt.elf -> gdt.bin -> gdt.o
+  # ${ZEPHYR_PREBUILT_EXECUTABLE}.elf -> gdt.bin -> gdt.o
   add_custom_command(
     OUTPUT gdt.bin
     COMMAND
     ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/gen_gdt.py
-    --kernel $<TARGET_FILE:zephyr_prebuilt>
+    --kernel $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
     --output-gdt gdt.bin
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-    DEPENDS zephyr_prebuilt
+    DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   add_custom_command(

--- a/arch/x86_64/core/CMakeLists.txt
+++ b/arch/x86_64/core/CMakeLists.txt
@@ -61,7 +61,7 @@ set(qkernel_file ${CMAKE_BINARY_DIR}/zephyr-qemu.elf)
 add_custom_target(qemu_kernel_target DEPENDS ${qkernel_file})
 add_custom_command(
   OUTPUT ${qkernel_file}
-  DEPENDS zephyr_prebuilt
+  DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
   COMMAND ${CMAKE_OBJCOPY} -O binary ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf ${CMAKE_CURRENT_BINARY_DIR}/zephyr-qemu.bin
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/qemuinc.c ${CMAKE_CURRENT_BINARY_DIR}
   COMMAND ${CMAKE_C_COMPILER} -m32 -c ${CMAKE_CURRENT_BINARY_DIR}/qemuinc.c -o ${CMAKE_CURRENT_BINARY_DIR}/zephyr-qemu.o

--- a/cmake/kobj.cmake
+++ b/cmake/kobj.cmake
@@ -22,7 +22,7 @@ function(gen_kobj gen_dir_out)
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
-  add_custom_target(kobj_types_h_target DEPENDS ${KOBJ_TYPES} ${KOBJ_OTYPE})
+  add_custom_target(${KOBJ_TYPES_H_TARGET} DEPENDS ${KOBJ_TYPES} ${KOBJ_OTYPE})
 
   set(${gen_dir_out} ${gen_dir} PARENT_SCOPE)
 

--- a/doc/kernel/other/interrupts.rst
+++ b/doc/kernel/other/interrupts.rst
@@ -308,8 +308,8 @@ struct _isr_list which is placed in a special .intList section:
     };
 
 Zephyr is built in two phases; the first phase of the build produces
-zephyr_prebuilt.elf which contains all the entries in the .intList section
-preceded by a header:
+``${ZEPHYR_PREBUILT_EXECUTABLE}``.elf which contains all the entries in
+the .intList section preceded by a header:
 
 .. code-block:: c
 
@@ -322,9 +322,10 @@ preceded by a header:
     };
 
 This data consisting of the header and instances of struct _isr_list inside
-zephyr_prebuilt.elf is then used by the gen_isr_tables.py script to generate a
-C file defining a vector table and software ISR table that are then compiled
-and linked into the final application.
+``${ZEPHYR_PREBUILT_EXECUTABLE}``.elf is then used by the
+gen_isr_tables.py script to generate a C file defining a vector table and
+software ISR table that are then compiled and linked into the final
+application.
 
 The priority level of any interrupt is not encoded in these tables, instead
 :c:macro:`IRQ_CONNECT` also has a runtime component which programs the desired

--- a/ext/hal/libmetal/libmetal/lib/CMakeLists.txt
+++ b/ext/hal/libmetal/libmetal/lib/CMakeLists.txt
@@ -62,7 +62,7 @@ endif (WITH_DEFAULT_LOGGER)
 
 if (WITH_ZEPHYR)
   zephyr_library_named(metal)
-  add_dependencies(metal offsets_h)
+  add_dependencies(metal ${OFFSETS_H_TARGET})
   zephyr_library_sources(${_sources})
   zephyr_include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 else (WITH_ZEPHYR)

--- a/ext/lib/ipc/open-amp/open-amp/lib/CMakeLists.txt
+++ b/ext/lib/ipc/open-amp/open-amp/lib/CMakeLists.txt
@@ -35,7 +35,7 @@ set_property (SOURCE ${_sources}
 # Build a shared library if so configured.
 if (WITH_ZEPHYR)
   zephyr_library_named(${OPENAMP_LIB})
-  add_dependencies(${OPENAMP_LIB} offsets_h)
+  add_dependencies(${OPENAMP_LIB} ${OFFSETS_H_TARGET})
   target_sources (${OPENAMP_LIB} PRIVATE ${_sources})
   zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 else (WITH_ZEPHYR)

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -51,6 +51,6 @@ target_sources_ifdef(
   )
 
 
-add_dependencies(kernel offsets_h)
+add_dependencies(kernel ${OFFSETS_H_TARGET})
 
 target_link_libraries(kernel zephyr_interface)

--- a/tests/unit/unittest.cmake
+++ b/tests/unit/unittest.cmake
@@ -20,8 +20,9 @@ endif()
 
 add_executable(testbinary ${SOURCES})
 
+set(KOBJ_TYPES_H_TARGET kobj_types_h_target)
 include($ENV{ZEPHYR_BASE}/cmake/kobj.cmake)
-add_dependencies(testbinary kobj_types_h_target)
+add_dependencies(testbinary ${KOBJ_TYPES_H_TARGET})
 gen_kobj(KOBJ_GEN_DIR)
 
 list(APPEND INCLUDE


### PR DESCRIPTION
This is done to allow changing the target name without modifying all
uses of the target.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>