### PR TITLE
dts: arm: msp432p4xx: Fix memory compatible

### DIFF
--- a/dts/arm/ti/msp432p4xx.dtsi
+++ b/dts/arm/ti/msp432p4xx.dtsi
@@ -12,7 +12,7 @@
 	};
 
 	sram0: memory@20000000 {
-		compatible = "sram";
+		compatible = "mmio-sram";
 	};
 
 	flash0: serial-flash@0 {


### PR DESCRIPTION
The memory compatible should be 'mmio-sram' not 'sram'.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>