### PR TITLE
rtc: stm32: Remove trivial endif comment

### DIFF
--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -241,7 +241,7 @@ static int rtc_stm32_init(struct device *dev)
 
 	LL_RCC_SetRTCClockSource(LL_RCC_RTC_CLKSOURCE_LSE);
 
-#endif /* CONFIG_RTC_STM32_CLOCK_SRC */
+#endif
 
 	LL_RCC_EnableRTC();
 


### PR DESCRIPTION
Removed the endif comment as the Kconfig symbol it referenced didn't
exist.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>