### PR TITLE
nrf52_bsim: Fix copy pasted comment

### DIFF
--- a/boards/posix/nrf52_bsim/Kconfig.defconfig
+++ b/boards/posix/nrf52_bsim/Kconfig.defconfig
@@ -26,7 +26,7 @@ if LOG
 config LOG_BACKEND_NATIVE_POSIX
 	default y if !SERIAL
 
-# For native_posix we can log immediately without any problem
+# For this board we can log immediately without any problem
 # Doing so will be nicer for debugging
 config LOG_INPLACE_PROCESS
 	default y


### PR DESCRIPTION
A comment which had been copied straight from the native_posix
board refered to the nrf52_bsim board as native_posix,
which it is not, and may confuse users.
Fix it.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>