### PR TITLE
boards: intel_s1000_crb: fix setting cache attributes

### DIFF
--- a/arch/xtensa/core/startup/reset-vector.S
+++ b/arch/xtensa/core/startup/reset-vector.S
@@ -433,16 +433,10 @@ _xtos_mpu_attribs:
 #elif XCHAL_HAVE_CACHEATTR || XCHAL_HAVE_MIMIC_CACHEATTR \
 		|| XCHAL_HAVE_XLT_CACHEATTR \
 		|| (XCHAL_HAVE_PTP_MMU && XCHAL_HAVE_SPANNING_WAY)
-/* FixMe: Setting CACHEATTR from _memmap_cacheattr_reset is making the
- * Intel_S1000 SoC get into some unknown state. Removing them only for
- * Intel_S1000_CRB
- */
-#ifndef CONFIG_BOARD_INTEL_S1000_CRB
 	/* note: absolute symbol, not a ptr */
 	movi	a2, _memmap_cacheattr_reset
 	/* set CACHEATTR from a2 (clobbers a3-a8) */
 	cacheattr_set
-#endif
 #endif
 
 	/* Now that caches are initialized, cache coherency can be enabled. */

--- a/soc/xtensa/intel_s1000/linker.ld
+++ b/soc/xtensa/intel_s1000/linker.ld
@@ -155,7 +155,27 @@ _memmap_cacheattr_bp_strict = 0x22F22FFF;
 _memmap_cacheattr_wb_allvalid = 0x44224222;
 _memmap_cacheattr_wt_allvalid = 0x11221222;
 _memmap_cacheattr_bp_allvalid = 0x22222222;
-_memmap_cacheattr_intel_s1000 = 0xf2ff4242;
+
+/*
+ * Cache attributes for memory addresses:
+ * (Each 4 bits correspond to 512MB of memory)
+ *
+ * 0x00000000 - 0x1FFFFFFF (bit  0 -  3) : Bypass cache
+ *                                         (region for hardware registers)
+ * 0x20000000 - 0x3FFFFFFF (bit  4 -  7) : No access
+ * 0x40000000 - 0x5FFFFFFF (bit  8 - 11) : No access
+ * 0x60000000 - 0x7FFFFFFF (bit 12 - 15) : No access
+ * 0x80000000 - 0x9FFFFFFF (bit 16 - 19) : Bypass cache
+ * 0xA0000000 - 0xBFFFFFFF (bit 20 - 23) : Cached, write-back
+ * 0xC0000000 - 0xDFFFFFFF (bit 24 - 27) : Bypass cache
+ * 0xE0000000 - 0xFFFFFFFF (bit 28 - 31) : Cached, write-back
+ *
+ * Note that this is both for instruction and data caches,
+ * as cacheattr_set macro sets them both to the same set of
+ * attributes.
+ */
+_memmap_cacheattr_intel_s1000 = 0x4242fff2;
+
 PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_intel_s1000);
 SECTIONS
 {


### PR DESCRIPTION
This reverts commit c9ace83c896c2b8b047995762b8af9a2a9a9bdc2 which
bypasses setting cache attributes.

The previous cache attributes actually set the text/data/etc.
sections to be inaccessible. So fix it.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>