### PR TITLE
printk: don't print incorrect 64-bit integers

### DIFF
--- a/include/misc/printk.h
+++ b/include/misc/printk.h
@@ -33,8 +33,11 @@ extern "C" {
  *   - character: \%c
  *   - percent: \%\%
  *
- * No other conversion specification capabilities are supported, such as flags,
- * field width, precision, or length attributes.
+ * Field width (with or without leading zeroes) are supported.
+ * Length attributes such as 'h' and 'l' are supported. However,
+ * integral values with %lld and %lli are only printed if they fit in 32 bits,
+ * otherwise 'ERR' is printed. Full 64-bit values may be printed with %llx.
+ * Flags and precision attributes are not supported.
  *
  * @param fmt Format string.
  * @param ... Optional list of format arguments.

--- a/tests/kernel/common/src/printk.c
+++ b/tests/kernel/common/src/printk.c
@@ -25,7 +25,7 @@ char *expected = "22 113 10000 32768 40000 22\n"
 		 "42 42   42       42\n"
 		 "42 42 0042 00000042\n"
 		 "255     42    abcdef  0x0000002a      42\n"
-		 "-1 4294967295 ffffffffffffffff\n"
+		 "ERR -1 ERR ffffffffffffffff\n"
 ;
 
 
@@ -86,7 +86,7 @@ void test_printk(void)
 	printk("%u %2u %4u %8u\n", 42, 42, 42, 42);
 	printk("%u %02u %04u %08u\n", 42, 42, 42, 42);
 	printk("%-8u%-6d%-4x%-2p%8d\n", 0xFF, 42, 0xABCDEF, (char *)42, 42);
-	printk("%lld %llu %llx\n", -1LL, -1ULL, -1ULL);
+	printk("%lld %lld %llu %llx\n", 0xFFFFFFFFFULL, -1LL, -1ULL, -1ULL);
 
 	ram_console[pos] = '\0';
 	zassert_true((strcmp(ram_console, expected) == 0), "printk failed");
@@ -117,8 +117,8 @@ void test_printk(void)
 			  "%-8u%-6d%-4x%-2p%8d\n",
 			  0xFF, 42, 0xABCDEF, (char *)42, 42);
 	count += snprintk(ram_console + count, sizeof(ram_console) - count,
-			  "%lld %llu %llx\n",
-			  -1LL, -1ULL, -1ULL);
+			  "%lld %lld %llu %llx\n",
+			  0xFFFFFFFFFULL, -1LL, -1ULL, -1ULL);
 	ram_console[count] = '\0';
 	zassert_true((strcmp(ram_console, expected) == 0), "snprintk failed");
 }


### PR DESCRIPTION
printk is supposed to be very lean, but should at least not
print garbage values. Now when a 64-bit integral value is
passed in to be printed, 'ERR' will be reported if it doesn't
fit in 32-bits instead of truncating it.

The printk documentation was slightly out of date, this has been
updated.

Fixes: #7179

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>