### PR TITLE
uart: native_posix: Fix out of bounds access

### DIFF
--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -65,7 +65,7 @@ static void attach_to_tty(const char *slave_tty)
 	if (auto_attach_cmd == NULL) {
 		auto_attach_cmd = (char *)default_cmd;
 	}
-	char command[strlen(auto_attach_cmd) + strlen(slave_tty)];
+	char command[strlen(auto_attach_cmd) + strlen(slave_tty) + 1];
 
 	sprintf(command, auto_attach_cmd, slave_tty);
 


### PR DESCRIPTION
Fix an out of bound access in the native_posix uart driver,
when generating the string to autoattach a terminal to the UART.
(The space for the null termination was missing)

Fixes: #14401
Coverity issue CID: 195855

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>