### PR TITLE
Ipv4 options support (silently ignoring those, but for chcksum calculation obviously)

### DIFF
--- a/subsys/net/ip/ipv4.h
+++ b/subsys/net/ip/ipv4.h
@@ -22,6 +22,8 @@
 
 #include "ipv4.h"
 
+#define NET_IPV4_IHL_MASK 0x0F
+
 /**
  * @brief Create IPv4 packet in provided net_pkt.
  *

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -518,7 +518,7 @@ u16_t net_calc_chksum_ipv4(struct net_pkt *pkt)
 {
 	u16_t sum;
 
-	sum = calc_chksum(0, pkt->buffer->data, NET_IPV4H_LEN);
+	sum = calc_chksum(0, pkt->buffer->data, net_pkt_ip_hdr_len(pkt));
 
 	sum = (sum == 0) ? 0xffff : htons(sum);
 


### PR DESCRIPTION
We forgot to support these, and maxwell found that missing feature. See #11618 