### PR TITLE
kconfig: boards: native_posix: Remove redundant BOARD_NATIVE_POSIX dep.

### DIFF
--- a/boards/posix/native_posix/Kconfig
+++ b/boards/posix/native_posix/Kconfig
@@ -1,11 +1,9 @@
-
 if BOARD_NATIVE_POSIX
 
 comment "Native POSIX options"
 
 config NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME
 	bool "Slow down execution to real time"
-	depends on BOARD_NATIVE_POSIX
 	default y if !TEST
 	help
 	  When selected the execution of the process will be slowed down to real time.


### PR DESCRIPTION
Appears within an `if BOARD_NATIVE_POSIX` in the same file.

`if FOO` is just shorthand for adding `depends on FOO` to each item within the
`if`. Dependencies on menus work similarly. There are no "conditional includes"
in Kconfig, so `if FOO` has no special meaning around a `source`. Conditional
includes wouldn't be possible, because an `if` condition could include
(directly or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.