### PR TITLE
Bluetooth: kconfig: Remove redundant dependencies

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -144,6 +144,7 @@ source "subsys/bluetooth/common/Kconfig"
 source "subsys/bluetooth/host/Kconfig"
 source "subsys/bluetooth/controller/Kconfig"
 source "subsys/bluetooth/shell/Kconfig"
+
 endif # BT_HCI
 
 endif # BT

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -6,8 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if BT_HCI
-
 config BT_HCI_VS
 	bool "Zephyr HCI Vendor-Specific Commands"
 	default y
@@ -53,7 +51,6 @@ config BT_DEBUG
 
 choice
 	prompt "Bluetooth debug type"
-	depends on BT
 	default BT_DEBUG_NONE
 
 config BT_DEBUG_NONE
@@ -101,7 +98,6 @@ config BT_MONITOR_ON_DEV_NAME
 
 config BT_DEBUG_HCI_DRIVER
 	bool "Bluetooth HCI driver debug"
-	depends on BT_DEBUG
 	help
 	  This option enables debug support for the active
 	  Bluetooth HCI driver, including the Controller-side HCI layer
@@ -114,5 +110,4 @@ config BT_DEBUG_RPA
 	  This option enables debug support for the Bluetooth
 	  Resolvable Private Address (RPA) generation and resolution.
 
-endif #BT_DEBUG
-endif # BT_HCI
+endif # BT_DEBUG

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -69,7 +69,6 @@ config BT_HCI_TX_PRIO
 
 config BT_WAIT_NOP
 	bool "Wait for \"NOP\" Command Complete event during init"
-	depends on BT_HCI
 	help
 	  Some controllers emit a Command Complete event for the NOP
 	  opcode to indicate that they're ready to receive commands.


### PR DESCRIPTION
`subsys/bluetooth/common/Kconfig` and `subsys/bluetooth/host/Kconfig` are
`source`d within `if BT` and `if BT_HCI`, in `subsys/bluetooth/Kconfig`, so
there's no need to add those dependencies within them.

`if FOO` is just shorthand for adding `depends on FOO` to each item within the
`if`. Dependencies on menus work similarly. There are no "conditional includes"
in Kconfig, so `if FOO` has no special meaning around a `source`. Conditional
includes wouldn't be possible, because an `if` condition could include
(directly or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.