### PR TITLE
scripts/dts cleanups, part 1

### DIFF
--- a/scripts/dts/devicetree.py
+++ b/scripts/dts/devicetree.py
@@ -261,14 +261,14 @@ def dump_to_dot(nodes, indent=0, start_string='digraph devicetree', name=None):
 
     ref_list = []
     for key, value in nodes.items():
-        if value.get('children'):
+        if value['children']:
             refs = dump_to_dot(value['children'], indent + 1, next_subgraph(), get_dot_node_name(value))
             ref_list.extend(refs)
         else:
             print("%s\"%s\";" % (spaces, get_dot_node_name(value)))
 
     for key, value in nodes.items():
-        refs = dump_all_refs(get_dot_node_name(value), value.get('props', {}), indent)
+        refs = dump_all_refs(get_dot_node_name(value), value['props'], indent)
         ref_list.extend(refs)
 
     if start_string.startswith("digraph"):

--- a/scripts/dts/extract/compatible.py
+++ b/scripts/dts/extract/compatible.py
@@ -36,44 +36,35 @@ class DTCompatible(DTDirective):
             compatible = [compatible, ]
 
         for i, comp in enumerate(compatible):
-            # Generate #define's
-            compat_label = convert_string_to_label(str(comp))
-            compat_defs = 'DT_COMPAT_' + compat_label
-            load_defs = {
-                compat_defs: "1",
-            }
-            insert_defs(node_address, load_defs, {})
-            # Generate #define for BUS a "sensor" might be on
-            # for example:
+            compat_label = convert_string_to_label(comp)
+
+            # Generate #define
+            insert_defs(node_address,
+                        {'DT_COMPAT_' + compat_label: '1'},
+                        {})
+
+            # Generate #define for BUS a "sensor" might be on, for example
             # #define DT_ST_LPS22HB_PRESS_BUS_SPI 1
             if 'parent' in binding:
-                bus = binding['parent']['bus']
-                compat_defs = 'DT_' + compat_label + '_BUS_' + bus.upper()
-                load_defs = {
-                    compat_defs: "1",
-                }
-                insert_defs(node_address, load_defs, {})
+                compat_def = 'DT_' + compat_label + '_BUS_' + \
+                    binding['parent']['bus'].upper()
+                insert_defs(node_address, {compat_def: '1'}, {})
 
         # Generate defines of the form:
         # #define DT_<COMPAT>_<INSTANCE ID> 1
-        instance = reduced[node_address]['instance_id']
-        for k in instance:
-            i = instance[k]
-            compat_instance = 'DT_' + convert_string_to_label(k) + '_' + str(i)
-            load_defs = {
-                compat_instance: "1",
-            }
-            insert_defs(node_address, load_defs, {})
+        for compat, instance_id in reduced[node_address]['instance_id'].items():
+            compat_instance = 'DT_' + convert_string_to_label(compat) + '_' + \
+                str(instance_id)
+
+            insert_defs(node_address, {compat_instance: '1'}, {})
 
             # Generate defines of the form:
             # #define DT_<COMPAT>_<INSTANCE ID>_BUS_<BUS> 1
             if 'parent' in binding:
                 bus = binding['parent']['bus']
-                compat_instance += '_BUS_' + bus.upper()
-                load_defs = {
-                    compat_instance: "1",
-                }
-                insert_defs(node_address, load_defs, {})
+                insert_defs(node_address,
+                            {compat_instance + '_BUS_' + bus.upper(): '1'},
+                            {})
 
 
 ##

--- a/scripts/dts/extract/compatible.py
+++ b/scripts/dts/extract/compatible.py
@@ -36,25 +36,22 @@ class DTCompatible(DTDirective):
             compatible = [compatible, ]
 
         for i, comp in enumerate(compatible):
-            compat_label = convert_string_to_label(comp)
-
             # Generate #define
             insert_defs(node_address,
-                        {'DT_COMPAT_' + compat_label: '1'},
+                        {'DT_COMPAT_' + str_to_label(comp): '1'},
                         {})
 
             # Generate #define for BUS a "sensor" might be on, for example
             # #define DT_ST_LPS22HB_PRESS_BUS_SPI 1
             if 'parent' in binding:
-                compat_def = 'DT_' + compat_label + '_BUS_' + \
+                compat_def = 'DT_' + str_to_label(comp) + '_BUS_' + \
                     binding['parent']['bus'].upper()
                 insert_defs(node_address, {compat_def: '1'}, {})
 
         # Generate defines of the form:
         # #define DT_<COMPAT>_<INSTANCE ID> 1
         for compat, instance_id in reduced[node_address]['instance_id'].items():
-            compat_instance = 'DT_' + convert_string_to_label(compat) + '_' + \
-                str(instance_id)
+            compat_instance = 'DT_' + str_to_label(compat) + '_' + str(instance_id)
 
             insert_defs(node_address, {compat_instance: '1'}, {})
 

--- a/scripts/dts/extract/default.py
+++ b/scripts/dts/extract/default.py
@@ -28,7 +28,7 @@ class DTDefault(DTDirective):
         prop_alias = {}
 
         if prop_type == 'boolean':
-            if prop in reduced[node_address]['props'].keys():
+            if prop in reduced[node_address]['props']:
                 prop_values = 1
             else:
                 prop_values = 0

--- a/scripts/dts/extract/default.py
+++ b/scripts/dts/extract/default.py
@@ -37,7 +37,7 @@ class DTDefault(DTDirective):
 
         if isinstance(prop_values, list):
             for i, prop_value in enumerate(prop_values):
-                prop_name = convert_string_to_label(prop)
+                prop_name = str_to_label(prop)
                 label = def_label + '_' + prop_name
                 if isinstance(prop_value, str):
                     prop_value = "\"" + prop_value + "\""
@@ -47,7 +47,7 @@ class DTDefault(DTDirective):
                         label + '_' + str(i),
                         prop_alias)
         else:
-            prop_name = convert_string_to_label(prop)
+            prop_name = str_to_label(prop)
             label = def_label + '_' + prop_name
 
             if prop_values == 'parent-label':
@@ -62,8 +62,7 @@ class DTDefault(DTDirective):
             if node_address in aliases:
                 add_prop_aliases(
                     node_address,
-                    lambda alias:
-                        convert_string_to_label(alias) + '_' + prop_name,
+                    lambda alias: str_to_label(alias) + '_' + prop_name,
                     label,
                     prop_alias)
 

--- a/scripts/dts/extract/directive.py
+++ b/scripts/dts/extract/directive.py
@@ -21,8 +21,7 @@ class DTDirective(object):
     #
     @staticmethod
     def get_label_string(label):
-        return convert_string_to_label(
-            '_'.join(x.strip() for x in label if x.strip()))
+        return str_to_label('_'.join(x.strip() for x in label if x.strip()))
 
     def __init__():
         pass

--- a/scripts/dts/extract/flash.py
+++ b/scripts/dts/extract/flash.py
@@ -79,7 +79,7 @@ class DTFlash(DTDirective):
         # for addr/size info, and the second reg property (assume first is mmio
         # register for the controller itself)
         is_spi_flash = False
-        if (nr_size_cells == 0):
+        if nr_size_cells == 0:
             is_spi_flash = True
             node_address = get_parent_address(node_address)
             (nr_address_cells, nr_size_cells) = get_addr_size_cells(node_address)
@@ -94,7 +94,7 @@ class DTFlash(DTDirective):
         # if we found a spi flash, but don't have mmio direct access support
         # which we determin by the spi controller node only have on reg element
         # (ie for the controller itself and no region for the MMIO flash access)
-        if (num_reg_elem == 1 and is_spi_flash):
+        if num_reg_elem == 1 and is_spi_flash:
             node_address = orig_node_addr
         else:
             # We assume the last reg property is the one we want

--- a/scripts/dts/extract/flash.py
+++ b/scripts/dts/extract/flash.py
@@ -32,10 +32,7 @@ class DTFlash(DTDirective):
         prop_def[label] = '"{}"'.format(partition_name)
 
         label = self.get_label_string(label_prefix + ["READ_ONLY",])
-        if node['props'].get('read-only'):
-            prop_def[label] = 1
-        else:
-            prop_def[label] = 0
+        prop_def[label] = 1 if 'read-only' in node['props'] else 0
 
         index = 0
         while index < len(partition_sectors):

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -47,23 +47,17 @@ def convert_string_to_label(s):
 
 
 def get_all_compatibles(d, name, comp_dict):
-    if 'props' in d:
-        compat = d['props'].get('compatible')
-        enabled = d['props'].get('status')
-
-    if enabled == "disabled":
+    if d['props'].get('status') == 'disabled':
         return comp_dict
 
-    if compat is not None:
-        comp_dict[name] = compat
+    if 'compatible' in d['props']:
+        comp_dict[name] = d['props']['compatible']
 
     if name != '/':
         name += '/'
 
-    if isinstance(d, dict):
-        if d['children']:
-            for k, v in d['children'].items():
-                get_all_compatibles(v, name + k, comp_dict)
+    for k, v in d['children'].items():
+        get_all_compatibles(v, name + k, comp_dict)
 
     return comp_dict
 

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -175,7 +175,7 @@ def get_reduced(nodes, path):
 
         # assign an instance ID for each compat
         compat = nodes['props'].get('compatible')
-        if (compat is not None):
+        if compat:
             if type(compat) is not list: compat = [ compat, ]
             reduced[path]['instance_id'] = {}
             for k in compat:
@@ -295,7 +295,7 @@ def enable_old_alias_names(enable):
     old_alias_names = enable
 
 def add_compat_alias(node_address, label_postfix, label, prop_aliases):
-    if ('instance_id' in reduced[node_address]):
+    if 'instance_id' in reduced[node_address]:
         instance = reduced[node_address]['instance_id']
         for k in instance:
             i = instance[k]
@@ -311,9 +311,9 @@ def add_prop_aliases(node_address,
         old_alias_label = alias_label_function(alias)
         new_alias_label = new_alias_prefix + '_' + old_alias_label
 
-        if (new_alias_label != prop_label):
+        if new_alias_label != prop_label:
             prop_aliases[new_alias_label] = prop_label
-        if (old_alias_names and old_alias_label != prop_label):
+        if old_alias_names and old_alias_label != prop_label:
             prop_aliases[old_alias_label] = prop_label
 
 def get_binding(node_address):

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -76,7 +76,7 @@ def get_aliases(root):
 
     # Treat alternate names as aliases
     for k in reduced:
-        if reduced[k].get('alt_name', None) is not None:
+        if 'alt_name' in reduced[k]:
             aliases[k].append(reduced[k]['alt_name'])
 
 def get_node_compats(node_address):

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -75,7 +75,7 @@ def get_aliases(root):
                 aliases[v].append(k)
 
     # Treat alternate names as aliases
-    for k in reduced.keys():
+    for k in reduced:
         if reduced[k].get('alt_name', None) is not None:
             aliases[k].append(reduced[k]['alt_name'])
 
@@ -83,7 +83,7 @@ def get_node_compats(node_address):
     compat = None
 
     try:
-        if 'props' in reduced[node_address].keys():
+        if 'props' in reduced[node_address]:
             compat = reduced[node_address]['props'].get('compatible')
 
         if not isinstance(compat, list):
@@ -98,7 +98,7 @@ def get_compat(node_address):
     compat = None
 
     try:
-        if 'props' in reduced[node_address].keys():
+        if 'props' in reduced[node_address]:
             compat = reduced[node_address]['props'].get('compatible')
 
         if compat == None:
@@ -142,15 +142,15 @@ def get_phandles(root, name, handles):
 
 def insert_defs(node_address, new_defs, new_aliases):
 
-    for key in new_defs.keys():
+    for key in new_defs:
         if key.startswith('DT_COMPAT_'):
             node_address = 'compatibles'
 
-    remove = [k for k in new_aliases if k in new_defs.keys()]
+    remove = [k for k in new_aliases if k in new_defs]
     for k in remove: del new_aliases[k]
 
     if node_address in defs:
-        remove = [k for k in new_aliases if k in defs[node_address].keys()]
+        remove = [k for k in new_aliases if k in defs[node_address]]
         for k in remove: del new_aliases[k]
         if 'aliases' in defs[node_address]:
             defs[node_address]['aliases'].update(new_aliases)
@@ -191,7 +191,7 @@ def get_reduced(nodes, path):
             if type(compat) is not list: compat = [ compat, ]
             reduced[path]['instance_id'] = {}
             for k in compat:
-                if k not in get_reduced.last_used_id.keys():
+                if k not in get_reduced.last_used_id:
                     get_reduced.last_used_id[k] = 0
                 else:
                     get_reduced.last_used_id[k] += 1
@@ -468,7 +468,7 @@ def extract_cells(node_address, prop, prop_values, names, index,
         # Get number of cells per element of current property
         for props in reduced[cell_parent]['props']:
             if props[0] == '#' and '-cells' in props:
-                if props in cell_yaml.keys():
+                if props in cell_yaml:
                     cell_yaml_names = props
                 else:
                     cell_yaml_names = '#cells'

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -35,15 +35,13 @@ name_config = {
 }
 
 
-def convert_string_to_label(s):
-    # Transmute ,-@/ to _
-    s = s.replace("-", "_")
-    s = s.replace(",", "_")
-    s = s.replace("@", "_")
-    s = s.replace("/", "_")
-    # Uppercase the string
-    s = s.upper()
-    return s
+def str_to_label(s):
+    # Change ,-@/ to _ and uppercase
+    return s.replace('-', '_') \
+            .replace(',', '_') \
+            .replace('@', '_') \
+            .replace('/', '_') \
+            .upper()
 
 
 def get_all_compatibles(d, name, comp_dict):
@@ -204,7 +202,7 @@ def get_reduced(nodes, path):
 
 def get_node_label(node_address):
     node_compat = get_compat(node_address)
-    def_label = convert_string_to_label(node_compat)
+    def_label = str_to_label(node_compat)
     if '@' in node_address:
         # See if we have number we can convert
         try:
@@ -215,10 +213,9 @@ def get_node_label(node_address):
             unit_addr = "%x" % unit_addr
         except:
             unit_addr = node_address.split('@')[-1]
-        def_label += '_' + convert_string_to_label(unit_addr)
+        def_label += '_' + str_to_label(unit_addr)
     else:
-        def_label += '_' + \
-                convert_string_to_label(node_address.split('/')[-1])
+        def_label += '_' + str_to_label(node_address.split('/')[-1])
     return def_label
 
 def get_parent_address(node_address):
@@ -299,13 +296,13 @@ def add_compat_alias(node_address, label_postfix, label, prop_aliases):
         instance = reduced[node_address]['instance_id']
         for k in instance:
             i = instance[k]
-            b = 'DT_' + convert_string_to_label(k) + '_' + str(i) + '_' + label_postfix
+            b = 'DT_' + str_to_label(k) + '_' + str(i) + '_' + label_postfix
             prop_aliases[b] = label
 
 def add_prop_aliases(node_address,
                      alias_label_function, prop_label, prop_aliases):
     node_compat = get_compat(node_address)
-    new_alias_prefix = 'DT_' + convert_string_to_label(node_compat)
+    new_alias_prefix = 'DT_' + str_to_label(node_compat)
 
     for alias in aliases[node_address]:
         old_alias_label = alias_label_function(alias)
@@ -404,9 +401,9 @@ def extract_controller(node_address, prop, prop_values, index,
             generation = ''
 
         if 'use-prop-name' in generation:
-            l_cellname = convert_string_to_label(prop + '_' + 'controller')
+            l_cellname = str_to_label(prop + '_' + 'controller')
         else:
-            l_cellname = convert_string_to_label(generic + '_' + 'controller')
+            l_cellname = str_to_label(generic + '_' + 'controller')
 
         label = l_base + [l_cellname] + l_idx
 
@@ -417,8 +414,7 @@ def extract_controller(node_address, prop, prop_values, index,
         if node_address in aliases:
             add_prop_aliases(
                 node_address,
-                lambda alias:
-                    '_'.join([convert_string_to_label(alias)] + label[1:]),
+                lambda alias: '_'.join([str_to_label(alias)] + label[1:]),
                 '_'.join(label),
                 prop_alias)
 
@@ -467,9 +463,9 @@ def extract_cells(node_address, prop, prop_values, names, index,
             generation = ''
 
         if 'use-prop-name' in generation:
-            l_cell = [convert_string_to_label(str(prop))]
+            l_cell = [str_to_label(str(prop))]
         else:
-            l_cell = [convert_string_to_label(str(generic))]
+            l_cell = [str_to_label(str(generic))]
 
         l_base = def_label.split('/')
         # Check if #define should be indexed (_0, _1, ...)
@@ -500,8 +496,7 @@ def extract_cells(node_address, prop, prop_values, names, index,
             if node_address in aliases:
                 add_prop_aliases(
                     node_address,
-                    lambda alias:
-                        '_'.join([convert_string_to_label(alias)] + label[1:]),
+                    lambda alias: '_'.join([str_to_label(alias)] + label[1:]),
                     '_'.join(label),
                     prop_alias)
 

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -115,23 +115,17 @@ def get_chosen(root):
 
 
 def get_phandles(root, name, handles):
-    if 'props' in root:
-        handle = root['props'].get('phandle')
-        enabled = root['props'].get('status')
-
-    if enabled == "disabled":
+    if root['props'].get('status') == 'disabled':
         return
 
-    if handle is not None:
-        phandles[handle] = name
+    if 'phandle' in root['props']:
+        phandles[root['props']['phandle']] = name
 
     if name != '/':
         name += '/'
 
-    if isinstance(root, dict):
-        if root['children']:
-            for k, v in root['children'].items():
-                get_phandles(v, name + k, handles)
+    for k, v in root['children'].items():
+        get_phandles(v, name + k, handles)
 
 
 def insert_defs(node_address, new_defs, new_aliases):

--- a/scripts/dts/extract/interrupts.py
+++ b/scripts/dts/extract/interrupts.py
@@ -21,8 +21,8 @@ class DTInterrupts(DTDirective):
         for comp in node_address.split('/')[1:]:
             address += '/' + comp
             if 'interrupt-parent' in reduced[address]['props']:
-                interrupt_parent = reduced[address]['props'].get(
-                    'interrupt-parent')
+                interrupt_parent = reduced[address]['props'][
+                    'interrupt-parent']
 
         return phandles[interrupt_parent]
 

--- a/scripts/dts/extract/interrupts.py
+++ b/scripts/dts/extract/interrupts.py
@@ -56,7 +56,7 @@ class DTInterrupts(DTDirective):
             l_idx = [str(index)]
 
             try:
-                name = [convert_string_to_label(names.pop(0))]
+                name = [str_to_label(names.pop(0))]
             except:
                 name = []
 
@@ -85,7 +85,7 @@ class DTInterrupts(DTDirective):
                     add_prop_aliases(
                         node_address,
                         lambda alias:
-                            '_'.join([convert_string_to_label(alias)] +
+                            '_'.join([str_to_label(alias)] +
                                      l_cell_prefix + name + l_cell_name),
                         l_fqn,
                         prop_alias)

--- a/scripts/dts/extract/pinctrl.py
+++ b/scripts/dts/extract/pinctrl.py
@@ -46,7 +46,7 @@ class DTPinCtrl(DTDirective):
             if cell_prefix is not None:
                 post_fix.append(cell_prefix)
 
-            for subnode in reduced.keys():
+            for subnode in reduced:
                 if pin_subnode in subnode and pin_node_address != subnode:
                     # found a subnode underneath the pinmux handle
                     pin_label = def_prefix + post_fix + subnode.split('/')[-2:]

--- a/scripts/dts/extract/pinctrl.py
+++ b/scripts/dts/extract/pinctrl.py
@@ -56,8 +56,8 @@ class DTPinCtrl(DTDirective):
                             [cell_yaml['#cells'][0]] + [str(i)]
                         func_label = key_label[:-2] + \
                             [cell_yaml['#cells'][1]] + [str(i)]
-                        key_label = convert_string_to_label('_'.join(key_label))
-                        func_label = convert_string_to_label('_'.join(func_label))
+                        key_label = str_to_label('_'.join(key_label))
+                        func_label = str_to_label('_'.join(func_label))
 
                         prop_def[key_label] = cells
                         prop_def[func_label] = \

--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -51,7 +51,7 @@ class DTReg(DTDirective):
 
         # generate defines
         l_base = def_label.split('/')
-        l_addr = [convert_string_to_label("BASE_ADDRESS")]
+        l_addr = [str_to_label("BASE_ADDRESS")]
         l_size = ["SIZE"]
 
         index = 0
@@ -103,15 +103,14 @@ class DTReg(DTDirective):
                 add_prop_aliases(
                     node_address,
                     lambda alias:
-                        '_'.join([convert_string_to_label(alias)] +
-                                 l_addr + l_idx),
+                        '_'.join([str_to_label(alias)] + l_addr + l_idx),
                     l_addr_fqn,
                     prop_alias)
+
                 add_prop_aliases(
                     node_address,
                     lambda alias:
-                        '_'.join([convert_string_to_label(alias)] +
-                                 l_size + l_idx),
+                        '_'.join([str_to_label(alias)] + l_size + l_idx),
                     l_size_fqn,
                     prop_alias)
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -484,7 +484,7 @@ def output_include_lines(fd):
         else:
             maxtabstop = (maxlength >> 3) + 1
 
-        if (maxtabstop * 8 - maxlength) <= 2:
+        if maxtabstop * 8 - maxlength <= 2:
             maxtabstop += 1
 
         prop_keys = sorted(defs[node])
@@ -592,10 +592,10 @@ def main():
         insert_defs('chosen', load_defs, {})
 
      # generate config and include file
-    if (args.keyvalue is not None):
+    if args.keyvalue is not None:
        generate_keyvalue_file(args.keyvalue[0])
 
-    if (args.include is not None):
+    if args.include is not None:
        generate_include_file(args.include[0])
 
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -258,12 +258,8 @@ def extract_property(node_compat, node_address, prop, prop_val, names):
     elif 'clocks' in prop:
         clocks.extract(node_address, prop, def_label)
     elif 'pwms' in prop or 'gpios' in prop:
-        # drop the 's' from the prop
-        generic = prop[:-1]
-        try:
-            prop_values = list(reduced[node_address]['props'].get(prop))
-        except:
-            prop_values = reduced[node_address]['props'].get(prop)
+        prop_values = reduced[node_address]['props'][prop]
+        generic = prop[:-1]  # Drop the 's' from the prop
 
         extract_controller(node_address, prop, prop_values, 0,
                            def_label, generic)

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -145,7 +145,7 @@ def extract_single(node_address, prop, key, def_label):
 
     if isinstance(prop, list):
         for i, p in enumerate(prop):
-            k = convert_string_to_label(key)
+            k = str_to_label(key)
             label = def_label + '_' + k
             if isinstance(p, str):
                 p = "\"" + p + "\""
@@ -155,7 +155,7 @@ def extract_single(node_address, prop, key, def_label):
                     prop_alias)
             prop_def[label + '_' + str(i)] = p
     else:
-        k = convert_string_to_label(key)
+        k = str_to_label(key)
         label = def_label + '_' + k
 
         if prop == 'parent-label':
@@ -170,8 +170,7 @@ def extract_single(node_address, prop, key, def_label):
         if node_address in aliases:
             add_prop_aliases(
                 node_address,
-                lambda alias:
-                    convert_string_to_label(alias) + '_' + k,
+                lambda alias: str_to_label(alias) + '_' + k,
                 label,
                 prop_alias)
 
@@ -184,7 +183,6 @@ def extract_string_prop(node_address, key, label):
     node = reduced[node_address]
     prop = node['props'][key]
 
-    k = convert_string_to_label(key)
     prop_def[label] = "\"" + prop + "\""
 
     if node_address in defs:
@@ -585,8 +583,7 @@ def main():
 
     # Add DT_CHOSEN_<X> defines to generated files
     for c in sorted(chosen):
-        chosen_def = 'DT_CHOSEN_' + convert_string_to_label(c)
-        insert_defs('chosen', {chosen_def: '1'}, {})
+        insert_defs('chosen', {'DT_CHOSEN_' + str_to_label(c): '1'}, {})
 
      # generate config and include file
     if args.keyvalue is not None:

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -312,7 +312,7 @@ def extract_node_include_info(reduced, root_node_address, sub_node_address,
                 # Handle each property individually, this ends up handling common
                 # patterns for things like reg, interrupts, etc that we don't need
                 # any special case handling at a node level
-                for c in node['props'].keys():
+                for c in node['props']:
                     # if prop is in filter list - ignore it
                     if c in filter_list:
                         continue
@@ -440,12 +440,12 @@ def get_key_value(k, v, tabstop):
 
 
 def output_keyvalue_lines(fd):
-    node_keys = sorted(defs.keys())
+    node_keys = sorted(defs)
     for node in node_keys:
         fd.write('# ' + node.split('/')[-1])
         fd.write("\n")
 
-        prop_keys = sorted(defs[node].keys())
+        prop_keys = sorted(defs[node])
         for prop in prop_keys:
             if prop == 'aliases':
                 for entry in sorted(defs[node][prop]):
@@ -472,12 +472,12 @@ def output_include_lines(fd):
     '''
     )
 
-    node_keys = sorted(defs.keys())
+    node_keys = sorted(defs)
     for node in node_keys:
         fd.write('/* ' + node.split('/')[-1] + ' */')
         fd.write("\n")
 
-        max_dict_key = lambda d: max(len(k) for k in d.keys())
+        max_dict_key = lambda d: max(len(k) for k in d)
         maxlength = 0
         if defs[node].get('aliases'):
             maxlength = max_dict_key(defs[node]['aliases'])
@@ -491,7 +491,7 @@ def output_include_lines(fd):
         if (maxtabstop * 8 - maxlength) <= 2:
             maxtabstop += 1
 
-        prop_keys = sorted(defs[node].keys())
+        prop_keys = sorted(defs[node])
         for prop in prop_keys:
             if prop == 'aliases':
                 for entry in sorted(defs[node][prop]):
@@ -588,7 +588,7 @@ def main():
     defs = generate_node_definitions()
 
     # Add DT_CHOSEN_<X> defines to generated files
-    for c in sorted(chosen.keys()):
+    for c in sorted(chosen):
         chosen_def = 'DT_CHOSEN_' + convert_string_to_label(c)
         load_defs = {
             chosen_def: "1",

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -586,10 +586,7 @@ def main():
     # Add DT_CHOSEN_<X> defines to generated files
     for c in sorted(chosen):
         chosen_def = 'DT_CHOSEN_' + convert_string_to_label(c)
-        load_defs = {
-            chosen_def: "1",
-        }
-        insert_defs('chosen', load_defs, {})
+        insert_defs('chosen', {chosen_def: '1'}, {})
 
      # generate config and include file
     if args.keyvalue is not None:

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -198,7 +198,7 @@ def extract_property(node_compat, node_address, prop, prop_val, names):
     node = reduced[node_address]
     yaml_node_compat = get_binding(node_address)
     if 'base_label' in yaml_node_compat:
-        def_label = yaml_node_compat.get('base_label')
+        def_label = yaml_node_compat['base_label']
     else:
         def_label = get_node_label(node_address)
 
@@ -449,10 +449,10 @@ def output_keyvalue_lines(fd):
         for prop in prop_keys:
             if prop == 'aliases':
                 for entry in sorted(defs[node][prop]):
-                    a = defs[node][prop].get(entry)
+                    a = defs[node][prop][entry]
                     fd.write("%s=%s\n" % (entry, defs[node].get(a)))
             else:
-                fd.write("%s=%s\n" % (prop, defs[node].get(prop)))
+                fd.write("%s=%s\n" % (prop, defs[node][prop]))
 
         fd.write("\n")
 
@@ -495,10 +495,10 @@ def output_include_lines(fd):
         for prop in prop_keys:
             if prop == 'aliases':
                 for entry in sorted(defs[node][prop]):
-                    a = defs[node][prop].get(entry)
+                    a = defs[node][prop][entry]
                     fd.write(get_key_value(entry, a, maxtabstop))
             else:
-                fd.write(get_key_value(prop, defs[node].get(prop), maxtabstop))
+                fd.write(get_key_value(prop, defs[node][prop], maxtabstop))
 
         fd.write("\n")
 


### PR DESCRIPTION
I have a huge ungainly diff that shoehorns [dtlib](https://github.com/zephyrproject-rtos/zephyr/pull/12140) into `scripts/dts`. I decided it might be better to split things up a bit, starting with some random cleanups to the existing code.

This is part one. There will be others.

Sorry for stomping on the Git history. I suspect it will have to be stomped on eventually anyway.

Some general code nits:

 - Using `dict.get(key)` instead of `dict[key]` when `key` is always in `dict` makes the code confusing. People reading it will assume that `key` might be missing.

 - There's a lot of single-letter variable names that aren't obvious at a glance.

   Often there's a more specific name than e.g. `key`/`k` that could be used too, like `compat`, if the key is a `compat` string.

 - There's a lot of catch-all `try: ... except: ...` blocks where it's not obvious at a glance what exception is expected to be thrown. It might be better to test for the `except:` condition explicitly, or at least catch a specific exception (like `KeyError`). That way, stuff like typos in variable names (which raise `NameError`) won't be hidden either.

 - Many functions start with a blank line, which looks a bit weird.