### PR TITLE
boards: intel_s1000_crb: print short filename in board image script

### DIFF
--- a/boards/xtensa/intel_s1000_crb/support/create_board_img.py
+++ b/boards/xtensa/intel_s1000_crb/support/create_board_img.py
@@ -218,8 +218,8 @@ def main():
 
         out_fp.close()
 
-    debug("Input %s = %ld bytes" % (args.in_file, in_file_size))
-    debug("Output %s = %ld bytes" % (args.out_file, out_file_size))
+    debug("Input %s = %ld bytes" % (os.path.basename(args.in_file), in_file_size))
+    debug("Output %s = %ld bytes" % (os.path.basename(args.out_file), out_file_size))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Print just the basename of the Input and Output filenames
when creating the board specific image for Intel S1000 CRB