### PR TITLE
kernel: induce a k_panic on a failed assertion

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4462,51 +4462,6 @@ extern void k_cpu_atomic_idle(unsigned int key);
  */
 extern void _sys_power_save_idle_exit(s32_t ticks);
 
-#ifdef _ARCH_EXCEPT
-/* This archtecture has direct support for triggering a CPU exception */
-#define _k_except_reason(reason)	_ARCH_EXCEPT(reason)
-#else
-
-/* NOTE: This is the implementation for arches that do not implement
- * _ARCH_EXCEPT() to generate a real CPU exception.
- *
- * We won't have a real exception frame to determine the PC value when
- * the oops occurred, so print file and line number before we jump into
- * the fatal error handler.
- */
-#define _k_except_reason(reason) do { \
-		printk("@ %s:%d:\n", __FILE__,  __LINE__); \
-		_NanoFatalErrorHandler(reason, &_default_esf); \
-		CODE_UNREACHABLE; \
-	} while (false)
-
-#endif /* _ARCH__EXCEPT */
-
-/**
- * @brief Fatally terminate a thread
- *
- * This should be called when a thread has encountered an unrecoverable
- * runtime condition and needs to terminate. What this ultimately
- * means is determined by the _fatal_error_handler() implementation, which
- * will be called will reason code _NANO_ERR_KERNEL_OOPS.
- *
- * If this is called from ISR context, the default system fatal error handler
- * will treat it as an unrecoverable system error, just like k_panic().
- * @req K-MISC-003
- */
-#define k_oops()	_k_except_reason(_NANO_ERR_KERNEL_OOPS)
-
-/**
- * @brief Fatally terminate the system
- *
- * This should be called when the Zephyr kernel has encountered an
- * unrecoverable runtime condition and needs to terminate. What this ultimately
- * means is determined by the _fatal_error_handler() implementation, which
- * will be called will reason code _NANO_ERR_KERNEL_PANIC.
- * @req K-MISC-004
- */
-#define k_panic()	_k_except_reason(_NANO_ERR_KERNEL_PANIC)
-
 /*
  * private APIs that are utilized by one or more public APIs
  */

--- a/include/kernel_includes.h
+++ b/include/kernel_includes.h
@@ -34,5 +34,6 @@
 #include <arch/cpu.h>
 #include <misc/rb.h>
 #include <sys_clock.h>
+#include <oops.h>
 
 #endif /* ZEPHYR_INCLUDE_KERNEL_INCLUDES_H_ */

--- a/include/misc/__assert.h
+++ b/include/misc/__assert.h
@@ -62,6 +62,7 @@
 #define ZEPHYR_INCLUDE_MISC___ASSERT_H_
 
 #include <stdbool.h>
+#include <oops.h>
 
 #ifdef CONFIG_ASSERT
 #ifndef __ASSERT_ON
@@ -86,10 +87,7 @@
 extern void posix_exit(int exit_code);
 #define __ASSERT_POST posix_exit(1)
 #else
-#define __ASSERT_POST             \
-	for (;;) {                \
-		/* spin thread */ \
-	}
+#define __ASSERT_POST k_panic()
 #endif
 
 #define __ASSERT_LOC(test)                               \

--- a/include/oops.h
+++ b/include/oops.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_OOPS_H
+#define ZEPHYR_OOPS_H
+
+#include <arch/cpu.h>
+#include <misc/printk.h>
+
+#ifdef _ARCH_EXCEPT
+/* This archtecture has direct support for triggering a CPU exception */
+#define _k_except_reason(reason)	_ARCH_EXCEPT(reason)
+#else
+
+/* NOTE: This is the implementation for arches that do not implement
+ * _ARCH_EXCEPT() to generate a real CPU exception.
+ *
+ * We won't have a real exception frame to determine the PC value when
+ * the oops occurred, so print file and line number before we jump into
+ * the fatal error handler.
+ */
+#define _k_except_reason(reason) do { \
+		printk("@ %s:%d:\n", __FILE__,  __LINE__); \
+		_NanoFatalErrorHandler(reason, &_default_esf); \
+		CODE_UNREACHABLE; \
+	} while (false)
+
+#endif /* _ARCH__EXCEPT */
+
+/**
+ * @brief Fatally terminate a thread
+ *
+ * This should be called when a thread has encountered an unrecoverable
+ * runtime condition and needs to terminate. What this ultimately
+ * means is determined by the _fatal_error_handler() implementation, which
+ * will be called will reason code _NANO_ERR_KERNEL_OOPS.
+ *
+ * If this is called from ISR context, the default system fatal error handler
+ * will treat it as an unrecoverable system error, just like k_panic().
+ * @req K-MISC-003
+ */
+#define k_oops()	_k_except_reason(_NANO_ERR_KERNEL_OOPS)
+
+/**
+ * @brief Fatally terminate the system
+ *
+ * This should be called when the Zephyr kernel has encountered an
+ * unrecoverable runtime condition and needs to terminate. What this ultimately
+ * means is determined by the _fatal_error_handler() implementation, which
+ * will be called will reason code _NANO_ERR_KERNEL_PANIC.
+ * @req K-MISC-004
+ */
+#define k_panic()	_k_except_reason(_NANO_ERR_KERNEL_PANIC)
+
+#endif /* ZEPHYR_OOPS_H */


### PR DESCRIPTION
This is preferable to spinning forever as it halts the entire
system and dumps logs.

New header file created to avoid a circular include dependency.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>