### PR TITLE
drivers: leuart_gecko: use DT_<COMPAT>_<INSTANCE>_<PROP> defines

### DIFF
--- a/boards/arm/efm32pg_stk3402a/Kconfig.defconfig
+++ b/boards/arm/efm32pg_stk3402a/Kconfig.defconfig
@@ -38,13 +38,6 @@ config GPIO_GECKO_PORTF
 
 endif # GPIO_GECKO
 
-if LEUART_GECKO
-
-config LEUART_GECKO_0
-	default y
-
-endif # LEUART_GECKO
-
 if I2C_GECKO
 
 config I2C_0

--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.dts
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.dts
@@ -62,7 +62,8 @@
 
 &leuart0 {
 	current-speed = <9600>;
-	location = <18>;
+	location-rx = <GECKO_LOCATION(18) GECKO_PORT_D GECKO_PIN(11)>;
+	location-tx = <GECKO_LOCATION(18) GECKO_PORT_D GECKO_PIN(10)>;
 	status = "ok";
 };
 

--- a/boards/arm/efr32mg_sltb004a/Kconfig.defconfig
+++ b/boards/arm/efr32mg_sltb004a/Kconfig.defconfig
@@ -29,13 +29,6 @@ config GPIO_GECKO_PORTF
 
 endif # GPIO_GECKO
 
-if LEUART_GECKO
-
-config LEUART_GECKO_0
-	default y
-
-endif # LEUART_GECKO
-
 if I2C_GECKO
 
 config I2C_0

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -61,7 +61,8 @@
 
 &leuart0 {
 	current-speed = <9600>;
-	location = <27>;
+	location-rx = <GECKO_LOCATION(27) GECKO_PORT_F GECKO_PIN(4)>;
+	location-tx = <GECKO_LOCATION(27) GECKO_PORT_F GECKO_PIN(3)>;
 	status = "ok";
 };
 

--- a/drivers/serial/Kconfig.leuart_gecko
+++ b/drivers/serial/Kconfig.leuart_gecko
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-menuconfig LEUART_GECKO
+config LEUART_GECKO
 	bool "Gecko leuart driver"
 	depends on HAS_SILABS_GECKO
 	depends on GPIO_GECKO
@@ -14,19 +14,3 @@ menuconfig LEUART_GECKO
 	select SOC_GECKO_LEUART
 	help
 	  Enable the Gecko leuart driver.
-
-if LEUART_GECKO
-
-config LEUART_GECKO_0
-	bool "Enable Gecko Low Energy UART 0"
-	help
-	  Enable support for Gecko LEUART0 port in the driver. Say y here if you
-	  want to use LEUART0 device.
-
-config LEUART_GECKO_1
-	bool "Enable Gecko Low Energy UART 1"
-	help
-	  Enable support for Gecko LEUART1 port in the driver. Say y here if you
-	  want to use LEUART1 device.
-
-endif # LEUART_GECKO

--- a/dts/arm/silabs/efm32hg.dtsi
+++ b/dts/arm/silabs/efm32hg.dtsi
@@ -53,6 +53,14 @@
 			label = "UART_1";
 		};
 
+		leuart0: leuart@40084000 { /* LEUART0 */
+			compatible = "silabs,gecko-leuart";
+			reg = <0x40084000 0x400>;
+			interrupts = <10 0>;
+			status = "disabled";
+			label = "LEUART_0";
+		};
+
 		gpio@40006100 {
 			compatible = "silabs,efm32-gpio";
 			reg = <0x40006100 0xf00>;

--- a/dts/arm/silabs/efm32pg12b.dtsi
+++ b/dts/arm/silabs/efm32pg12b.dtsi
@@ -26,7 +26,6 @@
 	};
 
 	aliases {
-		leuart-0 = &leuart0;
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
 	};

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -80,6 +80,22 @@
 			label = "UART_4";
 		};
 
+		leuart0: leuart@40084000 { /* LEUART0 */
+			compatible = "silabs,gecko-leuart";
+			reg = <0x40084000 0x400>;
+			interrupts = <24 0>;
+			status = "disabled";
+			label = "LEUART_0";
+		};
+
+		leuart1: leuart@40084400 { /* LEUART1 */
+			compatible = "silabs,gecko-leuart";
+			reg = <0x40084400 0x400>;
+			interrupts = <25 0>;
+			status = "disabled";
+			label = "LEUART_1";
+		};
+
 		gpio@40006100 {
 			compatible = "silabs,efm32-gpio";
 			reg = <0x40006100 0xf00>;

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -53,6 +53,14 @@
 			label = "USART_1";
 		};
 
+		leuart0: leuart@4004a000 { /* LEUART0 */
+			compatible = "silabs,gecko-leuart";
+			reg = <0x4004a000 0x400>;
+			interrupts = <21 0>;
+			status = "disabled";
+			label = "LEUART_0";
+		};
+
 		gpio: gpio@4000a400 {
 			compatible = "silabs,efr32xg1-gpio";
 			reg = <0x4000a400 0xc00>;

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -20,7 +20,6 @@
 	};
 
 	aliases {
-		leuart-0 = &leuart0;
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
 	};

--- a/dts/bindings/serial/silabs,gecko-leuart.yaml
+++ b/dts/bindings/serial/silabs,gecko-leuart.yaml
@@ -27,9 +27,18 @@ properties:
       description: required interrupts
       generation: define
 
-    location:
-      type: int
+    # Note: Not all SoC series support setting individual pin location. If this
+    # is a case all location-* properties need to have identical value.
+
+    location-rx:
+      type: array
       category: required
-      description: PIN location
+      description: RX pin configuration defined as <location port pin>
+      generation: define
+
+    location-tx:
+      type: array
+      category: required
+      description: TX pin configuration defined as <location port pin>
       generation: define
 ...

--- a/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
@@ -31,17 +31,6 @@
 #endif
 #endif /* CONFIG_GPIO_GECKO */
 
-#ifdef CONFIG_LEUART_GECKO
-#ifdef CONFIG_LEUART_GECKO_0
-#if (DT_SILABS_GECKO_LEUART_LEUART_0_LOCATION == 18)
-#define PIN_LEUART0_TXD {gpioPortD, 10, gpioModePushPull, 1}
-#define PIN_LEUART0_RXD {gpioPortD, 11, gpioModeInput, 1}
-#else
-#error ("Serial Driver for Gecko MCUs not implemented for this location index")
-#endif
-#endif /* CONFIG_LEUART_GECKO_0 */
-#endif /* CONFIG_LEUART_GECKO */
-
 #ifdef CONFIG_I2C_GECKO
 #ifdef CONFIG_I2C_0
 #if (DT_SILABS_GECKO_I2C_I2C_0_LOCATION == 15)

--- a/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
@@ -30,17 +30,6 @@
 #endif
 #endif /* CONFIG_GPIO_GECKO */
 
-#ifdef CONFIG_LEUART_GECKO
-#ifdef CONFIG_LEUART_GECKO_0
-#if (DT_SILABS_GECKO_LEUART_LEUART_0_LOCATION == 27)
-#define PIN_LEUART0_TXD {gpioPortF, 3, gpioModePushPull, 1}
-#define PIN_LEUART0_RXD {gpioPortF, 4, gpioModeInput, 1}
-#else
-#error ("Serial Driver for Gecko MCUs not implemented for this location index")
-#endif
-#endif /* CONFIG_LEUART_GECKO_0 */
-#endif /* CONFIG_LEUART_GECKO */
-
 #ifdef CONFIG_I2C_GECKO
 #ifdef CONFIG_I2C_0
 #if (DT_SILABS_GECKO_I2C_I2C_0_LOCATION == 15)


### PR DESCRIPTION
Use the new DT_<COMPAT>_<INSTANCE>_<PROP> defines to instantiate devices. This commit adds also ability to define individual pin locations on SoC series that support the feature. Definitions of GPIO pins assigned to a given location have been moved from soc_pinmap.h file to board DTS file.

Tested on efr32_slwstk6061a board.