### PR TITLE
doc: add clean target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Top level makefile for things not covered by cmake
+# Top level makefile for documentation build
 #
 
 ifndef ZEPHYR_BASE
@@ -12,6 +12,9 @@ SPHINXOPTS ?= -q
 
 # Documentation targets
 # ---------------------------------------------------------------------------
+clean:
+	rm -rf ${BUILDDIR}
+
 htmldocs:
 	mkdir -p ${BUILDDIR} && cmake -GNinja -DDOC_TAG=${DOC_TAG} -DSPHINXOPTS=${SPHINXOPTS} -B${BUILDDIR} -Hdoc/ && ninja -C ${BUILDDIR} htmldocs
 


### PR DESCRIPTION
Top-level Makefile is for documentation build convenience, so make it a
bit more convenient by adding a make clean target (sometimes needed when
to do a clean doc build when changes are made).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>