### PR TITLE
kconfigfunctions: Disambiguate reference to DTS generated database

### DIFF
--- a/doc/guides/kconfig/index.rst
+++ b/doc/guides/kconfig/index.rst
@@ -621,6 +621,7 @@ Device Tree Related Functions
 
   dt_int_val(kconf, _, name, unit):
        This function looks up 'name' in the DTS generated "conf" style database
+       (generated_dts_board.conf in <build_dir>/zephyr/include/generated/)
        and if it's found it will return the value as an decimal integer.  The
        function will divide the value based on 'unit':
            None        No division
@@ -630,6 +631,7 @@ Device Tree Related Functions
 
   dt_hex_val(kconf, _, name, unit):
        This function looks up 'name' in the DTS generated "conf" style database
+       (generated_dts_board.conf in <build_dir>/zephyr/include/generated/)
        and if it's found it will return the value as an hex integer.  The
        function will divide the value based on 'unit':
            None        No division
@@ -639,6 +641,7 @@ Device Tree Related Functions
 
   dt_str_val(kconf, _, name):
        This function looks up 'name' in the DTS generated "conf" style database
+       (generated_dts_board.conf in <build_dir>/zephyr/include/generated/)
        and if it's found it will return the value as string. if it's not found we
        return an empty string.
 

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -35,6 +35,7 @@ def _dt_units_to_scale(unit):
 def dt_int_val(kconf, _, name, unit=None):
     """
     This function looks up 'name' in the DTS generated "conf" style database
+    (generated_dts_board.conf in <build_dir>/zephyr/include/generated/)
     and if it's found it will return the value as an decimal integer.  The
     function will divide the value based on 'unit':
         None        No division
@@ -57,6 +58,7 @@ def dt_int_val(kconf, _, name, unit=None):
 def dt_hex_val(kconf, _, name, unit=None):
     """
     This function looks up 'name' in the DTS generated "conf" style database
+    (generated_dts_board.conf in <build_dir>/zephyr/include/generated/)
     and if it's found it will return the value as an hex integer.  The
     function will divide the value based on 'unit':
         None        No division
@@ -79,6 +81,7 @@ def dt_hex_val(kconf, _, name, unit=None):
 def dt_str_val(kconf, _, name):
     """
     This function looks up 'name' in the DTS generated "conf" style database
+    (generated_dts_board.conf in <build_dir>/zephyr/include/generated/)
     and if it's found it will return the value as string.  If it's not found we
     return an empty string.
     """


### PR DESCRIPTION
Documentation for kconfigfunctions, mentions they look up elements
in "the DTS generated "conf" style database". This indication
could be cryptic for new zephyr users. Adding the exact name and
path of the file for disambiguation.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>