### PR TITLE
dts: nxp: Fix typos: interrupts-names -> interrupt-names

### DIFF
--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -412,7 +412,7 @@
 			compatible = "nxp,kinetis-ethernet";
 			reg = <0x400c0004 0x620>;
 			interrupts = <83 0>, <84 0>, <85 0>;
-			interrupts-names = "TX", "RX", "ERR_MISC";
+			interrupt-names = "TX", "RX", "ERR_MISC";
 			status = "disabled";
 			local-mac-address = [00 00 00 00 00 00];
 			label = "ETH_0";
@@ -420,7 +420,7 @@
 				compatible = "nxp,kinetis-ptp";
 				status = "disabled";
 				interrupts = <82 0>;
-				interrupts-names = "IEEE1588_TMR";
+				interrupt-names = "IEEE1588_TMR";
 			};
 		};
 

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -308,7 +308,7 @@
 			compatible = "nxp,kinetis-ethernet";
 			reg = <0x402D8000 0x628>;
 			interrupts = <114 0>;
-			interrupts-names = "COMMON";
+			interrupt-names = "COMMON";
 			status = "disabled";
 			local-mac-address = [00 00 00 00 00 00];
 			label = "ETH_0";
@@ -316,7 +316,7 @@
 				compatible = "nxp,kinetis-ptp";
 				status = "disabled";
 				interrupts = <115 0>;
-				interrupts-names = "IEEE1588_TMR";
+				interrupt-names = "IEEE1588_TMR";
 			};
 		};
 


### PR DESCRIPTION
Found with a 'git grep s-names' while figuring out some `scripts/dts` code.