### PR TITLE
logging: Add buffer flushing on entering panic

### DIFF
--- a/subsys/logging/log_backend_native_posix.c
+++ b/subsys/logging/log_backend_native_posix.c
@@ -81,7 +81,7 @@ static void put(const struct log_backend *const backend,
 
 static void panic(struct log_backend const *const backend)
 {
-	/* Nothing to be done, this backend can always process logs */
+	log_output_flush(&log_output);
 }
 
 static void dropped(const struct log_backend *const backend, u32_t cnt)

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -232,6 +232,7 @@ static void log_backend_rtt_init(void)
 
 static void panic(struct log_backend const *const backend)
 {
+	log_output_flush(&log_output);
 	panic_mode = 1;
 }
 

--- a/subsys/logging/log_backend_uart.c
+++ b/subsys/logging/log_backend_uart.c
@@ -60,6 +60,7 @@ static void log_backend_uart_init(void)
 
 static void panic(struct log_backend const *const backend)
 {
+	log_output_flush(&log_output);
 }
 
 static void dropped(const struct log_backend *const backend, u32_t cnt)


### PR DESCRIPTION
It may happen that panic occured while logger backend
was formatting output data. In that case output buffer
could get corrupted as logger assumes that processing
happens in one context only (panic is the only exception).

Added log output buffer flushing on entering panic state.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>