### PR TITLE
samples: big_http_download: Set min_flash to 128K.

### DIFF
--- a/samples/net/sockets/big_http_download/sample.yaml
+++ b/samples/net/sockets/big_http_download/sample.yaml
@@ -6,4 +6,5 @@ tests:
     platform_exclude: esp32 qemu_x86_64 # No newlib
     harness: net
     min_ram: 32
+    min_flash: 128
     tags: net


### PR DESCRIPTION
Previously there was just "min_ram: 32", which took care about
suitable flash size implicitly. But now we have interesting boards
(e.g. lpcxpresso54114_m0) which tout RAM of 32K and Flash of 64K.
So, become more explicit about Flash requirement for the sample.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>