### PR TITLE
x86 stack overflow and test case improvements

### DIFF
--- a/arch/x86/core/excstub.S
+++ b/arch/x86/core/excstub.S
@@ -107,9 +107,22 @@ SECTION_FUNC(TEXT, _exception_enter)
 	pushl	%ebx
 	pushl	%ebp
 
+#ifdef CONFIG_USERSPACE
+	/* Test if interrupted context was in ring 3 */
+	testb	$3, 36(%esp)
+	jz 1f
+	/* It was. The original stack pointer is on the stack 44 bytes
+	 * from the current top
+	 */
+	pushl	44(%esp)
+	jmp 2f
+1:
+#endif
 	leal	44(%esp), %eax   /* Calculate ESP before interrupt occurred */
 	pushl	%eax             /* Save calculated ESP */
-
+#ifdef CONFIG_USERSPACE
+2:
+#endif
 	/* ESP is pointing to the ESF at this point */
 
 #if defined(CONFIG_FP_SHARING)

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -229,17 +229,10 @@ FUNC_NORETURN void _arch_syscall_oops(void *ssf_ptr)
 }
 
 #ifdef CONFIG_X86_KERNEL_OOPS
-/* The reason code gets pushed onto the stack right before the exception is
- * triggered, so it would be after the nano_esf data
- */
-struct oops_esf {
-	NANO_ESF nano_esf;
-	unsigned int reason;
-};
-
-FUNC_NORETURN void _do_kernel_oops(const struct oops_esf *esf)
+FUNC_NORETURN void _do_kernel_oops(const NANO_ESF *esf)
 {
-	_NanoFatalErrorHandler(esf->reason, &esf->nano_esf);
+	u32_t *stack_ptr = (u32_t *)esf->esp;
+	_NanoFatalErrorHandler(*stack_ptr, esf);
 }
 
 extern void (*_kernel_oops_handler)(void);


### PR DESCRIPTION
Fixes some problems on x86:

- User mode stack overflows were not being reported as such
- Stack corruption could cause a kernel crash while unwinding it
- Incorrect reporting of faulting stack pointer on exception

The associated test case has been improved to test this scenario.
ARM and ARC also have the first issue, I filed #13342 and #13341 

Fixes: #13413 