### PR TITLE
dts: Convert CONFIG_ to DT_ symbols for chosen prop

### DIFF
--- a/doc/guides/dts/index.rst
+++ b/doc/guides/dts/index.rst
@@ -300,17 +300,17 @@ The full set of Zephyr-specific ``chosen`` nodes follows:
    * - ``zephyr,ccm``
      - ``DT_CCM``
    * - ``zephyr,console``
-     - :option:`CONFIG_UART_CONSOLE_ON_DEV_NAME`
+     - `DT_UART_CONSOLE_ON_DEV_NAME`
    * - ``zephyr,shell-uart``
-     - :option:`CONFIG_UART_SHELL_ON_DEV_NAME`
+     - `DT_UART_SHELL_ON_DEV_NAME`
    * - ``zephyr,bt-uart``
-     - :option:`CONFIG_BT_UART_ON_DEV_NAME`
+     - `DT_BT_UART_ON_DEV_NAME`
    * - ``zephyr,uart-pipe``
-     - :option:`CONFIG_UART_PIPE_ON_DEV_NAME`
+     - `DT_UART_PIPE_ON_DEV_NAME`
    * - ``zephyr,bt-mon-uart``
-     - :option:`CONFIG_BT_MONITOR_ON_DEV_NAME`
+     - `DT_BT_MONITOR_ON_DEV_NAME`
    * - ``zephyr,uart-mcumgr``
-     - :option:`CONFIG_UART_MCUMGR_ON_DEV_NAME`
+     - `DT_UART_MCUMGR_ON_DEV_NAME`
 
 As chosen properties tend to be related to software configuration, it can be
 useful for the build system to know if a chosen property was defined. We

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -62,15 +62,14 @@ config BT_NO_DRIVER
 
 endchoice
 
-if !HAS_DTS
 config BT_UART_ON_DEV_NAME
 	string "Device Name of UART Device for Bluetooth"
+	default "$(dt_str_val,DT_BT_UART_ON_DEV_NAME)" if HAS_DTS
 	default "UART_0"
 	depends on BT_UART
 	help
 	  This option specifies the name of UART device to be used
 	  for Bluetooth.
-endif
 
 if BT_SPI
 

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -41,15 +41,14 @@ config UART_CONSOLE
 	  Enable this option to use one UART for console. Make sure
 	  CONFIG_UART_CONSOLE_ON_DEV_NAME is also set correctly.
 
-if !HAS_DTS
 config UART_CONSOLE_ON_DEV_NAME
 	string "Device Name of UART Device for UART Console"
+	default "$(dt_str_val,DT_UART_CONSOLE_ON_DEV_NAME)" if HAS_DTS
 	default "UART_0"
 	depends on UART_CONSOLE
 	help
 	  This option specifies the name of UART device to be used for
 	  UART console.
-endif
 
 config UART_CONSOLE_INIT_PRIORITY
 	int "Init priority"
@@ -191,15 +190,14 @@ config	UART_PIPE
 	  data (as contrary to console UART driver) and all aspects of received
 	  protocol data are handled by application provided callback.
 
-if !HAS_DTS
 config UART_PIPE_ON_DEV_NAME
 	string "Device Name of UART Device for pipe UART"
+	default "$(dt_str_val,DT_UART_PIPE_ON_DEV_NAME)" if HAS_DTS
 	default "UART_0"
 	depends on UART_PIPE
 	help
 	  This option specifies the name of UART device to be used
 	  for pipe UART.
-endif
 
 config UART_MCUMGR
 	bool "Enable mcumgr UART driver"
@@ -212,15 +210,14 @@ config UART_MCUMGR
 	  data are handled by an application provided callback.
 
 if UART_MCUMGR
-if !HAS_DTS
 config UART_MCUMGR_ON_DEV_NAME
 	string "Device Name of UART Device for mcumgr UART"
+	default "$(dt_str_val,DT_UART_MCUMGR_ON_DEV_NAME)" if HAS_DTS
 	default "UART_0"
 	depends on UART_MCUMGR
 	help
 	  This option specifies the name of UART device to be used
 	  for mcumgr UART.
-endif # !HAS_DTS
 
 config UART_MCUMGR_RX_BUF_SIZE
 	int "Size of receive buffer for mcumgr fragments received over UART, in bytes"

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -26,12 +26,12 @@ regs_config = {
 }
 
 name_config = {
-    'zephyr,console'     : 'CONFIG_UART_CONSOLE_ON_DEV_NAME',
-    'zephyr,shell-uart'  : 'CONFIG_UART_SHELL_ON_DEV_NAME',
-    'zephyr,bt-uart'     : 'CONFIG_BT_UART_ON_DEV_NAME',
-    'zephyr,uart-pipe'   : 'CONFIG_UART_PIPE_ON_DEV_NAME',
-    'zephyr,bt-mon-uart' : 'CONFIG_BT_MONITOR_ON_DEV_NAME',
-    'zephyr,uart-mcumgr' : 'CONFIG_UART_MCUMGR_ON_DEV_NAME'
+    'zephyr,console'     : 'DT_UART_CONSOLE_ON_DEV_NAME',
+    'zephyr,shell-uart'  : 'DT_UART_SHELL_ON_DEV_NAME',
+    'zephyr,bt-uart'     : 'DT_BT_UART_ON_DEV_NAME',
+    'zephyr,uart-pipe'   : 'DT_UART_PIPE_ON_DEV_NAME',
+    'zephyr,bt-mon-uart' : 'DT_BT_MONITOR_ON_DEV_NAME',
+    'zephyr,uart-mcumgr' : 'DT_UART_MCUMGR_ON_DEV_NAME'
 }
 
 

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -90,15 +90,14 @@ endchoice
 
 if BT_DEBUG
 
-if !HAS_DTS
 config BT_MONITOR_ON_DEV_NAME
 	string "Device Name of Bluetooth monitor logging UART"
 	depends on BT_DEBUG_MONITOR
+	default "$(dt_str_val,DT_BT_MONITOR_ON_DEV_NAME)" if HAS_DTS
 	default "UART_0"
 	help
 	 This option specifies the name of UART device to be used
 	 for the Bluetooth monitor logging.
-endif
 
 config BT_DEBUG_HCI_DRIVER
 	bool "Bluetooth HCI driver debug"

--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -24,14 +24,13 @@ config SHELL_BACKEND_SERIAL
 
 if SHELL_BACKEND_SERIAL
 
-if !HAS_DTS
 config UART_SHELL_ON_DEV_NAME
 	string "Device Name of UART Device for SHELL_BACKEND_SERIAL"
+	default "$(dt_str_val,DT_UART_SHELL_ON_DEV_NAME)" if HAS_DTS
 	default "UART_0"
 	help
 	  This option specifies the name of UART device to be used for the
 	  SHELL UART backend.
-endif
 
 # Internal config to enable UART interrupts if supported.
 config SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN


### PR DESCRIPTION
Replace generating CONFIG_ symbols with DT_ symbols for chosen properties like 'zephyr,console' or 'zephyr,bt-mon-uart'.  We know use a kconfigfunctions (dt_str_val) to extract the info from dts into Kconfig.
