### PR TITLE
tests: kernel: interrupt: Exclude platforms test isnt valid on

### DIFF
--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   arch.interrupt:
     arch_exclude: nios2 riscv32
+    platform_exclude: hexiwear_kw40z frdm_kw41z frdm_kl25z nucleo_f103rb
+        nucleo_f091rc olimexino_stm32 usb_kw24d512 stm32_min_dev v2m_beetle
     tags: interrupt


### PR DESCRIPTION
The test assumes that the last to IRQ numbers will be free, this isn't a
valid assumption and now that we detect multiple ISRs registering for
the some IRQ line, we see failures because of this assumption on some
platforms.  Exclude those platforms from this test for the time being.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>