### PR TITLE
tests: fs/nffs_fs_api: fix uninitialized reference time variable

### DIFF
--- a/tests/subsys/fs/nffs_fs_api/common/test_performance.c
+++ b/tests/subsys/fs/nffs_fs_api/common/test_performance.c
@@ -39,7 +39,7 @@ void test_performance(void)
 {
 	char filename[16];
 	struct fs_file_t file;
-	s64_t reftime;
+	s64_t reftime = k_uptime_get();
 	u32_t delta;
 	int i;
 	int rc;


### PR DESCRIPTION
The reftime variable used for performance numbers is not initialized
prior to being used. Initialize it to the current uptime so delta
can be calculated correctly.

Fixes #13877
Fixes CID-190936

Signed-off-by: Daniel Leung <daniel.leung@intel.com>