### PR TITLE
cmake: Don't assert when empty libraries are detected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -743,24 +743,6 @@ get_property(ZEPHYR_LIBS_PROPERTY GLOBAL PROPERTY ZEPHYR_LIBS)
 foreach(zephyr_lib ${ZEPHYR_LIBS_PROPERTY})
   # TODO: Could this become an INTERFACE property of zephyr_interface?
   add_dependencies(${zephyr_lib} ${OFFSETS_H_TARGET})
-
-  # Verify that all (non-imported) libraries have source
-  # files. Libraries without source files are not supported because
-  # they are an indication that something has been misconfigured.
-  get_target_property(lib_imported ${zephyr_lib} IMPORTED)
-  get_target_property(lib_sources  ${zephyr_lib} SOURCES)
-  if(lib_sources STREQUAL lib_sources-NOTFOUND
-      AND (NOT (${zephyr_lib} STREQUAL app))
-      AND (NOT lib_imported)
-      )
-    # app is not checked because it's sources are added to it after
-    # this CMakeLists.txt file has been processed
-    message(FATAL_ERROR "\
-The Zephyr library '${zephyr_lib}' was created without source files. \
-Empty (non-imported) libraries are not supported. \
-Either make sure that the library has the sources it should have, \
-or make sure it is not created when it has no source files.")
-  endif()
 endforeach()
 
 get_property(OUTPUT_FORMAT        GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT)


### PR DESCRIPTION
The empty-library check was introduced because in earlier versions of
CMake the error message for empty libraries was very cryptic. But in
3.13.2 CMake now reports:

> -- Configuring done
> CMake Error at ../../cmake/extensions.cmake:357 (add_library):
>   No SOURCES given to target: drivers__entropy
> Call Stack (most recent call first):
>   ../../cmake/extensions.cmake:334 (zephyr_library_named)
>   ../../drivers/entropy/CMakeLists.txt:1 (zephyr_library)

which should be clear enough.

In addition to being redundant, our empty library check is run earlier
than CMake's check, so it will falsely report libraries to be empty,
when in fact, in an out-of-tree driver use-case, they will not
actually be empty at Generation time.

CMake runs it's check at generation time and is not affected by this
problem, so we remove our own check.

This is a step, but not a complete solution, to resolving #8379.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>