### PR TITLE
boards: Change supported 'rtc' to 'counter' for QMSI RTC based boards

### DIFF
--- a/boards/arc/arduino_101_sss/arduino_101_sss.yaml
+++ b/boards/arc/arduino_101_sss/arduino_101_sss.yaml
@@ -11,7 +11,7 @@ supported:
   - i2c
   - spi
   - gpio
-  - rtc
+  - counter
   - watchdog
 testing:
   ignore_tags:

--- a/boards/arc/quark_se_c1000_ss_devboard/quark_se_c1000_ss_devboard.yaml
+++ b/boards/arc/quark_se_c1000_ss_devboard/quark_se_c1000_ss_devboard.yaml
@@ -12,7 +12,7 @@ supported:
   - i2c
   - spi
   - gpio
-  - rtc
+  - counter
   - watchdog
 testing:
   ignore_tags:

--- a/boards/x86/quark_d2000_crb/quark_d2000_crb.yaml
+++ b/boards/x86/quark_d2000_crb/quark_d2000_crb.yaml
@@ -14,7 +14,7 @@ supported:
   - spi
   - gpio
   - aio
-  - rtc
+  - counter
   - watchdog
   - dma
   - pwm

--- a/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.yaml
+++ b/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.yaml
@@ -12,7 +12,7 @@ supported:
   - i2c
   - spi
   - gpio
-  - rtc
+  - counter
   - aio
   - watchdog
   - dma


### PR DESCRIPTION
We've removed the QMSI RTC driver as part of the new counter API.  So
any old rtc tests don't build for QMSI based boards anymore.  Switch
this from 'rtc' to 'counter' in the board.yaml.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>