### PR TITLE
LD: Assert when CONFIG_PRIVILEGED_STACK_TEXT_AREA is too small

### DIFF
--- a/include/linker/priv_stacks-text.ld
+++ b/include/linker/priv_stacks-text.ld
@@ -7,16 +7,32 @@
 	/* We need to reserve room for the gperf generated hash functions.
 	 * Fortunately, unlike the data tables, the size of the code is
 	 * reasonably predictable.
-	 *
-	 * The linker will error out complaining that the location pointer
-	 * is moving backwards if the reserved room isn't large enough.
 	 */
 	_priv_stacks_text_area_start = .;
 	*(".priv_stacks.text*")
 	_priv_stacks_text_area_end = .;
+
+	_priv_stacks_text_area_used = _priv_stacks_text_area_end - _priv_stacks_text_area_start;
+
 #ifndef LINKER_PASS2
 	PROVIDE(_k_priv_stack_find = .);
 #endif
-	. += CONFIG_PRIVILEGED_STACK_TEXT_AREA - (_priv_stacks_text_area_end - _priv_stacks_text_area_start);
-#endif /* CONFIG_USERSPACE */
 
+	/* In a valid build the MAX function will always evaluate to the
+	second argument below, but to give the user a good error message
+	when the area overflows we need to temporarily corrupt the
+	location counter, and then detect the overflow with an assertion
+	later on. */
+
+	. = MAX(., _priv_stacks_text_area_start + CONFIG_PRIVILEGED_STACK_TEXT_AREA);
+
+	ASSERT(
+		CONFIG_PRIVILEGED_STACK_TEXT_AREA >= _priv_stacks_text_area_used,
+"The configuration system has incorrectly set
+'CONFIG_PRIVILEGED_STACK_TEXT_AREA' to
+CONFIG_PRIVILEGED_STACK_TEXT_AREA, which is not big enough. You must
+through Kconfig either disable 'CONFIG_USERSPACE', or set
+'CONFIG_PRIVILEGED_STACK_TEXT_AREA' to a value larger than
+CONFIG_PRIVILEGED_STACK_TEXT_AREA."
+		);
+#endif /* CONFIG_USERSPACE */


### PR DESCRIPTION
The error message is obscure when CONFIG_PRIVILEGED_STACK_TEXT_AREA is
configured incorrectly. It looks like this:

zephyr/linker.cmd:73 cannot move location counter backwards (from
0000000000069bfc to 0000000000069bd8)

This patch re-writes the linker script mechanism in a (believed and
tested) semantically equivalent way such that it is possible to use an
assertion.

The assertion's error message now looks like this:

Memory region         Used Size  Region Size  %age Used
           FLASH:      503012 B         1 MB     47.97%
            SRAM:       53760 B       256 KB     20.51%
        IDT_LIST:         120 B         2 KB      5.86
real-ld: The configuration system has incorrectly set
'CONFIG_PRIVILEGED_STACK_TEXT_AREA' to
128, which is not big enough. You must
through Kconfig either disable 'CONFIG_USERSPACE', or set
'CONFIG_PRIVILEGED_STACK_TEXT_AREA' to a value larger than
128 .
collect2: error: ld returned 1 exit status

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>