### PR TITLE
west_commands: pyocd: Sector erase by default

### DIFF
--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -71,7 +71,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                             help='path to pyocd tool, default is pyocd')
         parser.add_argument('--flash-opt', default=[], action='append',
                             help='''Additional options for pyocd flash,
-                            e.g. -ce to chip erase''')
+                            e.g. \'-e chip\' to chip erase''')
         parser.add_argument('--frequency',
                             help='SWD clock frequency in Hz')
         parser.add_argument('--gdb-port', default=DEFAULT_PYOCD_GDB_PORT,
@@ -125,6 +125,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
 
         cmd = ([self.pyocd] +
                ['flash'] +
+               ['-e', 'sector'] +
                self.flash_addr_args +
                self.daparg_args +
                self.target_args +

--- a/scripts/west_commands/tests/test_pyocd.py
+++ b/scripts/west_commands/tests/test_pyocd.py
@@ -63,12 +63,14 @@ TEST_DEF_PARAMS = ['--target', TEST_TARGET]
 
 FLASH_ALL_EXPECTED_CALL = ([TEST_PYOCD,
                             'flash',
+                            '-e', 'sector',
                             '-a', hex(TEST_ADDR), '-da', TEST_DAPARG,
                             '-t', TEST_TARGET, '-b', TEST_BOARD_ID,
                             '-f', TEST_FREQUENCY] +
                            TEST_FLASH_OPTS +
                            [RC_KERNEL_HEX])
-FLASH_DEF_EXPECTED_CALL = ['pyocd', 'flash', '-t', TEST_TARGET, RC_KERNEL_HEX]
+FLASH_DEF_EXPECTED_CALL = ['pyocd', 'flash', '-e', 'sector',
+                           '-t', TEST_TARGET, RC_KERNEL_HEX]
 
 
 DEBUG_ALL_EXPECTED_SERVER = [TEST_PYOCD,


### PR DESCRIPTION
Due to issues with the implementation of the default auto-erase in
pyocd, sometimes the chip is mass-erased even when not intended. To
avoid this issue, default to forcing sector erasing unless mass erasure
is explicitly requested by the user.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>