### PR TITLE
driver/sensor: lis2mdl: (FIX) change 'uint32_t' type into 'u32_t'

### DIFF
--- a/drivers/sensor/lis2mdl/lis2mdl_trigger.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_trigger.c
@@ -73,7 +73,7 @@ static void lis2mdl_handle_interrupt(void *arg)
 }
 
 static void lis2mdl_gpio_callback(struct device *dev,
-				    struct gpio_callback *cb, uint32_t pins)
+				    struct gpio_callback *cb, u32_t pins)
 {
 	struct lis2mdl_data *lis2mdl =
 		CONTAINER_OF(cb, struct lis2mdl_data, gpio_cb);


### PR DESCRIPTION
In zephyr drivers should always use u32_t.
Using uint32_t here generates issues in the CI when NEWLIB_LIBC
is defined.

Signed-off-by: Armando Visconti <armando.visconti@st.com>