### PR TITLE
tests: net: dhcpv4: Check null ptr dereference

### DIFF
--- a/tests/net/dhcpv4/src/main.c
+++ b/tests/net/dhcpv4/src/main.c
@@ -202,6 +202,9 @@ struct net_pkt *prepare_dhcp_offer(struct net_if *iface, u32_t xid)
 
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(offer), AF_INET,
 					IPPROTO_UDP, K_FOREVER);
+	if (!pkt) {
+		return NULL;
+	}
 
 	net_pkt_set_ipv4_ttl(pkt, 0xFF);
 
@@ -240,6 +243,9 @@ struct net_pkt *prepare_dhcp_ack(struct net_if *iface, u32_t xid)
 
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(offer), AF_INET,
 					IPPROTO_UDP, K_FOREVER);
+	if (!pkt) {
+		return NULL;
+	}
 
 	net_pkt_set_ipv4_ttl(pkt, 0xFF);
 


### PR DESCRIPTION
If pkt allocation fails, then prepare to handle NULL pointer.

Coverity-CID: 195880
Coverity-CID: 195816

Fixes #14413
Fixes #14395

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>