### PR TITLE
sanitycheck: Error out when running sanitycheck from Windows

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -159,11 +159,17 @@ Most everyday users will run with no arguments.
 
 """
 
+import os
+
+if os.name == 'nt':
+    print("Running sanitycheck on Windows is not supported yet.")
+    print("https://github.com/zephyrproject-rtos/zephyr/issues/2664")
+    exit(1)
+
 import contextlib
 import string
 import mmap
 import argparse
-import os
 import sys
 import re
 import subprocess


### PR DESCRIPTION
Running sanitycheck from Windows is not supported yet. Unfortunately,
the error message is obscure when a user is unaware of this and runs
it from Windows anyway.

This patch gives an easy to understand error message explaining this
issue.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>