### PR TITLE
subsys: fs/shell: fix unchecked return from fs_seek() in cmd_read()

### DIFF
--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -273,7 +273,13 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	if (offset > 0) {
-		fs_seek(&file, offset, FS_SEEK_SET);
+		err = fs_seek(&file, offset, FS_SEEK_SET);
+		if (err) {
+			shell_error(shell, "Failed to seek %s (%d)",
+				    path, err);
+			fs_close(&file);
+			return -ENOEXEC;
+		}
 	}
 
 	while (count > 0) {


### PR DESCRIPTION
Inside cmd_read(), result of fs_seek() is not checked which might
result in reading the wrong part of file. So fails the read if
fs_seek() fails.

Fixes #13862
Fixes CID-190953

Signed-off-by: Daniel Leung <daniel.leung@intel.com>