### PR TITLE
usb: cdc_acm: Fix composite build

### DIFF
--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -528,11 +528,11 @@ static void cdc_acm_irq_callback_work_handler(struct k_work *work)
  */
 static int cdc_acm_init(struct device *dev)
 {
+	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
 	cdc_acm_dev = dev;
 
 #ifndef CONFIG_USB_COMPOSITE_DEVICE
 	int ret;
-	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
 
 	cdc_acm_config.interface.payload_data = dev_data->interface_data;
 	cdc_acm_config.usb_device_description = usb_get_device_descriptor();


### PR DESCRIPTION
Fixes bug below:
subsys/usb/class/cdc_acm.c:554:15: error: ‘dev_data’ undeclared (first
use in this function) k_work_init(&dev_data->cb_work,
cdc_acm_irq_callback_work_handler); ^~~~~~~~

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>