### PR TITLE
run_ci.sh: git log what [base] version is being tested

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -15,7 +15,7 @@
 # -r  the remote to rebase on
 #
 # The script can be run locally using for exmaple:
-# ./scripts/ci/run_ci.sh -b master -r upstream  -l
+# ./scripts/ci/run_ci.sh -b master -r origin  -l
 
 set -xe
 
@@ -89,7 +89,7 @@ if [ -n "$MAIN_CI" ]; then
 
 	if [ -z "$BRANCH" ]; then
 		echo "No base branch given"
-		exit
+		exit 1
 	else
 		COMMIT_RANGE=$REMOTE/${BRANCH}..HEAD
 		echo "Commit range:" ${COMMIT_RANGE}
@@ -245,9 +245,10 @@ if [ -n "$MAIN_CI" ]; then
 		# builder 1.  For now, this is just done for the west
 		# extension commands, but additional directories which
 		# run pytest could go here too.
+		PYTEST=$(type -p pytest-3 || echo "pytest")
 		mkdir -p $(dirname ${WEST_COMMANDS_RESULTS_FILE})
 		WEST_SRC=$(west list --format='{abspath}' west)/src
-		PYTHONPATH=./scripts/west_commands:$WEST_SRC pytest \
+		PYTHONPATH=./scripts/west_commands:$WEST_SRC "${PYTEST}" \
 			  --junitxml=${WEST_COMMANDS_RESULTS_FILE} \
 			  ./scripts/west_commands/tests
 	else

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -96,9 +96,18 @@ if [ -n "$MAIN_CI" ]; then
 	fi
 	source zephyr-env.sh
 	SANITYCHECK="${ZEPHYR_BASE}/scripts/sanitycheck"
+
+	# Possibly the only record of what exact version is being tested:
+	short_git_log='git log -n 5 --oneline --decorate --abbrev=12 '
+
 	if [ -n "$PULL_REQUEST_NR" ]; then
+		$short_git_log $REMOTE/${BRANCH}
+		# Now let's pray this script is being run from a
+		# different location
+# https://stackoverflow.com/questions/3398258/edit-shell-script-while-its-running
 		git rebase $REMOTE/${BRANCH};
 	fi
+	$short_git_log
 fi
 
 function handle_coverage() {


### PR DESCRIPTION
Zephyr Continuous Integration made the choice of rebasing pull requests
on its fast moving master branch before testing them. Unfortunately the
Shippable interface assumes the other choice[*] and highlights the SHA1
of the pull request _before_ rebasing which is very misleading.  For now
the only way to realize this disconnect is to scrutinize the build logs
and/or this source code (or tribal knowledge).

To mitigate and reduce a bit this confusion, run a short:
  git log -n 5 --oneline --decorate
before and after rebase.

Making it worse, Shippable sub-runs are not pegged to a common base
version. For instance the reason why shippable sub-run 35578.1 passed
while all other 35578.x sub runs failed is very likely because PR #13803
was merged to master in the mean time. This commit would have been able
to prove that.

[*] In an ideal world with infinite time and resources, Continuous
Integration would test pull requests BOTH alone and combined with the
moving tip.