### PR TITLE
net: context: can: Fix typo in Kconfig option name

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -146,12 +146,12 @@ int net_context_get(sa_family_t family,
 			if (family != AF_PACKET && family != AF_CAN) {
 				return -EINVAL;
 			}
-		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_RAW) &&
+		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
 			   !IS_ENABLED(CONFIG_NET_SOCKETS_CAN)) {
 			if (family != AF_PACKET) {
 				return -EINVAL;
 			}
-		} else if (!IS_ENABLED(CONFIG_NET_SOCKETS_RAW) &&
+		} else if (!IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
 			   IS_ENABLED(CONFIG_NET_SOCKETS_CAN)) {
 			if (family != AF_CAN) {
 				return -EINVAL;


### PR DESCRIPTION
The option CONFIG_NET_SOCKETS_RAW name was changed to
CONFIG_NET_SOCKETS_PACKET but two checks using the old name
was left to net_context.c

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>