### PR TITLE
drivers: counter: Fix default top value callback in counter_nrfx_rtc.c

### DIFF
--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -172,9 +172,10 @@ static void event_handler(nrfx_rtc_int_type_t int_type, void *p_context)
 		/* Manually reset counter if top value is different than max. */
 		if (data->top != COUNTER_MAX_TOP_VALUE) {
 			nrfx_rtc_counter_clear(&get_nrfx_config(dev)->rtc);
-			nrfx_rtc_cc_set(&get_nrfx_config(dev)->rtc,
-					TOP_CH, data->top, true);
 		}
+
+		nrfx_rtc_cc_set(&get_nrfx_config(dev)->rtc,
+				TOP_CH, data->top, true);
 
 		if (data->top_cb) {
 			data->top_cb(dev, data->top_user_data);


### PR DESCRIPTION
In case of default top value, driver was calling top value
callback only on the first period. This was not expected behavior.

Fixes #12800.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>