### PR TITLE
openthread: fix source IP address selection

### DIFF
--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -60,6 +60,24 @@ struct net_l2 {
 	int (*enable)(struct net_if *iface, bool state);
 
 	/**
+	 * This function is used to override the default interface IPv6 address
+	 * lookup when sending outgoing data to dst.
+	 * Returns NULL if best_so_far value cannot be beaten.
+	 */
+	struct in6_addr *(*get_best_match_ipv6)(struct net_if *iface,
+						const struct in6_addr *addr,
+						u8_t *best_so_far);
+
+	/**
+	 * This function is used to override the default interface IPv4 address
+	 * lookup when sending outgoing data to dst.
+	 * Returns NULL if best_so_far value cannot be beaten.
+	 */
+	struct in_addr *(*get_best_match_ipv4)(struct net_if *iface,
+					       const struct in_addr *addr,
+					       u8_t *best_so_far);
+
+	/**
 	 * Return L2 flags for the network interface.
 	 */
 	enum net_l2_flags (*get_flags)(struct net_if *iface);
@@ -103,6 +121,20 @@ NET_L2_DECLARE_PUBLIC(OPENTHREAD_L2);
 		.recv = (_recv_fn),					\
 		.send = (_send_fn),					\
 		.enable = (_enable_fn),					\
+		.get_flags = (_get_flags_fn),				\
+	}
+
+
+#define NET_L2_INIT_MATCH(_name, _recv_fn, _send_fn, _enable_fn,	\
+			  _get_best_match_ipv6_fn, _get_best_match_ipv4_fn, \
+			  _get_flags_fn)				\
+	const struct net_l2 (NET_L2_GET_NAME(_name)) __used		\
+	__attribute__((__section__(".net_l2.init"))) = {		\
+		.recv = (_recv_fn),					\
+		.send = (_send_fn),					\
+		.enable = (_enable_fn),					\
+		.get_best_match_ipv6 = (_get_best_match_ipv6_fn),	\
+		.get_best_match_ipv4 = (_get_best_match_ipv4_fn),	\
 		.get_flags = (_get_flags_fn),				\
 	}
 

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2001,39 +2001,38 @@ const struct in6_addr *net_if_ipv6_select_src_addr(struct net_if *dst_iface,
 
 	if (!net_ipv6_is_ll_addr(dst) && !net_ipv6_is_addr_mcast(dst)) {
 
-		for (iface = __net_if_start;
-		     !dst_iface && iface != __net_if_end;
-		     iface++) {
-			struct in6_addr *addr;
-
-			addr = net_if_ipv6_get_best_match(iface, dst,
-							  &best_match);
-			if (addr) {
-				src = addr;
-			}
-		}
-
 		/* If caller has supplied interface, then use that */
 		if (dst_iface) {
 			src = net_if_ipv6_get_best_match(dst_iface, dst,
 							 &best_match);
-		}
+		} else {
+			for (iface = __net_if_start;
+			     iface != __net_if_end; iface++) {
+				struct in6_addr *addr;
 
-	} else {
-		for (iface = __net_if_start;
-		     !dst_iface && iface != __net_if_end;
-		     iface++) {
-			struct in6_addr *addr;
-
-			addr = net_if_ipv6_get_ll(iface, NET_ADDR_PREFERRED);
-			if (addr) {
-				src = addr;
-				break;
+				addr = net_if_ipv6_get_best_match(iface, dst,
+								  &best_match);
+				if (addr) {
+					src = addr;
+				}
 			}
 		}
 
+	} else {
 		if (dst_iface) {
 			src = net_if_ipv6_get_ll(dst_iface, NET_ADDR_PREFERRED);
+		} else {
+			for (iface = __net_if_start;
+			     iface != __net_if_end; iface++) {
+				struct in6_addr *addr;
+
+				addr = net_if_ipv6_get_ll(iface,
+							  NET_ADDR_PREFERRED);
+				if (addr) {
+					src = addr;
+					break;
+				}
+			}
 		}
 	}
 
@@ -2388,39 +2387,38 @@ const struct in_addr *net_if_ipv4_select_src_addr(struct net_if *dst_iface,
 
 	if (!net_ipv4_is_ll_addr(dst) && !net_ipv4_is_addr_mcast(dst)) {
 
-		for (iface = __net_if_start;
-		     !dst_iface && iface != __net_if_end;
-		     iface++) {
-			struct in_addr *addr;
-
-			addr = net_if_ipv4_get_best_match(iface, dst,
-							  &best_match);
-			if (addr) {
-				src = addr;
-			}
-		}
-
 		/* If caller has supplied interface, then use that */
 		if (dst_iface) {
 			src = net_if_ipv4_get_best_match(dst_iface, dst,
 							 &best_match);
-		}
+		} else {
+			for (iface = __net_if_start;
+			     iface != __net_if_end; iface++) {
+				struct in_addr *addr;
 
-	} else {
-		for (iface = __net_if_start;
-		     !dst_iface && iface != __net_if_end;
-		     iface++) {
-			struct in_addr *addr;
-
-			addr = net_if_ipv4_get_ll(iface, NET_ADDR_PREFERRED);
-			if (addr) {
-				src = addr;
-				break;
+				addr = net_if_ipv4_get_best_match(iface, dst,
+								  &best_match);
+				if (addr) {
+					src = addr;
+				}
 			}
 		}
 
+	} else {
 		if (dst_iface) {
 			src = net_if_ipv4_get_ll(dst_iface, NET_ADDR_PREFERRED);
+		} else {
+			for (iface = __net_if_start;
+			     iface != __net_if_end; iface++) {
+				struct in_addr *addr;
+
+				addr = net_if_ipv4_get_ll(iface,
+							  NET_ADDR_PREFERRED);
+				if (addr) {
+					src = addr;
+					break;
+				}
+			}
 		}
 	}
 

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1962,9 +1962,9 @@ static inline bool is_proper_ipv6_address(struct net_if_addr *addr)
 	return false;
 }
 
-static struct in6_addr *net_if_ipv6_get_best_match(struct net_if *iface,
-						   const struct in6_addr *dst,
-						   u8_t *best_so_far)
+static struct in6_addr *_net_if_ipv6_get_best_match(struct net_if *iface,
+						    const struct in6_addr *dst,
+						    u8_t *best_so_far)
 {
 	struct net_if_ipv6 *ipv6 = iface->config.ip.ipv6;
 	struct in6_addr *src = NULL;
@@ -1988,6 +1988,18 @@ static struct in6_addr *net_if_ipv6_get_best_match(struct net_if *iface,
 	}
 
 	return src;
+}
+
+static struct in6_addr *net_if_ipv6_get_best_match(struct net_if *iface,
+						   const struct in6_addr *dst,
+						   u8_t *best_so_far)
+{
+	if (net_if_l2(iface)->get_best_match_ipv6) {
+		return net_if_l2(iface)->get_best_match_ipv6(iface, dst,
+							     best_so_far);
+	}
+
+	return _net_if_ipv6_get_best_match(iface, dst, best_so_far);
 }
 #endif /* CONFIG_NET_IPV6 */
 
@@ -2320,9 +2332,9 @@ static inline bool is_proper_ipv4_address(struct net_if_addr *addr)
 	return false;
 }
 
-static struct in_addr *net_if_ipv4_get_best_match(struct net_if *iface,
-						  const struct in_addr *dst,
-						  u8_t *best_so_far)
+static struct in_addr *_net_if_ipv4_get_best_match(struct net_if *iface,
+						   const struct in_addr *dst,
+						   u8_t *best_so_far)
 {
 	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
 	struct in_addr *src = NULL;
@@ -2346,6 +2358,18 @@ static struct in_addr *net_if_ipv4_get_best_match(struct net_if *iface,
 	}
 
 	return src;
+}
+
+static struct in_addr *net_if_ipv4_get_best_match(struct net_if *iface,
+						  const struct in_addr *dst,
+						  u8_t *best_so_far)
+{
+	if (net_if_l2(iface)->get_best_match_ipv4) {
+		return net_if_l2(iface)->get_best_match_ipv4(iface, dst,
+							     best_so_far);
+	}
+
+	return _net_if_ipv4_get_best_match(iface, dst, best_so_far);
 }
 #endif /* CONFIG_NET_IPV4 */
 


### PR DESCRIPTION
This series of commits adds 2 new function pointers to the L2 layer API:
get_best_match_ipv6()
get_best_match_ipv4()

This allows the L2 layer to override the default logic which chooses the source IP address for outbound traffic.

This is important for OpenThread, because the current logic is completely broken.  OT uses several non-link local unicast IPs for mesh local purposes (like routing, etc), but these should not be used for outbound traffic if a border router prefix is assigned.  OpenThread already has it's own logic to correctly select the IP, so we should be able to use it.