### PR TITLE
boards: warp7_m4: Add i2c/gpio as supported peripherals

### DIFF
--- a/boards/arm/warp7_m4/warp7_m4.yaml
+++ b/boards/arm/warp7_m4/warp7_m4.yaml
@@ -18,3 +18,6 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+supported:
+  - i2c
+  - gpio


### PR DESCRIPTION
Add i2c/gpio to board yaml as supported peripherals on the warp7_m4.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>