### PR TITLE
drivers: ssd1306: Support GPIO reset function

### DIFF
--- a/drivers/display/ssd1306_regs.h
+++ b/drivers/display/ssd1306_regs.h
@@ -106,4 +106,7 @@
 #define SSD1306_READ_MODIFY_WRITE_START		0xe0
 #define SSD1306_READ_MODIFY_WRITE_END		0xee
 
+/* time constants in ms */
+#define SSD1306_RESET_DELAY			1
+
 #endif


### PR DESCRIPTION
Add the reset function to the SSD1306 driver.
`128x64 Display Mode` requires a reset.
https://github.com/zephyrproject-rtos/zephyr/blob/master/dts/bindings/display/solomon%2Cssd1306fb.yaml#L68-L71
``` yaml
    reset-gpios:
      type: compound
      category: optional
      generation: define, use-prop-name
```

**Related to reset in the [SSD1306 Datasheet](https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf)**
![image](https://user-images.githubusercontent.com/10510127/53234794-af62d500-36d3-11e9-9829-911e0b3f71d5.png)  
![image](https://user-images.githubusercontent.com/10510127/53234838-cacde000-36d3-11e9-8fdf-f233b39367ad.png)  
![image](https://user-images.githubusercontent.com/10510127/53235005-2d26e080-36d4-11e9-8959-43286fec53cc.png)

**Test environment**
Board: [stm32f4_disco](https://docs.zephyrproject.org/latest/boards/arm/stm32f4_disco/doc/index.html)
SSD1306 Module: [Monochrome 1.3" 128x64 OLED graphic display](https://www.adafruit.com/product/938)

The test was done by creating the [ssd1306_gpio_reset_with_stm32f4-disco](https://github.com/KwonTae-young/zephyr/tree/ssd1306_gpio_reset_with_stm32f4-disco) branch.
```
west init zephyrproject -m https://github.com/KwonTae-young/zephyr/ --mr ssd1306_gpio_reset_with_stm32f4-disc
cd zephyrproject/zephyr
source zephyr-env.sh
mkdir samples/display/cfb/build
cd samples/display/cfb/build/
cmake -DBOARD=stm32f4_disco ..
make -j8 flash
```

- console output
```
***** Booting Zephyr OS zephyr-v1.13.0-5042-geb9edf5a49 *****
initialized SSD1306
font width 20, font height 32
font width 15, font height 24
font width 10, font height 16
x_res 128, y_res 64, ppt 8, rows 8, cols 128
[00:00:00.014,389] <dbg> cfb.cfb_framebuffer_init: number of fonts 3
```


 - Before & After

| Before  | After | 
| ------- | ----- | 
| ![image](https://user-images.githubusercontent.com/10510127/53235286-cbb34180-36d4-11e9-8cd5-ce2e15bf0560.png) | ![image](https://user-images.githubusercontent.com/10510127/53235198-9ad30c80-36d4-11e9-8942-b085a67f050f.png) | 