### PR TITLE
libc: Cleanup/fix setting of system include paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,8 +348,6 @@ endif()
 
 zephyr_cc_option_ifdef(CONFIG_STACK_USAGE            -fstack-usage)
 
-zephyr_system_include_directories(${NOSTDINC})
-
 # Force an error when things like SYS_INIT(foo, ...) occur with a missing header.
 zephyr_cc_option(-Werror=implicit-int)
 

--- a/cmake/compiler/gcc/target_baremetal.cmake
+++ b/cmake/compiler/gcc/target_baremetal.cmake
@@ -5,6 +5,7 @@ macro(toolchain_cc_nostdinc)
     NOT COMPILER STREQUAL "xcc" AND
     NOT CONFIG_NATIVE_APPLICATION)
     zephyr_compile_options( -nostdinc)
+    zephyr_system_include_directories(${NOSTDINC})
   endif()
 
 endmacro()

--- a/lib/libc/newlib/CMakeLists.txt
+++ b/lib/libc/newlib/CMakeLists.txt
@@ -7,8 +7,12 @@ zephyr_library_sources(libc-hooks.c)
 # unable to, it will be up to the user to specify LIBC_*_DIR vars to
 # point to a newlib implementation.
 
+# We need to make sure this is included before the standard system
+# header include path's since we build with -ffreestanding and need
+# our libc headers to be picked instead of the toolchain's ffreestanding
+# headers.
 if(LIBC_INCLUDE_DIR)
-  zephyr_include_directories(${LIBC_INCLUDE_DIR})
+  zephyr_system_include_directories(${LIBC_INCLUDE_DIR})
 endif()
 
 if(LIBC_LIBRARY_DIR)


### PR DESCRIPTION
We use to build with -nostdinc and thus we explicitly set the system
include paths.  Instead we should let the compiler do that and remove
doing it outselves.

Since we build with -ffreestanding we do need to explicitly set the a
system include path for the libc headers.  Thus we change the libc
cases from zephyr_include_directories to
zephyr_system_include_directories.  We need to ensure that the libc
headers are picked up instead of the 'freestanding' toolchain headers.

Note for whatever reason the SDK 0.9.5 version of the tools was treating
-I and -isystem similarly and thus would find the libc headers first
before the 'freestanding' headers from the toolchain.

Fixes #14310

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>