### PR TITLE
doc: update udev rule instructions for the reel board

### DIFF
--- a/boards/arm/reel_board/doc/index.rst
+++ b/boards/arm/reel_board/doc/index.rst
@@ -377,12 +377,12 @@ and :ref:`application_run` for more details).
 Flashing
 ========
 
-If you use Linux, create a udev rule to fix a permission issue when not using
-root for flashing.
+If you use Linux, create a udev rule (as ``root``) to fix a permission issue
+when not using root for flashing.
 
 .. code-block:: console
 
-   $ echo 'ATTR{idProduct}=="0204", ATTR{idVendor}=="0d28", MODE="0666", GROUP="plugdev"' > /etc/udev/rules.d/50-cmsis-dap.rules
+   # echo 'ATTR{idProduct}=="0204", ATTR{idVendor}=="0d28", MODE="0666", GROUP="plugdev"' > /etc/udev/rules.d/50-cmsis-dap.rules
 
 Reload the rules and replug the device.
 


### PR DESCRIPTION
The creation of the udev rule requires the user to be root else
it will fail. Update the text of the documentation to make it clearer
and change the shell prompt of the command to '#'

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>