### PR TITLE
X86_64 should use host compiler and the host-gcc definition

### DIFF
--- a/boards/x86_64/qemu_x86_64/qemu_x86_64.yaml
+++ b/boards/x86_64/qemu_x86_64/qemu_x86_64.yaml
@@ -5,5 +5,6 @@ simulation: qemu
 arch: x86_64
 toolchain:
   - zephyr
+  - host
 testing:
   default: true

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -14,31 +14,6 @@ find_program(CMAKE_READELF    ${CROSS_COMPILE}readelf PATH ${TOOLCHAIN_HOME} NO_
 find_program(CMAKE_GDB        ${CROSS_COMPILE}gdb     PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 find_program(CMAKE_NM         ${CROSS_COMPILE}nm      PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
-# x86_64 should pick up a proper cross compiler if one is provided,
-# but falling back to using the host toolchain is a very sane behavior
-# too.
-# As an alternative to this fall back try ZEPHYR_TOOLCHAIN_VARIANT=host
-# directly.
-if(CONFIG_X86_64)
-  if(CMAKE_C_COMPILER STREQUAL CMAKE_C_COMPILER-NOTFOUND)
-    find_program(CMAKE_C_COMPILER   gcc    )
-    find_program(CMAKE_OBJCOPY      objcopy)
-    find_program(CMAKE_OBJDUMP      objdump)
-    find_program(CMAKE_AR           ar     )
-    find_program(CMAKE_RANLILB      ranlib )
-    find_program(CMAKE_READELF      readelf)
-    find_program(CMAKE_GDB          gdb    )
-  endif()
-
-  # When building in x32 mode with a host compiler, there is no libgcc
-  # shipped (because it's an x86_64 compiler, not x32).  That's
-  # actually non-fatal, as no known features we hit in existing code
-  # actually require the library.  But I can't find an exaustive list
-  # of exactly what can break, so this is fragile.  Long term we
-  # really need to be blessing a proper cross toolchain.
-  set(no_libgcc Y)
-endif()
-
 if(CONFIG_CPLUSPLUS)
   set(cplusplus_compiler ${CROSS_COMPILE}${C++})
 else()

--- a/cmake/generic_toolchain.cmake
+++ b/cmake/generic_toolchain.cmake
@@ -47,7 +47,7 @@ set(ZEPHYR_TOOLCHAIN_VARIANT ${ZEPHYR_TOOLCHAIN_VARIANT} CACHE STRING "Zephyr to
 assert(ZEPHYR_TOOLCHAIN_VARIANT "Zephyr toolchain variant invalid: please set the ZEPHYR_TOOLCHAIN_VARIANT-variable")
 
 # Pick host system's toolchain if we are targeting posix
-if(${ARCH} STREQUAL "posix")
+if((${ARCH} STREQUAL "posix") OR (${ARCH} STREQUAL "x86_64"))
   set(ZEPHYR_TOOLCHAIN_VARIANT "host")
 endif()
 

--- a/cmake/toolchain/host/generic.cmake
+++ b/cmake/toolchain/host/generic.cmake
@@ -1,1 +1,2 @@
 set(COMPILER host-gcc)
+set(TOOLCHAIN_HAS_NEWLIB OFF CACHE BOOL "True if toolchain supports newlib")


### PR DESCRIPTION
We had this working with the Zephyr variant and forcing host compiler from gcc
compiler definition which is used for cross toolchains.

Fixes #13220