### PR TITLE
samples: led_lp5562: Add filtering rule for LP5562 chip

### DIFF
--- a/samples/drivers/led_lp5562/sample.yaml
+++ b/samples/drivers/led_lp5562/sample.yaml
@@ -5,3 +5,5 @@ tests:
   test:
     platform_whitelist: nrf52840_pca10056
     tags: led
+    harness_config:
+        fixture: fixture_i2c_lp5562


### PR DESCRIPTION
The filtering rule to indicate that this sample should
only be run on boards with LP5562 chip connected via i2c

Signed-off-by: Cinly Ooi <cinly.ooi@intel.com>