### PR TITLE
dts: Fix varying baudrate settings for CAN

### DIFF
--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -59,7 +59,7 @@
 &can1 {
 	pinctrl-0 = <&can_pins_a>;
 	pinctrl-names = "default";
-	bus-speed = <250000>;
+	bus-speed = <125000>;
 	status = "ok";
 };
 

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -276,10 +276,10 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
 			label = "CAN_1";
-			bus-speed = <250000>;
+			bus-speed = <125000>;
 			sjw = <1>;
-			prop_seg_phase_seg1 = <5>;
-			phase_seg2 = <6>;
+			prop_seg_phase_seg1 = <4>;
+			phase_seg2 = <5>;
 		};
 
 		rtc: rtc@40002800 {


### PR DESCRIPTION
This commit fixes the varying baudrate settings for the STM32L4
and STM32F072.

Signed-off-by: Alexander Wachter <alexander.wachter@student.tugraz.at>