### PR TITLE
Documenting enablement of UART1 support for nrf52840_pca10056

### DIFF
--- a/boards/arm/nrf52840_pca10056/doc/nrf52840_pca10056.rst
+++ b/boards/arm/nrf52840_pca10056/doc/nrf52840_pca10056.rst
@@ -167,6 +167,57 @@ You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in :file:
 `boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts`.
 
+Using UART1
+***********
+
+The following approach can be used when an application needs to use
+more than one UART for connecting peripheral devices:
+
+1. Add device tree overlay file to the main directory of your application:
+
+   .. code-block:: console
+
+      $ cat nrf52840_pca10056.overlay
+      &uart1 {
+        compatible = "nordic,nrf-uarte";
+        current-speed = <115200>;
+        status = "ok";
+        tx-pin = <14>;
+        rx-pin = <16>;
+      };
+
+   In the overlay file above, pin P0.16 is used for RX and P0.14 is used for TX
+
+2. Go to menuconfig and enable :option:`CONFIG_UART_1_NRF_UARTE`:
+
+   (top menu) -> Device Drivers -> Serial Drivers -> nRF UART nrfx drivers
+
+3. Use the UART1 as ``device_get_binding("UART_1")``
+
+Overlay file naming
+===================
+The file has to be named ``<board>.overlay`` and placed in the app main directory to be
+picked up automatically by the device tree compiler.
+
+Selecting the pins
+==================
+To select the pin numbers for tx-pin and rx-pin:
+
+.. code-block:: console
+
+   tx-pin = <pin_no>
+
+Open the `nRF52840 Product Specification`_, chapter 7 'Hardware and Layout'.
+In the table 7.1.1 'aQFN73 ball assignments' select the pins marked
+'General purpose I/O'.  Note that pins marked as 'low frequency I/O only' can only be used
+in under-10KHz applications. They are not sutiable for 115200 speed of UART.
+
+Translate 'Pin' into number for Device tree by using the following formula::
+
+   pin_no = b\*32 + a
+
+where ``a`` and ``b`` are from the Pin value in the table (Pb.a).
+For example, for P0.1, ``pin_no = 1`` and for P1.0, ``pin_no = 32``.
 
 References
 **********
@@ -176,4 +227,4 @@ References
 .. _nRF52840 PDK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK
 .. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
 .. _J-Link Software and documentation pack: https://www.segger.com/jlink-software.html
-
+.. _nRF52840 Product Specification: http://infocenter.nordicsemi.com/pdf/nRF52840_PS_v1.0.pdf


### PR DESCRIPTION
Adding a set of BKMs on how to enable and configure UART1
for the nrf52840_pca10056 board. This instructions are likely valid
to most other nrf52840- family of boards.

Signed-off-by: Andrei Laperie <andrei.laperie@intel.com>