### PR TITLE
drivers: nrf_power_clock: Migrate to DTS.

### DIFF
--- a/boards/posix/nrf52_bsim/board_soc.h
+++ b/boards/posix/nrf52_bsim/board_soc.h
@@ -34,8 +34,14 @@
 #define OFFLOAD_SW_IRQ SWI0_EGU0_IRQn
 
 /* HACK due to the nrf52_bsim not yet supporting DTS */
+#if !defined(DT_NORDIC_NRF_CLOCK_0_LABEL)
+#define DT_NORDIC_NRF_CLOCK_0_LABEL "CLOCK"
+#endif
 #if !defined(DT_NORDIC_NRF_CLOCK_0_IRQ_0)
 #define DT_NORDIC_NRF_CLOCK_0_IRQ_0 POWER_CLOCK_IRQn
+#endif
+#if !defined(DT_NORDIC_NRF_CLOCK_0_IRQ_0_PRIORITY)
+#define DT_NORDIC_NRF_CLOCK_0_IRQ_0_PRIORITY 1
 #endif
 
 #ifdef __cplusplus

--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -13,21 +13,6 @@ menuconfig CLOCK_CONTROL_NRF
 
 if CLOCK_CONTROL_NRF
 
-config CLOCK_CONTROL_NRF_IRQ_PRIORITY
-	int "Power Clock Interrupt Priority"
-	range 0 7
-	default 1
-	help
-	  The interrupt priority for Power Clock interrupt.
-
-config CLOCK_CONTROL_NRF_M16SRC_DRV_NAME
-	string "NRFx 16MHz clock device name"
-	default "clk_m16src"
-
-config CLOCK_CONTROL_NRF_K32SRC_DRV_NAME
-	string "NRFx 32KHz clock device name"
-	default "clk_k32src"
-
 choice
 	prompt "32KHz clock source"
 	default CLOCK_CONTROL_NRF_K32SRC_XTAL

--- a/drivers/clock_control/nrf_power_clock.c
+++ b/drivers/clock_control/nrf_power_clock.c
@@ -436,7 +436,7 @@ static int _clock_control_init(struct device *dev)
 	 * NOTE: Currently the operations here are idempotent.
 	 */
 	IRQ_CONNECT(DT_NORDIC_NRF_CLOCK_0_IRQ_0,
-		    CONFIG_CLOCK_CONTROL_NRF_IRQ_PRIORITY,
+		    DT_NORDIC_NRF_CLOCK_0_IRQ_0_PRIORITY,
 		    _power_clock_isr, 0, 0);
 
 	irq_enable(DT_NORDIC_NRF_CLOCK_0_IRQ_0);
@@ -451,7 +451,7 @@ static const struct clock_control_driver_api _m16src_clock_control_api = {
 };
 
 DEVICE_AND_API_INIT(clock_nrf5_m16src,
-		    CONFIG_CLOCK_CONTROL_NRF_M16SRC_DRV_NAME,
+		    DT_NORDIC_NRF_CLOCK_0_LABEL "_16M",
 		    _clock_control_init, NULL, NULL, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &_m16src_clock_control_api);
@@ -463,7 +463,7 @@ static const struct clock_control_driver_api _k32src_clock_control_api = {
 };
 
 DEVICE_AND_API_INIT(clock_nrf5_k32src,
-		    CONFIG_CLOCK_CONTROL_NRF_K32SRC_DRV_NAME,
+		    DT_NORDIC_NRF_CLOCK_0_LABEL "_32K",
 		    _clock_control_init, NULL, NULL, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &_k32src_clock_control_api);

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -194,7 +194,7 @@ static int init_rtc(struct device *dev,
 	const struct counter_nrfx_config *nrfx_config = get_nrfx_config(dev);
 	const nrfx_rtc_t *rtc = &nrfx_config->rtc;
 
-	clock = device_get_binding(CONFIG_CLOCK_CONTROL_NRF_K32SRC_DRV_NAME);
+	clock = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_32K");
 	if (!clock) {
 		return -ENODEV;
 	}

--- a/drivers/led_strip/ws2812b_sw.c
+++ b/drivers/led_strip/ws2812b_sw.c
@@ -32,7 +32,7 @@ static int send_buf(u8_t *buf, size_t len)
 	 */
 	u32_t i = 0U;
 
-	clock = device_get_binding(CONFIG_CLOCK_CONTROL_NRF_M16SRC_DRV_NAME);
+	clock = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_16M");
 	if (!clock) {
 		LOG_ERR("Unable to get HF clock");
 		return -EIO;

--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -112,7 +112,7 @@ static int temp_nrf5_init(struct device *dev)
 	LOG_DBG("");
 
 	data->clk_m16_dev =
-		device_get_binding(CONFIG_CLOCK_CONTROL_NRF_M16SRC_DRV_NAME);
+		device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_16M");
 	__ASSERT_NO_MSG(data->clk_m16_dev);
 
 	k_sem_init(&data->device_sync_sem, 0, UINT_MAX);

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -92,7 +92,7 @@ int z_clock_driver_init(struct device *device)
 
 	ARG_UNUSED(device);
 
-	clock = device_get_binding(CONFIG_CLOCK_CONTROL_NRF_K32SRC_DRV_NAME);
+	clock = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_32K");
 	if (!clock) {
 		return -1;
 	}

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -527,7 +527,7 @@ static int hf_clock_enable(bool on, bool blocking)
 	struct device *clock;
 	static bool clock_requested;
 
-	clock = device_get_binding(CONFIG_CLOCK_CONTROL_NRF_M16SRC_DRV_NAME);
+	clock = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_16M");
 	if (!clock) {
 		LOG_ERR("NRF HF Clock device not found!");
 		return ret;

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -63,6 +63,7 @@
 			reg = <0x40000000 0x1000>;
 			interrupts = <0 1>;
 			status = "ok";
+			label = "CLOCK";
 		};
 
 		uart0: uart@40002000 {

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -61,6 +61,7 @@
 			reg = <0x40000000 0x1000>;
 			interrupts = <0 1>;
 			status = "ok";
+			label = "CLOCK";
 		};
 
 		uart0: uart@40002000 {

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -67,6 +67,7 @@
 			reg = <0x40000000 0x1000>;
 			interrupts = <0 1>;
 			status = "ok";
+			label = "CLOCK";
 		};
 
 		uart0: uart@40002000 {

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -74,6 +74,7 @@
 			reg = <0x40000000 0x1000>;
 			interrupts = <0 1>;
 			status = "ok";
+			label = "CLOCK";
 		};
 
 		uart0: uart@40002000 {

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -205,6 +205,7 @@ clock: clock@5000 {
 	reg = <0x5000 0x1000>;
 	interrupts = <5 1>;
 	status = "ok";
+	label = "CLOCK";
 };
 
 power: power@5000 {

--- a/dts/bindings/clock/nordic,nrf-clock.yaml
+++ b/dts/bindings/clock/nordic,nrf-clock.yaml
@@ -17,6 +17,12 @@ properties:
       description: compatible strings
       constraint: "nordic,nrf-clock"
 
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device (used by Zephyr for API name)
+      generation: define
+
     reg:
       type: array
       category: required

--- a/ext/hal/nordic/drivers/nrf_radio_802154/platform/clock/nrf_802154_clock_zephyr.c
+++ b/ext/hal/nordic/drivers/nrf_radio_802154/platform/clock/nrf_802154_clock_zephyr.c
@@ -60,7 +60,7 @@ void nrf_802154_clock_hfclk_start(void)
 {
     struct device *clk_m16;
 
-    clk_m16 = device_get_binding(CONFIG_CLOCK_CONTROL_NRF_M16SRC_DRV_NAME);
+    clk_m16 = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_16M");
     __ASSERT_NO_MSG(clk_m16 != NULL);
 
     clock_control_on(clk_m16, (void *)1); /* Blocking call. */
@@ -74,7 +74,7 @@ void nrf_802154_clock_hfclk_stop(void)
 {
     struct device *clk_m16;
 
-    clk_m16 = device_get_binding(CONFIG_CLOCK_CONTROL_NRF_M16SRC_DRV_NAME);
+    clk_m16 = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_16M");
     __ASSERT_NO_MSG(clk_m16 != NULL);
 
     hfclk_is_running = false;
@@ -91,7 +91,7 @@ void nrf_802154_clock_lfclk_start(void)
 {
     struct device *clk_k32;
 
-    clk_k32 = device_get_binding(CONFIG_CLOCK_CONTROL_NRF_K32SRC_DRV_NAME);
+    clk_k32 = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_32K");
     __ASSERT_NO_MSG(clk_k32 != NULL);
 
     clock_control_on(clk_k32, (void *)CLOCK_CONTROL_NRF_K32SRC);
@@ -105,7 +105,7 @@ void nrf_802154_clock_lfclk_stop(void)
 {
     struct device *clk_k32;
 
-    clk_k32 = device_get_binding(CONFIG_CLOCK_CONTROL_NRF_K32SRC_DRV_NAME);
+    clk_k32 = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_32K");
     __ASSERT_NO_MSG(clk_k32 != NULL);
 
     lfclk_is_running = false;

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -4928,7 +4928,7 @@ static void k32src_wait(void)
 	done = true;
 
 	struct device *lf_clock = device_get_binding(
-		CONFIG_CLOCK_CONTROL_NRF_K32SRC_DRV_NAME);
+		DT_NORDIC_NRF_CLOCK_0_LABEL "_32K");
 
 	LL_ASSERT(lf_clock);
 

--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -127,7 +127,7 @@ int ll_init(struct k_sem *sem_rx)
 
 	sem_recv = sem_rx;
 
-	clk_k32 = device_get_binding(CONFIG_CLOCK_CONTROL_NRF_K32SRC_DRV_NAME);
+	clk_k32 = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_32K");
 	if (!clk_k32) {
 		return -ENODEV;
 	}
@@ -158,7 +158,7 @@ int ll_init(struct k_sem *sem_rx)
 			  hal_ticker_instance0_trigger_set);
 	LL_ASSERT(!err);
 
-	clk_m16 = device_get_binding(CONFIG_CLOCK_CONTROL_NRF_M16SRC_DRV_NAME);
+	clk_m16 = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_16M");
 	if (!clk_m16) {
 		return -ENODEV;
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -111,7 +111,7 @@ int lll_init(void)
 	event.curr.abort_cb = NULL;
 
 	/* Initialize LF CLK */
-	clk_k32 = device_get_binding(CONFIG_CLOCK_CONTROL_NRF_K32SRC_DRV_NAME);
+	clk_k32 = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_32K");
 	if (!clk_k32) {
 		return -ENODEV;
 	}
@@ -120,7 +120,7 @@ int lll_init(void)
 
 	/* Initialize HF CLK */
 	lll.clk_hf =
-		device_get_binding(CONFIG_CLOCK_CONTROL_NRF_M16SRC_DRV_NAME);
+		device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_16M");
 	if (!lll.clk_hf) {
 		return -ENODEV;
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -14,7 +14,7 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
-#define DRV_NAME CONFIG_CLOCK_CONTROL_NRF_K32SRC_DRV_NAME
+#define DRV_NAME DT_NORDIC_NRF_CLOCK_0_LABEL "_32K"
 #define K32SRC   CLOCK_CONTROL_NRF_K32SRC
 
 static u8_t is_k32src_stable;

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -27,8 +27,8 @@ LOG_MODULE_DECLARE(power);
 #define NUM_CORE_DEVICES	4
 #define MAX_DEV_NAME_LEN	16
 static const char core_devices[NUM_CORE_DEVICES][MAX_DEV_NAME_LEN] = {
-	"clk_k32src",
-	"clk_m16src",
+	"CLOCK_32K",
+	"CLOCK_16M",
 	"sys_clock",
 	"UART_0",
 };


### PR DESCRIPTION
This PR migrates the nrf_power_clock driver to DTS.
This change is needed for proper device power management.