### PR TITLE
dts: intel_s1000_crb: put back block sizes

### DIFF
--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
@@ -45,6 +45,8 @@
 		label = "MX25UM512";
 		jedec-id = <0xc2 0x80 0x3a>;
 		size = <0x2000000>;
+		erase-block-size = <0x10000>;
+		write-block-size = <1>;
 	};
 };
 


### PR DESCRIPTION
Somehow these were getting generated as `FLASH_foo_BLOCK_SIZE` even
though there's no specification for them in the original yaml.  Put them
back until we can figure out what's going on.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>