### PR TITLE
tests/kernel/fifo/fifo_timeout: Tick alignment for oversensitive timing

### DIFF
--- a/tests/kernel/fifo/fifo_timeout/src/main.c
+++ b/tests/kernel/fifo/fifo_timeout/src/main.c
@@ -124,6 +124,8 @@ static void test_thread_pend_and_timeout(void *p1, void *p2, void *p3)
 	u32_t start_time;
 	void *packet;
 
+	k_sleep(1); /* Align to ticks */
+
 	start_time = k_cycle_get_32();
 	packet = k_fifo_get(d->fifo, d->timeout);
 	zassert_true(packet == NULL, NULL);
@@ -298,6 +300,8 @@ static void test_timeout_empty_fifo(void)
 	void *packet;
 	u32_t start_time, timeout;
 
+	k_sleep(1); /* Align to ticks */
+
 	/* Test empty fifo with timeout */
 	timeout = 10U;
 	start_time = k_cycle_get_32();
@@ -348,6 +352,8 @@ static void test_timeout_fifo_thread(void)
 	void *packet, *scratch_packet;
 	struct reply_packet reply_packet;
 	u32_t start_time, timeout;
+
+	k_sleep(1); /* Align to ticks */
 
 	/*
 	 * Test fifo with some timeout and child thread that puts


### PR DESCRIPTION
This test was written to wait on a fifo with a timeout, return, and
check the timing between the start and end using k_cycle_get_32() to
see that it didn't run long.  But timeouts expire on tick boundaries,
and so if tick expires between the start of the test and the entry to
k_fifo_get(), the timeout will take one full tick longer than expected
due to aliasing.

As it happened this passed everywhere except nRF (whose cycle timer is
32 kHz and thus more susceptible to coarser aliasing like this), and
even there it passed for a while until the spinlock validation layer
went in and added just enough time to the userspace code paths
(i.e. the code between the start time fetch and the point where the
fifo blocks takes longer) to open the window and push us over the
limit.

The workaround here is just to add a k_sleep(1) call, which is
guaranteed to block and wake up synchronously at the next tick.

Fixes #13289

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>