### PR TITLE
[DNM] cmake: dts: Extract #defines from root & SoC DTS compatible

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -94,6 +94,65 @@ if(SUPPORTS_DTS)
   endif()
 
   # Run the DTC on *.dts.pre.tmp to create the intermediary file *.dts_compiled
+  execute_process(
+    COMMAND ${DTC}
+    -O dts
+    -o ${BOARD}.dts_compiled
+    -b 0
+    ${BOARD}.dts.pre.tmp
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    RESULT_VARIABLE ret
+    )
+  if(NOT "${ret}" STREQUAL "0")
+    message(FATAL_ERROR "command failed with return code: ${ret}")
+  endif()
+
+  set(CMD_EARLY_EXTRACT_COMPAT ${PYTHON_EXECUTABLE}
+    ${ZEPHYR_BASE}/scripts/dts/extract_early_compat.py ${BOARD}.dts_compiled)
+
+  # Run extract_dts_includes.py to create a .conf and a header file that can be
+  # included into the CMake namespace
+  execute_process(
+    COMMAND ${CMD_EARLY_EXTRACT_COMPAT}
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    OUTPUT_VARIABLE COMPAT_DEFINES
+    RESULT_VARIABLE ret
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  if(NOT "${ret}" STREQUAL "0")
+    message(FATAL_ERROR "command failed with return code: ${ret}")
+  endif()
+  message("COMPAT DEFINES ARE ${COMPAT_DEFINES}")
+  separate_arguments(COMPAT_DEFINES)
+
+  # Run the C preprocessor on an empty C source file that has one or
+  # more DTS source files -include'd into it to create the
+  # intermediary file *.dts.pre.tmp
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER}
+    -x assembler-with-cpp
+    -nostdinc
+    -isystem ${DTS_APP_INCLUDE}
+    -isystem ${ZEPHYR_BASE}/include
+    -isystem ${ZEPHYR_BASE}/dts/${ARCH}
+    -isystem ${ZEPHYR_BASE}/dts
+    -include ${AUTOCONF_H}
+    ${DTC_INCLUDE_FLAG_FOR_DTS}  # include the DTS source and overlays
+    -I${ZEPHYR_BASE}/dts/common
+    ${COMPAT_DEFINES}
+    ${NOSYSDEF_CFLAG}
+    -D__DTS__
+    -P
+    -E ${ZEPHYR_BASE}/misc/empty_file.c
+    -o ${BOARD}.dts.pre.tmp
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    RESULT_VARIABLE ret
+    )
+  if(NOT "${ret}" STREQUAL "0")
+    message(FATAL_ERROR "command failed with return code: ${ret}")
+  endif()
+
+  # Run the DTC on *.dts.pre.tmp to create the intermediary file *.dts_compiled
 
   set(DTC_WARN_UNIT_ADDR_IF_ENABLED "")
   check_dtc_flag("-Wunique_unit_address_if_enabled" check)

--- a/scripts/dts/extract_early_compat.py
+++ b/scripts/dts/extract_early_compat.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2017, Linaro Limited
+# Copyright (c) 2018, Bobby Noelte
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# vim: ai:ts=4:sw=4
+
+import sys
+import pprint
+from devicetree import parse_file
+
+def convert_string_to_label(s):
+    # Transmute ,-@/ to _
+    s = s.replace("-", "_")
+    s = s.replace(",", "_")
+    s = s.replace("@", "_")
+    s = s.replace("/", "_")
+    # Uppercase the string
+    s = s.upper()
+    return s
+
+def main(args):
+    if len(args) == 1:
+        print('Usage: %s filename.dts' % args[0])
+        return 1
+
+    with open(args[1], "r") as fd:
+        dts = parse_file(fd)
+        root_compat = dts['/']['props']['compatible']
+        soc_compat = dts['/']['children']['soc']['props']['compatible']
+
+        if not isinstance(soc_compat, list):
+            soc_compat = [soc_compat]
+
+        if not isinstance(root_compat, list):
+            root_compat = [root_compat]
+
+        for k in root_compat:
+            if k != 'simple-bus':
+                sys.stdout.write('-D%s ' % convert_string_to_label(k))
+
+        for k in soc_compat:
+            if k != 'simple-bus':
+                sys.stdout.write('-DSOC_%s ' % convert_string_to_label(k))
+
+        sys.stdout.write('\n')
+        sys.stdout.flush()
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Utilize the root compatible and "/soc" compatible nodes to create a set of defines that are utilized inside the DTS.

This requires a two pass of the DTS, one to get the /root and /soc nodes, and a second once we know the #defines we want to generate.