### PR TITLE
assert: Add support for architecture specific assert behavior

### DIFF
--- a/include/arch/posix/arch.h
+++ b/include/arch/posix/arch.h
@@ -54,6 +54,9 @@ FUNC_NORETURN void _SysFatalErrorHandler(unsigned int reason,
 FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
 					  const NANO_ESF *esf);
 
+extern void posix_exit(int exit_code);
+#define __ARCH_POST_ASSERT(file, line) posix_exit(1)
+
 /**
  * @brief Explicitly nop operation.
  */

--- a/include/misc/__assert.h
+++ b/include/misc/__assert.h
@@ -82,9 +82,9 @@
 #if __ASSERT_ON
 #include <misc/printk.h>
 
-#if defined(CONFIG_ARCH_POSIX)
-extern void posix_exit(int exit_code);
-#define __ASSERT_POST posix_exit(1)
+#if defined(CONFIG_POST_ASSERT_ARCH_DEFINED)
+  #include "arch/cpu.h"
+  #define __ASSERT_POST __ARCH_POST_ASSERT(__FILE__, __LINE__)
 #else
 #define __ASSERT_POST             \
 	for (;;) {                \

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -159,6 +159,14 @@ config FORCE_NO_ASSERT
 	  CFLAGS and not Kconfig.  Added solely to be able to work
 	  around compiler bugs for specific tests.
 
+config POST_ASSERT_ARCH_DEFINED
+	bool "Make Arch define post assert behavior"
+	default y if ARCH_POSIX
+	help
+	  This boolean option enables architecure specific implemenation of
+	  post assertion behavior. Added to let architecture define what to
+	  do after an asserts occurs.
+
 config OBJECT_TRACING
 	bool "Kernel object tracing"
 	help


### PR DESCRIPTION
Add new kconfig for making it possible to control the behavior
of an assert depending on platform. If enabled __ARCH_ASSERT must
be defined in architecture to e.g. reset or newer ending loop.

Signed-off-by: Peter Herager <pehe@oticon.com>