### PR TITLE
shell: allow commands to suspend shell thread

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -374,6 +374,7 @@ struct shell_flags {
 	u32_t tx_rdy      :1;
 	u32_t mode_delete :1; /*!< Operation mode of backspace key */
 	u32_t history_exit:1; /*!< Request to exit history mode */
+	u32_t cmd_ctx	  :1; /*!< Shell is executing command */
 	u32_t last_nl     :8; /*!< Last received new line character */
 };
 
@@ -683,7 +684,10 @@ void shell_help(const struct shell *shell);
  * Pass command line to shell to execute.
  *
  * Note: This by no means makes any of the commands a stable interface, so
- * this function should only be used for debugging/diagnostic.
+ * 	 this function should only be used for debugging/diagnostic.
+ *
+ *	 This function must not be called from shell command context!
+
  *
  * @param[in] shell	Pointer to the shell instance. It can be NULL when
  *			the :option:`CONFIG_SHELL_BACKEND_DUMMY` option is

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -118,20 +118,20 @@ static void help_item_print(const struct shell *shell, const char *item_name,
 
 	if (!IS_ENABLED(CONFIG_NEWLIB_LIBC) && !IS_ENABLED(CONFIG_ARCH_POSIX)) {
 		/* print option name */
-		shell_fprintf(shell, SHELL_NORMAL, "%s%-*s%s:",
-			      tabulator,
-			      item_name_width, item_name,
-			      tabulator);
+		shell_internal_fprintf(shell, SHELL_NORMAL, "%s%-*s%s:",
+				       tabulator,
+				       item_name_width, item_name,
+				       tabulator);
 	} else {
 		u16_t tmp = item_name_width - strlen(item_name);
 		char space = ' ';
 
-		shell_fprintf(shell, SHELL_NORMAL, "%s%s", tabulator,
-			      item_name);
+		shell_internal_fprintf(shell, SHELL_NORMAL, "%s%s", tabulator,
+				       item_name);
 		for (u16_t i = 0; i < tmp; i++) {
 			shell_write(shell, &space, 1);
 		}
-		shell_fprintf(shell, SHELL_NORMAL, "%s:", tabulator);
+		shell_internal_fprintf(shell, SHELL_NORMAL, "%s:", tabulator);
 	}
 
 	if (item_help == NULL) {
@@ -176,7 +176,7 @@ void shell_help_subcmd_print(const struct shell *shell)
 		return;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "Subcommands:\n");
+	shell_internal_fprintf(shell, SHELL_NORMAL, "Subcommands:\n");
 
 	/* Printing subcommands and help string (if exists). */
 	cmd_idx = 0;
@@ -202,8 +202,8 @@ void shell_help_cmd_print(const struct shell *shell)
 	u16_t field_width = shell_strlen(shell->ctx->active_cmd.syntax) +
 							  shell_strlen(cmd_sep);
 
-	shell_fprintf(shell, SHELL_NORMAL, "%s%s",
-		      shell->ctx->active_cmd.syntax, cmd_sep);
+	shell_internal_fprintf(shell, SHELL_NORMAL, "%s%s",
+			       shell->ctx->active_cmd.syntax, cmd_sep);
 
 	formatted_text_print(shell, shell->ctx->active_cmd.help,
 			     field_width, false);

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -178,7 +178,7 @@ void shell_op_word_remove(const struct shell *shell)
 	/* Update display. */
 	shell_op_cursor_move(shell, -chars_to_delete);
 	cursor_save(shell);
-	shell_fprintf(shell, SHELL_NORMAL, "%s", str + 1);
+	shell_internal_fprintf(shell, SHELL_NORMAL, "%s", str + 1);
 	clear_eos(shell);
 	cursor_restore(shell);
 }
@@ -223,7 +223,7 @@ static void reprint_from_cursor(const struct shell *shell, u16_t diff,
 		clear_eos(shell);
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "%s",
+	shell_internal_fprintf(shell, SHELL_NORMAL, "%s",
 		      &shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos]);
 	shell->ctx->cmd_buff_pos = shell->ctx->cmd_buff_len;
 
@@ -336,21 +336,7 @@ void shell_cmd_line_erase(const struct shell *shell)
 
 static void print_prompt(const struct shell *shell)
 {
-	/* Below cannot be printed by shell_fprinf because it will cause
-	 * interrupt spin
-	 */
-	if (IS_ENABLED(CONFIG_SHELL_VT100_COLORS) &&
-	    shell->ctx->internal.flags.use_colors &&
-	    (SHELL_INFO != shell->ctx->vt100_ctx.col.col)) {
-		struct shell_vt100_colors col;
-
-		shell_vt100_colors_store(shell, &col);
-		shell_vt100_color_set(shell, SHELL_INFO);
-		shell_raw_fprintf(shell->fprintf_ctx, "%s", shell->ctx->prompt);
-		shell_vt100_colors_restore(shell, &col);
-	} else {
-		shell_raw_fprintf(shell->fprintf_ctx, "%s", shell->ctx->prompt);
-	}
+	shell_internal_fprintf(shell, SHELL_INFO, "%s", shell->ctx->prompt);
 }
 
 void shell_print_cmd(const struct shell *shell)
@@ -456,4 +442,41 @@ void shell_vt100_colors_restore(const struct shell *shell,
 {
 	shell_vt100_color_set(shell, color->col);
 	vt100_bgcolor_set(shell, color->bgcol);
+}
+
+void shell_internal_vfprintf(const struct shell *shell,
+			     enum shell_vt100_color color, const char *fmt,
+			     va_list args)
+{
+	if (IS_ENABLED(CONFIG_SHELL_VT100_COLORS) &&
+	    shell->ctx->internal.flags.use_colors &&
+	    (color != shell->ctx->vt100_ctx.col.col)) {
+		struct shell_vt100_colors col;
+
+		shell_vt100_colors_store(shell, &col);
+		shell_vt100_color_set(shell, color);
+
+		shell_fprintf_fmt(shell->fprintf_ctx, fmt, args);
+
+		shell_vt100_colors_restore(shell, &col);
+	} else {
+		shell_fprintf_fmt(shell->fprintf_ctx, fmt, args);
+	}
+}
+
+void shell_internal_fprintf(const struct shell *shell,
+			    enum shell_vt100_color color,
+			    const char *fmt, ...)
+{
+	__ASSERT_NO_MSG(shell);
+	__ASSERT(!k_is_in_isr(), "Thread context required.");
+	__ASSERT_NO_MSG(shell->ctx);
+	__ASSERT_NO_MSG(shell->fprintf_ctx);
+	__ASSERT_NO_MSG(fmt);
+
+	va_list args = { 0 };
+
+	va_start(args, fmt);
+	shell_internal_vfprintf(shell, color, fmt, args);
+	va_end(args);
 }

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -134,6 +134,16 @@ static inline void flag_history_exit_set(const struct shell *shell, bool val)
 	shell->ctx->internal.flags.history_exit = val ? 1 : 0;
 }
 
+static inline bool flag_cmd_ctx_get(const struct shell *shell)
+{
+	return shell->ctx->internal.flags.cmd_ctx == 1 ? true : false;
+}
+
+static inline void flag_cmd_ctx_set(const struct shell *shell, bool val)
+{
+	shell->ctx->internal.flags.cmd_ctx = val ? 1 : 0;
+}
+
 static inline u8_t flag_last_nl_get(const struct shell *shell)
 {
 	return shell->ctx->internal.flags.last_nl;
@@ -245,6 +255,17 @@ static inline void shell_vt100_colors_store(const struct shell *shell,
 
 void shell_vt100_colors_restore(const struct shell *shell,
 				const struct shell_vt100_colors *color);
+
+/* This function can be called only within shell thread but not from command
+ * handlers.
+ */
+void shell_internal_fprintf(const struct shell *shell,
+			    enum shell_vt100_color color,
+			    const char *fmt, ...);
+
+void shell_internal_vfprintf(const struct shell *shell,
+			     enum shell_vt100_color color, const char *fmt,
+			     va_list args);
 
 #ifdef __cplusplus
 }

--- a/subsys/shell/shell_wildcard.c
+++ b/subsys/shell/shell_wildcard.c
@@ -8,7 +8,7 @@
 #include <fnmatch.h>
 #include "shell_wildcard.h"
 #include "shell_utils.h"
-
+#include "shell_ops.h"
 
 static void subcmd_get(const struct shell_cmd_entry *cmd,
 		       size_t idx, const struct shell_static_entry **entry,
@@ -109,7 +109,7 @@ static enum shell_wildcard_status commands_expand(const struct shell *shell,
 					      &shell->ctx->cmd_tmp_buff_len,
 					      p_static_entry->syntax, pattern);
 			if (ret_val == SHELL_WILDCARD_CMD_MISSING_SPACE) {
-				shell_fprintf(shell,
+				shell_internal_fprintf(shell,
 					      SHELL_WARNING,
 					      "Command buffer is too short to"
 					      " expand all commands matching"


### PR DESCRIPTION
It was possible to deadlock the shell when command suspended shell's thread and then another thread wanted to print something on the shell.

To solve this shell releases mutex before entering command handler. To make it work correctly some adapations to shell internal print functions have been applied.

This issue has been discussed in PR #13260 

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>