### PR TITLE
net: context: Fix send function documentation 

### DIFF
--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -762,7 +762,7 @@ int net_context_send(struct net_pkt *pkt,
 		     void *user_data);
 
 /**
- * @brief Send a network buffer to a peer.
+ * @brief Send data to a peer.
  *
  * @details This function can be used to send network data to a peer
  * connection. This function will return immediately if the timeout
@@ -833,7 +833,7 @@ int net_context_sendto(struct net_pkt *pkt,
 
 
 /**
- * @brief Send a network buffer to a peer specified by address.
+ * @brief Send data to a peer specified by address.
  *
  * @details This function can be used to send network data to a peer
  * specified by address. This variant can only be used for datagram
@@ -850,8 +850,7 @@ int net_context_sendto(struct net_pkt *pkt,
  * @param context The network context to use.
  * @param buf The data buffer to send
  * @param len Length of the buffer
- * @param dst_addr Destination address. This will override the address
- * already set in network buffer.
+ * @param dst_addr Destination address.
  * @param addrlen Length of the address.
  * @param cb Caller-supplied callback function.
  * @param timeout Timeout for the connection. Possible values


### PR DESCRIPTION
Newly added net_context_send_new()/net_context_sendto_new() take
void *bug, size_t len params but in docstring, refer to "network
buffer", which is apperently copy-paste artifact.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>