### PR TITLE
arch: arm: mpu: Remove dead Kconfig reference

### DIFF
--- a/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
+++ b/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
@@ -147,11 +147,7 @@ void arm_core_mpu_configure_static_mpu_regions(
 /* Number of memory areas, inside which dynamic regions
  * may be programmed in run-time.
  */
-#if defined(CONFIG_APPLICATION_MEMORY)
-#define MPU_DYNAMIC_REGION_AREAS_NUM 2
-#else
 #define MPU_DYNAMIC_REGION_AREAS_NUM 1
-#endif
 
 /**
  * @brief mark a set of memory regions as eligible for dynamic configuration


### PR DESCRIPTION
CONFIG_APPLICATION_MEMORY doesn't exist anymore, so the bit of code in
arm_core_mpu_dev.h related to it is dead and should be removed.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>