### PR TITLE
soc: arm: sam3x: add MPU capability

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,7 @@
 /arch/arm/                                @MaureenHelm @galak
 /soc/arm/                                 @MaureenHelm @galak
 /soc/arm/arm/mps2/                        @fvincenzo
+/soc/arm/atmel_sam/sam3x/                 @ioannisg
 /soc/arm/atmel_sam/sam4s/                 @fallrisk
 /soc/arm/nxp*/                            @MaureenHelm
 /soc/arm/nordic_nrf/                      @ioannisg

--- a/soc/arm/atmel_sam/sam3x/Kconfig.series
+++ b/soc/arm/atmel_sam/sam3x/Kconfig.series
@@ -11,6 +11,7 @@ config SOC_SERIES_SAM3X
 	select CPU_CORTEX_M3
 	select SOC_FAMILY_SAM
 	select CPU_HAS_SYSTICK
+	select CPU_HAS_ARM_MPU
 	select ASF
 	help
 	  Enable support for Atmel SAM3X Cortex-M3 microcontrollers.


### PR DESCRIPTION
Add Memory Protection (MPU) capability to the Atmel SAM3X SoC.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>