### PR TITLE
x86: clear EFLAGS on double fault

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -446,6 +446,7 @@ static FUNC_NORETURN __used void _df_handler_top(void)
 	_main_tss.ss = DATA_SEG;
 	_main_tss.eip = (u32_t)_df_handler_bottom;
 	_main_tss.cr3 = (u32_t)X86_MMU_PDPT;
+	_main_tss.eflags = 0;
 
 	/* NT bit is set in EFLAGS so we will task switch back to _main_tss
 	 * and run _df_handler_bottom


### PR DESCRIPTION
In the event of a double fault, we do a HW task switch to
a special _df_tss hardware task which resets the stack
pointer to the interrupt stack and otherwise restores
the main hardware task to a runnable state so that
_df_handler_bottom() can run.

However, we need to make sure that _df_handler_bottom()
runs with interrupts locked, otherwise another IRQ could
corrupt the interrupt stack resulting in undefined
behavior.

We have very little stack space to work with in this
context, just zero it. It's a fatal error for the thread
in any event.

Fixes: #7291

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>