### PR TITLE
boards: arm: Fix setting of xtools

### DIFF
--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.yaml
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.yaml
@@ -7,11 +7,11 @@ flash: 1024
 toolchain:
   - zephyr
   - gccarmemb
+  - xtools
 supported:
   - i2c
   - gpio
 testing:
   ignore_tags:
-  - xtools
     - net
     - bluetooth

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114_m0.yaml
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114_m0.yaml
@@ -12,8 +12,8 @@ ram: 32
 flash: 64
 testing:
   ignore_tags:
-  - xtools
     - net
 toolchain:
+  - xtools
   - zephyr
   - gnuarmemb


### PR DESCRIPTION
efm32pg_stk3402a and lpcxpresso54114_m0 board yaml files didn't set
xtools under the toolchain category, fix that.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>