### PR TITLE
x86: fix app_smem MMU permissions

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -22,7 +22,8 @@ MMU_BOOT_REGION((u32_t)&_image_rom_start, (u32_t)&_image_rom_size,
 
 #ifdef CONFIG_APP_SHARED_MEM
 MMU_BOOT_REGION((u32_t)&_app_smem_start, (u32_t)&_app_smem_size,
-		MMU_ENTRY_WRITE | MMU_ENTRY_USER | MMU_ENTRY_EXECUTE_DISABLE);
+		MMU_ENTRY_WRITE | MMU_ENTRY_RUNTIME_USER |
+		MMU_ENTRY_EXECUTE_DISABLE);
 #endif
 
 #ifdef CONFIG_COVERAGE_GCOV


### PR DESCRIPTION
At boot, user threads were being granted access to the entire
app shared memory section. This is incorrect; user threads should
have no access until they are added to a memory domain, which
may contain partitions defined within it.

Change from MMU_ENTRY_USER (which grants permission at boot)
to MMU_ENTRY_RUNTIME_USER (which indicates that the pages may
be granted to user mode at runtime, but not at boot).

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>