### PR TITLE
Bluetooth: peripheral: Fix check of BT_GATT_WRITE_FLAG_CMD

### DIFF
--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -173,7 +173,7 @@ static ssize_t write_without_rsp_vnd(struct bt_conn *conn,
 	/* Write request received. Reject it since this char only accepts
 	 * Write Commands.
 	 */
-	if (!(flags | BT_GATT_WRITE_FLAG_CMD)) {
+	if (!(flags & BT_GATT_WRITE_FLAG_CMD)) {
 		return BT_GATT_ERR(BT_ATT_ERR_WRITE_REQ_REJECTED);
 	}
 


### PR DESCRIPTION
Check should be done with & instead of | otherwise it will always be
evaluated as 1/true regardless of the flags.

Fixes #12308

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>