### PR TITLE
Ieee802154 switch to new net pkt API

### DIFF
--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -792,7 +792,7 @@ end:
 /* Helper to uncompress Traffic class and Flow label */
 static inline u8_t uncompress_tfl(struct net_pkt *pkt,
 				  struct net_ipv6_hdr *ipv6,
-				  u8_t offset)
+				  u8_t offset, bool dry_run)
 {
 	u8_t tcl;
 
@@ -801,40 +801,54 @@ static inline u8_t uncompress_tfl(struct net_pkt *pkt,
 	case NET_6LO_IPHC_TF_00:
 		NET_DBG("ECN + DSCP + 4-bit Pad + Flow Label");
 
-		tcl = CIPHC[offset++];
+		tcl = CIPHC[offset];
 		tcl = (tcl >> 6) | (tcl << 2);
 
-		ipv6->vtc |= ((tcl & 0xF0) >> 4);
-		ipv6->tcflow = ((tcl & 0x0F) << 4) | (CIPHC[offset++] & 0x0F);
+		if (!dry_run) {
+			ipv6->vtc |= ((tcl & 0xF0) >> 4);
+			ipv6->tcflow = ((tcl & 0x0F) << 4) |
+				(CIPHC[offset + 1] & 0x0F);
 
-		memcpy(&ipv6->flow, &CIPHC[offset], 2);
-		offset += 2;
+			memcpy(&ipv6->flow, &CIPHC[offset + 2], 2);
+		}
+
+		offset += 4;
 		break;
 	case NET_6LO_IPHC_TF_01:
 		NET_DBG("ECN + 2-bit Pad + Flow Label, DSCP is elided");
 
-		tcl = ((CIPHC[offset] & 0xF0) >> 6);
-		ipv6->tcflow = ((tcl & 0x0F) << 4) | (CIPHC[offset++] & 0x0F);
+		if (!dry_run) {
+			tcl = ((CIPHC[offset] & 0xF0) >> 6);
+			ipv6->tcflow = ((tcl & 0x0F) << 4) |
+				(CIPHC[offset] & 0x0F);
 
-		memcpy(&ipv6->flow, &CIPHC[offset], 2);
-		offset += 2;
+			memcpy(&ipv6->flow, &CIPHC[offset + 1], 2);
+		}
+
+		offset += 3;
 		break;
 	case NET_6LO_IPHC_TF_10:
 		NET_DBG("Flow label elided");
 
-		tcl = CIPHC[offset];
-		tcl = (tcl >> 6) | (tcl << 2);
+		if (!dry_run) {
+			tcl = CIPHC[offset];
+			tcl = (tcl >> 6) | (tcl << 2);
 
-		ipv6->vtc |= ((tcl & 0xF0) >> 4);
-		ipv6->tcflow = (tcl & 0x0F) << 4;
-		ipv6->flow = 0;
+			ipv6->vtc |= ((tcl & 0xF0) >> 4);
+			ipv6->tcflow = (tcl & 0x0F) << 4;
+			ipv6->flow = 0;
+		}
+
 		offset++;
 		break;
 	case NET_6LO_IPHC_TF_11:
 		NET_DBG("Tcl and Flow label elided");
 
-		ipv6->tcflow = 0;
-		ipv6->flow = 0;
+		if (!dry_run) {
+			ipv6->tcflow = 0;
+			ipv6->flow = 0;
+		}
+
 		break;
 	}
 
@@ -844,20 +858,33 @@ static inline u8_t uncompress_tfl(struct net_pkt *pkt,
 /* Helper to uncompress Hoplimit */
 static inline u8_t uncompress_hoplimit(struct net_pkt *pkt,
 				       struct net_ipv6_hdr *ipv6,
-				       u8_t offset)
+				       u8_t offset, bool dry_run)
 {
 	switch (CIPHC[0] & NET_6LO_IPHC_HLIM255) {
 	case NET_6LO_IPHC_HLIM:
-		ipv6->hop_limit = CIPHC[offset++];
+		if (!dry_run) {
+			ipv6->hop_limit = CIPHC[offset];
+		}
+
+		offset++;
 		break;
 	case NET_6LO_IPHC_HLIM1:
-		ipv6->hop_limit = 1;
+		if (!dry_run) {
+			ipv6->hop_limit = 1;
+		}
+
 		break;
 	case NET_6LO_IPHC_HLIM64:
-		ipv6->hop_limit = 64;
+		if (!dry_run) {
+			ipv6->hop_limit = 64;
+		}
+
 		break;
 	case NET_6LO_IPHC_HLIM255:
-		ipv6->hop_limit = 255;
+		if (!dry_run) {
+			ipv6->hop_limit = 255;
+		}
+
 		break;
 	}
 
@@ -867,7 +894,7 @@ static inline u8_t uncompress_hoplimit(struct net_pkt *pkt,
 /* Helper to uncompress Source Address */
 static inline u8_t uncompress_sa(struct net_pkt *pkt,
 				 struct net_ipv6_hdr *ipv6,
-				 u8_t offset)
+				 u8_t offset, bool dry_run)
 {
 
 	NET_DBG("SAC_0");
@@ -876,33 +903,46 @@ static inline u8_t uncompress_sa(struct net_pkt *pkt,
 	case NET_6LO_IPHC_SAM_00:
 		NET_DBG("SAM_00 full src addr inlined");
 
-		memcpy(ipv6->src.s6_addr, &CIPHC[offset], 16);
+		if (!dry_run) {
+			memcpy(ipv6->src.s6_addr, &CIPHC[offset], 16);
+		}
+
 		offset += 16;
 		break;
 	case NET_6LO_IPHC_SAM_01:
 		NET_DBG("SAM_01 last 64 bits are inlined");
 
-		ipv6->src.s6_addr[0] = 0xFE;
-		ipv6->src.s6_addr[1] = 0x80;
+		if (!dry_run) {
+			ipv6->src.s6_addr[0] = 0xFE;
+			ipv6->src.s6_addr[1] = 0x80;
 
-		memcpy(&ipv6->src.s6_addr[8], &CIPHC[offset], 8);
+			memcpy(&ipv6->src.s6_addr[8], &CIPHC[offset], 8);
+		}
+
 		offset += 8;
 		break;
 	case NET_6LO_IPHC_SAM_10:
 		NET_DBG("SAM_10 src addr 16 bit compressed");
 
-		ipv6->src.s6_addr[0] = 0xFE;
-		ipv6->src.s6_addr[1] = 0x80;
-		ipv6->src.s6_addr[11] = 0xFF;
-		ipv6->src.s6_addr[12] = 0xFE;
+		if (!dry_run) {
+			ipv6->src.s6_addr[0] = 0xFE;
+			ipv6->src.s6_addr[1] = 0x80;
+			ipv6->src.s6_addr[11] = 0xFF;
+			ipv6->src.s6_addr[12] = 0xFE;
 
-		memcpy(&ipv6->src.s6_addr[14], &CIPHC[offset], 2);
+			memcpy(&ipv6->src.s6_addr[14], &CIPHC[offset], 2);
+		}
+
 		offset += 2;
 		break;
 	case NET_6LO_IPHC_SAM_11:
 		NET_DBG("SAM_11 generate src addr from ll");
 
-		net_ipv6_addr_create_iid(&ipv6->src, net_pkt_lladdr_src(pkt));
+		if (!dry_run) {
+			net_ipv6_addr_create_iid(&ipv6->src,
+						 net_pkt_lladdr_src(pkt));
+		}
+
 		break;
 	}
 
@@ -913,36 +953,50 @@ static inline u8_t uncompress_sa(struct net_pkt *pkt,
 static inline u8_t uncompress_sa_ctx(struct net_pkt *pkt,
 				     struct net_ipv6_hdr *ipv6,
 				     u8_t offset,
-				     struct net_6lo_context *ctx)
+				     struct net_6lo_context *ctx,
+				     bool dry_run)
 {
 	switch (CIPHC[1] & NET_6LO_IPHC_SAM_11) {
 	case NET_6LO_IPHC_SAM_01:
 		NET_DBG("SAM_01 last 64 bits are inlined");
 
-		/* First 8 bytes are from context */
-		memcpy(&ipv6->src.s6_addr[0], &ctx->prefix.s6_addr[0], 8);
+		if (!dry_run) {
+			/* First 8 bytes are from context */
+			memcpy(&ipv6->src.s6_addr[0],
+			       &ctx->prefix.s6_addr[0], 8);
 
-		/* And the rest are carried in-line*/
-		memcpy(&ipv6->src.s6_addr[8], &CIPHC[offset], 8);
+			/* And the rest are carried in-line*/
+			memcpy(&ipv6->src.s6_addr[8], &CIPHC[offset], 8);
+		}
+
 		offset += 8;
 
 		break;
 	case NET_6LO_IPHC_SAM_10:
 		NET_DBG("SAM_10 src addr 16 bit compressed");
 
-		/* First 8 bytes are from context */
-		memcpy(&ipv6->src.s6_addr[0], &ctx->prefix.s6_addr[0], 8);
+		if (!dry_run) {
+			/* First 8 bytes are from context */
+			memcpy(&ipv6->src.s6_addr[0],
+			       &ctx->prefix.s6_addr[0], 8);
 
-		ipv6->src.s6_addr[11] = 0xFF;
-		ipv6->src.s6_addr[12] = 0xFE;
+			ipv6->src.s6_addr[11] = 0xFF;
+			ipv6->src.s6_addr[12] = 0xFE;
 
-		/* And the rest are carried in-line */
-		memcpy(&ipv6->src.s6_addr[14], &CIPHC[offset], 2);
+			/* And the rest are carried in-line */
+			memcpy(&ipv6->src.s6_addr[14], &CIPHC[offset], 2);
+		}
+
 		offset += 2;
 
 		break;
 	case NET_6LO_IPHC_SAM_11:
 		NET_DBG("SAM_11 generate src addr from ll");
+
+		if (dry_run) {
+			break;
+		}
+
 		/* RFC 6282, 3.1.1. If SAC = 1 and SAM = 11
 		 * Derive addr using context information and
 		 * the encapsulating header.
@@ -965,7 +1019,7 @@ static inline u8_t uncompress_sa_ctx(struct net_pkt *pkt,
 /* Helpers to uncompress Destination Address */
 static inline u8_t uncompress_da_mcast(struct net_pkt *pkt,
 				       struct net_ipv6_hdr *ipv6,
-				       u8_t offset)
+				       u8_t offset, bool dry_run)
 {
 	NET_DBG("Dst is multicast");
 
@@ -985,33 +1039,47 @@ static inline u8_t uncompress_da_mcast(struct net_pkt *pkt,
 	case NET_6LO_IPHC_DAM_00:
 		NET_DBG("DAM_00 full dst addr inlined");
 
-		memcpy(&ipv6->dst.s6_addr[0], &CIPHC[offset], 16);
+		if (!dry_run) {
+			memcpy(&ipv6->dst.s6_addr[0], &CIPHC[offset], 16);
+		}
+
 		offset += 16;
 		break;
 	case NET_6LO_IPHC_DAM_01:
 		NET_DBG("DAM_01 2nd byte and last five bytes");
 
-		ipv6->dst.s6_addr[0] = 0xFF;
-		ipv6->dst.s6_addr[1] = CIPHC[offset++];
+		if (!dry_run) {
+			ipv6->dst.s6_addr[0] = 0xFF;
+			ipv6->dst.s6_addr[1] = CIPHC[offset];
 
-		memcpy(&ipv6->dst.s6_addr[11], &CIPHC[offset], 5);
-		offset += 5;
+			memcpy(&ipv6->dst.s6_addr[11], &CIPHC[offset + 1], 5);
+		}
+
+		offset += 6;
 		break;
 	case NET_6LO_IPHC_DAM_10:
 		NET_DBG("DAM_10 2nd byte and last three bytes");
 
-		ipv6->dst.s6_addr[0] = 0xFF;
-		ipv6->dst.s6_addr[1] = CIPHC[offset++];
+		if (!dry_run) {
+			ipv6->dst.s6_addr[0] = 0xFF;
+			ipv6->dst.s6_addr[1] = CIPHC[offset];
 
-		memcpy(&ipv6->dst.s6_addr[13], &CIPHC[offset], 3);
-		offset += 3;
+			memcpy(&ipv6->dst.s6_addr[13], &CIPHC[offset + 1], 3);
+		}
+
+		offset += 4;
 		break;
 	case NET_6LO_IPHC_DAM_11:
 		NET_DBG("DAM_11 8 bit compressed");
 
-		ipv6->dst.s6_addr[0] = 0xFF;
-		ipv6->dst.s6_addr[1] = 0x02;
-		ipv6->dst.s6_addr[15] = CIPHC[offset++];
+		if (!dry_run) {
+			ipv6->dst.s6_addr[0] = 0xFF;
+			ipv6->dst.s6_addr[1] = 0x02;
+			ipv6->dst.s6_addr[15] = CIPHC[offset];
+		}
+
+		offset++;
+
 		break;
 	}
 
@@ -1021,45 +1089,58 @@ static inline u8_t uncompress_da_mcast(struct net_pkt *pkt,
 /* Helper to uncompress Destination Address */
 static inline u8_t uncompress_da(struct net_pkt *pkt,
 				 struct net_ipv6_hdr *ipv6,
-				 u8_t offset)
+				 u8_t offset, bool dry_run)
 {
 	NET_DBG("DAC_0");
 
 	if (CIPHC[1] & NET_6LO_IPHC_M_1) {
-		return uncompress_da_mcast(pkt, ipv6, offset);
+		return uncompress_da_mcast(pkt, ipv6, offset, dry_run);
 	}
 
 	switch (CIPHC[1] & NET_6LO_IPHC_DAM_11) {
 	case NET_6LO_IPHC_DAM_00:
 		NET_DBG("DAM_00 full dst addr inlined");
 
-		memcpy(&ipv6->dst.s6_addr[0], &CIPHC[offset], 16);
+		if (!dry_run) {
+			memcpy(&ipv6->dst.s6_addr[0], &CIPHC[offset], 16);
+		}
+
 		offset += 16;
 		break;
 	case NET_6LO_IPHC_DAM_01:
 		NET_DBG("DAM_01 last 64 bits are inlined");
 
-		ipv6->dst.s6_addr[0] = 0xFE;
-		ipv6->dst.s6_addr[1] = 0x80;
+		if (!dry_run) {
+			ipv6->dst.s6_addr[0] = 0xFE;
+			ipv6->dst.s6_addr[1] = 0x80;
 
-		memcpy(&ipv6->dst.s6_addr[8], &CIPHC[offset], 8);
+			memcpy(&ipv6->dst.s6_addr[8], &CIPHC[offset], 8);
+		}
+
 		offset += 8;
 		break;
 	case NET_6LO_IPHC_DAM_10:
 		NET_DBG("DAM_10 dst addr 16 bit compressed");
 
-		ipv6->dst.s6_addr[0] = 0xFE;
-		ipv6->dst.s6_addr[1] = 0x80;
-		ipv6->dst.s6_addr[11] = 0xFF;
-		ipv6->dst.s6_addr[12] = 0xFE;
+		if (!dry_run) {
+			ipv6->dst.s6_addr[0] = 0xFE;
+			ipv6->dst.s6_addr[1] = 0x80;
+			ipv6->dst.s6_addr[11] = 0xFF;
+			ipv6->dst.s6_addr[12] = 0xFE;
 
-		memcpy(&ipv6->dst.s6_addr[14], &CIPHC[offset], 2);
+			memcpy(&ipv6->dst.s6_addr[14], &CIPHC[offset], 2);
+		}
+
 		offset += 2;
 		break;
 	case NET_6LO_IPHC_DAM_11:
 		NET_DBG("DAM_11 generate dst addr from ll");
 
-		net_ipv6_addr_create_iid(&ipv6->dst, net_pkt_lladdr_dst(pkt));
+		if (!dry_run) {
+			net_ipv6_addr_create_iid(&ipv6->dst,
+						 net_pkt_lladdr_dst(pkt));
+		}
+
 		break;
 	}
 
@@ -1070,42 +1151,55 @@ static inline u8_t uncompress_da(struct net_pkt *pkt,
 static inline u8_t uncompress_da_ctx(struct net_pkt *pkt,
 				     struct net_ipv6_hdr *ipv6,
 				     u8_t offset,
-				     struct net_6lo_context *ctx)
+				     struct net_6lo_context *ctx,
+				     bool dry_run)
 {
 	NET_DBG("DAC_1");
 
 	if (CIPHC[1] & NET_6LO_IPHC_M_1) {
-		return uncompress_da_mcast(pkt, ipv6, offset);
+		return uncompress_da_mcast(pkt, ipv6, offset, dry_run);
 	}
 
 	switch (CIPHC[1] & NET_6LO_IPHC_DAM_11) {
 	case NET_6LO_IPHC_DAM_01:
 		NET_DBG("DAM_01 last 64 bits are inlined");
 
-		/* First 8 bytes are from context */
-		memcpy(&ipv6->dst.s6_addr[0], &ctx->prefix.s6_addr[0], 8);
+		if (!dry_run) {
+			/* First 8 bytes are from context */
+			memcpy(&ipv6->dst.s6_addr[0],
+			       &ctx->prefix.s6_addr[0], 8);
 
-		/* And the rest are carried in-line */
-		memcpy(&ipv6->dst.s6_addr[8], &CIPHC[offset], 8);
+			/* And the rest are carried in-line */
+			memcpy(&ipv6->dst.s6_addr[8], &CIPHC[offset], 8);
+		}
+
 		offset += 8;
 
 		break;
 	case NET_6LO_IPHC_DAM_10:
 		NET_DBG("DAM_10 src addr 16 bit compressed");
 
-		/* First 8 bytes are from context */
-		memcpy(&ipv6->dst.s6_addr[0], &ctx->prefix.s6_addr[0], 8);
+		if (!dry_run) {
+			/* First 8 bytes are from context */
+			memcpy(&ipv6->dst.s6_addr[0],
+			       &ctx->prefix.s6_addr[0], 8);
 
-		ipv6->dst.s6_addr[11] = 0xFF;
-		ipv6->dst.s6_addr[12] = 0xFE;
+			ipv6->dst.s6_addr[11] = 0xFF;
+			ipv6->dst.s6_addr[12] = 0xFE;
 
-		/* And the restare carried in-line */
-		memcpy(&ipv6->dst.s6_addr[14], &CIPHC[offset], 2);
+			/* And the restare carried in-line */
+			memcpy(&ipv6->dst.s6_addr[14], &CIPHC[offset], 2);
+		}
+
 		offset += 2;
 
 		break;
 	case NET_6LO_IPHC_DAM_11:
 		NET_DBG("DAM_11 generate src addr from ll");
+
+		if (dry_run) {
+			break;
+		}
 
 		/* RFC 6282, 3.1.1. If SAC = 1 and SAM = 11
 		 * Derive addr using context information and
@@ -1119,6 +1213,7 @@ static inline u8_t uncompress_da_ctx(struct net_pkt *pkt,
 		 * Overwrite first 8 bytes from context prefix here.
 		 */
 		memcpy(&ipv6->dst.s6_addr[0], &ctx->prefix.s6_addr[0], 8);
+
 		break;
 	}
 
@@ -1129,7 +1224,7 @@ static inline u8_t uncompress_da_ctx(struct net_pkt *pkt,
 /* Helper to uncompress NH UDP */
 static inline u8_t uncompress_nh_udp(struct net_pkt *pkt,
 				     struct net_udp_hdr *udp,
-				     u8_t offset)
+				     u8_t offset, bool dry_run)
 {
 	/* Port uncompression
 	 * 00:  All 16 bits for src and dst are inlined
@@ -1143,40 +1238,48 @@ static inline u8_t uncompress_nh_udp(struct net_pkt *pkt,
 	case NET_6LO_NHC_UDP_PORT_00:
 		NET_DBG("src and dst ports are inlined");
 
-		memcpy(&udp->src_port, &CIPHC[offset], 2);
-		offset += 2;
+		if (!dry_run) {
+			memcpy(&udp->src_port, &CIPHC[offset], 2);
+			memcpy(&udp->dst_port, &CIPHC[offset + 2], 2);
+		}
 
-		memcpy(&udp->dst_port, &CIPHC[offset], 2);
-		offset += 2;
+		offset += 4;
 		break;
 	case NET_6LO_NHC_UDP_PORT_01:
 		NET_DBG("src full, dst 8 bits inlined");
 
-		memcpy(&udp->src_port, &CIPHC[offset], 2);
-		offset += 2;
+		if (!dry_run) {
+			memcpy(&udp->src_port, &CIPHC[offset], 2);
+			udp->dst_port = htons(((u16_t)NET_6LO_NHC_UDP_8_BIT_PORT
+					       << 8) | CIPHC[offset + 2]);
+		}
 
-		udp->dst_port = htons(((u16_t)NET_6LO_NHC_UDP_8_BIT_PORT
-				       << 8) | CIPHC[offset]);
-		offset++;
+		offset += 3;
 		break;
 	case NET_6LO_NHC_UDP_PORT_10:
 		NET_DBG("src 8 bits, dst full inlined");
 
-		udp->src_port = htons(((u16_t)NET_6LO_NHC_UDP_8_BIT_PORT
-				       << 8) | CIPHC[offset]);
-		offset++;
+		if (!dry_run) {
+			udp->src_port = htons(((u16_t)NET_6LO_NHC_UDP_8_BIT_PORT
+					       << 8) | CIPHC[offset]);
+			memcpy(&udp->dst_port, &CIPHC[offset + 1], 2);
+		}
 
-		memcpy(&udp->dst_port, &CIPHC[offset], 2);
-		offset += 2;
+		offset += 3;
 		break;
 	case NET_6LO_NHC_UDP_PORT_11:
 		NET_DBG("src and dst 4 bits inlined");
 
-		udp->src_port = htons((NET_6LO_NHC_UDP_4_BIT_PORT << 4) |
-				      (CIPHC[offset] >> 4));
+		if (!dry_run) {
+			udp->src_port = htons(
+				(NET_6LO_NHC_UDP_4_BIT_PORT << 4) |
+				(CIPHC[offset] >> 4));
 
-		udp->dst_port = htons((NET_6LO_NHC_UDP_4_BIT_PORT << 4) |
-				      (CIPHC[offset] & 0x0F));
+			udp->dst_port = htons(
+				(NET_6LO_NHC_UDP_4_BIT_PORT << 4) |
+				(CIPHC[offset] & 0x0F));
+		}
+
 		offset++;
 		break;
 	}
@@ -1209,18 +1312,23 @@ static inline void uncompress_cid(struct net_pkt *pkt,
 }
 #endif
 
-static inline bool uncompress_IPHC_header(struct net_pkt *pkt)
+static bool uncompress_IPHC_header(struct net_pkt *pkt,
+				   bool dry_run, int *diff)
 {
 	struct net_udp_hdr *udp = NULL;
 	u8_t offset = 2U;
 	u8_t chksum = 0U;
+	struct net_buf *frag = NULL;
 	struct net_ipv6_hdr *ipv6;
-	struct net_buf *frag;
 	u16_t len;
 #if defined(CONFIG_NET_6LO_CONTEXT)
 	struct net_6lo_context *src = NULL;
 	struct net_6lo_context *dst = NULL;
 #endif
+
+	if (dry_run && !diff) {
+		return false;
+	}
 
 	if (CIPHC[1] & NET_6LO_IPHC_CID_1) {
 #if defined(CONFIG_NET_6LO_CONTEXT)
@@ -1232,31 +1340,45 @@ static inline bool uncompress_IPHC_header(struct net_pkt *pkt)
 #endif
 	}
 
-	frag = net_pkt_get_frag(pkt, NET_6LO_RX_PKT_TIMEOUT);
-	if (!frag) {
-		return false;
+	if (!dry_run) {
+		frag = net_pkt_get_frag(pkt, NET_6LO_RX_PKT_TIMEOUT);
+		if (!frag) {
+			return false;
+		}
+
+		ipv6 = (struct net_ipv6_hdr *)(frag->data);
+	} else {
+		/* This is meant to avoid compiler warnings: that area
+		 * will not be modified.
+		 */
+		ipv6 = (struct net_ipv6_hdr *)(pkt->buffer->data);
 	}
 
-	ipv6 = (struct net_ipv6_hdr *)(frag->data);
-
 	/* Version is always 6 */
-	ipv6->vtc = 0x60;
-	net_pkt_set_ip_hdr_len(pkt, NET_IPV6H_LEN);
+	if (!dry_run) {
+		ipv6->vtc = 0x60;
+		net_pkt_set_ip_hdr_len(pkt, NET_IPV6H_LEN);
+	}
 
 	/* Uncompress Traffic class and Flow label */
-	offset = uncompress_tfl(pkt, ipv6, offset);
+	offset = uncompress_tfl(pkt, ipv6, offset, dry_run);
 
 	if (!(CIPHC[0] & NET_6LO_IPHC_NH_1)) {
-		ipv6->nexthdr = CIPHC[offset];
+		if (!dry_run) {
+			ipv6->nexthdr = CIPHC[offset];
+		}
+
 		offset++;
 	}
 
 	/* Uncompress Hoplimit */
-	offset = uncompress_hoplimit(pkt, ipv6, offset);
+	offset = uncompress_hoplimit(pkt, ipv6, offset, dry_run);
 
 	/* First set to zero and copy relevant bits */
-	(void)memset(&ipv6->src.s6_addr[0], 0, 16);
-	(void)memset(&ipv6->dst.s6_addr[0], 0, 16);
+	if (!dry_run) {
+		(void)memset(&ipv6->src.s6_addr[0], 0, 16);
+		(void)memset(&ipv6->dst.s6_addr[0], 0, 16);
+	}
 
 	/* Uncompress Source Address */
 	if (CIPHC[1] & NET_6LO_IPHC_SAC_1) {
@@ -1271,14 +1393,15 @@ static inline bool uncompress_IPHC_header(struct net_pkt *pkt)
 				goto fail;
 			}
 
-			offset = uncompress_sa_ctx(pkt, ipv6, offset, src);
+			offset = uncompress_sa_ctx(pkt, ipv6,
+						   offset, src, dry_run);
 #else
 			NET_WARN("Context based uncompression not enabled");
 			goto fail;
 #endif
 		}
 	} else {
-		offset = uncompress_sa(pkt, ipv6, offset);
+		offset = uncompress_sa(pkt, ipv6, offset, dry_run);
 	}
 
 	/* Uncompress Destination Address */
@@ -1297,15 +1420,19 @@ static inline bool uncompress_IPHC_header(struct net_pkt *pkt)
 			goto fail;
 		}
 
-		offset = uncompress_da_ctx(pkt, ipv6, offset, dst);
+		offset = uncompress_da_ctx(pkt, ipv6, offset, dst, dry_run);
 	} else {
-		offset = uncompress_da(pkt, ipv6, offset);
+		offset = uncompress_da(pkt, ipv6, offset, dry_run);
 	}
 #else
-	offset = uncompress_da(pkt, ipv6, offset);
+	offset = uncompress_da(pkt, ipv6, offset, dry_run);
 #endif
 
-	net_buf_add(frag, NET_IPV6H_LEN);
+	if (!dry_run) {
+		net_buf_add(frag, NET_IPV6H_LEN);
+	} else {
+		*diff = NET_IPV6H_LEN;
+	}
 
 	if (!(CIPHC[0] & NET_6LO_IPHC_NH_1)) {
 		NET_DBG("No following compressed header");
@@ -1321,24 +1448,40 @@ static inline bool uncompress_IPHC_header(struct net_pkt *pkt)
 	}
 
 	/* Uncompress UDP header */
-	ipv6->nexthdr = IPPROTO_UDP;
+	if (!dry_run) {
+		ipv6->nexthdr = IPPROTO_UDP;
 
-	udp = (struct net_udp_hdr *)(frag->data + NET_IPV6H_LEN);
+		udp = (struct net_udp_hdr *)(frag->data + NET_IPV6H_LEN);
+	}
+
 	chksum = CIPHC[offset] & NET_6LO_NHC_UDP_CHKSUM_1;
-	offset = uncompress_nh_udp(pkt, udp, offset);
+	offset = uncompress_nh_udp(pkt, udp, offset, dry_run);
 
 	if (!chksum) {
-		memcpy(&udp->chksum, &CIPHC[offset], 2);
+		if (!dry_run) {
+			memcpy(&udp->chksum, &CIPHC[offset], 2);
+		}
+
 		offset += 2;
 	}
 
-	net_buf_add(frag, NET_UDPH_LEN);
+	if (!dry_run) {
+		net_buf_add(frag, NET_UDPH_LEN);
+	} else {
+		*diff += NET_UDPH_LEN;
+	}
 
 end:
 	if (pkt->frags->len < offset) {
 		NET_ERR("pkt %p too short len %d vs %d", pkt,
 			pkt->frags->len, offset);
 		goto fail;
+	}
+
+	if (dry_run) {
+		/* We set the difference of header sizes */
+		*diff -= offset;
+		return true;
 	}
 
 	/* Move the data to beginning, no need for headers now */
@@ -1366,7 +1509,10 @@ end:
 	return true;
 
 fail:
-	net_pkt_frag_unref(frag);
+	if (frag) {
+		net_pkt_frag_unref(frag);
+	}
+
 	return false;
 }
 
@@ -1418,7 +1564,7 @@ bool net_6lo_uncompress(struct net_pkt *pkt)
 	if ((pkt->frags->data[0] & NET_6LO_DISPATCH_IPHC) ==
 	    NET_6LO_DISPATCH_IPHC) {
 		/* Uncompress IPHC header */
-		return uncompress_IPHC_header(pkt);
+		return uncompress_IPHC_header(pkt, false, NULL);
 
 	} else if ((pkt->frags->data[0] & NET_6LO_DISPATCH_IPV6) ==
 		   NET_6LO_DISPATCH_IPV6) {
@@ -1430,4 +1576,23 @@ bool net_6lo_uncompress(struct net_pkt *pkt)
 	NET_DBG("pkt %p is not compressed", pkt);
 
 	return true;
+}
+
+int net_6lo_uncompress_hdr_diff(struct net_pkt *pkt)
+{
+	if ((pkt->frags->data[0] & NET_6LO_DISPATCH_IPHC) ==
+	    NET_6LO_DISPATCH_IPHC) {
+		int len;
+
+		if (!uncompress_IPHC_header(pkt, true, &len)) {
+			return INT_MAX;
+		}
+
+		return len;
+	} else if ((pkt->frags->data[0] & NET_6LO_DISPATCH_IPV6) ==
+		   NET_6LO_DISPATCH_IPV6) {
+		return -1;
+	}
+
+	return 0;
 }

--- a/subsys/net/ip/6lo.h
+++ b/subsys/net/ip/6lo.h
@@ -78,4 +78,18 @@ void net_6lo_set_context(struct net_if *iface,
 			 struct net_icmpv6_nd_opt_6co *context);
 #endif
 
+/**
+ *  @brief Return the header size difference after uncompression
+ *
+ * @details This will do a dry-run on uncompressing the headers.
+ *          The point is only to calculate the difference.
+ *
+ * @param Pointer to network packet
+ *
+ * @return header difference or INT_MAX in case of error.
+ */
+#if defined(CONFIG_NET_6LO)
+int net_6lo_uncompress_hdr_diff(struct net_pkt *pkt);
+#endif
+
 #endif /* __NET_6LO_H */

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -228,7 +228,7 @@ static int ieee802154_send(struct net_if *iface, struct net_pkt *pkt)
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 	struct ieee802154_fragment_ctx f_ctx;
-	struct net_buf *frag;
+	struct net_buf *buf;
 	u8_t ll_hdr_size;
 	bool fragment;
 	int len;
@@ -251,21 +251,21 @@ static int ieee802154_send(struct net_if *iface, struct net_pkt *pkt)
 
 	len = 0;
 	frame_buf.len = 0;
-	frag = pkt->frags;
+	buf = pkt->buffer;
 
-	while (frag) {
+	while (buf) {
 		int ret;
 
 		net_buf_add(&frame_buf, ll_hdr_size);
 
 		if (fragment) {
 			ieee802154_fragment(&f_ctx, &frame_buf, true);
-			frag = f_ctx.frag;
+			buf = f_ctx.buf;
 		} else {
 			memcpy(frame_buf.data + frame_buf.len,
-			       frag->data, frag->len);
-			net_buf_add(&frame_buf, frag->len);
-			frag = frag->frags;
+			       buf->data, buf->len);
+			net_buf_add(&frame_buf, buf->len);
+			buf = buf->frags;
 		}
 
 		if (!ieee802154_create_data_frame(ctx, net_pkt_lladdr_dst(pkt),

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -69,29 +69,19 @@ static inline void ieee802154_acknowledge(struct net_if *iface,
 					  struct ieee802154_mpdu *mpdu)
 {
 	struct net_pkt *pkt;
-	struct net_buf *frag;
 
 	if (!mpdu->mhr.fs->fc.ar) {
 		return;
 	}
 
-	pkt = net_pkt_get_reserve_tx(BUF_TIMEOUT);
+	pkt = net_pkt_alloc_with_buffer(iface, IEEE802154_ACK_PKT_LENGTH,
+					AF_UNSPEC, 0, BUF_TIMEOUT);
 	if (!pkt) {
 		return;
 	}
 
-	frag = net_pkt_get_frag(pkt, BUF_TIMEOUT);
-	if (!frag) {
-		net_pkt_unref(pkt);
-		return;
-	}
-
-	net_pkt_frag_insert(pkt, frag);
-
 	if (ieee802154_create_ack_frame(iface, pkt, mpdu->mhr.fs->sequence)) {
-		net_buf_add(frag, IEEE802154_ACK_PKT_LENGTH);
-
-		ieee802154_tx(iface, pkt, frag);
+		ieee802154_tx(iface, pkt, pkt->buffer);
 	}
 
 	net_pkt_unref(pkt);
@@ -228,7 +218,7 @@ static enum net_verdict ieee802154_recv(struct net_if *iface,
 	pkt_hexdump(RX_PKT_TITLE " (with ll)", pkt, true);
 
 	hdr_len = (u8_t *)mpdu.payload - net_pkt_data(pkt);
-	net_buf_pull(pkt->frags, hdr_len);
+	net_buf_pull(pkt->buffer, hdr_len);
 
 	return ieee802154_manage_recv_packet(iface, pkt, hdr_len);
 

--- a/subsys/net/l2/ieee802154/ieee802154_fragment.h
+++ b/subsys/net/l2/ieee802154/ieee802154_fragment.h
@@ -21,7 +21,7 @@
 #include "ieee802154_frame.h"
 
 struct ieee802154_fragment_ctx {
-	struct net_buf *frag;
+	struct net_buf *buf;
 	u8_t *pos;
 	u16_t pkt_size;
 	u16_t processed;
@@ -41,8 +41,8 @@ void ieee802154_fragment_ctx_init(struct ieee802154_fragment_ctx *ctx,
 				  struct net_pkt *pkt, u16_t hdr_diff,
 				  bool iphc)
 {
-	ctx->frag = pkt->frags;
-	ctx->pos = ctx->frag->data;
+	ctx->buf = pkt->buffer;
+	ctx->pos = ctx->buf->data;
 	ctx->hdr_diff = hdr_diff;
 	ctx->pkt_size = net_pkt_get_len(pkt) + (iphc ? hdr_diff : -1);
 	ctx->offset = 0;

--- a/subsys/net/l2/ieee802154/ieee802154_frame.h
+++ b/subsys/net/l2/ieee802154/ieee802154_frame.h
@@ -469,7 +469,7 @@ bool ieee802154_create_data_frame(struct ieee802154_context *ctx,
 				  u8_t hdr_size);
 
 struct net_pkt *
-ieee802154_create_mac_cmd_frame(struct ieee802154_context *ctx,
+ieee802154_create_mac_cmd_frame(struct net_if *iface,
 				enum ieee802154_cfi type,
 				struct ieee802154_frame_params *params);
 

--- a/subsys/net/l2/ieee802154/ieee802154_mgmt.c
+++ b/subsys/net/l2/ieee802154/ieee802154_mgmt.c
@@ -104,7 +104,7 @@ static int ieee802154_scan(u32_t mgmt_request, struct net_if *iface,
 		params.dst.pan_id = IEEE802154_BROADCAST_PAN_ID;
 
 		pkt = ieee802154_create_mac_cmd_frame(
-			ctx, IEEE802154_CFI_BEACON_REQUEST, &params);
+			iface, IEEE802154_CFI_BEACON_REQUEST, &params);
 		if (!pkt) {
 			NET_DBG("Could not create Beacon Request");
 			return -ENOBUFS;
@@ -139,9 +139,9 @@ static int ieee802154_scan(u32_t mgmt_request, struct net_if *iface,
 		/* Active scan sends a beacon request */
 		if (mgmt_request == NET_REQUEST_IEEE802154_ACTIVE_SCAN) {
 			net_pkt_ref(pkt);
-			net_pkt_frag_ref(pkt->frags);
+			net_pkt_frag_ref(pkt->buffer);
 
-			ret = ieee802154_radio_send(iface, pkt, pkt->frags);
+			ret = ieee802154_radio_send(iface, pkt, pkt->buffer);
 			if (ret) {
 				NET_DBG("Could not send Beacon Request (%d)",
 					ret);
@@ -249,7 +249,7 @@ static int ieee802154_associate(u32_t mgmt_request, struct net_if *iface,
 	}
 
 	pkt = ieee802154_create_mac_cmd_frame(
-		ctx, IEEE802154_CFI_ASSOCIATION_REQUEST, &params);
+		iface, IEEE802154_CFI_ASSOCIATION_REQUEST, &params);
 	if (!pkt) {
 		ret = -ENOBUFS;
 		goto out;
@@ -322,7 +322,7 @@ static int ieee802154_disassociate(u32_t mgmt_request, struct net_if *iface,
 	params.pan_id = ctx->pan_id;
 
 	pkt = ieee802154_create_mac_cmd_frame(
-		ctx, IEEE802154_CFI_DISASSOCIATION_NOTIFICATION, &params);
+		iface, IEEE802154_CFI_DISASSOCIATION_NOTIFICATION, &params);
 	if (!pkt) {
 		return -ENOBUFS;
 	}

--- a/subsys/net/l2/ieee802154/ieee802154_radio_utils.h
+++ b/subsys/net/l2/ieee802154/ieee802154_radio_utils.h
@@ -67,7 +67,7 @@ static inline int wait_for_ack(struct net_if *iface,
 static inline int handle_ack(struct ieee802154_context *ctx,
 			     struct net_pkt *pkt)
 {
-	if (pkt->frags->len == IEEE802154_ACK_PKT_LENGTH) {
+	if (pkt->buffer->len == IEEE802154_ACK_PKT_LENGTH) {
 		struct ieee802154_fcf_seq *fs;
 
 		fs = ieee802154_validate_fc_seq(net_pkt_data(pkt), NULL);

--- a/subsys/net/l2/ieee802154/ieee802154_utils.h
+++ b/subsys/net/l2/ieee802154/ieee802154_utils.h
@@ -48,12 +48,12 @@ static inline int ieee802154_set_tx_power(struct net_if *iface, s16_t dbm)
 }
 
 static inline int ieee802154_tx(struct net_if *iface,
-				struct net_pkt *pkt, struct net_buf *frag)
+				struct net_pkt *pkt, struct net_buf *buf)
 {
 	const struct ieee802154_radio_api *radio =
 		net_if_get_device(iface)->driver_api;
 
-	return radio->tx(net_if_get_device(iface), pkt, frag);
+	return radio->tx(net_if_get_device(iface), pkt, buf);
 }
 
 static inline int ieee802154_start(struct net_if *iface)


### PR DESCRIPTION
Instead of using net_pkt_write in fragmentation, appending the frag to the packet is way more efficient (no allocation, de-allocation).