### PR TITLE
boards/x86: scripts: build_grub.sh to use grub-2.02-285-g5bc41db75

### DIFF
--- a/boards/x86/common/scripts/build_grub.sh
+++ b/boards/x86/common/scripts/build_grub.sh
@@ -21,12 +21,7 @@ prepare() {
   fi
 
   pushd src
-  git checkout grub-2.02
-  cat << EOF | awk ' { print $1 }' | git cherry-pick -x --stdin
-  grub-2.02-69-gc36c2a864  yylex: Explicilty cast fprintf to void.
-  grub-2.02-136-g563b1da6e Fix packed-not-aligned error on GCC 8
-  grub-2.02-100-g842c39046 x86-64: Treat R_X86_64_PLT32 as R_X86_64_PC32
-EOF
+  git checkout grub-2.02-285-g5bc41db75
   git clean -fdx
   popd
 }
@@ -34,6 +29,7 @@ EOF
 build() {
   pushd src
 
+  ./bootstrap
   ./autogen.sh
   ./configure --with-platform=efi --target=${TARGET_ARCH}
 

--- a/boards/x86/galileo/doc/index.rst
+++ b/boards/x86/galileo/doc/index.rst
@@ -216,14 +216,15 @@ copy of GRUB, follow these steps to test on supported boards using a custom GRUB
 
    .. code-block:: console
 
-      $ sudo apt-get install bison autoconf libopts25-dev flex automake
+      $ sudo apt-get install bison autoconf libopts25-dev flex automake \
+      pkg-config gettext autopoint
 
    On Fedora, type:
 
    .. code-block:: console
 
      $ sudo dnf install gnu-efi bison m4 autoconf help2man flex \
-        automake texinfo
+        automake texinfo gettext-devel
 
 #. Clone and build the GRUB repository using the script in Zephyr tree, type:
 

--- a/boards/x86/up_squared/doc/index.rst
+++ b/boards/x86/up_squared/doc/index.rst
@@ -180,14 +180,15 @@ copy of GRUB, follow these steps to test on supported boards using a custom GRUB
 
    .. code-block:: console
 
-      $ sudo apt-get install bison autoconf libopts25-dev flex automake
+      $ sudo apt-get install bison autoconf libopts25-dev flex automake \
+      pkg-config gettext autopoint
 
    On Fedora, type:
 
    .. code-block:: console
 
       $ sudo dnf install gnu-efi bison m4 autoconf help2man flex \
-      automake texinfo
+      automake texinfo gettext-devel
 
 #. Clone and build the GRUB repository using the script in Zephyr tree, type:
 


### PR DESCRIPTION
The build_grub.sh script cherry-picks 3 commits from the master branch
of grub because more recent build tools fail to build the latest stable
release (which is 2.02). This solves the problem on Fedora 29 for
example, but is not sufficient for Clear Linux.

This patch modifies the build_grub.sh script to use
grub-2.02-285-g5bc41db75 (latest from master as of 13 of March 2019).
That version compiles 'out-of-the-box' in the latest Ubuntu, Fedora and
Clear Linux.

There are additional tools required on the host system and the
documentation has been updated accordingly.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>