### PR TITLE
drivers: spi: added break in switch of function push_data

### DIFF
--- a/drivers/spi/spi_intel.c
+++ b/drivers/spi/spi_intel.c
@@ -96,6 +96,7 @@ static void push_data(struct device *dev)
 			case 1:
 				data = UNALIGNED_GET((u8_t *)
 						     (spi->ctx.tx_buf));
+				break;
 			case 2:
 				data = UNALIGNED_GET((u16_t *)
 						     (spi->ctx.tx_buf));


### PR DESCRIPTION
I added a new break statement in case 1

Before I thought that maybe it is good idea to make case 1 by default,
but it will be useless, so I decided to add break in case 1 instead of
making it by default:
Now switch part of the function must run like classic switch.

Coverity-CID: 190978
Fixes: #13842 

Signed-off-by: Maksim Masalski <maxxliferobot@gmail.com>