### PR TITLE
cmake: dtc: silence output from check_dtc_flag

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -709,6 +709,7 @@ function(check_dtc_flag flag ok)
     COMMAND
     ${DTC} ${flag} -v
     ERROR_QUIET
+    OUTPUT_QUIET
     RESULT_VARIABLE dtc_check_ret
   )
   if (dtc_check_ret EQUAL 0)


### PR DESCRIPTION
We'd get output from a cmake build that would have lines like:

Version: DTC 1.4.7
Version: DTC 1.4.7

This was a side effect of check_dtc_flag.  Add the OUTPUT_QUIET option
to execute_process to supress this output.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>