### PR TITLE
sanitycheck: return build.log when we think we crashed

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2382,11 +2382,16 @@ class TestSuite:
                     message=goal.reason)
                 p = ("%s/%s/%s" % (options.outdir, i.platform.name, i.test.name))
                 bl = os.path.join(p, "build.log")
+                hl = os.path.join(p, "handler.log")
+                log_file = bl
                 if goal.reason != 'build_error':
-                    bl = os.path.join(p, "handler.log")
+                    if os.path.exists(hl):
+                        log_file = hl
+                    else:
+                        log_file = bl
 
-                if os.path.exists(bl):
-                    with open(bl, "rb") as f:
+                if os.path.exists(log_file):
+                    with open(log_file, "rb") as f:
                         log = f.read().decode("utf-8")
                         filtered_string = ''.join(filter(lambda x: x in string.printable, log))
                         failure.text = filtered_string


### PR DESCRIPTION
In some cases sanitycheck handles a build error that started with 'make
run' as a handler crash when it actually failed during building. Right
now we try to attach the handler.log to the XML output even if it did
not exist. Check for the file and if it was not found, go back to the
build.log