### PR TITLE
boards: arm: stm32: Add jlink support for STM32F746G-DISCO board

### DIFF
--- a/boards/arm/stm32f746g_disco/board.cmake
+++ b/boards/arm/stm32f746g_disco/board.cmake
@@ -1,1 +1,8 @@
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+set_ifndef(STLINK_FW stlink)
+
+if(STLINK_FW STREQUAL jlink)
+  board_runner_args(jlink "--device=stm32f746NG" "--speed=4000")
+  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+elseif(STLINK_FW STREQUAL stlink)
+  include($ENV{ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+endif


### PR DESCRIPTION
The patch add jlink support for STM#@F746G discovery board

Signed-off-by: Wim Van Loocke <wimvanloocke@gmail.com>