### PR TITLE
Fix stack overflow when optimizations are disabled

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -52,6 +52,7 @@ config BT_HCI_TX_STACK_SIZE
 	default 512 if BT_H4
 	default 512 if BT_H5
 	default 416 if BT_SPI
+	default 940 if BT_CTLR && NO_OPTIMIZATIONS
 	default 640 if BT_CTLR
 	default 512 if BT_USERCHAN
 	# Even if no driver is selected the following default is still

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -264,6 +264,7 @@ config LOG_PROCESS_THREAD_SLEEP_MS
 config LOG_PROCESS_THREAD_STACK_SIZE
 	int "Stack size for the internal log processing thread"
 	default 2048 if COVERAGE_GCOV
+	default 1024 if NO_OPTIMIZATIONS
 	default 768
 	help
 	  Set the internal stack size for log processing thread.


### PR DESCRIPTION
When optimizations are disabled more RAM is used and we get a stack
overflow on several stacks. To rectify this, increase the stack
size when CONFIG_NO_OPTIMIZATIONS.

This does not scale well, and will have to be replaced by a more
general solution eventually, but in the mean time it follows the
existing best practice established by the GCOV infrastructure in
commit e908ea9

Only two stacks have been observed to need increasing, they are
blown when the sample peripheral_hr is run with CONFIG_NO_OPTIMIZATIONS.

This fixes #12820