### PR TITLE
cmake: clang: Support host's clang for non-MCU x86 targets on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,7 +402,8 @@ zephyr_ld_options(
   )
 
 get_property(TOPT GLOBAL PROPERTY TOPT)
-set_ifndef(  TOPT -T)
+set_ifndef(  TOPT -Wl,-T) # clang doesn't pick -T for some reason and complains,
+                          # while -Wl,-T works for both, gcc and clang
 
 if(NOT CONFIG_NATIVE_APPLICATION)
   # Funny thing is if this is set to =error, some architectures will

--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_compile_options(
-  -fno-freestanding
   -m32
   -MMD
   -MP
   ${ARCH_FLAG}
   -include ${ZEPHYR_BASE}/arch/posix/include/posix_cheats.h
   )
+
+# @Intent: Obtain compiler specific flags for no freestanding compilation
+toolchain_cc_no_freestanding_options()
 
 zephyr_include_directories(${BOARD_DIR})
 

--- a/boards/posix/native_posix/native_posix.yaml
+++ b/boards/posix/native_posix/native_posix.yaml
@@ -4,6 +4,7 @@ type: native
 arch: posix
 toolchain:
   - zephyr
+  - llvm
 supported:
   - netif:eth
   - usb_device

--- a/cmake/compiler/clang/generic.cmake
+++ b/cmake/compiler/clang/generic.cmake
@@ -1,3 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
-find_program(CMAKE_C_COMPILER clang PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+if(DEFINED TOOLCHAIN_HOME)
+  set(find_program_clang_args PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+endif()
+
+find_program(CMAKE_C_COMPILER clang ${find_program_clang_args})
+

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -79,3 +79,8 @@ include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_baremetal.cmake)
 macro(toolchain_cc_security_fortify)
   # No op, clang doesn't understand fortify at all
 endmacro()
+
+macro(toolchain_cc_no_freestanding_options)
+  # No op, this is used by the native_posix, clang has problems
+  # compiling the native_posix with -fno-freestanding.
+endmacro()

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -11,15 +11,22 @@ if(NOT DEFINED NOSYSDEF_CFLAG)
   set(NOSYSDEF_CFLAG -undef)
 endif()
 
-find_program(CMAKE_C_COMPILER    clang          PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_CXX_COMPILER  clang++        PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_AR            llvm-ar        PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_LINKER        llvm-link      PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_NM            llvm-nm        PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_OBJDUMP       llvm-objdump   PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_RANLIB        llvm-ranlib    PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-find_program(CMAKE_OBJCOPY       objcopy        PATH ${TOOLCHAIN_HOME})
-find_program(CMAKE_READELF       readelf        PATH ${TOOLCHAIN_HOME})
+if(DEFINED TOOLCHAIN_HOME)
+  set(find_program_clang_args PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+  set(find_program_binutils_args PATH ${TOOLCHAIN_HOME})
+endif()
+
+
+find_program(CMAKE_C_COMPILER    clang          ${find_program_clang_args})
+find_program(CMAKE_CXX_COMPILER  clang++        ${find_program_clang_args})
+find_program(CMAKE_AR            llvm-ar        ${find_program_clang_args})
+find_program(CMAKE_LINKER        llvm-link      ${find_program_clang_args})
+find_program(CMAKE_NM            llvm-nm        ${find_program_clang_args})
+find_program(CMAKE_OBJDUMP       llvm-objdump   ${find_program_clang_args})
+find_program(CMAKE_RANLIB        llvm-ranlib    ${find_program_clang_args})
+
+find_program(CMAKE_OBJCOPY       objcopy        ${find_program_binutils_args})
+find_program(CMAKE_READELF       readelf        ${find_program_binutils_args})
 
 foreach(file_name include include-fixed)
   execute_process(

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -62,6 +62,13 @@ set(CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags} -Wl,--
 string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 
 # Load toolchain_cc-family macros
+
+macro(toolchain_cc_nostdinc)
+  if(NOT "${ARCH}" STREQUAL "posix")
+    zephyr_compile_options( -nostdinc)
+  endif()
+endmacro()
+
 # Clang and GCC are almost feature+flag compatible, so reuse freestanding gcc
 include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_security_canaries.cmake)
 include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_optimizations.cmake)

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Configuration for host installed llvm
+# Configuration for host installed clang
 #
 
 set(NOSTDINC "")

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -63,9 +63,12 @@ string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 
 # Load toolchain_cc-family macros
 # Clang and GCC are almost feature+flag compatible, so reuse freestanding gcc
-include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_security_fortify.cmake)
 include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_security_canaries.cmake)
 include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_optimizations.cmake)
 include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_cpp.cmake)
 include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_asm.cmake)
 include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_baremetal.cmake)
+
+macro(toolchain_cc_security_fortify)
+  # No op, clang doesn't understand fortify at all
+endmacro()

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -132,6 +132,7 @@ list(APPEND CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags
 string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 
 # Load toolchain_cc-family macros
+include(${ZEPHYR_BASE}/cmake/compiler/${COMPILER}/target_freestanding.cmake)
 include(${ZEPHYR_BASE}/cmake/compiler/${COMPILER}/target_security_fortify.cmake)
 include(${ZEPHYR_BASE}/cmake/compiler/${COMPILER}/target_security_canaries.cmake)
 include(${ZEPHYR_BASE}/cmake/compiler/${COMPILER}/target_optimizations.cmake)

--- a/cmake/compiler/gcc/target_freestanding.cmake
+++ b/cmake/compiler/gcc/target_freestanding.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) 2019 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+macro(toolchain_cc_no_freestanding_options)
+
+  zephyr_cc_option(-fno-freestanding)
+
+endmacro()

--- a/cmake/compiler/host-gcc/target.cmake
+++ b/cmake/compiler/host-gcc/target.cmake
@@ -81,6 +81,7 @@ endforeach()
 
 # Load toolchain_cc-family macros
 # Significant overlap with freestanding gcc compiler so reuse it
+include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_freestanding.cmake)
 include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_security_fortify.cmake)
 include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_security_canaries.cmake)
 include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_optimizations.cmake)

--- a/cmake/generic_toolchain.cmake
+++ b/cmake/generic_toolchain.cmake
@@ -50,7 +50,9 @@ assert(ZEPHYR_TOOLCHAIN_VARIANT "Zephyr toolchain variant invalid: please set th
 
 # Pick host system's toolchain if we are targeting posix
 if((${ARCH} STREQUAL "posix") OR (${ARCH} STREQUAL "x86_64"))
-  set(ZEPHYR_TOOLCHAIN_VARIANT "host")
+  if(NOT "${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "llvm")
+    set(ZEPHYR_TOOLCHAIN_VARIANT "host")
+  endif()
 endif()
 
 # Configure the toolchain based on what SDK/toolchain is in use.

--- a/cmake/generic_toolchain.cmake
+++ b/cmake/generic_toolchain.cmake
@@ -41,6 +41,11 @@ if("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "gccarmemb")
   set(ZEPHYR_TOOLCHAIN_VARIANT "gnuarmemb")
 endif()
 
+# Host-tools don't unconditionally set TOOLCHAIN_HOME anymore,
+# but in case Zephyr's SDK toolchain is used, set TOOLCHAIN_HOME
+if("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "zephyr")
+  set(TOOLCHAIN_HOME ${HOST_TOOLS_HOME})
+endif()
 
 set(TOOLCHAIN_ROOT ${TOOLCHAIN_ROOT} CACHE STRING "Zephyr toolchain root")
 assert(TOOLCHAIN_ROOT "Zephyr toolchain root path invalid: please set the TOOLCHAIN_ROOT-variable")

--- a/cmake/toolchain/llvm/generic.cmake
+++ b/cmake/toolchain/llvm/generic.cmake
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
+find_appropriate_cache_directory(USER_CACHE_DIR)
+
+if((NOT "${USER_CACHE_DIR}" STREQUAL "") AND (EXISTS "${USER_CACHE_DIR}"))
+  message(STATUS "Invalidating toolchain capability cache in ${USER_CACHE_DIR}")
+  execute_process(COMMAND
+    ${CMAKE_COMMAND} -E remove_directory "${USER_CACHE_DIR}")
+endif()
+
 if(DEFINED $ENV{CLANG_ROOT_DIR})
   set(TOOLCHAIN_HOME ${CLANG_ROOT}/bin/)
 endif()

--- a/cmake/toolchain/llvm/generic.cmake
+++ b/cmake/toolchain/llvm/generic.cmake
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(CLANG_ROOT $ENV{CLANG_ROOT_DIR})
-set_ifndef(CLANG_ROOT /usr)
-
-set(TOOLCHAIN_HOME ${CLANG_ROOT}/bin/)
+if(DEFINED $ENV{CLANG_ROOT_DIR})
+  set(TOOLCHAIN_HOME ${CLANG_ROOT}/bin/)
+endif()
 
 set(COMPILER clang)
 
@@ -17,3 +16,7 @@ endif()
 set(CMAKE_C_COMPILER_TARGET   ${triple})
 set(CMAKE_ASM_COMPILER_TARGET ${triple})
 set(CMAKE_CXX_COMPILER_TARGET ${triple})
+
+if("${ARCH}" STREQUAL "posix")
+  set(TOOLCHAIN_HAS_NEWLIB OFF CACHE BOOL "True if toolchain supports newlib")
+endif()

--- a/cmake/toolchain/zephyr/0.9.5/host-tools.cmake
+++ b/cmake/toolchain/zephyr/0.9.5/host-tools.cmake
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(MINGW)
-  set(TOOLCHAIN_HOME ${ZEPHYR_SDK_INSTALL_DIR}/sysroots/i686-pokysdk-mingw32)
+  set(HOST_TOOLS_HOME ${ZEPHYR_SDK_INSTALL_DIR}/sysroots/i686-pokysdk-mingw32)
 else()
-  set(TOOLCHAIN_HOME ${ZEPHYR_SDK_INSTALL_DIR}/sysroots/${TOOLCHAIN_ARCH}-pokysdk-linux)
+  set(HOST_TOOLS_HOME ${ZEPHYR_SDK_INSTALL_DIR}/sysroots/${TOOLCHAIN_ARCH}-pokysdk-linux)
 endif()
 
 # Path used for searching by the find_*() functions, with appropriate
 # suffixes added. Ensures that the SDK's host tools will be found when
 # we call, e.g. find_program(QEMU qemu-system-x86)
-list(APPEND CMAKE_PREFIX_PATH ${TOOLCHAIN_HOME}/usr)
+list(APPEND CMAKE_PREFIX_PATH ${HOST_TOOLS_HOME}/usr)
 
 # TODO: Use find_* somehow for these as well?
-set_ifndef(QEMU_BIOS            ${TOOLCHAIN_HOME}/usr/share/qemu)
-set_ifndef(OPENOCD_DEFAULT_PATH ${TOOLCHAIN_HOME}/usr/share/openocd/scripts)
+set_ifndef(QEMU_BIOS            ${HOST_TOOLS_HOME}/usr/share/qemu)
+set_ifndef(OPENOCD_DEFAULT_PATH ${HOST_TOOLS_HOME}/usr/share/openocd/scripts)

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -156,7 +156,8 @@ Set Up a Toolchain
    In some specific configurations like non-MCU x86 targets on Linux,
    you may be able to re-use the native development tools provided by
    your operating system instead of an SDK by setting
-   ``ZEPHYR_TOOLCHAIN_VARIANT=host``.
+   ``ZEPHYR_TOOLCHAIN_VARIANT=host`` for gcc or
+   ``ZEPHYR_TOOLCHAIN_VARIANT=llvm`` for clang.
 
    If you want, you can use the SDK host tools (such as OpenOCD) with a
    different toolchain by keeping the :envvar:`ZEPHYR_SDK_INSTALL_DIR`


### PR DESCRIPTION
Pick host's clang if ZEPHYR_TOOLCHAIN_VARIANT=llvm.

This has been tested on samples/net/sockets/echo native_posix application with clang-7 and upstream’s version.

Compiles, links and runs with and without optimizations.

Instructions:

```
# sudo apt-get install clang
# cd samples/net/sockets/echo
# export ZEPHYR_TOOLCHAIN_VARIANT=llvm
# mkdir build
# cd build
# cmake -D BOARD=native_posix ..
```