### PR TITLE
Arch arm core fix fault report nxp mpu

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -112,7 +112,7 @@ config FLASH_BASE_ADDRESS
 	hex "Flash Base Address"
 	default $(dt_hex_val,DT_FLASH_BASE_ADDRESS) if (XIP && ARM) || !ARM
 	help
-	  This option specifies the base address of the flash on the board.  It is
+	  This option specifies the base address of the flash on the board. It is
 	  normally set by the board's defconfig file and the user should generally
 	  avoid modifying it via the menu configuration.
 

--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -198,6 +198,11 @@ static int _MemoryFaultIsRecoverable(NANO_ESF *esf)
 /* HardFault is used for all fault conditions on ARMv6-M. */
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 
+#if defined(CONFIG_MPU_STACK_GUARD) || defined(CONFIG_USERSPACE)
+u32_t z_check_thread_stack_fail(const u32_t fault_addr,
+	const u32_t psp);
+#endif /* CONFIG_MPU_STACK_GUARD || defined(CONFIG_USERSPACE) */
+
 /**
  *
  * @brief Dump MPU fault information
@@ -209,11 +214,13 @@ static int _MemoryFaultIsRecoverable(NANO_ESF *esf)
 static u32_t _MpuFault(NANO_ESF *esf, int fromHardFault)
 {
 	u32_t reason = _NANO_ERR_HW_EXCEPTION;
+	u32_t mmfar = -EINVAL;
 
 	PR_FAULT_INFO("***** MPU FAULT *****\n");
 
 	if ((SCB->CFSR & SCB_CFSR_MSTKERR_Msk) != 0) {
-		PR_FAULT_INFO("  Stacking error\n");
+		PR_FAULT_INFO("  Stacking error (context area might be"
+			" not valid)\n");
 	}
 	if ((SCB->CFSR & SCB_CFSR_MUNSTKERR_Msk) != 0) {
 		PR_FAULT_INFO("  Unstacking error\n");
@@ -228,7 +235,7 @@ static u32_t _MpuFault(NANO_ESF *esf, int fromHardFault)
 		 * Software must follow this sequence because another higher
 		 * priority exception might change the MMFAR value.
 		 */
-		u32_t mmfar = SCB->MMFAR;
+		mmfar = SCB->MMFAR;
 
 		if ((SCB->CFSR & SCB_CFSR_MMARVALID_Msk) != 0) {
 			PR_EXC("  MMFAR Address: 0x%x\n", mmfar);
@@ -236,32 +243,6 @@ static u32_t _MpuFault(NANO_ESF *esf, int fromHardFault)
 				/* clear SCB_MMAR[VALID] to reset */
 				SCB->CFSR &= ~SCB_CFSR_MMARVALID_Msk;
 			}
-#if defined(CONFIG_HW_STACK_PROTECTION)
-			/* When stack protection is enabled, we need to see
-			 * if the memory violation error is a stack corruption.
-			 * For that we investigate the address fail.
-			 */
-			struct k_thread *thread = _current;
-			u32_t guard_start;
-			if (thread != NULL) {
-#if defined(CONFIG_USERSPACE)
-				guard_start =
-					thread->arch.priv_stack_start ?
-					(u32_t)thread->arch.priv_stack_start :
-					(u32_t)thread->stack_obj;
-#else
-				guard_start = thread->stack_info.start;
-#endif
-				if (mmfar >= guard_start &&
-					mmfar < guard_start +
-					MPU_GUARD_ALIGN_AND_SIZE) {
-					/* Thread stack corruption */
-					reason = _NANO_ERR_STACK_CHK_FAIL;
-				}
-			}
-#else
-		(void)mmfar;
-#endif /* CONFIG_HW_STACK_PROTECTION */
 		}
 	}
 	if ((SCB->CFSR & SCB_CFSR_IACCVIOL_Msk) != 0) {
@@ -273,6 +254,61 @@ static u32_t _MpuFault(NANO_ESF *esf, int fromHardFault)
 			"  Floating-point lazy state preservation error\n");
 	}
 #endif /* !defined(CONFIG_ARMV7_M_ARMV8_M_FP) */
+
+	/* When stack protection is enabled, we need to assess
+	 * if the memory violation error is a stack corruption.
+	 *
+	 * By design, being a Stacking MemManage fault is a necessary
+	 * and sufficient condition for a thread stack corruption.
+	 */
+	if (SCB->CFSR & SCB_CFSR_MSTKERR_Msk) {
+#if defined(CONFIG_MPU_STACK_GUARD) || defined(CONFIG_USERSPACE)
+		/* MemManage Faults are always banked between security
+		 * states. Therefore, we can safely assume the fault
+		 * originated from the same security state.
+		 *
+		 * As we only assess thread stack corruption, we only
+		 * process the error further if the stack frame is on
+		 * PSP. For always-banked MemManage Fault, this is
+		 * equivalent to inspecting the RETTOBASE flag.
+		 */
+		if (SCB->ICSR & SCB_ICSR_RETTOBASE_Msk) {
+			u32_t min_stack_ptr = z_check_thread_stack_fail(mmfar,
+				((u32_t) &esf[0]));
+
+			if (min_stack_ptr) {
+				/* When MemManage Stacking Error has occurred,
+				 * the stack context frame might be corrupted
+				 * but the stack pointer may have actually
+				 * descent below the allowed (thread) stack
+				 * area. We may face a problem with un-stacking
+				 * the frame, upon the exception return, if we
+				 * do not have sufficient access permissions to
+				 * read the corrupted stack frame. Therefore,
+				 * we manually force the stack pointer to the
+				 * lowest allowed position, inside the thread's
+				 * stack.
+				 *
+				 * The manual adjustment of PSP is safe, as we
+				 * will not be re-scheduling this thread again
+				 * for execution; thread stack corruption is a
+				 * fatal error and a thread that corrupted its
+				 * stack needs to be aborted.
+				 */
+				__set_PSP(min_stack_ptr);
+
+				reason = _NANO_ERR_STACK_CHK_FAIL;
+			} else {
+				__ASSERT(0,
+					"Stacking error not a stack fail\n");
+			}
+		}
+#else
+	(void)mmfar;
+	__ASSERT(0,
+		"Stacking error without stack guard / User-mode support\n");
+#endif /* CONFIG_MPU_STACK_GUARD || CONFIG_USERSPACE */
+	}
 
 	/* clear MMFSR sticky bits */
 	SCB->CFSR |= SCB_CFSR_MEMFAULTSR_Msk;

--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -289,6 +289,13 @@ static u32_t _MpuFault(NANO_ESF *esf, int fromHardFault)
 				 * lowest allowed position, inside the thread's
 				 * stack.
 				 *
+				 * Note:
+				 * The PSP will normally be adjusted in a tail-
+				 * chained exception performing context switch,
+				 * after aborting the corrupted thread. The
+				 * adjustment, here, is required as tail-chain
+				 * cannot always be guaranteed.
+				 *
 				 * The manual adjustment of PSP is safe, as we
 				 * will not be re-scheduling this thread again
 				 * for execution; thread stack corruption is a
@@ -437,6 +444,16 @@ static int _BusFault(NANO_ESF *esf, int fromHardFault)
 						 * Therefore, we manually force
 						 * the stack pointer to the
 						 * lowest allowed position.
+						 *
+						 * Note:
+						 * The PSP will normally be
+						 * adjusted in a tail-chained
+						 * exception performing context
+						 * switch, after aborting the
+						 * corrupted thread. Here, the
+						 * adjustment is required as
+						 * tail-chain cannot always be
+						 * guaranteed.
 						 */
 						__set_PSP(min_stack_ptr);
 

--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -360,10 +360,6 @@ static int _BusFault(NANO_ESF *esf, int fromHardFault)
 				SCB->CFSR &= ~SCB_CFSR_BFARVALID_Msk;
 			}
 		}
-		/* it's possible to have both a precise and imprecise fault */
-		if ((SCB->CFSR & SCB_CFSR_IMPRECISERR_Msk) != 0) {
-			PR_FAULT_INFO("  Imprecise data bus error\n");
-		}
 	}
 	if (SCB->CFSR & SCB_CFSR_IMPRECISERR_Msk) {
 		PR_FAULT_INFO("  Imprecise data bus error\n");

--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -396,13 +396,17 @@ static u32_t _UsageFault(const NANO_ESF *esf)
 	}
 #if defined(CONFIG_ARMV8_M_MAINLINE)
 	if ((SCB->CFSR & SCB_CFSR_STKOF_Msk) != 0) {
-		PR_FAULT_INFO("  Stack overflow\n");
-#if defined(CONFIG_HW_STACK_PROTECTION)
-		/* Stack Overflows are reported as stack
-		 * corruption errors.
+		PR_FAULT_INFO("  Stack overflow (context area not valid)\n");
+#if defined(CONFIG_BUILTIN_STACK_GUARD)
+		/* Stack Overflows are always reported as stack corruption
+		 * errors. Note that the built-in stack overflow mechanism
+		 * prevents the context area to be loaded on the stack upon
+		 * UsageFault exception entry. As a result, we cannot rely
+		 * on the reported faulty instruction address, to determine
+		 * the instruction that triggered the stack overflow.
 		 */
 		reason = _NANO_ERR_STACK_CHK_FAIL;
-#endif /* CONFIG_HW_STACK_PROTECTION */
+#endif /* CONFIG_BUILTIN_STACK_GUARD */
 	}
 #endif /* CONFIG_ARMV8_M_MAINLINE */
 	if ((SCB->CFSR & SCB_CFSR_NOCP_Msk) != 0) {

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -270,18 +270,16 @@ void test_fatal(void)
 	 * once.
 	 */
 
-#ifndef CONFIG_CPU_HAS_NXP_MPU /* FIXME #7706 */
 	TC_PRINT("test stack HW-based overflow - supervisor 1\n");
 	check_stack_overflow(stack_hw_overflow, 0);
 
 	TC_PRINT("test stack HW-based overflow - supervisor 2\n");
 	check_stack_overflow(stack_hw_overflow, 0);
-#endif /* CONFIG_CPU_HAS_NXP_MPU */
 #endif /* CONFIG_HW_STACK_PROTECTION */
 
 #ifdef CONFIG_USERSPACE
 
-#if !defined(CONFIG_ARM) && !defined(CONFIG_ARC) /* FIXME #13341 #13342 */
+#if !defined(CONFIG_ARC) /* FIXME #13341 */
 	TC_PRINT("test stack HW-based overflow - user 1\n");
 	check_stack_overflow(stack_hw_overflow, K_USER);
 


### PR DESCRIPTION
Fixes #7706 
Fixes #13342 
Closes #13432 

This PR
- investigates stack corruptions, not only or precise memory violations, but also on stacking errors
-  refactors fault.c, so the assessment of stack fail is moved to thread.c, as it accesses kernel structures,
- allows reporting thread stack corruption for user threads stacks,
- improves error messages and inline documentation related to ARM memory faults,
