### PR TITLE
include: misc: Use logger in STACK_ANALYZE macro

### DIFF
--- a/include/misc/stack.h
+++ b/include/misc/stack.h
@@ -12,86 +12,80 @@
 #ifndef ZEPHYR_INCLUDE_MISC_STACK_H_
 #define ZEPHYR_INCLUDE_MISC_STACK_H_
 
-#include <misc/printk.h>
+#include <logging/log.h>
 
-#if defined(CONFIG_INIT_STACKS)
 static inline size_t stack_unused_space_get(const char *stack, size_t size)
 {
 	size_t unused = 0;
 
-#ifdef CONFIG_STACK_SENTINEL
-	/* First 4 bytes of the stack buffer reserved for the sentinel
-	 * value, it won't be 0xAAAAAAAA for thread stacks.
-	 */
-	const unsigned char *checked_stack = (const unsigned char *)stack + 4;
-#else
-	const unsigned char *checked_stack = (const unsigned char *)stack;
-#endif
+	if (IS_ENABLED(CONFIG_INIT_STACKS)) {
+		const unsigned char *checked_stack =
+			(const unsigned char *)stack;
 
-	/* TODO Currently all supported platforms have stack growth down and
-	 * there is no Kconfig option to configure it so this always build
-	 * "else" branch.  When support for platform with stack direction up
-	 * (or configurable direction) is added this check should be confirmed
-	 * that correct Kconfig option is used.
-	 */
-#if defined(CONFIG_STACK_GROWS_UP)
-	int i;
-	for (i = size - 1; i >= 0; i--) {
-		if (checked_stack[i] == 0xaaU) {
-			unused++;
+		if (IS_ENABLED(CONFIG_STACK_SENTINEL)) {
+			/* First 4 bytes of the stack buffer reserved for the
+			 * sentinel value, it won't be 0xAAAAAAAA for thread
+			 * stacks.
+			 */
+			checked_stack += 4;
+		}
+
+		/* TODO Currently all supported platforms have stack growth down
+		 * and there is no Kconfig option to configure it so this always
+		 * build "else" branch.
+		 * When support for platform with stack direction up
+		 * (or configurable direction) is added this check should be
+		 * confirmed that correct Kconfig option is used.
+		 */
+		if (IS_ENABLED(CONFIG_STACK_GROWS_UP)) {
+			for (size_t i = size; i > 0; i--) {
+				if (checked_stack[i - 1] == 0xaaU) {
+					unused++;
+				} else {
+					break;
+				}
+			}
 		} else {
-			break;
+			for (size_t i = 0; i < size; i++) {
+				if (checked_stack[i] == 0xaaU) {
+					unused++;
+				} else {
+					break;
+				}
+			}
 		}
 	}
-#else
-	size_t i;
-	for (i = 0; i < size; i++) {
-		if (checked_stack[i] == 0xaaU) {
-			unused++;
-		} else {
-			break;
-		}
-	}
-#endif
+
 	return unused;
 }
-#else
-static inline size_t stack_unused_space_get(const char *stack, size_t size)
-{
-	return 0;
-}
-#endif
 
-#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_PRINTK)
 static inline void stack_analyze(const char *name, const char *stack,
 				 unsigned int size)
 {
-	unsigned int pcnt, unused = 0;
+	if (IS_ENABLED(CONFIG_INIT_STACKS)) {
+		LOG_MODULE_DECLARE(kernel, CONFIG_KERNEL_LOG_LEVEL);
 
-	unused = stack_unused_space_get(stack, size);
+		unsigned int unused = stack_unused_space_get(stack, size);
+		unsigned int pcnt = ((size - unused) * 100) / size;
 
-	/* Calculate the real size reserved for the stack */
-	pcnt = ((size - unused) * 100) / size;
-
-	printk("%s (real size %u):\tunused %u\tusage %u / %u (%u %%)\n", name,
-	       size, unused, size - unused, size, pcnt);
+		LOG_INF("%s :\tunused %u\tusage %u / %u (%u %%)",
+			name, unused, size - unused, size, pcnt);
+	}
 }
-#else
-static inline void stack_analyze(const char *name, const char *stack,
-				 unsigned int size)
-{
-}
-#endif
+
 /**
- * @brief Analyze stacks
+ * @brief Analyze stacks.
  *
- * Use this macro to get information about stack usage
+ * Use this macro to get information about stack usage.
  *
  * @param name Name of the stack
  * @param sym The symbol of the stack
  */
-#define STACK_ANALYZE(name, sym) \
-	stack_analyze(name, K_THREAD_STACK_BUFFER(sym), \
-		      K_THREAD_STACK_SIZEOF(sym))
+#define STACK_ANALYZE(name, sym)				\
+	do {							\
+		stack_analyze(name,				\
+			      K_THREAD_STACK_BUFFER(sym),	\
+			      K_THREAD_STACK_SIZEOF(sym));	\
+	} while (0)
 
 #endif /* ZEPHYR_INCLUDE_MISC_STACK_H_ */


### PR DESCRIPTION
When printk is used stack size expanding may be needed. This is especially
a problem for threads with small stacks.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>