### PR TITLE
gpio: gpio_intel_apl: fix if condition leading to dead code

### DIFF
--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -243,7 +243,7 @@ static int gpio_intel_apl_config(struct device *dev, int access_op,
 	/* setup interrupt if desired */
 	if (flags & GPIO_INT) {
 		/* invert signal for interrupt controller */
-		if (flags & GPIO_INT_ACTIVE_LOW) {
+		if ((flags & GPIO_INT_ACTIVE_HIGH) == GPIO_INT_ACTIVE_LOW) {
 			cfg0 |= PAD_CFG0_RXINV;
 		}
 


### PR DESCRIPTION
GPIO_INT_ACTIVE_LOW is 0 which means it cannot be simply AND-ed.
So fix the condition.

Fixes #13880

Signed-off-by: Daniel Leung <daniel.leung@intel.com>