### PR TITLE
STM32 Flash fix and optimizations

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -210,11 +210,6 @@ static int flash_stm32_write_protection(struct device *dev, bool enable)
 	} else {
 		if (regs->cr & FLASH_CR_LOCK) {
 			regs->keyr = FLASH_KEY1;
-#ifdef CONFIG_SOC_SERIES_STM32F3X
-			/* On STM32F3 series some time is requested */
-			/* before writing again on key register */
-			flash_stm32_wait_flash_idle(dev);
-#endif /* CONFIG_SOC_SERIES_STM32F3X */
 			regs->keyr = FLASH_KEY2;
 		}
 	}

--- a/drivers/flash/flash_stm32f3x.c
+++ b/drivers/flash/flash_stm32f3x.c
@@ -56,11 +56,6 @@ static int erase_page(struct device *dev, unsigned int page)
 	regs->cr |= FLASH_CR_PER;
 	/* Set page address */
 	regs->ar = page_address;
-	/* Give some time to write operation to complete */
-	rc = flash_stm32_wait_flash_idle(dev);
-	if (rc < 0) {
-		return rc;
-	}
 	/* Set the STRT bit */
 	regs->cr |= FLASH_CR_STRT;
 

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -151,7 +151,8 @@ int flash_stm32_write_range(struct device *dev, unsigned int offset,
 	int i, rc = 0;
 
 	for (i = 0; i < len; i += 8, offset += 8) {
-		rc = write_dword(dev, offset, ((const u64_t *) data)[i>>3]);
+		rc = write_dword(dev, offset,
+				UNALIGNED_GET((const u64_t *) data + (i >> 3)));
 		if (rc < 0) {
 			return rc;
 		}

--- a/soc/arm/st_stm32/stm32f1/flash_registers.h
+++ b/soc/arm/st_stm32/stm32f1/flash_registers.h
@@ -37,15 +37,15 @@ union __ef_acr {
 
 /* 3.3.3 Embedded flash registers */
 struct stm32f10x_flash {
-	union __ef_acr acr;
-	u32_t keyr;
-	u32_t optkeyr;
-	u32_t sr;
-	u32_t cr;
-	u32_t ar;
-	u32_t rsvd;
-	u32_t obr;
-	u32_t wrpr;
+	volatile union __ef_acr acr;
+	volatile u32_t keyr;
+	volatile u32_t optkeyr;
+	volatile u32_t sr;
+	volatile u32_t cr;
+	volatile u32_t ar;
+	volatile u32_t rsvd;
+	volatile u32_t obr;
+	volatile u32_t wrpr;
 };
 
 #endif	/* _STM32F10X_FLASHREGISTERS_H_ */

--- a/soc/arm/st_stm32/stm32f3/flash_registers.h
+++ b/soc/arm/st_stm32/stm32f3/flash_registers.h
@@ -41,15 +41,15 @@ union ef_acr {
 
 /* 3.3.3 Embedded flash registers */
 struct stm32f3x_flash {
-	union ef_acr acr;
-	u32_t keyr;
-	u32_t optkeyr;
-	u32_t sr;
-	u32_t cr;
-	u32_t ar;
-	u32_t rsvd;
-	u32_t obr;
-	u32_t wrpr;
+	volatile union ef_acr acr;
+	volatile u32_t keyr;
+	volatile u32_t optkeyr;
+	volatile u32_t sr;
+	volatile u32_t cr;
+	volatile u32_t ar;
+	volatile u32_t rsvd;
+	volatile u32_t obr;
+	volatile u32_t wrpr;
 };
 
 /* list of device commands */


### PR DESCRIPTION
Fix in STM32l4 driver that could be vulnerable to unaligned memory access if data is not aligned in flash_write operation.

Additionally, rework flash registers definitions for STM32F1/STM32F3 (missing volatile instruction).