### PR TITLE
boards: nrf: correct the source of LED and Button definitions

### DIFF
--- a/boards/arm/nrf51_pca10028/doc/nrf51_pca10028.rst
+++ b/boards/arm/nrf51_pca10028/doc/nrf51_pca10028.rst
@@ -151,7 +151,7 @@ the board are working properly with Zephyr:
    samples/basic/button
 
 You can build and flash the examples to make sure Zephyr is running correctly on
-your board. The button and LED definitions can be found in :file:`boards/arm/nrf51_pca10028/board.h`.
+your board. The button and LED definitions can be found in :file:`boards/arm/nrf51_pca10028/nrf51_pca10028.dts`.
 
 References
 **********

--- a/boards/arm/nrf52840_pca10056/doc/nrf52840_pca10056.rst
+++ b/boards/arm/nrf52840_pca10056/doc/nrf52840_pca10056.rst
@@ -164,7 +164,8 @@ the board are working properly with Zephyr:
    samples/basic/button
 
 You can build and flash the examples to make sure Zephyr is running correctly on
-your board. The button and LED definitions can be found in :file:`boards/arm/nrf52840_pca10056/board.h`.
+your board. The button and LED definitions can be found in :file:
+`boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts`.
 
 
 References

--- a/boards/arm/nrf52_pca10040/doc/nrf52_pca10040.rst
+++ b/boards/arm/nrf52_pca10040/doc/nrf52_pca10040.rst
@@ -395,7 +395,7 @@ the board are working properly with Zephyr:
    samples/basic/button
 
 You can build and flash the examples to make sure Zephyr is running correctly on
-your board. The button and LED definitions can be found in :file:`boards/arm/nrf52_pca10040/board.h`.
+your board. The button and LED definitions can be found in :file:`boards/arm/nrf52_pca10040/nrf52_pca10040.dts`.
 
 References
 **********


### PR DESCRIPTION
board.h does not exist for any of the (official) Nordic nRF
boards. This commit corrects the information about the source
ofthe button and LED definitions.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>