### PR TITLE
soc: nxp_imx: Fix ethernet build error

### DIFF
--- a/soc/arm/nxp_imx/rt/soc.c
+++ b/soc/arm/nxp_imx/rt/soc.c
@@ -36,11 +36,9 @@ const clock_usb_pll_config_t usb1PllConfig = {
 
 #ifdef CONFIG_ETH_MCUX_0
 const clock_enet_pll_config_t ethPllConfig = {
-	.enableClkOutput0 = true,
-	.enableClkOutput1 = false,
-	.enableClkOutput2 = false,
-	.loopDivider0 = 1,
-	.loopDivider1 = 1
+	.enableClkOutput = true,
+	.enableClkOutput25M = false,
+	.loopDivider = 1,
 };
 #endif
 


### PR DESCRIPTION
Fixes an ethernet build error introduced with MCUXpresso SDK 2.5.0,
caused by a slight change in the ethernet pll configuration structure.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>