### PR TITLE
drivers: ssd1306: Add high and delay for reset.

### DIFF
--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -368,6 +368,8 @@ static int ssd1306_init_device(struct device *dev)
 	};
 
 #ifdef DT_SOLOMON_SSD1306FB_0_RESET_GPIOS_CONTROLLER
+	gpio_pin_write(driver->reset, DT_SOLOMON_SSD1306FB_0_RESET_GPIOS_PIN, 1);
+	k_sleep(SSD1306_RESET_DELAY);
 	gpio_pin_write(driver->reset, DT_SOLOMON_SSD1306FB_0_RESET_GPIOS_PIN, 0);
 	k_sleep(SSD1306_RESET_DELAY);
 	gpio_pin_write(driver->reset, DT_SOLOMON_SSD1306FB_0_RESET_GPIOS_PIN, 1);


### PR DESCRIPTION
Applying the reset added as #13663 causes abnormal operation.
After reset, driver operation is abnormal.

Adding the HIGH and delay of the GPIO solves this problem.

**Test environment**
Board: [stm32f4_disco](https://docs.zephyrproject.org/latest/boards/arm/stm32f4_disco/doc/index.html)
SSD1306 Module: [Monochrome 1.3" 128x64 OLED graphic display](https://www.adafruit.com/product/938)

**Refer to reset code**
1. https://github.com/adafruit/Adafruit_Python_SSD1306/blob/master/Adafruit_SSD1306/SSD1306.py#L156-L163
``` python
        # Set reset high for a millisecond.
        self._gpio.set_high(self._rst)
        time.sleep(0.001)
        # Set reset low for 10 milliseconds.
        self._gpio.set_low(self._rst)
        time.sleep(0.010)
        # Set reset high again.
        self._gpio.set_high(self._rst)
```
2. https://www.avrfreaks.net/comment/1770136#comment-1770136
```
    // reset
    output_high(DISPLAY_RESET);
    delay_ms(1);
    output_low(DISPLAY_RESET);
    delay_ms(10);
    output_high(DISPLAY_RESET); // Reset Pin High for normal operation
```

**Before & After**
1. Before
I2C does not output normally after reset.
![scope_4](https://user-images.githubusercontent.com/10510127/53310487-7784a900-38f0-11e9-80b0-a95ba0dde490.png)



2. After
After reset, I2C is output normally.
![scope_6](https://user-images.githubusercontent.com/10510127/53310503-83706b00-38f0-11e9-9ff8-4eeb5549b83b.png)
