### PR TITLE
kconfig: kconfigfunctions: update dt_str_val

### DIFF
--- a/doc/guides/kconfig/index.rst
+++ b/doc/guides/kconfig/index.rst
@@ -639,7 +639,8 @@ Device Tree Related Functions
 
   dt_str_val(kconf, _, name):
        This function looks up 'name' in the DTS generated "conf" style database
-       and if its found it will return the value as string.
+       and if its found it will return the value as string. if its not found we
+       return an empty string.
 
 Example Usage
 =============

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -79,12 +79,13 @@ def dt_hex_val(kconf, _, name, unit=None):
 def dt_str_val(kconf, _, name):
     """
     This function looks up 'name' in the DTS generated "conf" style database
-    and if its found it will return the value as string.
+    and if its found it will return the value as string.  If its not found we
+    return an empty string.
     """
     if doc_mode or name not in dt_defines:
         return ""
 
-    return dt_defines[name].strip('\"')
+    return dt_defines[name].strip('"')
 
 functions = {
         "dt_int_val": (dt_int_val, 1, 2),


### PR DESCRIPTION
Clarify the docs for dt_str_val that if the name isn't found we return
and empty string.  Also cleanup the code slightly as we don't need to
escape the double quote.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>