### PR TITLE
tests: intel_s1000: increase log buffer/stack

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -265,6 +265,7 @@ config LOG_PROCESS_THREAD_STACK_SIZE
 	int "Stack size for the internal log processing thread"
 	default 2048 if COVERAGE_GCOV
 	default 1024 if NO_OPTIMIZATIONS
+	default 1024 if XTENSA
 	default 768
 	help
 	  Set the internal stack size for log processing thread.


### PR DESCRIPTION
Crashes observed with default logger buffer/stack. Increase those to get
the test running again.

Fixes #12201