### PR TITLE
storage: flash_map: fix copyright assignment

### DIFF
--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017 Nordic Semiconductor ASA
  * Copyright (c) 2015 Runtime Inc
+ * Copyright (c) 2017 Linaro Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
Zephyr's flash_map code is largely copied wholesale from MCUboot, but the copyrights were done incorrectly when the copy/pasting happened.

The current copyright holders are listed as Nordic and Runtime. This is the patch which removed it from MCUboot; there is no copyright holder explicitly named:

https://github.com/JuulLabs-OSS/mcuboot/commit/b788c71c08394a403d7755d6f9dd3fd53e9d3d9c#diff-e4c0c184210793513328934f14840a4c

In fact, I was the author of a nontrivial portion of it, introduced here:

https://github.com/JuulLabs-OSS/mcuboot/commit/dc4c42bf6211e199990a5ec2c7192cf734a5f309#diff-e4c0c184210793513328934f14840a4c

At the time, I was working for Linaro, so add their copyright to the copy of this file introduced into Zephyr.
