### PR TITLE
xtensa: intel_s1000: turn on XTENSA_ASM2

### DIFF
--- a/soc/xtensa/intel_s1000/Kconfig.defconfig
+++ b/soc/xtensa/intel_s1000/Kconfig.defconfig
@@ -13,7 +13,7 @@ config IRQ_OFFLOAD_INTNUM
 	default 0
 
 config XTENSA_ASM2
-	default n
+	default y
 
 # S1000 does not have MISC0.
 # Since EXCSAVE2 is unused by Zephyr, use it instead.


### PR DESCRIPTION
Turns on XTENSA_ASM2 by default for intel_s1000.

Fixes #11034

Signed-off-by: Daniel Leung <daniel.leung@intel.com>