### PR TITLE
Add table-of-contents to network documentation pages

### DIFF
--- a/doc/guides/networking/native_posix_setup.rst
+++ b/doc/guides/networking/native_posix_setup.rst
@@ -3,6 +3,10 @@
 Networking with native_posix board
 ##################################
 
+.. contents::
+    :local:
+    :depth: 2
+
 This page describes how to set up a virtual network between a (Linux) host
 and a Zephyr application running in a native_posix board.
 

--- a/doc/guides/networking/overview.rst
+++ b/doc/guides/networking/overview.rst
@@ -3,6 +3,10 @@
 Overview
 ########
 
+.. contents::
+    :local:
+    :depth: 2
+
 Supported Features
 ******************
 

--- a/doc/guides/networking/qemu_eth_setup.rst
+++ b/doc/guides/networking/qemu_eth_setup.rst
@@ -3,6 +3,10 @@
 Networking with QEMU Ethernet
 #############################
 
+.. contents::
+    :local:
+    :depth: 2
+
 This page describes how to set up a virtual network between a (Linux) host
 and a Zephyr application running in QEMU.
 

--- a/doc/guides/networking/qemu_setup.rst
+++ b/doc/guides/networking/qemu_setup.rst
@@ -3,6 +3,10 @@
 Networking with QEMU
 ####################
 
+.. contents::
+    :local:
+    :depth: 2
+
 This page describes how to set up a virtual network between a (Linux) host
 and a Zephyr application running in a QEMU virtual machine (built for Zephyr
 targets such as qemu_x86 and qemu_cortex_m3).

--- a/doc/guides/networking/usbnet_setup.rst
+++ b/doc/guides/networking/usbnet_setup.rst
@@ -3,6 +3,10 @@
 USB Device Networking
 #####################
 
+.. contents::
+    :local:
+    :depth: 2
+
 This page describes how to set up networking between a Linux host
 and a Zephyr application running on USB supported devices.
 

--- a/doc/reference/networking/coap.rst
+++ b/doc/reference/networking/coap.rst
@@ -3,6 +3,10 @@
 CoAP
 #####
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/dhcpv4.rst
+++ b/doc/reference/networking/dhcpv4.rst
@@ -3,6 +3,10 @@
 DHCPv4
 ######
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/dns_resolve.rst
+++ b/doc/reference/networking/dns_resolve.rst
@@ -3,6 +3,10 @@
 DNS Resolve
 ###########
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/ethernet.rst
+++ b/doc/reference/networking/ethernet.rst
@@ -3,6 +3,10 @@
 Ethernet
 ########
 
+.. contents::
+    :local:
+    :depth: 2
+
 .. toctree::
    :maxdepth: 1
 

--- a/doc/reference/networking/ethernet_mgmt.rst
+++ b/doc/reference/networking/ethernet_mgmt.rst
@@ -3,6 +3,10 @@
 Ethernet Management
 ###################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/gptp.rst
+++ b/doc/reference/networking/gptp.rst
@@ -3,6 +3,10 @@
 generic Precision Time Protocol (gPTP)
 ######################################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/ieee802154.rst
+++ b/doc/reference/networking/ieee802154.rst
@@ -3,6 +3,10 @@
 IEEE 802.15.4
 #############
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 IEEE 802.15.4 is a technical standard which defines the operation of low-rate

--- a/doc/reference/networking/index.rst
+++ b/doc/reference/networking/index.rst
@@ -12,4 +12,3 @@ Networking
    protocols.rst
    system_mgmt.rst
    tsn.rst
-   net_shell.rst

--- a/doc/reference/networking/ip_4_6.rst
+++ b/doc/reference/networking/ip_4_6.rst
@@ -3,6 +3,10 @@
 IPv4/IPv6 Primitives and Helpers
 ################################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/lldp.rst
+++ b/doc/reference/networking/lldp.rst
@@ -3,6 +3,10 @@
 LLDP
 ####
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/lwm2m.rst
+++ b/doc/reference/networking/lwm2m.rst
@@ -3,6 +3,10 @@
 Lightweight M2M (LWM2M)
 #######################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/mqtt.rst
+++ b/doc/reference/networking/mqtt.rst
@@ -3,6 +3,10 @@
 MQTT
 ####
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/net_config.rst
+++ b/doc/reference/networking/net_config.rst
@@ -3,6 +3,10 @@
 Network Configuration Library
 #############################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/net_context.rst
+++ b/doc/reference/networking/net_context.rst
@@ -3,8 +3,5 @@
 Networking Context
 ##################
 
-Overview
-********
-
 The net_context API is not meant for application use. Application should use
 :ref:`bsd_sockets_interface` API instead.

--- a/doc/reference/networking/net_core.rst
+++ b/doc/reference/networking/net_core.rst
@@ -3,6 +3,10 @@
 Network Core Helpers
 ####################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/net_hostname.rst
+++ b/doc/reference/networking/net_hostname.rst
@@ -3,6 +3,10 @@
 Hostname Configuration
 ######################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/net_if.rst
+++ b/doc/reference/networking/net_if.rst
@@ -3,6 +3,10 @@
 Network Interface
 #################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/net_l2.rst
+++ b/doc/reference/networking/net_l2.rst
@@ -3,6 +3,10 @@
 L2 Layer Management
 ###################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/net_linkaddr.rst
+++ b/doc/reference/networking/net_linkaddr.rst
@@ -3,6 +3,10 @@
 Link Layer Address Handling
 ###########################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/net_mgmt.rst
+++ b/doc/reference/networking/net_mgmt.rst
@@ -3,6 +3,10 @@
 Network Management
 ##################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/net_offload.rst
+++ b/doc/reference/networking/net_offload.rst
@@ -1,5 +1,12 @@
 .. _net_offload_interface:
 
+Network Traffic Offloading
+==========================
+
+.. contents::
+    :local:
+    :depth: 2
+
 Network Offloading
 ##################
 

--- a/doc/reference/networking/net_pkt.rst
+++ b/doc/reference/networking/net_pkt.rst
@@ -3,6 +3,10 @@
 Packet Management
 #################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/net_shell.rst
+++ b/doc/reference/networking/net_shell.rst
@@ -3,9 +3,6 @@
 Network Shell
 #############
 
-Overview
-********
-
 Network shell provides helpers for figuring out network status,
 enabling/disabling features, and issuing commands like ping or DNS resolving.
 Note that ``net-shell`` should probably not be used in production code

--- a/doc/reference/networking/net_stats.rst
+++ b/doc/reference/networking/net_stats.rst
@@ -3,6 +3,10 @@
 Network Statistics
 ##################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/net_timeout.rst
+++ b/doc/reference/networking/net_timeout.rst
@@ -3,6 +3,10 @@
 Network Timeout
 ###############
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/promiscuous.rst
+++ b/doc/reference/networking/promiscuous.rst
@@ -3,6 +3,10 @@
 Promiscuous Mode
 ################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/ptp_time.rst
+++ b/doc/reference/networking/ptp_time.rst
@@ -4,6 +4,10 @@
 Precision Time Protocol (PTP) time format
 #########################################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/sockets.rst
+++ b/doc/reference/networking/sockets.rst
@@ -3,6 +3,10 @@
 BSD Sockets
 ###########
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/system_mgmt.rst
+++ b/doc/reference/networking/system_mgmt.rst
@@ -16,3 +16,4 @@ Network System Management
    net_linkaddr.rst
    ethernet_mgmt.rst
    traffic-class.rst
+   net_shell.rst

--- a/doc/reference/networking/thread.rst
+++ b/doc/reference/networking/thread.rst
@@ -3,6 +3,10 @@
 Thread protocol
 ###############
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 Thread is a low-power mesh networking technology, designed specifically for home

--- a/doc/reference/networking/trickle.rst
+++ b/doc/reference/networking/trickle.rst
@@ -3,6 +3,10 @@
 Trickle Timer Library
 #####################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 

--- a/doc/reference/networking/vlan.rst
+++ b/doc/reference/networking/vlan.rst
@@ -3,6 +3,10 @@
 Virtual LAN (VLAN) Support
 ##########################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Overview
 ********
 


### PR DESCRIPTION
The result HTML page looks better if there is table of contents at the start of the page.
I did not add this to net_context.rst and net_shell.rst as those contain only one chapter.