### PR TITLE
net: icmpv6: Fix echo request packet generation

### DIFF
--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -335,6 +335,7 @@ int net_icmpv6_send_echo_request(struct net_if *iface,
 
 	net_pkt_set_data(pkt, &icmpv6_access);
 
+	net_pkt_cursor_init(pkt);
 	net_ipv6_finalize(pkt, IPPROTO_ICMPV6);
 
 	NET_DBG("Sending ICMPv6 Echo Request type %d from %s to %s",


### PR DESCRIPTION
`net_ipv6_finalize` expects packet cursor to be reinitialized in order
to finalize packet correctly. This commits adds missing cursor
initialization.

Fixes #13437

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>