### PR TITLE
net: ping: Improve the output of the ping function

### DIFF
--- a/doc/reference/networking/net_shell.rst
+++ b/doc/reference/networking/net_shell.rst
@@ -31,7 +31,7 @@ The following net-shell commands are implemented:
    print more information if :option:`CONFIG_NET_BUF_POOL_USAGE` is set."
    "net nbr", "Print neighbor information. Only available if
    :option:`CONFIG_NET_IPV6` is set."
-   "net ping", "Ping a network host."
+   "net ping [-c count] [-i interval ms]", "Ping a network host."
    "net route", "Show IPv6 network routes. Only available if
    :option:`CONFIG_NET_ROUTE` is set."
    "net stats", "Show network statistics."

--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -561,7 +561,7 @@ static int execute_upload(const struct shell *shell,
 		 * some time and start the test after that.
 		 */
 		net_icmpv6_send_echo_request(net_if_get_default(),
-					     &ipv6->sin6_addr, 0, 0);
+					     &ipv6->sin6_addr, 0, 0, NULL, 0);
 
 		k_sleep(K_SECONDS(1));
 	}

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -60,7 +60,8 @@ int net_icmpv4_finalize(struct net_pkt *pkt)
 }
 
 static enum net_verdict icmpv4_handle_echo_request(struct net_pkt *pkt,
-						   struct net_ipv4_hdr *ip_hdr)
+						   struct net_ipv4_hdr *ip_hdr,
+						   struct net_icmp_hdr *icmp_hdr)
 {
 	struct net_pkt *reply = NULL;
 	s16_t payload_len;
@@ -319,7 +320,7 @@ enum net_verdict net_icmpv4_input(struct net_pkt *pkt,
 	SYS_SLIST_FOR_EACH_CONTAINER(&handlers, cb, node) {
 		if (cb->type == icmp_hdr->type &&
 		    (cb->code == icmp_hdr->code || cb->code == 0U)) {
-			return cb->handler(pkt, ip_hdr);
+			return cb->handler(pkt, ip_hdr, icmp_hdr);
 		}
 	}
 

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -129,7 +129,9 @@ drop:
 int net_icmpv4_send_echo_request(struct net_if *iface,
 				 struct in_addr *dst,
 				 u16_t identifier,
-				 u16_t sequence)
+				 u16_t sequence,
+				 const void *data,
+				 size_t data_size)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(icmpv4_access,
 					      struct net_icmpv4_echo_req);
@@ -146,7 +148,8 @@ int net_icmpv4_send_echo_request(struct net_if *iface,
 	src = &iface->config.ip.ipv4->unicast[0].address.in_addr;
 
 	pkt = net_pkt_alloc_with_buffer(iface,
-					sizeof(struct net_icmpv4_echo_req),
+					sizeof(struct net_icmpv4_echo_req)
+					+ data_size,
 					AF_INET, IPPROTO_ICMP,
 					PKT_WAIT_TIME);
 	if (!pkt) {
@@ -168,6 +171,7 @@ int net_icmpv4_send_echo_request(struct net_if *iface,
 	echo_req->sequence   = htons(sequence);
 
 	net_pkt_set_data(pkt, &icmpv4_access);
+	net_pkt_write(pkt, data, data_size);
 
 	net_pkt_cursor_init(pkt);
 

--- a/subsys/net/ip/icmpv4.h
+++ b/subsys/net/ip/icmpv4.h
@@ -34,7 +34,8 @@ struct net_icmpv4_echo_req {
 
 typedef enum net_verdict (*icmpv4_callback_handler_t)(
 					struct net_pkt *pkt,
-					struct net_ipv4_hdr *ip_hdr);
+					struct net_ipv4_hdr *ip_hdr,
+					struct net_icmp_hdr *icmp_hdr);
 
 struct net_icmpv4_handler {
 	sys_snode_t node;

--- a/subsys/net/ip/icmpv4.h
+++ b/subsys/net/ip/icmpv4.h
@@ -62,13 +62,18 @@ int net_icmpv4_send_error(struct net_pkt *pkt, u8_t type, u8_t code);
  * to this Echo Request. May be zero.
  * @param sequence A sequence number to aid in matching Echo Replies
  * to this Echo Request. May be zero.
+ * @param data Arbitrary payload data that will be included in the
+ * Echo Reply verbatim. May be zero.
+ * @param data_size Size of the Payload Data in bytes. May be zero.
  *
  * @return Return 0 if the sending succeed, <0 otherwise.
  */
 int net_icmpv4_send_echo_request(struct net_if *iface,
 				 struct in_addr *dst,
 				 u16_t identifier,
-				 u16_t sequence);
+				 u16_t sequence,
+				 const void *data,
+				 size_t data_size);
 
 void net_icmpv4_register_handler(struct net_icmpv4_handler *handler);
 

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -297,7 +297,9 @@ drop_no_pkt:
 int net_icmpv6_send_echo_request(struct net_if *iface,
 				 struct in6_addr *dst,
 				 u16_t identifier,
-				 u16_t sequence)
+				 u16_t sequence,
+				 const void *data,
+				 size_t data_size)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(icmpv6_access,
 					      struct net_icmpv6_echo_req);
@@ -309,7 +311,8 @@ int net_icmpv6_send_echo_request(struct net_if *iface,
 	src = net_if_ipv6_select_src_addr(iface, dst);
 
 	pkt = net_pkt_alloc_with_buffer(iface,
-					sizeof(struct net_icmpv6_echo_req),
+					sizeof(struct net_icmpv6_echo_req)
+					+ data_size,
 					AF_INET6, IPPROTO_ICMPV6,
 					PKT_WAIT_TIME);
 	if (!pkt) {
@@ -331,6 +334,7 @@ int net_icmpv6_send_echo_request(struct net_if *iface,
 	echo_req->sequence   = htons(sequence);
 
 	net_pkt_set_data(pkt, &icmpv6_access);
+	net_pkt_write(pkt, data, data_size);
 
 	net_pkt_cursor_init(pkt);
 	net_ipv6_finalize(pkt, IPPROTO_ICMPV6);

--- a/subsys/net/ip/icmpv6.h
+++ b/subsys/net/ip/icmpv6.h
@@ -178,13 +178,18 @@ int net_icmpv6_send_error(struct net_pkt *pkt, u8_t type, u8_t code,
  * to this Echo Request. May be zero.
  * @param sequence A sequence number to aid in matching Echo Replies
  * to this Echo Request. May be zero.
+ * @param data Arbitrary payload data that will be included in the
+ * Echo Reply verbatim. May be zero.
+ * @param data_size Size of the Payload Data in bytes. May be zero.
  *
  * @return Return 0 if the sending succeed, <0 otherwise.
  */
 int net_icmpv6_send_echo_request(struct net_if *iface,
 				 struct in6_addr *dst,
 				 u16_t identifier,
-				 u16_t sequence);
+				 u16_t sequence,
+				 const void *data,
+				 size_t data_size);
 
 void net_icmpv6_register_handler(struct net_icmpv6_handler *handler);
 void net_icmpv6_unregister_handler(struct net_icmpv6_handler *handler);

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2720,7 +2720,8 @@ static int ping_ipv6(const struct shell *shell, char *host)
 #if defined(CONFIG_NET_IPV4)
 
 static enum net_verdict handle_ipv4_echo_reply(struct net_pkt *pkt,
-						struct net_ipv4_hdr *ip_hdr);
+						struct net_ipv4_hdr *ip_hdr,
+						struct net_icmp_hdr *icmp_hdr);
 
 static struct net_icmpv4_handler ping4_handler = {
 	.type = NET_ICMPV4_ECHO_REPLY,
@@ -2734,7 +2735,8 @@ static inline void remove_ipv4_ping_handler(void)
 }
 
 static enum net_verdict handle_ipv4_echo_reply(struct net_pkt *pkt,
-						struct net_ipv4_hdr *ip_hdr)
+						struct net_ipv4_hdr *ip_hdr,
+						struct net_icmp_hdr *icmp_hdr)
 {
 	PR_SHELL(shell_for_ping, "Received echo reply from %s to %s\n",
 		 net_sprint_ipv4_addr(&ip_hdr->src),

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2703,7 +2703,9 @@ static int ping_ipv6(const struct shell *shell, char *host)
 	ret = net_icmpv6_send_echo_request(iface,
 					   &ipv6_target,
 					   sys_rand32_get(),
-					   sys_rand32_get());
+					   sys_rand32_get(),
+					   NULL,
+					   0);
 	if (ret) {
 		remove_ipv6_ping_handler();
 	} else {

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2763,7 +2763,9 @@ static int ping_ipv4(const struct shell *shell, char *host)
 		net_if_ipv4_select_src_iface(&ipv4_target),
 		&ipv4_target,
 		sys_rand32_get(),
-		sys_rand32_get());
+		sys_rand32_get(),
+		NULL,
+		0);
 	if (ret) {
 		remove_ipv4_ping_handler();
 	} else {


### PR DESCRIPTION
The output of the `net ping` function is a bit terse.

Let's make it more Linux-like by reporting TTL, measuring round-trip-time and also display RSSI when available.

**before:**
```
uart:~$ net ping fe80::7b7a:342f:9d73:b482
Sent a ping to fe80::7b7a:342f:9d73:b482
Received echo reply from fe80::7b7a:342f:9d73:b482 to fe80::d07:d5e9:7c9:572d
```

**after:**
```
uart:~$ net ping fe80::7b7a:342f:9d73:b482
PING fe80::7b7a:342f:9d73:b482
8 bytes from fe80::7b7a:342f:9d73:b482 to fe80::7841:4946:59b8:3d9c: icmp_seq=0 ttl=64 rssi=-53 dBm time=6.65ms
8 bytes from fe80::7b7a:342f:9d73:b482 to fe80::7841:4946:59b8:3d9c: icmp_seq=1 ttl=64 rssi=-57 dBm time=6.59ms
8 bytes from fe80::7b7a:342f:9d73:b482 to fe80::7841:4946:59b8:3d9c: icmp_seq=2 ttl=64 rssi=-57 dBm time=6.56ms
```