### PR TITLE
fs/nvs: Improve init speed and remove fs->locked

### DIFF
--- a/doc/subsystems/nvs/nvs.rst
+++ b/doc/subsystems/nvs/nvs.rst
@@ -34,8 +34,7 @@ is unchanged no write to flash is performed.
 To protect the flash area against frequent erases it is important that there is
 sufficient free space. NVS has a protection mechanism to avoid getting in a
 endless loop of flash page erases when there is limited free space. When such
-an endless loop is detected NVS is placed in a locked state and becomes a
-read-only file system.
+a loop is detected NVS returns that there is no more space available.
 
 For NVS the file system is declared as:
 


### PR DESCRIPTION
This patch removes the free space calculation from nvs initialization.
The free space calculation takes a long time, especially on external
flash. The available space can be calculated if required using the
routine nvs_calc_free_space.

This patch also removes the locked state of nvs, it is not possible to
get in a locked state.

Changes:

Removed locked state and free_space from the nvs structure.

nvs_reinit(): has been replaced with by an internal only function
_nvs_startup().

nvs_write(): removed the possibility to place the file system in a
locked state, if to many gc operations are required it will return
-ENOSPC.

ssize_t nvs_calc_free_space(): introduced, calculates the free space
that is available in the nvs file system.

Signed-off-by: Laczen <laczenjms@gmail.com>