### PR TITLE
extract_dts_includes: allow to overwrite Zephyrś bindings by project specific ones

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -426,8 +426,9 @@ def load_binding_file(fname):
                        .format(fname))
 
     if len(filepaths) > 1:
-        yaml_inc_error("Error: multiple candidates for file name '{}' in "
-                       "!include statement: {}".format(fname, filepaths))
+        print("Warning: multiple candidates for file name "
+              "'{}' in !include statement - using first of {}".
+              format(fname, filepaths))
 
     with open(filepaths[0], 'r', encoding='utf-8') as f:
         return yaml.load(f)


### PR DESCRIPTION
Multiple binding files of the same filename generate an error.
Make it a warning and use the first file found.

This allows to override Zephyrś bindings by project specific ones.

Signed-off-by: Bobby Noelte <b0661n0e17e@gmail.com>