### PR TITLE
Lower bitrate to 125000 for stm32f072b_disco  

### DIFF
--- a/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
@@ -79,6 +79,6 @@
 &can1 {
 	pinctrl-0 = <&can_pins_a>;
 	pinctrl-names = "default";
-	bus-speed = <250000>;
+	bus-speed = <125000>;
 	status = "ok";
 };


### PR DESCRIPTION
For normal (over-the-wire) mode of CAN sample lowering bitrate to 125000 to ensure reliable transfer on stm32f072b_disco boards