### PR TITLE
tests: coverage: GCOV counter value changed in GCC8.

### DIFF
--- a/tests/coverage/coverage.h
+++ b/tests/coverage/coverage.h
@@ -30,7 +30,11 @@
 #ifndef _COVERAGE_H_
 #define _COVERAGE_H_
 
+#if (__GNUC__ >= 8)
+#define GCOV_COUNTERS 9U
+#else
 #define GCOV_COUNTERS 10U
+#endif
 
 typedef u64_t gcov_type;
 


### PR DESCRIPTION
Updated the GCOV_COUNTERS value, without which the coverage data
was corrupted when gcc 8.2 was used.

GH-12571

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>