### PR TITLE
uart: ns16550: place header in correct spot

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -38,7 +38,7 @@
 #include <pci/pci_mgr.h>
 #endif /* CONFIG_PCI */
 
-#include "uart_ns16550.h"
+#include <drivers/serial/uart_ns16550.h>
 
 /* register definitions */
 

--- a/include/drivers/serial/uart_ns16550.h
+++ b/include/drivers/serial/uart_ns16550.h
@@ -5,7 +5,7 @@
  */
 
 /**
- * @file Header file for the NS16550 UART
+ * Header file for the NS16550 UART
  */
 
 #ifndef ZEPHYR_DRIVERS_SERIAL_UART_NS16550_H_


### PR DESCRIPTION
This is an application facing define, specific to this
driver, for the public uart_drv_cmd() API. Put it with
public headers.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>