### PR TITLE
net: pkt: fix race condition in packet reference counting

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -678,7 +678,7 @@ static inline void ts_register_tx_event(struct eth_context *context)
 	enet_ptp_time_data_t timeData;
 
 	pkt = ts_tx_pkt[ts_tx_rd];
-	if (pkt && pkt->ref > 0) {
+	if (pkt && atomic_get(&pkt->atomic_ref) > 0) {
 		if (eth_get_ptp_data(net_pkt_iface(pkt), pkt, &timeData,
 				     true)) {
 			int status;

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -83,6 +83,9 @@ struct net_pkt {
 	u8_t *appdata;	/* application data starts here */
 	u8_t *next_hdr;	/* where is the next header */
 
+	/** Reference counter */
+	atomic_t atomic_ref;
+
 	/* Filled by layer 2 when network packet is received. */
 	struct net_linkaddr lladdr_src;
 	struct net_linkaddr lladdr_dst;
@@ -108,9 +111,6 @@ struct net_pkt {
 #if defined(CONFIG_NET_TCP)
 	sys_snode_t sent_list;
 #endif
-
-	/** Reference counter */
-	u8_t ref;
 
 	u8_t sent_or_eof: 1;	/* For outgoing packet: is this sent or not
 				 * For incoming packet of a socket: last

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -355,7 +355,7 @@ struct net_pkt *net_pkt_get_reserve(struct k_mem_slab *slab,
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
 	NET_DBG("%s [%u] pkt %p ref %d (%s():%d)",
 		slab2str(slab), k_mem_slab_num_free_get(slab),
-		pkt, pkt->ref, caller, line);
+		pkt, atomic_get(&pkt->atomic_ref), caller, line);
 #endif
 	return pkt;
 }

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -219,7 +219,7 @@ static inline void net_print_frags(const char *str, struct net_pkt *pkt)
 		printk("%s", str);
 	}
 
-	printk("%p[%d]", pkt, pkt->ref);
+	printk("%p[%d]", pkt, atomic_get(&pkt->atomic_ref));
 
 	if (frag) {
 		printk("->");

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -968,12 +968,13 @@ static void tcp_sent_list_cb(struct net_tcp *tcp, void *user_data)
 		struct net_buf *frag = pkt->frags;
 
 		if (!*printed) {
-			PR("%p[%d/%zd]", pkt, pkt->ref,
+			PR("%p[%d/%zd]", pkt, atomic_get(&pkt->atomic_ref),
 			       net_pkt_get_len(pkt));
 			*printed = true;
 		} else {
 			PR("                %p[%d/%zd]",
-			       pkt, pkt->ref, net_pkt_get_len(pkt));
+			   pkt, atomic_get(&pkt->atomic_ref),
+			   net_pkt_get_len(pkt));
 		}
 
 		if (frag) {
@@ -1073,7 +1074,7 @@ static void allocs_cb(struct net_pkt *pkt,
 	if (func_alloc) {
 		if (in_use) {
 			PR("%p/%d\t%5s\t%5s\t%s():%d\n",
-			   pkt, pkt->ref, str,
+			   pkt, atomic_get(&pkt->atomic_ref), str,
 			   net_pkt_slab2str(pkt->slab),
 			   func_alloc, line_alloc);
 		} else {

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -185,8 +185,8 @@ static inline u32_t retry_timeout(const struct net_tcp *tcp)
 	do {								\
 		if (!is_6lo_technology(pkt)) {				\
 			NET_DBG("[%p] ref pkt %p new ref %d (%s:%d)",	\
-				tcp, pkt, pkt->ref + 1, __func__,	\
-				__LINE__);				\
+				tcp, pkt, atomic_get(&pkt->atomic_ref) + 1, \
+				__func__, __LINE__);			\
 			pkt = net_pkt_ref(pkt);				\
 		}							\
 	} while (0)

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -38,7 +38,8 @@ static void arp_entry_cleanup(struct arp_entry *entry, bool pending)
 
 	if (pending) {
 		NET_DBG("Releasing pending pkt %p (ref %d)",
-			entry->pending, entry->pending->ref - 1);
+			entry->pending,
+			atomic_get(&entry->pending->atomic_ref) - 1);
 		net_pkt_unref(entry->pending);
 		entry->pending = NULL;
 	}

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -475,7 +475,7 @@ void test_arp(void)
 	 */
 	net_pkt_unref(pkt2);
 
-	zassert_equal(pkt->ref, 2,
+	zassert_equal(atomic_get(&pkt->atomic_ref), 2,
 		"ARP cache should own the original packet");
 
 	/* Then a case where target is not in the same subnet */
@@ -579,7 +579,7 @@ void test_arp(void)
 	/**TESTPOINTS: Check ARP reply*/
 	zassert_false(send_status < 0, "ARP reply was not sent");
 
-	zassert_equal(pkt->ref, 1,
+	zassert_equal(atomic_get(&pkt->atomic_ref), 1,
 		      "ARP cache should no longer own the original packet");
 
 	net_pkt_unref(pkt);

--- a/tests/net/tx_timestamp/src/main.c
+++ b/tests/net/tx_timestamp/src/main.c
@@ -199,7 +199,7 @@ static void timestamp_setup(void)
 	net_if_call_timestamp_cb(pkt);
 
 	zassert_true(timestamp_cb_called, "Timestamp callback not called\n");
-	zassert_equal(pkt->ref, 0, "Pkt %p not released\n");
+	zassert_equal(atomic_get(&pkt->atomic_ref), 0, "Pkt %p not released\n");
 }
 
 static void timestamp_callback_2(struct net_pkt *pkt)
@@ -246,7 +246,7 @@ static void timestamp_setup_2nd_iface(void)
 	net_if_call_timestamp_cb(pkt);
 
 	zassert_true(timestamp_cb_called, "Timestamp callback not called\n");
-	zassert_equal(pkt->ref, 0, "Pkt %p not released\n");
+	zassert_equal(atomic_get(&pkt->atomic_ref), 0, "Pkt %p not released\n");
 }
 
 static void timestamp_setup_all(void)
@@ -272,7 +272,7 @@ static void timestamp_setup_all(void)
 	net_if_call_timestamp_cb(pkt);
 
 	zassert_true(timestamp_cb_called, "Timestamp callback not called\n");
-	zassert_equal(pkt->ref, 0, "Pkt %p not released\n");
+	zassert_equal(atomic_get(&pkt->atomic_ref), 0, "Pkt %p not released\n");
 
 	net_if_unregister_timestamp_cb(&timestamp_cb_3);
 }
@@ -297,7 +297,7 @@ static void timestamp_cleanup(void)
 	net_if_call_timestamp_cb(pkt);
 
 	zassert_false(timestamp_cb_called, "Timestamp callback called\n");
-	zassert_false(pkt->ref < 1, "Pkt %p released\n");
+	zassert_false(atomic_get(&pkt->atomic_ref) < 1, "Pkt %p released\n");
 
 	net_pkt_unref(pkt);
 }
@@ -502,8 +502,9 @@ static void check_timestamp_before_enabling(void)
 	 * should have unreffed the packet by now so the ref count
 	 * should be zero now.
 	 */
-	zassert_equal(pkt->ref, 0, "packet %p was not released (ref %d)\n",
-		      pkt, pkt->ref);
+	zassert_equal(atomic_get(&pkt->atomic_ref), 0,
+		      "packet %p was not released (ref %d)\n",
+		      pkt, atomic_get(&pkt->atomic_ref));
 }
 
 static void check_timestamp_after_enabling(void)
@@ -524,8 +525,9 @@ static void check_timestamp_after_enabling(void)
 	 * and timestamp_cb() should have unreffed the packet by now so
 	 * the ref count should be zero at this point.
 	 */
-	zassert_equal(pkt->ref, 0, "packet %p was not released (ref %d)\n",
-		      pkt, pkt->ref);
+	zassert_equal(atomic_get(&pkt->atomic_ref), 0,
+		      "packet %p was not released (ref %d)\n",
+		      pkt, atomic_get(&pkt->atomic_ref));
 }
 
 void test_main(void)


### PR DESCRIPTION
It has been observed that some network drivers, f.ex. the SAM E70 GMAC,
call net_pkt_unref from inside the interrupt that signals the successful
transmission of a packet. This conflicts with the net_pkt_unref call made
by ethernet_send after the packet has been given to the driver.

We fix this by using an atomic_t to hold the reference count as there
might be other, difficult to find cases of net_pkt_(un)ref being used
across threads and interrupts.

The name of the element has been changed from "ref" to "atomic_ref" to
cause a compile error when code still has not been converted to use the
atomic_* functions.

Fixes #12708

Signed-off-by: Daniel Glöckner <dg@emlix.com>