### PR TITLE
Bluetooth: GATT: Skip certain attributes when discovering descriptors

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -865,11 +865,27 @@ typedef u8_t (*bt_gatt_discover_func_t)(struct bt_conn *conn,
 					const struct bt_gatt_attr *attr,
 					struct bt_gatt_discover_params *params);
 
+/* GATT Discover types */
 enum {
+	/** Discover Primary Services. */
 	BT_GATT_DISCOVER_PRIMARY,
+	/** Discover Secondary Services. */
 	BT_GATT_DISCOVER_SECONDARY,
+	/** Discover Included Services. */
 	BT_GATT_DISCOVER_INCLUDE,
+	/** Discover Characteristic Values.
+	 *
+	 *  Discover Characteristic Value and its properties.
+	 */
 	BT_GATT_DISCOVER_CHARACTERISTIC,
+	/** Discover Descriptors.
+	 *
+	 *  Discover Attributes which are not services or characteristics.
+	 *
+	 *  Note: The use of this type of discover is not recommended for
+	 *  discovering in ranges across multiple services/characteristics
+	 *  as it may incur in extra round trips.
+	 */
 	BT_GATT_DISCOVER_DESCRIPTOR,
 };
 

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -887,6 +887,15 @@ enum {
 	 *  as it may incur in extra round trips.
 	 */
 	BT_GATT_DISCOVER_DESCRIPTOR,
+	/** Discover Attributes.
+	 *
+	 *  Discover Attributes of any type.
+	 *
+	 *  Note: The use of this type of discover is not recommended for
+	 *  discovering in ranges across multiple services/characteristics as
+	 *  it may incur in more round trips.
+	 */
+	BT_GATT_DISCOVER_ATTRIBUTE,
 };
 
 /** @brief GATT Discover Attributes parameters */

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2255,8 +2255,18 @@ static void gatt_find_info_rsp(struct bt_conn *conn, u8_t err,
 		/* Skip attributes that are not considered descriptors */
 		if (!bt_uuid_cmp(&u.uuid, BT_UUID_GATT_PRIMARY) ||
 		    !bt_uuid_cmp(&u.uuid, BT_UUID_GATT_SECONDARY) ||
-		    !bt_uuid_cmp(&u.uuid, BT_UUID_GATT_INCLUDE) ||
-		    !bt_uuid_cmp(&u.uuid, BT_UUID_GATT_CHRC)) {
+		    !bt_uuid_cmp(&u.uuid, BT_UUID_GATT_INCLUDE)) {
+			continue;
+		}
+
+		/* If Characteristic Declaration skip ahead as the next entry
+		 * must be its value.
+		 */
+		if (!bt_uuid_cmp(&u.uuid, bt_uuid_gatt_chrc)) {
+			if (length >= len) {
+				pdu = (const u8_t *)pdu + len;
+				length -= len;
+			}
 			continue;
 		}
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2252,6 +2252,14 @@ static void gatt_find_info_rsp(struct bt_conn *conn, u8_t err,
 			continue;
 		}
 
+		/* Skip attributes that are not considered descriptors */
+		if (!bt_uuid_cmp(&u.uuid, BT_UUID_GATT_PRIMARY) ||
+		    !bt_uuid_cmp(&u.uuid, BT_UUID_GATT_SECONDARY) ||
+		    !bt_uuid_cmp(&u.uuid, BT_UUID_GATT_INCLUDE) ||
+		    !bt_uuid_cmp(&u.uuid, BT_UUID_GATT_CHRC)) {
+			continue;
+		}
+
 		attr = (&(struct bt_gatt_attr)
 			BT_GATT_DESCRIPTOR(&u.uuid, 0, NULL, NULL, NULL));
 		attr->handle = handle;
@@ -2320,6 +2328,13 @@ int bt_gatt_discover(struct bt_conn *conn,
 	case BT_GATT_DISCOVER_CHARACTERISTIC:
 		return gatt_read_type(conn, params);
 	case BT_GATT_DISCOVER_DESCRIPTOR:
+		/* Only descriptors can be filtered */
+		if (!bt_uuid_cmp(params->uuid, BT_UUID_GATT_PRIMARY) ||
+		    !bt_uuid_cmp(params->uuid, BT_UUID_GATT_SECONDARY) ||
+		    !bt_uuid_cmp(params->uuid, BT_UUID_GATT_INCLUDE) ||
+		    !bt_uuid_cmp(params->uuid, BT_UUID_GATT_CHRC)) {
+			return -EINVAL;
+		}
 		return gatt_find_info(conn, params);
 	default:
 		BT_ERR("Invalid discovery type: %u", params->type);


### PR DESCRIPTION
When discovering descriptor Find Information procedure is used which
does not allow any filtering by the server so it will return all
attributes in the given range including services and characteristics.

Fixes #14265

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>