### PR TITLE
cmake: prework towards supporting board groups

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -333,8 +333,16 @@ if(DEFINED SHIELD AND DEFINED NOT_FOUND_SHIELD_LIST)
   message(FATAL_ERROR "Invalid usage")
 endif()
 
-get_filename_component(BOARD_ARCH_DIR ${BOARD_DIR}      DIRECTORY)
-get_filename_component(ARCH           ${BOARD_ARCH_DIR} NAME)
+# Determine arch by the directory name after 'boards'
+# We search until we find 'boards' so we can have any number
+get_filename_component(PARENT_DIR ${BOARD_DIR} PATH)
+get_filename_component(DIR_NAME  ${PARENT_DIR} NAME)
+while(NOT ("boards" STREQUAL ${DIR_NAME}))
+  set(ARCH ${DIR_NAME})
+  get_filename_component(GPARENT_DIR ${PARENT_DIR} PATH)
+  get_filename_component(DIR_NAME   ${GPARENT_DIR} NAME)
+  set(PARENT_DIR ${GPARENT_DIR})
+endwhile(NOT ("boards" STREQUAL ${DIR_NAME}))
 
 if(CONF_FILE)
   # CONF_FILE has either been specified on the cmake CLI or is already

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -266,7 +266,7 @@ foreach(root ${BOARD_ROOT})
   # already set
   find_path(BOARD_DIR
     NAMES ${BOARD}_defconfig
-    PATHS ${root}/boards/*/*
+    PATHS ${root}/boards/*/* ${root}/boards/*/*/*
     NO_DEFAULT_PATH
     )
   if(BOARD_DIR AND NOT (${root} STREQUAL ${ZEPHYR_BASE}))

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -334,7 +334,6 @@ if(DEFINED SHIELD AND DEFINED NOT_FOUND_SHIELD_LIST)
 endif()
 
 get_filename_component(BOARD_ARCH_DIR ${BOARD_DIR}      DIRECTORY)
-get_filename_component(BOARD_FAMILY   ${BOARD_DIR}      NAME)
 get_filename_component(ARCH           ${BOARD_ARCH_DIR} NAME)
 
 if(CONF_FILE)


### PR DESCRIPTION
These set of changes cleanup how we determine the ARCH dir based on the path to the board dir.  This allows us to support additional directories between boards/ARCH/ and BOARD_DIR.  So we can have:

boards/arm/96_boards/nitrogen
boards/arm/96_boards/neonkey
boards/arm/bbc_microbit