### PR TITLE
uart: pl011: Use correct masking for ICR

### DIFF
--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -133,7 +133,8 @@ struct pl011_data {
 		PL011_IMSC_PEIM | PL011_IMSC_BEIM | \
 		PL011_IMSC_OEIM)
 
-#define PL011_IMSC_MASK_ALL (PL011_ERROR_MASK | \
+#define PL011_IMSC_MASK_ALL (PL011_IMSC_OEIM | PL011_IMSC_BEIM | \
+		PL011_IMSC_PEIM | PL011_IMSC_FEIM | \
 		PL011_IMSC_RIMIM | PL011_IMSC_CTSMIM | \
 		PL011_IMSC_DCDMIM | PL011_IMSC_DSRMIM | \
 		PL011_IMSC_RXIM | PL011_IMSC_TXIM | \
@@ -377,7 +378,7 @@ static int pl011_init(struct device *dev)
 
 	/* initialize all IRQs as masked */
 	PL011_REGS(dev)->imsc = 0;
-	PL011_REGS(dev)->icr = PL011_REGS(dev)->icr;
+	PL011_REGS(dev)->icr = PL011_IMSC_MASK_ALL;
 
 	PL011_REGS(dev)->dmacr = 0;
 	__ISB();


### PR DESCRIPTION
This patch changes the ICR masking to use a fixed mask instead of
a buggy read/write of the current ICR to itself.  The ICR is write
only and reading this for information is unpredictable and should
be avoided.

Signed-off-by: Andy Gross <andy.gross@linaro.org>