### PR TITLE
x86: fix memory domain issue with adding partitions

### DIFF
--- a/arch/arc/core/mpu/arc_core_mpu.c
+++ b/arch/arc/core/mpu/arc_core_mpu.c
@@ -143,6 +143,12 @@ void _arch_mem_domain_destroy(struct k_mem_domain *domain)
 	arc_core_mpu_enable();
 }
 
+void _arch_mem_domain_partition_add(struct k_mem_domain *domain,
+				    u32_t partition_id)
+{
+	/* No-op on this architecture */
+}
+
 /*
  * Validate the given buffer is user accessible or not
  */

--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -314,6 +314,12 @@ void _arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 		&domain->partitions[partition_id], &reset_attr);
 }
 
+void _arch_mem_domain_partition_add(struct k_mem_domain *domain,
+				    u32_t partition_id)
+{
+	/* No-op on this architecture */
+}
+
 /*
  * Validate the given buffer is user accessible or not
  */

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -235,6 +235,24 @@ void z_x86_reset_pages(void *start, size_t size)
 #endif /* CONFIG_X86_KPTI */
 }
 
+static inline void activate_partition(struct k_mem_partition *partition)
+{
+	/* Set the partition attributes */
+	u64_t attr, mask;
+
+#if CONFIG_X86_KPTI
+	attr = partition->attr | MMU_ENTRY_PRESENT;
+	mask = K_MEM_PARTITION_PERM_MASK | MMU_PTE_P_MASK;
+#else
+	attr = partition->attr;
+	mask = K_MEM_PARTITION_PERM_MASK;
+#endif /* CONFIG_X86_KPTI */
+
+	_x86_mmu_set_flags(&USER_PDPT,
+			   (void *)partition->start,
+			   partition->size, attr, mask);
+}
+
 /* Helper macros needed to be passed to x86_update_mem_domain_pages */
 #define X86_MEM_DOMAIN_SET_PAGES   (0U)
 #define X86_MEM_DOMAIN_RESET_PAGES (1U)
@@ -244,7 +262,7 @@ static inline void _x86_mem_domain_pages_update(struct k_mem_domain *mem_domain,
 {
 	u32_t partition_index;
 	u32_t total_partitions;
-	struct k_mem_partition partition;
+	struct k_mem_partition *partition;
 	u32_t partitions_count;
 
 	/* If mem_domain doesn't point to a valid location return.*/
@@ -265,32 +283,19 @@ static inline void _x86_mem_domain_pages_update(struct k_mem_domain *mem_domain,
 	     partition_index++) {
 
 		/* Get the partition info */
-		partition = mem_domain->partitions[partition_index];
-		if (partition.size == 0) {
+		partition = &mem_domain->partitions[partition_index];
+		if (partition->size == 0) {
 			continue;
 		}
 		partitions_count++;
 		if (page_conf == X86_MEM_DOMAIN_SET_PAGES) {
-			/* Set the partition attributes */
-			u64_t attr, mask;
-
-#if CONFIG_X86_KPTI
-			attr = partition.attr | MMU_ENTRY_PRESENT;
-			mask = K_MEM_PARTITION_PERM_MASK | MMU_PTE_P_MASK;
-#else
-			attr = partition.attr;
-			mask = K_MEM_PARTITION_PERM_MASK;
-#endif /* CONFIG_X86_KPTI */
-
-			_x86_mmu_set_flags(&USER_PDPT,
-					   (void *)partition.start,
-					   partition.size, attr, mask);
+			activate_partition(partition);
 		} else {
-			z_x86_reset_pages((void *)partition.start,
-					  partition.size);
+			z_x86_reset_pages((void *)partition->start,
+					  partition->size);
 		}
 	}
- out:
+out:
 	return;
 }
 
@@ -311,21 +316,30 @@ void _arch_mem_domain_destroy(struct k_mem_domain *domain)
 
 /* Reset/destroy one partition spcified in the argument of the API. */
 void _arch_mem_domain_partition_remove(struct k_mem_domain *domain,
-				       u32_t  partition_id)
+				       u32_t partition_id)
 {
-	struct k_mem_partition partition;
+	struct k_mem_partition *partition;
 
-	if (domain == NULL) {
-		goto out;
-	}
-
+	__ASSERT_NO_MSG(domain != NULL);
 	__ASSERT(partition_id <= domain->num_partitions,
 		 "invalid partitions");
 
-	partition = domain->partitions[partition_id];
-	z_x86_reset_pages((void *)partition.start, partition.size);
- out:
-	return;
+	partition = &domain->partitions[partition_id];
+	z_x86_reset_pages((void *)partition->start, partition->size);
+}
+
+/* Reset/destroy one partition spcified in the argument of the API. */
+void _arch_mem_domain_partition_add(struct k_mem_domain *domain,
+				    u32_t partition_id)
+{
+	struct k_mem_partition *partition;
+
+	__ASSERT_NO_MSG(domain != NULL);
+	__ASSERT(partition_id <= domain->num_partitions,
+		 "invalid partitions");
+
+	partition = &domain->partitions[partition_id];
+	activate_partition(partition);
 }
 
 int _arch_mem_domain_max_partitions_get(void)

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -85,12 +85,27 @@ extern void _arch_mem_domain_configure(struct k_thread *thread);
  * A memory domain contains multiple partitions and this API provides the
  * freedom to remove a particular partition while keeping others intact.
  * This API will handle any arch/HW specific changes that needs to be done.
+ * Only called if the active thread's domain was modified.
  *
  * @param domain The memory domain structure
  * @param partition_id The partition that needs to be deleted
  */
 extern void _arch_mem_domain_partition_remove(struct k_mem_domain *domain,
-					      u32_t  partition_id);
+					      u32_t partition_id);
+
+/**
+ * @brief Remove a partition from the memory domain
+ *
+ * A memory domain contains multiple partitions and this API provides the
+ * freedom to add an additional partition to a memory domain.
+ * This API will handle any arch/HW specific changes that needs to be done.
+ * Only called if the active thread's domain was modified.
+ *
+ * @param domain The memory domain structure
+ * @param partition_id The partition that needs to be added
+ */
+extern void _arch_mem_domain_partition_add(struct k_mem_domain *domain,
+					   u32_t partition_id);
 
 /**
  * @brief Remove the memory domain
@@ -102,9 +117,7 @@ extern void _arch_mem_domain_partition_remove(struct k_mem_domain *domain,
  * @param domain The memory domain structure which needs to be deleted.
  */
 extern void _arch_mem_domain_destroy(struct k_mem_domain *domain);
-#endif
 
-#ifdef CONFIG_USERSPACE
 /**
  * @brief Check memory region permissions
  *

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -178,6 +178,13 @@ void k_mem_domain_add_partition(struct k_mem_domain *domain,
 
 	domain->num_partitions++;
 
+	/* Handle architecture-specific remove
+	 * only if it is the current thread.
+	 */
+	if (_current->mem_domain_info.mem_domain == domain) {
+		_arch_mem_domain_partition_add(domain, p_idx);
+	}
+
 	k_spin_unlock(&lock, key);
 }
 

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -678,6 +678,224 @@ extern u8_t *_k_priv_stack_find(void *obj);
 extern k_thread_stack_t ztest_thread_stack[];
 #endif
 
+struct k_mem_domain add_thread_drop_dom;
+struct k_mem_domain add_part_drop_dom;
+struct k_mem_domain remove_thread_drop_dom;
+struct k_mem_domain remove_part_drop_dom;
+
+struct k_mem_domain add_thread_ctx_dom;
+struct k_mem_domain add_part_ctx_dom;
+struct k_mem_domain remove_thread_ctx_dom;
+struct k_mem_domain remove_part_ctx_dom;
+
+K_APPMEM_PARTITION_DEFINE(access_part);
+K_APP_BMEM(access_part) volatile bool test_bool;
+
+static void user_half(void *arg1, void *arg2, void *arg3)
+{
+	test_bool = 1;
+	if (!expect_fault) {
+		ztest_test_pass();
+	} else {
+		ztest_test_fail();
+	}
+}
+
+/**
+ * Show that changing between memory domains and dropping to user mode works
+ * as expected.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+static void domain_add_thread_drop_to_user(void)
+{
+	struct k_mem_partition *parts[] = {&part0, &access_part,
+					   &ztest_mem_partition};
+
+	expect_fault = false;
+	k_mem_domain_init(&add_thread_drop_dom, ARRAY_SIZE(parts), parts);
+	k_mem_domain_remove_thread(k_current_get());
+
+	k_sleep(1);
+	k_mem_domain_add_thread(&add_thread_drop_dom, k_current_get());
+
+	k_thread_user_mode_enter(user_half, NULL, NULL, NULL);
+}
+
+/* Show that adding a partition to a domain and then dropping to user mode
+ * works as expected.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+static void domain_add_part_drop_to_user(void)
+{
+	struct k_mem_partition *parts[] = {&part0, &ztest_mem_partition};
+
+	expect_fault = false;
+	k_mem_domain_init(&add_part_drop_dom, ARRAY_SIZE(parts), parts);
+	k_mem_domain_remove_thread(k_current_get());
+	k_mem_domain_add_thread(&add_part_drop_dom, k_current_get());
+
+	k_sleep(1);
+	k_mem_domain_add_partition(&add_part_drop_dom, &access_part);
+
+	k_thread_user_mode_enter(user_half, NULL, NULL, NULL);
+}
+
+/* Show that self-removing from a memory domain and then dropping to user
+ * mode faults as expected.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+static void domain_remove_thread_drop_to_user(void)
+{
+	struct k_mem_partition *parts[] = {&part0, &access_part,
+					   &ztest_mem_partition};
+
+	expect_fault = true;
+	expected_reason = REASON_HW_EXCEPTION;
+	k_mem_domain_init(&remove_thread_drop_dom, ARRAY_SIZE(parts), parts);
+	k_mem_domain_remove_thread(k_current_get());
+	k_mem_domain_add_thread(&remove_thread_drop_dom, k_current_get());
+
+	k_sleep(1);
+	k_mem_domain_remove_thread(k_current_get());
+
+	k_thread_user_mode_enter(user_half, NULL, NULL, NULL);
+}
+
+/**
+ * Show that self-removing a partition from a domain we are a membed of,
+ * and then dropping to user mode faults as expected.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+static void domain_remove_part_drop_to_user(void)
+{
+	struct k_mem_partition *parts[] = {&part0, &access_part,
+					   &ztest_mem_partition};
+
+	expect_fault = true;
+	expected_reason = REASON_HW_EXCEPTION;
+	k_mem_domain_init(&remove_part_drop_dom, ARRAY_SIZE(parts), parts);
+	k_mem_domain_remove_thread(k_current_get());
+	k_mem_domain_add_thread(&remove_part_drop_dom, k_current_get());
+
+	k_sleep(1);
+	k_mem_domain_remove_partition(&remove_part_drop_dom, &access_part);
+
+	k_thread_user_mode_enter(user_half, NULL, NULL, NULL);
+}
+
+static void user_ctx_switch_half(void *arg1, void *arg2, void *arg3)
+{
+	test_bool = 1;
+	k_sem_give(&uthread_end_sem);
+}
+
+static void spawn_user(void)
+{
+	k_sem_reset(&uthread_end_sem);
+	k_object_access_grant(&uthread_end_sem, k_current_get());
+
+	k_thread_create(&kthread_thread, kthread_stack, STACKSIZE,
+			user_ctx_switch_half, NULL, NULL, NULL,
+			K_PRIO_PREEMPT(1), K_INHERIT_PERMS | K_USER,
+			K_NO_WAIT);
+
+	k_sem_take(&uthread_end_sem, K_FOREVER);
+	if (expect_fault) {
+		ztest_test_fail();
+	}
+}
+
+/**
+ * Show that changing between memory domains and then switching to another
+ * thread in the same domain works as expected.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+static void domain_add_thread_context_switch(void)
+{
+	struct k_mem_partition *parts[] = {&part0, &access_part,
+					   &ztest_mem_partition};
+
+	expect_fault = false;
+	k_mem_domain_init(&add_thread_ctx_dom, ARRAY_SIZE(parts), parts);
+	k_mem_domain_remove_thread(k_current_get());
+
+	k_sleep(1);
+	k_mem_domain_add_thread(&add_thread_ctx_dom, k_current_get());
+
+	spawn_user();
+}
+
+/* Show that adding a partition to a domain and then switching to another
+ * user thread in the same domain works as expected.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+static void domain_add_part_context_switch(void)
+{
+	struct k_mem_partition *parts[] = {&part0, &ztest_mem_partition};
+
+	expect_fault = false;
+	k_mem_domain_init(&add_part_ctx_dom, ARRAY_SIZE(parts), parts);
+	k_mem_domain_remove_thread(k_current_get());
+	k_mem_domain_add_thread(&add_part_ctx_dom, k_current_get());
+
+	k_sleep(1);
+	k_mem_domain_add_partition(&add_part_ctx_dom, &access_part);
+
+	spawn_user();
+}
+
+/* Show that self-removing from a memory domain and then switching to another
+ * user thread in the same domain faults as expected.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+static void domain_remove_thread_context_switch(void)
+{
+	struct k_mem_partition *parts[] = {&part0, &access_part,
+					   &ztest_mem_partition};
+
+	expect_fault = true;
+	expected_reason = REASON_HW_EXCEPTION;
+	k_mem_domain_init(&remove_thread_ctx_dom, ARRAY_SIZE(parts), parts);
+	k_mem_domain_remove_thread(k_current_get());
+	k_mem_domain_add_thread(&remove_thread_ctx_dom, k_current_get());
+
+	k_sleep(1);
+	k_mem_domain_remove_thread(k_current_get());
+
+	spawn_user();
+}
+
+/**
+ * Show that self-removing a partition from a domain we are a member of,
+ * and then switching to another user thread in the same domain faults as
+ * expected.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+static void domain_remove_part_context_switch(void)
+{
+	struct k_mem_partition *parts[] = {&part0, &access_part,
+					   &ztest_mem_partition};
+
+	expect_fault = true;
+	expected_reason = REASON_HW_EXCEPTION;
+	k_mem_domain_init(&remove_part_ctx_dom, ARRAY_SIZE(parts), parts);
+	k_mem_domain_remove_thread(k_current_get());
+	k_mem_domain_add_thread(&remove_part_ctx_dom, k_current_get());
+
+	k_sleep(1);
+	k_mem_domain_remove_partition(&remove_part_ctx_dom, &access_part);
+
+	spawn_user();
+}
+
 void test_main(void)
 {
 	struct k_mem_partition *parts[] = {&part0, &part1,
@@ -719,7 +937,15 @@ void test_main(void)
 			 ztest_unit_test(user_mode_enter),
 			 ztest_user_unit_test(write_kobject_user_pipe),
 			 ztest_user_unit_test(read_kobject_user_pipe),
-			 ztest_unit_test(access_other_memdomain)
+			 ztest_unit_test(access_other_memdomain),
+			 ztest_unit_test(domain_add_thread_drop_to_user),
+			 ztest_unit_test(domain_add_part_drop_to_user),
+			 ztest_unit_test(domain_remove_part_drop_to_user),
+			 ztest_unit_test(domain_remove_thread_drop_to_user),
+			 ztest_unit_test(domain_add_thread_context_switch),
+			 ztest_unit_test(domain_add_part_context_switch),
+			 ztest_unit_test(domain_remove_part_context_switch),
+			 ztest_unit_test(domain_remove_thread_context_switch)
 			 );
 	ztest_run_test_suite(userspace);
 }


### PR DESCRIPTION
Adding a partition to a domain, unlike the other APIs, has no call into arch code to let the arch code know that the domain had a partition added.

If the CPU switched to another thread in the same domain, or dropped privileges to user mode, the MMU page tables would not have the new partition policy in it.

A new arch API has been added which gets called when a partition is added.

ARM and ARC are unaffected, so their API implementations are no-ops.

Added test cases to prove that this and similar scenarios work as expected.

Fixes: #13918 