### PR TITLE
samples: sockets: echo_async: Check return value of setsockopt

### DIFF
--- a/samples/net/sockets/echo_async/src/socket_echo.c
+++ b/samples/net/sockets/echo_async/src/socket_echo.c
@@ -137,7 +137,11 @@ int main(void)
 	 * same port as IPv4 socket above.
 	 */
 	int TRUE = 1;
-	setsockopt(serv6, IPPROTO_IPV6, IPV6_V6ONLY, &TRUE, sizeof(TRUE));
+	res = setsockopt(serv6, IPPROTO_IPV6, IPV6_V6ONLY, &TRUE, sizeof(TRUE));
+	if (res < 0) {
+		printf("error: setsockopt: %d\n", errno);
+		exit(1);
+	}
 	#endif
 	res = bind(serv6, (struct sockaddr *)&bind_addr6, sizeof(bind_addr6));
 	if (res == -1) {

--- a/samples/net/sockets/echo_async_select/src/socket_echo_select.c
+++ b/samples/net/sockets/echo_async_select/src/socket_echo_select.c
@@ -121,7 +121,11 @@ int main(void)
 	 * same port as IPv4 socket above.
 	 */
 	int TRUE = 1;
-	setsockopt(serv6, IPPROTO_IPV6, IPV6_V6ONLY, &TRUE, sizeof(TRUE));
+	res = setsockopt(serv6, IPPROTO_IPV6, IPV6_V6ONLY, &TRUE, sizeof(TRUE));
+	if (res < 0) {
+		printf("error: setsockopt: %d\n", errno);
+		exit(1);
+	}
 	#endif
 	res = bind(serv6, (struct sockaddr *)&bind_addr6, sizeof(bind_addr6));
 	if (res == -1) {


### PR DESCRIPTION
This patch checks the return values of setsockopt.

Fixes: #14392, #14402
Coverity-CID: 195897, 195848

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>