### PR TITLE
boards: quark_se_c1000_ss_devboard: fix build warning

### DIFF
--- a/soc/arc/quark_se_c1000_ss/power.c
+++ b/soc/arc/quark_se_c1000_ss/power.c
@@ -68,11 +68,12 @@ void sys_set_power_state(enum power_states state)
 
 void sys_power_state_post_ops(enum power_states state)
 {
+	u32_t limit;
 	switch (state) {
 #if (defined(CONFIG_SYS_POWER_LOW_POWER_STATE))
 	case SYS_POWER_STATE_CPU_LPS_1:
 		/* Expire the timer as it is disabled in SS2. */
-		u32_t limit = _arc_v2_aux_reg_read(_ARC_V2_TMR0_LIMIT);
+		limit = _arc_v2_aux_reg_read(_ARC_V2_TMR0_LIMIT);
 		_arc_v2_aux_reg_write(_ARC_V2_TMR0_COUNT, limit - 1);
 	case SYS_POWER_STATE_CPU_LPS:
 		__builtin_arc_seti(0);


### PR DESCRIPTION
error: a label can only be part of a statement and a declaration is not a
statement u32_t limit = _arc_v2_aux_reg_read(_ARC_V2_TMR0_LIMIT);