### PR TITLE
samples: bluetooth: peripheral_hr: Rework FRDM-KW41Z shield support

### DIFF
--- a/samples/bluetooth/peripheral_hr/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hr/CMakeLists.txt
@@ -1,14 +1,5 @@
 cmake_minimum_required(VERSION 3.13.1)
 
-# Some boards could run this sample using frdm_kw41z shield, enforce
-# -DSHIELD option in case they are used
-if(BOARD STREQUAL mimxrt1020_evk OR
-   BOARD STREQUAL mimxrt1050_evk OR
-   BOARD STREQUAL mimxrt1060_evk OR
-   BOARD STREQUAL frdm_k64f)
-set(SHIELD frdm_kw41z)
-endif()
-
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(peripheral_hr)
 

--- a/samples/bluetooth/peripheral_hr/sample.yaml
+++ b/samples/bluetooth/peripheral_hr/sample.yaml
@@ -4,5 +4,11 @@ sample:
 tests:
   test:
     harness: bluetooth
-    platform_whitelist: qemu_cortex_m3 qemu_x86 mimxrt1020_evk mimxrt1050_evk mimxrt1060_evk frdm_k64f
+    platform_whitelist: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+  test_frdm_kw41z_shield:
+    harness: bluetooth
+    platform_whitelist: mimxrt1020_evk mimxrt1050_evk mimxrt1060_evk frdm_k64f
+    tags: bluetooth
+    extra_args: SHIELD=frdm_kw41z
+


### PR DESCRIPTION
Split out the boards that utilize the FRDM-KW41Z as a seperate test
where we explicitly set the shield as an extra_args instead of having to
do it in the CMakeLists.txt file.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>