### PR TITLE
soc: nrf: Add missing nRF52832 variants

### DIFF
--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_CIAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_CIAA
@@ -1,0 +1,20 @@
+# Kconfig.defconfig.nrf52832 - Nordic Semiconductor nRF52832 MCU
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
+if SOC_NRF52832_CIAA
+
+config SOC
+	string
+	default "nRF52832_CIAA"
+
+config NUM_IRQS
+	int
+	default 39
+
+endif # SOC_NRF52832_CIAA
+

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAB
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAB
@@ -1,0 +1,20 @@
+# Kconfig.defconfig.nrf52832 - Nordic Semiconductor nRF52832 MCU
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
+if SOC_NRF52832_QFAB
+
+config SOC
+	string
+	default "nRF52832_QFAB"
+
+config NUM_IRQS
+	int
+	default 39
+
+endif # SOC_NRF52832_QFAB
+

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.soc
@@ -1,6 +1,6 @@
 # Kconfig.soc - Nordic Semiconductor nRF52 MCU line
 #
-# Copyright (c) 2016 Nordic Semiconductor ASA
+# Copyright (c) 2016-2019 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -187,8 +187,16 @@ config SOC_NRF52810_QFAA
 	bool "NRF52810_QFAA"
 	select SOC_NRF52810
 
+config SOC_NRF52832_CIAA
+	bool "NRF52832_CIAA"
+	select SOC_NRF52832
+
 config SOC_NRF52832_QFAA
 	bool "NRF52832_QFAA"
+	select SOC_NRF52832
+
+config SOC_NRF52832_QFAB
+	bool "NRF52832_QFAB"
 	select SOC_NRF52832
 
 config SOC_NRF52840_QIAA


### PR DESCRIPTION
The CIAA and QFAB variants of the nRF52832 were missing in Kconfig,
although present in Device Tree. Add the relevant Kconfig entries in
order to be able to select them.

Fixes #12417

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>