### PR TITLE
soc: intel_s1000: Add SoC routine for GNA power-up

### DIFF
--- a/soc/xtensa/intel_s1000/soc.h
+++ b/soc/xtensa/intel_s1000/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2019 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -161,11 +161,21 @@ struct soc_dsp_shim_regs {
 /* Global Control registers */
 #define SOC_S1000_GLB_CTRL_BASE			(0x00081C00)
 
-#define SOC_S1000_GLB_CTRL_STRAPS		(SOC_S1000_GLB_CTRL_BASE + 0x40)
+#define SOC_GNA_POWER_CONTROL_SPA		(BIT(0))
+#define SOC_GNA_POWER_CONTROL_CPA		(BIT(8))
+#define SOC_GNA_POWER_CONTROL_CLK_EN		(BIT(16))
+
 #define SOC_S1000_STRAP_REF_CLK			(BIT_MASK(2) << 3)
 #define SOC_S1000_STRAP_REF_CLK_38P4		(0 << 3)
 #define SOC_S1000_STRAP_REF_CLK_19P2		(1 << 3)
 #define SOC_S1000_STRAP_REF_CLK_24P576		(2 << 3)
+
+struct soc_global_regs {
+	u32_t	reserved1[8];
+	u32_t	gna_power_control;
+	u32_t	reserved2[7];
+	u32_t	straps;
+};
 
 extern void _soc_irq_enable(u32_t irq);
 extern void _soc_irq_disable(u32_t irq);


### PR DESCRIPTION
This PR adds an SoC level routine to turn power and clock on for Intel GNA block in Intel S1000 SoC.
