### PR TITLE
boards: arc: quark_se_c1000_ss_devboard: Exclude watchdog testcase

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -2,4 +2,4 @@ tests:
   peripheral.watchdog:
     depends_on: watchdog
     tags: drivers watchdog
-    platform_exclude: quark_d2000_crb
+    platform_exclude: quark_d2000_crb quark_se_c1000_ss_devboard


### PR DESCRIPTION
watchdog timer driver for quark_se soc in zephyr cannot be used
to trigger reset of sensor subsystem. Timer 0/1 of sensor subsystem
can be configured for watchdog reset generation. refer 8.2.9
section in data sheet of quark_se_c1000.

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>