### PR TITLE
settings: Corrected type for offset variables

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -159,7 +159,7 @@ static void settings_fcb_compress(struct settings_fcb *cf)
 			break;
 		}
 
-		off_t val1_off;
+		size_t val1_off;
 
 		rc = settings_line_name_read(name1, sizeof(name1), &val1_off,
 					     &loc1);
@@ -178,7 +178,7 @@ static void settings_fcb_compress(struct settings_fcb *cf)
 		copy = 1;
 
 		while (fcb_getnext(&cf->cf_fcb, &loc2.loc) == 0) {
-			off_t val2_off;
+			size_t val2_off;
 
 			rc = settings_line_name_read(name2, sizeof(name2),
 						     &val2_off, &loc2);

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -171,7 +171,7 @@ int settings_file_save_and_compress(struct settings_file *cf, const char *name,
 	int copy;
 	int lines;
 	size_t new_name_len;
-	off_t val1_off;
+	size_t val1_off;
 
 	if (fs_open(&rf, cf->cf_name) != 0) {
 		return -ENOEXEC;
@@ -219,7 +219,7 @@ int settings_file_save_and_compress(struct settings_file *cf, const char *name,
 
 		copy = 1;
 		while (1) {
-			off_t val2_off;
+			size_t val2_off;
 
 			rc = settings_next_line_ctx(&loc2);
 


### PR DESCRIPTION
Changed type of offset variables from off_t to size_t through CFG and file based settings code so that pointer types in subsequent functions calls match the correct type.
