### PR TITLE
doc: Add support for west in zephyr application extension

### DIFF
--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -147,7 +147,8 @@ class ZephyrAppCommandsDirective(Directive):
         mkdir = 'mkdir' if num_slashes == 0 else 'mkdir -p'
 
         # Create host_os array
-        host_os = [host_os] if host_os != "all" else self.HOST_OS
+        host_os = [host_os] if host_os != "all" else [v for v in self.HOST_OS
+                                                        if v != 'all']
 
         run_config = {
             'board': board,
@@ -168,15 +169,16 @@ class ZephyrAppCommandsDirective(Directive):
             comment = '# On {}'
 
         for host in host_os:
-            if cd_to:
-                if host == "unix":
-                    if comment:
-                        content.append(comment.format('Linux/macOS'))
+            if host == "unix":
+                if comment:
+                    content.append(comment.format('Linux/macOS'))
+                if cd_to:
                     prefix = '$ZEPHYR_BASE/' if zephyr_app else ''
                     content.append('cd {}{}'.format(prefix, cd_to))
-                elif host == "win":
-                    if comment:
-                        content.append(comment.format('Windows'))
+            elif host == "win":
+                if comment:
+                    content.append(comment.format('Windows'))
+                if cd_to:
                     prefix = '%ZEPHYR_BASE%\\' if zephyr_app else ''
                     backslashified = cd_to.replace('/', '\\')
                     content.append('cd {}{}'.format(prefix, backslashified))

--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -135,7 +135,7 @@ class ZephyrAppCommandsDirective(Directive):
 
         if host_os not in self.HOST_OS:
             raise self.error('Unknown host-os {}; choose from: {}'.format(
-                generator, self.HOST_OS))
+                host_os, self.HOST_OS))
 
         if compact and skip_config:
             raise self.error('Both compact and maybe-skip-config options were given.')


### PR DESCRIPTION
Sample output:

CMake only:
```
# On Linux/macOS
cd samples/hello_world
mkdir build && cd build

# On Windows
cd samples\hello_world
mkdir build & cd build

# Use cmake to configure a Make-based build system:
cmake -DBOARD=native_posix -DSHIELD=x_nucleo_iks01a1 -DCONF_FILE=a.conf b.conf VERBOSE=1 ..

# Now run make on the generated build system:
make
```

West only, simple:
```
west build -b native_posix
```

West only, with flashing:
```
west build -b native_posix -s samples/hello_world
west flash
```
```
west build -b native_posix -s samples/hello_world -d build/board
west flash -d build/board
```
West only, with CMake args:
```
west build -b native_posix -s samples/hello_world -- -DSHIELD=x_nucleo_iks01a1 -DCONF_FILE=a.conf VERBOSE=1
```

CMake and west:
![image](https://user-images.githubusercontent.com/12450381/52593584-9b081800-2e49-11e9-8bb9-3ec9f767cb70.png)
