### PR TITLE
boards: arm: Add xtools as a supported toolchain

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.yaml
+++ b/boards/arm/96b_argonkey/96b_argonkey.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 256
 flash: 1024
 supported:

--- a/boards/arm/96b_carbon/96b_carbon.yaml
+++ b/boards/arm/96b_carbon/96b_carbon.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - gpio
   - ble

--- a/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.yaml
+++ b/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.yaml
@@ -7,6 +7,7 @@ flash: 256
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - ble
   - spi

--- a/boards/arm/96b_neonkey/96b_neonkey.yaml
+++ b/boards/arm/96b_neonkey/96b_neonkey.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 128
 flash: 512
 supported:

--- a/boards/arm/96b_nitrogen/96b_nitrogen.yaml
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - ble
   - gpio

--- a/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.yaml
+++ b/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - uart
   - gpio

--- a/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.yaml
+++ b/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.yaml
@@ -7,3 +7,4 @@ flash: 256
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools

--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.yaml
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.yaml
@@ -7,3 +7,4 @@ flash: 256
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools

--- a/boards/arm/arduino_due/arduino_due.yaml
+++ b/boards/arm/arduino_due/arduino_due.yaml
@@ -7,5 +7,6 @@ flash: 512
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - watchdog

--- a/boards/arm/arduino_zero/arduino_zero.yaml
+++ b/boards/arm/arduino_zero/arduino_zero.yaml
@@ -7,3 +7,4 @@ flash: 256
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools

--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.yaml
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.yaml
@@ -7,3 +7,4 @@ flash: 256
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools

--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.yaml
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.yaml
@@ -9,3 +9,4 @@ flash: 256
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools

--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.yaml
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 20
 flash: 192
 testing:

--- a/boards/arm/bbc_microbit/bbc_microbit.yaml
+++ b/boards/arm/bbc_microbit/bbc_microbit.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 16
 testing:
   ignore_tags:

--- a/boards/arm/cc2650_sensortag/cc2650_sensortag.yaml
+++ b/boards/arm/cc2650_sensortag/cc2650_sensortag.yaml
@@ -5,4 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 20

--- a/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.yaml
+++ b/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - netif:wifi
   - i2c

--- a/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.yaml
+++ b/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.yaml
@@ -13,6 +13,7 @@ flash: 32
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 testing:
   ignore_tags:
     - net

--- a/boards/arm/curie_ble/curie_ble.yaml
+++ b/boards/arm/curie_ble/curie_ble.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 16
 supported:
   - ble

--- a/boards/arm/cy8ckit_062_wifi_bt_m0/cy8ckit_062_wifi_bt_m0.yaml
+++ b/boards/arm/cy8ckit_062_wifi_bt_m0/cy8ckit_062_wifi_bt_m0.yaml
@@ -13,3 +13,4 @@ flash: 1024
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools

--- a/boards/arm/cy8ckit_062_wifi_bt_m4/cy8ckit_062_wifi_bt_m4.yaml
+++ b/boards/arm/cy8ckit_062_wifi_bt_m4/cy8ckit_062_wifi_bt_m4.yaml
@@ -13,3 +13,4 @@ flash: 1024
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - i2c
   - hts221

--- a/boards/arm/dragino_lsn50/dragino_lsn50.yaml
+++ b/boards/arm/dragino_lsn50/dragino_lsn50.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 20
 flash: 192
 testing:

--- a/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.yaml
+++ b/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.yaml
@@ -7,6 +7,7 @@ flash: 64
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - gpio
 testing:

--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.yaml
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.yaml
@@ -12,5 +12,6 @@ supported:
   - gpio
 testing:
   ignore_tags:
+  - xtools
     - net
     - bluetooth

--- a/boards/arm/efm32wg_stk3800/efm32wg_stk3800.yaml
+++ b/boards/arm/efm32wg_stk3800/efm32wg_stk3800.yaml
@@ -7,6 +7,7 @@ flash: 256
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - gpio
 testing:

--- a/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.yaml
+++ b/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.yaml
@@ -7,6 +7,7 @@ flash: 256
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - gpio
 testing:

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.yaml
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.yaml
@@ -7,6 +7,7 @@ flash: 1024
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 testing:
   ignore_tags:
     - net

--- a/boards/arm/frdm_k64f/frdm_k64f.yaml
+++ b/boards/arm/frdm_k64f/frdm_k64f.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - netif:eth
   - adc

--- a/boards/arm/frdm_kl25z/frdm_kl25z.yaml
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.yaml
@@ -7,6 +7,7 @@ flash: 128
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 testing:
   ignore_tags:
     - net

--- a/boards/arm/frdm_kw41z/frdm_kw41z.yaml
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - ieee802154
   - adc

--- a/boards/arm/hexiwear_k64/hexiwear_k64.yaml
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - ble
   - adc

--- a/boards/arm/hexiwear_kw40z/hexiwear_kw40z.yaml
+++ b/boards/arm/hexiwear_kw40z/hexiwear_kw40z.yaml
@@ -7,6 +7,7 @@ flash: 512
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 testing:
   ignore_tags:
     - net

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114_m0.yaml
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114_m0.yaml
@@ -12,6 +12,7 @@ ram: 32
 flash: 64
 testing:
   ignore_tags:
+  - xtools
     - net
 toolchain:
   - zephyr

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114_m4.yaml
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114_m4.yaml
@@ -13,5 +13,6 @@ flash: 256
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - gpio

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
@@ -11,6 +11,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 128
 flash: 128
 supported:

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
@@ -11,6 +11,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 128
 flash: 128
 supported:

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
@@ -11,5 +11,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 128
 flash: 128

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
@@ -11,5 +11,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 128
 flash: 128

--- a/boards/arm/mps2_an385/mps2_an385.yaml
+++ b/boards/arm/mps2_an385/mps2_an385.yaml
@@ -7,5 +7,6 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+  - xtools
 testing:
   default: true

--- a/boards/arm/msp_exp432p401r_launchxl/msp_exp432p401r_launchxl.yaml
+++ b/boards/arm/msp_exp432p401r_launchxl/msp_exp432p401r_launchxl.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 64
 flash: 256

--- a/boards/arm/nrf51_ble400/nrf51_ble400.yaml
+++ b/boards/arm/nrf51_ble400/nrf51_ble400.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 16
 supported:
   - ble

--- a/boards/arm/nrf51_blenano/nrf51_blenano.yaml
+++ b/boards/arm/nrf51_blenano/nrf51_blenano.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 16
 supported:
   - ble

--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.yaml
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 32
 supported:
   - adc

--- a/boards/arm/nrf51_vbluno51/nrf51_vbluno51.yaml
+++ b/boards/arm/nrf51_vbluno51/nrf51_vbluno51.yaml
@@ -5,4 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 32

--- a/boards/arm/nrf52810_pca10040/nrf52810_pca10040.yaml
+++ b/boards/arm/nrf52810_pca10040/nrf52810_pca10040.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 24
 flash: 192

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.yaml
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 64
 flash: 512

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.yaml
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - usb_device
   - ble

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.yaml
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - adc
   - usb_device

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.yaml
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.yaml
@@ -7,6 +7,7 @@ flash: 1024
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - usb_device
   - ble

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.yaml
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 64
 flash: 512

--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.yaml
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 64
 flash: 512

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 64
 flash: 512
 supported:

--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.yaml
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.yaml
@@ -7,3 +7,4 @@ flash: 512
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools

--- a/boards/arm/nrf52_sparkfun/nrf52_sparkfun.yaml
+++ b/boards/arm/nrf52_sparkfun/nrf52_sparkfun.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 64
 flash: 512

--- a/boards/arm/nrf52_vbluno52/nrf52_vbluno52.yaml
+++ b/boards/arm/nrf52_vbluno52/nrf52_vbluno52.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 64
 flash: 512

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.yaml
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.yaml
@@ -5,4 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 8

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.yaml
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.yaml
@@ -7,6 +7,7 @@ flash: 128
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - gpio
   - i2c

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 32
 flash: 256
 supported:

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.yaml
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 20
 supported:
   - pwm

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
@@ -7,6 +7,7 @@ flash: 1024
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - gpio
   - usb_device

--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.yaml
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 16
 flash: 64
 supported:

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.yaml
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 12
 testing:
   ignore_tags:

--- a/boards/arm/nucleo_f401re/nucleo_f401re.yaml
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - pwm
   - rtc

--- a/boards/arm/nucleo_f411re/nucleo_f411re.yaml
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - rtc

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.yaml
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 256
 flash: 1024
 supported:

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.yaml
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 320
 flash: 1536
 supported:

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.yaml
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 256
 flash: 2048
 supported:

--- a/boards/arm/nucleo_f446re/nucleo_f446re.yaml
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - rtc

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.yaml
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 320
 flash: 1024
 supported:

--- a/boards/arm/nucleo_f756zg/nucleo_f756zg.yaml
+++ b/boards/arm/nucleo_f756zg/nucleo_f756zg.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 320
 flash: 1024
 supported:

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.yaml
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - gpio
   - i2c

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 20
 flash: 192

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.yaml
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 64
 flash: 256
 supported:

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.yaml
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - pwm
 ram: 96

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.yaml
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - pwm
   - spi

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.yaml
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - rtc

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.yaml
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - rtc

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.yaml
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - rtc

--- a/boards/arm/olimexino_stm32/olimexino_stm32.yaml
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 20
 supported:
   - gpio

--- a/boards/arm/quark_se_c1000_ble/quark_se_c1000_ble.yaml
+++ b/boards/arm/quark_se_c1000_ble/quark_se_c1000_ble.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 16
 supported:
   - ble

--- a/boards/arm/reel_board/reel_board.yaml
+++ b/boards/arm/reel_board/reel_board.yaml
@@ -7,6 +7,7 @@ flash: 1024
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - i2c
   - spi

--- a/boards/arm/sam4s_xplained/sam4s_xplained.yaml
+++ b/boards/arm/sam4s_xplained/sam4s_xplained.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - gpio
   - watchdog

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained.yaml
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - netif:eth
   - adc

--- a/boards/arm/stm3210c_eval/stm3210c_eval.yaml
+++ b/boards/arm/stm3210c_eval/stm3210c_eval.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 64
 flash: 256

--- a/boards/arm/stm32373c_eval/stm32373c_eval.yaml
+++ b/boards/arm/stm32373c_eval/stm32373c_eval.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 32
 supported:
   - rtc

--- a/boards/arm/stm32_min_dev/stm32_min_dev.yaml
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 20
 supported:
   - i2c

--- a/boards/arm/stm32f072_eval/stm32f072_eval.yaml
+++ b/boards/arm/stm32f072_eval/stm32f072_eval.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 16
 flash: 128
 testing:

--- a/boards/arm/stm32f072b_disco/stm32f072b_disco.yaml
+++ b/boards/arm/stm32f072b_disco/stm32f072b_disco.yaml
@@ -7,6 +7,7 @@ flash: 128
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - gpio
   - i2c

--- a/boards/arm/stm32f0_disco/stm32f0_disco.yaml
+++ b/boards/arm/stm32f0_disco/stm32f0_disco.yaml
@@ -5,4 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 8

--- a/boards/arm/stm32f3_disco/stm32f3_disco.yaml
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 40
 supported:
   - gpio

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.yaml
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - rtc

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.yaml
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - rtc

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - rtc

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.yaml
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - rtc
   - i2c

--- a/boards/arm/stm32f4_disco/stm32f4_disco.yaml
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - pwm
   - rtc

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.yaml
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 256
 flash: 512
 supported:

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 320
 flash: 1024
 supported:

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.yaml
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 512
 flash: 2048
 supported:

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.yaml
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 96
 flash: 1024
 supported:

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.yaml
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 320
 flash: 1024
 supported:

--- a/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.yaml
+++ b/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.yaml
@@ -13,3 +13,4 @@ flash: 512
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools

--- a/boards/arm/usb_kw24d512/usb_kw24d512.yaml
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.yaml
@@ -7,6 +7,7 @@ flash: 512
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - ieee802154
   - usb_device

--- a/boards/arm/v2m_beetle/v2m_beetle.yaml
+++ b/boards/arm/v2m_beetle/v2m_beetle.yaml
@@ -5,3 +5,4 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools

--- a/boards/arm/warp7_m4/warp7_m4.yaml
+++ b/boards/arm/warp7_m4/warp7_m4.yaml
@@ -13,6 +13,7 @@ flash: 32
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 testing:
   ignore_tags:
     - net


### PR DESCRIPTION
Update all ARM boards to have xtools as a supported toolchain.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>