### PR TITLE
drivers/gpio: stm32: Return errors on not supported config

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -240,6 +240,11 @@ static int gpio_stm32_config(struct device *dev, int access_op,
 		return -ENOTSUP;
 	}
 
+	if ((flags & GPIO_POL_MASK) == GPIO_POL_INV) {
+		/* hardware cannot invert signal */
+		return -ENOTSUP;
+	}
+
 	/* figure out if we can map the requested GPIO
 	 * configuration
 	 */
@@ -274,6 +279,9 @@ static int gpio_stm32_config(struct device *dev, int access_op,
 			}
 
 			stm32_exti_trigger(pin, edge);
+		} else {
+			/* Level trigger interrupts not supported */
+			return -ENOTSUP;
 		}
 
 		if (stm32_exti_enable(pin) != 0) {


### PR DESCRIPTION
Following configuration options are not supported by STM32
gpio driver:
-GPIO_INT_LEVEL
-GPIO_POL_INV
Return an error when one of these is requested.

Fixes #12766

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>