### PR TITLE
subsys: Changed dead code part in function buffer_trim()

### DIFF
--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -359,12 +359,8 @@ static void buffer_trim(char *buff, u16_t *buff_len)
 	/* Counting whitespace characters starting from beginning of the
 	 * command.
 	 */
-	while (isspace((int) buff[i++])) {
-		if (i == 0) {
-			buff[0] = '\0';
-			return;
-		}
-	}
+	while (isspace((int) buff[i++]))
+      ;
 
 	/* Removing counted whitespace characters. */
 	if (--i > 0) {
@@ -378,4 +374,3 @@ void shell_cmd_trim(const struct shell *shell)
 	buffer_trim(shell->ctx->cmd_buff, &shell->ctx->cmd_buff_len);
 	shell->ctx->cmd_buff_pos = shell->ctx->cmd_buff_len;
 }
-


### PR DESCRIPTION
According to the Coverity issue 190614 (github issue #12319)
Fix for logically dead code in function buffer_trim
Before while execution cannot reach this statement: buff[0] = '\0';

Tested and noticed that part of code is unnecessary inside of while
For the test, I made the same function in CodeBlocks and send to it
string to detect and delete whitespaces. After deletion of dead code
part, I tested function again, it works.

Function buffer_trim first detects whitespace characters in the end
of the string using first while, then it adds '\0' to the end
of the string to mark that string has new end after all whitespace
characters. Second while finds whitespaces at the beginning
of the string and counts how many whitespaces it found.
In the end using if counted whitespaces are removing from the
string.


Fixes #12319 

Signed-off-by: Maksim Masalski <maxxliferobot@gmail.com>