### PR TITLE
drivers: eth: gmac: fix race condition in packet reference counting

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1396,10 +1396,10 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 	/* Account for a sent frame */
 	ring_buf_put(&queue->tx_frames, POINTER_TO_UINT(pkt));
 
-	irq_unlock(key);
-
 	/* pkt is internally queued, so it requires to hold a reference */
 	net_pkt_ref(pkt);
+
+	irq_unlock(key);
 
 	/* Guarantee that the first fragment got its bit removed before starting
 	 * sending packets to avoid packets getting stuck.


### PR DESCRIPTION
The SAM E70 GMAC ethernet driver reference a packet with net_pkt_ref()
when queueing a packet, and unreference it with net_pkt_unref() in the
ISR when it has been fully sent.

The call to net_pkt_ref() is done just after re-enabling the
interruptions, so there is however a small race condition that might
cause the packet to be unreference before being referenced. This is
only theoretical and has not been seen in practice.

Fix that by moving the call to net_pkt_ref() just before re-enabling
the interruptions.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>