### PR TITLE
stm32_spi: Add DMA capabilities for STM32F4 SOCs

### DIFF
--- a/drivers/dma/dma_stm32f4x.c
+++ b/drivers/dma/dma_stm32f4x.c
@@ -185,18 +185,18 @@ static void dma_stm32_write(struct dma_stm32_device *ddata,
 static void dma_stm32_dump_reg(struct dma_stm32_device *ddata, u32_t id)
 {
 	LOG_INF("Using stream: %d\n", id);
-	LOG_INF("SCR:   0x%x \t(config)\n",
-		    dma_stm32_read(ddata, DMA_STM32_SCR(id)));
-	LOG_INF("SNDTR:  0x%x \t(length)\n",
-		    dma_stm32_read(ddata, DMA_STM32_SNDTR(id)));
-	LOG_INF("SPAR:  0x%x \t(source)\n",
-		    dma_stm32_read(ddata, DMA_STM32_SPAR(id)));
-	LOG_INF("SM0AR: 0x%x \t(destination)\n",
-		    dma_stm32_read(ddata, DMA_STM32_SM0AR(id)));
-	LOG_INF("SM1AR: 0x%x \t(destination (double buffer mode))\n",
-		    dma_stm32_read(ddata, DMA_STM32_SM1AR(id)));
-	LOG_INF("SFCR:  0x%x \t(fifo control)\n",
-		    dma_stm32_read(ddata, DMA_STM32_SFCR(id)));
+	LOG_INF("SCR:   0x%x \t(config)",
+		dma_stm32_read(ddata, DMA_STM32_SCR(id)));
+	LOG_INF("SNDTR:  0x%x \t(length)",
+		dma_stm32_read(ddata, DMA_STM32_SNDTR(id)));
+	LOG_INF("SPAR:  0x%x \t(source)",
+		dma_stm32_read(ddata, DMA_STM32_SPAR(id)));
+	LOG_INF("SM0AR: 0x%x \t(destination)",
+		dma_stm32_read(ddata, DMA_STM32_SM0AR(id)));
+	LOG_INF("SM1AR: 0x%x \t(destination (double buffer mode))",
+		dma_stm32_read(ddata, DMA_STM32_SM1AR(id)));
+	LOG_INF("SFCR:  0x%x \t(fifo control)",
+		dma_stm32_read(ddata, DMA_STM32_SFCR(id)));
 }
 
 static u32_t dma_stm32_irq_status(struct dma_stm32_device *ddata,
@@ -246,12 +246,10 @@ static void dma_stm32_irq_handler(void *arg, u32_t id)
 
 	if ((irqstatus & DMA_STM32_TCI) && (config & DMA_STM32_SCR_TCIE)) {
 		dma_stm32_irq_clear(ddata, id, DMA_STM32_TCI);
-
 		stream->dma_callback(stream->callback_arg, id, 0);
 	} else {
-		LOG_ERR("Internal error: IRQ status: 0x%x\n", irqstatus);
+		LOG_ERR("Error on stream %d: IRQ status: 0x%x", id, irqstatus);
 		dma_stm32_irq_clear(ddata, id, irqstatus);
-
 		stream->dma_callback(stream->callback_arg, id, -EIO);
 	}
 }
@@ -387,7 +385,8 @@ static int dma_stm32_config(struct device *dev, u32_t id,
 		return -EINVAL;
 	}
 
-	if ((MEMORY_TO_MEMORY == stream->direction) && (!ddata->mem2mem)) {
+	if ((config->channel_direction == MEMORY_TO_MEMORY)
+			&& (!ddata->mem2mem)) {
 		LOG_ERR("DMA error: Memcopy not supported for device %s",
 			dev->config->name);
 		return -EINVAL;

--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -23,6 +23,16 @@ config SPI_STM32_HAS_FIFO
 config SPI_STM32_INTERRUPT
 	bool "STM32 MCU SPI Interrupt Support"
 	help
-	  Enable Interrupt support for the SPI Driver of STM32 family.
+	  Enable Interrupt support for the SPI Driver of STM32 family. Selecting this precludes
+	  the use of DMA for SPI.
+
+config SPI_STM32_DMA
+	bool "STM32 MCU SPI DMA Support"
+	depends on SOC_SERIES_STM32F4X && !SPI_STM32_INTERRUPT
+select DMA
+select DMA_STM32F4X
+default n
+	help
+	  Enable DMA support for the SPI Driver of STM32 family.
 
 endif # SPI_STM32

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -9,6 +9,10 @@
 
 #include "spi_context.h"
 
+#ifdef CONFIG_SPI_STM32_DMA
+#include <dma.h>
+#endif
+
 typedef void (*irq_config_func_t)(struct device *port);
 
 struct spi_stm32_config {
@@ -17,10 +21,21 @@ struct spi_stm32_config {
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 	irq_config_func_t irq_config;
 #endif
+#ifdef CONFIG_SPI_STM32_DMA
+	u32_t stream[2];
+	const char *dmadev;
+#endif
 };
 
 struct spi_stm32_data {
 	struct spi_context ctx;
+	bool armed;
+#ifdef CONFIG_SPI_STM32_DMA
+	struct device *d;
+	struct dma_config dma_conf[2];
+	struct dma_block_config b[2];
+	u32_t nDMA;
+#endif
 };
 
-#endif	/* ZEPHYR_DRIVERS_SPI_SPI_LL_STM32_H_ */
+#endif  /* ZEPHYR_DRIVERS_SPI_SPI_LL_STM32_H_ */

--- a/include/spi.h
+++ b/include/spi.h
@@ -160,12 +160,15 @@ struct spi_cs_control {
  *     cs_hold             [ 13 ]      - Hold on the CS line if possible.
  *     lock_on             [ 14 ]      - Keep resource locked for the caller.
  *     cs_active_high      [ 15 ]      - Active high CS logic.
+ *     defer_mode          [ 16 ]      - Defer transaction start on trigger.
+ *
  * @param slave is the slave number from 0 to host controller slave limit.
  * @param cs is a valid pointer on a struct spi_cs_control is CS line is
  *    emulated through a gpio line, or NULL otherwise.
  *
- * @note Only cs_hold and lock_on can be changed between consecutive
- * transceive call. Rest of the attributes are not meant to be tweaked.
+ * @note Only cs_hold, defer_mode and lock_on can be changed between
+ * consecutive transceive call. Rest of the attributes are not meant
+ * to be tweaked.
  */
 struct spi_config {
 	u32_t		frequency;


### PR DESCRIPTION
Addition of DMA for STM32F4xx family for SPI communication. To all
intents and purposes this works the same as Interrupt driven
DMA communication but is much faster and takes less CPU. Also
includes support for deferred spi start. This allows an SPI
transaction to be set up and triggered later. Useful for the
common pattern that an SPI transfer is triggered by an external
event.

Signed-off-by: Dave Marples <dave@marples.net>