### PR TITLE
libc: newlib: Rename adhoc read/write implementation for stdin/stdout

### DIFF
--- a/include/misc/libc-hooks.h
+++ b/include/misc/libc-hooks.h
@@ -23,9 +23,9 @@
  */
 #define _MLIBC_RESTRICT
 
-__syscall int _zephyr_read(char *buf, int nbytes);
+__syscall int _zephyr_read_stdin(char *buf, int nbytes);
 
-__syscall int _zephyr_write(const void *buf, int nbytes);
+__syscall int _zephyr_write_stdout(const void *buf, int nbytes);
 
 #else
 /* Minimal libc */

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -104,7 +104,7 @@ void __stdin_hook_install(unsigned char (*hook)(void))
 	_stdin_hook = hook;
 }
 
-int _impl__zephyr_read(char *buf, int nbytes)
+int _impl__zephyr_read_stdin(char *buf, int nbytes)
 {
 	int i = 0;
 
@@ -119,14 +119,14 @@ int _impl__zephyr_read(char *buf, int nbytes)
 }
 
 #ifdef CONFIG_USERSPACE
-Z_SYSCALL_HANDLER(_zephyr_read, buf, nbytes)
+Z_SYSCALL_HANDLER(_zephyr_read_stdin, buf, nbytes)
 {
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(buf, nbytes));
-	return _impl__zephyr_read((char *)buf, nbytes);
+	return _impl__zephyr_read_stdin((char *)buf, nbytes);
 }
 #endif
 
-int _impl__zephyr_write(const void *buffer, int nbytes)
+int _impl__zephyr_write_stdout(const void *buffer, int nbytes)
 {
 	const char *buf = buffer;
 	int i;
@@ -141,10 +141,10 @@ int _impl__zephyr_write(const void *buffer, int nbytes)
 }
 
 #ifdef CONFIG_USERSPACE
-Z_SYSCALL_HANDLER(_zephyr_write, buf, nbytes)
+Z_SYSCALL_HANDLER(_zephyr_write_stdout, buf, nbytes)
 {
 	Z_OOPS(Z_SYSCALL_MEMORY_READ(buf, nbytes));
-	return _impl__zephyr_write((const void *)buf, nbytes);
+	return _impl__zephyr_write_stdout((const void *)buf, nbytes);
 }
 #endif
 
@@ -153,7 +153,7 @@ int _read(int fd, char *buf, int nbytes)
 {
 	ARG_UNUSED(fd);
 
-	return _zephyr_read(buf, nbytes);
+	return _zephyr_read_stdin(buf, nbytes);
 }
 FUNC_ALIAS(_read, read, int);
 
@@ -161,7 +161,7 @@ int _write(int fd, const void *buf, int nbytes)
 {
 	ARG_UNUSED(fd);
 
-	return _zephyr_write(buf, nbytes);
+	return _zephyr_write_stdout(buf, nbytes);
 }
 FUNC_ALIAS(_write, write, int);
 


### PR DESCRIPTION
In case newlib is enabled, but POSIX subsys isn't, there're adhoc
implementations of read() and write() which work only with adhoc
stdin/stdout emulation layer. These are backed by system calls named
like "read" and "write". Rename all these functions and syscalls to
explicitly mention stdin/stdout in the names, to free namespace
for the implementation of generic read/write syscalls which will
integrate with POSIX fdtable.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>