### PR TITLE
tests: mem_alloc: Fix build issue with malloc test

### DIFF
--- a/tests/lib/mem_alloc/src/main.c
+++ b/tests/lib/mem_alloc/src/main.c
@@ -191,7 +191,7 @@ void test_memalloc_max(void)
 {
 	char *ptr = NULL;
 
-	ptr = malloc(0xF0000000);
+	ptr = malloc(0x7fffffff);
 	zassert_is_null(ptr, "malloc passed unexpectedly");
 	free(ptr);
 	ptr = NULL;


### PR DESCRIPTION
Since malloc takes a size_t, we should use 0x7fffffff as the max size
(ie what the larget unsigned int) would normall be.  Newer newlib's have
a check that will fail building since 0xf0000000 exceeds the size.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>