### PR TITLE
samples: mesh: taking care of interrupted transition [1.14 milestone]

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/common.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/common.h
@@ -8,6 +8,7 @@
 #ifndef _COMMON_H
 #define _COMMON_H
 
+void update_led_gpio(void);
 void update_light_state(void);
 
 #endif

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -105,9 +105,12 @@ static void light_default_status_init(void)
 	}
 
 	default_tt = gen_def_trans_time_srv_user_data.tt;
+
+	target_lightness = lightness;
+	target_temperature = temperature;
 }
 
-void update_light_state(void)
+void update_led_gpio(void)
 {
 	u8_t power, color;
 
@@ -139,6 +142,11 @@ void update_light_state(void)
 		/* LED4 Off */
 		gpio_pin_write(led_device[3], LED3_GPIO_PIN, 1);
 	}
+}
+
+void update_light_state(void)
+{
+	update_led_gpio();
 
 	if (*ptr_counter == 0 || reset == false) {
 		reset = true;

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.h
@@ -27,6 +27,8 @@ enum state_binding {
 extern u16_t lightness, target_lightness;
 extern s16_t temperature, target_temperature;
 
+void readjust_lightness(void);
+void readjust_temperature(void);
 void state_binding(u8_t lightness, u8_t temperature);
 void calculate_lightness_target_values(u8_t type);
 void calculate_temp_target_values(u8_t type);


### PR DESCRIPTION
With this commit, it is now possible that if (for e.g.) lightness
transition is interrupted by temperature transition (which could
be instantaneous or non-instanstaneous) then as soon as temperature
transition get over, then algorithm would achieve target value
of lightness.

Signed-off-by: Vikrant More <vikrant8051@gmail.com>