### PR TITLE
settings: Fix default value of flash area ID in Kconfig

### DIFF
--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -65,7 +65,7 @@ config SETTINGS_FCB_MAGIC
 
 config SETTINGS_FCB_FLASH_AREA
 	int "Flash area id used for settings"
-	default 4
+	default $(dt_int_val,DT_FLASH_AREA_STORAGE_ID)
 	depends on SETTINGS && SETTINGS_FCB
 	help
 	  Id of the Flash area where FCB instance used for settings is


### PR DESCRIPTION
Use the value extracted from DT instead of a hardcoded 4, as it is done
in commit 977b292d8072e4024664cf7293d42e532de64cd4 for tests.

The hardcoded value causes a hard fault at start up of the bluetooth/peripheral sample on nrf51_pca10028.