### PR TITLE
kernel/sched: fix xcc complaining about ALWAYS_INLINE

### DIFF
--- a/include/sched_priq.h
+++ b/include/sched_priq.h
@@ -33,7 +33,7 @@ struct k_thread;
 
 struct k_thread *_priq_dumb_best(sys_dlist_t *pq);
 void _priq_dumb_remove(sys_dlist_t *pq, struct k_thread *thread);
-void _priq_dumb_add(sys_dlist_t *pq, struct k_thread *thread);
+ALWAYS_INLINE void _priq_dumb_add(sys_dlist_t *pq, struct k_thread *thread);
 
 struct _priq_rb {
 	struct rbtree tree;
@@ -56,8 +56,8 @@ struct _priq_mq {
 	unsigned int bitmask; /* bit 1<<i set if queues[i] is non-empty */
 };
 
-void _priq_mq_add(struct _priq_mq *pq, struct k_thread *thread);
-void _priq_mq_remove(struct _priq_mq *pq, struct k_thread *thread);
+ALWAYS_INLINE void _priq_mq_add(struct _priq_mq *pq, struct k_thread *thread);
+ALWAYS_INLINE void _priq_mq_remove(struct _priq_mq *pq, struct k_thread *thread);
 struct k_thread *_priq_mq_best(struct _priq_mq *pq);
 
 #endif /* ZEPHYR_INCLUDE_SCHED_PRIQ_H_ */

--- a/include/toolchain/xcc.h
+++ b/include/toolchain/xcc.h
@@ -52,4 +52,10 @@
 #define __builtin_umulll_overflow(a, b, output) \
 	({ *output = (a) * (b); false; })
 
+#ifdef ALWAYS_INLINE
+/* XCC said it needs "gnu_inline" */
+#undef ALWAYS_INLINE
+  #define ALWAYS_INLINE inline __attribute__((always_inline)) __attribute__((gnu_inline))
+#endif
+
 #endif

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -37,7 +37,7 @@ void _add_thread_to_ready_q(struct k_thread *thread);
 void _move_thread_to_end_of_prio_q(struct k_thread *thread);
 void _remove_thread_from_ready_q(struct k_thread *thread);
 int _is_thread_time_slicing(struct k_thread *thread);
-void _unpend_thread_no_timeout(struct k_thread *thread);
+ALWAYS_INLINE void _unpend_thread_no_timeout(struct k_thread *thread);
 int _pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
 	       _wait_q_t *wait_q, s32_t timeout);
 int _pend_curr_irqlock(u32_t key, _wait_q_t *wait_q, s32_t timeout);
@@ -49,7 +49,7 @@ void _unpend_thread(struct k_thread *thread);
 int _unpend_all(_wait_q_t *wait_q);
 void _thread_priority_set(struct k_thread *thread, int prio);
 void *_get_next_switch_handle(void *interrupted);
-struct k_thread *_find_first_thread_to_unpend(_wait_q_t *wait_q,
+ALWAYS_INLINE struct k_thread *_find_first_thread_to_unpend(_wait_q_t *wait_q,
 					      struct k_thread *from);
 void idle(void *a, void *b, void *c);
 void z_time_slice(int ticks);


### PR DESCRIPTION
The first complain of xcc about the use of ALWAYS_INLINE in scheduler:

  kernel/sched.c:395: warning: C99 inline functions are not supported; using GNU89
  kernel/sched.c:395: warning: to disable this warning use -fgnu89-inline or the gnu_inline function attribute

This is fixed by following xcc's suggestion of using the gnu_inline
function attribute, and re-defining ALWAYS_INLINE.

The second complain:

  kernel/include/ksched.h:53: warning: ‘_find_first_thread_to_unpend’ declared inline after being called
  kernel/include/ksched.h:53: warning: previous declaration of ‘_find_first_thread_to_unpend’ was here

This is due to the mismatched signatures between function prototypes
and their implementations. So fix by making them identical.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>