### PR TITLE
drivers: gpio: stm32: add ASCR configuration for L47x+

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -163,6 +163,16 @@ int gpio_stm32_configure(u32_t *base_addr, int pin, int conf, int altf)
 		}
 	}
 
+#if defined(CONFIG_SOC_SERIES_STM32L4X) && defined(GPIO_ASCR_ASC0)
+	/*
+	 * For STM32L47xx/48xx, register ASCR should be configured to connect
+	 * analog switch of gpio lines to the ADC.
+	 */
+	if (mode == STM32_MODER_ANALOG_MODE) {
+		LL_GPIO_EnablePinAnalogControl(gpio, pin_ll);
+	}
+#endif
+
 	LL_GPIO_SetPinOutputType(gpio, pin_ll, otype >> STM32_OTYPER_SHIFT);
 
 	LL_GPIO_SetPinSpeed(gpio, pin_ll, ospeed >> STM32_OSPEEDR_SHIFT);


### PR DESCRIPTION
For STM32L47x/48x series devices, if we want to configure one
GPIO line as ADC input, we have to set the corresponding
bit in GPIOx_ASCR register to get ADC and GPIO line connected.

Signed-off-by: Song Qiang <songqiang1304521@gmail.com>