### PR TITLE
tests: cmsis_rtos_v2: Bugfix in test which leads to random errors

### DIFF
--- a/tests/cmsis_rtos_v2/src/kernel.c
+++ b/tests/cmsis_rtos_v2/src/kernel.c
@@ -27,7 +27,7 @@ void get_version_check(void *param)
 	status = osKernelGetInfo(&osv, infobuf, sizeof(infobuf));
 	if (status == osOK) {
 		version_i->os_info.api = osv.api;
-		version_i->os_info.api = osv.kernel;
+		version_i->os_info.kernel = osv.kernel;
 		strcpy(version_i->info, infobuf);
 	}
 }


### PR DESCRIPTION
Fix a quite silly bug in this testcase which led to random failures on CI.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

--------

Self contained bug report:

d_00: @00:00:00.000000  starting test - test_kernel_apis
==22168== Thread 2:
==22168== Conditional jump or move depends on uninitialised value(s)
==22168==    at 0x10E995: _zassert (ztest_assert.h:44)
==22168==    by 0x10EC94: test_kernel_apis (kernel.c:74)
==22168==    by 0x127F78: run_test_functions (ztest.c:58)
==22168==    by 0x128013: test_cb (ztest.c:195)
==22168==    by 0x111AD6: _thread_entry (thread_entry.c:29)
==22168==    by 0x1148D0: posix_thread_starter (posix_core.c:301)
==22168==    by 0x496C3BC: start_thread (pthread_create.c:463)
==22168==    by 0x4A7DE15: clone (clone.S:108)
==22168== 
d_00: @00:00:00.000000  
d_00: @00:00:00.000000      Assertion failed at tests/cmsis_rtos_v2/src/kernel.c:74: test_kernel_apis: version.os_info.kernel not equal to version_irq.os_info.kernel
