### PR TITLE
Bluetooth: Mesh: Fix checking for bt_mesh_provision() error

### DIFF
--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -1074,7 +1074,11 @@ static void prov_data(const u8_t *data)
 		identity_enable = false;
 	}
 
-	bt_mesh_provision(pdu, net_idx, flags, iv_index, addr, dev_key);
+	err = bt_mesh_provision(pdu, net_idx, flags, iv_index, addr, dev_key);
+	if (err) {
+		BT_ERR("Failed to provision (err %d)", err);
+		return;
+	}
 
 	/* After PB-GATT provisioning we should start advertising
 	 * using Node Identity.


### PR DESCRIPTION
There isn't much we can do if this fails, but at least log an error
about it.

Fixes #13855

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>