### PR TITLE
arch/x86: cmake: fix mmu_tables.bin no such file build error

### DIFF
--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -200,6 +200,20 @@ if(CONFIG_X86_MMU)
       user_mmu_tables.o
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       DEPENDS user_mmu_tables.bin
+      # Note that, although mmu_tables.o is not needed here, it is
+      # specified here to avoid running the command to generate
+      # mmu_tables.bin and user_mmu_tables.bin twice under parallel
+      # build.
+      #
+      # When timing is right under parallel build, both mmu_tables.o
+      # and user_mmu_tables.o can be triggered to build at the same
+      # time. If they both don't see {,user_}mmu_tables.bin are not
+      # there, the dependencies will cause them to be built in
+      # parallel. Since both paths are writing to the same files,
+      # the .bin files may disappear or get truncated, resulting in
+      # failure to build mmu_tables.o or user_mmu_tables.o. Hence
+      # the need for "fake" dependency here.
+      DEPENDS mmu_tables_o
     )
 
     add_custom_target(  user_mmu_tables_o DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/user_mmu_tables.o)


### PR DESCRIPTION
With parallel build, a cmake custom command with multiple outputs
creates multiple dependence paths. When these outputs are being
used by multiple downstream targets, the original custom command
is being executed multiple times. For mmu_tables.bin, the build
log shows:

  [ 81%] Generating mmulist.bin
  [ 82%] Generating mmulist.bin
  [ 82%] Generating mmu_tables.bin, user_mmu_tables.bin
  [ 83%] Generating mmu_tables.bin, user_mmu_tables.bin
  [ 91%] Generating user_mmu_tables.o
  [ 92%] Generating mmu_tables.o
  [ 92%] Built target user_mmu_tables_o
  [ 92%] Built target mmu_tables_o

Generating mmu_tables.o and user_mmu_tables.o (depending on
mmu_tables.bin and user_mmu_tables.bin, respectively) causes
the custom command generating the two .bin files to run twice.
When timing is right, for example, the path through building
mmu_tables.o has done with generating mmu_tables.bin/user_mmu_tables.bin
and starts building the object file. While the path through
user_mmu_tables.o just starts executing the command to generate
the .bin files. This may make the .bin files to disappear or
be truncated, and causing the mmu_tables.o target trying to read
mmu_tables.bin to fail.

The fix is to purposely combine the .bin files output to be
one target, so there would only be one path through this.

Fixes #13410

Signed-off-by: Daniel Leung <daniel.leung@intel.com>