### PR TITLE
scripts/dts cleanups, part 3

### DIFF
--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -60,7 +60,7 @@ def get_all_compatibles(d, name, comp_dict):
     return comp_dict
 
 
-def get_aliases(root):
+def create_aliases(root):
     if 'children' in root:
         if 'aliases' in root['children']:
             for k, v in root['children']['aliases']['props'].items():

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -157,10 +157,10 @@ def find_node_by_path(nodes, path):
     return d
 
 
-def get_reduced(nodes, path):
+def create_reduced(nodes, path):
     # compress nodes list to nodes w/ paths, add interrupt parent
-    if 'last_used_id' not in get_reduced.__dict__:
-        get_reduced.last_used_id = {}
+    if 'last_used_id' not in create_reduced.__dict__:
+        create_reduced.last_used_id = {}
 
     if 'props' in nodes:
         status = nodes['props'].get('status')
@@ -177,11 +177,11 @@ def get_reduced(nodes, path):
             if type(compat) is not list: compat = [ compat, ]
             reduced[path]['instance_id'] = {}
             for k in compat:
-                if k not in get_reduced.last_used_id:
-                    get_reduced.last_used_id[k] = 0
+                if k not in create_reduced.last_used_id:
+                    create_reduced.last_used_id[k] = 0
                 else:
-                    get_reduced.last_used_id[k] += 1
-                reduced[path]['instance_id'][k] = get_reduced.last_used_id[k]
+                    create_reduced.last_used_id[k] += 1
+                reduced[path]['instance_id'][k] = create_reduced.last_used_id[k]
 
         # Newer versions of dtc might have the properties that look like
         # reg = <1 2>, <3 4>;
@@ -197,7 +197,7 @@ def get_reduced(nodes, path):
             path += '/'
         if nodes['children']:
             for k, v in sorted(nodes['children'].items()):
-                get_reduced(v, path + k)
+                create_reduced(v, path + k)
 
 
 def get_node_label(node_address):

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -112,7 +112,7 @@ def get_chosen(root):
                 chosen[k] = v
 
 
-def get_phandles(root, name, handles):
+def create_phandles(root, name, handles):
     if root['props'].get('status') == 'disabled':
         return
 
@@ -123,7 +123,7 @@ def get_phandles(root, name, handles):
         name += '/'
 
     for k, v in root['children'].items():
-        get_phandles(v, name + k, handles)
+        create_phandles(v, name + k, handles)
 
 
 def insert_defs(node_address, new_defs, new_aliases):

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -124,8 +124,8 @@ def create_phandles(root, name):
     if name != '/':
         name += '/'
 
-    for k, v in root['children'].items():
-        create_phandles(v, name + k)
+    for child_name, child_node in root['children'].items():
+        create_phandles(child_node, name + child_name)
 
 
 def insert_defs(node_address, new_defs, new_aliases):

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -44,20 +44,22 @@ def str_to_label(s):
             .upper()
 
 
-def get_all_compatibles(d, name, comp_dict):
-    if d['props'].get('status') == 'disabled':
-        return comp_dict
+def all_compats(node, name):
+    if node['props'].get('status') == 'disabled':
+        return {}
 
-    if 'compatible' in d['props']:
-        comp_dict[name] = d['props']['compatible']
+    node_to_compat = {}
+
+    if 'compatible' in node['props']:
+        node_to_compat[name] = node['props']['compatible']
 
     if name != '/':
         name += '/'
 
-    for k, v in d['children'].items():
-        get_all_compatibles(v, name + k, comp_dict)
+    for child_name, child_node in node['children'].items():
+        node_to_compat.update(all_compats(child_node, name + child_name))
 
-    return comp_dict
+    return node_to_compat
 
 
 def create_aliases(root):

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -105,7 +105,7 @@ def get_compat(node_address):
     return compat
 
 
-def get_chosen(root):
+def create_chosen(root):
     if 'children' in root:
         if 'chosen' in root['children']:
             for k, v in root['children']['chosen']['props'].items():

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -114,7 +114,7 @@ def create_chosen(root):
                 chosen[k] = v
 
 
-def create_phandles(root, name, handles):
+def create_phandles(root, name):
     if root['props'].get('status') == 'disabled':
         return
 
@@ -125,7 +125,7 @@ def create_phandles(root, name, handles):
         name += '/'
 
     for k, v in root['children'].items():
-        create_phandles(v, name + k, handles)
+        create_phandles(v, name + k)
 
 
 def insert_defs(node_address, new_defs, new_aliases):

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -44,22 +44,26 @@ def str_to_label(s):
             .upper()
 
 
-def all_compats(node, name):
-    if node['props'].get('status') == 'disabled':
-        return {}
+def all_compats(node):
+    # Returns a set() of all 'compatible' strings that appear at or below
+    # 'node', skipping disabled nodes
 
-    node_to_compat = {}
+    if node['props'].get('status') == 'disabled':
+        return set()
+
+    compats = set()
 
     if 'compatible' in node['props']:
-        node_to_compat[name] = node['props']['compatible']
+        val = node['props']['compatible']
+        if isinstance(val, list):
+            compats.update(val)
+        else:
+            compats.add(val)
 
-    if name != '/':
-        name += '/'
+    for child_node in node['children'].values():
+        compats.update(all_compats(child_node))
 
-    for child_name, child_node in node['children'].items():
-        node_to_compat.update(all_compats(child_node, name + child_name))
-
-    return node_to_compat
+    return compats
 
 
 def create_aliases(root):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -505,7 +505,7 @@ def main():
     create_reduced(dts['/'], '/')
     create_phandles(dts['/'], '/', {})
     create_aliases(dts['/'])
-    get_chosen(dts['/'])
+    create_chosen(dts['/'])
 
     (extract.globals.bindings, extract.globals.bus_bindings,
      extract.globals.bindings_compat) = load_yaml_descriptions(dts, args.yaml)

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -42,17 +42,8 @@ class Bindings(yaml.Loader):
     _included = []
 
     @classmethod
-    def bindings(cls, compatibles, yaml_dirs):
-        # find unique set of compatibles across all active nodes
-        s = set()
-        for k, v in compatibles.items():
-            if isinstance(v, list):
-                for item in v:
-                    s.add(item)
-            else:
-                s.add(v)
-
-        # scan YAML files and find the ones we are interested in
+    def bindings(cls, compats, yaml_dirs):
+        # Scan YAML files and find the ones we are interested in
         cls._files = []
         for yaml_dir in yaml_dirs:
             for root, dirnames, filenames in os.walk(yaml_dir):
@@ -69,7 +60,7 @@ class Bindings(yaml.Loader):
                 if re.search('^\s+constraint:*', line):
                     c = line.split(':')[1].strip()
                     c = c.strip('"')
-                    if c in s:
+                    if c in compats:
                         if file not in file_load_list:
                             file_load_list.add(file)
                             with open(file, 'r', encoding='utf-8') as yf:
@@ -443,7 +434,7 @@ def write_header(f):
 
 
 def load_yaml_descriptions(root, yaml_dirs):
-    compatibles = all_compats(root, '/')
+    compatibles = all_compats(root)
 
     (bindings, bus, bindings_compat) = Bindings.bindings(compatibles, yaml_dirs)
     if not bindings:

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -503,7 +503,7 @@ def main():
 
     # Create some global data structures
     create_reduced(dts['/'], '/')
-    get_phandles(dts['/'], '/', {})
+    create_phandles(dts['/'], '/', {})
     get_aliases(dts['/'])
     get_chosen(dts['/'])
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -504,7 +504,7 @@ def main():
     # Create some global data structures
     create_reduced(dts['/'], '/')
     create_phandles(dts['/'], '/', {})
-    get_aliases(dts['/'])
+    create_aliases(dts['/'])
     get_chosen(dts['/'])
 
     (extract.globals.bindings, extract.globals.bus_bindings,

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -443,7 +443,7 @@ def write_header(f):
 
 
 def load_yaml_descriptions(root, yaml_dirs):
-    compatibles = get_all_compatibles(root, '/', {})
+    compatibles = all_compats(root, '/')
 
     (bindings, bus, bindings_compat) = Bindings.bindings(compatibles, yaml_dirs)
     if not bindings:

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -442,8 +442,8 @@ def write_header(f):
     f.write('#endif\n')
 
 
-def load_yaml_descriptions(dts, yaml_dirs):
-    compatibles = get_all_compatibles(dts['/'], '/', {})
+def load_yaml_descriptions(root, yaml_dirs):
+    compatibles = get_all_compatibles(root, '/', {})
 
     (bindings, bus, bindings_compat) = Bindings.bindings(compatibles, yaml_dirs)
     if not bindings:
@@ -497,18 +497,18 @@ def main():
     args = parse_arguments()
     enable_old_alias_names(args.old_alias_names)
 
-    # Parse DTS
+    # Parse DTS and fetch the root node
     with open(args.dts, 'r', encoding='utf-8') as f:
-        dts = parse_file(f)
+        root = parse_file(f)['/']
 
-    # Create some global data structures
-    create_reduced(dts['/'], '/')
-    create_phandles(dts['/'], '/', {})
-    create_aliases(dts['/'])
-    create_chosen(dts['/'])
+    # Create some global data structures from the parsed DTS
+    create_reduced(root, '/')
+    create_phandles(root, '/', {})
+    create_aliases(root)
+    create_chosen(root)
 
     (extract.globals.bindings, extract.globals.bus_bindings,
-     extract.globals.bindings_compat) = load_yaml_descriptions(dts, args.yaml)
+     extract.globals.bindings_compat) = load_yaml_descriptions(root, args.yaml)
 
     generate_node_definitions()
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -503,7 +503,7 @@ def main():
 
     # Create some global data structures from the parsed DTS
     create_reduced(root, '/')
-    create_phandles(root, '/', {})
+    create_phandles(root, '/')
     create_aliases(root)
     create_chosen(root)
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -43,39 +43,50 @@ class Bindings(yaml.Loader):
 
     @classmethod
     def bindings(cls, compats, yaml_dirs):
-        # Scan YAML files and find the ones we are interested in
+        # Find all .yaml files in yaml_dirs
         cls._files = []
         for yaml_dir in yaml_dirs:
             for root, dirnames, filenames in os.walk(yaml_dir):
                 for filename in fnmatch.filter(filenames, '*.yaml'):
                     cls._files.append(os.path.join(root, filename))
 
-        yaml_list = {}
-        yaml_list['node'] = {}
-        yaml_list['bus'] = {}
-        yaml_list['compat'] = []
-        file_load_list = set()
+        yaml_list = {'node': {}, 'bus': {}, 'compat': []}
+        loaded_yamls = set()
+
         for file in cls._files:
+            # Extract compat from 'constraint:' line
             for line in open(file, 'r', encoding='utf-8'):
-                if re.search('^\s+constraint:*', line):
-                    c = line.split(':')[1].strip()
-                    c = c.strip('"')
-                    if c in compats:
-                        if file not in file_load_list:
-                            file_load_list.add(file)
-                            with open(file, 'r', encoding='utf-8') as yf:
-                                cls._included = []
-                                l = yaml_traverse_inherited(file, yaml.load(yf, cls))
-                                if c not in yaml_list['compat']:
-                                    yaml_list['compat'].append(c)
-                                if 'parent' in l:
-                                    bus = l['parent']['bus']
-                                    if not bus in yaml_list['bus']:
-                                        yaml_list['bus'][bus] = {}
-                                    yaml_list['bus'][bus][c] = l
-                                else:
-                                    yaml_list['node'][c] = l
-        return (yaml_list['node'], yaml_list['bus'], yaml_list['compat'])
+                match = re.match(r'\s+constraint:\s*"([^"]*)"', line)
+                if match:
+                    break
+            else:
+                # No 'constraint:' line found. Move on to next yaml file.
+                continue
+
+            compat = match.group(1)
+            if compat not in compats or file in loaded_yamls:
+                # The compat does not appear in the device tree, or the yaml
+                # file has already been loaded
+                continue
+
+            loaded_yamls.add(file)
+
+            with open(file, 'r', encoding='utf-8') as yf:
+                cls._included = []
+                l = yaml_traverse_inherited(file, yaml.load(yf, cls))
+
+                if compat not in yaml_list['compat']:
+                    yaml_list['compat'].append(compat)
+
+                if 'parent' in l:
+                    bus = l['parent']['bus']
+                    if not bus in yaml_list['bus']:
+                        yaml_list['bus'][bus] = {}
+                    yaml_list['bus'][bus][compat] = l
+                else:
+                    yaml_list['node'][compat] = l
+
+        return yaml_list['node'], yaml_list['bus'], yaml_list['compat']
 
     def __init__(self, stream):
         filepath = os.path.realpath(stream.name)

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -155,22 +155,14 @@ def extract_bus_name(node_address, def_label):
                 {label: '"' + find_parent_prop(node_address, 'label') + '"'},
                 prop_alias)
 
+
 def extract_string_prop(node_address, key, label):
-
-    prop_def = {}
-
-    node = reduced[node_address]
-    prop = node['props'][key]
-
-    prop_def[label] = "\"" + prop + "\""
-
-    if node_address in defs:
-        defs[node_address].update(prop_def)
-    else:
-        defs[node_address] = prop_def
+    if node_address not in defs:
         # Make all defs have the special 'aliases' key, to remove existence
         # checks elsewhere
-        defs[node_address]['aliases'] = {}
+        defs[node_address] = {'aliases': {}}
+
+    defs[node_address][label] = '"' + reduced[node_address]['props'][key] + '"'
 
 
 def extract_property(node_compat, node_address, prop, prop_val, names):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -501,8 +501,8 @@ def main():
     with open(args.dts, 'r', encoding='utf-8') as f:
         dts = parse_file(f)
 
-    # Build up useful lists
-    get_reduced(dts['/'], '/')
+    # Create some global data structures
+    create_reduced(dts['/'], '/')
     get_phandles(dts['/'], '/', {})
     get_aliases(dts['/'])
     get_chosen(dts['/'])


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/zephyr/pull/13154.

Removes more dead code, simplifies some functions, and improves naming.

`get_all_compatibles()` returned a node-to-compatible-string mapping for all nodes, but tracing through the code, it was only ever used to generate a set with all compatible strings, in `Bindings.binding()`. Have `get_all_compatibles()` (renamed to `all_compats()`, for consistency) return that set directly instead.