### PR TITLE
net/context: No need to set pkt family as the allocator did already

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1673,8 +1673,6 @@ static int context_sendto_new(struct net_context *context,
 		ret = net_tcp_send_data(context, cb, token, user_data);
 	} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
 		   net_context_get_family(context) == AF_PACKET) {
-
-		net_pkt_set_family(pkt, AF_PACKET);
 		ret = net_pkt_write_new(pkt, buf, len);
 		if (ret < 0) {
 			goto fail;
@@ -1687,9 +1685,6 @@ static int context_sendto_new(struct net_context *context,
 	} else if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) &&
 		   net_context_get_family(context) == AF_CAN &&
 		   net_context_get_ip_proto(context) == CAN_RAW) {
-
-		net_pkt_set_family(pkt, AF_CAN);
-
 		ret = net_pkt_write_new(pkt, buf, len);
 		if (ret < 0) {
 			goto fail;


### PR DESCRIPTION
net_context uses net_pkt_alloc_with_buffer(), which sets the family and
protocol (according to parameters) so no need to set the family again.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>