### PR TITLE
Misc fixes for socket CAN

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -314,7 +314,7 @@ endif # NET_UDP
 
 config NET_MAX_CONN
 	int "How many network connections are supported"
-	depends on NET_UDP || NET_TCP || NET_SOCKETS_PACKET
+	depends on NET_UDP || NET_TCP || NET_SOCKETS_PACKET || NET_SOCKETS_CAN
 	default 8 if NET_IPV6 && NET_IPV4
 	default 4
 	help

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -922,6 +922,9 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET)) {
 			best_rank = 0;
 			best_match = i;
+		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN)) {
+			best_rank = 0;
+			best_match = i;
 		}
 	}
 

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -50,7 +50,14 @@ LOG_MODULE_REGISTER(net_pkt, CONFIG_NET_PKT_LOG_LEVEL);
 #if defined(CONFIG_NET_IPV4)
 #define MAX_IP_PROTO_LEN NET_IPV4H_LEN
 #else
+#if defined(CONFIG_NET_SOCKETS_CAN)
+/* TODO: Use CAN MTU here instead of hard coded value. There was
+ * weird circular dependency issue so this needs more TLC.
+ */
+#define MAX_IP_PROTO_LEN 8
+#else
 #error "Either IPv6 or IPv4 needs to be selected."
+#endif /* SOCKETS_CAN */
 #endif /* IPv4 */
 #endif /* IPv6 */
 
@@ -61,8 +68,12 @@ LOG_MODULE_REGISTER(net_pkt, CONFIG_NET_PKT_LOG_LEVEL);
 #if defined(CONFIG_NET_UDP)
 #define MAX_NEXT_PROTO_LEN NET_UDPH_LEN
 #else
+#if defined(CONFIG_NET_SOCKETS_CAN)
+#define MAX_NEXT_PROTO_LEN 0
+#else
 /* If no TCP and no UDP, apparently we still want pings to work. */
 #define MAX_NEXT_PROTO_LEN NET_ICMPH_LEN
+#endif /* SOCKETS_CAN */
 #endif /* UDP */
 #endif /* TCP */
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -851,6 +851,10 @@ static void get_addresses(struct net_context *context,
 #endif
 	if (context->local.family == AF_UNSPEC) {
 		snprintk(addr_local, local_len, "AF_UNSPEC");
+	} else if (context->local.family == AF_PACKET) {
+		snprintk(addr_local, local_len, "AF_PACKET");
+	} else if (context->local.family == AF_CAN) {
+		snprintk(addr_local, local_len, "AF_CAN");
 	} else {
 		snprintk(addr_local, local_len, "AF_UNK(%d)",
 			 context->local.family);
@@ -879,9 +883,13 @@ static void context_cb(struct net_context *context, void *user_data)
 	PR("[%2d] %p\t%p    %c%c%c   %16s\t%16s\n",
 	   (*count) + 1, context,
 	   net_context_get_iface(context),
-	   net_context_get_family(context) == AF_INET6 ? '6' : '4',
-	   net_context_get_type(context) == SOCK_DGRAM ? 'D' : 'S',
-	   net_context_get_ip_proto(context) == IPPROTO_UDP ? 'U' : 'T',
+	   net_context_get_family(context) == AF_INET6 ? '6' :
+	   (net_context_get_family(context) == AF_INET ? '4' : ' '),
+	   net_context_get_type(context) == SOCK_DGRAM ? 'D' :
+	   (net_context_get_type(context) == SOCK_STREAM ? 'S' :
+	    (net_context_get_type(context) == SOCK_RAW ? 'R' : ' ')),
+	   net_context_get_ip_proto(context) == IPPROTO_UDP ? 'U' :
+	   (net_context_get_ip_proto(context) == IPPROTO_TCP ? 'T' : ' '),
 	   addr_local, addr_remote);
 
 	(*count)++;

--- a/subsys/net/l2/canbus/canbus.c
+++ b/subsys/net/l2/canbus/canbus.c
@@ -18,10 +18,10 @@ static inline enum net_verdict canbus_recv(struct net_if *iface,
 {
 	net_pkt_lladdr_src(pkt)->addr = NULL;
 	net_pkt_lladdr_src(pkt)->len = 0;
-	net_pkt_lladdr_src(pkt)->type = NET_LINK_DUMMY;
+	net_pkt_lladdr_src(pkt)->type = NET_LINK_CANBUS;
 	net_pkt_lladdr_dst(pkt)->addr = NULL;
 	net_pkt_lladdr_dst(pkt)->len = 0;
-	net_pkt_lladdr_dst(pkt)->type = NET_LINK_DUMMY;
+	net_pkt_lladdr_dst(pkt)->type = NET_LINK_CANBUS;
 
 	net_pkt_set_family(pkt, AF_CAN);
 

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -98,7 +98,6 @@ config NET_SOCKETS_OFFLOAD
 
 config NET_SOCKETS_PACKET
 	bool "Enable packet socket support"
-	default n
 	depends on NET_L2_ETHERNET
 	help
 	  This is an initial version of packet socket support (special type
@@ -110,7 +109,6 @@ config NET_SOCKETS_PACKET
 
 config NET_SOCKETS_CAN
 	bool "Enable socket CAN support [EXPERIMENTAL]"
-	default n
 	select NET_L2_CANBUS
 	help
 	  The value depends on your network needs.

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -130,7 +130,7 @@ int _impl_zsock_socket(int family, int type, int proto)
 #endif
 
 #if defined(CONFIG_NET_SOCKETS_CAN)
-	if (family == AF_CAN && type == SOCK_RAW) {
+	if (family == AF_CAN) {
 		return zcan_socket(family, type, proto);
 	}
 #endif


### PR DESCRIPTION
Small fixes found after testing with nucleo board with more memory. Also fixed net-shell issues regarding "net conn" command when AF_CAN or AF_PACKET support is enabled.