### PR TITLE
boards: Update yaml for boards supporting rtc/counter (3/3)

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.yaml
+++ b/boards/arm/96b_argonkey/96b_argonkey.yaml
@@ -16,5 +16,6 @@ supported:
   - lps22hb
   - lsm6dsl
   - rtc
+  - counter
   - spi
   - vl53l0x

--- a/boards/arm/96b_carbon/96b_carbon.yaml
+++ b/boards/arm/96b_carbon/96b_carbon.yaml
@@ -11,6 +11,7 @@ supported:
   - ble
   - i2c
   - rtc
+  - counter
   - spi
   - usb_device
 ram: 96

--- a/boards/arm/96b_neonkey/96b_neonkey.yaml
+++ b/boards/arm/96b_neonkey/96b_neonkey.yaml
@@ -13,3 +13,4 @@ supported:
   - i2c
   - spi
   - rtc
+  - counter

--- a/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.yaml
+++ b/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.yaml
@@ -12,3 +12,4 @@ supported:
   - i2c
   - spi
   - rtc
+  - counter

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.yaml
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.yaml
@@ -8,3 +8,4 @@ toolchain:
   - xtools
 supported:
   - rtc
+  - counter

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.yaml
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.yaml
@@ -8,3 +8,4 @@ toolchain:
   - xtools
 supported:
   - rtc
+  - counter

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.yaml
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.yaml
@@ -8,3 +8,4 @@ toolchain:
   - xtools
 supported:
   - rtc
+  - counter


### PR DESCRIPTION
Few boards supporting RTC were missing rtc as supported rtc feature
in yaml files. Fix this.
Add counter to all boards supporting rtc as RTC IP now support
both rtc and counter API.
Change split in 3 parts in order to lower CI load and get shippable
happy.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>