### PR TITLE
arch: Correct ARM platform Flash options.

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -102,7 +102,7 @@ config SRAM_BASE_ADDRESS
 
 config FLASH_SIZE
 	int "Flash Size in kB"
-	default $(dt_int_val,DT_FLASH_SIZE) if (XIP && ARM) || !ARM
+	default $(dt_int_val,DT_FLASH_SIZE)
 	help
 	  This option specifies the size of the flash in kB.  It is normally set by
 	  the board's defconfig file and the user should generally avoid modifying
@@ -110,7 +110,7 @@ config FLASH_SIZE
 
 config FLASH_BASE_ADDRESS
 	hex "Flash Base Address"
-	default $(dt_hex_val,DT_FLASH_BASE_ADDRESS) if (XIP && ARM) || !ARM
+	default $(dt_hex_val,DT_FLASH_BASE_ADDRESS)
 	help
 	  This option specifies the base address of the flash on the board.  It is
 	  normally set by the board's defconfig file and the user should generally


### PR DESCRIPTION
The flash related options are required when build RAM based
binary on ARM platform.

Signed-off-by: Dong Xiang <dong.xiang@unisoc.com>