### PR TITLE
boards: x86_64: qemu_x86_64: Remove board.h

### DIFF
--- a/boards/x86_64/qemu_x86_64/board.h
+++ b/boards/x86_64/qemu_x86_64/board.h
@@ -1,5 +1,0 @@
-/*
- * Copyright (c) 2018 Intel Corporation
- *
- * SPDX-License-Identifier: Apache-2.0
- */


### PR DESCRIPTION
board.h shouldn't be needed and the file has no contents.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>