### PR TITLE
boards: arm: mps2_an385: Fix dtc warning

### DIFF
--- a/boards/arm/mps2_an385/mps2_an385.dts
+++ b/boards/arm/mps2_an385/mps2_an385.dts
@@ -129,7 +129,7 @@
 			interrupts = <17 3>;
 		};
 
-		eth0: eth@0 {
+		eth0: eth@40200000 {
 			/* Linux has "smsc,lan9115" */
 			compatible = "smsc,lan9220";
 			/* Such a big size from memory map in AN385 */


### PR DESCRIPTION
Fix dtc warning related to ethernet node name not matching the reg
property.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>