### PR TITLE
Improve log 'immediate' (former 'in place') mode and extend shell to support that mode

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -292,16 +292,19 @@ struct shell_transport_api {
 	int (*uninit)(const struct shell_transport *transport);
 
 	/**
-	 * @brief Function for reconfiguring the transport to work in blocking
-	 * mode.
+	 * @brief Function for enabling transport in given TX mode.
 	 *
-	 * @param transport  Pointer to the transfer instance.
-	 * @param blocking   If true, the transport is enabled in blocking mode.
+	 * Function can be used to reconfigure TX to work in blocking mode.
+	 *
+	 * @param transport   Pointer to the transfer instance.
+	 * @param blocking_tx If true, the transport TX is enabled in blocking
+	 *		      mode.
 	 *
 	 * @return NRF_SUCCESS on successful enabling, error otherwise (also if
 	 * not supported).
 	 */
-	int (*enable)(const struct shell_transport *transport, bool blocking);
+	int (*enable)(const struct shell_transport *transport,
+		      bool blocking_tx);
 
 	/**
 	 * @brief Function for writing data to the transport interface.

--- a/include/shell/shell_uart.h
+++ b/include/shell/shell_uart.h
@@ -26,7 +26,7 @@ struct shell_uart_ctrl_blk {
 	shell_transport_handler_t handler;
 	void *context;
 	atomic_t tx_busy;
-	bool blocking;
+	bool blocking_tx;
 #ifdef CONFIG_MCUMGR_SMP_SHELL
 	struct smp_shell_data smp;
 #endif /* CONFIG_MCUMGR_SMP_SHELL */

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -197,6 +197,20 @@ bool shell_cursor_in_empty_line(const struct shell *shell);
 
 void shell_cmd_line_erase(const struct shell *shell);
 
+/**
+ * @brief Print command buffer.
+ *
+ * @param shell Shell instance.
+ */
+void shell_print_cmd(const struct shell *shell);
+
+/**
+ * @brief Print prompt followed by command buffer.
+ *
+ * @param shell Shell instance.
+ */
+void shell_print_prompt_and_cmd(const struct shell *shell);
+
 /* Function sends data stream to the shell instance. Each time before the
  * shell_write function is called, it must be ensured that IO buffer of fprintf
  * is flushed to avoid synchronization issues.


### PR DESCRIPTION
1. First change is fairly trivial: Added interrupt locking when doing in place log processing to ensure that one will not interrupt another. Description from commit message:

When CONFIG_LOG_IMMEDIATE is enabled then logs are processed in the caller context. In that case, it must be ensured that one log call will not be interrupted by another. As log can be called from any context, interrupt locking is the only option.

When CONFIG_LOG_IMMEDIATE  is used then logger backend also works in blocking way without interrupts so blocking them will not interfere with backend processing.

2. Second change is in shell and it adds in place support to shell. Description from commit message:

Extended shell to be able to process logs in place (in the context of a log call). In order to achieve that, shell was extended to  support for TX blocking operations. If CONFIG_LOG_IMMEDIATE  is enabled then shell instance attempts to be initialized in blocking TX mode. If fails to do so, shell log backend is disabled. If successfully enabled logs are processed and printed in the context of the call.

Due to that change, user may experience interleaved output as shell has no means to multiplex shell output with logger output. In extreme, huge amount of log messages may prevent shell thread execution and shell may become unresponsive.

