### PR TITLE
arch: arm: enhance built-time rule to check for start addr alignment

### DIFF
--- a/include/arch/arm/cortex_m/mpu/arm_mpu_v8m.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu_v8m.h
@@ -252,7 +252,8 @@ typedef struct {
 #endif /* _ASMLANGUAGE */
 
 #define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size) \
-	BUILD_ASSERT_MSG((size > 0) && \
+	BUILD_ASSERT_MSG((size > 0) && ((u32_t)start % \
+			CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0) && \
 		((size) % CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0), \
-		" the size of the partition must align " \
+		" the start and size of the partition must align " \
 		"with the minimum MPU region size.")


### PR DESCRIPTION
Slightly enhance the build-time ASSERT rule for memory
partitions sanity on ARMv8-M platforms, to check,
additionally, for proper (32-byte) alignment of the start
address.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>