### PR TITLE
scripts/dts/extract: Don't warn for 'category' merge of 'required'

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -515,8 +515,15 @@ def dict_merge(parent, fname, dct, merge_dct):
             dict_merge(k, fname, dct[k], merge_dct[k])
         else:
             if k in dct and dct[k] != merge_dct[k]:
-                print("extract_dts_includes.py: {}('{}') merge of property '{}': '{}' overwrites '{}'.".format(
-                        fname, parent, k, merge_dct[k], dct[k]))
+                merge_warn = True
+                # Don't warn if we are changing the "category" from "optional
+                # to "required"
+                if (k == "category" and dct[k] == "optional" and
+                    merge_dct[k] == "required"):
+                    merge_warn = False
+                if merge_warn:
+                    print("extract_dts_includes.py: {}('{}') merge of property '{}': '{}' overwrites '{}'.".format(
+                            fname, parent, k, merge_dct[k], dct[k]))
             dct[k] = merge_dct[k]
 
 


### PR DESCRIPTION
We get warnings like:
	foo.yaml('BAH') merge of property 'category': 'required'
	overwrites 'optional'

This warning isn't meaningful as its reasonable to change the 'category'
of a property from 'optional' to 'required'.  So don't warn in the case
anymore.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>