### PR TITLE
doc: reduce sample index clutter

### DIFF
--- a/samples/samples.rst
+++ b/samples/samples.rst
@@ -5,7 +5,7 @@ Samples and Demos
 
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
    :glob:
 
    kernel
@@ -24,5 +24,6 @@ Samples and Demos
    portability/*
    gui/*
 
-To add a new sample document, please use the template available under
-:file:`doc/templates/sample.tmpl`
+.. comment
+   To add a new sample document, please use the template available under
+   :file:`doc/templates/sample.tmpl`


### PR DESCRIPTION
Docs in the samples folder are a mixture of samples and sample indexes
of more samples, cluttering the index display. This change eliminates
the clutter, be we should reorganize the sample docs so we have a
consistent doc hierarchy (and improved organization).

Fixes: #12758

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>