### PR TITLE
bluetooth: controller: Refactor PDU_RX_POOL_SIZE

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -7,12 +7,23 @@
 
 #define BDADDR_SIZE 6
 
-/* PDU Sizes */
+/*
+ * PDU Sizes
+ */
+/* Advertisement channel maximum payload size */
 #define PDU_AC_PAYLOAD_SIZE_MAX 37
-#define PDU_AC_SIZE_MAX         (offsetof(struct pdu_adv, payload) + \
-				PDU_AC_PAYLOAD_SIZE_MAX)
+/* Link Layer header size of Adv PDU. Assumes pdu_adv is packed */
+#define PDU_AC_LL_HEADER_SIZE  (offsetof(struct pdu_adv, payload))
+/* Advertisement channel maximum PDU size */
+#define PDU_AC_SIZE_MAX        (PDU_AC_LL_HEADER_SIZE + PDU_AC_PAYLOAD_SIZE_MAX)
+
+/* Data channel minimum payload */
 #define PDU_DC_PAYLOAD_SIZE_MIN 27
-#define PDU_EM_SIZE_MAX         offsetof(struct pdu_data, lldata)
+/* Link Layer header size of Data PDU. Assumes pdu_data is packed */
+#define PDU_DC_LL_HEADER_SIZE  (offsetof(struct pdu_data, lldata))
+
+/* Max size of an empty PDU. TODO: Remove; only used in Nordic LLL */
+#define PDU_EM_SIZE_MAX        (PDU_DC_LL_HEADER_SIZE)
 
 /* Extra bytes for enqueued node_rx metadata: rssi (always), resolving
  * index, directed adv report, and mesh channel and instant.

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -147,11 +147,20 @@ static MFIFO_DEFINE(ll_pdu_rx_free, sizeof(void *), LL_PDU_RX_CNT);
 #define PDU_RX_OCTETS_MAX 0
 #endif
 
-#define PDU_RX_POOL_SIZE (MROUND(offsetof(struct node_rx_pdu, pdu) + \
-				 sizeof(struct node_rx_ftr) + \
-				 MAX((PDU_AC_SIZE_MAX + PDU_AC_SIZE_EXTRA), \
-				     (offsetof(struct pdu_data, lldata) + \
-				      PDU_RX_OCTETS_MAX))) * RX_CNT)
+#define NODE_RX_HEADER_SIZE      (offsetof(struct node_rx_pdu, pdu))
+#define NODE_RX_FOOTER_SIZE      (sizeof(struct node_rx_ftr))
+#define NODE_RX_STRUCT_OVERHEAD  (NODE_RX_HEADER_SIZE + NODE_RX_FOOTER_SIZE)
+
+#define PDU_ADVERTIZE_SIZE       (PDU_AC_SIZE_MAX + PDU_AC_SIZE_EXTRA)
+#define PDU_DATA_SIZE            (PDU_DC_LL_HEADER_SIZE  + PDU_RX_OCTETS_MAX)
+
+#define PDU_RX_NODE_POOL_ELEMENT_SIZE                      \
+	MROUND(                                            \
+		NODE_RX_STRUCT_OVERHEAD                    \
+		+ MAX(PDU_ADVERTIZE_SIZE, PDU_DATA_SIZE)   \
+	)
+
+#define PDU_RX_POOL_SIZE (PDU_RX_NODE_POOL_ELEMENT_SIZE * RX_CNT)
 
 static struct {
 	u16_t size; /* Runtime (re)sized info */

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -137,10 +137,6 @@ static struct {
 static MFIFO_DEFINE(pdu_rx_free, sizeof(void *), PDU_RX_CNT);
 static MFIFO_DEFINE(ll_pdu_rx_free, sizeof(void *), LL_PDU_RX_CNT);
 
-#define PDU_RX_SIZE_MIN MROUND(offsetof(struct node_rx_pdu, pdu) + \
-			       sizeof(struct node_rx_ftr) + \
-			       (PDU_AC_SIZE_MAX + PDU_AC_SIZE_EXTRA))
-
 #if defined(CONFIG_BT_RX_BUF_LEN)
 #define PDU_RX_OCTETS_MAX (CONFIG_BT_RX_BUF_LEN - 11)
 #else
@@ -160,11 +156,9 @@ static MFIFO_DEFINE(ll_pdu_rx_free, sizeof(void *), LL_PDU_RX_CNT);
 		+ MAX(PDU_ADVERTIZE_SIZE, PDU_DATA_SIZE)   \
 	)
 
-#define PDU_RX_POOL_SIZE (PDU_RX_NODE_POOL_ELEMENT_SIZE * RX_CNT)
+#define PDU_RX_POOL_SIZE (PDU_RX_NODE_POOL_ELEMENT_SIZE * (RX_CNT + 1))
 
 static struct {
-	u16_t size; /* Runtime (re)sized info */
-
 	void *free;
 	u8_t pool[PDU_RX_POOL_SIZE];
 } mem_pdu_rx;
@@ -1060,9 +1054,8 @@ static inline int init_reset(void)
 	done_alloc();
 
 	/* Initialize rx pool. */
-	mem_pdu_rx.size = PDU_RX_SIZE_MIN;
-	mem_init(mem_pdu_rx.pool, mem_pdu_rx.size,
-		 sizeof(mem_pdu_rx.pool) / mem_pdu_rx.size,
+	mem_init(mem_pdu_rx.pool, (PDU_RX_NODE_POOL_ELEMENT_SIZE),
+		 sizeof(mem_pdu_rx.pool) / (PDU_RX_NODE_POOL_ELEMENT_SIZE),
 		 &mem_pdu_rx.free);
 
 	/* Initialize rx link pool. */


### PR DESCRIPTION
Two commits:

1. Refactor PDU_RX_POOL_SIZE into its constituents and name each term.
2. Remove PDU_RX_SIZE_MIN. See commit message for RX_CNT+1 explanation.

Signed-off-by: Mark Ruvald Pedersen <mped@oticon.com>