### PR TITLE
dts: intel_s1000: Fix dtc warnings

### DIFF
--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
@@ -7,7 +7,7 @@
 	compatible = "intel,s1000";
 
 	aliases {
-		uart_0 = &uart0;
+		uart-0 = &uart0;
 	};
 
 	chosen {

--- a/dts/xtensa/intel_s1000.dtsi
+++ b/dts/xtensa/intel_s1000.dtsi
@@ -97,9 +97,9 @@
 			#gpio-cells = <2>;
 		};
 
-		pinmux: pinmux@81C30 {
+		pinmux: pinmux@81c30 {
 			compatible = "intel,s1000-pinmux";
-			reg = <0x00081C30 0xC>;
+			reg = <0x00081c30 0xC>;
 		};
 
 		uart0: uart@80800 {


### PR DESCRIPTION
Fix the following dtc warnings on S1000:

	Warning (simple_bus_reg): /soc/pinmux@81C30: simple-bus unit
	address format error, expected "81c30"

	Warning (alias_paths): /aliases: aliases property name must
	include only lowercase and '-'

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>