### PR TITLE
Revert "Implement net_context locking"

### DIFF
--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -204,10 +204,6 @@ struct net_context {
 	 */
 	atomic_t refcount;
 
-	/** Internal lock for protecting this context from multiple access.
-	 */
-	struct k_mutex lock;
-
 	/** Local IP address. Note that the values are in network byte order.
 	 */
 	struct sockaddr_ptr local;

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1989,21 +1989,17 @@ NET_CONN_CB(tcp_established)
 	u8_t tcp_flags;
 	u16_t data_len;
 
-	k_mutex_lock(&context->lock, K_FOREVER);
-
 	NET_ASSERT(context && context->tcp);
 
 	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
 	if (!tcp_hdr) {
-		ret = NET_DROP;
-		goto unlock;
+		return NET_DROP;
 	}
 
 	if (net_tcp_get_state(context->tcp) < NET_TCP_ESTABLISHED) {
 		NET_ERR("Context %p in wrong state %d",
 			context, net_tcp_get_state(context->tcp));
-		ret = NET_DROP;
-		goto unlock;
+		return NET_DROP;
 	}
 
 	net_tcp_print_recv_info("DATA", pkt, tcp_hdr->src_port);
@@ -2021,8 +2017,7 @@ NET_CONN_CB(tcp_established)
 		 */
 resend_ack:
 		send_ack(context, &conn->remote_addr, true);
-		ret = NET_DROP;
-		goto unlock;
+		return NET_DROP;
 	}
 
 	if (net_tcp_seq_cmp(sys_get_be32(tcp_hdr->seq),
@@ -2031,8 +2026,7 @@ resend_ack:
 		 * match the next segment exactly, drop and wait for
 		 * retransmit
 		 */
-		ret = NET_DROP;
-		goto unlock;
+		return NET_DROP;
 	}
 
 	/*
@@ -2043,8 +2037,7 @@ resend_ack:
 		/* We only accept RST packet that has valid seq field. */
 		if (!net_tcp_validate_seq(context->tcp, pkt)) {
 			net_stats_update_tcp_seg_rsterr(net_pkt_iface(pkt));
-			ret = NET_DROP;
-			goto unlock;
+			return NET_DROP;
 		}
 
 		net_stats_update_tcp_seg_rst(net_pkt_iface(pkt));
@@ -2058,8 +2051,7 @@ resend_ack:
 
 		net_context_unref(context);
 
-		ret = NET_DROP;
-		goto unlock;
+		return NET_DROP;
 	}
 
 	/* Handle TCP state transition */
@@ -2129,8 +2121,7 @@ resend_ack:
 		NET_ERR("Context %p: overflow of recv window (%d vs %d), "
 			"pkt dropped",
 			context, net_tcp_get_recv_wnd(context->tcp), data_len);
-		ret = NET_DROP;
-		goto unlock;
+		return NET_DROP;
 	}
 
 	/* If the pkt has appdata, notify the recv callback which should
@@ -2165,9 +2156,6 @@ clean_up:
 
 		net_context_unref(context);
 	}
-
-unlock:
-	k_mutex_unlock(&context->lock);
 
 	return ret;
 }

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -766,7 +766,7 @@ void timeout_thread(struct net_context *ctx, void *param2, void *param3)
 		return;
 	}
 
-	if (!recv_cb_timeout_called) {
+	if (recv_cb_timeout_called) {
 		DBG("Data received on time, recv test failed\n");
 		cb_failure = true;
 		return;


### PR DESCRIPTION
Reverts zephyrproject-rtos/zephyr#8674

This seems to break CI right now as there are failures in:

```
qemu_x86:
   tests/net/lib/dns_resolve/net.dns
   tests/net/lib/dns_resolve/net.dns.no_ipv6

...
===================================================================
starting test - dns_query_ipv6_numeric
PASS - dns_query_ipv6_numeric
===================================================================
Test suite dns_tests succeeded
===================================================================
PROJECT EXECUTION SUCCESSFUL
***** CPU Page Fault (error code 0x00000002)
Supervisor thread wrote address 0x00000000
PDE: 0x025 Present, Read-only, User, Execute Enabled
PTE: 0x00 Non-present, Read-only, Supervisor, Execute Enabled
Current thread ID = 0x00401740
eax: 0x004016f0, ebx: 0x004016f0, ecx: 0x00000000, edx: 0x00000000
esi: 0x00000246, edi: 0x00000000, ebp: 0x0041c7d4, esp: 0x0041c7d4
eflags: 0x00000046 cs: 0x0008
call trace:
eip: 0x0000ea43
     0x0000ed2a (0x41c7e0)
     0x00004b38 (0x30)
     0x0000bf09 (0x4160e4)
     0x00002d08 (0x0)
Fatal fault in ISR! Spinning...
Terminate emulator due to fatal kernel error
```