### PR TITLE
segger: sysview: Fix constness of char pointer

### DIFF
--- a/subsys/debug/tracing/sysview.c
+++ b/subsys/debug/tracing/sysview.c
@@ -55,7 +55,7 @@ static void send_task_list_cb(void)
 
 	for (thread = _kernel.threads; thread; thread = thread->next_thread) {
 		char name[20];
-		char *tname = k_thread_name_get(thread);
+		const char *tname = k_thread_name_get(thread);
 
 		if (is_idle_thread(thread)) {
 			continue;


### PR DESCRIPTION
To match the signature of k_thread_name_get(), add a const modifier to
the local variable definition.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>