### PR TITLE
api: rename counter_disable_channel_alarm to counter_cancel_channel_alarm

### DIFF
--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -165,7 +165,7 @@ static int rtc_stm32_set_alarm(struct device *dev, u8_t chan_id,
 }
 
 
-static int rtc_stm32_disable_alarm(struct device *dev, u8_t chan_id)
+static int rtc_stm32_cancel_alarm(struct device *dev, u8_t chan_id)
 {
 	LL_RTC_DisableWriteProtection(RTC);
 	LL_RTC_ClearFlag_ALRA(RTC);
@@ -343,7 +343,7 @@ static const struct counter_driver_api rtc_stm32_driver_api = {
 		.stop = rtc_stm32_stop,
 		.read = rtc_stm32_read,
 		.set_alarm = rtc_stm32_set_alarm,
-		.disable_alarm = rtc_stm32_disable_alarm,
+		.cancel_alarm = rtc_stm32_cancel_alarm,
 		.set_top_value = rtc_stm32_set_top_value,
 		.get_pending_int = rtc_stm32_get_pending_int,
 		.get_top_value = rtc_stm32_get_top_value,

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -119,7 +119,7 @@ static int mcux_rtc_set_alarm(struct device *dev, u8_t chan_id,
 	return 0;
 }
 
-static int mcux_rtc_disable_alarm(struct device *dev, u8_t chan_id)
+static int mcux_rtc_cancel_alarm(struct device *dev, u8_t chan_id)
 {
 	struct mcux_rtc_data *data = dev->driver_data;
 
@@ -236,7 +236,7 @@ static const struct counter_driver_api mcux_rtc_driver_api = {
 	.stop = mcux_rtc_stop,
 	.read = mcux_rtc_read,
 	.set_alarm = mcux_rtc_set_alarm,
-	.disable_alarm = mcux_rtc_disable_alarm,
+	.cancel_alarm = mcux_rtc_cancel_alarm,
 	.set_top_value = mcux_rtc_set_top_value,
 	.get_pending_int = mcux_rtc_get_pending_int,
 	.get_top_value = mcux_rtc_get_top_value,

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -107,7 +107,7 @@ static void _disable(struct device *dev, u8_t id)
 	config->ch_data[id].callback = NULL;
 }
 
-static int counter_nrfx_disable_alarm(struct device *dev, u8_t chan_id)
+static int counter_nrfx_cancel_alarm(struct device *dev, u8_t chan_id)
 {
 	_disable(dev, chan_id);
 
@@ -230,7 +230,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 	.stop = counter_nrfx_stop,
 	.read = counter_nrfx_read,
 	.set_alarm = counter_nrfx_set_alarm,
-	.disable_alarm = counter_nrfx_disable_alarm,
+	.cancel_alarm = counter_nrfx_cancel_alarm,
 	.set_top_value = counter_nrfx_set_top_value,
 	.get_pending_int = counter_nrfx_get_pending_int,
 	.get_top_value = counter_nrfx_get_top_value,

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -108,7 +108,7 @@ static void _disable(struct device *dev, u8_t id)
 	config->ch_data[id].callback = NULL;
 }
 
-static int counter_nrfx_disable_alarm(struct device *dev, u8_t chan_id)
+static int counter_nrfx_cancel_alarm(struct device *dev, u8_t chan_id)
 {
 	_disable(dev, chan_id);
 
@@ -214,7 +214,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 	.stop = counter_nrfx_stop,
 	.read = counter_nrfx_read,
 	.set_alarm = counter_nrfx_set_alarm,
-	.disable_alarm = counter_nrfx_disable_alarm,
+	.cancel_alarm = counter_nrfx_cancel_alarm,
 	.set_top_value = counter_nrfx_set_top_value,
 	.get_pending_int = counter_nrfx_get_pending_int,
 	.get_top_value = counter_nrfx_get_top_value,

--- a/drivers/counter/counter_rtc_qmsi.c
+++ b/drivers/counter/counter_rtc_qmsi.c
@@ -83,7 +83,7 @@ static int rtc_qmsi_disable(struct device *dev)
 	return 0;
 }
 
-static int rtc_qmsi_disable_alarm(struct device *dev,
+static int rtc_qmsi_cancel_alarm(struct device *dev,
 			const struct counter_alarm_cfg *alarm_cfg)
 {
 	clk_periph_disable(CLK_PERIPH_RTC_REGISTER);
@@ -158,7 +158,7 @@ static const struct counter_driver_api api = {
 	.read = rtc_qmsi_read,
 	.set_wrap = rtc_qmsi_set_wrap,
 	.set_alarm = rtc_qmsi_set_alarm,
-	.disable_alarm = rtc_qmsi_disable_alarm,
+	.cancel_alarm = rtc_qmsi_cancel_alarm,
 	.get_pending_int = rtc_qmsi_get_pending_int,
 };
 

--- a/include/counter.h
+++ b/include/counter.h
@@ -93,7 +93,7 @@ typedef int (*counter_api_stop)(struct device *dev);
 typedef u32_t (*counter_api_read)(struct device *dev);
 typedef int (*counter_api_set_alarm)(struct device *dev, u8_t chan_id,
 				const struct counter_alarm_cfg *alarm_cfg);
-typedef int (*counter_api_disable_alarm)(struct device *dev, u8_t chan_id);
+typedef int (*counter_api_cancel_alarm)(struct device *dev, u8_t chan_id);
 typedef int (*counter_api_set_top_value)(struct device *dev, u32_t ticks,
 				    counter_top_callback_t callback,
 				    void *user_data);
@@ -107,7 +107,7 @@ struct counter_driver_api {
 	counter_api_stop stop;
 	counter_api_read read;
 	counter_api_set_alarm set_alarm;
-	counter_api_disable_alarm disable_alarm;
+	counter_api_cancel_alarm cancel_alarm;
 	counter_api_set_top_value set_top_value;
 	counter_api_get_pending_int get_pending_int;
 	counter_api_get_top_value get_top_value;
@@ -286,7 +286,7 @@ static inline int counter_set_channel_alarm(struct device *dev, u8_t chan_id,
 }
 
 /**
- * @brief Disable an alarm on a channel.
+ * @brief Cancel an alarm on a channel.
  *
  * @note API is not thread safe.
  *
@@ -297,7 +297,7 @@ static inline int counter_set_channel_alarm(struct device *dev, u8_t chan_id,
  * @retval -ENOTSUP if request is not supported or the counter was not started
  *		    yet.
  */
-static inline int counter_disable_channel_alarm(struct device *dev,
+static inline int counter_cancel_channel_alarm(struct device *dev,
 						u8_t chan_id)
 {
 	const struct counter_driver_api *api = dev->driver_api;
@@ -306,7 +306,7 @@ static inline int counter_disable_channel_alarm(struct device *dev,
 		return -ENOTSUP;
 	}
 
-	return api->disable_alarm(dev, chan_id);
+	return api->cancel_alarm(dev, chan_id);
 }
 
 /**

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -202,7 +202,7 @@ void test_single_shot_alarm_instance(const char *dev_name, bool set_top)
 	k_busy_wait(1.5*counter_ticks_to_us(dev, ticks));
 	zassert_equal(1, alarm_cnt, "Expecting alarm callback\n");
 
-	err = counter_disable_channel_alarm(dev, 0);
+	err = counter_cancel_channel_alarm(dev, 0);
 	zassert_equal(0, err, "Counter disabling alarm failed\n");
 
 	err = counter_set_top_value(dev, counter_get_max_top_value(dev),
@@ -300,10 +300,10 @@ void test_multiple_alarms_instance(const char *dev_name)
 			"Expected different order or callbacks\n");
 
 	/* tear down */
-	err = counter_disable_channel_alarm(dev, 0);
+	err = counter_cancel_channel_alarm(dev, 0);
 	zassert_equal(0, err, "Counter disabling alarm failed\n");
 
-	err = counter_disable_channel_alarm(dev, 1);
+	err = counter_cancel_channel_alarm(dev, 1);
 	zassert_equal(0, err, "Counter disabling alarm failed\n");
 }
 
@@ -350,12 +350,12 @@ void test_all_channels_instance(const char *str)
 	zassert_equal(nchan, alarm_cnt, "Expecting alarm callback\n");
 
 	for (int i = 0; i < nchan; i++) {
-		err = counter_disable_channel_alarm(dev, i);
+		err = counter_cancel_channel_alarm(dev, i);
 		zassert_equal(0, err, "Unexpected error on disabling alarm");
 	}
 
 	for (int i = nchan; i < n; i++) {
-		err = counter_disable_channel_alarm(dev, i);
+		err = counter_cancel_channel_alarm(dev, i);
 		zassert_equal(-ENOTSUP, err,
 				"Unexpected error on disabling alarm\n");
 	}


### PR DESCRIPTION
The topic-counters has just been merged. However, it seems like the one last change which was agreed upon has been overlooked. Namely aligning the names of `counter_set_channel_alarm` / `counter_disable_channel_alarm` functions.

This commit renames `counter_disable_channel_alarm()` to `counter_cancel_channel_alarm()` which, I believe, was the last agreed upon name.