### PR TITLE
net: stats: Wrong Kconfig options were used for statistics

### DIFF
--- a/include/net/net_stats.h
+++ b/include/net/net_stats.h
@@ -264,7 +264,7 @@ struct net_stats {
 	struct net_stats_ipv6_nd ipv6_nd;
 #endif
 
-#if defined(CONFIG_NET_IPV6_MLD)
+#if defined(CONFIG_NET_STATISTICS_MLD)
 	/** IPv6 MLD statistics */
 	struct net_stats_ipv6_mld ipv6_mld;
 #endif

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -691,33 +691,33 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 		PR("=================\n");
 	}
 
-#if defined(CONFIG_NET_IPV6)
+#if defined(CONFIG_NET_STATISTICS_IPV6)
 	PR("IPv6 recv      %d\tsent\t%d\tdrop\t%d\tforwarded\t%d\n",
 	   GET_STAT(iface, ipv6.recv),
 	   GET_STAT(iface, ipv6.sent),
 	   GET_STAT(iface, ipv6.drop),
 	   GET_STAT(iface, ipv6.forwarded));
-#if defined(CONFIG_NET_IPV6_ND)
+#if defined(CONFIG_NET_STATISTICS_IPV6_ND)
 	PR("IPv6 ND recv   %d\tsent\t%d\tdrop\t%d\n",
 	   GET_STAT(iface, ipv6_nd.recv),
 	   GET_STAT(iface, ipv6_nd.sent),
 	   GET_STAT(iface, ipv6_nd.drop));
-#endif /* CONFIG_NET_IPV6_ND */
+#endif /* CONFIG_NET_STATISTICS_IPV6_ND */
 #if defined(CONFIG_NET_STATISTICS_MLD)
 	PR("IPv6 MLD recv  %d\tsent\t%d\tdrop\t%d\n",
 	   GET_STAT(iface, ipv6_mld.recv),
 	   GET_STAT(iface, ipv6_mld.sent),
 	   GET_STAT(iface, ipv6_mld.drop));
 #endif /* CONFIG_NET_STATISTICS_MLD */
-#endif /* CONFIG_NET_IPV6 */
+#endif /* CONFIG_NET_STATISTICS_IPV6 */
 
-#if defined(CONFIG_NET_IPV4)
+#if defined(CONFIG_NET_STATISTICS_IPV4)
 	PR("IPv4 recv      %d\tsent\t%d\tdrop\t%d\tforwarded\t%d\n",
 	   GET_STAT(iface, ipv4.recv),
 	   GET_STAT(iface, ipv4.sent),
 	   GET_STAT(iface, ipv4.drop),
 	   GET_STAT(iface, ipv4.forwarded));
-#endif /* CONFIG_NET_IPV4 */
+#endif /* CONFIG_NET_STATISTICS_IPV4 */
 
 	PR("IP vhlerr      %d\thblener\t%d\tlblener\t%d\n",
 	   GET_STAT(iface, ip_errors.vhlerr),
@@ -728,7 +728,7 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 	   GET_STAT(iface, ip_errors.chkerr),
 	   GET_STAT(iface, ip_errors.protoerr));
 
-#if defined(CONFIG_NET_ICMPV4) || defined(CONFIG_NET_ICMPV6)
+#if defined(CONFIG_NET_STATISTICS_ICMP)
 	PR("ICMP recv      %d\tsent\t%d\tdrop\t%d\n",
 	   GET_STAT(iface, icmp.recv),
 	   GET_STAT(iface, icmp.sent),
@@ -738,7 +738,7 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 	   GET_STAT(iface, icmp.chkerr));
 #endif
 
-#if defined(CONFIG_NET_UDP)
+#if defined(CONFIG_NET_STATISTICS_UDP)
 	PR("UDP recv       %d\tsent\t%d\tdrop\t%d\n",
 	   GET_STAT(iface, udp.recv),
 	   GET_STAT(iface, udp.sent),


### PR DESCRIPTION
The net-shell was using wrong config options for statistics
support. Also net_stats.h had wrong config used for IPv6 MLD
statistics.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>