### PR TITLE
kconfig: drivers: wifi: Remove redundant WIFI deps.

### DIFF
--- a/drivers/wifi/Kconfig
+++ b/drivers/wifi/Kconfig
@@ -19,7 +19,6 @@ source "subsys/net/Kconfig.template.log_config.net"
 
 config WIFI_INIT_PRIORITY
 	int "WiFi driver init priority"
-	depends on WIFI
 	default 80
 	help
 	  WiFi device driver initialization priority.

--- a/drivers/wifi/eswifi/Kconfig.eswifi
+++ b/drivers/wifi/eswifi/Kconfig.eswifi
@@ -8,7 +8,6 @@
 
 menuconfig WIFI_ESWIFI
 	bool "Inventek eS-WiFi support"
-	depends on WIFI
 	select NET_L2_WIFI_MGMT
 	select WIFI_OFFLOAD
 	select NET_OFFLOAD

--- a/drivers/wifi/simplelink/Kconfig.simplelink
+++ b/drivers/wifi/simplelink/Kconfig.simplelink
@@ -8,7 +8,6 @@
 
 menuconfig WIFI_SIMPLELINK
 	bool "SimpleLink WiFi driver support"
-	depends on WIFI
 	select SIMPLELINK_HOST_DRIVER
 	select WIFI_OFFLOAD
 	select NET_L2_WIFI_MGMT


### PR DESCRIPTION
These symbols appear within an `if WIFI` (in `drivers/wifi/Kconfig`).

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. Dependencies on menus work similarly. There are no
"conditional includes" in Kconfig, so `if FOO` has no special meaning
around a source. Conditional includes wouldn't be possible, because an
if condition could include (directly or indirectly) forward references
to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.