### PR TITLE
scripts/dts cleanups, part 6

### DIFF
--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -1,16 +1,16 @@
 ---
-title: <Title should describe what node you are describing>
+title: <short description of the node>
 version: 0.1
 
 description: >
-    Describe in free form text w/ spanning lines what you
-    are describing
+    Longer free-form description of the node, with spanning
+    lines
 
 inherits:
   - !include other.yaml # or [other1.yaml, other2.yaml]
-# other.yaml contains bindings that also apply to this node.
-# In case there are duplicate definitions in the different
-# bindings the one that is defined first prevails.
+# Files with other bindings that also apply to the node. If an attribute is set
+# both in an included file and in the file that includes it, then the value
+# from the including file (the file with the !include) is used.
 
 < parent | child >:
 # parent/child is used to document implicit relation between nodes.
@@ -20,54 +20,55 @@ inherits:
 # parent and child should share same bus-type value.
    bus: <bus-type>
 
-# properties will be the contents of the device tree node
-# property names must match the property names in the DT
-
 properties:
 
-# A typical property entry will look like the following
-#   <name of property as it is in device tree>
+# A typical property entry looks like this:
+#
+#   <name of the property in the device tree - regexes are supported>:
 #     category: <required | optional>
 #     type: <string | int | array | compound>
 #     description: <description of property>
-#     generation: <define | structure>
+#     generation: define
+#
+# The 'generation' attribute can be set to 'define, use-prop-name' to use the
+# property name instead of a generic controller name, e.g. *_CS_GPIO_* instead
+# of *_GPIOS_*.
+#
+# The exact value of the 'generation' attribute is ignored otherwise. The
+# output is always #define's.
+#
+# The 'type' attribute is currently ignored.
 
-# At a minimum, the compatible is required for matching nodes
+# At a minimum, an entry for the 'compatible' property is required, for
+# matching nodes
     compatible: <list of string compatible matches>
       category: required
       type: string
       description: compatible of node
       generation: define
 
-# reg is used to denote mmio registers
+# 'reg' describes mmio registers
     reg:
+      category: required
       type: array
       description: mmio register space
       generation: define
-      category: required
 
-# interrupts specifies the interrupts that the driver may utilize
+# 'interrupts' specifies the interrupts that the driver may use
     interrupts:
-      type: array
       category: required
+      type: array
       description: required interrupts
       generation: define
 
-# If a node is a interrupt controller, gpio controller, pinmux device
-# or any device which is referenced via phandle plus some number of cells
-# then the cell fiels below must be present.
+# If a node is an interrupt controller, GPIO controller, pinmux device, or any
+# device referenced via a phandle plus some number of cells, then the cell
+# fields below must be present
 
 "#cells":
   - cell0    # name of first cell
   - cell1    # name of second cell
   - cell2    # name of third cell
   - and so on and so forth
-
-# When the "generation" attribute is set to "define", value "use-prop-name"
-# could be added to indicate that generated #define should use property
-# name instead of controller generic name, for instance _CS_GPIO_ instead
-# of _GPIOS_
-
-# "type" attribute is currently not used.
 
 ...

--- a/dts/bindings/mtd/partition.yaml
+++ b/dts/bindings/mtd/partition.yaml
@@ -13,28 +13,4 @@ properties:
       constraint: "fixed-partitions"
       generation: define
 
-    partition\d+:
-      type: string
-      generation: define
-
-      properties:
-          reg:
-            type: array
-            description: partition offset and size from flash bank
-            generation: define
-            category: required
-            label: offset
-
-          label:
-            type: string
-            description: Partition label
-            generation: define
-            category: required
-
-          read-only:
-            type: boolean
-            category: optional
-            description: Denotes read only partition
-            generation: define
-
 ...

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -128,8 +128,8 @@ def extract_property(node_compat, node_address, prop, prop_val, names):
         default.extract(node_address, prop, prop_val['type'], def_label)
 
 
-def extract_node_include_info(reduced, root_node_address, sub_node_address,
-                              y_sub):
+def generate_node_defines(reduced, root_node_address, sub_node_address,
+                          y_sub):
 
     filter_list = ['interrupt-names',
                     'reg-names',
@@ -151,8 +151,7 @@ def extract_node_include_info(reduced, root_node_address, sub_node_address,
         if 'properties' in v:
             for c in reduced:
                 if root_node_address + '/' in c:
-                    extract_node_include_info(
-                        reduced, root_node_address, c, v)
+                    generate_node_defines(reduced, root_node_address, c, v)
         if 'generation' in v:
 
             match = False
@@ -443,7 +442,7 @@ def generate_defines():
     for k, v in reduced.items():
         node_compat = get_compat(k)
         if node_compat is not None and node_compat in get_binding_compats():
-            extract_node_include_info(reduced, k, k, None)
+            generate_node_defines(reduced, k, k, None)
 
     if not defs:
         raise Exception("No information parsed from dts file.")

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -439,8 +439,7 @@ def yaml_inc_error(msg):
     raise yaml.constructor.ConstructorError(None, None, msg)
 
 
-def generate_node_definitions():
-
+def generate_defines():
     for k, v in reduced.items():
         node_compat = get_compat(k)
         if node_compat is not None and node_compat in get_binding_compats():
@@ -496,7 +495,7 @@ def main():
 
     load_bindings(root, args.yaml)
 
-    generate_node_definitions()
+    generate_defines()
 
     # Add DT_CHOSEN_<X> defines to generated files
     for c in sorted(chosen):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -461,6 +461,10 @@ def generate_defines():
     node_address = chosen.get('zephyr,code-partition', node_address)
     flash.extract(node_address, 'zephyr,code-partition', None)
 
+    # Add DT_CHOSEN_<X> defines
+    for c in sorted(chosen):
+        insert_defs('chosen', {'DT_CHOSEN_' + str_to_label(c): '1'}, {})
+
 
 def parse_arguments():
     rdh = argparse.RawDescriptionHelpFormatter
@@ -493,15 +497,14 @@ def main():
     create_aliases(root)
     create_chosen(root)
 
+    # Load any bindings (.yaml files) that match 'compatible' values from the
+    # DTS
     load_bindings(root, args.yaml)
 
+    # Generate keys and values for the configuration file and the header file
     generate_defines()
 
-    # Add DT_CHOSEN_<X> defines to generated files
-    for c in sorted(chosen):
-        insert_defs('chosen', {'DT_CHOSEN_' + str_to_label(c): '1'}, {})
-
-    # Generate config and header files
+    # Write the configuration file and the header file
 
     if args.keyvalue is not None:
         with open(args.keyvalue, 'w', encoding='utf-8') as f:

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -129,11 +129,6 @@ def extract_property(node_compat, node_address, prop, prop_val, names):
 
 
 def generate_node_defines(root_node_address, sub_node_address, y_sub):
-
-    filter_list = ['interrupt-names',
-                    'reg-names',
-                    'phandle',
-                    'linux,phandle']
     node = reduced[sub_node_address]
     node_compat = get_compat(root_node_address)
 
@@ -166,8 +161,8 @@ def generate_node_defines(root_node_address, sub_node_address, y_sub):
             # patterns for things like reg, interrupts, etc that we don't need
             # any special case handling at a node level
             for c in node['props']:
-                # if prop is in filter list - ignore it
-                if c in filter_list:
+                if c in {'interrupt-names', 'reg-names', 'phandle',
+                         'linux,phandle'}:
                     continue
 
                 if re.fullmatch(k, c):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -438,10 +438,9 @@ def yaml_inc_error(msg):
 
 
 def generate_defines():
-    for k, v in reduced.items():
-        node_compat = get_compat(k)
-        if node_compat is not None and node_compat in get_binding_compats():
-            generate_node_defines(k, k, None)
+    for node_path in reduced.keys():
+        if get_compat(node_path) in get_binding_compats():
+            generate_node_defines(node_path, node_path, None)
 
     if not defs:
         raise Exception("No information parsed from dts file.")

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -172,7 +172,7 @@ def extract_node_include_info(reduced, root_node_address, sub_node_address,
                 if c in filter_list:
                     continue
 
-                if re.match(k + '$', c):
+                if re.fullmatch(k, c):
 
                     if 'pinctrl-' in c:
                         names = deepcopy(node['props'].get(

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -128,8 +128,7 @@ def extract_property(node_compat, node_address, prop, prop_val, names):
         default.extract(node_address, prop, prop_val['type'], def_label)
 
 
-def generate_node_defines(reduced, root_node_address, sub_node_address,
-                          y_sub):
+def generate_node_defines(root_node_address, sub_node_address, y_sub):
 
     filter_list = ['interrupt-names',
                     'reg-names',
@@ -151,7 +150,7 @@ def generate_node_defines(reduced, root_node_address, sub_node_address,
         if 'properties' in v:
             for c in reduced:
                 if root_node_address + '/' in c:
-                    generate_node_defines(reduced, root_node_address, c, v)
+                    generate_node_defines(root_node_address, c, v)
         if 'generation' in v:
 
             match = False
@@ -442,7 +441,7 @@ def generate_defines():
     for k, v in reduced.items():
         node_compat = get_compat(k)
         if node_compat is not None and node_compat in get_binding_compats():
-            generate_node_defines(reduced, k, k, None)
+            generate_node_defines(k, k, None)
 
     if not defs:
         raise Exception("No information parsed from dts file.")


### PR DESCRIPTION
Changes:

 - Document support for regular expressions in bindings

 - Touch up `device_node.yaml.template` a bit in general

 - Remove dead attributes in `dts/bindings/mtd/partition.yaml`. Might be a leftover from an older way of doing things.

   This gets rid of the only nested `properties:` in a binding. Remove support for it. It makes the code harder to follow, especially as it's undocumented.

  - Remove misc. other dead code

  - Improve naming