### PR TITLE
Fix mcuboot tests

### DIFF
--- a/tests/subsys/dfu/mcuboot/src/main.c
+++ b/tests/subsys/dfu/mcuboot/src/main.c
@@ -110,6 +110,9 @@ void test_write_confirm(void)
 
 	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
 
+	zassert(boot_erase_img_bank(FLASH_AREA_IMAGE_0_OFFSET) == 0,
+		"pass", "fail");
+
 	ret = flash_read(flash_dev, FLASH_AREA_IMAGE_0_OFFSET +
 			 FLASH_AREA_IMAGE_0_SIZE - sizeof(img_magic), &readout,
 			 sizeof(img_magic));

--- a/tests/subsys/dfu/mcuboot/src/main.c
+++ b/tests/subsys/dfu/mcuboot/src/main.c
@@ -26,7 +26,7 @@ void test_bank_erase(void)
 	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
 
 	for (offs = FLASH_AREA_IMAGE_1_OFFSET;
-	     offs <= FLASH_AREA_IMAGE_1_OFFSET + FLASH_AREA_IMAGE_1_SIZE;
+	     offs < FLASH_AREA_IMAGE_1_OFFSET + FLASH_AREA_IMAGE_1_SIZE;
 	     offs += sizeof(temp)) {
 		ret = flash_read(flash_dev, offs, &temp, sizeof(temp));
 		zassert_true(ret == 0, "Reading from flash");
@@ -52,7 +52,7 @@ void test_bank_erase(void)
 	}
 
 	for (offs = FLASH_AREA_IMAGE_1_OFFSET;
-	     offs <= FLASH_AREA_IMAGE_1_OFFSET + FLASH_AREA_IMAGE_1_SIZE;
+	     offs < FLASH_AREA_IMAGE_1_OFFSET + FLASH_AREA_IMAGE_1_SIZE;
 	     offs += sizeof(temp)) {
 		ret = flash_read(flash_dev, offs, &temp, sizeof(temp));
 		zassert_true(ret == 0, "Reading from flash");


### PR DESCRIPTION
Fixed some failures in MCUBOOT tests:

1. Reads where performed past image boundary size
2. Erase image slot before tests