### PR TITLE
net/ieee802154: Compute ll hdr size before 6lo compression

### DIFF
--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -247,14 +247,14 @@ static int ieee802154_send(struct net_if *iface, struct net_pkt *pkt)
 		return -EINVAL;
 	}
 
+	ll_hdr_size = ieee802154_compute_header_size(iface,
+						     &NET_IPV6_HDR(pkt)->dst);
+
 	/* len will hold the hdr size difference on success */
 	len = net_6lo_compress(pkt, true);
 	if (len < 0) {
 		return len;
 	}
-
-	ll_hdr_size = ieee802154_compute_header_size(iface,
-						     &NET_IPV6_HDR(pkt)->dst);
 
 	fragment = ieee802154_fragment_is_needed(pkt, ll_hdr_size);
 	ieee802154_fragment_ctx_init(&f_ctx, pkt, len, true);


### PR DESCRIPTION
Or then the IP header access will be bogus afterwards.

Fixes #12154

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>