### PR TITLE
kconfig: drivers: rtc: Remove redundant RTC deps.

### DIFF
--- a/drivers/rtc/Kconfig
+++ b/drivers/rtc/Kconfig
@@ -23,7 +23,7 @@ source "subsys/logging/Kconfig.template.log_config"
 config RTC_0_NAME
 	string "Driver instance name"
 	default "RTC_0"
-	depends on RTC && !HAS_DTS
+	depends on !HAS_DTS
 	help
 	  RTC driver instance name
 

--- a/drivers/rtc/Kconfig.mcux_rtc
+++ b/drivers/rtc/Kconfig.mcux_rtc
@@ -7,6 +7,6 @@
 
 menuconfig RTC_MCUX
 	bool "MCUX RTC driver"
-	depends on RTC && HAS_MCUX_RTC
+	depends on HAS_MCUX_RTC
 	help
 	  Enable support for mcux rtc driver.


### PR DESCRIPTION
These symbols appear within an `if RTC` (in `drivers/rtc/Kconfig`).

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. There are no "conditional includes" in Kconfig, so
`if FOO` has no special meaning around a `source`. Conditional includes
wouldn't be possible, because an `if` condition could include (directly
or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.