### PR TITLE
nvs: fix alloc/data wra log format string

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -745,10 +745,10 @@ int nvs_init(struct nvs_fs *fs, const char *dev_name)
 	}
 
 	LOG_INF("%d Sectors of %d bytes", fs->sector_count, fs->sector_size);
-	LOG_INF("alloc wra: %d, %d",
+	LOG_INF("alloc wra: %d, %x",
 		(fs->ate_wra >> ADDR_SECT_SHIFT),
 		(fs->ate_wra & ADDR_OFFS_MASK));
-	LOG_INF("data wra: %d, %d",
+	LOG_INF("data wra: %d, %x",
 		(fs->data_wra >> ADDR_SECT_SHIFT),
 		(fs->data_wra & ADDR_OFFS_MASK));
 	LOG_INF("Free space: %d", fs->free_space);


### PR DESCRIPTION
Commit 41f86c3db2 ("nvs: fix warnings in logger") wrongly changed the
"%d" into "%x" while it was only supposed to suppress the warning.

This patch switches back the format string to "%x".

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>