### PR TITLE
macros: deleted macros SECONDS(), MSEC(), USEC()

### DIFF
--- a/include/sys_clock.h
+++ b/include/sys_clock.h
@@ -213,17 +213,6 @@ struct _timeout {
 	_timeout_func_t fn;
 };
 
-/*
- * Number of ticks for x seconds. NOTE: With MSEC() or USEC(),
- * since it does an integer division, x must be greater or equal to
- * 1000/CONFIG_SYS_CLOCK_TICKS_PER_SEC to get a non-zero value.
- * You may want to raise CONFIG_SYS_CLOCK_TICKS_PER_SEC depending on
- * your requirements.
- */
-#define SECONDS(x)	((x) * CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#define MSEC(x)		(SECONDS(x) / MSEC_PER_SEC)
-#define USEC(x)		(MSEC(x) / USEC_PER_MSEC)
-
 #ifdef __cplusplus
 }
 #endif

--- a/samples/drivers/gpio/src/main.c
+++ b/samples/drivers/gpio/src/main.c
@@ -104,6 +104,6 @@ void main(void)
 			toggle = 1;
 		}
 
-		k_sleep(SECONDS(2));
+		k_sleep(K_SECONDS(2));
 	}
 }

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -14,7 +14,7 @@ LOG_MODULE_DECLARE(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 #include "gptp_md.h"
 #include "gptp_private.h"
 
-#define NET_BUF_TIMEOUT MSEC(100)
+#define NET_BUF_TIMEOUT K_MSEC(100)
 
 static struct net_if_timestamp_cb sync_timestamp_cb;
 static struct net_if_timestamp_cb pdelay_response_timestamp_cb;

--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -158,7 +158,7 @@ void test_kobject_revoke_access(void *p1, void *p2, void *p3)
 			0, K_INHERIT_PERMS | K_USER, K_NO_WAIT);
 
 
-	k_sem_take(&sync_sem, MSEC(100));
+	k_sem_take(&sync_sem, K_MSEC(100));
 	k_object_access_revoke(&kobject_sem, k_current_get());
 
 	k_thread_create(&kobject_test_4_tid,
@@ -215,7 +215,7 @@ void test_kobject_grant_access_kobj(void *p1, void *p2, void *p3)
 			0, K_INHERIT_PERMS | K_USER, K_NO_WAIT);
 
 
-	k_sem_take(&sync_sem, MSEC(100));
+	k_sem_take(&sync_sem, K_MSEC(100));
 
 	k_thread_create(&kobject_test_reuse_2_tid,
 			kobject_stack_2,
@@ -346,7 +346,7 @@ void test_kobject_access_all_grant(void *p1, void *p2, void *p3)
 			NULL, NULL, NULL,
 			0, K_USER, K_NO_WAIT);
 
-	k_sem_take(&sync_sem, MSEC(100));
+	k_sem_take(&sync_sem, K_MSEC(100));
 
 	k_thread_create(&kobject_test_reuse_2_tid,
 			kobject_stack_4,
@@ -405,7 +405,7 @@ void test_thread_has_residual_permissions(void *p1, void *p2, void *p3)
 			0, K_INHERIT_PERMS | K_USER, K_NO_WAIT);
 
 
-	k_sem_take(&sync_sem, MSEC(100));
+	k_sem_take(&sync_sem, K_MSEC(100));
 
 	k_thread_create(&kobject_test_9_tid,
 			kobject_stack_1,
@@ -956,4 +956,3 @@ void test_create_new_invalid_prio_thread_from_user(void *p1, void *p2, void *p3)
 	k_sem_take(&sync_sem, SYNC_SEM_TIMEOUT);
 
 }
-

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -524,7 +524,7 @@ void test_mem_domain_remove_partitions(void *p1, void *p2, void *p3)
 			10, K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 
 
-	k_sem_take(&sync_sem, MSEC(100));
+	k_sem_take(&sync_sem, K_MSEC(100));
 
 	k_mem_domain_remove_partition(&mem_domain_tc3_mem_domain,
 				      &mem_domain_tc3_part2_struct);

--- a/tests/kernel/pipe/pipe/src/test_pipe.c
+++ b/tests/kernel/pipe/pipe/src/test_pipe.c
@@ -40,8 +40,8 @@ ZTEST_BMEM u8_t rx_buffer[PIPE_SIZE];
 #define ALL_BYTES (sizeof(tx_buffer))
 
 #define RETURN_SUCCESS  (0)
-#define TIMEOUT_VAL (MSEC(10))
-#define TIMEOUT_200MSEC (MSEC(200))
+#define TIMEOUT_VAL (K_MSEC(10))
+#define TIMEOUT_200MSEC (K_MSEC(200))
 
 /* encompasing structs */
 struct pipe_sequence {

--- a/tests/net/buf/src/main.c
+++ b/tests/net/buf/src/main.c
@@ -15,7 +15,7 @@
 
 #include <ztest.h>
 
-#define TEST_TIMEOUT SECONDS(1)
+#define TEST_TIMEOUT K_SECONDS(1)
 
 struct bt_data {
 	void *hci_sync;


### PR DESCRIPTION
Using help of the community, we decided to delete these macros SECONDS(), MSEC() and USEC() and replace them with K_MSEC() and K_SECONDS()

Fixes: #7817

Signed-off-by: Maksim Masalski <maxxliferobot@gmail.com>