### PR TITLE
Fix x86 (-m32) compilation with ZEPHYR_TOOLCHAIN_VARIANT=host

### DIFF
--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -33,6 +33,7 @@ foreach(isystem_include_dir ${NOSTDINC})
   list(APPEND isystem_include_flags -isystem ${isystem_include_dir})
 endforeach()
 
+# This libgcc code is partially duplicated in compiler/*/target.cmake
 execute_process(
   COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
   OUTPUT_VARIABLE LIBGCC_FILE_NAME

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -109,6 +109,7 @@ else()
   endif()
 
   if(NOT no_libgcc)
+    # This libgcc code is partially duplicated in compiler/*/target.cmake
     execute_process(
       COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
       OUTPUT_VARIABLE LIBGCC_FILE_NAME

--- a/cmake/compiler/host-gcc/target.cmake
+++ b/cmake/compiler/host-gcc/target.cmake
@@ -27,3 +27,17 @@ else()
   endif()
 endif()
 find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler}     CACHE INTERNAL " " FORCE)
+
+# This libgcc code is partially duplicated in compiler/*/target.cmake
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} --print-libgcc-file-name
+  OUTPUT_VARIABLE LIBGCC_FILE_NAME
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+assert_exists(LIBGCC_FILE_NAME)
+
+# While most x86_64 Linux distributions implement "multilib" and have
+# 32 bits libraries off the shelf, things like
+# "/usr/lib/gcc/x86_64-linux-gnu/7/IAMCU/libgcc.a" are unheard of.
+# So this does not support CONFIG_X86_IAMCU=y
+LIST(APPEND TOOLCHAIN_LIBS gcc)

--- a/cmake/compiler/host-gcc/target.cmake
+++ b/cmake/compiler/host-gcc/target.cmake
@@ -9,9 +9,10 @@ find_program(CMAKE_RANLILB      ranlib )
 find_program(CMAKE_READELF      readelf)
 find_program(CMAKE_GDB          gdb    )
 
+set(CMAKE_ASM_FLAGS           -m32 )
 set(CMAKE_C_FLAGS             -m32 )
 set(CMAKE_CXX_FLAGS           -m32 )
-set(CMAKE_SHARED_LINKER_FLAGS -m32 )
+set(CMAKE_SHARED_LINKER_FLAGS -m32 ) # unused?
 
 if(CONFIG_CPLUSPLUS)
   set(cplusplus_compiler g++)


### PR DESCRIPTION
These two patches are a complete compilation fix for the following x86 boards:

  galileo, minnowboard, qemu_x86, qemu_x86_nommu, up_squared,  up_squared_sbl

They are an incomplete fix for the following x86 boards which still fail (no regression) with "-lgcc not found"

  arduino_101, qemu_x86_nommu, quark_d2000_crb, quark_se_c1000_devboard,  tinytile

(I don't know whether the second subset can ever be supported by ZEPHYR_TOOLCHAIN_VARIANT=host)

Please share any suggestion to avoid the cmake code duplication.
