### PR TITLE
tests: posix: add newlib cfg option

### DIFF
--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -1,5 +1,12 @@
+common:
+  tags: posix
+  min_ram: 64
+  arch_exclude: posix
 tests:
   portability.posix:
-    tags: posix
-    min_ram: 64
-    arch_exclude: posix
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=n
+  portability.posix.newlib:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y

--- a/tests/posix/fs/testcase.yaml
+++ b/tests/posix/fs/testcase.yaml
@@ -1,6 +1,12 @@
+common:
+  arch_exclude: nios2 posix
+  min_ram: 128
+  tags: posix filesystem
 tests:
   portability.posix:
-    arch_exclude: nios2 posix
-    min_ram: 128
-    tags: posix filesystem
-
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=n
+  portability.posix.newlib:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y


### PR DESCRIPTION
Add a build variant of the posix tests with newlib enabled.  Since the
interation of posix is greatly related to the libc we should have these
tests build with and without newlib support.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>