### PR TITLE
soc: intel_s1000: add audio master clock config

### DIFF
--- a/soc/xtensa/intel_s1000/soc.c
+++ b/soc/xtensa/intel_s1000/soc.c
@@ -184,6 +184,24 @@ u32_t soc_get_ref_clk_freq(void)
 	return ref_clk_freq;
 }
 
+static inline void soc_set_audio_mclk(void)
+{
+#if (CONFIG_AUDIO)
+	int mclk;
+	volatile struct soc_mclk_control_regs *mclk_regs =
+		(volatile struct soc_mclk_control_regs *)SOC_MCLK_DIV_CTRL_BASE;
+
+	for (mclk = 0; mclk < SOC_NUM_MCLK_OUTPUTS; mclk++) {
+		/*
+		 * set divider to bypass mode which makes MCLK output frequency
+		 * to be the same as referece clock frequency
+		 */
+		mclk_regs->mdivxr[mclk] = SOC_MDIVXR_SET_DIVIDER_BYPASS;
+		mclk_regs->mdivctrl |= SOC_MDIVCTRL_MCLK_OUT_EN(mclk);
+	}
+#endif
+}
+
 static inline void soc_set_dmic_power(void)
 {
 #if (CONFIG_AUDIO_INTEL_DMIC)
@@ -228,6 +246,7 @@ static inline void soc_set_power_and_clock(void)
 
 	soc_set_dmic_power();
 	soc_set_gna_power();
+	soc_set_audio_mclk();
 }
 
 static inline void soc_read_bootstraps(void)

--- a/soc/xtensa/intel_s1000/soc.h
+++ b/soc/xtensa/intel_s1000/soc.h
@@ -99,7 +99,20 @@
 #define SSP_SIZE				0x0000200
 #define SSP_BASE(x)				(0x00077000 + (x) * SSP_SIZE)
 #define SSP_MN_DIV_SIZE				(8)
-#define SSP_MN_DIV_BASE(x)		(0x00078D00 + ((x) * SSP_MN_DIV_SIZE))
+#define SSP_MN_DIV_BASE(x)			\
+	(0x00078D00 + ((x) * SSP_MN_DIV_SIZE))
+
+/* MCLK control */
+#define SOC_MCLK_DIV_CTRL_BASE			0x78C00
+#define SOC_NUM_MCLK_OUTPUTS			2
+#define SOC_MDIVCTRL_MCLK_OUT_EN(mclk)		BIT(mclk)
+#define SOC_MDIVXR_SET_DIVIDER_BYPASS		BIT_MASK(12)
+
+struct soc_mclk_control_regs {
+	u32_t	mdivctrl;
+	u32_t	reserved[31];
+	u32_t	mdivxr[SOC_NUM_MCLK_OUTPUTS];
+};
 
 #define PDM_BASE				0x00010000
 


### PR DESCRIPTION
This PR add an SOC level routine to configure the audio master clock outputs on Intel S1000.