### PR TITLE
net/icmpv4: Disable broadcast echo request reply by default

### DIFF
--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -39,7 +39,7 @@ config NET_IF_MCAST_IPV4_ADDR_COUNT
 
 config NET_ICMPV4_ACCEPT_BROADCAST
 	bool "Accept broadcast ICMPv4 echo-request"
-	default y
+	default n
 	help
 	  If set, then respond to ICMPv4 echo-request that is sent to
 	  broadcast address.


### PR DESCRIPTION
Accepting broadcast echo request and replying to it could provide an
attack vector.

Fixes #12162

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>