### PR TITLE
samples: sockets: echo_server: Print port number to connect to

### DIFF
--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -105,7 +105,8 @@ static int process_tcp(struct data *data)
 	struct sockaddr_in client_addr;
 	socklen_t client_addr_len = sizeof(client_addr);
 
-	LOG_INF("Waiting for TCP connection (%s)...", data->proto);
+	LOG_INF("Waiting for TCP connection on port %d (%s)...",
+		MY_PORT, data->proto);
 
 	client = accept(data->tcp.sock, (struct sockaddr *)&client_addr,
 			&client_addr_len);

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -89,7 +89,8 @@ static int process_udp(struct data *data)
 	struct sockaddr client_addr;
 	socklen_t client_addr_len;
 
-	NET_INFO("Waiting for UDP packets (%s)...", data->proto);
+	NET_INFO("Waiting for UDP packets on port %d (%s)...",
+		 MY_PORT, data->proto);
 
 	do {
 		client_addr_len = sizeof(client_addr);


### PR DESCRIPTION
We have a great number of samples now, using different port numbers,
etc. Let them be self-documenting and print out port number used.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>