### PR TITLE
subsys/settings: fcb compress areas only once

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -251,7 +251,7 @@ static int settings_fcb_save(struct settings_store *cs, const char *name,
 	wbs = flash_area_align(cf->cf_fcb.fap);
 	len = settings_line_len_calc(name, val_len);
 
-	for (i = 0; i < CONFIG_SETTINGS_FCB_NUM_AREAS; i++) {
+	for (i = 0; i < cf->cf_fcb.f_sector_cnt - 1; i++) {
 		rc = fcb_append(&cf->cf_fcb, len, &loc.loc);
 		if (rc != FCB_ERR_NOSPACE) {
 			break;


### PR DESCRIPTION
fcb instance might use less areas than CONFIG_SETTINGS_FCB_NUM_AREAS.
During compression of completely filled up fcb it was possible to try
compress areas more than once.

What this patch fixes is not a bug - rather fix for inefficient service
of the corner case.

fixes #12657

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>