### PR TITLE
shell: meta-keys handle condition update

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -88,8 +88,9 @@ config SHELL_METAKEYS
 	bool "Enable metakeys"
 	default y
 	help
-	  Enables shell metakeys: Home, End, ctrl+a, ctrl+c, ctrl+e, ctrl+l,
-	  ctrl+u, ctrl+w
+	  Enables shell meta keys: Ctrl+a, Ctrl+b, Ctrl+c, Ctrl+d, Ctrl+e,
+	  Ctrl+f, Ctrl+k, Ctrl+l, Ctrl+u, Ctrl+w, Alt+b, Alt+f
+	  Meta keys will not be active when shell echo is set to off.
 
 config SHELL_HELP
 	bool "Enable help message"

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -949,7 +949,7 @@ static void state_collect(const struct shell *shell)
 				if (isprint((int) data)) {
 					flag_history_exit_set(shell, true);
 					shell_op_char_insert(shell, data);
-				} else {
+				} else if (flag_echo_get(shell)) {
 					ctrl_metakeys_handle(shell, data);
 				}
 				break;
@@ -960,11 +960,11 @@ static void state_collect(const struct shell *shell)
 			if (data == '[') {
 				receive_state_change(shell,
 						SHELL_RECEIVE_ESC_SEQ);
-			} else {
+				break;
+			} else if (flag_echo_get(shell)) {
 				alt_metakeys_handle(shell, data);
-				receive_state_change(shell,
-						SHELL_RECEIVE_DEFAULT);
 			}
+			receive_state_change(shell, SHELL_RECEIVE_DEFAULT);
 			break;
 
 		case SHELL_RECEIVE_ESC_SEQ:

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -258,7 +258,7 @@ static void data_insert(const struct shell *shell, const char *data, u16_t len)
 	reprint_from_cursor(shell, after, false);
 }
 
-void char_replace(const struct shell *shell, char data)
+static void char_replace(const struct shell *shell, char data)
 {
 	shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos++] = data;
 

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -261,6 +261,11 @@ static void data_insert(const struct shell *shell, const char *data, u16_t len)
 void char_replace(const struct shell *shell, char data)
 {
 	shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos++] = data;
+
+	if (!flag_echo_get(shell)) {
+		return;
+	}
+
 	shell_raw_fprintf(shell->fprintf_ctx, "%c", data);
 	if (shell_cursor_in_empty_line(shell)) {
 		cursor_next_line_move(shell);

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -181,8 +181,6 @@ void shell_op_cursor_home_move(const struct shell *shell);
 /* Function moves cursor to end of command. */
 void shell_op_cursor_end_move(const struct shell *shell);
 
-void char_replace(const struct shell *shell, char data);
-
 void shell_op_char_insert(const struct shell *shell, char data);
 
 void shell_op_char_backspace(const struct shell *shell);


### PR DESCRIPTION
Meta keys are active when they are enabled and when shell echo is set to on.
Updated meta keys description in shell's Kconfig file.

This change has been discussed with @aescolar in POSIX context.