### PR TITLE
drivers: eth_mcux: By default use 1 buffer each for hardware RX/TX

### DIFF
--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -35,7 +35,7 @@ config ETH_MCUX_PHY_EXTRA_DEBUG
 config ETH_MCUX_RX_BUFFERS
 	int "Number of MCUX RX buffers"
 	depends on ETH_MCUX
-	default 2
+	default 1
 	range 1 16
 	help
 	  Set the number of RX buffers provided to the MCUX driver.
@@ -43,7 +43,7 @@ config ETH_MCUX_RX_BUFFERS
 config ETH_MCUX_TX_BUFFERS
 	int "Number of MCUX TX buffers"
 	depends on ETH_MCUX
-	default 2
+	default 1
 	range 1 16
 	help
 	  Set the number of TX buffers provided to the MCUX driver.


### PR DESCRIPTION
It was reported, and confirmed by multiple parties that default
CONFIG_ETH_MCUX_RX_BUFFERS=2 under some packet load leads to
1s and increasing packet processing delay and eventual deadlock.
No reports were about CONFIG_ETH_MCUX_TX_BUFFERS=2, but be on safe
side and just set that to the minimal value as the current default,
to allow us to have good conservative base to test various networking
stack issues.

Fixes: #3132

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>