### PR TITLE
xtools: exclude "sources" when searching xtools output dir

### DIFF
--- a/cmake/toolchain/xtools/generic.cmake
+++ b/cmake/toolchain/xtools/generic.cmake
@@ -12,6 +12,7 @@ set(COMPILER gcc)
 # toolchains because choosing between iamcu and non-iamcu is dependent
 # on Kconfig, not ARCH.
 file(GLOB toolchain_paths ${TOOLCHAIN_HOME}/*)
+list(REMOVE_ITEM toolchain_paths ${TOOLCHAIN_HOME}/sources)
 list(GET  toolchain_paths 0 some_toolchain_path)
 get_filename_component(some_toolchain "${some_toolchain_path}" NAME)
 


### PR DESCRIPTION
When using xtools as toolchain, cmake searches the toolchain home
directory. However, if the first toolchain directory does not
begin with any character before "s", "sources" (if exists) would
become the first directory being probed. Since it does not
conform to "arch-vendor-abi" naming, cmake would fail.
So exclude "sources" from the list to avoid this issue.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>