### PR TITLE
sanitycheck: adapt default boards

### DIFF
--- a/boards/arm/nucleo_l496zg/nucleo_l496zg.yaml
+++ b/boards/arm/nucleo_l496zg/nucleo_l496zg.yaml
@@ -13,7 +13,6 @@ supported:
   - spi
   - pwm
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth


### PR DESCRIPTION
- nucleo_l496zg was added by mistake
