### PR TITLE
gen_isr_tables: fix typo for 3rd level INTR config symbol

### DIFF
--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -214,7 +214,7 @@ def main():
             if "CONFIG_3RD_LEVEL_INTERRUPTS" in syms:
                 num_aggregators = syms["CONFIG_NUM_3RD_LEVEL_AGGREGATORS"]
                 irq3_baseoffset = syms["CONFIG_3RD_LVL_ISR_TBL_OFFSET"]
-                list_3rd_lvl_offsets = [syms['CONFIG_3RD_LEVEL_INTR_{}_OFFSET'.
+                list_3rd_lvl_offsets = [syms['CONFIG_3RD_LVL_INTR_{}_OFFSET'.
                                              format(str(i).zfill(2))] for i in
                                         range(num_aggregators)]
 


### PR DESCRIPTION
The script looks for CONFIG_3RD_LEVEL_INTR_xx_OFFSET while
the config is actually CONFIG_3RD_LVL_INTR_xx_OFFSET.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>