### PR TITLE
kconfig: drivers: counter: Remove redundant COUNTER deps.

### DIFF
--- a/drivers/counter/Kconfig.imx_epit
+++ b/drivers/counter/Kconfig.imx_epit
@@ -7,7 +7,7 @@
 
 config COUNTER_IMX_EPIT
 	bool "IMX EPIT driver"
-	depends on COUNTER && HAS_IMX_EPIT
+	depends on HAS_IMX_EPIT
 	help
 	  Enable the IMX EPIT driver.
 

--- a/drivers/counter/Kconfig.qmsi
+++ b/drivers/counter/Kconfig.qmsi
@@ -8,7 +8,7 @@
 
 config AON_COUNTER_QMSI
 	bool "AON counter driver"
-	depends on COUNTER && QMSI
+	depends on QMSI
 	help
 	  Enable support for AON counter.
 
@@ -21,7 +21,7 @@ config AON_COUNTER_QMSI_DEV_NAME
 
 config AON_TIMER_QMSI
 	bool "AON periodic timer driver"
-	depends on COUNTER && QMSI
+	depends on QMSI
 	help
 	  Enable support for AON periodic timer.
 


### PR DESCRIPTION
These symbols appear within an `if COUNTER` (in
`drivers/counter/Kconfig`).

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. There are no "conditional includes" in Kconfig, so
`if FOO` has no special meaning around a `source`. Conditional includes
wouldn't be possible, because an `if` condition could include (directly
or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.