### PR TITLE
sanitycheck: coverage: Tolerate missing source files

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2880,7 +2880,10 @@ def generate_coverage(outdir, ignores):
                     coveragefile, "--rc", "lcov_branch_coverage=1"],
                 stdout=coveragelog)
 
+        #The --ignore-errors source option is added to avoid it exiting due to
+        #samples/application_development/external_lib/
         ret = subprocess.call(["genhtml", "--legend", "--branch-coverage",
+                               "--ignore-errors", "source",
                                "-output-directory",
                                os.path.join(outdir, "coverage")] + files,
                                stdout=coveragelog)


### PR DESCRIPTION
When calling genhtml to generate a coverage report directly from
sanitycheck (-C option), call it with the "--ignore-errors source"
option, so it does not exit when it meets a missing file, but
instead it warns the user and continues.

Fixes #13014

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>