### PR TITLE
misc: assert_post_action: Treat POSIX arch like others

### DIFF
--- a/lib/os/assert.c
+++ b/lib/os/assert.c
@@ -9,10 +9,5 @@
 
 void assert_post_action(void)
 {
-	if (IS_ENABLED(CONFIG_ARCH_POSIX)) {
-		extern void posix_exit(int exit_code);
-		posix_exit(1);
-	} else {
-		k_panic();
-	}
+	k_panic();
 }


### PR DESCRIPTION
(I missed #12732)

------------------------

After #12732, 69045011733b9e97bb8974a22bb83637520f61c1
asserts call k_panic.

Before this, the POSIX arch had its own hack in the
__ASSERT_POST implementation to terminate the process instead
of spining forever.

But the POSIX arch does implement k_panic properly, so there
is no need anymore for this hack.
=> Remove the special treatment for POSIX ARCH

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>