### PR TITLE
tests: stacks: increase STACK_LEN to 4

### DIFF
--- a/tests/kernel/stack/stack_api/src/test_stack_contexts.c
+++ b/tests/kernel/stack/stack_api/src/test_stack_contexts.c
@@ -7,7 +7,7 @@
 #include <ztest.h>
 #include <irq_offload.h>
 #define STACK_SIZE 512
-#define STACK_LEN 2
+#define STACK_LEN 4
 
 /**TESTPOINT: init via K_STACK_DEFINE*/
 K_STACK_DEFINE(kstack, STACK_LEN);


### PR DESCRIPTION
Test was failing on nios2 with:

../app/libapp.a(test_stack_contexts.c.obj): in function `tstack_pop':
/home/galak/git/zephyr/tests/kernel/stack/stack_api/src/test_stack_contexts.c:31:
warning: unable to reach (null) (at 0x004002f4) from the global pointer
(at 0x004082fc) because the offset (-32776) is out of the allowed range,
-32678 to 32767

Fixes #13595