### PR TITLE
drivers: wifi: eswifi: Fix coverity issues

### DIFF
--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -45,9 +45,8 @@ static int eswifi_reset(struct eswifi_dev *eswifi)
 	k_sleep(500);
 
 	/* fetch the cursor */
-	eswifi_request(eswifi, NULL, 0, eswifi->buf, sizeof(eswifi->buf));
-
-	return 0;
+	return eswifi_request(eswifi, NULL, 0, eswifi->buf,
+			      sizeof(eswifi->buf));
 }
 
 static inline int __parse_ssid(char *str, char *ssid)
@@ -328,7 +327,7 @@ static int eswifi_get_mac_addr(struct eswifi_dev *eswifi, u8_t addr[6])
 		return err;
 	}
 
-	for (i = 0; i < sizeof(eswifi->buf); i++) {
+	for (i = 0; i < sizeof(eswifi->buf) && byte < 6; i++) {
 		if (i < 2) {
 			continue;
 		}
@@ -466,6 +465,7 @@ static int eswifi_init(struct device *dev)
 	if (!eswifi->resetn.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
 			    DT_INVENTEK_ESWIFI_ESWIFI0_RESETN_GPIOS_CONTROLLER);
+		return -ENODEV;
 	}
 	eswifi->resetn.pin = DT_INVENTEK_ESWIFI_ESWIFI0_RESETN_GPIOS_PIN;
 	gpio_pin_configure(eswifi->resetn.dev, eswifi->resetn.pin,
@@ -476,6 +476,7 @@ static int eswifi_init(struct device *dev)
 	if (!eswifi->wakeup.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
 			    DT_INVENTEK_ESWIFI_ESWIFI0_WAKEUP_GPIOS_CONTROLLER);
+		return -ENODEV;
 	}
 	eswifi->wakeup.pin = DT_INVENTEK_ESWIFI_ESWIFI0_WAKEUP_GPIOS_PIN;
 	gpio_pin_configure(eswifi->wakeup.dev, eswifi->wakeup.pin,

--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -43,7 +43,7 @@ static int __read_data(struct eswifi_dev *eswifi, size_t len)
 	int err, i, read = 0;
 
 	/* Set max read size */
-	snprintf(size, sizeof(eswifi->buf), "R1=%u\r", len);
+	snprintf(size, sizeof(size), "R1=%u\r", len);
 	err = eswifi_request(eswifi, size, strlen(size),
 			     eswifi->buf, sizeof(eswifi->buf));
 	if (err || !eswifi_is_buf_at_ok(eswifi->buf)) {
@@ -52,7 +52,7 @@ static int __read_data(struct eswifi_dev *eswifi, size_t len)
 	}
 
 	/* Set timeout */
-	snprintf(timeout, sizeof(eswifi->buf), "R2=%u\r", 30); /* 30 ms */
+	snprintf(timeout, sizeof(timeout), "R2=%u\r", 30); /* 30 ms */
 	err = eswifi_request(eswifi, timeout, strlen(timeout),
 			     eswifi->buf, sizeof(eswifi->buf));
 	if (err || !eswifi_is_buf_at_ok(eswifi->buf)) {


### PR DESCRIPTION
This patch fixes the following issues:
CID 190622 (#1 of 1): Out-of-bounds access (OVERRUN)
CID 190632 (#1 of 1): Out-of-bounds access (OVERRUN)
CID 190623 (#1 of 1): Unchecked return value (CHECKED_RETURN)
CID 190628 (#1 of 1): Out-of-bounds write (OVERRUN)

Fixes #12301 
Fixes #12305 
Fixes #12310 
Fixes #12311 


Signed-off-by: Loic Poulain <loic.poulain@linaro.org>