### PR TITLE
drivers/interrupt_controller: stm32: Fix issue in irq lines connect

### DIFF
--- a/drivers/interrupt_controller/Kconfig.stm32
+++ b/drivers/interrupt_controller/Kconfig.stm32
@@ -98,14 +98,6 @@ config EXTI_STM32_PVD_IRQ_PRI
 	help
 	 IRQ priority of RVD Through interrupt
 
-config EXTI_STM32_RTC_ALARM_IRQ_PRI
-	int "RTC Alarm IRQ priority"
-	depends on EXTI_STM32
-	depends on SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32F2X
-	default 0
-	help
-	 IRQ priority of RTC Alarm interrupt
-
 config EXTI_STM32_OTG_FS_WKUP_IRQ_PRI
 	int "USB OTG FS Wake Up IRQ priority"
 	depends on EXTI_STM32

--- a/drivers/interrupt_controller/exti_stm32.c
+++ b/drivers/interrupt_controller/exti_stm32.c
@@ -457,7 +457,7 @@ static void __stm32_exti_connect_irqs(struct device *dev)
 		CONFIG_EXTI_STM32_EXTI15_10_IRQ_PRI,
 		__stm32_exti_isr_15_10, DEVICE_GET(exti_stm32),
 		0);
-#elif defined(CONFIG_SOC_SERIES_STM32F2X) || \
+#if defined(CONFIG_SOC_SERIES_STM32F2X) || \
       defined(CONFIG_SOC_SERIES_STM32F4X) || \
       defined(CONFIG_SOC_SERIES_STM32F7X)
 	IRQ_CONNECT(PVD_IRQn,
@@ -480,10 +480,12 @@ static void __stm32_exti_connect_irqs(struct device *dev)
 		CONFIG_EXTI_STM32_RTC_WKUP_IRQ_PRI,
 		__stm32_exti_isr_22, DEVICE_GET(exti_stm32),
 		0);
-#elif CONFIG_SOC_SERIES_STM32F7X
+#endif
+#if CONFIG_SOC_SERIES_STM32F7X
 	IRQ_CONNECT(LPTIM1_IRQn,
 		CONFIG_EXTI_STM32_LPTIM1_IRQ_PRI,
 		__stm32_exti_isr_23, DEVICE_GET(exti_stm32),
 		0);
+#endif /* CONFIG_SOC_SERIES_STM32F7X */
 #endif
 }

--- a/drivers/interrupt_controller/exti_stm32.c
+++ b/drivers/interrupt_controller/exti_stm32.c
@@ -110,9 +110,6 @@ int stm32_exti_enable(int line)
 		case 16:
 			irqnum = PVD_IRQn;
 			break;
-		case 17:
-			irqnum = RTC_Alarm_IRQn;
-			break;
 		case 18:
 			irqnum = OTG_FS_WKUP_IRQn;
 			break;
@@ -322,11 +319,6 @@ static inline void __stm32_exti_isr_16(void *arg)
 	__stm32_exti_isr(16, 17, arg);
 }
 
-static inline void __stm32_exti_isr_17(void *arg)
-{
-	__stm32_exti_isr(17, 18, arg);
-}
-
 static inline void __stm32_exti_isr_18(void *arg)
 {
 	__stm32_exti_isr(18, 19, arg);
@@ -463,10 +455,6 @@ static void __stm32_exti_connect_irqs(struct device *dev)
 	IRQ_CONNECT(PVD_IRQn,
 		CONFIG_EXTI_STM32_PVD_IRQ_PRI,
 		__stm32_exti_isr_16, DEVICE_GET(exti_stm32),
-		0);
-	IRQ_CONNECT(RTC_Alarm_IRQn,
-		CONFIG_EXTI_STM32_RTC_ALARM_IRQ_PRI,
-		__stm32_exti_isr_17, DEVICE_GET(exti_stm32),
 		0);
 	IRQ_CONNECT(OTG_FS_WKUP_IRQn,
 		CONFIG_EXTI_STM32_OTG_FS_WKUP_IRQ_PRI,


### PR DESCRIPTION
IRQ lines definition in function __stm32_exti_connect_irqs ifdefery
does not match __stm32_exti_isr_x_y functions definitions.
Fix this.

This bug fixed, an issue is revealed, since RTC Alarm IRQ was handled in 2 different drivers,
which caused compitalion issue when activated in RTC driver. This is fixed as well.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>