### PR TITLE
west_commands: add information on running tests

### DIFF
--- a/scripts/west_commands/README.txt
+++ b/scripts/west_commands/README.txt
@@ -8,4 +8,18 @@ on the multi-repo need to be in upstream west, not here. Try to limit
 what goes in here to just those files that change along with Zephyr
 itself.
 
+When extending this code, please keep the unit tests (in tests/) up to
+date. You can run the tests with this command from this directory:
+
+$ PYTHONPATH=$(west list --format="{abspath}" west)/src:$PWD py.test
+
+Windows users will need to find the path to .west/west/src in their
+Zephyr installation, then run something like this:
+
+> cmd /C "set PYTHONPATH=path\to\.west\west\src:path\to\zephyr\scripts\west_commands && py.test"
+
+Note that these tests are run as part of Zephyr's CI when submitting
+an upstream pull request, and pull requests which break the tests
+cannot be merged.
+
 Thanks!


### PR DESCRIPTION
Add information to the README on how to run the tests, and note that they are part of Zephyr's CI.
