### PR TITLE
tests/boards/intel_s1000_crb: fix potential uninit variables

### DIFF
--- a/tests/boards/intel_s1000_crb/src/i2c_test.c
+++ b/tests/boards/intel_s1000_crb/src/i2c_test.c
@@ -97,6 +97,13 @@ void test_i2c_write_led(struct device *i2c_dev, u16_t i2c_slave_led, u8_t color)
 		break;
 
 	default:
+		/* Go dark */
+		led_val[0] = 0x00;
+		led_val[1] = 0x00;
+		led_val[2] = 0x00;
+		led_val[3] = 0x00;
+		led_val[4] = 0x00;
+		led_val[5] = 0x00;
 		break;
 	}
 


### PR DESCRIPTION
The led_val[] may not be initialized depending on the switch-case.
So set them via default case.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>