### PR TITLE
dfu: mcuboot: rename boot_swap_type> mcuboot_swap_type

### DIFF
--- a/ext/lib/mgmt/mcumgr/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/ext/lib/mgmt/mcumgr/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -237,7 +237,7 @@ img_mgmt_impl_write_image_data(unsigned int offset, const void *data,
 int
 img_mgmt_impl_swap_type(void)
 {
-    switch (boot_swap_type()) {
+    switch (mcuboot_swap_type()) {
     case BOOT_SWAP_TYPE_NONE:
         return IMG_MGMT_SWAP_TYPE_NONE;
     case BOOT_SWAP_TYPE_TEST:

--- a/include/dfu/mcuboot.h
+++ b/include/dfu/mcuboot.h
@@ -143,7 +143,7 @@ int boot_write_img_confirmed(void);
  * @return a BOOT_SWAP_TYPE_[...] constant on success, negative errno code on
  * fail.
  */
-int boot_swap_type(void);
+int mcuboot_swap_type(void);
 
 /**
  * @brief Marks the image in slot 1 as pending. On the next reboot, the system

--- a/samples/subsys/usb/dfu/README.rst
+++ b/samples/subsys/usb/dfu/README.rst
@@ -86,7 +86,7 @@ showing this output to the console:
   [MCUBOOT] [INF] boot_status_source: Image 0: magic=unset, copy_done=0xff, image_ok=0xff
   [MCUBOOT] [INF] boot_status_source: Scratch: magic=unset, copy_done=0xe, image_ok=0xff
   [MCUBOOT] [INF] boot_status_source: Boot source: slot 0
-  [MCUBOOT] [INF] boot_swap_type: Swap type: test
+  [MCUBOOT] [INF] mcuboot_swap_type: Swap type: test
   [MCUBOOT] [INF] main: Bootloader chainload address offset: 0x20000
   [MCUBOOT] [INF] main: Jumping to the first image slot0
   ***** Booting Zephyr OS v1.11.0-830-g9df01813c4 *****
@@ -102,7 +102,7 @@ USB DFU sample, showing this output to the console:
   [MCUBOOT] [INF] boot_status_source: Image 0: magic=good, copy_done=0x1, image_ok=0xff
   [MCUBOOT] [INF] boot_status_source: Scratch: magic=unset, copy_done=0xe, image_ok=0xff
   [MCUBOOT] [INF] boot_status_source: Boot source: none
-  [MCUBOOT] [INF] boot_swap_type: Swap type: revert
+  [MCUBOOT] [INF] mcuboot_swap_type: Swap type: revert
   [MCUBOOT] [INF] main: Bootloader chainload address offset: 0x20000
   ***** Booting Zephyr OS v1.11.0-830-g9df01813c4 *****
 

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -416,7 +416,7 @@ static int boot_read_swap_state(u8_t bank_id, struct boot_swap_state *state)
 	return 0;
 }
 
-int boot_swap_type(void)
+int mcuboot_swap_type(void)
 {
 	const struct boot_swap_table *table;
 	struct boot_swap_state state_slot0;


### PR DESCRIPTION
This function conflicts with a function of the same name in mcuboot. This happens when building USB DFU support into mcuboot.

DFU over USB uses image manager and mcuboot internals to manage images downloaded to the device.