### PR TITLE
Netusb: fixes and adaptation to new net_pkt API

### DIFF
--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -256,25 +256,19 @@ static size_t ecm_eth_size(void *ecm_pkt, size_t len)
 
 static int ecm_send(struct net_pkt *pkt)
 {
-	struct net_buf *frag;
-	int b_idx = 0, ret;
+	size_t len = net_pkt_get_len(pkt);
+	int ret;
 
 	net_pkt_hexdump(pkt, "<");
 
-	if (!pkt->frags) {
-		return -ENODATA;
-	}
-
-	/* copy payload */
-	for (frag = pkt->frags; frag; frag = frag->frags) {
-		memcpy(&tx_buf[b_idx], frag->data, frag->len);
-		b_idx += frag->len;
+	if (net_pkt_read_new(pkt, tx_buf, len)) {
+		return -ENOBUFS;
 	}
 
 	/* transfer data to host */
 	ret = usb_transfer_sync(ecm_ep_data[ECM_IN_EP_IDX].ep_addr,
-				tx_buf, b_idx, USB_TRANS_WRITE);
-	if (ret != b_idx) {
+				tx_buf, len, USB_TRANS_WRITE);
+	if (ret != len) {
 		LOG_ERR("Transfer failure");
 		return -EINVAL;
 	}
@@ -285,7 +279,6 @@ static int ecm_send(struct net_pkt *pkt)
 static void ecm_read_cb(u8_t ep, int size, void *priv)
 {
 	struct net_pkt *pkt;
-	struct net_buf *frag;
 
 	if (size <= 0) {
 		goto done;
@@ -303,23 +296,15 @@ static void ecm_read_cb(u8_t ep, int size, void *priv)
 		}
 	}
 
-	pkt = net_pkt_get_reserve_rx(K_FOREVER);
+	pkt = net_pkt_alloc_with_buffer(netusb_net_iface(), size,
+					AF_UNSPEC, 0, K_FOREVER);
 	if (!pkt) {
 		LOG_ERR("no memory for network packet\n");
 		goto done;
 	}
 
-	frag = net_pkt_get_frag(pkt, K_FOREVER);
-	if (!frag) {
-		LOG_ERR("no memory for network packet\n");
-		net_pkt_unref(pkt);
-		goto done;
-	}
-
-	net_pkt_frag_insert(pkt, frag);
-
-	if (!net_pkt_append_all(pkt, size, rx_buf, K_FOREVER)) {
-		LOG_ERR("no memory for network packet\n");
+	if (net_pkt_write_new(pkt, rx_buf, size)) {
+		LOG_ERR("Unable to write into pkt\n");
 		net_pkt_unref(pkt);
 		goto done;
 	}

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -27,6 +27,8 @@ LOG_MODULE_REGISTER(usb_ecm);
 #include <class/usb_cdc.h>
 #include "netusb.h"
 
+#define ECM_FRAME_SIZE 1522
+
 #define USB_CDC_ECM_REQ_TYPE		0x21
 #define USB_CDC_SET_ETH_PKT_FILTER	0x43
 
@@ -101,7 +103,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 		.bDescriptorSubtype = ETHERNET_FUNC_DESC,
 		.iMACAddress = 4,
 		.bmEthernetStatistics = sys_cpu_to_le32(0), /* None */
-		.wMaxSegmentSize = sys_cpu_to_le16(NETUSB_MTU),
+		.wMaxSegmentSize = sys_cpu_to_le16(ECM_FRAME_SIZE),
 		.wNumberMCFilters = sys_cpu_to_le16(0), /* None */
 		.bNumberPowerFilters = 0, /* No wake up */
 	},
@@ -191,7 +193,7 @@ static struct usb_ep_cfg_data ecm_ep_data[] = {
 	},
 };
 
-static u8_t tx_buf[NETUSB_MTU], rx_buf[NETUSB_MTU];
+static u8_t tx_buf[ECM_FRAME_SIZE], rx_buf[ECM_FRAME_SIZE];
 
 static int ecm_class_handler(struct usb_setup_packet *setup, s32_t *len,
 			     u8_t **data)

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -19,7 +19,9 @@ LOG_MODULE_REGISTER(usb_eem);
 #include <class/usb_cdc.h>
 #include "netusb.h"
 
-static u8_t tx_buf[NETUSB_MTU], rx_buf[NETUSB_MTU];
+#define EEM_FRAME_SIZE 1522
+
+static u8_t tx_buf[EEM_FRAME_SIZE], rx_buf[EEM_FRAME_SIZE];
 
 struct usb_cdc_eem_config {
 	struct usb_if_descriptor if0;

--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -57,6 +57,11 @@ static int netusb_send(struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
+struct net_if *netusb_net_iface(void)
+{
+	return netusb.iface;
+}
+
 void netusb_recv(struct net_pkt *pkt)
 {
 	LOG_DBG("Recv pkt, len %u", net_pkt_get_len(pkt));

--- a/subsys/usb/class/netusb/netusb.h
+++ b/subsys/usb/class/netusb/netusb.h
@@ -26,6 +26,7 @@ struct netusb_function {
 	int (*send_pkt)(struct net_pkt *pkt);
 };
 
+struct net_if *netusb_net_iface(void);
 void netusb_recv(struct net_pkt *pkt);
 int try_write(u8_t ep, u8_t *data, u16_t len);
 

--- a/subsys/usb/class/netusb/netusb.h
+++ b/subsys/usb/class/netusb/netusb.h
@@ -8,7 +8,7 @@
  * USB definitions
  */
 
-#define NETUSB_MTU 1522
+#define NETUSB_MTU 1500
 
 #define CDC_ECM_INT_EP_ADDR		0x83
 #define CDC_ECM_IN_EP_ADDR		0x82


### PR DESCRIPTION
@finikorg Could you check? I doubt that ECM needs the same frame size as EEM. And actually, I count 1520 bytes for EEM, not 1522 (Eth mtu + Eth hdr + eem hdr + sentinel), or are the missing 2 bytes for FCS somewhere? I kept the value 1522 for both anyway.