### PR TITLE
add the handling of APP_SHARED_MEM in arc mpu driver

### DIFF
--- a/arch/arc/core/mpu/arc_core_mpu.c
+++ b/arch/arc/core/mpu/arc_core_mpu.c
@@ -7,6 +7,7 @@
 #include <device.h>
 #include <init.h>
 #include <kernel.h>
+#include <kernel_structs.h>
 #include <soc.h>
 #include <arch/arc/v2/mpu/arc_core_mpu.h>
 
@@ -100,7 +101,7 @@ void configure_mpu_user_context(struct k_thread *thread)
 void configure_mpu_mem_domain(struct k_thread *thread)
 {
 	LOG_DBG("configure thread %p's domain", thread);
-	arc_core_mpu_configure_mem_domain(thread->mem_domain_info.mem_domain);
+	arc_core_mpu_configure_mem_domain(thread);
 }
 
 int _arch_mem_domain_max_partitions_get(void)

--- a/include/arch/arc/v2/mpu/arc_core_mpu.h
+++ b/include/arch/arc/v2/mpu/arc_core_mpu.h
@@ -98,7 +98,7 @@ void configure_mpu_stack_guard(struct k_thread *thread);
 
 #if defined(CONFIG_USERSPACE)
 void arc_core_mpu_configure_user_context(struct k_thread *thread);
-void arc_core_mpu_configure_mem_domain(struct k_mem_domain *mem_domain);
+void arc_core_mpu_configure_mem_domain(struct k_thread *thread);
 void arc_core_mpu_mem_partition_remove(u32_t part_index);
 void arc_core_mpu_configure_mem_partition(u32_t part_index,
 					  struct k_mem_partition *part);


### PR DESCRIPTION

* add the handling of APP_SHARED_MEM. privileged threads can access all the mem
explictly defined in user mode, i.e., APP_MEM & APP_SHARED_MEM
* remove arc specific related code in tests/kernel/mem_protect/userspace. no need to disbale mpu to do app mem init because of changes in ARC MPU driver

Fixes #12844