### PR TITLE
Bluetooth: controller: Fix unchecked return value

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1253,6 +1253,7 @@ static void ticker_op_update_cb(u32_t status, void *param)
 
 static void ticker_op_stop_cb(u32_t status, void *param)
 {
+	u32_t retval;
 	static memq_link_t link;
 	static struct mayfly mfy = {0, 0, &link, NULL, lll_conn_tx_flush};
 
@@ -1261,7 +1262,9 @@ static void ticker_op_stop_cb(u32_t status, void *param)
 	mfy.param = param;
 
 	/* Flush pending tx PDUs in LLL (using a mayfly) */
-	mayfly_enqueue(TICKER_USER_ID_ULL_LOW, TICKER_USER_ID_LLL, 1, &mfy);
+	retval = mayfly_enqueue(TICKER_USER_ID_ULL_LOW, TICKER_USER_ID_LLL, 1,
+				&mfy);
+	LL_ASSERT(!retval);
 }
 
 static inline void disable(u16_t handle)


### PR DESCRIPTION
Check the return value of mayfly_enqueue() and assert if not successful.

Coverity ID: CID 190991
Fixes #13833.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>