### PR TITLE
drivers: uart_nsim: Add device tree support

### DIFF
--- a/boards/arc/nsim_em/Kconfig.defconfig
+++ b/boards/arc/nsim_em/Kconfig.defconfig
@@ -12,9 +12,6 @@ if SERIAL
 config UART_NSIM
 	default y
 
-config UART_NSIM_PORT_0_BASE_ADDR
-	default 0xf0000000
-
 endif # SERIAL
 
 

--- a/boards/arc/nsim_em/nsim_em.dts
+++ b/boards/arc/nsim_em/nsim_em.dts
@@ -42,7 +42,15 @@
 		reg = <0x80000000 0x80000>;
 	};
 
+	uart0: uart@f0000000 {
+		compatible = "snps,nsim-uart";
+		reg = <0xf0000000 0x100>;
+		label = "UART_0";
+	};
+
 	chosen {
 		zephyr,sram = &dccm0;
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 };

--- a/drivers/serial/Kconfig.nsim
+++ b/drivers/serial/Kconfig.nsim
@@ -4,20 +4,3 @@ config UART_NSIM
 	depends on SERIAL
 	help
 	  This enables the UART driver for the MetaWare nSim simulator.
-
-config UART_NSIM_PORT_0_NAME
-	string "Port 0 Device Name"
-	default "UART_0"
-	depends on UART_NSIM
-	help
-	  This is the device name for UART, and is included in the device
-	  struct.
-
-config UART_NSIM_PORT_0_BASE_ADDR
-	hex "Port 0 Register Address"
-	default 0x00000000
-	depends on UART_NSIM
-	help
-	  The base address of UART port.
-
-	  Leave this at 0x00000000 to skip initialization at boot.

--- a/drivers/serial/uart_nsim.c
+++ b/drivers/serial/uart_nsim.c
@@ -108,10 +108,10 @@ static const struct uart_driver_api uart_nsim_driver_api = {
 };
 
 static struct uart_device_config uart_nsim_dev_cfg_0 = {
-	.regs = CONFIG_UART_NSIM_PORT_0_BASE_ADDR,
+	.regs = DT_SNPS_NSIM_UART_0_BASE_ADDRESS,
 };
 
-DEVICE_AND_API_INIT(uart_nsim0, CONFIG_UART_NSIM_PORT_0_NAME, &uart_nsim_init,
+DEVICE_AND_API_INIT(uart_nsim0, DT_SNPS_NSIM_UART_0_LABEL, &uart_nsim_init,
 			NULL, &uart_nsim_dev_cfg_0,
 			PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 			&uart_nsim_driver_api);

--- a/dts/bindings/serial/snps,nsim-uart.yaml
+++ b/dts/bindings/serial/snps,nsim-uart.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2019, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: Synopsys ARC nSIM UART
+version: 0.1
+
+description: >
+    This binding gives a base representation of the Synopsys ARC nSIM UART
+
+inherits:
+    !include uart.yaml
+
+properties:
+    compatible:
+      constraint: "snps,nsim-uart"
+
+    reg:
+      type: array
+      description: mmio register space
+      generation: define
+      category: required
+
+    interrupts:
+      type: array
+      category: required
+      description: required interrupts
+      generation: define
+...

--- a/tests/drivers/build_all/testcase.yaml
+++ b/tests/drivers/build_all/testcase.yaml
@@ -46,11 +46,6 @@ tests:
     platform_exclude: zedboard_pulpino frdm_kw41z
     tags: drivers footprint
     depends_on: adc spi
-  test_nsim:
-    build_only: true
-    platform_whitelist: em_starterkit
-    extra_configs:
-      - CONFIG_UART_NSIM=y
   test_clock:
     build_only: true
     platform_whitelist: arduino_101


### PR DESCRIPTION
Add Device Tree support for uart nsim ARC driver.  Utilize the binding
from Linux that is "snps,arc-uart".

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>