### PR TITLE
dfu: Fix build issue with gcc8

### DIFF
--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -42,7 +42,7 @@ static bool flash_verify(struct device *dev, off_t offset,
 		if (memcmp(data, &temp, size)) {
 			LOG_ERR("offset=0x%08"PRIx32" VERIFY FAIL. "
 				"expected: 0x%08x, actual: 0x%08x",
-				(u32_t)offset, temp, *(__packed u32_t*)data);
+				(u32_t)offset, temp, UNALIGNED_GET(data));
 			break;
 		}
 		len -= size;


### PR DESCRIPTION
We get the following warning when buiding with gcc8:

	error: 'packed' attribute ignored for type 'u32_t *'
	{aka 'unsigned int *'} [-Werror=attributes]

Removing __pack from the cast fixes the issue.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>