### PR TITLE
doc/contribute: Add tip to run Checkpatch in pre-push hook

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -232,6 +232,7 @@
 /scripts/process_gperf.py                 @andrewboie
 /scripts/sanity_chk/                      @andrewboie @nashif
 /scripts/sanitycheck                      @andrewboie @nashif
+/scripts/series-push-hook.sh              @erwango
 /scripts/west_commands/                   @mbolivar
 /scripts/west-commands.yml                @mbolivar
 /subsys/bluetooth/                        @sjanc @jhedberg @Vudentz

--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -362,6 +362,34 @@ it to contain:
     set -e exec
     exec git diff --cached | ${ZEPHYR_BASE}/scripts/checkpatch.pl -
 
+Instead of running checkpatch at each commit, you may prefer to run it only
+before pushing on zephyr repo. To do this, make the file
+*$ZEPHYR_BASE/.git/hooks/pre-push* executable and edit it to contain:
+
+.. code-block:: bash
+
+    #!/bin/sh
+    remote="$1"
+    url="$2"
+
+    z40=0000000000000000000000000000000000000000
+
+    echo "Run push hook"
+
+    while read local_ref local_sha remote_ref remote_sha
+    do
+        args="$remote $url $local_ref $local_sha $remote_ref $remote_sha"
+        exec ${ZEPHYR_BASE}/series-push-hook.sh $args
+    done
+
+    exit 0
+
+If you want to override checkpatch verdict and push you branch despite reported
+issues, you can add option --no-verify to the git push command.
+
+A more complete alternative to this is using check_compliance.py script from
+ci-tools repo.
+
 .. _Contribution workflow:
 
 Contribution Workflow

--- a/scripts/series-push-hook.sh
+++ b/scripts/series-push-hook.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# Copyright (c) 2019 Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+remote=$1
+url=$2
+local_ref=$3
+local_sha=$4
+remote_ref=$5
+remote_sha=$6
+z40=0000000000000000000000000000000000000000
+
+set -e exec
+
+echo "Run push "
+
+if [ "$local_sha" = $z40 ]
+then
+	# Handle delete
+	:
+else
+	if [ "$remote_sha" = $z40 ]
+	then
+		# New branch, examine all commits since $remote/master
+		base_commit=`git rev-parse $remote/master`
+		range="$base_commit..$local_sha"
+	else
+		# Update to existing branch, examine new commits
+		range="$remote_sha..$local_sha"
+	fi
+
+	echo "Perform check patch"
+	/local/mcu/zephyr/zephyr-project/scripts/checkpatch.pl --git $range
+fi


### PR DESCRIPTION
Running Checkpatch in pre-commit hook could be a constraint
for day to day work. Though, running it before pushing to
zephyr repo.
Add a tip to run the script automatically before pushing thanks
to pre-psuh hook.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>