### PR TITLE
drivers: eth: gmac: keep a reference to the packet fragments

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -111,6 +111,7 @@ static struct net_buf *tx_frag_list_que1[PRIORITY_QUEUE1_TX_DESC_COUNT];
 #if GMAC_PRIORITY_QUEUE_NO == 2
 static struct net_buf *tx_frag_list_que2[PRIORITY_QUEUE2_TX_DESC_COUNT];
 #endif
+#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 /* TX frames accounting list */
 static struct net_pkt *tx_frame_list_que0[CONFIG_NET_PKT_TX_COUNT + 1];
 #if GMAC_PRIORITY_QUEUE_NO >= 1
@@ -118,6 +119,7 @@ static struct net_pkt *tx_frame_list_que1[CONFIG_NET_PKT_TX_COUNT + 1];
 #endif
 #if GMAC_PRIORITY_QUEUE_NO == 2
 static struct net_pkt *tx_frame_list_que2[CONFIG_NET_PKT_TX_COUNT + 1];
+#endif
 #endif
 
 #define MODULO_INC(val, max) {val = (++val < max) ? val : 0; }
@@ -283,7 +285,9 @@ static void tx_descriptors_init(Gmac *gmac, struct gmac_queue *queue)
 
 	/* Reset TX frame list */
 	ring_buf_reset(&queue->tx_frag_list);
+#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 	ring_buf_reset(&queue->tx_frames);
+#endif
 }
 
 #if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
@@ -484,8 +488,8 @@ static void tx_completed(Gmac *gmac, struct gmac_queue *queue)
 	struct gmac_desc_list *tx_desc_list = &queue->tx_desc_list;
 	struct gmac_desc *tx_desc;
 	struct net_buf *frag;
-	struct net_pkt *pkt;
 #if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
+	struct net_pkt *pkt;
 	u16_t vlan_tag = NET_VLAN_TAG_UNSPEC;
 	struct gptp_hdr *hdr;
 	struct eth_sam_dev_data *dev_data =
@@ -508,9 +512,9 @@ static void tx_completed(Gmac *gmac, struct gmac_queue *queue)
 		LOG_DBG("Dropping frag %p", frag);
 
 		if (tx_desc->w1 & GMAC_TXW1_LASTBUFFER) {
+#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 			/* Release net packet to the packet pool */
 			pkt = UINT_TO_POINTER(ring_buf_get(&queue->tx_frames));
-#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 #if defined(CONFIG_NET_VLAN)
 			struct net_eth_hdr *eth_hdr = NET_ETH_HDR(pkt);
 
@@ -526,10 +530,9 @@ static void tx_completed(Gmac *gmac, struct gmac_queue *queue)
 			if (hdr && need_timestamping(hdr)) {
 				net_if_add_tx_timestamp(pkt);
 			}
-#endif
 			net_pkt_unref(pkt);
 			LOG_DBG("Dropping pkt %p", pkt);
-
+#endif
 			break;
 		}
 	}
@@ -540,10 +543,12 @@ static void tx_completed(Gmac *gmac, struct gmac_queue *queue)
  */
 static void tx_error_handler(Gmac *gmac, struct gmac_queue *queue)
 {
-	struct net_pkt *pkt;
 	struct net_buf *frag;
 	struct ring_buf *tx_frag_list = &queue->tx_frag_list;
+#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
+	struct net_pkt *pkt;
 	struct ring_buf *tx_frames = &queue->tx_frames;
+#endif
 
 	queue->err_tx_flushed_count++;
 
@@ -559,6 +564,7 @@ static void tx_error_handler(Gmac *gmac, struct gmac_queue *queue)
 		MODULO_INC(tx_frag_list->tail, tx_frag_list->len);
 	}
 
+#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 	/* Free all pkt resources in the TX path */
 	while (tx_frames->tail != tx_frames->head) {
 		/* Release net packet to the packet pool */
@@ -567,6 +573,7 @@ static void tx_error_handler(Gmac *gmac, struct gmac_queue *queue)
 		LOG_DBG("Dropping pkt %p", pkt);
 		MODULO_INC(tx_frames->tail, tx_frames->len);
 	}
+#endif
 
 	/* Reinitialize TX descriptor list */
 	k_sem_reset(&queue->tx_desc_sem);
@@ -1365,11 +1372,13 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 	 */
 	tx_first_desc->w1 &= ~GMAC_TXW1_USED;
 
+#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 	/* Account for a sent frame */
 	ring_buf_put(&queue->tx_frames, POINTER_TO_UINT(pkt));
 
 	/* pkt is internally queued, so it requires to hold a reference */
 	net_pkt_ref(pkt);
+#endif
 
 	irq_unlock(key);
 
@@ -1897,10 +1906,12 @@ static struct eth_sam_dev_data eth0_data = {
 				.buf = (u32_t *)tx_frag_list_que0,
 				.len = ARRAY_SIZE(tx_frag_list_que0),
 			},
+#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 			.tx_frames = {
 				.buf = (u32_t *)tx_frame_list_que0,
 				.len = ARRAY_SIZE(tx_frame_list_que0),
 			},
+#endif
 		}, {
 			.que_idx = GMAC_QUE_1,
 			.rx_desc_list = {
@@ -1920,10 +1931,12 @@ static struct eth_sam_dev_data eth0_data = {
 				.buf = (u32_t *)tx_frag_list_que1,
 				.len = ARRAY_SIZE(tx_frag_list_que1),
 			},
+#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 			.tx_frames = {
 				.buf = (u32_t *)tx_frame_list_que1,
 				.len = ARRAY_SIZE(tx_frame_list_que1),
 			}
+#endif
 #endif
 		}, {
 			.que_idx = GMAC_QUE_2,
@@ -1944,10 +1957,12 @@ static struct eth_sam_dev_data eth0_data = {
 				.buf = (u32_t *)tx_frag_list_que2,
 				.len = ARRAY_SIZE(tx_frag_list_que2),
 			},
+#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 			.tx_frames = {
 				.buf = (u32_t *)tx_frame_list_que2,
 				.len = ARRAY_SIZE(tx_frame_list_que2),
 			}
+#endif
 #endif
 		}
 	},

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -103,6 +103,14 @@ static struct net_buf *rx_frag_list_que1[PRIORITY_QUEUE1_RX_DESC_COUNT];
 #if GMAC_PRIORITY_QUEUE_NO == 2
 static struct net_buf *rx_frag_list_que2[PRIORITY_QUEUE2_RX_DESC_COUNT];
 #endif
+/* TX buffer accounting list */
+static struct net_buf *tx_frag_list_que0[MAIN_QUEUE_TX_DESC_COUNT];
+#if GMAC_PRIORITY_QUEUE_NO >= 1
+static struct net_buf *tx_frag_list_que1[PRIORITY_QUEUE1_TX_DESC_COUNT];
+#endif
+#if GMAC_PRIORITY_QUEUE_NO == 2
+static struct net_buf *tx_frag_list_que2[PRIORITY_QUEUE2_TX_DESC_COUNT];
+#endif
 /* TX frames accounting list */
 static struct net_pkt *tx_frame_list_que0[CONFIG_NET_PKT_TX_COUNT + 1];
 #if GMAC_PRIORITY_QUEUE_NO >= 1
@@ -274,6 +282,7 @@ static void tx_descriptors_init(Gmac *gmac, struct gmac_queue *queue)
 	tx_desc_list->buf[tx_desc_list->len - 1].w1 |= GMAC_TXW1_WRAP;
 
 	/* Reset TX frame list */
+	ring_buf_reset(&queue->tx_frag_list);
 	ring_buf_reset(&queue->tx_frames);
 }
 
@@ -474,6 +483,7 @@ static void tx_completed(Gmac *gmac, struct gmac_queue *queue)
 {
 	struct gmac_desc_list *tx_desc_list = &queue->tx_desc_list;
 	struct gmac_desc *tx_desc;
+	struct net_buf *frag;
 	struct net_pkt *pkt;
 #if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 	u16_t vlan_tag = NET_VLAN_TAG_UNSPEC;
@@ -492,8 +502,13 @@ static void tx_completed(Gmac *gmac, struct gmac_queue *queue)
 		MODULO_INC(tx_desc_list->tail, tx_desc_list->len);
 		k_sem_give(&queue->tx_desc_sem);
 
+		/* Release net buffer to the buffer pool */
+		frag = UINT_TO_POINTER(ring_buf_get(&queue->tx_frag_list));
+		net_pkt_frag_unref(frag);
+		LOG_DBG("Dropping frag %p", frag);
+
 		if (tx_desc->w1 & GMAC_TXW1_LASTBUFFER) {
-			/* Release net buffer to the buffer pool */
+			/* Release net packet to the packet pool */
 			pkt = UINT_TO_POINTER(ring_buf_get(&queue->tx_frames));
 #if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 #if defined(CONFIG_NET_VLAN)
@@ -526,6 +541,8 @@ static void tx_completed(Gmac *gmac, struct gmac_queue *queue)
 static void tx_error_handler(Gmac *gmac, struct gmac_queue *queue)
 {
 	struct net_pkt *pkt;
+	struct net_buf *frag;
+	struct ring_buf *tx_frag_list = &queue->tx_frag_list;
 	struct ring_buf *tx_frames = &queue->tx_frames;
 
 	queue->err_tx_flushed_count++;
@@ -533,9 +550,18 @@ static void tx_error_handler(Gmac *gmac, struct gmac_queue *queue)
 	/* Stop transmission, clean transmit pipeline and control registers */
 	gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
 
+	/* Free all frag resources in the TX path */
+	while (tx_frag_list->tail != tx_frag_list->head) {
+		/* Release net buffer to the buffer pool */
+		frag = UINT_TO_POINTER(tx_frag_list->buf[tx_frag_list->tail]);
+		net_pkt_frag_unref(frag);
+		LOG_DBG("Dropping frag %p", frag);
+		MODULO_INC(tx_frag_list->tail, tx_frag_list->len);
+	}
+
 	/* Free all pkt resources in the TX path */
 	while (tx_frames->tail != tx_frames->head) {
-		/* Release net buffer to the buffer pool */
+		/* Release net packet to the packet pool */
 		pkt = UINT_TO_POINTER(tx_frames->buf[tx_frames->tail]);
 		net_pkt_unref(pkt);
 		LOG_DBG("Dropping pkt %p", pkt);
@@ -1306,6 +1332,12 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 		__ASSERT(tx_desc_list->head != tx_desc_list->tail,
 			 "tx_desc_list overflow");
 
+		/* Account for a sent frag */
+		ring_buf_put(&queue->tx_frag_list, POINTER_TO_UINT(frag));
+
+		/* frag is internally queued, so it requires to hold a reference */
+		net_pkt_frag_ref(frag);
+
 		irq_unlock(key);
 
 		/* Continue with the rest of fragments (only data) */
@@ -1861,6 +1893,10 @@ static struct eth_sam_dev_data eth0_data = {
 				.buf = (u32_t *)rx_frag_list_que0,
 				.len = ARRAY_SIZE(rx_frag_list_que0),
 			},
+			.tx_frag_list = {
+				.buf = (u32_t *)tx_frag_list_que0,
+				.len = ARRAY_SIZE(tx_frag_list_que0),
+			},
 			.tx_frames = {
 				.buf = (u32_t *)tx_frame_list_que0,
 				.len = ARRAY_SIZE(tx_frame_list_que0),
@@ -1879,6 +1915,10 @@ static struct eth_sam_dev_data eth0_data = {
 			.rx_frag_list = {
 				.buf = (u32_t *)rx_frag_list_que1,
 				.len = ARRAY_SIZE(rx_frag_list_que1),
+			},
+			.tx_frag_list = {
+				.buf = (u32_t *)tx_frag_list_que1,
+				.len = ARRAY_SIZE(tx_frag_list_que1),
 			},
 			.tx_frames = {
 				.buf = (u32_t *)tx_frame_list_que1,
@@ -1899,6 +1939,10 @@ static struct eth_sam_dev_data eth0_data = {
 			.rx_frag_list = {
 				.buf = (u32_t *)rx_frag_list_que2,
 				.len = ARRAY_SIZE(rx_frag_list_que2),
+			},
+			.tx_frag_list = {
+				.buf = (u32_t *)tx_frag_list_que2,
+				.len = ARRAY_SIZE(tx_frag_list_que2),
 			},
 			.tx_frames = {
 				.buf = (u32_t *)tx_frame_list_que2,

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -170,6 +170,7 @@ struct gmac_queue {
 	struct k_sem tx_desc_sem;
 
 	struct ring_buf rx_frag_list;
+	struct ring_buf tx_frag_list;
 	struct ring_buf tx_frames;
 
 	/** Number of RX frames dropped by the driver */

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -171,7 +171,9 @@ struct gmac_queue {
 
 	struct ring_buf rx_frag_list;
 	struct ring_buf tx_frag_list;
+#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 	struct ring_buf tx_frames;
+#endif
 
 	/** Number of RX frames dropped by the driver */
 	volatile u32_t err_rx_frames_dropped;


### PR DESCRIPTION
This is a preliminary PR to fix the issue preventing PR #12563 to be applied. I have labeled it DNM as I believe that the net_buf reference accounting is not thread safe and should be modified the same way the net_pkt reference accounting has been done. I'll look at that and update this PR with a new patch if needed.

Also note that it only solve the problem of the problem of the driver keeping a reference to the packet and not the fragment, however it doesn't solve the PTP issue.
