### PR TITLE
Tracing fixes for POSIX arch boards

### DIFF
--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -50,8 +50,6 @@ int __swap(unsigned int key)
 	_kernel.current->callee_saved.retval = -EAGAIN;
 	/* retval may be modified with a call to _set_thread_return_value() */
 
-	z_sys_trace_thread_switched_in();
-
 	posix_thread_status_t *ready_thread_ptr =
 		(posix_thread_status_t *)
 		_kernel.ready_q.cache->callee_saved.thread_status;

--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -93,7 +93,12 @@ void _arch_switch_to_main_thread(struct k_thread *main_thread,
 	posix_thread_status_t *ready_thread_ptr =
 			(posix_thread_status_t *)
 			_kernel.ready_q.cache->callee_saved.thread_status;
+
+	z_sys_trace_thread_switched_out();
+
 	_kernel.current = _kernel.ready_q.cache;
+
+	z_sys_trace_thread_switched_in();
 
 	posix_main_thread_start(ready_thread_ptr->thread_idx);
 } /* LCOV_EXCL_LINE */

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -57,6 +57,8 @@ static inline void vector_to_irq(int irq_nbr, int *may_swap)
 			*may_swap = 1;
 		}
 	}
+
+	sys_trace_isr_exit();
 	/* _int_latency_stop(); */
 }
 

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -111,6 +111,8 @@ static inline void vector_to_irq(int irq_nbr, int *may_swap)
 			*may_swap = 1;
 		}
 	}
+
+	sys_trace_isr_exit();
 	/* _int_latency_stop(); */
 
 	bs_trace_raw_time(7, "Irq %i (%s) ended\n", irq_nbr, irqnames[irq_nbr]);


### PR DESCRIPTION
Fix the tracing calls for the posix arch:
* isr_exit was missing
* z_sys_trace_thread_switched_in() was called where it shouldn't
* as a bonus trace the switch to the main thread

Fixes #13357