### PR TITLE
drivers: Changed return statement in function get_timeout()

### DIFF
--- a/drivers/watchdog/wdt_qmsi.c
+++ b/drivers/watchdog/wdt_qmsi.c
@@ -97,7 +97,7 @@ static u32_t get_timeout(u32_t  timeout)
 		count++;
 	}
 
-	return count - 1;
+	return ((count > 1U) ? (count - 1U) : 0);
 }
 
 static int wdt_qmsi_install_timeout(struct device *dev,


### PR DESCRIPTION
Fix for overflowed or truncated value  count-1U used as return value.
I decided to use a saturating subtract to avoid a vulnerability.
It will always return 0 or bigger value according to the conditions.
Now if count value is 0, function will return 0, not -1 as before.

Coverity-CID: 188890
Fixes: #10750

Signed-off-by: Masalski Maksim <maxxliferobot@gmail.com>