### PR TITLE
Fix zero-overhead loop in fake stackframe

### DIFF
--- a/arch/arc/core/regular_irq.S
+++ b/arch/arc/core/regular_irq.S
@@ -200,7 +200,8 @@ _rirq_return_from_coop:
 	ld_s r0, [r2, _thread_offset_to_return_value]
 	st_s r0, [sp, ___isf_t_r0_OFFSET]
 
-	st 0, [sp, ___isf_t_lp_count_OFFSET]
+	/* reset zero-overhead loops */
+	st 0, [sp, ___isf_t_lp_end_OFFSET]
 
 	/*
 	 * r13 is part of both the callee and caller-saved register sets because


### PR DESCRIPTION
Fixes incorrect PR #12480
lp_count set to zero doesn't reset zero overhead loops, it encodes a maximum loopcount.

Signed-off-by: Ruud Derwig Ruud.Derwig@synopsys.com