### PR TITLE
CODEOWNERS: add modem ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -114,6 +114,7 @@
 /drivers/interrupt_controller/            @andrewboie
 /drivers/led/                             @Mani-Sadhasivam
 /drivers/led_strip/                       @mbolivar
+/drivers/modem/                           @mike-scott
 /drivers/pinmux/stm32/                    @rsalveti @idlethread
 /drivers/sensor/                          @bogdan-davidoaia @MaureenHelm
 /drivers/sensor/hts*/                     @avisconti
@@ -164,6 +165,7 @@
 /include/display.h                        @vanwinkeljan
 /include/display/                         @vanwinkeljan
 /include/drivers/bluetooth/               @sjanc @jhedberg @Vudentz
+/include/drivers/modem/                   @mike-scott
 /include/drivers/ioapic.h                 @andrewboie
 /include/drivers/loapic.h                 @andrewboie
 /include/drivers/mvic.h                   @andrewboie


### PR DESCRIPTION
Add @mike-scott as modem drivers maintainer

Signed-off-by: Michael Scott <mike@foundries.io>