### PR TITLE
Revert "tests: posix: add newlib cfg option"

### DIFF
--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -1,12 +1,5 @@
-common:
-  tags: posix
-  min_ram: 64
-  arch_exclude: posix
 tests:
   portability.posix:
-    extra_configs:
-      - CONFIG_NEWLIB_LIBC=n
-  portability.posix.newlib:
-    filter: TOOLCHAIN_HAS_NEWLIB == 1
-    extra_configs:
-      - CONFIG_NEWLIB_LIBC=y
+    tags: posix
+    min_ram: 64
+    arch_exclude: posix

--- a/tests/posix/fs/testcase.yaml
+++ b/tests/posix/fs/testcase.yaml
@@ -1,12 +1,6 @@
-common:
-  arch_exclude: nios2 posix
-  min_ram: 128
-  tags: posix filesystem
 tests:
   portability.posix:
-    extra_configs:
-      - CONFIG_NEWLIB_LIBC=n
-  portability.posix.newlib:
-    filter: TOOLCHAIN_HAS_NEWLIB == 1
-    extra_configs:
-      - CONFIG_NEWLIB_LIBC=y
+    arch_exclude: nios2 posix
+    min_ram: 128
+    tags: posix filesystem
+


### PR DESCRIPTION
This test is breaking CI, we need a fix first before we go and enable
tests.

This reverts commit dc39a9adcfd1f6818c1ab3d1f7619ba82e8474a2.