### PR TITLE
drivers/sensor/vl53l0x: Remove unnecessary lib include check

### DIFF
--- a/drivers/sensor/vl53l0x/vl53l0x_types.h
+++ b/drivers/sensor/vl53l0x/vl53l0x_types.h
@@ -23,12 +23,6 @@
 #error "Error NULL definition should be done. Please add required include "
 #endif
 
-#if !defined(STDINT_H) && !defined(_GCC_STDINT_H) && !defined(__STDINT_DECLS) \
-	&& !defined(_GCC_WRAP_STDINT_H) && !defined(_STDINT_H)                \
-	&& !defined(__INC_stdint_h__)
- #pragma message("Review type definition of STDINT define for your platform")
-#endif /* _STDINT_H */
-
 /** use where fractional values are expected
  *
  * Given a floating point value f it's .16 bit point is (int)(f*(1<<16))


### PR DESCRIPTION
vl53l0x driver is using an external library to build, located under:
ext/hal/st/lib/sensor/vl53l0x.
This library is expecting stdint.h lib to be available and to
secure this for driver library inclusion work, a stdint.h file
header check was done. This check was based on assumptions on possible
header names for stdint.h.
Due to recent renaming of the zephyr header files, this check was
returning a false positive, generating warning at compilation.

Rather than updated with new header names, remove this check, since
driver porting is completed and stdint.h inclusion is actually
done.

Fixes #10134

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>