### PR TITLE
net: Deprecating net-app API and users of it

### DIFF
--- a/include/net/http.h
+++ b/include/net/http.h
@@ -47,7 +47,7 @@ extern "C" {
 
 struct http_ctx;
 
-enum http_state {
+__deprecated enum http_state {
 	  HTTP_STATE_CLOSED,
 	  HTTP_STATE_WAITING_HEADER,
 	  HTTP_STATE_RECEIVING_HEADER,
@@ -55,18 +55,18 @@ enum http_state {
 	  HTTP_STATE_OPEN,
 } __packed;
 
-enum http_url_flags {
+__deprecated enum http_url_flags {
 	HTTP_URL_STANDARD = 0,
 	HTTP_URL_WEBSOCKET,
 } __packed;
 
-enum http_connection_type {
+__deprecated enum http_connection_type {
 	HTTP_CONNECTION = 1,
 	WS_CONNECTION,
 };
 
 /* HTTP header fields struct */
-struct http_field_value {
+__deprecated struct http_field_value {
 	/** Field name, this variable will point to the beginning of the string
 	 *  containing the HTTP field name
 	 */
@@ -85,7 +85,7 @@ struct http_field_value {
 };
 
 /* HTTP root URL struct, used for pattern matching */
-struct http_root_url {
+__deprecated struct http_root_url {
 	/** URL */
 	const char *root;
 
@@ -102,7 +102,7 @@ struct http_root_url {
 	u8_t is_used;
 };
 
-enum http_verdict {
+__deprecated enum http_verdict {
 	HTTP_VERDICT_DROP,
 	HTTP_VERDICT_ACCEPT,
 };
@@ -120,12 +120,12 @@ enum http_verdict {
  * @return HTTP_VERDICT_DROP if connection is to be dropped,
  * HTTP_VERDICT_ACCEPT if the application wants to accept the unknown URL.
  */
-typedef enum http_verdict (*http_url_cb_t)(struct http_ctx *ctx,
+__deprecated typedef enum http_verdict (*http_url_cb_t)(struct http_ctx *ctx,
 					   enum http_connection_type type,
 					   const struct sockaddr *dst);
 
 /* Collection of URLs that this server will handle */
-struct http_server_urls {
+__deprecated struct http_server_urls {
 	/* First item is the default handler and it is always there.
 	 */
 	struct http_root_url default_url;
@@ -155,7 +155,7 @@ struct http_server_urls {
  * @param dst Remote socket address from where HTTP packet is received.
  * @param user_data The user data given in init call.
  */
-typedef void (*http_recv_cb_t)(struct http_ctx *ctx,
+__deprecated typedef void (*http_recv_cb_t)(struct http_ctx *ctx,
 			       struct net_pkt *pkt,
 			       int status,
 			       u32_t flags,
@@ -174,7 +174,7 @@ typedef void (*http_recv_cb_t)(struct http_ctx *ctx,
  * @param dst Remote socket address where the connection is established.
  * @param user_data The user data given in init call.
  */
-typedef void (*http_connect_cb_t)(struct http_ctx *ctx,
+__deprecated typedef void (*http_connect_cb_t)(struct http_ctx *ctx,
 				  enum http_connection_type type,
 				  const struct sockaddr *dst,
 				  void *user_data);
@@ -193,7 +193,7 @@ typedef void (*http_connect_cb_t)(struct http_ctx *ctx,
  * @param user_data_send The user data given in http_send() call.
  * @param user_data The user data given in init call.
  */
-typedef void (*http_send_cb_t)(struct http_ctx *ctx,
+__deprecated typedef void (*http_send_cb_t)(struct http_ctx *ctx,
 			       int status,
 			       void *user_data_send,
 			       void *user_data);
@@ -208,12 +208,12 @@ typedef void (*http_send_cb_t)(struct http_ctx *ctx,
  * @param status Error code for the closing.
  * @param user_data The user data given in init call.
  */
-typedef void (*http_close_cb_t)(struct http_ctx *ctx,
+__deprecated typedef void (*http_close_cb_t)(struct http_ctx *ctx,
 				int status,
 				void *user_data);
 
 /** Websocket and HTTP callbacks */
-struct http_cb {
+__deprecated struct http_cb {
 	/** Function that is called when a connection is established.
 	 */
 	http_connect_cb_t connect;
@@ -233,7 +233,7 @@ struct http_cb {
 
 #if defined(CONFIG_HTTP_CLIENT)
 /* Is there more data to come */
-enum http_final_call {
+__deprecated enum http_final_call {
 	HTTP_DATA_MORE = 0,
 	HTTP_DATA_FINAL = 1,
 };
@@ -256,7 +256,7 @@ enum http_final_call {
  * is there still more data to come.
  * @param user_data A valid pointer on some user data or NULL
  */
-typedef void (*http_response_cb_t)(struct http_ctx *ctx,
+__deprecated typedef void (*http_response_cb_t)(struct http_ctx *ctx,
 				   u8_t *data,
 				   size_t buflen,
 				   size_t datalen,
@@ -267,7 +267,7 @@ typedef void (*http_response_cb_t)(struct http_ctx *ctx,
  * HTTP client request. This contains all the data that is needed when doing
  * a HTTP request.
  */
-struct http_request {
+__deprecated struct http_request {
 	/** The HTTP method: GET, HEAD, OPTIONS, POST, ... */
 	enum http_method method;
 
@@ -303,7 +303,7 @@ struct http_request {
  * Http context information. This contains all the data that is
  * needed when working with http API.
  */
-struct http_ctx {
+__deprecated struct http_ctx {
 	/** Net app context. The http connection is handled via
 	 * the net app API.
 	 */
@@ -520,7 +520,7 @@ struct http_ctx {
  *
  * @return 0 if ok, <0 if error.
  */
-int http_server_init(struct http_ctx *ctx,
+__deprecated int http_server_init(struct http_ctx *ctx,
 		     struct http_server_urls *urls,
 		     struct sockaddr *server_addr,
 		     u8_t *request_buf,
@@ -548,7 +548,7 @@ int http_server_init(struct http_ctx *ctx,
  *
  * @return Return 0 if ok, <0 if error.
  */
-int http_server_set_tls(struct http_ctx *ctx,
+__deprecated int http_server_set_tls(struct http_ctx *ctx,
 			const char *server_banner,
 			u8_t *personalization_data,
 			size_t personalization_data_len,
@@ -569,7 +569,7 @@ int http_server_set_tls(struct http_ctx *ctx,
  *
  * @return 0 if server is enabled, <0 otherwise
  */
-int http_server_enable(struct http_ctx *ctx);
+__deprecated int http_server_enable(struct http_ctx *ctx);
 
 /**
  * @brief Disable HTTP server that is related to this context.
@@ -580,7 +580,7 @@ int http_server_enable(struct http_ctx *ctx);
  *
  * @return 0 if server is disabled, <0 if there was an error
  */
-int http_server_disable(struct http_ctx *ctx);
+__deprecated int http_server_disable(struct http_ctx *ctx);
 
 /**
  * @brief Add an URL to a list of URLs that are tied to certain webcontext.
@@ -593,7 +593,8 @@ int http_server_disable(struct http_ctx *ctx);
  * @return NULL if the URL is already registered, pointer to  URL if
  * registering was ok.
  */
-struct http_root_url *http_server_add_url(struct http_server_urls *urls,
+__deprecated struct http_root_url *http_server_add_url(
+					  struct http_server_urls *urls,
 					  const char *url, u8_t flags);
 
 /**
@@ -606,7 +607,8 @@ struct http_root_url *http_server_add_url(struct http_server_urls *urls,
  *
  * @return 0 if ok, <0 if error.
  */
-int http_server_del_url(struct http_server_urls *urls, const char *url);
+__deprecated int http_server_del_url(struct http_server_urls *urls,
+				     const char *url);
 
 /**
  * @brief Add default URL handler.
@@ -622,7 +624,8 @@ int http_server_del_url(struct http_server_urls *urls, const char *url);
  * @return NULL if default URL is already registered, pointer to default
  * URL if registering was ok.
  */
-struct http_root_url *http_server_add_default(struct http_server_urls *urls,
+__deprecated struct http_root_url *http_server_add_default(
+					      struct http_server_urls *urls,
 					      http_url_cb_t cb);
 
 /**
@@ -635,11 +638,11 @@ struct http_root_url *http_server_add_default(struct http_server_urls *urls,
  *
  * @return 0 if ok, <0 if error.
  */
-int http_server_del_default(struct http_server_urls *urls);
+__deprecated int http_server_del_default(struct http_server_urls *urls);
 
 #else /* CONFIG_HTTP_SERVER */
 
-static inline int http_server_init(struct http_ctx *ctx,
+__deprecated static inline int http_server_init(struct http_ctx *ctx,
 				   struct http_server_urls *urls,
 				   struct sockaddr *server_addr,
 				   u8_t *request_buf,
@@ -657,7 +660,7 @@ static inline int http_server_init(struct http_ctx *ctx,
 }
 
 #if defined(CONFIG_HTTPS) && defined(CONFIG_NET_APP_SERVER)
-static inline int http_server_set_tls(struct http_ctx *ctx,
+__deprecated static inline int http_server_set_tls(struct http_ctx *ctx,
 				      const char *server_banner,
 				      u8_t *personalization_data,
 				      size_t personalization_data_len,
@@ -718,7 +721,7 @@ struct http_root_url *http_server_add_url(struct http_server_urls *urls,
  *
  * @return Return 0 if ok, and <0 if error.
  */
-int http_request(struct http_ctx *ctx,
+__deprecated int http_request(struct http_ctx *ctx,
 		 struct http_request *req,
 		 s32_t timeout,
 		 void *user_data);
@@ -730,7 +733,7 @@ int http_request(struct http_ctx *ctx,
  *
  * @return Return 0 if ok, and <0 if error.
  */
-int http_request_cancel(struct http_ctx *ctx);
+__deprecated int http_request_cancel(struct http_ctx *ctx);
 
 /**
  * @brief Send a HTTP request to peer.
@@ -747,7 +750,7 @@ int http_request_cancel(struct http_ctx *ctx);
  *
  * @return Return 0 if ok, and <0 if error.
  */
-int http_client_send_req(struct http_ctx *http_ctx,
+__deprecated int http_client_send_req(struct http_ctx *http_ctx,
 			 struct http_request *req,
 			 http_response_cb_t cb,
 			 u8_t *response_buf,
@@ -775,7 +778,8 @@ int http_client_send_req(struct http_ctx *http_ctx,
  *
  * @return Return 0 if ok, and <0 if error.
  */
-static inline int http_client_send_get_req(struct http_ctx *http_ctx,
+__deprecated static inline
+int http_client_send_get_req(struct http_ctx *http_ctx,
 					   const char *url,
 					   const char *host,
 					   const char *extra_header_fields,
@@ -817,7 +821,7 @@ static inline int http_client_send_get_req(struct http_ctx *http_ctx,
  *
  * @return Return 0 if ok, <0 if error.
  */
-int http_client_init(struct http_ctx *http_ctx,
+__deprecated int http_client_init(struct http_ctx *http_ctx,
 		     const char *server,
 		     u16_t server_port,
 		     struct sockaddr *server_addr,
@@ -853,7 +857,7 @@ int http_client_init(struct http_ctx *http_ctx,
  *
  * @return Return 0 if ok, <0 if error.
  */
-int http_client_set_tls(struct http_ctx *ctx,
+__deprecated int http_client_set_tls(struct http_ctx *ctx,
 			u8_t *request_buf,
 			size_t request_buf_len,
 			u8_t *personalization_data,
@@ -874,7 +878,7 @@ int http_client_set_tls(struct http_ctx *ctx,
  *
  * @return 0 if ok, <0 if error.
  */
-int http_close(struct http_ctx *ctx);
+__deprecated int http_close(struct http_ctx *ctx);
 
 /**
  * @brief Release this http context.
@@ -886,7 +890,7 @@ int http_close(struct http_ctx *ctx);
  *
  * @return 0 if ok, <0 if error.
  */
-int http_release(struct http_ctx *ctx);
+__deprecated int http_release(struct http_ctx *ctx);
 
 /**
  * @brief Set various callbacks that are called at various stage of ws session.
@@ -899,7 +903,7 @@ int http_release(struct http_ctx *ctx);
  *
  * @return 0 if ok, <0 if error.
  */
-int http_set_cb(struct http_ctx *ctx,
+__deprecated int http_set_cb(struct http_ctx *ctx,
 		http_connect_cb_t connect_cb,
 		http_recv_cb_t recv_cb,
 		http_send_cb_t send_cb,
@@ -918,7 +922,7 @@ int http_set_cb(struct http_ctx *ctx,
  *
  * @return 0 if ok, <0 if error.
  */
-int http_send_msg_raw(struct http_ctx *ctx, struct net_pkt *pkt,
+__deprecated int http_send_msg_raw(struct http_ctx *ctx, struct net_pkt *pkt,
 		      void *user_send_data);
 
 /**
@@ -934,7 +938,8 @@ int http_send_msg_raw(struct http_ctx *ctx, struct net_pkt *pkt,
  *
  * @return 0 if ok, <0 if error.
  */
-int http_prepare_and_send(struct http_ctx *ctx, const char *payload,
+__deprecated int http_prepare_and_send(struct http_ctx *ctx,
+			  const char *payload,
 			  size_t payload_len,
 			  const struct sockaddr *dst,
 			  void *user_send_data);
@@ -951,7 +956,7 @@ int http_prepare_and_send(struct http_ctx *ctx, const char *payload,
  *
  * @return 0 if ok, <0 if error.
  */
-int http_send_chunk(struct http_ctx *ctx, const char *payload,
+__deprecated int http_send_chunk(struct http_ctx *ctx, const char *payload,
 		    size_t payload_len,
 		    const struct sockaddr *dst,
 		    void *user_send_data);
@@ -965,7 +970,7 @@ int http_send_chunk(struct http_ctx *ctx, const char *payload,
  *
  * @return 0 if ok, <0 if error.
  */
-int http_send_flush(struct http_ctx *ctx, void *user_send_data);
+__deprecated int http_send_flush(struct http_ctx *ctx, void *user_send_data);
 
 /**
  * @brief Send HTTP error message to peer.
@@ -978,7 +983,7 @@ int http_send_flush(struct http_ctx *ctx, void *user_send_data);
  *
  * @return 0 if ok, <0 if error.
  */
-int http_send_error(struct http_ctx *ctx, int code,
+__deprecated int http_send_error(struct http_ctx *ctx, int code,
 		    u8_t *html_payload, size_t html_len,
 		    const struct sockaddr *dst);
 
@@ -998,7 +1003,8 @@ int http_send_error(struct http_ctx *ctx, int code,
  *
  * @return <0 if error, other value tells how many bytes were added
  */
-int http_add_header(struct http_ctx *ctx, const char *http_header_field,
+__deprecated int http_add_header(struct http_ctx *ctx,
+		    const char *http_header_field,
 		    const struct sockaddr *dst,
 		    void *user_send_data);
 
@@ -1019,7 +1025,7 @@ int http_add_header(struct http_ctx *ctx, const char *http_header_field,
  *
  * @return <0 if error, other value tells how many bytes were added
  */
-int http_add_header_field(struct http_ctx *ctx, const char *name,
+__deprecated int http_add_header_field(struct http_ctx *ctx, const char *name,
 			  const char *value,
 			  const struct sockaddr *dst,
 			  void *user_send_data);
@@ -1034,7 +1040,7 @@ int http_add_header_field(struct http_ctx *ctx, const char *name,
  *
  * @return URL handler or NULL if no such handler was found.
  */
-struct http_root_url *http_url_find(struct http_ctx *ctx,
+__deprecated struct http_root_url *http_url_find(struct http_ctx *ctx,
 				    enum http_url_flags flags);
 
 #define http_change_state(ctx, new_state)			\
@@ -1050,7 +1056,7 @@ struct http_root_url *http_url_find(struct http_ctx *ctx,
  * @param func Function that changed the state (for debugging)
  * @param line Line number of the function (for debugging)
  */
-void _http_change_state(struct http_ctx *ctx,
+__deprecated void _http_change_state(struct http_ctx *ctx,
 			enum http_state new_state,
 			const char *func, int line);
 
@@ -1066,7 +1072,7 @@ void _http_change_state(struct http_ctx *ctx,
  * @param ctx The HTTP context to use.
  * @param user_data User specified data.
  */
-typedef void (*http_server_cb_t)(struct http_ctx *entry,
+__deprecated typedef void (*http_server_cb_t)(struct http_ctx *entry,
 				 void *user_data);
 
 /**
@@ -1076,7 +1082,8 @@ typedef void (*http_server_cb_t)(struct http_ctx *entry,
  * @param cb Callback to call for each HTTP connection.
  * @param user_data User provided data that is passed to callback.
  */
-void http_server_conn_foreach(http_server_cb_t cb, void *user_data);
+__deprecated void http_server_conn_foreach(http_server_cb_t cb,
+					   void *user_data);
 
 /**
  * @brief Register a callback that is called if HTTP connection is
@@ -1088,7 +1095,8 @@ void http_server_conn_foreach(http_server_cb_t cb, void *user_data);
  * deleted.
  * @param user_data User provided data that is passed to callback.
  */
-void http_server_conn_monitor(http_server_cb_t cb, void *user_data);
+__deprecated void http_server_conn_monitor(http_server_cb_t cb,
+					   void *user_data);
 
 /**
  * @brief HTTP connection was established.
@@ -1097,7 +1105,7 @@ void http_server_conn_monitor(http_server_cb_t cb, void *user_data);
  *
  * @param ctx HTTP context.
  */
-void http_server_conn_add(struct http_ctx *ctx);
+__deprecated void http_server_conn_add(struct http_ctx *ctx);
 
 /**
  * @brief HTTP connection was disconnected.
@@ -1106,7 +1114,7 @@ void http_server_conn_add(struct http_ctx *ctx);
  *
  * @param ctx HTTP context.
  */
-void http_server_conn_del(struct http_ctx *ctx);
+__deprecated void http_server_conn_del(struct http_ctx *ctx);
 #else
 #define http_server_conn_foreach(...)
 #define http_server_conn_monitor(...)

--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -55,13 +55,13 @@ extern "C" {
  * @{
  */
 
-enum net_app_type {
+__deprecated enum net_app_type {
 	NET_APP_UNSPEC = 0,
 	NET_APP_SERVER,
 	NET_APP_CLIENT,
 } __packed;
 
-struct net_app_ctx;
+__deprecated struct net_app_ctx;
 
 /**
  * @typedef net_app_recv_cb_t
@@ -79,7 +79,7 @@ struct net_app_ctx;
  * pkt parameter is set to NULL.
  * @param user_data The user data given in init call.
  */
-typedef void (*net_app_recv_cb_t)(struct net_app_ctx *ctx,
+__deprecated typedef void (*net_app_recv_cb_t)(struct net_app_ctx *ctx,
 				  struct net_pkt *pkt,
 				  int status,
 				  void *user_data);
@@ -97,7 +97,7 @@ typedef void (*net_app_recv_cb_t)(struct net_app_ctx *ctx,
  * error.
  * @param user_data The user data given in init call.
  */
-typedef void (*net_app_connect_cb_t)(struct net_app_ctx *ctx,
+__deprecated typedef void (*net_app_connect_cb_t)(struct net_app_ctx *ctx,
 				     int status,
 				     void *user_data);
 
@@ -115,7 +115,7 @@ typedef void (*net_app_connect_cb_t)(struct net_app_ctx *ctx,
  * @param user_data_send The user data given in net_app_send() call.
  * @param user_data The user data given in init call.
  */
-typedef void (*net_app_send_cb_t)(struct net_app_ctx *ctx,
+__deprecated typedef void (*net_app_send_cb_t)(struct net_app_ctx *ctx,
 				  int status,
 				  void *user_data_send,
 				  void *user_data);
@@ -131,12 +131,12 @@ typedef void (*net_app_send_cb_t)(struct net_app_ctx *ctx,
  * @param status Error code for the closing.
  * @param user_data The user data given in init call.
  */
-typedef void (*net_app_close_cb_t)(struct net_app_ctx *ctx,
+__deprecated typedef void (*net_app_close_cb_t)(struct net_app_ctx *ctx,
 				   int status,
 				   void *user_data);
 
 /** Network application callbacks */
-struct net_app_cb {
+__deprecated struct net_app_cb {
 	/** Function that is called when a connection is established.
 	 */
 	net_app_connect_cb_t connect;
@@ -157,7 +157,7 @@ struct net_app_cb {
 /* This is the same prototype as what net_context_sendto() has
  * so that we can override the sending of the data for TLS traffic.
  */
-typedef int (*net_app_send_data_t)(struct net_pkt *pkt,
+__deprecated typedef int (*net_app_send_data_t)(struct net_pkt *pkt,
 				   const struct sockaddr *dst_addr,
 				   socklen_t addrlen,
 				   net_context_send_cb_t cb,
@@ -167,7 +167,7 @@ typedef int (*net_app_send_data_t)(struct net_pkt *pkt,
 
 #if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 /* Internal information for managing TLS data */
-struct tls_context {
+__deprecated struct tls_context {
 	struct net_pkt *rx_pkt;
 	struct net_buf *hdr; /* IP + UDP/TCP header */
 	struct net_buf *frag;
@@ -182,7 +182,7 @@ struct tls_context {
 /* This struct is used to pass data to TLS thread when reading or sending
  * data.
  */
-struct net_app_fifo_block {
+__deprecated struct net_app_fifo_block {
 	struct k_mem_block block;
 	struct net_pkt *pkt;
 	void *token; /* Used when sending data */
@@ -205,7 +205,7 @@ struct net_app_fifo_block {
  *
  * @return 0 if ok, <0 if there is an error
  */
-typedef int (*net_app_cert_cb_t)(struct net_app_ctx *ctx,
+__deprecated typedef int (*net_app_cert_cb_t)(struct net_app_ctx *ctx,
 				 mbedtls_x509_crt *cert,
 				 mbedtls_pk_context *pkey);
 #endif /* CONFIG_NET_APP_SERVER */
@@ -221,7 +221,7 @@ typedef int (*net_app_cert_cb_t)(struct net_app_ctx *ctx,
  *
  * @return 0 if ok, <0 if there is an error
  */
-typedef int (*net_app_ca_cert_cb_t)(struct net_app_ctx *ctx,
+__deprecated typedef int (*net_app_ca_cert_cb_t)(struct net_app_ctx *ctx,
 				    void *ca_cert);
 #endif /* CONFIG_NET_APP_CLIENT */
 
@@ -235,12 +235,13 @@ typedef int (*net_app_ca_cert_cb_t)(struct net_app_ctx *ctx,
  * @param len Maximum size to provide
  * @param olen The actual amount of bytes put into the buffer (Can be 0)
  */
-typedef int (*net_app_entropy_src_cb_t)(void *data, unsigned char *output,
+__deprecated typedef int (*net_app_entropy_src_cb_t)(void *data,
+						     unsigned char *output,
 					size_t len, size_t *olen);
 #endif /* CONFIG_NET_APP_TLS || CONFIG_NET_APP_DTLS */
 
 #if defined(CONFIG_NET_APP_DTLS)
-struct dtls_timing_context {
+__deprecated struct dtls_timing_context {
 	u32_t snapshot;
 	u32_t int_ms;
 	u32_t fin_ms;
@@ -248,7 +249,7 @@ struct dtls_timing_context {
 #endif /* CONFIG_NET_APP_DTLS */
 
 /* Information for the context and local/remote addresses used. */
-struct net_app_endpoint {
+__deprecated struct net_app_endpoint {
 	/** Network context. */
 	struct net_context *ctx;
 
@@ -260,7 +261,7 @@ struct net_app_endpoint {
 };
 
 /** Network application context. */
-struct net_app_ctx {
+__deprecated struct net_app_ctx {
 #if defined(CONFIG_NET_IPV6)
 	struct net_app_endpoint ipv6;
 #endif
@@ -460,7 +461,7 @@ struct net_app_ctx {
  * @param data_pool Function which is used when allocating data network buffer.
  * This can be NULL in which case default DATA net_buf pool is used.
  */
-int net_app_set_net_pkt_pool(struct net_app_ctx *ctx,
+__deprecated int net_app_set_net_pkt_pool(struct net_app_ctx *ctx,
 			     net_pkt_get_slab_func_t tx_slab,
 			     net_pkt_get_pool_func_t data_pool);
 #else
@@ -489,7 +490,7 @@ int net_app_set_net_pkt_pool(struct net_app_ctx *ctx,
  *
  * @return 0 if ok, <0 if error.
  */
-int net_app_init_server(struct net_app_ctx *ctx,
+__deprecated int net_app_init_server(struct net_app_ctx *ctx,
 			enum net_sock_type sock_type,
 			enum net_ip_protocol proto,
 			struct sockaddr *server_addr,
@@ -515,7 +516,7 @@ int net_app_init_server(struct net_app_ctx *ctx,
  *
  * @return 0 if ok, <0 if error.
  */
-static inline int net_app_init_tcp_server(struct net_app_ctx *ctx,
+__deprecated static inline int net_app_init_tcp_server(struct net_app_ctx *ctx,
 					  struct sockaddr *server_addr,
 					  u16_t port,
 					  void *user_data)
@@ -547,7 +548,7 @@ static inline int net_app_init_tcp_server(struct net_app_ctx *ctx,
  *
  * @return 0 if ok, <0 if error.
  */
-static inline int net_app_init_udp_server(struct net_app_ctx *ctx,
+__deprecated static inline int net_app_init_udp_server(struct net_app_ctx *ctx,
 					  struct sockaddr *server_addr,
 					  u16_t port,
 					  void *user_data)
@@ -574,7 +575,7 @@ static inline int net_app_init_udp_server(struct net_app_ctx *ctx,
  *
  * @return 0 if ok, <0 if error.
  */
-int net_app_listen(struct net_app_ctx *ctx);
+__deprecated int net_app_listen(struct net_app_ctx *ctx);
 
 /**
  * @brief Enable server to serve connections.
@@ -585,7 +586,7 @@ int net_app_listen(struct net_app_ctx *ctx);
  *
  * @return 0 if ok, <0 if error.
  */
-bool net_app_server_enable(struct net_app_ctx *ctx);
+__deprecated bool net_app_server_enable(struct net_app_ctx *ctx);
 
 /**
  * @brief Disable server so that it will not serve any clients.
@@ -594,7 +595,7 @@ bool net_app_server_enable(struct net_app_ctx *ctx);
  *
  * @return 0 if ok, <0 if error.
  */
-bool net_app_server_disable(struct net_app_ctx *ctx);
+__deprecated bool net_app_server_disable(struct net_app_ctx *ctx);
 
 #endif /* CONFIG_NET_APP_SERVER */
 
@@ -635,7 +636,7 @@ bool net_app_server_disable(struct net_app_ctx *ctx);
  *
  * @return 0 if ok, <0 if error.
  */
-int net_app_init_client(struct net_app_ctx *ctx,
+__deprecated int net_app_init_client(struct net_app_ctx *ctx,
 			enum net_sock_type sock_type,
 			enum net_ip_protocol proto,
 			struct sockaddr *client_addr,
@@ -679,7 +680,7 @@ int net_app_init_client(struct net_app_ctx *ctx,
  *
  * @return 0 if ok, <0 if error.
  */
-static inline int net_app_init_tcp_client(struct net_app_ctx *ctx,
+__deprecated static inline int net_app_init_tcp_client(struct net_app_ctx *ctx,
 					  struct sockaddr *client_addr,
 					  struct sockaddr *peer_addr,
 					  const char *peer_addr_str,
@@ -732,7 +733,7 @@ static inline int net_app_init_tcp_client(struct net_app_ctx *ctx,
  *
  * @return 0 if ok, <0 if error.
  */
-static inline int net_app_init_udp_client(struct net_app_ctx *ctx,
+__deprecated static inline int net_app_init_udp_client(struct net_app_ctx *ctx,
 					  struct sockaddr *client_addr,
 					  struct sockaddr *peer_addr,
 					  const char *peer_addr_str,
@@ -759,7 +760,7 @@ static inline int net_app_init_udp_client(struct net_app_ctx *ctx,
  *
  * @return 0 if ok, <0 if error.
  */
-int net_app_connect(struct net_app_ctx *ctx, s32_t timeout);
+__deprecated int net_app_connect(struct net_app_ctx *ctx, s32_t timeout);
 #endif /* CONFIG_NET_APP_CLIENT */
 
 /**
@@ -773,7 +774,7 @@ int net_app_connect(struct net_app_ctx *ctx, s32_t timeout);
  *
  * @return 0 if ok, <0 if error.
  */
-int net_app_set_cb(struct net_app_ctx *ctx,
+__deprecated int net_app_set_cb(struct net_app_ctx *ctx,
 		   net_app_connect_cb_t connect_cb,
 		   net_app_recv_cb_t recv_cb,
 		   net_app_send_cb_t send_cb,
@@ -796,7 +797,7 @@ int net_app_set_cb(struct net_app_ctx *ctx,
  *
  * @return 0 if ok, <0 if error.
  */
-int net_app_send_pkt(struct net_app_ctx *ctx,
+__deprecated int net_app_send_pkt(struct net_app_ctx *ctx,
 		     struct net_pkt *pkt,
 		     const struct sockaddr *dst,
 		     socklen_t dst_len,
@@ -817,7 +818,7 @@ int net_app_send_pkt(struct net_app_ctx *ctx,
  *
  * @return 0 if ok, <0 if error.
  */
-int net_app_send_buf(struct net_app_ctx *ctx,
+__deprecated int net_app_send_buf(struct net_app_ctx *ctx,
 		     u8_t *buf,
 		     size_t buf_len,
 		     const struct sockaddr *dst,
@@ -834,7 +835,7 @@ int net_app_send_buf(struct net_app_ctx *ctx,
  *
  * @return valid net_pkt if ok, NULL if error.
  */
-struct net_pkt *net_app_get_net_pkt(struct net_app_ctx *ctx,
+__deprecated struct net_pkt *net_app_get_net_pkt(struct net_app_ctx *ctx,
 				    sa_family_t family,
 				    s32_t timeout);
 
@@ -863,7 +864,7 @@ struct net_pkt *net_app_get_net_pkt_with_dst(struct net_app_ctx *ctx,
  *
  * @return valid net_pkt if ok, NULL if error.
  */
-struct net_buf *net_app_get_net_buf(struct net_app_ctx *ctx,
+__deprecated struct net_buf *net_app_get_net_buf(struct net_app_ctx *ctx,
 				    struct net_pkt *pkt,
 				    s32_t timeout);
 
@@ -874,7 +875,7 @@ struct net_buf *net_app_get_net_buf(struct net_app_ctx *ctx,
  *
  * @return 0 if ok, <0 if error.
  */
-int net_app_close(struct net_app_ctx *ctx);
+__deprecated int net_app_close(struct net_app_ctx *ctx);
 
 /**
  * @brief Close a specific network connection.
@@ -884,7 +885,7 @@ int net_app_close(struct net_app_ctx *ctx);
  *
  * @return 0 if ok, <0 if error.
  */
-int net_app_close2(struct net_app_ctx *ctx,
+__deprecated int net_app_close2(struct net_app_ctx *ctx,
 		   struct net_context *net_ctx);
 
 /**
@@ -897,7 +898,7 @@ int net_app_close2(struct net_app_ctx *ctx,
  *
  * @return 0 if ok, <0 if error.
  */
-int net_app_release(struct net_app_ctx *ctx);
+__deprecated int net_app_release(struct net_app_ctx *ctx);
 
 #if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 #if defined(CONFIG_NET_APP_CLIENT)
@@ -927,7 +928,7 @@ int net_app_release(struct net_app_ctx *ctx);
  *
  * @return Return 0 if ok, <0 if error.
  */
-int net_app_client_tls(struct net_app_ctx *ctx,
+__deprecated int net_app_client_tls(struct net_app_ctx *ctx,
 		       u8_t *request_buf,
 		       size_t request_buf_len,
 		       u8_t *personalization_data,
@@ -963,7 +964,7 @@ int net_app_client_tls(struct net_app_ctx *ctx,
  *
  * @return Return 0 if ok, <0 if error.
  */
-int net_app_server_tls(struct net_app_ctx *ctx,
+__deprecated int net_app_server_tls(struct net_app_ctx *ctx,
 		       u8_t *request_buf,
 		       size_t request_buf_len,
 		       const char *server_banner,
@@ -983,9 +984,10 @@ int net_app_server_tls(struct net_app_ctx *ctx,
  * @}
  */
 
-typedef void (*net_app_ctx_cb_t)(struct net_app_ctx *ctx, void *user_data);
-void net_app_server_foreach(net_app_ctx_cb_t cb, void *user_data);
-void net_app_client_foreach(net_app_ctx_cb_t cb, void *user_data);
+__deprecated typedef void (*net_app_ctx_cb_t)(struct net_app_ctx *ctx,
+					      void *user_data);
+__deprecated void net_app_server_foreach(net_app_ctx_cb_t cb, void *user_data);
+__deprecated void net_app_client_foreach(net_app_ctx_cb_t cb, void *user_data);
 
 #ifdef __cplusplus
 }

--- a/include/net/websocket.h
+++ b/include/net/websocket.h
@@ -28,7 +28,7 @@ extern "C" {
 #define WS_FLAG_PING   0x00000010
 #define WS_FLAG_PONG   0x00000011
 
-enum ws_opcode  {
+__deprecated enum ws_opcode  {
 	WS_OPCODE_CONTINUE     = 0x00,
 	WS_OPCODE_DATA_TEXT    = 0x01,
 	WS_OPCODE_DATA_BINARY  = 0x02,
@@ -58,7 +58,8 @@ enum ws_opcode  {
  *
  * @return 0 if ok, <0 if error.
  */
-int ws_send_msg(struct http_ctx *ctx, u8_t *payload, size_t payload_len,
+__deprecated int ws_send_msg(struct http_ctx *ctx, u8_t *payload,
+		size_t payload_len,
 		enum ws_opcode opcode, bool mask, bool final,
 		const struct sockaddr *dst,
 		void *user_send_data);
@@ -80,7 +81,7 @@ int ws_send_msg(struct http_ctx *ctx, u8_t *payload, size_t payload_len,
  *
  * @return 0 if ok, <0 if error.
  */
-static inline int ws_send_msg_to_client(struct http_ctx *ctx,
+__deprecated static inline int ws_send_msg_to_client(struct http_ctx *ctx,
 					u8_t *payload,
 					size_t payload_len,
 					enum ws_opcode opcode,

--- a/subsys/net/lib/app/Kconfig
+++ b/subsys/net/lib/app/Kconfig
@@ -7,7 +7,7 @@
 #
 
 menuconfig NET_APP
-	bool "Network application API support [EXPERIMENTAL]"
+	bool "Network application API support [EXPERIMENTAL, Deprecated]"
 	default y
 	select NET_MGMT
 	select NET_MGMT_EVENT

--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -4,7 +4,7 @@
 #
 
 config HTTP
-	bool "HTTP support"
+	bool "HTTP support [Deprecated]"
 	help
 	  This option enables the HTTP library
 

--- a/subsys/net/lib/websocket/Kconfig
+++ b/subsys/net/lib/websocket/Kconfig
@@ -4,7 +4,7 @@
 #
 
 menuconfig WEBSOCKET
-	bool "Websocket support [EXPERIMENTAL]"
+	bool "Websocket support [EXPERIMENTAL, Deprecated]"
 	depends on HTTP
 	select NET_TCP
 	select BASE64


### PR DESCRIPTION
As we are migrating away from net-app API to BSD socket based APIs,
the net-app needs to be deprecated. This commit will also deprecate
net-app API users such as HTTP client and server API, websocket API.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>