### PR TITLE
SOCKS5 proxy support for the MQTT client (TCP)

### DIFF
--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -348,6 +348,11 @@ enum mqtt_transport_type {
 	MQTT_TRANSPORT_SECURE,
 #endif /* CONFIG_MQTT_LIB_TLS */
 
+#if defined(CONFIG_MQTT_LIB_SOCKS)
+	/** Use SOCKS5 proxy for MQTT connection. */
+	MQTT_TRANSPORT_SOCKS,
+#endif /* CONFIG_MQTT_LIB_SOCKS */
+
 	/** Shall not be used as a transport type.
 	 *  Indicator of maximum transport types possible.
 	 */
@@ -381,6 +386,18 @@ struct mqtt_transport {
 			struct mqtt_sec_config config;
 		} tls;
 #endif /* CONFIG_MQTT_LIB_TLS */
+
+#if defined(CONFIG_MQTT_LIB_SOCKS)
+		/* SOCKS5 proxy transport for MQTT */
+		struct {
+			/** Socket descriptor. */
+			int sock;
+
+			/** SOCKS5 proxy address. */
+			struct sockaddr_storage *proxy;
+		} socks5;
+#endif /* CONFIG_MQTT_LIB_SOCKS */
+
 	};
 };
 

--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -341,17 +341,17 @@ struct mqtt_sec_config {
 /** @brief MQTT transport type. */
 enum mqtt_transport_type {
 	/** Use non secure TCP transport for MQTT connection. */
-	MQTT_TRANSPORT_NON_SECURE = 0x00,
+	MQTT_TRANSPORT_NON_SECURE,
 
 #if defined(CONFIG_MQTT_LIB_TLS)
 	/** Use secure TCP transport (TLS) for MQTT connection. */
-	MQTT_TRANSPORT_SECURE     = 0x01,
+	MQTT_TRANSPORT_SECURE,
 #endif /* CONFIG_MQTT_LIB_TLS */
 
 	/** Shall not be used as a transport type.
 	 *  Indicator of maximum transport types possible.
 	 */
-	MQTT_TRANSPORT_NUM        = 0x02
+	MQTT_TRANSPORT_NUM
 };
 
 /** @brief MQTT transport specific data. */

--- a/include/net/socks.h
+++ b/include/net/socks.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 Antmicro Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_NET_SOCKS_H_
+#define ZEPHYR_INCLUDE_NET_SOCKS_H_
+
+#include <net/socket.h>
+
+/**@brief Connects to destination through a SOCKS5 proxy server.
+ *
+ * @param[in] proxy Address of the proxy server.
+ * @param[in] destination Address of the destination server.
+ *
+ * @retval File descriptor of the opened connection or an error code if it was
+ *         unsuccessful.
+ */
+#if defined(CONFIG_SOCKS)
+int socks5_client_tcp_connect(const struct sockaddr *proxy,
+			      const struct sockaddr *destination);
+#else
+inline int socks5_client_tcp_connect(const struct sockaddr *proxy,
+				     const struct sockaddr *destination)
+{
+	ARG_UNUSED(proxy);
+	ARG_UNUSED(destination);
+
+	return 0;
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_NET_SOCKS_H_ */

--- a/samples/net/mqtt_publisher/src/config.h
+++ b/samples/net/mqtt_publisher/src/config.h
@@ -25,6 +25,11 @@
 #endif
 #endif
 
+#if defined(CONFIG_MQTT_LIB_SOCKS)
+#define SOCKS5_PROXY_ADDR	SERVER_ADDR
+#define SOCKS5_PROXY_PORT	1080
+#endif
+
 #ifdef CONFIG_MQTT_LIB_TLS
 #define SERVER_PORT		8883
 #else

--- a/subsys/net/lib/CMakeLists.txt
+++ b/subsys/net/lib/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory_if_kconfig(coap)
 add_subdirectory_if_kconfig(lwm2m)
+add_subdirectory_if_kconfig(socks)
 add_subdirectory_if_kconfig(sntp)
 add_subdirectory_ifdef(CONFIG_DNS_RESOLVER      dns)
 add_subdirectory_ifdef(CONFIG_MQTT_LIB          mqtt)

--- a/subsys/net/lib/Kconfig
+++ b/subsys/net/lib/Kconfig
@@ -16,6 +16,8 @@ source "subsys/net/lib/http/Kconfig"
 
 source "subsys/net/lib/lwm2m/Kconfig"
 
+source "subsys/net/lib/socks/Kconfig"
+
 source "subsys/net/lib/sntp/Kconfig"
 
 endmenu

--- a/subsys/net/lib/mqtt/CMakeLists.txt
+++ b/subsys/net/lib/mqtt/CMakeLists.txt
@@ -12,3 +12,7 @@ zephyr_library_sources(
 zephyr_library_sources_ifdef(CONFIG_MQTT_LIB_TLS
   mqtt_transport_socket_tls.c
   )
+
+zephyr_library_sources_ifdef(CONFIG_MQTT_LIB_SOCKS
+  mqtt_transport_socks.c
+  )

--- a/subsys/net/lib/mqtt/Kconfig
+++ b/subsys/net/lib/mqtt/Kconfig
@@ -32,4 +32,10 @@ config MQTT_LIB_TLS
 	help
 	  Enable TLS support for socket MQTT Library
 
+config MQTT_LIB_SOCKS
+	bool "SOCKS proxy support for socket MQTT Library"
+	select SOCKS
+	help
+	  Enable SOCKS proxy support for socket MQTT Library
+
 endif # MQTT_LIB

--- a/subsys/net/lib/mqtt/mqtt_transport.c
+++ b/subsys/net/lib/mqtt/mqtt_transport.c
@@ -29,6 +29,11 @@ extern int mqtt_client_tls_read(struct mqtt_client *client, u8_t *data,
 extern int mqtt_client_tls_disconnect(struct mqtt_client *client);
 #endif /* CONFIG_MQTT_LIB_TLS */
 
+#if defined(CONFIG_MQTT_LIB_SOCKS)
+/* Transport handler functions for SOCKS5 proxy socket transport. */
+extern int mqtt_client_socks5_connect(struct mqtt_client *client);
+#endif /* CONFIG_MQTT_LIB_SOCKS */
+
 /**@brief Function pointer array for TCP/TLS transport handlers. */
 const struct transport_procedure transport_fn[MQTT_TRANSPORT_NUM] = {
 	{
@@ -43,8 +48,16 @@ const struct transport_procedure transport_fn[MQTT_TRANSPORT_NUM] = {
 		mqtt_client_tls_write,
 		mqtt_client_tls_read,
 		mqtt_client_tls_disconnect,
-	}
+	},
 #endif /* CONFIG_MQTT_LIB_TLS */
+#if defined(CONFIG_MQTT_LIB_SOCKS)
+	{
+		mqtt_client_socks5_connect,
+		mqtt_client_tcp_write,
+		mqtt_client_tcp_read,
+		mqtt_client_tcp_disconnect,
+	},
+#endif /* CONFIG_MQTT_LIB_SOCKS */
 };
 
 int mqtt_transport_connect(struct mqtt_client *client)

--- a/subsys/net/lib/mqtt/mqtt_transport_socks.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socks.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019 Antmicro Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @file mqtt_transport_socks.c
+ *
+ * @brief Internal functions to handle transport over SOCKS5 proxy.
+ */
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(net_mqtt_socks, CONFIG_MQTT_LOG_LEVEL);
+
+#include <errno.h>
+#include <net/socket.h>
+#include <net/socks.h>
+#include <net/mqtt.h>
+
+#include "mqtt_os.h"
+
+/**@brief Handles connect request for TCP socket transport.
+ *
+ * @param[in] client Identifies the client on which the procedure is requested.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ */
+int mqtt_client_socks5_connect(struct mqtt_client *client)
+{
+	const struct sockaddr *broker = client->broker;
+	const struct sockaddr *proxy =
+		(struct sockaddr *)client->transport.socks5.proxy;
+
+	if (proxy == NULL || broker == NULL) {
+		return -EINVAL;
+	}
+
+	client->transport.socks5.sock =
+		socks5_client_tcp_connect(proxy, broker);
+
+	if (client->transport.socks5.sock < 0) {
+		return client->transport.socks5.sock;
+	}
+
+	MQTT_TRC("Connect completed");
+	return 0;
+}

--- a/subsys/net/lib/socks/CMakeLists.txt
+++ b/subsys/net/lib/socks/CMakeLists.txt
@@ -1,0 +1,3 @@
+zephyr_library()
+
+zephyr_library_sources_if_kconfig(socks.c)

--- a/subsys/net/lib/socks/Kconfig
+++ b/subsys/net/lib/socks/Kconfig
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2018 Antmicro Ltd
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menuconfig SOCKS
+	bool "SOCKS5 proxy"
+	select NET_SOCKETS
+	select NET_SOCKETS_POSIX_NAMES
+	help
+	  Enable SOCKS5 proxy support
+
+if SOCKS
+
+module = SOCKS
+module-dep = NET_LOG
+module-str = Log level for SOCKS proxy
+module-help = Enable debug messages for SOCKS5 protocol
+source "subsys/net/Kconfig.template.log_config.net"
+
+endif # SOCKS

--- a/subsys/net/lib/socks/socks.c
+++ b/subsys/net/lib/socks/socks.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2019 Antmicro Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(net_socks, CONFIG_SOCKS_LOG_LEVEL);
+
+#include <zephyr.h>
+#include <net/socket.h>
+#include <net/socks.h>
+
+#include "socks_internal.h"
+
+static int socks5_tcp_send(int fd, u8_t *data, u32_t len)
+{
+	u32_t offset = 0U;
+	int ret;
+
+	while (offset < len) {
+		ret = send(fd, data + offset, len - offset, 0);
+		if (ret < 0) {
+			return ret;
+		}
+
+		offset += ret;
+	}
+
+	return 0;
+}
+
+static int socks5_tcp_recv(int fd, u8_t *data, u32_t len)
+{
+	u32_t offset = 0U;
+	int ret;
+
+	while (offset < len) {
+		ret = recv(fd, data + offset, len - offset, 0);
+		if (ret < 0) {
+			return ret;
+		}
+
+		offset += ret;
+	}
+
+	return 0;
+}
+
+int socks5_client_tcp_connect(const struct sockaddr *proxy,
+			      const struct sockaddr *destination)
+{
+	struct socks5_method_request mthd_req;
+	struct socks5_method_response mthd_rep;
+	struct socks5_command_request cmd_req;
+	struct socks5_command_response cmd_rep;
+	int size;
+	int ret;
+	int fd;
+
+	fd = socket(proxy->sa_family, SOCK_STREAM, IPPROTO_TCP);
+	if (fd < 0) {
+		return fd;
+	}
+
+	ret = connect(fd, proxy, sizeof(struct sockaddr_in));
+	if (ret < 0) {
+		LOG_ERR("Unable to connect to the proxy server");
+		(void)close(fd);
+		return ret;
+	}
+
+	/* Negotiate authentication method */
+	mthd_req.r.ver = SOCKS5_PKT_MAGIC;
+
+	/* We only support NOAUTH at the moment */
+	mthd_req.r.nmethods = 1;
+	mthd_req.methods[0] = SOCKS5_AUTH_METHOD_NOAUTH;
+
+	/* size + 1 because just one method is supported */
+	size = sizeof(struct socks5_method_request_common) + 1;
+
+	ret = socks5_tcp_send(fd, (u8_t *)&mthd_req, size);
+	if (ret < 0) {
+		(void)close(fd);
+		LOG_ERR("Could not send negotiation packet");
+		return ret;
+	}
+
+	ret = socks5_tcp_recv(fd, (u8_t *)&mthd_rep, sizeof(mthd_rep));
+	if (ret < 0) {
+		LOG_ERR("Could not receive negotiation response");
+		(void)close(fd);
+		return ret;
+	}
+
+	if (mthd_rep.ver != SOCKS5_PKT_MAGIC) {
+		LOG_ERR("Invalid negotiation response magic");
+		(void)close(fd);
+		return -EINVAL;
+	}
+
+	if (mthd_rep.method != SOCKS5_AUTH_METHOD_NOAUTH) {
+		LOG_ERR("Invalid negotiation response");
+		(void)close(fd);
+		return -ENOTSUP;
+	}
+
+	/* Negotiation complete - now connect to destination */
+	cmd_req.r.ver = SOCKS5_PKT_MAGIC;
+	cmd_req.r.cmd = SOCKS5_CMD_CONNECT;
+	cmd_req.r.rsv = SOCKS5_PKT_RSV;
+
+	if (proxy->sa_family == AF_INET) {
+		const struct sockaddr_in *d4 =
+			(struct sockaddr_in *)destination;
+
+		cmd_req.r.atyp = SOCKS5_ATYP_IPV4;
+
+		memcpy(&cmd_req.ipv4_addr.addr,
+		       (u8_t *)&d4->sin_addr,
+		       sizeof(cmd_req.ipv4_addr.addr));
+
+		cmd_req.ipv4_addr.port = d4->sin_port;
+
+		size = sizeof(struct socks5_command_request_common)
+			+ sizeof(struct socks5_ipv4_addr);
+	} else if (proxy->sa_family == AF_INET6) {
+		const struct sockaddr_in6 *d6 =
+			(struct sockaddr_in6 *)destination;
+
+		cmd_req.r.atyp = SOCKS5_ATYP_IPV6;
+
+		memcpy(&cmd_req.ipv6_addr.addr,
+		       (u8_t *)&d6->sin6_addr,
+		       sizeof(cmd_req.ipv6_addr.addr));
+
+		cmd_req.ipv4_addr.port = d6->sin6_port;
+
+		size = sizeof(struct socks5_command_request_common)
+			+ sizeof(struct socks5_ipv6_addr);
+	}
+
+	ret = socks5_tcp_send(fd, (u8_t *)&cmd_req, size);
+	if (ret < 0) {
+		LOG_ERR("Could not send CONNECT command");
+		(void)close(fd);
+		return -EINVAL;
+	}
+
+	ret = socks5_tcp_recv(fd, (u8_t *)&cmd_rep, size);
+	if (ret < 0) {
+		LOG_ERR("Could not receive CONNECT response");
+		(void)close(fd);
+		return -EINVAL;
+	}
+
+	if (cmd_rep.r.ver != SOCKS5_PKT_MAGIC) {
+		LOG_ERR("Invalid CONNECT response");
+		(void)close(fd);
+		return -EINVAL;
+	}
+
+	if (cmd_rep.r.rep != SOCKS5_CMD_RESP_SUCCESS) {
+		LOG_ERR("Unable to connect to destination");
+		(void)close(fd);
+		return -EINVAL;
+	}
+
+	/* Verifying the rest is not required */
+
+	LOG_DBG("Connection through SOCKS5 proxy successful");
+
+	return fd;
+}

--- a/subsys/net/lib/socks/socks_internal.h
+++ b/subsys/net/lib/socks/socks_internal.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2018 Antmicro Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SUBSYS_NET_LIB_SOCKS_SOCKS_INTERNAL_H_
+#define ZEPHYR_SUBSYS_NET_LIB_SOCKS_SOCKS_INTERNAL_H_
+
+#define SOCKS5_PKT_MAGIC			0x05
+#define SOCKS5_PKT_RSV				0x00
+
+#define SOCKS5_AUTH_METHOD_NOAUTH		0x00
+#define SOCKS5_AUTH_METHOD_GSSAPI		0x01
+#define SOCKS5_AUTH_METHOD_USERPASS		0x02
+#define SOCKS5_AUTH_METHOD_NONEG		0xFF
+
+#define SOCKS5_CMD_CONNECT			0x01
+#define SOCKS5_CMD_BIND				0x02
+#define SOCKS5_CMD_UDP_ASSOCIATE		0x03
+
+#define SOCKS5_ATYP_IPV4			0x01
+#define SOCKS5_ATYP_DOMAINNAME			0x03
+#define SOCKS5_ATYP_IPV6			0x04
+
+#define SOCKS5_CMD_RESP_SUCCESS			0x00
+#define SOCKS5_CMD_RESP_FAILURE			0x01
+#define SOCKS5_CMD_RESP_NOT_ALLOWED		0x02
+#define SOCKS5_CMD_RESP_NET_UNREACHABLE		0x03
+#define SOCKS5_CMD_RESP_HOST_UNREACHABLE	0x04
+#define SOCKS5_CMD_RESP_REFUSED			0x05
+#define SOCKS5_CMD_RESP_TTL_EXPIRED		0x06
+#define SOCKS5_CMD_RESP_CMD_NOT_SUPPORTED	0x07
+#define SOCKS5_CMD_RESP_ATYP_NOT_SUPPORTED	0x08
+
+struct socks5_method_request_common {
+	u8_t ver;
+	u8_t nmethods;
+} __packed;
+
+struct socks5_method_request {
+	struct socks5_method_request_common r;
+	u8_t methods[255];
+} __packed;
+
+struct socks5_method_response {
+	u8_t ver;
+	u8_t method;
+} __packed;
+
+struct socks5_ipv4_addr {
+	u8_t addr[4];
+	u16_t port;
+} __packed;
+
+struct socks5_ipv6_addr {
+	u8_t addr[16];
+	u16_t port;
+} __packed;
+
+struct socks5_command_request_common {
+	u8_t ver;
+	u8_t cmd;
+	u8_t rsv;
+	u8_t atyp;
+} __packed;
+
+struct socks5_command_request {
+	struct socks5_command_request_common r;
+	union {
+		struct socks5_ipv4_addr ipv4_addr;
+		struct socks5_ipv6_addr ipv6_addr;
+	};
+} __packed;
+
+struct socks5_command_response_common {
+	u8_t ver;
+	u8_t rep;
+	u8_t rsv;
+	u8_t atyp;
+} __packed;
+
+struct socks5_command_response {
+	struct socks5_command_response_common r;
+	union {
+		struct socks5_ipv4_addr ipv4_addr;
+		struct socks5_ipv6_addr ipv6_addr;
+	};
+} __packed;
+
+#endif /* ZEPHYR_SUBSYS_NET_LIB_SOCKS_SOCKS_INTERNAL_H_ */


### PR DESCRIPTION
The use-case is to be able to connect to a MQTT broker (cloud) from a corporate network. To do that a proxy is needed.

For test purposes though, the SOCKS5 proxy server is opened at the same ip as the MQTT broker.

The following assumptions are made:
```
10.0.0.116 - IP address of the proxy server and the mosquito broker
1883       - MQTT port
1080       - SOCKS5 proxy port
```

Sample setup:
```
$ sudo mosquitto -v -p 1883
```
And:
```
$ ssh -N -D 10.0.0.116:1080 10.0.0.116
```

With the default configuration of the `mqtt_publisher` sample - everything should work as earlier. After enabling `CONFIG_SOCKS` in menuconfig, the `mqtt_publisher` should attempt to connect to the broker through a proxy server.

The SOCKS5 implementation here is very limited. Basically only the features needed for the single use-case are implemented.

Thanks to the fact that no other strict SOCKS5 messages will be exchanged in this scenario, the original socks5 socket can be used by the mqtt lib after initializing the connection - this allows us to modify only the connect part of the mqtt lib and leave the rest untouched.