### PR TITLE
cmake: Fix VERSION warning in doc build

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13.1)
-project(Zephyr-Kernel-Doc VERSION ${PROJECT_VERSION} LANGUAGES)
+project(Zephyr-Kernel-Doc LANGUAGES)
 
 set(ZEPHYR_BASE $ENV{ZEPHYR_BASE})
 


### PR DESCRIPTION
The 'doc' build has been invoking 'project' with the argument "VERSION
${PROJECT_VERSION}". This is cargo cult code inherited from the
toplevel build system.

This can be safely removed because in the doc build the versioning
variables that are set by 'project' are unused and PROJECT_VERSION is
not available to be de-referenced at that point in time any way ...

This fixes #12282

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>