### PR TITLE
tests: kernel: interrupt: group IRQ line number selection together

### DIFF
--- a/tests/kernel/interrupt/src/interrupt.h
+++ b/tests/kernel/interrupt/src/interrupt.h
@@ -8,8 +8,6 @@
 #include <irq_offload.h>
 #include <kernel_structs.h>
 
-#define IRQ_LINE(offset) (CONFIG_NUM_IRQS - ((offset) + 1))
-
 
 #if defined(CONFIG_ARM)
 #include <arch/arm/cortex_m/cmsis.h>

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -3,6 +3,12 @@
 #define DURATION 5
 struct k_timer timer;
 
+/* This tests uses two IRQ lines, selected within the range of IRQ lines
+ * available on the target SOC the test executes on (and starting from
+ * the maximum available IRQ line index)
+ */
+#define IRQ_LINE(offset) (CONFIG_NUM_IRQS - ((offset) + 1))
+
 #define ISR0_OFFSET 1
 #define ISR1_OFFSET 2
 


### PR DESCRIPTION
This commit moves the definition of IRQ_LINE(..) macro from
interrupt.h into nested_irq.c, and adds some inline comments
documenting the use of it.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>