### PR TITLE
boards: 96b_carbon: Require BT for NET_L2_BT

### DIFF
--- a/boards/arm/96b_carbon/Kconfig.defconfig
+++ b/boards/arm/96b_carbon/Kconfig.defconfig
@@ -63,16 +63,32 @@ endif # BT
 
 if NETWORKING
 
+# Re-create the NET_L2_BT dependencies here
+config BT
+	default y
+
+config BT_PERIPHERAL
+	default BT
+
+config BT_CENTRAL
+	default BT
+
+config BT_SMP
+	default BT
+
+config BT_L2CAP_DYNAMIC_CHANNEL
+	default BT
+
 # BT is the only onboard network iface, so use it for IP networking
 # if it's enabled
 
 config NET_L2_BT
 	depends on NET_IPV6
-	default y
+	default BT
 
 config NET_L2_BT_ZEP1656
 	depends on NET_IPV6
-	default y
+	default BT
 
 endif # NETWORKING
 


### PR DESCRIPTION
Since NET_L2_BT no longer "select"s BT, enable the corresponding
dependencies within the defconfig file.

Fixes #14469

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>