### PR TITLE
arch: arm: fix macro name inside an inline comment

### DIFF
--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -52,7 +52,7 @@ SECTION_FUNC(TEXT, __pendsv)
     mov lr, r1
 #else
     pop {r0, lr}
-#endif /* CONFIG_ARMV6_M_ARMV8M_M_BASELINE */
+#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 #endif /* CONFIG_TRACING */
 
     /* protect the kernel state while we play with the thread lists */


### PR DESCRIPTION
Fix the spelling of CONFIG_ARMV6_M_ARMV8_M_BASELINE inside
an #endif comment.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>