### PR TITLE
samples/google_iot_mqtt: add missing yaml

### DIFF
--- a/samples/net/google_iot_mqtt/sample.yaml
+++ b/samples/net/google_iot_mqtt/sample.yaml
@@ -1,2 +1,8 @@
+common:
+  harness: net
+  tags: net
 sample:
   name: Full stack sample
+tests:
+  test:
+    depends_on: netif


### PR DESCRIPTION
The sample.yaml file was missing basic tags that allow it to be
properly selected by automated systems.

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>