### PR TITLE
dts: usbserial: Fix USB serial console device name

### DIFF
--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -311,7 +311,7 @@
 
 		usb_cdc: virtualcom {
 			compatible = "nordic,nrf-usbd";
-			label = "CDC_ACM";
+			label = "CDC_ACM_0";
 		};
 
 		wdt: watchdog@40010000 {

--- a/dts/x86/intel_curie.dtsi
+++ b/dts/x86/intel_curie.dtsi
@@ -109,7 +109,7 @@
 
 		usb_cdc: virtualcom {
 			compatible = "intel,qmsi-usb";
-			label = "CDC_ACM";
+			label = "CDC_ACM_0";
 		};
 
 		i2c0: i2c@b0002800 {


### PR DESCRIPTION
Fixes DT device name for USB serial console.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>