### PR TITLE
kconfig: pwm: Remove redundant deps. and clean up a bit

### DIFF
--- a/drivers/pwm/Kconfig.dw
+++ b/drivers/pwm/Kconfig.dw
@@ -8,7 +8,6 @@
 
 menuconfig PWM_DW
 	bool "DesignWare PWM"
-	depends on PWM
 	help
 	  Enable driver to utilize PWM on the DesignWare Timer IP block.
 	  Care must be taken if one is also to use the timer feature, as
@@ -18,7 +17,6 @@ if PWM_DW
 
 config PWM_DW_0_DRV_NAME
 	string "DesignWare PWM Device Name"
-	depends on PWM_DW
 	default "PWM_0"
 	help
 	  Specify the device name for the DesignWare PWM driver.

--- a/drivers/pwm/Kconfig.esp32
+++ b/drivers/pwm/Kconfig.esp32
@@ -8,7 +8,6 @@
 
 menuconfig PWM_LED_ESP32
 	bool "ESP32 PWM LED driver"
-	depends on PWM
 	help
 	  This option enables the PWM LED driver for ESP32 family of
 	  processors. Say y if you wish to use PWM LED port on ESP32.

--- a/drivers/pwm/Kconfig.imx
+++ b/drivers/pwm/Kconfig.imx
@@ -7,7 +7,6 @@
 
 menuconfig PWM_IMX
 	bool "i.MX PWM Driver"
-	depends on PWM
 	help
 	  Enable support for i.MX pwm driver.
 

--- a/drivers/pwm/Kconfig.nrf5_sw
+++ b/drivers/pwm/Kconfig.nrf5_sw
@@ -9,7 +9,7 @@
 menuconfig PWM_NRF5_SW
 	bool "Nordic Semiconductor nRF5x series S/W PWM"
 	default y if !PWM_NRFX
-	depends on PWM && SOC_FAMILY_NRF
+	depends on SOC_FAMILY_NRF
 	help
 	  Enable driver to utilize PWM on the Nordic Semiconductor nRF5x series.
 	  This implementation provides up to 3 pins using one HF timer, two PPI
@@ -43,4 +43,4 @@ config PWM_NRF5_SW_0_CLOCK_PRESCALER
 	  8: 62500 Hz
 	  9: 31250 Hz
 
-endif
+endif # PWM_NRF5_SW

--- a/drivers/pwm/Kconfig.pca9685
+++ b/drivers/pwm/Kconfig.pca9685
@@ -12,7 +12,7 @@
 
 menuconfig PWM_PCA9685
 	bool "PCA9685 I2C-based PWM chip"
-	depends on PWM && I2C
+	depends on I2C
 	help
 	  Enable driver for PCA9685 I2C-based PWM chip.
 

--- a/drivers/pwm/Kconfig.qmsi
+++ b/drivers/pwm/Kconfig.qmsi
@@ -8,28 +8,29 @@
 
 menuconfig PWM_QMSI
 	bool "QMSI PWM Driver"
-	depends on QMSI && PWM
+	depends on QMSI
 	help
 	  Enable QMSI PWM driver. This driver will use the QMSI library to
 	  access the SOC underlying timer IP block. This driver uses the
 	  DesignWare IP block that can be also handled by the PWM_DW driver
 
+if PWM_QMSI
+
 config PWM_QMSI_DEV_NAME
 	string "QMSI PWM Device Name"
-	depends on PWM_QMSI
 	default "PWM_0"
 	help
 	  Specify the device name for the PWM driver.
 
 config PWM_QMSI_NUM_PORTS
 	int "Number of PWM ports for PWM"
-	depends on PWM_QMSI
 	default 1
 	help
 	  Specify how many PWM ports on the IP block.
 
 config PWM_QMSI_API_REENTRANCY
 	bool "PWM shim driver API reentrancy"
-	depends on PWM_QMSI
 	help
 	  Enable support for PWM shim driver API reentrancy.
+
+endif # PWM_QMSI

--- a/drivers/pwm/Kconfig.sam
+++ b/drivers/pwm/Kconfig.sam
@@ -7,6 +7,5 @@
 menuconfig PWM_SAM
 	bool "Atmel SAM MCU Family PWM Driver"
 	depends on SOC_FAMILY_SAM
-	depends on PWM
 	help
 	  Enable PWM driver for Atmel SAM MCUs.

--- a/drivers/pwm/Kconfig.sifive
+++ b/drivers/pwm/Kconfig.sifive
@@ -8,7 +8,6 @@
 
 menuconfig PWM_SIFIVE
 	bool "SiFive Freedom PWM driver"
-	depends on PWM
 	depends on SOC_SERIES_RISCV32_SIFIVE_FREEDOM
 	depends on HAS_DTS
 	help

--- a/drivers/pwm/Kconfig.stm32
+++ b/drivers/pwm/Kconfig.stm32
@@ -8,149 +8,133 @@
 
 menuconfig PWM_STM32
 	bool "STM32 MCU PWM driver"
-	depends on PWM && SOC_FAMILY_STM32
+	depends on SOC_FAMILY_STM32
 	select USE_STM32_HAL_TIM
 	help
 	  This option enables the PWM driver for STM32 family of
 	  processors. Say y if you wish to use PWM port on STM32
 	  MCU.
 
+if PWM_STM32
+
 config PWM_STM32_1
 	bool "STM32 PWM 1 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM1 in the driver. Say y here
 	  if you want to use PWM1 output.
 
 config PWM_STM32_2
 	bool "STM32 PWM 2 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM2 in the driver. Say y here
 	  if you want to use PWM2 output.
 
 config PWM_STM32_3
 	bool "STM32 PWM 3 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM3 in the driver. Say y here
 	  if you want to use PWM3 output.
 
 config PWM_STM32_4
 	bool "STM32 PWM 4 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM4 in the driver. Say y here
 	  if you want to use PWM4 output.
 
 config PWM_STM32_5
 	bool "STM32 PWM 5 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM5 in the driver. Say y here
 	  if you want to use PWM5 output.
 
 config PWM_STM32_6
 	bool "STM32 PWM 6 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM6 in the driver. Say y here
 	  if you want to use PWM6 output.
 
 config PWM_STM32_7
 	bool "STM32 PWM 7 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM7 in the driver. Say y here
 	  if you want to use PWM7 output.
 
 config PWM_STM32_8
 	bool "STM32 PWM 8 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM8 in the driver. Say y here
 	  if you want to use PWM8 output.
 
 config PWM_STM32_9
 	bool "STM32 PWM 9 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM9 in the driver. Say y here
 	  if you want to use PWM9 output.
 
 config PWM_STM32_10
 	bool "STM32 PWM 10 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM10 in the driver. Say y here
 	  if you want to use PWM10 output.
 
 config PWM_STM32_11
 	bool "STM32 PWM 11 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM11 in the driver. Say y here
 	  if you want to use PWM11 output.
 
 config PWM_STM32_12
 	bool "STM32 PWM 12 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM12 in the driver. Say y here
 	  if you want to use PWM12 output.
 
 config PWM_STM32_13
 	bool "STM32 PWM 13 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM13 in the driver. Say y here
 	  if you want to use PWM13 output.
 
 config PWM_STM32_14
 	bool "STM32 PWM 14 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM14 in the driver. Say y here
 	  if you want to use PWM14 output.
 
 config PWM_STM32_15
 	bool "STM32 PWM 15 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM15 in the driver. Say y here
 	  if you want to use PWM15 output.
 
 config PWM_STM32_16
 	bool "STM32 PWM 16 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM16 in the driver. Say y here
 	  if you want to use PWM16 output.
 
 config PWM_STM32_17
 	bool "STM32 PWM 17 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM17 in the driver. Say y here
 	  if you want to use PWM17 output.
 
 config PWM_STM32_18
 	bool "STM32 PWM 18 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM18 in the driver. Say y here
 	  if you want to use PWM18 output.
 
 config PWM_STM32_19
 	bool "STM32 PWM 19 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM19 in the driver. Say y here
 	  if you want to use PWM19 output.
 
 config PWM_STM32_20
 	bool "STM32 PWM 20 Output"
-	depends on PWM_STM32
 	help
 	  Enable output for PWM20 in the driver. Say y here
 	  if you want to use PWM20 output.
+
+endif # PWM_STM32


### PR DESCRIPTION
 - Remove redundant dependencies on the `PWM` symbol (which show up as
   `PWM && PWM` in the documentation). The `source`s in
   `drivers/pwm/Kconfig` are already within an `if PWM` block.

 - Turn some repeated `depends on FOO` into `if FOO` blocks.

 - Turn some `if FOO`s that surround a single symbol into
   `depends on FOO`.

`if FOO` is equivalent to adding a `depends on FOO` to each symbol
within the `if`.