### PR TITLE
scripts/dts/extract: Generate fully qualified name define

### DIFF
--- a/scripts/dts/extract/compatible.py
+++ b/scripts/dts/extract/compatible.py
@@ -43,6 +43,13 @@ class DTCompatible(DTDirective):
                 compat_defs: "1",
             }
             insert_defs(node_address, load_defs, {})
+
+            # Generate #define for instances that have a reg prop
+            if reduced[node_address]['props'].get('reg') is not None:
+                load_defs = {
+                    def_label: "1",
+                }
+                insert_defs(node_address, load_defs, {})
             # Generate #define for BUS a "sensor" might be on
             # for example:
             # #define DT_ST_LPS22HB_PRESS_BUS_SPI 1


### PR DESCRIPTION
Generate a define based on the full qualified name of a device instance.
We limit this to instances that have a reg property at this point.

We generate something like:

	#define DT_NXP_KINETIS_UART_4006A000	1

This is useful for cases that we need a specific instance exists.  In
the NXP UART case, this is utilized by pinmux code currently.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>