### PR TITLE
nrf52_bsim: Add header to allow reusing native_posix drivers

### DIFF
--- a/boards/posix/nrf52_bsim/cmdline.h
+++ b/boards/posix/nrf52_bsim/cmdline.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * This header exists solely to allow drivers meant for the native_posix board
+ * to be used directly in the nrf52_bsim board.
+ * Note that such reuse should be done with great care.
+ *
+ * The command line arguments parsing logic from native_posix was born as a copy
+ * of the one from the BabbleSim's libUtil library
+ * They are therefore mostly equal except for types and functions names.
+ *
+ * This header converts these so the native_posix call to dynamically register
+ * command line arguments is passed to the nrf52_bsim one
+ */
+
+#include "../native_posix/cmdline_common.h"
+
+static inline void native_add_command_line_opts(struct args_struct_t *args)
+{
+	void bs_add_extra_dynargs(struct args_struct_t *args);
+	bs_add_extra_dynargs(args);
+}


### PR DESCRIPTION
This board and the native_posix board share the POSIX architecture.
Some of the native_posix drivers/backends only rely on the
underlaying operating system API, and do not require any special
HW model to operate.
Therefore it is quite easy to reuse some of them into this board.

Currently the only limitation, for some, is the interface they use
in the board to register their command line arguments.
This header provides a minimal shim to rename the, otherwise
equivalent, call.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

-----

So for example to compile the native_posix CTF bottom in the nrf52_bsim, you can run: 
```
build$ cmake ../samples/hello_world/ -DBOARD=nrf52_bsim -GNinja -DCONFIG_TRACING_CTF=y -DCONFIG_TRACING_CTF_BOTTOM_POSIX=y
```