### PR TITLE
samples: sockets: Remove Zephyr logging from POSIX-compatible samples

### DIFF
--- a/samples/net/sockets/big_http_download/src/big_http_download.c
+++ b/samples/net/sockets/big_http_download/src/big_http_download.c
@@ -21,9 +21,6 @@
 
 #else
 
-#include <logging/log.h>
-LOG_MODULE_REGISTER(net_big_http_download_sample, LOG_LEVEL_DBG);
-
 #include <net/socket.h>
 #include <kernel.h>
 

--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -17,9 +17,6 @@
 
 #else
 
-#include <logging/log.h>
-LOG_MODULE_REGISTER(net_dump_http_download_sample, LOG_LEVEL_DBG);
-
 #include <net/socket.h>
 #include <kernel.h>
 

--- a/samples/net/sockets/echo/src/socket_echo.c
+++ b/samples/net/sockets/echo/src/socket_echo.c
@@ -16,9 +16,6 @@
 
 #else
 
-#include <logging/log.h>
-LOG_MODULE_REGISTER(net_socket_echo_sample, LOG_LEVEL_DBG);
-
 #include <net/socket.h>
 #include <kernel.h>
 

--- a/samples/net/sockets/echo_async/src/socket_echo.c
+++ b/samples/net/sockets/echo_async/src/socket_echo.c
@@ -20,9 +20,6 @@
 
 #else
 
-#include <logging/log.h>
-LOG_MODULE_REGISTER(net_echo_async_sample, LOG_LEVEL_DBG);
-
 #include <fcntl.h>
 #include <net/socket.h>
 #include <kernel.h>

--- a/samples/net/sockets/http_get/src/http_get.c
+++ b/samples/net/sockets/http_get/src/http_get.c
@@ -16,8 +16,6 @@
 #include <netdb.h>
 
 #else
-#include <logging/log.h>
-LOG_MODULE_REGISTER(net_http_get_sample, LOG_LEVEL_DBG);
 
 #include <net/socket.h>
 #include <kernel.h>


### PR DESCRIPTION
As example of echo_async_select added recently shows, we no longer
need to define a logger unconditionally in each source file. These
samples are intended to show Zephyr compatibility with POSIX sockets
API, so the less there're differences between Zephyr vs POSIX
ifdefs, the better.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>