### PR TITLE
net: Fix inet_pton when offloading is enabled

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -261,6 +261,11 @@ static inline void freeaddrinfo(struct zsock_addrinfo *ai)
 
 #define addrinfo zsock_addrinfo
 
+static inline int inet_pton(sa_family_t family, const char *src, void *dst)
+{
+	return zsock_inet_pton(family, src, dst);
+}
+
 #else
 
 struct addrinfo {
@@ -275,6 +280,21 @@ struct addrinfo {
 };
 
 #include <net/socket_offload.h>
+
+static inline int inet_pton(sa_family_t family, const char *src, void *dst)
+{
+	if ((family != AF_INET) && (family != AF_INET6)) {
+		errno = EAFNOSUPPORT;
+		return -1;
+	}
+
+	if (net_addr_pton(family, src, dst) == 0) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
 #endif /* !defined(CONFIG_NET_SOCKETS_OFFLOAD) */
 
 #define POLLIN ZSOCK_POLLIN
@@ -290,11 +310,6 @@ static inline char *inet_ntop(sa_family_t family, const void *src, char *dst,
 			      size_t size)
 {
 	return net_addr_ntop(family, src, dst, size);
-}
-
-static inline int inet_pton(sa_family_t family, const char *src, void *dst)
-{
-	return zsock_inet_pton(family, src, dst);
 }
 
 #define EAI_BADFLAGS DNS_EAI_BADFLAGS


### PR DESCRIPTION
When offloading is enabled, a call to inet_pton() results in a call to
zsock_inet_pton() based on its implementation in include/net/socket.h.
This eventually leads to a call to _impl_zsock_inet_pton(), which is
not defined when offloading is enabled.

In this commit, we have chosen to directly call net_addr_pton() in
inet_pton() in the offload case to be efficient, and keep the
implementation as it is when offload is not enabled.

Fixes #12441

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>