### PR TITLE
drivers: console: kconfig: Remove redundant 'depends on UART_MCUMGR'

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -211,11 +211,11 @@ config UART_MCUMGR
 	  data are handled by an application provided callback.
 
 if UART_MCUMGR
+
 config UART_MCUMGR_ON_DEV_NAME
 	string "Device Name of UART Device for mcumgr UART"
 	default "$(dt_str_val,DT_UART_MCUMGR_ON_DEV_NAME)" if HAS_DTS
 	default "UART_0"
-	depends on UART_MCUMGR
 	help
 	  This option specifies the name of UART device to be used
 	  for mcumgr UART.


### PR DESCRIPTION
Appears within an `if UART_MCUMGR`.

`if FOO` is just shorthand for adding `depends on FOO` to each item
within the `if`.