### PR TITLE
x86: implement kernel page table isolation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1392,12 +1392,3 @@ if(CONFIG_BOARD_DEPRECATED)
       removed in version ${CONFIG_BOARD_DEPRECATED}"
   )
 endif()
-
-if(CONFIG_X86 AND CONFIG_USERSPACE AND NOT CONFIG_X86_NO_MELTDOWN)
-  message(WARNING "
-      WARNING: You have enabled CONFIG_USERSPACE on an x86-based target.
-      If your CPU is vulnerable to the Meltdown CPU bug, security of
-      supervisor-only memory pages is not guaranteed. This version of Zephyr
-      does not contain a fix for this issue."
-  )
-endif()

--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -154,13 +154,14 @@ if(CONFIG_X86_MMU)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   add_custom_command(
-    OUTPUT mmu_tables.bin
+    OUTPUT mmu_tables.bin user_mmu_tables.bin
     COMMAND
     ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/gen_mmu_x86.py
     -i mmulist.bin
     -k $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
     -o mmu_tables.bin
+    -u user_mmu_tables.bin
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:-v>
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS mmulist.bin
@@ -185,6 +186,28 @@ if(CONFIG_X86_MMU)
   set_property(TARGET mmu_tables PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/mmu_tables.o)
   add_dependencies(   mmu_tables mmu_tables_o)
   set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_OBJECT_FILES mmu_tables)
+
+  if(CONFIG_X86_KPTI)
+    add_custom_command(
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/user_mmu_tables.o
+      COMMAND
+      ${CMAKE_OBJCOPY}
+      -I binary
+      -B ${OUTPUT_ARCH}
+      -O ${OUTPUT_FORMAT}
+      --rename-section .data=.user_mmu_data
+      user_mmu_tables.bin
+      user_mmu_tables.o
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      DEPENDS user_mmu_tables.bin
+    )
+
+    add_custom_target(  user_mmu_tables_o DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/user_mmu_tables.o)
+    add_library(        user_mmu_tables STATIC IMPORTED GLOBAL)
+    set_property(TARGET user_mmu_tables PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/user_mmu_tables.o)
+    add_dependencies(   user_mmu_tables user_mmu_tables_o)
+    set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_OBJECT_FILES user_mmu_tables)
+  endif()
 endif()
 
 if(CONFIG_GDT_DYNAMIC)

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -123,6 +123,17 @@ config X86_USERSPACE
 	  supporting user-level threads that are protected from each other and
 	  from crashing the kernel.
 
+config X86_KPTI
+	bool "Enable kernel page table isolation"
+	default y
+	depends on USERSPACE
+	depends on !X86_NO_MELTDOWN
+	help
+	  Implements kernel page table isolation to mitigate Meltdown exploits
+	  to read Kernel RAM. Incurs a significant performance cost for
+	  user thread interrupts and system calls, and significant footprint
+	  increase for additional page tables and trampoline stacks.
+
 menu "Architecture Floating Point Options"
 depends on CPU_HAS_FPU
 

--- a/arch/x86/core/crt0.S
+++ b/arch/x86/core/crt0.S
@@ -348,7 +348,7 @@ __csSet:
 #ifdef CONFIG_X86_MMU
 
 	/* load the page directory address into the registers*/
-	movl $__mmu_tables_start, %eax
+	movl $z_x86_kernel_pdpt, %eax
 	movl %eax, %cr3
 
 	/* Enable PAE */

--- a/arch/x86/core/excstub.S
+++ b/arch/x86/core/excstub.S
@@ -72,7 +72,9 @@ SECTION_FUNC(TEXT, _exception_enter)
 
 	cld
 
-
+#ifdef CONFIG_X86_KPTI
+	call z_x86_trampoline_to_kernel
+#endif
 	/*
 	 * Swap ecx and handler function on the current stack;
 	 */
@@ -210,7 +212,7 @@ nestedException:
 	addl	$4, %esp	/* "pop" error code */
 
 	/* Pop of EFLAGS will re-enable interrupts and restore direction flag */
-	iret
+	KPTI_IRET
 
 #if CONFIG_X86_KERNEL_OOPS
 SECTION_FUNC(TEXT, _kernel_oops_handler)

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -301,11 +301,11 @@ static void dump_entry_flags(x86_page_entry_data_t flags)
 	       "Execute Disable" : "Execute Enabled");
 }
 
-static void dump_mmu_flags(void *addr)
+static void dump_mmu_flags(struct x86_mmu_pdpt *pdpt, void *addr)
 {
 	x86_page_entry_data_t pde_flags, pte_flags;
 
-	_x86_mmu_get_flags(addr, &pde_flags, &pte_flags);
+	_x86_mmu_get_flags(pdpt, addr, &pde_flags, &pte_flags);
 
 	printk("PDE: ");
 	dump_entry_flags(pde_flags);
@@ -331,7 +331,7 @@ static void dump_page_fault(NANO_ESF *esf)
 	       cr2);
 
 #ifdef CONFIG_X86_MMU
-	dump_mmu_flags((void *)cr2);
+	dump_mmu_flags(&z_x86_kernel_pdpt, (void *)cr2);
 #endif
 }
 #endif /* CONFIG_EXCEPTION_DEBUG */
@@ -390,7 +390,7 @@ struct task_state_segment _df_tss = {
 	.es = DATA_SEG,
 	.ss = DATA_SEG,
 	.eip = (u32_t)_df_handler_top,
-	.cr3 = (u32_t)X86_MMU_PDPT
+	.cr3 = (u32_t)&z_x86_kernel_pdpt
 };
 
 static FUNC_NORETURN __used void _df_handler_bottom(void)
@@ -407,7 +407,8 @@ static FUNC_NORETURN __used void _df_handler_bottom(void)
 	 * one byte, since if a single push operation caused the fault ESP
 	 * wouldn't be decremented
 	 */
-	_x86_mmu_get_flags((u8_t *)_df_esf.esp - 1, &pde_flags, &pte_flags);
+	_x86_mmu_get_flags(&z_x86_kernel_pdpt,
+			   (u8_t *)_df_esf.esp - 1, &pde_flags, &pte_flags);
 	if ((pte_flags & MMU_ENTRY_PRESENT) != 0) {
 		printk("***** Double Fault *****\n");
 		reason = _NANO_ERR_CPU_EXCEPTION;
@@ -445,7 +446,7 @@ static FUNC_NORETURN __used void _df_handler_top(void)
 	_main_tss.es = DATA_SEG;
 	_main_tss.ss = DATA_SEG;
 	_main_tss.eip = (u32_t)_df_handler_bottom;
-	_main_tss.cr3 = (u32_t)X86_MMU_PDPT;
+	_main_tss.cr3 = (u32_t)&z_x86_kernel_pdpt;
 	_main_tss.eflags = 0;
 
 	/* NT bit is set in EFLAGS so we will task switch back to _main_tss

--- a/arch/x86/core/intstub.S
+++ b/arch/x86/core/intstub.S
@@ -69,6 +69,20 @@
  * void _interrupt_enter(void *isr, void *isr_param);
  */
 SECTION_FUNC(TEXT, _interrupt_enter)
+	/*
+	 * Note that the processor has pushed both the EFLAGS register
+	 * and the logical return address (cs:eip) onto the stack prior
+	 * to invoking the handler specified in the IDT. The stack looks
+	 * like this:
+	 *
+	 *  24 SS (only on privilege level change)
+	 *  20 ESP (only on privilege level change)
+	 *  16 EFLAGS
+	 *  12 CS
+	 *  8  EIP
+	 *  4  isr_param
+	 *  0  isr   <-- stack pointer
+	 */
 
 #ifdef CONFIG_EXECUTION_BENCHMARKING
 	pushl %eax
@@ -91,20 +105,9 @@ SECTION_FUNC(TEXT, _interrupt_enter)
 
 	cld
 
-	/*
-	 * Note that the processor has pushed both the EFLAGS register
-	 * and the logical return address (cs:eip) onto the stack prior
-	 * to invoking the handler specified in the IDT. The stack looks
-	 * like this:
-	 *
-	 *  EFLAGS
-	 *  CS
-	 *  EIP
-	 *  isr_param
-	 *  isr   <-- stack pointer
-	 */
-
-
+#ifdef CONFIG_X86_KPTI
+	call z_x86_trampoline_to_kernel
+#endif
 	/*
 	 * Swap EAX with isr_param and EDX with isr.
 	 * Push ECX onto the stack
@@ -314,7 +317,7 @@ alreadyOnIntStack:
 	popl	%eax
 
 	/* Pop of EFLAGS will re-enable interrupts and restore direction flag */
-	iret
+	KPTI_IRET
 
 #endif /* CONFIG_PREEMPT_ENABLED */
 
@@ -350,7 +353,7 @@ nestedInterrupt:
 	popl	%edx
 	popl	%eax
 	/* Pop of EFLAGS will re-enable interrupts and restore direction flag */
-	iret
+	KPTI_IRET
 
 
 #ifdef CONFIG_SYS_POWER_MANAGEMENT

--- a/arch/x86/core/userspace.S
+++ b/arch/x86/core/userspace.S
@@ -21,10 +21,174 @@ GTEXT(z_arch_user_string_nlen_fixup)
 /* Imports */
 GDATA(_k_syscall_table)
 
+#ifdef CONFIG_X86_KPTI
+/* Switch from the shadow to the kernel page table, switch to the interrupted
+ * thread's kernel stack, and copy all context from the trampoline stack.
+ *
+ * Assumes all registers are callee-saved since this gets called from other
+ * ASM code. Assumes a particular stack layout which is correct for
+ * _exception_enter and _interrupt_enter when invoked with a call instruction:
+ *
+ *  28 SS
+ *  24 ES
+ *  20 EFLAGS
+ *  16 CS
+ *  12 EIP
+ *  8  isr_param or exc code
+ *  4  isr or exc handler
+ *  0  return address
+ */
+SECTION_FUNC(TEXT, z_x86_trampoline_to_kernel)
+	/* Check interrupted code segment to see if we came from ring 3
+	 * and hence on the trampoline stack
+	 */
+	testb $3, 16(%esp) /* Offset of CS */
+	jz 1f
+
+	/* Stash these regs as we need to use them */
+	pushl	%esi
+	pushl	%edi
+
+	/* Switch to kernel page table */
+	movl	$z_x86_kernel_pdpt, %esi
+	movl	%esi, %cr3
+
+	/* Save old trampoline stack pointer in %edi */
+	movl	%esp, %edi
+
+	/* %esp = _kernel->current->stack_info.start
+	 *
+	 * This is the lowest address of the user mode stack, and higest
+	 * address of the kernel stack, they are adjacent.
+	 * We want to transplant context here.
+	 */
+	movl	$_kernel, %esi
+	movl	_kernel_offset_to_current(%esi), %esi
+	movl	_thread_offset_to_stack_start(%esi), %esp
+
+	/* Transplant stack context and restore ESI/EDI. Taking care to zero
+	 * or put uninteresting values where we stashed ESI/EDI since the
+	 * trampoline page is insecure and there might a context switch
+	 * on the way out instead of returning to the original thread
+	 * immediately.
+	 */
+	pushl	36(%edi)	/* SS */
+	pushl	32(%edi)	/* ESP */
+	pushl	28(%edi)	/* EFLAGS */
+	pushl	24(%edi)	/* CS */
+	pushl	20(%edi)	/* EIP */
+	pushl	16(%edi)	/* error code or isr parameter */
+	pushl	12(%edi)	/* exception/irq handler */
+	pushl   8(%edi)		/* return address */
+	movl	4(%edi), %esi	/* restore ESI */
+	movl	$0, 4(%edi)	/* Zero old esi storage area */
+	xchgl	%edi, (%edi)	/* Exchange old edi to restore it and put
+				   old sp in the storage area */
+
+	/* Trampoline stack should have nothing sensitive in it at this point */
+1:
+	ret
+
+/* Copy interrupt return stack context to the trampoline stack, switch back
+ * to the user page table, and only then 'iret'. We jump to this instead
+ * of calling 'iret' if KPTI is turned on.
+ *
+ * Stack layout is expected to be as follows:
+ *
+ * 16 SS
+ * 12 ESP
+ * 8 EFLAGS
+ * 4 CS
+ * 0 EIP
+ *
+ * This function is conditionally macroed to KPTI_IRET/KPTI_IRET_USER
+ */
+SECTION_FUNC(TEXT, z_x86_trampoline_to_user)
+	/* Check interrupted code segment to see if we came from ring 3
+	 * and hence on the trampoline stack
+	 */
+	testb $3, 4(%esp) /* Offset of CS */
+	jz 1f
+
+	/* Otherwise, fall through ... */
+
+SECTION_FUNC(TEXT, z_x86_trampoline_to_user_always)
+	/* Stash EDI, need a free register */
+	pushl	%edi
+
+	/* Store old stack pointer and switch to trampoline stack */
+	movl	%esp, %edi
+	movl	$z_trampoline_stack_end, %esp
+
+	/* Lock IRQs until we get out, we don't want anyone else using the
+	 * trampoline stack
+	 */
+	cli
+
+	/* Copy context */
+	pushl	20(%edi)	/* SS */
+	pushl	16(%edi)	/* ESP */
+	pushl	12(%edi)	/* EFLAGS */
+	pushl   8(%edi)		/* CS */
+	pushl   4(%edi)		/* EIP */
+	xchgl	%edi, (%edi)	/* Exchange old edi to restore it and put
+				   trampoline stack address in its old storage
+				   area */
+	/* Switch to user page table */
+	pushl	%eax
+	movl	$z_x86_user_pdpt, %eax
+	movl	%eax, %cr3
+	popl	%eax
+	movl	$0, -4(%esp)	/* Delete stashed EAX data */
+
+	/* Trampoline stack should have nothing sensitive in it at this point */
+1:
+	iret
+#endif /* CONFIG_X86_KPTI */
+
 /* Landing site for syscall SW IRQ. Marshal arguments and call C function for
- * further processing. We're on the kernel stack for the invoking thread.
+ * further processing. We're on the kernel stack for the invoking thread,
+ * unless KPTI is enabled, in which case we're on the trampoline stack and
+ * need to get off it before enabling interrupts.
  */
 SECTION_FUNC(TEXT, _x86_syscall_entry_stub)
+#ifdef CONFIG_X86_KPTI
+	/* Stash these regs as we need to use them */
+	pushl	%esi
+	pushl	%edi
+
+	/* Switch to kernel page table */
+	movl	$z_x86_kernel_pdpt, %esi
+	movl	%esi, %cr3
+
+	/* Save old trampoline stack pointer in %edi */
+	movl	%esp, %edi
+
+	/* %esp = _kernel->current->stack_info.start
+	 *
+	 * This is the lowest address of the user mode stack, and higest
+	 * address of the kernel stack, they are adjacent.
+	 * We want to transplant context here.
+	 */
+	movl	$_kernel, %esi
+	movl	_kernel_offset_to_current(%esi), %esi
+	movl	_thread_offset_to_stack_start(%esi), %esp
+
+	/* Transplant context according to layout above. Variant of logic
+	 * in x86_trampoline_to_kernel */
+	pushl	24(%edi)	/* SS */
+	pushl	20(%edi)	/* ESP */
+	pushl	16(%edi)	/* EFLAGS */
+	pushl	12(%edi)	/* CS */
+	pushl	8(%edi)		/* EIP */
+	movl	4(%edi), %esi	/* restore ESI */
+	movl	$0, 4(%edi)	/* Zero old esi storage area */
+	xchgl	%edi, (%edi)	/* Exchange old edi to restore it and put
+				   old sp in the storage area */
+
+	/* Trampoline stack should have nothing sensitive in it at this point */
+#endif /* CONFIG_X86_KPTI */
+
 	sti			/* re-enable interrupts */
 	cld			/* clear direction flag, restored on 'iret' */
 
@@ -74,7 +238,7 @@ _id_ok:
 	pop	%ecx		/* Clean ECX and get arg6 off the stack */
 	pop	%edx		/* Clean EDX and get ssf off the stack */
 #endif
-	iret
+	KPTI_IRET_USER
 
 _bad_syscall:
 	/* ESI had a bogus syscall value in it, replace with the bad syscall
@@ -237,4 +401,4 @@ SECTION_FUNC(TEXT, _x86_userspace_enter)
 #endif
 
 	/* We will land in _thread_entry() in user mode after this */
-	iret
+	KPTI_IRET_USER

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -88,6 +88,11 @@ int _arch_buffer_validate(void *addr, size_t size, int write)
 			end_pde_num = MMU_PDE_NUM((char *)addr + size - 1);
 		}
 
+		/* Ensure page directory pointer table entry is present */
+		if (X86_MMU_GET_PDPTE_INDEX(&USER_PDPT, pdpte)->p == 0) {
+			return -EPERM;
+		}
+
 		struct x86_mmu_pd *pd_address =
 			X86_MMU_GET_PD_ADDR_INDEX(&USER_PDPT, pdpte);
 

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -39,7 +39,7 @@ static inline void kernel_arch_init(void)
 	_kernel.irq_stack = K_THREAD_STACK_BUFFER(_interrupt_stack) +
 				CONFIG_ISR_STACK_SIZE;
 #if CONFIG_X86_STACK_PROTECTION
-	_x86_mmu_set_flags(_interrupt_stack, MMU_PAGE_SIZE,
+	_x86_mmu_set_flags(&z_x86_kernel_pdpt, _interrupt_stack, MMU_PAGE_SIZE,
 			   MMU_ENTRY_NOT_PRESENT, MMU_PTE_P_MASK);
 #endif
 }

--- a/arch/x86/include/mmustructs.h
+++ b/arch/x86/include/mmustructs.h
@@ -146,49 +146,48 @@
  * Returns the page table entry for the addr
  * use the union to extract page entry related information.
  */
-#define X86_MMU_GET_PTE(addr)\
+#define X86_MMU_GET_PTE(pdpt, addr)\
 	((union x86_mmu_pte *)\
-	 (&X86_MMU_GET_PT_ADDR(addr)->entry[MMU_PAGE_NUM(addr)]))
+	 (&X86_MMU_GET_PT_ADDR(pdpt, addr)->entry[MMU_PAGE_NUM(addr)]))
 
 /*
  * Returns the Page table address for the particular address.
  * Page Table address(returned value) is always 4KBytes aligned.
  */
-#define X86_MMU_GET_PT_ADDR(addr) \
+#define X86_MMU_GET_PT_ADDR(pdpt, addr) \
 	((struct x86_mmu_pt *)\
-	 (X86_MMU_GET_PDE(addr)->pt << MMU_PAGE_SHIFT))
+	 (X86_MMU_GET_PDE(pdpt, addr)->pt << MMU_PAGE_SHIFT))
 
 /* Returns the page directory entry for the addr
  * use the union to extract page directory entry related information.
  */
-#define X86_MMU_GET_PDE(addr)\
+#define X86_MMU_GET_PDE(pdpt, addr)\
 	((union x86_mmu_pde_pt *)					\
-	 (&X86_MMU_GET_PD_ADDR(addr)->entry[MMU_PDE_NUM(addr)]))
+	 (&X86_MMU_GET_PD_ADDR(pdpt, addr)->entry[MMU_PDE_NUM(addr)]))
 
 /* Returns the page directory entry for the addr
  * use the union to extract page directory entry related information.
  */
-#define X86_MMU_GET_PD_ADDR(addr) \
+#define X86_MMU_GET_PD_ADDR(pdpt, addr) \
 	((struct x86_mmu_pd *)		       \
-	 (X86_MMU_GET_PDPTE(addr)->pd << MMU_PAGE_SHIFT))
+	 (X86_MMU_GET_PDPTE(pdpt, addr)->pd << MMU_PAGE_SHIFT))
 
 /* Returns the page directory pointer entry */
-#define X86_MMU_GET_PDPTE(addr) \
-	((union x86_mmu_pdpte *)		       \
-	 (&X86_MMU_PDPT->entry[MMU_PDPTE_NUM(addr)]))
+#define X86_MMU_GET_PDPTE(pdpt, addr) \
+	(&((pdpt)->entry[MMU_PDPTE_NUM(addr)]))
 
 /* Return the Page directory address.
  * input is the entry number
  */
-#define X86_MMU_GET_PD_ADDR_INDEX(index) \
+#define X86_MMU_GET_PD_ADDR_INDEX(pdpt, index) \
 	((struct x86_mmu_pd *)		       \
-	 (X86_MMU_GET_PDPTE_INDEX(index)->pd << MMU_PAGE_SHIFT))
+	 (X86_MMU_GET_PDPTE_INDEX(pdpt, index)->pd << MMU_PAGE_SHIFT))
 
 /* Returns the page directory pointer entry.
  * Input is the entry number
  */
-#define X86_MMU_GET_PDPTE_INDEX(index) \
-	((union x86_mmu_pdpte *)(&X86_MMU_PDPT->entry[index]))
+#define X86_MMU_GET_PDPTE_INDEX(pdpt, index) \
+	(&((pdpt)->entry[index]))
 
 /* memory partition arch/soc independent attribute */
 #define K_MEM_PARTITION_P_RW_U_RW   (MMU_ENTRY_WRITE | \

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -647,11 +647,8 @@ extern struct task_state_segment _main_tss;
 extern const NANO_ESF _default_esf;
 
 #ifdef CONFIG_X86_MMU
-/* Linker variable. It is needed to access the start of the Page directory */
-
-extern u64_t __mmu_tables_start;
-#define X86_MMU_PDPT ((struct x86_mmu_pdpt *)\
-		      (u32_t *)(void *)&__mmu_tables_start)
+/* kernel's page table */
+extern struct x86_mmu_pdpt z_x86_kernel_pdpt;
 
 /**
  * @brief Fetch page table flags for a particular page
@@ -659,11 +656,12 @@ extern u64_t __mmu_tables_start;
  * Given a memory address, return the flags for the containing page's
  * PDE and PTE entries. Intended for debugging.
  *
+ * @param pdpt Which page table to use
  * @param addr Memory address to example
  * @param pde_flags Output parameter for page directory entry flags
  * @param pte_flags Output parameter for page table entry flags
  */
-void _x86_mmu_get_flags(void *addr,
+void _x86_mmu_get_flags(struct x86_mmu_pdpt *pdpt, void *addr,
 			x86_page_entry_data_t *pde_flags,
 			x86_page_entry_data_t *pte_flags);
 
@@ -674,14 +672,14 @@ void _x86_mmu_get_flags(void *addr,
  * Modify bits in the existing page tables for a particular memory
  * range, which must be page-aligned
  *
+ * @param pdpt Which page table to use
  * @param ptr Starting memory address which must be page-aligned
  * @param size Size of the region, must be page size multiple
  * @param flags Value of bits to set in the page table entries
  * @param mask Mask indicating which particular bits in the page table entries to
  *	 modify
  */
-
-void _x86_mmu_set_flags(void *ptr,
+void _x86_mmu_set_flags(struct x86_mmu_pdpt *pdpt, void *ptr,
 			size_t size,
 			x86_page_entry_data_t flags,
 			x86_page_entry_data_t mask);

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -649,7 +649,12 @@ extern const NANO_ESF _default_esf;
 #ifdef CONFIG_X86_MMU
 /* kernel's page table */
 extern struct x86_mmu_pdpt z_x86_kernel_pdpt;
-
+#ifdef CONFIG_X86_KPTI
+extern struct x86_mmu_pdpt z_x86_user_pdpt;
+#define USER_PDPT	z_x86_user_pdpt
+#else
+#define USER_PDPT	z_x86_kernel_pdpt
+#endif
 /**
  * @brief Fetch page table flags for a particular page
  *
@@ -683,6 +688,8 @@ void _x86_mmu_set_flags(struct x86_mmu_pdpt *pdpt, void *ptr,
 			size_t size,
 			x86_page_entry_data_t flags,
 			x86_page_entry_data_t mask);
+
+void z_x86_reset_pages(void *start, size_t size);
 
 #endif /* CONFIG_X86_MMU */
 

--- a/include/arch/x86/asm.h
+++ b/include/arch/x86/asm.h
@@ -74,6 +74,16 @@
 
 #endif /* CONFIG_RETPOLINE */
 
+#ifdef CONFIG_X86_KPTI
+GTEXT(z_x86_trampoline_to_user)
+GTEXT(z_x86_trampoline_to_kernel)
+
+#define KPTI_IRET	jmp z_x86_trampoline_to_user
+#define KPTI_IRET_USER	jmp z_x86_trampoline_to_user_always
+#else
+#define KPTI_IRET	iret
+#define KPTI_IRET_USER	iret
+#endif /* CONFIG_X86_KPTI */
 #endif /* _ASMLANGUAGE */
 
 #endif /* ZEPHYR_INCLUDE_ARCH_X86_ASM_H_ */

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -375,6 +375,10 @@ SECTIONS
 	__mmu_tables_start = .;
 	z_x86_kernel_pdpt = .;
 	KEEP(*(.mmu_data));
+#ifdef CONFIG_X86_KPTI
+	z_x86_user_pdpt = .;
+	KEEP(*(.user_mmu_data));
+#endif /* CONFIG_X86_KPTI */
 	__mmu_tables_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -373,6 +373,7 @@ SECTIONS
 	/* Page Tables are located here if MMU is enabled.*/
 	MMU_PAGE_ALIGN
 	__mmu_tables_start = .;
+	z_x86_kernel_pdpt = .;
 	KEEP(*(.mmu_data));
 	__mmu_tables_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -274,14 +274,6 @@ SECTIONS
 	*(".kernel.*")
 
 #ifdef CONFIG_DYNAMIC_INTERRUPTS
-	. = ALIGN(8);
-	_idt_base_address = .;
-#ifdef LINKER_PASS2
-	KEEP(*(staticIdt))
-#else
-	. += CONFIG_IDT_NUM_VECTORS * 8;
-#endif /* LINKER_PASS2 */
-
 #ifndef CONFIG_X86_FIXED_IRQ_MAPPING
 	. = ALIGN(4);
 	_irq_to_interrupt_vector = .;
@@ -300,7 +292,6 @@ SECTIONS
 #endif /* LINKER_PASS2 */
 #endif /* CONFIG_DYNAMIC_INTERRUPTS */
 
-
 #ifdef CONFIG_SOC_RWDATA_LD
 #include <soc-rwdata.ld>
 #endif
@@ -309,6 +300,27 @@ SECTIONS
 /* Located in project source directory */
 #include <custom-rwdata.ld>
 #endif
+
+#ifdef CONFIG_X86_KPTI
+	MMU_PAGE_ALIGN
+	z_shared_kernel_page_start = .;
+	/* Special page containing supervisor data that is still mapped in
+	 * user mode page tables. IDT, GDT, TSSes, trampoline stack, and
+	 * any LDT must go here as they always must live in a page that is
+	 * marked 'present'. Still not directly user accessible, but
+	 * no sensitive data should be here as Meltdown exploits may read it.
+	 */
+#endif /* CONFIG_X86_KPTI */
+
+#ifdef CONFIG_DYNAMIC_INTERRUPTS
+	. = ALIGN(8);
+	_idt_base_address = .;
+#ifdef LINKER_PASS2
+	KEEP(*(staticIdt))
+#else
+	. += CONFIG_IDT_NUM_VECTORS * 8;
+#endif /* LINKER_PASS2 */
+#endif /* CONFIG_DYNAMIC_INTERRUPTS */
 
 #ifdef CONFIG_GDT_DYNAMIC
 	KEEP(*(.tss))
@@ -328,6 +340,18 @@ SECTIONS
 	. += GDT_NUM_ENTRIES * 8;
 #endif /* LINKER_PASS2 */
 #endif /* CONFIG_GDT_DYNAMIC */
+
+#ifdef CONFIG_X86_KPTI
+	z_trampoline_stack_start = .;
+	MMU_PAGE_ALIGN
+	z_trampoline_stack_end = .;
+	z_shared_kernel_page_end = .;
+
+	ASSERT(z_trampoline_stack_end - z_trampoline_stack_start >= 40,
+		"trampoline stack too small");
+	ASSERT(z_shared_kernel_page_end - z_shared_kernel_page_start == 4096,
+	       "shared kernel area is not one memory page");
+#endif /* CONFIG_X86_KPTI */
 
 	. = ALIGN(4);
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)

--- a/kernel/include/offsets_short.h
+++ b/kernel/include/offsets_short.h
@@ -61,7 +61,8 @@
 #define _thread_offset_to_esf \
 	(___thread_t_arch_OFFSET + ___thread_arch_t_esf_OFFSET)
 
-
+#define _thread_offset_to_stack_start \
+	(___thread_t_stack_info_OFFSET + ___thread_stack_info_t_start_OFFSET)
 /* end - threads */
 
 #endif /* ZEPHYR_KERNEL_INCLUDE_OFFSETS_SHORT_H_ */

--- a/scripts/gen_mmu_x86.py
+++ b/scripts/gen_mmu_x86.py
@@ -11,15 +11,6 @@ import re
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 
-#  global variables
-pd_complete = ''
-inputfile = ''
-outputfile = ''
-list_of_pde = {}
-num_of_regions = 0
-read_buff = ''
-raw_info = []
-
 mmu_region_details = namedtuple("mmu_region_details",
                                 "pde_index page_entries_info")
 
@@ -31,47 +22,73 @@ valid_pages_inside_pde = namedtuple("valid_pages_inside_pde", "start_addr size \
 mmu_region_details_pdpt = namedtuple("mmu_region_details_pdpt",
                                      "pdpte_index pd_entries")
 
-page_tables_list = []
-pd_tables_list = []
-pd_start_addr = 0
-validation_issue_memory_overlap = [False, 0, -1]
-output_offset = 0
-print_string_pde_list = ''
-pde_pte_string = {}
-FourMB = (1024 * 4096)  # In Bytes
-
-#  Constants
+# Constants
 PAGE_ENTRY_PRESENT = 1
 PAGE_ENTRY_READ_WRITE = 1 << 1
 PAGE_ENTRY_USER_SUPERVISOR = 1 << 2
-PAGE_ENTRY_PWT = 0 << 3
-PAGE_ENTRY_PCD = 0 << 4
-PAGE_ENTRY_ACCESSED = 0 << 5  # this is a read only field
-PAGE_ENTRY_DIRTY = 0 << 6  # this is a read only field
-PAGE_ENTRY_PAT = 0 << 7
-PAGE_ENTRY_GLOBAL = 0 << 8
-PAGE_ENTRY_ALLOC = 1 << 9
-PAGE_ENTRY_CUSTOM = 0 << 10
-#############
+PAGE_ENTRY_XD = 1 << 63
 
+# Struct formatters
+struct_mmu_regions_format = "<IIQ"
+header_values_format = "<II"
+page_entry_format = "<Q"
 
-#*****************************************************************************#
-# class for PAE 4KB Mode
+entry_counter = 0
+def print_code(val):
+    global entry_counter
+
+    if not val & PAGE_ENTRY_PRESENT:
+        ret = '.'
+    else:
+        if (val & PAGE_ENTRY_READ_WRITE):
+            # Writable page
+            if (val & PAGE_ENTRY_XD):
+                # Readable, writeable, not executable
+                ret = 'w'
+            else:
+                # Readable, writable, executable
+                ret = 'a'
+        else:
+            # Read-only
+            if (val & PAGE_ENTRY_XD):
+                # Read-only
+                ret = 'r'
+            else:
+                # Readable, executable
+                ret = 'x'
+
+        if (val & PAGE_ENTRY_USER_SUPERVISOR):
+            # User accessible pages are capital letters
+            ret = ret.upper()
+
+    sys.stdout.write(ret)
+    entry_counter = entry_counter + 1
+    if (entry_counter == 128):
+        sys.stdout.write("\n")
+        entry_counter = 0
+
 class PageMode_PAE:
     total_pages = 511
-    write_page_entry_bin = "Q"
+
     size_addressed_per_pde = (512 * 4096)  # 2MB In Bytes
     size_addressed_per_pdpte = (512 * size_addressed_per_pde)  # In Bytes
     list_of_pdpte = {}
-    pdpte_print_string = {}
-    print_string_pdpte_list = ''
 
-    # TODO enable all page tables on just a flag
+    def __init__(self, pd_start_addr, mem_regions, syms, kpti):
+        self.pd_start_addr = pd_start_addr
+        self.mem_regions = mem_regions
+        self.pd_tables_list = []
+        self.output_offset = 0
+        self.kpti = kpti
+        self.syms = syms
 
-    def __init__(self):
         for i in range(4):
             self.list_of_pdpte[i] = mmu_region_details_pdpt(pdpte_index=i,
                                                             pd_entries={})
+        self.populate_required_structs()
+        self.pdpte_create_binary_file()
+        self.page_directory_create_binary_file()
+        self.page_table_create_binary_file()
 
     # return the pdpte number for the give address
     def get_pdpte_number(self, value):
@@ -89,94 +106,38 @@ class PageMode_PAE:
         return len(self.get_pdpte_list())
 
     def get_pdpte_list(self):
-        return list({temp[0] for temp in pd_tables_list})
+        return list({temp[0] for temp in self.pd_tables_list})
 
     # the return value will have the page address and it is assumed to be a 4096
     # boundary.hence the output of this API will be a 20bit address of the page
     # table
     def address_of_page_table(self, pdpte, page_table_number):
-        global pd_start_addr
-
         # first page given to page directory pointer
         # and 2nd page till 5th page are used for storing the page directories.
 
         # set the max pdpte used. this tells how many pd are needed after
         # that we start keeping the pt
         PT_start_addr = self.get_number_of_pd() * 4096 +\
-            pd_start_addr + 4096
+            self.pd_start_addr + 4096
         return (PT_start_addr +
-                (pd_tables_list.index([pdpte, page_table_number]) *
+                (self.pd_tables_list.index([pdpte, page_table_number]) *
                  4096) >> 12)
-
-    #   union x86_mmu_pae_pde {
-    # 	u64_t  value;
-    # 	struct {
-    # 		u64_t p:1;
-    # 		u64_t rw:1;
-    # 		u64_t us:1;
-    # 		u64_t pwt:1;
-    # 		u64_t pcd:1;
-    # 		u64_t a:1;
-    # 		u64_t ignored1:1;
-    # 		u64_t ps:1;
-    # 		u64_t ignored2:4;
-    # 		u64_t page_table:20;
-    # 		u64_t igonred3:29;
-    # 		u64_t xd:1;
-    # 	};
-    # };
 
     def get_binary_pde_value(self, pdpte, value):
         perms = value.page_entries_info[0].permissions
 
         present = PAGE_ENTRY_PRESENT
+
         read_write = check_bits(perms, [1, 29]) << 1
         user_mode = check_bits(perms, [2, 28]) << 2
 
-        pwt = PAGE_ENTRY_PWT
-        pcd = PAGE_ENTRY_PCD
-        a = PAGE_ENTRY_ACCESSED
-        ps = 0 << 7  # set to make sure that the phy page is 4KB
         page_table = self.address_of_page_table(pdpte, value.pde_index) << 12
-        xd = 0
-        return (present |
-                read_write |
-                user_mode |
-                pwt |
-                pcd |
-                a |
-                ps |
-                page_table |
-                xd)
+        return present | read_write | user_mode | page_table
 
-    # union x86_mmu_pae_pte {
-    # 	u64_t  value;
-    # 	struct {
-    # 		u64_t p:1;
-    # 		u64_t rw:1;
-    # 		u64_t us:1;
-    # 		u64_t pwt:1;
-    # 		u64_t pcd:1;
-    # 		u64_t a:1;
-    # 		u64_t d:1;
-    # 		u64_t pat:1;
-    # 		u64_t g:1;
-    # 		u64_t ignore:3;
-    # 		u64_t page:20;
-    # 		u64_t igonred3:29;
-    # 		u64_t xd:1;
-    # 	};
-    # };
     def get_binary_pte_value(self, value, pde, pte, perm_for_pte):
-        present = PAGE_ENTRY_PRESENT
         read_write = perm_for_pte & PAGE_ENTRY_READ_WRITE
         user_mode = perm_for_pte & PAGE_ENTRY_USER_SUPERVISOR
-        pwt = PAGE_ENTRY_PWT
-        pcd = PAGE_ENTRY_PCD
-        a = PAGE_ENTRY_ALLOC
-        d = PAGE_ENTRY_DIRTY
-        pat = PAGE_ENTRY_PAT
-        g = PAGE_ENTRY_GLOBAL
+        xd = perm_for_pte & PAGE_ENTRY_XD
 
         # This points to the actual memory in the HW
         # totally 20 bits to rep the phy address
@@ -184,11 +145,21 @@ class PageMode_PAE:
         # next 9bits is pte
         page_table = ((value.pdpte_index << 18) | (pde << 9) | pte) << 12
 
-        xd = ((perm_for_pte >> 63) & 0x1) << 63
+        if self.kpti:
+            if user_mode:
+                present = PAGE_ENTRY_PRESENT
+            else:
+                if page_table == self.syms['z_shared_kernel_page_start']:
+                    present = PAGE_ENTRY_PRESENT
+                else:
+                    present = 0
+        else:
+            present = PAGE_ENTRY_PRESENT
 
-        binary_value = (present | read_write | user_mode |
-                        pwt | pcd | a | d | pat | g |
-                        page_table | xd)
+
+
+
+        binary_value = (present | read_write | user_mode | page_table | xd)
         return binary_value
 
     def clean_up_unused_pdpte(self):
@@ -220,25 +191,25 @@ class PageMode_PAE:
             self.list_of_pdpte[pdpte].pd_entries[pde_index] = mem_region_values
 
     def populate_required_structs(self):
-        for region in raw_info:
-            pdpte_index = self.get_pdpte_number(region[0])
-            pde_index = self.get_pde_number(region[0])
-            pte_valid_addr_start = self.get_pte_number(region[0])
+        for start, size, flags in self.mem_regions:
+            pdpte_index = self.get_pdpte_number(start)
+            pde_index = self.get_pde_number(start)
+            pte_valid_addr_start = self.get_pte_number(start)
 
             # Get the end of the page table entries
             # Since a memory region can take up only a few entries in the Page
             # table, this helps us get the last valid PTE.
-            pte_valid_addr_end = self.get_pte_number(region[0] +
-                                                     region[1] - 1)
+            pte_valid_addr_end = self.get_pte_number(start +
+                                                     size - 1)
 
-            mem_size = region[1]
+            mem_size = size
 
             # In-case the start address aligns with a page table entry other
             # than zero and the mem_size is greater than (1024*4096) i.e 4MB
             # in case where it overflows the currenty PDE's range then limit the
             # PTE to 1024 and so make the mem_size reflect the actual size
             # taken up in the current PDE
-            if (region[1] + (pte_valid_addr_start * 4096)) >= \
+            if (size + (pte_valid_addr_start * 4096)) >= \
                (self.size_addressed_per_pde):
 
                 pte_valid_addr_end = self.total_pages
@@ -247,14 +218,14 @@ class PageMode_PAE:
 
             self.set_pde_pte_values(pdpte_index,
                                     pde_index,
-                                    region[0],
+                                    start,
                                     mem_size,
                                     pte_valid_addr_start,
                                     pte_valid_addr_end,
-                                    region[2])
+                                    flags)
 
-            if [pdpte_index, pde_index] not in pd_tables_list:
-                pd_tables_list.append([pdpte_index, pde_index])
+            if [pdpte_index, pde_index] not in self.pd_tables_list:
+                self.pd_tables_list.append([pdpte_index, pde_index])
 
             # IF the current pde couldn't fit the entire requested region
             # size then there is a need to create new PDEs to match the size.
@@ -263,7 +234,7 @@ class PageMode_PAE:
             # PDE/PDEs so the size remaining will be
             # requested size - allocated size(in the current PDE)
 
-            overflow_size = region[1] - mem_size
+            overflow_size = size - mem_size
 
             # create all the extra PDEs needed to fit the requested size
             # this loop starts from the current pde till the last pde that is
@@ -271,10 +242,10 @@ class PageMode_PAE:
             # 22
             if overflow_size != 0:
                 for extra_pdpte in range(pdpte_index,
-                                         self.get_pdpte_number(region[0] +
-                                                               region[1]) + 1):
+                                         self.get_pdpte_number(start +
+                                                               size) + 1):
                     for extra_pde in range(pde_index + 1, self.get_pde_number(
-                            region[0] + region[1]) + 1):
+                            start + size) + 1):
 
                         # new pde's start address
                         # each page directory entry has a addr range of
@@ -307,85 +278,90 @@ class PageMode_PAE:
                                                 extra_region_size,
                                                 0,
                                                 extra_pte_valid_addr_end,
-                                                region[2])
+                                                flags)
 
                         # for the next iteration of the loop the size needs
                         # to decreased
                         overflow_size -= extra_region_size
 
-                        if [extra_pdpte, extra_pde] not in pd_tables_list:
-                            pd_tables_list.append([extra_pdpte, extra_pde])
+                        if [extra_pdpte, extra_pde] not in self.pd_tables_list:
+                            self.pd_tables_list.append([extra_pdpte, extra_pde])
 
                         if overflow_size == 0:
                             break
 
-        pd_tables_list.sort()
+        self.pd_tables_list.sort()
         self.clean_up_unused_pdpte()
 
-    def pdpte_create_binary_file(self):
-        global output_buffer
-        global output_offset
-        global pd_start_addr
 
+        pages_for_pdpte = 1
+        pages_for_pd = self.get_number_of_pd()
+        pages_for_pt = len(self.pd_tables_list)
+        self.output_buffer = ctypes.create_string_buffer((pages_for_pdpte +
+                                                   pages_for_pd +
+                                                   pages_for_pt) * 4096)
+
+    def pdpte_create_binary_file(self):
         # pae needs a pdpte at 32byte aligned address
 
         # Even though we have only 4 entries in the pdpte we need to move
-        # the output_offset variable to the next page to start pushing
+        # the self.output_offset variable to the next page to start pushing
         # the pd contents
+        #
+        # FIXME: This wastes a ton of RAM!!
+        if (args.verbose):
+            print("PDPTE at 0x%x" % self.pd_start_addr)
+
         for pdpte in range(self.total_pages + 1):
             if pdpte in self.get_pdpte_list():
                 present = 1 << 0
-                pwt = 0 << 3
-                pcd = 0 << 4
-                addr_of_pd = (((pd_start_addr + 4096) +
+                addr_of_pd = (((self.pd_start_addr + 4096) +
                                self.get_pdpte_list().index(pdpte) *
                                4096) >> 12) << 12
-                binary_value = (present | pwt | pcd | addr_of_pd)
-                self.pdpte_verbose_output(pdpte, binary_value)
+                binary_value = (present | addr_of_pd)
             else:
                 binary_value = 0
 
-            struct.pack_into(self.write_page_entry_bin,
-                             output_buffer,
-                             output_offset,
+            struct.pack_into(page_entry_format,
+                             self.output_buffer,
+                             self.output_offset,
                              binary_value)
 
-            output_offset += struct.calcsize(self.write_page_entry_bin)
+            self.output_offset += struct.calcsize(page_entry_format)
+
 
     def page_directory_create_binary_file(self):
-        global output_buffer
-        global output_offset
-        pdpte_number_count = 0
         for pdpte, pde_info in self.list_of_pdpte.items():
-
-            pde_number_count = 0
+            if (args.verbose):
+                print("Page directory %d at 0x%x" % (pde_info.pdpte_index,
+                        self.pd_start_addr + self.output_offset))
             for pde in range(self.total_pages + 1):
                 binary_value = 0  # the page directory entry is not valid
 
                 # if i have a valid entry to populate
-                # if pde in sorted(list_of_pde.keys()):
-                if pde in sorted(pde_info.pd_entries.keys()):
+                if pde in pde_info.pd_entries.keys():
                     value = pde_info.pd_entries[pde]
                     binary_value = self.get_binary_pde_value(pdpte, value)
-                    self.pde_verbose_output(pdpte, pde, binary_value)
 
-                pde_number_count += 1
-                struct.pack_into(self.write_page_entry_bin,
-                                 output_buffer,
-                                 output_offset,
+                struct.pack_into(page_entry_format,
+                                 self.output_buffer,
+                                 self.output_offset,
                                  binary_value)
+                if (args.verbose):
+                    print_code(binary_value)
 
-                output_offset += struct.calcsize(self.write_page_entry_bin)
+                self.output_offset += struct.calcsize(page_entry_format)
 
     def page_table_create_binary_file(self):
-        global output_buffer
-        global output_offset
-
-        pdpte_number_count = 0
         for pdpte, pde_info in sorted(self.list_of_pdpte.items()):
-            pdpte_number_count += 1
             for pde, pte_info in sorted(pde_info.pd_entries.items()):
-                pte_number_count = 0
+                pe_info = pte_info.page_entries_info[0]
+                start_addr = pe_info.start_addr & ~0x1FFFFF
+                end_addr = start_addr + 0x1FFFFF
+                if (args.verbose):
+                    print("Page table for 0x%08x - 0x%08x at 0x%08x" %
+                            (start_addr, end_addr,
+                                self.pd_start_addr + self.output_offset))
                 for pte in range(self.total_pages + 1):
                     binary_value = 0  # the page directory entry is not valid
 
@@ -405,279 +381,81 @@ class PageMode_PAE:
                                                                  pde,
                                                                  pte,
                                                                  perm_for_pte)
-                        pte_number_count += 1
-                        self.pte_verbose_output(pdpte, pde, pte, binary_value)
 
-                    # print(binary_value, (self.write_page_entry_bin))
-
-                    struct.pack_into(self.write_page_entry_bin,
-                                     output_buffer,
-                                     output_offset,
+                    if (args.verbose):
+                        print_code(binary_value)
+                    struct.pack_into(page_entry_format,
+                                     self.output_buffer,
+                                     self.output_offset,
                                      binary_value)
-                    output_offset += struct.calcsize(self.write_page_entry_bin)
+                    self.output_offset += struct.calcsize(page_entry_format)
 
-    # To populate the binary file the module struct needs a buffer of the
-    # excat size This returns the size needed for the given set of page tables.
-    def set_binary_file_size(self):
-        pages_for_pdpte = 1
-        pages_for_pd = self.get_number_of_pd()
-        pages_for_pt = len(pd_tables_list)
-        binary_size = ctypes.create_string_buffer((pages_for_pdpte +
-                                                   pages_for_pd +
-                                                   pages_for_pt) * 4096)
-        return binary_size
-
-    # prints the details of the pde
-    def verbose_output(self):
-        print("\nTotal Page directory Page pointer entries " +
-              str(self.get_number_of_pd()))
-        count = 0
-        for pdpte, pde_info in sorted(self.list_of_pdpte.items()):
-            print(
-                "In page directory page table pointer " +
-                format_string(pdpte))
-
-            for pde, pte_info in sorted(pde_info.pd_entries.items()):
-                for pte in pte_info.page_entries_info:
-                    count += 1
-                    print("    In Page directory entry " + format_string(pde) +
-                          ": valid start address = " +
-                          hex_32(pte.start_addr) + ", end address = " +
-                          hex_32((pte.pte_valid_addr_end + 1) * 4096 - 1 +
-                                 (pde * (self.size_addressed_per_pde)) +
-                                 (pdpte * self.size_addressed_per_pdpte)))
-
-    def pdpte_verbose_output(self, pdpte, binary_value):
-        if args.verbose < 2:
-            return
-
-        present = format_string(binary_value & 0x1)
-        pwt = format_string((binary_value >> 3) & 0x1)
-        pcd = format_string((binary_value >> 4) & 0x1)
-        page_table_addr = format_string(hex((binary_value >> 12) & 0xFFFFF))
-
-        self.print_string_pdpte_list += (format_string(str(pdpte)) +
-                                         " | " + (present) + " | " +
-                                         (pwt) + " | " +
-                                         (pcd) + " | " +
-                                         page_table_addr + "\n")
-
-    def pdpte_print_elements(self):
-        print("\nPAGE DIRECTORIES POINTER ")
-        print(format_string("PDPTE") + " | " +
-              format_string('P') + " | " +
-              format_string('pwt') + " | " +
-              format_string('pcd') + " | " +
-              format_string('Addr'))
-        print(self.print_string_pdpte_list)
-        print("END OF PAGE DIRECTORY POINTER")
-
-    def pde_verbose_output(self, pdpte, pde, binary_value):
-        if args.verbose < 2:
-            return
-
-        global print_string_pde_list
-
-        present = format_string(binary_value & 0x1)
-        read_write = format_string((binary_value >> 1) & 0x1)
-        user_mode = format_string((binary_value >> 2) & 0x1)
-        pwt = format_string((binary_value >> 3) & 0x1)
-        pcd = format_string((binary_value >> 4) & 0x1)
-        a = format_string((binary_value >> 5) & 0x1)
-        ignored1 = format_string(0)
-        ps = format_string((binary_value >> 7) & 0x1)
-        ignored2 = format_string(0000)
-        page_table_addr = format_string(hex((binary_value >> 12) & 0xFFFFF))
-        xd = format_string((binary_value >> 63) & 0x1)
-
-        print_string_pde_list = (format_string(str(pde)) + " | " +
-                                 (present) + " | " +
-                                 (read_write) + " | " +
-                                 (user_mode) + " | " +
-                                 (pwt) + " | " +
-                                 (pcd) + " | " +
-                                 (a) + " | " +
-                                 (ps) + " | " +
-                                 page_table_addr + " | " +
-                                 (xd) + "\n")
-
-        if pdpte in self.pdpte_print_string.keys():
-            self.pdpte_print_string[pdpte] += (print_string_pde_list)
-        else:
-            self.pdpte_print_string[pdpte] = print_string_pde_list
-
-    # print all the tables for a given page table mode
-    def print_all_page_table_info(self):
-        self.pdpte_print_elements()
-        self.pde_print_elements()
-        self.pte_print_elements()
-
-    def pde_print_elements(self):
-        global print_string_pde_list
-
-        for pdpte, print_string in sorted(self.pdpte_print_string.items()):
-            print("\n PAGE DIRECTORIES for PDPT " + str(pdpte))
-            print(format_string("PDE") + " | " +
-                  format_string('P') + " | " +
-                  format_string('rw') + " | " +
-                  format_string('us') + " | " +
-                  format_string('pwt') + " | " +
-                  format_string('pcd') + " | " +
-                  format_string('a') + " | " +
-                  format_string('ps') + " | " +
-                  format_string('Addr') + " | " +
-                  format_string('xd'))
-            print(print_string)
-            print("END OF PAGE DIRECTORIES for PDPT " + str(pdpte))
-
-    def pte_verbose_output(self, pdpte, pde, pte, binary_value):
-        global pde_pte_string
-
-        present = format_string((binary_value >> 0) & 0x1)
-        read_write = format_string((binary_value >> 1) & 0x1)
-        user_mode = format_string((binary_value >> 2) & 0x1)
-        pwt = format_string((binary_value >> 3) & 0x1)
-        pcd = format_string((binary_value >> 4) & 0x1)
-        a = format_string((binary_value >> 5) & 0x1)
-        d = format_string((binary_value >> 6) & 0x1)
-        pat = format_string((binary_value >> 7) & 0x1)
-        g = format_string((binary_value >> 8) & 0x1)
-        page_table_addr = hex_20((binary_value >> 12) & 0xFFFFF)
-        xd = format_string((binary_value >> 63) & 0x1)
-
-        print_string_list = (format_string(str(pte)) + " | " +
-                             (present) + " | " +
-                             (read_write) + " | " +
-                             (user_mode) + " | " +
-                             (pwt) + " | " +
-                             (pcd) + " | " +
-                             (a) + " | " +
-                             (d) + " | " +
-                             (pat) + " | " +
-                             (g) + " | " +
-                             page_table_addr + " | " +
-                             (xd) + "\n"
-                             )
-
-        if (pdpte, pde) in pde_pte_string.keys():
-            pde_pte_string[(pdpte, pde)] += (print_string_list)
-        else:
-            pde_pte_string[(pdpte, pde)] = print_string_list
-
-    def pte_print_elements(self):
-        global pde_pte_string
-
-        for (pdpte, pde), print_string in sorted(pde_pte_string.items()):
-            print(
-                "\nPAGE TABLE for PDPTE = " +
-                str(pdpte) +
-                " and PDE = " +
-                str(pde))
-
-            print(format_string("PTE") + " | " +
-                  format_string('P') + " | " +
-                  format_string('rw') + " | " +
-                  format_string('us') + " | " +
-                  format_string('pwt') + " | " +
-                  format_string('pcd') + " | " +
-                  format_string('a') + " | " +
-                  format_string('d') + " | " +
-                  format_string('pat') + " | " +
-                  format_string('g') + " | " +
-                  format_string('Page Addr') + " | " +
-                  format_string('xd'))
-            print(print_string)
-            print("END OF PAGE TABLE " + str(pde))
 
 
 #*****************************************************************************#
 
+def read_mmu_list(filename):
+    with open(filename, 'rb') as fp:
+        mmu_list_data = fp.read()
 
-def print_list_of_pde(list_of_pde):
-    for key, value in list_of_pde.items():
-        print(key, value)
-        print('\n')
+    regions = []
 
-
-# read the binary from the input file and populate a dict for
-# start address of mem region
-# size of the region - so page tables entries will be created with this
-# read write permissions
-
-def read_mmu_list_marshal_param(page_table):
-
-    global read_buff
-    global page_tables_list
-    global pd_start_addr
-    global validation_issue_memory_overlap
-    read_buff = input_file.read()
-    input_file.close()
-
-    # read contents of the binary file first 2 values read are
-    # num_of_regions and page directory start address both calculated and
-    # populated by the linker
+    # Read mmu_list header data
     num_of_regions, pd_start_addr = struct.unpack_from(
-        header_values_format, read_buff, 0)
+        header_values_format, mmu_list_data, 0)
 
     # a offset used to remember next location to read in the binary
     size_read_from_binary = struct.calcsize(header_values_format)
 
-    # for each of the regions mentioned in the binary loop and populate all the
-    # required parameters
-    for region in range(num_of_regions):
-        basic_mem_region_values = struct.unpack_from(struct_mmu_regions_format,
-                                                     read_buff,
+    if (args.verbose):
+        print("Start address of page tables: 0x%08x" % pd_start_addr)
+        print("Build-time memory regions:")
+
+    # Read all the region definitions
+    for region_index in range(num_of_regions):
+        addr, size, flags = struct.unpack_from(struct_mmu_regions_format,
+                                                     mmu_list_data,
                                                      size_read_from_binary)
         size_read_from_binary += struct.calcsize(struct_mmu_regions_format)
 
+        if (args.verbose):
+            print("    Region %03d: 0x%08x - 0x%08x (0x%016x)" %
+                    (region_index, addr, addr + size - 1, flags))
+
         # ignore zero sized memory regions
-        if basic_mem_region_values[1] == 0:
+        if size == 0:
             continue
 
+        if (addr & 0xFFF) != 0:
+            print("Memory region %d start address %x is not page-aligned" %
+                    (region_index, addr))
+            sys.exit(2)
+
+        if (size & 0xFFF) != 0:
+            print("Memory region %d size %zu is not page-aligned" %
+                    (region_index, size))
+            sys.exit(2)
+
         # validate for memory overlap here
-        for i in raw_info:
-            start_location = basic_mem_region_values[0]
-            end_location = basic_mem_region_values[0] + \
-                basic_mem_region_values[1]
+        for other_region_index in range(len(regions)):
+            other_addr, other_size, _ = regions[other_region_index]
 
-            overlap_occurred = ((start_location >= i[0]) and
-                                (start_location <= (i[0] + i[1]))) and \
-                ((end_location >= i[0]) and
-                 (end_location <= i[0] + i[1]))
+            end_addr = addr + size
+            other_end_addr = other_addr + other_size
 
-            if overlap_occurred:
-                validation_issue_memory_overlap = [
-                    True,
-                    start_location,
-                    page_table.get_pde_number(start_location)]
-                return
+            overlap_occurred = ((addr >= other_addr) and
+                                (addr <= other_end_addr))
+
+            if (addr >= other_addr) and (addr <= other_end_addr):
+                print("Memory region %d (%x:%x) overlaps memory region %d (%x:%x)" %
+                        (region_index, addr, end_addr, other_region_index,
+                            other_addr, other_end_addr))
+                sys.exit(2)
 
         # add the retrived info another list
-        raw_info.append(basic_mem_region_values)
+        regions.append((addr, size, flags))
 
-
-def validate_pde_regions():
-    # validation for correct page alignment of the regions
-    for key, value in list_of_pde.items():
-        for pages_inside_pde in value.page_entries_info:
-            if pages_inside_pde.start_addr & (0xFFF) != 0:
-                print("Memory Regions are not page aligned",
-                      hex(pages_inside_pde.start_addr))
-                sys.exit(2)
-
-            # validation for correct page alignment of the regions
-            if pages_inside_pde.size & (0xFFF) != 0:
-                print("Memory Regions size is not page aligned",
-                      hex(pages_inside_pde.size))
-                sys.exit(2)
-
-    # validation for spiling of the regions across various
-    if validation_issue_memory_overlap[0] == True:
-        print("Memory Regions are overlapping at memory address " +
-              str(hex(validation_issue_memory_overlap[1])) +
-              " with Page directory Entry number " +
-              str(validation_issue_memory_overlap[2]))
-        sys.exit(2)
+    return (pd_start_addr, regions)
 
 
 def check_bits(val, bits):
@@ -685,86 +463,6 @@ def check_bits(val, bits):
         if val & (1 << b):
             return 1
     return 0
-
-
-# Read the parameters passed to the file
-def parse_args():
-    global args
-
-    parser = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
-
-    parser.add_argument("-e", "--big-endian", action="store_true",
-                        help="Target encodes data in big-endian format"
-                        "(little endian is the default)")
-
-    parser.add_argument("-i", "--input",
-                        help="Input file from which MMU regions are read.")
-    parser.add_argument("-k", "--kernel",
-                        help="Zephyr kernel image")
-    parser.add_argument(
-        "-o", "--output",
-        help="Output file into which the page tables are written.")
-    parser.add_argument("-v", "--verbose", action="count", default=0,
-                        help="Print debugging information. Multiple "
-                             "invocations increase verbosity")
-    args = parser.parse_args()
-    if "VERBOSE" in os.environ:
-        args.verbose = 1
-
-
-# the format for writing in the binary file would be decided by the
-# endian selected
-def set_struct_endian_format(page_table):
-    endian_string = "<"
-    if args.big_endian is True:
-        endian_string = ">"
-    global struct_mmu_regions_format
-    global header_values_format
-
-    struct_mmu_regions_format = endian_string + "IIQ"
-    header_values_format = endian_string + "II"
-    page_table.write_page_entry_bin = (endian_string +
-                                      page_table.write_page_entry_bin)
-
-
-def format_string(input_str):
-    output_str = '{0: <5}'.format(str(input_str))
-    return output_str
-
-# format for 32bit hex value
-
-
-def hex_32(input_value):
-    output_value = "{0:#0{1}x}".format(input_value, 10)
-    return output_value
-
-# format for 20bit hex value
-
-
-def hex_20(input_value):
-    output_value = "{0:#0{1}x}".format(input_value, 7)
-    return output_value
-
-
-def verbose_output(page_table):
-    if args.verbose == 0:
-        return
-
-    print("\nMemory Regions as defined:")
-    for info in raw_info:
-        print("Memory region start address = " + hex_32(info[0]) +
-              ", Memory size = " + hex_32(info[1]) +
-              ", Permission = " + hex(info[2]))
-
-    page_table.verbose_output()
-
-    if args.verbose > 1:
-        page_table.print_all_page_table_info()
-
-# build sym table
-
 
 def get_symbols(obj):
     for section in obj.iter_sections():
@@ -774,49 +472,52 @@ def get_symbols(obj):
 
     raise LookupError("Could not find symbol table")
 
+# Read the parameters passed to the file
+def parse_args():
+    global args
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument("-i", "--input",
+                        help="Input file from which MMU regions are read.")
+    parser.add_argument("-k", "--kernel",
+                        help="Zephyr kernel image")
+    parser.add_argument("-o", "--output",
+                        help="Output file into which the page tables are "
+                             "written.")
+    parser.add_argument("-u", "--user-output",
+                        help="User mode page tables for KPTI")
+    parser.add_argument("-v", "--verbose", action="count", default=0,
+                        help="Print debugging information. Multiple "
+                             "invocations increase verbosity")
+    args = parser.parse_args()
+    if "VERBOSE" in os.environ:
+        args.verbose = 1
 
 def main():
-    global output_buffer
     parse_args()
 
+    with open(args.kernel, "rb") as fp:
+        kernel = ELFFile(fp)
+        syms = get_symbols(kernel)
+
+    pd_start_addr, regions = read_mmu_list(args.input)
+
     # select the page table needed
-    page_table = PageMode_PAE()
-
-    set_struct_endian_format(page_table)
-
-    global input_file
-    input_file = open(args.input, 'rb')
-
-    global binary_output_file
-    binary_output_file = open(args.output, 'wb')
-
-    # inputfile= file_name
-    read_mmu_list_marshal_param(page_table)
-
-    # populate the required structs
-    page_table.populate_required_structs()
-
-    # validate the inputs
-    validate_pde_regions()
-
-    # The size of the output buffer has to match the number of bytes we write
-    # this corresponds to the number of page tables gets created.
-    output_buffer = page_table.set_binary_file_size()
-
-    try:
-        page_table.pdpte_create_binary_file()
-    except BaseException:
-        pass
-    page_table.page_directory_create_binary_file()
-    page_table.page_table_create_binary_file()
+    page_table = PageMode_PAE(pd_start_addr, regions, syms, False)
 
     # write the binary data into the file
-    binary_output_file.write(output_buffer)
-    binary_output_file.close()
+    with open(args.output, 'wb') as fp:
+        fp.write(page_table.output_buffer)
 
-    # verbose output needed by the build system
-    verbose_output(page_table)
+    if "CONFIG_X86_KPTI" in syms:
+        pd_start_addr += page_table.output_offset
 
+        user_page_table = PageMode_PAE(pd_start_addr, regions, syms, True)
+        with open(args.user_output, 'wb') as fp:
+            fp.write(user_page_table.output_buffer)
 
 if __name__ == "__main__":
     main()

--- a/tests/kernel/boot_page_table/src/boot_page_table.c
+++ b/tests/kernel/boot_page_table/src/boot_page_table.c
@@ -45,7 +45,7 @@ static void starting_addr_range(u32_t start_addr_range)
 	for (addr_range = start_addr_range; addr_range <=
 	     (start_addr_range + STARTING_ADDR_RANGE_LMT);
 	     addr_range += 0x1000) {
-		value = X86_MMU_GET_PTE(addr_range);
+		value = X86_MMU_GET_PTE(&z_x86_kernel_pdpt, addr_range);
 		status &= check_param(value, REGION_PERM);
 		zassert_false((status == 0), "error at %d permissions %d\n",
 			      addr_range, REGION_PERM);
@@ -60,7 +60,7 @@ static void before_start_addr_range(u32_t start_addr_range)
 	for (addr_range = start_addr_range - 0x7000;
 	     addr_range < (start_addr_range); addr_range += 0x1000) {
 
-		value = X86_MMU_GET_PTE(addr_range);
+		value = X86_MMU_GET_PTE(&z_x86_kernel_pdpt, addr_range);
 		status &= check_param_nonset_region(value, REGION_PERM);
 
 		zassert_false((status == 0), "error at %d permissions %d\n",
@@ -76,7 +76,7 @@ static void ending_start_addr_range(u32_t start_addr_range)
 	for (addr_range = start_addr_range + ADDR_SIZE; addr_range <
 	     (start_addr_range + ADDR_SIZE + 0x10000);
 	     addr_range += 0x1000) {
-		value = X86_MMU_GET_PTE(addr_range);
+		value = X86_MMU_GET_PTE(&z_x86_kernel_pdpt, addr_range);
 		status &= check_param_nonset_region(value, REGION_PERM);
 		zassert_false((status == 0), "error at %d permissions %d\n",
 			      addr_range, REGION_PERM);

--- a/tests/kernel/mem_protect/x86_mmu_api/src/userbuffer_validate.c
+++ b/tests/kernel/mem_protect/x86_mmu_api/src/userbuffer_validate.c
@@ -27,7 +27,7 @@ void reset_flag(void);
 void reset_multi_pte_page_flag(void);
 void reset_multi_pde_flag(void);
 
-#define PDPT &z_x86_kernel_pdpt
+#define PDPT &USER_PDPT
 
 #define ADDR_PAGE_1 ((u8_t *)__bss_start + SKIP_SIZE * MMU_PAGE_SIZE)
 #define ADDR_PAGE_2 ((u8_t *)__bss_start + (SKIP_SIZE + 1) * MMU_PAGE_SIZE)

--- a/tests/kernel/mem_protect/x86_mmu_api/src/userbuffer_validate.c
+++ b/tests/kernel/mem_protect/x86_mmu_api/src/userbuffer_validate.c
@@ -27,10 +27,19 @@ void reset_flag(void);
 void reset_multi_pte_page_flag(void);
 void reset_multi_pde_flag(void);
 
+#define PDPT &z_x86_kernel_pdpt
+
 #define ADDR_PAGE_1 ((u8_t *)__bss_start + SKIP_SIZE * MMU_PAGE_SIZE)
 #define ADDR_PAGE_2 ((u8_t *)__bss_start + (SKIP_SIZE + 1) * MMU_PAGE_SIZE)
-#define PRESET_PAGE_1_VALUE (X86_MMU_GET_PTE(ADDR_PAGE_1)->p = 1)
-#define PRESET_PAGE_2_VALUE (X86_MMU_GET_PTE(ADDR_PAGE_2)->p = 1)
+#define PRESET_PAGE_1_VALUE (X86_MMU_GET_PTE(PDPT, ADDR_PAGE_1)->p = 1)
+#define PRESET_PAGE_2_VALUE (X86_MMU_GET_PTE(PDPT, ADDR_PAGE_2)->p = 1)
+
+
+static void set_flags(void *ptr, size_t size, x86_page_entry_data_t flags,
+		      x86_page_entry_data_t mask)
+{
+	_x86_mmu_set_flags(PDPT, ptr, size, flags, mask);
+}
 
 
 /* if Failure occurs
@@ -45,7 +54,7 @@ static int buffer_rw_read(void)
 {
 	PRESET_PAGE_1_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_READ,
 			   MMU_PDE_RW_MASK);
@@ -66,7 +75,7 @@ static int buffer_writeable_write(void)
 {
 	PRESET_PAGE_1_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE,
 			   MMU_PDE_RW_MASK);
@@ -86,7 +95,7 @@ static int buffer_readable_read(void)
 {
 	PRESET_PAGE_1_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_READ,
 			   MMU_PDE_RW_MASK);
@@ -106,7 +115,7 @@ static int buffer_readable_write(void)
 {
 	PRESET_PAGE_1_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE,
 			   MMU_PDE_RW_MASK);
@@ -128,7 +137,7 @@ static int buffer_supervisor_rw(void)
 {
 	PRESET_PAGE_1_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
@@ -149,7 +158,7 @@ static int buffer_supervisor_w(void)
 {
 	PRESET_PAGE_1_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
@@ -170,7 +179,7 @@ static int buffer_user_rw_user(void)
 {
 	PRESET_PAGE_1_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_USER,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
@@ -189,7 +198,7 @@ static int buffer_user_rw_supervisor(void)
 {
 	PRESET_PAGE_1_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
@@ -210,12 +219,12 @@ static int multi_page_buffer_user(void)
 	PRESET_PAGE_1_VALUE;
 	PRESET_PAGE_2_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
 
-	_x86_mmu_set_flags(ADDR_PAGE_2,
+	set_flags(ADDR_PAGE_2,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
@@ -236,12 +245,12 @@ static int multi_page_buffer_write_user(void)
 	PRESET_PAGE_1_VALUE;
 	PRESET_PAGE_2_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
 
-	_x86_mmu_set_flags(ADDR_PAGE_2,
+	set_flags(ADDR_PAGE_2,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
@@ -262,12 +271,12 @@ static int multi_page_buffer_read_user(void)
 	PRESET_PAGE_1_VALUE;
 	PRESET_PAGE_2_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_READ | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
 
-	_x86_mmu_set_flags(ADDR_PAGE_2,
+	set_flags(ADDR_PAGE_2,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_READ | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
@@ -288,12 +297,12 @@ static int multi_page_buffer_read(void)
 	PRESET_PAGE_1_VALUE;
 	PRESET_PAGE_2_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_READ | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
 
-	_x86_mmu_set_flags(ADDR_PAGE_2,
+	set_flags(ADDR_PAGE_2,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_READ | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
@@ -314,12 +323,12 @@ static int multi_pde_buffer_rw(void)
 	PRESET_PAGE_1_VALUE;
 	PRESET_PAGE_2_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_READ,
 			   MMU_PDE_RW_MASK);
 
-	_x86_mmu_set_flags(ADDR_PAGE_2,
+	set_flags(ADDR_PAGE_2,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_READ,
 			   MMU_PDE_RW_MASK);
@@ -341,12 +350,12 @@ static int multi_pde_buffer_writeable_write(void)
 	PRESET_PAGE_1_VALUE;
 	PRESET_PAGE_2_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE,
 			   MMU_PDE_RW_MASK);
 
-	_x86_mmu_set_flags(ADDR_PAGE_2,
+	set_flags(ADDR_PAGE_2,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE,
 			   MMU_PDE_RW_MASK);
@@ -367,12 +376,12 @@ static int multi_pde_buffer_readable_read(void)
 	PRESET_PAGE_1_VALUE;
 	PRESET_PAGE_2_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_READ,
 			   MMU_PDE_RW_MASK);
 
-	_x86_mmu_set_flags(ADDR_PAGE_2,
+	set_flags(ADDR_PAGE_2,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_READ,
 			   MMU_PDE_RW_MASK);
@@ -393,12 +402,12 @@ static int multi_pde_buffer_readable_write(void)
 	PRESET_PAGE_1_VALUE;
 	PRESET_PAGE_2_VALUE;
 
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE,
 			   MMU_PDE_RW_MASK);
 
-	_x86_mmu_set_flags(ADDR_PAGE_2,
+	set_flags(ADDR_PAGE_2,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE,
 			   MMU_PDE_RW_MASK);
@@ -417,7 +426,7 @@ static int multi_pde_buffer_readable_write(void)
 
 void reset_flag(void)
 {
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_USER,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
@@ -425,12 +434,12 @@ void reset_flag(void)
 
 void reset_multi_pte_page_flag(void)
 {
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_USER,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
 
-	_x86_mmu_set_flags(ADDR_PAGE_2,
+	set_flags(ADDR_PAGE_2,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_USER,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
@@ -438,12 +447,12 @@ void reset_multi_pte_page_flag(void)
 
 void reset_multi_pde_flag(void)
 {
-	_x86_mmu_set_flags(ADDR_PAGE_1,
+	set_flags(ADDR_PAGE_1,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_USER,
 			   MMU_PDE_RW_MASK | MMU_PDE_US_MASK);
 
-	_x86_mmu_set_flags(ADDR_PAGE_2,
+	set_flags(ADDR_PAGE_2,
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_USER,
 			   MMU_PDE_RW_MASK | MMU_PDE_US_MASK);


### PR DESCRIPTION
With the 'experimental' flag being removed from user mode for 1.14, we need to address this CPU bug which allows for side-channel attacks.

When threads are running in user mode, they now use an alternate set of page tables, where any memory pages (except a very special shared page) not granted user access are marked non-present in the page table.

Any transition between page tables needs to be done manually upon interrupt/exception/syscall enter/exit. A special stack in the shared page is used for this purpose.

The asm code in here might be able to be optimized further, but let's get this correct first.