### PR TITLE
tests/kernel/sched/schedule_api: Restore spinning for timer alignment

### DIFF
--- a/tests/kernel/sched/schedule_api/src/test_sched.h
+++ b/tests/kernel/sched/schedule_api/src/test_sched.h
@@ -23,6 +23,8 @@ struct thread_data {
 	int executed;
 };
 
+void spin_for_ms(int ticks);
+
 void test_priority_cooperative(void);
 void test_priority_preemptible(void);
 void test_yield_cooperative(void);

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -51,7 +51,7 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 	/* Keep the current thread busy for more than one slice, even though,
 	 * when timeslice used up the next thread should be scheduled in.
 	 */
-	k_busy_wait(1000 * BUSY_MS);
+	spin_for_ms(BUSY_MS);
 	k_sem_give(&sema);
 }
 

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -55,7 +55,7 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 		 * even though, when timeslice used up the next thread
 		 * should be scheduled in.
 		 */
-		k_busy_wait(1000 * BUSY_MS);
+		spin_for_ms(BUSY_MS);
 		k_sem_give(&sema1);
 	}
 
@@ -102,7 +102,7 @@ void test_slice_scheduling(void)
 		 * even though, when timeslice used up the next thread
 		 * should be scheduled in.
 		 */
-		k_busy_wait(1000 * BUSY_MS);
+		spin_for_ms(BUSY_MS);
 
 		/* relinquish CPU and wait for each thread to complete*/
 		for (int i = 0; i < NUM_THREAD; i++) {


### PR DESCRIPTION
Commit 0cc362f87371 ("tests/kernel: Simplify timer spinning") was
added to work around a qemu bug with dropped interrupts on x86_64.
But it turns out that the tick alignment that the original
implementation provided (fundamentally, it spins waiting on the timer
driver to report tick changes) was needed for correct operation on
nRF52.

The effectively revert that commit (and refactors all the spinning
into a single utility) and replaces it with a workaround targeted to
qemu on x86_64 only.  Fixes #11721

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>