### PR TITLE
net: mqtt: Fix typo "seg_tag_list"

### DIFF
--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -330,7 +330,7 @@ struct mqtt_sec_config {
 	u32_t sec_tag_count;
 
 	/** Indicates the list of security tags to be used for the session. */
-	sec_tag_t *seg_tag_list;
+	sec_tag_t *sec_tag_list;
 
 	/** Peer hostname for ceritificate verification.
 	 *  May be NULL to skip hostname verification.

--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -280,7 +280,7 @@ static void client_init(struct mqtt_client *client)
 
 	tls_config->peer_verify = 2;
 	tls_config->cipher_list = NULL;
-	tls_config->seg_tag_list = m_sec_tags;
+	tls_config->sec_tag_list = m_sec_tags;
 	tls_config->sec_tag_count = ARRAY_SIZE(m_sec_tags);
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 	tls_config->hostname = TLS_SNI_HOSTNAME;

--- a/subsys/net/lib/mqtt_sock/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt_sock/mqtt_transport_socket_tls.c
@@ -55,9 +55,9 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 		}
 	}
 
-	if (tls_config->seg_tag_list != NULL && tls_config->sec_tag_count > 0) {
+	if (tls_config->sec_tag_list != NULL && tls_config->sec_tag_count > 0) {
 		ret = setsockopt(client->transport.tls.sock, SOL_TLS,
-				 TLS_SEC_TAG_LIST, tls_config->seg_tag_list,
+				 TLS_SEC_TAG_LIST, tls_config->sec_tag_list,
 				 sizeof(sec_tag_t) * tls_config->sec_tag_count);
 		if (ret < 0) {
 			goto error;


### PR DESCRIPTION
This fixes a typo in `include/net/mqtt.h` where it was "seg_tag_list" instead of "sec_tag_list".