### PR TITLE
boards: arm: nrf52840_blip: Documentation and DTS fixes

### DIFF
--- a/boards/arm/nrf52840_blip/doc/nrf52840_blip.rst
+++ b/boards/arm/nrf52840_blip/doc/nrf52840_blip.rst
@@ -91,8 +91,8 @@ LED
 ---
 
 * LED1 (green) = P0.13
-* LED2 (green) = P0.14
-* LED3 (green) = P0.15
+* LED2 (red)   = P0.14
+* LED3 (blue)  = P0.15
 
 Push buttons
 ------------

--- a/boards/arm/nrf52840_blip/dts_fixup.h
+++ b/boards/arm/nrf52840_blip/dts_fixup.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2019 Tavish Naruka <tavishnaruka@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* This file is a temporary workaround for mapping of the generated information
+ * to the current driver definitions.  This will be removed when the drivers
+ * are modified to handle the generated information, or the mapping of
+ * generated data matches the driver definitions.
+ */
+
+#define DT_DISK_SDHC0_BUS_ADDRESS			DT_NORDIC_NRF_SPI_40004000_ZEPHYR_MMC_SPI_SLOT_0_BASE_ADDRESS
+#define DT_DISK_SDHC0_BUS_NAME				DT_NORDIC_NRF_SPI_40004000_ZEPHYR_MMC_SPI_SLOT_0_BUS_NAME
+#define DT_DISK_SDHC0_CS_GPIOS_CONTROLLER		SPI_1_CS_GPIOS_CONTROLLER
+#define DT_DISK_SDHC0_CS_GPIOS_PIN			SPI_1_CS_GPIOS_PIN

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -96,16 +96,16 @@
 
 &spi0 {
 	status = "ok";
-	sck-pin = <25>;
-	mosi-pin = <34>;
-	miso-pin = <24>;
+	sck-pin = <19>;
+	mosi-pin = <20>;
+	miso-pin = <21>;
 };
 
 &spi1 {
 	status = "ok";
-	sck-pin = <19>;
-	mosi-pin = <20>;
-	miso-pin = <21>;
+	sck-pin = <25>;
+	mosi-pin = <34>;
+	miso-pin = <24>;
 };
 
 &spi2 {


### PR DESCRIPTION
The pins connected to the sensors and microsd card on board
were mapped to SPI_0 and I2C_0, but for nrf52 chips they
cannot both be used together. Added dts_fixup.h to enable
the use of SDHC driver for using microSD slot on board.

LED colors in documentation were incorrect.

Blip is yet unreleased, so change will not affect anyone really.