### PR TITLE
boards: nrf: Prevent DTC warnings "duplicate unit-address"

### DIFF
--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -76,7 +76,7 @@
 	scl-pin = <22>;
 };
 
-&spi0 {
+&spi1 {
 	status = "ok";
 	sck-pin = <26>;
 	mosi-pin = <23>;

--- a/boards/arm/96b_nitrogen/Kconfig.defconfig
+++ b/boards/arm/96b_nitrogen/Kconfig.defconfig
@@ -18,7 +18,7 @@ endif # I2C
 
 if SPI
 
-config SPI_0
+config SPI_1
 	default y
 
 endif # SPI

--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -102,13 +102,15 @@
 };
 
 &i2c1 {
-	status = "ok";
+	/* Cannot be used together with spi1. */
+	/* status = "ok"; */
 	sda-pin = <5>;
 	scl-pin = <6>;
 };
 
 &spi0 {
-	status = "ok";
+	/* Cannot be used together with i2c0. */
+	/* status = "ok"; */
 	sck-pin = <7>;
 	mosi-pin = <29>;
 	miso-pin = <30>;

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -89,13 +89,15 @@
 };
 
 &i2c1 {
-	status = "ok";
+	/* Cannot be used together with spi1. */
+	/* status = "ok"; */
 	sda-pin = <2>;
 	scl-pin = <3>;
 };
 
 &spi0 {
-	status = "ok";
+	/* Cannot be used together with i2c0. */
+	/* status = "ok"; */
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -107,7 +107,8 @@
 };
 
 &i2c1 {
-	status = "ok";
+	/* Cannot be used together with spi1. */
+	/* status = "ok"; */
 	sda-pin = <30>;
 	scl-pin = <31>;
 };
@@ -119,7 +120,8 @@
 };
 
 &spi0 {
-	status = "ok";
+	/* Cannot be used together with i2c0. */
+	/* status = "ok"; */
 	sck-pin = <27>;
 	mosi-pin = <26>;
 	miso-pin = <29>;

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -93,7 +93,8 @@
 };
 
 &i2c1 {
-	status = "ok";
+	/* Cannot be used together with spi1. */
+	/* status = "ok"; */
 	sda-pin = <30>;
 	scl-pin = <31>;
 };
@@ -103,7 +104,8 @@
  * limited GPIOs available on dongle board.
  */
 &spi0 {
-	status = "ok";
+	/* Cannot be used together with i2c0. */
+	/* status = "ok"; */
 	sck-pin = <27>;
 	mosi-pin = <26>;
 	miso-pin = <42>;

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -104,7 +104,8 @@
 };
 
 &i2c1 {
-	status = "ok";
+	/* Cannot be used together with spi1. */
+	/* status = "ok"; */
 	sda-pin = <30>;
 	scl-pin = <31>;
 };
@@ -116,7 +117,8 @@
 };
 
 &spi0 {
-	status = "ok";
+	/* Cannot be used together with i2c0. */
+	/* status = "ok"; */
 	sck-pin = <27>;
 	mosi-pin = <26>;
 	miso-pin = <25>;


### PR DESCRIPTION
**boards: 96b_nitrogen: Enable by default SPI_1 instead of SPI_0**

SPI_0 cannot be used simultaneously with I2C_0, since in nRF52832 SoC
these instances share certain hardware resources.

**boards: nrf: Correct I2C and SPI instances enabled by default in dts**

Do not enable by default both I2C and SPI nodes for the peripherals
with the same instance number, since they use the same MMIO base
address and DTC will issue a warning in such situation.
This patch corrects dts files for the following boards:
- nrf51_pca10028
- nrf52_pca10040
- nrf52840_blip
- nrf52840_pca10056
- nrf52840_pca10059

Fixes #12589.