### PR TITLE
MISRAfication: remove stack allocation & recursion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,11 @@ if(NOT CONFIG_RTTI)
   )
 endif()
 
+if(CONFIG_MISRA_SANE)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=vla>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=vla>)
+endif()
+
 # @Intent: Obtain compiler specific flags for standard C includes
 toolchain_cc_nostdinc()
 

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -402,4 +402,13 @@ config REBOOT
 	  Enable the sys_reboot() API. Enabling this can drag in other subsystems
 	  needed to perform a "safe" reboot (e.g. SYSTEM_CLOCK_DISABLE, to stop the
 	  system clock before issuing a reset).
+
+config MISRA_SANE
+	bool "MISRA standards compliance features"
+	help
+	  Causes the source code to build in "MISRA" mode, which
+	  disallows some otherwise-permitted features of the C
+	  standard for safety reasons.  Specifically variable length
+	  arrays are not permitted (and gcc will enforce this).
+
 endmenu

--- a/cmake/extra_flags.cmake
+++ b/cmake/extra_flags.cmake
@@ -25,4 +25,3 @@ if(EXTRA_AFLAGS)
     zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:${F}>)
   endforeach()
 endif()
-

--- a/include/misc/rb.h
+++ b/include/misc/rb.h
@@ -87,7 +87,9 @@ typedef void (*rb_visit_t)(struct rbnode *node, void *cookie);
 
 struct rbnode *_rb_child(struct rbnode *node, int side);
 int _rb_is_black(struct rbnode *node);
+#ifndef CONFIG_MISRA_SANE
 void _rb_walk(struct rbnode *node, rb_visit_t visit_fn, void *cookie);
+#endif
 struct rbnode *_rb_get_minmax(struct rbtree *tree, int side);
 
 /**
@@ -127,6 +129,7 @@ static inline struct rbnode *rb_get_max(struct rbtree *tree)
  */
 bool rb_contains(struct rbtree *tree, struct rbnode *node);
 
+#ifndef CONFIG_MISRA_SANE
 /**
  * @brief Walk/enumerate a rbtree
  *
@@ -164,7 +167,6 @@ struct _rb_foreach {
 
 struct rbnode *_rb_foreach_next(struct rbtree *tree, struct _rb_foreach *f);
 
-#ifndef CONFIG_MISRA_SANE
 /**
  * @brief Walk a tree in-order without recursing
  *

--- a/lib/os/mempool.c
+++ b/lib/os/mempool.c
@@ -162,35 +162,40 @@ static void *block_alloc(struct sys_mem_pool_base *p, int l, size_t lsz)
 static unsigned int bfree_recombine(struct sys_mem_pool_base *p, int level,
 				    size_t *lsizes, int bn, unsigned int key)
 {
-	int i, lsz = lsizes[level];
-	void *block = block_ptr(p, lsz, bn);
+	while (level >= 0) {
+		int i, lsz = lsizes[level];
+		void *block = block_ptr(p, lsz, bn);
 
-	__ASSERT(block_fits(p, block, lsz), "");
+		__ASSERT(block_fits(p, block, lsz), "");
 
-	/* Put it back */
-	set_free_bit(p, level, bn);
-	sys_dlist_append(&p->levels[level].free_list, block);
+		/* Put it back */
+		set_free_bit(p, level, bn);
+		sys_dlist_append(&p->levels[level].free_list, block);
 
-	/* Relax the lock (might result in it being taken, which is OK!) */
-	pool_irq_unlock(p, key);
-	key = pool_irq_lock(p);
+		/* Relax the lock (might result in it being taken, which is OK!) */
+		pool_irq_unlock(p, key);
+		key = pool_irq_lock(p);
 
-	/* Check if we can recombine its superblock, and repeat */
-	if (level == 0 || partner_bits(p, level, bn) != 0xf) {
-		return key;
-	}
-
-	for (i = 0; i < 4; i++) {
-		int b = (bn & ~3) + i;
-
-		if (block_fits(p, block_ptr(p, lsz, b), lsz)) {
-			clear_free_bit(p, level, b);
-			sys_dlist_remove(block_ptr(p, lsz, b));
+		/* Check if we can recombine its superblock, and repeat */
+		if (level == 0 || partner_bits(p, level, bn) != 0xf) {
+			return key;
 		}
-	}
 
-	/* Free the larger block (tail recursion!) */
-	return bfree_recombine(p, level - 1, lsizes, bn / 4, key);
+		for (i = 0; i < 4; i++) {
+			int b = (bn & ~3) + i;
+
+			if (block_fits(p, block_ptr(p, lsz, b), lsz)) {
+				clear_free_bit(p, level, b);
+				sys_dlist_remove(block_ptr(p, lsz, b));
+			}
+		}
+
+		/* Free the larger block */
+		level = level - 1;
+		bn = bn / 4;
+	}
+	__ASSERT(0, "out of levels");
+	return -1;
 }
 
 static void block_free(struct sys_mem_pool_base *p, int level,

--- a/lib/os/mempool.c
+++ b/lib/os/mempool.c
@@ -10,6 +10,12 @@
 #include <misc/mempool_base.h>
 #include <misc/mempool.h>
 
+#ifdef CONFIG_MISRA_SANE
+#define LVL_ARRAY_SZ(n) (8 * sizeof(void *) / 2)
+#else
+#define LVL_ARRAY_SZ(n) (n)
+#endif
+
 static bool level_empty(struct sys_mem_pool_base *p, int l)
 {
 	return sys_dlist_is_empty(&p->levels[l].free_list);
@@ -228,7 +234,7 @@ int _sys_mem_pool_block_alloc(struct sys_mem_pool_base *p, size_t size,
 	int i, from_l, alloc_l = -1, free_l = -1;
 	unsigned int key;
 	void *data = NULL;
-	size_t lsizes[p->n_levels];
+	size_t lsizes[LVL_ARRAY_SZ(p->n_levels)];
 
 	/* Walk down through levels, finding the one from which we
 	 * want to allocate and the smallest one with a free entry
@@ -298,7 +304,7 @@ int _sys_mem_pool_block_alloc(struct sys_mem_pool_base *p, size_t size,
 void _sys_mem_pool_block_free(struct sys_mem_pool_base *p, u32_t level,
 			      u32_t block)
 {
-	size_t lsizes[p->n_levels];
+	size_t lsizes[LVL_ARRAY_SZ(p->n_levels)];
 	int i;
 
 	/* As in _sys_mem_pool_block_alloc(), we build a table of level sizes

--- a/lib/os/rb.c
+++ b/lib/os/rb.c
@@ -490,6 +490,7 @@ void rb_remove(struct rbtree *tree, struct rbnode *node)
 	tree->root = stack[0];
 }
 
+#ifndef CONFIG_MISRA_SANE
 void _rb_walk(struct rbnode *node, rb_visit_t visit_fn, void *cookie)
 {
 	if (node != NULL) {
@@ -498,6 +499,7 @@ void _rb_walk(struct rbnode *node, rb_visit_t visit_fn, void *cookie)
 		_rb_walk(get_child(node, 1), visit_fn, cookie);
 	}
 }
+#endif
 
 struct rbnode *_rb_child(struct rbnode *node, int side)
 {

--- a/lib/os/rb.c
+++ b/lib/os/rb.c
@@ -223,7 +223,11 @@ void rb_insert(struct rbtree *tree, struct rbnode *node)
 		return;
 	}
 
+#ifdef CONFIG_MISRA_SANE
+	struct rbnode **stack = &tree->iter_stack[0];
+#else
 	struct rbnode *stack[tree->max_depth + 1];
+#endif
 
 	int stacksz = find_and_stack(tree, node, stack);
 
@@ -357,7 +361,12 @@ static void fix_missing_black(struct rbnode **stack, int stacksz,
 
 void rb_remove(struct rbtree *tree, struct rbnode *node)
 {
-	struct rbnode *stack[tree->max_depth + 1], *tmp;
+	struct rbnode *tmp;
+#ifdef CONFIG_MISRA_SANE
+	struct rbnode **stack = &tree->iter_stack[0];
+#else
+	struct rbnode *stack[tree->max_depth + 1];
+#endif
 
 	int stacksz = find_and_stack(tree, node, stack);
 

--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -3,3 +3,11 @@ tests:
     tags: kernel
     min_flash: 33
     min_ram: 32
+  kernel.common.misra:
+    tags: kernel
+    min_flash: 33
+    min_ram: 32
+    # Some configurations are known-incompliant and won't build
+    filter: not ((CONFIG_I2C or CONFIG_SPI) and CONFIG_USERSPACE)
+    extra_configs:
+      - CONFIG_MISRA_SANE=y

--- a/tests/lib/rbtree/testcase.yaml
+++ b/tests/lib/rbtree/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   libraries.data_structures.rbtree:
     tags: rbtree
+    filter: not CONFIG_MISRA_SANE


### PR DESCRIPTION
Fixes for MISRA pedantry.  This is done in a minimal-impact way, since we're in a stabilization period.  It introduces a MISRA_SANE kconfig that is disabled by default and affects no code paths unless enabled.   A single variant of tests/kernel/common is added to provide coverage for the case where it's enabled.

Later on we can argue about removing the kconfig and whether or not alloca and tail recursion is actually needed.

Note that one amusing side effect is that each of these two patches removes one of the two "walker" APIs for rbtree, so in MISRA mode it's not possible to enumerate the tree.  But as it happens none of our code actually needs to do that...