### PR TITLE
kconfig: boards: nrf52_bsim: Remove redundant BOARD_NRF52_BSIM dep.

### DIFF
--- a/boards/posix/nrf52_bsim/Kconfig
+++ b/boards/posix/nrf52_bsim/Kconfig
@@ -1,11 +1,9 @@
-
 if BOARD_NRF52_BSIM
 
 comment "NRF52_BSIM options"
 
 config PRINTK_HOOK_INIT_PRIORITY
 	int
-	depends on BOARD_NRF52_BSIM
 	default 50
 	help
 	  Just the driver init priority


### PR DESCRIPTION
Appears within an `if BOARD_NRF52_BSIM` in the same file.

`if FOO` is just shorthand for adding `depends on FOO` to each item within the
`if`. Dependencies on menus work similarly. There are no "conditional includes"
in Kconfig, so `if FOO` has no special meaning around a `source`. Conditional
includes wouldn't be possible, because an `if` condition could include
(directly or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.