### PR TITLE
atomic: Add atomic_set_bit_to() API

### DIFF
--- a/include/atomic.h
+++ b/include/atomic.h
@@ -412,6 +412,29 @@ static inline void atomic_set_bit(atomic_t *target, int bit)
 }
 
 /**
+ * @brief Atomically set a bit to a given value.
+ *
+ * Atomically set bit number @a bit of @a target to value @a val.
+ * The target may be a single atomic variable or an array of them.
+ *
+ * @param target Address of atomic variable or array.
+ * @param bit Bit number (starting from 0).
+ * @param val true for 1, false for 0.
+ *
+ * @return N/A
+ */
+static inline void atomic_set_bit_to(atomic_t *target, int bit, bool val)
+{
+	atomic_val_t mask = ATOMIC_MASK(bit);
+
+	if (val) {
+		(void)atomic_or(ATOMIC_ELEM(target, bit), mask);
+	} else {
+		(void)atomic_and(ATOMIC_ELEM(target, bit), ~mask);
+	}
+}
+
+/**
  * @}
  */
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -328,11 +328,7 @@ static int set_advertise_enable(bool enable)
 		return err;
 	}
 
-	if (enable) {
-		atomic_set_bit(bt_dev.flags, BT_DEV_ADVERTISING);
-	} else {
-		atomic_clear_bit(bt_dev.flags, BT_DEV_ADVERTISING);
-	}
+	atomic_set_bit_to(bt_dev.flags, BT_DEV_ADVERTISING, enable);
 
 	return 0;
 }
@@ -460,11 +456,8 @@ static int set_le_scan_enable(u8_t enable)
 		return err;
 	}
 
-	if (enable == BT_HCI_LE_SCAN_ENABLE) {
-		atomic_set_bit(bt_dev.flags, BT_DEV_SCANNING);
-	} else {
-		atomic_clear_bit(bt_dev.flags, BT_DEV_SCANNING);
-	}
+	atomic_set_bit_to(bt_dev.flags, BT_DEV_SCANNING,
+			  enable == BT_HCI_LE_SCAN_ENABLE);
 
 	return 0;
 }
@@ -3143,12 +3136,8 @@ static int start_le_scan(u8_t scan_type, u16_t interval, u16_t window)
 		return err;
 	}
 
-	if (scan_type == BT_HCI_LE_SCAN_ACTIVE) {
-		atomic_set_bit(bt_dev.flags, BT_DEV_ACTIVE_SCAN);
-	} else {
-		atomic_clear_bit(bt_dev.flags, BT_DEV_ACTIVE_SCAN);
-	}
-
+	atomic_set_bit_to(bt_dev.flags, BT_DEV_ACTIVE_SCAN,
+			  scan_type == BT_HCI_LE_SCAN_ACTIVE);
 
 	return 0;
 }
@@ -5435,11 +5424,8 @@ int bt_le_scan_start(const struct bt_le_scan_param *param, bt_le_scan_cb_t cb)
 		}
 	}
 
-	if (param->filter_dup) {
-		atomic_set_bit(bt_dev.flags, BT_DEV_SCAN_FILTER_DUP);
-	} else {
-		atomic_clear_bit(bt_dev.flags, BT_DEV_SCAN_FILTER_DUP);
-	}
+	atomic_set_bit_to(bt_dev.flags, BT_DEV_SCAN_FILTER_DUP,
+			  param->filter_dup);
 
 	err = start_le_scan(param->type, param->interval, param->window);
 	if (err) {
@@ -5682,17 +5668,10 @@ static int write_scan_enable(u8_t scan)
 		return err;
 	}
 
-	if (scan & BT_BREDR_SCAN_INQUIRY) {
-		atomic_set_bit(bt_dev.flags, BT_DEV_ISCAN);
-	} else {
-		atomic_clear_bit(bt_dev.flags, BT_DEV_ISCAN);
-	}
-
-	if (scan & BT_BREDR_SCAN_PAGE) {
-		atomic_set_bit(bt_dev.flags, BT_DEV_PSCAN);
-	} else {
-		atomic_clear_bit(bt_dev.flags, BT_DEV_PSCAN);
-	}
+	atomic_set_bit_to(bt_dev.flags, BT_DEV_ISCAN,
+			  (scan & BT_BREDR_SCAN_INQUIRY));
+	atomic_set_bit_to(bt_dev.flags, BT_DEV_PSCAN,
+			  (scan & BT_BREDR_SCAN_PAGE));
 
 	return 0;
 }

--- a/tests/kernel/common/src/atomic.c
+++ b/tests/kernel/common/src/atomic.c
@@ -142,6 +142,21 @@ void test_atomic(void)
 		zassert_true(target == (orig | (1 << i)), "atomic_set_bit");
 	}
 
+	/* atomic_set_bit_to(&target, i, false) */
+	for (i = 0; i < 32; i++) {
+		orig = 0x0F0F0F0F;
+		target = orig;
+		atomic_set_bit_to(&target, i, false);
+		zassert_true(target == (orig & ~(1 << i)), "atomic_set_bit_to");
+	}
+
+	/* atomic_set_bit_to(&target, i, true) */
+	for (i = 0; i < 32; i++) {
+		orig = 0x0F0F0F0F;
+		target = orig;
+		atomic_set_bit_to(&target, i, true);
+		zassert_true(target == (orig | (1 << i)), "atomic_set_bit_to");
+	}
 }
 /**
  * @}


### PR DESCRIPTION
Several places in the code have constructions like this:
```
        if (bool_variable) {
                atomic_set_bit(flags, FLAG);
        } else {
                atomic_clear_bit(flags, FLAG);
        }
```
To reduce the amount of code for such situations, introduce a new 
atomic_set_bit_to() helper which lets you condense the above five
lines to a single one:
```
        atomic_set_bit_to(flags, FLAG, bool_variable);
```

I've also included a simple patch to the Bluetooth subsystem to demonstrate how the new API can be taken advantage of - I do have other patches (in particular to Bluetooth Mesh) to do the same, however I'll leave those for later PRs.