### PR TITLE
net: tcp: Release connect() semaphore if connection is refused

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2198,6 +2198,8 @@ NET_CONN_CB(tcp_synack_received)
 
 		net_stats_update_tcp_seg_rst(net_pkt_iface(pkt));
 
+		k_sem_give(&context->tcp->connect_wait);
+
 		if (context->connect_cb) {
 			context->connect_cb(context, -ECONNREFUSED,
 					    context->user_data);


### PR DESCRIPTION
Trying to connect to a non-open socket causes connect() to hang forever.
This patch releases connect() to return error to the caller.

Signed-off-by: Björn Stenberg <bjorn@haxx.se>
