### PR TITLE
timer: xtensa: restore smp_timer_init()

### DIFF
--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -118,3 +118,11 @@ u32_t _timer_cycle_get_32(void)
 {
 	return ccount();
 }
+
+#ifdef CONFIG_SMP
+void smp_timer_init(void)
+{
+	set_ccompare(ccount() + CYC_PER_TICK);
+	irq_enable(TIMER_IRQ);
+}
+#endif


### PR DESCRIPTION
The smp_timer_init() was removed during timer re-write.
This results in undefined references error during compilation
when CONFIG_SMP=y. So add it back so we can compile for SMP.
The logic is updated from the previous version to the latest
in the driver.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>