### PR TITLE
kernel/work_q: Fix locking across multiple queues

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2533,7 +2533,6 @@ typedef void (*k_work_handler_t)(struct k_work *work);
 struct k_work_q {
 	struct k_queue queue;
 	struct k_thread thread;
-	struct k_spinlock lock;
 };
 
 enum {


### PR DESCRIPTION
There was a detected user error in the code where racing insertions of
k_delayed_work items into different queues would be detected and
flagged as an error (honestly I don't see much value there -- Zephyr
doesn't as a general rule protect against errors like this, and
work_q's are inherently kernel things that don't require
userspace-style checking).

This got broken with spinlockification, where each work_q object got
its own lock, so the single lock wouldn't protect against the other
insert function any more.  As it happens, that was needless.  The core
synchronization on a work_q is in the internal k_queue object anyway
-- the lock in this file was only ever used for (very fast,
noncontending) delayed work insertion.  So go back to a global lock to
preserve the original behavior.

Fixes #14104

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>