### PR TITLE
arch: arm: mpu: nxp: disable mpu before reprogramming

### DIFF
--- a/arch/arm/core/cortex_m/mpu/nxp_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/nxp_mpu.c
@@ -327,9 +327,16 @@ static int _mpu_configure_dynamic_mpu_regions(const struct k_mem_partition
 {
 	/* Reset MPU regions inside which dynamic memory regions may
 	 * be programmed.
+	 *
+	 * Re-programming these regions will temporarily leave memory areas
+	 * outside all MPU regions.
+	 * This might trigger memory faults if ISRs occurring during
+	 * re-programming perform access in those areas.
 	 */
+	arm_core_mpu_disable();
 	_region_init(mpu_config.sram_region, (const struct nxp_mpu_region *)
 		&mpu_config.mpu_regions[mpu_config.sram_region]);
+	arm_core_mpu_enable();
 
 	u32_t mpu_reg_index = static_regions_num;
 


### PR DESCRIPTION
This is needed, because an interrupt can happen after the main/static
MPU region is disabled and before it is re-enabled.

This region gets implicitly disabled inside the _region_init call, when
its configuration registers changes:

```
  SYSMPU->WORD[index][0] = region_base;
  SYSMPU->WORD[index][1] = region_end;
  SYSMPU->WORD[index][2] = region_attr;
  SYSMPU->WORD[index][3] = SYSMPU_WORD_VLD_MASK;

```
The TRM says this about the WORD0, WORD1 and WORD2 registers:

>   Writes to this register clear the region descriptor’s valid bit
>   (RGDn_WORD3[VLD]).

And thus if an interrupt happens after writing to WORD0 and before
writing VLD to WORD3 again, the code executes with enabled and yet
misconfigured MPU.

Fixes #13482

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>