### PR TITLE
posix: rename priority in sched_param struct

### DIFF
--- a/include/posix/posix_sched.h
+++ b/include/posix/posix_sched.h
@@ -21,7 +21,7 @@ extern "C" {
 #endif /* SCHED_RR */
 
 struct sched_param {
-	int priority;
+	int sched_priority;
 };
 
 /**

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -84,7 +84,7 @@ static s32_t posix_to_zephyr_priority(u32_t priority, int policy)
 int pthread_attr_setschedparam(pthread_attr_t *attr,
 			       const struct sched_param *schedparam)
 {
-	int priority = schedparam->priority;
+	int priority = schedparam->sched_priority;
 
 	if ((attr == NULL) || (attr->initialized == 0) ||
 	    (is_posix_prio_valid(priority, attr->schedpolicy) == false)) {
@@ -262,7 +262,7 @@ int pthread_setschedparam(pthread_t pthread, int policy,
 		return EINVAL;
 	}
 
-	new_prio = posix_to_zephyr_priority(param->priority, policy);
+	new_prio = posix_to_zephyr_priority(param->sched_priority, policy);
 
 	if (is_posix_prio_valid(new_prio, policy) == false) {
 		return EINVAL;
@@ -306,7 +306,7 @@ int pthread_getschedparam(pthread_t pthread, int *policy,
 
 	priority = k_thread_priority_get((k_tid_t) thread);
 
-	param->priority = zephyr_to_posix_priority(priority, policy);
+	param->sched_priority = zephyr_to_posix_priority(priority, policy);
 	return 0;
 }
 
@@ -564,7 +564,7 @@ int pthread_attr_getschedparam(const pthread_attr_t *attr,
 		return EINVAL;
 	}
 
-	schedparam->priority = attr->priority;
+	schedparam->sched_priority = attr->priority;
 	return 0;
 }
 

--- a/tests/posix/common/src/mutex.c
+++ b/tests/posix/common/src/mutex.c
@@ -67,7 +67,7 @@ void test_posix_normal_mutex(void)
 	int schedpolicy = SCHED_FIFO;
 	int ret, type, protocol, temp;
 
-	schedparam.priority = 2;
+	schedparam.sched_priority = 2;
 	ret = pthread_attr_init(&attr);
 	if (ret != 0) {
 		zassert_false(pthread_attr_destroy(&attr),
@@ -126,7 +126,7 @@ void test_posix_recursive_mutex(void)
 	int schedpolicy = SCHED_FIFO;
 	int ret, type, protocol, temp;
 
-	schedparam2.priority = 2;
+	schedparam2.sched_priority = 2;
 	ret = pthread_attr_init(&attr2);
 	if (ret != 0) {
 		zassert_false(pthread_attr_destroy(&attr2),

--- a/tests/posix/common/src/posix_rwlock.c
+++ b/tests/posix/common/src/posix_rwlock.c
@@ -22,7 +22,7 @@ static void *thread_top(void *p1)
 	pthread = (pthread_t) pthread_self();
 	pthread_getschedparam(pthread, &policy, &param);
 	printk("Thread %d scheduling policy = %d & priority %d started\n",
-	       (s32_t) p1, policy, param.priority);
+	       (s32_t) p1, policy, param.sched_priority);
 
 	ret = pthread_rwlock_tryrdlock(&rwlock);
 	if (ret) {
@@ -84,7 +84,7 @@ void test_posix_rw_lock(void)
 			      "Unable to create pthread object attrib");
 
 		/* Setting scheduling priority */
-		schedparam.priority = i + 1;
+		schedparam.sched_priority = i + 1;
 		pthread_attr_setschedparam(&attr[i], &schedparam);
 
 		/* Setting stack */

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -66,7 +66,7 @@ void *thread_top_exec(void *p1)
 
 	pthread_getschedparam(pthread_self(), &policy, &schedparam);
 	printk("Thread %d starting with scheduling policy %d & priority %d\n",
-		 id, policy, schedparam.priority);
+		 id, policy, schedparam.sched_priority);
 	/* Try a double-lock here to exercise the failing case of
 	 * trylock.  We don't support RECURSIVE locks, so this is
 	 * guaranteed to fail.
@@ -187,7 +187,7 @@ void *thread_top_term(void *p1)
 	int val = (u32_t) p1;
 	struct sched_param param, getschedparam;
 
-	param.priority = N_THR_T - (s32_t) p1;
+	param.sched_priority = N_THR_T - (s32_t) p1;
 
 	self = pthread_self();
 
@@ -199,7 +199,7 @@ void *thread_top_term(void *p1)
 			"Unable to get thread priority!");
 
 	printk("Thread %d starting with a priority of %d\n", (s32_t) p1,
-			getschedparam.priority);
+			getschedparam.sched_priority);
 
 	if (val % 2) {
 		ret = pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &oldstate);
@@ -233,13 +233,13 @@ void test_posix_pthread_execution(void)
 	size_t stacksize;
 
 	sem_init(&main_sem, 0, 1);
-	schedparam.priority = CONFIG_NUM_COOP_PRIORITIES - 1;
+	schedparam.sched_priority = CONFIG_NUM_COOP_PRIORITIES - 1;
 	min_prio = sched_get_priority_min(schedpolicy);
 	max_prio = sched_get_priority_max(schedpolicy);
 
 	ret = (min_prio < 0 || max_prio < 0 ||
-			schedparam.priority < min_prio ||
-			schedparam.priority > max_prio);
+			schedparam.sched_priority < min_prio ||
+			schedparam.sched_priority > max_prio);
 
 	/* TESTPOINT: Check if scheduling priority is valid */
 	zassert_false(ret,
@@ -310,8 +310,9 @@ void test_posix_pthread_execution(void)
 
 		pthread_attr_setschedparam(&attr[i], &schedparam);
 		pthread_attr_getschedparam(&attr[i], &getschedparam);
-		zassert_equal(schedparam.priority, getschedparam.priority,
-				"scheduling priorities do not match!");
+		zassert_equal(schedparam.sched_priority,
+			      getschedparam.sched_priority,
+			      "scheduling priorities do not match!");
 
 		ret = pthread_create(&newthread[i], &attr[i], thread_top_exec,
 				(void *)i);
@@ -372,7 +373,7 @@ void test_posix_pthread_termination(void)
 						    PTHREAD_CREATE_DETACHED);
 		}
 
-		schedparam.priority = 2;
+		schedparam.sched_priority = 2;
 		pthread_attr_setschedparam(&attr[i], &schedparam);
 		pthread_attr_setstack(&attr[i], &stack_t[i][0], STACKS);
 		ret = pthread_create(&newthread[i], &attr[i], thread_top_term,
@@ -390,7 +391,7 @@ void test_posix_pthread_termination(void)
 	zassert_equal(ret, EINVAL, "invalid policy set!");
 
 	/* TESTPOINT: Try setting invalid priority */
-	schedparam.priority = PRIO_INVALID;
+	schedparam.sched_priority = PRIO_INVALID;
 	ret = pthread_setschedparam(newthread[0], SCHED_RR, &schedparam);
 	zassert_equal(ret, EINVAL, "invalid priority set!");
 

--- a/tests/posix/common/src/pthread_key.c
+++ b/tests/posix/common/src/pthread_key.c
@@ -143,7 +143,7 @@ void test_posix_multiple_threads_single_key(void)
 					"Unable to create pthread object attr");
 		}
 
-		schedparam.priority = 2;
+		schedparam.sched_priority = 2;
 		pthread_attr_setschedparam(&attr[i], &schedparam);
 		pthread_attr_setstack(&attr[i], &stackp[i][0], STACKSZ);
 
@@ -188,7 +188,7 @@ void test_posix_single_thread_multiple_keys(void)
 				"Unable to create pthread object attr");
 	}
 
-	schedparam.priority = 2;
+	schedparam.sched_priority = 2;
 	pthread_attr_setschedparam(&attr, &schedparam);
 	pthread_attr_setstack(&attr, &stackp[0][0], STACKSZ);
 

--- a/tests/posix/common/src/semaphore.c
+++ b/tests/posix/common/src/semaphore.c
@@ -29,7 +29,7 @@ void initialize_thread_attr(pthread_attr_t *attr)
 {
 	int ret;
 
-	schedparam.priority = 1;
+	schedparam.sched_priority = 1;
 
 	ret = pthread_attr_init(attr);
 	if (ret != 0) {


### PR DESCRIPTION
Priority member in the sched_param struct should be named
sched_priority.

Fixes #13470