### PR TITLE
x86: fix ROM permissions

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -17,8 +17,12 @@
 /* Mark text and rodata as read-only.
  * Userspace may read all text and rodata.
  */
-MMU_BOOT_REGION((u32_t)&_image_rom_start, (u32_t)&_image_rom_size,
+MMU_BOOT_REGION((u32_t)&_image_text_start, (u32_t)&_image_text_size,
 		MMU_ENTRY_READ | MMU_ENTRY_USER);
+
+MMU_BOOT_REGION((u32_t)&_image_rodata_start, (u32_t)&_image_rodata_size,
+		MMU_ENTRY_READ | MMU_ENTRY_USER |
+		MMU_ENTRY_EXECUTE_DISABLE);
 
 #ifdef CONFIG_APP_SHARED_MEM
 MMU_BOOT_REGION((u32_t)&_app_smem_start, (u32_t)&_app_smem_size,

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -117,9 +117,11 @@ SECTIONS
 
 #include <linker/kobject-text.ld>
 
+	MMU_PAGE_ALIGN
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 	_image_text_end = .;
+	_image_text_size = _image_text_end - _image_text_start;
 	_image_rodata_start = .;
 
 #include <linker/common-rom.ld>
@@ -162,19 +164,21 @@ SECTIONS
 #include <linker/kobject-rom.ld>
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
-	_image_rodata_end = .;
 	MMU_PAGE_ALIGN
+	/* ROM ends here, position counter will now be in RAM areas */
 #ifdef CONFIG_XIP
-	/* Kernel ROM extends to the end of flash. Need to do this to program
-	 * the MMU
+	/* For XIP systems, the kernel object tables are kept at the end
+	 * of ROM and are unpredictable in size; the true size of the ROM
+	 * region isn't know when the MMU tables are generated.
+	 * Just set the rom region to extend to the end of flash.
 	 */
 	_image_rom_end = _image_rom_start + KB(DT_ROM_SIZE);
 #else
-	/* ROM ends here, position counter will now be in RAM areas */
 	_image_rom_end = .;
 #endif
 	_image_rom_size = _image_rom_end - _image_rom_start;
-
+	_image_rodata_end = _image_rom_end;
+	_image_rodata_size = _image_rodata_end - _image_rodata_start;
 	GROUP_END(ROMABLE_REGION)
 	/*
 	 * Needed for dynamic linking which we do not have, do discard

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -186,9 +186,11 @@ extern char _image_ram_end[];
 
 extern char _image_text_start[];
 extern char _image_text_end[];
+extern char _image_text_size[];
 
 extern char _image_rodata_start[];
 extern char _image_rodata_end[];
+extern char _image_rodata_size[];
 
 extern char _vector_start[];
 extern char _vector_end[];


### PR DESCRIPTION
Only the text area now has execute permissions,
instead of both text and rodata.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>