### PR TITLE
kconfig: move Zephyr modules Kconfig entries to the top

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -7,6 +7,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+source "$(PROJECT_BINARY_DIR)/Kconfig.modules"
+
 # Include these first so that any properties (e.g. defaults) below can be
 # overriden in *.defconfig files (by defining symbols in multiple locations).
 # After merging all the symbol definitions, Kconfig picks the first property
@@ -37,8 +39,6 @@ source "lib/Kconfig"
 source "subsys/Kconfig"
 
 source "ext/Kconfig"
-
-source "$(PROJECT_BINARY_DIR)/Kconfig.modules"
 
 menu "Build and Link Features"
 


### PR DESCRIPTION
Zephyr modules' Kconfig entries appear in a seemingly random spot
in menuconfig. This patch moves those entries at the top of the menu,
to improve their visibility and make their location predictable.

FYI: @SebastianBoe @carlescufi 