### PR TITLE
cmake: west: Detect whether inside an installation

### DIFF
--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -17,8 +17,17 @@ elseif(WEST)
     ${WEST} list --format={posixpath}
     OUTPUT_VARIABLE
     west_project_output
+    ERROR_VARIABLE
+    west_project_error
+    RESULT_VARIABLE
+    west_list_result
   )
-  string(REGEX REPLACE "[\r\n]+" ";" west_project_list "${west_project_output}")
+  if(NOT ${west_list_result})
+    string(REGEX REPLACE "[\r\n]+" ";" west_project_list "${west_project_output}")
+  elseif(NOT ("${west_project_error}" MATCHES
+              "^Error: .* is not in a west installation\..*"))
+    message(FATAL_ERROR "${west_project_error}")
+  endif()
 endif()
 
 if(ZEPHYR_EXTRA_MODULES)


### PR DESCRIPTION
If one invokes cmake with west in the PATH but not inside a west
installation (i.e. in a monorepo setup), west will try to list the
zephyr modules issuing an error message. Using the --version option,
detect if west is being invoked from within an installation and disable
it in the negative case to avoid such errors.

Fixes #14177

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>