### PR TITLE
logging: Fix RTT log backend lagging if no host

### DIFF
--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -185,7 +185,7 @@ static int data_out_block_mode(u8_t *data, size_t length, void *ctx)
 
 		if (ret) {
 			on_write(retry_cnt);
-		} else {
+		} else if (host_present) {
 			retry_cnt--;
 			on_failed_write(retry_cnt);
 		}


### PR DESCRIPTION
In case it was detected that RTT host was not present
backend was still performing single sleep or busy wait
round before dropping data. That was degrading log
processing performance.

Fixes #13424.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>