### PR TITLE
samples/drivers/counter/alarm: Fix YAML schema failure

### DIFF
--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -10,7 +10,6 @@ tests:
         ordered: true
         regex:
             - "Counter alarm sample"
-            -
             - "Set alarm in 2 sec"
             - "!!! Alarm !!!"
             - "Now: 2"


### PR DESCRIPTION
On my build host (where apparently the Python has a different version
of yaml than CI) this test is producing schema faiulres from the YAML:

    E: samples/drivers/counter/alarm/sample.yaml: can't load (skipping):
       <SchemaError: error code 2: Schema validation failed:
     - Value 'None' is not of type 'str'.
       Path: '/tests/test/harness_config/regex/1'.: Path: '/'>

The bug seems to be that the regex must be a list of strings, and the
empty list element is being parsed as a python None.  Just remove,
presumably the intent was an empty string, which is a noop in a regex
anyway.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>