### PR TITLE
kconfig: tests: Fix double 'source' of subsys/testsuite/Kconfig

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -38,8 +38,6 @@ source "subsys/Kconfig"
 
 source "ext/Kconfig"
 
-source "subsys/testsuite/Kconfig"
-
 source "$(PROJECT_BINARY_DIR)/Kconfig.modules"
 
 menu "Build and Link Features"


### PR DESCRIPTION
Both `Kconfig.zephyr` and `subsys/Kconfig` `source`s `subsys/testsuite/Kconfig`, giving multiple redundant identical definitions for the symbols in it.

Remove the `source` in `Kconfig.zephyr`.