### PR TITLE
Instant doc/ gratification: do not re-run doxygen when not needed

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -112,10 +112,25 @@ add_custom_target(
   COMMENT "Copying files to ${RST_OUT}"
 )
 
-set(ARGS ${DOXYFILE_OUT})
+# For incremental builds not to miss any source change this MUST be kept
+# a superset of INPUT= and FILE_PATTERNS= in zephyr.doxyfile.in
+file(GLOB_RECURSE  DOXY_SOURCES
+  ${ZEPHYR_BASE}/include/*.[c,h,S]
+  ${ZEPHYR_BASE}/lib/libc/*.[c,h,S]
+  ${ZEPHYR_BASE}/tests/*.[h,c,S]
+  )
+# For debug. Also find generated list in doc/_build/(build.ninja|CMakeFiles/)
+# message("DOXY_SOURCES= " ${DOXY_SOURCES})
 
-add_custom_target(
-  doxy
+set(ARGS ${DOXYFILE_OUT})
+set(DOXY_RUN_TSTAMP ${CMAKE_CURRENT_BINARY_DIR}/last_doxy_run_tstamp)
+
+
+# Create timestamp first so we re-run if source files are edited while
+# doxygen is running
+add_custom_command(
+  OUTPUT ${DOXY_RUN_TSTAMP}
+  COMMAND cmake -E touch ${DOXY_RUN_TSTAMP}
   COMMAND ${CMAKE_COMMAND}
     -DCOMMAND=${DOXYGEN_EXECUTABLE}
     -DARGS="${ARGS}"
@@ -123,6 +138,7 @@ add_custom_target(
     -DERROR_FILE=${DOXY_LOG}
     -DWORKING_DIRECTORY=${CMAKE_CURRENT_LIST_DIR}
     -P ${ZEPHYR_BASE}/cmake/util/execute_process.cmake
+  DEPENDS ${DOXY_SOURCES}
   COMMENT "Running ${DOXYGEN_EXECUTABLE}"
 )
 
@@ -138,9 +154,9 @@ add_custom_target(
     ${PYTHON_EXECUTABLE} scripts/restore_modification_times.py
     --loglevel  WARN  ${DOXY_OUT}/xml
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  DEPENDS ${DOXY_RUN_TSTAMP}
+  COMMENT "Fixing modification times of ${DOXY_OUT}/xml/ output"
 )
-
-add_dependencies(doxy_real_modified_times doxy)
 
 add_custom_target(
   pristine

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -76,8 +76,8 @@ set(CONTENT_OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/extracted-content.txt)
 configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
 file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/Kconfig.modules)
 
-# This command is used to copy all documentation source files into the build
-# directory,
+# This command is used to copy all documentation source files from the
+# ZEPHYR_BASE/ environment variable into the build directory,
 #
 # We need to make copies because Sphinx requires a single
 # documentation root directory, but Zephyr's documentation is
@@ -109,6 +109,7 @@ add_custom_target(
   # Copy all files in doc/ to the rst folder
   COMMAND ${EXTRACT_CONTENT_COMMAND}
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  COMMENT "Copying files to ${RST_OUT}"
 )
 
 set(ARGS ${DOXYFILE_OUT})
@@ -122,6 +123,7 @@ add_custom_target(
     -DERROR_FILE=${DOXY_LOG}
     -DWORKING_DIRECTORY=${CMAKE_CURRENT_LIST_DIR}
     -P ${ZEPHYR_BASE}/cmake/util/execute_process.cmake
+  COMMENT "Running ${DOXYGEN_EXECUTABLE}"
 )
 
 # Doxygen doesn't support incremental builds.
@@ -134,7 +136,7 @@ add_custom_target(
   doxy_real_modified_times
   COMMAND ${CMAKE_COMMAND} -E env
     ${PYTHON_EXECUTABLE} scripts/restore_modification_times.py
-    --loglevel ERROR  ${DOXY_OUT}/xml
+    --loglevel  WARN  ${DOXY_OUT}/xml
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
 
@@ -169,6 +171,7 @@ add_custom_target(
   KCONFIG_DOC_MODE=1
   ${PYTHON_EXECUTABLE} scripts/genrest.py Kconfig ${RST_OUT}/doc/reference/kconfig/
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  COMMENT "Running genrest.py Kconfig ${RST_OUT}/doc/reference/kconfig/"
 )
 
 set(KI_SCRIPT ${ZEPHYR_BASE}/scripts/filter-known-issues.py)
@@ -196,6 +199,12 @@ add_custom_target(
   USES_TERMINAL
 )
 
+# "breathe", the sphinx plugin that parses XML output from doxygen, has
+# an "everything on everything" dependency issue reported at:
+# https://github.com/michaeljones/breathe/issues/420 In other words
+# changing 1 source file costs the same build time than changing all
+# source files. breathe is fortunately smart enough not to run at all
+# when *nothing* has changed.
 add_custom_target(
   html
   COMMAND ${SPHINX_BUILD_HTML_COMMAND}
@@ -203,7 +212,7 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -P ${ZEPHYR_BASE}/cmake/util/fmerge.cmake ${DOC_LOG} ${DOXY_LOG} ${SPHINX_LOG}
   COMMAND ${PYTHON_EXECUTABLE} ${KI_SCRIPT} --config-dir ${CONFIG_DIR} --errors ${DOC_WARN} --warnings ${DOC_WARN} ${DOC_LOG}
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-  COMMENT "Generating HTML documentation"
+  COMMENT "Generating HTML documentation with ${SPHINXBUILD} ${SPHINXOPTS}"
   ${SPHINX_USES_TERMINAL}
 )
 

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -750,6 +750,8 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
+# This MUST be kept in sync with DOXY_SOURCES in doc/CMakeLists.txt
+# for incremental (and faster) builds to work correctly.
 INPUT                  = @ZEPHYR_BASE@/include/ \
                          @ZEPHYR_BASE@/include/misc/ \
                          @ZEPHYR_BASE@/include/arch/x86/ \
@@ -786,6 +788,8 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf and *.qsf.
 
+# This MUST be kept in sync with DOXY_SOURCES in doc/CMakeLists.txt
+# for incremental (and faster) builds to work correctly.
 FILE_PATTERNS          = "*.c" \
                          "*.h" \
                          "*.S"


### PR DESCRIPTION
Use file(GLOB_RECURSE ...) to generate a superset of doxygen input
files. Use this list as a dependency for a new empty file
doc/_build/last_doxy_run_tstamp.
    
The incremental build time to re-run "make htmldocs-fast" after a small
.rst doc change is brought down from from ~8s to ~4s on my Linux system
 and from ~30s to less than 10s on my MacBook.
    
Doxygen changes are still slow for a couple reasons isolated and
documented in doc/CMakeLists.txt)
