### PR TITLE
scripts/dts cleanups, part 4

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -103,15 +103,12 @@ class Bindings(yaml.Loader):
         if isinstance(node, yaml.ScalarNode):
             return self._extract_file(self.construct_scalar(node))
 
-        elif isinstance(node, yaml.SequenceNode):
-            result = []
-            for filename in self.construct_sequence(node):
-                result.append(self._extract_file(filename))
-            return result
+        if isinstance(node, yaml.SequenceNode):
+            return [self._extract_file(fname)
+                    for fname in self.construct_sequence(node)]
 
-        else:
-            print("Error:: unrecognised node type in !include statement")
-            raise yaml.constructor.ConstructorError
+        print("Error:: unrecognised node type in !include statement")
+        raise yaml.constructor.ConstructorError
 
     def _extract_file(self, filename):
         filepaths = [filepath for filepath in self._files if filepath.endswith(filename)]

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -109,12 +109,6 @@ class Bindings(yaml.Loader):
                 result.append(self._extract_file(filename))
             return result
 
-        elif isinstance(node, yaml.MappingNode):
-            result = {}
-            for k, v in self.construct_mapping(node).iteritems():
-                result[k] = self._extract_file(v)
-            return result
-
         else:
             print("Error:: unrecognised node type in !include statement")
             raise yaml.constructor.ConstructorError

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -363,8 +363,7 @@ def merge_included_bindings(fname, node):
 
     if 'inherits' in node:
         for inherits in node.pop('inherits'):
-            if 'inherits' in inherits:
-                inherits = merge_included_bindings(fname, inherits)
+            inherits = merge_included_bindings(fname, inherits)
             # title, description, version of inherited node
             # are overwritten by intention. Remove to prevent dct_merge to
             # complain about duplicates.

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -99,10 +99,16 @@ class Bindings(yaml.Loader):
         Bindings.add_constructor('!include', Bindings._include)
 
     def _include(self, node):
+        # Implements !include. Returns a list with the top-level YAML
+        # structures for the included files (a single-element list if there's
+        # just one file).
+
         if isinstance(node, yaml.ScalarNode):
+            # !include foo.yaml
             return [self._extract_file(self.construct_scalar(node))]
 
         if isinstance(node, yaml.SequenceNode):
+            # !include [foo.yaml, bar.yaml]
             return [self._extract_file(fname)
                     for fname in self.construct_sequence(node)]
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -73,7 +73,7 @@ class Bindings(yaml.Loader):
 
             with open(file, 'r', encoding='utf-8') as yf:
                 cls._included = []
-                l = yaml_traverse_inherited(file, yaml.load(yf, cls))
+                l = merge_included_bindings(file, yaml.load(yf, cls))
 
                 if compat not in yaml_list['compat']:
                     yaml_list['compat'].append(compat)
@@ -334,7 +334,7 @@ def dict_merge(parent, fname, dct, merge_dct):
             dct[k] = merge_dct[k]
 
 
-def yaml_traverse_inherited(fname, node):
+def merge_included_bindings(fname, node):
     """ Recursive overload procedure inside ``node``
     ``inherits`` section is searched for and used as node base when found.
     Base values are then overloaded by node values
@@ -364,7 +364,7 @@ def yaml_traverse_inherited(fname, node):
     if 'inherits' in node:
         for inherits in node.pop('inherits'):
             if 'inherits' in inherits:
-                inherits = yaml_traverse_inherited(fname, inherits)
+                inherits = merge_included_bindings(fname, inherits)
             # title, description, version of inherited node
             # are overwritten by intention. Remove to prevent dct_merge to
             # complain about duplicates.

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -96,7 +96,7 @@ class Bindings(yaml.Loader):
     def __init__(self, stream):
         filepath = os.path.realpath(stream.name)
         if filepath in self._included:
-            print("Error:: circular inclusion for file name '{}'".
+            print("Error: circular inclusion for file name '{}'".
                   format(stream.name))
             raise yaml.constructor.ConstructorError
         self._included.append(filepath)
@@ -117,13 +117,13 @@ class Bindings(yaml.Loader):
             return [self._extract_file(fname)
                     for fname in self.construct_sequence(node)]
 
-        print("Error:: unrecognised node type in !include statement")
+        print("Error: unrecognised node type in !include statement")
         raise yaml.constructor.ConstructorError
 
     def _extract_file(self, filename):
         filepaths = [filepath for filepath in self._files if filepath.endswith(filename)]
         if len(filepaths) == 0:
-            print("Error:: unknown file name '{}' in !include statement".
+            print("Error: unknown file name '{}' in !include statement".
                   format(filename))
             raise yaml.constructor.ConstructorError
         elif len(filepaths) > 1:
@@ -133,7 +133,7 @@ class Bindings(yaml.Loader):
                 if os.path.basename(filename) == os.path.basename(filepath):
                     files.append(filepath)
             if len(files) > 1:
-                print("Error:: multiple candidates for file name '{}' in !include statement".
+                print("Error: multiple candidates for file name '{}' in !include statement".
                       format(filename), filepaths)
                 raise yaml.constructor.ConstructorError
             filepaths = files

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -100,7 +100,7 @@ class Bindings(yaml.Loader):
 
     def _include(self, node):
         if isinstance(node, yaml.ScalarNode):
-            return self._extract_file(self.construct_scalar(node))
+            return [self._extract_file(self.construct_scalar(node))]
 
         if isinstance(node, yaml.SequenceNode):
             return [self._extract_file(fname)
@@ -356,12 +356,7 @@ def yaml_traverse_inherited(fname, node):
               "in '{}', should be removed.".format(node['title']))
 
     if 'inherits' in node:
-        if isinstance(node['inherits'], list):
-            inherits_list  = node['inherits']
-        else:
-            inherits_list  = [node['inherits'],]
-        node.pop('inherits')
-        for inherits in inherits_list:
+        for inherits in node.pop('inherits'):
             if 'inherits' in inherits:
                 inherits = yaml_traverse_inherited(fname, inherits)
             # title, description, version of inherited node

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -344,22 +344,7 @@ def merge_included_bindings(fname, node):
     # section of the binding. 'fname' is the path to the top-level binding
     # file, and 'node' the current top-level YAML node being processed.
 
-    # do some consistency checks. Especially id is needed for further
-    # processing. title must be first to check.
-    if 'title' not in node:
-        # If 'title' is missing, make fault finding more easy.
-        # Give a hint what node we are looking at.
-        print("extract_dts_includes.py: node without 'title' -", node)
-    for prop in ('title', 'version', 'description'):
-        if prop not in node:
-            node[prop] = "<unknown {}>".format(prop)
-            print("extract_dts_includes.py: '{}' property missing".format(prop),
-                  "in '{}' binding. Using '{}'.".format(node['title'], node[prop]))
-
-    # warn if we have an 'id' field
-    if 'id' in node:
-        print("extract_dts_includes.py: WARNING: id field set",
-              "in '{}', should be removed.".format(node['title']))
+    check_binding_properties(node)
 
     if 'inherits' in node:
         for inherits in node.pop('inherits'):
@@ -372,7 +357,27 @@ def merge_included_bindings(fname, node):
             inherits.pop('description', None)
             dict_merge(None, fname, inherits, node)
             node = inherits
+
     return node
+
+
+def check_binding_properties(node):
+    # Checks that the top-level YAML node 'node' has the expected properties.
+    # Prints warnings and substitutes defaults otherwise.
+
+    if 'title' not in node:
+        print("extract_dts_includes.py: node without 'title' -", node)
+
+    for prop in 'title', 'version', 'description':
+        if prop not in node:
+            node[prop] = "<unknown {}>".format(prop)
+            print("extract_dts_includes.py: '{}' property missing "
+                  "in '{}' binding. Using '{}'."
+                  .format(prop, node['title'], node[prop]))
+
+    if 'id' in node:
+        print("extract_dts_includes.py: WARNING: id field set "
+              "in '{}', should be removed.".format(node['title']))
 
 
 def define_str(name, value, value_tabs, is_deprecated=False):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -97,7 +97,6 @@ class Bindings(yaml.Loader):
         self._included.append(filepath)
         super(Bindings, self).__init__(stream)
         Bindings.add_constructor('!include', Bindings._include)
-        Bindings.add_constructor('!import',  Bindings._include)
 
     def _include(self, node):
         if isinstance(node, yaml.ScalarNode):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -340,14 +340,9 @@ def dict_merge(parent, fname, dct, merge_dct):
 
 
 def merge_included_bindings(fname, node):
-    """ Recursive overload procedure inside ``node``
-    ``inherits`` section is searched for and used as node base when found.
-    Base values are then overloaded by node values
-    and some consistency checks are done.
-    :param fname: initial yaml file being processed
-    :param node:
-    :return: node
-    """
+    # Recursively merges properties from files !include'd from the 'inherits'
+    # section of the binding. 'fname' is the path to the top-level binding
+    # file, and 'node' the current top-level YAML node being processed.
 
     # do some consistency checks. Especially id is needed for further
     # processing. title must be first to check.


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/zephyr/pull/13205.

Cleans up some binding (.yaml)-related stuff this time around.