### PR TITLE
net: context: Remove dead code from net_context_connect

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1117,8 +1117,6 @@ int net_context_connect(struct net_context *context,
 		goto unlock;
 	}
 
-	ret = 0;
-
 unlock:
 	k_mutex_unlock(&context->lock);
 


### PR DESCRIPTION
The ret=0; statement cannot be reached.

Coverity-CID: 190973
Fixes #13846

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>