### PR TITLE
libc: Fix fwrite function name

### DIFF
--- a/include/misc/libc-hooks.h
+++ b/include/misc/libc-hooks.h
@@ -32,7 +32,7 @@ __syscall int z_zephyr_write_stdout(const void *buf, int nbytes);
 
 __syscall int _zephyr_fputc(int c, FILE *stream);
 
-__syscall size_t z_zephyr_fwrite(const void *_MLIBC_RESTRICT ptr, size_t size,
+__syscall size_t zephyr_fwrite(const void *_MLIBC_RESTRICT ptr, size_t size,
 				size_t nitems, FILE *_MLIBC_RESTRICT stream);
 #endif /* CONFIG_NEWLIB_LIBC */
 

--- a/include/misc/libc-hooks.h
+++ b/include/misc/libc-hooks.h
@@ -30,7 +30,7 @@ __syscall int z_zephyr_write_stdout(const void *buf, int nbytes);
 #else
 /* Minimal libc */
 
-__syscall int _zephyr_fputc(int c, FILE *stream);
+__syscall int zephyr_fputc(int c, FILE * stream);
 
 __syscall size_t zephyr_fwrite(const void *_MLIBC_RESTRICT ptr, size_t size,
 				size_t nitems, FILE *_MLIBC_RESTRICT stream);

--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -25,21 +25,21 @@ void __stdout_hook_install(int (*hook)(int))
 	_stdout_hook = hook;
 }
 
-int z_impl__zephyr_fputc(int c, FILE *stream)
+int z_impl_zephyr_fputc(int c, FILE *stream)
 {
 	return (stdout == stream) ? _stdout_hook(c) : EOF;
 }
 
 #ifdef CONFIG_USERSPACE
-Z_SYSCALL_HANDLER(_zephyr_fputc, c, stream)
+Z_SYSCALL_HANDLER(zephyr_fputc, c, stream)
 {
-	return z_impl__zephyr_fputc(c, (FILE *)stream);
+	return z_impl_zephyr_fputc(c, (FILE *)stream);
 }
 #endif
 
 int fputc(int c, FILE *stream)
 {
-	return _zephyr_fputc(c, stream);
+	return zephyr_fputc(c, stream);
 }
 
 int fputs(const char *_MLIBC_RESTRICT string, FILE *_MLIBC_RESTRICT stream)

--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -52,7 +52,7 @@ int fputs(const char *_MLIBC_RESTRICT string, FILE *_MLIBC_RESTRICT stream)
 	return len == ret ? 0 : EOF;
 }
 
-size_t z_impl__zephyr_fwrite(const void *_MLIBC_RESTRICT ptr, size_t size,
+size_t z_impl_zephyr_fwrite(const void *_MLIBC_RESTRICT ptr, size_t size,
 			    size_t nitems, FILE *_MLIBC_RESTRICT stream)
 {
 	size_t i;
@@ -82,11 +82,11 @@ done:
 }
 
 #ifdef CONFIG_USERSPACE
-Z_SYSCALL_HANDLER(z_zephyr_fwrite, ptr, size, nitems, stream)
+Z_SYSCALL_HANDLER(zephyr_fwrite, ptr, size, nitems, stream)
 {
 
 	Z_OOPS(Z_SYSCALL_MEMORY_ARRAY_READ(ptr, nitems, size));
-	return z_impl__zephyr_fwrite((const void *_MLIBC_RESTRICT)ptr, size,
+	return z_impl_zephyr_fwrite((const void *_MLIBC_RESTRICT)ptr, size,
 				    nitems, (FILE *_MLIBC_RESTRICT)stream);
 }
 #endif
@@ -94,7 +94,7 @@ Z_SYSCALL_HANDLER(z_zephyr_fwrite, ptr, size, nitems, stream)
 size_t fwrite(const void *_MLIBC_RESTRICT ptr, size_t size, size_t nitems,
 			  FILE *_MLIBC_RESTRICT stream)
 {
-	return z_zephyr_fwrite(ptr, size, nitems, stream);
+	return zephyr_fwrite(ptr, size, nitems, stream);
 }
 
 


### PR DESCRIPTION
Commit 4344e27c267e1139c26dbd9cafcca4b3069ea821 changed the reserved
function names, but got the naming wrong for fwrite.  Change fwrite to
match fputc naming and fixes build issues.

Fixes #14275

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>