### PR TITLE
Board: Add arduino interfaces to nrf52840_pca10056

### DIFF
--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -74,6 +74,10 @@
 	};
 };
 
+arduino_i2c: &i2c0 {};
+arduino_spi: &spi1 {};
+arduino_serial: &uart0 {};
+
 &adc {
 	status ="ok";
 };


### PR DESCRIPTION
Add arduino interfaces in dts to board nrf52840_10056

Fixes: #[13708](https://github.com/zephyrproject-rtos/zephyr/issues/13708)

Signed-off-by: Grzegorz Bernat grz.bernat@gmail.com