### PR TITLE
sensor: lis2dh: Fix gcc8 compiler warning

### DIFF
--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -207,7 +207,8 @@ static int lis2dh_acc_odr_set(struct device *dev, u16_t freq)
 	}
 
 	/* adjust odr index for LP enabled mode, see table above */
-	if ((value & LIS2DH_LP_EN_BIT_MASK) == 1 && (odr == LIS2DH_ODR_9 + 1)) {
+	if (((value & LIS2DH_LP_EN_BIT_MASK) == LIS2DH_LP_EN_BIT_MASK) &&
+		(odr == LIS2DH_ODR_9 + 1)) {
 		odr--;
 	}
 


### PR DESCRIPTION
We get the following warning with sdk-ng:

	drivers/sensor/lis2dh/lis2dh.c:210:38: error: bitwise comparison
	always evaluates to false [-Werror=tautological-compare]

	if ((value & LIS2DH_LP_EN_BIT_MASK) == 1 && ...
                                      ^~
The test needs to be:
	(value & LIS2DH_LP_EN_BIT_MASK) == LIS2DH_LP_EN_BIT_MASK

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>