### PR TITLE
drivers: timer: nrf: refactor for speed and correctness

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -39,17 +39,17 @@
 
 static u32_t last_count;
 
-static u32_t counter_sub(u32_t a, u32_t b)
+static inline u32_t counter_sub(u32_t a, u32_t b)
 {
 	return (a - b) & COUNTER_MAX;
 }
 
-static void set_comparator(u32_t cyc)
+static inline void set_comparator(u32_t cyc)
 {
 	nrf_rtc_cc_set(RTC, 0, cyc);
 }
 
-static u32_t counter(void)
+static inline u32_t counter(void)
 {
 	return nrf_rtc_counter_get(RTC);
 }

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -22,8 +22,6 @@
 
 #define MIN_DELAY 32
 
-static struct k_spinlock lock;
-
 static u32_t last_count;
 
 static u32_t counter_sub(u32_t a, u32_t b)
@@ -54,7 +52,7 @@ void rtc1_nrf5_isr(void *arg)
 	ARG_UNUSED(arg);
 	RTC->EVENTS_COMPARE[0] = 0;
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	u32_t key = irq_lock();
 	u32_t t = counter();
 	u32_t dticks = counter_sub(t, last_count) / CYC_PER_TICK;
 
@@ -69,7 +67,7 @@ void rtc1_nrf5_isr(void *arg)
 		set_comparator(next);
 	}
 
-	k_spin_unlock(&lock, key);
+	irq_unlock(key);
 	z_clock_announce(dticks);
 }
 
@@ -117,7 +115,7 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	ticks = (ticks == K_FOREVER) ? MAX_TICKS : ticks;
 	ticks = max(min(ticks - 1, (s32_t)MAX_TICKS), 0);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	u32_t key = irq_lock();
 	u32_t cyc, t = counter();
 
 	/* Round up to next tick boundary */
@@ -131,7 +129,7 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	}
 
 	set_comparator(cyc);
-	k_spin_unlock(&lock, key);
+	irq_unlock(key);
 #endif
 }
 
@@ -141,18 +139,18 @@ u32_t z_clock_elapsed(void)
 		return 0;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	u32_t key = irq_lock();
 	u32_t ret = counter_sub(counter(), last_count) / CYC_PER_TICK;
 
-	k_spin_unlock(&lock, key);
+	irq_unlock(key);
 	return ret;
 }
 
 u32_t _timer_cycle_get_32(void)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	u32_t key = irq_lock();
 	u32_t ret = counter_sub(counter(), last_count) + last_count;
 
-	k_spin_unlock(&lock, key);
+	irq_unlock(key);
 	return ret;
 }

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -31,7 +31,7 @@ static u32_t counter_sub(u32_t a, u32_t b)
 
 static void set_comparator(u32_t cyc)
 {
-	nrf_rtc_cc_set(RTC, 0, cyc & COUNTER_MAX);
+	nrf_rtc_cc_set(RTC, 0, cyc);
 }
 
 static u32_t counter(void)


### PR DESCRIPTION
The existing implementation of `nrf_rtc_timer:z_clock_set_timeout()` calculates the compare value based on a complex series of operations including an unconditional integer division and multiplication intended to ensure the compare value is aligned to a tick boundary.  On the nRF51 this division requires a call to an outline function with a data-dependent execution time.

In the common case where the timeout is configured less than one tick past the last observed tick the division can be elided, as can several extra operations intended to deal with fractional ticks.

The code also failed to correctly account for a ticks-per-cycle that violated the minimum delay required to guarantee a compare value would produce a compare event.  The minimum delay was also unreasonably long (about 1 ms).  Reduce it to a more reasonable value to allow for a higher ticks-per-second, and diagnose attempts to set the tick frequency above the supported maximum (8192 Hz).

Finally, move the parts of the compare calculation that are not dependent on the live counter value out of the locked region.

Prior to this change (but after a couple minor enhancements also present in this PR) the observed time between the `irq_lock()` and `irq_unlock()` in `z_clock_set_timeout()` on the nRF51 ranged between 5 us and 8 us.

With the revised algorithm the observed lock duration is between 2.16 us (1024 Hz) and 2.88 us (100 Hz) in the common case that the compare is set within the current tick.  If the compare is set late the duration will be higher, but no greater than the previous implementation.

These changes also remove significant instability with larger ticks-per-second (#12542) when `CONFIG_TIMESLICING=y` is present, allowing `CONFIG_TICKS_PER_SEC` to be increased to its maximum of 8192.

Closes #12541