### PR TITLE
drivers: can: socket: Use proper filter when setsockopt is called

### DIFF
--- a/drivers/can/socket_can_generic.h
+++ b/drivers/can/socket_can_generic.h
@@ -85,10 +85,7 @@ static inline int socket_can_setsockopt(struct device *dev, void *obj,
 		return -1;
 	}
 
-	if (optlen != sizeof(struct can_filter)) {
-		errno = EINVAL;
-		return -1;
-	}
+	__ASSERT_NO_MSG(optlen == sizeof(struct zcan_filter));
 
 	ret = can_attach_msgq(socket_context->can_dev, socket_context->msgq,
 			      optval);

--- a/include/can.h
+++ b/include/can.h
@@ -423,7 +423,7 @@ static inline int _impl_can_configure(struct device *dev, enum can_mode mode,
  * @param frame Pointer to can_frame struct.
  * @param zframe Pointer to zcan_frame struct.
  */
-static inline void can_copy_frame_to_zframe(struct can_frame *frame,
+static inline void can_copy_frame_to_zframe(const struct can_frame *frame,
 					    struct zcan_frame *zframe)
 {
 	zframe->id_type = (frame->can_id & BIT(31)) >> 31;
@@ -439,7 +439,7 @@ static inline void can_copy_frame_to_zframe(struct can_frame *frame,
  * @param zframe Pointer to zcan_frame struct.
  * @param frame Pointer to can_frame struct.
  */
-static inline void can_copy_zframe_to_frame(struct zcan_frame *zframe,
+static inline void can_copy_zframe_to_frame(const struct zcan_frame *zframe,
 					    struct can_frame *frame)
 {
 	frame->can_id = (zframe->id_type << 31) | (zframe->rtr << 30) |
@@ -456,7 +456,7 @@ static inline void can_copy_zframe_to_frame(struct zcan_frame *zframe,
  * @param zfilter Pointer to zcan_frame_filter struct.
  */
 static inline
-void can_copy_filter_to_zfilter(struct can_filter *filter,
+void can_copy_filter_to_zfilter(const struct can_filter *filter,
 				struct zcan_filter *zfilter)
 {
 	zfilter->id_type = (filter->can_id & BIT(31)) >> 31;
@@ -474,7 +474,7 @@ void can_copy_filter_to_zfilter(struct can_filter *filter,
  * @param filter Pointer to can_filter struct.
  */
 static inline
-void can_copy_zfilter_to_filter(struct zcan_filter *zfilter,
+void can_copy_zfilter_to_filter(const struct zcan_filter *zfilter,
 				struct can_filter *filter)
 {
 	filter->can_id = (zfilter->id_type << 31) |

--- a/samples/net/sockets/can/src/main.c
+++ b/samples/net/sockets/can/src/main.c
@@ -90,17 +90,20 @@ static void rx(int fd)
 
 static int setup_socket(void)
 {
-	const struct zcan_filter filter = {
+	const struct zcan_filter zfilter = {
 		.id_type = CAN_STANDARD_IDENTIFIER,
 		.rtr = CAN_DATAFRAME,
 		.std_id = 0x1,
 		.rtr_mask = 1,
 		.std_id_mask = CAN_STD_ID_MASK
 	};
+	struct can_filter filter;
 	struct sockaddr_can can_addr;
 	struct net_if *iface;
 	int fd;
 	int ret;
+
+	can_copy_zfilter_to_filter(&zfilter, &filter);
 
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(CANBUS));
 	if (!iface) {
@@ -125,7 +128,8 @@ static int setup_socket(void)
 		goto cleanup;
 	}
 
-	ret = setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, &filter, sizeof(filter));
+	ret = setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, &filter,
+			 sizeof(filter));
 	if (ret < 0) {
 		ret = -errno;
 		LOG_ERR("Cannot set CAN sockopt (%d)", ret);


### PR DESCRIPTION
We need to be prepared to receive either can_filter and zcan_filter
structs.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>