### PR TITLE
dma: stm32f4: Use dma_config for checking memcopy support

### DIFF
--- a/drivers/dma/dma_stm32f4x.c
+++ b/drivers/dma/dma_stm32f4x.c
@@ -387,7 +387,7 @@ static int dma_stm32_config(struct device *dev, u32_t id,
 		return -EINVAL;
 	}
 
-	if ((MEMORY_TO_MEMORY == stream->direction) && (!ddata->mem2mem)) {
+	if (MEMORY_TO_MEMORY == config->channel_direction && !ddata->mem2mem) {
 		LOG_ERR("DMA error: Memcopy not supported for device %s",
 			dev->config->name);
 		return -EINVAL;


### PR DESCRIPTION
Checking for the memcopy support using dma_stm32_stream will give wrong
result as it won't get initialised at that point of time. Hence, use
the dma_config member directly for checking the memcopy support.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>