### PR TITLE
test: Kconfig: Correct HAS_COVERAGE_SUPPORT description

### DIFF
--- a/tests/Kconfig
+++ b/tests/Kconfig
@@ -34,7 +34,8 @@ config HAS_COVERAGE_SUPPORT
 	bool
 	help
 	  The code coverage report generation is only available on boards
-	  with enough RAM.
+	  with enough spare RAM to buffer the coverage data, or on boards
+	  based on the POSIX ARCH.
 
 config COVERAGE
 	bool "Create coverage data"


### PR DESCRIPTION
HAS_COVERAGE_SUPPORT can be set both on boards with enough RAM to
store the coverage results, or for POSIX ARCH based ones

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>