### PR TITLE
boards: bbc_microbit: Add i2c/gpio as supported peripherals

### DIFF
--- a/boards/arm/bbc_microbit/bbc_microbit.yaml
+++ b/boards/arm/bbc_microbit/bbc_microbit.yaml
@@ -12,3 +12,5 @@ testing:
     - net
 supported:
   - ble
+  - i2c
+  - gpio


### PR DESCRIPTION
Add i2c/gpio to board yaml as supported peripherals on the bbc_microbit

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>