### PR TITLE
scripts: west commands: add text for "west --help"

### DIFF
--- a/scripts/west-commands.yml
+++ b/scripts/west-commands.yml
@@ -1,17 +1,23 @@
+# Keep the help strings in sync with the values in the .py files!
 west-commands:
   - file: scripts/west_commands/build.py
     commands:
       - name: build
         class: Build
+        help: compile a Zephyr application
   - file: scripts/west_commands/flash.py
     commands:
       - name: flash
         class: Flash
+        help: flash and run a binary on a board
   - file: scripts/west_commands/debug.py
     commands:
       - name: debug
         class: Debug
+        help: flash and interactively debug a Zephyr application
       - name: debugserver
         class: DebugServer
+        help: connect to board and launch a debug server
       - name: attach
         class: Attach
+        help: interactively debug a board

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -45,6 +45,7 @@ class Build(WestCommand):
     def __init__(self):
         super(Build, self).__init__(
             'build',
+            # Keep this in sync with the string in west-commands.yml.
             'compile a Zephyr application',
             BUILD_DESCRIPTION,
             accepts_unknown_args=False)

--- a/scripts/west_commands/debug.py
+++ b/scripts/west_commands/debug.py
@@ -17,6 +17,7 @@ class Debug(WestCommand):
     def __init__(self):
         super(Debug, self).__init__(
             'debug',
+            # Keep this in sync with the string in west-commands.yml.
             'flash and interactively debug a Zephyr application',
             dedent('''
             Connect to the board, program the flash, and start a
@@ -37,6 +38,7 @@ class DebugServer(WestCommand):
     def __init__(self):
         super(DebugServer, self).__init__(
             'debugserver',
+            # Keep this in sync with the string in west-commands.yml.
             'connect to board and launch a debug server',
             dedent('''
             Connect to the board and launch a debug server which accepts
@@ -55,11 +57,13 @@ class DebugServer(WestCommand):
         do_run_common(self, my_args, runner_args,
                       'ZEPHYR_BOARD_DEBUG_RUNNER')
 
+
 class Attach(WestCommand):
 
     def __init__(self):
         super(Attach, self).__init__(
             'attach',
+            # Keep this in sync with the string in west-commands.yml.
             'interactively debug a board',
             dedent('''
             Like 'debug', this connects to the board and starts a debugging

--- a/scripts/west_commands/flash.py
+++ b/scripts/west_commands/flash.py
@@ -17,6 +17,7 @@ class Flash(WestCommand):
     def __init__(self):
         super(Flash, self).__init__(
             'flash',
+            # Keep this in sync with the string in west-commands.yml.
             'flash and run a binary on a board',
             dedent('''
             Connects to the board and reprograms it with a new binary\n\n''') +


### PR DESCRIPTION
Although each of these command implementations has good output for
"west <command> --help", the "west --help" output is missing the
one-line descriptions.

Add them by modifying west-commands.yml to use a new 'help' key in
each command name. These need to be kept in sync with the Python
sources. For now just do that by copy/pasting. We could add fancy
logic to load the help from west-commands.yml later if we want.
