### PR TITLE
shell: fix coverity issue

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -608,6 +608,9 @@ static int execute(const struct shell *shell)
 		return -ENOEXEC;
 	}
 
+	/* Initialize help variable */
+	help_entry.help = NULL;
+
 	/* Below loop is analyzing subcommands of found root command. */
 	while (true) {
 		if (cmd_lvl >= argc) {


### PR DESCRIPTION
Fixing a case where variable could be used without an initialization.

Fixes: #13831