### PR TITLE
kconfig: drivers: serial: Remove redundant dependencies

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -116,4 +116,4 @@ source "drivers/serial/Kconfig.pl011"
 
 source "drivers/serial/Kconfig.rv32m1_lpuart"
 
-endif
+endif # SERIAL

--- a/drivers/serial/Kconfig.native_posix
+++ b/drivers/serial/Kconfig.native_posix
@@ -12,7 +12,6 @@ if UART_NATIVE_POSIX
 config UART_NATIVE_POSIX_PORT_0_NAME
 	string "Port 0 Device Name"
 	default "UART_0"
-	depends on UART_NATIVE_POSIX
 	help
 	  This is the device name for UART, and is included in the device
 	  struct.
@@ -56,4 +55,4 @@ config NATIVE_UART_AUTOATTACH_DEFAULT_CMD
 	  This is only applicable if a UART is configured to use its own PTY with
 	  NATIVE_UART_x_ON_OWN_PTY.
 
-endif #UART_NATIVE_POSIX
+endif # UART_NATIVE_POSIX

--- a/drivers/serial/Kconfig.nsim
+++ b/drivers/serial/Kconfig.nsim
@@ -1,6 +1,5 @@
 config UART_NSIM
 	bool "UART driver for MetaWare nSim"
 	select SERIAL_HAS_DRIVER
-	depends on SERIAL
 	help
 	  This enables the UART driver for the MetaWare nSim simulator.


### PR DESCRIPTION
One of these is from `source`ing a file within an `if SERIAL`, and then
adding another `depends on SERIAL` within it.

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. There are no "conditional includes" in Kconfig, so
`if FOO` has no special meaning around a `source`. Conditional includes
wouldn't be possible, because an `if` condition could include (directly
or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.