### PR TITLE
logging: Handle panic occuring before log initialization

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -385,6 +385,11 @@ void log_panic(void)
 		return;
 	}
 
+	/* If panic happend early logger might not be initialized.
+	 * Forcing initialization of the logger and auto-starting backends.
+	 */
+	log_init();
+
 	for (int i = 0; i < log_backend_count_get(); i++) {
 		backend = log_backend_get(i);
 


### PR DESCRIPTION
Log backends (marked as autostart) are initialized late. By default
in logger thread which has the lowest priority. If log_panic() occurs
earlier no logs is printed because there is no backend enabled.

This patch fixes it by adding log_init() call to log_panic(). Log_init()
can be called multiple times.

This patch ensures that logs are printed if early panic occurs if
backend is configured to auto-start. This is not the case if shell
is acting as log backend.

Fixes #12851.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>