### PR TITLE
doc: Instruct windows users to not install the lastest gnuarmemb

### DIFF
--- a/doc/getting_started/toolchain_3rd_party_x_compilers.rst
+++ b/doc/getting_started/toolchain_3rd_party_x_compilers.rst
@@ -14,9 +14,15 @@ GNU ARM Embedded
 
    .. warning::
 
-      Like the Zephyr repository, do not install the toolchain in a directory
-      with spaces anywhere in the path. On Windows, we'll assume you install
-      into the directory :file:`C:\\gnu_arm_embedded`.
+      Do not install the toolchain into a path with spaces. On
+      Windows, we'll assume you install into the directory
+      :file:`C:\\gnu_arm_embedded`.
+
+   .. warning::
+
+	  The GNU ARM Embedded Toolchain for Windows, version **8-2018-q4-major**
+	  has a `critical bug <https://github.com/zephyrproject-rtos/zephyr/issues/12257>`_
+	  and should not be used. Toolchain version **7-2018-q2-update** is known to work.
 
 #. Configure the environment variables needed to inform the Zephyr build system
    to use this toolchain:


### PR DESCRIPTION
The latest release of the Windows toolchain has a critical bug,
Windows users should install the next-to-latest release instead.

To prevent Windows users from being affected we add a note about this
in the documentation.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/12257

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>