### PR TITLE
drivers/serial: stm32: LPUART max baud rate is 9600

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -341,6 +341,10 @@ static int uart_stm32_configure(struct device *dev,
 	}
 
 	if (cfg->baudrate != data->baud_rate) {
+		if (IS_LPUART_INSTANCE(UartInstance) &&
+			(data->baud_rate > 9600)) {
+				return -ENOTSUP;
+			}
 		uart_stm32_set_baudrate(dev, cfg->baudrate);
 		data->baud_rate = cfg->baudrate;
 	}
@@ -628,6 +632,9 @@ static int uart_stm32_init(struct device *dev)
 				 LL_USART_STOPBITS_1);
 
 	/* Set the default baudrate */
+	if (IS_LPUART_INSTANCE(UartInstance) &&	(data->baud_rate > 9600)) {
+		return -ENOTSUP;
+	}
 	uart_stm32_set_baudrate(dev, data->baud_rate);
 
 	LL_USART_Enable(UartInstance);


### PR DESCRIPTION
LPUART instances do not support baud rates higher than 9600.
Return and error if configured with value higher than 9600.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>