### PR TITLE
debug: openocd: change how we manage differences between versions

### DIFF
--- a/subsys/debug/openocd.c
+++ b/subsys/debug/openocd.c
@@ -25,10 +25,12 @@ enum {
 	OPENOCD_OFFSET_T_COOP_FLOAT,
 };
 
-/* Forward-compatibility notes: 1) Increment OPENOCD_OFFSET_VERSION element
- * each time an offset is added to this table.  2) Only append items to this
- * table; otherwise, OpenOCD versions that expects version 0 will read garbage
- * values.
+/* Forward-compatibility notes: 1) Only append items to this table; otherwise
+ * OpenOCD versions that expect less items will read garbage values.
+ * 2) Avoid incompatible changes that affect the interpretation of existing
+ * items. But if you have to do them, increment OPENOCD_OFFSET_VERSION
+ * and submit a patch for OpenOCD to deal with both the old and new scheme.
+ * Only version 1 is backward compatible to version 0.
  */
 __attribute__((used, section(".openocd_dbg")))
 size_t _kernel_openocd_offsets[] = {
@@ -81,7 +83,13 @@ size_t _kernel_openocd_offsets[] = {
 	[OPENOCD_OFFSET_T_PREEMPT_FLOAT] = OPENOCD_UNIMPLEMENTED,
 	[OPENOCD_OFFSET_T_COOP_FLOAT] = OPENOCD_UNIMPLEMENTED,
 #endif
+	/* Version is still 1, but existence of following elements must be
+	 * checked with _kernel_openocd_num_offsets.
+	 */
 };
+
+__attribute__((used, section(".openocd_dbg")))
+size_t _kernel_openocd_num_offsets = ARRAY_SIZE(_kernel_openocd_offsets);
 
 __attribute__((used, section(".openocd_dbg")))
 u8_t _kernel_openocd_size_t_size = (u8_t)sizeof(size_t);


### PR DESCRIPTION
Every time the array of offsets was changed, it was changed in a backward compatible way by appending elements to the end. But the last time this was done, it was forgotten to raise the version number. On top of that the patch for OpenOCD to support Zephyr has never been updated to support anything else than version 0. So the idea of using a version number to track compatible changes didn't work out.

Therefore add another symbol that can be read by OpenOCD to get the number of elements in the array. This value is automatically calculated during compilation. The version number element should from now on be incremented only for incompatible changes.

Fixes: #13448