### PR TITLE
kconfig: drivers: flash: Remove redundant FLASH dependencies

### DIFF
--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -64,4 +64,4 @@ source "drivers/flash/Kconfig.sam"
 
 source "drivers/flash/Kconfig.w25qxxdv"
 
-endif
+endif # FLASH

--- a/drivers/flash/Kconfig.gecko
+++ b/drivers/flash/Kconfig.gecko
@@ -6,7 +6,7 @@
 
 config SOC_FLASH_GECKO
 	bool "Silicon Labs Gecko flash driver"
-	depends on FLASH && SOC_FAMILY_EXX32
+	depends on SOC_FAMILY_EXX32
 	select FLASH_HAS_DRIVER_ENABLED
 	select SOC_GECKO_MSC
 	help

--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -8,7 +8,7 @@
 menuconfig SPI_NOR
 	bool "SPI NOR Flash"
 	select FLASH_HAS_DRIVER_ENABLED
-	depends on SPI && FLASH
+	depends on SPI
 
 if SPI_NOR
 

--- a/drivers/flash/Kconfig.qmsi
+++ b/drivers/flash/Kconfig.qmsi
@@ -6,7 +6,7 @@
 
 menuconfig SOC_FLASH_QMSI
 	bool "QMSI flash driver"
-	depends on QMSI && FLASH
+	depends on QMSI
 	select FLASH_HAS_DRIVER_ENABLED
 	help
 	  Enable QMSI Quark flash driver.


### PR DESCRIPTION
These are from source'ing a file within an `if FLASH`, and then adding
another `depends on FLASH` within it.

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. There are no "conditional includes" in Kconfig, so
`if FOO` has no special meaning around a `source`. Conditional includes
wouldn't be possible, because an `if` condition could include (directly
or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.