### PR TITLE
libc: ctype: Fix operations between signed and unsigned types

### DIFF
--- a/lib/libc/minimal/include/ctype.h
+++ b/lib/libc/minimal/include/ctype.h
@@ -15,54 +15,58 @@ extern "C" {
 
 static inline int isupper(int a)
 {
-	return ((unsigned)(a)-'A') < 26;
+	return (int)(((unsigned)(a)-(unsigned)'A') < 26U);
 }
 
 static inline int isalpha(int c)
 {
-	return (((unsigned)c|32)-'a') < 26;
+	return (int)((((unsigned)c|32u)-(unsigned)'a') < 26U);
 }
 
 static inline int isspace(int c)
 {
-	return c == ' ' || ((unsigned)c-'\t') < 5;
+	return (int)(c == (int)' ' || ((unsigned)c-(unsigned)'\t') < 5U);
 }
 
 static inline int isgraph(int c)
 {
-	return ((((unsigned)c) > ' ') && (((unsigned)c) <= '~'));
+	return (int)((((unsigned)c) > ' ') &&
+			(((unsigned)c) <= (unsigned)'~'));
 }
 
 static inline int isprint(int c)
 {
-	return ((((unsigned)c) >= ' ') && (((unsigned)c) <= '~'));
+	return (int)((((unsigned)c) >= ' ') &&
+			(((unsigned)c) <= (unsigned)'~'));
 }
 
 static inline int isdigit(int a)
 {
-	return (((unsigned)(a)-'0') < 10);
+	return (int)(((unsigned)(a)-(unsigned)'0') < 10U);
 }
 
 static inline int isxdigit(int a)
 {
 	unsigned int ua = (unsigned int)a;
 
-	return ((ua - '0') < 10U) || ((ua | 32U) - 'a' < 6);
+	return (int)(((ua - (unsigned)'0') < 10U) ||
+			((ua | 32U) - (unsigned)'a' < 6U));
 }
 
 static inline int tolower(int chr)
 {
-	return (chr >= 'A' && chr <= 'Z') ? (chr + 32) : (chr);
+	return (chr >= (int)'A' && chr <= (int)'Z') ? (chr + 32) : (chr);
 }
 
 static inline int toupper(int chr)
 {
-	return (chr >= 'a' && chr <= 'z') ? (chr - 32) : (chr);
+	return (int)((chr >= (int)'a' && chr <=
+				(int)'z') ? (chr - 32) : (chr));
 }
 
 static inline int isalnum(int chr)
 {
-	return isalpha(chr) || isdigit(chr);
+	return (int)(isalpha(chr) || isdigit(chr));
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
MISRA-C says that char type should not be used in arithmetically as the
data doesn't represent numbers.

MISRA-C rules 10.1 and 10.2

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>