### PR TITLE
net: sockets: recv_stream: Check that the underlying net_context active

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -676,6 +676,11 @@ static inline ssize_t zsock_recv_stream(struct net_context *ctx,
 	struct net_pkt_cursor backup;
 	int res;
 
+	if (!net_context_is_used(ctx)) {
+		errno = EBADF;
+		return -1;
+	}
+
 	if ((flags & ZSOCK_MSG_DONTWAIT) || sock_is_nonblock(ctx)) {
 		timeout = K_NO_WAIT;
 	}


### PR DESCRIPTION
It may be closed by the stack behind our back (something which needs
to be fixed).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>