### PR TITLE
kconfig: Remove redundant 'default n' properties

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -260,7 +260,6 @@ menu "Interrupt Configuration"
 #
 config DYNAMIC_INTERRUPTS
 	bool "Enable installation of IRQs at runtime"
-	default n
 	help
 	  Enable installation of interrupts at runtime, which will move some
 	  interrupt-related data structures to RAM instead of ROM, and

--- a/arch/x86_64/Kconfig
+++ b/arch/x86_64/Kconfig
@@ -3,7 +3,6 @@ config ARCH
 
 config XUK_DEBUG
 	bool "Debug logging at lowest level"
-	default n
 	help
 	  When true, enables debug logging from the XUK layer in very
 	  early boot situations (including the 16 and 32 bit stub

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -368,7 +368,6 @@ config CLOCK_STM32_PLL_R_DIVISOR
 
 config CLOCK_STM32_LSE
 	bool "Low-speed external clock"
-	default n
 	help
 	  Enable the low-speed external (LSE) clock supplied with a 32.768 kHz
 	  crystal resonator oscillator.
@@ -376,7 +375,6 @@ config CLOCK_STM32_LSE
 config CLOCK_STM32_MSI_PLL_MODE
 	bool "MSI PLL MODE"
 	depends on CLOCK_STM32_LSE
-	default n
 	help
 	  Enable hardware auto-calibration with LSE.
 

--- a/drivers/i2s/Kconfig.stm32
+++ b/drivers/i2s/Kconfig.stm32
@@ -9,7 +9,6 @@ menuconfig I2S_STM32
 	bool "STM32 MCU I2S controller driver"
 	depends on I2S && SOC_SERIES_STM32F4X
 	select DMA
-	default n
 	help
 	  Enable I2S support on the STM32 family of processors.
 	  (Tested on the STM32F4 series)
@@ -26,7 +25,6 @@ config I2S_STM32_TX_BLOCK_COUNT
 
 config I2S_STM32_USE_PLLI2S_ENABLE
 	bool "Enable usage of PLL"
-	default n
 	help
 	  Enable it if I2S clock should be provided by the PLLI2S.
 	  If not enabled the clock will be provided by HSI/HSE.
@@ -65,33 +63,28 @@ config I2S_STM32_PLLI2S_PLLR
 	  frequency is less than or equal to 192MHz.
 	  Allowed values: 2-7
 
-config	I2S_1
+config I2S_1
 	bool "I2S port 1"
-	default n
 	help
 	  Enable I2S controller port 1.
 
-config	I2S_2
+config I2S_2
 	bool "I2S port 2"
-	default n
 	help
 	  Enable I2S controller port 2.
 
-config	I2S_3
+config I2S_3
 	bool "I2S port 3"
-	default n
 	help
 	  Enable I2S controller port 3.
 
-config	I2S_4
+config I2S_4
 	bool "I2S port 4"
-	default n
 	help
 	  Enable I2S controller port 4.
 
-config	I2S_5
+config I2S_5
 	bool "I2S port 5"
-	default n
 	help
 	  Enable I2S controller port 5.
 

--- a/drivers/ipm/Kconfig
+++ b/drivers/ipm/Kconfig
@@ -26,7 +26,6 @@ config IPM_MCUX
 
 config IPM_IMX
 	bool "IMX IPM driver"
-	default n
 	depends on IPM && HAS_IMX_HAL
 	help
 	  Driver for NXP i.MX messaging unit

--- a/drivers/watchdog/Kconfig.stm32
+++ b/drivers/watchdog/Kconfig.stm32
@@ -16,7 +16,6 @@ menuconfig IWDG_STM32
 config IWDG_STM32_START_AT_BOOT
 	bool "Start IWDG during boot"
 	depends on IWDG_STM32
-	default n
 	help
 	  Enable this setting to allow IWDG to be automatically started
 	  during device initialization. Note that once IWDG is started

--- a/ext/hal/microchip/Kconfig
+++ b/ext/hal/microchip/Kconfig
@@ -4,4 +4,3 @@
 
 menuconfig HAS_MEC_HAL
 	bool "Microchip MEC HAL drivers support"
-	default n

--- a/lib/cmsis_rtos_v1/Kconfig
+++ b/lib/cmsis_rtos_v1/Kconfig
@@ -5,7 +5,6 @@
 #
 config CMSIS_RTOS_V1
 	bool "CMSIS RTOS v1 API"
-	default n
 	depends on THREAD_CUSTOM_DATA
 	depends on POLL
 	help

--- a/lib/cmsis_rtos_v2/Kconfig
+++ b/lib/cmsis_rtos_v2/Kconfig
@@ -5,7 +5,6 @@
 #
 config CMSIS_RTOS_V2
 	bool "CMSIS RTOS v2 API"
-	default n
 	depends on POLL
 	depends on THREAD_NAME
 	depends on THREAD_STACK_INFO

--- a/soc/arm/cypress/Kconfig
+++ b/soc/arm/cypress/Kconfig
@@ -21,10 +21,9 @@ endchoice
 
 config SOC_FAMILY_PSOC6
 	bool
-	# omit prompt to signify a "hidden" option
-	default n
 
 if SOC_FAMILY_PSOC6
+
 config SOC_FAMILY
 	string
 	default "cypress"

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -157,7 +157,6 @@ config BT_SETTINGS
 if BT_SETTINGS
 config BT_SETTINGS_CCC_STORE_ON_WRITE
 	bool "Store CCC value immediately after it has been written"
-	default n
 	help
 	  Store Client Configuration Characteristic value right after it has
 	  been updated.
@@ -371,7 +370,6 @@ config BT_GATT_CACHING
 
 config BT_GATT_ENFORCE_CHANGE_UNAWARE
 	bool "GATT Enforce change-unaware state"
-	default n
 	depends on BT_GATT_CACHING
 	help
 	 When enable this option blocks notification and indications to client

--- a/subsys/bluetooth/services/Kconfig.dis
+++ b/subsys/bluetooth/services/Kconfig.dis
@@ -7,7 +7,6 @@
 
 menuconfig BT_GATT_DIS
 	bool "Enable GATT Device Information service"
-	default n
 
 if BT_GATT_DIS
 

--- a/subsys/debug/Kconfig.segger
+++ b/subsys/debug/Kconfig.segger
@@ -10,7 +10,6 @@ config HAS_SEGGER_RTT
 config USE_SEGGER_RTT
 	bool "Enable SEGGER RTT libraries."
 	depends on HAS_SEGGER_RTT
-	default n
 	help
 	  Enable Segger J-Link RTT libraries for platforms that support it.
 	  Selection of this option enables use of RTT for various subsytems.
@@ -28,7 +27,6 @@ config SEGGER_SYSTEMVIEW
 config SEGGER_SYSTEMVIEW_BOOT_ENABLE
 	bool "Start logging SystemView events on system start"
 	depends on SEGGER_SYSTEMVIEW
-	default n
 
 config SEGGER_SYSVIEW_RTT_BUFFER_SIZE
 	int "Buffer size for SystemView RTT"

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -435,7 +435,6 @@ endif # LOG_BACKEND_RTT
 config LOG_BACKEND_NATIVE_POSIX
 	bool "Enable native backend"
 	depends on ARCH_POSIX
-	default n
 	help
 	  Enable backend in native_posix
 

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -474,7 +474,6 @@ config NET_BUF_DATA_POOL_SIZE
 
 config NET_HEADERS_ALWAYS_CONTIGUOUS
 	bool
-	default n
 	help
 	  This a hidden option, which one should use with a lot of care.
 	  NO bug reports will be accepted if that option is enabled!

--- a/subsys/net/ip/Kconfig.debug
+++ b/subsys/net/ip/Kconfig.debug
@@ -38,7 +38,6 @@ config NET_DEBUG_NET_PKT_EXTERNALS
 
 config NET_DEBUG_NET_PKT_NON_FRAGILE_ACCESS
 	bool "Reduce r/w fragility by resetting the packet cursor when freed"
-	default n
 	select NET_DEBUG_NET_PKT_ALLOC
 	help
 	  This MUST not be used unless you have an hard to catch bug. This will

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -39,7 +39,6 @@ config NET_IF_MCAST_IPV4_ADDR_COUNT
 
 config NET_ICMPV4_ACCEPT_BROADCAST
 	bool "Accept broadcast ICMPv4 echo-request"
-	default n
 	help
 	  If set, then respond to ICMPv4 echo-request that is sent to
 	  broadcast address.

--- a/subsys/net/l2/ethernet/lldp/Kconfig
+++ b/subsys/net/l2/ethernet/lldp/Kconfig
@@ -8,7 +8,6 @@ menu "Link Layer Discovery Protocol (LLDP) options"
 
 config NET_LLDP
 	bool "Enable LLDP"
-	default n
 	depends on NET_L2_ETHERNET
 	select NET_MGMT
 	select NET_MGMT_EVENT

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -40,7 +40,6 @@ config HAS_COVERAGE_SUPPORT
 config COVERAGE
 	bool "Create coverage data"
 	depends on HAS_COVERAGE_SUPPORT
-	default n
 	help
 	  This option will build your application with the -coverage option
 	  which will generate data that can be used to create coverage reports.


### PR DESCRIPTION
Some more were added since the cleanup pass in June 2018. See e.g.
commit 2d50da70a1 ("drivers: ipm: Kconfig: Remove redundant 'default n'
properties") for a motivation. It also avoids people wondering whether
or not they need to put in 'default n', and thinking it might make a difference.