### PR TITLE
tests: hwinfo: Fix invalid assertion

### DIFF
--- a/tests/drivers/hwinfo/api/src/main.c
+++ b/tests/drivers/hwinfo/api/src/main.c
@@ -34,7 +34,7 @@ static void test_device_id_get(void)
 {
 	u8_t buffer_1[BUFFER_LENGTH];
 	u8_t buffer_2[BUFFER_LENGTH];
-	size_t length_read_1, length_read_2;
+	ssize_t length_read_1, length_read_2;
 	int i;
 
 	length_read_1 = hwinfo_get_device_id(buffer_1, 1);


### PR DESCRIPTION
The return of hwinfo_get_device_id is a signed size and it returns a
negative number in case of error. This test was using an unsigned
variable invalidating the errror check.

Fixes #13884
Fixes CID-190929

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>