### PR TITLE
Removed doc reference to non-existing HW PWM for nRF51 PCA10028

### DIFF
--- a/boards/arm/nrf51_pca10028/doc/nrf51_pca10028.rst
+++ b/boards/arm/nrf51_pca10028/doc/nrf51_pca10028.rst
@@ -16,7 +16,6 @@ nRF51822 ARM Cortex-M0 CPU and the following devices:
 * :abbr:`GPIO (General Purpose Input Output)`
 * :abbr:`I2C (Inter-Integrated Circuit)`
 * :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`PWM (Pulse Width Modulation)`
 * RADIO (Bluetooth Low Energy)
 * :abbr:`RTC (nRF RTC System Clock)`
 * Segger RTT (RTT Console)
@@ -62,8 +61,6 @@ hardware features:
 | I2C(M)    | on-chip    | i2c                  |
 +-----------+------------+----------------------+
 | NVIC      | on-chip    | arch/arm             |
-+-----------+------------+----------------------+
-| PWM       | on-chip    | pwm                  |
 +-----------+------------+----------------------+
 | RADIO     | on-chip    | Bluetooth            |
 +-----------+------------+----------------------+


### PR DESCRIPTION
Hello, according to what has been found out in the issue #11782, the specified board (nRF51 PCA10028) doesn't have hardware PWM so I removed it.

Official documentation about the [SoC](https://www.nordicsemi.com/-/media/DocLib/Other/Product_Spec/nRF51RMv301.pdf?la=en) and the [DK](https://www.nordicsemi.com/-/media/DocLib/Other/User_Guides) as reference.

I was wondering if the [page of official documentation](https://docs.zephyrproject.org/latest/boards/arm/nrf51_pca10028/doc/nrf51_pca10028.html) will be automatically regenerated or it need some manual intervention.

Thanks for your time and work :)