### PR TITLE
net: ipv6: Extension header length failure not properly checked

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -486,7 +486,7 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 
 	nexthdr = hdr->nexthdr;
 	while (!net_ipv6_is_nexthdr_upper_layer(nexthdr)) {
-		u16_t exthdr_len;
+		int exthdr_len;
 
 		NET_DBG("IPv6 next header %d", nexthdr);
 


### PR DESCRIPTION
The ipv6_handle_ext_hdr_options() can return negative value
but we stored it into unsigned variable and then checked < 0.

Coverity-CID: 190995
Fixes #13830

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>