### PR TITLE
drivers/timer/nrf_rtc_timer: Revert recent changes

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2016-2017 Nordic Semiconductor ASA
  * Copyright (c) 2018 Intel Corporation
- * Copyright (c) 2019 Peter Bigot Consulting, LLC
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,40 +15,28 @@
 
 #define RTC NRF_RTC1
 
-/*
- * Compare values must be set to at least 2 greater than the current
- * counter value to ensure that the compare fires.  Compare values are
- * generally determined by reading the counter, then performing some
- * calculations to convert a relative delay to an absolute delay.
- * Assume that the counter will not increment more than twice during
- * these calculations, allowing for a final check that can replace a
- * too-low compare with a value that will guarantee fire.
- */
-#define MIN_DELAY 4
-
+#define COUNTER_MAX 0x00ffffff
 #define CYC_PER_TICK (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC	\
 		      / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#if CYC_PER_TICK < MIN_DELAY
-#error Cycles per tick is too small
-#endif
+#define MAX_TICKS ((COUNTER_MAX - CYC_PER_TICK) / CYC_PER_TICK)
 
-#define COUNTER_MAX 0x00ffffffU
-#define MAX_TICKS ((COUNTER_MAX - MIN_DELAY) / CYC_PER_TICK)
-#define MAX_DELAY (MAX_TICKS * CYC_PER_TICK)
+#define MIN_DELAY 32
+
+static struct k_spinlock lock;
 
 static u32_t last_count;
 
-static inline u32_t counter_sub(u32_t a, u32_t b)
+static u32_t counter_sub(u32_t a, u32_t b)
 {
 	return (a - b) & COUNTER_MAX;
 }
 
-static inline void set_comparator(u32_t cyc)
+static void set_comparator(u32_t cyc)
 {
-	nrf_rtc_cc_set(RTC, 0, cyc);
+	nrf_rtc_cc_set(RTC, 0, cyc & COUNTER_MAX);
 }
 
-static inline u32_t counter(void)
+static u32_t counter(void)
 {
 	return nrf_rtc_counter_get(RTC);
 }
@@ -67,7 +54,7 @@ void rtc1_nrf_isr(void *arg)
 	ARG_UNUSED(arg);
 	RTC->EVENTS_COMPARE[0] = 0;
 
-	u32_t key = irq_lock();
+	k_spinlock_key_t key = k_spin_lock(&lock);
 	u32_t t = counter();
 	u32_t dticks = counter_sub(t, last_count) / CYC_PER_TICK;
 
@@ -82,7 +69,7 @@ void rtc1_nrf_isr(void *arg)
 		set_comparator(next);
 	}
 
-	irq_unlock(key);
+	k_spin_unlock(&lock, key);
 	z_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1);
 }
 
@@ -130,53 +117,21 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	ticks = (ticks == K_FOREVER) ? MAX_TICKS : ticks;
 	ticks = MAX(MIN(ticks - 1, (s32_t)MAX_TICKS), 0);
 
-	/*
-	 * Get the requested delay in tick-aligned cycles.  Increase
-	 * by one tick to round up so we don't timeout early due to
-	 * cycles elapsed since the last tick.  Cap at the maximum
-	 * tick-aligned delta.
-	 */
-	u32_t cyc = MIN((1 + ticks) * CYC_PER_TICK, MAX_DELAY);
+	k_spinlock_key_t key = k_spin_lock(&lock);
+	u32_t cyc, t = counter();
 
-	u32_t key = irq_lock();
-	u32_t d = counter_sub(counter(), last_count);
+	/* Round up to next tick boundary */
+	cyc = ticks * CYC_PER_TICK + counter_sub(t, last_count);
+	cyc += (CYC_PER_TICK - 1);
+	cyc = (cyc / CYC_PER_TICK) * CYC_PER_TICK;
+	cyc += last_count;
 
-	/*
-	 * We've already accounted for anything less than a full tick,
-	 * and assumed we meet the minimum delay for the tick.  If
-	 * that's not true, we have to adjust, which may involve a
-	 * rare and expensive integer division.
-	 */
-	if (d > (CYC_PER_TICK - MIN_DELAY)) {
-		if (d >= CYC_PER_TICK) {
-			/*
-			 * We're late by at least one tick.  Adjust
-			 * the compare offset for the missed ones, and
-			 * reduce d to be the portion since the last
-			 * (unseen) tick.
-			 */
-			u32_t missed_ticks = d / CYC_PER_TICK;
-			u32_t missed_cycles = missed_ticks * CYC_PER_TICK;
-			cyc += missed_cycles;
-			d -= missed_cycles;
-		}
-		if (d > (CYC_PER_TICK - MIN_DELAY)) {
-			/*
-			 * We're (now) within the tick, but too close
-			 * to meet the minimum delay required to
-			 * guarantee compare firing.  Step up to the
-			 * next tick.
-			 */
-			cyc += CYC_PER_TICK;
-		}
-		if (cyc > MAX_DELAY) {
-			/* Don't adjust beyond the counter range. */
-			cyc = MAX_DELAY;
-		}
+	if (counter_sub(cyc, t) < MIN_DELAY) {
+		cyc += CYC_PER_TICK;
 	}
-	set_comparator(last_count + cyc);
 
-	irq_unlock(key);
+	set_comparator(cyc);
+	k_spin_unlock(&lock, key);
 #endif
 }
 
@@ -186,18 +141,18 @@ u32_t z_clock_elapsed(void)
 		return 0;
 	}
 
-	u32_t key = irq_lock();
+	k_spinlock_key_t key = k_spin_lock(&lock);
 	u32_t ret = counter_sub(counter(), last_count) / CYC_PER_TICK;
 
-	irq_unlock(key);
+	k_spin_unlock(&lock, key);
 	return ret;
 }
 
 u32_t _timer_cycle_get_32(void)
 {
-	u32_t key = irq_lock();
+	k_spinlock_key_t key = k_spin_lock(&lock);
 	u32_t ret = counter_sub(counter(), last_count) + last_count;
 
-	irq_unlock(key);
+	k_spin_unlock(&lock, key);
 	return ret;
 }


### PR DESCRIPTION
[Trial balloon to see if a simple reversion is enough to address the bug]

Per #13610, recent changes to this driver seem to have introduced
unexpected latency regressions.  This patch effectively reverts these
patches which changed the meat of the driver:

ac36886e62 drivers: nrf: timer: add inline qualifier where
           inlining is intended
084363a0dc drivers: timer: nrf: refactor for speed and correctness
71882ff8c4 drivers: timer: nrf: drop unnecessary counter mask
4b24e88fa4 drivers: timer: nrf: use irq_lock instead of spinlock

While backporting these seemingly unrelated hygiene patches:

7cbdb6c5c0 drivers/timer: Restore non-tickless tick count behavior
d30c9aeafd drivers: nrf_power_clock: Migrate to DTS.
75f77db432 include: misc: util.h: Rename min/max to MIN/MAX

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>