### PR TITLE
Cleanup flash driver kconfig code

### DIFF
--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -44,27 +44,7 @@ config FLASH_PAGE_LAYOUT
 	help
 	  Enables API for retrieving the layout of flash memory pages.
 
-config SOC_FLASH_NRF
-	bool "Nordic Semiconductor nRF flash driver"
-	depends on SOC_FAMILY_NRF
-	select FLASH_HAS_PAGE_LAYOUT
-	select FLASH_HAS_DRIVER_ENABLED
-	help
-	  Enables Nordic Semiconductor nRF flash driver.
-
-config SOC_FLASH_NRF_RADIO_SYNC
-	bool "Nordic nRFx flash driver synchronized with radio"
-	depends on SOC_FLASH_NRF && BT_CTLR
-	default y
-	help
-	  Enable synchronization between flash memory driver and radio.
-
-config SOC_FLASH_NRF_UICR
-	bool "Access to UICR"
-	depends on SOC_FLASH_NRF
-	help
-	  Enable operations on UICR. Once enabled UICR are written or read as
-	  ordinary flash memory. Erase is possible for whole UICR at once.
+source "drivers/flash/Kconfig.nrf"
 
 source "drivers/flash/Kconfig.mcux"
 

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -78,19 +78,7 @@ config SOC_FLASH_MCUX
 	  have an impact on the overall system performance - whether
 	  this is acceptable or not will depend on the use case.
 
-config SOC_FLASH_NIOS2_QSPI
-	bool "Nios-II QSPI flash driver"
-	depends on HAS_ALTERA_HAL
-	select FLASH_HAS_DRIVER_ENABLED
-	help
-	  Enables the Nios-II QSPI flash driver.
-
-config SOC_FLASH_NIOS2_QSPI_DEV_NAME
-	string "Nios-II QSPI flash device name"
-	depends on SOC_FLASH_NIOS2_QSPI
-	default "NIOS2_QSPI_FLASH"
-	help
-	  Specify the device name for the QSPI flash driver.
+source "drivers/flash/Kconfig.nios2_qspi"
 
 source "drivers/flash/Kconfig.gecko"
 

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -66,17 +66,7 @@ config SOC_FLASH_NRF_UICR
 	  Enable operations on UICR. Once enabled UICR are written or read as
 	  ordinary flash memory. Erase is possible for whole UICR at once.
 
-config SOC_FLASH_MCUX
-	bool "MCUX flash shim driver"
-	depends on HAS_MCUX
-	select FLASH_HAS_PAGE_LAYOUT
-	select FLASH_HAS_DRIVER_ENABLED
-	help
-	  Enables the MCUX flash shim driver.
-	  WARNING: This driver will disable the system interrupts for
-	  the duration of the flash erase/write operations. This will
-	  have an impact on the overall system performance - whether
-	  this is acceptable or not will depend on the use case.
+source "drivers/flash/Kconfig.mcux"
 
 source "drivers/flash/Kconfig.nios2_qspi"
 

--- a/drivers/flash/Kconfig.mcux
+++ b/drivers/flash/Kconfig.mcux
@@ -1,0 +1,11 @@
+config SOC_FLASH_MCUX
+	bool "MCUX flash shim driver"
+	depends on HAS_MCUX
+	select FLASH_HAS_PAGE_LAYOUT
+	select FLASH_HAS_DRIVER_ENABLED
+	help
+	  Enables the MCUX flash shim driver.
+	  WARNING: This driver will disable the system interrupts for
+	  the duration of the flash erase/write operations. This will
+	  have an impact on the overall system performance - whether
+	  this is acceptable or not will depend on the use case.

--- a/drivers/flash/Kconfig.nios2_qspi
+++ b/drivers/flash/Kconfig.nios2_qspi
@@ -1,0 +1,13 @@
+config SOC_FLASH_NIOS2_QSPI
+	bool "Nios-II QSPI flash driver"
+	depends on HAS_ALTERA_HAL
+	select FLASH_HAS_DRIVER_ENABLED
+	help
+	  Enables the Nios-II QSPI flash driver.
+
+config SOC_FLASH_NIOS2_QSPI_DEV_NAME
+	string "Nios-II QSPI flash device name"
+	depends on SOC_FLASH_NIOS2_QSPI
+	default "NIOS2_QSPI_FLASH"
+	help
+	  Specify the device name for the QSPI flash driver.

--- a/drivers/flash/Kconfig.nrf
+++ b/drivers/flash/Kconfig.nrf
@@ -1,0 +1,21 @@
+config SOC_FLASH_NRF
+	bool "Nordic Semiconductor nRF flash driver"
+	depends on SOC_FAMILY_NRF
+	select FLASH_HAS_PAGE_LAYOUT
+	select FLASH_HAS_DRIVER_ENABLED
+	help
+	  Enables Nordic Semiconductor nRF flash driver.
+
+config SOC_FLASH_NRF_RADIO_SYNC
+	bool "Nordic nRFx flash driver synchronized with radio"
+	depends on SOC_FLASH_NRF && BT_CTLR
+	default y
+	help
+	  Enable synchronization between flash memory driver and radio.
+
+config SOC_FLASH_NRF_UICR
+	bool "Access to UICR"
+	depends on SOC_FLASH_NRF
+	help
+	  Enable operations on UICR. Once enabled UICR are written or read as
+	  ordinary flash memory. Erase is possible for whole UICR at once.


### PR DESCRIPTION
Cleanup the Kconfig code for the flash driver. Platform-specific
options should be in their own Kconfig files to be consistent and to
not pollute the common configuration.