### PR TITLE
logging: Set panic_mode flag after flushing in log_panic

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -398,13 +398,13 @@ void log_panic(void)
 		}
 	}
 
-	panic_mode = true;
-
 	if (!IS_ENABLED(CONFIG_LOG_IMMEDIATE)) {
 		/* Flush */
 		while (log_process(false) == true) {
 		}
 	}
+
+	panic_mode = true;
 }
 
 static bool msg_filter_check(struct log_backend const *backend,


### PR DESCRIPTION
In case log_panic is called from context which can be
interrupted, it is safer to set panic_mode flag after
logs are flushed. If flag was set before flushing and
log_panic was interrupted then another context was
attempting to process log message directly, competing
for log backends.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>