### PR TITLE
shell: Allocate proper amount of history slab memory

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -493,7 +493,7 @@ extern void shell_print_stream(const void *user_ctx, const char *data,
 	SHELL_LOG_BACKEND_DEFINE(_name, _name##_out_buffer,		      \
 				 CONFIG_SHELL_PRINTF_BUFF_SIZE,		      \
 				 _log_queue_size, _log_timeout);	      \
-	SHELL_HISTORY_DEFINE(_name, 128, 8);/*todo*/			      \
+	SHELL_HISTORY_DEFINE(_name, CONFIG_SHELL_CMD_BUFF_SIZE, 7);	      \
 	SHELL_FPRINTF_DEFINE(_name##_fprintf, &_name, _name##_out_buffer,     \
 			     CONFIG_SHELL_PRINTF_BUFF_SIZE,		      \
 			     true, shell_print_stream);			      \

--- a/include/shell/shell_history.h
+++ b/include/shell/shell_history.h
@@ -22,11 +22,19 @@ struct shell_history {
 	sys_dlist_t list;
 	sys_dnode_t *current;
 };
+
+struct shell_history_item {
+	sys_dnode_t dnode;
+	u16_t len;
+	char data[];
+};
+
 #if CONFIG_SHELL_HISTORY
 #define SHELL_HISTORY_DEFINE(_name, block_size, block_count)	\
 								\
 	K_MEM_SLAB_DEFINE(_name##_history_memslab,		\
-			  block_size, block_count, 4);		\
+		 ROUND_UP(block_size + sizeof(struct shell_history_item), \
+			  sizeof(void *)), block_count, 4);		\
 	static struct shell_history _name##_history = {		\
 		.mem_slab = &_name##_history_memslab		\
 	}

--- a/subsys/shell/shell_history.c
+++ b/subsys/shell/shell_history.c
@@ -7,12 +7,6 @@
 #include <shell/shell_history.h>
 #include <string.h>
 
-struct shell_history_item {
-	sys_dnode_t dnode;
-	u16_t len;
-	char data[1];
-};
-
 void shell_history_mode_exit(struct shell_history *history)
 {
 	history->current = NULL;


### PR DESCRIPTION
This patch increases the amount of slab memory per item for the shell
history to match the maximum command input buffer size plus the
accounting information for the dnode list item.

Signed-off-by: Andy Gross <andy.gross@linaro.org>