### PR TITLE
Boards nrf9160 pca10090 flash range fixes

### DIFF
--- a/boards/arm/nrf9160_pca10090/Kconfig.defconfig
+++ b/boards/arm/nrf9160_pca10090/Kconfig.defconfig
@@ -38,11 +38,21 @@ config SPI_3
 endif # SPI
 
 # For the secure version of the board the firmware is linked at the beginning
-# of the flash, or in the code-partition defined in DT if it is intended to
-# be loaded by MCUboot. For the non-secure version of the board, the firmware
+# of the flash, or into the code-partition defined in DT if it is intended to
+# be loaded by MCUboot. If the secure firmware is to be combined with a non-
+# secure image (TRUSTED_EXECUTION_SECURE=y), the secure FW image shall always
+# be restricted to the size of its code partition.
+# For the non-secure version of the board, the firmware
 # must be linked into the code-partition (non-secure) defined in DT, regardless.
 # Apply this configuration below by setting the Kconfig symbols used by
 # the linker according to the information extracted from DT partitions.
+
+if BOARD_NRF9160_PCA10090 && TRUSTED_EXECUTION_SECURE
+
+config FLASH_LOAD_SIZE
+	default $(dt_hex_val,DT_CODE_PARTITION_SIZE)
+
+endif # BOARD_NRF9160_PCA10090 && TRUSTED_EXECUTION_SECURE
 
 if BOARD_NRF9160_PCA10090NS
 

--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_partition_conf.dts
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_partition_conf.dts
@@ -21,10 +21,6 @@
  * the beginning of the Non-Secure image (not its size).
  */
 
-&flash0 {
-	reg = <0x00000000 DT_SIZE_K(256)>;
-};
-
 &slot0_partition {
 	reg = <0x00010000 0x30000>;
 };


### PR DESCRIPTION
Two patches, here:
- remove the over-writing of flash0 rag property, we do not really need that, since we have int in SOC dtsi
- tell the strictly SECURE firmware image to restrict to the size of its partition (regardless of whether we use it with MCUboot). Default Secure images (ignoring TrustZone can still use the entire flash)