### PR TITLE
drivers: can: fix typo

### DIFF
--- a/drivers/can/stm32_can.h
+++ b/drivers/can/stm32_can.h
@@ -67,7 +67,7 @@ struct can_stm32_data {
 struct can_stm32_config {
 	CAN_TypeDef *can;   /*!< CAN Registers*/
 	u32_t bus_speed;
-	u8_t swj;
+	u8_t sjw;
 	u8_t prop_bs1;
 	u8_t bs2;
 	struct stm32_pclken pclken;


### PR DESCRIPTION
Sadly I had missed another typo, that after the last typo fixes causes an error now. 

@jukkar  here the typo fix :-/ 