### PR TITLE
kernel/timer: Make k_timer "duration" realtime but "period" regular

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1427,6 +1427,15 @@ extern void k_timer_init(struct k_timer *timer,
  * The timer's status is reset to zero and the timer begins counting down
  * using the new duration and period values.
  *
+ * @note There is a subtle difference in the timer conventions between
+ * duration and period.  The "duration" argument takes a timeout in
+ * true real time from the instant of the call; the callback will not
+ * occur until after the specified timeout has expired.  But
+ * subsequent callbacks using the "period" callback will be scheduled
+ * relative to their nominal time in the sequence to preserve regular
+ * timekeeping.  They may be closer together than period in the case
+ * where a previous callback was delayed.
+ *
  * @param timer     Address of timer.
  * @param duration  Initial timer duration (in milliseconds).
  * @param period    Timer period (in milliseconds).

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -25,7 +25,8 @@ static inline void _init_timeout(struct _timeout *t, _timeout_func_t fn)
 	t->dticks = _INACTIVE;
 }
 
-void _add_timeout(struct _timeout *to, _timeout_func_t fn, s32_t ticks);
+void _add_timeout(struct _timeout *to, _timeout_func_t fn,
+		  s32_t ticks, bool realtime);
 
 int _abort_timeout(struct _timeout *to);
 
@@ -38,7 +39,7 @@ extern void z_thread_timeout(struct _timeout *to);
 
 static inline void _add_thread_timeout(struct k_thread *th, s32_t ticks)
 {
-	_add_timeout(&th->base.timeout, z_thread_timeout, ticks);
+	_add_timeout(&th->base.timeout, z_thread_timeout, ticks, true);
 }
 
 static inline int _abort_thread_timeout(struct k_thread *thread)

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -62,7 +62,8 @@ static s32_t elapsed(void)
 	return announce_remaining == 0 ? z_clock_elapsed() : 0;
 }
 
-void _add_timeout(struct _timeout *to, _timeout_func_t fn, s32_t ticks)
+void _add_timeout(struct _timeout *to, _timeout_func_t fn,
+		  s32_t ticks, bool realtime)
 {
 	__ASSERT(to->dticks < 0, "");
 	to->fn = fn;
@@ -70,6 +71,10 @@ void _add_timeout(struct _timeout *to, _timeout_func_t fn, s32_t ticks)
 
 	LOCKED(&timeout_lock) {
 		struct _timeout *t;
+
+		if (realtime) {
+			ticks += announce_remaining;
+		}
 
 		to->dticks = ticks + elapsed();
 		for (t = first(); t != NULL; t = next(t)) {

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -57,7 +57,7 @@ void _timer_expiration_handler(struct _timeout *t)
 	if (timer->period > 0) {
 		key = irq_lock();
 		_add_timeout(&timer->timeout, _timer_expiration_handler,
-			     timer->period);
+			     timer->period, false);
 		irq_unlock(key);
 	}
 
@@ -127,7 +127,7 @@ void _impl_k_timer_start(struct k_timer *timer, s32_t duration, s32_t period)
 	timer->period = period_in_ticks;
 	timer->status = 0;
 	_add_timeout(&timer->timeout, _timer_expiration_handler,
-		     duration_in_ticks);
+		     duration_in_ticks, true);
 	irq_unlock(key);
 }
 

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -77,7 +77,7 @@ int k_delayed_work_submit_to_queue(struct k_work_q *work_q,
 	} else {
 		/* Add timeout */
 		_add_timeout(&work->timeout, work_timeout,
-			     _TICK_ALIGN + _ms_to_ticks(delay));
+			     _TICK_ALIGN + _ms_to_ticks(delay), true);
 	}
 
 	err = 0;


### PR DESCRIPTION
[For discussion, mostly.  This is a quickly thrown together version of the change I expected to see in #12485, modifying the interpretation of k_timer_start() arguments only without trying to get into a rework of the way timeout queuing is done.]

When tickless is enabled and we have a delayed tick announcement, the
timeout callback will of course be late.  Some existing code wants to
reschedule callbacks relative to when the timeout "should" have
occurred, while some apps are going to naturally expect the timeout is
a realtime quantity relative to the true current time.

Split these conventions by some careful redocumentation of the
difference between the "duration" (initial timeout) and "period"
arguments to k_timer_start(), and a flag passed to _add_timeout().

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>