### PR TITLE
settings: enable logging instead of ASSERT

### DIFF
--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -15,6 +15,12 @@ menuconfig SETTINGS
 	  It supports several back-ends to store and load serialized data from
 	  and it can do so atomically for all involved modules.
 
+if SETTINGS
+module = SETTINGS
+module-str = settings
+source "subsys/logging/Kconfig.template.log_config"
+endif
+
 # Hidden option to enable encoding length into settings entry
 config SETTINGS_ENCODE_LEN
 	depends on SETTINGS

--- a/subsys/settings/src/settings.c
+++ b/subsys/settings/src/settings.c
@@ -14,6 +14,9 @@
 #include "settings_priv.h"
 #include <zephyr/types.h>
 
+#include <logging/log.h>
+LOG_MODULE_REGISTER(settings, CONFIG_SETTINGS_LOG_LEVEL);
+
 sys_slist_t settings_handlers;
 
 static u8_t settings_cmd_inited;

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -13,6 +13,9 @@
 #include "settings/settings_fcb.h"
 #include "settings_priv.h"
 
+#include <logging/log.h>
+LOG_MODULE_DECLARE(settings, CONFIG_SETTINGS_LOG_LEVEL);
+
 #define SETTINGS_FCB_VERS		1
 
 struct settings_fcb_load_cb_arg {
@@ -211,11 +214,16 @@ static void settings_fcb_compress(struct settings_fcb *cf)
 			continue;
 		}
 		rc = fcb_append_finish(&cf->cf_fcb, &loc2.loc);
-		__ASSERT(rc == 0, "Failed to finish fcb_append.\n");
+
+		if (rc != 0) {
+			LOG_ERR("Failed to finish fcb_append (%d)", rc);
+		}
 	}
 	rc = fcb_rotate(&cf->cf_fcb);
 
-	__ASSERT(rc == 0, "Failed to fcb rotate.\n");
+	if (rc != 0) {
+		LOG_ERR("Failed to fcb rotate (%d)", rc);
+	}
 }
 
 static size_t get_len_cb(void *ctx)

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -7,7 +7,6 @@
 
 #include <ctype.h>
 #include <string.h>
-#include <misc/__assert.h>
 
 #include "settings/settings.h"
 #include "settings_priv.h"
@@ -16,7 +15,8 @@
 #include "base64.h"
 #endif
 
-#include "misc/printk.h"
+#include <logging/log.h>
+LOG_MODULE_DECLARE(settings, CONFIG_SETTINGS_LOG_LEVEL);
 
 int settings_line_parse(char *buf, char **namep, char **valp)
 {
@@ -447,7 +447,9 @@ size_t settings_line_val_get_len(off_t val_off, void *read_cb_ctx)
 		rc = settings_line_raw_read(len - 2, raw, 2, &len, read_cb_ctx);
 		if (rc || len != 2) {
 			/* very unexpected error */
-			__ASSERT(rc == 0, "Failed to read the storage.\n");
+			if (rc != 0) {
+				LOG_ERR("Failed to read the storage (%d)", rc);
+			}
 			return 0;
 		}
 

--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -12,10 +12,12 @@
 #include <stddef.h>
 #include <sys/types.h>
 #include <errno.h>
-#include <misc/__assert.h>
 
 #include "settings/settings.h"
 #include "settings_priv.h"
+
+#include <logging/log.h>
+LOG_MODULE_DECLARE(settings, CONFIG_SETTINGS_LOG_LEVEL);
 
 struct settings_dup_check_arg {
 	const char *name;
@@ -48,8 +50,15 @@ void settings_dst_register(struct settings_store *cs)
 static void settings_load_cb(char *name, void *val_read_cb_ctx, off_t off,
 			     void *cb_arg)
 {
-	 int rc = settings_set_value_priv(name, val_read_cb_ctx, off, 0);
-	__ASSERT(rc == 0, "set-value operation failure\n");
+	int rc = settings_set_value_priv(name, val_read_cb_ctx, off, 0);
+
+	if (rc != 0) {
+		LOG_ERR("set-value failure. key: %s error(%d)",
+			name, rc);
+	} else {
+		LOG_DBG("set-value OK. key: %s",
+			name);
+	}
 	(void)rc;
 }
 


### PR DESCRIPTION
This patch introduce logging to settings.

Error in stored data record might occurred in runtime, so
better to switch assertion to error logging.

I treat this patch as bugfix since bad key-value pair might brick the device while assertions are compiled in.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>