### PR TITLE
app_shmem: auto-initialize partitions

### DIFF
--- a/doc/kernel/usermode/usermode_sharedmem.rst
+++ b/doc/kernel/usermode/usermode_sharedmem.rst
@@ -42,13 +42,9 @@ The resulting section name can be seen in the linker.map as
 "data_smem_id" and "data_smem_idb".
 
 To create a k_mem_partition, call the macro K_APPMEM_PARTITION_DEFINE(part0)
-where "part0" is the name then used to refer to that partition.
-This macro only creates a function and necessary data structures for
-the later "initialization".
-
-Once the partition is initialized, the standard memory domain APIs may
-be used to add it to domains; the declared name is a k_mem_partition
-symbol.
+where "part0" is the name then used to refer to that partition. The
+standard memory domain APIs may be used to add it to domains; the declared
+name is a k_mem_partition symbol.
 
 Example:
 
@@ -64,8 +60,6 @@ Example:
 
             int main()
             {
-                    appmem_init_part_part0();
-                    appmem_init_app_memory();
                     k_mem_domain_init(&dom0, 0, NULL)
                     k_mem_domain_add_partition(&dom0, part0);
                     k_mem_domain_add_thread(&dom0, k_current_get());
@@ -79,11 +73,4 @@ app_macro_support.h:
 .. code-block:: c
 
  FOR_EACH(K_APPMEM_PARTITION_DEFINE, part0, part1, part2);
-
-Similarly, the appmem_init_part_* can also be used in the macro:
-
-.. code-block:: c
-
- FOR_EACH(appmem_init_part, part0, part1, part2);
-
 

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -42,6 +42,13 @@
 	}
 #endif
 
+	SECTION_PROLOGUE(app_shmem_regions, (OPTIONAL),)
+	{
+		__app_shmem_regions_start = .;
+		KEEP(*(SORT(".app_regions.*")));
+		__app_shmem_regions_end = .;
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
 	SECTION_PROLOGUE (devconfig, (OPTIONAL),)
 	{
 		__devconfig_start = .;

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -116,7 +116,7 @@
 #define APP_INPUT_SECTION(sect)    *(MAYBE_EXCLUDE_SOME_FILES sect)
 #define KERNEL_INPUT_SECTION(sect) *(sect)
 
-#define APP_SMEM_SECTION() KEEP(*(SORT(data_smem_[_a-zA-Z0-9]*)))
+#define APP_SMEM_SECTION() KEEP(*(SORT("data_smem_*")))
 
 #ifdef CONFIG_X86 /* LINKER FILES: defines used by linker script */
 /* Should be moved to linker-common-defs.h */

--- a/samples/userspace/shared_mem/src/main.c
+++ b/samples/userspace/shared_mem/src/main.c
@@ -105,12 +105,7 @@ void main(void)
 	k_tid_t tPT, tENC, tCT;
 
 	k_thread_access_grant(k_current_get(), &allforone);
-	/* initialize the partition structures  */
-	FOR_EACH(appmem_init_part, part0, part1, part2, part3, part4);
 
-	printk("init partitions complete\n");
-	appmem_init_app_memory();
-	printk("init app memory complete\n");
 	/*
 	 * create an enc thread init the memory domain and add partitions
 	 * then add the thread to the domain.

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -679,7 +679,7 @@ class SizeCalculator:
                    "_k_memory_pool", "exceptions", "initshell",
                    "_static_thread_area", "_k_timer_area",
                    "_k_mem_slab_area", "_k_mem_pool_area", "sw_isr_table",
-                   "_k_sem_area", "_k_mutex_area",
+                   "_k_sem_area", "_k_mutex_area", "app_shmem_regions",
                    "_k_fifo_area", "_k_lifo_area", "_k_stack_area",
                    "_k_msgq_area", "_k_mbox_area", "_k_pipe_area",
                    "net_if", "net_if_dev", "net_stack", "net_l2_data",

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -689,24 +689,6 @@ void test_main(void)
 {
 	struct k_mem_partition *parts[] = {&part0, &part1};
 
-	/* partitions must be initialized first */
-	FOR_EACH(appmem_init_part, part0, part1, part2);
-	/*
-	 * Next, the app_memory must be initialized in order to
-	 * calculate size of the dynamically created subsections.
-	 */
-#if defined(CONFIG_ARC)
-	/*
-	 * appmem_init_app_memory will access all partitions
-	 * For CONFIG_ARC_MPU_VER == 3, these partitions are not added
-	 * into MPU now, so need to disable mpu first to do app_bss_zero()
-	 */
-	arc_core_mpu_disable();
-	appmem_init_app_memory();
-	arc_core_mpu_enable();
-#else
-	appmem_init_app_memory();
-#endif
 	k_mem_domain_init(&dom0, 2, parts);
 	k_mem_domain_add_thread(&dom0, k_current_get());
 


### PR DESCRIPTION
There are no longer per-partition initialization functions.
Instead, we iterate over all of them at boot to set up the
derived k_mem_partitions properly.

Some ARC-specific hacks that should never have been applied
have been removed from the userspace test.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>