### PR TITLE
filter-known-issues.py: clarify what "new" means

### DIFF
--- a/scripts/filter-known-issues.py
+++ b/scripts/filter-known-issues.py
@@ -236,7 +236,8 @@ if warnings or errors:
         errors.flush()
     if ((os.path.isfile(args.warnings) and os.path.getsize(args.warnings) > 0) or
         (os.path.isfile(args.errors) and os.path.getsize(args.errors) > 0)):
-        print("\n\nNew errors/warnings found, please fix them:\n")
+        print('''\n\n ---- New errors/warnings not tracked as .known-issues/, \
+please fix them ----\n''')
         if args.warnings:
             print(open(args.warnings, "r").read())
         if args.errors and (args.errors != args.warnings):
@@ -244,3 +245,5 @@ if warnings or errors:
     else:
         print("\n\nNo new errors/warnings.\n")
 
+    print('''\nTo see *all* new error/warnings you must make/ninja clean and \
+rebuild from scratch.''')


### PR DESCRIPTION
When building incrementally, filter-known-issues.py reports a varying
and totally different set of "new" issues than when building from
scratch. Warnings for unrelated upstream code disappearing and
re-appearing are especially confusing. Expand the messages a bit to
clarify.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>