### PR TITLE
ARM : save and restore r3 register when call configure_mpu_stack_guard

### DIFF
--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -97,7 +97,9 @@ _arch_switch_to_main_thread(struct k_thread *main_thread,
 		*/
 		"mov %%r0, %3 \t\n"
 		"push {r2, lr} \t\n"
+		"push {r3, lr} \t\n"
 		"blx configure_mpu_stack_guard \t\n"
+		"pop {r3, lr} \t\n"
 		"pop {r2, lr} \t\n"
 #endif
 		/* branch to _thread_entry(_main, 0, 0, 0) */


### PR DESCRIPTION
When MPU_STACK_GUARD is enable in DEBUG_OPTIMIZATIONS mode,
it cause a MPU FAULT /   Instruction Access Violation.

Fixes zephyrproject-rtos#12821

Signed-off-by: Nicolas LANTZ <nicolas.lantz@ubicore.net>