### PR TITLE
doc: turbo mode for kconfig options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,8 @@ SPHINXOPTS ?= -q
 htmldocs:
 	mkdir -p ${BUILDDIR} && cmake -GNinja -DDOC_TAG=${DOC_TAG} -DSPHINXOPTS=${SPHINXOPTS} -B${BUILDDIR} -Hdoc/ && ninja -C ${BUILDDIR} htmldocs
 
+htmldocs-fast:
+	mkdir -p ${BUILDDIR} && cmake -GNinja -DKCONFIG_TURBO_MODE=1 -DDOC_TAG=${DOC_TAG} -DSPHINXOPTS=${SPHINXOPTS} -B${BUILDDIR} -Hdoc/ && ninja -C ${BUILDDIR} htmldocs
+
 pdfdocs:
 	mkdir -p ${BUILDDIR} && cmake -GNinja -DDOC_TAG=${DOC_TAG} -DSPHINXOPTS=${SPHINXOPTS} -B${BUILDDIR} -Hdoc/ && ninja -C ${BUILDDIR} pdfdocs

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -144,6 +144,7 @@ add_custom_target(
   ARCH=*
   SOC_DIR=soc/
   SRCARCH=x86
+  KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
   ${PYTHON_EXECUTABLE} scripts/genrest.py Kconfig ${RST_OUT}/doc/reference/kconfig/
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -212,6 +212,28 @@ them out as "expected" warnings by adding a conf file to the
 ``.known-issues/doc`` folder, following the example of other conf files
 found there.
 
+Developer-mode Document Building
+********************************
+
+Building the documentation for all the Kconfig options significantly
+adds to the total doc build time.  When making and testing major changes
+to the documentation, we provide an option to temporarily stub-out
+the auto-generated configuration documentation so the doc build process
+runs much faster.
+
+To enable this mode, set the following option when invoking cmake::
+
+   -DKCONFIG_TURBO_MODE=1
+
+or invoke make with the following target::
+
+   cd ~/zephyr
+   source zephyr-env.sh
+
+   # To generate HTML output without detailed Kconfig
+   make htmldocs-fast
+
+
 .. _reStructuredText: http://sphinx-doc.org/rest.html
 .. _Sphinx: http://sphinx-doc.org/
 .. _Windows Python Path: https://docs.python.org/3/using/windows.html#finding-the-python-executable


### PR DESCRIPTION
Building the complete documentation is a time consuming task due to the amount
of auto-generated pages we create during the documentation build process. When
making major changes to the documentation and rebuilding the documentation very
often it is possible to skip the Kconfig option generation and just enable
generation empty option definition to satisfy references. 

To build in turbo mode, use

  `make htmldocs-fast`