### PR TITLE
kconfig: arch: arm/arc: Remove duplicated CPU_HAS_MPU dependencies

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -143,7 +143,6 @@ depends on CPU_HAS_MPU
 
 config ARC_MPU_ENABLE
 	bool "Enable MPU"
-	depends on CPU_HAS_MPU
 	select ARC_MPU
 	help
 	  Enable MPU

--- a/arch/arc/core/mpu/Kconfig
+++ b/arch/arc/core/mpu/Kconfig
@@ -15,7 +15,6 @@ config ARC_MPU_VER
 
 config ARC_CORE_MPU
 	bool "ARC Core MPU functionalities"
-	depends on CPU_HAS_MPU
 	help
 	  ARC core MPU functionalities
 
@@ -28,7 +27,6 @@ config MPU_STACK_GUARD
 
 config ARC_MPU
 	bool "ARC MPU Support"
-	depends on CPU_HAS_MPU
 	select ARC_CORE_MPU
 	select THREAD_STACK_INFO
 	select MEMORY_PROTECTION

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -168,6 +168,4 @@ source "arch/arm/core/cortex_m/Kconfig"
 
 source "arch/arm/core/cortex_m/mpu/Kconfig"
 
-if CPU_HAS_TEE
 source "arch/arm/core/cortex_m/tz/Kconfig"
-endif

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -166,9 +166,7 @@ endmenu
 
 source "arch/arm/core/cortex_m/Kconfig"
 
-if CPU_HAS_MPU
 source "arch/arm/core/cortex_m/mpu/Kconfig"
-endif
 
 if CPU_HAS_TEE
 source "arch/arm/core/cortex_m/tz/Kconfig"

--- a/arch/arm/core/cortex_m/mpu/Kconfig
+++ b/arch/arm/core/cortex_m/mpu/Kconfig
@@ -6,9 +6,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+if CPU_HAS_MPU
+
 config ARM_MPU
 	bool "ARM MPU Support"
-	depends on CPU_HAS_MPU
 	select MEMORY_PROTECTION
 	select THREAD_STACK_INFO
 	select ARCH_HAS_EXECUTABLE_PAGE_BIT
@@ -42,3 +43,5 @@ config MPU_ALLOW_FLASH_WRITE
 	depends on ARM_MPU
 	help
 	  Enable this to allow MPU RWX access to flash memory
+
+endif # CPU_HAS_MPU


### PR DESCRIPTION
 - The ARC CPU_HAS_MPU dependencies were added within the menu

       menu "ARCH MPU Options"
           depends on CPU_HAS_MPU

   (`arch/arc/core/mpu/Kconfig` is source'd within it).

 - The ARM CPU_HAS_MPU dependencies were redundantly added by

       if CPU_HAS_MPU
       source "arch/arm/core/cortex_m/mpu/Kconfig"
       endif

   and by some `depends on CPU_HAS_MPU` within that file. Remove the
   `depends on` and move the `if` into the file instead.

Tip: Jump to symbols with `/` in the menuconfig and press `?` to check
their dependencies. If there are duplicated dependencies, the
`included via ...` path can be handy to discover where they are added.