### PR TITLE
cmake: Toolchain abstraction: security

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,10 +75,13 @@ zephyr_compile_definitions(
   __ZEPHYR__=1
 )
 
-if(NOT CONFIG_NO_OPTIMIZATIONS)
-zephyr_compile_definitions(
-  _FORTIFY_SOURCE=2
-)
+# @Intent: Set compiler flags to enable buffer overflow checks in libc functions
+# @config in CONFIG_NO_OPTIMIZATIONS optional : Optimizations may affect security
+toolchain_cc_security_fortify()
+
+# @Intent: Set compiler flags to detect general stack overflows across all functions
+if(CONFIG_STACK_CANARIES)
+  toolchain_cc_security_canaries()
 endif()
 
 if(BUILD_VERSION)
@@ -268,13 +271,6 @@ zephyr_cc_option(-fno-pie)
 zephyr_cc_option(-fno-pic)
 zephyr_cc_option(-fno-strict-overflow)
 zephyr_cc_option(-Wno-pointer-sign)
-
-if(CONFIG_STACK_CANARIES)
-  zephyr_compile_options(-fstack-protector-all)
-
-  # Only a valid option with GCC 7.x and above
-  zephyr_cc_option(-mstack-protector-guard=global)
-endif()
 
 if(CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT)
   if(CONFIG_OMIT_FRAME_POINTER)

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -51,3 +51,8 @@ list(APPEND TOOLCHAIN_LIBS gcc)
 
 set(CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags} -Wl,--unresolved-symbols=ignore-in-object-files)
 string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+
+# Load toolchain_cc-family macros
+# Clang and GCC are almost feature+flag compatible, so reuse freestanding gcc
+include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_security_fortify.cmake)
+include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_security_canaries.cmake)

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -160,3 +160,7 @@ endforeach()
 # toolchain-specific flags at generation time.
 list(APPEND CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags} -Wl,--unresolved-symbols=ignore-in-object-files)
 string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+
+# Load toolchain_cc-family macros
+include(${ZEPHYR_BASE}/cmake/compiler/${COMPILER}/target_security_fortify.cmake)
+include(${ZEPHYR_BASE}/cmake/compiler/${COMPILER}/target_security_canaries.cmake)

--- a/cmake/compiler/gcc/target_security_canaries.cmake
+++ b/cmake/compiler/gcc/target_security_canaries.cmake
@@ -1,0 +1,9 @@
+# See root CMakeLists.txt for description and expectations of this macro
+macro(toolchain_cc_security_canaries)
+
+  zephyr_compile_options(-fstack-protector-all)
+
+  # Only a valid option with GCC 7.x and above
+  zephyr_cc_option(-mstack-protector-guard=global)
+
+endmacro()

--- a/cmake/compiler/gcc/target_security_fortify.cmake
+++ b/cmake/compiler/gcc/target_security_fortify.cmake
@@ -1,0 +1,13 @@
+# See root CMakeLists.txt for description and expectations of this macro
+macro(toolchain_cc_security_fortify)
+
+  if(NOT CONFIG_NO_OPTIMIZATIONS)
+    # _FORTIFY_SOURCE: Detect common-case buffer overflows for certain functions
+    # _FORTIFY_SOURCE=1 : Compile-time checks (requires -O1 at least)
+    # _FORTIFY_SOURCE=2 : Additional lightweight run-time checks
+    zephyr_compile_definitions(
+      _FORTIFY_SOURCE=2
+    )
+  endif()
+
+endmacro()

--- a/cmake/compiler/host-gcc/target.cmake
+++ b/cmake/compiler/host-gcc/target.cmake
@@ -41,3 +41,8 @@ assert_exists(LIBGCC_FILE_NAME)
 # "/usr/lib/gcc/x86_64-linux-gnu/7/IAMCU/libgcc.a" are unheard of.
 # So this does not support CONFIG_X86_IAMCU=y
 LIST(APPEND TOOLCHAIN_LIBS gcc)
+
+# Load toolchain_cc-family macros
+# Significant overlap with freestanding gcc compiler so reuse it
+include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_security_fortify.cmake)
+include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_security_canaries.cmake)


### PR DESCRIPTION
Introduce the first of the toolchain_cc-family of macros: toolchain_cc_security. More to come.

No functional change expected.

This is motivated by the wish to abstract Zephyr's usage of toolchains, permitting easier porting to other (commercial) toolchains.

Every toolchain's target.cmake must now make sure toolchain_cc_security macro is defined. Then it will be defined there, but only later called from `/CMakeLists.txt`. This pattern will be repeated for other aspects, like optimizations, warnings, linker, and binutils.

-------------

Part of #16031