### PR TITLE
soc: quark_se: Fixed build after recent changes in Power Management.

### DIFF
--- a/soc/arc/quark_se_c1000_ss/power.c
+++ b/soc/arc/quark_se_c1000_ss/power.c
@@ -68,13 +68,14 @@ void sys_set_power_state(enum power_states state)
 
 void sys_power_state_post_ops(enum power_states state)
 {
-	u32_t limit;
 	switch (state) {
 #if (defined(CONFIG_SYS_POWER_LOW_POWER_STATE))
 	case SYS_POWER_STATE_CPU_LPS_1:
-		/* Expire the timer as it is disabled in SS2. */
-		limit = _arc_v2_aux_reg_read(_ARC_V2_TMR0_LIMIT);
-		_arc_v2_aux_reg_write(_ARC_V2_TMR0_COUNT, limit - 1);
+		{
+			/* Expire the timer as it is disabled in SS2. */
+			u32_t limit = _arc_v2_aux_reg_read(_ARC_V2_TMR0_LIMIT);
+			_arc_v2_aux_reg_write(_ARC_V2_TMR0_COUNT, limit - 1);
+		}
 	case SYS_POWER_STATE_CPU_LPS:
 		__builtin_arc_seti(0);
 		break;

--- a/soc/x86/intel_quark/quark_se/power.c
+++ b/soc/x86/intel_quark/quark_se/power.c
@@ -60,6 +60,7 @@ static void _deep_sleep(enum power_states state)
 void sys_set_power_state(enum power_states state)
 {
 	switch (state) {
+#if (defined(CONFIG_SYS_POWER_LOW_POWER_STATE))
 	case SYS_POWER_STATE_CPU_LPS:
 		qm_power_cpu_c1();
 		break;
@@ -69,6 +70,7 @@ void sys_set_power_state(enum power_states state)
 	case SYS_POWER_STATE_CPU_LPS_2:
 		qm_power_cpu_c2lp();
 		break;
+#endif
 #if (defined(CONFIG_SYS_POWER_DEEP_SLEEP))
 	case SYS_POWER_STATE_DEEP_SLEEP:
 	case SYS_POWER_STATE_DEEP_SLEEP_1:
@@ -83,12 +85,14 @@ void sys_set_power_state(enum power_states state)
 void sys_power_state_post_ops(enum power_states state)
 {
 	switch (state) {
+#if (defined(CONFIG_SYS_POWER_LOW_POWER_STATE))
 	case SYS_POWER_STATE_CPU_LPS_2:
 		*_REG_TIMER_ICR = 1U;
 	case SYS_POWER_STATE_CPU_LPS_1:
 	case SYS_POWER_STATE_CPU_LPS:
 		__asm__ volatile("sti");
 		break;
+#endif
 #if (defined(CONFIG_SYS_POWER_DEEP_SLEEP))
 	case SYS_POWER_STATE_DEEP_SLEEP_1:
 #ifdef CONFIG_ARC_INIT


### PR DESCRIPTION
This PR adds the missinf #ifdefs fixig build when low power states
are not enabled.