### PR TITLE
drivers: wifi: simplelink: Remove SO_REUSEADDR and TCP_NODELAY

### DIFF
--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -464,9 +464,7 @@ static int map_credentials(int sd, const void *optval, socklen_t optlen)
  *  Remove once Zephyr has POSIX socket options defined.
  */
 #define SO_BROADCAST  (200)
-#define SO_REUSEADDR  (201)
 #define SO_SNDBUF     (202)
-#define TCP_NODELAY   (203)
 
 /* Needed to keep line lengths < 80: */
 #define _SEC_DOMAIN_VERIF SL_SO_SECURE_DOMAIN_NAME_VERIFICATION


### PR DESCRIPTION
The SimpleLink driver has been defining these macros for its local use.
Given these have been defined in a recent commit in Zephyr
(9c86dbfd8ec02cc7a58786f7a3e8366a74aebc08), we should now avoid
redefining them to prevent build errors.

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>