### PR TITLE
linker: x86: add orphan linker sections

### DIFF
--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -107,6 +107,7 @@ SECTIONS
 	*(.text)
 	*(".text.*")
 	*(.gnu.linkonce.t.*)
+	*(.eh_frame_hdr)
 	*(.eh_frame)
 	*(.init)
 	*(.fini)
@@ -449,6 +450,8 @@ SECTIONS
 #endif
 
 #include <linker/debug-sections.ld>
+
+	/DISCARD/ : { *(.note.GNU-stack) }
 
 	}
 

--- a/include/linker/debug-sections.ld
+++ b/include/linker/debug-sections.ld
@@ -7,6 +7,7 @@
 	SECTION_PROLOGUE(.stab.exclstr, 0,)    { *(.stab.exclstr) }
 	SECTION_PROLOGUE(.stab.index, 0,)      { *(.stab.index) }
 	SECTION_PROLOGUE(.stab.indexstr, 0,)   { *(.stab.indexstr) }
+	SECTION_PROLOGUE(.gnu.build.attributes, 0,) { *(.gnu.build.attributes .gnu.build.attributes.*) }
 	SECTION_PROLOGUE(.comment, 0,)         { *(.comment) }
 	/* DWARF debug sections.
 	   Symbols in the DWARF debugging sections are relative to the beginning


### PR DESCRIPTION
Add missing linker section to avoid warning about orphans when building
with host compiler.

Fixes #12719