### PR TITLE
Arch arm add option to enable stackalign

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -282,7 +282,10 @@ config STACK_ALIGN_DOUBLE_WORD
 	default y
 	help
 	  This is needed to conform to AAPCS, the procedure call standard for
-	  the ARM. It wastes stack space.
+	  the ARM. It wastes stack space. The option also enforces alignment
+	  of stack upon exception entry on Cortex-M3 and Cortex-M4 (ARMv7-M).
+	  Note that for ARMv6-M, ARMv8-M, and Cortex-M7 MCUs stack alignment
+	  on exception entry is enabled by default and it is not configurable.
 
 config RUNTIME_NMI
 	bool "Attach an NMI handler at runtime"

--- a/arch/arm/include/cortex_m/stack.h
+++ b/arch/arm/include/cortex_m/stack.h
@@ -55,6 +55,17 @@ static ALWAYS_INLINE void _InterruptStackSetup(void)
 #error "Built-in MSP limit checks not supported by HW"
 #endif
 #endif /* CONFIG_BUILTIN_STACK_GUARD */
+
+#if defined(CONFIG_STACK_ALIGN_DOUBLE_WORD)
+	/* Enforce double-word stack alignment on exception entry
+	 * for Cortex-M3 and Cortex-M4 (ARMv7-M) MCUs. For the rest
+	 * of ARM Cortex-M processors this setting is enforced by
+	 * default and it is not configurable.
+	 */
+#if defined(CONFIG_CPU_CORTEX_M3) || defined(CONFIG_CPU_CORTEX_M4)
+	SCB->CCR |= SCB_CCR_STKALIGN_Msk;
+#endif
+#endif /* CONFIG_STACK_ALIGN_DOUBLE_WORD */
 }
 
 #endif /* _ASMLANGUAGE */


### PR DESCRIPTION
Enforcing stack alignment on exception entry for ARM MCUs where this is not default.