### PR TITLE
toolchain: Improve error message on mismatching SDK version

### DIFF
--- a/cmake/toolchain/zephyr/host-tools.cmake
+++ b/cmake/toolchain/zephyr/host-tools.cmake
@@ -35,6 +35,7 @@ string(STRIP ${SDK_VERSION_PRE2} SDK_VERSION)
 if(${REQUIRED_SDK_VER} VERSION_GREATER ${SDK_VERSION})
   message(FATAL_ERROR "The SDK version you are using is old, please update your SDK.
 You need at least SDK version ${REQUIRED_SDK_VER}.
+You have version ${SDK_VERSION} (${ZEPHYR_SDK_INSTALL_DIR}).
 The new version of the SDK can be download from:
 https://github.com/zephyrproject-rtos/meta-zephyr-sdk/releases/download/${REQUIRED_SDK_VER}/zephyr-sdk-${REQUIRED_SDK_VER}-setup.run
 ")

--- a/cmake/toolchain/zephyr/host-tools.cmake
+++ b/cmake/toolchain/zephyr/host-tools.cmake
@@ -33,10 +33,10 @@ string(REGEX REPLACE "-.*" "" SDK_VERSION_PRE2 ${SDK_VERSION_PRE1})
 # Strip any trailing spaces/newlines from the version string
 string(STRIP ${SDK_VERSION_PRE2} SDK_VERSION)
 if(${REQUIRED_SDK_VER} VERSION_GREATER ${SDK_VERSION})
-  message(FATAL_ERROR "The SDK version you are using is old, please update your SDK.
+  message(FATAL_ERROR "The SDK version you are using is too old, please update your SDK.
 You need at least SDK version ${REQUIRED_SDK_VER}.
 You have version ${SDK_VERSION} (${ZEPHYR_SDK_INSTALL_DIR}).
-The new version of the SDK can be download from:
+The new version of the SDK can be downloaded from:
 https://github.com/zephyrproject-rtos/meta-zephyr-sdk/releases/download/${REQUIRED_SDK_VER}/zephyr-sdk-${REQUIRED_SDK_VER}-setup.run
 ")
 endif()


### PR DESCRIPTION
Add useful information to the error message printed when the installed
SDK does not fulfill version requirements.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>