### PR TITLE
ext: lib: crypto: unify the API of CCM alogrithm

### DIFF
--- a/drivers/crypto/crypto_tc_shim.c
+++ b/drivers/crypto/crypto_tc_shim.c
@@ -125,7 +125,9 @@ static int do_ccm_encrypt_mac(struct cipher_ctx *ctx,
 	 * of this and provide sufficient buffer space in output buffer to hold
 	 * both encrypted output and hash
 	 */
-	aead_op->tag = op->out_buf + op->in_len;
+	if (aead_op->tag) {
+		memcpy(aead_op->tag, op->out_buf + op->in_len, ccm.mlen);
+	}
 
 	/* Before returning TC_CRYPTO_SUCCESS, tc_ccm_generation_encryption()
 	 * will advance the output buffer pointer by op->in_len bytes,

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -1283,11 +1283,6 @@ static int _cc2520_crypto_ccm(struct cipher_ctx *ctx,
 		return -EINVAL;
 	}
 
-	if (apkt->tag) {
-		LOG_ERR("CCM encryption does not take a tag");
-		return -EINVAL;
-	}
-
 	m = insert_crypto_parameters(ctx, apkt, ccm_nonce, &auth_crypt);
 	if (m < 0) {
 		LOG_ERR("Inserting crypto parameters failed");
@@ -1312,7 +1307,10 @@ static int _cc2520_crypto_ccm(struct cipher_ctx *ctx,
 		return -EIO;
 	}
 
-	apkt->tag = apkt->pkt->out_buf + apkt->pkt->in_len;
+	if (apkt->tag) {
+		memcpy(apkt->tag, apkt->pkt->out_buf + apkt->pkt->in_len,
+					ctx->mode_params.ccm_info.tag_len);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
unify the API of CCM alogrithm's implemation for TinyCrypt,
mbedTLS and cc2520 crypto device to make users easy to use.

Fixes #8339.

Signed-off-by: Wentong Wu wentong.wu@intel.com