### PR TITLE
doc: up_squared: add 'west' build option to the UP2 documentation

### DIFF
--- a/boards/x86/up_squared/doc/index.rst
+++ b/boards/x86/up_squared/doc/index.rst
@@ -207,6 +207,7 @@ Build Zephyr application
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world
+      :tool: all
       :board: up_squared
       :goals: build
 


### PR DESCRIPTION
It is also possible to use 'west' to build the 'hello_world' sample
application for the UP2 (up_squared) board. This patch makes it
explicit in the documentation.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>