### PR TITLE
tests: fs: Add missing return check

### DIFF
--- a/tests/subsys/fs/nffs_fs_api/common/test_append.c
+++ b/tests/subsys/fs/nffs_fs_api/common/test_append.c
@@ -95,7 +95,8 @@ void test_append(void)
 
 	/*** Repeated appends to a large file. */
 	for (i = 0; i < 1000; i++) {
-		fs_stat(NFFS_MNTP"/mydir/gaga.txt", &info);
+		rc = fs_stat(NFFS_MNTP"/mydir/gaga.txt", &info);
+		zassert_equal(rc, 0, "fs_stat returned error");
 		zassert_equal(info.size, i, "file lengths not matching");
 
 		c = '0' + i % 10;


### PR DESCRIPTION
Checking the return of fs_stat to ensure that there is not hidden error.
Problem spotted by coverity.

Fixes CID 190949
Fixes #13866

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>