### PR TITLE
sockets: Properly refcount TCP sockets

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -382,11 +382,15 @@ int net_context_put(struct net_context *context)
 	context->recv_cb = NULL;
 	context->send_cb = NULL;
 
-	if (net_tcp_put(context) >= 0) {
-		goto unlock;
-	}
-
+	/* Decrement refcount on user app's behalf */
 	net_context_unref(context);
+
+	/* net_tcp_put() will handle decrementing refcount on stack's behalf */
+	net_tcp_put(context);
+	/* Assume it's better to have goto to immediate label than ugly
+	 * not indented #ifdef (if only they were intended!).
+	 */
+	goto unlock;
 
 unlock:
 	k_mutex_unlock(&context->lock);

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -702,6 +702,11 @@ static inline ssize_t zsock_recv_stream(struct net_context *ctx,
 	struct net_pkt_cursor backup;
 	int res;
 
+	if (!net_context_is_used(ctx)) {
+		errno = EBADF;
+		return -1;
+	}
+
 	if ((flags & ZSOCK_MSG_DONTWAIT) || sock_is_nonblock(ctx)) {
 		timeout = K_NO_WAIT;
 	}

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -109,6 +109,17 @@ int zsock_socket_internal(int family, int type, int proto)
 	_k_object_recycle(ctx);
 #endif
 
+	/* TCP context is effectively owned by both application
+	 * and the stack: stack may detect that peer closed/aborted
+	 * connection, but it must not dispose of the context behind
+	 * the application back. Likewise, when application "closes"
+	 * context, it's not disposed of immediately - there's yet
+	 * closing handshake for stack to perform.
+	 */
+	if (proto == IPPROTO_TCP) {
+		net_context_ref(ctx);
+	}
+
 	z_finalize_fd(fd, ctx, (const struct fd_op_vtable *)&sock_fd_op_vtable);
 
 	NET_DBG("socket: ctx=%p, fd=%d", ctx, fd);
@@ -389,6 +400,15 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 			return -1;
 		}
 	}
+
+	/* TCP context is effectively owned by both application
+	 * and the stack: stack may detect that peer closed/aborted
+	 * connection, but it must not dispose of the context behind
+	 * the application back. Likewise, when application "closes"
+	 * context, it's not disposed of immediately - there's yet
+	 * closing handshake for stack to perform.
+	 */
+	net_context_ref(ctx);
 
 	NET_DBG("accept: ctx=%p, fd=%d", ctx, fd);
 


### PR DESCRIPTION
    net: socket: Increment TCP context refcount on socket(), accept()
    
    TCP context is effectively owned by both application and the stack:
    stack may detect that peer closed/aborted connection, but it must
    not dispose of the context behind the application back. Likewise,
    when application "closes" context, it's not disposed of immediately,
    there's yet closing handshake for stack to perform.
    
    This effectively means that TCP contexts have refcount of 2 when
    they're created. Without this change, following situation is
    possible: peer opens connection, an app get a context (or socket)
    via accept, peer sends data, closes connection. An app still holds
    a reference to connection, but stack may dispose of context, and
    even reuse it for a new connection. Then application holds a reference
    to either free, or completely different context.
    
    This situation was very clearly and 100% reproducible when making
    Zephyr port of open62541 library, which works in async manner using
    select().
    
    Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>
