### PR TITLE
dts: nrf: Add SoC compatiable property

### DIFF
--- a/dts/arm/nordic/nrf51822_qfaa.dtsi
+++ b/dts/arm/nordic/nrf51822_qfaa.dtsi
@@ -14,3 +14,9 @@
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(16)>;
 };
+
+/ {
+	soc {
+		compatible = "nordic,nRF51822-QFAA", "nordic,nRF51822", "nordic,nRF51", "simple-bus";
+	};
+};

--- a/dts/arm/nordic/nrf51822_qfab.dtsi
+++ b/dts/arm/nordic/nrf51822_qfab.dtsi
@@ -14,3 +14,9 @@
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(16)>;
 };
+
+/ {
+	soc {
+		compatible = "nordic,nRF51822-QFAB", "nordic,nRF51822", "nordic,nRF51", "simple-bus";
+	};
+};

--- a/dts/arm/nordic/nrf51822_qfac.dtsi
+++ b/dts/arm/nordic/nrf51822_qfac.dtsi
@@ -14,3 +14,9 @@
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
 };
+
+/ {
+	soc {
+		compatible = "nordic,nRF51822-QFAC", "nordic,nRF51822", "nordic,nRF51", "simple-bus";
+	};
+};

--- a/dts/arm/nordic/nrf52810_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52810_qfaa.dtsi
@@ -14,3 +14,9 @@
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(24)>;
 };
+
+/ {
+	soc {
+		compatible = "nordic,nRF52810-QFAA", "nordic,nRF52810", "nordic,nRF52", "simple-bus";
+	};
+};

--- a/dts/arm/nordic/nrf52832_ciaa.dtsi
+++ b/dts/arm/nordic/nrf52832_ciaa.dtsi
@@ -14,3 +14,9 @@
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };
+
+/ {
+	soc {
+		compatible = "nordic,nRF52832-CIAA", "nordic,nRF52832", "nordic,nRF52", "simple-bus";
+	};
+};

--- a/dts/arm/nordic/nrf52832_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52832_qfaa.dtsi
@@ -14,3 +14,9 @@
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };
+
+/ {
+	soc {
+		compatible = "nordic,nRF52832-QFAA", "nordic,nRF52832", "nordic,nRF52", "simple-bus";
+	};
+};

--- a/dts/arm/nordic/nrf52832_qfab.dtsi
+++ b/dts/arm/nordic/nrf52832_qfab.dtsi
@@ -14,3 +14,9 @@
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
 };
+
+/ {
+	soc {
+		compatible = "nordic,nRF52832-QFAB", "nordic,nRF52832", "nordic,nRF52", "simple-bus";
+	};
+};

--- a/dts/arm/nordic/nrf52840_qiaa.dtsi
+++ b/dts/arm/nordic/nrf52840_qiaa.dtsi
@@ -14,3 +14,9 @@
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };
+
+/ {
+	soc {
+		compatible = "nordic,nRF52840-QIAA", "nordic,nRF52840", "nordic,nRF52", "simple-bus";
+	};
+};

--- a/dts/arm/nordic/nrf9160_sica.dtsi
+++ b/dts/arm/nordic/nrf9160_sica.dtsi
@@ -14,3 +14,9 @@
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };
+
+/ {
+	soc {
+		compatible = "nordic,nRF9160-SICA", "nordic,nRF9160", "nordic,nRF91", "simple-bus";
+	};
+};

--- a/dts/arm/nordic/nrf9160ns_sica.dtsi
+++ b/dts/arm/nordic/nrf9160ns_sica.dtsi
@@ -14,3 +14,9 @@
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };
+
+/ {
+	soc {
+		compatible = "nordic,nRF9160-SICA", "nordic,nRF9160", "nordic,nRF91", "simple-bus";
+	};
+};


### PR DESCRIPTION
Add a compatiable property to the SoC level nodes to tell what SoC we
are on.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>