### PR TITLE
scripts: Update pyocd version to 0.14.3

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -10,7 +10,7 @@ ply==3.10
 hub==2.0
 gitlint
 pyelftools==0.24
-pyocd==0.12.0
+pyocd==0.14.3
 pyserial
 pykwalify
 # "win32" is used for 64-bit Windows as well


### PR DESCRIPTION
pyocd recently merged its command-line tools into a unified pyocd tool
with subcommands. The separate command-line tools still remain, but are
deprecated. Update the pyocd version required by zephyr in preparation
for updating the pyocd runner to use the new unified tool commands.

Pin pyocd to a specific version rather than allowing any version greater
than or equal to 0.14.0 because there have been a few unstable releases
recently. Version 0.14.3 is what I have been using locally and know to
be stable.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>