### PR TITLE
arch/x86_64: Fix printf format string

### DIFF
--- a/arch/x86_64/core/xuk-stub32.c
+++ b/arch/x86_64/core/xuk-stub32.c
@@ -179,11 +179,7 @@ void cstart(unsigned int magic, unsigned int arg)
 	 * using BIOS e820 like Linux does.
 	 */
 	if (magic == BOOT_MAGIC_MULTIBOOT) {
-		printf("Hi there!\n");
-		printf("This is a second line!\n");
-		printf("And this line was generated from %s\n", "printf!");
-
-		printf("Magic: %p MBI Addr: %p\n", magic, arg);
+		printf("Magic: %p MBI Addr: %p\n", (void *)magic, (void *)arg);
 
 		int mem_lower = *(int *)(arg + 4);
 		int mem_upper = *(int *)(arg + 8);


### PR DESCRIPTION
There was a spot where the early boot code was logging using %p to
emit an integer, and Coverity doesn't like that.  Fixes #14420 and
Fixes #14418

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>