### PR TITLE
drivers: eth: gmac: various priority queues/Qav fixes

### DIFF
--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -28,6 +28,27 @@ config ETH_SAM_GMAC_QUEUES
 	  Select the number of hardware queues used by the driver. Packets will be
 	  routed to appropriate queues based on their priority.
 
+config ETH_SAM_GMAC_FORCE_QUEUE
+	bool "Force all traffic to be routed through a specific queue"
+	depends on ETH_SAM_GMAC_QUEUES > 1
+	depends on NET_TC_RX_COUNT < 5
+	help
+	  This option is meant to be used only for debugging. Use it to force all
+	  traffic to be routed through a specific hardware queue. With this enabled
+	  it is easier to verify whether the chosen hardware queue actually works.
+	  This works only if there are four or fewer RX traffic classes enabled, as
+	  the SAM GMAC hardware supports screening up to four traffic classes.
+
+config ETH_SAM_GMAC_FORCED_QUEUE
+	int "Queue to force the packets to"
+	depends on ETH_SAM_GMAC_FORCE_QUEUE
+	default 0
+	range 0 1 if ETH_SAM_GMAC_QUEUES = 2
+	range 0 2 if ETH_SAM_GMAC_QUEUES = 3
+	help
+	  Which queue to force the routing to. This affects both the TX and RX queues
+	  setup.
+
 config ETH_SAM_GMAC_BUF_RX_COUNT
 	int "Network RX buffers preallocated by the SAM ETH driver"
 	default 12

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -893,8 +893,18 @@ static int gmac_init(Gmac *gmac, u32_t gmac_ncfgr_val)
 	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 1, 75);
 	eth_sam_gmac_setup_qav(gmac, 1, true);
 #elif GMAC_PRIORITY_QUEUE_NO == 2
-	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 1, 0);
-	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 2, 75);
+	/* For multiple priority queues, 802.1Qav suggests using 75% for the
+	 * highest priority queue, and 0% for the lower priority queues.
+	 * This is because the lower priority queues are supposed to be using
+	 * the bandwidth available from the higher priority queues AND its own
+	 * available bandwidth (see 802.1Q 34.3.1 for more details).
+	 * This does not work like that in SAM GMAC - the lower priority queues
+	 * are not using the bandwidth reserved for the higher priority queues
+	 * at all. Thus we still set the default to a total of the recommended
+	 * 75%, but split the bandwidth between them manually.
+	 */
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 1, 25);
+	eth_sam_gmac_setup_qav_delta_bandwidth(gmac, 2, 50);
 	eth_sam_gmac_setup_qav(gmac, 1, true);
 	eth_sam_gmac_setup_qav(gmac, 2, true);
 #endif

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1028,6 +1028,8 @@ static int priority_queue_init(Gmac *gmac, struct gmac_queue *queue)
 	queue->err_rx_flushed_count = 0U;
 	queue->err_tx_flushed_count = 0U;
 
+	LOG_INF("Queue %d activated", queue->que_idx);
+
 	return 0;
 }
 
@@ -1057,6 +1059,8 @@ static int priority_queue_init_as_idle(Gmac *gmac, struct gmac_queue *queue)
 	gmac->GMAC_RBQBAPQ[queue->que_idx - 1] = (u32_t)rx_desc_list->buf;
 	/* Set Transmit Buffer Queue Pointer Register */
 	gmac->GMAC_TBQBAPQ[queue->que_idx - 1] = (u32_t)tx_desc_list->buf;
+
+	LOG_INF("Queue %d set to idle", queue->que_idx);
 
 	return 0;
 }

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -661,7 +661,7 @@ static int eth_sam_gmac_setup_qav(Gmac *gmac, int queue_id, bool enable)
 		return -EINVAL;
 	}
 
-	if (queue_id == 1) {
+	if (queue_id == GMAC_QUE_2) {
 		if (enable) {
 			gmac->GMAC_CBSCR |= GMAC_CBSCR_QAE;
 		} else {
@@ -685,7 +685,7 @@ static int eth_sam_gmac_get_qav_status(Gmac *gmac, int queue_id, bool *enabled)
 		return -EINVAL;
 	}
 
-	if (queue_id == 1) {
+	if (queue_id == GMAC_QUE_2) {
 		*enabled = gmac->GMAC_CBSCR & GMAC_CBSCR_QAE;
 	} else {
 		*enabled = gmac->GMAC_CBSCR & GMAC_CBSCR_QBE;
@@ -706,7 +706,7 @@ static int eth_sam_gmac_setup_qav_idle_slope(Gmac *gmac, int queue_id,
 
 	cbscr_val = gmac->GMAC_CBSISQA;
 
-	if (queue_id == 1) {
+	if (queue_id == GMAC_QUE_2) {
 		gmac->GMAC_CBSCR &= ~GMAC_CBSCR_QAE;
 		gmac->GMAC_CBSISQA = idle_slope;
 	} else {
@@ -747,7 +747,7 @@ static int eth_sam_gmac_get_qav_idle_slope(Gmac *gmac, int queue_id,
 		return -EINVAL;
 	}
 
-	if (queue_id == 1) {
+	if (queue_id == GMAC_QUE_2) {
 		*idle_slope = gmac->GMAC_CBSISQA;
 	} else {
 		*idle_slope = gmac->GMAC_CBSISQB;


### PR DESCRIPTION
When re-testing multiple queues/Qav support, it turned out to be very easy to break with the current master.

After some bisecting, it turned out, that this started happening after removing the tx timeout code from the driver (18b07e09e000ff681739b1baf94767c81afad933).

While the lack of timeouts is partly a problem here, it also revealed some other issues, which I am trying to address here.

Let me start by copying an excerpt from 802.1Q, chapter 34.3.1 (this is basically about Qav parameters):

> The recommended default value of deltaBandwidth(N) for the highest numbered traffic class supported is 75%, and for any lower numbered traffic classes, the recommended default value is 0%. The deltaBandwidth(N) for a given N, plus the deltaBandwidth(N) values for any higher priority queues (larger values of N) defines the total percentage of the Port’s bandwidth that can be reserved for that queue and all higher priority queues. For the highest priority queue, this means that the maximum value of operIdleSlope(N) is 
>  eltaBandwidth(N)% of portTransmitRate. However, if operIdleSlope(N) is actually less than this maximum value, any lower priority queue that supports the credit-based shaper 
>  lgorithm can make use of the reservable bandwidth that is unused by the higher priority queue. So, for queue N-1, the maximum value of (operIdleSlope(N) + operIdleSlope(N-1)) is (deltaBandwidth(N) + deltaBandwidth(N1))% of portTransmitRate. 
> 
> NOTE 1—For example, suppose two queues, 3 and 2, support the credit-based shaper algorithm for SR classes A and B, respectively. Suppose deltaBandwidth(3) for SR class A is currently 20%, and deltaBandwidth(2) for SR class B is currently 30%. If operIdleSlope(3) is 
>  currently 10% of portTransmitRate, then half of queue 3’s maximum allocation is unused, and the maximum value of operIdleSlope(2) is therefore currently 40% of portTransmitRate. However, if operIdleSlope(3) increases to the full 20% that it is entitled to use, the maximum value of operIdleSlope(2) reduces to 30% of portTransmitRate.

So my understanding of that, is that with Qav, the default delta bandwidth in case of GMAC, should be:
Queue 1: 0%
Queue 2: 75%

And Queue 1 should be able to use the bandwidth assigned to Queue 2, if Queue 2 is not using it.

However that is not the case in SAM GMAC. With such settings, Queue 1 was hardly able to send anything at all. Most of the times it would just get stuck, and hold the buffers forever, quickly making the network stack lose any free buffers (even if the the other queues - the non-priority and the highest priority queue were idle). Note that I tested it by enabling all the queues, and forcing all the traffic to a specific queue (Queue 1 in this case) - I've actually included a commit with an additional symbol that makes it easy to configure it that way - since it will be useful only for debugging let me know whether such patch is even acceptable (but let's keep for now, at least until this gets reviewed).

To fix that, the default Qav settings have been changed to 25% - 50% - this still sets the total priority bandwidth to 75% (to keep the 25% for the non-priority queue), but splits that amount to individual queues manually.

Also note here, that setting it to 0% is still a valid thing to do in my opinion (and users can do this with the management interface). In such case, the timeout mechanism would be a nice thing to have.

While doing the tests described above, I've also noticed that there is another issue with the Qav settings. Throughout the SAM E-70 datasheet, the queued are mostly referred to as Queue 0, Queue 1 and Queue 2 - Queue 0 being the non-priority.
However in context of Qav, the queues are called Queue A and Queue B.

Additionally, Queue 2 and Queue B are sometimes referred to as "the highest priority queue". Based on that, the code used the following "mapping" when setting the Qav params:
Queue 1 - Queue A
Queue 2 - Queue B

However the tests revealed, that it does not work like that, and the mapping should actually be:
Queue 1 - Queue B
Queue 2 - Queue A

Unfortunately I cannot find any confirmation of that in the datasheet.

Since there are two changes that are based solely on observations, and because the way the hardware behaves is different than how I understand it _should_ (according to the ieee and the datasheet), I would be very glad if this could be reviewed in more depth.