### PR TITLE
Flash shell improvements

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -52,12 +52,18 @@ static int cmd_erase(const struct shell *shell, size_t argc, char *argv[])
 	if (argc > 2) {
 		size = strtoul(argv[2], NULL, 16);
 	} else {
-#if defined(CONFIG_SOC_FLASH_NRF)
-		size = NRF_FICR->CODEPAGESIZE;
-#else
-		error(shell, "Missing size.");
-		return -EINVAL;
-#endif
+		struct flash_pages_info info;
+
+		result = flash_get_page_info_by_offs(flash_dev, page_addr,
+						     &info);
+
+		if (result != 0) {
+			error(shell, "Could not determine page size, "
+				    "code %d.", result);
+			return -EINVAL;
+		}
+
+		size = info.size;
 	}
 
 	flash_write_protection_set(flash_dev, 0);

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -14,15 +14,6 @@
 #include "flash.h"
 #include <soc.h>
 
-extern const struct shell *ctx_shell;
-
-#define print(_sh, _ft, ...) \
-	shell_fprintf(_sh ? _sh : ctx_shell, SHELL_NORMAL, _ft "\r\n", \
-		      ##__VA_ARGS__)
-#define error(_sh, _ft, ...) \
-	shell_fprintf(_sh ? _sh : ctx_shell, SHELL_ERROR, _ft "\r\n", \
-		      ##__VA_ARGS__)
-
 #define FLASH_SHELL_MODULE "flash"
 #define BUF_ARRAY_CNT 16
 #define TEST_ARR_SIZE 0x1000
@@ -38,12 +29,12 @@ static int cmd_erase(const struct shell *shell, size_t argc, char *argv[])
 
 	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
 	if (!flash_dev) {
-		error(shell, "Flash driver was not found!");
+		shell_error(shell, "Flash driver was not found!");
 		return -ENODEV;
 	}
 
 	if (argc < 2) {
-		error(shell, "Missing page address.");
+		shell_error(shell, "Missing page address.");
 		return -EINVAL;
 	}
 
@@ -58,7 +49,7 @@ static int cmd_erase(const struct shell *shell, size_t argc, char *argv[])
 						     &info);
 
 		if (result != 0) {
-			error(shell, "Could not determine page size, "
+			shell_error(shell, "Could not determine page size, "
 				    "code %d.", result);
 			return -EINVAL;
 		}
@@ -71,9 +62,9 @@ static int cmd_erase(const struct shell *shell, size_t argc, char *argv[])
 	result = flash_erase(flash_dev, page_addr, size);
 
 	if (result) {
-		error(shell, "Erase Failed, code %d.", result);
+		shell_error(shell, "Erase Failed, code %d.", result);
 	} else {
-		print(shell, "Erase success.");
+		shell_print(shell, "Erase success.");
 	}
 
 	return result;
@@ -89,17 +80,17 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 
 	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
 	if (!flash_dev) {
-		error(shell, "Flash driver was not found!");
+		shell_error(shell, "Flash driver was not found!");
 		return -ENODEV;
 	}
 
 	if (argc < 2) {
-		error(shell, "Missing address.");
+		shell_error(shell, "Missing address.");
 		return -EINVAL;
 	}
 
 	if (argc <= 2) {
-		error(shell, "Type data to be written.");
+		shell_error(shell, "Type data to be written.");
 		return -EINVAL;
 	}
 
@@ -115,18 +106,18 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 
 	if (flash_write(flash_dev, w_addr, buf_array,
 			sizeof(buf_array[0]) * j) != 0) {
-		error(shell, "Write internal ERROR!");
+		shell_error(shell, "Write internal ERROR!");
 		return -EIO;
 	}
 
-	print(shell, "Write OK.");
+	shell_print(shell, "Write OK.");
 
 	flash_read(flash_dev, w_addr, check_array, sizeof(buf_array[0]) * j);
 
 	if (memcmp(buf_array, check_array, sizeof(buf_array[0]) * j) == 0) {
-		print(shell, "Verified.");
+		shell_print(shell, "Verified.");
 	} else {
-		error(shell, "Verification ERROR!");
+		shell_error(shell, "Verification ERROR!");
 		return -EIO;
 	}
 
@@ -141,12 +132,12 @@ static int cmd_read(const struct shell *shell, size_t argc, char *argv[])
 
 	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
 	if (!flash_dev) {
-		error(shell, "Flash driver was not found!");
+		shell_error(shell, "Flash driver was not found!");
 		return -ENODEV;
 	}
 
 	if (argc < 2) {
-		error(shell, "Missing address.");
+		shell_error(shell, "Missing address.");
 		return -EINVAL;
 	}
 
@@ -162,11 +153,11 @@ static int cmd_read(const struct shell *shell, size_t argc, char *argv[])
 		u32_t data;
 
 		flash_read(flash_dev, addr, &data, sizeof(data));
-		print(shell, "0x%08x ", data);
+		shell_print(shell, "0x%08x ", data);
 		addr += sizeof(data);
 	}
 
-	print(shell, "");
+	shell_print(shell, "");
 
 	return 0;
 }
@@ -181,12 +172,12 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 
 	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
 	if (!flash_dev) {
-		error(shell, "Flash driver was not found!");
+		shell_error(shell, "Flash driver was not found!");
 		return -ENODEV;
 	}
 
 	if (argc != 4) {
-		error(shell, "3 parameters reqired.");
+		shell_error(shell, "3 parameters reqired.");
 		return -EINVAL;
 	}
 
@@ -195,7 +186,8 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 	repeat = strtoul(argv[3], NULL, 16);
 
 	if (size > TEST_ARR_SIZE) {
-		error(shell, "<size> must be at most 0x%x.", TEST_ARR_SIZE);
+		shell_error(shell, "<size> must be at most 0x%x.",
+			    TEST_ARR_SIZE);
 		return -EINVAL;
 	}
 
@@ -208,21 +200,21 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 	while (repeat--) {
 		result = flash_erase(flash_dev, addr, size);
 		if (result) {
-			error(shell, "Erase Failed, code %d.", result);
+			shell_error(shell, "Erase Failed, code %d.", result);
 			return -EIO;
 		}
 
-		print(shell, "Erase OK.");
+		shell_print(shell, "Erase OK.");
 
 		if (flash_write(flash_dev, addr, test_arr, size) != 0) {
-			error(shell, "Write internal ERROR!");
+			shell_error(shell, "Write internal ERROR!");
 			return -EIO;
 		}
 
-		print(shell, "Write OK.");
+		shell_print(shell, "Write OK.");
 	}
 
-	print(shell, "Erase-Write test done.");
+	shell_print(shell, "Erase-Write test done.");
 
 	return 0;
 }
@@ -237,7 +229,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(flash_cmds) {
 
 static int cmd_flash(const struct shell *shell, size_t argc, char **argv)
 {
-	error(shell, "%s:unknown parameter: %s", argv[0], argv[1]);
+	shell_error(shell, "%s:unknown parameter: %s", argv[0], argv[1]);
 	return -EINVAL;
 }
 


### PR DESCRIPTION
This PR contains 2 commits.

The first commit uses flash page layout to get page size in the erase command.
This was a remark of @aurel32 on PR #12349 

The second commit removes the ctx_shell extern variable from flash shell else flash shell has a dependency on Bluetooth shell where ctx_shell is declared as a global variable.
This problem was already flagged by issue #10760
