### PR TITLE
Some DT cleanups on NXP SoCs

### DIFF
--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -308,7 +308,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			cs = <&gpiob 10 0>, <&gpiob 9 0>;
 			pinctrl-0 = <&spi0_default>;
 			pinctrl-names = "default";
 		};

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -253,7 +253,6 @@
 			label = "SPI_1";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 13>;
 
-			cs-gpios = <&gpiob 10 0>;
 			pinctrl-0 = <&spi1_default>;
 			pinctrl-names = "default";
 			#address-cells = <1>;

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -192,7 +192,6 @@
 			label = "SPI_0";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 12>;
 
-			cs = <&gpiob 18 0>, <&gpiob 17 0>;
 			pinctrl-0 = <&spi0_default>;
 			pinctrl-names = "default";
 			#address-cells = <1>;

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -195,7 +195,6 @@
 			label = "SPI_0";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 12>;
 
-			cs = <&gpiob 18 0>, <&gpiob 17 0>;
 			pinctrl-0 = <&spi0_default>;
 			pinctrl-names = "default";
 			#address-cells = <1>;

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -303,9 +303,9 @@
 			};
 		};
 
-		trng: random@400CC000 {
+		trng: random@400cc000 {
 			compatible = "nxp,kinetis-trng";
-			reg = <0x400CC000 0x4000>;
+			reg = <0x400cc000 0x4000>;
 			status = "ok";
 			interrupts = <53 0>;
 			label = "TRNG";


### PR DESCRIPTION
* Cleanup dtc warning on i.mx-RT
* Cleanup stale 'cs' property on K-series
* Remove unused cs-gpios on kw2xd