### PR TITLE
scripts: gitlint: Consistent case for Signed-off-by

### DIFF
--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -51,8 +51,8 @@ class BodyMaxLineCount(CommitRule):
             return [RuleViolation(self.id, message, line_nr=1)]
 
 class SignedOffBy(CommitRule):
-    """ This rule will enforce that each commit contains a "Signed-Off-By" line.
-    We keep things simple here and just check whether the commit body contains a line that starts with "Signed-Off-By".
+    """ This rule will enforce that each commit contains a "Signed-off-by" line.
+    We keep things simple here and just check whether the commit body contains a line that starts with "Signed-off-by".
     """
 
     # A rule MUST have a human friendly name
@@ -70,7 +70,7 @@ class SignedOffBy(CommitRule):
                     return [RuleViolation(self.id, "Signed-off-by: must have a full name", line_nr=1)]
                 else:
                     return
-        return [RuleViolation(self.id, "Body does not contain a 'Signed-Off-By' line", line_nr=1)]
+        return [RuleViolation(self.id, "Body does not contain a 'Signed-off-by:' line", line_nr=1)]
 
 class TitleMaxLengthRevert(LineRule):
     name = "title-max-length-no-revert"


### PR DESCRIPTION
The commit header as added by "git commit -s" is "Signed-off-by:",
and not any other casing. While it perhaps case-insensitive, use
canonical casing to not confuse (attentive) users.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>