### PR TITLE
soc: same70: always enable data cache

### DIFF
--- a/soc/arm/atmel_sam/same70/soc.c
+++ b/soc/arm/atmel_sam/same70/soc.c
@@ -229,17 +229,9 @@ static int atmel_same70_init(struct device *arg)
 
 	SCB_EnableICache();
 
-/*
- * The Atmel SAM GMAC Ethernet driver is using a scatter-gather technique
- * to exchange data with the Ethernet driver. This requires the use use of
- * a non-cached memory area. This is currently not supported on Zephyr, so
- * do not enable the cache in that case.
- */
-#ifndef CONFIG_ETH_SAM_GMAC
 	if (!(SCB->CCR & SCB_CCR_DC_Msk)) {
 		SCB_EnableDCache();
 	}
-#endif
 
 	/* Clear all faults */
 	_ClearFaults();


### PR DESCRIPTION
Now that the SAM Ethernet driver can work when the cached is enabled, it
is possible to unconditionally enable the data cache on the SAM E70 SoC.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>

Note: this can only been merged once PR #11888 and PR #12817 get in, hence the DNM label.