### PR TITLE
cmake: Rebuild when DTS sources are modified

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -44,6 +44,12 @@ if(CONFIG_HAS_DTS)
       message(STATUS "Overlaying ${dts_file}")
     endif()
 
+    # Ensure that changes to 'dts_file's cause CMake to be re-run
+    set_property(DIRECTORY APPEND PROPERTY
+      CMAKE_CONFIGURE_DEPENDS
+      ${dts_file}
+      )
+
     math(EXPR i "${i}+1")
   endforeach()
 


### PR DESCRIPTION
Ensure that changes to DeviceTree sources cause CMake to be re-run
when make/ninja is invoked.

Note that this is not perfect, as it does not cover files that are
\#included, but it will cover most DT changes.

This fixes #12692

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>