### PR TITLE
allow system clock driver selection for cortex m

### DIFF
--- a/arch/arm/core/cortex_m/vector_table.S
+++ b/arch/arm/core/cortex_m/vector_table.S
@@ -66,8 +66,5 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
     .word __reserved
     .word __pendsv
-#if defined(CONFIG_CORTEX_M_SYSTICK)
-    .word _timer_int_handler
-#else
-    .word __reserved
-#endif
+    .word z_clock_isr
+

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -48,7 +48,7 @@ static u32_t elapsed(void)
 }
 
 /* Callout out of platform assembly, not hooked via IRQ_CONNECT... */
-void _timer_int_handler(void *arg)
+void z_clock_isr(void *arg)
 {
 	ARG_UNUSED(arg);
 	u32_t dticks;

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -18,6 +18,11 @@
 
 /* Weak-linked noop defaults for optional driver interfaces: */
 
+void __weak z_clock_isr(void *arg)
+{
+	__ASSERT_NO_MSG(false);
+}
+
 int __weak z_clock_driver_init(struct device *device)
 {
 	return 0;


### PR DESCRIPTION
The selection of the Cortex M systick driver to be used as a system clock driver is controlled by CONFIG_CORTEX_M_SYSTICK.

To replace it by another driver CONFIG_CORTEX_M_SYSTICK must be set to 'n'. Unfortunately this also controls the interrupt vector for the systick interrupt. It is now routed to __reserved. More bad the interrupt vector can not be set by IRQ_CONNECT as it is one of the hard coded interrupts in the interrupt table.

Route the hard coded systick interrupt to z_clock_isr and make z_clock_isr a weak symbol that can be overwritten by an alternative systick system clock driver.

Signed-off-by: Bobby Noelte <b0661n0e17e@gmail.com>