### PR TITLE
settings: always uses the storage partition for FCB

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -271,6 +271,7 @@
 /tests/net/lib/coap/                      @rveerama1
 /tests/net/socket/                        @jukkar @tbursztyka @pfalcon
 /tests/subsys/fs/                         @nashif @ramakrishnapallala
+/tests/subsys/settings/                   @nvlsianpu
 
 # Get all docs reviewed
 *.rst                                     @dbkinder

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -63,14 +63,6 @@ config SETTINGS_FCB_MAGIC
 	help
 	  Magic 32-bit word for to identify valid settings area
 
-config SETTINGS_FCB_FLASH_AREA
-	int "Flash area id used for settings"
-	default $(dt_int_val,DT_FLASH_AREA_STORAGE_ID)
-	depends on SETTINGS && SETTINGS_FCB
-	help
-	  Id of the Flash area where FCB instance used for settings is
-	  expected to operate.
-
 config SETTINGS_FS_DIR
 	string "Serialization directory"
 	default "/settings"

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -38,7 +38,7 @@ int settings_fcb_src(struct settings_fcb *cf)
 	cf->cf_fcb.f_scratch_cnt = 1;
 
 	while (1) {
-		rc = fcb_init(CONFIG_SETTINGS_FCB_FLASH_AREA, &cf->cf_fcb);
+		rc = fcb_init(DT_FLASH_AREA_STORAGE_ID, &cf->cf_fcb);
 		if (rc) {
 			return -EINVAL;
 		}

--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -59,7 +59,7 @@ static void settings_init_fcb(void)
 	int rc;
 	const struct flash_area *fap;
 
-	rc = flash_area_get_sectors(CONFIG_SETTINGS_FCB_FLASH_AREA, &cnt,
+	rc = flash_area_get_sectors(DT_FLASH_AREA_STORAGE_ID, &cnt,
 				    settings_fcb_area);
 	if (rc != 0 && rc != -ENOMEM) {
 		k_panic();
@@ -70,7 +70,7 @@ static void settings_init_fcb(void)
 	rc = settings_fcb_src(&config_init_settings_fcb);
 
 	if (rc != 0) {
-		rc = flash_area_open(CONFIG_SETTINGS_FCB_FLASH_AREA, &fap);
+		rc = flash_area_open(DT_FLASH_AREA_STORAGE_ID, &fap);
 
 		if (rc == 0) {
 			rc = flash_area_erase(fap, 0, fap->fa_size);

--- a/tests/subsys/settings/fcb/base64/Kconfig
+++ b/tests/subsys/settings/fcb/base64/Kconfig
@@ -1,4 +1,0 @@
-config SETTINGS_FCB_FLASH_AREA
-	default $(dt_int_val,DT_FLASH_AREA_IMAGE_SCRATCH_ID)
-
-source "Kconfig.zephyr"

--- a/tests/subsys/settings/fcb/base64/nrf52840_pca10056.overlay
+++ b/tests/subsys/settings/fcb/base64/nrf52840_pca10056.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,9 +17,9 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		storage_partition: partition@70000 {
+		storage_partition: partition@de000 {
 			label = "storage";
-			reg = <0x00070000 0x10000>;
+			reg = <0x000de000 0x00010000>;
 		};
 	};
 };

--- a/tests/subsys/settings/fcb/raw/Kconfig
+++ b/tests/subsys/settings/fcb/raw/Kconfig
@@ -1,4 +1,0 @@
-config SETTINGS_FCB_FLASH_AREA
-	default $(dt_int_val,DT_FLASH_AREA_IMAGE_SCRATCH_ID)
-
-source "Kconfig.zephyr"

--- a/tests/subsys/settings/fcb/raw/nrf52840_pca10056.overlay
+++ b/tests/subsys/settings/fcb/raw/nrf52840_pca10056.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,9 +17,9 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		storage_partition: partition@70000 {
+		storage_partition: partition@de000 {
 			label = "storage";
-			reg = <0x00070000 0x10000>;
+			reg = <0x000de000 0x00010000>;
 		};
 	};
 };

--- a/tests/subsys/settings/fcb/raw/nrf52_pca10040.overlay
+++ b/tests/subsys/settings/fcb/raw/nrf52_pca10040.overlay
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/delete-node/ &storage_partition;
+/delete-node/ &scratch_partition;
+
 &flash0 {
 	/*
 	 * For more information, see:
@@ -14,20 +17,8 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 0xc000>;
-		};
-		slot0_partition: partition@c000 {
-			label = "image-0";
-			reg = <0x0000C000 0x32000>;
-		};
-		slot1_partition: partition@3e000 {
-			label = "image-1";
-			reg = <0x0003E000 0x32000>;
-		};
-		scratch_partition: partition@70000 {
-			label = "image-scratch";
+		storage_partition: partition@70000 {
+			label = "storage";
 			reg = <0x00070000 0x10000>;
 		};
 	};

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -176,7 +176,7 @@ void config_wipe_fcb(struct flash_sector *fs, int cnt)
 	int rc;
 	int i;
 
-	rc = flash_area_open(CONFIG_SETTINGS_FCB_FLASH_AREA, &fap);
+	rc = flash_area_open(DT_FLASH_AREA_STORAGE_ID, &fap);
 
 	for (i = 0; i < cnt; i++) {
 		rc = flash_area_erase(fap, fs[i].fs_off, fs[i].fs_size);

--- a/tests/subsys/settings/fcb_init/Kconfig
+++ b/tests/subsys/settings/fcb_init/Kconfig
@@ -1,4 +1,0 @@
-config SETTINGS_FCB_FLASH_AREA
-	default $(dt_int_val,DT_FLASH_AREA_STORAGE_ID)
-
-source "Kconfig.zephyr"


### PR DESCRIPTION
It was possible via Kconfig to assign any partition for FCB using
its number. Partitions flash_area_id becomes non predefined
(are auto-generated). So it is possible only to guess which
number will be signed to certain area.

Unfortunately it is not possible to transfer FLASH_AREA_XXX_ID
label via Kconfig.

Patch assigns settings to the storage partition and remove
SETTINGS_FCB_FLASH_AREA property from settings Kconfig.

fixes #13388

I Added myself as settings tests codeowner - I'm already settings codeowner, so this makes sense.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>