### PR TITLE
drivers: gpio: Validate pin number before indexing array in mcux drivers

### DIFF
--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -38,6 +38,11 @@ static int gpio_mcux_configure(struct device *dev,
 	u32_t pcr = 0U;
 	u8_t i;
 
+	/* Check for an invalid pin number */
+	if (pin >= ARRAY_SIZE(port_base->PCR)) {
+		return -EINVAL;
+	}
+
 	/* Check for an invalid pin configuration */
 	if ((flags & GPIO_INT) && (flags & GPIO_DIR_OUT)) {
 		return -EINVAL;

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -77,6 +77,11 @@ static int gpio_mcux_lpc_write(struct device *dev,
 	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
 
+	/* Check for an invalid pin number */
+	if (pin >= ARRAY_SIZE(gpio_base->B[config->port_no])) {
+		return -EINVAL;
+	}
+
 	if (access_op == GPIO_ACCESS_BY_PIN) {
 		/* Set/Clear the data output for the respective pin */
 		gpio_base->B[config->port_no][pin] = value;


### PR DESCRIPTION
Validates the gpio pin number before using it to index into a
memory-mapped register array. Otherwise, a user could send a high pin
number and cause an out-of-bounds access.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #7381

Note that the bug mentioned only gpio_mcux.c, but I checked all three mcux drivers for issue. gpio_mcux_igpio.c was not affected.