### PR TITLE
Arch arm fix fpu arch selection

### DIFF
--- a/cmake/fpu-for-gcc-m-cpu.cmake
+++ b/cmake/fpu-for-gcc-m-cpu.cmake
@@ -1,5 +1,11 @@
 # Defines a mapping from GCC_M_CPU to FPU
 
-set(FPU_FOR_cortex-m4      fpv4-sp-d16)
-set(FPU_FOR_cortex-m7      fpv5-d16)
-set(FPU_FOR_cortex-m33     fpv5-sp-d16)
+if(CONFIG_CPU_HAS_FPU_DOUBLE_PRECISION)
+  set(PRECISION_TOKEN)
+else()
+  set(PRECISION_TOKEN sp-)
+endif()
+
+set(FPU_FOR_cortex-m4      fpv4-${PRECISION_TOKEN}d16)
+set(FPU_FOR_cortex-m7      fpv5-${PRECISION_TOKEN}d16)
+set(FPU_FOR_cortex-m33     fpv5-${PRECISION_TOKEN}d16)

--- a/soc/arm/Kconfig
+++ b/soc/arm/Kconfig
@@ -1,3 +1,11 @@
+# Kconfig - general options signifying CPU capabilities of ARM SoCs
+
+#
+# Copyright (c) 2018 Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 config CPU_HAS_ARM_MPU
 	bool
 	# Omit prompt to signify "hidden" option

--- a/soc/arm/Kconfig
+++ b/soc/arm/Kconfig
@@ -39,6 +39,15 @@ config CPU_HAS_NRF_IDAU
 	  (IDAU: "Implementation-Defined Attribution Unit", in accordance with
 	  ARM terminology).
 
+config CPU_HAS_FPU_DOUBLE_PRECISION
+	bool
+	# Omit prompt to signify "hidden" option
+	depends on CPU_CORTEX_M7
+	select CPU_HAS_FPU
+	help
+	  When enabled, indicates that the SoC has a double
+	  floating point precision unit.
+
 config HAS_SWO
 	bool
 	# Omit prompt to signify "hidden" option

--- a/soc/arm/atmel_sam/same70/Kconfig.series
+++ b/soc/arm/atmel_sam/same70/Kconfig.series
@@ -8,7 +8,7 @@ config SOC_SERIES_SAME70
 	bool "Atmel SAME70 MCU"
 	select CPU_CORTEX_M7
 	select SOC_FAMILY_SAM
-	select CPU_HAS_FPU
+	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_SYSTICK
 	select ASF
 	select XIP

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -20,7 +20,7 @@ config SOC_MIMXRT1021
 	select HAS_MCUX_LPSPI
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_TRNG
-	select CPU_HAS_FPU
+	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
 	select INIT_SYS_PLL
 	select INIT_USB1_PLL
@@ -37,7 +37,7 @@ config SOC_MIMXRT1051
 	select HAS_MCUX_LPSPI
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_TRNG
-	select CPU_HAS_FPU
+	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
 	select INIT_ARM_PLL
 	select INIT_SYS_PLL
@@ -55,7 +55,7 @@ config SOC_MIMXRT1052
 	select HAS_MCUX_LPSPI
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_TRNG
-	select CPU_HAS_FPU
+	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ARM_MPU
 	select INIT_ARM_PLL
 	select INIT_SYS_PLL
@@ -72,7 +72,7 @@ config SOC_MIMXRT1061
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_TRNG
-	select CPU_HAS_FPU
+	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_MPU
 	select INIT_ARM_PLL
 	select INIT_SYS_PLL
@@ -89,7 +89,7 @@ config SOC_MIMXRT1062
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_TRNG
-	select CPU_HAS_FPU
+	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_MPU
 	select INIT_ARM_PLL
 	select INIT_SYS_PLL
@@ -105,7 +105,7 @@ config SOC_MIMXRT1064
 	select HAS_MCUX_IGPIO
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_TRNG
-	select CPU_HAS_FPU
+	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_MPU
 	select INIT_ARM_PLL
 	select INIT_SYS_PLL

--- a/soc/arm/st_stm32/stm32f7/Kconfig.soc
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.soc
@@ -20,5 +20,6 @@ config SOC_STM32F756XX
 
 config SOC_STM32F769XI
 	bool "STM32F769XI"
+	select CPU_HAS_FPU_DOUBLE_PRECISION
 
 endchoice


### PR DESCRIPTION
Distinguish between single and double precision FPU selection for Cortex-M7 .


Fixes #8374