### PR TITLE
sanitycheck: add option to set gcov tool

### DIFF
--- a/samples/mpu/mpu_stack_guard_test/sample.yaml
+++ b/samples/mpu/mpu_stack_guard_test/sample.yaml
@@ -5,7 +5,7 @@ tests:
     tags: mpu stackguard
     harness: console
     # We do not handle segfaults here
-    arch_exclude: posix riscv32 nios2 xtensa x86_64
+    arch_whitelist: arm
     platform_exclude: qemu_cortex_m3
     harness_config:
       type: multi_line

--- a/scripts/gen_gcov_files.py
+++ b/scripts/gen_gcov_files.py
@@ -16,13 +16,14 @@ import re
 def retrieve_data(input_file):
     extracted_coverage_info = {}
     capture_data = False
+    reached_end = False
     with open(input_file, 'r') as fp:
         for line in fp.readlines():
             if re.search("GCOV_COVERAGE_DUMP_START", line):
                 capture_data = True
                 continue
             if re.search("GCOV_COVERAGE_DUMP_END", line):
-                capture_data = True
+                reached_end = True
                 break
             # Loop until the coverage data is found.
             if not capture_data:
@@ -33,6 +34,9 @@ def retrieve_data(input_file):
             # Remove the trailing new line char
             hex_dump = line.split("<")[1][:-1]
             extracted_coverage_info.update({file_name:hex_dump})
+
+    if not reached_end:
+        print("incomplete data captured from %s" %input_file)
     return extracted_coverage_info
 
 def create_gcda_files(extracted_coverage_info):

--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -2,6 +2,17 @@ import re
 from collections import OrderedDict
 
 class Harness:
+    GCOV_START = "GCOV_COVERAGE_DUMP_START"
+    GCOV_END = "GCOV_COVERAGE_DUMP_END"
+    FAULTS = [
+            "Unknown Fatal Error",
+            "MPU FAULT",
+            "Kernel Panic",
+            "Kernel OOPS",
+            "BUS FAULT",
+            "CPU Page Fault"
+            ]
+
     def __init__(self):
         self.state = None
         self.type = None
@@ -13,6 +24,7 @@ class Harness:
         self.id = None
         self.fail_on_fault = True
         self.fault = False
+        self.capture_coverage = False
 
     def configure(self, instance):
         config = instance.test.harness_config
@@ -41,33 +53,35 @@ class Console(Harness):
 
             if len(self.matches) == len(self.regex):
                 # check ordering
-                if not self.ordered:
-                    self.state = "passed"
-                    return
-                ordered = True
-                pos = 0
-                for k,v in self.matches.items():
-                    if k != self.regex[pos]:
-                        ordered = False
-                    pos += 1
+                if self.ordered:
+                    ordered = True
+                    pos = 0
+                    for k,v in self.matches.items():
+                        if k != self.regex[pos]:
+                            ordered = False
+                        pos += 1
 
-                if ordered:
-                    self.state = "passed"
+                    if ordered:
+                        self.state = "passed"
+                    else:
+                        self.state = "failed"
                 else:
-                    self.state = "failed"
+                    self.state = "passed"
+
+        if self.fail_on_fault:
+            for fault in self.FAULTS:
+                if fault in line:
+                    self.fault = True
+
+        if self.GCOV_START in line:
+            self.capture_coverage = True
+        elif self.GCOV_END in line:
+            self.capture_coverage = False
 
 class Test(Harness):
     RUN_PASSED = "PROJECT EXECUTION SUCCESSFUL"
     RUN_FAILED = "PROJECT EXECUTION FAILED"
 
-    faults = [
-            "Unknown Fatal Error",
-            "MPU FAULT",
-            "Kernel Panic",
-            "Kernel OOPS",
-            "BUS FAULT",
-            "CPU Page Fault"
-            ]
 
     def handle(self, line):
         result = re.compile("(PASS|FAIL|SKIP) - (test_)?(.*)")
@@ -86,7 +100,11 @@ class Test(Harness):
             self.state = "failed"
 
         if self.fail_on_fault:
-            for fault in self.faults:
+            for fault in self.FAULTS:
                 if fault in line:
                     self.fault = True
 
+        if self.GCOV_START in line:
+            self.capture_coverage = True
+        elif self.GCOV_END in line:
+            self.capture_coverage = False

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2677,6 +2677,8 @@ def parse_arguments():
         which will ultimately disable ccache.
         """
     )
+    parser.add_argument("--gcov-tool", default="gcov",
+                        help="Path to the gcov tool. Default is gcov in the path.")
 
     parser.add_argument("--enable-coverage", action="store_true",
                         help="Enable code coverage using gcov.")
@@ -2838,20 +2840,23 @@ def generate_coverage(outdir, ignores):
         extracted_coverage_info = retrieve_data(filename)
         create_gcda_files(extracted_coverage_info)
 
+    gcov_tool = options.gcov_tool
+
     with open(os.path.join(outdir, "coverage.log"), "a") as coveragelog:
         coveragefile = os.path.join(outdir, "coverage.info")
         ztestfile = os.path.join(outdir, "ztest.info")
-        subprocess.call(["lcov", "--capture", "--directory", outdir,
-                         "--rc", "lcov_branch_coverage=1",
-                         "--output-file", coveragefile], stdout=coveragelog)
+        subprocess.call(["lcov", "--gcov-tool", gcov_tool,
+                            "--capture", "--directory", outdir,
+                            "--rc", "lcov_branch_coverage=1",
+                            "--output-file", coveragefile], stdout=coveragelog)
         # We want to remove tests/* and tests/ztest/test/* but save tests/ztest
-        subprocess.call(["lcov", "--extract", coveragefile,
+        subprocess.call(["lcov", "--gcov-tool", gcov_tool, "--extract", coveragefile,
                          os.path.join(ZEPHYR_BASE, "tests", "ztest", "*"),
                          "--output-file", ztestfile,
                          "--rc", "lcov_branch_coverage=1"], stdout=coveragelog)
 
         if os.path.exists(ztestfile) and os.path.getsize(ztestfile) > 0:
-            subprocess.call(["lcov", "--remove", ztestfile,
+            subprocess.call(["lcov", "--gcov-tool", gcov_tool, "--remove", ztestfile,
                              os.path.join(ZEPHYR_BASE, "tests/ztest/test/*"),
                              "--output-file", ztestfile,
                              "--rc", "lcov_branch_coverage=1"],
@@ -2862,8 +2867,9 @@ def generate_coverage(outdir, ignores):
 
         for i in ignores:
             subprocess.call(
-                ["lcov", "--remove", coveragefile, i, "--output-file",
-                 coveragefile, "--rc", "lcov_branch_coverage=1"],
+                ["lcov", "--gcov-tool", gcov_tool, "--remove",
+                    coveragefile, i, "--output-file",
+                    coveragefile, "--rc", "lcov_branch_coverage=1"],
                 stdout=coveragelog)
 
         ret = subprocess.call(["genhtml", "--legend", "--branch-coverage",

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1040,12 +1040,16 @@ class MakeGenerator:
         elif type == "native":
             handler = BinaryHandler(instance)
             handler.binary = os.path.join(outdir, "zephyr", "zephyr.exe")
+            if options.enable_coverage:
+                args += ["EXTRA_LDFLAGS=--coverage"]
         elif type == "nsim":
             handler = BinaryHandler(instance)
             handler.call_make_run = True
         elif type == "unit":
             handler = BinaryHandler(instance)
             handler.binary = os.path.join(outdir, "testbinary")
+            if options.enable_coverage:
+                args += ["EXTRA_LDFLAGS=--coverage"]
         elif type == "device":
             handler = DeviceHandler(instance)
         elif type == "renode":
@@ -1053,8 +1057,6 @@ class MakeGenerator:
             handler.pid_fn = os.path.join(instance.outdir, "renode.pid")
             handler.call_make_run = True
 
-        if options.enable_coverage:
-            args += ["EXTRA_LDFLAGS=--coverage"]
 
         if type == 'qemu':
             args.append("QEMU_PIPE=%s" % handler.get_fifo())

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -601,12 +601,11 @@ class QEMUHandler(Handler):
                 # if we get some state, that means test is doing well, we reset
                 # the timeout and wait for 2 more seconds just in case we have
                 # crashed after test has completed
-
-                if harness.type:
-                    break
-                else:
-                    if not timeout_extended:
-                        timeout_extended= True
+                if not timeout_extended or harness.capture_coverage:
+                    timeout_extended= True
+                    if harness.capture_coverage:
+                        timeout_time = time.time() + 10
+                    else:
                         timeout_time = time.time() + 2
 
             # TODO: Add support for getting numerical performance data
@@ -2787,18 +2786,19 @@ def size_report(sc):
          (sc.rom_size, sc.ram_size))
     info("")
 
-def retrieve_data(intput_file):
+def retrieve_gcov_data(intput_file):
     if VERBOSE:
         print("Working on %s" %intput_file)
     extracted_coverage_info = {}
     capture_data = False
+    capture_complete = False
     with open(intput_file, 'r') as fp:
         for line in fp.readlines():
             if re.search("GCOV_COVERAGE_DUMP_START", line):
                 capture_data = True
                 continue
             if re.search("GCOV_COVERAGE_DUMP_END", line):
-                capture_data = True
+                capture_complete = True
                 break
             # Loop until the coverage data is found.
             if not capture_data:
@@ -2815,7 +2815,9 @@ def retrieve_data(intput_file):
             else:
                 continue
             extracted_coverage_info.update({file_name:hex_dump})
-    return extracted_coverage_info
+    if not capture_data:
+        capture_complete = True
+    return {'complete': capture_complete, 'data': extracted_coverage_info}
 
 def create_gcda_files(extracted_coverage_info):
     if VERBOSE:
@@ -2837,8 +2839,14 @@ def create_gcda_files(extracted_coverage_info):
 def generate_coverage(outdir, ignores):
 
     for filename in glob.glob("%s/**/handler.log" %outdir, recursive=True):
-        extracted_coverage_info = retrieve_data(filename)
-        create_gcda_files(extracted_coverage_info)
+        gcov_data = retrieve_gcov_data(filename)
+        capture_complete = gcov_data['complete']
+        extracted_coverage_info = gcov_data['data']
+        if capture_complete:
+            create_gcda_files(extracted_coverage_info)
+            verbose("Gcov data captured: {}".format(filename))
+        else:
+            error("Gcov data capture incomplete: {}".format(filename))
 
     gcov_tool = options.gcov_tool
 


### PR DESCRIPTION
When building with older versions of the toolchain we need to use gcov from
the same tool set, otherwise data formar might not be compatible.

Added an option to point to the gcov tool from the same toolchain used to
build the code. By default the host gcov is used.

Relates to #12571