### PR TITLE
net: sockets: Fix logging message

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -254,7 +254,7 @@ static void zsock_received_cb(struct net_context *ctx,
 			NET_DBG("Marked socket %p as peer-closed", ctx);
 		} else {
 			net_pkt_set_eof(last_pkt, true);
-			NET_DBG("Set EOF flag on pkt %p", ctx);
+			NET_DBG("Set EOF flag on pkt %p", last_pkt);
 		}
 		return;
 	}


### PR DESCRIPTION
A debug message told "Set EOF flag on pkt %p", but actually printed
net_context instead of net_pkt.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>