### PR TITLE
boards: rv32m1_vega: Have identifier match name

### DIFF
--- a/boards/riscv32/rv32m1_vega/rv32m1_vega_ri5cy.yaml
+++ b/boards/riscv32/rv32m1_vega/rv32m1_vega_ri5cy.yaml
@@ -1,4 +1,4 @@
-identifier: rv32m1_vega
+identifier: rv32m1_vega_ri5cy
 name: RV32M1-VEGA
 type: mcu
 arch: riscv32


### PR DESCRIPTION
We expect that identifier in yaml will match board name for sanitycheck.
Change the identifier to match so sanitycheck runs propertly.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>