### PR TITLE
boards/intel_s1000_crb: fix image creation with custom filename

### DIFF
--- a/boards/xtensa/intel_s1000_crb/CMakeLists.txt
+++ b/boards/xtensa/intel_s1000_crb/CMakeLists.txt
@@ -5,8 +5,8 @@ endif()
 
 set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
   COMMAND ${PYTHON_EXECUTABLE} ${BOARD_DIR}/support/create_board_img.py
-  -i ${PROJECT_BINARY_DIR}/zephyr.bin
-  -o ${PROJECT_BINARY_DIR}/zephyr_${BOARD}.bin
+  -i ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.bin
+  -o ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}_${BOARD}.bin
   -l $<TARGET_FILE:${ZEPHYR_PREBUILT_EXECUTABLE}>
   -sk
 )


### PR DESCRIPTION
The command to create the board image binary file assumes the input
is always called zephyr.bin. This is not always the case if custom
name is defined in CONFIG_KERNEL_BIN_NAME. So update the call of
command to use CONFIG_KERNEL_BIN_NAME.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>