### PR TITLE
boards: arm: mimxrt*_evk: boot cleanups

### DIFF
--- a/boards/arm/mimxrt1020_evk/Kconfig
+++ b/boards/arm/mimxrt1020_evk/Kconfig
@@ -15,6 +15,7 @@ config CODE_ITCM
 
 config CODE_QSPI
 	depends on BOARD_MIMXRT1020_EVK
+	select NXP_IMX_RT_BOOT_HEADER
 	bool "Link code into external QSPI memory"
 
 endchoice

--- a/boards/arm/mimxrt1050_evk/Kconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig
@@ -15,10 +15,12 @@ config CODE_ITCM
 
 config CODE_HYPERFLASH
 	depends on BOARD_MIMXRT1050_EVK
+	select NXP_IMX_RT_BOOT_HEADER
 	bool "Link code into external HyperFlash memory"
 
 config CODE_QSPI
 	depends on BOARD_MIMXRT1050_EVK_QSPI
+	select NXP_IMX_RT_BOOT_HEADER
 	bool "Link code into external QSPI memory"
 
 endchoice

--- a/boards/arm/mimxrt1060_evk/Kconfig
+++ b/boards/arm/mimxrt1060_evk/Kconfig
@@ -15,10 +15,12 @@ config CODE_ITCM
 
 config CODE_HYPERFLASH
 	depends on BOARD_MIMXRT1060_EVK_HYPERFLASH
+	select NXP_IMX_RT_BOOT_HEADER
 	bool "Link code into external HyperFlash memory"
 
 config CODE_QSPI
 	depends on BOARD_MIMXRT1060_EVK
+	select NXP_IMX_RT_BOOT_HEADER
 	bool "Link code into external QSPI memory"
 
 endchoice

--- a/boards/arm/mimxrt1064_evk/Kconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig
@@ -14,6 +14,7 @@ config CODE_ITCM
 	bool "Link code into internal instruction tightly coupled memory (ITCM)"
 
 config CODE_INTERNAL_QSPI
+	select NXP_IMX_RT_BOOT_HEADER
 	bool "Link code into internal QSPI memory"
 
 endchoice

--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -10,13 +10,6 @@ if BOARD_MIMXRT1064_EVK
 config BOARD
 	default "mimxrt1064_evk"
 
-if CODE_INTERNAL_QSPI
-
-config NXP_IMX_RT_BOOT_HEADER
-	def_bool y
-
-endif
-
 if GPIO_MCUX_IGPIO
 
 config GPIO_MCUX_IGPIO_1

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -63,11 +63,7 @@
 	w25q32jvwj0: w25q32jvwj@0 {
 		compatible = "winbond,w25q32jvwj", "jedec,spi-nor";
 		reg = <0>;
-#if defined(CONFIG_CODE_INTERNAL_QSPI)
 		status = "ok";
-#else
-		status = "disabled";
-#endif
 	};
 };
 


### PR DESCRIPTION
Enable CONFIG_NXP_IMX_RT_BOOT_HEADER in Kconfig for all mimxrt*_evk boards if we are booting from one of the "external" memories (Qspi, hyperflash)

Also cleaned up the 1064 to always enable the QSPI regardless of what memory we are booting from.
