### PR TITLE
arch: arm: arm_core_mpu: Fixed the build when coverage was enabled.

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -68,7 +68,7 @@ void _arch_configure_static_mpu_regions(void)
 #if defined(CONFIG_COVERAGE_GCOV) && defined(CONFIG_USERSPACE)
 		{
 		.start = (u32_t)&__gcov_bss_start,
-		.size = (u32_t)&__gcov_bss_size
+		.size = (u32_t)&__gcov_bss_size,
 		.attr = K_MEM_PARTITION_P_RW_U_RW,
 		},
 #endif /* CONFIG_COVERAGE_GCOV && CONFIG_USERSPACE */


### PR DESCRIPTION
The build was broken when CONFIG_COVERAGE was enabled.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>