### PR TITLE
Revert "net: sockets: recv_stream: Check that the underlying net_context active"

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -682,11 +682,6 @@ static inline ssize_t zsock_recv_stream(struct net_context *ctx,
 	struct net_pkt_cursor backup;
 	int res;
 
-	if (!net_context_is_used(ctx)) {
-		errno = EBADF;
-		return -1;
-	}
-
 	if ((flags & ZSOCK_MSG_DONTWAIT) || sock_is_nonblock(ctx)) {
 		timeout = K_NO_WAIT;
 	}


### PR DESCRIPTION
This reverts commit 8cb5d083cb53627964ed72fb9fa3fb7a5219739f.

This was breaking tests on master due to missing dependency that is
still being reviewed.