### PR TITLE
Fix build error when CONFIG_ETH_ENC28J60_0_GPIO_SPI_CS=y

### DIFF
--- a/dts/bindings/ethernet/microchip,enc28j60.yaml
+++ b/dts/bindings/ethernet/microchip,enc28j60.yaml
@@ -22,4 +22,8 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
+    cs-gpios:
+      type: compound
+      category: optional
+      generation: define, use-prop-name
 ...


### PR DESCRIPTION
drivers: eth: enc28j60: Fix build error when CONFIG_ETH_ENC28J60_0_GPIO_SPI_CS=y

microchip,enc28j60.yaml can't create CS define.
Add rule for create DT_MICROCHIP_ENC28J60_0_CS_GPIOS_ .

Fixed #12640

Signed-off-by: Frank Li <lgl88911@163.com>