### PR TITLE
net: sntp: get rid of the callback function

### DIFF
--- a/include/net/sntp.h
+++ b/include/net/sntp.h
@@ -10,22 +10,6 @@
 
 #include <net/socket.h>
 
-struct sntp_ctx;
-
-/**
- * @typedef sntp_resp_cb_t
- * @brief SNTP response callback.
- *
- * @details The callback is called after a sntp response is received
- *
- * @param ctx Address of sntp context.
- * @param status Error code of sntp response.
- * @param epoch_time Seconds since 1 January 1970.
- */
-
-typedef void (*sntp_resp_cb_t)(struct sntp_ctx *ctx, int status,
-			       u64_t epoch_time);
-
 /** SNTP context */
 struct sntp_ctx {
 	struct {
@@ -39,9 +23,6 @@ struct sntp_ctx {
 	 *  reply matches the one in client request.
 	 */
 	u32_t expected_orig_ts;
-
-	/** SNTP response callback */
-	sntp_resp_cb_t cb;
 };
 
 /**
@@ -61,12 +42,11 @@ int sntp_init(struct sntp_ctx *ctx, struct sockaddr *addr,
  *
  * @param ctx Address of sntp context.
  * @param timeout Timeout of waiting for sntp response (in milliseconds).
- * @param callback Callback function of sntp response.
+ * @param epoch_time Seconds since 1 January 1970.
  *
  * @return 0 if ok, <0 if error.
  */
-int sntp_request(struct sntp_ctx *ctx, u32_t timeout,
-		 sntp_resp_cb_t callback);
+int sntp_request(struct sntp_ctx *ctx, u32_t timeout, u64_t *epoch_time);
 
 /**
  * @brief Release SNTP context

--- a/samples/net/sockets/sntp_client/src/main.c
+++ b/samples/net/sockets/sntp_client/src/main.c
@@ -12,18 +12,12 @@ LOG_MODULE_REGISTER(net_sntp_client_sample, LOG_LEVEL_DBG);
 
 #define SNTP_PORT 123
 
-void resp_callback(struct sntp_ctx *ctx, int status,
-		   u64_t epoch_time)
-{
-	LOG_DBG("time: %lld", epoch_time);
-	LOG_DBG("status: %d", status);
-}
-
 void main(void)
 {
 	struct sntp_ctx ctx;
 	struct sockaddr_in addr;
 	struct sockaddr_in6 addr6;
+	u64_t epoch_time;
 	int rv;
 
 	/* ipv4 */
@@ -40,11 +34,13 @@ void main(void)
 		goto end;
 	}
 
-	rv = sntp_request(&ctx, K_FOREVER, resp_callback);
+	rv = sntp_request(&ctx, K_FOREVER, &epoch_time);
 	if (rv < 0) {
 		LOG_ERR("Failed to send sntp request: %d", rv);
 		goto end;
 	}
+	LOG_DBG("time: %lld", epoch_time);
+	LOG_DBG("status: %d", rv);
 
 	sntp_close(&ctx);
 
@@ -62,11 +58,14 @@ void main(void)
 		goto end;
 	}
 
-	rv = sntp_request(&ctx, K_NO_WAIT, resp_callback);
+	rv = sntp_request(&ctx, K_NO_WAIT, &epoch_time);
 	if (rv < 0) {
 		LOG_ERR("Failed to send sntp request: %d", rv);
 		goto end;
 	}
+
+	LOG_DBG("time: %lld", epoch_time);
+	LOG_DBG("status: %d", rv);
 
 end:
 	sntp_close(&ctx);


### PR DESCRIPTION
The original SNTP client library was designed for the net-app API, for
which it makes sense to have a callback function, which is called
asynchronously when an answer is received.

For the socket based interface, the callback is called just before
sntp_request() returns. It gets the status and the epoch_time in
parameter, however the status is already returned by sntp_request(). It
therefore make sense to replace the callback function by a pointer to
epoch_time.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>