### PR TITLE
can: cast value 1U to type ULL in function can_stm32_set_filter

### DIFF
--- a/drivers/can/stm32_can.c
+++ b/drivers/can/stm32_can.c
@@ -655,7 +655,7 @@ static inline int can_stm32_set_filter(const struct zcan_filter *filter,
 
 	do {
 		u64_t usage_shifted = (device_data->filter_usage >> filter_nr);
-		u64_t usage_demand_mask = (1U << register_demand) - 1;
+		u64_t usage_demand_mask = ((u64_t)1U << register_demand) - 1;
 		bool bank_is_empty;
 
 		bank_nr = filter_nr / 4;

--- a/drivers/can/stm32_can.c
+++ b/drivers/can/stm32_can.c
@@ -655,7 +655,7 @@ static inline int can_stm32_set_filter(const struct zcan_filter *filter,
 
 	do {
 		u64_t usage_shifted = (device_data->filter_usage >> filter_nr);
-		u64_t usage_demand_mask = ((u64_t)1U << register_demand) - 1;
+		u64_t usage_demand_mask = (1ULL << register_demand) - 1;
 		bool bank_is_empty;
 
 		bank_nr = filter_nr / 4;


### PR DESCRIPTION
Potentially overflowing expression 1U << register_demand
changed to the 1ULL << register_demand to avoid overflow.

Coverity-CID: 190996
Fixes: #13829

Signed-off-by: Maksim Masalski <maxxliferobot@gmail.com>