### PR TITLE
net/ethernet: Remove inserted L2 header buffer

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -2183,7 +2183,13 @@ struct net_pkt *net_pkt_clone(struct net_pkt *pkt, s32_t timeout)
 
 	net_pkt_set_ip_hdr_len(clone, net_pkt_ip_hdr_len(pkt));
 	net_pkt_set_vlan_tag(clone, net_pkt_vlan_tag(pkt));
+	net_pkt_set_appdata(clone, NULL);
 	net_pkt_set_appdatalen(clone, net_pkt_appdatalen(pkt));
+	net_pkt_set_transport_proto(clone, net_pkt_transport_proto(pkt));
+
+	net_pkt_set_timestamp(clone, net_pkt_timestamp(pkt));
+	net_pkt_set_priority(clone, net_pkt_priority(pkt));
+	net_pkt_set_orig_iface(clone, net_pkt_orig_iface(pkt));
 
 	net_pkt_set_family(clone, net_pkt_family(pkt));
 

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -493,6 +493,18 @@ static void ethernet_update_tx_stats(struct net_if *iface, struct net_pkt *pkt)
 }
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
 
+static void ethernet_remove_l2_header(struct net_pkt *pkt)
+{
+	struct net_buf *buf;
+
+	/* Remove the buffer added in ethernet_fill_header() */
+	buf = pkt->buffer;
+	pkt->buffer = buf->frags;
+	buf->frags = NULL;
+
+	net_pkt_frag_unref(buf);
+}
+
 static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 {
 	const struct ethernet_api *api = net_if_get_device(iface)->driver_api;
@@ -566,12 +578,14 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 	ret = api->send(net_if_get_device(iface), pkt);
 	if (ret != 0) {
 		eth_stats_update_errors_tx(iface);
+		ethernet_remove_l2_header(pkt);
 		goto error;
 	}
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	ethernet_update_tx_stats(iface, pkt);
 #endif
 	ret = net_pkt_get_len(pkt);
+	ethernet_remove_l2_header(pkt);
 
 	net_pkt_unref(pkt);
 error:

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -190,11 +190,9 @@ static int eth_tx_offloading_disabled(struct device *dev, struct net_pkt *pkt)
 		memcpy(((struct net_eth_hdr *)net_pkt_data(pkt))->dst.addr,
 		       lladdr, sizeof(lladdr));
 
-		net_pkt_ref(pkt);
-
-		if (net_recv_data(net_pkt_iface(pkt), pkt) < 0) {
+		if (net_recv_data(net_pkt_iface(pkt),
+				  net_pkt_clone(pkt, K_NO_WAIT)) < 0) {
 			test_failed = true;
-			net_pkt_unref(pkt);
 			zassert_true(false, "Packet %p receive failed\n", pkt);
 		}
 

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -1026,15 +1026,11 @@ static int tester_send(struct device *dev, struct net_pkt *pkt)
 		udp_hdr->dst_port = port;
 		net_udp_set_hdr(pkt, udp_hdr);
 
-		if (net_recv_data(net_pkt_iface(pkt), pkt) < 0) {
+		if (net_recv_data(net_pkt_iface(pkt),
+				  net_pkt_clone(pkt, K_NO_WAIT)) < 0) {
 			TC_ERROR("Data receive failed.");
 			goto out;
 		}
-
-		/* L2 or net_if will unref the pkt, but we are pushing it
-		 * to rx path, so let's reference it or it will be freed.
-		 */
-		net_pkt_ref(pkt);
 
 		timeout_token = 0;
 

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -247,15 +247,11 @@ static int tester_send(struct device *dev, struct net_pkt *pkt)
 	}
 
 	/* Feed this data back to us */
-	if (net_recv_data(net_pkt_iface(pkt), pkt) < 0) {
+	if (net_recv_data(net_pkt_iface(pkt),
+			  net_pkt_clone(pkt, K_NO_WAIT)) < 0) {
 		TC_ERROR("Data receive failed.");
 		goto out;
 	}
-
-	/* L2 will unref pkt, so since it got to rx path we need to ref it again
-	 * or it will be freed.
-	 */
-	net_pkt_ref(pkt);
 
 	return 0;
 

--- a/tests/net/traffic_class/src/main.c
+++ b/tests/net/traffic_class/src/main.c
@@ -183,11 +183,9 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 		udp_hdr->src_port = udp_hdr->dst_port;
 		udp_hdr->dst_port = port;
 
-		net_pkt_ref(pkt);
-
-		if (net_recv_data(net_pkt_iface(pkt), pkt) < 0) {
+		if (net_recv_data(net_pkt_iface(pkt),
+				  net_pkt_clone(pkt, K_NO_WAIT)) < 0) {
 			test_failed = true;
-			net_pkt_unref(pkt);
 			zassert_true(false, "Packet %p receive failed\n", pkt);
 		}
 


### PR DESCRIPTION
The packet can be referenced somewhere else and letting the newly added
L2 header will generate corrupt packet. If the same packet is being
resent, ethernet will add again its L2 header. Thus the need to remove
such L2 header every time a packet has been sent, successfully or not.

Fixes #12560

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>