### PR TITLE
doc: Applying backslash escapes to  "uncrustify" command

### DIFF
--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -312,9 +312,9 @@ standards together with a configuration file we've provided:
 .. code-block:: bash
 
    # On Linux/macOS
-   uncrustify --replace --no-backup -l C -c $ZEPHYR_BASE/.uncrustify.cfg my_source_file.c
+   uncrustify --replace --no-backup -l C -c $ZEPHYR_BASE/\.uncrustify.cfg my_source_file.c
    # On Windows
-   uncrustify --replace --no-backup -l C -c %ZEPHYR_BASE%\.uncrustify.cfg my_source_file.c
+   uncrustify --replace --no-backup -l C -c %ZEPHYR_BASE%\\\.uncrustify.cfg my_source_file.c
 
 On Linux systems, you can install uncrustify with
 


### PR DESCRIPTION
Added backslash escape to dot (.) and backslash (\\)

The backslash escape to dot in ".uncrustify.cfg"s are
importance because it had misled this submitter to use
"uncrustify.cfg" (no dot) instead

The backslash escape to Windows path separated (\\) is applied
to make sure the backslash escapes are interpreted
correctly for dot ('.') preceeding the filename, and
for aesthetic reason.

Signed-off-by: Cinly Ooi <cinly.ooi@intel.com>