### PR TITLE
doc: net: Enhance DHCPv4 documentation

### DIFF
--- a/doc/reference/networking/dhcpv4.rst
+++ b/doc/reference/networking/dhcpv4.rst
@@ -1,11 +1,25 @@
 .. _dhcpv4_interface:
 
-DHCP v4
-#######
+DHCPv4
+######
 
 Overview
 ********
 
+The Dynamic Host Configuration Protocol (DHCP) is a network management protocol
+used on IPv4 networks. A DHCPv4 server dynamically assigns an IPv4 address
+and other network configuration parameters to each device on a network so they
+can communicate with other IP networks.
+See this
+`DHCP Wikipedia article <https://en.wikipedia.org/wiki/Dynamic_Host_Configuration_Protocol>`_
+for a detailed overview of how DHCP works.
+
+Note that Zephyr only supports DHCP client functionality.
+
+Sample usage
+************
+
+See :ref:`dhcpv4-client-sample` for details.
 
 API Reference
 *************

--- a/include/net/dhcpv4.h
+++ b/include/net/dhcpv4.h
@@ -25,6 +25,8 @@ extern "C" {
 #include <misc/slist.h>
 #include <zephyr/types.h>
 
+/** @cond INTERNAL_HIDDEN */
+
 /** Current state of DHCPv4 client address negotiation.
  *
  * Additions removals and reorders in this definition must be
@@ -39,6 +41,8 @@ enum net_dhcpv4_state {
 	NET_DHCPV4_REBINDING,
 	NET_DHCPV4_BOUND,
 } __packed;
+
+/** @endcond */
 
 /**
  *  @brief Start DHCPv4 client on an iface
@@ -62,12 +66,16 @@ void net_dhcpv4_start(struct net_if *iface);
  */
 void net_dhcpv4_stop(struct net_if *iface);
 
+/** @cond INTERNAL_HIDDEN */
+
 /**
  *  @brief DHCPv4 state name
  *
  *  @internal
  */
 const char *net_dhcpv4_state_name(enum net_dhcpv4_state state);
+
+/** @endcond */
 
 /**
  * @}


### PR DESCRIPTION
Add short overview for DHCPv4. Do not add dhcpv4 library internal
state in the documentation.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>