### PR TITLE
doc/guide/dts: Clean up DTS template

### DIFF
--- a/doc/guides/dts/index.rst
+++ b/doc/guides/dts/index.rst
@@ -195,9 +195,10 @@ compatible that denotes the unique board described by the .dts file.
 Device Tree Source File Template
 ================================
 
-.. code-block:: yaml
+.. code-block:: none
 
-  /dts-v1/
+  /dts-v1/;
+
   / {
           model = "Model name for your board";
           compatible = "compatible for your board";


### PR DESCRIPTION
Add a missing semicolon after `/dts-v1/`, and a blank line between
`/dts-v1/` and the root node.

Use `code-block:: none` instead of `code-block:: yaml` as well.
DTS is not YAML.