### PR TITLE
net/ip: Protocol family do not have to follow any other OS's value

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -37,9 +37,9 @@ extern "C" {
 #define NET_VLAN_TAG_UNSPEC 0x0fff
 
 /** Protocol families */
-#define PF_UNSPEC	0	/* Unspecified.  */
-#define PF_INET		2	/* IP protocol family.  */
-#define PF_INET6	10	/* IP version 6.  */
+#define PF_UNSPEC	0	/* Unspecified. */
+#define PF_INET		1	/* IP protocol family version 4. */
+#define PF_INET6	2	/* IP protocol family version 6. */
 
 /** Address families.  */
 #define AF_UNSPEC	PF_UNSPEC

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -88,7 +88,7 @@ static void net_ctx_get_fail(void)
 	zassert_equal(ret, -EPROTONOSUPPORT,
 		      "Invalid context protocol test failed");
 
-	ret = net_context_get(1, SOCK_DGRAM, IPPROTO_UDP, &context);
+	ret = net_context_get(4, SOCK_DGRAM, IPPROTO_UDP, &context);
 	zassert_equal(ret, -EAFNOSUPPORT,
 		      "Invalid context family test failed");
 


### PR DESCRIPTION
It is the macro name that matters, not its value. Here, that will help
to save 1 bit in struct net_pkt later on.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>