### PR TITLE
device: gpio: fix mis-use of slist API in callback processing

### DIFF
--- a/drivers/gpio/gpio_utils.h
+++ b/drivers/gpio/gpio_utils.h
@@ -44,9 +44,9 @@ static inline void _gpio_fire_callbacks(sys_slist_t *list,
 					struct device *port,
 					u32_t pins)
 {
-	struct gpio_callback *cb;
+	struct gpio_callback *cb, *tmp;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(list, cb, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(list, cb, tmp, node) {
 		if (cb->pin_mask & pins) {
 			__ASSERT(cb->handler, "No callback handler!");
 			cb->handler(port, cb, pins);

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -252,6 +252,10 @@ static inline void gpio_init_callback(struct gpio_callback *callback,
  * @param callback A valid Application's callback structure pointer.
  * @return 0 if successful, negative errno code on failure.
  *
+ * @note Callbacks may be added to the device from within a callback
+ * handler invocation, but whether they are invoked for the current
+ * GPIO event is not specified.
+ *
  * Note: enables to add as many callback as needed on the same port.
  */
 static inline int gpio_add_callback(struct device *port,
@@ -270,6 +274,13 @@ static inline int gpio_add_callback(struct device *port,
  * @param port Pointer to the device structure for the driver instance.
  * @param callback A valid application's callback structure pointer.
  * @return 0 if successful, negative errno code on failure.
+ *
+ * @warning It is explicitly permitted, within a callback handler, to
+ * remove the registration for the callback that is running, i.e. @p
+ * callback.  Attempts to remove other registrations on the same
+ * device may result in undefined behavior, including failure to
+ * invoke callbacks that remain registered and unintended invocation
+ * of removed callbacks.
  *
  * Note: enables to remove as many callbacks as added through
  *       gpio_add_callback().

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -77,15 +77,15 @@ struct gpio_callback {
 	/** Actual callback function being called when relevant. */
 	gpio_callback_handler_t handler;
 
-	/** A mask of pins (pin_mask) or a specific pin (pin) the callback
-	 * is interested in, if 0 the callback will never be called.
-	 * The pin_mask or pin can be modified whenever
+	/** A mask of pins the callback is interested in, if 0 the callback
+	 * will never be called. Such pin_mask can be modified whenever
 	 * necessary by the owner, and thus will affect the handler being
 	 * called or not. The selected pins must be configured to trigger
 	 * an interrupt.
 	 */
 	union {
 		u32_t pin_mask;
+		/* @todo Remove `pin` when #11565 is resolved */
 		u32_t pin;
 	};
 };

--- a/tests/drivers/gpio/gpio_basic_api/src/main.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/main.c
@@ -53,6 +53,7 @@ void test_main(void)
 			 ztest_unit_test(test_gpio_callback_edge_low),
 			 ztest_unit_test(test_gpio_callback_level_high),
 			 ztest_unit_test(test_gpio_callback_add_remove),
+			 ztest_unit_test(test_gpio_callback_self_remove),
 			 ztest_unit_test(test_gpio_callback_enable_disable),
 			 ztest_unit_test(test_gpio_callback_level_low));
 	ztest_run_test_suite(gpio_basic_test);

--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio.h
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio.h
@@ -61,6 +61,7 @@ struct drv_data {
 	struct gpio_callback gpio_cb;
 	int mode;
 	int index;
+	int aux;
 };
 
 void test_gpio_pin_read_write(void);
@@ -69,6 +70,7 @@ void test_gpio_callback_edge_low(void);
 void test_gpio_callback_level_high(void);
 void test_gpio_callback_level_low(void);
 void test_gpio_callback_add_remove(void);
+void test_gpio_callback_self_remove(void);
 void test_gpio_callback_enable_disable(void);
 
 #endif /* __TEST_GPIO_H__ */


### PR DESCRIPTION
### driver: gpio: remove documentation related to pin-based callback configuration

This reverts the documentation component of commit
eb6ea28649f6364f17642835af0aa7706c37a10b.

The original change broke the API contract: drivers that use GPIOs need
to be able to configure callbacks without being aware of whether a
particular implementation expects to use a mask or a pin ordinal.

Revert the API documentation to its original format, and mark that the
added field should be removed when issue #11565 is resolved.

### drivers: gpio: fix mis-use of slist API in callback processing

The iterator over registered callbacks failed to account for the
possibility that the callback would remove itself from the list.  If
this occurred any remaining callbacks would no longer be reachable from
the node.  Switch to the slist iterator that is safe for self-removal.

Note that the slist API remains unsafe for removal of subsequent nodes.
Even with the corrected code removal of the next callback registration
(cached in tmp) will result in it being called anyway, with the
remaining unremoved registrations not being called.  If the next
callback were removed and re-registered on a different device, the
callbacks would be invoked for the wrong device.

Resolve this by a documentation change describing the conditions under
which a change to callback registration from within a callback are
permitted.  Add a similar note regarding the effect of adding a
callback.  The current event invocation behavior for callbacks added
within an event is explicitly left unspecified, though in the current
slist implementation newly added callbacks will not be invoked until the
next event.

Closes #10186
