### PR TITLE
esp32: fix build error regarding multiplt BIT() definitions

### DIFF
--- a/arch/xtensa/core/irq_offload.c
+++ b/arch/xtensa/core/irq_offload.c
@@ -8,11 +8,6 @@
 #include <arch/xtensa/arch.h>
 #include <xtensa_api.h>
 
-#ifndef CONFIG_BOARD_QEMU_XTENSA
-/* qemu_xtensa has no soc definitions */
-#include <soc.h>
-#endif
-
 /*
  * Xtensa core should support software interrupt in order to allow using
  * irq_offload feature


### PR DESCRIPTION
This partially reverts commit 5a47c60dbf4f24fa9ad2206502d5eab152587eac.
The soc.h is now only included when _soc_irq_*() is being referred.

Fixes #11077.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>