### PR TITLE
linker: add .note.GNU-stack to arc linker

### DIFF
--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -300,4 +300,5 @@ SECTIONS {
 	KEEP(*(.gnu.attributes))
 	}
 
+    /DISCARD/ : { *(.note.GNU-stack) }
 	}


### PR DESCRIPTION
When building for ARC this new section appears with gcc 8.2.