### PR TITLE
drivers: watchdog: wdt_sam: use the generic disable option

### DIFF
--- a/drivers/watchdog/Kconfig.sam
+++ b/drivers/watchdog/Kconfig.sam
@@ -12,10 +12,3 @@ menuconfig WDT_SAM
 	default y
 	help
 	  Enable WDT driver for Atmel SAM MCUs.
-
-config WDT_SAM_DISABLE_AT_BOOT
-	bool "Disable WDT during boot"
-	depends on WDT_SAM
-	default y
-	help
-	  Select this option to disable the WDT during boot.

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -241,7 +241,7 @@ static void wdt_sam_irq_config(void)
 
 static int wdt_sam_init(struct device *dev)
 {
-#ifdef CONFIG_WDT_SAM_DISABLE_AT_BOOT
+#ifdef CONFIG_WDT_DISABLE_AT_BOOT
 	wdt_sam_disable(dev);
 #endif
 


### PR DESCRIPTION
Use the generic option WDT_DISABLE_AT_BOOT instead of the SAM specific
one WDT_SAM_DISABLE_AT_BOOT (note the generic one has been introduced
after the SAM one).

This also have the consequence of changing the default value for yes to
no, fixing the watchdog tests.

Fixes #13290

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>