### PR TITLE
samples: Use DT_ prefix define for DT filters / limit conf to DT_ only

### DIFF
--- a/samples/basic/blinky/sample.yaml
+++ b/samples/basic/blinky/sample.yaml
@@ -3,6 +3,5 @@ sample:
 tests:
   test:
     tags: LED gpio
-    # The filters below are from DTS
-    filter: LED0_GPIO_CONTROLLER
+    filter: DT_GPIO_LEDS_LED0_GPIO_CONTROLLER
     depends_on: gpio

--- a/samples/basic/button/sample.yaml
+++ b/samples/basic/button/sample.yaml
@@ -3,6 +3,5 @@ sample:
 tests:
   test:
     tags: button gpio
-    # The filters below are from DTS
-    filter: SW0_GPIO_CONTROLLER
+    filter: DT_GPIO_KEYS_SW0_GPIO_CONTROLLER
     depends_on: gpio

--- a/samples/basic/disco/sample.yaml
+++ b/samples/basic/disco/sample.yaml
@@ -2,6 +2,5 @@ sample:
   name: Disco Lights
 tests:
   test:
-    # The filters below are from DTS
-    filter: LED0_GPIO_CONTROLLER and LED1_GPIO_CONTROLLER
+    filter: DT_GPIO_LEDS_LED0_GPIO_CONTROLLER and DT_GPIO_LEDS_LED1_GPIO_CONTROLLER
     tags: LED gpio

--- a/samples/basic/rgb_led/sample.yaml
+++ b/samples/basic/rgb_led/sample.yaml
@@ -2,7 +2,8 @@ sample:
   name: RGB LED
 tests:
   test:
-    # The filters below are from DTS
-    filter: RED_PWM_LED_PWM_CONTROLLER
+    filter: DT_PWM_LEDS_RED_PWM_LED_PWM_CONTROLLER and
+            DT_PWM_LEDS_GREEN_PWM_LED_PWM_CONTROLLER and
+            DT_PWM_LEDS_BLUE_PWM_LED_PWM_CONTROLLER
     tags: drivers pwm
     depends_on: pwm

--- a/samples/basic/threads/sample.yaml
+++ b/samples/basic/threads/sample.yaml
@@ -5,5 +5,4 @@ sample:
 tests:
   test:
     tags: kernel threads gpio
-    # The filters below are from DTS
-    filter: LED0_GPIO_CONTROLLER and LED1_GPIO_CONTROLLER
+    filter: DT_GPIO_LEDS_LED0_GPIO_CONTROLLER and DT_GPIO_LEDS_LED1_GPIO_CONTROLLER

--- a/samples/drivers/gpio/sample.yaml
+++ b/samples/drivers/gpio/sample.yaml
@@ -3,8 +3,7 @@ sample:
 tests:
   test:
     tags: drivers
-    # The filters below are from DTS
-    filter: LED0_GPIO_CONTROLLER and SW0_GPIO_CONTROLLER
+    filter: DT_GPIO_LEDS_LED0_GPIO_CONTROLLER and DT_GPIO_KEYS_SW0_GPIO_CONTROLLER
     harness: console
     harness_config:
         type: one_line

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -397,14 +397,15 @@ def write_conf(f):
         f.write('# ' + node.split('/')[-1] + '\n')
 
         for prop in sorted(defs[node]):
-            if prop != 'aliases':
+            if prop != 'aliases' and prop.startswith("DT_"):
                 f.write('%s=%s\n' % (prop, defs[node][prop]))
 
         for alias in sorted(defs[node]['aliases']):
             alias_target = defs[node]['aliases'][alias]
             if alias_target not in defs[node]:
                 alias_target = defs[node]['aliases'][alias_target]
-            f.write('%s=%s\n' % (alias, defs[node].get(alias_target)))
+            if alias.startswith("DT_"):
+                f.write('%s=%s\n' % (alias, defs[node].get(alias_target)))
 
         f.write('\n')
 


### PR DESCRIPTION
Update the filters that are extracting info from DT to use a define that
has a DT_ prefix so its clear that its coming from DT_.  Also this lets
us remove any non-DT prefixed defines in the conf db.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>