### PR TITLE
net: lwm2m: fix rendering of zero value float32/64

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_util.c
+++ b/subsys/net/lib/lwm2m/lwm2m_util.c
@@ -20,6 +20,12 @@ int lwm2m_f32_to_b32(float32_value_t *f32, u8_t *b32, size_t len)
 		return -EINVAL;
 	}
 
+	/* handle zero value special case */
+	if (f32->val1 == 0 && f32->val2 == 0) {
+		memset(b32, 0, len);
+		return 0;
+	}
+
 	v = f32->val1;
 	/* sign handled later */
 	if (v < 0) {
@@ -94,6 +100,12 @@ int lwm2m_f64_to_b64(float64_value_t *f64, u8_t *b64, size_t len)
 
 	if (len != 8) {
 		return -EINVAL;
+	}
+
+	/* handle zero value special case */
+	if (f64->val1 == 0LL && f64->val2 == 0LL) {
+		memset(b64, 0, len);
+		return 0;
 	}
 
 	v = f64->val1;


### PR DESCRIPTION
Zero is a special value in the binary32/64 format.  It has all zero
bits (sign=0, exponent=0 and fraction=0).

Handle this special case explicitly instead of trying to encode
in binary format which results in an incorrect value of 0.5.

Signed-off-by: Michael Scott <mike@foundries.io>