### PR TITLE
Fix mbedTLS tests

### DIFF
--- a/ext/lib/crypto/mbedtls/configs/config-tls-generic.h
+++ b/ext/lib/crypto/mbedtls/configs/config-tls-generic.h
@@ -27,6 +27,7 @@
 #endif
 
 #if defined(CONFIG_MBEDTLS_TEST)
+#define MBEDTLS_SELF_TEST
 #define MBEDTLS_DEBUG_C
 #endif
 

--- a/lib/libc/minimal/include/stdlib.h
+++ b/lib/libc/minimal/include/stdlib.h
@@ -24,6 +24,8 @@ void *calloc(size_t nmemb, size_t size);
 void *realloc(void *ptr, size_t size);
 void *reallocarray(void *ptr, size_t nmemb, size_t size);
 
+int rand(void);
+
 #define abs(x) ((x) < 0 ? -(x) : (x))
 
 #ifdef __cplusplus

--- a/tests/crypto/mbedtls/src/mbedtls.c
+++ b/tests/crypto/mbedtls/src/mbedtls.c
@@ -414,17 +414,17 @@ void test_mbedtls(void)
 
 	if (v != 0) {
 		mbedtls_printf("  Executed %d test suites\n\n", suites_tested);
-
 		if (suites_failed > 0) {
 			mbedtls_printf("  [ %d tests FAIL ]\n\n",
 				       suites_failed);
-			TC_END_RESULT(TC_FAIL);
-			TC_END_REPORT(TC_FAIL);
 		} else {
 			mbedtls_printf("  [ All tests PASS ]\n\n");
-			TC_END_RESULT(TC_PASS);
-			TC_END_REPORT(TC_PASS);
 		}
+		zassert_not_equal(suites_tested, 0,
+			      "ran %d tests", suites_tested);
+		zassert_equal(suites_failed, 0,
+			      "%d tests failed", suites_failed);
+
 #if defined(_WIN32)
 		mbedtls_printf("  Press Enter to exit this program.\n");
 		fflush(stdout);

--- a/tests/crypto/mbedtls/testcase.yaml
+++ b/tests/crypto/mbedtls/testcase.yaml
@@ -1,7 +1,8 @@
 tests:
   crypto.mbedtls:
     filter: not CONFIG_DEBUG
-    min_flash: 33
+    platform_exclude: qemu_x86_64 # FIXME
+    min_flash: 65
     min_ram: 32
     tags: crypto mbedtls
     timeout: 200


### PR DESCRIPTION
MBEDTLS_SELF_TEST is needed when setting CONFIG_MBEDTLS_TEST
