### PR TITLE
boards: reel_board: Fix FXO8700 driver interrupt

### DIFF
--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -91,6 +91,7 @@
 		reg = <0x1d>;
 		label = "MMA8652FC";
 		int1-gpios = <&gpio0 24 0>;
+		int2-gpios = <&gpio0 25 0>;
 	};
 
 	hdc1008@43 {


### PR DESCRIPTION
The schematic shows that both INT1 & INT2 from the MMA8652FC are wired
up, update the dts to reflect this.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>