### PR TITLE
mergehex: Improve the error feedback when merged hex files overlap

### DIFF
--- a/scripts/mergehex.py
+++ b/scripts/mergehex.py
@@ -8,6 +8,7 @@
 # Any conflicts will result in an error being reported.
 
 from intelhex import IntelHex
+from intelhex import AddressOverlapError
 
 import argparse
 
@@ -18,11 +19,18 @@ def merge_hex_files(output, input_hex_files):
     for hex_file_path in input_hex_files:
         to_merge = IntelHex(hex_file_path)
 
-        # Since 'arm-none-eabi-objcopy' incorrectly inserts record type '03 - Start Segment Address', we need to remove
-        # the start_addr to avoid conflicts when merging.
+        # Since 'arm-none-eabi-objcopy' incorrectly inserts record
+        # type '03 - Start Segment Address', we need to remove the
+        # start_addr to avoid conflicts when merging.
         to_merge.start_addr = None
 
-        ih.merge(to_merge)
+        try:
+            ih.merge(to_merge)
+        except AddressOverlapError as e:
+            raise AddressOverlapError("{} has merge issues".format(hex_file_path))
+
+        print("Merged {}".format(hex_file_path))
+
     ih.write_hex_file(output)
 
 


### PR DESCRIPTION
When merging hex files, and there is an overlap between the hex files,
display the hex file that failed to merge.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>