### PR TITLE
 soc: nxp_imx: Promote driver defaults to soc series level

### DIFF
--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -6,7 +6,7 @@
 
 menuconfig ETH_MCUX
 	bool "MCUX Ethernet driver"
-	depends on HAS_MCUX
+	depends on HAS_MCUX_ENET
 	help
 	  Enable MCUX Ethernet driver.  Note, this driver performs one shot PHY
 	  setup.  There is no support for PHY disconnect, reconnect or

--- a/ext/hal/nxp/mcux/Kconfig
+++ b/ext/hal/nxp/mcux/Kconfig
@@ -22,6 +22,11 @@ config HAS_MCUX_CCM
 	help
 	  Set if the clock control module (CCM) module is present in the SoC.
 
+config HAS_MCUX_ENET
+	bool
+	help
+	  Set if the ethernet (ENET) module is present in the SoC.
+
 config HAS_MCUX_FTM
 	bool
 	help

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1021
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1021
@@ -11,13 +11,6 @@ config SOC
 	string
 	default "mimxrt1021"
 
-if CLOCK_CONTROL
-
-config CLOCK_CONTROL_MCUX_CCM
-	default y
-
-endif # CLOCK_CONTROL
-
 config ARM_DIV
 	default 0
 
@@ -29,40 +22,5 @@ config IPG_DIV
 
 config GPIO
 	default y
-
-if GPIO
-
-config GPIO_MCUX_IGPIO
-	default y
-
-endif # GPIO
-
-if I2C
-
-config I2C_MCUX_LPI2C
-	default y
-
-endif # I2C
-
-if SERIAL
-
-config UART_MCUX_LPUART
-	default y
-
-endif # SERIAL
-
-if ENTROPY_GENERATOR
-
-config ENTROPY_MCUX_TRNG
-	default y
-
-endif # ENTROPY_GENERATOR
-
-if NET_L2_ETHERNET
-
-config ETH_MCUX
-	def_bool y
-
-endif # NET_L2_ETHERNET
 
 endif # SOC_MIMXRT1021

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
@@ -11,13 +11,6 @@ config SOC
 	string
 	default "mimxrt1052"
 
-if CLOCK_CONTROL
-
-config CLOCK_CONTROL_MCUX_CCM
-	default y
-
-endif # CLOCK_CONTROL
-
 config ARM_DIV
 	default 1
 
@@ -30,49 +23,11 @@ config IPG_DIV
 config GPIO
 	default y
 
-if GPIO
-
-config GPIO_MCUX_IGPIO
-	default y
-
-endif # GPIO
-
-if I2C
-
-config I2C_MCUX_LPI2C
-	default y
-
-endif # I2C
-
-if SERIAL
-
-config UART_MCUX_LPUART
-	default y
-
-endif # SERIAL
-
-if SPI
-
-config SPI_MCUX_LPSPI
-	default y
-
-endif # SPI
-
 if NET_L2_ETHERNET
-
-config ETH_MCUX
-	def_bool y
 
 config INIT_ENET_PLL
 	def_bool y
 
 endif # NET_L2_ETHERNET
-
-if ENTROPY_GENERATOR
-
-config ENTROPY_MCUX_TRNG
-	default y
-
-endif # ENTROPY_GENERATOR
 
 endif # SOC_MIMXRT1052

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1062
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1062
@@ -11,13 +11,6 @@ config SOC
 	string
 	default "mimxrt1062"
 
-if CLOCK_CONTROL
-
-config CLOCK_CONTROL_MCUX_CCM
-	default y
-
-endif # CLOCK_CONTROL
-
 config ARM_DIV
 	default 1
 
@@ -29,33 +22,5 @@ config IPG_DIV
 
 config GPIO
 	default y
-
-if GPIO
-
-config GPIO_MCUX_IGPIO
-	default y
-
-endif # GPIO
-
-if I2C
-
-config I2C_MCUX_LPI2C
-	default y
-
-endif # I2C
-
-if SERIAL
-
-config UART_MCUX_LPUART
-	default y
-
-endif # SERIAL
-
-if ENTROPY_GENERATOR
-
-config ENTROPY_MCUX_TRNG
-	default y
-
-endif # ENTROPY_GENERATOR
 
 endif # SOC_MIMXRT1062

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
@@ -11,13 +11,6 @@ config SOC
 	string
 	default "mimxrt1064"
 
-if CLOCK_CONTROL
-
-config CLOCK_CONTROL_MCUX_CCM
-	def_bool y
-
-endif # CLOCK_CONTROL
-
 config ARM_DIV
 	default 1
 
@@ -29,26 +22,5 @@ config IPG_DIV
 
 config GPIO
 	def_bool y
-
-if GPIO
-
-config GPIO_MCUX_IGPIO
-	def_bool y
-
-endif # GPIO
-
-if SERIAL
-
-config UART_MCUX_LPUART
-	def_bool y
-
-endif # SERIAL
-
-if ENTROPY_GENERATOR
-
-config ENTROPY_MCUX_TRNG
-	default y
-
-endif #ENTROPY_MCUX_TRNG
 
 endif # SOC_MIMXRT1064

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -20,6 +20,55 @@ config TEXT_SECTION_OFFSET
 
 config INIT_ENET_PLL
 
+if CLOCK_CONTROL
+
+config CLOCK_CONTROL_MCUX_CCM
+	default y if HAS_MCUX_CCM
+
+endif # CLOCK_CONTROL
+
+if GPIO
+
+config GPIO_MCUX_IGPIO
+	default y if HAS_MCUX_IGPIO
+
+endif # GPIO
+
+if ENTROPY_GENERATOR
+
+config ENTROPY_MCUX_TRNG
+	default y if HAS_MCUX_TRNG
+
+endif # ENTROPY_GENERATOR
+
+if I2C
+
+config I2C_MCUX_LPI2C
+	default y if HAS_MCUX_LPI2C
+
+endif # I2C
+
+if NET_L2_ETHERNET
+
+config ETH_MCUX
+	def_bool y if HAS_MCUX_ENET
+
+endif # NET_L2_ETHERNET
+
+if SERIAL
+
+config UART_MCUX_LPUART
+	default y if HAS_MCUX_LPUART
+
+endif # SERIAL
+
+if SPI
+
+config SPI_MCUX_LPSPI
+	default y if HAS_MCUX_LPSPI
+
+endif # SPI
+
 source "soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt*"
 
 endif # SOC_SERIES_IMX_RT

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -13,6 +13,7 @@ config SOC_MIMXRT1021
 	bool "SOC_MIMXRT1021"
 	select HAS_MCUX
 	select HAS_MCUX_CCM
+	select HAS_MCUX_ENET
 	select HAS_MCUX_IGPIO
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPSPI
@@ -28,6 +29,7 @@ config SOC_MIMXRT1051
 	bool "SOC_MIMXRT1051"
 	select HAS_MCUX
 	select HAS_MCUX_CCM
+	select HAS_MCUX_ENET
 	select HAS_MCUX_IGPIO
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPSPI
@@ -43,6 +45,7 @@ config SOC_MIMXRT1052
 	bool "SOC_MIMXRT1052"
 	select HAS_MCUX
 	select HAS_MCUX_CCM
+	select HAS_MCUX_ENET
 	select HAS_MCUX_IGPIO
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPSPI
@@ -58,6 +61,7 @@ config SOC_MIMXRT1061
 	bool "SOC_MIMXRT1061"
 	select HAS_MCUX
 	select HAS_MCUX_CCM
+	select HAS_MCUX_ENET
 	select HAS_MCUX_IGPIO
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPUART
@@ -72,6 +76,7 @@ config SOC_MIMXRT1062
 	bool "SOC_MIMXRT1062"
 	select HAS_MCUX
 	select HAS_MCUX_CCM
+	select HAS_MCUX_ENET
 	select HAS_MCUX_IGPIO
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPUART
@@ -86,6 +91,7 @@ config SOC_MIMXRT1064
 	bool "SOC_MIMXRT1064"
 	select HAS_MCUX
 	select HAS_MCUX_CCM
+	select HAS_MCUX_ENET
 	select HAS_MCUX_IGPIO
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_TRNG

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.soc
@@ -13,6 +13,7 @@ config SOC_MK64F12
 	bool "SOC_MK64F12"
 	select HAS_MCUX
 	select HAS_MCUX_ADC16
+	select HAS_MCUX_ENET
 	select HAS_MCUX_FTM
 	select HAS_MCUX_RNGA
 	select HAS_MCUX_SIM


### PR DESCRIPTION
Streamlines repetitious code enabling default drivers by promoting it to
the soc series level.