### PR TITLE
Tasks/samples.harness

### DIFF
--- a/samples/subsys/usb/cdc_acm/sample.yaml
+++ b/samples/subsys/usb/cdc_acm/sample.yaml
@@ -6,10 +6,23 @@ tests:
     tags: usb
     harness: console
     harness_config:
-      type: one_line
+      type: multi_line
       regex:
         - "Wait for DTR"
+        - "DTR set, start test"
+        - "Baudrate detected"
+        - "Starting indefinite read/write data loop"
+        - "At least one read/write data cycle completed"
   usb.cdc-acm_comp:
     depends_on: usb_device
     tags: usb
     extra_args: "-DOVERLAY_CONFIG=overlay-composite-cdc-msc.conf"
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "Wait for DTR"
+        - "DTR set, start test"
+        - "Baudrate detected"
+        - "At least one read/write data cycle completed"
+

--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -77,6 +77,7 @@ void main(void)
 	struct device *dev;
 	u32_t baudrate, bytes_read, dtr = 0U;
 	int ret;
+	int i = 0;
 
 	dev = device_get_binding(CONFIG_CDC_ACM_PORT_NAME_0);
 	if (!dev) {
@@ -120,5 +121,9 @@ void main(void)
 	/* Echo the received data */
 	while (1) {
 		read_and_echo_data(dev, (int *) &bytes_read);
+		i++;
+		if (i == 1) {
+		    printf("At least one read/write data cycle completed");
+		}
 	}
 }

--- a/samples/subsys/usb/cdc_acm_composite/sample.yaml
+++ b/samples/subsys/usb/cdc_acm_composite/sample.yaml
@@ -4,3 +4,16 @@ tests:
   usb.cdc-acm-composite:
     depends_on: usb_device
     tags: usb
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "Wait for Bindings"
+        - "Wait for DTR"
+        - "DTR set, start test"
+        - "Baudrate detected"
+        - "Baudrate detected"
+        - "Set Interrupt handlers"
+        - "Starting writing data"
+        - "Enable rx interrupts"
+

--- a/samples/subsys/usb/cdc_acm_composite/src/main.c
+++ b/samples/subsys/usb/cdc_acm_composite/src/main.c
@@ -86,6 +86,8 @@ void main(void)
 	struct device *dev0, *dev1;
 	u32_t dtr = 0U;
 
+	printf("Wait for Bindings\n");
+
 	dev0 = device_get_binding(CONFIG_CDC_ACM_PORT_NAME_0);
 	if (!dev0) {
 		printf("CDC ACM device %s not found\n",
@@ -131,13 +133,15 @@ void main(void)
 	dev_data1->dev = dev1;
 	dev_data1->peer = dev0;
 
+	printf("Setting Interrupt handlers ...\n");
 	uart_irq_callback_user_data_set(dev0, interrupt_handler, dev_data0);
 	uart_irq_callback_user_data_set(dev1, interrupt_handler, dev_data1);
 
+	printf("Starting writing data ...\n");
 	write_data(dev0, banner, strlen(banner));
 	write_data(dev1, banner, strlen(banner));
 
-	/* Enable rx interrupts */
+	printf("Enable rx interrupts ...\n");
 	uart_irq_rx_enable(dev0);
 	uart_irq_rx_enable(dev1);
 }


### PR DESCRIPTION
This pull request improve the ability for test framework to comprehend and confirm that test runs on two sample tests do cover all important areas in the test cases. With a more verbose output, it is also easier to identify which part of the test had failed.

This PR was developed when it was noted that the two test cases in samples/subsys/usb/cdc_acm did not produce the correct result in a few circumstances: 

(1) It was demonstrated that if the test run got stuck between  "Waiting for DTR" and "DTR set, start test", the testcase "usb.cdc-acm" incorrectly passed because it was only looking for the string "Wait for DTR".

(2) testcase "usb.cdc-acm_comp" was setup wrongly. It was setup to detect the end of the test case but the last "while(1)" loop had ensured that in the test run will not exit and the test case will not end. If the test run did exit, it is actually a failure.

samples/subsys/usb/cdc_acm_composite exibit similar behaviour as samples/subsys/usb/cdc_acm and was updated.
