### PR TITLE
Bluetooth: Fixes length limit in `bt_hex_real`

### DIFF
--- a/subsys/bluetooth/common/log.c
+++ b/subsys/bluetooth/common/log.c
@@ -26,7 +26,7 @@ const char *bt_hex_real(const void *buf, size_t len)
 	const u8_t *b = buf;
 	int i;
 
-	len = min(len, (sizeof(hex) - 1) / 2);
+	len = min(len, (sizeof(str) - 1) / 2);
 
 	for (i = 0; i < len; i++) {
 		str[i * 2]     = hex[b[i] >> 4];


### PR DESCRIPTION
Since `str` is the output buffer, `bt_hex_real` should limit its output
length according to the `str` size, not the `hex` size.

Signed-off-by: Jiahao Li <reg@ljh.me>