### PR TITLE
Introduce API for get driver structure belongs to the flash_area.

### DIFF
--- a/include/flash_map.h
+++ b/include/flash_map.h
@@ -88,6 +88,15 @@ int flash_area_get_sectors(int fa_id, u32_t *count,
  */
 int flash_area_has_driver(const struct flash_area *fa);
 
+/**
+ * Get driver for given flash area.
+ *
+ * @param fa Flash area.
+ *
+ * @return device driver.
+ */
+struct device *flash_area_get_device(const struct flash_area *fa);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -247,3 +247,8 @@ int flash_area_has_driver(const struct flash_area *fa)
 
 	return 1;
 }
+
+struct device *flash_area_get_device(const struct flash_area *fa)
+{
+	return device_get_binding(fa->fa_dev_name);
+}


### PR DESCRIPTION
Some more complex operation on flash areas might want to be done using
driver directly. It not make sense to wrap every possible flash related
operation by flash_map API.

For instance mcuboot will require this patch.

flash_area_has_driver() API is kept for backward compatibility.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>