### PR TITLE
arch: x86: fatal: If possible, print thread name in crash dump

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -137,6 +137,10 @@ static void unwind_stack(u32_t base_ptr, u16_t cs)
 FUNC_NORETURN void z_NanoFatalErrorHandler(unsigned int reason,
 					  const NANO_ESF *pEsf)
 {
+#ifdef CONFIG_THREAD_NAME
+	const char *thread_name = k_thread_name_get(k_current_get());
+#endif
+
 	LOG_PANIC();
 
 	z_debug_fatal_hook(pEsf);
@@ -184,7 +188,11 @@ FUNC_NORETURN void z_NanoFatalErrorHandler(unsigned int reason,
 		break;
 	}
 
-	printk("Current thread ID = %p\n"
+	printk("Current thread ID = %p"
+#ifdef CONFIG_THREAD_NAME
+	       " (%s)"
+#endif
+	       "\n"
 	       "eax: 0x%08x, ebx: 0x%08x, ecx: 0x%08x, edx: 0x%08x\n"
 	       "esi: 0x%08x, edi: 0x%08x, ebp: 0x%08x, esp: 0x%08x\n"
 	       "eflags: 0x%08x cs: 0x%04x\n"
@@ -193,6 +201,9 @@ FUNC_NORETURN void z_NanoFatalErrorHandler(unsigned int reason,
 #endif
 	       "eip: 0x%08x\n",
 	       k_current_get(),
+#ifdef CONFIG_THREAD_NAME
+	       thread_name ? thread_name : "unknown",
+#endif
 	       pEsf->eax, pEsf->ebx, pEsf->ecx, pEsf->edx,
 	       pEsf->esi, pEsf->edi, pEsf->ebp, pEsf->esp,
 	       pEsf->eflags, pEsf->cs & 0xFFFFU, pEsf->eip);

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -10,6 +10,9 @@ source "subsys/testsuite/ztest/Kconfig"
 
 config TEST
 	bool "Mark project as a test"
+	# For tests, store thread names in binary and dump them on crash to
+	# ease debugging.
+	select THREAD_NAME
 	help
 	  Mark a project or an application as a test. This will enable a few
 	  test defaults.


### PR DESCRIPTION
It's relatively hard to figure out what thread a crash happens in
from the crash dump. E.g, it's usually not immediately possible to
find it out from linker map due to the fact that static symbols are
not there (https://sourceware.org/bugzilla/show_bug.cgi?id=16566).

So, try to do it as easy if possible, by just printing thread name
in a dump, if thread names are enabled at all.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>