### PR TITLE
boards: arm: nrf52840-based: Free up flash room for storage/sample apps

### DIFF
--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -153,19 +153,26 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000069000>;
+			reg = <0x0000C000 0x000067000>;
 		};
-		slot1_partition: partition@75000 {
+		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00075000 0x000069000>;
+			reg = <0x00073000 0x000067000>;
 		};
-		scratch_partition: partition@de000 {
+		scratch_partition: partition@da000 {
 			label = "image-scratch";
-			reg = <0x000de000 0x0001e000>;
+			reg = <0x000da000 0x0001e000>;
 		};
-		storage_partition: partition@fc000 {
+
+		/*
+		 * The flash starting at 0x000f8000 and ending at
+		 * 0x000fffff is reserved for use by the application.
+		 */
+
+		/* Storage partition will be used by FCB/NFFS/NVS if enabled. */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -140,19 +140,26 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000069000>;
+			reg = <0x0000C000 0x000067000>;
 		};
-		slot1_partition: partition@75000 {
+		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00075000 0x000069000>;
+			reg = <0x00073000 0x000067000>;
 		};
-		scratch_partition: partition@de000 {
+		scratch_partition: partition@da000 {
 			label = "image-scratch";
-			reg = <0x000de000 0x0001e000>;
+			reg = <0x000da000 0x0001e000>;
 		};
-		storage_partition: partition@fc000 {
+
+		/*
+		 * The flash starting at 0x000f8000 and ending at
+		 * 0x000fffff is reserved for use by the application.
+		 */
+
+		/* Storage partition will be used by FCB/NFFS/NVS if enabled. */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -113,19 +113,26 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000069000>;
+			reg = <0x0000C000 0x000067000>;
 		};
-		slot1_partition: partition@75000 {
+		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00075000 0x000069000>;
+			reg = <0x00073000 0x000067000>;
 		};
-		scratch_partition: partition@de000 {
+		scratch_partition: partition@da000 {
 			label = "image-scratch";
-			reg = <0x000de000 0x0001e000>;
+			reg = <0x000da000 0x0001e000>;
 		};
-		storage_partition: partition@fc000 {
+
+		/*
+		 * The flash starting at 0x000f8000 and ending at
+		 * 0x000fffff is reserved for use by the application.
+		 */
+
+		/* Storage partition will be used by FCB/NFFS/NVS if enabled. */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -111,19 +111,26 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000069000>;
+			reg = <0x0000C000 0x000067000>;
 		};
-		slot1_partition: partition@75000 {
+		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00075000 0x000069000>;
+			reg = <0x00073000 0x000067000>;
 		};
-		scratch_partition: partition@de000 {
+		scratch_partition: partition@da000 {
 			label = "image-scratch";
-			reg = <0x000de000 0x0001e000>;
+			reg = <0x000da000 0x0001e000>;
 		};
-		storage_partition: partition@fc000 {
+
+		/*
+		 * The flash starting at 0x000f8000 and ending at
+		 * 0x000fffff is reserved for use by the application.
+		 */
+
+		/* Storage partition will be used by FCB/NFFS/NVS if enabled. */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -175,19 +175,26 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000069000>;
+			reg = <0x0000C000 0x000067000>;
 		};
-		slot1_partition: partition@75000 {
+		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00075000 0x000069000>;
+			reg = <0x00073000 0x000067000>;
 		};
-		scratch_partition: partition@de000 {
+		scratch_partition: partition@da000 {
 			label = "image-scratch";
-			reg = <0x000de000 0x0001e000>;
+			reg = <0x000da000 0x0001e000>;
 		};
-		storage_partition: partition@fc000 {
+
+		/*
+		 * The flash starting at 0x000f8000 and ending at
+		 * 0x000fffff is reserved for use by the application.
+		 */
+
+		/* Storage partition will be used by FCB/NFFS/NVS if enabled. */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/nrf52840_pca10090/nrf52840_pca10090.dts
+++ b/boards/arm/nrf52840_pca10090/nrf52840_pca10090.dts
@@ -64,19 +64,26 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000069000>;
+			reg = <0x0000C000 0x000067000>;
 		};
-		slot1_partition: partition@75000 {
+		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00075000 0x000069000>;
+			reg = <0x00073000 0x000067000>;
 		};
-		scratch_partition: partition@de000 {
+		scratch_partition: partition@da000 {
 			label = "image-scratch";
-			reg = <0x000de000 0x0001e000>;
+			reg = <0x000da000 0x0001e000>;
 		};
-		storage_partition: partition@fc000 {
+
+		/*
+		 * The flash starting at 0x000f8000 and ending at
+		 * 0x000fffff is reserved for use by the application.
+		 */
+
+		/* Storage partition will be used by FCB/NFFS/NVS if enabled. */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/particle_argon/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/mesh_feather.dtsi
@@ -80,20 +80,26 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000069000>;
+			reg = <0x0000C000 0x000067000>;
 		};
-		slot1_partition: partition@75000 {
+		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00075000 0x000069000>;
+			reg = <0x00073000 0x000067000>;
 		};
-		scratch_partition: partition@de000 {
+		scratch_partition: partition@da000 {
 			label = "image-scratch";
-			reg = <0x000de000 0x0001e000>;
+			reg = <0x000da000 0x0001e000>;
 		};
 
-		storage_partition: partition@fc000 {
+		/*
+		 * The flash starting at 0x000f8000 and ending at
+		 * 0x000fffff is reserved for use by the application.
+		 */
+
+		/* Storage partition will be used by FCB/NFFS/NVS if enabled. */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/particle_boron/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/mesh_feather.dtsi
@@ -80,20 +80,26 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000069000>;
+			reg = <0x0000C000 0x000067000>;
 		};
-		slot1_partition: partition@75000 {
+		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00075000 0x000069000>;
+			reg = <0x00073000 0x000067000>;
 		};
-		scratch_partition: partition@de000 {
+		scratch_partition: partition@da000 {
 			label = "image-scratch";
-			reg = <0x000de000 0x0001e000>;
+			reg = <0x000da000 0x0001e000>;
 		};
 
-		storage_partition: partition@fc000 {
+		/*
+		 * The flash starting at 0x000f8000 and ending at
+		 * 0x000fffff is reserved for use by the application.
+		 */
+
+		/* Storage partition will be used by FCB/NFFS/NVS if enabled. */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/particle_xenon/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/mesh_feather.dtsi
@@ -80,20 +80,26 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000069000>;
+			reg = <0x0000C000 0x000067000>;
 		};
-		slot1_partition: partition@75000 {
+		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00075000 0x000069000>;
+			reg = <0x00073000 0x000067000>;
 		};
-		scratch_partition: partition@de000 {
+		scratch_partition: partition@da000 {
 			label = "image-scratch";
-			reg = <0x000de000 0x0001e000>;
+			reg = <0x000da000 0x0001e000>;
 		};
 
-		storage_partition: partition@fc000 {
+		/*
+		 * The flash starting at 0x000f8000 and ending at
+		 * 0x000fffff is reserved for use by the application.
+		 */
+
+		/* Storage partition will be used by FCB/NFFS/NVS if enabled. */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -151,20 +151,26 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000069000>;
+			reg = <0x0000C000 0x000067000>;
 		};
-		slot1_partition: partition@75000 {
+		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00075000 0x000069000>;
+			reg = <0x00073000 0x000067000>;
 		};
-		scratch_partition: partition@de000 {
+		scratch_partition: partition@da000 {
 			label = "image-scratch";
-			reg = <0x000de000 0x0001e000>;
+			reg = <0x000da000 0x0001e000>;
 		};
 
-		storage_partition: partition@fc000 {
+		/*
+		 * The flash starting at 0x000f8000 and ending at
+		 * 0x000fffff is reserved for use by the application.
+		 */
+
+		/* Storage partition will be used by FCB/NFFS/NVS if enabled. */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -59,19 +59,26 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000069000>;
+			reg = <0x0000C000 0x000067000>;
 		};
-		slot1_partition: partition@75000 {
+		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00075000 0x000069000>;
+			reg = <0x00073000 0x000067000>;
 		};
-		scratch_partition: partition@de000 {
+		scratch_partition: partition@da000 {
 			label = "image-scratch";
-			reg = <0x000de000 0x0001e000>;
+			reg = <0x000da000 0x0001e000>;
 		};
-		storage_partition: partition@fc000 {
+
+		/*
+		 * The flash starting at 0x000f8000 and ending at
+		 * 0x000fffff is reserved for use by the application.
+		 */
+
+		/* Storage partition will be used by FCB/NFFS/NVS if enabled. */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/tests/subsys/dfu/mcuboot/nrf52840_pca10056.overlay
+++ b/tests/subsys/dfu/mcuboot/nrf52840_pca10056.overlay
@@ -20,19 +20,15 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000E000 0x000068000>;
+			reg = <0x0000E000 0x000066000>;
 		};
-		slot1_partition: partition@75000 {
+		slot1_partition: partition@73000 {
 			label = "image-1";
-			reg = <0x00076000 0x000068000>;
+			reg = <0x00074000 0x000066000>;
 		};
-		scratch_partition: partition@de000 {
+		scratch_partition: partition@da000 {
 			label = "image-scratch";
-			reg = <0x000de000 0x0001e000>;
-		};
-		storage_partition: partition@fc000 {
-			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000da000 0x0001e000>;
 		};
 	};
 };


### PR DESCRIPTION
The current flash configurations for all nRF52840's in Zephyr is
VERY constrained when it comes to allowing samples any space for
storage or custom areas.  It only leaves the last 4 pages of flash
for "storage".

The nRF52840 is also capable of using OpenThread which defaults
to using the last 4 pages of flash for storing OpenThread-related
network data.

This means that while using OpenThread under any configuration
designed to use mcuboot partition slots, there is no space left
over for storage of any kind.

Let's reduce the scratch partition size to a reasonable 72k
(down from 120k) and make room for storage, OpenThread and
a bit extra which can be used later when more use cases arise.

Signed-off-by: Michael Scott <mike@foundries.io>