### PR TITLE
drivers: counter: mcux: Fix sanitycheck test build issue

### DIFF
--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -252,7 +252,8 @@ static struct mcux_rtc_config mcux_rtc_config_0 = {
 	.irq_config_func = mcux_rtc_irq_config_0,
 	.info = {
 		.max_top_value = UINT32_MAX,
-		.freq = RTC_0_CLOCK_FREQUENCY / RTC_0_PRESCALER,
+		.freq = DT_NXP_KINETIS_RTC_0_CLOCK_FREQUENCY /
+				DT_NXP_KINETIS_RTC_0_PRESCALER,
 		.count_up = true,
 		.channels = 1,
 	},


### PR DESCRIPTION
The generated defines RTC_0_CLOCK_FREQUENCY and RTC_0_PRESCALER are
maked as deprecated by dts generation.  This causes a build warning and
an error during sanitycheck runs.  Replace with the DT_ prefixed
versions that are not deprecated.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>