### PR TITLE
boards: arm: Enable building with Zephyr toolchain

### DIFF
--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090.yaml
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - gnuarmemb
   - xtools
+  - zephyr
 ram: 64
 flash: 256
 supported:

--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090ns.yaml
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090ns.yaml
@@ -5,6 +5,7 @@ arch: arm
 toolchain:
   - gnuarmemb
   - xtools
+  - zephyr
 ram: 128
 flash: 256
 supported:

--- a/boards/arm/v2m_musca/v2m_musca.yaml
+++ b/boards/arm/v2m_musca/v2m_musca.yaml
@@ -5,5 +5,6 @@ arch: arm
 toolchain:
   - gnuarmemb
   - xtools
+  - zephyr
 supported:
   - counter

--- a/boards/arm/v2m_musca/v2m_musca_nonsecure.yaml
+++ b/boards/arm/v2m_musca/v2m_musca_nonsecure.yaml
@@ -5,4 +5,5 @@ arch: arm
 toolchain:
   - gnuarmemb
   - xtools
+  - zephyr
 ram: 64


### PR DESCRIPTION
Now that we have SDK 0.10.0 we can enable building this board with the
Zephyr toolchain.  SDK 0.10.0 introduced support for the ARM v8m based
cores which these boards utilize.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>