### PR TITLE
drivers: WNC-M14A2A modem fixes

### DIFF
--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -603,7 +603,7 @@ static void on_cmd_atcmdecho_nosock_imei(struct net_buf **buf, u16_t len)
 	if (len < MDM_IMEI_LENGTH) {
 		LOG_DBG("Waiting for data");
 		/* wait for more data */
-		k_sleep(K_MSEC(100));
+		k_sleep(K_MSEC(500));
 		wncm14a2a_read_rx(buf);
 	}
 

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1445,14 +1445,8 @@ error:
 	return;
 }
 
-static void wncm14a2a_modem_reset_work(struct k_work *work)
-{
-	wncm14a2a_modem_reset();
-}
-
 static int wncm14a2a_init(struct device *dev)
 {
-	static struct k_delayed_work reset_work;
 	int i, ret = 0;
 
 	ARG_UNUSED(dev);
@@ -1513,10 +1507,7 @@ static int wncm14a2a_init(struct device *dev)
 	/* init RSSI query */
 	k_delayed_work_init(&ictx.rssi_query_work, wncm14a2a_rssi_query_work);
 
-	/* Let's start the modem reset in a workq so that init can proceed */
-	k_delayed_work_init(&reset_work, wncm14a2a_modem_reset_work);
-	ret = k_delayed_work_submit_to_queue(&wncm14a2a_workq,
-					     &reset_work, K_MSEC(10));
+	wncm14a2a_modem_reset();
 
 error:
 	return ret;


### PR DESCRIPTION
2 patches:
- Fix the initialization so that the modem will be ready for samples
- Add a bit more time for the IMEI data to be collected from the modem