### PR TITLE
doc: eliminate doc build missing image warning

### DIFF
--- a/doc/documentation/doc-guidelines.rst
+++ b/doc/documentation/doc-guidelines.rst
@@ -390,13 +390,13 @@ Images
 
 Images are included in documentation by using an image directive::
 
-   .. image:: images/mypicture.jpg
+   .. image:: ../images/doc-gen-flow.png
       :align: center
       :alt: alt text for the image
 
 or if you'd like to add an image caption, use::
 
-    .. figure:: images/mypicture.jpg
+    .. figure:: ../images/doc-gen-flow.png
        :alt: image description
 
        Caption for the figure


### PR DESCRIPTION
Out-of-tree doc builds rely on extract__content.py to copy needed
content from the source folders to the build folders. To minimize what's
copied, all the reST files are copied plus files referenced by the reST
files.  The extract_content.py script does a pattern match scan for
directives that reference other files (e.g., .. image::) and copies the
referenced file.  It's not a smart parser though and doesn't ignore
directives in comments or in code-blocks.  Rather than teaching the
script how to properly parse reST files, we'll just change the example
(in a code-block) to reference an existing image.

Fixes: #12621

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>