### PR TITLE
drivers: sensor: hts221: support triggered readings

### DIFF
--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
@@ -98,6 +98,7 @@
 		compatible = "st,hts221";
 		reg = <0x5f>;
 		label = "HTS221";
+		drdy-gpios = <&gpio0 24 GPIO_INT_ACTIVE_HIGH>;
 	};
 
 	ccs811: ccs811@5a {

--- a/drivers/sensor/hts221/hts221.c
+++ b/drivers/sensor/hts221/hts221.c
@@ -17,6 +17,10 @@
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
 LOG_MODULE_REGISTER(HTS221);
 
+static const char * const hts221_odr_strings[] = {
+	"1", "7", "12.5"
+};
+
 static int hts221_channel_get(struct device *dev,
 			       enum sensor_channel chan,
 			       struct sensor_value *val)

--- a/drivers/sensor/hts221/hts221.c
+++ b/drivers/sensor/hts221/hts221.c
@@ -14,7 +14,7 @@
 
 #include "hts221.h"
 
-#define LOG_LEVEL CONFIG_SENSOR_LEVEL
+#define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
 LOG_MODULE_REGISTER(HTS221);
 
 static int hts221_channel_get(struct device *dev,

--- a/drivers/sensor/hts221/hts221.h
+++ b/drivers/sensor/hts221/hts221.h
@@ -19,7 +19,7 @@
 
 #define HTS221_REG_CTRL1		0x20
 #define HTS221_PD_BIT			BIT(7)
-#define HTS221_BDU_BIT			BIT(3)
+#define HTS221_BDU_BIT			BIT(2)
 #define HTS221_ODR_SHIFT		0
 
 #define HTS221_REG_CTRL3		0x22

--- a/drivers/sensor/hts221/hts221.h
+++ b/drivers/sensor/hts221/hts221.h
@@ -28,10 +28,6 @@
 #define HTS221_REG_DATA_START		0x28
 #define HTS221_REG_CONVERSION_START	0x30
 
-static const char * const hts221_odr_strings[] = {
-	"1", "7", "12.5"
-};
-
 struct hts221_data {
 	struct device *i2c;
 	s16_t rh_sample;

--- a/dts/bindings/sensor/st,hts221.yaml
+++ b/dts/bindings/sensor/st,hts221.yaml
@@ -21,6 +21,7 @@ properties:
     drdy-gpios:
       type: compound
       category: optional
+      description: DRDY pin
       generation: define, use-prop-name
 
 ...

--- a/samples/sensor/hts221/src/main.c
+++ b/samples/sensor/hts221/src/main.c
@@ -10,9 +10,44 @@
 #include <stdio.h>
 #include <misc/util.h>
 
+static void process_sample(struct device *dev)
+{
+	static unsigned int obs;
+	struct sensor_value temp, hum;
+	if (sensor_sample_fetch(dev) < 0) {
+		printf("Sensor sample update error\n");
+		return;
+	}
+
+	if (sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &temp) < 0) {
+		printf("Cannot read HTS221 temperature channel\n");
+		return;
+	}
+
+	if (sensor_channel_get(dev, SENSOR_CHAN_HUMIDITY, &hum) < 0) {
+		printf("Cannot read HTS221 humidity channel\n");
+		return;
+	}
+
+	++obs;
+	printf("Observation:%u\n", obs);
+
+	/* display temperature */
+	printf("Temperature:%.1f C\n", sensor_value_to_double(&temp));
+
+	/* display humidity */
+	printf("Relative Humidity:%.1f%%\n",
+	       sensor_value_to_double(&hum));
+}
+
+static void hts221_handler(struct device *dev,
+			   struct sensor_trigger *trig)
+{
+	process_sample(dev);
+}
+
 void main(void)
 {
-	struct sensor_value temp, hum;
 	struct device *dev = device_get_binding("HTS221");
 
 	if (dev == NULL) {
@@ -20,29 +55,20 @@ void main(void)
 		return;
 	}
 
-	while (1) {
-		if (sensor_sample_fetch(dev) < 0) {
-			printf("Sensor sample update error\n");
+	if (IS_ENABLED(CONFIG_HTS221_TRIGGER)) {
+		struct sensor_trigger trig = {
+			.type = SENSOR_TRIG_DATA_READY,
+			.chan = SENSOR_CHAN_ALL,
+		};
+		if (sensor_trigger_set(dev, &trig, hts221_handler) < 0) {
+			printf("Cannot configure trigger\n");
 			return;
-		}
+		};
+	}
 
-		if (sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &temp) < 0) {
-			printf("Cannot read HTS221 temperature channel\n");
-			return;
-		}
-
-		if (sensor_channel_get(dev, SENSOR_CHAN_HUMIDITY, &hum) < 0) {
-			printf("Cannot read HTS221 humidity channel\n");
-			return;
-		}
-
-		/* display temperature */
-		printf("Temperature:%.1f C\n", sensor_value_to_double(&temp));
-
-		/* display humidity */
-		printf("Relative Humidity:%.1f%%\n",
-		       sensor_value_to_double(&hum));
-
+	while (!IS_ENABLED(CONFIG_HTS221_TRIGGER)) {
+		process_sample(dev);
 		k_sleep(2000);
 	}
+	k_sleep(K_FOREVER);
 }


### PR DESCRIPTION
This PR fixes an error in configuring for triggered readings and updates the sample to support this feature.

Tested on `nrf52_pca20020` (Thingy:52).  Verified non-trigger on `x-nucleo-iks01a2` but trigger support can't be verified until #12703 gets some love.