### PR TITLE
net/pkt: Allocate relevant size on AF_UNSPEC

### DIFF
--- a/tests/net/net_pkt_new/src/main.c
+++ b/tests/net/net_pkt_new/src/main.c
@@ -60,6 +60,7 @@ static const struct ethernet_api fake_dev_api = {
 
 #define _ETH_L2_LAYER ETHERNET_L2
 #define _ETH_L2_CTX_TYPE NET_L2_GET_CTX_TYPE(ETHERNET_L2)
+#define L2_HDR_SIZE sizeof(struct net_eth_hdr)
 #else
 static const struct dummy_api fake_dev_api = {
 	.iface_api.init = fake_dev_iface_init,
@@ -68,6 +69,7 @@ static const struct dummy_api fake_dev_api = {
 
 #define _ETH_L2_LAYER DUMMY_L2
 #define _ETH_L2_CTX_TYPE NET_L2_GET_CTX_TYPE(DUMMY_L2)
+#define L2_HDR_SIZE 0
 #endif
 
 NET_DEVICE_INIT(fake_dev, "fake_dev",
@@ -154,7 +156,7 @@ static void test_net_pkt_allocate_with_buffer(void)
 	zassert_true(pkt != NULL, "Pkt not allocated");
 
 	zassert_false(pkt_is_of_size(pkt, 1800), "Pkt size is not right");
-	zassert_true(pkt_is_of_size(pkt, net_if_get_mtu(eth_if)),
+	zassert_true(pkt_is_of_size(pkt, net_if_get_mtu(eth_if) + L2_HDR_SIZE),
 		     "Pkt size is not right");
 
 	/* Freeing the packet */


### PR DESCRIPTION
In case of Ethernet, if the size is > than MTU and if AF_UNSPEC is
provided to the allocator will need to take into account the ethernet
header size which is not accounted in the MTU.

Other current L2 do not follow that rule as their MTU is based on IP one
(IPv6 most of the time).

Fixes #12982

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>