### PR TITLE
scripts/dts cleanups, part 10

### DIFF
--- a/scripts/dts/extract/clocks.py
+++ b/scripts/dts/extract/clocks.py
@@ -23,7 +23,7 @@ class DTClocks(DTDirective):
 
         clock_consumer = reduced[node_path]
         clock_consumer_bindings = get_binding(node_path)
-        clock_consumer_label = 'DT_' + get_node_label(node_path)
+        clock_consumer_label = 'DT_' + node_label(node_path)
 
         clock_index = 0
         clock_cell_index = 0
@@ -43,8 +43,7 @@ class DTClocks(DTDirective):
                 clock_provider = reduced[clock_provider_node_path]
                 clock_provider_bindings = get_binding(
                                             clock_provider_node_path)
-                clock_provider_label = get_node_label( \
-                                                clock_provider_node_path)
+                clock_provider_label = node_label(clock_provider_node_path)
                 nr_clock_cells = int(clock_provider['props'].get(
                                      '#clock-cells', 0))
                 clock_cells_string = clock_provider_bindings.get(

--- a/scripts/dts/extract/clocks.py
+++ b/scripts/dts/extract/clocks.py
@@ -15,10 +15,6 @@ from extract.directive import DTDirective
 # directives.
 #
 class DTClocks(DTDirective):
-
-    def __init__(self):
-        pass
-
     def _extract_consumer(self, node_path, clocks, def_label):
 
         clock_consumer = reduced[node_path]

--- a/scripts/dts/extract/compatible.py
+++ b/scripts/dts/extract/compatible.py
@@ -14,10 +14,6 @@ from extract.directive import DTDirective
 # - compatible
 #
 class DTCompatible(DTDirective):
-
-    def __init__(self):
-        pass
-
     ##
     # @brief Extract compatible
     #

--- a/scripts/dts/extract/default.py
+++ b/scripts/dts/extract/default.py
@@ -11,10 +11,6 @@ from extract.directive import DTDirective
 # @brief Manage directives in a default way.
 #
 class DTDefault(DTDirective):
-
-    def __init__(self):
-        pass
-
     ##
     # @brief Extract directives in a default way
     #

--- a/scripts/dts/extract/directive.py
+++ b/scripts/dts/extract/directive.py
@@ -23,9 +23,6 @@ class DTDirective(object):
     def get_label_string(label):
         return str_to_label('_'.join(x.strip() for x in label if x.strip()))
 
-    def __init__():
-        pass
-
     ##
     # @brief Extract directive information.
     #

--- a/scripts/dts/extract/flash.py
+++ b/scripts/dts/extract/flash.py
@@ -15,8 +15,6 @@ from extract.reg import reg
 #
 class DTFlash(DTDirective):
     def __init__(self):
-        # Node of the flash
-        self._flash_node = None
         self._flash_area = {}
 
     def _extract_partition(self, node_path):
@@ -138,20 +136,20 @@ class DTFlash(DTDirective):
 
         insert_defs(node_path, prop_def, prop_alias)
 
-    def _extract_flash(self, node_path, prop, def_label):
-        if node_path == 'dummy-flash':
-            # We will add addr/size of 0 for systems with no flash controller
-            # This is what they already do in the Kconfig options anyway
-            insert_defs(node_path,
+    def extract_flash(self):
+        node_path = chosen.get('zephyr,flash')
+        if not node_path:
+            # Add addr/size 0 for systems with no flash controller. This is
+            # what they already do in the Kconfig options anyway.
+            insert_defs('dummy-flash',
                         {'DT_FLASH_BASE_ADDRESS': 0, 'DT_FLASH_SIZE': 0},
                         {})
-            self._flash_base_address = 0
             return
 
-        self._flash_node = reduced[node_path]
+        flash_node = reduced[node_path]
         orig_node_addr = node_path
 
-        (nr_address_cells, nr_size_cells) = get_addr_size_cells(node_path)
+        nr_address_cells, nr_size_cells = get_addr_size_cells(node_path)
         # if the nr_size_cells is 0, assume a SPI flash, need to look at parent
         # for addr/size info, and the second reg property (assume first is mmio
         # register for the controller itself)
@@ -193,28 +191,26 @@ class DTFlash(DTDirective):
                         {})
 
         for prop in 'write-block-size', 'erase-block-size':
-            if prop in self._flash_node['props']:
-                default.extract(node_path, prop, None, def_label)
+            if prop in flash_node['props']:
+                default.extract(node_path, prop, None, 'DT_FLASH')
 
                 # Add an non-DT prefix alias for compatiability
                 prop_alias = {}
                 label_post = '_' + str_to_label(prop)
-                prop_alias['FLASH' + label_post] = def_label + label_post
+                prop_alias['FLASH' + label_post] = 'DT_FLASH' + label_post
                 insert_defs(node_path, {}, prop_alias)
 
 
-    def _extract_code_partition(self, node_path, prop, def_label):
-        if node_path == 'dummy-flash':
-            node = None
-        else:
-            node = reduced[node_path]
-            if self._flash_node is None:
-                # No flash node scanned before-
-                raise Exception(
-                    "Code partition '{}' {} without flash definition."
-                        .format(prop, node_path))
+    def extract_code_partition(self):
+        node_path = chosen.get('zephyr,code-partition')
+        if not node_path:
+            # Fall back on zephyr,flash if zephyr,code-partition isn't set.
+            # node_path will be 'dummy-flash' if neither is set.
+            node_path = chosen.get('zephyr,flash', 'dummy-flash')
 
-        if node and node is not self._flash_node:
+        node = reduced.get(node_path)
+
+        if node and node is not reduced.get(chosen.get('zephyr,flash')):
             # only compute the load offset if the code partition
             # is not the same as the flash base address
             load_offset = node['props']['reg'][0]
@@ -228,27 +224,7 @@ class DTFlash(DTDirective):
                      'DT_CODE_PARTITION_SIZE': load_size},
                     {})
 
-    ##
-    # @brief Extract flash
-    #
-    # @param node_path Path to node owning the
-    #                  flash definition.
-    # @param prop compatible property name
-    # @param def_label Define label string of node owning the
-    #                  compatible definition.
-    #
-    def extract(self, node_path, prop, def_label):
 
-        if prop == 'zephyr,flash':
-            # indicator for flash
-            self._extract_flash(node_path, prop, def_label)
-        elif prop == 'zephyr,code-partition':
-            # indicator for code_partition
-            self._extract_code_partition(node_path, prop, def_label)
-        else:
-            raise Exception(
-                "DTFlash.extract called with unexpected directive ({})."
-                    .format(prop))
 ##
 # @brief Management information for flash.
 flash = DTFlash()

--- a/scripts/dts/extract/flash.py
+++ b/scripts/dts/extract/flash.py
@@ -14,7 +14,6 @@ from extract.reg import reg
 # @brief Manage flash directives.
 #
 class DTFlash(DTDirective):
-
     def __init__(self):
         # Node of the flash
         self._flash_node = None

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import sys
+
 from collections import defaultdict
 
 # globals
@@ -187,7 +189,10 @@ def node_label(node_path):
 
 
 def get_parent_path(node_path):
-    # Turns /foo/bar into /foo
+    # Turns /foo/bar into /foo. Returns None for /.
+
+    if node_path == '/':
+        return None
 
     return '/'.join(node_path.split('/')[:-1]) or '/'
 
@@ -467,3 +472,10 @@ def extract_cells(node_path, prop, prop_values, names, index,
                     prop_alias)
 
             insert_defs(node_path, prop_def, prop_alias)
+
+
+def err(msg):
+    # General error reporting helper. Prints a message to stderr and exits with
+    # status 1.
+
+    sys.exit("error: " + msg)

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -355,7 +355,7 @@ def extract_controller(node_path, prop, prop_values, index,
         if l_cell is None:
             continue
 
-        l_base = def_label.split('/')
+        l_base = [def_label]
 
         # Check is defined should be indexed (_0, _1)
         if handle_single or i == 0 and len(prop_array) == 1:
@@ -438,7 +438,7 @@ def extract_cells(node_path, prop, prop_values, names, index,
         else:
             l_cell = [str_to_label(str(generic))]
 
-        l_base = def_label.split('/')
+        l_base = [def_label]
         # Check if #define should be indexed (_0, _1, ...)
         if handle_single or i == 0 and len(prop_array) == 1:
             # Less than 2 elements in prop_values

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -167,7 +167,7 @@ def create_reduced(node, path):
             create_reduced(child_node, path + child_name)
 
 
-def get_node_label(node_path):
+def node_label(node_path):
     node_compat = get_compat(node_path)
     def_label = str_to_label(node_compat)
     if '@' in node_path:

--- a/scripts/dts/extract/interrupts.py
+++ b/scripts/dts/extract/interrupts.py
@@ -11,10 +11,6 @@ from extract.directive import DTDirective
 # @brief Manage interrupts directives.
 #
 class DTInterrupts(DTDirective):
-
-    def __init__(self):
-        pass
-
     def _find_parent_irq_node(self, node_path):
         address = ''
 

--- a/scripts/dts/extract/interrupts.py
+++ b/scripts/dts/extract/interrupts.py
@@ -11,17 +11,6 @@ from extract.directive import DTDirective
 # @brief Manage interrupts directives.
 #
 class DTInterrupts(DTDirective):
-    def _find_parent_irq_node(self, node_path):
-        address = ''
-
-        for comp in node_path.split('/')[1:]:
-            address += '/' + comp
-            if 'interrupt-parent' in reduced[address]['props']:
-                interrupt_parent = reduced[address]['props'][
-                    'interrupt-parent']
-
-        return phandles[interrupt_parent]
-
     ##
     # @brief Extract interrupts
     #
@@ -40,7 +29,9 @@ class DTInterrupts(DTDirective):
         except:
             props = [node['props'].get(prop)]
 
-        irq_parent = self._find_parent_irq_node(node_path)
+        irq_parent = parent_irq_node(node_path)
+        if not irq_parent:
+            err(node_path + " has no interrupt-parent")
 
         l_base = def_label.split('/')
         index = 0
@@ -87,6 +78,17 @@ class DTInterrupts(DTDirective):
 
             index += 1
             insert_defs(node_path, prop_def, prop_alias)
+
+
+def parent_irq_node(node_path):
+    while node_path:
+        if 'interrupt-parent' in reduced[node_path]['props']:
+            return phandles[reduced[node_path]['props']['interrupt-parent']]
+
+        node_path = get_parent_path(node_path)
+
+    return None
+
 
 ##
 # @brief Management information for interrupts.

--- a/scripts/dts/extract/pinctrl.py
+++ b/scripts/dts/extract/pinctrl.py
@@ -11,10 +11,6 @@ from extract.directive import DTDirective
 # @brief Manage pinctrl-x directive.
 #
 class DTPinCtrl(DTDirective):
-
-    def __init__(self):
-        pass
-
     ##
     # @brief Extract pinctrl information.
     #

--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -13,10 +13,6 @@ from extract.directive import DTDirective
 # @brief Manage reg directive.
 #
 class DTReg(DTDirective):
-
-    def __init__(self):
-        pass
-
     ##
     # @brief Extract reg directive info
     #
@@ -27,7 +23,6 @@ class DTReg(DTDirective):
     #                  compatible definition.
     #
     def extract(self, node_path, names, def_label, div):
-
         node = reduced[node_path]
         node_compat = get_compat(node_path)
         binding = get_binding(node_path)

--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -47,7 +47,7 @@ class DTReg(DTDirective):
                     extract_cells(node_path, "cs-gpios", cs_gpios, None, reg[0], def_label, "cs-gpio", True)
 
         # generate defines
-        l_base = def_label.split('/')
+        l_base = [def_label]
         l_addr = [str_to_label("BASE_ADDRESS")]
         l_size = ["SIZE"]
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -66,10 +66,10 @@ def generate_prop_defines(node_path, prop):
         # If the binding specifies a parent for the node, then include the
         # parent in the #define's generated for the properties
         parent_path = get_parent_path(node_path)
-        def_label = 'DT_' + get_node_label(parent_path) + '_' \
-                          + get_node_label(node_path)
+        def_label = 'DT_' + node_label(parent_path) + '_' \
+                          + node_label(node_path)
     else:
-        def_label = 'DT_' + get_node_label(node_path)
+        def_label = 'DT_' + node_label(node_path)
 
     names = prop_names(reduced[node_path], prop)
 
@@ -174,7 +174,7 @@ def generate_bus_defines(node_path):
     # Generate *_BUS_NAME #define
     extract_bus_name(
         node_path,
-        'DT_' + get_node_label(parent_path) + '_' + get_node_label(node_path))
+        'DT_' + node_label(parent_path) + '_' + node_label(node_path))
 
 
 def prop_names(node, prop_name):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -457,10 +457,8 @@ def generate_defines():
         if k in chosen:
             extract_string_prop(chosen[k], "label", v)
 
-    node_path = chosen.get('zephyr,flash', 'dummy-flash')
-    flash.extract(node_path, 'zephyr,flash', 'DT_FLASH')
-    node_path = chosen.get('zephyr,code-partition', node_path)
-    flash.extract(node_path, 'zephyr,code-partition', None)
+    flash.extract_flash()
+    flash.extract_code_partition()
 
     # Add DT_CHOSEN_<X> defines
     for c in sorted(chosen):


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/zephyr/pull/13649.

Makes the Flash handling code less twisty/more direct, e.g. by getting rid of some magic string values that were passed around, removing parameters for things that are available globally, and by removing an instance variable (`_flash_node`) that can easily be derived wherever it's needed.

Also includes some cleanups to the interrupt handling and some misc. stuff.