### PR TITLE
drivers: can: Fix none negative and overlapping error numbers and some other nits

### DIFF
--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -19,12 +19,13 @@ Z_SYSCALL_HANDLER(can_send, dev, msg, timeout, callback_isr) {
 
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, send));
 
-	Z_OOPS(Z_SYSCALL_MEMORY_READ((struct can_msg *)msg,
-				      sizeof(struct can_msg)));
-	Z_OOPS(Z_SYSCALL_MEMORY_READ(((struct can_msg *)msg)->data,
-				     sizeof((struct can_msg *)msg)->data));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ((const struct zcan_frame *)msg,
+				      sizeof(struct zcan_frame)));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(((struct zcan_frame *)msg)->data,
+				     sizeof((struct zcan_frame *)msg)->data));
 
-	return _impl_can_send((struct device *)dev, (struct can_msg *)msg,
+	return _impl_can_send((struct device *)dev,
+			      (const struct zcan_frame *)msg,
 			      (s32_t)timeout, (can_tx_callback_t) callback_isr);
 }
 
@@ -32,8 +33,8 @@ Z_SYSCALL_HANDLER(can_attach_msgq, dev, msgq, filter) {
 
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, attach_msgq));
 
-	Z_OOPS(Z_SYSCALL_MEMORY_READ((struct can_filter *)filter,
-				     sizeof(struct can_filter)));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ((struct zcan_filter *)filter,
+				     sizeof(struct zcan_filter)));
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE((struct k_msgq *)msgq,
 				      sizeof(struct k_msgq)));
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(((struct k_msgq *)msgq)->buffer_start,
@@ -42,19 +43,19 @@ Z_SYSCALL_HANDLER(can_attach_msgq, dev, msgq, filter) {
 
 	return _impl_can_attach_msgq((struct device *)dev,
 				     (struct k_msgq *)msgq,
-				     (const struct can_filter *) filter);
+				     (const struct zcan_filter *) filter);
 }
 
 Z_SYSCALL_HANDLER(can_attach_isr, dev, isr, filter) {
 
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, attach_isr));
 
-	Z_OOPS(Z_SYSCALL_MEMORY_READ((struct can_filter *)filter,
-				     sizeof(struct can_filter)));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ((struct zcan_filter *)filter,
+				     sizeof(struct zcan_filter)));
 
 	return _impl_can_attach_isr((struct device *)dev,
 				    (can_rx_callback_t)isr,
-				    (const struct can_filter *) filter);
+				    (const struct zcan_filter *) filter);
 }
 
 Z_SYSCALL_HANDLER(can_detach, dev, filter_id) {

--- a/drivers/can/stm32_can.c
+++ b/drivers/can/stm32_can.c
@@ -319,8 +319,8 @@ static int can_stm32_init(struct device *dev)
 	return 0;
 }
 
-int can_stm32_send(struct device *dev, struct zcan_frame *msg, s32_t timeout,
-		   can_tx_callback_t callback)
+int can_stm32_send(struct device *dev, const struct zcan_frame *msg,
+		   s32_t timeout, can_tx_callback_t callback)
 {
 	const struct can_stm32_config *cfg = DEV_CFG(dev);
 	struct can_stm32_data *data = DEV_DATA(dev);

--- a/include/can.h
+++ b/include/can.h
@@ -245,7 +245,7 @@ typedef int (*can_configure_t)(struct device *dev, enum can_mode mode,
  * @retval 0 If successful.
  * @retval CAN_TX_* on failure.
  */
-typedef int (*can_send_t)(struct device *dev, struct zcan_frame *msg,
+typedef int (*can_send_t)(struct device *dev, const struct zcan_frame *msg,
 			  s32_t timeout, can_tx_callback_t callback_isr);
 
 
@@ -313,10 +313,11 @@ struct can_driver_api {
 };
 
 
-__syscall int can_send(struct device *dev, struct zcan_frame *msg,
+__syscall int can_send(struct device *dev, const struct zcan_frame *msg,
 		       s32_t timeout, can_tx_callback_t callback_isr);
 
-static inline int _impl_can_send(struct device *dev, struct zcan_frame *msg,
+static inline int _impl_can_send(struct device *dev,
+				 const struct zcan_frame *msg,
 				 s32_t timeout, can_tx_callback_t callback_isr)
 {
 	const struct can_driver_api *api = dev->driver_api;
@@ -344,7 +345,7 @@ static inline int _impl_can_send(struct device *dev, struct zcan_frame *msg,
  * @retval -EIO General input / output error.
  * @retval -EINVAL if length > 8.
  */
-static inline int can_write(struct device *dev, u8_t *data, u8_t length,
+static inline int can_write(struct device *dev, const u8_t *data, u8_t length,
 			    u32_t id, enum can_rtr rtr, s32_t timeout)
 {
 	struct zcan_frame msg;

--- a/include/can.h
+++ b/include/can.h
@@ -39,19 +39,19 @@ extern "C" {
 /** send successfully */
 #define CAN_TX_OK       (0)
 /** general send error */
-#define CAN_TX_ERR      (1)
+#define CAN_TX_ERR      (-2)
 /** bus arbitration lost during sending */
-#define CAN_TX_ARB_LOST (2)
+#define CAN_TX_ARB_LOST (-3)
 /** controller is in bus off state */
-#define CAN_TX_BUS_OFF  (3)
+#define CAN_TX_BUS_OFF  (-4)
 /** unexpected error */
-#define CAN_TX_UNKNOWN  (4)
+#define CAN_TX_UNKNOWN  (-5)
 
 /** attach_* failed because there is no unused filter left*/
 #define CAN_NO_FREE_FILTER (-1)
 
 /** operation timed out*/
-#define CAN_TIMEOUT (1)
+#define CAN_TIMEOUT (-1)
 
 /**
  * @brief Statically define and initialize a can message queue.


### PR DESCRIPTION
This PR makes the CAN error numbers negative and none overlapping.
The zcan_frame is now const for sending.
Fixed the userspace handler types that have changed after Linux compatibility changes.