### PR TITLE
drivers: eth: sam-e70: revision B has more queues

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -79,6 +79,14 @@ static struct gmac_desc rx_desc_que1[PRIORITY_QUEUE1_RX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
 static struct gmac_desc rx_desc_que2[PRIORITY_QUEUE2_RX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#if GMAC_QUEUE_NUM > 3
+static struct gmac_desc rx_desc_que3[PRIORITY_QUEUE3_RX_DESC_COUNT]
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+static struct gmac_desc rx_desc_que4[PRIORITY_QUEUE4_RX_DESC_COUNT]
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+static struct gmac_desc rx_desc_que5[PRIORITY_QUEUE5_RX_DESC_COUNT]
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#endif
 /* TX descriptors list */
 static struct gmac_desc tx_desc_que0[MAIN_QUEUE_TX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
@@ -86,6 +94,14 @@ static struct gmac_desc tx_desc_que1[PRIORITY_QUEUE1_TX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
 static struct gmac_desc tx_desc_que2[PRIORITY_QUEUE2_TX_DESC_COUNT]
 	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#if GMAC_QUEUE_NUM > 3
+static struct gmac_desc tx_desc_que3[PRIORITY_QUEUE3_TX_DESC_COUNT]
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+static struct gmac_desc tx_desc_que4[PRIORITY_QUEUE4_TX_DESC_COUNT]
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+static struct gmac_desc tx_desc_que5[PRIORITY_QUEUE5_TX_DESC_COUNT]
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
+#endif
 
 /* RX buffer accounting list */
 static struct net_buf *rx_frag_list_que0[MAIN_QUEUE_RX_DESC_COUNT];
@@ -1702,7 +1718,7 @@ static void eth0_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	/* Initialize GMAC queues */
-	for (i = 0; i < GMAC_QUEUE_NO; i++) {
+	for (i = 0; i < GMAC_QUEUE_NUM; i++) {
 		result = queue_init(cfg->regs, &dev_data->queue_list[i]);
 		if (result < 0) {
 			LOG_ERR("Unable to initialize ETH queue%d", i);
@@ -2050,6 +2066,38 @@ static struct eth_sam_dev_data eth0_data = {
 			}
 #endif
 #endif
+#endif
+#if GMAC_QUEUE_NUM > 3
+		}, {
+			.que_idx = GMAC_QUE_3,
+			.rx_desc_list = {
+				.buf = rx_desc_que3,
+				.len = ARRAY_SIZE(rx_desc_que3),
+			},
+			.tx_desc_list = {
+				.buf = tx_desc_que3,
+				.len = ARRAY_SIZE(tx_desc_que3),
+			},
+		}, {
+			.que_idx = GMAC_QUE_4,
+			.rx_desc_list = {
+				.buf = rx_desc_que4,
+				.len = ARRAY_SIZE(rx_desc_que4),
+			},
+			.tx_desc_list = {
+				.buf = tx_desc_que4,
+				.len = ARRAY_SIZE(tx_desc_que4),
+			},
+		}, {
+			.que_idx = GMAC_QUE_5,
+			.rx_desc_list = {
+				.buf = rx_desc_que5,
+				.len = ARRAY_SIZE(rx_desc_que5),
+			},
+			.tx_desc_list = {
+				.buf = tx_desc_que5,
+				.len = ARRAY_SIZE(tx_desc_que5),
+			},
 #endif
 		}
 	},

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -31,7 +31,13 @@
 /** Memory alignment of the RX/TX Buffer Descriptor List */
 #define GMAC_DESC_ALIGNMENT               4
 /** Total number of queues supported by GMAC hardware module */
-#define GMAC_QUEUE_NO                     3
+#ifdef CONFIG_SOC_ATMEL_SAME70_REVB
+#define GMAC_QUEUE_NUM                    6
+#else
+#define GMAC_QUEUE_NUM                    3
+#endif
+BUILD_ASSERT_MSG(ARRAY_SIZE(GMAC->GMAC_TBQBAPQ) + 1 == GMAC_QUEUE_NUM,
+		 "GMAC_QUEUE_NUM doesn't match soc header");
 /** Number of priority queues used */
 #define GMAC_PRIORITY_QUEUE_NO            (CONFIG_ETH_SAM_GMAC_QUEUES - 1)
 
@@ -55,6 +61,17 @@
 #else
 #define PRIORITY_QUEUE1_RX_DESC_COUNT         1
 #define PRIORITY_QUEUE1_TX_DESC_COUNT         1
+#endif
+
+#if GMAC_QUEUE_NUM > 3
+#define PRIORITY_QUEUE3_RX_DESC_COUNT         1
+#define PRIORITY_QUEUE3_TX_DESC_COUNT         1
+
+#define PRIORITY_QUEUE4_RX_DESC_COUNT         1
+#define PRIORITY_QUEUE4_TX_DESC_COUNT         1
+
+#define PRIORITY_QUEUE5_RX_DESC_COUNT         1
+#define PRIORITY_QUEUE5_TX_DESC_COUNT         1
 #endif
 
 /*
@@ -147,6 +164,11 @@ enum queue_idx {
 	GMAC_QUE_0,  /** Main queue */
 	GMAC_QUE_1,  /** Priority queue 1 */
 	GMAC_QUE_2,  /** Priority queue 2 */
+#if GMAC_QUEUE_NUM > 3
+	GMAC_QUE_3,  /** Priority queue 3 */
+	GMAC_QUE_4,  /** Priority queue 4 */
+	GMAC_QUE_5,  /** Priority queue 5 */
+#endif
 };
 
 /** Minimal ring buffer implementation */
@@ -217,7 +239,7 @@ struct eth_sam_dev_data {
 	struct device *ptp_clock;
 #endif
 	u8_t mac_addr[6];
-	struct gmac_queue queue_list[GMAC_QUEUE_NO];
+	struct gmac_queue queue_list[GMAC_QUEUE_NUM];
 };
 
 #define DEV_CFG(dev) \


### PR DESCRIPTION
If we don't initialize all queues, the DMA engine gets stuck when trying to read a descriptor from NULL.