### PR TITLE
kconfiglib: Clarify kconfig_filenames doc re. absolute paths

### DIFF
--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2018, Ulf Magnusson
+# Copyright (c) 2011-2019, Ulf Magnusson
 # SPDX-License-Identifier: ISC
 
 """
@@ -609,7 +609,8 @@ class Kconfig(object):
     kconfig_filenames:
       A list with the filenames of all Kconfig files included in the
       configuration, relative to $srctree (or relative to the current directory
-      if $srctree isn't set).
+      if $srctree isn't set), except absolute paths (e.g.
+      'source "/foo/Kconfig") are kept as-is.
 
       The files are listed in the order they are source'd, starting with the
       top-level Kconfig file. If a file is source'd multiple times, it will

--- a/scripts/kconfig/menuconfig.py
+++ b/scripts/kconfig/menuconfig.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2018, Nordic Semiconductor ASA and Ulf Magnusson
+# Copyright (c) 2018-2019, Nordic Semiconductor ASA and Ulf Magnusson
 # SPDX-License-Identifier: ISC
 
 """


### PR DESCRIPTION
Update Kconfiglib (and menuconfig, just to sync) to upstream revision
99a7af769352b, to add the commit below, for a doc issue reported by
Sebastian Bøe:

    Document that kconfig_filenames keeps absolute paths as-is

    Came up in https://github.com/ulfalizer/Kconfiglib/issues/67.