### PR TITLE
drivers: hwinfo: Add drivers for NXP SoC

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.yaml
+++ b/boards/arm/frdm_k64f/frdm_k64f.yaml
@@ -15,5 +15,6 @@ supported:
   - gpio
   - usb_device
   - watchdog
+  - hwinfo
 testing:
   default: true

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
@@ -16,3 +16,4 @@ ram: 32768
 flash: 8192
 supported:
   - i2c
+  - hwinfo

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
@@ -18,3 +18,4 @@ supported:
   - i2c
   - spi
   - netif:eth
+  - hwinfo

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
@@ -17,3 +17,4 @@ flash: 8192
 supported:
   - spi
   - netif:eth
+  - hwinfo

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -14,3 +14,5 @@ toolchain:
   - xtools
 ram: 128
 flash: 128
+supported:
+  - hwinfo

--- a/drivers/hwinfo/CMakeLists.txt
+++ b/drivers/hwinfo/CMakeLists.txt
@@ -1,7 +1,8 @@
 zephyr_sources_ifdef(CONFIG_USERSPACE   hwinfo_handlers.c)
 zephyr_sources_ifdef(CONFIG_HWINFO      hwinfo_weak_impl.c)
 
-zephyr_sources_ifdef(CONFIG_HWINFO_STM32   hwinfo_stm32.c)
-zephyr_sources_ifdef(CONFIG_HWINFO_NRF     hwinfo_nrf.c)
+zephyr_sources_ifdef(CONFIG_HWINFO_STM32      hwinfo_stm32.c)
+zephyr_sources_ifdef(CONFIG_HWINFO_NRF        hwinfo_nrf.c)
+zephyr_sources_ifdef(CONFIG_HWINFO_MCUX_SIM   hwinfo_mcux_sim.c)
 
 zephyr_sources_ifdef(CONFIG_HWINFO_SHELL hwinfo_shell.c)

--- a/drivers/hwinfo/CMakeLists.txt
+++ b/drivers/hwinfo/CMakeLists.txt
@@ -4,5 +4,6 @@ zephyr_sources_ifdef(CONFIG_HWINFO      hwinfo_weak_impl.c)
 zephyr_sources_ifdef(CONFIG_HWINFO_STM32      hwinfo_stm32.c)
 zephyr_sources_ifdef(CONFIG_HWINFO_NRF        hwinfo_nrf.c)
 zephyr_sources_ifdef(CONFIG_HWINFO_MCUX_SIM   hwinfo_mcux_sim.c)
+zephyr_sources_ifdef(CONFIG_HWINFO_IMXRT      hwinfo_imxrt.c)
 
 zephyr_sources_ifdef(CONFIG_HWINFO_SHELL hwinfo_shell.c)

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -33,4 +33,11 @@ config HWINFO_NRF
 	help
 	  Enable Nordic NRF hwinfo driver.
 
+config HWINFO_MCUX_SIM
+	bool "NXP kinetis device ID"
+	default y
+	depends on HAS_MCUX_SIM
+	help
+	  Enable NXP kinetis mcux hwinfo driver.
+
 endif

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -40,4 +40,11 @@ config HWINFO_MCUX_SIM
 	help
 	  Enable NXP kinetis mcux hwinfo driver.
 
+config HWINFO_IMXRT
+	bool "NXP i.mx RT device ID"
+	default y
+	depends on SOC_SERIES_IMX_RT
+	help
+	  Enable NXP i.mx RT hwinfo driver.
+
 endif

--- a/drivers/hwinfo/hwinfo_imxrt.c
+++ b/drivers/hwinfo/hwinfo_imxrt.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Alexander Wachter
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <soc.h>
+#include <hwinfo.h>
+#include <string.h>
+
+struct imxrt_uid {
+	u32_t id[2];
+};
+
+ssize_t _impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
+{
+	struct imxrt_uid dev_id;
+
+	dev_id.id[0] = OCOTP->CFG1;
+	dev_id.id[1] = OCOTP->CFG2;
+
+	if (length > sizeof(dev_id.id)) {
+		length = sizeof(dev_id.id);
+	}
+
+	memcpy(buffer, dev_id.id, length);
+
+	return length;
+}

--- a/drivers/hwinfo/hwinfo_mcux_sim.c
+++ b/drivers/hwinfo/hwinfo_mcux_sim.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019 Alexander Wachter
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <hwinfo.h>
+#include <string.h>
+#include <fsl_sim.h>
+
+#if defined(SIM_UIDH)
+#define HWINFO_DEVICE_ID_LENGTH_H 1
+#else
+#define HWINFO_DEVICE_ID_LENGTH_H 0
+#endif
+#if (defined(FSL_FEATURE_SIM_HAS_UIDM) && FSL_FEATURE_SIM_HAS_UIDM)
+#define HWINFO_DEVICE_ID_LENGTH_M 1
+#else
+#define HWINFO_DEVICE_ID_LENGTH_M 2
+#endif
+#define HWINFO_DEVICE_ID_LENGTH_L 1
+
+#define HWINFO_DEVICE_ID_LENGTH_TOTAL (HWINFO_DEVICE_ID_LENGTH_L + \
+				       HWINFO_DEVICE_ID_LENGTH_M + \
+				       HWINFO_DEVICE_ID_LENGTH_H)
+
+struct kinetis_uid {
+	u32_t id[HWINFO_DEVICE_ID_LENGTH_TOTAL];
+};
+
+ssize_t _impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
+{
+	struct kinetis_uid dev_id;
+
+	dev_id.id[0] = SIM->UIDL;
+#if (defined(FSL_FEATURE_SIM_HAS_UIDM) && FSL_FEATURE_SIM_HAS_UIDM)
+	dev_id.id[1] = SIM->UIDM;
+#else
+	dev_id.id[1] = SIM->UIDML;
+	dev_id.id[2] = SIM->UIDMH;
+#if defined(SIM_UIDH)
+	dev_id.id[3] = SIM->UIDH;
+#endif /* SIM_UIDH */
+#endif /* defined(FSL_FEATURE_SIM_HAS_UIDM) && FSL_FEATURE_SIM_HAS_UIDM */
+
+	if (length > sizeof(dev_id.id)) {
+		length = sizeof(dev_id.id);
+	}
+
+	memcpy(buffer, dev_id.id, length);
+
+	return length;
+}


### PR DESCRIPTION
This PR adds hwinfo device id driver support for NXP LPC and kinetis SOC.