### PR TITLE
arch: posix: Bugfix in POSIX cheats header

### DIFF
--- a/arch/posix/include/posix_cheats.h
+++ b/arch/posix/include/posix_cheats.h
@@ -23,7 +23,7 @@
  * some prefix, and we ensure this header is included
  */
 
-#ifdef CONFIG_PTHREAD_IPC
+#ifdef CONFIG_POSIX_API
 
 #define timespec zap_timespec
 #define timeval  zap_timeval
@@ -189,7 +189,7 @@
 #define stat		zap_stat
 #define mkdir		zap_mkdir
 
-#endif /* CONFIG_PTHREAD_IPC */
+#endif /* CONFIG_POSIX_API */
 
 #endif /* CONFIG_ARCH_POSIX */
 


### PR DESCRIPTION
In 8dc69e09dad6366f2a443e37c7f3d5a7b3c4e2d9 (#10280)
the POSIX API main kconfig option was replaced from
PTHREAD_IPC to POSIX_API.
But the posix_cheats.h header was left using the old option.
This means that some applications/tests which were not
selecting the PTHREAD_IPC API, but using some other Zephyr
POSIX compatible APIs could have trouble when compiled for the
POSIX architecture.

Fixes #13011

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>