### PR TITLE
Arch arm fix new thread init

### DIFF
--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -38,14 +38,14 @@ extern u8_t *_k_priv_stack_find(void *obj);
  *
  * <options> is currently unused.
  *
- * @param pStackMem the aligned stack memory
- * @param stackSize stack size in bytes
+ * @param stack      pointer to the aligned stack memory
+ * @param stackSize  size of the available stack memory in bytes
  * @param pEntry the entry point
  * @param parameter1 entry point to the first param
  * @param parameter2 entry point to the second param
  * @param parameter3 entry point to the third param
- * @param priority thread priority
- * @param options thread options: K_ESSENTIAL, K_FP_REGS
+ * @param priority   thread priority
+ * @param options    thread options: K_ESSENTIAL, K_FP_REGS
  *
  * @return N/A
  */

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -182,6 +182,10 @@ void configure_builtin_stack_guard(struct k_thread *thread)
 	u32_t guard_start = thread->arch.priv_stack_start ?
 			    (u32_t)thread->arch.priv_stack_start :
 			    (u32_t)thread->stack_obj;
+
+	__ASSERT(thread->stack_info.start == ((u32_t)thread->stack_obj),
+		"stack_info.start does not point to the start of the"
+		"thread allocated area.");
 #else
 	u32_t guard_start = thread->stack_info.start;
 #endif

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -224,17 +224,21 @@ extern "C" {
  * since the underlying implementation may actually create something larger
  * (for instance a guard area).
  *
+ * The value returned here is guaranteed to match the size of the stack that
+ * is available for the thread, i.e. excluding the size of areas that are not
+ * to be used (for instance the guard area).
+ *
  * The value returned here is NOT guaranteed to match the 'size' parameter
  * passed to K_THREAD_STACK_DEFINE and related macros.
  *
  * In the case of CONFIG_USERSPACE=y and
- * CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT, the size will be larger than the
- * requested size.
+ * CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT=y, the returned size will be
+ * smaller than the requested 'size'.
  *
  * In all other configurations, the size will be correct.
  *
  * @param sym Stack memory symbol
- * @return Size of the stack
+ * @return Actual size of the stack available for the thread
  */
 #define _ARCH_THREAD_STACK_SIZEOF(sym) (sizeof(sym) - MPU_GUARD_ALIGN_AND_SIZE)
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -195,7 +195,7 @@ config THREAD_USERSPACE_LOCAL_DATA
 config THREAD_USERSPACE_LOCAL_DATA_ARCH_DEFER_SETUP
 	bool
 	depends on THREAD_USERSPACE_LOCAL_DATA
-	default y if ARCH="arc"
+	default y if ARC || ARM
 
 config ERRNO
 	bool "Enable errno support"

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -338,6 +338,11 @@ static inline size_t adjust_stack_size(size_t stack_size)
 
 #endif /* CONFIG_STACK_POINTER_RANDOM */
 
+/*
+ * Note:
+ * The caller must guarantee that the stack_size passed here corresponds
+ * to the amount of stack memory available for the thread.
+ */
 void _setup_new_thread(struct k_thread *new_thread,
 		       k_thread_stack_t *stack, size_t stack_size,
 		       k_thread_entry_t entry,


### PR DESCRIPTION
Fixes #13465 

In brief, the patch does the following:
- moves the reservation of userspace thread local data into the arm-specific `_new_thread()`
- corrects the value saved, eventually in `stack_info.size`, which was causing MPU errors, as the user local data were falling outside the MPU-programmed thread stack,
- improves the documentation of _ARCH_THREAD_STACK_SIZEOF, to stress that it gives the area available for the thread operation (i.e. excluding the guard).
- misc stuff, e.g. an assert statement when programming the built-in guard in ARMv8-M.

Priority is high, as the priority of the bug reported in #13465.