### PR TITLE
logging: Use vprintk for stirng formatting by default

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -212,13 +212,14 @@ config LOG_IMMEDIATE
 	  flawlessly in that mode because one log operation can be interrupted
 	  by another one in the higher priority context.
 
-config LOG_DISABLE_FANCY_OUTPUT_FORMATTING
+config LOG_ENABLE_FANCY_OUTPUT_FORMATTING
 	depends on !NEWLIB_LIBC && !ARCH_POSIX
-	bool "Use vprintk() instead of minimal libc _prf()"
+	bool "Format strings with minimal libc _prf() instead of _vprintk()"
 	help
-	  Selecting this option will choose vprintk for handling format
-	  strings instead of the more robust _prf() function in minimal
-	  libc.  Choosing this option can save around ~3K flash.
+	  Selecting this option will choose more robust _prf() function from
+	  minimal libc for handling format strings instead of the _vprintk()
+	  function. Choosing this option adds around ~3K flash and ~250 bytes on
+	  stack.
 
 if !LOG_IMMEDIATE
 

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -115,7 +115,7 @@ static int print_formatted(const struct log_output *log_output,
 
 	va_start(args, fmt);
 #if !defined(CONFIG_NEWLIB_LIBC) && !defined(CONFIG_ARCH_POSIX) && \
-    !defined(CONFIG_LOG_DISABLE_FANCY_OUTPUT_FORMATTING)
+    defined(CONFIG_LOG_ENABLE_FANCY_OUTPUT_FORMATTING)
 	length = _prf(out_func, (void *)log_output, (char *)fmt, args);
 #else
 	_vprintk(out_func, (void *)log_output, fmt, args);
@@ -553,7 +553,7 @@ void log_output_string(const struct log_output *log_output,
 	}
 
 #if !defined(CONFIG_NEWLIB_LIBC) && !defined(CONFIG_ARCH_POSIX) && \
-    !defined(CONFIG_LOG_DISABLE_FANCY_OUTPUT_FORMATTING)
+    defined(CONFIG_LOG_ENABLE_FANCY_OUTPUT_FORMATTING)
 	length = _prf(out_func, (void *)log_output, (char *)fmt, ap);
 #else
 	_vprintk(out_func, (void *)log_output, fmt, ap);


### PR DESCRIPTION
Previously, _prf function was used when present and _vprintk
was used otherwise. _prf supports reacher formatting but at
cost of 3k flash and >250 bytes on stack. Stack usage then
depended on which function was used and that was causing
troubles when trimming stack sizes.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>