### PR TITLE
doc: net: Enhance DNS resolver documentation

### DIFF
--- a/doc/reference/networking/dns_resolve.rst
+++ b/doc/reference/networking/dns_resolve.rst
@@ -6,6 +6,32 @@ DNS Resolve
 Overview
 ********
 
+The DNS resolver implements a basic DNS resolver according
+to `IETF RFC1035 on Domain Implementation and Specification <https://tools.ietf.org/html/rfc1035>`_.
+Supported DNS answers are IPv4/IPv6 addresses and CNAME.
+
+If a CNAME is received, the DNS resolver will create another DNS query.
+The number of additional queries is controlled by the
+option:`CONFIG_DNS_RESOLVER_ADDITIONAL_QUERIES` Kconfig variable.
+
+The multicast DNS (mDNS) client resolver support can be enabled by setting
+:option:`CONFIG_MDNS_RESOLVER` Kconfig option.
+See `IETF RFC6762 <https://tools.ietf.org/html/rfc6762>`_ for more details
+about mDNS.
+
+The link-local multicast name resolution (LLMNR) client resolver support can be
+enabled by setting the :option:`CONFIG_LLMNR_RESOLVER` Kconfig variable.
+See `IETF RFC4795 <https://tools.ietf.org/html/rfc4795>`_ for more details
+about LLMNR.
+
+For more information about DNS configuration variables, see:
+:file:`subsys/net/lib/dns/Kconfig`. The DNS resolver API can be found at
+:file:`include/net/dns_resolve.h`.
+
+Sample usage
+************
+
+See sample :ref:`dns-resolve-sample` for details.
 
 API Reference
 *************

--- a/samples/net/dns_resolve/README.rst
+++ b/samples/net/dns_resolve/README.rst
@@ -6,25 +6,15 @@ DNS Resolve Application
 Overview
 ********
 
-The DNS resolver sample application implements a basic DNS resolver according
-to RFC 1035. Supported DNS answers are IPv4/IPv6 addresses and CNAME.
+This application will setup IP address for the device, and then
+try to resolve various hostnames according to how the user has
+configured the system.
 
-If a CNAME is received, the DNS resolver will create another DNS query.
-The number of additional queries is controlled by the
-DNS_RESOLVER_ADDITIONAL_QUERIES Kconfig variable.
-
-The multicast DNS (mDNS) client resolver support can be enabled by setting
-:option:`CONFIG_MDNS_RESOLVER` Kconfig option.
-See https://tools.ietf.org/html/rfc6762 for more details about mDNS.
-
-The link-local multicast name resolution (LLMNR) client resolver support can be
-enabled by setting the :option:`CONFIG_LLMNR_RESOLVER` Kconfig option.
-See https://tools.ietf.org/html/rfc4795 for more details about LLMNR.
-
-For more information about DNS configuration variables, see:
-:file:`subsys/net/lib/dns/Kconfig`. The DNS resolver API can be found at
-:file:`include/net/dns_resolve.h`. The sample code can be found at:
-:file:`samples/net/dns_resolve`.
+- If IPv4 is enabled, then A record for ``www.zephyrproject.org`` is
+  resolved.
+- If IPv6 is enabled, then AAAA record for ``www.zephyrproject.org`` is
+  resolved.
+- If mDNS is enabled, then ``zephyr.local`` name is resolved.
 
 Requirements
 ************


### PR DESCRIPTION
Add more information about DNS resolver to documentation. Move
generic DNS information from the sample application into DNS
resolver documentation.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>