### PR TITLE
doc: api: Reference MQTT over sockets library

### DIFF
--- a/doc/api/networking.rst
+++ b/doc/api/networking.rst
@@ -195,7 +195,7 @@ DHCPv4
 MQTT 3.1.1
 ==========
 
-.. doxygengroup:: mqtt
+.. doxygengroup:: mqtt_socket
    :project: Zephyr
 
 CoAP over Sockets


### PR DESCRIPTION
The MQTT over sockets doxygen group was not referenced, hence the API
documentation was missing. Replace legacy MQTT lib reference with a new
one.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>