### PR TITLE
arch: arc: fix the overkilled codes caused by removing APP_MEM

### DIFF
--- a/arch/arc/core/mpu/arc_mpu.c
+++ b/arch/arc/core/mpu/arc_mpu.c
@@ -460,6 +460,17 @@ void arc_core_mpu_configure_user_context(struct k_thread *thread)
 	}
 
 	arc_core_mpu_configure(THREAD_STACK_USER_REGION, base, size);
+
+#if defined(CONFIG_APP_SHARED_MEM) && CONFIG_ARC_MPU_VER == 3
+	/*
+	 * here, need to clear THREAD_APP_DATA_REGION for user thread as it will
+	 * be set by kernel thread to to access app_shared mem. For user thread
+	 * the handling of app_shared mem is done by
+	 * THREAD_DOMAIN_PARTITION_REGION
+	 */
+	_region_init(_get_region_index_by_type(THREAD_APP_DATA_REGION)
+		     , 0, 0, 0);
+#endif
 }
 
 /**

--- a/boards/arc/em_starterkit/arc_mpu_regions.c
+++ b/boards/arc/em_starterkit/arc_mpu_regions.c
@@ -11,6 +11,18 @@
 
 #ifdef CONFIG_USERSPACE
 static struct arc_mpu_region mpu_regions[] = {
+#if CONFIG_ARC_MPU_VER == 3
+	/* Region ICCM */
+	MPU_REGION_ENTRY("IMAGE ROM",
+			 (u32_t) _image_rom_start,
+			 (u32_t) _image_rom_size,
+			 REGION_FLASH_ATTR),
+	MPU_REGION_ENTRY("KERNEL MEMORY",
+			 (u32_t) __kernel_ram_start,
+			 (u32_t) __kernel_ram_size,
+			 AUX_MPU_RDP_KW | AUX_MPU_RDP_KR),
+
+#else
 #if DT_ICCM_SIZE > 0
 	/* Region ICCM */
 	MPU_REGION_ENTRY("ICCM",
@@ -33,6 +45,7 @@ static struct arc_mpu_region mpu_regions[] = {
 			AUX_MPU_RDP_KW | AUX_MPU_RDP_KR |
 			AUX_MPU_RDP_KE | AUX_MPU_RDP_UE),
 #endif
+#endif /* ARC_MPU_VER == 3 */
 	/* Region Peripheral */
 	MPU_REGION_ENTRY("PERIPHERAL",
 			 0xF0000000,


### PR DESCRIPTION
these codes are overkilled by commit 41f6011c

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>