### PR TITLE
samples/net/echo: Prune OpenThread tests

### DIFF
--- a/samples/net/echo_client/sample.yaml
+++ b/samples/net/echo_client/sample.yaml
@@ -21,9 +21,11 @@ tests:
     platform_whitelist: nrf52840_pca10056
   test_nrf_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
+    slow: true
     tags: net openthread
     platform_whitelist: nrf52840_pca10056
   test_kw41z_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
+    slow: true
     tags: net openthread
     platform_whitelist: frdm_kw41z

--- a/samples/net/echo_client/sample.yaml
+++ b/samples/net/echo_client/sample.yaml
@@ -23,8 +23,6 @@ tests:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
     tags: net openthread
     platform_whitelist: nrf52840_pca10056
-  test_kw41z:
-    platform_whitelist: frdm_kw41z
   test_kw41z_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
     tags: net openthread

--- a/samples/net/echo_server/sample.yaml
+++ b/samples/net/echo_server/sample.yaml
@@ -40,8 +40,6 @@ tests:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
     tags: net openthread
     platform_whitelist: nrf52840_pca10056
-  test_kw41z:
-    platform_whitelist: frdm_kw41z
   test_kw41z_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
     tags: net openthread

--- a/samples/net/echo_server/sample.yaml
+++ b/samples/net/echo_server/sample.yaml
@@ -38,9 +38,11 @@ tests:
     tags: net usb
   test_nrf_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
+    slow: true
     tags: net openthread
     platform_whitelist: nrf52840_pca10056
   test_kw41z_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
+    slow: true
     tags: net openthread
     platform_whitelist: frdm_kw41z

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -27,10 +27,10 @@ pairs:
     skip testcase unconditionally. This can be used for broken tests.
 
   slow: <True|False> (default False)
-    Don't run this test case unless --enable-slow was passed in on the
-    command line. Intended for time-consuming test cases that are only
-    run under certain circumstances, like daily builds. These test cases
-    are still compiled.
+    Don't build or run this test case unless --enable-slow was passed
+    in on the command line. Intended for time-consuming test cases
+    that are only run under certain circumstances, like daily
+    builds.
 
   extra_args: <list of extra arguments>
     Extra cache entries to pass to CMake when building or running the
@@ -156,6 +156,7 @@ To load arguments from a file, write '+' before the file name, e.g.,
 line break instead of white spaces.
 
 Most everyday users will run with no arguments.
+
 """
 
 import contextlib
@@ -1061,9 +1062,9 @@ class MakeGenerator:
         args.append("BOARD={}".format(ti.platform.name))
         args.extend(extra_args)
 
-        do_run_slow = options.enable_slow or not ti.test.slow
         do_build_only = ti.build_only or options.build_only
-        do_run = (not do_build_only) and do_run_slow
+        do_run = not do_build_only
+        skip_slow = ti.test.slow and not options.enable_slow
 
         # FIXME: Need refactoring and cleanup
         type = None
@@ -1079,7 +1080,10 @@ class MakeGenerator:
         elif options.device_testing and (not ti.build_only) and (not options.build_only):
             type = "device"
 
-        self.add_goal(ti, type, args)
+        if not skip_slow:
+            self.add_goal(ti, type, args)
+        else:
+            verbose("Skipping slow test: " + ti.name)
 
     def execute(self, callback_fn=None, context=None):
         """Execute all the registered build goals


### PR DESCRIPTION
(Workaround for #12206 pending west integration of external dependencies)

Currently the OpenThread integration wants to download (from github)
configure and build the whole library at the app level, and we're
doing it four times every time we run sanitycheck.  And it's a slow
process that doesn't parallelize well.  It's adding almost a whole
minute to my ~6 minute build times on a very parallel host.

Eventually this external dependency handling will be integrated in
west, but for now let's run just one OpenThread test.

Note that this thread also removes the needless "test_kw41z" tests,
which look like mistakes to me.  That platform is already whitelisted
in the main test (named "test"), and this version includes no variant
configuration, it's just a duplication.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>