### PR TITLE
drivers: gpio: Fix mcux driver to init successfully with no irq

### DIFF
--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -264,11 +264,8 @@ static int gpio_mcux_porta_init(struct device *dev)
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_porta), 0);
 
 	irq_enable(DT_NXP_KINETIS_GPIO_GPIO_A_IRQ);
-
-	return 0;
-#else
-	return -1;
 #endif
+	return 0;
 }
 #endif /* CONFIG_GPIO_MCUX_PORTA */
 
@@ -300,11 +297,8 @@ static int gpio_mcux_portb_init(struct device *dev)
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_portb), 0);
 
 	irq_enable(DT_NXP_KINETIS_GPIO_GPIO_B_IRQ);
-
-	return 0;
-#else
-	return -1;
 #endif
+	return 0;
 }
 #endif /* CONFIG_GPIO_MCUX_PORTB */
 
@@ -336,11 +330,8 @@ static int gpio_mcux_portc_init(struct device *dev)
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_portc), 0);
 
 	irq_enable(DT_NXP_KINETIS_GPIO_GPIO_C_IRQ);
-
-	return 0;
-#else
-	return -1;
 #endif
+	return 0;
 }
 #endif /* CONFIG_GPIO_MCUX_PORTC */
 
@@ -372,11 +363,8 @@ static int gpio_mcux_portd_init(struct device *dev)
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_portd), 0);
 
 	irq_enable(DT_NXP_KINETIS_GPIO_GPIO_D_IRQ);
-
-	return 0;
-#else
-	return -1;
 #endif
+	return 0;
 }
 #endif /* CONFIG_GPIO_MCUX_PORTD */
 
@@ -408,10 +396,7 @@ static int gpio_mcux_porte_init(struct device *dev)
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_porte), 0);
 
 	irq_enable(DT_NXP_KINETIS_GPIO_GPIO_E_IRQ);
-
-	return 0;
-#else
-	return -1;
 #endif
+	return 0;
 }
 #endif /* CONFIG_GPIO_MCUX_PORTE */


### PR DESCRIPTION
Some mcux gpio instances do not have dedicated interrupt vectors and
therefore conditionalize out the IRQ_CONNECT() and irq_enable() calls
during driver initialization. The driver initialization incorrectly
returned an error in this case, when really it just has nothing to do.
The driver can still be used without interrupts, and the gpio configure
function returns an error if an application tries otherwise.

Commit a68120de6d414117ddb67566a7397a5e23556841 introduced a check on
the init return value to prevent applications from using drivers that
fail to initialize. This in turn caused zephyr/samples/basic/threads to
assert on the frdm_kl25z board. Fix this by modifying the mcux gpio
driver to return success when there is no interrupt to connect.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #13462
Fixes #13463