### PR TITLE
doc: fix formatting error in security doc

### DIFF
--- a/doc/security/sensor-threat.rst
+++ b/doc/security/sensor-threat.rst
@@ -49,7 +49,7 @@ included in this model:
    for updates to this image are:
 
    a. The image shall only be replaced with an authorized image
-   [th-authrepl]_.
+      [th-authrepl]_.
 
    b. When an authorized replacement image is available, the update
       shall be done in a timely manner [th-timely-update]_.


### PR DESCRIPTION
Continuation of a bullet list item wasn't indented properly, causing a
new list to be started (with odd indentation).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>