### PR TITLE
net: sockets: Implement gai_strerror()

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -195,6 +195,8 @@ static inline void zsock_freeaddrinfo(struct zsock_addrinfo *ai)
 	free(ai);
 }
 
+const char *zsock_gai_strerror(int errcode);
+
 #define NI_NUMERICHOST 1
 #define NI_NUMERICSERV 2
 #define NI_NOFQDN 4
@@ -299,6 +301,11 @@ static inline int getaddrinfo(const char *host, const char *service,
 static inline void freeaddrinfo(struct zsock_addrinfo *ai)
 {
 	zsock_freeaddrinfo(ai);
+}
+
+static inline const char *gai_strerror(int errcode)
+{
+	return zsock_gai_strerror(errcode);
 }
 
 static inline int getnameinfo(const struct sockaddr *addr, socklen_t addrlen,

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -222,4 +222,23 @@ int zsock_getaddrinfo(const char *host, const char *service,
 	return ret;
 }
 
+#define ERR(e) case DNS_ ## e: return #e
+const char *zsock_gai_strerror(int errcode)
+{
+	switch (errcode) {
+	ERR(EAI_BADFLAGS);
+	ERR(EAI_NONAME);
+	ERR(EAI_AGAIN);
+	ERR(EAI_FAIL);
+	ERR(EAI_NODATA);
+	ERR(EAI_MEMORY);
+	ERR(EAI_SYSTEM);
+	ERR(EAI_SERVICE);
+
+	default:
+		return "EAI_UNKNOWN";
+	}
+}
+#undef ERR
+
 #endif


### PR DESCRIPTION
To save binary size, currently just returns textual name of error
code, e.g. EAI_FAIL -> "EAI_FAIL". Based on real usecases, can be
replaced with user-friendly message later. (Current usecase is to
allow/help to elaborate sockets API by proof-of-concept porting
existing socket apps).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>