### PR TITLE
net: socket: Split select-related declaration to separate header

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -25,27 +25,18 @@
 #include <zephyr/types.h>
 #include <net/net_ip.h>
 #include <net/dns_resolve.h>
+#include <net/socket_select.h>
 #include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-struct zsock_timeval {
-	/* Using longs, as many (?) implementations seem to use it. */
-	long tv_sec;
-	long tv_usec;
-};
-
 struct zsock_pollfd {
 	int fd;
 	short events;
 	short revents;
 };
-
-typedef struct zsock_fd_set {
-	u32_t bitset[(CONFIG_POSIX_MAX_FDS + 31) / 32];
-} zsock_fd_set;
 
 /* Values are compatible with Linux */
 #define ZSOCK_POLLIN 1
@@ -174,19 +165,6 @@ __syscall int zsock_fcntl(int sock, int cmd, int flags);
 
 __syscall int zsock_poll(struct zsock_pollfd *fds, int nfds, int timeout);
 
-/* select() API is inefficient, and implemented as inefficient wrapper on
- * top of poll(). Avoid select(), use poll directly().
- */
-int zsock_select(int nfds, zsock_fd_set *readfds, zsock_fd_set *writefds,
-		 zsock_fd_set *exceptfds, struct zsock_timeval *timeout);
-
-#define ZSOCK_FD_SETSIZE (sizeof(((zsock_fd_set *)0)->bitset) * 8)
-
-void ZSOCK_FD_ZERO(zsock_fd_set *set);
-int ZSOCK_FD_ISSET(int fd, zsock_fd_set *set);
-void ZSOCK_FD_CLR(int fd, zsock_fd_set *set);
-void ZSOCK_FD_SET(int fd, zsock_fd_set *set);
-
 int zsock_getsockopt(int sock, int level, int optname,
 		     void *optval, socklen_t *optlen);
 
@@ -230,9 +208,6 @@ int zsock_getnameinfo(const struct sockaddr *addr, socklen_t addrlen,
 #if defined(CONFIG_NET_SOCKETS_POSIX_NAMES)
 
 #define pollfd zsock_pollfd
-#define fd_set zsock_fd_set
-#define timeval zsock_timeval
-#define FD_SETSIZE ZSOCK_FD_SETSIZE
 
 #if !defined(CONFIG_NET_SOCKETS_OFFLOAD)
 static inline int socket(int family, int type, int proto)
@@ -300,33 +275,6 @@ static inline ssize_t recvfrom(int sock, void *buf, size_t max_len, int flags,
 static inline int poll(struct zsock_pollfd *fds, int nfds, int timeout)
 {
 	return zsock_poll(fds, nfds, timeout);
-}
-
-static inline int select(int nfds, zsock_fd_set *readfds,
-			 zsock_fd_set *writefds, zsock_fd_set *exceptfds,
-			 struct timeval *timeout)
-{
-	return zsock_select(nfds, readfds, writefds, exceptfds, timeout);
-}
-
-static inline void FD_ZERO(zsock_fd_set *set)
-{
-	ZSOCK_FD_ZERO(set);
-}
-
-static inline int FD_ISSET(int fd, zsock_fd_set *set)
-{
-	return ZSOCK_FD_ISSET(fd, set);
-}
-
-static inline void FD_CLR(int fd, zsock_fd_set *set)
-{
-	ZSOCK_FD_CLR(fd, set);
-}
-
-static inline void FD_SET(int fd, zsock_fd_set *set)
-{
-	ZSOCK_FD_SET(fd, set);
 }
 
 static inline int getsockopt(int sock, int level, int optname,

--- a/include/net/socket_select.h
+++ b/include/net/socket_select.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_NET_SOCKET_SELECT_H_
+#define ZEPHYR_INCLUDE_NET_SOCKET_SELECT_H_
+
+#include <zephyr/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct zsock_timeval {
+	/* Using longs, as many (?) implementations seem to use it. */
+	long tv_sec;
+	long tv_usec;
+};
+
+typedef struct zsock_fd_set {
+	u32_t bitset[(CONFIG_POSIX_MAX_FDS + 31) / 32];
+} zsock_fd_set;
+
+/* select() API is inefficient, and implemented as inefficient wrapper on
+ * top of poll(). Avoid select(), use poll directly().
+ */
+int zsock_select(int nfds, zsock_fd_set *readfds, zsock_fd_set *writefds,
+		 zsock_fd_set *exceptfds, struct zsock_timeval *timeout);
+
+#define ZSOCK_FD_SETSIZE (sizeof(((zsock_fd_set *)0)->bitset) * 8)
+
+void ZSOCK_FD_ZERO(zsock_fd_set *set);
+int ZSOCK_FD_ISSET(int fd, zsock_fd_set *set);
+void ZSOCK_FD_CLR(int fd, zsock_fd_set *set);
+void ZSOCK_FD_SET(int fd, zsock_fd_set *set);
+
+#ifdef CONFIG_NET_SOCKETS_POSIX_NAMES
+
+#define fd_set zsock_fd_set
+#define timeval zsock_timeval
+#define FD_SETSIZE ZSOCK_FD_SETSIZE
+
+static inline int select(int nfds, zsock_fd_set *readfds,
+			 zsock_fd_set *writefds, zsock_fd_set *exceptfds,
+			 struct timeval *timeout)
+{
+	return zsock_select(nfds, readfds, writefds, exceptfds, timeout);
+}
+
+static inline void FD_ZERO(zsock_fd_set *set)
+{
+	ZSOCK_FD_ZERO(set);
+}
+
+static inline int FD_ISSET(int fd, zsock_fd_set *set)
+{
+	return ZSOCK_FD_ISSET(fd, set);
+}
+
+static inline void FD_CLR(int fd, zsock_fd_set *set)
+{
+	ZSOCK_FD_CLR(fd, set);
+}
+
+static inline void FD_SET(int fd, zsock_fd_set *set)
+{
+	ZSOCK_FD_SET(fd, set);
+}
+
+#endif /* CONFIG_NET_SOCKETS_POSIX_NAMES */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_NET_SOCKET_SELECT_H_ */


### PR DESCRIPTION
select() is a rather peculiar construct, defining/depending on many
types and symbols. Making that to coexist with POSIX subsystem is
an ongoing challange. To facilitate that, let's split those
definitions to a separate header (which e.g. can be included without
including all the rest of socket defines).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>