### PR TITLE
scripts: west: explicitly ask for --sectorerase for nRF9160_pca10090

### DIFF
--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2017 Linaro Limited.
+# Copyright (c) 2019 Nordic Semiconductor ASA.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -104,10 +105,10 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
                 program_cmd
             ])
         else:
-            if self.family == 'NRF51':
-                commands.append(program_cmd + ['--sectorerase'])
-            else:
+            if self.family == 'NRF52':
                 commands.append(program_cmd + ['--sectoranduicrerase'])
+            else:
+                commands.append(program_cmd + ['--sectorerase'])
 
         if self.family == 'NRF52' and not self.softreset:
             commands.extend([

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -114,29 +114,25 @@ EXPECTED_COMMANDS = {
 
     # NRF91:
     '9NNN':
-    (['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF91', '--snr', TEST_DEF_SNR, '--sectoranduicrerase'],  # noqa: E501
-     ['nrfjprog', '--pinresetenable', '-f', 'NRF91', '--snr', TEST_DEF_SNR],
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF91', '--snr', TEST_DEF_SNR, '--sectorerase'],  # noqa: E501
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
     '9NNY':
     (['nrfjprog', '--eraseall', '-f', 'NRF91', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF91', '--snr', TEST_DEF_SNR],  # noqa: E501
-     ['nrfjprog', '--pinresetenable', '-f', 'NRF91', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
     '9NYN':
-    (['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF91', '--snr', TEST_OVR_SNR, '--sectoranduicrerase'],  # noqa: E501
-     ['nrfjprog', '--pinresetenable', '-f', 'NRF91', '--snr', TEST_OVR_SNR],
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF91', '--snr', TEST_OVR_SNR, '--sectorerase'],  # noqa: E501
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_OVR_SNR]),
 
     '9NYY':
     (['nrfjprog', '--eraseall', '-f', 'NRF91', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF91', '--snr', TEST_OVR_SNR],  # noqa: E501
-     ['nrfjprog', '--pinresetenable', '-f', 'NRF91', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_OVR_SNR]),
 
     '9YNN':
-    (['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF91', '--snr', TEST_DEF_SNR, '--sectoranduicrerase'],  # noqa: E501
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF91', '--snr', TEST_DEF_SNR, '--sectorerase'],  # noqa: E501
      ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
     '9YNY':
@@ -145,7 +141,7 @@ EXPECTED_COMMANDS = {
      ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
     '9YYN':
-    (['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF91', '--snr', TEST_OVR_SNR, '--sectoranduicrerase'],  # noqa: E501
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '-f', 'NRF91', '--snr', TEST_OVR_SNR, '--sectorerase'],  # noqa: E501
      ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_OVR_SNR]),
 
     '9YYY':

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -176,7 +176,7 @@ def expected_commands(family, softreset, snr, erase):
 #
 
 TEST_CASES = [(f, sr, snr, e)
-              for f in ('NRF51', 'NRF52')
+              for f in ('NRF51', 'NRF52', 'NRF91')
               for sr in (False, True)
               for snr in (TEST_OVR_SNR, None)
               for e in (False, True)]


### PR DESCRIPTION
When flashing nRF9160_pca10090 board with nrfjprog explicitly
request for --sectorerase, instead of --sectoranduicrerase.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>