### PR TITLE
SAM GMAC ethernet driver fixes

### DIFF
--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -30,8 +30,11 @@
 
 /** RX descriptors count for main queue */
 #define MAIN_QUEUE_RX_DESC_COUNT CONFIG_ETH_SAM_GMAC_BUF_RX_COUNT
-/** TX descriptors count for main queue */
-#define MAIN_QUEUE_TX_DESC_COUNT (CONFIG_NET_BUF_TX_COUNT + 1)
+/** TX descriptors count for main queue. They should be able to store a full
+ ** packet, that might use either the TX or the RX buffers.
+ */
+#define MAIN_QUEUE_TX_DESC_COUNT (max(CONFIG_NET_BUF_RX_COUNT, \
+				      CONFIG_NET_BUF_TX_COUNT) + 1)
 
 /** RX/TX descriptors count for priority queues */
 #if GMAC_PRIORITY_QUEUE_NO == 2

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -169,7 +169,6 @@ struct gmac_queue {
 	struct gmac_desc_list rx_desc_list;
 	struct gmac_desc_list tx_desc_list;
 	struct k_sem tx_desc_sem;
-	struct k_delayed_work tx_timeout_work;
 
 	struct ring_buf rx_frag_list;
 	struct ring_buf tx_frames;


### PR DESCRIPTION
This set of 3 patches aims to fix issue #11255. It has been tested with ICMPv4 and ICMPv6 ping with a 0.00001 interval during 2 hours, both as standalone and with PR#11888 + PR#12555. For me it fixes the reported issue, although I am almost sure there are more bugs lying down in the driver, especially as these patches only touch the TX path.

Fixes: #11255