### PR TITLE
m2gl025_miv: Ignore lifo_usage tests

### DIFF
--- a/tests/kernel/lifo/lifo_usage/testcase.yaml
+++ b/tests/kernel/lifo/lifo_usage/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   kernel.lifo.usage:
     min_ram: 32
     tags: kernel userspace
+    platform_exclude: m2gl025_miv


### PR DESCRIPTION
These tests fail on hardware. An appropriate issue will be filed on
GitHub, but it doesn't make sense to hold the CI from going green.

Fixes #13960.
