### PR TITLE
boards: Add arduino_i2c in yaml when supported

### DIFF
--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.yaml
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.yaml
@@ -12,6 +12,7 @@ testing:
   ignore_tags:
     - net
 supported:
+  - arduino_i2c
   - spi
   - i2c
   - gpio

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_i2c
   - i2c
   - hts221
   - pwm

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.yaml
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 8
 flash: 64
 supported:
+  - arduino_i2c
   - i2c
   - spi
   - gpio

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.yaml
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.yaml
@@ -9,6 +9,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_i2c
   - gpio
   - i2c
   - spi

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 32
 flash: 256
 supported:
+  - arduino_i2c
   - gpio
   - i2c
   - spi

--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.yaml
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 16
 flash: 64
 supported:
+  - arduino_i2c
   - i2c
   - spi
   - gpio

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.yaml
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.yaml
@@ -13,6 +13,7 @@ testing:
     - bluetooth
     - net
 supported:
+  - arduino_i2c
   - gpio
   - i2c
   - spi

--- a/boards/arm/nucleo_f401re/nucleo_f401re.yaml
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_i2c
   - pwm
   - rtc
   - gpio

--- a/boards/arm/nucleo_f411re/nucleo_f411re.yaml
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_i2c
   - rtc
   - gpio
   - spi

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.yaml
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 256
 flash: 1024
 supported:
+  - arduino_i2c
   - pwm
   - i2c
   - spi

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.yaml
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 320
 flash: 1536
 supported:
+  - arduino_i2c
   - pwm
   - i2c
   - spi

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.yaml
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 256
 flash: 2048
 supported:
+  - arduino_i2c
   - netif:eth
   - i2c
   - spi

--- a/boards/arm/nucleo_f446re/nucleo_f446re.yaml
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_i2c
   - rtc
   - gpio
   - spi

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.yaml
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 320
 flash: 1024
 supported:
+  - arduino_i2c
   - uart
   - gpio
   - netif:eth

--- a/boards/arm/nucleo_f756zg/nucleo_f756zg.yaml
+++ b/boards/arm/nucleo_f756zg/nucleo_f756zg.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 320
 flash: 1024
 supported:
+  - arduino_i2c
   - uart
   - gpio
   - netif:eth

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.yaml
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_i2c
   - gpio
   - i2c
   - spi

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 20
 flash: 192
 supported:
+  - arduino_i2c
   - gpio
   - i2c
   - spi

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.yaml
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_i2c
   - pwm
   - gpio
   - spi

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.yaml
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_i2c
   - pwm
   - spi
   - i2c

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.yaml
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_i2c
   - rtc
   - i2c
   - spi

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.yaml
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 256
 flash: 512
 supported:
+  - arduino_i2c
   - gpio
   - i2c
   - spi

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 320
 flash: 1024
 supported:
+  - arduino_i2c
   - netif:eth
   - i2c
   - spi

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.yaml
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 512
 flash: 2048
 supported:
+  - arduino_i2c
   - i2c
   - spi
   - gpio

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.yaml
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 320
 flash: 1024
 supported:
+  - arduino_i2c
   - pwm
   - i2c
   - spi

--- a/samples/shields/x_nucleo_iks01a1/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a1/sample.yaml
@@ -2,6 +2,7 @@ sample:
   name: X-NUCLEO-IKS01A1 sensor shield
 tests:
   test:
+    platform_exclude: disco_l475_iot1
     harness: shield
     tags: shield
     depends_on: arduino_i2c


### PR DESCRIPTION
Update boards yaml file with arduino_i2c supported option

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>