### PR TITLE
linker: riscv32: Fix .riscv.attributes orphan sections warning

### DIFF
--- a/include/arch/riscv32/common/linker.ld
+++ b/include/arch/riscv32/common/linker.ld
@@ -191,4 +191,10 @@ SECTIONS
 
 #include <linker/debug-sections.ld>
 
+    SECTION_PROLOGUE(.riscv.attributes, 0,)
+	{
+	KEEP(*(.riscv.attributes))
+	KEEP(*(.gnu.attributes))
+	}
+
 }

--- a/soc/riscv32/openisa_rv32m1/linker.ld
+++ b/soc/riscv32/openisa_rv32m1/linker.ld
@@ -191,6 +191,11 @@ SECTIONS
 
 #include <linker/debug-sections.ld>
 
+    SECTION_PROLOGUE(.riscv.attributes, 0,)
+	{
+	KEEP(*(.riscv.attributes))
+	KEEP(*(.gnu.attributes))
+	}
     /*
      * Pulpino toolchains emit these sections; we don't care about them,
      * but need to avoid build system warnings about orphaned sections.


### PR DESCRIPTION
Add similar fix to riscv32 linker scripts that we have on ARM for
.riscv.attributes section.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>