### PR TITLE
kernel: Make heap smallest object size configurable

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -485,6 +485,15 @@ config HEAP_MEM_POOL_SIZE
 	  dynamically allocating memory using k_malloc(). Supported values
 	  are: 256, 1024, 4096, and 16384. A size of zero means that no
 	  heap memory pool is defined.
+
+config HEAP_MEM_POOL_MIN_SIZE
+	int "The smallest blocks in the heap memory pool (in bytes)"
+	depends on HEAP_MEM_POOL_SIZE != 0
+	default 64
+	help
+	  This option specifies the size of the smallest block in the pool.
+	  Option must be a power of 2 and lower than or equal to the size
+	  of the entire pool.
 endmenu
 
 config ARCH_HAS_CUSTOM_SWAP_TO_MAIN

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -179,7 +179,8 @@ void k_free(void *ptr)
  * that has the address of the associated memory pool struct.
  */
 
-K_MEM_POOL_DEFINE(_heap_mem_pool, 64, CONFIG_HEAP_MEM_POOL_SIZE, 1, 4);
+K_MEM_POOL_DEFINE(_heap_mem_pool, CONFIG_HEAP_MEM_POOL_MIN_SIZE,
+		  CONFIG_HEAP_MEM_POOL_SIZE, 1, 4);
 #define _HEAP_MEM_POOL (&_heap_mem_pool)
 
 void *k_malloc(size_t size)


### PR DESCRIPTION
Allow application to chose the size of the smallest object taken from
the heap.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>