### PR TITLE
scripts: requirements.txt: freeze pyyaml at 3.13

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -5,7 +5,7 @@ docutils==0.14
 sphinx_rtd_theme
 sphinxcontrib-svg2pdfconverter
 junit2html
-PyYAML>=3.12
+PyYAML==3.13
 ply==3.10
 hub==2.0
 gitlint


### PR DESCRIPTION
PyYAML 5.1 was just released, which doesn't support !include as
previous versions do. This breaks our DTS bindings parsing. Freeze
the PyYAML version in requirements.txt to a known good version to
prevent new installs from breaking.

Reported-by: Andy Doan <andy@foundries.io>
Reported-by: Michael Scott <mike@foundries.io>
Signed-off-by: Marti Bolivar <marti@foundries.io>