### PR TITLE
kconfig: drivers: spi: Remove duplicated dependencies

### DIFF
--- a/drivers/spi/Kconfig.dw
+++ b/drivers/spi/Kconfig.dw
@@ -21,7 +21,7 @@ if SPI_DW
 
 config SPI_DW_ARC_AUX_REGS
 	bool "Registers are part of ARC auxiliary registers"
-	depends on SPI_DW && ARC
+	depends on ARC
 	default y
 	help
 	  SPI IP block registers are part of user extended auxiliary

--- a/drivers/spi/Kconfig.sifive
+++ b/drivers/spi/Kconfig.sifive
@@ -8,7 +8,6 @@
 
 menuconfig SPI_SIFIVE
 	bool "SiFive SPI controller driver"
-	depends on SPI
 	depends on SOC_SERIES_RISCV32_SIFIVE_FREEDOM
 	help
 	  Enable the SPI peripherals on SiFive Freedom processors
@@ -18,7 +17,6 @@ if SPI_SIFIVE
 config SIFIVE_SPI_0_ROM
 	bool "SPI 0 is used to access SPI Flash ROM"
 	default y
-	depends on SPI_SIFIVE
 	help
 	  If enabled, SPI 0 is reserved for accessing the SPI flash ROM and a
 	  driver interface won't be instantiated for SPI 0.

--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -8,7 +8,7 @@
 
 menuconfig SPI_STM32
 	bool "STM32 MCU SPI controller driver"
-	depends on SPI && SOC_FAMILY_STM32
+	depends on SOC_FAMILY_STM32
 	select USE_STM32_LL_SPI
 	help
 	  Enable SPI support on the STM32 family of processors.


### PR DESCRIPTION
The two redundant SPI dependencies are from 'source'ing a file within an
'if SPI' and then adding another 'depends on SPI' within it.

'if FOO' is just shorthand for adding depends on FOO to each item within
the 'if'. There are no "conditional includes" in Kconfig, so 'if FOO' has
no special meaning around a source. Conditional includes wouldn't be
possible, because an if condition could include (directly or indirectly)
forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
('ninja menuconfig', then / to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.