### PR TITLE
tests: drivers: counter: Fix coverity issues

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -121,6 +121,7 @@ void test_set_top_value_with_alarm_instance(const char *dev_name)
 	int err;
 	u32_t cnt;
 	u32_t ticks;
+	u32_t tmp_top_cnt;
 
 	top_cnt = 0;
 
@@ -141,9 +142,10 @@ void test_set_top_value_with_alarm_instance(const char *dev_name)
 
 	k_busy_wait(5.2*COUNTER_PERIOD_US);
 
-	zassert_true((u32_t)top_cnt == 5,
+	tmp_top_cnt = top_cnt; /* to avoid passing volatile to the macro */
+	zassert_true(tmp_top_cnt == 5,
 			"Unexpected number of turnarounds (%d) (dev: %s).\n",
-			(u32_t)top_cnt, dev_name);
+			tmp_top_cnt, dev_name);
 }
 
 void test_set_top_value_with_alarm(void)
@@ -168,6 +170,7 @@ void test_single_shot_alarm_instance(const char *dev_name, bool set_top)
 	struct device *dev;
 	int err;
 	u32_t ticks;
+	u32_t tmp_alarm_cnt;
 
 	dev = device_get_binding(dev_name);
 	ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
@@ -205,10 +208,12 @@ void test_single_shot_alarm_instance(const char *dev_name, bool set_top)
 	zassert_equal(0, err, "Counter set alarm failed\n");
 
 	k_busy_wait(1.5*counter_ticks_to_us(dev, ticks));
-	zassert_equal(1, (u32_t)alarm_cnt, "Expecting alarm callback\n");
+	tmp_alarm_cnt = alarm_cnt; /* to avoid passing volatile to the macro */
+	zassert_equal(1, tmp_alarm_cnt, "Expecting alarm callback\n");
 
 	k_busy_wait(1.5*counter_ticks_to_us(dev, ticks));
-	zassert_equal(1, (u32_t)alarm_cnt, "Expecting alarm callback\n");
+	tmp_alarm_cnt = alarm_cnt; /* to avoid passing volatile to the macro */
+	zassert_equal(1, tmp_alarm_cnt, "Expecting alarm callback\n");
 
 	err = counter_cancel_channel_alarm(dev, 0);
 	zassert_equal(0, err, "Counter disabling alarm failed\n");
@@ -266,6 +271,7 @@ void test_multiple_alarms_instance(const char *dev_name)
 	struct device *dev;
 	int err;
 	u32_t ticks;
+	u32_t tmp_alarm_cnt;
 
 	dev = device_get_binding(dev_name);
 	ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
@@ -302,7 +308,8 @@ void test_multiple_alarms_instance(const char *dev_name)
 	zassert_equal(0, err, "Counter set alarm failed\n");
 
 	k_busy_wait(1.2*counter_ticks_to_us(dev, 2*ticks));
-	zassert_equal(2, (u32_t)alarm_cnt, "Counter set alarm failed\n");
+	tmp_alarm_cnt = alarm_cnt; /* to avoid passing volatile to the macro */
+	zassert_equal(2, tmp_alarm_cnt, "Counter set alarm failed\n");
 	zassert_equal(&alarm_cfg2, clbk_data[0],
 			"Expected different order or callbacks\n");
 	zassert_equal(&alarm_cfg, clbk_data[1],
@@ -330,6 +337,7 @@ void test_all_channels_instance(const char *str)
 	bool limit_reached = false;
 	struct counter_alarm_cfg alarm_cfgs;
 	u32_t ticks;
+	u32_t tmp_alarm_cnt;
 
 	dev = device_get_binding(str);
 	ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
@@ -355,7 +363,8 @@ void test_all_channels_instance(const char *str)
 	}
 
 	k_busy_wait(1.5*counter_ticks_to_us(dev, ticks));
-	zassert_equal(nchan, (u32_t)alarm_cnt, "Expecting alarm callback\n");
+	tmp_alarm_cnt = alarm_cnt; /* to avoid passing volatile to the macro */
+	zassert_equal(nchan, tmp_alarm_cnt, "Expecting alarm callback\n");
 
 	for (int i = 0; i < nchan; i++) {
 		err = counter_cancel_channel_alarm(dev, i);


### PR DESCRIPTION
Apparently, casting was not enough for coverity. Adding temporary variable.

Issues 190937, 190952, 190967, 190983

Fixes #13876 
Fixes #13863 
Fixes #13851 
Fixes #13839 

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>