### PR TITLE
fs: fix build break due to invalid comparsion

### DIFF
--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <misc/fdtable.h>
 
-BUILD_ASSERT_MSG(PATH_MAX > MAX_FILE_NAME,
+BUILD_ASSERT_MSG(PATH_MAX >= MAX_FILE_NAME,
 		"PATH_MAX is less than MAX_FILE_NAME");
 
 struct posix_fs_desc {


### PR DESCRIPTION
In limits.h PATH_MAX is defined to same value as in nffs

Signed-off-by: Dominik <dominik@itetech.pl>