### PR TITLE
shell: documentation update

### DIFF
--- a/doc/subsystems/shell/shell.rst
+++ b/doc/subsystems/shell/shell.rst
@@ -39,7 +39,8 @@ See the :ref:`shell_api` documentation for more information.
 Connecting to Segger RTT via TCP (on macOS, for example)
 ========================================================
 
-On macOS JLinkRTTClient won't let you enter input. Instead, please use following procedure:
+On macOS JLinkRTTClient won't let you enter input. Instead, please use following
+procedure:
 
 * Open up a first Terminal window and enter:
 
@@ -55,7 +56,8 @@ On macOS JLinkRTTClient won't let you enter input. Instead, please use following
 
      nc localhost 19021
 
-* Now you should have a network connection to RTT that will let you enter input to the shell.
+* Now you should have a network connection to RTT that will let you enter input
+  to the shell.
 
 
 Commands
@@ -363,32 +365,32 @@ The shell module supports the following meta keys:
 
    * - Meta keys
      - Action
-   * - ctrl + a
+   * - :kbd:`Ctrl + a`
      - Moves the cursor to the beginning of the line.
-   * - ctrl + b
+   * - :kbd:`Ctrl + b`
      - Moves the cursor backward one character.
-   * - ctrl + c
+   * - :kbd:`Ctrl + c`
      - Preserves the last command on the screen and starts a new command in
        a new line.
-   * - ctrl + d
+   * - :kbd:`Ctrl + d`
      - Deletes the character under the cursor.
-   * - ctrl + e
+   * - :kbd:`Ctrl + e`
      - Moves the cursor to the end of the line.
-   * - ctrl + f
+   * - :kbd:`Ctrl + f`
      - Moves the cursor forward one character.
-   * - ctrl + k
+   * - :kbd:`Ctrl + k`
      - Deletes from the cursor to the end of the line.
-   * - ctrl + l
+   * - :kbd:`Ctrl + l`
      - Clears the screen and leaves the currently typed command at the top of
        the screen.
-   * - ctrl + u
+   * - :kbd:`Ctrl + u`
      - Clears the currently typed command.
-   * - ctrl + w
+   * - :kbd:`Ctrl + w`
      - Removes the word or part of the word to the left of the cursor. Words
        separated by period instead of space are treated as one word.
-   * - alt + b
+   * - :kbd:`Alt + b`
      - Moves the cursor backward one word.
-   * - alt + f
+   * - :kbd:`Alt + f`
      - Moves the cursor forward one word.
 
 Usage

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -278,6 +278,13 @@ static int cmd_help(const struct shell *shell, size_t argc, char **argv)
 		" all commands or its subcommands.\n"
 		"You can try to call commands with <-h> or <--help> parameter"
 		" for more information.");
+#if CONFIG_SHELL_METAKEYS
+	shell_print(shell,
+		"Shell supports following meta-keys:\n"
+		"Ctrl+a, Ctrl+b, Ctrl+c, Ctrl+d, Ctrl+e, Ctrl+f, Ctrl+k,"
+		" Ctrl+l, Ctrl+u, Ctrl+w\nAlt+b, Alt+f.\nPlease refer to"
+		" shell documentation for more details.");
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
1. Update shell documentation according to proposals in PR #12437 (Extend shell meta keys).
2. Fix lines exceeding 80 characters limit.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>