### PR TITLE
kconfig: subsys: dfu: Remove redundant IMG_MANAGER dep.

### DIFF
--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -21,7 +21,6 @@ if IMG_MANAGER
 choice
 	prompt "Image manager"
 	default MCUBOOT_IMG_MANAGER
-	depends on IMG_MANAGER
 	help
 	  Choice support for managing DFU image.
 	  So far only mcuboot support is available.
@@ -31,6 +30,7 @@ config MCUBOOT_IMG_MANAGER
 	select FLASH_MAP
 	help
 	  Enable support for managing DFU image downloaded using mcuboot.
+
 endchoice
 
 config IMG_BLOCK_BUF_SIZE


### PR DESCRIPTION
Appears within an `if IMG_MANAGER`.

`if FOO` is just shorthand for adding `depends on FOO` to each item within the
`if`. Dependencies on menus work similarly. There are no "conditional includes"
in Kconfig, so `if FOO` has no special meaning around a `source`. Conditional
includes wouldn't be possible, because an `if` condition could include
(directly or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.