### PR TITLE
cmake: Rename CMake variable out of the reserved CONFIG_ namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,8 +307,8 @@ if(CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT)
   endif()
 endif()
 
-separate_arguments(CONFIG_COMPILER_OPT_AS_LIST UNIX_COMMAND ${CONFIG_COMPILER_OPT})
-zephyr_compile_options(${CONFIG_COMPILER_OPT_AS_LIST})
+separate_arguments(COMPILER_OPT_AS_LIST UNIX_COMMAND ${CONFIG_COMPILER_OPT})
+zephyr_compile_options(${COMPILER_OPT_AS_LIST})
 
 # TODO: Include arch compiler options at this point.
 

--- a/misc/generated/CMakeLists.txt
+++ b/misc/generated/CMakeLists.txt
@@ -2,11 +2,11 @@ set(CONFIGS_C ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/configs.c)
 
 file(STRINGS
   ${AUTOCONF_H}
-  CONFIG_LIST
+  LIST_OF_CONFIGS
   REGEX "^#define CONFIG_"
   ENCODING "UTF-8"
   )
-foreach (CONFIG ${CONFIG_LIST})
+foreach (CONFIG ${LIST_OF_CONFIGS})
   string(REGEX REPLACE "#define (CONFIG_[A-Z|_|0-9]*) (.*)" "GEN_ABSOLUTE_SYM(\\1, \\2)" CONFIG ${CONFIG})
   string(REGEX REPLACE "\"(.*)\"" "1" CONFIG ${CONFIG})
   set(GEN_ABS_SYM_LIST "${GEN_ABS_SYM_LIST}${CONFIG};\n")


### PR DESCRIPTION
Rename the poorly named CMake variable 'CONFIG_COMPILER_OPT_AS_LIST'
to 'COMPILER_OPT_AS_LIST' to take it out of the Kconfig-reserved
namespace 'CONFIG_*'.

This is a small step towards resolving #12144

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>