### PR TITLE
tests/subsys/settings/fcb: add check for target compatibility

### DIFF
--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -313,6 +313,20 @@ int c3_handle_export(int (*cb)(const char *name, void *value, size_t val_len))
 	return 0;
 }
 
+void tests_settings_check_target(void)
+{
+	const struct flash_area *fap;
+	int rc;
+	u8_t wbs;
+
+	rc = flash_area_open(DT_FLASH_AREA_STORAGE_ID, &fap);
+	zassert_true(rc == 0, "Can't open storage flash area");
+
+	wbs = flash_area_align(fap);
+	zassert_true(wbs <= 16,
+		"Flash driver is not compatible with the settings fcb-backend");
+}
+
 void test_settings_encode(void);
 void config_empty_lookups(void);
 void test_config_insert(void);
@@ -350,6 +364,7 @@ void test_main(void)
 			 ztest_unit_test(test_config_getset_int64),
 			 ztest_unit_test(test_config_commit),
 			 /* FCB as backing storage*/
+			 ztest_unit_test(tests_settings_check_target),
 			 ztest_unit_test(test_config_save_fcb_unaligned),
 			 ztest_unit_test(test_config_empty_fcb),
 			 ztest_unit_test(test_config_save_1_fcb),

--- a/tests/subsys/settings/fcb/src/settings_test_save_unaligned.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_unaligned.c
@@ -21,8 +21,11 @@ void test_config_save_fcb_unaligned(void)
 	rc = settings_fcb_src(&cf);
 	zassert_true(rc == 0, "can't register FCB as configuration source");
 
-	/* override flash driver alignment */
-	cf.cf_fcb.f_align = 4;
+	if (cf.cf_fcb.f_align == 1) {
+		/* override flash driver alignment */
+		cf.cf_fcb.f_align = 4;
+	}
+
 	settings_mount_fcb_backend(&cf);
 
 	rc = settings_fcb_dst(&cf);


### PR DESCRIPTION
Added tests of flash driver compatibility with fcb-backend.

For flash drivers which support write-block-size bigger than 1 B
test of unaligned data access uses native write-block-size
as it is dedicated to check whether settings works well on platform
which has 1 B access which is native on the current DUT.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>