### PR TITLE
scripts: Update pyocd version to 0.16.1

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -10,7 +10,7 @@ ply==3.10
 hub==2.0
 gitlint
 pyelftools==0.24
-pyocd==0.15.0
+pyocd==0.16.1
 pyserial
 pykwalify
 # "win32" is used for 64-bit Windows as well


### PR DESCRIPTION
Update the pyocd version to pick up a fix for the command 'pyocd erase',
which was broken in 0.15.0 and fixed in 0.16.0. Although we don't have
any in-tree uses of this command in zephyr, there will soon be in-tree
uses in mcuboot when the deprecated 'pyocd-flashtool' and 'pyocd-tool'
commands are replaced with the new unified pyocd commands.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>