### PR TITLE
boards: arm: nrf: added uart-mcumgr to nrf9160_pca10090

### DIFF
--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
@@ -12,6 +12,7 @@
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,uart-mcumgr = &uart0;
 	};
 
 	leds {


### PR DESCRIPTION
This adds uart support for mcumgr on nrf9160_pca10090.

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>