### PR TITLE
fix CONFIG_STACK_CANARIES with CONFIG_USERSPACE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1157,7 +1157,7 @@ if(CONFIG_APP_SHARED_MEM AND CONFIG_USERSPACE)
     )
 
   if(CONFIG_NEWLIB_LIBC)
-    set(NEWLIB_PART -l libc.a z_newlib_partition)
+    set(NEWLIB_PART -l libc.a z_libc_partition)
   endif()
   add_custom_command(
     OUTPUT ${APP_SMEM_LD}

--- a/include/app_memory/app_memdomain.h
+++ b/include/app_memory/app_memdomain.h
@@ -5,6 +5,8 @@
 #include <misc/dlist.h>
 #include <kernel.h>
 
+#ifdef CONFIG_APP_SHARED_MEM
+
 #if defined(CONFIG_X86)
 #define MEM_DOMAIN_ALIGN_SIZE _STACK_BASE_ALIGN
 #elif defined(STACK_ALIGN)
@@ -94,4 +96,13 @@ struct z_app_region {
 	}; \
 	K_APP_BMEM(name) char name##_placeholder;
 
+#else
+
+#define K_APP_BMEM(ptn)
+#define K_APP_DMEM(ptn)
+#define K_APP_DMEM_SECTION(ptn) .data
+#define K_APP_BMEM_SECTION(ptn) .bss
+#define K_APPMEM_PARTITION_DEFINE(name)
+
+#endif /* CONFIG_APP_SHARED_MEM */
 #endif /* ZEPHYR_INCLUDE_APP_MEMORY_APP_MEMDOMAIN_H_ */

--- a/include/misc/libc-hooks.h
+++ b/include/misc/libc-hooks.h
@@ -27,13 +27,6 @@ __syscall int _zephyr_read(char *buf, int nbytes);
 
 __syscall int _zephyr_write(const void *buf, int nbytes);
 
-#ifdef CONFIG_APP_SHARED_MEM
-/* Memory partition containing newlib's globals. This includes all the globals
- * within libc.a and the supporting zephyr hooks, but not the malloc arena.
- */
-extern struct k_mem_partition z_newlib_partition;
-#endif /* CONFIG_APP_SHARED_MEM */
-
 #else
 /* Minimal libc */
 
@@ -46,6 +39,9 @@ __syscall size_t _zephyr_fwrite(const void *_MLIBC_RESTRICT ptr, size_t size,
 #ifdef CONFIG_APP_SHARED_MEM
 /* Memory partition containing the libc malloc arena */
 extern struct k_mem_partition z_malloc_partition;
+
+/* C library globals, except the malloc arena */
+extern struct k_mem_partition z_libc_partition;
 #endif
 
 #include <syscalls/libc-hooks.h>

--- a/kernel/compiler_stack_protect.c
+++ b/kernel/compiler_stack_protect.c
@@ -22,6 +22,7 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <kernel.h>
+#include <app_memory/app_memdomain.h>
 
 /**
  *
@@ -45,7 +46,11 @@ void FUNC_NORETURN _StackCheckHandler(void)
  * Symbol referenced by GCC compiler generated code for canary value.
  * The canary value gets initialized in _Cstart().
  */
-void __noinit *__stack_chk_guard;
+#ifdef CONFIG_APP_SHARED_MEM
+K_APP_DMEM(z_libc_partition) uintptr_t __stack_chk_guard;
+#else
+__noinit uintptr_t __stack_chk_guard;
+#endif
 
 /**
  *

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -159,6 +159,10 @@ void _bss_zero(void)
 #endif
 }
 
+#ifdef CONFIG_STACK_CANARIES
+extern volatile uintptr_t __stack_chk_guard;
+#endif /* CONFIG_STACK_CANARIES */
+
 
 #ifdef CONFIG_XIP
 /**
@@ -183,9 +187,29 @@ void _data_copy(void)
 	data_copy_xip_relocation();
 #endif	/* CONFIG_CODE_DATA_RELOCATION */
 #ifdef CONFIG_APP_SHARED_MEM
+#ifdef CONFIG_STACK_CANARIES
+	/* stack canary checking is active for all C functions.
+	 * __stack_chk_guard is some uninitialized value living in the
+	 * app shared memory sections. Preserve it, and don't make any
+	 * function calls to perform the memory copy. The true canary
+	 * value gets set later in _Cstart().
+	 */
+	uintptr_t guard_copy = __stack_chk_guard;
+	u8_t *src = (u8_t *)&_app_smem_rom_start;
+	u8_t *dst = (u8_t *)&_app_smem_start;
+	u32_t count = (u32_t)&_app_smem_end - (u32_t)&_app_smem_start;
+
+	guard_copy = __stack_chk_guard;
+	while (count > 0) {
+		*(dst++) = *(src++);
+		count--;
+	}
+	__stack_chk_guard = guard_copy;
+#else
 	(void)memcpy(&_app_smem_start, &_app_smem_rom_start,
 		 ((u32_t) &_app_smem_end - (u32_t) &_app_smem_start));
-#endif
+#endif /* CONFIG_STACK_CANARIES */
+#endif /* CONFIG_APP_SHARED_MEM */
 }
 #endif
 
@@ -434,10 +458,6 @@ sys_rand32_fallback:
 	 */
 	return sys_rand32_get();
 }
-
-#ifdef CONFIG_STACK_CANARIES
-extern uintptr_t __stack_chk_guard;
-#endif /* CONFIG_STACK_CANARIES */
 
 /**
  *

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -17,6 +17,9 @@
 #include <device.h>
 #include <init.h>
 #include <stdbool.h>
+#include <app_memory/app_memdomain.h>
+
+K_APPMEM_PARTITION_DEFINE(z_libc_partition);
 
 #define LOG_LEVEL CONFIG_KERNEL_LOG_LEVEL
 #include <logging/log.h>

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -17,21 +17,13 @@
 #include <app_memory/app_memdomain.h>
 #include <init.h>
 
-#ifdef CONFIG_APP_SHARED_MEM
-K_APPMEM_PARTITION_DEFINE(z_newlib_partition);
-#define LIBC_BSS	K_APP_BMEM(z_newlib_partition)
-#define LIBC_DATA	K_APP_DMEM(z_newlib_partition)
+#define LIBC_BSS	K_APP_BMEM(z_libc_partition)
+#define LIBC_DATA	K_APP_DMEM(z_libc_partition)
 
 #if CONFIG_NEWLIB_LIBC_ALIGNED_HEAP_SIZE
 K_APPMEM_PARTITION_DEFINE(z_malloc_partition);
 #define MALLOC_BSS	K_APP_BMEM(z_malloc_partition)
 #endif /* CONFIG_NEWLIB_LIBC_ALIGNED_HEAP_SIZE */
-
-#else
-#define LIBC_BSS
-#define LIBC_DATA
-#define MALLOC_BSS
-#endif /* CONFIG_APP_SHARED_MEM */
 
 #define USED_RAM_END_ADDR   POINTER_TO_UINT(&_end)
 

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -302,11 +302,9 @@ void main(void)
 #ifdef CONFIG_APP_SHARED_MEM
 	struct k_mem_partition *parts[] = {
 		&ztest_mem_partition,
-#ifdef CONFIG_NEWLIB_LIBC
-		/* Newlib libc.a library and hooks globals */
-		&z_newlib_partition,
-#endif
-		/* Both minimal and newlib libc expose this for malloc arena */
+		/* C library globals, stack canary storage, etc */
+		&z_libc_partition,
+		/* Required for access to malloc arena */
 		&z_malloc_partition
 	};
 

--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -13,8 +13,8 @@
 #define STACKSIZE       (2048 + CONFIG_TEST_EXTRA_STACKSIZE)
 #define PRIORITY        5
 
-static int count;
-static int ret = TC_PASS;
+ZTEST_BMEM static int count;
+ZTEST_BMEM static int ret = TC_PASS;
 
 void check_input(const char *name, const char *input);
 
@@ -118,9 +118,9 @@ void test_main(void)
 	/* Start thread */
 	k_thread_create(&alt_thread_data, alt_thread_stack_area, STACKSIZE,
 			(k_thread_entry_t)alternate_thread, NULL, NULL, NULL,
-			K_PRIO_PREEMPT(PRIORITY), 0, K_NO_WAIT);
+			K_PRIO_PREEMPT(PRIORITY), K_USER, K_NO_WAIT);
 
 	ztest_test_suite(stackprot,
-			 ztest_unit_test(test_stackprot));
+			 ztest_user_unit_test(test_stackprot));
 	ztest_run_test_suite(stackprot);
 }


### PR DESCRIPTION
Stack canaries rely on a global variable containing the generated stack canary value. This was faulting from user threads since the storage area is in kernel memory. Now it is stored in a generic partition for C library globals.

Fixes #13642 