### PR TITLE
kernel/work_q: Clarify docs for k_delayed_work_cancel()

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2790,6 +2790,10 @@ extern int k_delayed_work_submit_to_queue(struct k_work_q *work_q,
  *
  * @note Can be called by ISRs.
  *
+ * @note The result of calling this on a k_delayed_work item that has
+ * not been submitted (i.e. before the return of the
+ * k_delayed_work_submit_to_queue() call) is undefined.
+ *
  * @param work Address of delayed work item.
  *
  * @retval 0 Work item countdown canceled.


### PR DESCRIPTION
You can't cancel what hasn't been submitted.  Clarification added
following minor bike shed in github.  Fixes #14105

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>