### PR TITLE
soc/arm: stm32: Add common to zephyr include directories

### DIFF
--- a/soc/arm/st_stm32/CMakeLists.txt
+++ b/soc/arm/st_stm32/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(${SOC_SERIES})
 add_subdirectory(common)
+zephyr_include_directories(common)


### PR DESCRIPTION
st_stm32/common/ is not added to Cmake include pathes.
Fix this with zephyr_include_directories.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>