### PR TITLE
net: tcp: do not drop successfully received packets

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2409,8 +2409,8 @@ NET_CONN_CB(tcp_syn_rcvd)
 		pkt_get_sockaddr(net_context_get_family(context),
 				 pkt, &pkt_src_addr);
 		send_syn_ack(context, &pkt_src_addr, &remote_addr);
-
-		return NET_DROP;
+		net_pkt_unref(pkt);
+		return NET_OK;
 	}
 
 	/*
@@ -2525,6 +2525,8 @@ NET_CONN_CB(tcp_syn_rcvd)
 					addrlen,
 					0,
 					context->user_data);
+		net_pkt_unref(pkt);
+		return NET_OK;
 	}
 
 	return NET_DROP;


### PR DESCRIPTION
Each time a successfully TCP connection is done, the number of dropped
TCP packets increases by 2. This is happens because when receiving an
initial SYN packet, or an ACK packet following a SYN+ACK packet,
NET_DROP is returned even if there is no error.

Fix that by replacing the two corresponding "return NET_DROP" by
"net_pkt_unref(pkt)" followed by "return 0".

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>