### PR TITLE
doc: net: Fix VLAN documentation in doc and in sample

### DIFF
--- a/doc/reference/networking/vlan.rst
+++ b/doc/reference/networking/vlan.rst
@@ -24,11 +24,10 @@ real network interface. This is similar to how Linux implements VLANs. The
 that is run on top of *eth0*.
 
 VLAN support must be enabled at compile time by setting option
-:option:`CONFIG_NET_VLAN` and also setting option
-:option:`CONFIG_NET_VLAN_COUNT` to reflect how many network interfaces there
-will be in the system.  For example, if there is one network interface without
-VLAN support, and two with VLAN support, the :option:`CONFIG_NET_VLAN_COUNT`
-should be set to 3.
+:option:`CONFIG_NET_VLAN` and :option:`CONFIG_NET_VLAN_COUNT` to reflect how
+many network interfaces there will be in the system.  For example, if there is
+one network interface without VLAN support, and two with VLAN support, the
+:option:`CONFIG_NET_VLAN_COUNT` option should be set to 3.
 
 Even if VLAN is enabled in a :file:`prj.conf` file, the VLAN needs to be
 activated at runtime by the application. The VLAN API provides a
@@ -38,9 +37,9 @@ function. The VLAN tagging for a given network interface can be disabled by a
 :cpp:func:`net_eth_vlan_disable()` function. The application needs to configure
 the VLAN network interface itself, such as setting the IP address, etc.
 
-See also the :ref:`vlan-sample` VLAN sample application for API usage
+See also the :ref:`VLAN sample application <vlan-sample>` for API usage
 example. The source code for that sample application can be found at
-:file:`samples/net/vlan`.
+:zephyr_file:`samples/net/vlan`.
 
 The net-shell module contains *net vlan add* and *net vlan del* commands
 that can be used to enable or disable VLAN tags for a given network interface.

--- a/samples/net/vlan/README.rst
+++ b/samples/net/vlan/README.rst
@@ -10,7 +10,7 @@ The VLAN sample application for Zephyr will setup two virtual LAN networks.
 The application sample enables net-shell and allows users to view VLAN settings.
 
 The source code for this sample application can be found at:
-:file:`samples/net/vlan`.
+:zephyr_file:`samples/net/vlan`.
 
 Requirements
 ************
@@ -21,11 +21,15 @@ Building and Running
 ********************
 
 A good way to run this VLAN application is with QEMU as described in
-:ref:`networking_with_qemu`.
-Currently only one VLAN network (tag) is supported when Zephyr is run inside
-QEMU. If you're using a FRDM-K64F board, then multiple VLAN networks can be
-configured. Note that VLAN is only supported for boards that have an ethernet
-port or that support USB networking.
+:ref:`networking_with_eth_qemu`. You can use *zeth-vlan.conf* configuration
+file when running *net-setup.sh* script in Linux like this:
+
+.. code-block:: console
+
+    ./net-setup.sh -c zeth-vlan.conf
+
+Note that VLAN is only supported for boards that have an ethernet port or
+that support USB networking.
 
 Follow these steps to build the VLAN sample application:
 
@@ -45,9 +49,9 @@ with these settings:
 Setting up Linux Host
 =====================
 
-The :file:`samples/net/vlan/vlan-setup-linux.sh` provides a script that can be
-executed on the Linux host. It creates two VLANs on the Linux host and creates
-routes to Zephyr.
+The :zephyr_file:`samples/net/vlan/vlan-setup-linux.sh` provides a script that
+can be executed on the Linux host. It creates two VLAN interfaces *vlan.100*
+and *vlan.200* on the Linux host and creates routes to Zephyr.
 
 If everything is configured correctly, you will be able to successfully execute
 the following commands on the Linux host.
@@ -58,3 +62,7 @@ the following commands on the Linux host.
     ping -c 1 198.51.100.1
     ping -c 1 2001:db8:200::1
     ping -c 1 203.0.113.1
+
+The network packets to *2001:db8:100::1* or *198.51.100.1* will have VLAN
+tag 100 set to them. The vlan tag 200 will be set to network packets to
+*2001:db8:200::1* or *203.0.113.1*.


### PR DESCRIPTION
The VLAN documentation had double wording and proper links to files
in github was missing, which did not look good in the rendered HTML
page.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>