### PR TITLE
driver: eth: gmac: scale down the TX path

### DIFF
--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -177,7 +177,7 @@ struct gmac_queue {
 	struct k_sem tx_sem;
 #endif
 
-	struct ring_buf rx_frag_list;
+	struct net_buf **rx_frag_list;
 
 #if GMAC_MULTIPLE_TX_PACKETS == 1
 	struct ring_buf tx_frag_list;

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -12,6 +12,13 @@
 
 #include <zephyr/types.h>
 
+/* This option enables support to push multiple packets to the DMA engine.
+ * This currently doesn't work given the current version of net_pkt or
+ * net_buf does not allowed access from multiple threads. This option is
+ * therefore currenlty disabled.
+ */
+#define GMAC_MULTIPLE_TX_PACKETS 0
+
 #define GMAC_MTU 1500
 #define GMAC_FRAME_SIZE_MAX (GMAC_MTU + 18)
 
@@ -164,12 +171,19 @@ struct gmac_desc_list {
 struct gmac_queue {
 	struct gmac_desc_list rx_desc_list;
 	struct gmac_desc_list tx_desc_list;
+#if GMAC_MULTIPLE_TX_PACKETS == 1
 	struct k_sem tx_desc_sem;
+#else
+	struct k_sem tx_sem;
+#endif
 
 	struct ring_buf rx_frag_list;
+
+#if GMAC_MULTIPLE_TX_PACKETS == 1
 	struct ring_buf tx_frag_list;
 #if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
 	struct ring_buf tx_frames;
+#endif
 #endif
 
 	/** Number of RX frames dropped by the driver */


### PR DESCRIPTION
This PR downscale the TX path following the discussion in PR #12563. It means that the GMAC driver is now safe with regard to this PR, even in the PTP case.