### PR TITLE
arch: arm: mpu: get the region sizes from the linker

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -68,14 +68,14 @@ void _arch_configure_static_mpu_regions(void)
 #if defined(CONFIG_COVERAGE_GCOV) && defined(CONFIG_USERSPACE)
 		{
 		.start = (u32_t)&__gcov_bss_start,
-		.size = (u32_t)&__gcov_bss_end - (u32_t)&__gcov_bss_start,
+		.size = (u32_t)&__gcov_bss_size
 		.attr = K_MEM_PARTITION_P_RW_U_RW,
 		},
 #endif /* CONFIG_COVERAGE_GCOV && CONFIG_USERSPACE */
 #if defined(CONFIG_NOCACHE_MEMORY)
 		{
 		.start = (u32_t)&_nocache_ram_start,
-		.size = (u32_t)&_nocache_ram_end - (u32_t)&_nocache_ram_start,
+		.size = (u32_t)&_nocache_ram_size,
 		.attr = K_MEM_PARTITION_P_RW_U_NA_NOCACHE,
 		}
 #endif /* CONFIG_NOCACHE_MEMORY */


### PR DESCRIPTION
The linker file defines the __gcov_bss_size and _nocache_ram_size
symbols to get the size of the __gcov_bss and _nocache_ram section. Use
that instead of computing the value at runtime from the start and end
symbols.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>