### PR TITLE
samples: mesh: enable SMP service for DFU [v1.14.0 milestone]

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(app PRIVATE
 	       src/mesh/transition.c
 	       )
 
+target_sources_ifdef(CONFIG_MCUMGR app PRIVATE src/smp_svr.c)
+
 zephyr_include_directories(
 	src/
 	src/mesh

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/prj_smp_svr.conf
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/prj_smp_svr.conf
@@ -1,0 +1,33 @@
+# Enable mcumgr.
+CONFIG_MCUMGR=y
+
+# Ensure an MCUboot-compatible binary is generated.
+CONFIG_BOOTLOADER_MCUBOOT=y
+
+# Allow for large Bluetooth data packets.
+CONFIG_BT_L2CAP_TX_MTU=260
+CONFIG_BT_RX_BUF_LEN=260
+
+# Enable the Bluetooth and shell mcumgr transports.
+CONFIG_MCUMGR_SMP_BT=y
+#CONFIG_MCUMGR_SMP_SHELL=y
+#CONFIG_MCUMGR_SMP_UART=y
+
+# Bluetooth support requires a net_buf user_data size >= 7.
+CONFIG_NET_BUF_USER_DATA_SIZE=7
+
+# Enable flash operations.
+CONFIG_FLASH=y
+
+# Required by the `taskstat` command.
+CONFIG_THREAD_MONITOR=y
+
+# Enable statistics and statistic names.
+CONFIG_STATS=y
+CONFIG_STATS_NAMES=y
+
+# Enable all core commands.
+CONFIG_MCUMGR_CMD_FS_MGMT=y
+CONFIG_MCUMGR_CMD_IMG_MGMT=y
+CONFIG_MCUMGR_CMD_OS_MGMT=y
+CONFIG_MCUMGR_CMD_STAT_MGMT=y

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -8,14 +8,18 @@
 #include <gpio.h>
 
 #include "app_gpio.h"
-#include "storage.h"
-
 #include "ble_mesh.h"
 #include "device_composition.h"
 #include "no_transition_work_handler.h"
 #include "publisher.h"
 #include "state_binding.h"
+#include "storage.h"
 #include "transition.h"
+
+#if defined(CONFIG_MCUMGR)
+#include <mgmt/smp_bt.h>
+#include "smp_svr.h"
+#endif
 
 static bool reset;
 
@@ -185,6 +189,10 @@ void main(void)
 
 	app_gpio_init();
 
+#if defined(CONFIG_MCUMGR)
+	smp_svr_init();
+#endif
+
 	printk("Initializing...\n");
 
 	ps_settings_init();
@@ -203,4 +211,11 @@ void main(void)
 
 	short_time_multireset_bt_mesh_unprovisioning();
 	k_timer_start(&reset_counter_timer, K_MSEC(7000), 0);
+
+#if defined(CONFIG_MCUMGR)
+	/* Initialize the Bluetooth mcumgr transport. */
+	smp_bt_register();
+
+	k_timer_start(&smp_svr_timer, 0, K_MSEC(1000));
+#endif
 }

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/smp_svr.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/smp_svr.c
@@ -1,0 +1,69 @@
+/* Bluetooth: Mesh Generic OnOff, Generic Level, Lighting & Vendor Models
+ *
+ * Copyright (c) 2018 Vikrant More
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <assert.h>
+#include <bluetooth/conn.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/gatt.h>
+#include <mgmt/buf.h>
+#include <mgmt/smp_bt.h>
+#include <stats.h>
+#include <stdlib.h>
+#include <string.h>
+#include <zephyr.h>
+
+#ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
+#include "img_mgmt/img_mgmt.h"
+#endif
+#ifdef CONFIG_MCUMGR_CMD_OS_MGMT
+#include "os_mgmt/os_mgmt.h"
+#endif
+#ifdef CONFIG_MCUMGR_CMD_STAT_MGMT
+#include "stat_mgmt/stat_mgmt.h"
+#endif
+
+/* Define an example stats group; approximates seconds since boot. */
+STATS_SECT_START(smp_svr_stats)
+STATS_SECT_ENTRY(ticks)
+STATS_SECT_END;
+
+/* Assign a name to the `ticks` stat. */
+STATS_NAME_START(smp_svr_stats)
+STATS_NAME(smp_svr_stats, ticks)
+STATS_NAME_END(smp_svr_stats);
+
+/* Define an instance of the stats group. */
+STATS_SECT_DECL(smp_svr_stats) smp_svr_stats;
+
+void smp_svr_init(void)
+{
+	int rc;
+
+	rc = STATS_INIT_AND_REG(smp_svr_stats, STATS_SIZE_32, "smp_svr_stats");
+	assert(rc == 0);
+
+	/* Register the built-in mcumgr command handlers. */
+#ifdef CONFIG_MCUMGR_CMD_FS_MGMT
+	fs_mgmt_register_group();
+#endif
+#ifdef CONFIG_MCUMGR_CMD_OS_MGMT
+	os_mgmt_register_group();
+#endif
+#ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
+	img_mgmt_register_group();
+#endif
+#ifdef CONFIG_MCUMGR_CMD_STAT_MGMT
+	stat_mgmt_register_group();
+#endif
+}
+
+static void smp_svr_timer_handler(struct k_timer *dummy)
+{
+	STATS_INC(smp_svr_stats, ticks);
+}
+
+K_TIMER_DEFINE(smp_svr_timer, smp_svr_timer_handler, NULL);

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/smp_svr.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/smp_svr.h
@@ -1,0 +1,16 @@
+/* Bluetooth: Mesh Generic OnOff, Generic Level, Lighting & Vendor Models
+ *
+ * Copyright (c) 2018 Vikrant More
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SMP_SVR_H
+#define _SMP_SVR_H
+
+extern struct k_timer smp_svr_timer;
+
+void smp_svr_init(void);
+void smp_svr(void);
+
+#endif


### PR DESCRIPTION
This commit enable Bluetooth SMP Service which will help
us to do Device Firmware Upgrade over thr air. By default
it is not enable.

Reference: $zephyr/samples/subsys/mgmt/mcumgr/smp_svr

Signed-off-by: Vikrant More <vikrant8051@gmail.com>