### PR TITLE
boards: Update yaml for boards supporting rtc/counter (2/3)

### DIFF
--- a/boards/arm/stm32373c_eval/stm32373c_eval.yaml
+++ b/boards/arm/stm32373c_eval/stm32373c_eval.yaml
@@ -9,3 +9,4 @@ toolchain:
 ram: 32
 supported:
   - rtc
+  - counter

--- a/boards/arm/stm32f3_disco/stm32f3_disco.yaml
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.yaml
@@ -11,6 +11,7 @@ supported:
   - gpio
   - i2c
   - rtc
+  - counter
   - spi
   - usb_device
   - lsm303dlhc

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.yaml
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.yaml
@@ -8,3 +8,4 @@ toolchain:
   - xtools
 supported:
   - rtc
+  - counter

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.yaml
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.yaml
@@ -8,3 +8,4 @@ toolchain:
   - xtools
 supported:
   - rtc
+  - counter

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
@@ -8,3 +8,4 @@ toolchain:
   - xtools
 supported:
   - rtc
+  - counter

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.yaml
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.yaml
@@ -9,6 +9,7 @@ toolchain:
 supported:
   - arduino_i2c
   - rtc
+  - counter
   - i2c
   - spi
   - gpio

--- a/boards/arm/stm32f4_disco/stm32f4_disco.yaml
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.yaml
@@ -9,4 +9,5 @@ toolchain:
 supported:
   - pwm
   - rtc
+  - counter
   - usb

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
@@ -16,4 +16,5 @@ supported:
   - gpio
   - pwm
   - rtc
+  - counter
   - usb_device

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.yaml
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.yaml
@@ -10,3 +10,5 @@ ram: 96
 flash: 1024
 supported:
   - gpio
+  - rtc
+  - counter

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.yaml
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.yaml
@@ -14,3 +14,5 @@ supported:
   - i2c
   - spi
   - gpio
+  - rtc
+  - counter


### PR DESCRIPTION
Few boards supporting RTC were missing rtc as supported rtc feature
in yaml files. Fix this.
Add counter to all boards supporting rtc as RTC IP now support
both rtc and counter API.
Change split in 3 parts in order to lower CI load and get shippable
happy.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>