### PR TITLE
settings: create properly sized fcb-record when record content is unaligned

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -249,7 +249,7 @@ static int settings_fcb_save(struct settings_store *cs, const char *name,
 		return -EINVAL;
 	}
 
-	wbs = flash_area_align(cf->cf_fcb.fap);
+	wbs = cf->cf_fcb.f_align;
 	len = settings_line_len_calc(name, val_len);
 
 	for (i = 0; i < cf->cf_fcb.f_sector_cnt - 1; i++) {

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -263,7 +263,7 @@ int settings_next_line_ctx(struct line_entry_ctx *entry_ctx)
 
 int settings_line_len_calc(const char *name, size_t val_len)
 {
-	int len, mod;
+	int len;
 
 #ifdef CONFIG_SETTINGS_USE_BASE64
 	/* <enc(value)> */
@@ -274,11 +274,7 @@ int settings_line_len_calc(const char *name, size_t val_len)
 #endif
 	/* <name>=<enc(value)> */
 	len += strlen(name) + 1;
-	mod = len % settings_io_cb.rwbs;
-	if (mod) {
-		 /*additional \0 for meet flash alignment */
-		len += settings_io_cb.rwbs - mod;
-	}
+
 	return len;
 }
 

--- a/subsys/settings/src/settings_priv.h
+++ b/subsys/settings/src/settings_priv.h
@@ -39,6 +39,7 @@ void settings_line_io_init(int (*read_cb)(void *ctx, off_t off, char *buf,
 int settings_line_write(const char *name, const char *value, size_t val_len,
 			off_t w_loc, void *cb_arg);
 
+/* Get len of record without alignment to write-block-size */
 int settings_line_len_calc(const char *name, size_t val_len);
 
 #ifdef CONFIG_SETTINGS_ENCODE_LEN

--- a/tests/subsys/settings/fcb/src/settings_test.h
+++ b/tests/subsys/settings/fcb/src/settings_test.h
@@ -23,6 +23,7 @@
 #define SETTINGS_TEST_FCB_FLASH_CNT   4
 
 extern u8_t val8;
+extern u8_t val8_un;
 extern u32_t val32;
 extern u64_t val64;
 

--- a/tests/subsys/settings/fcb/src/settings_test_save_unaligned.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_unaligned.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "settings_test.h"
+#include "settings/settings_fcb.h"
+
+void test_config_save_fcb_unaligned(void)
+{
+	int rc;
+	struct settings_fcb cf;
+
+	config_wipe_srcs();
+
+	cf.cf_fcb.f_magic = CONFIG_SETTINGS_FCB_MAGIC;
+	cf.cf_fcb.f_sectors = fcb_sectors;
+	cf.cf_fcb.f_sector_cnt = ARRAY_SIZE(fcb_sectors);
+
+	rc = settings_fcb_src(&cf);
+	zassert_true(rc == 0, "can't register FCB as configuration source");
+
+	/* override flash driver alignment */
+	cf.cf_fcb.f_align = 4;
+	settings_mount_fcb_backend(&cf);
+
+	rc = settings_fcb_dst(&cf);
+	zassert_true(rc == 0,
+		     "can't register FCB as configuration destination");
+
+	val8_un = 33U;
+	rc = settings_save();
+	zassert_true(rc == 0, "fcb write error");
+
+	val8_un = 0U;
+
+	rc = settings_load();
+	zassert_true(rc == 0, "fcb redout error");
+	zassert_true(val8_un == 33, "bad value read");
+
+	val8_un = 15;
+	rc = settings_save();
+	zassert_true(rc == 0, "fcb write error");
+}

--- a/tests/subsys/settings/src/settings_enc.c
+++ b/tests/subsys/settings/src/settings_enc.c
@@ -34,11 +34,6 @@ static void test_encoding_iteration(char const *name, char const *value,
 
 	settings_line_io_init(NULL, write_handler, NULL, wbs);
 
-	rc = settings_line_len_calc(name, strlen(value));
-
-	zassert_equal(rc, exp_len, "Wrong line length calculated, was %d.\n",
-		      rc);
-
 	enc_buf_cnt = 0;
 
 	rc = settings_line_write(name, value, strlen(value), 0,


### PR DESCRIPTION
settings_line_len_calc() is used to determine key-value record size.
It unnecessary aligned this size to write-block-size.

Record size in flash layout is actually adjusted independently by
fcb itself and setting settings_line_write().

fixes #12967