### PR TITLE
power: Eliminate SYS_PM_* power states.

### DIFF
--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -113,21 +113,9 @@ can be done in the available time. The power management operation must halt
 execution on a CPU or SOC low power state. Before entering the low power state,
 the SOC interface must setup a wake event.
 
-The power management subsystem expects the :code:`sys_suspend()` to
-return one of the following values based on the power management operations
-the SOC interface executed:
-
-:code:`SYS_PM_NOT_HANDLED`
-
-   Indicates that no power management operations were performed.
-
-:code:`SYS_PM_LOW_POWER_STATE`
-
-   Indicates that the CPU was put in a low power state.
-
-:code:`SYS_PM_DEEP_SLEEP`
-
-   Indicates that the SOC was put in a deep sleep state.
+The power management subsystem expects the :code:`sys_suspend()` to return
+the power state which was used or :code:`SYS_POWER_STATE_ACTIVE` if SoC was
+kept in active state.
 
 Resume Hook function
 ====================
@@ -184,26 +172,26 @@ The power management subsystem classifies power management schemes
 into two categories based on whether the CPU loses execution context during the
 power state transition.
 
-* SYS_PM_LOW_POWER_STATE
-* SYS_PM_DEEP_SLEEP
+* Low Power State
+* Deep Sleep State
 
-SYS_PM_LOW_POWER_STATE
-======================
+Low Power State
+===============
 
 CPU does not lose execution context. Devices also do not lose power while
 entering power states in this category. The wake latencies of power states
 in this category are relatively low.
 
-SYS_PM_DEEP_SLEEP
-=================
+Deep Sleep State
+================
 
 CPU is power gated and loses execution context. Execution will resume at
 OS startup code or at a resume point determined by a bootloader that supports
 deep sleep resume. Depending on the SOC's implementation of the power saving
 feature, it may turn off power to most devices. RAM may be retained by some
 implementations, while others may remove power from RAM saving considerable
-power. Power states in this category save more power than
-`SYS_PM_LOW_POWER_STATE`_ and would have higher wake latencies.
+power. Power states in this category save more power than Low Power states
+and would have higher wake latencies.
 
 Device Power Management Infrastructure
 **************************************
@@ -451,11 +439,11 @@ the following configuration flags.
 
 :option:`CONFIG_SYS_POWER_LOW_POWER_STATE`
 
-   The SOC interface enables this flag to use the :code:`SYS_PM_LOW_POWER_STATE` policy.
+   This flag enables support for the Low Power states.
 
 :option:`CONFIG_SYS_POWER_DEEP_SLEEP`
 
-   This flag enables support for the :code:`SYS_PM_DEEP_SLEEP` policy.
+   This flag enables support for the Deep Sleep states.
 
 :option:`CONFIG_DEVICE_POWER_MANAGEMENT`
 

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -82,7 +82,7 @@ static void sys_power_save_idle(void)
 	/*
 	 * Call the suspend hook function of the soc interface to allow
 	 * entry into a low power state. The function returns
-	 * SYS_PM_NOT_HANDLED if low power state was not entered, in which
+	 * SYS_POWER_STATE_ACTIVE if low power state was not entered, in which
 	 * case, kernel does normal idle processing.
 	 *
 	 * This function is entered with interrupts disabled. If a low power
@@ -92,7 +92,7 @@ static void sys_power_save_idle(void)
 	 * idle processing re-enables interrupts which is essential for
 	 * the kernel's scheduling logic.
 	 */
-	if (sys_suspend(ticks) == SYS_PM_NOT_HANDLED) {
+	if (sys_suspend(ticks) == SYS_POWER_STATE_ACTIVE) {
 		sys_pm_idle_exit_notify = 0U;
 		k_cpu_idle();
 	}

--- a/soc/x86/intel_quark/quark_se/power.c
+++ b/soc/x86/intel_quark/quark_se/power.c
@@ -60,6 +60,7 @@ static void _deep_sleep(enum power_states state)
 void sys_set_power_state(enum power_states state)
 {
 	switch (state) {
+#if (defined(CONFIG_SYS_POWER_LOW_POWER_STATE))
 	case SYS_POWER_STATE_CPU_LPS:
 		qm_power_cpu_c1();
 		break;
@@ -69,6 +70,7 @@ void sys_set_power_state(enum power_states state)
 	case SYS_POWER_STATE_CPU_LPS_2:
 		qm_power_cpu_c2lp();
 		break;
+#endif
 #if (defined(CONFIG_SYS_POWER_DEEP_SLEEP))
 	case SYS_POWER_STATE_DEEP_SLEEP:
 	case SYS_POWER_STATE_DEEP_SLEEP_1:
@@ -83,12 +85,14 @@ void sys_set_power_state(enum power_states state)
 void sys_power_state_post_ops(enum power_states state)
 {
 	switch (state) {
+#if (defined(CONFIG_SYS_POWER_LOW_POWER_STATE))
 	case SYS_POWER_STATE_CPU_LPS_2:
 		*_REG_TIMER_ICR = 1U;
 	case SYS_POWER_STATE_CPU_LPS_1:
 	case SYS_POWER_STATE_CPU_LPS:
 		__asm__ volatile("sti");
 		break;
+#endif
 #if (defined(CONFIG_SYS_POWER_DEEP_SLEEP))
 	case SYS_POWER_STATE_DEEP_SLEEP_1:
 #ifdef CONFIG_ARC_INIT

--- a/subsys/power/policy/pm_policy.h
+++ b/subsys/power/policy/pm_policy.h
@@ -37,7 +37,7 @@ extern void sys_pm_resume_devices(void);
 /**
  * @brief Function to get the next PM state based on the ticks
  */
-extern int sys_pm_policy_next_state(s32_t ticks, enum power_states *state);
+extern enum power_states sys_pm_policy_next_state(s32_t ticks);
 
 /**
  * @brief Application defined function for Lower Power entry

--- a/subsys/power/policy/policy_dummy.c
+++ b/subsys/power/policy/policy_dummy.c
@@ -9,71 +9,33 @@
 #include <soc.h>
 #include "pm_policy.h"
 
-#define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
-LOG_MODULE_DECLARE(power);
+LOG_MODULE_DECLARE(power, CONFIG_PM_LOG_LEVEL);
 
-#if !(defined(CONFIG_SYS_POWER_STATE_CPU_LPS_SUPPORTED) || \
-		defined(CONFIG_SYS_POWER_STATE_CPU_LPS_1_SUPPORTED) || \
-		defined(CONFIG_SYS_POWER_STATE_CPU_LPS_2_SUPPORTED) || \
-		defined(CONFIG_SYS_POWER_STATE_DEEP_SLEEP_SUPPORTED) || \
-		defined(CONFIG_SYS_POWER_STATE_DEEP_SLEEP_1_SUPPORTED) || \
-		defined(CONFIG_SYS_POWER_STATE_DEEP_SLEEP_2_SUPPORTED))
-#error "Enable Low Power States at SoC Level"
-#endif
-
-struct sys_pm_policy {
-	enum power_states pm_state;
-	int sys_state;
-};
-
-/* PM Policy based on SoC/Platform residency requirements */
-static struct sys_pm_policy pm_policy[] = {
-#ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_SUPPORTED
-	{SYS_POWER_STATE_CPU_LPS, SYS_PM_LOW_POWER_STATE},
-#endif
-
-#ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_1_SUPPORTED
-	{SYS_POWER_STATE_CPU_LPS_1, SYS_PM_LOW_POWER_STATE},
-#endif
-
-#ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_2_SUPPORTED
-	{SYS_POWER_STATE_CPU_LPS_2, SYS_PM_LOW_POWER_STATE},
-#endif
-
-#ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_SUPPORTED
-	{SYS_POWER_STATE_DEEP_SLEEP, SYS_PM_DEEP_SLEEP},
-#endif
-
-#ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_1_SUPPORTED
-	{SYS_POWER_STATE_DEEP_SLEEP_1, SYS_PM_DEEP_SLEEP},
-#endif
-
-#ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_2_SUPPORTED
-	{SYS_POWER_STATE_DEEP_SLEEP_2, SYS_PM_DEEP_SLEEP},
-#endif
-};
-
-int sys_pm_policy_next_state(s32_t ticks, enum power_states *pm_state)
+enum power_states sys_pm_policy_next_state(s32_t ticks)
 {
-	static int cur_pm_idx;
-	int i = cur_pm_idx;
+	static u8_t cur_power_state;
+	int i = cur_power_state;
+
+	if (SYS_POWER_STATE_MAX == 0) {
+		/* No power states to go through. */
+		return SYS_POWER_STATE_ACTIVE;
+	}
 
 	do {
-		i = (i + 1) % ARRAY_SIZE(pm_policy);
+		i = (i + 1) % SYS_POWER_STATE_MAX;
 
 #ifdef CONFIG_PM_CONTROL_STATE_LOCK
-		if (!sys_pm_ctrl_is_state_enabled(pm_policy[i].pm_state)) {
+		if (!sys_pm_ctrl_is_state_enabled((enum power_states)(i))) {
 			continue;
 		}
 #endif
-		cur_pm_state = i;
-		*pm_state = pm_policy[cur_pm_state].pm_state;
+		cur_power_state = i;
 
-		LOG_DBG("pm_state: %d, idx: %d\n", *pm_state, i);
-		return pm_policy[cur_pm_state].sys_state;
-	} while (i != curr_pm_idx);
+		LOG_DBG("Selected power state: %u", i);
+		return (enum power_states)(i);
+	} while (i != cur_power_state);
 
 	LOG_DBG("No suitable power state found!");
-	return SYS_PM_NOT_HANDLED;
+	return SYS_POWER_STATE_ACTIVE;
 }

--- a/subsys/power/policy/policy_residency.c
+++ b/subsys/power/policy/policy_residency.c
@@ -15,78 +15,57 @@ LOG_MODULE_DECLARE(power);
 
 #define SECS_TO_TICKS		CONFIG_SYS_CLOCK_TICKS_PER_SEC
 
-#if !(defined(CONFIG_SYS_POWER_STATE_CPU_LPS_SUPPORTED) || \
-		defined(CONFIG_SYS_POWER_STATE_CPU_LPS_1_SUPPORTED) || \
-		defined(CONFIG_SYS_POWER_STATE_CPU_LPS_2_SUPPORTED) || \
-		defined(CONFIG_SYS_POWER_STATE_DEEP_SLEEP_SUPPORTED) || \
-		defined(CONFIG_SYS_POWER_STATE_DEEP_SLEEP_1_SUPPORTED) || \
-		defined(CONFIG_SYS_POWER_STATE_DEEP_SLEEP_2_SUPPORTED))
-#error "Enable Low Power States at SoC Level"
-#endif
-
-struct sys_pm_policy {
-	enum power_states pm_state;
-	int sys_state;
-	int min_residency;
-};
-
 /* PM Policy based on SoC/Platform residency requirements */
-static struct sys_pm_policy pm_policy[] = {
+static const unsigned int pm_min_residency[] = {
 #ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_SUPPORTED
-	{SYS_POWER_STATE_CPU_LPS, SYS_PM_LOW_POWER_STATE,
-			CONFIG_PM_LPS_MIN_RES * SECS_TO_TICKS},
+	CONFIG_PM_LPS_MIN_RES * SECS_TO_TICKS,
 #endif
 
 #ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_1_SUPPORTED
-	{SYS_POWER_STATE_CPU_LPS_1, SYS_PM_LOW_POWER_STATE,
-			CONFIG_PM_LPS_1_MIN_RES * SECS_TO_TICKS},
+	CONFIG_PM_LPS_1_MIN_RES * SECS_TO_TICKS,
 #endif
 
 #ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_2_SUPPORTED
-	{SYS_POWER_STATE_CPU_LPS_2, SYS_PM_LOW_POWER_STATE,
-			CONFIG_PM_LPS_2_MIN_RES * SECS_TO_TICKS},
+	CONFIG_PM_LPS_2_MIN_RES * SECS_TO_TICKS,
 #endif
 
 #ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_SUPPORTED
-	{SYS_POWER_STATE_DEEP_SLEEP, SYS_PM_DEEP_SLEEP,
-			CONFIG_PM_DEEP_SLEEP_MIN_RES * SECS_TO_TICKS},
+	CONFIG_PM_DEEP_SLEEP_MIN_RES * SECS_TO_TICKS,
 #endif
 
 #ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_1_SUPPORTED
-	{SYS_POWER_STATE_DEEP_SLEEP_1, SYS_PM_DEEP_SLEEP,
-			CONFIG_PM_DEEP_SLEEP_1_MIN_RES * SECS_TO_TICKS},
+	CONFIG_PM_DEEP_SLEEP_1_MIN_RES * SECS_TO_TICKS,
 #endif
 
 #ifdef CONFIG_SYS_POWER_STATE_DEEP_SLEEP_2_SUPPORTED
-	{SYS_POWER_STATE_DEEP_SLEEP_2, SYS_PM_DEEP_SLEEP,
-			CONFIG_PM_DEEP_SLEEP_2_MIN_RES * SECS_TO_TICKS},
+	CONFIG_PM_DEEP_SLEEP_2_MIN_RES * SECS_TO_TICKS,
 #endif
 };
 
-int sys_pm_policy_next_state(s32_t ticks, enum power_states *pm_state)
+enum power_states sys_pm_policy_next_state(s32_t ticks)
 {
 	int i;
 
-	if ((ticks != K_FOREVER) && (ticks < pm_policy[0].min_residency)) {
-		LOG_ERR("Not enough time for PM operations: %d\n", ticks);
-		return SYS_PM_NOT_HANDLED;
+	if ((ticks != K_FOREVER) && (ticks < pm_min_residency[0])) {
+		LOG_ERR("Not enough time for PM operations: %d", ticks);
+		return SYS_POWER_STATE_ACTIVE;
 	}
 
-	for (i = ARRAY_SIZE(pm_policy) - 1; i >= 0; i--) {
+	for (i = ARRAY_SIZE(pm_min_residency) - 1; i >= 0; i--) {
 #ifdef CONFIG_PM_CONTROL_STATE_LOCK
-		if (!sys_pm_ctrl_is_state_enabled(pm_policy[i].pm_state)) {
+		if (!sys_pm_ctrl_is_state_enabled((enum power_states)(i))) {
 			continue;
 		}
 #endif
 		if ((ticks == K_FOREVER) ||
-		    (ticks >= pm_policy[i].min_residency)) {
-			*pm_state = pm_policy[i].pm_state;
-			LOG_DBG("ticks: %d, pm_state: %d, min_residency: %d\n",
-				ticks, *pm_state, pm_policy[i].min_residency);
-			return pm_policy[i].sys_state;
+		    (ticks >= pm_min_residency[i])) {
+			LOG_DBG("Selected power state %d "
+					"(ticks: %d, min_residency: %u)",
+					i, ticks, pm_min_residency[i]);
+			return (enum power_states)(i);
 		}
 	}
 
 	LOG_DBG("No suitable power state found!");
-	return SYS_PM_NOT_HANDLED;
+	return SYS_POWER_STATE_ACTIVE;
 }

--- a/tests/kernel/profiling/profiling_api/src/main.c
+++ b/tests/kernel/profiling/profiling_api/src/main.c
@@ -5,6 +5,7 @@
  */
 
 #include <ztest.h>
+#include <power.h>
 #include <irq_offload.h>
 #include <misc/stack.h>
 
@@ -23,7 +24,8 @@ static void tdata_dump_callback(const struct k_thread *thread, void *user_data)
 }
 
 /*power hook functions*/
-int sys_suspend(s32_t ticks)
+
+enum power_states sys_suspend(s32_t ticks)
 {
 	static bool test_flag;
 
@@ -35,7 +37,7 @@ int sys_suspend(s32_t ticks)
 		test_flag = true;
 	}
 
-	return 0;
+	return SYS_POWER_STATE_ACTIVE;
 }
 
 void sys_resume(void)


### PR DESCRIPTION
The power management framework used two different abstractions
to describe power states. The SYS_PM_* given coarse information
what kind of power state (low power or deep sleep) was used,
while the SYS_POWER_STATE_* abstraction provided information
about particular power mode.

This PR removes the SYS_PM_* abstraction as the same
information is already carried in SYS_POWER_STATE_*.