### PR TITLE
dts: Convert CONFIG_CCM to DT_CCM

### DIFF
--- a/doc/guides/dts/index.rst
+++ b/doc/guides/dts/index.rst
@@ -298,7 +298,7 @@ The full set of Zephyr-specific ``chosen`` nodes follows:
    * - ``zephyr,sram``
      - ``CONFIG_SRAM``
    * - ``zephyr,ccm``
-     - ``CONFIG_CCM``
+     - ``DT_CCM``
    * - ``zephyr,console``
      - :option:`CONFIG_UART_CONSOLE_ON_DEV_NAME`
    * - ``zephyr,shell-uart``

--- a/doc/guides/kconfig/index.rst
+++ b/doc/guides/kconfig/index.rst
@@ -637,6 +637,10 @@ Device Tree Related Functions
            'm' or 'M'  divide by 1,048,576 (1 << 20)
            'g' or 'G'  divide by 1,073,741,824 (1 << 30)
 
+  dt_str_val(kconf, _, name):
+       This function looks up 'name' in the DTS generated "conf" style database
+       and if its found it will return the value as string.
+
 Example Usage
 =============
 

--- a/dts/bindings/arm/st,stm32-ccm.yaml
+++ b/dts/bindings/arm/st,stm32-ccm.yaml
@@ -19,6 +19,4 @@ properties:
       generation: define
       category: required
 
-base_label: CCM
-
 ...

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -93,8 +93,8 @@ MEMORY
 #ifdef CONFIG_TI_CCFG_PRESENT
     FLASH_CCFG            (rwx): ORIGIN = CCFG_ADDR, LENGTH = CCFG_SIZE
 #endif
-#ifdef CONFIG_CCM_BASE_ADDRESS
-    CCM                   (rw) : ORIGIN = CONFIG_CCM_BASE_ADDRESS, LENGTH = CONFIG_CCM_SIZE * 1K
+#ifdef DT_CCM_BASE_ADDRESS
+    CCM                   (rw) : ORIGIN = DT_CCM_BASE_ADDRESS, LENGTH = DT_CCM_SIZE * 1K
 #endif
     SRAM                  (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
 
@@ -455,7 +455,7 @@ SECTIONS
 
     GROUP_END(RAMABLE_REGION)
 
-#ifdef CONFIG_CCM_BASE_ADDRESS
+#ifdef DT_CCM_BASE_ADDRESS
 
     GROUP_START(CCM)
 
@@ -492,7 +492,7 @@ SECTIONS
 
     GROUP_END(CCM)
 
-#endif /* CONFIG_CCM_BASE_ADDRESS */
+#endif /* DT_CCM_BASE_ADDRESS */
 
 #ifdef CONFIG_CUSTOM_SECTIONS_LD
 /* Located in project source directory */

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -202,7 +202,7 @@ extern char __gcov_bss_size[];
 /* end address of image, used by newlib for the heap */
 extern char _end[];
 
-#ifdef CONFIG_CCM_BASE_ADDRESS
+#ifdef DT_CCM_BASE_ADDRESS
 extern char __ccm_data_rom_start[];
 extern char __ccm_start[];
 extern char __ccm_data_start[];
@@ -212,7 +212,7 @@ extern char __ccm_bss_end[];
 extern char __ccm_noinit_start[];
 extern char __ccm_noinit_end[];
 extern char __ccm_end[];
-#endif /* CONFIG_CCM_BASE_ADDRESS */
+#endif /* DT_CCM_BASE_ADDRESS */
 
 /* Used by the Security Attribution Unit to configure the
  * Non-Secure Callable region.

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -144,7 +144,7 @@ void _bss_zero(void)
 {
 	(void)memset(&__bss_start, 0,
 		     ((u32_t) &__bss_end - (u32_t) &__bss_start));
-#ifdef CONFIG_CCM_BASE_ADDRESS
+#ifdef DT_CCM_BASE_ADDRESS
 	(void)memset(&__ccm_bss_start, 0,
 		     ((u32_t) &__ccm_bss_end - (u32_t) &__ccm_bss_start));
 #endif
@@ -173,7 +173,7 @@ void _data_copy(void)
 {
 	(void)memcpy(&__data_ram_start, &__data_rom_start,
 		 ((u32_t) &__data_ram_end - (u32_t) &__data_ram_start));
-#ifdef CONFIG_CCM_BASE_ADDRESS
+#ifdef DT_CCM_BASE_ADDRESS
 	(void)memcpy(&__ccm_data_start, &__ccm_data_rom_start,
 		 ((u32_t) &__ccm_data_end - (u32_t) &__ccm_data_start));
 #endif

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -22,7 +22,7 @@ old_alias_names = False
 
 regs_config = {
     'zephyr,sram'  : 'DT_SRAM',
-    'zephyr,ccm'   : 'CONFIG_CCM'
+    'zephyr,ccm'   : 'DT_CCM'
 }
 
 name_config = {

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -76,8 +76,18 @@ def dt_hex_val(kconf, _, name, unit=None):
 
     return hex(d)
 
+def dt_str_val(kconf, _, name):
+    """
+    This function looks up 'name' in the DTS generated "conf" style database
+    and if its found it will return the value as string.
+    """
+    if doc_mode or name not in dt_defines:
+        return ""
+
+    return dt_defines[name].strip('\"')
 
 functions = {
         "dt_int_val": (dt_int_val, 1, 2),
         "dt_hex_val": (dt_hex_val, 1, 2),
+        "dt_str_val": (dt_str_val, 1, 1),
 }


### PR DESCRIPTION
Since we know do DTS before Kconfig we should try and remove dts from
creating Kconfig namespaced symbols and leave that to Kconfig.  So
rename CONFIG_CCM_<FOO> to DT_CCM_<FOO>.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>