### PR TITLE
Spinlock validation augmentation

### DIFF
--- a/kernel/include/kernel_structs.h
+++ b/kernel/include/kernel_structs.h
@@ -15,6 +15,7 @@
 #include <misc/rb.h>
 #include <misc/util.h>
 #include <string.h>
+#include <spinlock.h>
 #endif
 
 #define K_NUM_PRIORITIES \
@@ -106,6 +107,10 @@ struct _cpu {
 #ifdef CONFIG_SMP
 	/* True when _current is allowed to context switch */
 	u8_t swap_ok;
+#endif
+
+#ifdef SPIN_VALIDATE
+	u8_t spin_depth;
 #endif
 };
 

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -59,6 +59,10 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 
 	if (is_spinlock) {
 		k_spin_release(lock);
+#ifdef SPIN_VALIDATE
+		__ASSERT(_current_cpu->spin_depth == 0,
+			 "Swapping with spinlock held!");
+#endif
 	}
 
 	new_thread = z_get_next_ready_thread();
@@ -142,6 +146,10 @@ static inline int z_swap_irqlock(unsigned int key)
 static ALWAYS_INLINE int z_swap(struct k_spinlock *lock, k_spinlock_key_t key)
 {
 	k_spin_release(lock);
+#ifdef SPIN_VALIDATE
+	__ASSERT(_current_cpu->spin_depth == 0,
+		 "Swapping with spinlock held!");
+#endif
 	return z_swap_irqlock(key.key);
 }
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -720,6 +720,7 @@ int z_spin_lock_valid(struct k_spinlock *l)
 		}
 	}
 	l->thread_cpu = _current_cpu->id | (u32_t)_current;
+	_current_cpu->spin_depth++;
 	return 1;
 }
 
@@ -729,6 +730,7 @@ int z_spin_unlock_valid(struct k_spinlock *l)
 		return 0;
 	}
 	l->thread_cpu = 0;
+	_current_cpu->spin_depth--;
 	return 1;
 }
 #endif


### PR DESCRIPTION
No need to merge this for 1.14.  It's a check I added at one point when we noticed a spot where the kernel was trying to swap away with a spinlock held (recursive irqlocks worked like that, but with spinlocks you must be 100% sure there is only one lock being released in _Swap() -- and that's a good thing!).

It's cheap and easy, but as it happens everything else passes with it, so there's no rush to get it into the tree.