### PR TITLE
runners: add Black Magic Probe runner cmake file

### DIFF
--- a/boards/common/blackmagicprobe.board.cmake
+++ b/boards/common/blackmagicprobe.board.cmake
@@ -1,0 +1,3 @@
+set_ifndef(BOARD_FLASH_RUNNER blackmagicprobe)
+set_ifndef(BOARD_DEBUG_RUNNER blackmagicprobe)
+board_finalize_runner_args(blackmagicprobe) # No default arguments to provide


### PR DESCRIPTION
Added required cmake file for blackmagicprobe
runner added in #12380.

Signed-off-by: Tavish Naruka <tavishnaruka@gmail.com>