### PR TITLE
Spinlock checking & timeout fix

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -198,7 +198,7 @@ void z_clock_announce(s32_t ticks)
 	curr_tick += announce_remaining;
 	announce_remaining = 0;
 
-	z_clock_set_timeout(_get_next_timeout_expiry(), false);
+	z_clock_set_timeout(next_timeout(), false);
 
 	k_spin_unlock(&timeout_lock, key);
 }


### PR DESCRIPTION
The last recursive spinlock fix actually missed a similar spot, as @dcpleung (working on an SMP platform) stumbled on.  Fix that, but also add a validation layer to the spinlocks themselves so that when CONFIG_ASSERT is true they check for legal usage.