### PR TITLE
Restore SMP to a working state, enable pervasively on x86_64

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -35,6 +35,7 @@ config X86
 config X86_64
 	bool "x86_64 architecture"
 	select ATOMIC_OPERATIONS_BUILTIN
+	select SCHED_IPI_SUPPORTED
 
 config NIOS2
 	bool "Nios II Gen 2 architecture"

--- a/arch/x86_64/core/demo-kernel.c
+++ b/arch/x86_64/core/demo-kernel.c
@@ -46,11 +46,6 @@ void test_timers(void)
 	printf("tsc %d apic %d\n", tsc1 - tsc0, apic0 - apic1);
 }
 
-unsigned int _init_cpu_stack(int cpu)
-{
-	return (long)alloc_page(0) + 4096;
-}
-
 void handler_timer(void *arg, int err)
 {
 	printf("Timer expired on CPU%d\n", (int)(long)xuk_get_f_ptr());
@@ -159,6 +154,7 @@ void _cpu_start(int cpu)
 	test_timers();
 
 	if (cpu == 0) {
+		xuk_start_cpu(1, (long)alloc_page(0) + 4096);
 		xuk_set_isr(0x1f3, 0, (void *)handler_f3, (void *)0x12345678);
 	}
 

--- a/arch/x86_64/core/shared-page.h
+++ b/arch/x86_64/core/shared-page.h
@@ -57,7 +57,7 @@ struct xuk_shared_mem {
 	int vgacol;
 };
 
-#define _shared (*((struct xuk_shared_mem *)(long)SHARED_ADDR))
+#define _shared (*((volatile struct xuk_shared_mem *)(long)SHARED_ADDR))
 
 static inline void shared_init(void)
 {

--- a/arch/x86_64/core/x86_64.c
+++ b/arch/x86_64/core/x86_64.c
@@ -69,7 +69,7 @@ void *_isr_exit_restore_stack(void *interrupted)
 	return (nested || next == interrupted) ? NULL : next;
 }
 
-struct {
+volatile struct {
 	void (*fn)(int, void*);
 	void *arg;
 } cpu_init[CONFIG_MP_NUM_CPUS];

--- a/arch/x86_64/core/x86_64.c
+++ b/arch/x86_64/core/x86_64.c
@@ -72,15 +72,15 @@ void *_isr_exit_restore_stack(void *interrupted)
 struct {
 	void (*fn)(int, void*);
 	void *arg;
-	unsigned int esp;
 } cpu_init[CONFIG_MP_NUM_CPUS];
 
 /* Called from Zephyr initialization */
 void z_arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 		     void (*fn)(int, void *), void *arg)
 {
+	xuk_start_cpu(cpu_num, (int)(sz + (char *)stack));
+
 	cpu_init[cpu_num].arg = arg;
-	cpu_init[cpu_num].esp = (int)(long)(sz + (char *)stack);
 
 	/* This is our flag to the spinning CPU.  Do this last */
 	cpu_init[cpu_num].fn = fn;
@@ -155,18 +155,9 @@ void _cpu_start(int cpu)
 	}
 }
 
-/* Returns the initial stack to use for CPU startup on auxiliary (not
- * cpu 0) processors to the xuk layer, which gets selected by the
- * non-arch Zephyr kernel and stashed by z_arch_start_cpu()
- */
-unsigned int _init_cpu_stack(int cpu)
-{
-	return cpu_init[cpu].esp;
-}
-
 int z_arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
-			      void (*routine)(void *parameter), void *parameter,
-			      u32_t flags)
+			       void (*routine)(void *parameter), void *parameter,
+			       u32_t flags)
 {
 	ARG_UNUSED(flags);
 	__ASSERT(priority >= 2 && priority <= 15,

--- a/arch/x86_64/core/xuk.c
+++ b/arch/x86_64/core/xuk.c
@@ -314,8 +314,8 @@ void xuk_set_isr_mask(int interrupt, int masked)
 static void setup_fg_segs(int cpu)
 {
 	int fi = 3 + 2 * cpu, gi = 3 + 2 * cpu + 1;
-	struct gdt64 *fs = &_shared.gdt[fi];
-	struct gdt64 *gs = &_shared.gdt[gi];
+	struct gdt64 *fs = (struct gdt64 *) &_shared.gdt[fi];
+	struct gdt64 *gs = (struct gdt64 *) &_shared.gdt[gi];
 
 	gdt64_set_base(fs, (long)&_shared.fs_ptrs[cpu]);
 	gdt64_set_base(gs, (long)&_shared.gs_ptrs[cpu]);

--- a/arch/x86_64/core/xuk.c
+++ b/arch/x86_64/core/xuk.c
@@ -492,15 +492,17 @@ static void smp_init(void)
 	};
 	while (_apic.ICR_LO.send_pending) {
 	}
+}
 
-	for (int i = 1; i < CONFIG_MP_NUM_CPUS; i++) {
-		_shared.smpinit_stack = _init_cpu_stack(i);
-		printf("Granting stack @ %xh to CPU %d\n",
-		       _shared.smpinit_stack, i);
+void xuk_start_cpu(int cpu, unsigned int stack)
+{
+	int act = _shared.num_active_cpus;
 
-		while (_shared.num_active_cpus <= i) {
-			__asm__("pause");
-		}
+	printf("Granting stack @ %xh to CPU %d\n", stack, cpu);
+	_shared.smpinit_stack = stack;
+
+	while (_shared.num_active_cpus == act) {
+		__asm__ volatile("pause");
 	}
 }
 

--- a/arch/x86_64/core/xuk.h
+++ b/arch/x86_64/core/xuk.h
@@ -138,14 +138,15 @@ struct xuk_stack_frame {
 long xuk_setup_stack(long sp, void *fn, unsigned int eflags,
 		     long *args, int nargs);
 
+
+/* Starts the numbered CPU running with the specified initial stack
+ * pointer
+ */
+
+void xuk_start_cpu(int cpu, unsigned int stack);
 /*
  * OS-defined utilities required by the xuk layer:
  */
-
-/* Returns the address of a stack pointer in 32 bit memory to be used
- * by AP processor bootstraping and startup.
- */
-unsigned int _init_cpu_stack(int cpu);
 
 /* OS CPU startup entry point, running on the stack returned by
  * init_cpu_stack()

--- a/arch/x86_64/include/kernel_arch_func.h
+++ b/arch/x86_64/include/kernel_arch_func.h
@@ -102,4 +102,6 @@ extern int x86_64_except_reason;
 		__asm__ volatile("int $5");	\
 	} while (false)
 
+void z_arch_sched_ipi(void);
+
 #endif /* _KERNEL_ARCH_FUNC_H */

--- a/boards/x86_64/qemu_x86_64/Kconfig.defconfig
+++ b/boards/x86_64/qemu_x86_64/Kconfig.defconfig
@@ -6,4 +6,9 @@ config BUILD_OUTPUT_BIN
 config BOARD
 	default "qemu_x86_64"
 
+# In theory we could ask qemu for any configuration, but this seems
+# like a good default.
+config MP_NUM_CPUS
+	default 2
+
 endif # BOARD_QEMU_X86_64

--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -227,6 +227,10 @@ if(NOT QEMU_PIPE)
   set(QEMU_PIPE_COMMENT "\nTo exit from QEMU enter: 'CTRL+a, x'\n")
 endif()
 
+if(CONFIG_SMP)
+  list(APPEND QEMU_SMP_FLAGS -smp cpus=${CONFIG_MP_NUM_CPUS})
+endif()
+
 # Use flags passed in from the environment
 set(env_qemu $ENV{QEMU_EXTRA_FLAGS})
 separate_arguments(env_qemu)
@@ -254,6 +258,7 @@ foreach(target ${qemu_targets})
     ${QEMU_FLAGS}
     ${QEMU_EXTRA_FLAGS}
     ${MORE_FLAGS_FOR_${target}}
+    ${QEMU_SMP_FLAGS}
     ${QEMU_KERNEL_OPTION}
     DEPENDS ${logical_target_for_zephyr_elf}
     WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -98,6 +98,14 @@ int z_clock_driver_init(struct device *device)
 	return 0;
 }
 
+void smp_timer_init(void)
+{
+	/* Noop, the HPET is a single system-wide device and it's
+	 * configured to deliver interrupts to every CPU, so there's
+	 * nothing to do at initialization on auxiliary CPUs.
+	 */
+}
+
 void z_clock_set_timeout(s32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);

--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -38,6 +38,7 @@ static inline void z_arch_irq_unlock(int key)
 struct k_spinlock;
 int z_spin_lock_valid(struct k_spinlock *l);
 int z_spin_unlock_valid(struct k_spinlock *l);
+void z_spin_lock_set_owner(struct k_spinlock *l);
 #define SPIN_VALIDATE
 #endif
 #endif
@@ -81,6 +82,9 @@ static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)
 	}
 #endif
 
+#ifdef SPIN_VALIDATE
+	z_spin_lock_set_owner(l);
+#endif
 	return k;
 }
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -715,6 +715,17 @@ config MP_NUM_CPUS
 	  Number of multiprocessing-capable cores available to the
 	  multicpu API and SMP features.
 
+config SCHED_IPI_SUPPORTED
+	bool "Architecture supports broadcast interprocessor interrupts"
+	help
+	  True if the architecture supports a call to
+	  z_arch_sched_ipi() to broadcast an interrupt that will call
+	  z_sched_ipi() on other CPUs in the system.  Required for
+	  k_thread_abort() to operate with reasonable latency
+	  (otherwise we might have to wait for the other thread to
+	  take an interrupt, which can be arbitrarily far in the
+	  future).
+
 endmenu
 
 config TICKLESS_IDLE

--- a/kernel/include/kernel_structs.h
+++ b/kernel/include/kernel_structs.h
@@ -46,6 +46,9 @@
 /* Thread is suspended */
 #define _THREAD_SUSPENDED (BIT(4))
 
+/* Thread is being aborted (SMP only) */
+#define _THREAD_ABORTING (BIT(5))
+
 /* Thread is present in the ready queue */
 #define _THREAD_QUEUED (BIT(6))
 

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -53,6 +53,8 @@ struct k_thread *z_find_first_thread_to_unpend(_wait_q_t *wait_q,
 					      struct k_thread *from);
 void idle(void *a, void *b, void *c);
 void z_time_slice(int ticks);
+void z_sched_abort(struct k_thread *thread);
+void z_sched_ipi(void);
 
 static inline void z_pend_curr_unlocked(_wait_q_t *wait_q, s32_t timeout)
 {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -353,8 +353,8 @@ void z_remove_thread_from_ready_q(struct k_thread *thread)
 		if (z_is_thread_queued(thread)) {
 			_priq_run_remove(&_kernel.ready_q.runq, thread);
 			z_mark_thread_as_not_queued(thread);
-			update_cache(thread == _current);
 		}
+		update_cache(thread == _current);
 	}
 }
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -886,12 +886,16 @@ void z_impl_k_yield(void)
 
 	if (!is_idle(_current)) {
 		LOCKED(&sched_spinlock) {
-			_priq_run_remove(&_kernel.ready_q.runq, _current);
-			_priq_run_add(&_kernel.ready_q.runq, _current);
+			if (!IS_ENABLED(CONFIG_SMP) ||
+			    z_is_thread_queued(_current)) {
+				_priq_run_remove(&_kernel.ready_q.runq,
+						 _current);
+				_priq_run_add(&_kernel.ready_q.runq,
+					      _current);
+			}
 			update_cache(1);
 		}
 	}
-
 	z_swap_unlocked();
 }
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -585,6 +585,14 @@ void *z_get_next_switch_handle(void *interrupted)
 			reset_time_slice();
 			_current_cpu->swap_ok = 0;
 			set_current(th);
+#ifdef SPIN_VALIDATE
+			/* Changed _current!  Update the spinlock
+			 * bookeeping so the validation doesn't get
+			 * confused when the "wrong" thread tries to
+			 * release the lock.
+			 */
+			z_spin_lock_set_owner(&sched_spinlock);
+#endif
 		}
 	}
 #else

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -12,6 +12,7 @@
 
 #ifdef CONFIG_SMP
 static atomic_t global_lock;
+static atomic_t start_flag;
 
 unsigned int z_smp_global_lock(void)
 {
@@ -71,9 +72,8 @@ static void smp_init_top(int key, void *arg)
 	atomic_t *start_flag = arg;
 
 	/* Wait for the signal to begin scheduling */
-	do {
-		k_busy_wait(100);
-	} while (!atomic_get(start_flag));
+	while (!atomic_get(start_flag)) {
+	}
 
 	/* Switch out of a dummy thread.  Trick cribbed from the main
 	 * thread init.  Should probably unify implementations.
@@ -89,12 +89,9 @@ static void smp_init_top(int key, void *arg)
 
 	CODE_UNREACHABLE;
 }
-#endif
 
 void smp_init(void)
 {
-	atomic_t start_flag;
-
 	(void)atomic_clear(&start_flag);
 
 #if defined(CONFIG_SMP) && CONFIG_MP_NUM_CPUS > 1
@@ -114,3 +111,4 @@ void smp_init(void)
 
 	(void)atomic_set(&start_flag, 1);
 }
+#endif

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -60,13 +60,11 @@ void z_smp_release_global_lock(struct k_thread *thread)
 	}
 }
 
-#endif
-
 extern k_thread_stack_t _interrupt_stack1[];
 extern k_thread_stack_t _interrupt_stack2[];
 extern k_thread_stack_t _interrupt_stack3[];
 
-#if defined(CONFIG_SMP) && CONFIG_MP_NUM_CPUS > 1
+#if CONFIG_MP_NUM_CPUS > 1
 static void smp_init_top(int key, void *arg)
 {
 	atomic_t *start_flag = arg;
@@ -89,6 +87,7 @@ static void smp_init_top(int key, void *arg)
 
 	CODE_UNREACHABLE;
 }
+#endif
 
 void smp_init(void)
 {
@@ -111,4 +110,5 @@ void smp_init(void)
 
 	(void)atomic_set(&start_flag, 1);
 }
-#endif
+
+#endif /* CONFIG_SMP */

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -65,7 +65,7 @@ extern k_thread_stack_t _interrupt_stack1[];
 extern k_thread_stack_t _interrupt_stack2[];
 extern k_thread_stack_t _interrupt_stack3[];
 
-#ifdef CONFIG_SMP
+#if defined(CONFIG_SMP) && CONFIG_MP_NUM_CPUS > 1
 static void smp_init_top(int key, void *arg)
 {
 	atomic_t *start_flag = arg;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -582,6 +582,10 @@ void z_thread_single_abort(struct k_thread *thread)
 		thread->fn_abort();
 	}
 
+	if (IS_ENABLED(CONFIG_SMP)) {
+		z_sched_abort(thread);
+	}
+
 	if (z_is_thread_ready(thread)) {
 		z_remove_thread_from_ready_q(thread);
 	} else {

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -723,7 +723,6 @@ int z_spin_lock_valid(struct k_spinlock *l)
 			return 0;
 		}
 	}
-	l->thread_cpu = _current_cpu->id | (u32_t)_current;
 	return 1;
 }
 
@@ -735,4 +734,10 @@ int z_spin_unlock_valid(struct k_spinlock *l)
 	l->thread_cpu = 0;
 	return 1;
 }
+
+void z_spin_lock_set_owner(struct k_spinlock *l)
+{
+	l->thread_cpu = _current_cpu->id | (u32_t)_current;
+}
+
 #endif

--- a/soc/x86_64/x86_64/Kconfig.defconfig
+++ b/soc/x86_64/x86_64/Kconfig.defconfig
@@ -6,4 +6,10 @@ config SOC
 config USE_SWITCH
 	default y
 
+# Make this the default even if we have only one CPU, mostly for test
+# coverage.  Uniprocessor apps for production purposes can get a
+# moderate code size savings by turning it off.
+config SMP
+	default y
+
 endif

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -15,7 +15,7 @@
 #error SMP test requires at least two CPUs!
 #endif
 
-#define T2_STACK_SIZE 2048
+#define T2_STACK_SIZE (2048 + CONFIG_TEST_EXTRA_STACKSIZE)
 #define STACK_SIZE (384 + CONFIG_TEST_EXTRA_STACKSIZE)
 #define DELAY_US 50000
 #define TIMEOUT 1000


### PR DESCRIPTION
SMP got kinda rotten across the timer and scheduler rework, as our only SMP platform was a hardware-only device (esp32) with somewhat quirky behavior in hardware test integration and no serious users within the community.

This series fixes a bunch of bugs that crept in, and a few that were never discovered originally (the kernel/smp test itself has been significantly enhanced since).  And it caps it off by making SMP the default on x86_64 (everywhere it works, anyway -- lots of tests aren't smp-safe by design).

Full disclosure: the interprocessor interrupt framework in the "Support synchronous k_thread_abort" patch probably constitutes a new feature from the perspective of the 1.14 code freeze.  But (1) this was much easier than trying to find all the uses of k_thread_abort() throughout the tests and "fix" them to work in SMP (where k_thread_abort() basically didn't work by design) and (2) if you look carefully, I believe it's true that there are ZERO changes in code paths when CONFIG_SMP=n.  It only affects the situation I'm fixing here.