### PR TITLE
app_memory: cleanup and fixed issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1179,6 +1179,7 @@ if(CONFIG_APP_SHARED_MEM AND CONFIG_USERSPACE)
     ${ZEPHYR_BASE}/scripts/gen_app_partitions.py
     -d ${OBJ_FILE_DIR}
     -o ${APP_SMEM_LD}
+    $<$<BOOL:CONFIG_NEWLIB_LIBC>:--newlib-libc>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/
     COMMENT "Generating app_smem linker section"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1170,7 +1170,7 @@ if(CONFIG_APP_SHARED_MEM AND CONFIG_USERSPACE)
   add_custom_target(
     ${APP_SMEM_DEP} ALL
     DEPENDS app
-    kernel
+    kernel ${ZEPHYR_LIBS_PROPERTY}
     )
 
   add_custom_command(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,10 +324,10 @@ zephyr_cc_option(-Wpointer-arith)
 
 # Declare MPU userspace dependencies before the linker scripts to make
 # sure the order of dependencies are met
-if(CONFIG_CPU_HAS_MPU AND CONFIG_USERSPACE)
-  if(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT AND CONFIG_APP_SHARED_MEM )
+if(CONFIG_APP_SHARED_MEM AND CONFIG_USERSPACE)
     set(APP_SMEM_DEP app_smem_linker)
-  endif()
+endif()
+if(CONFIG_CPU_HAS_MPU AND CONFIG_USERSPACE)
   if(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT AND CONFIG_ARC AND CONFIG_APPLICATION_MEMORY)
     set(ALIGN_SIZING_DEP app_sizing_prebuilt linker_app_sizing_script)
   endif()
@@ -1163,30 +1163,29 @@ configure_file(
      $ENV{ZEPHYR_BASE}/include/arch/arm/cortex_m/scripts/app_smem.ld
      ${PROJECT_BINARY_DIR}/include/generated/app_smem.ld)
 
+if(CONFIG_APP_SHARED_MEM AND CONFIG_USERSPACE)
+  set(APP_SMEM_LD "${PROJECT_BINARY_DIR}/include/generated/app_smem.ld")
+  set(OBJ_FILE_DIR "${PROJECT_BINARY_DIR}/../")
+
+  add_custom_target(
+    ${APP_SMEM_DEP} ALL
+    DEPENDS app
+    kernel
+    )
+
+  add_custom_command(
+    TARGET ${APP_SMEM_DEP}
+    COMMAND ${PYTHON_EXECUTABLE}
+    ${ZEPHYR_BASE}/scripts/gen_app_partitions.py
+    -d ${OBJ_FILE_DIR}
+    -o ${APP_SMEM_LD}
+    $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/
+    COMMENT "Generating app_smem linker section"
+    )
+endif()
+
 if(CONFIG_CPU_HAS_MPU AND CONFIG_USERSPACE)
-
-    if(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT AND CONFIG_APP_SHARED_MEM)
-        set(APP_SMEM_LD "${PROJECT_BINARY_DIR}/include/generated/app_smem.ld")
-        set(OBJ_FILE_DIR "${PROJECT_BINARY_DIR}/../")
-
-        add_custom_target(
-          ${APP_SMEM_DEP} ALL
-          DEPENDS app
-          kernel
-         )
-
-        add_custom_command(
-          TARGET ${APP_SMEM_DEP}
-          COMMAND ${PYTHON_EXECUTABLE}
-          ${ZEPHYR_BASE}/scripts/gen_app_partitions.py
-          -d ${OBJ_FILE_DIR}
-          -o ${APP_SMEM_LD}
-          $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/
-          COMMENT "Generating power of 2 aligned app_smem linker section"
-         )
-  endif()
-
 
   if(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT AND CONFIG_ARC AND CONFIG_APPLICATION_MEMORY)
 

--- a/arch/x86/core/crt0.S
+++ b/arch/x86/core/crt0.S
@@ -322,6 +322,14 @@ __csSet:
 	call	_x86_data_copy
 #endif /* CONFIG_APPLICATION_MEMORY */
 
+#ifdef CONFIG_APP_SHARED_MEM
+	movl	$_app_smem_start, %edi /* DATA in RAM (dest) */
+	movl	$_app_smem_rom_start, %esi /* DATA in ROM (src) */
+	movl	$_app_smem_num_words, %ecx /* Size of DATA in quad bytes */
+
+	call	_x86_data_copy
+#endif /* CONFIG_APP_SHARED_MEM */
+
 #endif /* CONFIG_XIP */
 
 	/*

--- a/include/app_memory/app_memdomain.h
+++ b/include/app_memory/app_memdomain.h
@@ -30,11 +30,11 @@
  */
 #define _app_dmem_pad(id) \
 	__attribute__((aligned(MEM_DOMAIN_ALIGN_SIZE), \
-		section("data_smem_" #id)))
+		section("data_smem_" #id "_data")))
 
 #define _app_bmem_pad(id) \
 	__attribute__((aligned(MEM_DOMAIN_ALIGN_SIZE), \
-		section("data_smem_" #id "b")))
+		section("data_smem_" #id "_bss")))
 
 /*
  * Qualifier to collect any object preceded with _app
@@ -44,10 +44,10 @@
  * initialized to zero.
  */
 #define _app_dmem(id) \
-	__attribute__((section("data_smem_" #id)))
+	__attribute__((section("data_smem_" #id "_data")))
 
 #define _app_bmem(id) \
-	__attribute__((section("data_smem_" #id "b")))
+	__attribute__((section("data_smem_" #id "_bss")))
 
 /*
  * Creation of a struct to save start addresses, sizes, and

--- a/include/app_memory/app_memdomain.h
+++ b/include/app_memory/app_memdomain.h
@@ -82,23 +82,40 @@ struct app_region {
 #endif	/* CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT */
 
 #define appmem_partition(name) \
-	extern char *data_smem_##name; \
-	extern char *data_smem_##name##b; \
-	smem_size_declare(name);		  \
 	_app_dmem_pad(name) char name##_dmem_pad; \
 	_app_bmem_pad(name) char name##_bmem_pad; \
-	__kernel struct k_mem_partition mem_domain_##name; \
-	__kernel struct app_region name; \
+	__kernel struct k_mem_partition mem_partition_##name; \
+	__kernel struct app_region name;
+
+#define appmem_partition_header(name) \
+	extern char *data_smem_##name;	  \
+	extern char *data_smem_##name##b; \
+	smem_size_declare(name); \
+	extern struct k_mem_partition mem_partition_##name; \
+	extern struct app_region name; \
 	static inline void appmem_init_part_##name(void) \
 	{ \
 		name.dmem_start = (char *)&data_smem_##name; \
 		name.bmem_start = (char *)&data_smem_##name##b; \
 		smem_size_assign(name);				\
 		sys_dlist_append(&app_mem_list, &name.lnode); \
-		mem_domain_##name.start = (u32_t) name.dmem_start; \
-		mem_domain_##name.attr = K_MEM_PARTITION_P_RW_U_RW; \
-		name.partition = &mem_domain_##name; \
+		mem_partition_##name.start = (u32_t) name.dmem_start; \
+		mem_partition_##name.attr = K_MEM_PARTITION_P_RW_U_RW; \
+		name.partition = &mem_partition_##name; \
 	}
+
+/* A helper function that should be called to define multiple partitions*/
+#define APPMEM_PARTITION_OBJECT_DEFINE(...)\
+	FOR_EACH(appmem_partition, __VA_ARGS__)
+
+/* This defines all the functions that are needed to configure
+ * the memory partitions. Usually goes in a common header file.
+ */
+#define APPMEM_PARTITION_HEADER_DEFINE(...)\
+	FOR_EACH(appmem_partition_header, __VA_ARGS__)
+
+/* Returns the mem_partition struct */
+#define APPMEM_PARTITION_GET(name) (mem_partition_##name)
 
 /*
  * A wrapper around the k_mem_domain_* functions. Goal here was
@@ -107,7 +124,10 @@ struct app_region {
  * types (i.e. app_region, k_mem_domain, etc).
  */
 #define appmem_domain(name) \
-	__kernel struct k_mem_domain domain_##name; \
+	__kernel struct k_mem_domain domain_##name;
+
+#define appmem_domain_header(name) \
+	extern struct k_mem_domain domain_##name; \
 	static inline void appmem_add_thread_##name(k_tid_t thread) \
 	{ \
 		k_mem_domain_add_thread(&domain_##name, thread); \
@@ -131,6 +151,18 @@ struct app_region {
 		k_mem_domain_init(&domain_##name, 1, &region.partition); \
 	}
 
+/* A helper function that should be called to define multiple domains
+ * Only an object will get defined. Must be placed in a .c file.
+ */
+#define APPMEM_DOMAIN_OBJECT_DEFINE(...)\
+	FOR_EACH(appmem_domain, __VA_ARGS__)
+
+/* This defines all the functions that are needed to configure
+ * the memory domains. Usually goes in a common header file.
+ */
+#define APPMEM_DOMAIN_HEADER_DEFINE(...)\
+	FOR_EACH(appmem_domain_header, __VA_ARGS__)
+
 /*
  * The following allows the FOR_EACH macro to call each partition's
  * appmem_init_part_##name . Note: semicolon needed or else compiler
@@ -139,6 +171,10 @@ struct app_region {
  */
 #define appmem_init_part(name) \
 	appmem_init_part_##name();
+
+/* A helper function that should be called to initialize multiple partitions */
+#define APPMEM_INIT_PARTITIONS(...)		\
+	FOR_EACH(appmem_init_part, __VA_ARGS__)
 
 extern sys_dlist_t app_mem_list;
 

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -139,22 +139,12 @@ SECTIONS {
 #include <app_data_alignment.ld>
 
 #if defined(CONFIG_APP_SHARED_MEM)
-#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
 #define APP_SHARED_ALIGN MPU_MIN_SIZE_ALIGN
-		#include <app_smem.ld>
-#else
-	SECTION_PROLOGUE(_APP_SMEM_SECTION_NAME, (OPTIONAL),)
-	{
-		MPU_MIN_SIZE_ALIGN
-		_image_ram_start = .;
-		_app_smem_start = .;
-		APP_SMEM_SECTION()
-		MPU_MIN_SIZE_ALIGN
-		_app_smem_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#define SMEM_PARTITION_ALIGN MPU_ALIGN
 
-#endif  /* CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT */
+#include <app_smem.ld>
 
+	_image_ram_start = _app_smem_start;
 	_app_smem_size = _app_smem_end - _app_smem_start;
 	_app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
 #endif /* CONFIG_APP_SHARED_MEM */

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -411,22 +411,9 @@ SECTIONS
 
 #if defined(CONFIG_APP_SHARED_MEM)
 #define APP_SHARED_ALIGN . = ALIGN(_region_min_align);
-#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
-		#include <app_smem.ld>
-#else
-	SECTION_PROLOGUE(_APP_SMEM_SECTION_NAME, (OPTIONAL),)
-	{
-		APP_SHARED_ALIGN;
-		_app_smem_start = .;
-		APP_SMEM_SECTION()
-		/* Align the end of shared app mem section with the
-		 * minimum granularity required by MPU.
-		 */
-		APP_SHARED_ALIGN;
-		_app_smem_end = .;
+#define SMEM_PARTITION_ALIGN MPU_ALIGN
 
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-#endif  /* CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT */
+#include <app_smem.ld>
 
 	_app_smem_size = _app_smem_end - _app_smem_start;
 	_app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -202,25 +202,27 @@ SECTIONS
 	__gcov_bss_size = __gcov_bss_end - __gcov_bss_start;
 #endif /* CONFIG_COVERAGE_GCOV */
 
+#ifdef CONFIG_APP_SHARED_MEM
 	/* APP SHARED MEMORY REGION */
-	SECTION_PROLOGUE(_APP_SMEM_SECTION_NAME, (OPTIONAL),)
-	{
-		_image_ram_start = .;
-		_app_smem_start = .;
-		APP_SMEM_SECTION()
-		MMU_PAGE_ALIGN
-		_app_smem_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+#define SMEM_PARTITION_ALIGN(size) MMU_PAGE_ALIGN
+#define APP_SHARED_ALIGN  MMU_PAGE_ALIGN
 
+#include <app_smem.ld>
+
+	_image_ram_start = _app_smem_start;
 	_app_smem_size = _app_smem_end - _app_smem_start;
 	_app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
-
+	_app_smem_num_words = _app_smem_size >> 2;
+#endif /* CONFIG_APP_SHARED_MEM */
 
 #ifdef CONFIG_APPLICATION_MEMORY
 	SECTION_DATA_PROLOGUE(_APP_DATA_SECTION_NAME, (OPTIONAL),)
 	{
 #ifndef CONFIG_XIP
 		MMU_PAGE_ALIGN
+#endif
+#if !defined(CONFIG_APP_SHARED_MEM)
+		_image_ram_start = .;
 #endif
 		__app_ram_start = .;
 		__app_data_ram_start = .;
@@ -256,7 +258,9 @@ SECTIONS
 	SECTION_PROLOGUE(_BSS_SECTION_NAME, (NOLOAD OPTIONAL),)
 	{
 	MMU_PAGE_ALIGN
-
+#if !defined(CONFIG_APP_SHARED_MEM)  && !defined(CONFIG_APPLICATION_MEMORY)
+	_image_ram_start = .;
+#endif
 	/*
 	 * For performance, BSS section is forced to be both 4 byte aligned and
 	 * a multiple of 4 bytes.

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -188,7 +188,7 @@ void _data_copy(void)
 #endif	/* CONFIG_CODE_DATA_RELOCATION */
 #ifdef CONFIG_APP_SHARED_MEM
 	(void)memcpy(&_app_smem_start, &_app_smem_rom_start,
-		 ((u32_t) &_app_smem_end - (u32_t) &_app_smem_start));
+		     ((u32_t) &_app_smem_size));
 #endif
 #ifdef CONFIG_APPLICATION_MEMORY
 	(void)memcpy(&__app_data_ram_start, &__app_data_rom_start,

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -14,6 +14,7 @@
 #include <misc/errno_private.h>
 #include <misc/libc-hooks.h>
 #include <syscall_handler.h>
+#include <app_memory/app_memdomain.h>
 
 #define USED_RAM_END_ADDR   POINTER_TO_UINT(&_end)
 
@@ -50,7 +51,7 @@ extern void *_heap_sentry;
 static unsigned char *heap_base = UINT_TO_POINTER(USED_RAM_END_ADDR);
 #endif /* CONFIG_NEWLIB_LIBC_ALIGNED_HEAP_SIZE */
 
-static unsigned int heap_sz;
+_app_bmem(libc) static unsigned int heap_sz;
 
 static int _stdout_hook_default(int c)
 {

--- a/samples/userspace/shared_mem/src/main.c
+++ b/samples/userspace/shared_mem/src/main.c
@@ -27,9 +27,9 @@
  */
 
 /* prepare the memory partition structures  */
-FOR_EACH(appmem_partition, part0, part1, part2, part3, part4);
+APPMEM_PARTITION_OBJECT_DEFINE(part0, part1, part2, part3, part4);
 /* prepare the memory domain structures  */
-FOR_EACH(appmem_domain, dom0, dom1, dom2);
+APPMEM_DOMAIN_OBJECT_DEFINE(dom0, dom1, dom2);
 /* each variable starts with a name defined in main.h
  * the names are symbolic for the memory partitions
  * purpose.
@@ -104,7 +104,7 @@ void main(void)
 
 	k_thread_access_grant(k_current_get(), &allforone);
 	/* initialize the partition structures  */
-	FOR_EACH(appmem_init_part, part0, part1, part2, part3, part4);
+	APPMEM_INIT_PARTITIONS(part0, part1, part2, part3, part4);
 
 	printk("init partitions complete\n");
 	appmem_init_app_memory();

--- a/samples/userspace/shared_mem/src/main.h
+++ b/samples/userspace/shared_mem/src/main.h
@@ -39,6 +39,9 @@ void ct(void);
 #define _app_ct_d _app_dmem(part4)
 #define _app_ct_b _app_bmem(part4)
 
+APPMEM_DOMAIN_HEADER_DEFINE(dom0, dom1, dom2);
+APPMEM_PARTITION_HEADER_DEFINE(part0, part1, part2, part3, part4);
+
 /*
  * Constant
  */

--- a/scripts/gen_app_partitions.py
+++ b/scripts/gen_app_partitions.py
@@ -21,12 +21,26 @@ print_template = """
 		/* Auto generated code do not modify */
 		SMEM_PARTITION_ALIGN(data_smem_{0}_bss_end - data_smem_{0}_data_start);
 		data_smem_{0}_data_start = .;
-		KEEP(*(data_smem_{0}))
+		KEEP(*(data_smem_{0}_data))
 		data_smem_{0}_bss_start = .;
-		KEEP(*(data_smem_{0}b))
+		KEEP(*(data_smem_{0}_bss))
 		SMEM_PARTITION_ALIGN(data_smem_{0}_bss_end - data_smem_{0}_data_start);
 		data_smem_{0}_bss_end = .;
 """
+#code for library functions. that need to placed in partitions.
+print_template_libc = """
+		/* Auto generated code do not modify */
+		SMEM_PARTITION_ALIGN(data_smem_{0}_bss_end - data_smem_{0}_data_start);
+		data_smem_{0}_data_start = .;
+		*{0}.a:*(.data .data.*)
+		KEEP(*(data_smem_{0}_data))
+		data_smem_{0}_bss_start = .;
+		*{0}.a:*(.bss .bss.* COMMON COMMON.*)
+		KEEP(*(data_smem_{0}_bss))
+		SMEM_PARTITION_ALIGN(data_smem_{0}_bss_end - data_smem_{0}_data_start);
+		data_smem_{0}_bss_end = .;
+"""
+
 linker_start_seq = """
 	SECTION_PROLOGUE(_APP_SMEM_SECTION_NAME, (OPTIONAL),)
 	{
@@ -57,7 +71,9 @@ def find_partitions(filename, full_list_of_partitions, partitions_source_file):
         sections = [ x for x in full_lib.iter_sections()]
         for section in sections:
             if ("smem" in  section.name and not ".rel" in section.name):
-                partition_name = section.name.split("data_smem_")[1]
+                partition_name = section.name.split("data_smem_")[1].split("_data")[0].split("_bss")[0]
+                if partition_name == "libc":
+                    continue
                 if partition_name not in full_list_of_partitions:
                     full_list_of_partitions.append(partition_name)
                     if args.verbose:
@@ -67,9 +83,10 @@ def find_partitions(filename, full_list_of_partitions, partitions_source_file):
 
 def cleanup_remove_bss_regions(full_list_of_partitions):
     for partition in full_list_of_partitions:
-        if (partition+"b" in full_list_of_partitions):
-            full_list_of_partitions.remove(partition+"b")
+        if (partition+"_bss" in full_list_of_partitions):
+            full_list_of_partitions.remove(partition+"_bss")
     return full_list_of_partitions
+
 
 def generate_final_linker(linker_file, full_list_of_partitions):
     string = linker_start_seq
@@ -77,6 +94,13 @@ def generate_final_linker(linker_file, full_list_of_partitions):
     for partition in full_list_of_partitions:
         string += print_template.format(partition)
         size_string += size_cal_string.format(partition)
+
+    # for libc we need to do a bit more linker magic to get it to
+    # work with APP_SHARED_MEM. Here we just check if libc is enabled
+    # if so we add some linker magic to get this working.
+    if(args.newlib_libc):
+        string += print_template_libc.format("libc")
+        size_string += size_cal_string.format("libc")
 
     string += linker_end_seq
     string += size_string
@@ -95,6 +119,8 @@ def parse_args():
                         help="Output ld file")
     parser.add_argument("-v", "--verbose", action="count", default =0,
                         help="Verbose Output")
+    parser.add_argument("--newlib-libc", required=False, action='store_true',
+                        help="Newlib specific code is included")
     args = parser.parse_args()
 
 

--- a/subsys/app_memory/app_memdomain.c
+++ b/subsys/app_memory/app_memdomain.c
@@ -13,7 +13,7 @@ sys_dlist_t app_mem_list = SYS_DLIST_STATIC_INIT(&app_mem_list);
  * The following zeroizes each "bss" part of each subsection
  * as per the entries in the list.
  */
-void app_bss_zero(void)
+static inline void app_bss_zero(void)
 {
 	sys_dnode_t *node, *next_node;
 
@@ -22,67 +22,6 @@ void app_bss_zero(void)
 		struct app_region *region =
 			CONTAINER_OF(node, struct app_region, lnode);
 		(void)memset(region->bmem_start, 0, region->bmem_size);
-	}
-}
-
-/*
- * The following calculates the size of each subsection and adds
- * the computed sizes to the region structures. These calculations
- * are needed both for zeroizing "bss" parts of the partitions and
- * for the creation of the k_mem_partition.
- */
-void app_calc_size(void)
-{
-	sys_dnode_t *node, *next_node;
-
-	SYS_DLIST_FOR_EACH_NODE_SAFE(&app_mem_list, node, next_node)
-	{
-#ifndef CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
-		if (sys_dlist_is_tail(&app_mem_list, node)) {
-			struct app_region *region =
-				CONTAINER_OF(node, struct app_region, lnode);
-			region->bmem_size =
-				_app_smem_end -
-				(char *)region->bmem_start;
-			region->dmem_size =
-				(char *)region->bmem_start -
-				(char *)region->dmem_start;
-			region->smem_size =
-				region->bmem_size + region->dmem_size;
-			region->partition[0].size =
-				region->dmem_size + region->bmem_size;
-		} else {
-			struct app_region *region =
-				CONTAINER_OF(node, struct app_region, lnode);
-			struct app_region *nRegion =
-				CONTAINER_OF(next_node, struct app_region,
-					lnode);
-			region->bmem_size =
-				(char *)nRegion->dmem_start -
-				(char *)region->bmem_start;
-			region->dmem_size =
-				(char *)region->bmem_start -
-				(char *)region->dmem_start;
-			region->smem_size =
-				region->bmem_size + region->dmem_size;
-			region->partition[0].size =
-				region->dmem_size + region->bmem_size;
-		}
-
-#else
-		/* For power of 2 MPUs linker provides support to help us
-		 * calculate the region sizes.
-		 */
-		struct app_region *region =
-				CONTAINER_OF(node, struct app_region, lnode);
-
-		region->dmem_size = (char *)region->bmem_start -
-			(char *)region->dmem_start;
-		region->bmem_size = (char *)region->smem_size -
-			(char *)region->dmem_size;
-
-		region->partition[0].size = (s32_t)region->smem_size;
-#endif	/* CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT */
 	}
 }
 
@@ -102,7 +41,6 @@ void appmem_init_app_memory(void)
 	arc_core_mpu_disable();
 #endif
 
-	app_calc_size();
 	app_bss_zero();
 
 #ifdef CONFIG_ARC

--- a/subsys/app_memory/app_memdomain.c
+++ b/subsys/app_memory/app_memdomain.c
@@ -92,6 +92,21 @@ void app_calc_size(void)
  */
 void appmem_init_app_memory(void)
 {
+#ifdef CONFIG_ARC
+	/*
+	 * appmem_init_app_memory will access all partitions
+	 * For CONFIG_ARC_MPU_VER == 3, these partitions are not added
+	 * into MPU now, so need to disable mpu first to do app_bss_zero()
+	 */
+	extern void arc_core_mpu_disable(void);
+	arc_core_mpu_disable();
+#endif
+
 	app_calc_size();
 	app_bss_zero();
+
+#ifdef CONFIG_ARC
+	extern void arc_core_mpu_enable(void);
+	arc_core_mpu_enable();
+#endif
 }


### PR DESCRIPTION
Gist of the changes. 

1. Added new macros. Which makes this feature more feasible to real use cases.
2.  Optimized calculation of partition sizes. Now all calculation are given by linker.
3. app_smem.ld is used by default on all architectures that support userspace.
4.  Fixed a few bugs in the code.
5.  Data/bss of libc comes in as a partition, which can be configured like any other partitions.
6. Updated the test and sample for app_smem.

cleanup patches taken from the PR. #11896. The test cases and use cases are still in the other PR.