### PR TITLE
Cleanup x86 build scripts

### DIFF
--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -108,7 +108,7 @@ add_custom_command(
   -I binary
   -B ${OUTPUT_ARCH}
   -O ${OUTPUT_FORMAT}
-  --rename-section .data=irq_vectors_alloc_data
+  --rename-section .data=irq_vectors_alloc
   irq_vectors_alloc.bin
   irq_vectors_alloc.o
   DEPENDS gen_idt_output irq_vectors_alloc.bin

--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -153,6 +153,12 @@ if(CONFIG_X86_MMU)
     DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
+
+  add_custom_target(
+    mmu_tables_bin_target
+    DEPENDS
+    mmu_tables.bin
+  )
   add_custom_command(
     OUTPUT mmu_tables.bin user_mmu_tables.bin
     COMMAND
@@ -179,6 +185,7 @@ if(CONFIG_X86_MMU)
     mmu_tables.o
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS mmu_tables.bin
+    mmu_tables_bin_target
     )
 
   add_custom_target(  mmu_tables_o DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/mmu_tables.o)
@@ -216,6 +223,11 @@ if(CONFIG_GDT_DYNAMIC)
   # way.
   #
   # ${ZEPHYR_PREBUILT_EXECUTABLE}.elf -> gdt.bin -> gdt.o
+  add_custom_target(
+    gdt_bin_target
+    DEPENDS
+    gdt.bin
+  )
   add_custom_command(
     OUTPUT gdt.bin
     COMMAND
@@ -239,6 +251,7 @@ if(CONFIG_GDT_DYNAMIC)
     gdt.o
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS gdt.bin
+    gdt_bin_target
     )
 
   add_custom_target(  gdt_o DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gdt.o)

--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -75,65 +75,33 @@ add_subdirectory(core)
 get_property(OUTPUT_ARCH   GLOBAL PROPERTY PROPERTY_OUTPUT_ARCH)
 get_property(OUTPUT_FORMAT GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT)
 
-add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/irq_int_vector_map.o
-  COMMAND
-  ${CMAKE_OBJCOPY}
-  -I binary
-  -B ${OUTPUT_ARCH}
-  -O ${OUTPUT_FORMAT}
-  --rename-section .data=irq_int_vector_map
-  irq_int_vector_map.bin
-  irq_int_vector_map.o
-  DEPENDS gen_idt_output irq_int_vector_map.bin
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  )
-add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/staticIdt.o
-  COMMAND
-  ${CMAKE_OBJCOPY}
-  -I binary
-  -B ${OUTPUT_ARCH}
-  -O ${OUTPUT_FORMAT}
-  --rename-section .data=staticIdt
-  staticIdt.bin
-  staticIdt.o
-  DEPENDS gen_idt_output staticIdt.bin
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  )
-add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/irq_vectors_alloc.o
-  COMMAND
-  ${CMAKE_OBJCOPY}
-  -I binary
-  -B ${OUTPUT_ARCH}
-  -O ${OUTPUT_FORMAT}
-  --rename-section .data=irq_vectors_alloc
-  irq_vectors_alloc.bin
-  irq_vectors_alloc.o
-  DEPENDS gen_idt_output irq_vectors_alloc.bin
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  )
+# Convert the .bin file argument to a .o file, create a wrapper
+# library for the .o file, and register the library as a generated
+# file that is to be linked in after the first link.
+function(add_bin_file_to_the_next_link target_dependency bin)
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${bin}.o
+    COMMAND
+    ${CMAKE_OBJCOPY}
+    -I binary
+    -B ${OUTPUT_ARCH}
+    -O ${OUTPUT_FORMAT}
+    --rename-section .data=${bin}
+    ${bin}.bin
+    ${bin}.o
+    DEPENDS ${target_dependency} ${bin}.bin
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+  add_custom_target(${bin}_o DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${bin}.o)
+  add_library(${bin} STATIC IMPORTED GLOBAL)
+  set_property(TARGET ${bin} PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/${bin}.o)
+  add_dependencies(${bin} ${bin}_o)
+  set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_OBJECT_FILES ${bin})
+endfunction()
 
-add_custom_target(irq_int_vector_map_o DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/irq_int_vector_map.o)
-add_custom_target(staticIdt_o          DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/staticIdt.o)
-add_custom_target(irq_vectors_alloc_o  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/irq_vectors_alloc.o)
-
-add_library(irq_int_vector_map STATIC IMPORTED GLOBAL)
-add_library(staticIdt          STATIC IMPORTED GLOBAL)
-add_library(irq_vectors_alloc  STATIC IMPORTED GLOBAL)
-
-set_property(TARGET irq_int_vector_map PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/irq_int_vector_map.o)
-set_property(TARGET staticIdt          PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/staticIdt.o)
-set_property(TARGET irq_vectors_alloc  PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/irq_vectors_alloc.o)
-
-add_dependencies(irq_int_vector_map irq_int_vector_map_o)
-add_dependencies(staticIdt          staticIdt_o)
-add_dependencies(irq_vectors_alloc  irq_vectors_alloc_o)
-
-set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_OBJECT_FILES irq_int_vector_map)
-set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_OBJECT_FILES staticIdt)
-set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_OBJECT_FILES irq_vectors_alloc)
+add_bin_file_to_the_next_link(gen_idt_output staticIdt)
+add_bin_file_to_the_next_link(gen_idt_output irq_int_vector_map)
+add_bin_file_to_the_next_link(gen_idt_output irq_vectors_alloc)
 
 if(CONFIG_X86_MMU)
   # Use gen_mmu.py and objcopy to generate mmu_tables.o from from the
@@ -157,7 +125,8 @@ if(CONFIG_X86_MMU)
   add_custom_target(
     mmu_tables_bin_target
     DEPENDS
-    mmu_tables.bin
+    user_mmu_tables.bin
+         mmu_tables.bin
   )
   add_custom_command(
     OUTPUT mmu_tables.bin user_mmu_tables.bin
@@ -173,47 +142,10 @@ if(CONFIG_X86_MMU)
     DEPENDS mmulist.bin
     DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
     )
-  add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mmu_tables.o
-    COMMAND
-    ${CMAKE_OBJCOPY}
-    -I binary
-    -B ${OUTPUT_ARCH}
-    -O ${OUTPUT_FORMAT}
-    --rename-section .data=mmu_tables
-    mmu_tables.bin
-    mmu_tables.o
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS mmu_tables.bin
-    mmu_tables_bin_target
-    )
 
-  add_custom_target(  mmu_tables_o DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/mmu_tables.o)
-  add_library(        mmu_tables STATIC IMPORTED GLOBAL)
-  set_property(TARGET mmu_tables PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/mmu_tables.o)
-  add_dependencies(   mmu_tables mmu_tables_o)
-  set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_OBJECT_FILES mmu_tables)
-
+  add_bin_file_to_the_next_link(  mmu_tables_bin_target      mmu_tables)
   if(CONFIG_X86_KPTI)
-    add_custom_command(
-      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/user_mmu_tables.o
-      COMMAND
-      ${CMAKE_OBJCOPY}
-      -I binary
-      -B ${OUTPUT_ARCH}
-      -O ${OUTPUT_FORMAT}
-      --rename-section .data=user_mmu_tables
-      user_mmu_tables.bin
-      user_mmu_tables.o
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      DEPENDS user_mmu_tables.bin
-    )
-
-    add_custom_target(  user_mmu_tables_o DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/user_mmu_tables.o)
-    add_library(        user_mmu_tables STATIC IMPORTED GLOBAL)
-    set_property(TARGET user_mmu_tables PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/user_mmu_tables.o)
-    add_dependencies(   user_mmu_tables user_mmu_tables_o)
-    set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_OBJECT_FILES user_mmu_tables)
+    add_bin_file_to_the_next_link(mmu_tables_bin_target user_mmu_tables)
   endif()
 endif()
 
@@ -239,24 +171,6 @@ if(CONFIG_GDT_DYNAMIC)
     DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
-  add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gdt.o
-    COMMAND
-    ${CMAKE_OBJCOPY}
-    -I binary
-    -B ${OUTPUT_ARCH}
-    -O ${OUTPUT_FORMAT}
-    --rename-section .data=gdt
-    gdt.bin
-    gdt.o
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS gdt.bin
-    gdt_bin_target
-    )
 
-  add_custom_target(  gdt_o DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gdt.o)
-  add_library(        gdt STATIC IMPORTED GLOBAL)
-  set_property(TARGET gdt PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/gdt.o)
-  add_dependencies(   gdt gdt_o)
-  set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_OBJECT_FILES gdt)
+  add_bin_file_to_the_next_link(gdt_bin_target gdt)
 endif()

--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -195,7 +195,7 @@ if(CONFIG_X86_MMU)
       -I binary
       -B ${OUTPUT_ARCH}
       -O ${OUTPUT_FORMAT}
-      --rename-section .data=.user_mmu_data
+      --rename-section .data=user_mmu_tables
       user_mmu_tables.bin
       user_mmu_tables.o
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -174,7 +174,7 @@ if(CONFIG_X86_MMU)
     -I binary
     -B ${OUTPUT_ARCH}
     -O ${OUTPUT_FORMAT}
-    --rename-section .data=.mmu_data
+    --rename-section .data=mmu_tables
     mmu_tables.bin
     mmu_tables.o
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -234,7 +234,7 @@ if(CONFIG_GDT_DYNAMIC)
     -I binary
     -B ${OUTPUT_ARCH}
     -O ${OUTPUT_FORMAT}
-    --rename-section .data=gdt_ram_data
+    --rename-section .data=gdt
     gdt.bin
     gdt.o
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -290,7 +290,7 @@ SECTIONS
 
 	z_interrupt_vectors_allocated = .;
 #ifdef LINKER_PASS2
-	KEEP(*(irq_vectors_alloc_data))
+	KEEP(*(irq_vectors_alloc))
 #else
 	. += (CONFIG_IDT_NUM_VECTORS + 7) / 8;
 #endif /* LINKER_PASS2 */

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -331,7 +331,7 @@ SECTIONS
 	. = ALIGN(8);
 	_gdt = .;
 #ifdef LINKER_PASS2
-	KEEP(*(gdt_ram_data))
+	KEEP(*(gdt))
 #else /* LINKER_PASS2 */
 
 #ifdef CONFIG_USERSPACE

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -381,7 +381,7 @@ SECTIONS
 	KEEP(*(mmu_tables));
 #ifdef CONFIG_X86_KPTI
 	z_x86_user_pdpt = .;
-	KEEP(*(.user_mmu_data));
+	KEEP(*(user_mmu_tables));
 #endif /* CONFIG_X86_KPTI */
 	__mmu_tables_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -378,7 +378,7 @@ SECTIONS
 	MMU_PAGE_ALIGN
 	__mmu_tables_start = .;
 	z_x86_kernel_pdpt = .;
-	KEEP(*(.mmu_data));
+	KEEP(*(mmu_tables));
 #ifdef CONFIG_X86_KPTI
 	z_x86_user_pdpt = .;
 	KEEP(*(.user_mmu_data));


### PR DESCRIPTION
The same pattern is used five times In the x86 build scripts and the
same code has been copied and modified the same amount of times. This
has resulted in a system that is inconsistent in inconsequential ways and
is difficult to make changes to.

To enforce consistency and improve maintainability we refactor the
code into a function.

Also, wrapper-targets are used to follow best-practices wrt. dependency management.

Fixes #13410 