### PR TITLE
kconfig: Use a short consistent prompt style

### DIFF
--- a/drivers/counter/Kconfig.qmsi
+++ b/drivers/counter/Kconfig.qmsi
@@ -53,15 +53,13 @@ config RTC_QMSI
 if RTC_QMSI
 
 config RTC_QMSI_API_REENTRANCY
-	bool
-	prompt "RTC shim driver API reentrancy"
+	bool "RTC shim driver API reentrancy"
 	help
 	  Enable support for RTC shim driver API reentrancy.
 
 config RTC_PRESCALER
-	int
+	int "Prescaler size"
 	default 1
-	prompt "Prescaler size"
 	help
 	  RTC prescaler used to determine ticks per second
 

--- a/drivers/display/Kconfig.ssd1673
+++ b/drivers/display/Kconfig.ssd1673
@@ -21,8 +21,7 @@ choice
 	  Specify the type of EPD connected to the SSD1673 controller.
 
 config SSD1673_EPD_GDE0213B1
-	bool
-	prompt "GDE0213B1 2.13\""
+	bool "GDE0213B1 2.13\""
 
 endchoice
 

--- a/drivers/ethernet/Kconfig.e1000
+++ b/drivers/ethernet/Kconfig.e1000
@@ -7,8 +7,7 @@
 #
 
 menuconfig ETH_E1000
-	bool
-	prompt "Intel(R) PRO/1000 Gigabit Ethernet driver"
+	bool "Intel(R) PRO/1000 Gigabit Ethernet driver"
 	depends on NET_L2_ETHERNET && PCI_ENUMERATION
 	help
 	  Enable Intel(R) PRO/1000 Gigabit Ethernet driver.

--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -6,8 +6,7 @@
 
 
 menuconfig SPI_NOR
-	bool
-	prompt "SPI NOR Flash"
+	bool "SPI NOR Flash"
 	select FLASH_HAS_DRIVER_ENABLED
 	depends on SPI && FLASH
 

--- a/drivers/neural_net/Kconfig
+++ b/drivers/neural_net/Kconfig
@@ -6,8 +6,7 @@
 #
 
 menuconfig NEURAL_NET_ACCEL
-	bool
-	prompt "Neural Network Accelerator Drivers"
+	bool "Neural Network Accelerator Drivers"
 	help
 	  Enable support for Neural Network Accelerators
 

--- a/drivers/neural_net/Kconfig.intel_gna
+++ b/drivers/neural_net/Kconfig.intel_gna
@@ -6,8 +6,7 @@
 #
 
 menuconfig INTEL_GNA
-	bool
-	prompt "Intel GNA Inferencing Engine"
+	bool "Intel GNA Inferencing Engine"
 	help
 	  Enable support for Intel's GMM and Neural Network Accelerator
 

--- a/ext/lib/fnmatch/Kconfig
+++ b/ext/lib/fnmatch/Kconfig
@@ -5,8 +5,7 @@
 #
 
 config FNMATCH
-	bool
-	prompt "Fnmatch Support"
+	bool "Fnmatch Support"
 	help
 	  This option enables the fnmatch library
 

--- a/ext/lib/mgmt/mcumgr/cmd/os_mgmt/Kconfig
+++ b/ext/lib/mgmt/mcumgr/cmd/os_mgmt/Kconfig
@@ -16,16 +16,14 @@
 # Under the License.
 
 menuconfig MCUMGR_CMD_OS_MGMT
-    bool
-    prompt "Enable mcumgr handlers for OS management"
+    bool "Enable mcumgr handlers for OS management"
     select REBOOT
     help
       Enables mcumgr handlers for OS management
 
 if MCUMGR_CMD_OS_MGMT
 config OS_MGMT_RESET_MS
-    int
-    prompt "Delay before executing reset command (ms)"
+    int "Delay before executing reset command (ms)"
     default 250
     help
       When a reset command is received, the system waits this many milliseconds

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -88,8 +88,7 @@ config BT_CTLR_DUP_FILTER_LEN
 	  duplicates while scanning.
 
 config BT_CTLR_MESH_SCAN_FILTERS
-	prompt "Number of Mesh scan filters"
-	int
+	int "Number of Mesh scan filters"
 	depends on BT_HCI_MESH_EXT
 	default 1
 	range 1 15
@@ -98,8 +97,7 @@ config BT_CTLR_MESH_SCAN_FILTERS
 	  the Intel Mesh Vendor Specific Extensions.
 
 config BT_CTLR_MESH_SF_PATTERNS
-	prompt "Number of Mesh scan filter patterns"
-	int
+	int "Number of Mesh scan filter patterns"
 	depends on BT_HCI_MESH_EXT
 	default 15
 	range 1 15
@@ -338,9 +336,8 @@ config BT_CTLR_ADV_EXT
 	  Controller.
 
 config BT_ADV_SET
-	prompt "LE Advertising Extensions Sets"
+	int "LE Advertising Extensions Sets"
 	depends on BT_CTLR_ADV_EXT
-	int
 	default 1
 	help
 	  Maximum supported advertising sets.
@@ -365,8 +362,7 @@ menu "Advanced features"
 	visible if BT_CTLR_ADVANCED_FEATURES
 
 config BT_CTLR_FILTER
-	prompt "Device Whitelist Support"
-	bool
+	bool "Device Whitelist Support"
 	default y
 	help
 	  Enable support for controller device whitelist feature
@@ -477,8 +473,7 @@ config BT_CTLR_SCHED_ADVANCED
 
 if BT_LL_SW_SPLIT
 config BT_CTLR_LLL_PRIO
-	prompt "Lower Link Layer (Radio) IRQ priority"
-	int
+	int "Lower Link Layer (Radio) IRQ priority"
 	range 0 3 if SOC_SERIES_NRF51X
 	range 0 6 if SOC_SERIES_NRF52X
 	default 0
@@ -486,8 +481,7 @@ config BT_CTLR_LLL_PRIO
 	  The interrupt priority for event preparation and radio IRQ.
 
 config BT_CTLR_ULL_HIGH_PRIO
-	prompt "Upper Link Layer High IRQ priority"
-	int
+	int "Upper Link Layer High IRQ priority"
 	range BT_CTLR_LLL_PRIO 3 if SOC_SERIES_NRF51X
 	range BT_CTLR_LLL_PRIO 6 if SOC_SERIES_NRF52X
 	default 0
@@ -496,8 +490,7 @@ config BT_CTLR_ULL_HIGH_PRIO
 	  higher priority functions.
 
 config BT_CTLR_ULL_LOW_PRIO
-	prompt "Upper Link Layer Low IRQ priority"
-	int
+	int "Upper Link Layer Low IRQ priority"
 	range BT_CTLR_ULL_HIGH_PRIO 3 if SOC_SERIES_NRF51X
 	range BT_CTLR_ULL_HIGH_PRIO 6 if SOC_SERIES_NRF52X
 	default 0
@@ -506,8 +499,7 @@ config BT_CTLR_ULL_LOW_PRIO
 	  lower priority functions.
 
 config BT_CTLR_LOWEST_PRIO
-	prompt "Link Layer Lowest IRQ priority"
-	int
+	int "Link Layer Lowest IRQ priority"
 	range BT_CTLR_ULL_LOW_PRIO 3 if SOC_SERIES_NRF51X
 	range BT_CTLR_ULL_LOW_PRIO 6 if SOC_SERIES_NRF52X
 	default 0
@@ -515,8 +507,7 @@ config BT_CTLR_LOWEST_PRIO
 	  The interrupt priority for RNG and other non-critical functions.
 
 config BT_CTLR_LOW_LAT
-	prompt "Low latency non-negotiating event pre-emption"
-	bool
+	bool "Low latency non-negotiating event pre-emption"
 	default y if SOC_SERIES_NRF51X
 	help
 	  Use low latency non-negotiating event pre-emption. This reduces
@@ -689,31 +680,27 @@ config BT_CTLR_PA_LNA_GPIOTE_CHAN
 
 if BT_LL_SW_SPLIT
 config BT_TMP
-	prompt "Temporary Role"
+	bool "Temporary Role"
 	depends on BT_SHELL
-	bool
 	default y
 	help
 	  Temporary role to manual test ULL/LLL split architecture.
 
 if BT_TMP
 config BT_TMP_MAX
-	prompt "Temporary Role Max. Instances"
-	int
+	int "Temporary Role Max. Instances"
 	default 3
 	help
 	  Maximum supported Temporary role instances.
 
 config BT_TMP_TX_SIZE_MAX
-	prompt "Temporary Role Max. Tx buffer size"
-	int
+	int "Temporary Role Max. Tx buffer size"
 	default 10
 	help
 	  Temporary role's maximum transmit buffer size in bytes.
 
 config BT_TMP_TX_COUNT_MAX
-	prompt "Temporary Role Max. Tx buffers"
-	int
+	int "Temporary Role Max. Tx buffers"
 	default 1
 	help
 	  Temporary role's maximum transmit buffer count.

--- a/subsys/usb/class/hid/Kconfig
+++ b/subsys/usb/class/hid/Kconfig
@@ -36,8 +36,7 @@ config USB_HID_DEVICE_NAME_1
 endif # USB_COMPOSITE_DEVICE
 
 config ENABLE_HID_INT_OUT_EP
-	bool
-	prompt "Enable USB HID Device Interrupt OUT Endpoint"
+	bool "Enable USB HID Device Interrupt OUT Endpoint"
 	help
 	  Enable USB HID Device Interrupt OUT Endpoint.
 
@@ -68,8 +67,7 @@ config USB_HID_REPORTS
 	  Must be equal or higher than highest report ID (if they are not consecutive).
 
 config USB_HID_BOOT_PROTOCOL
-	bool
-	prompt "Enable USB HID Boot Protocol handling"
+	bool "Enable USB HID Boot Protocol handling"
 	help
 	  Sets bInterfaceSubClass to 1 and enables Set_Protocol and Get_Protocol
 	  requests handling.


### PR DESCRIPTION
Same change as in commit 8cf8db3a73 ("Kconfig: Use a short, consistent
style for prompts"), fixing stuff that got introduced since then.