### PR TITLE
requirements: update to pyocd 0.15.0

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -10,7 +10,7 @@ ply==3.10
 hub==2.0
 gitlint
 pyelftools==0.24
-pyocd==0.14.3
+pyocd==0.15.0
 pyserial
 pykwalify
 # "win32" is used for 64-bit Windows as well


### PR DESCRIPTION
Previous release had some issues with unicode and was failing to install
in our CI. Those issues were fixed in this release.