### PR TITLE
ext: hal: nordic: add nrfx misc for nRF9160

### DIFF
--- a/ext/hal/nordic/CMakeLists.txt
+++ b/ext/hal/nordic/CMakeLists.txt
@@ -16,11 +16,16 @@ if(CONFIG_HAS_NRFX)
   zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52810      NRF52810_XXAA)
   zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52832      NRF52832_XXAA)
   zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52840      NRF52840_XXAA)
+  zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9160       NRF9160_XXAA)
+
+  # Connect Kconfig compilation option for Non-Secure software with option required by MDK/nrfx
+  zephyr_compile_definitions_ifdef(CONFIG_ARM_NONSECURE_FIRMWARE NRF_TRUSTZONE_NONSECURE)
 
   zephyr_sources_ifdef(CONFIG_SOC_SERIES_NRF51X nrfx/mdk/system_nrf51.c)
   zephyr_sources_ifdef(CONFIG_SOC_NRF52810      nrfx/mdk/system_nrf52810.c)
   zephyr_sources_ifdef(CONFIG_SOC_NRF52832      nrfx/mdk/system_nrf52.c)
   zephyr_sources_ifdef(CONFIG_SOC_NRF52840      nrfx/mdk/system_nrf52840.c)
+  zephyr_sources_ifdef(CONFIG_SOC_NRF9160       nrfx/mdk/system_nrf9160.c)
 
   zephyr_sources(nrfx_glue.c)
 


### PR DESCRIPTION
This commit adds nrfx_config_nrf9160.h header and its
conditional inclusion in nrfx_config.h, when building
for nRF9160 SOC.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>