### PR TITLE
net: context: Explicit net_sock_type enum conversion

### DIFF
--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -405,7 +405,7 @@ enum net_sock_type net_context_get_type(struct net_context *context)
 {
 	NET_ASSERT(context);
 
-	return ((context->flags & NET_CONTEXT_TYPE) >> 6);
+	return (enum net_sock_type)((context->flags & NET_CONTEXT_TYPE) >> 6);
 }
 
 /**


### PR DESCRIPTION
When compiling with C++ support, a build error occur:

net_context.h: In function ‘net_sock_type net_context_get_type(net_context*)’:
net_context.h:402:75: error: invalid conversion from ‘long unsigned int’ to ‘net_sock_type’ [-fpermissive]
  enum net_sock_type t = ((context->flags & NET_CONTEXT_TYPE) >> 6);

Let's fix that using a cast.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>