### PR TITLE
doc: dts: bindings: Fix a spell mistake

### DIFF
--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -68,6 +68,6 @@ properties:
 # name instead of controller generic name, for instance _CS_GPIO_ instead
 # of _GPIOS_
 
-# "type" attribute is currenty not used.
+# "type" attribute is currently not used.
 
 ...


### PR DESCRIPTION
Fix a spell mistake in device node yaml template.

Signed-off-by: Song Qiang <songqiang1304521@gmail.com>