### PR TITLE
drivers: modem: wistron kconfig separation

### DIFF
--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -13,6 +13,10 @@ menuconfig MODEM
 
 if MODEM
 
+module = MODEM
+module-str = modem
+source "subsys/logging/Kconfig.template.log_config"
+
 config MODEM_RECEIVER
 	bool "Enable modem receiver helper driver"
 	depends on SERIAL_SUPPORT_INTERRUPT
@@ -41,55 +45,8 @@ config MODEM_SHELL
 	  Activate shell module that provides modem utilities like
 	  sending a command to the modem UART.
 
-config MODEM_WNCM14A2A
-	bool "Enable Wistron LTE-M modem driver"
-	select MODEM_RECEIVER
-	select NET_OFFLOAD
-	select UART_MCUX_2 if BOARD_FRDM_K64F
-	select GPIO_NRF_P1 if SOC_NRF52840
-	select UART_1_NRF_UARTE if SOC_NRF52840
-	select UART_1_NRF_FLOW_CONTROL if SOC_NRF52840
-	help
-	  Choose this setting to enable Wistron WNC-M14A2A LTE-M modem driver.
-	  NOTE: Currently the pin settings only work with FRDM K64F shield.
+source "drivers/modem/Kconfig.wncm14a2a"
 
 config MODEM_WNCM14A2A_RX_STACK_SIZE
-	int "Size of the stack for the WNC-M14A2A modem driver RX thread"
-	depends on MODEM_WNCM14A2A
-	default 1028
-	help
-	  This stack is used by the WNCM14A2A RX thread.
-
-config MODEM_WNCM14A2A_RX_WORKQ_STACK_SIZE
-	int "Size of the stack for the WNC-M14A2A modem driver work queue"
-	depends on MODEM_WNCM14A2A
-	default 2048
-	help
-	  This stack is used by the work queue to pass off net_pkt data
-	  to the rest of the network stack, letting the rx thread continue
-	  processing data.
-
-config MODEM_WNCM14A2A_APN_NAME
-	string "APN name for establishing network connection"
-	depends on MODEM_WNCM14A2A
-	default "m2m.com.attz"
-	help
-	  This setting is used in the AT%PDNSET command to set the APN name
-	  for the network connection context.  Normally, don't need to change
-	  this value.
-
-config MODEM_WNCM14A2A_INIT_PRIORITY
-	int "WNC-M14A2A driver init priority"
-	depends on MODEM_WNCM14A2A
-	default 80
-	help
-	  WNC-M14A2A device driver initialization priority.
-	  Do not mess with it unless you know what you are doing.
-	  Note that the priority needs to be lower than the net stack
-	  so that it can start before the networking sub-system.
-
-module = MODEM
-module-str = modem
-source "subsys/logging/Kconfig.template.log_config"
 
 endif # MODEM

--- a/drivers/modem/Kconfig.wncm14a2a
+++ b/drivers/modem/Kconfig.wncm14a2a
@@ -1,0 +1,59 @@
+# Kconfig - WNCM 14A2A driver options
+
+#
+# Copyright (c) 2018 Foundries.io
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menuconfig MODEM_WNCM14A2A
+	bool "Enable Wistron LTE-M modem driver"
+	depends on MODEM
+	select MODEM_RECEIVER
+	select NET_OFFLOAD
+	select UART_MCUX_2 if BOARD_FRDM_K64F
+	select GPIO_NRF_P1 if SOC_NRF52840
+	select UART_1_NRF_UARTE if SOC_NRF52840
+	select UART_1_NRF_FLOW_CONTROL if SOC_NRF52840
+	help
+	  Choose this setting to enable Wistron WNC-M14A2A LTE-M modem driver.
+	  NOTE: Currently the pin settings only work with FRDM K64F shield.
+
+if MODEM_WNCM14A2A
+
+config MODEM_WNCM14A2A_RX_STACK_SIZE
+	int "Size of the stack for the WNC-M14A2A modem driver RX thread"
+	depends on MODEM_WNCM14A2A
+	default 1028
+	help
+	  This stack is used by the WNCM14A2A RX thread.
+
+config MODEM_WNCM14A2A_RX_WORKQ_STACK_SIZE
+	int "Size of the stack for the WNC-M14A2A modem driver work queue"
+	depends on MODEM_WNCM14A2A
+	default 2048
+	help
+	  This stack is used by the work queue to pass off net_pkt data
+	  to the rest of the network stack, letting the rx thread continue
+	  processing data.
+
+config MODEM_WNCM14A2A_APN_NAME
+	string "APN name for establishing network connection"
+	depends on MODEM_WNCM14A2A
+	default "m2m.com.attz"
+	help
+	  This setting is used in the AT%PDNSET command to set the APN name
+	  for the network connection context.  Normally, don't need to change
+	  this value.
+
+config MODEM_WNCM14A2A_INIT_PRIORITY
+	int "WNC-M14A2A driver init priority"
+	depends on MODEM_WNCM14A2A
+	default 80
+	help
+	  WNC-M14A2A device driver initialization priority.
+	  Do not mess with it unless you know what you are doing.
+	  Note that the priority needs to be lower than the net stack
+	  so that it can start before the networking sub-system.
+
+endif


### PR DESCRIPTION
Separates Wistron Kconfig to a separate file.
This makes it cleaner for the future modem drivers and follows the same structure as every other driver category.