### PR TITLE
arch: POSIX: Add Kconfig option to stop on all faults

### DIFF
--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -27,4 +27,14 @@ config ARCH_POSIX_RECOMMENDED_STACK_SIZE
 	  thread stack, the real stack is the native underlying pthread stack.
 	  Therefore the allocated stack can be limited to this size)
 
+config ARCH_POSIX_STOP_ON_FATAL_ERROR
+	bool "Terminate execution on fatal errors"
+	depends on ARCH_POSIX
+	help
+	  If set, when a fatal error occurs, the execution will stop immediately with
+	  an error. If not set, the default Zephyr behaviour will be followed:
+	  terminate only if the fault was triggered in an ISR or essential thread,
+	  otherwise abort the current thread and attempt to continue.
+	  Enabling this option may simplify locating and debugging faults
+
 endmenu

--- a/arch/posix/core/fatal.c
+++ b/arch/posix/core/fatal.c
@@ -85,13 +85,14 @@ FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
  * This routine implements the corrective action to be taken when the system
  * detects a fatal error.
  *
- * This sample implementation attempts to abort the current thread and allow
+ * If CONFIG_ARCH_POSIX_STOP_ON_FATAL_ERROR is not set,
+ * it will attempt to abort the current thread and allow
  * the system to continue executing, which may permit the system to continue
  * functioning with degraded capabilities.
  *
- * System designers may wish to enhance or substitute this sample
- * implementation to take other actions, such as logging error (or debug)
- * information to a persistent repository and/or rebooting the system.
+ * If CONFIG_ARCH_POSIX_STOP_ON_FATAL_ERROR is set, or the thread is an
+ * essential thread or interrupt, the execution will be terminated, and an error
+ * code will be returned to the invoking shell
  *
  * @param reason the fatal error reason
  * @param pEsf pointer to exception stack frame
@@ -117,7 +118,10 @@ FUNC_NORETURN __weak void _SysFatalErrorHandler(unsigned int reason,
 			k_is_in_isr() ? "ISR" : "essential thread");
 	}
 	printk("Fatal fault in thread %p! Aborting.\n", _current);
-	k_thread_abort(_current);
+
+	if (!IS_ENABLED(CONFIG_ARCH_POSIX_STOP_ON_FATAL_ERROR)) {
+		k_thread_abort(_current);
+	}
 
 hang_system:
 


### PR DESCRIPTION
Due to popular demand:

Added an option to stop the execution of the posix arch based
executable on the first fault, even if the fault stemmed from a
non essential thread.
Having it fail faster, in the first fault, will ease debugging
in many cases.
The option is disabled by default to preserve the old behavior.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>