### PR TITLE
Bluetooth: Mesh: Fixes existing friend lookup in Friend Request handling

### DIFF
--- a/subsys/bluetooth/host/mesh/friend.c
+++ b/subsys/bluetooth/host/mesh/friend.c
@@ -848,13 +848,7 @@ int bt_mesh_friend_req(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 	}
 
 	old_friend = sys_be16_to_cpu(msg->prev_addr);
-	if (BT_MESH_ADDR_IS_UNICAST(old_friend)) {
-		frnd = bt_mesh_friend_find(rx->sub->net_idx, old_friend,
-					   true, false);
-	} else {
-		frnd = bt_mesh_friend_find(rx->sub->net_idx, rx->ctx.addr,
-					   true, false);
-	}
+	frnd = bt_mesh_friend_find(rx->sub->net_idx, rx->ctx.addr, true, false);
 
 	if (frnd) {
 		BT_WARN("Existing LPN re-requesting Friendship");


### PR DESCRIPTION
Currently, when handling a Friend Request message with `prev_addr` set, we look
up existing friend entry using `prev_addr` as the address. However, `prev_addr`
is the address of the requesting node's previous friend, NOT the address of the
requesting node itself. Therefore, we should always look up existing friend
entry using `rx->ctx.addr` as the address.