### PR TITLE
arch/x86_64: Non-kconfig symbols shouldn't look like kconfig

### DIFF
--- a/arch/x86_64/core/xuk-config.h
+++ b/arch/x86_64/core/xuk-config.h
@@ -19,7 +19,7 @@
 
 #define CONFIG_MP_NUM_CPUS 2
 
-#define CONFIG_XUK_64_BIT_ABI 1
+#define XUK_64_BIT_ABI 1
 
 #endif /* CONFIG_X86_64 */
 #endif /* _XUK_CONFIG_H */

--- a/arch/x86_64/core/xuk.c
+++ b/arch/x86_64/core/xuk.c
@@ -108,7 +108,7 @@ __asm__(".align 16\n"
 	"    push %r11\n"
 	"    mov %rsp, %r8\n"
 	"    sub $48, %r8\n"
-#ifdef CONFIG_XUK_64_BIT_ABI
+#ifdef XUK_64_BIT_ABI
 	"    movq %r8, (%rdx)\n"
 #else
 	"    movl %r8d, (%rdx)\n"


### PR DESCRIPTION
The lowest level of the x86_64 bit port supports the full 64 bit ABI
just fine, but Zephyr does not (yet) and builds under the x32 ABI
instead.  The xuk layer can be built with or without the -mx32 switch,
and it had a configurable in a header to tell it what it was.  At some
point during development I swept through and turned all those tunables
into kconfigs, but this one wasn't used by zephyr and so it got the
CONFIG_* rename but never had an entry added to a Kconfig file to
match it, and eventually got picked up by Ulf's unused symbol
detector.

Rename back.  It will probably become a kconfig again someday when we
need it.  Fixes #14059.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>