### PR TITLE
doc/CMakeLists.txt: find sphinx-build-3 before sphinx-build

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(LATEX)
 
 find_program(
   SPHINXBUILD
-  sphinx-build
+  NAMES sphinx-build-3 sphinx-build
   )
 if(${SPHINXBUILD} STREQUAL SPHINXBUILD-NOTFOUND)
   message(FATAL_ERROR "The 'sphinx-build' command was not found. Make sure you have Sphinx installed.")


### PR DESCRIPTION
On (at least) Fedora the /usr/bin/sphinx-build binary always belong to
python2-sphinx which results in a confusing "cannot import name
DEVNULL" error below (DEVNULL is available from python 3.3).

Tell find_program() to look for sphinx-build-3 first and then
sphinx-build next.

(shorten) Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/sphinx/config.py",
    line 161, in __init__ execfile_(filename, config)
  ...
  File "conf.py", line 17, in <module>
    from subprocess import CalledProcessError, check_output, DEVNULL
ImportError: cannot import name DEVNULL

Signed-off-by: Marc Herbert <marc.herbert@intel.com>