### PR TITLE
Bluetooth: Give proper names to Bluetooth threads

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -444,11 +444,13 @@ static int hci_driver_open(void)
 			K_THREAD_STACK_SIZEOF(prio_recv_thread_stack),
 			prio_recv_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(CONFIG_BT_CTLR_RX_PRIO), 0, K_NO_WAIT);
+	k_thread_name_set(&prio_recv_thread_data, "BT RX pri");
 
 	k_thread_create(&recv_thread_data, recv_thread_stack,
 			K_THREAD_STACK_SIZEOF(recv_thread_stack),
 			recv_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(CONFIG_BT_RX_PRIO), 0, K_NO_WAIT);
+	k_thread_name_set(&recv_thread_data, "BT RX");
 
 	BT_DBG("Success.");
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4700,6 +4700,7 @@ int bt_enable(bt_ready_cb_t cb)
 			hci_tx_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(CONFIG_BT_HCI_TX_PRIO),
 			0, K_NO_WAIT);
+	k_thread_name_set(&tx_thread_data, "BT TX");
 
 #if !defined(CONFIG_BT_RECV_IS_RX_THREAD)
 	/* RX thread */
@@ -4708,6 +4709,7 @@ int bt_enable(bt_ready_cb_t cb)
 			(k_thread_entry_t)hci_rx_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(CONFIG_BT_RX_PRIO),
 			0, K_NO_WAIT);
+	k_thread_name_set(&rx_thread_data, "BT RX");
 #endif
 
 	if (IS_ENABLED(CONFIG_BT_TINYCRYPT_ECC)) {

--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -322,4 +322,5 @@ void bt_hci_ecc_init(void)
 	k_thread_create(&ecc_thread_data, ecc_thread_stack,
 			K_THREAD_STACK_SIZEOF(ecc_thread_stack), ecc_thread,
 			NULL, NULL, NULL, K_PRIO_PREEMPT(10), 0, K_NO_WAIT);
+	k_thread_name_set(&ecc_thread_data, "BT ECC");
 }

--- a/subsys/bluetooth/host/mesh/adv.c
+++ b/subsys/bluetooth/host/mesh/adv.c
@@ -306,6 +306,7 @@ void bt_mesh_adv_init(void)
 	k_thread_create(&adv_thread_data, adv_thread_stack,
 			K_THREAD_STACK_SIZEOF(adv_thread_stack), adv_thread,
 			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+	k_thread_name_set(&adv_thread_data, "BT Mesh adv");
 }
 
 int bt_mesh_scan_enable(void)

--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -757,6 +757,7 @@ static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
 			K_THREAD_STACK_SIZEOF(dlc->stack),
 			rfcomm_dlc_tx_thread, dlc, NULL, NULL, K_PRIO_COOP(7),
 			0, K_NO_WAIT);
+	k_thread_name_set(&dlc->tx_thread, "BT DLC");
 
 	if (dlc->ops && dlc->ops->connected) {
 		dlc->ops->connected(dlc);


### PR DESCRIPTION
Provide names for all Bluetooth threads so that they don't show up as
"NA" when issuing the "kernel stacks" command in the shell.

To get this info the following Kconfig options need to be enabled:
```
CONFIG_THREAD_STACK_INFO=y
CONFIG_THREAD_MONITOR=y
CONFIG_KERNEL_SHELL=y
CONFIG_INIT_STACKS=y
CONFIG_THREAD_NAME=y
```
After issuing the "kernel stacks" command the output should look
something like this:
```
uart:~$ kernel stacks
0x200011D0 BT RX      (real size 1024): unused 760      usage 264 / 1024 (25 %)
0x20001148 BT RX pri  (real size 448):  unused 280      usage 168 / 448 (37 %)
0x20000654 BT ECC     (real size 1100): unused 168      usage 932 / 1100 (84 %)
0x20000764 BT TX      (real size 640):  unused 280      usage 360 / 640 (56 %)
0x20001ED8 sysworkq   (real size 1024): unused 592      usage 432 / 1024 (42 %)
0x200004C4 shell_uart (real size 2048): unused 904      usage 1144 / 2048 (55 %)
0x20000058 logging    (real size 768):  unused 584      usage 184 / 768 (23 %)
0x20001D84 idle       (real size 256):  unused 184      usage 72 / 256 (28 %)
0x20001E08 main       (real size 1024): unused 768      usage 256 / 1024 (25 %)
```
Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>