### PR TITLE
scripts/dts cleanups, part 7

### DIFF
--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -155,47 +155,43 @@ def insert_defs(node_address, new_defs, new_aliases):
         defs[node_address] = new_defs
 
 
-def create_reduced(nodes, path):
-    # compress nodes list to nodes w/ paths, add interrupt parent
-    if 'last_used_id' not in create_reduced.__dict__:
-        create_reduced.last_used_id = {}
+# Dictionary where all keys default to 0. Used by create_reduced().
+last_used_id = defaultdict(int)
 
-    if 'props' in nodes:
-        status = nodes['props'].get('status')
 
-        if status == "disabled":
-            return
+def create_reduced(node, path):
+    # Compress nodes list to nodes w/ paths, add interrupt parent
 
-    if isinstance(nodes, dict):
-        reduced[path] = dict(nodes)
+    if node['props'].get('status') == 'disabled':
+        return
 
-        # assign an instance ID for each compat
-        compat = nodes['props'].get('compatible')
-        if compat:
-            if type(compat) is not list: compat = [ compat, ]
-            reduced[path]['instance_id'] = {}
-            for k in compat:
-                if k not in create_reduced.last_used_id:
-                    create_reduced.last_used_id[k] = 0
-                else:
-                    create_reduced.last_used_id[k] += 1
-                reduced[path]['instance_id'][k] = create_reduced.last_used_id[k]
+    reduced[path] = node.copy()
+    reduced[path].pop('children', None)
 
-        # Newer versions of dtc might have the properties that look like
-        # reg = <1 2>, <3 4>;
-        # So we need to flatten the list in that case to be:
-        # reg = <1 2 3 4>
-        for p in nodes['props']:
-            prop_val = nodes['props'][p]
-            if isinstance(prop_val, list) and isinstance(prop_val[0], list):
-                nodes['props'][p] = [item for sublist in prop_val for item in sublist]
+    # Assign an instance ID for each compat
+    compat = node['props'].get('compatible')
+    if compat:
+        if type(compat) is not list:
+            compat = [compat]
 
-        reduced[path].pop('children', None)
+        reduced[path]['instance_id'] = {}
+        for comp in compat:
+            reduced[path]['instance_id'][comp] = last_used_id[comp]
+            last_used_id[comp] += 1
+
+    # Flatten 'prop = <1 2>, <3 4>' (which turns into nested lists) to
+    # 'prop = <1 2 3 4>'
+    for val in node['props'].values():
+        if isinstance(val, list) and isinstance(val[0], list):
+            # In-place modification
+            val[:] = [item for sublist in val for item in sublist]
+
+    if node['children']:
         if path != '/':
             path += '/'
-        if nodes['children']:
-            for k, v in sorted(nodes['children'].items()):
-                create_reduced(v, path + k)
+
+        for child_name, child_node in sorted(node['children'].items()):
+            create_reduced(child_node, path + child_name)
 
 
 def get_node_label(node_address):

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -155,14 +155,6 @@ def insert_defs(node_address, new_defs, new_aliases):
         defs[node_address] = new_defs
 
 
-def find_node_by_path(nodes, path):
-    d = nodes
-    for k in path[1:].split('/'):
-        d = d['children'][k]
-
-    return d
-
-
 def create_reduced(nodes, path):
     # compress nodes list to nodes w/ paths, add interrupt parent
     if 'last_used_id' not in create_reduced.__dict__:

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -57,8 +57,9 @@ def extract_string_prop(node_address, key, label):
     defs[node_address][label] = '"' + reduced[node_address]['props'][key] + '"'
 
 
-def extract_property(node_compat, node_address, prop, prop_val):
+def extract_property(node_address, prop):
     node = reduced[node_address]
+    node_compat = get_compat(node_address)
     yaml_node_compat = get_binding(node_address)
     def_label = get_node_label(node_address)
 
@@ -122,7 +123,9 @@ def extract_property(node_compat, node_address, prop, prop_val):
         extract_cells(node_address, prop, prop_values,
                       names, 0, def_label, generic)
     else:
-        default.extract(node_address, prop, prop_val['type'], def_label)
+        default.extract(node_address, prop,
+                        yaml_node_compat['properties'][prop]['type'],
+                        def_label)
 
 
 def generate_node_defines(node_path):
@@ -155,12 +158,12 @@ def generate_node_defines(node_path):
 
             if re.fullmatch(k, c):
                 match = True
-                extract_property(node_compat, node_path, c, v)
+                extract_property(node_path, c)
 
         # Handle the case that we have a boolean property, but its not
         # in the dts
         if not match and v['type'] == 'boolean':
-            extract_property(node_compat, node_path, k, v)
+            extract_property(node_path, k)
 
 
 def prop_names(node, prop_name):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -57,7 +57,7 @@ def extract_string_prop(node_address, key, label):
     defs[node_address][label] = '"' + reduced[node_address]['props'][key] + '"'
 
 
-def extract_property(node_compat, node_address, prop, prop_val, names):
+def extract_property(node_compat, node_address, prop, prop_val):
     node = reduced[node_address]
     yaml_node_compat = get_binding(node_address)
     def_label = get_node_label(node_address)
@@ -100,6 +100,8 @@ def extract_property(node_compat, node_address, prop, prop_val, names):
         extract_bus_name(node_address, 'DT_' + def_label)
 
     def_label = 'DT_' + def_label
+
+    names = prop_names(node, prop)
 
     if prop == 'reg':
         reg.extract(node_address, names, def_label, 1)
@@ -153,13 +155,12 @@ def generate_node_defines(node_path):
 
             if re.fullmatch(k, c):
                 match = True
-                extract_property(node_compat, node_path, c, v,
-                                 prop_names(node, c))
+                extract_property(node_compat, node_path, c, v)
 
         # Handle the case that we have a boolean property, but its not
         # in the dts
         if not match and v['type'] == 'boolean':
-            extract_property(node_compat, node_path, k, v, None)
+            extract_property(node_compat, node_path, k, v)
 
 
 def prop_names(node, prop_name):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -129,14 +129,11 @@ def extract_property(node_address, prop):
 
 
 def generate_node_defines(node_path):
-    node = reduced[node_path]
-    node_compat = get_compat(node_path)
-
-    if node_compat not in get_binding_compats():
+    if get_compat(node_path) not in get_binding_compats():
         return
 
-    for k, v in get_binding(node_path)['properties'].items():
-        if 'generation' not in v:
+    for yaml_prop, yaml_val in get_binding(node_path)['properties'].items():
+        if 'generation' not in yaml_val:
             continue
 
         # Handle any per node extraction first.  For example we
@@ -151,19 +148,19 @@ def generate_node_defines(node_path):
         # Handle each property individually, this ends up handling common
         # patterns for things like reg, interrupts, etc that we don't need
         # any special case handling at a node level
-        for c in node['props']:
-            if c in {'interrupt-names', 'reg-names', 'phandle',
-                     'linux,phandle'}:
+        for prop in reduced[node_path]['props']:
+            if prop in {'interrupt-names', 'reg-names', 'phandle',
+                        'linux,phandle'}:
                 continue
 
-            if re.fullmatch(k, c):
+            if re.fullmatch(yaml_prop, prop):
                 match = True
-                extract_property(node_path, c)
+                extract_property(node_path, prop)
 
         # Handle the case that we have a boolean property, but its not
         # in the dts
-        if not match and v['type'] == 'boolean':
-            extract_property(node_path, k)
+        if not match and yaml_val['type'] == 'boolean':
+            extract_property(node_path, yaml_prop)
 
 
 def prop_names(node, prop_name):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -426,8 +426,7 @@ def yaml_inc_error(msg):
 
 def generate_defines():
     for node_path in reduced.keys():
-        if get_compat(node_path) in get_binding_compats():
-            generate_node_defines(node_path)
+        generate_node_defines(node_path)
 
     if not defs:
         raise Exception("No information parsed from dts file.")


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/zephyr/pull/13385.

 - Gets rid of some mysterious `deepcopy()`s (which deserved a comment... took me a long time to figure
   out why `deepcopy()` was used there)

 - Adds a helper function for fetching `*-names` properties

 - Gets rid of a some parameters that can be derived inside functions instead. That makes it clearer what they're about.

 - Misc. other simplifications

 - Misc. dead code removal

As a side note, I suspect there might be code in `extract_property()` that should be moved to `generate_node_defines()`. `extract_property()` deals with individual device tree properties (`foo = ...`), and not with whole nodes. I need to check some more though.

Only recently figured out that that's what `extract_property()` is about, so I don't blame anyone for placing it there...