### PR TITLE
Bluetooth: controller: Fix tx power level set and get

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -425,6 +425,7 @@ static void write_auth_payload_timeout(struct net_buf *buf,
 }
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
+#if defined(CONFIG_BT_CONN)
 static void read_tx_power_level(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_read_tx_power_level *cmd = (void *)buf->data;
@@ -443,6 +444,7 @@ static void read_tx_power_level(struct net_buf *buf, struct net_buf **evt)
 	rp->status = status;
 	rp->handle = sys_cpu_to_le16(handle);
 }
+#endif /* CONFIG_BT_CONN */
 
 static int ctrl_bb_cmd_handle(u16_t  ocf, struct net_buf *cmd,
 			      struct net_buf **evt)
@@ -460,9 +462,11 @@ static int ctrl_bb_cmd_handle(u16_t  ocf, struct net_buf *cmd,
 		set_event_mask_page_2(cmd, evt);
 		break;
 
+#if defined(CONFIG_BT_CONN)
 	case BT_OCF(BT_HCI_OP_READ_TX_POWER_LEVEL):
 		read_tx_power_level(cmd, evt);
 		break;
+#endif /* CONFIG_BT_CONN */
 
 #if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL)
 	case BT_OCF(BT_HCI_OP_SET_CTL_TO_HOST_FLOW):

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -11506,8 +11506,10 @@ u8_t ll_tx_pwr_lvl_get(u16_t handle, u8_t type, s8_t *tx_pwr_lvl)
 
 	/*TODO: check type here for current or maximum */
 
-	/* TODO: Support TX Power Level other than 0dBm */
-	*tx_pwr_lvl = 0;
+	/* TODO: Support TX Power Level other than default when dynamic
+	 *       updates is implemented.
+	 */
+	*tx_pwr_lvl = RADIO_TXP_DEFAULT;
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
@@ -1,32 +1,52 @@
 /*
- * Copyright (c) 2016-2017 Nordic Semiconductor ASA
+ * Copyright (c) 2016-2019 Nordic Semiconductor ASA
  * Copyright (c) 2016 Vinayak Kariappa Chettimada
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/types.h>
-
-/* TODO: Remove weak attribute when refactored architecture replaces the old
- *       controller implementation. */
 #include <toolchain.h>
+#include <soc.h>
+#include <bluetooth/hci.h>
 
-u8_t __weak ll_tx_pwr_lvl_get(u16_t handle, u8_t type, s8_t *tx_pwr_lvl)
+#include "hal/ccm.h"
+#include "hal/radio.h"
+
+#include "util/memq.h"
+
+#include "pdu.h"
+
+#include "lll.h"
+#include "lll_conn.h"
+#include "ull_conn_internal.h"
+
+#if defined(CONFIG_BT_LL_SW_SPLIT)
+u8_t ll_tx_pwr_lvl_get(u16_t handle, u8_t type, s8_t *tx_pwr_lvl)
 {
-	/* TODO: check for active connection */
+	struct ll_conn *conn;
+
+	conn = ll_connected_get(handle);
+	if (!conn) {
+		return BT_HCI_ERR_UNKNOWN_CONN_ID;
+	}
 
 	/* TODO: check type here for current or maximum */
 
-	/* TODO: Support TX Power Level other than 0dBm */
-	*tx_pwr_lvl = 0;
+	/* TODO: Support TX Power Level other than default when dynamic
+	 *       updates is implemented.
+	 */
+	*tx_pwr_lvl = RADIO_TXP_DEFAULT;
 
 	return 0;
 }
+#endif
 
 void ll_tx_pwr_get(s8_t *min, s8_t *max)
 {
-	/* TODO: Support TX Power Level other than 0dBm */
-	*min = 0;
-	*max = 0;
+	/* TODO: Support TX Power Level other than default when dynamic
+	 *       updates is implemented.
+	 */
+	*min = RADIO_TXP_DEFAULT;
+	*max = RADIO_TXP_DEFAULT;
 }
-

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -141,7 +141,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 	radio_reset();
 	/* TODO: other Tx Power settings */
-	radio_tx_power_set(0);
+	radio_tx_power_set(RADIO_TXP_DEFAULT);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	/* TODO: if coded we use S8? */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -145,7 +145,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 	radio_reset();
 	/* TODO: other Tx Power settings */
-	radio_tx_power_set(0);
+	radio_tx_power_set(RADIO_TXP_DEFAULT);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	/* TODO: if coded we use S8? */


### PR DESCRIPTION
Fix implementation to correctly return the configured
default Tx Power Level.

Also, fix the missing use of RADIO_TXP_DEFAULT in the new
ULL/LLL implementation of Advertiser and Observer states.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>