### PR TITLE
soc: intel_s1000: make zephyr_prebuilt.elf a lot smaller

### DIFF
--- a/soc/xtensa/intel_s1000/memory.h
+++ b/soc/xtensa/intel_s1000/memory.h
@@ -63,7 +63,7 @@
  * Interrupt Descriptor Table (IDT). This is a bogus address as this
  * section will be stripped off in the final image.
  */
-#define IDT_BASE				0xFFFFF7FF
+#define IDT_BASE				(RAM_BASE + RAM_SIZE)
 
 /* size of the Interrupt Descriptor Table (IDT) */
 #define IDT_SIZE				0x2000


### PR DESCRIPTION
Due to fake IDT_BASE address, zephyr_prebuilt.elf is about 1.1GB
in size due to all the empty space between end of SRAM and IDT_BASE.
So move the IDT_BASE to the empty space just after SRAM. The section
will be discarded in the final zephyr.elf so it should not be a big
issue. After this change, zephyr_prebuilt.elf is now a bit smaller
than 5MB.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>