### PR TITLE
doc: add note about force pushes to contrib guide

### DIFF
--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -540,6 +540,15 @@ workflow here:
    By force pushing your update, your original pull request will be updated
    with your changes so you won't need to resubmit the pull request.
 
+   .. note:: While amending commits and force pushing is a common review model
+      outside GitHub, and the one recommended by Zephyr, it's not the main
+      model supported by GitHub. Forced pushes can cause unexpected behavior,
+      such as not being able to use "View Changes" buttons except for the last
+      one - GitHub complains it can't find older commits. You're also not
+      always able to compare the latest reviewed version with the latest
+      submitted version. When rewriting history GitHub only guarantees access
+      to the latest version.
+
 #. If the CI run fails, you will need to make changes to your code in order
    to fix the issues and amend your commits by rebasing as described above.
    Additional information about the CI system can be found in
@@ -579,7 +588,7 @@ does and why it's needed. A change summary of ``"Fixes stuff"`` will be rejected
 
 .. warning::
    An empty change summary body is not permitted. Even for trivial changes, please
-   include a summary body in the commmit message.
+   include a summary body in the commit message.
 
 The description body of the commit message must include:
 


### PR DESCRIPTION
Let folks know that using amend and force pushes for adding review
changes is the recommend method for contributing to the project, but it
can cause some unexpected behavior from GitHub.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>

--------------
EDIT

cc:
- #39194
- https://gitlab.com/gitlab-org/gitlab/-/issues/24096 support `git range-diff`