### PR TITLE
tests: usb: Include desc_sections test for native_posix

### DIFF
--- a/tests/subsys/usb/desc_sections/testcase.yaml
+++ b/tests/subsys/usb/desc_sections/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   usb.desc_sections:
-    platform_whitelist: frdm_k64f
+    platform_whitelist: frdm_k64f native_posix
     tags: usb desc_sections


### PR DESCRIPTION
After including native_posix USB controller we can perform some simple
tests on native_posix.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>