### PR TITLE
doc: net: Fix instructions how to compile qemu_x86 with e1000

### DIFF
--- a/doc/guides/networking/qemu_eth_setup.rst
+++ b/doc/guides/networking/qemu_eth_setup.rst
@@ -78,5 +78,6 @@ In terminal #2, type:
    :zephyr-app: samples/net/sockets/echo_server
    :host-os: unix
    :board: qemu_x86
+   :gen-args: -DOVERLAY_CONFIG=overlay-e1000.conf
    :goals: run
    :compact:


### PR DESCRIPTION
The qemu_x86 compile instructions for Ethernet were missing
the e1000 overlay config.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>