### PR TITLE
boards: rv32m1_vega: Fix red and blue led labels

### DIFF
--- a/boards/riscv32/rv32m1_vega/rv32m1_vega_ri5cy.dts
+++ b/boards/riscv32/rv32m1_vega/rv32m1_vega_ri5cy.dts
@@ -29,7 +29,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		red_led: led_0 {
+		blue_led: led_0 {
 			gpios = <&gpioa 22 0>;
 			label = "User LD1";
 		};
@@ -37,7 +37,7 @@
 			gpios = <&gpioa 23 0>;
 			label = "User LD2";
 		};
-		blue_led: led_2 {
+		red_led: led_2 {
 			gpios = <&gpioa 24 0>;
 			label = "User LD3";
 		};


### PR DESCRIPTION
The red and blue led labels were swapped on the rv32m1_vega board.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>