### PR TITLE
net: tcp: Clean up socket shutdown

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1383,11 +1383,6 @@ static void queue_fin(struct net_context *ctx)
 	}
 
 	net_tcp_queue_pkt(ctx, pkt);
-
-	ret = net_tcp_send_pkt(pkt);
-	if (ret < 0) {
-		net_pkt_unref(pkt);
-	}
 }
 
 int net_tcp_put(struct net_context *context)

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2462,6 +2462,14 @@ int net_tcp_accept(struct net_context *context,
 		return -EINVAL;
 	}
 
+	if (cb == NULL) {
+		/* The context is being shut down */
+		if (net_context_get_ip_proto(context) == IPPROTO_TCP) {
+			context->tcp->accept_cb = NULL;
+			return 0;
+		}
+	}
+
 	local_addr.sa_family = net_context_get_family(context);
 
 #if defined(CONFIG_NET_IPV6)


### PR DESCRIPTION
The sending of the FIN needed to just use the retry logic
to send the packet instead of a direct send then passing
to retry logic. The previous behavior caused a memory fault
because the buffer associated with the pkt would get
freed but the retry logic still attempted to resend it.

The fix then revealed a secondary problem with closing the
socket where zsock_close_ctx() wanted to call net_context_accept()
to clear the callbacks but this would print an error
message because the context structure already existed
from the original call to net_context_accept() in
zsock_listen_ctx() at the start of the listen().

Signed-off-by: david leach <david.leach@nxp.com>