### PR TITLE
 Add per ADC channel configuration for single-ended vs differential input

### DIFF
--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -25,6 +25,20 @@ if ADC
 config ADC_CONFIGURABLE_INPUTS
 	bool
 
+config ADC_HAS_DIFF_PER_CHANNEL
+    bool
+    help
+      This option is enabled when the ADC manages differential inputs on a
+      channel to channel basis.
+
+config ADC_CONFIGURABLE_DIFF_PER_CHANNEL
+	bool "Enable differential acquisition per channel"
+    depends on ADC_HAS_DIFF_PER_CHANNEL
+	help
+	  By selecting this option a driver can (if supported) re-configure any ADC
+	  channel in a given adc sequence as differential or not without having to
+	  setup the ADC again
+
 config ADC_ASYNC
 	bool "Enable asynchronous call support"
 	select POLL

--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -26,14 +26,14 @@ config ADC_CONFIGURABLE_INPUTS
 	bool
 
 config ADC_HAS_DIFF_PER_CHANNEL
-    bool
-    help
-      This option is enabled when the ADC manages differential inputs on a
-      channel to channel basis.
+	bool
+	help
+	  This option is enabled when the ADC manages differential inputs on a
+	  channel to channel basis.
 
 config ADC_CONFIGURABLE_DIFF_PER_CHANNEL
 	bool "Enable differential acquisition per channel"
-    depends on ADC_HAS_DIFF_PER_CHANNEL
+	depends on ADC_HAS_DIFF_PER_CHANNEL
 	help
 	  By selecting this option a driver can (if supported) re-configure any ADC
 	  channel in a given adc sequence as differential or not without having to

--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -27,18 +27,13 @@ struct mcux_adc16_data {
 	u16_t *repeat_buffer;
 	u32_t channels;
 	u8_t channel_id;
-#if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
-	bool differential;
-#endif
 };
 
 static int mcux_adc16_channel_setup(struct device *dev,
 				    const struct adc_channel_cfg *channel_cfg)
 {
 	u8_t channel_id = channel_cfg->channel_id;
-#if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
-	struct mcux_adc16_data *data = dev->driver_data;
-#endif
+
 	if (channel_id > (ADC_SC1_ADCH_MASK >> ADC_SC1_ADCH_SHIFT)) {
 		LOG_ERR("Channel %d is not valid", channel_id);
 		return -EINVAL;
@@ -49,14 +44,11 @@ static int mcux_adc16_channel_setup(struct device *dev,
 		return -EINVAL;
 	}
 
-#if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
-    data->differential = channel_cfg->differential;
-#else
 	if (channel_cfg->differential) {
 		LOG_ERR("Differential channels are not supported");
 		return -EINVAL;
 	}
-#endif
+
 	if (channel_cfg->gain != ADC_GAIN_1) {
 		LOG_ERR("Invalid channel gain");
 		return -EINVAL;
@@ -179,7 +171,7 @@ static void mcux_adc16_start_channel(struct device *dev)
 	LOG_DBG("Starting channel %d", data->channel_id);
 
 #if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
-	channel_config.enableDifferentialConversion = data->differential;
+	channel_config.enableDifferentialConversion = false;
 #endif
 	channel_config.enableInterruptOnConversionCompleted = true;
 	channel_config.channelNumber = data->channel_id;

--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -48,7 +48,7 @@ static int mcux_adc16_channel_setup(struct device *dev,
 	}
 
 	if (channel_cfg->differential) {
-		LOG_ERR("Differential channels are not supported");
+		LOG_ERR("Differential channels are not supported at the controller level");
 		return -EINVAL;
 	}
 
@@ -175,14 +175,11 @@ static void mcux_adc16_start_channel(struct device *dev)
 
 #if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
 #ifdef CONFIG_ADC_CONFIGURABLE_DIFF_PER_CHANNEL
-    if((data->differential_channels & BIT(data->channel_id)) != 0U)
-    {
-        channel_config.enableDifferentialConversion = true;
-    }
-    else
-    {
-        channel_config.enableDifferentialConversion = false;
-    }
+	if( (data->differential_channels & BIT(data->channel_id) ) != 0U) {
+		channel_config.enableDifferentialConversion = true;
+	} else {
+		channel_config.enableDifferentialConversion = false;
+	}
 #else
 	channel_config.enableDifferentialConversion = false;
 #endif

--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -27,13 +27,18 @@ struct mcux_adc16_data {
 	u16_t *repeat_buffer;
 	u32_t channels;
 	u8_t channel_id;
+#if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
+	bool differential;
+#endif
 };
 
 static int mcux_adc16_channel_setup(struct device *dev,
 				    const struct adc_channel_cfg *channel_cfg)
 {
 	u8_t channel_id = channel_cfg->channel_id;
-
+#if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
+	struct mcux_adc16_data *data = dev->driver_data;
+#endif
 	if (channel_id > (ADC_SC1_ADCH_MASK >> ADC_SC1_ADCH_SHIFT)) {
 		LOG_ERR("Channel %d is not valid", channel_id);
 		return -EINVAL;
@@ -44,11 +49,14 @@ static int mcux_adc16_channel_setup(struct device *dev,
 		return -EINVAL;
 	}
 
+#if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
+    data->differential = channel_cfg->differential;
+#else
 	if (channel_cfg->differential) {
 		LOG_ERR("Differential channels are not supported");
 		return -EINVAL;
 	}
-
+#endif
 	if (channel_cfg->gain != ADC_GAIN_1) {
 		LOG_ERR("Invalid channel gain");
 		return -EINVAL;
@@ -171,7 +179,7 @@ static void mcux_adc16_start_channel(struct device *dev)
 	LOG_DBG("Starting channel %d", data->channel_id);
 
 #if defined(FSL_FEATURE_ADC16_HAS_DIFF_MODE) && FSL_FEATURE_ADC16_HAS_DIFF_MODE
-	channel_config.enableDifferentialConversion = false;
+	channel_config.enableDifferentialConversion = data->differential;
 #endif
 	channel_config.enableInterruptOnConversionCompleted = true;
 	channel_config.channelNumber = data->channel_id;

--- a/include/adc.h
+++ b/include/adc.h
@@ -218,6 +218,14 @@ struct adc_sequence {
 	 */
 	u32_t channels;
 
+#ifdef CONFIG_ADC_CONFIGURABLE_DIFF_PER_CHANNEL
+	/**
+	 * Bit-mask indicating that the matching channel is acquired in
+	 * differential mode.
+	 */
+	u32_t differential_channels;
+#endif
+
 	/**
 	 * Pointer to a buffer where the samples are to be written. Samples
 	 * from subsequent samplings are written sequentially in the buffer.

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.soc
@@ -20,7 +20,7 @@ config SOC_MK64F12
 	select HAS_OSC
 	select HAS_MCG
 	select CPU_HAS_FPU
-
+	select ADC_HAS_DIFF_PER_CHANNEL
 endchoice
 
 if SOC_SERIES_KINETIS_K6X


### PR DESCRIPTION
The only way provided by the current ADC API to toggle between differential and single-ended acquisition is to call adc_channel_setup at the ADC controller level while at least some of the ADC controllers are rather conceived to enable differential acquisition on a channel to channel basis. This pull request provides an option to enable or not differential conversion per channel in the adc_sequence structure without going through adc_channel_setup. It’s not enabled by default so it shouldn’t break anything that doesn’t explicitly enable the API. It has been enabled and tested through the mcux driver.