### PR TITLE
shell: net: Switch to synchronous getaddrinfo call

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -56,6 +56,9 @@ source "subsys/net/ip/Kconfig.ipv4"
 config NET_SHELL
 	bool "Enable network shell utilities"
 	select SHELL
+	select NET_SOCKETS if DNS_RESOLVER
+	select NEWLIB_LIBC if DNS_RESOLVER
+	select NET_SOCKETS_POSIX_NAMES if DNS_RESOLVER
 	help
 	  Activate shell module that provides network commands like
 	  ping to the console.


### PR DESCRIPTION
This patch fixes an issue with the 'net dns query' shell command.  The
asynchronous nature of the dns_get_addr_info call makes this unsuitable
for the use inside the shell.  Instead, let's use the synchronous
getaddrinfo to acquire DNS records.

Signed-off-by: Andy Gross <andy.gross@linaro.org>