### PR TITLE
WNC-M14A2A modem Coverity fixes

### DIFF
--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1182,13 +1182,17 @@ static void wncm14a2a_rx(void)
 						break;
 					}
 
-					/* locate next cr/lf */
-					len = net_buf_findcrlf(rx_buf,
+					/*
+					 * We've handled the current line
+					 * and need to exit the "search for
+					 * handler loop".  Let's skip any
+					 * "extra" data and look for the next
+					 * CR/LF, leaving us ready for the
+					 * next handler search.  Ignore the
+					 * length returned.
+					 */
+					(void)net_buf_findcrlf(rx_buf,
 							       &frag, &offset);
-					if (!frag) {
-						break;
-					}
-
 					break;
 				}
 			}

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -789,7 +789,7 @@ static void on_cmd_sockread(struct net_buf **buf, u16_t len)
 	i = 0;
 	value_size = sizeof(value);
 	(void)memset(value, 0, value_size);
-	while (*buf && i < value_size) {
+	while (*buf && i < value_size - 1) {
 		value[i++] = net_buf_pull_u8(*buf);
 		len--;
 		if (!(*buf)->len) {


### PR DESCRIPTION
- Fix illegal memory access in on_cmd_sockread()
- Cleanup the handler block in wncm14a2a_rx()

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/12290
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/12315