### PR TITLE
boards: Add missing sdram dts compatible to mimxrt10{20,60,64} boards

### DIFF
--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -35,6 +35,7 @@
 	sdram0: memory@80000000 {
 		/* ISSI IS42S16160J-6TLI */
 		device_type = "memory";
+		compatible = "mmio-sram";
 		reg = <0x80000000 0x2000000>;
 	};
 

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -32,6 +32,7 @@
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
 		device_type = "memory";
+		compatible = "mmio-sram";
 		reg = <0x80000000 0x2000000>;
 	};
 

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -32,6 +32,7 @@
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
 		device_type = "memory";
+		compatible = "mmio-sram";
 		reg = <0x80000000 0x2000000>;
 	};
 


### PR DESCRIPTION
The sdram memory node was missing a dts compatible on several imx rt
boards.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>