### PR TITLE
boards: cc3220sf_launchxl: Set CONFIG_FLASH defaults for non-XIP

### DIFF
--- a/soc/arm/ti_simplelink/cc32xx/Kconfig.defconfig.cc3220sf
+++ b/soc/arm/ti_simplelink/cc32xx/Kconfig.defconfig.cc3220sf
@@ -44,4 +44,11 @@ config GPIO_CC32XX_A3
 
 endif # GPIO
 
+if !XIP
+config FLASH_SIZE
+	default 0
+config FLASH_BASE_ADDRESS
+	default 0
+endif
+
 endif # SOC_CC3220SF


### PR DESCRIPTION
In case of !XIP, set defaults for CONFIG_FLASH_SIZE and
CONFIG_FLASH_BASE_ADDRESS in Kconfig.

Fixes: #13113

Signed-off-by: Gil Pitney <gil.pitney@linaro.org>