### PR TITLE
Fixup the QSPI/Hyperflash nodes on i.mx RT boards

### DIFF
--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -27,7 +27,7 @@
 #if defined(CONFIG_CODE_ITCM)
 		zephyr,flash = &itcm0;
 #elif defined(CONFIG_CODE_QSPI)
-		zephyr,flash = &qspi0;
+		zephyr,flash = &is25wp064;
 #endif
 		zephyr,sram = &dtcm0;
 		zephyr,console = &uart1;
@@ -58,9 +58,10 @@
 };
 
 &flexspi0 {
-	qspi0: qspi@60000000 {
-		/* ISSI IS25LP064A-JBLE */
-		reg = <0x60000000 0x800000>;
+	reg = <0x402a8000 0x4000>, <0x60000000 0x800000>;
+	is25wp064: is25wp064@0 {
+		compatible = "issi,is25wp064", "jedec,spi-nor";
+		reg = <0>;
 		status = "ok";
 	};
 };

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -63,9 +63,10 @@
 arduino_serial: &uart3 {};
 
 &flexspi0 {
+	reg = <0x402a8000 0x4000>, <0x60000000 0x4000000>;
 	hyperflash0: hyperflash@0 {
-		/* Cypress S26KS512SDPBHI02 */
-		reg = <0x60000000 0x4000000>;
+		compatible = "cypress,s26ks512s";
+		reg = <0>;
 		status = "ok";
 	};
 };

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -11,7 +11,7 @@
 #if defined(CONFIG_CODE_ITCM)
 		zephyr,flash = &itcm0;
 #elif defined(CONFIG_CODE_QSPI)
-		zephyr,flash = &qspi0;
+		zephyr,flash = &is25wp064;
 #endif
 	};
 };
@@ -19,9 +19,10 @@
 /delete-node/ &hyperflash0;
 
 &flexspi0 {
-	qspi0: qspi@0 {
-		/* ISSI IS25WP064AJBLE */
-		reg = <0x60000000 0x800000>;
+	reg = <0x402a8000 0x4000>, <0x60000000 0x800000>;
+	is25wp064: is25wp064@0 {
+		compatible = "issi,is25wp064", "jedec,spi-nor";
+		reg = <0>;
 		status = "ok";
 	};
 };

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -27,7 +27,7 @@
 #if defined(CONFIG_CODE_ITCM)
 		zephyr,flash = &itcm0;
 #elif defined(CONFIG_CODE_QSPI)
-		zephyr,flash = &qspi0;
+		zephyr,flash = &is25wp064;
 #endif
 		zephyr,sram = &dtcm0;
 		zephyr,console = &uart1;
@@ -58,9 +58,10 @@
 };
 
 &flexspi0 {
-	qspi0: qspi@60000000 {
-		/* ISSI IS25WP064AJBLE */
-		reg = <0x60000000 0x800000>;
+	reg = <0x402a8000 0x4000>, <0x60000000 0x800000>;
+	is25wp064: is25wp064@0 {
+		compatible = "issi,is25wp064", "jedec,spi-nor";
+		reg = <0>;
 		status = "ok";
 	};
 };

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
@@ -16,11 +16,12 @@
 	};
 };
 
-/delete-node/ &qspi0;
+/delete-node/ &is25wp064;
 &flexspi0 {
-	hyperflash0: hyperflash@60000000 {
-		/* Cypress S26KS512SDPBHI02 */
-		reg = <0x60000000 0x4000000>;
+	reg = <0x402a8000 0x4000>, <0x60000000 0x4000000>;
+	hyperflash0: hyperflash@0 {
+		compatible = "cypress,s26ks512s";
+		reg = <0>;
 		status = "ok";
 	};
 };

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -51,7 +51,7 @@
 			interrupts = <108 0>;
 			label = "FLEXSPI0";
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		semc0: semc0@402f0000 {

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -21,7 +21,6 @@ bindings_compat = []
 old_alias_names = False
 
 regs_config = {
-    'zephyr,flash' : 'CONFIG_FLASH',
     'zephyr,sram'  : 'CONFIG_SRAM',
     'zephyr,ccm'   : 'CONFIG_CCM'
 }


### PR DESCRIPTION
The flash nodes were not correct for the cases of qspi or hyperflash.

Fixup the DTS nodes and flash generation script to handle things properly.