### PR TITLE
drivers: hwinfo: change stm32 device id driver from HAL to LL

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -22,8 +22,8 @@ config HWINFO_SHELL
 config HWINFO_STM32
 	bool "STM32 hwinfo"
 	default y
-	depends on (SOC_SERIES_STM32F0X || SOC_SERIES_STM32F3X || \
-		    SOC_SERIES_STM32L4X || SOC_SERIES_STM32F7X)
+	depends on SOC_FAMILY_STM32
+	select USE_STM32_LL_UTILS
 	help
 	  Enable STM32 hwinfo driver.
 

--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -8,13 +8,6 @@
 #include <hwinfo.h>
 #include <string.h>
 
-#if !defined(CONFIG_SOC_SERIES_STM32F0X) && \
-	!defined(CONFIG_SOC_SERIES_STM32F3X) && \
-	!defined(CONFIG_SOC_SERIES_STM32L4X) && \
-	!defined(CONFIG_SOC_SERIES_STM32F7X)
-#error ID only available on STM32F0, STM32F3, STM32L4 and STM32F7 series
-#endif
-
 struct stm32_uid {
 	u32_t id[3];
 };
@@ -23,9 +16,9 @@ ssize_t _impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 {
 	struct stm32_uid dev_id;
 
-	dev_id.id[0] = HAL_GetUIDw0();
-	dev_id.id[1] = HAL_GetUIDw1();
-	dev_id.id[2] = HAL_GetUIDw2();
+	dev_id.id[0] = LL_GetUID_Word0();
+	dev_id.id[1] = LL_GetUID_Word1();
+	dev_id.id[2] = LL_GetUID_Word2();
 
 	if (length > sizeof(dev_id.id)) {
 		length = sizeof(dev_id.id);


### PR DESCRIPTION
Use LL drivers instead of HAL driver because LL driver is available
for all soc while HAL driver is not.