### PR TITLE
net: ip: Introduce mesh_local flag

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -75,7 +75,10 @@ struct net_if_addr {
 	/** Is this IP address used or not */
 	u8_t is_used : 1;
 
-	u8_t _unused : 6;
+	/** Is this IP address usage limited to the subnet (mesh) or not */
+	u8_t is_mesh_local : 1;
+
+	u8_t _unused : 5;
 };
 
 /**

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1970,6 +1970,13 @@ static struct in6_addr *net_if_ipv6_get_best_match(struct net_if *iface,
 
 		len = get_diff_ipv6(dst, &ipv6->unicast[i].address.in6_addr);
 		if (len >= *best_so_far) {
+			/* Mesh local address can only be selected for the same
+			 * subnet.
+			 */
+			if (ipv6->unicast[i].is_mesh_local && len < 64) {
+				continue;
+			}
+
 			*best_so_far = len;
 			src = &ipv6->unicast[i].address.in6_addr;
 		}

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -348,11 +348,12 @@ static void iface_cb(struct net_if *iface, void *user_data)
 			continue;
 		}
 
-		PR("\t%s %s %s%s\n",
+		PR("\t%s %s %s%s%s\n",
 		   net_sprint_ipv6_addr(&unicast->address.in6_addr),
 		   addrtype2str(unicast->addr_type),
 		   addrstate2str(unicast->addr_state),
-		   unicast->is_infinite ? " infinite" : "");
+		   unicast->is_infinite ? " infinite" : "",
+		   unicast->is_mesh_local ? " meshlocal" : "");
 		count++;
 	}
 

--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -12,6 +12,7 @@ LOG_MODULE_DECLARE(net_l2_openthread, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 #include <net/openthread.h>
 
 #include <openthread/ip6.h>
+#include <openthread/thread.h>
 
 #include "openthread_utils.h"
 
@@ -23,6 +24,15 @@ static bool is_anycast_locator(const otNetifAddress *address)
 	       address->mAddress.mFields.m16[5] == htons(0x00ff) &&
 	       address->mAddress.mFields.m16[6] == htons(0xfe00) &&
 	       address->mAddress.mFields.m8[14] == ALOC16_MASK;
+}
+
+static bool is_mesh_local(struct openthread_context *context,
+			  const u8_t *address)
+{
+	const otMeshLocalPrefix *ml_prefix =
+				otThreadGetMeshLocalPrefix(context->instance);
+
+	return (memcmp(address, ml_prefix->m8, sizeof(ml_prefix)) == 0);
 }
 
 int pkt_list_add(struct openthread_context *context, struct net_pkt *pkt)
@@ -77,6 +87,7 @@ void pkt_list_remove_last(struct openthread_context *context)
 void add_ipv6_addr_to_zephyr(struct openthread_context *context)
 {
 	const otNetifAddress *address;
+	struct net_if_addr *if_addr;
 
 	for (address = otIp6GetUnicastAddresses(context->instance);
 	     address; address = address->mNext) {
@@ -94,9 +105,18 @@ void add_ipv6_addr_to_zephyr(struct openthread_context *context)
 				       buf, sizeof(buf))));
 		}
 
-		net_if_ipv6_addr_add(context->iface,
-				     (struct in6_addr *)(&address->mAddress),
-				     NET_ADDR_ANY, 0);
+		if_addr = net_if_ipv6_addr_add(
+					context->iface,
+					(struct in6_addr *)(&address->mAddress),
+					NET_ADDR_AUTOCONF, 0);
+
+		if (if_addr == NULL) {
+			NET_ERR("Cannot add OpenThread unicast address");
+			continue;
+		}
+
+		if_addr->is_mesh_local = is_mesh_local(
+					context, address->mAddress.mFields.m8);
 	}
 }
 
@@ -123,6 +143,9 @@ void add_ipv6_addr_to_ot(struct openthread_context *context)
 			break;
 		}
 	}
+
+	ipv6->unicast[i].is_mesh_local = is_mesh_local(
+			context, ipv6->unicast[i].address.in6_addr.s6_addr);
 
 	addr.mValid = true;
 	addr.mPreferred = true;


### PR DESCRIPTION
This PR introduces a concept of mesh-local address. Such addresses (used for instance by Thread) are fine to use for on-mesh communication, but should not be used when sending packets off-mesh.

Source address selection algorithm needs to distinguish between addresses that have mesh-local (or Realm-local in IPv6 nomenclature) scope and other addresses. As they all have form of ULA, it cannot be distinguished on the address format itself, which lead to erroneous source address assignment. Therfore, an additional flag was added to the `net_if_addr ` structure that can store this information.

Mesh-local addresses will only be used as a source address for destinations placed within the same subnet (mesh).

A sample interface configuration is shown below. Starred addresses were marked as `meshlocal`, therefore they'll only be selected for on-mesh communication.
```
Interface 0x200149a0 (<unknown type>) [0]
=========================================
Link addr : 16:0F:22:72:A6:90:22:3D
MTU       : 1280
IPv6 unicast addresses (max 8):
        *fdde:ad00:beef:0:1bc2:6311:f1e7:31a4 autoconf preferred infinite meshlocal
        fe80::28a6:a531:967d:9660 autoconf preferred infinite
        *fdde:ad00:beef::2 manual preferred infinite meshlocal
        fd5f:a074:3e6e:5:1aec:4f9f:9138:4d39 autoconf preferred infinite
        fdbe:387:ce8d:15:1797:25ec:a7e5:92a3 autoconf preferred infinite
        2a02:f78:1:315:1696:202:12d0:762c autoconf preferred infinite
        fd11:22::2554:c337:1897:ab6f autoconf preferred infinite
IPv6 multicast addresses (max 8):
        ff33:40:fdde:ad00:beef::1
        ff32:40:fdde:ad00:beef::1
        ff02::1
        ff03::1
        ff03::fc
        ff02::2
        ff03::2
IPv6 prefixes (max 2):
        <none>
IPv6 hop limit           : 64
IPv6 base reachable time : 30000
IPv6 reachable time      : 38475
IPv6 retransmit timer    : 0
```

Resolves #12203