### PR TITLE
boards: nrf52_blenano2: standardize scratch and storage partitions

### DIFF
--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
@@ -82,11 +82,18 @@
 		};
 		scratch_partition: partition@70000 {
 			label = "image-scratch";
-			reg = <0x00070000 0xD000>;
+			reg = <0x00070000 0xa000>;
 		};
-		storage_partition: partition@7D000 {
+
+		/*
+		 * The flash starting at 0x0007a000 and ending at
+		 * 0x0007ffff (sectors 122-127) is reserved for use
+		 * by the application. If enabled, partition for FCB/NFFS
+		 * will be created in this area.
+		 */
+		storage_partition: partition@7a000 {
 			label = "storage";
-			reg = <0x0007D000 0x00004000>;
+			reg = <0x0007a000 0x00006000>;
 		};
 	};
 };


### PR DESCRIPTION
Most of the other nRF52832 boards have the following settings for
scratch and storage partitions:

scratch_partition: partition@70000 {
	label = "image-scratch";
	reg = <0x00070000 0xa000>;
};

storage_partition: partition@7a000 {
	label = "storage";
	reg = <0x0007a000 0x00006000>;
};

Let's remove the snowflake settings in BLENano2 which coincidentally
are incorrect: storage overruns the flash area by 0x1000 and causes
a crash when enabling FCB storage.

Signed-off-by: Michael Scott <mike@foundries.io>