### PR TITLE
doc: bluetooth: Add reference to Bluetooth API

### DIFF
--- a/doc/reference/bluetooth/index.rst
+++ b/doc/reference/bluetooth/index.rst
@@ -1,3 +1,4 @@
+.. _bluetooth_api:
 
 Bluetooth
 #########


### PR DESCRIPTION
Add a general reference to the Bluetooth API pages.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>