### PR TITLE
Generic socket CAN support

### DIFF
--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -297,7 +297,7 @@ struct net_context {
 	u16_t flags;
 
 	/** Network interface assigned to this context */
-	u8_t iface;
+	s8_t iface;
 };
 
 static inline bool net_context_is_used(struct net_context *context)

--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -50,7 +50,7 @@ enum net_context_state {
  * stored into a bit field to save space.
  */
 /** Protocol family of this connection */
-#define NET_CONTEXT_FAMILY (BIT(4) | BIT(5))
+#define NET_CONTEXT_FAMILY (BIT(3) | BIT(4) | BIT(5))
 
 /** Type of the connection (datagram / stream / raw) */
 #define NET_CONTEXT_TYPE   (BIT(6) | BIT(7))
@@ -361,7 +361,7 @@ static inline sa_family_t net_context_get_family(struct net_context *context)
 {
 	NET_ASSERT(context);
 
-	return ((context->flags & NET_CONTEXT_FAMILY) >> 4);
+	return ((context->flags & NET_CONTEXT_FAMILY) >> 3);
 }
 
 /**
@@ -371,7 +371,7 @@ static inline sa_family_t net_context_get_family(struct net_context *context)
  * of the context.
  *
  * @param context Network context.
- * @param family Address family (AF_INET, AF_INET6 or AF_PACKET)
+ * @param family Address family (AF_INET, AF_INET6, AF_PACKET, AF_CAN)
  */
 static inline void net_context_set_family(struct net_context *context,
 					  sa_family_t family)
@@ -380,10 +380,10 @@ static inline void net_context_set_family(struct net_context *context,
 
 	NET_ASSERT(context);
 
-	if (family == AF_UNSPEC || family == AF_INET ||
-	    family == AF_INET6 || family == AF_PACKET) {
-		/* Family is in BIT(4) and BIT(5)*/
-		flag = family << 4;
+	if (family == AF_UNSPEC || family == AF_INET || family == AF_INET6 ||
+	    family == AF_PACKET || family == AF_CAN) {
+		/* Family is in BIT(4), BIT(5) and BIT(6) */
+		flag = family << 3;
 	}
 
 	context->flags |= flag;

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -155,6 +155,11 @@ struct sockaddr_ll_ptr {
 	u8_t        *sll_addr;    /* Physical-layer address  */
 };
 
+struct sockaddr_can_ptr {
+	sa_family_t can_family;
+	int         can_ifindex;
+};
+
 /* Packet types.  */
 #define PACKET_HOST         0     /* To us            */
 #define PACKET_BROADCAST    1     /* To all           */
@@ -1062,6 +1067,20 @@ static inline
 struct sockaddr_ll_ptr *net_sll_ptr(const struct sockaddr_ptr *addr)
 {
 	return (struct sockaddr_ll_ptr *)addr;
+}
+
+/**
+ * @brief Get sockaddr_can_ptr from sockaddr_ptr. This is a helper so that
+ * the code needing this functionality can be made shorter.
+ *
+ * @param addr Socket address
+ *
+ * @return Pointer to CAN socket address
+ */
+static inline
+struct sockaddr_can_ptr *net_can_ptr(const struct sockaddr_ptr *addr)
+{
+	return (struct sockaddr_can_ptr *)addr;
 }
 
 /**

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -43,12 +43,14 @@ extern "C" {
 #define PF_INET		1	/* IP protocol family version 4. */
 #define PF_INET6	2	/* IP protocol family version 6. */
 #define PF_PACKET	3	/* Packet family. */
+#define PF_CAN		4	/* Controller Area Network.  */
 
 /** Address families.  */
 #define AF_UNSPEC	PF_UNSPEC
 #define AF_INET		PF_INET
 #define AF_INET6	PF_INET6
 #define AF_PACKET	PF_PACKET
+#define AF_CAN		PF_CAN
 
 /** Protocol numbers from IANA */
 enum net_ip_protocol {

--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -97,6 +97,12 @@ NET_L2_DECLARE_PUBLIC(BLUETOOTH_L2);
 NET_L2_DECLARE_PUBLIC(OPENTHREAD_L2);
 #endif /* CONFIG_NET_L2_OPENTHREAD */
 
+#ifdef CONFIG_NET_L2_CANBUS
+#define CANBUS_L2		CANBUS
+#define CANBUS_L2_CTX_TYPE	void*
+NET_L2_DECLARE_PUBLIC(CANBUS_L2);
+#endif /* CONFIG_NET_L2_CANBUS */
+
 #define NET_L2_INIT(_name, _recv_fn, _send_fn, _enable_fn, _get_flags_fn) \
 	const struct net_l2 (NET_L2_GET_NAME(_name)) __used		\
 	__attribute__((__section__(".net_l2.init"))) = {		\

--- a/include/net/net_linkaddr.h
+++ b/include/net/net_linkaddr.h
@@ -45,6 +45,7 @@ enum net_link_type {
 	NET_LINK_BLUETOOTH,
 	NET_LINK_ETHERNET,
 	NET_LINK_DUMMY,
+	NET_LINK_CANBUS,
 } __packed;
 
 /**

--- a/include/net/socket_can.h
+++ b/include/net/socket_can.h
@@ -36,6 +36,10 @@ extern "C" {
 #define SOL_CAN_BASE 100
 #define SOL_CAN_RAW (SOL_CAN_BASE + CAN_RAW)
 
+enum {
+	CAN_RAW_FILTER = 1,
+};
+
 /* Socket CAN MTU size */
 #define CAN_MTU		(sizeof(struct can_msg))
 
@@ -60,6 +64,14 @@ struct canbus_api {
 
 	/** Send a CAN packet by socket */
 	int (*send)(struct device *dev, struct net_pkt *pkt);
+
+	/** Set socket CAN option */
+	int (*setsockopt)(struct device *dev, void *obj, int level, int optname,
+			  const void *optval, socklen_t optlen);
+
+	/** Get socket CAN option */
+	int (*getsockopt)(struct device *dev, void *obj, int level, int optname,
+			  const void *optval, socklen_t *optlen);
 };
 
 /**

--- a/include/net/socket_can.h
+++ b/include/net/socket_can.h
@@ -19,6 +19,7 @@ extern "C" {
 
 #include <zephyr/types.h>
 #include <net/net_ip.h>
+#include <net/net_if.h>
 #include <can.h>
 
 /**
@@ -45,6 +46,20 @@ extern "C" {
 struct sockaddr_can {
 	sa_family_t can_family;
 	int         can_ifindex;
+};
+
+/**
+ * CAN L2 driver API. Used by socket CAN.
+ */
+struct canbus_api {
+	/**
+	 * The net_if_api must be placed in first position in this
+	 * struct so that we are compatible with network interface API.
+	 */
+	struct net_if_api iface_api;
+
+	/** Send a CAN packet by socket */
+	int (*send)(struct device *dev, struct net_pkt *pkt);
 };
 
 /**

--- a/include/net/socket_can.h
+++ b/include/net/socket_can.h
@@ -1,0 +1,40 @@
+/** @file
+ * @brief Socket CAN definitions.
+ *
+ * Definitions for socket CAN support.
+ */
+
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_NET_SOCKET_CAN_H_
+#define ZEPHYR_INCLUDE_NET_SOCKET_CAN_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/types.h>
+
+/**
+ * @brief Socket CAN library
+ * @defgroup socket_can Network Core Library
+ * @ingroup networking
+ * @{
+ */
+
+/* Protocols of the protocol family PF_CAN */
+#define CAN_RAW 1
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_NET_SOCKET_CAN_H_ */

--- a/include/net/socket_can.h
+++ b/include/net/socket_can.h
@@ -18,6 +18,8 @@ extern "C" {
 #endif
 
 #include <zephyr/types.h>
+#include <net/net_ip.h>
+#include <can.h>
 
 /**
  * @brief Socket CAN library
@@ -28,6 +30,22 @@ extern "C" {
 
 /* Protocols of the protocol family PF_CAN */
 #define CAN_RAW 1
+
+/* Socket CAN options */
+#define SOL_CAN_BASE 100
+#define SOL_CAN_RAW (SOL_CAN_BASE + CAN_RAW)
+
+/* Socket CAN MTU size */
+#define CAN_MTU		(sizeof(struct can_msg))
+
+/**
+ * struct sockaddr_can - The sockaddr structure for CAN sockets
+ *
+ */
+struct sockaddr_can {
+	sa_family_t can_family;
+	int         can_ifindex;
+};
 
 /**
  * @}

--- a/subsys/net/ip/CMakeLists.txt
+++ b/subsys/net/ip/CMakeLists.txt
@@ -28,6 +28,7 @@ zephyr_library_sources_ifdef(CONFIG_NET_TCP          connection.c tcp.c)
 zephyr_library_sources_ifdef(CONFIG_NET_TRICKLE      trickle.c)
 zephyr_library_sources_ifdef(CONFIG_NET_UDP          connection.c udp.c)
 zephyr_library_sources_ifdef(CONFIG_NET_SOCKETS_PACKET  connection.c packet_socket.c)
+zephyr_library_sources_ifdef(CONFIG_NET_SOCKETS_CAN  connection.c canbus_socket.c)
 zephyr_library_sources_ifdef(CONFIG_NET_PROMISCUOUS_MODE promiscuous.c)
 
 if(CONFIG_NET_SHELL)

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -516,6 +516,10 @@ config NET_DEFAULT_IF_DUMMY
 	bool "Dummy testing interface"
 	depends on NET_L2_DUMMY
 
+config NET_DEFAULT_IF_CANBUS
+	bool "Socket CAN interface"
+	depends on NET_L2_CANBUS
+
 endchoice
 
 config NET_PKT_TIMESTAMP

--- a/subsys/net/ip/canbus_socket.c
+++ b/subsys/net/ip/canbus_socket.c
@@ -1,0 +1,29 @@
+/** @file
+ * @brief CANBUS Sockets related functions
+ */
+
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(net_sockets_can, CONFIG_NET_SOCKETS_LOG_LEVEL);
+
+#include <errno.h>
+#include <net/net_pkt.h>
+#include <net/net_context.h>
+#include <net/socket_can.h>
+
+#include "connection.h"
+
+enum net_verdict net_canbus_socket_input(struct net_pkt *pkt)
+{
+	if (net_pkt_family(pkt) == AF_CAN &&
+	    net_if_l2(net_pkt_iface(pkt)) == &NET_L2_GET_NAME(CANBUS)) {
+		return net_conn_input(pkt, NULL, CAN_RAW, NULL);
+	}
+
+	return NET_CONTINUE;
+}

--- a/subsys/net/ip/canbus_socket.h
+++ b/subsys/net/ip/canbus_socket.h
@@ -1,0 +1,36 @@
+/** @file
+ * @brief CANBUS Socket related functions
+ *
+ * This is not to be included by the application.
+ */
+
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __CAN_SOCKET_H
+#define __CAN_SOCKET_H
+
+#include <zephyr/types.h>
+
+/**
+ * @brief Called by net_core.c when a CANBUS packet is received.
+ *
+ * @param pkt Network packet
+ *
+ * @return NET_OK if the packet was consumed, NET_DROP if
+ * the packet parsing failed and the caller should handle
+ * the received packet.
+ */
+#if defined(CONFIG_NET_SOCKETS_CAN)
+enum net_verdict net_canbus_socket_input(struct net_pkt *pkt);
+#else
+static inline enum net_verdict net_canbus_socket_input(struct net_pkt *pkt)
+{
+	return NET_CONTINUE;
+}
+#endif
+
+#endif /* __CAN_SOCKET_H */

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -285,7 +285,7 @@ static inline enum net_verdict cache_check(struct net_pkt *pkt,
 
 			NET_DBG("Cache %s listener for pkt %p src port %u "
 				"dst port %u family %d cache[%d] 0x%x",
-				net_proto2str(proto), pkt,
+				net_proto2str(net_pkt_family(pkt), proto), pkt,
 				src_port, dst_port,
 				net_pkt_family(pkt), *pos,
 				conn_cache[*pos].value);
@@ -844,7 +844,7 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 #endif
 
 	NET_DBG("Check %s listener for pkt %p src port %u dst port %u"
-		" family %d", net_proto2str(proto), pkt,
+		" family %d", net_proto2str(net_pkt_family(pkt), proto), pkt,
 		ntohs(src_port), ntohs(dst_port), net_pkt_family(pkt));
 
 	for (i = 0; i < CONFIG_NET_MAX_CONN; i++) {

--- a/subsys/net/ip/connection.h
+++ b/subsys/net/ip/connection.h
@@ -140,7 +140,7 @@ int net_conn_change_callback(struct net_conn_handle *handle,
  * disabled, the function will always return NET_DROP.
  */
 #if defined(CONFIG_NET_UDP) || defined(CONFIG_NET_TCP) || \
-	defined(CONFIG_NET_SOCKETS_PACKET)
+	defined(CONFIG_NET_SOCKETS_PACKET) || defined(CONFIG_NET_SOCKETS_CAN)
 enum net_verdict net_conn_input(struct net_pkt *pkt,
 				union net_ip_header *ip_hdr,
 				u8_t proto,

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -537,7 +537,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 
 		NET_DBG("Context %p binding to %s [%s]:%d iface %p",
 			context,
-			net_proto2str(net_context_get_ip_proto(context)),
+			net_proto2str(AF_INET6,
+				      net_context_get_ip_proto(context)),
 			log_strdup(net_sprint_ipv6_addr(ptr)),
 			ntohs(addr6->sin6_port), iface);
 
@@ -628,7 +629,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 
 		NET_DBG("Context %p binding to %s %s:%d iface %p",
 			context,
-			net_proto2str(net_context_get_ip_proto(context)),
+			net_proto2str(AF_INET,
+				      net_context_get_ip_proto(context)),
 			log_strdup(net_sprint_ipv4_addr(ptr)),
 			ntohs(addr4->sin_port), iface);
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -240,7 +240,7 @@ int net_context_get(sa_family_t family,
 			}
 		}
 
-		contexts[i].iface = 0;
+		contexts[i].iface = -1;
 		contexts[i].flags = 0;
 		atomic_set(&contexts[i].refcount, 1);
 
@@ -451,7 +451,7 @@ static int bind_default(struct net_context *context)
 	if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) && family == AF_CAN) {
 		struct sockaddr_can can_addr;
 
-		if (context->iface) {
+		if (context->iface >= 0) {
 			return 0;
 		} else {
 #if defined(CONFIG_NET_L2_CANBUS)

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -45,6 +45,7 @@ LOG_MODULE_REGISTER(net_core, CONFIG_NET_CORE_LOG_LEVEL);
 #include "route.h"
 
 #include "packet_socket.h"
+#include "canbus_socket.h"
 
 #include "connection.h"
 #include "udp_internal.h"
@@ -107,6 +108,11 @@ static inline enum net_verdict process_data(struct net_pkt *pkt,
 
 			return ret;
 		}
+	}
+
+	ret = net_canbus_socket_input(pkt);
+	if (ret != NET_CONTINUE) {
+		return ret;
 	}
 
 	/* L2 has modified the buffer starting point, it is easier

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -368,6 +368,9 @@ struct net_if *net_if_get_default(void)
 #if defined(CONFIG_NET_DEFAULT_IF_OFFLOAD)
 	iface = net_if_get_first_by_type(NULL);
 #endif
+#if defined(CONFIG_NET_DEFAULT_IF_CANBUS)
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(CANBUS));
+#endif
 
 	return iface ? iface : __net_if_start;
 }

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -81,7 +81,7 @@ int net_ipv6_send_fragmented_pkt(struct net_if *iface, struct net_pkt *pkt,
 				 u16_t pkt_len);
 #endif
 
-extern const char *net_proto2str(enum net_ip_protocol proto);
+extern const char *net_proto2str(int family, int proto);
 extern char *net_byte_to_hex(char *ptr, u8_t byte, char base, bool pad);
 extern char *net_sprint_ll_addr_buf(const u8_t *ll, u8_t ll_len,
 				    char *buf, int buflen);

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -181,6 +181,16 @@ static const char *iface2str(struct net_if *iface, const char **extra)
 	}
 #endif
 
+#ifdef CONFIG_NET_L2_CANBUS
+	if (net_if_l2(iface) == &NET_L2_GET_NAME(CANBUS)) {
+		if (extra) {
+			*extra = "======";
+		}
+
+		return "CANBUS";
+	}
+#endif
+
 	if (extra) {
 		*extra = "==============";
 	}

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -930,7 +930,8 @@ static void conn_handler_cb(struct net_conn *conn, void *user_data)
 	}
 
 	PR("[%2d] %p %p\t%s\t%16s\t%16s\n",
-	   (*count) + 1, conn, conn->cb, net_proto2str(conn->proto),
+	   (*count) + 1, conn, conn->cb,
+	   net_proto2str(conn->local_addr.sa_family, conn->proto),
 	   addr_local, addr_remote);
 
 	(*count)++;

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(net_utils, CONFIG_NET_UTILS_LOG_LEVEL);
 #include <net/net_ip.h>
 #include <net/net_pkt.h>
 #include <net/net_core.h>
+#include <net/socket_can.h>
 
 char *net_sprint_addr(sa_family_t af, const void *addr)
 {
@@ -32,19 +33,28 @@ char *net_sprint_addr(sa_family_t af, const void *addr)
 	return net_addr_ntop(af, addr, s, NET_IPV6_ADDR_LEN);
 }
 
-const char *net_proto2str(enum net_ip_protocol proto)
+const char *net_proto2str(int family, int proto)
 {
-	switch (proto) {
-	case IPPROTO_ICMP:
-		return "ICMPv4";
-	case IPPROTO_TCP:
-		return "TCP";
-	case IPPROTO_UDP:
-		return "UDP";
-	case IPPROTO_ICMPV6:
-		return "ICMPv6";
-	default:
-		break;
+	if (family == AF_INET || family == AF_INET6) {
+		switch (proto) {
+		case IPPROTO_ICMP:
+			return "ICMPv4";
+		case IPPROTO_TCP:
+			return "TCP";
+		case IPPROTO_UDP:
+			return "UDP";
+		case IPPROTO_ICMPV6:
+			return "ICMPv6";
+		default:
+			break;
+		}
+	} else if (family == AF_CAN) {
+		switch (proto) {
+		case CAN_RAW:
+			return "CAN_RAW";
+		default:
+			break;
+		}
 	}
 
 	return "UNK_PROTO";

--- a/subsys/net/l2/CMakeLists.txt
+++ b/subsys/net/l2/CMakeLists.txt
@@ -21,3 +21,7 @@ endif()
 if(CONFIG_NET_L2_WIFI_MGMT OR CONFIG_NET_L2_WIFI_SHELL)
   add_subdirectory(wifi)
 endif()
+
+if(CONFIG_NET_L2_CANBUS)
+  add_subdirectory(canbus)
+endif()

--- a/subsys/net/l2/Kconfig
+++ b/subsys/net/l2/Kconfig
@@ -98,4 +98,9 @@ config NET_L2_WIFI_SHELL
 	  This can be used for controlling WiFi through the console via
 	  exposing a shell module named "wifi".
 
+config NET_L2_CANBUS
+	bool "Enable CANBUS l2 layer"
+	help
+	  Add a CANBUS L2 layer driver.
+
 endmenu

--- a/subsys/net/l2/canbus/CMakeLists.txt
+++ b/subsys/net/l2/canbus/CMakeLists.txt
@@ -1,0 +1,6 @@
+zephyr_library()
+zephyr_library_compile_definitions_ifdef(
+  CONFIG_NEWLIB_LIBC __LINUX_ERRNO_EXTENSIONS__
+  )
+
+zephyr_library_sources_ifdef(CONFIG_NET_L2_CANBUS canbus.c)

--- a/subsys/net/l2/canbus/canbus.c
+++ b/subsys/net/l2/canbus/canbus.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(net_l2_canbus, LOG_LEVEL_NONE);
+
+#include <net/net_core.h>
+#include <net/net_l2.h>
+#include <net/net_if.h>
+#include <net/net_pkt.h>
+#include <net/socket_can.h>
+
+static inline enum net_verdict canbus_recv(struct net_if *iface,
+					   struct net_pkt *pkt)
+{
+	net_pkt_lladdr_src(pkt)->addr = NULL;
+	net_pkt_lladdr_src(pkt)->len = 0;
+	net_pkt_lladdr_src(pkt)->type = NET_LINK_DUMMY;
+	net_pkt_lladdr_dst(pkt)->addr = NULL;
+	net_pkt_lladdr_dst(pkt)->len = 0;
+	net_pkt_lladdr_dst(pkt)->type = NET_LINK_DUMMY;
+
+	net_pkt_set_family(pkt, AF_CAN);
+
+	return NET_CONTINUE;
+}
+
+static inline int canbus_send(struct net_if *iface, struct net_pkt *pkt)
+{
+	const struct canbus_api *api = net_if_get_device(iface)->driver_api;
+	int ret;
+
+	ret = api->send(net_if_get_device(iface), pkt);
+	if (!ret) {
+		ret = net_pkt_get_len(pkt);
+		net_pkt_unref(pkt);
+	}
+
+	return ret;
+}
+
+NET_L2_INIT(CANBUS_L2, canbus_recv, canbus_send, NULL, NULL);

--- a/subsys/net/lib/sockets/CMakeLists.txt
+++ b/subsys/net/lib/sockets/CMakeLists.txt
@@ -8,6 +8,7 @@ zephyr_sources(
   )
 zephyr_sources_ifdef(CONFIG_NET_SOCKETS_SOCKOPT_TLS sockets_tls.c)
 zephyr_sources_ifdef(CONFIG_NET_SOCKETS_PACKET sockets_packet.c)
+zephyr_sources_ifdef(CONFIG_NET_SOCKETS_CAN sockets_can.c)
 endif()
 zephyr_sources_ifdef(CONFIG_NET_SOCKETS_OFFLOAD     socket_offload.c)
 

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -111,6 +111,7 @@ config NET_SOCKETS_PACKET
 config NET_SOCKETS_CAN
 	bool "Enable socket CAN support [EXPERIMENTAL]"
 	default n
+	select NET_L2_CANBUS
 	help
 	  The value depends on your network needs.
 

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -108,6 +108,12 @@ config NET_SOCKETS_PACKET
 	  while sending. While receiving, packets (including all the headers)
 	  will be feed to sockets as it as from the driver.
 
+config NET_SOCKETS_CAN
+	bool "Enable socket CAN support [EXPERIMENTAL]"
+	default n
+	help
+	  The value depends on your network needs.
+
 module = NET_SOCKETS
 module-dep = NET_LOG
 module-str = Log level for BSD sockets compatible API calls

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -129,6 +129,12 @@ int _impl_zsock_socket(int family, int type, int proto)
 	}
 #endif
 
+#if defined(CONFIG_NET_SOCKETS_CAN)
+	if (family == AF_CAN && type == SOCK_RAW) {
+		return zcan_socket(family, type, proto);
+	}
+#endif
+
 	return zsock_socket_internal(family, type, proto);
 }
 

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -329,12 +329,58 @@ static ssize_t can_sock_recvfrom_vmeth(void *obj, void *buf, size_t max_len,
 static int can_sock_getsockopt_vmeth(void *obj, int level, int optname,
 				     void *optval, socklen_t *optlen)
 {
+	if (level == SOL_CAN_RAW) {
+		const struct canbus_api *api;
+		struct net_if *iface;
+		struct device *dev;
+
+		if (optval == NULL) {
+			errno = EINVAL;
+			return -1;
+		}
+
+		iface = net_context_get_iface(obj);
+		dev = net_if_get_device(iface);
+		api = dev->driver_api;
+
+		if (!api->getsockopt) {
+			errno = ENOTSUP;
+			return -1;
+		}
+
+		return api->getsockopt(dev, obj, level, optname, optval,
+				       optlen);
+	}
+
 	return zcan_getsockopt_ctx(obj, level, optname, optval, optlen);
 }
 
 static int can_sock_setsockopt_vmeth(void *obj, int level, int optname,
 				     const void *optval, socklen_t optlen)
 {
+	if (level == SOL_CAN_RAW) {
+		const struct canbus_api *api;
+		struct net_if *iface;
+		struct device *dev;
+
+		if (optval == NULL) {
+			errno = EINVAL;
+			return -1;
+		}
+
+		iface = net_context_get_iface(obj);
+		dev = net_if_get_device(iface);
+		api = dev->driver_api;
+
+		if (!api->setsockopt) {
+			errno = ENOTSUP;
+			return -1;
+		}
+
+		return api->setsockopt(dev, obj, level, optname, optval,
+				       optlen);
+	}
+
 	return zcan_setsockopt_ctx(obj, level, optname, optval, optlen);
 }
 

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include <fcntl.h>
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(net_sock_can, CONFIG_NET_SOCKETS_LOG_LEVEL);
+
+#include <kernel.h>
+#include <entropy.h>
+#include <misc/util.h>
+#include <net/net_context.h>
+#include <net/net_pkt.h>
+#include <net/socket.h>
+#include <syscall_handler.h>
+#include <misc/fdtable.h>
+#include <net/socket_can.h>
+
+#include "sockets_internal.h"
+
+extern const struct socket_op_vtable sock_fd_op_vtable;
+
+static const struct socket_op_vtable can_sock_fd_op_vtable;
+
+static inline int _k_fifo_wait_non_empty(struct k_fifo *fifo, int32_t timeout)
+{
+	struct k_poll_event events[] = {
+		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE,
+					 K_POLL_MODE_NOTIFY_ONLY, fifo),
+	};
+
+	return k_poll(events, ARRAY_SIZE(events), timeout);
+}
+
+int zcan_socket(int family, int type, int proto)
+{
+	struct net_context *ctx;
+	int fd;
+	int ret;
+
+	if (proto != CAN_RAW) {
+		errno = EOPNOTSUPP;
+		return -1;
+	}
+
+	fd = z_reserve_fd();
+	if (fd < 0) {
+		return -1;
+	}
+
+	ret = net_context_get(family, type, proto, &ctx);
+	if (ret < 0) {
+		z_free_fd(fd);
+		errno = -ret;
+		return -1;
+	}
+
+	/* Initialize user_data, all other calls will preserve it */
+	ctx->user_data = NULL;
+
+	k_fifo_init(&ctx->recv_q);
+
+#ifdef CONFIG_USERSPACE
+	/* Set net context object as initialized and grant access to the
+	 * calling thread (and only the calling thread)
+	 */
+	_k_object_recycle(ctx);
+#endif
+
+	z_finalize_fd(fd, ctx,
+		      (const struct fd_op_vtable *)&can_sock_fd_op_vtable);
+
+	return fd;
+}
+
+static void zcan_received_cb(struct net_context *ctx, struct net_pkt *pkt,
+			     union net_ip_header *ip_hdr,
+			     union net_proto_header *proto_hdr,
+			     int status, void *user_data)
+{
+	NET_DBG("ctx %p pkt %p st %d ud %p", ctx, pkt, status, user_data);
+
+	/* if pkt is NULL, EOF */
+	if (!pkt) {
+		struct net_pkt *last_pkt = k_fifo_peek_tail(&ctx->recv_q);
+
+		if (!last_pkt) {
+			/* If there're no packets in the queue, recv() may
+			 * be blocked waiting on it to become non-empty,
+			 * so cancel that wait.
+			 */
+			sock_set_eof(ctx);
+			k_fifo_cancel_wait(&ctx->recv_q);
+			NET_DBG("Marked socket %p as peer-closed", ctx);
+		} else {
+			net_pkt_set_eof(last_pkt, true);
+			NET_DBG("Set EOF flag on pkt %p", ctx);
+		}
+
+		return;
+	}
+
+	/* Normal packet */
+	net_pkt_set_eof(pkt, false);
+
+	k_fifo_put(&ctx->recv_q, pkt);
+}
+
+static int zcan_bind_ctx(struct net_context *ctx, const struct sockaddr *addr,
+			 socklen_t addrlen)
+{
+	struct sockaddr_can *can_addr = (struct sockaddr_can *)addr;
+	struct net_if *iface;
+	int ret;
+
+	if (addrlen != sizeof(struct sockaddr_can)) {
+		return -EINVAL;
+	}
+
+	iface = net_if_get_by_index(can_addr->can_ifindex);
+	if (!iface) {
+		return -ENOENT;
+	}
+
+	net_context_set_iface(ctx, iface);
+
+	ret = net_context_bind(ctx, addr, addrlen);
+	if (ret < 0) {
+		errno = -ret;
+		return -1;
+	}
+
+	/* For CAN socket, we expect to receive packets after call to bind().
+	 */
+	ret = net_context_recv(ctx, zcan_received_cb, K_NO_WAIT,
+			       ctx->user_data);
+	if (ret < 0) {
+		errno = -ret;
+		return -1;
+	}
+
+	return 0;
+}
+
+ssize_t zcan_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
+			int flags, const struct sockaddr *dest_addr,
+			socklen_t addrlen)
+{
+	struct sockaddr_can can_addr;
+	s32_t timeout = K_FOREVER;
+	int ret;
+
+	/* Setting destination address does not probably make sense here so
+	 * ignore it. You need to use bind() to set the CAN interface.
+	 */
+	if (dest_addr) {
+		NET_DBG("CAN destination address ignored");
+	}
+
+	if ((flags & ZSOCK_MSG_DONTWAIT) || sock_is_nonblock(ctx)) {
+		timeout = K_NO_WAIT;
+	}
+
+	if (addrlen == 0) {
+		addrlen = sizeof(struct sockaddr_can);
+	}
+
+	if (dest_addr == NULL) {
+		memset(&can_addr, 0, sizeof(can_addr));
+
+		can_addr.can_ifindex = -1;
+		can_addr.can_family = AF_CAN;
+
+		dest_addr = (struct sockaddr *)&can_addr;
+	}
+
+	ret = net_context_sendto_new(ctx, buf, len, dest_addr, addrlen, NULL,
+				     timeout, NULL, ctx->user_data);
+	if (ret < 0) {
+		errno = -ret;
+		return -1;
+	}
+
+	return len;
+}
+
+static ssize_t zcan_recvfrom_ctx(struct net_context *ctx, void *buf,
+				 size_t max_len, int flags,
+				 struct sockaddr *src_addr,
+				 socklen_t *addrlen)
+{
+	size_t recv_len = 0;
+	s32_t timeout = K_FOREVER;
+	struct net_pkt *pkt;
+
+	if ((flags & ZSOCK_MSG_DONTWAIT) || sock_is_nonblock(ctx)) {
+		timeout = K_NO_WAIT;
+	}
+
+	if (flags & ZSOCK_MSG_PEEK) {
+		int ret;
+
+		ret = _k_fifo_wait_non_empty(&ctx->recv_q, timeout);
+		/* EAGAIN when timeout expired, EINTR when cancelled */
+		if (ret && ret != -EAGAIN && ret != -EINTR) {
+			errno = -ret;
+			return -1;
+		}
+
+		pkt = k_fifo_peek_head(&ctx->recv_q);
+	} else {
+		pkt = k_fifo_get(&ctx->recv_q, timeout);
+	}
+
+	if (!pkt) {
+		errno = EAGAIN;
+		return -1;
+	}
+
+	/* We do not handle any headers here, just pass the whole packet to
+	 * the caller.
+	 */
+	recv_len = net_pkt_get_len(pkt);
+	if (recv_len > max_len) {
+		recv_len = max_len;
+	}
+
+	if (net_pkt_read_new(pkt, buf, recv_len)) {
+		errno = EIO;
+		return -1;
+	}
+
+	if (!(flags & ZSOCK_MSG_PEEK)) {
+		net_pkt_unref(pkt);
+	} else {
+		net_pkt_cursor_init(pkt);
+	}
+
+	return recv_len;
+}
+
+static int zcan_getsockopt_ctx(struct net_context *ctx, int level, int optname,
+			       void *optval, socklen_t *optlen)
+{
+	if (!optval || !optlen) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	return sock_fd_op_vtable.getsockopt(ctx, level, optname,
+					    optval, optlen);
+}
+
+static int zcan_setsockopt_ctx(struct net_context *ctx, int level, int optname,
+			       const void *optval, socklen_t optlen)
+{
+	return sock_fd_op_vtable.setsockopt(ctx, level, optname,
+					    optval, optlen);
+}
+
+static ssize_t can_sock_read_vmeth(void *obj, void *buffer, size_t count)
+{
+	return zcan_recvfrom_ctx(obj, buffer, count, 0, NULL, 0);
+}
+
+static ssize_t can_sock_write_vmeth(void *obj, const void *buffer,
+				    size_t count)
+{
+	return zcan_sendto_ctx(obj, buffer, count, 0, NULL, 0);
+}
+
+static int can_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
+{
+	return sock_fd_op_vtable.fd_vtable.ioctl(obj, request, args);
+}
+
+/*
+ * TODO: A CAN socket can be bound to a network device using SO_BINDTODEVICE.
+ */
+static int can_sock_bind_vmeth(void *obj, const struct sockaddr *addr,
+			       socklen_t addrlen)
+{
+	return zcan_bind_ctx(obj, addr, addrlen);
+}
+
+/* The connect() function is no longer necessary. */
+static int can_sock_connect_vmeth(void *obj, const struct sockaddr *addr,
+				  socklen_t addrlen)
+{
+	return 0;
+}
+
+/*
+ * The listen() and accept() functions are without any functionality,
+ * since the client-Server-Semantic is no longer present.
+ * When we use RAW-sockets we are sending unconnected packets.
+ */
+static int can_sock_listen_vmeth(void *obj, int backlog)
+{
+	return 0;
+}
+
+static int can_sock_accept_vmeth(void *obj, struct sockaddr *addr,
+				 socklen_t *addrlen)
+{
+	return 0;
+}
+
+static ssize_t can_sock_sendto_vmeth(void *obj, const void *buf, size_t len,
+				     int flags,
+				     const struct sockaddr *dest_addr,
+				     socklen_t addrlen)
+{
+	return zcan_sendto_ctx(obj, buf, len, flags, dest_addr, addrlen);
+}
+
+static ssize_t can_sock_recvfrom_vmeth(void *obj, void *buf, size_t max_len,
+				       int flags, struct sockaddr *src_addr,
+				       socklen_t *addrlen)
+{
+	return zcan_recvfrom_ctx(obj, buf, max_len, flags,
+				 src_addr, addrlen);
+}
+
+static int can_sock_getsockopt_vmeth(void *obj, int level, int optname,
+				     void *optval, socklen_t *optlen)
+{
+	return zcan_getsockopt_ctx(obj, level, optname, optval, optlen);
+}
+
+static int can_sock_setsockopt_vmeth(void *obj, int level, int optname,
+				     const void *optval, socklen_t optlen)
+{
+	return zcan_setsockopt_ctx(obj, level, optname, optval, optlen);
+}
+
+static const struct socket_op_vtable can_sock_fd_op_vtable = {
+	.fd_vtable = {
+		.read = can_sock_read_vmeth,
+		.write = can_sock_write_vmeth,
+		.ioctl = can_sock_ioctl_vmeth,
+	},
+	.bind = can_sock_bind_vmeth,
+	.connect = can_sock_connect_vmeth,
+	.listen = can_sock_listen_vmeth,
+	.accept = can_sock_accept_vmeth,
+	.sendto = can_sock_sendto_vmeth,
+	.recvfrom = can_sock_recvfrom_vmeth,
+	.getsockopt = can_sock_getsockopt_vmeth,
+	.setsockopt = can_sock_setsockopt_vmeth,
+};

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -50,5 +50,6 @@ struct socket_op_vtable {
 int ztls_socket(int family, int type, int proto);
 
 int zpacket_socket(int family, int type, int proto);
+int zcan_socket(int family, int type, int proto);
 
 #endif /* _SOCKETS_INTERNAL_H_ */

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -88,7 +88,7 @@ static void net_ctx_get_fail(void)
 	zassert_equal(ret, -EPROTONOSUPPORT,
 		      "Invalid context protocol test failed");
 
-	ret = net_context_get(4, SOCK_DGRAM, IPPROTO_UDP, &context);
+	ret = net_context_get(99, SOCK_DGRAM, IPPROTO_UDP, &context);
 	zassert_equal(ret, -EAFNOSUPPORT,
 		      "Invalid context family test failed");
 


### PR DESCRIPTION
This is a rewrite of #11454. It builts on top of raw socket support #12564 and virtual socket layer.
~~Please ignore the raw socket patches in this pr and if you have comments to it, go directly to #12564~~.

The BSD socket CAN support works the same way as in Linux.

The patches that are part of the socket CAN:
```
net: link: Add link addres type for CANBUS addresses
net: socket: can: Add socket CAN support
net: l2: Add CANBUS L2 layer
net: can: Add CAN handling to net_context
```
