### PR TITLE
ci: Use latest docker image: 0.6.1

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -21,7 +21,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.6
+        image_tag: v0.6.1
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
Use latest docker image with renode and an update to the SDK pre-release
(not used by default).