### PR TITLE
net: sockets: tls: Detect EOF in poll prepare

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1785,6 +1785,8 @@ static int ztls_poll_update_ctx(struct net_context *ctx,
 			(*pev)->state = K_POLL_STATE_NOT_READY;
 			goto again;
 		}
+
+		goto next;
 	}
 
 	return 0;


### PR DESCRIPTION
First patch adds EOF handling in a `poll` in a similar manner as #13230 did for regular sockets.

Second patch fixes regression spotted when testing above - in case poll descriptor was not reported as ready, it was not incremented.