### PR TITLE
doc: net: Add SNTP API documentation

### DIFF
--- a/doc/reference/networking/apis.rst
+++ b/doc/reference/networking/apis.rst
@@ -14,4 +14,5 @@ Network APIs
    net_timeout.rst
    net_context.rst
    promiscuous.rst
+   sntp.rst
    trickle.rst

--- a/doc/reference/networking/sntp.rst
+++ b/doc/reference/networking/sntp.rst
@@ -1,0 +1,23 @@
+.. _sntp_interface:
+
+Simple Network Time Protocol Library
+####################################
+
+.. contents::
+    :local:
+    :depth: 2
+
+Overview
+********
+
+The SNTP library implements
+`IETF RFC4330 (Simple Network Time Protocol v4) <https://tools.ietf.org/html/rfc4330>`_.
+
+SNTP provides a way to synchronize clocks in computer networks.
+
+
+API Reference
+*************
+
+.. doxygengroup:: sntp
+   :project: Zephyr

--- a/include/net/sntp.h
+++ b/include/net/sntp.h
@@ -10,6 +10,13 @@
 
 #include <net/socket.h>
 
+/**
+ * @brief Simple Network Time Protocol API
+ * @defgroup sntp SNTP
+ * @ingroup networking
+ * @{
+ */
+
 /** SNTP context */
 struct sntp_ctx {
 	struct {
@@ -54,5 +61,9 @@ int sntp_request(struct sntp_ctx *ctx, u32_t timeout, u64_t *epoch_time);
  * @param ctx Address of sntp context.
  */
 void sntp_close(struct sntp_ctx *ctx);
+
+/**
+ * @}
+ */
 
 #endif


### PR DESCRIPTION
Documentation for Simple Network Time Protocol library was
missing.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>