### PR TITLE
drivers: modem: cleanup

### DIFF
--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -48,6 +48,4 @@ config MODEM_SHELL
 
 source "drivers/modem/Kconfig.wncm14a2a"
 
-config MODEM_WNCM14A2A_RX_STACK_SIZE
-
 endif # MODEM

--- a/drivers/modem/Kconfig.wncm14a2a
+++ b/drivers/modem/Kconfig.wncm14a2a
@@ -10,6 +10,7 @@ menuconfig MODEM_WNCM14A2A
 	bool "Enable Wistron LTE-M modem driver"
 	select MODEM_RECEIVER
 	select NET_OFFLOAD
+	imply GPIO
 	select UART_MCUX_2 if BOARD_FRDM_K64F
 	select GPIO_NRF_P1 if SOC_NRF52840
 	select UART_1_NRF_UARTE if SOC_NRF52840

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -30,11 +30,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include "ipv4.h"
 #endif
 #if defined(CONFIG_NET_UDP)
-#include <net/udp.h>
 #include "udp_internal.h"
-#endif
-#if defined(CONFIG_NET_TCP)
-#include <net/tcp.h>
 #endif
 
 #include <drivers/modem/modem_receiver.h>


### PR DESCRIPTION
- WNC-M14A2A requires use of GPIOs in the driver.  Let's make sure we imply GPIO if the modem is selected, as several HW now do not select GPIO by default.
- Cleanup the drivers/modem/Kconfig due to left over artifact from the WNC-M14A2A split.
- Fix timeout handling for WNC-M14A2A
- WNC-M14A2A: Cleaned up includes