### PR TITLE
drivers: flash: spi_nor.c: Correct the calculation of SECTORS_COUNT

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -27,7 +27,7 @@
 #define MASK_64K 0xFFFF
 
 #define SPI_NOR_MAX_ADDR_WIDTH 4
-#define SECTORS_COUNT ((DT_JEDEC_SPI_NOR_0_SIZE / 8192) \
+#define SECTORS_COUNT ((DT_JEDEC_SPI_NOR_0_SIZE / 8) \
 		       / CONFIG_SPI_NOR_SECTOR_SIZE)
 
 #define JEDEC_ID(x)		    \


### PR DESCRIPTION
The patch 44758977f81bb61d4f299ade72ff82517c11af7a made a change where
SECTORS_COUNT was not calculated properly. This patch corrects it.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>