### PR TITLE
Bluetooth: use passive scanning consistently in central samples

### DIFF
--- a/samples/bluetooth/central/src/main.c
+++ b/samples/bluetooth/central/src/main.c
@@ -112,7 +112,7 @@ void main(void)
 
 	bt_conn_cb_register(&conn_callbacks);
 
-	err = bt_le_scan_start(BT_LE_SCAN_ACTIVE, device_found);
+	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, device_found);
 	if (err) {
 		printk("Scanning failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -222,8 +222,7 @@ void main(void)
 
 	bt_conn_cb_register(&conn_callbacks);
 
-	err = bt_le_scan_start(BT_LE_SCAN_ACTIVE, device_found);
-
+	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, device_found);
 	if (err) {
 		printk("Scanning failed to start (err %d)\n", err);
 		return;


### PR DESCRIPTION
Use only passive scanning in Bluetooth central and central_hr samples.  The examples previously used passive and active scanning for no particular reason.