### PR TITLE
drivers: spi_sam: initialize tx and rx

### DIFF
--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -275,7 +275,8 @@ static void spi_sam_fast_transceive(struct device *dev,
 	size_t tx_count = 0;
 	size_t rx_count = 0;
 	Spi *regs = cfg->regs;
-	const struct spi_buf *tx = NULL, *rx = NULL;
+	const struct spi_buf *tx = NULL;
+	const struct spi_buf *rx = NULL;
 
 	if (tx_bufs) {
 		tx = tx_bufs->buffers;

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -280,8 +280,8 @@ static void spi_sam0_fast_transceive(struct device *dev,
 	size_t tx_count = 0;
 	size_t rx_count = 0;
 	SercomSpi *regs = cfg->regs;
-	const struct spi_buf *tx;
-	const struct spi_buf *rx;
+	const struct spi_buf *tx = NULL;
+	const struct spi_buf *rx = NULL;
 
 	if (tx_bufs) {
 		tx = tx_bufs->buffers;


### PR DESCRIPTION
initialize both tx and rx in the spi_sam0 driver. Make the spi_sam
driver look the same by splitting the declaration into 2 lines.

Discovered with gcc 8.2