### PR TITLE
ARM ASM push / pop rework

### DIFF
--- a/arch/arm/core/cpu_idle.S
+++ b/arch/arm/core/cpu_idle.S
@@ -114,11 +114,15 @@ SECTION_FUNC(TEXT, _NanoIdleValClear)
 
 SECTION_FUNC(TEXT, k_cpu_idle)
 #ifdef CONFIG_TRACING
-	push {lr}
+	push {r0, lr}
 	bl    z_sys_trace_idle
-	pop {r0}
-	mov lr, r0
-#endif
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+	pop {r0, r1}
+        mov lr, r1
+#else
+	pop {r0, lr}
+#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
+#endif /* CONFIG_TRACING */
 
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 	cpsie i
@@ -158,11 +162,15 @@ SECTION_FUNC(TEXT, k_cpu_idle)
 
 SECTION_FUNC(TEXT, k_cpu_atomic_idle)
 #ifdef CONFIG_TRACING
-	push {lr}
+	push {r0, lr}
 	bl    z_sys_trace_idle
-	pop {r1}
-	mov lr, r1
-#endif
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+        pop {r0, r1}
+        mov lr, r1
+#else
+	pop {r0, lr}
+#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
+#endif /* CONFIG_TRACING */
 
 	/*
 	 * Lock PRIMASK while sleeping: wfe will still get interrupted by

--- a/arch/arm/core/exc_exit.S
+++ b/arch/arm/core/exc_exit.S
@@ -87,14 +87,13 @@ _EXIT_EXC:
 #endif /* CONFIG_PREEMPT_ENABLED */
 
 #ifdef CONFIG_STACK_SENTINEL
-    push {lr}
+    push {r0, lr}
     bl _check_stack_sentinel
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-    pop {r0}
-    mov lr, r0
+    pop {r0, r1}
+    mov lr, r1
 #else
-    pop {lr}
+    pop {r0, lr}
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 #endif /* CONFIG_STACK_SENTINEL */
-
     bx lr

--- a/arch/arm/core/fault_s.S
+++ b/arch/arm/core/fault_s.S
@@ -139,9 +139,9 @@ _s_stack_frame_endif:
 	 */
 	mov r1, lr
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
-	push {lr}
+	push {r0, lr}
 	bl _Fault
 
-	pop {pc}
+	pop {r0, pc}
 
 	.end

--- a/arch/arm/core/isr_wrapper.S
+++ b/arch/arm/core/isr_wrapper.S
@@ -41,7 +41,7 @@ GTEXT(_IntExit)
  */
 SECTION_FUNC(TEXT, _isr_wrapper)
 
-	push {lr}		/* lr is now the first item on the stack */
+	push {r0,lr}		/* r0, lr are now the first items on the stack */
 
 #ifdef CONFIG_EXECUTION_BENCHMARKING
 	bl read_timer_start_of_isr
@@ -106,17 +106,17 @@ _idle_state_cleared:
 
 	ldm r1!,{r0,r3}	/* arg in r0, ISR in r3 */
 #ifdef CONFIG_EXECUTION_BENCHMARKING
-	stm sp!,{r0-r3} /* Save r0 to r4 into stack */
-	push {lr}
+	stm sp!,{r0-r3} /* Save r0 to r3 into stack */
+	push {r0, lr}
 	bl read_timer_end_of_isr
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-	pop {r3}
+	pop {r0, r3}
 	mov lr,r3
 #else
-	pop {lr}
+	pop {r0, lr}
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
-	ldm sp!,{r0-r3} /* Restore r0 to r4 regs */
-#endif
+	ldm sp!,{r0-r3} /* Restore r0 to r3 regs */
+#endif /* CONFIG_EXECUTION_BENCHMARKING */
 	blx r3		/* call ISR */
 
 #ifdef CONFIG_TRACING
@@ -124,10 +124,10 @@ _idle_state_cleared:
 #endif
 
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-	pop {r3}
+	pop {r0, r3}
 	mov lr, r3
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	pop {lr}
+	pop {r0, lr}
 #else
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -45,14 +45,14 @@ SECTION_FUNC(TEXT, __pendsv)
 
 #ifdef CONFIG_TRACING
     /* Register the context switch */
-    push {lr}
+    push {r0, lr}
     bl z_sys_trace_thread_switched_out
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-    pop {r0}
-    mov lr, r0
+    pop {r0, r1}
+    mov lr, r1
 #else
-    pop {lr}
-#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
+    pop {r0, lr}
+#endif /* CONFIG_ARMV6_M_ARMV8M_M_BASELINE */
 #endif /* CONFIG_TRACING */
 
     /* protect the kernel state while we play with the thread lists */
@@ -242,29 +242,29 @@ _thread_irq_disabled:
 #endif /* CONFIG_BUILTIN_STACK_GUARD */
 
 #ifdef CONFIG_EXECUTION_BENCHMARKING
-    stm sp!,{r0-r3} /* Save regs r0 to r4 on stack */
-    push {lr}
+    stm sp!,{r0-r3} /* Save regs r0 to r3 on stack */
+    push {r0, lr}
     bl read_timer_end_of_swap
-
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-    pop {r3}
-    mov lr,r3
+    pop {r0, r1}
+    mov lr,r1
 #else
-    pop {lr}
+    pop {r0, lr}
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
-    ldm sp!,{r0-r3} /* Load back regs ro to r4 */
+    ldm sp!,{r0-r3} /* Load back regs r0 to r3 */
+
 #endif /* CONFIG_EXECUTION_BENCHMARKING */
 
 #ifdef CONFIG_TRACING
     /* Register the context switch */
-    push {lr}
+    push {r0, lr}
     bl z_sys_trace_thread_switched_in
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-    pop {r0}
-    mov lr, r0
+    pop {r0, r1}
+    mov lr, r1
 #else
-    pop {lr}
-#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
+    pop {r0, lr}
+#endif
 #endif /* CONFIG_TRACING */
 
     /* exc return */
@@ -303,19 +303,19 @@ _stack_frame_endif:
     beq _oops
 
 #if CONFIG_IRQ_OFFLOAD
-    push {lr}
+    push {r0, lr}
     blx _irq_do_offload  /* call C routine which executes the offload */
-    pop {r3}
-    mov lr, r3
-#endif
+    pop {r0, r1}
+    mov lr, r1
+#endif /* CONFIG_IRQ_OFFLOAD */
 
     /* exception return is done in _IntExit() */
     b _IntExit
 
 _oops:
-    push {lr}
+    push {r0, lr}
     blx _do_kernel_oops
-    pop {pc}
+    pop {r0, pc}
 
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 /**
@@ -367,18 +367,18 @@ SECTION_FUNC(TEXT, __svc)
     beq _oops
 
 #if CONFIG_IRQ_OFFLOAD
-    push {lr}
+    push {r0, lr}
     blx _irq_do_offload  /* call C routine which executes the offload */
-    pop {lr}
+    pop {r0, lr}
 
     /* exception return is done in _IntExit() */
     b _IntExit
 #endif
 
 _oops:
-    push {lr}
+    push {r0, lr}
     blx _do_kernel_oops
-    pop {pc}
+    pop {r0, pc}
 
 #if CONFIG_USERSPACE
     /*

--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -128,10 +128,16 @@ SECTION_FUNC(TEXT,_arm_userspace_enter)
 
 #ifdef CONFIG_EXECUTION_BENCHMARKING
     stm sp!,{r0-r3} /* Save regs r0 to r4 on stack */
-    push {lr}
+    push {r0, lr}
     bl read_timer_end_of_userspace_enter
-    pop {lr}
-    ldm sp!,{r0-r3} /* Load back regs ro to r4 */
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+    pop {r0, r3}
+    mov lr,r3
+#else
+    pop {r0, lr}
+#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
+    ldm sp!,{r0-r3} /* Restore r0 to r3 regs */
+
 #endif /* CONFIG_EXECUTION_BENCHMARKING */
 
     /* change processor mode to unprivileged */

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -111,7 +111,7 @@ _arch_switch_to_main_thread(struct k_thread *main_thread,
 		  "r"(_main), "r"(_thread_entry),
 		  "r"(main_thread)
 
-		: "r0", "r1", "sp"
+		: "r0", "r1", "r3", "sp"
 	);
 
 	CODE_UNREACHABLE;


### PR DESCRIPTION
This change takes all of the ASM function calls and makes sure that we are pushing 8 byte aligned amounts onto the stack before making function calls.  The slight complication on this was v6m thumb issues with not being able to pop LR.