### PR TITLE
soc: arm: nrf52: Fix CONFIG_SYS_POWER_MANAGEMENT exclusion

### DIFF
--- a/soc/arm/nordic_nrf/nrf51/soc_power.h
+++ b/soc/arm/nordic_nrf/nrf51/soc_power.h
@@ -14,6 +14,8 @@
 extern "C" {
 #endif
 
+#ifdef CONFIG_SYS_POWER_MANAGEMENT
+
 /*
  * Power state map:
  * SYS_POWER_STATE_DEEP_SLEEP: System OFF
@@ -28,6 +30,8 @@ void sys_set_power_state(enum power_states state);
  * @brief Do any SoC or architecture specific post ops after low power states.
  */
 void sys_power_state_post_ops(enum power_states state);
+
+#endif /* CONFIG_SYS_POWER_MANAGEMENT */
 
 #ifdef __cplusplus
 }

--- a/soc/arm/nordic_nrf/nrf52/soc_power.h
+++ b/soc/arm/nordic_nrf/nrf52/soc_power.h
@@ -14,6 +14,8 @@
 extern "C" {
 #endif
 
+#ifdef CONFIG_SYS_POWER_MANAGEMENT
+
 /*
  * Power state map:
  * SYS_POWER_STATE_DEEP_SLEEP: System OFF
@@ -28,6 +30,8 @@ void sys_set_power_state(enum power_states state);
  * @brief Do any SoC or architecture specific post ops after low power states.
  */
 void sys_power_state_post_ops(enum power_states state);
+
+#endif /* CONFIG_SYS_POWER_MANAGEMENT */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This commit fixes compile warning with CONFIG_SYS_POWER_MANAGEMENT=n.
For example, MCUboot disables CONFIG_SYS_POWER_MANAGEMENT by default.