### PR TITLE
doc: fix broken link in board doc

### DIFF
--- a/boards/arm/atsamd20_xpro/doc/atsamd20_xpro.rst
+++ b/boards/arm/atsamd20_xpro/doc/atsamd20_xpro.rst
@@ -134,7 +134,7 @@ References
 .. target-notes::
 
 .. _Microchip website:
-    www.microchip.com/DevelopmentTools/ProductDetails.aspx?PartNO=ATSAMD20-XPRO
+    https://www.microchip.com/DevelopmentTools/ProductDetails.aspx?PartNO=ATSAMD20-XPRO
 
 .. _SAM D20 Xplained Pro Schematic:
     http://ww1.microchip.com/downloads/en/DeviceDoc/SAMD20-Xplained-Pro_Design-Documentation.zip


### PR DESCRIPTION
Link was missing a protocol (https://) so was picked up as a relative
link.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>