### PR TITLE
net: openthread: move the flash area to the storage partition

### DIFF
--- a/subsys/net/lib/openthread/platform/flash.c
+++ b/subsys/net/lib/openthread/platform/flash.c
@@ -22,7 +22,7 @@ otError utilsFlashInit(void)
 {
 	int i;
 	struct flash_pages_info info;
-	size_t pages_count;
+	u32_t ot_flash_index;
 
 	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
 
@@ -30,24 +30,26 @@ otError utilsFlashInit(void)
 		return OT_ERROR_NOT_IMPLEMENTED;
 	}
 
-	pages_count = flash_get_page_count(flash_dev);
-
-	if (flash_get_page_info_by_idx(flash_dev,
-		pages_count - CONFIG_OT_PLAT_FLASH_PAGES_COUNT - 1, &info)) {
-
+	if (flash_get_page_info_by_offs(flash_dev, FLASH_AREA_STORAGE_OFFSET,
+					&info)) {
 		return OT_ERROR_FAILED;
 	}
 
+	ot_flash_index = info.index;
 	ot_flash_offset = info.start_offset;
 	ot_flash_size = 0;
 
 	for (i = 0; i < CONFIG_OT_PLAT_FLASH_PAGES_COUNT; i++) {
 		if (flash_get_page_info_by_idx(flash_dev,
-			pages_count - i - 1, &info)) {
+			ot_flash_index + i, &info)) {
 
 			return OT_ERROR_FAILED;
 		}
 		ot_flash_size += info.size;
+	}
+
+	if (ot_flash_size > FLASH_AREA_STORAGE_SIZE) {
+		return OT_ERROR_FAILED;
 	}
 
 	return OT_ERROR_NONE;


### PR DESCRIPTION
OpenThread currently uses the 4 last pages of the flash memory to store
its data. This does not work correctly when a bootloader is used (either
MCUboot or nRF5 bootloader) as this area is used for other purpose.

This patch therefore move the OpenThread flash area to the storage area.
In the long term it should be better to use the settings subsystem
instead of the OpenThread flash platform system, but that is a more
complicated change.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>