### PR TITLE
Error handling in simplelink_sockets.c

### DIFF
--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -671,8 +671,30 @@ static int simplelink_setsockopt(int sd, int level, int optname,
 					       _SEC_DOMAIN_VERIF,
 					       (const char *)optval, optlen);
 			break;
-		case TLS_CIPHERSUITE_LIST:
 		case TLS_PEER_VERIFY:
+			if (optval) {
+				/*
+				 * Not currently supported. Verification
+				 * is automatically performed if a CA
+				 * certificate is set. We are returning
+				 * success here to allow
+				 * mqtt_client_tls_connect()
+				 * to proceed, given it requires
+				 * verification and it is indeed
+				 * performed when the cert is set.
+				 */
+				if (*(u32_t *)optval != 2) {
+					retval = slcb_SetErrno(ENOTSUP);
+					goto exit;
+				} else {
+					retval = 0;
+				}
+			} else {
+				retval = slcb_SetErrno(EINVAL);
+				goto exit;
+			}
+			break;
+		case TLS_CIPHERSUITE_LIST:
 		case TLS_DTLS_ROLE:
 			/* Not yet supported: */
 			retval = slcb_SetErrno(ENOTSUP);


### PR DESCRIPTION
In #12745, the driver is not returning correct error codes when error occurs.
The error handling function is expecting negative input values, but
that is not true for BSD error codes. So I am taking an approach
where I use a function to convert SimpleLink error codes to BSD
error codes, and call slcb_setErrno() to set the errno independently.

After fixing this, I observe an error when running the mqtt_publisher sample.
This is due to mqtt_client_tls_connect() calling setsockopt() to set
the TLS_PEER_VERIFY option. Given a positive number was previously returned,
the error from setsockopt() was not caught. To enable the mqtt libary,
simplelink_sockets.c has been modified to return success if this option
is set to 2.