### PR TITLE
usb_dc_stm32: Fix check endpoint capabilities

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -557,7 +557,7 @@ int usb_dc_ep_check_cap(const struct usb_dc_ep_cfg_data * const cfg)
 		return -1;
 	}
 
-	if (ep_idx > DT_USB_NUM_BIDIR_ENDPOINTS) {
+	if (ep_idx > (DT_USB_NUM_BIDIR_ENDPOINTS - 1)) {
 		LOG_ERR("endpoint index/address out of range");
 		return -1;
 	}


### PR DESCRIPTION
DT_USB_NUM_BIDIR_ENDPOINTS includes EP0, which we should not
take it into account when we check endpoint capabilities

Fixes #13066

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>