### PR TITLE
boards: cc3220sf_launchxl: Provide dts aliases for leds 1 and 2

### DIFF
--- a/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
+++ b/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
@@ -11,6 +11,8 @@
 		uart-1 = &uart1;
 		i2c-0 = &i2c0;
 		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
 		/* sw0/1 alias defined for compatibility with samples */
 		sw0 = &sw2;
 		sw1 = &sw3;


### PR DESCRIPTION
Previously, only led0 was enabled.

This allows the samples/basic/disco sample to build/run for
this board.

Signed-off-by: Gil Pitney <gil.pitney@linaro.org>