### PR TITLE
net: lwm2m: fix json formatter putchar check

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -391,7 +391,7 @@ static size_t put_json_postfix(struct lwm2m_output_context *out)
 		return 0;
 	}
 
-	if (put_char(out, '}') < 0) {
+	if (put_char(out, '}') < 1) {
 		/* TODO: Generate error? */
 		return 0;
 	}


### PR DESCRIPTION
Found via Coverity CID 191001: Control flow issues  (NO_EFFECT)
This less-than-zero comparison of an unsigned value is never true:
"put_char(out, '}') < 0U".

Let's fix this check to be less than 1 instead as it should have
been originally.

Signed-off-by: Michael Scott <mike@foundries.io>