### PR TITLE
CODEOWNERS: Add codeowner to boards/shields

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -76,6 +76,7 @@
 /boards/nios2/altera_max10/               @ramakrishnapallala
 /boards/posix/                            @aescolar
 /boards/riscv32/                          @kgugala @pgielda @nategraff-sifive
+/boards/shields/                          @erwango
 /boards/x86/                              @andrewboie @nashif
 /boards/x86/arduino_101/                  @nashif
 /boards/x86/galileo/                      @nashif


### PR DESCRIPTION
Following new shield introduction in #14057, it has been highlighted
there was no codeowner for boards/shields/.
Assign erwango as codeowner.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>