### PR TITLE
Build or sanitycheck fixes for Openisa rv32m1/rv32m1_vega_ri5cy board

### DIFF
--- a/boards/riscv32/rv32m1_vega/rv32m1_vega_ri5cy.yaml
+++ b/boards/riscv32/rv32m1_vega/rv32m1_vega_ri5cy.yaml
@@ -4,3 +4,4 @@ type: mcu
 arch: riscv32
 toolchain:
   - cross-compile
+  - zephyr

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -874,7 +874,7 @@ class SizeCalculator:
     # These get copied into RAM only on non-XIP
     ro_sections = ["text", "ctors", "init_array", "reset", "object_access",
                    "rodata", "devconfig", "net_l2", "vector", "sw_isr_table",
-                   "_bt_settings_area"]
+                   "_bt_settings_area", "vectors"]
 
     def __init__(self, filename, extra_sections):
         """Constructor

--- a/soc/riscv32/openisa_rv32m1/linker.ld
+++ b/soc/riscv32/openisa_rv32m1/linker.ld
@@ -107,6 +107,8 @@ SECTIONS
     SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
 	{
 	. = ALIGN(4);
+	*(.srodata)
+	*(".srodata.*")
 	*(.rodata)
 	*(.rodata.*)
 	*(.gnu.linkonce.r.*)

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -66,6 +66,8 @@
 #define TICK_IRQ IRQ_TIMER0
 #elif defined(CONFIG_RISCV_MACHINE_TIMER)
 #define TICK_IRQ RISCV_MACHINE_TIMER_IRQ
+#elif defined(CONFIG_RV32M1_LPTMR_TIMER)
+#define TICK_IRQ DT_OPENISA_RV32M1_LPTMR_SYSTEM_LPTMR_IRQ
 #elif defined(CONFIG_CPU_CORTEX_M)
 /*
  * The Cortex-M use the SYSTICK exception for the system timer, which is


### PR DESCRIPTION
A few fixes to get the rv32m1_vega_ri5cy to pass sanitycheck completely.