### PR TITLE
cmake: Introduce simple host toolchain for POSIX arch

### DIFF
--- a/cmake/generic_toolchain.cmake
+++ b/cmake/generic_toolchain.cmake
@@ -46,15 +46,13 @@ assert(TOOLCHAIN_ROOT "Zephyr toolchain root path invalid: please set the TOOLCH
 set(ZEPHYR_TOOLCHAIN_VARIANT ${ZEPHYR_TOOLCHAIN_VARIANT} CACHE STRING "Zephyr toolchain variant")
 assert(ZEPHYR_TOOLCHAIN_VARIANT "Zephyr toolchain variant invalid: please set the ZEPHYR_TOOLCHAIN_VARIANT-variable")
 
-if(${ARCH} STREQUAL "posix" OR (ZEPHYR_TOOLCHAIN_VARIANT STREQUAL "host"))
-  set(COMPILER host-gcc)
+# Pick host system's toolchain if we are targeting posix
+if(${ARCH} STREQUAL "posix")
+  set(ZEPHYR_TOOLCHAIN_VARIANT "host")
 endif()
-
 
 # Configure the toolchain based on what SDK/toolchain is in use.
-if(NOT (COMPILER STREQUAL "host-gcc"))
-  include(${TOOLCHAIN_ROOT}/cmake/toolchain/${ZEPHYR_TOOLCHAIN_VARIANT}/generic.cmake)
-endif()
+include(${TOOLCHAIN_ROOT}/cmake/toolchain/${ZEPHYR_TOOLCHAIN_VARIANT}/generic.cmake)
 
 # Configure the toolchain based on what toolchain technology is used
 # (gcc, host-gcc etc.)

--- a/cmake/toolchain/host/generic.cmake
+++ b/cmake/toolchain/host/generic.cmake
@@ -1,0 +1,1 @@
+set(COMPILER host-gcc)

--- a/cmake/toolchain/host/target.cmake
+++ b/cmake/toolchain/host/target.cmake
@@ -1,0 +1,1 @@
+# This file intentionally left blank.


### PR DESCRIPTION
Make POSIX's host toolchain follow the convention of other toolchains.

In preparation for future toolchain abstraction.

-------------

Part of #16031