### PR TITLE
samples: sensors: adt7420: Fail gracefully if sensor not found

### DIFF
--- a/samples/sensor/adt7420/src/main.c
+++ b/samples/sensor/adt7420/src/main.c
@@ -93,7 +93,11 @@ void main(void)
 {
 	struct device *dev = device_get_binding(DT_ADI_ADT7420_0_LABEL);
 
-	__ASSERT(dev != NULL, "Failed to get device binding");
+	if (dev == NULL) {
+		printf("Failed to get device binding\n");
+		return;
+	}
+
 	printf("device is %p, name is %s\n", dev, dev->config->name);
 
 	process(dev);


### PR DESCRIPTION
Fixes the adt7420 sensor sample to fail gracefully if the sensor device
is not found and asserts are not enabled.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #12849