### PR TITLE
kconfig: drivers: modem: Remove redundant MODEM_WNCM14A2A deps

### DIFF
--- a/drivers/modem/Kconfig.wncm14a2a
+++ b/drivers/modem/Kconfig.wncm14a2a
@@ -8,7 +8,6 @@
 
 menuconfig MODEM_WNCM14A2A
 	bool "Enable Wistron LTE-M modem driver"
-	depends on MODEM
 	select MODEM_RECEIVER
 	select NET_OFFLOAD
 	select UART_MCUX_2 if BOARD_FRDM_K64F
@@ -23,14 +22,12 @@ if MODEM_WNCM14A2A
 
 config MODEM_WNCM14A2A_RX_STACK_SIZE
 	int "Size of the stack for the WNC-M14A2A modem driver RX thread"
-	depends on MODEM_WNCM14A2A
 	default 1028
 	help
 	  This stack is used by the WNCM14A2A RX thread.
 
 config MODEM_WNCM14A2A_RX_WORKQ_STACK_SIZE
 	int "Size of the stack for the WNC-M14A2A modem driver work queue"
-	depends on MODEM_WNCM14A2A
 	default 2048
 	help
 	  This stack is used by the work queue to pass off net_pkt data
@@ -39,7 +36,6 @@ config MODEM_WNCM14A2A_RX_WORKQ_STACK_SIZE
 
 config MODEM_WNCM14A2A_APN_NAME
 	string "APN name for establishing network connection"
-	depends on MODEM_WNCM14A2A
 	default "m2m.com.attz"
 	help
 	  This setting is used in the AT%PDNSET command to set the APN name
@@ -48,7 +44,6 @@ config MODEM_WNCM14A2A_APN_NAME
 
 config MODEM_WNCM14A2A_INIT_PRIORITY
 	int "WNC-M14A2A driver init priority"
-	depends on MODEM_WNCM14A2A
 	default 80
 	help
 	  WNC-M14A2A device driver initialization priority.
@@ -56,4 +51,4 @@ config MODEM_WNCM14A2A_INIT_PRIORITY
 	  Note that the priority needs to be lower than the net stack
 	  so that it can start before the networking sub-system.
 
-endif
+endif # MODEM_WNCM14A2A


### PR DESCRIPTION
These symbols are already within an `if MODEM_WNCM14A2A`, so no need to
put `depends on MODEM_WNCM14A2A` on them.

Also remove a redundant `depends on MODEM` from `MODEM_WNCM14A2A`.
`drivers/modem/Kconfig.wncm14a2a` is already sourced within an 'if MODEM',
in `drivers/modem/Kconfig`.

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. There are no "conditional includes" in Kconfig, so
`if FOO` has no special meaning around a `source`. Conditional includes
wouldn't be possible, because an `if` condition could include (directly
or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.