### PR TITLE
boards: mimxrt1064_evk: Default to internal flash and external sdram

### DIFF
--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -10,6 +10,14 @@ if BOARD_MIMXRT1064_EVK
 config BOARD
 	default "mimxrt1064_evk"
 
+choice CODE_LOCATION
+	default CODE_FLEXSPI2
+endchoice
+
+choice DATA_LOCATION
+	default DATA_SEMC
+endchoice
+
 if GPIO_MCUX_IGPIO
 
 config GPIO_MCUX_IGPIO_1

--- a/boards/arm/mimxrt1064_evk/board.cmake
+++ b/boards/arm/mimxrt1064_evk/board.cmake
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-board_runner_args(jlink "--device=Cortex-M7")
+board_runner_args(jlink "--device=MIMXRT1064")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -12,8 +12,8 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 128
-flash: 128
+ram: 32768
+flash: 4096
 supported:
   - hwinfo
   - netif:eth


### PR DESCRIPTION
JLink V6.44 (2019-03-01) added support for the imx rt1064 soc, including
programming the internal flash on flexspi2. Updates the mimxrt1064_evk
board to use the internal flash and external sdram memories by default,
now that the debug tools support them.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>