### PR TITLE
net: gptp: Fix pkt allocation with debugs enabled

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -159,7 +159,6 @@ static struct net_pkt *setup_gptp_frame(struct net_if *iface,
 	pkt = net_pkt_alloc_with_buffer_debug(iface, sizeof(struct gptp_hdr) +
 					      extra_header, AF_UNSPEC, 0,
 					      NET_BUF_TIMEOUT, caller, line);
-	pkt = net_pkt_get_reserve_tx_debug(NET_BUF_TIMEOUT, caller, line);
 #else
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(struct gptp_hdr) +
 					extra_header, AF_UNSPEC, 0,


### PR DESCRIPTION
Commit 44964c735ea ("net/gptp: Switch GPTP to new net_pkt API") changed
the callback used for allocation (from net_pkt_get_reserve_tx to
net_pkt_alloc_with_buffer), but for compilation with
CONFIG_NET_DEBUG_NET_PKT_ALLOC enabled, both callbacks are used
(the first pointer was just overwritten, causing MPU FAULT).

Here is an example:
```
uart:~$ ***** Booting Zephyr OS v1.14.0-rc1-135-ge9b962d0dc *****
[00:00:02.820,007] <inf> eth_sam_phy: common abilities: speed 100 Mb, full duplex
[00:00:02.825,238] <inf> net_config: Initializing network
[00:00:02.825,250] <inf> net_config: IPv4 address: 192.0.2.1
***** MPU FAULT *****
  Data Access Violation
  MMFAR Address: 0x407021
***** Hardware exception *****
Current thread ID = 0x20400e88
Faulting instruction address = 0x40b542
Fatal fault in thread 0x20400e88! Aborting.
[00:00:02.930,033] <inf> net_config: IPv6 address: fe80::fec2:3dff:fe12:aad
[00:00:02.937,860] <inf> net_config: IPv6 address: fe80::fec2:3dff:fe12:aad
***** MPU FAULT *****
  Data Access Violation
  MMFAR Address: 0x407021
***** Hardware exception *****
Current thread ID = 0x2040283c
Faulting instruction address = 0x40b648
Fatal fault in thread 0x2040283c! Aborting.
```