### PR TITLE
kconfig: drivers: clock_control: Remove redundant CLOCK_CONTROL deps.

### DIFF
--- a/drivers/clock_control/Kconfig.beetle
+++ b/drivers/clock_control/Kconfig.beetle
@@ -35,7 +35,7 @@ config ARM_CLOCK_CONTROL_DEV_NAME
 
 config CLOCK_CONTROL_BEETLE_ENABLE_PLL
 	bool "Enable PLL on Beetle"
-	depends on CLOCK_CONTROL && SOC_SERIES_BEETLE
+	depends on SOC_SERIES_BEETLE
 	help
 	  Enable PLL on Beetle.
 

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -10,7 +10,6 @@ if SOC_FAMILY_STM32
 
 menuconfig CLOCK_CONTROL_STM32_CUBE
 	bool "STM32 Reset & Clock Control"
-	depends on CLOCK_CONTROL
 	select USE_STM32_LL_UTILS
 	help
 	  Enable driver for Reset & Clock Control subsystem found


### PR DESCRIPTION
These symbols appear within an `if CLOCK_CONTROL` (in
`drivers/clock_control/Kconfig`).

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. There are no "conditional includes" in Kconfig, so
`if FOO` has no special meaning around a `source`. Conditional includes
wouldn't be possible, because an `if` condition could include (directly
or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.