### PR TITLE
C++ :  Fix error: template with C linkage

### DIFF
--- a/include/can.h
+++ b/include/can.h
@@ -20,13 +20,13 @@
  * @{
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <zephyr/types.h>
 #include <device.h>
 #include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define CAN_EX_ID      (1 << 31)
 #define CAN_MAX_STD_ID (0x7FF)

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -19,12 +19,12 @@
  * @{
  */
 
+#include <zephyr/types.h>
+#include <device.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <zephyr/types.h>
-#include <device.h>
 
 /*
  * The following #defines are used to configure the I2C controller.

--- a/include/sensor.h
+++ b/include/sensor.h
@@ -19,13 +19,13 @@
  * @{
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <zephyr/types.h>
 #include <device.h>
 #include <errno.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Representation of a sensor readout value.


### PR DESCRIPTION
If we include this headers files in cpp source code,
the compiler say"error: template with C linkage".

Includes must be moved outside the 'extern "C"' section.
