### PR TITLE
doc: fix docs, include, and Kconfig misspellings

### DIFF
--- a/doc/development_process/api_lifecycle.rst
+++ b/doc/development_process/api_lifecycle.rst
@@ -68,7 +68,7 @@ Stable
 The API has proven satisfactory, but cleanup in the underlying code may cause
 minor changes. Backwards-compatibility will be maintained if reasonable.
 
-An API can be declared ``stable`` after fullfilling the following requirements:
+An API can be declared ``stable`` after fulfilling the following requirements:
 
 - Test cases for the new API with 100% coverage
 - Complete documentation in code. All public interfaces shall be documented

--- a/doc/development_process/documentation.rst
+++ b/doc/development_process/documentation.rst
@@ -8,7 +8,7 @@ API Documentation
 Well documented APIs enhance the experience for developers and are an essential
 requirement for defining an API's success. Doxygen is a general purpose
 documentation tool that the zephyr project uses for documenting APIs. It
-generates either an on-line documentation browser (in HTML) and/or providess
+generates either an on-line documentation browser (in HTML) and/or provides
 input for other tools that is used to generate a reference manual from
 documented source files. In particular, doxygen's XML output is used as an input
 when producing the Zephyr project's online documentation.
@@ -30,7 +30,7 @@ document all test code using the same tools and in the same context and generate
 documentation for all unit and integration tests maintained in the same
 environment. Tests are documented using references to the APIs or functionality
 they validate by creating a link back to the APIs and by adding a reference to
-the original resquirements.
+the original requirements.
 
 
 Documentation Guidelines

--- a/doc/guides/networking/networking_with_host.rst
+++ b/doc/guides/networking/networking_with_host.rst
@@ -32,7 +32,7 @@ possible:
 
 * native_posix board.
 
-  * The Zepher instance can be executed as a user space process in the host
+  * The Zephyr instance can be executed as a user space process in the host
     system. This is the most convenient way to debug the Zephyr system as one
     can attach host debugger directly to the running Zephyr instance. This
     requires that there is an adaptation driver in Zephyr for interfacing

--- a/include/can.h
+++ b/include/can.h
@@ -416,7 +416,7 @@ static inline int _impl_can_configure(struct device *dev, enum can_mode mode,
 }
 
 /**
- * @brief Converter that translates betwen can_frame and zcan_frame structs.
+ * @brief Converter that translates between can_frame and zcan_frame structs.
  *
  * @param frame Pointer to can_frame struct.
  * @param zframe Pointer to zcan_frame struct.
@@ -432,7 +432,7 @@ static inline void can_copy_frame_to_zframe(struct can_frame *frame,
 }
 
 /**
- * @brief Converter that translates betwen zcan_frame and can_frame structs.
+ * @brief Converter that translates between zcan_frame and can_frame structs.
  *
  * @param zframe Pointer to zcan_frame struct.
  * @param frame Pointer to can_frame struct.
@@ -447,7 +447,7 @@ static inline void can_copy_zframe_to_frame(struct zcan_frame *zframe,
 }
 
 /**
- * @brief Converter that translates betwen can_filter and zcan_frame_filter
+ * @brief Converter that translates between can_filter and zcan_frame_filter
  * structs.
  *
  * @param filter Pointer to can_filter struct.
@@ -465,7 +465,7 @@ void can_copy_filter_to_zfilter(struct can_filter *filter,
 }
 
 /**
- * @brief Converter that translates betwen zcan_filter and can_filter
+ * @brief Converter that translates between zcan_filter and can_filter
  * structs.
  *
  * @param zfilter Pointer to zcan_filter struct.

--- a/include/net/socket_offload_ops.h
+++ b/include/net/socket_offload_ops.h
@@ -28,7 +28,7 @@ extern "C" {
 #include <net/socket.h>  /* needed for struct pollfd */
 
 /**
- * @brief An offloaded Socket API interafce
+ * @brief An offloaded Socket API interface
  *
  * It is assumed that these offload functions follow the
  * POSIX socket API standard for arguments, return values and setting of errno.

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -237,12 +237,12 @@ config IMAGE_VECTOR_TABLE_OFFSET
 	help
 	  The Image Vector Table (IVT) provides the boot ROM with pointers to
 	  the application entry point and device configuration data. The boot
-	  ROM reqiures a fixed IVT offset for each type of boot device.
+	  ROM requires a fixed IVT offset for each type of boot device.
 
 config DEVICE_CONFIGURATION_DATA
 	bool "Enable device configuration data"
 	help
-	  Device configuration data (DCD) provides a sequence of commmands to
+	  Device configuration data (DCD) provides a sequence of commands to
 	  the boot ROM to initialize components such as an SDRAM.
 
 endif # NXP_IMX_RT_BOOT_HEADER

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -507,10 +507,10 @@ config BT_CTLR_LOWEST_PRIO
 	  The interrupt priority for RNG and other non-critical functions.
 
 config BT_CTLR_LOW_LAT
-	bool "Low latency non-negotiating event pre-emption"
+	bool "Low latency non-negotiating event preemption"
 	default y if SOC_SERIES_NRF51X
 	help
-	  Use low latency non-negotiating event pre-emption. This reduces
+	  Use low latency non-negotiating event preemption. This reduces
 	  Radio ISR latencies by the controller event scheduling framework.
 	  Consequently, this reduces on-air radio utilization due to redundant
 	  radio state switches.

--- a/subsys/debug/Kconfig.segger
+++ b/subsys/debug/Kconfig.segger
@@ -12,7 +12,7 @@ config USE_SEGGER_RTT
 	depends on HAS_SEGGER_RTT
 	help
 	  Enable Segger J-Link RTT libraries for platforms that support it.
-	  Selection of this option enables use of RTT for various subsytems.
+	  Selection of this option enables use of RTT for various subsystems.
 	  Note that by enabling this option, RTT buffers consume more RAM.
 
 if USE_SEGGER_RTT

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -478,7 +478,7 @@ config NET_HEADERS_ALWAYS_CONTIGUOUS
 	  This a hidden option, which one should use with a lot of care.
 	  NO bug reports will be accepted if that option is enabled!
 	  You are warned.
-	  If you are 100% sure the headers memore space is always in a
+	  If you are 100% sure the headers memory space is always in a
 	  contiguous space, this will save stack usage and ROM in net core.
 	  This is a possible case when using IPv4 only, with
 	  NET_BUF_FIXED_DATA_SIZE enabled and NET_BUF_DATA_SIZE of 128 for

--- a/subsys/net/ip/Kconfig.debug
+++ b/subsys/net/ip/Kconfig.debug
@@ -42,7 +42,7 @@ config NET_DEBUG_NET_PKT_NON_FRAGILE_ACCESS
 	help
 	  This MUST not be used unless you have an hard to catch bug. This will
 	  reset the pkt cursor when it's freed, so any subsequent r/w operations
-	  will not segfault, but just bail out and hopefuly it will enable you
+	  will not segfault, but just bail out and hopefully it will enable you
 	  to know who/where the packet was freed already. Do not set this, by
 	  any means, unless you are actively debugging.
 

--- a/subsys/power/policy/Kconfig
+++ b/subsys/power/policy/Kconfig
@@ -27,7 +27,7 @@ config SYS_PM_LPS_1_MIN_RES
 	depends on HAS_STATE_LOW_POWER_1
 	default 5000
 	help
-	  Minimum residency in miliseconds to enter SYS_POWER_STATE_LOW_POWER_1
+	  Minimum residency in milliseconds to enter SYS_POWER_STATE_LOW_POWER_1
 	  state.
 
 config SYS_PM_LPS_2_MIN_RES
@@ -35,7 +35,7 @@ config SYS_PM_LPS_2_MIN_RES
 	depends on HAS_STATE_LOW_POWER_2
 	default 10000
 	help
-	  Minimum residency in miliseconds to enter SYS_POWER_STATE_LOW_POWER_2
+	  Minimum residency in milliseconds to enter SYS_POWER_STATE_LOW_POWER_2
 	  state.
 
 config SYS_PM_LPS_3_MIN_RES
@@ -43,7 +43,7 @@ config SYS_PM_LPS_3_MIN_RES
 	depends on HAS_STATE_LOW_POWER_3
 	default 30000
 	help
-	  Minimum residency in miliseconds to enter SYS_POWER_STATE_LOW_POWER_3
+	  Minimum residency in milliseconds to enter SYS_POWER_STATE_LOW_POWER_3
 	  state.
 
 config SYS_PM_DEEP_SLEEP_1_MIN_RES
@@ -51,7 +51,7 @@ config SYS_PM_DEEP_SLEEP_1_MIN_RES
 	depends on HAS_STATE_DEEP_SLEEP_1
 	default 60000
 	help
-	  Minimum residency in miliseconds to enter SYS_POWER_STATE_DEEP_SLEEP_1
+	  Minimum residency in milliseconds to enter SYS_POWER_STATE_DEEP_SLEEP_1
 	  state.
 
 config SYS_PM_DEEP_SLEEP_2_MIN_RES
@@ -59,7 +59,7 @@ config SYS_PM_DEEP_SLEEP_2_MIN_RES
 	depends on HAS_STATE_DEEP_SLEEP_2
 	default 90000
 	help
-	  Minimum residency in miliseconds to enter SYS_POWER_STATE_DEEP_SLEEP_2
+	  Minimum residency in milliseconds to enter SYS_POWER_STATE_DEEP_SLEEP_2
 	  state.
 
 config SYS_PM_DEEP_SLEEP_3_MIN_RES
@@ -67,7 +67,7 @@ config SYS_PM_DEEP_SLEEP_3_MIN_RES
 	depends on HAS_STATE_DEEP_SLEEP_3
 	default 120000
 	help
-	  Minimum residency in miliseconds to enter SYS_POWER_STATE_DEEP_SLEEP_3
+	  Minimum residency in milliseconds to enter SYS_POWER_STATE_DEEP_SLEEP_3
 	  state.
 
 endif # SYS_PM_POLICY_RESIDENCY

--- a/subsys/usb/class/hid/Kconfig
+++ b/subsys/usb/class/hid/Kconfig
@@ -31,7 +31,7 @@ config USB_HID_DEVICE_NAME_1
 	depends on USB_HID_DEVICE_1
 	default "HID_1"
 	help
-	  Device name for the seconf HID Device.
+	  Device name for the second HID Device.
 
 endif # USB_COMPOSITE_DEVICE
 


### PR DESCRIPTION
Fix misspellings missed during regular reviews

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>