### PR TITLE
soc: nxp_imx: Default to on-chip memories at soc level

### DIFF
--- a/boards/arm/mimxrt1020_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1020_evk/Kconfig.defconfig
@@ -10,6 +10,14 @@ if BOARD_MIMXRT1020_EVK
 config BOARD
 	default "mimxrt1020_evk" if BOARD_MIMXRT1020_EVK
 
+choice CODE_LOCATION
+	default CODE_FLEXSPI
+endchoice
+
+choice DATA_LOCATION
+	default DATA_SEMC
+endchoice
+
 if GPIO_MCUX_IGPIO
 
 config GPIO_MCUX_IGPIO_1

--- a/boards/arm/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig.defconfig
@@ -10,6 +10,14 @@ if BOARD_MIMXRT1050_EVK || BOARD_MIMXRT1050_EVK_QSPI
 config BOARD
 	default "mimxrt1050_evk"
 
+choice CODE_LOCATION
+	default CODE_FLEXSPI
+endchoice
+
+choice DATA_LOCATION
+	default DATA_SEMC
+endchoice
+
 if GPIO_MCUX_IGPIO
 
 config GPIO_MCUX_IGPIO_1

--- a/boards/arm/mimxrt1060_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1060_evk/Kconfig.defconfig
@@ -11,6 +11,14 @@ config BOARD
 	default "mimxrt1060_evk" if BOARD_MIMXRT1060_EVK
 	default "mimxrt1060_evk_hyperflash" if BOARD_MIMXRT1060_EVK_HYPERFLASH
 
+choice CODE_LOCATION
+	default CODE_FLEXSPI
+endchoice
+
+choice DATA_LOCATION
+	default DATA_SEMC
+endchoice
+
 if GPIO_MCUX_IGPIO
 
 config GPIO_MCUX_IGPIO_1

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
@@ -23,12 +23,4 @@ config IPG_DIV
 config GPIO
 	def_bool y
 
-choice CODE_LOCATION
-	default CODE_ITCM
-endchoice
-
-choice DATA_LOCATION
-	default DATA_DTCM
-endchoice
-
 endif # SOC_MIMXRT1064

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -248,7 +248,7 @@ endif # NXP_IMX_RT_BOOT_HEADER
 
 choice CODE_LOCATION
 	prompt "Code location selection"
-	default CODE_FLEXSPI
+	default CODE_ITCM
 
 config CODE_ITCM
 	bool "Link code into internal instruction tightly coupled memory (ITCM)"
@@ -261,7 +261,7 @@ endchoice
 
 choice DATA_LOCATION
 	prompt "Data location selection"
-	default DATA_SEMC
+	default DATA_DTCM
 
 config DATA_DTCM
 	bool "Link data into internal data tightly coupled memory (DTCM)"


### PR DESCRIPTION
Refactor the imx rt code/data location config defaults such that we
default to on-chip memories at the soc level and override to external
memories at the board level. This means that we frequently override soc
defaults for evk boards, but it removes the assumption that all imx rt
boards (particularly non-evk boards) will have the same external
memories as evk boards.

The end result is that imx rt evk boards still have the same defaults as
before, but the way we get there is different.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

This addresses comments from https://github.com/zephyrproject-rtos/zephyr/pull/13337#discussion_r256179904