### PR TITLE
misc:rb: Fix possible infinity loop

### DIFF
--- a/include/misc/rb.h
+++ b/include/misc/rb.h
@@ -178,10 +178,11 @@ struct rbnode *_rb_foreach_next(struct rbtree *tree, struct _rb_foreach *f);
  * @param node The symbol name of a local iterator
  * @param field The field name of a struct rbnode inside node
  */
-#define RB_FOR_EACH_CONTAINER(tree, node, field)			\
-	for (struct _rb_foreach __f = _RB_FOREACH_INIT(tree, node);	\
-	     (node = CONTAINER_OF(_rb_foreach_next(tree, &__f),		\
-				  __typeof__(*(node)), field)) != NULL;	\
-	     /**/)
+#define RB_FOR_EACH_CONTAINER(tree, node, field)		           \
+	for (struct _rb_foreach __f = _RB_FOREACH_INIT(tree, node);	   \
+			({struct rbnode *n = _rb_foreach_next(tree, &__f); \
+			 node = n ? CONTAINER_OF(n, __typeof__(*(node)),   \
+					 field) : NULL; }) != NULL;        \
+			 /**/)
 
 #endif /* ZEPHYR_INCLUDE_MISC_RB_H_ */


### PR DESCRIPTION
The macro RB_FOR_EACH_CONTAINER could run infinitely when the function
_rb_foreach_next returns NULL.

Fixes #13464

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>