### PR TITLE
logging: introduce LOG_DISABLE_FANCY_OUTPUT_FORMATTING to save flash

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -212,6 +212,14 @@ config LOG_IMMEDIATE
 	  flawlessly in that mode because one log operation can be interrupted
 	  by another one in the higher priority context.
 
+config LOG_DISABLE_FANCY_OUTPUT_FORMATTING
+	depends on !NEWLIB_LIBC && !ARCH_POSIX
+	bool "Use vprintk() instead of minimal libc _prf()"
+	help
+	  Selecting this option will choose vprintk for handling format
+	  strings instead of the more robust _prf() function in minimal
+	  libc.  Choosing this option can save around ~3K flash.
+
 if !LOG_IMMEDIATE
 
 choice

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -114,7 +114,8 @@ static int print_formatted(const struct log_output *log_output,
 	int length = 0;
 
 	va_start(args, fmt);
-#if !defined(CONFIG_NEWLIB_LIBC) && !defined(CONFIG_ARCH_POSIX)
+#if !defined(CONFIG_NEWLIB_LIBC) && !defined(CONFIG_ARCH_POSIX) && \
+    !defined(CONFIG_LOG_DISABLE_FANCY_OUTPUT_FORMATTING)
 	length = _prf(out_func, (void *)log_output, (char *)fmt, args);
 #else
 	_vprintk(out_func, (void *)log_output, fmt, args);
@@ -551,7 +552,8 @@ void log_output_string(const struct log_output *log_output,
 				level, domain_id, source_id);
 	}
 
-#if !defined(CONFIG_NEWLIB_LIBC) && !defined(CONFIG_ARCH_POSIX)
+#if !defined(CONFIG_NEWLIB_LIBC) && !defined(CONFIG_ARCH_POSIX) && \
+    !defined(CONFIG_LOG_DISABLE_FANCY_OUTPUT_FORMATTING)
 	length = _prf(out_func, (void *)log_output, (char *)fmt, ap);
 #else
 	_vprintk(out_func, (void *)log_output, fmt, ap);


### PR DESCRIPTION
The new Logger subsys uses a very robust formatter function in minimal
libc: _prf().  This adds up to ~3K flash.  For resource constrained
devices running samples that don't use the extra formatting options,
allow them to select LOG_DISABLE_FANCY_OUTPUT_FORMATTING to revert
back to vprintk.

MCUBOOT is one such sample that has a very limited amount of output
and benefits from the flash savings due to small bootloader partition
sizes.

Signed-off-by: Michael Scott <mike@foundries.io>