### PR TITLE
scripts: west: Add reset-after-load argument to jlink runner

### DIFF
--- a/boards/arm/lpcxpresso54114/board.cmake
+++ b/boards/arm/lpcxpresso54114/board.cmake
@@ -12,9 +12,9 @@ if(LPCLINK_FW STREQUAL jlink)
 endif()
 
 if(CONFIG_BOARD_LPCXPRESSO54114_M4)
-board_runner_args(jlink "--device=LPC54114J256_M4")
+board_runner_args(jlink "--device=LPC54114J256_M4" "--reset-after-load")
 elseif(CONFIG_BOARD_LPCXPRESSO54114_M0)
-board_runner_args(jlink "--device=LPC54114J256_M0")
+board_runner_args(jlink "--device=LPC54114J256_M0" "--reset-after-load")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -4,6 +4,7 @@
 
 '''Runner for debugging with J-Link.'''
 
+import argparse
 import os
 import tempfile
 import sys
@@ -16,13 +17,17 @@ from runners.core import ZephyrBinaryRunner, RunnerCaps, \
 DEFAULT_JLINK_EXE = 'JLink.exe' if sys.platform == 'win32' else 'JLinkExe'
 DEFAULT_JLINK_GDB_PORT = 2331
 
+class ToggleAction(argparse.Action):
+
+    def __call__(self, parser, args, ignored, option):
+        setattr(args, self.dest, not option.startswith('--no-'))
 
 class JLinkBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for the J-Link GDB server.'''
 
     def __init__(self, cfg, device,
                  commander=DEFAULT_JLINK_EXE,
-                 flash_addr=0x0, erase=True,
+                 flash_addr=0x0, erase=True, reset_after_load=False,
                  iface='swd', speed='auto',
                  gdbserver='JLinkGDBServer', gdb_port=DEFAULT_JLINK_GDB_PORT,
                  tui=False):
@@ -34,6 +39,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         self.commander = commander
         self.flash_addr = flash_addr
         self.erase = erase
+        self.reset_after_load = reset_after_load
         self.gdbserver = gdbserver
         self.iface = iface
         self.speed = speed
@@ -70,6 +76,12 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                             help='J-Link Commander, default is JLinkExe')
         parser.add_argument('--erase', default=False, action='store_true',
                             help='if given, mass erase flash before loading')
+        parser.add_argument('--reset-after-load', '--no-reset-after-load',
+                            dest='reset_after_load', nargs=0,
+                            action=ToggleAction,
+                            help='reset after loading? (default: no)')
+
+        parser.set_defaults(reset_after_load=False)
 
     @classmethod
     def create(cls, cfg, args):
@@ -78,6 +90,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         return JLinkBinaryRunner(cfg, args.device,
                                  commander=args.commander,
                                  flash_addr=flash_addr, erase=args.erase,
+                                 reset_after_load=args.reset_after_load,
                                  iface=args.iface, speed=args.speed,
                                  gdbserver=args.gdbserver,
                                  gdb_port=args.gdb_port,
@@ -120,6 +133,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                 client_cmd += ['-ex', 'monitor halt',
                                '-ex', 'monitor reset',
                                '-ex', 'load']
+                if self.reset_after_load:
+                    client_cmd += ['-ex', 'monitor reset']
+
             self.print_gdbserver_message()
             self.run_server_and_client(server_cmd, client_cmd)
 
@@ -135,6 +151,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
 
         lines.append('loadfile {} 0x{:x}'.format(self.bin_name,
                                                  self.flash_addr))
+        if self.reset_after_load:
+            lines.append('r') # Reset and halt the target
+
         lines.append('g') # Start the CPU
         lines.append('q') # Close the connection and quit
 


### PR DESCRIPTION
Adds a new argument to the jlink runner to reset the device after
loading code to flash. This fixes a problem with the lpcxpresso54114
board where it was necessary to manually reset the board to get new code
to start running after the 'ninja flash' command. This new argument is
optional and false by default because there are some cases were we must
not reset after load, such as when we load the application into ITCM on
imx rt devices.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>