### PR TITLE
spi: spi_mcux_lpspi: Convert to use DT_ prefixed defines

### DIFF
--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -275,9 +275,9 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 static void spi_mcux_config_func_0(struct device *dev);
 
 static const struct spi_mcux_config spi_mcux_config_0 = {
-	.base = (LPSPI_Type *) SPI_0_BASE_ADDRESS,
-	.clock_name = SPI_0_CLOCK_CONTROLLER,
-	.clock_subsys = (clock_control_subsys_t) SPI_0_CLOCK_NAME,
+	.base = (LPSPI_Type *) DT_NXP_IMX_LPSPI_SPI_0_BASE_ADDRESS,
+	.clock_name = DT_NXP_IMX_LPSPI_SPI_0_CLOCK_CONTROLLER,
+	.clock_subsys = (clock_control_subsys_t) DT_NXP_IMX_LPSPI_SPI_0_CLOCK_NAME,
 	.irq_config_func = spi_mcux_config_func_0,
 };
 
@@ -286,17 +286,17 @@ static struct spi_mcux_data spi_mcux_data_0 = {
 	SPI_CONTEXT_INIT_SYNC(spi_mcux_data_0, ctx),
 };
 
-DEVICE_AND_API_INIT(spi_mcux_0, SPI_0_LABEL, &spi_mcux_init,
+DEVICE_AND_API_INIT(spi_mcux_0, DT_NXP_IMX_LPSPI_SPI_0_LABEL, &spi_mcux_init,
 		    &spi_mcux_data_0, &spi_mcux_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &spi_mcux_driver_api);
 
 static void spi_mcux_config_func_0(struct device *dev)
 {
-	IRQ_CONNECT(SPI_0_IRQ, SPI_0_IRQ_PRIORITY,
+	IRQ_CONNECT(DT_NXP_IMX_LPSPI_SPI_0_IRQ, DT_NXP_IMX_LPSPI_SPI_0_IRQ_PRIORITY,
 		    spi_mcux_isr, DEVICE_GET(spi_mcux_0), 0);
 
-	irq_enable(SPI_0_IRQ);
+	irq_enable(DT_NXP_IMX_LPSPI_SPI_0_IRQ);
 }
 #endif /* SPI_0 */
 
@@ -304,9 +304,9 @@ static void spi_mcux_config_func_0(struct device *dev)
 static void spi_mcux_config_func_1(struct device *dev);
 
 static const struct spi_mcux_config spi_mcux_config_1 = {
-	.base = (LPSPI_Type *) SPI_1_BASE_ADDRESS,
-	.clock_name = SPI_1_CLOCK_CONTROLLER,
-	.clock_subsys = (clock_control_subsys_t) SPI_1_CLOCK_NAME,
+	.base = (LPSPI_Type *) DT_NXP_IMX_LPSPI_SPI_1_BASE_ADDRESS,
+	.clock_name = DT_NXP_IMX_LPSPI_SPI_1_CLOCK_CONTROLLER,
+	.clock_subsys = (clock_control_subsys_t) DT_NXP_IMX_LPSPI_SPI_1_CLOCK_NAME,
 	.irq_config_func = spi_mcux_config_func_1,
 };
 
@@ -315,17 +315,17 @@ static struct spi_mcux_data spi_mcux_data_1 = {
 	SPI_CONTEXT_INIT_SYNC(spi_mcux_data_1, ctx),
 };
 
-DEVICE_AND_API_INIT(spi_mcux_1, SPI_1_LABEL, &spi_mcux_init,
+DEVICE_AND_API_INIT(spi_mcux_1, DT_NXP_IMX_LPSPI_SPI_1_LABEL, &spi_mcux_init,
 		    &spi_mcux_data_1, &spi_mcux_config_1,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &spi_mcux_driver_api);
 
 static void spi_mcux_config_func_1(struct device *dev)
 {
-	IRQ_CONNECT(SPI_1_IRQ, SPI_1_IRQ_PRIORITY,
+	IRQ_CONNECT(DT_NXP_IMX_LPSPI_SPI_1_IRQ, DT_NXP_IMX_LPSPI_SPI_1_IRQ_PRIORITY,
 		    spi_mcux_isr, DEVICE_GET(spi_mcux_1), 0);
 
-	irq_enable(SPI_1_IRQ);
+	irq_enable(DT_NXP_IMX_LPSPI_SPI_1_IRQ);
 }
 #endif /* SPI_1 */
 
@@ -333,9 +333,9 @@ static void spi_mcux_config_func_1(struct device *dev)
 static void spi_mcux_config_func_2(struct device *dev);
 
 static const struct spi_mcux_config spi_mcux_config_2 = {
-	.base = (LPSPI_Type *) SPI_2_BASE_ADDRESS,
-	.clock_name = SPI_2_CLOCK_CONTROLLER,
-	.clock_subsys = (clock_control_subsys_t) SPI_2_CLOCK_NAME,
+	.base = (LPSPI_Type *) DT_NXP_IMX_LPSPI_SPI_2_BASE_ADDRESS,
+	.clock_name = DT_NXP_IMX_LPSPI_SPI_2_CLOCK_CONTROLLER,
+	.clock_subsys = (clock_control_subsys_t) DT_NXP_IMX_LPSPI_SPI_2_CLOCK_NAME,
 	.irq_config_func = spi_mcux_config_func_2,
 };
 
@@ -344,17 +344,17 @@ static struct spi_mcux_data spi_mcux_data_2 = {
 	SPI_CONTEXT_INIT_SYNC(spi_mcux_data_2, ctx),
 };
 
-DEVICE_AND_API_INIT(spi_mcux_2, SPI_2_LABEL, &spi_mcux_init,
+DEVICE_AND_API_INIT(spi_mcux_2, DT_NXP_IMX_LPSPI_SPI_2_LABEL, &spi_mcux_init,
 		    &spi_mcux_data_2, &spi_mcux_config_2,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &spi_mcux_driver_api);
 
 static void spi_mcux_config_func_2(struct device *dev)
 {
-	IRQ_CONNECT(SPI_2_IRQ, SPI_2_IRQ_PRIORITY,
+	IRQ_CONNECT(DT_NXP_IMX_LPSPI_SPI_2_IRQ, DT_NXP_IMX_LPSPI_SPI_2_IRQ_PRIORITY,
 		    spi_mcux_isr, DEVICE_GET(spi_mcux_2), 0);
 
-	irq_enable(SPI_2_IRQ);
+	irq_enable(DT_NXP_IMX_LPSPI_SPI_2_IRQ);
 }
 #endif /* SPI_2 */
 
@@ -362,9 +362,9 @@ static void spi_mcux_config_func_2(struct device *dev)
 static void spi_mcux_config_func_3(struct device *dev);
 
 static const struct spi_mcux_config spi_mcux_config_3 = {
-	.base = (LPSPI_Type *) SPI_3_BASE_ADDRESS,
-	.clock_name = SPI_3_CLOCK_CONTROLLER,
-	.clock_subsys = (clock_control_subsys_t) SPI_3_CLOCK_NAME,
+	.base = (LPSPI_Type *) DT_NXP_IMX_LPSPI_SPI_3_BASE_ADDRESS,
+	.clock_name = DT_NXP_IMX_LPSPI_SPI_3_CLOCK_CONTROLLER,
+	.clock_subsys = (clock_control_subsys_t) DT_NXP_IMX_LPSPI_SPI_3_CLOCK_NAME,
 	.irq_config_func = spi_mcux_config_func_3,
 };
 
@@ -373,16 +373,16 @@ static struct spi_mcux_data spi_mcux_data_3 = {
 	SPI_CONTEXT_INIT_SYNC(spi_mcux_data_3, ctx),
 };
 
-DEVICE_AND_API_INIT(spi_mcux_3, SPI_3_LABEL, &spi_mcux_init,
+DEVICE_AND_API_INIT(spi_mcux_3, DT_NXP_IMX_LPSPI_SPI_3_LABEL, &spi_mcux_init,
 		    &spi_mcux_data_3, &spi_mcux_config_3,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &spi_mcux_driver_api);
 
 static void spi_mcux_config_func_3(struct device *dev)
 {
-	IRQ_CONNECT(SPI_3_IRQ, SPI_3_IRQ_PRIORITY,
+	IRQ_CONNECT(DT_NXP_IMX_LPSPI_SPI_3_IRQ, DT_NXP_IMX_LPSPI_SPI_3_IRQ_PRIORITY,
 		    spi_mcux_isr, DEVICE_GET(spi_mcux_3), 0);
 
-	irq_enable(SPI_3_IRQ);
+	irq_enable(DT_NXP_IMX_LPSPI_SPI_3_IRQ);
 }
 #endif /* CONFIG_SPI_3 */


### PR DESCRIPTION
The spi mcux_lpspi driver has been using non DT_ prefixed defines for
DT generated defines.  Switch to use DT_ prefixed ones as we want to
deprecated the non DT_ prefixed defines.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>