### PR TITLE
logging: Fix silent logs dropping when LOG_MODE_OVERFLOW disabled

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -540,6 +540,10 @@ bool log_is_strdup(void *buf);
  */
 void log_free(void *buf);
 
+/** @brief Indicate to the log core that one log message has been dropped.
+ */
+void log_dropped(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -439,8 +439,6 @@ static void msg_process(struct log_msg *msg, bool bypass)
 				log_backend_put(backend, msg);
 			}
 		}
-	} else {
-		atomic_inc(&dropped_cnt);
 	}
 
 	log_msg_put(msg);
@@ -486,6 +484,11 @@ bool log_process(bool bypass)
 u32_t log_buffered_cnt(void)
 {
 	return buffered_cnt;
+}
+
+void log_dropped(void)
+{
+	atomic_inc(&dropped_cnt);
 }
 
 u32_t log_src_cnt_get(u32_t domain_id)

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -74,10 +74,13 @@ union log_msg_chunk *log_msg_no_space_handle(void)
 	if (IS_ENABLED(CONFIG_LOG_MODE_OVERFLOW)) {
 		do {
 			more = log_process(true);
+			log_dropped();
 			err = k_mem_slab_alloc(&log_msg_pool,
 					       (void **)&msg,
 					       K_NO_WAIT);
 		} while ((err != 0) && more);
+	} else {
+		log_dropped();
 	}
 	return msg;
 


### PR DESCRIPTION
There was no notification about dropped logs When logger operated
in the mode where message is dropped when logger has no space to
store the message. Notification was printed only if logger operated
in the mode which overwrites oldest log.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>