### PR TITLE
Bluetooth: controller: ULL/LLL: Fix compile error with PA/LNA

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
@@ -214,7 +214,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	radio_gpio_pa_lna_enable(remainder_us +
-				 radio_rx_ready_delay_get(conn->phy_rx, 1) -
+				 radio_rx_ready_delay_get(lll->phy_rx, 1) -
 				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
 #else /* !CONFIG_BT_CTLR_PHY */
 	radio_gpio_pa_lna_enable(remainder_us +


### PR DESCRIPTION
During regression testing of PA/LNA feature it was noticed
that compilation failed due to missing port of the code
conditionally compiled for PA/LNA feature.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>