### PR TITLE
doc: net: Move networking chapters around

### DIFF
--- a/doc/reference/networking/apis.rst
+++ b/doc/reference/networking/apis.rst
@@ -1,0 +1,17 @@
+.. _net_apis:
+
+Network APIs
+############
+
+.. toctree::
+   :maxdepth: 1
+
+   sockets.rst
+   ip_4_6.rst
+   dns_resolve.rst
+   net_mgmt.rst
+   net_stats.rst
+   net_timeout.rst
+   net_context.rst
+   promiscuous.rst
+   trickle.rst

--- a/doc/reference/networking/buf_mgmt.rst
+++ b/doc/reference/networking/buf_mgmt.rst
@@ -1,0 +1,10 @@
+.. _net_buf_mgmt:
+
+Network Buffer Management
+#########################
+
+.. toctree::
+   :maxdepth: 1
+
+   net_buf.rst
+   net_pkt.rst

--- a/doc/reference/networking/ethernet.rst
+++ b/doc/reference/networking/ethernet.rst
@@ -3,6 +3,12 @@
 Ethernet
 ########
 
+.. toctree::
+   :maxdepth: 1
+
+   vlan.rst
+   lldp.rst
+
 Overview
 ********
 

--- a/doc/reference/networking/index.rst
+++ b/doc/reference/networking/index.rst
@@ -4,30 +4,11 @@ Networking
 ##########
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
-   sockets.rst
-   dhcpv4.rst
-   dns_resolve.rst
-   gptp.rst
-   ieee802154.rst
-   ip_4_6.rst
-   net_buf.rst
-   net_config.rst
-   net_context.rst
-   net_core.rst
-   net_hostname.rst
-   net_if.rst
-   net_l2.rst
-   net_linkaddr.rst
-   net_mgmt.rst
-   net_offload.rst
-   net_pkt.rst
-   net_stats.rst
+   apis.rst
+   buf_mgmt.rst
    net_tech.rst
-   net_timeout.rst
-   promiscuous.rst
    protocols.rst
-   ptp_time.rst
-   traffic-class.rst
-   trickle.rst
+   system_mgmt.rst
+   tsn.rst

--- a/doc/reference/networking/net_tech.rst
+++ b/doc/reference/networking/net_tech.rst
@@ -7,7 +7,5 @@ Networking Technologies
    :maxdepth: 1
 
    ethernet.rst
-   ethernet_mgmt
-   vlan
-   lldp
+   ieee802154.rst
 

--- a/doc/reference/networking/system_mgmt.rst
+++ b/doc/reference/networking/system_mgmt.rst
@@ -1,0 +1,18 @@
+.. _net_system_mgmt:
+
+Network System Management
+#########################
+
+.. toctree::
+   :maxdepth: 1
+
+   net_config.rst
+   dhcpv4.rst
+   net_hostname.rst
+   net_core.rst
+   net_if.rst
+   net_l2.rst
+   net_offload.rst
+   net_linkaddr.rst
+   ethernet_mgmt.rst
+   traffic-class.rst

--- a/doc/reference/networking/tsn.rst
+++ b/doc/reference/networking/tsn.rst
@@ -1,0 +1,10 @@
+.. _net_tsn:
+
+Time Sensitive Networking
+#########################
+
+.. toctree::
+   :maxdepth: 1
+
+   gptp.rst
+   ptp_time.rst


### PR DESCRIPTION
Trying to group the networking chapters so that the layout is
more logical.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>