### PR TITLE
sanitycheck: handle serial exception

### DIFF
--- a/samples/basic/blink_led/sample.yaml
+++ b/samples/basic/blink_led/sample.yaml
@@ -8,3 +8,4 @@ tests:
         hexiwear_k64 colibri_imx7d_m4 nrf52832_mdk nrf52840_mdk, nucleo_l496zg
     tags: drivers pwm
     depends_on: pwm
+    harness: led

--- a/samples/basic/blinky/sample.yaml
+++ b/samples/basic/blinky/sample.yaml
@@ -5,3 +5,4 @@ tests:
     tags: LED gpio
     filter: DT_GPIO_LEDS_LED0_GPIO_CONTROLLER
     depends_on: gpio
+    harness: led

--- a/samples/basic/button/sample.yaml
+++ b/samples/basic/button/sample.yaml
@@ -5,3 +5,4 @@ tests:
     tags: button gpio
     filter: DT_GPIO_KEYS_SW0_GPIO_CONTROLLER
     depends_on: gpio
+    harness: button

--- a/samples/basic/disco/sample.yaml
+++ b/samples/basic/disco/sample.yaml
@@ -4,3 +4,4 @@ tests:
   test:
     filter: DT_GPIO_LEDS_LED0_GPIO_CONTROLLER and DT_GPIO_LEDS_LED1_GPIO_CONTROLLER
     tags: LED gpio
+    harness: led

--- a/samples/basic/fade_led/sample.yaml
+++ b/samples/basic/fade_led/sample.yaml
@@ -8,3 +8,4 @@ tests:
         nrf51_pca10028 nrf52840_pca10056
     tags: drivers pwm
     depends_on: pwm
+    harness: led

--- a/samples/basic/rgb_led/sample.yaml
+++ b/samples/basic/rgb_led/sample.yaml
@@ -7,3 +7,4 @@ tests:
             DT_PWM_LEDS_BLUE_PWM_LED_PWM_CONTROLLER
     tags: drivers pwm
     depends_on: pwm
+    harness: led

--- a/samples/basic/servo_motor/sample.yaml
+++ b/samples/basic/servo_motor/sample.yaml
@@ -6,3 +6,4 @@ tests:
     platform_whitelist: arduino_101 quark_d2000_crb bbc_microbit
     tags: drivers pwm
     depends_on: pwm
+    harness: motor

--- a/samples/basic/threads/sample.yaml
+++ b/samples/basic/threads/sample.yaml
@@ -7,3 +7,10 @@ tests:
     tags: kernel threads gpio
     filter: DT_GPIO_LEDS_LED0_GPIO_CONTROLLER and DT_GPIO_LEDS_LED1_GPIO_CONTROLLER
     depends_on: gpio
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "Toggle USR0 LED(.*)"
+        - "Toggle USR1 LED(.*)"

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -624,6 +624,9 @@ class DeviceHandler(Handler):
                 serial_line = ser.readline()
             except TypeError:
                 pass
+            except serial.serialutil.SerialException:
+                ser.close()
+                break
 
             # Just because ser_fileno has data doesn't mean an entire line
             # is available yet.


### PR DESCRIPTION
Do not throw excpetion when there is no serial output, just timeout.

Fixes #13541