### PR TITLE
tests: kernel: userspace: fix test for non-secure builds

### DIFF
--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -271,7 +271,7 @@ static void write_kerntext(void)
 	expect_fault = true;
 	expected_reason = REASON_HW_EXCEPTION;
 	BARRIER();
-	memcpy(&_is_thread_essential, 0, 4);
+	memset(&_is_thread_essential, 0, 4);
 	zassert_unreachable("Write to kernel text did not fault");
 }
 


### PR DESCRIPTION
This commit fixes a test in kernel/mem_protect/userspace,
which was attempting to read from an address that was not
necessarily within the image memory range, causing faults
in TrustZone-enabled builds.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>