### PR TITLE
net: socket: Add zsock_freeaddrinfo()

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -194,6 +194,11 @@ int zsock_getaddrinfo(const char *host, const char *service,
 		      const struct zsock_addrinfo *hints,
 		      struct zsock_addrinfo **res);
 
+static inline void zsock_freeaddrinfo(struct zsock_addrinfo *ai)
+{
+	free(ai);
+}
+
 #if defined(CONFIG_NET_SOCKETS_POSIX_NAMES)
 
 #define pollfd zsock_pollfd
@@ -312,7 +317,7 @@ static inline int getaddrinfo(const char *host, const char *service,
 
 static inline void freeaddrinfo(struct zsock_addrinfo *ai)
 {
-	free(ai);
+	zsock_freeaddrinfo(ai);
 }
 
 #define addrinfo zsock_addrinfo


### PR DESCRIPTION
The convention is that implementation of any Socket API function
lives in zsock_*(), and then it's optionally aliased to bare POSIX
name if requested. This convention must be followed to get proper
integration into the general POSIX subsystem.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>