### PR TITLE
boards: nrf: Enable HW PWMs on nrf52832_mdk and nrf52840_mdk

### DIFF
--- a/boards/arm/nrf52832_mdk/Kconfig.defconfig
+++ b/boards/arm/nrf52832_mdk/Kconfig.defconfig
@@ -16,6 +16,13 @@ config I2C_0
 
 endif # I2C
 
+if PWM
+
+config PWM_0
+	default y
+
+endif # PWM
+
 config BT_CTLR
 	default BT
 

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -89,6 +89,12 @@
 	scl-pin = <31>;
 };
 
+&pwm0 {
+	status = "ok";
+	ch0-pin = <22>;
+	ch0-inverted;
+};
+
 &flash0 {
 	/*
 	 * For more information, see:

--- a/boards/arm/nrf52840_mdk/Kconfig.defconfig
+++ b/boards/arm/nrf52840_mdk/Kconfig.defconfig
@@ -16,6 +16,13 @@ config I2C_0
 
 endif # I2C
 
+if PWM
+
+config PWM_0
+	default y
+
+endif # PWM
+
 if USB
 
 config USB_NRF52840

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -91,6 +91,12 @@
 	scl-pin = <31>;
 };
 
+&pwm0 {
+	status = "ok";
+	ch0-pin = <22>;
+	ch0-inverted;
+};
+
 &flash0 {
 	/*
 	 * For more information, see:


### PR DESCRIPTION
This is a follow-up to commit e2b38e02bf08a338224559a2378a44b609f58e73 (PR #13059). I forgot to make these changes there.

Default PWM instances are enabled in Kconfig and DTS (with channel 0 set to LED0 pin) for these boards so that it is possible to build basic samples blink_led and fade_led for them without extra modifications.
