### PR TITLE
scripts/dts cleanups, part 2

### DIFF
--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -230,13 +230,12 @@ def get_parent_address(node_address):
 def find_parent_prop(node_address, prop):
     parent_address = get_parent_address(node_address)
 
-    if prop in reduced[parent_address]['props']:
-        parent_prop = reduced[parent_address]['props'].get(prop)
-    else:
+    if prop not in reduced[parent_address]['props']:
         raise Exception("Parent of node " + node_address +
                         " has no " + prop + " property")
 
-    return parent_prop
+    return reduced[parent_address]['props'][prop]
+
 
 # Get the #{address,size}-cells for a given node
 def get_addr_size_cells(node_address):

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -218,13 +218,9 @@ def get_node_label(node_address):
         def_label += '_' + str_to_label(node_address.split('/')[-1])
     return def_label
 
+
 def get_parent_address(node_address):
-    parent_address = ''
-
-    for comp in node_address.split('/')[1:-1]:
-        parent_address += '/' + comp
-
-    return parent_address
+    return '/'.join(node_address.split('/')[:-1])
 
 
 def find_parent_prop(node_address, prop):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -395,9 +395,9 @@ def yaml_traverse_inherited(fname, node):
     return node
 
 
-def get_key_value(k, v, value_tabs):
-    line = "#define " + k
-    return line + (value_tabs - len(line)//8)*'\t' + str(v) + '\n'
+def define_str(name, value, value_tabs):
+    line = "#define " + name
+    return line + (value_tabs - len(line)//8)*'\t' + str(value) + '\n'
 
 
 def write_conf(f):
@@ -443,11 +443,11 @@ def write_header(f):
 
         for prop in sorted(defs[node]):
             if prop != 'aliases':
-                f.write(get_key_value(prop, defs[node][prop], value_tabs))
+                f.write(define_str(prop, defs[node][prop], value_tabs))
 
         for alias in sorted(defs[node]['aliases']):
             alias_target = defs[node]['aliases'][alias]
-            f.write(get_key_value(alias, alias_target, value_tabs))
+            f.write(define_str(alias, alias_target, value_tabs))
 
         f.write('\n')
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -428,10 +428,6 @@ def output_keyvalue_lines(fd):
 
         fd.write("\n")
 
-def generate_keyvalue_file(kv_file):
-    with open(kv_file, "w") as fd:
-        output_keyvalue_lines(fd)
-
 
 def output_include_lines(fd):
     fd.write('''\
@@ -475,18 +471,6 @@ def output_include_lines(fd):
         fd.write("\n")
 
     fd.write("#endif\n")
-
-
-def generate_include_file(inc_file):
-    with open(inc_file, "w") as fd:
-        output_include_lines(fd)
-
-
-def load_and_parse_dts(dts_file):
-    with open(dts_file, "r", encoding="utf-8") as fd:
-        dts = parse_file(fd)
-
-    return dts
 
 
 def load_yaml_descriptions(dts, yaml_dirs):
@@ -546,9 +530,11 @@ def main():
     args = parse_arguments()
     enable_old_alias_names(args.old_alias_names)
 
-    dts = load_and_parse_dts(args.dts)
+    # Parse DTS
+    with open(args.dts, 'r', encoding='utf-8') as f:
+        dts = parse_file(f)
 
-    # build up useful lists
+    # Build up useful lists
     get_reduced(dts['/'], '/')
     get_phandles(dts['/'], '/', {})
     get_aliases(dts['/'])
@@ -563,12 +549,15 @@ def main():
     for c in sorted(chosen):
         insert_defs('chosen', {'DT_CHOSEN_' + str_to_label(c): '1'}, {})
 
-     # generate config and include file
+    # Generate config and header files
+
     if args.keyvalue is not None:
-       generate_keyvalue_file(args.keyvalue)
+        with open(args.keyvalue, 'w', encoding='utf-8') as f:
+            output_keyvalue_lines(f)
 
     if args.include is not None:
-       generate_include_file(args.include)
+        with open(args.include, 'w', encoding='utf-8') as f:
+            output_include_lines(f)
 
 
 if __name__ == '__main__':

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -138,24 +138,22 @@ class Bindings(yaml.Loader):
         with open(filepaths[0], 'r', encoding='utf-8') as f:
             return yaml.load(f, Bindings)
 
-def extract_single(node_address, prop, key, def_label):
+def extract_single(node_address, def_label):
 
     prop_alias = {}
 
-    k = str_to_label(key)
-    label = def_label + '_' + k
+    label = def_label + '_BUS_NAME'
 
-    if prop == 'parent-label':
-        prop = find_parent_prop(node_address, 'label')
+    prop = find_parent_prop(node_address, 'label')
 
     prop = "\"" + prop + "\""
-    add_compat_alias(node_address, k, label, prop_alias)
+    add_compat_alias(node_address, 'BUS_NAME', label, prop_alias)
 
     # generate defs for node aliases
     if node_address in aliases:
         add_prop_aliases(
             node_address,
-            lambda alias: str_to_label(alias) + '_' + k,
+            lambda alias: str_to_label(alias) + '_BUS_NAME',
             label,
             prop_alias)
 
@@ -224,8 +222,7 @@ def extract_property(node_compat, node_address, prop, prop_val, names):
             def_label = parent_label + '_' + def_label
 
             # Generate bus-name define
-            extract_single(node_address, 'parent-label',
-                           'bus-name', 'DT_' + def_label)
+            extract_single(node_address, 'DT_' + def_label)
 
     if 'base_label' not in yaml_node_compat:
         def_label = 'DT_' + def_label

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -414,23 +414,23 @@ def get_key_value(k, v, tabstop):
     return line
 
 
-def output_keyvalue_lines(fd):
+def write_conf(f):
     for node in sorted(defs):
-        fd.write('# ' + node.split('/')[-1] + '\n')
+        f.write('# ' + node.split('/')[-1] + '\n')
 
         for prop in sorted(defs[node]):
             if prop != 'aliases':
-                fd.write('%s=%s\n' % (prop, defs[node][prop]))
+                f.write('%s=%s\n' % (prop, defs[node][prop]))
 
         for alias in sorted(defs[node]['aliases']):
             alias_target = defs[node]['aliases'][alias]
-            fd.write('%s=%s\n' % (alias, defs[node].get(alias_target)))
+            f.write('%s=%s\n' % (alias, defs[node].get(alias_target)))
 
-        fd.write('\n')
+        f.write('\n')
 
 
-def output_include_lines(fd):
-    fd.write('''\
+def write_header(f):
+    f.write('''\
 /**********************************************
 *                 Generated include file
 *                      DO NOT MODIFY
@@ -442,8 +442,8 @@ def output_include_lines(fd):
 
     node_keys = sorted(defs)
     for node in node_keys:
-        fd.write('/* ' + node.split('/')[-1] + ' */')
-        fd.write("\n")
+        f.write('/* ' + node.split('/')[-1] + ' */')
+        f.write("\n")
 
         max_dict_key = lambda d: max(len(k) for k in d)
         maxlength = 0
@@ -464,13 +464,13 @@ def output_include_lines(fd):
             if prop == 'aliases':
                 for entry in sorted(defs[node][prop]):
                     a = defs[node][prop][entry]
-                    fd.write(get_key_value(entry, a, maxtabstop))
+                    f.write(get_key_value(entry, a, maxtabstop))
             else:
-                fd.write(get_key_value(prop, defs[node][prop], maxtabstop))
+                f.write(get_key_value(prop, defs[node][prop], maxtabstop))
 
-        fd.write("\n")
+        f.write("\n")
 
-    fd.write("#endif\n")
+    f.write("#endif\n")
 
 
 def load_yaml_descriptions(dts, yaml_dirs):
@@ -551,11 +551,11 @@ def main():
 
     if args.keyvalue is not None:
         with open(args.keyvalue, 'w', encoding='utf-8') as f:
-            output_keyvalue_lines(f)
+            write_conf(f)
 
     if args.include is not None:
         with open(args.include, 'w', encoding='utf-8') as f:
-            output_include_lines(f)
+            write_header(f)
 
 
 if __name__ == '__main__':

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -529,12 +529,12 @@ def parse_arguments():
     rdh = argparse.RawDescriptionHelpFormatter
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=rdh)
 
-    parser.add_argument("-d", "--dts", nargs=1, required=True, help="DTS file")
+    parser.add_argument("-d", "--dts", required=True, help="DTS file")
     parser.add_argument("-y", "--yaml", nargs='+', required=True,
                         help="YAML file directories, we allow multiple")
-    parser.add_argument("-i", "--include", nargs=1,
+    parser.add_argument("-i", "--include",
                         help="Generate include file for the build system")
-    parser.add_argument("-k", "--keyvalue", nargs=1,
+    parser.add_argument("-k", "--keyvalue",
                         help="Generate config file for the build system")
     parser.add_argument("--old-alias-names", action='store_true',
                         help="Generate aliases also in the old way, without "
@@ -546,7 +546,7 @@ def main():
     args = parse_arguments()
     enable_old_alias_names(args.old_alias_names)
 
-    dts = load_and_parse_dts(args.dts[0])
+    dts = load_and_parse_dts(args.dts)
 
     # build up useful lists
     get_reduced(dts['/'], '/')
@@ -565,10 +565,10 @@ def main():
 
      # generate config and include file
     if args.keyvalue is not None:
-       generate_keyvalue_file(args.keyvalue[0])
+       generate_keyvalue_file(args.keyvalue)
 
     if args.include is not None:
-       generate_include_file(args.include[0])
+       generate_include_file(args.include)
 
 
 if __name__ == '__main__':

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -436,17 +436,14 @@ def write_header(f):
 */
 #ifndef GENERATED_DTS_BOARD_UNFIXED_H
 #define GENERATED_DTS_BOARD_UNFIXED_H
-    '''
-    )
+''')
 
-    node_keys = sorted(defs)
-    for node in node_keys:
-        f.write('/* ' + node.split('/')[-1] + ' */')
-        f.write("\n")
+    for node in sorted(defs):
+        f.write('/* ' + node.split('/')[-1] + ' */\n')
 
         max_dict_key = lambda d: max(len(k) for k in d)
         maxlength = 0
-        if defs[node].get('aliases'):
+        if defs[node]['aliases']:
             maxlength = max_dict_key(defs[node]['aliases'])
         maxlength = max(maxlength, max_dict_key(defs[node])) + len('#define ')
 
@@ -458,18 +455,17 @@ def write_header(f):
         if maxtabstop * 8 - maxlength <= 2:
             maxtabstop += 1
 
-        prop_keys = sorted(defs[node])
-        for prop in prop_keys:
-            if prop == 'aliases':
-                for entry in sorted(defs[node][prop]):
-                    a = defs[node][prop][entry]
-                    f.write(get_key_value(entry, a, maxtabstop))
-            else:
+        for prop in sorted(defs[node]):
+            if prop != 'aliases':
                 f.write(get_key_value(prop, defs[node][prop], maxtabstop))
 
-        f.write("\n")
+        for alias in sorted(defs[node]['aliases']):
+            alias_target = defs[node]['aliases'][alias]
+            f.write(get_key_value(alias, alias_target, maxtabstop))
 
-    f.write("#endif\n")
+        f.write('\n')
+
+    f.write('#endif\n')
 
 
 def load_yaml_descriptions(dts, yaml_dirs):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -214,9 +214,8 @@ def extract_property(node_compat, node_address, prop, prop_val, names):
                         # Need to generate alias name for this node:
                         aliases[node_address].append(node_alias)
 
-            # Use parent label to generate label
-            parent_label = get_node_label(parent_address)
-            def_label = parent_label + '_' + def_label
+            # Build the name from the parent node's label
+            def_label = get_node_label(parent_address) + '_' + def_label
 
             # Generate *_BUS_NAME #define
             extract_bus_name(node_address, 'DT_' + def_label)

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -138,7 +138,7 @@ class Bindings(yaml.Loader):
         with open(filepaths[0], 'r', encoding='utf-8') as f:
             return yaml.load(f, Bindings)
 
-def extract_single(node_address, def_label):
+def extract_bus_name(node_address, def_label):
     label = def_label + '_BUS_NAME'
     prop_alias = {}
 
@@ -218,8 +218,8 @@ def extract_property(node_compat, node_address, prop, prop_val, names):
             parent_label = get_node_label(parent_address)
             def_label = parent_label + '_' + def_label
 
-            # Generate bus-name define
-            extract_single(node_address, 'DT_' + def_label)
+            # Generate *_BUS_NAME #define
+            extract_bus_name(node_address, 'DT_' + def_label)
 
     if 'base_label' not in yaml_node_compat:
         def_label = 'DT_' + def_label

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -143,36 +143,23 @@ def extract_single(node_address, prop, key, def_label):
     prop_def = {}
     prop_alias = {}
 
-    if isinstance(prop, list):
-        for i, p in enumerate(prop):
-            k = str_to_label(key)
-            label = def_label + '_' + k
-            if isinstance(p, str):
-                p = "\"" + p + "\""
-            add_compat_alias(node_address,
-                    k + '_' + str(i),
-                    label + '_' + str(i),
-                    prop_alias)
-            prop_def[label + '_' + str(i)] = p
-    else:
-        k = str_to_label(key)
-        label = def_label + '_' + k
+    k = str_to_label(key)
+    label = def_label + '_' + k
 
-        if prop == 'parent-label':
-            prop = find_parent_prop(node_address, 'label')
+    if prop == 'parent-label':
+        prop = find_parent_prop(node_address, 'label')
 
-        if isinstance(prop, str):
-            prop = "\"" + prop + "\""
-        add_compat_alias(node_address, k, label, prop_alias)
-        prop_def[label] = prop
+    prop = "\"" + prop + "\""
+    add_compat_alias(node_address, k, label, prop_alias)
+    prop_def[label] = prop
 
-        # generate defs for node aliases
-        if node_address in aliases:
-            add_prop_aliases(
-                node_address,
-                lambda alias: str_to_label(alias) + '_' + k,
-                label,
-                prop_alias)
+    # generate defs for node aliases
+    if node_address in aliases:
+        add_prop_aliases(
+            node_address,
+            lambda alias: str_to_label(alias) + '_' + k,
+            label,
+            prop_alias)
 
     insert_defs(node_address, prop_def, prop_alias)
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -139,17 +139,12 @@ class Bindings(yaml.Loader):
             return yaml.load(f, Bindings)
 
 def extract_single(node_address, def_label):
-
+    label = def_label + '_BUS_NAME'
     prop_alias = {}
 
-    label = def_label + '_BUS_NAME'
-
-    prop = find_parent_prop(node_address, 'label')
-
-    prop = "\"" + prop + "\""
     add_compat_alias(node_address, 'BUS_NAME', label, prop_alias)
 
-    # generate defs for node aliases
+    # Generate defines for node aliases
     if node_address in aliases:
         add_prop_aliases(
             node_address,
@@ -157,7 +152,9 @@ def extract_single(node_address, def_label):
             label,
             prop_alias)
 
-    insert_defs(node_address, {label: prop}, prop_alias)
+    insert_defs(node_address,
+                {label: '"' + find_parent_prop(node_address, 'label') + '"'},
+                prop_alias)
 
 def extract_string_prop(node_address, key, label):
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -140,7 +140,6 @@ class Bindings(yaml.Loader):
 
 def extract_single(node_address, prop, key, def_label):
 
-    prop_def = {}
     prop_alias = {}
 
     k = str_to_label(key)
@@ -151,7 +150,6 @@ def extract_single(node_address, prop, key, def_label):
 
     prop = "\"" + prop + "\""
     add_compat_alias(node_address, k, label, prop_alias)
-    prop_def[label] = prop
 
     # generate defs for node aliases
     if node_address in aliases:
@@ -161,7 +159,7 @@ def extract_single(node_address, prop, key, def_label):
             label,
             prop_alias)
 
-    insert_defs(node_address, prop_def, prop_alias)
+    insert_defs(node_address, {label: prop}, prop_alias)
 
 def extract_string_prop(node_address, key, label):
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -490,7 +490,7 @@ def generate_node_definitions():
         if node_compat is not None and node_compat in get_binding_compats():
             extract_node_include_info(reduced, k, k, None)
 
-    if defs == {}:
+    if not defs:
         raise Exception("No information parsed from dts file.")
 
     for k, v in regs_config.items():
@@ -505,8 +505,6 @@ def generate_node_definitions():
     flash.extract(node_address, 'zephyr,flash', 'FLASH')
     node_address = chosen.get('zephyr,code-partition', node_address)
     flash.extract(node_address, 'zephyr,code-partition', 'FLASH')
-
-    return defs
 
 
 def parse_arguments():
@@ -543,7 +541,7 @@ def main():
     (extract.globals.bindings, extract.globals.bus_bindings,
      extract.globals.bindings_compat) = load_yaml_descriptions(dts, args.yaml)
 
-    defs = generate_node_definitions()
+    generate_node_definitions()
 
     # Add DT_CHOSEN_<X> defines to generated files
     for c in sorted(chosen):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -169,6 +169,9 @@ def extract_string_prop(node_address, key, label):
         defs[node_address].update(prop_def)
     else:
         defs[node_address] = prop_def
+        # Make all defs have the special 'aliases' key, to remove existence
+        # checks elsewhere
+        defs[node_address]['aliases'] = {}
 
 
 def extract_property(node_compat, node_address, prop, prop_val, names):
@@ -412,21 +415,18 @@ def get_key_value(k, v, tabstop):
 
 
 def output_keyvalue_lines(fd):
-    node_keys = sorted(defs)
-    for node in node_keys:
-        fd.write('# ' + node.split('/')[-1])
-        fd.write("\n")
+    for node in sorted(defs):
+        fd.write('# ' + node.split('/')[-1] + '\n')
 
-        prop_keys = sorted(defs[node])
-        for prop in prop_keys:
-            if prop == 'aliases':
-                for entry in sorted(defs[node][prop]):
-                    a = defs[node][prop][entry]
-                    fd.write("%s=%s\n" % (entry, defs[node].get(a)))
-            else:
-                fd.write("%s=%s\n" % (prop, defs[node][prop]))
+        for prop in sorted(defs[node]):
+            if prop != 'aliases':
+                fd.write('%s=%s\n' % (prop, defs[node][prop]))
 
-        fd.write("\n")
+        for alias in sorted(defs[node]['aliases']):
+            alias_target = defs[node]['aliases'][alias]
+            fd.write('%s=%s\n' % (alias, defs[node].get(alias_target)))
+
+        fd.write('\n')
 
 
 def output_include_lines(fd):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -9,7 +9,6 @@
 # vim: ai:ts=4:sw=4
 
 import sys
-from os import listdir
 import os, fnmatch
 import re
 import yaml


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/zephyr/pull/13118.

Removes more dead code, and turns `extract_single()` into `extract_bus_name()`, which is how it's used by its sole caller.

Other misc. simplifications and renamings are included as well.