### PR TITLE
Bluetooth: settings: Fix missing log_strdup() call

### DIFF
--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -40,7 +40,7 @@ void bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
 			 addr->type);
 	}
 
-	BT_DBG("Encoded path %s", path);
+	BT_DBG("Encoded path %s", log_strdup(path));
 }
 
 int bt_settings_decode_key(char *key, bt_addr_le_t *addr)


### PR DESCRIPTION
The bt_settings_encode_key() cannot know if the given path pointer is
on the stack or not, so the only safe way to pass it to the logger is
by using a log_strdup() call. Not doing this will likely cause
corrupted strings to show up in the log output.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>