### PR TITLE
Arch arm mpu reduce run-time stack usage

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -191,7 +191,7 @@ int arm_core_mpu_buffer_validate(void *addr, size_t size, int write)
  * @brief configure fixed (static) MPU regions.
  */
 void arm_core_mpu_configure_static_mpu_regions(const struct k_mem_partition
-	static_regions[], const u8_t regions_num,
+	*static_regions[], const u8_t regions_num,
 	const u32_t background_area_start, const u32_t background_area_end)
 {
 	if (_mpu_configure_static_mpu_regions(static_regions, regions_num,
@@ -223,7 +223,7 @@ void arm_core_mpu_mark_areas_for_dynamic_regions(
  * @brief configure dynamic MPU regions.
  */
 void arm_core_mpu_configure_dynamic_mpu_regions(const struct k_mem_partition
-	dynamic_regions[], u8_t regions_num)
+	*dynamic_regions[], u8_t regions_num)
 {
 	if (_mpu_configure_dynamic_mpu_regions(dynamic_regions, regions_num)
 		== -EINVAL) {

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
@@ -245,25 +245,25 @@ static int _mpu_configure_region(const u8_t index,
  * sanity check of the memory regions to be programmed.
  */
 static int _mpu_configure_regions(const struct k_mem_partition
-	regions[], u8_t regions_num, u8_t start_reg_index,
+	*regions[], u8_t regions_num, u8_t start_reg_index,
 	bool do_sanity_check)
 {
 	int i;
 	int reg_index = start_reg_index;
 
 	for (i = 0; i < regions_num; i++) {
-		if (regions[i].size == 0) {
+		if (regions[i]->size == 0) {
 			continue;
 		}
 		/* Non-empty region. */
 
 		if (do_sanity_check &&
-				(!_mpu_partition_is_valid(&regions[i]))) {
+				(!_mpu_partition_is_valid(regions[i]))) {
 			LOG_ERR("Partition %u: sanity check failed.", i);
 			return -EINVAL;
 		}
 
-		reg_index = _mpu_configure_region(reg_index, &regions[i]);
+		reg_index = _mpu_configure_region(reg_index, regions[i]);
 
 		if (reg_index == -EINVAL) {
 			return reg_index;
@@ -285,7 +285,7 @@ static int _mpu_configure_regions(const struct k_mem_partition
  * performed, the error signal is propagated to the caller of the function.
  */
 static int _mpu_configure_static_mpu_regions(const struct k_mem_partition
-	static_regions[], const u8_t regions_num,
+	*static_regions[], const u8_t regions_num,
 	const u32_t background_area_base,
 	const u32_t background_area_end)
 {
@@ -314,7 +314,7 @@ static int _mpu_configure_static_mpu_regions(const struct k_mem_partition
  * performed, the error signal is propagated to the caller of the function.
  */
 static int _mpu_configure_dynamic_mpu_regions(const struct k_mem_partition
-		dynamic_regions[], u8_t regions_num)
+	*dynamic_regions[], u8_t regions_num)
 {
 	int mpu_reg_index = static_regions_num;
 

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
@@ -258,20 +258,20 @@ static int _mpu_configure_region(const u8_t index,
  * sanity check of the memory regions to be programmed.
  */
 static int _mpu_configure_regions(const struct k_mem_partition
-	regions[], u8_t regions_num, u8_t start_reg_index,
+	*regions[], u8_t regions_num, u8_t start_reg_index,
 	bool do_sanity_check)
 {
 	int i;
 	int reg_index = start_reg_index;
 
 	for (i = 0; i < regions_num; i++) {
-		if (regions[i].size == 0) {
+		if (regions[i]->size == 0) {
 			continue;
 		}
 		/* Non-empty region. */
 
 		if (do_sanity_check &&
-			(!_mpu_partition_is_valid(&regions[i]))) {
+			(!_mpu_partition_is_valid(regions[i]))) {
 			LOG_ERR("Partition %u: sanity check failed.", i);
 			return -EINVAL;
 		}
@@ -280,7 +280,7 @@ static int _mpu_configure_regions(const struct k_mem_partition
 		 * inside which the new region will be configured.
 		 */
 		int u_reg_index =
-			_get_region_index(regions[i].start, regions[i].size);
+			_get_region_index(regions[i]->start, regions[i]->size);
 
 		if ((u_reg_index == -EINVAL) ||
 			(u_reg_index > (reg_index - 1))) {
@@ -295,9 +295,9 @@ static int _mpu_configure_regions(const struct k_mem_partition
 		 */
 		u32_t u_reg_base = _mpu_region_get_base(u_reg_index);
 		u32_t u_reg_last = _mpu_region_get_last_addr(u_reg_index);
-		u32_t reg_last = regions[i].start + regions[i].size - 1;
+		u32_t reg_last = regions[i]->start + regions[i]->size - 1;
 
-		if ((regions[i].start == u_reg_base) &&
+		if ((regions[i]->start == u_reg_base) &&
 			(reg_last == u_reg_last)) {
 			/* The new region overlaps entirely with the
 			 * underlying region. In this case we simply
@@ -305,17 +305,17 @@ static int _mpu_configure_regions(const struct k_mem_partition
 			 * underlying region with those of the new
 			 * region.
 			 */
-			_mpu_configure_region(u_reg_index, &regions[i]);
-		} else if (regions[i].start == u_reg_base) {
+			_mpu_configure_region(u_reg_index, regions[i]);
+		} else if (regions[i]->start == u_reg_base) {
 			/* The new region starts exactly at the start of the
 			 * underlying region; the start of the underlying
 			 * region needs to be set to the end of the new region.
 			 */
 			_mpu_region_set_base(u_reg_index,
-				regions[i].start + regions[i].size);
+				regions[i]->start + regions[i]->size);
 
 			reg_index =
-				_mpu_configure_region(reg_index, &regions[i]);
+				_mpu_configure_region(reg_index, regions[i]);
 
 			if (reg_index == -EINVAL) {
 				return reg_index;
@@ -329,10 +329,10 @@ static int _mpu_configure_regions(const struct k_mem_partition
 			 * new region.
 			 */
 			_mpu_region_set_limit(u_reg_index,
-				regions[i].start - 1);
+				regions[i]->start - 1);
 
 			reg_index =
-				_mpu_configure_region(reg_index, &regions[i]);
+				_mpu_configure_region(reg_index, regions[i]);
 
 			if (reg_index == -EINVAL) {
 				return reg_index;
@@ -345,10 +345,10 @@ static int _mpu_configure_regions(const struct k_mem_partition
 			 * into two regions.
 			 */
 			_mpu_region_set_limit(u_reg_index,
-				regions[i].start - 1);
+				regions[i]->start - 1);
 
 			reg_index =
-				_mpu_configure_region(reg_index, &regions[i]);
+				_mpu_configure_region(reg_index, regions[i]);
 
 			if (reg_index == -EINVAL) {
 				return reg_index;
@@ -363,10 +363,11 @@ static int _mpu_configure_regions(const struct k_mem_partition
 
 			_mpu_region_get_access_attr(u_reg_index,
 				&fill_region.attr);
-			fill_region.base = regions[i].start + regions[i].size;
+			fill_region.base = regions[i]->start +
+				regions[i]->size;
 			fill_region.attr.r_limit =
-			REGION_LIMIT_ADDR((regions[i].start + regions[i].size),
-				(u_reg_last - reg_last));
+			REGION_LIMIT_ADDR((regions[i]->start +
+				regions[i]->size), (u_reg_last - reg_last));
 
 			reg_index =
 				_region_allocate_and_init(reg_index,
@@ -393,7 +394,7 @@ static int _mpu_configure_regions(const struct k_mem_partition
  * performed, the error signal is propagated to the caller of the function.
  */
 static int _mpu_configure_static_mpu_regions(const struct k_mem_partition
-	static_regions[], const u8_t regions_num,
+	*static_regions[], const u8_t regions_num,
 	const u32_t background_area_base,
 	const u32_t background_area_end)
 {
@@ -464,7 +465,7 @@ static int _mpu_mark_areas_for_dynamic_regions(
  * performed, the error signal is propagated to the caller of the function.
  */
 static int _mpu_configure_dynamic_mpu_regions(const struct k_mem_partition
-	dynamic_regions[], u8_t regions_num)
+	*dynamic_regions[], u8_t regions_num)
 {
 	int mpu_reg_index = static_regions_num;
 

--- a/arch/arm/core/cortex_m/mpu/nxp_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/nxp_mpu.c
@@ -241,19 +241,19 @@ static int _mpu_configure_regions(const struct k_mem_partition
 	int reg_index = start_reg_index;
 
 	for (i = 0; i < regions_num; i++) {
-		if (regions[i].size == 0) {
+		if (regions[i]->size == 0) {
 			continue;
 		}
 		/* Non-empty region. */
 
 		if (do_sanity_check &&
-				(!_mpu_partition_is_valid(&regions[i]))) {
+				(!_mpu_partition_is_valid(regions[i]))) {
 			LOG_ERR("Partition %u: sanity check failed.", i);
 			return -EINVAL;
 		}
 
 #if defined(CONFIG_MPU_STACK_GUARD)
-		if (regions[i].attr.ap_attr == MPU_REGION_SU_RX) {
+		if (regions[i]->attr.ap_attr == MPU_REGION_SU_RX) {
 
 			/* Attempt to configure an MPU Stack Guard region; this
 			 * will require splitting of the underlying SRAM region
@@ -261,7 +261,7 @@ static int _mpu_configure_regions(const struct k_mem_partition
 			 * be programmed afterwards.
 			 */
 			reg_index =
-				_mpu_sram_partitioning(reg_index, &regions[i]);
+				_mpu_sram_partitioning(reg_index, regions[i]);
 		}
 #endif /* CONFIG_MPU_STACK_GUARD */
 
@@ -269,7 +269,7 @@ static int _mpu_configure_regions(const struct k_mem_partition
 			return reg_index;
 		}
 
-		reg_index = _mpu_configure_region(reg_index, &regions[i]);
+		reg_index = _mpu_configure_region(reg_index, regions[i]);
 
 		if (reg_index == -EINVAL) {
 			return reg_index;

--- a/arch/arm/core/cortex_m/mpu/nxp_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/nxp_mpu.c
@@ -234,7 +234,7 @@ static int _mpu_sram_partitioning(u8_t index,
  * sanity check of the memory regions to be programmed.
  */
 static int _mpu_configure_regions(const struct k_mem_partition
-	regions[], u8_t regions_num, u8_t start_reg_index,
+	*regions[], u8_t regions_num, u8_t start_reg_index,
 	bool do_sanity_check)
 {
 	int i;
@@ -291,7 +291,7 @@ static int _mpu_configure_regions(const struct k_mem_partition
  * performed, the error signal is propagated to the caller of the function.
  */
 static int _mpu_configure_static_mpu_regions(const struct k_mem_partition
-	static_regions[], const u8_t regions_num,
+	*static_regions[], const u8_t regions_num,
 	const u32_t background_area_base,
 	const u32_t background_area_end)
 {
@@ -320,7 +320,7 @@ static int _mpu_configure_static_mpu_regions(const struct k_mem_partition
  * performed, the error signal is propagated to the caller of the function.
  */
 static int _mpu_configure_dynamic_mpu_regions(const struct k_mem_partition
-		dynamic_regions[], u8_t regions_num)
+	*dynamic_regions[], u8_t regions_num)
 {
 	/* Reset MPU regions inside which dynamic memory regions may
 	 * be programmed.
@@ -534,7 +534,7 @@ int arm_core_mpu_buffer_validate(void *addr, size_t size, int write)
  * @brief configure fixed (static) MPU regions.
  */
 void arm_core_mpu_configure_static_mpu_regions(const struct k_mem_partition
-	static_regions[], const u8_t regions_num,
+	*static_regions[], const u8_t regions_num,
 	const u32_t background_area_start, const u32_t background_area_end)
 {
 	if (_mpu_configure_static_mpu_regions(static_regions, regions_num,
@@ -549,7 +549,7 @@ void arm_core_mpu_configure_static_mpu_regions(const struct k_mem_partition
  * @brief configure dynamic MPU regions.
  */
 void arm_core_mpu_configure_dynamic_mpu_regions(const struct k_mem_partition
-	dynamic_regions[], u8_t regions_num)
+	*dynamic_regions[], u8_t regions_num)
 {
 	if (_mpu_configure_dynamic_mpu_regions(dynamic_regions, regions_num)
 		== -EINVAL) {

--- a/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
+++ b/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
@@ -126,7 +126,8 @@ void arm_core_mpu_disable(void);
  *
  * The function shall be invoked once, upon system initialization.
  *
- * @param static_regions[] an array of memory partitions to be programmed
+ * @param static_regions[] an array of pointers to memory partitions
+ *                         to be programmed
  * @param regions_num the number of regions to be programmed
  * @param background_area_start the start address of the background memory area
  * @param background_area_end the end address of the background memory area
@@ -139,7 +140,7 @@ void arm_core_mpu_disable(void);
  *   requirements of the MPU hardware.
  */
 void arm_core_mpu_configure_static_mpu_regions(
-	const struct k_mem_partition static_regions[], const u8_t regions_num,
+	const struct k_mem_partition *static_regions[], const u8_t regions_num,
 	const u32_t background_area_start, const u32_t background_area_end);
 
 #if defined(CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS)
@@ -182,7 +183,8 @@ void arm_core_mpu_mark_areas_for_dynamic_regions(
  * within a (background) memory area. The total number of HW MPU regions
  * to be programmed depends on the MPU architecture.
  *
- * @param dynamic_regions[] an array of memory partitions to be programmed
+ * @param dynamic_regions[] an array of pointers to memory partitions
+ *                          to be programmed
  * @param regions_num the number of regions to be programmed
  *
  * The function shall assert if the operation cannot be not performed
@@ -190,7 +192,7 @@ void arm_core_mpu_mark_areas_for_dynamic_regions(
  * not exceed the number of (currently) available MPU indices.
  */
 void arm_core_mpu_configure_dynamic_mpu_regions(
-	const struct k_mem_partition dynamic_regions[], u8_t regions_num);
+	const struct k_mem_partition *dynamic_regions[], u8_t regions_num);
 
 #if defined(CONFIG_USERSPACE)
 /**


### PR DESCRIPTION
Fixes #13783 

The aim of this PR is to reduce the run-time stack usage when re-programming the ARM MPU during context-switch and/or arm-user-mode-enter. What it does is to change how the configuration is passed from `arm_core_mpu.c ` to the HW-specific MPU drivers (ARMv7, ARMv8, and NXP MPU):

Instead of creating the complete desired memory map online and supplying it to the drivers as an arrray of k_mem_partition objects, we, now, only create an array of pointers to k_mem_partition_object and supply that to the drivers.

Reduction to stack usage is observed, mainly, when CONFIG_USERSPACE is set: this is because the mem-domain partition information is kept in kernel globals and we just supply pointers to the mem-domain partitions.

In builds without USERSPACE support there is practically no stack usage reduction, as the only dynamic region could be the the MPU guard, and that one is still generated online. However, since this is the only dynamic region, the stack usage is not a problem in this scenario.
