### PR TITLE
tests: i2c_slave_spi: update to new DT compatible naming

### DIFF
--- a/drivers/i2c/slave/eeprom_slave.c
+++ b/drivers/i2c/slave/eeprom_slave.c
@@ -203,44 +203,44 @@ static int i2c_eeprom_slave_init(struct device *dev)
 	return 0;
 }
 
-#ifdef CONFIG_I2C_EEPROM_SLAVE_0
+#ifdef DT_ATMEL_AT24_0
 
 static struct i2c_eeprom_slave_data i2c_eeprom_slave_0_dev_data;
 
-static u8_t i2c_eeprom_slave_0_buffer[(EEPROM_SLAVE_0_SIZE * 1024)];
+static u8_t i2c_eeprom_slave_0_buffer[(DT_ATMEL_AT24_0_SIZE * 1024)];
 
 static const struct i2c_eeprom_slave_config i2c_eeprom_slave_0_cfg = {
-	.controller_dev_name = EEPROM_SLAVE_0_BUS_NAME,
-	.address = EEPROM_SLAVE_0_BASE_ADDRESS,
-	.buffer_size = (EEPROM_SLAVE_0_SIZE * 1024),
+	.controller_dev_name = DT_ATMEL_AT24_0_BUS_NAME,
+	.address = DT_ATMEL_AT24_0_BASE_ADDRESS,
+	.buffer_size = (DT_ATMEL_AT24_0_SIZE * 1024),
 	.buffer = i2c_eeprom_slave_0_buffer
 };
 
-DEVICE_AND_API_INIT(i2c_eeprom_slave_0, EEPROM_SLAVE_0_LABEL,
+DEVICE_AND_API_INIT(i2c_eeprom_slave_0, DT_ATMEL_AT24_0_LABEL,
 		    &i2c_eeprom_slave_init,
 		    &i2c_eeprom_slave_0_dev_data, &i2c_eeprom_slave_0_cfg,
 		    POST_KERNEL, CONFIG_I2C_SLAVE_INIT_PRIORITY,
 		    &api_funcs);
 
-#endif /* CONFIG_I2C_EEPROM_SLAVE_0 */
+#endif /* DT_ATMEL_AT24_0 */
 
-#ifdef CONFIG_I2C_EEPROM_SLAVE_1
+#ifdef DT_ATMEL_AT24_1
 
 static struct i2c_eeprom_slave_data i2c_eeprom_slave_1_dev_data;
 
-static u8_t i2c_eeprom_slave_1_buffer[(EEPROM_SLAVE_1_SIZE * 1024)];
+static u8_t i2c_eeprom_slave_1_buffer[(DT_ATMEL_AT24_1_SIZE * 1024)];
 
 static const struct i2c_eeprom_slave_config i2c_eeprom_slave_1_cfg = {
-	.controller_dev_name = EEPROM_SLAVE_1_BUS_NAME,
-	.address = EEPROM_SLAVE_1_BASE_ADDRESS,
-	.buffer_size = (EEPROM_SLAVE_1_SIZE * 1024),
+	.controller_dev_name = DT_ATMEL_AT24_1_BUS_NAME,
+	.address = DT_ATMEL_AT24_1_BASE_ADDRESS,
+	.buffer_size = (DT_ATMEL_AT24_1_SIZE * 1024),
 	.buffer = i2c_eeprom_slave_1_buffer
 };
 
-DEVICE_AND_API_INIT(i2c_eeprom_slave_1, EEPROM_SLAVE_1_LABEL,
+DEVICE_AND_API_INIT(i2c_eeprom_slave_1, DT_ATMEL_AT24_1_LABEL,
 		    &i2c_eeprom_slave_init,
 		    &i2c_eeprom_slave_1_dev_data, &i2c_eeprom_slave_1_cfg,
 		    POST_KERNEL, CONFIG_I2C_SLAVE_INIT_PRIORITY,
 		    &api_funcs);
 
-#endif /* CONFIG_I2C_EEPROM_SLAVE_1 */
+#endif /* DT_ATMEL_AT24_1 */

--- a/dts/bindings/slave/atmel,at24.yaml
+++ b/dts/bindings/slave/atmel,at24.yaml
@@ -8,14 +8,14 @@ title: Virtual I2C slave eeprom
 version: 0.1
 
 description: >
-    This binding gives a base representation of I2C slave eeprom
+    This binding gives a base representation of a generic I2C slave EEPROM
 
 inherits:
     !include i2c-device.yaml
 
 properties:
     compatible:
-      constraint: "i2c,eeprom"
+      constraint: "atmel,at24"
     size:
       type: int
       category: required

--- a/tests/drivers/i2c/i2c_slave_api/nucleo_f091rc.overlay
+++ b/tests/drivers/i2c/i2c_slave_api/nucleo_f091rc.overlay
@@ -1,12 +1,5 @@
-/ {
-	aliases {
-		eeprom-slave-0 = &ep_0;
-		eeprom-slave-1 = &ep_1;
-	};
-};
-
 &i2c1 {
-	ep_0: eeprom@54 {
+	eeprom@54 {
 		compatible = "atmel,at24";
 		reg = <0x54>;
 		label = "EEPROM_SLAVE_0";
@@ -16,7 +9,7 @@
 
 
 &i2c2 {
-	ep_1: eeprom@56 {
+	eeprom@56 {
 		compatible = "atmel,at24";
 		reg = <0x56>;
 		label = "EEPROM_SLAVE_1";

--- a/tests/drivers/i2c/i2c_slave_api/nucleo_f091rc.overlay
+++ b/tests/drivers/i2c/i2c_slave_api/nucleo_f091rc.overlay
@@ -7,7 +7,7 @@
 
 &i2c1 {
 	ep_0: eeprom@54 {
-		compatible = "i2c,eeprom";
+		compatible = "atmel,at24";
 		reg = <0x54>;
 		label = "EEPROM_SLAVE_0";
 		size = <1>;
@@ -17,7 +17,7 @@
 
 &i2c2 {
 	ep_1: eeprom@56 {
-		compatible = "i2c,eeprom";
+		compatible = "atmel,at24";
 		reg = <0x56>;
 		label = "EEPROM_SLAVE_1";
 		size = <1>;

--- a/tests/drivers/i2c/i2c_slave_api/src/main.c
+++ b/tests/drivers/i2c/i2c_slave_api/src/main.c
@@ -137,77 +137,95 @@ void test_eeprom_slave(void)
 	struct device *i2c_1;
 	int ret, offset;
 
+
 	i2c_0 = device_get_binding(
-			EEPROM_SLAVE_0_BUS_NAME);
+			DT_ATMEL_AT24_0_BUS_NAME);
 	zassert_not_null(i2c_0, "I2C device %s not found",
-			 EEPROM_SLAVE_0_BUS_NAME);
+			 DT_ATMEL_AT24_0_BUS_NAME);
 
 	LOG_INF("Found I2C Master device %s",
-		    EEPROM_SLAVE_0_BUS_NAME);
+		    DT_ATMEL_AT24_0_BUS_NAME);
 
 	i2c_1 = device_get_binding(
-			EEPROM_SLAVE_1_BUS_NAME);
+			DT_ATMEL_AT24_1_BUS_NAME);
 	zassert_not_null(i2c_1, "I2C device %s not found",
-			 EEPROM_SLAVE_1_BUS_NAME);
+			 DT_ATMEL_AT24_1_BUS_NAME);
 
 	LOG_INF("Found I2C Master device %s",
-		    EEPROM_SLAVE_1_BUS_NAME);
+		    DT_ATMEL_AT24_1_BUS_NAME);
 
-	eeprom_0 = device_get_binding(EEPROM_SLAVE_0_LABEL);
+	/*
+	 * Normal applications would interact with an EEPROM
+	 * identified by the string literal used in the binding node
+	 * label property ("EEPROM_SLAVE_0") rather than the generated
+	 * macro DT_ATMEL_AT24_0_LABEL.  There is no guarantee that
+	 * the index for the compatible is persistent across builds;
+	 * for example DT_ATMEL_AT24_0 might refer to "EEPROM_SLAVE_1"
+	 * if the order of the node declarations were changed in the
+	 * overlay file.
+	 *
+	 * The label string cannot be directly used to determine the
+	 * correct parent bus and device index for whitebox testing in
+	 * this application.  So for this application only, where the
+	 * devices are interchangeable, the device is selected the
+	 * using the generated macro.
+	 */
+
+	eeprom_0 = device_get_binding(DT_ATMEL_AT24_0_LABEL);
 	zassert_not_null(eeprom_0, "EEPROM device %s not found",
-			 EEPROM_SLAVE_0_LABEL);
+			 DT_ATMEL_AT24_0_LABEL);
 
-	LOG_INF("Found EEPROM device %s", EEPROM_SLAVE_0_LABEL);
+	LOG_INF("Found EEPROM device %s", DT_ATMEL_AT24_0_LABEL);
 
-	eeprom_1 = device_get_binding(EEPROM_SLAVE_1_LABEL);
+	eeprom_1 = device_get_binding(DT_ATMEL_AT24_1_LABEL);
 	zassert_not_null(eeprom_1, "EEPROM device %s not found",
-			 EEPROM_SLAVE_1_LABEL);
+			 DT_ATMEL_AT24_1_LABEL);
 
-	LOG_INF("Found EEPROM device %s", EEPROM_SLAVE_1_LABEL);
+	LOG_INF("Found EEPROM device %s", DT_ATMEL_AT24_1_LABEL);
 
 	/* Program dummy bytes */
 	ret = eeprom_slave_program(eeprom_0, eeprom_0_data, TEST_DATA_SIZE);
 	zassert_equal(ret, 0, "Failed to program EEPROM %s",
-		      EEPROM_SLAVE_0_LABEL);
+		      DT_ATMEL_AT24_0_LABEL);
 
 	ret = eeprom_slave_program(eeprom_1, eeprom_1_data, TEST_DATA_SIZE);
 	zassert_equal(ret, 0, "Failed to program EEPROM %s",
-		      EEPROM_SLAVE_1_LABEL);
+		      DT_ATMEL_AT24_1_LABEL);
 
 	/* Attach EEPROM */
 	ret = i2c_slave_driver_register(eeprom_0);
 	zassert_equal(ret, 0, "Failed to register EEPROM %s",
-		      EEPROM_SLAVE_0_LABEL);
+		      DT_ATMEL_AT24_0_LABEL);
 
-	LOG_INF("EEPROM %s Attached !", EEPROM_SLAVE_0_LABEL);
+	LOG_INF("EEPROM %s Attached !", DT_ATMEL_AT24_0_LABEL);
 
 	ret = i2c_slave_driver_register(eeprom_1);
 	zassert_equal(ret, 0, "Failed to register EEPROM %s",
-		      EEPROM_SLAVE_1_LABEL);
+		      DT_ATMEL_AT24_1_LABEL);
 
-	LOG_INF("EEPROM %s Attached !", EEPROM_SLAVE_1_LABEL);
+	LOG_INF("EEPROM %s Attached !", DT_ATMEL_AT24_1_LABEL);
 
 	/* Run Tests without bus access conflicts */
-	run_full_read(i2c_0, EEPROM_SLAVE_1_BASE_ADDRESS, eeprom_1_data);
-	run_full_read(i2c_1, EEPROM_SLAVE_0_BASE_ADDRESS, eeprom_0_data);
+	run_full_read(i2c_0, DT_ATMEL_AT24_1_BASE_ADDRESS, eeprom_1_data);
+	run_full_read(i2c_1, DT_ATMEL_AT24_0_BASE_ADDRESS, eeprom_0_data);
 
 	for (offset = 0 ; offset < TEST_DATA_SIZE-1 ; ++offset) {
-		run_partial_read(i2c_0, EEPROM_SLAVE_1_BASE_ADDRESS,
+		run_partial_read(i2c_0, DT_ATMEL_AT24_1_BASE_ADDRESS,
 				 eeprom_1_data, offset);
 	}
 
 	for (offset = 0 ; offset < TEST_DATA_SIZE-1 ; ++offset) {
-		run_partial_read(i2c_1, EEPROM_SLAVE_0_BASE_ADDRESS,
+		run_partial_read(i2c_1, DT_ATMEL_AT24_0_BASE_ADDRESS,
 				 eeprom_0_data, offset);
 	}
 
 	for (offset = 0 ; offset < TEST_DATA_SIZE-1 ; ++offset) {
-		run_program_read(i2c_0, EEPROM_SLAVE_1_BASE_ADDRESS,
+		run_program_read(i2c_0, DT_ATMEL_AT24_1_BASE_ADDRESS,
 				 offset);
 	}
 
 	for (offset = 0 ; offset < TEST_DATA_SIZE-1 ; ++offset) {
-		run_program_read(i2c_1, EEPROM_SLAVE_0_BASE_ADDRESS,
+		run_program_read(i2c_1, DT_ATMEL_AT24_0_BASE_ADDRESS,
 				 offset);
 	}
 
@@ -216,17 +234,17 @@ void test_eeprom_slave(void)
 	/* Detach EEPROM */
 	ret = i2c_slave_driver_unregister(eeprom_0);
 	zassert_equal(ret, 0, "Failed to unregister EEPROM %s",
-		      EEPROM_SLAVE_0_LABEL);
+		      DT_ATMEL_AT24_0_LABEL);
 
 	LOG_INF("EEPROM %s Detached !",
-		    EEPROM_SLAVE_0_LABEL);
+		    DT_ATMEL_AT24_0_LABEL);
 
 	ret = i2c_slave_driver_unregister(eeprom_1);
 	zassert_equal(ret, 0, "Failed to unregister EEPROM %s",
-		      EEPROM_SLAVE_1_LABEL);
+		      DT_ATMEL_AT24_1_LABEL);
 
 	LOG_INF("EEPROM %s Detached !",
-		    EEPROM_SLAVE_1_LABEL);
+		    DT_ATMEL_AT24_1_LABEL);
 }
 
 void test_main(void)

--- a/tests/drivers/i2c/i2c_slave_api/stm32f072b_disco.overlay
+++ b/tests/drivers/i2c/i2c_slave_api/stm32f072b_disco.overlay
@@ -1,12 +1,5 @@
-/ {
-	aliases {
-		eeprom-slave-0 = &ep_0;
-		eeprom-slave-1 = &ep_1;
-	};
-};
-
 &i2c1 {
-	ep_0: eeprom@54 {
+	eeprom@54 {
 		compatible = "atmel,at24";
 		reg = <0x54>;
 		label = "EEPROM_SLAVE_0";
@@ -16,7 +9,7 @@
 
 
 &i2c2 {
-	ep_1: eeprom@56 {
+	eeprom@56 {
 		compatible = "atmel,at24";
 		reg = <0x56>;
 		label = "EEPROM_SLAVE_1";

--- a/tests/drivers/i2c/i2c_slave_api/stm32f072b_disco.overlay
+++ b/tests/drivers/i2c/i2c_slave_api/stm32f072b_disco.overlay
@@ -7,7 +7,7 @@
 
 &i2c1 {
 	ep_0: eeprom@54 {
-		compatible = "i2c,eeprom";
+		compatible = "atmel,at24";
 		reg = <0x54>;
 		label = "EEPROM_SLAVE_0";
 		size = <1>;
@@ -17,7 +17,7 @@
 
 &i2c2 {
 	ep_1: eeprom@56 {
-		compatible = "i2c,eeprom";
+		compatible = "atmel,at24";
 		reg = <0x56>;
 		label = "EEPROM_SLAVE_1";
 		size = <1>;


### PR DESCRIPTION
### dts: correct compatible name for I2C EEPROM devices
 
Zephyr has been using "i2c,eeprom" for the compatible property.  This is
inconsistent with the property documentation which expects
"manufacturer,model" to be used.

The Linux standard compatible name for I2C EEPROMs is "atmel,at24".  The
standard for SPI EEPROMS is "atmel,at25".  We don't have support for the
latter, but change the name for the former.

### tests: i2c_slave_spi: update to proposed DT compatible naming

In driver and application code use the new device-tree values produced
by standard compatible-instance bindings.

As this code may be used as an example add a comment describing how the
binding instance number cannot be reliably used to distinguish multiple
instances.
