### PR TITLE
samples/96b_argonkey: microphone: Fix coverity bug 190958

### DIFF
--- a/samples/boards/96b_argonkey/microphone/src/main.c
+++ b/samples/boards/96b_argonkey/microphone/src/main.c
@@ -145,7 +145,7 @@ void main(void)
 
 	/* Acquire microphone audio */
 	for (ms = 0; ms < NUM_MS; ms++) {
-		dmic_read(mic_dev, 0, &rx_block[ms], &rx_size, 2000);
+		ret = dmic_read(mic_dev, 0, &rx_block[ms], &rx_size, 2000);
 		if (ret < 0) {
 			printk("microphone audio read error\n");
 			return;


### PR DESCRIPTION
Fix coverity CID 190958: Logically dead code (DEADCODE)
(bug: #13857)

Condition (ret < 0) was tested, but 'ret' variable was not
assigned.

Signed-off-by: Armando Visconti <armando.visconti@st.com>