### PR TITLE
net: if: Start index numbering from 1

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -1632,7 +1632,7 @@ bool net_if_need_calc_tx_checksum(struct net_if *iface);
  *
  * @return Pointer to interface or NULL if not found.
  */
-struct net_if *net_if_get_by_index(u8_t index);
+struct net_if *net_if_get_by_index(int index);
 
 /**
  * @brief Get interface index according to pointer
@@ -1641,7 +1641,7 @@ struct net_if *net_if_get_by_index(u8_t index);
  *
  * @return Interface index
  */
-u8_t net_if_get_by_iface(struct net_if *iface);
+int net_if_get_by_iface(struct net_if *iface);
 
 /**
  * @typedef net_if_cb_t

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2818,21 +2818,27 @@ bool net_if_need_calc_rx_checksum(struct net_if *iface)
 	return need_calc_checksum(iface, ETHERNET_HW_RX_CHKSUM_OFFLOAD);
 }
 
-struct net_if *net_if_get_by_index(u8_t index)
+struct net_if *net_if_get_by_index(int index)
 {
-	if (&__net_if_start[index] >= __net_if_end) {
+	if (index <= 0) {
+		return NULL;
+	}
+
+	if (&__net_if_start[index - 1] >= __net_if_end) {
 		NET_DBG("Index %d is too large", index);
 		return NULL;
 	}
 
-	return &__net_if_start[index];
+	return &__net_if_start[index - 1];
 }
 
-u8_t net_if_get_by_iface(struct net_if *iface)
+int net_if_get_by_iface(struct net_if *iface)
 {
-	NET_ASSERT(iface >= __net_if_start && iface < __net_if_end);
+	if (!(iface >= __net_if_start && iface < __net_if_end)) {
+		return -1;
+	}
 
-	return iface - __net_if_start;
+	return (iface - __net_if_start) + 1;
 }
 
 void net_if_foreach(net_if_cb_t cb, void *user_data)

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -482,8 +482,8 @@ static void test_ipv4_addresses(void)
 
 	iface = NULL;
 
-	iface1 = net_if_get_by_index(0);
-	iface2 = net_if_get_by_index(1);
+	iface1 = net_if_get_by_index(1);
+	iface2 = net_if_get_by_index(2);
 
 	ifmaddr1 = net_if_ipv4_maddr_lookup(&maddr4a, &iface);
 	zassert_not_null(ifmaddr1, "IPv4 multicast address lookup failed");

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -1166,17 +1166,19 @@ static void test_setup(void)
 	/* The semaphore is there to wait the data to be received. */
 	k_sem_init(&wait_data, 0, UINT_MAX);
 
-	iface1 = net_if_get_by_index(0);
-	iface2 = net_if_get_by_index(1);
+	iface1 = net_if_get_by_index(1);
+	iface2 = net_if_get_by_index(2);
 
-	((struct net_if_test *)net_if_get_device(iface1)->driver_data)->idx = 0U;
-	((struct net_if_test *)net_if_get_device(iface2)->driver_data)->idx = 1U;
+	((struct net_if_test *)net_if_get_device(iface1)->driver_data)->idx =
+		net_if_get_by_iface(iface1);
+	((struct net_if_test *)net_if_get_device(iface2)->driver_data)->idx =
+		net_if_get_by_iface(iface2);
 
 	idx = net_if_get_by_iface(iface1);
-	zassert_equal(idx, 0, "Invalid index iface1");
+	zassert_equal(idx, 1, "Invalid index iface1");
 
 	idx = net_if_get_by_iface(iface2);
-	zassert_equal(idx, 1, "Invalid index iface2");
+	zassert_equal(idx, 2, "Invalid index iface2");
 
 	zassert_not_null(iface1, "Interface 1");
 	zassert_not_null(iface2, "Interface 2");

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -203,8 +203,12 @@ static void test_init(void)
 	k_sem_init(&wait_data2, 0, UINT_MAX);
 
 	iface1 = net_if_get_by_index(0);
+	zassert_is_null(iface1, "iface1");
 
-	((struct net_if_test *)net_if_get_device(iface1)->driver_data)->idx = 0U;
+	iface1 = net_if_get_by_index(1);
+
+	((struct net_if_test *)net_if_get_device(iface1)->driver_data)->idx =
+		net_if_get_by_iface(iface1);
 
 #if defined(CONFIG_NET_IPV6)
 	ifaddr = net_if_ipv6_addr_add(iface1, &my_addr1,


### PR DESCRIPTION
In order to follow the BSD socket numbering of the network
interfaces, start numbering from 1. The index 0 is reserved
to mean any interface in BSD socket code.

Fixes #13084

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>