### PR TITLE
Arch arm barrier instructions in irq disabling

### DIFF
--- a/arch/arm/core/swap.c
+++ b/arch/arm/core/swap.c
@@ -65,5 +65,8 @@ int __swap(int key)
 	/* clear mask or enable all irqs to take a pendsv */
 	irq_unlock(0);
 
+	/* Context switch is performed here. Returning implies the
+	 * thread has been context-switched-in again.
+	 */
 	return _current->arch.swap_return_value;
 }

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -61,6 +61,7 @@ SECTION_FUNC(TEXT, __pendsv)
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
     movs.n r0, #_EXC_IRQ_DEFAULT_PRIO
     msr BASEPRI, r0
+    isb /* Make the effect of disabling interrupts be realized immediately */
 #else
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */

--- a/include/arch/arm/cortex_m/asm_inline_gcc.h
+++ b/include/arch/arm/cortex_m/asm_inline_gcc.h
@@ -132,7 +132,8 @@ static ALWAYS_INLINE unsigned int z_arch_irq_lock(void)
 	__asm__ volatile(
 		"mov %1, %2;"
 		"mrs %0, BASEPRI;"
-		"msr BASEPRI, %1"
+		"msr BASEPRI, %1;"
+		"isb;"
 		: "=r"(key), "=r"(tmp)
 		: "i"(_EXC_IRQ_DEFAULT_PRIO)
 		: "memory");


### PR DESCRIPTION
One patch is clearly, just, informative.
The second patch deals with securing recognition of interrupts-disable, according to the ARM recommendations. 

Reference here: https://static.docs.arm.com/dai0321/a/DAI0321A_programming_guide_memory_barriers_for_m_profile.pdf