### PR TITLE
drivers: eth: native_posix: Null terminate interface name

### DIFF
--- a/drivers/ethernet/eth_native_posix_adapt.c
+++ b/drivers/ethernet/eth_native_posix_adapt.c
@@ -67,7 +67,7 @@ int eth_iface_create(const char *if_name, bool tun_only)
 #ifdef __linux
 	ifr.ifr_flags = (tun_only ? IFF_TUN : IFF_TAP) | IFF_NO_PI;
 
-	strncpy(ifr.ifr_name, if_name, IFNAMSIZ);
+	strncpy(ifr.ifr_name, if_name, IFNAMSIZ - 1);
 
 	ret = ioctl(fd, TUNSETIFF, (void *)&ifr);
 	if (ret < 0) {


### PR DESCRIPTION
The interface name is IFNAMSIZ long so we must not copy it
full which would overwrite the terminating null byte.

Coverity-CID: 195770
Fixes #14419

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>