### PR TITLE
Modem receiver KConfig is missing CONFIG_UART_INTERRUPT_DRIVEN dependency

### DIFF
--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -15,6 +15,8 @@ if MODEM
 
 config MODEM_RECEIVER
 	bool "Enable modem receiver helper driver"
+	depends on SERIAL_SUPPORT_INTERRUPT
+	select UART_INTERRUPT_DRIVEN
 	help
 	  This driver allows modem drivers to communicate over UART with custom
 	  defined protocols. Driver doesn't inspect received data and all
@@ -41,8 +43,6 @@ config MODEM_SHELL
 
 config MODEM_WNCM14A2A
 	bool "Enable Wistron LTE-M modem driver"
-	depends on SERIAL_SUPPORT_INTERRUPT
-	select UART_INTERRUPT_DRIVEN
 	select MODEM_RECEIVER
 	select NET_OFFLOAD
 	select UART_MCUX_2 if BOARD_FRDM_K64F


### PR DESCRIPTION
It seems like modem receiver is missing `depends on CONFIG_UART_INTERRUPT_DRIVEN.`

Without `CONFIG_UART_INTERRUPT_DRIVEN`  we have the following output
```
[43/114] Building C object zephyr/CMakeFiles/zephyr.dir/drivers/modem/modem_receiver.c.obj
E:/fw_tests/zephyr/drivers/modem/modem_receiver.c: In function 'mdm_receiver_flush':
E:/fw_tests/zephyr/drivers/modem/modem_receiver.c:76:9: warning: implicit declaration of function 'uart_fifo_read' [-Wimplicit-function-declaration]
  while (uart_fifo_read(ctx->uart_dev, &c, 1) > 0) {
         ^~~~~~~~~~~~~~
E:/fw_tests/zephyr/drivers/modem/modem_receiver.c: In function 'mdm_receiver_isr':
E:/fw_tests/zephyr/drivers/modem/modem_receiver.c:99:9: warning: implicit declaration of function 'uart_irq_rx_ready' [-Wimplicit-function-declaration]
         uart_irq_rx_ready(ctx->uart_dev)) {
         ^~~~~~~~~~~~~~~~~
E:/fw_tests/zephyr/drivers/modem/modem_receiver.c: In function 'mdm_receiver_send':
E:/fw_tests/zephyr/drivers/modem/modem_receiver.c:136:13: warning: implicit declaration of function 'uart_fifo_fill' [-Wimplicit-function-declaration]
   written = uart_fifo_fill(ctx->uart_dev,
             ^~~~~~~~~~~~~~
E:/fw_tests/zephyr/drivers/modem/modem_receiver.c: In function 'mdm_receiver_setup':
E:/fw_tests/zephyr/drivers/modem/modem_receiver.c:162:2: warning: implicit declaration of function 'uart_irq_callback_set' [-Wimplicit-function-declaration]
  uart_irq_callback_set(ctx->uart_dev, mdm_receiver_isr);
  ^~~~~~~~~~~~~~~~~~~~~
```
The warnings are gone with added dependency.