### PR TITLE
kernel: Enforce k_mem_slab block size alignment

### DIFF
--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -73,6 +73,10 @@ SYS_INIT(init_mem_slab_module, PRE_KERNEL_1,
 void k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
 		    size_t block_size, u32_t num_blocks)
 {
+	/* block size must be word aligned */
+	__ASSERT((slab->block_size & (sizeof(void *) - 1)) == 0,
+		 "block size not word aligned");
+
 	slab->num_blocks = num_blocks;
 	slab->block_size = block_size;
 	slab->buffer = buffer;
@@ -88,6 +92,10 @@ int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, s32_t timeout)
 {
 	unsigned int key = irq_lock();
 	int result;
+
+	/* block size must be word aligned */
+	__ASSERT((slab->block_size & (sizeof(void *) - 1)) == 0,
+		 "block size not word aligned");
 
 	if (slab->free_list != NULL) {
 		/* take a free block */


### PR DESCRIPTION
This patch puts checks in place to ensure that callers to the k_mem_slab
APIs provide word aligned block sizes.  If this is not done, this can
result in unaligned accesses and subsequent crashes.

Signed-off-by: Andy Gross <andy.gross@linaro.org>