### PR TITLE
drivers: modem: receiver: uart fixes and switch to ring buffer

### DIFF
--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -17,6 +17,7 @@ config MODEM_RECEIVER
 	bool "Enable modem receiver helper driver"
 	depends on SERIAL_SUPPORT_INTERRUPT
 	select UART_INTERRUPT_DRIVEN
+	select RING_BUFFER
 	help
 	  This driver allows modem drivers to communicate over UART with custom
 	  defined protocols. Driver doesn't inspect received data and all

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -174,7 +174,8 @@ int mdm_receiver_register(struct mdm_receiver_context *ctx,
 
 	ctx->uart_dev = device_get_binding(uart_dev_name);
 	if (!ctx->uart_dev) {
-		return -ENOENT;
+		LOG_ERR("Binding failure for uart: %s", uart_dev_name);
+		return -ENODEV;
 	}
 
 	/* k_pipe is setup later in mdm_receiver_flush() */

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -177,19 +177,19 @@ int mdm_receiver_recv(struct mdm_receiver_context *ctx,
 int mdm_receiver_send(struct mdm_receiver_context *ctx,
 		      const u8_t *buf, size_t size)
 {
+	int written;
+
 	if (!ctx) {
 		return -EINVAL;
 	}
 
-	while (size)  {
-		int written;
-
+	while (size) {
 		written = uart_fifo_fill(ctx->uart_dev,
 					 (const u8_t *)buf, size);
 		if (written < 0) {
 			/* error */
 			uart_irq_tx_disable(ctx->uart_dev);
-			return written;
+			return -EIO;
 		} else if (written < size) {
 			k_yield();
 		}

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -83,9 +83,8 @@ static void mdm_receiver_flush(struct mdm_receiver_context *ctx)
 {
 	u8_t c;
 
-	if (!ctx) {
-		return;
-	}
+	__ASSERT(ctx, "invalid ctx");
+	__ASSERT(ctx->uart_dev, "invalid ctx device");
 
 	while (uart_fifo_read(ctx->uart_dev, &c, 1) > 0) {
 		continue;
@@ -142,9 +141,7 @@ static void mdm_receiver_isr(struct device *uart_dev)
  */
 static void mdm_receiver_setup(struct mdm_receiver_context *ctx)
 {
-	if (!ctx) {
-		return;
-	}
+	__ASSERT(ctx, "invalid ctx");
 
 	uart_irq_rx_disable(ctx->uart_dev);
 	uart_irq_tx_disable(ctx->uart_dev);

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -174,26 +174,13 @@ int mdm_receiver_recv(struct mdm_receiver_context *ctx,
 int mdm_receiver_send(struct mdm_receiver_context *ctx,
 		      const u8_t *buf, size_t size)
 {
-	int written;
-
 	if (!ctx) {
 		return -EINVAL;
 	}
 
-	while (size) {
-		written = uart_fifo_fill(ctx->uart_dev,
-					 (const u8_t *)buf, size);
-		if (written < 0) {
-			/* error */
-			uart_irq_tx_disable(ctx->uart_dev);
-			return -EIO;
-		} else if (written < size) {
-			k_yield();
-		}
-
-		size -= written;
-		buf += written;
-	}
+	do {
+		uart_poll_out(ctx->uart_dev, *buf++);
+	} while (size--);
 
 	return 0;
 }

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -166,8 +166,12 @@ int mdm_receiver_recv(struct mdm_receiver_context *ctx,
 		return -EINVAL;
 	}
 
-	*bytes_read = ring_buf_get(&ctx->rx_rb, buf, size);
+	if (size == 0) {
+		*bytes_read = 0;
+		return 0;
+	}
 
+	*bytes_read = ring_buf_get(&ctx->rx_rb, buf, size);
 	return 0;
 }
 
@@ -176,6 +180,10 @@ int mdm_receiver_send(struct mdm_receiver_context *ctx,
 {
 	if (!ctx) {
 		return -EINVAL;
+	}
+
+	if (size == 0) {
+		return 0;
 	}
 
 	do {
@@ -191,7 +199,7 @@ int mdm_receiver_register(struct mdm_receiver_context *ctx,
 {
 	int ret;
 
-	if (!ctx) {
+	if ((!ctx) || (size == 0)) {
 		return -EINVAL;
 	}
 

--- a/include/drivers/modem/modem_receiver.h
+++ b/include/drivers/modem/modem_receiver.h
@@ -14,8 +14,8 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_RECEIVER_H_
 #define ZEPHYR_INCLUDE_DRIVERS_MODEM_MODEM_RECEIVER_H_
 
-#include <stdlib.h>
 #include <kernel.h>
+#include <ring_buffer.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,9 +25,7 @@ struct mdm_receiver_context {
 	struct device *uart_dev;
 
 	/* rx data */
-	u8_t *uart_pipe_buf;
-	size_t uart_pipe_size;
-	struct k_pipe uart_pipe;
+	struct ring_buf rx_rb;
 	struct k_sem rx_sem;
 
 	/* modem data */

--- a/include/drivers/modem/modem_receiver.h
+++ b/include/drivers/modem/modem_receiver.h
@@ -36,12 +36,52 @@ struct mdm_receiver_context {
 	int   data_rssi;
 };
 
+/**
+ * @brief  Gets receiver context by id.
+ *
+ * @param  id: receiver context id.
+ *
+ * @retval Receiver context or NULL.
+ */
 struct mdm_receiver_context *mdm_receiver_context_from_id(int id);
 
+/**
+ * @brief  Get received data.
+ *
+ * @param  *ctx: receiver context.
+ * @param  *buf: buffer to copy the received data to.
+ * @param  size: buffer size.
+ * @param  *bytes_read: amount of received bytes
+ *
+ * @retval 0 if ok, < 0 if error.
+ */
 int mdm_receiver_recv(struct mdm_receiver_context *ctx,
 		      u8_t *buf, size_t size, size_t *bytes_read);
+
+/**
+ * @brief  Sends the data over specified receiver context.
+ *
+ * @param  *ctx: receiver context.
+ * @param  *buf: buffer with the data to send.
+ * @param  size: the amount of data to send.
+ *
+ * @retval 0 if ok, < 0 if error.
+ */
 int mdm_receiver_send(struct mdm_receiver_context *ctx,
 		      const u8_t *buf, size_t size);
+
+/**
+ * @brief  Registers receiver context.
+ *
+ * @note   Aquires receivers device, and prepares the context to be used.
+ *
+ * @param  *ctx: receiver context to register.
+ * @param  *uart_dev_name: communication device for the receiver context.
+ * @param  *buf: rx buffer to use for received data.
+ * @param  size: rx buffer size.
+ *
+ * @retval 0 if ok, < 0 if error.
+ */
 int mdm_receiver_register(struct mdm_receiver_context *ctx,
 			  const char *uart_dev_name,
 			  u8_t *buf, size_t size);


### PR DESCRIPTION
The modem receiver doesn't work stable enough with `k_pipe`. I experienced data loss, and rx freezes.

After some investigation, it seems like the receiver omits almost every note regarding kernel and uart API usage. Therefore I propose the following modifications:

- Switched to ring buffer from pipe API
> Kernel doesn't allow for an ISR to send or receive data to/from
> a pipe even when there is no attempt to wait for space/data.
- Corrected uart fifo usage, sending is done with `uart_poll_out`
> Likewise, not calling this function from an ISR if uart_irq_tx_ready() returns true may lead to undefined behavior, e.g. infinite interrupt loops.
- Bug: `rx_sem` shall be given back when the buffer|pipe was full and uart data has been flushed|drained
- Correct error code, use `ENODEV `when `device_get_binding` fails
- Added comments and asserts
_To make it easier for others_