### PR TITLE
 usb: netusb: Align NETUSB_MTU & wMaxSegmentSize and increase it to 1522

### DIFF
--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -101,7 +101,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 		.bDescriptorSubtype = ETHERNET_FUNC_DESC,
 		.iMACAddress = 4,
 		.bmEthernetStatistics = sys_cpu_to_le32(0), /* None */
-		.wMaxSegmentSize = sys_cpu_to_le16(1514),
+		.wMaxSegmentSize = sys_cpu_to_le16(NETUSB_MTU),
 		.wNumberMCFilters = sys_cpu_to_le16(0), /* None */
 		.bNumberPowerFilters = 0, /* No wake up */
 	},

--- a/subsys/usb/class/netusb/netusb.h
+++ b/subsys/usb/class/netusb/netusb.h
@@ -8,7 +8,7 @@
  * USB definitions
  */
 
-#define NETUSB_MTU 1500
+#define NETUSB_MTU 1522
 
 #define CDC_ECM_INT_EP_ADDR		0x83
 #define CDC_ECM_IN_EP_ADDR		0x82


### PR DESCRIPTION
 I saw a misalignment problem between the declared ECM wMaxSegmentSize and the NETUSB_MTU.
As rx_buf & tx_buf are defined with a NETUSB_MTU size, this cause that the frames over 1500 bytes can not be received and are discarded.

Secondly, as fragmentation is not supported (for UDP and TCP datagram), I suggest to increase the  NETUSB_MTU to the maximum of the possible ethernet frame size :1522