### PR TITLE
tests: lib: mem_alloc: esp32 to skip newlib test

### DIFF
--- a/tests/lib/mem_alloc/testcase.yaml
+++ b/tests/lib/mem_alloc/testcase.yaml
@@ -6,5 +6,5 @@ tests:
   libraries.libc.newlib:
     extra_args: CONF_FILE=prj_newlib.conf
     arch_exclude: posix
-    platform_exclude: qemu_x86_64 # No newlib
+    platform_exclude: esp32 qemu_x86_64 # No newlib
     tags: clib newlib


### PR DESCRIPTION
esp32 has no support for newlib

Signed-off-by: Cinly Ooi <cinly.ooi@intel.com>