### PR TITLE
drivers: flash: mcux: Exclude KW40Z from flash driver

### DIFF
--- a/drivers/flash/Kconfig.mcux
+++ b/drivers/flash/Kconfig.mcux
@@ -1,6 +1,6 @@
 config SOC_FLASH_MCUX
 	bool "MCUX flash shim driver"
-	depends on HAS_MCUX
+	depends on HAS_MCUX && !SOC_MKW40Z4
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
 	help


### PR DESCRIPTION
The KW40Z isn't supported by the MCUX flash driver so don't allow it to
be selected for that SoC.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>