### PR TITLE
kconfig: gpio: Remove lots of redundant GPIO dependencies

### DIFF
--- a/drivers/gpio/Kconfig.altera_nios2
+++ b/drivers/gpio/Kconfig.altera_nios2
@@ -8,7 +8,7 @@
 
 menuconfig GPIO_ALTERA_NIOS2
 	bool "Altera Nios-II PIO Controllers"
-	depends on GPIO && HAS_ALTERA_HAL
+	depends on HAS_ALTERA_HAL
 	help
 	  Enable config options to support the PIO controllers
 	  on Altera Nios-II family processors.

--- a/drivers/gpio/Kconfig.atmel_sam3
+++ b/drivers/gpio/Kconfig.atmel_sam3
@@ -8,7 +8,7 @@
 
 menuconfig GPIO_ATMEL_SAM3
 	bool "Atmel SAM3 PIO Controllers"
-	depends on GPIO && SOC_SERIES_SAM3X
+	depends on SOC_SERIES_SAM3X
 	help
 	  Enable config options to support the PIO controllers
 	  on Atmel SAM3 family processors.

--- a/drivers/gpio/Kconfig.cc2650
+++ b/drivers/gpio/Kconfig.cc2650
@@ -4,7 +4,7 @@
 
 menuconfig GPIO_CC2650
 	bool "TI CC2650 GPIO driver"
-	depends on GPIO && SOC_SERIES_CC2650
+	depends on SOC_SERIES_CC2650
 	help
 	  Enable the GPIO driver on boards equipped with TI CC2650.
 

--- a/drivers/gpio/Kconfig.cc32xx
+++ b/drivers/gpio/Kconfig.cc32xx
@@ -3,7 +3,7 @@
 
 menuconfig GPIO_CC32XX
 	bool "TI CC32XX GPIO driver"
-	depends on GPIO && SOC_FAMILY_TISIMPLELINK
+	depends on SOC_FAMILY_TISIMPLELINK
 	select HAS_DTS_GPIO
 	help
 	  Enable the GPIO driver on TI SimpleLink CC32xx boards
@@ -12,25 +12,21 @@ if GPIO_CC32XX
 
 config GPIO_CC32XX_A0
 	bool "GPIO block A0"
-	depends on GPIO_CC32XX
 	help
 	  Include support for the GPIO port A0.
 
 config GPIO_CC32XX_A1
 	bool "GPIO block A1"
-	depends on GPIO_CC32XX
 	help
 	  Include support for the GPIO port A1.
 
 config GPIO_CC32XX_A2
 	bool "GPIO block A2"
-	depends on GPIO_CC32XX
 	help
 	  Include support for the GPIO port A2.
 
 config GPIO_CC32XX_A3
 	bool "GPIO block A3"
-	depends on GPIO_CC32XX
 	help
 	  Include support for the GPIO port A3.
 

--- a/drivers/gpio/Kconfig.cmsdk_ahb
+++ b/drivers/gpio/Kconfig.cmsdk_ahb
@@ -8,7 +8,7 @@
 
 menuconfig GPIO_CMSDK_AHB
 	bool "ARM CMSDK (Cortex-M System Design Kit) AHB GPIO Controllers"
-	depends on GPIO && SOC_SERIES_BEETLE
+	depends on SOC_SERIES_BEETLE
 	help
 	  Enable config options to support the ARM CMSDK GPIO controllers.
 
@@ -20,7 +20,6 @@ if GPIO_CMSDK_AHB
 
 config GPIO_CMSDK_AHB_PORT0
 	bool "Enable driver for GPIO Port 0"
-	depends on GPIO_CMSDK_AHB
 	help
 	  Build the driver to utilize GPIO controller Port 0.
 
@@ -42,7 +41,6 @@ config GPIO_CMSDK_AHB_PORT0_IRQ_PRI
 
 config GPIO_CMSDK_AHB_PORT1
 	bool "Enable driver for GPIO Port 1"
-	depends on GPIO_CMSDK_AHB
 	help
 	  Build the driver to utilize GPIO controller Port 1.
 
@@ -64,7 +62,6 @@ config GPIO_CMSDK_AHB_PORT1_IRQ_PRI
 
 config GPIO_CMSDK_AHB_PORT2
 	bool "Enable driver for GPIO Port 2"
-	depends on GPIO_CMSDK_AHB
 	help
 	  Build the driver to utilize GPIO controller Port 2.
 
@@ -86,7 +83,6 @@ config GPIO_CMSDK_AHB_PORT2_IRQ_PRI
 
 config GPIO_CMSDK_AHB_PORT3
 	bool "Enable driver for GPIO Port 3"
-	depends on GPIO_CMSDK_AHB
 	help
 	  Build the driver to utilize GPIO controller Port 3.
 

--- a/drivers/gpio/Kconfig.dw
+++ b/drivers/gpio/Kconfig.dw
@@ -8,7 +8,6 @@
 
 menuconfig GPIO_DW
 	bool "Designware GPIO"
-	depends on GPIO
 	select HAS_DTS_GPIO
 	help
 	  Enable driver for Designware GPIO

--- a/drivers/gpio/Kconfig.esp32
+++ b/drivers/gpio/Kconfig.esp32
@@ -8,7 +8,7 @@
 
 menuconfig GPIO_ESP32
 	bool "ESP32 GPIO"
-	depends on GPIO && SOC_ESP32
+	depends on SOC_ESP32
 	help
 	  Enables the ESP32 GPIO driver
 

--- a/drivers/gpio/Kconfig.gecko
+++ b/drivers/gpio/Kconfig.gecko
@@ -7,7 +7,7 @@
 
 menuconfig GPIO_GECKO
 	bool "Gecko GPIO driver"
-	depends on GPIO && HAS_SILABS_GECKO
+	depends on HAS_SILABS_GECKO
 	select HAS_DTS_GPIO
 	select SOC_GECKO_GPIO
 	help

--- a/drivers/gpio/Kconfig.imx
+++ b/drivers/gpio/Kconfig.imx
@@ -7,7 +7,7 @@
 
 menuconfig GPIO_IMX
 	bool "IMX GPIO driver"
-	depends on GPIO && HAS_IMX_GPIO
+	depends on HAS_IMX_GPIO
 	select HAS_DTS_GPIO
 	help
 	  Enable the IMX GPIO driver.

--- a/drivers/gpio/Kconfig.intel
+++ b/drivers/gpio/Kconfig.intel
@@ -8,7 +8,6 @@
 
 menuconfig GPIO_INTEL_APL
 	bool "Intel Apollo Lake SoC GPIO"
-	depends on GPIO
 	select HAS_DTS_GPIO
 	help
 	  Enable driver for Intel Apollo Lake SoC GPIO

--- a/drivers/gpio/Kconfig.mcux
+++ b/drivers/gpio/Kconfig.mcux
@@ -8,7 +8,7 @@
 
 menuconfig GPIO_MCUX
 	bool "MCUX GPIO driver"
-	depends on GPIO && HAS_MCUX
+	depends on HAS_MCUX
 	select HAS_DTS_GPIO
 	help
 	  Enable the MCUX pinmux driver.

--- a/drivers/gpio/Kconfig.mcux_igpio
+++ b/drivers/gpio/Kconfig.mcux_igpio
@@ -7,7 +7,7 @@
 
 menuconfig GPIO_MCUX_IGPIO
 	bool "MCUX IGPIO driver"
-	depends on GPIO && HAS_MCUX_IGPIO
+	depends on HAS_MCUX_IGPIO
 	select HAS_DTS_GPIO
 	help
 	  Enable the MCUX IGPIO driver.

--- a/drivers/gpio/Kconfig.mcux_lpc
+++ b/drivers/gpio/Kconfig.mcux_lpc
@@ -7,7 +7,7 @@
 
 menuconfig GPIO_MCUX_LPC
 	bool "MCUX LPC GPIO driver"
-	depends on GPIO && HAS_MCUX
+	depends on HAS_MCUX
 	help
 	  Enable the MCUX LPC pinmux driver.
 

--- a/drivers/gpio/Kconfig.pcal9535a
+++ b/drivers/gpio/Kconfig.pcal9535a
@@ -8,7 +8,7 @@
 
 menuconfig GPIO_PCAL9535A
 	bool "PCAL9535A I2C-based GPIO chip"
-	depends on GPIO && I2C
+	depends on I2C
 	help
 	  Enable driver for PCAL9535A I2C-based GPIO chip.
 
@@ -22,7 +22,6 @@ config GPIO_PCAL9535A_INIT_PRIORITY
 
 config GPIO_PCAL9535A_0
 	bool "PCAL9535A GPIO chip #0"
-	depends on GPIO_PCAL9535A
 	help
 	  Enable config options for the PCAL9535A I2C-based GPIO chip #0.
 
@@ -48,7 +47,6 @@ config GPIO_PCAL9535A_0_I2C_MASTER_DEV_NAME
 
 config GPIO_PCAL9535A_1
 	bool "PCAL9535A GPIO chip #1"
-	depends on GPIO_PCAL9535A
 	help
 	  Enable config options for the PCAL9535A I2C-based GPIO chip #1.
 
@@ -74,7 +72,6 @@ config GPIO_PCAL9535A_1_I2C_MASTER_DEV_NAME
 
 config GPIO_PCAL9535A_2
 	bool "PCAL9535A GPIO chip #2"
-	depends on GPIO_PCAL9535A
 	help
 	  Enable config options for the PCAL9535A I2C-based GPIO chip #2.
 
@@ -100,7 +97,6 @@ config GPIO_PCAL9535A_2_I2C_MASTER_DEV_NAME
 
 config GPIO_PCAL9535A_3
 	bool "PCAL9535A GPIO chip #3"
-	depends on GPIO_PCAL9535A
 	help
 	  Enable config options for the PCAL9535A I2C-based GPIO chip #3.
 
@@ -124,4 +120,4 @@ config GPIO_PCAL9535A_3_I2C_MASTER_DEV_NAME
 	  Specify the device name of the I2C master device to which this
 	  PCAL9535A chip #3 is binded.
 
-endif #GPIO_PCAL9535A
+endif # GPIO_PCAL9535A

--- a/drivers/gpio/Kconfig.qmsi
+++ b/drivers/gpio/Kconfig.qmsi
@@ -8,7 +8,7 @@
 
 menuconfig GPIO_QMSI
 	bool "QMSI GPIO driver"
-	depends on GPIO && QMSI
+	depends on QMSI
 	select HAS_DTS_GPIO
 	help
 	  Enable the GPIO driver found on Intel Microcontroller
@@ -16,7 +16,7 @@ menuconfig GPIO_QMSI
 
 menuconfig GPIO_QMSI_SS
 	bool "QMSI GPIO SS driver"
-	depends on GPIO && QMSI && ARC
+	depends on QMSI && ARC
 	select HAS_DTS_GPIO
 	help
 	  Enable the GPIO driver found on Intel Microcontroller

--- a/drivers/gpio/Kconfig.rv32m1
+++ b/drivers/gpio/Kconfig.rv32m1
@@ -7,7 +7,7 @@
 
 menuconfig GPIO_RV32M1
 	bool "RV32M1 GPIO driver"
-	depends on GPIO && SOC_OPENISA_RV32M1_RISCV32
+	depends on SOC_OPENISA_RV32M1_RISCV32
 	select HAS_DTS_GPIO
 	help
 	  Enable the RV32M1 GPIO driver.

--- a/drivers/gpio/Kconfig.sam
+++ b/drivers/gpio/Kconfig.sam
@@ -5,7 +5,7 @@
 
 menuconfig GPIO_SAM
 	bool "Atmel SAM GPIO (PORT) driver"
-	depends on GPIO && SOC_FAMILY_SAM
+	depends on SOC_FAMILY_SAM
 	select HAS_DTS_GPIO
 	help
 	  Enable support for the Atmel SAM 'PORT' GPIO controllers.

--- a/drivers/gpio/Kconfig.sam0
+++ b/drivers/gpio/Kconfig.sam0
@@ -5,7 +5,7 @@
 
 menuconfig GPIO_SAM0
 	bool "Atmel SAM0 GPIO (PORT) driver"
-	depends on GPIO && SOC_FAMILY_SAM0
+	depends on SOC_FAMILY_SAM0
 	select HAS_DTS_GPIO
 	help
 	  Enable support for the Atmel SAM0 'PORT' GPIO controllers.

--- a/drivers/gpio/Kconfig.sch
+++ b/drivers/gpio/Kconfig.sch
@@ -8,7 +8,6 @@
 
 menuconfig GPIO_SCH
 	bool "Intel SCH GPIO controller"
-	depends on GPIO
 	help
 	  Enable the SCH GPIO driver found on Intel boards
 
@@ -16,14 +15,12 @@ if GPIO_SCH
 
 config GPIO_SCH_INIT_PRIORITY
 	int "Init priority"
-	depends on GPIO_SCH
 	default 60
 	help
 	  Device driver initialization priority.
 
 config GPIO_SCH_0
 	bool "Enable SCH GPIO port 0"
-	depends on GPIO_SCH
 
 config GPIO_SCH_0_DEV_NAME
 	string "Name of the device"
@@ -32,7 +29,6 @@ config GPIO_SCH_0_DEV_NAME
 
 config GPIO_SCH_1
 	bool "Enable SCH GPIO port 1"
-	depends on GPIO_SCH
 
 config GPIO_SCH_1_DEV_NAME
 	string "Name of the device"

--- a/drivers/gpio/Kconfig.sifive
+++ b/drivers/gpio/Kconfig.sifive
@@ -7,7 +7,7 @@
 
 menuconfig GPIO_SIFIVE
 	bool "SiFive Freedom Processor GPIO driver"
-	depends on GPIO && SOC_RISCV32_SIFIVE_FREEDOM
+	depends on SOC_RISCV32_SIFIVE_FREEDOM
 	select HAS_DTS_GPIO
 	help
 	  Enable driver for the SiFive Freedom GPIO controller.

--- a/drivers/gpio/Kconfig.stellaris
+++ b/drivers/gpio/Kconfig.stellaris
@@ -6,7 +6,7 @@
 
 menuconfig GPIO_STELLARIS
 	bool "TI Stellaris GPIO Driver"
-	depends on GPIO && SOC_TI_LM3S6965
+	depends on SOC_TI_LM3S6965
 	select HAS_DTS_GPIO
 	help
 	  Enable support for the Stellaris GPIO controllers.

--- a/drivers/gpio/Kconfig.stm32
+++ b/drivers/gpio/Kconfig.stm32
@@ -7,7 +7,7 @@
 
 menuconfig GPIO_STM32
 	bool "GPIO Driver for STM32 family of MCUs"
-	depends on GPIO && SOC_FAMILY_STM32
+	depends on SOC_FAMILY_STM32
 	select HAS_DTS_GPIO
 	help
 	  Enable GPIO driver for STM32 line of MCUs

--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -8,7 +8,7 @@
 
 menuconfig GPIO_SX1509B
 	bool "SX1509B I2C GPIO chip"
-	depends on GPIO && I2C
+	depends on I2C
 	select HAS_DTS_GPIO
 	help
 	  Enable driver for SX1509B I2C GPIO chip.


### PR DESCRIPTION
Most of these are from source'ing a file within an `if GPIO`, and then
adding another `depends on GPIO` within it.

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. There are no "conditional includes" in Kconfig, so
`if FOO` has no special meaning around a `source`. Conditional includes
wouldn't be possible, because an `if` condition could include (directly
or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.