### PR TITLE
net/context: Lock/unlock mutex on new send/sendto functions

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -887,7 +887,7 @@ int net_context_connect(struct net_context *context,
 
 		ret = bind_default(context);
 		if (ret) {
-			return ret;
+			goto unlock;
 		}
 
 		net_sin_ptr(&context->local)->sin_family = AF_INET;

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2097,7 +2097,8 @@ resend_ack:
 	if (tcp_flags & NET_TCP_ACK) {
 		if (!net_tcp_ack_received(context,
 					  sys_get_be32(tcp_hdr->ack))) {
-			return NET_DROP;
+			ret = NET_DROP;
+			goto unlock;
 		}
 
 		/* TCP state might be changed after maintaining the sent pkt


### PR DESCRIPTION
This was forgotten modification as commit 93e5181fbdf came in master
though commit 0d519f7bcf7 was already written.

Thus fixing the missing lock/unlock.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>