### PR TITLE
Various STM32 flash related testing additions

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -176,6 +176,11 @@ arduino_serial: &uart4 {};
 			label = "image-scratch";
 			reg = <0x000F8000 0x00006000>;
 		};
+
+		storage_partition: partition@fc000 {
+			label = "storage";
+			reg = <0x000fc000 0x00004000>;
+		};
 	};
 
 

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - ble
   - spi
+  - nvs
   - vl53l0x
   - watchdog
 ram: 96

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -75,3 +75,21 @@ arduino_spi: &spi1 {
 &idwg {
 	status = "ok";
 };
+
+&flash0 {
+	/*
+	 * For more information, see:
+	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 4Kb of storage at the end of the 256Kb of flash */
+		storage_partition: partition@3f000 {
+			label = "storage";
+			reg = <0x0003f000 0x00001000>;
+		};
+	};
+};

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
@@ -12,6 +12,7 @@ supported:
   - arduino_i2c
   - gpio
   - i2c
+  - nvs
   - spi
   - watchdog
 testing:

--- a/dts/arm/st/f0/stm32f030.dtsi
+++ b/dts/arm/st/f0/stm32f030.dtsi
@@ -5,3 +5,13 @@
  */
 
 #include <st/f0/stm32f0.dtsi>
+
+/ {
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				erase-block-size = <1024>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/f0/stm32f051.dtsi
+++ b/dts/arm/st/f0/stm32f051.dtsi
@@ -5,3 +5,13 @@
  */
 
 #include <st/f0/stm32f0.dtsi>
+
+/ {
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				erase-block-size = <1024>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/f0/stm32f070.dtsi
+++ b/dts/arm/st/f0/stm32f070.dtsi
@@ -8,6 +8,12 @@
 
 / {
 	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				erase-block-size = <2048>;
+			};
+		};
+
 		spi2: spi@40003800 {
 			compatible = "st,stm32-spi-fifo";
 			#address-cells = <1>;

--- a/dts/arm/st/f0/stm32f072.dtsi
+++ b/dts/arm/st/f0/stm32f072.dtsi
@@ -8,6 +8,12 @@
 
 / {
 	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				erase-block-size = <2048>;
+			};
+		};
+
 		pinctrl: pin-controller@48000000 {
 
 			gpioe: gpio@48001000 {

--- a/dts/arm/st/f0/stm32f091.dtsi
+++ b/dts/arm/st/f0/stm32f091.dtsi
@@ -8,6 +8,12 @@
 
 / {
 	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				erase-block-size = <2048>;
+			};
+		};
+
 		timers2: timers@40000000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40000000 0x400>;

--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -4,6 +4,6 @@ sample:
   name: Flash shell
 tests:
   test:
-    platform_whitelist: 96b_carbon frdm_k64f frdm_kw41z frdm_kl25z
+    platform_whitelist: 96b_carbon frdm_k64f frdm_kw41z frdm_kl25z nucleo_f746zg
     tags: flash shell
     harness: keyboard

--- a/samples/subsys/nvs/src/main.c
+++ b/samples/subsys/nvs/src/main.c
@@ -216,6 +216,13 @@ void main(void)
 				}
 				sys_reboot(0);
 			}
+		} else {
+			printk("Reboot counter reached max value.\n");
+			printk("Reset to 0 and exit test.\n");
+			reboot_counter = 0;
+			nvs_write(&fs, RBT_CNT_ID, &reboot_counter,
+			  sizeof(reboot_counter));
+			break;
 		}
 	}
 }


### PR DESCRIPTION
These commits intent to increase flash testing coverage on STM32 socs.
Additionally fix a bug in nvs sample.

Fixes part of STM32 related flash non covered files in #12860.