### PR TITLE
shell: Fix prompt length not updated in shell_prompt_change

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1359,6 +1359,7 @@ int shell_prompt_change(const struct shell *shell, const char *prompt)
 		return -EINVAL;
 	}
 	shell->ctx->prompt = prompt;
+	shell->ctx->vt100_ctx.cons.name_len = shell_strlen(prompt);
 
 	return 0;
 }


### PR DESCRIPTION
Prompt length is used when printing log messages to erase
prompt. If length is not updated and new prompt is longer
than default one then only part of the prompt is erased
which looks like data corruption.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>