### PR TITLE
drivers: i2c: document incompletely supported capabilities and deprecate/remove functions

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1490,10 +1490,9 @@ static void get_mac_addr_from_i2c_eeprom(u8_t mac_addr[6])
 		return;
 	}
 
-	i2c_burst_read_addr(dev, CONFIG_ETH_SAM_GMAC_MAC_I2C_SLAVE_ADDRESS,
-			    (u8_t *)&iaddr,
-			    CONFIG_ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS_SIZE,
-			    mac_addr, 6);
+	i2c_write_read(dev, CONFIG_ETH_SAM_GMAC_MAC_I2C_SLAVE_ADDRESS,
+		       &iaddr, CONFIG_ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS_SIZE,
+		       mac_addr, 6);
 }
 #endif
 

--- a/drivers/sensor/sht3xd/sht3xd.c
+++ b/drivers/sensor/sht3xd/sht3xd.c
@@ -90,20 +90,8 @@ static int sht3xd_sample_fetch(struct device *dev, enum sensor_channel chan)
 		SHT3XD_CMD_FETCH & 0xFF
 	};
 
-	struct i2c_msg msgs[2] = {
-		{
-			.buf = tx_buf,
-			.len = sizeof(tx_buf),
-			.flags = I2C_MSG_WRITE | I2C_MSG_RESTART,
-		},
-		{
-			.buf = rx_buf,
-			.len = sizeof(rx_buf),
-			.flags = I2C_MSG_READ | I2C_MSG_STOP,
-		},
-	};
-
-	if (i2c_transfer(i2c, msgs, 2, address) < 0) {
+	if (i2c_write_read(i2c, address, tx_buf, sizeof(tx_buf),
+			   rx_buf, sizeof(rx_buf)) < 0) {
 		LOG_DBG("Failed to read data sample!");
 		return -EIO;
 	}

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -395,6 +395,39 @@ static inline int i2c_read(struct device *dev, u8_t *buf,
 	return i2c_transfer(dev, &msg, 1, addr);
 }
 
+/**
+ * @brief Write then read data from an I2C device.
+ *
+ * This supports the common operation "this is what I want", "now give
+ * it to me" transaction pair through a combined write-then-read bus
+ * transaction.
+ *
+ * @param dev Pointer to the device structure for the driver instance
+ * @param addr Address of the I2C device
+ * @param write_buf Pointer to the data to be written
+ * @param num_write Number of bytes to write
+ * @param read_buf Pointer to storage for read data
+ * @param num_read Number of bytes to read
+ *
+ * @retval 0 if successful
+ * @retval negative on error.
+ */
+static inline int i2c_write_read(struct device *dev, u16_t addr,
+				 const void *write_buf, size_t num_write,
+				 void *read_buf, size_t num_read)
+{
+	struct i2c_msg msg[2];
+
+	msg[0].buf = (u8_t *)write_buf;
+	msg[0].len = num_write;
+	msg[0].flags = I2C_MSG_WRITE;
+
+	msg[1].buf = (u8_t *)read_buf;
+	msg[1].len = num_read;
+	msg[1].flags = I2C_MSG_RESTART | I2C_MSG_READ | I2C_MSG_STOP;
+
+	return i2c_transfer(dev, msg, 2, addr);
+}
 
 /**
  * @brief Read multiple bytes from an internal address of an I2C device.

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -82,16 +82,33 @@ extern "C" {
 /** Send STOP after this message. */
 #define I2C_MSG_STOP			(1 << 1)
 
-/** RESTART I2C transaction for this message. */
+/** RESTART I2C transaction for this message.
+ *
+ * @note Not all I2C drivers have or require explicit support for this
+ * feature. Some drivers require this be present on a read message
+ * that follows a write, or vice-versa.  Some drivers will merge
+ * adjacent fragments into a single transaction using this flag; some
+ * will not. */
 #define I2C_MSG_RESTART			(1 << 2)
 
-/** Use 10-bit addressing for this message. */
+/** Use 10-bit addressing for this message.
+ *
+ * @note Not all SoC I2C implementations support this feature. */
 #define I2C_MSG_ADDR_10_BITS		(1 << 3)
 
 /**
  * @brief One I2C Message.
  *
  * This defines one I2C message to transact on the I2C bus.
+ *
+ * @note Some of the configurations supported by this API may not be
+ * supported by specific SoC I2C hardware implementations, in
+ * particular features related to bus transactions intended to read or
+ * write data from different buffers within a single transaction.
+ * Invocations of i2c_transfer() may not indicate an error when an
+ * unsupported configuration is encountered.  In some cases drivers
+ * will generate separate transactions for each message fragment, with
+ * or without presence of @ref I2C_MSG_RESTART in #flags.
  */
 struct i2c_msg {
 	/** Data buffer in bytes */
@@ -204,6 +221,14 @@ static inline int _impl_i2c_configure(struct device *dev, u32_t dev_config)
  *
  * The array of message @a msgs must not be NULL.  The number of
  * message @a num_msgs may be zero,in which case no transfer occurs.
+ *
+ * @note Not all scatter/gather transactions can be supported by all
+ * drivers.  As an example, a gather write (multiple consecutive
+ * `i2c_msg` buffers all configured for `I2C_MSG_WRITE`) may be packed
+ * into a single transaction by some drivers, but others may emit each
+ * fragment as a distinct write transaction, which will not produce
+ * the same behavior.  See the documentation of `struct i2c_msg` for
+ * limitations on support for multi-message bus transactions.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param msgs Array of messages to transfer.
@@ -435,6 +460,8 @@ static inline int i2c_write_read(struct device *dev, u16_t addr,
  * This routine reads multiple bytes from an internal address of an
  * I2C device synchronously.
  *
+ * Instances of this may be replaced by i2c_write_read().
+
  * @param dev Pointer to the device structure for the driver instance.
  * @param dev_addr Address of the I2C device for reading.
  * @param start_addr Internal address from which the data is being read.
@@ -444,21 +471,15 @@ static inline int i2c_write_read(struct device *dev, u16_t addr,
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  */
-static inline int i2c_burst_read(struct device *dev, u16_t dev_addr,
-				 u8_t start_addr, u8_t *buf,
+static inline int i2c_burst_read(struct device *dev,
+				 u16_t dev_addr,
+				 u8_t start_addr,
+				 u8_t *buf,
 				 u32_t num_bytes)
 {
-	struct i2c_msg msg[2];
-
-	msg[0].buf = &start_addr;
-	msg[0].len = 1;
-	msg[0].flags = I2C_MSG_WRITE;
-
-	msg[1].buf = buf;
-	msg[1].len = num_bytes;
-	msg[1].flags = I2C_MSG_RESTART | I2C_MSG_READ | I2C_MSG_STOP;
-
-	return i2c_transfer(dev, msg, 2, dev_addr);
+	return i2c_write_read(dev, dev_addr,
+			      &start_addr, sizeof(start_addr),
+			      buf, num_bytes);
 }
 
 /**
@@ -466,6 +487,11 @@ static inline int i2c_burst_read(struct device *dev, u16_t dev_addr,
  *
  * This routine writes multiple bytes to an internal address of an
  * I2C device synchronously.
+ *
+ * @warning The combined write synthesized by this API may not be
+ * supported on all I2C devices.  Uses of this API may be made more
+ * portable by replacing them with calls to i2c_write() passing a
+ * buffer containing the combined address and data.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param dev_addr Address of the I2C device for writing.
@@ -476,8 +502,10 @@ static inline int i2c_burst_read(struct device *dev, u16_t dev_addr,
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  */
-static inline int i2c_burst_write(struct device *dev, u16_t dev_addr,
-				  u8_t start_addr, const u8_t *buf,
+static inline int i2c_burst_write(struct device *dev,
+				  u16_t dev_addr,
+				  u8_t start_addr,
+				  const u8_t *buf,
 				  u32_t num_bytes)
 {
 	struct i2c_msg msg[2];
@@ -510,7 +538,9 @@ static inline int i2c_burst_write(struct device *dev, u16_t dev_addr,
 static inline int i2c_reg_read_byte(struct device *dev, u16_t dev_addr,
 				    u8_t reg_addr, u8_t *value)
 {
-	return i2c_burst_read(dev, dev_addr, reg_addr, value, 1);
+	return i2c_write_read(dev, dev_addr,
+			      &reg_addr, sizeof(reg_addr),
+			      value, sizeof(*value));
 }
 
 /**
@@ -518,6 +548,9 @@ static inline int i2c_reg_read_byte(struct device *dev, u16_t dev_addr,
  *
  * This routine writes a value to an 8-bit internal register of an I2C
  * device synchronously.
+ *
+ * @note This function internally combines the register and value into
+ * a single bus transaction.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param dev_addr Address of the I2C device for writing.
@@ -540,6 +573,9 @@ static inline int i2c_reg_write_byte(struct device *dev, u16_t dev_addr,
  *
  * This routine updates the value of a set of bits from an 8-bit internal
  * register of an I2C device synchronously.
+ *
+ * @note If the calculated new register value matches the value that
+ * was read this function will not generate a write operation.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param dev_addr Address of the I2C device for updating.
@@ -576,33 +612,32 @@ static inline int i2c_reg_update_byte(struct device *dev, u8_t dev_addr,
  * This routine reads multiple bytes from a 16 bit internal address of an
  * I2C device synchronously.
  *
+ * @deprecated Replace with i2c_write_read().
+ *
  * @param dev Pointer to the device structure for the driver instance.
- * @param dev_addr Address of the I2C device for reading.
- * @param start_addr Internal 16 bit address from which the data is being read.
+ * @param dev_addr Address of the I2C device for reading
+ * @param start_addr Internal 16 bit address from which the data is
+ * being read.  Target device will receive this in big-endian byte
+ * order.
  * @param buf Memory pool that stores the retrieved data.
  * @param num_bytes Number of bytes being read.
  *
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-static inline int i2c_burst_read16(struct device *dev, u16_t dev_addr,
-				   u16_t start_addr, u8_t *buf,
-				   u32_t num_bytes)
+__deprecated static inline int i2c_burst_read16(struct device *dev,
+						u16_t dev_addr,
+						u16_t start_addr,
+						u8_t *buf,
+						u32_t num_bytes)
 {
 	u8_t addr_buffer[2];
-	struct i2c_msg msg[2];
 
 	addr_buffer[1] = start_addr & 0xFF;
 	addr_buffer[0] = start_addr >> 8;
-	msg[0].buf = addr_buffer;
-	msg[0].len = 2;
-	msg[0].flags = I2C_MSG_WRITE;
-
-	msg[1].buf = buf;
-	msg[1].len = num_bytes;
-	msg[1].flags = I2C_MSG_RESTART | I2C_MSG_READ | I2C_MSG_STOP;
-
-	return i2c_transfer(dev, msg, 2, dev_addr);
+	return i2c_write_read(dev, dev_addr,
+			      addr_buffer, sizeof(addr_buffer),
+			      buf, num_bytes);
 }
 
 /**
@@ -611,18 +646,26 @@ static inline int i2c_burst_read16(struct device *dev, u16_t dev_addr,
  * This routine writes multiple bytes to a 16 bit internal address of an
  * I2C device synchronously.
  *
+ * @deprecated The combined write synthesized by this API may not be
+ * supported on all I2C devices.  Replace this with a single call to
+ * i2c_write() with a buffer containing the combined address and data.
+ *
  * @param dev Pointer to the device structure for the driver instance.
  * @param dev_addr Address of the I2C device for writing.
- * @param start_addr Internal 16 bit address to which the data is being written.
+ * @param start_addr Internal 16 bit address from which the data is
+ * being written.  Target device will receive this in big-endian byte
+ * order.
  * @param buf Memory pool from which the data is transferred.
  * @param num_bytes Number of bytes being written.
  *
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-static inline int i2c_burst_write16(struct device *dev, u16_t dev_addr,
-				    u16_t start_addr, const u8_t *buf,
-				    u32_t num_bytes)
+__deprecated static inline int i2c_burst_write16(struct device *dev,
+						 u16_t dev_addr,
+						 u16_t start_addr,
+						 const u8_t *buf,
+						 u32_t num_bytes)
 {
 	u8_t addr_buffer[2];
 	struct i2c_msg msg[2];
@@ -643,8 +686,10 @@ static inline int i2c_burst_write16(struct device *dev, u16_t dev_addr,
 /**
  * @brief Read internal 16 bit address register of an I2C device.
  *
- * This routine reads the value of an 16-bit internal register of an I2C
- * device synchronously.
+ * This routine reads the 8-bit value of internal register identified
+ * by a 16-bit register address synchronously.
+ *
+ * @deprecated Replace with i2c_write_read().
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param dev_addr Address of the I2C device for reading.
@@ -654,10 +699,18 @@ static inline int i2c_burst_write16(struct device *dev, u16_t dev_addr,
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-static inline int i2c_reg_read16(struct device *dev, u16_t dev_addr,
-				 u16_t reg_addr, u8_t *value)
+__deprecated static inline int i2c_reg_read16(struct device *dev,
+					      u16_t dev_addr,
+					      u16_t reg_addr,
+					      u8_t *value)
 {
-	return i2c_burst_read16(dev, dev_addr, reg_addr, value, 1);
+	u8_t addr_buffer[2];
+
+	addr_buffer[1] = reg_addr & 0xFF;
+	addr_buffer[0] = reg_addr >> 8;
+	return i2c_write_read(dev, dev_addr,
+			      addr_buffer, sizeof(addr_buffer),
+			      value, sizeof(*value));
 }
 
 /**
@@ -665,6 +718,10 @@ static inline int i2c_reg_read16(struct device *dev, u16_t dev_addr,
  *
  * This routine writes a value to an 16-bit internal register of an I2C
  * device synchronously.
+ *
+ * @deprecated The combined write synthesized by this API may not be
+ * supported on all I2C devices.  Replace this with a single call to
+ * i2c_write() with a buffer containing the combined address and data.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param dev_addr Address of the I2C device for writing.
@@ -674,10 +731,25 @@ static inline int i2c_reg_read16(struct device *dev, u16_t dev_addr,
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-static inline int i2c_reg_write16(struct device *dev, u16_t dev_addr,
-				  u16_t reg_addr, u8_t value)
+__deprecated static inline int i2c_reg_write16(struct device *dev,
+					       u16_t dev_addr,
+					       u16_t reg_addr,
+					       u8_t value)
 {
-	return i2c_burst_write16(dev, dev_addr, reg_addr, &value, 1);
+	u8_t addr_buffer[2];
+	struct i2c_msg msg[2];
+
+	addr_buffer[1] = reg_addr & 0xFF;
+	addr_buffer[0] = reg_addr >> 8;
+	msg[0].buf = addr_buffer;
+	msg[0].len = 2;
+	msg[0].flags = I2C_MSG_WRITE;
+
+	msg[1].buf = (u8_t *)&value;
+	msg[1].len = sizeof(value);
+	msg[1].flags = I2C_MSG_WRITE | I2C_MSG_STOP;
+
+	return i2c_transfer(dev, msg, 2, dev_addr);
 }
 
 /**
@@ -685,6 +757,14 @@ static inline int i2c_reg_write16(struct device *dev, u16_t dev_addr,
  *
  * This routine updates the value of a set of bits from a 16-bit internal
  * register of an I2C device synchronously.
+ *
+ * @note If the calculated new register value matches the value that
+ * was read this function will not generate a write operation.
+ *
+ * @deprecated The combined write synthesized by this API may not be
+ * supported on all I2C devices.  Replace this with a call to
+ * i2c_write_read() followed by value manipulation, then a call to
+ * i2c_write() with a buffer containing the combined address and data.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param dev_addr Address of the I2C device for updating.
@@ -695,14 +775,22 @@ static inline int i2c_reg_write16(struct device *dev, u16_t dev_addr,
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-static inline int i2c_reg_update16(struct device *dev, u16_t dev_addr,
-				   u16_t reg_addr, u8_t mask,
-				   u8_t value)
+__deprecated static inline int i2c_reg_update16(struct device *dev,
+						u16_t dev_addr,
+						u16_t reg_addr,
+						u8_t mask,
+						u8_t value)
 {
+	u8_t addr_buffer[2];
+	struct i2c_msg msg[2];
 	u8_t old_value, new_value;
 	int rc;
 
-	rc = i2c_reg_read16(dev, dev_addr, reg_addr, &old_value);
+	addr_buffer[1] = reg_addr & 0xFF;
+	addr_buffer[0] = reg_addr >> 8;
+	rc = i2c_write_read(dev, dev_addr,
+			    addr_buffer, sizeof(addr_buffer),
+			    &old_value, sizeof(old_value));
 	if (rc != 0) {
 		return rc;
 	}
@@ -712,7 +800,15 @@ static inline int i2c_reg_update16(struct device *dev, u16_t dev_addr,
 		return 0;
 	}
 
-	return i2c_reg_write16(dev, dev_addr, reg_addr, new_value);
+	msg[0].buf = addr_buffer;
+	msg[0].len = 2;
+	msg[0].flags = I2C_MSG_WRITE;
+
+	msg[1].buf = &new_value;
+	msg[1].len = sizeof(new_value);
+	msg[1].flags = I2C_MSG_WRITE | I2C_MSG_STOP;
+
+	return i2c_transfer(dev, msg, 2, dev_addr);
 }
 
 /**
@@ -721,6 +817,8 @@ static inline int i2c_reg_update16(struct device *dev, u16_t dev_addr,
  *
  * This routine reads multiple bytes from an addr_size byte internal
  * address of an I2C device synchronously.
+ *
+ * @deprecated Replace with i2c_write_read().
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param dev_addr Address of the I2C device for reading.
@@ -733,22 +831,15 @@ static inline int i2c_reg_update16(struct device *dev, u16_t dev_addr,
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-static inline int i2c_burst_read_addr(struct device *dev, u16_t dev_addr,
-				      const u8_t *start_addr,
-				      const u8_t addr_size,
-				      u8_t *buf, u32_t num_bytes)
+__deprecated static inline int i2c_burst_read_addr(struct device *dev,
+						   u16_t dev_addr,
+						   const u8_t *start_addr,
+						   const u8_t addr_size,
+						   u8_t *buf,
+						   u32_t num_bytes)
 {
-	struct i2c_msg msg[2];
-
-	msg[0].buf = (u8_t *)start_addr;
-	msg[0].len = addr_size;
-	msg[0].flags = I2C_MSG_WRITE;
-
-	msg[1].buf = buf;
-	msg[1].len = num_bytes;
-	msg[1].flags = I2C_MSG_RESTART | I2C_MSG_READ | I2C_MSG_STOP;
-
-	return i2c_transfer(dev, msg, 2, dev_addr);
+	return i2c_write_read(dev, dev_addr, start_addr, addr_size,
+			      buf, num_bytes);
 }
 
 /**
@@ -756,6 +847,10 @@ static inline int i2c_burst_read_addr(struct device *dev, u16_t dev_addr,
  * address of an I2C device.
  * This routine writes multiple bytes to an addr_size byte internal
  * address of an I2C device synchronously.
+ *
+ * @deprecated The combined write synthesized by this API may not be
+ * supported on all I2C devices.  Replace this with a single call to
+ * i2c_write() with a buffer containing the combined address and data.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param dev_addr Address of the I2C device for writing.
@@ -768,10 +863,12 @@ static inline int i2c_burst_read_addr(struct device *dev, u16_t dev_addr,
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-static inline int i2c_burst_write_addr(struct device *dev, u16_t dev_addr,
-				       const u8_t *start_addr,
-				       const u8_t addr_size,
-				       const u8_t *buf, u32_t num_bytes)
+__deprecated static inline int i2c_burst_write_addr(struct device *dev,
+						    u16_t dev_addr,
+						    const u8_t *start_addr,
+						    const u8_t addr_size,
+						    const u8_t *buf,
+						    u32_t num_bytes)
 {
 	struct i2c_msg msg[2];
 
@@ -793,6 +890,8 @@ static inline int i2c_burst_write_addr(struct device *dev, u16_t dev_addr,
  * This routine reads the value of an addr_size byte internal register
  * of an I2C device synchronously.
  *
+ * @deprecated Replace with i2c_write_read().
+ *
  * @param dev Pointer to the device structure for the driver instance.
  * @param dev_addr Address of the I2C device for reading.
  * @param reg_addr Array to an internal register address from which
@@ -803,14 +902,14 @@ static inline int i2c_burst_write_addr(struct device *dev, u16_t dev_addr,
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-static inline int i2c_reg_read_addr(struct device *dev,
-				    u16_t dev_addr,
-				    const u8_t *reg_addr,
-				    u8_t addr_size,
-				    u8_t *value)
+__deprecated static inline int i2c_reg_read_addr(struct device *dev,
+						 u16_t dev_addr,
+						 const u8_t *reg_addr,
+						 u8_t addr_size,
+						 u8_t *value)
 {
-	return i2c_burst_read_addr(dev, dev_addr, reg_addr,
-				   addr_size, value, 1);
+	return i2c_write_read(dev, dev_addr, reg_addr, addr_size,
+			      value, sizeof(*value));
 }
 
 /**
@@ -819,6 +918,10 @@ static inline int i2c_reg_read_addr(struct device *dev,
  *
  * This routine writes a value to an addr_size byte internal register
  * of an I2C device synchronously.
+ *
+ * @deprecated The combined write synthesized by this API may not be
+ * supported on all I2C devices.  Replace this with a single call to
+ * i2c_write() with a buffer containing the combined address and data.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param dev_addr Address of the I2C device for writing.
@@ -830,14 +933,23 @@ static inline int i2c_reg_read_addr(struct device *dev,
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-static inline int i2c_reg_write_addr(struct device *dev,
-				     u16_t dev_addr,
-				     const u8_t *reg_addr,
-				     const u8_t addr_size,
-				     u8_t value)
+__deprecated static inline int i2c_reg_write_addr(struct device *dev,
+						  u16_t dev_addr,
+						  const u8_t *reg_addr,
+						  const u8_t addr_size,
+						  u8_t value)
 {
-	return i2c_burst_write_addr(dev, dev_addr, reg_addr,
-				    addr_size, &value, 1);
+	struct i2c_msg msg[2];
+
+	msg[0].buf = (u8_t *)reg_addr;
+	msg[0].len = addr_size;
+	msg[0].flags = I2C_MSG_WRITE;
+
+	msg[1].buf = &value;
+	msg[1].len = sizeof(value);
+	msg[1].flags = I2C_MSG_WRITE | I2C_MSG_STOP;
+
+	return i2c_transfer(dev, msg, 2, dev_addr);
 }
 
 /**
@@ -846,6 +958,14 @@ static inline int i2c_reg_write_addr(struct device *dev,
  *
  * This routine updates the value of a set of bits from a addr_size byte
  * internal register of an I2C device synchronously.
+ *
+ * @note If the calculated new register value matches the value that
+ * was read this function will not generate a write operation.
+ *
+ * @deprecated The combined write synthesized by this API may not be
+ * supported on all I2C devices.  Replace this with a call to
+ * i2c_read() followed by a call to i2c_write() with a buffer
+ * containing the combined address and data.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param dev_addr Address of the I2C device for updating.
@@ -858,18 +978,19 @@ static inline int i2c_reg_write_addr(struct device *dev,
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-static inline int i2c_reg_update_addr(struct device *dev,
-				      u16_t dev_addr,
-				      const u8_t *reg_addr,
-				      u8_t addr_size,
-				      u8_t mask,
-				      u8_t value)
+__deprecated static inline int i2c_reg_update_addr(struct device *dev,
+						   u16_t dev_addr,
+						   const u8_t *reg_addr,
+						   u8_t addr_size,
+						   u8_t mask,
+						   u8_t value)
 {
+	struct i2c_msg msg[2];
 	u8_t old_value, new_value;
 	int rc;
 
-	rc = i2c_reg_read_addr(dev, dev_addr, reg_addr,
-			       addr_size, &old_value);
+	rc = i2c_write_read(dev, dev_addr, reg_addr, addr_size,
+			    &old_value, sizeof(old_value));
 	if (rc != 0) {
 		return rc;
 	}
@@ -879,8 +1000,15 @@ static inline int i2c_reg_update_addr(struct device *dev,
 		return 0;
 	}
 
-	return i2c_reg_write_addr(dev, dev_addr, reg_addr,
-				  addr_size, new_value);
+	msg[0].buf = (u8_t *)reg_addr;
+	msg[0].len = addr_size;
+	msg[0].flags = I2C_MSG_WRITE;
+
+	msg[1].buf = &new_value;
+	msg[1].len = sizeof(new_value);
+	msg[1].flags = I2C_MSG_WRITE | I2C_MSG_STOP;
+
+	return i2c_transfer(dev, msg, 2, dev_addr);
 }
 
 struct i2c_client_config {

--- a/samples/sensor/sht3xd/efr32mg_sltb004a.overlay
+++ b/samples/sensor/sht3xd/efr32mg_sltb004a.overlay
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&i2c0 { /* SDA 0, SCL 1 */
+&i2c0 { /* SDA H16=PC10, SCL H15=PC11, ALERT H13=PF6 */
 	sht3xd@44 {
 		compatible = "sensirion,sht3xd";
 		reg = <0x44>;
 		label = "SHT3XD";
-		alert-gpios = <&gpio0 2 GPIO_INT_ACTIVE_HIGH>;
+		alert-gpios = <&gpiof 6 GPIO_INT_ACTIVE_HIGH>;
 	};
 };

--- a/samples/sensor/sht3xd/frdm_k64f.overlay
+++ b/samples/sensor/sht3xd/frdm_k64f.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2019 Peter Bigot Consulting, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c0 { /* SDA PTE25, SCL PTE24, ALERT PTE26 */
+	sht3xd@44 {
+		compatible = "sensirion,sht3xd";
+		reg = <0x44>;
+		label = "SHT3XD";
+		alert-gpios = <&gpioe 26 GPIO_INT_ACTIVE_HIGH>;
+	};
+};

--- a/samples/sensor/sht3xd/nrf52840_pca10056.overlay
+++ b/samples/sensor/sht3xd/nrf52840_pca10056.overlay
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&i2c0 { /* SDA 0, SCL 1 */
+&i2c0 { /* SDA P0.26, SCL P0.27, ALERT P1.10 */
 	sht3xd@44 {
 		compatible = "sensirion,sht3xd";
 		reg = <0x44>;
 		label = "SHT3XD";
-		alert-gpios = <&gpio0 2 GPIO_INT_ACTIVE_HIGH>;
+		alert-gpios = <&gpio1 10 GPIO_INT_ACTIVE_HIGH>;
 	};
 };

--- a/samples/sensor/sht3xd/nucleo_l476rg.overlay
+++ b/samples/sensor/sht3xd/nucleo_l476rg.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2019 Peter Bigot Consulting, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c1 { /* SDA CN5.9=PB9, SCL CN5.10=PB8, ALERT CN5.1=D8=PA9 */
+/* &i2c3 { * SDA CN7.36=PC1, SCL CN7.38=PC0, ALERT CN7.34=PB0 */
+	sht3xd@44 {
+		compatible = "sensirion,sht3xd";
+		reg = <0x44>;
+		label = "SHT3XD";
+		alert-gpios = <&gpioa 9 GPIO_INT_ACTIVE_HIGH>;
+	};
+};

--- a/samples/sensor/sht3xd/sample.yaml
+++ b/samples/sensor/sht3xd/sample.yaml
@@ -9,5 +9,12 @@ sample:
 tests:
   test:
     build_only: true
-    platform_whitelist: nrf51_ble400
+    platform_whitelist: efr32mg_sltb004a frdm_k64f nrf51_ble400
+      nrf52840_pca10056 nucleo_l476rg
+    tags: sensors
+  test_trigger:
+    build_only: true
+    extra_args: CONF_FILE="trigger.conf"
+    platform_whitelist: efr32mg_sltb004a frdm_k64f nrf51_ble400
+      nrf52840_pca10056 nucleo_l476rg
     tags: sensors

--- a/samples/sensor/sht3xd/trigger.conf
+++ b/samples/sensor/sht3xd/trigger.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2019 Peter Bigot Consulting, LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_STDOUT_CONSOLE=y
+CONFIG_I2C=y
+CONFIG_SENSOR=y
+CONFIG_SHT3XD=y
+CONFIG_SHT3XD_TRIGGER=y
+CONFIG_SHT3XD_TRIGGER_GLOBAL_THREAD=y


### PR DESCRIPTION
## Overview 
This PR provides a "resolution" to #11612.  Analysis suggests that the I2C API was too ambitious about the cross-platform potential for creating single transactions that source or sink data from multiple addresses.

In particular, not all I2C driver implementations are capable of supporting a [gather write transaction](https://github.com/zephyrproject-rtos/zephyr/issues/11612#issuecomment-450505974): multiple message fragments gathered from non-contiguous addresses and transferred through a single I2C write transaction.  As an example, the sample FRAM code referenced in #11720 must be rewritten to pack the address and data into a single buffer in order for it to work on Nordic devices.

The resolution is to document the issue, provide new API to simplify use of the most common multi-transaction operation (a write of arbitrary length followed by a read of arbitrary length), and deprecate the problematic helper functions.

https://github.com/zephyrproject-rtos/zephyr/issues/11612#issuecomment-441366533 also notes that there are many "helper" functions for read, write, and update operations given a variety of register addressing schemes.  None of these are used in Zephyr proper, and the write implementation for them does not work with all I2C driver implementations.  **In a separate commit these helper functions are removed**.  If consensus is that this is a bad idea, the commit removing them can be dropped from this PR.

Below are the API functions affected by this PR, with notes on whether the function worked across driver implementations, is used, and is deprecated.

## Code Cleanup Remaining

The following changes are out of scope for this PR, primarily because they would touch code that I can't test due to lack of the corresponding hardware.
* drivers/sensor/max44009 uses `i2c_transfer` in a way that can probably be replaced by `i2c_write_read`
* drivers/sensor/mcp9808 uses `i2c_transfer` in a way that can probably be replaced by `i2c_write_read`
* drivers/sensor/tmp007 uses `i2c_transfer` in a way that can probably be replaced by `i2c_write_read`
* samples/drivers/i2c_fujitsu_fram must be rewritten to aggregate all content for a multi-part write into a single buffer to work on Nordic and possibly other I2C driver implementations (#11720)
* samples/drivers/current_sensing should be rewritten to use `i2c_write_read()` for `read_reg16`, and must be rewritten to pack the register and value into a single buffer for `write_reg16`, if the code is to work on Nordic and possibly other I2C driver implementations.

In addition to these untouched items the PR includes replacement of one use of a deprecated function in `drivers/ethernet/eth_sam_gmac`.

## Reviewed, some deprecated, all remain active

### i2c_burst_read()
8-bit register address, length of result specified in call.

* Works correctly
* Used in Zephyr
* Not deprecated (but the companion `i2c_burst_write()` is deprecated). Implementation updated to use `i2c_write_read()`, so it could be deprecated.

### i2c_burst_write()
8-bit register address, length to write specified in call.

* Does **not** work correctly across SoC I2C variants
* Used in Zephyr
* Deprecated to `i2c_write()` with caller responsible for packing register together with data into a contiguous buffer.  Implementation left unmodified to temporarily support existing operational use.

### i2c_reg_read_byte()
8-bit register address, single-byte result.

* Works correctly
* Used in Zephyr
* Not deprecated.  Implementation updated to use `i2c_write_read()`.

### i2c_reg_write_byte()

8-bit register address, 8-bit value to write.

* Works correctly (existing implementation packs address and value into a stack-allocated buffer passed to `i2c_write()`.)
* Used in Zephyr
* Not deprecated.

### i2c_reg_update_byte()

8-bit register address, 8-bit value read, manipulated, then written back.

* Works correctly
* Used in Zephyr
* Not deprecated

## Deprecated, removed in secondary commit

**NOTE** These functions are not visible in the aggregate diff for the initial version of this PR.  Review the first commit directly to see the related changes before the functions were removed.

### i2c_burst_read16()

16-bit big-endian register address, length of result specified in call.

* May not work correctly across SoC I2C variants (depends on `I2C_MSG_RESTART` support)
* **Not** used in Zephyr
* Deprecated to i2c_write_read() where caller is responsible for ensuring register address endianness is correct.  Implementation updated to use this behavior.

### i2c_burst_write16()

16-bit big-endian register address, length to write specified in call.

* Does **not** work correctly across SoC I2C variants
* **Not** used in Zephyr (except as delegated from `i2c_reg_write16()`)
* Deprecate to `i2c_write()` where caller is responsible for packing register address in appropriate byte order with data into a contiguous buffer.  Implementation left unmodified to temporarily support any existing operational use.

### i2c_reg_read16()

16-bit big-endian register address, 8-bit value read

* Works correctly (delegates to `i2c_burst_read16()`)
* **Not** used in Zephyr (except delegated from unused `i2c_reg_update16()`)
* Deprecated to i2c_write_read() where caller is responsible for ensuring register address endianness is correct.  Implementation updated to use this behavior.

### i2c_reg_write16()

16-bit big-endian register address, 8-bit value written.

* Does **not** work correctly across SoC I2C variants (delegates to
  `i2c_burst_write16()`)
* **Not** used in Zephyr (except delegated from unused `i2c_reg_update16()`)
* Deprecate to `i2c_write()` where caller is responsible for packing register address in appropriate byte order together with data into a contiguous buffer.  Implementation left unmodified to temporarily support any existing operational use.

### i2c_reg_update16()

16-bit big-endian register address, 8-bit value read, manipulated, and written.

* Does **not** work correctly across SoC I2C variants (depends on
  `i2c_reg_write16()`)
* **Not** used in Zephyr
* Deprecate, replace with explicit `i2c_write_read()` and `i2_write()` operations at call site.  Implementation left unmodified to temporarily support any existing operational use.

### i2c_burst_read_addr()

Register "address" of arbitrary length, length of result specified in call.

* Does **not** work correctly across SoC I2C variants
* Used in Zephyr (`drivers/ethernet/eth_sam_gmac.c`).  This use has been replaced replaced by `i2c_write_read()`.
* Deprecate to `i2c_write_read()`. where caller is responsible for packing register address in appropriate byte order with data into a contiguous buffer.  Implementation updated to use this behavior.

### i2c_burst_write_addr()

Register "address" of arbitrary length, length to write specified in call.

* Does **not** work correctly across SoC I2C variants
* **Not** used in Zephyr (except delegated from unused
  `i2c_reg_write_addr()`)
* Deprecate to `i2c_write()` where caller is responsible for packing register address in appropriate byte order with together with data into a contiguous buffer.  Implementation left unmodified to temporarily support any existing operational use.

### i2c_reg_read_addr()

Register "address" of arbitrary length, 8-bit value read.

* Does **not** work correctly across SoC I2C variants
* **Not** used in Zephyr (except delegated from unused `i2c_reg_update_addr()`)
* Deprecate to `i2c_write_read()`.  Implementation updated to use this behavior.

### i2c_reg_write_addr()

Register "address" of arbitrary length, 8-bit value written.

* Does **not** work correctly across SoC I2C variants 
* **Not** used in Zephyr (except delegated from unused `i2c_reg_update_addr()`)
* Deprecate to `i2c_write()` where caller is responsible for packing register address in appropriate byte order together with data into a contiguous buffer.  Implementation (delegate to `i2c_burst_write_addr()`) left unmodified to temporarily support any existing operational use.

### i2c_reg_update_addr()

Register "address" of arbitrary length, 8-bit value read, manipulated, and written.

* Does **not** work correctly across SoC I2C variants
* **Not** used in Zephyr
* Deprecate, replace with explicit `i2c_write_read()` and `i2_write()` operations at call site.  Implementation left unmodified to temporarily support any existing operational use.