### PR TITLE
scripts/coccinelle: Add script for counting identifier length

### DIFF
--- a/scripts/coccinelle/identifier_length.cocci
+++ b/scripts/coccinelle/identifier_length.cocci
@@ -1,0 +1,30 @@
+// Copyright: (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+virtual report
+
+@r_idlen@
+type T;
+identifier I;
+constant C;
+position p;
+@@
+
+(
+  T I@p (...);
+|
+  I@p (...)
+|
+  T I@p = C;
+|
+  T I@p;
+)
+
+@script:python depends on report@
+id << r_idlen.I;
+pos << r_idlen.p;
+@@
+
+if (len(id) > 31):
+   msg="WARNING: Identifier %s length %d > 31" % (id, len(id))
+   coccilib.report.print_report(pos[0], msg)


### PR DESCRIPTION
Add a simple Coccinelle script that counts identifier lengths and
prints out a warning if it is longer than 31 characters. This in order
to help out with #9894 

The script can be run with:
spatch -D report --very-quiet \
--include-headers --recursive-includes \
--cocci-file $ZEPHYR_BASE/scripts/coccinelle/identifier_length.cocci \
--dir $ZEPHYR_BASE \
kernel/

Where '--include-headers' and '--recursive-includes' can be omitted
if neede.

Signed-off-by: Patrik Flykt <patrik.flykt@intel.com>