### PR TITLE
doc: west: Do not fail doc build if west not used

### DIFF
--- a/doc/tools/west/flash-debug.rst
+++ b/doc/tools/west/flash-debug.rst
@@ -246,10 +246,8 @@ upstream Zephyr, the runner should be added into a new or existing
    changes break existing test cases, CI testing on upstream pull
    requests will fail.
 
-API Documentation for the ``runners.core`` module follows.
-
-.. automodule:: runners.core
-   :members:
+API Documentation for the ``runners.core`` module can be found in
+:ref:`west-apis`.
 
 Doing it By Hand
 ****************

--- a/doc/tools/west/west-apis.rst
+++ b/doc/tools/west/west-apis.rst
@@ -5,4 +5,6 @@
 West APIs
 #########
 
+.. automodule:: runners.core
+   :members:
 

--- a/doc/tools/west/west-not-found.rst
+++ b/doc/tools/west/west-not-found.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+.. _west-apis:
+
+West APIs
+#########
+
+The west APIs are not documented since either west was missing or the zephyr
+repository was not initialized using west during the documentation build.
+


### PR DESCRIPTION
In case west is not present or was not used to initialize the local
zephyr repository, avoid failing the documentation build by including a
placeholder file.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>