### PR TITLE
cmake: userspce: Always compile priv_stacks_hash.c as -Os

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1026,9 +1026,10 @@ if(CONFIG_ARM AND CONFIG_USERSPACE)
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/${PRIV_STACKS_OUTPUT_SRC}
     PROPERTIES COMPILE_DEFINITIONS "${compile_definitions_interface}")
 
+  # always compile priv_stacks_hash.c at optimization -Os
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/${PRIV_STACKS_OUTPUT_SRC}
     PROPERTIES COMPILE_FLAGS
-    "${NO_COVERAGE_FLAGS} -fno-function-sections -fno-data-sections ")
+    "${NO_COVERAGE_FLAGS} -Os -fno-function-sections -fno-data-sections ")
 
   # We need precise control of where generated text/data ends up in the final
   # kernel image. Disable function/data sections and use objcopy to move


### PR DESCRIPTION
The gperf hash table 'kobject_hash.c' is always compiled as -Os to
resolve bug #5226, the same bug also affects the gperf hash table
'priv_stacks_hash.c'.

In this patch we copy over the fix from 'kobject_hash.c' to also fix
'priv_stacks_hash.c'.

See #5672 for more discussion on the original fix.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>