### PR TITLE
scripts/*syscalls.py: sort os.walk() for a more deterministic build

### DIFF
--- a/scripts/parse_syscalls.py
+++ b/scripts/parse_syscalls.py
@@ -23,7 +23,9 @@ def analyze_headers(multiple_directories):
     ret = []
 
     for base_path in multiple_directories:
-        for root, dirs, files in os.walk(base_path):
+        for root, dirs, files in os.walk(base_path, topdown=True):
+            dirs.sort()
+            files.sort()
             for fn in files:
 
                 # toolchain/common.h has the definition of __syscall which we
@@ -52,7 +54,9 @@ def parse_args():
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument("-i", "--include", required=True, action='append',
-                        help="Base include directory")
+                        help='''include directories recursively scanned
+                        for .h files.  Can be specified multiple times:
+                        -i topdir1 -i topdir2 ...''')
     parser.add_argument(
         "-j", "--json-file", required=True,
         help="Write system call prototype information as json to file")

--- a/scripts/subfolder_list.py
+++ b/scripts/subfolder_list.py
@@ -45,7 +45,8 @@ def main():
     else:
         dirlist.extend(args.directory)
     dirlist.extend(os.linesep)
-    for root, dirs, files in os.walk(args.directory):
+    for root, dirs, _ in os.walk(args.directory, topdown=True):
+        dirs.sort()
         for subdir in dirs:
             if(args.create_links is not None):
                 directory = os.path.join(root, subdir)


### PR DESCRIPTION
Found by "disordered --shuffle-dirents=yes".

Sorting os.walk() in scripts/subfolder_list.py removes the randomness in
the following files:

  build/zephyr/misc/generated/syscalls_subdirs.txt
  build/zephyr/CMakeFiles/syscall_list_h_target.dir/ or build.ninja

Sorting os.walk() in scripts/parse_syscalls.py removes the randomness
in:

  build/zephyr/misc/generated/syscalls.json
  build/zephyr/include/generated/syscall_dispatch.c
  build/zephyr/include/generated/syscall_list.h

Note my (limited so far) testing did *not* observe any randomness in any
object file that this would address; the main purpose here is to remove
a very large amount of noise in diffoscope.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>