### PR TITLE
boards: x86: quark_d2000_crb: exclude watchdog test case

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   peripheral.watchdog:
     depends_on: watchdog
     tags: drivers watchdog
+    platform_exclude: quark_d2000_crb


### PR DESCRIPTION
patch exclude the watchdog test case for quark_d2000_crb
,as it seen that upon watchdog reset the conents of ram are lost.
Hence the existing testcase fails.

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>