### PR TITLE
Fix shell to compile with c++

### DIFF
--- a/doc/reference/shell/index.rst
+++ b/doc/reference/shell/index.rst
@@ -86,11 +86,9 @@ Use the following macros for adding shell commands:
   All root commands must have different name.
 * :c:macro:`SHELL_CMD` - Initialize a command.
 * :c:macro:`SHELL_CMD_ARG` - Initialize a command with arguments.
-* :c:macro:`SHELL_CREATE_STATIC_SUBCMD_SET` - Create a static subcommands
+* :c:macro:`SHELL_STATIC_SUBCMD_SET_CREATE` - Create a static subcommands
   array.
-* :c:macro:`SHELL_SUBCMD_SET_END` - shall be placed as last in
-  :c:macro:`SHELL_CREATE_STATIC_SUBCMD_SET` macro.
-* :c:macro:`SHELL_CREATE_DYNAMIC_CMD` - Create a dynamic subcommands array.
+* :c:macro:`SHELL_DYNAMIC_CMD_CREATE` - Create a dynamic subcommands array.
 
 Commands can be created in any file in the system that includes
 :file:`include/shell/shell.h`. All created commands are available for all
@@ -109,13 +107,12 @@ subcommands.
 .. code-block:: c
 
 	/* Creating subcommands (level 1 command) array for command "demo". */
-	SHELL_CREATE_STATIC_SUBCMD_SET(sub_demo)
-	{
+	SHELL_STATIC_SUBCMD_SET_CREATE(sub_demo,
 		SHELL_CMD(params, NULL, "Print params command.",
 						       cmd_demo_params),
 		SHELL_CMD(ping,   NULL, "Ping command.", cmd_demo_ping),
-		SHELL_SUBCMD_SET_END /* Array terminated. */
-	};
+		SHELL_SUBCMD_SET_END
+	);
 	/* Creating root (level 0) command "demo" */
 	SHELL_CMD_REGISTER(demo, &sub_demo, "Demo commands", NULL);
 
@@ -166,9 +163,8 @@ Newly added commands can be prompted or autocompleted with the :kbd:`Tab` key.
 		}
 	}
 
-	SHELL_CREATE_DYNAMIC_CMD(m_sub_dynamic_set, dynamic_cmd_get);
-	SHELL_CREATE_STATIC_SUBCMD_SET(m_sub_dynamic)
-	{
+	SHELL_DYNAMIC_CMD_CREATE(m_sub_dynamic_set, dynamic_cmd_get);
+	SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_dynamic,
 		SHELL_CMD(add, NULL,"Add new command to dynamic_cmd_buffer and"
 			  " sort them alphabetically.",
 			  cmd_dynamic_add),
@@ -181,7 +177,7 @@ Newly added commands can be prompted or autocompleted with the :kbd:`Tab` key.
 			  "Show all commands in dynamic_cmd_buffer.",
 			  cmd_dynamic_show),
 		SHELL_SUBCMD_SET_END
-	};
+	);
 	SHELL_CMD_REGISTER(dynamic, &m_sub_dynamic,
 		   "Demonstrate dynamic command usage.", cmd_dynamic);
 
@@ -405,13 +401,12 @@ The following code shows a simple use case of this library:
 	}
 
 	/* Creating subcommands (level 1 command) array for command "demo". */
-	SHELL_CREATE_STATIC_SUBCMD_SET(sub_demo)
-	{
+	SHELL_STATIC_SUBCMD_SET_CREATE(sub_demo,
 		SHELL_CMD(params, NULL, "Print params command.",
 						       cmd_demo_params),
 		SHELL_CMD(ping,   NULL, "Ping command.", cmd_demo_ping),
-		SHELL_SUBCMD_SET_END /* Array terminated. */
-	};
+		SHELL_SUBCMD_SET_END
+	);
 	/* Creating root (level 0) command "demo" without a handler */
 	SHELL_CMD_REGISTER(demo, &sub_demo, "Demo commands", NULL);
 

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -219,13 +219,13 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(flash_cmds) {
+SHELL_STATIC_SUBCMD_SET_CREATE(flash_cmds,
 	SHELL_CMD(erase, NULL, "<page address> <size>", cmd_erase),
 	SHELL_CMD(read, NULL, "<address> <Dword count>", cmd_read),
 	SHELL_CMD(test, NULL, "<address> <size> <repeat count>", cmd_test),
 	SHELL_CMD(write, NULL, "<address> <dword> <dword>...", cmd_write),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 static int cmd_flash(const struct shell *shell, size_t argc, char **argv)
 {

--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -142,12 +142,11 @@ static int cmd_gpio_set(const struct shell *shell,
 }
 
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_gpio) {
-	/* Alphabetically sorted. */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_gpio,
 	SHELL_CMD(conf, NULL, "Configure GPIO", cmd_gpio_conf),
 	SHELL_CMD(get, NULL, "Get GPIO value", cmd_gpio_get),
 	SHELL_CMD(set, NULL, "Set GPIO", cmd_gpio_set),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
-};
+);
 
 SHELL_CMD_REGISTER(gpio, &sub_gpio, "GPIO commands", NULL);

--- a/drivers/hwinfo/hwinfo_shell.c
+++ b/drivers/hwinfo/hwinfo_shell.c
@@ -38,10 +38,9 @@ static int cmd_get_device_id(const struct shell *shell, size_t argc, char **argv
 	return 0;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_hwinfo) {
-	/* Alphabetically sorted. */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_hwinfo,
 	SHELL_CMD_ARG(devid, NULL, "Show device id", cmd_get_device_id, 1, 0),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
-};
+);
 
 SHELL_CMD_ARG_REGISTER(hwinfo, &sub_hwinfo, "HWINFO commands", NULL, 2, 0);

--- a/drivers/modem/modem_shell.c
+++ b/drivers/modem/modem_shell.c
@@ -110,12 +110,11 @@ static int cmd_modem_send(const struct shell *shell, size_t argc,
 	return 0;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_modem) {
-	/* Alphabetically sorted. */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_modem,
 	SHELL_CMD(list, NULL, "List registered modems", cmd_modem_list),
 	SHELL_CMD(send, NULL, "Send an AT <command> to a registered modem "
 			      "receiver", cmd_modem_send),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
-};
+);
 
 SHELL_CMD_REGISTER(modem, &sub_modem, "Modem commands", NULL);

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -143,7 +143,7 @@ struct shell_static_entry {
 #define SHELL_CMD_REGISTER(syntax, subcmd, help, handler) \
 	static const struct shell_static_entry UTIL_CAT(_shell_, syntax) = \
 	SHELL_CMD(syntax, subcmd, help, handler);			   \
-	static const struct shell_cmd_entry UTIL_CAT(shell_cmd_, syntax)   \
+	const struct shell_cmd_entry UTIL_CAT(shell_cmd_, syntax)	   \
 	__attribute__ ((section("."					   \
 			STRINGIFY(UTIL_CAT(shell_root_cmd_, syntax)))))	   \
 	__attribute__((used)) = {					   \

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -110,7 +110,7 @@ struct shell_static_entry {
 	const char *help;			/*!< Command help string. */
 	const struct shell_cmd_entry *subcmd;	/*!< Pointer to subcommand. */
 	shell_cmd_handler handler;		/*!< Command handler. */
-	const struct shell_static_args *args;	/*!< Command arguments. */
+	struct shell_static_args args;		/*!< Command arguments. */
 };
 
 /**
@@ -213,8 +213,7 @@ struct shell_static_entry {
 	.subcmd = _subcmd,						      \
 	.help  = (const char *)_help,					      \
 	.handler = _handler,						      \
-	.args = _mandatory ?						      \
-	(&(struct shell_static_args) SHELL_ARG(_mandatory, _optional)) : NULL \
+	.args = SHELL_ARG(_mandatory, _optional)			      \
 }
 
 /**

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -71,17 +71,6 @@ struct shell_cmd_entry {
 
 struct shell;
 
-/**
- * @brief Initializes a shell command arguments
- *
- * @param[in] _mandatory Number of mandatory arguments.
- * @param[in] _optional  Number of optional arguments.
- */
-#define SHELL_ARG(_mandatory, _optional) {	\
-	.mandatory = _mandatory,		\
-	.optional = _optional,			\
-}
-
 struct shell_static_args {
 	u8_t mandatory; /*!< Number of mandatory arguments. */
 	u8_t optional;  /*!< Number of optional arguments. */
@@ -137,7 +126,7 @@ struct shell_static_entry {
 			STRINGIFY(UTIL_CAT(shell_root_cmd_, syntax)))))	   \
 	__attribute__((used)) = {					   \
 		.is_dynamic = false,					   \
-		.u.entry = &UTIL_CAT(_shell_, syntax)			   \
+		.u = {.entry = &UTIL_CAT(_shell_, syntax)}		   \
 	}
 
 /**
@@ -159,7 +148,32 @@ struct shell_static_entry {
 			STRINGIFY(UTIL_CAT(shell_root_cmd_, syntax)))))	   \
 	__attribute__((used)) = {					   \
 		.is_dynamic = false,					   \
-		.u.entry = &UTIL_CAT(_shell_, syntax)			   \
+		.u = { .entry = &UTIL_CAT(_shell_, syntax) }		   \
+	}
+
+/**
+ * @brief Macro for creating a subcommand set. It must be used outside of any
+ * function body.
+ *
+ * Example usage:
+ * SHELL_STATIC_SUBCMD_SET_CREATE(
+ *	foo,
+ *	SHELL_CMD(abc, ...),
+ *	SHELL_CMD(def, ...),
+ *	SHELL_SUBCMD_SET_END
+ * )
+ *
+ * @param[in] name	Name of the subcommand set.
+ * @param[in] ...	List of commands created with @ref SHELL_CMD_ARG or
+ *			or @ref SHELL_CMD
+ */
+#define SHELL_STATIC_SUBCMD_SET_CREATE(name, ...)			\
+	static const struct shell_static_entry shell_##name[] = {	\
+		__VA_ARGS__						\
+	};								\
+	static const struct shell_cmd_entry name = {			\
+		.is_dynamic = false,					\
+		.u = { .entry = shell_##name }				\
 	}
 
 /**
@@ -176,6 +190,7 @@ struct shell_static_entry {
 	};							\
 	static const struct shell_static_entry shell_##name[] =
 
+
 /**
  * @brief Define ending subcommands set.
  *
@@ -188,11 +203,20 @@ struct shell_static_entry {
  * @param[in] name	Name of the dynamic entry.
  * @param[in] get	Pointer to the function returning dynamic commands array
  */
-#define SHELL_CREATE_DYNAMIC_CMD(name, get)		\
+#define SHELL_DYNAMIC_CMD_CREATE(name, get)		\
 	static const struct shell_cmd_entry name = {	\
 		.is_dynamic = true,			\
-		.u.dynamic_get = get			\
+		.u = { .dynamic_get = get }		\
 	}
+
+/**
+ * @brief Macro for creating a dynamic entry.
+ *
+ * @param[in] name	Name of the dynamic entry.
+ * @param[in] get	Pointer to the function returning dynamic commands array
+ */
+#define SHELL_CREATE_DYNAMIC_CMD(name, get)		\
+	SHELL_DYNAMIC_CMD_CREATE(name, get)
 
 /**
  * @brief Initializes a shell command with arguments.
@@ -210,10 +234,10 @@ struct shell_static_entry {
 #define SHELL_CMD_ARG(_syntax, _subcmd, _help, _handler,		      \
 		      _mandatory, _optional) {				      \
 	.syntax = (const char *)STRINGIFY(_syntax),			      \
-	.subcmd = _subcmd,						      \
 	.help  = (const char *)_help,					      \
+	.subcmd = _subcmd,						      \
 	.handler = _handler,						      \
-	.args = SHELL_ARG(_mandatory, _optional)			      \
+	.args = {. mandatory = _mandatory, .optional =  _optional}	      \
 }
 
 /**

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -177,12 +177,14 @@ struct shell_static_entry {
 	}
 
 /**
- * @brief Macro for creating a subcommand set. It must be used outside of any
- * function body.
+ * @brief Deprecated macro for creating a subcommand set.
+ *
+ * It must be used outside of any function body.
  *
  * @param[in] name	Name of the subcommand set.
  */
 #define SHELL_CREATE_STATIC_SUBCMD_SET(name)			\
+	__DEPRECATED_MACRO					\
 	static const struct shell_static_entry shell_##name[];	\
 	static const struct shell_cmd_entry name = {		\
 		.is_dynamic = false,				\
@@ -210,13 +212,13 @@ struct shell_static_entry {
 	}
 
 /**
- * @brief Macro for creating a dynamic entry.
+ * @brief Deprecated macro for creating a dynamic entry.
  *
  * @param[in] name	Name of the dynamic entry.
  * @param[in] get	Pointer to the function returning dynamic commands array
  */
 #define SHELL_CREATE_DYNAMIC_CMD(name, get)		\
-	SHELL_DYNAMIC_CMD_CREATE(name, get)
+	__DEPRECATED_MACRO SHELL_DYNAMIC_CMD_CREATE(name, get)
 
 /**
  * @brief Initializes a shell command with arguments.

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -591,8 +591,7 @@ void main(void)
 }
 
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_flash)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_flash,
 	/* Alphabetically sorted to ensure correct Tab autocompletion. */
 	SHELL_CMD_ARG(erase,	NULL,	ERASE_HELP,	cmd_erase, 3, 0),
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
@@ -610,7 +609,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_flash)
 	SHELL_CMD_ARG(write_block_size,	NULL,	WRITE_BLOCK_SIZE_HELP,
 						    cmd_write_block_size, 1, 0),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
-};
+);
 
 SHELL_CMD_REGISTER(flash, &sub_flash, "Flash realated commands.", cmd_flash);
 

--- a/samples/mpu/mpu_test/src/main.c
+++ b/samples/mpu/mpu_test/src/main.c
@@ -152,8 +152,7 @@ void main(void)
 
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_mpu)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_mpu,
 	SHELL_CMD_ARG(mtest, NULL, MTEST_CMD_HELP, cmd_mtest, 2, 1),
 	SHELL_CMD(read, NULL, READ_CMD_HELP, cmd_read),
 	SHELL_CMD(run, NULL, RUN_CMD_HELP, cmd_run),
@@ -165,7 +164,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_mpu)
 	SHELL_CMD(write, NULL, WRITE_CMD_HELP, cmd_write),
 #endif /* SOC_FLASH_MCUX*/
 	SHELL_SUBCMD_SET_END /* Array terminated. */
-};
+);
 SHELL_CMD_REGISTER(mpu, &sub_mpu, "MPU related commands.", NULL);
 
 

--- a/samples/net/promiscuous_mode/src/main.c
+++ b/samples/net/promiscuous_mode/src/main.c
@@ -200,8 +200,7 @@ static int cmd_promisc_off(const struct shell *shell,
 	return set_promisc_mode(shell, argc, argv, false);
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(promisc_commands)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(promisc_commands,
 	SHELL_CMD(on, NULL,
 		  "Turn promiscuous mode on\n"
 		  "promisc on  <interface index>  "
@@ -212,7 +211,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(promisc_commands)
 		      "Turn off promiscuous mode for the interface\n",
 		  cmd_promisc_off),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 SHELL_CMD_REGISTER(promisc, &promisc_commands,
 		   "Promiscuous mode commands", NULL);

--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -1095,8 +1095,7 @@ static void zperf_init(const struct shell *shell)
 	zperf_session_init();
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(zperf_cmd_tcp)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(zperf_cmd_tcp,
 	SHELL_CMD(upload, NULL,
 		  "<dest ip> <dest port> <duration> <packet size>[K]\n"
 		  "<dest ip>     IP destination\n"
@@ -1130,10 +1129,9 @@ SHELL_CREATE_STATIC_SUBCMD_SET(zperf_cmd_tcp)
 		  "Example: tcp download 5001\n",
 		  cmd_tcp_download),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(zperf_cmd_udp)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(zperf_cmd_udp,
 	SHELL_CMD(upload, NULL,
 		  "<dest ip> [<dest port> <duration> <packet size>[K] "
 							"<baud rate>[K|M]]\n"
@@ -1170,10 +1168,9 @@ SHELL_CREATE_STATIC_SUBCMD_SET(zperf_cmd_udp)
 		  "Example: udp download 5001\n",
 		  cmd_udp_download),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(zperf_commands)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(zperf_commands,
 	SHELL_CMD(connectap, NULL,
 		  "Connect to AP",
 		  cmd_connectap),
@@ -1193,7 +1190,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(zperf_commands)
 		  "Zperf version",
 		  cmd_version),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 SHELL_CMD_REGISTER(zperf, &zperf_commands, "Zperf commands", NULL);
 

--- a/samples/subsys/shell/shell_module/src/dynamic_cmd.c
+++ b/samples/subsys/shell/shell_module/src/dynamic_cmd.c
@@ -156,8 +156,7 @@ static void dynamic_cmd_get(size_t idx, struct shell_static_entry *entry)
 }
 
 SHELL_CREATE_DYNAMIC_CMD(m_sub_dynamic_set, dynamic_cmd_get);
-SHELL_CREATE_STATIC_SUBCMD_SET(m_sub_dynamic)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_dynamic,
 	SHELL_CMD_ARG(add, NULL,
 		"Add a new dynamic command.\nExample usage: [ dynamic add test "
 		"] will add a dynamic command 'test'.\nIn this example, command"
@@ -172,7 +171,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(m_sub_dynamic)
 	SHELL_CMD_ARG(show, NULL,
 		"Show all added dynamic commands.", cmd_dynamic_show, 1, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 SHELL_CMD_REGISTER(dynamic, &m_sub_dynamic,
 		   "Demonstrate dynamic command usage.", NULL);

--- a/samples/subsys/shell/shell_module/src/dynamic_cmd.c
+++ b/samples/subsys/shell/shell_module/src/dynamic_cmd.c
@@ -155,7 +155,7 @@ static void dynamic_cmd_get(size_t idx, struct shell_static_entry *entry)
 	}
 }
 
-SHELL_CREATE_DYNAMIC_CMD(m_sub_dynamic_set, dynamic_cmd_get);
+SHELL_DYNAMIC_CMD_CREATE(m_sub_dynamic_set, dynamic_cmd_get);
 SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_dynamic,
 	SHELL_CMD_ARG(add, NULL,
 		"Add a new dynamic command.\nExample usage: [ dynamic add test "

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -61,9 +61,7 @@ static int cmd_log_test_stop(const struct shell *shell, size_t argc,
 	return 0;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_test_start)
-{
-	/* Alphabetically sorted. */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_log_test_start,
 	SHELL_CMD_ARG(demo, NULL,
 		  "Start log timer which generates log message every 200ms.",
 		  cmd_log_test_start_demo, 1, 0),
@@ -71,14 +69,12 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_test_start)
 		  "Start log timer which generates log message every 10ms.",
 		  cmd_log_test_start_flood, 1, 0),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
-};
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_test)
-{
-	/* Alphabetically sorted. */
+);
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_log_test,
 	SHELL_CMD_ARG(start, &sub_log_test_start, "Start log test", NULL, 2, 0),
 	SHELL_CMD_ARG(stop, NULL, "Stop log test.", cmd_log_test_stop, 1, 0),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
-};
+);
 
 SHELL_CMD_REGISTER(log_test, &sub_log_test, "Log test", NULL);
 
@@ -112,13 +108,11 @@ static int cmd_version(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_demo)
-{
-	/* Alphabetically sorted. */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_demo,
 	SHELL_CMD(params, NULL, "Print params command.", cmd_demo_params),
 	SHELL_CMD(ping, NULL, "Ping command.", cmd_demo_ping),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
-};
+);
 SHELL_CMD_REGISTER(demo, &sub_demo, "Demo commands", NULL);
 
 SHELL_CMD_ARG_REGISTER(version, NULL, "Show kernel version", cmd_version, 1, 0);

--- a/subsys/bluetooth/host/mesh/shell.c
+++ b/subsys/bluetooth/host/mesh/shell.c
@@ -1932,7 +1932,7 @@ static int cmd_del_fault(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(mesh_cmds) {
+SHELL_STATIC_SUBCMD_SET_CREATE(mesh_cmds,
 	SHELL_CMD_ARG(init, NULL, NULL, cmd_init, 1, 0),
 	SHELL_CMD_ARG(timeout, NULL, "[timeout in seconds]", cmd_timeout, 1, 1),
 #if defined(CONFIG_BT_MESH_PB_ADV)
@@ -2026,7 +2026,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(mesh_cmds) {
 	SHELL_CMD_ARG(del-fault, NULL, "[Fault ID]", cmd_del_fault, 1, 1),
 
 	SHELL_SUBCMD_SET_END
-};
+);
 
 static int cmd_mesh(const struct shell *shell, size_t argc, char **argv)
 {

--- a/subsys/bluetooth/shell/bredr.c
+++ b/subsys/bluetooth/shell/bredr.c
@@ -534,7 +534,7 @@ static int cmd_sdp_find_record(const struct shell *shell,
 #define HELP_NONE "[none]"
 #define HELP_ADDR_LE "<address: XX:XX:XX:XX:XX:XX> <type: (public|random)>"
 
-SHELL_CREATE_STATIC_SUBCMD_SET(br_cmds) {
+SHELL_STATIC_SUBCMD_SET_CREATE(br_cmds,
 	SHELL_CMD_ARG(auth-pincode, NULL, "<pincode>", cmd_auth_pincode, 2, 0),
 	SHELL_CMD_ARG(connect, NULL, "<address>", cmd_connect, 2, 0),
 	SHELL_CMD_ARG(discovery, NULL,
@@ -546,7 +546,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(br_cmds) {
 	SHELL_CMD_ARG(pscan, NULL, "<value: on, off>", cmd_connectable, 2, 0),
 	SHELL_CMD_ARG(sdp-find, NULL, "<HFPAG>", cmd_sdp_find_record, 2, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 static int cmd_br(const struct shell *shell, size_t argc, char **argv)
 {

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1332,7 +1332,7 @@ static int cmd_auth_passkey(const struct shell *shell,
 #define HELP_NONE "[none]"
 #define HELP_ADDR_LE "<address: XX:XX:XX:XX:XX:XX> <type: (public|random)>"
 
-SHELL_CREATE_STATIC_SUBCMD_SET(bt_cmds) {
+SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 	SHELL_CMD_ARG(init, NULL, HELP_ADDR_LE, cmd_init, 1, 0),
 #if defined(CONFIG_BT_HCI)
 	SHELL_CMD_ARG(hci-cmd, NULL, "<ogf> <ocf> [data]", cmd_hci_cmd, 3, 1),
@@ -1419,7 +1419,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(bt_cmds) {
 	SHELL_CMD(ull_reset, NULL, HELP_NONE, cmd_ull_reset),
 #endif /* CONFIG_BT_LL_SW_SPLIT */
 	SHELL_SUBCMD_SET_END
-};
+);
 
 static int cmd_bt(const struct shell *shell, size_t argc, char **argv)
 {

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -766,7 +766,7 @@ static int cmd_metrics(const struct shell *shell, size_t argc, char *argv[])
 
 #define HELP_NONE "[none]"
 
-SHELL_CREATE_STATIC_SUBCMD_SET(gatt_cmds) {
+SHELL_STATIC_SUBCMD_SET_CREATE(gatt_cmds,
 #if defined(CONFIG_BT_GATT_CLIENT)
 	SHELL_CMD_ARG(discover-characteristic, NULL,
 		      "[UUID] [start handle] [end handle]", cmd_discover, 1, 3),
@@ -807,7 +807,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(gatt_cmds) {
 		      "unregister pre-predefined test service",
 		      cmd_unregister_test_svc, 1, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 static int cmd_gatt(const struct shell *shell, size_t argc, char **argv)
 {

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -395,13 +395,13 @@ static int cmd_whitelist_remove(const struct shell *shell, size_t argc, char *ar
 
 #define HELP_NONE "[none]"
 
-SHELL_CREATE_STATIC_SUBCMD_SET(whitelist_cmds) {
+SHELL_STATIC_SUBCMD_SET_CREATE(whitelist_cmds,
 	SHELL_CMD_ARG(add, NULL, HELP_NONE, cmd_whitelist_add, 1, 0),
 	SHELL_CMD_ARG(remove, NULL, HELP_NONE, cmd_whitelist_remove, 1, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(l2cap_cmds) {
+SHELL_STATIC_SUBCMD_SET_CREATE(l2cap_cmds,
 	SHELL_CMD_ARG(connect, NULL, "<psm>", cmd_connect, 1, 0),
 	SHELL_CMD_ARG(disconnect, NULL, HELP_NONE, cmd_disconnect, 1, 0),
 	SHELL_CMD_ARG(metrics, NULL, "<value on, off>", cmd_metrics, 2, 0),
@@ -411,7 +411,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(l2cap_cmds) {
 	SHELL_CMD_ARG(send, NULL, "<number of packets>", cmd_send, 2, 0),
 	SHELL_CMD_ARG(whitelist, &whitelist_cmds, HELP_NONE, NULL, 1, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 static int cmd_l2cap(const struct shell *shell, size_t argc, char **argv)
 {

--- a/subsys/bluetooth/shell/rfcomm.c
+++ b/subsys/bluetooth/shell/rfcomm.c
@@ -233,13 +233,13 @@ static int cmd_disconnect(const struct shell *shell, size_t argc, char *argv[])
 #define HELP_NONE "[none]"
 #define HELP_ADDR_LE "<address: XX:XX:XX:XX:XX:XX> <type: (public|random)>"
 
-SHELL_CREATE_STATIC_SUBCMD_SET(rfcomm_cmds) {
+SHELL_STATIC_SUBCMD_SET_CREATE(rfcomm_cmds,
 	SHELL_CMD_ARG(register, NULL, "<channel>", cmd_register, 2, 0),
 	SHELL_CMD_ARG(connect, NULL, "<channel>", cmd_connect, 2, 0),
 	SHELL_CMD_ARG(disconnect, NULL, HELP_NONE, cmd_disconnect, 1, 0),
 	SHELL_CMD_ARG(send, NULL, "<number of packets>", cmd_send, 2, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 static int cmd_rfcomm(const struct shell *shell, size_t argc, char **argv)
 {

--- a/subsys/bluetooth/shell/ticker.c
+++ b/subsys/bluetooth/shell/ticker.c
@@ -124,10 +124,10 @@ int cmd_ticker_info(const struct shell *shell, size_t argc, char *argv[])
 
 #define HELP_NONE "[none]"
 
-SHELL_CREATE_STATIC_SUBCMD_SET(ticker_cmds) {
+SHELL_STATIC_SUBCMD_SET_CREATE(ticker_cmds,
 	SHELL_CMD_ARG(info, NULL, HELP_NONE, cmd_ticker_info, 1, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 static int cmd_ticker(const struct shell *shell, size_t argc, char **argv)
 {

--- a/subsys/fb/cfb_shell.c
+++ b/subsys/fb/cfb_shell.c
@@ -433,7 +433,7 @@ static int cmd_init(const struct shell *shell, size_t argc, char *argv[])
 	return err;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_cmd_get_param) {
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmd_get_param,
 
 	SHELL_CMD_ARG(all, NULL, NULL, cmd_get_param_all, 1, 0),
 	SHELL_CMD_ARG(height, NULL, NULL, cmd_get_param_height, 1, 0),
@@ -442,16 +442,16 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_cmd_get_param) {
 	SHELL_CMD_ARG(rows, NULL, NULL, cmd_get_param_rows, 1, 0),
 	SHELL_CMD_ARG(cols, NULL, NULL, cmd_get_param_cols, 1, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_cmd_scroll) {
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmd_scroll,
 
 	SHELL_CMD_ARG(vertical, NULL, HELP_PRINT, cmd_scroll_vert, 4, 0),
 	SHELL_CMD_ARG(horizontal, NULL, HELP_PRINT, cmd_scroll_horz, 4, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(cfb_cmds) {
+SHELL_STATIC_SUBCMD_SET_CREATE(cfb_cmds,
 	SHELL_CMD_ARG(init, NULL, HELP_NONE, cmd_init, 1, 0),
 	SHELL_CMD_ARG(get_device, NULL, HELP_NONE, cmd_get_device, 1, 0),
 	SHELL_CMD(get_param, &sub_cmd_get_param,
@@ -464,7 +464,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(cfb_cmds) {
 		  "horizontal direction", NULL),
 	SHELL_CMD_ARG(clear, NULL, HELP_NONE, cmd_clear, 1, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 SHELL_CMD_REGISTER(cfb, &cfb_cmds, "Character Framebuffer shell commands",
 		   NULL);

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -456,8 +456,7 @@ static int cmd_mount_nffs(const struct shell *shell, size_t argc, char **argv)
 #endif
 
 #if defined(CONFIG_FILE_SYSTEM_NFFS) || defined(CONFIG_FAT_FILESYSTEM_ELM)
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_fs_mount)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_fs_mount,
 #if defined(CONFIG_FAT_FILESYSTEM_ELM)
 	SHELL_CMD_ARG(fat, NULL,
 		      "Mount fatfs. fs mount fat <mount-point>",
@@ -471,11 +470,10 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_fs_mount)
 #endif
 
 	SHELL_SUBCMD_SET_END
-};
+);
 #endif
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_fs)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_fs,
 	SHELL_CMD(cd, NULL, "Change working directory", cmd_cd),
 	SHELL_CMD(ls, NULL, "List files in current directory", cmd_ls),
 	SHELL_CMD_ARG(mkdir, NULL, "Create directory", cmd_mkdir, 2, 0),
@@ -489,6 +487,6 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_fs)
 	SHELL_CMD_ARG(trunc, NULL, "Truncate file", cmd_trunc, 2, 255),
 	SHELL_CMD_ARG(write, NULL, "Write file", cmd_write, 3, 255),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 SHELL_CMD_REGISTER(fs, &sub_fs, "File system commands", NULL);

--- a/subsys/logging/log_cmds.c
+++ b/subsys/logging/log_cmds.c
@@ -266,7 +266,7 @@ static int cmd_log_backend_disable(const struct shell *shell,
 
 static void module_name_get(size_t idx, struct shell_static_entry *entry);
 
-SHELL_CREATE_DYNAMIC_CMD(dsub_module_name, module_name_get);
+SHELL_DYNAMIC_CMD_CREATE(dsub_module_name, module_name_get);
 
 static void module_name_get(size_t idx, struct shell_static_entry *entry)
 {
@@ -286,7 +286,7 @@ static void severity_lvl_get(size_t idx, struct shell_static_entry *entry)
 					severity_lvls_sorted[idx] : NULL;
 }
 
-SHELL_CREATE_DYNAMIC_CMD(dsub_severity_lvl, severity_lvl_get);
+SHELL_DYNAMIC_CMD_CREATE(dsub_severity_lvl, severity_lvl_get);
 
 static int log_halt(const struct shell *shell,
 		    const struct log_backend *backend,
@@ -394,7 +394,7 @@ static void backend_name_get(size_t idx, struct shell_static_entry *entry)
 	}
 }
 
-SHELL_CREATE_DYNAMIC_CMD(dsub_backend_name_dynamic, backend_name_get);
+SHELL_DYNAMIC_CMD_CREATE(dsub_backend_name_dynamic, backend_name_get);
 
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_log_stat,

--- a/subsys/logging/log_cmds.c
+++ b/subsys/logging/log_cmds.c
@@ -364,8 +364,7 @@ static int cmd_log_backends_list(const struct shell *shell,
 }
 
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_backend)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_log_backend,
 	SHELL_CMD_ARG(disable, &dsub_module_name,
 		  "'log disable <module_0> .. <module_n>' disables logs in "
 		  "specified modules (all if no modules specified).",
@@ -379,7 +378,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_backend)
 	SHELL_CMD(halt, NULL, "Halt logging", cmd_log_backend_halt),
 	SHELL_CMD(status, NULL, "Logger status", cmd_log_backend_status),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 static void backend_name_get(size_t idx, struct shell_static_entry *entry)
 {
@@ -398,8 +397,7 @@ static void backend_name_get(size_t idx, struct shell_static_entry *entry)
 SHELL_CREATE_DYNAMIC_CMD(dsub_backend_name_dynamic, backend_name_get);
 
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_stat)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_log_stat,
 	SHELL_CMD(backend, &dsub_backend_name_dynamic,
 			"Logger backends commands.", NULL),
 	SHELL_CMD_ARG(disable, &dsub_module_name,
@@ -416,7 +414,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_stat)
 		      cmd_log_backends_list, 1, 0),
 	SHELL_CMD(status, NULL, "Logger status", cmd_log_self_status),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 SHELL_CMD_REGISTER(log, &sub_log_stat, "Commands for controlling logger",
 		   NULL);

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3637,7 +3637,7 @@ static char *set_iface_index_help(size_t idx)
 
 static void iface_index_get(size_t idx, struct shell_static_entry *entry);
 
-SHELL_CREATE_DYNAMIC_CMD(iface_index, iface_index_get);
+SHELL_DYNAMIC_CMD_CREATE(iface_index, iface_index_get);
 
 static void iface_index_get(size_t idx, struct shell_static_entry *entry)
 {
@@ -3712,7 +3712,7 @@ static char *set_nbr_address(size_t idx)
 
 static void nbr_address_get(size_t idx, struct shell_static_entry *entry);
 
-SHELL_CREATE_DYNAMIC_CMD(nbr_address, nbr_address_get);
+SHELL_DYNAMIC_CMD_CREATE(nbr_address, nbr_address_get);
 
 #define NBR_ADDRESS_CMD &nbr_address
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3570,15 +3570,13 @@ usage:
 	return 0;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_arp)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_arp,
 	SHELL_CMD(flush, NULL, "Remove all entries from ARP cache.",
 		  cmd_net_arp_flush),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_dns)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_dns,
 	SHELL_CMD(cancel, NULL, "Cancel all pending requests.",
 		  cmd_net_dns_cancel),
 	SHELL_CMD(query, NULL,
@@ -3586,16 +3584,15 @@ SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_dns)
 		  "(default) or IPv6 address for a host name.",
 		  cmd_net_dns_query),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_gptp)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_gptp,
 	SHELL_CMD(port, NULL,
 		  "'net gptp [<port>]' prints detailed information about "
 		  "gPTP port.",
 		  cmd_net_gptp_port),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 #if !defined(NET_VLAN_MAX_COUNT)
 #define MAX_IFACE_COUNT NET_IF_MAX_CONFIGS
@@ -3655,8 +3652,7 @@ static void iface_index_get(size_t idx, struct shell_static_entry *entry)
 #define IFACE_DYN_CMD NULL
 #endif /* CONFIG_NET_SHELL_DYN_CMD_COMPLETION */
 
-SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_iface)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_iface,
 	SHELL_CMD(up, IFACE_DYN_CMD,
 		  "'net iface up <index>' takes network interface up.",
 		  cmd_net_iface_up),
@@ -3669,7 +3665,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_iface)
 		  "information.",
 		  cmd_net_iface),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 #if defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_SHELL_DYN_CMD_COMPLETION)
 static
@@ -3732,13 +3728,12 @@ static void nbr_address_get(size_t idx, struct shell_static_entry *entry)
 #define NBR_ADDRESS_CMD NULL
 #endif /* CONFIG_NET_IPV6 && CONFIG_NET_SHELL_DYN_CMD_COMPLETION */
 
-SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_nbr)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_nbr,
 	SHELL_CMD(rm, NBR_ADDRESS_CMD,
 		  "'net nbr rm <address>' removes neighbor from cache.",
 		  cmd_net_nbr_rm),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 #if defined(CONFIG_NET_STATISTICS) && \
 	defined(CONFIG_NET_STATISTICS_PER_INTERFACE) && \
@@ -3750,8 +3745,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_nbr)
 	* CONFIG_NET_SHELL_DYN_CMD_COMPLETION
 	*/
 
-SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_stats)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_stats,
 	SHELL_CMD(all, NULL,
 		  "Show network statistics for all network interfaces.",
 		  cmd_net_stats_all),
@@ -3760,10 +3754,9 @@ SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_stats)
 		  "one specific network interface.",
 		  cmd_net_stats_iface),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_tcp)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_tcp,
 	SHELL_CMD(connect, NULL,
 		  "'net tcp connect <address> <port>' connects to TCP peer.",
 		  cmd_net_tcp_connect),
@@ -3773,10 +3766,9 @@ SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_tcp)
 	SHELL_CMD(close, NULL,
 		  "'net tcp close' closes TCP connection.", cmd_net_tcp_close),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_vlan)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_vlan,
 	SHELL_CMD(add, NULL,
 		  "'net vlan add <tag> <index>' adds VLAN tag to the "
 		  "network interface.",
@@ -3786,11 +3778,9 @@ SHELL_CREATE_STATIC_SUBCMD_SET(net_cmd_vlan)
 		  "interface.",
 		  cmd_net_vlan_del),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(net_commands)
-{
-	/* Alphabetically sorted. */
+SHELL_STATIC_SUBCMD_SET_CREATE(net_commands,
 	SHELL_CMD(allocs, NULL, "Print network memory allocations.",
 		  cmd_net_allocs),
 	SHELL_CMD(arp, &net_cmd_arp, "Print information about IPv4 ARP cache.",
@@ -3822,7 +3812,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(net_commands)
 		  cmd_net_tcp),
 	SHELL_CMD(vlan, &net_cmd_vlan, "Show VLAN information.", cmd_net_vlan),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 SHELL_CMD_REGISTER(net, &net_commands, "Networking commands", NULL);
 

--- a/subsys/net/l2/bluetooth/bluetooth_shell.c
+++ b/subsys/net/l2/bluetooth/bluetooth_shell.c
@@ -166,8 +166,7 @@ static int shell_cmd_advertise(const struct shell *shell,
 	return 0;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(bt_commands)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(bt_commands,
 	SHELL_CMD(advertise, NULL,
 		  "on/off",
 		  shell_cmd_advertise),
@@ -181,7 +180,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(bt_commands)
 		  "",
 		  shell_cmd_disconnect),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 SHELL_CMD_REGISTER(net_bt, &bt_commands, "Net Bluetooth commands", NULL);
 

--- a/subsys/net/l2/ieee802154/ieee802154_shell.c
+++ b/subsys/net/l2/ieee802154/ieee802154_shell.c
@@ -591,8 +591,7 @@ static int cmd_ieee802154_get_tx_power(const struct shell *shell,
 	return 0;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(ieee802154_commands)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(ieee802154_commands,
 	SHELL_CMD(ack, NULL,
 		  "<set/1 | unset/0> Set auto-ack flag",
 		  cmd_ieee802154_ack),
@@ -637,7 +636,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(ieee802154_commands)
 		  "<-18/-7/-4/-2/0/1/2/3/5> Set TX power",
 		  cmd_ieee802154_set_tx_power),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 SHELL_CMD_REGISTER(ieee802154, &ieee802154_commands, "IEEE 802.15.4 commands",
 		   NULL);

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -307,18 +307,16 @@ static int cmd_wifi_ap_disable(const struct shell *shell, size_t argc,
 	return 0;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(wifi_cmd_ap)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(wifi_cmd_ap,
 	SHELL_CMD(enable, NULL, "<SSID> <SSID length> [channel] [PSK]",
 		  cmd_wifi_ap_enable),
 	SHELL_CMD(disable, NULL,
 		  "Disable Access Point mode",
 		  cmd_wifi_ap_disable),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(wifi_commands)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 	SHELL_CMD(connect, NULL,
 		  "\"<SSID>\"\n<SSID length>\n<channel number (optional), "
 		  "0 means all>\n"
@@ -329,7 +327,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(wifi_commands)
 	SHELL_CMD(scan, NULL, "Scan Wifi AP", cmd_wifi_scan),
 	SHELL_CMD(ap, &wifi_cmd_ap, "Access Point mode commands", NULL),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 SHELL_CMD_REGISTER(wifi, &wifi_commands, "Wifi commands", NULL);
 

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -95,12 +95,10 @@ static int cmd_device_list(const struct shell *shell,
 }
 
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_device)
-{
-	/* Alphabetically sorted. */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_device,
 	SHELL_CMD(levels, NULL, "List configured devices by levels", cmd_device_levels),
 	SHELL_CMD(list, NULL, "List configured devices", cmd_device_list),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
-};
+);
 
 SHELL_CMD_REGISTER(device, &sub_device, "Device commands", NULL);

--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -142,18 +142,14 @@ static int cmd_kernel_reboot_cold(const struct shell *shell,
 	return 0;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_kernel_reboot)
-{
-	/* Alphabetically sorted. */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_kernel_reboot,
 	SHELL_CMD(cold, NULL, "Cold reboot.", cmd_kernel_reboot_cold),
 	SHELL_CMD(warm, NULL, "Warm reboot.", cmd_kernel_reboot_warm),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
-};
+);
 #endif
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_kernel)
-{
-	/* Alphabetically sorted. */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_kernel,
 	SHELL_CMD(cycles, NULL, "Kernel cycles.", cmd_kernel_cycles),
 #if defined(CONFIG_REBOOT)
 	SHELL_CMD(reboot, &sub_kernel_reboot, "Reboot.", NULL),
@@ -166,6 +162,6 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_kernel)
 	SHELL_CMD(uptime, NULL, "Kernel uptime.", cmd_kernel_uptime),
 	SHELL_CMD(version, NULL, "Kernel version.", cmd_kernel_version),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
-};
+);
 
 SHELL_CMD_REGISTER(kernel, &sub_kernel, "Kernel commands", NULL);

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -535,23 +535,13 @@ static int exec_cmd(const struct shell *shell, size_t argc, char **argv,
 		}
 	}
 
-	if (shell->ctx->active_cmd.args) {
-		const struct shell_static_args *args;
+	if (shell->ctx->active_cmd.args.mandatory) {
+		u8_t mand = shell->ctx->active_cmd.args.mandatory;
+		u8_t opt = shell->ctx->active_cmd.args.optional;
+		bool in_range = (argc >= mand) && (argc <= (mand + opt));
 
-		args = shell->ctx->active_cmd.args;
-
-		if (args->optional > 0) {
-			/* Check if argc is within allowed range */
-			ret_val = cmd_precheck(shell,
-					       ((argc >= args->mandatory)
-					       &&
-					       (argc <= args->mandatory +
-					       args->optional)));
-		} else {
-			/* Perform exact match if there are no optional args */
-			ret_val = cmd_precheck(shell,
-					       (args->mandatory == argc));
-		}
+		/* Check if argc is within allowed range */
+		ret_val = cmd_precheck(shell, in_range);
 	}
 
 	if (!ret_val) {

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -394,54 +394,48 @@ static int cmd_resize(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(m_sub_colors)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_colors,
 	SHELL_CMD_ARG(off, NULL, SHELL_HELP_COLORS_OFF, cmd_colors_off, 1, 0),
 	SHELL_CMD_ARG(on, NULL, SHELL_HELP_COLORS_ON, cmd_colors_on, 1, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(m_sub_echo)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_echo,
 	SHELL_CMD_ARG(off, NULL, SHELL_HELP_ECHO_OFF, cmd_echo_off, 1, 0),
 	SHELL_CMD_ARG(on, NULL, SHELL_HELP_ECHO_ON, cmd_echo_on, 1, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(m_sub_shell_stats)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_shell_stats,
 	SHELL_CMD_ARG(reset, NULL, SHELL_HELP_STATISTICS_RESET,
 			cmd_shell_stats_reset, 1, 0),
 	SHELL_CMD_ARG(show, NULL, SHELL_HELP_STATISTICS_SHOW,
 			cmd_shell_stats_show, 1, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(m_sub_backspace_mode)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_backspace_mode,
 	SHELL_CMD_ARG(backspace, NULL, SHELL_HELP_BACKSPACE_MODE_BACKSPACE,
 			cmd_bacskpace_mode_backspace, 1, 0),
 	SHELL_CMD_ARG(delete, NULL, SHELL_HELP_BACKSPACE_MODE_DELETE,
 			cmd_bacskpace_mode_delete, 1, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(m_sub_shell)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_shell,
 	SHELL_CMD(backspace_mode, &m_sub_backspace_mode,
 			SHELL_HELP_BACKSPACE_MODE, NULL),
 	SHELL_CMD(colors, &m_sub_colors, SHELL_HELP_COLORS, NULL),
 	SHELL_CMD_ARG(echo, &m_sub_echo, SHELL_HELP_ECHO, cmd_echo, 1, 1),
 	SHELL_CMD(stats, &m_sub_shell_stats, SHELL_HELP_STATISTICS, NULL),
 	SHELL_SUBCMD_SET_END
-};
+);
 
-SHELL_CREATE_STATIC_SUBCMD_SET(m_sub_resize)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_resize,
 	SHELL_CMD_ARG(default, NULL, SHELL_HELP_RESIZE_DEFAULT,
 			cmd_resize_default, 1, 0),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 SHELL_CMD_ARG_REGISTER(clear, NULL, SHELL_HELP_CLEAR, cmd_clear, 1, 0);
 SHELL_CMD_REGISTER(shell, &m_sub_shell, SHELL_HELP_SHELL, NULL);

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -60,14 +60,14 @@ static int cmd_hrs_simulate(const struct shell *shell,
 #define HELP_NONE "[none]"
 #define HELP_ADDR_LE "<address: XX:XX:XX:XX:XX:XX> <type: (public|random)>"
 
-SHELL_CREATE_STATIC_SUBCMD_SET(hrs_cmds) {
+SHELL_STATIC_SUBCMD_SET_CREATE(hrs_cmds,
 #if defined(CONFIG_BT_CONN)
 	SHELL_CMD_ARG(hrs-simulate, NULL,
 		"register and simulate Heart Rate Service <value: on, off>",
 		cmd_hrs_simulate, 2, 0),
 #endif /* CONFIG_BT_CONN */
 	SHELL_SUBCMD_SET_END
-};
+);
 
 static int cmd_hrs(const struct shell *shell, size_t argc, char **argv)
 {

--- a/tests/shell/src/main.c
+++ b/tests/shell/src/main.c
@@ -223,13 +223,12 @@ static int cmd_wildcard(const struct shell *shell, size_t argc, char **argv)
 	return valid_arguments;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(m_sub_test_shell_cmdl)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_test_shell_cmdl,
 	SHELL_CMD(argument_1, NULL, NULL, NULL),
 	SHELL_CMD(argument_2, NULL, NULL, NULL),
 	SHELL_CMD(dummy, NULL, NULL, NULL),
 	SHELL_SUBCMD_SET_END
-};
+);
 SHELL_CMD_REGISTER(test_wildcard, &m_sub_test_shell_cmdl, NULL, cmd_wildcard);
 
 

--- a/tests/shell/src/main.c
+++ b/tests/shell/src/main.c
@@ -268,7 +268,7 @@ static void dynamic_cmd_get(size_t idx, struct shell_static_entry *entry)
 	}
 }
 
-SHELL_CREATE_DYNAMIC_CMD(m_sub_test_dynamic, dynamic_cmd_get);
+SHELL_DYNAMIC_CMD_CREATE(m_sub_test_dynamic, dynamic_cmd_get);
 SHELL_CMD_REGISTER(test_dynamic, &m_sub_test_dynamic, NULL, cmd_dynamic);
 
 


### PR DESCRIPTION
Here is the first step in direction of shell being cpp friendly. Well, this step is enough but second step would be required to keep zephyr consistent.

There are some cosmetics to allow cpp compilation and one api related change. It's around creation of subcommand array. The syntax we had now cannot be transferred to c++ (see #13257 ).

As i didn't want to break API, i created macro `SHELL_STATIC_SUBCMD_SET_CREATE` (compared to current one `SHELL_CREATE_STATIC_SUBCMD_SET`). The plan is to deprecate old macro (and replace usage across tree) in a separate PR. I moved verb to the end of the macro name to be in line with `SHELL_CMD_REGISTER`. I also added macro `SHELL_DYNAMIC_CMD_CREATE` and plan to deprecate `SHELL_CREATE_DYNAMIC_CMD` to have all naming consistent across the file.

@nashif please let me know if that could go to 1.14. There is no functional changes planned. it's just about structures initialization and this is a bug since code does not compile in c++.
