### PR TITLE
ext: debug: segger: Missing SEGGER_RTT_printf function

### DIFF
--- a/ext/debug/segger/CMakeLists.txt
+++ b/ext/debug/segger/CMakeLists.txt
@@ -3,6 +3,7 @@ zephyr_include_directories_ifdef(CONFIG_USE_SEGGER_RTT rtt)
 zephyr_sources_ifdef(CONFIG_USE_SEGGER_RTT
 	rtt/SEGGER_RTT.c
 	rtt/SEGGER_RTT_zephyr.c
+	rtt/SEGGER_RTT_printf.c
 	)
 zephyr_include_directories_ifdef(CONFIG_SEGGER_SYSTEMVIEW systemview)
 zephyr_sources_ifdef(CONFIG_SEGGER_SYSTEMVIEW systemview/SEGGER_SYSVIEW.c)


### PR DESCRIPTION
Fixed the file ext/debug/segger/CMakeLists.txt to include the file rtt/SEGGER_RTT_printf.c 
to be compiled when CONFIG_USE_SEGGER_RTT=y to be able to use the function 
SEGGER_RTT_printf

Signed-off-by: Gustavo F Nobrega <gustavofn@gmail.com>