### PR TITLE
kconfig: silabs_exx32: Remove duplicated SOC_EFM32* dependencies

### DIFF
--- a/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.efm32hg
+++ b/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.efm32hg
@@ -6,8 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if SOC_SERIES_EFM32HG
-
 if GPIO
 
 config GPIO_GECKO
@@ -35,5 +33,3 @@ config SOC_FLASH_GECKO
 	default y
 
 endif # FLASH
-
-endif # SOC_SERIES_EFM32HG

--- a/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.efm32pg12b
+++ b/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.efm32pg12b
@@ -6,8 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if SOC_SERIES_EFM32PG12B
-
 if GPIO || LOG_BACKEND_SWO
 
 config GPIO_GECKO
@@ -38,5 +36,3 @@ config SOC_FLASH_GECKO
 	default y
 
 endif # FLASH
-
-endif # SOC_SERIES_EFM32PG12B

--- a/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.efm32wg
+++ b/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.efm32wg
@@ -6,8 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if SOC_SERIES_EFM32WG
-
 if GPIO
 
 config GPIO_GECKO
@@ -35,5 +33,3 @@ config SOC_FLASH_GECKO
 	default y
 
 endif # FLASH
-
-endif # SOC_SERIES_EFM32WG

--- a/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.efr32fg1p
+++ b/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.efr32fg1p
@@ -6,8 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if SOC_SERIES_EFR32FG1P
-
 if GPIO || LOG_BACKEND_SWO
 
 config GPIO_GECKO
@@ -35,5 +33,3 @@ config SOC_FLASH_GECKO
 	default y
 
 endif # FLASH
-
-endif # SOC_SERIES_EFR32FG1P

--- a/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.efr32mg12p
+++ b/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.efr32mg12p
@@ -6,8 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if SOC_SERIES_EFR32MG12P
-
 if GPIO || LOG_BACKEND_SWO
 
 config GPIO_GECKO
@@ -38,5 +36,3 @@ config SOC_FLASH_GECKO
 	default y
 
 endif # FLASH
-
-endif # SOC_SERIES_EFR32MG12P


### PR DESCRIPTION
The `Kconfig.defconfig.efr32*` files added redundant dependencies on
`SOC_EFM32*` that are already added in the `Kconfig.defconfig.series` files
that source them.

Tip: Jump to symbols with '/' in the menuconfig and press '?' to check
their dependencies. If there are duplicated dependencies, the
'included via ...' path can be handy to discover where they are added.

(See #14134 for a longer explanation re. how `if` works.)