### PR TITLE
Fix CoAP coverity issue

### DIFF
--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -46,7 +46,7 @@ static inline bool append_be16(struct coap_packet *cpkt, u16_t data)
 		return false;
 	}
 
-	cpkt->data[cpkt->offset++] = (data & 0xFF) >> 8;
+	cpkt->data[cpkt->offset++] = data >> 8;
 	cpkt->data[cpkt->offset++] = (u8_t) data;
 
 	return true;


### PR DESCRIPTION
To get u8_t value, just right shift the operands are enough.

Fixes #12298
Coverity-CID: 190635
