### PR TITLE
tests: subsys: logging: Enable log_core test on nios2

### DIFF
--- a/tests/subsys/logging/log_core/testcase.yaml
+++ b/tests/subsys/logging/log_core/testcase.yaml
@@ -1,6 +1,5 @@
 tests:
   logging.log_core:
     tags: log_core logging
-    platform_exclude: altera_max10 qemu_nios2 nucleo_l053r8
-      nucleo_f030r8 quark_d2000_crb stm32f0_disco native_posix
-      nrf52_bsim
+    platform_exclude: nucleo_l053r8 nucleo_f030r8 quark_d2000_crb
+      stm32f0_disco native_posix nrf52_bsim


### PR DESCRIPTION
Nios2 platform was disabled due to compilation error. Meanwhile,
issue has been solved (https://github.com/zephyrproject-rtos/zephyr/commit/f75d11adb29adcea41b696d1591a6719bb74dc23) and tests can be re-enabled.

Fixes #10102.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>