### PR TITLE
sanitycheck: do not overide OVERLAY_CONFIG

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -19,6 +19,10 @@ if(CONF_FILE)
 string(REPLACE " " ";" CONF_FILE_AS_LIST "${CONF_FILE}")
 endif()
 
+if(OVERLAY_CONFIG)
+  string(REPLACE " " ";" OVERLAY_CONFIG_AS_LIST "${OVERLAY_CONFIG}")
+endif()
+
 set(ENV{srctree}            ${ZEPHYR_BASE})
 set(ENV{KERNELVERSION}      ${KERNELVERSION})
 set(ENV{KCONFIG_CONFIG}     ${DOTCONFIG})
@@ -82,7 +86,7 @@ set(
   merge_config_files
   ${BOARD_DEFCONFIG}
   ${CONF_FILE_AS_LIST}
-  ${OVERLAY_CONFIG}
+  ${OVERLAY_CONFIG_AS_LIST}
   ${EXTRA_KCONFIG_OPTIONS_FILE}
   ${config_files}
 )

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1258,9 +1258,20 @@ class MakeGenerator:
             by execute() will be keyed by its .name field.
         """
         args = ti.test.extra_args[:]
+
+        # merge overlay files into one variable
+        overlays = ""
+        idx = 0
+        for a in args:
+            m = re.search('OVERLAY_CONFIG="(.*)"', a)
+            if m:
+                overlays += m.group(1)
+                del args[idx]
+                idx += 1
+
         if len(ti.test.extra_configs) > 0 or options.coverage:
-            args.append("OVERLAY_CONFIG=%s" %
-                        os.path.join(ti.outdir, "overlay.conf"))
+            args.append("OVERLAY_CONFIG=\"%s %s\"" %(overlays,
+                        os.path.join(ti.outdir, "overlay.conf")))
 
         if ti.test.type == "unit" and options.enable_coverage:
             args.append("COVERAGE=1")


### PR DESCRIPTION
We have been overriding OVERLAY_CONFIG coming from tests. Concat all
files and create one variable that we pass to kconfig as list.

Fixes #13320