### PR TITLE
include: linker: Fix linker sections

### DIFF
--- a/include/linker/sections.h
+++ b/include/linker/sections.h
@@ -15,34 +15,34 @@
 #ifndef ZEPHYR_INCLUDE_LINKER_SECTIONS_H_
 #define ZEPHYR_INCLUDE_LINKER_SECTIONS_H_
 
-#define _TEXT_SECTION_NAME text
-#define _RODATA_SECTION_NAME rodata
-#define _CTOR_SECTION_NAME ctors
-/* Linker issue with XIP where the name "data" cannot be used */
-#define _DATA_SECTION_NAME datas
-#define _BSS_SECTION_NAME bss
-#define _NOINIT_SECTION_NAME noinit
+#define _TEXT_SECTION_NAME .text
+#define _RODATA_SECTION_NAME .rodata
+#define _CTOR_SECTION_NAME .ctors
+#define _DATA_SECTION_NAME .data
+#define _BSS_SECTION_NAME .bss
+#define _INIT_SECTION_NAME .init
+#define _NOINIT_SECTION_NAME .noinit
 
-#define _APP_SMEM_SECTION_NAME		app_smem
-#define _APP_DATA_SECTION_NAME		app_datas
-#define _APP_BSS_SECTION_NAME		app_bss
-#define _APP_NOINIT_SECTION_NAME	app_noinit
+#define _APP_SMEM_SECTION_NAME		.app_smem
+#define _APP_DATA_SECTION_NAME		.app_data
+#define _APP_BSS_SECTION_NAME		.app_bss
+#define _APP_NOINIT_SECTION_NAME	.app_noinit
 
-#define _UNDEFINED_SECTION_NAME undefined
+#define _UNDEFINED_SECTION_NAME .undefined
 
 /* Various text section names */
-#define TEXT text
+#define TEXT .text
 #if defined(CONFIG_X86)
-#define TEXT_START text_start /* beginning of TEXT section */
+#define TEXT_START .text_start /* beginning of TEXT section */
 #else
-#define TEXT_START text /* beginning of TEXT section */
+#define TEXT_START .text /* beginning of TEXT section */
 #endif
 
 /* Various data type section names */
-#define BSS bss
-#define RODATA rodata
-#define DATA data
-#define NOINIT noinit
+#define BSS .bss
+#define RODATA .rodata
+#define DATA .data
+#define NOINIT .noinit
 
 /* Interrupts */
 #define IRQ_VECTOR_TABLE	.gnu.linkonce.irq_vector_table
@@ -68,7 +68,7 @@
 #define IMX_BOOT_DCD	.boot_hdr.dcd_data
 
 #ifdef CONFIG_NOCACHE_MEMORY
-#define _NOCACHE_SECTION_NAME nocache
+#define _NOCACHE_SECTION_NAME .nocache
 #endif
 
 #include <linker/section_tags.h>


### PR DESCRIPTION
Changes the linker sections to follow the
[ELF Spec](http://refspecs.linuxbase.org/elf/elf.pdf)
instead of using sections without `.` infront for special
sections.

Fixes #12490

Signed-off-by: Sigvart M. Hovland <sigvart.hovland@nordicsemi.no>