### PR TITLE
arch: xtensa: dts: Move HAS_DTS to arch level

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -47,6 +47,7 @@ config RISCV32
 
 config XTENSA
 	bool "Xtensa architecture"
+	select HAS_DTS
 
 config ARCH_POSIX
 	bool "POSIX (native) architecture"

--- a/boards/xtensa/esp32/Kconfig.board
+++ b/boards/xtensa/esp32/Kconfig.board
@@ -6,4 +6,3 @@
 config BOARD_ESP32
 	bool "ESP32 Development Board"
 	depends on SOC_ESP32
-	select HAS_DTS

--- a/boards/xtensa/intel_s1000_crb/Kconfig.board
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.board
@@ -6,4 +6,3 @@
 config  BOARD_INTEL_S1000_CRB
 	bool "Xtensa on Intel_S1000"
 	depends on SOC_INTEL_S1000
-	select HAS_DTS

--- a/boards/xtensa/qemu_xtensa/Kconfig.board
+++ b/boards/xtensa/qemu_xtensa/Kconfig.board
@@ -6,5 +6,4 @@
 config  BOARD_QEMU_XTENSA
 	bool "Xtensa emulation using QEMU"
 	depends on SOC_XTENSA_SAMPLE_CONTROLLER
-	select HAS_DTS
 	select QEMU_TARGET

--- a/boards/xtensa/xt-sim/Kconfig.board
+++ b/boards/xtensa/xt-sim/Kconfig.board
@@ -6,4 +6,3 @@
 config BOARD_XT_SIM
 	bool "Xtensa Development ISS"
 	depends on SIMULATOR_XTENSA
-	select HAS_DTS


### PR DESCRIPTION
Now that all supported xtensa boards use DTS we can move the Kconfig
setting to the arch level.  Remove HAS_DTS from board Kconfig files.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>