### PR TITLE
drivers: uart_ns16550: remove soc specific codes and bug fixes

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -193,10 +193,8 @@
 #ifdef UART_NS16550_ACCESS_IOPORT
 #define INBYTE(x) sys_in8(x)
 #define OUTBYTE(x, d) sys_out8(d, x)
-#ifdef CONFIG_SOC_ARC_IOT
-#define UART_REG_ADDR_INTERVAL 4 /* address diff of adjacent regs. */
-#else
-#define UART_REG_ADDR_INTERVAL 1
+#ifndef UART_REG_ADDR_INTERVAL
+#define UART_REG_ADDR_INTERVAL 1 /* address diff of adjacent regs. */
 #endif
 #else
 #define INBYTE(x) sys_read8(x)
@@ -254,8 +252,12 @@ static void set_baud_rate(struct device *dev, u32_t baud_rate)
 	u8_t lcr_cache;
 
 	if ((baud_rate != 0) && (dev_cfg->sys_clk_freq != 0)) {
-		/* calculate baud rate divisor */
-		divisor = ((dev_cfg->sys_clk_freq / baud_rate) >> 4) + 1;
+		/*
+		 * calculate baud rate divisor. a variant of
+		 * (u32_t)(dev_cfg->sys_clk_freq / (16.0 * baud_rate) + 0.5)
+		 */
+		divisor = ((dev_cfg->sys_clk_freq + (baud_rate << 3))
+					/ baud_rate) >> 4;
 
 		/* set the DLAB to access the baud rate divisor registers */
 		lcr_cache = INBYTE(LCR(dev));
@@ -327,16 +329,11 @@ static int uart_ns16550_init(struct device *dev)
 
 	old_level = irq_lock();
 
-#ifdef CONFIG_SOC_ARC_IOT
-	/* enbale clk for uart before write any regs */
-	OUTBYTE(DLF(dev), 1);
-#endif
-
-	set_baud_rate(dev, dev_data->baud_rate);
-
 #ifdef CONFIG_UART_NS16550_DLF
 	set_dlf(dev, dev_data->dlf);
 #endif
+
+	set_baud_rate(dev, dev_data->baud_rate);
 
 	/* 8 data bits, 1 stop bit, no parity, clear DLAB */
 	OUTBYTE(LCR(dev), LCR_CS8 | LCR_1_STB | LCR_PDIS);

--- a/soc/arc/snps_arc_iot/Kconfig.defconfig
+++ b/soc/arc/snps_arc_iot/Kconfig.defconfig
@@ -37,12 +37,18 @@ if SERIAL
 config UART_NS16550
 	def_bool y
 
+config UART_NS16550_DLF
+	def_bool y
+
 endif # SERIAL
 
 if UART_CONSOLE
 
 config UART_NS16550_PORT_0
 	def_bool y
+
+config UART_NS16550_PORT_0_DLF
+	default 1
 
 endif # UART_CONSOLE
 

--- a/soc/arc/snps_arc_iot/soc.h
+++ b/soc/arc/snps_arc_iot/soc.h
@@ -23,6 +23,7 @@
  * UART: use lr and sr to access subsystem uart IP
  */
 #define UART_NS16550_ACCESS_IOPORT
+#define UART_REG_ADDR_INTERVAL 4
 
 
 /* ARC EM Core IRQs */


### PR DESCRIPTION
* remove soc specific codes
* optimize the caculation of baudrate.
   the correct formula is 
        divisor =  (u32_t)(dev_cfg->sys_clk_freq / (16.0 * baud_rate) + 0.5)
  here a variant is used to replace the old one

Fixes #12652

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>