### PR TITLE
kconfig: arm: cortex_m: Remove duplicated CPU_CORTEX_M dependencies

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -263,7 +263,6 @@ config ARMV8_M_DSP
 	  implementation supporting the DSP Extension.
 
 menu "ARM Cortex-M options"
-	depends on CPU_CORTEX_M
 
 config LDREX_STREX_AVAILABLE
 	bool
@@ -313,6 +312,7 @@ config FAULT_DUMP
 
 config XIP
 	default y
+
 endmenu
 
 menu "ARM Cortex-M0/M0+/M3/M4/M7/M23/M33 options"


### PR DESCRIPTION
The "ARM Cortex-M options" menu is already within a 'if CPU_CORTEX_M',
so no need to put 'depends on CPU_CORTEX_M' on it.

Tip: Jump to symbols with '/' in the menuconfig and press '?' to check
their dependencies. If there are duplicated dependencies, the
'included via ...' path can be handy to discover where they are added.

(See https://github.com/zephyrproject-rtos/zephyr/pull/14134 for a longer explanation re. how `if` works.)