### PR TITLE
kconfig: Removed prompt for TEXT_SECTION_OFFSET when MCUboot is used

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -109,7 +109,8 @@ config FLASH_LOAD_SIZE
 endif
 
 config TEXT_SECTION_OFFSET
-	hex "TEXT section offset"
+	hex
+	prompt "TEXT section offset" if !BOOTLOADER_MCUBOOT
 	default 0x200 if BOOTLOADER_MCUBOOT
 	default 0
 	help


### PR DESCRIPTION
When this syntax is used for the type definition:

hex "TEXT section offset"

Kconfig expect the user to enter the value for TEXT_SECTION_OFFSET and
the defaut value for BOOTLOADER_MCUBOOT is not used. Changing the syntax
to this:

hex
	prompt "TEXT section offset" if !BOOTLOADER_MCUBOOT

will tell Kconfig that TEXT_SECTION_OFFSET will not be set by the user
when BOOTLOADER_MCUBOOT is set and then Kconfig will use the default
value.

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>