### PR TITLE
boards: arm: particle_*: add code-partition fix for mcuboot apps

### DIFF
--- a/boards/arm/particle_argon/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/mesh_feather.dtsi
@@ -26,6 +26,7 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {

--- a/boards/arm/particle_boron/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/mesh_feather.dtsi
@@ -26,6 +26,7 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {

--- a/boards/arm/particle_xenon/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/mesh_feather.dtsi
@@ -26,6 +26,7 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {


### PR DESCRIPTION
To build apps for mcuboot, a zephyr,code-partition needs to be
identified in the DTS chosen block.  Without this entry, the
following configs will always be 0:
CONFIG_FLASH_LOAD_OFFSET
CONFIG_FLASH_LOAD_SIZE

Signed-off-by: Michael Scott <mike@foundries.io>