### PR TITLE
usb: usb_dc: Replace CONFIG_ symbols that should be DT_

### DIFF
--- a/drivers/usb/device/usb_dc_sam.c
+++ b/drivers/usb/device/usb_dc_sam.c
@@ -294,7 +294,7 @@ int usb_dc_attach(void)
 	}
 #else
 	regval |= USBHS_DEVCTRL_SPDCONF_NORMAL;
-#endif /* CONFIG_USBHS_MAX_SPEED */
+#endif /* DT_USBHS_MAXIMUM_SPEED */
 	USBHS->USBHS_DEVCTRL = regval;
 
 	/* Enable the USB clock */

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -55,7 +55,7 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(usb_dc_stm32);
 
-#if defined(DT_USB_BASE_ADDRESS) && defined(CONFIG_USB_HS_BASE_ADDRES)
+#if defined(DT_USB_BASE_ADDRESS) && defined(DT_USB_HS_BASE_ADDRESS)
 #error "Only one interface should be enabled at a time, OTG FS or OTG HS"
 #endif
 
@@ -329,7 +329,7 @@ static u32_t usb_dc_stm32_get_maximum_speed(void)
 			"USB controller will default to its maximum HW "
 			"capability");
 	}
-#endif /* CONFIG_USB_MAX_SPEED */
+#endif /* DT_USB_MAXIMUM_SPEED */
 
 	return speed;
 }


### PR DESCRIPTION
1. Fix trailing comment for DT_USBHS_MAXIMUM_SPEED
2. Fix missed CONFIG_USB_HS_BASE_ADDRES that should be
   DT_USB_HS_BASE_ADDRESS

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>