### PR TITLE
arch: arc: fixes the hanlding of CONFIG_EXECUTION_BENCHMARKING

### DIFF
--- a/arch/arc/core/isr_wrapper.S
+++ b/arch/arc/core/isr_wrapper.S
@@ -230,47 +230,38 @@ From RIRQ:
  */
 
 SECTION_FUNC(TEXT, _isr_wrapper)
-#ifdef CONFIG_EXECUTION_BENCHMARKING
-	push_s r0
-	push_s blink
-	push_s r13
-	push_s r12
-	push r11
-	push r10
-	push r9
-	push r8
-	push r7
-	push r6
-	push r5
-	push r4
-	push_s r3
-	push_s r2
-	push_s r1
-
-	bl read_timer_start_of_isr
-
-	pop_s r1
-	pop_s r2
-	pop_s r3
-	pop r4
-	pop r5
-	pop r6
-	pop r7
-	pop r8
-	pop r9
-	pop r10
-	pop r11
-	pop_s r12
-	pop_s r13
-	pop_s blink
-	pop_s r0
-
-#endif
-
 #if CONFIG_ARC_FIRQ
 #if CONFIG_RGF_NUM_BANKS == 1
 	st r0,[saved_r0]
 #endif
+
+#ifdef CONFIG_EXECUTION_BENCHMARKING
+#if CONFIG_RGF_NUM_BANKS !=1
+	lr r0, [_ARC_V2_STATUS32]
+	and r0, r0, ~_ARC_V2_STATUS32_RB(7)
+	kflag r0
+#endif
+/*
+ * read_timer_start_of_isr just uses several
+ * register now, no need to save all regs
+ */
+	push_s r0
+	push_s r1
+	push_s blink
+
+	bl read_timer_start_of_isr
+
+	pop_s blink
+	pop_s r1
+	pop_s r0
+
+#if CONFIG_RGF_NUM_BANKS !=1
+	lr r0, [_ARC_V2_STATUS32]
+	or r0, r0, _ARC_V2_STATUS32_RB(1)
+	kflag r0
+#endif
+#endif
+
 	lr r0, [_ARC_V2_AUX_IRQ_ACT]
 	ffs r0, r0
 	cmp r0, 0
@@ -326,7 +317,9 @@ rirq_path:
 	j_s [r2]
 #endif
 #else
-
+#ifdef CONFIG_EXECUTION_BENCHMARKING
+	bl read_timer_start_of_isr
+#endif
 	mov r3, _rirq_exit
 	mov r2, _rirq_enter
 	j_s [r2]
@@ -374,8 +367,6 @@ _skip_sys_power_save_idle_exit:
 /* when getting here, r3 contains the interrupt exit stub to call */
 SECTION_FUNC(TEXT, _isr_demux)
 	push_s r3
-
-
 	/* cannot be done before this point because we must be able to run C */
 	/* r0 is available to be stomped here, and exit_tickless_idle uses it */
 	exit_tickless_idle
@@ -383,9 +374,9 @@ SECTION_FUNC(TEXT, _isr_demux)
 
 	lr r0, [_ARC_V2_ICAUSE]
 	/* handle software triggered interrupt */
-	lr	r3, [_ARC_V2_AUX_IRQ_HINT]
-	brne	r3, r0, irq_hint_handled
-	sr	0, [_ARC_V2_AUX_IRQ_HINT]
+	lr r3, [_ARC_V2_AUX_IRQ_HINT]
+	brne r3, r0, irq_hint_handled
+	sr 0, [_ARC_V2_AUX_IRQ_HINT]
 irq_hint_handled:
 
 	sub r0, r0, 16
@@ -396,39 +387,10 @@ irq_hint_handled:
 	ld_s r1, [r0, 4] /* ISR into r1 */
 #ifdef CONFIG_EXECUTION_BENCHMARKING
 	push_s r0
-	push_s blink
-	push_s r13
-	push_s r12
-	push r11
-	push r10
-	push r9
-	push r8
-	push r7
-	push r6
-	push r5
-	push r4
-	push_s r3
-	push_s r2
 	push_s r1
-
 	bl read_timer_end_of_isr
-
 	pop_s r1
-	pop_s r2
-	pop_s r3
-	pop r4
-	pop r5
-	pop r6
-	pop r7
-	pop r8
-	pop r9
-	pop r10
-	pop r11
-	pop_s r12
-	pop_s r13
-	pop_s blink
 	pop_s r0
-
 #endif
 	jl_s.d [r1]
 	ld_s r0, [r0] /* delay slot: ISR parameter into r0  */

--- a/arch/arc/core/isr_wrapper.S
+++ b/arch/arc/core/isr_wrapper.S
@@ -234,34 +234,6 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 #if CONFIG_RGF_NUM_BANKS == 1
 	st r0,[saved_r0]
 #endif
-
-#ifdef CONFIG_EXECUTION_BENCHMARKING
-#if CONFIG_RGF_NUM_BANKS !=1
-	lr r0, [_ARC_V2_STATUS32]
-	and r0, r0, ~_ARC_V2_STATUS32_RB(7)
-	kflag r0
-#endif
-/*
- * read_timer_start_of_isr just uses several
- * register now, no need to save all regs
- */
-	push_s r0
-	push_s r1
-	push_s blink
-
-	bl read_timer_start_of_isr
-
-	pop_s blink
-	pop_s r1
-	pop_s r0
-
-#if CONFIG_RGF_NUM_BANKS !=1
-	lr r0, [_ARC_V2_STATUS32]
-	or r0, r0, _ARC_V2_STATUS32_RB(1)
-	kflag r0
-#endif
-#endif
-
 	lr r0, [_ARC_V2_AUX_IRQ_ACT]
 	ffs r0, r0
 	cmp r0, 0
@@ -317,9 +289,6 @@ rirq_path:
 	j_s [r2]
 #endif
 #else
-#ifdef CONFIG_EXECUTION_BENCHMARKING
-	bl read_timer_start_of_isr
-#endif
 	mov r3, _rirq_exit
 	mov r2, _rirq_enter
 	j_s [r2]
@@ -367,6 +336,10 @@ _skip_sys_power_save_idle_exit:
 /* when getting here, r3 contains the interrupt exit stub to call */
 SECTION_FUNC(TEXT, _isr_demux)
 	push_s r3
+
+#ifdef CONFIG_EXECUTION_BENCHMARKING
+	bl read_timer_start_of_isr
+#endif
 	/* cannot be done before this point because we must be able to run C */
 	/* r0 is available to be stomped here, and exit_tickless_idle uses it */
 	exit_tickless_idle


### PR DESCRIPTION
when firq is enabled and there are multiple register banks,
it requires different handling

Fixes #12949 
Fixes #12947 

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>