### PR TITLE
net: arp: Update the ARP cache if receiving ARP req

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -395,6 +395,20 @@ static inline bool net_eth_is_addr_broadcast(struct net_eth_addr *addr)
 	return false;
 }
 
+static inline bool net_eth_is_addr_unspecified(struct net_eth_addr *addr)
+{
+	if (addr->addr[0] == 0x00 &&
+	    addr->addr[1] == 0x00 &&
+	    addr->addr[2] == 0x00 &&
+	    addr->addr[3] == 0x00 &&
+	    addr->addr[4] == 0x00 &&
+	    addr->addr[5] == 0x00) {
+		return true;
+	}
+
+	return false;
+}
+
 static inline bool net_eth_is_addr_multicast(struct net_eth_addr *addr)
 {
 #if defined(CONFIG_NET_IPV6)


### PR DESCRIPTION
If we receive the ARP request, then check if the ARP cache
contains an entry for this IP address already. If it does,
then update the MAC address in the cache.

Fixes #10188

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>