### PR TITLE
dts: arm: nordic: Add flash controller alias to nrf9160ns.dtsi

### DIFF
--- a/dts/arm/nordic/nrf9160ns.dtsi
+++ b/dts/arm/nordic/nrf9160ns.dtsi
@@ -26,6 +26,7 @@
 	};
 
 	aliases {
+		flash-controller = &flash_controller;
 		rtc-0 = &rtc0;
 		rtc-1 = &rtc1;
 		clock = &clock;


### PR DESCRIPTION
Added missing flash-controller alias to nrf9160ns used by subsystem such
as `mcumgr`.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>