### PR TITLE
boards: 96b_argonkey: Add hts221 sensor to supported list

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.yaml
+++ b/boards/arm/96b_argonkey/96b_argonkey.yaml
@@ -11,5 +11,6 @@ flash: 1024
 supported:
   - gpio
   - i2c
+  - hts221
   - rtc
   - spi


### PR DESCRIPTION
Add hts221 sensor to 96b_argonkey.yaml so we build and samples/tests
associated with the hts221.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>