### PR TITLE
gpio: gpio_sch: fix check for interrupt trigger

### DIFF
--- a/drivers/gpio/gpio_sch.c
+++ b/drivers/gpio/gpio_sch.c
@@ -132,9 +132,11 @@ static int gpio_sch_config(struct device *dev,
 	const struct gpio_sch_config *info = dev->config->config_info;
 
 	/* Do some sanity check first */
-	if (flags & (GPIO_INT | GPIO_INT_LEVEL)) {
-		/* controller does not support level trigger */
-		return -EINVAL;
+	if (flags & GPIO_INT) {
+		if (!(flags & GPIO_INT_EDGE)) {
+			/* controller does not support level trigger */
+			return -EINVAL;
+		}
 	}
 
 	if (access_op == GPIO_ACCESS_BY_PIN) {


### PR DESCRIPTION
The controller does not support trigger. However, the check for
this condition was incorrectly (as GPIO_INT_LEVEL is 0). So fix
it.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>