### PR TITLE
bluetooth: controller: Moved vendor specific HCI to hal

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -145,6 +145,7 @@ zephyr_library_sources_ifdef(
   ll_sw/nordic/hal/nrf5/radio/radio.c
   ll_sw/nordic/hal/nrf5/mayfly.c
   ll_sw/nordic/hal/nrf5/ticker.c
+  hci/nordic/hal/nrf5/hci.c
   )
 
 zephyr_library_include_directories(
@@ -156,6 +157,8 @@ zephyr_library_include_directories(
 if(CONFIG_SOC_COMPATIBLE_NRF)
   zephyr_library_include_directories(
     ll_sw/nordic
+    hci/nordic
+    hci
     )
 endif()
 

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -33,6 +33,7 @@
 #include "ll.h"
 #include "ll_feat.h"
 #include "hci_internal.h"
+#include "hal/hci_vendor_hal.h"
 
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 #include "ll_sw/ll_mesh.h"
@@ -102,7 +103,7 @@ static void le_conn_complete(struct pdu_data *pdu_data, u16_t handle,
 			     struct net_buf *buf);
 #endif /* CONFIG_BT_CONN */
 
-static void evt_create(struct net_buf *buf, u8_t evt, u8_t len)
+void evt_create(struct net_buf *buf, u8_t evt, u8_t len)
 {
 	struct bt_hci_evt_hdr *hdr;
 
@@ -111,7 +112,7 @@ static void evt_create(struct net_buf *buf, u8_t evt, u8_t len)
 	hdr->len = len;
 }
 
-static void *cmd_complete(struct net_buf **buf, u8_t plen)
+void *cmd_complete(struct net_buf **buf, u8_t plen)
 {
 	struct bt_hci_evt_cmd_complete *cc;
 
@@ -1799,173 +1800,6 @@ static int controller_cmd_handle(u16_t  ocf, struct net_buf *cmd,
 }
 
 #if defined(CONFIG_BT_HCI_VS)
-static void vs_read_version_info(struct net_buf *buf, struct net_buf **evt)
-{
-	struct bt_hci_rp_vs_read_version_info *rp;
-
-	rp = cmd_complete(evt, sizeof(*rp));
-
-	rp->status = 0x00;
-	rp->hw_platform = BT_HCI_VS_HW_PLAT;
-	rp->hw_variant = BT_HCI_VS_HW_VAR;
-
-	rp->fw_variant = 0;
-	rp->fw_version = (KERNEL_VERSION_MAJOR & 0xff);
-	rp->fw_revision = KERNEL_VERSION_MINOR;
-	rp->fw_build = (KERNEL_PATCHLEVEL & 0xffff);
-}
-
-static void vs_read_supported_commands(struct net_buf *buf,
-				       struct net_buf **evt)
-{
-	struct bt_hci_rp_vs_read_supported_commands *rp;
-
-	rp = cmd_complete(evt, sizeof(*rp));
-
-	rp->status = 0x00;
-	(void)memset(&rp->commands[0], 0, sizeof(rp->commands));
-
-	/* Set Version Information, Supported Commands, Supported Features. */
-	rp->commands[0] |= BIT(0) | BIT(1) | BIT(2);
-#if defined(CONFIG_BT_HCI_VS_EXT)
-	/* Write BD_ADDR, Read Build Info */
-	rp->commands[0] |= BIT(5) | BIT(7);
-	/* Read Static Addresses, Read Key Hierarchy Roots */
-	rp->commands[1] |= BIT(0) | BIT(1);
-#endif /* CONFIG_BT_HCI_VS_EXT */
-}
-
-static void vs_read_supported_features(struct net_buf *buf,
-				       struct net_buf **evt)
-{
-	struct bt_hci_rp_vs_read_supported_features *rp;
-
-	rp = cmd_complete(evt, sizeof(*rp));
-
-	rp->status = 0x00;
-	(void)memset(&rp->features[0], 0x00, sizeof(rp->features));
-}
-
-#if defined(CONFIG_BT_HCI_VS_EXT)
-static void vs_write_bd_addr(struct net_buf *buf, struct net_buf **evt)
-{
-	struct bt_hci_cp_vs_write_bd_addr *cmd = (void *)buf->data;
-	struct bt_hci_evt_cc_status *ccst;
-
-	ll_addr_set(0, &cmd->bdaddr.val[0]);
-
-	ccst = cmd_complete(evt, sizeof(*ccst));
-	ccst->status = 0x00;
-}
-
-static void vs_read_build_info(struct net_buf *buf, struct net_buf **evt)
-{
-	struct bt_hci_rp_vs_read_build_info *rp;
-
-#define HCI_VS_BUILD_INFO "Zephyr OS v" \
-	KERNEL_VERSION_STRING CONFIG_BT_CTLR_HCI_VS_BUILD_INFO
-
-	const char build_info[] = HCI_VS_BUILD_INFO;
-
-#define BUILD_INFO_EVT_LEN (sizeof(struct bt_hci_evt_hdr) + \
-			    sizeof(struct bt_hci_evt_cmd_complete) + \
-			    sizeof(struct bt_hci_rp_vs_read_build_info) + \
-			    sizeof(build_info))
-
-	BUILD_ASSERT(CONFIG_BT_RX_BUF_LEN >= BUILD_INFO_EVT_LEN);
-
-	rp = cmd_complete(evt, sizeof(*rp) + sizeof(build_info));
-	rp->status = 0x00;
-	memcpy(rp->info, build_info, sizeof(build_info));
-}
-
-static void vs_read_static_addrs(struct net_buf *buf, struct net_buf **evt)
-{
-	struct bt_hci_rp_vs_read_static_addrs *rp;
-
-#if defined(CONFIG_SOC_COMPATIBLE_NRF)
-	/* Read address from nRF5-specific storage
-	 * Non-initialized FICR values default to 0xFF, skip if no address
-	 * present. Also if a public address lives in FICR, do not use in this
-	 * function.
-	 */
-	if (((NRF_FICR->DEVICEADDR[0] != UINT32_MAX) ||
-	    ((NRF_FICR->DEVICEADDR[1] & UINT16_MAX) != UINT16_MAX)) &&
-	      (NRF_FICR->DEVICEADDRTYPE & 0x01)) {
-		struct bt_hci_vs_static_addr *addr;
-
-		rp = cmd_complete(evt, sizeof(*rp) + sizeof(*addr));
-		rp->status = 0x00;
-		rp->num_addrs = 1;
-
-		addr = &rp->a[0];
-		sys_put_le32(NRF_FICR->DEVICEADDR[0], &addr->bdaddr.val[0]);
-		sys_put_le16(NRF_FICR->DEVICEADDR[1], &addr->bdaddr.val[4]);
-		/* The FICR value is a just a random number, with no knowledge
-		 * of the Bluetooth Specification requirements for random
-		 * static addresses.
-		 */
-		BT_ADDR_SET_STATIC(&addr->bdaddr);
-
-		/* Mark IR as invalid */
-		(void)memset(addr->ir, 0x00, sizeof(addr->ir));
-
-		return;
-	}
-#endif /* CONFIG_SOC_FAMILY_NRF */
-
-	rp = cmd_complete(evt, sizeof(*rp));
-	rp->status = 0x00;
-	rp->num_addrs = 0;
-}
-
-static void vs_read_key_hierarchy_roots(struct net_buf *buf,
-					struct net_buf **evt)
-{
-	struct bt_hci_rp_vs_read_key_hierarchy_roots *rp;
-
-	rp = cmd_complete(evt, sizeof(*rp));
-	rp->status = 0x00;
-
-#if defined(CONFIG_SOC_COMPATIBLE_NRF)
-	/* Fill in IR if present */
-	if ((NRF_FICR->IR[0] != UINT32_MAX) &&
-	    (NRF_FICR->IR[1] != UINT32_MAX) &&
-	    (NRF_FICR->IR[2] != UINT32_MAX) &&
-	    (NRF_FICR->IR[3] != UINT32_MAX)) {
-		sys_put_le32(NRF_FICR->IR[0], &rp->ir[0]);
-		sys_put_le32(NRF_FICR->IR[1], &rp->ir[4]);
-		sys_put_le32(NRF_FICR->IR[2], &rp->ir[8]);
-		sys_put_le32(NRF_FICR->IR[3], &rp->ir[12]);
-	} else {
-		/* Mark IR as invalid */
-		(void)memset(rp->ir, 0x00, sizeof(rp->ir));
-	}
-
-	/* Fill in ER if present */
-	if ((NRF_FICR->ER[0] != UINT32_MAX) &&
-	    (NRF_FICR->ER[1] != UINT32_MAX) &&
-	    (NRF_FICR->ER[2] != UINT32_MAX) &&
-	    (NRF_FICR->ER[3] != UINT32_MAX)) {
-		sys_put_le32(NRF_FICR->ER[0], &rp->er[0]);
-		sys_put_le32(NRF_FICR->ER[1], &rp->er[4]);
-		sys_put_le32(NRF_FICR->ER[2], &rp->er[8]);
-		sys_put_le32(NRF_FICR->ER[3], &rp->er[12]);
-	} else {
-		/* Mark ER as invalid */
-		(void)memset(rp->er, 0x00, sizeof(rp->er));
-	}
-
-	return;
-#else
-	/* Mark IR as invalid */
-	(void)memset(rp->ir, 0x00, sizeof(rp->ir));
-	/* Mark ER as invalid */
-	(void)memset(rp->er, 0x00, sizeof(rp->er));
-#endif /* CONFIG_SOC_FAMILY_NRF */
-}
-#endif /* CONFIG_BT_HCI_VS_EXT */
-
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 static void mesh_get_opts(struct net_buf *buf, struct net_buf **evt)
 {
@@ -2080,7 +1914,7 @@ static void mesh_advertise_cancel(struct net_buf *buf, struct net_buf **evt)
 	rp->adv_slot = adv_slot;
 }
 
-static int mesh_cmd_handle(struct net_buf *cmd, struct net_buf **evt)
+int mesh_cmd_handle(struct net_buf *cmd, struct net_buf **evt)
 {
 	struct bt_hci_cp_mesh *cp_mesh;
 	u8_t mesh_op;
@@ -2117,78 +1951,7 @@ static int mesh_cmd_handle(struct net_buf *cmd, struct net_buf **evt)
 	return 0;
 }
 #endif /* CONFIG_BT_HCI_MESH_EXT */
-
-static int vendor_cmd_handle(u16_t ocf, struct net_buf *cmd,
-			     struct net_buf **evt)
-{
-	switch (ocf) {
-	case BT_OCF(BT_HCI_OP_VS_READ_VERSION_INFO):
-		vs_read_version_info(cmd, evt);
-		break;
-
-	case BT_OCF(BT_HCI_OP_VS_READ_SUPPORTED_COMMANDS):
-		vs_read_supported_commands(cmd, evt);
-		break;
-
-	case BT_OCF(BT_HCI_OP_VS_READ_SUPPORTED_FEATURES):
-		vs_read_supported_features(cmd, evt);
-		break;
-
-#if defined(CONFIG_BT_HCI_VS_EXT)
-	case BT_OCF(BT_HCI_OP_VS_READ_BUILD_INFO):
-		vs_read_build_info(cmd, evt);
-		break;
-
-	case BT_OCF(BT_HCI_OP_VS_WRITE_BD_ADDR):
-		vs_write_bd_addr(cmd, evt);
-		break;
-
-	case BT_OCF(BT_HCI_OP_VS_READ_STATIC_ADDRS):
-		vs_read_static_addrs(cmd, evt);
-		break;
-
-	case BT_OCF(BT_HCI_OP_VS_READ_KEY_HIERARCHY_ROOTS):
-		vs_read_key_hierarchy_roots(cmd, evt);
-		break;
-#endif /* CONFIG_BT_HCI_VS_EXT */
-
-#if defined(CONFIG_BT_HCI_MESH_EXT)
-	case BT_OCF(BT_HCI_OP_VS_MESH):
-		mesh_cmd_handle(cmd, evt);
-		break;
-#endif /* CONFIG_BT_HCI_MESH_EXT */
-
-	default:
-		return -EINVAL;
-	}
-
-	return 0;
-}
-#endif
-
-#if !defined(CONFIG_BT_HCI_VS_EXT)
-uint8_t bt_read_static_addr(bt_addr_le_t *addr)
-{
-#if defined(CONFIG_SOC_FAMILY_NRF)
-	if (((NRF_FICR->DEVICEADDR[0] != UINT32_MAX) ||
-	    ((NRF_FICR->DEVICEADDR[1] & UINT16_MAX) != UINT16_MAX)) &&
-	     (NRF_FICR->DEVICEADDRTYPE & 0x01)) {
-		sys_put_le32(NRF_FICR->DEVICEADDR[0], &addr->a.val[0]);
-		sys_put_le16(NRF_FICR->DEVICEADDR[1], &addr->a.val[4]);
-
-		/* The FICR value is a just a random number, with no knowledge
-		 * of the Bluetooth Specification requirements for random
-		 * static addresses.
-		 */
-		BT_ADDR_SET_STATIC(&addr->a);
-
-		addr->type = BT_ADDR_LE_RANDOM;
-		return 1;
-	}
-#endif /* CONFIG_SOC_FAMILY_NRF */
-	return 0;
-}
-#endif /* !CONFIG_BT_HCI_VS_EXT */
+#endif /* CONFIG_BT_HCI_VS */
 
 struct net_buf *hci_cmd_handle(struct net_buf *cmd, void **node_rx)
 {

--- a/subsys/bluetooth/controller/hci/hci_internal.h
+++ b/subsys/bluetooth/controller/hci/hci_internal.h
@@ -19,18 +19,6 @@ extern atomic_t hci_state_mask;
 #define HCI_CLASS_EVT_CONNECTION  2
 #define HCI_CLASS_ACL_DATA        3
 
-#if defined(CONFIG_SOC_COMPATIBLE_NRF)
-#define BT_HCI_VS_HW_PLAT BT_HCI_VS_HW_PLAT_NORDIC
-#if defined(CONFIG_SOC_SERIES_NRF51X)
-#define BT_HCI_VS_HW_VAR  BT_HCI_VS_HW_VAR_NORDIC_NRF51X
-#elif defined(CONFIG_SOC_COMPATIBLE_NRF52X)
-#define BT_HCI_VS_HW_VAR  BT_HCI_VS_HW_VAR_NORDIC_NRF52X
-#endif
-#else
-#define BT_HCI_VS_HW_PLAT 0
-#define BT_HCI_VS_HW_VAR  0
-#endif /* CONFIG_SOC_FAMILY_NRF */
-
 void hci_init(struct k_poll_signal *signal_host_buf);
 struct net_buf *hci_cmd_handle(struct net_buf *cmd, void **node_rx);
 void hci_evt_encode(struct node_rx_pdu *node_rx, struct net_buf *buf);
@@ -40,3 +28,5 @@ int hci_acl_handle(struct net_buf *acl, struct net_buf **evt);
 void hci_acl_encode(struct node_rx_pdu *node_rx, struct net_buf *buf);
 void hci_num_cmplt_encode(struct net_buf *buf, u16_t handle, u8_t num);
 #endif
+void *cmd_complete(struct net_buf **buf, u8_t plen);
+void evt_create(struct net_buf *buf, u8_t evt, u8_t len);

--- a/subsys/bluetooth/controller/hci/nordic/hal/hci_vendor_hal.h
+++ b/subsys/bluetooth/controller/hci/nordic/hal/hci_vendor_hal.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2016 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "hal/nrf5/hci.h"

--- a/subsys/bluetooth/controller/hci/nordic/hal/nrf5/hci.c
+++ b/subsys/bluetooth/controller/hci/nordic/hal/nrf5/hci.c
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2016-2018 Nordic Semiconductor ASA
+ * Copyright (c) 2016 Vinayak Kariappa Chettimada
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+#include <zephyr/types.h>
+#include <string.h>
+#include <version.h>
+
+#include <soc.h>
+#include <toolchain.h>
+#include <errno.h>
+#include <atomic.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/hci_vs.h>
+#include <bluetooth/buf.h>
+#include <bluetooth/bluetooth.h>
+#include <drivers/bluetooth/hci_driver.h>
+#include <misc/byteorder.h>
+#include <misc/util.h>
+
+#include "util/util.h"
+#include "util/memq.h"
+#include "hal/ecb.h"
+#include "hal/ccm.h"
+#include "hal/hci_vendor_hal.h"
+#include "ll_sw/pdu.h"
+#include "ll_sw/lll.h"
+#include "ll_sw/lll_conn.h"
+#include "ll_sw/ull_conn_types.h"
+#include "ll.h"
+#include "ll_feat.h"
+#include "hci_internal.h"
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_nrf5_hci
+#include "common/log.h"
+#include "hal/debug.h"
+
+#if defined(CONFIG_BT_HCI_VS)
+static void vs_read_version_info(struct net_buf *buf, struct net_buf **evt)
+{
+	struct bt_hci_rp_vs_read_version_info *rp;
+
+	rp = cmd_complete(evt, sizeof(*rp));
+
+	rp->status = 0x00;
+	rp->hw_platform = BT_HCI_VS_HW_PLAT;
+	rp->hw_variant = BT_HCI_VS_HW_VAR;
+
+	rp->fw_variant = 0;
+	rp->fw_version = (KERNEL_VERSION_MAJOR & 0xff);
+	rp->fw_revision = KERNEL_VERSION_MINOR;
+	rp->fw_build = (KERNEL_PATCHLEVEL & 0xffff);
+}
+
+static void vs_read_supported_commands(struct net_buf *buf,
+				       struct net_buf **evt)
+{
+	struct bt_hci_rp_vs_read_supported_commands *rp;
+
+	rp = cmd_complete(evt, sizeof(*rp));
+
+	rp->status = 0x00;
+	(void)memset(&rp->commands[0], 0, sizeof(rp->commands));
+
+	/* Set Version Information, Supported Commands, Supported Features. */
+	rp->commands[0] |= BIT(0) | BIT(1) | BIT(2);
+#if defined(CONFIG_BT_HCI_VS_EXT)
+	/* Write BD_ADDR, Read Build Info */
+	rp->commands[0] |= BIT(5) | BIT(7);
+	/* Read Static Addresses, Read Key Hierarchy Roots */
+	rp->commands[1] |= BIT(0) | BIT(1);
+#endif /* CONFIG_BT_HCI_VS_EXT */
+}
+
+static void vs_read_supported_features(struct net_buf *buf,
+				       struct net_buf **evt)
+{
+	struct bt_hci_rp_vs_read_supported_features *rp;
+
+	rp = cmd_complete(evt, sizeof(*rp));
+
+	rp->status = 0x00;
+	(void)memset(&rp->features[0], 0x00, sizeof(rp->features));
+}
+
+#if defined(CONFIG_BT_HCI_VS_EXT)
+static void vs_write_bd_addr(struct net_buf *buf, struct net_buf **evt)
+{
+	struct bt_hci_cp_vs_write_bd_addr *cmd = (void *)buf->data;
+	struct bt_hci_evt_cc_status *ccst;
+
+	ll_addr_set(0, &cmd->bdaddr.val[0]);
+
+	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst->status = 0x00;
+}
+
+static void vs_read_build_info(struct net_buf *buf, struct net_buf **evt)
+{
+	struct bt_hci_rp_vs_read_build_info *rp;
+
+#define HCI_VS_BUILD_INFO "Zephyr OS v" \
+	KERNEL_VERSION_STRING CONFIG_BT_CTLR_HCI_VS_BUILD_INFO
+
+	const char build_info[] = HCI_VS_BUILD_INFO;
+
+#define BUILD_INFO_EVT_LEN (sizeof(struct bt_hci_evt_hdr) + \
+			    sizeof(struct bt_hci_evt_cmd_complete) + \
+			    sizeof(struct bt_hci_rp_vs_read_build_info) + \
+			    sizeof(build_info))
+
+	BUILD_ASSERT(CONFIG_BT_RX_BUF_LEN >= BUILD_INFO_EVT_LEN);
+
+	rp = cmd_complete(evt, sizeof(*rp) + sizeof(build_info));
+	rp->status = 0x00;
+	memcpy(rp->info, build_info, sizeof(build_info));
+}
+
+static void vs_read_static_addrs(struct net_buf *buf, struct net_buf **evt)
+{
+	struct bt_hci_rp_vs_read_static_addrs *rp;
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF)
+	/* Read address from nRF5-specific storage
+	 * Non-initialized FICR values default to 0xFF, skip if no address
+	 * present. Also if a public address lives in FICR, do not use in this
+	 * function.
+	 */
+	if (((NRF_FICR->DEVICEADDR[0] != UINT32_MAX) ||
+	    ((NRF_FICR->DEVICEADDR[1] & UINT16_MAX) != UINT16_MAX)) &&
+	      (NRF_FICR->DEVICEADDRTYPE & 0x01)) {
+		struct bt_hci_vs_static_addr *addr;
+
+		rp = cmd_complete(evt, sizeof(*rp) + sizeof(*addr));
+		rp->status = 0x00;
+		rp->num_addrs = 1;
+
+		addr = &rp->a[0];
+		sys_put_le32(NRF_FICR->DEVICEADDR[0], &addr->bdaddr.val[0]);
+		sys_put_le16(NRF_FICR->DEVICEADDR[1], &addr->bdaddr.val[4]);
+		/* The FICR value is a just a random number, with no knowledge
+		 * of the Bluetooth Specification requirements for random
+		 * static addresses.
+		 */
+		BT_ADDR_SET_STATIC(&addr->bdaddr);
+
+		/* Mark IR as invalid */
+		(void)memset(addr->ir, 0x00, sizeof(addr->ir));
+
+		return;
+	}
+#endif /* CONFIG_SOC_FAMILY_NRF */
+
+	rp = cmd_complete(evt, sizeof(*rp));
+	rp->status = 0x00;
+	rp->num_addrs = 0;
+}
+
+static void vs_read_key_hierarchy_roots(struct net_buf *buf,
+					struct net_buf **evt)
+{
+	struct bt_hci_rp_vs_read_key_hierarchy_roots *rp;
+
+	rp = cmd_complete(evt, sizeof(*rp));
+	rp->status = 0x00;
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF)
+	/* Fill in IR if present */
+	if ((NRF_FICR->IR[0] != UINT32_MAX) &&
+	    (NRF_FICR->IR[1] != UINT32_MAX) &&
+	    (NRF_FICR->IR[2] != UINT32_MAX) &&
+	    (NRF_FICR->IR[3] != UINT32_MAX)) {
+		sys_put_le32(NRF_FICR->IR[0], &rp->ir[0]);
+		sys_put_le32(NRF_FICR->IR[1], &rp->ir[4]);
+		sys_put_le32(NRF_FICR->IR[2], &rp->ir[8]);
+		sys_put_le32(NRF_FICR->IR[3], &rp->ir[12]);
+	} else {
+		/* Mark IR as invalid */
+		(void)memset(rp->ir, 0x00, sizeof(rp->ir));
+	}
+
+	/* Fill in ER if present */
+	if ((NRF_FICR->ER[0] != UINT32_MAX) &&
+	    (NRF_FICR->ER[1] != UINT32_MAX) &&
+	    (NRF_FICR->ER[2] != UINT32_MAX) &&
+	    (NRF_FICR->ER[3] != UINT32_MAX)) {
+		sys_put_le32(NRF_FICR->ER[0], &rp->er[0]);
+		sys_put_le32(NRF_FICR->ER[1], &rp->er[4]);
+		sys_put_le32(NRF_FICR->ER[2], &rp->er[8]);
+		sys_put_le32(NRF_FICR->ER[3], &rp->er[12]);
+	} else {
+		/* Mark ER as invalid */
+		(void)memset(rp->er, 0x00, sizeof(rp->er));
+	}
+
+	return;
+#else
+	/* Mark IR as invalid */
+	(void)memset(rp->ir, 0x00, sizeof(rp->ir));
+	/* Mark ER as invalid */
+	(void)memset(rp->er, 0x00, sizeof(rp->er));
+#endif /* CONFIG_SOC_FAMILY_NRF */
+}
+#endif /* CONFIG_BT_HCI_VS_EXT */
+
+int vendor_cmd_handle(u16_t ocf, struct net_buf *cmd,
+			     struct net_buf **evt)
+{
+	switch (ocf) {
+	case BT_OCF(BT_HCI_OP_VS_READ_VERSION_INFO):
+		vs_read_version_info(cmd, evt);
+		break;
+
+	case BT_OCF(BT_HCI_OP_VS_READ_SUPPORTED_COMMANDS):
+		vs_read_supported_commands(cmd, evt);
+		break;
+
+	case BT_OCF(BT_HCI_OP_VS_READ_SUPPORTED_FEATURES):
+		vs_read_supported_features(cmd, evt);
+		break;
+
+#if defined(CONFIG_BT_HCI_VS_EXT)
+	case BT_OCF(BT_HCI_OP_VS_READ_BUILD_INFO):
+		vs_read_build_info(cmd, evt);
+		break;
+
+	case BT_OCF(BT_HCI_OP_VS_WRITE_BD_ADDR):
+		vs_write_bd_addr(cmd, evt);
+		break;
+
+	case BT_OCF(BT_HCI_OP_VS_READ_STATIC_ADDRS):
+		vs_read_static_addrs(cmd, evt);
+		break;
+
+	case BT_OCF(BT_HCI_OP_VS_READ_KEY_HIERARCHY_ROOTS):
+		vs_read_key_hierarchy_roots(cmd, evt);
+		break;
+#endif /* CONFIG_BT_HCI_VS_EXT */
+
+#if defined(CONFIG_BT_HCI_MESH_EXT)
+	case BT_OCF(BT_HCI_OP_VS_MESH):
+		mesh_cmd_handle(cmd, evt);
+		break;
+#endif /* CONFIG_BT_HCI_MESH_EXT */
+
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+#endif
+
+#if !defined(CONFIG_BT_HCI_VS_EXT)
+uint8_t bt_read_static_addr(bt_addr_le_t *addr)
+{
+#if defined(CONFIG_SOC_FAMILY_NRF)
+	if (((NRF_FICR->DEVICEADDR[0] != UINT32_MAX) ||
+	    ((NRF_FICR->DEVICEADDR[1] & UINT16_MAX) != UINT16_MAX)) &&
+	     (NRF_FICR->DEVICEADDRTYPE & 0x01)) {
+		sys_put_le32(NRF_FICR->DEVICEADDR[0], &addr->a.val[0]);
+		sys_put_le16(NRF_FICR->DEVICEADDR[1], &addr->a.val[4]);
+
+		/* The FICR value is a just a random number, with no knowledge
+		 * of the Bluetooth Specification requirements for random
+		 * static addresses.
+		 */
+		BT_ADDR_SET_STATIC(&addr->a);
+
+		addr->type = BT_ADDR_LE_RANDOM;
+		return 1;
+	}
+#endif /* CONFIG_SOC_FAMILY_NRF */
+	return 0;
+}
+#endif /* !CONFIG_BT_HCI_VS_EXT */

--- a/subsys/bluetooth/controller/hci/nordic/hal/nrf5/hci.h
+++ b/subsys/bluetooth/controller/hci/nordic/hal/nrf5/hci.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF)
+#define BT_HCI_VS_HW_PLAT BT_HCI_VS_HW_PLAT_NORDIC
+#if defined(CONFIG_SOC_SERIES_NRF51X)
+#define BT_HCI_VS_HW_VAR  BT_HCI_VS_HW_VAR_NORDIC_NRF51X
+#elif defined(CONFIG_SOC_COMPATIBLE_NRF52X)
+#define BT_HCI_VS_HW_VAR  BT_HCI_VS_HW_VAR_NORDIC_NRF52X
+#endif
+#else
+#define BT_HCI_VS_HW_PLAT 0
+#define BT_HCI_VS_HW_VAR  0
+#endif /* CONFIG_SOC_FAMILY_NRF */
+
+#if defined(CONFIG_BT_HCI_MESH_EXT)
+int mesh_cmd_handle(struct net_buf *cmd, struct net_buf **evt);
+#endif /* CONFIG_BT_HCI_MESH_EXT */
+
+int vendor_cmd_handle(u16_t ocf, struct net_buf *cmd,
+		      struct net_buf **evt);


### PR DESCRIPTION
Moved vendor specific part of hci.c to hal, thereby enabling out-of-tree
HCI implementations.

Signed-off-by: Morten Priess <mtpr@oticon.com>