### PR TITLE
tests: Enable kernel.device test for qemu_x86_64

### DIFF
--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -1,11 +1,12 @@
 common:
   tags: device
-  platform_whitelist: native_posix qemu_x86
 tests:
   kernel.device:
     tags: device
+    platform_whitelist: native_posix qemu_x86 qemu_x86_64
   kernel.device.pm:
     tags: device
     extra_configs:
       - CONFIG_DEVICE_POWER_MANAGEMENT=y
+    platform_whitelist: native_posix qemu_x86 #cannot run on qemu_x86_64 yet
 


### PR DESCRIPTION
Reworked platform_whitelist to enable the "test kernel.device" for
qemu_x86_64

kernel.device.pm is not yet enabled for qemu_x86_64 because
there is a link error

   undefined symbol `_DEVICE_STRUCT_SIZEOF'
   referenced in expression

Signed-off-by: Cinly Ooi <cinly.ooi@intel.com>