### PR TITLE
Bluetooth: controller: 32-bit word align allocations

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -12,6 +12,7 @@
 #include <misc/util.h>
 #include <drivers/clock_control/nrf_clock_control.h>
 
+#include "util/mem.h"
 #include "util/memq.h"
 #include "util/mfifo.h"
 

--- a/subsys/bluetooth/controller/util/mfifo.h
+++ b/subsys/bluetooth/controller/util/mfifo.h
@@ -10,10 +10,10 @@
 			u8_t const n; /* TODO: const, optimise RAM use */ \
 			u8_t f; \
 			u8_t l; \
-			u8_t m[sz * ((cnt) + 1)]; \
+			u8_t MALIGN(4) m[MROUND(sz) * ((cnt) + 1)]; \
 		} mfifo_##name = { \
 			.n = ((cnt) + 1), \
-			.s = (sz), \
+			.s = MROUND(sz), \
 			.f = 0, \
 			.l = 0, \
 		}


### PR DESCRIPTION
nRF51 series requires the 32-bit word aligned accesses to
avoid hardfaults.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>