### PR TITLE
soc: select CONFIG_CPU_CORTEX_M_HAS_VTOR for SAMD21 series

### DIFF
--- a/soc/arm/atmel_sam0/samd20/Kconfig.series
+++ b/soc/arm/atmel_sam0/samd20/Kconfig.series
@@ -5,11 +5,11 @@
 
 config SOC_SERIES_SAMD20
 	bool "Atmel SAMD20 MCU"
-	select CPU_CORTEX_M
 	select CPU_CORTEX_M0PLUS
 	select SOC_FAMILY_SAM0
 	select SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	select CPU_HAS_SYSTICK
+	select CPU_CORTEX_M_HAS_VTOR
 	select ASF
 	help
 	  Enable support for Atmel SAMD20 Cortex-M0+ microcontrollers.

--- a/soc/arm/atmel_sam0/samd21/Kconfig.series
+++ b/soc/arm/atmel_sam0/samd21/Kconfig.series
@@ -9,6 +9,7 @@ config SOC_SERIES_SAMD21
 	select SOC_FAMILY_SAM0
 	select SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	select CPU_HAS_SYSTICK
+	select CPU_CORTEX_M_HAS_VTOR
 	select ASF
 	help
 	  Enable support for Atmel SAMD21 Cortex-M0+ microcontrollers.


### PR DESCRIPTION
SAMD21 series have available the Optional Vector Table Offset Register (VTOR).

If this option is not selected, SCB->VTOR is not configured properly and the application hangs if it's located in an offset different than 0. 

Screenshot from the datasheet attached.

![image](https://user-images.githubusercontent.com/3835572/51060405-f5fee300-15ef-11e9-8c87-8aad77a0bb25.png)
