### PR TITLE
linker: sort sections by alignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,13 @@ zephyr_ld_options(
   ${LINKERFLAGPREFIX},--build-id=none
   )
 
+# Sort the common symbols and each input section by alignment
+# in descending order to minimize padding between these symbols.
+zephyr_ld_options(
+  ${LINKERFLAGPREFIX},--sort-common=descending
+  ${LINKERFLAGPREFIX},--sort-section=alignment
+  )
+
 get_property(TOPT GLOBAL PROPERTY TOPT)
 set_ifndef(  TOPT -T)
 

--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -141,6 +141,8 @@ SECTIONS
 
     SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
         {
+        . = ALIGN(4);
+
         *(.rodata)
         *(".rodata.*")
         *(.gnu.linkonce.r.*)
@@ -154,6 +156,7 @@ SECTIONS
 #include <custom-rodata.ld>
 #endif
 
+        . = ALIGN(4);
         } GROUP_LINK_IN(ROMABLE_REGION)
 
     _image_rom_end = .;


### PR DESCRIPTION
This turns on the linker flag to sort sections by alignment in decreasing size of symbols. This helps to minimize padding between symbols.
    
This also adds the linker options to sort common symbols by alignment in descending to minimize the need for padding.