### PR TITLE
Fix compile error with CONFIG_NRFX_USB and CONFIG_NEWLIB_LIBC

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1243,7 +1243,7 @@ static void usbd_work_handler(struct k_work *item)
 				break;
 			}
 		default:
-			LOG_ERR("Unknown USBD event: %"PRIu32".", ev->evt_type);
+			LOG_ERR("Unknown USBD event: %"PRId16".", ev->evt_type);
 			break;
 		}
 		usbd_evt_free(ev);

--- a/ext/hal/nordic/nrfx/drivers/src/nrfx_usbd.c
+++ b/ext/hal/nordic/nrfx/drivers/src/nrfx_usbd.c
@@ -265,7 +265,7 @@ static uint32_t m_ep_ready;
  * Mask prepared USBD data for transmission.
  * It is cleared when no more data to transmit left.
  */
-static uint32_t m_ep_dma_waiting;
+static atomic_t m_ep_dma_waiting;
 
 /**
  * @brief Current EasyDMA state.
@@ -850,7 +850,7 @@ void nrfx_usbd_ep_abort(nrfx_usbd_ep_t ep)
  */
 static void usbd_ep_abort_all(void)
 {
-    uint32_t ep_waiting = m_ep_dma_waiting | (m_ep_ready & NRFX_USBD_EPOUT_BIT_MASK);
+    atomic_t ep_waiting = m_ep_dma_waiting | (m_ep_ready & NRFX_USBD_EPOUT_BIT_MASK);
     while (0 != ep_waiting)
     {
         uint8_t bitpos = __CLZ(__RBIT(ep_waiting));

--- a/ext/hal/nordic/nrfx_glue.h
+++ b/ext/hal/nordic/nrfx_glue.h
@@ -62,7 +62,7 @@ extern "C" {
  * @param expression  Expression to evaluate.
  */
 #define NRFX_STATIC_ASSERT(expression) \
-        static_assert(expression, "assertion failed")
+        BUILD_ASSERT_MSG(expression, "assertion failed")
 
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
We can not build with CONFIG_NRFX_USB and CONFIG_NEWLIB_LIBC in current tree and I fixed it.
I'm using zephyr-sdk-0.9.5 .