### PR TITLE
Corrected __ASSERT include paths in settings subsytem

### DIFF
--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -6,7 +6,6 @@
  */
 
 #include <string.h>
-#include <assert.h>
 #include <zephyr.h>
 
 #include <fs.h>

--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <assert.h>
-
 #include <string.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -7,7 +7,7 @@
 
 #include <ctype.h>
 #include <string.h>
-#include <assert.h>
+#include <misc/__assert.h>
 
 #include "settings/settings.h"
 #include "settings_priv.h"


### PR DESCRIPTION
Renamed <assert.h> to <misc/__assert.h> and removed <assert.h> where
not needed else settings tests will fail if assert is enabled.
