### PR TITLE
doc: net: Hide misc host connectivity chapters from index

### DIFF
--- a/doc/guides/networking/index.rst
+++ b/doc/guides/networking/index.rst
@@ -14,7 +14,3 @@ operation of the stacks and how they were implemented.
    ip-stack-architecture.rst
    networking-api-usage.rst
    networking_with_host.rst
-   native_posix_setup.rst
-   qemu_eth_setup.rst
-   qemu_setup.rst
-   usbnet_setup.rst

--- a/doc/guides/networking/networking_with_host.rst
+++ b/doc/guides/networking/networking_with_host.rst
@@ -3,6 +3,15 @@
 Networking with the host system
 ###############################
 
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   native_posix_setup.rst
+   qemu_eth_setup.rst
+   qemu_setup.rst
+   usbnet_setup.rst
+
 While developing networking software, it is usually necessary to connect and
 exchange data with the host system like a Linux desktop computer.
 Depending on what board is used for development, the following options are


### PR DESCRIPTION
No need to show

* native_posix board setup (native_posix_setup.rst)
* QEMU Ethernet setup (qemu_eth_setup.rst)
* QEMU SLIP setup (qemu_setup.rst)
* USBNET setup (usbnet_setup.rst)

in main network index as links to those chapters are already
found in "Networking with the host system"
(networking_with_host.rst) chapter. In order not to trigger
a doxygen warning, place the chapters into hidden toctree.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>