### PR TITLE
spi: spi_intel: Fix missing 'break' in case

### DIFF
--- a/drivers/spi/spi_intel.c
+++ b/drivers/spi/spi_intel.c
@@ -96,6 +96,7 @@ static void push_data(struct device *dev)
 			case 1:
 				data = UNALIGNED_GET((u8_t *)
 						     (spi->ctx.tx_buf));
+				break;
 			case 2:
 				data = UNALIGNED_GET((u16_t *)
 						     (spi->ctx.tx_buf));


### PR DESCRIPTION
Coverity scan found issue with a missing 'break' statement.  Fix
push_data by adding the break after handling the 1 byte case.

Coverity CID: 190978
Fixes #13842

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>