### PR TITLE
samples: flash_shell: Enable on all platforms with a flash driver

### DIFF
--- a/drivers/flash/Kconfig.sam
+++ b/drivers/flash/Kconfig.sam
@@ -10,6 +10,7 @@ config SOC_FLASH_SAM
 	default y
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
+	depends on SOC_SERIES_SAME70
 	help
 	  Enable the Atmel SAM series internal flash driver.
 

--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -30,7 +30,7 @@ LOG_MODULE_REGISTER(flash_sam0);
  * Number of lock regions.  The number is fixed and the region size
  * grows with the flash size.
  */
-#define LOCK_REGIONS DT_ATMEL_SAM0_NVMCTRL_0_LOCK_REGIONS
+#define LOCK_REGIONS DT_INST_0_ATMEL_SAM0_NVMCTRL_LOCK_REGIONS
 #define LOCK_REGION_SIZE (FLASH_SIZE / LOCK_REGIONS)
 
 #if defined(NVMCTRL_BLOCK_SIZE)

--- a/samples/drivers/flash_shell/Kconfig
+++ b/samples/drivers/flash_shell/Kconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2020, Linaro Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+if ARM_MPU
+config MPU_ALLOW_FLASH_WRITE
+	def_bool y
+endif

--- a/samples/drivers/flash_shell/prj.conf
+++ b/samples/drivers/flash_shell/prj.conf
@@ -7,4 +7,3 @@ CONFIG_FLASH=y
 # If that's the case and you're interested in the flash layout, enable
 # it here.
 # CONFIG_FLASH_PAGE_LAYOUT=y
-CONFIG_MPU_ALLOW_FLASH_WRITE=y

--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -4,6 +4,7 @@ sample:
   name: Flash shell
 tests:
   sample.drivers.flash.shell:
-    platform_whitelist: 96b_carbon frdm_k64f frdm_kw41z frdm_kl25z nucleo_f746zg
     tags: flash shell
+    filter: CONFIG_FLASH_HAS_DRIVER_ENABLED
     harness: keyboard
+    min_ram: 12

--- a/west.yml
+++ b/west.yml
@@ -86,7 +86,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
       path: tools/net-tools
     - name: hal_nxp
-      revision: 62b46313b8e07e2d5062fd62f14ee9dfeb201b76
+      revision: pull/29/head
       path: modules/hal/nxp
     - name: open-amp
       revision: 9b591b289e1f37339bd038b5a1f0e6c8ad39c63a


### PR DESCRIPTION
Try and build the flash_shell on all platforms that have a flash driver
rather than a limited set of know platforms.  This hopefully acts as a
build coverage test for all the flash drivers.

The flash shell requires around 10K of memory so limit it to systems
with 12K or more.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>