### PR TITLE
drivers: modem: wncm14a2a: stop reading when bytes read is 0

### DIFF
--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1083,7 +1083,7 @@ static void wncm14a2a_read_rx(struct net_buf **buf)
 					uart_buffer,
 					sizeof(uart_buffer),
 					&bytes_read);
-		if (ret < 0) {
+		if (ret < 0 || bytes_read == 0) {
 			/* mdm_receiver buffer is empty */
 			break;
 		}


### PR DESCRIPTION
Let's also check for bytes_read == 0 after calling mdm_receiver_recv()
and if so, break the loop so we don't endlessly loop.

Signed-off-by: Michael Scott <mike@foundries.io>