### PR TITLE
tests: intel_s1000: Fix broken tests for Intel S1000 CRB

### DIFF
--- a/tests/boards/intel_s1000_crb/src/i2c_test.c
+++ b/tests/boards/intel_s1000_crb/src/i2c_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2019 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,7 +33,7 @@
 #include <device.h>
 #include <i2c.h>
 
-#define I2C_DEV                 CONFIG_I2C_0_NAME
+#define I2C_DEV                 "I2C_0"
 #define I2C_ADDR_LED_MAT0       0x65
 #define I2C_ADDR_LED_MAT1       0x69
 #define LED0                    0x02

--- a/tests/boards/intel_s1000_crb/src/i2s_test.c
+++ b/tests/boards/intel_s1000_crb/src/i2s_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2019 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,14 +7,17 @@
 /**
  * @file
  *
- * @brief Sample app to illustrate I2S transmission (playback) on Intel S1000 CRB.
+ * @brief Test app to illustrate I2S transmission/reception on Intel S1000 CRB
  *
  * The i2s_cavs driver is being used.
  *
- * In this sample app, I2S communication is tested for the below 2 modes:
- * ping-pong mode - the buffer is statically allocated.
- * short block mode - the buffer is dynamically allocated. This example shows
- * only 2 blocks but more can be included.
+ * In this test app, I2S transmission and reception are tested as follows:
+ * I2S port #3 of Intel S1000 is configured for birectional mode
+ *     i.e., I2S_DIR_TX and I2S_DIR_RX
+ * After each frame is received, it is sent/looped back on the same I2S
+ * The transmit direction is started after 2 frames are queued. This is done to
+ * ensure that there is enough data for the DMA and I2S are available when the
+ * start operation is triggered
  */
 
 #include <zephyr.h>
@@ -23,8 +26,8 @@
 #include <device.h>
 #include <i2s.h>
 
-#define I2S_DEV_NAME "I2S_1"
-#define NUM_TX_BLOCKS 4
+#define I2S_DEV_NAME "I2S_3"
+#define NUM_I2S_BUFFERS 4
 
 /* size of stack area used by each thread */
 #define STACKSIZE               2048
@@ -39,72 +42,24 @@ extern struct k_sem thread_sem;
 
 #define NUM_OF_CHANNELS		2
 #define FRAME_CLK_FREQ		48000
+#define I2S_WORDSIZE		32
 #define BLOCK_SIZE		192
-#define BLOCK_SIZE_BYTES	(BLOCK_SIZE * sizeof(s16_t))
-
-#define SAMPLE_NO		(BLOCK_SIZE/NUM_OF_CHANNELS)
+#define BLOCK_SIZE_BYTES	(BLOCK_SIZE * sizeof(s32_t))
+#define FRAMES_PER_ITERATION	50
 #define TIMEOUT			2000
 
-K_MEM_SLAB_DEFINE(tx_0_mem_slab, BLOCK_SIZE_BYTES, NUM_TX_BLOCKS, 1);
+static char __aligned(4) audio_buffers[BLOCK_SIZE_BYTES * NUM_I2S_BUFFERS];
+static struct k_mem_slab i2s_mem_slab;
 
-static void fill_buf_const(s16_t *tx_block, s16_t val_l, s16_t val_r)
-{
-	for (int i = 0; i < SAMPLE_NO; i++) {
-		tx_block[2 * i] = val_l;
-		tx_block[2 * i + 1] = val_r;
-	}
-}
-
-static int tx_block_write(struct device *dev_i2s, s16_t att_l,
-			  s16_t att_r, int err)
-{
-	void *tx_block;
-	int ret;
-
-	ret = k_mem_slab_alloc(&tx_0_mem_slab, &tx_block, K_FOREVER);
-	if (ret < 0) {
-		printk("Error: failed to allocate tx_block\n");
-		return -1;
-	}
-	fill_buf_const((u16_t *)tx_block, att_l, att_r);
-	ret = i2s_write(dev_i2s, tx_block, BLOCK_SIZE_BYTES);
-	if (ret < 0) {
-		k_mem_slab_free(&tx_0_mem_slab, &tx_block);
-	}
-	if (ret != err) {
-		printk("Error: i2s_write failed expected %d, actual %d\n",
-			 err, ret);
-		return -1;
-	}
-
-	return 0;
-}
-
-static s16_t ping_block[BLOCK_SIZE];
-static s16_t pong_block[BLOCK_SIZE];
-
-static int tx_pingpong_write(struct device *dev_i2s, s16_t *tx_block,
-			     s16_t att_l, s16_t att_r, int err)
+/** Configure I2S bidirectional transfer. */
+void test_i2s_bidirectional_transfer_configure(void)
 {
 	int ret;
-
-	fill_buf_const((s16_t *)tx_block, att_l, att_r);
-	ret = i2s_write(dev_i2s, tx_block, BLOCK_SIZE_BYTES);
-	if (ret != err) {
-		printk("Error: i2s_write failed expected %d, actual %d\n",
-			 err, ret);
-		return -1;
-	}
-
-	return 0;
-}
-
-/** Configure I2S TX transfer. */
-void test_i2s_tx_transfer_configure_0(u8_t mode)
-{
 	struct device *dev_i2s;
 	struct i2s_config i2s_cfg;
-	int ret;
+
+	k_mem_slab_init(&i2s_mem_slab, audio_buffers, BLOCK_SIZE_BYTES,
+			NUM_I2S_BUFFERS);
 
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
 	if (!dev_i2s) {
@@ -113,117 +68,95 @@ void test_i2s_tx_transfer_configure_0(u8_t mode)
 	}
 
 	/* Configure */
-	i2s_cfg.word_size = 16;
+	i2s_cfg.word_size = I2S_WORDSIZE;
 	i2s_cfg.channels = NUM_OF_CHANNELS;
 	i2s_cfg.format = I2S_FMT_DATA_FORMAT_I2S | I2S_FMT_CLK_NF_NB;
-	i2s_cfg.options = I2S_OPT_FRAME_CLK_SLAVE | I2S_OPT_BIT_CLK_SLAVE;
-	i2s_cfg.options |= mode;
+	i2s_cfg.options = I2S_OPT_FRAME_CLK_MASTER | I2S_OPT_BIT_CLK_MASTER;
 	i2s_cfg.frame_clk_freq = FRAME_CLK_FREQ;
 	i2s_cfg.block_size = BLOCK_SIZE_BYTES;
-	i2s_cfg.mem_slab = &tx_0_mem_slab;
+	i2s_cfg.mem_slab = &i2s_mem_slab;
 	i2s_cfg.timeout = TIMEOUT;
 
 	ret = i2s_configure(dev_i2s, I2S_DIR_TX, &i2s_cfg);
 	if (ret != 0) {
-		printk("i2s configuration failed with %d error\n", ret);
+		printk("I2S_TX configuration failed with %d error\n", ret);
+		return;
+	}
+	ret = i2s_configure(dev_i2s, I2S_DIR_RX, &i2s_cfg);
+	if (ret != 0) {
+		printk("I2S_RX configuration failed with %d error\n", ret);
 		return;
 	}
 }
 
-/** @brief Short I2S transfer.
+/** @brief Bi-Directional I2S transfer.
  *
- * - TX stream START trigger starts transmission.
- * - sending a short sequence of data returns success.
- * - TX stream DRAIN trigger empties the transmit queue.
+ * - TX/RX stream START trigger starts transmission/reception.
+ * - TX/RX stream STOP trigger stops the transmission/reception.
  */
-void test_i2s_transfer_short(void)
+void test_i2s_bidirectional_transfer(void)
 {
 	struct device *dev_i2s;
+	int frames = 0;
+	void *buffer;
+	size_t size;
 	int ret;
 
+	printk("Testing I2S bidirectional transfer\n");
 	dev_i2s = device_get_binding(I2S_DEV_NAME);
 	if (!dev_i2s) {
 		printk("I2S: Device driver not found.\n");
 		return;
 	}
 
-	/* Prefill TX queue */
-	ret = tx_block_write(dev_i2s, 0xA0A0, 0xF0F0, 0);
+	/* Start reception */
+	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_START);
 	if (ret != 0) {
-		printk("Prefill write failed with %d error\n", ret);
+		printk("RX Start failed with %d error\n", ret);
 		return;
 	}
 
-	/* Start transmission */
-	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	if (ret != 0) {
-		printk("Start Trigger failed with %d error\n", ret);
-		return;
+	/* iteratively receive a frame and send it back */
+	while (frames++ < FRAMES_PER_ITERATION) {
+		ret = i2s_read(dev_i2s, &buffer, &size);
+		if (ret != 0) {
+			printk("i2s_read failed with %d error\n", ret);
+			return;
+		}
+
+		/* send the buffer */
+		ret = i2s_write(dev_i2s, buffer, size);
+		if (ret != 0) {
+			printk("i2s_write failed with %d error\n", ret);
+			return;
+		}
+
+		/* Start transmission after 2 frames are queued */
+		if (frames == 2) {
+			ret = i2s_trigger(dev_i2s, I2S_DIR_TX,
+					I2S_TRIGGER_START);
+			if (ret != 0) {
+				printk("TX Start failed with %d error\n", ret);
+				return;
+			}
+		}
 	}
-
-	ret = tx_block_write(dev_i2s, 0x0A0A, 0x0F0F, 0);
-	if (ret != 0) {
-		printk("Post-start write failed with %d error\n", ret);
-		return;
-	}
-
-	/* All data written, drain TX queue and stop the transmission */
-	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	if (ret != 0) {
-		printk("Drain Trigger failed");
-		return;
-	}
-}
-
-/** @brief Ping-Pong I2S transfer.
- *
- * - TX stream START trigger starts transmission.
- * - sending / receiving a ping-pong sequence of data returns success.
- * - TX stream STOP trigger stops the transmission.
- */
-void test_i2s_transfer_pingpong(void)
-{
-	struct device *dev_i2s;
-	int ret;
-
-	dev_i2s = device_get_binding(I2S_DEV_NAME);
-	if (!dev_i2s) {
-		printk("I2S: Device driver not found.\n");
-		return;
-	}
-
-	/* Prefill the ping buffer */
-	ret = tx_pingpong_write(dev_i2s, ping_block, 0xA0A0, 0xF0F0, 0);
-	if (ret != 0) {
-		printk("Ping-block write failed with %d error\n", ret);
-		return;
-	}
-
-	/* Prefill the pong buffer */
-	ret = tx_pingpong_write(dev_i2s, pong_block, 0x0A0A, 0x0F0F, 0);
-	if (ret != 0) {
-		printk("Ping-block write failed with %d error\n", ret);
-		return;
-	}
-
-	/* Start transmission */
-	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_START);
-	if (ret != 0) {
-		printk("Start Trigger failed with %d error\n", ret);
-		return;
-	}
-
-	/* The data in the ping-pong buffers will constantly be getting
-	 * transmitted one after the other in this duration
-	 */
-	k_sleep(200);
 
 	/* Stop transmission */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_TX, I2S_TRIGGER_STOP);
 	if (ret != 0) {
-		printk("Stop Trigger failed with %d error\n", ret);
+		printk("TX Stop failed with %d error\n", ret);
 		return;
 	}
+
+	/* Stop reception */
+	ret = i2s_trigger(dev_i2s, I2S_DIR_RX, I2S_TRIGGER_STOP);
+	if (ret != 0) {
+		printk("RX Stop failed with %d error\n", ret);
+		return;
+	}
+	printk("Completed %d bidirectional frames on " I2S_DEV_NAME "\n",
+			FRAMES_PER_ITERATION);
 }
 
 /* i2s_thread is a static thread that is spawned automatically */
@@ -233,24 +166,12 @@ void i2s_thread(void *dummy1, void *dummy2, void *dummy3)
 	ARG_UNUSED(dummy2);
 	ARG_UNUSED(dummy3);
 
+	test_i2s_bidirectional_transfer_configure();
+
 	while (1) {
-		printk("Testing I2S normal mode\n");
 		k_sem_take(&thread_sem, K_FOREVER);
 
-		test_i2s_tx_transfer_configure_0(0);
-		test_i2s_transfer_short();
-
-		/* let other threads have a turn */
-		k_sem_give(&thread_sem);
-
-		/* wait a while */
-		k_sleep(SLEEPTIME);
-
-		printk("Testing I2S ping-pong mode\n");
-		k_sem_take(&thread_sem, K_FOREVER);
-
-		test_i2s_tx_transfer_configure_0(I2S_OPT_PINGPONG);
-		test_i2s_transfer_pingpong();
+		test_i2s_bidirectional_transfer();
 
 		/* let other threads have a turn */
 		k_sem_give(&thread_sem);


### PR DESCRIPTION
This PR fixes the following tests that were broken due to changes made in the DMA and I2S driver design.
- DMA test updated to use single block transfer since the DMA driver no longer supports linked list mode
- I2S test updated to use bidirectional transfers and the redesigned API behavior on Intel S1000
Fixes #11390

This PR also updates the I2C test and Resolves #13218