### PR TITLE
boards: nrf: Indicate watchdog as supported on Nordic DK boards

### DIFF
--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.yaml
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.yaml
@@ -11,6 +11,7 @@ supported:
   - adc
   - ble
   - nvs
+  - watchdog
 testing:
   default: true
   ignore_tags:

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.yaml
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.yaml
@@ -11,3 +11,4 @@ supported:
   - usb_device
   - ble
   - ieee802154
+  - watchdog

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
@@ -13,3 +13,4 @@ supported:
   - nvs
   - i2c
   - spi
+  - watchdog

--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090.yaml
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090.yaml
@@ -9,3 +9,4 @@ ram: 64
 flash: 256
 supported:
   - i2c
+  - watchdog

--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090ns.yaml
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090ns.yaml
@@ -9,3 +9,4 @@ ram: 128
 flash: 256
 supported:
   - i2c
+  - watchdog

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -144,6 +144,7 @@
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
 			interrupts = <16 1>;
+			status = "ok";
 			label = "WDT";
 		};
 	};

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -130,6 +130,7 @@
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
 			interrupts = <16 1>;
+			status = "ok";
 			label = "WDT";
 		};
 	};

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -184,6 +184,7 @@
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
 			interrupts = <16 1>;
+			status = "ok";
 			label = "WDT";
 		};
 	};

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -245,6 +245,7 @@
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
 			interrupts = <16 1>;
+			status = "ok";
 			label = "WDT";
 		};
 

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -218,6 +218,7 @@ wdt: watchdog@18000 {
 	compatible = "nordic,nrf-watchdog";
 	reg = <0x18000 0x1000>;
 	interrupts = <24 1>;
+	status = "ok";
 	label = "WDT";
 };
 


### PR DESCRIPTION
Indicate that watchdog is supported on several Nordic DK boards
so that the wdt_nrfx driver is covered by CI builds.

Related to #12860.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>