### PR TITLE
tests: net: mqtt: Fix the error handling aftre read

### DIFF
--- a/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
+++ b/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
@@ -118,8 +118,11 @@ void publish_handler(struct mqtt_client *const client,
 	while (payload_left > 0) {
 		wait(APP_SLEEP_MSECS);
 		rc = mqtt_read_publish_payload(client, buf, sizeof(buf));
-		if (rc <= 0 && rc != -EAGAIN) {
+		if (rc <= 0) {
 			TC_PRINT("Failed to receive payload, err: %d\n", -rc);
+			if (rc == -EAGAIN) {
+				continue;
+			}
 			goto error;
 		}
 


### PR DESCRIPTION
If the rc = -EAGAIN from mqtt_read_publich_payload(), it shouldn't be
used in memcpy() since it is a negative value, and instead, it should
try to read again.

Fix: #13825
Coverity-CID: 191002

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>