### PR TITLE
boards: arm: frdm_k64f: remove default n configs

### DIFF
--- a/boards/arm/frdm_k64f/Kconfig.defconfig
+++ b/boards/arm/frdm_k64f/Kconfig.defconfig
@@ -75,9 +75,6 @@ if I2C
 config I2C_0
 	default y
 
-config I2C_1
-	default n
-
 endif # I2C
 
 if ADC
@@ -98,12 +95,6 @@ if SPI
 
 config SPI_0
 	default y
-
-config SPI_1
-	default n
-
-config SPI_2
-	default n
 
 endif # SPI
 


### PR DESCRIPTION
Bool configs are default n, unless explicitly set otherwise.

Signed-off-by: Sean Nyekjaer <sean.nyekjaer@prevas.dk>