### PR TITLE
arch: arm: mpu: add a missing comma

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -68,7 +68,7 @@ void _arch_configure_static_mpu_regions(void)
 #if defined(CONFIG_COVERAGE_GCOV) && defined(CONFIG_USERSPACE)
 		{
 		.start = (u32_t)&__gcov_bss_start,
-		.size = (u32_t)&__gcov_bss_size
+		.size = (u32_t)&__gcov_bss_size,
 		.attr = K_MEM_PARTITION_P_RW_U_RW,
 		},
 #endif /* CONFIG_COVERAGE_GCOV && CONFIG_USERSPACE */


### PR DESCRIPTION
Commit 8236f3d72c68 ("arch: arm: mpu: get the region sizes from the
linker") broke gcov support with userspace due to a missing comma. Fix
that.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>