### PR TITLE
Fix kernel asynchronous event polling interface

### DIFF
--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -332,7 +332,7 @@ static int signal_poll_event(struct k_poll_event *event, u32_t state)
 	__ASSERT(event->poller->thread != NULL,
 		 "poller should have a thread\n");
 
-	event->poller->is_polling = true;
+	event->poller->is_polling = false;
 
 	if (!_is_thread_pending(thread)) {
 		goto ready_event;


### PR DESCRIPTION
Commit 76b3518ce6 ("kernel: Make statements evaluate boolean
expressions") changed the type of is_polling in the struct _poller
from int to bool. In the conversion a "0" has been changed into "true"
instead of "false". Fix that.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>