### PR TITLE
Remove NRF dependency from flash shell

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -52,7 +52,12 @@ static int cmd_erase(const struct shell *shell, size_t argc, char *argv[])
 	if (argc > 2) {
 		size = strtoul(argv[2], NULL, 16);
 	} else {
+#if defined(CONFIG_SOC_FLASH_NRF)
 		size = NRF_FICR->CODEPAGESIZE;
+#else
+		error(shell, "Missing size.");
+		return -EINVAL;
+#endif
 	}
 
 	flash_write_protection_set(flash_dev, 0);


### PR DESCRIPTION
Flash shell erase command contains NRF specific code (```NRF_FICR->CODEPAGESIZE```) which prevents it from compiling on other targets.

This PR put the line under _ifdef_ based on ```CONFIG_SOC_FLASH_NRF```.