### PR TITLE
arch: arm: fix thread and interrupt stack start calculations

### DIFF
--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -59,7 +59,7 @@ void _new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 
 	_ASSERT_VALID_PRIO(priority, pEntry);
 
-#if CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
+#if CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT && CONFIG_USERSPACE
 	char *stackEnd = pStackMem + stackSize - MPU_GUARD_ALIGN_AND_SIZE;
 #else
 	char *stackEnd = pStackMem + stackSize;

--- a/arch/arm/include/cortex_m/stack.h
+++ b/arch/arm/include/cortex_m/stack.h
@@ -39,7 +39,8 @@ extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
  */
 static ALWAYS_INLINE void _InterruptStackSetup(void)
 {
-#ifdef CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
+#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT) && \
+	defined(CONFIG_USERSPACE)
 	u32_t msp = (u32_t)(K_THREAD_STACK_BUFFER(_interrupt_stack) +
 			    CONFIG_ISR_STACK_SIZE - MPU_GUARD_ALIGN_AND_SIZE);
 #else

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -73,7 +73,8 @@ _arch_switch_to_main_thread(struct k_thread *main_thread,
 	/* get high address of the stack, i.e. its start (stack grows down) */
 	char *start_of_main_stack;
 
-#ifdef CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
+#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT) && \
+	defined(CONFIG_USERSPACE)
 	start_of_main_stack =
 		K_THREAD_STACK_BUFFER(main_stack) + main_stack_size -
 		MPU_GUARD_ALIGN_AND_SIZE;


### PR DESCRIPTION
Based on the definition of _ARCH_THREAD_STACK_DEFINE() macro
for ARM, the MPU Stack Guard region is placed inside the
allocated stack object, only if
CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT and CONFIG_USERSPACE
are both set. For ARM stack objects, allocated using the
_ARCH_THREAD_STACK_DEFINE() macro, such as the threads' stacks
and the interrupt stack, the above must be reflected on how we
set the initial start of the stacks.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>