### PR TITLE
drivers/timer: Restore non-tickless tick count behavior

### DIFF
--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -53,7 +53,7 @@ static void hpet_isr(void *arg)
 	}
 
 	k_spin_unlock(&lock, key);
-	z_clock_announce(dticks);
+	z_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1);
 }
 
 static void set_timer0_irq(unsigned int irq)

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -83,7 +83,7 @@ void rtc1_nrf_isr(void *arg)
 	}
 
 	irq_unlock(key);
-	z_clock_announce(dticks);
+	z_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1);
 }
 
 int z_clock_driver_init(struct device *device)

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -68,7 +68,7 @@ static void timer_isr(void *arg)
 	}
 
 	k_spin_unlock(&lock, key);
-	z_clock_announce(dticks);
+	z_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1);
 }
 
 int z_clock_driver_init(struct device *device)

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -54,7 +54,7 @@ static void ccompare_isr(void *arg)
 	}
 
 	k_spin_unlock(&lock, key);
-	z_clock_announce(dticks);
+	z_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1);
 }
 
 /* The legacy Xtensa platform code handles the timer interrupt via a


### PR DESCRIPTION
The newer series of timer drivers will compare counters vs. the last
tick boundary to compute a number of ticks to announce to the kernel.
In the case of CONFIG_TICKLESS=n, this actually represents a change of
behavior from our old scheme where "ticks" always reflected the number
of interrupts received.

The distinction only matters when an interrupt is delayed more than a
full tick, of course.  But that actually makes a difference to some
timekeeping code.  Restore the old behavior.

This also has the benefit of further reducing code size when !TICKLESS
and improving performance of the ISR by removing the division
(remember Cortex M0 has no hardware divide!).

Fixes #12409

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>