### PR TITLE
cmake: more deterministic git describe --abbrev=12

### DIFF
--- a/cmake/git.cmake
+++ b/cmake/git.cmake
@@ -3,7 +3,8 @@
 # https://cmake.org/cmake/help/latest/module/FindGit.html
 find_package(Git QUIET)
 if(GIT_FOUND)
-  execute_process(COMMAND ${GIT_EXECUTABLE} describe
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --abbrev=12
     WORKING_DIRECTORY                ${ZEPHYR_BASE}
     OUTPUT_VARIABLE                  BUILD_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
Hardcode --abbrev=12 not to depend on personal git config preference.
12 is deemed large enough for the Linux kernel which should leave some
room:
https://public-inbox.org/git/xmqq37knwcf4.fsf@gitster.mtv.corp.google.com/

Add --dirty because it should be the default: who likes to be duped into
thinking they're debugging an exact version when they're not?

Signed-off-by: Marc Herbert <marc.herbert@intel.com>