### PR TITLE
editorconfig: basic EditorConfig configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,56 @@
+# EditorConfig: https://editorconfig.org/
+
+# top-most EditorConfig file
+root = true
+
+# All (Defaults)
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = false
+trim_trailing_whitespace = true
+
+# C
+[*.{c,h}]
+indent_style = tab
+indent_size = 8
+
+# Python
+[*.py]
+indent_style = space
+indent_size = 4
+
+# Perl
+[*.pl]
+indent_style = tab
+indent_size = 8
+
+# YAML
+[*.yml]
+indent_style = space
+indent_size = 2
+
+# Shell Script
+[*.sh]
+indent_style = space
+indent_size = 4
+
+# Windows Command Script
+[*.cmd]
+end_of_line = crlf
+indent_style = tab
+indent_size = 8
+
+# Valgrind Suppression File
+[*.supp]
+indent_style = space
+indent_size = 3
+
+# CMake
+[{CMakeLists.txt,*.cmake}]
+indent_style = space
+indent_size = 2
+
+# Makefile
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
EditorConfig ([https://editorconfig.org](https://editorconfig.org)) is a widely supported
configuration tool that helps to ensure better consistency amongst
developers by auto-configuring an editor to match the original/intended
style i.e. tab-width etc.

This configuration covers many of the common file formats used in
zephyr.

The configuration was derived by looking at existing files and
ascertaining what configuration they currently use.

This is the top-most EditorConfig file meaning this is the root of all
other EditorConfigs, however sub-directories can set their own up if
they wish to override this.

This has proven especially useful when viewing uncrustified C source
code where the tab-width should be 8 to get proper alignment but many
editors use a tab-width of 4.

Lots of editors support this natively and those that do not probably
have a plugin or extension.

Tested by opening and saving various files to ensure no changes
occurred.

Signed-off-by: Carlos Stuart <carlosstuart1970@gmail.com>