### PR TITLE
Fix various compiler warnings

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -422,7 +422,7 @@ static inline u32_t log_dynamic_source_id(struct log_source_dynamic_data *data)
 static inline __printf_like(1, 2)
 void log_printf_arg_checker(const char *fmt, ...)
 {
-
+	ARG_UNUSED(fmt);
 }
 
 /** @brief Standard log with no arguments.

--- a/lib/cmsis_rtos_v2/kernel.c
+++ b/lib/cmsis_rtos_v2/kernel.c
@@ -25,7 +25,8 @@ osStatus_t osKernelGetInfo(osVersion_t *version, char *id_buf, uint32_t id_size)
 	}
 
 	if ((id_buf != NULL) && (version != NULL)) {
-		snprintf(id_buf, id_size, "Zephyr V%2d.%2d.%2d",
+		snprintf(id_buf, id_size,
+			 "Zephyr V%2"PRIu32".%2"PRIu32".%2"PRIu32,
 			 SYS_KERNEL_VER_MAJOR(version->kernel),
 			 SYS_KERNEL_VER_MINOR(version->kernel),
 			 SYS_KERNEL_VER_PATCHLEVEL(version->kernel));


### PR DESCRIPTION
Fixed compiler warning in logging subsystem when compiling with -Wextra.
Fixed compiler warning in cmsis_rtos_v2 when compiling with newlib.