### PR TITLE
Bluetooth: meaningful error codes on advertising start

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -343,6 +343,11 @@ struct bt_le_adv_param {
  *  @param sd_len Number of elements in sd
  *
  *  @return Zero on success or (negative) error code otherwise.
+ *  @return -ECONNREFUSED When connectable advertising is requested and there
+ *			  is already maximum number of connections established.
+ *			  This error code is only guaranteed when using Zephyr
+ *			  controller, for other controllers code returned in
+ *			  this case may be -EIO.
  */
 int bt_le_adv_start(const struct bt_le_adv_param *param,
 		    const struct bt_data *ad, size_t ad_len,

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -10500,15 +10500,14 @@ u32_t radio_adv_enable(u16_t interval, u8_t chan_map, u8_t filter_policy,
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}
 
-		link = mem_acquire(&_radio.link_rx_free);
-		if (!link) {
-			return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
-		}
-
 		conn = mem_acquire(&_radio.conn_free);
 		if (!conn) {
-			mem_release(link, &_radio.link_rx_free);
+			return BT_HCI_ERR_CONN_LIMIT_EXCEEDED;
+		}
 
+		link = mem_acquire(&_radio.link_rx_free);
+		if (!link) {
+			mem_release(conn, &_radio.conn_free);
 			return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
 		}
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -274,7 +274,15 @@ int bt_hci_cmd_send_sync(u16_t opcode, struct net_buf *buf,
 	BT_DBG("opcode 0x%04x status 0x%02x", opcode, cmd(buf)->status);
 
 	if (cmd(buf)->status) {
-		err = -EIO;
+		switch (cmd(buf)->status) {
+		case BT_HCI_ERR_CONN_LIMIT_EXCEEDED:
+			err = -ECONNREFUSED;
+			break;
+		default:
+			err = -EIO;
+			break;
+		}
+
 		net_buf_unref(buf);
 	} else {
 		err = 0;


### PR DESCRIPTION
Translate HCI error codes to POSIX error codes in order to be able to
distinguish reason of connectable advertising start failure.

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>