### PR TITLE
net: doc: Add missing doxygen comments to structs

### DIFF
--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -54,6 +54,10 @@ struct ieee802154_filter {
 /* @endcond */
 };
 
+/**
+ * @brief IEEE 802.15.4 radio interface API.
+ *
+ */
 struct ieee802154_radio_api {
 	/**
 	 * Mandatory to get in first position.

--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -27,6 +27,7 @@ extern "C" {
 
 struct net_if;
 
+/** L2 flags */
 enum net_l2_flags {
 	/** IP multicast supported */
 	NET_L2_MULTICAST			= BIT(0),
@@ -38,6 +39,11 @@ enum net_l2_flags {
 	NET_L2_PROMISC_MODE			= BIT(2),
 } __packed;
 
+/**
+ * @brief Network L2 structure
+ *
+ * Used to provide an interface to lower network stack.
+ */
 struct net_l2 {
 	/**
 	 * This function is used by net core to get iface's L2 layer parsing

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -51,7 +51,10 @@ struct net_pkt_cursor {
 	u8_t *pos;
 };
 
-/* Note that if you add new fields into net_pkt, remember to update
+/**
+ * @brief Network packet.
+ *
+ * Note that if you add new fields into net_pkt, remember to update
  * net_pkt_clone() function.
  */
 struct net_pkt {


### PR DESCRIPTION
The doxygen comment for ieee802154_radio_api, net_l2 and
net_pkt structs was missing, which meant that no documentation
was generated for them.

Also add comment to "enum net_l2_flags" as that looks better in
the generated html file.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>