### PR TITLE
drivers: usb: Fix coverity issue (195758)

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1114,7 +1114,7 @@ static void usbd_event_transfer_data(nrfx_usbd_evt_t const *const p_event)
 static void usbd_event_handler(nrfx_usbd_evt_t const *const p_event)
 {
 	struct nrf_usbd_ep_ctx *ep_ctx;
-	struct usbd_event evt;
+	struct usbd_event evt = {0};
 	bool put_evt = false;
 
 	switch (p_event->type) {


### PR DESCRIPTION
Fix issue reported by coverity regarding reading a variable
before initializing it with a value.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>