### PR TITLE
lib: os: fdtable: Add underscore aliases for read/write/close/lseek

### DIFF
--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -156,6 +156,7 @@ ssize_t read(int fd, void *buf, size_t sz)
 
 	return fdtable[fd].vtable->read(fdtable[fd].obj, buf, sz);
 }
+FUNC_ALIAS(read, _read, ssize_t);
 
 ssize_t write(int fd, const void *buf, size_t sz)
 {
@@ -165,6 +166,7 @@ ssize_t write(int fd, const void *buf, size_t sz)
 
 	return fdtable[fd].vtable->write(fdtable[fd].obj, buf, sz);
 }
+FUNC_ALIAS(write, _write, ssize_t);
 
 int close(int fd)
 {
@@ -179,6 +181,7 @@ int close(int fd)
 
 	return res;
 }
+FUNC_ALIAS(close, _close, int);
 
 int fsync(int fd)
 {
@@ -198,6 +201,7 @@ off_t lseek(int fd, off_t offset, int whence)
 	return z_fdtable_call_ioctl(fdtable[fd].vtable, fdtable[fd].obj, ZFD_IOCTL_LSEEK,
 			  offset, whence);
 }
+FUNC_ALIAS(lseek, _lseek, off_t);
 
 int ioctl(int fd, unsigned long request, ...)
 {


### PR DESCRIPTION
These get references by newlib builds in other toolchains, e.g.
gnuarmemb, and lack of them breaks linking. Tested that
tests/posix/fs and tests/posix/common actually work with these
changes.

Fixes: #13906

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>