### PR TITLE
kconfig: subsys: net: Remove redundant dependencies

### DIFF
--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -45,7 +45,6 @@ config NET_ICMPV4_ACCEPT_BROADCAST
 
 config NET_DHCPV4
 	bool "Enable DHCPv4 client"
-	depends on NET_IPV4
 
 config NET_DHCPV4_INITIAL_DELAY_MAX
 	int "Maximum time out for initial discover request"
@@ -58,7 +57,7 @@ config NET_DHCPV4_INITIAL_DELAY_MAX
 
 config NET_IPV4_AUTO
 	bool "Enable IPv4 autoconfiguration [EXPERIMENTAL]"
-	depends on NET_IPV4 && NET_ARP
+	depends on NET_ARP
 	help
 	  Enables IPv4 auto IP address configuration (see RFC 3927)
 

--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -21,7 +21,6 @@ if NET_L2_OPENTHREAD
 
 config OPENTHREAD_PLAT
 	bool
-	depends on NET_L2_OPENTHREAD
 	help
 	  This option enables OpenThread platform
 

--- a/subsys/net/lib/lwm2m/Kconfig.ipso
+++ b/subsys/net/lib/lwm2m/Kconfig.ipso
@@ -6,7 +6,6 @@
 
 menuconfig LWM2M_IPSO_SUPPORT
 	bool "IPSO Alliance Smart Object Support"
-	depends on LWM2M
 	help
 	  This option adds general support for IPSO objects
 


### PR DESCRIPTION
`subsys/net/lib/lwm2m/Kconfig.ipso` is `source`d within an `if LWM2M`, in
`subsys/net/lib/lwm2m/Kconfig`, so the `depends on LWM2M` is redundant.

The `depends on NET_IPV4` and `depends on NET_L2_OPENTHREAD` are within
corresponding `if`s in the same file.

`if FOO` is just shorthand for adding `depends on FOO` to each item within the
`if`. Dependencies on menus work similarly. There are no "conditional includes"
in Kconfig, so `if FOO` has no special meaning around a `source`. Conditional
includes wouldn't be possible, because an `if` condition could include
(directly or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.