### PR TITLE
arch: arm: introduces sync barriers in _arch_irq_unlock()

### DIFF
--- a/include/arch/arm/cortex_m/asm_inline_gcc.h
+++ b/include/arch/arm/cortex_m/asm_inline_gcc.h
@@ -169,9 +169,15 @@ static ALWAYS_INLINE void z_arch_irq_unlock(unsigned int key)
 	if (key) {
 		return;
 	}
-	__asm__ volatile("cpsie i" : : : "memory");
+	__asm__ volatile(
+		"cpsie i;"
+		"isb"
+		: : : "memory");
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	__asm__ volatile("msr BASEPRI, %0" :  : "r"(key) : "memory");
+	__asm__ volatile(
+		"msr BASEPRI, %0;"
+		"isb;"
+		:  : "r"(key) : "memory");
 #else
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */


### PR DESCRIPTION
The ARM Cortex-M 321 application note is stressing that
when enabling interrupts by executing CPSIE i(f), or by MSR
instructions (on PRIMASK, FAULTMASK, or BASEPRI registers),
there is a need for synchronization barrier instructions,
if there is a requirement for the effect of enabling
interrupts to be recongnized immediately. _arch_irq_unlock()
is invoked in several places, therefore, we add the
barriers to make the interrupt enabling function
applicable to all usage scenarios.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>