### PR TITLE
settings: fix read-out more than stored bug.

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -120,7 +120,8 @@ static int read_handler(void *ctx, off_t off, char *buf, size_t *len)
 	struct fcb_entry_ctx *entry_ctx = ctx;
 
 	if (off >= entry_ctx->loc.fe_data_len) {
-		return -EINVAL;
+		*len = 0;
+		return 0;
 	}
 
 	if ((off + *len) > entry_ctx->loc.fe_data_len) {

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -346,7 +346,8 @@ static int read_handler(void *ctx, off_t off, char *buf, size_t *len)
 	/* 0 is reserved for reding the length-field only */
 	if (entry_ctx->len != 0) {
 		if (off >= entry_ctx->len) {
-			return -EINVAL;
+			*len = 0;
+			return 0;
 		}
 
 		if ((off + *len) > entry_ctx->len) {


### PR DESCRIPTION
When setting read handler was requested for more
data than is stored, it should read reduced amount
of data (by the API define).

Back-end implementation support that, but not for corner-case
when the last call to back-end handler was out of data bounds.

This patch makes any request to read data which begins outside
of the record zero-length read-out, instead of being prohibited
before, which fix the issue.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>