### PR TITLE
drivers/interrupt_controller: stm32: Use LL API

### DIFF
--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -28,6 +28,10 @@
  */
 #include <kernel_includes.h>
 
+#ifdef CONFIG_EXTI_STM32
+#include <stm32f0xx_ll_exti.h>
+#endif
+
 #ifdef CONFIG_SERIAL_HAS_DRIVER
 #include <stm32f0xx_ll_usart.h>
 #endif

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -28,6 +28,10 @@
  */
 #include <kernel_includes.h>
 
+#ifdef CONFIG_EXTI_STM32
+#include <stm32f1xx_ll_exti.h>
+#endif
+
 #ifdef CONFIG_SERIAL_HAS_DRIVER
 #include <stm32f1xx_ll_usart.h>
 #endif

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -27,6 +27,10 @@
  */
 #include <kernel_includes.h>
 
+#ifdef CONFIG_EXTI_STM32
+#include <stm32f2xx_ll_exti.h>
+#endif
+
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32f2xx_ll_utils.h>
 #include <stm32f2xx_ll_bus.h>

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -29,6 +29,10 @@
  */
 #include <kernel_includes.h>
 
+#ifdef CONFIG_EXTI_STM32
+#include <stm32f3xx_ll_exti.h>
+#endif
+
 #ifdef CONFIG_SERIAL_HAS_DRIVER
 #include <stm32f3xx_ll_usart.h>
 #endif

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -28,6 +28,10 @@
  */
 #include <kernel_includes.h>
 
+#ifdef CONFIG_EXTI_STM32
+#include <stm32f4xx_ll_exti.h>
+#endif
+
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32f4xx_ll_utils.h>
 #include <stm32f4xx_ll_bus.h>

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -27,6 +27,10 @@
  */
 #include <kernel_includes.h>
 
+#ifdef CONFIG_EXTI_STM32
+#include <stm32f7xx_ll_exti.h>
+#endif
+
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32f7xx_ll_utils.h>
 #include <stm32f7xx_ll_bus.h>

--- a/soc/arm/st_stm32/stm32l0/soc.h
+++ b/soc/arm/st_stm32/stm32l0/soc.h
@@ -29,6 +29,10 @@
 
 #include <stm32l0xx_ll_system.h>
 
+#ifdef CONFIG_EXTI_STM32
+#include <stm32l0xx_ll_exti.h>
+#endif
+
 #ifdef CONFIG_SERIAL_HAS_DRIVER
 #include <stm32l0xx_ll_usart.h>
 #include <stm32l0xx_ll_lpuart.h>

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -30,6 +30,10 @@
  */
 #include <kernel_includes.h>
 
+#ifdef CONFIG_EXTI_STM32
+#include <stm32l4xx_ll_exti.h>
+#endif
+
 #ifdef CONFIG_GPIO_STM32
 /* Required to enable VDDio2 for port G */
 #include <stm32l4xx_ll_pwr.h>


### PR DESCRIPTION
exti driver implementation does not fit all SoCs because
some EXTI ip does not match stm32_exti register map provided.
Instead of providing exti register map for all SoCs, use LL API
which abstracts IP variations and enable uniform use of the drivers
on all STM32SoCs.

Tested on F1/F3/F4/F7/L0/L4

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>