### PR TITLE
ext : hal : mec1501 Add the MEC1501 external headers.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -142,6 +142,7 @@
 /ext/fs/                                  @nashif @ramakrishnapallala
 /ext/hal/cmsis/                           @MaureenHelm @galak
 /ext/hal/libmetal/                        @galak
+/ext/hal/microchip/                       @scottwcpg @franciscomunoz @albertofloyd
 /ext/hal/nordic/                          @carlescufi @anangl
 /ext/hal/nxp/                             @MaureenHelm
 /ext/hal/qmsi/                            @nashif

--- a/ext/hal/microchip/CMakeLists.txt
+++ b/ext/hal/microchip/CMakeLists.txt
@@ -1,1 +1,1 @@
-zephyr_include_directories_ifdef(CONFIG_HAS_MEC_HAL mec)
+add_subdirectory_ifdef(CONFIG_HAS_MEC_HAL mec)

--- a/ext/hal/microchip/README.txt
+++ b/ext/hal/microchip/README.txt
@@ -7,3 +7,7 @@ sed -i -e 's/[ \t\r]*$//g' MCHP_MEC1701_bit_fields.h, then file was renamed
 to MCHP_MEC1701.h
 
 Field EOF was renamed to PEOF as it was collapsing with EOF defined in stdio.h
+
+2019-03-11
+Add MEC1501 header files.
+

--- a/ext/hal/microchip/mec/CMakeLists.txt
+++ b/ext/hal/microchip/mec/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+zephyr_include_directories_ifdef(CONFIG_SOC_SERIES_MEC1701X ./)
+
+zephyr_include_directories_ifdef(CONFIG_SOC_SERIES_MEC1501X common)
+zephyr_include_directories_ifdef(CONFIG_SOC_SERIES_MEC1501X mec1501)
+

--- a/ext/hal/microchip/mec/common/cpu.h
+++ b/ext/hal/microchip/mec/common/cpu.h
@@ -1,0 +1,279 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file cpu.h
+ *MEC1701 CPU abstractions
+ */
+/** @defgroup cpu
+ */
+
+
+#ifndef _CPU_H
+#define _CPU_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#ifdef __CC_ARM             /* Keil ARM MDK */
+
+#ifndef UINT8_C
+#define UINT8_C(x) (unsigned char)(x)
+#endif
+
+#ifndef UINT16_C
+#define UINT16_C(x) (unsigned int)(x)
+#endif
+
+#ifndef UINT32_C
+#define UINT32_C(x) (unsigned long)(x)
+#endif
+
+#define USED __attribute__((used))
+#define WEAK __attribute__((weak))
+#define INLINE __inline
+#define NORETURN __declspec(noreturn)
+#define PACKED __packed
+#define CPU_GET_INTERRUPT_STATE() __get_PRIMASK()
+#define CPU_SET_INTERRUPT_STATE(x) __set_PRIMASK((x))
+
+/*
+ * Keil MDK intrisic __disable_irq() returns the value of MSR PRIMASK
+ * before disabling interrupts.
+*/
+#define CPU_DISABLE_INTERRUPTS() __disable_irq()
+#define CPU_GET_DISABLE_INTERRUPTS(x) {(x) = __disable_irq();}
+#define CPU_RESTORE_INTERRUPTS(x) { if (!(x)) { __enable_irq(); } }
+#define CPU_ENABLE_INTERRUPTS() __enable_irq()
+
+#define CPU_NOP() __nop()
+#define CPU_WAIT_FOR_INTR() __wfi()
+
+#define CPU_REV(x) __rev(x)
+
+#define CPU_CLZ(x) __clz(x)
+
+/*
+ * The microsecond delay register is implemented in a Normal Data Memory
+ * Region. Normal regions have relaxed data ordering semantics. This can
+ * cause issues because writes to this register can complete before a
+ * previous write to Device or Strongly ordered memory. Please use the
+ * inline code after this definition. It uses the Data Synchronization
+ * Barrier instruction to insure all outstanding writes complete before
+ * the instruction after DSB is executed.
+ * #define MEC2016_DELAY_REG   *((volatile uint8_t*) MEC2016_DELAY_REG_BASE)
+ */
+
+static inline void MICROSEC_DELAY(unsigned char n)
+{
+    volatile unsigned long *pdly_reg;
+
+    pdly_reg = (volatile unsigned long *)0x10000000ul;
+
+    __asm volatile (
+        "\tstrb  n, [pdly_reg]\n"
+        "\tldrb  n, [pdly_reg]\n"
+        "\tadd   n, #0\n"
+        "\tdmb\n");
+}
+
+#elif defined(__XC32_PART_SUPPORT_VERSION) /* Microchip XC32 compiler customized GCC */
+
+#error "!!! FORCED BUILD ERROR: compiler.h XC32 support has not been implemented !!!"
+
+#elif defined(__GNUC__) && defined(__ARM_EABI__)    /* GCC for ARM (arm-none-eabi-gcc) */
+
+#include <stdint.h>
+#include <stddef.h>
+
+__attribute__( ( always_inline ) ) static inline void __NOP_THUMB2(void)
+{
+  __asm volatile ("nop");
+}
+
+#define CPU_NOP() __NOP_THUMB2()
+
+__attribute__( ( always_inline ) ) static inline void __WFI_THUMB2(void)
+{
+    __asm volatile ("dsb");
+    __asm volatile ("isb");
+    __asm volatile ("wfi");
+    __asm volatile ("nop");
+    __asm volatile ("nop");
+    __asm volatile ("nop");
+}
+
+#define CPU_WAIT_FOR_INTR() __WFI_THUMB2()
+
+/* We require user have ARM CMSIS header files available and configured
+ * core_cmFunc.h includes inlines for global interrupt control.
+ * For some reason, CMSIS __disable_irq for GCC does not return current PRIMASK
+ * value. */
+
+__attribute__( ( always_inline ) ) static inline uint32_t __get_disable_irq(void)
+{
+    uint32_t pri_mask;
+
+    __asm volatile (
+        "\tmrs %0, primask\n"
+        "\tcpsid i\n"
+        "\tdsb\n"
+        "\tisb\n"
+        : "=r" (pri_mask) :: "memory"
+    );
+    return pri_mask;
+}
+
+__attribute__((always_inline)) static inline uint32_t __get_primask(void)
+{
+    uint32_t pri_mask;
+
+    __asm volatile (
+        "\tmrs %0, primask\n"
+        "\tisb\n"
+        : "=r" (pri_mask) :: "memory"
+    );
+    return pri_mask;
+}
+
+__attribute__((always_inline)) static inline void __enable_irqs(void)
+{
+    __asm volatile ("cpsie i" : : : "memory");
+}
+
+__attribute__((always_inline)) static inline void __disable_irqs(void)
+{
+    __asm volatile (
+        "\tcpsid i\n"
+        "\tdsb\n"
+        "\tisb\n" : : : "memory");
+}
+
+
+#define CPU_GET_INTERRUPT_STATE() __get_primask()
+#define CPU_GET_DISABLE_INTERRUPTS(x) {(x) = __get_disable_irq();}
+#define CPU_RESTORE_INTERRUPTS(x) { if (!(x)) { __enable_irqs(); } }
+#define CPU_ENABLE_INTERRUPTS() __enable_irqs()
+#define CPU_DISABLE_INTERRUPTS() __disable_irqs()
+
+
+__attribute__( ( always_inline ) ) static inline uint32_t __REV_THUMB2(uint32_t u32)
+{
+    return __builtin_bswap32(u32);
+}
+
+#define CPU_REV(x) __REV_THUMB2(x)
+
+/*
+ * __builtin_clz() will not be available if user compiles with built-ins disabled flag.
+ */
+#define CPU_CLZ(x) __builtin_clz(x)
+
+__attribute__( ( always_inline, noreturn ) ) static inline void CPU_JMP(uint32_t addr)
+{
+    addr |= (1ul << 0);
+    __asm volatile (
+        "\n\t"
+        "\tBX  %0 \n"
+        "\tNOP \n"
+        :   /* no outputs */
+        :"r"(addr)
+        :);
+    while(1);
+}
+
+
+/*
+ * The microsecond delay register is implemented in a Normal Data Memory
+ * Region. Normal regions have relaxed data ordering semantics. This can
+ * cause issues because writes to this register can complete before a
+ * previous write to Device or Strongly ordered memory. Please use the
+ * inline code after this definition. It uses the Data Synchronization
+ * Barrier instruction to insure all outstanding writes complete before
+ * the instruction after DSB is executed.
+ * #define MEC2016_DELAY_REG   *((volatile uint8_t*) MEC2016_DELAY_REG_BASE)
+ */
+
+static inline void MICROSEC_DELAY(uint8_t n)
+{
+    uint32_t dly_reg_addr = 0x10000000ul;
+
+    __asm volatile (
+        "\tstrb  %0, [%1]\n"
+        "\tldrb  %0, [%1]\n"
+        "\tadd  %0, #0\n"
+        "\tdmb\n"
+        :
+        : "r" (n), "r" (dly_reg_addr)
+        : "memory"
+    );
+}
+
+static inline void write_read_back8(volatile uint8_t* addr, uint8_t val)
+{
+    __asm__ __volatile__ (
+            "\n\t"
+            "strb %1, [%0]      \n\t"
+            "ldrb %1, [%0]      \n\t"
+            : /* No outputs */
+            : "r" (addr), "r" (val)
+            : "memory");
+}
+
+static inline void write_read_back16(volatile uint16_t* addr, uint16_t val)
+{
+        __asm__ __volatile__ (
+            "\n\t"
+            "strh %1, [%0]      \n\t"
+            "ldrh %1, [%0]      \n\t"
+            : /* No outputs */
+            : "r" (addr), "r" (val)
+            : "memory");
+}
+
+static inline void write_read_back32(volatile uint32_t* addr, uint32_t val)
+{
+        __asm__ __volatile__ (
+            "\n\t"
+            "str %1, [%0]       \n\t"
+            "ldr %1, [%0]       \n\t"
+            : /* No outputs */
+            : "r" (addr), "r" (val)
+            : "memory");
+}
+
+#else                       // Any other compiler
+
+#error "!!! FORCED BUILD ERROR: cpu.h Unknown compiler !!!"
+
+#endif
+
+#endif // #ifndef _CPU_H
+/**   @}
+ */

--- a/ext/hal/microchip/mec/common/mec_retval.h
+++ b/ext/hal/microchip/mec/common/mec_retval.h
@@ -1,0 +1,55 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file mec_retval.h
+ *MEC Peripheral library return values
+ */
+/** @defgroup MEC Peripherals Return values
+ */
+
+#ifndef _MEC_RETVAL_H
+#define _MEC_RETVAL_H
+
+#define MEC_RET_OK              0
+#define MEC_RET_ERR             1
+#define MEC_RET_ERR_INVAL       2 /* bad parameter */
+#define MEC_RET_ERR_BUSY        3
+#define MEC_RET_ERR_NOP         4
+#define MEC_RET_ERR_XFR         5
+#define MEC_RET_ERR_TIMEOUT     6
+#define MEC_RET_ERR_NACK        7 /* a device did not respond */
+#define MEC_RET_ERR_HW          8
+
+#define MEC_FALSE   0
+#define MEC_TRUE    1
+
+#define MEC_OFF     0
+#define MEC_ON      1
+
+#endif // #ifndef _MEC_RETVAL_H
+/* end mec_retval.h */
+/**   @}
+ */

--- a/ext/hal/microchip/mec/common/regaccess.h
+++ b/ext/hal/microchip/mec/common/regaccess.h
@@ -1,0 +1,61 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _REGACCESS_H
+#define _REGACCESS_H
+
+#include <stdint.h>
+
+#define MMCR32(a)   *(volatile uint32_t *)(a)
+#define MMCR16(a)   *(volatile uint16_t *)(a)
+#define MMCR8(a)    *(volatile uint8_t *)(a)
+
+#define MMCR_RD32(a, v)   v = *(volatile uint32_t *)(a)
+#define MMCR_RD16(a, v)   v = *(volatile uint16_t *)(a)
+#define MMCR_RD8(a, v)    v = *(volatile uint8_t *)(a)
+
+#define MMCR_WR32(a, d)   *(volatile uint32_t *)(a) = (d)
+#define MMCR_WR16(a, h)   *(volatile uint16_t *)(a) = (h)
+#define MMCR_WR8(a, b)    *(volatile uint8_t *)(a) = (b)
+
+#define REG32(a)    *(volatile uint32_t *)(a)
+#define REG16(a)    *(volatile uint16_t *)(a)
+#define REG8(a)     *(volatile uint8_t *)(a)
+
+#define REG32W(a, d)    *(volatile uint32_t *)(a) = (d)
+#define REG16W(a, h)    *(volatile uint16_t *)(a) = (h)
+#define REG8W(a, b)     *(volatile uint8_t *)(a) = (b)
+
+#define REG32R(a, d)    (d) = *(volatile uint32_t *)(a) = (d)
+#define REG16R(a, h)    (h) = *(volatile uint16_t *)(a) = (h)
+#define REG8R(a, b)     (b) = *(volatile uint8_t *)(a) = (b)
+
+#define REG32_OFS(a, ofs)   *(volatile uint32_t *)((a) + (ofs))
+#define REG16_OFS(a, ofs)   *(volatile uint16_t *)((a) + (ofs))
+#define REG8_OFS(a, ofs)    *(volatile uint8_t *)((a) + (ofs))
+
+
+#endif // #ifndef _REGACCESS_H

--- a/ext/hal/microchip/mec/mec1501/MEC1501hsz.h
+++ b/ext/hal/microchip/mec/mec1501/MEC1501hsz.h
@@ -1,0 +1,557 @@
+/**************************************************************************//**
+ * @file     MEC1501hsz.h
+ * @brief    CMSIS Cortex-M4 Core Peripheral Access Layer Header File for
+ *           Device Microchip MEC1501-H-SZ
+ * @version  V5.00
+ * @date     03. January 2019
+ * Copyright (c) 2019 Microchip Technology Inc.
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ * Copyright (c) 2019 Microchip Technology Incorporated. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MEC1501HSZ_H
+#define MEC1501HSZ_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup MCHP
+  * @{
+  */
+
+
+/** @addtogroup MEC1501
+  * @{
+  */
+
+
+/** @addtogroup Configuration_of_CMSIS
+  * @{
+  */
+
+
+
+/* =========================================================================================================================== */
+/* ================                                Interrupt Number Definition                                ================ */
+/* =========================================================================================================================== */
+
+typedef enum IRQn
+{
+/* =======================================  ARM Cortex-M4 Specific Interrupt Numbers  ======================================== */
+
+  Reset_IRQn                = -15,              /*!< -15  Reset Vector, invoked on Power up and warm reset                     */
+  NonMaskableInt_IRQn       = -14,              /*!< -14  Non maskable Interrupt, cannot be stopped or preempted               */
+  HardFault_IRQn            = -13,              /*!< -13  Hard Fault, all classes of Fault                                     */
+  MemoryManagement_IRQn     = -12,              /*!< -12  Memory Management, MPU mismatch, including Access Violation
+                                                          and No Match                                                         */
+  BusFault_IRQn             = -11,              /*!< -11  Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory
+                                                          related Fault                                                        */
+  UsageFault_IRQn           = -10,              /*!< -10  Usage Fault, i.e. Undef Instruction, Illegal State Transition        */
+  SVCall_IRQn               =  -5,              /*!< -5 System Service Call via SVC instruction                                */
+  DebugMonitor_IRQn         =  -4,              /*!< -4 Debug Monitor                                                          */
+  PendSV_IRQn               =  -2,              /*!< -2 Pendable request for system service                                    */
+  SysTick_IRQn              =  -1,              /*!< -1 System Tick Timer                                                      */
+
+/* ===========================================  MEC15xx Specific Interrupt Numbers  ========================================= */
+
+    GIRQ08_IRQn                 = 0,  /*!< GPIO 0140 - 0176 */
+    GIRQ09_IRQn                 = 1,  /*!< GPIO 0100 - 0136 */
+    GIRQ10_IRQn                 = 2,  /*!< GPIO 0040 - 0076 */
+    GIRQ11_IRQn                 = 3,  /*!< GPIO 0000 - 0036 */
+    GIRQ12_IRQn                 = 4,  /*!< GPIO 0200 - 0236 */
+    GIRQ13_IRQn                 = 5,  /*!< SMBus Aggregated */
+    GIRQ14_IRQn                 = 6,  /*!< DMA Aggregated */
+    GIRQ15_IRQn                 = 7,
+    GIRQ16_IRQn                 = 8,
+    GIRQ17_IRQn                 = 9,
+    GIRQ18_IRQn                 = 10,
+    GIRQ19_IRQn                 = 11,
+    GIRQ20_IRQn                 = 12,
+    GIRQ21_IRQn                 = 13,
+    /* GIRQ22 is not connected to EC. It's purpose is peripheral clock wake */
+    GIRQ23_IRQn                 = 14,
+    GIRQ24_IRQn                 = 15,
+    GIRQ25_IRQn                 = 16,
+    GIRQ26_IRQn                 = 17,  /*!< GPIO 0240 - 0276 */
+    /* Reserved gap, 18-19 */
+    /* GIRQ's 8 - 12, 24 - 26 no direct connections */
+    SMB0_IRQn                   = 20, /* GIRQ13 b[0] */
+    SMB1_IRQn                   = 21, /* GIRQ13 b[1] */
+    SMB2_IRQn                   = 22, /* GIRQ13 b[2] */
+    SMB3_IRQn                   = 23, /* GIRQ13 b[3] */
+    DMA0_IRQn                   = 24, /* GIRQ14 b[0] */
+    DMA1_IRQn                   = 25, /* GIRQ14 b[1] */
+    DMA2_IRQn                   = 26, /* GIRQ14 b[2] */
+    DMA3_IRQn                   = 27, /* GIRQ14 b[3] */
+    DMA4_IRQn                   = 28, /* GIRQ14 b[4] */
+    DMA5_IRQn                   = 29, /* GIRQ14 b[5] */
+    DMA6_IRQn                   = 30, /* GIRQ14 b[6] */
+    DMA7_IRQn                   = 31, /* GIRQ14 b[7] */
+    DMA8_IRQn                   = 32, /* GIRQ14 b[8] */
+    DMA9_IRQn                   = 33, /* GIRQ14 b[9] */
+    DMA10_IRQn                  = 34, /* GIRQ14 b[10] */
+    DMA11_IRQn                  = 35, /* GIRQ14 b[11] */
+    /* Reserved gap, 36-37 */
+    /* Reserved gap, 38-39 */
+    UART0_IRQn                  = 40, /* GIRQ15 b[0] */
+    UART1_IRQn                  = 41, /* GIRQ15 b[1] */
+    EMI0_IRQn                   = 42, /* GIRQ15 b[2] */
+    EMI1_IRQn                   = 43, /* GIRQ15 b[3] */
+    UART2_IRQn                  = 44, /* GIRQ15 b[4] */
+    AEC0_IBF_IRQn               = 45, /* GIRQ15 b[5] */
+    AEC0_OBE_IRQn               = 46, /* GIRQ15 b[6] */
+    AEC1_IBF_IRQn               = 47, /* GIRQ15 b[7] */
+    AEC1_OBE_IRQn               = 48, /* GIRQ15 b[8] */
+    AEC2_IBF_IRQn               = 49, /* GIRQ15 b[9] */
+    AEC2_OBE_IRQn               = 50, /* GIRQ15 b[10] */
+    AEC3_IBF_IRQn               = 51, /* GIRQ15 b[11] */
+    AEC3_OBE_IRQn               = 52, /* GIRQ15 b[12] */
+    /* Reserved gap, 53-54 */
+    APM1_CTL_IRQn               = 55, /* GIRQ15 b[15] */
+    APM1_EN_IRQn                = 56, /* GIRQ15 b[16] */
+    APM1_STS_IRQn               = 57, /* GIRQ15 b[17] */
+    KBC_OBE_IRQn                = 58, /* GIRQ15 b[18] */
+    KBC_IBF_IRQn                = 59, /* GIRQ15 b[19] */
+    MBOX_IRQn                   = 60, /* GIRQ15 b[20] */
+    /* reserved gap 61 */
+    P80CAP0_IRQn                = 62, /* GIRQ15 b[22] */
+    P80CAP1_IRQn                = 63, /* GIRQ15 b[23] */
+    /* reserved gap 64 */
+    PKE_ERR_IRQn                = 65, /* GIRQ16 b[0] */
+    PKE_DONE_IRQn               = 66, /* GIRQ16 b[1] */
+    RNG_IRQn                    = 67, /* GIRQ16 b[2] */
+    AES_IRQn                    = 68, /* GIRQ16 b[3] */
+    HASH_IRQn                   = 69, /* GIRQ16 b[4] */
+    PECI_IRQn                   = 70, /* GIRQ17 b[0] */
+    TACH0_IRQn                  = 71, /* GIRQ17 b[1] */
+    TACH1_IRQn                  = 72, /* GIRQ17 b[2] */
+    TACH2_IRQn                  = 73, /* GIRQ17 b[3] */
+    /* reserved gap 74-77 */
+    ADC_SNGL_IRQn               = 78, /* GIRQ17 b[8] */
+    ADC_RPT_IRQn                = 79, /* GIRQ17 b[9] */
+    /* reserved gap 80-82 */
+    LED0_IRQn                   = 83, /* GIRQ17 b[13] */
+    LED1_IRQn                   = 84, /* GIRQ17 b[14] */
+    LED2_IRQn                   = 85, /* GIRQ17 b[15] */
+    /* reserved gap 86 */
+    PHOT_IRQn                   = 87, /* GIRQ17 b[17] */
+    /* reserved gap 88-89 */
+    SPISLV_IRQn                 = 90, /* GIRQ18 b[0] */
+    QMSPI_IRQn                  = 91, /* GIRQ18 b[1] */
+    /* reserved gap 92-99 */
+    PS2_0_ACT_IRQn              = 100, /* GIRQ18 b[10] */
+    PS2_1_ACT_IRQn              = 101, /* GIRQ18 b[11] */
+    /* reserved gap 102 */
+    ESPI_PC_IRQn                = 103, /* GIRQ19 b[0] */
+    ESPI_BM1_IRQn               = 104, /* GIRQ19 b[1] */
+    ESPI_BM2_IRQn               = 105, /* GIRQ19 b[2] */
+    ESPI_LTR_IRQn               = 106, /* GIRQ19 b[3] */
+    ESPI_OOB_UP_IRQn            = 107, /* GIRQ19 b[4] */
+    ESPI_OOB_DN_IRQn            = 108, /* GIRQ19 b[5] */
+    ESPI_FLASH_IRQn             = 109, /* GIRQ19 b[6] */
+    ESPI_RESET_IRQn             = 110, /* GIRQ19 b[7] */
+    RTMR_IRQn                   = 111, /* GIRQ23 b[10] */
+    HTMR0_IRQn                  = 112, /* GIRQ23 b[16] */
+    HTMR1_IRQn                  = 113, /* GIRQ23 b[17] */
+    WK_IRQn                     = 114, /* GIRQ21 b[3] */
+    WKSUB_IRQn                  = 115, /* GIRQ21 b[4] */
+    WKSEC_IRQn                  = 116, /* GIRQ21 b[5] */
+    WKSUBSEC_IRQn               = 117, /* GIRQ21 b[6] */
+    SYSPWR_IRQn                 = 118, /* GIRQ21 b[7] */
+    RTC_IRQn                    = 119, /* GIRQ21 b[8] */
+    RTC_ALARM_IRQn              = 120, /* GIRQ21 b[9] */
+    VCI_OVRD_IN_IRQn            = 121, /* GIRQ21 b[10] */
+    VCI_IN0_IRQn                = 122, /* GIRQ21 b[11] */
+    VCI_IN1_IRQn                = 123, /* GIRQ21 b[12] */
+    VCI_IN2_IRQn                = 124, /* GIRQ21 b[13] */
+    VCI_IN3_IRQn                = 125, /* GIRQ21 b[14] */
+    /* reserved 126 - 128 */
+    PS2_0A_WAKE_IRQn            = 129, /* GIRQ21 b[18] */
+    PS2_0B_WAKE_IRQn            = 130, /* GIRQ21 b[19] */
+    /* reserved gap 131 */
+    PS2_1B_WAKE_IRQn            = 132, /* GIRQ21 b[21] */
+    /* reserved gap 133 - 134 */
+    KEYSCAN_IRQn                = 135, /* GIRQ21 b[25] */
+    B16TMR0_IRQn                = 136, /* GIRQ23 b[0] */
+    B16TMR1_IRQn                = 137, /* GIRQ23 b[1] */
+    /* reserved gap 138 - 139 */
+    B32TMR0_IRQn                = 140, /* GIRQ23 b[4] */
+    B32TMR1_IRQn                = 141, /* GIRQ23 b[5] */
+    /* reserved 142 - 145 */
+    CCT_IRQn                    = 146, /* GIRQ18 b[20] */
+    CCT_CAP0_IRQn               = 147, /* GIRQ18 b[21] */
+    CCT_CAP1_IRQn               = 148, /* GIRQ18 b[22] */
+    CCT_CAP2_IRQn               = 149, /* GIRQ18 b[23] */
+    CCT_CAP3_IRQn               = 150, /* GIRQ18 b[24] */
+    CCT_CAP4_IRQn               = 151, /* GIRQ18 b[25] */
+    CCT_CAP5_IRQn               = 152, /* GIRQ18 b[26] */
+    CCT_CMP0_IRQn               = 153, /* GIRQ18 b[27] */
+    CCT_CMP1_IRQn               = 154, /* GIRQ18 b[28] */
+    EEPROM_CTRL_IRQn            = 155, /* GIRQ18 b[13] */
+    ESPI_VWIRE_IRQn             = 156, /* GIRQ19 b[8] */
+    /* reserved gap 157 */
+    SMB4_IRQn                   = 158, /* GIRQ13 b[4] */
+    TACH3_IRQn                  = 159, /* GIRQ17 b[4] */
+    CEC_IRQn                    = 160, /* GIRQ17 b[5] */
+    SGPIOCtrl0_IRQn             = 161, /* GIRQ18 b[14] */
+    SGPIOCtrl1_IRQn             = 162, /* GIRQ18 b[15] */
+    SGPIOCtrl2_IRQn             = 163, /* GIRQ18 b[16] */
+    SGPIOCtrl3_IRQn             = 164, /* GIRQ18 b[17] */
+    /* reserved gap 165 */
+    SAF_DONE_IRQn               = 166, /* GIRQ19 b[9] */
+    SAF_ERR_IRQn                = 167, /* GIRQ19 b[10] */
+    I2C0_IRQn                   = 168, /* GIRQ13 b[5] */
+    I2C1_IRQn                   = 169, /* GIRQ13 b[6] */
+    I2C2_IRQn                   = 170, /* GIRQ13 b[7] */
+    WDT_IRQn                    = 171, /* GIRQ21 b[2] */
+    GLUE_IRQn                   = 172, /* GIRQ23 b[26] */
+    OTP_READY_IRQn              = 173, /* GIRQ20 b[3] */
+    MAX_IRQn                    = 174
+} IRQn_Type;
+
+
+
+/* =========================================================================================================================== */
+/* ================                           Processor and Core Peripheral Section                           ================ */
+/* =========================================================================================================================== */
+
+/* ===========================  Configuration of the Arm Cortex-M4 Processor and Core Peripherals  =========================== */
+
+#define __CM4_REV                 0x0201    /*!< Core Revision r2p1 */
+
+#define __MPU_PRESENT             1         /*!< Set to 1 if MPU is present */
+#define __VTOR_PRESENT            1         /*!< Set to 1 if VTOR is present */
+#define __NVIC_PRIO_BITS          3         /*!< Number of Bits used for Priority Levels */
+#define __Vendor_SysTickConfig    0         /*!< Set to 1 if different SysTick Config is used */
+#define __FPU_PRESENT             0         /*!< Set to 1 if FPU is present */
+#define __FPU_DP                  0         /*!< Set to 1 if FPU is double precision FPU (default is single precision FPU) */
+#define __ICACHE_PRESENT          0         /*!< Set to 1 if I-Cache is present */
+#define __DCACHE_PRESENT          0         /*!< Set to 1 if D-Cache is present */
+#define __DTCM_PRESENT            0         /*!< Set to 1 if DTCM is present */
+
+
+/** @} */ /* End of group Configuration_of_CMSIS */
+
+#include "core_cm4.h"                      /*!< Arm Cortex-M4 processor and core peripherals */
+
+
+/* ========================================  Start of section using anonymous unions  ======================================== */
+#if   defined (__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined (__ICCARM__)
+  #pragma language=extended
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wc11-extensions"
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning 586
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+/* ======================================================================== */
+/* ================   Device Specific Peripheral Section   ================ */
+/* ======================================================================== */
+
+
+/** @addtogroup MEC1501_Peripheral_peripherals
+  * @{
+  */
+
+/*@}*/ /* end of group MEC15xx_Peripherals */
+
+/* =========================================  End of section using anonymous unions  ========================================= */
+#if   defined (__CC_ARM)
+  #pragma pop
+#elif defined (__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning restore
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+/* =========================================================================*/
+/* ================ Device Specific Peripheral Address Map ================ */
+/* =========================================================================*/
+
+/** @addtogroup Device_Peripheral_peripheralAddr
+  * @{
+  */
+
+/* Peripheral and SRAM base address */
+#define CODE_SRAM_BASE          (0x000E0000UL)    /*!< (CODE SRAM ) Base Address */
+#define DATA_SRAM_BASE          (0x00118000UL)    /*!< (DATA SRAM ) Base Address */
+#define PERIPH_BASE             (0x40000000UL)    /*!< (Peripheral) Base Address */
+
+/* Peripheral memory map */
+#define WDT_BASE            (PERIPH_BASE + 0x0400)  /*!< (WDT0   )  Base Address */
+#define B16TMR0_BASE        (PERIPH_BASE + 0x0C00)  /*!< (B16TMR0 ) Base Address */
+#define B16TMR1_BASE        (PERIPH_BASE + 0x0C20)  /*!< (B16TMR1 ) Base Address */
+#define B32TMR0_BASE        (PERIPH_BASE + 0x0C80)  /*!< (B32TMR0 ) Base Address */
+#define B32TMR1_BASE        (PERIPH_BASE + 0x0CA0)  /*!< (B32TMR1 ) Base Address */
+#define CCT_BASE            (PERIPH_BASE + 0x1000)  /*!< (CCT0 ) Base Address */
+#define DMA_BASE            (PERIPH_BASE + 0x2400)  /*!< (DMA ) Base Address */
+#define DMA_CHAN_BASE(n)    (DMA_BASE + (((n)+1)<<6))
+#define DMA_CH0_BASE        (DMA_BASE + 0x0040)
+#define DMA_CH1_BASE        (DMA_BASE + 0x0080)
+#define DMA_CH2_BASE        (DMA_BASE + 0x00C0)
+#define DMA_CH3_BASE        (DMA_BASE + 0x0100)
+#define DMA_CH4_BASE        (DMA_BASE + 0x0140)
+#define DMA_CH5_BASE        (DMA_BASE + 0x0180)
+#define DMA_CH6_BASE        (DMA_BASE + 0x01C0)
+#define DMA_CH7_BASE        (DMA_BASE + 0x0200)
+#define DMA_CH8_BASE        (DMA_BASE + 0x0240)
+#define DMA_CH9_BASE        (DMA_BASE + 0x0280)
+#define DMA_CH10_BASE       (DMA_BASE + 0x02C0)
+#define DMA_CH11_BASE       (DMA_BASE + 0x0300)
+#define EEPROM_CTRL_BASE    (PERIPH_BASE + 0x2C00)  /*!< (EEPROM_CTRL ) Base Address */
+#define PROCHOT_BASE        (PERIPH_BASE + 0x3400)  /*!< (PROCHOT ) Base Address */
+#define SMB_BASE(n)         (PERIPH_BASE + 0x4000 + ((n)<<10))
+#define SMB0_BASE           (PERIPH_BASE + 0x4000)  /*!< (SMB0 ) Base Address */
+#define SMB1_BASE           (PERIPH_BASE + 0x4400)  /*!< (SMB1 ) Base Address */
+#define SMB2_BASE           (PERIPH_BASE + 0x4800)  /*!< (SMB2 ) Base Address */
+#define SMB3_BASE           (PERIPH_BASE + 0x4C00)  /*!< (SMB3 ) Base Address */
+#define SMB4_BASE           (PERIPH_BASE + 0x5000)  /*!< (SMB4 ) Base Address */
+#define I2C_BASE(n)         (PERIPH_BASE + 0x5100 + ((n)<<8))
+#define I2C0_BASE           (PERIPH_BASE + 0x5100)  /*!< (I2C0 ) Base Address */
+#define I2C1_BASE           (PERIPH_BASE + 0x5200)  /*!< (I2C1 ) Base Address */
+#define I2C2_BASE           (PERIPH_BASE + 0x5200)  /*!< (I2C2 ) Base Address */
+#define PWM_BASE(n)         (PERIPH_BASE + 0x5800 + ((n)<<4))
+#define PWM0_BASE           (PERIPH_BASE + 0x5800)  /*!< (PWM0 ) Base Address */
+#define PWM1_BASE           (PERIPH_BASE + 0x5810)  /*!< (PWM1 ) Base Address */
+#define PWM2_BASE           (PERIPH_BASE + 0x5820)  /*!< (PWM2 ) Base Address */
+#define PWM3_BASE           (PERIPH_BASE + 0x5830)  /*!< (PWM3 ) Base Address */
+#define PWM4_BASE           (PERIPH_BASE + 0x5840)  /*!< (PWM4 ) Base Address */
+#define PWM5_BASE           (PERIPH_BASE + 0x5850)  /*!< (PWM5 ) Base Address */
+#define PWM6_BASE           (PERIPH_BASE + 0x5860)  /*!< (PWM6 ) Base Address */
+#define PWM7_BASE           (PERIPH_BASE + 0x5870)  /*!< (PWM7 ) Base Address */
+#define PWM8_BASE           (PERIPH_BASE + 0x5880)  /*!< (PWM8 ) Base Address */
+#define TACH_BASE(n)        (PERIPH_BASE + 0x6000 + ((n)<<4))
+#define TACH0_BASE          (PERIPH_BASE + 0x6000)  /*!< (TACH0 ) Base Address */
+#define TACH1_BASE          (PERIPH_BASE + 0x6010)  /*!< (TACH1 ) Base Address */
+#define TACH2_BASE          (PERIPH_BASE + 0x6020)  /*!< (TACH2 ) Base Address */
+#define TACH3_BASE          (PERIPH_BASE + 0x6030)  /*!< (TACH3 ) Base Address */
+#define PECI_BASE           (PERIPH_BASE + 0x6400)  /*!< (PECI ) Base Address */
+#define HDMI_CEC_BASE       (PERIPH_BASE + 0x6800)  /*!< (HDMI_CEC ) Base Address */
+#define SPISLV_BASE         (PERIPH_BASE + 0x7000)  /*!< (SPISLV ) Base Address */
+#define RTMR_BASE           (PERIPH_BASE + 0x7400)  /*!< (RTMR ) Base Address */
+#define ADC_BASE            (PERIPH_BASE + 0x7C00)  /*!< (ADC ) Base Address */
+#define TFDP_BASE           (PERIPH_BASE + 0x8C00)  /*!< (TFDP ) Base Address */
+#define PS2_0_BASE          (PERIPH_BASE + 0x9000)  /*!< (PS2 0 ) Base Address */
+#define PS2_1_BASE          (PERIPH_BASE + 0x9040)  /*!< (PS2 1 ) Base Address */
+#define HTMR0_BASE          (PERIPH_BASE + 0x9800)  /*!< (HTMR0 ) Base Address */
+#define HTMR1_BASE          (PERIPH_BASE + 0x9820)  /*!< (HTMR1 ) Base Address */
+#define KEYSCAN_BASE        (PERIPH_BASE + 0x9C00)  /*!< (KEYSCAN ) Base Address */
+#define VBATR_BASE          (PERIPH_BASE + 0xA400)  /*!< (VBATR ) Base Address */
+#define VBATM_BASE          (PERIPH_BASE + 0xA800)  /*!< (VBATM ) Base Address */
+#define WKTMR_BASE          (PERIPH_BASE + 0xAC80)  /*!< (WKTMR ) Base Address */
+#define VCI_BASE            (PERIPH_BASE + 0xAE00)  /*!< (VCI ) Base Address */
+#define LED0_BASE           (PERIPH_BASE + 0xB800)  /*!< (BBLED0 ) Base Address */
+#define LED1_BASE           (PERIPH_BASE + 0xB900)  /*!< (BBLED1 ) Base Address */
+#define LED2_BASE           (PERIPH_BASE + 0xBA00)  /*!< (BBLED2 ) Base Address */
+#define ECIA_BASE           (PERIPH_BASE + 0xE000)  /*!< (ECIA ) Base Address */
+#define ECS_BASE            (PERIPH_BASE + 0xFC00)  /*!< (ECS ) Base Address */
+#define QMSPI_BASE          (PERIPH_BASE + 0x70000) /*!< (QMSPI0 ) Base Address */
+#define PCR_BASE            (PERIPH_BASE + 0x80100) /*!< (PCR ) Base Address */
+#define GPIO_BASE           (PERIPH_BASE + 0x81000) /*!< (GPIO ) Base Address */
+#define GPIO_CTRL_BASE      (GPIO_BASE)             /*!< (GPIO ) Control Base Address */
+#define GPIO_PARIN_BASE     (GPIO_BASE + 0x0300)    /*!< (GPIO Parallel I/O) Base Address */
+#define GPIO_PAROUT_BASE    (GPIO_BASE + 0x0380)    /*!< (GPIO Parallel I/O) Base Address */
+#define GPIO_LOCK_BASE      (GPIO_BASE + 0x03E8)    /*!< (GPIO Lock) Base Address */
+#define GPIO_CTRL2_BASE     (GPIO_BASE + 0x0500)    /*!< (GPIO ) Control2 Base Address */
+#define OTP_BASE            (PERIPH_BASE + 0x82000) /*!< (OTP ) Base Address */
+#define MBOX_BASE           (PERIPH_BASE + 0xF0000) /*!< (MBOX ) Base Address */
+#define KBC_BASE            (PERIPH_BASE + 0xF0400) /*!< (KBC ) Base Address */
+#define ACPI_EC_BASE(n)     (PERIPH_BASE + 0xF0800 + ((n)<<10))
+#define ACPI_EC0_BASE       (PERIPH_BASE + 0xF0800) /*!< (ACPI EC0 ) Base Address */
+#define ACPI_EC1_BASE       (PERIPH_BASE + 0xF0C00) /*!< (ACPI EC1 ) Base Address */
+#define ACPI_EC2_BASE       (PERIPH_BASE + 0xF1000) /*!< (ACPI EC2 ) Base Address */
+#define ACPI_EC3_BASE       (PERIPH_BASE + 0xF1400) /*!< (ACPI EC3 ) Base Address */
+#define ACPI_PM1_BASE       (PERIPH_BASE + 0xF1C00) /*!< (ACPI PM1 ) Base Address */
+#define PORT92_BASE         (PERIPH_BASE + 0xF2000) /*!< (PORT92 ) Base Address */
+#define UART_BASE(n)        (PERIPH_BASE + 0xF2400 + ((n)<<10))
+#define UART0_BASE          (PERIPH_BASE + 0xF2400) /*!< (UART0 ) Base Address */
+#define UART1_BASE          (PERIPH_BASE + 0xF2800) /*!< (UART1 ) Base Address */
+#define UART2_BASE          (PERIPH_BASE + 0xF2C00) /*!< (UART2 ) Base Address */
+#define ESPI_IO_BASE        (PERIPH_BASE + 0xF3400) /*!< (ESPI IO Component) Base Address */
+#define ESPI_IO_PC_BASE     ((ESPI_IO_BASE) + 0x100ul) /*!< (ESPI IO Peripheral Channel) Base Address */
+#define ESPI_IO_HOST_BAR_BASE   ((ESPI_IO_BASE) + 0x120ul) /*!< (ESPI IO Host IO BAR) Base Address */
+#define ESPI_IO_LTR_BASE    ((ESPI_IO_BASE) + 0x220ul) /*!< (ESPI IO LTR) Base Address */
+#define ESPI_IO_OOB_BASE    ((ESPI_IO_BASE) + 0x240ul) /*!< (ESPI IO Out-of-Band Channel) Base Address */
+#define ESPI_IO_FC_BASE     ((ESPI_IO_BASE) + 0x280ul) /*!< (ESPI IO Flash Channel) Base Address */
+#define ESPI_IO_CAP_BASE    ((ESPI_IO_BASE) + 0x2B0ul) /*!< (ESPI IO Capabilities) Base Address */
+#define ESPI_IO_EC_BAR_BASE ((ESPI_IO_BASE) + 0x334ul) /*!< (ESPI IO EC IO BAR) Base Address */
+#define ESPI_IO_VW_BASE     ((ESPI_IO_BASE) + 0x2B0ul) /*!< (ESPI IO EC IO VW registers) Base Address */
+#define ESPI_MEM_BASE       (PERIPH_BASE + 0xF3800)  /*!< (ESPI Memory Component) Base Address */
+#define EMI0_BASE           (PERIPH_BASE + 0xF4000)  /*!< (EMI0 ) Base Address */
+#define EMI1_BASE           (PERIPH_BASE + 0xF4400)  /*!< (EMI1 ) Base Address */
+#define RTC_BASE            (PERIPH_BASE + 0xF5000)  /*!< (RTC ) Base Address */
+#define P80CAP0_BASE        (PERIPH_BASE + 0xF8000)  /*!< (P80CAP0 ) Base Address */
+#define P80CAP1_BASE        (PERIPH_BASE + 0xF8400)  /*!< (P80CAP1 ) Base Address */
+#define ESPI_VW_BASE        (PERIPH_BASE + 0xF9C00)  /*!< (ESPI VW Component) Base Address */
+#define ESPI_SMVW_BASE      (ESPI_VW_BASE + 0x200ul)  /*!< (ESPI VW Component Slave-to-Master) Base Address */
+#define GCFG_BASE           (PERIPH_BASE + 0xFFF00)  /*!< (GCFG ) Base Address */
+
+
+/** @} */ /* End of group Device_Peripheral_peripheralAddr */
+
+#include "component/dma.h"
+#include "component/ecia.h"
+#include "component/ecs.h"
+#include "component/gpio.h"
+#include "component/espi_io.h"
+#include "component/espi_mem.h"
+#include "component/espi_vw.h"
+#include "component/led.h"
+#include "component/pcr.h"
+#include "component/smb.h"
+#include "component/timer.h"
+#include "component/uart.h"
+#include "component/vbat.h"
+#include "component/wdt.h"
+
+
+/* =========================================================================================================================== */
+/* ================                                  Peripheral declaration                                   ================ */
+/* =========================================================================================================================== */
+
+
+/** @addtogroup Device_Peripheral_declaration
+  * @{
+  */
+
+#define WDT_REGS        ((WDT_Type *) WDT_BASE)
+#define B16TMR0_REGS    ((BTMR_Type *) B16TMR0_BASE)
+#define B16TMR1_REGS    ((BTMR_Type *) B16TMR1_BASE)
+#define B32TMR0_REGS    ((BTMR_Type *) B32TMR0_BASE)
+#define B32TMR1_REGS    ((BTMR_Type *) B32TMR1_BASE)
+#define CCT_REGS        ((CCT_Type *) CCT_BASE)
+/* DMA Block including channels */
+#define DMA_REGS        ((DMA_Type *) DMA_BASE)
+/* Individual DMA channels */
+#define DMA0_REGS       ((DMA_CHAN_WCRC_Type *) DMA_CHAN_BASE(0))
+#define DMA1_REGS       ((DMA_CHAN_WMF_Type *) DMA_CHAN_BASE(1))
+#define DMA2_REGS       ((DMA_CHAN_Type *) DMA_CHAN_BASE(2))
+#define DMA3_REGS       ((DMA_CHAN_Type *) DMA_CHAN_BASE(3))
+#define DMA4_REGS       ((DMA_CHAN_Type *) DMA_CHAN_BASE(4))
+#define DMA5_REGS       ((DMA_CHAN_Type *) DMA_CHAN_BASE(5))
+#define DMA6_REGS       ((DMA_CHAN_Type *) DMA_CHAN_BASE(6))
+#define DMA7_REGS       ((DMA_CHAN_Type *) DMA_CHAN_BASE(7))
+#define DMA8_REGS       ((DMA_CHAN_Type *) DMA_CHAN_BASE(8))
+#define DMA9_REGS       ((DMA_CHAN_Type *) DMA_CHAN_BASE(9))
+#define DMA10_REGS      ((DMA_CHAN_Type *) DMA_CHAN_BASE(10))
+#define DMA11_REGS      ((DMA_CHAN_Type *) DMA_CHAN_BASE(11))
+
+#define SMB0_REGS       ((SMB_Type *) SMB0_BASE)
+#define SMB1_REGS       ((SMB_Type *) SMB1_BASE)
+#define SMB2_REGS       ((SMB_Type *) SMB2_BASE)
+#define SMB3_REGS       ((SMB_Type *) SMB3_BASE)
+#define SMB4_REGS       ((SMB_Type *) SMB4_BASE)
+
+#define RTMR_REGS       ((RTMR_Type *) RTMR_BASE)
+
+#define HTMR0_REGS      ((HTMR_Type *) HTMR0_BASE)
+#define HTMR1_REGS      ((HTMR_Type *) HTMR1_BASE)
+
+#define VBATR_REGS      ((VBATR_Type *) VBATR_BASE)
+#define VBATM_REGS      ((VBATM_Type *) VBATM_BASE)
+#define WKTMR_REGS      ((WKTMR_Type *) WKTMR_BASE)
+
+#define LED0_REGS       ((LED_Type *) LED0_BASE)
+#define LED1_REGS       ((LED_Type *) LED1_BASE)
+#define LED2_REGS       ((LED_Type *) LED2_BASE)
+
+#define ECIA_REGS       ((ECIA_Type *) ECIA_BASE)
+#define GIRQ08_REGS     ((GIRQ_Type *) ECIA_BASE)
+#define GIRQ09_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x14))
+#define GIRQ10_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x28))
+#define GIRQ11_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x3C))
+#define GIRQ12_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x50))
+#define GIRQ13_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x64))
+#define GIRQ14_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x78))
+#define GIRQ15_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x8C))
+#define GIRQ16_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0xA0))
+#define GIRQ17_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0xB4))
+#define GIRQ18_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0xC8))
+#define GIRQ19_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0xDC))
+#define GIRQ20_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0xF0))
+#define GIRQ21_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x104))
+#define GIRQ22_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x118))
+#define GIRQ23_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x12C))
+#define GIRQ24_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x140))
+#define GIRQ25_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x154))
+#define GIRQ26_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x168))
+
+#define ECS_REGS        ((ECS_Type *) ECS_BASE)
+
+#define QMSPI_REGS      ((QMSPI_Type *) QMSPI_BASE)
+
+#define PCR_REGS        ((PCR_Type *) PCR_BASE)
+
+#define GPIO_REGS       ((GPIO_Type *)(GPIO_BASE))
+
+#define UART0_REGS      ((UART_Type *) UART0_BASE)
+#define UART1_REGS      ((UART_Type *) UART1_BASE)
+#define UART2_REGS      ((UART_Type *) UART2_BASE)
+
+#define ESPI_PC_REGS        ((ESPI_IO_PC *)(ESPI_IO_PC_BASE))
+#define ESPI_HIO_BAR_REGS   ((ESPI_IO_BAR_HOST *)(ESPI_IO_HOST_BAR_BASE))
+#define ESPI_LTR_REGS       ((ESPI_IO_LTR *)(ESPI_IO_LTR_BASE))
+#define ESPI_OOB_REGS       ((ESPI_IO_OOB *)(ESPI_IO_OOB_BASE))
+#define ESPI_FC_REGS        ((ESPI_IO_FC *)(ESPI_IO_FC_BASE))
+#define ESPI_CAP_REGS       ((ESPI_IO_CAP *)(ESPI_IO_CAP_BASE))
+#define ESPI_EIO_BAR_REGS   ((ESPI_IO_BAR_EC *)(ESPI_IO_EC_BAR_BASE))
+
+#define ESPI_MEM_REGS   ((ESPI_MEM_Type *)(ESPI_MEM_BASE))
+
+/* eSPI Virtual Wire registers in IO component */
+#define ESPI_IO_VW_REGS      ((ESPI_IO_VW *) ESPI_IO_VW_BASE)
+/* eSPI Virtual Wire registers for each group of 4 VWires */
+#define ESPI_M2S_VW_REGS    ((ESPI_M2S_VW *) ESPI_VW_BASE)
+#define ESPI_S2M_VW_REGS    ((ESPI_S2M_VW *) (ESPI_SMVW_BASE))
+
+/** @} */ /* End of group MEC1501 */
+
+/** @} */ /* End of group MCHP */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* MEC1501HSZ_H */

--- a/ext/hal/microchip/mec/mec1501/component/dma.h
+++ b/ext/hal/microchip/mec/mec1501/component/dma.h
@@ -1,0 +1,359 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file dma.h
+ *MEC1501 DMA controller definitions
+ */
+/** @defgroup MEC1501 Peripherals DMA
+ */
+
+#ifndef _DMA_H
+#define _DMA_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#define NUM_DMA_CHANNELS            12ul
+
+#define DMA_BLOCK_BASE_ADDR         0x40002400ul
+#define DMA_CHAN_OFFSET             0x40
+#define DMA_CHAN_ADDR(n)            ((DMA_BLOCK_BASE_ADDR) + (((uint32_t)(n)+1) << 6))
+
+#define DMA_GIRQ_ID                 14
+#define DMA_GIRQ_SRC_ADDR           0x4000E078ul
+#define DMA_GIRQ_EN_SET_ADDR        0x4000E07Cul
+#define DMA_GIRQ_RESULT_ADDR        0x4000E080ul
+#define DMA_GIRQ_EN_CLR_ADDR        0x4000E084ul
+
+#define DMACH_GIRQ_NUM              14u
+#define DMACH_GIRQ_IDX              ((DMACH_GIRQ_NUM) - 8u)
+
+/*
+ * Value used for GIRQ Source, Set Enable,
+ * Result, and Clear Enable registers.
+ * 0 <= ch < 12
+ */
+#define DMACH_GIRQ_VAL(ch)           (1ul << (ch))
+
+/*
+ * DMA channel direct NVIC external interrupt inputs
+ * 0 <= ch < 12
+ */
+#define DMACH_DIRECT_NVIC_NUM(ch)   (24ul + (ch))
+
+
+//
+// Device Numbers for Channel Control Reg Device Number Field
+//
+#define DMA_DEVNUM_I2CSMB0_SLV      0ul
+#define DMA_DEVNUM_I2CSMB0_MTR      1ul
+#define DMA_DEVNUM_I2CSMB1_SLV      2ul
+#define DMA_DEVNUM_I2CSMB1_MTR      3ul
+#define DMA_DEVNUM_I2CSMB2_SLV      4ul
+#define DMA_DEVNUM_I2CSMB2_MTR      5ul
+#define DMA_DEVNUM_I2CSMB3_SLV      6ul
+#define DMA_DEVNUM_I2CSMB3_MTR      7ul
+#define DMA_DEVNUM_I2CSMB4_SLV      8ul
+#define DMA_DEVNUM_I2CSMB4_RX       9ul
+#define DMA_DEVNUM_QMSPI_TX         10ul
+#define DMA_DEVNUM_QMSPI_RX         11ul
+#define DMA_DEVNUM_MAX              12ul
+
+
+#define DMA_CHAN_REG_BLEN              0x40ul
+
+
+/* DMA Block Layout
+ * DMA Main registers start at block base
+ * Three registers located at word boundaries (0, 4, 8)
+ * Each channel starts at base + ((channel_number + 1) * DMA_CHAN_REG_BLEN)
+ * DMA Main @ base
+ * DMA Channel 0 @ base + DMA_CHAN_REG_BLEN
+ * DMA Channel 1 @ base + (2 * DMA_CHAN_REG_BLEN)
+ *
+ */
+
+/*
+ * DMA Main Registers
+ */
+#define DMAM_CTRL_OFS                       0x00
+#define DMAM_FDATA_RO_OFS                   0x04
+#define DMAM_FSM_RO_OFS                     0x08
+
+#define DMAM_CTRL_OFFSET                    0x00ul
+#define DMAM_CTRL_MASK                      0x03UL
+#define DMAM_CTRL_ENABLE                    (1UL << 0)
+#define DMAM_CTRL_SOFT_RESET                (1UL << 1)
+
+/*
+ * DMA channel register offsets
+ */
+#define DMA_ACT_OFS             0x00
+#define DMA_MSTART_ADDR_OFS     0x04
+#define DMA_MEND_ADDR_OFS       0x08
+#define DMA_DEV_ADDR_OFS        0x0C
+#define DMA_CNTL_OFS            0x10
+#define DMA_ISTS_OFS            0x14
+#define DMA_IEN_OFS             0x18
+#define DMA_FSM_RO_OFS          0x1C
+/* Channels with optional ALU */
+#define DMA_ALU_CNTL_OFS        0x20
+#define DMA_ALU_DATA_OFS        0x24
+#define DMA_ALU_STS_OFS         0x28
+
+/*
+ * Channel Activate, Offset 0x00, R/W
+ */
+#define DMACH_ACTIVATE_REG_OFS          0ul
+#define DMACH_ACTIVATE_REG_MASK         0x01ul
+#define DMACH_ACTIVATE_VAL              (1UL << 0)
+
+/*
+ * Target (destination) Start Memory Address, Offset 0x04
+ */
+#define DMACH_START_ADDR_REG_OFS        0x04ul
+#define DMACH_START_ADDR_REG_MASK       0xFFFFFFFFul
+
+/*
+ * Target (destination) End Memory Address, Offset 0x08
+ */
+#define DMACH_END_ADDR_REG_OFS          0x08ul
+#define DMACH_END_ADDR_REG_MASK         0xFFFFFFFFul
+
+/*
+ * Source (device) Address, Offset 0x0C
+ */
+#define DMACH_DEV_ADDR_REG_OFS          0x0Cul
+#define DMACH_DEV_ADDR_REG_MASK         0xFFFFFFFFul
+
+/*
+ * Control, Offset 0x10
+ */
+#define DMACH_C_REG_OFS             0x10ul
+#define DMACH_C_REG_MASK            0x037FFF3Ful
+#define DMACH_C_RUN                 (1UL << 0)
+#define DMACH_C_REQ_STS_RO          (1UL << 1)
+#define DMACH_C_DONE_STS_RO         (1UL << 2)
+#define DMACH_C_CHAN_STS_MASK       (0x03UL << 3)
+#define DMACH_C_BUSY_STS_POS        5u
+#define DMACH_C_BUSY_STS            (1UL << 5)
+#define DMACH_C_DIR_POS             8u
+#define DMACH_C_DEV2MEM             (0UL << 8)
+#define DMACH_C_MEM2DEV             (1UL << 8)
+#define DMACH_C_DEV_NUM_POS         9u
+#define DMACH_C_DEV_NUM_MASK0       0x7Ful
+#define DMACH_C_DEV_NUM_MASK        (0x7F << 9)
+#define DMACH_C_NO_INCR_MEM         (0UL << 16)
+#define DMACH_C_INCR_MEM            (1UL << 16)
+#define DMACH_C_NO_INCR_DEV         (0UL << 17)
+#define DMACH_C_INCR_DEV            (1UL << 17)
+#define DMACH_C_LOCK_CHAN           (1UL << 18)
+#define DMACH_C_DIS_HWFLC           (1UL << 19)
+#define DMACH_C_XFRU_POS            20u
+#define DMACH_C_XFRU_MASK0          0x07ul
+#define DMACH_C_XFRU_MASK           (0x07ul << 20)
+#define DMACH_C_XFRU_1B             (1UL << DMACH_C_XFRU_POS)
+#define DMACH_C_XFRU_2B             (2UL << DMACH_C_XFRU_POS)
+#define DMACH_C_XFRU_4B             (4UL << DMACH_C_XFRU_POS)
+#define DMACH_C_XFER_GO             (1UL << 24)
+#define DMACH_C_XFER_ABORT          (1UL << 25)
+/* combine direction and device number fields */
+#define DMACH_C_DEVDIR_POS          8
+#define DMACH_C_DEVDIR_MASK0        0xFF
+#define DMACH_C_DEVDIR_MASK         (0xFF << 8)
+
+/*
+ * Channel Interrupt Status, Offset 0x14
+ */
+#define DMACH_STS_REG_OFS           0x14ul
+#define DMACH_STS_REG_MASK          0x07ul
+#define DMACH_STS_BUS_ERR           (1UL << 0)
+#define DMACH_STS_FLOW_CTRL_ERR     (1UL << 1)
+#define DMACH_STS_DONE              (1UL << 2)
+#define DMACH_STS_ALL               0x07ul
+
+/*
+ * Channel Interrupt Enable, Offset 0x18
+ */
+#define DMACH_IEN_REG_OFS                   0x18ul
+#define DMACH_IEN_REG_MASK                  0x07ul
+#define DMACH_IEN_BUS_ERR                   (1UL << 0)
+#define DMACH_IEN_FLOW_CTRL_ERR             (1UL << 1)
+#define DMACH_IEN_DONE                      (1UL << 2)
+#define DMACH_IEN_ALL                       0x07ul
+
+/*
+ * Channel State, Offset 0x1C
+ */
+#define DMACH_STATE_REG_OFS                 0x1Cul
+#define DMACH_STATE_REG_MASK                0x0FFFFul
+
+/*
+ * DMA Block with optional ALU includes four extra registers.
+ * Channel's total register allocation is 0x40
+ */
+
+/*
+ * ALU Control, Offset 0x20
+ */
+#define DMACH_ALU_CTRL_OFS                  0x20ul
+#define DMACH_ALU_CTRL_MASK                 0x03ul
+#define DMACH_ALU_ENABLE_POS                0
+#define DMACH_ALU_MASK                      (1ul << (DMACH_ALU_ENABLE_POS))
+#define DMACH_ALU_DISABLE                   (0ul << (DMACH_ALU_ENABLE_POS))
+#define DMACH_ALU_ENABLE                    (1ul << (DMACH_ALU_ENABLE_POS))
+#define DMACH_ALU_POST_XFER_EN_POS          1
+#define DMACH_ALU_POST_XFER_EN_MASK         (1ul << (DMACH_ALU_POST_XFER_EN_POS))
+#define DMACH_ALU_POST_XFER_DIS             (0ul << (DMACH_ALU_POST_XFER_EN_POS))
+#define DMACH_ALU_POST_XFER_EN              (1ul << (DMACH_ALU_POST_XFER_EN_POS))
+
+/*
+ * ALU Data, Offset 0x24
+ */
+#define DMACH_ALU_DATA_OFS                  0x24ul
+#define DMACH_ALU_DATA_MASK                 0xFFFFFFFFul
+
+/*
+ * ALU Status, Offset 0x28 Read-Only
+ */
+#define DMACH_ALU_STS_OFS               0x28ul
+#define DMACH_ALU_STS_MASK              0x0Ful
+#define DMACH_ALU_STS_DONE_POS          0u
+#define DMACH_ALU_STS_RUN_POS           1u
+#define DMACH_ALU_STS_XFR_DONE_POS      2u
+#define DMACH_ALU_STS_DATA_RDY_POS      3u
+#define DMACH_ALU_STS_DONE              (1ul << (DMACH_ALU_STS_DONE_POS))
+#define DMACH_ALU_STS_RUN               (1ul << (DMACH_ALU_STS_RUN_POS))
+#define DMACH_ALU_STS_XFR_DONE          (1ul << (DMACH_ALU_STS_XFR_DONE_POS))
+#define DMACH_ALU_STS_DATA_RDY          (1ul << ((DMACH_ALU_STS_DATA_RDY_POS))
+
+/*
+ * ALU Test, Offset 0x2C Reserved
+ */
+#define DMACH_ALU_TEST_OFFSET               0x2Cul
+#define DMACH_ALU_TEST_MASK                 0xFFFFFFFFul
+
+/*
+ * Channel 0 has ALU for CRC32
+ * Channel 1 has ALU for memory fill
+ * Channels 2-11 do not implement an ALU
+ */
+#define DMA_NUM_CHAN            12
+#define DMA_CHAN_SPACING        0x40
+#define DMA_CHAN_SPACING_POF2   6
+
+#define DMA_CHAN_WCRC         0
+#define DMA_CHAN_WMF          1
+#define MAX_DMA_CHAN          12
+#define NUM_DMA_CHAN_NO_ALU   ((MAX_DMA_CHAN) - 2)
+/*
+ * NOTE: structure size is 0x40 (64) bytes as each channel
+ * is spaced every 0x40 bytes from DMA block base address.
+ */
+typedef struct
+{
+    __IOM uint8_t  ACTV;            /*!< (@ 0x00000000) DMA channel activate  */
+          uint8_t  RSVD1[3];
+    __IOM uint32_t MSTART;          /*!< (@ 0x00000004) DMA channel memory start address  */
+    __IOM uint32_t MEND;            /*!< (@ 0x00000008) DMA channel memory end address  */
+    __IOM uint32_t DSTART;          /*!< (@ 0x0000000C) DMA channel device start address  */
+    __IOM uint32_t CTRL;            /*!< (@ 0x00000010) DMA channel control  */
+    __IOM uint8_t  ISTS;            /*!< (@ 0x00000014) DMA channel interrupt status  */
+          uint8_t  RSVD2[3];
+    __IOM uint8_t  IEN;             /*!< (@ 0x00000018) DMA channel interrupt enable  */
+          uint8_t  RSVD3[3];
+    __IM  uint32_t FSM;             /*!< (@ 0x0000001C) DMA channel FSM (RO)  */
+    __IOM uint8_t  CRC_EN;          /*!< (@ 0x00000020) DMA channels [0-1] CRC Enable */
+          uint8_t  RSVD4[3];
+    __IOM uint32_t CRC_DATA;        /*!< (@ 0x00000024) DMA channels [0-1] CRC Data */
+    __IOM uint8_t  CRC_STS;         /*!< (@ 0x00000028) DMA channels [0-1] CRC post status (RO) */
+          uint8_t  RSVD5[3];
+    __IM  uint32_t CRC_FSM;         /*!< (@ 0x0000002C) DMA channels [0-1] CRC FSM (RO) */
+          uint8_t  RSVD6[16];       /* pad to 0x40(64) byte size */
+} DMA_CHAN_WCRC_Type; /* DMA Channel with CRC ALU */
+
+typedef struct
+{
+    __IOM uint8_t  ACTV;            /*!< (@ 0x00000000) DMA channel activate  */
+          uint8_t  RSVD1[3];
+    __IOM uint32_t MSTART;          /*!< (@ 0x00000004) DMA channel memory start address  */
+    __IOM uint32_t MEND;            /*!< (@ 0x00000008) DMA channel memory end address  */
+    __IOM uint32_t DSTART;          /*!< (@ 0x0000000C) DMA channel device start address  */
+    __IOM uint32_t CTRL;            /*!< (@ 0x00000010) DMA channel control  */
+    __IOM uint8_t  ISTS;            /*!< (@ 0x00000014) DMA channel interrupt status  */
+          uint8_t  RSVD2[3];
+    __IOM uint8_t  IEN;             /*!< (@ 0x00000018) DMA channel interrupt enable  */
+          uint8_t  RSVD3[3];
+    __IM  uint32_t FSM;             /*!< (@ 0x0000001C) DMA channel FSM (RO)  */
+    __IOM uint8_t  FILL_EN;         /*!< (@ 0x00000020) DMA channel 1 Memory Fill Enable */
+          uint8_t  RSVD4[3];
+    __IOM uint32_t FILL_DATA;       /*!< (@ 0x00000024) DMA channels 1 Memory Fill Data */
+    __IOM uint8_t  FILL_STS;        /*!< (@ 0x00000028) DMA channels 1 Memory Fill post status (RO) */
+          uint8_t  RSVD5[3];
+    __IM  uint32_t FILL_FSM;        /*!< (@ 0x0000002C) DMA channels 1 Memory Fill FSM (RO) */
+          uint8_t  RSVD6[16];       /* pad to 0x40(64) byte size */
+} DMA_CHAN_WMF_Type; /* DMA Channel with Memory Fill ALU */
+
+typedef struct
+{
+    __IOM uint8_t  ACTV;            /*!< (@ 0x00000000) DMA channel activate  */
+          uint8_t  RSVD1[3];
+    __IOM uint32_t MSTART;          /*!< (@ 0x00000004) DMA channel memory start address  */
+    __IOM uint32_t MEND;            /*!< (@ 0x00000008) DMA channel memory end address  */
+    __IOM uint32_t DSTART;          /*!< (@ 0x0000000C) DMA channel device start address  */
+    __IOM uint32_t CTRL;            /*!< (@ 0x00000010) DMA channel control  */
+    __IOM uint8_t  ISTS;            /*!< (@ 0x00000014) DMA channel interrupt status  */
+          uint8_t  RSVD2[3];
+    __IOM uint8_t  IEN;             /*!< (@ 0x00000018) DMA channel interrupt enable  */
+          uint8_t  RSVD3[3];
+    __IM  uint32_t FSM;             /*!< (@ 0x0000001C) DMA channel FSM (RO)  */
+          uint8_t  RSVD4[0x20];     /* pad to 0x40(64) byte size */
+} DMA_CHAN_Type; /* DMA Channel with no ALU */
+
+typedef union {
+    DMA_CHAN_WCRC_Type  CHWCRC;     /* Channel with CRC-32 ALU */
+    DMA_CHAN_WMF_Type   CHWMF;      /* Channel with Memory Fill ALU */
+    DMA_CHAN_Type       CHNALU;     /* Channel without ALU */
+} DMA_CHAN;
+
+/**
+  * @brief DMA Block(DMA)
+  */
+typedef struct
+{                           /*!< (@ 0x40002400) DMA Structure        */
+  __IOM uint8_t  ACTRST;    /*!< (@ 0x00000000) DMA block activate/reset */
+        uint8_t  RSVDA[3];
+  __IOM uint32_t DATA_PKT;  /*!< (@ 0x00000004) DMA data packet (RO) */
+  __IOM uint32_t ARB_FSM;   /*!< (@ 0x00000008) DMA Arbiter FSM (RO) */
+        uint32_t RSVDB[13];
+    DMA_CHAN     CHAN[DMA_NUM_CHAN]; /*!< (@ 0x00000040 - 0x0000027F) DMA Channels 0 - 11 */
+} DMA_Type;
+
+#endif // #ifndef _DMA_H
+/* end dma.h */
+/**   @}
+ */

--- a/ext/hal/microchip/mec/mec1501/component/ecia.h
+++ b/ext/hal/microchip/mec/mec1501/component/ecia.h
@@ -1,0 +1,107 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file mec1501_ecia.h
+ *MEC1501 EC Interrupt Aggregator Subsystem definitions
+ */
+/** @defgroup MEC1501 Peripherals ECIA
+ */
+
+#ifndef _ECIA_H
+#define _ECIA_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+
+#define MEC_ECIA_ADDR   0x4000E000
+#define MEC_FIRST_GIRQ  8
+#define MEC_LAST_GIRQ   26
+
+#define MEC_ECIA_GIRQ_NO_NVIC   22
+
+#define MEC_ECIA_AGGR_BITMAP ((1ul << 8) + (1ul << 9) + (1ul << 10) +\
+                                (1ul << 11) + (1ul << 12) + (1ul << 24) +\
+                                (1ul << 25) + (1ul << 26))
+
+#define MEC_ECIA_DIRECT_BITMAP  ((1ul << 13) + (1ul << 14) +\
+                                     (1ul << 15) + (1ul << 16) +\
+                                     (1ul << 17) + (1ul << 18) +\
+                                     (1ul << 19) + (1ul << 21) +\
+                                     (1ul << 23))
+
+/*
+ * ARM Cortex-M4 NVIC registers
+ * External sources are grouped by 32-bit registers.
+ * MEC15xx has 173 external sources requiring 6 32-bit registers.
+  */
+#define MEC_NUM_NVIC_REGS           6
+#define MEC_NVIC_SET_EN_BASE        0xE000E100
+#define MEC_NVIC_CLR_EN_BASE        0xE000E180
+#define MEC_NVIC_SET_PEND_BASE      0xE000E200
+#define MEC_NVIC_CLR_PEND_BASE      0xE000E280
+#define MEC_NVIC_ACTIVE_BASE        0xE000E800
+#define MEC_NVIC_PRI_BASE           0xE000E400
+
+/* =========================================================================*/
+/* ================            ECIA                        ================ */
+/* =========================================================================*/
+
+/**
+  * @brief EC Interrupt Aggregator (ECIA)
+  */
+#define GIRQ_START_NUM              8
+#define GIRQ_LAST_NUM               26
+#define GIRQ_IDX(girq)              ((girq) - 8)
+#define GIRQ_IDX_FIRST              0
+#define GIRQ_IDX_MAX                19
+#define MAX_NVIC_IDX                6
+
+/* size = 0x14(20) bytes */
+typedef struct
+{
+    __IOM uint32_t SRC;
+    __IOM uint32_t EN_SET;
+    __IOM uint32_t RESULT;
+    __IOM uint32_t EN_CLR;
+          uint8_t  RSVD1[4];
+} GIRQ_Type;
+
+typedef struct
+{               /*!< (@ 0x4000E000) ECIA Structure   */
+    GIRQ_Type       GIRQ[GIRQ_IDX_MAX]; /*! (@ 0x00000000) GIRQ08 - GIRQ26 */
+          uint8_t   RSVD2[(0x200 - ((GIRQ_IDX_MAX) * (20)))]; /* offsets 0x0180 - 0x1FF */
+    __IOM uint32_t  BLK_EN_SET;         /*! (@ 0x00000200) Aggregated GIRQ output Enable Set */
+    __IOM uint32_t  BLK_EN_CLR;         /*! (@ 0x00000204) Aggregated GIRQ output Enable Clear */
+    __IM  uint32_t  BLK_ACTIVE;         /*! (@ 0x00000204) GIRQ Active (RO) */
+} ECIA_Type;
+
+#endif // #ifndef _ECIA_H
+/* end ecia.h */
+/**   @}
+ */
+
+

--- a/ext/hal/microchip/mec/mec1501/component/ecs.h
+++ b/ext/hal/microchip/mec/mec1501/component/ecs.h
@@ -1,0 +1,166 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file ecs.h
+ *MEC1501 EC Subsystem (ECS) registers
+ */
+/** @defgroup MEC1501 Peripherals ECS
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifndef _ECS_H
+#define _ECS_H
+
+/* =========================================================================*/
+/* ================            ECS                         ================ */
+/* =========================================================================*/
+
+#define ECS_AHB_ERR_CTRL_DIS_POS    (1ul << 0)
+#define ECS_AHB_ERR_CTRL_DIS        (1ul << (ECS_AHB_ERR_CTRL_DIS_POS))
+
+#define ECS_INTR_CNTL_DIRECT_POS    0
+#define ECS_INTR_CNTL_DIRECT_EN     (1ul << (ECS_INTR_CNTL_DIRECT_POS))
+
+#define ECS_ETM_CTRL_EN_POS         0
+#define ECS_ETM_CTRL_EN             (1ul << (ECS_ETM_CTRL_EN_POS))
+
+#define ECS_DBG_CTRL_MASK           0x1Ful
+#define ECS_DBG_CTRL_DBG_EN_POS     0
+#define ECS_DBG_CTRL_DBG_EN         (1ul << (ECS_DBG_CTRL_DBG_EN_POS))
+#define ECS_DBG_CTRL_MODE_POS       1
+#define ECS_DBG_CTRL_MODE_MASK0     0x03
+#define ECS_DBG_CTRL_MODE_MASK      ((ECS_DBG_CTRL_DBG_MODE_MASK0) << (ECS_DBG_CTRL_DBG_MODE_POS))
+#define ECS_DBG_CTRL_MODE_JTAG      (0x00 << (ECS_DBG_CTRL_DBG_MODE_POS))
+#define ECS_DBG_CTRL_MODE_SWD       (0x02 << (ECS_DBG_CTRL_DBG_MODE_POS))
+#define ECS_DBG_CTRL_MODE_SWD_SWV   (0x01 << (ECS_DBG_CTRL_DBG_MODE_POS))
+#define ECS_DBG_CTRL_PUEN_POS       3
+#define ECS_DBG_CTRL_PUEN           (1ul << (ECS_DBG_CTRL_PUEN_POS))
+#define ECS_DBG_CTRL_BSCAN_POS      4
+#define ECS_DBG_CTRL_BSCAN_EN       (1ul << (ECS_DBG_CTRL_BSCAN_POS))
+
+#define ECS_AESH_BSWAP_MASK         0xFFul
+#define ECS_DW_SWAP_IN_POS          0
+#define ECS_DW_SWAP_IN_EN           (1ul << (ECS_DW_SWAP_IN_POS))
+#define ECS_DW_SWAP_OUT_POS         1
+#define ECS_DW_SWAP_OUT_EN          (1ul << (ECS_DW_SWAP_OUT_POS))
+#define ECS_BLK_SWAP_IN_POS         2
+#define ECS_BLK_SWAP_IN_MASK        (0x07 << (ECS_BLK_SWAP_IN_POS))
+#define ECS_BLK_SWAP_IN_DIS         (0x00 << (ECS_BLK_SWAP_IN_POS))
+#define ECS_BLK_SWAP_IN_8B          (0x01 << (ECS_BLK_SWAP_IN_POS))
+#define ECS_BLK_SWAP_IN_16B         (0x02 << (ECS_BLK_SWAP_IN_POS))
+#define ECS_BLK_SWAP_IN_64B         (0x03 << (ECS_BLK_SWAP_IN_POS))
+#define ECS_BLK_SWAP_IN_128B        (0x04 << (ECS_BLK_SWAP_IN_POS))
+#define ECS_BLK_SWAP_OUT_POS        5
+#define ECS_BLK_SWAP_OUT_MASK       (0x07 << (ECS_BLK_SWAP_OUT_POS))
+#define ECS_BLK_SWAP_OUT_DIS        (0x00 << (ECS_BLK_SWAP_OUT_POS))
+#define ECS_BLK_SWAP_OUT_8B         (0x01 << (ECS_BLK_SWAP_OUT_POS))
+#define ECS_BLK_SWAP_OUT_16B        (0x02 << (ECS_BLK_SWAP_OUT_POS))
+#define ECS_BLK_SWAP_OUT_64B        (0x03 << (ECS_BLK_SWAP_OUT_POS))
+#define ECS_BLK_SWAP_OUT_128B       (0x04 << (ECS_BLK_SWAP_OUT_POS))
+
+/* EC Subystem GPIO Bank Power */
+#define ECS_GBPWR_LOCK_POS          7
+#define ECS_GBPWR_LOCK              (1ul << (ECS_GBPWR_LOCK_POS))
+#define ECS_VTR3_LVL_POS            2
+#define ECS_VTR3_LVL_18             (1ul << (ECS_VTR3_LVL_POS))
+#define ECS_VTR2_LVL_POS            1
+#define ECS_VTR2_LVL_18             (1ul << (ECS_VTR2_LVL_POS))
+
+/* EC Subsystem Comparator Control */
+#define ECS_CC_CMP0_EN_POS          0
+#define ECS_CC_CMP0_EN              (1ul  << (ECS_CC_CMP0_EN_POS))
+#define ECS_CC_CMP0_CFG_LOCK_POS    2
+#define ECS_CC_CMP0_CFG_LOCK        (1ul << (ECS_CC_CMP0_CFG_LOCK_POS))
+#define ECS_CC_CMP1_EN_POS          4
+#define ECS_CC_CMP1_EN              (1ul << (ECS_CC_CMP1_EN_POS))
+
+/* EC Subsystem Comparator Sleep Control */
+#define ECS_CSC_CMP0_SLP_EN_POS     0
+#define ECS_CSC_CMP0_SLP_EN         (1ul << (ECS_CSC_CMP0_SLP_EN_POS))
+#define ECS_CSC_CMP1_SLP_EN_POS     1
+#define ECS_CSC_CMP1_SLP_EN         (1ul << (ECS_CSC_CMP1_SLP_EN_POS))
+
+/**
+  * @brief EC Subsystem (ECS)
+  */
+typedef struct
+{                               /*!< (@ 0x4000FC00) ECS Structure   */
+    __IOM uint8_t   RSVD1[4];
+    __IOM uint32_t  AHB_ERR_ADDR;       /*!< (@ 0x0004) ECS AHB Error Address */
+    __IOM uint32_t  TEST08;
+    __IOM uint32_t  TEST0C;
+    __IOM uint32_t  TEST10;
+    __IOM uint32_t  AHB_ERR_CTRL;       /*!< (@ 0x0014) ECS AHB Error Control */
+    __IOM uint32_t  INTR_CTRL;          /*!< (@ 0x0018) ECS Interupt Control */
+    __IOM uint32_t  ETM_CTRL;           /*!< (@ 0x001C) ECS ETM Trace Control */
+    __IOM uint32_t  DEBUG_CTRL;         /*!< (@ 0x0020) ECS Debug Control */
+    __IOM uint32_t  OTP_LOCK;           /*!< (@ 0x0024) ECS OTP Lock Enable */
+    __IOM uint32_t  WDT_CNT;            /*!< (@ 0x0028) ECS WDT Event Count */
+    __IOM uint32_t  AESH_BSWAP_CTRL;    /*!< (@ 0x002C) ECS AES-Hash Byte Swap Control */
+    __IOM uint32_t  TEST30;
+    __IOM uint32_t  TEST34;
+    __IOM uint32_t  ADC_VREF_PWRDN;     /*!< (@ 0x0038) ECS ADC Vref Power Down */
+    __IOM uint32_t  TEST3C;
+    __IOM uint32_t  PECI_DIS;           /*!< (@ 0x0040) ECS PECI Disable */
+    __IOM uint32_t  GPIO_PAD_TST;       /*!< (@ 0x0044) ECS GPIO Pad Test */
+    __IOM uint32_t  SMBUS_SW_EN0;       /*!< (@ 0x0048) ECS SMBus SW Enable 0 */
+    __IOM uint32_t  STAP_TMIR;          /*!< (@ 0x004C) ECS STAP Test Mirror */
+    __IOM uint32_t  VCI_FW_OVR;         /*!< (@ 0x0050) ECS VCI FW Override */
+    __IOM uint32_t  BROM_STS;           /*!< (@ 0x0054) ECS Boot-ROM Status */
+          uint8_t   RSVD2[4];
+    __IOM uint32_t  CRYPTO_SRST;        /*!< (@ 0x005C) ECS Crypto HW Soft Reset */
+    __IOM uint32_t  TEST60;
+    __IOM uint32_t  GPIO_BANK_PWR;      /*!< (@ 0x0064) ECS GPIO Bank Power Select */
+    __IOM uint32_t  TEST68;
+    __IOM uint32_t  TEST6C;
+    __IOM uint32_t  JTAG_MCFG;          /*!< (@ 0x0070) ECS JTAG Master Config */
+    __IOM uint32_t  JTAG_MSTS;          /*!< (@ 0x0074) ECS JTAG Master Status */
+    __IOM uint32_t  JTAG_MTDO;          /*!< (@ 0x0078) ECS JTAG Master TDO */
+    __IOM uint32_t  JTAG_MTDI;          /*!< (@ 0x007C) ECS JTAG Master TDI */
+    __IOM uint32_t  JTAG_MTMS;          /*!< (@ 0x0080) ECS JTAG Master TMS */
+    __IOM uint32_t  JTAG_MCMD;          /*!< (@ 0x0084) ECS JTAG Master Command */
+          uint8_t   RSVD3[8];
+    __IOM uint32_t  VW_FW_OVR;          /*!< (@ 0x0090) ECS VWire FW Override */
+    __IOM uint32_t  CMP_CTRL;           /*!< (@ 0x0094) ECS Analog Comparator Control */
+    __IOM uint32_t  CMP_SLP_CTRL;       /*!< (@ 0x0098) ECS Analog Comparator Sleep Control */
+          uint8_t   RSVD4[(0xF0 - 0x9C)];
+    __IOM uint32_t  IP_TRIM;            /*!< (@ 0x00F0) ECS IP Trim */
+          uint8_t   RSVD5[12];
+    __IOM uint32_t  TEST100;
+          uint8_t   RSVD6[(0x180 - 0x94)];
+    __IOM uint32_t  FW_SCR0;            /*!< (@ 0x0180) ECS FW Scratch 0 */
+    __IOM uint32_t  FW_SCR1;            /*!< (@ 0x0180) ECS FW Scratch 1 */
+    __IOM uint32_t  FW_SCR2;            /*!< (@ 0x0180) ECS FW Scratch 2 */
+    __IOM uint32_t  FW_SCR3;            /*!< (@ 0x0180) ECS FW Scratch 3 */
+} ECS_Type;
+
+#endif // #ifndef _ECS_H
+/* end ecs.h */
+/**   @}
+ */
+

--- a/ext/hal/microchip/mec/mec1501/component/espi_io.h
+++ b/ext/hal/microchip/mec/mec1501/component/espi_io.h
@@ -1,0 +1,353 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file espi_io.h
+ *MEC1501 eSPI IO Component definitions
+ */
+/** @defgroup MEC1501 Peripherals eSPI IO Component
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifndef _ESPI_IO_H
+#define _ESPI_IO_H
+
+
+/*------------------------------------------------------------------*/
+
+/* eSPI Global Capabilities 0 */
+#define ESPI_GBL_CAP0_MASK          0x0Fu
+#define ESPI_GBL_CAP0_PC_SUPP       (1u << 0)
+#define ESPI_GBL_CAP0_VW_SUPP       (1u << 1)
+#define ESPI_GBL_CAP0_OOB_SUPP      (1u << 2)
+#define ESPI_GBL_CAP0_FC_SUPP       (1u << 3)
+
+/* eSPI Global Capabilities 1 */
+#define ESPI_GBL_CAP1_MASK              0xFFu
+#define ESPI_GBL_CAP1_MAX_FREQ_POS      0u
+#define ESPI_GBL_CAP1_MAX_FREQ_MASK     0x07u
+#define ESPI_GBL_CAP1_MAX_FREQ_20M      0x00u
+#define ESPI_GBL_CAP1_MAX_FREQ_25M      0x01u
+#define ESPI_GBL_CAP1_MAX_FREQ_33M      0x02u
+#define ESPI_GBL_CAP1_MAX_FREQ_50M      0x03u
+#define ESPI_GBL_CAP1_MAX_FREQ_66M      0x04u
+#define ESPI_GBL_CAP1_ALERT_POS         3 /* Read-Only */
+#define ESPI_GBL_CAP1_ALERT_DED_PIN     (1u << (ESPI_GBL_CAP1_ALERT_POS))
+#define ESPI_GBL_CAP1_ALERT_ON_IO1      (0u << (ESPI_GBL_CAP1_ALERT_POS))
+#define ESPI_GBL_CAP1_IO_MODE_POS       4
+#define ESPI_GBL_CAP1_IO_MODE_MASK0     0x03u
+#define ESPI_GBL_CAP1_IO_MODE_MASK      ((ESPI_GBL_CAP1_IO_MODE_MASK0) << (ESPI_GBL_CAP1_IO_MODE_POS))
+#define ESPI_GBL_CAP1_IO_MODE0_1        0u
+#define ESPI_GBL_CAP1_IO_MODE0_12       1u
+#define ESPI_GBL_CAP1_IO_MODE0_14       2u
+#define ESPI_GBL_CAP1_IO_MODE0_124      3u
+#define ESPI_GBL_CAP1_IO_MODE_1         ((ESPI_GBL_CAP1_IO_MODE0_1) << (ESPI_GBL_CAP1_IO_MODE_POS))
+#define ESPI_GBL_CAP1_IO_MODE_12        ((ESPI_GBL_CAP1_IO_MODE0_12) << (ESPI_GBL_CAP1_IO_MODE_POS))
+#define ESPI_GBL_CAP1_IO_MODE_14        ((ESPI_GBL_CAP1_IO_MODE0_14) << (ESPI_GBL_CAP1_IO_MODE_POS))
+#define ESPI_GBL_CAP1_IO_MODE_124       ((ESPI_GBL_CAP1_IO_MODE0_124) << (ESPI_GBL_CAP1_IO_MODE_POS))
+/*
+ * Support Open Drain ALERT pin configuration
+ * EC sets this bit if it can support open-drain ESPI_ALERT#
+ */
+#define ESPI_GBL_CAP1_ALERT_ODS_POS     6u
+#define ESPI_GBL_CAP1_ALERT_ODS         (1u << (ESPI_GBL_CAP1_ALERT_ODS_POS))
+/*
+ * Read-Only ALERT Open Drain select.
+ * If EC has indicated it can support open-drain ESPI_ALERT# then
+ * the Host can enable open-drain ESPI_ALERT# by sending a configuraiton
+ * message. This read-only bit relects the configuration selection.
+ */
+#define ESPI_GBL_CAP1_ALERT_ODS_SEL_POS 7u
+#define ESPI_GBL_CAP1_ALERT_SEL_ODS     (1u << (ESPI_GBL_CAP1_ALERT_ODS_SEL_POS))
+
+/* Peripheral Channel(PC) Capabilites */
+#define ESPI_PC_CAP_MASK                0x07u
+#define ESPI_PC_CAP_MAX_PLD_SZ_MASK     0x07u
+#define ESPI_PC_CAP_MAX_PLD_SZ_64       0x01u
+#define ESPI_PC_CAP_MAX_PLD_SZ_128      0x02u
+#define ESPI_PC_CAP_MAX_PLD_SZ_256      0x03u
+
+/* Virtual Wire(VW) Capabilities */
+#define ESPI_VW_CAP_MASK                0x3Fu
+#define ESPI_VW_CAP_MAX_VW_CNT_MASK     0x3Fu
+
+/* Out-of-Band(OOB) Capabilities */
+#define ESPI_OOB_CAP_MASK               0x07u
+#define ESPI_OOB_CAP_MAX_PLD_SZ_MASK    0x07u
+#define ESPI_OOB_CAP_MAX_PLD_SZ_73      0x01u
+#define ESPI_OOB_CAP_MAX_PLD_SZ_137     0x02u
+#define ESPI_OOB_CAP_MAX_PLD_SZ_265     0x03u
+
+/* Flash Channel(FC) Capabilities */
+#define ESPI_FC_CAP_MASK                0xFFu
+#define ESPI_FC_CAP_MAX_PLD_SZ_MASK     0x07u
+#define ESPI_FC_CAP_MAX_PLD_SZ_64       0x01u
+#define ESPI_FC_CAP_SHARE_POS           3u
+#define ESPI_FC_CAP_SHARE_MASK0         0x03u
+#define ESPI_FC_CAP_SHARE_MASK          ((ESPI_FC_CAP_SHARE_MASK0) << (ESPI_FC_CAP_SHARE_POS))
+#define ESPI_FC_CAP_SHARE_MAF_ONLY      (0u << (ESPI_FC_CAP_SHARE_POS))
+#define ESPI_FC_CAP_SHARE_MAF2_ONLY     (1u << (ESPI_FC_CAP_SHARE_POS))
+#define ESPI_FC_CAP_SHARE_SAF_ONLY      (2u << (ESPI_FC_CAP_SHARE_POS))
+#define ESPI_FC_CAP_SHARE_MAF_SAF       (3u << (ESPI_FC_CAP_SHARE_POS))
+#define ESPI_FC_CAP_MAX_RD_SZ_POS       5u
+#define ESPI_FC_CAP_MAX_RD_SZ_MASK0     0x07u
+#define ESPI_FC_CAP_MAX_RD_SZ_MASK      ((ESPI_FC_CAP_MAX_RD_SZ_MASK0) << (ESPI_FC_CAP_MAX_RD_SZ_POS))
+#define ESPI_FC_CAP_MAX_RD_SZ_64        ((0x01u) << (ESPI_FC_CAP_MAX_RD_SZ_POS))
+
+/* PC Ready */
+#define ESPI_PC_READY_MASK              0x01u;
+#define ESPI_PC_READY                   0x01u;
+
+/* OOB Ready */
+#define ESPI_OOB_READY_MASK             0x01u;
+#define ESPI_OOB_READY                  0x01u;
+
+/* FC Ready */
+#define ESPI_FC_READY_MASK              0x01u;
+#define ESPI_FC_READY                   0x01u;
+
+/* ESPI_RESET# Interrupt Status */
+#define ESPI_RST_ISTS_MASK              0x03u;
+#define ESPI_RST_ISTS_POS               0u
+#define ESPI_RST_ISTS                   (1u << (ESPI_RST_ISTS_POS))
+#define ESPI_RST_ISTS_PIN_RO_POS        1ul
+#define ESPI_RST_ISTS_PIN_RO_HI         (1u << (ESPI_RST_ISTS_PIN_RO_POS))
+
+/* ESPI_RESET# Interrupt Enable */
+#define ESPI_RST_IEN_MASK               0x01
+#define ESPI_RST_IEN                    0x01
+
+/* eSPI Platform Reset Source */
+#define ESPI_PLTRST_SRC_MASK            0x01
+#define ESPI_PLTRST_SRC_POS             0
+#define ESPI_PLTRST_SRC_IS_PIN          0x01
+#define ESPI_PLTRST_SRC_IS_VW           0x00
+
+/* VW Ready */
+#define ESPI_VW_READY_MASK              0x01u;
+#define ESPI_VW_READY                   0x01u;
+
+/* VW Error Status */
+#define ESPI_VW_ERR_STS_MASK                0x33u
+#define ESPI_VW_ERR_STS_FATAL_POS           0u
+#define ESPI_VW_ERR_STS_FATAL_RO            (1u << (ESPI_VW_ERR_STS_FATAL_POS))
+#define ESPI_VW_ERR_STS_FATAL_CLR_POS       1u
+#define ESPI_VW_ERR_STS_FATAL_CLR_WO        (1u << (ESPI_VW_ERR_STS_FATAL_CLR_POS))
+#define ESPI_VW_ERR_STS_NON_FATAL_POS       4u
+#define ESPI_VW_ERR_STS_NON_FATAL_RO        (1u << (ESPI_VW_ERR_STS_NON_FATAL_POS))
+#define ESPI_VW_ERR_STS_NON_FATAL_CLR_POS   5u
+#define ESPI_VW_ERR_STS_NON_FATAL_CLR_WO    (1u << (ESPI_VW_ERR_STS_NON_FATAL_CLR_POS))
+
+/* VW Channel Enable Status */
+#define ESPI_VW_EN_STS_MASK                 0x01u
+#define ESPI_VW_EN_STS_RO                   0x01u
+
+/* =========================================================================*/
+/* ================           eSPI IO Component            ================ */
+/* =========================================================================*/
+
+/**
+  * @brief ESPI Host interface IO Component (ESPI_IO)
+  */
+
+/* IO BAR indices */
+#define ESPI_IO_BAR_IOC     0
+#define ESPI_IO_BAR_MEMC    1
+#define ESPI_IO_BAR_MBOX    2
+#define ESPI_IO_BAR_KBC     3
+#define ESPI_IO_BAR_AEC0    4
+#define ESPI_IO_BAR_AEC1    5
+#define ESPI_IO_BAR_AEC2    6
+#define ESPI_IO_BAR_AEC3    7
+#define ESPI_IO_BAR_RSVD8   8
+#define ESPI_IO_BAR_PM1     9
+#define ESPI_IO_BAR_PORT92  10
+#define ESPI_IO_BAR_UART0   11
+#define ESPI_IO_BAR_UART1   12
+#define ESPI_IO_BAR_EMI0    13
+#define ESPI_IO_BAR_EMI1    14
+#define ESPI_IO_BAR_RSVD15  15
+#define ESPI_IO_BAR_P80CAP0 16
+#define ESPI_IO_BAR_P80CAP1 17
+#define ESPI_IO_BAR_RTC     18
+#define ESPI_IO_BAR_ASIF    19
+#define ESPI_IO_BAR_32B     20
+#define ESPI_IO_BAR_UART2   21
+#define ESPI_IO_BAR_GLUE    22
+#define ESPI_IO_BAR_MAX     23
+
+/* SERIRQ indices */
+#define ESPI_SIRQ_MBOX_SIRQ     0
+#define ESPI_SIRQ_MBOX_SMI      1
+#define ESPI_SIRQ_KBC_KIRQ      2
+#define ESPI_SIRQ_KBC_MIRQ      3
+#define ESPI_SIRQ_ACPI_EC0      4
+#define ESPI_SIRQ_ACPI_EC1      5
+#define ESPI_SIRQ_ACPI_EC2      6
+#define ESPI_SIRQ_ACPI_EC3      7
+#define ESPI_SIRQ_RSVD8         8
+#define ESPI_SIRQ_UART0         9
+#define ESPI_SIRQ_UART1         10
+#define ESPI_SIRQ_EMI0_HOST     11
+#define ESPI_SIRQ_EMI0_E2H      12
+#define ESPI_SIRQ_EMI1_HOST     13
+#define ESPI_SIRQ_EMI1_E2H      14
+#define ESPI_SIRQ_RSVD15        15
+#define ESPI_SIRQ_RSVD16        16
+#define ESPI_SIRQ_RTC           17
+#define ESPI_SIRQ_EC            18
+#define ESPI_SIRQ_UART2         19
+#define ESPI_SIRQ_MAX           20
+
+/*
+ * ESPI_IO_CAP - eSPI IO capabilities, channel ready, activate,
+ * EC 
+ * registers @ 0x400F36B0
+ */
+typedef struct
+{
+   __IOM uint32_t   VW_EN_STS;                   /*! (@ 0x36B0) Virtual Wire Enable Status */
+          uint8_t       RSVD1[0x36E0 - 0x36B4];
+    __IOM uint8_t   CAP_ID;                      /*! (@ 0x36E0) Capabilities ID */
+    __IOM uint8_t   GLB_CAP0;                    /*! (@ 0x36E1) Global Capabilities 0 */
+    __IOM uint8_t   GLB_CAP1;                    /*! (@ 0x36E2) Global Capabilities 1 */
+    __IOM uint8_t   PC_CAP;                      /*! (@ 0x3633) Periph Chan Capabilities */
+    __IOM uint8_t   VW_CAP;                      /*! (@ 0x3634) Virtual Wire Chan Capabilities */
+    __IOM uint8_t   OOB_CAP;                     /*! (@ 0x3635) OOB Chan Capabilities */
+    __IOM uint8_t   FC_CAP;                      /*! (@ 0x3636) Flash Chan Capabilities */
+    __IOM uint8_t   PC_RDY;                      /*! (@ 0x3637) PC ready */
+    __IOM uint8_t   OOB_RDY;                     /*! (@ 0x3638) OOB ready */
+    __IOM uint8_t   FC_RDY;                      /*! (@ 0x3639) OOB ready */
+    __IOM uint8_t   ERST_STS;                    /*! (@ 0x363A) eSPI Reset interrupt status */
+    __IOM uint8_t   ERST_IEN;                    /*! (@ 0x363B) eSPI Reset interrupt enable */
+    __IOM uint8_t   PLTRST_SRC;                  /*! (@ 0x363C) Platform Reset Source */
+    __IOM uint8_t   VW_RDY;                      /*! (@ 0x363D) VW ready */
+          uint8_t       RSVD2[0x3730 - 0x36EE];
+    __IOM uint32_t  ACTV;                        /*! (@ 0x3730) eSPI IO activate */
+          uint8_t       RSVD3[0x37F0 - 0x3734];
+    __IOM uint32_t  VW_ERR_STS;                  /*! (@ 0x37F0) IO Virtual Wire Error */
+} ESPI_IO_CAP;
+
+/*
+ * ESPI_IO_PC - eSPI IO Peripheral Channel registers @ 0x400F3500
+ */
+typedef struct
+{
+    __IOM uint32_t      PC_LC_ADDR_LSW;              /*! (@ 0x00000100) Periph Chan Last Cycle address LSW */
+    __IOM uint32_t      PC_LC_ADDR_MSW;              /*! (@ 0x00000104) Periph Chan Last Cycle address MSW */
+    __IOM uint32_t      PC_LC_LEN_TYPE_TAG;          /*! (@ 0x00000108) Periph Chan Last Cycle length/type/tag */
+    __IOM uint32_t      PC_ERR_ADDR_LSW;             /*! (@ 0x0000010C) Periph Chan Error Address LSW */
+    __IOM uint32_t      PC_ERR_ADDR_MSW;             /*! (@ 0x00000110) Periph Chan Error Address MSW */
+    __IOM uint32_t      PC_STATUS;                   /*! (@ 0x00000114) Periph Chan Status */
+    __IOM uint32_t      PC_IEN;                      /*! (@ 0x00000118) Periph Chan IEN */
+} ESPI_IO_PC;
+
+/*
+ * ESPIO_IO_LTR - eSPI IO LTR registers @ 0x400F3620
+ */
+typedef struct
+{
+    __IOM uint32_t      LTR_STS;                     /*! (@ 0x0220) LTR Periph Status */
+    __IOM uint32_t      LTR_EN;                      /*! (@ 0x0224) LTR Periph Enable */
+    __IOM uint32_t      LTR_CTRL;                    /*! (@ 0x0228) LTR Periph Control */
+    __IOM uint32_t      LTR_MESG;                    /*! (@ 0x022C) LTR Periph Message */
+} ESPI_IO_LTR;
+
+/*
+ * ESPIO_IO_OOB - eSPI IO OOB registers @ 0x400F3640
+ */
+typedef struct
+{
+    __IOM uint32_t      RX_ADDR_LSW;             /*! (@ 0x0240) OOB Receive Address bits[31:0] */
+    __IOM uint32_t      RX_ADDR_MSW;             /*! (@ 0x0244) OOB Receive Address bits[63:32] */
+    __IOM uint32_t      TX_ADDR_LSW;             /*! (@ 0x0248) OOB Transmit Address bits[31:0] */
+    __IOM uint32_t      TX_ADDR_MSW;             /*! (@ 0x024C) OOB Transmit Address bits[63:32] */
+    __IOM uint32_t      RX_LEN;                  /*! (@ 0x0250) OOB Receive length */
+    __IOM uint32_t      TX_LEN;                  /*! (@ 0x0254) OOB Transmit length */
+    __IOM uint32_t      RX_CTRL;                 /*! (@ 0x0258) OOB Receive control */
+    __IOM uint32_t      RX_IEN;                  /*! (@ 0x025C) OOB Receive interrupt enable */
+    __IOM uint32_t      RX_STS;                  /*! (@ 0x0260) OOB Receive interrupt status */
+    __IOM uint32_t      TX_CTRL;                 /*! (@ 0x0264) OOB Transmit control */
+    __IOM uint32_t      TX_IEN;                  /*! (@ 0x0268) OOB Transmit interrupt enable */
+    __IOM uint32_t      TX_STS;                  /*! (@ 0x026C) OOB Transmit interrupt status */
+} ESPI_IO_OOB;
+
+/*
+ * ESPI_IO_FC - eSPI IO Flash channel registers @ 0x40003680
+ */
+typedef struct
+{
+    __IOM uint32_t      FL_ADDR_LSW;                /*! (@ 0x0280) FC flash address bits[31:0] */
+    __IOM uint32_t      FL_ADDR_MSW;                /*! (@ 0x0284) FC flash address bits[63:32] */
+    __IOM uint32_t      MEM_ADDR_LSW;               /*! (@ 0x0288) FC EC Memory address bits[31:0] */
+    __IOM uint32_t      MEM_ADDR_MSW;               /*! (@ 0x028C) FC EC Memory address bits[63:32] */
+    __IOM uint32_t      XFR_LEN;                    /*! (@ 0x0290) FC transfer length */
+    __IOM uint32_t      CTRL;                       /*! (@ 0x0294) FC Control */
+    __IOM uint32_t      IEN;                        /*! (@ 0x0298) FC interrupt enable */
+    __IOM uint32_t      CFG;                        /*! (@ 0x029C) FC configuration */
+    __IOM uint32_t      STS;                        /*! (@ 0x02A0) FC status */
+} ESPI_IO_FC;
+
+/*
+ * ESPI_IO_BAR_HOST - eSPI IO Host visible BAR registers @ 0x400F3520
+ */
+typedef struct
+{
+    __IOM uint32_t      IOBAR_INH_LSW;               /*! (@ 0x00000120) BAR Inhibit LSW */
+    __IOM uint32_t      IOBAR_INH_MSW;               /*! (@ 0x00000124) BAR Inhibit MSW */
+    __IOM uint32_t      IOBAR_INIT;                  /*! (@ 0x00000128) BAR Init */
+    __IOM uint32_t      EC_IRQ;                      /*! (@ 0x0000012C) EC IRQ */
+          uint8_t           RSVD3[4];
+    union {
+        __IOM uint32_t  u32;
+        struct {
+            __IOM uint16_t VALID;
+            __IOM uint16_t HOST_IO_ADDR;
+        } HIB;
+    } HOST_IO_BAR[ESPI_IO_BAR_MAX]; /*! (@ 0x3534 - 0x358F) Host address IO BAR's */
+} ESPI_IO_BAR_HOST;
+
+/*
+ * ESPIO_IO_BAR_EC - eSPI IO EC-only component of IO BAR @ 0x400F3734
+ */
+typedef struct
+{
+    union {
+        __IOM uint32_t  u32;
+        struct {
+            __IOM uint8_t  MASK;
+            __IOM uint8_t  LDN;
+            __IOM uint16_t VIRT;
+        } EIB;
+    } EC_IO_BAR[ESPI_IO_BAR_MAX]; /*! (@ 0x3734 - 0x378F) Host address IO BAR's */
+} ESPI_IO_BAR_EC;
+
+#endif /* #ifndef _ESPI_IO_H */
+/* end espi_io.h */
+/**   @}
+ */
+

--- a/ext/hal/microchip/mec/mec1501/component/espi_mem.h
+++ b/ext/hal/microchip/mec/mec1501/component/espi_mem.h
@@ -1,0 +1,170 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file espi_mem.h
+ *MEC1501 eSPI Memory Component definitions
+ */
+/** @defgroup MEC1501 Peripherals eSPI MEM
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifndef _ESPI_MEM_H
+#define _ESPI_MEM_H
+
+
+/*------------------------------------------------------------------*/
+
+/* =========================================================================*/
+/* ================           eSPI Memory Component        ================ */
+/* =========================================================================*/
+
+/**
+  * @brief ESPI Host interface Memory Component (ESPI_MEM)
+  */
+
+typedef struct
+{   /*! (@ 0x400F3800) eSPI Memory Compoent registers */
+          uint8_t  RSVD1[0x130];
+    __IOM uint16_t BAR_LDI_MBX_H0;        /*! (@ 0x0130) Mailbox Logical Device BAR Internal b[15:0] */
+    __IOM uint16_t BAR_LDI_MBX_H1;        /*! (@ 0x0132) Mailbox Logical Device BAR Internal b[31:16] */
+    __IOM uint16_t BAR_LDI_MBX_H2;        /*! (@ 0x0134) Mailbox Logical Device BAR Internal b[47:32] */
+    __IOM uint16_t BAR_LDI_MBX_H3;        /*! (@ 0x0136) Mailbox Logical Device BAR Internal b[63:48] */
+    __IOM uint16_t BAR_LDI_MBX_H4;        /*! (@ 0x0138) Mailbox Logical Device BAR Internal b[79:64] */
+    __IOM uint16_t BAR_LDI_ACPI_EC0_H0;   /*! (@ 0x013A) ACPI EC0 Logical Device BAR Internal b[15:0] */
+    __IOM uint16_t BAR_LDI_ACPI_EC0_H1;   /*! (@ 0x013C) ACPI EC0 Logical Device BAR Internal b[31:16] */
+    __IOM uint16_t BAR_LDI_ACPI_EC0_H2;   /*! (@ 0x013E) ACPI EC0 Logical Device BAR Internal b[47:32] */
+    __IOM uint16_t BAR_LDI_ACPI_EC0_H3;   /*! (@ 0x0140) ACPI EC0 Logical Device BAR Internal b[63:48] */
+    __IOM uint16_t BAR_LDI_ACPI_EC0_H4;   /*! (@ 0x0142) ACPI EC0 Logical Device BAR Internal b[79:64] */
+    __IOM uint16_t BAR_LDI_ACPI_EC1_H0;   /*! (@ 0x0144) ACPI EC1 Logical Device BAR Internal b[15:0] */
+    __IOM uint16_t BAR_LDI_ACPI_EC1_H1;   /*! (@ 0x0146) ACPI EC1 Logical Device BAR Internal b[31:16] */
+    __IOM uint16_t BAR_LDI_ACPI_EC1_H2;   /*! (@ 0x0148) ACPI EC1 Logical Device BAR Internal b[47:32] */
+    __IOM uint16_t BAR_LDI_ACPI_EC1_H3;   /*! (@ 0x014A) ACPI EC1 Logical Device BAR Internal b[63:48] */
+    __IOM uint16_t BAR_LDI_ACPI_EC1_H4;   /*! (@ 0x014C) ACPI EC1 Logical Device BAR Internal b[79:64] */
+    __IOM uint16_t BAR_LDI_ACPI_EC2_H0;   /*! (@ 0x014E) ACPI EC2 Logical Device BAR Internal b[15:0] */
+    __IOM uint16_t BAR_LDI_ACPI_EC2_H1;   /*! (@ 0x0150) ACPI EC2 Logical Device BAR Internal b[31:16] */
+    __IOM uint16_t BAR_LDI_ACPI_EC2_H2;   /*! (@ 0x0152) ACPI EC2 Logical Device BAR Internal b[47:32] */
+    __IOM uint16_t BAR_LDI_ACPI_EC2_H3;   /*! (@ 0x0154) ACPI EC2 Logical Device BAR Internal b[63:48] */
+    __IOM uint16_t BAR_LDI_ACPI_EC2_H4;   /*! (@ 0x0156) ACPI EC2 Logical Device BAR Internal b[79:64] */
+    __IOM uint16_t BAR_LDI_ACPI_EC3_H0;   /*! (@ 0x0158) ACPI EC3 Logical Device BAR Internal b[15:0] */
+    __IOM uint16_t BAR_LDI_ACPI_EC3_H1;   /*! (@ 0x015A) ACPI EC3 Logical Device BAR Internal b[31:16] */
+    __IOM uint16_t BAR_LDI_ACPI_EC3_H2;   /*! (@ 0x015C) ACPI EC3 Logical Device BAR Internal b[47:32] */
+    __IOM uint16_t BAR_LDI_ACPI_EC3_H3;   /*! (@ 0x015E) ACPI EC3 Logical Device BAR Internal b[63:48] */
+    __IOM uint16_t BAR_LDI_ACPI_EC3_H4;   /*! (@ 0x0160) ACPI EC3 Logical Device BAR Internal b[79:64] */
+          uint8_t  RSVD2[0x16C - 0x162];
+    __IOM uint16_t BAR_LDI_EM0_H0;        /*! (@ 0x016C) EMI0 Logical Device BAR Internal b[15:0] */
+    __IOM uint16_t BAR_LDI_EM0_H1;        /*! (@ 0x016E) EMI0 Logical Device BAR Internal b[31:16] */
+    __IOM uint16_t BAR_LDI_EM0_H2;        /*! (@ 0x0170) EMI0 Logical Device BAR Internal b[47:32] */
+    __IOM uint16_t BAR_LDI_EM0_H3;        /*! (@ 0x0172) EMI0 Logical Device BAR Internal b[63:48] */
+    __IOM uint16_t BAR_LDI_EM0_H4;        /*! (@ 0x0174) EMI0 Logical Device BAR Internal b[79:64] */
+    __IOM uint16_t BAR_LDI_EM1_H0;        /*! (@ 0x0176) EMI1 Logical Device BAR Internal b[15:0] */
+    __IOM uint16_t BAR_LDI_EM1_H1;        /*! (@ 0x0178) EMI1 Logical Device BAR Internal b[31:16] */
+    __IOM uint16_t BAR_LDI_EM1_H2;        /*! (@ 0x017A) EMI1 Logical Device BAR Internal b[47:32] */
+    __IOM uint16_t BAR_LDI_EM1_H3;        /*! (@ 0x017C) EMI1 Logical Device BAR Internal b[63:48] */
+    __IOM uint16_t BAR_LDI_EM1_H4;        /*! (@ 0x017E) EMI1 Logical Device BAR Internal b[79:64] */
+          uint8_t  RSVD3[0x1AC - 0x180];
+    __IOM uint16_t BAR_SRAM0_H0;        /*! (@ 0x01AC) SRAM0 BAR Internal b[15:0] */
+    __IOM uint16_t BAR_SRAM0_H1;        /*! (@ 0x01AE) SRAM0 BAR Internal b[31:16] */
+    __IOM uint16_t BAR_SRAM0_H2;        /*! (@ 0x01B0) SRAM0 BAR Internal b[47:32] */
+    __IOM uint16_t BAR_SRAM0_H3;        /*! (@ 0x01B2) SRAM0 BAR Internal b[63:48] */
+    __IOM uint16_t BAR_SRAM0_H4;        /*! (@ 0x01B4) SRAM0 BAR Internal b[79:64] */
+    __IOM uint16_t BAR_SRAM1_H0;        /*! (@ 0x01B6) SRAM1 BAR Internal b[15:0] */
+    __IOM uint16_t BAR_SRAM1_H1;        /*! (@ 0x01B8) SRAM1 BAR Internal b[31:16] */
+    __IOM uint16_t BAR_SRAM1_H2;        /*! (@ 0x01BA) SRAM1 BAR Internal b[47:32] */
+    __IOM uint16_t BAR_SRAM1_H3;        /*! (@ 0x01BC) SRAM1 BAR Internal b[63:48] */
+    __IOM uint16_t BAR_SRAM1_H4;        /*! (@ 0x01BE) SRAM1 BAR Internal b[79:64] */
+          uint8_t  RSVD4[0x200 - 0x1C0];
+    __IOM uint32_t BM_STS;              /*! (@ 0x0200) Bus Master Status */
+    __IOM uint32_t BM_IEN;              /*! (@ 0x0204) Bus Master interrupt enable */
+    __IOM uint32_t BM_CFG;              /*! (@ 0x0208) Bus Master configuration */
+          uint8_t  RSVD5[4];
+    __IOM uint32_t BM1_CTRL;            /*! (@ 0x0210) Bus Master 1 control */
+    __IOM uint32_t BM1_HOST_ADDR_LSW;   /*! (@ 0x0214) Bus Master 1 host address bits[31:0] */
+    __IOM uint32_t BM1_HOST_ADDR_MSW;   /*! (@ 0x0218) Bus Master 1 host address bits[63:32] */
+    __IOM uint32_t BM1_EC_ADDR_LSW;     /*! (@ 0x021C) Bus Master 1 EC address bits[31:0] */
+    __IOM uint32_t BM1_EC_ADDR_MSW;     /*! (@ 0x0220) Bus Master 1 EC address bits[63:32] */
+    __IOM uint32_t BM2_CTRL;            /*! (@ 0x0224) Bus Master 2 control */
+    __IOM uint32_t BM2_HOST_ADDR_LSW;   /*! (@ 0x0228) Bus Master 2 host address bits[31:0] */
+    __IOM uint32_t BM2_HOST_ADDR_MSW;   /*! (@ 0x022C) Bus Master 2 host address bits[63:32] */
+    __IOM uint32_t BM2_EC_ADDR_LSW;     /*! (@ 0x0230) Bus Master 2 EC address bits[31:0] */
+    __IOM uint32_t BM2_EC_ADDR_MSW;     /*! (@ 0x0234) Bus Master 2 EC address bits[63:32] */
+          uint8_t  RSVD6[0x330 - 0x238];
+    __IOM uint16_t BAR_LDH_MBX_H0;        /*! (@ 0x0330) Mailbox Logical Device BAR Host b[15:0] */
+    __IOM uint16_t BAR_LDH_MBX_H1;        /*! (@ 0x0332) Mailbox Logical Device BAR Host b[31:16] */
+    __IOM uint16_t BAR_LDH_MBX_H2;        /*! (@ 0x0334) Mailbox Logical Device BAR Host b[47:32] */
+    __IOM uint16_t BAR_LDH_MBX_H3;        /*! (@ 0x0336) Mailbox Logical Device BAR Host b[63:48] */
+    __IOM uint16_t BAR_LDH_MBX_H4;        /*! (@ 0x0338) Mailbox Logical Device BAR Host b[79:64] */
+    __IOM uint16_t BAR_LDH_ACPI_EC0_H0;   /*! (@ 0x033A) ACPI EC0 Logical Device BAR Host b[15:0] */
+    __IOM uint16_t BAR_LDH_ACPI_EC0_H1;   /*! (@ 0x033C) ACPI EC0 Logical Device BAR Host b[31:16] */
+    __IOM uint16_t BAR_LDH_ACPI_EC0_H2;   /*! (@ 0x033E) ACPI EC0 Logical Device BAR Host b[47:32] */
+    __IOM uint16_t BAR_LDH_ACPI_EC0_H3;   /*! (@ 0x0340) ACPI EC0 Logical Device BAR Host b[63:48] */
+    __IOM uint16_t BAR_LDH_ACPI_EC0_H4;   /*! (@ 0x0342) ACPI EC0 Logical Device BAR Host b[79:64] */
+    __IOM uint16_t BAR_LDH_ACPI_EC1_H0;   /*! (@ 0x0344) ACPI EC1 Logical Device BAR Host b[15:0] */
+    __IOM uint16_t BAR_LDH_ACPI_EC1_H1;   /*! (@ 0x0346) ACPI EC1 Logical Device BAR Host b[31:16] */
+    __IOM uint16_t BAR_LDH_ACPI_EC1_H2;   /*! (@ 0x0348) ACPI EC1 Logical Device BAR Host b[47:32] */
+    __IOM uint16_t BAR_LDH_ACPI_EC1_H3;   /*! (@ 0x034A) ACPI EC1 Logical Device BAR Host b[63:48] */
+    __IOM uint16_t BAR_LDH_ACPI_EC1_H4;   /*! (@ 0x034C) ACPI EC1 Logical Device BAR Host b[79:64] */
+    __IOM uint16_t BAR_LDH_ACPI_EC2_H0;   /*! (@ 0x034E) ACPI EC2 Logical Device BAR Host b[15:0] */
+    __IOM uint16_t BAR_LDH_ACPI_EC2_H1;   /*! (@ 0x0350) ACPI EC2 Logical Device BAR Host b[31:16] */
+    __IOM uint16_t BAR_LDH_ACPI_EC2_H2;   /*! (@ 0x0352) ACPI EC2 Logical Device BAR Host b[47:32] */
+    __IOM uint16_t BAR_LDH_ACPI_EC2_H3;   /*! (@ 0x0354) ACPI EC2 Logical Device BAR Host b[63:48] */
+    __IOM uint16_t BAR_LDH_ACPI_EC2_H4;   /*! (@ 0x0356) ACPI EC2 Logical Device BAR Host b[79:64] */
+    __IOM uint16_t BAR_LDH_ACPI_EC3_H0;   /*! (@ 0x0358) ACPI EC3 Logical Device BAR Host b[15:0] */
+    __IOM uint16_t BAR_LDH_ACPI_EC3_H1;   /*! (@ 0x035A) ACPI EC3 Logical Device BAR Host b[31:16] */
+    __IOM uint16_t BAR_LDH_ACPI_EC3_H2;   /*! (@ 0x035C) ACPI EC3 Logical Device BAR Host b[47:32] */
+    __IOM uint16_t BAR_LDH_ACPI_EC3_H3;   /*! (@ 0x035E) ACPI EC3 Logical Device BAR Host b[63:48] */
+    __IOM uint16_t BAR_LDH_ACPI_EC3_H4;   /*! (@ 0x0360) ACPI EC3 Logical Device BAR Host b[79:64] */
+          uint8_t  RSVD7[0x36C - 0x362];
+    __IOM uint16_t BAR_LDH_EM0_H0;        /*! (@ 0x036C) EMI0 Logical Device BAR Internal b[15:0] */
+    __IOM uint16_t BAR_LDH_EM0_H1;        /*! (@ 0x036E) EMI0 Logical Device BAR Internal b[31:16] */
+    __IOM uint16_t BAR_LDH_EM0_H2;        /*! (@ 0x0370) EMI0 Logical Device BAR Internal b[47:32] */
+    __IOM uint16_t BAR_LDH_EM0_H3;        /*! (@ 0x0372) EMI0 Logical Device BAR Internal b[63:48] */
+    __IOM uint16_t BAR_LDH_EM0_H4;        /*! (@ 0x0374) EMI0 Logical Device BAR Internal b[79:64] */
+    __IOM uint16_t BAR_LDH_EM1_H0;        /*! (@ 0x0376) EMI1 Logical Device BAR Internal b[15:0] */
+    __IOM uint16_t BAR_LDH_EM1_H1;        /*! (@ 0x0378) EMI1 Logical Device BAR Internal b[31:16] */
+    __IOM uint16_t BAR_LDH_EM1_H2;        /*! (@ 0x037A) EMI1 Logical Device BAR Internal b[47:32] */
+    __IOM uint16_t BAR_LDH_EM1_H3;        /*! (@ 0x037C) EMI1 Logical Device BAR Internal b[63:48] */
+    __IOM uint16_t BAR_LDH_EM1_H4;        /*! (@ 0x037E) EMI1 Logical Device BAR Internal b[79:64] */
+          uint8_t  RSVD8[0x3AC - 0x380];
+    __IOM uint16_t BAR_SRAM0_HOST_H0;     /*! (@ 0x03AC) SRAM0 BAR Host b[15:0] */
+    __IOM uint16_t BAR_SRAM0_HOST_H1;     /*! (@ 0x03AE) SRAM0 BAR Host b[31:16] */
+    __IOM uint16_t BAR_SRAM0_HOST_H2;     /*! (@ 0x03B0) SRAM0 BAR Host b[47:32] */
+    __IOM uint16_t BAR_SRAM0_HOST_H3;     /*! (@ 0x03B2) SRAM0 BAR Host b[63:48] */
+    __IOM uint16_t BAR_SRAM0_HOST_H4;     /*! (@ 0x03B4) SRAM0 BAR Host b[79:64] */
+    __IOM uint16_t BAR_SRAM1_HOST_H0;     /*! (@ 0x03B6) SRAM1 BAR Host b[15:0] */
+    __IOM uint16_t BAR_SRAM1_HOST_H1;     /*! (@ 0x03B8) SRAM1 BAR Host b[31:16] */
+    __IOM uint16_t BAR_SRAM1_HOST_H2;     /*! (@ 0x03BA) SRAM1 BAR Host b[47:32] */
+    __IOM uint16_t BAR_SRAM1_HOST_H3;     /*! (@ 0x03BC) SRAM1 BAR Host b[63:48] */
+    __IOM uint16_t BAR_SRAM1_HOST_H4;     /*! (@ 0x03BE) SRAM1 BAR Host b[79:64] */
+} ESPI_MEM_Type;
+
+
+#endif /* #ifndef _ESPI_MEM_H */
+/* end espi_mem.h */
+/**   @}
+ */
+

--- a/ext/hal/microchip/mec/mec1501/component/espi_vw.h
+++ b/ext/hal/microchip/mec/mec1501/component/espi_vw.h
@@ -1,0 +1,238 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file espi_vw.h
+ *MEC1501 eSPI Virtual Wire definitions
+ */
+/** @defgroup MEC1501 Peripherals eSPI VW
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifndef _ESPI_VW_H
+#define _ESPI_VW_H
+
+
+/*------------------------------------------------------------------*/
+
+
+/* Master to Slave VW register: 96-bit (3 32 bit registers) */
+/* 32-bit word 0 (bits[31:0]) */
+#define ESPI_M2SW0_OFS                  0ul
+#define ESPI_M2SW0_IDX_POS              0
+#define ESPI_M2SW0_IDX_MASK             0xFFu
+#define ESPI_M2SW0_MTOS_SRC_POS         8u
+#define ESPI_M2SW0_MTOS_SRC_MASK0       0x03u
+#define ESPI_M2SW0_MTOS_SRC_MASK        ((ESPI_VW_M2S_MTOS_SRC_MASK0) << (ESPI_VW_M2S_MTOS_SRC_POS))
+#define ESPI_M2SW0_MTOS_SRC_ESPI_RST    ((0ul) << (ESPI_VW_M2S_MTOS_SRC_POS))
+#define ESPI_M2SW0_MTOS_SRC_SYS_RST     ((1ul) << (ESPI_VW_M2S_MTOS_SRC_POS))
+#define ESPI_M2SW0_MTOS_SRC_SIO_RST     ((2ul) << (ESPI_VW_M2S_MTOS_SRC_POS))
+#define ESPI_M2SW0_MTOS_SRC_PLTRST      ((3ul) << (ESPI_VW_M2S_MTOS_SRC_POS))
+#define ESPI_M2SW0_MTOS_STATE_POS       12u
+#define ESPI_M2SW0_MTOS_STATE_MASK0     0x0Ful
+#define ESPI_M2SW0_MTOS_STATE_MASK      ((ESPI_VW_M2S_MTOS_STATE_MASK0) << (ESPI_VW_M2S_MTOS_STATE_POS))
+/* 32-bit word 1 (bits[63:32]) */
+#define ESPI_M2SW1_OFS                  4ul
+#define ESPI_M2SW1_SRC0_SEL_POS         0
+#define ESPI_M2SW1_SRC_SEL_MASK0        0x0Ful
+#define ESPI_M2SW1_SRC0_SEL_MASK        ((ESPI_M2SW1_SRC_SEL_MASK0) << (ESPI_M2SW1_SRC0_SEL_POS))
+#define ESPI_M2SW1_SRC1_SEL_POS         8
+#define ESPI_M2SW1_SRC1_SEL_MASK        ((ESPI_M2SW1_SRC_SEL_MASK0) << (ESPI_M2SW1_SRC1_SEL_POS))
+#define ESPI_M2SW1_SRC2_SEL_POS         16
+#define ESPI_M2SW1_SRC2_SEL_MASK        ((ESPI_M2SW1_SRC_SEL_MASK0) << (ESPI_M2SW1_SRC2_SEL_POS))
+#define ESPI_M2SW1_SRC3_SEL_POS         24
+#define ESPI_M2SW1_SRC3_SEL_MASK        ((ESPI_M2SW1_SRC_SEL_MASK0) << (ESPI_M2SW1_SRC3_SEL_POS))
+/* 0 <= n < 4 */
+#define ESPI_M2SW1_SRC_SEL_POS(n)       ((n) << 3)
+#define ESPI_M2SW1_SRC_SEL_MASK(n)      ((0x0Ful) << (ESPI_M2SW1_SRC_SEL_POS(n)))
+#define ESPI_M2SW1_SRC_SEL_VAL(n, v)    (((uint32_t)(v) & 0x0Ful) << (ESPI_M2SW1_SRC_SEL_POS(n)))
+/* 32-bit word 2 (bits[95:64]) */
+#define ESPI_M2SW2_OFS                  8ul
+#define ESPI_M2SW2_SRC_MASK0            0x0Ful
+#define ESPI_M2SW2_SRC0_POS             0
+#define ESPI_M2SW2_SRC0_MASK            ((ESPI_M2SW1_SRC_MASK0) << (ESPI_M2SW1_SRC0_POS))
+#define ESPI_M2SW2_SRC1_POS             8u
+#define ESPI_M2SW2_SRC1_MASK            ((ESPI_M2SW1_SRC_MASK0) << (ESPI_M2SW1_SRC1_POS))
+#define ESPI_M2SW2_SRC2_POS             16u
+#define ESPI_M2SW2_SRC2_MASK            ((ESPI_M2SW1_SRC_MASK0) << (ESPI_M2SW2_SRC1_POS))
+#define ESPI_M2SW2_SRC3_POS             24u
+#define ESPI_M2SW2_SRC3_MASK            ((ESPI_M2SW1_SRC_MASK0) << (ESPI_M2SW2_SRC3_POS))
+/* 0 <= n < 4 */
+#define ESPI_M2SW2_SRC_POS(n)           ((n) << 3)
+#define ESPI_M2SW2_SRC_MASK(n)          ((ESPI_M2SW2_SRC_MASK0) << (ESPI_M2SW2_SRC_POS(n)))
+#define ESPI_M2SW2_SRC_VAL(n, v)        (((uint32_t)(v) & 0x0Ful) << (ESPI_M2SW2_SRC_POS(n)))
+
+/*
+ * Zero based values used for above SRC_SEL fields.
+ * These values select the interrupt sensitivity for the VWire.
+ * Example: Set SRC1 to Level High
+ *
+ * r = read MSVW1 register
+ * r &= ESPI_M2SW1_SRC_SEL_MASK(1)
+ * r |= ESPI_MSVW1_SRC_SEL_VAL(1, ESPI_IRQ_SEL_LVL_HI)
+ * write r to MSVW1 register
+ */
+#define ESPI_IRQ_SEL_LVL_LO         0
+#define ESPI_IRQ_SEL_LVL_HI         1
+#define ESPI_IRQ_SEL_DIS            4
+/* NOTE: Edge trigger modes allow VWires to wake MEC1501 from deep sleep */
+#define ESPI_IRQ_SEL_REDGE          0x0D
+#define ESPI_IRQ_SEL_FEDGE          0x0E
+#define ESPI_IRQ_SEL_BEDGE          0x0F
+
+/* Slave to Master VW register: 64-bit (2 32 bit registers) */
+/* 32-bit word 0 (bits[31:0]) */
+#define ESPI_S2MW0_OFS                  0
+#define ESPI_S2MW0_IDX_POS              0
+#define ESPI_S2MW0_IDX_MASK             0xFFu
+#define ESPI_S2MW0_STOM_POS             8u
+#define ESPI_S2MW0_STOM_SRC_POS         8u
+#define ESPI_S2MW0_STOM_MASK0           0xF3u
+#define ESPI_S2MW0_STOM_MASK            ((ESPI_S2MW0_STOM_MASK0) << (ESPI_S2MW0_STOM_SRC_POS))
+#define ESPI_S2MW0_STOM_SRC_MASK0       0x03ul
+#define ESPI_S2MW0_STOM_SRC_MASK        ((ESPI_S2MW0_STOM_SRC_MASK0) << (ESPI_S2MW0_STOM_SRC_POS))
+#define ESPI_S2MW0_STOM_SRC_ESPI_RST    ((0ul) << (ESPI_S2MW0_STOM_SRC_POS))
+#define ESPI_S2MW0_STOM_SRC_SYS_RST     ((1ul) << (ESPI_S2MW0_STOM_SRC_POS))
+#define ESPI_S2MW0_STOM_SRC_SIO_RST     ((2ul) << (ESPI_S2MW0_STOM_SRC_POS))
+#define ESPI_S2MW0_STOM_SRC_PLTRST      ((3ul) << (ESPI_S2MW0_STOM_SRC_POS))
+#define ESPI_S2MW0_STOM_STATE_POS       12u
+#define ESPI_S2MW0_STOM_STATE_MASK0     0x0Ful
+#define ESPI_S2MW0_STOM_STATE_MASK      ((ESPI_S2MW0_STOM_STATE_MASK0) << (ESPI_S2MW0_STOM_STATE_POS))
+#define ESPI_S2MW0_CHG0_POS             16u
+#define ESPI_S2MW0_CHG0                 (1ul << (ESPI_S2MW0_CHG0_POS))
+#define ESPI_S2MW0_CHG1_POS             17u
+#define ESPI_S2MW0_CHG1                 (1ul << (ESPI_S2MW0_CHG1_POS))
+#define ESPI_S2MW0_CHG2_POS             18u
+#define ESPI_S2MW0_CHG2                 (1ul << (ESPI_S2MW0_CHG2_POS))
+#define ESPI_S2MW0_CHG3_POS             19u
+#define ESPI_S2MW0_CHG3                 (1ul << (ESPI_S2MW0_CHG3_POS))
+#define ESPI_S2MW0_CHG_ALL_POS          16u
+#define ESPI_S2MW0_CHG_ALL_MASK0        0x0Ful
+#define ESPI_S2MW0_CHG_ALL_MASK         ((ESPI_S2MW0_CHG_ALL_MASK0) << (ESPI_S2MW0_CHG0_POS))
+/* 0 <= n < 4 */
+#define ESPI_S2MW1_CHG_POS(n)           ((n) + 16u)
+#define ESPI_S2MW1_CHG(v, n)            (((uint32_t)(v) >> ESPI_S2MW1_CHG_POS(n)) & 0x01)
+
+/* 32-bit word 1 (bits[63:32]) */
+#define ESPI_S2MW1_OFS                  4ul
+#define ESPI_S2MW1_SRC0_POS             0u
+#define ESPI_S2MW1_SRC0                 (1ul << (ESPI_S2MW1_SRC0_POS))
+#define ESPI_S2MW1_SRC1_POS             8u
+#define ESPI_S2MW1_SRC1                 (1ul << (ESPI_S2MW1_SRC1_POS))
+#define ESPI_S2MW1_SRC2_POS             16u
+#define ESPI_S2MW1_SRC2                 (1ul << (ESPI_S2MW1_SRC2_POS))
+#define ESPI_S2MW1_SRC3_POS             24u
+#define ESPI_S2MW1_SRC3                 (1ul << (ESPI_S2MW1_SRC3_POS))
+/* 0 <= n < 4 */
+#define ESPI_S2MW1_SRC_POS(n)           ((n) << 3)
+#define ESPI_S2MW1_SRC(v, n)            (((uint32_t)(v) & 0x01) << (ESPI_S2MW1_SRC_POS(n)))
+
+/* =========================================================================*/
+/* ================           ESPI_VW                      ================ */
+/* =========================================================================*/
+
+/**
+  * @brief eSPI Virtual Wires (ESPI_VW)
+  */
+
+#define ESPI_MSVW_IDX_MAX   10
+#define ESPI_SMVW_IDX_MAX   10
+
+#define ESPI_NUM_MSVW       11
+#define ESPI_NUM_SMVW       11
+
+/* Master-to-Slave VW byte indices */
+#define MSVW_INDEX          0
+#define MSVW_MTOS           1
+#define MSVW_SRC0_IRQ_SEL   4
+#define MSVW_SRC1_IRQ_SEL   5
+#define MSVW_SRC2_IRQ_SEL   6
+#define MSVW_SRC3_IRQ_SEL   7
+#define MSVW_SRC0           8
+#define MSVW_SRC1           9
+#define MSVW_SRC2           10
+#define MSVW_SRC3           11
+
+/* Slave-to-Master VW byte indices */
+#define SMVW_INDEX          0
+#define SMVW_STOM           1
+#define SMVW_CHANGED        2
+#define SMVW_SRC0           4
+#define SMVW_SRC1           5
+#define SMVW_SRC2           6
+#define SMVW_SRC3           7
+
+/*
+ * ESPI_IO_VW - eSPI IO component registers related to VW channel @ 0x400F36B0
+ */
+typedef struct
+{
+    __IOM uint32_t  VW_EN_STS;      /*! (@ 0x0000) Virtual Wire Enable Status */
+    uint8_t             RSVD1[0x30];
+    __IOM uint8_t   VW_CAP;         /*! (@ 0x0034) Virtual Wire Chan Capabilities */
+    uint8_t             RSVD2[8];
+    __IOM uint8_t   VW_RDY;         /*! (@ 0x003D) VW ready */
+    uint8_t             RSVD3[0x102];
+    __IOM uint32_t  VW_ERR_STS;     /*! (@ 0x0140) IO Virtual Wire Error */
+} ESPI_IO_VW;
+
+/* Master-to-Slave Virtual Wire 96-bit register */
+typedef struct espi_msvw_reg
+{
+    __IOM uint8_t  INDEX;
+    __IOM uint8_t  MTOS;
+          uint8_t  RSVD1[2];
+    __IOM uint8_t  SRC_IRQ_SEL[4];
+    __IOM uint8_t  SRC[4];    
+} ESPI_MSVW_REG;
+
+typedef struct
+{
+    ESPI_MSVW_REG   M2S[ESPI_NUM_MSVW];
+} ESPI_M2S_VW;
+
+/* Slave-to-Master Virtual Wire 64-bit register */
+typedef struct espi_smvw_reg
+{
+    __IOM uint8_t  INDEX;
+    __IOM uint8_t  STOM;
+    __IM  uint8_t  SRC_CHG;
+          uint8_t  RSVD1[1];
+    __IOM uint8_t  SRC[4];
+} ESPI_SMVW_REG;
+
+typedef struct
+{
+    ESPI_SMVW_REG   S2M[ESPI_NUM_SMVW];
+} ESPI_S2M_VW;
+
+
+#endif /* #ifndef _ESPI_VW_H */
+/* end espi_vw.h */
+/**   @}
+ */
+

--- a/ext/hal/microchip/mec/mec1501/component/gpio.h
+++ b/ext/hal/microchip/mec/mec1501/component/gpio.h
@@ -1,0 +1,499 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file gpio.h
+ *MEC1501 GPIO definitions
+ */
+/** @defgroup MEC1501 Peripherals GPIO
+ */
+
+#ifndef _GPIO_H
+#define _GPIO_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+
+#define NUM_GPIO_PORTS      6
+#define MAX_NUM_GPIO        (NUM_GPIO_PORTS * 32)
+
+#define GPIO_BASE_ADDR          0x40081000ul
+#define GPIO_CTRL2_OFS          0x0500ul
+
+/*
+ * !!! MEC15xx data sheets pin numbering is octal !!!
+ * n = pin number in octal or the equivalent in decimal or hex
+ * Example: GPIO135
+ * n = 0135 or n = 0x5D or n = 93
+ */
+#define GPIO_CTRL_ADDR(n) ((uintptr_t)(GPIO_BASE_ADDR) + ((uintptr_t)(n) << 2))
+
+#define GPIO_CTRL2_ADDR(n) ((uintptr_t)(GPIO_BASE_ADDR + GPIO_CTRL2_OFS) +\
+                            ((uintptr_t)(n) << 2))
+/*
+ * MEC1501H-B0-SZ (144-pin)
+ */
+#define GPIO_PORT_A_BITMAP 0x7FFFFF9Dul   /* GPIO_0000 - GPIO_0036    GIRQ11 */
+#define GPIO_PORT_B_BITMAP 0x0FFFFFFDul   /* GPIO_0040 - GPIO_0076    GIRQ10 */
+#define GPIO_PORT_C_BITMAP 0x07FF3CF7ul   /* GPIO_0100 - GPIO_0136    GIRQ09 */
+#define GPIO_PORT_D_BITMAP 0x272EFFFFul   /* GPIO_0140 - GPIO_0176    GIRQ08 */
+#define GPIO_PORT_E_BITMAP 0x00DE00FFul   /* GPIO_0200 - GPIO_0236    GIRQ12 */
+#define GPIO_PORT_F_BITMAP 0x0000397Ful   /* GPIO_0240 - GPIO_0276    GIRQ26 */
+
+#define GPIO_PORT_A_DRVSTR_BITMAP   0x7FFFFF9Dul
+#define GPIO_PORT_B_DRVSTR_BITMAP   0x0FFFFFFDul
+#define GPIO_PORT_C_DRVSTR_BITMAP   0x07FF3CF7ul
+#define GPIO_PORT_D_DRVSTR_BITMAP   0x272EFFFFul
+#define GPIO_PORT_E_DRVSTR_BITMAP   0x00DE00FFul
+#define GPIO_PORT_F_DRVSTR_BITMAP   0x0000397Ful
+
+/*
+ * GPIO Port to ECIA GIRQ mapping
+ */
+#define GPIO_PORT_A_GIRQ    11u
+#define GPIO_PORT_B_GIRQ    10u
+#define GPIO_PORT_C_GIRQ    9u
+#define GPIO_PORT_D_GIRQ    8u
+#define GPIO_PORT_E_GIRQ    12u
+#define GPIO_PORT_F_GIRQ    26u
+
+/*
+ * GPIO Port GIRQ to NVIC external input
+ * GPIO GIRQ's are always aggregated.
+ */
+#define GPIO_PORT_A_NVIC    3u
+#define GPIO_PORT_B_NVIC    2u
+#define GPIO_PORT_C_NVIC    1u
+#define GPIO_PORT_D_NVIC    0u
+#define GPIO_PORT_E_NVIC    4u
+#define GPIO_PORT_F_NVIC    17u
+
+/*
+ * Control
+ */
+#define GPIO_CTRL_MASK          0x0101BFFFul
+/* bits[15:0] of Control register */
+#define GPIO_CTRL_CFG_MASK      0xBFFFul
+
+/* Disable interrupt detect and pad */
+#define GPIO_CTRL_DIS_PIN       0x8040ul
+
+#define GPIO_CTRL_DFLT          0x8040ul
+#define GPIO_CTRL_DFLT_MASK     0xfffful
+
+
+#define GPIO000_CTRL_DFLT       0x1040ul
+#define GPIO161_CTRL_DFLT       0x1040ul
+#define GPIO162_CTRL_DFLT       0x1040ul
+#define GPIO163_CTRL_DFLT       0x1040ul
+#define GPIO172_CTRL_DFLT       0x1040ul
+#define GPIO062_CTRL_DFLT       0x8240ul
+#define GPIO170_CTRL_DFLT       0x0041ul    /* Boot-ROM JTAG_STRAP_BS */
+#define GPIO116_CTRL_DFLT       0x0041ul
+#define GPIO250_CTRL_DFLT       0x1240ul
+
+#define GPIO_PUD_POS            0
+#define GPIO_PUD_BLEN           2
+#define GPIO_PUD_MASK           (0x03UL << (GPIO_PUD_POS))
+#define GPIO_PUD_NONE           0x00
+#define GPIO_PUD_PU             0x01
+#define GPIO_PUD_PD             0x02
+/* Repeater(keeper) mode */
+#define GPIO_PUD_RPT            0x03
+
+#define GPIO_PWRG_POS           2
+#define GPIO_PWRG_BLEN          2
+#define GPIO_PWRG_MASK          (0x03UL << (GPIO_PWRG_POS))
+#define GPIO_PWRG_VTR_IO        (0x00UL << (GPIO_PWRG_POS))
+#define GPIO_PWRG_VCC_IO        (0x01UL << (GPIO_PWRG_POS))
+#define GPIO_PWRG_OFF           (0x02UL << (GPIO_PWRG_POS))
+#define GPIO_PWRG_RSVD          (0x03UL << (GPIO_PWRG_POS))
+
+#define GPIO_IDET_POS           4
+#define GPIO_IDET_BLEN          4
+#define GPIO_IDET_MASK          (0x0FUL << (GPIO_IDET_POS))
+#define GPIO_IDET_LVL_LO        (0x00UL << (GPIO_IDET_POS))
+#define GPIO_IDET_LVL_HI        (0x01UL << (GPIO_IDET_POS))
+#define GPIO_IDET_DIS           (0x04UL << (GPIO_IDET_POS))
+#define GPIO_IDET_REDGE         (0x0DUL << (GPIO_IDET_POS))
+#define GPIO_IDET_FEDGE         (0x0EUL << (GPIO_IDET_POS))
+#define GPIO_IDET_BEDGE         (0x0FUL << (GPIO_IDET_POS))
+
+#define GPIO_BUFT_POS           8
+#define GPIO_BUFT_BLEN          1
+#define GPIO_BUFT_MASK          (1ul << (GPIO_BUFT_POS))
+#define GPIO_BUFT_PUSHPULL      (0x00UL << (GPIO_BUFT_POS))
+#define GPIO_BUFT_OPENDRAIN     (0x01UL << (GPIO_BUFT_POS))
+
+#define GPIO_DIR_POS            9
+#define GPIO_DIR_BLEN           1
+#define GPIO_DIR_MASK           (0x01UL << (GPIO_DIR_POS))
+#define GPIO_DIR_INPUT          (0x00UL << (GPIO_DIR_POS))
+#define GPIO_DIR_OUTPUT         (0x01UL << (GPIO_DIR_POS))
+
+#define GPIO_ALTOUT_POS         10
+#define GPIO_ALTOUT_BLEN        1
+#define GPIO_ALTOUT_MASK        (1ul << (GPIO_ALTOUT_POS))
+#define GPIO_ALTOUT_DIS         (0x01UL << (GPIO_ALTOUT_POS))
+#define GPIO_ALTOUT_EN          (0x00UL << (GPIO_ALTOUT_POS))
+
+#define GPIO_POLARITY_POS       11
+#define GPIO_POLARITY_BLEN      1
+#define GPIO_POLARITY_MASK      (1ul << (GPIO_POLARITY_POS))
+#define GPIO_POLARITY_NON_INV   (0x00UL << (GPIO_POLARITY_POS))
+#define GPIO_POLARITY_INV       (0x01UL << (GPIO_POLARITY_POS))
+
+#define GPIO_MUX_POS            12
+#define GPIO_MUX_BLEN           2
+#define GPIO_MUX_MASK0          0x03ul
+#define GPIO_MUX_MASK           (0x0FUL << (GPIO_MUX_POS))
+#define GPIO_MUX_GPIO           (0x00UL << (GPIO_MUX_POS))
+#define GPIO_MUX_FUNC1          (0x01UL << (GPIO_MUX_POS))
+#define GPIO_MUX_FUNC2          (0x02UL << (GPIO_MUX_POS))
+#define GPIO_MUX_FUNC3          (0x03UL << (GPIO_MUX_POS))
+
+#define GPIO_PADIN_DIS_POS      15
+#define GPIO_PADIN_DIS_BLEN     1
+#define GPIO_PADIN_DIS_MASK0    0x01ul
+#define GPIO_PADIN_DIS_MASK     (0x01ul << (GPIO_PADIN_DIS_POS))
+#define GPIO_PADIN_DIS          (0x01ul << (GPIO_PADIN_DIS_POS))
+#define GPIO_PADIN_EN           (0ul << (GPIO_PADIN_DIS_POS))
+
+#define GPIO_OUTPUT_BITPOS      (16)
+#define GPIO_OUTPUT_BLEN        (1)
+#define GPIO_OUTPUT_MASK        (1ul << (GPIO_OUTPUT_BITPOS))
+#define GPIO_OUT_LO             (0x00UL << (GPIO_OUTPUT_BITPOS))
+#define GPIO_OUT_HI             (0x01UL << (GPIO_OUTPUT_BITPOS))
+#define GP_OUTPUT_0             (0x00UL)    // Byte or Bit-banding usage
+#define GP_OUTPUT_1             (0x01UL)
+
+#define GPIO_PADIN_BITPOS       (24)
+#define GPIO_PADIN_BLEN         (1)
+#define GPIO_PADIN_LOW          (0x00UL << (GPIO_PADIN_BITPOS))
+#define GPIO_PADIN_HI           (0x01UL << (GPIO_PADIN_BITPOS))
+#define GP_PADIN_LO             (0x00UL)    // Byte or Bit-banding usage
+#define GP_PADIN_HI             (0x01UL)
+
+#define GPIO_PIN_LOW            (0UL)
+#define GPIO_PIN_HIGH           (1UL)
+
+#define GPIO_DRIVE_OD_HI        (GPIO_BUFT_OPENDRAIN + GPIO_DIR_OUTPUT +\
+    GPIO_ALTOUT_EN + GPIO_POLARITY_NON_INV + GPIO_MUX_GPIO + GPIO_OUTPUT_1)
+
+#define GPIO_DRIVE_OD_HI_MASK   (GPIO_BUFT_MASK + GPIO_DIR_MASK +\
+    GPIO_ALTOUT_MASK + GPIO_POLARITY_MASK + GPIO_MUX_MASK + GPIO_OUTPUT_MASK)
+
+/*
+ * Drive Strength
+ * For GPIO pins that implement drive strength each pin
+ * has a 32-bit register containing bit fields for
+ * slew rate and buffer drive strength
+ */
+#define GPIO_DRV_STR_OFFSET     (0x0500ul)
+#define GPIO_DRV_SLEW_POS    	0ul
+#define GPIO_DRV_SLEW_MASK      (1ul << GPIO_DRV_SLEW_POS)
+#define GPIO_DRV_SLEW_SLOW      (0ul << GPIO_DRV_SLEW_POS)
+#define GPIO_DRV_SLEW_FAST      (1ul << GPIO_DRV_SLEW_POS)
+#define GPIO_DRV_STR_POS     	4ul
+#define GPIO_DRV_STR_LEN        2ul
+#define GPIO_DRV_STR_MASK       (0x03ul << GPIO_DRV_STR_POS)
+#define GPIO_DRV_STR_2MA        (0ul << GPIO_DRV_STR_POS)
+#define GPIO_DRV_STR_4MA        (1ul << GPIO_DRV_STR_POS)
+#define GPIO_DRV_STR_8MA        (2ul << GPIO_DRV_STR_POS)
+#define GPIO_DRV_STR_12MA       (3ul << GPIO_DRV_STR_POS)
+
+/*
+ * Indices for GPIO Control/Control2 register arrays
+ */
+#define GPIO_PIN_0000       (0u)    /* Port A at register offset 00h */
+#define GPIO_PIN_0001       (1u)
+#define GPIO_PIN_0002       (2u)
+#define GPIO_PIN_0003       (3u)
+#define GPIO_PIN_0004       (4u)
+#define GPIO_PIN_0005       (5u)
+#define GPIO_PIN_0006       (6u)
+#define GPIO_PIN_0007       (7u)
+
+#define GPIO_PIN_0010       (8u)
+#define GPIO_PIN_0011       (9u)
+#define GPIO_PIN_0012       (10u)
+#define GPIO_PIN_0013       (11u)
+#define GPIO_PIN_0014       (12u)
+#define GPIO_PIN_0015       (13u)
+#define GPIO_PIN_0016       (14u)
+#define GPIO_PIN_0017       (15u)
+
+#define GPIO_PIN_0020       (16u)
+#define GPIO_PIN_0021       (17u)
+#define GPIO_PIN_0022       (18u)
+#define GPIO_PIN_0023       (19u)
+#define GPIO_PIN_0024       (20u)
+#define GPIO_PIN_0025       (21u)
+#define GPIO_PIN_0026       (22u)
+#define GPIO_PIN_0027       (23u)
+
+#define GPIO_PIN_0030       (24u)
+#define GPIO_PIN_0031       (25u)
+#define GPIO_PIN_0032       (26u)
+#define GPIO_PIN_0033       (27u)
+#define GPIO_PIN_0034       (28u)
+#define GPIO_PIN_0035       (29u)
+#define GPIO_PIN_0036       (30u)
+
+#define GPIO_PIN_0040       (32u)   /* Port B at register offset 80h */
+#define GPIO_PIN_0041       (33u)
+#define GPIO_PIN_0042       (34u)
+#define GPIO_PIN_0043       (35u)
+#define GPIO_PIN_0044       (36u)
+#define GPIO_PIN_0045       (37u)
+#define GPIO_PIN_0046       (38u)
+#define GPIO_PIN_0047       (39u)
+
+#define GPIO_PIN_0050       (40u)
+#define GPIO_PIN_0051       (41u)
+#define GPIO_PIN_0052       (42u)
+#define GPIO_PIN_0053       (43u)
+#define GPIO_PIN_0054       (44u)
+#define GPIO_PIN_0055       (45u)
+#define GPIO_PIN_0056       (46u)
+#define GPIO_PIN_0057       (47u)
+
+#define GPIO_PIN_0060       (48u)
+#define GPIO_PIN_0061       (49u)
+#define GPIO_PIN_0062       (50u)
+#define GPIO_PIN_0063       (51u)
+#define GPIO_PIN_0064       (52u)
+#define GPIO_PIN_0065       (53u)
+#define GPIO_PIN_0066       (54u)
+#define GPIO_PIN_0067       (55u)
+
+#define GPIO_PIN_0070       (56u)
+#define GPIO_PIN_0071       (57u)
+#define GPIO_PIN_0072       (58u)
+#define GPIO_PIN_0073       (59u)
+#define GPIO_PIN_0074       (60u)
+#define GPIO_PIN_0075       (61u)
+#define GPIO_PIN_0076       (62u)
+
+#define GPIO_PIN_0100       (64u)   /* Port C at register offset 100h */
+#define GPIO_PIN_0101       (65u)
+#define GPIO_PIN_0102       (66u)
+#define GPIO_PIN_0103       (67u)
+#define GPIO_PIN_0104       (68u)
+#define GPIO_PIN_0105       (69u)
+#define GPIO_PIN_0106       (70u)
+#define GPIO_PIN_0107       (71u)
+
+#define GPIO_PIN_0110       (72u)
+#define GPIO_PIN_0111       (73u)
+#define GPIO_PIN_0112       (74u)
+#define GPIO_PIN_0113       (75u)
+#define GPIO_PIN_0114       (76u)
+#define GPIO_PIN_0115       (77u)
+#define GPIO_PIN_0116       (78u)
+#define GPIO_PIN_0117       (79u)
+
+#define GPIO_PIN_0120       (80u)
+#define GPIO_PIN_0121       (81u)
+#define GPIO_PIN_0122       (82u)
+#define GPIO_PIN_0123       (83u)
+#define GPIO_PIN_0124       (84u)
+#define GPIO_PIN_0125       (85u)
+#define GPIO_PIN_0126       (86u)
+#define GPIO_PIN_0127       (87u)
+
+#define GPIO_PIN_0130       (88u)
+#define GPIO_PIN_0131       (89u)
+#define GPIO_PIN_0132       (90u)
+#define GPIO_PIN_0133       (91u)
+#define GPIO_PIN_0134       (92u)
+#define GPIO_PIN_0135       (93u)
+#define GPIO_PIN_0136       (94u)
+
+#define GPIO_PIN_0140       (96u)   /* Port D at register offset 180h */
+#define GPIO_PIN_0141       (97u)
+#define GPIO_PIN_0142       (98u)
+#define GPIO_PIN_0143       (99u)
+#define GPIO_PIN_0144       (100u)
+#define GPIO_PIN_0145       (101u)
+#define GPIO_PIN_0146       (102u)
+#define GPIO_PIN_0147       (103u)
+
+#define GPIO_PIN_0150       (104u)
+#define GPIO_PIN_0151       (105u)
+#define GPIO_PIN_0152       (106u)
+#define GPIO_PIN_0153       (107u)
+#define GPIO_PIN_0154       (108u)
+#define GPIO_PIN_0155       (109u)
+#define GPIO_PIN_0156       (110u)
+#define GPIO_PIN_0157       (111u)
+
+#define GPIO_PIN_0160       (112u)
+#define GPIO_PIN_0161       (113u)
+#define GPIO_PIN_0162       (114u)
+#define GPIO_PIN_0163       (115u)
+#define GPIO_PIN_0164       (116u)
+#define GPIO_PIN_0165       (117u)
+#define GPIO_PIN_0166       (118u)
+#define GPIO_PIN_0167       (119u)
+
+#define GPIO_PIN_0170       (120u)
+#define GPIO_PIN_0171       (121u)
+#define GPIO_PIN_0172       (122u)
+#define GPIO_PIN_0173       (123u)
+#define GPIO_PIN_0174       (124u)
+#define GPIO_PIN_0175       (125u)
+#define GPIO_PIN_0176       (126u)
+
+#define GPIO_PIN_0200       (128u)  /* Port E at register offset 200h */
+#define GPIO_PIN_0201       (129u)
+#define GPIO_PIN_0202       (130u)
+#define GPIO_PIN_0203       (131u)
+#define GPIO_PIN_0204       (132u)
+#define GPIO_PIN_0205       (133u)
+#define GPIO_PIN_0206       (134u)
+#define GPIO_PIN_0207       (135u)
+
+#define GPIO_PIN_0210       (136u)
+#define GPIO_PIN_0211       (137u)
+#define GPIO_PIN_0212       (138u)
+#define GPIO_PIN_0213       (139u)
+#define GPIO_PIN_0214       (140u)
+#define GPIO_PIN_0215       (141u)
+#define GPIO_PIN_0216       (142u)
+#define GPIO_PIN_0217       (143u)
+
+#define GPIO_PIN_0220       (144u)
+#define GPIO_PIN_0221       (145u)
+#define GPIO_PIN_0222       (146u)
+#define GPIO_PIN_0223       (147u)
+#define GPIO_PIN_0224       (148u)
+#define GPIO_PIN_0225       (149u)
+#define GPIO_PIN_0226       (150u)
+#define GPIO_PIN_0227       (151u)
+
+#define GPIO_PIN_0230       (152u)
+#define GPIO_PIN_0231       (153u)
+#define GPIO_PIN_0232       (154u)
+#define GPIO_PIN_0233       (155u)
+#define GPIO_PIN_0234       (156u)
+#define GPIO_PIN_0235       (157u)
+#define GPIO_PIN_0236       (158u)
+
+#define GPIO_PIN_0240       (160u)  /* Port F at register offset 280h */
+#define GPIO_PIN_0241       (161u)
+#define GPIO_PIN_0242       (162u)
+#define GPIO_PIN_0243       (163u)
+#define GPIO_PIN_0244       (164u)
+#define GPIO_PIN_0245       (165u)
+#define GPIO_PIN_0246       (166u)
+#define GPIO_PIN_0247       (167u)
+
+#define GPIO_PIN_0250       (168u)
+#define GPIO_PIN_0251       (169u)
+#define GPIO_PIN_0252       (170u)
+#define GPIO_PIN_0253       (172u)
+#define GPIO_PIN_0254       (173u)
+#define GPIO_PIN_0255       (174u)
+
+#define GPIO_PIN_MAX        (175u)
+
+
+/* =========================================================================*/
+/* ================            GPIO                        ================ */
+/* =========================================================================*/
+
+/**
+  * @brief GPIO Control (GPIO)
+  */
+#define GPIO_CTRL_BEGIN     0
+#define GPIO_CTRL_END       0x2C4
+#define GPIO_PIN_BEGIN      0x300
+#define GPIO_PIN_END        0x318
+#define GPIO_POUT_BEGIN     0x380
+#define GPIO_POUT_END       0x398
+#define GPIO_LOCK_BEGIN     0x3E8
+#define GPIO_LOCK_END       0x400
+#define GPIO_CTRL2_BEGIN    0x500
+#define GPIO_CTRL2_END      0x7B4
+
+#define MAX_GPIO_PIN    ((GPIO_CTRL_END) / 4)
+#define MAX_GPIO_BANK   6u
+#define GPIO_LOCK5_IDX      0u
+#define GPIO_LOCK4_IDX      1u
+#define GPIO_LOCK3_IDX      2u
+#define GPIO_LOCK2_IDX      3u
+#define GPIO_LOCK1_IDX      4u
+#define GPIO_LOCK0_IDX      5u
+#define GPIO_LOCK_MAX_IDX   6u
+
+typedef union
+{
+    __IOM uint32_t u32;
+    __IOM uint16_t u16[2];
+    __IOM uint8_t  u8[4];
+} GPIO_CTRL_Type;
+
+typedef union
+{
+    __IOM uint32_t u32;
+} GPIO_PARIN_Type;
+
+typedef union
+{
+    __IOM uint32_t u32;
+} GPIO_PAROUT_Type;
+
+typedef union
+{
+    __IOM uint32_t u32;
+    __IOM uint16_t u16[2];
+    __IOM uint8_t  u8[4];
+} GPIO_CTRL2_Type;
+
+typedef struct
+{
+    GPIO_CTRL_Type      CTRL[MAX_GPIO_PIN];     /*!< (@ 0x00000000) GPIO Control register array */
+    uint8_t             RSVD1[0x300 - 0x2C4];
+    GPIO_PARIN_Type     PARIN[MAX_GPIO_BANK];   /*!< (@ 0x00000300) GPIO Parallel Input */
+    uint8_t             RSVD2[0x380 - 0x318];
+    GPIO_PAROUT_Type    PAROUT[MAX_GPIO_BANK];  /*!< (@ 0x00000380) GPIO Parallel Output */
+    uint8_t             RSVD3[0x3E8 - 0x398];
+    __IOM uint32_t      LOCK5;                  /*!< (@ 0x000003E8) GPIO Lock 5 */
+    __IOM uint32_t      LOCK4;                  /*!< (@ 0x000003EC) GPIO Lock 4 */
+    __IOM uint32_t      LOCK3;                  /*!< (@ 0x000003F0) GPIO Lock 3 */
+    __IOM uint32_t      LOCK2;                  /*!< (@ 0x000003F4) GPIO Lock 2 */
+    __IOM uint32_t      LOCK1;                  /*!< (@ 0x000003F8) GPIO Lock 1 */
+    __IOM uint32_t      LOCK0;                  /*!< (@ 0x000003FC) GPIO Lock 0 */
+    uint8_t             RSVD4[0x500 - 0x400];
+    GPIO_CTRL2_Type     CTRL2[MAX_GPIO_PIN];    /*!< (@ 0x00000500) GPIO Control 2 register array */
+} GPIO_Type;
+
+
+#endif /* #ifndef _GPIO_H */
+/* end gpio.h */
+/**   @}
+ */

--- a/ext/hal/microchip/mec/mec1501/component/led.h
+++ b/ext/hal/microchip/mec/mec1501/component/led.h
@@ -1,0 +1,155 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file led.h
+ *MEC1501 Breathing-Blinking LED definitions
+ */
+/** @defgroup MEC1501 Peripherals LED
+ */
+
+#ifndef _LED_H
+#define _LED_H
+
+#define LED_NUM_BLOCKS          3
+
+#define LED_CFG_OFS             0x00
+#define LED_LIMITS_OFS          0x04
+#define LED_DELAY_OFS           0x08
+#define LED_UPD_STEP_OFS        0x0C
+#define LED_UPD_INTRVL_OFS      0x10
+#define LED_OUTPUT_DLY_OFS      0x14
+
+/*
+ * LED Configuration Register
+ */
+#define LED_CFG_CNTL_MASK               0x0003u
+#define     LED_CFG_CNTL_LO             0x0000u
+#define     LED_CFG_CNTL_BREATH         0x0001u
+#define     LED_CFG_CNTL_BLINK          0x0002u
+#define     LED_CFG_CNTL_HI             0x0003u
+#define LED_CFG_CLK_SRC_MCLK            0x0002u
+#define LED_CFG_CLK_SRC_32K             0x0000u
+#define LED_CFG_SYNC                    0x0008u
+#define LED_CFG_PWM_COUNT_WIDTH_MASK    0x0030u
+#define     LED_CFG_COUNT_WIDTH_8       0x0000u
+#define     LED_CFG_COUNT_WIDTH_7       0x0010u
+#define     LED_CFG_COUNT_WIDTH_6       0x0020u
+#define LED_CFG_EN_UPDATE               0x0040u
+#define LED_CFG_RESET                   0x0080u
+#define LED_CFG_WDT_PRELOAD_MASK        0xFF00u
+#define LED_CFG_WDT_PRELOAD_POR         0x1400u
+#define LED_CFG_SYMMETRY_EN             0x10000u
+
+/*
+ * LED Limit Register
+ */
+#define LED_LIM_MIN_POS             0u
+#define LED_LIM_MIN_MASK            0xFFu
+#define LED_LIM_MAX_POS             8u
+#define LED_LIM_MAX_MASK            0xFF00ul
+
+/*
+ * LED Delay Register
+ */
+#define LED_DLY_LO_MASK             0x0000FFFul
+#define LED_DLY_HI_MASK             0x0FFF000ul
+#define LED_DLY_HI_POS              12u
+
+/*
+ * LED Step Size Register
+ */
+#define LED_STEP_FIELD_WIDTH        4u
+#define LED_STEP_MASK0              0x0Ful
+#define LED_STEP0_POS               0
+#define LED_STEP0_MASK              0x0000000Ful
+#define LED_STEP1_POS               4
+#define LED_STEP1_MASK              0x000000F0ul
+#define LED_STEP2_POS               8
+#define LED_STEP2_MASK              0x00000F00ul
+#define LED_STEP3_POS               12
+#define LED_STEP3_MASK              0x0000F000ul
+#define LED_STEP4_POS               16
+#define LED_STEP4_MASK              0x000F0000ul
+#define LED_STEP5_POS               20
+#define LED_STEP5_MASK              0x00F00000ul
+#define LED_STEP6_POS               24
+#define LED_STEP6_MASK              0x0F000000ul
+#define LED_STEP7_POS               28
+#define LED_STEP7_MASK              0xF0000000ul
+
+/*
+ * LED Update Register
+ */
+#define LED_UPDT_FIELD_WIDTH        4u
+#define LED_UPDT_MASK0              0x0Ful;
+#define LED_UPDT0_POS               0
+#define LED_UPDT0_MASK              0x0000000Ful
+#define LED_UPDT1_POS               4
+#define LED_UPDT1_MASK              0x000000F0ul
+#define LED_UPDT2_POS               8
+#define LED_UPDT2_MASK              0x00000F00ul
+#define LED_UPDT3_POS               12
+#define LED_UPDT3_MASK              0x0000F000ul
+#define LED_UPDT4_POS               16
+#define LED_UPDT4_MASK              0x000F0000ul
+#define LED_UPDT5_POS               20
+#define LED_UPDT5_MASK              0x00F00000ul
+#define LED_UPDT6_POS               24
+#define LED_UPDT6_MASK              0x0F000000ul
+#define LED_UPDT7_POS               28
+#define LED_UPDT7_MASK              0xF0000000ul
+
+
+#define BLINK_0P5_HZ_DUTY_CYCLE     0x010ul
+#define BLINK_0P5_HZ_PRESCALE       0x0FFul
+#define BLINK_1_HZ_DUTY_CYCLE       0x020ul
+#define BLINK_1_HZ_PRESCALE         0x07Ful
+
+/* =======================================================================*/
+/* ================            LED                       ================ */
+/* =======================================================================*/
+
+#define LED_MAX_INSTANCES      3
+#define LED_SPACING            0x100
+#define LED_SPACING_PWROF2     8
+
+/**
+  * @brief Breathing-Blinking LED (LED)
+  */
+typedef struct
+{               /*!< (@ 0x4000B800) BBLED Structure   */
+    __IOM uint32_t CFG;         /*! (@ 0x00000000) LED configuration */
+    __IOM uint32_t LIMIT;       /*! (@ 0x00000004) LED limits */
+    __IOM uint32_t DLY;         /*! (@ 0x00000008) LED delay */
+    __IOM uint32_t STEP;        /*! (@ 0x0000000C) LED update step size */
+    __IOM uint32_t INTRVL;      /*! (@ 0x00000010) LED update interval */
+    __IOM uint32_t OUTDLY;      /*! (@ 0x00000014) LED output delay */
+} LED_Type;
+
+#endif /* #ifndef _LED_H */
+/* end led.h */
+/**   @}
+ */

--- a/ext/hal/microchip/mec/mec1501/component/pcr.h
+++ b/ext/hal/microchip/mec/mec1501/component/pcr.h
@@ -1,0 +1,301 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file pcr.h
+ *MEC1501 Power Control Reset definitions
+ */
+/** @defgroup MEC1501 Peripherals PCR
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifndef _PCR_H
+#define _PCR_H
+
+#define PCR_BASE_ADDR           0x40080100ul
+
+#define PCR_SYS_SLP_CTRL_ADDR   (PCR_BASE_ADDR)
+#define PCR_SYS_CLK_CTRL_ADDR   (PCR_BASE_ADDR + 0x04)
+#define PCR_SLOW_CLK_CTRL_ADDR  (PCR_BASE_ADDR + 0x08)
+#define PCR_OSC_ID_ADDR         (PCR_BASE_ADDR + 0x0C)
+#define PCR_PRS_ADDR            (PCR_BASE_ADDR + 0x10)
+#define PCR_PR_CTRL_ADDR        (PCR_BASE_ADDR + 0x14)
+#define PCR_SYS_RESET_ADDR      (PCR_BASE_ADDR + 0x18)
+#define PCR_PKE_CLK_CTRL_ADDR   (PCR_BASE_ADDR + 0x1C)
+#define PCR_SLP_EN0_ADDR        (PCR_BASE_ADDR + 0x30)
+#define PCR_CLK_REQ0_ADDR       (PCR_BASE_ADDR + 0x50)
+#define PCR_SLP_EN1_ADDR        (PCR_BASE_ADDR + 0x34)
+#define PCR_CLK_REQ1_ADDR       (PCR_BASE_ADDR + 0x54)
+#define PCR_SLP_EN2_ADDR        (PCR_BASE_ADDR + 0x38)
+#define PCR_CLK_REQ2_ADDR       (PCR_BASE_ADDR + 0x58)
+#define PCR_SLP_EN3_ADDR        (PCR_BASE_ADDR + 0x3C)
+#define PCR_CLK_REQ3_ADDR       (PCR_BASE_ADDR + 0x5C)
+#define PCR_SLP_EN4_ADDR        (PCR_BASE_ADDR + 0x40)
+#define PCR_CLK_REQ4_ADDR       (PCR_BASE_ADDR + 0x60)
+
+#define PCR_SLP_EN_ADDR(n)       (PCR_BASE_ADDR + 0x30 + ((n) << 2))
+#define PCR_CLK_REQ_ADDR(n)      (PCR_BASE_ADDR + 0x50 + ((n) << 2))
+
+#define PCR_SLEEP_EN    (1u)
+#define PCR_SLEEP_DIS   (0u)
+
+/*
+ * MEC1501 PCR implements multiple SLP_EN, CLR_REQ, and RST_EN registers.
+ */
+#define MAX_PCR_SCR_REGS    5
+
+/*
+ * VTR Powered PCR registers
+ */
+
+#define PCR_SLP(bitpos)     (1ul << (bitpos))
+
+/*
+ * PCR System Sleep Control
+ */
+#define PCR_SYS_SLP_CTRL_OFS            0x00
+#define PCR_SYS_SLP_CTRL_MASK           0x09
+#define PCR_SYS_SLP_CTRL_SLP_LIGHT      (0 << 0)
+#define PCR_SYS_SLP_CTRL_SLP_HEAVY      (1 << 0)
+#define PCR_SYS_SLP_CTRL_SLP_ALL        (1 << 3)
+
+/*
+ * PCR Process Clock Control
+ * Divides 48MHz clock to ARM Cortex-M4 core including
+ * SysTick and NVIC.
+ */
+#define PCR_PROC_CLK_CTRL_OFS           0x04
+#define PCR_PROC_CLK_CTRL_MASK          0xFF
+#define PCR_PROC_CLK_CTRL_48MHZ         0x01
+#define PCR_PROC_CLK_CTRL_16MHZ         0x03
+#define PCR_PROC_CLK_CTRL_12MHZ         0x04
+#define PCR_PROC_CLK_CTRL_4MHZ          0x10
+#define PCR_PROC_CLK_CTRL_1MHZ          0x30
+
+/*
+ * PCR Slow Clock Control
+ * Clock divicder for 100KHz clock domain
+ */
+#define PCR_SLOW_CLK_CTRL_OFS           0x08
+#define PCR_SLOW_CLK_CTRL_MASK          0x3FF
+#define PCR_SLOW_CLK_CTRL_100KHZ        0x1E0
+
+/*
+ * PCR Oscillator ID register (Read-Only)
+ */
+#define PCR_OSC_ID_OFS                  0x0C
+#define PCR_OSC_ID_MASK                 0x1FF
+#define PCR_OSC_ID_PLL_LOCK             (1u << 8)
+
+/*
+ * PCR Power Reset Status Register
+ */
+#define PCR_PRS_OFS                     0x10
+#define PCR_PRS_MASK                    0xCEC
+#define PCR_PRS_VCC_PWRGD_STATE_RO      (1u << 2)
+#define PCR_PRS_HOST_RESET_STATE_RO     (1u << 3)
+#define PCR_PRS_VBAT_RST_RWC            (1u << 5)
+#define PCR_PRS_VTR_RST_RWC             (1u << 6)
+#define PCR_PRS_JTAG_RST_RWC            (1u << 7)
+#define PCR_PRS_32K_ACTIVE_RO           (1u << 10)
+#define PCR_PRS_LPC_ESPI_CLK_ACTIVE_RO  (1u << 11)
+
+/*
+ * PCR Power Reset Control Register
+ */
+#define PCR_PR_CTRL_OFS                 0x14
+#define PCR_PR_CTRL_MASK                0x101
+#define PCR_PR_CTRL_PWR_INV             (1 << 0)
+#define PCR_PR_CTRL_USE_ESPI_PLTRST     (0 << 8)
+#define PCR_PR_CTRL_USE_LRESET          (1 << 8)
+
+/*
+ * PCR System Reset Register
+ */
+#define PCR_SYS_RESET_OFS               0x18
+#define PCR_SYS_RESET_MASK              0x100
+#define PCR_SYS_RESET_NOW               (1 << 8)
+
+/*
+ * PCR PKE Clock Register
+ */
+#define PCR_PKE_CLK_CTRL_OFS            0x1C
+#define PCR_PKE_CLK_CTRL_MASK           0x03
+#define PCR_PKE_CLK_CTRL_96M            0x00
+#define PCR_PKE_CLK_CTRL_48M            0x03
+
+/*
+ * Sleep Enable Reg 0       (Offset +30h)
+ * Clock Required Reg 0     (Offset +50h)
+ * Reset Enable Reg 3       (Offset +70h)
+ */
+#define PCR0_JTAG_STAP_POS      0u
+
+/*
+ * Sleep Enable Reg 1       (Offset +34h)
+ * Clock Required Reg 1     (Offset +54h)
+ * Reset Enable Reg 1       (Offset +74h)
+ */
+#define PCR1_ECIA_POS           0u
+#define PCR1_PECI_POS           1u
+#define PCR1_TACH0_POS          2u
+#define PCR1_PWM0_POS           4u
+#define PCR1_PMC_POS            5u
+#define PCR1_DMA_POS            6u
+#define PCR1_TFDP_POS           7u
+#define PCR1_CPU_POS            8u
+#define PCR1_WDT_POS            9u
+#define PCR1_I2CSMB0_POS        10u
+#define PCR1_TACH1_POS          11u
+#define PCR1_TACH2_POS          12u
+#define PCR1_TACH3_POS          13u
+#define PCR1_PWM1_POS           20u
+#define PCR1_PWM2_POS           21u
+#define PCR1_PWM3_POS           22u
+#define PCR1_PWM4_POS           23u
+#define PCR1_PWM5_POS           24u
+#define PCR1_PWM6_POS           25u
+#define PCR1_PWM7_POS           26u
+#define PCR1_PWM8_POS           27u
+#define PCR1_ECS_POS            29u
+#define PCR1_BTMR0_POS          30u
+#define PCR1_BTMR1_POS          31u
+
+/*
+ * Sleep Enable Reg 2       (Offset +38h)
+ * Clock Required Reg 2     (Offset +58h)
+ * Reset Enable Reg 2       (Offset +78h)
+ */
+#define PCR2_EMI0_POS           0u
+#define PCR2_UART0_POS          1u
+#define PCR2_UART1_POS          2u
+#define PCR2_GCFG_POS           12u
+#define PCR2_ACPI_EC0_POS       13u
+#define PCR2_ACPI_EC1_POS       14u
+#define PCR2_ACPI_PM1_POS       15u
+#define PCR2_EM8042_POS         16u
+#define PCR2_MBOX_POS           17u
+#define PCR2_RTC_POS            18u
+#define PCR2_ESPI_POS           19u
+#define PCR2_SCR32_POS          20u
+#define PCR2_ACPI_EC2_POS       21u
+#define PCR2_ACPI_EC3_POS       22u
+#define PCR2_PORT80CAP0_POS     25u
+#define PCR2_PORT80CAP1_POS     26u
+#define PCR2_ESPI_SAF_POS       27u
+#define PCR2_UART2_POS          28u
+
+/*
+ * Sleep Enable Reg 3       (Offset +3Ch)
+ * Clock Required Reg 3     (Offset +5Ch)
+ * Reset Enable Reg 3       (Offset +7Ch)
+ */
+#define PCR3_HDMI_CEC_POS           1u
+#define PCR3_ADC_POS                3u
+#define PCR3_PS20_POS               5u
+#define PCR3_PS21_POS               6u
+#define PCR3_HTMR0_POS              10u
+#define PCR3_KEYSCAN_POS            11u
+#define PCR3_I2CSMB1_POS            13u
+#define PCR3_I2CSMB2_POS            14u
+#define PCR3_I2CSMB3_POS            15u
+#define PCR3_LED0_POS               16u
+#define PCR3_LED1_POS               17u
+#define PCR3_LED2_POS               18u
+#define PCR3_I2CSMB4_POS            20u
+#define PCR3_BTMR4_POS              23u
+#define PCR3_BTMR5_POS              24u
+#define PCR3_PKE_POS                26u
+#define PCR3_RNG_POS                27u
+#define PCR3_AESH_POS               28u
+#define PCR3_HTMR1_POS              29u
+#define PCR3_CCT_POS                30u
+
+/*
+ * Sleep Enable Reg 4       (Offset +40h)
+ * Clock Required Reg 4     (Offset +60h)
+ * Reset Enable Reg 4       (Offset +80h)
+ */
+#define PCR4_RTMR_POS           6u
+#define PCR4_QMSPI_POS          8u
+#define PCR4_I2C0_POS           10u
+#define PCR4_I2C1_POS           11u
+#define PCR4_I2C3_POS           12u
+#define PCR4_SPISLV_POS         16u
+
+/* Reset Enable Lock        (Offset +84h) */
+#define PCR_RSTEN_UNLOCK    0xA6382D4C
+#define PCR_RSTEN_LOCK      0xA6382D4D
+
+
+/* =====================================================================*/
+/* ================          PCR                       ================ */
+/* =====================================================================*/
+
+/**
+  * @brief Power Control Reset (PCR)
+  */
+#define PCR_MAX_SLPEN_IDX   5
+
+typedef struct
+{           /*!< (@ 0x40080100) PCR Structure   */
+    __IOM uint32_t SYS_SLP_CTRL;            /*!< (@ 0x0000) System Sleep Control */
+    __IOM uint32_t PROC_CLK_CTRL;           /*!< (@ 0x0004) Processor Clock Control */
+    __IOM uint32_t SLOW_CLK_CTRL;           /*!< (@ 0x0008) Slow Clock Control */
+    __IOM uint32_t OSC_ID;                  /*!< (@ 0x000C) Processor Clock Control */
+    __IOM uint32_t PWR_RST_STS;             /*!< (@ 0x0010) Power Reset Status */
+    __IOM uint32_t PWR_RST_CTRL;            /*!< (@ 0x0014) Power Reset Control */
+    __IOM uint32_t SYS_RST;                 /*!< (@ 0x0018) System Reset */
+    __IOM uint32_t TEST1C;
+    __IOM uint32_t TEST20;
+          uint8_t  RSVD1[12];
+    __IOM uint32_t SLP_EN0;                 /*!< (@ 0x0030) Sleep Enable 0 */
+    __IOM uint32_t SLP_EN1;                 /*!< (@ 0x0034) Sleep Enable 1 */
+    __IOM uint32_t SLP_EN2;                 /*!< (@ 0x0038) Sleep Enable 2 */
+    __IOM uint32_t SLP_EN3;                 /*!< (@ 0x003C) Sleep Enable 3 */
+    __IOM uint32_t SLP_EN4;                 /*!< (@ 0x0040) Sleep Enable 4 */
+          uint8_t  RSVD2[12];
+    __IOM uint32_t CLK_REQ0;                /*!< (@ 0x0050) Clock Required 0 (RO) */
+    __IOM uint32_t CLK_REQ1;                /*!< (@ 0x0054) Clock Required 1 (RO) */
+    __IOM uint32_t CLK_REQ2;                /*!< (@ 0x0058) Clock Required 2 (RO) */
+    __IOM uint32_t CLK_REQ3;                /*!< (@ 0x005C) Clock Required 3 (RO) */
+    __IOM uint32_t CLK_REQ4;                /*!< (@ 0x0060) Clock Required 4 (RO) */
+          uint8_t  RSVD3[12];
+    __IOM uint32_t RST_EN0;                 /*!< (@ 0x0070) Peripheral Reset 0 */
+    __IOM uint32_t RST_EN1;                 /*!< (@ 0x0074) Peripheral Reset 1 */
+    __IOM uint32_t RST_EN2;                 /*!< (@ 0x0078) Peripheral Reset 2 */
+    __IOM uint32_t RST_EN3;                 /*!< (@ 0x007C) Peripheral Reset 3 */
+    __IOM uint32_t RST_EN4;                 /*!< (@ 0x0080) Peripheral Reset 4 */
+    __IOM uint32_t RST_EN_LOCK;             /*!< (@ 0x0084) Peripheral Lock */
+} PCR_Type;
+
+
+#endif // #ifndef _DEFS_H
+/* end pcr.h */
+/**   @}
+ */
+

--- a/ext/hal/microchip/mec/mec1501/component/qmspi.h
+++ b/ext/hal/microchip/mec/mec1501/component/qmspi.h
@@ -1,0 +1,363 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file qmspi.h
+ *MEC1501 Quad Master SPI Registers
+ */
+/** @defgroup MEC1501 Peripherals QMSPI
+ */
+
+#ifndef _QMSPI_H_
+#define _QMSPI_H_
+
+#define QMPSPI_HW_VER               3
+
+#define QMSPI_BASE_ADDR             0x40070000ul
+
+#define QMSPI_PORT_GPIO_BASE        0x40081000ul
+#define QMSPI_PORT_GPIO_BASE2       0x40081500ul
+
+#define QMSPI_MAX_DESCR             16ul
+
+#define QMSPI_INPUT_CLOCK_FREQ_HZ   48000000ul
+#define QMSPI_MAX_FREQ_KHZ          ((QMSPI_INPUT_CLOCK_FREQ_HZ) / 1000)
+#define QMSPI_MIN_FREQ_KHZ          (QMSPI_MAX_FREQ_KHZ / 256)
+
+#define QMSPI_GIRQ_NUM              18
+#define QMSPI_GIRQ_POS              1
+#define QMSPI_GIRQ_OFS              (((QMSPI0_GIRQ_NUM) - 8) * 20)
+#define QMSPI_GIRQ_BASE_ADDR        0x4000E0C8ul
+/* Sleep Enable 4 bit 8 */
+#define QMSPI_PCR_SLP_EN_ADDR       0x40080140ul
+#define QMSPI_PCR_SLP_EN_BITPOS     8
+
+#define QMSPI_GIRQ_SRC_ADDR        (QMSPI_GIRQ_BASE_ADDR)
+#define QMSPI_GIRQ_ENSET_ADDR      (QMSPI_GIRQ_BASE_ADDR + 0x04)
+#define QMSPI_GIRQ_RESULT_ADDR     (QMSPI_GIRQ_BASE_ADDR + 0x08)
+#define QMSPI_GIRQ_ENCLR_ADDR      (QMSPI_GIRQ_BASE_ADDR + 0x0C)
+
+#define QMSPI_GIRQ_EN              (1ul << (QMSPI_GIRQ_POS))
+#define QMSPI_GIRQ_STS             (1ul << (QMSPI_GIRQ_POS))
+
+/* Mode 0: Clock idle = Low. Data changes on falling edge, sample on rising edge */
+#define QMSPI_SPI_MODE0             0
+/* Mode 1: Clock idle = Low. Data changes on rising edge, sample on falling edge */
+#define QMSPI_SPI_MODE1             0x06
+/* Mode 2: Clock idle = High. Data changes on rising edge, sample on falling edge */
+#define QMSPI_SPI_MODE2             0x06
+/* Mode 3: Clock idle = High. Data changes on falling edge, sample on rising edge */
+#define QMSPI_SPI_MODE3             0x07
+
+/* DMA Main */
+#define QMSPI_DMA_MAIN_ACT_ADDR     0x40002400ul
+#define QMSPI_DMA_MAIN_PKT_ADDR     0x40002404ul
+
+/* Choose DMA channel 10 for QMSPI transmit */
+#define QMSPI_TX_DMA_CHAN           10
+#define QMSPI_TX_DMA_ACT_ADDR       0x400026C0ul
+#define QMSPI_TX_DMA_MSTART_ADDR    0x400026C4ul
+#define QMSPI_TX_DMA_MEND_ADDR      0x400026C8ul
+#define QMSPI_TX_DMA_DEV_ADDR       0x400026CCul
+#define QMSPI_TX_DMA_CTRL_ADDR      0x400026D0ul
+#define QMSPI_TX_DMA_ISTS_ADDR      0x400026D4ul
+#define QMSPI_TX_DMA_IEN_ADDR       0x400026D8ul
+#define QMSPI_TX_DMA_FSM_ADDR       0x400026DCul
+
+/* Choose DMA channel 11 for QMSPI receive */
+#define QMSPI_RX_DMA_CHAN           11
+#define QMSPI_RX_DMA_ACT_ADDR       0x40002700ul
+#define QMSPI_RX_DMA_MSTART_ADDR    0x40002704ul
+#define QMSPI_RX_DMA_MEND_ADDR      0x40002708ul
+#define QMSPI_RX_DMA_DEV_ADDR       0x4000270Cul
+#define QMSPI_RX_DMA_CTRL_ADDR      0x40002710ul
+#define QMSPI_RX_DMA_ISTS_ADDR      0x40002714ul
+#define QMSPI_RX_DMA_IEN_ADDR       0x40002718ul
+#define QMSPI_RX_DMA_FSM_ADDR       0x4000271Cul
+
+// Device ID used with DMA block
+#define QMSPI_TX_DMA_REQ_ID         10u
+#define QMSPI_RX_DMA_REQ_ID         11u
+
+/*
+ * QMSPI DMA ID and DMA direction 8-bit value
+ * b[7:1] = QMSPI DMA ID
+ * b[0] = direction
+ *      = 0 dev to mem (read from device write to memory)
+ *      = 1 mem to dev (read from memory write to device)
+ */
+#define QMSPI_TX_DMA_DEVDIR     ((QMSPI_TX_DMA_REQ_ID << 1) + 0x01)
+#define QMSPI_RX_DMA_DEVDIR     ((QMSPI_RX_DMA_REQ_ID << 1) + 0x00)
+
+/* Default DMA.Control values without unit length
+ * b[16]=1 increment memory address
+ * b[15:9]=QMSPI DMA ID for TX or RX
+ * b[8]=direction: 1(Mem2Device), 0(Dev2Mem)
+ * b[0]=1 RUN
+ */
+#define QMSPI_TX_DMA_CTRL   ((1ul << 16) + (12ul << 9) + (1ul << 8) + (1ul << 0))
+#define QMSPI_RX_DMA_CTRL   ((1ul << 16) + (13ul << 9) + (0ul << 8) + (1ul << 0))
+
+#define QMSPI_TX_FIFO_LEN           8
+#define QMSPI_RX_FIFO_LEN           8
+
+#define QMSPI_M_ACT_SRST_OFS        0
+#define QMSPI_M_SPI_MODE_OFS        1
+#define QMSPI_M_CLK_DIV_OFS         2
+#define QMSPI_CTRL_OFS              4
+#define QMSPI_EXE_OFS               8
+#define QMSPI_IF_CTRL_OFS           0x0C
+#define QMSPI_STS_OFS               0x10
+#define QMSPI_BUF_CNT_STS_OFS       0x14
+#define QMSPI_IEN_OFS               0x18
+#define QMSPI_BUF_CNT_TRIG_OFS      0x1C
+#define QMSPI_TX_FIFO_OFS           0x20
+#define QMSPI_RX_FIFO_OFS           0x24
+#define QMSPI_CSTM_OFS              0x28
+/* 0 <= n < QMSPI_MAX_DESCR */
+#define QMSPI_DESCR_OFS(n)          (0x30 + ((uint32_t)(n) << 2))
+
+#define QMSPI_MODE_ADDR             (QMSPI_BASE_ADDR + 0x00)
+#define QMSPI_CTRL_ADDR             (QMSPI_BASE_ADDR + 0x04)
+#define QMSPI_EXE_ADDR              (QMSPI_BASE_ADDR + 0x08)
+#define QMSPI_IFC_ADDR              (QMSPI_BASE_ADDR + 0x0C)
+#define QMSPI_STS_ADDR              (QMSPI_BASE_ADDR + 0x10)
+#define QMSPI_BUFCNT_STS_ADDR       (QMSPI_BASE_ADDR + 0x14)
+#define QMSPI_TX_BCNT_STS_ADDR      (QMSPI_BASE_ADDR + 0x14)
+#define QMSPI_RX_BCNT_STS_ADDR      (QMSPI_BASE_ADDR + 0x16)
+#define QMSPI_IEN_ADDR              (QMSPI_BASE_ADDR + 0x18)
+#define QMSPI_TXB_ADDR              (QMSPI_BASE_ADDR + 0x20)
+#define QMSPI_RXB_ADDR              (QMSPI_BASE_ADDR + 0x24)
+#define QMSPI_CSTM_ADDR             (QMSPI_BASE_ADDR + 0x28)
+#define QMSPI_DESCR_ADDR(n)         (QMSPI_BASE_ADDR + (0x30 + ((uint32_t)(n) << 2)))
+
+// Mode Register
+#define QMSPI_M_SRST            0x02
+#define QMSPI_M_ACTIVATE        0x01
+#define QMSPI_M_SIG_POS         8
+#define QMSPI_M_SIG_MASK0       0x07
+#define QMSPI_M_SIG_MASK        0x0700ul
+#define QMSPI_M_SIG_MODE0_VAL   0x00
+#define QMSPI_M_SIG_MODE1_VAL   0x06
+#define QMSPI_M_SIG_MODE2_VAL   0x01
+#define QMSPI_M_SIG_MODE3_VAL   0x07
+#define QMSPI_M_SIG_MODE0       (0x00 << QMSPI_M_SIG_POS)
+#define QMSPI_M_SIG_MODE1       (0x06 << QMSPI_M_SIG_POS)
+#define QMSPI_M_SIG_MODE2       (0x01 << QMSPI_M_SIG_POS)
+#define QMSPI_M_SIG_MODE3       (0x07 << QMSPI_M_SIG_POS)
+#define QMSPI_M_CS_POS          12
+#define QMSPI_M_CS_MASK0        0x03
+#define QMSPI_M_CS_MASK         (0x03ul << 12)
+#define QMSPI_M_CS0             (0x00ul << 12)
+#define QMSPI_M_CS1             (0x01ul << 12)
+#define QMSPI_M_CS(n)           (((n) & QMSPI_M_CS_MASK0) << QMSPI_M_CS_POS)
+#define QMSPI_M_FDIV_POS        16
+#define QMSPI_M_FDIV_MASK0      0xFF
+#define QMSPI_M_FDIV_MASK       0x00FF0000
+
+// Control/Descriptors
+#define QMSPI_C_IFM_MASK        0x03ul
+#define QMSPI_C_IFM_1X          0x00ul
+#define QMSPI_C_IFM_2X          0x01ul
+#define QMSPI_C_IFM_4X          0x02ul
+#define QMSPI_C_TX_MASK         (0x03ul << 2)
+#define QMSPI_C_TX_DIS          (0x00ul << 2)
+#define QMSPI_C_TX_DATA         (0x01ul << 2)
+#define QMSPI_C_TX_ZEROS        (0x02ul << 2)
+#define QMSPI_C_TX_ONES         (0x03ul << 2)
+#define QMSPI_C_TX_DMA_POS      4
+#define QMSPI_C_TX_DMA_MASK     (0x03ul << 4)
+#define QMSPI_C_TX_DMA_DIS      (0x00ul << 4)
+#define QMSPI_C_TX_DMA_1B       (0x01ul << 4)
+#define QMSPI_C_TX_DMA_2B       (0x02ul << 4)
+#define QMSPI_C_TX_DMA_4B       (0x03ul << 4)
+#define QMSPI_C_RX_DIS          (0ul << 6)
+#define QMSPI_C_RX_EN           (1ul << 6)
+#define QMSPI_C_RX_DMA_POS      7
+#define QMSPI_C_RX_DMA_MASK     (0x03ul << 7)
+#define QMSPI_C_RX_DMA_DIS      (0x00ul << 7)
+#define QMSPI_C_RX_DMA_1B       (0x01ul << 7)
+#define QMSPI_C_RX_DMA_2B       (0x02ul << 7)
+#define QMSPI_C_RX_DMA_4B       (0x03ul << 7)
+#define QMSPI_C_NO_CLOSE        (0ul << 9)
+#define QMSPI_C_CLOSE           (1ul << 9)
+#define QMSPI_C_XFR_UNITS_POS   10u
+#define QMSPI_C_XFR_UNITS_MASK  (0x03ul << 10)
+#define QMSPI_C_XFR_UNITS_BITS  (0x00ul << 10)
+#define QMSPI_C_XFR_UNITS_1     (0x01ul << 10)
+#define QMSPI_C_XFR_UNITS_4     (0x02ul << 10)
+#define QMSPI_C_XFR_UNITS_16    (0x03ul << 10)
+#define QMSPI_C_NEXT_DESCR_POS  12
+#define QMSPI_C_NEXT_DESCR_MASK0    0x0Ful
+#define QMSPI_C_NEXT_DESCR_MASK (0x0Ful << 12)
+#define QMSPI_C_DESCR0          (0 << 12)
+#define QMSPI_C_DESCR1          (1ul << 12)
+#define QMSPI_C_DESCR2          (2ul << 12)
+#define QMSPI_C_DESCR3          (3ul << 12)
+#define QMSPI_C_DESCR4          (4ul << 12)
+#define QMSPI_C_DESCR(n)        (((uint32_t)(n) & 0x0f) << 12)
+#define QMSPI_C_NEXT_DESCR(n)   (((uint32_t)(n) & 0x0f) << 12)
+#define QMSPI_C_DESCR_EN_POS    16
+#define QMSPI_C_DESCR_EN        (1ul << 16)
+#define QMSPI_C_DESCR_LAST      (1ul << 16)
+#define QMSPI_C_MAX_UNITS       0x7FFFul
+#define QMSPI_C_MAX_UNITS_MASK  0x7FFFul
+#define QMSPI_C_XFR_NUNITS_POS  17
+#define QMSPI_C_XFR_NUNITS_MASK (0x7FFFul << 17)
+#define QMSPI_C_XFR_NUNITS(n)       ((uint32_t)(n) << 17)
+#define QMSPI_C_XFR_NUNITS_GET(n)   (((uint32_t)(n) >> 17) & QMSPI_C_MAX_UNITS_MASK)
+
+/* Exe */
+#define QMSPI_EXE_START         0x01
+#define QMSPI_EXE_STOP          0x02
+#define QMSPI_EXE_CLR_FIFOS     0x04
+
+/* Interface Control */
+#define QMSPI_IFC_DFLT          0x00
+
+/* Status Register */
+#define QMSPI_STS_DONE          (1ul << 0)
+#define QMSPI_STS_DMA_DONE      (1ul << 1)
+#define QMSPI_STS_TXB_ERR       (1ul << 2)
+#define QMSPI_STS_RXB_ERR       (1ul << 3)
+#define QMSPI_STS_PROG_ERR      (1ul << 4)
+#define QMSPI_STS_TXBF          (1ul << 8)
+#define QMSPI_STS_TXBE          (1ul << 9)
+#define QMSPI_STS_TXBR          (1ul << 10)
+#define QMSPI_STS_TXBS          (1ul << 11)
+#define QMSPI_STS_RXBF          (1ul << 12)
+#define QMSPI_STS_RXBE          (1ul << 13)
+#define QMSPI_STS_RXBR          (1ul << 14)
+#define QMSPI_STS_RXBS          (1ul << 15)
+#define QMSPI_STS_ACTIVE        (1ul << 16)
+
+/* Buffer Count Status (RO) */
+#define QMSPI_TX_BUF_CNT_STS_POS    0
+#define QMSPI_RX_BUF_CNT_STS_POS    16
+
+/* Interrupt Enable Register */
+#define QMSPI_IEN_XFR_DONE      (1ul << 0)
+#define QMSPI_IEN_DMA_DONE      (1ul << 1)
+#define QMSPI_IEN_TXB_ERR       (1ul << 2)
+#define QMSPI_IEN_RXB_ERR       (1ul << 3)
+#define QMSPI_IEN_PROG_ERR      (1ul << 4)
+#define QMSPI_IEN_TXB_FULL      (1ul << 8)
+#define QMSPI_IEN_TXB_EMPTY     (1ul << 9)
+#define QMSPI_IEN_TXB_REQ       (1ul << 10)
+#define QMSPI_IEN_RXB_FULL      (1ul << 12)
+#define QMSPI_IEN_RXB_EMPTY     (1ul << 13)
+#define QMSPI_IEN_RXB_REQ       (1ul << 14)
+
+/* Buffer Count Trigger (RW) */
+#define QMSPI_TX_BUF_CNT_TRIG_POS   0
+#define QMSPI_RX_BUF_CNT_TRIG_POS   16
+
+/* Chip Select Timing (RW) */
+#define QMSPI_CSTM_MASK                 0xFF0F0F0Ful
+#define QMSPI_CSTM_DFLT                 0x06060406ul
+#define QMSPI_DLY_CS_ON_CK_STR_POS      0
+#define QMSPI_DLY_CS_ON_CK_STR_MASK     0x0Ful
+#define QMSPI_DLY_CK_STP_CS_OFF_POS     8
+#define QMSPI_DLY_CK_STP_CS_OFF_MASK    (0x0Ful << 8)
+#define QMSPI_DLY_LST_DAT_HLD_POS       16
+#define QMSPI_DLY_LST_DAT_HLD_MASK      (0x0Ful << 16)
+#define QMSPI_DLY_CS_OFF_CS_ON_POS      24
+#define QMSPI_DLY_CS_OFF_CS_ON_MASK     (0x0Ful << 24)
+
+#define QMSPI_PORT_MAX_IO_PINS  4
+#define QMSPI_PORT_MAX_CS       4
+
+/* Full duplex and Dual I/O:
+ * CS#, CLK, IO0(MOSI), IO1(MISO)
+ * do not connect IO2(WP#) or IO3(HOLD#) to QMSPI.
+ */
+#define QMSPI_PORT_MASK_FULL_DUPLEX     0x0F
+#define QMSPI_PORT_MASK_DUAL            0x0F
+
+#define QMSPI_PIN_IO0_POS   0
+#define QMSPI_PIN_IO1_POS   1
+#define QMSPI_PIN_IO2_POS   2
+#define QMSPI_PIN_IO3_POS   3
+#define QMSPI_PIN_CLK_POS   4
+#define QMSPI_PIN_CS0_POS   8
+#define QMSPI_PIN_CS1_POS   9
+
+#define QMSPI_PIN_IO0       (1ul << QMSPI_PIN_IO0_POS)
+#define QMSPI_PIN_IO1       (1ul << QMSPI_PIN_IO1_POS)
+#define QMSPI_PIN_IO2       (1ul << QMSPI_PIN_IO2_POS)
+#define QMSPI_PIN_IO3       (1ul << QMSPI_PIN_IO3_POS)
+#define QMSPI_PIN_CLK       (1ul << QMSPI_PIN_CLK_POS)
+#define QMSPI_PIN_CS0       (1ul << QMSPI_PIN_CS0_POS)
+#define QMSPI_PIN_CS1       (1ul << QMSPI_PIN_CS1_POS)
+
+
+/* =========================================================================*/
+/* ================            QMSPI                       ================ */
+/* =========================================================================*/
+#define QMSPI_MAX_DESCRIPTOR    16
+
+typedef union
+{
+    uint32_t u32;
+    uint16_t u16[2];
+    uint8_t  u8[4];
+} QMSPI_TX_FIFO;
+
+typedef union
+{
+    uint32_t u32;
+    uint16_t u16[2];
+    uint8_t  u8[4];
+} QMSPI_RX_FIFO;
+
+typedef struct
+{
+    __IOM uint32_t u32;
+} QMSPI_DESCR;
+
+/**
+  * @brief Quad Master SPI (QMSPI)
+  */
+typedef struct
+{                       /*!< (@ 0x40070000) QMSPI Structure   */
+    __IOM uint32_t  MODE;           /*!< (@ 0x00000000) QMSPI Mode */
+    __IOM uint32_t  CTRL;           /*!< (@ 0x00000004) QMSPI Control */
+    __IOM uint32_t  EXE;            /*!< (@ 0x00000008) QMSPI Execute */
+    __IOM uint32_t  IFCTRL;         /*!< (@ 0x0000000C) QMSPI Interface control */
+    __IOM uint32_t  STS;            /*!< (@ 0x00000010) QMSPI Status */
+    __IOM uint32_t  BCNT_STS;       /*!< (@ 0x00000014) QMSPI Buffer Count Status (RO) */
+    __IOM uint32_t  IEN;            /*!< (@ 0x00000018) QMSPI Interrupt Enable */
+    __IOM uint32_t  BCNT_TRIG;      /*!< (@ 0x0000001C) QMSPI Buffer Count Trigger */
+    QMSPI_TX_FIFO   TX_FIFO;        /*!< (@ 0x00000020) QMSPI TX FIFO */
+    QMSPI_RX_FIFO   RX_FIFO;        /*!< (@ 0x00000024) QMSPI RX FIFO */
+    __IOM uint32_t  CSTM;           /*!< (@ 0x00000028) QMSPI CS Timing */
+          uint8_t   RSVD1[4];
+    QMSPI_DESCR     DESCR[QMSPI_MAX_DESCRIPTOR]; /*!< (@ 0x00000030) QMSPI Descriptors 0-15 */
+} QMSPI_Type;
+
+#endif /* #ifndef _QMSPI_H */
+/* end qmspi.h */
+/**   @}
+ */

--- a/ext/hal/microchip/mec/mec1501/component/smb.h
+++ b/ext/hal/microchip/mec/mec1501/component/smb.h
@@ -1,0 +1,472 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file smb.h
+ *MEC1501 SMB register definitions
+ */
+/** @defgroup MEC1501 Peripherals SMB
+ */
+
+#ifndef _SMB_H
+#define _SMB_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+
+#define SMB0_BASE_ADDR      0x40004000ul
+#define SMB1_BASE_ADDR      0x40004400ul
+#define SMB2_BASE_ADDR      0x40004800ul
+#define SMB3_BASE_ADDR      0x40004C00ul
+#define SMB4_BASE_ADDR      0x40005000ul
+#define SMB_INST_OFS_POF2   10u
+
+/* 0 <= n < 5 */
+#define SMB_BASE_ADDR(n)    ((SMB0_BASE_ADDR) + (n) << (SMB_INST_OFS_POF2))
+
+/*
+ * Offset 0x00
+ * Control and Status register
+ * Write to Control
+ * Read from Status
+ * Size 8-bit
+ */
+#define SMB_CTRL_OFS        0x00
+#define SMB_CTRL_MASK       0xCFu
+#define SMB_CTRL_ACK        (1u << 0)
+#define SMB_CTRL_STO        (1u << 1)
+#define SMB_CTRL_STA        (1u << 2)
+#define SMB_CTRL_ENI        (1u << 3)
+/* bits [5:4] reserved */
+#define SMB_CTRL_ESO        (1u << 6)
+#define SMB_CTRL_PIN        (1u << 7)
+/* Status Read-only */
+#define SMB_STS_OFS         0x00
+#define SMB_STS_NBB         (1u << 0)
+#define SMB_STS_LAB         (1u << 1)
+#define SMB_STS_AAS         (1u << 2)
+#define SMB_STS_LRB_AD0     (1u << 3)
+#define SMB_STS_BER         (1u << 4)
+#define SMB_STS_EXT_STOP    (1u << 5)
+#define SMB_STS_SAD         (1u << 6)
+#define SMB_STS_PIN         (1u << 7)
+
+/*
+ * Offset 0x04
+ * Own Address b[7:0] = Slave address 1
+ * b[14:8] = Slave address 2
+ */
+#define SMB_OWN_ADDR_OFS    0x04ul
+#define SMB_OWN_ADDR2_OFS   0x05ul
+#define SMB_OWN_ADDR_MASK   0x7F7Ful
+
+/*
+ * Offset 0x08
+ * Data register, 8-bit
+ * Data to be shifted out or shifted in.
+ */
+#define SMB_DATA_OFS        0x08ul
+
+/*
+ * Offset 0x0C
+ * Master Command register
+ */
+#define SMB_MSTR_CMD_OFS            0x0Cul
+#define SMB_MSTR_CMD_RD_CNT_OFS     0x0Ful    /* byte 3 */
+#define SMB_MSTR_CMD_WR_CNT_OFS     0x0Eul    /* byte 2 */
+#define SMB_MSTR_CMD_OP_OFS         0x0Dul    /* byte 1 */
+#define SMB_MSTR_CMD_M_OFS          0x0Cul    /* byte 0 */
+#define SMB_MSTR_CMD_MASK           0xFFFF3FF3ul
+/* 32-bit definitions */
+#define SMB_MSTR_CMD_MRUN           (1ul << 0)
+#define SMB_MSTR_CMD_MPROCEED       (1ul << 1)
+#define SMB_MSTR_CMD_START0         (1ul << 8)
+#define SMB_MSTR_CMD_STARTN         (1ul << 9)
+#define SMB_MSTR_CMD_STOP           (1ul << 10)
+#define SMB_MSTR_CMD_PEC_TERM       (1ul << 11)
+#define SMB_MSTR_CMD_READM          (1ul << 12)
+#define SMB_MSTR_CMD_READ_PEC       (1ul << 13)
+#define SMB_MSTR_CMD_RD_CNT_POS     24
+#define SMB_MSTR_CMD_WR_CNT_POS     16
+/* byte 0 definitions */
+#define SMB_MSTR_CMD_B0_MRUN        (1ul << 0)
+#define SMB_MSTR_CMD_B0_MPROCEED    (1ul << 1)
+/* byte 1 definitions */
+#define SMB_MSTR_CMD_B1_START0      (1ul << (8-8))
+#define SMB_MSTR_CMD_B1_STARTN      (1ul << (9-8))
+#define SMB_MSTR_CMD_B1_STOP        (1ul << (10-8))
+#define SMB_MSTR_CMD_B1_PEC_TERM    (1ul << (11-8))
+#define SMB_MSTR_CMD_B1_READM       (1ul << (12-8))
+#define SMB_MSTR_CMD_B1_READ_PEC    (1ul << (13-8))
+
+
+/*
+ * Offset 0x10
+ * Slave Command register
+ */
+#define SMB_SLV_CMD_OFS             0x10ul
+#define SMB_SLV_CMD_MASK            0x00FFFF07ul
+#define SMB_SLV_CMD_SRUN            (1ul << 0)
+#define SMB_SLV_CMD_SPROCEED        (1ul << 1)
+#define SMB_SLV_CMD_SEND_PEC        (1ul << 2)
+#define SMB_SLV_WR_CNT_POS          8u
+#define SMB_SLV_RD_CNT_POS          16u
+
+/*
+ * Offset 0x14
+ * PEC CRC register, 8-bit read-write
+ */
+#define SMB_PEC_CRC_OFS             0x14ul
+
+/*
+ * Offset 0x18
+ * Repeated Start Hold Time register, 8-bit read-write
+ */
+#define SMB_RSHT_OFS                0x18ul
+
+/*
+ * Offset 0x20
+ * Complettion register, 32-bit
+ */
+#define SMB_CMPL_OFS                0x20ul
+#define SMB_CMPL_MASK               0xE33B7F7Cul
+#define SMB_CMPL_RW1C_MASK          0xE1397F00ul
+#define SMB_CMPL_DTEN               (1ul << 2)
+#define SMB_CMPL_MCEN               (1ul << 3)
+#define SMB_CMPL_SCEN               (1ul << 4)
+#define SMB_CMPL_BIDEN              (1ul << 5)
+#define SMB_CMPL_TIMERR             (1ul << 6)
+#define SMB_CMPL_DTO_RWC            (1ul << 8)
+#define SMB_CMPL_MCTO_RWC           (1ul << 9)
+#define SMB_CMPL_SCTO_RWC           (1ul << 10)
+#define SMB_CMPL_CHDL_RWC           (1ul << 11)
+#define SMB_CMPL_CHDH_RWC           (1ul << 12)
+#define SMB_CMPL_BER_RWC            (1ul << 13)
+#define SMB_CMPL_LEB_RWC            (1ul << 14)
+#define SMB_CMPL_SNAKR_RWC          (1ul << 16)
+#define SMB_CMPL_STR_RO             (1ul << 17)
+#define SMB_CMPL_SPROT_RWC          (1ul << 19)
+#define SMB_CMPL_RPT_RD_RWC         (1ul << 20)
+#define SMB_CMPL_RPT_WR_RWC         (1ul << 21)
+#define SMB_CMPL_MNAKX_RWC          (1ul << 24)
+#define SMB_CMPL_MTR_RO             (1ul << 25)
+#define SMB_CMPL_IDLE_RWC           (1ul << 29)
+#define SMB_CMPL_MDONE_RWC          (1ul << 30)
+#define SMB_CMPL_SDONE_RWC          (1ul << 31)
+
+/*
+ * Offset 0x24
+ * Idle Scaling register
+ */
+#define SMB_IDLSC_OFS               0x24ul
+#define SMB_IDLSC_DLY_OFS           0x24ul
+#define SMB_IDLSC_BUS_OFS           0x26ul
+#define SMB_IDLSC_MASK              0x0FFF0FFFul
+#define SMB_IDLSC_BUS_MIN_POS       0
+#define SMB_IDLSC_DLY_POS           16
+
+/*
+ * Offset 0x28
+ * Configure register
+ */
+#define SMB_CFG_OFS                 0x28ul
+#define SMB_CFG_MASK                0xF00F5FBFul
+#define SMB_CFG_PORT_SEL_MASK       0x0Ful
+#define SMB_CFG_TCEN                (1ul << 4)
+#define SMB_CFG_SLOW_CLK            (1ul << 5)
+#define SMB_CFG_PCEN                (1ul << 7)
+#define SMB_CFG_FEN                 (1ul << 8)
+#define SMB_CFG_RESET               (1ul << 9)
+#define SMB_CFG_ENAB                (1ul << 10)
+#define SMB_CFG_DSA                 (1ul << 11)
+#define SMB_CFG_FAIR                (1ul << 12)
+#define SMB_CFG_GC_EN               (1ul << 14)
+#define SMB_CFG_FLUSH_SXBUF_WO      (1ul << 16)
+#define SMB_CFG_FLUSH_SRBUF_WO      (1ul << 17)
+#define SMB_CFG_FLUSH_MXBUF_WO      (1ul << 18)
+#define SMB_CFG_FLUSH_MRBUF_WO      (1ul << 19)
+#define SMB_CFG_EN_AAS              (1ul << 28)
+#define SMB_CFG_ENIDI               (1ul << 29)
+#define SMB_CFG_ENMI                (1ul << 30)
+#define SMB_CFG_ENSI                (1ul << 31)
+
+/*
+ * Offset 0x2C
+ * Bus Clock register
+ */
+#define SMB_BUS_CLK_OFS             0x2Cul
+#define SMB_BUS_CLK_MASK            0x0000FFFFul
+#define SMB_BUS_CLK_LO_POS          0
+#define SMB_BUS_CLK_HI_POS          8
+
+/*
+ * Offset 0x30
+ * Block ID register, 8-bit read-only
+ */
+#define SMB_BLOCK_ID_OFS            0x30ul
+#define SMB_BLOCK_ID_MASK           0xFFul
+
+/*
+ * Offset 0x34
+ * Block Revision register, 8-bit read-only
+ */
+#define SMB_BLOCK_REV_OFS           0x34ul
+#define SMB_BLOCK_REV_MASK          0xFFul
+
+
+/*
+ * Offset 0x38
+ * Bit-Bang Control register, 8-bit read-write
+ */
+#define SMB_BB_OFS                  0x38ul
+#define SMB_BB_MASK                 0x7Fu
+#define SMB_BB_EN                   (1u << 0)
+#define SMB_BB_SCL_DIR_IN           (0u << 1)
+#define SMB_BB_SCL_DIR_OUT          (1u << 1)
+#define SMB_BB_SDA_DIR_IN           (0u << 2)
+#define SMB_BB_SDA_DIR_OUT          (1u << 2)
+#define SMB_BB_CL                   (1u << 3)
+#define SMB_BB_DAT                  (1u << 4)
+#define SMB_BB_IN_POS               5u
+#define SMB_BB_IN_MASK0             0x03
+#define SMB_BB_IN_MASK              (0x03 << 5)
+#define SMB_BB_CLKI_RO              (1u << 5)
+#define SMB_BB_DATI_RO              (1u << 6)
+
+/*
+ * Offset 0x40
+ * Data Timing register
+ */
+#define SMB_DATA_TM_OFS                 0x40ul
+#define SMB_DATA_TM_MASK                0xFFFFFFFFul
+#define SMB_DATA_TM_DATA_HOLD_POS       0
+#define SMB_DATA_TM_DATA_HOLD_MASK      0xFFul
+#define SMB_DATA_TM_DATA_HOLD_MASK0     0xFFul
+#define SMB_DATA_TM_RESTART_POS         8
+#define SMB_DATA_TM_RESTART_MASK        0xFF00ul
+#define SMB_DATA_TM_RESTART_MASK0       0xFFul
+#define SMB_DATA_TM_STOP_POS            16
+#define SMB_DATA_TM_STOP_MASK           0xFF0000ul
+#define SMB_DATA_TM_STOP_MASK0          0xFFul
+#define SMB_DATA_TM_FSTART_POS          24
+#define SMB_DATA_TM_FSTART_MASK         0xFF000000ul
+#define SMB_DATA_TM_FSTART_MASK0        0xFFul
+
+/*
+ * Offset 0x44
+ * Time-out Scaling register
+ */
+#define SMB_TMTSC_OFS                   0x44ul
+#define SMB_TMTSC_MASK                  0xFFFFFFFFul
+#define SMB_TMTSC_CLK_HI_POS            0
+#define SMB_TMTSC_CLK_HI_MASK           0xFFul
+#define SMB_TMTSC_CLK_HI_MASK0          0xFFul
+#define SMB_TMTSC_SLV_POS               8
+#define SMB_TMTSC_SLV_MASK              0xFF00ul
+#define SMB_TMTSC_SLV_MASK0             0xFFul
+#define SMB_TMTSC_MSTR_POS              16
+#define SMB_TMTSC_MSTR_MASK             0xFF0000ul
+#define SMB_TMTSC_MSTR_MASK0            0xFFul
+#define SMB_TMTSC_BUS_POS               24
+#define SMB_TMTSC_BUS_MASK              0xFF000000ul
+#define SMB_TMTSC_BUS_MASK0             0xFFul
+
+/*
+ * Offset 0x48
+ * Slave Transmit Buffer register
+ * 8-bit read-write
+ */
+#define SMB_SLV_TX_BUF_OFS              0x48ul
+
+/*
+ * Offset 0x4C
+ * Slave Receive Buffer register
+ * 8-bit read-write
+ */
+#define SMB_SLV_RX_BUF_OFS              0x4Cul
+
+/*
+ * Offset 0x50
+ * Master Transmit Buffer register
+ * 8-bit read-write
+ */
+#define SMB_MSTR_TX_BUF_OFS             0x50ul
+
+/*
+ * Offset 0x54
+ * Master Receive Buffer register
+ * 8-bit read-write
+ */
+#define SMB_MSTR_RX_BUF_OFS             0x54ul
+
+/*
+ * Offset 0x58
+ * I2C FSM read-only
+ */
+#define SMB_I2C_FSM_OFS                 0x58ul
+
+/*
+ * Offset 0x5C
+ * SMB Netork layer FSM read-only
+ */
+#define SMB_FSM_OFS                     0x5Cul
+
+/*
+ * Offset 0x60
+ * Wake Status register
+ */
+#define SMB_WAKE_STS_OFS                0x60ul
+#define SMB_WAKE_STS_START_RWC          1ul << 0
+
+/*
+ * Offset 0x64
+ * Wake Enable register
+ */
+#define SMB_WAKE_EN_OFS                 0x64ul
+#define SMB_WAKE_EN                     (1ul << 0)
+
+/*
+ * Offset 0x68
+ *
+ */
+#define SMB_WAKE_SYNC_OFS               0x68ul
+#define SMB_WAKE_FAST_RESYNC_EN         (1ul << 0)
+
+/*
+ * I2C GIRQ and NVIC mapping
+ */
+#define SMB_GIRQ            13u
+#define SMB_GIRQ_IDX        (13u - 8u)
+#define SMB_NVIC_BLOCK      5
+#define SMB0_NVIC_DIRECT    20
+#define SMB1_NVIC_DIRECT    21
+#define SMB2_NVIC_DIRECT    22
+#define SMB3_NVIC_DIRECT    23
+#define SMB4_NVIC_DIRECT    158
+
+#define SMB_GIRQ_SRC_ADDR       0x4000E064ul
+#define SMB_GIRQ_SET_EN_ADDR    0x4000E068ul
+#define SMB_GIRQ_RESULT_ADDR    0x4000E06Cul
+#define SMB_GIRQ_CLR_EN_ADDR    0x4000E070ul
+
+/* register access */
+
+static inline uintptr_t smb_base_addr(uint8_t id)
+{
+    return (uintptr_t)(SMB0_BASE_ADDR) + ((uintptr_t)id << (SMB_INST_OFS_POF2));
+}
+
+/* =========================================================================*/
+/* ================            SMB                         ================ */
+/* =========================================================================*/
+#define SMB_MAX_INSTANCES     5
+#define SMB_INST_SPACING      0x400
+#define SMB_INST_SPACING_P2   10
+
+typedef union
+{
+    __OM  uint8_t  CTRL;
+    __IM  uint8_t  STS;
+} SMB_CTRL_STS_Type;
+
+typedef union
+{
+    __IOM uint32_t u32;
+    __IOM uint16_t u16[2];
+    __IOM uint8_t  u8[4];
+} SMB_MTRCMD_Type;
+
+typedef union
+{
+    __IOM uint32_t u32;
+    __IOM uint16_t u16[2];
+    __IOM uint8_t  u8[4];
+} SMB_SLVCMD_Type;
+
+typedef union
+{
+    __IOM uint32_t u32;
+    __IOM uint16_t u16[2];
+    __IOM uint8_t  u8[4];
+} SMB_COMPL_Type;
+
+typedef union
+{
+    __IOM uint32_t u32;
+    __IOM uint16_t u16[2];
+    __IOM uint8_t  u8[4];
+} SMB_CFG_Type;
+
+/**
+  * @brief SMBus Network Layer Block (SMB)
+  */
+typedef struct
+{                         /*!< (@ 0x40004000) SMB Structure        */
+    SMB_CTRL_STS_Type   CTRLSTS;        /*!< (@ 0x00000000) SMB Status(RO), Control(WO) */
+          uint8_t       RSVD1[3];
+    __IOM uint32_t      OWN_ADDR;       /*!< (@ 0x00000004) SMB Own address 1 */
+    __IOM uint8_t       I2CDATA;        /*!< (@ 0x00000008) SMB I2C Data */
+          uint8_t       RSVD2[3];
+    SMB_MTRCMD_Type     MCMD;           /*!< (@ 0x0000000C) SMB SMB master command */
+    SMB_SLVCMD_Type     SCMD;           /*!< (@ 0x00000010) SMB SMB slave command */
+    __IOM uint8_t       PEC;            /*!< (@ 0x00000014) SMB PEC value */
+          uint8_t       RSVD3[3];
+    __IOM uint8_t       RSHTM;          /*!< (@ 0x00000018) SMB Repeated-Start hold time */
+          uint8_t       RSVD4[7];
+    SMB_COMPL_Type      COMPL;          /*!< (@ 0x00000020) SMB Completion */
+    __IOM uint32_t      IDLSC;          /*!< (@ 0x00000024) SMB Idle scaling */
+    SMB_CFG_Type        CFG;            /*!< (@ 0x00000028) SMB Configuration */
+    __IOM uint32_t      BUSCLK;         /*!< (@ 0x0000002C) SMB Bus Clock */
+    __IOM uint8_t       BLKID;          /*!< (@ 0x00000030) SMB Block ID */
+          uint8_t       RSVD5[3];
+    __IOM uint8_t       BLKREV;         /*!< (@ 0x00000034) SMB Block revision */
+          uint8_t       RSVD6[3];
+    __IOM uint8_t       BBCTRL;         /*!< (@ 0x00000038) SMB Bit-Bang control */
+          uint8_t       RSVD7[3];
+    __IOM uint32_t      CLKSYNC;        /*!< (@ 0x0000003C) SMB Clock Sync */
+    __IOM uint32_t      DATATM;         /*!< (@ 0x00000040) SMB Data timing */
+    __IOM uint32_t      TMOUTSC;        /*!< (@ 0x00000044) SMB Time-out scaling */
+    __IOM uint8_t       SLV_TXB;        /*!< (@ 0x00000048) SMB SMB slave TX buffer */
+          uint8_t       RSVD8[3];
+    __IOM uint8_t       SLV_RXB;        /*!< (@ 0x0000004C) SMB SMB slave RX buffer */
+          uint8_t       RSVD9[3];
+    __IOM uint8_t       MTR_TXB;        /*!< (@ 0x00000050) SMB SMB Master TX buffer */
+          uint8_t       RSVD10[3];
+    __IOM uint8_t       MTR_RXB;        /*!< (@ 0x00000054) SMB SMB Master RX buffer */
+          uint8_t       RSVD11[3];
+    __IOM uint32_t      FSM;            /*!< (@ 0x00000058) SMB FSM (RO) */
+    __IOM uint32_t      FSM_SMB;        /*!< (@ 0x0000005C) SMB FSM SMB (RO) */
+    __IOM uint8_t       WAKE_STS;       /*!< (@ 0x00000060) SMB Wake status */
+          uint8_t       RSVD12[3];
+    __IOM uint8_t       WAKE_EN;        /*!< (@ 0x00000064) SMB Wake enable */
+          uint8_t       RSVD13[3];
+    __IOM uint32_t      FAST_RSYNC;     /*!< (@ 0x00000068) SMB Fast Resync */
+} SMB_Type;
+
+#endif // #ifndef _SMB_H
+/* end smb.h */
+/**   @}
+ */

--- a/ext/hal/microchip/mec/mec1501/component/timer.h
+++ b/ext/hal/microchip/mec/mec1501/component/timer.h
@@ -1,0 +1,332 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file timer.h
+ *MEC1501 Timer definitions
+ */
+/** @defgroup MEC1501 Peripherals Timers
+ */
+
+#ifndef _TIMER_H
+#define _TIMER_H
+
+
+/*
+ * Basic timers base address
+ * Offset between each timer block
+ */
+#define B16TMR_BASE               0x40000C00
+#define B16TMR_MAX_INSTANCE       2
+#define B32TMR_BASE               0x40000C80
+#define B32TMR_MAX_INSTANCE       2
+
+/*
+ * Offset between instances of the TMR blocks
+ */
+#define BTMR_INSTANCE_POS               5ul
+#define BTMR_INSTANCE_OFS               (1ul << (BTMR_INSTANCE_POS))
+
+/*
+ * Basic Timer Count Register (Offset +00h)
+ * 32-bit R/W
+ * 16-bit Basic timers: bits[15:0]=R/W, bits[31:15]=RO=0
+ */
+#define BTMR_CNT_OFS                0x00
+
+/*
+ * Basic Timer Preload Register (Offset +04h)
+ * 32-bit R/W
+ * 16-bit Basic timers: bits[15:0]=R/W, bits[31:15]=RO=0
+ */
+#define BTMR_PRELOAD_OFS            0x04
+
+
+/*
+ * Basic Timer Status Register (Offset +08h)
+ * R/W1C
+ */
+#define BTMR_STS_OFS                0x08
+#define BTMR_STS_MASK               0x01
+#define BTMR_STS_ACTIVE_POS         0
+#define BTMR_STS_ACTIVE             0x01ul
+
+/*
+ * Basic Timer Interrupt Enable Register (Offset +0Ch)
+ */
+#define BTMR_INTEN_OFS              0x0C
+#define BTMR_INTEN_MASK             0x01ul
+#define BTMR_INTEN_POS              0
+#define BTMR_INTEN                  0x01ul
+#define BTMR_INTDIS                 0ul
+
+/*
+ * Basic Timer Control Register (Offset +10h)
+ */
+#define BTMR_CTRL_OFS                   0x10ul
+#define BTMR_CTRL_MASK                  0xFFFF00FDul
+
+#define BTMR_CTRL_PRESCALE_POS          16u
+#define BTMR_CTRL_PRESCALE_MASK0        0xFFFFul
+#define BTMR_CTRL_PRESCALE_MASK         0xFFFF0000ul
+
+#define BTMR_CTRL_HALT                   0x80ul
+#define BTMR_CTRL_RELOAD                 0x40ul
+#define BTMR_CTRL_START                  0x20ul
+#define BTMR_CTRL_SOFT_RESET             0x10ul
+#define BTMR_CTRL_AUTO_RESTART           0x08ul
+#define BTMR_CTRL_COUNT_UP               0x04ul
+#define BTMR_CTRL_ENABLE                 0x01ul
+/* */
+#define BTMR_CTRL_HALT_POS              7
+#define BTMR_CTRL_RELOAD_POS            6
+#define BTMR_CTRL_START_POS             5
+#define BTMR_CTRL_SRESET_POS            4
+#define BTMR_CTRL_AUTO_RESTART_POS      3
+#define BTMR_CTRL_COUNT_DIR_POS         2
+#define BTMR_CTRL_ENABLE_POS            0
+
+/* =========================================================================*/
+/* ================   32/16-bit Basic Timer                ================ */
+/* =========================================================================*/
+
+/*
+ * Each Basic Timer is spaced 0x20 bytes apart.
+ */
+#define BTMR_SPACING            0x20
+#define BTMR_SPACING_PWROF2     5
+#define BTMR_MAX_INSTANCE       4
+
+/**
+  * @brief 32-bit and 16-bit Basic Timer (BTMR)
+  * @note Basic timers 0 & 1 are 16-bit, 2 & 3 are 32-bit.
+  */
+typedef struct
+{                           /*!< (@ 0x40000C00) BTMR Structure        */
+  __IOM uint32_t CNT;       /*!< (@ 0x00000000) BTMR Count            */
+  __IOM uint32_t PRLD;      /*!< (@ 0x00000004) BTMR Preload          */
+  __IOM uint8_t  STS;       /*!< (@ 0x00000008) BTMR Status           */
+        uint8_t  RSVDC[3];
+  __IOM uint8_t  IEN;       /*!< (@ 0x0000000C) BTMR Interrupt Enable */
+        uint8_t  RSVDD[3];
+        uint32_t CTRL;      /*!< (@ 0x00000010) BTMR Control          */
+} BTMR_Type;
+
+/* =========================================================================*/
+/* ================            HTMR                        ================ */
+/* =========================================================================*/
+
+#define HTMR_MAX_INSTANCES      2
+#define HTMR_SPACING            0x20
+#define HTMR_SPACING_PWROF2     5
+
+/*
+ * Set count resolution in bit[0]
+ * 0 = 30.5 us (32786 Hz)
+ * 1 = 125 ms (8 Hz)
+ */
+#define HTMR_CTRL_REG_MASK      0x01ul
+#define HTMR_CTRL_RESOL_POS     0u
+#define HTMR_CTRL_RESOL_MASK    (1u << (HTMR_CTRL_EN_POS))
+#define HTMR_CTRL_RESOL_30US    (0u << (HTMR_CTRL_EN_POS))
+#define HTMR_CTRL_RESOL_125MS   (1u << (HTMR_CTRL_EN_POS))
+
+/*
+ * Hibernation timer is started and stopped by writing a value
+ * to the CNT (count) register.
+ * Writing a non-zero value resets and start the counter counting down.
+ * Writing 0 stops the timer.
+ */
+#define HTMR_CNT_STOP_VALUE     0u
+
+/**
+  * @brief Hibernation Timer (HTMR)
+  */
+typedef struct
+{                           /*!< (@ 0x40009800) HTMR Structure   */
+    __IOM uint16_t PRLD;    /*!< (@ 0x00000000) HTMR Preload */
+          uint8_t  RSVD1[2];
+    __IOM uint16_t CTRL;    /*!< (@ 0x00000004) HTMR Control */
+          uint8_t  RSVD2[2];
+    __IM  uint16_t CNT;     /*!< (@ 0x00000008) HTMR Count (RO) */
+          uint8_t  RSVD3[2];
+} HTMR_Type;
+
+/* =========================================================================*/
+/* ================   Capture/Compare Timer                ================ */
+/* =========================================================================*/
+
+#define CCT_BASE_ADDR          0x40001000
+#define CCT_MAX_INSTANCE       1
+
+/* Control register at offset 0x00 */
+#define CCT_CTRL_ACTIVATE               (1ul << 0)
+#define CCT_CTRL_FREE_RUN_EN            (1ul << 1)
+#define CCT_CTRL_FREE_RUN_RESET         (1ul << 2)  /* self clearing bit */
+#define CCT_CTRL_TCLK_MASK0             (0x07ul)
+#define CCT_CTRL_TCLK_MASK              ((CCT_CTRL_TCLK_MASK0) << 4)
+#define CCT_CTRL_TCLK_DIV_1             (0ul)
+#define CCT_CTRL_TCLK_DIV_2             (1ul << 4)
+#define CCT_CTRL_TCLK_DIV_4             (2ul << 4)
+#define CCT_CTRL_TCLK_DIV_8             (3ul << 4)
+#define CCT_CTRL_TCLK_DIV_16            (4ul << 4)
+#define CCT_CTRL_TCLK_DIV_32            (5ul << 4)
+#define CCT_CTRL_TCLK_DIV_64            (6ul << 4)
+#define CCT_CTRL_TCLK_DIV_128           (7ul << 4)
+#define CCT_CTRL_COMP0_EN               (1ul << 8)
+#define CCT_CTRL_COMP1_EN               (1ul << 9)
+#define CCT_CTRL_COMP1_SET              (1ul << 16) /* R/WS */
+#define CCT_CTRL_COMP0_SET              (1ul << 17) /* R/WS */
+
+/**
+  * @brief Capture/Compare Timer (CCT)
+  */
+typedef struct
+{                                   /*!< (@ 0x40001000) CCT Structure         */
+    __IOM uint32_t CTRL;            /*!< (@ 0x00000000) CCT Control           */
+    __IOM uint32_t CAP0_CTRL;       /*!< (@ 0x00000004) CCT Capture 0 Control */
+    __IOM uint32_t CAP1_CTRL;       /*!< (@ 0x00000008) CCT Capture 1 Control */
+    __IOM uint32_t FREE_RUN;        /*!< (@ 0x0000000C) CCT Free run counter  */
+    __IOM uint32_t CAP0;            /*!< (@ 0x00000010) CCT Capture 0         */
+    __IOM uint32_t CAP1;            /*!< (@ 0x00000014) CCT Capture 1         */
+    __IOM uint32_t CAP2;            /*!< (@ 0x00000018) CCT Capture 2         */
+    __IOM uint32_t CAP3;            /*!< (@ 0x0000001C) CCT Capture 3         */
+    __IOM uint32_t CAP4;            /*!< (@ 0x00000020) CCT Capture 4         */
+    __IOM uint32_t CAP5;            /*!< (@ 0x00000024) CCT Capture 5         */
+    __IOM uint32_t COMP0;           /*!< (@ 0x00000028) CCT Compare 0         */
+    __IOM uint32_t COMP1;           /*!< (@ 0x0000002C) CCT Compare 1         */
+} CCT_Type;
+
+
+/* =========================================================================*/
+/* ================            RTMR                        ================ */
+/* =========================================================================*/
+
+#define RTMR_CTRL_MASK              0x1Ful
+#define RTMR_CTRL_BLK_EN_POS        0u
+#define RTMR_CTRL_BLK_EN_MASK       (1ul << (RTMR_CTRL_BLK_EN_POS))
+#define RTMR_CTRL_BLK_EN            (1ul << (RTMR_CTRL_BLK_EN_POS))
+
+#define RTMR_CTRL_AUTO_RELOAD_POS   1u
+#define RTMR_CTRL_AUTO_RELOAD_MASK  (1ul << (RTMR_CTRL_AUTO_RELOAD_POS))
+#define RTMR_CTRL_AUTO_RELOAD       (1ul << (RTMR_CTRL_AUTO_RELOAD_POS))
+
+#define RTMR_CTRL_START_POS         2u
+#define RTMR_CTRL_START_MASK        (1ul << (RTMR_CTRL_START_POS))
+#define RTMR_CTRL_START             (1ul << (RTMR_CTRL_START_POS))
+
+#define RTMR_CTRL_HW_HALT_EN_POS    3u
+#define RTMR_CTRL_HW_HALT_EN_MASK   (1ul << (RTMR_CTRL_HW_HALT_EN_POS))
+#define RTMR_CTRL_HW_HALT_EN        (1ul << (RTMR_CTRL_HW_HALT_EN_POS))
+
+#define RTMR_CTRL_FW_HALT_EN_POS    4u
+#define RTMR_CTRL_FW_HALT_EN_MASK   (1ul << (RTMR_CTRL_FW_HALT_EN_POS))
+#define RTMR_CTRL_FW_HALT_EN        (1ul << (RTMR_CTRL_FW_HALT_EN_POS))
+
+
+/**
+  * @brief RTOS Timer (RTMR)
+  */
+typedef struct
+{                           /*!< (@ 0x40007400) RTMR Structure   */
+    __IOM uint32_t CNT;     /*!< (@ 0x00000000) RTMR Counter */
+    __IOM uint32_t PRLD;    /*!< (@ 0x00000004) RTMR Preload */
+    __IOM uint8_t  CTRL;    /*!< (@ 0x00000008) RTMR Control */
+          uint8_t  RSVD1[3];
+    __IOM uint32_t SOFTIRQ; /*!< (@ 0x0000000C) RTMR Soft IRQ */
+} RTMR_Type;
+
+/* =========================================================================*/
+/* ================            WKTMR                       ================ */
+/* =========================================================================*/
+
+#define WKTMR_CTRL_MASK                 0x41ul
+#define WKTMR_CTRL_WT_EN_POS            0u
+#define WKTMR_CTRL_WT_EN_MASK           (1ul << (WKTMR_CTRL_WT_EN_POS))
+#define WKTMR_CTRL_WT_EN                (1ul << (WKTMR_CTRL_WT_EN_POS))
+#define WKTMR_CTRL_PWRUP_EV_EN_POS      6u
+#define WKTMR_CTRL_PWRUP_EV_EN_MASK     (1ul << (WKTMR_CTRL_PWRUP_EV_EN_POS))
+#define WKTMR_CTRL_PWRUP_EV_EN          (1ul << (WKTMR_CTRL_PWRUP_EV_EN_POS))
+
+#define WKTMR_ALARM_CNT_MASK            0x0FFFFFFFul
+#define WKTMR_TMR_CMP_MASK              0x0FFFFFFFul
+#define WKTMR_CLK_DIV_MASK              0x7FFFul
+
+#define WKTMR_SS_MASK                   0x0Ful
+#define WKTMR_SS_RATE_DIS               0x00
+#define WKTMR_SS_RATE_2HZ               0x01ul
+#define WKTMR_SS_RATE_4HZ               0x02ul
+#define WKTMR_SS_RATE_8HZ               0x03ul
+#define WKTMR_SS_RATE_16HZ              0x04ul
+#define WKTMR_SS_RATE_32HZ              0x05ul
+#define WKTMR_SS_RATE_64HZ              0x06ul
+#define WKTMR_SS_RATE_128HZ             0x07ul
+#define WKTMR_SS_RATE_256HZ             0x08ul
+#define WKTMR_SS_RATE_512HZ             0x09ul
+#define WKTMR_SS_RATE_1024HZ            0x0Aul
+#define WKTMR_SS_RATE_2048HZ            0x0Bul
+#define WKTMR_SS_RATE_4096HZ            0x0Cul
+#define WKTMR_SS_RATE_8192HZ            0x0Dul
+#define WKTMR_SS_RATE_16384HZ           0x0Eul
+#define WKTMR_SS_RATE_32768HZ           0x0Ful
+
+#define WKTMR_SWKC_MASK                 0x3C3ul
+#define WKTMR_SWKC_PWRUP_EV_STS_POS     0ul
+#define WKTMR_SWKC_PWRUP_EV_STS_MASK    (1ul << (WKTMR_SWKC_PWRUP_EV_STS_POS))
+#define WKTMR_SWKC_PWRUP_EV_STS         (1ul << (WKTMR_SWKC_PWRUP_EV_STS_POS))
+#define WKTMR_SWKC_SYSPWR_PRES_STS_POS  4ul
+#define WKTMR_SWKC_SYSPWR_PRES_STS_MASK (1ul << (WKTMR_SWKC_SYSPWR_PRES_STS_POS))
+#define WKTMR_SWKC_SYSPWR_PRES_STS      (1ul << (WKTMR_SWKC_SYSPWR_PRES_STS_POS))
+#define WKTMR_SWKC_SYSPWR_PRES_EN_POS   5ul
+#define WKTMR_SWKC_SYSPWR_PRES_EN_MASK  (1ul << (WKTMR_SWKC_SYSPWR_PRES_EN_POS))
+#define WKTMR_SWKC_SYSPWR_PRES_EN       (1ul << (WKTMR_SWKC_SYSPWR_PRES_EN_POS))
+#define WKTMR_SWKC_AUTO_RELOAD_POS      6ul
+#define WKTMR_SWKC_AUTO_RELOAD_MASK     (1ul << (WKTMR_SWKC_AUTO_RELOAD_POS))
+#define WKTMR_SWKC_AUTO_RELOAD          (1ul << (WKTMR_SWKC_AUTO_RELOAD_POS))
+
+/* TODO - More register defines */
+
+/**
+  * @brief Week Timer (WKTMR)
+  */
+
+typedef struct
+{               /*!< (@ 0x4000AC80) WKTMR Structure   */
+    __IOM uint32_t CTRL;            /*! (@ 0x00000000) WKTMR control */
+    __IOM uint32_t ALARM_CNT;       /*! (@ 0x00000004) WKTMR Week alarm counter */
+    __IOM uint32_t TMR_COMP;        /*! (@ 0x00000008) WKTMR Week timer compare */
+    __IM  uint32_t CLKDIV;          /*! (@ 0x0000000C) WKTMR Clock Divider (RO) */
+    __IOM uint32_t SS_INTR_SEL;     /*! (@ 0x00000010) WKTMR Sub-second interrupt select */
+    __IOM uint32_t SWK_CTRL;        /*! (@ 0x00000014) WKTMR Sub-week control */
+    __IOM uint32_t SWK_ALARM;       /*! (@ 0x00000018) WKTMR Sub-week alarm */
+    __IOM uint32_t BGPO_DATA;       /*! (@ 0x0000001C) WKTMR BGPO data */
+    __IOM uint32_t BGPO_PWR;        /*! (@ 0x00000020) WKTMR BGPO power */
+    __IOM uint32_t BGPO_RST;        /*! (@ 0x00000024) WKTMR BGPO reset */
+} WKTMR_Type;
+
+#endif /* #ifndef _TIMER_H */
+/* end timer.h */
+/**   @}
+ */

--- a/ext/hal/microchip/mec/mec1501/component/uart.h
+++ b/ext/hal/microchip/mec/mec1501/component/uart.h
@@ -1,0 +1,258 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file uart.h
+ *MEC1501 UART Peripheral Library API
+ */
+/** @defgroup MEC1501 Peripherals UART
+ */
+
+#ifndef _UART_H
+#define _UART_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define UART0_ID            0
+#define UART1_ID            1
+#define UART2_ID            2
+#define UART_MAX_ID         3
+
+#define UART_RX_FIFO_MAX_LEN    16u
+#define UART_TX_FIFO_MAX_LEN    16u
+
+#define UART_BAUD_RATE_MIN      50
+#define UART_BAUD_RATE_MAX      1500000
+
+#define UART0_BASE_ADDRESS      0x400F2400ul
+#define UART1_BASE_ADDRESS      0x400F2800ul
+#define UART2_BASE_ADDRESS      0x400F2C00ul
+
+#define UART_GIRQ_NUM                   15
+#define UART_GIRQ_ID                    7
+#define UART_GIRQ_SRC_ADDR              0x4000E08Cul
+#define UART_GIRQ_EN_SET_ADDR           0x4000E090ul
+#define UART_GIRQ_RESULT_ADDR           0x4000E094ul
+#define UART_GIRQ_EN_CLR_ADDR           0x4000E098ul
+#define UART0_GIRQ_BIT                  0
+#define UART1_GIRQ_BIT                  1
+#define UART2_GIRQ_BIT                  4
+#define UART0_GIRQ_VAL                  (1ul << (UART0_GIRQ_BIT))
+#define UART1_GIRQ_VAL                  (1ul << (UART1_GIRQ_BIT))
+#define UART2_GIRQ_VAL                  (1ul << (UART2_GIRQ_BIT))
+#define UART0_NVIC_DIRECT_NUM           40
+#define UART1_NVIC_DIRECT_NUM           41
+#define UART2_NVIC_DIRECT_NUM           44
+#define UART_NVIC_SETEN_GIRQ_ADDR       0xE000E100ul
+#define UART_NVIC_SETEN_GIRQ_BIT        7             /* aggregated */
+#define UART_NVIC_SETEN_DIRECT_ADDR     0xE000E104ul
+#define UART0_NVIC_SETEN_DIRECT_BIT     (40 - 32)
+#define UART1_NVIC_SETEN_DIRECT_BIT     (41 - 32)
+#define UART2_NVIC_SETEN_DIRECT_BIT     (44 - 32)
+
+/* CMSIS NVIC macro IRQn parameter */
+#define UART_NVIC_IRQn                  7ul     /* aggregated */
+#define UART0_NVIC_IRQn                 41ul    /* UART0 direct mode */
+#define UART1_NVIC_IRQn                 42ul    /* UART1 direct mode */
+#define UART2_NVIC_IRQn                 44ul    /* UART2 direct mode */
+
+
+/* Interrupt Enable Register, R/W DLAB=0 */
+#define UART_IER_RW             1
+#define UART_IER_MASK           0x0Ful
+#define UART_IER_ERDAI          0x01ul /* Received data available and timeouts */
+#define UART_IER_ETHREI         0x02ul /* TX Holding register empty */
+#define UART_IER_ELSI           0x04ul /* Errors: Overrun, Parity, Framing, and Break */
+#define UART_IER_EMSI           0x08ul /* Modem Status */
+#define UART_IER_ALL            0x0Ful
+
+/* FIFO Contro Register, Write-Only */
+#define UART_FCR_WO                 2
+#define UART_FCR_MASK               0xCF
+#define UART_FCR_EXRF               0x01 /* Enable TX & RX FIFO's */
+#define UART_FCR_CLR_RX_FIFO        0x02 /* Clear RX FIFO, bit is self-clearing */
+#define UART_FCR_CLR_TX_FIFO        0x04 /* Clear TX FIFO, bit is self-clearing */
+#define UART_FCR_DMA_EN             0x08 /* DMA Mode Enable. Not implemented */
+#define UART_FCR_RX_FIFO_LVL_MASK   0xC0 /* RX FIFO trigger level mask */
+#define UART_FCR_RX_FIFO_LVL_1      0x00
+#define UART_FCR_RX_FIFO_LVL_4      0x40
+#define UART_FCR_RX_FIFO_LVL_8      0x80
+#define UART_FCR_RX_FIFO_LVL_14     0xC0
+
+/* Interrupt Identification Register, Read-Only */
+#define UART_IIR_RO                 2
+#define UART_IIR_MASK               0xCF
+#define UART_IIR_NOT_IPEND          0x01
+#define UART_IIR_INTID_MASK0        0x07
+#define UART_IIR_INTID_POS          1
+#define UART_IIR_INTID_MASK         0x0E
+#define UART_IIR_FIFO_EN_MASK       0xC0
+/* interrupt values */
+#define UART_IIR_INT_NONE           0x01
+#define UART_IIR_INT_LS             0x06 /* Highest priority: Line status, overrun, framing, or break */
+#define UART_IIR_INT_RX             0x04 /* Highest-1. RX data available or RX FIFO trigger level reached */
+#define UART_IIR_INT_RX_TMOUT       0x0C /* Highest-2. RX timeout */
+#define UART_IIR_INT_THRE           0x02 /* Highest-3. TX Holding register empty. */
+#define UART_IIR_INT_MS             0x00 /* Highest-4. MODEM status. */
+
+/* Line Control Register R/W */
+#define UART_LCR_RW                 3
+#define UART_LCR_WORD_LEN_MASK      0x03
+#define UART_LCR_WORD_LEN_5         0x00
+#define UART_LCR_WORD_LEN_6         0x01
+#define UART_LCR_WORD_LEN_7         0x02
+#define UART_LCR_WORD_LEN_8         0x03
+#define UART_LCR_STOP_BIT_1         0x00
+#define UART_LCR_STOP_BIT_2         0x04 /* 2 for 6-8 bits or 1.5 for 5 bits */
+#define UART_LCR_PARITY_NONE        0x00
+#define UART_LCR_PARITY_EN          0x08
+#define UART_LCR_PARITY_ODD         0x00
+#define UART_LCR_PARITY_EVEN        0x10
+#define UART_LCR_STICK_PARITY       0x20
+#define UART_LCR_BREAK_EN           0x40
+#define UART_LCR_DLAB_EN            0x80
+
+/* MODEM Control Register R/W */
+#define UART_MCR_RW                 4
+#define UART_MCR_MASK               0x1F
+#define UART_MCR_DTRn               0x01
+#define UART_MCR_RTSn               0x02
+#define UART_MCR_OUT1               0x04
+#define UART_MCR_OUT2               0x08
+#define UART_MCR_LOOPBCK_EN         0x10
+
+/* Line Status Register RO */
+#define UART_LSR_RO                 5
+#define UART_LSR_DATA_RDY           0x01
+#define UART_LSR_OVERRUN            0x02
+#define UART_LSR_PARITY             0x04
+#define UART_LSR_FRAME              0x08
+#define UART_LSR_RX_BREAK           0x10
+#define UART_LSR_THRE               0x20
+#define UART_LSR_TEMT               0x40
+#define UART_LSR_FIFO_ERR           0x80
+#define UART_LSR_ANY                0xFF
+
+/* MODEM Status Register RO */
+#define UART_MSR_RO                 6
+#define UART_MSR_DCTS               0x01
+#define UART_MSR_DDSR               0x02
+#define UART_MSR_TERI               0x04
+#define UART_MSR_DDCD               0x08
+#define UART_MSR_CTS                0x10
+#define UART_MSR_DSR                0x20
+#define UART_MSR_RI                 0x40
+#define UART_MSR_DCD                0x80
+
+/* Scratch Register RO */
+#define UART_SCR_RW                 7
+
+/* UART Logical Device Activate Register */
+#define UART_LD_ACT                 0x330
+#define UART_LD_ACTIVATE            0x01
+
+/* UART Logical Device Config Register */
+#define UART_LD_CFG                 0x3F0
+#define UART_LD_CFG_INTCLK          (0u << 0)
+#define UART_LD_CFG_EXTCLK          (1u << 0)
+#define UART_LD_CFG_RESET_SYS       (0u << 1)
+#define UART_LD_CFG_RESET_VCC       (1u << 1)
+#define UART_LD_CFG_NO_INVERT       (0u << 2)
+#define UART_LD_CFG_INVERT          (1u << 2)
+
+/* BAUD rate generator */
+#define UART_INT_CLK_24M            (1ul << 15)
+
+/* 1.8MHz internal clock source */
+#define UART_1P8M_BAUD_50           2304
+#define UART_1P8M_BAUD_110          1536
+#define UART_1P8M_BAUD_150          768
+#define UART_1P8M_BAUD_300          384
+#define UART_1P8M_BAUD_1200         96
+#define UART_1P8M_BAUD_2400         48
+#define UART_1P8M_BAUD_9600         12
+#define UART_1P8M_BAUD_19200        6
+#define UART_1P8M_BAUD_38400        3
+#define UART_1P8M_BAUD_57600        2
+#define UART_1P8M_BAUD_115200       1
+
+/* 24MHz internal clock source. n = 24e6 / (BAUD * 16) = 1500000 / BAUD */
+#define UART_24M_BAUD_115200        ((13) + (UART_INT_CLK_24M))
+#define UART_24M_BAUD_57600         ((26) + (UART_INT_CLK_24M))
+
+
+/* =========================================================================*/
+/* ================            UART                        ================ */
+/* =========================================================================*/
+
+/**
+  * @brief UART interface (UART)
+  */
+
+#define UART_NUM_INSTANCES       3
+#define UART_SPACING             0x400
+#define UART_SPACING_PWROF2      10
+
+typedef union
+{
+    __OM  uint8_t  TXB;         /*!< (@ 0x0000) UART Transmit Buffer(WO) LCR.DLAB=0 */
+    __IM  uint8_t  RXB;         /*!< (@ 0x0000) UART Receive Buffer(RO) LCR.DLAB=0 */
+    __IOM uint8_t  BRGD_LSB;    /*!< (@ 0x0000) UART BAUD Rate Generator LSB(RW) LCR.DLAB=1 */
+} UART_RTXB_BRGL;
+
+typedef union
+{
+    __IOM uint8_t  IEN;         /*!< (@ 0x0001) UART Interrupt Enable(RW) LCR.DLAB=0 */
+    __IOM uint8_t  BRGD_MSB;    /*!< (@ 0x0001) UART BAUD Rate Generator MSB(RW) LCR.DLAB=1 */
+} UART_RTXB_BRGH;
+
+typedef union
+{
+    __IM  uint8_t  IID;         /*!< (@ 0x0002) UART FIFO Control(WO) */
+    __OM  uint8_t  FCR;         /*!< (@ 0x0002) UART Interrupt Indentification(RO) */
+} UART_FCR_IIR;
+
+typedef struct
+{               /*!< (@ 0x400F2400) UART Structure   */
+    UART_RTXB_BRGL  RTXB;
+    UART_RTXB_BRGH  IER;
+    UART_FCR_IIR    FCID;
+    __IOM uint8_t   LCR;        /*!< (@ 0x400F2403) UART Line Control(RW) */
+    __IOM uint8_t   MCR;        /*!< (@ 0x400F2404) UART Modem Control(RW) */
+    __IOM uint8_t   LSR;        /*!< (@ 0x400F2405) UART Line Status(RO) */
+    __IOM uint8_t   MSR;        /*!< (@ 0x400F2406) UART Modem Status(RO) */
+    __IOM uint8_t   SCR;        /*!< (@ 0x400F2407) UART Scratch(RW) */
+          uint8_t   RSVDA[0x330 - 0x08];
+    __IOM uint8_t   ACTV;       /*!< (@ 0x400F2730) UART Activate(RW) */
+          uint8_t   RSVDB[0x3F0 - 0x331];
+    __IOM uint8_t   CFG_SEL;    /*!< (@ 0x400F27F0) UART Configuration Select(RW) */
+} UART_Type;
+
+
+#endif /* #ifndef _UART_H */
+/* end uart.h */
+/**   @}
+ */

--- a/ext/hal/microchip/mec/mec1501/component/vbat.h
+++ b/ext/hal/microchip/mec/mec1501/component/vbat.h
@@ -1,0 +1,123 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file vbat.h
+ *MEC1501 VBAT Registers and memory definitions
+ */
+/** @defgroup MEC1501 Peripherals VBAT
+ */
+
+#ifndef _VBAT_H
+#define _VBAT_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/*
+ * VBAT Registers Registers
+ */
+
+#define VBAT_REGISTERS_ADDR         0x4000A400
+#define VBAT_MEMORY_ADDR            0x4000A800
+#define VBAT_MEMORY_SIZE            64
+
+/*
+ * Offset 0x00 Power-Fail and Reset Status
+ */
+#define VBATR_PFRS_OFS              (0ul)
+#define VBATR_PFRS_MASK             0x7C
+#define VBATR_PFRS_SYS_RST_POS      2
+#define VBATR_PFRS_JTAG_POS         3
+#define VBATR_PFRS_RESETI_POS       4
+#define VBATR_PFRS_WDT_POS          5
+#define VBATR_PFRS_SYSRESETREQ_POS  6
+#define VBATR_PFRS_VBAT_RST_POS     7
+
+#define VBATR_PFRS_SYS_RST          (1 << 2)
+#define VBATR_PFRS_JTAG             (1 << 3)
+#define VBATR_PFRS_RESETI           (1 << 4)
+#define VBATR_PFRS_WDT              (1 << 5)
+#define VBATR_PFRS_SYSRESETREQ      (1 << 6)
+#define VBATR_PFRS_VBAT_RST         (1 << 7)
+
+/*
+ * Offset 0x08 32K Clock Enable
+ */
+#define VBATR_CLKEN_OFS             0x08
+#define VBATR_CLKEN_MASK            0x0E
+#define VBATR_CLKEN_32K_DOM_POS     1
+#define VBATR_CLKEN_32K_SRC_POS     2
+#define VBATR_CLKEN_XTAL_SEL_POS    3
+
+#define VBATR_CLKEN_32K_DOM_ALWYS_ON        (0 << 1)
+#define VBATR_CLKEN_32K_DOM_32K_IN_PIN      (1 << 1)
+#define VBATR_CLKEN_32K_ALWYS_ON_SI_OSC     (0 << 2)
+#define VBATR_CLKEN_32K_ALWYS_ON_XTAL       (1 << 2)
+#define VBATR_CLKEN_XTAL12_PARALLEL         (0 << 3)
+#define VBATR_CLKEN_XTAL2_SE_32K            (1 << 3)
+
+/* =========================================================================*/
+/* ================            VBATR                       ================ */
+/* =========================================================================*/
+
+/**
+  * @brief VBAT Register Bank (VBATR)
+  */
+typedef struct
+{           /*!< (@ 0x4000A400) VBATR Structure   */
+    __IOM uint32_t PFRS;            /*! (@ 0x00000000) VBATR Power Fail Reset Status */
+          uint8_t  RSVD1[4];
+    __IOM uint32_t CLK32_EN;        /*! (@ 0x00000008) VBATR 32K clock enable */
+          uint8_t  RSVD2[20];
+    __IOM uint32_t MCNT_LO;         /*! (@ 0x00000020) VBATR monotonic count lo */
+    __IOM uint32_t MCNT_HI;         /*! (@ 0x00000024) VBATR monotonic count hi */
+} VBATR_Type;
+
+/* =========================================================================*/
+/* ================            VBATM                       ================ */
+/* =========================================================================*/
+
+/**
+  * @brief VBAT Memory (VBATM)
+  */
+#define VBAT_MEM_LEN    64
+
+typedef struct
+{               /*!< (@ 0x4000A800) VBATM Structure   */
+    union vbmem_u {
+        uint32_t u32[(VBAT_MEM_LEN)/4];
+        uint16_t u16[(VBAT_MEM_LEN)/2];
+        uint8_t  u8[VBAT_MEM_LEN];
+    } MEM;
+} VBATM_Type;
+
+
+#endif /* #ifndef _VBAT_H */
+/* end vbat.h */
+/**   @}
+ */
+
+

--- a/ext/hal/microchip/mec/mec1501/component/wdt.h
+++ b/ext/hal/microchip/mec/mec1501/component/wdt.h
@@ -1,0 +1,99 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file wdt.h
+ *MEC1501 Watch Dog Timer Registers
+ */
+/** @defgroup MEC1501 Peripherals WDT
+ */
+
+#ifndef _WDT_H
+#define _WDT_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* =========================================================================*/
+/* ================   WDT                                  ================ */
+/* =========================================================================*/
+
+#define WDT_CTRL_MASK               0x021Dul
+#define WDT_CTRL_EN_POS             0u
+#define WDT_CTRL_EN_MASK            (1u1 << (WDT_CTRL_EN_POS))
+#define WDT_CTRL_EN                 (1u1 << (WDT_CTRL_EN_POS))
+#define WDT_CTRL_HTMR_STALL_POS     2u
+#define WDT_CTRL_HTMR_STALL_MASK    (1u1 << (WDT_CTRL_HTMR_STALL_POS))
+#define WDT_CTRL_HTMR_STALL_EN      (1u1 << (WDT_CTRL_HTMR_STALL_POS))
+#define WDT_CTRL_WKTMR_STALL_POS    3u
+#define WDT_CTRL_WKTMR_STALL_MASK   (1u1 << (WDT_CTRL_WKTMR_STALL_POS))
+#define WDT_CTRL_WKTMR_STALL_EN     (1u1 << (WDT_CTRL_WKTMR_STALL_POS))
+#define WDT_CTRL_JTAG_STALL_POS     4u
+#define WDT_CTRL_JTAG_STALL_MASK    (1u1 << (WDT_CTRL_JTAG_STALL_POS))
+#define WDT_CTRL_JTAG_STALL_EN      (1u1 << (WDT_CTRL_JTAG_STALL_POS))
+/*
+ * If this bit is set when the WDT counts down it will clear this
+ * bit, fire an interrupt if IEN is enabled, and start counting up.
+ * Once it reaches maximum count it actives its reset output.
+ * This feature allows WDT ISR time to take action before WDT asserts
+ * its reset signal.
+ * If this bit is clear WDT will immediately assert its reset signal
+ * when counter counts down to 0.
+ */
+#define WDT_CTRL_INH1_POS           9u
+#define WDT_CTRL_INH1_MASK          (1u1 << (WDT_CTRL_INH1_POS))
+#define WDT_CTRL_INH1_EN            (1u1 << (WDT_CTRL_INH1_POS))
+
+/* Interrupt Enable Register */
+#define WDT_IEN_MASK                0x01ul
+#define WDT_IEN_EVENT_IRQ_POS       0u
+#define WDT_IEN_EVENT_IRQ_MASK      (1ul << (WDT_IEN_EVENT_IRQ_POS))
+#define WDT_IEN_EVENT_IRQ_EN        (1ul << (WDT_IEN_EVENT_IRQ_POS))
+
+/**
+  * @brief Watch Dog Timer (WDT)
+  */
+typedef struct
+{
+    __IOM uint16_t LOAD;        /*!< (@ 0x00000000) WDT Load     */
+          uint8_t  RSVD1[2];
+    __IOM uint16_t CTRL;        /*!< (@ 0x00000004) WDT Control  */
+          uint8_t  RSVD2[2];
+    __OM  uint8_t  KICK;        /*!< (@ 0x00000008) WDT Kick (WO) */
+          uint8_t  RSVD3[3];
+    __IM  uint16_t CNT;         /*!< (@ 0x0000000C) WDT Count (RO)  */
+          uint8_t  RSVD4[2];
+    __IOM uint16_t STS;         /*!< (@ 0x00000010) WDT Status  */
+          uint8_t RSVD5[2];
+    __IOM uint8_t  IEN;         /*!< (@ 0x00000010) WDT Interrupt Enable  */
+} WDT_Type;
+
+
+#endif /* #ifndef _WDT_H */
+/* end wdt.h */
+/**   @}
+ */
+
+


### PR DESCRIPTION
Origin: Microchip CPG
URL: https://www.microchip.com
Version: 0.1
Purpose: Initial MEC1501 device header files.
License: Apache
Maintained-by: External

Signed-off-by: Scott Worley <scott.worley@microchip.com>