### PR TITLE
cmake: Fix dependencies for LD script generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -753,6 +753,11 @@ endif() # CONFIG_CODE_DATA_RELOCATION
 construct_add_custom_command_for_linker_pass(
   linker
   custom_command
+  ${ALIGN_SIZING_DEP}
+  ${PRIV_STACK_DEP}
+  ${APP_SMEM_DEP}
+  ${CODE_RELOCATION_DEP}
+  ${OFFSETS_H_TARGET}
   )
 add_custom_command(
   ${custom_command}
@@ -761,11 +766,7 @@ add_custom_command(
 add_custom_target(
   ${LINKER_SCRIPT_TARGET}
   DEPENDS
-  ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP}
-  ${APP_SMEM_DEP}
-  ${CODE_RELOCATION_DEP}
   linker.cmd
-  ${OFFSETS_H_TARGET}
   )
 
 # Give the '${LINKER_SCRIPT_TARGET}' target all of the include directories so
@@ -1132,22 +1133,25 @@ if(CONFIG_APP_SHARED_MEM AND CONFIG_USERSPACE)
   set(OBJ_FILE_DIR "${PROJECT_BINARY_DIR}/../")
 
   add_custom_target(
-    ${APP_SMEM_DEP} ALL
-    DEPENDS app
-    kernel ${ZEPHYR_LIBS_PROPERTY}
+    ${APP_SMEM_DEP}
+    DEPENDS
+    ${APP_SMEM_LD}
     )
 
   if(CONFIG_NEWLIB_LIBC)
     set(NEWLIB_PART -l libc.a z_newlib_partition)
   endif()
   add_custom_command(
-    TARGET ${APP_SMEM_DEP}
+    OUTPUT ${APP_SMEM_LD}
     COMMAND ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/gen_app_partitions.py
     -d ${OBJ_FILE_DIR}
     -o ${APP_SMEM_LD}
     ${NEWLIB_PART}
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
+    DEPENDS
+    kernel
+    ${ZEPHYR_LIBS_PROPERTY}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/
     COMMENT "Generating app_smem linker section"
     )
@@ -1157,6 +1161,11 @@ if(CONFIG_USERSPACE AND CONFIG_ARM)
   construct_add_custom_command_for_linker_pass(
     linker_priv_stacks
     custom_command
+    ${ALIGN_SIZING_DEP}
+    ${CODE_RELOCATION_DEP}
+    ${APP_SMEM_DEP}
+    ${APP_SMEM_LD}
+    ${OFFSETS_H_TARGET}
     )
   add_custom_command(
     ${custom_command}
@@ -1165,10 +1174,7 @@ if(CONFIG_USERSPACE AND CONFIG_ARM)
   add_custom_target(
     linker_priv_stacks_script
     DEPENDS
-    ${ALIGN_SIZING_DEP} ${APP_SMEM_DEP}
-    ${CODE_RELOCATION_DEP}
     linker_priv_stacks.cmd
-    ${OFFSETS_H_TARGET}
     )
 
   set_property(TARGET
@@ -1201,6 +1207,11 @@ if(GKOF OR GKSF)
   construct_add_custom_command_for_linker_pass(
     linker_pass_final
     custom_command
+    ${ALIGN_SIZING_DEP}
+    ${PRIV_STACK_DEP}
+    ${CODE_RELOCATION_DEP}
+    ${ZEPHYR_PREBUILT_EXECUTABLE}
+    ${OFFSETS_H_TARGET}
     )
   add_custom_command(
     ${custom_command}
@@ -1210,11 +1221,7 @@ if(GKOF OR GKSF)
   add_custom_target(
     ${LINKER_PASS_FINAL_SCRIPT_TARGET}
     DEPENDS
-    ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP}
-    ${CODE_RELOCATION_DEP}
-    ${ZEPHYR_PREBUILT_EXECUTABLE}
     linker_pass_final.cmd
-    ${OFFSETS_H_TARGET}
     )
   set_property(TARGET
     ${LINKER_PASS_FINAL_SCRIPT_TARGET}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,6 +426,7 @@ endif()
 configure_file(version.h.in ${PROJECT_BINARY_DIR}/include/generated/version.h)
 
 function(construct_add_custom_command_for_linker_pass linker_output_name output_variable)
+  set(extra_dependencies ${ARGN})
   set(linker_cmd_file_name ${linker_output_name}.cmd)
 
   if (${linker_output_name} MATCHES "^linker_pass_final$")
@@ -458,6 +459,7 @@ function(construct_add_custom_command_for_linker_pass linker_output_name output_
     OUTPUT ${linker_cmd_file_name}
     DEPENDS
     ${LINKER_SCRIPT}
+    ${extra_dependencies}
     # NB: 'linker_script_dep' will use a keyword that ends 'DEPENDS'
     ${linker_script_dep}
     COMMAND ${CMAKE_C_COMPILER}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,7 +456,9 @@ function(construct_add_custom_command_for_linker_pass linker_output_name output_
 
   set(${output_variable}
     OUTPUT ${linker_cmd_file_name}
-    DEPENDS ${LINKER_SCRIPT}
+    DEPENDS
+    ${LINKER_SCRIPT}
+    # NB: 'linker_script_dep' will use a keyword that ends 'DEPENDS'
     ${linker_script_dep}
     COMMAND ${CMAKE_C_COMPILER}
     -x assembler-with-cpp
@@ -479,16 +481,16 @@ endfunction()
 # Error-out when the deprecated naming convention is found (until
 # after 1.14.0 has been released)
 foreach(path
-	${BOARD_DIR}/dts.fixup
-	${PROJECT_SOURCE_DIR}/soc/${ARCH}/${SOC_PATH}/dts.fixup
+    ${BOARD_DIR}/dts.fixup
+    ${PROJECT_SOURCE_DIR}/soc/${ARCH}/${SOC_PATH}/dts.fixup
     ${APPLICATION_SOURCE_DIR}/dts.fixup
-	)
+    )
   if(EXISTS ${path})
-	message(FATAL_ERROR
-	  "A deprecated filename has been detected. Porting is required."
-	  "The file '${path}' exists, but it should be named dts_fixup.h instead."
-	  "See https://github.com/zephyrproject-rtos/zephyr/pull/10352 for more details"
-	  )
+    message(FATAL_ERROR
+      "A deprecated filename has been detected. Porting is required."
+      "The file '${path}' exists, but it should be named dts_fixup.h instead."
+      "See https://github.com/zephyrproject-rtos/zephyr/pull/10352 for more details"
+      )
   endif()
 endforeach()
 
@@ -502,14 +504,14 @@ set_ifndef(DTS_CAT_OF_FIXUP_FILES ${ZEPHYR_BINARY_DIR}/include/generated/generat
 # #include'ing
 file(WRITE ${DTS_CAT_OF_FIXUP_FILES} "/* May only be included by generated_dts_board.h */\n\n")
 foreach(fixup_file
-      ${DTS_BOARD_FIXUP_FILE}
-      ${DTS_SOC_FIXUP_FILE}
-      ${DTS_APP_FIXUP_FILE}
-      ${shield_dts_fixups}
-	)
+    ${DTS_BOARD_FIXUP_FILE}
+    ${DTS_SOC_FIXUP_FILE}
+    ${DTS_APP_FIXUP_FILE}
+    ${shield_dts_fixups}
+    )
   if(EXISTS ${fixup_file})
-	file(READ ${fixup_file} contents)
-	file(APPEND ${DTS_CAT_OF_FIXUP_FILES} "${contents}")
+    file(READ ${fixup_file} contents)
+    file(APPEND ${DTS_CAT_OF_FIXUP_FILES} "${contents}")
   endif()
 endforeach()
 
@@ -746,7 +748,10 @@ if (CONFIG_CODE_DATA_RELOCATION)
   set(CODE_RELOCATION_DEP code_relocation_source_lib)
 endif() # CONFIG_CODE_DATA_RELOCATION
 
-construct_add_custom_command_for_linker_pass(linker custom_command)
+construct_add_custom_command_for_linker_pass(
+  linker
+  custom_command
+  )
 add_custom_command(
   ${custom_command}
 )
@@ -1147,7 +1152,10 @@ if(CONFIG_APP_SHARED_MEM AND CONFIG_USERSPACE)
 endif()
 
 if(CONFIG_USERSPACE AND CONFIG_ARM)
-  construct_add_custom_command_for_linker_pass(linker_priv_stacks custom_command)
+  construct_add_custom_command_for_linker_pass(
+    linker_priv_stacks
+    custom_command
+    )
   add_custom_command(
     ${custom_command}
     )
@@ -1188,7 +1196,10 @@ if(GKOF OR GKSF)
   # The second linker pass uses the same source linker script of the
   # first pass (LINKER_SCRIPT), but this time with a different output
   # file and preprocessed with the define LINKER_PASS2.
-  construct_add_custom_command_for_linker_pass(linker_pass_final custom_command)
+  construct_add_custom_command_for_linker_pass(
+    linker_pass_final
+    custom_command
+    )
   add_custom_command(
     ${custom_command}
     )


### PR DESCRIPTION
The dependencies relating to generating LD scripts are declared
incorrectly. This manifests itself as broken incremental builds as
shown in #13001.

This commit aligns the LD script generation with the Zephyr standard
for declaring custom commands.

For instance, custom commands should generate files that are wrapped
by targets. The custom commands should declare the dependencies, not
the targets.

Also, when using custom commands, the OUTPUT signature should be used,
not the TARGET signature, as app_smem was doing.

For details about how Zephyr uses custom commands see
https://samthursfield.wordpress.com/2015/11/21/cmake-dependencies-between-targets-and-files-and-custom-commands/

This fixes #13001.