### PR TITLE
scripts/dts cleanups, part 5

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -198,39 +198,39 @@ def extract_node_include_info(reduced, root_node_address, sub_node_address,
                         extract_property(
                             node_compat, sub_node_address, k, v, None)
 
-def dict_merge(parent, fname, dct, merge_dct):
+def dict_merge(parent, fname, to_dict, from_dict):
     # from https://gist.github.com/angstwad/bf22d1822c38a92ec0a9
 
     """ Recursive dict merge. Inspired by :meth:``dict.update()``, instead of
     updating only top-level keys, dict_merge recurses down into dicts nested
-    to an arbitrary depth, updating keys. The ``merge_dct`` is merged into
-    ``dct``.
+    to an arbitrary depth, updating keys. The ``from_dict`` is merged into
+    ``to_dict``.
     :param parent: parent tuple key
     :param fname: yaml file being processed
-    :param dct: dict onto which the merge is executed
-    :param merge_dct: dct merged into dct
+    :param to_dict: dict onto which the merge is executed
+    :param from_dict: dictionary merged into to_dict
     :return: None
     """
-    for k, v in merge_dct.items():
-        if (k in dct and isinstance(dct[k], dict)
-                and isinstance(merge_dct[k], Mapping)):
-            dict_merge(k, fname, dct[k], merge_dct[k])
+    for k, v in from_dict.items():
+        if (k in to_dict and isinstance(to_dict[k], dict)
+                and isinstance(from_dict[k], dict)):
+            dict_merge(k, fname, to_dict[k], from_dict[k])
         else:
-            dct[k] = merge_dct[k]
+            to_dict[k] = from_dict[k]
 
             # Warn when overriding a property and changing its value...
-            if (k in dct and dct[k] != merge_dct[k] and
+            if (k in to_dict and to_dict[k] != from_dict[k] and
                 # ...unless it's the 'title', 'description', or 'version'
                 # property. These are overriden deliberately.
                 not k in {'title', 'version', 'description'} and
                 # Also allow the category to be changed from 'optional' to
                 # 'required' without a warning
-                not (k == "category" and dct[k] == "optional" and
-                     merge_dct[k] == "required")):
+                not (k == "category" and to_dict[k] == "optional" and
+                     from_dict[k] == "required")):
 
                 print("extract_dts_includes.py: {}('{}') merge of property "
                       "'{}': '{}' overwrites '{}'"
-                      .format(fname, parent, k, merge_dct[k], dct[k]))
+                      .format(fname, parent, k, from_dict[k], to_dict[k]))
 
 
 def merge_included_bindings(fname, node):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -419,8 +419,7 @@ def yaml_include(loader, node):
         return [load_binding_file(fname)
                 for fname in loader.construct_sequence(node)]
 
-    print("Error: unrecognised node type in !include statement")
-    raise yaml.constructor.ConstructorError
+    yaml_inc_error("Error: unrecognised node type in !include statement")
 
 
 def load_binding_file(fname):
@@ -432,17 +431,21 @@ def load_binding_file(fname):
                  if os.path.basename(filepath) == os.path.basename(fname)]
 
     if not filepaths:
-        print("Error: unknown file name '{}' in !include statement"
-              .format(fname))
-        raise yaml.constructor.ConstructorError
+        yaml_inc_error("Error: unknown file name '{}' in !include statement"
+                       .format(fname))
 
     if len(filepaths) > 1:
-        print("Error: multiple candidates for file name '{}' in !include "
-              "statement: {}".format(fname, filepaths))
-        raise yaml.constructor.ConstructorError
+        yaml_inc_error("Error: multiple candidates for file name '{}' in "
+                       "!include statement: {}".format(fname, filepaths))
 
     with open(filepaths[0], 'r', encoding='utf-8') as f:
         return yaml.load(f)
+
+
+def yaml_inc_error(msg):
+    # Helper for reporting errors in the !include implementation
+
+    raise yaml.constructor.ConstructorError(None, None, msg)
 
 
 def generate_node_definitions():

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -449,13 +449,12 @@ def write_header(f):
 
 
 def load_bindings(root, yaml_dirs):
-    compatibles = all_compats(root)
+    extract.globals.bindings, extract.globals.bus_bindings, \
+    extract.globals.bindings_compat = \
+        Bindings.bindings(all_compats(root), yaml_dirs)
 
-    (bindings, bus, bindings_compat) = Bindings.bindings(compatibles, yaml_dirs)
-    if not bindings:
-        raise Exception("Missing YAML information.  Check YAML sources")
-
-    return (bindings, bus, bindings_compat)
+    if not extract.globals.bindings:
+        raise Exception("No bindings found in '{}'".format(yaml_dirs))
 
 
 def generate_node_definitions():
@@ -513,8 +512,7 @@ def main():
     create_aliases(root)
     create_chosen(root)
 
-    (extract.globals.bindings, extract.globals.bus_bindings,
-     extract.globals.bindings_compat) = load_bindings(root, args.yaml)
+    load_bindings(root, args.yaml)
 
     generate_node_definitions()
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -31,13 +31,10 @@ from extract.default import default
 
 
 class Bindings(yaml.Loader):
-    ##
-    # Files that are already included.
-    # Must be reset on the load of every new binding
-    _included = []
-
     @classmethod
     def bindings(cls, dts_compats):
+        global included
+
         compat_to_binding = {}
         # Maps buses to dictionaries that map compats to YAML nodes
         bus_to_binding = defaultdict(dict)
@@ -70,7 +67,7 @@ class Bindings(yaml.Loader):
                 compats.append(compat)
 
             with open(file, 'r', encoding='utf-8') as yf:
-                cls._included = []
+                included = []
                 binding = merge_included_bindings(file, yaml.load(yf, cls))
 
                 if 'parent' in binding:
@@ -82,11 +79,11 @@ class Bindings(yaml.Loader):
 
     def __init__(self, stream):
         filepath = os.path.realpath(stream.name)
-        if filepath in self._included:
+        if filepath in included:
             print("Error: circular inclusion for file name '{}'".
                   format(stream.name))
             raise yaml.constructor.ConstructorError
-        self._included.append(filepath)
+        included.append(filepath)
         super(Bindings, self).__init__(stream)
         Bindings.add_constructor('!include', Bindings._include)
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -198,23 +198,15 @@ def extract_node_include_info(reduced, root_node_address, sub_node_address,
                         extract_property(
                             node_compat, sub_node_address, k, v, None)
 
-def dict_merge(parent, fname, to_dict, from_dict):
-    # from https://gist.github.com/angstwad/bf22d1822c38a92ec0a9
+def merge_properties(parent, fname, to_dict, from_dict):
+    # Recursively merges the 'from_dict' dictionary into 'to_dict', to
+    # implement !include. 'parent' is the current parent key being looked at.
+    # 'fname' is the top-level .yaml file.
 
-    """ Recursive dict merge. Inspired by :meth:``dict.update()``, instead of
-    updating only top-level keys, dict_merge recurses down into dicts nested
-    to an arbitrary depth, updating keys. The ``from_dict`` is merged into
-    ``to_dict``.
-    :param parent: parent tuple key
-    :param fname: yaml file being processed
-    :param to_dict: dict onto which the merge is executed
-    :param from_dict: dictionary merged into to_dict
-    :return: None
-    """
     for k, v in from_dict.items():
         if (k in to_dict and isinstance(to_dict[k], dict)
-                and isinstance(from_dict[k], dict)):
-            dict_merge(k, fname, to_dict[k], from_dict[k])
+                         and isinstance(from_dict[k], dict)):
+            merge_properties(k, fname, to_dict[k], from_dict[k])
         else:
             to_dict[k] = from_dict[k]
 
@@ -243,7 +235,7 @@ def merge_included_bindings(fname, node):
     if 'inherits' in node:
         for inherited in node.pop('inherits'):
             inherited = merge_included_bindings(fname, inherited)
-            dict_merge(None, fname, inherited, node)
+            merge_properties(None, fname, inherited, node)
             node = inherited
 
     return node

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -59,24 +59,23 @@ class Bindings(yaml.Loader):
         raise yaml.constructor.ConstructorError
 
     def _extract_file(self, filename):
-        filepaths = [filepath for filepath in binding_files if filepath.endswith(filename)]
-        if len(filepaths) == 0:
-            print("Error: unknown file name '{}' in !include statement".
-                  format(filename))
+        filepaths = [
+            filepath for filepath in binding_files
+            if os.path.basename(filepath) == os.path.basename(filename)]
+
+        if not filepaths:
+            print("Error: unknown file name '{}' in !include statement"
+                  .format(filename))
             raise yaml.constructor.ConstructorError
-        elif len(filepaths) > 1:
-            # multiple candidates for filename
-            files = []
-            for filepath in filepaths:
-                if os.path.basename(filename) == os.path.basename(filepath):
-                    files.append(filepath)
-            if len(files) > 1:
-                print("Error: multiple candidates for file name '{}' in !include statement".
-                      format(filename), filepaths)
-                raise yaml.constructor.ConstructorError
-            filepaths = files
+
+        if len(filepaths) > 1:
+            print("Error: multiple candidates for file name '{}' in !include "
+                  "statement: {}".format(filename, filepaths))
+            raise yaml.constructor.ConstructorError
+
         with open(filepaths[0], 'r', encoding='utf-8') as f:
             return yaml.load(f, Bindings)
+
 
 def extract_bus_name(node_address, def_label):
     label = def_label + '_BUS_NAME'

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -448,7 +448,7 @@ def write_header(f):
     f.write('#endif\n')
 
 
-def load_yaml_descriptions(root, yaml_dirs):
+def load_bindings(root, yaml_dirs):
     compatibles = all_compats(root)
 
     (bindings, bus, bindings_compat) = Bindings.bindings(compatibles, yaml_dirs)
@@ -514,7 +514,7 @@ def main():
     create_chosen(root)
 
     (extract.globals.bindings, extract.globals.bus_bindings,
-     extract.globals.bindings_compat) = load_yaml_descriptions(root, args.yaml)
+     extract.globals.bindings_compat) = load_bindings(root, args.yaml)
 
     generate_node_definitions()
 


### PR DESCRIPTION
Most significant change is getting rid of the `Bindings` class, replacing it with plain functions. There's less hoops before getting to the meat of the code now too.

`Bindings` was only used to implement `!include`, but it was pretty difficult to see in the old code. `pyyaml` supports implementing a custom tag with a plain function.