### PR TITLE
drivers/serial: ns16550: Remove unused Kconfig symbols

### DIFF
--- a/drivers/serial/Kconfig.ns16550
+++ b/drivers/serial/Kconfig.ns16550
@@ -57,34 +57,6 @@ menuconfig UART_NS16550_PORT_0
 	  This tells the driver to configure the UART port at boot, depending on
 	  the additional configure options below.
 
-if !HAS_DTS
-config UART_NS16550_PORT_0_NAME
-	string "Port 0 Device Name"
-	default "UART_0"
-	depends on UART_NS16550_PORT_0
-	help
-	  This is the device name for UART, and is included in the device
-	  struct.
-
-if !HAS_DTS && !ARC
-config UART_NS16550_PORT_0_IRQ_PRI
-	int "Port 0 Interrupt Priority"
-	default 0
-	depends on UART_NS16550_PORT_0
-	help
-	  The interrupt priority for UART port.
-endif
-
-config UART_NS16550_PORT_0_BAUD_RATE
-	int "Port 0 Baud Rate"
-	default 0
-	depends on UART_NS16550_PORT_0
-	help
-	  The baud rate for UART port to be set to at boot.
-
-	  Leave at 0 to skip initialization.
-endif
-
 config UART_NS16550_PORT_0_OPTIONS
 	int "Port 0 Options"
 	default 0
@@ -113,34 +85,6 @@ menuconfig UART_NS16550_PORT_1
 	help
 	  This tells the driver to configure the UART port at boot, depending on
 	  the additional configure options below.
-
-if !HAS_DTS
-config UART_NS16550_PORT_1_NAME
-	string "Port 1 Device Name"
-	default "UART_1"
-	depends on UART_NS16550_PORT_1
-	help
-	  This is the device name for UART, and is included in the device
-	  struct.
-
-if !HAS_DTS && !ARC
-config UART_NS16550_PORT_1_IRQ_PRI
-	int "Port 1 Interrupt Priority"
-	default 0
-	depends on UART_NS16550_PORT_1
-	help
-	  The interrupt priority for UART port.
-endif
-
-config UART_NS16550_PORT_1_BAUD_RATE
-	int "Port 1 Baud Rate"
-	default 0
-	depends on UART_NS16550_PORT_1
-	help
-	  The baud rate for UART port to be set to at boot.
-
-	  Leave at 0 to skip initialization.
-endif
 
 config UART_NS16550_PORT_1_OPTIONS
 	int "Port 1 Options"

--- a/soc/nios2/nios2f-zephyr/Kconfig.defconfig
+++ b/soc/nios2/nios2f-zephyr/Kconfig.defconfig
@@ -49,8 +49,6 @@ config UART_NS16550_PORT_0
 
 if UART_NS16550_PORT_0
 
-config UART_NS16550_PORT_0_IRQ_PRI
-	default 3
 config UART_NS16550_PORT_0_OPTIONS
 	default 0
 


### PR DESCRIPTION
These symbols are not referenced anywhere. The values always come from DTS, at least if https://github.com/zephyrproject-rtos/zephyr/pull/13760 was correct.