### PR TITLE
console: tty: Remove dependency on older "consoles"

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -7,6 +7,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Setting shared by different subsystems
+config UART_CONSOLE_ON_DEV_NAME
+	string "Device Name of UART Device for UART Console"
+	default "$(dt_str_val,DT_UART_CONSOLE_ON_DEV_NAME)" if HAS_DTS
+	default "UART_0"
+	depends on (UART_CONSOLE || CONSOLE_SUBSYS)
+	help
+	  This option specifies the name of UART device to be used for
+	  UART console.
+
 menuconfig CONSOLE
 	bool "Console drivers"
 
@@ -40,15 +50,6 @@ config UART_CONSOLE
 	help
 	  Enable this option to use one UART for console. Make sure
 	  CONFIG_UART_CONSOLE_ON_DEV_NAME is also set correctly.
-
-config UART_CONSOLE_ON_DEV_NAME
-	string "Device Name of UART Device for UART Console"
-	default "$(dt_str_val,DT_UART_CONSOLE_ON_DEV_NAME)" if HAS_DTS
-	default "UART_0"
-	depends on UART_CONSOLE
-	help
-	  This option specifies the name of UART device to be used for
-	  UART console.
 
 config UART_CONSOLE_INIT_PRIORITY
 	int "Init priority"

--- a/subsys/console/tty.c
+++ b/subsys/console/tty.c
@@ -8,8 +8,6 @@
 #include <uart.h>
 #include <misc/printk.h>
 #include <tty.h>
-#include <drivers/console/console.h>
-#include <drivers/console/uart_console.h>
 
 static int tty_irq_input_hook(struct tty_serial *tty, u8_t c);
 static int tty_putchar(struct tty_serial *tty, u8_t c);


### PR DESCRIPTION
Console subsystem doesn't depend on older consoles-in-drivers, the
only common thing between them is CONFIG_UART_CONSOLE_ON_DEV_NAME
setting, so make it so (by depending on either UART_CONSOLE or
CONSOLE_SUBSYS.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>