### PR TITLE
Bluetooth: shell: Fix incorrect indentation

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -325,7 +325,7 @@ static int cmd_init(const struct shell *shell, size_t argc, char *argv[])
 {
 	int err;
 
-    ctx_shell = shell;
+	ctx_shell = shell;
 
 	err = bt_enable(bt_ready);
 	if (err) {


### PR DESCRIPTION
This line was indented using four spaces instead of a tab.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>