### PR TITLE
cmake: Fix dependency issue in x86 build scripts

### DIFF
--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -122,14 +122,20 @@ if(CONFIG_X86_MMU)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 
+  if(CONFIG_X86_KPTI)
+    set(user_mmu_tables_bin user_mmu_tables.bin)
+  endif()
+
   add_custom_target(
     mmu_tables_bin_target
     DEPENDS
-    user_mmu_tables.bin
-         mmu_tables.bin
+    mmu_tables.bin
+    ${user_mmu_tables_bin}
   )
   add_custom_command(
-    OUTPUT mmu_tables.bin user_mmu_tables.bin
+    OUTPUT
+    mmu_tables.bin
+    ${user_mmu_tables_bin}
     COMMAND
     ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/gen_mmu_x86.py


### PR DESCRIPTION
Incremental builds have been broken in x86 due to a misconfigured
dependency. mmu_tables.bin is always generated, even for "nothing to
do" builds.

We fix this by removing the stray dependency on user_mmu_tables.bin
when not CONFIG_X86_KPTI.

Steps to reproduce:

Build any sample twice with qemu_x86 and observe that the second build
regenerates mmu_tables.bin.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>