### PR TITLE
logging: Force LOG_PRINTK option if RTT backend is used

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -431,6 +431,17 @@ config LOG_BACKEND_RTT_BUFFER_SIZE
 	  Specify reserved size of up-buffer used for logger output.
 
 endif # LOG_BACKEND_RTT_BUFFER
+
+
+# Enable processing of printk calls using log if terminal buffer is used.
+# Same buffer is used by RTT console. If printk would go through RTT console
+# that will lead to corruption of RTT data which is not protected against being
+# interrupted by an interrupt.
+config LOG_BACKEND_RTT_FORCE_PRINTK
+	bool
+	default y if LOG_BACKEND_RTT_BUFFER = 0
+	select LOG_PRINTK
+
 endif # LOG_BACKEND_RTT
 
 config LOG_BACKEND_NATIVE_POSIX


### PR DESCRIPTION
Log RTT backed is using mutex for locking access to RTT data.
RTT console (which by default is used by printk) writes to
RTT data directly and it cannot use mutex because it can be
called from any context (including interrupt). If both
modules access RTT buffer 0, data can be corrupted.

This patch forces LOG_PRINTK option if RTT backend is used to
ensure single point of access to RTT buffer 0 data.

Fixes #11393.

I agree with points in the the discussion in #11393:
> Well, I don't see CONFIG_LOG_PRINTK as a workaround rather than proper solution

> btw CONFIG_LOG_PRINTK should be usable workaround



Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>