### PR TITLE
uart: sifive: Fix trivial CONFIG -> DT missed conversion

### DIFF
--- a/drivers/serial/uart_sifive.c
+++ b/drivers/serial/uart_sifive.c
@@ -429,7 +429,7 @@ static const struct uart_sifive_device_config uart_sifive_dev_cfg_1 = {
 #endif
 };
 
-DEVICE_AND_API_INIT(uart_sifive_1, CONFIG_SIFIVE_UART_1_LABEL,
+DEVICE_AND_API_INIT(uart_sifive_1, DT_SIFIVE_UART_1_LABEL,
 		    uart_sifive_init,
 		    &uart_sifive_data_1, &uart_sifive_dev_cfg_1,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,


### PR DESCRIPTION
CONFIG_SIFIVE_UART_1_LABEL should have been DT_SIFIVE_UART_1_LABEL.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>