### PR TITLE
nucleo_f429zi: Add JLink support for flash, modelled after nucleo_f070rb support.

### DIFF
--- a/boards/arm/nucleo_f429zi/board.cmake
+++ b/boards/arm/nucleo_f429zi/board.cmake
@@ -1,1 +1,8 @@
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+set_ifndef(STLINK_FW stlink)
+
+if(STLINK_FW STREQUAL jlink)
+  board_runner_args(jlink "--device=stm32f429zi" "--speed=4000")
+  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+elseif(STLINK_FW STREQUAL stlink)
+  include($ENV{ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+endif()


### PR DESCRIPTION
Signed-off-by: Dave Marples <dave@marples.net>
Added ability to use JLink in addition to OpenOCD for flash step via ninja/make using `-DSTLINK_FW=jlink` on cmake command line.