### PR TITLE
app_shmem: delete parallel API for domains

### DIFF
--- a/doc/kernel/usermode/usermode_sharedmem.rst
+++ b/doc/kernel/usermode/usermode_sharedmem.rst
@@ -46,19 +46,9 @@ where "part0" is the name then used to refer to that partition.
 This macro only creates a function and necessary data structures for
 the later "initialization".
 
-To create a memory domain for the partition, the macro appmem_domain(dom0)
-is called where "dom0" is the name then used for the memory domain.
-To initialize the partition (effectively adding the partition
-to a linked list), appmem_init_part_part0() is called. This is followed
-by appmem_init_app_memory(), which walks all partitions in the linked
-list and calculates the sizes for each partition.
-
-Once the partition is initialized, the domain can be
-initialized with appmem_init_domain_dom0(part0) which initializes the
-domain with partition part0.
-
-After the domain has been initialized, the current thread
-can be added using appmem_add_thread_dom0(k_current_get()).
+Once the partition is initialized, the standard memory domain APIs may
+be used to add it to domains; the declared name is a k_mem_partition
+symbol.
 
 Example:
 
@@ -67,17 +57,18 @@ Example:
             /* create partition at top of file outside functions */
             appmem_partition(part0);
             /* create domain */
-            appmem_domain(dom0);
+            struct k_mem_domain dom0;
             /* assign variables to the domain */
-            _app_dmem(dom0) int var1;
-            _app_bmem(dom0) static volatile int var2;
+            _app_dmem(part0) int var1;
+            _app_bmem(part0) static volatile int var2;
 
             int main()
             {
                     appmem_init_part_part0();
                     appmem_init_app_memory();
-                    appmem_init_domain_dom0(part0);
-                    appmem_add_thread_dom0(k_current_get());
+                    k_mem_domain_init(&dom0, 0, NULL)
+                    k_mem_domain_add_partition(&dom0, part0);
+                    k_mem_domain_add_thread(&dom0, k_current_get());
                     ...
             }
 
@@ -88,12 +79,6 @@ app_macro_support.h:
 .. code-block:: c
 
  FOR_EACH(appmem_partition, part0, part1, part2);
-
-or, for multiple domains, similarly:
-
-.. code-block:: c
-
- FOR_EACH(appmem_domain, dom0, dom1);
 
 Similarly, the appmem_init_part_* can also be used in the macro:
 

--- a/samples/userspace/shared_mem/src/main.c
+++ b/samples/userspace/shared_mem/src/main.c
@@ -29,7 +29,7 @@
 /* prepare the memory partition structures  */
 FOR_EACH(appmem_partition, part0, part1, part2, part3, part4);
 /* prepare the memory domain structures  */
-FOR_EACH(appmem_domain, dom0, dom1, dom2);
+struct k_mem_domain dom0, dom1, dom2;
 /* each variable starts with a name defined in main.h
  * the names are symbolic for the memory partitions
  * purpose.
@@ -99,7 +99,9 @@ _app_ct_d char ctMSG[] = "CT!\n";
 
 void main(void)
 {
-
+	struct k_mem_partition *dom1_parts[] = {&part2, &part1, &part3};
+	struct k_mem_partition *dom2_parts[] = {&part4, &part3};
+	struct k_mem_partition *dom0_parts[] = {&part0, &part1};
 	k_tid_t tPT, tENC, tCT;
 
 	k_thread_access_grant(k_current_get(), &allforone);
@@ -120,12 +122,9 @@ void main(void)
 	k_thread_access_grant(tENC, &allforone);
 	/* use K_FOREVER followed by k_thread_start*/
 	printk("ENC Thread Created %08X\n", (unsigned int) tENC);
-	appmem_init_domain_dom1(part2);
-	printk("init domain complete\n");
-	appmem_add_part_dom1(part1);
-	appmem_add_part_dom1(part3);
+	k_mem_domain_init(&dom1, 3, dom1_parts);
 	printk("Partitions added to dom1\n");
-	appmem_add_thread_dom1(tENC);
+	k_mem_domain_add_thread(&dom1, tENC);
 	printk("dom1 Created\n");
 
 
@@ -135,9 +134,8 @@ void main(void)
 			K_FOREVER);
 	k_thread_access_grant(tPT, &allforone);
 	printk("PT Thread Created %08X\n", (unsigned int) tPT);
-	appmem_init_domain_dom0(part0);
-	appmem_add_part_dom0(part1);
-	appmem_add_thread_dom0(tPT);
+	k_mem_domain_init(&dom0, 2, dom0_parts);
+	k_mem_domain_add_thread(&dom0, tPT);
 	printk("dom0 Created\n");
 
 	tCT = k_thread_create(&ct_thread, ct_stack, STACKSIZE,
@@ -146,9 +144,8 @@ void main(void)
 			K_FOREVER);
 	k_thread_access_grant(tCT, &allforone);
 	printk("CT Thread Created %08X\n", (unsigned int) tCT);
-	appmem_init_domain_dom2(part4);
-	appmem_add_part_dom2(part3);
-	appmem_add_thread_dom2(tCT);
+	k_mem_domain_init(&dom2, 2, dom2_parts);
+	k_mem_domain_add_thread(&dom2, tCT);
 	printk("dom2 Created\n");
 
 	k_thread_start(&enc_thread);


### PR DESCRIPTION
The app shared memory macros for declaring domains provide
no value, despite the stated intentions.

Just declare memory domains using the standard APIs for it.

To support this, symbols declared for app shared memory
partitions now are struct k_mem_partition, which can be
passed to the k_mem_domain APIs as normal, instead of the
app_region structs which are of no interest to the end
user.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>