### PR TITLE
eth: eth_mcux: wait in send for the packet to be sent [REVERT ME]

### DIFF
--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -46,7 +46,7 @@ config ETH_MCUX_TX_BUFFERS
 	int "Number of MCUX TX buffers"
 	depends on ETH_MCUX
 	default 1
-	range 1 16
+	range 1 1
 	help
 	  Set the number of TX buffers provided to the MCUX driver.
 

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -497,8 +497,6 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 	bool timestamped_frame;
 #endif
 
-	k_sem_take(&context->tx_buf_sem, K_FOREVER);
-
 	/* As context->frame_buf is shared resource used by both eth_tx
 	 * and eth_rx, we need to protect it with irq_lock.
 	 */
@@ -545,6 +543,8 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 		LOG_ERR("ENET_SendFrame error: %d", (int)status);
 		return -1;
 	}
+
+	k_sem_take(&context->tx_buf_sem, K_FOREVER);
 
 	return 0;
 }
@@ -795,7 +795,7 @@ static int eth_0_init(struct device *dev)
 #endif
 
 	k_sem_init(&context->tx_buf_sem,
-		   CONFIG_ETH_MCUX_TX_BUFFERS, CONFIG_ETH_MCUX_TX_BUFFERS);
+		   0, CONFIG_ETH_MCUX_TX_BUFFERS);
 	k_work_init(&context->phy_work, eth_mcux_phy_work);
 	k_delayed_work_init(&context->delayed_phy_work,
 			    eth_mcux_delayed_phy_work);


### PR DESCRIPTION
Wait in the send callback for the packet to be actually sent.

After this change, only one TX packet will be handled at once.
This is needed because of the way the TX packets are currently handled
in L2 after this PR: #12563

This is similar to what #13167 did for the SAM GMAC on SAM E-70.

Without this, packet time-stamping does not work with the current stack.

This commit is minimalistic on purpose to make it easily revertible when
the network stack is able to properly handle DMA drivers for TX packets
again.

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>