### PR TITLE
doc: fix misspellings in docs

### DIFF
--- a/boards/arm/mec2016evb_assy6797/doc/index.rst
+++ b/boards/arm/mec2016evb_assy6797/doc/index.rst
@@ -74,7 +74,7 @@ Microchip to provide the schematic for this board.
 System Clock
 ============
 
-The MEC1701 MCU is configured to use the 48Mhz internal oscilator with the
+The MEC1701 MCU is configured to use the 48Mhz internal oscillator with the
 on-chip PLL to generate a resulting EC clock rate of 12 MHz. See Processor clock
 control register (chapter 4 in user manual)
 
@@ -87,7 +87,7 @@ Jumper settings
 ***************
 
 Please follow the jumper settings below to properly demo this
-board. Advanced users may deviate from this recomendation.
+board. Advanced users may deviate from this recommendation.
 
 Jump setting for MEC2016 EVB Assy 6797 Rev A1p0
 ===============================================
@@ -151,7 +151,7 @@ Programming and Debugging
 *************************
 
 This board comes with a Cortex ETM port which facilitates tracing and debugging
-using a single physical conection.  In attidion, it comes with sockets for
+using a single physical connection.  In addition, it comes with sockets for
 JTAG only sessions.
 
 Flashing

--- a/boards/arm/nrf52840_pca10056/doc/index.rst
+++ b/boards/arm/nrf52840_pca10056/doc/index.rst
@@ -209,7 +209,7 @@ To select the pin numbers for tx-pin and rx-pin:
 Open the `nRF52840 Product Specification`_, chapter 7 'Hardware and Layout'.
 In the table 7.1.1 'aQFN73 ball assignments' select the pins marked
 'General purpose I/O'.  Note that pins marked as 'low frequency I/O only' can only be used
-in under-10KHz applications. They are not sutiable for 115200 speed of UART.
+in under-10KHz applications. They are not suitable for 115200 speed of UART.
 
 Translate 'Pin' into number for Device tree by using the following formula::
 

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -708,7 +708,7 @@ The way that the script determines if a matching :file:`CMakeLists.txt` and
 - If the project contains a file named :file:`<path>/zephyr/Kconfig` the build
   system will match it
 
-Example of a :file:`<path>/zephyr/module.yml` file refering to
+Example of a :file:`<path>/zephyr/module.yml` file referring to
 :file:`CMakeLists.txt` and :file:`Kconfig` files at the root of the module:
 
 .. code-block:: console

--- a/samples/display/cfb_shell/README.rst
+++ b/samples/display/cfb_shell/README.rst
@@ -124,7 +124,7 @@ column and row positions, and the text to be displayed in double quotation
 marks when it contains spaces. If the text hits the edge of the display, the
 remaining characters will be displayed in the next line. The text will scroll
 until it hits the display boundary, last column for horizontal and last row
-for vertical direction. The text passed with the srcoll command will be moved
+for vertical direction. The text passed with the scroll command will be moved
 vertically or horizontally on the display.
 
 

--- a/samples/net/google_iot_mqtt/README.rst
+++ b/samples/net/google_iot_mqtt/README.rst
@@ -9,7 +9,7 @@ Overview
 This sample application demonstrates a "full stack" application.  This
 currently is able to
 
-- Aquire a DHCPv4 lease.
+- Acquire a DHCPv4 lease.
 - Connect to an SNTP server and acquire current time
 - Establish a TLS connection with the Google IOT Cloud servers
 - Publish data to the Google IOT Cloud
@@ -38,7 +38,7 @@ Users will also be required to configure the following Kconfig options
 based on their Google Cloud IOT project:
 
 - CLOUD_CLIENT_ID - created from <telemetry>/<region>/registries/<registry name>/devices/<device name>
-- CLOUD_AUDIENCE - created from telementry without projects on front
+- CLOUD_AUDIENCE - created from telemetry without projects on front
 - CLOUD_SUBSCRIBE_CONFIG - created from /devices/<device name>/config
 - CLOUD_PUBLISH_TOPIC - created from /devices/<device name>/state
 


### PR DESCRIPTION
Fix misspelling in boards, samples, and doc missed during regular
reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>