### PR TITLE
scripts: size_report: Fix output of header break line

### DIFF
--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -367,7 +367,7 @@ def print_tree(data, total, depth):
 
     print('{:92s} {:10s} {:8s}'.format(
         bcolors["FAIL"] + "Path", "Size", "%" + bcolors["ENDC"]))
-    print("'='*110i")
+    print('=' * 110)
     for i in sorted(data):
         p = i.split(os.path.sep)
         if depth and len(p) > depth:


### PR DESCRIPTION
Was apparently an artifact of Python2 to Python3 conversion. Led to
printing of literal '='*110i instead of a line of ='s.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>