### PR TITLE
C++ : Fix error: template with C linkage

### DIFF
--- a/include/uart.h
+++ b/include/uart.h
@@ -20,14 +20,14 @@
  * @{
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <errno.h>
 #include <stddef.h>
 
 #include <device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @brief Line control signals. */
 enum uart_line_ctrl {


### PR DESCRIPTION
If we include this header files in cpp source code,
the compiler say"error: template with C linkage".

Include <device.h> must be moved outside the 'extern "C"' section.
