### PR TITLE
doc: add (more) missing API docs

### DIFF
--- a/doc/api/bluetooth.rst
+++ b/doc/api/bluetooth.rst
@@ -20,6 +20,12 @@ BR/EDR (Bluetooth Classic) APIs require :option:`CONFIG_BT_BREDR`.
    .. doxygengroup:: bluetooth
    .. doxygengroup:: bt_test_cb
 
+Bluetooth Controller
+********************
+
+.. doxygengroup:: bt_ctrl
+   :project: Zephyr
+
 Bluetooth Mesh Profile
 **********************
 
@@ -96,6 +102,18 @@ Generic Attribute Profile (GATT)
 ********************************
 
 .. doxygengroup:: bt_gatt
+   :project: Zephyr
+
+GATT Server
+===========
+
+.. doxygengroup:: bt_gatt_server
+   :project: Zephyr
+
+GATT Client
+===========
+
+.. doxygengroup:: bt_gatt_client
    :project: Zephyr
 
 HCI RAW channel

--- a/doc/api/file_system.rst
+++ b/doc/api/file_system.rst
@@ -7,6 +7,7 @@ File System APIs
 .. comment
    not documenting
    .. doxygengroup:: file_system
+   .. doxygengroup:: file_system_storage
 
 File System Functions
 *******************************

--- a/doc/api/io_interfaces.rst
+++ b/doc/api/io_interfaces.rst
@@ -18,6 +18,12 @@ ADC Interface
 .. doxygengroup:: adc_interface
    :project: Zephyr
 
+CAN Interface
+*************
+
+.. doxygengroup:: can_interface
+   :project: Zephyr
+
 DMA Interface
 *************
 
@@ -34,6 +40,12 @@ I2C Interface
 *************
 
 .. doxygengroup:: i2c_interface
+   :project: Zephyr
+
+I2C EEPROM Slave Driver
+***********************
+
+.. doxygengroup:: i2c_eeprom_slave_api
    :project: Zephyr
 
 I2S Interface

--- a/doc/api/logger_api.rst
+++ b/doc/api/logger_api.rst
@@ -4,6 +4,12 @@
 Logger system API
 #################
 
+.. comment
+   not documenting
+   .. doxygengroup:: logging
+   .. doxygengroup:: logger
+
+
 .. contents::
    :depth: 2
    :local:

--- a/doc/api/power_management_api.rst
+++ b/doc/api/power_management_api.rst
@@ -3,6 +3,10 @@
 Power Management APIs
 #####################
 
+.. comment
+   not documenting
+   .. doxygengroup:: power_management_api
+
 Power Management Hook Interface
 *******************************
 

--- a/doc/subsystems/nvs/nvs.rst
+++ b/doc/subsystems/nvs/nvs.rst
@@ -110,3 +110,7 @@ The NVS subsystem APIs are provided by ``nvs.h``:
 
 .. doxygengroup:: nvs_high_level_api
    :project: Zephyr
+
+.. comment
+   not documenting
+   .. doxygengroup:: nvs


### PR DESCRIPTION
As mentioned in issue #12265, some APIs
aren't included in the generated
API docs because doxygengroup directives were missing. Also add a
comment referencing defgroups that are just organizational and the
scanning script can ignore.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>