### PR TITLE
drivers: modem: fix extra bytes sent by mdm_receiver_send()

### DIFF
--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -188,7 +188,7 @@ int mdm_receiver_send(struct mdm_receiver_context *ctx,
 
 	do {
 		uart_poll_out(ctx->uart_dev, *buf++);
-	} while (size--);
+	} while (--size);
 
 	return 0;
 }


### PR DESCRIPTION
mdm_receiver_send() was sending 1 too many bytes of buf.  This ended
up being the NULL terminator.  Size should be reduced prior to the
while check so that this doesn't happen.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/14001

Signed-off-by: Michael Scott <mike@foundries.io>