### PR TITLE
Fix/enable runners on imx rt1020 and rt1060 boards

### DIFF
--- a/boards/arm/mimxrt1020_evk/board.cmake
+++ b/boards/arm/mimxrt1020_evk/board.cmake
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-board_runner_args(jlink "--device=MCIMXRT1021")
+board_runner_args(jlink "--device=MIMXRT1021xxx5A")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/mimxrt1020_evk/board.cmake
+++ b/boards/arm/mimxrt1020_evk/board.cmake
@@ -4,5 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set_ifndef(OPENSDA_FW jlink)
+
+if(OPENSDA_FW STREQUAL jlink)
+  set_ifndef(BOARD_DEBUG_RUNNER jlink)
+  set_ifndef(BOARD_FLASH_RUNNER jlink)
+elseif(OPENSDA_FW STREQUAL daplink)
+  set_ifndef(BOARD_DEBUG_RUNNER pyocd)
+  set_ifndef(BOARD_FLASH_RUNNER pyocd)
+endif()
+
+board_runner_args(pyocd "--target=mimxrt1020")
 board_runner_args(jlink "--device=MIMXRT1021xxx5A")
+
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/mimxrt1060_evk/board.cmake
+++ b/boards/arm/mimxrt1060_evk/board.cmake
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-board_runner_args(jlink "--device=MCIMXRT1062")
+board_runner_args(jlink "--device=MIMXRT1062xxx6A")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
- Fixes incorrect jlink device names on the rt1020 and rt1060 boards
- Enables pyocd runner on rt1020 board