### PR TITLE
sockets: Define commonly used socket option symbols

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -52,11 +52,13 @@ extern "C" {
 #define AF_PACKET       PF_PACKET  /**< Packet family.                */
 #define AF_CAN          PF_CAN     /**< Controller Area Network.      */
 
-/** Protocol numbers from IANA */
+/** Protocol numbers from IANA/BSD */
 enum net_ip_protocol {
+	IPPROTO_IP = 0,            /**< IP protocol (pseudo-val for setsockopt() */
 	IPPROTO_ICMP = 1,          /**< ICMP protocol   */
 	IPPROTO_TCP = 6,           /**< TCP protocol    */
 	IPPROTO_UDP = 17,          /**< UDP protocol    */
+	IPPROTO_IPV6 = 41,         /**< IPv6 protocol   */
 	IPPROTO_ICMPV6 = 58,       /**< ICMPv6 protocol */
 };
 

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -433,6 +433,18 @@ static inline char *inet_ntop(sa_family_t family, const void *src, char *dst,
 #define EAI_SERVICE DNS_EAI_SERVICE
 #endif /* defined(CONFIG_NET_SOCKETS_POSIX_NAMES) */
 
+#define SOL_SOCKET 1
+
+/* Socket options for SOL_SOCKET level */
+#define SO_REUSEADDR 2
+#define SO_ERROR 4
+
+/* Socket options for IPPROTO_TCP level */
+#define TCP_NODELAY 1
+
+/* Socket options for IPPROTO_IPV6 level */
+#define IPV6_V6ONLY 26
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1082,6 +1082,28 @@ int zsock_getsockopt(int sock, int level, int optname,
 int zsock_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 			 const void *optval, socklen_t optlen)
 {
+	switch (level) {
+	case SOL_SOCKET:
+		switch (optname) {
+		case SO_REUSEADDR:
+			/* Ignore for now. Provided to let port
+			 * existing apps.
+			 */
+			return 0;
+		}
+		break;
+
+	case IPPROTO_TCP:
+		switch (optname) {
+		case TCP_NODELAY:
+			/* Ignore for now. Provided to let port
+			 * existing apps.
+			 */
+			return 0;
+		}
+		break;
+	}
+
 	errno = ENOPROTOOPT;
 	return -1;
 }


### PR DESCRIPTION
... And even dummy-implement a couple. All these options were required to port https://github.com/open62541/open62541 to Zephyr.
