### PR TITLE
shell: Add support for notifying about dropped logs

### DIFF
--- a/include/shell/shell_log_backend.h
+++ b/include/shell/shell_log_backend.h
@@ -27,7 +27,7 @@ enum shell_log_backend_state {
 
 /** @brief Shell log backend control block (RW data). */
 struct shell_log_backend_control_block {
-	atomic_t cnt;
+	atomic_t dropped_cnt;
 	enum shell_log_backend_state state;
 };
 


### PR DESCRIPTION
Extended shell log backend to print warning message on dropped
log messages.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>