### PR TITLE
nvs: fix warnings in logger

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -745,10 +745,10 @@ int nvs_init(struct nvs_fs *fs, const char *dev_name)
 	}
 
 	LOG_INF("%d Sectors of %d bytes", fs->sector_count, fs->sector_size);
-	LOG_INF("alloc wra: %d, %" PRIx32 "",
+	LOG_INF("alloc wra: %d, %d",
 		(fs->ate_wra >> ADDR_SECT_SHIFT),
 		(fs->ate_wra & ADDR_OFFS_MASK));
-	LOG_INF("data wra: %d, %" PRIx32 "",
+	LOG_INF("data wra: %d, %d",
 		(fs->data_wra >> ADDR_SECT_SHIFT),
 		(fs->data_wra & ADDR_OFFS_MASK));
 	LOG_INF("Free space: %d", fs->free_space);


### PR DESCRIPTION
When compiling NVS with NEWLIB_LIBC=y, GCC outputs the following
warning:

In file included from $ZEPHYR/include/logging/log.h:11:0,
                 from $ZEPHYR/subsys/fs/nvs/nvs.c:17:
$ZEPHYR/subsys/fs/nvs/nvs.c: In function 'nvs_init':
$ZEPHYR/subsys/fs/nvs/nvs.c:748:10: warning: format '%lx' expects
argument of type 'long unsigned int', but argument 3 has type 'u32_t
{aka unsigned int}' [-Wformat=]
  LOG_INF("alloc wra: %d, %" PRIx32 "",
          ^
fs->ate_wra and fs->data_wra are both defined as u32_t, so they need to
be printed with '%d'.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>