### PR TITLE
CODEOWNERS: fix 3 check-compliance.py issues not reported by github

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -133,7 +133,7 @@
 /drivers/wifi/eswifi/                     @loicpoulain
 /dts/arm/st/                              @erwango
 /dts/arm/nordic/                          @ioannisg @carlescufi
-/dts/bindings/can                         @alexanderwachter
+/dts/bindings/can/                        @alexanderwachter
 /ext/fs/                                  @nashif @ramakrishnapallala
 /ext/hal/cmsis/                           @MaureenHelm @galak
 /ext/hal/nordic/                          @carlescufi @anangl
@@ -204,7 +204,7 @@
 /kernel/device.c                          @andrewboie @andyross @nashif
 /kernel/idle.c                            @andrewboie @andyross @nashif
 /samples/bluetooth/                       @sjanc @jhedberg @Vudentz
-/samples/boards/intel_s1000_crb           @sathishkuttan @rgundi @nashif
+/samples/boards/intel_s1000_crb/          @sathishkuttan @rgundi @nashif
 /samples/display/                         @vanwinkeljan
 /samples/drivers/CAN/                     @alexanderwachter
 /samples/gui/                             @vanwinkeljan
@@ -222,10 +222,10 @@
 /scripts/elf_helper.py                    @andrewboie
 /scripts/sanity_chk/expr_parser.py        @andrewboie @nashif
 /scripts/gen_app_partitions.py            @andrewboie
-/scripts/gen_gdt.py                       @andrewboie
-/scripts/gen_idt.py                       @andrewboie
+/arch/x86/gen_gdt.py                      @andrewboie
+/arch/x86/gen_idt.py                      @andrewboie
 /scripts/gen_kobject_list.py              @andrewboie
-/scripts/gen_mmu_x86.py                   @andrewboie
+/arch/x86/gen_mmu_x86.py                  @andrewboie
 /scripts/gen_priv_stacks.py               @agross-linaro
 /scripts/gen_syscall_header.py            @andrewboie
 /scripts/gen_syscalls.py                  @andrewboie


### PR DESCRIPTION
- PR #13722 moved 3 gen_*.py to /arch/x86/ without updating CODEOWNERS
- PR #13745 forgot a trailing slash in /dts/bindings/can
- PR #13675 forgot a trailing slash in /samples/boards/intel_s1000_crb

No idea why github doesn't keep reporting these every time and
impossible to tell as CI hides most of its logs.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>