### PR TITLE
drivers/i2c: stm32: (FIX) add semaphore to lock bus

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -24,6 +24,7 @@ struct i2c_stm32_data {
 #ifdef CONFIG_I2C_STM32_INTERRUPT
 	struct k_sem device_sync_sem;
 #endif
+	struct k_sem bus_mutex;
 	u32_t dev_config;
 #ifdef CONFIG_I2C_STM32_V1
 	u16_t slave_address;


### PR DESCRIPTION
Add mutex to lock STM32 I2C bus in order to guarantee that data transfers are atomic and have exclusive access to the bus.

Issue has been found fetching data from multiple sensors on I2C bus in a mixed context of thread and triggered interrupt.