### PR TITLE
kconfig: arch: posix: Remove redundant ARCH_POSIX dep.

### DIFF
--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -18,7 +18,6 @@ config ARCH_DEFCONFIG
 
 config ARCH_POSIX_RECOMMENDED_STACK_SIZE
 	int
-	depends on ARCH_POSIX
 	default 24
 	help
 	  In bytes, stack size for Zephyr threads meant only for the POSIX


### PR DESCRIPTION
Appears within a menu that already has a `depends on ARCH_POSIX`.

`depends on FOO` on a menu will add `depends on FOO` to each item within
it. `if FOO` work similarly.

Tip: When adding a symbol, check its dependencies in the menuconfig
('ninja menuconfig', then / to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.