### PR TITLE
net:lwm2m: fix json NULL deref / code flow in read_number()

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -540,9 +540,9 @@ static size_t read_number(struct lwm2m_input_context *in,
 	char c;
 
 	/* initialize values to 0 */
-	value1 = 0;
+	*value1 = 0;
 	if (value2) {
-		value2 = 0;
+		*value2 = 0;
 	}
 
 	fd = engine_get_in_user_data(in);


### PR DESCRIPTION
Per Coverity report, we are assigning the value1 and value2
s64_t pointers a value of 0.  Later when we go to use value1
and value2, they are of course ... NULL.

Fix the typos in the initial assignment of 0 to the
references of value1 and value2.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/13867
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/13882

Signed-off-by: Michael Scott <mike@foundries.io>