### PR TITLE
Bluetooth: Mesh: Remove redundant stack variable

### DIFF
--- a/subsys/bluetooth/host/mesh/friend.c
+++ b/subsys/bluetooth/host/mesh/friend.c
@@ -802,7 +802,6 @@ int bt_mesh_friend_req(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 {
 	struct bt_mesh_ctl_friend_req *msg = (void *)buf->data;
 	struct bt_mesh_friend *frnd = NULL;
-	u16_t old_friend;
 	u32_t poll_to;
 	int i;
 
@@ -847,9 +846,7 @@ int bt_mesh_friend_req(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 		return 0;
 	}
 
-	old_friend = sys_be16_to_cpu(msg->prev_addr);
 	frnd = bt_mesh_friend_find(rx->sub->net_idx, rx->ctx.addr, true, false);
-
 	if (frnd) {
 		BT_WARN("Existing LPN re-requesting Friendship");
 		friend_clear(frnd);
@@ -881,8 +878,8 @@ init_friend:
 	BT_DBG("LPN 0x%04x rssi %d recv_delay %u poll_to %ums",
 	       frnd->lpn, rx->rssi, frnd->recv_delay, frnd->poll_to);
 
-	if (BT_MESH_ADDR_IS_UNICAST(old_friend) &&
-	    !bt_mesh_elem_find(old_friend)) {
+	if (BT_MESH_ADDR_IS_UNICAST(frnd->clear.frnd) &&
+	    !bt_mesh_elem_find(frnd->clear.frnd)) {
 		clear_procedure_start(frnd);
 	}
 


### PR DESCRIPTION
The msg->prev_addr is already stored in frnd->clear.frnd, so there's
no need to have an extra stack variable for this (in the form of
prev_addr).

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>