### PR TITLE
tests: drivers: counter: Fix test for nrf52 platform

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -97,6 +97,7 @@ static void counter_tear_down_instance(const char *dev_name)
 
 	err = counter_stop(dev);
 	zassert_equal(0, err, "Counter failed to stop\n");
+
 }
 
 static void test_all_instances(counter_test_func_t func)
@@ -106,11 +107,6 @@ static void test_all_instances(counter_test_func_t func)
 		func(devices[i]);
 		counter_tear_down_instance(devices[i]);
 	}
-}
-
-void counter_tear_down(void)
-{
-
 }
 
 static void top_handler(struct device *dev, void *user_data)
@@ -330,23 +326,22 @@ void test_all_channels_instance(const char *str)
 	const int n = 10;
 	int nchan = 0;
 	bool limit_reached = false;
-	struct counter_alarm_cfg alarm_cfgs[n];
+	struct counter_alarm_cfg alarm_cfgs;
 	u32_t ticks;
 
 	dev = device_get_binding(str);
 	ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
 
-	for (int i = 0; i < n; i++) {
-		alarm_cfgs[i].absolute = false;
-		alarm_cfgs[i].ticks = ticks;
-		alarm_cfgs[i].callback = alarm_handler2;
-	}
+	alarm_cfgs.absolute = false;
+	alarm_cfgs.ticks = ticks;
+	alarm_cfgs.callback = alarm_handler2;
+	alarm_cfgs.user_data = NULL;
 
 	err = counter_start(dev);
 	zassert_equal(0, err, "Counter failed to start");
 
 	for (int i = 0; i < n; i++) {
-		err = counter_set_channel_alarm(dev, i, &alarm_cfgs[i]);
+		err = counter_set_channel_alarm(dev, i, &alarm_cfgs);
 		if ((err == 0) && !limit_reached) {
 			nchan++;
 		} else if (err == -ENOTSUP) {
@@ -380,21 +375,11 @@ void test_all_channels(void)
 void test_main(void)
 {
 	ztest_test_suite(test_counter,
-		ztest_unit_test_setup_teardown(test_set_top_value_with_alarm,
-					unit_test_noop,
-					counter_tear_down),
-		ztest_unit_test_setup_teardown(test_single_shot_alarm_notop,
-					unit_test_noop,
-					counter_tear_down),
-		ztest_unit_test_setup_teardown(test_single_shot_alarm_top,
-					unit_test_noop,
-					counter_tear_down),
-		ztest_unit_test_setup_teardown(test_multiple_alarms,
-					unit_test_noop,
-					counter_tear_down),
-		ztest_unit_test_setup_teardown(test_all_channels,
-					unit_test_noop,
-					counter_tear_down)
+		ztest_unit_test(test_set_top_value_with_alarm),
+		ztest_unit_test(test_single_shot_alarm_notop),
+		ztest_unit_test(test_single_shot_alarm_top),
+		ztest_unit_test(test_multiple_alarms),
+		ztest_unit_test(test_all_channels)
 			 );
 	ztest_run_test_suite(test_counter);
 }

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -79,6 +79,11 @@ const char *devices[] = {
 typedef void (*counter_test_func_t)(const char *dev_name);
 
 
+static void counter_setup_instance(const char *dev_name)
+{
+	alarm_cnt = 0;
+}
+
 static void counter_tear_down_instance(const char *dev_name)
 {
 	int err;
@@ -97,6 +102,7 @@ static void counter_tear_down_instance(const char *dev_name)
 static void test_all_instances(counter_test_func_t func)
 {
 	for (int i = 0; i < ARRAY_SIZE(devices); i++) {
+		counter_setup_instance(devices[i]);
 		func(devices[i]);
 		counter_tear_down_instance(devices[i]);
 	}
@@ -190,11 +196,12 @@ void test_single_shot_alarm_instance(const char *dev_name, bool set_top)
 
 		zassert_equal(0, err, "Counter failed to set top value\n");
 
+		alarm_cfg.ticks = ticks + 1;
 		err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
 		zassert_equal(-EINVAL, err,
 			      "Counter should return error because ticks"
 			      " exceeded the limit set alarm\n");
-		alarm_cfg.ticks = ticks - 100;
+		alarm_cfg.ticks = ticks - 1;
 	}
 
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
@@ -241,7 +248,7 @@ void test_single_shot_alarm_top(void)
 #endif
 }
 
-static void *clbk_data[2];
+static void *clbk_data[10];
 
 static void alarm_handler2(struct device *dev, u8_t chan_id, u32_t counter,
 			   void *user_data)


### PR DESCRIPTION
Fix failing tests.

Tests were failing because:
1. `alarm_cnt` was not reset before the test.
2. one test was failing because it was expecting that setting `top_value` for channel_alarm is too much but in fact `top_value+1` is too much.

Fixes #13254.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>