### PR TITLE
dts: bindings: smsc,lan9220: Fix warning related to id field

### DIFF
--- a/dts/bindings/ethernet/smsc,lan9220.yaml
+++ b/dts/bindings/ethernet/smsc,lan9220.yaml
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 title: SMSC/Microchip LAN9220 Ethernet controller
-id: smsc,lan9220
 version: 0.1
 
 description: >


### PR DESCRIPTION
We get the following warning:

	extract_dts_includes.py: WARNING: id field set in
	'SMSC/Microchip LAN9220 Ethernet controller', should be
	removed.

Removed the id: field to fix.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>