### PR TITLE
dts: nordic: add missing nRF91 flash controller binding

### DIFF
--- a/dts/bindings/flash_controller/nordic,nrf91-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf91-flash-controller.yaml
@@ -1,0 +1,15 @@
+---
+title: Nordic NVMC
+version: 0.1
+
+description: >
+    This binding gives a base representation of the Nordic NVMC
+
+inherits:
+    !include flash-controller.yaml
+
+properties:
+    compatible:
+      constraint: "nordic,nrf91-flash-controller"
+
+...


### PR DESCRIPTION
This commits adds the binding for nRF9160 flash controller.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>