### PR TITLE
riscv32: Explicitly set target when calling gcc

### DIFF
--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -106,6 +106,10 @@ else()
     list(APPEND TOOLCHAIN_C_FLAGS
       -mcpu=${GCC_M_CPU}
       )
+  elseif("${ARCH}" STREQUAL "riscv32")
+    list(APPEND TOOLCHAIN_C_FLAGS
+      -march=rv32imac -mabi=ilp32 -mcmodel=medlow
+      )
   endif()
 
   if(NOT no_libgcc)


### PR DESCRIPTION
Some toolchains default to RV64, so this is necessary.

Please review extra carefully, because this is my first PR in this project and I didn't even know this existed yesterday. Nice project, btw! :+1: 