### PR TITLE
shell: fix spelling mistake in Kconfig

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -47,7 +47,8 @@ config SHELL_CMD_BUFF_SIZE
 	int "Shell command buffer size"
 	default 256
 	help
-	  Maximum command size.
+	  Maximum command size in bytes. One byte is reserved for the string
+	  terminator character.
 
 config SHELL_PRINTF_BUFF_SIZE
 	int "Shell print buffer size"
@@ -108,7 +109,7 @@ config SHELL_HISTORY
 	default y
 	help
 	  Enable commands history. History can be accessed using up and down
-	  arrows
+	  arrows.
 
 if SHELL_HISTORY
 
@@ -145,7 +146,7 @@ config SHELL_CMDS_RESIZE
 	  By default shell assumes width of a terminal screen set to 80
 	  characters. Each time terminal screen width is changed resize command
 	  must be called to ensure correct text display on the terminal screen.
-	  Resize command can be turned off to safe code memory (~0,5k).
+	  The resize command can be turned off to save code memory (~0,5k).
 
 config SHELL_LOG_BACKEND
 	bool

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1223,7 +1223,6 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 			return;
 		}
 
-
 		if (shell->iface->api->update) {
 			shell->iface->api->update(shell->iface);
 		}
@@ -1452,3 +1451,4 @@ int shell_execute_cmd(const struct shell *shell, const char *cmd)
 
 	return execute(shell);
 }
+


### PR DESCRIPTION
Fixed spelling mistake in shell's Kconfig file.
Updated description in SHELL_CMD_BUFF_SIZE description.
In shell.c: removed obsolete empty line, added empty line
at the end of file.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>