### PR TITLE
can: Add the padding to can_frame as Linux expects that

### DIFF
--- a/include/can.h
+++ b/include/can.h
@@ -124,6 +124,12 @@ struct can_frame {
 	/** The length of the message */
 	u8_t can_dlc;
 
+	/** @cond INTERNAL_HIDDEN */
+	u8_t pad;   /* padding */
+	u8_t res0;  /* reserved / padding */
+	u8_t res1;  /* reserved / padding */
+	/** @endcond */
+
 	/** The message data */
 	u8_t data[CAN_MAX_DLEN];
 };


### PR DESCRIPTION
The can_frame struct must be identical with Linux in order
to send data properly.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>