### PR TITLE
Cortexm asm to c use cmsis

### DIFF
--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -23,6 +23,45 @@
 #include <kernel_internal.h>
 #include <arch/arm/cortex_m/cmsis.h>
 #include <string.h>
+#include <cortex_m/stack.h>
+
+void switch_sp_to_psp(void)
+{
+	__set_CONTROL(__get_CONTROL() | CONTROL_SPSEL_Msk);
+	/*
+	 * When changing the stack pointer, software must use an ISB instruction
+	 * immediately after the MSR instruction. This ensures that instructions
+	 * after the ISB instruction execute using the new stack pointer.
+	 */
+	__ISB();
+}
+
+void set_and_switch_to_psp(void)
+{
+	u32_t process_sp;
+
+	process_sp = (u32_t)&_interrupt_stack + CONFIG_ISR_STACK_SIZE;
+	__set_PSP(process_sp);
+	switch_sp_to_psp();
+}
+
+void lock_interrupts(void)
+{
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+	__disable_irq();
+#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	__set_BASEPRI(_EXC_IRQ_DEFAULT_PRIO);
+#else
+#error Unknown ARM architecture
+#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
+}
+
+#ifdef CONFIG_INIT_STACKS
+void init_stacks(void)
+{
+	memset(&_interrupt_stack, 0xAA, CONFIG_ISR_STACK_SIZE);
+}
+#endif
 
 #ifdef CONFIG_CPU_CORTEX_M_HAS_VTOR
 

--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -67,16 +67,6 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
     bl _WdogInit
 #endif
 
-#ifdef CONFIG_INIT_STACKS
-    bl	init_stacks
-#endif
-
-    /*
-     * Set PSP and use it to boot without using MSP, so that it
-     * gets set to _interrupt_stack during initialisation.
-     */
-    bl set_and_switch_to_psp
-
     /*
      * 'bl' jumps the furthest of the branch instructions that are
      * supported on all platforms. So it is used when jumping to _PrepC

--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -19,8 +19,6 @@
 _ASM_FILE_PROLOGUE
 
 GTEXT(__reset)
-GTEXT(memset)
-GDATA(_interrupt_stack)
 #if defined(CONFIG_PLATFORM_SPECIFIC_INIT)
 GTEXT(_PlatformInit)
 #endif
@@ -63,43 +61,21 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 #endif
 
     /* lock interrupts: will get unlocked when switch to main task */
-#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-    cpsid i
-#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-    movs.n r0, #_EXC_IRQ_DEFAULT_PRIO
-    msr BASEPRI, r0
-#else
-#error Unknown ARM architecture
-#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
-
+    bl	lock_interrupts
 #ifdef CONFIG_WDOG_INIT
     /* board-specific watchdog initialization is necessary */
     bl _WdogInit
 #endif
 
 #ifdef CONFIG_INIT_STACKS
-    ldr r0, =_interrupt_stack
-    ldr r1, =0xaa
-    ldr r2, =CONFIG_ISR_STACK_SIZE
-    bl memset
+    bl	init_stacks
 #endif
 
     /*
      * Set PSP and use it to boot without using MSP, so that it
      * gets set to _interrupt_stack during initialisation.
      */
-    ldr r0, =_interrupt_stack
-    ldr r1, =CONFIG_ISR_STACK_SIZE
-    adds r0, r0, r1
-    msr PSP, r0
-    movs.n r0, #2	/* switch to using PSP (bit1 of CONTROL reg) */
-    msr CONTROL, r0
-    /*
-     * When changing the stack pointer, software must use an ISB instruction
-     * immediately after the MSR instruction. This ensures that instructions
-     * after the ISB instruction execute using the new stack pointer.
-    */
-    isb
+    bl set_and_switch_to_psp
 
     /*
      * 'bl' jumps the furthest of the branch instructions that are


### PR DESCRIPTION
This patchset uses the cmsis functions to replace some of the assembly coding done in reset.S for cortex-m architectures. It brings more code clarity and the benefit of easy code maintenance as cmsis repo takes care of intrinsic functions. 

We should be able to move all the stuff from reset.S to PrepC, let's keep it for next patch.

Cheers,
Vikas