### PR TITLE
 Bluetooth: settings: Always initialize key when storing Client Features

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2856,27 +2856,28 @@ static int bt_gatt_store_cf(struct bt_conn *conn)
 
 	cfg = find_cf_cfg(conn);
 	if (!cfg) {
-		/* No cfg found just cleare it */
+		/* No cfg found, just clear it */
+		BT_DBG("No config for CF");
 		str = NULL;
 		len = 0;
-		goto save;
+	} else {
+		str = (char *)cfg->data;
+		len = sizeof(cfg->data);
+
+		if (conn->id) {
+			char id_str[4];
+
+			snprintk(id_str, sizeof(id_str), "%u", conn->id);
+			bt_settings_encode_key(key, sizeof(key), "cf",
+					       &conn->le.dst, id_str);
+		}
 	}
 
-	if (conn->id) {
-		char id_str[4];
-
-		snprintk(id_str, sizeof(id_str), "%u", conn->id);
-		bt_settings_encode_key(key, sizeof(key), "cf",
-				       &conn->le.dst, id_str);
-	} else {
+	if (!cfg || !conn->id) {
 		bt_settings_encode_key(key, sizeof(key), "cf",
 				       &conn->le.dst, NULL);
 	}
 
-	str = (char *)cfg->data;
-	len = sizeof(cfg->data);
-
-save:
 	err = settings_save_one(key, str, len);
 	if (err) {
 		BT_ERR("Failed to store Client Features (err %d)", err);

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2884,7 +2884,7 @@ static int bt_gatt_store_cf(struct bt_conn *conn)
 		return err;
 	}
 
-	BT_DBG("Stored CF for %s (%s)", bt_addr_le_str(&conn->le.dst), key);
+	BT_DBG("Stored CF for %s (%s)", bt_addr_le_str(&conn->le.dst), log_strdup(key));
 #endif /* CONFIG_BT_GATT_CACHING */
 	return 0;
 

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -81,7 +81,7 @@ int bt_settings_decode_key(char *key, bt_addr_le_t *addr)
 		}
 	}
 
-	BT_DBG("Decoded %s as %s", key, bt_addr_le_str(addr));
+	BT_DBG("Decoded %s as %s", log_strdup(key), bt_addr_le_str(addr));
 
 	return 0;
 }


### PR DESCRIPTION
Fixes #13572.

Initialize key used to store Client Features even when config was not
found.