### PR TITLE
kconfig: drivers: i2s: Remove redundant deps.

### DIFF
--- a/drivers/i2s/Kconfig.stm32
+++ b/drivers/i2s/Kconfig.stm32
@@ -7,7 +7,7 @@
 
 menuconfig I2S_STM32
 	bool "STM32 MCU I2S controller driver"
-	depends on I2S && SOC_SERIES_STM32F4X
+	depends on SOC_SERIES_STM32F4X
 	select DMA
 	help
 	  Enable I2S support on the STM32 family of processors.


### PR DESCRIPTION
`I2S_STM32` is already within an `if I2S`, in `drivers/i2s/Kconfig`.

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`. There are no "conditional includes" in Kconfig, so
`if FOO` has no special meaning around a `source`. Conditional includes
wouldn't be possible, because an `if` condition could include (directly
or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.