### PR TITLE
net:shell: Fix cmd_net_http_monitor build error

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2452,7 +2452,7 @@ static int cmd_net_http_monitor(const struct shell *shell, size_t argc,
 #if defined(CONFIG_NET_DEBUG_HTTP_CONN) && defined(CONFIG_HTTP_SERVER)
 	PR_INFO("Activating HTTP monitor. Type \"net http\" "
 		"to disable HTTP connection monitoring.\n");
-	http_server_conn_monitor(http_server_cb, &count);
+	http_server_conn_monitor(http_server_cb, &http_monitor_count);
 #else
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);


### PR DESCRIPTION
As there is no declar 'http_monitor_count',Enable CONFIG_NET_DEBUG_HTTP_CONN will build error.
Using http_monitor_count replace count.

Signed-off-by: Frank Li <lgl88911@163.com>