### PR TITLE
scripts: gen_kobject_list: Fix error log call

### DIFF
--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -277,7 +277,7 @@ def main():
         thread_counter = eh.get_thread_counter()
         if thread_counter > max_threads:
             sys.stderr.write("Too many thread objects (%d)\n" % thread_counter)
-            sys.stderr.write("Increase CONFIG_MAX_THREAD_BYTES to %d\n",
+            sys.stderr.write("Increase CONFIG_MAX_THREAD_BYTES to %d\n" %
                              -(-thread_counter // 8))
             sys.exit(1)
 


### PR DESCRIPTION
A trivial bug that caused the following error when this situation
actually happened:

```
  Too many thread objects (21)
  Traceback (most recent call last):
    File "/zephyr/scripts/gen_kobject_list.py", line 307, in <module>
      main()
    File "/zephyr/scripts/gen_kobject_list.py", line 281, in main
      -(-thread_counter // 8))
  TypeError: write() takes exactly one argument (2 given)
```

With this commit, the detected error is printed correctly, e.g:

```
  Too many thread objects (21)
  Increase CONFIG_MAX_THREAD_BYTES to 3
```