### PR TITLE
bluetooth: controller: Update slot reservation time calculation for ADV

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -327,7 +327,7 @@ static void isr_tx(void *param)
 	/* TODO: MOVE ^^ */
 
 	radio_isr_set(isr_rx, param);
-	radio_tmr_tifs_set(TIFS_US);
+	radio_tmr_tifs_set(EVENT_IFS_US);
 	radio_switch_complete_and_tx(0, 0, 0, 0);
 	radio_pkt_rx_set(radio_pkt_scratch_get());
 
@@ -347,7 +347,7 @@ static void isr_tx(void *param)
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
 	/* +/- 2us active clock jitter, +1 us hcto compensation */
-	hcto = radio_tmr_tifs_base_get() + TIFS_US + 4 + 1;
+	hcto = radio_tmr_tifs_base_get() + EVENT_IFS_US + 4 + 1;
 	hcto += radio_rx_chain_delay_get(0, 0);
 	hcto += addr_us_get(0);
 	hcto -= radio_tx_chain_delay_get(0, 0);
@@ -371,7 +371,7 @@ static void isr_tx(void *param)
 #endif /* CONFIG_BT_CTLR_PROFILE_ISR */
 
 	radio_gpio_lna_setup();
-	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + TIFS_US - 4 -
+	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US - 4 -
 				 radio_tx_chain_delay_get(0, 0) -
 				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
@@ -593,7 +593,7 @@ static void chan_prepare(struct lll_adv *lll)
 	    (!IS_ENABLED(CONFIG_BT_CTLR_ADV_EXT) ||
 	     (pdu->type != PDU_ADV_TYPE_EXT_IND))) {
 		radio_isr_set(isr_tx, lll);
-		radio_tmr_tifs_set(TIFS_US);
+		radio_tmr_tifs_set(EVENT_IFS_US);
 		radio_switch_complete_and_rx(0);
 	} else {
 		radio_isr_set(isr_done, lll);
@@ -661,7 +661,8 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 #endif /* CONFIG_BT_CTLR_PROFILE_ISR */
 
 		radio_gpio_pa_setup();
-		radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + TIFS_US -
+		radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
+					 EVENT_IFS_US -
 					 radio_rx_chain_delay_get(0, 0) -
 					 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -247,7 +247,7 @@ void lll_conn_isr_rx(void *param)
 		}
 	} else {
 		radio_isr_set(lll_conn_isr_tx, param);
-		radio_tmr_tifs_set(TIFS_US);
+		radio_tmr_tifs_set(EVENT_IFS_US);
 
 #if defined(CONFIG_BT_CTLR_PHY)
 		radio_switch_complete_and_rx(lll->phy_rx);
@@ -278,11 +278,11 @@ void lll_conn_isr_rx(void *param)
 	radio_gpio_pa_setup();
 
 #if defined(CONFIG_BT_CTLR_PHY)
-	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + TIFS_US -
+	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US -
 				 radio_rx_chain_delay_get(lll->phy_rx, 1) -
 				 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
 #else /* !CONFIG_BT_CTLR_PHY */
-	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + TIFS_US -
+	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US -
 				 radio_rx_chain_delay_get(0, 0) -
 				 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
 #endif /* !CONFIG_BT_CTLR_PHY */
@@ -376,7 +376,7 @@ void lll_conn_isr_tx(void *param)
 	/* TODO: MOVE ^^ */
 
 	radio_isr_set(lll_conn_isr_rx, param);
-	radio_tmr_tifs_set(TIFS_US);
+	radio_tmr_tifs_set(EVENT_IFS_US);
 #if defined(CONFIG_BT_CTLR_PHY)
 	radio_switch_complete_and_tx(lll->phy_rx, 0,
 				     lll->phy_tx,
@@ -391,7 +391,8 @@ void lll_conn_isr_tx(void *param)
 	LL_ASSERT(!radio_is_ready());
 
 	/* +/- 2us active clock jitter, +1 us hcto compensation */
-	hcto = radio_tmr_tifs_base_get() + TIFS_US + 4 + RANGE_DELAY_US + 1;
+	hcto = radio_tmr_tifs_base_get() + EVENT_IFS_US + 4 +
+		RANGE_DELAY_US + 1;
 #if defined(CONFIG_BT_CTLR_PHY)
 	hcto += radio_rx_chain_delay_get(lll->phy_rx, 1);
 	hcto += addr_us_get(lll->phy_rx);
@@ -418,12 +419,12 @@ void lll_conn_isr_tx(void *param)
 #if defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
 	radio_gpio_lna_setup();
 #if defined(CONFIG_BT_CTLR_PHY)
-	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + TIFS_US - 4 -
+	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US - 4 -
 				 radio_tx_chain_delay_get(lll->phy_tx,
 							  lll->phy_flags) -
 				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
 #else /* !CONFIG_BT_CTLR_PHY */
-	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + TIFS_US - 4 -
+	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US - 4 -
 				 radio_tx_chain_delay_get(0, 0) -
 				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
 #endif /* !CONFIG_BT_CTLR_PHY */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
@@ -151,7 +151,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 	radio_isr_set(lll_conn_isr_tx, lll);
 
-	radio_tmr_tifs_set(TIFS_US);
+	radio_tmr_tifs_set(EVENT_IFS_US);
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	radio_switch_complete_and_rx(lll->phy_rx);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -167,7 +167,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 	radio_isr_set(isr_rx, lll);
 
-	radio_tmr_tifs_set(TIFS_US);
+	radio_tmr_tifs_set(EVENT_IFS_US);
 	radio_switch_complete_and_tx(0, 0, 0, 0);
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
@@ -432,7 +432,7 @@ static void isr_tx(void *param)
 	LL_ASSERT(node_rx);
 
 	radio_isr_set(isr_rx, param);
-	radio_tmr_tifs_set(TIFS_US);
+	radio_tmr_tifs_set(EVENT_IFS_US);
 	radio_switch_complete_and_tx(0, 0, 0, 0);
 	radio_pkt_rx_set(node_rx->pdu);
 
@@ -448,7 +448,7 @@ static void isr_tx(void *param)
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
 	/* +/- 2us active clock jitter, +1 us hcto compensation */
-	hcto = radio_tmr_tifs_base_get() + TIFS_US + 4 + 1;
+	hcto = radio_tmr_tifs_base_get() + EVENT_IFS_US + 4 + 1;
 	hcto += radio_rx_chain_delay_get(0, 0);
 	hcto += addr_us_get(0);
 	hcto -= radio_tx_chain_delay_get(0, 0);
@@ -459,7 +459,7 @@ static void isr_tx(void *param)
 
 #if defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
 	radio_gpio_lna_setup();
-	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + TIFS_US - 4 -
+	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US - 4 -
 				 radio_tx_chain_delay_get(0, 0) -
 				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
@@ -487,7 +487,7 @@ static void isr_done(void *param)
 	node_rx = ull_pdu_rx_alloc_peek(1);
 	LL_ASSERT(node_rx);
 
-	radio_tmr_tifs_set(TIFS_US);
+	radio_tmr_tifs_set(EVENT_IFS_US);
 	radio_switch_complete_and_tx(0, 0, 0, 0);
 	radio_pkt_rx_set(node_rx->pdu);
 	radio_rssi_measure();
@@ -746,7 +746,8 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 #endif /* CONFIG_BT_CTLR_PROFILE_ISR */
 
 		radio_gpio_pa_setup();
-		radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + TIFS_US -
+		radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
+					 EVENT_IFS_US -
 					 radio_rx_chain_delay_get(0, 0) -
 					 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
@@ -837,7 +838,7 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 		lll->state = 1U;
 		radio_isr_set(isr_tx, lll);
 
-		radio_tmr_tifs_set(TIFS_US);
+		radio_tmr_tifs_set(EVENT_IFS_US);
 		radio_switch_complete_and_rx(0);
 		radio_pkt_tx_set(pdu_tx);
 
@@ -860,7 +861,8 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 #endif /* CONFIG_BT_CTLR_PROFILE_ISR */
 
 		radio_gpio_pa_setup();
-		radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + TIFS_US -
+		radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
+					 EVENT_IFS_US -
 					 radio_rx_chain_delay_get(0, 0) -
 					 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
@@ -173,7 +173,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 	radio_isr_set(lll_conn_isr_rx, lll);
 
-	radio_tmr_tifs_set(TIFS_US);
+	radio_tmr_tifs_set(EVENT_IFS_US);
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	radio_switch_complete_and_tx(lll->phy_rx, 0, lll->phy_tx,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_tim_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_tim_internal.h
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define TIFS_US 150
-
 /* Range Delay
  * Refer to BT Spec v5.1 Vol.6, Part B, Section 4.2.3 Range Delay
  * "4 / 1000" is an approximation of the propagation time in us of the

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
@@ -9,4 +9,16 @@
 #define EVENT_OVERHEAD_PREEMPT_MIN_US 0
 #define EVENT_OVERHEAD_PREEMPT_MAX_US EVENT_OVERHEAD_XTAL_US
 #define EVENT_OVERHEAD_START_US       200
+/* Worst-case time margin needed after event end-time in the air
+ * (done/preempt race margin + power-down/chain delay)
+ */
+#define EVENT_OVERHEAD_END_US         40
 #define EVENT_JITTER_US               16
+
+#define EVENT_RX_JITTER_US(phy) 16    /* Radio Rx timing uncertainty */
+#define EVENT_RX_TO_US(phy) ((((((phy)&0x03) + 4)<<3)/BIT((((phy)&0x3)>>1))) + \
+				  EVENT_RX_JITTER_US(phy))
+
+/* TODO - fix up numbers re. HW */
+#define EVENT_RX_TX_TURNARROUND(phy)  ((phy) == 1?100:((phy) == 2 ? 80:900))
+

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -17,6 +17,18 @@
 /* Advertisement channel maximum PDU size */
 #define PDU_AC_SIZE_MAX        (PDU_AC_LL_HEADER_SIZE + PDU_AC_PAYLOAD_SIZE_MAX)
 
+#define ACCESS_ADDR_SIZE        4
+#define ADVA_SIZE               6
+#define SCANA_SIZE              6
+#define INITA_SIZE              6
+#define TARGETA_SIZE            6
+#define LLDATA_SIZE             22
+#define CRC_SIZE                3
+#define PREAMBLE_SIZE(phy)      (phy&0x3)
+#define LL_HEADER_SIZE(phy)     (PREAMBLE_SIZE(phy) + PDU_AC_LL_HEADER_SIZE \
+				  + ACCESS_ADDR_SIZE + CRC_SIZE)
+#define BYTES2US(bytes, phy)    (((bytes)<<3)/BIT((phy&0x3)>>1))
+
 /* Data channel minimum payload */
 #define PDU_DC_PAYLOAD_SIZE_MIN 27
 /* Link Layer header size of Data PDU. Assumes pdu_data is packed */
@@ -24,6 +36,15 @@
 
 /* Max size of an empty PDU. TODO: Remove; only used in Nordic LLL */
 #define PDU_EM_SIZE_MAX        (PDU_DC_LL_HEADER_SIZE)
+
+/* Event interframe timings */
+#define EVENT_IFS_US            150
+/* Standard allows 2 us timing uncertainty inside the event */
+#define EVENT_IFS_MAX_US        (EVENT_IFS_US + 2)
+/* Controller will layout extended adv with minimum separation */
+#define EVENT_MAFS_US           300
+/* Standard allows 2 us timing uncertainty inside the event */
+#define EVENT_MAFS_MAX_US       (EVENT_MAFS_US + 2)
 
 /* Extra bytes for enqueued node_rx metadata: rssi (always), resolving
  * index, directed adv report, and mesh channel and instant.

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1742,7 +1742,7 @@ static inline int event_conn_upd_prep(struct ll_conn *conn,
 				   lll_conn_ppm_get(lll->slave.sca)) *
 				  conn_interval_us) + (1000000 - 1)) / 1000000U;
 			lll->slave.window_widening_max_us =
-				(conn_interval_us >> 1) - TIFS_US;
+				(conn_interval_us >> 1) - EVENT_IFS_US;
 			lll->slave.window_size_prepare_us =
 				conn->llcp.conn_upd.win_size * 1250U;
 			conn->slave.ticks_to_offset = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -492,7 +492,7 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	conn->evt.ticks_slot =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
-				       ftr->us_radio_rdy + 328 + TIFS_US +
+				       ftr->us_radio_rdy + 328 + EVENT_IFS_US +
 				       328);
 
 	ticks_slot_offset = MAX(conn->evt.ticks_active_to_start,

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -91,7 +91,8 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		(((lll_conn_ppm_local_get() +
 		   lll_conn_ppm_get(lll->slave.sca)) *
 		  conn_interval_us) + (1000000 - 1)) / 1000000U;
-	lll->slave.window_widening_max_us = (conn_interval_us >> 1) - TIFS_US;
+	lll->slave.window_widening_max_us = (conn_interval_us >> 1) -
+					    EVENT_IFS_US;
 	lll->slave.window_size_event_us = pdu_adv->connect_ind.win_size * 1250U;
 
 	/* procedure timeouts */
@@ -270,7 +271,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	conn->evt.ticks_slot =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
-				       ftr->us_radio_rdy + 328 + TIFS_US +
+				       ftr->us_radio_rdy + 328 + EVENT_IFS_US +
 				       328);
 
 	ticks_slot_offset = MAX(conn->evt.ticks_active_to_start,


### PR DESCRIPTION
Correct slot reservation time calc for legacy advertise
Add dependency on data lengths for advertise and scan response