### PR TITLE
net: sockets: Add fcntl to socket offloading API

### DIFF
--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -777,6 +777,16 @@ static void simplelink_freeaddrinfo(struct addrinfo *res)
 	free(res);
 }
 
+static int simplelink_fctnl(int fd, int cmd, va_list args)
+{
+	ARG_UNUSED(fd);
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(args);
+
+	errno = ENOTSUP;
+	return -1;
+}
+
 void simplelink_sockets_init(void)
 {
 	k_mutex_init(&ga_mutex);
@@ -798,4 +808,5 @@ const struct socket_offload simplelink_ops = {
 	.sendto = simplelink_sendto,
 	.getaddrinfo = simplelink_getaddrinfo,
 	.freeaddrinfo = simplelink_freeaddrinfo,
+	.fcntl = simplelink_fctnl,
 };

--- a/include/net/socket_offload.h
+++ b/include/net/socket_offload.h
@@ -158,6 +158,8 @@ static inline void freeaddrinfo(struct addrinfo *res)
 	return socket_ops->freeaddrinfo(res);
 }
 
+int fcntl(int fd, int cmd, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/net/socket_offload_ops.h
+++ b/include/net/socket_offload_ops.h
@@ -49,6 +49,7 @@ struct socket_offload {
 			   const struct addrinfo *hints,
 			   struct addrinfo **res);
 	void (*freeaddrinfo)(struct addrinfo *res);
+	int (*fcntl)(int fd, int cmd, va_list args);
 };
 
 extern void socket_offload_register(const struct socket_offload *ops);

--- a/subsys/net/lib/sockets/socket_offload.c
+++ b/subsys/net/lib/sockets/socket_offload.c
@@ -19,3 +19,18 @@ void socket_offload_register(const struct socket_offload *ops)
 
 	socket_ops = ops;
 }
+
+int fcntl(int fd, int cmd, ...)
+{
+	__ASSERT_NO_MSG(socket_ops);
+	__ASSERT_NO_MSG(socket_ops->fcntl);
+
+	va_list args;
+	int res;
+
+	va_start(args, cmd);
+	res = socket_ops->fcntl(fd, cmd, args);
+	va_end(args);
+
+	return res;
+}


### PR DESCRIPTION
Offload fcntl calls through socket offloading API.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>