### PR TITLE
Generate DT_<COMPAT>_<INSTANCE>_<PROP> defines

### DIFF
--- a/scripts/dts/extract/clocks.py
+++ b/scripts/dts/extract/clocks.py
@@ -71,10 +71,19 @@ class DTClocks(DTDirective):
                         clock_label = self.get_label_string([
                             clock_consumer_label, clock_cells_string,
                             str(clock_index)])
+                        add_compat_alias(node_address,
+                                self.get_label_string(["",
+                                    clock_cells_string, str(clock_index)]),
+                                clock_label, prop_alias)
                     else:
                         clock_label = self.get_label_string([
                             clock_consumer_label, clock_cells_string,
                             clock_cell_name, str(clock_index)])
+                        add_compat_alias(node_address,
+                                self.get_label_string(["",
+                                    clock_cells_string, clock_cell_name,
+                                    str(clock_index)]),
+                                clock_label, prop_alias)
                     prop_def[clock_label] = str(cell)
                     if clock_index == 0 and \
                         len(clocks) == (len(clock_cells) + 1):
@@ -110,6 +119,12 @@ class DTClocks(DTDirective):
                             clock_consumer_label, clock_cells_string,
                             clock_cell_name])
                         prop_alias[clock_alias_label] = clock_label
+                        add_compat_alias(node_address,
+                                self.get_label_string(["",
+                                    clock_cells_string, clock_cell_name]),
+                                clock_label, prop_alias)
+
+
                 # Legacy clocks definitions by extract_controller
                 clock_provider_label_str = clock_provider['props'].get('label',
                                                                        None)
@@ -131,6 +146,9 @@ class DTClocks(DTDirective):
                     clock_label = self.get_label_string([clock_consumer_label,
                                                          clock_cell_name,
                                                          index])
+                    add_compat_alias(node_address,
+                            self.get_label_string(["", clock_cell_name, index]),
+                            clock_label, prop_alias)
                     prop_def[clock_label] = '"' + clock_provider_label_str + '"'
                     if node_address in aliases:
                         add_prop_aliases(

--- a/scripts/dts/extract/compatible.py
+++ b/scripts/dts/extract/compatible.py
@@ -54,6 +54,27 @@ class DTCompatible(DTDirective):
                 }
                 insert_defs(node_address, load_defs, {})
 
+        # Generate defines of the form:
+        # #define DT_<COMPAT>_<INSTANCE ID> 1
+        instance = reduced[node_address]['instance_id']
+        for k in instance:
+            i = instance[k]
+            compat_instance = 'DT_' + convert_string_to_label(k) + '_' + str(i)
+            load_defs = {
+                compat_instance: "1",
+            }
+            insert_defs(node_address, load_defs, {})
+
+            # Generate defines of the form:
+            # #define DT_<COMPAT>_<INSTANCE ID>_BUS_<BUS> 1
+            if 'parent' in binding:
+                bus = binding['parent']['bus']
+                compat_instance += '_BUS_' + bus.upper()
+                load_defs = {
+                    compat_instance: "1",
+                }
+                insert_defs(node_address, load_defs, {})
+
 
 ##
 # @brief Management information for compatible.

--- a/scripts/dts/extract/default.py
+++ b/scripts/dts/extract/default.py
@@ -42,6 +42,10 @@ class DTDefault(DTDirective):
                 if isinstance(prop_value, str):
                     prop_value = "\"" + prop_value + "\""
                 prop_def[label + '_' + str(i)] = prop_value
+                add_compat_alias(node_address,
+                        prop_name + '_' + str(i),
+                        label + '_' + str(i),
+                        prop_alias)
         else:
             prop_name = convert_string_to_label(prop)
             label = def_label + '_' + prop_name
@@ -52,6 +56,7 @@ class DTDefault(DTDirective):
             if isinstance(prop_values, str):
                 prop_values = "\"" + prop_values + "\""
             prop_def[label] = prop_values
+            add_compat_alias(node_address, prop_name, label, prop_alias)
 
             # generate defs for node aliases
             if node_address in aliases:

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -168,6 +168,9 @@ def find_node_by_path(nodes, path):
 
 def get_reduced(nodes, path):
     # compress nodes list to nodes w/ paths, add interrupt parent
+    if 'last_used_id' not in get_reduced.__dict__:
+        get_reduced.last_used_id = {}
+
     if 'props' in nodes:
         status = nodes['props'].get('status')
 
@@ -176,11 +179,24 @@ def get_reduced(nodes, path):
 
     if isinstance(nodes, dict):
         reduced[path] = dict(nodes)
+
+        # assign an instance ID for each compat
+        compat = nodes['props'].get('compatible')
+        if (compat is not None):
+            if type(compat) is not list: compat = [ compat, ]
+            reduced[path]['instance_id'] = {}
+            for k in compat:
+                if k not in get_reduced.last_used_id.keys():
+                    get_reduced.last_used_id[k] = 0
+                else:
+                    get_reduced.last_used_id[k] += 1
+                reduced[path]['instance_id'][k] = get_reduced.last_used_id[k]
+
         reduced[path].pop('children', None)
         if path != '/':
             path += '/'
         if nodes['children']:
-            for k, v in nodes['children'].items():
+            for k, v in sorted(nodes['children'].items()):
                 get_reduced(v, path + k)
 
 

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -146,7 +146,12 @@ def insert_defs(node_address, new_defs, new_aliases):
         if key.startswith('DT_COMPAT_'):
             node_address = 'compatibles'
 
+    remove = [k for k in new_aliases if k in new_defs.keys()]
+    for k in remove: del new_aliases[k]
+
     if node_address in defs:
+        remove = [k for k in new_aliases if k in defs[node_address].keys()]
+        for k in remove: del new_aliases[k]
         if 'aliases' in defs[node_address]:
             defs[node_address]['aliases'].update(new_aliases)
         else:

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -297,6 +297,14 @@ def enable_old_alias_names(enable):
     global old_alias_names
     old_alias_names = enable
 
+def add_compat_alias(node_address, label_postfix, label, prop_aliases):
+    if ('instance_id' in reduced[node_address]):
+        instance = reduced[node_address]['instance_id']
+        for k in instance:
+            i = instance[k]
+            b = 'DT_' + convert_string_to_label(k) + '_' + str(i) + '_' + label_postfix
+            prop_aliases[b] = label
+
 def add_prop_aliases(node_address,
                      alias_label_function, prop_label, prop_aliases):
     node_compat = get_compat(node_address)

--- a/scripts/dts/extract/interrupts.py
+++ b/scripts/dts/extract/interrupts.py
@@ -76,9 +76,16 @@ class DTInterrupts(DTDirective):
 
                 l_fqn = '_'.join(l_base + l_cell_prefix + l_idx + l_cell_name)
                 prop_def[l_fqn] = props.pop(0)
+                add_compat_alias(node_address,
+                        '_'.join(l_cell_prefix + l_idx + l_cell_name),
+                        l_fqn, prop_alias)
+
                 if len(name):
                     alias_list = l_base + l_cell_prefix + name + l_cell_name
                     prop_alias['_'.join(alias_list)] = l_fqn
+                    add_compat_alias(node_address,
+                            '_'.join(l_cell_prefix + name + l_cell_name),
+                            l_fqn, prop_alias)
 
                 if node_address in aliases:
                     add_prop_aliases(

--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -77,13 +77,17 @@ class DTReg(DTDirective):
             l_size_fqn = '_'.join(l_base + l_size + l_idx)
             if nr_address_cells:
                 prop_def[l_addr_fqn] = hex(addr)
+                add_compat_alias(node_address, '_'.join(l_addr + l_idx), l_addr_fqn, prop_alias)
             if nr_size_cells:
                 prop_def[l_size_fqn] = int(size / div)
+                add_compat_alias(node_address, '_'.join(l_size + l_idx), l_size_fqn, prop_alias)
             if len(name):
                 if nr_address_cells:
                     prop_alias['_'.join(l_base + name + l_addr)] = l_addr_fqn
+                    add_compat_alias(node_address, '_'.join(name + l_addr), l_addr_fqn, prop_alias)
                 if nr_size_cells:
                     prop_alias['_'.join(l_base + name + l_size)] = l_size_fqn
+                    add_compat_alias(node_address, '_'.join(name + l_size), l_size_fqn, prop_alias)
 
             # generate defs for node aliases
             if node_address in aliases:

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -184,6 +184,7 @@ def extract_controller(node_address, prop, prop_values, index, def_label, generi
 
         label = l_base + [l_cellname] + l_idx
 
+        add_compat_alias(node_address, '_'.join(label[1:]), '_'.join(label), prop_alias)
         prop_def['_'.join(label)] = "\"" + l_cell + "\""
 
         #generate defs also if node is referenced as an alias in dts
@@ -262,6 +263,7 @@ def extract_cells(node_address, prop, prop_values, names, index,
         else:
             label = l_base + l_cell + l_cellname + l_idx
         label_name = l_base + [name] + l_cellname
+        add_compat_alias(node_address, '_'.join(label[1:]), '_'.join(label), prop_alias)
         prop_def['_'.join(label)] = prop_values.pop(0)
         if len(name):
             prop_alias['_'.join(label_name)] = '_'.join(label)
@@ -294,6 +296,10 @@ def extract_single(node_address, prop, key, def_label):
             label = def_label + '_' + k
             if isinstance(p, str):
                 p = "\"" + p + "\""
+            add_compat_alias(node_address,
+                    k + '_' + str(i),
+                    label + '_' + str(i),
+                    prop_alias)
             prop_def[label + '_' + str(i)] = p
     else:
         k = convert_string_to_label(key)
@@ -304,6 +310,7 @@ def extract_single(node_address, prop, key, def_label):
 
         if isinstance(prop, str):
             prop = "\"" + prop + "\""
+        add_compat_alias(node_address, k, label, prop_alias)
         prop_def[label] = prop
 
         # generate defs for node aliases


### PR DESCRIPTION
Add support to generate defines of the form DT_<COMPAT>_<INSTANCE>_<PROP>.  The idea is that we can utilize this in drivers to remove the need for dts_fixup.h.  The <INSTANCE> value is determined by the script and starts at 0 and counts up for each instance of a given <COMPAT>.  

This PR is based on some other cleanup work (PR #12423).