### PR TITLE
Add net_buf_pull_mem() API

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -297,6 +297,19 @@ void net_buf_simple_push_u8(struct net_buf_simple *buf, u8_t val);
 void *net_buf_simple_pull(struct net_buf_simple *buf, size_t len);
 
 /**
+ *  @brief Remove data from the beginning of the buffer.
+ *
+ *  Removes data from the beginning of the buffer by modifying the data
+ *  pointer and buffer length.
+ *
+ *  @param buf Buffer to update.
+ *  @param len Number of bytes to remove.
+ *
+ *  @return Pointer to the old location of the buffer data.
+ */
+void *net_buf_simple_pull_mem(struct net_buf_simple *buf, size_t len);
+
+/**
  *  @brief Remove a 8-bit value from the beginning of the buffer
  *
  *  Same idea as with net_buf_simple_pull(), but a helper for operating
@@ -1146,6 +1159,20 @@ static inline void *net_buf_user_data(const struct net_buf *buf)
  *  @return New beginning of the buffer data.
  */
 #define net_buf_pull(buf, len) net_buf_simple_pull(&(buf)->b, len)
+
+/**
+ *  @def net_buf_pull_mem
+ *  @brief Remove data from the beginning of the buffer.
+ *
+ *  Removes data from the beginning of the buffer by modifying the data
+ *  pointer and buffer length.
+ *
+ *  @param buf Buffer to update.
+ *  @param len Number of bytes to remove.
+ *
+ *  @return Pointer to the old beginning of the buffer data.
+ */
+#define net_buf_pull_mem(buf, len) net_buf_simple_pull_mem(&(buf)->b, len)
 
 /**
  *  @def net_buf_pull_u8

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2090,10 +2090,8 @@ static int mesh_cmd_handle(struct net_buf *cmd, struct net_buf **evt)
 		return -EINVAL;
 	}
 
-	cp_mesh = (void *)cmd->data;
+	cp_mesh = net_buf_pull_mem(cmd, sizeof(*cp_mesh));
 	mesh_op = cp_mesh->opcode;
-
-	net_buf_pull(cmd, sizeof(*cp_mesh));
 
 	switch (mesh_op) {
 	case BT_HCI_OC_MESH_GET_OPTS:
@@ -2205,16 +2203,14 @@ struct net_buf *hci_cmd_handle(struct net_buf *cmd, void **node_rx)
 		return NULL;
 	}
 
-	chdr = (void *)cmd->data;
-	/* store in a global for later CC/CS event creation */
-	_opcode = sys_le16_to_cpu(chdr->opcode);
-
+	chdr = net_buf_pull_mem(cmd, sizeof(*chdr));
 	if (cmd->len < chdr->param_len) {
 		BT_ERR("Invalid HCI CMD packet length");
 		return NULL;
 	}
 
-	net_buf_pull(cmd, sizeof(*chdr));
+	/* store in a global for later CC/CS event creation */
+	_opcode = sys_le16_to_cpu(chdr->opcode);
 
 	ocf = BT_OCF(_opcode);
 
@@ -2284,10 +2280,9 @@ int hci_acl_handle(struct net_buf *buf, struct net_buf **evt)
 		return -EINVAL;
 	}
 
-	acl = (void *)buf->data;
+	acl = net_buf_pull_mem(buf, sizeof(*acl));
 	len = sys_le16_to_cpu(acl->len);
 	handle = sys_le16_to_cpu(acl->handle);
-	net_buf_pull(buf, sizeof(*acl));
 
 	if (buf->len < len) {
 		BT_ERR("Invalid HCI ACL packet length");

--- a/subsys/bluetooth/host/avdtp.c
+++ b/subsys/bluetooth/host/avdtp.c
@@ -145,7 +145,7 @@ void bt_avdtp_l2cap_encrypt_changed(struct bt_l2cap_chan *chan, u8_t status)
 
 int bt_avdtp_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
-	struct bt_avdtp_single_sig_hdr *hdr = (void *)buf->data;
+	struct bt_avdtp_single_sig_hdr *hdr;
 	struct bt_avdtp *session = AVDTP_CHAN(chan);
 	u8_t i, msgtype, sigid, tid;
 
@@ -154,13 +154,13 @@ int bt_avdtp_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		return 0;
 	}
 
+	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
 	msgtype = AVDTP_GET_MSG_TYPE(hdr->hdr);
 	sigid = AVDTP_GET_SIG_ID(hdr->signal_id);
 	tid = AVDTP_GET_TR_ID(hdr->hdr);
 
 	BT_DBG("msg_type[0x%02x] sig_id[0x%02x] tid[0x%02x]",
 		msgtype, sigid, tid);
-	net_buf_pull(buf, sizeof(*hdr));
 
 	/* validate if there is an outstanding resp expected*/
 	if (msgtype != BT_AVDTP_CMD) {

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1278,7 +1278,7 @@ static void reject_cmd(struct bt_l2cap *l2cap, u8_t ident,
 static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_l2cap *l2cap = CONTAINER_OF(chan, struct bt_l2cap, chan);
-	struct bt_l2cap_sig_hdr *hdr = (void *)buf->data;
+	struct bt_l2cap_sig_hdr *hdr;
 	u16_t len;
 
 	if (buf->len < sizeof(*hdr)) {
@@ -1286,8 +1286,8 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		return 0;
 	}
 
+	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
 	len = sys_le16_to_cpu(hdr->len);
-	net_buf_pull(buf, sizeof(*hdr));
 
 	BT_DBG("Signaling code 0x%02x ident %u len %u", hdr->code,
 	       hdr->ident, len);
@@ -1575,7 +1575,7 @@ static void l2cap_chan_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 void bt_l2cap_recv(struct bt_conn *conn, struct net_buf *buf)
 {
-	struct bt_l2cap_hdr *hdr = (void *)buf->data;
+	struct bt_l2cap_hdr *hdr;
 	struct bt_l2cap_chan *chan;
 	u16_t cid;
 
@@ -1591,8 +1591,8 @@ void bt_l2cap_recv(struct bt_conn *conn, struct net_buf *buf)
 		return;
 	}
 
+	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
 	cid = sys_le16_to_cpu(hdr->cid);
-	net_buf_pull(buf, sizeof(*hdr));
 
 	BT_DBG("Packet for CID %u len %u", cid, buf->len);
 

--- a/subsys/bluetooth/host/mesh/beacon.c
+++ b/subsys/bluetooth/host/mesh/beacon.c
@@ -283,8 +283,7 @@ static void secure_beacon_recv(struct net_buf_simple *buf)
 	data = buf->data;
 
 	flags = net_buf_simple_pull_u8(buf);
-	net_id = buf->data;
-	net_buf_simple_pull(buf, 8);
+	net_id = net_buf_simple_pull(buf, 8);
 	iv_index = net_buf_simple_pull_be32(buf);
 	auth = buf->data;
 

--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -1252,9 +1252,7 @@ static void mod_pub_va_set(struct bt_mesh_model *model,
 		return;
 	}
 
-	label_uuid = buf->data;
-	net_buf_simple_pull(buf, 16);
-
+	label_uuid = net_buf_simple_pull_mem(buf, 16);
 	pub_app_idx = net_buf_simple_pull_le16(buf);
 	cred_flag = ((pub_app_idx >> 12) & BIT_MASK(1));
 	pub_app_idx &= BIT_MASK(12);
@@ -1784,8 +1782,7 @@ static void mod_sub_va_add(struct bt_mesh_model *model,
 		return;
 	}
 
-	label_uuid = buf->data;
-	net_buf_simple_pull(buf, 16);
+	label_uuid = net_buf_simple_pull_mem(buf, 16);
 
 	BT_DBG("elem_addr 0x%04x", elem_addr);
 
@@ -1862,8 +1859,7 @@ static void mod_sub_va_del(struct bt_mesh_model *model,
 		return;
 	}
 
-	label_uuid = buf->data;
-	net_buf_simple_pull(buf, 16);
+	label_uuid = net_buf_simple_pull_mem(buf, 16);
 
 	BT_DBG("elem_addr 0x%04x", elem_addr);
 
@@ -1930,8 +1926,7 @@ static void mod_sub_va_overwrite(struct bt_mesh_model *model,
 		return;
 	}
 
-	label_uuid = buf->data;
-	net_buf_simple_pull(buf, 16);
+	label_uuid = net_buf_simple_pull_mem(buf, 16);
 
 	BT_DBG("elem_addr 0x%04x", elem_addr);
 

--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -1262,16 +1262,20 @@ static void rfcomm_handle_disc(struct bt_rfcomm_session *session, u8_t dlci)
 static void rfcomm_handle_msg(struct bt_rfcomm_session *session,
 			      struct net_buf *buf)
 {
-	struct bt_rfcomm_msg_hdr *hdr = (void *)buf->data;
+	struct bt_rfcomm_msg_hdr *hdr;
 	u8_t msg_type, len, cr;
 
+	if (buf->len < sizeof(*hdr)) {
+		BT_ERR("Too small RFCOMM message");
+		return;
+	}
+
+	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
 	msg_type = BT_RFCOMM_GET_MSG_TYPE(hdr->type);
 	cr = BT_RFCOMM_GET_MSG_CR(hdr->type);
 	len = BT_RFCOMM_GET_LEN(hdr->len);
 
 	BT_DBG("msg type %x cr %x", msg_type, cr);
-
-	net_buf_pull(buf, sizeof(*hdr));
 
 	switch (msg_type) {
 	case BT_RFCOMM_PN:

--- a/subsys/bluetooth/host/sdp.c
+++ b/subsys/bluetooth/host/sdp.c
@@ -1339,7 +1339,7 @@ static int bt_sdp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	struct bt_l2cap_br_chan *ch = CONTAINER_OF(chan,
 			struct bt_l2cap_br_chan, chan);
 	struct bt_sdp *sdp = CONTAINER_OF(ch, struct bt_sdp, chan);
-	struct bt_sdp_hdr *hdr = (struct bt_sdp_hdr *)buf->data;
+	struct bt_sdp_hdr *hdr;
 	u16_t err = BT_SDP_INVALID_SYNTAX;
 	size_t i;
 
@@ -1352,9 +1352,8 @@ static int bt_sdp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		return 0;
 	}
 
+	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
 	BT_DBG("Received SDP code 0x%02x len %u", hdr->op_code, buf->len);
-
-	net_buf_pull(buf, sizeof(*hdr));
 
 	if (sys_cpu_to_be16(hdr->param_len) != buf->len) {
 		err = BT_SDP_INVALID_PDU_SIZE;
@@ -1719,7 +1718,7 @@ static void sdp_client_notify_result(struct bt_sdp_client *session,
 static int sdp_client_receive(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_sdp_client *session = SDP_CLIENT_CHAN(chan);
-	struct bt_sdp_hdr *hdr = (void *)buf->data;
+	struct bt_sdp_hdr *hdr;
 	struct bt_sdp_pdu_cstate *cstate;
 	u16_t len, tid, frame_len;
 	u16_t total;
@@ -1731,6 +1730,7 @@ static int sdp_client_receive(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		return 0;
 	}
 
+	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
 	if (hdr->op_code == BT_SDP_ERROR_RSP) {
 		BT_INFO("Error SDP PDU response");
 		return 0;
@@ -1738,7 +1738,6 @@ static int sdp_client_receive(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 	len = sys_be16_to_cpu(hdr->param_len);
 	tid = sys_be16_to_cpu(hdr->tid);
-	net_buf_pull(buf, sizeof(*hdr));
 
 	BT_DBG("SDP PDU tid %u len %u", tid, len);
 

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1299,7 +1299,7 @@ static int smp_br_error(struct bt_smp_br *smp, u8_t reason)
 static int bt_smp_br_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_smp_br *smp = CONTAINER_OF(chan, struct bt_smp_br, chan);
-	struct bt_smp_hdr *hdr = (void *)buf->data;
+	struct bt_smp_hdr *hdr;
 	u8_t err;
 
 	if (buf->len < sizeof(*hdr)) {
@@ -1307,9 +1307,8 @@ static int bt_smp_br_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		return 0;
 	}
 
+	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
 	BT_DBG("Received SMP code 0x%02x len %u", hdr->code, buf->len);
-
-	net_buf_pull(buf, sizeof(*hdr));
 
 	/*
 	 * If SMP timeout occurred "no further SMP commands shall be sent over
@@ -3513,7 +3512,7 @@ static const struct {
 static int bt_smp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_smp *smp = CONTAINER_OF(chan, struct bt_smp, chan);
-	struct bt_smp_hdr *hdr = (void *)buf->data;
+	struct bt_smp_hdr *hdr;
 	u8_t err;
 
 	if (buf->len < sizeof(*hdr)) {
@@ -3521,9 +3520,8 @@ static int bt_smp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		return 0;
 	}
 
+	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
 	BT_DBG("Received SMP code 0x%02x len %u", hdr->code, buf->len);
-
-	net_buf_pull(buf, sizeof(*hdr));
 
 	/*
 	 * If SMP timeout occurred "no further SMP commands shall be sent over

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -868,6 +868,20 @@ void *net_buf_simple_pull(struct net_buf_simple *buf, size_t len)
 	return buf->data += len;
 }
 
+void *net_buf_simple_pull_mem(struct net_buf_simple *buf, size_t len)
+{
+	void *data = buf->data;
+
+	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
+
+	NET_BUF_SIMPLE_ASSERT(buf->len >= len);
+
+	buf->len -= len;
+	buf->data += len;
+
+	return data;
+}
+
 u8_t net_buf_simple_pull_u8(struct net_buf_simple *buf)
 {
 	u8_t val;


### PR DESCRIPTION
The new API added in this PR was recently requested in issue #12562. While it's not a good idea to change the existing semantics of net_buf_pull(), we can add a new API called net_buf_pull_mem() which behaves the same, except that it returns the old data pointer. It turns out that many places in the code become more readable this way.