### PR TITLE
samples: bluetooth: Make ECC thread params configurable

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -512,6 +512,22 @@ config BT_TINYCRYPT_ECC
 	  to enabled for a combined build with Zephyr's own controller, since it
 	  does not have any special ECC support itself (at least not currently).
 
+if BT_TINYCRYPT_ECC
+config BT_ECC_THREAD_STACK_SIZE
+	int "Size of the ecc thread stack"
+	default 1100
+	range 512 65536
+	help
+	  Size of the ecc thread stack.
+
+config BT_ECC_THREAD_PRIO
+	int "Priority of ecc thread"
+	default 10
+	help
+	  Priority at which the ecc thread runs.
+
+endif #BT_TINYCRYPT_ECC
+
 if BT_DEBUG
 config BT_DEBUG_SETTINGS
 	bool "Bluetooth storage debug"

--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -36,7 +36,7 @@
 #endif
 
 static struct k_thread ecc_thread_data;
-static K_THREAD_STACK_DEFINE(ecc_thread_stack, 1100);
+static K_THREAD_STACK_DEFINE(ecc_thread_stack, CONFIG_BT_ECC_THREAD_STACK_SIZE);
 
 /* based on Core Specification 4.2 Vol 3. Part H 2.3.5.6.1 */
 static const u32_t debug_private_key[8] = {
@@ -321,6 +321,7 @@ void bt_hci_ecc_init(void)
 {
 	k_thread_create(&ecc_thread_data, ecc_thread_stack,
 			K_THREAD_STACK_SIZEOF(ecc_thread_stack), ecc_thread,
-			NULL, NULL, NULL, K_PRIO_PREEMPT(10), 0, K_NO_WAIT);
+			NULL, NULL, NULL, CONFIG_BT_ECC_THREAD_PRIO, 0,
+			K_NO_WAIT);
 	k_thread_name_set(&ecc_thread_data, "BT ECC");
 }


### PR DESCRIPTION
Make ECC thread stack size and priority configurable.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>