### PR TITLE
soc: riscv32: openisa_rv32m1: Remove duplicated HAS_DTS

### DIFF
--- a/soc/riscv32/openisa_rv32m1/Kconfig.soc
+++ b/soc/riscv32/openisa_rv32m1/Kconfig.soc
@@ -11,7 +11,6 @@ config SOC_OPENISA_RV32M1_RISCV32
 	# The following select is also due to limitations in the linker script.
 	# (We can't make it a 'depends on' without causing a dependency loop).
 	select XIP
-	select HAS_DTS
 	select HAS_RV32M1_LPUART
 	select ATOMIC_OPERATIONS_C
 	select VEGA_SDK_HAL


### PR DESCRIPTION
HAS_DTS is selected at the arch level so we don't need to duplicate the
select in the SoC Kconfig.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>