### PR TITLE
kconfig: drivers: pwm: Remove redundant deps.

### DIFF
--- a/drivers/pwm/Kconfig.esp32
+++ b/drivers/pwm/Kconfig.esp32
@@ -16,7 +16,6 @@ if PWM_LED_ESP32
 
 config PWM_LED_ESP32_DEV_NAME_0
 	string "ESP32 PWM LED Name"
-	depends on PWM_LED_ESP32
 	default "PWM_LED"
 	help
 	  Specify the device name for the PWM driver.

--- a/drivers/pwm/Kconfig.pca9685
+++ b/drivers/pwm/Kconfig.pca9685
@@ -20,14 +20,12 @@ if PWM_PCA9685
 
 config PWM_PCA9685_INIT_PRIORITY
 	int "Init priority"
-	depends on PWM_PCA9685
 	default 70
 	help
 	  Device driver initialization priority.
 
 config PWM_PCA9685_0
 	bool "PCA9685 PWM chip #0"
-	depends on PWM_PCA9685
 	help
 	  Enable config options for the PCA9685 I2C-based PWM chip #0.
 


### PR DESCRIPTION
`drivers/pwm/Kconfig.esp32` is `source`d within an `if PWM` in
`drivers/pwm/Kconfig`.

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. Dependencies on menus work similarly. There are no
"conditional includes" in Kconfig, so `if FOO` has no special meaning
around a source. Conditional includes wouldn't be possible, because an
if condition could include (directly or indirectly) forward references
to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.