### PR TITLE
Usb dfu

### DIFF
--- a/include/usb/class/usb_dfu.h
+++ b/include/usb/class/usb_dfu.h
@@ -119,4 +119,6 @@ enum dfu_state {
 	dfuERROR,
 };
 
+void wait_for_usb_dfu(void);
+
 #endif /* ZEPHYR_INCLUDE_USB_CLASS_USB_DFU_H_ */

--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -126,9 +126,17 @@ source "subsys/usb/class/hid/Kconfig"
 config USB_DFU_CLASS
 	bool "USB DFU Class Driver"
 	select MPU_ALLOW_FLASH_WRITE
+	select POLL
 	depends on IMG_MANAGER
 	help
 	  USB DFU class driver
+
+config USB_DFU_WAIT_DELAY_MS
+	int
+	depends on USB_DFU_CLASS
+	default 12000
+	help
+	  A thread can wait for a prescribed time (in ms) for DFU to begin
 
 config USB_DFU_MAX_XFER_SIZE
 	int


### PR DESCRIPTION
This patchset introduces a signal completion event for DFU. Generally when DFU is in progress, the system is not expected to be doing anything else in addition. Hence, a completion signal would help the system to know that DFU is over and it can proceed towards next tasks.

This is especially useful in a bootloader scenario like MCUBoot.