### PR TITLE
dts: bindings: openisa,rv32m1-event-unit: remove base_label

### DIFF
--- a/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
@@ -25,8 +25,6 @@ properties:
       description: mmio register space
       generation: define
 
-base_label: RV32M1_EVENT_UNIT
-
 "#cells":
   - irq
 ...


### PR DESCRIPTION
We aren't using the defines generated by base_label for this device and
we should use DT_ prefixed ones if/when we do.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>