### PR TITLE
tests/drivers/watchdog/wdt_basic_api/ behavior wrong.

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -300,7 +300,7 @@ static int test_wdt_bad_window_max(void)
 
 void test_wdt(void)
 {
-	if (m_testcase_index != 1) {
+	if ((m_testcase_index != 1) && (m_testcase_index != 2)) {
 		zassert_true(test_wdt_no_callback() == TC_PASS, NULL);
 	}
 	if (m_testcase_index == 1) {


### PR DESCRIPTION
tests:  watchdog:  Debug for boards enabled TEST_WDT_CALLBACK_2

The original code cannot go to the next step on those boards enabled TEST_WDT_CALLBACK_2 macro, because of the flow control issue. So the test function cannot finish, and the board keeps restart.  As a result, failure on the test.

Fixes #13468

Signed-off-by: Aaron Tsui <aaron.tsui@outlook.com>