### PR TITLE
CODEOWNERS: Add owners for storage-related subsystems

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -223,6 +223,8 @@
 /subsys/bluetooth/                        @sjanc @jhedberg @Vudentz
 /subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot
 /subsys/fs/                               @nashif
+/subsys/fs/fcb                            @nvlsianpu
+/subsys/fs/nvs                            @Laczen
 /subsys/logging/                          @nordic-krch
 /subsys/net/buf.c                         @jukkar @jhedberg @tbursztyka @pfalcon
 /subsys/net/ip/                           @jukkar @tbursztyka @pfalcon
@@ -233,7 +235,9 @@
 /subsys/net/lib/mqtt/                     @jukkar @tbursztyka
 /subsys/net/lib/coap/                     @rveerama1
 /subsys/net/lib/sockets/                  @jukkar @tbursztyka @pfalcon
+/subsys/settings/                         @nvlsianpu
 /subsys/shell/                            @jarz-nordic @nordic-krch
+/subsys/storage                           @nvlsianpu
 /subsys/usb/                              @jfischer-phytec-iot @finikorg
 /tests/boards/native_posix/               @aescolar
 /tests/bluetooth/                         @sjanc @jhedberg @Vudentz


### PR DESCRIPTION
Storage was not properly covered in terms of maintainership, add
maintainers for the corresponding subystems.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>