### PR TITLE
ext: hal: atmel: sam: fix GMAC priority queues related registers

### DIFF
--- a/ext/hal/atmel/asf/sam/include/same70/README
+++ b/ext/hal/atmel/asf/sam/include/same70/README
@@ -40,3 +40,5 @@ Patch Lst:
       Several missing symbols for same70q21 SoC are added:
       - TC Channel Mode Register: Waveform Mode definitions
       - Legacy peripheral IDs definitions
+   * Fix the GMAC priority queues related register to match the
+     datasheet.

--- a/ext/hal/atmel/asf/sam/include/same70/component/gmac.h
+++ b/ext/hal/atmel/asf/sam/include/same70/component/gmac.h
@@ -2702,7 +2702,7 @@ typedef union {
 #define GMAC_PEFRN_Msk                      _U_(0x3FFFFFFF)                                /**< (GMAC_PEFRN) Register Mask  */
 
 
-/* -------- GMAC_ISRPQ : (GMAC Offset: 0x3fc) (R/ 32) Interrupt Status Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_ISRPQ : (GMAC Offset: 0x400) (R/ 32) Interrupt Status Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { 
   struct {
@@ -2722,7 +2722,7 @@ typedef union {
 } GMAC_ISRPQ_Type;
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_ISRPQ_OFFSET                   (0x3FC)                                       /**<  (GMAC_ISRPQ) Interrupt Status Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_ISRPQ_OFFSET                   (0x400)                                       /**<  (GMAC_ISRPQ) Interrupt Status Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_ISRPQ_RCOMP_Pos                1                                              /**< (GMAC_ISRPQ) Receive Complete Position */
 #define GMAC_ISRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_ISRPQ_RCOMP_Pos)             /**< (GMAC_ISRPQ) Receive Complete Mask */
@@ -2749,7 +2749,7 @@ typedef union {
 #define GMAC_ISRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_ISRPQ) Register Mask  */
 
 
-/* -------- GMAC_TBQBAPQ : (GMAC Offset: 0x43c) (R/W 32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_TBQBAPQ : (GMAC Offset: 0x440) (R/W 32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { 
   struct {
@@ -2760,7 +2760,7 @@ typedef union {
 } GMAC_TBQBAPQ_Type;
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_TBQBAPQ_OFFSET                 (0x43C)                                       /**<  (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_TBQBAPQ_OFFSET                 (0x440)                                       /**<  (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_TBQBAPQ_TXBQBA_Pos             2                                              /**< (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Position */
 #define GMAC_TBQBAPQ_TXBQBA_Msk             (_U_(0x3FFFFFFF) << GMAC_TBQBAPQ_TXBQBA_Pos)   /**< (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Mask */
@@ -2769,7 +2769,7 @@ typedef union {
 #define GMAC_TBQBAPQ_Msk                    _U_(0xFFFFFFFC)                                /**< (GMAC_TBQBAPQ) Register Mask  */
 
 
-/* -------- GMAC_RBQBAPQ : (GMAC Offset: 0x47c) (R/W 32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_RBQBAPQ : (GMAC Offset: 0x480) (R/W 32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { 
   struct {
@@ -2780,7 +2780,7 @@ typedef union {
 } GMAC_RBQBAPQ_Type;
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_RBQBAPQ_OFFSET                 (0x47C)                                       /**<  (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_RBQBAPQ_OFFSET                 (0x480)                                       /**<  (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_RBQBAPQ_RXBQBA_Pos             2                                              /**< (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Position */
 #define GMAC_RBQBAPQ_RXBQBA_Msk             (_U_(0x3FFFFFFF) << GMAC_RBQBAPQ_RXBQBA_Pos)   /**< (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Mask */
@@ -2789,7 +2789,7 @@ typedef union {
 #define GMAC_RBQBAPQ_Msk                    _U_(0xFFFFFFFC)                                /**< (GMAC_RBQBAPQ) Register Mask  */
 
 
-/* -------- GMAC_RBSRPQ : (GMAC Offset: 0x49c) (R/W 32) Receive Buffer Size Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_RBSRPQ : (GMAC Offset: 0x4a0) (R/W 32) Receive Buffer Size Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { 
   struct {
@@ -2800,7 +2800,7 @@ typedef union {
 } GMAC_RBSRPQ_Type;
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_RBSRPQ_OFFSET                  (0x49C)                                       /**<  (GMAC_RBSRPQ) Receive Buffer Size Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_RBSRPQ_OFFSET                  (0x4A0)                                       /**<  (GMAC_RBSRPQ) Receive Buffer Size Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_RBSRPQ_RBS_Pos                 0                                              /**< (GMAC_RBSRPQ) Receive Buffer Size Position */
 #define GMAC_RBSRPQ_RBS_Msk                 (_U_(0xFFFF) << GMAC_RBSRPQ_RBS_Pos)           /**< (GMAC_RBSRPQ) Receive Buffer Size Mask */
@@ -2970,7 +2970,7 @@ typedef union {
 #define GMAC_ST2RPQ_Msk                     _U_(0x7FFFFF77)                                /**< (GMAC_ST2RPQ) Register Mask  */
 
 
-/* -------- GMAC_IERPQ : (GMAC Offset: 0x5fc) (/W 32) Interrupt Enable Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_IERPQ : (GMAC Offset: 0x600) (/W 32) Interrupt Enable Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { 
   struct {
@@ -2990,7 +2990,7 @@ typedef union {
 } GMAC_IERPQ_Type;
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_IERPQ_OFFSET                   (0x5FC)                                       /**<  (GMAC_IERPQ) Interrupt Enable Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_IERPQ_OFFSET                   (0x600)                                       /**<  (GMAC_IERPQ) Interrupt Enable Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_IERPQ_RCOMP_Pos                1                                              /**< (GMAC_IERPQ) Receive Complete Position */
 #define GMAC_IERPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IERPQ_RCOMP_Pos)             /**< (GMAC_IERPQ) Receive Complete Mask */
@@ -3017,7 +3017,7 @@ typedef union {
 #define GMAC_IERPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IERPQ) Register Mask  */
 
 
-/* -------- GMAC_IDRPQ : (GMAC Offset: 0x61c) (/W 32) Interrupt Disable Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_IDRPQ : (GMAC Offset: 0x620) (/W 32) Interrupt Disable Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { 
   struct {
@@ -3037,7 +3037,7 @@ typedef union {
 } GMAC_IDRPQ_Type;
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_IDRPQ_OFFSET                   (0x61C)                                       /**<  (GMAC_IDRPQ) Interrupt Disable Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_IDRPQ_OFFSET                   (0x620)                                       /**<  (GMAC_IDRPQ) Interrupt Disable Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_IDRPQ_RCOMP_Pos                1                                              /**< (GMAC_IDRPQ) Receive Complete Position */
 #define GMAC_IDRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IDRPQ_RCOMP_Pos)             /**< (GMAC_IDRPQ) Receive Complete Mask */
@@ -3064,7 +3064,7 @@ typedef union {
 #define GMAC_IDRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IDRPQ) Register Mask  */
 
 
-/* -------- GMAC_IMRPQ : (GMAC Offset: 0x63c) (R/W 32) Interrupt Mask Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_IMRPQ : (GMAC Offset: 0x640) (R/W 32) Interrupt Mask Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { 
   struct {
@@ -3084,7 +3084,7 @@ typedef union {
 } GMAC_IMRPQ_Type;
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_IMRPQ_OFFSET                   (0x63C)                                       /**<  (GMAC_IMRPQ) Interrupt Mask Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_IMRPQ_OFFSET                   (0x640)                                       /**<  (GMAC_IMRPQ) Interrupt Mask Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_IMRPQ_RCOMP_Pos                1                                              /**< (GMAC_IMRPQ) Receive Complete Position */
 #define GMAC_IMRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IMRPQ_RCOMP_Pos)             /**< (GMAC_IMRPQ) Receive Complete Mask */


### PR DESCRIPTION
The latest update of the SAM E70 HAL (commit 6ad7e13608) shifted the
GMAC priority queues related registers by 4 bytes. It is not cleared
yet, if it is change is a mistake or a change from 0 based indexing
to 1 based indexing. Indeed the main queue is the number 0, and the
first priority queue is therefore the number 1.

In the meantime revert that change, and use the old registers addresses
matching the datasheet.

Fixes #12945

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>