### PR TITLE
systemview: Use proper task names when these are available.

### DIFF
--- a/subsys/debug/tracing/sysview.c
+++ b/subsys/debug/tracing/sysview.c
@@ -55,6 +55,7 @@ static void send_task_list_cb(void)
 
 	for (thread = _kernel.threads; thread; thread = thread->next_thread) {
 		char name[20];
+		char *tname = k_thread_name_get(thread);
 
 		if (is_idle_thread(thread)) {
 			continue;
@@ -64,7 +65,7 @@ static void send_task_list_cb(void)
 			 (uintptr_t)&thread->entry);
 		SEGGER_SYSVIEW_SendTaskInfo(&(SEGGER_SYSVIEW_TASKINFO) {
 			.TaskID = (u32_t)(uintptr_t)thread,
-			.sName = name,
+		      .sName = tname?tname:name,
 			.StackSize = thread->stack_info.size,
 			.StackBase = thread->stack_info.start,
 			.Prio = thread->base.prio,


### PR DESCRIPTION
Trivial patch to recover the task name from the task structure when it
is present and include it in the information returned to SystemView.
When these data are not present patch will revert to old behaviour.

Signed-off-by: Dave Marples <dave@marples.net>