### PR TITLE
net: offload: Remove CONFIG_NET_OFFLOAD from header file

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -523,19 +523,16 @@ void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt);
  *
  * @return True if IP offlining is active, false otherwise.
  */
+static inline bool net_if_is_ip_offloaded(struct net_if *iface)
+{
 #if defined(CONFIG_NET_OFFLOAD)
-static inline bool net_if_is_ip_offloaded(struct net_if *iface)
-{
 	return (iface->if_dev->offload != NULL);
-}
 #else
-static inline bool net_if_is_ip_offloaded(struct net_if *iface)
-{
 	ARG_UNUSED(iface);
 
 	return false;
-}
 #endif
+}
 
 /**
  * @brief Return the IP offload plugin
@@ -544,12 +541,14 @@ static inline bool net_if_is_ip_offloaded(struct net_if *iface)
  *
  * @return NULL if there is no offload plugin defined, valid pointer otherwise
  */
-#if defined(CONFIG_NET_OFFLOAD)
 static inline struct net_offload *net_if_offload(struct net_if *iface)
 {
+#if defined(CONFIG_NET_OFFLOAD)
 	return iface->if_dev->offload;
-}
+#else
+	return NULL;
 #endif
+}
 
 /**
  * @brief Get an network interface's link address

--- a/include/net/net_offload.h
+++ b/include/net/net_offload.h
@@ -19,8 +19,6 @@
  * @{
  */
 
-#if defined(CONFIG_NET_OFFLOAD)
-
 #include <net/buf.h>
 #include <net/net_ip.h>
 #include <net/net_context.h>
@@ -431,8 +429,6 @@ static inline int net_offload_put(struct net_if *iface,
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* CONFIG_NET_OFFLOAD */
 
 /**
  * @}


### PR DESCRIPTION
The extra check for CONFIG_NET_OFFLOAD is not needed as it
prevents documentation generation for this API.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>