### PR TITLE
codeowner: add codeowner for ST stm32 development boards

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -64,11 +64,14 @@
 /boards/arm/nrf52840_pca10056/            @carlescufi
 /boards/arm/nrf52840_pca10059/            @lemrey
 /boards/arm/nrf9160_pca10090/             @ioannisg
+/boards/arm/nucleo*/                      @erwango
 /boards/arm/nucleo_f401re/                @rsalveti @idlethread
 /boards/arm/sam4s_xplained/               @fallrisk
 /boards/arm/v2m_beetle/                   @fvincenzo
 /boards/arm/olimexino_stm32/              @ydamigos
+/boards/arm/stm32*_disco/                 @erwango
 /boards/arm/stm32f3_disco/                @ydamigos
+/boards/arm/stm32*_eval/                  @erwango
 /boards/nios2/                            @ramakrishnapallala
 /boards/nios2/altera_max10/               @ramakrishnapallala
 /boards/posix/                            @aescolar


### PR DESCRIPTION
Add codeowner for STM32 based ST development boards

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>