### PR TITLE
drivers: eth_enc28j60: fix calculation of frame length

### DIFF
--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -533,7 +533,7 @@ static int eth_enc28j60_rx(struct device *dev)
 		/* Get the frame length from the rx status vector,
 		 * minus CRC size at the end which is always present
 		 */
-		frm_len = (info[1] << 8) | (info[0] - 4);
+		frm_len = sys_get_le16(info) - 4;
 		lengthfr = frm_len;
 
 		/* Get the frame from the buffer */


### PR DESCRIPTION
Fix calculation of frame length in eth_enc28j60_rx().
The calculation was incorrect because the CRC size was
subtracted only from the lower byte.