### PR TITLE
boards: particle: fix BT selection

### DIFF
--- a/boards/arm/particle_argon/Kconfig.defconfig
+++ b/boards/arm/particle_argon/Kconfig.defconfig
@@ -40,4 +40,11 @@ config IEEE802154_NRF5
 
 endif # IEEE802154
 
+if BT
+
+config BT_CTLR
+	default y
+
+endif # BT
+
 endif # BOARD_PARTICLE_ARGON

--- a/boards/arm/particle_boron/Kconfig.defconfig
+++ b/boards/arm/particle_boron/Kconfig.defconfig
@@ -40,4 +40,11 @@ config IEEE802154_NRF5
 
 endif # IEEE802154
 
+if BT
+
+config BT_CTLR
+	default y
+
+endif # BT
+
 endif # BOARD_PARTICLE_BORON

--- a/boards/arm/particle_xenon/Kconfig.defconfig
+++ b/boards/arm/particle_xenon/Kconfig.defconfig
@@ -41,4 +41,11 @@ config IEEE802154_NRF5
 
 endif # IEEE802154
 
+if BT
+
+config BT_CTLR
+	default y
+
+endif # BT
+
 endif # BOARD_PARTICLE_XENON


### PR DESCRIPTION
When selecting BT we need to select BT_CTRL for most bluetooth
samples to work correctly.

Let's fix that in the board files.

Fixes the following error when CONFIG_BT is selected:
```
zephyr/drivers/bluetooth/hci/h4.c:463:30:
error: ‘CONFIG_BT_UART_ON_DEV_NAME’ undeclared (first use in
this function)
  h4_dev = device_get_binding(CONFIG_BT_UART_ON_DEV_NAME);
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
```

Signed-off-by: Michael Scott <mike@foundries.io>