### PR TITLE
arch: arc: Replace CONFIG_APP_SHARED_MEM with CONFIG_USERSPACE

### DIFF
--- a/arch/arc/core/mpu/arc_mpu.c
+++ b/arch/arc/core/mpu/arc_mpu.c
@@ -461,7 +461,7 @@ void arc_core_mpu_configure_user_context(struct k_thread *thread)
 
 	arc_core_mpu_configure(THREAD_STACK_USER_REGION, base, size);
 
-#if defined(CONFIG_APP_SHARED_MEM) && CONFIG_ARC_MPU_VER == 3
+#if defined(CONFIG_USERSPACE) && CONFIG_ARC_MPU_VER == 3
 	/*
 	 * here, need to clear THREAD_APP_DATA_REGION for user thread as it will
 	 * be set by kernel thread to to access app_shared mem. For user thread


### PR DESCRIPTION
CONFIG_APP_SHARED_MEM was removed in commit 4ce652e4b2 ("userspace: remove APP_SHARED_MEM Kconfig").