### PR TITLE
power: Make power_state enum global

### DIFF
--- a/include/power.h
+++ b/include/power.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_POWER_H_
 #define ZEPHYR_INCLUDE_POWER_H_
 
+#include <zephyr/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -28,6 +30,36 @@ extern unsigned char sys_pm_idle_exit_notify;
  * @{
  * @}
  */
+
+/**
+ * @brief Power Management states.
+ */
+enum power_states {
+#ifdef CONFIG_SYS_POWER_LOW_POWER_STATE
+# ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_SUPPORTED
+	SYS_POWER_STATE_CPU_LPS,
+# endif
+# ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_1_SUPPORTED
+	SYS_POWER_STATE_CPU_LPS_1,
+# endif
+# ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_2_SUPPORTED
+	SYS_POWER_STATE_CPU_LPS_2,
+# endif
+#endif /* CONFIG_SYS_POWER_LOW_POWER_STATE */
+
+#ifdef CONFIG_SYS_POWER_DEEP_SLEEP
+# ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_SUPPORTED
+	SYS_POWER_STATE_DEEP_SLEEP,
+# endif
+# ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_1_SUPPORTED
+	SYS_POWER_STATE_DEEP_SLEEP_1,
+# endif
+# ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_2_SUPPORTED
+	SYS_POWER_STATE_DEEP_SLEEP_2,
+# endif
+#endif /* CONFIG_SYS_POWER_DEEP_SLEEP */
+	SYS_POWER_STATE_MAX
+};
 
 /**
  * @brief Power Management Hooks

--- a/soc/arc/quark_se_c1000_ss/CMakeLists.txt
+++ b/soc/arc/quark_se_c1000_ss/CMakeLists.txt
@@ -12,6 +12,9 @@ zephyr_compile_definitions_ifdef(
 zephyr_sources(
   soc.c
   soc_config.c
+  )
+
+zephyr_sources_ifdef(CONFIG_SYS_POWER_MANAGEMENT
   power.c
   soc_power.S
   )

--- a/soc/arc/quark_se_c1000_ss/soc_power.h
+++ b/soc/arc/quark_se_c1000_ss/soc_power.h
@@ -7,6 +7,8 @@
 #ifndef _SOC_POWER_H_
 #define _SOC_POWER_H_
 
+#include <power.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,16 +21,14 @@ extern "C" {
  */
 #define GP0_BIT_SLEEP_READY BIT(0)
 
-enum power_states {
-	SYS_POWER_STATE_CPU_LPS,       /* SS1 state with Timer ON */
-	SYS_POWER_STATE_CPU_LPS_1,     /* SS2 state */
-	SYS_POWER_STATE_CPU_LPS_2,     /* Not supported*/
-	SYS_POWER_STATE_DEEP_SLEEP,    /* SS2 with LPSS enabled state */
-	SYS_POWER_STATE_DEEP_SLEEP_1,  /* SLEEP state */
-	SYS_POWER_STATE_DEEP_SLEEP_2,  /* SLEEP state with LPMODE enabled */
-
-	SYS_POWER_STATE_MAX
-};
+/*
+ * Power state map:
+ * SYS_POWER_STATE_CPU_LPS:		SS1 state with Timer ON
+ * SYS_POWER_STATE_CPU_LPS_1:		SS1 state with Timer ON
+ * SYS_POWER_STATE_DEEP_SLEEP:		SS2 with LPSS enabled state
+ * SYS_POWER_STATE_DEEP_SLEEP_1:	SLEEP state
+ * SYS_POWER_STATE_DEEP_SLEEP_2:	SLEEP state with LPMODE enabled
+ */
 
 /**
  * @brief Put processor into low power state

--- a/soc/arm/nordic_nrf/nrf51/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf51/CMakeLists.txt
@@ -1,4 +1,7 @@
 zephyr_sources(
-  power.c
   soc.c
+  )
+
+zephyr_sources_ifdef(CONFIG_SYS_POWER_MANAGEMENT
+  power.c
   )

--- a/soc/arm/nordic_nrf/nrf51/power.c
+++ b/soc/arm/nordic_nrf/nrf51/power.c
@@ -89,11 +89,3 @@ bool sys_is_valid_power_state(enum power_states state)
 
 	/* Not reached */
 }
-
-/* Overrides the weak ARM implementation:
-   Set general purpose retention register and reboot */
-void sys_arch_reboot(int type)
-{
-	nrf_power_gpregret_set((uint8_t)type);
-	NVIC_SystemReset();
-}

--- a/soc/arm/nordic_nrf/nrf51/soc.c
+++ b/soc/arm/nordic_nrf/nrf51/soc.c
@@ -16,6 +16,7 @@
 #include <kernel.h>
 #include <init.h>
 #include <nrfx.h>
+#include <nrf_power.h>
 #include <soc/nrfx_coredep.h>
 #include <logging/log.h>
 
@@ -29,6 +30,14 @@ extern void _NmiInit(void);
 #include <system_nrf51.h>
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);
+
+/* Overrides the weak ARM implementation:
+   Set general purpose retention register and reboot */
+void sys_arch_reboot(int type)
+{
+	nrf_power_gpregret_set((uint8_t)type);
+	NVIC_SystemReset();
+}
 
 static int nordicsemi_nrf51_init(struct device *arg)
 {

--- a/soc/arm/nordic_nrf/nrf51/soc_power.h
+++ b/soc/arm/nordic_nrf/nrf51/soc_power.h
@@ -8,37 +8,16 @@
 #define _SOC_POWER_H_
 
 #include <stdbool.h>
+#include <power.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-enum power_states {
-#ifdef CONFIG_SYS_POWER_LOW_POWER_STATE
-# ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_SUPPORTED
-	SYS_POWER_STATE_CPU_LPS,	/* Not used */
-# endif
-# ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_1_SUPPORTED
-	SYS_POWER_STATE_CPU_LPS_1,	/* Not used */
-# endif
-# ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_2_SUPPORTED
-	SYS_POWER_STATE_CPU_LPS_2,	/* Not used */
-# endif
-#endif /* CONFIG_SYS_POWER_LOW_POWER_STATE */
-
-#ifdef CONFIG_SYS_POWER_DEEP_SLEEP
-# ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_SUPPORTED
-	SYS_POWER_STATE_DEEP_SLEEP,	/* System OFF */
-# endif
-# ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_1_SUPPORTED
-	SYS_POWER_STATE_DEEP_SLEEP_1,	/* Not used */
-# endif
-# ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_2_SUPPORTED
-	SYS_POWER_STATE_DEEP_SLEEP_2,	/* Not used */
-# endif
-#endif /* CONFIG_SYS_POWER_DEEP_SLEEP */
-	SYS_POWER_STATE_MAX		/* Do nothing */
-};
+/*
+ * Power state map:
+ * SYS_POWER_STATE_DEEP_SLEEP: System OFF
+ */
 
 /**
  * @brief Put processor into low power state

--- a/soc/arm/nordic_nrf/nrf52/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf52/CMakeLists.txt
@@ -1,6 +1,11 @@
 zephyr_sources(
-  power.c
   soc.c
   )
 
-zephyr_sources_ifdef(CONFIG_ARM_MPU mpu_regions.c)
+zephyr_sources_ifdef(CONFIG_SYS_POWER_MANAGEMENT
+  power.c
+  )
+
+zephyr_sources_ifdef(CONFIG_ARM_MPU
+  mpu_regions.c
+  )

--- a/soc/arm/nordic_nrf/nrf52/power.c
+++ b/soc/arm/nordic_nrf/nrf52/power.c
@@ -89,11 +89,3 @@ bool sys_is_valid_power_state(enum power_states state)
 
 	/* Not reached */
 }
-
-/* Overrides the weak ARM implementation:
-   Set general purpose retention register and reboot */
-void sys_arch_reboot(int type)
-{
-	nrf_power_gpregret_set((uint8_t)type);
-	NVIC_SystemReset();
-}

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -16,6 +16,7 @@
 #include <init.h>
 #include <cortex_m/exc.h>
 #include <nrfx.h>
+#include <nrf_power.h>
 #include <soc/nrfx_coredep.h>
 #include <logging/log.h>
 
@@ -40,6 +41,14 @@ extern void _NmiInit(void);
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);
+
+/* Overrides the weak ARM implementation:
+   Set general purpose retention register and reboot */
+void sys_arch_reboot(int type)
+{
+	nrf_power_gpregret_set((uint8_t)type);
+	NVIC_SystemReset();
+}
 
 static int nordicsemi_nrf52_init(struct device *arg)
 {

--- a/soc/arm/nordic_nrf/nrf52/soc_power.h
+++ b/soc/arm/nordic_nrf/nrf52/soc_power.h
@@ -8,37 +8,16 @@
 #define _SOC_POWER_H_
 
 #include <stdbool.h>
+#include <power.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-enum power_states {
-#ifdef CONFIG_SYS_POWER_LOW_POWER_STATE
-# ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_SUPPORTED
-	SYS_POWER_STATE_CPU_LPS,	/* Not used */
-# endif
-# ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_1_SUPPORTED
-	SYS_POWER_STATE_CPU_LPS_1,	/* Not used */
-# endif
-# ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_2_SUPPORTED
-	SYS_POWER_STATE_CPU_LPS_2,	/* Not used */
-# endif
-#endif /* CONFIG_SYS_POWER_LOW_POWER_STATE */
-
-#ifdef CONFIG_SYS_POWER_DEEP_SLEEP
-# ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_SUPPORTED
-	SYS_POWER_STATE_DEEP_SLEEP,	/* System OFF */
-# endif
-# ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_1_SUPPORTED
-	SYS_POWER_STATE_DEEP_SLEEP_1,	/* Not used */
-# endif
-# ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_2_SUPPORTED
-	SYS_POWER_STATE_DEEP_SLEEP_2,	/* Not used */
-# endif
-#endif /* CONFIG_SYS_POWER_DEEP_SLEEP */
-	SYS_POWER_STATE_MAX		/* Do nothing */
-};
+/*
+ * Power state map:
+ * SYS_POWER_STATE_DEEP_SLEEP: System OFF
+ */
 
 /**
  * @brief Put processor into low power state

--- a/soc/x86/intel_quark/quark_se/CMakeLists.txt
+++ b/soc/x86/intel_quark/quark_se/CMakeLists.txt
@@ -12,6 +12,9 @@ zephyr_sources(
   soc.c
   soc_config.c
   eoi.c
+  )
+
+zephyr_sources_ifdef(CONFIG_SYS_POWER_MANAGEMENT
   power.c
   soc_power.S
   )

--- a/soc/x86/intel_quark/quark_se/soc_power.h
+++ b/soc/x86/intel_quark/quark_se/soc_power.h
@@ -7,6 +7,8 @@
 #ifndef _SOC_POWER_H_
 #define _SOC_POWER_H_
 
+#include <power.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,16 +21,14 @@ extern "C" {
  */
 #define GP0_BIT_SLEEP_READY BIT(0)
 
-enum power_states {
-	SYS_POWER_STATE_CPU_LPS,       /* C1 state */
-	SYS_POWER_STATE_CPU_LPS_1,     /* C2 state */
-	SYS_POWER_STATE_CPU_LPS_2,     /* C2LP state */
-	SYS_POWER_STATE_DEEP_SLEEP,    /* SLEEP state */
-	SYS_POWER_STATE_DEEP_SLEEP_1,  /* SLEEP state with LPMODE enabled */
-	SYS_POWER_STATE_DEEP_SLEEP_2,  /* Not Supported */
-
-	SYS_POWER_STATE_MAX
-};
+/*
+ * Power state map:
+ * SYS_POWER_STATE_CPU_LPS:		C1 state
+ * SYS_POWER_STATE_CPU_LPS_1:		C2 state
+ * SYS_POWER_STATE_CPU_LPS_2:		C2LP state
+ * SYS_POWER_STATE_DEEP_SLEEP:		SLEEP state
+ * SYS_POWER_STATE_DEEP_SLEEP_1:	SLEEP state with LPMODE enabled
+ */
 
 /**
  * @brief Put processor into low power state


### PR DESCRIPTION
Currently each SoC has to define own list of power states.
However all these definitions have to be the same, as common power
management code uses them.

This commit replaces per-soc power state list by global definition.
