### PR TITLE
scripts/dts cleanups, part 9

### DIFF
--- a/dts/bindings/can/st,stm32-can.yaml
+++ b/dts/bindings/can/st,stm32-can.yaml
@@ -28,7 +28,6 @@ properties:
       type: array
       category: optional
       description: names off the interrupt lines
-      generation: define
 
     gpio-port:
       type: string

--- a/dts/bindings/crypto/arm,cryptocell-310.yaml
+++ b/dts/bindings/crypto/arm,cryptocell-310.yaml
@@ -40,4 +40,3 @@ properties:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
-      generation: define

--- a/dts/bindings/flash_controller/flash-controller.yaml
+++ b/dts/bindings/flash_controller/flash-controller.yaml
@@ -34,6 +34,5 @@ properties:
       type: stringlist
       category: optional
       description: names of required interrupts
-      generation: define
 
 ...

--- a/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
+++ b/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
@@ -33,6 +33,5 @@ properties:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
-      generation: define
 
 ...

--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -33,5 +33,4 @@ properties:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
-      generation: define
 ...

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -33,5 +33,4 @@ properties:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
-      generation: define
 ...

--- a/dts/bindings/i2s/st,stm32-i2s.yaml
+++ b/dts/bindings/i2s/st,stm32-i2s.yaml
@@ -33,6 +33,5 @@ properties:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
-      generation: define
 
 ...

--- a/dts/bindings/rtc/rtc.yaml
+++ b/dts/bindings/rtc/rtc.yaml
@@ -36,7 +36,6 @@ properties:
       type: stringlist
       category: optional
       description: names of required interrupts
-      generation: define
     prescaler:
       type: int
       category: required

--- a/dts/bindings/serial/uart.yaml
+++ b/dts/bindings/serial/uart.yaml
@@ -38,7 +38,6 @@ properties:
       type: stringlist
       category: optional
       description: names of required interrupts
-      generation: define
     pinctrl-\d+:
       type: array
       category: optional

--- a/dts/bindings/spi/st,stm32-spi-fifo.yaml
+++ b/dts/bindings/spi/st,stm32-spi-fifo.yaml
@@ -34,6 +34,5 @@ properties:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
-      generation: define
 
 ...

--- a/dts/bindings/spi/st,stm32-spi.yaml
+++ b/dts/bindings/spi/st,stm32-spi.yaml
@@ -33,6 +33,5 @@ properties:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
-      generation: define
 
 ...

--- a/dts/bindings/usb/nordic,nrf-usbd.yaml
+++ b/dts/bindings/usb/nordic,nrf-usbd.yaml
@@ -33,7 +33,6 @@ properties:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
-      generation: define
 
     num-isoin-endpoints:
       type: int

--- a/dts/bindings/usb/nxp,kinetis-usbd.yaml
+++ b/dts/bindings/usb/nxp,kinetis-usbd.yaml
@@ -33,5 +33,4 @@ properties:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
-      generation: define
 ...

--- a/dts/bindings/usb/st,stm32-otgfs.yaml
+++ b/dts/bindings/usb/st,stm32-otgfs.yaml
@@ -33,7 +33,6 @@ properties:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
-      generation: define
 
     ram-size:
       type: int

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -33,7 +33,6 @@ properties:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
-      generation: define
 
     ram-size:
       type: int

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -33,7 +33,6 @@ properties:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
-      generation: define
 
     ram-size:
       type: int

--- a/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
+++ b/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
@@ -40,4 +40,3 @@ properties:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
-      generation: define

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -77,21 +77,6 @@ def create_aliases(root):
             aliases[node_path].append(node['alt_name'])
 
 
-def get_node_compats(node_path):
-    compat = None
-
-    try:
-        if 'props' in reduced[node_path]:
-            compat = reduced[node_path]['props'].get('compatible')
-
-        if not isinstance(compat, list):
-            compat = [compat, ]
-
-    except:
-        pass
-
-    return compat
-
 def get_compat(node_path):
     compat = None
 

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -94,10 +94,8 @@ def get_compat(node_path):
 
 
 def create_chosen(root):
-    if 'children' in root:
-        if 'chosen' in root['children']:
-            for k, v in root['children']['chosen']['props'].items():
-                chosen[k] = v
+    if 'chosen' in root['children']:
+        chosen.update(root['children']['chosen']['props'])
 
 
 def create_phandles(root, name):

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -16,7 +16,7 @@ defs = {}
 structs = {}
 bindings = {}
 bus_bindings = {}
-bindings_compat = []
+binding_compats = []
 old_alias_names = False
 
 regs_config = {
@@ -305,7 +305,7 @@ def get_binding(node_path):
     return binding
 
 def get_binding_compats():
-    return bindings_compat
+    return binding_compats
 
 def build_cell_array(prop_array):
     index = 0

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -199,7 +199,9 @@ def get_node_label(node_path):
 
 
 def get_parent_path(node_path):
-    return '/'.join(node_path.split('/')[:-1])
+    # Turns /foo/bar into /foo
+
+    return '/'.join(node_path.split('/')[:-1]) or '/'
 
 
 def find_parent_prop(node_path, prop):
@@ -215,8 +217,6 @@ def find_parent_prop(node_path, prop):
 # Get the #{address,size}-cells for a given node
 def get_addr_size_cells(node_path):
     parent_addr = get_parent_path(node_path)
-    if parent_addr == '':
-        parent_addr = '/'
 
     # The DT spec says that if #address-cells is missing default to 2
     # if #size-cells is missing default to 1

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -6,7 +6,6 @@
 #
 
 from collections import defaultdict
-from copy import deepcopy
 
 # globals
 phandles = {}
@@ -221,16 +220,20 @@ def get_addr_size_cells(node_path):
     return (nr_addr, nr_size)
 
 def translate_addr(addr, node_path, nr_addr_cells, nr_size_cells):
-
-    try:
-        ranges = deepcopy(find_parent_prop(node_path, 'ranges'))
-        if type(ranges) is not list: ranges = [ ]
-    except:
-        return 0
-
     parent_path = get_parent_path(node_path)
 
-    (nr_p_addr_cells, nr_p_size_cells) = get_addr_size_cells(parent_path)
+    ranges = reduced[parent_path]['props'].get('ranges')
+    if not ranges:
+        return 0
+
+    if isinstance(ranges, list):
+        ranges = ranges.copy()  # Modified in-place below
+    else:
+        # Empty value ('ranges;'), meaning the parent and child address spaces
+        # are the same
+        ranges = []
+
+    nr_p_addr_cells, nr_p_size_cells = get_addr_size_cells(parent_path)
 
     range_offset = 0
     while ranges:

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -78,20 +78,17 @@ def create_aliases(root):
 
 
 def get_compat(node_path):
-    compat = None
+    # Returns the value of the 'compatible' property for the node at
+    # 'node_path'. Also checks the node's parent.
+    #
+    # Returns None if neither the node nor its parent has a 'compatible'
+    # property.
 
-    try:
-        if 'props' in reduced[node_path]:
-            compat = reduced[node_path]['props'].get('compatible')
+    compat = reduced[node_path]['props'].get('compatible') or \
+             reduced[get_parent_path(node_path)]['props'].get('compatible')
 
-        if compat == None:
-            compat = find_parent_prop(node_path, 'compatible')
-
-        if isinstance(compat, list):
-            compat = compat[0]
-
-    except:
-        pass
+    if isinstance(compat, list):
+        return compat[0]
 
     return compat
 

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -111,7 +111,6 @@ def create_phandles(root, name):
 
 
 def insert_defs(node_path, new_defs, new_aliases):
-
     for key in new_defs:
         if key.startswith('DT_COMPAT_'):
             node_path = 'compatibles'
@@ -122,11 +121,7 @@ def insert_defs(node_path, new_defs, new_aliases):
     if node_path in defs:
         remove = [k for k in new_aliases if k in defs[node_path]]
         for k in remove: del new_aliases[k]
-        if 'aliases' in defs[node_path]:
-            defs[node_path]['aliases'].update(new_aliases)
-        else:
-            defs[node_path]['aliases'] = new_aliases
-
+        defs[node_path]['aliases'].update(new_aliases)
         defs[node_path].update(new_defs)
     else:
         new_defs['aliases'] = new_aliases

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -13,7 +13,6 @@ aliases = defaultdict(list)
 chosen = {}
 reduced = {}
 defs = {}
-structs = {}
 bindings = {}
 bus_bindings = {}
 binding_compats = []

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -67,15 +67,15 @@ def all_compats(node):
 
 
 def create_aliases(root):
-    if 'children' in root:
-        if 'aliases' in root['children']:
-            for k, v in root['children']['aliases']['props'].items():
-                aliases[v].append(k)
+    if 'aliases' in root['children']:
+        for name, node_path in root['children']['aliases']['props'].items():
+            aliases[node_path].append(name)
 
     # Treat alternate names as aliases
-    for k in reduced:
-        if 'alt_name' in reduced[k]:
-            aliases[k].append(reduced[k]['alt_name'])
+    for node_path, node in reduced.items():
+        if 'alt_name' in node:
+            aliases[node_path].append(node['alt_name'])
+
 
 def get_node_compats(node_path):
     compat = None

--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from copy import deepcopy
+
 from extract.globals import *
 from extract.directive import DTDirective
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -123,10 +123,6 @@ def generate_node_defines(node_path):
         # patterns for things like reg, interrupts, etc that we don't need
         # any special case handling at a node level
         for prop in reduced[node_path]['props']:
-            if prop in {'interrupt-names', 'reg-names', 'phandle',
-                        'linux,phandle'}:
-                continue
-
             if re.fullmatch(yaml_prop, prop):
                 match = True
                 generate_prop_defines(node_path, prop)

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -379,7 +379,7 @@ def load_bindings(root, binding_dirs):
 
     extract.globals.bindings = compat_to_binding
     extract.globals.bus_bindings = bus_to_binding
-    extract.globals.bindings_compat = compats
+    extract.globals.binding_compats = compats
 
 
 def find_binding_files(binding_dirs):


### PR DESCRIPTION
Builds on https://github.com/zephyrproject-rtos/zephyr/pull/13593, so it should go in first.

 - Fixes `get_parent_path()` for top-level nodes (`/foo`). Also removes some code that seemed to work around the bug.

 - Stops `generate_node_defines()` from ignoring certain properties. The binding is respected instead.

 - Removes more redundant code, e.g. checks for keys that always exist

 - Removes some unused functions/variables

 - Gets rid of a `deepcopy()` and a catch-all `try/except`

 - Improves naming

I really want to get rid of the code in `insert_defs()` that checks for duplicates. After part 8, it only seems to be needed to handle some flash-related defines. Unfortunately, it's pretty tricky to follow how the flash stuff is supposed to work.