### PR TITLE
ext/hal: stm32: Use of (__packed uint32_t *) produces warnings

### DIFF
--- a/ext/hal/st/stm32cube/stm32f1xx/README
+++ b/ext/hal/st/stm32cube/stm32f1xx/README
@@ -52,3 +52,11 @@ Patch List:
      Impacted files:
       drivers/include/stm32f1xx_ll_rcc.h
      ST Bug tracker ID: 37419
+
+    *Use of (__packed uint32_t *) produces warning
+      Using GNU 8.2.0, (__packed uint32_t *) generates warning.
+      Replace with CMSIS macros __UNALIGNED_UINT32_READ and
+      __UNALIGNED_UINT32_WRITE.
+     Impacted files:
+      drivers/include/stm32f1xx_ll_usb.c
+     ST Bug tracker ID: 61323

--- a/ext/hal/st/stm32cube/stm32f1xx/drivers/src/stm32f1xx_ll_usb.c
+++ b/ext/hal/st/stm32cube/stm32f1xx/drivers/src/stm32f1xx_ll_usb.c
@@ -653,7 +653,7 @@ HAL_StatusTypeDef USB_WritePacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *src, uin
   count32b =  (len + 3) / 4;
   for (index = 0; index < count32b; index++, src += 4)
   {
-    USBx_DFIFO(ch_ep_num) = *((__packed uint32_t *)src);
+    USBx_DFIFO(ch_ep_num) = __UNALIGNED_UINT32_READ(src);
   }
   return HAL_OK;
 }
@@ -675,7 +675,7 @@ void *USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len)
 
   for ( index = 0; index < count32b; index++, dest += 4 )
   {
-    *(__packed uint32_t *)dest = USBx_DFIFO(0);
+    __UNALIGNED_UINT32_WRITE(dest, USBx_DFIFO(0));
 
   }
   return ((void *)dest);

--- a/ext/hal/st/stm32cube/stm32f2xx/README
+++ b/ext/hal/st/stm32cube/stm32f2xx/README
@@ -48,3 +48,10 @@ Patch List:
      ext/hal/st/stm32cube/stm32f2xx/drivers/src/stm32f2xx_ll_usb.c
     ST Bug Tracker ID: 34714
 
+    *Use of (__packed uint32_t *) produces warning
+      Using GNU 8.2.0, (__packed uint32_t *) generates warning.
+      Replace with CMSIS macros __UNALIGNED_UINT32_READ and
+      __UNALIGNED_UINT32_WRITE.
+     Impacted files:
+      drivers/include/stm32f2xx_ll_usb.c
+     ST Bug tracker ID: 61324

--- a/ext/hal/st/stm32cube/stm32f2xx/drivers/src/stm32f2xx_ll_usb.c
+++ b/ext/hal/st/stm32cube/stm32f2xx/drivers/src/stm32f2xx_ll_usb.c
@@ -768,7 +768,7 @@ HAL_StatusTypeDef USB_WritePacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *src, uin
     count32b =  (len + 3U) / 4U;
     for (i = 0U; i < count32b; i++, src += 4U)
     {
-      USBx_DFIFO(ch_ep_num) = *((__packed uint32_t *)src);
+      USBx_DFIFO(ch_ep_num) = __UNALIGNED_UINT32_READ(src);
     }
   }
   return HAL_OK;
@@ -794,7 +794,7 @@ void *USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len)
 
   for ( i = 0U; i < count32b; i++, dest += 4U )
   {
-    *(__packed uint32_t *)dest = USBx_DFIFO(0U);
+    __UNALIGNED_UINT32_WRITE(dest, USBx_DFIFO(0U));
 
   }
   return ((void *)dest);

--- a/ext/hal/st/stm32cube/stm32f4xx/README
+++ b/ext/hal/st/stm32cube/stm32f4xx/README
@@ -53,3 +53,11 @@ Patch List:
      CMakeLists.txt
      drivers/include/stm32f4xx_hal_conf.h
      drivers/src/Legacy/stm32f4_hal_can.c
+
+    *Use of (__packed uint32_t *) produces warning
+      Using GNU 8.2.0, (__packed uint32_t *) generates warning.
+      Replace with CMSIS macros __UNALIGNED_UINT32_READ and
+      __UNALIGNED_UINT32_WRITE.
+     Impacted files:
+      drivers/include/stm32f4xx_ll_usb.c
+     ST Bug tracker ID: 61325

--- a/ext/hal/st/stm32cube/stm32f4xx/drivers/src/stm32f4xx_ll_usb.c
+++ b/ext/hal/st/stm32cube/stm32f4xx/drivers/src/stm32f4xx_ll_usb.c
@@ -883,7 +883,7 @@ HAL_StatusTypeDef USB_WritePacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *src, uin
     count32b =  (len + 3U) / 4U;
     for (i = 0U; i < count32b; i++, src += 4U)
     {
-      USBx_DFIFO(ch_ep_num) = *((__packed uint32_t *)src);
+      USBx_DFIFO(ch_ep_num) = __UNALIGNED_UINT32_READ(src);
     }
   }
   return HAL_OK;
@@ -909,7 +909,7 @@ void *USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len)
 
   for ( i = 0U; i < count32b; i++, dest += 4U )
   {
-    *(__packed uint32_t *)dest = USBx_DFIFO(0U);
+    __UNALIGNED_UINT32_WRITE(dest, USBx_DFIFO(0U));
 
   }
   return ((void *)dest);

--- a/ext/hal/st/stm32cube/stm32f7xx/README
+++ b/ext/hal/st/stm32cube/stm32f7xx/README
@@ -66,3 +66,11 @@ Patch List:
     Impacted files:
      drivers/include/stm32f7xx_ll_exti.h
     ST Bug tracker ID: 55274
+
+    *Use of (__packed uint32_t *) produces warning
+      Using GNU 8.2.0, (__packed uint32_t *) generates warning.
+      Replace with CMSIS macros __UNALIGNED_UINT32_READ and
+      __UNALIGNED_UINT32_WRITE.
+     Impacted files:
+      drivers/include/stm32f7xx_ll_usb.c
+     ST Bug tracker ID: 61327

--- a/ext/hal/st/stm32cube/stm32f7xx/drivers/src/stm32f7xx_ll_usb.c
+++ b/ext/hal/st/stm32cube/stm32f7xx/drivers/src/stm32f7xx_ll_usb.c
@@ -866,7 +866,7 @@ HAL_StatusTypeDef USB_WritePacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *src, uin
     count32b =  ((uint32_t)len + 3U) / 4U;
     for (i = 0U; i < count32b; i++)
     {
-      USBx_DFIFO((uint32_t)ch_ep_num) = *((__packed uint32_t *)pSrc);
+      USBx_DFIFO((uint32_t)ch_ep_num) = __UNALIGNED_UINT32_READ(pSrc);
       pSrc++;
     }
   }
@@ -895,7 +895,7 @@ void *USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len)
 
   for (i = 0U; i < count32b; i++)
   {
-    *(__packed uint32_t *)pDest = USBx_DFIFO(0U);
+    __UNALIGNED_UINT32_WRITE(pDest, USBx_DFIFO(0U));
     pDest++;
   }
 

--- a/ext/hal/st/stm32cube/stm32l4xx/README
+++ b/ext/hal/st/stm32cube/stm32l4xx/README
@@ -63,3 +63,12 @@ Patch List:
     Impacted files:
      drivers/include/stm32l4xx_ll_exti.h
     ST Bug tracker ID: 55275
+
+
+    *Use of (__packed uint32_t *) produces warning
+      Using GNU 8.2.0, (__packed uint32_t *) generates warning.
+      Replace with CMSIS macros __UNALIGNED_UINT32_READ and
+      __UNALIGNED_UINT32_WRITE.
+     Impacted files:
+      drivers/include/stm32l4xx_ll_usb.c
+     ST Bug tracker ID: 61328

--- a/ext/hal/st/stm32cube/stm32l4xx/drivers/src/stm32l4xx_ll_usb.c
+++ b/ext/hal/st/stm32cube/stm32l4xx/drivers/src/stm32l4xx_ll_usb.c
@@ -743,7 +743,7 @@ HAL_StatusTypeDef USB_WritePacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *src, uin
   count32b = ((uint32_t)len + 3U) / 4U;
   for (i = 0U; i < count32b; i++)
   {
-    USBx_DFIFO((uint32_t)ch_ep_num) = *((__packed uint32_t *)pSrc);
+    USBx_DFIFO((uint32_t)ch_ep_num) = __UNALIGNED_UINT32_READ(pSrc);
     pSrc++;
   }
 
@@ -767,7 +767,7 @@ void *USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len)
 
   for (i = 0U; i < count32b; i++)
   {
-    *(__packed uint32_t *)pDest = USBx_DFIFO(0U);
+    __UNALIGNED_UINT32_WRITE(pDest, USBx_DFIFO(0U));
     pDest++;
   }
 


### PR DESCRIPTION
Using Zephyr SDK 0.10.0-rc2, GNUCC 8.2.0 is used and (__packed uint32_t *) are now generating warnings..
Replace with CMSIS macros __UNALIGNED_UINT32_READ and __UNALIGNED_UINT32_WRITE

Fixes #13237 
