### PR TITLE
nrf52_bsim: Improve compile time check of HW models version

### DIFF
--- a/boards/posix/nrf52_bsim/CMakeLists.txt
+++ b/boards/posix/nrf52_bsim/CMakeLists.txt
@@ -16,8 +16,8 @@ endif()
 if(NOT DEFINED ENV{NO_NRF52_BSIM_VERSION_WARNING})
   if(GIT_FOUND) #boilerplate.cmake searches for git
     file(STRINGS "hw_models_version" NRF52_HW_MODELS_TAG) #desired version
-    execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
-      ${NRF52_HW_MODELS_TAG}
+    execute_process(COMMAND ${GIT_EXECUTABLE} merge-base --is-ancestor
+      ${NRF52_HW_MODELS_TAG} HEAD
       WORKING_DIRECTORY $ENV{BSIM_COMPONENTS_PATH}/ext_NRF52_hw_models/
       OUTPUT_VARIABLE NRF52_HW_MODELS_TAG_FOUND
       OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -41,12 +41,12 @@ if(NOT DEFINED ENV{NO_NRF52_BSIM_VERSION_WARNING})
       )
       message(STATUS "Found NRF52 models version ${NRF52_HW_MODELS_TAG_FOUND}")
 
-      message(STATUS "To disable this check set the environment variable\
+      message(FATAL_ERROR "To disable this check set the environment variable\
  NO_NRF52_BSIM_VERSION_WARNING")
 
     elseif(CMAKE_VERBOSE_MAKEFILE)
-      message(STATUS "nrf52_bsim: git describe --tags --abbrev=0\
- ${NRF52_HW_MODELS_TAG},
+      message(STATUS "nrf52_bsim: git merge-base --is-ancestor\
+ ${NRF52_HW_MODELS_TAG} HEAD,
  stdout: ${NRF52_HW_MODELS_TAG_FOUND}
  stderr: ${stderr}")
     endif()


### PR DESCRIPTION
In 4940a3cac270445edf9444c9fd2334328b820012 a compile time
check of the HW model version was added. This check worked
fine for cases in which the problem was that people had not
fetched a new enough version of the HW models.
But in some cases people will have fetched a new enough version
but be (unknowingly) in a past detached HEAD (or old tag).

With this change we ensure that the required tag is an actual
ancestor for the current HW models version HEAD

Also fail with an error, instead of just printing a warning.
Users can still disable this warning if they know what they are
doing.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>