### PR TITLE
kconfig: arch: arm: Remove redundant ARM_SECURE_FIRMWARE dep.

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -103,7 +103,6 @@ depends on ARM_SECURE_FIRMWARE
 
 config ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS
 	bool "Secure Firmware has Secure Entry functions"
-	depends on ARM_SECURE_FIRMWARE
 	help
 	  Option indicates that ARM Secure Firmware contains
 	  Secure Entry functions that may be called from


### PR DESCRIPTION
Appears within a menu that already has `depends on ARM_SECURE_FIRMWARE`.

`depends on FOO` on a menu will add `depends on FOO` to each item within
it. `if FOO` work similarly.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.