### PR TITLE
boards: arm: Cleanup xtools toolchain support

### DIFF
--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
@@ -11,5 +11,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 ram: 128
 flash: 128

--- a/boards/arm/mps2_an385/mps2_an385.yaml
+++ b/boards/arm/mps2_an385/mps2_an385.yaml
@@ -7,6 +7,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-  - xtools
 testing:
   default: true

--- a/boards/arm/nrf52840_blip/nrf52840_blip.yaml
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - adc
   - usb_device

--- a/boards/arm/particle_argon/particle_argon.yaml
+++ b/boards/arm/particle_argon/particle_argon.yaml
@@ -7,6 +7,7 @@ flash: 1024
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - i2c
   - spi

--- a/boards/arm/particle_boron/particle_boron.yaml
+++ b/boards/arm/particle_boron/particle_boron.yaml
@@ -7,6 +7,7 @@ flash: 1024
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - i2c
   - spi

--- a/boards/arm/particle_xenon/particle_xenon.yaml
+++ b/boards/arm/particle_xenon/particle_xenon.yaml
@@ -12,6 +12,7 @@ flash: 1024
 toolchain:
   - zephyr
   - gnuarmemb
+  - xtools
 supported:
   - i2c
   - spi


### PR DESCRIPTION
Add 'xtools' as supported toolchain for new boards and remove duplicate
entry from mps2_an385

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>