### PR TITLE
sphinx-moderncmakedomain DEMO: convert .cmake comments to html

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
 # *DOCUMENTATION*
+
+#.rst:
+# /CMakeLists.txt
+# ---------------------
 #
 # Note that this is *NOT* the top-level CMakeLists.txt. That's in the
 # application. See the Application Development Primer documentation
@@ -45,6 +49,9 @@ endif()
 define_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT BRIEF_DOCS " " FULL_DOCS " ")
 set_property(   GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-little${ARCH}) # BFD format
 
+#.rst:
+# .. variable:: add_library(zephyr_interface INTERFACE)
+#
 # "zephyr_interface" is a source-less library that encapsulates all the global
 # compiler options needed by all source files. All zephyr libraries,
 # including the library named "zephyr" link with this library to
@@ -52,6 +59,12 @@ set_property(   GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-little${ARCH}) # BF
 # https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#interface-libraries
 add_library(zephyr_interface INTERFACE)
 
+#.rst:
+# .. image:: zephyr_interface.svg
+
+#.rst:
+# .. variable:: zephyr_library_name(zephyr)
+#
 # "zephyr" is a catch-all CMake library for source files that can be
 # built purely with the include paths, defines, and other compiler
 # flags that come with zephyr_interface.

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -1,3 +1,7 @@
+
+#.rst:
+# /app/boilerplate.cmake
+# ----------------------------
 # This file must be included into the toplevel CMakeLists.txt file of
 # Zephyr applications, e.g. zephyr/samples/hello_world/CMakeLists.txt
 # must start with the line:
@@ -6,7 +10,7 @@
 #
 # It exists to reduce boilerplate code that Zephyr expects to be in
 # application CMakeLists.txt code.
-
+#
 # CMake version 3.13.1 is the real minimum supported version.
 #
 # Unfortunately CMake requires the toplevel CMakeLists.txt file to
@@ -452,6 +456,9 @@ if(CONFIG_QEMU_TARGET)
   endif()
 endif()
 
+#.rst:
+# .. variable:: zephyr_library_named(app)
+#
 # "app" is a CMake library containing all the application code and is
 # modified by the entry point ${APPLICATION_SOURCE_DIR}/CMakeLists.txt
 # that was specified when cmake was called.
@@ -460,6 +467,9 @@ set_property(TARGET app PROPERTY ARCHIVE_OUTPUT_DIRECTORY app)
 
 add_subdirectory(${ZEPHYR_BASE} ${__build_dir})
 
+#.rst:
+# .. command:: target_link_libraries_ifdef(app ZEPHYR_INTERFACE_LIBS)
+#
 # Link 'app' with the Zephyr interface libraries.
 #
 # NB: This must be done in boilerplate.cmake because 'app' can only be

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1,3 +1,8 @@
+
+#.rst:
+# /cmake/extensions.cmake
+# -----------------------------
+
 ########################################################
 # Table of contents
 ########################################################
@@ -301,7 +306,8 @@ macro(get_property_and_add_prefix result target property prefix)
   endforeach()
 endmacro()
 
-# 1.2 zephyr_library_*
+#.rst:
+# .. command:: zephyr_library_*
 #
 # Zephyr libraries use CMake's library concept and a set of
 # assumptions about how zephyr code is organized to cut down on

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -91,6 +91,7 @@ set(EXTRACT_CONTENT_COMMAND
   --ignore ${CMAKE_CURRENT_BINARY_DIR}
   # Copy all files in doc to the rst folder.
   "*:doc:${RST_OUT}"
+&& ./cmake_hack.sh
   # We want to copy the .rst files in samples/ and boards/ to the rst
   # folder, and also the doc folder inside rst.
   #
@@ -300,10 +301,20 @@ add_custom_target(
 
 endif()
 
+# Hack disabling doxygen entirely when not interested in it, builds docs
+# about 3 times faster.  This unsurprisingly generate at lot of "cannot
+# find doxygengroup" warnings but only when building from scratch the
+# first time.
+add_custom_target(
+  fakedoxylog
+  COMMAND echo "Doxygen disabled with doc/CMakeLists.txt hack" > ${DOXY_LOG}
+)
+
 #
 # Dependencies and final targets
 #
-add_dependencies(html content doxy_real_modified_times kconfig)
+#add_dependencies(html content doxy_real_modified_times kconfig)
+add_dependencies(html content fakedoxylog kconfig)
 
 add_custom_target(
   htmldocs

--- a/doc/cmake_hack.sh
+++ b/doc/cmake_hack.sh
@@ -34,13 +34,19 @@ rsync -a ../CMakeLists.txt _build/rst/cmake/
 # rm -rf _build/rst/doc/{guides/,releases/,reference/kconfigxx/}
 # find _build -name '*.rst' | wc; exit 1
 
+BDIR=build-graphiz-sphinx-hack
 
 # cmake --graphviz
 ( cd ../samples/hello_world/
-  mkdir -p build && cd build
-  ZEPHYR_TOOLCHAIN_VARIANT=host cmake -DBOARD=qemu_x86 --graphviz=cmake.dot ..
+
+  rm -rf "${BDIR}"/
+
+  # --graphiz doesn't output in -B, always in cwd
+  mkdir "${BDIR}" && cd "${BDIR}"
+
+  cmake -DBOARD=qemu_x86 --graphviz=cmake.dot ..
 )
 
 mkdir -p _build/html # CMake creates this but later
-dot -Tsvg ../samples/hello_world/build/cmake.dot.zephyr_interface.dependers \
+dot -Tsvg ../samples/hello_world/"${BDIR}"/cmake.dot.zephyr_interface.dependers \
     > _build/html/zephyr_interface.svg

--- a/doc/cmake_hack.sh
+++ b/doc/cmake_hack.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# Copyright (c) 2019, Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# FIXME: move (most of) this to doc/scripts/extract_content.py
+
+# requires
+# pip3 install --user sphinxcontrib-moderncmakedomain
+#
+# to test:
+
+
+set -e
+set -x
+
+# Stop if not run from the expected place
+test -d ../doc/_build
+
+
+# Copy CMakeLists.txt and *.cmake source files to the build directory.
+#
+# it's quite hard to keep track of the directory hierarchy...
+# rsync -av --include='*/' --include='*.cmake' --include='CMakeLists.txt' --exclude='*' .. _build/rst/
+# mv _build/rst/CMakeLists.txt _build/rst/cmake/
+rsync -a --include='*/' --include='*.cmake' --include='CMakeLists.txt' --exclude='*' ../cmake/  _build/rst/cmake/
+rsync -a ../CMakeLists.txt _build/rst/cmake/
+
+
+# Alternative hack to speed up the initial build.
+# Main speed-up hack is disabling doxygen see doc/CMakeList.txt
+# Unsurprisingly generates many "undefined" warnings
+# rm -rf _build/rst/doc/{guides/,releases/,reference/kconfigxx/}
+# find _build -name '*.rst' | wc; exit 1
+
+
+# cmake --graphviz
+( cd ../samples/hello_world/
+  mkdir -p build && cd build
+  ZEPHYR_TOOLCHAIN_VARIANT=host cmake -DBOARD=qemu_x86 --graphviz=cmake.dot ..
+)
+
+mkdir -p _build/html # CMake creates this but later
+dot -Tsvg ../samples/hello_world/build/cmake.dot.zephyr_interface.dependers \
+    > _build/html/zephyr_interface.svg

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -67,6 +67,17 @@ extensions = [
     'zephyr.link-roles'
 ]
 
+# If moderncmakedomain is missing, then excluding just zephyr-cmake.rst
+# is enough not to generate any new error or warning. In other words
+# this part of the documentation can probably be made optional.
+try:
+    import sphinxcontrib.moderncmakedomain
+except ImportError:
+    pass
+else:
+    extensions += [ 'sphinxcontrib.moderncmakedomain' ]
+    primary_domain = 'cmake'
+
 # Only use SVG converter when it is really needed, e.g. LaTeX.
 if tags.has("svgconvert"):
     extensions.append('sphinxcontrib.rsvgconverter')

--- a/doc/zephyr-cmake.rst
+++ b/doc/zephyr-cmake.rst
@@ -1,0 +1,16 @@
+.. See https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html#cmake-domain
+   and https://pypi.org/project/sphinxcontrib-moderncmakedomain/
+
+.. output of this file is in doc/_build/html/zephyr-cmake.html
+
+.. cmake-module:: ../cmake/CMakeLists.txt
+
+.. cmake-module:: ../cmake/app/boilerplate.cmake
+
+.. cmake-module:: ../cmake/extensions.cmake
+
+.. Purposedly broken cmake-module command to trigger a harmless warning
+   that can be used as an anchor in the ocean of warnings in the logs
+   - and help see which other commands above were quiet hence successful.
+
+.. cmake-moduleXX ../I_WAS_HERE/CMakeLists.txt


### PR DESCRIPTION
Quick and dirty proof of concept to (hopefully) get some feedback.

Related to issue #9947

Includes a test hack to disable doxygen and reduce the build time to
less than 10 seconds.  To test on Linux:

   SPHINXOPTS=-v make htmldocs-fast

Output in:

   doc/_build/html/zephyr-cmake.html

Signed-off-by: Marc Herbert <marc.herbert@intel.com>