### PR TITLE
display: ssd1673: replace k_busy_wait by k_sleep

### DIFF
--- a/drivers/display/ssd1673.c
+++ b/drivers/display/ssd1673.c
@@ -94,7 +94,7 @@ static inline void ssd1673_busy_wait(struct ssd1673_data *driver)
 
 	gpio_pin_read(driver->busy, DT_SOLOMON_SSD1673FB_0_BUSY_GPIOS_PIN, &val);
 	while (val) {
-		k_busy_wait(SSD1673_BUSY_DELAY);
+		k_sleep(SSD1673_BUSY_DELAY);
 		gpio_pin_read(driver->busy, DT_SOLOMON_SSD1673FB_0_BUSY_GPIOS_PIN, &val);
 	}
 }


### PR DESCRIPTION
The SSD1673 driver currently use k_busy_wait to wait for the
controller to finish the execution of a commmand. However a display
update command can take from a few hundreds of ms (default LUT) to
almost a second (initial LUT). k_busy_wait is just a spinning loop,
which prevents all the threads with lower priority to not be executed
during that time. That could be the case for example of the shell or
the log thread.

As the timing is not critical, it's better to use k_sleep instead,
allowing the CPU to process other threads. In the long term it might
even be better to use an interrupt there, but might not be that easy if
we want to support to various SoCs that can be connected to such a
display.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>