### PR TITLE
samples: echo_server: Test overlays for eth_e1000 and eth_stellaris

### DIFF
--- a/samples/net/echo_server/sample.yaml
+++ b/samples/net/echo_server/sample.yaml
@@ -50,6 +50,14 @@ tests:
     extra_args: OVERLAY_CONFIG="overlay-enc28j60.conf"
     tags: net enc28j60
     platform_whitelist: arduino_101
+  test_e1000:
+    extra_args: OVERLAY_CONFIG="overlay-e1000.conf"
+    tags: net
+    platform_whitelist: qemu_x86
+  test_stellaris:
+    extra_args: OVERLAY_CONFIG="overlay-qemu_cortex_m3_eth.conf"
+    tags: net
+    platform_whitelist: qemu_cortex_m3
   test_smsc911x:
     extra_args: OVERLAY_CONFIG="overlay-smsc911x.conf"
     tags: net


### PR DESCRIPTION
By adding relevant test config to sample.yaml.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>