### PR TITLE
arch: arm: nxp mpu: align MPU disable function with that of ARM MPU

### DIFF
--- a/arch/arm/core/cortex_m/mpu/nxp_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/nxp_mpu.c
@@ -384,7 +384,8 @@ void arm_core_mpu_enable(void)
  */
 void arm_core_mpu_disable(void)
 {
-	__DSB();
+	/* Force any outstanding transfers to complete before disabling MPU */
+	__DMB();
 
 	/* Disable MPU */
 	SYSMPU->CESR &= ~SYSMPU_CESR_VLD_MASK;


### PR DESCRIPTION
This commit aligns the implementation of arm_core_mpu_disable()
function in NXP MPU with the implementation in the ARM MPU
module, by introducing a Data Memory Barrier, (DMB) instead of
a DSB instruction. This is in accordance with the ARM guidelines
of using the memory protection unit.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>