### PR TITLE
kconfig: ethernet: Remove duplicated dependencies

### DIFF
--- a/drivers/ethernet/Kconfig.e1000
+++ b/drivers/ethernet/Kconfig.e1000
@@ -8,7 +8,7 @@
 
 menuconfig ETH_E1000
 	bool "Intel(R) PRO/1000 Gigabit Ethernet driver"
-	depends on NET_L2_ETHERNET && PCI_ENUMERATION
+	depends on PCI_ENUMERATION
 	help
 	  Enable Intel(R) PRO/1000 Gigabit Ethernet driver.
 

--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -15,6 +15,7 @@ menuconfig ETH_MCUX
 	  configuration change.
 
 if ETH_MCUX
+
 config ETH_MCUX_PROMISCUOUS_MODE
 	bool "Enable promiscuous mode"
 	help
@@ -36,7 +37,6 @@ config ETH_MCUX_PHY_EXTRA_DEBUG
 
 config ETH_MCUX_RX_BUFFERS
 	int "Number of MCUX RX buffers"
-	depends on ETH_MCUX
 	default 1
 	range 1 16
 	help
@@ -44,7 +44,6 @@ config ETH_MCUX_RX_BUFFERS
 
 config ETH_MCUX_TX_BUFFERS
 	int "Number of MCUX TX buffers"
-	depends on ETH_MCUX
 	default 1
 	range 1 1
 	help

--- a/drivers/ethernet/Kconfig.smsc911x
+++ b/drivers/ethernet/Kconfig.smsc911x
@@ -6,7 +6,6 @@
 
 menuconfig ETH_SMSC911X
 	bool "SMSC911x/9220 Ethernet driver"
-	depends on NET_L2_ETHERNET
 	help
 	  Enable driver for SMSC/LAN911x/9220 family of chips.
 

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -21,35 +21,31 @@ config ETH_STM32_HAL_NAME
 
 config ETH_STM32_HAL_IRQ_PRI
 	int "Controller interrupt priority"
-	depends on ETH_STM32_HAL
 	default 0
 	help
 	  IRQ priority
 
 config ETH_STM32_HAL_RX_THREAD_STACK_SIZE
 	int "RX thread stack size"
-	depends on ETH_STM32_HAL
 	default 1500
 	help
 	  RX thread stack size
 
 config ETH_STM32_HAL_RX_THREAD_PRIO
 	int "RX thread priority"
-	depends on ETH_STM32_HAL
 	default 2
 	help
 	  RX thread priority
 
 config ETH_STM32_HAL_PHY_ADDRESS
 	int "Phy address"
-	depends on ETH_STM32_HAL
 	default 0
 	help
 	  The phy address to use.
 
 config ETH_STM32_HAL_RANDOM_MAC
 	bool "Random MAC address"
-	depends on ETH_STM32_HAL && ENTROPY_GENERATOR
+	depends on ENTROPY_GENERATOR
 	default y
 	help
 	  Generate a random MAC address dynamically.
@@ -76,13 +72,12 @@ config ETH_STM32_HAL_MAC5
 	range 0 0xff
 	help
 	  This is the byte 5 of the MAC address.
-endif
+
+endif # !ETH_STM32_HAL_RANDOM_MAC
 
 config ETH_STM32_HAL_MII
 	bool "Use MII interface"
-	depends on ETH_STM32_HAL
 	help
 	  Use the MII physical interface instead of RMII.
 
 endif # ETH_STM32_HAL
-

--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -6,7 +6,6 @@
 
 menuconfig NET_GPTP
 	bool "Enable IEEE 802.1AS (gPTP) support [EXPERIMENTAL]"
-	depends on NET_L2_ETHERNET
 	select NET_PKT_TIMESTAMP
 	select PTP_CLOCK
 	help
@@ -39,7 +38,6 @@ config NET_GPTP_PROBE_CLOCK_SOURCE_ON_DEMAND
 
 choice
 	prompt "gPTP Clock Accuracy"
-	depends on NET_GPTP
 	default NET_GPTP_CLOCK_ACCURACY_UNKNOWN
 	help
 	  Specify the accuracy of the clock. This setting should reflect
@@ -206,4 +204,4 @@ config NET_GPTP_STATISTICS
 	  Enable this if you need to collect gPTP statistics. The statistics
 	  can be seen in net-shell if needed.
 
-endif
+endif # NET_GPTP

--- a/subsys/net/l2/ethernet/lldp/Kconfig
+++ b/subsys/net/l2/ethernet/lldp/Kconfig
@@ -8,7 +8,6 @@ menu "Link Layer Discovery Protocol (LLDP) options"
 
 config NET_LLDP
 	bool "Enable LLDP"
-	depends on NET_L2_ETHERNET
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	help


### PR DESCRIPTION
Some of these are from 'source'ing a file within a menu that has a
'depends on NET_L2_ETHERNET' (in drivers/ethernet/Kconfig) and then
adding another 'depends on NET_L2_ETHERNET' within it.

Similarly, subsys/net/l2/ethernet/Kconfig sources files within an
'if NET_L2_ETHERNET'.

'if FOO' is just shorthand for adding 'depends on FOO' to each item within
the 'if'. Dependencies on menus work similarly. There are no
"conditional includes" in Kconfig, so 'if FOO' has no special meaning
around a source. Conditional includes wouldn't be possible, because an
if condition could include (directly or indirectly) forward references
to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
('ninja menuconfig', then / to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.