### PR TITLE
drivers/pinmux: stm32: Clean up after gpio driver factorization

### DIFF
--- a/drivers/pinmux/stm32/pinmux_stm32.c
+++ b/drivers/pinmux/stm32/pinmux_stm32.c
@@ -23,6 +23,10 @@
 
 #include "pinmux.h"
 
+#define GPIO_REG_SIZE         0x400
+/* base address for where GPIO registers start */
+#define GPIO_PORTS_BASE       (GPIOA_BASE)
+
 static const u32_t ports_enable[STM32_PORTS_MAX] = {
 	STM32_PERIPH_GPIOA,
 	STM32_PERIPH_GPIOB,

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -18,10 +18,6 @@
 #ifndef _STM32F0_SOC_H_
 #define _STM32F0_SOC_H_
 
-#define GPIO_REG_SIZE         0x400
-/* base address for where GPIO registers start */
-#define GPIO_PORTS_BASE       (GPIOA_BASE)
-
 #ifndef _ASMLANGUAGE
 
 #include <stm32f0xx.h>

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -18,10 +18,6 @@
 #ifndef _STM32F1_SOC_H_
 #define _STM32F1_SOC_H_
 
-#define GPIO_REG_SIZE         0x400
-/* base address for where GPIO registers start */
-#define GPIO_PORTS_BASE       (GPIOA_BASE)
-
 #ifndef _ASMLANGUAGE
 
 #include <stm32f1xx.h>

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -17,10 +17,6 @@
 #ifndef _STM32F2_SOC_H_
 #define _STM32F2_SOC_H_
 
-#define GPIO_REG_SIZE         0x400
-/* base address for where GPIO registers start */
-#define GPIO_PORTS_BASE       (GPIOA_BASE)
-
 #ifndef _ASMLANGUAGE
 
 #include <stm32f2xx.h>

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -19,10 +19,6 @@
 #ifndef _STM32F3_SOC_H_
 #define _STM32F3_SOC_H_
 
-#define GPIO_REG_SIZE         0x400
-/* base address for where GPIO registers start */
-#define GPIO_PORTS_BASE       (GPIOA_BASE)
-
 #ifndef _ASMLANGUAGE
 
 #include <stm32f3xx.h>

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -18,10 +18,6 @@
 #ifndef _STM32F4_SOC_H_
 #define _STM32F4_SOC_H_
 
-#define GPIO_REG_SIZE         0x400
-/* base address for where GPIO registers start */
-#define GPIO_PORTS_BASE       (GPIOA_BASE)
-
 #ifndef _ASMLANGUAGE
 
 #include <stm32f4xx.h>

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -17,10 +17,6 @@
 #ifndef _STM32F7_SOC_H_
 #define _STM32F7_SOC_H_
 
-#define GPIO_REG_SIZE         0x400
-/* base address for where GPIO registers start */
-#define GPIO_PORTS_BASE       (GPIOA_BASE)
-
 #ifndef _ASMLANGUAGE
 
 #include <stm32f7xx.h>

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -17,10 +17,6 @@
 #ifndef _STM32L0_SOC_H_
 #define _STM32L0_SOC_H_
 
-#define GPIO_REG_SIZE         0x400
-/* base address for where GPIO registers start */
-#define GPIO_PORTS_BASE       (GPIOA_BASE)
-
 #ifndef _ASMLANGUAGE
 
 #include <stm32l0xx.h>

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -30,10 +30,6 @@
  */
 #include <kernel_includes.h>
 
-#define GPIO_REG_SIZE         0x400
-/* base address for where GPIO registers start */
-#define GPIO_PORTS_BASE       (GPIOA_BASE)
-
 #ifdef CONFIG_GPIO_STM32
 /* Required to enable VDDio2 for port G */
 #include <stm32l4xx_ll_pwr.h>


### PR DESCRIPTION
Clean up a left over from GPIO driver factorization.
Definition of GPIO_REG_SIZE and GPIO_PORTS_BASE do not need anymore
to be spread accross SoCs.
Put these definitions directly in STM32 pinmux driver.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>