### PR TITLE
net: ipv6: Do not pass ICMPv6 packets to net_conn_input

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -577,11 +577,9 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 	}
 
 	if (verdict == NET_DROP) {
-		if (nexthdr == IPPROTO_ICMPV6) {
-			return verdict;
-		}
-
 		goto drop;
+	} else if (nexthdr == IPPROTO_ICMPV6) {
+		return verdict;
 	}
 
 	ip.ipv6 = hdr;


### PR DESCRIPTION
ICMPv6 network packets are processed and consumed (if not dropped) within `net_icmpv6_input` function. Therefore they shoud not be passed to the `net_conn_input` function.

This fixes the assertion I've mentioned in #13301. If ICMPv6 packet was not intended for drop, it was processed after `net_icmpv6_input`, even though it was already freed in the respective ICMPv6 handler. This could lead to a system crash (or assert if enabled) when packet was reallocated in a meantime.

And another side effect is that packet was marked for drop in `net_conn_input`, which led to double-release of this packet (Zephyr seems to be protected against it though, hence it was not the source of crash):
```
[00:00:24.143,933] <err> net_conn: No suitable protocol handler configured
[00:00:24.145,424] <err> net_pkt: *** ERROR *** pkt 0x0041f80c is freed already by handle_na_input():1689 (processing_data():151)
```

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>