### PR TITLE
Bluetooth: gatt: ccc changed cb after connection cb

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2080,8 +2080,6 @@ static void bt_att_connected(struct bt_l2cap_chan *chan)
 
 	k_delayed_work_init(&att->timeout_work, att_timeout);
 	sys_slist_init(&att->reqs);
-
-	bt_gatt_connected(ch->chan.conn);
 }
 
 static void bt_att_disconnected(struct bt_l2cap_chan *chan)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -33,6 +33,7 @@
 #include "keys.h"
 #include "smp.h"
 #include "att_internal.h"
+#include "gatt_internal.h"
 
 NET_BUF_POOL_DEFINE(acl_tx_pool, CONFIG_BT_L2CAP_TX_BUF_COUNT,
 		    BT_L2CAP_BUF_SIZE(CONFIG_BT_L2CAP_TX_MTU),
@@ -136,6 +137,8 @@ static void notify_connected(struct bt_conn *conn)
 			cb->connected(conn, conn->err);
 		}
 	}
+
+	bt_gatt_connected(conn);
 }
 
 static void notify_disconnected(struct bt_conn *conn)


### PR DESCRIPTION
Fixes #13316

Changed the order of Bluetooth callbacks. Now the connected callback is
received before CCC changed callbacks.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>