### PR TITLE
kconfig: drivers: entropy: Remove duplicated ENTROPY_GENERATOR deps.

### DIFF
--- a/drivers/entropy/Kconfig.esp32
+++ b/drivers/entropy/Kconfig.esp32
@@ -6,7 +6,7 @@
 
 config ENTROPY_ESP32_RNG
 	bool "ESP32 entropy number generator driver"
-	depends on ENTROPY_GENERATOR && SOC_ESP32
+	depends on SOC_ESP32
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the entropy number generator for ESP32 SoCs.

--- a/drivers/entropy/Kconfig.mcux
+++ b/drivers/entropy/Kconfig.mcux
@@ -6,7 +6,7 @@
 
 menuconfig ENTROPY_MCUX_RNGA
 	bool "MCUX RNGA driver"
-	depends on ENTROPY_GENERATOR && HAS_MCUX_RNGA
+	depends on HAS_MCUX_RNGA
 	select ENTROPY_HAS_DRIVER
 	select HAS_DTS_ENTROPY
 	help
@@ -15,7 +15,7 @@ menuconfig ENTROPY_MCUX_RNGA
 
 menuconfig ENTROPY_MCUX_TRNG
 	bool "MCUX TRNG driver"
-	depends on ENTROPY_GENERATOR && HAS_MCUX_TRNG
+	depends on HAS_MCUX_TRNG
 	select ENTROPY_HAS_DRIVER
 	select HAS_DTS_ENTROPY
 	help

--- a/drivers/entropy/Kconfig.native_posix
+++ b/drivers/entropy/Kconfig.native_posix
@@ -1,7 +1,6 @@
-
 menuconfig FAKE_ENTROPY_NATIVE_POSIX
 	bool "Native posix entropy driver"
-	depends on ENTROPY_GENERATOR && ARCH_POSIX
+	depends on ARCH_POSIX
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the test random number generator for the

--- a/drivers/entropy/Kconfig.nrf5
+++ b/drivers/entropy/Kconfig.nrf5
@@ -7,7 +7,6 @@
 
 menuconfig ENTROPY_NRF5_RNG
 	bool "nRF5 RNG driver"
-	depends on ENTROPY_GENERATOR
 	depends on SOC_COMPATIBLE_NRF
 	select ENTROPY_HAS_DRIVER
 	help
@@ -19,7 +18,6 @@ if ENTROPY_NRF5_RNG
 
 config ENTROPY_NRF5_BIAS_CORRECTION
 	bool "Enable bias correction (uniform distribution)"
-	depends on ENTROPY_NRF5_RNG
 	help
 	  This option enables the RNG bias correction, which guarantees a
 	  uniform distribution of 0 and 1. When this option is enabled, the time
@@ -64,7 +62,6 @@ config ENTROPY_NRF5_ISR_THRESHOLD
 
 config ENTROPY_NRF5_PRI
 	int "RNG interrupt priority"
-	depends on ENTROPY_NRF5_RNG
 	range 0 2 if SOC_SERIES_NRF51X
 	range 0 5 if SOC_COMPATIBLE_NRF52X
 	default 2 if SOC_SERIES_NRF51X
@@ -72,4 +69,4 @@ config ENTROPY_NRF5_PRI
 	help
 	  nRF5X RNG IRQ priority.
 
-endif #ENTROPY_NRF5_RNG
+endif # ENTROPY_NRF5_RNG

--- a/drivers/entropy/Kconfig.sam
+++ b/drivers/entropy/Kconfig.sam
@@ -7,7 +7,6 @@
 menuconfig ENTROPY_SAM_RNG
 	bool "Atmel SAM MCU Family True Random Number Generator (TRNG) Driver"
 	depends on SOC_FAMILY_SAM
-	depends on ENTROPY_GENERATOR
 	select ENTROPY_HAS_DRIVER
 	select HAS_DTS_ENTROPY
 	help

--- a/drivers/entropy/Kconfig.stm32
+++ b/drivers/entropy/Kconfig.stm32
@@ -7,7 +7,6 @@
 menuconfig ENTROPY_STM32_RNG
 	bool "STM32 RNG driver"
 	depends on SOC_FAMILY_STM32
-	depends on ENTROPY_GENERATOR
 	select ENTROPY_HAS_DRIVER
 	select USE_STM32_LL_RNG
 	help


### PR DESCRIPTION
Also remove some duplicated dependencies for the related symbol
ENTROPY_NRF5_RNG.

The redundant ENTROPY_GENERATOR deps. are in files sourced within a

    if ENTROPY_GENERATOR
    ...
    endif

block in drivers/entropy/Kconfig.

The redundant ENTROPY_NRF5_RNG deps. are due to redundant 'depends on'
within an 'if' in the same file.

Tip: Jump to symbols with '/' in the menuconfig and press '?' to check
their dependencies. If there are duplicated dependencies, the
'included via ...' path can be handy to discover where they are added.