### PR TITLE
doc: Clean up build instructions and use of variables

### DIFF
--- a/boards/arm/cy8ckit_062_wifi_bt_m0/doc/index.rst
+++ b/boards/arm/cy8ckit_062_wifi_bt_m0/doc/index.rst
@@ -128,13 +128,9 @@ Cy_WDT_Disable().
 
 Build the project for CM0+
 
-.. code-block:: console
-
-   $ cd samples/hello_world
-   $ mkdir build
-   $ cd build
-   $ cmake -G"Eclipse CDT4 - Ninja" -DBOARD=cy8ckit_062_wifi_bt_m0 ..
-   $ ninja
+.. zephyr-app-commands::
+   :board: cy8ckit_062_wifi_bt_m0
+   :goals: build
 
 Switch the DevKit into CMSIS-DAP mode using SW3 (LED2 should blink) and flash
 the board:

--- a/boards/riscv32/hifive1/doc/index.rst
+++ b/boards/riscv32/hifive1/doc/index.rst
@@ -17,14 +17,12 @@ Programming and debugging
 Building
 ========
 
-Applications for the ``HiFive1`` board configuration can be built as usual
-(see :ref:`build_an_application`).
-In order to build the application for ``HiFive1``, set the ``BOARD`` variable
-to ``hifive1``.
+Applications for the ``hifive1`` board configuration can be built as usual
+(see :ref:`build_an_application`) using the corresponding board name:
 
-.. code-block:: bash
-
-   export BOARD="hifive1"
+.. zephyr-app-commands::
+   :board: hifive1
+   :goals: build
 
 Flashing
 ========
@@ -34,14 +32,13 @@ RISC-V support. Download the tarball for your OS from the `SiFive website
 <https://www.sifive.com/boards>`_ and extract it.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can
-overwrite that behavior by adding the ``OPENOCD`` parameter to the
-``cmake`` command:
+overwrite that behavior by adding the
+``-DOPENOCD=<path/to/riscv-openocd/bin/openocd>`` parameter when building:
 
-.. code-block:: bash
-
-   # run from your build folder
-   cmake -GNinja -DBOARD=hifive1 -DOPENOCD=path/to/riscv-openocd/bin/openocd ..
-
+.. zephyr-app-commands::
+   :board: hifive1
+   :goals: build
+   :gen-args: -DOPENOCD=<path/to/riscv-openocd/bin/openocd>
 
 When using a custom toolchain it should be enough to have the downloaded
 version of the binary in your ``PATH``.

--- a/boards/riscv32/m2gl025_miv/doc/index.rst
+++ b/boards/riscv32/m2gl025_miv/doc/index.rst
@@ -18,13 +18,11 @@ Building
 ========
 
 Applications for the ``m2gl025_miv`` board configuration can be built as usual
-(see :ref:`build_an_application`).
-In order to build the application for ``m2gl025_miv``, set the ``BOARD`` variable
-to ``m2gl025_miv``.
+(see :ref:`build_an_application`):
 
-.. code-block:: bash
-
-   export BOARD="m2gl025_miv"
+.. zephyr-app-commands::
+   :board: m2gl025_miv
+   :goals: build
 
 Flashing
 ========

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -252,6 +252,19 @@ You can control the Zephyr build system using many variables. This
 section describes the most important ones that every Zephyr developer
 should know about.
 
+.. note::
+   All variables listed in this section can be supplied to the build system
+   in 3 ways (in order of precedence):
+
+   * As a parameter to the ``cmake`` invocation via the ``-D`` command-line
+     switch
+   * As an environment variables (``export`` on Linux/macOS and ``set`` on
+     Windows)
+   * As a ``set(<VARIABLE>, <VALUE>)`` statement in your :file:`CMakeLists.txt`
+
+   The exception is :makevar:`ZEPHYR_BASE`, which **must** be exported as an
+   environment variable.
+
 * :makevar:`ZEPHYR_BASE`: Sets the path to the directory containing Zephyr,
   which is needed by the build system's boilerplate file.  This is an
   environment variable set by the :file:`zephyr-env.sh` script on Linux/macOS
@@ -297,16 +310,12 @@ Basics
 
 #. Navigate to the application directory :file:`<home>/app`.
 
-#. Enter the following commands to build the application's
-   :file:`zephyr.elf` image using the configuration settings for the
-   board type specified in the application's :file:`CMakeLists.txt`.
+#. Enter the following commands to build the application's :file:`zephyr.elf`
+   image for the board specified in the command-line parameters:
 
-   .. code-block:: console
-
-       mkdir build
-       cd build
-       cmake -GNinja ..
-       ninja
+   .. zephyr-app-commands::
+      :board: <board>
+      :goals: build
 
    If desired, you can build the application using the configuration settings
    specified in an alternate :file:`.conf` file using the :code:`CONF_FILE`
@@ -315,21 +324,13 @@ Basics
 
    .. code-block:: console
 
-       # On Linux/macOS
-       export CONF_FILE=prj.alternate.conf
-       # On Windows
-       set CONF_FILE=prj.alternate.conf
-
-       cmake -GNinja ..
+       cmake -GNinja -DBOARD=<board> -DCONF_FILE=prj.alternate.conf ..
        ninja
 
-   If desired, you can generate project files for a different board
-   type than the one specified in the application's
-   :file:`CMakeLists.txt` by defining the environment variable
-   :code:`BOARD`.
-
-   Both the :code:`CONF_FILE` and :code:`BOARD` parameters can be specified
-   when building the application.
+   As described in the previous section, you can instead choose to permanently
+   set the board and configuration settings by either exporting :makevar:`BOARD`
+   and :makevar:`CONF_FILE` environment variables or by setting their values
+   in your :file:`CMakeLists.txt` using ``set()`` statements.
 
 Build Directory Contents
 ========================

--- a/samples/display/cfb_shell/README.rst
+++ b/samples/display/cfb_shell/README.rst
@@ -13,14 +13,10 @@ Building and Running
 
 Build the sample app by choosing the target board, for example:
 
-.. code-block:: console
-
-         cmake -DBOARD=reel_board
-
-
 .. zephyr-app-commands::
    :zephyr-app: samples/display/cfb_shell
-   :goals: run
+   :board: reel_board
+   :goals: build
 
 
 Shell Module Command Help


### PR DESCRIPTION
Remove most unnecessary instances of `export` and `cmake` use that can
instead be replaced with `zephyr-app-commands` or similar. This is to
avoid documentation using different mechanisms to describe the same
actions and in preparation for documenting `west build` everywhere.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>