### PR TITLE
net: gptp: fix src MAC address

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -172,8 +172,8 @@ static struct net_pkt *setup_gptp_frame(struct net_if *iface,
 	net_buf_add(pkt->buffer, sizeof(struct gptp_hdr) + extra_header);
 	net_pkt_set_gptp(pkt, true);
 
-	net_pkt_lladdr_src(pkt)->addr = (u8_t *)net_if_get_link_addr(iface);
-	net_pkt_lladdr_src(pkt)->len = sizeof(struct net_eth_addr);
+	net_pkt_lladdr_src(pkt)->addr = net_if_get_link_addr(iface)->addr;
+	net_pkt_lladdr_src(pkt)->len = net_if_get_link_addr(iface)->len;
 
 	net_pkt_lladdr_dst(pkt)->addr = (u8_t *)&gptp_multicast_eth_addr;
 	net_pkt_lladdr_dst(pkt)->len = sizeof(struct net_eth_addr);


### PR DESCRIPTION
The return value of net_if_get_link_addr points to a struct net_linkaddr
instead of to the raw MAC address. Without this fix the source address
will always end in 06:03 and will most likely be the same for different
boards running the same software.