### PR TITLE
cmake: samples: mesh: Remove redundant CMake code

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
@@ -4,8 +4,6 @@ set(QEMU_EXTRA_FLAGS -s)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(onoff_level_lighting_vnd_app)
 
-target_link_libraries(app PUBLIC subsys__bluetooth)
-
 target_sources(app PRIVATE
 	       src/main.c
 	       src/app_gpio.c


### PR DESCRIPTION
This sample is linking the 'app' with 'subsys__bluetooth', which will
add zephyr/subsys/bluetooth to the include path of the app. But this
is unnecessary as the app already has this path on it's include path.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>