### PR TITLE
zephyr-env.sh: append scripts dir to PATH, don't prepend

### DIFF
--- a/zephyr-env.sh
+++ b/zephyr-env.sh
@@ -53,7 +53,7 @@ if [ "$win_build" -eq 1 ]; then
 fi
 unset win_build
 if ! echo "${PATH}" | grep -q "${scripts_path}"; then
-    export PATH=${scripts_path}:${PATH}
+    export PATH=${PATH}:${scripts_path}
 fi
 unset scripts_path
 


### PR DESCRIPTION
The decisions to both prepend to PATH and put a 'west' launcher script
in the scripts directory turned out to cause a lot of annoyance,
because it breaks the usual usage of running "hash -r" when trying to
clear the "west" entry from bash's cache of commands:

1. zephyr tree A is pre-transition to west
2. zephyr tree B is post-transition
3. user has 'west' installed via pip somewhere in PATH
4. user runs "source A/zephyr-env.sh"
5. user runs "west", gets launcher script from A/scripts as expected
6. user runs "hash -r; cd B; west xyz ..." to try to use the system
   west in installation B
7. bash find A/scripts in PATH before the one from pip
8. old west is run in B. whoops.

It's too late to fix this for old trees, but in case we ever put a
command in here that conflicts with a user command again, let's do the
kind thing and append to PATH, so system locations will be searched
first after a hash -r.
