### PR TITLE
doc: add extension to handle HTML redirects

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'sphinx.ext.extlinks',
     'sphinx.ext.autodoc',
     'zephyr.application',
+    'zephyr.html_redirects',
     'only.eager_only'
 ]
 
@@ -260,6 +261,13 @@ sourcelink_suffix = '.txt'
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'zephyrdoc'
 
+
+# Custom added feature to allow redirecting old URLs
+#
+# list of tuples (old_url, new_url) for pages to redirect
+# (URLs should be relative to document root, only)
+html_redirect_pages = [('contribute/contribute_guidelines', 'contribute/index'),]
+
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
@@ -369,6 +377,7 @@ html_context = {
                  ("1.9.2", "/1.9.0/"),
                 )
 }
+
 
 extlinks = {'jira': ('https://jira.zephyrproject.org/browse/%s', ''),
             'github': ('https://github.com/zephyrproject-rtos/zephyr/issues/%s', '')

--- a/doc/extensions/zephyr/html_redirects.py
+++ b/doc/extensions/zephyr/html_redirects.py
@@ -1,0 +1,69 @@
+# Copyright 2018-2019 Espressif Systems (Shanghai) PTE LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# Mechanism to generate static HTML redirect pages in the output
+#
+# Uses redirect_template.html and the list of pages given in
+# conf.html_redirect_pages
+#
+# Adapted from ideas in https://tech.signavio.com/2017/managing-sphinx-redirects
+import os.path
+
+from sphinx.builders.html import StandaloneHTMLBuilder
+
+REDIRECT_TEMPLATE = """
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=$NEWURL" />
+    <script>
+      window.location.href = "$NEWURL"
+    </script>
+  </head>
+  <body>
+  <p>Page has moved <a href="$NEWURL">here</a>.</p>
+  </body>
+</html>
+"""
+
+
+def setup(app):
+    app.add_config_value('html_redirect_pages', [], 'html')
+    app.connect('build-finished', create_redirect_pages)
+
+
+def create_redirect_pages(app, docname):
+    if not isinstance(app.builder, StandaloneHTMLBuilder):
+        return  # only relevant for standalone HTML output
+
+    for (old_url, new_url) in app.config.html_redirect_pages:
+        print("Creating redirect %s to %s..." % (old_url, new_url))
+        if old_url.startswith('/'):
+            print("Stripping leading / from URL in config file...")
+            old_url = old_url[1:]
+
+        new_url = app.builder.get_relative_uri(old_url, new_url)
+        out_file = app.builder.get_outfilename(old_url)
+        print("HTML file %s redirects to relative URL %s" % (out_file, new_url))
+
+        out_dir = os.path.dirname(out_file)
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir)
+
+        content = REDIRECT_TEMPLATE.replace("$NEWURL", new_url)
+
+        if not os.path.exists(out_file):
+            with open(out_file, "w") as rp:
+                rp.write(content)


### PR DESCRIPTION
Handle redirects for moved pages. This extension is originally from the
ESP32 project and is maintained here:

https://github.com/espressif/esp-idf/blob/master/docs/html_redirects.py

Commit b240a181b7215158ef4db22ee7e694f938868502