### PR TITLE
ext: lib: crypto: Extend generic mbedTLS config

### DIFF
--- a/ext/lib/crypto/mbedtls/Kconfig.tls-generic
+++ b/ext/lib/crypto/mbedtls/Kconfig.tls-generic
@@ -175,6 +175,11 @@ config MBEDTLS_CIPHER_AES_ENABLED
 	bool "Enable the AES block cipher"
 	default y
 
+config MBEDTLS_AES_ROM_TABLES
+	depends on MBEDTLS_CIPHER_AES_ENABLED
+	bool "Use precomputed AES tables stored in ROM."
+	default y
+
 config MBEDTLS_CIPHER_CAMELLIA_ENABLED
 	bool "Enable the Camellia block cipher"
 

--- a/ext/lib/crypto/mbedtls/configs/config-tls-generic.h
+++ b/ext/lib/crypto/mbedtls/configs/config-tls-generic.h
@@ -118,6 +118,10 @@
 #define MBEDTLS_AES_C
 #endif
 
+#if defined(CONFIG_MBEDTLS_AES_ROM_TABLES)
+#define MBEDTLS_AES_ROM_TABLES
+#endif
+
 #if defined(CONFIG_MBEDTLS_CIPHER_CAMELLIA_ENABLED)
 #define MBEDTLS_CAMELLIA_C
 #endif


### PR DESCRIPTION
Extend generic mbedTLS configuration file with MBEDTLS_AES_ROM_TABLES
option. This allows to save some RAM (~8kB) in favour of ROM and
performance.

Resolves #12601.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>