### PR TITLE
kernel: enhance documentation of z_arch_buffer_validate

### DIFF
--- a/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
+++ b/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
@@ -262,6 +262,10 @@ int arm_core_mpu_get_max_available_dyn_regions(void);
 
 /**
  * @brief validate the given buffer is user accessible or not
+ *
+ * Note: Validation will always return failure, if the supplied buffer
+ *       spans multiple enabled MPU regions (even if these regions all
+ *       permit user access).
  */
 int arm_core_mpu_buffer_validate(void *addr, size_t size, int write);
 

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -125,6 +125,18 @@ extern void z_arch_mem_domain_destroy(struct k_mem_domain *domain);
  * configuration would allow a user thread to read/write that region. Used by
  * system calls to validate buffers coming in from userspace.
  *
+ * Notes:
+ * The function is guaranteed to never return validation success, if the entire
+ * buffer area is not user accessible.
+ *
+ * The function is guaranteed to correctly validate the permissions of the
+ * supplied buffer, if the user access permissions of the entire buffer are
+ * enforced by a single, enabled memory management region.
+ *
+ * In some architectures the validation will always return failure
+ * if the supplied memory buffer spans multiple enabled memory management
+ * regions (even if all such regions permit user access).
+ *
  * @param addr start address of the buffer
  * @param size the size of the buffer
  * @param write If nonzero, additionally check if the area is writable.

--- a/kernel/include/syscall_handler.h
+++ b/kernel/include/syscall_handler.h
@@ -295,6 +295,22 @@ extern int z_user_string_copy(char *dst, char *src, size_t maxlen);
  */
 #define Z_SYSCALL_VERIFY(expr) Z_SYSCALL_VERIFY_MSG(expr, #expr)
 
+/**
+ * @brief Runtime check that a user thread has read and/or write permission to
+ *        a memory area
+ *
+ * Checks that the particular memory area is readable and/or writeable by the
+ * currently running thread if the CPU was in user mode, and generates a kernel
+ * oops if it wasn't. Prevents userspace from getting the kernel to read and/or
+ * modify memory the thread does not have access to, or passing in garbage
+ * pointers that would crash/pagefault the kernel if dereferenced.
+ *
+ * @param ptr Memory area to examine
+ * @param size Size of the memory area
+ * @param write If the thread should be able to write to this memory, not just
+ *		read it
+ * @return 0 on success, nonzero on failure
+ */
 #define Z_SYSCALL_MEMORY(ptr, size, write) \
 	Z_SYSCALL_VERIFY_MSG(z_arch_buffer_validate((void *)ptr, size, write) \
 			     == 0, \
@@ -313,8 +329,6 @@ extern int z_user_string_copy(char *dst, char *src, size_t maxlen);
  *
  * @param ptr Memory area to examine
  * @param size Size of the memory area
- * @param write If the thread should be able to write to this memory, not just
- *		read it
  * @return 0 on success, nonzero on failure
  */
 #define Z_SYSCALL_MEMORY_READ(ptr, size) \
@@ -331,8 +345,6 @@ extern int z_user_string_copy(char *dst, char *src, size_t maxlen);
  *
  * @param ptr Memory area to examine
  * @param size Size of the memory area
- * @param write If the thread should be able to write to this memory, not just
- *		read it
  * @param 0 on success, nonzero on failure
  */
 #define Z_SYSCALL_MEMORY_WRITE(ptr, size) \


### PR DESCRIPTION
This commit enhances the documentation of z_arch_buffer_validate
describing the cases where the validation is performed
successfully, as well as the cases where the result is
undefined.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>