### PR TITLE
mbedtls: provide user mode access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1149,13 +1149,17 @@ if(CONFIG_USERSPACE)
   if(CONFIG_NEWLIB_LIBC)
     set(NEWLIB_PART -l libc.a z_libc_partition)
   endif()
+  if(CONFIG_MBEDTLS)
+    set(MBEDTLS_PART -l libext__lib__crypto__mbedtls.a k_mbedtls_partition)
+  endif()
+
   add_custom_command(
     OUTPUT ${APP_SMEM_LD}
     COMMAND ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/gen_app_partitions.py
     -d ${OBJ_FILE_DIR}
     -o ${APP_SMEM_LD}
-    ${NEWLIB_PART}
+    ${NEWLIB_PART} ${MBEDTLS_PART}
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     DEPENDS
     kernel

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -144,6 +144,7 @@
 /ext/lib/crypto/mbedtls/                  @nashif
 /ext/lib/crypto/tinycrypt/                @ceolin
 /include/adc.h                            @anangl
+/include/app_memory/                      @andrewboie
 /include/arch/arc/                        @vonhust @ruuddw
 /include/arch/arc/arch.h                  @andrewboie
 /include/arch/arc/v2/irq.h                @andrewboie

--- a/ext/lib/crypto/mbedtls/zephyr_init.c
+++ b/ext/lib/crypto/mbedtls/zephyr_init.c
@@ -11,6 +11,7 @@
  */
 
 #include <init.h>
+#include <app_memory/app_memdomain.h>
 
 #if defined(CONFIG_MBEDTLS)
 #if !defined(CONFIG_MBEDTLS_CFG_FILE)

--- a/include/app_memory/partitions.h
+++ b/include/app_memory/partitions.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_APP_MEMORY_PARTITIONS_H
+#define ZEPHYR_APP_MEMORY_PARTITIONS_H
+
+#ifdef CONFIG_USERSPACE
+#include <kernel.h> /* For struct k_mem_partition */
+
+#if defined(CONFIG_MBEDTLS)
+extern struct k_mem_partition k_mbedtls_partition;
+#endif /* CONFIG_MBEDTLS */
+#endif /* CONFIG_USERSPACE */
+#endif /* ZEPHYR_APP_MEMORY_PARTITIONS_H */

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -185,6 +185,14 @@ extern FUNC_NORETURN void _arch_syscall_oops(void *ssf);
  * @return Length of the string, not counting NULL byte, up to maxsize
  */
 extern size_t z_arch_user_string_nlen(const char *s, size_t maxsize, int *err);
+
+/**
+ * @brief Zero out BSS sections for application shared memory
+ *
+ * This isn't handled by any platform bss zeroing, and is called from
+ * _Cstart() if userspace is enabled.
+ */
+extern void z_app_shmem_bss_zero(void);
 #endif /* CONFIG_USERSPACE */
 
 /**

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -496,6 +496,10 @@ FUNC_NORETURN void _Cstart(void)
 	_current = &dummy_thread;
 #endif
 
+#ifdef CONFIG_USERSPACE
+	z_app_shmem_bss_zero();
+#endif
+
 	/* perform basic hardware initialization */
 	_sys_device_do_config_level(_SYS_INIT_LEVEL_PRE_KERNEL_1);
 	_sys_device_do_config_level(_SYS_INIT_LEVEL_PRE_KERNEL_2);

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -24,6 +24,14 @@
 K_APPMEM_PARTITION_DEFINE(z_libc_partition);
 #endif
 
+/* TODO: Find a better place to put this. Since we pull the entire
+ * libext__lib__crypto__mbedtls.a globals into app shared memory
+ * section, we can't put this in ext/lib/crypto/mbedtls/zephyr_init.c
+ */
+#ifdef CONFIG_MBEDTLS
+K_APPMEM_PARTITION_DEFINE(k_mbedtls_partition);
+#endif
+
 #define LOG_LEVEL CONFIG_KERNEL_LOG_LEVEL
 #include <logging/log.h>
 LOG_MODULE_DECLARE(kernel);

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -737,7 +737,7 @@ out:
 extern char __app_shmem_regions_start[];
 extern char __app_shmem_regions_end[];
 
-static int app_shmem_bss_zero(struct device *unused)
+void z_app_shmem_bss_zero(void)
 {
 	struct z_app_region *region, *end;
 
@@ -747,11 +747,7 @@ static int app_shmem_bss_zero(struct device *unused)
 	for ( ; region < end; region++) {
 		(void)memset(region->bss_start, 0, region->bss_size);
 	}
-
-	return 0;
 }
-
-SYS_INIT(app_shmem_bss_zero, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 /*
  * Default handlers if otherwise unimplemented

--- a/tests/crypto/mbedtls/src/main.c
+++ b/tests/crypto/mbedtls/src/main.c
@@ -5,12 +5,17 @@
  */
 
 #include <ztest.h>
+#include <app_memory/partitions.h>
+
 extern void test_mbedtls(void);
 
 /**test case main entry*/
 void test_main(void)
 {
+#ifdef CONFIG_USERSPACE
+	k_mem_domain_add_partition(&ztest_mem_domain, &k_mbedtls_partition);
+#endif
 	ztest_test_suite(test_mbedtls_fn,
-		ztest_unit_test(test_mbedtls));
+		ztest_user_unit_test(test_mbedtls));
 	ztest_run_test_suite(test_mbedtls_fn);
 }

--- a/tests/crypto/mbedtls/src/mbedtls.c
+++ b/tests/crypto/mbedtls/src/mbedtls.c
@@ -75,7 +75,7 @@
 #if defined(MBEDTLS_RSA_C)
 int rand(void)
 {
-	static u32_t seed = 7U;
+	static ZTEST_DMEM u32_t seed = 7U;
 
 	seed ^= seed << 13;
 	seed ^= seed >> 17;
@@ -155,7 +155,7 @@ static void create_entropy_seed_file(void)
 #endif
 
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
-unsigned char buf[16384];
+ZTEST_BMEM unsigned char buf[16000];
 #endif
 
 void test_mbedtls(void)


### PR DESCRIPTION
The mbedtls library has some globals which results in faults
when user mode tries to access them.

Instantiate a memory partition for mbedtls's globals.
Add the mbedtls heap, and the function pointers used by
mbedtls's platform abstraction.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>