### PR TITLE
net: tcp: Call cb in case last ACK is not received

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1761,6 +1761,11 @@ static void handle_ack_timeout(struct k_work *work)
 		 */
 		net_tcp_change_state(tcp, NET_TCP_CLOSED);
 
+		if (tcp->context->recv_cb) {
+			tcp->context->recv_cb(tcp->context, NULL, 0,
+					      tcp->recv_user_data);
+		}
+
 		net_context_unref(tcp->context);
 	}
 }


### PR DESCRIPTION
After receiving FIN, the TCP stack will send a FIN and start
a timer to track the reception of the associated ACK. In case this
ACK is never received then the context will be released
without calling the associated received callback which leads to
upper layers not being informed that the connection was closed.

This issue was observed when using sockets, the effect is
that in this case the socket would never be closed and stay
in limbo forever.

Signed-off-by: Léonard Bise <leonard.bise@gmail.com>