### PR TITLE
Arch arm fault fix nonsecure

### DIFF
--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -715,9 +715,32 @@ void _Fault(NANO_ESF *esf, u32_t exc_return)
 			}
 		}
 	}
+#elif defined(CONFIG_ARM_NONSECURE_FIRMWARE)
+	if ((exc_return & EXC_RETURN_INDICATOR_PREFIX) !=
+			EXC_RETURN_INDICATOR_PREFIX) {
+		/* Invalid EXC_RETURN value */
+		goto _exit_fatal;
+	}
+	if (exc_return & EXC_RETURN_EXCEPTION_SECURE_Secure) {
+		/* Non-Secure Firmware shall only handle Non-Secure Exceptions.
+		 * This is a fatal error.
+		 */
+		goto _exit_fatal;
+	}
+
+	if (exc_return & EXC_RETURN_RETURN_STACK_Secure) {
+		/* Exception entry occurred in Secure stack.
+		 *
+		 * Note that Non-Secure firmware cannot inspect the Secure
+		 * stack to determine the root cause of the fault. Fault
+		 * inspection will indicate the Non-Secure instruction
+		 * that performed the branch to the Secure domain.
+		 */
+		PR_FAULT_INFO("Exception occurred in Secure State\n");
+	}
 #else
 	(void) exc_return;
-#endif /* CONFIG_ARM_SECURE_FIRMWARE*/
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
 
 	reason = _FaultHandle(esf, fault);
 
@@ -725,7 +748,8 @@ void _Fault(NANO_ESF *esf, u32_t exc_return)
 		return;
 	}
 
-#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+#if defined(CONFIG_ARM_SECURE_FIRMWARE) || \
+	defined(CONFIG_ARM_NONSECURE_FIRMWARE)
 _exit_fatal:
 	reason = _NANO_ERR_HW_EXCEPTION;
 #endif

--- a/arch/arm/core/fault_s.S
+++ b/arch/arm/core/fault_s.S
@@ -97,7 +97,8 @@ _stack_frame_endif:
 	eors.n r0, r0
 	msr BASEPRI, r0
 
-#if !defined(CONFIG_ARM_SECURE_FIRMWARE)
+#if !defined(CONFIG_ARM_SECURE_FIRMWARE) && \
+	!defined(CONFIG_ARM_NONSECURE_FIRMWARE)
 	/* this checks to see if we are in a nested exception */
 	ldr ip, =_SCS_ICSR
 	ldr ip, [ip]
@@ -113,7 +114,8 @@ _stack_frame_endif:
 #else
 	/* RETTOBASE flag is not banked between security states.
 	 * Therefore, we cannot rely on this flag, to obtain the SP
-	 * in Secure state. Instead, we use the EXC_RETURN SPSEL flag.
+	 * of the current security state.
+	 * Instead, we use the EXC_RETURN.SPSEL flag.
 	 */
  	ldr r0, =0x4
 	mov r1, lr
@@ -124,21 +126,23 @@ _stack_frame_endif:
 _s_stack_frame_msp:
 	mrs r0, MSP
 _s_stack_frame_endif:
-#endif /* CONFIG_ARM_SECURE_FIRMWARE */
+#endif /* CONFIG_ARM_SECURE_FIRMWARE || CONFIG_ARM_NONSECURE_FIRMWARE */
 #else
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 
-#if defined(CONFIG_ARM_SECURE_FIRMWARE)
-	/* In ARM Secure firmware, the stack pointer that is retrieved
-	 * above points to the Secure stack. However, the exeption may
-	 * have occurred in Non-Secure state.
+#if defined(CONFIG_ARM_SECURE_FIRMWARE) || \
+	defined(CONFIG_ARM_NONSECURE_FIRMWARE)
+	/* The stack pointer that is retrieved above, points to the stack,
+	 * where the exception is taken. However, the exeption may have
+	 * occurred in the alternative security state.
+	 *
 	 * To determine this we need to inspect the EXC_RETURN value
 	 * located in the LR. Therefore, we supply the LR value as an
 	 * argument to the fault handler.
 	 */
 	mov r1, lr
-#endif /* CONFIG_ARM_SECURE_FIRMWARE */
+#endif /* CONFIG_ARM_SECURE_FIRMWARE || CONFIG_ARM_NONSECURE_FIRMWARE */
 	push {r0, lr}
 	bl _Fault
 


### PR DESCRIPTION
Fixes some bugs with Secure/Non-Secure firmware and error handling (Reported in the commit messages)
Only affects builds with TrustZone-M enabled.
