### PR TITLE
kconfig: lvgl: Remove redundant LVGL dep.

### DIFF
--- a/lib/gui/lvgl/Kconfig
+++ b/lib/gui/lvgl/Kconfig
@@ -366,11 +366,10 @@ rsource "Kconfig.objects"
 config APP_LINK_WITH_LVGL
 	bool "Link 'app' with LVGL"
 	default y
-	depends on LVGL
 	help
 	  Add LVGL header files to the 'app' include path. It may be
 	  disabled if the include paths for LVGL are causing aliasing
 	  issues for 'app'.
 
-endif
+endif # LVGL
 


### PR DESCRIPTION
Appears within an `if LVGL`.

`if FOO` is just shorthand for adding `depends on FOO` to each item within the
`if`. Dependencies on menus work similarly. There are no "conditional includes"
in Kconfig, so `if FOO` has no special meaning around a `source`. Conditional
includes wouldn't be possible, because an `if` condition could include
(directly or indirectly) forward references to symbols not defined yet.

Tip: When adding a symbol, check its dependencies in the menuconfig
(`ninja menuconfig`, then `/` to jump to the symbol). The menuconfig also
shows how the file with the symbol got included, so if you see
duplicated dependencies, it's easy to hunt down where they come from.