### PR TITLE
adc: return EBUSY when requesting new sampling while one in progress

### DIFF
--- a/drivers/adc/adc_context.h
+++ b/drivers/adc/adc_context.h
@@ -84,7 +84,7 @@ static inline void adc_context_request_next_sampling(struct adc_context *ctx)
 		 * complete. Instead, note this fact, and inform the user about
 		 * it after the sequence is done.
 		 */
-		ctx->status = -EIO;
+		ctx->status = -EBUSY;
 	}
 }
 

--- a/include/adc.h
+++ b/include/adc.h
@@ -325,7 +325,7 @@ static inline int adc_channel_setup(struct device *dev,
  * @retval -ENOMEM  If the provided buffer is to small to hold the results
  *                  of all requested samplings.
  * @retval -ENOTSUP If the requested mode of operation is not supported.
- * @retval -EIO     If another sampling was triggered while the previous one
+ * @retval -EBUSY   If another sampling was triggered while the previous one
  *                  was still in progress. This may occur only when samplings
  *                  are done with intervals, and it indicates that the selected
  *                  interval was too small. All requested samples are written


### PR DESCRIPTION
Inside adc_context_request_next_sampling(), it tries to signal an I/O
error if there is a new request while a sampling is in progress.
However, it is not exactly an I/O error. The system is simply busy.
So signal EBUSY instead.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>