### PR TITLE
gpio: mcux_igpio: Cleanup old CONFIG_ symbols

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -203,12 +203,12 @@ static int mcux_igpio_1_init(struct device *dev)
 static int mcux_igpio_2_init(struct device *dev);
 
 static const struct mcux_igpio_config mcux_igpio_2_config = {
-	.base = (GPIO_Type *)CONFIG_MCUX_IGPIO_2_BASE_ADDRESS,
+	.base = (GPIO_Type *)DT_MCUX_IGPIO_2_BASE_ADDRESS,
 };
 
 static struct mcux_igpio_data mcux_igpio_2_data;
 
-DEVICE_AND_API_INIT(mcux_igpio_2, CONFIG_MCUX_IGPIO_2_NAME,
+DEVICE_AND_API_INIT(mcux_igpio_2, DT_MCUX_IGPIO_2_NAME,
 		    mcux_igpio_2_init,
 		    &mcux_igpio_2_data, &mcux_igpio_2_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -216,15 +216,15 @@ DEVICE_AND_API_INIT(mcux_igpio_2, CONFIG_MCUX_IGPIO_2_NAME,
 
 static int mcux_igpio_2_init(struct device *dev)
 {
-	IRQ_CONNECT(CONFIG_MCUX_IGPIO_2_IRQ_0, CONFIG_MCUX_IGPIO_2_IRQ_0_PRI,
+	IRQ_CONNECT(DT_MCUX_IGPIO_2_IRQ_0, DT_MCUX_IGPIO_2_IRQ_0_PRI,
 		    mcux_igpio_port_isr, DEVICE_GET(mcux_igpio_2), 0);
 
-	irq_enable(CONFIG_MCUX_IGPIO_2_IRQ_0);
+	irq_enable(DT_MCUX_IGPIO_2_IRQ_0);
 
-	IRQ_CONNECT(CONFIG_MCUX_IGPIO_2_IRQ_1, CONFIG_MCUX_IGPIO_2_IRQ_1_PRI,
+	IRQ_CONNECT(DT_MCUX_IGPIO_2_IRQ_1, DT_MCUX_IGPIO_2_IRQ_1_PRI,
 		    mcux_igpio_port_isr, DEVICE_GET(mcux_igpio_2), 0);
 
-	irq_enable(CONFIG_MCUX_IGPIO_2_IRQ_1);
+	irq_enable(DT_MCUX_IGPIO_2_IRQ_1);
 
 	return 0;
 }
@@ -234,12 +234,12 @@ static int mcux_igpio_2_init(struct device *dev)
 static int mcux_igpio_3_init(struct device *dev);
 
 static const struct mcux_igpio_config mcux_igpio_3_config = {
-	.base = (GPIO_Type *)CONFIG_MCUX_IGPIO_3_BASE_ADDRESS,
+	.base = (GPIO_Type *)DT_MCUX_IGPIO_3_BASE_ADDRESS,
 };
 
 static struct mcux_igpio_data mcux_igpio_3_data;
 
-DEVICE_AND_API_INIT(mcux_igpio_3, CONFIG_MCUX_IGPIO_3_NAME,
+DEVICE_AND_API_INIT(mcux_igpio_3, DT_MCUX_IGPIO_3_NAME,
 		    mcux_igpio_3_init,
 		    &mcux_igpio_3_data, &mcux_igpio_3_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -247,15 +247,15 @@ DEVICE_AND_API_INIT(mcux_igpio_3, CONFIG_MCUX_IGPIO_3_NAME,
 
 static int mcux_igpio_3_init(struct device *dev)
 {
-	IRQ_CONNECT(CONFIG_MCUX_IGPIO_3_IRQ_0, CONFIG_MCUX_IGPIO_3_IRQ_0_PRI,
+	IRQ_CONNECT(DT_MCUX_IGPIO_3_IRQ_0, DT_MCUX_IGPIO_3_IRQ_0_PRI,
 		    mcux_igpio_port_isr, DEVICE_GET(mcux_igpio_3), 0);
 
-	irq_enable(CONFIG_MCUX_IGPIO_3_IRQ_0);
+	irq_enable(DT_MCUX_IGPIO_3_IRQ_0);
 
-	IRQ_CONNECT(CONFIG_MCUX_IGPIO_3_IRQ_1, CONFIG_MCUX_IGPIO_3_IRQ_1_PRI,
+	IRQ_CONNECT(DT_MCUX_IGPIO_3_IRQ_1, DT_MCUX_IGPIO_3_IRQ_1_PRI,
 		    mcux_igpio_port_isr, DEVICE_GET(mcux_igpio_3), 0);
 
-	irq_enable(CONFIG_MCUX_IGPIO_3_IRQ_1);
+	irq_enable(DT_MCUX_IGPIO_3_IRQ_1);
 
 	return 0;
 }
@@ -265,12 +265,12 @@ static int mcux_igpio_3_init(struct device *dev)
 static int mcux_igpio_4_init(struct device *dev);
 
 static const struct mcux_igpio_config mcux_igpio_4_config = {
-	.base = (GPIO_Type *)CONFIG_MCUX_IGPIO_4_BASE_ADDRESS,
+	.base = (GPIO_Type *)DT_MCUX_IGPIO_4_BASE_ADDRESS,
 };
 
 static struct mcux_igpio_data mcux_igpio_4_data;
 
-DEVICE_AND_API_INIT(mcux_igpio_4, CONFIG_MCUX_IGPIO_4_NAME,
+DEVICE_AND_API_INIT(mcux_igpio_4, DT_MCUX_IGPIO_4_NAME,
 		    mcux_igpio_4_init,
 		    &mcux_igpio_4_data, &mcux_igpio_4_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -278,15 +278,15 @@ DEVICE_AND_API_INIT(mcux_igpio_4, CONFIG_MCUX_IGPIO_4_NAME,
 
 static int mcux_igpio_4_init(struct device *dev)
 {
-	IRQ_CONNECT(CONFIG_MCUX_IGPIO_4_IRQ_0, CONFIG_MCUX_IGPIO_4_IRQ_0_PRI,
+	IRQ_CONNECT(DT_MCUX_IGPIO_4_IRQ_0, DT_MCUX_IGPIO_4_IRQ_0_PRI,
 		    mcux_igpio_port_isr, DEVICE_GET(mcux_igpio_4), 0);
 
-	irq_enable(CONFIG_MCUX_IGPIO_4_IRQ_0);
+	irq_enable(DT_MCUX_IGPIO_4_IRQ_0);
 
-	IRQ_CONNECT(CONFIG_MCUX_IGPIO_4_IRQ_1, CONFIG_MCUX_IGPIO_4_IRQ_1_PRI,
+	IRQ_CONNECT(DT_MCUX_IGPIO_4_IRQ_1, DT_MCUX_IGPIO_4_IRQ_1_PRI,
 		    mcux_igpio_port_isr, DEVICE_GET(mcux_igpio_4), 0);
 
-	irq_enable(CONFIG_MCUX_IGPIO_4_IRQ_1);
+	irq_enable(DT_MCUX_IGPIO_4_IRQ_1);
 
 	return 0;
 }


### PR DESCRIPTION
A number of CONFIG_ symbols should have been converted to DT_ defines
instead.  Clean that up for PORT2..PORT4.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>