### PR TITLE
userspace: increase gperf text areas

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -190,9 +190,8 @@ config PRIVILEGED_STACK_SIZE
 
 config PRIVILEGED_STACK_TEXT_AREA
 	int "Privileged stacks text area"
-	default 256 if (DEBUG || STACK_CANARIES || CODE_DATA_RELOCATION)
 	default 512 if COVERAGE_GCOV
-	default 128
+	default 256
 	depends on ARCH_HAS_USERSPACE
 	help
 	  Stack text area size for privileged stacks.
@@ -200,9 +199,7 @@ config PRIVILEGED_STACK_TEXT_AREA
 config KOBJECT_TEXT_AREA
 	int "Size if kobject text area"
 	default 512 if COVERAGE_GCOV
-	default 256 if (!SIZE_OPTIMIZATIONS || STACK_CANARIES || ARC)
-	default 256 if CODE_DATA_RELOCATION
-	default 128
+	default 256
 	depends on ARCH_HAS_USERSPACE
 	help
 	  Size of kernel object text area. Used in linker script.


### PR DESCRIPTION
128 already gets exceeded in a lot of cases, and the binaries
with the new SDK are very slightly larger. Just kick this up
to 256 and get rid of all the exceptions.

Fixes: #13594

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>