### PR TITLE
Switch logging to new net_pkt/net_context API

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -2036,7 +2036,7 @@ struct net_pkt *net_pkt_rx_alloc_on_iface_debug(struct net_if *iface,
 						int line);
 #define net_pkt_rx_alloc_on_iface(_iface, _timeout)			\
 	net_pkt_rx_alloc_on_iface_debug(_iface, _timeout,		\
-					   __func__, __LINE__)
+					__func__, __LINE__)
 
 int net_pkt_alloc_buffer_debug(struct net_pkt *pkt,
 			       size_t size,
@@ -2045,7 +2045,7 @@ int net_pkt_alloc_buffer_debug(struct net_pkt *pkt,
 			       const char *caller, int line);
 #define net_pkt_alloc_buffer(_pkt, _size, _proto, _timeout)		\
 	net_pkt_alloc_buffer_debug(_pkt, _size, _proto, _timeout,	\
-				      __func__, __LINE__)
+				   __func__, __LINE__)
 
 struct net_pkt *net_pkt_alloc_with_buffer_debug(struct net_if *iface,
 						size_t size,
@@ -2056,9 +2056,9 @@ struct net_pkt *net_pkt_alloc_with_buffer_debug(struct net_if *iface,
 						int line);
 #define net_pkt_alloc_with_buffer(_iface, _size, _family,		\
 				  _proto, _timeout)			\
-	net_pkt_alloc_with_buffer_debug(_iface, _size, _family,	\
-					   _proto, _timeout,		\
-					   __func__, __LINE__)
+	net_pkt_alloc_with_buffer_debug(_iface, _size, _family,		\
+					_proto, _timeout,		\
+					__func__, __LINE__)
 
 struct net_pkt *net_pkt_rx_alloc_with_buffer_debug(struct net_if *iface,
 						   size_t size,
@@ -2070,9 +2070,9 @@ struct net_pkt *net_pkt_rx_alloc_with_buffer_debug(struct net_if *iface,
 #define net_pkt_rx_alloc_with_buffer(_iface, _size, _family,		\
 				     _proto, _timeout)			\
 	net_pkt_rx_alloc_with_buffer_debug(_iface, _size, _family,	\
-					      _proto, _timeout,		\
-					      __func__, __LINE__)
-#endif
+					   _proto, _timeout,		\
+					   __func__, __LINE__)
+#endif /* NET_PKT_DEBUG_ENABLED */
 /** @endcond */
 
 /**
@@ -2164,7 +2164,6 @@ struct net_pkt *net_pkt_rx_alloc_with_buffer(struct net_if *iface,
 					     sa_family_t family,
 					     enum net_ip_protocol proto,
 					     s32_t timeout);
-
 #endif
 
 /**

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -2018,6 +2018,12 @@ struct net_pkt *net_pkt_alloc_debug(s32_t timeout,
 #define net_pkt_alloc(_timeout)					\
 	net_pkt_alloc_debug(_timeout, __func__, __LINE__)
 
+struct net_pkt *net_pkt_alloc_from_slab_debug(struct k_mem_slab *slab,
+					      s32_t timeout,
+					      const char *caller, int line);
+#define net_pkt_alloc_from_slab(_slab, _timeout)			\
+	net_pkt_alloc_from_slab_debug(_slab, _timeout, __func__, __LINE__)
+
 struct net_pkt *net_pkt_rx_alloc_debug(s32_t timeout,
 				       const char *caller, int line);
 #define net_pkt_rx_alloc(_timeout)				\
@@ -2087,6 +2093,25 @@ struct net_pkt *net_pkt_rx_alloc_with_buffer_debug(struct net_if *iface,
  */
 #if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_pkt *net_pkt_alloc(s32_t timeout);
+#endif
+
+/**
+ * @brief Allocate an initialized net_pkt from a specific slab
+ *
+ * @details unlike net_pkt_alloc() which uses core slabs, this one will use
+ *          an external slab (see NET_PKT_SLAB_DEFINE()).
+ *          Do _not_ use it unless you know what you are doing. Basically, only
+ *          net_context should be using this, in order to allocate packet and
+ *          then buffer on its local slab/pool (if any).
+ *
+ * @param slab    The slab to use for allocating the packet
+ * @param timeout Maximum time in milliseconds to wait for an allocation.
+ *
+ * @return a pointer to a newly allocated net_pkt on success, NULL otherwise.
+ */
+#if !defined(NET_PKT_DEBUG_ENABLED)
+struct net_pkt *net_pkt_alloc_from_slab(struct k_mem_slab *slab,
+					s32_t timeout);
 #endif
 
 /**

--- a/subsys/logging/log_backend_net.c
+++ b/subsys/logging/log_backend_net.c
@@ -58,33 +58,19 @@ static int line_out(u8_t *data, size_t length, void *output_ctx)
 {
 	struct net_context *ctx = (struct net_context *)output_ctx;
 	int ret = -ENOMEM;
-	struct net_pkt *pkt;
 
 	if (ctx == NULL) {
 		return length;
 	}
 
-	pkt = net_pkt_get_tx(ctx, K_NO_WAIT);
-	if (pkt == NULL) {
-		goto fail;
-	}
-
-	if (net_pkt_append_all(pkt, length, data, K_NO_WAIT) == false) {
-		goto fail;
-	}
-
-	ret = net_context_send(pkt, NULL, K_NO_WAIT, NULL, NULL);
+	ret = net_context_send_new(ctx, data, length,
+				   NULL, K_NO_WAIT, NULL, NULL);
 	if (ret < 0) {
 		goto fail;
 	}
 
 	DBG(data);
-
 fail:
-	if (ret < 0 && (pkt != NULL)) {
-		net_pkt_unref(pkt);
-	}
-
 	return length;
 }
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1532,6 +1532,43 @@ static void context_finalize_packet(struct net_context *context,
 	}
 }
 
+static struct net_pkt *context_alloc_pkt(struct net_context *context,
+					 size_t len, s32_t timeout)
+{
+	struct net_pkt *pkt;
+
+#if defined(CONFIG_NET_CONTEXT_NET_PKT_POOL)
+	if (context->tx_slab) {
+		pkt = net_pkt_alloc_from_slab(context->tx_slab(), timeout);
+		if (!pkt) {
+			return NULL;
+		}
+
+		net_pkt_set_iface(pkt, net_context_get_iface(context));
+		net_pkt_set_family(pkt, net_context_get_family(context));
+		net_pkt_set_context(pkt, context);
+
+		if (net_pkt_alloc_buffer(pkt, len,
+					 net_context_get_ip_proto(context),
+					 timeout)) {
+			net_pkt_unref(pkt);
+			return NULL;
+		}
+
+		return pkt;
+	}
+#endif
+	pkt = net_pkt_alloc_with_buffer(net_context_get_iface(context), len,
+					net_context_get_family(context),
+					net_context_get_ip_proto(context),
+					timeout);
+
+	net_pkt_set_context(pkt, context);
+
+	return pkt;
+}
+
+
 static int context_sendto_new(struct net_context *context,
 			      const void *buf,
 			      size_t len,
@@ -1630,10 +1667,7 @@ static int context_sendto_new(struct net_context *context,
 		return -EINVAL;
 	}
 
-	pkt = net_pkt_alloc_with_buffer(net_context_get_iface(context), len,
-					net_context_get_family(context),
-					net_context_get_ip_proto(context),
-					PKT_WAIT_TIME);
+	pkt = context_alloc_pkt(context, len, PKT_WAIT_TIME);
 	if (!pkt) {
 		return -ENOMEM;
 	}
@@ -1644,7 +1678,6 @@ static int context_sendto_new(struct net_context *context,
 		len = tmp_len;
 	}
 
-	net_pkt_set_context(pkt, context);
 	context->send_cb = cb;
 	context->user_data = user_data;
 	net_pkt_set_token(pkt, token);


### PR DESCRIPTION
I need to make new net_pkt allocator aware of external slab/pool (working on it). That's an unused feature elsewhere, but it really makes sense here in logging obviously.