### PR TITLE
kconfig: drivers: audio: Remove redundant AUDIO_DMIC deps.

### DIFF
--- a/drivers/audio/Kconfig.intel_dmic
+++ b/drivers/audio/Kconfig.intel_dmic
@@ -6,6 +6,5 @@
 
 menuconfig AUDIO_INTEL_DMIC
 	bool "Intel digital PDM microphone driver support"
-	depends on AUDIO_DMIC
 	help
 	  Enable Intel digital PDM microphone driver

--- a/drivers/audio/Kconfig.mpxxdtyy
+++ b/drivers/audio/Kconfig.mpxxdtyy
@@ -6,7 +6,6 @@
 
 menuconfig AUDIO_MPXXDTYY
 	bool "ST Digital PDM microphone attached to I2S support"
-	depends on AUDIO_DMIC
 	depends on I2S
 	select HAS_STLIB
 	help


### PR DESCRIPTION
These files are `source`d within an `if AUDIO_DMIC`, in
`drivers/audio/Kconfig`.

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. There are no "conditional includes" in Kconfig, so
`if FOO` has no special meaning around a `source`. Conditional includes
wouldn't be possible, because an `if` condition could include (directly
or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.