### PR TITLE
drivers: eth_mcux: Optimize check if received frame too large

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -555,14 +555,13 @@ static void eth_rx(struct device *iface)
 		goto flush;
 	}
 
-	pkt = net_pkt_get_reserve_rx(K_NO_WAIT);
-	if (!pkt) {
+	if (sizeof(context->frame_buf) < frame_length) {
+		LOG_ERR("frame too large (%d)", frame_length);
 		goto flush;
 	}
 
-	if (sizeof(context->frame_buf) < frame_length) {
-		LOG_ERR("frame too large (%d)", frame_length);
-		net_pkt_unref(pkt);
+	pkt = net_pkt_get_reserve_rx(K_NO_WAIT);
+	if (!pkt) {
 		goto flush;
 	}
 


### PR DESCRIPTION
For some reason, there was sequence like:

1. Get size of RX packet.
2. Allocate pkt buffer.
3. Check if the size of RX packet is too large, then deallocate pkt
buffer and error out.

Instead, reorder operations to check size before allocating buf.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>