### PR TITLE
lib: os: ring_buffer: Fix not handled return value

### DIFF
--- a/lib/os/ring_buffer.c
+++ b/lib/os/ring_buffer.c
@@ -144,6 +144,7 @@ u32_t ring_buf_put(struct ring_buf *buf, const u8_t *data, u32_t size)
 	u8_t *dst;
 	u32_t partial_size;
 	u32_t total_size = 0U;
+	int err;
 
 	do {
 		partial_size = ring_buf_put_claim(buf, &dst, size);
@@ -153,7 +154,8 @@ u32_t ring_buf_put(struct ring_buf *buf, const u8_t *data, u32_t size)
 		data += partial_size;
 	} while (size && partial_size);
 
-	ring_buf_put_finish(buf, total_size);
+	err = ring_buf_put_finish(buf, total_size);
+	__ASSERT_NO_MSG(err == 0);
 
 	return total_size;
 }
@@ -200,6 +202,7 @@ u32_t ring_buf_get(struct ring_buf *buf, u8_t *data, u32_t size)
 	u8_t *src;
 	u32_t partial_size;
 	u32_t total_size = 0U;
+	int err;
 
 	do {
 		partial_size = ring_buf_get_claim(buf, &src, size);
@@ -209,7 +212,8 @@ u32_t ring_buf_get(struct ring_buf *buf, u8_t *data, u32_t size)
 		data += partial_size;
 	} while (size && partial_size);
 
-	ring_buf_get_finish(buf, total_size);
+	err = ring_buf_get_finish(buf, total_size);
+	__ASSERT_NO_MSG(err == 0);
 
 	return total_size;
 }


### PR DESCRIPTION
Some function return values were not handled. Added assert in case
those functions return error. It is possible only if same ring buffer
instance is used without any protection from multiple contexts.

Fixes #10755.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>