### PR TITLE
CI: Enable sanitycheck to build with multiple toolchain variants

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -8,6 +8,9 @@ env:
         - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.9.5
         - ZEPHYR_TOOLCHAIN_VARIANT=zephyr
         - MATRIX_BUILDS="5"
+        - ESPRESSIF_TOOLCHAIN_PATH=/opt/toolchain/esp32/xtensa-esp32-elf
+        - ESP_IDF_PATH=/opt/toolchain/esp32/esp-idf
+        - XTOOLS_TOOLCHAIN_PATH=/opt/sdk/zephyr-sdk-0.10.0-beta5
     matrix:
         - MATRIX_BUILD="1"
         - MATRIX_BUILD="2"

--- a/cmake/generic_toolchain.cmake
+++ b/cmake/generic_toolchain.cmake
@@ -17,14 +17,6 @@ but Zephyr ignores flags from the environment. Use 'cmake -DEXTRA_${var}=$ENV{${
   endif()
 endforeach()
 
-# Until we completely deprecate it
-if(NOT DEFINED ENV{ZEPHYR_TOOLCHAIN_VARIANT})
-  if(DEFINED ENV{ZEPHYR_GCC_VARIANT})
-    message(WARNING "ZEPHYR_GCC_VARIANT is deprecated, please use ZEPHYR_TOOLCHAIN_VARIANT instead")
-    set(ZEPHYR_TOOLCHAIN_VARIANT $ENV{ZEPHYR_GCC_VARIANT})
-  endif()
-endif()
-
 if(NOT ZEPHYR_TOOLCHAIN_VARIANT)
   if(DEFINED ENV{ZEPHYR_TOOLCHAIN_VARIANT})
     set(ZEPHYR_TOOLCHAIN_VARIANT $ENV{ZEPHYR_TOOLCHAIN_VARIANT})
@@ -32,13 +24,6 @@ if(NOT ZEPHYR_TOOLCHAIN_VARIANT)
     set(ZEPHYR_TOOLCHAIN_VARIANT cross-compile)
   endif()
 endif()
-
-# Until we completely deprecate it
-if("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "gccarmemb")
-  message(WARNING "gccarmemb is deprecated, please use gnuarmemb instead")
-  set(ZEPHYR_TOOLCHAIN_VARIANT "gnuarmemb")
-endif()
-
 
 set(TOOLCHAIN_ROOT ${TOOLCHAIN_ROOT} CACHE STRING "Zephyr toolchain root")
 assert(TOOLCHAIN_ROOT "Zephyr toolchain root path invalid: please set the TOOLCHAIN_ROOT-variable")

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -172,11 +172,6 @@ additional variable(s) specific to that toolchain (usually, this is just one
 more variable which contains the path where you installed the toolchain on your
 file system).
 
-.. note::
-
-   In previous releases of Zephyr, the ``ZEPHYR_TOOLCHAIN_VARIANT`` variable
-   was called ``ZEPHYR_GCC_VARIANT``.
-
 The following toolchain installation options are available. The right choice
 for you depends on where you want to run Zephyr and any other requirements you
 may have. Check your :ref:`board-level documentation <boards>` if you are

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -19,7 +19,7 @@
 
 set -xe
 
-SANITYCHECK_OPTIONS=" --inline-logs --enable-coverage -N"
+SANITYCHECK_OPTIONS="--toolchain-variant xtools --toolchain-variant espressif --toolchain-variant zephyr --inline-logs --enable-coverage -N"
 SANITYCHECK_OPTIONS_RETRY="${SANITYCHECK_OPTIONS} --only-failed --outdir=out-2nd-pass"
 SANITYCHECK_OPTIONS_RETRY_2="${SANITYCHECK_OPTIONS} --only-failed --outdir=out-3nd-pass"
 export BSIM_OUT_PATH="${BSIM_OUT_PATH:-/opt/bsim/}"

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1975,12 +1975,7 @@ class TestSuite:
 
     def apply_filters(self):
 
-        toolchain = os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT", None) or \
-                    os.environ.get("ZEPHYR_GCC_VARIANT", None)
-
-        if toolchain == "gccarmemb":
-            # Remove this translation when gccarmemb is no longer supported.
-            toolchain = "gnuarmemb"
+        toolchain = os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT", None)
 
         try:
             if not toolchain:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1207,6 +1207,14 @@ class MakeGenerator:
         build_logfile = os.path.join(outdir, "build.log")
         run_logfile = os.path.join(outdir, "run.log")
 
+        for variant in instance.platform.supported_toolchains:
+            if variant in options.toolchain_variant and \
+                (variant not in instance.test.toolchain_exclude or \
+                variant in instance.test.toolchain_whitelist):
+                args += ["ZEPHYR_TOOLCHAIN_VARIANT=\"%s\"" %variant]
+                break
+
+
         if not os.path.exists(outdir):
             os.makedirs(outdir)
 
@@ -1975,10 +1983,20 @@ class TestSuite:
 
     def apply_filters(self):
 
+        def common_member(a, b):
+            a_set = set(a)
+            b_set = set(b)
+            if (a_set & b_set):
+                return True
+            else:
+                return False
+
         toolchain = os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT", None)
+        if toolchain and toolchain not in options.toolchain_variant:
+            options.toolchain_variant.append(toolchain)
 
         try:
-            if not toolchain:
+            if not options.toolchain_variant:
                 raise SanityRuntimeError("E: Variable ZEPHYR_TOOLCHAIN_VARIANT is not defined")
         except Exception as e:
             print(str(e))
@@ -2059,8 +2077,16 @@ class TestSuite:
                     if tc.platform_exclude and plat.name in tc.platform_exclude:
                         continue
 
-                    if tc.toolchain_exclude and toolchain in tc.toolchain_exclude:
-                        continue
+                    if tc.toolchain_exclude:
+                        exclude = False
+                        for toolchain in options.toolchain_variant:
+                            if toolchain in tc.toolchain_exclude:
+                                exclude = True
+                            elif toolchain in plat.supported_toolchains:
+                                exclude = False
+                                break
+                        if exclude:
+                            continue
 
                     if platform_filter and plat.name not in platform_filter:
                         continue
@@ -2083,12 +2109,21 @@ class TestSuite:
                     if tc.platform_whitelist and plat.name not in tc.platform_whitelist:
                         continue
 
-                    if tc.toolchain_whitelist and toolchain not in tc.toolchain_whitelist:
-                        continue
+                    if tc.toolchain_whitelist:
+                        exclude = False
+                        for toolchain in options.toolchain_variant:
+                            if toolchain not in tc.toolchain_whitelist:
+                                exclude = True
+                            elif toolchain in plat.supported_toolchains:
+                                exclude = False
+                                break
+                        if exclude:
+                            continue
 
                     if (plat.env_satisfied and tc.tc_filter
                             and (plat.default or all_plats or platform_filter)
-                            and (toolchain in plat.supported_toolchains or options.force_toolchain)):
+                            and (common_member(options.toolchain_variant, plat.supported_toolchains) or \
+                                    options.force_toolchain)):
                         args = tc.extra_args[:]
                         args.append("BOARD={}".format(plat.name))
                         args.extend(extra_args)
@@ -2216,9 +2251,17 @@ class TestSuite:
                         discards[instance] = "In test case platform exclude"
                         continue
 
-                    if tc.toolchain_exclude and toolchain in tc.toolchain_exclude:
-                        discards[instance] = "In test case toolchain exclude"
-                        continue
+                    if tc.toolchain_exclude:
+                        exclude = False
+                        for toolchain in options.toolchain_variant:
+                            if toolchain in tc.toolchain_exclude:
+                                exclude = True
+                            elif toolchain in plat.supported_toolchains:
+                                exclude = False
+                                break
+                        if exclude:
+                            discards[instance] = "In test case toolchain exclude"
+                            continue
 
                     if platform_filter and plat.name not in platform_filter:
                         discards[instance] = "Command line platform filter"
@@ -2228,16 +2271,23 @@ class TestSuite:
                         discards[instance] = "Not in testcase platform whitelist"
                         continue
 
-                    if tc.toolchain_whitelist and toolchain not in tc.toolchain_whitelist:
-                        discards[instance] = "Not in testcase toolchain whitelist"
-                        continue
-
+                    if tc.toolchain_whitelist:
+                        exclude = False
+                        for toolchain in options.toolchain_variant:
+                            if toolchain not in tc.toolchain_whitelist:
+                                exclude = True
+                            elif toolchain in plat.supported_toolchains:
+                                exclude = False
+                                break
+                        if exclude:
+                            discards[instance] = "In test case toolchain exclude"
+                            continue
                     if not plat.env_satisfied:
                         discards[instance] = "Environment ({}) not satisfied".format(", ".join(plat.env))
                         continue
 
                     if not options.force_toolchain \
-                        and toolchain and (toolchain not in plat.supported_toolchains) \
+                        and not (common_member(options.toolchain_variant, plat.supported_toolchains)) \
                         and tc.type != 'unit':
                         discards[instance] = "Not supported by the toolchain"
                         continue
@@ -2642,6 +2692,10 @@ def parse_arguments():
     parser.add_argument("--force-toolchain", action="store_true",
             help="Do not filter based on toolchain, use the set "
             " toolchain unconditionally")
+
+    parser.add_argument("--toolchain-variant", action="append", default=[],
+            help="Set list of variants to support, multiple variants possible")
+
     parser.add_argument(
         "-p", "--platform", action="append",
         help="Platform filter for testing. This option may be used multiple "


### PR DESCRIPTION
Allow sanitycheck to run with multiple toolchains, not only the one set in
the environment. This will allow testing more boards in CI when the
toolchain supported those boards is available and ready to be used.

This can be set using --toolchain-variant multiple times. The default of
getting the variant from the environment is still supported.


This PR will allow building esp32 and some of the new boards based on Cortex-M33 SoCs.

Resolves #12997 

DNM: Still need to cleanup some of the python-foo
