### PR TITLE
doc: net: context: Add comment to use BSD socket API instead

### DIFF
--- a/doc/reference/networking/net_context.rst
+++ b/doc/reference/networking/net_context.rst
@@ -6,9 +6,5 @@ Networking Context
 Overview
 ********
 
-
-API Reference
-*************
-
-.. doxygengroup:: net_context
-   :project: Zephyr
+The net_context API is not meant for application use. Application should use
+:ref:`bsd_sockets_interface` API instead.


### PR DESCRIPTION
The net_context API is being phased out.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>