### PR TITLE
Add support for ssd16xx monochrome EPD controllers

### DIFF
--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -123,6 +123,8 @@
 		reg = <0>;
 		width = <250>;
 		height = <120>;
+		pp-width-bits = <8>;
+		pp-height-bits = <8>;
 		reset-gpios = <&gpio0 15 0>;
 		dc-gpios = <&gpio0 16 0>;
 		busy-gpios = <&gpio0 14 0>;

--- a/drivers/display/ssd1673.c
+++ b/drivers/display/ssd1673.c
@@ -18,9 +18,9 @@ LOG_MODULE_REGISTER(ssd1673);
 #include "ssd1673_regs.h"
 #include <display/cfb.h>
 
-#define EPD_PANEL_WIDTH			250
-#define EPD_PANEL_HEIGHT		120
-#define EPD_PANEL_NUMOF_COLUMS		250
+#define EPD_PANEL_WIDTH			DT_SOLOMON_SSD1673FB_0_WIDTH
+#define EPD_PANEL_HEIGHT		DT_SOLOMON_SSD1673FB_0_HEIGHT
+#define EPD_PANEL_NUMOF_COLUMS		EPD_PANEL_WIDTH
 #define EPD_PANEL_NUMOF_ROWS_PER_PAGE	8
 #define EPD_PANEL_NUMOF_PAGES		(EPD_PANEL_HEIGHT / \
 					 EPD_PANEL_NUMOF_ROWS_PER_PAGE)
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(ssd1673);
 #define SSD1673_PANEL_FIRST_PAGE	0
 #define SSD1673_PANEL_LAST_PAGE		(EPD_PANEL_NUMOF_PAGES - 1)
 #define SSD1673_PANEL_FIRST_GATE	0
-#define SSD1673_PANEL_LAST_GATE		249
+#define SSD1673_PANEL_LAST_GATE		(EPD_PANEL_NUMOF_COLUMS - 1)
 
 #define SSD1673_PIXELS_PER_BYTE		8
 
@@ -360,7 +360,7 @@ static int ssd1673_set_pixel_format(const struct device *dev,
 static int ssd1673_clear_and_write_buffer(struct device *dev)
 {
 	int err;
-	u8_t clear_page[SSD1673_RAM_YRES];
+	u8_t clear_page[EPD_PANEL_WIDTH];
 	u8_t page;
 	struct spi_buf sbuf;
 	struct spi_buf_set buf_set = {.buffers = &sbuf, .count = 1};
@@ -432,7 +432,7 @@ static int ssd1673_controller_init(struct device *dev)
 	}
 	ssd1673_busy_wait(driver);
 
-	tmp[0] = (SSD1673_RAM_YRES - 1);
+	tmp[0] = SSD1673_PANEL_LAST_GATE;
 	tmp[1] = 0U;
 	err = ssd1673_write_cmd(driver, SSD1673_CMD_GDO_CTRL, tmp, 2);
 	if (err < 0) {

--- a/drivers/display/ssd1673_regs.h
+++ b/drivers/display/ssd1673_regs.h
@@ -73,16 +73,11 @@
 #define SSD1673_VAL_DUMMY_LINE			0x1a
 #define SSD1673_VAL_GATE_LWIDTH			0x08
 
-/** Maximum resolution in the X direction */
-#define SSD1673_RAM_XRES			152
 /** Maximum resolution in the Y direction */
 #define SSD1673_RAM_YRES			250
 
 /* time constants in ms */
 #define SSD1673_RESET_DELAY			1
 #define SSD1673_BUSY_DELAY			1
-
-/** Size of each RAM in octets */
-#define SSD1673_RAM_SIZE	(SSD1673_RAM_XRES * SSD1673_RAM_YRES / 8)
 
 #endif /* __SSD1673_REGS_H__ */

--- a/drivers/display/ssd1673_regs.h
+++ b/drivers/display/ssd1673_regs.h
@@ -73,9 +73,6 @@
 #define SSD1673_VAL_DUMMY_LINE			0x1a
 #define SSD1673_VAL_GATE_LWIDTH			0x08
 
-/** Maximum resolution in the Y direction */
-#define SSD1673_RAM_YRES			250
-
 /* time constants in ms */
 #define SSD1673_RESET_DELAY			1
 #define SSD1673_BUSY_DELAY			1

--- a/dts/bindings/display/solomon,ssd1673fb.yaml
+++ b/dts/bindings/display/solomon,ssd1673fb.yaml
@@ -29,6 +29,18 @@ properties:
       description: Width in pixel of the panel driven by the controller
       generation: define
 
+    pp-height-bits:
+      type: int
+      category: required
+      description: Number of bits used for the height parameters
+      generation: define
+
+    pp-width-bits:
+      type: int
+      category: required
+      description: Number of bits used for the width parameters
+      generation: define
+
     orientation-flipped:
       type: boolean
       category: optional


### PR DESCRIPTION
This PR updates the existing ssd1673 driver to add support for more EPD controllers. It has been tested with a Waveshare 1.54inch e-Paper Module using a ssd1607 controller. Note however that I used an additional patch to update the LUTs, as this EPD use different ones. I still have to find a way to provide an easy way to use different LUTs for different EPD.

I believe this driver can be extended to provide support for all the ssd16xx family, including the 3- or 4- colors ones. It therefore might make sense to rename this driver.