### PR TITLE
samples: crypto: Fix mbedtls benchmark time calculations

### DIFF
--- a/samples/crypto/mbedtls_benchmark/sample.yaml
+++ b/samples/crypto/mbedtls_benchmark/sample.yaml
@@ -6,4 +6,4 @@ sample:
   name: mbedTLS Benchmark
 tests:
   test:
-    platform_whitelist: qemu_x86 frdm_k64f sam_e70_xplained
+    platform_whitelist: qemu_x86 frdm_k64f sam_e70_xplained nrf52840_pca10056

--- a/samples/crypto/mbedtls_benchmark/src/benchmark.c
+++ b/samples/crypto/mbedtls_benchmark/src/benchmark.c
@@ -159,7 +159,7 @@ void mbedtls_set_alarm(int seconds)
 do {                                                                  \
 	unsigned long ii, jj;                                         \
 	u32_t tsc;                                                    \
-	u32_t delta;                                                  \
+	u64_t delta;                                                  \
 	int ret = 0;                                                  \
 								      \
 	mbedtls_printf(HEADER_FORMAT, TITLE);                         \
@@ -179,7 +179,7 @@ do {                                                                  \
 	}                                                             \
 								      \
 	delta = k_cycle_get_32() - tsc;                               \
-	delta = SYS_CLOCK_HW_CYCLES_TO_NS(delta);                     \
+	delta = SYS_CLOCK_HW_CYCLES_TO_NS64(delta);                   \
 								      \
 	mbedtls_printf("%9lu KiB/s,  %9lu ns/byte\n",                 \
 		       ii * BUFSIZE / 1024,                           \


### PR DESCRIPTION
mbedTLS benchmark used 32-bit arithmetics for time calculations
(nanosecond resolution), which could overflow on slower platforms
on more time-consuming benchmark tests. In result, the benchmark
could give incorrect timing information. Using 64-bit arithmetics
prevents this issue.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>