### PR TITLE
drivers: can: Z_SYCALL_HANDLER should return int

### DIFF
--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -63,4 +63,6 @@ Z_SYSCALL_HANDLER(can_detach, dev, filter_id) {
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, detach));
 
 	_impl_can_detach((struct device *)dev, (int)filter_id);
+
+	return 0;
 }


### PR DESCRIPTION
can_handlers.c:65:1: warning: control reaches end of non-void function
[-Wreturn-type]

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>