### PR TITLE
native_posix: Remove all references to the defunct legacy shell

### DIFF
--- a/boards/posix/native_posix/doc/board.rst
+++ b/boards/posix/native_posix/doc/board.rst
@@ -448,14 +448,9 @@ The following peripherals are currently provided with this board:
   For more information refer to the section `UART`_.
 
 **Console driver**:
-  A console driver is provided which by default is configured to:
-
-  - Redirect any :c:func:`printk` write to the native host application's
-    ``stdout``.
-
-  - If the legacy shell is compiled with your application, redirect the
-    native application's ``stdin`` to the legacy shell for any input.
-    For more information refer to the section `Legacy shell support`_.
+  A console driver is provided which by default is configured to
+  redirect any :c:func:`printk` write to the native host application's
+  ``stdout``.
 
 **Real time clock**
   The real time clock model provides a model of a constantly powered clock.
@@ -568,55 +563,3 @@ option ``-attach_uart_cmd=<"cmd">``. Where the default command is given by
 :option:`CONFIG_NATIVE_UART_AUTOATTACH_DEFAULT_CMD`.
 Note that the default command assumes both ``xterm`` and ``screen`` are
 installed in the system.
-
-
-Legacy shell support
-********************
-
-When the legacy shell subsystem is compiled with your application,
-the native standard input (``stdin``) will be redirected to the shell.
-You may use this shell interactively through the console,
-by piping another process output to it, or by feeding it a file.
-
-When using it interactively you may want to select the option
-:option:`CONFIG_NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME`.
-
-When feeding ``stdin`` from a pipe or file, the console driver will ensure
-reproducibility between runs of the process:
-
-- The execution of the process will be stalled while waiting for new ``stdin``
-  data to be ready.
-
-- Commands will be fed to the shell as fast as the shell can process them.
-  To allow controlling the flow of commands to the shell, you may use the
-  driver directive ``!wait <ms>``.
-
-- When the file ends, or the pipe is closed the driver will stop attempting to
-  read it.
-
-Driver directives
-=================
-
-The console driver understands a set of special commands: driver directives.
-These directives are captured by the console driver itself and are not
-forwarded to the shell.
-These directives are:
-
-- ``!wait <ms>``: When received, the driver will pause feeding commands to the
-  shell for ``<ms>`` milliseconds.
-
-- ``!quit``: When received the driver will cause the application to gracefully
-  exit by calling :c:func:`posix_exit`.
-
-
-Use example
-===========
-
-For example, after you have built an application with the legacy shell, you
-can feed it the following set of commands through a pipe:
-
-.. code-block:: console
-
-   echo -e \
-   'select kernel\nuptime\n!wait 500\nuptime\n!wait 1000\nuptime\n!quit' \
-   | zephyr/zephyr.exe

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -261,9 +261,9 @@ config NATIVE_POSIX_CONSOLE
 config NATIVE_POSIX_STDIN_CONSOLE
 	bool "Use the host terminal stdin"
 	depends on NATIVE_POSIX_CONSOLE
-	default y if !NATIVE_UART_0_ON_STDINOUT
 	help
-	  Feed the host terminal stdin to the Zephyr console/shell.
+	  No current use. Kept only as there is plans to start using these
+	  drivers with the shell
 
 config NATIVE_STDIN_POLL_PERIOD
 	int "Polling period for stdin"

--- a/drivers/serial/Kconfig.native_posix
+++ b/drivers/serial/Kconfig.native_posix
@@ -36,8 +36,8 @@ config NATIVE_UART_0_ON_STDINOUT
 	  invoked the native_posix executable. This is good enough for automated
 	  testing, or when feeding from a file/pipe.
 	  Note that other, non UART messages, will also be printed to the terminal.
-	  This option should NOT be used in conjunction with the legacy shell
-	  native_posix backend (NATIVE_POSIX_STDIN_CONSOLE)
+	  This option should NOT be used in conjunction with
+	  NATIVE_POSIX_STDIN_CONSOLE
 	  It is strongly discouraged to try to use this option with the new shell
 	  interactively, as the default terminal configuration is NOT appropriate
 	  for interactive use.


### PR DESCRIPTION
Remove all references in the documentation and Kconfig options
to the legacy shell to avoid confusing users and developers

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>