### PR TITLE
drivers: stm32: fix the STM32F1 series gpio configuration

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -78,7 +78,7 @@ static inline u32_t stm32_pinval_get(int pin)
 	if (pin < 8) {
 		pinval |= 1 << pin;
 	} else {
-		pinval |= (1 << pin) | 0x04000000;
+		pinval |= (1 << (pin % 8)) | 0x04000000;
 	}
 #else
 	pinval = 1 << pin;


### PR DESCRIPTION
This patch fix the STM32F1 series gpio configuration issue
for the pin number large than 7.

Fixes #12594

Signed-off-by: Harry Jiang <explora26@gmail.com>