### PR TITLE
doc: fix broken internal link in app dev doc

### DIFF
--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -130,7 +130,7 @@ subdirectories which are not described here.
 :file:`ext`
     Externally created code that has been integrated into Zephyr
     from other sources and that must live inside the zephyr repository unlike
-    `external projects <ext-projs>`_
+    `external projects <ext-projs_>`_
 
 :file:`include`
     Include files for all public APIs, except those defined under :file:`lib`.


### PR DESCRIPTION
Reference to internal page link was incorrect (looked like a reference
to an external page).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>