### PR TITLE
cmake: Remove kconfig-usage target

### DIFF
--- a/cmake/usage/CMakeLists.txt
+++ b/cmake/usage/CMakeLists.txt
@@ -7,10 +7,5 @@ add_custom_target(
   -P ${CMAKE_CURRENT_SOURCE_DIR}/usage.cmake
   )
 
-add_custom_target(
-  kconfig-usage
-  ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/kconfig-usage.cmake
-  )
-
 # NB: The reason it is 'usage' and not help is that CMake already
 # defines a target 'help'


### PR DESCRIPTION
This target uses a file which no longer exists.
Invoking it results in an error.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>