### PR TITLE
userspace: properly namespace linker vars

### DIFF
--- a/include/app_memory/app_memdomain.h
+++ b/include/app_memory/app_memdomain.h
@@ -62,10 +62,10 @@ struct z_app_region {
 	size_t bss_size;
 };
 
-#define Z_APP_START(id) data_smem_##id##_start
-#define Z_APP_SIZE(id) data_smem_##id##_size
-#define Z_APP_BSS_START(id) data_smem_##id##_bss_start
-#define Z_APP_BSS_SIZE(id) data_smem_##id##_bss_size
+#define Z_APP_START(id) z_data_smem_##id##_part_start
+#define Z_APP_SIZE(id) z_data_smem_##id##_part_size
+#define Z_APP_BSS_START(id) z_data_smem_##id##_bss_start
+#define Z_APP_BSS_SIZE(id) z_data_smem_##id##_bss_size
 
 /* If a partition is declared with K_APPMEM_PARTITION, but never has any
  * data assigned to its contents, then no symbols with its prefix will end

--- a/scripts/gen_app_partitions.py
+++ b/scripts/gen_app_partitions.py
@@ -19,8 +19,8 @@ from elftools.elf.elffile import ELFFile
 # initialization purpose when USERSPACE is enabled.
 data_template = """
 		/* Auto generated code do not modify */
-		SMEM_PARTITION_ALIGN(data_smem_{0}_bss_end - data_smem_{0}_start);
-		data_smem_{0}_start = .;
+		SMEM_PARTITION_ALIGN(z_data_smem_{0}_bss_end - z_data_smem_{0}_part_start);
+		z_data_smem_{0}_part_start = .;
 		KEEP(*(data_smem_{0}_data))
 """
 
@@ -29,7 +29,7 @@ library_data_template = """
 """
 
 bss_template = """
-		data_smem_{0}_bss_start = .;
+		z_data_smem_{0}_bss_start = .;
 		KEEP(*(data_smem_{0}_bss))
 """
 
@@ -38,9 +38,9 @@ library_bss_template = """
 """
 
 footer_template = """
-		SMEM_PARTITION_ALIGN(data_smem_{0}_bss_end - data_smem_{0}_start);
-		data_smem_{0}_bss_end = .;
-		data_smem_{0}_end = .;
+		z_data_smem_{0}_bss_end = .;
+		SMEM_PARTITION_ALIGN(z_data_smem_{0}_bss_end - z_data_smem_{0}_part_start);
+		z_data_smem_{0}_part_end = .;
 """
 
 linker_start_seq = """
@@ -57,8 +57,8 @@ linker_end_seq = """
 """
 
 size_cal_string = """
-	data_smem_{0}_size = data_smem_{0}_end - data_smem_{0}_start;
-	data_smem_{0}_bss_size = data_smem_{0}_bss_end - data_smem_{0}_bss_start;
+	z_data_smem_{0}_part_size = z_data_smem_{0}_part_end - z_data_smem_{0}_part_start;
+	z_data_smem_{0}_bss_size = z_data_smem_{0}_bss_end - z_data_smem_{0}_bss_start;
 """
 
 section_regex = re.compile(r'data_smem_([A-Za-z0-9_]*)_(data|bss)')


### PR DESCRIPTION
App shared memory defines a bunch of symbols in the
linker script. Namespace them properly as private
zephyr variables.

The variables which indicate the bounds of the entire
partition now end with "_part_start", "_part_size",
and "_part_end" to make them easy for scripts to
distinguish them from other generated symbols for
data/bss sizes.

Finally, the bss size is not rounded up, this was
causing unnecessary memory to be zeroed.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>