### PR TITLE
drivers: serial: sam: fixed return value of u(s)art_sam_irq_is_pending

### DIFF
--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -309,8 +309,8 @@ static int uart_sam_irq_is_pending(struct device *dev)
 {
 	volatile Uart * const uart = DEV_CFG(dev)->regs;
 
-	return    ((uart->UART_SR & UART_SR_TXRDY)
-		| (uart->UART_SR & UART_SR_RXRDY));
+	return (uart->UART_IMR & (UART_IMR_TXRDY | UART_IMR_RXRDY)) &
+		(uart->UART_SR & (UART_SR_TXRDY | UART_SR_RXRDY));
 }
 
 static int uart_sam_irq_update(struct device *dev)

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -296,8 +296,8 @@ static int usart_sam_irq_is_pending(struct device *dev)
 {
 	volatile Usart * const usart = DEV_CFG(dev)->regs;
 
-	return    ((usart->US_CSR & US_CSR_TXRDY)
-		| (usart->US_CSR & US_CSR_RXRDY));
+	return (usart->US_IMR & (US_IMR_TXRDY | US_IMR_RXRDY)) &
+		(usart->US_CSR & (US_CSR_TXRDY | US_CSR_RXRDY));
 }
 
 static int usart_sam_irq_update(struct device *dev)


### PR DESCRIPTION
The function usart_sam_irq_is_pending (uart_sam_irq_is_pending) return only the masked value of US_CSR register but it doesn't respect if the IRQ is enabled or not. For proper function it must check if the IRQ is enabled for the event.

Signed-off-by: Jiri Kubias <jiri.kubias@leapslabs.com>