### PR TITLE
arc: fix the pollution of lp_xxx regs in _rirq_return_from_coop

### DIFF
--- a/arch/arc/core/regular_irq.S
+++ b/arch/arc/core/regular_irq.S
@@ -200,6 +200,8 @@ _rirq_return_from_coop:
 	ld_s r0, [r2, _thread_offset_to_return_value]
 	st_s r0, [sp, ___isf_t_r0_OFFSET]
 
+	st 0, [sp, ___isf_t_lp_count_OFFSET]
+
 	/*
 	 * r13 is part of both the callee and caller-saved register sets because
 	 * the processor is only able to save registers in pair in the regular


### PR DESCRIPTION
in the _rirq_return_from_coop, a fake irq stack frame is created.
But the value of lp_start, lp_end, lp_count are not set correctly.
When rtie is executed, the zero-overhead loop will be enabled, if
the pc crosses the value of lp_end and lp_count is not zero. The pc
will jump to lp_start. This will break down the system.

This commit fixs this bug and set the correct value of lp_start, lp_end
and lp_count.

Fixes #12479