### PR TITLE
samples: shields: x_nucleo_iks01a1

### DIFF
--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -87,7 +87,7 @@
 	status ="ok";
 };
 
-&uart0 {
+arduino_serial: &uart0 {
 	status = "ok";
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
@@ -97,7 +97,7 @@
 	cts-pin = <7>;
 };
 
-&i2c0 {
+arduino_i2c: &i2c0 {
 	status = "ok";
 	sda-pin = <26>;
 	scl-pin = <27>;
@@ -122,7 +122,7 @@
 	miso-pin = <25>;
 };
 
-&spi1 {
+arduino_spi: &spi1 {
 	status = "ok";
 	sck-pin = <31>;
 	mosi-pin = <30>;


### PR DESCRIPTION
Fix "arduino_i2c not found" issue, similar to #13708

Add arduino interfaces in dts to board nrf52_10040

Signed-off-by: Aaron Tsui <aaron.tsui@outlook.com>