### PR TITLE
kconfig: drivers: i2c: Remove redundant I2C_SLAVE dep.

### DIFF
--- a/drivers/i2c/slave/Kconfig.eeprom
+++ b/drivers/i2c/slave/Kconfig.eeprom
@@ -8,7 +8,6 @@
 
 config I2C_EEPROM_SLAVE
 	bool "I2C Slave EEPROM driver"
-	depends on I2C_SLAVE
 	help
 	  Enable virtual I2C Slave EEPROM driver
 


### PR DESCRIPTION
`I2C_EEPROM_SLAVE` is already within an `if I2C_SLAVE`, in
`drivers/i2c/slave/Kconfig`.

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. There are no "conditional includes" in Kconfig, so
`if FOO` has no special meaning around a `source`. Conditional includes
wouldn't be possible, because an `if` condition could include (directly
or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.