### PR TITLE
Fix build errors with SPI flash on intel S1000 CRB

### DIFF
--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -10,7 +10,7 @@
 
 #if defined(DT_FLASH_DEV_NAME)
 #define FA_DEV_ID SOC_FLASH_0_ID
-#elif defined(CONFIG_SPI_FLASH_W25QXXDV) || defined(DT_SPI_NOR_DRV_NAME)
+#elif defined(CONFIG_SPI_FLASH_W25QXXDV) || defined(DT_JEDEC_SPI_NOR_0_LABEL)
 #define FA_DEV_ID SPI_FLASH_0_ID
 #endif
 

--- a/tests/boards/intel_s1000_crb/src/spi_flash.c
+++ b/tests/boards/intel_s1000_crb/src/spi_flash.c
@@ -56,7 +56,7 @@ void test_flash(void)
 	u32_t magic[4];
 	int i;
 
-	flash_dev = device_get_binding(DT_SPI_NOR_DRV_NAME);
+	flash_dev = device_get_binding(DT_JEDEC_SPI_NOR_0_LABEL);
 
 	if (!flash_dev) {
 		LOG_ERR("SPI flash driver was not found!\n");


### PR DESCRIPTION
Related to recent changes in label name coming from DTS.