### PR TITLE
kconfig: pinmux: Remove lots of redundant PINMUX dependencies

### DIFF
--- a/boards/x86/galileo/Kconfig
+++ b/boards/x86/galileo/Kconfig
@@ -7,46 +7,41 @@
 #
 
 if PINMUX && BOARD_GALILEO
+
 comment "Galileo Pinmux Options"
 
 config PINMUX_GALILEO_EXP0_NAME
 	string "Name of the GPIO expander 0"
-	depends on PINMUX && BOARD_GALILEO
 	default "EXP0"
 	help
 	  The name of the GPIO expander labeled as EXP0 in the schematic.
 
 config PINMUX_GALILEO_EXP1_NAME
 	string "Name of the GPIO expander 1"
-	depends on PINMUX && BOARD_GALILEO
 	default "EXP1"
 	help
 	  The name of the GPIO expander labeled as EXP1 in the schematic.
 
 config PINMUX_GALILEO_EXP2_NAME
 	string "Name of the GPIO expander 2"
-	depends on PINMUX && BOARD_GALILEO
 	default "EXP2"
 	help
 	  The name of the GPIO expander labeled as EXP2 in the schematic.
 
 config PINMUX_GALILEO_PWM0_NAME
 	string "Name of the PWM LED expander 0"
-	depends on PINMUX && BOARD_GALILEO
 	default "PWM0"
 	help
 	  The name of the PWM LED expander labeled as PWM0 in the schematic.
 
 config PINMUX_GALILEO_GPIO_DW_NAME
 	string "Name of the DesignWare GPIO"
-	depends on PINMUX && BOARD_GALILEO
 	default "GPIO_0"
 	help
 	  The name of the DesignWare GPIO with GPIO<0>..GPIO<7> in the schematic.
 
 config PINMUX_GALILEO_GPIO_INTEL_CW_NAME
 	string "Name of the Legacy Bridge Core Well GPIO"
-	depends on PINMUX && BOARD_GALILEO
 	default "GPIO_M0"
 	help
 	  The name of the Legacy Bridge Core Well GPIO with GPIO<8>..GPIO<9>
@@ -54,9 +49,9 @@ config PINMUX_GALILEO_GPIO_INTEL_CW_NAME
 
 config PINMUX_GALILEO_GPIO_INTEL_RW_NAME
 	string "Name of the Legacy Bridge Resume Well GPIO"
-	depends on PINMUX && BOARD_GALILEO
 	default "GPIO_M1"
 	help
 	  The name of the Legacy Bridge Resume Well GPIO with
 	  GPIO_SUS<0>..GPIO_SUS<5> in the schematic.
+
 endif

--- a/drivers/pinmux/Kconfig
+++ b/drivers/pinmux/Kconfig
@@ -16,7 +16,6 @@ if PINMUX
 
 config PINMUX_NAME
 	string "Pinmux driver name"
-	depends on PINMUX
 	default "PINMUX"
 	help
 	  The name of the pinmux driver.
@@ -24,7 +23,6 @@ config PINMUX_NAME
 config PINMUX_INIT_PRIORITY
 	int "Init priority"
 	default 45
-	depends on PINMUX
 	help
 	  Pinmux driver initialization priority.
 	  Pinmux driver almost certainly should be initialized before the
@@ -37,7 +35,7 @@ config PINMUX_INIT_PRIORITY
 
 config PINMUX_QMSI
 	bool "Enable QMSI pinmux dev driver"
-	depends on PINMUX && QMSI
+	depends on QMSI
 	help
 	  Enables the pinmux dev driver for QMSI supported boards.
 

--- a/drivers/pinmux/Kconfig.beetle
+++ b/drivers/pinmux/Kconfig.beetle
@@ -8,6 +8,6 @@
 
 menuconfig PINMUX_BEETLE
 	bool "ARM V2M Beetle Pin multiplexer driver"
-	depends on PINMUX && SOC_SERIES_BEETLE
+	depends on SOC_SERIES_BEETLE
 	help
 	  Enable driver for ARM V2M Beetle Pin multiplexer.

--- a/drivers/pinmux/Kconfig.cc2650
+++ b/drivers/pinmux/Kconfig.cc2650
@@ -4,7 +4,7 @@
 
 config PINMUX_CC2650
 	bool "Pinmux driver for CC2650 SoC"
-	depends on PINMUX && SOC_SERIES_CC2650
+	depends on SOC_SERIES_CC2650
 	depends on GPIO
 	depends on GPIO_CC2650
 	help

--- a/drivers/pinmux/Kconfig.esp32
+++ b/drivers/pinmux/Kconfig.esp32
@@ -8,7 +8,7 @@
 
 menuconfig PINMUX_ESP32
 	bool "ESP32 Pin multiplexer driver"
-	depends on PINMUX && SOC_ESP32
+	depends on SOC_ESP32
 	help
 	  Enable driver for ESP32 Pin multiplexer.
 

--- a/drivers/pinmux/Kconfig.intel_s1000
+++ b/drivers/pinmux/Kconfig.intel_s1000
@@ -6,6 +6,6 @@
 
 menuconfig PINMUX_INTEL_S1000
 	bool "Intel S1000 I/O multiplexer driver"
-	depends on PINMUX && SOC_INTEL_S1000
+	depends on SOC_INTEL_S1000
 	help
 	  Enable driver for Intel S1000 I/O multiplexer.

--- a/drivers/pinmux/Kconfig.rv32m1
+++ b/drivers/pinmux/Kconfig.rv32m1
@@ -7,7 +7,7 @@
 
 menuconfig PINMUX_RV32M1
 	bool "RV32M1 pinmux driver"
-	depends on PINMUX && SOC_OPENISA_RV32M1_RISCV32
+	depends on SOC_OPENISA_RV32M1_RISCV32
 	help
 	  Enable the RV32M1 pinmux driver.
 

--- a/drivers/pinmux/Kconfig.sam0
+++ b/drivers/pinmux/Kconfig.sam0
@@ -5,6 +5,6 @@
 
 menuconfig PINMUX_SAM0
 	bool "Atmel SAM0 pin multiplexer driver"
-	depends on PINMUX && SOC_FAMILY_SAM0
+	depends on SOC_FAMILY_SAM0
 	help
 	  Enable support for the Atmel SAM0 PORT pin multiplexer.

--- a/drivers/pinmux/Kconfig.sifive
+++ b/drivers/pinmux/Kconfig.sifive
@@ -7,7 +7,7 @@
 
 menuconfig PINMUX_SIFIVE
 	bool "SiFive Freedom SOC pinmux driver"
-	depends on PINMUX && SOC_SERIES_RISCV32_SIFIVE_FREEDOM
+	depends on SOC_SERIES_RISCV32_SIFIVE_FREEDOM
 	help
 	  Enable driver for the SiFive Freedom SOC pinmux driver
 

--- a/drivers/pinmux/Kconfig.stm32
+++ b/drivers/pinmux/Kconfig.stm32
@@ -7,7 +7,7 @@
 
 config PINMUX_STM32
 	bool "Pinmux driver for STM32 MCUs"
-	depends on PINMUX && SOC_FAMILY_STM32
+	depends on SOC_FAMILY_STM32
 	help
 	 Enable pin multiplexer for STM32 MCUs
 


### PR DESCRIPTION
Most of these are from source'ing a file within an `if PINMUX`, and then
adding another `depends on PINMUX` within it.

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. There are no "conditional includes" in Kconfig, so
`if FOO` has no special meaning around a `source`. Conditional includes
wouldn't be possible, because an `if` condition could include (directly
or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.