### PR TITLE
boards: reel_board: fix power consumption and remove cts,rts pins from uart node

### DIFF
--- a/boards/arm/reel_board/board.c
+++ b/boards/arm/reel_board/board.c
@@ -24,6 +24,20 @@ static int board_reel_board_init(struct device *dev)
 
 	gpio->OUTSET = BIT(PERIPH_PON_PIN);
 
+	/*
+	 * Enable pull-up on UART RX pin to reduce power consumption.
+	 * If the board is powered by battery and the debugger is
+	 * not connected via USB to the host, the SoC consumes up
+	 * to 2mA more than expected.
+	 * The consumption increases because RX pin is floating
+	 * (High-Impedance state of pin B from Dual-Supply Bus Transceiver).
+	 */
+	gpio = NRF_P0;
+	gpio->PIN_CNF[DT_NORDIC_NRF_UART_0_RX_PIN] =
+		(GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos) |
+		(GPIO_PIN_CNF_PULL_Pullup << GPIO_PIN_CNF_PULL_Pos) |
+		(GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos);
+
 	return 0;
 }
 

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -77,8 +77,6 @@
 	status = "ok";
 	tx-pin = <6>;
 	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
 };
 
 &i2c0 {


### PR DESCRIPTION
Enable pull-up on UART RX pin to reduce power consumption.
If the board is powered by battery and the debugger is
not connected via USB to the host, the SoC consumes up
to 2mA more than expected.
The consumption increases because RX pin is floating
(High-Impedance state of pin B from Dual-Supply Bus Transceiver U6).

Remove cts,rts pins from uart node.
The pins are used for expansion connector.