### PR TITLE
cmake: Fix setting of -nostdinc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,10 @@ if(NOT CONFIG_RTTI)
   )
 endif()
 
+if(NOT CONFIG_NATIVE_APPLICATION)
+  set(NOSTDINC_F -nostdinc)
+endif()
+
 zephyr_compile_options(
   -g # TODO: build configuration enough?
   -Wall
@@ -373,10 +377,6 @@ zephyr_ld_options(
   ${LINKERFLAGPREFIX},--gc-sections
   ${LINKERFLAGPREFIX},--build-id=none
   )
-
-if(NOT CONFIG_NATIVE_APPLICATION)
-  set(NOSTDINC_F -nostdinc)
-endif()
 
 get_property(TOPT GLOBAL PROPERTY TOPT)
 set_ifndef(  TOPT -T)

--- a/cmake/compiler/host-gcc/target.cmake
+++ b/cmake/compiler/host-gcc/target.cmake
@@ -57,6 +57,24 @@ if (NOT CONFIG_X86_64)
   LIST(APPEND TOOLCHAIN_LIBS gcc)
 endif()
 
+set(NOSTDINC "")
+
+# Note that NOSYSDEF_CFLAG may be an empty string, and
+# set_ifndef() does not work with empty string.
+if(NOT DEFINED NOSYSDEF_CFLAG)
+  set(NOSYSDEF_CFLAG -undef)
+endif()
+
+foreach(file_name include)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} --print-file-name=${file_name}
+    OUTPUT_VARIABLE _OUTPUT
+    )
+  string(REGEX REPLACE "\n" "" _OUTPUT "${_OUTPUT}")
+
+  list(APPEND NOSTDINC ${_OUTPUT})
+endforeach()
+
 # Load toolchain_cc-family macros
 # Significant overlap with freestanding gcc compiler so reuse it
 include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_security_fortify.cmake)


### PR DESCRIPTION
We where defining the variable NOSTDINC_F after we tried to use it.
Move the definition before the first reference fixes things.  When
-nostdinc now enabled we need to explicitly add the compiler include
path for x86_64 based builds (x86_64 and ARCH_POSIX).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>