### PR TITLE
m2gl025_miv: Set performance in Renode script.

### DIFF
--- a/boards/riscv32/m2gl025_miv/support/m2gl025_miv.resc
+++ b/boards/riscv32/m2gl025_miv/support/m2gl025_miv.resc
@@ -8,6 +8,7 @@ mach create $name
 machine LoadPlatformDescription @platforms/boards/miv-board.repl
 
 showAnalyzer uart
+cpu PerformanceInMips 80
 
 macro reset
 """

--- a/tests/crypto/tinycrypt/testcase.yaml
+++ b/tests/crypto/tinycrypt/testcase.yaml
@@ -3,3 +3,4 @@ tests:
     tags: tinycrypt crypto aes ccm
     min_ram: 48
     min_flash: 129
+    timeout: 300


### PR DESCRIPTION
This fix allows Renode to resemble the time flow of the hardware more
precisely. The performance value was established manually, there is no
indication in the docs on what is the average performance.

It allows tests/posix/common/portability.posix to pass, but fails on
tests/kernel/lifo/lifo_usage/kernel.lifo.usage.

The latter also fails on hardware.
