### PR TITLE
soc: imxrt: Fixup setting of MPU Kconfig

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -73,7 +73,7 @@ config SOC_MIMXRT1061
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
-	select CPU_HAS_MPU
+	select CPU_HAS_ARM_MPU
 	select INIT_ARM_PLL
 	select INIT_SYS_PLL
 	select INIT_USB1_PLL
@@ -90,7 +90,7 @@ config SOC_MIMXRT1062
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
-	select CPU_HAS_MPU
+	select CPU_HAS_ARM_MPU
 	select INIT_ARM_PLL
 	select INIT_SYS_PLL
 	select INIT_USB1_PLL
@@ -106,7 +106,7 @@ config SOC_MIMXRT1064
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_TRNG
 	select CPU_HAS_FPU_DOUBLE_PRECISION
-	select CPU_HAS_MPU
+	select CPU_HAS_ARM_MPU
 	select INIT_ARM_PLL
 	select INIT_SYS_PLL
 	select INIT_USB1_PLL


### PR DESCRIPTION
We should be selecting CPU_HAS_ARM_MPU at this level and not
CPU_HAS_MPU.  Change the cases of CPU_HAS_MPU to CPU_HAS_ARM_MPU.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>