### PR TITLE
doc: boards: arm: nrf52840_pca10059: fix instructions for flashing

### DIFF
--- a/boards/arm/nrf52840_pca10059/doc/index.rst
+++ b/boards/arm/nrf52840_pca10059/doc/index.rst
@@ -134,7 +134,7 @@ Create an application package, using nrfutil::
 
 Flash it onto the board::
 
-	nrfutil dfu usb_serial -pkg pkg.zip -p /dev/ttyACM0
+	nrfutil dfu usb-serial -pkg pkg.zip -p /dev/ttyACM0
 
 Observe the green LED on the board blinking.
 


### PR DESCRIPTION
The instructions for flashing the board using nrfutil were incorrect.

CC: @jhedberg 