### PR TITLE
drivers: i2c: mcux_lpi2c: Fix unexpected I2C start condition

### DIFF
--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -120,6 +120,13 @@ static int i2c_mcux_transfer(struct device *dev, struct i2c_msg *msgs,
 		transfer.data = msgs->buf;
 		transfer.dataSize = msgs->len;
 
+		/* Prevent the controller to send a start condition between
+		 * messages, except if explicitely requested.
+		 */
+		if (i != 0 && !(msgs->flags & I2C_MSG_RESTART)) {
+			transfer.flags |= kI2C_TransferNoStartFlag;
+		}
+
 		/* Start the transfer */
 		status = I2C_MasterTransferNonBlocking(base,
 				&data->handle, &transfer);

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -116,6 +116,14 @@ static int mcux_lpi2c_transfer(struct device *dev, struct i2c_msg *msgs,
 
 		/* Initialize the transfer descriptor */
 		transfer.flags = mcux_lpi2c_convert_flags(msgs->flags);
+
+		/* Prevent the controller to send a start condition between
+		 * messages, except if explicitely requested.
+		 */
+		if (i != 0 && !(msgs->flags & I2C_MSG_RESTART)) {
+			transfer.flags |= kLPI2C_TransferNoStartFlag;
+		}
+
 		transfer.slaveAddress = addr;
 		transfer.direction = (msgs->flags & I2C_MSG_READ)
 			? kLPI2C_Read : kLPI2C_Write;


### PR DESCRIPTION
Ensure that no I2C start condition is inserted between messages of
a same transfer, except if explicitely requested (restart flag).

This fix issue with I2C register write functions.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>