### PR TITLE
net: tcp: Check TCP ACK flag properly during conn establishment

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2338,7 +2338,7 @@ NET_CONN_CB(tcp_syn_rcvd)
 	/*
 	 * If we receive ACK, we go to ESTABLISHED state.
 	 */
-	if (NET_TCP_FLAGS(tcp_hdr) == NET_TCP_ACK) {
+	if (NET_TCP_FLAGS(tcp_hdr) & NET_TCP_ACK) {
 		struct net_context *new_context;
 		socklen_t addrlen;
 		int ret;


### PR DESCRIPTION
Multiple flag bits were set so the ACK flag set was not checked
properly which meant that connection establishment was not
successfull.

Fixes #13943

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>