### PR TITLE
drivers: watchdog: stm32 iwdg bug fixes

### DIFF
--- a/drivers/watchdog/iwdg_stm32.c
+++ b/drivers/watchdog/iwdg_stm32.c
@@ -106,8 +106,8 @@ static int iwdg_stm32_install_timeout(struct device *dev,
 
 	iwdg_stm32_convert_timeout(timeout, &prescaler, &reload);
 
-	if (IS_IWDG_TIMEOUT(timeout) || IS_IWDG_PRESCALER(prescaler) ||
-	    IS_IWDG_RELOAD(reload)) {
+	if (!IS_IWDG_TIMEOUT(timeout) || !IS_IWDG_PRESCALER(prescaler) ||
+	    !IS_IWDG_RELOAD(reload)) {
 		/* One of the parameters provided is invalid */
 		return -EINVAL;
 	}

--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -19,6 +19,7 @@
 #define WDT_DEV_NAME DT_WDT_0_NAME
 #endif
 
+#ifndef CONFIG_IWDG_STM32
 static void wdt_callback(struct device *wdt_dev, int channel_id)
 {
 	ARG_UNUSED(wdt_dev);
@@ -27,6 +28,7 @@ static void wdt_callback(struct device *wdt_dev, int channel_id)
 	 * Remember that SoC reset will be done soon.
 	 */
 }
+#endif
 
 void main(void)
 {
@@ -50,9 +52,12 @@ void main(void)
 	wdt_config.window.min = 0;
 	wdt_config.window.max = 5000;
 
-	/* Set up watchdog callback. Jump into it when watchdog expired. */
+	/* Set up watchdog callback. Jump into it when watchdog expired.
+	 * But for STM32 SoC, this parameter is invalid.
+	 */
+#ifndef CONFIG_IWDG_STM32
 	wdt_config.callback = wdt_callback;
-
+#endif
 	wdt_channel_id = wdt_install_timeout(wdt, &wdt_config);
 	if (wdt_channel_id < 0) {
 		printk("Watchdog install error\n");


### PR DESCRIPTION
This patch fixed the stm32 iwdg parameters check bug in the function
iwdg_stm32_install_timeout

Signed-off-by: Yong Jin <jinyong.iot@foxmail.com>