### PR TITLE
boards: mimxrt1020_evk: Add jlinkscript init file

### DIFF
--- a/boards/arm/mimxrt1020_evk/board.cmake
+++ b/boards/arm/mimxrt1020_evk/board.cmake
@@ -15,7 +15,7 @@ elseif(OPENSDA_FW STREQUAL daplink)
 endif()
 
 board_runner_args(pyocd "--target=mimxrt1020")
-board_runner_args(jlink "--device=MIMXRT1021xxx5A")
+board_runner_args(jlink "--device=MIMXRT1021xxx5A" "--jlinkscriptfile=${ZEPHYR_BASE}/boards/arm/mimxrt1020_evk/evkmimxrt1020_sdram_init.jlinkscript")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/mimxrt1020_evk/evkmimxrt1020_sdram_init.jlinkscript
+++ b/boards/arm/mimxrt1020_evk/evkmimxrt1020_sdram_init.jlinkscript
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2017 NXP
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+void Clock_Init()
+{
+  unsigned int reg;
+  // Enable all clocks
+  MEM_WriteU32(0x400FC068,0xffffffff);
+  MEM_WriteU32(0x400FC06C,0xffffffff);
+  MEM_WriteU32(0x400FC070,0xffffffff);
+  MEM_WriteU32(0x400FC074,0xffffffff);
+  MEM_WriteU32(0x400FC078,0xffffffff);
+  MEM_WriteU32(0x400FC07C,0xffffffff);
+  MEM_WriteU32(0x400FC080,0xffffffff);
+
+  // Enable SYS PLL
+  MEM_WriteU32(0x400D8030,0x00002001);
+  do
+  {
+    reg = MEM_ReadU32(0x400D8030);
+  } while((reg & 0x80000000) == 0);
+
+  // Ungate SYS PLL PFD2
+  reg = MEM_ReadU32(0x400D8100);
+  reg &= ~0x00800000;
+  MEM_WriteU32(0x400D8100, reg);
+
+  // SEMC clock source selection
+  // SDRAM running at 133Mhz
+  // CBCDR:
+  //   SEMC_ALT_CLK_SEL: 0 PLL2 (SYS PLL) PFD2
+  //   SEMC_CLK_SEL: 1 SEMC_ALT_CLK
+  //   SEMC_PODF: 2 divided by 3
+  reg = MEM_ReadU32(0x400FC014);
+  reg |= 0x40;
+  MEM_WriteU32(0x400FC014, reg);
+
+  // Disable MPU which will be enabled by ROM to prevent code execution
+  reg = MEM_ReadU32(0xE000ED94);
+  reg &= ~0x1;
+  MEM_WriteU32(0xE000ED94, reg);
+
+  Report("Clock Init Done");
+}
+
+void SDRAM_WaitIpCmdDone(void)
+{
+  unsigned int reg;
+  do
+  {
+      reg = MEM_ReadU32(0x402F003C);
+  }while((reg & 0x3) == 0);
+}
+
+void SDRAM_Init() {
+  // Config IOMUX for SDRAM
+  MEM_WriteU32(0x401F8014,0x00000000); // EMC_00
+  MEM_WriteU32(0x401F8018,0x00000000); // EMC_01
+  MEM_WriteU32(0x401F801C,0x00000000); // EMC_02
+  MEM_WriteU32(0x401F8020,0x00000000); // EMC_03
+  MEM_WriteU32(0x401F8024,0x00000000); // EMC_04
+  MEM_WriteU32(0x401F8028,0x00000000); // EMC_05
+  MEM_WriteU32(0x401F802C,0x00000000); // EMC_06
+  MEM_WriteU32(0x401F8030,0x00000000); // EMC_07
+  MEM_WriteU32(0x401F8034,0x00000000); // EMC_08
+  MEM_WriteU32(0x401F8038,0x00000000); // EMC_09
+  MEM_WriteU32(0x401F803C,0x00000000); // EMC_10
+  MEM_WriteU32(0x401F8040,0x00000000); // EMC_11
+  MEM_WriteU32(0x401F8044,0x00000000); // EMC_12
+  MEM_WriteU32(0x401F8048,0x00000000); // EMC_13
+  MEM_WriteU32(0x401F804C,0x00000000); // EMC_14
+  MEM_WriteU32(0x401F8050,0x00000000); // EMC_15
+  MEM_WriteU32(0x401F8054,0x00000000); // EMC_16
+  MEM_WriteU32(0x401F8058,0x00000000); // EMC_17
+  MEM_WriteU32(0x401F805C,0x00000000); // EMC_18
+  MEM_WriteU32(0x401F8060,0x00000000); // EMC_19
+  MEM_WriteU32(0x401F8064,0x00000000); // EMC_20
+  MEM_WriteU32(0x401F8068,0x00000000); // EMC_21
+  MEM_WriteU32(0x401F806C,0x00000000); // EMC_22
+  MEM_WriteU32(0x401F8070,0x00000000); // EMC_23
+  MEM_WriteU32(0x401F8074,0x00000000); // EMC_24
+  MEM_WriteU32(0x401F8078,0x00000000); // EMC_25
+  MEM_WriteU32(0x401F807C,0x00000000); // EMC_26
+  MEM_WriteU32(0x401F8080,0x00000000); // EMC_27
+  MEM_WriteU32(0x401F8084,0x00000010); // EMC_28, DQS PIN, enable SION
+  MEM_WriteU32(0x401F8088,0x00000000); // EMC_29
+  MEM_WriteU32(0x401F808C,0x00000000); // EMC_30
+  MEM_WriteU32(0x401F8090,0x00000000); // EMC_31
+  MEM_WriteU32(0x401F8094,0x00000000); // EMC_32
+  MEM_WriteU32(0x401F8098,0x00000000); // EMC_33
+  MEM_WriteU32(0x401F809C,0x00000000); // EMC_34
+  MEM_WriteU32(0x401F80A0,0x00000000); // EMC_35
+  MEM_WriteU32(0x401F80A4,0x00000000); // EMC_36
+  MEM_WriteU32(0x401F80A8,0x00000000); // EMC_37
+  MEM_WriteU32(0x401F80AC,0x00000000); // EMC_38
+  MEM_WriteU32(0x401F80B0,0x00000000); // EMC_39
+  MEM_WriteU32(0x401F80B4,0x00000000); // EMC_40
+  MEM_WriteU32(0x401F80B8,0x00000000); // EMC_41
+
+  // PAD ctrl
+  // drive strength = 0x7 to increase drive strength
+  // otherwise the data7 bit may fail.
+  MEM_WriteU32(0x401F8204,0x000000F1); // EMC_00
+  MEM_WriteU32(0x401F8208,0x000000F1); // EMC_01
+  MEM_WriteU32(0x401F820C,0x000000F1); // EMC_02
+  MEM_WriteU32(0x401F8210,0x000000F1); // EMC_03
+  MEM_WriteU32(0x401F8214,0x000000F1); // EMC_04
+  MEM_WriteU32(0x401F8218,0x000000F1); // EMC_05
+  MEM_WriteU32(0x401F821C,0x000000F1); // EMC_06
+  MEM_WriteU32(0x401F8220,0x000000F1); // EMC_07
+  MEM_WriteU32(0x401F8224,0x000000F1); // EMC_08
+  MEM_WriteU32(0x401F8228,0x000000F1); // EMC_09
+  MEM_WriteU32(0x401F822C,0x000000F1); // EMC_10
+  MEM_WriteU32(0x401F8230,0x000000F1); // EMC_11
+  MEM_WriteU32(0x401F8234,0x000000F1); // EMC_12
+  MEM_WriteU32(0x401F8238,0x000000F1); // EMC_13
+  MEM_WriteU32(0x401F823C,0x000000F1); // EMC_14
+  MEM_WriteU32(0x401F8240,0x000000F1); // EMC_15
+  MEM_WriteU32(0x401F8244,0x000000F1); // EMC_16
+  MEM_WriteU32(0x401F8248,0x000000F1); // EMC_17
+  MEM_WriteU32(0x401F824C,0x000000F1); // EMC_18
+  MEM_WriteU32(0x401F8250,0x000000F1); // EMC_19
+  MEM_WriteU32(0x401F8254,0x000000F1); // EMC_20
+  MEM_WriteU32(0x401F8258,0x000000F1); // EMC_21
+  MEM_WriteU32(0x401F825C,0x000000F1); // EMC_22
+  MEM_WriteU32(0x401F8260,0x000000F1); // EMC_23
+  MEM_WriteU32(0x401F8264,0x000000F1); // EMC_24
+  MEM_WriteU32(0x401F8268,0x000000F1); // EMC_25
+  MEM_WriteU32(0x401F826C,0x000000F1); // EMC_26
+  MEM_WriteU32(0x401F8270,0x000000F1); // EMC_27
+  MEM_WriteU32(0x401F8274,0x000000F1); // EMC_28
+  MEM_WriteU32(0x401F8278,0x000000F1); // EMC_29
+  MEM_WriteU32(0x401F827C,0x000000F1); // EMC_30
+  MEM_WriteU32(0x401F8280,0x000000F1); // EMC_31
+  MEM_WriteU32(0x401F8284,0x000000F1); // EMC_32
+  MEM_WriteU32(0x401F8288,0x000000F1); // EMC_33
+  MEM_WriteU32(0x401F828C,0x000000F1); // EMC_34
+  MEM_WriteU32(0x401F8290,0x000000F1); // EMC_35
+  MEM_WriteU32(0x401F8294,0x000000F1); // EMC_36
+  MEM_WriteU32(0x401F8298,0x000000F1); // EMC_37
+  MEM_WriteU32(0x401F829C,0x000000F1); // EMC_38
+  MEM_WriteU32(0x401F82A0,0x000000F1); // EMC_39
+  MEM_WriteU32(0x401F82A4,0x000000F1); // EMC_40
+  MEM_WriteU32(0x401F82A8,0x000000F1); // EMC_41
+
+  // Config SDR Controller Registers/
+  MEM_WriteU32(0x402F0000,0x10000004); // MCR
+  MEM_WriteU32(0x402F0008,0x00030524); // BMCR0
+  MEM_WriteU32(0x402F000C,0x06030524); // BMCR1
+  MEM_WriteU32(0x402F0010,0x8000001B); // BR0, 32MB
+  MEM_WriteU32(0x402F0014,0x8200001B); // BR1, 32MB
+  MEM_WriteU32(0x402F0018,0x8400001B); // BR2, 32MB
+  MEM_WriteU32(0x402F001C,0x8600001B); // BR3, 32MB
+  MEM_WriteU32(0x402F0020,0x90000021); // BR4,
+  MEM_WriteU32(0x402F0024,0xA0000019); // BR5,
+  MEM_WriteU32(0x402F0028,0xA8000017); // BR6,
+  MEM_WriteU32(0x402F002C,0xA900001B); // BR7,
+  MEM_WriteU32(0x402F0030,0x00000021); // BR8,
+  MEM_WriteU32(0x402F0004,0x000079A8);  //IOCR,SEMC_CCSX0 as NOR CE, SEMC_CSX1 as PSRAM CE, SEMC_CSX2 as NAND CE, SEMC_CSX3 as DBI CE.
+
+  // MEM_WriteU32(0x402F0004,0x00000008); // IOCR, SEMC_CCSX0 as SDRAM_CS1
+  MEM_WriteU32(0x402F0040,0x00000F31); // SDRAMCR0
+  MEM_WriteU32(0x402F0044,0x00652922); // SDRAMCR1
+  MEM_WriteU32(0x402F0048,0x00010920); // SDRAMCR2
+  MEM_WriteU32(0x402F004C,0x50210A09); // SDRAMCR3
+
+  MEM_WriteU32(0x402F0080,0x00000021); // DBICR0
+  MEM_WriteU32(0x402F0084,0x00888888); // DBICR1
+  MEM_WriteU32(0x402F0094,0x00000002); // IPCR1
+  MEM_WriteU32(0x402F0098,0x00000000); // IPCR2
+
+  MEM_WriteU32(0x402F0090,0x80000000); // IPCR0
+  MEM_WriteU32(0x402F009C,0xA55A000F); // IPCMD, SD_CC_IPREA
+  SDRAM_WaitIpCmdDone();
+  MEM_WriteU32(0x402F0090,0x80000000); // IPCR0
+  MEM_WriteU32(0x402F009C,0xA55A000C); // SD_CC_IAF
+  SDRAM_WaitIpCmdDone();
+  MEM_WriteU32(0x402F0090,0x80000000); // IPCR0
+  MEM_WriteU32(0x402F009C,0xA55A000C); // SD_CC_IAF
+  SDRAM_WaitIpCmdDone();
+  MEM_WriteU32(0x402F00A0,0x00000033); // IPTXDAT
+  MEM_WriteU32(0x402F0090,0x80000000); // IPCR0
+  MEM_WriteU32(0x402F009C,0xA55A000A); // SD_CC_IMS
+  SDRAM_WaitIpCmdDone();
+  MEM_WriteU32(0x402F004C,0x50210A09 ); // enable sdram self refresh again after initialization done.
+
+  Report("SDRAM Init Done");
+}
+
+/* ConfigTarget */
+void ConfigTargetSettings(void)
+{
+  Report("Config JTAG Speed to 4000kHz");
+  JTAG_Speed = 4000;
+}
+
+/* SetupTarget */
+void SetupTarget(void) {
+
+  Report("Enabling i.MXRT SDRAM");
+  Clock_Init();
+  SDRAM_Init();
+}
+
+/* ResetTarget */
+void ResetTarget(void) {
+  unsigned int v;
+  unsigned int Tmp;
+  //
+  // J-Link DLL expects CPU to be reset and halted when leaving this function
+  //
+  Report("J-Link script: ResetTarget()");
+  // Read IDCODE
+  v=JLINK_CORESIGHT_ReadDP(0);
+  Report1("DP0: ", v);
+
+  // Power up Debugger
+  JLINK_CORESIGHT_WriteDP(1, 0x50000000);
+  v=JLINK_CORESIGHT_ReadDP(1);
+  Report1("DP1: ", v);
+
+
+  JLINK_CORESIGHT_WriteAP(0, 0x23000042);
+  v=JLINK_CORESIGHT_ReadAP(0);
+  Report1("AHB-AP0: ", v);
+
+  JLINK_CORESIGHT_WriteAP(1, 0xE000EDF0);
+  v=JLINK_CORESIGHT_ReadAP(1);
+  Report1("AHB-AP1: ", v);
+  v=JLINK_CORESIGHT_ReadAP(3);
+  Report1("AHB-AP3: ", v);
+  JLINK_CORESIGHT_WriteAP(3, 0xa05f0003);
+  v=JLINK_CORESIGHT_ReadAP(3);
+  Report1("AHB-AP3: ", v);
+
+  Clock_Init();
+  SDRAM_Init();
+}

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -24,7 +24,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                  flash_addr=0x0, erase=True,
                  iface='swd', speed='auto',
                  gdbserver='JLinkGDBServer', gdb_port=DEFAULT_JLINK_GDB_PORT,
-                 tui=False):
+                 tui=False, jlinkscriptfile=''):
         super(JLinkBinaryRunner, self).__init__(cfg)
         self.bin_name = cfg.bin_file
         self.elf_name = cfg.elf_file
@@ -38,6 +38,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         self.speed = speed
         self.gdb_port = gdb_port
         self.tui_arg = ['-tui'] if tui else []
+        self.jlinkscriptfile = jlinkscriptfile
 
     @classmethod
     def name(cls):
@@ -69,6 +70,11 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                             help='J-Link Commander, default is JLinkExe')
         parser.add_argument('--erase', default=False, action='store_true',
                             help='if given, mass erase flash before loading')
+        parser.add_argument('--jlinkscriptfile', default='',
+                            help='J-Linkscriptfiles are mainly used to connect '
+                                 'to targets which need a special connection '
+                                 'sequence before communication with the core is '
+                                 'possible.')
 
     @classmethod
     def create(cls, cfg, args):
@@ -80,7 +86,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                                  iface=args.iface, speed=args.speed,
                                  gdbserver=args.gdbserver,
                                  gdb_port=args.gdb_port,
-                                 tui=args.tui)
+                                 tui=args.tui,
+                                 jlinkscriptfile=args.jlinkscriptfile)
 
     def print_gdbserver_message(self):
         log.inf('J-Link GDB server running on port {}'.format(self.gdb_port))
@@ -94,6 +101,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                        '-device', self.device,
                        '-silent',
                        '-singlerun'])
+        if self.jlinkscriptfile != '':
+            server_cmd = server_cmd + ['-jlinkscriptfile', self.jlinkscriptfile]
 
         if command == 'flash':
             self.flash(**kwargs)


### PR DESCRIPTION
The mimxrt1020_evk relies on the boot ROM to configure the SRAM but when using the debugger the SRAM is not initialized. J-Link uses an init script to initialize the platform before starting the debug  session.