### PR TITLE
kconfig: subsys: usb: Remove redundant USB_DEVICE_STACK deps.

### DIFF
--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -6,8 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if USB_DEVICE_STACK
-
 config USB_CDC_ACM
 	bool "USB CDC ACM Device Class Driver"
 	select SERIAL_HAS_DRIVER
@@ -147,5 +145,3 @@ config USB_DFU_DETACH_TIMEOUT
 	int
 	depends on USB_DFU_CLASS
 	default 1000
-
-endif # CONFIG_USB_DEVICE_STACK

--- a/subsys/usb/class/netusb/Kconfig
+++ b/subsys/usb/class/netusb/Kconfig
@@ -7,7 +7,6 @@
 #
 
 menu "USB Device Networking support"
-	depends on USB_DEVICE_STACK
 
 config USB_DEVICE_NETWORK
 	bool


### PR DESCRIPTION
`subsys/usb/Kconfig` `source`s `subsys/usb/class/Kconfig` (which in turn
`source`s `subsys/usb/class/netusb/Kconfig`) within an
`if USB_DEVICE_STACK`, so the dependencies on `USB_DEVICE_STACK` added
within those files are redundant.

`if FOO` is just shorthand for adding `depends on FOO` to each item within the
`if`. Dependencies on menus work similarly. There are no "conditional includes"
in Kconfig, so `if FOO` has no special meaning around a `source`. Conditional
includes wouldn't be possible, because an `if` condition could include
(directly or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.