### PR TITLE
board: stm32_min_dev: Add USB support

### DIFF
--- a/boards/arm/stm32_min_dev/doc/index.rst
+++ b/boards/arm/stm32_min_dev/doc/index.rst
@@ -97,6 +97,8 @@ The stm32_min_dev board configuration supports the following hardware features:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| USB       | on-chip    | USB device           |
++-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
 

--- a/boards/arm/stm32_min_dev/pinmux.c
+++ b/boards/arm/stm32_min_dev/pinmux.c
@@ -45,6 +45,10 @@ static const struct pin_config pinconf[] = {
 	{STM32_PIN_PB14, STM32F1_PINMUX_FUNC_PB14_SPI2_MASTER_MISO},
 	{STM32_PIN_PB15, STM32F1_PINMUX_FUNC_PB15_SPI2_MASTER_MOSI},
 #endif /* CONFIG_SPI_2 */
+#ifdef USB_DC_STM32
+	{STM32_PIN_PA11, STM32F1_PINMUX_FUNC_PA11_USB_DM},
+	{STM32_PIN_PA12, STM32F1_PINMUX_FUNC_PA12_USB_DP},
+#endif /* USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(struct device *port)

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dts
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dts
@@ -70,3 +70,7 @@
 		status = "ok";
 	};
 };
+
+&usb {
+	status = "ok";
+};


### PR DESCRIPTION
Add support USB to stm32_min_dev board

Signed-off-by: Harry Jiang <explora26@gmail.com>