### PR TITLE
boards: udoo_neo_full_m4: not a default testing platform

### DIFF
--- a/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.yaml
+++ b/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.yaml
@@ -18,5 +18,3 @@ supported:
   - uart
   - gpio
   - counter
-testing:
-  default: true


### PR DESCRIPTION
This should not be run as a default platform in sanitycheck.