### PR TITLE
boards: nrf52_pca20020: Add hts221 sensor to supported list

### DIFF
--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.yaml
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.yaml
@@ -8,3 +8,6 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - i2c
+  - hts221


### PR DESCRIPTION
Add hts221 sensor to nrf52_pca20020.yaml so we build and samples/tests
associated with the hts221.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>