### PR TITLE
gpio: rebased bug fixes from #11880

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -64,7 +64,7 @@ static int convert_int_type(int flags)
 		return 2;	/* Defaults to falling edge. */
 	}
 
-	if ((flags & GPIO_INT_LEVEL) == GPIO_INT_LEVEL) {
+	if ((flags & GPIO_INT_EDGE) == GPIO_INT_LEVEL) {
 		if ((flags & GPIO_INT_ACTIVE_HIGH) == GPIO_INT_ACTIVE_HIGH) {
 			return 5;
 		}

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
@@ -93,7 +93,7 @@ static int test_callback(int mode)
 		goto pass_exit;
 	}
 
-	if ((mode & GPIO_INT_LEVEL) == GPIO_INT_LEVEL) {
+	if ((mode & GPIO_INT_EDGE) == GPIO_INT_LEVEL) {
 		if (cb_cnt != MAX_INT_CNT) {
 			TC_ERROR("not trigger callback correctly\n");
 			goto err_exit;


### PR DESCRIPTION
Relates to #13076 and #13143.  This, by the way, is exactly why something like:

```
   if ((flags & FOO_MASK) == FOO_VALUE) { }
```

is superior to:
```
   if (flags & FOO_VALUE) { }
```
