### PR TITLE
kernel: Document resolution of k_uptime_get*()

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1612,7 +1612,12 @@ static inline void *_impl_k_timer_user_data_get(struct k_timer *timer)
  * This routine returns the elapsed time since the system booted,
  * in milliseconds.
  *
- * @return Current uptime.
+ * @note While this function returns time in milliseconds, it does not mean it
+ * has millisecond resolution. The actual resolution depends on
+ * :option:`CONFIG_SYS_CLOCK_TICKS_PER_SEC` config option, and with the default
+ * setting of 100, system time is updated in increments of 10ms.
+ *
+ * @return Current uptime in milliseconds.
  */
 __syscall s64_t k_uptime_get(void);
 
@@ -1651,7 +1656,12 @@ void k_disable_sys_clock_always_on(void);
  * cannot hold a system uptime time larger than approximately 50 days, so the
  * caller must handle possible rollovers.
  *
- * @return Current uptime.
+ * @note While this function returns time in milliseconds, it does not mean it
+ * has millisecond resolution. The actual resolution depends on
+ * :option:`CONFIG_SYS_CLOCK_TICKS_PER_SEC` config option, and with the default
+ * setting of 100, system time is updated in increments of 10ms.
+ *
+ * @return Current uptime in milliseconds.
  */
 __syscall u32_t k_uptime_get_32(void);
 


### PR DESCRIPTION
While k_uptime_get() and k_uptime_get32() return time in
milliseconds, they don't need to have millisecond resolution.
Resolution with default Zephyr settings in 10ms.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>