### PR TITLE
pci: properly scan all device resources

### DIFF
--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -333,6 +333,7 @@ static int pci_dev_scan(union pci_addr_reg pci_ctrl_addr,
 				if (lookup.barofs >= max_bars) {
 					lookup.baridx = 0;
 					lookup.barofs = 0;
+					lookup.func++;
 				}
 
 				return 1;
@@ -406,7 +407,6 @@ int pci_bus_scan(struct pci_dev_info *dev_info)
 			pci_ctrl_addr.field.device = lookup.dev;
 
 			if (pci_dev_scan(pci_ctrl_addr, dev_info)) {
-				lookup.func++;
 				return 1;
 			}
 


### PR DESCRIPTION
The change in commit e5349d74ab12d3a4c6c87f8723ed3c9a5355ae1b
results in only one resource being returned for a device with
pci_bus_scan(). The root cause for that issue was actually
because of wrapping around when scanning through BARs, where
BARs were scanned 0->1->2->..->6->0->1->.. in an endless loop
for a single bus:dev.function. So revert that commit and put
in a fix by moving on to the next function after going
through all the BARs.

Fixes #1550

Signed-off-by: Daniel Leung <daniel.leung@intel.com>