### PR TITLE
soc: openisa_rv32m1: Implement sys_arch_reboot()

### DIFF
--- a/soc/riscv32/openisa_rv32m1/soc.c
+++ b/soc/riscv32/openisa_rv32m1/soc.c
@@ -59,6 +59,13 @@ static const scg_lpfll_config_t rv32m1_lpfll_cfg = {
 	.trimConfig = NULL,
 };
 
+void sys_arch_reboot(int type)
+{
+	ARG_UNUSED(type);
+
+	EVENT_UNIT->SLPCTRL |= EVENT_SLPCTRL_SYSRSTREQST_MASK;
+}
+
 void _arch_irq_enable(unsigned int irq)
 {
 	if (IS_ENABLED(CONFIG_MULTI_LEVEL_INTERRUPTS)) {


### PR DESCRIPTION
Implements sys_arch_reboot() on the openisa_rv32m1 soc to enable zephyr
micropython on the rv32m1_vega board.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>