### PR TITLE
Fix build warnings in rv32m1 drivers

### DIFF
--- a/drivers/clock_control/clock_control_rv32m1_pcc.c
+++ b/drivers/clock_control/clock_control_rv32m1_pcc.c
@@ -58,24 +58,24 @@ static const struct clock_control_driver_api rv32m1_pcc_api = {
 	.get_rate = rv32m1_pcc_get_rate,
 };
 
-#if defined(PCC_0_BASE_ADDRESS)
+#if defined(DT_OPENISA_RV32M1_PCC_PCC_0_BASE_ADDRESS)
 static struct rv32m1_pcc_config rv32m1_pcc0_config = {
-	.base_address = PCC_0_BASE_ADDRESS
+	.base_address = DT_OPENISA_RV32M1_PCC_PCC_0_BASE_ADDRESS
 };
 
-DEVICE_AND_API_INIT(rv32m1_pcc0, PCC_0_LABEL,
+DEVICE_AND_API_INIT(rv32m1_pcc0, DT_OPENISA_RV32M1_PCC_PCC_0_LABEL,
 		    &rv32m1_pcc_init,
 		    NULL, &rv32m1_pcc0_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,
 		    &rv32m1_pcc_api);
 #endif
 
-#if defined(PCC_1_BASE_ADDRESS)
+#if defined(DT_OPENISA_RV32M1_PCC_PCC_1_BASE_ADDRESS)
 static struct rv32m1_pcc_config rv32m1_pcc1_config = {
-	.base_address = PCC_1_BASE_ADDRESS
+	.base_address = DT_OPENISA_RV32M1_PCC_PCC_1_BASE_ADDRESS
 };
 
-DEVICE_AND_API_INIT(rv32m1_pcc1, PCC_1_LABEL,
+DEVICE_AND_API_INIT(rv32m1_pcc1, DT_OPENISA_RV32M1_PCC_PCC_1_LABEL,
 		    &rv32m1_pcc_init,
 		    NULL, &rv32m1_pcc1_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -242,9 +242,9 @@ static const struct gpio_driver_api gpio_rv32m1_driver_api = {
 static int gpio_rv32m1_porta_init(struct device *dev);
 
 static const struct gpio_rv32m1_config gpio_rv32m1_porta_config = {
-	.gpio_base = (GPIO_Type *) GPIO_A_BASE_ADDRESS,
+	.gpio_base = (GPIO_Type *) DT_OPENISA_RV32M1_GPIO_GPIO_A_BASE_ADDRESS,
 	.port_base = PORTA,
-#ifdef GPIO_A_IRQ
+#ifdef DT_OPENISA_RV32M1_GPIO_GPIO_A_IRQ
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -253,7 +253,7 @@ static const struct gpio_rv32m1_config gpio_rv32m1_porta_config = {
 
 static struct gpio_rv32m1_data gpio_rv32m1_porta_data;
 
-DEVICE_AND_API_INIT(gpio_rv32m1_porta, GPIO_A_LABEL,
+DEVICE_AND_API_INIT(gpio_rv32m1_porta, DT_OPENISA_RV32M1_GPIO_GPIO_A_LABEL,
 		    gpio_rv32m1_porta_init,
 		    &gpio_rv32m1_porta_data, &gpio_rv32m1_porta_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -261,11 +261,12 @@ DEVICE_AND_API_INIT(gpio_rv32m1_porta, GPIO_A_LABEL,
 
 static int gpio_rv32m1_porta_init(struct device *dev)
 {
-#ifdef GPIO_A_IRQ
-	IRQ_CONNECT(GPIO_A_IRQ, GPIO_A_IRQ_PRIORITY,
+#ifdef DT_OPENISA_RV32M1_GPIO_GPIO_A_IRQ
+	IRQ_CONNECT(DT_OPENISA_RV32M1_GPIO_GPIO_A_IRQ,
+		    DT_OPENISA_RV32M1_GPIO_GPIO_A_IRQ_PRIORITY,
 		    gpio_rv32m1_port_isr, DEVICE_GET(gpio_rv32m1_porta), 0);
 
-	irq_enable(GPIO_A_IRQ);
+	irq_enable(DT_OPENISA_RV32M1_GPIO_GPIO_A_IRQ);
 
 	return 0;
 #else
@@ -278,9 +279,9 @@ static int gpio_rv32m1_porta_init(struct device *dev)
 static int gpio_rv32m1_portb_init(struct device *dev);
 
 static const struct gpio_rv32m1_config gpio_rv32m1_portb_config = {
-	.gpio_base = (GPIO_Type *) GPIO_B_BASE_ADDRESS,
+	.gpio_base = (GPIO_Type *) DT_OPENISA_RV32M1_GPIO_GPIO_B_BASE_ADDRESS,
 	.port_base = PORTB,
-#ifdef GPIO_B_IRQ
+#ifdef DT_OPENISA_RV32M1_GPIO_GPIO_B_IRQ
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -289,7 +290,7 @@ static const struct gpio_rv32m1_config gpio_rv32m1_portb_config = {
 
 static struct gpio_rv32m1_data gpio_rv32m1_portb_data;
 
-DEVICE_AND_API_INIT(gpio_rv32m1_portb, GPIO_B_LABEL,
+DEVICE_AND_API_INIT(gpio_rv32m1_portb, DT_OPENISA_RV32M1_GPIO_GPIO_B_LABEL,
 		    gpio_rv32m1_portb_init,
 		    &gpio_rv32m1_portb_data, &gpio_rv32m1_portb_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -297,11 +298,12 @@ DEVICE_AND_API_INIT(gpio_rv32m1_portb, GPIO_B_LABEL,
 
 static int gpio_rv32m1_portb_init(struct device *dev)
 {
-#ifdef GPIO_B_IRQ
-	IRQ_CONNECT(GPIO_B_IRQ, GPIO_B_IRQ_PRIORITY,
+#ifdef DT_OPENISA_RV32M1_GPIO_GPIO_B_IRQ
+	IRQ_CONNECT(DT_OPENISA_RV32M1_GPIO_GPIO_B_IRQ,
+		    DT_OPENISA_RV32M1_GPIO_GPIO_B_IRQ_PRIORITY,
 		    gpio_rv32m1_port_isr, DEVICE_GET(gpio_rv32m1_portb), 0);
 
-	irq_enable(GPIO_B_IRQ);
+	irq_enable(DT_OPENISA_RV32M1_GPIO_GPIO_B_IRQ);
 
 	return 0;
 #else
@@ -314,9 +316,9 @@ static int gpio_rv32m1_portb_init(struct device *dev)
 static int gpio_rv32m1_portc_init(struct device *dev);
 
 static const struct gpio_rv32m1_config gpio_rv32m1_portc_config = {
-	.gpio_base = (GPIO_Type *) GPIO_C_BASE_ADDRESS,
+	.gpio_base = (GPIO_Type *) DT_OPENISA_RV32M1_GPIO_GPIO_C_BASE_ADDRESS,
 	.port_base = PORTC,
-#ifdef GPIO_C_IRQ
+#ifdef DT_OPENISA_RV32M1_GPIO_GPIO_C_IRQ
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -325,7 +327,7 @@ static const struct gpio_rv32m1_config gpio_rv32m1_portc_config = {
 
 static struct gpio_rv32m1_data gpio_rv32m1_portc_data;
 
-DEVICE_AND_API_INIT(gpio_rv32m1_portc, GPIO_C_LABEL,
+DEVICE_AND_API_INIT(gpio_rv32m1_portc, DT_OPENISA_RV32M1_GPIO_GPIO_C_LABEL,
 		    gpio_rv32m1_portc_init,
 		    &gpio_rv32m1_portc_data, &gpio_rv32m1_portc_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -333,11 +335,12 @@ DEVICE_AND_API_INIT(gpio_rv32m1_portc, GPIO_C_LABEL,
 
 static int gpio_rv32m1_portc_init(struct device *dev)
 {
-#ifdef GPIO_C_IRQ
-	IRQ_CONNECT(GPIO_C_IRQ, GPIO_C_IRQ_PRIORITY,
+#ifdef DT_OPENISA_RV32M1_GPIO_GPIO_C_IRQ
+	IRQ_CONNECT(DT_OPENISA_RV32M1_GPIO_GPIO_C_IRQ,
+		    DT_OPENISA_RV32M1_GPIO_GPIO_C_IRQ_PRIORITY,
 		    gpio_rv32m1_port_isr, DEVICE_GET(gpio_rv32m1_portc), 0);
 
-	irq_enable(GPIO_C_IRQ);
+	irq_enable(DT_OPENISA_RV32M1_GPIO_GPIO_C_IRQ);
 
 	return 0;
 #else
@@ -350,9 +353,9 @@ static int gpio_rv32m1_portc_init(struct device *dev)
 static int gpio_rv32m1_portd_init(struct device *dev);
 
 static const struct gpio_rv32m1_config gpio_rv32m1_portd_config = {
-	.gpio_base = (GPIO_Type *) GPIO_D_BASE_ADDRESS,
+	.gpio_base = (GPIO_Type *) DT_OPENISA_RV32M1_GPIO_GPIO_D_BASE_ADDRESS,
 	.port_base = PORTD,
-#ifdef GPIO_D_IRQ
+#ifdef DT_OPENISA_RV32M1_GPIO_GPIO_D_IRQ
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -361,7 +364,7 @@ static const struct gpio_rv32m1_config gpio_rv32m1_portd_config = {
 
 static struct gpio_rv32m1_data gpio_rv32m1_portd_data;
 
-DEVICE_AND_API_INIT(gpio_rv32m1_portd, GPIO_D_LABEL,
+DEVICE_AND_API_INIT(gpio_rv32m1_portd, DT_OPENISA_RV32M1_GPIO_GPIO_D_LABEL,
 		    gpio_rv32m1_portd_init,
 		    &gpio_rv32m1_portd_data, &gpio_rv32m1_portd_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -369,11 +372,12 @@ DEVICE_AND_API_INIT(gpio_rv32m1_portd, GPIO_D_LABEL,
 
 static int gpio_rv32m1_portd_init(struct device *dev)
 {
-#ifdef GPIO_D_IRQ
-	IRQ_CONNECT(GPIO_D_IRQ, GPIO_D_IRQ_PRIORITY,
+#ifdef DT_OPENISA_RV32M1_GPIO_GPIO_D_IRQ
+	IRQ_CONNECT(DT_OPENISA_RV32M1_GPIO_GPIO_D_IRQ,
+		    DT_OPENISA_RV32M1_GPIO_GPIO_D_IRQ_PRIORITY,
 		    gpio_rv32m1_port_isr, DEVICE_GET(gpio_rv32m1_portd), 0);
 
-	irq_enable(GPIO_D_IRQ);
+	irq_enable(DT_OPENISA_RV32M1_GPIO_GPIO_D_IRQ);
 
 	return 0;
 #else
@@ -386,9 +390,9 @@ static int gpio_rv32m1_portd_init(struct device *dev)
 static int gpio_rv32m1_porte_init(struct device *dev);
 
 static const struct gpio_rv32m1_config gpio_rv32m1_porte_config = {
-	.gpio_base = (GPIO_Type *) GPIO_E_BASE_ADDRESS,
+	.gpio_base = (GPIO_Type *) DT_OPENISA_RV32M1_GPIO_GPIO_E_BASE_ADDRESS,
 	.port_base = PORTE,
-#ifdef GPIO_E_IRQ
+#ifdef DT_OPENISA_RV32M1_GPIO_GPIO_E_IRQ
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -397,7 +401,7 @@ static const struct gpio_rv32m1_config gpio_rv32m1_porte_config = {
 
 static struct gpio_rv32m1_data gpio_rv32m1_porte_data;
 
-DEVICE_AND_API_INIT(gpio_rv32m1_porte, GPIO_E_LABEL,
+DEVICE_AND_API_INIT(gpio_rv32m1_porte, DT_OPENISA_RV32M1_GPIO_GPIO_E_LABEL,
 		    gpio_rv32m1_porte_init,
 		    &gpio_rv32m1_porte_data, &gpio_rv32m1_porte_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -405,11 +409,12 @@ DEVICE_AND_API_INIT(gpio_rv32m1_porte, GPIO_E_LABEL,
 
 static int gpio_rv32m1_porte_init(struct device *dev)
 {
-#ifdef GPIO_E_IRQ
-	IRQ_CONNECT(GPIO_E_IRQ, GPIO_E_IRQ_PRIORITY,
+#ifdef DT_OPENISA_RV32M1_GPIO_GPIO_E_IRQ
+	IRQ_CONNECT(DT_OPENISA_RV32M1_GPIO_GPIO_E_IRQ,
+		    DT_OPENISA_RV32M1_GPIO_GPIO_E_IRQ_PRIORITY,
 		    gpio_rv32m1_port_isr, DEVICE_GET(gpio_rv32m1_porte), 0);
 
-	irq_enable(GPIO_E_IRQ);
+	irq_enable(DT_OPENISA_RV32M1_GPIO_GPIO_E_IRQ);
 
 	return 0;
 #else

--- a/drivers/interrupt_controller/rv32m1_intmux.c
+++ b/drivers/interrupt_controller/rv32m1_intmux.c
@@ -116,9 +116,10 @@ static const struct irq_next_level_api rv32m1_intmux_apis = {
 };
 
 static const struct rv32m1_intmux_config rv32m1_intmux_cfg = {
-	.regs = (INTMUX_Type *)INTMUX_BASE_ADDRESS,
-	.clock_name = INTMUX_CLOCK_CONTROLLER,
-	.clock_subsys = UINT_TO_POINTER(INTMUX_CLOCK_NAME),
+	.regs = (INTMUX_Type *)DT_OPENISA_RV32M1_INTMUX_INTMUX_BASE_ADDRESS,
+	.clock_name = DT_OPENISA_RV32M1_INTMUX_INTMUX_CLOCK_CONTROLLER,
+	.clock_subsys =
+		UINT_TO_POINTER(DT_OPENISA_RV32M1_INTMUX_INTMUX_CLOCK_NAME),
 	.isr_base = &_sw_isr_table[CONFIG_2ND_LVL_ISR_TBL_OFFSET],
 };
 
@@ -190,6 +191,7 @@ static int rv32m1_intmux_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(intmux, INTMUX_LABEL, &rv32m1_intmux_init, NULL,
+DEVICE_AND_API_INIT(intmux, DT_OPENISA_RV32M1_INTMUX_INTMUX_LABEL,
+		    &rv32m1_intmux_init, NULL,
 		    &rv32m1_intmux_cfg, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &rv32m1_intmux_apis);

--- a/drivers/pinmux/pinmux_rv32m1.c
+++ b/drivers/pinmux/pinmux_rv32m1.c
@@ -65,7 +65,7 @@ static const struct pinmux_driver_api pinmux_rv32m1_driver_api = {
 
 #ifdef CONFIG_PINMUX_RV32M1_PORTA
 static const struct pinmux_rv32m1_config pinmux_rv32m1_porta_config = {
-	.base = (PORT_Type *)PINMUX_A_BASE_ADDRESS,
+	.base = (PORT_Type *)DT_OPENISA_RV32M1_PINMUX_PINMUX_A_BASE_ADDRESS,
 	.clock_ip_name = kCLOCK_PortA,
 };
 
@@ -78,7 +78,7 @@ DEVICE_AND_API_INIT(pinmux_porta, CONFIG_PINMUX_RV32M1_PORTA_NAME,
 
 #ifdef CONFIG_PINMUX_RV32M1_PORTB
 static const struct pinmux_rv32m1_config pinmux_rv32m1_portb_config = {
-	.base = (PORT_Type *)PINMUX_B_BASE_ADDRESS,
+	.base = (PORT_Type *)DT_OPENISA_RV32M1_PINMUX_PINMUX_B_BASE_ADDRESS,
 	.clock_ip_name = kCLOCK_PortB,
 };
 
@@ -91,7 +91,7 @@ DEVICE_AND_API_INIT(pinmux_portb, CONFIG_PINMUX_RV32M1_PORTB_NAME,
 
 #ifdef CONFIG_PINMUX_RV32M1_PORTC
 static const struct pinmux_rv32m1_config pinmux_rv32m1_portc_config = {
-	.base = (PORT_Type *)PINMUX_C_BASE_ADDRESS,
+	.base = (PORT_Type *)DT_OPENISA_RV32M1_PINMUX_PINMUX_C_BASE_ADDRESS,
 	.clock_ip_name = kCLOCK_PortC,
 };
 
@@ -104,7 +104,7 @@ DEVICE_AND_API_INIT(pinmux_portc, CONFIG_PINMUX_RV32M1_PORTC_NAME,
 
 #ifdef CONFIG_PINMUX_RV32M1_PORTD
 static const struct pinmux_rv32m1_config pinmux_rv32m1_portd_config = {
-	.base = (PORT_Type *)PINMUX_D_BASE_ADDRESS,
+	.base = (PORT_Type *)DT_OPENISA_RV32M1_PINMUX_PINMUX_D_BASE_ADDRESS,
 	.clock_ip_name = kCLOCK_PortD,
 };
 
@@ -117,7 +117,7 @@ DEVICE_AND_API_INIT(pinmux_portd, CONFIG_PINMUX_RV32M1_PORTD_NAME,
 
 #ifdef CONFIG_PINMUX_RV32M1_PORTE
 static const struct pinmux_rv32m1_config pinmux_rv32m1_porte_config = {
-	.base = (PORT_Type *)PINMUX_E_BASE_ADDRESS,
+	.base = (PORT_Type *)DT_OPENISA_RV32M1_PINMUX_PINMUX_E_BASE_ADDRESS,
 	.clock_ip_name = kCLOCK_PortE,
 };
 

--- a/drivers/timer/rv32m1_lptmr_timer.c
+++ b/drivers/timer/rv32m1_lptmr_timer.c
@@ -30,7 +30,8 @@
 #error "system timer misconfiguration; unsupported clock rate"
 #endif
 
-#define SYSTEM_TIMER_INSTANCE ((LPTMR_Type *)(SYSTEM_LPTMR_BASE_ADDRESS))
+#define SYSTEM_TIMER_INSTANCE \
+	((LPTMR_Type *)(DT_OPENISA_RV32M1_LPTMR_SYSTEM_LPTMR_BASE_ADDRESS))
 #define SYSTEM_TIMER_IRQ_PRIO 0
 
 #define SIRC_RANGE_8MHZ      SCG_SIRCCFG_RANGE(1)
@@ -55,8 +56,8 @@ int z_clock_driver_init(struct device *unused)
 	u32_t csr, psr, sircdiv; /* LPTMR registers */
 
 	ARG_UNUSED(unused);
-	IRQ_CONNECT(SYSTEM_LPTMR_IRQ, SYSTEM_TIMER_IRQ_PRIO, lptmr_irq_handler,
-		    NULL, 0);
+	IRQ_CONNECT(DT_OPENISA_RV32M1_LPTMR_SYSTEM_LPTMR_IRQ,
+		    SYSTEM_TIMER_IRQ_PRIO, lptmr_irq_handler, NULL, 0);
 
 	if ((SCG->SIRCCSR & SCG_SIRCCSR_SIRCEN_MASK) == SCG_SIRCCSR_SIRCEN(0)) {
 		/*
@@ -121,7 +122,7 @@ int z_clock_driver_init(struct device *unused)
 	 * Enable interrupts and the timer. There's no need to clear the
 	 * TFC bit in the csr variable, as it's already clear.
 	 */
-	irq_enable(SYSTEM_LPTMR_IRQ);
+	irq_enable(DT_OPENISA_RV32M1_LPTMR_SYSTEM_LPTMR_IRQ);
 	csr = SYSTEM_TIMER_INSTANCE->CSR;
 	csr |= LPTMR_CSR_TEN(1);
 	SYSTEM_TIMER_INSTANCE->CSR = csr;


### PR DESCRIPTION
Converts rv32m1 drivers to use 'DT_' prefixed defines instead of deprecated non-prefixed defines.

Fixes #13964