### PR TITLE
logging: Fix reporting of dropped logs before backend init

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -386,7 +386,7 @@ bool log_process(bool bypass)
 {
 	struct log_msg *msg;
 
-	if (!backend_attached) {
+	if (!backend_attached && !bypass) {
 		return false;
 	}
 	unsigned int key = irq_lock();


### PR DESCRIPTION
Dropped logs were not counted if logger has no backend
attached (system startup phase).

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>