### PR TITLE
Remove case ranges

### DIFF
--- a/drivers/led/lp3943.c
+++ b/drivers/led/lp3943.c
@@ -63,18 +63,34 @@ struct lp3943_data {
 static int lp3943_get_led_reg(u32_t *led, u8_t *reg)
 {
 	switch (*led) {
-	case 0 ... 3:
+	case 0:
+	case 1:
+	case 2:
+		/* Fall through */
+	case 3:
 		*reg = LP3943_LS0;
 		break;
-	case 4 ... 7:
+	case 4:
+	case 5:
+	case 6:
+		/* Fall through */
+	case 7:
 		*reg = LP3943_LS1;
 		*led -= 4;
 		break;
-	case 8 ... 11:
+	case 8:
+	case 9:
+	case 10:
+		/* Fall through */
+	case 11:
 		*reg = LP3943_LS2;
 		*led -= 8;
 		break;
-	case 12 ... 15:
+	case 12:
+	case 13:
+	case 14:
+		/* Fall through */
+	case 15:
 		*reg = LP3943_LS3;
 		*led -= 12;
 		break;

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -128,7 +128,16 @@ void _vprintk(out_func_t out, void *ctx, const char *fmt, va_list ap)
 					goto still_might_format;
 				}
 				/* Fall through */
-			case '1' ... '9':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+				/* Fall through */
+			case '9':
 				if (min_width < 0) {
 					min_width = *fmt - '0';
 				} else {


### PR DESCRIPTION
Remove five case ranges/GNUisms, four in a led driver and one in printk as reported in #11594 