### PR TITLE
riscv32: linker: Link .srodata section

### DIFF
--- a/include/arch/riscv32/common/linker.ld
+++ b/include/arch/riscv32/common/linker.ld
@@ -104,6 +104,8 @@ SECTIONS
     SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
 	{
 		 . = ALIGN(4);
+		 *(.srodata)
+		 *(".srodata.*")
 		 *(.rodata)
 		 *(".rodata.*")
 		 *(.gnu.linkonce.r.*)


### PR DESCRIPTION
Building tests/kernel/common/kernel.common with the new crosstools SDK-ng resulted in an orphan short read-only data section. Fix this by adding the .srodata section to the RISC-V linker script.

The kernel test builds successfully with this patch under both SDK 0.9.5 and 0.10-beta4.