### PR TITLE
doc: add rstcheck to doc guidelines

### DIFF
--- a/.rstcheck.cfg
+++ b/.rstcheck.cfg
@@ -1,0 +1,7 @@
+[rstcheck]
+ignore_directives=zephyr-app-commands,doxygengroup,doxygenenum,doxygenstruct
+ignore_roles=zephyr_file,zephyr_raw,jira,github
+ignore_substitutions=reg,trade,plusminus,micro,deg,version
+ignore_language=c
+ignore_messages=(Hyperlink target ".*" is not referenced|Duplicate implicit target name: ".*")
+report=info

--- a/doc/documentation/doc-guidelines.rst
+++ b/doc/documentation/doc-guidelines.rst
@@ -25,6 +25,27 @@ This document provides a quick reference for commonly used reST and
 Sphinx-defined directives and roles used to create the documentation
 you're reading.
 
+Checking reST syntax
+********************
+
+The restructuredText syntax has some quirks that can be unexpected, such
+as needing a blank line before the first item of a list, getting the
+indentation right on list items, and making the heading underline at
+least as long as the heading.
+
+While not perfect, there is a tool that is Sphinx-aware and can do a
+quick syntax check:  `rstcheck <https://pypi.org/project/rstcheck>`_.
+Install this tool using::
+
+   pip3 install --user rstcheck
+
+An ``.rstcheck.cfg`` configuration file is included in the Zephyr
+repo with options that eliminate most false-positive messages.  Run
+rstcheck on a file before submitting your PR, or recursively on
+all your local files with::
+
+   rstcheck -r .
+
 Headings
 ********
 


### PR DESCRIPTION
Add a mention of the rstcheck (python) tool to the documentation
guidelines, and include an .rstcheck.cfg file with useful configuration
options that reduce false-positive messages.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>