### PR TITLE
doc: remove SYS_LOG from documentation

### DIFF
--- a/doc/subsystems/logging/index.rst
+++ b/doc/subsystems/logging/index.rst
@@ -4,5 +4,4 @@ Logging
 .. toctree::
    :maxdepth: 1
 
-   system_log
    logger

--- a/doc/subsystems/logging/system_log.rst
+++ b/doc/subsystems/logging/system_log.rst
@@ -1,7 +1,13 @@
+:orphan:
+
 .. _system_log:
 
-System Logging
-##############
+System Logging (Deprecated)
+###########################
+
+.. note::
+
+   This feature is deprecated, please use :ref:`logger` instead.
 
 The system log API provides a common interface to process messages issued by
 developers. These messages are currently printed on the terminal but the API is


### PR DESCRIPTION
Make old and obsoleted SYS_LOG orphan until we completely remove it.