### PR TITLE
tests: spi: spi_loopback: Drop default SPI_1_NAME symbol

### DIFF
--- a/tests/drivers/spi/spi_loopback/Kconfig
+++ b/tests/drivers/spi/spi_loopback/Kconfig
@@ -4,7 +4,6 @@ source "Kconfig.zephyr"
 
 config SPI_LOOPBACK_DRV_NAME
 	string "SPI device name to use for test"
-	default SPI_1_NAME
 
 config SPI_LOOPBACK_CS_GPIO
 	bool "SPI port CS pin is controlled via a GPIO port during test"


### PR DESCRIPTION
We use to define the SPI bus device name in Kconfig, however now that
all SPI bus controllers use DTS that comes from DTS, so SPI_1_NAME is
never set to anything.  So remove it and leave it to the config frag in
the boards dir in the test to set the name.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>