### PR TITLE
tests: ipm: disable on qemu_x86_64 [REVERT ME]

### DIFF
--- a/tests/drivers/ipm/testcase.yaml
+++ b/tests/drivers/ipm/testcase.yaml
@@ -2,4 +2,5 @@ tests:
   peripheral.mailbox:
     filter: not CONFIG_SOC_QUARK_SE_C1000_SS
     arch_exclude: posix xtensa
+    platform_exclude: qemu_x86_64 # see issue #12478
     tags: drivers ipc


### PR DESCRIPTION
Fails sporadically on this platform and causing CI blockage.
Filed bug #12478. Should be reverted once bug is fixed.