### PR TITLE
 net: 6lo: Fix ieee802154 fragmentation

### DIFF
--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -606,7 +606,7 @@ static int kw41z_tx(struct device *dev, struct net_pkt *pkt,
 	 */
 
 	/* Perform automatic reception of ACK frame, if required */
-	if (ieee802154_is_ar_flag_set(pkt)) {
+	if (ieee802154_is_ar_flag_set(frag)) {
 		tx_timeout = kw41z->tx_warmup_time + KW41Z_SHR_PHY_TIME +
 				 payload_len * KW41Z_PER_BYTE_TIME + 10 +
 				 KW41Z_ACK_WAIT_TIME;

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1098,8 +1098,8 @@ static int mcr20a_tx(struct device *dev,
 		     struct net_buf *frag)
 {
 	struct mcr20a_context *mcr20a = dev->driver_data;
-	u8_t seq = ieee802154_is_ar_flag_set(pkt) ? MCR20A_XCVSEQ_TX_RX :
-						    MCR20A_XCVSEQ_TX;
+	u8_t seq = ieee802154_is_ar_flag_set(frag) ? MCR20A_XCVSEQ_TX_RX :
+						     MCR20A_XCVSEQ_TX;
 	int retval;
 
 	k_mutex_lock(&mcr20a->phy_mutex, K_FOREVER);

--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -114,16 +114,16 @@ struct ieee802154_radio_api {
 /**
  * @brief Check if AR flag is set on the frame inside given net_pkt
  *
- * @param pkt A valid pointer on a net_pkt structure, must not be NULL,
+ * @param frag A valid pointer on a net_buf structure, must not be NULL,
  *        and its length should be at least made of 1 byte (ACK frames
  *        are the smallest frames on 15.4 and made of 3 bytes, not
  *        not counting the FCS part).
  *
  * @return True if AR flag is set, False otherwise
  */
-static inline bool ieee802154_is_ar_flag_set(struct net_pkt *pkt)
+static inline bool ieee802154_is_ar_flag_set(struct net_buf *frag)
 {
-	return (*net_pkt_data(pkt) & IEEE802154_AR_FLAG_SET);
+	return (*frag->data & IEEE802154_AR_FLAG_SET);
 }
 
 #ifndef CONFIG_IEEE802154_RAW_MODE

--- a/subsys/net/l2/ieee802154/ieee802154_fragment.c
+++ b/subsys/net/l2/ieee802154/ieee802154_fragment.c
@@ -95,7 +95,7 @@ static inline void set_datagram_tag(u8_t *ptr, u16_t tag)
 static inline void set_up_frag_hdr(struct net_buf *frag, u16_t size,
 				   u8_t offset)
 {
-	u8_t pos = frag->len > 0 ? (u8_t) frag->len - 1 : 0U;
+	u8_t pos = frag->len;
 
 	if (!offset) {
 		net_buf_add(frag, NET_6LO_FRAG1_HDR_LEN);

--- a/subsys/net/l2/ieee802154/ieee802154_fragment.h
+++ b/subsys/net/l2/ieee802154/ieee802154_fragment.h
@@ -34,7 +34,8 @@ struct ieee802154_fragment_ctx {
 static inline bool ieee802154_fragment_is_needed(struct net_pkt *pkt,
 						 u8_t ll_hdr_size)
 {
-	return (net_pkt_get_len(pkt) + ll_hdr_size > IEEE802154_MTU);
+	return (net_pkt_get_len(pkt) + ll_hdr_size >
+			IEEE802154_MTU - IEEE802154_MFR_LENGTH);
 }
 
 static inline

--- a/subsys/net/l2/ieee802154/ieee802154_radio_utils.h
+++ b/subsys/net/l2/ieee802154/ieee802154_radio_utils.h
@@ -25,10 +25,10 @@ static inline bool prepare_for_ack(struct ieee802154_context *ctx,
 				   struct net_pkt *pkt,
 				   struct net_buf *frag)
 {
-	if (ieee802154_is_ar_flag_set(pkt)) {
+	if (ieee802154_is_ar_flag_set(frag)) {
 		struct ieee802154_fcf_seq *fs;
 
-		fs = (struct ieee802154_fcf_seq *)net_pkt_data(pkt);
+		fs = (struct ieee802154_fcf_seq *)frag->data;
 
 		ctx->ack_seq = fs->sequence;
 		ctx->ack_received = false;


### PR DESCRIPTION
First commit fixes fragmentation at 802.15.4 6lowpan layer which caused larger packets to be corrupted.

Second commit fixes ACK logic on platforms that do not support hardware ACK (qemu namely). MHR was read from incorrect buffer, resulting in incorrect behavior (blocking on ACK wait while it shouldn't).