### PR TITLE
scripts/dts cleanups, part 8

### DIFF
--- a/scripts/dts/extract/clocks.py
+++ b/scripts/dts/extract/clocks.py
@@ -19,16 +19,16 @@ class DTClocks(DTDirective):
     def __init__(self):
         pass
 
-    def _extract_consumer(self, node_address, clocks, def_label):
+    def _extract_consumer(self, node_path, clocks, def_label):
 
-        clock_consumer = reduced[node_address]
-        clock_consumer_bindings = get_binding(node_address)
-        clock_consumer_label = 'DT_' + get_node_label(node_address)
+        clock_consumer = reduced[node_path]
+        clock_consumer_bindings = get_binding(node_path)
+        clock_consumer_label = 'DT_' + get_node_label(node_path)
 
         clock_index = 0
         clock_cell_index = 0
         nr_clock_cells = 0
-        clock_provider_node_address = ''
+        clock_provider_node_path = ''
         clock_provider = {}
         for cell in clocks:
             if clock_cell_index == 0:
@@ -37,14 +37,14 @@ class DTClocks(DTDirective):
                         ("Could not find the clock provider node {} for clocks"
                          " = {} in clock consumer node {}. Did you activate"
                          " the clock node?. Last clock provider: {}.")
-                            .format(str(cell), str(clocks), node_address,
+                            .format(str(cell), str(clocks), node_path,
                                     str(clock_provider)))
-                clock_provider_node_address = phandles[cell]
-                clock_provider = reduced[clock_provider_node_address]
+                clock_provider_node_path = phandles[cell]
+                clock_provider = reduced[clock_provider_node_path]
                 clock_provider_bindings = get_binding(
-                                            clock_provider_node_address)
+                                            clock_provider_node_path)
                 clock_provider_label = get_node_label( \
-                                                clock_provider_node_address)
+                                                clock_provider_node_path)
                 nr_clock_cells = int(clock_provider['props'].get(
                                      '#clock-cells', 0))
                 clock_cells_string = clock_provider_bindings.get(
@@ -71,7 +71,7 @@ class DTClocks(DTDirective):
                         clock_label = self.get_label_string([
                             clock_consumer_label, clock_cells_string,
                             str(clock_index)])
-                        add_compat_alias(node_address,
+                        add_compat_alias(node_path,
                                 self.get_label_string(["",
                                     clock_cells_string, str(clock_index)]),
                                 clock_label, prop_alias)
@@ -79,7 +79,7 @@ class DTClocks(DTDirective):
                         clock_label = self.get_label_string([
                             clock_consumer_label, clock_cells_string,
                             clock_cell_name, str(clock_index)])
-                        add_compat_alias(node_address,
+                        add_compat_alias(node_path,
                                 self.get_label_string(["",
                                     clock_cells_string, clock_cell_name,
                                     str(clock_index)]),
@@ -90,10 +90,10 @@ class DTClocks(DTDirective):
                         index = ''
                     else:
                         index = str(clock_index)
-                    if node_address in aliases:
+                    if node_path in aliases:
                         if clock_cells_string == clock_cell_name:
                             add_prop_aliases(
-                                node_address,
+                                node_path,
                                 lambda alias:
                                     self.get_label_string([
                                         alias,
@@ -103,7 +103,7 @@ class DTClocks(DTDirective):
                                 prop_alias)
                         else:
                             add_prop_aliases(
-                                node_address,
+                                node_path,
                                 lambda alias:
                                     self.get_label_string([
                                         alias,
@@ -119,7 +119,7 @@ class DTClocks(DTDirective):
                             clock_consumer_label, clock_cells_string,
                             clock_cell_name])
                         prop_alias[clock_alias_label] = clock_label
-                        add_compat_alias(node_address,
+                        add_compat_alias(node_path,
                                 self.get_label_string(["",
                                     clock_cells_string, clock_cell_name]),
                                 clock_label, prop_alias)
@@ -146,13 +146,13 @@ class DTClocks(DTDirective):
                     clock_label = self.get_label_string([clock_consumer_label,
                                                          clock_cell_name,
                                                          index])
-                    add_compat_alias(node_address,
+                    add_compat_alias(node_path,
                             self.get_label_string(["", clock_cell_name, index]),
                             clock_label, prop_alias)
                     prop_def[clock_label] = '"' + clock_provider_label_str + '"'
-                    if node_address in aliases:
+                    if node_path in aliases:
                         add_prop_aliases(
-                            node_address,
+                            node_path,
                             lambda alias:
                                 self.get_label_string([
                                     alias,
@@ -161,7 +161,7 @@ class DTClocks(DTDirective):
                             clock_label,
                             prop_alias)
 
-                insert_defs(node_address, prop_def, prop_alias)
+                insert_defs(node_path, prop_def, prop_alias)
 
                 clock_cell_index = 0
                 clock_index += 1
@@ -169,13 +169,13 @@ class DTClocks(DTDirective):
     ##
     # @brief Extract clocks related directives
     #
-    # @param node_address Address of node owning the clockxxx definition.
+    # @param node_path Path to node owning the clockxxx definition.
     # @param prop clockxxx property name
     # @param def_label Define label string of node owning the directive.
     #
-    def extract(self, node_address, prop, def_label):
+    def extract(self, node_path, prop, def_label):
 
-        properties = reduced[node_address]['props'][prop]
+        properties = reduced[node_path]['props'][prop]
 
         prop_list = []
         if not isinstance(properties, list):
@@ -185,7 +185,7 @@ class DTClocks(DTDirective):
 
         if prop == 'clocks':
             # indicator for clock consumers
-            self._extract_consumer(node_address, prop_list, def_label)
+            self._extract_consumer(node_path, prop_list, def_label)
         else:
             raise Exception(
                 "DTClocks.extract called with unexpected directive ({})."

--- a/scripts/dts/extract/compatible.py
+++ b/scripts/dts/extract/compatible.py
@@ -21,23 +21,23 @@ class DTCompatible(DTDirective):
     ##
     # @brief Extract compatible
     #
-    # @param node_address Address of node owning the
-    #                     compatible definition.
+    # @param node_path Path to node owning the
+    #                  compatible definition.
     # @param prop compatible property name
     # @param def_label Define label string of node owning the
     #                  compatible definition.
     #
-    def extract(self, node_address, prop, def_label):
+    def extract(self, node_path, prop, def_label):
 
         # compatible definition
-        binding = get_binding(node_address)
-        compatible = reduced[node_address]['props'][prop]
+        binding = get_binding(node_path)
+        compatible = reduced[node_path]['props'][prop]
         if not isinstance(compatible, list):
             compatible = [compatible, ]
 
         for i, comp in enumerate(compatible):
             # Generate #define
-            insert_defs(node_address,
+            insert_defs(node_path,
                         {'DT_COMPAT_' + str_to_label(comp): '1'},
                         {})
 
@@ -46,20 +46,20 @@ class DTCompatible(DTDirective):
             if 'parent' in binding:
                 compat_def = 'DT_' + str_to_label(comp) + '_BUS_' + \
                     binding['parent']['bus'].upper()
-                insert_defs(node_address, {compat_def: '1'}, {})
+                insert_defs(node_path, {compat_def: '1'}, {})
 
         # Generate defines of the form:
         # #define DT_<COMPAT>_<INSTANCE ID> 1
-        for compat, instance_id in reduced[node_address]['instance_id'].items():
+        for compat, instance_id in reduced[node_path]['instance_id'].items():
             compat_instance = 'DT_' + str_to_label(compat) + '_' + str(instance_id)
 
-            insert_defs(node_address, {compat_instance: '1'}, {})
+            insert_defs(node_path, {compat_instance: '1'}, {})
 
             # Generate defines of the form:
             # #define DT_<COMPAT>_<INSTANCE ID>_BUS_<BUS> 1
             if 'parent' in binding:
                 bus = binding['parent']['bus']
-                insert_defs(node_address,
+                insert_defs(node_path,
                             {compat_instance + '_BUS_' + bus.upper(): '1'},
                             {})
 

--- a/scripts/dts/extract/default.py
+++ b/scripts/dts/extract/default.py
@@ -18,22 +18,22 @@ class DTDefault(DTDirective):
     ##
     # @brief Extract directives in a default way
     #
-    # @param node_address Address of node owning the clockxxx definition.
+    # @param node_path Path to node owning the clockxxx definition.
     # @param prop property name
     # @param prop type (string, boolean, etc)
     # @param def_label Define label string of node owning the directive.
     #
-    def extract(self, node_address, prop, prop_type, def_label):
+    def extract(self, node_path, prop, prop_type, def_label):
         prop_def = {}
         prop_alias = {}
 
         if prop_type == 'boolean':
-            if prop in reduced[node_address]['props']:
+            if prop in reduced[node_path]['props']:
                 prop_values = 1
             else:
                 prop_values = 0
         else:
-            prop_values = reduced[node_address]['props'][prop]
+            prop_values = reduced[node_path]['props'][prop]
 
         if isinstance(prop_values, list):
             for i, prop_value in enumerate(prop_values):
@@ -42,7 +42,7 @@ class DTDefault(DTDirective):
                 if isinstance(prop_value, str):
                     prop_value = "\"" + prop_value + "\""
                 prop_def[label + '_' + str(i)] = prop_value
-                add_compat_alias(node_address,
+                add_compat_alias(node_path,
                         prop_name + '_' + str(i),
                         label + '_' + str(i),
                         prop_alias)
@@ -51,22 +51,22 @@ class DTDefault(DTDirective):
             label = def_label + '_' + prop_name
 
             if prop_values == 'parent-label':
-                prop_values = find_parent_prop(node_address, 'label')
+                prop_values = find_parent_prop(node_path, 'label')
 
             if isinstance(prop_values, str):
                 prop_values = "\"" + prop_values + "\""
             prop_def[label] = prop_values
-            add_compat_alias(node_address, prop_name, label, prop_alias)
+            add_compat_alias(node_path, prop_name, label, prop_alias)
 
             # generate defs for node aliases
-            if node_address in aliases:
+            if node_path in aliases:
                 add_prop_aliases(
-                    node_address,
+                    node_path,
                     lambda alias: str_to_label(alias) + '_' + prop_name,
                     label,
                     prop_alias)
 
-        insert_defs(node_address, prop_def, prop_alias)
+        insert_defs(node_path, prop_def, prop_alias)
 
 ##
 # @brief Management information for directives handled by default.

--- a/scripts/dts/extract/directive.py
+++ b/scripts/dts/extract/directive.py
@@ -29,9 +29,9 @@ class DTDirective(object):
     ##
     # @brief Extract directive information.
     #
-    # @param node_address Address of node issueuing the directive.
+    # @param node_path Path to node issuing the directive.
     # @param prop Directive property name
     # @param def_label Define label string of node owning the directive.
     #
-    def extract(self, node_address, prop, def_label):
+    def extract(self, node_path, prop, def_label):
         pass

--- a/scripts/dts/extract/flash.py
+++ b/scripts/dts/extract/flash.py
@@ -20,35 +20,35 @@ class DTFlash(DTDirective):
         self._flash_node = None
         self._flash_area = {}
 
-    def _extract_partition(self, node_address):
+    def _extract_partition(self, node_path):
         prop_def = {}
         prop_alias = {}
-        node = reduced[node_address]
+        node = reduced[node_path]
 
         partition_name = node['props']['label']
         partition_sectors = node['props']['reg']
 
         # Build Index based partition IDs
-        if node_address in self._flash_area:
-            area_id = self._flash_area[node_address]["id"]
+        if node_path in self._flash_area:
+            area_id = self._flash_area[node_path]["id"]
         else:
             area_id = len(self._flash_area)
-            self._flash_area[node_address] = {'id': area_id }
+            self._flash_area[node_path] = {'id': area_id }
         partition_idx = str(area_id)
 
         # Extract a per partition dev name, something like:
         # #define DT_FLASH_AREA_1_DEV             "FLASH_CTRL"
 
-        # For now assume node_address is something like:
+        # For now assume node_path is something like:
         # /flash-controller@4001E000/flash@0/partitions/partition@fc000
         # first we go up 2 levels to get the flash, check its compat
         #
         # The flash controller might be the flash itself (for cases like NOR
         # flashes), for the case of 'soc-nv-flash' we assume its the parent
         # of the flash node.
-        ctrl_addr = '/' + '/'.join(node_address.split('/')[1:-2])
+        ctrl_addr = '/' + '/'.join(node_path.split('/')[1:-2])
         if get_compat(ctrl_addr) == "soc-nv-flash":
-            ctrl_addr = '/' + '/'.join(node_address.split('/')[1:-3])
+            ctrl_addr = '/' + '/'.join(node_path.split('/')[1:-3])
 
         node = reduced[ctrl_addr]
         name = "\"{}\"".format(node['props']['label'])
@@ -94,12 +94,12 @@ class DTFlash(DTDirective):
     def _create_legacy_label(self, prop_alias, label):
         prop_alias[label.lstrip('DT_')] = label
 
-    def extract_partition(self, node_address):
+    def extract_partition(self, node_path):
         prop_def = {}
         prop_alias = {}
-        node = reduced[node_address]
+        node = reduced[node_path]
 
-        self._extract_partition(node_address)
+        self._extract_partition(node_path)
 
         partition_name = node['props']['label']
         partition_sectors = node['props']['reg']
@@ -137,33 +137,33 @@ class DTFlash(DTDirective):
             label_prefix + ["SIZE", '0'])
         self._create_legacy_label(prop_alias, label)
 
-        insert_defs(node_address, prop_def, prop_alias)
+        insert_defs(node_path, prop_def, prop_alias)
 
-    def _extract_flash(self, node_address, prop, def_label):
-        if node_address == 'dummy-flash':
+    def _extract_flash(self, node_path, prop, def_label):
+        if node_path == 'dummy-flash':
             # We will add addr/size of 0 for systems with no flash controller
             # This is what they already do in the Kconfig options anyway
-            insert_defs(node_address,
+            insert_defs(node_path,
                         {'DT_FLASH_BASE_ADDRESS': 0, 'DT_FLASH_SIZE': 0},
                         {})
             self._flash_base_address = 0
             return
 
-        self._flash_node = reduced[node_address]
-        orig_node_addr = node_address
+        self._flash_node = reduced[node_path]
+        orig_node_addr = node_path
 
-        (nr_address_cells, nr_size_cells) = get_addr_size_cells(node_address)
+        (nr_address_cells, nr_size_cells) = get_addr_size_cells(node_path)
         # if the nr_size_cells is 0, assume a SPI flash, need to look at parent
         # for addr/size info, and the second reg property (assume first is mmio
         # register for the controller itself)
         is_spi_flash = False
         if nr_size_cells == 0:
             is_spi_flash = True
-            node_address = get_parent_address(node_address)
-            (nr_address_cells, nr_size_cells) = get_addr_size_cells(node_address)
+            node_path = get_parent_path(node_path)
+            (nr_address_cells, nr_size_cells) = get_addr_size_cells(node_path)
 
-        node_compat = get_compat(node_address)
-        reg = reduced[node_address]['props']['reg']
+        node_compat = get_compat(node_path)
+        reg = reduced[node_path]['props']['reg']
         if type(reg) is not list: reg = [ reg, ]
         props = list(reg)
 
@@ -173,7 +173,7 @@ class DTFlash(DTDirective):
         # which we determin by the spi controller node only have on reg element
         # (ie for the controller itself and no region for the MMIO flash access)
         if num_reg_elem == 1 and is_spi_flash:
-            node_address = orig_node_addr
+            node_path = orig_node_addr
         else:
             # We assume the last reg property is the one we want
             while props:
@@ -185,35 +185,35 @@ class DTFlash(DTDirective):
                 for x in range(nr_size_cells):
                     size += props.pop(0) << (32 * (nr_size_cells - x - 1))
 
-            addr += translate_addr(addr, node_address, nr_address_cells,
+            addr += translate_addr(addr, node_path, nr_address_cells,
                                    nr_size_cells)
 
-            insert_defs(node_address,
+            insert_defs(node_path,
                         {'DT_FLASH_BASE_ADDRESS': hex(addr),
                          'DT_FLASH_SIZE': size//1024},
                         {})
 
         for prop in 'write-block-size', 'erase-block-size':
             if prop in self._flash_node['props']:
-                default.extract(node_address, prop, None, def_label)
+                default.extract(node_path, prop, None, def_label)
 
                 # Add an non-DT prefix alias for compatiability
                 prop_alias = {}
                 label_post = '_' + str_to_label(prop)
                 prop_alias['FLASH' + label_post] = def_label + label_post
-                insert_defs(node_address, {}, prop_alias)
+                insert_defs(node_path, {}, prop_alias)
 
 
-    def _extract_code_partition(self, node_address, prop, def_label):
-        if node_address == 'dummy-flash':
+    def _extract_code_partition(self, node_path, prop, def_label):
+        if node_path == 'dummy-flash':
             node = None
         else:
-            node = reduced[node_address]
+            node = reduced[node_path]
             if self._flash_node is None:
                 # No flash node scanned before-
                 raise Exception(
                     "Code partition '{}' {} without flash definition."
-                        .format(prop, node_address))
+                        .format(prop, node_path))
 
         if node and node is not self._flash_node:
             # only compute the load offset if the code partition
@@ -224,7 +224,7 @@ class DTFlash(DTDirective):
             load_offset = 0
             load_size = 0
 
-        insert_defs(node_address,
+        insert_defs(node_path,
                     {'DT_CODE_PARTITION_OFFSET': load_offset,
                      'DT_CODE_PARTITION_SIZE': load_size},
                     {})
@@ -232,20 +232,20 @@ class DTFlash(DTDirective):
     ##
     # @brief Extract flash
     #
-    # @param node_address Address of node owning the
-    #                     flash definition.
+    # @param node_path Path to node owning the
+    #                  flash definition.
     # @param prop compatible property name
     # @param def_label Define label string of node owning the
     #                  compatible definition.
     #
-    def extract(self, node_address, prop, def_label):
+    def extract(self, node_path, prop, def_label):
 
         if prop == 'zephyr,flash':
             # indicator for flash
-            self._extract_flash(node_address, prop, def_label)
+            self._extract_flash(node_path, prop, def_label)
         elif prop == 'zephyr,code-partition':
             # indicator for code_partition
-            self._extract_code_partition(node_address, prop, def_label)
+            self._extract_code_partition(node_path, prop, def_label)
         else:
             raise Exception(
                 "DTFlash.extract called with unexpected directive ({})."

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -77,12 +77,12 @@ def create_aliases(root):
         if 'alt_name' in reduced[k]:
             aliases[k].append(reduced[k]['alt_name'])
 
-def get_node_compats(node_address):
+def get_node_compats(node_path):
     compat = None
 
     try:
-        if 'props' in reduced[node_address]:
-            compat = reduced[node_address]['props'].get('compatible')
+        if 'props' in reduced[node_path]:
+            compat = reduced[node_path]['props'].get('compatible')
 
         if not isinstance(compat, list):
             compat = [compat, ]
@@ -92,15 +92,15 @@ def get_node_compats(node_address):
 
     return compat
 
-def get_compat(node_address):
+def get_compat(node_path):
     compat = None
 
     try:
-        if 'props' in reduced[node_address]:
-            compat = reduced[node_address]['props'].get('compatible')
+        if 'props' in reduced[node_path]:
+            compat = reduced[node_path]['props'].get('compatible')
 
         if compat == None:
-            compat = find_parent_prop(node_address, 'compatible')
+            compat = find_parent_prop(node_path, 'compatible')
 
         if isinstance(compat, list):
             compat = compat[0]
@@ -132,27 +132,27 @@ def create_phandles(root, name):
         create_phandles(child_node, name + child_name)
 
 
-def insert_defs(node_address, new_defs, new_aliases):
+def insert_defs(node_path, new_defs, new_aliases):
 
     for key in new_defs:
         if key.startswith('DT_COMPAT_'):
-            node_address = 'compatibles'
+            node_path = 'compatibles'
 
     remove = [k for k in new_aliases if k in new_defs]
     for k in remove: del new_aliases[k]
 
-    if node_address in defs:
-        remove = [k for k in new_aliases if k in defs[node_address]]
+    if node_path in defs:
+        remove = [k for k in new_aliases if k in defs[node_path]]
         for k in remove: del new_aliases[k]
-        if 'aliases' in defs[node_address]:
-            defs[node_address]['aliases'].update(new_aliases)
+        if 'aliases' in defs[node_path]:
+            defs[node_path]['aliases'].update(new_aliases)
         else:
-            defs[node_address]['aliases'] = new_aliases
+            defs[node_path]['aliases'] = new_aliases
 
-        defs[node_address].update(new_defs)
+        defs[node_path].update(new_defs)
     else:
         new_defs['aliases'] = new_aliases
-        defs[node_address] = new_defs
+        defs[node_path] = new_defs
 
 
 # Dictionary where all keys default to 0. Used by create_reduced().
@@ -194,42 +194,42 @@ def create_reduced(node, path):
             create_reduced(child_node, path + child_name)
 
 
-def get_node_label(node_address):
-    node_compat = get_compat(node_address)
+def get_node_label(node_path):
+    node_compat = get_compat(node_path)
     def_label = str_to_label(node_compat)
-    if '@' in node_address:
+    if '@' in node_path:
         # See if we have number we can convert
         try:
-            unit_addr = int(node_address.split('@')[-1], 16)
-            (nr_addr_cells, nr_size_cells) = get_addr_size_cells(node_address)
-            unit_addr += translate_addr(unit_addr, node_address,
+            unit_addr = int(node_path.split('@')[-1], 16)
+            (nr_addr_cells, nr_size_cells) = get_addr_size_cells(node_path)
+            unit_addr += translate_addr(unit_addr, node_path,
                          nr_addr_cells, nr_size_cells)
             unit_addr = "%x" % unit_addr
         except:
-            unit_addr = node_address.split('@')[-1]
+            unit_addr = node_path.split('@')[-1]
         def_label += '_' + str_to_label(unit_addr)
     else:
-        def_label += '_' + str_to_label(node_address.split('/')[-1])
+        def_label += '_' + str_to_label(node_path.split('/')[-1])
     return def_label
 
 
-def get_parent_address(node_address):
-    return '/'.join(node_address.split('/')[:-1])
+def get_parent_path(node_path):
+    return '/'.join(node_path.split('/')[:-1])
 
 
-def find_parent_prop(node_address, prop):
-    parent_address = get_parent_address(node_address)
+def find_parent_prop(node_path, prop):
+    parent_path = get_parent_path(node_path)
 
-    if prop not in reduced[parent_address]['props']:
-        raise Exception("Parent of node " + node_address +
+    if prop not in reduced[parent_path]['props']:
+        raise Exception("Parent of node " + node_path +
                         " has no " + prop + " property")
 
-    return reduced[parent_address]['props'][prop]
+    return reduced[parent_path]['props'][prop]
 
 
 # Get the #{address,size}-cells for a given node
-def get_addr_size_cells(node_address):
-    parent_addr = get_parent_address(node_address)
+def get_addr_size_cells(node_path):
+    parent_addr = get_parent_path(node_path)
     if parent_addr == '':
         parent_addr = '/'
 
@@ -240,17 +240,17 @@ def get_addr_size_cells(node_address):
 
     return (nr_addr, nr_size)
 
-def translate_addr(addr, node_address, nr_addr_cells, nr_size_cells):
+def translate_addr(addr, node_path, nr_addr_cells, nr_size_cells):
 
     try:
-        ranges = deepcopy(find_parent_prop(node_address, 'ranges'))
+        ranges = deepcopy(find_parent_prop(node_path, 'ranges'))
         if type(ranges) is not list: ranges = [ ]
     except:
         return 0
 
-    parent_address = get_parent_address(node_address)
+    parent_path = get_parent_path(node_path)
 
-    (nr_p_addr_cells, nr_p_size_cells) = get_addr_size_cells(parent_address)
+    (nr_p_addr_cells, nr_p_size_cells) = get_addr_size_cells(parent_path)
 
     range_offset = 0
     while ranges:
@@ -271,7 +271,7 @@ def translate_addr(addr, node_address, nr_addr_cells, nr_size_cells):
             break
 
     parent_range_offset = translate_addr(addr + range_offset,
-            parent_address, nr_p_addr_cells, nr_p_size_cells)
+            parent_path, nr_p_addr_cells, nr_p_size_cells)
     range_offset += parent_range_offset
 
     return range_offset
@@ -280,20 +280,20 @@ def enable_old_alias_names(enable):
     global old_alias_names
     old_alias_names = enable
 
-def add_compat_alias(node_address, label_postfix, label, prop_aliases):
-    if 'instance_id' in reduced[node_address]:
-        instance = reduced[node_address]['instance_id']
+def add_compat_alias(node_path, label_postfix, label, prop_aliases):
+    if 'instance_id' in reduced[node_path]:
+        instance = reduced[node_path]['instance_id']
         for k in instance:
             i = instance[k]
             b = 'DT_' + str_to_label(k) + '_' + str(i) + '_' + label_postfix
             prop_aliases[b] = label
 
-def add_prop_aliases(node_address,
+def add_prop_aliases(node_path,
                      alias_label_function, prop_label, prop_aliases):
-    node_compat = get_compat(node_address)
+    node_compat = get_compat(node_path)
     new_alias_prefix = 'DT_' + str_to_label(node_compat)
 
-    for alias in aliases[node_address]:
+    for alias in aliases[node_path]:
         old_alias_label = alias_label_function(alias)
         new_alias_label = new_alias_prefix + '_' + old_alias_label
 
@@ -302,8 +302,8 @@ def add_prop_aliases(node_address,
         if old_alias_names and old_alias_label != prop_label:
             prop_aliases[old_alias_label] = prop_label
 
-def get_binding(node_address):
-    compat = get_compat(node_address)
+def get_binding(node_path):
+    compat = get_compat(node_path)
 
     # For just look for the binding in the main dict
     # if we find it here, return it, otherwise it best
@@ -311,8 +311,8 @@ def get_binding(node_address):
     if compat in bindings:
         return bindings[compat]
 
-    parent_addr = get_parent_address(node_address)
-    parent_compat = get_compat(parent_addr)
+    parent_path = get_parent_path(node_path)
+    parent_compat = get_compat(parent_path)
 
     parent_binding = bindings[parent_compat]
 
@@ -350,7 +350,7 @@ def build_cell_array(prop_array):
     return ret_array
 
 
-def extract_controller(node_address, prop, prop_values, index,
+def extract_controller(node_path, prop, prop_values, index,
                        def_label, generic, handle_single=False):
 
     prop_def = {}
@@ -384,7 +384,7 @@ def extract_controller(node_address, prop, prop_values, index,
 
         # Check node generation requirements
         try:
-            generation = get_binding(node_address)['properties'
+            generation = get_binding(node_path)['properties'
                     ][prop]['generation']
         except:
             generation = ''
@@ -396,21 +396,21 @@ def extract_controller(node_address, prop, prop_values, index,
 
         label = l_base + [l_cellname] + l_idx
 
-        add_compat_alias(node_address, '_'.join(label[1:]), '_'.join(label), prop_alias)
+        add_compat_alias(node_path, '_'.join(label[1:]), '_'.join(label), prop_alias)
         prop_def['_'.join(label)] = "\"" + l_cell + "\""
 
         #generate defs also if node is referenced as an alias in dts
-        if node_address in aliases:
+        if node_path in aliases:
             add_prop_aliases(
-                node_address,
+                node_path,
                 lambda alias: '_'.join([str_to_label(alias)] + label[1:]),
                 '_'.join(label),
                 prop_alias)
 
-        insert_defs(node_address, prop_def, prop_alias)
+        insert_defs(node_path, prop_def, prop_alias)
 
 
-def extract_cells(node_address, prop, prop_values, names, index,
+def extract_cells(node_path, prop, prop_values, names, index,
                   def_label, generic, handle_single=False):
 
     prop_array = build_cell_array(prop_values)
@@ -446,7 +446,7 @@ def extract_cells(node_address, prop, prop_values, names, index,
                 else:
                     cell_yaml_names = '#cells'
         try:
-            generation = get_binding(node_address)['properties'][prop
+            generation = get_binding(node_path)['properties'][prop
                     ]['generation']
         except:
             generation = ''
@@ -476,17 +476,17 @@ def extract_cells(node_address, prop, prop_values, names, index,
             else:
                 label = l_base + l_cell + l_cellname + l_idx
             label_name = l_base + [name] + l_cellname
-            add_compat_alias(node_address, '_'.join(label[1:]), '_'.join(label), prop_alias)
+            add_compat_alias(node_path, '_'.join(label[1:]), '_'.join(label), prop_alias)
             prop_def['_'.join(label)] = elem[j+1]
             if name:
                 prop_alias['_'.join(label_name)] = '_'.join(label)
 
             # generate defs for node aliases
-            if node_address in aliases:
+            if node_path in aliases:
                 add_prop_aliases(
-                    node_address,
+                    node_path,
                     lambda alias: '_'.join([str_to_label(alias)] + label[1:]),
                     '_'.join(label),
                     prop_alias)
 
-            insert_defs(node_address, prop_def, prop_alias)
+            insert_defs(node_path, prop_def, prop_alias)

--- a/scripts/dts/extract/interrupts.py
+++ b/scripts/dts/extract/interrupts.py
@@ -15,10 +15,10 @@ class DTInterrupts(DTDirective):
     def __init__(self):
         pass
 
-    def _find_parent_irq_node(self, node_address):
+    def _find_parent_irq_node(self, node_path):
         address = ''
 
-        for comp in node_address.split('/')[1:]:
+        for comp in node_path.split('/')[1:]:
             address += '/' + comp
             if 'interrupt-parent' in reduced[address]['props']:
                 interrupt_parent = reduced[address]['props'][
@@ -29,23 +29,22 @@ class DTInterrupts(DTDirective):
     ##
     # @brief Extract interrupts
     #
-    # @param node_address Address of node owning the
-    #                     interrupts definition.
+    # @param node_path Path to node owning the
+    #                  interrupts definition.
     # @param prop compatible property name
     # @param names (unused)
     # @param def_label Define label string of node owning the
     #                  compatible definition.
     #
-    def extract(self, node_address, prop, names, def_label):
-
-        node = reduced[node_address]
+    def extract(self, node_path, prop, names, def_label):
+        node = reduced[node_path]
 
         try:
             props = list(node['props'].get(prop))
         except:
             props = [node['props'].get(prop)]
 
-        irq_parent = self._find_parent_irq_node(node_address)
+        irq_parent = self._find_parent_irq_node(node_path)
 
         l_base = def_label.split('/')
         index = 0
@@ -70,20 +69,20 @@ class DTInterrupts(DTDirective):
 
                 l_fqn = '_'.join(l_base + l_cell_prefix + l_idx + l_cell_name)
                 prop_def[l_fqn] = props.pop(0)
-                add_compat_alias(node_address,
+                add_compat_alias(node_path,
                         '_'.join(l_cell_prefix + l_idx + l_cell_name),
                         l_fqn, prop_alias)
 
                 if len(name):
                     alias_list = l_base + l_cell_prefix + name + l_cell_name
                     prop_alias['_'.join(alias_list)] = l_fqn
-                    add_compat_alias(node_address,
+                    add_compat_alias(node_path,
                             '_'.join(l_cell_prefix + name + l_cell_name),
                             l_fqn, prop_alias)
 
-                if node_address in aliases:
+                if node_path in aliases:
                     add_prop_aliases(
-                        node_address,
+                        node_path,
                         lambda alias:
                             '_'.join([str_to_label(alias)] +
                                      l_cell_prefix + name + l_cell_name),
@@ -91,7 +90,7 @@ class DTInterrupts(DTDirective):
                         prop_alias)
 
             index += 1
-            insert_defs(node_address, prop_def, prop_alias)
+            insert_defs(node_path, prop_def, prop_alias)
 
 ##
 # @brief Management information for interrupts.

--- a/scripts/dts/extract/pinctrl.py
+++ b/scripts/dts/extract/pinctrl.py
@@ -18,14 +18,14 @@ class DTPinCtrl(DTDirective):
     ##
     # @brief Extract pinctrl information.
     #
-    # @param node_address Address of node owning the pinctrl definition.
+    # @param node_path Path to node owning the pinctrl definition.
     # @param prop pinctrl-x key
     # @param def_label Define label string of client node owning the pinctrl
     #                  definition.
     #
-    def extract(self, node_address, prop, def_label):
+    def extract(self, node_path, prop, def_label):
 
-        pinconf = reduced[node_address]['props'][prop]
+        pinconf = reduced[node_path]['props'][prop]
 
         prop_list = []
         if not isinstance(pinconf, list):
@@ -37,9 +37,9 @@ class DTPinCtrl(DTDirective):
 
         prop_def = {}
         for p in prop_list:
-            pin_node_address = phandles[p]
-            pin_subnode = '/'.join(pin_node_address.split('/')[-1:])
-            cell_yaml = get_binding(pin_node_address)
+            pin_node_path = phandles[p]
+            pin_subnode = '/'.join(pin_node_path.split('/')[-1:])
+            cell_yaml = get_binding(pin_node_path)
             cell_prefix = 'PINMUX'
             post_fix = []
 
@@ -47,7 +47,7 @@ class DTPinCtrl(DTDirective):
                 post_fix.append(cell_prefix)
 
             for subnode in reduced:
-                if pin_subnode in subnode and pin_node_address != subnode:
+                if pin_subnode in subnode and pin_node_path != subnode:
                     # found a subnode underneath the pinmux handle
                     pin_label = def_prefix + post_fix + subnode.split('/')[-2:]
 
@@ -63,7 +63,7 @@ class DTPinCtrl(DTDirective):
                         prop_def[func_label] = \
                             reduced[subnode]['props'][cells]
 
-        insert_defs(node_address, prop_def, {})
+        insert_defs(node_path, prop_def, {})
 
 ##
 # @brief Management information for pinctrl-[x].

--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -18,22 +18,22 @@ class DTReg(DTDirective):
     ##
     # @brief Extract reg directive info
     #
-    # @param node_address Address of node owning the
-    #                     reg definition.
+    # @param node_path Path to node owning the
+    #                  reg definition.
     # @param names (unused)
     # @param def_label Define label string of node owning the
     #                  compatible definition.
     #
-    def extract(self, node_address, names, def_label, div):
+    def extract(self, node_path, names, def_label, div):
 
-        node = reduced[node_address]
-        node_compat = get_compat(node_address)
-        binding = get_binding(node_address)
+        node = reduced[node_path]
+        node_compat = get_compat(node_path)
+        binding = get_binding(node_path)
 
-        reg = reduced[node_address]['props']['reg']
+        reg = reduced[node_path]['props']['reg']
         if type(reg) is not list: reg = [ reg, ]
 
-        (nr_address_cells, nr_size_cells) = get_addr_size_cells(node_address)
+        (nr_address_cells, nr_size_cells) = get_addr_size_cells(node_path)
 
         if 'parent' in binding:
             bus = binding['parent']['bus']
@@ -41,13 +41,13 @@ class DTReg(DTDirective):
                 cs_gpios = None
 
                 try:
-                    cs_gpios = deepcopy(find_parent_prop(node_address, 'cs-gpios'))
+                    cs_gpios = deepcopy(find_parent_prop(node_path, 'cs-gpios'))
                 except:
                     pass
 
                 if cs_gpios:
-                    extract_controller(node_address, "cs-gpios", cs_gpios, reg[0], def_label, "cs-gpio", True)
-                    extract_cells(node_address, "cs-gpios", cs_gpios, None, reg[0], def_label, "cs-gpio", True)
+                    extract_controller(node_path, "cs-gpios", cs_gpios, reg[0], def_label, "cs-gpio", True)
+                    extract_cells(node_path, "cs-gpios", cs_gpios, None, reg[0], def_label, "cs-gpio", True)
 
         # generate defines
         l_base = def_label.split('/')
@@ -79,42 +79,42 @@ class DTReg(DTDirective):
             for x in range(nr_size_cells):
                 size += props.pop(0) << (32 * (nr_size_cells - x - 1))
 
-            addr += translate_addr(addr, node_address,
+            addr += translate_addr(addr, node_path,
                     nr_address_cells, nr_size_cells)
 
             l_addr_fqn = '_'.join(l_base + l_addr + l_idx)
             l_size_fqn = '_'.join(l_base + l_size + l_idx)
             if nr_address_cells:
                 prop_def[l_addr_fqn] = hex(addr)
-                add_compat_alias(node_address, '_'.join(l_addr + l_idx), l_addr_fqn, prop_alias)
+                add_compat_alias(node_path, '_'.join(l_addr + l_idx), l_addr_fqn, prop_alias)
             if nr_size_cells:
                 prop_def[l_size_fqn] = int(size / div)
-                add_compat_alias(node_address, '_'.join(l_size + l_idx), l_size_fqn, prop_alias)
+                add_compat_alias(node_path, '_'.join(l_size + l_idx), l_size_fqn, prop_alias)
             if len(name):
                 if nr_address_cells:
                     prop_alias['_'.join(l_base + name + l_addr)] = l_addr_fqn
-                    add_compat_alias(node_address, '_'.join(name + l_addr), l_addr_fqn, prop_alias)
+                    add_compat_alias(node_path, '_'.join(name + l_addr), l_addr_fqn, prop_alias)
                 if nr_size_cells:
                     prop_alias['_'.join(l_base + name + l_size)] = l_size_fqn
-                    add_compat_alias(node_address, '_'.join(name + l_size), l_size_fqn, prop_alias)
+                    add_compat_alias(node_path, '_'.join(name + l_size), l_size_fqn, prop_alias)
 
             # generate defs for node aliases
-            if node_address in aliases:
+            if node_path in aliases:
                 add_prop_aliases(
-                    node_address,
+                    node_path,
                     lambda alias:
                         '_'.join([str_to_label(alias)] + l_addr + l_idx),
                     l_addr_fqn,
                     prop_alias)
                 if nr_size_cells:
                     add_prop_aliases(
-                        node_address,
+                        node_path,
                         lambda alias:
                             '_'.join([str_to_label(alias)] + l_size + l_idx),
                         l_size_fqn,
                         prop_alias)
 
-            insert_defs(node_address, prop_def, prop_alias)
+            insert_defs(node_path, prop_def, prop_alias)
 
             # increment index for definition creation
             index += 1

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -132,15 +132,14 @@ def generate_node_defines(node_path):
     if get_compat(node_path) not in get_binding_compats():
         return
 
+    # We extract a few different #defines for a flash partition, so it's easier
+    # to handle it in one step
+    if 'partition@' in node_path:
+        flash.extract_partition(node_path)
+        return
+
     for yaml_prop, yaml_val in get_binding(node_path)['properties'].items():
         if 'generation' not in yaml_val:
-            continue
-
-        # Handle any per node extraction first.  For example we
-        # extract a few different defines for a flash partition so its
-        # easier to handle the partition node in one step
-        if 'partition@' in node_path:
-            flash.extract_partition(node_path)
             continue
 
         match = False

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -58,6 +58,9 @@ def extract_string_prop(node_path, key, label):
 
 
 def generate_prop_defines(node_path, prop):
+    # Generates #defines (and .conf file values) from the prop
+    # named 'prop' on the device tree node at 'node_path'
+
     binding = get_binding(node_path)
     if 'parent' in binding and 'bus' in binding['parent']:
         # If the binding specifies a parent for the node, then include the
@@ -95,6 +98,9 @@ def generate_prop_defines(node_path, prop):
 
 
 def generate_node_defines(node_path):
+    # Generates #defines (and .conf file values) from the device
+    # tree node at 'node_path'
+
     if get_compat(node_path) not in get_binding_compats():
         return
 
@@ -437,6 +443,8 @@ def yaml_inc_error(msg):
 
 
 def generate_defines():
+    # Generates #defines (and .conf file values) from DTS
+
     for node_path in reduced.keys():
         generate_node_defines(node_path)
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -57,7 +57,7 @@ def extract_string_prop(node_path, key, label):
     defs[node_path][label] = '"' + reduced[node_path]['props'][key] + '"'
 
 
-def extract_property(node_path, prop):
+def generate_prop_defines(node_path, prop):
     binding = get_binding(node_path)
     if 'parent' in binding and 'bus' in binding['parent']:
         # If the binding specifies a parent for the node, then include the
@@ -123,12 +123,12 @@ def generate_node_defines(node_path):
 
             if re.fullmatch(yaml_prop, prop):
                 match = True
-                extract_property(node_path, prop)
+                generate_prop_defines(node_path, prop)
 
         # Handle the case that we have a boolean property, but its not
         # in the dts
         if not match and yaml_val['type'] == 'boolean':
-            extract_property(node_path, yaml_prop)
+            generate_prop_defines(node_path, yaml_prop)
 
 
 def generate_bus_defines(node_path):


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/zephyr/pull/13499.

 - Some per-node #defines were being redundantly generated once per property, making it difficult to understand the intent of e.g. `extract_property()`.

   Generate all per-node #defines separately, before looping over the properties. That also shortens `extract_property()` a lot.

 - Avoid some naming confusion by calling `/foo/bar` a "path" instead of an "address". "Address"  is confusing when you have code dealing with e.g. address cells.

Another confusing thing (to me at least) is that the code calls the `FOO` part of `#define FOO BAR` a "label". I've never seen macro names being called labels, and it gets worse since a label in device tree is a very specific thing. Some parts of the code shorten "label" to "l_" too.

I tried to do some renaming re. the label stuff too, but it gets pretty big, so I think I'll do after some other stuff.