### PR TITLE
power: Power Management state forcing

### DIFF
--- a/doc/reference/power_management/index.rst
+++ b/doc/reference/power_management/index.rst
@@ -459,9 +459,14 @@ Power Management Hook Interface
 .. doxygengroup:: power_management_hook_interface
    :project: Zephyr
 
+System Power Management APIs
+============================
+
+.. doxygengroup:: system_power_management_api
+   :project: Zephyr
+
 Device Power Management APIs
 ============================
 
 .. doxygengroup:: device_power_management_api
    :project: Zephyr
-

--- a/include/power.h
+++ b/include/power.h
@@ -17,7 +17,6 @@ extern "C" {
 
 extern unsigned char sys_pm_idle_exit_notify;
 
-
 /**
  * @defgroup power_management_api Power Management
  * @{
@@ -25,7 +24,7 @@ extern unsigned char sys_pm_idle_exit_notify;
  */
 
 /**
- * @brief Power Management states.
+ * @brief System power states.
  */
 enum power_states {
 	SYS_POWER_STATE_AUTO	= (-2),
@@ -55,6 +54,14 @@ enum power_states {
 #endif /* CONFIG_SYS_POWER_DEEP_SLEEP */
 	SYS_POWER_STATE_MAX
 };
+
+/**
+ * @brief System Power Management API
+ *
+ * @defgroup system_power_management_api System Power Management API
+ * @ingroup power_management_api
+ * @{
+ */
 
 /**
  * @brief Check if particular power state is a low power state.
@@ -115,17 +122,9 @@ static inline bool sys_pm_is_deep_sleep_state(enum power_states state)
 }
 
 /**
- * @brief Power Management Hooks
- *
- * @defgroup power_management_hook_interface Power Management Hooks
- * @ingroup power_management_api
- * @{
- */
-
-/**
  * @brief Function to disable power management idle exit notification
  *
- * sys_resume() would be called from the ISR of the event that caused
+ * The sys_resume() would be called from the ISR of the event that caused
  * exit from kernel idling after PM operations. For some power operations,
  * this notification may not be necessary. This function can be called in
  * sys_suspend to disable the corresponding sys_resume notification.
@@ -135,6 +134,79 @@ static inline void sys_pm_idle_exit_notification_disable(void)
 {
 	sys_pm_idle_exit_notify = 0;
 }
+
+/**
+ * @brief Force usage of given power state.
+ *
+ * This function overrides decision made by PM policy
+ * forcing usage of given power state in all subseqent
+ * suspend operations. Forcing the SYS_POWER_STATE_AUTO
+ * state restores normal operation.
+ *
+ * @param state Power state which should be used in all
+ *		subsequent suspend operations or
+ *		SYS_POWER_STATE_AUTO.
+ */
+extern void sys_pm_force_power_state(enum power_states state);
+
+#ifdef CONFIG_PM_CONTROL_OS_DEBUG
+/**
+ * @brief Dump Low Power states related debug info
+ *
+ * Dump Low Power states debug info like LPS entry count and residencies.
+ */
+extern void sys_pm_dump_debug_info(void);
+
+#endif /* CONFIG_PM_CONTROL_OS_DEBUG */
+
+#ifdef CONFIG_PM_CONTROL_STATE_LOCK
+/**
+ * @brief Disable particular power state
+ *
+ * @details Disabled state cannot be selected by the Zephyr power
+ *	    management policies. Application defined policy should
+ *	    use the @ref sys_pm_ctrl_is_state_enabled function to
+ *	    check if given state could is enabled and could be used.
+ *
+ * @param [in] state Power state to be disabled.
+ */
+extern void sys_pm_ctrl_disable_state(enum power_states state);
+
+/**
+ * @brief Enable particular power state
+ *
+ * @details Enabled state can be selected by the Zephyr power
+ *	    management policies. Application defined policy should
+ *	    use the @ref sys_pm_ctrl_is_state_enabled function to
+ *	    check if given state could is enabled and could be used.
+ *	    By default all power states are enabled.
+ *
+ * @param [in] state Power state to be enabled.
+ */
+extern void sys_pm_ctrl_enable_state(enum power_states state);
+
+/**
+ * @brief Check if particular power state is enabled
+ *
+ * This function returns true if given power state is enabled.
+ *
+ * @param [in] state Power state.
+ */
+extern bool sys_pm_ctrl_is_state_enabled(enum power_states state);
+
+#endif /* CONFIG_PM_CONTROL_STATE_LOCK */
+
+/**
+ * @}
+ */
+
+/**
+ * @brief Power Management Hooks
+ *
+ * @defgroup power_management_hook_interface Power Management Hooks
+ * @ingroup power_management_api
+ * @{
+ */
 
 /**
  * @brief Hook function to notify exit from deep sleep
@@ -200,69 +272,6 @@ void sys_resume(void);
  * @return Power state which was selected and entered.
  */
 extern enum power_states sys_suspend(s32_t ticks);
-
-/**
- * @brief Force usage of given power state.
- *
- * This function overrides decision made by PM policy
- * forcing usage of given power state in all subseqent
- * suspend operations.
- *
- * Forcing the SYS_POWER_STATE_AUTO power state restores
- * normal operation.
- *
- * @param state Power state which should be used in all
- *		subsequent suspend operations or
- *		SYS_POWER_STATE_AUTO.
- */
-extern void sys_pm_force_power_state(enum power_states state);
-
-#ifdef CONFIG_PM_CONTROL_OS_DEBUG
-/**
- * @brief Dump Low Power states related debug info
- *
- * Dump Low Power states debug info like LPS entry count and residencies.
- */
-extern void sys_pm_dump_debug_info(void);
-
-#endif /* CONFIG_PM_CONTROL_OS_DEBUG */
-
-#ifdef CONFIG_PM_CONTROL_STATE_LOCK
-/**
- * @brief Disable particular power state
- *
- * @details Disabled state cannot be selected by the Zephyr power
- *	    management policies. Application defined policy should
- *	    use the @ref sys_pm_ctrl_is_state_enabled function to
- *	    check if given state could is enabled and could be used.
- *
- * @param [in] state Power state to be disabled.
- */
-extern void sys_pm_ctrl_disable_state(enum power_states state);
-
-/**
- * @brief Enable particular power state
- *
- * @details Enabled state can be selected by the Zephyr power
- *	    management policies. Application defined policy should
- *	    use the @ref sys_pm_ctrl_is_state_enabled function to
- *	    check if given state could is enabled and could be used.
- *	    By default all power states are enabled.
- *
- * @param [in] state Power state to be enabled.
- */
-extern void sys_pm_ctrl_enable_state(enum power_states state);
-
-/**
- * @brief Check if particular power state is enabled
- *
- * This function returns true if given power state is enabled.
- *
- * @param [in] state Power state.
- */
-extern bool sys_pm_ctrl_is_state_enabled(enum power_states state);
-
-#endif /* CONFIG_PM_CONTROL_STATE_LOCK */
 
 /**
  * @}

--- a/include/power.h
+++ b/include/power.h
@@ -28,6 +28,7 @@ extern unsigned char sys_pm_idle_exit_notify;
  * @brief Power Management states.
  */
 enum power_states {
+	SYS_POWER_STATE_AUTO	= (-2),
 	SYS_POWER_STATE_ACTIVE	= (-1),
 #ifdef CONFIG_SYS_POWER_LOW_POWER_STATE
 # ifdef CONFIG_SYS_POWER_STATE_CPU_LPS_SUPPORTED
@@ -199,6 +200,22 @@ void sys_resume(void);
  * @return Power state which was selected and entered.
  */
 extern enum power_states sys_suspend(s32_t ticks);
+
+/**
+ * @brief Force usage of given power state.
+ *
+ * This function overrides decision made by PM policy
+ * forcing usage of given power state in all subseqent
+ * suspend operations.
+ *
+ * Forcing the SYS_POWER_STATE_AUTO power state restores
+ * normal operation.
+ *
+ * @param state Power state which should be used in all
+ *		subsequent suspend operations or
+ *		SYS_POWER_STATE_AUTO.
+ */
+extern void sys_pm_force_power_state(enum power_states state);
 
 #ifdef CONFIG_PM_CONTROL_OS_DEBUG
 /**

--- a/samples/boards/nrf52/power_mgr/README.rst
+++ b/samples/boards/nrf52/power_mgr/README.rst
@@ -104,5 +104,9 @@ nRF52 core output
   --> Entering to SYS_POWER_STATE_CPU_LPS_2 state.
   --> Exited from SYS_POWER_STATE_CPU_LPS_2 state.
 
-  Press BUTTON1 to enter into Deep Sleep state. Press BUTTON2 to exit Deep Sleep state
-  --> Entering to SYS_POWER_STATE_DEEP_SLEEP state.
+  <-- Enabling SYS_POWER_STATE_CPU_LPS_1 state --->
+  <-- Forcing SYS_POWER_STATE_CPU_LPS_2 state --->
+
+  <-- App doing busy wait for 10 Sec -->
+
+  <-- App going to sleep for 10 Sec -->

--- a/samples/boards/nrf52/power_mgr/src/main.c
+++ b/samples/boards/nrf52/power_mgr/src/main.c
@@ -51,7 +51,7 @@ void main(void)
 	/*
 	 * Start the demo.
 	 */
-	for (int i = 1; i <= 6; i++) {
+	for (int i = 1; i <= 8; i++) {
 		unsigned int sleep_seconds;
 
 		switch (i) {
@@ -71,6 +71,16 @@ void main(void)
 			sys_pm_ctrl_disable_state(SYS_POWER_STATE_CPU_LPS_1);
 			break;
 
+		case 7:
+			printk("\n<-- Enabling %s state --->\n",
+				       STRINGIFY(SYS_POWER_STATE_CPU_LPS_1));
+			sys_pm_ctrl_enable_state(SYS_POWER_STATE_CPU_LPS_1);
+
+			printk("<-- Forcing %s state --->\n",
+				       STRINGIFY(SYS_POWER_STATE_CPU_LPS_2));
+			sys_pm_force_power_state(SYS_POWER_STATE_CPU_LPS_2);
+			break;
+
 		default:
 			/* Do nothing. */
 			break;
@@ -86,6 +96,11 @@ void main(void)
 							sleep_seconds);
 		k_sleep(K_SECONDS(sleep_seconds));
 	}
+
+	/* Restore automatic power management. */
+	printk("\n<-- Forcing %s state --->\n",
+		       STRINGIFY(SYS_POWER_STATE_AUTO));
+	sys_pm_force_power_state(SYS_POWER_STATE_AUTO);
 
 	printk("\nPress BUTTON1 to enter into Deep Sleep state. "
 			"Press BUTTON2 to exit Deep Sleep state\n");

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -16,6 +16,7 @@
 LOG_MODULE_REGISTER(power);
 
 static int post_ops_done = 1;
+static enum power_states forced_pm_state = SYS_POWER_STATE_AUTO;
 static enum power_states pm_state;
 
 #ifdef CONFIG_PM_CONTROL_OS_DEBUG
@@ -73,11 +74,22 @@ __weak void sys_pm_notify_lps_exit(enum power_states state)
 	/* This function can be overridden by the application. */
 }
 
+void sys_pm_force_power_state(enum power_states state)
+{
+	__ASSERT(state >= SYS_POWER_STATE_AUTO &&
+		 state <  SYS_POWER_STATE_MAX,
+		 "Invalid power state %d!", state);
+
+	forced_pm_state = state;
+}
+
 enum power_states sys_suspend(s32_t ticks)
 {
 	bool deep_sleep;
 
-	pm_state = sys_pm_policy_next_state(ticks);
+	pm_state = (forced_pm_state == SYS_POWER_STATE_AUTO) ?
+		   sys_pm_policy_next_state(ticks) : forced_pm_state;
+
 	if (pm_state == SYS_POWER_STATE_ACTIVE) {
 		LOG_DBG("No PM operations done.");
 		return pm_state;


### PR DESCRIPTION
At the moment application which chosen policy based power management does not have an option to override decision taken by the policy (it could only disable some power states).

This PR adds the sys_pm_force_power_state() method, which allow the application to choose power state used when OS decide to suspend the SoC as well as extends the power_mgr sample in order to demonstrate power state forcing using the sys_pm_force_power_state() API

There is also small documentation fix: Part of the PM API is moved to correct group.