### PR TITLE
Arch arm v8m mpu fix buffer validate func

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,8 @@
 /.known-issues/                           @inakypg @nashif
 /arch/arc/                                @vonhust @ruuddw
 /arch/arm/                                @MaureenHelm @galak
+/arch/arm/core/cortex_m/cmse/             @ioannisg
+/arch/arm/include/cortex_m/cmse/          @ioannisg
 /soc/arm/                                 @MaureenHelm @galak
 /soc/arm/arm/mps2/                        @fvincenzo
 /soc/arm/atmel_sam/sam4s/                 @fallrisk

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
@@ -225,6 +225,25 @@ static inline int _is_enabled_region(u32_t index)
 /**
  * This internal function validates whether a given memory buffer
  * is user accessible or not.
+ *
+ * Note: [Doc. number: ARM-ECM-0359818]
+ * "Some SAU, IDAU, and MPU configurations block the efficient implementation
+ * of an address range check. The CMSE intrinsic operates under the assumption
+ * that the configuration of the SAU, IDAU, and MPU is constrained as follows:
+ * - An object is allocated in a single MPU/SAU/IDAU region.
+ * - A stack is allocated in a single region.
+ *
+ * These points imply that the memory buffer does not span across multiple MPU,
+ * SAU, or IDAU regions."
+ *
+ * MPU regions are configurable, however, some platforms might have fixed-size
+ * SAU or IDAU regions. So, even if a buffer is allocated inside a single MPU
+ * region, it might span across multiple SAU/IDAU regions, which will make the
+ * TT-based address range check fail.
+ *
+ * Therefore, the function performs a second check, which is based on MPU only,
+ * in case the fast address range check fails.
+ *
  */
 static inline int _mpu_buffer_validate(void *addr, size_t size, int write)
 {


### PR DESCRIPTION
- Fixing a bug in _mpu_buffer_validate for ARMv8-M MCUs with TrustZone support. The bug is assigned priority low, given that there are a couple of such boards in the tree (musca_a and nrf9160_pca10090).
- Assigning Code owner for ARMv8-M CMSE module