### PR TITLE
GMAC: reduce memory pressure on the IP stack

### DIFF
--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -39,7 +39,7 @@ config ETH_SAM_GMAC_TX_TIMEOUT_MSEC
 
 config ETH_SAM_GMAC_BUF_RX_COUNT
 	int "Network RX buffers preallocated by the SAM ETH driver"
-	default 18
+	default 12
 	help
 	  Number of network buffers that will be permanently allocated by the
 	  Ethernet driver. These buffers are used in receive path. They are

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -62,13 +62,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 	are not large enough to hold a full frame
 #endif
 
-#if CONFIG_NET_BUF_DATA_SIZE * CONFIG_NET_BUF_TX_COUNT \
-	< GMAC_FRAME_SIZE_MAX
-#pragma message "Maximum frame size GMAC driver is able to transmit " \
-	"CONFIG_NET_BUF_DATA_SIZE * CONFIG_NET_BUF_TX_COUNT is smaller" \
-	"than a full Ethernet frame"
-#endif
-
 #if CONFIG_NET_BUF_DATA_SIZE & 0x3F
 #pragma message "CONFIG_NET_BUF_DATA_SIZE should be a multiple of 64 bytes " \
 	"due to the granularity of RX DMA"

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -26,11 +26,8 @@
 
 /** RX descriptors count for main queue */
 #define MAIN_QUEUE_RX_DESC_COUNT CONFIG_ETH_SAM_GMAC_BUF_RX_COUNT
-/** TX descriptors count for main queue. They should be able to store a full
- ** packet, that might use either the TX or the RX buffers.
- */
-#define MAIN_QUEUE_TX_DESC_COUNT (max(CONFIG_NET_BUF_RX_COUNT, \
-				      CONFIG_NET_BUF_TX_COUNT) + 1)
+/** TX descriptors count for main queue */
+#define MAIN_QUEUE_TX_DESC_COUNT (CONFIG_NET_BUF_TX_COUNT + 1)
 
 /** RX/TX descriptors count for priority queues */
 #if GMAC_PRIORITY_QUEUE_NO == 2


### PR DESCRIPTION
There have been many complaints that the GMAC ethernet driver put too much pressure on the IP stack. This PR partially addresses this. I know that some people will still feel grumpy about that, but that is a first step. After this PR, the minimum values are:
NET_BUF_TX_COUNT=0
NET_BUF_RX_COUNT=24

Contrary to what I have seen there is no minimum value enforced on NET_PKT_TX_COUNT or CONFIG_NET_PKT_RX_COUNT.