### PR TITLE
samples: sockets: Clean up headers included

### DIFF
--- a/samples/net/sockets/big_http_download/src/big_http_download.c
+++ b/samples/net/sockets/big_http_download/src/big_http_download.c
@@ -26,7 +26,6 @@ LOG_MODULE_REGISTER(net_big_http_download_sample, LOG_LEVEL_DBG);
 
 #include <net/socket.h>
 #include <kernel.h>
-#include <net/net_app.h>
 
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 #include <net/tls_credentials.h>

--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -22,9 +22,6 @@ LOG_MODULE_REGISTER(net_dump_http_download_sample, LOG_LEVEL_DBG);
 
 #include <net/socket.h>
 #include <kernel.h>
-#include <net/net_app.h>
-
-#include <net/buf.h>
 
 #endif
 

--- a/samples/net/sockets/echo/src/socket_echo.c
+++ b/samples/net/sockets/echo/src/socket_echo.c
@@ -21,7 +21,6 @@ LOG_MODULE_REGISTER(net_socket_echo_sample, LOG_LEVEL_DBG);
 
 #include <net/socket.h>
 #include <kernel.h>
-#include <net/net_app.h>
 
 #endif
 

--- a/samples/net/sockets/echo_async/src/socket_echo.c
+++ b/samples/net/sockets/echo_async/src/socket_echo.c
@@ -26,7 +26,6 @@ LOG_MODULE_REGISTER(net_echo_async_sample, LOG_LEVEL_DBG);
 #include <fcntl.h>
 #include <net/socket.h>
 #include <kernel.h>
-#include <net/net_app.h>
 
 #endif
 

--- a/samples/net/sockets/echo_async_select/src/socket_echo_select.c
+++ b/samples/net/sockets/echo_async_select/src/socket_echo_select.c
@@ -22,7 +22,6 @@
 #include <fcntl.h>
 #include <net/socket.h>
 #include <kernel.h>
-#include <net/net_app.h>
 
 #endif
 

--- a/samples/net/sockets/http_get/src/http_get.c
+++ b/samples/net/sockets/http_get/src/http_get.c
@@ -21,7 +21,6 @@ LOG_MODULE_REGISTER(net_http_get_sample, LOG_LEVEL_DBG);
 
 #include <net/socket.h>
 #include <kernel.h>
-#include <net/net_app.h>
 
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 #include <net/tls_credentials.h>


### PR DESCRIPTION
Don't include net_app.h and net_buf.h, the first is deprecated, the
latter is low-level header, both shouldn't be used for socket apps.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>