### PR TITLE
Add socket CAN dispatcher support

### DIFF
--- a/drivers/can/socket_can_generic.h
+++ b/drivers/can/socket_can_generic.h
@@ -80,6 +80,7 @@ static inline int socket_can_setsockopt(struct device *dev, void *obj,
 					const void *optval, socklen_t optlen)
 {
 	struct socket_can_context *socket_context = dev->driver_data;
+	struct net_context *ctx = obj;
 	int ret;
 
 	if (level != SOL_CAN_RAW && optname != CAN_RAW_FILTER) {
@@ -96,12 +97,22 @@ static inline int socket_can_setsockopt(struct device *dev, void *obj,
 		return -1;
 	}
 
+	net_context_set_filter_id(ctx, ret);
+
 	return 0;
+}
+
+static inline void socket_can_close(struct device *dev, int filter_id)
+{
+	struct socket_can_context *socket_context = dev->driver_data;
+
+	can_detach(socket_context->can_dev, filter_id);
 }
 
 static struct canbus_api socket_can_api = {
 	.iface_api.init = socket_can_iface_init,
 	.send = socket_can_send,
+	.close = socket_can_close,
 	.setsockopt = socket_can_setsockopt,
 };
 

--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -274,6 +274,10 @@ struct net_context {
 	void *offload_context;
 #endif /* CONFIG_NET_OFFLOAD */
 
+#if defined(CONFIG_NET_SOCKETS_CAN)
+	int can_filter_id;
+#endif /* CONFIG_NET_SOCKETS_CAN */
+
 	/** Option values */
 	struct {
 #if defined(CONFIG_NET_CONTEXT_PRIORITY)
@@ -431,6 +435,56 @@ static inline void net_context_set_type(struct net_context *context,
 
 	context->flags |= flag;
 }
+
+/**
+ * @brief Set CAN filter id for this network context.
+ *
+ * @details This function sets the CAN filter id of the context.
+ *
+ * @param context Network context.
+ * @param filter_id CAN filter id
+ */
+#if defined(CONFIG_NET_SOCKETS_CAN)
+static inline void net_context_set_filter_id(struct net_context *context,
+					     int filter_id)
+{
+	NET_ASSERT(context);
+
+	context->can_filter_id = filter_id;
+}
+#else
+static inline void net_context_set_filter_id(struct net_context *context,
+					     int filter_id)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(filter_id);
+}
+#endif
+
+/**
+ * @brief Get CAN filter id for this network context.
+ *
+ * @details This function gets the CAN filter id of the context.
+ *
+ * @param context Network context.
+ *
+ * @return Filter id of this network context
+ */
+#if defined(CONFIG_NET_SOCKETS_CAN)
+static inline int net_context_get_filter_id(struct net_context *context)
+{
+	NET_ASSERT(context);
+
+	return context->can_filter_id;
+}
+#else
+static inline int net_context_get_filter_id(struct net_context *context)
+{
+	ARG_UNUSED(context);
+
+	return -1;
+}
+#endif
 
 /**
  * @brief Get context IP protocol for this network context.

--- a/include/net/socket_can.h
+++ b/include/net/socket_can.h
@@ -65,6 +65,9 @@ struct canbus_api {
 	/** Send a CAN packet by socket */
 	int (*send)(struct device *dev, struct net_pkt *pkt);
 
+	/** Close the related CAN socket */
+	void (*close)(struct device *dev, int filter_id);
+
 	/** Set socket CAN option */
 	int (*setsockopt)(struct device *dev, void *obj, int level, int optname,
 			  const void *optval, socklen_t optlen);

--- a/samples/net/sockets/can/sample.yaml
+++ b/samples/net/sockets/can/sample.yaml
@@ -1,9 +1,15 @@
 common:
   tags: net socket can CAN
   depends_on: can
+  harness: can
+  platform_whitelist: stm32f072b_disco nucleo_l432kc
 sample:
   description: Test BSD sockets CAN support
   name: Socket CAN example
 tests:
-  sample.net.sockets.can:
-    platform_whitelist: stm32f072b_disco nucleo_l432kc
+  sample.net.sockets.can.test_with_one_socket:
+    extra_configs:
+      - CONFIG_NET_SOCKETS_CAN_RECEIVERS=1
+  sample.net.sockets.can.test_with_two_sockets:
+    extra_configs:
+      - CONFIG_NET_SOCKETS_CAN_RECEIVERS=2

--- a/samples/net/sockets/can/src/main.c
+++ b/samples/net/sockets/can/src/main.c
@@ -12,8 +12,8 @@ LOG_MODULE_REGISTER(net_socket_can_sample, LOG_LEVEL_DBG);
 #include <net/socket.h>
 #include <net/socket_can.h>
 
-#define PRIORITY  7
-#define STACKSIZE 750
+#define PRIORITY  k_thread_priority_get(k_current_get())
+#define STACKSIZE 1024
 #define SLEEP_PERIOD K_SECONDS(1)
 
 static k_tid_t tx_tid;
@@ -26,6 +26,18 @@ static k_tid_t rx_tid;
 static K_THREAD_STACK_DEFINE(rx_stack, STACKSIZE);
 static struct k_thread rx_data;
 #endif
+
+#define CLOSE_PERIOD 15
+
+static const struct zcan_filter zfilter = {
+	.id_type = CAN_STANDARD_IDENTIFIER,
+	.rtr = CAN_DATAFRAME,
+	.std_id = 0x1,
+	.rtr_mask = 1,
+	.std_id_mask = CAN_STD_ID_MASK
+};
+
+static struct can_filter filter;
 
 static void tx(int *can_fd)
 {
@@ -57,8 +69,38 @@ static void tx(int *can_fd)
 	}
 }
 
-static void rx(int *can_fd)
+static int create_socket(const struct can_filter *filter)
 {
+	struct sockaddr_can can_addr;
+	int fd, ret;
+
+	fd = socket(AF_CAN, SOCK_RAW, CAN_RAW);
+	if (fd < 0) {
+		LOG_ERR("Cannot create %s CAN socket (%d)", "2nd", fd);
+		return fd;
+	}
+
+	can_addr.can_ifindex = net_if_get_by_iface(
+		net_if_get_first_by_type(&NET_L2_GET_NAME(CANBUS)));
+	can_addr.can_family = PF_CAN;
+
+	ret = bind(fd, (struct sockaddr *)&can_addr, sizeof(can_addr));
+	if (ret < 0) {
+		LOG_ERR("Cannot bind %s CAN socket (%d)", "2nd", -errno);
+		(void)close(fd);
+		return ret;
+	}
+
+	(void)setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, filter,
+			 sizeof(*filter));
+
+	return fd;
+}
+
+static void rx(int *can_fd, int *do_close_period,
+	       const struct can_filter *filter)
+{
+	int close_period = POINTER_TO_INT(do_close_period);
 	int fd = POINTER_TO_INT(can_fd);
 	struct sockaddr_can can_addr;
 	socklen_t addr_len;
@@ -98,19 +140,29 @@ static void rx(int *can_fd)
 		} else {
 			LOG_INF("[%d] EXT Remote message received", fd);
 		}
+
+		if (POINTER_TO_INT(do_close_period) > 0) {
+			close_period--;
+			if (close_period <= 0) {
+				(void)close(fd);
+
+				k_sleep(K_SECONDS(1));
+
+				fd = create_socket(filter);
+				if (fd < 0) {
+					LOG_ERR("Cannot get socket (%d)",
+						-errno);
+					return;
+				}
+
+				close_period = POINTER_TO_INT(do_close_period);
+			}
+		}
 	}
 }
 
 static int setup_socket(void)
 {
-	const struct zcan_filter zfilter = {
-		.id_type = CAN_STANDARD_IDENTIFIER,
-		.rtr = CAN_DATAFRAME,
-		.std_id = 0x1,
-		.rtr_mask = 1,
-		.std_id_mask = CAN_STD_ID_MASK
-	};
-	struct can_filter filter;
 	struct sockaddr_can can_addr;
 	struct net_if *iface;
 	int fd, rx_fd;
@@ -163,38 +215,29 @@ static int setup_socket(void)
 
 	LOG_DBG("Started socket CAN TX thread");
 
+	LOG_INF("1st RX fd %d", fd);
+
 	rx_fd = fd;
 
 #if CONFIG_NET_SOCKETS_CAN_RECEIVERS == 2
-	fd = socket(AF_CAN, SOCK_RAW, CAN_RAW);
-	if (fd < 0) {
-		ret = -errno;
-		LOG_ERR("Cannot create %s CAN socket (%d)", "2nd", ret);
-		fd = rx_fd;
-		goto cleanup;
-	}
+	fd = create_socket(&filter);
+	if (fd >= 0) {
+		rx_tid = k_thread_create(&rx_data, rx_stack,
+					 K_THREAD_STACK_SIZEOF(rx_stack),
+					 (k_thread_entry_t)rx,
+					 INT_TO_POINTER(fd),
+					 INT_TO_POINTER(CLOSE_PERIOD),
+					 &filter, PRIORITY, 0, K_NO_WAIT);
+		if (!rx_tid) {
+			ret = -ENOENT;
+			errno = -ret;
+			LOG_ERR("Cannot create 2nd RX thread!");
+			goto cleanup2;
+		}
 
-	can_addr.can_ifindex = net_if_get_by_iface(iface);
-	can_addr.can_family = PF_CAN;
-
-	ret = bind(fd, (struct sockaddr *)&can_addr, sizeof(can_addr));
-	if (ret < 0) {
-		ret = -errno;
-		LOG_ERR("Cannot bind %s CAN socket (%d)", "2nd", ret);
-		goto cleanup2;
-	}
-
-	setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, &filter, sizeof(filter));
-
-	rx_tid = k_thread_create(&rx_data, rx_stack,
-				 K_THREAD_STACK_SIZEOF(rx_stack),
-				 (k_thread_entry_t)rx, INT_TO_POINTER(fd),
-				 NULL, NULL, PRIORITY, 0, K_NO_WAIT);
-	if (!rx_tid) {
-		ret = -ENOENT;
-		errno = -ret;
-		LOG_ERR("Cannot create 2nd RX thread!");
-		goto cleanup2;
+		LOG_INF("2nd RX fd %d", fd);
+	} else {
+		LOG_ERR("2nd RX not created (%d)", fd);
 	}
 #endif
 
@@ -214,11 +257,14 @@ void main(void)
 {
 	int fd;
 
+	/* Let the device start before doing anything */
+	k_sleep(K_SECONDS(2));
+
 	fd = setup_socket();
 	if (fd < 0) {
 		LOG_ERR("Cannot start CAN application (%d)", fd);
 		return;
 	}
 
-	rx(INT_TO_POINTER(fd));
+	rx(INT_TO_POINTER(fd), NULL, NULL);
 }

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -306,6 +306,10 @@ int net_conn_register(u16_t proto, u8_t family,
 			if (net_sin(local_addr)->sin_addr.s_addr) {
 				flags |= NET_CONN_LOCAL_ADDR_SPEC;
 			}
+		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) &&
+			   local_addr->sa_family == AF_CAN) {
+			memcpy(&conn->local_addr, local_addr,
+			       sizeof(struct sockaddr_can));
 		} else {
 			NET_ERR("Local address family not set");
 			goto error;

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -330,7 +330,8 @@ int net_context_unref(struct net_context *context)
 	net_tcp_unref(context);
 
 	if (context->conn_handler) {
-		if (IS_ENABLED(CONFIG_NET_TCP) || IS_ENABLED(CONFIG_NET_UDP)) {
+		if (IS_ENABLED(CONFIG_NET_TCP) || IS_ENABLED(CONFIG_NET_UDP) ||
+		    IS_ENABLED(CONFIG_NET_SOCKETS_CAN)) {
 			net_conn_unregister(context->conn_handler);
 		}
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1645,6 +1645,7 @@ static enum net_verdict net_context_raw_packet_received(
 static int recv_raw(struct net_context *context,
 		    net_context_recv_cb_t cb,
 		    s32_t timeout,
+		    struct sockaddr *local_addr,
 		    void *user_data)
 {
 	int ret;
@@ -1665,7 +1666,7 @@ static int recv_raw(struct net_context *context,
 
 	ret = net_conn_register(net_context_get_ip_proto(context),
 				net_context_get_family(context),
-				NULL, NULL, 0, 0,
+				NULL, local_addr, 0, 0,
 				net_context_raw_packet_received,
 				user_data,
 				&context->conn_handler);
@@ -1704,10 +1705,16 @@ int net_context_recv(struct net_context *context,
 	} else {
 		if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
 		    net_context_get_family(context) == AF_PACKET) {
-			ret = recv_raw(context, cb, timeout, user_data);
+			ret = recv_raw(context, cb, timeout, NULL, user_data);
 		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) &&
 			   net_context_get_family(context) == AF_CAN) {
-			ret = recv_raw(context, cb, timeout, user_data);
+			struct sockaddr_can local_addr = {
+				.can_family = AF_CAN,
+			};
+
+			ret = recv_raw(context, cb, timeout,
+				       (struct sockaddr *)&local_addr,
+				       user_data);
 			if (ret == -EALREADY) {
 				/* This is perfectly normal for CAN sockets.
 				 * The SocketCAN will dispatch the packet to

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1708,6 +1708,13 @@ int net_context_recv(struct net_context *context,
 		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) &&
 			   net_context_get_family(context) == AF_CAN) {
 			ret = recv_raw(context, cb, timeout, user_data);
+			if (ret == -EALREADY) {
+				/* This is perfectly normal for CAN sockets.
+				 * The SocketCAN will dispatch the packet to
+				 * correct net_context listener.
+				 */
+				ret = 0;
+			}
 		} else {
 			ret = -EPROTOTYPE;
 		}

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -426,9 +426,13 @@ static inline void l3_init(void)
 
 	net_ipv4_autoconf_init();
 
-#if defined(CONFIG_NET_UDP) || defined(CONFIG_NET_TCP)
-	net_conn_init();
-#endif
+	if (IS_ENABLED(CONFIG_NET_UDP) ||
+	    IS_ENABLED(CONFIG_NET_TCP) ||
+	    IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) ||
+	    IS_ENABLED(CONFIG_NET_SOCKETS_CAN)) {
+		net_conn_init();
+	}
+
 	net_tcp_init();
 
 	net_route_init();

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -936,6 +936,11 @@ static void conn_handler_cb(struct net_conn *conn, void *user_data)
 			 ntohs(net_sin(&conn->remote_addr)->sin_port));
 	} else
 #endif
+#ifdef CONFIG_NET_L2_CANBUS
+	if (conn->local_addr.sa_family == AF_CAN) {
+		snprintk(addr_local, sizeof(addr_local), "-");
+	} else
+#endif
 	if (conn->local_addr.sa_family == AF_UNSPEC) {
 		snprintk(addr_local, sizeof(addr_local), "AF_UNSPEC");
 	} else {

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -124,6 +124,14 @@ config NET_SOCKETS_CAN
 	help
 	  The value depends on your network needs.
 
+config NET_SOCKETS_CAN_RECEIVERS
+	int "How many simultaneous SocketCAN receivers are allowed"
+	default 1
+	depends on NET_SOCKETS_CAN
+	help
+	  The value tells how many sockets can receive data from same
+	  Socket-CAN interface.
+
 module = NET_SOCKETS
 module-dep = NET_LOG
 module-str = Log level for BSD sockets compatible API calls

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -22,6 +22,17 @@ LOG_MODULE_REGISTER(net_sock_can, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include "sockets_internal.h"
 
+#define MEM_ALLOC_TIMEOUT K_MSEC(50)
+
+struct can_recv {
+	struct net_if *iface;
+	struct net_context *ctx;
+	canid_t can_id;
+	canid_t can_mask;
+};
+
+static struct can_recv receivers[CONFIG_NET_SOCKETS_CAN_RECEIVERS];
+
 extern const struct socket_op_vtable sock_fd_op_vtable;
 
 static const struct socket_op_vtable can_sock_fd_op_vtable;
@@ -77,32 +88,87 @@ static void zcan_received_cb(struct net_context *ctx, struct net_pkt *pkt,
 			     union net_proto_header *proto_hdr,
 			     int status, void *user_data)
 {
-	NET_DBG("ctx %p pkt %p st %d ud %p", ctx, pkt, status, user_data);
+	/* The ctx parameter is not really relevant here. It refers to first
+	 * net_context that was used when registering CAN socket.
+	 * In practice there can be multiple sockets that are interested in
+	 * same CAN id packets. That is why we need to implement the dispatcher
+	 * which will give the packet to correct net_context(s).
+	 */
+	struct net_pkt *clone = NULL;
+	int i;
 
-	/* if pkt is NULL, EOF */
-	if (!pkt) {
-		struct net_pkt *last_pkt = k_fifo_peek_tail(&ctx->recv_q);
+	for (i = 0; i < ARRAY_SIZE(receivers); i++) {
+		struct zcan_frame *zframe =
+			(struct zcan_frame *)net_pkt_data(pkt);
+		struct can_frame frame;
 
-		if (!last_pkt) {
-			/* If there're no packets in the queue, recv() may
-			 * be blocked waiting on it to become non-empty,
-			 * so cancel that wait.
-			 */
-			sock_set_eof(ctx);
-			k_fifo_cancel_wait(&ctx->recv_q);
-			NET_DBG("Marked socket %p as peer-closed", ctx);
-		} else {
-			net_pkt_set_eof(last_pkt, true);
-			NET_DBG("Set EOF flag on pkt %p", ctx);
+		if (receivers[i].iface != net_pkt_iface(pkt)) {
+			continue;
 		}
 
-		return;
+		can_copy_zframe_to_frame(zframe, &frame);
+
+		if ((frame.can_id & receivers[i].can_mask) !=
+		    (receivers[i].can_id & receivers[i].can_mask)) {
+			continue;
+		}
+
+		/* If there are multiple receivers configured, we use the
+		 * original net_pkt as a template, and just clone it to all
+		 * recipients. This is done like this so that we avoid the
+		 * original net_pkt being freed while we are cloning it.
+		 */
+		if (pkt != NULL && ARRAY_SIZE(receivers) > 1) {
+			/* There are multiple receivers, we need to clone
+			 * the packet.
+			 */
+			clone = net_pkt_clone(pkt, MEM_ALLOC_TIMEOUT);
+			if (!clone) {
+				/* Sent the packet to at least one recipient
+				 * if there is no memory to clone the packet.
+				 */
+				clone = pkt;
+			}
+		} else {
+			clone = pkt;
+		}
+
+		ctx = receivers[i].ctx;
+
+		NET_DBG("[%d] ctx %p pkt %p st %d", i, ctx, clone, status);
+
+		/* if pkt is NULL, EOF */
+		if (!clone) {
+			struct net_pkt *last_pkt =
+				k_fifo_peek_tail(&ctx->recv_q);
+
+			if (!last_pkt) {
+				/* If there're no packets in the queue,
+				 * recv() may be blocked waiting on it to
+				 * become non-empty, so cancel that wait.
+				 */
+				sock_set_eof(ctx);
+				k_fifo_cancel_wait(&ctx->recv_q);
+
+				NET_DBG("Marked socket %p as peer-closed", ctx);
+			} else {
+				net_pkt_set_eof(last_pkt, true);
+
+				NET_DBG("Set EOF flag on pkt %p", ctx);
+			}
+
+			return;
+		} else {
+			/* Normal packet */
+			net_pkt_set_eof(clone, false);
+
+			k_fifo_put(&ctx->recv_q, clone);
+		}
 	}
 
-	/* Normal packet */
-	net_pkt_set_eof(pkt, false);
-
-	k_fifo_put(&ctx->recv_q, pkt);
+	if (clone && clone != pkt) {
+		net_pkt_unref(pkt);
+	}
 }
 
 static int zcan_bind_ctx(struct net_context *ctx, const struct sockaddr *addr,
@@ -232,19 +298,17 @@ static ssize_t zcan_recvfrom_ctx(struct net_context *ctx, void *buf,
 	}
 
 	if (net_pkt_read(pkt, (void *)&zframe, sizeof(zframe))) {
+		net_pkt_unref(pkt);
+
 		errno = EIO;
 		return -1;
-	}
-
-	if (!(flags & ZSOCK_MSG_PEEK)) {
-		net_pkt_unref(pkt);
-	} else {
-		net_pkt_cursor_init(pkt);
 	}
 
 	NET_ASSERT(recv_len == sizeof(struct can_frame));
 
 	can_copy_zframe_to_frame(&zframe, (struct can_frame *)buf);
+
+	net_pkt_unref(pkt);
 
 	return recv_len;
 }
@@ -361,52 +425,190 @@ static int can_sock_getsockopt_vmeth(void *obj, int level, int optname,
 	return zcan_getsockopt_ctx(obj, level, optname, optval, optlen);
 }
 
+static int can_register_receiver(struct net_if *iface, struct net_context *ctx,
+				 canid_t can_id, canid_t can_mask)
+{
+	int i;
+
+	NET_DBG("Max %lu receivers", ARRAY_SIZE(receivers));
+
+	for (i = 0; i < ARRAY_SIZE(receivers); i++) {
+		if (receivers[i].ctx != NULL) {
+			continue;
+		}
+
+		receivers[i].ctx = ctx;
+		receivers[i].iface = iface;
+		receivers[i].can_id = can_id;
+		receivers[i].can_mask = can_mask;
+
+		return i;
+	}
+
+	return -ENOENT;
+}
+
+static void can_unregister_receiver(struct net_if *iface,
+				    struct net_context *ctx,
+				    canid_t can_id, canid_t can_mask)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(receivers); i++) {
+		if (receivers[i].ctx == ctx &&
+		    receivers[i].iface == iface &&
+		    receivers[i].can_id == can_id &&
+		    receivers[i].can_mask == can_mask) {
+			receivers[i].ctx = NULL;
+			return;
+		}
+	}
+}
+
+static int can_register_filters(struct net_if *iface, struct net_context *ctx,
+				const struct can_filter *filters, int count)
+{
+	int i, ret;
+
+	NET_DBG("Registering %d filters", count);
+
+	for (i = 0; i < count; i++) {
+		ret = can_register_receiver(iface, ctx, filters[i].can_id,
+					    filters[i].can_mask);
+		if (ret < 0) {
+			goto revert;
+		}
+	}
+
+	return 0;
+
+revert:
+	for (i = 0; i < count; i++) {
+		can_unregister_receiver(iface, ctx, filters[i].can_id,
+					filters[i].can_mask);
+	}
+
+	return ret;
+}
+
+static void can_unregister_filters(struct net_if *iface,
+				   struct net_context *ctx,
+				   const struct can_filter *filters,
+				   int count)
+{
+	int i;
+
+	NET_DBG("Unregistering %d filters", count);
+
+	for (i = 0; i < count; i++) {
+		can_unregister_receiver(iface, ctx, filters[i].can_id,
+					filters[i].can_mask);
+	}
+}
+
+static bool is_already_attached(struct can_filter *filter,
+				struct net_if *iface,
+				struct net_context *ctx)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(receivers); i++) {
+		if (receivers[i].ctx != ctx && receivers[i].iface == iface &&
+		    ((receivers[i].can_id & receivers[i].can_mask) ==
+		     (UNALIGNED_GET(&filter->can_id) &
+		      UNALIGNED_GET(&filter->can_mask)))) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 static int can_sock_setsockopt_vmeth(void *obj, int level, int optname,
 				     const void *optval, socklen_t optlen)
 {
-	if (level == SOL_CAN_RAW) {
-		const struct canbus_api *api;
-		struct net_if *iface;
-		struct device *dev;
+	const struct canbus_api *api;
+	struct net_if *iface;
+	struct device *dev;
+	int ret;
 
-		/* The application must use can_filter and then we convert
-		 * it to zcan_filter as the CANBUS drivers expects that.
-		 */
-		if (optname == CAN_RAW_FILTER &&
-		    optlen != sizeof(struct can_filter)) {
-			errno = EINVAL;
-			return -1;
-		}
-
-		if (optval == NULL) {
-			errno = EINVAL;
-			return -1;
-		}
-
-		iface = net_context_get_iface(obj);
-		dev = net_if_get_device(iface);
-		api = dev->driver_api;
-
-		if (!api || !api->setsockopt) {
-			errno = ENOTSUP;
-			return -1;
-		}
-
-		if (optname == CAN_RAW_FILTER) {
-			struct zcan_filter zfilter;
-
-			can_copy_filter_to_zfilter((struct can_filter *)optval,
-						   &zfilter);
-
-			return api->setsockopt(dev, obj, level, optname,
-					       &zfilter, sizeof(zfilter));
-		}
-
-		return api->setsockopt(dev, obj, level, optname,
-				       optval, optlen);
+	if (level != SOL_CAN_RAW) {
+		return zcan_setsockopt_ctx(obj, level, optname, optval, optlen);
 	}
 
-	return zcan_setsockopt_ctx(obj, level, optname, optval, optlen);
+	/* The application must use CAN_filter and then we convert
+	 * it to zcan_filter as the CANBUS drivers expects that.
+	 */
+	if (optname == CAN_RAW_FILTER && optlen != sizeof(struct can_filter)) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (optval == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	iface = net_context_get_iface(obj);
+	dev = net_if_get_device(iface);
+	api = dev->driver_api;
+
+	if (!api || !api->setsockopt) {
+		errno = ENOTSUP;
+		return -1;
+	}
+
+	if (optname == CAN_RAW_FILTER) {
+		int count, i;
+
+		if (optlen % sizeof(struct can_filter) != 0) {
+			errno = EINVAL;
+			return -1;
+		}
+
+		count = optlen / sizeof(struct can_filter);
+
+		ret = can_register_filters(iface, obj, optval, count);
+		if (ret < 0) {
+			errno = -ret;
+			return -1;
+		}
+
+		for (i = 0; i < count; i++) {
+			struct can_filter *filter;
+			struct zcan_filter zfilter;
+			bool duplicate;
+
+			filter = &((struct can_filter *)optval)[i];
+
+			/* If someone has already attached the same filter to
+			 * same interface, we do not need to do it here again.
+			 */
+			duplicate = is_already_attached(filter, iface, obj);
+			if (duplicate) {
+				continue;
+			}
+
+			can_copy_filter_to_zfilter(filter, &zfilter);
+
+			ret = api->setsockopt(dev, obj, level, optname,
+					      &zfilter, sizeof(zfilter));
+			if (ret < 0) {
+				break;
+			}
+		}
+
+		if (ret < 0) {
+			can_unregister_filters(iface, obj, optval, count);
+
+			errno = -ret;
+			return -1;
+		}
+
+		return 0;
+	}
+
+	return api->setsockopt(dev, obj, level, optname, optval, optlen);
 }
 
 static const struct socket_op_vtable can_sock_fd_op_vtable = {


### PR DESCRIPTION
This allows application(s) to listen same CAN-IDs for the same network interface.