### PR TITLE
Extend util.h with macros for conditional code generation

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -285,8 +285,8 @@ char *log_strdup(const char *str);
 #else
 #define _LOG_LEVEL_RESOLVE(...) \
 	_LOG_EVAL(LOG_LEVEL, \
-		  (__LOG_ARG_2(__VA_ARGS__, LOG_LEVEL)), \
-		  (__LOG_ARG_2(__VA_ARGS__, CONFIG_LOG_DEFAULT_LEVEL)))
+		  (GET_ARG2(__VA_ARGS__, LOG_LEVEL)), \
+		  (GET_ARG2(__VA_ARGS__, CONFIG_LOG_DEFAULT_LEVEL)))
 #endif
 
 /* Return first argument */
@@ -355,7 +355,7 @@ char *log_strdup(const char *str);
 #define LOG_MODULE_REGISTER(...)					\
 	_LOG_EVAL(							\
 		_LOG_LEVEL_RESOLVE(__VA_ARGS__),			\
-		(_LOG_MODULE_DATA_CREATE(_LOG_ARG1(__VA_ARGS__),	\
+		(_LOG_MODULE_DATA_CREATE(GET_ARG1(__VA_ARGS__),		\
 				      _LOG_LEVEL_RESOLVE(__VA_ARGS__))),\
 		()/*Empty*/						\
 	)								\
@@ -389,20 +389,20 @@ char *log_strdup(const char *str);
  */
 #define LOG_MODULE_DECLARE(...)						      \
 	extern const struct log_source_const_data			      \
-			LOG_ITEM_CONST_DATA(_LOG_ARG1(__VA_ARGS__));	      \
+			LOG_ITEM_CONST_DATA(GET_ARG1(__VA_ARGS__));	      \
 	extern struct log_source_dynamic_data				      \
-			LOG_ITEM_DYNAMIC_DATA(_LOG_ARG1(__VA_ARGS__));	      \
+			LOG_ITEM_DYNAMIC_DATA(GET_ARG1(__VA_ARGS__));	      \
 									      \
 	static const struct log_source_const_data *			      \
 		__log_current_const_data __attribute__((unused)) =	      \
 			_LOG_LEVEL_RESOLVE(__VA_ARGS__) ?		      \
-			&LOG_ITEM_CONST_DATA(_LOG_ARG1(__VA_ARGS__)) : NULL;  \
+			&LOG_ITEM_CONST_DATA(GET_ARG1(__VA_ARGS__)) : NULL;   \
 									      \
 	static struct log_source_dynamic_data *				      \
 		__log_current_dynamic_data __attribute__((unused)) =	      \
 			(_LOG_LEVEL_RESOLVE(__VA_ARGS__) &&		      \
 			IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) ?	      \
-			&LOG_ITEM_DYNAMIC_DATA(_LOG_ARG1(__VA_ARGS__)) : NULL;\
+			&LOG_ITEM_DYNAMIC_DATA(GET_ARG1(__VA_ARGS__)) : NULL; \
 									      \
 	static const u32_t __log_level __attribute__((unused)) =	      \
 					_LOG_LEVEL_RESOLVE(__VA_ARGS__)

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -39,24 +39,13 @@ extern "C" {
 	_LOG_RESOLVED_LEVEL1(_level, _default)
 
 #define _LOG_RESOLVED_LEVEL1(_level, _default) \
-	__LOG_RESOLVED_LEVEL2(_LOG_XXXX##_level, _level, _default)
+	__COND_CODE(_LOG_XXXX##_level, (_level), (_default))
 
 #define _LOG_XXXX0 _LOG_YYYY,
 #define _LOG_XXXX1 _LOG_YYYY,
 #define _LOG_XXXX2 _LOG_YYYY,
 #define _LOG_XXXX3 _LOG_YYYY,
 #define _LOG_XXXX4 _LOG_YYYY,
-
-#define __LOG_RESOLVED_LEVEL2(one_or_two_args, _level, _default) \
-	__LOG_ARG_2(one_or_two_args _level, _default)
-
-#define LOG_DEBRACKET(...) __VA_ARGS__
-
-#define __LOG_ARG_1(val, ...) val
-#define __LOG_ARG_2(ignore_this, val, ...) val
-#define __LOG_ARGS_LESS1(val, ...) __VA_ARGS__
-
-#define __LOG_ARG_2_DEBRACKET(ignore_this, val, ...) LOG_DEBRACKET val
 
 /**
  * @brief Macro for conditional code generation if provided log level allows.
@@ -76,35 +65,12 @@ extern "C" {
 	_LOG_EVAL1(_eval_level, _iftrue, _iffalse)
 
 #define _LOG_EVAL1(_eval_level, _iftrue, _iffalse) \
-	_LOG_EVAL2(_LOG_ZZZZ##_eval_level, _iftrue, _iffalse)
+	__COND_CODE(_LOG_ZZZZ##_eval_level, _iftrue, _iffalse)
 
 #define _LOG_ZZZZ1 _LOG_YYYY,
 #define _LOG_ZZZZ2 _LOG_YYYY,
 #define _LOG_ZZZZ3 _LOG_YYYY,
 #define _LOG_ZZZZ4 _LOG_YYYY,
-
-#define _LOG_EVAL2(one_or_two_args, _iftrue, _iffalse) \
-	__LOG_ARG_2_DEBRACKET(one_or_two_args _iftrue, _iffalse)
-
-/**
- * @brief Macro for condition code generation.
- *
- * @param _eval Parameter evaluated against 0
- * @param _ifzero Code included if _eval is 0. Must be wrapped in brackets.
- * @param _ifnzero Code included if _eval is not  0.
- *		   Must be wrapped in brackets.
- */
-
-#define _LOG_Z_EVAL(_eval, _ifzero, _ifnzero) \
-	_LOG_Z_EVAL1(_eval, _ifzero, _ifnzero)
-
-#define _LOG_Z_EVAL1(_eval, _ifzero, _ifnzero) \
-	_LOG_Z_EVAL2(_LOG_Z_ZZZZ##_eval, _ifzero, _ifnzero)
-
-#define _LOG_Z_ZZZZ0 _LOG_Z_YYYY,
-
-#define _LOG_Z_EVAL2(one_or_two_args, _ifzero, _ifnzero) \
-	__LOG_ARG_2_DEBRACKET(one_or_two_args _ifzero, _ifnzero)
 
 /** @brief Macro for getting log level for given module.
  *
@@ -156,7 +122,7 @@ extern "C" {
 
 /**
  * @brief Macro for optional injection of function name as first argument of
- *	  formatted string. _LOG_Z_EVAL() macro is used to handle no arguments
+ *	  formatted string. COND_CODE_0() macro is used to handle no arguments
  *	  case.
  *
  *	  The purpose of this macro is to prefix string literal with format
@@ -165,10 +131,10 @@ extern "C" {
  *	  used.
  */
 
-#define _LOG_STR(...) "%s: " __LOG_ARG_1(__VA_ARGS__), __func__\
-		_LOG_Z_EVAL(NUM_VA_ARGS_LESS_1(__VA_ARGS__),\
+#define _LOG_STR(...) "%s: " GET_ARG1(__VA_ARGS__), __func__\
+		COND_CODE_0(NUM_VA_ARGS_LESS_1(__VA_ARGS__),\
 			    (),\
-			    (, __LOG_ARGS_LESS1(__VA_ARGS__))\
+			    (, GET_ARGS_LESS_1(__VA_ARGS__))\
 			   )
 
 

--- a/include/misc/util.h
+++ b/include/misc/util.h
@@ -201,6 +201,91 @@ static inline s64_t arithmetic_shift_right(s64_t value, u8_t shift)
 #define _IS_ENABLED3(ignore_this, val, ...) val
 
 /**
+ * @brief Insert code depending on result of flag evaluation.
+ *
+ * This is based on same idea as @ref IS_ENABLED macro but as the result of
+ * flag evaluation provided code is injected. Because preprocessor interprets
+ * each comma as argument boundary, code must be provided in the brackets.
+ * Brackets are stripped away during macro processing.
+ *
+ * Usage example:
+ *
+ * #define MACRO(x) COND_CODE_1(CONFIG_FLAG, (u32_t x;), ())
+ *
+ * It can be considered as alternative to:
+ *
+ * #if defined(CONFIG_FLAG) && (CONFIG_FLAG == 1)
+ * #define MACRO(x) u32_t x;
+ * #else
+ * #define MACRO(x)
+ * #endif
+ *
+ * However, the advantage of that approach is that code is resolved in place
+ * where it is used while \#if method resolves given macro when header is
+ * included and product is fixed in the given scope.
+ *
+ * @note Flag can also be a result of preprocessor output e.g.
+ *	 product of NUM_VA_ARGS_LESS_1(...).
+ *
+ * @param _flag		Evaluated flag
+ * @param _if_1_code	Code used if flag exists and equal 1. Argument must be
+ *			in brackets.
+ * @param _else_code	Code used if flag doesn't exists or isn't equal 1.
+ *
+ */
+#define COND_CODE_1(_flag, _if_1_code, _else_code) \
+	_COND_CODE_1(_flag, _if_1_code, _else_code)
+
+#define _COND_CODE_1(_flag, _if_1_code, _else_code) \
+	__COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
+
+/**
+ * @brief Insert code depending on result of flag evaluation.
+ *
+ * See @ref COND_CODE_1 for details.
+ *
+ * @param _flag		Evaluated flag
+ * @param _if_0_code	Code used if flag exists and equal 0. Argument must be
+ *			in brackets.
+ * @param _else_code	Code used if flag doesn't exists or isn't equal 0.
+ *
+ */
+#define COND_CODE_0(_flag, _if_0_code, _else_code) \
+	_COND_CODE_0(_flag, _if_0_code, _else_code)
+
+#define _COND_CODE_0(_flag, _if_0_code, _else_code) \
+	__COND_CODE(_ZZZZ##_flag, _if_0_code, _else_code)
+
+#define _ZZZZ0 _YYYY,
+
+/* Macro used internally by @ref COND_CODE_1 and @ref COND_CODE_0. */
+#define __COND_CODE(one_or_two_args, _if_code, _else_code) \
+	__GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
+
+/* Macro used internally to remove brackets from argument. */
+#define __DEBRACKET(...) __VA_ARGS__
+
+/* Macro used internally for getting second argument and removing brackets
+ * around that argument. It is expected that parameter is provided in brackets
+ */
+#define __GET_ARG2_DEBRACKET(ignore_this, val, ...) __DEBRACKET val
+
+/**
+ * @brief Get first argument from variable list of arguments
+ */
+#define GET_ARG1(arg1, ...) arg1
+
+/**
+ * @brief Get second argument from variable list of arguments
+ */
+#define GET_ARG2(arg1, arg2, ...) arg2
+
+/**
+ * @brief Get all arguments except the first one.
+ */
+#define GET_ARGS_LESS_1(val, ...) __VA_ARGS__
+
+/**
  * Macros for doing code-generation with the preprocessor.
  *
  * Generally it is better to generate code with the preprocessor than

--- a/include/misc/util.h
+++ b/include/misc/util.h
@@ -205,20 +205,20 @@ static inline s64_t arithmetic_shift_right(s64_t value, u8_t shift)
  *
  * This is based on same idea as @ref IS_ENABLED macro but as the result of
  * flag evaluation provided code is injected. Because preprocessor interprets
- * each comma as argument boundary, code must be provided in the brackets.
+ * each comma as an argument boundary, code must be provided in the brackets.
  * Brackets are stripped away during macro processing.
  *
  * Usage example:
  *
- * #define MACRO(x) COND_CODE_1(CONFIG_FLAG, (u32_t x;), ())
+ * \#define MACRO(x) COND_CODE_1(CONFIG_FLAG, (u32_t x;), ())
  *
  * It can be considered as alternative to:
  *
- * #if defined(CONFIG_FLAG) && (CONFIG_FLAG == 1)
- * #define MACRO(x) u32_t x;
- * #else
- * #define MACRO(x)
- * #endif
+ * \#if defined(CONFIG_FLAG) && (CONFIG_FLAG == 1)
+ * \#define MACRO(x) u32_t x;
+ * \#else
+ * \#define MACRO(x)
+ * \#endif
  *
  * However, the advantage of that approach is that code is resolved in place
  * where it is used while \#if method resolves given macro when header is

--- a/tests/misc/util/CMakeLists.txt
+++ b/tests/misc/util/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.13.1)
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(util)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/misc/util/prj.conf
+++ b/tests/misc/util/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/misc/util/src/main.c
+++ b/tests/misc/util/src/main.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ztest.h>
+#include <misc/util.h>
+
+#define TEST_DEFINE_1 1
+#define TEST_DEFINE_0 0
+
+void test_COND_CODE_1(void)
+{
+	/* Test validates that expected code has been injected. Failure would
+	 * be seen in compilation (lack of variable or ununsed variable.
+	 */
+	COND_CODE_1(1, (u32_t x0 = 1;), (u32_t y0;))
+	zassert_true((x0 == 1), NULL);
+
+	COND_CODE_1(NOT_EXISTING_DEFINE, (u32_t x1 = 1;), (u32_t y1 = 1;))
+	zassert_true((y1 == 1), NULL);
+
+	COND_CODE_1(TEST_DEFINE_1, (u32_t x2 = 1;), (u32_t y2 = 1;))
+	zassert_true((x2 == 1), NULL);
+
+	COND_CODE_1(2, (u32_t x3 = 1;), (u32_t y3 = 1;))
+	zassert_true((y3 == 1), NULL);
+}
+
+void test_COND_CODE_0(void)
+{
+	/* Test validates that expected code has been injected. Failure would
+	 * be seen in compilation (lack of variable or ununsed variable.
+	 */
+	COND_CODE_0(0, (u32_t x0 = 1;), (u32_t y0;))
+	zassert_true((x0 == 1), NULL);
+
+	COND_CODE_0(NOT_EXISTING_DEFINE, (u32_t x1 = 1;), (u32_t y1 = 1;))
+	zassert_true((y1 == 1), NULL);
+
+	COND_CODE_0(TEST_DEFINE_0, (u32_t x2 = 1;), (u32_t y2 = 1;))
+	zassert_true((x2 == 1), NULL);
+
+	COND_CODE_0(2, (u32_t x3 = 1;), (u32_t y3 = 1;))
+	zassert_true((y3 == 1), NULL);
+}
+
+/*test case main entry*/
+void test_main(void)
+{
+	ztest_test_suite(test_ringbuffer_api,
+			 ztest_unit_test(test_COND_CODE_1),
+			 ztest_unit_test(test_COND_CODE_0)
+			 );
+	ztest_run_test_suite(test_ringbuffer_api);
+}

--- a/tests/misc/util/testcase.yaml
+++ b/tests/misc/util/testcase.yaml
@@ -1,0 +1,3 @@
+tests:
+  util_test:
+    tags: util


### PR DESCRIPTION
Some macros that were in log_core.h for a while are in fact generic and can be moved to util.h. Some macros are obvious once (GET_ARGx) and some are more tricky (COND_CODE_x). COND_CODE macros are based on the same principle as IS_ENABLED but is used for different purpose.

PR contains 3 commits:
- adding new macros to util.h
- adding test for new macros
- cleaning up logger headers to use macros util.h
