### PR TITLE
toolchain: Recommend using the gnu-mcu-eclipse distro over gnuarmemb

### DIFF
--- a/doc/getting_started/toolchain_3rd_party_x_compilers.rst
+++ b/doc/getting_started/toolchain_3rd_party_x_compilers.rst
@@ -41,7 +41,7 @@ GNU ARM Embedded
    equivalent to the official GNU Arm Embedded Toolchain distribution,
    by ARM. But the Eclipse release is recommended over the official
    release because historically it has been faster releasing
-   bugfixes and also been built to compile faster.
+   bugfixes and also compiles applications faster.
 
 Intel ISSM
 **********

--- a/doc/getting_started/toolchain_3rd_party_x_compilers.rst
+++ b/doc/getting_started/toolchain_3rd_party_x_compilers.rst
@@ -16,7 +16,7 @@ GNU ARM Embedded
 
       Like the Zephyr repository, do not install the toolchain in a directory
       with spaces anywhere in the path. On Windows, we'll assume you install
-      into the directory :file:`C:\\gnu_arm_embedded`.
+      into the directory :file:`C:\\gnu-mcu-eclipse`.
 
 #. Configure the environment variables needed to inform the Zephyr build system
    to use this toolchain:
@@ -31,11 +31,17 @@ GNU ARM Embedded
 
       # Linux or macOS
       export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-      export GNUARMEMB_TOOLCHAIN_PATH="~/gnu_arm_embedded"
+      export GNUARMEMB_TOOLCHAIN_PATH="~/gnu-mcu-eclipse/arm-none-eabi-gcc/8.2.1-1.4-20190214-0604"
 
       # Windows in cmd.exe
       set ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-      set GNUARMEMB_TOOLCHAIN_PATH=C:\gnu_arm_embedded
+      set GNUARMEMB_TOOLCHAIN_PATH=C:/gnu-mcu-eclipse/arm-none-eabi-gcc/8.2.1-1.4-20190214-0604
+
+   The "GNU MCU Eclipse ARM Embedded GCC" release is functionally
+   equivalent to the official GNU Arm Embedded Toolchain distribution,
+   by ARM. But the Eclipse release is recommended over the official
+   release because historically it has been swifter at releasing
+   bugfixes and also been built to compile faster.
 
 Intel ISSM
 **********
@@ -114,7 +120,7 @@ You can build toolchains from source code using crosstool-NG.
       export ZEPHYR_TOOLCHAIN_VARIANT=xtools
       export XTOOLS_TOOLCHAIN_PATH=/Volumes/CrossToolNGNew/build/output/
 
-.. _GNU ARM Embedded: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm
+.. _GNU ARM Embedded: https://github.com/gnu-mcu-eclipse/arm-none-eabi-gcc/releases
 .. _ISSM Toolchain: https://software.intel.com/en-us/articles/issm-toolchain-only-download
 .. _Getting Started on Arduino 101 with ISSM: https://software.intel.com/en-us/articles/getting-started-arduino-101genuino-101-with-intel-system-studio-for-microcontrollers
 .. _crosstool-ng site: http://crosstool-ng.org

--- a/doc/getting_started/toolchain_3rd_party_x_compilers.rst
+++ b/doc/getting_started/toolchain_3rd_party_x_compilers.rst
@@ -40,7 +40,7 @@ GNU ARM Embedded
    The "GNU MCU Eclipse ARM Embedded GCC" release is functionally
    equivalent to the official GNU Arm Embedded Toolchain distribution,
    by ARM. But the Eclipse release is recommended over the official
-   release because historically it has been swifter at releasing
+   release because historically it has been faster releasing
    bugfixes and also been built to compile faster.
 
 Intel ISSM


### PR DESCRIPTION
Change the recommended GNU ARM Embedded toolchain distribution to
gnu-mcu-eclipse instead of the release maintained by ARM.

This change is done for two reasons, either of which individually
justifies changing the recommended distribution.

The official release does not do bugfix releases, but gnu-mcu-eclipse
does. For instance, a fix to #12257 was developed 8. January and
released by gnu-mcu-eclipse on the 20. January, but has as of 7. March
still not been released by ARM.

The official release of the gcc compiler is significantly slower at
compiling than the gnu-mcu-eclipse release is. Both clean ninja builds
and individual source files are measured to build over twice as fast
with gnu-mcu-eclipse (measured on Linux).

This fixes #12257.

gnu-mcu-eclipse claims to be a drop-in replacement for the official
release, and AFAICT from comparing them this is correct. But more
testing will be needed to be sure.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>