### PR TITLE
power: add stdbool.h to power.h

### DIFF
--- a/include/power.h
+++ b/include/power.h
@@ -14,10 +14,6 @@
 extern "C" {
 #endif
 
-#ifdef CONFIG_SYS_POWER_MANAGEMENT
-
-extern unsigned char sys_pm_idle_exit_notify;
-
 /**
  * @defgroup power_management_api Power Management
  * @{
@@ -55,6 +51,10 @@ enum power_states {
 #endif /* CONFIG_SYS_POWER_DEEP_SLEEP */
 	SYS_POWER_STATE_MAX
 };
+
+#ifdef CONFIG_SYS_POWER_MANAGEMENT
+
+extern unsigned char sys_pm_idle_exit_notify;
 
 /**
  * @brief System Power Management API

--- a/include/power.h
+++ b/include/power.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_INCLUDE_POWER_H_
 
 #include <zephyr/types.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
`power.h` used `bool`, but `stdbool.h` was not included.
Additionally, fix https://github.com/zephyrproject-rtos/zephyr/issues/13194 by declaring power states unconditionally.