### PR TITLE
soc: nxp_kinetis: Add HAS_MCUX_FTFX to conditionalize mcux flash driver

### DIFF
--- a/drivers/flash/Kconfig.mcux
+++ b/drivers/flash/Kconfig.mcux
@@ -1,6 +1,6 @@
 config SOC_FLASH_MCUX
 	bool "MCUX flash shim driver"
-	depends on HAS_MCUX
+	depends on HAS_MCUX_FTFX
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
 	help

--- a/ext/hal/nxp/mcux/Kconfig
+++ b/ext/hal/nxp/mcux/Kconfig
@@ -38,6 +38,12 @@ config HAS_MCUX_ENET
 	help
 	  Set if the ethernet (ENET) module is present in the SoC.
 
+config HAS_MCUX_FTFX
+	bool
+	help
+	  Set if the flash memory (FTFA, FTFE, or FTFL) module is present in
+	  the SoC.
+
 config HAS_MCUX_FTM
 	bool
 	help

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.soc
@@ -14,6 +14,7 @@ config SOC_MK64F12
 	select HAS_MCUX
 	select HAS_MCUX_ADC16
 	select HAS_MCUX_ENET
+	select HAS_MCUX_FTFX
 	select HAS_MCUX_FTM
 	select HAS_MCUX_RNGA
 	select HAS_MCUX_SIM

--- a/soc/arm/nxp_kinetis/kl2x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/kl2x/Kconfig.soc
@@ -14,6 +14,7 @@ config SOC_MKL25Z4
 	select CPU_CORTEX_M0PLUS
 	select HAS_MCUX
 	select HAS_MCUX_ADC16
+	select HAS_MCUX_FTFX
 	select HAS_MCUX_LPSCI
 	select HAS_MCUX_SIM
 	select HAS_OSC

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.soc
@@ -14,6 +14,7 @@ config SOC_MKW22D5
 	select CPU_CORTEX_M4
 	select HAS_MCUX
 	select HAS_MCUX_ADC16
+	select HAS_MCUX_FTFX
 	select HAS_MCUX_FTM
 	select HAS_MCUX_RNGA
 	select HAS_MCUX_SIM
@@ -25,6 +26,7 @@ config SOC_MKW24D5
 	select CPU_CORTEX_M4
 	select HAS_MCUX
 	select HAS_MCUX_ADC16
+	select HAS_MCUX_FTFX
 	select HAS_MCUX_FTM
 	select HAS_MCUX_RNGA
 	select HAS_MCUX_SIM
@@ -47,6 +49,7 @@ config SOC_MKW41Z4
 	select CPU_CORTEX_M0PLUS
 	select HAS_MCUX
 	select HAS_MCUX_ADC16
+	select HAS_MCUX_FTFX
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_RTC
 	select HAS_MCUX_SIM


### PR DESCRIPTION
Adds a new config HAS_MCUX_FTFX to conditionalize the mcux flash driver
on socs that support it. Selects HAS_MCUX_FTFX on all kinetis socs
except kw40z, because even though this soc has the relevant hardware,
its CMSIS header file is not compatible with the mcux flash driver in
ext/.

This change also prevents enabling the mcux flash driver on lpc and imx
rt boards.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>