### PR TITLE
Add jlink runner to for all STM32 boards with default arguments. By default OpenOCD is used.

### DIFF
--- a/boards/arm/b_l072z_lrwan1/board.cmake
+++ b/boards/arm/b_l072z_lrwan1/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32L072CZ" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/disco_l475_iot1/board.cmake
+++ b/boards/arm/disco_l475_iot1/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32L475VG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/disco_l475_iot1/doc/index.rst
+++ b/boards/arm/disco_l475_iot1/doc/index.rst
@@ -47,9 +47,9 @@ More information about the board can be found at the `Disco L475 IoT1 website`_.
 Hardware
 ********
 
-The STM32L475RG SoC provides the following hardware IPs:
+The STM32L475VG SoC provides the following hardware IPs:
 
-- Ultra-low-power with FlexPowerControl (down to 130 nA Standby mode and 100 uA/MHz run mode)
+- Ultra-low-power with FlexPowerControl (down to 120 nA Standby mode and 100 uA/MHz run mode)
 - Core: ARM |reg| 32-bit Cortex |reg|-M4 CPU with FPU, frequency up to 80 MHz, 100DMIPS/1.25DMIPS/MHz (Dhrystone 2.1)
 - Clock Sources:
         - 4 to 48 MHz crystal oscillator
@@ -76,7 +76,7 @@ The STM32L475RG SoC provides the following hardware IPs:
         - Quad SPI memory interface
 - 4x digital filters for sigma delta modulator
 - Rich analog peripherals (independent supply)
-        - 3x 12-bit ADC 5 MSPS, up to 16-bit with hardware oversampling, 200 uA/MSPS
+        - 2x 12-bit ADC 5 MSPS, up to 16-bit with hardware oversampling, 200 uA/MSPS
         - 2x 12-bit DAC, low-power sample and hold
         - 2x operational amplifiers with built-in PGA
         - 2x ultra-low-power comparators
@@ -94,8 +94,8 @@ The STM32L475RG SoC provides the following hardware IPs:
 - Development support: serial wire debug (SWD), JTAG, Embedded Trace Macrocell |trade|
 
 
-More information about STM32L476RG can be found here:
-       - `STM32L475RG on www.st.com`_
+More information about STM32L475VG can be found here:
+       - `STM32L475VG on www.st.com`_
        - `STM32L475 reference manual`_
 
 Supported Features
@@ -226,8 +226,8 @@ You can debug an application in the usual way.  Here is an example for the
 .. _STM32 Disco L475 IoT1 board User Manual:
    http://www.st.com/resource/en/user_manual/dm00347848.pdf
 
-.. _STM32L475RG on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32l475rg.html
+.. _STM32L475VG on www.st.com:
+   https://www.st.com/en/microcontrollers-microprocessors/stm32l475vg.html
 
 .. _STM32L475 reference manual:
    http://www.st.com/resource/en/reference_manual/dm00083560.pdf

--- a/boards/arm/dragino_lsn50/board.cmake
+++ b/boards/arm/dragino_lsn50/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32L072CZ" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f030r8/board.cmake
+++ b/boards/arm/nucleo_f030r8/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F030R8" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f070rb/board.cmake
+++ b/boards/arm/nucleo_f070rb/board.cmake
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set_ifndef(STLINK_FW stlink)
+board_runner_args(jlink "--device=STM32F070RB" "--speed=4000")
 
-if(STLINK_FW STREQUAL jlink)
-  board_runner_args(jlink "--device=stm32f070rb" "--speed=4000")
-  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
-elseif(STLINK_FW STREQUAL stlink)
-  include($ENV{ZEPHYR_BASE}/boards/common/openocd.board.cmake)
-endif()
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f091rc/board.cmake
+++ b/boards/arm/nucleo_f091rc/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F091RC" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f103rb/board.cmake
+++ b/boards/arm/nucleo_f103rb/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F103RB" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f207zg/board.cmake
+++ b/boards/arm/nucleo_f207zg/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F207ZG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f302r8/board.cmake
+++ b/boards/arm/nucleo_f302r8/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F302R8" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f334r8/board.cmake
+++ b/boards/arm/nucleo_f334r8/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F334R8" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f401re/board.cmake
+++ b/boards/arm/nucleo_f401re/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F401RE" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f411re/board.cmake
+++ b/boards/arm/nucleo_f411re/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F411RE" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f412zg/board.cmake
+++ b/boards/arm/nucleo_f412zg/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F412ZG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f413zh/board.cmake
+++ b/boards/arm/nucleo_f413zh/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F413ZH" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f429zi/board.cmake
+++ b/boards/arm/nucleo_f429zi/board.cmake
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set_ifndef(STLINK_FW stlink)
+board_runner_args(jlink "--device=STM32F429ZI" "--speed=4000")
 
-if(STLINK_FW STREQUAL jlink)
-  board_runner_args(jlink "--device=stm32f429zi" "--speed=4000")
-  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
-elseif(STLINK_FW STREQUAL stlink)
-  include($ENV{ZEPHYR_BASE}/boards/common/openocd.board.cmake)
-endif()
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f446re/board.cmake
+++ b/boards/arm/nucleo_f446re/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F446RE" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f746zg/board.cmake
+++ b/boards/arm/nucleo_f746zg/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F746ZG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f756zg/board.cmake
+++ b/boards/arm/nucleo_f756zg/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F756ZG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_l053r8/board.cmake
+++ b/boards/arm/nucleo_l053r8/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32L053R8" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_l073rz/board.cmake
+++ b/boards/arm/nucleo_l073rz/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32L073RZ" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_l432kc/board.cmake
+++ b/boards/arm/nucleo_l432kc/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32L432KC" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_l476rg/board.cmake
+++ b/boards/arm/nucleo_l476rg/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32L476RG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_l496zg/board.cmake
+++ b/boards/arm/nucleo_l496zg/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32L496ZG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_l4r5zi/board.cmake
+++ b/boards/arm/nucleo_l4r5zi/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32L4R5ZI" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/olimex_stm32_e407/board.cmake
+++ b/boards/arm/olimex_stm32_e407/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F407ZG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/olimex_stm32_h407/board.cmake
+++ b/boards/arm/olimex_stm32_h407/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F407ZG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/olimex_stm32_p405/board.cmake
+++ b/boards/arm/olimex_stm32_p405/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F405RG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/olimexino_stm32/board.cmake
+++ b/boards/arm/olimexino_stm32/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F103RB" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm3210c_eval/board.cmake
+++ b/boards/arm/stm3210c_eval/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F107VC" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32373c_eval/board.cmake
+++ b/boards/arm/stm32373c_eval/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F373VC" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32_min_dev/board.cmake
+++ b/boards/arm/stm32_min_dev/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F103C8" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32f072_eval/board.cmake
+++ b/boards/arm/stm32f072_eval/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F072VB" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32f072b_disco/board.cmake
+++ b/boards/arm/stm32f072b_disco/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-include($ENV{ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+board_runner_args(jlink "--device=STM32F072RB" "--speed=4000")
+
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32f0_disco/board.cmake
+++ b/boards/arm/stm32f0_disco/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F051R8" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32f3_disco/board.cmake
+++ b/boards/arm/stm32f3_disco/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F303VC" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32f411e_disco/board.cmake
+++ b/boards/arm/stm32f411e_disco/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F411VE" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32f412g_disco/board.cmake
+++ b/boards/arm/stm32f412g_disco/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F412ZG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32f429i_disc1/board.cmake
+++ b/boards/arm/stm32f429i_disc1/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F429ZI" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32f469i_disco/board.cmake
+++ b/boards/arm/stm32f469i_disco/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F469NI" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32f4_disco/board.cmake
+++ b/boards/arm/stm32f4_disco/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F407VG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32f723e_disco/board.cmake
+++ b/boards/arm/stm32f723e_disco/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F723IE" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32f746g_disco/board.cmake
+++ b/boards/arm/stm32f746g_disco/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F746NG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32f769i_disco/board.cmake
+++ b/boards/arm/stm32f769i_disco/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32F769NI" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32l476g_disco/board.cmake
+++ b/boards/arm/stm32l476g_disco/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32L476VG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32l496g_disco/board.cmake
+++ b/boards/arm/stm32l496g_disco/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=STM32L496AG" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/doc/guides/debugging/probes.rst
+++ b/doc/guides/debugging/probes.rst
@@ -188,22 +188,28 @@ Using Segger J-Link
 Once STLink is flashed with SEGGER FW and J-Link GDB server is installed on your
 host computer, you can flash and debug as follows:
 
-Use the CMake ``flash`` target with the argument ``STLINK_FW=jlink`` to
-build your Zephyr application.
+Use CMake with ``-DZEPHYR_BOARD_FLASH_RUNNER=jlink`` to change the default OpenOCD
+runner to J-Link. Alternatively, you might add the following line to your
+application ``CMakeList.txt`` file.
 
-  .. zephyr-app-commands::
-     :zephyr-app: samples/hello_world
-     :gen-args: -DSTLINK_FW=jlink
-     :goals: flash
+  .. code-block:: cmake
 
-Use the CMake ``debug`` target with the argument ``STLINK_FW=jlink`` to build
-your Zephyr application, invoke the J-Link GDB server, attach a GDB client, and
-program your Zephyr application to flash. It will leave you at a GDB prompt.
+     set(ZEPHYR_BOARD_FLASH_RUNNER jlink)
 
-  .. zephyr-app-commands::
-     :zephyr-app: samples/hello_world
-     :gen-args: -DSTLINK_FW=jlink
-     :goals: debug
+If you use West (Zephyr’s meta-tool) you can modify the default runner using
+the ``--runner`` (or ``-r``) option.
+
+  .. code-block:: console
+
+     west flash --runner jlink
+
+To attach a debugger to your board and open up a debug console with ``jlink``.
+
+  .. code-block:: console
+
+     west debug --runner jlink
+
+For more information about West and available options, see :ref:`west`.
 
 If you configured your Zephyr application to use `Segger RTT`_ console instead,
 open telnet:


### PR DESCRIPTION
Fixes #10739 and extends it to all boards which use STM32.

Sets 'STLINK_FW'  to 'stlink' by default, and when set to 'jlink' provides correct arguments.

Additionally, the discovery board l475 IoT documentation regarding used µC is corrected in a separate commit.