### PR TITLE
drivers/interrupt_controller: stm32: Complete driver factorization

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -306,7 +306,10 @@ static int gpio_stm32_config(struct device *dev, int access_op,
 			stm32_exti_trigger(pin, edge);
 		}
 
-		stm32_exti_enable(pin);
+		if (stm32_exti_enable(pin) != 0) {
+			return -ENOSYS;
+		}
+
 	}
 
 	return 0;

--- a/drivers/interrupt_controller/exti_stm32.c
+++ b/drivers/interrupt_controller/exti_stm32.c
@@ -23,23 +23,23 @@
 #include <misc/__assert.h>
 #include "exti_stm32.h"
 
-#ifdef CONFIG_SOC_SERIES_STM32F0X
+#if defined(CONFIG_SOC_SERIES_STM32F0X)
 #define EXTI_LINES 32
-#elif CONFIG_SOC_SERIES_STM32F1X
+#elif defined(CONFIG_SOC_SERIES_STM32F1X)
 #define EXTI_LINES 19
-#elif CONFIG_SOC_SERIES_STM32F2X
+#elif defined(CONFIG_SOC_SERIES_STM32F2X)
 #define EXTI_LINES 23
-#elif CONFIG_SOC_STM32F302X8
+#elif defined(CONFIG_SOC_STM32F302X8)
 #define EXTI_LINES 36
-#elif CONFIG_SOC_STM32F303XC
+#elif defined(CONFIG_SOC_STM32F303XC)
 #define EXTI_LINES 36
-#elif CONFIG_SOC_STM32F334X8
+#elif defined(CONFIG_SOC_STM32F334X8)
 #define EXTI_LINES 36
-#elif CONFIG_SOC_STM32F373XC
+#elif defined(CONFIG_SOC_STM32F373XC)
 #define EXTI_LINES 29
-#elif CONFIG_SOC_SERIES_STM32F4X
+#elif defined(CONFIG_SOC_SERIES_STM32F4X)
 #define EXTI_LINES 23
-#elif CONFIG_SOC_SERIES_STM32F7X
+#elif defined(CONFIG_SOC_SERIES_STM32F7X)
 #define EXTI_LINES 24
 #elif defined(CONFIG_SOC_SERIES_STM32L0X)
 #define EXTI_LINES 30
@@ -100,7 +100,8 @@ void stm32_exti_enable(int line)
 
 	exti->imr |= 1 << line;
 
-#ifdef CONFIG_SOC_SERIES_STM32F0X
+#if defined(CONFIG_SOC_SERIES_STM32F0X) || \
+    defined(CONFIG_SOC_SERIES_STM32L0X)
 	if (line >= 4 && line <= 15) {
 		irqnum = EXTI4_15_IRQn;
 	}	else if (line >= 2  && line <= 3) {
@@ -117,16 +118,12 @@ void stm32_exti_enable(int line)
 		 */
 		return;
 	}
-#elif CONFIG_SOC_SERIES_STM32F1X
-	if (line >= 5 && line <= 9) {
-		irqnum = EXTI9_5_IRQn;
-	} else if (line >= 10 && line <= 15) {
-		irqnum = EXTI15_10_IRQn;
-	} else {
-		/* pins 0..4 are mapped to EXTI0.. EXTI4 */
-		irqnum = EXTI0_IRQn + line;
-	}
-#elif CONFIG_SOC_SERIES_STM32F2X
+#elif defined(CONFIG_SOC_SERIES_STM32F1X) || \
+      defined(CONFIG_SOC_SERIES_STM32F2X) || \
+      defined(CONFIG_SOC_SERIES_STM32F3X) || \
+      defined(CONFIG_SOC_SERIES_STM32F4X) || \
+      defined(CONFIG_SOC_SERIES_STM32F7X) || \
+      defined(CONFIG_SOC_SERIES_STM32L4X)
 	if (line >= 5 && line <= 9) {
 		irqnum = EXTI9_5_IRQn;
 	} else if (line >= 10 && line <= 15) {
@@ -136,6 +133,9 @@ void stm32_exti_enable(int line)
 		irqnum = EXTI0_IRQn + line;
 	} else {
 		switch (line) {
+#if defined(CONFIG_SOC_SERIES_STM32F2X) || \
+    defined(CONFIG_SOC_SERIES_STM32F4X) || \
+    defined(CONFIG_SOC_SERIES_STM32F7X)
 		case 16:
 			irqnum = PVD_IRQn;
 			break;
@@ -151,107 +151,15 @@ void stm32_exti_enable(int line)
 		case 22:
 			irqnum = RTC_WKUP_IRQn;
 			break;
-		}
-	}
-#elif CONFIG_SOC_SERIES_STM32F3X
-	if (line >= 5 && line <= 9) {
-		irqnum = EXTI9_5_IRQn;
-	} else if (line >= 10 && line <= 15) {
-		irqnum = EXTI15_10_IRQn;
-	} else {
-		/* pins 0..4 are mapped to EXTI0.. EXTI4 */
-		irqnum = EXTI0_IRQn + line;
-	}
-#elif CONFIG_SOC_SERIES_STM32F4X
-	if (line >= 5 && line <= 9) {
-		irqnum = EXTI9_5_IRQn;
-	} else if (line >= 10 && line <= 15) {
-		irqnum = EXTI15_10_IRQn;
-	} else if (line >= 0 && line <= 4) {
-		/* pins 0..4 are mapped to EXTI0.. EXTI4 */
-		irqnum = EXTI0_IRQn + line;
-	} else {
-		switch (line) {
-		case 16:
-			irqnum = PVD_IRQn;
-			break;
-		case 17:
-			irqnum = RTC_Alarm_IRQn;
-			break;
-		case 18:
-			irqnum = OTG_FS_WKUP_IRQn;
-			break;
-		case 21:
-			irqnum = TAMP_STAMP_IRQn;
-			break;
-		case 22:
-			irqnum = RTC_WKUP_IRQn;
-			break;
-		}
-	}
-#elif CONFIG_SOC_SERIES_STM32F7X
-	if (line >= 5 && line <= 9) {
-		irqnum = EXTI9_5_IRQn;
-	} else if (line >= 10 && line <= 15) {
-		irqnum = EXTI15_10_IRQn;
-	} else if (line >= 0 && line <= 4) {
-		/* pins 0..4 are mapped to EXTI0.. EXTI4 */
-		irqnum = EXTI0_IRQn + line;
-	} else {
-		switch (line) {
-		case 16:
-			irqnum = PVD_IRQn;
-			break;
-		case 17:
-			irqnum = RTC_Alarm_IRQn;
-			break;
-		case 18:
-			irqnum = OTG_FS_WKUP_IRQn;
-			break;
-		case 21:
-			irqnum = TAMP_STAMP_IRQn;
-			break;
-		case 22:
-			irqnum = RTC_WKUP_IRQn;
-			break;
+#endif
+#if defined(CONFIG_SOC_SERIES_STM32F7X)
 		case 23:
 			irqnum = LPTIM1_IRQn;
 			break;
+#endif
+		default:
+			return;
 		}
-	}
-#elif defined(CONFIG_SOC_SERIES_STM32L0X)
-	if (line >= 4 && line <= 15) {
-		irqnum = EXTI4_15_IRQn;
-	}	else if (line >= 2  && line <= 3) {
-		irqnum = EXTI2_3_IRQn;
-	}	else if (line >= 0  && line <= 1) {
-		irqnum = EXTI0_1_IRQn;
-	} else {
-		/* > 15 are not mapped on an IRQ */
-		/*
-		 * On STM32L0X, this function also support enabling EXTI
-		 * lines that are not connected to an IRQ. This might be used
-		 * by other drivers or boards, to allow the device wakeup on
-		 * some non-GPIO signals.
-		 */
-		return;
-	}
-#elif defined(CONFIG_SOC_SERIES_STM32L4X)
-	if (line >= 5 && line <= 9) {
-		irqnum = EXTI9_5_IRQn;
-	} else if (line >= 10 && line <= 15) {
-		irqnum = EXTI15_10_IRQn;
-	} else if (line < 5) {
-		/* pins 0..4 are mapped to EXTI0.. EXTI4 */
-		irqnum = EXTI0_IRQn + line;
-	} else {/* > 15 are not mapped on an IRQ */
-		/*
-		 * On STM32L4X, this function also support enabling EXTI
-		 * lines that are not connected to an IRQ. This might be used
-		 * by other drivers or boards, to allow the device wakeup on
-		 * some non-GPIO signals.
-		 */
-		return;
 	}
 #else
 	#error "Unknown STM32 SoC"
@@ -476,7 +384,8 @@ static void __stm32_exti_connect_irqs(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-#ifdef CONFIG_SOC_SERIES_STM32F0X
+#if defined(CONFIG_SOC_SERIES_STM32F0X) || \
+    defined(CONFIG_SOC_SERIES_STM32L0X)
 	IRQ_CONNECT(EXTI0_1_IRQn,
 		CONFIG_EXTI_STM32_EXTI1_0_IRQ_PRI,
 		__stm32_exti_isr_0_1, DEVICE_GET(exti_stm32),
@@ -489,7 +398,12 @@ static void __stm32_exti_connect_irqs(struct device *dev)
 		CONFIG_EXTI_STM32_EXTI15_4_IRQ_PRI,
 		__stm32_exti_isr_4_15, DEVICE_GET(exti_stm32),
 		0);
-#elif CONFIG_SOC_SERIES_STM32F1X
+#elif defined(CONFIG_SOC_SERIES_STM32F1X) || \
+      defined(CONFIG_SOC_SERIES_STM32F2X) || \
+      defined(CONFIG_SOC_SERIES_STM32F3X) || \
+      defined(CONFIG_SOC_SERIES_STM32F4X) || \
+      defined(CONFIG_SOC_SERIES_STM32F7X) || \
+      defined(CONFIG_SOC_SERIES_STM32L4X)
 	IRQ_CONNECT(EXTI0_IRQn,
 		CONFIG_EXTI_STM32_EXTI0_IRQ_PRI,
 		__stm32_exti_isr_0, DEVICE_GET(exti_stm32),
@@ -498,117 +412,17 @@ static void __stm32_exti_connect_irqs(struct device *dev)
 		CONFIG_EXTI_STM32_EXTI1_IRQ_PRI,
 		__stm32_exti_isr_1, DEVICE_GET(exti_stm32),
 		0);
-	IRQ_CONNECT(EXTI2_IRQn,
-		CONFIG_EXTI_STM32_EXTI2_IRQ_PRI,
-		__stm32_exti_isr_2, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI3_IRQn,
-		CONFIG_EXTI_STM32_EXTI3_IRQ_PRI,
-		__stm32_exti_isr_3, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI4_IRQn,
-		CONFIG_EXTI_STM32_EXTI4_IRQ_PRI,
-		__stm32_exti_isr_4, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI9_5_IRQn,
-		CONFIG_EXTI_STM32_EXTI9_5_IRQ_PRI,
-		__stm32_exti_isr_9_5, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI15_10_IRQn,
-		CONFIG_EXTI_STM32_EXTI15_10_IRQ_PRI,
-		__stm32_exti_isr_15_10, DEVICE_GET(exti_stm32),
-		0);
-#elif CONFIG_SOC_SERIES_STM32F2X
-	IRQ_CONNECT(EXTI0_IRQn,
-		CONFIG_EXTI_STM32_EXTI0_IRQ_PRI,
-		__stm32_exti_isr_0, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI1_IRQn,
-		CONFIG_EXTI_STM32_EXTI1_IRQ_PRI,
-		__stm32_exti_isr_1, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI2_IRQn,
-		CONFIG_EXTI_STM32_EXTI2_IRQ_PRI,
-		__stm32_exti_isr_2, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI3_IRQn,
-		CONFIG_EXTI_STM32_EXTI3_IRQ_PRI,
-		__stm32_exti_isr_3, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI4_IRQn,
-		CONFIG_EXTI_STM32_EXTI4_IRQ_PRI,
-		__stm32_exti_isr_4, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI9_5_IRQn,
-		CONFIG_EXTI_STM32_EXTI9_5_IRQ_PRI,
-		__stm32_exti_isr_9_5, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI15_10_IRQn,
-		CONFIG_EXTI_STM32_EXTI15_10_IRQ_PRI,
-		__stm32_exti_isr_15_10, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(PVD_IRQn,
-		CONFIG_EXTI_STM32_PVD_IRQ_PRI,
-		__stm32_exti_isr_16, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(RTC_Alarm_IRQn,
-		CONFIG_EXTI_STM32_RTC_ALARM_IRQ_PRI,
-		__stm32_exti_isr_17, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(OTG_FS_WKUP_IRQn,
-		CONFIG_EXTI_STM32_OTG_FS_WKUP_IRQ_PRI,
-		__stm32_exti_isr_18, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(TAMP_STAMP_IRQn,
-		CONFIG_EXTI_STM32_TAMP_STAMP_IRQ_PRI,
-		__stm32_exti_isr_21, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(RTC_WKUP_IRQn,
-		CONFIG_EXTI_STM32_RTC_WKUP_IRQ_PRI,
-		__stm32_exti_isr_22, DEVICE_GET(exti_stm32),
-		0);
-#elif CONFIG_SOC_SERIES_STM32F3X
-	IRQ_CONNECT(EXTI0_IRQn,
-		CONFIG_EXTI_STM32_EXTI0_IRQ_PRI,
-		__stm32_exti_isr_0, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI1_IRQn,
-		CONFIG_EXTI_STM32_EXTI1_IRQ_PRI,
-		__stm32_exti_isr_1, DEVICE_GET(exti_stm32),
-		0);
+#ifdef CONFIG_SOC_SERIES_STM32F3X
 	IRQ_CONNECT(EXTI2_TSC_IRQn,
 		CONFIG_EXTI_STM32_EXTI2_IRQ_PRI,
 		__stm32_exti_isr_2, DEVICE_GET(exti_stm32),
 		0);
-	IRQ_CONNECT(EXTI3_IRQn,
-		CONFIG_EXTI_STM32_EXTI3_IRQ_PRI,
-		__stm32_exti_isr_3, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI4_IRQn,
-		CONFIG_EXTI_STM32_EXTI4_IRQ_PRI,
-		__stm32_exti_isr_4, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI9_5_IRQn,
-		CONFIG_EXTI_STM32_EXTI9_5_IRQ_PRI,
-		__stm32_exti_isr_9_5, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI15_10_IRQn,
-		CONFIG_EXTI_STM32_EXTI15_10_IRQ_PRI,
-		__stm32_exti_isr_15_10, DEVICE_GET(exti_stm32),
-		0);
-#elif CONFIG_SOC_SERIES_STM32F4X
-	IRQ_CONNECT(EXTI0_IRQn,
-		CONFIG_EXTI_STM32_EXTI0_IRQ_PRI,
-		__stm32_exti_isr_0, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI1_IRQn,
-		CONFIG_EXTI_STM32_EXTI1_IRQ_PRI,
-		__stm32_exti_isr_1, DEVICE_GET(exti_stm32),
-		0);
+#else
 	IRQ_CONNECT(EXTI2_IRQn,
 		CONFIG_EXTI_STM32_EXTI2_IRQ_PRI,
 		__stm32_exti_isr_2, DEVICE_GET(exti_stm32),
 		0);
+#endif /* CONFIG_SOC_SERIES_STM32F3X */
 	IRQ_CONNECT(EXTI3_IRQn,
 		CONFIG_EXTI_STM32_EXTI3_IRQ_PRI,
 		__stm32_exti_isr_3, DEVICE_GET(exti_stm32),
@@ -625,6 +439,9 @@ static void __stm32_exti_connect_irqs(struct device *dev)
 		CONFIG_EXTI_STM32_EXTI15_10_IRQ_PRI,
 		__stm32_exti_isr_15_10, DEVICE_GET(exti_stm32),
 		0);
+#elif defined(CONFIG_SOC_SERIES_STM32F2X) || \
+      defined(CONFIG_SOC_SERIES_STM32F4X) || \
+      defined(CONFIG_SOC_SERIES_STM32F7X)
 	IRQ_CONNECT(PVD_IRQn,
 		CONFIG_EXTI_STM32_PVD_IRQ_PRI,
 		__stm32_exti_isr_16, DEVICE_GET(exti_stm32),
@@ -646,99 +463,9 @@ static void __stm32_exti_connect_irqs(struct device *dev)
 		__stm32_exti_isr_22, DEVICE_GET(exti_stm32),
 		0);
 #elif CONFIG_SOC_SERIES_STM32F7X
-	IRQ_CONNECT(EXTI0_IRQn,
-		CONFIG_EXTI_STM32_EXTI0_IRQ_PRI,
-		__stm32_exti_isr_0, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI1_IRQn,
-		CONFIG_EXTI_STM32_EXTI1_IRQ_PRI,
-		__stm32_exti_isr_1, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI2_IRQn,
-		CONFIG_EXTI_STM32_EXTI2_IRQ_PRI,
-		__stm32_exti_isr_2, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI3_IRQn,
-		CONFIG_EXTI_STM32_EXTI3_IRQ_PRI,
-		__stm32_exti_isr_3, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI4_IRQn,
-		CONFIG_EXTI_STM32_EXTI4_IRQ_PRI,
-		__stm32_exti_isr_4, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI9_5_IRQn,
-		CONFIG_EXTI_STM32_EXTI9_5_IRQ_PRI,
-		__stm32_exti_isr_9_5, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI15_10_IRQn,
-		CONFIG_EXTI_STM32_EXTI15_10_IRQ_PRI,
-		__stm32_exti_isr_15_10, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(PVD_IRQn,
-		CONFIG_EXTI_STM32_PVD_IRQ_PRI,
-		__stm32_exti_isr_16, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(RTC_Alarm_IRQn,
-		CONFIG_EXTI_STM32_RTC_ALARM_IRQ_PRI,
-		__stm32_exti_isr_17, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(OTG_FS_WKUP_IRQn,
-		CONFIG_EXTI_STM32_OTG_FS_WKUP_IRQ_PRI,
-		__stm32_exti_isr_18, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(TAMP_STAMP_IRQn,
-		CONFIG_EXTI_STM32_TAMP_STAMP_IRQ_PRI,
-		__stm32_exti_isr_21, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(RTC_WKUP_IRQn,
-		CONFIG_EXTI_STM32_RTC_WKUP_IRQ_PRI,
-		__stm32_exti_isr_22, DEVICE_GET(exti_stm32),
-		0);
 	IRQ_CONNECT(LPTIM1_IRQn,
 		CONFIG_EXTI_STM32_LPTIM1_IRQ_PRI,
 		__stm32_exti_isr_23, DEVICE_GET(exti_stm32),
-		0);
-#elif defined(CONFIG_SOC_SERIES_STM32L0X)
-	IRQ_CONNECT(EXTI0_1_IRQn,
-		CONFIG_EXTI_STM32_EXTI1_0_IRQ_PRI,
-		__stm32_exti_isr_0_1, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI2_3_IRQn,
-		CONFIG_EXTI_STM32_EXTI3_2_IRQ_PRI,
-		__stm32_exti_isr_2_3, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI4_15_IRQn,
-		CONFIG_EXTI_STM32_EXTI15_4_IRQ_PRI,
-		__stm32_exti_isr_4_15, DEVICE_GET(exti_stm32),
-		0);
-#elif defined(CONFIG_SOC_SERIES_STM32L4X)
-	IRQ_CONNECT(EXTI0_IRQn,
-		CONFIG_EXTI_STM32_EXTI0_IRQ_PRI,
-		__stm32_exti_isr_0, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI1_IRQn,
-		CONFIG_EXTI_STM32_EXTI1_IRQ_PRI,
-		__stm32_exti_isr_1, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI2_IRQn,
-		CONFIG_EXTI_STM32_EXTI2_IRQ_PRI,
-		__stm32_exti_isr_2, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI3_IRQn,
-		CONFIG_EXTI_STM32_EXTI3_IRQ_PRI,
-		__stm32_exti_isr_3, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI4_IRQn,
-		CONFIG_EXTI_STM32_EXTI4_IRQ_PRI,
-		__stm32_exti_isr_4, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI9_5_IRQn,
-		CONFIG_EXTI_STM32_EXTI9_5_IRQ_PRI,
-		__stm32_exti_isr_9_5, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(EXTI15_10_IRQn,
-		CONFIG_EXTI_STM32_EXTI15_10_IRQ_PRI,
-		__stm32_exti_isr_15_10, DEVICE_GET(exti_stm32),
 		0);
 #endif
 }

--- a/drivers/interrupt_controller/exti_stm32.h
+++ b/drivers/interrupt_controller/exti_stm32.h
@@ -31,7 +31,7 @@
  *
  * @param line EXTI# line
  */
-void stm32_exti_enable(int line);
+int stm32_exti_enable(int line);
 
 /**
  * @brief disable EXTI interrupt for specific line


### PR DESCRIPTION
Complete code factorization in stm32 exti drivers.

Tested and validated against all STM32 series

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>