### PR TITLE
DeviceTree: Convert 'generated_dts_board.h' into a source file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,6 +468,54 @@ function(construct_add_custom_command_for_linker_pass linker_output_name output_
     )
 endfunction()
 
+# Error-out when the deprecated naming convention is found (until
+# after 1.14.0 has been released)
+foreach(path
+	${BOARD_DIR}/dts.fixup
+	${PROJECT_SOURCE_DIR}/soc/${ARCH}/${SOC_PATH}/dts.fixup
+    ${APPLICATION_SOURCE_DIR}/dts.fixup
+	)
+  if(EXISTS ${path})
+	message(FATAL_ERROR
+	  "A deprecated filename has been detected. Porting is required."
+	  "The file '${path}' exists, but it should be named dts_fixup.h instead."
+	  "See https://github.com/zephyrproject-rtos/zephyr/pull/10352 for more details"
+	  )
+  endif()
+endforeach()
+
+set_ifndef(  DTS_BOARD_FIXUP_FILE                                   ${BOARD_DIR}/dts_fixup.h)
+set_ifndef(    DTS_SOC_FIXUP_FILE                 ${SOC_DIR}/${ARCH}/${SOC_PATH}/dts_fixup.h)
+set(           DTS_APP_FIXUP_FILE                      ${APPLICATION_SOURCE_DIR}/dts_fixup.h)
+set_ifndef(DTS_SHIELDS_FIXUP_FILE ${ZEPHYR_BINARY_DIR}/include/generated/shields/dts_fixup.h)
+
+# Concatenate the shield fixups into a single file for easy
+# #include'ing
+foreach(f ${shield_dts_fixups})
+  if(EXISTS ${f})
+	file(READ ${f} contents)
+	file(APPEND ${DTS_SHIELDS_FIXUP_FILE} "${contents}")
+  endif()
+endforeach()
+
+foreach(fixup_source
+      DTS_BOARD_FIXUP_FILE
+        DTS_SOC_FIXUP_FILE
+        DTS_APP_FIXUP_FILE
+	DTS_SHIELDS_FIXUP_FILE
+	)
+  if(EXISTS ${${fixup_source}})
+	# Add defines such that generated_dts_board.h knows which fixups
+	# are present and where they
+	# are. e.g. -DDTS_SOC_FIXUP_FILE=/path/to/fixup.h
+	zephyr_compile_definitions(${fixup_source}="${${fixup_source}}")
+	set_property(GLOBAL APPEND PROPERTY
+	  PROPERTY_LINKER_SCRIPT_DEFINES
+	  -D${fixup_source}="${${fixup_source}}"
+	  )
+  endif()
+endforeach()
+
 # Unfortunately, the order in which CMakeLists.txt code is processed
 # matters so we need to be careful about how we order the processing
 # of subdirectories. One example is "Compiler flags added late in the

--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -1,6 +1,6 @@
 # Zephyr code can configure itself based on a KConfig'uration with the
 # header file autoconf.h. There exists an analogous file
-# generated_dts_board.h that allows configuration based on information
+# generated_dts_board_unfixed.h that allows configuration based on information
 # encoded in DTS.
 #
 # Here we call on dtc, the gcc preprocessor, and
@@ -8,7 +8,7 @@
 # CMake configure-time.
 #
 # See ~/zephyr/doc/dts
-set(GENERATED_DTS_BOARD_H    ${PROJECT_BINARY_DIR}/include/generated/generated_dts_board.h)
+set(GENERATED_DTS_BOARD_UNFIXED_H    ${PROJECT_BINARY_DIR}/include/generated/generated_dts_board_unfixed.h)
 set(GENERATED_DTS_BOARD_CONF ${PROJECT_BINARY_DIR}/include/generated/generated_dts_board.conf)
 set_ifndef(DTS_SOURCE ${BOARD_DIR}/${BOARD}.dts)
 set_ifndef(DTS_COMMON_OVERLAYS ${ZEPHYR_BASE}/dts/common/common.dts)
@@ -48,7 +48,7 @@ if(CONFIG_HAS_DTS)
   endforeach()
 
   # TODO: Cut down on CMake configuration time by avoiding
-  # regeneration of generated_dts_board.h on every configure. How
+  # regeneration of generated_dts_board_unfixed.h on every configure. How
   # challenging is this? What are the dts dependencies? We run the
   # preprocessor, and it seems to be including all kinds of
   # directories with who-knows how many header files.
@@ -95,46 +95,6 @@ if(CONFIG_HAS_DTS)
     message(FATAL_ERROR "command failed with return code: ${ret}")
   endif()
 
-  # Error-out when the deprecated naming convention is found (until
-  # after 1.14.0 has been released)
-  foreach(path
-    ${BOARD_DIR}/dts.fixup
-    ${PROJECT_SOURCE_DIR}/soc/${ARCH}/${SOC_PATH}/dts.fixup
-      ${APPLICATION_SOURCE_DIR}/dts.fixup
-    )
-    if(EXISTS ${path})
-      message(FATAL_ERROR
-      "A deprecated filename has been detected. Porting is required."
-      "The file '${path}' exists, but it should be named dts_fixup.h instead."
-      "See https://github.com/zephyrproject-rtos/zephyr/pull/10352 for more details"
-      )
-    endif()
-  endforeach()
-
-  # Run extract_dts_includes.py for the header file
-  # generated_dts_board.h
-  set_ifndef(DTS_BOARD_FIXUP_FILE ${BOARD_DIR}/dts_fixup.h)
-  set_ifndef(DTS_SOC_FIXUP_FILE   ${SOC_DIR}/${ARCH}/${SOC_PATH}/dts_fixup.h)
-
-  list(APPEND dts_fixups
-    ${DTS_BOARD_FIXUP_FILE}
-    ${DTS_SOC_FIXUP_FILE}
-    ${APPLICATION_SOURCE_DIR}/dts_fixup.h
-    ${shield_dts_fixups}
-    )
-
-  foreach(fixup ${dts_fixups})
-    if(EXISTS ${fixup})
-      list(APPEND existing_dts_fixups ${fixup})
-    endif()
-  endforeach()
-
-  if("${existing_dts_fixups}" STREQUAL "")
-    unset(DTS_FIXUPS_WITH_FLAG)
-  else()
-    set(DTS_FIXUPS_WITH_FLAG --fixup ${existing_dts_fixups})
-  endif()
-
   if(NOT EXISTS ${DTS_APP_BINDINGS})
     set(DTS_APP_BINDINGS)
   endif()
@@ -142,9 +102,8 @@ if(CONFIG_HAS_DTS)
   set(CMD_EXTRACT_DTS_INCLUDES ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/dts/extract_dts_includes.py
     --dts ${BOARD}.dts_compiled
     --yaml ${ZEPHYR_BASE}/dts/bindings ${DTS_APP_BINDINGS}
-    ${DTS_FIXUPS_WITH_FLAG}
     --keyvalue ${GENERATED_DTS_BOARD_CONF}
-    --include ${GENERATED_DTS_BOARD_H}
+    --include ${GENERATED_DTS_BOARD_UNFIXED_H}
     --old-alias-names
     )
 
@@ -163,5 +122,5 @@ if(CONFIG_HAS_DTS)
   import_kconfig(DT_     ${GENERATED_DTS_BOARD_CONF})
 
 else()
-  file(WRITE ${GENERATED_DTS_BOARD_H} "/* WARNING. THIS FILE IS AUTO-GENERATED. DO NOT MODIFY! */")
+  file(WRITE ${GENERATED_DTS_BOARD_UNFIXED_H} "/* WARNING. THIS FILE IS AUTO-GENERATED. DO NOT MODIFY! */")
 endif()

--- a/include/generated_dts_board.h
+++ b/include/generated_dts_board.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2019 Nordic Semiconductor
+ *
+ * Not a generated file. Feel free to modify.
+ *
+ * Poorly named for legacy compatibility reasons.
+ */
+
+#ifndef GENERATED_DTS_BOARD_H
+#define GENERATED_DTS_BOARD_H
+
+#include <generated_dts_board_unfixed.h>
+
+/* The following definitions fixup the generated include */
+
+#ifdef DTS_BOARD_FIXUP_FILE
+#include DTS_BOARD_FIXUP_FILE
+#endif
+
+#ifdef DTS_SOC_FIXUP_FILE
+#include DTS_SOC_FIXUP_FILE
+#endif
+
+#ifdef DTS_APP_FIXUP_FILE
+#include DTS_APP_FIXUP_FILE
+#endif
+
+#ifdef DTS_SHIELDS_FIXUP_FILE
+#include DTS_SHIELDS_FIXUP_FILE
+#endif
+
+#endif /* GENERATED_DTS_BOARD_H */

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -607,7 +607,7 @@ def generate_keyvalue_file(kv_file):
         output_keyvalue_lines(fd)
 
 
-def output_include_lines(fd, fixups):
+def output_include_lines(fd):
     compatible = reduced['/']['props']['compatible'][0]
 
     fd.write("/**************************************************\n")
@@ -616,8 +616,8 @@ def output_include_lines(fd, fixups):
     fd.write(" *               DO NOT MODIFY\n")
     fd.write(" */\n")
     fd.write("\n")
-    fd.write("#ifndef DEVICE_TREE_BOARD_H" + "\n")
-    fd.write("#define DEVICE_TREE_BOARD_H" + "\n")
+    fd.write("#ifndef GENERATED_DTS_BOARD_UNFIXED_H" + "\n")
+    fd.write("#define GENERATED_DTS_BOARD_UNFIXED_H" + "\n")
     fd.write("\n")
 
     node_keys = sorted(defs.keys())
@@ -650,28 +650,12 @@ def output_include_lines(fd, fixups):
 
         fd.write("\n")
 
-    if fixups:
-        for fixup in fixups:
-            if os.path.exists(fixup):
-                fd.write("\n")
-                fd.write(
-                    "/* Following definitions fixup the generated include */\n")
-                try:
-                    with open(fixup, "r", encoding="utf-8") as fixup_fd:
-                        for line in fixup_fd.readlines():
-                            fd.write(line)
-                        fd.write("\n")
-                except:
-                    raise Exception(
-                        "Input file " + os.path.abspath(fixup) +
-                        " does not exist.")
-
     fd.write("#endif\n")
 
 
-def generate_include_file(inc_file, fixups):
+def generate_include_file(inc_file):
     with open(inc_file, "w") as fd:
-        output_include_lines(fd, fixups)
+        output_include_lines(fd)
 
 
 def load_and_parse_dts(dts_file):
@@ -724,8 +708,6 @@ def parse_arguments():
     parser.add_argument("-d", "--dts", nargs=1, required=True, help="DTS file")
     parser.add_argument("-y", "--yaml", nargs='+', required=True,
                         help="YAML file directories, we allow multiple")
-    parser.add_argument("-f", "--fixup", nargs='+',
-                        help="Fixup file(s), we allow multiple")
     parser.add_argument("-i", "--include", nargs=1,
                         help="Generate include file for the build system")
     parser.add_argument("-k", "--keyvalue", nargs=1,
@@ -766,7 +748,7 @@ def main():
        generate_keyvalue_file(args.keyvalue[0])
 
     if (args.include is not None):
-       generate_include_file(args.include[0], args.fixup)
+       generate_include_file(args.include[0])
 
 
 if __name__ == '__main__':

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -608,17 +608,15 @@ def generate_keyvalue_file(kv_file):
 
 
 def output_include_lines(fd):
-    compatible = reduced['/']['props']['compatible'][0]
-
-    fd.write("/**************************************************\n")
-    fd.write(" * Generated include file for " + compatible)
-    fd.write("\n")
-    fd.write(" *               DO NOT MODIFY\n")
-    fd.write(" */\n")
-    fd.write("\n")
-    fd.write("#ifndef GENERATED_DTS_BOARD_UNFIXED_H" + "\n")
-    fd.write("#define GENERATED_DTS_BOARD_UNFIXED_H" + "\n")
-    fd.write("\n")
+    fd.write('''\
+/**********************************************
+*                 Generated include file
+*                      DO NOT MODIFY
+*/
+#ifndef GENERATED_DTS_BOARD_UNFIXED_H
+#define GENERATED_DTS_BOARD_UNFIXED_H
+    '''
+    )
 
     node_keys = sorted(defs.keys())
     for node in node_keys:


### PR DESCRIPTION
extract_dts_includes.py has been generating DT output and then
concatenating it with fixup header files to create
'generated_dts_board.h'.

In this patch we instead introduce a source file named
'generated_dts_board.h' and have it \#include the appropriate DT
output and fixup files.

This results in a simpler system because users can now read
'generated_dts_board.h' as C source code to see how fixup files and
generated DT output relate to each other. Whereas before they would
have to either read documentation or python code to gain the same
understanding.

Also, it reduces the scope and complexity of one of our most bloated
python scripts, extract_dts_includes.py.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>