### PR TITLE
Bluetooth: GATT: Add bt_gatt_write_without_rsp_cb

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -697,7 +697,7 @@ ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
  *
  *  @param conn Connection object.
  */
-typedef void (*bt_gatt_notify_complete_func_t) (struct bt_conn *conn);
+typedef void (*bt_gatt_complete_func_t) (struct bt_conn *conn);
 
 /** @brief Notify attribute value change with callback.
  *
@@ -713,7 +713,7 @@ typedef void (*bt_gatt_notify_complete_func_t) (struct bt_conn *conn);
  */
 int bt_gatt_notify_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		      const void *data, u16_t len,
-		      bt_gatt_notify_complete_func_t func);
+		      bt_gatt_complete_func_t func);
 
 /** @brief Notify attribute value change.
  *
@@ -999,6 +999,30 @@ struct bt_gatt_write_params {
  */
 int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
 
+/** @brief Write Attribute Value by handle without response with callback.
+ *
+ * This function works in the same way as @ref bt_gatt_write_without_response.
+ * With the addition that after sending the write the callback function will be
+ * called.
+ *
+ * Note: By using a callback it also disable the internal flow control
+ * which would prevent sending multiple commands without wainting their
+ * transmissions to complete, so if that is required the caller shall not
+ * submit more data until the callback is called.
+ *
+ * @param conn Connection object.
+ * @param handle Attribute handle.
+ * @param data Data to be written.
+ * @param length Data length.
+ * @param sign Whether to sign data
+ * @param func Transmission complete callback.
+ *
+ * @return 0 in case of success or negative value in case of error.
+ */
+int bt_gatt_write_without_response_cb(struct bt_conn *conn, u16_t handle,
+				      const void *data, u16_t length,
+				      bool sign, bt_gatt_complete_func_t func);
+
 /** @brief Write Attribute Value by handle without response
  *
  * This procedure write the attribute value without requiring an
@@ -1012,9 +1036,13 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
  *
  * @return 0 in case of success or negative value in case of error.
  */
-int bt_gatt_write_without_response(struct bt_conn *conn, u16_t handle,
-				   const void *data, u16_t length,
-				   bool sign);
+static inline int bt_gatt_write_without_response(struct bt_conn *conn,
+						 u16_t handle, const void *data,
+						 u16_t length, bool sign)
+{
+	return bt_gatt_write_without_response_cb(conn, handle, data, length,
+						 sign, NULL);
+}
 
 struct bt_gatt_subscribe_params;
 

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -270,7 +270,9 @@ struct bt_gatt_ccc {
 struct bt_gatt_cpf {
 	/** Format of the value of the characteristic */
 	u8_t format;
-	/** Exponent field to determine how the value of this characteristic is further formatted */
+	/** Exponent field to determine how the value of this characteristic is
+	 * further formatted
+	 */
 	s8_t exponent;
 	/** Unit of the characteristic */
 	u16_t unit;
@@ -599,7 +601,8 @@ ssize_t bt_gatt_attr_read_cep(struct bt_conn *conn,
  *
  *  Read CUD attribute value from local database storing the result into buffer
  *  after encoding it.
- *  NOTE: Only use this with attributes which user_data is a NULL-terminated C string.
+ *  NOTE: Only use this with attributes which user_data is a NULL-terminated C
+ *  string.
  *
  *  @param conn Connection object
  *  @param attr Attribute to read
@@ -729,7 +732,8 @@ int bt_gatt_notify_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
  *  @param data Pointer to Attribute data.
  *  @param len Attribute value length.
  */
-static inline int bt_gatt_notify(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static inline int bt_gatt_notify(struct bt_conn *conn,
+				 const struct bt_gatt_attr *attr,
 				 const void *data, u16_t len)
 {
 	return bt_gatt_notify_cb(conn, attr, data, len, NULL);

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -242,7 +242,7 @@ struct net_buf *bt_att_create_pdu(struct bt_conn *conn, u8_t op,
 				  size_t len);
 
 /* Send ATT PDU over a connection */
-int bt_att_send(struct bt_conn *conn, struct net_buf *buf);
+int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb);
 
 /* Send ATT Request over a connection */
 int bt_att_req_send(struct bt_conn *conn, struct bt_att_req *req);


### PR DESCRIPTION
This adds bt_gatt_write_response_cb works similarly to bt_gatt_notify_cb which can take a callback to be called when the PDU is considered transmitted over the air.

Fixes #11558