### PR TITLE
samples: cdc_acm: Remove reduntant inclusion

### DIFF
--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -17,7 +17,6 @@
 #include <device.h>
 #include <uart.h>
 #include <zephyr.h>
-#include <stdio.h>
 
 static const char *banner1 = "Send characters to the UART device\r\n";
 static const char *banner2 = "Characters read:\r\n";


### PR DESCRIPTION
Remove reduntant inclusion of stdio.h

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>