### PR TITLE
zephyr: mitigate bounds check bypass vulnerabilities in syscalls

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -61,7 +61,6 @@ config X86_IAMCU
 	  assembly code will need to be updated to conform to the new calling
 	  convention.  If in doubt say N
 
-menu "Memory Management"
 config X86_MMU
 	bool "Enable Memory Management Unit"
 	select MEMORY_PROTECTION
@@ -74,20 +73,49 @@ config X86_NO_MELTDOWN
 	bool
 	help
 	  This hidden option should be set on a per-SOC basis to indicate that
-	  a particular SOC is not vulnerable to the Meltdown CPU vulnerability.
+	  a particular SOC is not vulnerable to the Meltdown CPU vulnerability,
+	  as described in CVE-2017-5754.
+
+config X86_NO_SPECTRE_V1
+	bool
+	help
+	  This hidden option should be set on a per-SOC basis to indicate that
+	  a particular SOC is not vulnerable to the Spectre V1, V1.1, and V1.2
+	  CPU vulnerabilities as described in CVE-2017-5753 and CVE-2018-3693.
 
 config X86_NO_SPECTRE_V2
 	bool
 	help
 	  This hidden option should be set on a per-SOC basis to indicate that
-	  a particular SOC is not vulnerable to the Spectre V2 CPU vulnerability.
+	  a particular SOC is not vulnerable to the Spectre V2 CPU
+	  vulnerability, as described in CVE-2017-5715.
 
 config X86_NO_SPECTRE_V4
 	bool
 	help
 	  This hidden option should be set on a per-SOC basis to indicate that
-	  a particular SOC is not vulnerable to the Spectre V4 CPU vulnerability.
-endmenu
+	  a particular SOC is not vulnerable to the Spectre V4 CPU
+	  vulnerability, as described in CVE-2018-3639.
+
+config X86_NO_LAZY_FP
+	bool
+	help
+	  This hidden option should be set on a per-SOC basis to indicate
+	  that a particular SOC is not vulnerable to the Lazy FP CPU
+	  vulnerability, as described in CVE-2018-3665.
+
+config X86_NO_SPECULATIVE_VULNERABILITIES
+	bool
+	select X86_NO_MELTDOWN
+	select X86_NO_SPECTRE_V1
+	select X86_NO_SPECTRE_V2
+	select X86_NO_SPECTRE_V4
+	select X86_NO_LAZY_FP
+	help
+	  This hidden option should be set on a per-SOC basis that a
+	  particular SOC does not perform any kind of speculative execution,
+	  or is a newer chip which is immune to the class of vulnerabilities
+	  which exploit speculative execution side channel attacks.
 
 config X86_ENABLE_TSS
 	bool

--- a/arch/x86/core/Kconfig
+++ b/arch/x86/core/Kconfig
@@ -101,3 +101,13 @@ config X86_RETPOLINE
 	  description of how retpolines work can be found here[1].
 
 	  [1] https://support.google.com/faqs/answer/7625886
+
+config X86_BOUNDS_CHECK_BYPASS_MITIGATION
+	bool
+	depends on USERSPACE
+	default y if !X86_NO_SPECTRE_V1
+	select BOUNDS_CHECK_BYPASS_MITIGATION
+	help
+	  Hidden config to select arch-independent option to enable
+	  Spectre V1 mitigations by default if the CPU is not known
+	  to be immune to it.

--- a/arch/x86/core/userspace.S
+++ b/arch/x86/core/userspace.S
@@ -199,6 +199,10 @@ SECTION_FUNC(TEXT, _x86_syscall_entry_stub)
 	jae	_bad_syscall
 
 _id_ok:
+#ifdef CONFIG_BOUNDS_CHECK_BYPASS_MITIGATION
+	/* Prevent speculation with bogus system call IDs */
+	lfence
+#endif
 	/* Marshal arguments per calling convention to match what is expected
 	 * for _k_syscall_handler_t functions
 	 */

--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -26,6 +26,7 @@
 #include <sys_io.h>
 #include <misc/__assert.h>
 #include <misc/slist.h>
+#include <misc/speculation.h>
 
 #include "gpio_utils.h"
 
@@ -204,6 +205,7 @@ static int gpio_intel_apl_config(struct device *dev, int access_op,
 	if (pin > cfg->num_pins) {
 		return -EINVAL;
 	}
+	pin = k_array_index_sanitize(pin, cfg->num_pins + 1);
 
 	raw_pin = cfg->pin_offset + pin;
 
@@ -294,6 +296,7 @@ static int gpio_intel_apl_write(struct device *dev, int access_op,
 	if (pin > cfg->num_pins) {
 		return -EINVAL;
 	}
+	pin = k_array_index_sanitize(pin, cfg->num_pins + 1);
 
 	raw_pin = cfg->pin_offset + pin;
 
@@ -329,6 +332,7 @@ static int gpio_intel_apl_read(struct device *dev, int access_op,
 	if (pin > cfg->num_pins) {
 		return -EINVAL;
 	}
+	pin = k_array_index_sanitize(pin, cfg->num_pins + 1);
 
 	raw_pin = cfg->pin_offset + pin;
 
@@ -372,6 +376,7 @@ static int gpio_intel_apl_enable_callback(struct device *dev,
 	if (pin > cfg->num_pins) {
 		return -EINVAL;
 	}
+	pin = k_array_index_sanitize(pin, cfg->num_pins + 1);
 
 	raw_pin = cfg->pin_offset + pin;
 
@@ -403,6 +408,7 @@ static int gpio_intel_apl_disable_callback(struct device *dev,
 	if (pin > cfg->num_pins) {
 		return -EINVAL;
 	}
+	pin = k_array_index_sanitize(pin, cfg->num_pins + 1);
 
 	raw_pin = cfg->pin_offset + pin;
 

--- a/include/misc/speculation.h
+++ b/include/misc/speculation.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_MISC_SPECULATION_H
+#define ZEPHYR_MISC_SPECULATION_H
+
+#include <zephyr/types.h>
+
+/**
+ * Sanitize an array index against bounds check bypass attacks aka the
+ * Spectre V1 vulnerability.
+ *
+ * CPUs with speculative execution may speculate past any size checks and
+ * leak confidential data due to analyzsis of micro-architectural properties.
+ * This will unconditionally truncate any out-of-bounds indexes to
+ * zero in the speculative execution path using bit twiddling instead of
+ * any branch instructions.
+ *
+ * Example usage:
+ *
+ * if (index < size) {
+ *     index = k_array_index_sanitize(index, size);
+ *     data = array[index];
+ * }
+ *
+ * @param index Untrusted array index which has been validated, but not used
+ * @param array_size Size of the array
+ * @return The original index value if < size, or 0
+ */
+static inline u32_t k_array_index_sanitize(u32_t index, u32_t array_size)
+{
+#ifdef CONFIG_BOUNDS_CHECK_BYPASS_MITIGATION
+	s32_t signed_index = index, signed_array_size = array_size;
+
+	/* Take the difference between index and max.
+	 * A proper value will result in a negative result. We also AND in
+	 * the complement of index, so that we automatically reject any large
+	 * indexes which would wrap around the difference calculation.
+	 *
+	 * Sign-extend just the sign bit to produce a mask of all 1s (accept)
+	 * or all 0s (truncate).
+	 */
+	u32_t mask = ((signed_index - signed_array_size) & ~signed_index) >> 31;
+
+	return index & mask;
+#else
+	ARG_UNUSED(array_size);
+
+	return index;
+#endif /* CONFIG_BOUNDS_CHECK_BYPASS_MITIGATION */
+}
+#endif /* ZEPHYR_MISC_SPECULATION_H */

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -651,6 +651,17 @@ config STACK_POINTER_RANDOM
 	  This is currently only implemented for systems whose stack pointers
 	  grow towards lower memory addresses.
 
+config BOUNDS_CHECK_BYPASS_MITIGATION
+	bool "Enable bounds check bypass mitigations for speculative execution"
+	depends on USERSPACE
+	help
+	  Untrusted parameters from user mode may be used in system calls to
+	  index arrays during speculative execution, also known as the Spectre
+	  V1 vulnerability. When enabled, various macros defined in
+	  misc/speculation.h will insert fence instructions or other appropriate
+	  mitigations after bounds checking any array index parameters passed
+	  in from untrusted sources (user mode threads). When disabled, these
+	  macros do nothing.
 endmenu
 
 config MAX_DOMAIN_PARTITIONS

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -17,6 +17,7 @@
 #include <fcntl.h>
 #include <kernel.h>
 #include <misc/fdtable.h>
+#include <misc/speculation.h>
 
 struct fd_entry {
 	void *obj;
@@ -64,7 +65,14 @@ static int _find_fd_entry(void)
 
 static int _check_fd(int fd)
 {
-	if (fd < 0 || fd >= ARRAY_SIZE(fdtable) || fdtable[fd].obj == NULL) {
+	if (fd < 0 || fd >= ARRAY_SIZE(fdtable)) {
+		errno = EBADF;
+		return -1;
+	}
+
+	fd = k_array_index_sanitize(fd, ARRAY_SIZE(fdtable));
+
+	if (fdtable[fd].obj == NULL) {
 		errno = EBADF;
 		return -1;
 	}


### PR DESCRIPTION
This is an initial pass to mitigate Spectre V1.

- Kconfig ontology set up
- On x86, system call IDs and memory bounds checks are now fenced
- We have an arch-agnostic API to clamp array indexes to safe boundaries without using branch instructions. This has been applied to file descriptor parameters passed to Socket APIs.
- Apollo lake GPIO driver updated since pin values turn into MMIO offsets.

Fixes: #14125 