### PR TITLE
Cleanup kernel object linker script, and remove SORT_BY_NAME()

### DIFF
--- a/arch/nios2/Kconfig
+++ b/arch/nios2/Kconfig
@@ -89,7 +89,7 @@ config GP_GLOBAL
 	help
 	  Use global pointer relative offsets for small globals declared
 	  anywhere in the executable. Note that if any small globals that are put
-	  in alternate sections (such as _k_task_list_ptr) they must be declared
+	  in alternate sections they must be declared
 	  in headers with proper __attribute__((section)) or the linker will
 	  error out.
 

--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -50,70 +50,70 @@
 	SECTION_DATA_PROLOGUE(_k_timer_area, (OPTIONAL), SUBALIGN(4))
 	{
 		_k_timer_list_start = .;
-		KEEP(*(SORT_BY_NAME("._k_timer.static.*")))
+		KEEP(*("._k_timer.static.*"))
 		_k_timer_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(_k_mem_slab_area, (OPTIONAL), SUBALIGN(4))
 	{
 		_k_mem_slab_list_start = .;
-		KEEP(*(SORT_BY_NAME("._k_mem_slab.static.*")))
+		KEEP(*("._k_mem_slab.static.*"))
 		_k_mem_slab_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(_k_mem_pool_area, (OPTIONAL), SUBALIGN(4))
 	{
 		_k_mem_pool_list_start = .;
-		KEEP(*(SORT_BY_NAME("._k_mem_pool.static.*")))
+		KEEP(*("._k_mem_pool.static.*"))
 		_k_mem_pool_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(_k_sem_area, (OPTIONAL), SUBALIGN(4))
 	{
 		_k_sem_list_start = .;
-		KEEP(*(SORT_BY_NAME("._k_sem.static.*")))
+		KEEP(*("._k_sem.static.*"))
 		_k_sem_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(_k_mutex_area, (OPTIONAL), SUBALIGN(4))
 	{
 		_k_mutex_list_start = .;
-		KEEP(*(SORT_BY_NAME("._k_mutex.static.*")))
+		KEEP(*("._k_mutex.static.*"))
 		_k_mutex_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(_k_queue_area, (OPTIONAL), SUBALIGN(4))
 	{
 		_k_queue_list_start = .;
-		KEEP(*(SORT_BY_NAME("._k_queue.static.*")))
+		KEEP(*("._k_queue.static.*"))
 		_k_queue_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(_k_stack_area, (OPTIONAL), SUBALIGN(4))
 	{
 		_k_stack_list_start = .;
-		KEEP(*(SORT_BY_NAME("._k_stack.static.*")))
+		KEEP(*("._k_stack.static.*"))
 		_k_stack_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(_k_msgq_area, (OPTIONAL), SUBALIGN(4))
 	{
 		_k_msgq_list_start = .;
-		KEEP(*(SORT_BY_NAME("._k_msgq.static.*")))
+		KEEP(*("._k_msgq.static.*"))
 		_k_msgq_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(_k_mbox_area, (OPTIONAL), SUBALIGN(4))
 	{
 		_k_mbox_list_start = .;
-		KEEP(*(SORT_BY_NAME("._k_mbox.static.*")))
+		KEEP(*("._k_mbox.static.*"))
 		_k_mbox_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(_k_pipe_area, (OPTIONAL), SUBALIGN(4))
 	{
 		_k_pipe_list_start = .;
-		KEEP(*(SORT_BY_NAME("._k_pipe.static.*")))
+		KEEP(*("._k_pipe.static.*"))
 		_k_pipe_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 

--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -63,7 +63,6 @@
 
 	SECTION_DATA_PROLOGUE(_k_mem_pool_area, (OPTIONAL), SUBALIGN(4))
 	{
-		KEEP(*(SORT_BY_NAME("._k_memory_pool.struct*")))
 		_k_mem_pool_list_start = .;
 		KEEP(*(SORT_BY_NAME("._k_mem_pool.static.*")))
 		_k_mem_pool_list_end = .;
@@ -135,17 +134,6 @@
 		*(._k_event_list.event.*)
 		KEEP(*(SORT_BY_NAME("._k_event_list*")))
 		_k_event_list_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-	SECTION_DATA_PROLOGUE(_k_memory_pool, (OPTIONAL), SUBALIGN(4))
-	{
-		*(._k_memory_pool.struct*)
-		KEEP(*(SORT_BY_NAME("._k_memory_pool.struct*")))
-
-		_k_mem_pool_start = .;
-		*(._k_memory_pool.*)
-		KEEP(*(SORT_BY_NAME("._k_memory_pool*")))
-		_k_mem_pool_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(_net_buf_pool_area, (OPTIONAL), SUBALIGN(4))

--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -117,25 +117,6 @@
 		_k_pipe_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-	SECTION_DATA_PROLOGUE(_k_task_list, (OPTIONAL), SUBALIGN(4))
-	{
-		_k_task_list_start = .;
-		*(._k_task_list.public.*)
-		*(._k_task_list.private.*)
-		_k_task_list_idle_start = .;
-		*(._k_task_list.idle.*)
-		KEEP(*(SORT_BY_NAME("._k_task_list*")))
-		_k_task_list_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-	SECTION_DATA_PROLOGUE(_k_event_list, (OPTIONAL), SUBALIGN(4))
-	{
-		_k_event_list_start = .;
-		*(._k_event_list.event.*)
-		KEEP(*(SORT_BY_NAME("._k_event_list*")))
-		_k_event_list_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
 	SECTION_DATA_PROLOGUE(_net_buf_pool_area, (OPTIONAL), SUBALIGN(4))
 	{
 		_net_buf_pool_list = .;

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -856,7 +856,7 @@ class SizeCalculator:
     alloc_sections = ["bss", "noinit", "app_bss", "app_noinit", "ccm_bss",
                       "ccm_noinit"]
     rw_sections = ["datas", "initlevel", "_k_task_list", "_k_event_list",
-                   "_k_memory_pool", "exceptions", "initshell",
+                   "exceptions", "initshell",
                    "_static_thread_area", "_k_timer_area",
                    "_k_mem_slab_area", "_k_mem_pool_area", "sw_isr_table",
                    "_k_sem_area", "_k_mutex_area", "app_shmem_regions",

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -855,8 +855,7 @@ class SizeCalculator:
 
     alloc_sections = ["bss", "noinit", "app_bss", "app_noinit", "ccm_bss",
                       "ccm_noinit"]
-    rw_sections = ["datas", "initlevel", "_k_task_list", "_k_event_list",
-                   "exceptions", "initshell",
+    rw_sections = ["datas", "initlevel", "exceptions", "initshell",
                    "_static_thread_area", "_k_timer_area",
                    "_k_mem_slab_area", "_k_mem_pool_area", "sw_isr_table",
                    "_k_sem_area", "_k_mutex_area", "app_shmem_regions",


### PR DESCRIPTION
Previous commits removed the relevant code to put symbols into certain linker sections but the entries in linker script were not removed. So this removes those entries.

Also, for kernel objects, there is no need to sort by name. This should not affect the size of binaries as all those kernel object symbols are of fixed size.