### PR TITLE
tests: dynamic_thread: increase stack size

### DIFF
--- a/tests/kernel/threads/dynamic_thread/src/main.c
+++ b/tests/kernel/threads/dynamic_thread/src/main.c
@@ -8,7 +8,7 @@
 #include <irq_offload.h>
 #include <misc/stack.h>
 
-#define STACKSIZE (256 + CONFIG_TEST_EXTRA_STACKSIZE)
+#define STACKSIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
 
 #if defined(CONFIG_USERSPACE) && defined(CONFIG_DYNAMIC_OBJECTS)
 


### PR DESCRIPTION
256 isn't enough on some boards.

Fixes: #13166

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>