### PR TITLE
doc: clarify BOARD_ROOT documentation

### DIFF
--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -580,7 +580,7 @@ targeting this board by specifying the location of your custom board
 information with the ``-DBOARD_ROOT`` parameter to the CMake
 build system::
 
-   cmake -DBOARD=<board name> -DBOARD_ROOT=<path the directory containig a "boards" directory> ..
+   cmake -DBOARD=<board name> -DBOARD_ROOT=<path to directory containing a boards/ directory> ..
 
 
 This will use your custom board configuration and will generate the

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -580,7 +580,7 @@ targeting this board by specifying the location of your custom board
 information with the ``-DBOARD_ROOT`` parameter to the CMake
 build system::
 
-   cmake -DBOARD=<board name> -DBOARD_ROOT=<path to boards> ..
+   cmake -DBOARD=<board name> -DBOARD_ROOT=<path the directory containig a "boards" directory> ..
 
 
 This will use your custom board configuration and will generate the


### PR DESCRIPTION
clarify BOARD_ROOT must point to dir ABOVE boards