### PR TITLE
scripts: fix path issue in push-hook script

### DIFF
--- a/scripts/series-push-hook.sh
+++ b/scripts/series-push-hook.sh
@@ -33,5 +33,5 @@ else
 	fi
 
 	echo "Perform check patch"
-	/local/mcu/zephyr/zephyr-project/scripts/checkpatch.pl --git $range
+	${ZEPHYR_BASE}/scripts/checkpatch.pl --git $range
 fi


### PR DESCRIPTION
series-puh-hook.sh script was pushed with local path
instead of ${ZEPHYR_BASE}.
Fix this.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>