### PR TITLE
west: commands: build: Specify source dir without a flag

### DIFF
--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -234,10 +234,10 @@ class ZephyrAppCommandsDirective(Directive):
         cmake_args = ' --{}'.format(cmake_args) if cmake_args != '' else ''
         # ignore zephyr_app since west needs to run within
         # the installation. Instead rely on relative path.
-        src = ' -s {}'.format(cd_to) if cd_to else ''
+        src = ' {}'.format(cd_to) if cd_to else ''
         dst = ' -d {}'.format(build_dir) if build_dir != 'build' else ''
 
-        goal_args = ' -b {}{}{}{}'.format(board, src, dst, cmake_args)
+        goal_args = ' -b {}{}{}{}'.format(board, dst, src, cmake_args)
         if 'build' in goals:
             content.append('west build{}'.format(goal_args))
             # No longer need to specify additional args, they are in the

--- a/doc/guides/west/build-flash-debug.rst
+++ b/doc/guides/west/build-flash-debug.rst
@@ -61,9 +61,9 @@ no additional parameters.
   whether ``-b`` is required, just try leaving it out. West will print an
   error if the option is required and was not given.
 
-To specify the source directory, use ``--source-dir`` (or ``-s``)::
+Specify the source directory path as the first positional argument::
 
-  west build -b <BOARD> --source-dir path/to/source/directory
+  west build -b <BOARD> path/to/source/directory
 
 Additionally you can specify the build system target using the ``--target``
 (or ``-t``) option. For example, to run the ``clean`` target::
@@ -79,10 +79,11 @@ Finally, you can add additional arguments to the CMake invocation performed by
 command. For example, to use the Unix Makefiles CMake generator instead of
 Ninja (which ``west build`` uses by default), run::
 
-  west build -- -G'Unix Makefiles'
+  west build -b reel_board samples/hello_world -- -G'Unix Makefiles'
 
-As another example, the following command adds the ``file.conf`` Kconfig
-fragment to the files which are merged into your final build configuration::
+As another example, and assuming you have already built a sample, the following
+command adds the ``file.conf`` Kconfig fragment to the files which are merged
+into your final build configuration::
 
   west build -- -DOVERLAY_CONFIG=file.conf
 

--- a/scripts/west_commands/tests/test_build.py
+++ b/scripts/west_commands/tests/test_build.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from argparse import Namespace
+from unittest.mock import patch
+
+from build import Build
+import pytest
+
+TEST_CASES = [
+    {'r': [],
+     's': None, 'c': None},
+    {'r': ['source_dir'],
+     's': 'source_dir', 'c': None},
+    {'r': ['source_dir', '--'],
+     's': 'source_dir', 'c': None},
+    {'r': ['source_dir', '--', 'cmake_opt'],
+     's': 'source_dir', 'c': ['cmake_opt']},
+    {'r': ['source_dir', '--', 'cmake_opt', 'cmake_opt2'],
+     's': 'source_dir', 'c': ['cmake_opt', 'cmake_opt2']},
+    {'r': ['thing_one', 'thing_two'],
+     's': 'thing_one', 'c': ['thing_two']},
+    {'r': ['thing_one', 'thing_two', 'thing_three'],
+     's': 'thing_one', 'c': ['thing_two', 'thing_three']},
+    {'r': ['--'],
+     's': None, 'c': None},
+    {'r': ['--', '--'],
+     's': None, 'c': ['--']},
+    {'r': ['--', 'cmake_opt'],
+     's': None, 'c': ['cmake_opt']},
+    {'r': ['--', 'cmake_opt', 'cmake_opt2'],
+     's': None, 'c': ['cmake_opt', 'cmake_opt2']},
+    {'r': ['--', 'cmake_opt', 'cmake_opt2', '--'],
+     's': None, 'c': ['cmake_opt', 'cmake_opt2', '--']},
+    {'r': ['--', 'cmake_opt', 'cmake_opt2', '--', 'tool_opt'],
+     's': None, 'c': ['cmake_opt', 'cmake_opt2', '--', 'tool_opt']},
+    {'r': ['--', 'cmake_opt', 'cmake_opt2', '--', 'tool_opt', 'tool_opt2'],
+     's': None, 'c': ['cmake_opt', 'cmake_opt2', '--', 'tool_opt',
+                      'tool_opt2']},
+    {'r': ['--', 'cmake_opt', 'cmake_opt2', '--', 'tool_opt', 'tool_opt2',
+           '--'],
+     's': None, 'c': ['cmake_opt', 'cmake_opt2', '--', 'tool_opt', 'tool_opt2',
+                      '--']},
+    ]
+
+ARGS = Namespace(board=None, build_dir=None, cmake=False, command='build',
+                 force=False, help=None, target=None, verbose=3, version=False,
+                 zephyr_base=None)
+
+@pytest.mark.parametrize('test_case', TEST_CASES)
+def test_parse_remainder(test_case):
+    b = Build()
+
+    b.args = Namespace()
+    b._parse_remainder(test_case['r'])
+    assert b.args.source_dir == test_case['s']
+    assert b.args.cmake_opts == test_case['c']
+


### PR DESCRIPTION
In order to simplify the usage of `west build`, take a positional
argument with the source directory instead of requiring the `-s,
--source-dir` flag. This makes it easier and quicker to invoke west when
building, as well as being consistent with CMake.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>