### PR TITLE
shell: unify commands execution

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -24,7 +24,7 @@
 	#error too small SHELL_PRINTF_BUFF_SIZE
 #endif
 
-#define SHELL_MSG_COMMAND_NOT_FOUND	": command not found"
+#define SHELL_MSG_CMD_NOT_FOUND		": command not found"
 
 #define SHELL_INIT_OPTION_PRINTER	(NULL)
 
@@ -564,7 +564,7 @@ static int execute(const struct shell *shell)
 	size_t cmd_lvl = SHELL_CMD_ROOT_LVL;
 	size_t cmd_with_handler_lvl = 0;
 	bool wildcard_found = false;
-	size_t cmd_idx;
+	size_t cmd_idx = 0;
 	size_t argc;
 	char quote;
 
@@ -598,29 +598,13 @@ static int execute(const struct shell *shell)
 		return -ENOEXEC;
 	}
 
-	/*  Searching for a matching root command. */
-	p_cmd = shell_root_cmd_find(argv[0]);
-	if (p_cmd == NULL) {
-		shell_fprintf(shell, SHELL_ERROR, "%s%s\n", argv[0],
-			      SHELL_MSG_COMMAND_NOT_FOUND);
-		return -ENOEXEC;
-	}
-
-	/* checking if root command has a handler */
-	shell->ctx->active_cmd = *p_cmd->u.entry;
-	help_entry = *p_cmd->u.entry;
-
-	p_cmd = p_cmd->u.entry->subcmd;
-	cmd_lvl++;
-	cmd_idx = 0;
-
 	/* Below loop is analyzing subcommands of found root command. */
 	while (true) {
 		if (cmd_lvl >= argc) {
 			break;
 		}
 
-		if (IS_ENABLED(CONFIG_SHELL_HELP) &&
+		if (IS_ENABLED(CONFIG_SHELL_HELP) && (cmd_lvl > 0) &&
 		    (!strcmp(argv[cmd_lvl], "-h") ||
 		     !strcmp(argv[cmd_lvl], "--help"))) {
 			/* Command called with help option so it makes no sense
@@ -637,7 +621,7 @@ static int execute(const struct shell *shell)
 			return -ENOEXEC;
 		}
 
-		if (IS_ENABLED(CONFIG_SHELL_WILDCARD)) {
+		if (IS_ENABLED(CONFIG_SHELL_WILDCARD) && (cmd_lvl > 0)) {
 			enum shell_wildcard_status status;
 
 			status = shell_wildcard_process(shell, p_cmd,
@@ -663,31 +647,32 @@ static int execute(const struct shell *shell)
 			      &d_entry);
 
 		if ((cmd_idx == 0) || (p_static_entry == NULL)) {
+			if (cmd_lvl == 0) {
+				shell_error(shell, "%s%s", argv[0],
+					    SHELL_MSG_CMD_NOT_FOUND);
+				return -ENOEXEC;
+			}
 			break;
 		}
 
 		if (strcmp(argv[cmd_lvl], p_static_entry->syntax) == 0) {
 			/* checking if command has a handler */
 			if (p_static_entry->handler != NULL) {
-				if (IS_ENABLED(CONFIG_SHELL_WILDCARD)) {
-					if (wildcard_found) {
-						shell_op_cursor_end_move(shell);
-						shell_op_cond_next_line(shell);
+				if (IS_ENABLED(CONFIG_SHELL_WILDCARD) &&
+				    (wildcard_found)) {
+					shell_op_cursor_end_move(shell);
+					shell_op_cond_next_line(shell);
 
-						/* An error occurred, fnmatch
-						 * argument cannot be followed
-						 * by argument with a handler to
-						 * avoid multiple function
-						 * calls.
-						 */
-						shell_fprintf(shell,
-							SHELL_ERROR,
-							"Error: requested"
-							" multiple function"
-							" executions\n");
+					/* An error occurred, fnmatch  argument
+					 * cannot be followed by argument with
+					 * a handler to avoid multiple function
+					 * calls.
+					 */
+					shell_fprintf(shell, SHELL_ERROR,
+						"Error: requested multiple"
+						" function executions\n");
 
-						return -ENOEXEC;
-					}
+					return -ENOEXEC;
 				}
 
 				shell->ctx->active_cmd = *p_static_entry;
@@ -704,7 +689,7 @@ static int execute(const struct shell *shell)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_SHELL_WILDCARD)) {
+	if (IS_ENABLED(CONFIG_SHELL_WILDCARD) && wildcard_found) {
 		shell_wildcard_finalize(shell);
 		/* cmd_buffer has been overwritten by function finalize function
 		 * with all expanded commands. Hence shell_make_argv needs to

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -225,7 +225,7 @@ static inline u32_t shell_root_cmd_count(void)
 }
 
 /* Function returning pointer to root command matching requested syntax. */
-const struct shell_cmd_entry *shell_root_cmd_find(const char *syntax)
+const struct shell_static_entry *shell_root_cmd_find(const char *syntax)
 {
 	const size_t cmd_count = shell_root_cmd_count();
 	const struct shell_cmd_entry *cmd;
@@ -233,7 +233,7 @@ const struct shell_cmd_entry *shell_root_cmd_find(const char *syntax)
 	for (size_t cmd_idx = 0; cmd_idx < cmd_count; ++cmd_idx) {
 		cmd = shell_root_cmd_get(cmd_idx);
 		if (strcmp(syntax, cmd->u.entry->syntax) == 0) {
-			return cmd;
+			return cmd->u.entry;
 		}
 	}
 

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -64,7 +64,7 @@ void shell_cmd_get(const struct shell_cmd_entry *command, size_t lvl,
 int shell_command_add(char *buff, u16_t *buff_len,
 		      const char *new_cmd, const char *pattern);
 
-const struct shell_cmd_entry *shell_root_cmd_find(const char *syntax);
+const struct shell_static_entry *shell_root_cmd_find(const char *syntax);
 
 void shell_spaces_trim(char *str);
 


### PR DESCRIPTION
This change removes special handling of root commands.
Currently there is one loop in execute function that is used
to search commands on each level.

This change will allow to simplify "select" command
introduction.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>