### PR TITLE
kconfig: Don't load env var if in doc mode

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -164,7 +164,6 @@ add_custom_target(
   SOC_DIR=soc/
   SRCARCH=x86
   PROJECT_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}
-  GENERATED_DTS_BOARD_CONF=not_applicable
   KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
   KCONFIG_DOC_MODE=1
   ${PYTHON_EXECUTABLE} scripts/genrest.py Kconfig ${RST_OUT}/doc/reference/kconfig/

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -11,16 +11,17 @@ import os
 
 doc_mode = os.environ.get('KCONFIG_DOC_MODE') == "1"
 
-# The env var 'GENERATED_DTS_BOARD_CONF' must be set
-GENERATED_DTS_BOARD_CONF = os.environ['GENERATED_DTS_BOARD_CONF']
-
 dt_defines = {}
-if (not doc_mode) and os.path.isfile(GENERATED_DTS_BOARD_CONF):
-    with open(GENERATED_DTS_BOARD_CONF, 'r', encoding='utf-8') as fd:
-        for line in fd:
-            if '=' in line:
-                define, val = line.split('=')
-                dt_defines[define] = val.strip()
+if (not doc_mode):
+    # The env var 'GENERATED_DTS_BOARD_CONF' must be set unless we are in
+    # doc mode
+    GENERATED_DTS_BOARD_CONF = os.environ['GENERATED_DTS_BOARD_CONF']
+    if os.path.isfile(GENERATED_DTS_BOARD_CONF):
+        with open(GENERATED_DTS_BOARD_CONF, 'r', encoding='utf-8') as fd:
+            for line in fd:
+                if '=' in line:
+                    define, val = line.split('=')
+                    dt_defines[define] = val.strip()
 
 def _dt_units_to_scale(unit):
     if not unit:


### PR DESCRIPTION
Do not load the GENERATED_DTS_BOARD_CONF if in doc mode, since it will
not defined as it doesn't apply. No need to defined it to a dummy value.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>