### PR TITLE
drivers: watchdog: align sample and test to new DT

### DIFF
--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -10,8 +10,14 @@
 #include <watchdog.h>
 #include <misc/printk.h>
 
-#define WDT_DEV_NAME   CONFIG_WDT_0_NAME
 #define WDT_FEED_TRIES 5
+
+
+#ifdef CONFIG_WDT_0_NAME
+#define WDT_DEV_NAME CONFIG_WDT_0_NAME
+#else
+#define WDT_DEV_NAME DT_WDT_0_NAME
+#endif
 
 static void wdt_callback(struct device *wdt_dev, int channel_id)
 {

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -62,7 +62,11 @@
 #include <ztest.h>
 #include "test_wdt.h"
 
+#ifdef CONFIG_WDT_0_NAME
 #define WDT_DEV_NAME CONFIG_WDT_0_NAME
+#else
+#define WDT_DEV_NAME DT_WDT_0_NAME
+#endif
 
 #define WDT_TEST_STATE_IDLE        0
 #define WDT_TEST_STATE_CHECK_RESET 1


### PR DESCRIPTION
Sample application and test are aligned to new DT naming convention.

Signed-off-by: Karol Lasończyk <karol.lasonczyk@nordicsemi.no>