### PR TITLE
Cleanup DTC warning check for unit-address

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -80,12 +80,20 @@ if(CONFIG_HAS_DTS)
   endif()
 
   # Run the DTC on *.dts.pre.tmp to create the intermediary file *.dts_compiled
+
+  set(DTC_WARN_UNIT_ADDR_IF_ENABLED "")
+  check_dtc_flag("-Wunique_unit_address_if_enabled" check)
+  if (check)
+    set(DTC_WARN_UNIT_ADDR_IF_ENABLED "-Wunique_unit_address_if_enabled")
+  endif()
   execute_process(
     COMMAND ${DTC}
     -O dts
     -o ${BOARD}.dts_compiled
     -b 0
     -E unit_address_vs_reg
+    -W no-unique_unit_address
+    ${DTC_WARN_UNIT_ADDR_IF_ENABLED}
     ${EXTRA_DTC_FLAGS} # User settable
     ${BOARD}.dts.pre.tmp
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -697,6 +697,27 @@ function(zephyr_code_relocate file location)
     "${location}:${CMAKE_CURRENT_SOURCE_DIR}/${file}")
 endfunction()
 
+# Usage:
+#   check_dtc_flag("-Wtest" DTC_WARN_TEST)
+#
+# Writes 1 to the output variable 'ok' if
+# the flag is supported, otherwise writes 0.
+#
+# using
+function(check_dtc_flag flag ok)
+  execute_process(
+    COMMAND
+    ${DTC} ${flag} -v
+    ERROR_QUIET
+    RESULT_VARIABLE dtc_check_ret
+  )
+  if (dtc_check_ret EQUAL 0)
+    set(${ok} 1 PARENT_SCOPE)
+  else()
+    set(${ok} 0 PARENT_SCOPE)
+  endif()
+endfunction()
+
 ########################################################
 # 2. Kconfig-aware extensions
 ########################################################


### PR DESCRIPTION
Add support for disabling dtc's (unique_unit_address) check, but enabling (unique_unit_address_if_enabled).  This covers the case for some SoCs in which multiple peripherals are at the same MMIO address, but only one should be enabled at a time.