### PR TITLE
boards: nucleo_l4r5zi: Add flash & debug support

### DIFF
--- a/boards/arm/nucleo_l4r5zi/doc/index.rst
+++ b/boards/arm/nucleo_l4r5zi/doc/index.rst
@@ -218,10 +218,28 @@ Ethernet over USB is configured as the default network interface (EEM)
 Programming and Debugging
 *************************
 
-Currently, the usual way of programming and debugging does not
-exist. This will hopefully be added to a future version of the SDK. In
-the meantime, the `STM32 ST-LINK utility`_ program can be used by
-connecting CN1 to your PC and selecting the zephyr.bin file to flash.
+Connect the Nucleo L4R5ZI to your host computer using the USB port.
+Then build and flash an application. Here is an example for the
+:ref:`hello_world` application.
+
+Run a serial host program to connect with your Nucleo board:
+
+.. code-block:: console
+
+   $ minicom -D /dev/ttyACM0
+
+Then build and flash the application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nucleo_l4r5zi
+   :goals: build flash
+
+You should see the following message on the console:
+
+.. code-block:: console
+
+   Hello World! arm
 
 .. _Nucleo L4R5ZI website:
    http://www.st.com/en/evaluation-tools/nucleo-l4r5zi.html

--- a/boards/arm/nucleo_l4r5zi/support/openocd.cfg
+++ b/boards/arm/nucleo_l4r5zi/support/openocd.cfg
@@ -1,0 +1,12 @@
+source [find board/st_nucleo_l4.cfg]
+
+$_TARGETNAME configure -event gdb-attach {
+	echo "Debugger attaching: halting execution"
+	reset halt
+	gdb_breakpoint_override hard
+}
+
+$_TARGETNAME configure -event gdb-detach {
+	echo "Debugger detaching: resuming execution"
+	resume
+}


### PR DESCRIPTION
Following introduction of zephyr sdk0.10 and openocd branch
from from 20190130, stm32l4+ SoC support is now available and
flash and debug operations are available on nucleo_l4r5zi board.

Fixes #12094

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>