### PR TITLE
doc: tools: corrected file path in documentation

### DIFF
--- a/doc/tools/code-relocation.rst
+++ b/doc/tools/code-relocation.rst
@@ -94,7 +94,7 @@ This section shows additional configuration options that can be set in
 Sample
 ======
 A sample showcasing this feature is provided at
-``$ZEPHYR_BASE/samples/test_relocation/``
+``$ZEPHYR_BASE/samples/application_development/test_relocation/``
 
 This is an example of using the code relocation feature.
 


### PR DESCRIPTION
Corrected file path for code relocation sample path in documentation

Fix for GH #12543

Signed-off-by: Varun Sharma <varun.sharma@intel.com>