### PR TITLE
bluetooth: controller: Introduce ull_ref_dec for consistency

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1462,7 +1462,7 @@ static inline void rx_demux_event_done(memq_link_t *link,
 
 	/* Decrement prepare reference */
 	LL_ASSERT(ull_hdr->ref);
-	ull_hdr->ref--;
+	ull_ref_dec(ull_hdr);
 
 	/* If disable initiated, signal the semaphore */
 	if (!ull_hdr->ref && ull_hdr->disabled_cb) {

--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -9,6 +9,11 @@ static inline u8_t ull_ref_inc(struct ull_hdr *hdr)
 	return ++hdr->ref;
 }
 
+static inline u8_t ull_ref_dec(struct ull_hdr *hdr)
+{
+	return hdr->ref--;
+}
+
 static inline void ull_hdr_init(struct ull_hdr *hdr)
 {
 	hdr->disabled_cb = hdr->disabled_param = NULL;


### PR DESCRIPTION
ull_ref_inc already existed, but not ull_ref_decr.
No functional change expected.
Consistency is preferred due to code navigation.

Signed-off-by: Mark Ruvald Pedersen <mped@oticon.com>