### PR TITLE
ext: silabs: rename ramfunc section to match Zephyr's

### DIFF
--- a/ext/hal/silabs/gecko/emlib/inc/em_ramfunc.h
+++ b/ext/hal/silabs/gecko/emlib/inc/em_ramfunc.h
@@ -143,7 +143,7 @@ extern "C" {
 
 #elif defined(__GNUC__)
 /* Simplicity Studio, Atollic and Vanilla armgcc */
-#define SL_RAMFUNC_DECLARATOR          __attribute__ ((section(".ram")))
+#define SL_RAMFUNC_DECLARATOR          __attribute__ ((section(".ramfunc")))
 #define SL_RAMFUNC_DEFINITION_BEGIN    SL_RAMFUNC_DECLARATOR
 #define SL_RAMFUNC_DEFINITION_END
 


### PR DESCRIPTION
Functions which have to be located in RAM are placed by SiLabs library code in section '.ram'. Corresponding section used by Zephyr is called '.ramfunc'. This patch renames SiLabs section name to match Zephyr's.

This solution was chosen over adding '.ram' function to Zephyr linker scripts not to pollute them. However, this patch needs to be reapplied every time SiLabs library version is updated.

Fixes #13192