### PR TITLE
boards: arm: nrf52840_pca10059: more dts updates

### DIFF
--- a/boards/arm/nrf52840_pca10059/fstab-debugger.dts
+++ b/boards/arm/nrf52840_pca10059/fstab-debugger.dts
@@ -12,25 +12,25 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* The size of this partition ensures MCUBoot can be built
-		 * with an RTT console, CDC ACM support, and w/o optimizations
+		/* The size of this partition ensures that MCUBoot can be built
+		 * with an RTT console, CDC ACM support, and w/o optimizations.
 		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000f000>;
+			reg = <0x000000000 0x00012000>;
 		};
 
-		slot0_partition: partition@f000 {
+		slot0_partition: partition@12000 {
 			label = "image-0";
-			reg = <0x0000f000 0x000069000>;
+			reg = <0x00012000 0x000069000>;
 		};
-		slot1_partition: partition@78000 {
+		slot1_partition: partition@7b000 {
 			label = "image-1";
-			reg = <0x00078000 0x000069000>;
+			reg = <0x0007b000 0x000069000>;
 		};
-		scratch_partition: partition@e1000 {
+		scratch_partition: partition@e4000 {
 			label = "image-scratch";
-			reg = <0x000e1000 0x0001b000>;
+			reg = <0x000e4000 0x00018000>;
 		};
 		storage_partition: partition@fc000 {
 			label = "storage";

--- a/boards/arm/nrf52840_pca10059/fstab-stock.dts
+++ b/boards/arm/nrf52840_pca10059/fstab-stock.dts
@@ -13,8 +13,8 @@
 		#size-cells = <1>;
 
 		/* MCUboot placed after Nordic MBR.
-		 * The size of this partition ensures MCUBoot can be built
-		 * with an RTT console, CDC ACM support, and w/o optimizations.
+		 * The size of this partition ensures that MCUBoot
+		 * can be built with CDC ACM support and w/o optimizations.
 		 */
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059_defconfig
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059_defconfig
@@ -14,7 +14,6 @@ CONFIG_UART_INTERRUPT_DRIVEN=y
 
 # enable console
 CONFIG_CONSOLE=y
-CONFIG_RTT_CONSOLE=y
 
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y


### PR DESCRIPTION
- Remove RTT_CONSOLE from board defaults
- Fix comment in fstab-stock to reflect that no RTT console is available
- Update MCUBoot partition in fstab-debugger to have enough space for RTT console and logs

@carlescufi please have a look.


