### PR TITLE
tests: kernel: gen_isr_table: Exclude platforms test isnt valid on

### DIFF
--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   arch.interrupt:
+    platform_exclude: nucleo_f103rb olimexino_stm32 stm32_min_dev
+        usb_kw24d512 v2m_beetle
     filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     tags: interrupt isr_table


### PR DESCRIPTION
The test assumes that the last to IRQ number will be free, this isn't a
valid assumption and now that we detect multiple ISRs registering for
the some IRQ line, we see failures because of this assumption on some
platforms.  Exclude those platforms from this test for the time being.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>