### PR TITLE
drivers: i2c_gecko: use DT_<COMPAT>_<INSTANCE>_<PROP> defines

### DIFF
--- a/boards/arm/efm32pg_stk3402a/Kconfig.defconfig
+++ b/boards/arm/efm32pg_stk3402a/Kconfig.defconfig
@@ -38,11 +38,4 @@ config GPIO_GECKO_PORTF
 
 endif # GPIO_GECKO
 
-if I2C_GECKO
-
-config I2C_0
-	default y
-
-endif # I2C_GECKO
-
 endif # BOARD_EFM32PG_STK3402A

--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.dts
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.dts
@@ -68,7 +68,8 @@
 };
 
 &i2c0 {
-	location = <15>;
+	location-sda = <GECKO_LOCATION(15) GECKO_PORT_C GECKO_PIN(10)>;
+	location-scl = <GECKO_LOCATION(15) GECKO_PORT_C GECKO_PIN(11)>;
 	status = "ok";
 };
 

--- a/boards/arm/efr32mg_sltb004a/Kconfig.defconfig
+++ b/boards/arm/efr32mg_sltb004a/Kconfig.defconfig
@@ -29,14 +29,4 @@ config GPIO_GECKO_PORTF
 
 endif # GPIO_GECKO
 
-if I2C_GECKO
-
-config I2C_0
-	default y
-
-config I2C_1
-	default y
-
-endif # I2C_GECKO
-
 endif # BOARD_EFR32MG_SLTB004A

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -67,12 +67,14 @@
 };
 
 &i2c0 {
-	location = <15>;
+	location-sda = <GECKO_LOCATION(15) GECKO_PORT_C GECKO_PIN(10)>;
+	location-scl = <GECKO_LOCATION(15) GECKO_PORT_C GECKO_PIN(11)>;
 	status = "ok";
 };
 
 &i2c1 {
-	location = <17>;
+	location-sda = <GECKO_LOCATION(17) GECKO_PORT_C GECKO_PIN(4)>;
+	location-scl = <GECKO_LOCATION(17) GECKO_PORT_C GECKO_PIN(5)>;
 	status = "ok";
 };
 

--- a/dts/arm/silabs/efm32hg.dtsi
+++ b/dts/arm/silabs/efm32hg.dtsi
@@ -1,5 +1,6 @@
 #include <arm/armv6-m.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
 
 / {
@@ -59,6 +60,17 @@
 			interrupts = <10 0>;
 			status = "disabled";
 			label = "LEUART_0";
+		};
+
+		i2c0: i2c@4000a000 {
+			compatible = "silabs,gecko-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x4000a000 0x400>;
+			interrupts = <5 0>;
+			label = "I2C_0";
+			status = "disabled";
 		};
 
 		gpio@40006100 {

--- a/dts/arm/silabs/efm32pg12b.dtsi
+++ b/dts/arm/silabs/efm32pg12b.dtsi
@@ -25,11 +25,6 @@
 	       compatible = "mmio-sram";
 	};
 
-	aliases {
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-	};
-
 	soc {
 		flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -1,5 +1,6 @@
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
 
 / {
@@ -94,6 +95,28 @@
 			interrupts = <25 0>;
 			status = "disabled";
 			label = "LEUART_1";
+		};
+
+		i2c0: i2c@4000a000 {
+			compatible = "silabs,gecko-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x4000a000 0x400>;
+			interrupts = <9 0>;
+			label = "I2C_0";
+			status = "disabled";
+		};
+
+		i2c1: i2c@4000a400 {
+			compatible = "silabs,gecko-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x4000a400 0x400>;
+			interrupts = <10 0>;
+			label = "I2C_1";
+			status = "disabled";
 		};
 
 		gpio@40006100 {

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -1,5 +1,6 @@
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
 
 / {
@@ -59,6 +60,17 @@
 			interrupts = <21 0>;
 			status = "disabled";
 			label = "LEUART_0";
+		};
+
+		i2c0: i2c@4000c000 {
+			compatible = "silabs,gecko-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x4000c000 0x400>;
+			interrupts = <16 0>;
+			label = "I2C_0";
+			status = "disabled";
 		};
 
 		gpio: gpio@4000a400 {

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -19,11 +19,6 @@
 		compatible = "mmio-sram";
 	};
 
-	aliases {
-		i2c-0 = &i2c0;
-		i2c-1 = &i2c1;
-	};
-
 	soc {
 		flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";

--- a/dts/bindings/i2c/silabs,gecko-i2c.yaml
+++ b/dts/bindings/i2c/silabs,gecko-i2c.yaml
@@ -32,9 +32,18 @@ properties:
       description: required interrupts
       generation: define
 
-    location:
-     type: int
-     category: required
-     description: PIN location
-     generation: define
+    # Note: Not all SoC series support setting individual pin location. If this
+    # is a case all location-* properties need to have identical value.
+
+    location-sda:
+      type: array
+      category: required
+      description: SDA pin configuration defined as <location port pin>
+      generation: define
+
+    location-scl:
+      type: array
+      category: required
+      description: SCL pin configuration defined as <location port pin>
+      generation: define
 ...

--- a/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.efm32hg
+++ b/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.efm32hg
@@ -22,6 +22,13 @@ config UART_GECKO
 
 endif # SERIAL
 
+if I2C
+
+config I2C_GECKO
+	default y
+
+endif # I2C
+
 if FLASH
 
 config SOC_FLASH_GECKO

--- a/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
@@ -31,24 +31,4 @@
 #endif
 #endif /* CONFIG_GPIO_GECKO */
 
-#ifdef CONFIG_I2C_GECKO
-#ifdef CONFIG_I2C_0
-#if (DT_SILABS_GECKO_I2C_I2C_0_LOCATION == 15)
-#define PIN_I2C0_SDA {gpioPortC, 10, gpioModeWiredAnd, 1}
-#define PIN_I2C0_SCL {gpioPortC, 11, gpioModeWiredAnd, 1}
-#else
-#error ("I2C Driver for Gecko MCUs not implemented for this location index")
-#endif
-#endif /* CONFIG_I2C_0 */
-
-#ifdef CONFIG_I2C_1
-#if (DT_SILABS_GECKO_I2C_I2C_1_LOCATION == 6)
-#define PIN_I2C1_SDA {gpioPortB, 6, gpioModeWiredAnd, 1}
-#define PIN_I2C1_SCL {gpioPortB, 7, gpioModeWiredAnd, 1}
-#else
-#error ("I2C Driver for Gecko MCUs not implemented for this location index")
-#endif
-#endif /* CONFIG_I2C_1 */
-#endif /* CONFIG_I2C_GECKO */
-
 #endif /* _SILABS_EFM32PG12B_SOC_PINMAP_H_ */

--- a/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.efm32wg
+++ b/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.efm32wg
@@ -22,6 +22,13 @@ config UART_GECKO
 
 endif # SERIAL
 
+if I2C
+
+config I2C_GECKO
+	default y
+
+endif # I2C
+
 if FLASH
 
 config SOC_FLASH_GECKO

--- a/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.efr32fg1p
+++ b/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.efr32fg1p
@@ -22,6 +22,13 @@ config UART_GECKO
 
 endif # SERIAL
 
+if I2C
+
+config I2C_GECKO
+	default y
+
+endif # I2C
+
 if FLASH
 
 config SOC_FLASH_GECKO

--- a/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
@@ -30,24 +30,4 @@
 #endif
 #endif /* CONFIG_GPIO_GECKO */
 
-#ifdef CONFIG_I2C_GECKO
-#ifdef CONFIG_I2C_0
-#if (DT_SILABS_GECKO_I2C_I2C_0_LOCATION == 15)
-#define PIN_I2C0_SDA {gpioPortC, 10, gpioModeWiredAnd, 1}
-#define PIN_I2C0_SCL {gpioPortC, 11, gpioModeWiredAnd, 1}
-#else
-#error ("I2C Driver for Gecko MCUs not implemented for this location index")
-#endif
-#endif /* CONFIG_I2C_0 */
-
-#ifdef CONFIG_I2C_1
-#if (DT_SILABS_GECKO_I2C_I2C_1_LOCATION == 17)
-#define PIN_I2C1_SDA {gpioPortC, 4, gpioModeWiredAnd, 1}
-#define PIN_I2C1_SCL {gpioPortC, 5, gpioModeWiredAnd, 1}
-#else
-#error ("I2C Driver for Gecko MCUs not implemented for this location index")
-#endif
-#endif /* CONFIG_I2C_1 */
-#endif /* CONFIG_I2C_GECKO */
-
 #endif /* _SOC_PINMAP_H_ */


### PR DESCRIPTION
Use the new `DT_<COMPAT>_<INSTANCE>_<PROP>` defines to instantiate devices. This commit adds also ability to define individual pin locations on SoC series that support the feature. Definitions of GPIO
pins assigned to a given location have been moved from soc_pinmap.h file to board DTS file.