### PR TITLE
kconfig: drivers: sensor: Remove redundant dependencies

### DIFF
--- a/drivers/sensor/grove/Kconfig
+++ b/drivers/sensor/grove/Kconfig
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-if SENSOR
+
 config GROVE_LIGHT_SENSOR
 	bool "Enable the Seeed Grove Light Sensor"
 	depends on ADC && NEWLIB_LIBC
@@ -81,7 +81,5 @@ config GROVE_TEMPERATURE_SENSOR_ADC_CHANNEL
 	help
 	  Specify the channel of the ADC to which the Grove Temperature Sensor
 	  is connected.
-
-endif
 
 endif

--- a/drivers/sensor/lis2dw12/Kconfig
+++ b/drivers/sensor/lis2dw12/Kconfig
@@ -70,7 +70,6 @@ endif # LIS2DW12_TRIGGER
 
 choice
 	prompt "Accelerometer Full-scale range setting"
-	depends on LIS2DW12
 	default LIS2DW12_ACCEL_RANGE_RUNTIME
 
 config LIS2DW12_ACCEL_RANGE_RUNTIME
@@ -91,7 +90,6 @@ endchoice
 
 choice
 	prompt "Accelerometer sampling frequency (ODR)"
-	depends on LIS2DW12
 	default LIS2DW12_ODR_RUNTIME
 
 config LIS2DW12_ODR_RUNTIME


### PR DESCRIPTION
Most of these are from `source`ing `drivers/sensor/grove/Kconfig` within
an `if SENSOR` (in `drivers/sensor/Kconfig`), and then adding another
`if SENSOR` within it.

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. There are no "conditional includes" in Kconfig, so
`if FOO` has no special meaning around a `source`. Conditional includes
wouldn't be possible, because an `if` condition could include (directly
or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.