### PR TITLE
samples: sockets: Update echo_client/echo_server documentation

### DIFF
--- a/samples/net/sockets/echo_client/README.rst
+++ b/samples/net/sockets/echo_client/README.rst
@@ -10,9 +10,6 @@ The echo-client sample application for Zephyr implements a UDP/TCP client
 that will send IPv4 or IPv6 packets, wait for the data to be sent back,
 and then verify it matches the data that was sent.
 
-This sample is a port of the :ref:`echo-client-sample`. It has been rewritten
-to use socket API instead of native net-app API.
-
 The source code for this sample application can be found at:
 :file:`samples/net/sockets/echo_client`.
 
@@ -28,22 +25,52 @@ There are multiple ways to use this application. One of the most common
 usage scenario is to run echo-client application inside QEMU. This is
 described in :ref:`networking_with_qemu`.
 
+There are configuration files for different boards and setups in the
+echo-client directory:
+
+- :file:`prj.conf`
+  Generic config file, normally you should use this.
+
+- :file:`overlay-ot.conf`
+  This overlay config enables support for OpenThread.
+
+- :file:`overlay-802154.conf`
+  This overlay config enables support for native IEEE 802.15.4 connectivity.
+  Note, that by default IEEE 802.15.4 L2 uses unacknowledged communication. To
+  improve connection reliability, acknowledgments can be enabled with shell
+  command: ``ieee802154 ack set``.
+
+- :file:`overlay-bt.conf`
+  This overlay config enables support for Bluetooth IPSP connectivity.
+
+- :file:`overlay-qemu_802154.conf`
+  This overlay config enables support for two QEMU's when simulating
+  IEEE 802.15.4 network that are connected together.
+
+- :file:`overlay-tls.conf`
+  This overlay config enables support for TLS.
+
 Build echo-client sample application like this:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/net/sockets/echo_client
-   :board: <board_to_use>
+   :board: <board to use>
+   :conf: <config file to use>
    :goals: build
    :compact:
 
-``board_to_use`` defaults to ``qemu_x86``. In this case, you can run the
-application in QEMU using ``make run``. If you used another BOARD, you
-will need to consult its documentation for application deployment
-instructions. You can read about Zephyr support for specific boards in
-the documentation at :ref:`boards`.
+Example building for the nRF52840_pca10056 with OpenThread support:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/net/sockets/echo_client
+   :host-os: unix
+   :board: nrf52840_pca10056
+   :conf: "prj.conf overlay-ot.conf"
+   :goals: run
+   :compact:
 
 Enabling TLS support
-=================================
+====================
 
 Enable TLS support in the sample by building the project with the
 ``overlay-tls.conf`` overlay file enabled, for example, using these commands:
@@ -62,7 +89,6 @@ The certificate and private key used by the sample can be found in the sample's
 ``src`` directory. The default certificates used by Socket Echo Client and
 :ref:`sockets-echo-server-sample` enable establishing a secure connection
 between the samples.
-
 
 Running echo-server in Linux Host
 =================================

--- a/samples/net/sockets/echo_server/README.rst
+++ b/samples/net/sockets/echo_server/README.rst
@@ -11,9 +11,6 @@ that complements the echo-client sample application: the echo-server listens
 for incoming IPv4 or IPv6 packets (sent by the echo client) and simply sends
 them back.
 
-This sample is a port of the :ref:`echo-server-sample`. It has been rewritten
-to use socket API instead of native net-app API.
-
 The source code for this sample application can be found at:
 :file:`samples/net/sockets/echo_server`.
 
@@ -29,22 +26,52 @@ There are multiple ways to use this application. One of the most common
 usage scenario is to run echo-server application inside QEMU. This is
 described in :ref:`networking_with_qemu`.
 
+There are configuration files for different boards and setups in the
+echo-server directory:
+
+- :file:`prj.conf`
+  Generic config file, normally you should use this.
+
+- :file:`overlay-ot.conf`
+  This overlay config enables support for OpenThread.
+
+- :file:`overlay-802154.conf`
+  This overlay config enables support for native IEEE 802.15.4 connectivity.
+  Note, that by default IEEE 802.15.4 L2 uses unacknowledged communication. To
+  improve connection reliability, acknowledgments can be enabled with shell
+  command: ``ieee802154 ack set``.
+
+- :file:`overlay-bt.conf`
+  This overlay config enables support for Bluetooth IPSP connectivity.
+
+- :file:`overlay-qemu_802154.conf`
+  This overlay config enables support for two QEMU's when simulating
+  IEEE 802.15.4 network that are connected together.
+
+- :file:`overlay-tls.conf`
+  This overlay config enables support for TLS.
+
 Build echo-server sample application like this:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/net/sockets/echo_server
-   :board: <board_to_use>
+   :board: <board to use>
+   :conf: <config file to use>
    :goals: build
    :compact:
 
-``board_to_use`` defaults to ``qemu_x86``. In this case, you can run the
-application in QEMU using ``make run``. If you used another BOARD, you
-will need to consult its documentation for application deployment
-instructions. You can read about Zephyr support for specific boards in
-the documentation at :ref:`boards`.
+Example building for the nRF52840_pca10056 with OpenThread support:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/net/sockets/echo_server
+   :host-os: unix
+   :board: nrf52840_pca10056
+   :conf: "prj.conf overlay-ot.conf"
+   :goals: run
+   :compact:
 
 Enabling TLS support
-=================================
+====================
 
 Enable TLS support in the sample by building the project with the
 ``overlay-tls.conf`` overlay file enabled, for example, using these commands:


### PR DESCRIPTION
As the net-app based echo samples are being removed, there's no use referencing them any longer in their socket counterparts.

Additionally, overlay configuration descriptions were added in the same manner original samples did.

As the overlay configuration described in the documentation of the original samples is not present in their socket counterparts, I took the liberty of modifying the build example with nRF hardware and OpenThread overlay, as that's the configuration I was able to verify and I know it works well.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>