### PR TITLE
soc: stm32: Explicit rules in Kconfig.defconfig hierachy + minor optmization

### DIFF
--- a/soc/arm/st_stm32/common/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/common/Kconfig.defconfig.series
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Here are set all the Kconfig symbols common to the whole STM32 family
+
 if SOC_FAMILY_STM32
 
 if SERIAL

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.series
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Kconfig symbols common to STM32F0 series
+
 if SOC_SERIES_STM32F0X
 
 source "soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f0*"
@@ -13,6 +15,8 @@ config SOC_SERIES
 	default "stm32f0"
 
 if GPIO_STM32
+
+# GPIO ports A, B and C are set in ../common/Kconfig.defconfig.series
 
 config GPIO_STM32_PORTD
 	default y

--- a/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.series
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Kconfig symbols common to STM32F1 series
+
 if SOC_SERIES_STM32F1X
 
 source "soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f1*"
@@ -13,6 +15,8 @@ config SOC_SERIES
 	default "stm32f1"
 
 if GPIO_STM32
+
+# GPIO ports A, B and C are set in ../common/Kconfig.defconfig.series
 
 config GPIO_STM32_PORTD
 	default y

--- a/soc/arm/st_stm32/stm32f2/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f2/Kconfig.defconfig.series
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Kconfig symbols common to STM32F2 series
+
 if SOC_SERIES_STM32F2X
 
 source "soc/arm/st_stm32/stm32f2/Kconfig.defconfig.stm32f2*"
@@ -13,6 +15,8 @@ config SOC_SERIES
 	default "stm32f2"
 
 if GPIO_STM32
+
+# GPIO ports A, B and C are set in ../common/Kconfig.defconfig.series
 
 config GPIO_STM32_PORTD
 	default y

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.series
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Kconfig symbols common to STM32F3 series
+
 if SOC_SERIES_STM32F3X
 
 source "soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f3*"
@@ -13,6 +15,8 @@ config SOC_SERIES
 	default "stm32f3"
 
 if GPIO_STM32
+
+# GPIO ports A, B and C are set in ../common/Kconfig.defconfig.series
 
 config GPIO_STM32_PORTD
 	default y

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Kconfig symbols common to STM32F4 series
+
 if SOC_SERIES_STM32F4X
 
 source "soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f4*"
@@ -13,6 +15,8 @@ config SOC_SERIES
 	default "stm32f4"
 
 if GPIO_STM32
+
+# GPIO ports A, B and C are set in ../common/Kconfig.defconfig.series
 
 config GPIO_STM32_PORTD
 	default y

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.series
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Kconfig symbols common to STM32F7 series
+
 if SOC_SERIES_STM32F7X
 
 source "soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f7*"
@@ -13,6 +15,8 @@ config SOC_SERIES
 	default "stm32f7"
 
 if GPIO_STM32
+
+# GPIO ports A, B and C are set in ../common/Kconfig.defconfig.series
 
 config GPIO_STM32_PORTD
 	default y

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Kconfig symbols common to STM32L0 series
+
 if SOC_SERIES_STM32L0X
 
 source "soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l0*"
@@ -13,6 +15,8 @@ config SOC_SERIES
 	default "stm32l0"
 
 if GPIO_STM32
+
+# GPIO ports A, B and C are set in ../common/Kconfig.defconfig.series
 
 endif # GPIO_STM32
 

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
@@ -6,6 +6,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Kconfig symbols common to STM32L4 series
+
 if SOC_SERIES_STM32L4X
 
 source "soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4*"
@@ -16,10 +18,13 @@ config SOC_SERIES
 
 if GPIO_STM32
 
+# GPIO ports A, B and C are set in ../common/Kconfig.defconfig.series
+
 config GPIO_STM32_PORTH
 	default y
 
 endif # GPIO_STM32
+
 if I2C_STM32
 
 config I2C_STM32_V2

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
@@ -13,6 +13,13 @@ source "soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4*"
 config SOC_SERIES
 	default "stm32l4"
 
+
+if GPIO_STM32
+
+config GPIO_STM32_PORTH
+	default y
+
+endif # GPIO_STM32
 if I2C_STM32
 
 config I2C_STM32_V2

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l432xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l432xx
@@ -24,4 +24,3 @@ config GPIO_STM32_PORTH
 endif # GPIO_STM32
 
 endif # SOC_STM32L432XC
-

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l433xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l433xx
@@ -23,10 +23,6 @@ config GPIO_STM32_PORTD
 config GPIO_STM32_PORTE
 	default y
 
-config GPIO_STM32_PORTH
-	default y
-
 endif # GPIO_STM32
 
 endif # SOC_STM32L433XC
-

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l452xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l452xx
@@ -23,10 +23,6 @@ config GPIO_STM32_PORTD
 config GPIO_STM32_PORTE
 	default y
 
-config GPIO_STM32_PORTH
-	default y
-
 endif # GPIO_STM32
 
 endif # SOC_STM32L452XC
-

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l471xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l471xx
@@ -29,9 +29,6 @@ config GPIO_STM32_PORTF
 config GPIO_STM32_PORTG
 	default y
 
-config GPIO_STM32_PORTH
-	default y
-
 endif # GPIO_STM32
 
 endif # SOC_STM32L471XX

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l475xg
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l475xg
@@ -29,9 +29,6 @@ config GPIO_STM32_PORTF
 config GPIO_STM32_PORTG
 	default y
 
-config GPIO_STM32_PORTH
-	default y
-
 endif # GPIO_STM32
 
 endif # SOC_STM32L475XG

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l476xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l476xx
@@ -30,9 +30,6 @@ config GPIO_STM32_PORTF
 config GPIO_STM32_PORTG
 	default y
 
-config GPIO_STM32_PORTH
-	default y
-
 endif # GPIO_STM32
 
 endif # SOC_STM32L476XG

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l496xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l496xx
@@ -30,13 +30,9 @@ config GPIO_STM32_PORTF
 config GPIO_STM32_PORTG
 	default y
 
-config GPIO_STM32_PORTH
-	default y
-
 config GPIO_STM32_PORTI
 	default y
 
 endif # GPIO_STM32
 
 endif # SOC_STM32L496XG
-

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4r5xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4r5xx
@@ -29,9 +29,6 @@ config GPIO_STM32_PORTF
 config GPIO_STM32_PORTG
 	default y
 
-config GPIO_STM32_PORTH
-	default y
-
 endif # GPIO_STM32
 
 endif # SOC_STM32L4R5XI


### PR DESCRIPTION
There are some implicit rules in STM32 family Kconfig.defconfig fragments organizations.
Add comments to explicit these rules.

Additionally perform a minor optimization in STM32L4 series Kconfig definitions 