### PR TITLE
Rename reserved function names

### DIFF
--- a/arch/arc/core/fault.c
+++ b/arch/arc/core/fault.c
@@ -151,9 +151,9 @@ void _Fault(NANO_ESF *esf)
 	}
 #endif
 
-	vector = _ARC_V2_ECR_VECTOR(ecr);
-	code =  _ARC_V2_ECR_CODE(ecr);
-	parameter = _ARC_V2_ECR_PARAMETER(ecr);
+	vector = Z_ARC_V2_ECR_VECTOR(ecr);
+	code =  Z_ARC_V2_ECR_CODE(ecr);
+	parameter = Z_ARC_V2_ECR_PARAMETER(ecr);
 
 
 	/* exception raised by kernel */

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -19,7 +19,7 @@
 #include <syscall.h>
 
 GTEXT(_Fault)
-GTEXT(_do_kernel_oops)
+GTEXT(z_do_kernel_oops)
 GTEXT(__reset)
 GTEXT(__memory_error)
 GTEXT(__instruction_error)
@@ -35,7 +35,7 @@ GTEXT(__ev_div_zero)
 GTEXT(__ev_dc_error)
 GTEXT(__ev_maligned)
 #ifdef CONFIG_IRQ_OFFLOAD
-GTEXT(_irq_do_offload);
+GTEXT(z_irq_do_offload);
 #endif
 
 GDATA(exc_nest_count)
@@ -215,7 +215,7 @@ _do_non_syscall_trap:
 exc_nest_handle:
 	push_s r0
 
-	jl _irq_do_offload
+	jl z_irq_do_offload
 
 	pop sp
 

--- a/arch/arc/core/irq_manage.c
+++ b/arch/arc/core/irq_manage.c
@@ -40,7 +40,7 @@ void z_arch_irq_enable(unsigned int irq)
 {
 	unsigned int key = irq_lock();
 
-	_arc_v2_irq_unit_int_enable(irq);
+	z_arc_v2_irq_unit_int_enable(irq);
 	irq_unlock(key);
 }
 
@@ -57,7 +57,7 @@ void z_arch_irq_disable(unsigned int irq)
 {
 	unsigned int key = irq_lock();
 
-	_arc_v2_irq_unit_int_disable(irq);
+	z_arc_v2_irq_unit_int_disable(irq);
 	irq_unlock(key);
 }
 
@@ -83,7 +83,7 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags)
 
 	__ASSERT(prio < CONFIG_NUM_IRQ_PRIO_LEVELS,
 		 "invalid priority %d for irq %d", prio, irq);
-	_arc_v2_irq_unit_prio_set(irq, prio);
+	z_arc_v2_irq_unit_prio_set(irq, prio);
 	irq_unlock(key);
 }
 

--- a/arch/arc/core/irq_offload.c
+++ b/arch/arc/core/irq_offload.c
@@ -15,7 +15,7 @@ static irq_offload_routine_t offload_routine;
 static void *offload_param;
 
 /* Called by trap_s exception handler */
-void _irq_do_offload(void)
+void z_irq_do_offload(void)
 {
 	offload_routine(offload_param);
 }

--- a/arch/arc/core/mpu/arc_mpu.c
+++ b/arch/arc/core/mpu/arc_mpu.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(mpu);
  * @brief Get the number of supported MPU regions
  *
  */
-static inline u8_t _get_num_regions(void)
+static inline u8_t get_num_regions(void)
 {
 	u32_t num = z_arc_v2_aux_reg_read(_ARC_V2_MPU_BUILD);
 
@@ -34,7 +34,7 @@ static inline u8_t _get_num_regions(void)
  * This internal function is utilized by the MPU driver to parse the intent
  * type (i.e. THREAD_STACK_REGION) and return the correct parameter set.
  */
-static inline u32_t _get_region_attr_by_type(u32_t type)
+static inline u32_t get_region_attr_by_type(u32_t type)
 {
 	switch (type) {
 	case THREAD_STACK_USER_REGION:
@@ -51,7 +51,6 @@ static inline u32_t _get_region_attr_by_type(u32_t type)
 		return 0;
 	}
 }
-
 
 #if CONFIG_ARC_MPU_VER == 2
 #include "arc_mpu_v2_internal.h"

--- a/arch/arc/core/mpu/arc_mpu_v2_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v2_internal.h
@@ -57,7 +57,7 @@ static inline void _region_init(u32_t index, u32_t region_addr, u32_t size,
  * This internal function is utilized by the MPU driver to parse the intent
  * type (i.e. THREAD_STACK_REGION) and return the correct region index.
  */
-static inline int _get_region_index_by_type(u32_t type)
+static inline int get_region_index_by_type(u32_t type)
 {
 	/*
 	 * The new MPU regions are allocated per type after the statically
@@ -71,21 +71,21 @@ static inline int _get_region_index_by_type(u32_t type)
 	 */
 	switch (type) {
 	case THREAD_STACK_USER_REGION:
-		return _get_num_regions() - mpu_config.num_regions
+		return get_num_regions() - mpu_config.num_regions
 		       - THREAD_STACK_REGION;
 	case THREAD_STACK_REGION:
 	case THREAD_APP_DATA_REGION:
 	case THREAD_STACK_GUARD_REGION:
-		return _get_num_regions() - mpu_config.num_regions - type;
+		return get_num_regions() - mpu_config.num_regions - type;
 	case THREAD_DOMAIN_PARTITION_REGION:
 #if defined(CONFIG_MPU_STACK_GUARD)
-		return _get_num_regions() - mpu_config.num_regions - type;
+		return get_num_regions() - mpu_config.num_regions - type;
 #else
 		/*
 		 * Start domain partition region from stack guard region
 		 * since stack guard is not enabled.
 		 */
-		return _get_num_regions() - mpu_config.num_regions - type + 1;
+		return get_num_regions() - mpu_config.num_regions - type + 1;
 #endif
 	default:
 		__ASSERT(0, "Unsupported type");
@@ -154,8 +154,8 @@ static inline bool _is_user_accessible_region(u32_t r_index, int write)
  */
 static inline int _mpu_configure(u8_t type, u32_t base, u32_t size)
 {
-	s32_t region_index =  _get_region_index_by_type(type);
-	u32_t region_attr = _get_region_attr_by_type(type);
+	s32_t region_index =  get_region_index_by_type(type);
+	u32_t region_attr = get_region_attr_by_type(type);
 
 	LOG_DBG("Region info: 0x%x 0x%x", base, size);
 
@@ -283,7 +283,7 @@ void arc_core_mpu_default(u32_t region_attr)
 int arc_core_mpu_region(u32_t index, u32_t base, u32_t size,
 			 u32_t region_attr)
 {
-	if (index >= _get_num_regions()) {
+	if (index >= get_num_regions()) {
 		return -EINVAL;
 	}
 
@@ -304,7 +304,7 @@ int arc_core_mpu_region(u32_t index, u32_t base, u32_t size,
 void arc_core_mpu_configure_mem_domain(struct k_thread *thread)
 {
 	int region_index =
-		_get_region_index_by_type(THREAD_DOMAIN_PARTITION_REGION);
+		get_region_index_by_type(THREAD_DOMAIN_PARTITION_REGION);
 	u32_t num_partitions;
 	struct k_mem_partition *pparts;
 	struct k_mem_domain *mem_domain = NULL;
@@ -348,7 +348,7 @@ void arc_core_mpu_remove_mem_domain(struct k_mem_domain *mem_domain)
 	ARG_UNUSED(mem_domain);
 
 	int region_index =
-		_get_region_index_by_type(THREAD_DOMAIN_PARTITION_REGION);
+		get_region_index_by_type(THREAD_DOMAIN_PARTITION_REGION);
 
 	for (; region_index >= 0; region_index--) {
 		_region_init(region_index, 0, 0, 0);
@@ -367,7 +367,7 @@ void arc_core_mpu_remove_mem_partition(struct k_mem_domain *domain,
 	ARG_UNUSED(domain);
 
 	int region_index =
-		_get_region_index_by_type(THREAD_DOMAIN_PARTITION_REGION);
+		get_region_index_by_type(THREAD_DOMAIN_PARTITION_REGION);
 
 	LOG_DBG("disable region 0x%x", region_index + part_id);
 	/* Disable region */
@@ -379,7 +379,7 @@ void arc_core_mpu_remove_mem_partition(struct k_mem_domain *domain,
  */
 int arc_core_mpu_get_max_domain_partition_regions(void)
 {
-	return _get_region_index_by_type(THREAD_DOMAIN_PARTITION_REGION) + 1;
+	return get_region_index_by_type(THREAD_DOMAIN_PARTITION_REGION) + 1;
 }
 
 /**
@@ -395,7 +395,7 @@ int arc_core_mpu_buffer_validate(void *addr, size_t size, int write)
 	 * matched region that grants permission or denies access.
 	 *
 	 */
-	for (r_index = 0; r_index < _get_num_regions(); r_index++) {
+	for (r_index = 0; r_index < get_num_regions(); r_index++) {
 		if (!_is_enabled_region(r_index) ||
 		    !_is_in_region(r_index, (u32_t)addr, size)) {
 			continue;
@@ -426,7 +426,7 @@ static int arc_mpu_init(struct device *arg)
 	u32_t num_regions;
 	u32_t i;
 
-	num_regions = _get_num_regions();
+	num_regions = get_num_regions();
 
 	/* ARC MPU supports up to 16 Regions */
 	if (mpu_config.num_regions > num_regions) {

--- a/arch/arc/core/mpu/arc_mpu_v3_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v3_internal.h
@@ -148,7 +148,7 @@ static inline int _mpu_probe(u32_t addr)
  */
 static inline int _dynamic_region_allocate_index(void)
 {
-	if (dynamic_region_index >= _get_num_regions()) {
+	if (dynamic_region_index >= get_num_regions()) {
 		LOG_ERR("no enough mpu entries %d", dynamic_region_index);
 		return -EINVAL;
 	}
@@ -314,7 +314,7 @@ static int _dynamic_region_allocate_and_init(u32_t base, u32_t size,
 static void _mpu_reset_dynamic_regions(void)
 {
 	u32_t i;
-	u32_t num_regions = _get_num_regions();
+	u32_t num_regions = get_num_regions();
 
 	for (i = static_regions_num; i < num_regions; i++) {
 		_region_init(i, 0, 0, 0);
@@ -341,7 +341,7 @@ static void _mpu_reset_dynamic_regions(void)
  */
 static inline int _mpu_configure(u8_t type, u32_t base, u32_t size)
 {
-	u32_t region_attr = _get_region_attr_by_type(type);
+	u32_t region_attr = get_region_attr_by_type(type);
 
 	return _dynamic_region_allocate_and_init(base, size, region_attr);
 }
@@ -493,7 +493,7 @@ void arc_core_mpu_default(u32_t region_attr)
 int arc_core_mpu_region(u32_t index, u32_t base, u32_t size,
 			 u32_t region_attr)
 {
-	if (index >= _get_num_regions()) {
+	if (index >= get_num_regions()) {
 		return -EINVAL;
 	}
 
@@ -576,7 +576,7 @@ void arc_core_mpu_remove_mem_partition(struct k_mem_domain *domain,
 int arc_core_mpu_get_max_domain_partition_regions(void)
 {
 	/* consider the worst case: each partition requires split */
-	return (_get_num_regions() - MPU_REGION_NUM_FOR_THREAD) / 2;
+	return (get_num_regions() - MPU_REGION_NUM_FOR_THREAD) / 2;
 }
 
 /**
@@ -619,7 +619,7 @@ static int arc_mpu_init(struct device *arg)
 	u32_t num_regions;
 	u32_t i;
 
-	num_regions = _get_num_regions();
+	num_regions = get_num_regions();
 
 	/* ARC MPU supports up to 16 Regions */
 	if (mpu_config.num_regions > num_regions) {

--- a/arch/arc/core/prep_c.c
+++ b/arch/arc/core/prep_c.c
@@ -117,7 +117,7 @@ extern FUNC_NORETURN void z_cstart(void);
 
 void _PrepC(void)
 {
-	_icache_setup();
+	z_icache_setup();
 	adjust_vector_table_base();
 	z_bss_zero();
 	z_data_copy();

--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -141,8 +141,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #endif
 	}
 
-	_new_thread_init(thread, pStackMem, stackAdjSize, priority, options);
-
+	z_new_thread_init(thread, pStackMem, stackAdjSize, priority, options);
 
 	/* carve the thread entry struct from the "base" of
 		the privileged stack */
@@ -152,9 +151,9 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	/* fill init context */
 	pInitCtx->status32 = 0U;
 	if (options & K_USER) {
-		pInitCtx->pc = ((u32_t)_user_thread_entry_wrapper);
+		pInitCtx->pc = ((u32_t)z_user_thread_entry_wrapper);
 	} else {
-		pInitCtx->pc = ((u32_t)_thread_entry_wrapper);
+		pInitCtx->pc = ((u32_t)z_thread_entry_wrapper);
 	}
 
 	/*
@@ -168,7 +167,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #else /* For no USERSPACE feature */
 	stackEnd = pStackMem + stackSize;
 
-	_new_thread_init(thread, pStackMem, stackSize, priority, options);
+	z_new_thread_init(thread, pStackMem, stackSize, priority, options);
 
 	stackAdjEnd = stackEnd;
 
@@ -177,7 +176,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 		sizeof(struct init_stack_frame));
 
 	pInitCtx->status32 = 0U;
-	pInitCtx->pc = ((u32_t)_thread_entry_wrapper);
+	pInitCtx->pc = ((u32_t)z_thread_entry_wrapper);
 #endif
 
 #ifdef CONFIG_ARC_HAS_SECURE
@@ -270,7 +269,7 @@ FUNC_NORETURN void z_arch_user_mode_enter(k_thread_entry_t user_entry,
 	/* need to lock cpu here ? */
 	configure_mpu_thread(_current);
 
-	_arc_userspace_enter(user_entry, p1, p2, p3,
+	z_arc_userspace_enter(user_entry, p1, p2, p3,
 			     (u32_t)_current->stack_obj,
 			     _current->stack_info.size);
 	CODE_UNREACHABLE;

--- a/arch/arc/core/thread_entry_wrapper.S
+++ b/arch/arc/core/thread_entry_wrapper.S
@@ -14,7 +14,7 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 
-GTEXT(_thread_entry_wrapper)
+GTEXT(z_thread_entry_wrapper)
 
 /*
  * @brief Wrapper for z_thread_entry
@@ -25,7 +25,7 @@ GTEXT(_thread_entry_wrapper)
  * @return N/A
  */
 
-SECTION_FUNC(TEXT, _thread_entry_wrapper)
+SECTION_FUNC(TEXT, z_thread_entry_wrapper)
 
 	pop_s r3
 	pop_s r2

--- a/arch/arc/core/userspace.S
+++ b/arch/arc/core/userspace.S
@@ -44,9 +44,9 @@
 	mov r13, 0
 .endm
 
-GTEXT(_arc_userspace_enter)
+GTEXT(z_arc_userspace_enter)
 GTEXT(_arc_do_syscall)
-GTEXT(_user_thread_entry_wrapper)
+GTEXT(z_user_thread_entry_wrapper)
 GTEXT(z_arch_user_string_nlen)
 GTEXT(z_arch_user_string_nlen_fault_start)
 GTEXT(z_arch_user_string_nlen_fault_end)
@@ -57,7 +57,7 @@ GTEXT(z_arch_user_string_nlen_fixup)
  *
  * @return N/A
  */
-SECTION_FUNC(TEXT, _user_thread_entry_wrapper)
+SECTION_FUNC(TEXT, z_user_thread_entry_wrapper)
 	pop_s r3
 	pop_s r2
 	pop_s r1
@@ -74,7 +74,7 @@ SECTION_FUNC(TEXT, _user_thread_entry_wrapper)
 
 /*
  * when CONFIG_INIT_STACKS is enable, stack will be initialized
- * in _new_thread_init.
+ * in z_new_thread_init.
  */
 	j _arc_go_to_user_space
 
@@ -87,7 +87,7 @@ SECTION_FUNC(TEXT, _user_thread_entry_wrapper)
  * not transition back later, unless they are doing system calls.
  *
  */
-SECTION_FUNC(TEXT, _arc_userspace_enter)
+SECTION_FUNC(TEXT, z_arc_userspace_enter)
 	/*
 	 * In ARCv2, the U bit can only be set through exception return
 	 */
@@ -151,7 +151,7 @@ _arc_go_to_user_space:
 	lr r0, [_ARC_V2_STATUS32]
 	bset r0, r0, _ARC_V2_STATUS32_U_BIT
 
-	mov r1, _thread_entry_wrapper
+	mov r1, z_thread_entry_wrapper
 
 	/* fake exception return */
 	kflag _ARC_V2_STATUS32_AE

--- a/arch/arc/include/kernel_arch_func.h
+++ b/arch/arc/include/kernel_arch_func.h
@@ -33,7 +33,7 @@ extern "C" {
 
 static ALWAYS_INLINE void kernel_arch_init(void)
 {
-	_irq_setup();
+	z_irq_setup();
 }
 
 static ALWAYS_INLINE void
@@ -49,7 +49,7 @@ z_set_thread_return_value(struct k_thread *thread, unsigned int value)
  *
  * @return IRQ number
  */
-static ALWAYS_INLINE int _INTERRUPT_CAUSE(void)
+static ALWAYS_INLINE int Z_INTERRUPT_CAUSE(void)
 {
 	u32_t irq_num = z_arc_v2_aux_reg_read(_ARC_V2_ICAUSE);
 
@@ -58,10 +58,10 @@ static ALWAYS_INLINE int _INTERRUPT_CAUSE(void)
 
 #define z_is_in_isr	z_arc_v2_irq_unit_is_in_isr
 
-extern void _thread_entry_wrapper(void);
-extern void _user_thread_entry_wrapper(void);
+extern void z_thread_entry_wrapper(void);
+extern void z_user_thread_entry_wrapper(void);
 
-extern void _arc_userspace_enter(k_thread_entry_t user_entry, void *p1,
+extern void z_arc_userspace_enter(k_thread_entry_t user_entry, void *p1,
 		 void *p2, void *p3, u32_t stack, u32_t size);
 
 #endif /* _ASMLANGUAGE */

--- a/arch/arc/include/tracing_arch.h
+++ b/arch/arc/include/tracing_arch.h
@@ -24,9 +24,9 @@ extern "C" {
  *
  * @return The key of the interrupt that is currently being processed.
  */
-int _sys_current_irq_key_get(void)
+int z_sys_current_irq_key_get(void)
 {
-	return _INTERRUPT_CAUSE();
+	return Z_INTERRUPT_CAUSE();
 }
 
 #ifdef __cplusplus

--- a/arch/arc/include/v2/cache.h
+++ b/arch/arc/include/v2/cache.h
@@ -34,7 +34,7 @@ extern "C" {
  *
  * Enables the i-cache and sets it to direct access mode.
  */
-static ALWAYS_INLINE void _icache_setup(void)
+static ALWAYS_INLINE void z_icache_setup(void)
 {
 	u32_t icache_config = (
 		IC_CACHE_DIRECT | /* direct mapping (one-way assoc.) */

--- a/arch/arc/include/v2/irq.h
+++ b/arch/arc/include/v2/irq.h
@@ -36,11 +36,11 @@ extern "C" {
 extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
 
 /*
- * _irq_setup
+ * z_irq_setup
  *
  * Configures interrupt handling parameters
  */
-static ALWAYS_INLINE void _irq_setup(void)
+static ALWAYS_INLINE void z_irq_setup(void)
 {
 	u32_t aux_irq_ctrl_value = (
 		_ARC_V2_AUX_IRQ_CTRL_LOOP_REGS | /* save lp_xxx registers */

--- a/arch/arm/core/cortex_m/nmi.c
+++ b/arch/arm/core/cortex_m/nmi.c
@@ -20,14 +20,14 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 
-extern void _SysNmiOnReset(void);
+extern void z_SysNmiOnReset(void);
 #if !defined(CONFIG_RUNTIME_NMI)
-#define handler _SysNmiOnReset
+#define handler z_SysNmiOnReset
 #endif
 
 #ifdef CONFIG_RUNTIME_NMI
 typedef void (*_NmiHandler_t)(void);
-static _NmiHandler_t handler = _SysNmiOnReset;
+static _NmiHandler_t handler = z_SysNmiOnReset;
 
 /**
  *
@@ -39,7 +39,7 @@ static _NmiHandler_t handler = _SysNmiOnReset;
  * @return N/A
  */
 
-static void _DefaultHandler(void)
+static void DefaultHandler(void)
 {
 	printk("NMI received! Rebooting...\n");
 	/* In ARM implementation sys_reboot ignores the parameter */
@@ -59,7 +59,7 @@ static void _DefaultHandler(void)
 
 void z_NmiInit(void)
 {
-	handler = _DefaultHandler;
+	handler = DefaultHandler;
 }
 
 /**

--- a/arch/arm/core/cortex_m/nmi.c
+++ b/arch/arm/core/cortex_m/nmi.c
@@ -73,7 +73,7 @@ void z_NmiInit(void)
  * @return N/A
  */
 
-void _NmiHandlerSet(void (*pHandler)(void))
+void z_NmiHandlerSet(void (*pHandler)(void))
 {
 	handler = pHandler;
 }

--- a/arch/arm/core/cortex_m/nmi_on_reset.S
+++ b/arch/arm/core/cortex_m/nmi_on_reset.S
@@ -20,8 +20,8 @@
 
 _ASM_FILE_PROLOGUE
 
-GTEXT(_SysNmiOnReset)
+GTEXT(z_SysNmiOnReset)
 
-SECTION_FUNC(TEXT, _SysNmiOnReset)
+SECTION_FUNC(TEXT, z_SysNmiOnReset)
     wfi
-    b _SysNmiOnReset
+    b z_SysNmiOnReset

--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -161,7 +161,7 @@ extern FUNC_NORETURN void z_cstart(void);
  * @return N/A
  */
 
-extern void _IntLibInit(void);
+extern void z_IntLibInit(void);
 
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
 	extern u64_t __start_time_stamp;
@@ -183,7 +183,7 @@ void _PrepC(void)
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
 	__start_time_stamp = 0U;
 #endif
-	_IntLibInit();
+	z_IntLibInit();
 	z_cstart();
 	CODE_UNREACHABLE;
 }

--- a/arch/arm/core/cpu_idle.S
+++ b/arch/arm/core/cpu_idle.S
@@ -20,7 +20,7 @@
 
 _ASM_FILE_PROLOGUE
 
-GTEXT(_CpuIdleInit)
+GTEXT(z_CpuIdleInit)
 #ifdef CONFIG_SYS_POWER_MANAGEMENT
 GTEXT(_NanoIdleValGet)
 GTEXT(_NanoIdleValClear)
@@ -46,10 +46,10 @@ GTEXT(k_cpu_atomic_idle)
  *
  * C function prototype:
  *
- * void _CpuIdleInit (void);
+ * void z_CpuIdleInit (void);
  */
 
-SECTION_FUNC(TEXT, _CpuIdleInit)
+SECTION_FUNC(TEXT, z_CpuIdleInit)
 	ldr r1, =_SCB_SCR
 	movs.n r2, #_SCR_INIT_BITS
 	str r2, [r1]
@@ -179,14 +179,14 @@ SECTION_FUNC(TEXT, k_cpu_atomic_idle)
 	cpsid i
 
 	/*
-	 * No need to set SEVONPEND, it's set once in _CpuIdleInit() and never
+	 * No need to set SEVONPEND, it's set once in z_CpuIdleInit() and never
 	 * touched again.
 	 */
 
 	/* r0: interrupt mask from caller */
 
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-	/* No BASEPRI, call wfe directly (SEVONPEND set in _CpuIdleInit()) */
+	/* No BASEPRI, call wfe directly (SEVONPEND set in z_CpuIdleInit()) */
 	wfe
 
 	cmp r0, #0

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -92,7 +92,7 @@ void z_NanoFatalErrorHandler(unsigned int reason,
 	z_SysFatalErrorHandler(reason, pEsf);
 }
 
-void _do_kernel_oops(const NANO_ESF *esf)
+void z_do_kernel_oops(const NANO_ESF *esf)
 {
 	z_NanoFatalErrorHandler(esf->r0, esf);
 }
@@ -106,6 +106,6 @@ FUNC_NORETURN void z_arch_syscall_oops(void *ssf_ptr)
 
 	oops_esf.pc = ssf_contents[3];
 
-	_do_kernel_oops(&oops_esf);
+	z_do_kernel_oops(&oops_esf);
 	CODE_UNREACHABLE;
 }

--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -137,7 +137,7 @@
  */
 
 #if (CONFIG_FAULT_DUMP == 1)
-static void _FaultShow(const NANO_ESF *esf, int fault)
+static void FaultShow(const NANO_ESF *esf, int fault)
 {
 	PR_EXC("Fault! EXC #%d\n", fault);
 
@@ -156,7 +156,7 @@ static void _FaultShow(const NANO_ESF *esf, int fault)
  *
  * For Dump level 0, no information needs to be generated.
  */
-static void _FaultShow(const NANO_ESF *esf, int fault)
+static void FaultShow(const NANO_ESF *esf, int fault)
 {
 	(void)esf;
 	(void)fault;
@@ -176,7 +176,7 @@ static const struct z_exc_handle exceptions[] = {
  *
  * @return 1 if error is recoverable, otherwise return 0.
  */
-static int _MemoryFaultIsRecoverable(NANO_ESF *esf)
+static int MemoryFaultIsRecoverable(NANO_ESF *esf)
 {
 #ifdef CONFIG_USERSPACE
 	for (int i = 0; i < ARRAY_SIZE(exceptions); i++) {
@@ -211,7 +211,7 @@ u32_t z_check_thread_stack_fail(const u32_t fault_addr,
  *
  * @return error code to identify the fatal error reason
  */
-static u32_t _MpuFault(NANO_ESF *esf, int fromHardFault)
+static u32_t MpuFault(NANO_ESF *esf, int fromHardFault)
 {
 	u32_t reason = _NANO_ERR_HW_EXCEPTION;
 	u32_t mmfar = -EINVAL;
@@ -321,7 +321,7 @@ static u32_t _MpuFault(NANO_ESF *esf, int fromHardFault)
 	SCB->CFSR |= SCB_CFSR_MEMFAULTSR_Msk;
 
 	/* Assess whether system shall ignore/recover from this MPU fault. */
-	if (_MemoryFaultIsRecoverable(esf)) {
+	if (MemoryFaultIsRecoverable(esf)) {
 		reason = _NANO_ERR_RECOVERABLE;
 	}
 
@@ -336,7 +336,7 @@ static u32_t _MpuFault(NANO_ESF *esf, int fromHardFault)
  *
  * @return N/A
  */
-static int _BusFault(NANO_ESF *esf, int fromHardFault)
+static int BusFault(NANO_ESF *esf, int fromHardFault)
 {
 	u32_t reason = _NANO_ERR_HW_EXCEPTION;
 
@@ -477,7 +477,7 @@ static int _BusFault(NANO_ESF *esf, int fromHardFault)
 	/* clear BFSR sticky bits */
 	SCB->CFSR |= SCB_CFSR_BUSFAULTSR_Msk;
 
-	if (_MemoryFaultIsRecoverable(esf)) {
+	if (MemoryFaultIsRecoverable(esf)) {
 		reason = _NANO_ERR_RECOVERABLE;
 	}
 
@@ -492,7 +492,7 @@ static int _BusFault(NANO_ESF *esf, int fromHardFault)
  *
  * @return error code to identify the fatal error reason
  */
-static u32_t _UsageFault(const NANO_ESF *esf)
+static u32_t UsageFault(const NANO_ESF *esf)
 {
 	u32_t reason = _NANO_ERR_HW_EXCEPTION;
 
@@ -548,7 +548,7 @@ static u32_t _UsageFault(const NANO_ESF *esf)
  *
  * @return N/A
  */
-static void _SecureFault(const NANO_ESF *esf)
+static void SecureFault(const NANO_ESF *esf)
 {
 	PR_FAULT_INFO("***** SECURE FAULT *****\n");
 
@@ -587,7 +587,7 @@ static void _SecureFault(const NANO_ESF *esf)
  *
  * @return N/A
  */
-static void _DebugMonitor(const NANO_ESF *esf)
+static void DebugMonitor(const NANO_ESF *esf)
 {
 	ARG_UNUSED(esf);
 
@@ -607,14 +607,14 @@ static void _DebugMonitor(const NANO_ESF *esf)
  *
  * @return error code to identify the fatal error reason
  */
-static u32_t _HardFault(NANO_ESF *esf)
+static u32_t HardFault(NANO_ESF *esf)
 {
 	u32_t reason = _NANO_ERR_HW_EXCEPTION;
 
 	PR_FAULT_INFO("***** HARD FAULT *****\n");
 
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-	if (_MemoryFaultIsRecoverable(esf) != 0) {
+	if (MemoryFaultIsRecoverable(esf) != 0) {
 		reason = _NANO_ERR_RECOVERABLE;
 	}
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
@@ -623,14 +623,14 @@ static u32_t _HardFault(NANO_ESF *esf)
 	} else if ((SCB->HFSR & SCB_HFSR_FORCED_Msk) != 0) {
 		PR_EXC("  Fault escalation (see below)\n");
 		if (SCB_MMFSR != 0) {
-			reason = _MpuFault(esf, 1);
+			reason = MpuFault(esf, 1);
 		} else if (SCB_BFSR != 0) {
-			reason = _BusFault(esf, 1);
+			reason = BusFault(esf, 1);
 		} else if (SCB_UFSR != 0) {
-			reason = _UsageFault(esf);
+			reason = UsageFault(esf);
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
 		} else if (SAU->SFSR != 0) {
-			_SecureFault(esf);
+			SecureFault(esf);
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 		}
 	}
@@ -649,7 +649,7 @@ static u32_t _HardFault(NANO_ESF *esf)
  *
  * @return N/A
  */
-static void _ReservedException(const NANO_ESF *esf, int fault)
+static void ReservedException(const NANO_ESF *esf, int fault)
 {
 	ARG_UNUSED(esf);
 
@@ -659,45 +659,45 @@ static void _ReservedException(const NANO_ESF *esf, int fault)
 }
 
 /* Handler function for ARM fault conditions. */
-static u32_t _FaultHandle(NANO_ESF *esf, int fault)
+static u32_t FaultHandle(NANO_ESF *esf, int fault)
 {
 	u32_t reason = _NANO_ERR_HW_EXCEPTION;
 
 	switch (fault) {
 	case 3:
-		reason = _HardFault(esf);
+		reason = HardFault(esf);
 		break;
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 	/* HardFault is used for all fault conditions on ARMv6-M. */
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	case 4:
-		reason = _MpuFault(esf, 0);
+		reason = MpuFault(esf, 0);
 		break;
 	case 5:
-		reason = _BusFault(esf, 0);
+		reason = BusFault(esf, 0);
 		break;
 	case 6:
-		reason = _UsageFault(esf);
+		reason = UsageFault(esf);
 		break;
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
 	case 7:
-		_SecureFault(esf);
+		SecureFault(esf);
 		break;
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 	case 12:
-		_DebugMonitor(esf);
+		DebugMonitor(esf);
 		break;
 #else
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 	default:
-		_ReservedException(esf, fault);
+		ReservedException(esf, fault);
 		break;
 	}
 
 	if (reason != _NANO_ERR_RECOVERABLE) {
 		/* Dump generic information about the fault. */
-		_FaultShow(esf, fault);
+		FaultShow(esf, fault);
 	}
 
 	return reason;
@@ -711,7 +711,7 @@ static u32_t _FaultHandle(NANO_ESF *esf, int fault)
  *
  * @param secure_esf Pointer to the secure stack frame.
  */
-static void _SecureStackDump(const NANO_ESF *secure_esf)
+static void SecureStackDump(const NANO_ESF *secure_esf)
 {
 	/*
 	 * In case a Non-Secure exception interrupted the Secure
@@ -747,7 +747,7 @@ static void _SecureStackDump(const NANO_ESF *secure_esf)
 	PR_FAULT_INFO("  S instruction address:  0x%x\n", sec_ret_addr);
 
 }
-#define SECURE_STACK_DUMP(esf) _SecureStackDump(esf)
+#define SECURE_STACK_DUMP(esf) SecureStackDump(esf)
 #else
 /* We do not dump the Secure stack information for lower dump levels. */
 #define SECURE_STACK_DUMP(esf)
@@ -859,7 +859,7 @@ void _Fault(NANO_ESF *esf, u32_t exc_return)
 	(void) exc_return;
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 
-	reason = _FaultHandle(esf, fault);
+	reason = FaultHandle(esf, fault);
 
 	if (reason == _NANO_ERR_RECOVERABLE) {
 		return;
@@ -880,7 +880,7 @@ _exit_fatal:
  *
  * @return N/A
  */
-void _FaultInit(void)
+void z_FaultInit(void)
 {
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)

--- a/arch/arm/core/irq_init.c
+++ b/arch/arm/core/irq_init.c
@@ -33,7 +33,7 @@
  * @return N/A
  */
 
-void _IntLibInit(void)
+void z_IntLibInit(void)
 {
 	int irq = 0;
 

--- a/arch/arm/core/irq_offload.c
+++ b/arch/arm/core/irq_offload.c
@@ -15,7 +15,7 @@ volatile irq_offload_routine_t offload_routine;
 static void *offload_param;
 
 /* Called by __svc */
-void _irq_do_offload(void)
+void z_irq_do_offload(void)
 {
 	offload_routine(offload_param);
 }

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -22,8 +22,8 @@ _ASM_FILE_PROLOGUE
 
 GTEXT(__svc)
 GTEXT(__pendsv)
-GTEXT(_do_kernel_oops)
-GTEXT(_arm_do_syscall)
+GTEXT(z_do_kernel_oops)
+GTEXT(z_arm_do_syscall)
 GDATA(_k_neg_eagain)
 
 GDATA(_kernel)
@@ -303,7 +303,7 @@ _stack_frame_endif:
 
 #if CONFIG_IRQ_OFFLOAD
     push {r0, lr}
-    bl _irq_do_offload  /* call C routine which executes the offload */
+    bl z_irq_do_offload  /* call C routine which executes the offload */
     pop {r0, r1}
     mov lr, r1
 #endif /* CONFIG_IRQ_OFFLOAD */
@@ -313,7 +313,7 @@ _stack_frame_endif:
 
 _oops:
     push {r0, lr}
-    bl _do_kernel_oops
+    bl z_do_kernel_oops
     pop {r0, pc}
 
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
@@ -369,7 +369,7 @@ SECTION_FUNC(TEXT, __svc)
 
 #if CONFIG_IRQ_OFFLOAD
     push {r0, lr}
-    bl _irq_do_offload  /* call C routine which executes the offload */
+    bl z_irq_do_offload  /* call C routine which executes the offload */
     pop {r0, lr}
 
     /* exception return is done in _IntExit() */
@@ -378,7 +378,7 @@ SECTION_FUNC(TEXT, __svc)
 
 _oops:
     push {r0, lr}
-    bl _do_kernel_oops
+    bl z_do_kernel_oops
     pop {r0, pc}
 
 #if CONFIG_USERSPACE
@@ -405,8 +405,8 @@ _oops:
      */
 _do_syscall:
     ldr r8, [r0, #24]   /* grab address of PC from stack frame */
-    ldr r1, =_arm_do_syscall
-    str r1, [r0, #24]   /* overwrite the PC to point to _arm_do_syscall */
+    ldr r1, =z_arm_do_syscall
+    str r1, [r0, #24]   /* overwrite the PC to point to z_arm_do_syscall */
 
     /* validate syscall limit, only set priv mode if valid */
     ldr ip, =K_SYSCALL_LIMIT
@@ -437,7 +437,7 @@ valid_syscall_id:
     isb
     pop {r0, r1}
 
-    /* return from SVC to the modified LR - _arm_do_syscall */
+    /* return from SVC to the modified LR - z_arm_do_syscall */
     bx lr
 #endif
 

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -17,7 +17,7 @@
 #include <wait_q.h>
 
 #ifdef CONFIG_USERSPACE
-extern u8_t *_k_priv_stack_find(void *obj);
+extern u8_t *z_priv_stack_find(void *obj);
 #endif
 
 /**
@@ -97,7 +97,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 
 	struct __esf *pInitCtx;
 
-	_new_thread_init(thread, pStackMem, stackSize, priority,
+	z_new_thread_init(thread, pStackMem, stackSize, priority,
 			 options);
 
 	/* carve the thread entry struct from the "base" of the stack */
@@ -151,9 +151,9 @@ FUNC_NORETURN void z_arch_user_mode_enter(k_thread_entry_t user_entry,
 
 	/* Set up privileged stack before entering user mode */
 	_current->arch.priv_stack_start =
-		(u32_t)_k_priv_stack_find(_current->stack_obj);
+		(u32_t)z_priv_stack_find(_current->stack_obj);
 
-	_arm_userspace_enter(user_entry, p1, p2, p3,
+	z_arm_userspace_enter(user_entry, p1, p2, p3,
 			     (u32_t)_current->stack_info.start,
 			     _current->stack_info.size);
 	CODE_UNREACHABLE;

--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -16,8 +16,8 @@
 
 _ASM_FILE_PROLOGUE
 
-GTEXT(_arm_userspace_enter)
-GTEXT(_arm_do_syscall)
+GTEXT(z_arm_userspace_enter)
+GTEXT(z_arm_do_syscall)
 GTEXT(z_arch_user_string_nlen)
 GTEXT(z_arch_user_string_nlen_fault_start)
 GTEXT(z_arch_user_string_nlen_fault_end)
@@ -36,7 +36,7 @@ GDATA(_k_syscall_table)
  * not transition back later, unless they are doing system calls.
  *
  */
-SECTION_FUNC(TEXT,_arm_userspace_enter)
+SECTION_FUNC(TEXT,z_arm_userspace_enter)
     /* move user_entry to lr */
     mov lr, r0
 
@@ -77,7 +77,7 @@ SECTION_FUNC(TEXT,_arm_userspace_enter)
      *
      * Note that the risk for overflow is higher if using the normal thread
      * stack, since we do not control how much stack is actually left, when
-     * user invokes _arm_userspace_enter().
+     * user invokes z_arm_userspace_enter().
      */
     push {r0,r1,r2,r3,ip,lr}
     ldr r0, =_kernel
@@ -177,7 +177,7 @@ SECTION_FUNC(TEXT,_arm_userspace_enter)
  * 4) Restoring stack and calling back to the caller of the SVC
  *
  */
-SECTION_FUNC(TEXT, _arm_do_syscall)
+SECTION_FUNC(TEXT, z_arm_do_syscall)
     /*
      * r0-r5 contain arguments
      * r6 contains call_id

--- a/arch/arm/include/cortex_m/exc.h
+++ b/arch/arm/include/cortex_m/exc.h
@@ -144,7 +144,7 @@ static ALWAYS_INLINE void z_ExcSetup(void)
  *
  * @return N/A
  */
-static ALWAYS_INLINE void _ClearFaults(void)
+static ALWAYS_INLINE void z_clearfaults(void)
 {
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)

--- a/arch/arm/include/cortex_m/exc.h
+++ b/arch/arm/include/cortex_m/exc.h
@@ -49,7 +49,7 @@ extern volatile irq_offload_routine_t offload_routine;
  *
  * @return 1 if in ISR, 0 if not.
  */
-static ALWAYS_INLINE bool _IsInIsr(void)
+static ALWAYS_INLINE bool z_IsInIsr(void)
 {
 	u32_t vector = __get_IPSR();
 
@@ -93,7 +93,7 @@ static ALWAYS_INLINE bool _IsInIsr(void)
  *
  * @return N/A
  */
-static ALWAYS_INLINE void _ExcSetup(void)
+static ALWAYS_INLINE void z_ExcSetup(void)
 {
 	NVIC_SetPriority(PendSV_IRQn, 0xff);
 

--- a/arch/arm/include/cortex_m/stack.h
+++ b/arch/arm/include/cortex_m/stack.h
@@ -37,7 +37,7 @@ extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
  *
  * @return N/A
  */
-static ALWAYS_INLINE void _InterruptStackSetup(void)
+static ALWAYS_INLINE void z_InterruptStackSetup(void)
 {
 #if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT) && \
 	defined(CONFIG_USERSPACE)

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -27,8 +27,8 @@ extern "C" {
 #endif
 
 #ifndef _ASMLANGUAGE
-extern void _FaultInit(void);
-extern void _CpuIdleInit(void);
+extern void z_FaultInit(void);
+extern void z_CpuIdleInit(void);
 #ifdef CONFIG_ARM_MPU
 extern void z_arch_configure_static_mpu_regions(void);
 extern void z_arch_configure_dynamic_mpu_regions(struct k_thread *thread);
@@ -36,10 +36,10 @@ extern void z_arch_configure_dynamic_mpu_regions(struct k_thread *thread);
 
 static ALWAYS_INLINE void kernel_arch_init(void)
 {
-	_InterruptStackSetup();
-	_ExcSetup();
-	_FaultInit();
-	_CpuIdleInit();
+	z_InterruptStackSetup();
+	z_ExcSetup();
+	z_FaultInit();
+	z_CpuIdleInit();
 }
 
 static ALWAYS_INLINE void
@@ -134,9 +134,9 @@ z_set_thread_return_value(struct k_thread *thread, unsigned int value)
 
 extern void k_cpu_atomic_idle(unsigned int key);
 
-#define z_is_in_isr() _IsInIsr()
+#define z_is_in_isr() z_IsInIsr()
 
-extern FUNC_NORETURN void _arm_userspace_enter(k_thread_entry_t user_entry,
+extern FUNC_NORETURN void z_arm_userspace_enter(k_thread_entry_t user_entry,
 					       void *p1, void *p2, void *p3,
 					       u32_t stack_end,
 					       u32_t stack_start);

--- a/arch/arm/include/tracing_arch.h
+++ b/arch/arm/include/tracing_arch.h
@@ -25,7 +25,7 @@ extern "C" {
  *
  * @return The key of the interrupt that is currently being processed.
  */
-int _sys_current_irq_key_get(void)
+int z_sys_current_irq_key_get(void)
 {
 	return __get_IPSR();
 }

--- a/arch/nios2/core/cache.c
+++ b/arch/nios2/core/cache.c
@@ -15,23 +15,23 @@
  * text to memory, such as a boot copier or runtime synthesis of code.  If the
  * new text was written with instructions that do not bypass cache memories,
  * this should immediately be followed by an invocation of
- * _nios2_dcache_flush_all() so that cached instruction data is committed to
+ * z_nios2_dcache_flush_all() so that cached instruction data is committed to
  * RAM.
  *
  * See Chapter 9 of the Nios II Gen 2 Software Developer's Handbook for more
  * information on cache considerations.
  */
 #if ALT_CPU_ICACHE_SIZE > 0
-void _nios2_icache_flush_all(void)
+void z_nios2_icache_flush_all(void)
 {
 	u32_t i;
 
 	for (i = 0U; i < ALT_CPU_ICACHE_SIZE; i += ALT_CPU_ICACHE_LINE_SIZE) {
-		_nios2_icache_flush(i);
+		z_nios2_icache_flush(i);
 	}
 
 	/* Get rid of any stale instructions in the pipeline */
-	_nios2_pipeline_flush();
+	z_nios2_pipeline_flush();
 }
 #endif
 
@@ -51,26 +51,26 @@ void _nios2_icache_flush_all(void)
  * information on cache considerations.
  */
 #if ALT_CPU_DCACHE_SIZE > 0
-void _nios2_dcache_flush_all(void)
+void z_nios2_dcache_flush_all(void)
 {
 	u32_t i;
 
 	for (i = 0U; i < ALT_CPU_DCACHE_SIZE; i += ALT_CPU_DCACHE_LINE_SIZE) {
-		_nios2_dcache_flush(i);
+		z_nios2_dcache_flush(i);
 	}
 }
 #endif
 
 /*
- * _nios2_dcache_flush_no_writeback() is called to flush the data cache for a
+ * z_nios2_dcache_flush_no_writeback() is called to flush the data cache for a
  * memory region of length "len" bytes, starting at address "start".
  *
  * Any dirty lines in the data cache are NOT written back to memory.
  * Make sure you really want this behavior.  If you aren't 100% sure,
- * use the _nios2_dcache_flush() routine instead.
+ * use the z_nios2_dcache_flush() routine instead.
  */
 #if ALT_CPU_DCACHE_SIZE > 0
-void _nios2_dcache_flush_no_writeback(void *start, u32_t len)
+void z_nios2_dcache_flush_no_writeback(void *start, u32_t len)
 {
 	u8_t *i;
 	u8_t *end = ((char *) start) + len;

--- a/arch/nios2/core/exception.S
+++ b/arch/nios2/core/exception.S
@@ -15,7 +15,7 @@ GTEXT(_exception)
 GTEXT(_Fault)
 GTEXT(__swap)
 #ifdef CONFIG_IRQ_OFFLOAD
-GTEXT(_irq_do_offload)
+GTEXT(z_irq_do_offload)
 GTEXT(_offload_routine)
 #endif
 

--- a/arch/nios2/core/fatal.c
+++ b/arch/nios2/core/fatal.c
@@ -174,7 +174,7 @@ FUNC_NORETURN void _Fault(const NANO_ESF *esf)
 	u32_t exc_reg, badaddr_reg, eccftl;
 	enum nios2_exception_cause cause;
 
-	exc_reg = _nios2_creg_read(NIOS2_CR_EXCEPTION);
+	exc_reg = z_nios2_creg_read(NIOS2_CR_EXCEPTION);
 
 	/* Bit 31 indicates potentially fatal ECC error */
 	eccftl = (exc_reg & NIOS2_EXCEPTION_REG_ECCFTL_MASK) != 0U;
@@ -188,7 +188,7 @@ FUNC_NORETURN void _Fault(const NANO_ESF *esf)
 	printk("reason: %s\n", cause_str(cause));
 #endif
 	if (BIT(cause) & NIOS2_BADADDR_CAUSE_MASK) {
-		badaddr_reg = _nios2_creg_read(NIOS2_CR_BADADDR);
+		badaddr_reg = z_nios2_creg_read(NIOS2_CR_BADADDR);
 		printk("Badaddr: 0x%x\n", badaddr_reg);
 	}
 #endif /* ALT_CPU_HAS_EXTRA_EXCEPTION_INFO */
@@ -246,7 +246,7 @@ hang_system:
 #endif
 
 #ifdef ALT_CPU_HAS_DEBUG_STUB
-	_nios2_break();
+	z_nios2_break();
 #endif
 	for (;;) {
 		k_cpu_idle();

--- a/arch/nios2/core/irq_manage.c
+++ b/arch/nios2/core/irq_manage.c
@@ -25,7 +25,7 @@ void z_irq_spurious(void *unused)
 {
 	ARG_UNUSED(unused);
 	printk("Spurious interrupt detected! ipending: %x\n",
-	       _nios2_creg_read(NIOS2_CR_IPENDING));
+	       z_nios2_creg_read(NIOS2_CR_IPENDING));
 	z_NanoFatalErrorHandler(_NANO_ERR_SPURIOUS_INT, &_default_esf);
 }
 
@@ -37,9 +37,9 @@ void z_arch_irq_enable(unsigned int irq)
 
 	key = irq_lock();
 
-	ienable = _nios2_creg_read(NIOS2_CR_IENABLE);
+	ienable = z_nios2_creg_read(NIOS2_CR_IENABLE);
 	ienable |= BIT(irq);
-	_nios2_creg_write(NIOS2_CR_IENABLE, ienable);
+	z_nios2_creg_write(NIOS2_CR_IENABLE, ienable);
 
 	irq_unlock(key);
 };
@@ -53,9 +53,9 @@ void z_arch_irq_disable(unsigned int irq)
 
 	key = irq_lock();
 
-	ienable = _nios2_creg_read(NIOS2_CR_IENABLE);
+	ienable = z_nios2_creg_read(NIOS2_CR_IENABLE);
 	ienable &= ~BIT(irq);
-	_nios2_creg_write(NIOS2_CR_IENABLE, ienable);
+	z_nios2_creg_write(NIOS2_CR_IENABLE, ienable);
 
 	irq_unlock(key);
 };
@@ -80,7 +80,7 @@ void _enter_irq(u32_t ipending)
 	_kernel.nested++;
 
 #ifdef CONFIG_IRQ_OFFLOAD
-	_irq_do_offload();
+	z_irq_do_offload();
 #endif
 
 	while (ipending) {

--- a/arch/nios2/core/irq_offload.c
+++ b/arch/nios2/core/irq_offload.c
@@ -15,7 +15,7 @@ static volatile void *offload_param;
  * Just in case the offload routine itself generates an unhandled
  * exception, clear the offload_routine global before executing.
  */
-void _irq_do_offload(void)
+void z_irq_do_offload(void)
 {
 	irq_offload_routine_t tmp;
 

--- a/arch/nios2/core/prep_c.c
+++ b/arch/nios2/core/prep_c.c
@@ -39,13 +39,13 @@ void _PrepC(void)
 	/* In most XIP scenarios we copy the exception code into RAM, so need
 	 * to flush instruction cache.
 	 */
-	_nios2_icache_flush_all();
+	z_nios2_icache_flush_all();
 #if ALT_CPU_ICACHE_SIZE > 0
 	/* Only need to flush the data cache here if there actually is an
 	 * instruction cache, so that the cached instruction data written is
 	 * actually committed.
 	 */
-	_nios2_dcache_flush_all();
+	z_nios2_dcache_flush_all();
 #endif
 #endif
 	z_cstart();

--- a/arch/nios2/core/swap.S
+++ b/arch/nios2/core/swap.S
@@ -10,7 +10,7 @@
 
 /* exports */
 GTEXT(__swap)
-GTEXT(_thread_entry_wrapper)
+GTEXT(z_thread_entry_wrapper)
 
 /* imports */
 GTEXT(z_sys_trace_thread_switched_in)
@@ -171,9 +171,9 @@ no_unlock:
 	ret
 
 
-/* void _thread_entry_wrapper(void)
+/* void z_thread_entry_wrapper(void)
  */
-SECTION_FUNC(TEXT, _thread_entry_wrapper)
+SECTION_FUNC(TEXT, z_thread_entry_wrapper)
 	/* This all corresponds to struct init_stack_frame defined in
 	 * thread.c. We need to take this stuff off the stack and put
 	 * it in the apporpriate registers

--- a/arch/nios2/core/thread.c
+++ b/arch/nios2/core/thread.c
@@ -14,12 +14,12 @@
  * to z_thread_entry() since this arch puts the first four arguments
  * in r4-r7 and not on the stack
  */
-void _thread_entry_wrapper(k_thread_entry_t, void *, void *, void *);
+void z_thread_entry_wrapper(k_thread_entry_t, void *, void *, void *);
 
 struct init_stack_frame {
 	/* top of the stack / most recently pushed */
 
-	/* Used by _thread_entry_wrapper. pulls these off the stack and
+	/* Used by z_thread_entry_wrapper. pulls these off the stack and
 	 * into argument registers before calling z_thread_entry()
 	 */
 	k_thread_entry_t entry_point;
@@ -41,7 +41,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 
 	struct init_stack_frame *iframe;
 
-	_new_thread_init(thread, stack_memory, stack_size, priority, options);
+	z_new_thread_init(thread, stack_memory, stack_size, priority, options);
 
 	/* Initial stack frame data, stored at the base of the stack */
 	iframe = (struct init_stack_frame *)
@@ -54,7 +54,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	iframe->arg3 = arg3;
 
 	thread->callee_saved.sp = (u32_t)iframe;
-	thread->callee_saved.ra = (u32_t)_thread_entry_wrapper;
+	thread->callee_saved.ra = (u32_t)z_thread_entry_wrapper;
 	thread->callee_saved.key = NIOS2_STATUS_PIE_MSK;
 	/* Leave the rest of thread->callee_saved junk */
 }

--- a/arch/nios2/include/kernel_arch_func.h
+++ b/arch/nios2/include/kernel_arch_func.h
@@ -44,21 +44,21 @@ z_set_thread_return_value(struct k_thread *thread, unsigned int value)
 #define z_is_in_isr() (_kernel.nested != 0U)
 
 #ifdef CONFIG_IRQ_OFFLOAD
-void _irq_do_offload(void);
+void z_irq_do_offload(void);
 #endif
 
 #if ALT_CPU_ICACHE_SIZE > 0
-void _nios2_icache_flush_all(void);
+void z_nios2_icache_flush_all(void);
 #else
-#define _nios2_icache_flush_all() do { } while (0)
+#define z_nios2_icache_flush_all() do { } while (0)
 #endif
 
 #if ALT_CPU_DCACHE_SIZE > 0
-void _nios2_dcache_flush_all(void);
-void _nios2_dcache_flush_no_writeback(void *start, u32_t len);
+void z_nios2_dcache_flush_all(void);
+void z_nios2_dcache_flush_no_writeback(void *start, u32_t len);
 #else
-#define _nios2_dcache_flush_all() do { } while (0)
-#define _nios2_dcache_flush_no_writeback(x, y) do { } while (0)
+#define z_nios2_dcache_flush_all() do { } while (0)
+#define z_nios2_dcache_flush_no_writeback(x, y) do { } while (0)
 #endif
 
 #endif /* _ASMLANGUAGE */

--- a/arch/nios2/include/tracing_arch.h
+++ b/arch/nios2/include/tracing_arch.h
@@ -26,11 +26,11 @@ extern "C" {
  *
  * @return The key of the interrupt that is currently being processed.
  */
-static inline int _sys_current_irq_key_get(void)
+static inline int z_sys_current_irq_key_get(void)
 {
 	u32_t ipending;
 
-	ipending = _nios2_creg_read(NIOS2_CR_IPENDING);
+	ipending = z_nios2_creg_read(NIOS2_CR_IPENDING);
 	return find_lsb_set(ipending) - 1;
 }
 

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -166,7 +166,7 @@ static void posix_let_run(int next_allowed_th)
 	 * Note that as we hold the mutex, they are going to be blocked until
 	 * we reach our own posix_wait_until_allowed() while loop
 	 */
-	_SAFE_CALL(pthread_cond_broadcast(&cond_threads));
+	PC_SAFE_CALL(pthread_cond_broadcast(&cond_threads));
 }
 
 
@@ -175,7 +175,7 @@ static void posix_preexit_cleanup(void)
 	/*
 	 * Release the mutex so the next allowed thread can run
 	 */
-	_SAFE_CALL(pthread_mutex_unlock(&mtx_threads));
+	PC_SAFE_CALL(pthread_mutex_unlock(&mtx_threads));
 
 	/* We detach ourselves so nobody needs to join to us */
 	pthread_detach(pthread_self());
@@ -246,7 +246,7 @@ static void posix_cleanup_handler(void *arg)
 #endif
 
 
-	_SAFE_CALL(pthread_mutex_unlock(&mtx_threads));
+	PC_SAFE_CALL(pthread_mutex_unlock(&mtx_threads));
 
 	/* We detach ourselves so nobody needs to join to us */
 	pthread_detach(pthread_self());
@@ -271,7 +271,7 @@ static void *posix_thread_starter(void *arg)
 	 * We block until all other running threads reach the while loop
 	 * in posix_wait_until_allowed() and they release the mutex
 	 */
-	_SAFE_CALL(pthread_mutex_lock(&mtx_threads));
+	PC_SAFE_CALL(pthread_mutex_lock(&mtx_threads));
 
 	/*
 	 * The program may have been finished before this thread ever got to run
@@ -372,7 +372,7 @@ void posix_new_thread(posix_thread_status_t *ptr)
 	threads_table[t_slot].thead_cnt = thread_create_count++;
 	ptr->thread_idx = t_slot;
 
-	_SAFE_CALL(pthread_create(&threads_table[t_slot].thread,
+	PC_SAFE_CALL(pthread_create(&threads_table[t_slot].thread,
 				  NULL,
 				  posix_thread_starter,
 				  (void *)ptr));
@@ -403,7 +403,7 @@ void posix_init_multithreading(void)
 	threads_table_size = PC_ALLOC_CHUNK_SIZE;
 
 
-	_SAFE_CALL(pthread_mutex_lock(&mtx_threads));
+	PC_SAFE_CALL(pthread_mutex_lock(&mtx_threads));
 }
 
 /**

--- a/arch/posix/core/thread.c
+++ b/arch/posix/core/thread.c
@@ -57,7 +57,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 
 	posix_thread_status_t *thread_status;
 
-	_new_thread_init(thread, stack_memory, stack_size, priority, options);
+	z_new_thread_init(thread, stack_memory, stack_size, priority, options);
 
 	/* We store it in the same place where normal archs store the
 	 * "initial stack frame"

--- a/arch/posix/include/posix_arch_internal.h
+++ b/arch/posix/include/posix_arch_internal.h
@@ -9,13 +9,13 @@
 
 #include "toolchain.h"
 
-#define _SAFE_CALL(a) _safe_call(a, #a)
+#define PC_SAFE_CALL(a) pc_safe_call(a, #a)
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-static inline void _safe_call(int test, const char *test_str)
+static inline void pc_safe_call(int test, const char *test_str)
 {
 	/* LCOV_EXCL_START */ /* See Note1 */
 	if (unlikely(test)) {
@@ -34,6 +34,6 @@ static inline void _safe_call(int test, const char *test_str)
 /*
  * Note 1:
  *
- * All checks for the host pthreads functions which are wrapped by _SAFE_CALL
+ * All checks for the host pthreads functions which are wrapped by PC_SAFE_CALL
  * are meant to never fail, and therefore will not be covered.
  */

--- a/arch/posix/include/tracing_arch.h
+++ b/arch/posix/include/tracing_arch.h
@@ -27,7 +27,7 @@ extern "C" {
  *
  * @return The key of the interrupt that is currently being processed.
  */
-static inline int _sys_current_irq_key_get(void)
+static inline int z_sys_current_irq_key_get(void)
 {
 	return posix_get_current_irq();
 }

--- a/arch/riscv32/core/irq_offload.c
+++ b/arch/riscv32/core/irq_offload.c
@@ -17,7 +17,7 @@ static volatile void *offload_param;
  * Just in case the offload routine itself generates an unhandled
  * exception, clear the offload_routine global before executing.
  */
-void _irq_do_offload(void)
+void z_irq_do_offload(void)
 {
 	irq_offload_routine_t tmp;
 

--- a/arch/riscv32/core/isr.S
+++ b/arch/riscv32/core/isr.S
@@ -218,12 +218,12 @@ on_irq_stack:
 	beqz t1, call_irq
 
 	/*
-	 * Call _irq_do_offload to handle IRQ offloading.
+	 * Call z_irq_do_offload to handle IRQ offloading.
 	 * Set return address to on_thread_stack in order to jump there
-	 * upon returning from _irq_do_offload
+	 * upon returning from z_irq_do_offload
 	 */
 	la ra, on_thread_stack
-	tail _irq_do_offload
+	tail z_irq_do_offload
 
 call_irq:
 #ifdef CONFIG_TRACING

--- a/arch/riscv32/core/swap.S
+++ b/arch/riscv32/core/swap.S
@@ -10,7 +10,7 @@
 
 /* exports */
 GTEXT(__swap)
-GTEXT(_thread_entry_wrapper)
+GTEXT(z_thread_entry_wrapper)
 
 /* Use ABI name of registers for the sake of simplicity */
 
@@ -103,11 +103,11 @@ SECTION_FUNC(exception.other, __swap)
 
 
 /*
- * void _thread_entry_wrapper(k_thread_entry_t, void *, void *, void *)
+ * void z_thread_entry_wrapper(k_thread_entry_t, void *, void *, void *)
  */
-SECTION_FUNC(TEXT, _thread_entry_wrapper)
+SECTION_FUNC(TEXT, z_thread_entry_wrapper)
 	/*
-	 * _thread_entry_wrapper is called for every new thread upon the return
+	 * z_thread_entry_wrapper is called for every new thread upon the return
 	 * of __swap or ISR. Its address, as well as its input function
 	 * arguments thread_entry_t, void *, void *, void * are restored from
 	 * the thread stack (initialized via function _thread).

--- a/arch/riscv32/core/thread.c
+++ b/arch/riscv32/core/thread.c
@@ -10,7 +10,7 @@
 #include <wait_q.h>
 #include <string.h>
 
-void _thread_entry_wrapper(k_thread_entry_t thread,
+void z_thread_entry_wrapper(k_thread_entry_t thread,
 			   void *arg1,
 			   void *arg2,
 			   void *arg3);
@@ -25,7 +25,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 
 	struct __esf *stack_init;
 
-	_new_thread_init(thread, stack_memory, stack_size, priority, options);
+	z_new_thread_init(thread, stack_memory, stack_size, priority, options);
 
 	/* Initial stack frame for thread */
 	stack_init = (struct __esf *)
@@ -50,18 +50,18 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	 * within the RISCV32 architecture implementation, initially set:
 	 * 1) MSTATUS to SOC_MSTATUS_DEF_RESTORE in the thread stack to enable
 	 *    interrupts when the newly created thread will be scheduled;
-	 * 2) MEPC to the address of the _thread_entry_wrapper in the thread
+	 * 2) MEPC to the address of the z_thread_entry_wrapper in the thread
 	 *    stack.
 	 * Hence, when going out of an interrupt/exception/context-switch,
 	 * after scheduling the newly created thread:
 	 * 1) interrupts will be enabled, as the MSTATUS register will be
 	 *    restored following the MSTATUS value set within the thread stack;
-	 * 2) the core will jump to _thread_entry_wrapper, as the program
+	 * 2) the core will jump to z_thread_entry_wrapper, as the program
 	 *    counter will be restored following the MEPC value set within the
 	 *    thread stack.
 	 */
 	stack_init->mstatus = SOC_MSTATUS_DEF_RESTORE;
-	stack_init->mepc = (u32_t)_thread_entry_wrapper;
+	stack_init->mepc = (u32_t)z_thread_entry_wrapper;
 
 	thread->callee_saved.sp = (u32_t)stack_init;
 }

--- a/arch/riscv32/include/kernel_arch_func.h
+++ b/arch/riscv32/include/kernel_arch_func.h
@@ -44,7 +44,7 @@ FUNC_NORETURN void z_NanoFatalErrorHandler(unsigned int reason,
 #define z_is_in_isr() (_kernel.nested != 0U)
 
 #ifdef CONFIG_IRQ_OFFLOAD
-int _irq_do_offload(void);
+int z_irq_do_offload(void);
 #endif
 
 #endif /* _ASMLANGUAGE */

--- a/arch/riscv32/include/tracing_arch.h
+++ b/arch/riscv32/include/tracing_arch.h
@@ -26,7 +26,7 @@ extern "C" {
  *
  * @return The key of the interrupt that is currently being processed.
  */
-static inline int _sys_current_irq_key_get(void)
+static inline int z_sys_current_irq_key_get(void)
 {
 	u32_t mcause;
 

--- a/arch/x86/core/cache.c
+++ b/arch/x86/core/cache.c
@@ -63,10 +63,10 @@ _sys_cache_flush_sig(_cache_flush_clflush)
 _sys_cache_flush_t *sys_cache_flush;
 static void init_cache_flush(void)
 {
-	if (_is_clflush_available()) {
+	if (z_is_clflush_available()) {
 		sys_cache_flush = _cache_flush_clflush;
 	} else {
-		sys_cache_flush = _cache_flush_wbinvd;
+		sys_cache_flush = z_cache_flush_wbinvd;
 	}
 }
 #else
@@ -83,7 +83,7 @@ FUNC_ALIAS(_cache_flush_clflush, sys_cache_flush, void);
 size_t sys_cache_line_size;
 static void init_cache_line_size(void)
 {
-	sys_cache_line_size = _cache_line_size_get();
+	sys_cache_line_size = z_cache_line_size_get();
 }
 #else
 #define init_cache_line_size() do { } while ((0))

--- a/arch/x86/core/cache_s.S
+++ b/arch/x86/core/cache_s.S
@@ -16,12 +16,12 @@
 
 #if defined(CONFIG_CLFLUSH_DETECT)
 
-	#define CACHE_FLUSH_NAME _cache_flush_wbinvd
+	#define CACHE_FLUSH_NAME z_cache_flush_wbinvd
 	#define CPUID_CFLSH_BIT (1 << 19)
 
-	GTEXT(_is_clflush_available)
+	GTEXT(z_is_clflush_available)
 
-SECTION_FUNC(TEXT, _is_clflush_available)
+SECTION_FUNC(TEXT, z_is_clflush_available)
 	pushl %ebx
 	movl $1, %eax
 	cpuid
@@ -62,9 +62,9 @@ SECTION_FUNC(TEXT, CACHE_FLUSH_NAME)
 
 	#define CPUID_CACHE_LINE_MASK (0xff << 8)
 
-	GTEXT(_cache_line_size_get)
+	GTEXT(z_cache_line_size_get)
 
-SECTION_FUNC(TEXT, _cache_line_size_get)
+SECTION_FUNC(TEXT, z_cache_line_size_get)
 	pushl %ebx
 	movl $1, %eax
 	cpuid

--- a/arch/x86/core/excstub.S
+++ b/arch/x86/core/excstub.S
@@ -26,7 +26,7 @@
 	GTEXT(_kernel_oops_handler)
 
 	/* externs (internal APIs) */
-	GTEXT(_do_kernel_oops)
+	GTEXT(z_do_kernel_oops)
 
 /**
  *
@@ -230,6 +230,6 @@ nestedException:
 #if CONFIG_X86_KERNEL_OOPS
 SECTION_FUNC(TEXT, _kernel_oops_handler)
 	push $0 /* dummy error code */
-	push $_do_kernel_oops
+	push $z_do_kernel_oops
 	jmp _exception_enter
 #endif

--- a/arch/x86/core/float.c
+++ b/arch/x86/core/float.c
@@ -57,15 +57,15 @@ extern u32_t _sse_mxcsr_default_value;
  * specified thread control block. The SSE registers are saved only if the
  * thread is actually using them.
  */
-static void _FpCtxSave(struct k_thread *thread)
+static void FpCtxSave(struct k_thread *thread)
 {
 #ifdef CONFIG_SSE
 	if ((thread->base.user_options & K_SSE_REGS) != 0) {
-		_do_fp_and_sse_regs_save(&thread->arch.preempFloatReg);
+		z_do_fp_and_sse_regs_save(&thread->arch.preempFloatReg);
 		return;
 	}
 #endif
-	_do_fp_regs_save(&thread->arch.preempFloatReg);
+	z_do_fp_regs_save(&thread->arch.preempFloatReg);
 }
 
 /*
@@ -74,12 +74,12 @@ static void _FpCtxSave(struct k_thread *thread)
  * This routine initializes the system's "live" floating point context.
  * The SSE registers are initialized only if the thread is actually using them.
  */
-static inline void _FpCtxInit(struct k_thread *thread)
+static inline void FpCtxInit(struct k_thread *thread)
 {
-	_do_fp_regs_init();
+	z_do_fp_regs_init();
 #ifdef CONFIG_SSE
 	if ((thread->base.user_options & K_SSE_REGS) != 0) {
-		_do_sse_regs_init();
+		z_do_sse_regs_init();
 	}
 #endif
 }
@@ -123,13 +123,13 @@ void k_float_enable(struct k_thread *thread, unsigned int options)
 	fp_owner = _kernel.current_fp;
 	if (fp_owner != NULL) {
 		if ((fp_owner->base.thread_state & _INT_OR_EXC_MASK) != 0) {
-			_FpCtxSave(fp_owner);
+			FpCtxSave(fp_owner);
 		}
 	}
 
 	/* Now create a virgin FP context */
 
-	_FpCtxInit(thread);
+	FpCtxInit(thread);
 
 	/* Associate the new FP context with the specified thread */
 
@@ -157,7 +157,7 @@ void k_float_enable(struct k_thread *thread, unsigned int options)
 			 */
 
 			_kernel.current_fp = thread;
-			_FpAccessDisable();
+			z_FpAccessDisable();
 		} else {
 			/*
 			 * We are FP-capable (and thus had FPU ownership on
@@ -176,7 +176,7 @@ void k_float_enable(struct k_thread *thread, unsigned int options)
 			 * handling an interrupt or exception.)
 			 */
 
-			_FpCtxSave(thread);
+			FpCtxSave(thread);
 		}
 	}
 
@@ -205,7 +205,7 @@ void k_float_disable(struct k_thread *thread)
 	thread->base.user_options &= ~_FP_USER_MASK;
 
 	if (thread == _current) {
-		_FpAccessDisable();
+		z_FpAccessDisable();
 		_kernel.current_fp = (struct k_thread *)0;
 	} else {
 		if (_kernel.current_fp == thread) {

--- a/arch/x86/core/intstub.S
+++ b/arch/x86/core/intstub.S
@@ -23,8 +23,8 @@
 	/* exports (internal APIs) */
 
 	GTEXT(_interrupt_enter)
-	GTEXT(_SpuriousIntNoErrCodeHandler)
-	GTEXT(_SpuriousIntHandler)
+	GTEXT(z_SpuriousIntNoErrCodeHandler)
+	GTEXT(z_SpuriousIntHandler)
 	GTEXT(_irq_sw_handler)
 	GTEXT(z_dynamic_stubs_begin)
 
@@ -389,11 +389,11 @@ handle_idle:
 
 /**
  *
- * _SpuriousIntHandler -
+ * z_SpuriousIntHandler -
  * @brief Spurious interrupt handler stubs
  *
  * Interrupt-gate descriptors are statically created for all slots in the IDT
- * that point to _SpuriousIntHandler() or _SpuriousIntNoErrCodeHandler().  The
+ * that point to z_SpuriousIntHandler() or z_SpuriousIntNoErrCodeHandler().  The
  * former stub is connected to exception vectors where the processor pushes an
  * error code onto the stack (or kernel stack) in addition to the EFLAGS/CS/EIP
  * records.
@@ -408,23 +408,23 @@ handle_idle:
  *
  * C function prototype:
  *
- * void _SpuriousIntHandler (void);
+ * void z_SpuriousIntHandler (void);
  *
  * INTERNAL
  * The gen_idt tool creates an interrupt-gate descriptor for all
  * connections.  The processor will automatically clear the IF bit
  * in the EFLAGS register upon execution of the handler,
- * thus _SpuriousIntNoErrCodeHandler()/_SpuriousIntHandler() shall be
+ * thus z_SpuriousIntNoErrCodeHandler()/z_SpuriousIntHandler() shall be
  * invoked with interrupts disabled.
  */
-SECTION_FUNC(TEXT, _SpuriousIntNoErrCodeHandler)
+SECTION_FUNC(TEXT, z_SpuriousIntNoErrCodeHandler)
 
 	pushl	$0			/* push dummy err code onto stk */
 
-	/* fall through to _SpuriousIntHandler */
+	/* fall through to z_SpuriousIntHandler */
 
 
-SECTION_FUNC(TEXT, _SpuriousIntHandler)
+SECTION_FUNC(TEXT, z_SpuriousIntHandler)
 
 	cld				/* Clear direction flag */
 
@@ -464,7 +464,7 @@ SECTION_FUNC(TEXT, _SpuriousIntHandler)
 #if CONFIG_IRQ_OFFLOAD
 SECTION_FUNC(TEXT, _irq_sw_handler)
 	push $0
-	push $_irq_do_offload
+	push $z_irq_do_offload
 	jmp _interrupt_enter
 
 #endif

--- a/arch/x86/core/irq_manage.c
+++ b/arch/x86/core/irq_manage.c
@@ -24,19 +24,19 @@
 #include <kswap.h>
 #include <arch/x86/segmentation.h>
 
-extern void _SpuriousIntHandler(void *handler);
-extern void _SpuriousIntNoErrCodeHandler(void *handler);
+extern void z_SpuriousIntHandler(void *handler);
+extern void z_SpuriousIntNoErrCodeHandler(void *handler);
 
 /*
  * Place the addresses of the spurious interrupt handlers into the intList
  * section. The genIdt tool can then populate any unused vectors with
  * these routines.
  */
-void *__attribute__((section(".spurIsr"))) MK_ISR_NAME(_SpuriousIntHandler) =
-	&_SpuriousIntHandler;
+void *__attribute__((section(".spurIsr"))) MK_ISR_NAME(z_SpuriousIntHandler) =
+	&z_SpuriousIntHandler;
 void *__attribute__((section(".spurNoErrIsr")))
-	MK_ISR_NAME(_SpuriousIntNoErrCodeHandler) =
-		&_SpuriousIntNoErrCodeHandler;
+	MK_ISR_NAME(z_SpuriousIntNoErrCodeHandler) =
+		&z_SpuriousIntNoErrCodeHandler;
 
 /* FIXME: IRQ direct inline functions have to be placed here and not in
  * arch/cpu.h as inline functions due to nasty circular dependency between
@@ -72,7 +72,7 @@ void z_arch_isr_direct_header(void)
 
 void z_arch_isr_direct_footer(int swap)
 {
-	_irq_controller_eoi();
+	z_irq_controller_eoi();
 	z_int_latency_stop();
 	sys_trace_isr_exit();
 	--_kernel.nested;
@@ -249,11 +249,11 @@ static void idt_vector_install(int vector, void *irq_handler)
 	int key;
 
 	key = irq_lock();
-	_init_irq_gate(&z_x86_idt.entries[vector], CODE_SEG,
+	z_init_irq_gate(&z_x86_idt.entries[vector], CODE_SEG,
 		       (u32_t)irq_handler, 0);
 #ifdef CONFIG_MVIC
 	/* MVIC requires IDT be reloaded if the entries table is ever changed */
-	_set_idt(&z_x86_idt);
+	z_set_idt(&z_x86_idt);
 #endif
 	irq_unlock(key);
 }

--- a/arch/x86/core/irq_offload.c
+++ b/arch/x86/core/irq_offload.c
@@ -20,7 +20,7 @@ static irq_offload_routine_t offload_routine;
 static void *offload_param;
 
 /* Called by asm stub */
-void _irq_do_offload(void)
+void z_irq_do_offload(void)
 {
 	offload_routine(offload_param);
 }

--- a/arch/x86/core/spec_ctrl.c
+++ b/arch/x86/core/spec_ctrl.c
@@ -58,9 +58,9 @@ static int spec_ctrl_init(struct device *dev)
 	}
 #endif
 	if (enable_bits != 0U) {
-		u64_t cur = _x86_msr_read(IA32_SPEC_CTRL_MSR);
+		u64_t cur = z_x86_msr_read(IA32_SPEC_CTRL_MSR);
 
-		_x86_msr_write(IA32_SPEC_CTRL_MSR,
+		z_x86_msr_write(IA32_SPEC_CTRL_MSR,
 			       cur | enable_bits);
 	}
 

--- a/arch/x86/core/swap.S
+++ b/arch/x86/core/swap.S
@@ -24,7 +24,7 @@
 	/* exports (internal APIs) */
 
 	GTEXT(__swap)
-	GTEXT(_x86_thread_entry_wrapper)
+	GTEXT(z_x86_thread_entry_wrapper)
 	GTEXT(_x86_user_thread_entry_wrapper)
 
 	/* externs */
@@ -479,7 +479,7 @@ time_read_not_needed:
  * @return this routine does NOT return.
  */
 
-SECTION_FUNC(TEXT, _x86_thread_entry_wrapper)
+SECTION_FUNC(TEXT, z_x86_thread_entry_wrapper)
 #ifdef CONFIG_X86_IAMCU
 	/* IAMCU calling convention has first 3 arguments supplied in
 	 * registers not the stack

--- a/arch/x86/core/thread.c
+++ b/arch/x86/core/thread.c
@@ -69,7 +69,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 
 	Z_ASSERT_VALID_PRIO(priority, entry);
 	stack_buf = K_THREAD_STACK_BUFFER(stack);
-	_new_thread_init(thread, stack_buf, stack_size, priority, options);
+	z_new_thread_init(thread, stack_buf, stack_size, priority, options);
 
 #if CONFIG_X86_USERSPACE
 	if ((options & K_USER) == 0U) {
@@ -103,7 +103,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	if ((options & K_USER) != 0U) {
 #ifdef _THREAD_WRAPPER_REQUIRED
 		initial_frame->edi = (u32_t)z_arch_user_mode_enter;
-		initial_frame->thread_entry = _x86_thread_entry_wrapper;
+		initial_frame->thread_entry = z_x86_thread_entry_wrapper;
 #else
 		initial_frame->thread_entry = z_arch_user_mode_enter;
 #endif /* _THREAD_WRAPPER_REQUIRED */
@@ -112,7 +112,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	{
 #ifdef _THREAD_WRAPPER_REQUIRED
 		initial_frame->edi = (u32_t)z_thread_entry;
-		initial_frame->thread_entry = _x86_thread_entry_wrapper;
+		initial_frame->thread_entry = z_x86_thread_entry_wrapper;
 #else
 		initial_frame->thread_entry = z_thread_entry;
 #endif
@@ -190,18 +190,18 @@ FUNC_NORETURN void z_arch_user_mode_enter(k_thread_entry_t user_entry,
 			   (MMU_PTE_P_MASK | MMU_PTE_RW_MASK |
 			    MMU_PTE_US_MASK));
 
-	_x86_userspace_enter(user_entry, p1, p2, p3, stack_end,
+	z_x86_userspace_enter(user_entry, p1, p2, p3, stack_end,
 			     _current->stack_info.start);
 	CODE_UNREACHABLE;
 }
 
 
 /* Implemented in userspace.S */
-extern void _x86_syscall_entry_stub(void);
+extern void z_x86_syscall_entry_stub(void);
 
 /* Syscalls invoked by 'int 0x80'. Installed in the IDT at DPL=3 so that
  * userspace can invoke it.
  */
-NANO_CPU_INT_REGISTER(_x86_syscall_entry_stub, -1, -1, 0x80, 3);
+NANO_CPU_INT_REGISTER(z_x86_syscall_entry_stub, -1, -1, 0x80, 3);
 
 #endif /* CONFIG_X86_USERSPACE */

--- a/arch/x86/core/userspace.S
+++ b/arch/x86/core/userspace.S
@@ -11,8 +11,8 @@
 #include <syscall.h>
 
 /* Exports */
-GTEXT(_x86_syscall_entry_stub)
-GTEXT(_x86_userspace_enter)
+GTEXT(z_x86_syscall_entry_stub)
+GTEXT(z_x86_userspace_enter)
 GTEXT(z_arch_user_string_nlen)
 GTEXT(z_arch_user_string_nlen_fault_start)
 GTEXT(z_arch_user_string_nlen_fault_end)
@@ -151,7 +151,7 @@ SECTION_FUNC(TEXT, z_x86_trampoline_to_user_always)
  * unless KPTI is enabled, in which case we're on the trampoline stack and
  * need to get off it before enabling interrupts.
  */
-SECTION_FUNC(TEXT, _x86_syscall_entry_stub)
+SECTION_FUNC(TEXT, z_x86_syscall_entry_stub)
 #ifdef CONFIG_X86_KPTI
 	/* Stash these regs as we need to use them */
 	pushl	%esi
@@ -295,14 +295,14 @@ z_arch_user_string_nlen_fixup:
 	ret
 
 
-/* FUNC_NORETURN void _x86_userspace_enter(k_thread_entry_t user_entry,
+/* FUNC_NORETURN void z_x86_userspace_enter(k_thread_entry_t user_entry,
  *					   void *p1, void *p2, void *p3,
  *					   u32_t stack_end,
  *					   u32_t stack_start)
  *
  * A one-way trip to userspace.
  */
-SECTION_FUNC(TEXT, _x86_userspace_enter)
+SECTION_FUNC(TEXT, z_x86_userspace_enter)
 	pop	%esi	/* Discard return address on stack */
 
 	/* Fetch parameters on the stack */

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -264,7 +264,7 @@ static inline void activate_partition(struct k_mem_partition *partition)
 #define X86_MEM_DOMAIN_SET_PAGES   (0U)
 #define X86_MEM_DOMAIN_RESET_PAGES (1U)
 /* Pass 1 to page_conf if reset of mem domain pages is needed else pass a 0*/
-static inline void _x86_mem_domain_pages_update(struct k_mem_domain *mem_domain,
+static inline void x86_mem_domain_pages_update(struct k_mem_domain *mem_domain,
 						u32_t page_conf)
 {
 	u32_t partition_index;
@@ -309,7 +309,7 @@ out:
 /* Load the partitions of the thread. */
 void z_arch_mem_domain_configure(struct k_thread *thread)
 {
-	_x86_mem_domain_pages_update(thread->mem_domain_info.mem_domain,
+	x86_mem_domain_pages_update(thread->mem_domain_info.mem_domain,
 				     X86_MEM_DOMAIN_SET_PAGES);
 }
 
@@ -318,7 +318,7 @@ void z_arch_mem_domain_configure(struct k_thread *thread)
  */
 void z_arch_mem_domain_destroy(struct k_mem_domain *domain)
 {
-	_x86_mem_domain_pages_update(domain, X86_MEM_DOMAIN_RESET_PAGES);
+	x86_mem_domain_pages_update(domain, X86_MEM_DOMAIN_RESET_PAGES);
 }
 
 /* Reset/destroy one partition spcified in the argument of the API. */

--- a/arch/x86/include/asm_inline_gcc.h
+++ b/arch/x86/include/asm_inline_gcc.h
@@ -51,7 +51,7 @@ static inline unsigned int EflagsGet(void)
  *
  * @return N/A
  */
-static inline void _FpAccessDisable(void)
+static inline void z_FpAccessDisable(void)
 {
 	void *tempReg;
 
@@ -72,11 +72,11 @@ static inline void _FpAccessDisable(void)
  * This routine saves the system's "live" non-integer context into the
  * specified area.  If the specified thread supports SSE then
  * x87/MMX/SSEx thread info is saved, otherwise only x87/MMX thread is saved.
- * Function is invoked by _FpCtxSave(struct k_thread *thread)
+ * Function is invoked by FpCtxSave(struct k_thread *thread)
  *
  * @return N/A
  */
-static inline void _do_fp_regs_save(void *preemp_float_reg)
+static inline void z_do_fp_regs_save(void *preemp_float_reg)
 {
 	__asm__ volatile("fnsave (%0);\n\t"
 			 :
@@ -92,11 +92,11 @@ static inline void _do_fp_regs_save(void *preemp_float_reg)
  * This routine saves the system's "live" non-integer context into the
  * specified area.  If the specified thread supports SSE then
  * x87/MMX/SSEx thread info is saved, otherwise only x87/MMX thread is saved.
- * Function is invoked by _FpCtxSave(struct k_thread *thread)
+ * Function is invoked by FpCtxSave(struct k_thread *thread)
  *
  * @return N/A
  */
-static inline void _do_fp_and_sse_regs_save(void *preemp_float_reg)
+static inline void z_do_fp_and_sse_regs_save(void *preemp_float_reg)
 {
 	__asm__ volatile("fxsave (%0);\n\t"
 			 :
@@ -113,7 +113,7 @@ static inline void _do_fp_and_sse_regs_save(void *preemp_float_reg)
  *
  * @return N/A
  */
-static inline void _do_fp_regs_init(void)
+static inline void z_do_fp_regs_init(void)
 {
 	__asm__ volatile("fninit\n\t");
 }
@@ -127,7 +127,7 @@ static inline void _do_fp_regs_init(void)
  *
  * @return N/A
  */
-static inline void _do_sse_regs_init(void)
+static inline void z_do_sse_regs_init(void)
 {
 	__asm__ volatile("ldmxcsr _sse_mxcsr_default_value\n\t");
 }

--- a/arch/x86/include/cache_private.h
+++ b/arch/x86/include/cache_private.h
@@ -13,9 +13,9 @@
 extern "C" {
 #endif
 
-extern int _is_clflush_available(void);
-extern void _cache_flush_wbinvd(vaddr_t addr, size_t len);
-extern size_t _cache_line_size_get(void);
+extern int z_is_clflush_available(void);
+extern void z_cache_flush_wbinvd(vaddr_t addr, size_t len);
+extern size_t z_cache_line_size_get(void);
 
 #ifdef __cplusplus
 }

--- a/arch/x86/include/kernel_arch_data.h
+++ b/arch/x86/include/kernel_arch_data.h
@@ -41,7 +41,7 @@
 #endif
 
 /* Some configurations require that the stack/registers be adjusted before
- * z_thread_entry. See discussion in swap.S for _x86_thread_entry_wrapper()
+ * z_thread_entry. See discussion in swap.S for z_x86_thread_entry_wrapper()
  */
 #if defined(CONFIG_X86_IAMCU) || defined(CONFIG_DEBUG_INFO)
 #define _THREAD_WRAPPER_REQUIRED
@@ -98,8 +98,8 @@
 #define IV_INTEL_RESERVED_END 31
 
 /*
- * Model specific register (MSR) definitions.  Use the _x86_msr_read() and
- * _x86_msr_write() primitives to read/write the MSRs.  Only the so-called
+ * Model specific register (MSR) definitions.  Use the z_x86_msr_read() and
+ * z_x86_msr_write() primitives to read/write the MSRs.  Only the so-called
  * "Architectural MSRs" are listed, i.e.  the subset of MSRs and associated
  * bit fields which will not change on future processor generations.
  */
@@ -398,7 +398,7 @@
 #include <misc/util.h>
 
 #ifdef _THREAD_WRAPPER_REQUIRED
-extern void _x86_thread_entry_wrapper(k_thread_entry_t entry,
+extern void z_x86_thread_entry_wrapper(k_thread_entry_t entry,
 				      void *p1, void *p2, void *p3);
 #endif /* _THREAD_WRAPPER_REQUIRED */
 

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -77,7 +77,7 @@ extern void k_cpu_atomic_idle(unsigned int key);
  *
  * @return N/A
  */
-static inline void _x86_msr_write(unsigned int msr, u64_t data)
+static inline void z_x86_msr_write(unsigned int msr, u64_t data)
 {
 	u32_t high = data >> 32;
 	u32_t low = data & 0xFFFFFFFF;
@@ -95,7 +95,7 @@ static inline void _x86_msr_write(unsigned int msr, u64_t data)
  *
  * @return N/A
  */
-static inline u64_t _x86_msr_read(unsigned int msr)
+static inline u64_t z_x86_msr_read(unsigned int msr)
 {
 	u64_t ret;
 
@@ -109,16 +109,16 @@ static inline u64_t _x86_msr_read(unsigned int msr)
 
 static inline u32_t read_x2apic(unsigned int reg)
 {
-	return _x86_msr_read(MSR_X2APIC_BASE + reg);
+	return z_x86_msr_read(MSR_X2APIC_BASE + reg);
 }
 
 static inline void write_x2apic(unsigned int reg, u32_t val)
 {
-	_x86_msr_write(MSR_X2APIC_BASE + reg, val);
+	z_x86_msr_write(MSR_X2APIC_BASE + reg, val);
 }
 #endif
 
-extern FUNC_NORETURN void _x86_userspace_enter(k_thread_entry_t user_entry,
+extern FUNC_NORETURN void z_x86_userspace_enter(k_thread_entry_t user_entry,
 					       void *p1, void *p2, void *p3,
 					       u32_t stack_end,
 					       u32_t stack_start);

--- a/arch/x86/include/mmustructs.h
+++ b/arch/x86/include/mmustructs.h
@@ -251,11 +251,11 @@ struct mmu_region {
 		.flags = permission_flags,				\
 	}
 
-#define _MMU_BOOT_REGION(id, addr, region_size, permission_flags)	\
+#define Z_MMU_BOOT_REGION(id, addr, region_size, permission_flags)	\
 	__MMU_BOOT_REGION(id, addr, region_size, permission_flags)
 
 #define MMU_BOOT_REGION(addr, region_size, permission_flags)		\
-	_MMU_BOOT_REGION(__COUNTER__, addr, region_size, permission_flags)
+	Z_MMU_BOOT_REGION(__COUNTER__, addr, region_size, permission_flags)
 
 /*
  * The following defines the format of a 64-bit page directory pointer entry

--- a/arch/x86/include/tracing_arch.h
+++ b/arch/x86/include/tracing_arch.h
@@ -26,9 +26,9 @@ extern "C" {
  *
  * @return The key of the interrupt that is currently being processed.
  */
-static inline int _sys_current_irq_key_get(void)
+static inline int z_sys_current_irq_key_get(void)
 {
-	return _irq_controller_isr_vector_get();
+	return z_irq_controller_isr_vector_get();
 }
 
 #ifdef __cplusplus

--- a/arch/x86_64/core/demo-kernel.c
+++ b/arch/x86_64/core/demo-kernel.c
@@ -59,19 +59,19 @@ void handler_f3(void *arg, int err)
 	printf("end f3 handler\n");
 }
 
-void _unhandled_vector(int vector, int err, struct xuk_entry_frame *f)
+void z_unhandled_vector(int vector, int err, struct xuk_entry_frame *f)
 {
 	(void)f;
-	_putchar = putchar;
+	z_putchar = putchar;
 	printf("Unhandled vector %d (err %xh) on CPU%d\n",
 	       vector, err, (int)(long)xuk_get_f_ptr());
 }
 
-void _isr_entry(void)
+void z_isr_entry(void)
 {
 }
 
-void *_isr_exit_restore_stack(void *interrupted)
+void *z_isr_exit_restore_stack(void *interrupted)
 {
 	/* Somewhat hacky test of the ISR exit modes.  Two ways of
 	 * specifying "this stack", one of which does the full spill
@@ -129,9 +129,9 @@ void test_local_ipi(void)
 	};
 }
 
-void _cpu_start(int cpu)
+void z_cpu_start(int cpu)
 {
-	_putchar = putchar;
+	z_putchar = putchar;
 	printf("Entering demo kernel\n");
 
 	/* Make sure the FS/GS pointers work, then set F to store our

--- a/arch/x86_64/core/printf.h
+++ b/arch/x86_64/core/printf.h
@@ -17,7 +17,7 @@ struct _pfr {
 };
 
 /* Set this function pointer to something that generates output */
-static void (*_putchar)(int c);
+static void (*z_putchar)(int c);
 
 static void pc(struct _pfr *r, int c)
 {
@@ -25,7 +25,7 @@ static void pc(struct _pfr *r, int c)
 		if (r->idx <= r->len)
 			r->buf[r->idx] = c;
 	} else {
-		_putchar(c);
+		z_putchar(c);
 	}
 	r->idx++;
 }
@@ -56,7 +56,7 @@ static void endrec(struct _pfr *r)
 		r->buf[r->idx] = 0;
 }
 
-static int _vpf(struct _pfr *r, const char *f, va_list ap)
+static int vpf(struct _pfr *r, const char *f, va_list ap)
 {
 	for (/**/; *f; f++) {
 		if (*f != '%') {
@@ -109,7 +109,7 @@ static int _vpf(struct _pfr *r, const char *f, va_list ap)
 #define CALL_VPF(rec)				\
 	va_list ap;				\
 	va_start(ap, f);			\
-	int ret = _vpf(&r, f, ap);		\
+	int ret = vpf(&r, f, ap);		\
 	va_end(ap);				\
 	return ret
 

--- a/arch/x86_64/core/serial.h
+++ b/arch/x86_64/core/serial.h
@@ -9,7 +9,7 @@
 
 #define _PORT 0x3f8
 
-static inline void _serout(int c)
+static inline void serout(int c)
 {
 	while (!(ioport_in8(_PORT + 5) & 0x20)) {
 	}
@@ -19,9 +19,9 @@ static inline void _serout(int c)
 static inline void serial_putc(int c)
 {
 	if (c == '\n') {
-		_serout('\r');
+		serout('\r');
 	}
-	_serout(c);
+	serout(c);
 }
 
 static inline void serial_puts(const char *s)

--- a/arch/x86_64/core/vgacon.h
+++ b/arch/x86_64/core/vgacon.h
@@ -7,7 +7,7 @@
 
 /* Super-primitive VGA text console output-only "terminal" driver */
 
-static inline unsigned short *_vga_row(int row)
+static inline unsigned short *vga_row(int row)
 {
 	return ((unsigned short *)0xb8000) + 80 * row;
 }
@@ -18,7 +18,7 @@ static inline unsigned short *_vga_row(int row)
  */
 static inline void vga_put(int ch, int color, int row, int col)
 {
-	unsigned short *rp = _vga_row(row);
+	unsigned short *rp = vga_row(row);
 
 	rp[col] = (color << 8) | ch;
 }
@@ -28,11 +28,11 @@ static inline void vgacon_putc(char c)
 	if (_shared.vgacol == 80) {
 		for (int r = 0; r < 24; r++) {
 			for (int c = 0; c < 80; c++) {
-				_vga_row(r)[c] = _vga_row(r+1)[c];
+				vga_row(r)[c] = vga_row(r+1)[c];
 			}
 		}
 		for (int c = 0; c < 80; c++) {
-			_vga_row(24)[c] = 0x9000;
+			vga_row(24)[c] = 0x9000;
 		}
 		_shared.vgacol = 0;
 	}

--- a/arch/x86_64/core/x86_64.c
+++ b/arch/x86_64/core/x86_64.c
@@ -32,7 +32,7 @@ void z_new_thread(struct k_thread *t, k_thread_stack_t *stack,
 	char *base = K_THREAD_STACK_BUFFER(stack);
 	char *top = base + sz;
 
-	_new_thread_init(t, base, sz, prio, opts);
+	z_new_thread_init(t, base, sz, prio, opts);
 
 	t->switch_handle = (void *)xuk_setup_stack((long) top,
 						   (void *)z_thread_entry,
@@ -46,7 +46,7 @@ void k_cpu_idle(void)
 	__asm__ volatile("sti; hlt");
 }
 
-void _unhandled_vector(int vector, int err, struct xuk_entry_frame *f)
+void z_unhandled_vector(int vector, int err, struct xuk_entry_frame *f)
 {
 	/* Yes, there are five regsiters missing.  See notes on
 	 * xuk_entry_frame/xuk_stack_frame.
@@ -62,12 +62,12 @@ void _unhandled_vector(int vector, int err, struct xuk_entry_frame *f)
 	z_NanoFatalErrorHandler(x86_64_except_reason, NULL);
 }
 
-void _isr_entry(void)
+void z_isr_entry(void)
 {
 	z_arch_curr_cpu()->nested++;
 }
 
-void *_isr_exit_restore_stack(void *interrupted)
+void *z_isr_exit_restore_stack(void *interrupted)
 {
 	bool nested = (--z_arch_curr_cpu()->nested) > 0;
 	void *next = z_get_next_switch_handle(interrupted);
@@ -139,7 +139,7 @@ void z_arch_sched_ipi(void)
 
 
 /* Called from xuk layer on actual CPU start */
-void _cpu_start(int cpu)
+void z_cpu_start(int cpu)
 {
 	xuk_set_f_ptr(cpu, &_kernel.cpus[cpu]);
 

--- a/arch/x86_64/core/xuk-stub32.c
+++ b/arch/x86_64/core/xuk-stub32.c
@@ -163,7 +163,7 @@ void cstart(unsigned int magic, unsigned int arg)
 		shared_init();
 #ifdef CONFIG_XUK_DEBUG
 		serial_init();
-		_putchar = putchar;
+		z_putchar = putchar;
 #endif
 
 		printf("Entering stub32 on boot cpu, magic %xh stack ~%xh\n",

--- a/arch/x86_64/core/xuk.c
+++ b/arch/x86_64/core/xuk.c
@@ -174,7 +174,7 @@ long _isr_c_top(unsigned long vecret, unsigned long rsp,
 	struct vhandler *h = &vector_handlers[vector];
 	struct xuk_entry_frame *frame = (void *)rsp;
 
-	_isr_entry();
+	z_isr_entry();
 
 	/* Set current priority in CR8 to the currently-serviced IRQ
 	 * and re-enable interrupts
@@ -189,7 +189,7 @@ long _isr_c_top(unsigned long vecret, unsigned long rsp,
 	if (h->fn) {
 		h->fn(h->arg, err);
 	} else {
-		_unhandled_vector(vector, err, frame);
+		z_unhandled_vector(vector, err, frame);
 	}
 
 	/* Mask interrupts to finish processing (they'll get restored
@@ -208,7 +208,7 @@ long _isr_c_top(unsigned long vecret, unsigned long rsp,
 	 * hook doesn't want to switch, it will return null and never
 	 * save the value of the pointer.
 	 */
-	return (long)_isr_exit_restore_stack((void *)(rsp - 48));
+	return (long)z_isr_exit_restore_stack((void *)(rsp - 48));
 }
 
 static long choose_isr_entry(int vector)
@@ -515,7 +515,7 @@ void _cstart64(int cpu_id)
 	}
 
 #ifdef CONFIG_XUK_DEBUG
-	_putchar = putchar;
+	z_putchar = putchar;
 #endif
 	printf("\n==\nHello from 64 bit C code on CPU%d (stack ~%xh)\n",
 	       cpu_id, (int)(long)&cpu_id);
@@ -587,8 +587,8 @@ void _cstart64(int cpu_id)
 		smp_init();
 	}
 
-	printf("Calling _cpu_start on CPU %d\n", cpu_id);
-	_cpu_start(cpu_id);
+	printf("Calling z_cpu_start on CPU %d\n", cpu_id);
+	z_cpu_start(cpu_id);
 }
 
 long xuk_setup_stack(long sp, void *fn, unsigned int eflags,

--- a/arch/x86_64/core/xuk.h
+++ b/arch/x86_64/core/xuk.h
@@ -151,22 +151,22 @@ void xuk_start_cpu(int cpu, unsigned int stack);
 /* OS CPU startup entry point, running on the stack returned by
  * init_cpu_stack()
  */
-void _cpu_start(int cpu);
+void z_cpu_start(int cpu);
 
 /* Called on receipt of an unregistered interrupt/exception.  Passes
  * the vector number and the CPU error code, if any.
  */
-void _unhandled_vector(int vector, int err, struct xuk_entry_frame *f);
+void z_unhandled_vector(int vector, int err, struct xuk_entry_frame *f);
 
 /* Called on ISR entry before nested interrupts are enabled so the OS
  * can arrange bookeeping.  Really should be exposed as an inline and
  * not a function call; cycles on interrupt entry are precious.
  */
-void _isr_entry(void);
+void z_isr_entry(void);
 
 /* Called on ISR exit to choose a next thread to run.  The argument is
  * a context pointer to the thread that was interrupted.
  */
-void *_isr_exit_restore_stack(void *interrupted);
+void *z_isr_exit_restore_stack(void *interrupted);
 
 #endif /* _XUK_H */

--- a/arch/x86_64/include/kernel_arch_func.h
+++ b/arch/x86_64/include/kernel_arch_func.h
@@ -51,7 +51,7 @@ void z_arch_irq_disable(unsigned int irq);
 void z_arch_irq_enable(unsigned int irq);
 
 /* Not a standard Zephyr function, but probably will be */
-static inline unsigned long long _arch_k_cycle_get_64(void)
+static inline unsigned long long z_arch_k_cycle_get_64(void)
 {
 	unsigned int hi, lo;
 
@@ -65,13 +65,13 @@ static inline unsigned int z_arch_k_cycle_get_32(void)
 	extern u32_t z_timer_cycle_get_32(void);
 	return z_timer_cycle_get_32();
 #else
-	return (u32_t)_arch_k_cycle_get_64();
+	return (u32_t)z_arch_k_cycle_get_64();
 #endif
 }
 
 #define z_is_in_isr() (z_arch_curr_cpu()->nested != 0)
 
-static inline void _arch_switch(void *switch_to, void **switched_from)
+static inline void z_arch_switch(void *switch_to, void **switched_from)
 {
 	xuk_switch(switch_to, switched_from);
 }

--- a/arch/xtensa/core/irq_offload.c
+++ b/arch/xtensa/core/irq_offload.c
@@ -17,7 +17,7 @@ static irq_offload_routine_t offload_routine;
 static void *offload_param;
 
 /* Called by ISR dispatcher */
-void _irq_do_offload(void *unused)
+void z_irq_do_offload(void *unused)
 {
 	ARG_UNUSED(unused);
 	offload_routine(offload_param);
@@ -26,11 +26,11 @@ void _irq_do_offload(void *unused)
 void irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	IRQ_CONNECT(CONFIG_IRQ_OFFLOAD_INTNUM, XCHAL_EXCM_LEVEL,
-		_irq_do_offload, NULL, 0);
+		z_irq_do_offload, NULL, 0);
 	z_arch_irq_disable(CONFIG_IRQ_OFFLOAD_INTNUM);
 	offload_routine = routine;
 	offload_param = parameter;
-	_xt_set_intset(BIT(CONFIG_IRQ_OFFLOAD_INTNUM));
+	z_xt_set_intset(BIT(CONFIG_IRQ_OFFLOAD_INTNUM));
 	/*
 	 * Enable the software interrupt, in case it is disabled, so that IRQ
 	 * offload is serviced.

--- a/arch/xtensa/core/thread.c
+++ b/arch/xtensa/core/thread.c
@@ -14,7 +14,7 @@
 #include <xtensa_config.h>
 #include <kernel_internal.h>
 
-extern void _xt_user_exit(void);
+extern void z_xt_user_exit(void);
 
 /*
  * @brief Initialize a new thread
@@ -57,7 +57,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	char *cpStack;
 #endif
 
-	_new_thread_init(thread, pStack, stackSize, priority, options);
+	z_new_thread_init(thread, pStack, stackSize, priority, options);
 
 #ifdef CONFIG_DEBUG
 	printk("\nstackPtr = %p, stackSize = %d\n", pStack, stackSize);
@@ -96,7 +96,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	pInitCtx->a1   = (u32_t)pInitCtx + XT_STK_FRMSZ;
 
 	/* user exception exit dispatcher */
-	pInitCtx->exit = (u32_t)_xt_user_exit;
+	pInitCtx->exit = (u32_t)z_xt_user_exit;
 
 	/* Set initial PS to int level 0, EXCM disabled, user mode.
 	 * Also set entry point argument arg.

--- a/arch/xtensa/core/xt_zephyr.S
+++ b/arch/xtensa/core/xt_zephyr.S
@@ -11,7 +11,7 @@
 	.extern _interrupt_stack
 	.extern _kernel
 #ifdef CONFIG_SYS_CLOCK_EXISTS
-	.extern _timer_int_handler
+	.extern timer_int_handler
 #endif
 	.set _interrupt_stack_top,  _interrupt_stack + CONFIG_ISR_STACK_SIZE
 
@@ -279,7 +279,7 @@ _zxt_timer_int:
 	s32i a2, sp, 4
 	s32i a3, sp, 8
 	/* TODO: movi a2, _xt_interrupt_table */
-	movi a3, _timer_int_handler
+	movi a3, timer_int_handler
 	/* TODO: l32i a2, a2, 0 */
 	callx0   a3
 	/* Restore a2 and a3. */
@@ -287,7 +287,7 @@ _zxt_timer_int:
 	l32i a3, sp, 8
 #else
 	/* TODO: movi a6, _xt_interrupt_table */
-	movi a7, _timer_int_handler
+	movi a7, timer_int_handler
 	/* TODO: l32i a6, a6, 0 */
 	callx4   a7
 #endif

--- a/arch/xtensa/core/xt_zephyr.S
+++ b/arch/xtensa/core/xt_zephyr.S
@@ -308,7 +308,7 @@ _zxt_timer_int:
  * _zxt_tick_timer_init
  * void _zxt_tick_timer_init(void)
  *
- * Initialize timer and timer interrupt handler (_xt_tick_divisor_init() has
+ * Initialize timer and timer interrupt handler (z_xt_tick_divisor_init() has
  * already been been called).
  * Callable from C (obeys ABI conventions on entry).
  *

--- a/arch/xtensa/core/xtensa-asm2.c
+++ b/arch/xtensa/core/xtensa-asm2.c
@@ -69,7 +69,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack, size_t sz,
 	/* Align downward.  The API as specified requires a runtime check. */
 	top = (char *)(((unsigned int)top) & ~3);
 
-	_new_thread_init(thread, base, sz, prio, opts);
+	z_new_thread_init(thread, base, sz, prio, opts);
 
 	thread->switch_handle = xtensa_init_stack((void *)top, entry,
 						  p1, p2, p3);

--- a/arch/xtensa/core/xtensa_context.S
+++ b/arch/xtensa/core/xtensa_context.S
@@ -283,7 +283,7 @@ _xt_context_restore:
     ret
 
 
-/* _xt_coproc_init
+/* z_xt_coproc_init
  *
  * Initializes global co-processor management data, setting all co-processors
  * to "unowned". Leaves CPENABLE as it found it (does NOT clear it).
@@ -303,15 +303,15 @@ _xt_context_restore:
  *  None.
  *
  * Obeys ABI conventions per prototype:
- *  void _xt_coproc_init(void)
+ *  void z_xt_coproc_init(void)
  */
 
 #if XCHAL_CP_NUM > 0
 
-    .global _xt_coproc_init
-    .type   _xt_coproc_init,@function
+    .global z_xt_coproc_init
+    .type   z_xt_coproc_init,@function
     .align  4
-_xt_coproc_init:
+z_xt_coproc_init:
     ENTRY0
 
     /* Initialize thread co-processor ownerships to 0 (unowned). */

--- a/arch/xtensa/core/xtensa_vectors.S
+++ b/arch/xtensa/core/xtensa_vectors.S
@@ -644,10 +644,10 @@ _xt_user_exc:
  * on entry and used to return to a thread or interrupted interrupt handler.
  */
 
-    .global     _xt_user_exit
-    .type       _xt_user_exit,@function
+    .global     z_xt_user_exit
+    .type       z_xt_user_exit,@function
     .align      4
-_xt_user_exit:
+z_xt_user_exit:
     l32i    a0, sp, XT_STK_ps       /* retrieve interruptee's PS */
     wsr     a0, PS
     l32i    a0, sp, XT_STK_pc       /* retrieve interruptee's PC */
@@ -797,7 +797,7 @@ _xt_coproc_exc:
     #if XCHAL_HAVE_WINDOWED
     s32e    a0, sp, -16                 /* for debug backtrace */
     #endif
-    movi    a0, _xt_user_exit           /* save exit point for dispatch */
+    movi    a0, z_xt_user_exit           /* save exit point for dispatch */
     s32i    a0, sp, XT_STK_exit
 
     rsr     a0, EXCCAUSE
@@ -900,7 +900,7 @@ _xt_coproc_exc:
     xchal_cpi_load_funcbody
 
     /* Restore interruptee's saved registers. */
-    /* Can omit rsync for wsr.CPENABLE here because _xt_user_exit does
+    /* Can omit rsync for wsr.CPENABLE here because z_xt_user_exit does
      * it.
      */
 .L_xt_coproc_done:
@@ -909,7 +909,7 @@ _xt_coproc_exc:
     l32i    a4,  sp, XT_STK_a4
     l32i    a3,  sp, XT_STK_a3
     l32i    a2,  sp, XT_STK_a2
-    call0   _xt_user_exit           /* return via exit dispatcher */
+    call0   z_xt_user_exit           /* return via exit dispatcher */
     /* Never returns here - call0 is used as a jump (see note at top) */
 
 .L_check_cs:
@@ -959,7 +959,7 @@ _xt_lowint1:
     s32i    a0, sp, XT_STK_pc
     rsr     a0, EXCSAVE_1           /* save interruptee's a0 */
     s32i    a0, sp, XT_STK_a0
-    movi    a0, _xt_user_exit       /* save exit point for dispatch */
+    movi    a0, z_xt_user_exit       /* save exit point for dispatch */
     s32i    a0, sp, XT_STK_exit
 
     /* Save rest of interrupt context and enter RTOS. */

--- a/arch/xtensa/include/kernel_arch_data.h
+++ b/arch/xtensa/include/kernel_arch_data.h
@@ -56,7 +56,7 @@ typedef struct _kernel_arch _kernel_arch_t;
 
 #ifdef CONFIG_USE_SWITCH
 void xtensa_switch(void *switch_to, void **switched_from);
-#define _arch_switch xtensa_switch
+#define z_arch_switch xtensa_switch
 #endif
 
 /* stacks */

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -36,7 +36,7 @@ extern void FatalErrorHandler(void);
 extern void ReservedInterruptHandler(unsigned int intNo);
 
 /* Defined in xtensa_context.S */
-extern void _xt_coproc_init(void);
+extern void z_xt_coproc_init(void);
 
 extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
 
@@ -86,7 +86,7 @@ static ALWAYS_INLINE void kernel_arch_init(void)
 	/* Initialize co-processor management for threads.
 	 * Leave CPENABLE alone.
 	 */
-	_xt_coproc_init();
+	z_xt_coproc_init();
 #endif
 
 #ifdef CONFIG_INIT_STACKS

--- a/arch/xtensa/include/tracing_arch.h
+++ b/arch/xtensa/include/tracing_arch.h
@@ -24,7 +24,7 @@ extern "C" {
  *
  * @return The key of the interrupt that is currently being processed.
  */
-static inline int _sys_current_irq_key_get(void)
+static inline int z_sys_current_irq_key_get(void)
 {
 	return 0;
 }

--- a/arch/xtensa/include/xtensa_api.h
+++ b/arch/xtensa/include/xtensa_api.h
@@ -50,7 +50,7 @@ extern void z_xt_ints_off(unsigned int mask);
 /*
  * Call this function to set the specified (s/w) interrupt.
  */
-static inline void _xt_set_intset(unsigned int arg)
+static inline void z_xt_set_intset(unsigned int arg)
 {
 	xthal_set_intset(arg);
 }

--- a/arch/xtensa/include/xtensa_timer.h
+++ b/arch/xtensa/include/xtensa_timer.h
@@ -147,7 +147,7 @@
 #if USE_INTERNAL_TIMER || (EXTERNAL_TIMER_IRQ < 0)
 #ifndef __ASSEMBLER__
 extern unsigned int _xt_tick_divisor;
-extern void _xt_tick_divisor_init(void);
+extern void z_xt_tick_divisor_init(void);
 #endif
 
 #endif // Internal/External timer

--- a/boards/posix/native_posix/board_irq.h
+++ b/boards/posix/native_posix/board_irq.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-void _isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
+void z_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
 		void *isr_param_p);
 void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
 
@@ -32,7 +32,7 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  */
 #define Z_ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 ({ \
-	_isr_declare(irq_p, 0, isr_p, isr_param_p); \
+	z_isr_declare(irq_p, 0, isr_p, isr_param_p); \
 	z_irq_priority_set(irq_p, priority_p, flags_p); \
 	irq_p; \
 })
@@ -45,7 +45,7 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  */
 #define Z_ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
 ({ \
-	_isr_declare(irq_p, ISR_FLAG_DIRECT, (void (*)(void *))isr_p, NULL); \
+	z_isr_declare(irq_p, ISR_FLAG_DIRECT, (void (*)(void *))isr_p, NULL); \
 	z_irq_priority_set(irq_p, priority_p, flags_p); \
 	irq_p; \
 })

--- a/boards/posix/native_posix/hw_models_top.c
+++ b/boards/posix/native_posix/hw_models_top.c
@@ -85,12 +85,12 @@ void hwm_set_sig_handler(void)
 	struct sigaction act;
 
 	act.sa_handler = hwm_signal_end_handler;
-	_SAFE_CALL(sigemptyset(&act.sa_mask));
+	PC_SAFE_CALL(sigemptyset(&act.sa_mask));
 
 	act.sa_flags = SA_RESETHAND;
 
-	_SAFE_CALL(sigaction(SIGTERM, &act, NULL));
-	_SAFE_CALL(sigaction(SIGINT, &act, NULL));
+	PC_SAFE_CALL(sigaction(SIGTERM, &act, NULL));
+	PC_SAFE_CALL(sigaction(SIGINT, &act, NULL));
 }
 
 

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -235,7 +235,7 @@ int posix_get_current_irq(void)
 /**
  * Configure a static interrupt.
  *
- * _isr_declare will populate the interrupt table table with the interrupt's
+ * z_isr_declare will populate the interrupt table table with the interrupt's
  * parameters, the vector table and the software ISR table.
  *
  * We additionally set the priority in the interrupt controller at
@@ -247,7 +247,7 @@ int posix_get_current_irq(void)
  * @param isr_param_p ISR parameter
  * @param flags_p IRQ options
  */
-void _isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
+void z_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
 		void *isr_param_p)
 {
 	irq_vector_table[irq_p].irq   = irq_p;
@@ -316,7 +316,7 @@ void irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	off_routine = routine;
 	off_parameter = parameter;
-	_isr_declare(OFFLOAD_SW_IRQ, 0, offload_sw_irq_handler, NULL);
+	z_isr_declare(OFFLOAD_SW_IRQ, 0, offload_sw_irq_handler, NULL);
 	z_arch_irq_enable(OFFLOAD_SW_IRQ);
 	posix_sw_set_pending_IRQ(OFFLOAD_SW_IRQ);
 	z_arch_irq_disable(OFFLOAD_SW_IRQ);

--- a/boards/posix/nrf52_bsim/board_irq.h
+++ b/boards/posix/nrf52_bsim/board_irq.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-void _isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
+void z_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
 		void *isr_param_p);
 void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
 
@@ -32,7 +32,7 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  */
 #define Z_ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 ({ \
-	_isr_declare(irq_p, 0, isr_p, isr_param_p); \
+	z_isr_declare(irq_p, 0, isr_p, isr_param_p); \
 	z_irq_priority_set(irq_p, priority_p, flags_p); \
 	irq_p; \
 })
@@ -45,7 +45,7 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  */
 #define Z_ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
 ({ \
-	_isr_declare(irq_p, ISR_FLAG_DIRECT, (void (*)(void *))isr_p, NULL); \
+	z_isr_declare(irq_p, ISR_FLAG_DIRECT, (void (*)(void *))isr_p, NULL); \
 	z_irq_priority_set(irq_p, priority_p, flags_p); \
 	irq_p; \
 })

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -298,7 +298,7 @@ int posix_get_current_irq(void)
 /**
  * Configure a static interrupt.
  *
- * _isr_declare will populate the interrupt table table with the interrupt's
+ * z_isr_declare will populate the interrupt table table with the interrupt's
  * parameters, the vector table and the software ISR table.
  *
  * We additionally set the priority in the interrupt controller at
@@ -310,7 +310,7 @@ int posix_get_current_irq(void)
  * @param isr_param_p ISR parameter
  * @param flags_p IRQ options
  */
-void _isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
+void z_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
 		void *isr_param_p)
 {
 	irq_vector_table[irq_p].irq   = irq_p;
@@ -379,7 +379,7 @@ void irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	off_routine = routine;
 	off_parameter = parameter;
-	_isr_declare(OFFLOAD_SW_IRQ, 0, offload_sw_irq_handler, NULL);
+	z_isr_declare(OFFLOAD_SW_IRQ, 0, offload_sw_irq_handler, NULL);
 	z_arch_irq_enable(OFFLOAD_SW_IRQ);
 	posix_sw_set_pending_IRQ(OFFLOAD_SW_IRQ);
 	z_arch_irq_disable(OFFLOAD_SW_IRQ);

--- a/boards/riscv32/hifive1/prci.h
+++ b/boards/riscv32/hifive1/prci.h
@@ -7,8 +7,8 @@
 #ifndef _SIFIVE_PRCI_H
 #define _SIFIVE_PRCI_H
 
-#define _REG32(p, i) (*(volatile uint32_t *) ((p) + (i)))
-#define PRCI_REG(offset) _REG32(PRCI_BASE_ADDR, offset)
+#define Z_REG32(p, i) (*(volatile uint32_t *) ((p) + (i)))
+#define PRCI_REG(offset) Z_REG32(PRCI_BASE_ADDR, offset)
 
 /* Register offsets */
 

--- a/boards/x86/arduino_101/pinmux.c
+++ b/boards/x86/arduino_101/pinmux.c
@@ -18,7 +18,7 @@
 /*
  * This is the full pinmap that we have available on the board for configuration
  * including the ball position and the various modes that can be set.  In the
- * _pinmux_defaults we do not spend any time setting values that are using mode
+ * pinmux_defaults we do not spend any time setting values that are using mode
  * A as the hardware brings up all devices by default in mode A.
  */
 
@@ -111,7 +111,7 @@
  */
 #define PINMUX_MAX_REGISTERS	5
 
-static void _pinmux_defaults(u32_t base)
+static void pinmux_defaults(u32_t base)
 {
 	u32_t mux_config[PINMUX_MAX_REGISTERS] = { 0, 0, 0, 0, 0 };
 	int i = 0;
@@ -151,9 +151,9 @@ static void _pinmux_defaults(u32_t base)
 	}
 }
 
-static inline void _pinmux_pullups(u32_t base_address)
+static inline void pinmux_pullups(u32_t base_address)
 {
-	_quark_mcu_set_mux(base_address + PINMUX_PULLUP_OFFSET, 104,
+	z_quark_mcu_set_mux(base_address + PINMUX_PULLUP_OFFSET, 104,
 			  PINMUX_PULLUP_ENABLE);
 }
 
@@ -161,8 +161,8 @@ static int pinmux_initialize(struct device *port)
 {
 	ARG_UNUSED(port);
 
-	_pinmux_defaults(PINMUX_BASE_ADDR);
-	_pinmux_pullups(PINMUX_BASE_ADDR);
+	pinmux_defaults(PINMUX_BASE_ADDR);
+	pinmux_pullups(PINMUX_BASE_ADDR);
 
 	return 0;
 }

--- a/boards/x86/galileo/pinmux.c
+++ b/boards/x86/galileo/pinmux.c
@@ -482,7 +482,7 @@ static struct mux_path _galileo_path[PINMUX_NUM_PINS * NUM_PIN_FUNCS] = {
 			     { NONE,  0, DONT_CARE, (GPIO_DIR_IN)  } } },
 };
 
-int _galileo_pinmux_set_pin(struct device *port, u8_t pin, u32_t func)
+int z_galileo_pinmux_set_pin(struct device *port, u8_t pin, u32_t func)
 {
 	struct galileo_data * const drv_data = port->driver_data;
 
@@ -576,7 +576,7 @@ int _galileo_pinmux_set_pin(struct device *port, u8_t pin, u32_t func)
 	return 0;
 }
 
-int _galileo_pinmux_get_pin(struct device *port, u32_t pin, u32_t *func)
+int z_galileo_pinmux_get_pin(struct device *port, u32_t pin, u32_t *func)
 {
 	struct galileo_data * const drv_data = port->driver_data;
 	struct pin_config *mux_config = drv_data->mux_config;
@@ -662,7 +662,7 @@ static int pinmux_set(struct device *dev,
 		return -EINVAL;
 	}
 
-	return _galileo_pinmux_set_pin(dev, pin, func);
+	return z_galileo_pinmux_set_pin(dev, pin, func);
 }
 
 static int pinmux_get(struct device *dev,
@@ -673,7 +673,7 @@ static int pinmux_get(struct device *dev,
 		return -EINVAL;
 	}
 
-	return _galileo_pinmux_get_pin(dev, pin, func);
+	return z_galileo_pinmux_get_pin(dev, pin, func);
 }
 
 static struct pinmux_driver_api api_funcs = {
@@ -733,7 +733,7 @@ static int pinmux_galileo_initialize(struct device *port)
 	 * from the above mapping as selected by the end user
 	 */
 	for (i = 0; i < PINMUX_NUM_PINS; i++) {
-		_galileo_pinmux_set_pin(port,
+		z_galileo_pinmux_set_pin(port,
 				 mux_config[i].pin_num,
 				 mux_config[i].mode);
 	}

--- a/boards/x86/galileo/pinmux_galileo.h
+++ b/boards/x86/galileo/pinmux_galileo.h
@@ -29,8 +29,8 @@ struct galileo_data {
 
 struct galileo_data galileo_pinmux_driver;
 
-int _galileo_pinmux_set_pin(struct device *port, u8_t pin, u32_t func);
+int z_galileo_pinmux_set_pin(struct device *port, u8_t pin, u32_t func);
 
-int _galileo_pinmux_get_pin(struct device *port, u32_t pin, u32_t *func);
+int z_galileo_pinmux_get_pin(struct device *port, u32_t pin, u32_t *func);
 
 #endif /* __PINMUX_GALILEO_PRIV_H */

--- a/boards/x86/quark_d2000_crb/pinmux.c
+++ b/boards/x86/quark_d2000_crb/pinmux.c
@@ -30,7 +30,7 @@
  * associated pins and ball points.
  * This is the full pinmap that we have available on the board for configuration
  * including the ball position and the various modes that can be set.  In the
- * _pinmux_defaults we do not spend any time setting values that are using mode
+ * pinmux_defaults we do not spend any time setting values that are using mode
  * A as the hardware brings up all devices by default in mode A.
  */
 	/* pin, ball, mode A, mode B,      mode C       */
@@ -64,7 +64,7 @@
 
 #define PINMUX_MAX_REGISTERS 2
 
-static void _pinmux_defaults(u32_t base)
+static void pinmux_defaults(u32_t base)
 {
 	u32_t mux_config[PINMUX_MAX_REGISTERS] = { 0, 0 };
 	int i = 0;
@@ -91,10 +91,10 @@ static int pinmux_initialize(struct device *port)
 {
 	ARG_UNUSED(port);
 
-	_pinmux_defaults(PINMUX_BASE_ADDR);
+	pinmux_defaults(PINMUX_BASE_ADDR);
 
 	/* Enable the UART RX pin to receive input */
-	_quark_mcu_set_mux(PINMUX_BASE_ADDR + PINMUX_INPUT_OFFSET, 5, 0x1);
+	z_quark_mcu_set_mux(PINMUX_BASE_ADDR + PINMUX_INPUT_OFFSET, 5, 0x1);
 
 	return 0;
 }

--- a/boards/x86/quark_se_c1000_devboard/pinmux.c
+++ b/boards/x86/quark_se_c1000_devboard/pinmux.c
@@ -19,7 +19,7 @@
 /*
  * This is the full pinmap that we have available on the board for configuration
  * including the ball position and the various modes that can be set.  In the
- * _pinmux_defaults we do not spend any time setting values that are using mode
+ * pinmux_defaults we do not spend any time setting values that are using mode
  * A as the hardware brings up all devices by default in mode A.
  */
 
@@ -100,7 +100,7 @@
  * the bit description from above
  */
 #define PINMUX_MAX_REGISTERS	5
-static void _pinmux_defaults(u32_t base)
+static void pinmux_defaults(u32_t base)
 {
 	u32_t mux_config[PINMUX_MAX_REGISTERS] = { 0, 0, 0, 0, 0};
 	int i = 0;
@@ -144,7 +144,7 @@ static int pinmux_initialize(struct device *port)
 {
 	ARG_UNUSED(port);
 
-	_pinmux_defaults(PINMUX_BASE_ADDR);
+	pinmux_defaults(PINMUX_BASE_ADDR);
 
 	return 0;
 }

--- a/boards/x86/tinytile/pinmux.c
+++ b/boards/x86/tinytile/pinmux.c
@@ -18,7 +18,7 @@
 /*
  * This is the full pinmap that we have available on the board for configuration
  * including the ball position and the various modes that can be set.  In the
- * _pinmux_defaults we do not spend any time setting values that are using mode
+ * pinmux_defaults we do not spend any time setting values that are using mode
  * A as the hardware brings up all devices by default in mode A.
  */
 
@@ -111,7 +111,7 @@
  */
 #define PINMUX_MAX_REGISTERS	5
 
-static void _pinmux_defaults(u32_t base)
+static void pinmux_defaults(u32_t base)
 {
 	u32_t mux_config[PINMUX_MAX_REGISTERS] = { 0, 0, 0, 0, 0 };
 	int i = 0;
@@ -151,9 +151,9 @@ static void _pinmux_defaults(u32_t base)
 	}
 }
 
-static inline void _pinmux_pullups(u32_t base_address)
+static inline void pinmux_pullups(u32_t base_address)
 {
-	_quark_mcu_set_mux(base_address + PINMUX_PULLUP_OFFSET, 104,
+	z_quark_mcu_set_mux(base_address + PINMUX_PULLUP_OFFSET, 104,
 			  PINMUX_PULLUP_ENABLE);
 }
 
@@ -161,8 +161,8 @@ static int pinmux_initialize(struct device *port)
 {
 	ARG_UNUSED(port);
 
-	_pinmux_defaults(PINMUX_BASE_ADDR);
-	_pinmux_pullups(PINMUX_BASE_ADDR);
+	pinmux_defaults(PINMUX_BASE_ADDR);
+	pinmux_pullups(PINMUX_BASE_ADDR);
 
 	return 0;
 }

--- a/drivers/adc/adc_context.h
+++ b/drivers/adc/adc_context.h
@@ -61,16 +61,16 @@ struct adc_context {
 
 #ifdef ADC_CONTEXT_USES_KERNEL_TIMER
 #define ADC_CONTEXT_INIT_TIMER(_data, _ctx_name) \
-	._ctx_name.timer = _K_TIMER_INITIALIZER(_data._ctx_name.timer, \
+	._ctx_name.timer = Z_TIMER_INITIALIZER(_data._ctx_name.timer, \
 						adc_context_on_timer_expired, \
 						NULL)
 #endif /* ADC_CONTEXT_USES_KERNEL_TIMER */
 
 #define ADC_CONTEXT_INIT_LOCK(_data, _ctx_name) \
-	._ctx_name.lock = _K_SEM_INITIALIZER(_data._ctx_name.lock, 0, 1)
+	._ctx_name.lock = Z_SEM_INITIALIZER(_data._ctx_name.lock, 0, 1)
 
 #define ADC_CONTEXT_INIT_SYNC(_data, _ctx_name) \
-	._ctx_name.sync = _K_SEM_INITIALIZER(_data._ctx_name.sync, 0, 1)
+	._ctx_name.sync = Z_SEM_INITIALIZER(_data._ctx_name.sync, 0, 1)
 
 
 static inline void adc_context_request_next_sampling(struct adc_context *ctx)

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -60,7 +60,7 @@ static struct {
 		u8_t hdr[4];
 	};
 } rx = {
-	.fifo = _K_FIFO_INITIALIZER(rx.fifo),
+	.fifo = Z_FIFO_INITIALIZER(rx.fifo),
 };
 
 static struct {
@@ -68,7 +68,7 @@ static struct {
 	struct net_buf *buf;
 	struct k_fifo   fifo;
 } tx = {
-	.fifo = _K_FIFO_INITIALIZER(tx.fifo),
+	.fifo = Z_FIFO_INITIALIZER(tx.fifo),
 };
 
 static struct device *h4_dev;
@@ -456,7 +456,7 @@ static const struct bt_hci_driver drv = {
 	.send		= h4_send,
 };
 
-static int _bt_uart_init(struct device *unused)
+static int bt_uart_init(struct device *unused)
 {
 	ARG_UNUSED(unused);
 
@@ -470,4 +470,4 @@ static int _bt_uart_init(struct device *unused)
 	return 0;
 }
 
-SYS_INIT(_bt_uart_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(bt_uart_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -761,7 +761,7 @@ static const struct bt_hci_driver drv = {
 	.send		= h5_queue,
 };
 
-static int _bt_uart_init(struct device *unused)
+static int bt_uart_init(struct device *unused)
 {
 	ARG_UNUSED(unused);
 
@@ -776,4 +776,4 @@ static int _bt_uart_init(struct device *unused)
 	return 0;
 }
 
-SYS_INIT(_bt_uart_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(bt_uart_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -529,7 +529,7 @@ static const struct bt_hci_driver drv = {
 	.send		= bt_spi_send,
 };
 
-static int _bt_spi_init(struct device *unused)
+static int bt_spi_init(struct device *unused)
 {
 	ARG_UNUSED(unused);
 
@@ -568,4 +568,4 @@ static int _bt_spi_init(struct device *unused)
 	return 0;
 }
 
-SYS_INIT(_bt_spi_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(bt_spi_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -213,7 +213,7 @@ static const struct bt_hci_driver drv = {
 	.send		= uc_send,
 };
 
-static int _bt_uc_init(struct device *unused)
+static int bt_uc_init(struct device *unused)
 {
 	ARG_UNUSED(unused);
 
@@ -222,7 +222,7 @@ static int _bt_uc_init(struct device *unused)
 	return 0;
 }
 
-SYS_INIT(_bt_uc_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(bt_uc_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 
 static void cmd_bt_dev_found(char *argv, int offset)
 {

--- a/drivers/clock_control/nrf_power_clock.c
+++ b/drivers/clock_control/nrf_power_clock.c
@@ -21,7 +21,7 @@ static u8_t m16src_ref;
 static u8_t m16src_grd;
 static u8_t k32src_initialized;
 
-static int _m16src_start(struct device *dev, clock_control_subsys_t sub_system)
+static int m16src_start(struct device *dev, clock_control_subsys_t sub_system)
 {
 	bool blocking;
 	u32_t imask;
@@ -103,7 +103,7 @@ hf_already_started:
 	}
 }
 
-static int _m16src_stop(struct device *dev, clock_control_subsys_t sub_system)
+static int m16src_stop(struct device *dev, clock_control_subsys_t sub_system)
 {
 	u32_t imask;
 
@@ -144,7 +144,7 @@ static int _m16src_stop(struct device *dev, clock_control_subsys_t sub_system)
 	return 0;
 }
 
-static int _k32src_start(struct device *dev, clock_control_subsys_t sub_system)
+static int k32src_start(struct device *dev, clock_control_subsys_t sub_system)
 {
 	u32_t lf_clk_src;
 	u32_t imask;
@@ -248,7 +248,7 @@ static int _k32src_start(struct device *dev, clock_control_subsys_t sub_system)
 		 */
 		nrf_clock_int_enable(NRF_CLOCK_INT_HF_STARTED_MASK);
 
-		err = _m16src_start(dev, false);
+		err = m16src_start(dev, false);
 		if (!err) {
 			NVIC_SetPendingIRQ(DT_NORDIC_NRF_CLOCK_0_IRQ_0);
 		} else {
@@ -390,7 +390,7 @@ void nrf_power_clock_isr(void *arg)
 		NRF_CLOCK->EVENTS_DONE = 0;
 
 		/* Calibration done, stop 16M Xtal. */
-		err = _m16src_stop(dev, NULL);
+		err = m16src_stop(dev, NULL);
 		__ASSERT_NO_MSG(!err || err == -EBUSY);
 
 		/* Start timer for next calibration. */
@@ -408,7 +408,7 @@ void nrf_power_clock_isr(void *arg)
 		 */
 		NRF_CLOCK->INTENSET = CLOCK_INTENSET_HFCLKSTARTED_Msk;
 
-		err = _m16src_start(dev, false);
+		err = m16src_start(dev, false);
 		if (!err) {
 			NVIC_SetPendingIRQ(DT_NORDIC_NRF_CLOCK_0_IRQ_0);
 		} else {
@@ -435,7 +435,7 @@ void nrf_power_clock_isr(void *arg)
 #endif
 }
 
-static int _clock_control_init(struct device *dev)
+static int clock_control_init(struct device *dev)
 {
 	/* TODO: Initialization will be called twice, once for 32KHz and then
 	 * for 16 MHz clock. The vector is also shared for other power related
@@ -453,26 +453,26 @@ static int _clock_control_init(struct device *dev)
 }
 
 static const struct clock_control_driver_api _m16src_clock_control_api = {
-	.on = _m16src_start,
-	.off = _m16src_stop,
+	.on = m16src_start,
+	.off = m16src_stop,
 	.get_rate = NULL,
 };
 
 DEVICE_AND_API_INIT(clock_nrf5_m16src,
 		    DT_NORDIC_NRF_CLOCK_0_LABEL "_16M",
-		    _clock_control_init, NULL, NULL, PRE_KERNEL_1,
+		    clock_control_init, NULL, NULL, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &_m16src_clock_control_api);
 
 static const struct clock_control_driver_api _k32src_clock_control_api = {
-	.on = _k32src_start,
+	.on = k32src_start,
 	.off = NULL,
 	.get_rate = NULL,
 };
 
 DEVICE_AND_API_INIT(clock_nrf5_k32src,
 		    DT_NORDIC_NRF_CLOCK_0_LABEL "_32K",
-		    _clock_control_init, NULL, NULL, PRE_KERNEL_1,
+		    clock_control_init, NULL, NULL, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &_k32src_clock_control_api);
 

--- a/drivers/clock_control/stm32_ll_clock.c
+++ b/drivers/clock_control/stm32_ll_clock.c
@@ -14,22 +14,22 @@
 #include "stm32_ll_clock.h"
 
 /* Macros to fill up prescaler values */
-#define _ahb_prescaler(v) LL_RCC_SYSCLK_DIV_ ## v
-#define ahb_prescaler(v) _ahb_prescaler(v)
+#define z_ahb_prescaler(v) LL_RCC_SYSCLK_DIV_ ## v
+#define ahb_prescaler(v) z_ahb_prescaler(v)
 
-#define _apb1_prescaler(v) LL_RCC_APB1_DIV_ ## v
-#define apb1_prescaler(v) _apb1_prescaler(v)
+#define z_apb1_prescaler(v) LL_RCC_APB1_DIV_ ## v
+#define apb1_prescaler(v) z_apb1_prescaler(v)
 
 #ifndef CONFIG_SOC_SERIES_STM32F0X
-#define _apb2_prescaler(v) LL_RCC_APB2_DIV_ ## v
-#define apb2_prescaler(v) _apb2_prescaler(v)
+#define z_apb2_prescaler(v) LL_RCC_APB2_DIV_ ## v
+#define apb2_prescaler(v) z_apb2_prescaler(v)
 #endif /* CONFIG_SOC_SERIES_STM32F0X  */
 
-#define _mco1_prescaler(v) LL_RCC_MCO1_DIV_ ## v
-#define mco1_prescaler(v) _mco1_prescaler(v)
+#define z_mco1_prescaler(v) LL_RCC_MCO1_DIV_ ## v
+#define mco1_prescaler(v) z_mco1_prescaler(v)
 
-#define _mco2_prescaler(v) LL_RCC_MCO2_DIV_ ## v
-#define mco2_prescaler(v) _mco2_prescaler(v)
+#define z_mco2_prescaler(v) LL_RCC_MCO2_DIV_ ## v
+#define mco2_prescaler(v) z_mco2_prescaler(v)
 
 /**
  * @brief fill in AHB/APB buses configuration structure

--- a/drivers/clock_control/stm32f2x_ll_clock.c
+++ b/drivers/clock_control/stm32f2x_ll_clock.c
@@ -17,11 +17,11 @@
 #ifdef CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL
 
 /* Macros to fill up division factors values */
-#define _pllm(v) LL_RCC_PLLM_DIV_ ## v
-#define pllm(v) _pllm(v)
+#define z_pllm(v) LL_RCC_PLLM_DIV_ ## v
+#define pllm(v) z_pllm(v)
 
-#define _pllp(v) LL_RCC_PLLP_DIV_ ## v
-#define pllp(v) _pllp(v)
+#define z_pllp(v) LL_RCC_PLLP_DIV_ ## v
+#define pllp(v) z_pllp(v)
 
 /**
  * @brief fill in pll configuration structure

--- a/drivers/clock_control/stm32f4x_ll_clock.c
+++ b/drivers/clock_control/stm32f4x_ll_clock.c
@@ -17,11 +17,11 @@
 #ifdef CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL
 
 /* Macros to fill up division factors values */
-#define _pllm(v) LL_RCC_PLLM_DIV_ ## v
-#define pllm(v) _pllm(v)
+#define z_pllm(v) LL_RCC_PLLM_DIV_ ## v
+#define pllm(v) z_pllm(v)
 
-#define _pllp(v) LL_RCC_PLLP_DIV_ ## v
-#define pllp(v) _pllp(v)
+#define z_pllp(v) LL_RCC_PLLP_DIV_ ## v
+#define pllp(v) z_pllp(v)
 
 /**
  * @brief fill in pll configuration structure

--- a/drivers/clock_control/stm32f7x_ll_clock.c
+++ b/drivers/clock_control/stm32f7x_ll_clock.c
@@ -15,11 +15,11 @@
 #ifdef CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL
 
 /* Macros to fill up division factors values */
-#define _pllm(v) LL_RCC_PLLM_DIV_ ## v
-#define pllm(v) _pllm(v)
+#define z_pllm(v) LL_RCC_PLLM_DIV_ ## v
+#define pllm(v) z_pllm(v)
 
-#define _pllp(v) LL_RCC_PLLP_DIV_ ## v
-#define pllp(v) _pllp(v)
+#define z_pllp(v) LL_RCC_PLLP_DIV_ ## v
+#define pllp(v) z_pllp(v)
 
 /**
  * @brief fill in pll configuration structure

--- a/drivers/clock_control/stm32l0x_ll_clock.c
+++ b/drivers/clock_control/stm32l0x_ll_clock.c
@@ -17,11 +17,11 @@
 #ifdef CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL
 
 /* Macros to fill up multiplication and division factors values */
-#define _pll_mul(v) LL_RCC_PLL_MUL_ ## v
-#define pll_mul(v) _pll_mul(v)
+#define z_pll_mul(v) LL_RCC_PLL_MUL_ ## v
+#define pll_mul(v) z_pll_mul(v)
 
-#define _pll_div(v) LL_RCC_PLL_DIV_ ## v
-#define pll_div(v) _pll_div(v)
+#define z_pll_div(v) LL_RCC_PLL_DIV_ ## v
+#define pll_div(v) z_pll_div(v)
 
 /**
  * @brief Fill PLL configuration structure

--- a/drivers/clock_control/stm32l4x_ll_clock.c
+++ b/drivers/clock_control/stm32l4x_ll_clock.c
@@ -17,11 +17,11 @@
 #ifdef CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL
 
 /* Macros to fill up division factors values */
-#define _pllm(v) LL_RCC_PLLM_DIV_ ## v
-#define pllm(v) _pllm(v)
+#define z_pllm(v) LL_RCC_PLLM_DIV_ ## v
+#define pllm(v) z_pllm(v)
 
-#define _pllr(v) LL_RCC_PLLR_DIV_ ## v
-#define pllr(v) _pllr(v)
+#define z_pllr(v) LL_RCC_PLLR_DIV_ ## v
+#define pllr(v) z_pllr(v)
 
 /**
  * @brief fill in pll configuration structure

--- a/drivers/counter/counter_imx_epit.c
+++ b/drivers/counter/counter_imx_epit.c
@@ -152,7 +152,7 @@ static const struct counter_driver_api imx_epit_driver_api = {
 
 #define COUNTER_IMX_EPIT_DEVICE(idx)					       \
 static int imx_epit_config_func_##idx(struct device *dev);		       \
-static const struct imx_epit_config imx_epit_##idx##_config = {		       \
+static const struct imx_epit_config imx_epit_##idx##z_config = {		       \
 	.info = {							       \
 			.max_top_value = COUNTER_MAX_RELOAD,		       \
 			.freq = 1U,					       \
@@ -165,7 +165,7 @@ static const struct imx_epit_config imx_epit_##idx##_config = {		       \
 static struct imx_epit_data imx_epit_##idx##_data;			       \
 DEVICE_AND_API_INIT(epit_##idx, DT_COUNTER_IMX_EPIT_##idx##_LABEL,	       \
 		    &imx_epit_config_func_##idx,			       \
-		    &imx_epit_##idx##_data, &imx_epit_##idx##_config.info,     \
+		    &imx_epit_##idx##_data, &imx_epit_##idx##z_config.info,     \
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	       \
 		    &imx_epit_driver_api);				       \
 static int imx_epit_config_func_##idx(struct device *dev)		       \

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -104,7 +104,7 @@ static int counter_nrfx_set_alarm(struct device *dev, u8_t chan_id,
 	return 0;
 }
 
-static void _disable(struct device *dev, u8_t id)
+static void disable(struct device *dev, u8_t id)
 {
 	const struct counter_nrfx_config *config = get_nrfx_config(dev);
 
@@ -114,7 +114,7 @@ static void _disable(struct device *dev, u8_t id)
 
 static int counter_nrfx_cancel_alarm(struct device *dev, u8_t chan_id)
 {
-	_disable(dev, chan_id);
+	disable(dev, chan_id);
 
 	return 0;
 }
@@ -164,7 +164,7 @@ static void alarm_event_handler(struct device *dev, u32_t id)
 
 	cc_val = nrf_rtc_cc_get(config->rtc.p_reg, ID_TO_CC(id));
 
-	_disable(dev, id);
+	disable(dev, id);
 	clbk(dev, id, cc_val, config->ch_data[id].user_data);
 }
 
@@ -262,7 +262,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 	static struct counter_nrfx_ch_data				       \
 		counter##idx##_ch_data[CC_TO_ID(RTC##idx##_CC_NUM)];	       \
 	LOG_INSTANCE_REGISTER(LOG_MODULE_NAME, idx, CONFIG_COUNTER_LOG_LEVEL); \
-	static const struct counter_nrfx_config nrfx_counter_##idx##_config = {\
+	static const struct counter_nrfx_config nrfx_counter_##idx##z_config = {\
 		.info = {						       \
 			.max_top_value = COUNTER_MAX_TOP_VALUE,		       \
 			.freq = RTC_CLOCK /				       \
@@ -278,7 +278,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 			    DT_NORDIC_NRF_RTC_RTC_##idx##_LABEL,	       \
 			    counter_##idx##_init,			       \
 			    &counter_##idx##_data,			       \
-			    &nrfx_counter_##idx##_config.info,		       \
+			    &nrfx_counter_##idx##z_config.info,		       \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \
 			    &counter_nrfx_driver_api)
 

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -140,7 +140,7 @@ static int counter_nrfx_set_alarm(struct device *dev, u8_t chan_id,
 	return 0;
 }
 
-static void _disable(struct device *dev, u8_t id)
+static void disable(struct device *dev, u8_t id)
 {
 	const struct counter_nrfx_config *config = get_nrfx_config(dev);
 
@@ -150,7 +150,7 @@ static void _disable(struct device *dev, u8_t id)
 
 static int counter_nrfx_cancel_alarm(struct device *dev, u8_t chan_id)
 {
-	_disable(dev, chan_id);
+	disable(dev, chan_id);
 
 	return 0;
 }
@@ -201,7 +201,7 @@ static void alarm_event_handler(struct device *dev, u32_t id)
 	}
 
 	cc_val = nrfx_timer_capture_get(&config->timer, ID_TO_CC(id));
-	_disable(dev, id);
+	disable(dev, id);
 	clbk(dev, id, cc_val, config->ch_data[id].user_data);
 }
 
@@ -271,7 +271,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 	static struct counter_nrfx_ch_data				       \
 		counter##idx##_ch_data[CC_TO_ID(TIMER##idx##_CC_NUM)];	       \
 	LOG_INSTANCE_REGISTER(LOG_MODULE_NAME, idx, CONFIG_COUNTER_LOG_LEVEL); \
-	static const struct counter_nrfx_config nrfx_counter_##idx##_config = {\
+	static const struct counter_nrfx_config nrfx_counter_##idx##z_config = {\
 		.info = {						       \
 			.max_top_value = (TIMER##idx##_MAX_SIZE == 32) ?       \
 					0xffffffff : 0x0000ffff,	       \
@@ -288,7 +288,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 			    DT_NORDIC_NRF_TIMER_TIMER_##idx##_LABEL,	       \
 			    counter_##idx##_init,			       \
 			    &counter_##idx##_data,			       \
-			    &nrfx_counter_##idx##_config.info,		       \
+			    &nrfx_counter_##idx##z_config.info,		       \
 			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \
 			    &counter_nrfx_driver_api)
 

--- a/drivers/display/grove_lcd_rgb.c
+++ b/drivers/display/grove_lcd_rgb.c
@@ -85,7 +85,7 @@ static u8_t color_define[][3] = {
 /********************************************
  *  PRIVATE FUNCTIONS
  *******************************************/
-static void _rgb_reg_set(struct device * const i2c, u8_t addr, u8_t dta)
+static void rgb_reg_set(struct device * const i2c, u8_t addr, u8_t dta)
 {
 	u8_t data[2] = { addr, dta };
 
@@ -93,7 +93,7 @@ static void _rgb_reg_set(struct device * const i2c, u8_t addr, u8_t dta)
 }
 
 
-static inline void _sleep(u32_t sleep_in_ms)
+static inline void sleep(u32_t sleep_in_ms)
 {
 	k_busy_wait(SLEEP_IN_US(sleep_in_ms));
 }
@@ -147,7 +147,7 @@ void glcd_clear(struct device *port)
 
 	i2c_write(dev->i2c, clear, sizeof(clear), rom->lcd_addr);
 	LOG_DBG("clear, delay 20 ms");
-	_sleep(20);
+	sleep(20);
 }
 
 
@@ -164,7 +164,7 @@ void glcd_display_state_set(struct device *port, u8_t opt)
 	i2c_write(dev->i2c, data, sizeof(data), rom->lcd_addr);
 
 	LOG_DBG("set display_state options, delay 5 ms");
-	_sleep(5);
+	sleep(5);
 }
 
 
@@ -215,9 +215,9 @@ void glcd_color_set(struct device *port, u8_t r, u8_t g, u8_t b)
 {
 	struct glcd_data * const dev = port->driver_data;
 
-	_rgb_reg_set(dev->i2c, REGISTER_R, r);
-	_rgb_reg_set(dev->i2c, REGISTER_G, g);
-	_rgb_reg_set(dev->i2c, REGISTER_B, b);
+	rgb_reg_set(dev->i2c, REGISTER_R, r);
+	rgb_reg_set(dev->i2c, REGISTER_G, g);
+	rgb_reg_set(dev->i2c, REGISTER_B, b);
 }
 
 
@@ -233,7 +233,7 @@ void glcd_function_set(struct device *port, u8_t opt)
 	i2c_write(dev->i2c, data, sizeof(data), rom->lcd_addr);
 
 	LOG_DBG("set function options, delay 5 ms");
-	_sleep(5);
+	sleep(5);
 }
 
 
@@ -288,7 +288,7 @@ int glcd_initialize(struct device *port)
 	 * VDD to power on, so pause a little here, 30 ms min, so we go 50
 	 */
 	LOG_DBG("delay 50 ms while the VDD powers on");
-	_sleep(50);
+	sleep(50);
 
 	/* Configure everything for the display function first */
 	cmd = GLCD_CMD_FUNCTION_SET | GLCD_FS_ROWS_2;
@@ -309,15 +309,15 @@ int glcd_initialize(struct device *port)
 
 	/* Now power on the background RGB control */
 	LOG_INF("configuring the RGB background");
-	_rgb_reg_set(dev->i2c, 0x00, 0x00);
-	_rgb_reg_set(dev->i2c, 0x01, 0x05);
-	_rgb_reg_set(dev->i2c, 0x08, 0xAA);
+	rgb_reg_set(dev->i2c, 0x00, 0x00);
+	rgb_reg_set(dev->i2c, 0x01, 0x05);
+	rgb_reg_set(dev->i2c, 0x08, 0xAA);
 
 	/* Now set the background color to white */
 	LOG_DBG("background set to white");
-	_rgb_reg_set(dev->i2c, REGISTER_R, color_define[GROVE_RGB_WHITE][0]);
-	_rgb_reg_set(dev->i2c, REGISTER_G, color_define[GROVE_RGB_WHITE][1]);
-	_rgb_reg_set(dev->i2c, REGISTER_B, color_define[GROVE_RGB_WHITE][2]);
+	rgb_reg_set(dev->i2c, REGISTER_R, color_define[GROVE_RGB_WHITE][0]);
+	rgb_reg_set(dev->i2c, REGISTER_G, color_define[GROVE_RGB_WHITE][1]);
+	rgb_reg_set(dev->i2c, REGISTER_B, color_define[GROVE_RGB_WHITE][2]);
 
 	return 0;
 }

--- a/drivers/display/mb_display.c
+++ b/drivers/display/mb_display.c
@@ -326,7 +326,7 @@ static void clear_display(struct k_timer *timer)
 }
 
 static struct mb_display display = {
-	.timer = _K_TIMER_INITIALIZER(display.timer, show_row, clear_display),
+	.timer = Z_TIMER_INITIALIZER(display.timer, show_row, clear_display),
 };
 
 static void start_scroll(struct mb_display *disp, s32_t duration)

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -751,9 +751,9 @@ static struct eth_enc28j60_runtime eth_enc28j60_0_runtime = {
 		DT_MICROCHIP_ENC28J60_0_LOCAL_MAC_ADDRESS_4,
 		DT_MICROCHIP_ENC28J60_0_LOCAL_MAC_ADDRESS_5
 	},
-	.tx_rx_sem = _K_SEM_INITIALIZER(eth_enc28j60_0_runtime.tx_rx_sem,
+	.tx_rx_sem = Z_SEM_INITIALIZER(eth_enc28j60_0_runtime.tx_rx_sem,
 					1,  UINT_MAX),
-	.int_sem  = _K_SEM_INITIALIZER(eth_enc28j60_0_runtime.int_sem,
+	.int_sem  = Z_SEM_INITIALIZER(eth_enc28j60_0_runtime.int_sem,
 				       0, UINT_MAX),
 };
 

--- a/drivers/flash/flash_page_layout.c
+++ b/drivers/flash/flash_page_layout.c
@@ -6,7 +6,7 @@
 
 #include <flash.h>
 
-static int _flash_get_page_info(struct device *dev, off_t offs,
+static int flash_get_page_info(struct device *dev, off_t offs,
 				   bool use_addr, struct flash_pages_info *info)
 {
 	const struct flash_driver_api *api = dev->driver_api;
@@ -55,13 +55,13 @@ static int _flash_get_page_info(struct device *dev, off_t offs,
 int z_impl_flash_get_page_info_by_offs(struct device *dev, off_t offs,
 				      struct flash_pages_info *info)
 {
-	return _flash_get_page_info(dev, offs, true, info);
+	return flash_get_page_info(dev, offs, true, info);
 }
 
 int z_impl_flash_get_page_info_by_idx(struct device *dev, u32_t page_index,
 				     struct flash_pages_info *info)
 {
-	return _flash_get_page_info(dev, page_index, false, info);
+	return flash_get_page_info(dev, page_index, false, info);
 }
 
 size_t z_impl_flash_get_page_count(struct device *dev)

--- a/drivers/gpio/gpio_atmel_sam3.c
+++ b/drivers/gpio/gpio_atmel_sam3.c
@@ -33,7 +33,7 @@ struct gpio_sam3_runtime {
 	sys_slist_t		cb;
 };
 
-static void _config(struct device *dev, u32_t mask, int flags)
+static void config(struct device *dev, u32_t mask, int flags)
 {
 	const struct gpio_sam3_config *cfg = dev->config->config_info;
 
@@ -101,10 +101,10 @@ static int gpio_sam3_config(struct device *dev, int access_op,
 {
 	switch (access_op) {
 	case GPIO_ACCESS_BY_PIN:
-		_config(dev, BIT(pin), flags);
+		config(dev, BIT(pin), flags);
 		break;
 	case GPIO_ACCESS_BY_PORT:
-		_config(dev, (0xFFFFFFFF), flags);
+		config(dev, (0xFFFFFFFF), flags);
 		break;
 	default:
 		return -ENOTSUP;
@@ -193,7 +193,7 @@ static void gpio_sam3_isr(void *arg)
 
 	int_stat = cfg->port->PIO_ISR;
 
-	_gpio_fire_callbacks(&context->cb, dev, int_stat);
+	gpio_fire_callbacks(&context->cb, dev, int_stat);
 }
 
 static int gpio_sam3_manage_callback(struct device *dev,
@@ -202,7 +202,7 @@ static int gpio_sam3_manage_callback(struct device *dev,
 {
 	struct gpio_sam3_runtime *context = dev->driver_data;
 
-	return _gpio_manage_callback(&context->cb, callback, set);
+	return gpio_manage_callback(&context->cb, callback, set);
 }
 
 static int gpio_sam3_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_cc2650.c
+++ b/drivers/gpio/gpio_cc2650.c
@@ -200,7 +200,7 @@ static void gpio_cc2650_isr(void *arg)
 
 	sys_write32(evflags | call_mask, evflags31_0);
 
-	_gpio_fire_callbacks(&data->callbacks, dev, call_mask);
+	gpio_fire_callbacks(&data->callbacks, dev, call_mask);
 }
 
 
@@ -297,7 +297,7 @@ static int gpio_cc2650_manage_callback(struct device *port,
 {
 	struct gpio_cc2650_data *data = port->driver_data;
 
-	return _gpio_manage_callback(&data->callbacks, callback, set);
+	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 static int gpio_cc2650_enable_callback(struct device *port,

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -129,7 +129,7 @@ static int gpio_cc32xx_manage_callback(struct device *dev,
 {
 	struct gpio_cc32xx_data *data = DEV_DATA(dev);
 
-	return _gpio_manage_callback(&data->callbacks, callback, set);
+	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 
@@ -179,7 +179,7 @@ static void gpio_cc32xx_port_isr(void *arg)
 	MAP_GPIOIntClear(config->port_base, int_status);
 
 	/* Call the registered callbacks */
-	_gpio_fire_callbacks(&data->callbacks, (struct device *)dev,
+	gpio_fire_callbacks(&data->callbacks, (struct device *)dev,
 			     enabled_int);
 
 	/* Re-enable the interrupts */

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -209,7 +209,7 @@ static void gpio_cmsdk_ahb_isr(void *arg)
 
 	int_stat = cfg->port->intstatus;
 
-	_gpio_fire_callbacks(&data->gpio_cb, dev, int_stat);
+	gpio_fire_callbacks(&data->gpio_cb, dev, int_stat);
 
 	/* clear the port interrupts */
 	cfg->port->intclear = 0xFFFFFFFF;
@@ -221,7 +221,7 @@ static int gpio_cmsdk_ahb_manage_callback(struct device *dev,
 {
 	struct gpio_cmsdk_ahb_dev_data *data = dev->driver_data;
 
-	return _gpio_manage_callback(&data->gpio_cb, callback, set);
+	return gpio_manage_callback(&data->gpio_cb, callback, set);
 }
 
 static int gpio_cmsdk_ahb_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -79,7 +79,7 @@ static void dw_set_bit(u32_t base_addr, u32_t offset,
 #endif
 
 #ifdef CONFIG_GPIO_DW_CLOCK_GATE
-static inline void _gpio_dw_clock_config(struct device *port)
+static inline void gpio_dw_clock_config(struct device *port)
 {
 	char *drv = CONFIG_GPIO_DW_CLOCK_GATE_DRV_NAME;
 	struct device *clk;
@@ -92,7 +92,7 @@ static inline void _gpio_dw_clock_config(struct device *port)
 	}
 }
 
-static inline void _gpio_dw_clock_on(struct device *port)
+static inline void gpio_dw_clock_on(struct device *port)
 {
 	const struct gpio_dw_config *config = port->config->config_info;
 	struct gpio_dw_runtime *context = port->driver_data;
@@ -100,7 +100,7 @@ static inline void _gpio_dw_clock_on(struct device *port)
 	clock_control_on(context->clock, config->clock_data);
 }
 
-static inline void _gpio_dw_clock_off(struct device *port)
+static inline void gpio_dw_clock_off(struct device *port)
 {
 	const struct gpio_dw_config *config = port->config->config_info;
 	struct gpio_dw_runtime *context = port->driver_data;
@@ -108,9 +108,9 @@ static inline void _gpio_dw_clock_off(struct device *port)
 	clock_control_off(context->clock, config->clock_data);
 }
 #else
-#define _gpio_dw_clock_config(...)
-#define _gpio_dw_clock_on(...)
-#define _gpio_dw_clock_off(...)
+#define gpio_dw_clock_config(...)
+#define gpio_dw_clock_on(...)
+#define gpio_dw_clock_off(...)
 #endif
 
 #ifdef CONFIG_SOC_QUARK_SE_C1000_SS
@@ -291,7 +291,7 @@ static inline int gpio_dw_manage_callback(struct device *port,
 {
 	struct gpio_dw_runtime *context = port->driver_data;
 
-	return _gpio_manage_callback(&context->callbacks, callback, set);
+	return gpio_manage_callback(&context->callbacks, callback, set);
 }
 
 static inline int gpio_dw_enable_callback(struct device *port, int access_op,
@@ -345,7 +345,7 @@ static u32_t gpio_dw_get_power_state(struct device *port)
 
 static inline int gpio_dw_suspend_port(struct device *port)
 {
-	_gpio_dw_clock_off(port);
+	gpio_dw_clock_off(port);
 	gpio_dw_set_power_state(port, DEVICE_PM_SUSPEND_STATE);
 
 	return 0;
@@ -353,7 +353,7 @@ static inline int gpio_dw_suspend_port(struct device *port)
 
 static inline int gpio_dw_resume_from_suspend_port(struct device *port)
 {
-	_gpio_dw_clock_on(port);
+	gpio_dw_clock_on(port);
 	gpio_dw_set_power_state(port, DEVICE_PM_ACTIVE_STATE);
 	return 0;
 }
@@ -422,7 +422,7 @@ static void gpio_dw_isr(void *arg)
 
 	dw_write(base_addr, PORTA_EOI, int_status);
 
-	_gpio_fire_callbacks(&context->callbacks, port, int_status);
+	gpio_fire_callbacks(&context->callbacks, port, int_status);
 }
 
 static const struct gpio_driver_api api_funcs = {
@@ -481,7 +481,7 @@ static int gpio_dw_initialize(struct device *port)
 		/* interrupts in sync with system clock */
 		dw_set_bit(base_addr, INT_CLOCK_SYNC, LS_SYNC_POS, 1);
 
-		_gpio_dw_clock_config(port);
+		gpio_dw_clock_config(port);
 
 		/* mask and disable interrupts */
 		dw_write(base_addr, INTMASK, ~(0));

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -210,7 +210,7 @@ static int gpio_esp32_manage_callback(struct device *dev,
 {
 	struct gpio_esp32_data *data = dev->driver_data;
 
-	return _gpio_manage_callback(&data->cb, callback, set);
+	return gpio_manage_callback(&data->cb, callback, set);
 }
 
 static int gpio_esp32_enable_callback(struct device *dev,
@@ -247,7 +247,7 @@ static void gpio_esp32_fire_callbacks(struct device *device)
 	u32_t values = *data->port.irq.status_reg;
 
 	if (values & data->cb_pins) {
-		_gpio_fire_callbacks(&data->cb, device, values);
+		gpio_fire_callbacks(&data->cb, device, values);
 	}
 
 	*data->port.irq.ack_reg = values;

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -192,7 +192,7 @@ static int gpio_gecko_manage_callback(struct device *dev,
 {
 	struct gpio_gecko_data *data = dev->driver_data;
 
-	return _gpio_manage_callback(&data->callbacks, callback, set);
+	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 static int gpio_gecko_enable_callback(struct device *dev,
@@ -244,7 +244,7 @@ static void gpio_gecko_common_isr(void *arg)
 		enabled_int = int_status & port_data->pin_callback_enables;
 		int_status &= ~enabled_int;
 
-		_gpio_fire_callbacks(&port_data->callbacks, port_dev,
+		gpio_fire_callbacks(&port_data->callbacks, port_dev,
 				     enabled_int);
 	}
 	/* Clear the pending interrupts */

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -109,7 +109,7 @@ static int imx_gpio_manage_callback(struct device *dev,
 {
 	struct imx_gpio_data *data = dev->driver_data;
 
-	return _gpio_manage_callback(&data->callbacks, callback, set);
+	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 static int imx_gpio_enable_callback(struct device *dev,
@@ -163,7 +163,7 @@ static void imx_gpio_port_isr(void *arg)
 	int_flags = GPIO_ISR_REG(config->base);
 	enabled_int = int_flags & data->pin_callback_enables;
 
-	_gpio_fire_callbacks(&data->callbacks, dev, enabled_int);
+	gpio_fire_callbacks(&data->callbacks, dev, enabled_int);
 
 	GPIO_ISR_REG(config->base) = enabled_int;
 }

--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -360,7 +360,7 @@ static int gpio_intel_apl_manage_callback(struct device *dev,
 {
 	struct gpio_intel_apl_data *data = dev->driver_data;
 
-	return _gpio_manage_callback(&data->cb, callback, set);
+	return gpio_manage_callback(&data->cb, callback, set);
 }
 
 static int gpio_intel_apl_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -179,7 +179,7 @@ static int gpio_mcux_manage_callback(struct device *dev,
 {
 	struct gpio_mcux_data *data = dev->driver_data;
 
-	return _gpio_manage_callback(&data->callbacks, callback, set);
+	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 static int gpio_mcux_enable_callback(struct device *dev,
@@ -220,7 +220,7 @@ static void gpio_mcux_port_isr(void *arg)
 	int_status = config->port_base->ISFR;
 	enabled_int = int_status & data->pin_callback_enables;
 
-	_gpio_fire_callbacks(&data->callbacks, dev, enabled_int);
+	gpio_fire_callbacks(&data->callbacks, dev, enabled_int);
 
 	/* Clear the port interrupts */
 	config->port_base->ISFR = 0xFFFFFFFF;

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -107,7 +107,7 @@ static int mcux_igpio_manage_callback(struct device *dev,
 {
 	struct mcux_igpio_data *data = dev->driver_data;
 
-	return _gpio_manage_callback(&data->callbacks, callback, set);
+	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 static int mcux_igpio_enable_callback(struct device *dev,
@@ -154,7 +154,7 @@ static void mcux_igpio_port_isr(void *arg)
 	int_flags = GPIO_PortGetInterruptFlags(config->base);
 	enabled_int = int_flags & data->pin_callback_enables;
 
-	_gpio_fire_callbacks(&data->callbacks, dev, enabled_int);
+	gpio_fire_callbacks(&data->callbacks, dev, enabled_int);
 
 	GPIO_ClearPinsInterruptFlags(config->base, enabled_int);
 }

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -257,7 +257,7 @@ static int gpio_nrfx_manage_callback(struct device *port,
 				     struct gpio_callback *callback,
 				     bool set)
 {
-	return _gpio_manage_callback(&get_port_data(port)->callbacks,
+	return gpio_manage_callback(&get_port_data(port)->callbacks,
 				     callback, set);
 }
 
@@ -400,7 +400,7 @@ static u32_t check_level_trigger_pins(struct device *port)
 
 static inline void fire_callbacks(struct device *port, u32_t pins)
 {
-	_gpio_fire_callbacks(&get_port_data(port)->callbacks, port, pins);
+	gpio_fire_callbacks(&get_port_data(port)->callbacks, port, pins);
 }
 
 #ifdef CONFIG_GPIO_NRF_P0

--- a/drivers/gpio/gpio_pcal9535a.c
+++ b/drivers/gpio/gpio_pcal9535a.c
@@ -54,7 +54,7 @@ LOG_MODULE_REGISTER(gpio_pcal9535a);
  * @param dev Device struct.
  * @return 1 if I2C master is identified, 0 if not.
  */
-static inline int _has_i2c_master(struct device *dev)
+static inline int has_i2c_master(struct device *dev)
 {
 	struct gpio_pcal9535a_drv_data * const drv_data =
 		(struct gpio_pcal9535a_drv_data * const)dev->driver_data;
@@ -77,7 +77,7 @@ static inline int _has_i2c_master(struct device *dev)
  *
  * @return 0 if successful, failed otherwise.
  */
-static int _read_port_regs(struct device *dev, u8_t reg,
+static int read_port_regs(struct device *dev, u8_t reg,
 			   union gpio_pcal9535a_port_data *buf)
 {
 	const struct gpio_pcal9535a_config * const config =
@@ -113,7 +113,7 @@ error:
  *
  * @return 0 if successful, failed otherwise.
  */
-static int _write_port_regs(struct device *dev, u8_t reg,
+static int write_port_regs(struct device *dev, u8_t reg,
 			    union gpio_pcal9535a_port_data *buf)
 {
 	const struct gpio_pcal9535a_config * const config =
@@ -147,7 +147,7 @@ static int _write_port_regs(struct device *dev, u8_t reg,
  *
  * @return 0 if successful, failed otherwise
  */
-static int _setup_pin_dir(struct device *dev, int access_op,
+static int setup_pin_dir(struct device *dev, int access_op,
 			  u32_t pin, int flags)
 {
 	struct gpio_pcal9535a_drv_data * const drv_data =
@@ -183,7 +183,7 @@ static int _setup_pin_dir(struct device *dev, int access_op,
 		goto done;
 	}
 
-	ret = _write_port_regs(dev, REG_CONF_PORT0, port);
+	ret = write_port_regs(dev, REG_CONF_PORT0, port);
 
 done:
 	return ret;
@@ -199,7 +199,7 @@ done:
  *
  * @return 0 if successful, failed otherwise
  */
-static int _setup_pin_pullupdown(struct device *dev, int access_op,
+static int setup_pin_pullupdown(struct device *dev, int access_op,
 				 u32_t pin, int flags)
 {
 	struct gpio_pcal9535a_drv_data * const drv_data =
@@ -244,7 +244,7 @@ static int _setup_pin_pullupdown(struct device *dev, int access_op,
 		goto done;
 	}
 
-	ret = _write_port_regs(dev, REG_PUD_SEL_PORT0, port);
+	ret = write_port_regs(dev, REG_PUD_SEL_PORT0, port);
 	if (ret) {
 		goto done;
 	}
@@ -276,7 +276,7 @@ en_dis:
 		goto done;
 	}
 
-	ret = _write_port_regs(dev, REG_PUD_EN_PORT0, port);
+	ret = write_port_regs(dev, REG_PUD_EN_PORT0, port);
 
 done:
 	return ret;
@@ -292,7 +292,7 @@ done:
  *
  * @return 0 if successful, failed otherwise
  */
-static int _setup_pin_polarity(struct device *dev, int access_op,
+static int setup_pin_polarity(struct device *dev, int access_op,
 			       u32_t pin, int flags)
 {
 	struct gpio_pcal9535a_drv_data * const drv_data =
@@ -328,7 +328,7 @@ static int _setup_pin_polarity(struct device *dev, int access_op,
 		goto done;
 	}
 
-	ret = _write_port_regs(dev, REG_POL_INV_PORT0, port);
+	ret = write_port_regs(dev, REG_POL_INV_PORT0, port);
 	if (!ret) {
 		drv_data->out_pol_inv = port->all;
 	}
@@ -362,25 +362,25 @@ static int gpio_pcal9535a_config(struct device *dev, int access_op,
 		return -ENOTSUP;
 	}
 
-	if (!_has_i2c_master(dev)) {
+	if (!has_i2c_master(dev)) {
 		return -EINVAL;
 	}
 
-	ret = _setup_pin_dir(dev, access_op, pin, flags);
+	ret = setup_pin_dir(dev, access_op, pin, flags);
 	if (ret) {
 		LOG_ERR("PCAL9535A[0x%X]: error setting pin direction (%d)",
 			i2c_addr, ret);
 		goto done;
 	}
 
-	ret = _setup_pin_polarity(dev, access_op, pin, flags);
+	ret = setup_pin_polarity(dev, access_op, pin, flags);
 	if (ret) {
 		LOG_ERR("PCAL9535A[0x%X]: error setting pin polarity (%d)",
 			i2c_addr, ret);
 		goto done;
 	}
 
-	ret = _setup_pin_pullupdown(dev, access_op, pin, flags);
+	ret = setup_pin_pullupdown(dev, access_op, pin, flags);
 	if (ret) {
 		LOG_ERR("PCAL9535A[0x%X]: error setting pin pull up/down "
 			"(%d)", i2c_addr, ret);
@@ -411,7 +411,7 @@ static int gpio_pcal9535a_write(struct device *dev, int access_op,
 	u16_t new_value;
 	int ret;
 
-	if (!_has_i2c_master(dev)) {
+	if (!has_i2c_master(dev)) {
 		return -EINVAL;
 	}
 
@@ -445,7 +445,7 @@ static int gpio_pcal9535a_write(struct device *dev, int access_op,
 		goto done;
 	}
 
-	ret = _write_port_regs(dev, REG_OUTPUT_PORT0, port);
+	ret = write_port_regs(dev, REG_OUTPUT_PORT0, port);
 
 done:
 	return ret;
@@ -467,11 +467,11 @@ static int gpio_pcal9535a_read(struct device *dev, int access_op,
 	union gpio_pcal9535a_port_data buf;
 	int ret;
 
-	if (!_has_i2c_master(dev)) {
+	if (!has_i2c_master(dev)) {
 		return -EINVAL;
 	}
 
-	ret = _read_port_regs(dev, REG_INPUT_PORT0, &buf);
+	ret = read_port_regs(dev, REG_INPUT_PORT0, &buf);
 	if (ret != 0) {
 		goto done;
 	}

--- a/drivers/gpio/gpio_qmsi.c
+++ b/drivers/gpio/gpio_qmsi.c
@@ -176,7 +176,7 @@ static void gpio_qmsi_callback(void *data, u32_t status)
 	const u32_t enabled_mask = context->pin_callbacks & status;
 
 	if (enabled_mask) {
-		_gpio_fire_callbacks(&context->callbacks, port, enabled_mask);
+		gpio_fire_callbacks(&context->callbacks, port, enabled_mask);
 	}
 }
 
@@ -307,7 +307,7 @@ static inline int gpio_qmsi_manage_callback(struct device *port,
 {
 	struct gpio_qmsi_runtime *context = port->driver_data;
 
-	return _gpio_manage_callback(&context->callbacks, callback, set);
+	return gpio_manage_callback(&context->callbacks, callback, set);
 }
 
 static inline int gpio_qmsi_enable_callback(struct device *port,

--- a/drivers/gpio/gpio_qmsi_ss.c
+++ b/drivers/gpio/gpio_qmsi_ss.c
@@ -145,7 +145,7 @@ static void ss_gpio_qmsi_callback(void *data, uint32_t status)
 	const u32_t enabled_mask = context->pin_callbacks & status;
 
 	if (enabled_mask) {
-		_gpio_fire_callbacks(&context->callbacks, port, enabled_mask);
+		gpio_fire_callbacks(&context->callbacks, port, enabled_mask);
 	}
 }
 
@@ -296,7 +296,7 @@ static inline int ss_gpio_qmsi_manage_callback(struct device *port,
 {
 	struct ss_gpio_qmsi_runtime *context = port->driver_data;
 
-	return _gpio_manage_callback(&context->callbacks, callback, set);
+	return gpio_manage_callback(&context->callbacks, callback, set);
 }
 
 static inline int ss_gpio_qmsi_enable_callback(struct device *port,

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -179,7 +179,7 @@ static int gpio_rv32m1_manage_callback(struct device *dev,
 {
 	struct gpio_rv32m1_data *data = dev->driver_data;
 
-	_gpio_manage_callback(&data->callbacks, callback, set);
+	gpio_manage_callback(&data->callbacks, callback, set);
 
 	return 0;
 }
@@ -222,7 +222,7 @@ static void gpio_rv32m1_port_isr(void *arg)
 	int_status = config->port_base->ISFR;
 	enabled_int = int_status & data->pin_callback_enables;
 
-	_gpio_fire_callbacks(&data->callbacks, dev, enabled_int);
+	gpio_fire_callbacks(&data->callbacks, dev, enabled_int);
 
 	/* Clear the port interrupts */
 	config->port_base->ISFR = 0xFFFFFFFF;

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -193,7 +193,7 @@ static void gpio_sam_isr(void *arg)
 
 	int_stat = pio->PIO_ISR;
 
-	_gpio_fire_callbacks(&context->cb, dev, int_stat);
+	gpio_fire_callbacks(&context->cb, dev, int_stat);
 }
 
 static int gpio_sam_manage_callback(struct device *port,
@@ -202,7 +202,7 @@ static int gpio_sam_manage_callback(struct device *port,
 {
 	struct gpio_sam_runtime *context = port->driver_data;
 
-	return _gpio_manage_callback(&context->cb, callback, set);
+	return gpio_manage_callback(&context->cb, callback, set);
 }
 
 static int gpio_sam_enable_callback(struct device *port,

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -72,7 +72,7 @@ static void gpio_sifive_irq_handler(void *arg)
 			 (cfg->gpio_irq_base - RISCV_MAX_GENERIC_IRQ));
 
 	/* Call the corresponding callback registered for the pin */
-	_gpio_fire_callbacks(&data->cb, dev, pin_mask);
+	gpio_fire_callbacks(&data->cb, dev, pin_mask);
 
 	/*
 	 * Write to either the rise_ip, fall_ip, high_ip or low_ip registers
@@ -274,7 +274,7 @@ static int gpio_sifive_manage_callback(struct device *dev,
 {
 	struct gpio_sifive_data *data = DEV_GPIO_DATA(dev);
 
-	return _gpio_manage_callback(&data->cb, callback, set);
+	return gpio_manage_callback(&data->cb, callback, set);
 }
 
 static int gpio_sifive_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -66,7 +66,7 @@ static void gpio_stellaris_isr(void *arg)
 	u32_t base = cfg->base;
 	u32_t int_stat = sys_read32(GPIO_REG_ADDR(base, GPIO_MIS_OFFSET));
 
-	_gpio_fire_callbacks(&context->cb, dev, int_stat);
+	gpio_fire_callbacks(&context->cb, dev, int_stat);
 
 	sys_write32(int_stat, GPIO_REG_ADDR(base, GPIO_ICR_OFFSET));
 }
@@ -214,7 +214,7 @@ static int gpio_stellaris_manage_callback(struct device *dev,
 {
 	struct gpio_stellaris_runtime *context = DEV_DATA(dev);
 
-	_gpio_manage_callback(&context->cb, callback, set);
+	gpio_manage_callback(&context->cb, callback, set);
 
 	return 0;
 }

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -32,7 +32,7 @@ static void gpio_stm32_isr(int line, void *arg)
 	struct gpio_stm32_data *data = dev->driver_data;
 
 	if ((BIT(line) & data->cb_pins) != 0) {
-		_gpio_fire_callbacks(&data->cb, dev, BIT(line));
+		gpio_fire_callbacks(&data->cb, dev, BIT(line));
 	}
 }
 
@@ -340,7 +340,7 @@ static int gpio_stm32_manage_callback(struct device *dev,
 {
 	struct gpio_stm32_data *data = dev->driver_data;
 
-	return _gpio_manage_callback(&data->cb, callback, set);
+	return gpio_manage_callback(&data->cb, callback, set);
 }
 
 static int gpio_stm32_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -363,7 +363,7 @@ static const struct gpio_sx1509b_config gpio_sx1509b_cfg = {
 };
 
 static struct gpio_sx1509b_drv_data gpio_sx1509b_drvdata = {
-	.lock = _K_SEM_INITIALIZER(gpio_sx1509b_drvdata.lock, 1, 1),
+	.lock = Z_SEM_INITIALIZER(gpio_sx1509b_drvdata.lock, 1, 1),
 };
 
 static const struct gpio_driver_api gpio_sx1509b_drv_api_funcs = {

--- a/drivers/gpio/gpio_utils.h
+++ b/drivers/gpio/gpio_utils.h
@@ -21,7 +21,7 @@
  *
  * @return 0 on success, negative errno otherwise.
  */
-static inline int _gpio_manage_callback(sys_slist_t *callbacks,
+static inline int gpio_manage_callback(sys_slist_t *callbacks,
 					struct gpio_callback *callback,
 					bool set)
 {
@@ -50,7 +50,7 @@ static inline int _gpio_manage_callback(sys_slist_t *callbacks,
  * @param port A pointer on the gpio driver instance
  * @param pins The actual pin mask that triggered the interrupt
  */
-static inline void _gpio_fire_callbacks(sys_slist_t *list,
+static inline void gpio_fire_callbacks(sys_slist_t *list,
 					struct device *port,
 					u32_t pins)
 {

--- a/drivers/i2c/i2c-priv.h
+++ b/drivers/i2c/i2c-priv.h
@@ -15,7 +15,7 @@ extern "C" {
 #include <dt-bindings/i2c/i2c.h>
 #include <logging/log.h>
 
-static inline u32_t _i2c_map_dt_bitrate(u32_t bitrate)
+static inline u32_t i2c_map_dt_bitrate(u32_t bitrate)
 {
 	switch (bitrate) {
 	case I2C_BITRATE_STANDARD:

--- a/drivers/i2c/i2c_cc32xx.c
+++ b/drivers/i2c/i2c_cc32xx.c
@@ -109,7 +109,7 @@ static int i2c_cc32xx_configure(struct device *dev, u32_t dev_config_raw)
 	return 0;
 }
 
-static void _i2c_cc32xx_prime_transfer(struct device *dev, struct i2c_msg *msg,
+static void i2c_cc32xx_prime_transfer(struct device *dev, struct i2c_msg *msg,
 				      u16_t addr)
 {
 	struct i2c_cc32xx_data *data = DEV_DATA(dev);
@@ -167,7 +167,7 @@ static int i2c_cc32xx_transfer(struct device *dev, struct i2c_msg *msgs,
 	for (int i = 0; i < num_msgs; i++) {
 
 		/* Begin the transfer */
-		_i2c_cc32xx_prime_transfer(dev, msgs, addr);
+		i2c_cc32xx_prime_transfer(dev, msgs, addr);
 
 		/* Wait for the transfer to complete */
 		k_sem_take(&data->transfer_complete, K_FOREVER);
@@ -188,7 +188,7 @@ static int i2c_cc32xx_transfer(struct device *dev, struct i2c_msg *msgs,
 	return retval;
 }
 
-static void _i2c_cc32xx_isr_handle_write(u32_t base,
+static void i2c_cc32xx_isr_handle_write(u32_t base,
 					 struct i2c_cc32xx_data *data)
 {
 	/* Decrement write Counter */
@@ -225,7 +225,7 @@ static void _i2c_cc32xx_isr_handle_write(u32_t base,
 	}
 }
 
-static void _i2c_cc32xx_isr_handle_read(u32_t base,
+static void i2c_cc32xx_isr_handle_read(u32_t base,
 					struct i2c_cc32xx_data *data)
 {
 
@@ -307,10 +307,10 @@ static void i2c_cc32xx_isr(void *arg)
 	/* Handle (read or write) transmit complete: */
 	} else if (int_status & (I2C_MASTER_INT_DATA | I2C_MASTER_INT_START)) {
 		if (data->state == I2C_CC32XX_WRITE_MODE) {
-			_i2c_cc32xx_isr_handle_write(base, data);
+			i2c_cc32xx_isr_handle_write(base, data);
 		}
 		if (data->state == I2C_CC32XX_READ_MODE) {
-			_i2c_cc32xx_isr_handle_read(base, data);
+			i2c_cc32xx_isr_handle_read(base, data);
 		}
 	/* Some unanticipated H/W state: */
 	} else {
@@ -347,7 +347,7 @@ static int i2c_cc32xx_init(struct device *dev)
 	HWREG(COMMON_REG_BASE) = regval;
 
 	/* Set to default configuration: */
-	bitrate_cfg = _i2c_map_dt_bitrate(config->bitrate);
+	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 	error = i2c_cc32xx_configure(dev, I2C_MODE_MASTER | bitrate_cfg);
 	if (error) {
 		return error;

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -38,7 +38,7 @@ LOG_MODULE_REGISTER(i2c_dw);
 
 #include "i2c-priv.h"
 
-static inline void _i2c_dw_data_ask(struct device *dev)
+static inline void i2c_dw_data_ask(struct device *dev)
 {
 	struct i2c_dw_dev_config * const dw = dev->driver_data;
 	u32_t data;
@@ -96,7 +96,7 @@ static inline void _i2c_dw_data_ask(struct device *dev)
 	}
 }
 
-static void _i2c_dw_data_read(struct device *dev)
+static void i2c_dw_data_read(struct device *dev)
 {
 	struct i2c_dw_dev_config * const dw = dev->driver_data;
 
@@ -123,7 +123,7 @@ static void _i2c_dw_data_read(struct device *dev)
 }
 
 
-static int _i2c_dw_data_send(struct device *dev)
+static int i2c_dw_data_send(struct device *dev)
 {
 	struct i2c_dw_dev_config * const dw = dev->driver_data;
 	u32_t data = 0U;
@@ -168,7 +168,7 @@ static int _i2c_dw_data_send(struct device *dev)
 	return 0;
 }
 
-static inline void _i2c_dw_transfer_complete(struct device *dev)
+static inline void i2c_dw_transfer_complete(struct device *dev)
 {
 	struct i2c_dw_dev_config * const dw = dev->driver_data;
 	u32_t value;
@@ -235,7 +235,7 @@ static void i2c_dw_isr(void *arg)
 
 		/* Check if the RX FIFO reached threshold */
 		if (intr_stat.bits.rx_full) {
-			_i2c_dw_data_read(port);
+			i2c_dw_data_read(port);
 		}
 
 		/* Check if the TX FIFO is ready for commands.
@@ -245,9 +245,9 @@ static void i2c_dw_isr(void *arg)
 		if (intr_stat.bits.tx_empty) {
 			if ((dw->xfr_flags & I2C_MSG_RW_MASK)
 			    == I2C_MSG_WRITE) {
-				ret = _i2c_dw_data_send(port);
+				ret = i2c_dw_data_send(port);
 			} else {
-				_i2c_dw_data_ask(port);
+				i2c_dw_data_ask(port);
 			}
 
 			/* If STOP is not expected, finish processing this
@@ -270,11 +270,11 @@ static void i2c_dw_isr(void *arg)
 	return;
 
 done:
-	_i2c_dw_transfer_complete(port);
+	i2c_dw_transfer_complete(port);
 }
 
 
-static int _i2c_dw_setup(struct device *dev, u16_t slave_address)
+static int i2c_dw_setup(struct device *dev, u16_t slave_address)
 {
 	struct i2c_dw_dev_config * const dw = dev->driver_data;
 	u32_t value;
@@ -422,7 +422,7 @@ static int i2c_dw_transfer(struct device *dev,
 
 	dw->state |= I2C_DW_BUSY;
 
-	ret = _i2c_dw_setup(dev, slave_address);
+	ret = i2c_dw_setup(dev, slave_address);
 	if (ret) {
 		dw->state = I2C_DW_STATE_READY;
 		return ret;
@@ -684,7 +684,7 @@ static int i2c_dw_initialize(struct device *dev)
 
 	rom->config_func(dev);
 
-	dw->app_config = I2C_MODE_MASTER | _i2c_map_dt_bitrate(rom->bitrate);
+	dw->app_config = I2C_MODE_MASTER | i2c_map_dt_bitrate(rom->bitrate);
 
 	if (i2c_dw_runtime_configure(dev, dw->app_config) != 0) {
 		LOG_DBG("I2C: Cannot set default configuration");

--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -168,7 +168,7 @@ static int i2c_gecko_init(struct device *dev)
 
 	i2c_gecko_config_pins(dev, &config->pin_sda, &config->pin_scl);
 
-	bitrate_cfg = _i2c_map_dt_bitrate(config->bitrate);
+	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 
 	error = i2c_gecko_configure(dev, I2C_MODE_MASTER | bitrate_cfg);
 	if (error) {

--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -335,7 +335,7 @@ static int i2c_imx_init(struct device *dev)
 
 	k_sem_init(&data->device_sync_sem, 0, UINT_MAX);
 
-	bitrate_cfg = _i2c_map_dt_bitrate(config->bitrate);
+	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 
 	error = i2c_imx_configure(dev, I2C_MODE_MASTER | bitrate_cfg);
 	if (error) {

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -234,7 +234,7 @@ static int i2c_stm32_init(struct device *dev)
 	}
 #endif /* CONFIG_SOC_SERIES_STM32F3X) || CONFIG_SOC_SERIES_STM32F0X */
 
-	bitrate_cfg = _i2c_map_dt_bitrate(cfg->bitrate);
+	bitrate_cfg = i2c_map_dt_bitrate(cfg->bitrate);
 
 	ret = i2c_stm32_runtime_configure(dev, I2C_MODE_MASTER | bitrate_cfg);
 	if (ret < 0) {

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -195,7 +195,7 @@ int i2c_stm32_slave_register(struct device *dev,
 		return -EBUSY;
 	}
 
-	bitrate_cfg = _i2c_map_dt_bitrate(cfg->bitrate);
+	bitrate_cfg = i2c_map_dt_bitrate(cfg->bitrate);
 
 	ret = i2c_stm32_runtime_configure(dev, bitrate_cfg);
 	if (ret < 0) {

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -181,7 +181,7 @@ static int i2c_mcux_init(struct device *dev)
 	I2C_MasterTransferCreateHandle(base, &data->handle,
 			i2c_mcux_master_transfer_callback, dev);
 
-	bitrate_cfg = _i2c_map_dt_bitrate(config->bitrate);
+	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 
 	error = i2c_mcux_configure(dev, I2C_MODE_MASTER | bitrate_cfg);
 	if (error) {

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -197,7 +197,7 @@ static int mcux_lpi2c_init(struct device *dev)
 	LPI2C_MasterTransferCreateHandle(base, &data->handle,
 			mcux_lpi2c_master_transfer_callback, dev);
 
-	bitrate_cfg = _i2c_map_dt_bitrate(config->bitrate);
+	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 
 	error = mcux_lpi2c_configure(dev, I2C_MODE_MASTER | bitrate_cfg);
 	if (error) {

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -175,19 +175,19 @@ static int init_twi(struct device *dev, const nrfx_twi_config_t *config)
 		return init_twi(dev, &config);				       \
 	}								       \
 	static struct i2c_nrfx_twi_data twi_##idx##_data = {		       \
-		.transfer_sync = _K_SEM_INITIALIZER(                           \
+		.transfer_sync = Z_SEM_INITIALIZER(                           \
 			twi_##idx##_data.transfer_sync, 1, 1),                 \
-		.completion_sync = _K_SEM_INITIALIZER(                         \
+		.completion_sync = Z_SEM_INITIALIZER(                         \
 			twi_##idx##_data.completion_sync, 0, 1)	               \
 	};								       \
-	static const struct i2c_nrfx_twi_config twi_##idx##_config = {	       \
+	static const struct i2c_nrfx_twi_config twi_##idx##z_config = {	       \
 		.twi = NRFX_TWI_INSTANCE(idx)				       \
 	};								       \
 	DEVICE_AND_API_INIT(twi_##idx,					       \
 			    DT_NORDIC_NRF_I2C_I2C_##idx##_LABEL,	       \
 			    twi_##idx##_init,				       \
 			    &twi_##idx##_data,				       \
-			    &twi_##idx##_config,			       \
+			    &twi_##idx##z_config,			       \
 			    POST_KERNEL,				       \
 			    CONFIG_I2C_INIT_PRIORITY,			       \
 			    &i2c_nrfx_twi_driver_api)

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -178,19 +178,19 @@ static int init_twim(struct device *dev, const nrfx_twim_config_t *config)
 		return init_twim(dev, &config);				       \
 	}								       \
 	static struct i2c_nrfx_twim_data twim_##idx##_data = {		       \
-		.transfer_sync = _K_SEM_INITIALIZER(                           \
+		.transfer_sync = Z_SEM_INITIALIZER(                           \
 			twim_##idx##_data.transfer_sync, 1, 1),                \
-		.completion_sync = _K_SEM_INITIALIZER(                         \
+		.completion_sync = Z_SEM_INITIALIZER(                         \
 			twim_##idx##_data.completion_sync, 0, 1)               \
 	};								       \
-	static const struct i2c_nrfx_twim_config twim_##idx##_config = {       \
+	static const struct i2c_nrfx_twim_config twim_##idx##z_config = {       \
 		.twim = NRFX_TWIM_INSTANCE(idx)				       \
 	};								       \
 	DEVICE_AND_API_INIT(twim_##idx,					       \
 			    DT_NORDIC_NRF_I2C_I2C_##idx##_LABEL,	       \
 			    twim_##idx##_init,				       \
 			    &twim_##idx##_data,				       \
-			    &twim_##idx##_config,			       \
+			    &twim_##idx##z_config,			       \
 			    POST_KERNEL,				       \
 			    CONFIG_I2C_INIT_PRIORITY,			       \
 			    &i2c_nrfx_twim_driver_api)

--- a/drivers/i2c/i2c_qmsi.c
+++ b/drivers/i2c/i2c_qmsi.c
@@ -313,7 +313,7 @@ static int i2c_qmsi_init(struct device *dev)
 
 	clk_periph_enable(config->clock_gate);
 
-	bitrate_cfg = _i2c_map_dt_bitrate(config->bitrate);
+	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 
 	err = i2c_qmsi_configure(dev, I2C_MODE_MASTER | bitrate_cfg);
 	if (err < 0) {

--- a/drivers/i2c/i2c_qmsi_ss.c
+++ b/drivers/i2c/i2c_qmsi_ss.c
@@ -363,7 +363,7 @@ static int i2c_qmsi_ss_init(struct device *dev)
 
 	k_sem_init(&driver_data->sem, 1, UINT_MAX);
 
-	bitrate_cfg = _i2c_map_dt_bitrate(config->bitrate);
+	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 
 	err = i2c_qmsi_ss_configure(dev, I2C_MODE_MASTER | bitrate_cfg);
 

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -315,7 +315,7 @@ static int i2c_sam_twi_initialize(struct device *dev)
 	/* Reset TWI module */
 	twi->TWI_CR = TWI_CR_SWRST;
 
-	bitrate_cfg = _i2c_map_dt_bitrate(dev_cfg->bitrate);
+	bitrate_cfg = i2c_map_dt_bitrate(dev_cfg->bitrate);
 
 	ret = i2c_sam_twi_configure(dev, I2C_MODE_MASTER | bitrate_cfg);
 	if (ret < 0) {

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -302,7 +302,7 @@ static int i2c_sam_twihs_initialize(struct device *dev)
 	/* Reset the module */
 	twihs->TWIHS_CR = TWIHS_CR_SWRST;
 
-	bitrate_cfg = _i2c_map_dt_bitrate(dev_cfg->bitrate);
+	bitrate_cfg = i2c_map_dt_bitrate(dev_cfg->bitrate);
 
 	ret = i2c_sam_twihs_configure(dev, I2C_MODE_MASTER | bitrate_cfg);
 	if (ret < 0) {

--- a/drivers/i2c/i2c_sifive.c
+++ b/drivers/i2c/i2c_sifive.c
@@ -311,7 +311,7 @@ static int i2c_sifive_init(struct device *dev)
 	u32_t dev_config = 0U;
 	int rc = 0;
 
-	dev_config = (I2C_MODE_MASTER | _i2c_map_dt_bitrate(config->f_bus));
+	dev_config = (I2C_MODE_MASTER | i2c_map_dt_bitrate(config->f_bus));
 
 	rc = i2c_sifive_configure(dev, dev_config);
 	if (rc != 0) {

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -110,8 +110,8 @@ static int i2s_stm32_enable_clock(struct device *dev)
 #define PLLI2S_MAX_MS_TIME	1 /* PLLI2S lock time is 300us max */
 static u16_t plli2s_ms_count;
 
-#define _pllr(v) LL_RCC_PLLI2SR_DIV_ ## v
-#define pllr(v) _pllr(v)
+#define z_pllr(v) LL_RCC_PLLI2SR_DIV_ ## v
+#define pllr(v) z_pllr(v)
 #endif
 
 static int i2s_stm32_set_clock(struct device *dev, u32_t bit_clk_freq)

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -50,7 +50,7 @@ static struct spi_cs_control cs_ctrl;
 /***********************
  * Debugging functions *
  **********************/
-static void _cc1200_print_status(u8_t status)
+static void cc1200_print_status(u8_t status)
 {
 	if (status == CC1200_STATUS_IDLE) {
 		LOG_DBG("Idling");
@@ -75,7 +75,7 @@ static void _cc1200_print_status(u8_t status)
  * Generic functions *
  ********************/
 
-bool _cc1200_access_reg(struct cc1200_context *ctx, bool read, u8_t addr,
+bool z_cc1200_access_reg(struct cc1200_context *ctx, bool read, u8_t addr,
 			void *data, size_t length, bool extended, bool burst)
 {
 	u8_t cmd_buf[2];
@@ -160,8 +160,8 @@ static u8_t get_status(struct cc1200_context *ctx)
 {
 	u8_t val;
 
-	if (_cc1200_access_reg(ctx, true, CC1200_INS_SNOP,
-			       &val, 1, false, false)) {
+	if (z_cc1200_access_reg(ctx, true, CC1200_INS_SNOP,
+				&val, 1, false, false)) {
 		/* See Section 3.1.2 */
 		return val & CC1200_STATUS_MASK;
 	}
@@ -239,7 +239,7 @@ static bool write_reg_freq(struct cc1200_context *ctx, u32_t freq)
 	freq_data[1] = (u8_t)((freq & 0x0000FF00) >> 8);
 	freq_data[2] = (u8_t)(freq & 0x000000FF);
 
-	return _cc1200_access_reg(ctx, false, CC1200_REG_FREQ2,
+	return z_cc1200_access_reg(ctx, false, CC1200_REG_FREQ2,
 				  freq_data, 3, true, true);
 }
 
@@ -329,13 +329,13 @@ rf_install_settings(struct device *dev,
 {
 	struct cc1200_context *cc1200 = dev->driver_data;
 
-	if (!_cc1200_access_reg(cc1200, false, CC1200_REG_SYNC3,
-				(void *)rf_settings->registers,
-				CC1200_RF_NON_EXT_SPACE_REGS, false, true) ||
-	    !_cc1200_access_reg(cc1200, false, CC1200_REG_IF_MIX_CFG,
-				(void *)rf_settings->registers +
-				CC1200_RF_NON_EXT_SPACE_REGS,
-				CC1200_RF_EXT_SPACE_REGS, true, true) ||
+	if (!z_cc1200_access_reg(cc1200, false, CC1200_REG_SYNC3,
+				 (void *)rf_settings->registers,
+				 CC1200_RF_NON_EXT_SPACE_REGS, false, true) ||
+	    !z_cc1200_access_reg(cc1200, false, CC1200_REG_IF_MIX_CFG,
+				 (void *)rf_settings->registers +
+				 CC1200_RF_NON_EXT_SPACE_REGS,
+				 CC1200_RF_EXT_SPACE_REGS, true, true) ||
 	    !write_reg_pkt_len(cc1200, 0xFF)) {
 		LOG_ERR("Could not install RF settings");
 		return false;
@@ -365,7 +365,7 @@ static int rf_calibrate(struct cc1200_context *ctx)
 
 	k_busy_wait(USEC_PER_MSEC * 10U);
 
-	_cc1200_print_status(get_status(ctx));
+	cc1200_print_status(get_status(ctx));
 
 	return 0;
 }
@@ -377,7 +377,7 @@ static int rf_calibrate(struct cc1200_context *ctx)
 static inline bool write_txfifo(struct cc1200_context *ctx,
 				void *data, size_t length)
 {
-	return _cc1200_access_reg(ctx, false,
+	return z_cc1200_access_reg(ctx, false,
 				  CC1200_REG_TXFIFO,
 				  data, length, false, true);
 }
@@ -389,7 +389,7 @@ static inline bool write_txfifo(struct cc1200_context *ctx,
 static inline bool read_rxfifo(struct cc1200_context *ctx,
 			       void *data, size_t length)
 {
-	return _cc1200_access_reg(ctx, true,
+	return z_cc1200_access_reg(ctx, true,
 				  CC1200_REG_RXFIFO,
 				  data, length, false, true);
 }
@@ -398,8 +398,8 @@ static inline u8_t get_packet_length(struct cc1200_context *ctx)
 {
 	u8_t len;
 
-	if (_cc1200_access_reg(ctx, true, CC1200_REG_RXFIFO,
-			       &len, 1, false, true)) {
+	if (z_cc1200_access_reg(ctx, true, CC1200_REG_RXFIFO,
+				&len, 1, false, true)) {
 		return len;
 	}
 
@@ -642,7 +642,7 @@ static int cc1200_tx(struct device *dev,
 	}
 
 out:
-	_cc1200_print_status(get_status(cc1200));
+	cc1200_print_status(get_status(cc1200));
 
 	if (atomic_get(&cc1200->tx) == 1 &&
 	    read_reg_num_txbytes(cc1200) != 0) {
@@ -677,7 +677,7 @@ static int cc1200_start(struct device *dev)
 
 	enable_gpio0_interrupt(cc1200, true);
 
-	_cc1200_print_status(get_status(cc1200));
+	cc1200_print_status(get_status(cc1200));
 
 	return 0;
 }

--- a/drivers/ieee802154/ieee802154_cc1200.h
+++ b/drivers/ieee802154/ieee802154_cc1200.h
@@ -47,43 +47,43 @@ struct cc1200_context {
  ***************************
  */
 
-bool _cc1200_access_reg(struct cc1200_context *ctx, bool read, u8_t addr,
+bool z_cc1200_access_reg(struct cc1200_context *ctx, bool read, u8_t addr,
 			void *data, size_t length, bool extended, bool burst);
 
-static inline u8_t _cc1200_read_single_reg(struct cc1200_context *ctx,
+static inline u8_t cc1200_read_single_reg(struct cc1200_context *ctx,
 					   u8_t addr, bool extended)
 {
 	u8_t val;
 
-	if (_cc1200_access_reg(ctx, true, addr, &val, 1, extended, false)) {
+	if (z_cc1200_access_reg(ctx, true, addr, &val, 1, extended, false)) {
 		return val;
 	}
 
 	return 0;
 }
 
-static inline bool _cc1200_write_single_reg(struct cc1200_context *ctx,
+static inline bool cc1200_write_single_reg(struct cc1200_context *ctx,
 					    u8_t addr, u8_t val, bool extended)
 {
-	return _cc1200_access_reg(ctx, false, addr, &val, 1, extended, false);
+	return z_cc1200_access_reg(ctx, false, addr, &val, 1, extended, false);
 }
 
-static inline bool _cc1200_instruct(struct cc1200_context *ctx, u8_t addr)
+static inline bool cc1200_instruct(struct cc1200_context *ctx, u8_t addr)
 {
-	return _cc1200_access_reg(ctx, false, addr, NULL, 0, false, false);
+	return z_cc1200_access_reg(ctx, false, addr, NULL, 0, false, false);
 }
 
 #define DEFINE_REG_READ(__reg_name, __reg_addr, __ext)			\
 	static inline u8_t read_reg_##__reg_name(struct cc1200_context *ctx) \
 	{								\
-		return _cc1200_read_single_reg(ctx, __reg_addr, __ext);	\
+		return cc1200_read_single_reg(ctx, __reg_addr, __ext);	\
 	}
 
 #define DEFINE_REG_WRITE(__reg_name, __reg_addr, __ext)			\
 	static inline bool write_reg_##__reg_name(struct cc1200_context *ctx, \
 						  u8_t val)		\
 	{								\
-		return _cc1200_write_single_reg(ctx, __reg_addr,	\
+		return cc1200_write_single_reg(ctx, __reg_addr,	\
 						val, __ext);		\
 	}
 
@@ -107,7 +107,7 @@ DEFINE_REG_READ(num_rxbytes, CC1200_REG_NUM_RXBYTES, true)
 #define DEFINE_STROBE_INSTRUCTION(__ins_name, __ins_addr)		\
 	static inline bool instruct_##__ins_name(struct cc1200_context *ctx) \
 	{								\
-		return _cc1200_instruct(ctx, __ins_addr);		\
+		return cc1200_instruct(ctx, __ins_addr);		\
 	}
 
 DEFINE_STROBE_INSTRUCTION(sres, CC1200_INS_SRES)

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -64,7 +64,7 @@ static struct spi_cs_control cs_ctrl;
  * DEBUG *
  ********/
 #if LOG_LEVEL == LOG_LEVEL_DBG
-static inline void _cc2520_print_gpio_config(struct device *dev)
+static inline void cc2520_print_gpio_config(struct device *dev)
 {
 	struct cc2520_context *cc2520 = dev->driver_data;
 
@@ -81,7 +81,7 @@ static inline void _cc2520_print_gpio_config(struct device *dev)
 		    read_reg_gpioctrl(cc2520));
 }
 
-static inline void _cc2520_print_exceptions(struct cc2520_context *cc2520)
+static inline void cc2520_print_exceptions(struct cc2520_context *cc2520)
 {
 	u8_t flag = read_reg_excflag0(cc2520);
 
@@ -156,7 +156,7 @@ static inline void _cc2520_print_exceptions(struct cc2520_context *cc2520)
 	}
 }
 
-static inline void _cc2520_print_errors(struct cc2520_context *cc2520)
+static inline void cc2520_print_errors(struct cc2520_context *cc2520)
 {
 	u8_t flag = read_reg_excflag2(cc2520);
 
@@ -191,18 +191,18 @@ static inline void _cc2520_print_errors(struct cc2520_context *cc2520)
 	}
 }
 #else
-#define _cc2520_print_gpio_config(...)
-#define _cc2520_print_exceptions(...)
-#define _cc2520_print_errors(...)
+#define cc2520_print_gpio_config(...)
+#define cc2520_print_exceptions(...)
+#define cc2520_print_errors(...)
 #endif /* LOG_LEVEL == LOG_LEVEL_DBG */
 
 
 /*********************
  * Generic functions *
  ********************/
-#define _usleep(usec) k_busy_wait(usec)
+#define z_usleep(usec) k_busy_wait(usec)
 
-bool _cc2520_access(struct cc2520_context *ctx, bool read, u8_t ins,
+bool z_cc2520_access(struct cc2520_context *ctx, bool read, u8_t ins,
 		    u16_t addr, void *data, size_t length)
 {
 	u8_t cmd_buf[2];
@@ -248,11 +248,11 @@ bool _cc2520_access(struct cc2520_context *ctx, bool read, u8_t ins,
 	return (spi_write(ctx->spi, &ctx->spi_cfg, &tx) == 0);
 }
 
-static inline u8_t _cc2520_status(struct cc2520_context *ctx)
+static inline u8_t cc2520_status(struct cc2520_context *ctx)
 {
 	u8_t status;
 
-	if (_cc2520_access(ctx, true, CC2520_INS_SNOP, 0, &status, 1)) {
+	if (z_cc2520_access(ctx, true, CC2520_INS_SNOP, 0, &status, 1)) {
 		return status;
 	}
 
@@ -265,8 +265,8 @@ static bool verify_osc_stabilization(struct cc2520_context *cc2520)
 	u8_t status;
 
 	do {
-		status = _cc2520_status(cc2520);
-		_usleep(1);
+		status = cc2520_status(cc2520);
+		z_usleep(1);
 		timeout--;
 	} while (!(status & CC2520_STATUS_XOSC_STABLE_N_RUNNING) && timeout);
 
@@ -299,7 +299,7 @@ static inline u8_t *get_mac(struct device *dev)
 	return cc2520->mac_addr;
 }
 
-static int _cc2520_set_pan_id(struct device *dev, u16_t pan_id)
+static int cc2520_set_pan_id(struct device *dev, u16_t pan_id)
 {
 	struct cc2520_context *cc2520 = dev->driver_data;
 
@@ -315,7 +315,7 @@ static int _cc2520_set_pan_id(struct device *dev, u16_t pan_id)
 	return 0;
 }
 
-static int _cc2520_set_short_addr(struct device *dev, u16_t short_addr)
+static int cc2520_set_short_addr(struct device *dev, u16_t short_addr)
 {
 	struct cc2520_context *cc2520 = dev->driver_data;
 
@@ -331,7 +331,7 @@ static int _cc2520_set_short_addr(struct device *dev, u16_t short_addr)
 	return 0;
 }
 
-static int _cc2520_set_ieee_addr(struct device *dev, const u8_t *ieee_addr)
+static int cc2520_set_ieee_addr(struct device *dev, const u8_t *ieee_addr)
 {
 	struct cc2520_context *cc2520 = dev->driver_data;
 
@@ -477,13 +477,13 @@ static inline bool write_txfifo_length(struct cc2520_context *ctx, u8_t len)
 {
 	u8_t length = len + CC2520_FCS_LENGTH;
 
-	return _cc2520_access(ctx, false, CC2520_INS_TXBUF, 0, &length, 1);
+	return z_cc2520_access(ctx, false, CC2520_INS_TXBUF, 0, &length, 1);
 }
 
 static inline bool write_txfifo_content(struct cc2520_context *ctx,
 					u8_t *frame, u8_t len)
 {
-	return _cc2520_access(ctx, false, CC2520_INS_TXBUF, 0, frame, len);
+	return z_cc2520_access(ctx, false, CC2520_INS_TXBUF, 0, frame, len);
 }
 
 static inline bool verify_txfifo_status(struct cc2520_context *cc2520,
@@ -503,7 +503,7 @@ static inline bool verify_tx_done(struct cc2520_context *cc2520)
 	u8_t status;
 
 	do {
-		_usleep(1);
+		z_usleep(1);
 		timeout--;
 		status = read_reg_excflag0(cc2520);
 	} while (!(status & EXCFLAG0_TX_FRM_DONE) && timeout);
@@ -533,7 +533,7 @@ static inline u8_t read_rxfifo_length(struct cc2520_context *ctx)
 	u8_t len;
 
 
-	if (_cc2520_access(ctx, true, CC2520_INS_RXBUF, 0, &len, 1)) {
+	if (z_cc2520_access(ctx, true, CC2520_INS_RXBUF, 0, &len, 1)) {
 		return len;
 	}
 
@@ -543,7 +543,7 @@ static inline u8_t read_rxfifo_length(struct cc2520_context *ctx)
 static inline bool read_rxfifo_content(struct cc2520_context *ctx,
 				       struct net_buf *buf, u8_t len)
 {
-	if (!_cc2520_access(ctx, true, CC2520_INS_RXBUF, 0, buf->data, len)) {
+	if (!z_cc2520_access(ctx, true, CC2520_INS_RXBUF, 0, buf->data, len)) {
 		return false;
 	}
 
@@ -589,7 +589,7 @@ static inline bool verify_crc(struct cc2520_context *ctx, struct net_pkt *pkt)
 {
 	u8_t fcs[2];
 
-	if (!_cc2520_access(ctx, true, CC2520_INS_RXBUF, 0, &fcs, 2)) {
+	if (!z_cc2520_access(ctx, true, CC2520_INS_RXBUF, 0, &fcs, 2)) {
 		return false;
 	}
 
@@ -675,8 +675,8 @@ static void cc2520_rx(int arg)
 				K_THREAD_STACK_SIZEOF(cc2520->cc2520_rx_stack));
 		continue;
 flush:
-		_cc2520_print_exceptions(cc2520);
-		_cc2520_print_errors(cc2520);
+		cc2520_print_exceptions(cc2520);
+		cc2520_print_errors(cc2520);
 		flush_rxfifo(cc2520);
 out:
 		if (pkt) {
@@ -741,11 +741,11 @@ static int cc2520_filter(struct device *dev,
 	}
 
 	if (type == IEEE802154_FILTER_TYPE_IEEE_ADDR) {
-		return _cc2520_set_ieee_addr(dev, filter->ieee_addr);
+		return cc2520_set_ieee_addr(dev, filter->ieee_addr);
 	} else if (type == IEEE802154_FILTER_TYPE_SHORT_ADDR) {
-		return _cc2520_set_short_addr(dev, filter->short_addr);
+		return cc2520_set_short_addr(dev, filter->short_addr);
 	} else if (type == IEEE802154_FILTER_TYPE_PAN_ID) {
-		return _cc2520_set_pan_id(dev, filter->pan_id);
+		return cc2520_set_pan_id(dev, filter->pan_id);
 	}
 
 	return -ENOTSUP;
@@ -858,8 +858,8 @@ error:
 	k_sem_give(&cc2520->access_lock);
 #endif
 	LOG_ERR("No TX_FRM_DONE");
-	_cc2520_print_exceptions(cc2520);
-	_cc2520_print_errors(cc2520);
+	cc2520_print_exceptions(cc2520);
+	cc2520_print_errors(cc2520);
 
 	atomic_set(&cc2520->tx, 0);
 	instruct_sflushtx(cc2520);
@@ -913,17 +913,17 @@ static int power_on_and_setup(struct device *dev)
 
 	/* Switching to LPM2 mode */
 	set_reset(dev, 0);
-	_usleep(150);
+	z_usleep(150);
 
 	set_vreg_en(dev, 0);
-	_usleep(250);
+	z_usleep(250);
 
 	/* Then to ACTIVE mode */
 	set_vreg_en(dev, 1);
-	_usleep(250);
+	z_usleep(250);
 
 	set_reset(dev, 1);
-	_usleep(150);
+	z_usleep(150);
 
 	if (!verify_osc_stabilization(cc2520)) {
 		return -EIO;
@@ -968,7 +968,7 @@ static int power_on_and_setup(struct device *dev)
 
 	setup_gpio_callbacks(dev);
 
-	_cc2520_print_gpio_config(dev);
+	cc2520_print_gpio_config(dev);
 
 	return 0;
 }
@@ -1097,17 +1097,17 @@ NET_STACK_INFO_ADDR(RX, cc2520,
 
 #ifdef CONFIG_IEEE802154_CC2520_CRYPTO
 
-static inline bool _cc2520_read_ram(struct cc2520_context *ctx, u16_t addr,
+static inline bool cc2520_read_ram(struct cc2520_context *ctx, u16_t addr,
 				    u8_t *data_buf, u8_t len)
 {
-	return _cc2520_access(ctx, true, CC2520_INS_MEMRD,
+	return z_cc2520_access(ctx, true, CC2520_INS_MEMRD,
 			      addr, data_buf, len);
 }
 
-static inline bool _cc2520_write_ram(struct cc2520_context *ctx, u16_t addr,
+static inline bool cc2520_write_ram(struct cc2520_context *ctx, u16_t addr,
 				     u8_t *data_buf, u8_t len)
 {
-	return _cc2520_access(ctx, false, CC2520_INS_MEMWR,
+	return z_cc2520_access(ctx, false, CC2520_INS_MEMWR,
 			      addr, data_buf, len);
 }
 
@@ -1245,7 +1245,7 @@ static int insert_crypto_parameters(struct cipher_ctx *ctx,
 	}
 
 	/* Writing the frame in RAM */
-	if (!_cc2520_write_ram(cc2520, CC2520_MEM_DATA, in_buf, in_len)) {
+	if (!cc2520_write_ram(cc2520, CC2520_MEM_DATA, in_buf, in_len)) {
 		LOG_ERR("Cannot write the frame in RAM");
 		return -EIO;
 	}
@@ -1254,7 +1254,7 @@ static int insert_crypto_parameters(struct cipher_ctx *ctx,
 	sys_memcpy_swap(data, ctx->key.bit_stream, ctx->keylen);
 
 	/* Writing the key in RAM */
-	if (!_cc2520_write_ram(cc2520, CC2520_MEM_KEY, data, 16)) {
+	if (!cc2520_write_ram(cc2520, CC2520_MEM_KEY, data, 16)) {
 		LOG_ERR("Cannot write the key in RAM");
 		return -EIO;
 	}
@@ -1262,7 +1262,7 @@ static int insert_crypto_parameters(struct cipher_ctx *ctx,
 	generate_nonce(ccm_nonce, data, apkt, m);
 
 	/* Writing the nonce in RAM */
-	if (!_cc2520_write_ram(cc2520, CC2520_MEM_NONCE, data, 16)) {
+	if (!cc2520_write_ram(cc2520, CC2520_MEM_NONCE, data, 16)) {
 		LOG_ERR("Cannot write the nonce in RAM");
 		return -EIO;
 	}
@@ -1270,7 +1270,7 @@ static int insert_crypto_parameters(struct cipher_ctx *ctx,
 	return m;
 }
 
-static int _cc2520_crypto_ccm(struct cipher_ctx *ctx,
+static int cc2520_crypto_ccm(struct cipher_ctx *ctx,
 			      struct cipher_aead_pkt *apkt,
 			      u8_t *ccm_nonce)
 {
@@ -1301,7 +1301,7 @@ static int _cc2520_crypto_ccm(struct cipher_ctx *ctx,
 	if (!instruct_uccm_ccm(cc2520, false, CC2520_MEM_KEY >> 4, auth_crypt,
 			       CC2520_MEM_NONCE >> 4, CC2520_MEM_DATA,
 			       0x000, apkt->ad_len, m) ||
-	    !_cc2520_read_ram(cc2520, CC2520_MEM_DATA,
+	    !cc2520_read_ram(cc2520, CC2520_MEM_DATA,
 			      apkt->pkt->out_buf, apkt->pkt->out_len)) {
 		LOG_ERR("CCM or reading result from RAM failed");
 		return -EIO;
@@ -1315,7 +1315,7 @@ static int _cc2520_crypto_ccm(struct cipher_ctx *ctx,
 	return 0;
 }
 
-static int _cc2520_crypto_uccm(struct cipher_ctx *ctx,
+static int cc2520_crypto_uccm(struct cipher_ctx *ctx,
 			       struct cipher_aead_pkt *apkt,
 			       u8_t *ccm_nonce)
 {
@@ -1343,7 +1343,7 @@ static int _cc2520_crypto_uccm(struct cipher_ctx *ctx,
 	if (!instruct_uccm_ccm(cc2520, true, CC2520_MEM_KEY >> 4, auth_crypt,
 			       CC2520_MEM_NONCE >> 4, CC2520_MEM_DATA,
 			       0x000, apkt->ad_len, m) ||
-	    !_cc2520_read_ram(cc2520, CC2520_MEM_DATA,
+	    !cc2520_read_ram(cc2520, CC2520_MEM_DATA,
 			      apkt->pkt->out_buf, apkt->pkt->out_len)) {
 		LOG_ERR("UCCM or reading result from RAM failed");
 		return -EIO;
@@ -1380,9 +1380,9 @@ static int cc2520_crypto_begin_session(struct device *dev,
 	}
 
 	if (op_type == CRYPTO_CIPHER_OP_ENCRYPT) {
-		ctx->ops.ccm_crypt_hndlr = _cc2520_crypto_ccm;
+		ctx->ops.ccm_crypt_hndlr = cc2520_crypto_ccm;
 	} else {
-		ctx->ops.ccm_crypt_hndlr = _cc2520_crypto_uccm;
+		ctx->ops.ccm_crypt_hndlr = cc2520_crypto_uccm;
 	}
 
 	ctx->ops.cipher_mode = mode;

--- a/drivers/ieee802154/ieee802154_cc2520.h
+++ b/drivers/ieee802154/ieee802154_cc2520.h
@@ -48,7 +48,7 @@ struct cc2520_context {
  ***************************
  */
 
-bool _cc2520_access(struct cc2520_context *ctx, bool read, u8_t ins,
+bool z_cc2520_access(struct cc2520_context *ctx, bool read, u8_t ins,
 		    u16_t addr, void *data, size_t length);
 
 #define DEFINE_SREG_READ(__reg_name, __reg_addr)			\
@@ -56,7 +56,7 @@ bool _cc2520_access(struct cc2520_context *ctx, bool read, u8_t ins,
 	{								\
 		u8_t val;						\
 									\
-		if (_cc2520_access(ctx, true, CC2520_INS_MEMRD,		\
+		if (z_cc2520_access(ctx, true, CC2520_INS_MEMRD,		\
 				   __reg_addr, &val, 1)) {		\
 			return val;					\
 		}							\
@@ -68,7 +68,7 @@ bool _cc2520_access(struct cc2520_context *ctx, bool read, u8_t ins,
 	static inline bool write_reg_##__reg_name(struct cc2520_context *ctx, \
 						  u8_t val)		\
 	{								\
-		return _cc2520_access(ctx, false, CC2520_INS_MEMWR,	\
+		return z_cc2520_access(ctx, false, CC2520_INS_MEMWR,	\
 				      __reg_addr, &val, 1);		\
 	}
 
@@ -77,7 +77,7 @@ bool _cc2520_access(struct cc2520_context *ctx, bool read, u8_t ins,
 	{								\
 		u8_t val;						\
 									\
-		if (_cc2520_access(ctx, true, CC2520_INS_REGRD,		\
+		if (z_cc2520_access(ctx, true, CC2520_INS_REGRD,		\
 				   __reg_addr, &val, 1)) {		\
 			return val;					\
 		}							\
@@ -89,7 +89,7 @@ bool _cc2520_access(struct cc2520_context *ctx, bool read, u8_t ins,
 	static inline bool write_reg_##__reg_name(struct cc2520_context *ctx, \
 						  u8_t val)		\
 	{								\
-		return _cc2520_access(ctx, false, CC2520_INS_REGWR,	\
+		return z_cc2520_access(ctx, false, CC2520_INS_REGWR,	\
 				      __reg_addr, &val, 1);		\
 	}
 
@@ -140,7 +140,7 @@ DEFINE_SREG_WRITE(extclock, CC2520_SREG_EXTCLOCK)
 	static inline bool write_mem_##__mem_name(struct cc2520_context *ctx, \
 						  u8_t *buf)		\
 	{								\
-		return _cc2520_access(ctx, false, CC2520_INS_MEMWR,	\
+		return z_cc2520_access(ctx, false, CC2520_INS_MEMWR,	\
 				      __addr, buf, __sz);		\
 	}
 
@@ -153,30 +153,30 @@ DEFINE_MEM_WRITE(ext_addr, CC2520_MEM_EXT_ADDR, 8)
  ******************************
  */
 
-static inline bool _cc2520_command_strobe(struct cc2520_context *ctx,
+static inline bool cc2520_command_strobe(struct cc2520_context *ctx,
 					  u8_t instruction)
 {
-	return _cc2520_access(ctx, false, instruction, 0, NULL, 0);
+	return z_cc2520_access(ctx, false, instruction, 0, NULL, 0);
 }
 
-static inline bool _cc2520_command_strobe_snop(struct cc2520_context *ctx,
+static inline bool cc2520_command_strobe_snop(struct cc2520_context *ctx,
 					       u8_t instruction)
 {
 	u8_t snop[1] = { CC2520_INS_SNOP };
 
-	return _cc2520_access(ctx, false, instruction, 0, snop, 1);
+	return z_cc2520_access(ctx, false, instruction, 0, snop, 1);
 }
 
 #define DEFINE_STROBE_INSTRUCTION(__ins_name, __ins)			\
 	static inline bool instruct_##__ins_name(struct cc2520_context *ctx) \
 	{								\
-		return _cc2520_command_strobe(ctx, __ins);		\
+		return cc2520_command_strobe(ctx, __ins);		\
 	}
 
 #define DEFINE_STROBE_SNOP_INSTRUCTION(__ins_name, __ins)		\
 	static inline bool instruct_##__ins_name(struct cc2520_context *ctx) \
 	{								\
-		return _cc2520_command_strobe_snop(ctx, __ins);		\
+		return cc2520_command_strobe_snop(ctx, __ins);		\
 	}
 
 DEFINE_STROBE_INSTRUCTION(srxon, CC2520_INS_SRXON)

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -145,10 +145,10 @@ static const u16_t pll_frac_lt[16] = {
 	2048, 12288, 22528, 32768
 };
 
-#define _usleep(usec) k_busy_wait(usec)
+#define z_usleep(usec) k_busy_wait(usec)
 
 /* Read direct (dreg is true) or indirect register (dreg is false) */
-u8_t _mcr20a_read_reg(struct mcr20a_context *dev, bool dreg, u8_t addr)
+u8_t z_mcr20a_read_reg(struct mcr20a_context *dev, bool dreg, u8_t addr)
 {
 	u8_t cmd_buf[3] = {
 		dreg ? (MCR20A_REG_READ | addr) :
@@ -180,7 +180,7 @@ u8_t _mcr20a_read_reg(struct mcr20a_context *dev, bool dreg, u8_t addr)
 }
 
 /* Write direct (dreg is true) or indirect register (dreg is false) */
-bool _mcr20a_write_reg(struct mcr20a_context *dev, bool dreg, u8_t addr,
+bool z_mcr20a_write_reg(struct mcr20a_context *dev, bool dreg, u8_t addr,
 		       u8_t value)
 {
 	u8_t cmd_buf[3] = {
@@ -202,7 +202,7 @@ bool _mcr20a_write_reg(struct mcr20a_context *dev, bool dreg, u8_t addr,
 }
 
 /* Write multiple bytes to direct or indirect register */
-bool _mcr20a_write_burst(struct mcr20a_context *dev, bool dreg, u16_t addr,
+bool z_mcr20a_write_burst(struct mcr20a_context *dev, bool dreg, u16_t addr,
 			 u8_t *data_buf, u8_t len)
 {
 	u8_t cmd_buf[2] = {
@@ -229,7 +229,7 @@ bool _mcr20a_write_burst(struct mcr20a_context *dev, bool dreg, u16_t addr,
 }
 
 /* Read multiple bytes from direct or indirect register */
-bool _mcr20a_read_burst(struct mcr20a_context *dev, bool dreg, u16_t addr,
+bool z_mcr20a_read_burst(struct mcr20a_context *dev, bool dreg, u16_t addr,
 			u8_t *data_buf, u8_t len)
 {
 	u8_t cmd_buf[2] = {
@@ -405,7 +405,7 @@ error:
 	return -EIO;
 }
 
-static inline void _xcvseq_wait_until_idle(struct mcr20a_context *mcr20a)
+static inline void xcvseq_wait_until_idle(struct mcr20a_context *mcr20a)
 {
 	u8_t state;
 	u8_t retries = MCR20A_GET_SEQ_STATE_RETRIES;
@@ -441,7 +441,7 @@ static inline int mcr20a_abort_sequence(struct mcr20a_context *mcr20a,
 		return -1;
 	}
 
-	_xcvseq_wait_until_idle(mcr20a);
+	xcvseq_wait_until_idle(mcr20a);
 
 	/* Clear relevant interrupt flags */
 	if (!write_reg_irqsts1(mcr20a, MCR20A_IRQSTS1_IRQ_MASK)) {
@@ -594,7 +594,7 @@ out:
  * if a new sequence is to be set. This function is only to be called
  * when a sequence has been completed.
  */
-static inline bool _irqsts1_event(struct mcr20a_context *mcr20a,
+static inline bool irqsts1_event(struct mcr20a_context *mcr20a,
 				  u8_t *dregs)
 {
 	u8_t seq = dregs[MCR20A_PHY_CTRL1] & MCR20A_PHY_CTRL1_XCVSEQ_MASK;
@@ -681,7 +681,7 @@ static inline bool _irqsts1_event(struct mcr20a_context *mcr20a,
  * Currently we use only T4CMP to cancel the running sequence,
  * usually the TR.
  */
-static inline bool _irqsts3_event(struct mcr20a_context *mcr20a,
+static inline bool irqsts3_event(struct mcr20a_context *mcr20a,
 				  u8_t *dregs)
 {
 	bool retval = false;
@@ -736,9 +736,9 @@ static void mcr20a_thread_main(void *arg)
 		ctrl1 = dregs[MCR20A_PHY_CTRL1];
 
 		if (dregs[MCR20A_IRQSTS3] & MCR20A_IRQSTS3_IRQ_MASK) {
-			set_new_seq = _irqsts3_event(mcr20a, dregs);
+			set_new_seq = irqsts3_event(mcr20a, dregs);
 		} else if (dregs[MCR20A_IRQSTS1] & MCR20A_IRQSTS1_SEQIRQ) {
-			set_new_seq = _irqsts1_event(mcr20a, dregs);
+			set_new_seq = irqsts1_event(mcr20a, dregs);
 		}
 
 		if (dregs[MCR20A_IRQSTS2] & MCR20A_IRQSTS2_IRQ_MASK) {
@@ -759,7 +759,7 @@ static void mcr20a_thread_main(void *arg)
 				LOG_ERR("Failed to reset SEQ manager");
 			}
 
-			_xcvseq_wait_until_idle(mcr20a);
+			xcvseq_wait_until_idle(mcr20a);
 
 			if (!write_burst_irqsts1_ctrl1(mcr20a, dregs)) {
 				LOG_ERR("Failed to write CTRL1");
@@ -1158,7 +1158,7 @@ static int mcr20a_start(struct device *dev)
 	}
 
 	do {
-		_usleep(50);
+		z_usleep(50);
 		timeout--;
 		status = read_reg_pwr_modes(mcr20a);
 	} while (!(status & MCR20A_PWR_MODES_XTAL_READY) && timeout);
@@ -1251,9 +1251,9 @@ static int mcr20a_update_overwrites(struct mcr20a_context *dev)
 	     i < sizeof(overwrites_indirect) / sizeof(overwrites_t);
 	     i++) {
 
-		if (!_mcr20a_write_reg(dev, false,
-				       overwrites_indirect[i].address,
-				       overwrites_indirect[i].data)) {
+		if (!z_mcr20a_write_reg(dev, false,
+					overwrites_indirect[i].address,
+					overwrites_indirect[i].data)) {
 			goto error;
 		}
 	}
@@ -1274,11 +1274,11 @@ static int power_on_and_setup(struct device *dev)
 
 	if (!PART_OF_KW2XD_SIP) {
 		set_reset(dev, 0);
-		_usleep(150);
+		z_usleep(150);
 		set_reset(dev, 1);
 
 		do {
-			_usleep(50);
+			z_usleep(50);
 			timeout--;
 			gpio_pin_read(mcr20a->irq_gpio,
 				      DT_NXP_MCR20A_0_IRQB_GPIOS_PIN, &status);

--- a/drivers/ieee802154/ieee802154_mcr20a.h
+++ b/drivers/ieee802154/ieee802154_mcr20a.h
@@ -42,25 +42,25 @@ struct mcr20a_context {
 
 #include "ieee802154_mcr20a_regs.h"
 
-u8_t _mcr20a_read_reg(struct mcr20a_context *dev, bool dreg, u8_t addr);
-bool _mcr20a_write_reg(struct mcr20a_context *dev, bool dreg, u8_t addr,
+u8_t z_mcr20a_read_reg(struct mcr20a_context *dev, bool dreg, u8_t addr);
+bool z_mcr20a_write_reg(struct mcr20a_context *dev, bool dreg, u8_t addr,
 		       u8_t value);
-bool _mcr20a_write_burst(struct mcr20a_context *dev, bool dreg, u16_t addr,
+bool z_mcr20a_write_burst(struct mcr20a_context *dev, bool dreg, u16_t addr,
 			 u8_t *data_buf, u8_t len);
-bool _mcr20a_read_burst(struct mcr20a_context *dev, bool dreg, u16_t addr,
+bool z_mcr20a_read_burst(struct mcr20a_context *dev, bool dreg, u16_t addr,
 			u8_t *data_buf, u8_t len);
 
 #define DEFINE_REG_READ(__reg_name, __reg_addr, __dreg)			\
 	static inline u8_t read_reg_##__reg_name(struct mcr20a_context *dev) \
 	{								\
-		return _mcr20a_read_reg(dev, __dreg, __reg_addr);	\
+		return z_mcr20a_read_reg(dev, __dreg, __reg_addr);	\
 	}
 
 #define DEFINE_REG_WRITE(__reg_name, __reg_addr, __dreg)		\
 	static inline bool write_reg_##__reg_name(struct mcr20a_context *dev, \
 						  u8_t value)		\
 	{								\
-		return _mcr20a_write_reg(dev, __dreg, __reg_addr, value); \
+		return z_mcr20a_write_reg(dev, __dreg, __reg_addr, value); \
 	}
 
 #define DEFINE_DREG_READ(__reg_name, __reg_addr)	\
@@ -153,14 +153,14 @@ DEFINE_BITS_SET(clk_out_div, MCR20A_CLK_OUT, _DIV)
 	static inline bool write_burst_##__reg_addr(			\
 		struct mcr20a_context *dev, u8_t *buf)			\
 	{								\
-		return _mcr20a_write_burst(dev, __dreg, __addr, buf, __sz); \
+		return z_mcr20a_write_burst(dev, __dreg, __addr, buf, __sz); \
 	}
 
 #define DEFINE_BURST_READ(__reg_addr, __addr, __sz, __dreg)		    \
 	static inline bool read_burst_##__reg_addr(struct mcr20a_context *dev, \
 						   u8_t *buf)		\
 	{								    \
-		return _mcr20a_read_burst(dev, __dreg, __addr, buf, __sz);  \
+		return z_mcr20a_read_burst(dev, __dreg, __addr, buf, __sz);  \
 	}
 
 DEFINE_BURST_WRITE(t1cmp, MCR20A_T1CMP_LSB, 3, true)

--- a/drivers/interrupt_controller/arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/arcv2_irq_unit.c
@@ -61,7 +61,7 @@ static struct arc_v2_irq_unit_ctx ctx;
  * @return N/A
  */
 
-static int _arc_v2_irq_unit_init(struct device *unused)
+static int arc_v2_irq_unit_init(struct device *unused)
 {
 	ARG_UNUSED(unused);
 	int irq; /* the interrupt index */
@@ -107,7 +107,7 @@ unsigned int z_arc_v2_irq_unit_trigger_get(int irq)
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 
-static int _arc_v2_irq_unit_suspend(struct device *dev)
+static int arc_v2_irq_unit_suspend(struct device *dev)
 {
 	u8_t irq;
 
@@ -135,7 +135,7 @@ static int _arc_v2_irq_unit_suspend(struct device *dev)
 	return 0;
 }
 
-static int _arc_v2_irq_unit_resume(struct device *dev)
+static int arc_v2_irq_unit_resume(struct device *dev)
 {
 	u8_t irq;
 	u32_t status32;
@@ -166,7 +166,7 @@ static int _arc_v2_irq_unit_resume(struct device *dev)
 	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_VECT_BASE, ctx.irq_vect_base);
 
 	status32 = z_arc_v2_aux_reg_read(_ARC_V2_STATUS32);
-	status32 |= _ARC_V2_STATUS32_E(_ARC_V2_DEF_IRQ_LEVEL);
+	status32 |= Z_ARC_V2_STATUS32_E(_ARC_V2_DEF_IRQ_LEVEL);
 
 	__builtin_arc_kflag(status32);
 
@@ -175,7 +175,7 @@ static int _arc_v2_irq_unit_resume(struct device *dev)
 	return 0;
 }
 
-static int _arc_v2_irq_unit_get_state(struct device *dev)
+static int arc_v2_irq_unit_get_state(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
@@ -186,19 +186,19 @@ static int _arc_v2_irq_unit_get_state(struct device *dev)
  * Implements the driver control management functionality
  * the *context may include IN data or/and OUT data
  */
-static int _arc_v2_irq_unit_device_ctrl(struct device *device,
+static int arc_v2_irq_unit_device_ctrl(struct device *device,
 		u32_t ctrl_command, void *context, device_pm_cb cb, void *arg)
 {
 	int ret = 0;
 
 	if (ctrl_command == DEVICE_PM_SET_POWER_STATE) {
 		if (*((u32_t *)context) == DEVICE_PM_SUSPEND_STATE) {
-			ret = _arc_v2_irq_unit_suspend(device);
+			ret = arc_v2_irq_unit_suspend(device);
 		} else if (*((u32_t *)context) == DEVICE_PM_ACTIVE_STATE) {
-			ret = _arc_v2_irq_unit_resume(device);
+			ret = arc_v2_irq_unit_resume(device);
 		}
 	} else if (ctrl_command == DEVICE_PM_GET_POWER_STATE) {
-		*((u32_t *)context) = _arc_v2_irq_unit_get_state(device);
+		*((u32_t *)context) = arc_v2_irq_unit_get_state(device);
 	}
 
 	if (cb) {
@@ -208,10 +208,10 @@ static int _arc_v2_irq_unit_device_ctrl(struct device *device,
 	return ret;
 }
 
-SYS_DEVICE_DEFINE("arc_v2_irq_unit", _arc_v2_irq_unit_init,
-		_arc_v2_irq_unit_device_ctrl, PRE_KERNEL_1,
-		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_DEVICE_DEFINE("arc_v2_irq_unit", arc_v2_irq_unit_init,
+		  arc_v2_irq_unit_device_ctrl, PRE_KERNEL_1,
+		  CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #else
-SYS_INIT(_arc_v2_irq_unit_init, PRE_KERNEL_1,
+SYS_INIT(arc_v2_irq_unit_init, PRE_KERNEL_1,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif   /* CONFIG_DEVICE_POWER_MANAGEMENT */

--- a/drivers/interrupt_controller/ioapic_intr.c
+++ b/drivers/interrupt_controller/ioapic_intr.c
@@ -80,7 +80,7 @@ static void __IoApicSet(s32_t offset, u32_t value);
 static void ioApicRedSetHi(unsigned int irq, u32_t upper32);
 static void ioApicRedSetLo(unsigned int irq, u32_t lower32);
 static u32_t ioApicRedGetLo(unsigned int irq);
-static void _IoApicRedUpdateLo(unsigned int irq, u32_t value,
+static void IoApicRedUpdateLo(unsigned int irq, u32_t value,
 					u32_t mask);
 
 /*
@@ -135,7 +135,7 @@ int _ioapic_init(struct device *unused)
  */
 void z_ioapic_irq_enable(unsigned int irq)
 {
-	_IoApicRedUpdateLo(irq, 0, IOAPIC_INT_MASK);
+	IoApicRedUpdateLo(irq, 0, IOAPIC_INT_MASK);
 }
 
 /**
@@ -149,7 +149,7 @@ void z_ioapic_irq_enable(unsigned int irq)
  */
 void z_ioapic_irq_disable(unsigned int irq)
 {
-	_IoApicRedUpdateLo(irq, IOAPIC_INT_MASK, IOAPIC_INT_MASK);
+	IoApicRedUpdateLo(irq, IOAPIC_INT_MASK, IOAPIC_INT_MASK);
 }
 
 
@@ -312,7 +312,7 @@ void z_ioapic_irq_set(unsigned int irq, unsigned int vector, u32_t flags)
  */
 void z_ioapic_int_vec_set(unsigned int irq, unsigned int vector)
 {
-	_IoApicRedUpdateLo(irq, vector, IOAPIC_VEC_MASK);
+	IoApicRedUpdateLo(irq, vector, IOAPIC_VEC_MASK);
 }
 
 /**
@@ -428,7 +428,7 @@ static void ioApicRedSetHi(unsigned int irq, u32_t upper32)
  * @param mask  Mask of bits to be modified
  * @return N/A
  */
-static void _IoApicRedUpdateLo(unsigned int irq,
+static void IoApicRedUpdateLo(unsigned int irq,
 				u32_t value,
 				u32_t mask)
 {

--- a/drivers/interrupt_controller/loapic_intr.c
+++ b/drivers/interrupt_controller/loapic_intr.c
@@ -47,7 +47,7 @@
  * local APIC have been extended and/or modified in the local xAPIC.
  *
  * This driver contains three routines for use.  They are:
- * _loapic_init() initializes the Local APIC for the interrupt mode chosen.
+ * z_loapic_init() initializes the Local APIC for the interrupt mode chosen.
  * _loapic_enable()/disable() enables / disables the Local APIC.
  *
  * Local APIC is used in the Virtual Wire Mode: delivery mode ExtINT.
@@ -216,7 +216,7 @@ static ALWAYS_INLINE void LOAPIC_WRITE(mem_addr_t addr, u32_t data)
  *
  */
 
-static int _loapic_init(struct device *unused)
+static int loapic_init(struct device *unused)
 {
 	ARG_UNUSED(unused);
 	s32_t loApicMaxLvt; /* local APIC Max LVT */
@@ -459,9 +459,9 @@ int loapic_resume(struct device *port)
 	ARG_UNUSED(port);
 
 	/* Assuming all loapic device registers lose their state, the call to
-	 * _loapic_init(), should bring all the registers to a sane state.
+	 * z_loapic_init(), should bring all the registers to a sane state.
 	 */
-	_loapic_init(NULL);
+	loapic_init(NULL);
 
 	for (loapic_irq = 0; loapic_irq < LOAPIC_IRQ_COUNT; loapic_irq++) {
 
@@ -507,17 +507,17 @@ static int loapic_device_ctrl(struct device *port, u32_t ctrl_command,
 	return ret;
 }
 
-SYS_DEVICE_DEFINE("loapic", _loapic_init, loapic_device_ctrl, PRE_KERNEL_1,
+SYS_DEVICE_DEFINE("loapic", loapic_init, loapic_device_ctrl, PRE_KERNEL_1,
 		  CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #else
-SYS_INIT(_loapic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(loapic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif   /* CONFIG_DEVICE_POWER_MANAGEMENT */
 
 
 #if CONFIG_LOAPIC_SPURIOUS_VECTOR
-extern void _loapic_spurious_handler(void);
+extern void z_loapic_spurious_handler(void);
 
-NANO_CPU_INT_REGISTER(_loapic_spurious_handler, NANO_SOFT_IRQ,
+NANO_CPU_INT_REGISTER(z_loapic_spurious_handler, NANO_SOFT_IRQ,
 		      LOAPIC_SPURIOUS_VECTOR_ID >> 4,
 		      LOAPIC_SPURIOUS_VECTOR_ID, 0);
 #endif

--- a/drivers/interrupt_controller/loapic_spurious.S
+++ b/drivers/interrupt_controller/loapic_spurious.S
@@ -12,8 +12,8 @@
 #include <kernel_structs.h>
 #include <arch/x86/asm.h>
 
-	GTEXT(_loapic_spurious_handler)
+	GTEXT(z_loapic_spurious_handler)
 
-SECTION_FUNC(TEXT, _loapic_spurious_handler)
+SECTION_FUNC(TEXT, z_loapic_spurious_handler)
 	iret
 

--- a/drivers/interrupt_controller/mvic.c
+++ b/drivers/interrupt_controller/mvic.c
@@ -62,7 +62,7 @@ static inline u32_t compute_ioregsel(unsigned int irq)
  *
  * @returns N/A
  */
-static void _mvic_rte_set(unsigned int irq, u32_t value)
+static void mvic_rte_set(unsigned int irq, u32_t value)
 {
 	unsigned int key; /* interrupt lock level */
 	u32_t regsel;
@@ -92,7 +92,7 @@ static void _mvic_rte_set(unsigned int irq, u32_t value)
  *
  * @returns N/A
  */
-static void _mvic_rte_update(unsigned int irq, u32_t value, u32_t mask)
+static void mvic_rte_update(unsigned int irq, u32_t value, u32_t mask)
 {
 	unsigned int key;
 	u32_t regsel, old_value, updated_value;
@@ -123,14 +123,14 @@ static void _mvic_rte_update(unsigned int irq, u32_t value, u32_t mask)
  *
  * @returns: N/A
  */
-static int _mvic_init(struct device *unused)
+static int mvic_init(struct device *unused)
 {
 	ARG_UNUSED(unused);
 	int i;
 
 	/* By default mask all interrupt lines */
 	for (i = 0; i < MVIC_NUM_RTES; i++) {
-		_mvic_rte_set(i, MVIC_IOWIN_MASK);
+		mvic_rte_set(i, MVIC_IOWIN_MASK);
 	}
 
 	/* reset the task priority and timer initial count registers */
@@ -151,7 +151,7 @@ static int _mvic_init(struct device *unused)
 	return 0;
 
 }
-SYS_INIT(_mvic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(mvic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 
 void z_arch_irq_enable(unsigned int irq)
@@ -160,7 +160,7 @@ void z_arch_irq_enable(unsigned int irq)
 		sys_write32(sys_read32(MVIC_LVTTIMER) & ~MVIC_LVTTIMER_MASK,
 			    MVIC_LVTTIMER);
 	} else {
-		_mvic_rte_update(irq, 0, MVIC_IOWIN_MASK);
+		mvic_rte_update(irq, 0, MVIC_IOWIN_MASK);
 	}
 }
 
@@ -171,7 +171,7 @@ void z_arch_irq_disable(unsigned int irq)
 		sys_write32(sys_read32(MVIC_LVTTIMER) | MVIC_LVTTIMER_MASK,
 			    MVIC_LVTTIMER);
 	} else {
-		_mvic_rte_update(irq, MVIC_IOWIN_MASK, MVIC_IOWIN_MASK);
+		mvic_rte_update(irq, MVIC_IOWIN_MASK, MVIC_IOWIN_MASK);
 	}
 }
 
@@ -186,7 +186,7 @@ void __irq_controller_irq_config(unsigned int vector, unsigned int irq,
 	 * interrupts need their triggering set
 	 */
 	if (irq != CONFIG_MVIC_TIMER_IRQ) {
-		_mvic_rte_set(irq, MVIC_IOWIN_MASK | flags);
+		mvic_rte_set(irq, MVIC_IOWIN_MASK | flags);
 	} else {
 		__ASSERT(flags == 0U,
 			 "Timer interrupt cannot have triggering flags set");

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -211,7 +211,7 @@ static void wncm14a2a_read_rx(struct net_buf **buf);
 
 /*** Verbose Debugging Functions ***/
 #if defined(ENABLE_VERBOSE_MODEM_RECV_HEXDUMP)
-static inline void _hexdump(const u8_t *packet, size_t length)
+static inline void hexdump(const u8_t *packet, size_t length)
 {
 	char output[sizeof("xxxxyyyy xxxxyyyy")];
 	int n = 0, k = 0;
@@ -261,7 +261,7 @@ static inline void _hexdump(const u8_t *packet, size_t length)
 	}
 }
 #else
-#define _hexdump(...)
+#define hexdump(...)
 #endif
 
 static struct wncm14a2a_socket *socket_get(void)
@@ -1058,7 +1058,7 @@ static void wncm14a2a_read_rx(struct net_buf **buf)
 			break;
 		}
 
-		_hexdump(uart_buffer, bytes_read);
+		hexdump(uart_buffer, bytes_read);
 
 		/* make sure we have storage */
 		if (!*buf) {

--- a/drivers/pinmux/pinmux_esp32.c
+++ b/drivers/pinmux/pinmux_esp32.c
@@ -112,7 +112,7 @@ static int pinmux_pullup(struct device *dev, u32_t pin, u8_t func)
 	return -EINVAL;
 }
 
-#define CFG(id)   ((GPIO_ ## id ## _REG) & 0xff)
+#define CFG(id)   ((GPIO_ ## id ## Z_REG) & 0xff)
 static int pinmux_input(struct device *dev, u32_t pin, u8_t func)
 {
 	static const u8_t offs[2][3] = {

--- a/drivers/pinmux/stm32/pinmux_stm32.c
+++ b/drivers/pinmux/stm32/pinmux_stm32.c
@@ -122,7 +122,7 @@ static int stm32_pin_configure(int pin, int func, int altf)
  *
  * @return 0 on success, error otherwise
  */
-int _pinmux_stm32_set(u32_t pin, u32_t func,
+int z_pinmux_stm32_set(u32_t pin, u32_t func,
 				struct device *clk)
 {
 	/* make sure to enable port clock first */
@@ -148,7 +148,7 @@ void stm32_setup_pins(const struct pin_config *pinconf,
 	clk = device_get_binding(STM32_CLOCK_CONTROL_NAME);
 
 	for (i = 0; i < pins; i++) {
-		_pinmux_stm32_set(pinconf[i].pin_num,
+		z_pinmux_stm32_set(pinconf[i].pin_num,
 				  pinconf[i].mode,
 				  clk);
 	}

--- a/drivers/pinmux/stm32/pinmux_stm32.h
+++ b/drivers/pinmux/stm32/pinmux_stm32.h
@@ -77,7 +77,7 @@ clock_control_subsys_t stm32_get_port_clock(int port);
  * @param clk clock control device, for enabling/disabling clock gate
  * for the port
  */
-int _pinmux_stm32_set(u32_t pin, u32_t func,
+int z_pinmux_stm32_set(u32_t pin, u32_t func,
 		      struct device *clk);
 
 /**

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -360,7 +360,7 @@ static int pwm_nrfx_pm_control(struct device *dev,
 		.countertop = NRFX_PWM_DEFAULT_CONFIG_TOP_VALUE,	      \
 		.prescaler = NRFX_PWM_DEFAULT_CONFIG_BASE_CLOCK 	      \
 	};								      \
-	static const struct pwm_nrfx_config pwm_nrfx_##idx##_config = {	      \
+	static const struct pwm_nrfx_config pwm_nrfx_##idx##z_config = {	      \
 		.pwm = NRFX_PWM_INSTANCE(idx),				      \
 		.initial_config = {					      \
 			.output_pins = {				      \
@@ -383,7 +383,7 @@ static int pwm_nrfx_pm_control(struct device *dev,
 		      DT_NORDIC_NRF_PWM_PWM_##idx##_LABEL,		      \
 		      pwm_nrfx_init, pwm_##idx##_nrfx_pm_control,	      \
 		      &pwm_nrfx_##idx##_data,				      \
-		      &pwm_nrfx_##idx##_config,				      \
+		      &pwm_nrfx_##idx##z_config,				      \
 		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	      \
 		      &pwm_nrfx_drv_api_funcs)
 

--- a/drivers/pwm/pwm_pca9685.c
+++ b/drivers/pwm/pwm_pca9685.c
@@ -43,7 +43,7 @@
  * @param dev Device struct.
  * @return 1 if I2C master is identified, 0 if not.
  */
-static inline int _has_i2c_master(struct device *dev)
+static inline int has_i2c_master(struct device *dev)
 {
 	struct pwm_pca9685_drv_data * const drv_data =
 		(struct pwm_pca9685_drv_data * const)dev->driver_data;
@@ -71,7 +71,7 @@ static int pwm_pca9685_pin_set_cycles(struct device *dev, u32_t pwm,
 	u8_t buf[] = { 0, 0, 0, 0, 0};
 
 	ARG_UNUSED(period_count);
-	if (!_has_i2c_master(dev)) {
+	if (!has_i2c_master(dev)) {
 		return -EINVAL;
 	}
 

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -14,7 +14,7 @@ LOG_MODULE_REGISTER(pwm_sifive, CONFIG_PWM_LOG_LEVEL);
 
 /* Macros */
 
-#define PWM_REG(_config, _offset) ((mem_addr_t) ((_config)->base + _offset))
+#define PWM_REG(z_config, _offset) ((mem_addr_t) ((z_config)->base + _offset))
 
 /* Register Offsets */
 #define REG_PWMCFG		0x00

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1231,7 +1231,7 @@ static int uarte_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 			    (.int_driven = &uarte##idx##_int_driven,),	       \
 			    ())						       \
 	};								       \
-	static const struct uarte_nrfx_config uarte_##idx##_config = {	       \
+	static const struct uarte_nrfx_config uarte_##idx##z_config = {	       \
 		.uarte_regs = (NRF_UARTE_Type *)			       \
 			DT_NORDIC_NRF_UARTE_UART_##idx##_BASE_ADDRESS,	       \
 		.rts_cts_pins_set = IS_ENABLED(UARTE_##idx##_CONFIG_RTS_CTS),  \
@@ -1273,7 +1273,7 @@ static int uarte_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 		      uarte_##idx##_init,				       \
 		      uarte_nrfx_pm_control,				       \
 		      &uarte_##idx##_data,				       \
-		      &uarte_##idx##_config,				       \
+		      &uarte_##idx##z_config,				       \
 		      PRE_KERNEL_1,					       \
 		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		       \
 		      &uart_nrfx_uarte_driver_api)

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -51,10 +51,10 @@ struct spi_context {
 };
 
 #define SPI_CONTEXT_INIT_LOCK(_data, _ctx_name)				\
-	._ctx_name.lock = _K_SEM_INITIALIZER(_data._ctx_name.lock, 0, 1)
+	._ctx_name.lock = Z_SEM_INITIALIZER(_data._ctx_name.lock, 0, 1)
 
 #define SPI_CONTEXT_INIT_SYNC(_data, _ctx_name)				\
-	._ctx_name.sync = _K_SEM_INITIALIZER(_data._ctx_name.sync, 0, 1)
+	._ctx_name.sync = Z_SEM_INITIALIZER(_data._ctx_name.sync, 0, 1)
 
 static inline bool spi_context_configured(struct spi_context *ctx,
 					  const struct spi_config *config)

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -508,8 +508,8 @@ int spi_dw_init(struct device *dev)
 	const struct spi_dw_config *info = dev->config->config_info;
 	struct spi_dw_data *spi = dev->driver_data;
 
-	_clock_config(dev);
-	_clock_on(dev);
+	clock_config(dev);
+	clock_on(dev);
 
 	info->config_func();
 
@@ -554,7 +554,7 @@ void spi_config_0_irq(void)
 	IRQ_CONNECT(DT_SPI_0_IRQ, DT_SPI_0_IRQ_PRI,
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_0), DT_SPI_DW_IRQ_FLAGS);
 	irq_enable(DT_SPI_0_IRQ);
-	_spi_int_unmask(SPI_DW_PORT_0_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_0_INT_MASK);
 #else
 	IRQ_CONNECT(DT_SPI_0_IRQ_RX_AVAIL, DT_SPI_0_IRQ_RX_AVAIL_PRI,
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_0), DT_SPI_DW_IRQ_FLAGS);
@@ -567,9 +567,9 @@ void spi_config_0_irq(void)
 	irq_enable(DT_SPI_0_IRQ_TX_REQ);
 	irq_enable(DT_SPI_0_IRQ_ERR_INT);
 
-	_spi_int_unmask(SPI_DW_PORT_0_RX_INT_MASK);
-	_spi_int_unmask(SPI_DW_PORT_0_TX_INT_MASK);
-	_spi_int_unmask(SPI_DW_PORT_0_ERROR_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_0_RX_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_0_TX_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_0_ERROR_INT_MASK);
 #endif
 }
 #endif /* CONFIG_SPI_0 */
@@ -602,7 +602,7 @@ void spi_config_1_irq(void)
 	IRQ_CONNECT(DT_SPI_1_IRQ, DT_SPI_1_IRQ_PRI,
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_1), DT_SPI_DW_IRQ_FLAGS);
 	irq_enable(DT_SPI_1_IRQ);
-	_spi_int_unmask(SPI_DW_PORT_1_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_1_INT_MASK);
 #else
 	IRQ_CONNECT(DT_SPI_1_IRQ_RX_AVAIL, DT_SPI_1_IRQ_RX_AVAIL_PRI,
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_1), DT_SPI_DW_IRQ_FLAGS);
@@ -615,9 +615,9 @@ void spi_config_1_irq(void)
 	irq_enable(DT_SPI_1_IRQ_TX_REQ);
 	irq_enable(DT_SPI_1_IRQ_ERR_INT);
 
-	_spi_int_unmask(SPI_DW_PORT_1_RX_INT_MASK);
-	_spi_int_unmask(SPI_DW_PORT_1_TX_INT_MASK);
-	_spi_int_unmask(SPI_DW_PORT_1_ERROR_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_1_RX_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_1_TX_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_1_ERROR_INT_MASK);
 #endif
 }
 #endif /* CONFIG_SPI_1 */
@@ -650,7 +650,7 @@ void spi_config_2_irq(void)
 	IRQ_CONNECT(DT_SPI_2_IRQ, DT_SPI_2_IRQ_PRI,
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_2), DT_SPI_DW_IRQ_FLAGS);
 	irq_enable(DT_SPI_2_IRQ);
-	_spi_int_unmask(SPI_DW_PORT_2_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_2_INT_MASK);
 #else
 	IRQ_CONNECT(DT_SPI_2_IRQ_RX_AVAIL, DT_SPI_2_IRQ_RX_AVAIL_PRI,
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_2), DT_SPI_DW_IRQ_FLAGS);
@@ -663,9 +663,9 @@ void spi_config_2_irq(void)
 	irq_enable(DT_SPI_2_IRQ_TX_REQ);
 	irq_enable(DT_SPI_2_IRQ_ERR_INT);
 
-	_spi_int_unmask(SPI_DW_PORT_2_RX_INT_MASK);
-	_spi_int_unmask(SPI_DW_PORT_2_TX_INT_MASK);
-	_spi_int_unmask(SPI_DW_PORT_2_ERROR_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_2_RX_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_2_TX_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_2_ERROR_INT_MASK);
 #endif
 }
 #endif /* CONFIG_SPI_2 */
@@ -698,7 +698,7 @@ void spi_config_3_irq(void)
 	IRQ_CONNECT(DT_SPI_3_IRQ, DT_SPI_3_IRQ_PRI,
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_3), DT_SPI_DW_IRQ_FLAGS);
 	irq_enable(DT_SPI_3_IRQ);
-	_spi_int_unmask(SPI_DW_PORT_3_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_3_INT_MASK);
 #else
 	IRQ_CONNECT(DT_SPI_3_IRQ_RX_AVAIL, DT_SPI_3_IRQ_RX_AVAIL_PRI,
 		    spi_dw_isr, DEVICE_GET(spi_dw_port_3), DT_SPI_DW_IRQ_FLAGS);
@@ -711,9 +711,9 @@ void spi_config_3_irq(void)
 	irq_enable(DT_SPI_3_IRQ_TX_REQ);
 	irq_enable(DT_SPI_3_IRQ_ERR_INT);
 
-	_spi_int_unmask(SPI_DW_PORT_3_RX_INT_MASK);
-	_spi_int_unmask(SPI_DW_PORT_3_TX_INT_MASK);
-	_spi_int_unmask(SPI_DW_PORT_3_ERROR_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_3_RX_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_3_TX_INT_MASK);
+	z_spi_int_unmask(SPI_DW_PORT_3_ERROR_INT_MASK);
 #endif
 }
 #endif /* CONFIG_SPI_3 */

--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -53,46 +53,46 @@ struct spi_dw_data {
 
 
 #ifdef CONFIG_SPI_DW_ARC_AUX_REGS
-#define _REG_READ(__sz) sys_in##__sz
-#define _REG_WRITE(__sz) sys_out##__sz
-#define _REG_SET_BIT sys_io_set_bit
-#define _REG_CLEAR_BIT sys_io_clear_bit
-#define _REG_TEST_BIT sys_io_test_bit
+#define Z_REG_READ(__sz) sys_in##__sz
+#define Z_REG_WRITE(__sz) sys_out##__sz
+#define Z_REG_SET_BIT sys_io_set_bit
+#define Z_REG_CLEAR_BIT sys_io_clear_bit
+#define Z_REG_TEST_BIT sys_io_test_bit
 #else
-#define _REG_READ(__sz) sys_read##__sz
-#define _REG_WRITE(__sz) sys_write##__sz
-#define _REG_SET_BIT sys_set_bit
-#define _REG_CLEAR_BIT sys_clear_bit
-#define _REG_TEST_BIT sys_test_bit
+#define Z_REG_READ(__sz) sys_read##__sz
+#define Z_REG_WRITE(__sz) sys_write##__sz
+#define Z_REG_SET_BIT sys_set_bit
+#define Z_REG_CLEAR_BIT sys_clear_bit
+#define Z_REG_TEST_BIT sys_test_bit
 #endif /* CONFIG_SPI_DW_ARC_AUX_REGS */
 
 #define DEFINE_MM_REG_READ(__reg, __off, __sz)				\
 	static inline u32_t read_##__reg(u32_t addr)			\
 	{								\
-		return _REG_READ(__sz)(addr + __off);			\
+		return Z_REG_READ(__sz)(addr + __off);			\
 	}
 #define DEFINE_MM_REG_WRITE(__reg, __off, __sz)				\
 	static inline void write_##__reg(u32_t data, u32_t addr)	\
 	{								\
-		_REG_WRITE(__sz)(data, addr + __off);			\
+		Z_REG_WRITE(__sz)(data, addr + __off);			\
 	}
 
 #define DEFINE_SET_BIT_OP(__reg_bit, __reg_off, __bit)			\
 	static inline void set_bit_##__reg_bit(u32_t addr)		\
 	{								\
-		_REG_SET_BIT(addr + __reg_off, __bit);			\
+		Z_REG_SET_BIT(addr + __reg_off, __bit);			\
 	}
 
 #define DEFINE_CLEAR_BIT_OP(__reg_bit, __reg_off, __bit)		\
 	static inline void clear_bit_##__reg_bit(u32_t addr)		\
 	{								\
-		_REG_CLEAR_BIT(addr + __reg_off, __bit);		\
+		Z_REG_CLEAR_BIT(addr + __reg_off, __bit);		\
 	}
 
 #define DEFINE_TEST_BIT_OP(__reg_bit, __reg_off, __bit)			\
 	static inline int test_bit_##__reg_bit(u32_t addr)		\
 	{								\
-		return _REG_TEST_BIT(addr + __reg_off, __bit);		\
+		return Z_REG_TEST_BIT(addr + __reg_off, __bit);		\
 	}
 
 /* Common registers settings, bits etc... */
@@ -206,8 +206,8 @@ struct spi_dw_data {
 #else
 #include "spi_dw_regs.h"
 
-#define _extra_clock_on(...)
-#define _extra_clock_off(...)
+#define z_extra_clock_on(...)
+#define z_extra_clock_off(...)
 
 #endif
 
@@ -221,10 +221,10 @@ struct spi_dw_data {
 #define _INT_UNMASK	INT_UNMASK_IA
 #endif
 
-#define _spi_int_unmask(__mask)						\
+#define z_spi_int_unmask(__mask)						\
 	sys_write32(sys_read32(__mask) & _INT_UNMASK, __mask)
 #else
-#define _spi_int_unmask(...)
+#define z_spi_int_unmask(...)
 #endif /* CONFIG_SOC_QUARK_SE_C1000 || CONFIG_SOC_QUARK_SE_C1000_SS */
 
 /* Based on those macros above, here are common helpers for some registers */
@@ -244,7 +244,7 @@ DEFINE_TEST_BIT_OP(sr_busy, DW_SPI_REG_SR, DW_SPI_SR_BUSY_BIT)
 
 #include <string.h>
 
-static inline int _clock_config(struct device *dev)
+static inline int clock_config(struct device *dev)
 {
 	const struct spi_dw_config *info = dev->config->config_info;
 	struct spi_dw_data *spi = dev->driver_data;
@@ -262,7 +262,7 @@ static inline int _clock_config(struct device *dev)
 	return 0;
 }
 
-static inline void _clock_on(struct device *dev)
+static inline void clock_on(struct device *dev)
 {
 	struct spi_dw_data *spi = dev->driver_data;
 
@@ -272,10 +272,10 @@ static inline void _clock_on(struct device *dev)
 		clock_control_on(spi->clock, info->clock_data);
 	}
 
-	_extra_clock_on(dev);
+	extra_clock_on(dev);
 }
 
-static inline void _clock_off(struct device *dev)
+static inline void clock_off(struct device *dev)
 {
 	struct spi_dw_data *spi = dev->driver_data;
 
@@ -285,12 +285,12 @@ static inline void _clock_off(struct device *dev)
 		clock_control_off(spi->clock, info->clock_data);
 	}
 
-	_extra_clock_off(dev);
+	extra_clock_off(dev);
 }
 #else
-#define _clock_config(...)
-#define _clock_on(...)
-#define _clock_off(...)
+#define clock_config(...)
+#define clock_on(...)
+#define clock_off(...)
 #endif /* CONFIG_CLOCK_CONTROL */
 
 #ifdef __cplusplus

--- a/drivers/spi/spi_dw_quark_se_ss_regs.h
+++ b/drivers/spi/spi_dw_quark_se_ss_regs.h
@@ -132,14 +132,14 @@ static inline u32_t read_dr(u32_t addr)
 DEFINE_SET_BIT_OP(clk_ena, DW_SPI_REG_CTRLR0, DW_SPI_CTRLR0_CLK_ENA_BIT)
 DEFINE_CLEAR_BIT_OP(clk_ena, DW_SPI_REG_CTRLR0, DW_SPI_CTRLR0_CLK_ENA_BIT)
 
-static inline void _extra_clock_on(struct device *dev)
+static inline void extra_clock_on(struct device *dev)
 {
 	const struct spi_dw_config *info = dev->config->config_info;
 
 	set_bit_clk_ena(info->regs);
 }
 
-static inline void _extra_clock_off(struct device *dev)
+static inline void extra_clock_off(struct device *dev)
 {
 	const struct spi_dw_config *info = dev->config->config_info;
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -294,13 +294,13 @@ static int init_spi(struct device *dev, const nrfx_spi_config_t *config)
 		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
 		.busy = false,						       \
 	};								       \
-	static const struct spi_nrfx_config spi_##idx##_config = {	       \
+	static const struct spi_nrfx_config spi_##idx##z_config = {	       \
 		.spi = NRFX_SPI_INSTANCE(idx),				       \
 	};								       \
 	DEVICE_AND_API_INIT(spi_##idx, DT_NORDIC_NRF_SPI_SPI_##idx##_LABEL,    \
 			    spi_##idx##_init,				       \
 			    &spi_##idx##_data,				       \
-			    &spi_##idx##_config,			       \
+			    &spi_##idx##z_config,			       \
 			    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,	       \
 			    &spi_nrfx_driver_api)
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -331,7 +331,7 @@ static int init_spim(struct device *dev, const nrfx_spim_config_t *config)
 		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
 		.busy = false,						       \
 	};								       \
-	static const struct spi_nrfx_config spi_##idx##_config = {	       \
+	static const struct spi_nrfx_config spi_##idx##z_config = {	       \
 		.spim = NRFX_SPIM_INSTANCE(idx),			       \
 		.max_chunk_len = (1 << SPIM##idx##_EASYDMA_MAXCNT_SIZE) - 1,   \
 	};								       \
@@ -339,7 +339,7 @@ static int init_spim(struct device *dev, const nrfx_spim_config_t *config)
 			    DT_NORDIC_NRF_SPI_SPI_##idx##_LABEL,	       \
 			    spi_##idx##_init,				       \
 			    &spi_##idx##_data,				       \
-			    &spi_##idx##_config,			       \
+			    &spi_##idx##z_config,			       \
 			    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,	       \
 			    &spi_nrfx_driver_api)
 

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -271,7 +271,7 @@ static int init_spis(struct device *dev, const nrfx_spis_config_t *config)
 		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \
 		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
 	};								       \
-	static const struct spi_nrfx_config spi_##idx##_config = {	       \
+	static const struct spi_nrfx_config spi_##idx##z_config = {	       \
 		.spis = NRFX_SPIS_INSTANCE(idx),			       \
 		.max_buf_len = (1 << SPIS##idx##_EASYDMA_MAXCNT_SIZE) - 1,     \
 	};								       \
@@ -279,7 +279,7 @@ static int init_spis(struct device *dev, const nrfx_spis_config_t *config)
 			    DT_NORDIC_NRF_SPIS_SPI_##idx##_LABEL,	       \
 			    spi_##idx##_init,				       \
 			    &spi_##idx##_data,				       \
-			    &spi_##idx##_config,			       \
+			    &spi_##idx##z_config,			       \
 			    POST_KERNEL,				       \
 			    CONFIG_SPI_INIT_PRIORITY,			       \
 			    &spi_nrfx_driver_api)

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -129,7 +129,7 @@ static u32_t elapsed(void)
  *
  * @return N/A
  */
-static void _timer_int_handler(void *unused)
+static void timer_int_handler(void *unused)
 {
 	ARG_UNUSED(unused);
 	u32_t dticks;
@@ -164,7 +164,7 @@ int z_clock_driver_init(struct device *device)
 	last_load = CYC_PER_TICK;
 
 	IRQ_CONNECT(IRQ_TIMER0, CONFIG_ARCV2_TIMER_IRQ_PRIORITY,
-		    _timer_int_handler, NULL, 0);
+		    timer_int_handler, NULL, 0);
 
 	timer0_limit_register_set(last_load - 1);
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT

--- a/drivers/timer/legacy_api.h
+++ b/drivers/timer/legacy_api.h
@@ -10,15 +10,15 @@
  */
 
 #ifdef CONFIG_TICKLESS_IDLE
-void _timer_idle_enter(s32_t ticks);
+void z_timer_idle_enter(s32_t ticks);
 void z_clock_idle_exit(void);
 #endif
 
 #ifdef CONFIG_TICKLESS_KERNEL
-void _set_time(u32_t time);
-extern u32_t _get_program_time(void);
-extern u32_t _get_remaining_program_time(void);
-extern u32_t _get_elapsed_program_time(void);
+void z_set_time(u32_t time);
+extern u32_t z_get_program_time(void);
+extern u32_t z_get_remaining_program_time(void);
+extern u32_t z_get_elapsed_program_time(void);
 #endif
 
 extern u64_t z_clock_uptime(void);
@@ -27,9 +27,9 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 {
 #ifdef CONFIG_TICKLESS_KERNEL
 	if (idle) {
-		_timer_idle_enter(ticks);
+		z_timer_idle_enter(ticks);
 	} else {
-		_set_time(ticks == K_FOREVER ? 0 : ticks);
+		z_set_time(ticks == K_FOREVER ? 0 : ticks);
 	}
 #endif
 }

--- a/drivers/timer/loapic_timer.c
+++ b/drivers/timer/loapic_timer.c
@@ -23,7 +23,7 @@
  *
  * If the TICKLESS_IDLE kernel configuration option is enabled, the timer may
  * be programmed to wake the system in N >= TICKLESS_IDLE_THRESH ticks.  The
- * kernel invokes _timer_idle_enter() to program the down counter in one-shot
+ * kernel invokes z_timer_idle_enter() to program the down counter in one-shot
  * mode to trigger an interrupt in N ticks.  When the timer expires or when
  * another interrupt is detected, the kernel's interrupt stub invokes
  * z_clock_idle_exit() to leave the tickless idle state.
@@ -45,7 +45,7 @@
  * straddled, the following will occur:
  *    a. Enter tickless idle in one-shot mode
  *    b. Immediately leave tickless idle
- *    c. Process the tick event in the _timer_int_handler() and revert
+ *    c. Process the tick event in the timer_int_handler() and revert
  *       to periodic mode.
  *    d. Re-run the scheduler and possibly re-enter tickless idle
  *
@@ -55,9 +55,9 @@
  * 5. Tickless idle may be prematurely aborted due to a non-timer interrupt.
  * Its handler may make a thread ready to run, so any elapsed ticks
  * must be accounted for and the timer must also expire at the end of the
- * next logical tick so _timer_int_handler() can put it back in periodic mode.
+ * next logical tick so timer_int_handler() can put it back in periodic mode.
  * This can only be distinguished from the previous factor by the execution of
- * _timer_int_handler().
+ * timer_int_handler().
  *
  * 6. Tickless idle may end naturally.  The down counter should be zero in
  * this case. However, some targets do not implement the local APIC timer
@@ -277,7 +277,7 @@ static inline void program_max_cycles(void)
 }
 #endif
 
-void _timer_int_handler(void *unused /* parameter is not used */
+void timer_int_handler(void *unused /* parameter is not used */
 				 )
 {
 #ifdef CONFIG_EXECUTION_BENCHMARKING
@@ -380,12 +380,12 @@ void _timer_int_handler(void *unused /* parameter is not used */
 }
 
 #ifdef CONFIG_TICKLESS_KERNEL
-u32_t _get_program_time(void)
+u32_t z_get_program_time(void)
 {
 	return programmed_full_ticks;
 }
 
-u32_t _get_remaining_program_time(void)
+u32_t z_get_remaining_program_time(void)
 {
 	if (programmed_full_ticks == 0U) {
 		return 0;
@@ -394,7 +394,7 @@ u32_t _get_remaining_program_time(void)
 	return current_count_register_get() / cycles_per_tick;
 }
 
-u32_t _get_elapsed_program_time(void)
+u32_t z_get_elapsed_program_time(void)
 {
 	if (programmed_full_ticks == 0U) {
 		return 0;
@@ -404,7 +404,7 @@ u32_t _get_elapsed_program_time(void)
 	    (current_count_register_get() / cycles_per_tick);
 }
 
-void _set_time(u32_t time)
+void z_set_time(u32_t time)
 {
 	if (!time) {
 		programmed_full_ticks = 0U;
@@ -479,14 +479,14 @@ static void tickless_idle_init(void)
  *
  * @return N/A
  */
-void _timer_idle_enter(s32_t ticks /* system ticks */
+void z_timer_idle_enter(s32_t ticks /* system ticks */
 				)
 {
 #ifdef CONFIG_TICKLESS_KERNEL
 	if (ticks != K_FOREVER) {
 		/* Need to reprogram only if current program is smaller */
 		if (ticks > programmed_full_ticks) {
-			_set_time(ticks);
+			z_set_time(ticks);
 		}
 	} else {
 		programmed_full_ticks = 0U;
@@ -576,9 +576,9 @@ void z_clock_idle_exit(void)
 	if ((remaining_cycles == 0U) ||
 		(remaining_cycles >= programmed_cycles)) {
 		/*
-		 * The timer has expired. The handler _timer_int_handler() is
+		 * The timer has expired. The handler timer_int_handler() is
 		 * guaranteed to execute. Track the number of elapsed ticks. The
-		 * handler _timer_int_handler() will account for the final tick.
+		 * handler timer_int_handler() will account for the final tick.
 		 */
 
 		_sys_idle_elapsed_ticks = programmed_full_ticks;
@@ -612,7 +612,7 @@ void z_clock_idle_exit(void)
 	 * NOTE #2: In the case of a straddled tick, it is assumed that when the
 	 * timer is reprogrammed, it will be reprogrammed with a cycle count
 	 * sufficiently close to one tick that the timer will not expire before
-	 * _timer_int_handler() is executed.
+	 * timer_int_handler() is executed.
 	 */
 
 	remaining_full_ticks = remaining_cycles / cycles_per_tick;
@@ -669,7 +669,7 @@ int z_clock_driver_init(struct device *device)
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 	loapic_timer_device_power_state = DEVICE_PM_ACTIVE_STATE;
 #endif
-	IRQ_CONNECT(TIMER_IRQ, TIMER_IRQ_PRIORITY, _timer_int_handler, 0, 0);
+	IRQ_CONNECT(TIMER_IRQ, TIMER_IRQ_PRIORITY, timer_int_handler, 0, 0);
 
 	/* Everything has been configured. It is now safe to enable the
 	 * interrupt
@@ -782,7 +782,7 @@ u32_t z_timer_cycle_get_32(void)
 	/* TSC runs same as the bus speed, nothing to do but return the TSC
 	 * value
 	 */
-	return _do_read_cpu_timestamp32();
+	return z_do_read_cpu_timestamp32();
 #endif
 }
 

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -44,7 +44,7 @@ u32_t z_timer_cycle_get_32(void)
  * if sys_ticks is K_FOREVER (or another negative number),
  * we will effectively silence the tick interrupts forever
  */
-void _timer_idle_enter(s32_t sys_ticks)
+void z_timer_idle_enter(s32_t sys_ticks)
 {
 	if (silent_ticks > 0) { /* LCOV_EXCL_BR_LINE */
 		/* LCOV_EXCL_START */

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -62,7 +62,7 @@ static void ccompare_isr(void *arg)
  * pervasive.
  */
 #ifndef CONFIG_XTENSA_ASM2
-void _timer_int_handler(void *arg)
+void timer_int_handler(void *arg)
 {
 	return ccompare_isr(arg);
 }

--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -64,7 +64,7 @@ struct usb_dw_ctrl_prv {
 
 static struct usb_dw_ctrl_prv usb_dw_ctrl;
 
-static inline void _usb_dw_int_unmask(void)
+static inline void usb_dw_int_unmask(void)
 {
 #if defined(CONFIG_SOC_QUARK_SE_C1000)
 	QM_INTERRUPT_ROUTER->usb_0_int_mask &= ~BIT(0);
@@ -752,7 +752,7 @@ int usb_dc_attach(void)
 	    usb_dw_isr_handler, 0, IOAPIC_EDGE | IOAPIC_HIGH);
 	irq_enable(USB_DW_IRQ);
 
-	_usb_dw_int_unmask();
+	usb_dw_int_unmask();
 
 	usb_dw_ctrl.attached = 1U;
 

--- a/drivers/watchdog/wdog_cmsdk_apb.c
+++ b/drivers/watchdog/wdog_cmsdk_apb.c
@@ -145,7 +145,7 @@ static const struct wdt_driver_api wdog_cmsdk_apb_api = {
 };
 
 #ifdef CONFIG_RUNTIME_NMI
-extern void _NmiHandlerSet(void (*pHandler)(void));
+extern void z_NmiHandlerSet(void (*pHandler)(void));
 
 static int wdog_cmsdk_apb_has_fired(void)
 {
@@ -186,7 +186,7 @@ static int wdog_cmsdk_apb_init(struct device *dev)
 
 #ifdef CONFIG_RUNTIME_NMI
 	/* Configure the interrupts */
-	_NmiHandlerSet(wdog_cmsdk_apb_isr);
+	z_NmiHandlerSet(wdog_cmsdk_apb_isr);
 #endif
 
 #ifdef CONFIG_WDOG_CMSDK_APB_START_AT_BOOT

--- a/drivers/wifi/simplelink/simplelink.c
+++ b/drivers/wifi/simplelink/simplelink.c
@@ -92,7 +92,7 @@ static void simplelink_scan_work_handler(struct k_work *work)
 
 		/* Iterate over the table, and call the scan_result callback. */
 		while (index < simplelink_data.num_results_or_err) {
-			_simplelink_get_scan_result(index, &scan_result);
+			z_simplelink_get_scan_result(index, &scan_result);
 			simplelink_data.cb(simplelink_data.iface, 0,
 					   &scan_result);
 			/* Yield, to ensure notifications get delivered:  */
@@ -112,7 +112,7 @@ static void simplelink_scan_work_handler(struct k_work *work)
 		s32_t delay;
 
 		/* Try again: */
-		simplelink_data.num_results_or_err = _simplelink_start_scan();
+		simplelink_data.num_results_or_err = z_simplelink_start_scan();
 		simplelink_data.scan_retries++;
 		delay = (simplelink_data.num_results_or_err > 0 ? 0 :
 			 SCAN_RETRY_DELAY);
@@ -139,7 +139,7 @@ static int simplelink_mgmt_scan(struct device *dev, scan_result_cb_t cb)
 	k_delayed_work_cancel(&simplelink_data.work);
 
 	/* "Request" the scan: */
-	err = _simplelink_start_scan();
+	err = z_simplelink_start_scan();
 
 	/* Now, launch a delayed work handler to do retries and reporting.
 	 * Indicate (to the work handler) either a positive number of results
@@ -167,7 +167,7 @@ static int simplelink_mgmt_connect(struct device *dev,
 {
 	int ret;
 
-	ret = _simplelink_connect(params);
+	ret = z_simplelink_connect(params);
 
 	return ret ? -EIO : ret;
 }
@@ -176,7 +176,7 @@ static int simplelink_mgmt_disconnect(struct device *dev)
 {
 	int ret;
 
-	ret = _simplelink_disconnect();
+	ret = z_simplelink_disconnect();
 
 	return ret ? -EIO : ret;
 }
@@ -215,9 +215,9 @@ static void simplelink_iface_init(struct net_if *iface)
 	iface->if_dev->offload = &simplelink_offload;
 
 	/* Initialize and configure NWP to defaults: */
-	ret = _simplelink_init(simplelink_wifi_cb);
+	ret = z_simplelink_init(simplelink_wifi_cb);
 	if (ret) {
-		LOG_ERR("_simplelink_init failed!");
+		LOG_ERR("z_simplelink_init failed!");
 		return;
 	}
 
@@ -229,7 +229,7 @@ static void simplelink_iface_init(struct net_if *iface)
 	}
 
 	/* Grab our MAC address: */
-	_simplelink_get_mac(simplelink_data.mac);
+	z_simplelink_get_mac(simplelink_data.mac);
 
 	LOG_DBG("MAC Address %02X:%02X:%02X:%02X:%02X:%02X",
 		simplelink_data.mac[0], simplelink_data.mac[1],

--- a/drivers/wifi/simplelink/simplelink_support.c
+++ b/drivers/wifi/simplelink/simplelink_support.c
@@ -488,7 +488,7 @@ void SimpleLinkNetAppRequestMemFreeEventHandler(u8_t *buffer)
  * - Whether network hidden or visible
  * - Other types of security
  */
-void _simplelink_get_scan_result(int index,
+void z_simplelink_get_scan_result(int index,
 				 struct wifi_scan_result *scan_result)
 {
 	SlWlanNetworkEntry_t *net_entry;
@@ -515,7 +515,7 @@ void _simplelink_get_scan_result(int index,
 	scan_result->rssi = net_entry->Rssi;
 }
 
-int _simplelink_start_scan(void)
+int z_simplelink_start_scan(void)
 {
 	s32_t ret;
 
@@ -533,7 +533,7 @@ int _simplelink_start_scan(void)
 	return ret;
 }
 
-void _simplelink_get_mac(unsigned char *mac)
+void z_simplelink_get_mac(unsigned char *mac)
 {
 	u16_t mac_len = SL_MAC_ADDR_LEN;
 	u16_t config_opt = 0U;
@@ -542,7 +542,7 @@ void _simplelink_get_mac(unsigned char *mac)
 		     &mac_len, (u8_t *)mac);
 }
 
-int _simplelink_connect(struct wifi_connect_req_params *params)
+int z_simplelink_connect(struct wifi_connect_req_params *params)
 {
 	SlWlanSecParams_t secParams = { 0 };
 	long lretval;
@@ -565,7 +565,7 @@ int _simplelink_connect(struct wifi_connect_req_params *params)
 	return lretval;
 }
 
-int _simplelink_disconnect(void)
+int z_simplelink_disconnect(void)
 {
 	long lretval;
 
@@ -575,7 +575,7 @@ int _simplelink_disconnect(void)
 	return lretval;
 }
 
-int _simplelink_init(simplelink_wifi_cb_t wifi_cb)
+int z_simplelink_init(simplelink_wifi_cb_t wifi_cb)
 {
 	int retval;
 

--- a/drivers/wifi/simplelink/simplelink_support.h
+++ b/drivers/wifi/simplelink/simplelink_support.h
@@ -35,13 +35,13 @@ struct sl_connect_state {
 typedef void (*simplelink_wifi_cb_t)(u32_t mgmt_event,
 				     struct sl_connect_state *conn);
 
-extern int _simplelink_start_scan(void);
-extern void _simplelink_get_scan_result(int index,
+extern int z_simplelink_start_scan(void);
+extern void z_simplelink_get_scan_result(int index,
 					struct wifi_scan_result *scan_result);
-extern void _simplelink_get_mac(unsigned char *mac);
-extern int _simplelink_init(simplelink_wifi_cb_t wifi_cb);
-extern int _simplelink_connect(struct wifi_connect_req_params *params);
-extern int _simplelink_disconnect(void);
+extern void z_simplelink_get_mac(unsigned char *mac);
+extern int z_simplelink_init(simplelink_wifi_cb_t wifi_cb);
+extern int z_simplelink_connect(struct wifi_connect_req_params *params);
+extern int z_simplelink_disconnect(void);
 
 #ifdef __cplusplus
 }

--- a/ext/hal/cypress/PDL/3.1.0/drivers/include/cy_sysclk.h
+++ b/ext/hal/cypress/PDL/3.1.0/drivers/include/cy_sysclk.h
@@ -29,7 +29,7 @@
 * clock system.
 *
 * The PDL defines clock system capabilities in:\n
-* devices\<family\>/<series\>/include\<series\>_config.h. (E.g.
+* devices\<family\>/<series\>/include\<series\>z_config.h. (E.g.
 * devices/psoc6/psoc63/include/psoc63_config.h). 
 * User-configurable clock speeds are defined in the file system_<series>.h.
 *

--- a/ext/hal/libmetal/libmetal/lib/system/zephyr/mutex.h
+++ b/ext/hal/libmetal/libmetal/lib/system/zephyr/mutex.h
@@ -29,7 +29,7 @@ typedef struct k_sem metal_mutex_t;
  * METAL_MUTEX_INIT - used for initializing an mutex elmenet in a static struct
  * or global
  */
-#define METAL_MUTEX_INIT(m) _K_SEM_INITIALIZER(m, 1, 1)
+#define METAL_MUTEX_INIT(m) Z_SEM_INITIALIZER(m, 1, 1)
 /*
  * METAL_MUTEX_DEFINE - used for defining and initializing a global or
  * static singleton mutex

--- a/ext/hal/nxp/mcux/drivers/imx/fsl_gpio.h
+++ b/ext/hal/nxp/mcux/drivers/imx/fsl_gpio.h
@@ -45,7 +45,7 @@ typedef enum _gpio_interrupt_mode
 } gpio_interrupt_mode_t;
 
 /*! @brief GPIO Init structure definition. */
-typedef struct _gpio_pin_config
+typedef struct z_gpio_pin_config
 {
     gpio_pin_direction_t direction; /*!< Specifies the pin direction. */
     uint8_t outputLogic;            /*!< Set a default output logic, which has no use in input */

--- a/ext/hal/nxp/mcux/drivers/kinetis/fsl_gpio.h
+++ b/ext/hal/nxp/mcux/drivers/kinetis/fsl_gpio.h
@@ -65,7 +65,7 @@ typedef enum _gpio_checker_attribute
  * Note that in some use cases, the corresponding port property should be configured in advance
  *        with the PORT_SetPinConfig().
  */
-typedef struct _gpio_pin_config
+typedef struct z_gpio_pin_config
 {
     gpio_pin_direction_t pinDirection; /*!< GPIO direction, input or output */
     /* Output configurations; ignore if configured as an input pin */

--- a/ext/hal/nxp/mcux/drivers/lpc/fsl_gpio.h
+++ b/ext/hal/nxp/mcux/drivers/lpc/fsl_gpio.h
@@ -41,7 +41,7 @@ typedef enum _gpio_pin_direction
  * Every pin can only be configured as either output pin or input pin at a time.
  * If configured as a input pin, then leave the outputConfig unused.
  */
-typedef struct _gpio_pin_config
+typedef struct z_gpio_pin_config
 {
     gpio_pin_direction_t pinDirection; /*!< GPIO direction, input or output */
     /* Output configurations, please ignore if configured as a input one */

--- a/ext/hal/openisa/vega_sdk_riscv/devices/RV32M1/drivers/fsl_gpio.h
+++ b/ext/hal/openisa/vega_sdk_riscv/devices/RV32M1/drivers/fsl_gpio.h
@@ -65,7 +65,7 @@ typedef enum _gpio_checker_attribute
  * Note that in some use cases, the corresponding port property should be configured in advance
  *        with the PORT_SetPinConfig().
  */
-typedef struct _gpio_pin_config
+typedef struct z_gpio_pin_config
 {
     gpio_pin_direction_t pinDirection; /*!< GPIO direction, input or output */
     /* Output configurations; ignore if configured as an input pin */

--- a/include/arch/arc/v2/arcv2_irq_unit.h
+++ b/include/arch/arc/v2/arcv2_irq_unit.h
@@ -67,7 +67,7 @@ void z_arc_v2_irq_unit_irq_enable_set(
  */
 
 static ALWAYS_INLINE
-void _arc_v2_irq_unit_int_enable(int irq)
+void z_arc_v2_irq_unit_int_enable(int irq)
 {
 	z_arc_v2_irq_unit_irq_enable_set(irq, _ARC_V2_INT_ENABLE);
 }
@@ -81,7 +81,7 @@ void _arc_v2_irq_unit_int_enable(int irq)
  */
 
 static ALWAYS_INLINE
-void _arc_v2_irq_unit_int_disable(int irq)
+void z_arc_v2_irq_unit_int_disable(int irq)
 {
 	z_arc_v2_irq_unit_irq_enable_set(irq, _ARC_V2_INT_DISABLE);
 }
@@ -95,7 +95,7 @@ void _arc_v2_irq_unit_int_disable(int irq)
  */
 
 static ALWAYS_INLINE
-void _arc_v2_irq_unit_prio_set(int irq, unsigned char prio)
+void z_arc_v2_irq_unit_prio_set(int irq, unsigned char prio)
 {
 	z_arc_v2_aux_reg_write(_ARC_V2_IRQ_SELECT, irq);
 #ifdef CONFIG_ARC_HAS_SECURE

--- a/include/arch/arc/v2/aux_regs.h
+++ b/include/arch/arc/v2/aux_regs.h
@@ -146,9 +146,9 @@ extern "C" {
 #define _ARC_V2_IRQ_PRIORITY_SECURE 0x100
 
 /* exception cause register masks */
-#define _ARC_V2_ECR_VECTOR(X) ((X & 0xff0000) >> 16)
-#define _ARC_V2_ECR_CODE(X) ((X & 0xff00) >> 8)
-#define _ARC_V2_ECR_PARAMETER(X) (X & 0xff)
+#define Z_ARC_V2_ECR_VECTOR(X) ((X & 0xff0000) >> 16)
+#define Z_ARC_V2_ECR_CODE(X) ((X & 0xff00) >> 8)
+#define Z_ARC_V2_ECR_PARAMETER(X) (X & 0xff)
 
 #ifndef _ASMLANGUAGE
 #if defined(__GNUC__)

--- a/include/arch/arc/v2/aux_regs.h
+++ b/include/arch/arc/v2/aux_regs.h
@@ -108,7 +108,7 @@ extern "C" {
 
 /* STATUS32/STATUS32_P0 bits */
 #define _ARC_V2_STATUS32_H (1 << 0)
-#define _ARC_V2_STATUS32_E(x) ((x) << 1)
+#define Z_ARC_V2_STATUS32_E(x) ((x) << 1)
 #define _ARC_V2_STATUS32_AE_BIT 5
 #define _ARC_V2_STATUS32_AE (1 << _ARC_V2_STATUS32_AE_BIT)
 #define _ARC_V2_STATUS32_DE (1 << 6)

--- a/include/arch/nios2/nios2.h
+++ b/include/arch/nios2/nios2.h
@@ -84,7 +84,7 @@ static inline u32_t _nios2_read_sp(void)
 /*
  * Functions for useful processor instructions.
  */
-static inline void _nios2_break(void)
+static inline void z_nios2_break(void)
 {
 	__asm__ volatile("break");
 }
@@ -102,17 +102,17 @@ static inline void _nios2_dcache_addr_flush(void *addr)
 	__asm__ volatile ("flushda (%0)" :: "r" (addr));
 }
 
-static inline void _nios2_dcache_flush(u32_t offset)
+static inline void z_nios2_dcache_flush(u32_t offset)
 {
 	__asm__ volatile ("flushd (%0)" :: "r" (offset));
 }
 
-static inline void _nios2_icache_flush(u32_t offset)
+static inline void z_nios2_icache_flush(u32_t offset)
 {
 	__asm__ volatile ("flushi %0" :: "r" (offset));
 }
 
-static inline void _nios2_pipeline_flush(void)
+static inline void z_nios2_pipeline_flush(void)
 {
 	__asm__ volatile ("flushp");
 }
@@ -145,15 +145,15 @@ enum nios2_creg {
  * we get errors "Control register number must be in range 0-31 for
  * __builtin_rdctl" with the following code:
  *
- * static inline u32_t _nios2_creg_read(enum nios2_creg reg)
+ * static inline u32_t z_nios2_creg_read(enum nios2_creg reg)
  * {
  *          return __builtin_rdctl(reg);
  * }
  *
  * This compiles just fine with -Os.
  */
-#define _nios2_creg_read(reg) __builtin_rdctl(reg)
-#define _nios2_creg_write(reg, val) __builtin_wrctl(reg, val)
+#define z_nios2_creg_read(reg) __builtin_rdctl(reg)
+#define z_nios2_creg_write(reg, val) __builtin_wrctl(reg, val)
 
 #define z_nios2_get_register_address(base, regnum) \
 	((void *)(((u8_t *)base) + ((regnum) * (SYSTEM_BUS_WIDTH / 8))))

--- a/include/arch/x86/asm_inline_gcc.h
+++ b/include/arch/x86/asm_inline_gcc.h
@@ -217,7 +217,7 @@ static inline u64_t z_tsc_read(void)
  */
 
 static ALWAYS_INLINE
-	u32_t _do_read_cpu_timestamp32(void)
+	u32_t z_do_read_cpu_timestamp32(void)
 {
 	u32_t rv;
 

--- a/include/arch/x86/irq_controller.h
+++ b/include/arch/x86/irq_controller.h
@@ -79,13 +79,13 @@ static inline void z_irq_controller_irq_config(unsigned int vector,
  * @return the vector of the interrupt that is currently being processed, or
  * -1 if this can't be determined
  */
-static inline int _irq_controller_isr_vector_get(void)
+static inline int z_irq_controller_isr_vector_get(void)
 {
 	return __irq_controller_isr_vector_get();
 }
 
 
-static inline void _irq_controller_eoi(void)
+static inline void z_irq_controller_eoi(void)
 {
 	__irq_controller_eoi();
 }

--- a/include/arch/x86/segmentation.h
+++ b/include/arch/x86/segmentation.h
@@ -407,7 +407,7 @@ static inline void z_sd_set_seg_offset(struct segment_descriptor *sd,
  * @param offset offset of handler
  * @param dpl descriptor privilege level
  */
-static inline void _init_irq_gate(struct segment_descriptor *sd,
+static inline void z_init_irq_gate(struct segment_descriptor *sd,
 				  u16_t seg_selector, u32_t offset,
 				  u32_t dpl)
 {
@@ -509,7 +509,7 @@ static inline void _set_gdt(const struct pseudo_descriptor *gdt)
  *
  * @param idt Pointer to IDT pseudo descriptor.
  */
-static inline void _set_idt(const struct pseudo_descriptor *idt)
+static inline void z_set_idt(const struct pseudo_descriptor *idt)
 {
 	__asm__ __volatile__ ("lidt %0" :: "m" (*idt));
 }

--- a/include/arch/x86/syscall.h
+++ b/include/arch/x86/syscall.h
@@ -31,7 +31,7 @@ extern "C" {
 
 /* Syscall invocation macros. x86-specific machine constraints used to ensure
  * args land in the proper registers, see implementation of
- * _x86_syscall_entry_stub in userspace.S
+ * z_x86_syscall_entry_stub in userspace.S
  *
  * the entry stub clobbers EDX and ECX on IAMCU systems
  */

--- a/include/device.h
+++ b/include/device.h
@@ -149,7 +149,7 @@ extern "C" {
 	static struct device_pm _CONCAT(__pm_, dev_name) __used           \
 							= {               \
 		.usage = ATOMIC_INIT(0),                                  \
-		.lock = _K_SEM_INITIALIZER(                               \
+		.lock = Z_SEM_INITIALIZER(                               \
 				_CONCAT(__pm_, dev_name).lock, 1, 1),     \
 		.signal = K_POLL_SIGNAL_INITIALIZER(                      \
 				_CONCAT(__pm_, dev_name).signal),         \

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1387,7 +1387,7 @@ struct k_timer {
 	_OBJECT_TRACING_NEXT_PTR(k_timer)
 };
 
-#define _K_TIMER_INITIALIZER(obj, expiry, stop) \
+#define Z_TIMER_INITIALIZER(obj, expiry, stop) \
 	{ \
 	.timeout = { \
 		.node = {},\
@@ -1403,7 +1403,7 @@ struct k_timer {
 	_OBJECT_TRACING_INIT \
 	}
 
-#define K_TIMER_INITIALIZER DEPRECATED_MACRO _K_TIMER_INITIALIZER
+#define K_TIMER_INITIALIZER DEPRECATED_MACRO Z_TIMER_INITIALIZER
 
 /**
  * INTERNAL_HIDDEN @endcond
@@ -1458,7 +1458,7 @@ typedef void (*k_timer_stop_t)(struct k_timer *timer);
 #define K_TIMER_DEFINE(name, expiry_fn, stop_fn) \
 	struct k_timer name \
 		__in_section(_k_timer, static, name) = \
-		_K_TIMER_INITIALIZER(name, expiry_fn, stop_fn)
+		Z_TIMER_INITIALIZER(name, expiry_fn, stop_fn)
 
 /**
  * @brief Initialize a timer.
@@ -2051,12 +2051,12 @@ struct k_fifo {
 /**
  * @cond INTERNAL_HIDDEN
  */
-#define _K_FIFO_INITIALIZER(obj) \
+#define Z_FIFO_INITIALIZER(obj) \
 	{ \
 	._queue = _K_QUEUE_INITIALIZER(obj._queue) \
 	}
 
-#define K_FIFO_INITIALIZER DEPRECATED_MACRO _K_FIFO_INITIALIZER
+#define K_FIFO_INITIALIZER DEPRECATED_MACRO Z_FIFO_INITIALIZER
 
 /**
  * INTERNAL_HIDDEN @endcond
@@ -2256,7 +2256,7 @@ struct k_fifo {
 #define K_FIFO_DEFINE(name) \
 	struct k_fifo name \
 		__in_section(_k_queue, static, name) = \
-		_K_FIFO_INITIALIZER(name)
+		Z_FIFO_INITIALIZER(name)
 
 /** @} */
 
@@ -3010,7 +3010,7 @@ struct k_sem {
 	_OBJECT_TRACING_NEXT_PTR(k_sem)
 };
 
-#define _K_SEM_INITIALIZER(obj, initial_count, count_limit) \
+#define Z_SEM_INITIALIZER(obj, initial_count, count_limit) \
 	{ \
 	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q), \
 	.count = initial_count, \
@@ -3019,7 +3019,7 @@ struct k_sem {
 	_OBJECT_TRACING_INIT \
 	}
 
-#define K_SEM_INITIALIZER DEPRECATED_MACRO _K_SEM_INITIALIZER
+#define K_SEM_INITIALIZER DEPRECATED_MACRO Z_SEM_INITIALIZER
 
 /**
  * INTERNAL_HIDDEN @endcond
@@ -3140,7 +3140,7 @@ static inline unsigned int z_impl_k_sem_count_get(struct k_sem *sem)
 #define K_SEM_DEFINE(name, initial_count, count_limit) \
 	struct k_sem name \
 		__in_section(_k_sem, static, name) = \
-		_K_SEM_INITIALIZER(name, initial_count, count_limit); \
+		Z_SEM_INITIALIZER(name, initial_count, count_limit); \
 	BUILD_ASSERT(((count_limit) != 0) && \
 		     ((initial_count) <= (count_limit)));
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -576,7 +576,7 @@ struct k_thread {
 	/** z_swap() return value */
 	int swap_retval;
 
-	/** Context handle returned via _arch_switch() */
+	/** Context handle returned via z_arch_switch() */
 	void *switch_handle;
 #endif
 	/** resource pool */

--- a/include/linker/priv_stacks-text.ld
+++ b/include/linker/priv_stacks-text.ld
@@ -15,7 +15,7 @@
 	_priv_stacks_text_area_used = _priv_stacks_text_area_end - _priv_stacks_text_area_start;
 
 #ifndef LINKER_PASS2
-	PROVIDE(_k_priv_stack_find = .);
+	PROVIDE(z_priv_stack_find = .);
 #endif
 
 	/* In a valid build the MAX function will always evaluate to the

--- a/include/misc/printk.h
+++ b/include/misc/printk.h
@@ -52,7 +52,7 @@ extern __printf_like(3, 4) int snprintk(char *str, size_t size,
 extern __printf_like(3, 0) int vsnprintk(char *str, size_t size,
 					  const char *fmt, va_list ap);
 
-extern __printf_like(3, 0) void _vprintk(int (*out)(int f, void *c), void *ctx,
+extern __printf_like(3, 0) void z_vprintk(int (*out)(int f, void *c), void *ctx,
 					 const char *fmt, va_list ap);
 #else
 static inline __printf_like(1, 2) void printk(const char *fmt, ...)

--- a/kernel/include/kernel_structs.h
+++ b/kernel/include/kernel_structs.h
@@ -212,7 +212,7 @@ extern void z_init_thread_base(struct _thread_base *thread_base,
 			      int priority, u32_t initial_state,
 			      unsigned int options);
 
-static ALWAYS_INLINE void _new_thread_init(struct k_thread *thread,
+static ALWAYS_INLINE void z_new_thread_init(struct k_thread *thread,
 					    char *pStack, size_t stackSize,
 					    int prio, unsigned int options)
 {

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -29,7 +29,7 @@ void z_smp_release_global_lock(struct k_thread *thread);
 /* context switching and scheduling-related routines */
 #ifdef CONFIG_USE_SWITCH
 
-/* New style context switching.  _arch_switch() is a lower level
+/* New style context switching.  z_arch_switch() is a lower level
  * primitive that doesn't know about the scheduler or return value.
  * Needed for SMP, where the scheduler requires spinlocking that we
  * don't want to have to do in per-architecture assembly.
@@ -76,7 +76,7 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 		}
 #endif
 		_current = new_thread;
-		_arch_switch(new_thread->switch_handle,
+		z_arch_switch(new_thread->switch_handle,
 			     &old_thread->switch_handle);
 	}
 

--- a/lib/libc/minimal/source/stdout/fprintf.c
+++ b/lib/libc/minimal/source/stdout/fprintf.c
@@ -11,7 +11,7 @@
 
 #define DESC(d) ((void *)d)
 
-extern int _prf(int (*func)(), void *dest,
+extern int z_prf(int (*func)(), void *dest,
 				const char *format, va_list vargs);
 
 int fprintf(FILE *_MLIBC_RESTRICT F, const char *_MLIBC_RESTRICT format, ...)
@@ -20,7 +20,7 @@ int fprintf(FILE *_MLIBC_RESTRICT F, const char *_MLIBC_RESTRICT format, ...)
 	int     r;
 
 	va_start(vargs, format);
-	r = _prf(fputc, DESC(F), format, vargs);
+	r = z_prf(fputc, DESC(F), format, vargs);
 	va_end(vargs);
 
 	return r;
@@ -31,7 +31,7 @@ int vfprintf(FILE *_MLIBC_RESTRICT F, const char *_MLIBC_RESTRICT format,
 {
 	int r;
 
-	r = _prf(fputc, DESC(F), format, vargs);
+	r = z_prf(fputc, DESC(F), format, vargs);
 
 	return r;
 }
@@ -42,7 +42,7 @@ int printf(const char *_MLIBC_RESTRICT format, ...)
 	int     r;
 
 	va_start(vargs, format);
-	r = _prf(fputc, DESC(stdout), format, vargs);
+	r = z_prf(fputc, DESC(stdout), format, vargs);
 	va_end(vargs);
 
 	return r;
@@ -52,7 +52,7 @@ int vprintf(const char *_MLIBC_RESTRICT format, va_list vargs)
 {
 	int r;
 
-	r = _prf(fputc, DESC(stdout), format, vargs);
+	r = z_prf(fputc, DESC(stdout), format, vargs);
 
 	return r;
 }

--- a/lib/libc/minimal/source/stdout/prf.c
+++ b/lib/libc/minimal/source/stdout/prf.c
@@ -429,7 +429,7 @@ static int _atoi(char **sptr)
 	return i;
 }
 
-int _prf(int (*func)(), void *dest, char *format, va_list vargs)
+int z_prf(int (*func)(), void *dest, char *format, va_list vargs)
 {
 	/*
 	 * Due the fact that buffer is passed to functions in this file,

--- a/lib/libc/minimal/source/stdout/sprintf.c
+++ b/lib/libc/minimal/source/stdout/sprintf.c
@@ -9,7 +9,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-extern int _prf(int (*func)(), void *dest,
+extern int z_prf(int (*func)(), void *dest,
 				const char *format, va_list vargs);
 
 struct emitter {
@@ -44,7 +44,7 @@ int snprintf(char *_MLIBC_RESTRICT s, size_t len,
 	p.len = (int) len;
 
 	va_start(vargs, format);
-	r = _prf(sprintf_out, (void *) (&p), format, vargs);
+	r = z_prf(sprintf_out, (void *) (&p), format, vargs);
 	va_end(vargs);
 
 	*(p.ptr) = 0;
@@ -62,7 +62,7 @@ int sprintf(char *_MLIBC_RESTRICT s, const char *_MLIBC_RESTRICT format, ...)
 	p.len = (int) 0x7fffffff; /* allow up to "maxint" characters */
 
 	va_start(vargs, format);
-	r = _prf(sprintf_out, (void *) (&p), format, vargs);
+	r = z_prf(sprintf_out, (void *) (&p), format, vargs);
 	va_end(vargs);
 
 	*(p.ptr) = 0;
@@ -83,7 +83,7 @@ int vsnprintf(char *_MLIBC_RESTRICT s, size_t len,
 	p.ptr = s;
 	p.len = (int) len;
 
-	r = _prf(sprintf_out, (void *) (&p), format, vargs);
+	r = z_prf(sprintf_out, (void *) (&p), format, vargs);
 
 	*(p.ptr) = 0;
 	return r;
@@ -98,7 +98,7 @@ int vsprintf(char *_MLIBC_RESTRICT s, const char *_MLIBC_RESTRICT format,
 	p.ptr = s;
 	p.len = (int) 0x7fffffff; /* allow up to "maxint" characters */
 
-	r = _prf(sprintf_out, (void *) (&p), format, vargs);
+	r = z_prf(sprintf_out, (void *) (&p), format, vargs);
 
 	*(p.ptr) = 0;
 	return r;

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -98,7 +98,7 @@ static void print_err(out_func_t out, void *ctx)
  *
  * @return N/A
  */
-void _vprintk(out_func_t out, void *ctx, const char *fmt, va_list ap)
+void z_vprintk(out_func_t out, void *ctx, const char *fmt, va_list ap)
 {
 	int might_format = 0; /* 1 if encountered a '%' */
 	enum pad_type padding = PAD_NONE;
@@ -316,7 +316,7 @@ void vprintk(const char *fmt, va_list ap)
 	if (_is_user_context()) {
 		struct buf_out_context ctx = { 0 };
 
-		_vprintk(buf_char_out, &ctx, fmt, ap);
+		z_vprintk(buf_char_out, &ctx, fmt, ap);
 
 		if (ctx.buf_count) {
 			buf_flush(&ctx);
@@ -324,7 +324,7 @@ void vprintk(const char *fmt, va_list ap)
 	} else {
 		struct out_context ctx = { 0 };
 
-		_vprintk(char_out, &ctx, fmt, ap);
+		z_vprintk(char_out, &ctx, fmt, ap);
 	}
 }
 #else
@@ -332,7 +332,7 @@ void vprintk(const char *fmt, va_list ap)
 {
 	struct out_context ctx = { 0 };
 
-	_vprintk(char_out, &ctx, fmt, ap);
+	z_vprintk(char_out, &ctx, fmt, ap);
 }
 #endif
 
@@ -510,7 +510,7 @@ int snprintk(char *str, size_t size, const char *fmt, ...)
 	va_list ap;
 
 	va_start(ap, fmt);
-	_vprintk((out_func_t)str_out, &ctx, fmt, ap);
+	z_vprintk((out_func_t)str_out, &ctx, fmt, ap);
 	va_end(ap);
 
 	if (ctx.count < ctx.max) {
@@ -524,7 +524,7 @@ int vsnprintk(char *str, size_t size, const char *fmt, va_list ap)
 {
 	struct str_context ctx = { str, size, 0 };
 
-	_vprintk((out_func_t)str_out, &ctx, fmt, ap);
+	z_vprintk((out_func_t)str_out, &ctx, fmt, ap);
 
 	if (ctx.count < ctx.max) {
 		str[ctx.count] = '\0';

--- a/scripts/gen_priv_stacks.py
+++ b/scripts/gen_priv_stacks.py
@@ -32,7 +32,7 @@ kobjects = {
 
 
 header = """%compare-lengths
-%define lookup-function-name _k_priv_stack_map_lookup
+%define lookup-function-name z_priv_stack_map_lookup
 %language=ANSI-C
 %global-table
 %struct-type
@@ -63,10 +63,10 @@ structure = """struct _k_priv_stack_map {
 # turned into a string, we told gperf to expect binary strings that are not
 # NULL-terminated.
 footer = """%%
-u8_t *_k_priv_stack_find(void *obj)
+u8_t *z_priv_stack_find(void *obj)
 {
     const struct _k_priv_stack_map *map =
-        _k_priv_stack_map_lookup((const char *)obj, sizeof(void *));
+        z_priv_stack_map_lookup((const char *)obj, sizeof(void *));
     return map->priv_stack_addr;
 }
 """

--- a/soc/arc/quark_se_c1000_ss/power.c
+++ b/soc/arc/quark_se_c1000_ss/power.c
@@ -18,20 +18,20 @@
 #include "vreg.h"
 
 #if (defined(CONFIG_SYS_POWER_DEEP_SLEEP_STATES))
-extern void _power_soc_sleep(void);
-extern void _power_soc_deep_sleep(void);
-extern void _power_soc_lpss_mode(void);
+extern void z_power_soc_sleep(void);
+extern void z_power_soc_deep_sleep(void);
+extern void z_power_soc_lpss_mode(void);
 
-static void _deep_sleep(enum power_states state)
+static void deep_sleep(enum power_states state)
 {
 	qm_power_soc_set_ss_restore_flag();
 
 	switch (state) {
 	case SYS_POWER_STATE_DEEP_SLEEP_2:
-		_power_soc_sleep();
+		z_power_soc_sleep();
 		break;
 	case SYS_POWER_STATE_DEEP_SLEEP_3:
-		_power_soc_deep_sleep();
+		z_power_soc_deep_sleep();
 		break;
 	default:
 		break;
@@ -54,11 +54,11 @@ void sys_set_power_state(enum power_states state)
 	case SYS_POWER_STATE_DEEP_SLEEP_1:
 		qm_ss_power_soc_lpss_enable();
 		qm_power_soc_set_ss_restore_flag();
-		_power_soc_lpss_mode();
+		z_power_soc_lpss_mode();
 		break;
 	case SYS_POWER_STATE_DEEP_SLEEP_2:
 	case SYS_POWER_STATE_DEEP_SLEEP_3:
-		_deep_sleep(state);
+		deep_sleep(state);
 		break;
 #endif
 	default:
@@ -90,7 +90,7 @@ void _sys_pm_power_state_exit_post_ops(enum power_states state)
 		 * its execution.
 		 */
 		if ((QM_SCSS_GP->gp0 & GP0_BIT_SLEEP_READY) == 0) {
-			_quark_se_ss_ready();
+			z_quark_se_ss_ready();
 			__builtin_arc_seti(0);
 		} else {
 			QM_SCSS_GP->gp0 &= ~GP0_BIT_SLEEP_READY;

--- a/soc/arc/quark_se_c1000_ss/soc.c
+++ b/soc/arc/quark_se_c1000_ss/soc.c
@@ -24,7 +24,7 @@ static int quark_se_arc_init(struct device *arg)
 {
 	ARG_UNUSED(arg);
 
-	_quark_se_ss_ready();
+	quark_se_ss_ready();
 
 	return 0;
 }

--- a/soc/arc/quark_se_c1000_ss/soc.h
+++ b/soc/arc/quark_se_c1000_ss/soc.h
@@ -201,7 +201,7 @@
 #define DT_RTC_0_IRQ_FLAGS			(IOAPIC_EDGE | IOAPIC_HIGH)
 
 
-static inline void _quark_se_ss_ready(void)
+static inline void quark_se_ss_ready(void)
 {
 	shared_data->flags |= ARC_READY;
 }

--- a/soc/arc/quark_se_c1000_ss/soc_power.S
+++ b/soc/arc/quark_se_c1000_ss/soc_power.S
@@ -11,11 +11,11 @@
 #ifdef CONFIG_SYS_POWER_DEEP_SLEEP_STATES
 GDATA(_pm_arc_context)
 
-GTEXT(_sys_resume_from_deep_sleep)
-GTEXT(_power_restore_cpu_context)
-GTEXT(_power_soc_sleep)
-GTEXT(_power_soc_deep_sleep)
-GTEXT(_power_soc_lpss_mode)
+GTEXT(sys_resume_from_deep_sleep)
+GTEXT(z_power_restore_cpu_context)
+GTEXT(z_power_soc_sleep)
+GTEXT(z_power_soc_deep_sleep)
+GTEXT(z_power_soc_lpss_mode)
 
 #define GPS0_REGISTER  0xb0800100
 #define GP0_REGISTER 0xb0800114
@@ -47,7 +47,7 @@ SECTION_FUNC(TEXT, save_cpu_context)
 
 	j_s [blink] /* Jump to context of BLINK register. */
 
-SECTION_FUNC(TEXT, _power_soc_sleep)
+SECTION_FUNC(TEXT, z_power_soc_sleep)
 	/*
 	 * Save the return address.
 	 * The restore function will pop this and jump
@@ -60,7 +60,7 @@ SECTION_FUNC(TEXT, _power_soc_sleep)
 	j @qm_power_soc_sleep
 	/* Does not return */
 
-SECTION_FUNC(TEXT, _power_soc_deep_sleep)
+SECTION_FUNC(TEXT, z_power_soc_deep_sleep)
 	/*
 	 * Save the return address.
 	 * The restore function will pop this and jump
@@ -73,7 +73,7 @@ SECTION_FUNC(TEXT, _power_soc_deep_sleep)
 	j @qm_power_soc_deep_sleep
 	/* Does not return */
 
-SECTION_FUNC(TEXT, _power_soc_lpss_mode)
+SECTION_FUNC(TEXT, z_power_soc_lpss_mode)
 	/*
 	 * Setup 'sleep' instruction operand.
 	 */

--- a/soc/arm/atmel_sam/sam3x/soc.c
+++ b/soc/arm/atmel_sam/sam3x/soc.c
@@ -209,7 +209,7 @@ static int atmel_sam3x_init(struct device *arg)
 
 	key = irq_lock();
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/*
 	 * Set FWS (Flash Wait State) value before increasing Master Clock

--- a/soc/arm/atmel_sam/sam4s/soc.c
+++ b/soc/arm/atmel_sam/sam4s/soc.c
@@ -197,7 +197,7 @@ static int atmel_sam4s_init(struct device *arg)
 	key = irq_lock();
 
 	/* Clear all faults. */
-	_ClearFaults();
+	z_clearfaults();
 
 	/*
 	 * Set FWS (Flash Wait State) value before increasing Master Clock

--- a/soc/arm/atmel_sam/same70/soc.c
+++ b/soc/arm/atmel_sam/same70/soc.c
@@ -234,7 +234,7 @@ static int atmel_same70_init(struct device *arg)
 	}
 
 	/* Clear all faults */
-	_ClearFaults();
+	z_clearfaults();
 
 	/*
 	 * Set FWS (Flash Wait State) value before increasing Master Clock

--- a/soc/arm/atmel_sam0/samd20/soc.c
+++ b/soc/arm/atmel_sam0/samd20/soc.c
@@ -172,7 +172,7 @@ static int atmel_samd_init(struct device *arg)
 
 	key = irq_lock();
 
-	_ClearFaults();
+	z_clearfaults();
 
 	flash_waitstates_init();
 	osc8m_init();

--- a/soc/arm/atmel_sam0/samd21/soc.c
+++ b/soc/arm/atmel_sam0/samd21/soc.c
@@ -173,7 +173,7 @@ static int atmel_samd_init(struct device *arg)
 
 	key = irq_lock();
 
-	_ClearFaults();
+	z_clearfaults();
 
 	flash_waitstates_init();
 	osc8m_init();

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -69,7 +69,7 @@ static int nordicsemi_nrf52_init(struct device *arg)
 	nrf_power_dcdcen_set(true);
 #endif
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Install default handler that simply resets the CPU
 	* if configured in the kernel, NOP otherwise

--- a/soc/arm/nordic_nrf/nrf91/soc.c
+++ b/soc/arm/nordic_nrf/nrf91/soc.c
@@ -50,7 +50,7 @@ static int nordicsemi_nrf91_init(struct device *arg)
 	NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Msk;
 #endif
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Install default handler that simply resets the CPU
 	* if configured in the kernel, NOP otherwise

--- a/soc/arm/nxp_imx/mcimx6x_m4/soc.c
+++ b/soc/arm/nxp_imx/mcimx6x_m4/soc.c
@@ -187,7 +187,7 @@ static int mcimx6x_m4_init(struct device *arg)
 	/* Initialize Cache */
 	SOC_CacheInit();
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Initialize clock */
 	SOC_ClockInit();

--- a/soc/arm/nxp_imx/rt/soc.c
+++ b/soc/arm/nxp_imx/rt/soc.c
@@ -210,7 +210,7 @@ static int imxrt_init(struct device *arg)
 		SCB_EnableDCache();
 	}
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Initialize system clock */
 	clkInit();

--- a/soc/arm/nxp_kinetis/k6x/soc.c
+++ b/soc/arm/nxp_kinetis/k6x/soc.c
@@ -180,7 +180,7 @@ static int fsl_frdm_k64f_init(struct device *arg)
 	SYSMPU->CESR = temp_reg;
 #endif /* !CONFIG_ARM_MPU */
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Initialize PLL/system clock to 120 MHz */
 	clkInit();

--- a/soc/arm/nxp_kinetis/kwx/soc_kw2xd.c
+++ b/soc/arm/nxp_kinetis/kwx/soc_kw2xd.c
@@ -189,7 +189,7 @@ static int kw2xd_init(struct device *arg)
 	/* release I/O power hold to allow normal run state */
 	PMC->REGSC |= PMC_REGSC_ACKISO_MASK;
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Initialize PLL/system clock to 48 MHz */
 	clkInit();

--- a/soc/arm/nxp_lpc/lpc54xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc54xxx/soc.c
@@ -87,7 +87,7 @@ static int nxp_lpc54114_init(struct device *arg)
 	/* disable interrupts */
 	oldLevel = irq_lock();
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Initialize FRO/system clock to 48 MHz */
 	clkInit();

--- a/soc/arm/silabs_exx32/common/soc.c
+++ b/soc/arm/silabs_exx32/common/soc.c
@@ -119,7 +119,7 @@ static int silabs_exx32_init(struct device *arg)
 	/* handle chip errata */
 	CHIP_Init();
 
-	_ClearFaults();
+	z_clearfaults();
 
 #ifdef CONFIG_SOC_GECKO_EMU_DCDC
 	dcdc_init();

--- a/soc/arm/st_stm32/stm32f0/soc.c
+++ b/soc/arm/st_stm32/stm32f0/soc.c
@@ -62,7 +62,7 @@ static int stm32f0_init(struct device *arg)
 
 	key = irq_lock();
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise

--- a/soc/arm/st_stm32/stm32f1/soc.c
+++ b/soc/arm/st_stm32/stm32f1/soc.c
@@ -30,7 +30,7 @@ static int stm32f1_init(struct device *arg)
 
 	key = irq_lock();
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise

--- a/soc/arm/st_stm32/stm32f2/soc.c
+++ b/soc/arm/st_stm32/stm32f2/soc.c
@@ -34,7 +34,7 @@ static int stm32f2_init(struct device *arg)
 
 	key = irq_lock();
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise

--- a/soc/arm/st_stm32/stm32f3/soc.c
+++ b/soc/arm/st_stm32/stm32f3/soc.c
@@ -30,7 +30,7 @@ static int stm32f3_init(struct device *arg)
 
 	key = irq_lock();
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise

--- a/soc/arm/st_stm32/stm32f4/soc.c
+++ b/soc/arm/st_stm32/stm32f4/soc.c
@@ -31,7 +31,7 @@ static int st_stm32f4_init(struct device *arg)
 
 	key = irq_lock();
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise

--- a/soc/arm/st_stm32/stm32f7/soc.c
+++ b/soc/arm/st_stm32/stm32f7/soc.c
@@ -37,7 +37,7 @@ static int st_stm32f7_init(struct device *arg)
 		SCB_EnableDCache();
 	}
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise

--- a/soc/arm/st_stm32/stm32l0/soc.c
+++ b/soc/arm/st_stm32/stm32l0/soc.c
@@ -32,7 +32,7 @@ static int stm32l0_init(struct device *arg)
 
 	key = irq_lock();
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise

--- a/soc/arm/st_stm32/stm32l4/soc.c
+++ b/soc/arm/st_stm32/stm32l4/soc.c
@@ -31,7 +31,7 @@ static int stm32l4_init(struct device *arg)
 
 	key = irq_lock();
 
-	_ClearFaults();
+	z_clearfaults();
 
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise

--- a/soc/arm/ti_lm3s6965/reboot.S
+++ b/soc/arm/ti_lm3s6965/reboot.S
@@ -13,8 +13,8 @@ _ASM_FILE_PROLOGUE
 
 GDATA(_interrupt_stack)
 
-GTEXT(_do_software_reboot)
-SECTION_FUNC(TEXT,_do_software_reboot)
+GTEXT(z_do_software_reboot)
+SECTION_FUNC(TEXT,z_do_software_reboot)
 
 	eors r0, r0
 
@@ -26,8 +26,8 @@ SECTION_FUNC(TEXT,_do_software_reboot)
 	bx r0
 
 
-GTEXT(_force_exit_one_nested_irq)
-SECTION_FUNC(TEXT,_force_exit_one_nested_irq)
+GTEXT(z_force_exit_one_nested_irq)
+SECTION_FUNC(TEXT,z_force_exit_one_nested_irq)
 
 	ldr r0, =_SCS_ICSR_RETTOBASE
 	ldr r1, =_SCS_ICSR
@@ -41,9 +41,9 @@ SECTION_FUNC(TEXT,_force_exit_one_nested_irq)
 	*/
 	ittee eq
 		ldreq lr, =0xfffffff1
-		ldreq r2, =_force_exit_one_nested_irq
+		ldreq r2, =z_force_exit_one_nested_irq
 		ldrne lr, =0xfffffffd
-		ldrne r2, =_do_software_reboot
+		ldrne r2, =z_do_software_reboot
 
 	ldr ip, =_interrupt_stack
 	add.w ip, ip, #(___esf_t_SIZEOF * 2) /* enough for a stack frame */

--- a/soc/arm/ti_lm3s6965/sys_arch_reboot.c
+++ b/soc/arm/ti_lm3s6965/sys_arch_reboot.c
@@ -28,8 +28,8 @@ void sys_arch_reboot(int type)
      * which address can _always_ be found in the vector table reset slot
      * located at address 0x4.
      */
-	extern void _do_software_reboot(void);
-	extern void _force_exit_one_nested_irq(void);
+	extern void z_do_software_reboot(void);
+	extern void z_force_exit_one_nested_irq(void);
 	/*
 	 * force enable interrupts locked via PRIMASK if somehow disabled: the
 	 * boot code does not enable them
@@ -37,10 +37,10 @@ void sys_arch_reboot(int type)
 	__asm__ volatile("cpsie i" :::);
 
 	if ((SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) == 0) {
-		_do_software_reboot();
+		z_do_software_reboot();
 	} else {
 		__asm__ volatile(
-			"ldr r0,  =_force_exit_one_nested_irq\n\t"
+			"ldr r0,  =z_force_exit_one_nested_irq\n\t"
 			"bx r0\n\t"
 			:::);
 	}

--- a/soc/x86/intel_quark/include/pinmux_quark_mcu.h
+++ b/soc/x86/intel_quark/include/pinmux_quark_mcu.h
@@ -34,7 +34,7 @@
 #define PIN_CONFIG(A, _pin, _func) \
 	(A[((_pin) / 16)] |= ((0x3 & (_func)) << (((_pin) % 16) * 2)))
 
-static inline int _quark_mcu_set_mux(u32_t base, u32_t pin, u8_t func)
+static inline int z_quark_mcu_set_mux(u32_t base, u32_t pin, u8_t func)
 {
 	/*
 	 * the registers are 32-bit wide, but each pin requires 1 bit

--- a/soc/x86/intel_quark/quark_se/eoi.c
+++ b/soc/x86/intel_quark/quark_se/eoi.c
@@ -26,7 +26,7 @@ void z_lakemont_eoi(void)
 	 * we have is the vector # in the IDT. So unconditionally
 	 * write to IOAPIC_EOI for every interrupt
 	 */
-	sys_write32(_irq_controller_isr_vector_get(),
+	sys_write32(z_irq_controller_isr_vector_get(),
 		    DT_IOAPIC_BASE_ADDRESS + IOAPIC_EOI);
 
 	/* Send EOI to the LOAPIC as well */

--- a/soc/x86/intel_quark/quark_se/power.c
+++ b/soc/x86/intel_quark/quark_se/power.c
@@ -21,15 +21,15 @@ u64_t _pm_save_gdtr;
 u64_t _pm_save_idtr;
 u32_t _pm_save_esp;
 
-extern void _power_soc_sleep(void);
-extern void _power_restore_cpu_context(void);
-extern void _power_soc_deep_sleep(void);
+extern void z_power_soc_sleep(void);
+extern void z_power_restore_cpu_context(void);
+extern void z_power_soc_deep_sleep(void);
 
 #if (defined(CONFIG_SYS_POWER_DEEP_SLEEP_STATES))
 static u32_t  *__x86_restore_info =
 	(u32_t *)CONFIG_BSP_SHARED_RESTORE_INFO_RAM_ADDR;
 
-static void _deep_sleep(enum power_states state)
+static void deep_sleep(enum power_states state)
 {
 	/*
 	 * Setting resume vector inside the restore_cpu_context
@@ -39,17 +39,17 @@ static void _deep_sleep(enum power_states state)
 	 * can be done before cpu context is restored and control
 	 * transferred to _sys_suspend.
 	 */
-	qm_x86_set_resume_vector(_power_restore_cpu_context,
+	qm_x86_set_resume_vector(z_power_restore_cpu_context,
 				 *__x86_restore_info);
 
 	qm_power_soc_set_x86_restore_flag();
 
 	switch (state) {
 	case SYS_POWER_STATE_DEEP_SLEEP_1:
-		_power_soc_sleep();
+		z_power_soc_sleep();
 		break;
 	case SYS_POWER_STATE_DEEP_SLEEP_2:
-		_power_soc_deep_sleep();
+		z_power_soc_deep_sleep();
 		break;
 	default:
 		break;
@@ -74,7 +74,7 @@ void sys_set_power_state(enum power_states state)
 #if (defined(CONFIG_SYS_POWER_DEEP_SLEEP_STATES))
 	case SYS_POWER_STATE_DEEP_SLEEP_1:
 	case SYS_POWER_STATE_DEEP_SLEEP_2:
-		_deep_sleep(state);
+		deep_sleep(state);
 		break;
 #endif
 	default:
@@ -96,7 +96,7 @@ void _sys_pm_power_state_exit_post_ops(enum power_states state)
 #if (defined(CONFIG_SYS_POWER_DEEP_SLEEP_STATES))
 	case SYS_POWER_STATE_DEEP_SLEEP_2:
 #ifdef CONFIG_ARC_INIT
-		_arc_init(NULL);
+		z_arc_init(NULL);
 #endif /* CONFIG_ARC_INIT */
 		/* Fallthrough */
 	case SYS_POWER_STATE_DEEP_SLEEP_1:

--- a/soc/x86/intel_quark/quark_se/soc.c
+++ b/soc/x86/intel_quark/quark_se/soc.c
@@ -62,7 +62,7 @@ MMU_BOOT_REGION(0xB0500000, 256*1024, MMU_ENTRY_WRITE);
  * @return N/A
  */
 /* This function is also called at deep sleep resume. */
-int _arc_init(struct device *arg)
+int z_arc_init(struct device *arg)
 {
 	u32_t *reset_vector;
 
@@ -108,7 +108,7 @@ skip_arc_init:
 	return 0;
 }
 
-SYS_INIT(_arc_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(z_arc_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 #endif /*CONFIG_ARC_INIT*/
 

--- a/soc/x86/intel_quark/quark_se/soc.h
+++ b/soc/x86/intel_quark/quark_se/soc.h
@@ -84,7 +84,7 @@
 #endif /*  _ASMLANGUAGE */
 
 #ifdef CONFIG_ARC_INIT
-int _arc_init(struct device *arg);
+int z_arc_init(struct device *arg);
 #endif /* CONFIG_ARC_INIT */
 
 #endif /* __SOC_H_ */

--- a/soc/x86/intel_quark/quark_se/soc_power.S
+++ b/soc/x86/intel_quark/quark_se/soc_power.S
@@ -11,10 +11,10 @@ GDATA(_pm_save_gdtr)
 GDATA(_pm_save_idtr)
 GDATA(_pm_save_esp)
 
-GTEXT(_sys_resume_from_deep_sleep)
-GTEXT(_power_restore_cpu_context)
-GTEXT(_power_soc_sleep)
-GTEXT(_power_soc_deep_sleep)
+GTEXT(sys_resume_from_deep_sleep)
+GTEXT(z_power_restore_cpu_context)
+GTEXT(z_power_soc_sleep)
+GTEXT(z_power_soc_deep_sleep)
 
 SECTION_FUNC(TEXT, save_cpu_context)
 	movl %esp, %eax                 /* save ptr to return address */
@@ -43,7 +43,7 @@ SECTION_FUNC(TEXT, save_cpu_context)
 	pushl (%eax)                    /* push return address */
 	ret
 
-SECTION_FUNC(TEXT, _power_restore_cpu_context)
+SECTION_FUNC(TEXT, z_power_restore_cpu_context)
 	lgdtl _pm_save_gdtr		/* restore gdtr */
 	lidtl _pm_save_idtr		/* restore idtr */
 	movl _pm_save_esp, %esp		/* restore saved stack ptr */
@@ -70,23 +70,23 @@ SECTION_FUNC(TEXT, _power_restore_cpu_context)
 	 *
 	 *          Saved context
 	 * ESP ---> Return address of save_cpu_context
-	 *          Return address of _power_soc_sleep/deep_sleep
+	 *          Return address of z_power_soc_sleep/deep_sleep
 	 *
 	 * We just popped the saved context. Next we pop out the address
 	 * of the caller of save_cpu_context.Then the ret would return
-	 * to caller of _power_soc_sleep or _power_soc_deep_sleep.
+	 * to caller of z_power_soc_sleep or z_power_soc_deep_sleep.
 	 *
 	 */
 	addl $4, %esp
 	ret
 
-SECTION_FUNC(TEXT, _power_soc_sleep)
+SECTION_FUNC(TEXT, z_power_soc_sleep)
 	call save_cpu_context
 	wbinvd
 	call qm_power_soc_sleep
 	/* Does not return */
 
-SECTION_FUNC(TEXT, _power_soc_deep_sleep)
+SECTION_FUNC(TEXT, z_power_soc_deep_sleep)
 	call save_cpu_context
 	wbinvd
 	call qm_power_soc_deep_sleep
@@ -104,8 +104,8 @@ SECTION_FUNC(TEXT, _power_soc_deep_sleep)
  */
 SECTION_FUNC(TEXT, _sys_resume_from_deep_sleep)
 	movl $CONFIG_BSP_SHARED_RESTORE_INFO_RAM_ADDR, %eax
-	cmpl $_power_restore_cpu_context, (%eax)
-	je _power_restore_cpu_context
+	cmpl $z_power_restore_cpu_context, (%eax)
+	je z_power_restore_cpu_context
 	ret
 
 #endif

--- a/soc/xtensa/esp32/esp32-mp.c
+++ b/soc/xtensa/esp32/esp32-mp.c
@@ -11,16 +11,16 @@
 #include <spinlock.h>
 #include <kernel_structs.h>
 
-#define _REG(base, off) (*(volatile u32_t *)((base) + (off)))
+#define Z_REG(base, off) (*(volatile u32_t *)((base) + (off)))
 
 #define RTC_CNTL_BASE             0x3ff48000
-#define RTC_CNTL_OPTIONS0     _REG(RTC_CNTL_BASE, 0x0)
-#define RTC_CNTL_SW_CPU_STALL _REG(RTC_CNTL_BASE, 0xac)
+#define RTC_CNTL_OPTIONS0     Z_REG(RTC_CNTL_BASE, 0x0)
+#define RTC_CNTL_SW_CPU_STALL Z_REG(RTC_CNTL_BASE, 0xac)
 
 #define DPORT_BASE                 0x3ff00000
-#define DPORT_APPCPU_CTRL_A    _REG(DPORT_BASE, 0x02C)
-#define DPORT_APPCPU_CTRL_B    _REG(DPORT_BASE, 0x030)
-#define DPORT_APPCPU_CTRL_C    _REG(DPORT_BASE, 0x034)
+#define DPORT_APPCPU_CTRL_A    Z_REG(DPORT_BASE, 0x02C)
+#define DPORT_APPCPU_CTRL_B    Z_REG(DPORT_BASE, 0x030)
+#define DPORT_APPCPU_CTRL_C    Z_REG(DPORT_BASE, 0x034)
 
 struct cpustart_rec {
 	int cpu;
@@ -103,10 +103,10 @@ static void appcpu_entry2(void)
  * set to zero for the called function (a null return value is the
  * signal for "top of stack" to the debugger).
  */
-void _appcpu_stack_switch(void *stack, void *entry);
+void z_appcpu_stack_switch(void *stack, void *entry);
 __asm__("\n"
 	".align 4"		"\n"
-	"_appcpu_stack_switch:"	"\n\t"
+	"z_appcpu_stack_switch:"	"\n\t"
 
 	"entry a1, 16"		"\n\t"
 
@@ -153,7 +153,7 @@ __asm__("\n"
  */
 static void appcpu_entry1(void)
 {
-	_appcpu_stack_switch(appcpu_top, appcpu_entry2);
+	z_appcpu_stack_switch(appcpu_top, appcpu_entry2);
 }
 
 /* The calls and sequencing here were extracted from the ESP-32

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -486,7 +486,7 @@ static const struct bt_hci_driver drv = {
 	.send	= hci_driver_send,
 };
 
-static int _hci_driver_init(struct device *unused)
+static int hci_driver_init(struct device *unused)
 {
 	ARG_UNUSED(unused);
 
@@ -495,4 +495,4 @@ static int _hci_driver_init(struct device *unused)
 	return 0;
 }
 
-SYS_INIT(_hci_driver_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(hci_driver_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -69,13 +69,13 @@ struct bt_dev bt_dev = {
 	 * initial Command Complete for NOP.
 	 */
 #if !defined(CONFIG_BT_WAIT_NOP)
-	.ncmd_sem      = _K_SEM_INITIALIZER(bt_dev.ncmd_sem, 1, 1),
+	.ncmd_sem      = Z_SEM_INITIALIZER(bt_dev.ncmd_sem, 1, 1),
 #else
-	.ncmd_sem      = _K_SEM_INITIALIZER(bt_dev.ncmd_sem, 0, 1),
+	.ncmd_sem      = Z_SEM_INITIALIZER(bt_dev.ncmd_sem, 0, 1),
 #endif
-	.cmd_tx_queue  = _K_FIFO_INITIALIZER(bt_dev.cmd_tx_queue),
+	.cmd_tx_queue  = Z_FIFO_INITIALIZER(bt_dev.cmd_tx_queue),
 #if !defined(CONFIG_BT_RECV_IS_RX_THREAD)
-	.rx_queue      = _K_FIFO_INITIALIZER(bt_dev.rx_queue),
+	.rx_queue      = Z_FIFO_INITIALIZER(bt_dev.rx_queue),
 #endif
 };
 

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -66,7 +66,7 @@ static struct {
 	atomic_t other;
 } drops;
 
-extern int _prf(int (*func)(), void *dest,
+extern int z_prf(int (*func)(), void *dest,
 		const char *format, va_list vargs);
 
 static void monitor_send(const void *data, size_t len)

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -2252,7 +2252,7 @@ static u8_t smp_master_ident(struct bt_smp *smp, struct net_buf *buf)
 }
 #endif /* !CONFIG_BT_SMP_SC_PAIR_ONLY */
 
-static int _smp_init(struct bt_smp *smp)
+static int smp_init(struct bt_smp *smp)
 {
 	/* Initialize SMP context without clearing L2CAP channel context */
 	(void)memset((u8_t *)smp + sizeof(smp->chan), 0,
@@ -2355,7 +2355,7 @@ int bt_smp_send_security_req(struct bt_conn *conn)
 		return -EINVAL;
 	}
 
-	if (_smp_init(smp) != 0) {
+	if (smp_init(smp) != 0) {
 		return -ENOBUFS;
 	}
 
@@ -2394,7 +2394,7 @@ static u8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 	 * is already initialized.
 	 */
 	if (!atomic_test_bit(smp->flags, SMP_FLAG_SEC_REQ)) {
-		int ret = _smp_init(smp);
+		int ret = smp_init(smp);
 
 		if (ret) {
 			return ret;
@@ -2533,7 +2533,7 @@ int bt_smp_send_pairing_req(struct bt_conn *conn)
 		return -EINVAL;
 	}
 
-	if (_smp_init(smp)) {
+	if (smp_init(smp)) {
 		return -ENOBUFS;
 	}
 

--- a/subsys/debug/tracing/include/tracing_sysview.h
+++ b/subsys/debug/tracing/include/tracing_sysview.h
@@ -26,7 +26,7 @@ static inline int is_idle_thread(struct k_thread *thread)
 }
 
 
-static inline void _sys_trace_thread_switched_in(void)
+static inline void z_sys_trace_thread_switched_in(void)
 {
 	struct k_thread *thread;
 
@@ -39,7 +39,7 @@ static inline void _sys_trace_thread_switched_in(void)
 	}
 }
 
-#define sys_trace_thread_switched_in() _sys_trace_thread_switched_in()
+#define sys_trace_thread_switched_in() z_sys_trace_thread_switched_in()
 
 #define sys_trace_thread_switched_out() SEGGER_SYSVIEW_OnTaskStopExec()
 

--- a/subsys/debug/tracing/sysview_config.c
+++ b/subsys/debug/tracing/sysview_config.c
@@ -7,7 +7,7 @@
 #include <SEGGER_SYSVIEW.h>
 #include "SEGGER_SYSVIEW_Zephyr.h"
 
-static void _cbSendSystemDesc(void)
+static void cbSendSystemDesc(void)
 {
 	SEGGER_SYSVIEW_SendSysDesc("N=ZephyrSysView");
 	SEGGER_SYSVIEW_SendSysDesc("D=" CONFIG_BOARD " "
@@ -19,7 +19,7 @@ void SEGGER_SYSVIEW_Conf(void)
 {
 	SEGGER_SYSVIEW_Init(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
 			    CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
-			    &SYSVIEW_X_OS_TraceAPI, _cbSendSystemDesc);
+			    &SYSVIEW_X_OS_TraceAPI, cbSendSystemDesc);
 
 #if defined(DT_PHYS_RAM_ADDR)       /* x86 */
 	SEGGER_SYSVIEW_SetRAMBase(DT_PHYS_RAM_ADDR);

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -18,8 +18,8 @@ LOG_MODULE_REGISTER(fs_nvs, CONFIG_NVS_LOG_LEVEL);
 
 
 /* basic routines */
-/* _nvs_al_size returns size aligned to fs->write_block_size */
-static inline size_t _nvs_al_size(struct nvs_fs *fs, size_t len)
+/* nvs_al_size returns size aligned to fs->write_block_size */
+static inline size_t nvs_al_size(struct nvs_fs *fs, size_t len)
 {
 	if (fs->write_block_size <= 1U) {
 		return len;
@@ -30,7 +30,7 @@ static inline size_t _nvs_al_size(struct nvs_fs *fs, size_t len)
 
 /* flash routines */
 /* basic aligned flash write to nvs address */
-static int _nvs_flash_al_wrt(struct nvs_fs *fs, u32_t addr, const void *data,
+static int nvs_flash_al_wrt(struct nvs_fs *fs, u32_t addr, const void *data,
 			     size_t len)
 {
 	const u8_t *data8 = (const u8_t *)data;
@@ -81,7 +81,7 @@ end:
 }
 
 /* basic flash read from nvs address */
-static int _nvs_flash_rd(struct nvs_fs *fs, u32_t addr, void *data,
+static int nvs_flash_rd(struct nvs_fs *fs, u32_t addr, void *data,
 			 size_t len)
 {
 	int rc;
@@ -97,44 +97,44 @@ static int _nvs_flash_rd(struct nvs_fs *fs, u32_t addr, void *data,
 }
 
 /* allocation entry write */
-static int _nvs_flash_ate_wrt(struct nvs_fs *fs, const struct nvs_ate *entry)
+static int nvs_flash_ate_wrt(struct nvs_fs *fs, const struct nvs_ate *entry)
 {
 	int rc;
 
-	rc = _nvs_flash_al_wrt(fs, fs->ate_wra, entry,
+	rc = nvs_flash_al_wrt(fs, fs->ate_wra, entry,
 			       sizeof(struct nvs_ate));
-	fs->ate_wra -= _nvs_al_size(fs, sizeof(struct nvs_ate));
+	fs->ate_wra -= nvs_al_size(fs, sizeof(struct nvs_ate));
 
 	return rc;
 }
 
 /* data write */
-static int _nvs_flash_data_wrt(struct nvs_fs *fs, const void *data, size_t len)
+static int nvs_flash_data_wrt(struct nvs_fs *fs, const void *data, size_t len)
 {
 	int rc;
 
-	rc = _nvs_flash_al_wrt(fs, fs->data_wra, data, len);
-	fs->data_wra += _nvs_al_size(fs, len);
+	rc = nvs_flash_al_wrt(fs, fs->data_wra, data, len);
+	fs->data_wra += nvs_al_size(fs, len);
 
 	return rc;
 }
 
 /* flash ate read */
-static int _nvs_flash_ate_rd(struct nvs_fs *fs, u32_t addr,
+static int nvs_flash_ate_rd(struct nvs_fs *fs, u32_t addr,
 			     struct nvs_ate *entry)
 {
-	return _nvs_flash_rd(fs, addr, entry, sizeof(struct nvs_ate));
+	return nvs_flash_rd(fs, addr, entry, sizeof(struct nvs_ate));
 }
 
 /* end of basic flash routines */
 
 /* advanced flash routines */
 
-/* _nvs_flash_block_cmp compares the data in flash at addr to data
+/* nvs_flash_block_cmp compares the data in flash at addr to data
  * in blocks of size NVS_BLOCK_SIZE aligned to fs->write_block_size
  * returns 0 if equal, 1 if not equal, errcode if error
  */
-static int _nvs_flash_block_cmp(struct nvs_fs *fs, u32_t addr, const void *data,
+static int nvs_flash_block_cmp(struct nvs_fs *fs, u32_t addr, const void *data,
 				size_t len)
 {
 	const u8_t *data8 = (const u8_t *)data;
@@ -145,7 +145,7 @@ static int _nvs_flash_block_cmp(struct nvs_fs *fs, u32_t addr, const void *data,
 	block_size = NVS_BLOCK_SIZE & ~(fs->write_block_size - 1U);
 	while (len) {
 		bytes_to_cmp = MIN(block_size, len);
-		rc = _nvs_flash_rd(fs, addr, buf, bytes_to_cmp);
+		rc = nvs_flash_rd(fs, addr, buf, bytes_to_cmp);
 		if (rc) {
 			return rc;
 		}
@@ -160,11 +160,11 @@ static int _nvs_flash_block_cmp(struct nvs_fs *fs, u32_t addr, const void *data,
 	return 0;
 }
 
-/* _nvs_flash_cmp_const compares the data in flash at addr to a constant
+/* nvs_flash_cmp_const compares the data in flash at addr to a constant
  * value. returns 0 if all data in flash is equal to value, 1 if not equal,
  * errcode if error
  */
-static int _nvs_flash_cmp_const(struct nvs_fs *fs, u32_t addr, u8_t value,
+static int nvs_flash_cmp_const(struct nvs_fs *fs, u32_t addr, u8_t value,
 				size_t len)
 {
 	int rc;
@@ -175,7 +175,7 @@ static int _nvs_flash_cmp_const(struct nvs_fs *fs, u32_t addr, u8_t value,
 	(void)memset(cmp, value, block_size);
 	while (len) {
 		bytes_to_cmp = MIN(block_size, len);
-		rc = _nvs_flash_block_cmp(fs, addr, cmp, bytes_to_cmp);
+		rc = nvs_flash_block_cmp(fs, addr, cmp, bytes_to_cmp);
 		if (rc) {
 			return rc;
 		}
@@ -188,7 +188,7 @@ static int _nvs_flash_cmp_const(struct nvs_fs *fs, u32_t addr, u8_t value,
 /* flash block move: move a block at addr to the current data write location
  * and updates the data write location.
  */
-static int _nvs_flash_block_move(struct nvs_fs *fs, u32_t addr, size_t len)
+static int nvs_flash_block_move(struct nvs_fs *fs, u32_t addr, size_t len)
 {
 	int rc;
 	size_t bytes_to_copy, block_size;
@@ -198,11 +198,11 @@ static int _nvs_flash_block_move(struct nvs_fs *fs, u32_t addr, size_t len)
 
 	while (len) {
 		bytes_to_copy = MIN(block_size, len);
-		rc = _nvs_flash_rd(fs, addr, buf, bytes_to_copy);
+		rc = nvs_flash_rd(fs, addr, buf, bytes_to_copy);
 		if (rc) {
 			return rc;
 		}
-		rc = _nvs_flash_data_wrt(fs, buf, bytes_to_copy);
+		rc = nvs_flash_data_wrt(fs, buf, bytes_to_copy);
 		if (rc) {
 			return rc;
 		}
@@ -215,13 +215,13 @@ static int _nvs_flash_block_move(struct nvs_fs *fs, u32_t addr, size_t len)
 /* erase a sector by first checking it is used and then erasing if required
  * return 0 if OK, errorcode on error.
  */
-static int _nvs_flash_erase_sector(struct nvs_fs *fs, u32_t addr)
+static int nvs_flash_erase_sector(struct nvs_fs *fs, u32_t addr)
 {
 	int rc;
 	off_t offset;
 
 	addr &= ADDR_SECT_MASK;
-	rc = _nvs_flash_cmp_const(fs, addr, 0xff, fs->sector_size);
+	rc = nvs_flash_cmp_const(fs, addr, 0xff, fs->sector_size);
 	if (rc <= 0) {
 		/* flash error or empty sector */
 		return rc;
@@ -247,7 +247,7 @@ static int _nvs_flash_erase_sector(struct nvs_fs *fs, u32_t addr)
 }
 
 /* crc update on allocation entry */
-static void _nvs_ate_crc8_update(struct nvs_ate *entry)
+static void nvs_ate_crc8_update(struct nvs_ate *entry)
 {
 	u8_t crc8;
 
@@ -258,7 +258,7 @@ static void _nvs_ate_crc8_update(struct nvs_ate *entry)
 /* crc check on allocation entry
  * returns 0 if OK, 1 on crc fail
  */
-static int _nvs_ate_crc8_check(const struct nvs_ate *entry)
+static int nvs_ate_crc8_check(const struct nvs_ate *entry)
 {
 	u8_t crc8;
 
@@ -269,11 +269,11 @@ static int _nvs_ate_crc8_check(const struct nvs_ate *entry)
 	return 1;
 }
 
-/* _nvs_ate_cmp_const compares an ATE to a constant value. returns 0 if
+/* nvs_ate_cmp_const compares an ATE to a constant value. returns 0 if
  * the whole ATE is equal to value, 1 if not equal.
  */
 
-static int _nvs_ate_cmp_const(const struct nvs_ate *entry, u8_t value)
+static int nvs_ate_cmp_const(const struct nvs_ate *entry, u8_t value)
 {
 	const u8_t *data8 = (const u8_t *)entry;
 	int i;
@@ -288,27 +288,27 @@ static int _nvs_ate_cmp_const(const struct nvs_ate *entry, u8_t value)
 }
 
 /* store an entry in flash */
-static int _nvs_flash_wrt_entry(struct nvs_fs *fs, u16_t id, const void *data,
+static int nvs_flash_wrt_entry(struct nvs_fs *fs, u16_t id, const void *data,
 				size_t len)
 {
 	int rc;
 	struct nvs_ate entry;
 	size_t ate_size;
 
-	ate_size = _nvs_al_size(fs, sizeof(struct nvs_ate));
+	ate_size = nvs_al_size(fs, sizeof(struct nvs_ate));
 
 	entry.id = id;
 	entry.offset = (u16_t)(fs->data_wra & ADDR_OFFS_MASK);
 	entry.len = (u16_t)len;
 	entry.part = 0xff;
 
-	_nvs_ate_crc8_update(&entry);
+	nvs_ate_crc8_update(&entry);
 
-	rc = _nvs_flash_data_wrt(fs, data, len);
+	rc = nvs_flash_data_wrt(fs, data, len);
 	if (rc) {
 		return rc;
 	}
-	rc = _nvs_flash_ate_wrt(fs, &entry);
+	rc = nvs_flash_ate_wrt(fs, &entry);
 	if (rc) {
 		return rc;
 	}
@@ -320,16 +320,16 @@ static int _nvs_flash_wrt_entry(struct nvs_fs *fs, u16_t id, const void *data,
 /* walking through allocation entry list, from newest to oldest entries
  * read ate from addr, modify addr to the previous ate
  */
-static int _nvs_prev_ate(struct nvs_fs *fs, u32_t *addr, struct nvs_ate *ate)
+static int nvs_prev_ate(struct nvs_fs *fs, u32_t *addr, struct nvs_ate *ate)
 {
 	int rc;
 	struct nvs_ate close_ate, end_ate;
 	u32_t data_end_addr, ate_end_addr;
 	size_t ate_size;
 
-	ate_size = _nvs_al_size(fs, sizeof(struct nvs_ate));
+	ate_size = nvs_al_size(fs, sizeof(struct nvs_ate));
 
-	rc = _nvs_flash_ate_rd(fs, *addr, ate);
+	rc = nvs_flash_ate_rd(fs, *addr, ate);
 	if (rc) {
 		return rc;
 	}
@@ -346,19 +346,19 @@ static int _nvs_prev_ate(struct nvs_fs *fs, u32_t *addr, struct nvs_ate *ate)
 		*addr -= (1 << ADDR_SECT_SHIFT);
 	}
 
-	rc = _nvs_flash_ate_rd(fs, *addr, &close_ate);
+	rc = nvs_flash_ate_rd(fs, *addr, &close_ate);
 	if (rc) {
 		return rc;
 	}
 
-	rc = _nvs_ate_cmp_const(&close_ate, 0xff);
+	rc = nvs_ate_cmp_const(&close_ate, 0xff);
 	/* at the end of filesystem */
 	if (!rc) {
 		*addr = fs->ate_wra;
 		return 0;
 	}
 
-	if (!_nvs_ate_crc8_check(&close_ate)) {
+	if (!nvs_ate_crc8_check(&close_ate)) {
 		(*addr) &= ADDR_SECT_MASK;
 		/* update the address so it points to the last added ate */
 		(*addr) += close_ate.offset;
@@ -371,11 +371,11 @@ static int _nvs_prev_ate(struct nvs_fs *fs, u32_t *addr, struct nvs_ate *ate)
 	ate_end_addr = *addr;
 	data_end_addr = *addr & ADDR_SECT_MASK;
 	while (ate_end_addr > data_end_addr) {
-		rc = _nvs_flash_ate_rd(fs, ate_end_addr, &end_ate);
+		rc = nvs_flash_ate_rd(fs, ate_end_addr, &end_ate);
 		if (rc) {
 			return rc;
 		}
-		if (!_nvs_ate_crc8_check(&end_ate)) {
+		if (!nvs_ate_crc8_check(&end_ate)) {
 			/* found a valid ate, update data_end_addr and *addr */
 			data_end_addr &= ADDR_SECT_MASK;
 			data_end_addr += end_ate.offset + end_ate.len;
@@ -390,7 +390,7 @@ static int _nvs_prev_ate(struct nvs_fs *fs, u32_t *addr, struct nvs_ate *ate)
 	return 0;
 }
 
-static void _nvs_sector_advance(struct nvs_fs *fs, u32_t *addr)
+static void nvs_sector_advance(struct nvs_fs *fs, u32_t *addr)
 {
 	*addr += (1 << ADDR_SECT_SHIFT);
 	if ((*addr >> ADDR_SECT_SHIFT) == fs->sector_count) {
@@ -401,13 +401,13 @@ static void _nvs_sector_advance(struct nvs_fs *fs, u32_t *addr)
 /* allocation entry close (this closes the current sector) by writing offset
  * of last ate to the sector end.
  */
-static int _nvs_sector_close(struct nvs_fs *fs)
+static int nvs_sector_close(struct nvs_fs *fs)
 {
 	int rc;
 	struct nvs_ate close_ate;
 	size_t ate_size;
 
-	ate_size = _nvs_al_size(fs, sizeof(struct nvs_ate));
+	ate_size = nvs_al_size(fs, sizeof(struct nvs_ate));
 
 	close_ate.id = 0xFFFF;
 	close_ate.len = 0U;
@@ -416,11 +416,11 @@ static int _nvs_sector_close(struct nvs_fs *fs)
 	fs->ate_wra &= ADDR_SECT_MASK;
 	fs->ate_wra += (fs->sector_size - ate_size);
 
-	_nvs_ate_crc8_update(&close_ate);
+	nvs_ate_crc8_update(&close_ate);
 
-	rc = _nvs_flash_ate_wrt(fs, &close_ate);
+	rc = nvs_flash_ate_wrt(fs, &close_ate);
 
-	_nvs_sector_advance(fs, &fs->ate_wra);
+	nvs_sector_advance(fs, &fs->ate_wra);
 
 	fs->data_wra = fs->ate_wra & ADDR_SECT_MASK;
 
@@ -432,7 +432,7 @@ static int _nvs_sector_close(struct nvs_fs *fs)
  * that has just been started. The data to gc is in the sector after this new
  * sector.
  */
-static int _nvs_gc(struct nvs_fs *fs)
+static int nvs_gc(struct nvs_fs *fs)
 {
 	int rc;
 	struct nvs_ate close_ate, gc_ate, wlk_ate;
@@ -440,22 +440,22 @@ static int _nvs_gc(struct nvs_fs *fs)
 	      data_addr, stop_addr;
 	size_t ate_size;
 
-	ate_size = _nvs_al_size(fs, sizeof(struct nvs_ate));
+	ate_size = nvs_al_size(fs, sizeof(struct nvs_ate));
 
 	sec_addr = (fs->ate_wra & ADDR_SECT_MASK);
-	_nvs_sector_advance(fs, &sec_addr);
+	nvs_sector_advance(fs, &sec_addr);
 	gc_addr = sec_addr + fs->sector_size - ate_size;
 
 	/* if the sector is not closed don't do gc */
-	rc = _nvs_flash_ate_rd(fs, gc_addr, &close_ate);
+	rc = nvs_flash_ate_rd(fs, gc_addr, &close_ate);
 	if (rc < 0) {
 		/* flash error */
 		return rc;
 	}
 
-	rc = _nvs_ate_cmp_const(&close_ate, 0xff);
+	rc = nvs_ate_cmp_const(&close_ate, 0xff);
 	if (!rc) {
-		rc = _nvs_flash_erase_sector(fs, sec_addr);
+		rc = nvs_flash_erase_sector(fs, sec_addr);
 		if (rc) {
 			return rc;
 		}
@@ -469,14 +469,14 @@ static int _nvs_gc(struct nvs_fs *fs)
 
 	while (1) {
 		gc_prev_addr = gc_addr;
-		rc = _nvs_prev_ate(fs, &gc_addr, &gc_ate);
+		rc = nvs_prev_ate(fs, &gc_addr, &gc_ate);
 		if (rc) {
 			return rc;
 		}
 		wlk_addr = fs->ate_wra;
 		while (1) {
 			wlk_prev_addr = wlk_addr;
-			rc = _nvs_prev_ate(fs, &wlk_addr, &wlk_ate);
+			rc = nvs_prev_ate(fs, &wlk_addr, &wlk_ate);
 			if (rc) {
 				return rc;
 			}
@@ -486,7 +486,7 @@ static int _nvs_gc(struct nvs_fs *fs)
 			 * invalid, don't consider these as a match.
 			 */
 			if ((wlk_ate.id == gc_ate.id) &&
-			    (!_nvs_ate_crc8_check(&wlk_ate))) {
+			    (!nvs_ate_crc8_check(&wlk_ate))) {
 				break;
 			}
 		}
@@ -501,14 +501,14 @@ static int _nvs_gc(struct nvs_fs *fs)
 			data_addr += gc_ate.offset;
 
 			gc_ate.offset = (u16_t)(fs->data_wra & ADDR_OFFS_MASK);
-			_nvs_ate_crc8_update(&gc_ate);
+			nvs_ate_crc8_update(&gc_ate);
 
-			rc = _nvs_flash_block_move(fs, data_addr, gc_ate.len);
+			rc = nvs_flash_block_move(fs, data_addr, gc_ate.len);
 			if (rc) {
 				return rc;
 			}
 
-			rc = _nvs_flash_ate_wrt(fs, &gc_ate);
+			rc = nvs_flash_ate_wrt(fs, &gc_ate);
 			if (rc) {
 				return rc;
 			}
@@ -520,14 +520,14 @@ static int _nvs_gc(struct nvs_fs *fs)
 		}
 	}
 
-	rc = _nvs_flash_erase_sector(fs, sec_addr);
+	rc = nvs_flash_erase_sector(fs, sec_addr);
 	if (rc) {
 		return rc;
 	}
 	return 0;
 }
 
-static int _nvs_startup(struct nvs_fs *fs)
+static int nvs_startup(struct nvs_fs *fs)
 {
 	int rc;
 	struct nvs_ate last_ate;
@@ -541,16 +541,16 @@ static int _nvs_startup(struct nvs_fs *fs)
 
 	k_mutex_lock(&fs->nvs_lock, K_FOREVER);
 
-	ate_size = _nvs_al_size(fs, sizeof(struct nvs_ate));
+	ate_size = nvs_al_size(fs, sizeof(struct nvs_ate));
 	/* step through the sectors to find the last sector */
 	for (u16_t i = 0; i < fs->sector_count; i++) {
 		addr = (i << ADDR_SECT_SHIFT) + fs->sector_size - ate_size;
-		rc = _nvs_flash_cmp_const(fs, addr, 0xff,
+		rc = nvs_flash_cmp_const(fs, addr, 0xff,
 					  sizeof(struct nvs_ate));
 		if (rc) {
 			/* closed sector */
-			_nvs_sector_advance(fs, &addr);
-			rc = _nvs_flash_cmp_const(fs, addr, 0xff,
+			nvs_sector_advance(fs, &addr);
+			rc = nvs_flash_cmp_const(fs, addr, 0xff,
 						  sizeof(struct nvs_ate));
 			if (!rc) {
 				/* open sector */
@@ -560,12 +560,12 @@ static int _nvs_startup(struct nvs_fs *fs)
 		/* none of the sectors where closed, set the address to
 		 * the first sector
 		 */
-		_nvs_sector_advance(fs, &addr);
+		nvs_sector_advance(fs, &addr);
 	}
 	/* search for the first ate containing all 0xff) */
 	while (1) {
 		addr -= ate_size;
-		rc = _nvs_flash_cmp_const(fs, addr, 0xff,
+		rc = nvs_flash_cmp_const(fs, addr, 0xff,
 					  sizeof(struct nvs_ate));
 		if (!rc) {
 			/* found ff empty location */
@@ -582,14 +582,14 @@ static int _nvs_startup(struct nvs_fs *fs)
 
 	if ((addr & ADDR_OFFS_MASK) != fs->sector_size - 2 * ate_size) {
 		addr += ate_size;
-		rc = _nvs_flash_ate_rd(fs, addr, &last_ate);
+		rc = nvs_flash_ate_rd(fs, addr, &last_ate);
 		if (rc) {
 			goto end;
 		}
-		if (!_nvs_ate_crc8_check(&last_ate)) {
+		if (!nvs_ate_crc8_check(&last_ate)) {
 			/* crc8 is ok, complete write of ate was performed */
 			fs->data_wra += last_ate.offset;
-			fs->data_wra += _nvs_al_size(fs, last_ate.len);
+			fs->data_wra += nvs_al_size(fs, last_ate.len);
 		}
 	}
 
@@ -599,7 +599,7 @@ static int _nvs_startup(struct nvs_fs *fs)
 		if (!empty_len) {
 			break;
 		}
-		rc = _nvs_flash_cmp_const(fs, fs->data_wra, 0xff, empty_len);
+		rc = nvs_flash_cmp_const(fs, fs->data_wra, 0xff, empty_len);
 		if (rc < 0) {
 			goto end;
 		}
@@ -614,21 +614,21 @@ static int _nvs_startup(struct nvs_fs *fs)
 	 * otherwise the data may not fit into the sector.
 	 */
 	addr = fs->ate_wra & ADDR_SECT_MASK;
-	_nvs_sector_advance(fs, &addr);
-	rc = _nvs_flash_cmp_const(fs, addr, 0xff, fs->sector_size);
+	nvs_sector_advance(fs, &addr);
+	rc = nvs_flash_cmp_const(fs, addr, 0xff, fs->sector_size);
 	if (rc < 0) {
 		goto end;
 	}
 	if (rc) {
 		/* the sector after fs->ate_wrt is not empty */
-		rc = _nvs_flash_erase_sector(fs, fs->ate_wra);
+		rc = nvs_flash_erase_sector(fs, fs->ate_wra);
 		if (rc) {
 			goto end;
 		}
 		fs->ate_wra &= ADDR_SECT_MASK;
 		fs->ate_wra += (fs->sector_size - 2 * ate_size);
 		fs->data_wra = (fs->ate_wra & ADDR_SECT_MASK);
-		rc = _nvs_gc(fs);
+		rc = nvs_gc(fs);
 		if (rc) {
 			goto end;
 		}
@@ -651,7 +651,7 @@ int nvs_clear(struct nvs_fs *fs)
 
 	for (u16_t i = 0; i < fs->sector_count; i++) {
 		addr = i << ADDR_SECT_SHIFT;
-		rc = _nvs_flash_erase_sector(fs, addr);
+		rc = nvs_flash_erase_sector(fs, addr);
 		if (rc) {
 			return rc;
 		}
@@ -698,7 +698,7 @@ int nvs_init(struct nvs_fs *fs, const char *dev_name)
 		return -EINVAL;
 	}
 
-	rc = _nvs_startup(fs);
+	rc = nvs_startup(fs);
 	if (rc) {
 		return rc;
 	}
@@ -730,8 +730,8 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 		return -EACCES;
 	}
 
-	ate_size = _nvs_al_size(fs, sizeof(struct nvs_ate));
-	data_size = _nvs_al_size(fs, len);
+	ate_size = nvs_al_size(fs, sizeof(struct nvs_ate));
+	data_size = nvs_al_size(fs, len);
 
 	/* The maximum data size is sector size - 3 ate
 	 * where: 1 ate for data, 1 ate for sector close
@@ -748,11 +748,11 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 
 	while (1) {
 		rd_addr = wlk_addr;
-		rc = _nvs_prev_ate(fs, &wlk_addr, &wlk_ate);
+		rc = nvs_prev_ate(fs, &wlk_addr, &wlk_ate);
 		if (rc) {
 			return rc;
 		}
-		if ((wlk_ate.id == id) && (!_nvs_ate_crc8_check(&wlk_ate))) {
+		if ((wlk_ate.id == id) && (!nvs_ate_crc8_check(&wlk_ate))) {
 			break;
 		}
 		if (wlk_addr == fs->ate_wra) {
@@ -772,7 +772,7 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 			}
 		} else {
 			/* compare the data and if equal return 0 */
-			rc = _nvs_flash_block_cmp(fs, rd_addr, data, len);
+			rc = nvs_flash_block_cmp(fs, rd_addr, data, len);
 			if (rc <= 0) {
 				return rc;
 			}
@@ -796,19 +796,19 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 		/* Leave space for delete ate */
 		if (sector_freespace >= data_size + ate_size) {
 
-			rc = _nvs_flash_wrt_entry(fs, id, data, len);
+			rc = nvs_flash_wrt_entry(fs, id, data, len);
 			if (rc) {
 				goto end;
 			}
 			break;
 		}
 
-		rc = _nvs_sector_close(fs);
+		rc = nvs_sector_close(fs);
 		if (rc) {
 			goto end;
 		}
 
-		rc = _nvs_gc(fs);
+		rc = nvs_gc(fs);
 		if (rc) {
 			goto end;
 		}
@@ -839,7 +839,7 @@ ssize_t nvs_read_hist(struct nvs_fs *fs, u16_t id, void *data, size_t len,
 		return -EACCES;
 	}
 
-	ate_size = _nvs_al_size(fs, sizeof(struct nvs_ate));
+	ate_size = nvs_al_size(fs, sizeof(struct nvs_ate));
 
 	if (len > (fs->sector_size - 2 * ate_size)) {
 		return -EINVAL;
@@ -852,11 +852,11 @@ ssize_t nvs_read_hist(struct nvs_fs *fs, u16_t id, void *data, size_t len,
 
 	while (cnt_his <= cnt) {
 		rd_addr = wlk_addr;
-		rc = _nvs_prev_ate(fs, &wlk_addr, &wlk_ate);
+		rc = nvs_prev_ate(fs, &wlk_addr, &wlk_ate);
 		if (rc) {
 			goto err;
 		}
-		if ((wlk_ate.id == id) &&  (!_nvs_ate_crc8_check(&wlk_ate))) {
+		if ((wlk_ate.id == id) &&  (!nvs_ate_crc8_check(&wlk_ate))) {
 			cnt_his++;
 		}
 		if (wlk_addr == fs->ate_wra) {
@@ -871,7 +871,7 @@ ssize_t nvs_read_hist(struct nvs_fs *fs, u16_t id, void *data, size_t len,
 
 	rd_addr &= ADDR_SECT_MASK;
 	rd_addr += wlk_ate.offset;
-	rc = _nvs_flash_rd(fs, rd_addr, data, MIN(len, wlk_ate.len));
+	rc = nvs_flash_rd(fs, rd_addr, data, MIN(len, wlk_ate.len));
 	if (rc) {
 		goto err;
 	}
@@ -903,7 +903,7 @@ ssize_t nvs_calc_free_space(struct nvs_fs *fs)
 		return -EACCES;
 	}
 
-	ate_size = _nvs_al_size(fs, sizeof(struct nvs_ate));
+	ate_size = nvs_al_size(fs, sizeof(struct nvs_ate));
 
 	free_space = 0;
 	for (u16_t i = 1; i < fs->sector_count; i++) {
@@ -913,7 +913,7 @@ ssize_t nvs_calc_free_space(struct nvs_fs *fs)
 	step_addr = fs->ate_wra;
 
 	while (1) {
-		rc = _nvs_prev_ate(fs, &step_addr, &step_ate);
+		rc = nvs_prev_ate(fs, &step_addr, &step_ate);
 		if (rc) {
 			return rc;
 		}
@@ -921,7 +921,7 @@ ssize_t nvs_calc_free_space(struct nvs_fs *fs)
 		wlk_addr = fs->ate_wra;
 
 		while (1) {
-			rc = _nvs_prev_ate(fs, &wlk_addr, &wlk_ate);
+			rc = nvs_prev_ate(fs, &wlk_addr, &wlk_ate);
 			if (rc) {
 				return rc;
 			}
@@ -932,9 +932,9 @@ ssize_t nvs_calc_free_space(struct nvs_fs *fs)
 		}
 
 		if ((wlk_addr == step_addr) && step_ate.len &&
-		    (!_nvs_ate_crc8_check(&step_ate))) {
+		    (!nvs_ate_crc8_check(&step_ate))) {
 			/* count needed */
-			free_space -= _nvs_al_size(fs, step_ate.len);
+			free_space -= nvs_al_size(fs, step_ate.len);
 			free_space -= ate_size;
 		}
 

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -46,8 +46,8 @@ static u32_t timestamp_div;
 
 typedef int (*out_func_t)(int c, void *ctx);
 
-extern int _prf(int (*func)(), void *dest, char *format, va_list vargs);
-extern void _vprintk(out_func_t out, void *log_output,
+extern int z_prf(int (*func)(), void *dest, char *format, va_list vargs);
+extern void z_vprintk(out_func_t out, void *log_output,
 		     const char *fmt, va_list ap);
 
 /* The RFC 5424 allows very flexible mapping and suggest the value 0 being the
@@ -116,9 +116,9 @@ static int print_formatted(const struct log_output *log_output,
 	va_start(args, fmt);
 #if !defined(CONFIG_NEWLIB_LIBC) && !defined(CONFIG_ARCH_POSIX) && \
     defined(CONFIG_LOG_ENABLE_FANCY_OUTPUT_FORMATTING)
-	length = _prf(out_func, (void *)log_output, (char *)fmt, args);
+	length = z_prf(out_func, (void *)log_output, (char *)fmt, args);
 #else
-	_vprintk(out_func, (void *)log_output, fmt, args);
+	z_vprintk(out_func, (void *)log_output, fmt, args);
 #endif
 	va_end(args);
 
@@ -554,9 +554,9 @@ void log_output_string(const struct log_output *log_output,
 
 #if !defined(CONFIG_NEWLIB_LIBC) && !defined(CONFIG_ARCH_POSIX) && \
     defined(CONFIG_LOG_ENABLE_FANCY_OUTPUT_FORMATTING)
-	length = _prf(out_func, (void *)log_output, (char *)fmt, ap);
+	length = z_prf(out_func, (void *)log_output, (char *)fmt, ap);
 #else
-	_vprintk(out_func, (void *)log_output, fmt, ap);
+	z_vprintk(out_func, (void *)log_output, fmt, ap);
 #endif
 
 	(void)length;

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -263,7 +263,7 @@ static int mgmt_event_wait_call(struct net_if *iface,
 				int timeout)
 {
 	struct mgmt_event_wait sync_data = {
-		.sync_call = _K_SEM_INITIALIZER(sync_data.sync_call, 0, 1),
+		.sync_call = Z_SEM_INITIALIZER(sync_data.sync_call, 0, 1),
 	};
 	struct net_mgmt_event_callback sync = {
 		.sync_call = &sync_data.sync_call,

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -493,7 +493,6 @@ static inline struct net_buf_pool *get_data_pool(struct net_context *context)
 #define get_data_pool(...) NULL
 #endif /* CONFIG_NET_CONTEXT_NET_PKT_POOL */
 
-
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 void net_pkt_unref_debug(struct net_pkt *pkt, const char *caller, int line)
 {

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2640,22 +2640,22 @@ static const struct shell *shell_for_ping;
 
 #if defined(CONFIG_NET_IPV6)
 
-static enum net_verdict _handle_ipv6_echo_reply(struct net_pkt *pkt,
+static enum net_verdict handle_ipv6_echo_reply(struct net_pkt *pkt,
 						struct net_ipv6_hdr *ip_hdr,
 						struct net_icmp_hdr *icmp_hdr);
 
 static struct net_icmpv6_handler ping6_handler = {
 	.type = NET_ICMPV6_ECHO_REPLY,
 	.code = 0,
-	.handler = _handle_ipv6_echo_reply,
+	.handler = handle_ipv6_echo_reply,
 };
 
-static inline void _remove_ipv6_ping_handler(void)
+static inline void remove_ipv6_ping_handler(void)
 {
 	net_icmpv6_unregister_handler(&ping6_handler);
 }
 
-static enum net_verdict _handle_ipv6_echo_reply(struct net_pkt *pkt,
+static enum net_verdict handle_ipv6_echo_reply(struct net_pkt *pkt,
 						struct net_ipv6_hdr *ip_hdr,
 						struct net_icmp_hdr *icmp_hdr)
 {
@@ -2665,13 +2665,13 @@ static enum net_verdict _handle_ipv6_echo_reply(struct net_pkt *pkt,
 		 net_sprint_ipv6_addr(&ip_hdr->src),
 		 net_sprint_ipv6_addr(&ip_hdr->dst));
 	k_sem_give(&ping_timeout);
-	_remove_ipv6_ping_handler();
+	remove_ipv6_ping_handler();
 
 	net_pkt_unref(pkt);
 	return NET_OK;
 }
 
-static int _ping_ipv6(const struct shell *shell, char *host)
+static int ping_ipv6(const struct shell *shell, char *host)
 {
 	struct in6_addr ipv6_target;
 	struct net_if *iface = net_if_get_default();
@@ -2705,7 +2705,7 @@ static int _ping_ipv6(const struct shell *shell, char *host)
 					   sys_rand32_get(),
 					   sys_rand32_get());
 	if (ret) {
-		_remove_ipv6_ping_handler();
+		remove_ipv6_ping_handler();
 	} else {
 		PR("Sent a ping to %s\n", host);
 	}
@@ -2713,40 +2713,40 @@ static int _ping_ipv6(const struct shell *shell, char *host)
 	return ret;
 }
 #else
-#define _ping_ipv6(...) -ENOTSUP
-#define _remove_ipv6_ping_handler()
+#define ping_ipv6(...) -ENOTSUP
+#define remove_ipv6_ping_handler()
 #endif /* CONFIG_NET_IPV6 */
 
 #if defined(CONFIG_NET_IPV4)
 
-static enum net_verdict _handle_ipv4_echo_reply(struct net_pkt *pkt,
+static enum net_verdict handle_ipv4_echo_reply(struct net_pkt *pkt,
 						struct net_ipv4_hdr *ip_hdr);
 
 static struct net_icmpv4_handler ping4_handler = {
 	.type = NET_ICMPV4_ECHO_REPLY,
 	.code = 0,
-	.handler = _handle_ipv4_echo_reply,
+	.handler = handle_ipv4_echo_reply,
 };
 
-static inline void _remove_ipv4_ping_handler(void)
+static inline void remove_ipv4_ping_handler(void)
 {
 	net_icmpv4_unregister_handler(&ping4_handler);
 }
 
-static enum net_verdict _handle_ipv4_echo_reply(struct net_pkt *pkt,
+static enum net_verdict handle_ipv4_echo_reply(struct net_pkt *pkt,
 						struct net_ipv4_hdr *ip_hdr)
 {
 	PR_SHELL(shell_for_ping, "Received echo reply from %s to %s\n",
 		 net_sprint_ipv4_addr(&ip_hdr->src),
 		 net_sprint_ipv4_addr(&ip_hdr->dst));
 	k_sem_give(&ping_timeout);
-	_remove_ipv4_ping_handler();
+	remove_ipv4_ping_handler();
 
 	net_pkt_unref(pkt);
 	return NET_OK;
 }
 
-static int _ping_ipv4(const struct shell *shell, char *host)
+static int ping_ipv4(const struct shell *shell, char *host)
 {
 	struct in_addr ipv4_target;
 	int ret;
@@ -2763,7 +2763,7 @@ static int _ping_ipv4(const struct shell *shell, char *host)
 		sys_rand32_get(),
 		sys_rand32_get());
 	if (ret) {
-		_remove_ipv4_ping_handler();
+		remove_ipv4_ping_handler();
 	} else {
 		PR("Sent a ping to %s\n", host);
 	}
@@ -2771,8 +2771,8 @@ static int _ping_ipv4(const struct shell *shell, char *host)
 	return ret;
 }
 #else
-#define _ping_ipv4(...) -ENOTSUP
-#define _remove_ipv4_ping_handler()
+#define ping_ipv4(...) -ENOTSUP
+#define remove_ipv4_ping_handler()
 #endif /* CONFIG_NET_IPV4 */
 #endif /* CONFIG_NET_IPV6 || CONFIG_NET_IPV4 */
 
@@ -2800,7 +2800,7 @@ static int cmd_net_ping(const struct shell *shell, size_t argc, char *argv[])
 	shell_for_ping = shell;
 
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
-		ret = _ping_ipv6(shell, host);
+		ret = ping_ipv6(shell, host);
 		if (!ret) {
 			goto wait_reply;
 		} else if (ret == -EIO) {
@@ -2810,7 +2810,7 @@ static int cmd_net_ping(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
-		ret = _ping_ipv4(shell, host);
+		ret = ping_ipv4(shell, host);
 		if (ret) {
 			if (ret == -EIO) {
 				PR_WARNING("Cannot send IPv4 ping\n");
@@ -2826,8 +2826,8 @@ wait_reply:
 	ret = k_sem_take(&ping_timeout, K_SECONDS(2));
 	if (ret == -EAGAIN) {
 		PR_INFO("Ping timeout\n");
-		_remove_ipv6_ping_handler();
-		_remove_ipv4_ping_handler();
+		remove_ipv6_ping_handler();
+		remove_ipv4_ping_handler();
 
 		return -ETIMEDOUT;
 	}

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -48,7 +48,7 @@ static int wifi_connect(u32_t mgmt_request, struct net_if *iface,
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_CONNECT, wifi_connect);
 
-static void _scan_result_cb(struct net_if *iface, int status,
+static void scan_result_cb(struct net_if *iface, int status,
 			    struct wifi_scan_result *entry)
 {
 	if (!iface) {
@@ -81,7 +81,7 @@ static int wifi_scan(u32_t mgmt_request, struct net_if *iface,
 		return -ENOTSUP;
 	}
 
-	return off_api->scan(dev, _scan_result_cb);
+	return off_api->scan(dev, scan_result_cb);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_SCAN, wifi_scan);

--- a/subsys/net/lib/config/bt_settings.c
+++ b/subsys/net/lib/config/bt_settings.c
@@ -32,7 +32,7 @@ static struct bt_gatt_attr attrs[] = {
 static struct bt_gatt_service ipss_svc = BT_GATT_SERVICE(attrs);
 #endif
 
-int _net_config_bt_setup(void)
+int z_net_config_bt_setup(void)
 {
 	struct net_if *iface;
 	struct device *dev;

--- a/subsys/net/lib/config/bt_settings.h
+++ b/subsys/net/lib/config/bt_settings.h
@@ -7,7 +7,7 @@
  */
 
 #if defined(CONFIG_NET_L2_BT) && defined(CONFIG_NET_CONFIG_SETTINGS)
-int _net_config_bt_setup(void);
+int z_net_config_bt_setup(void);
 #else
-#define _net_config_bt_setup(...) 0
+#define z_net_config_bt_setup(...) 0
 #endif

--- a/subsys/net/lib/config/ieee802154_settings.c
+++ b/subsys/net/lib/config/ieee802154_settings.c
@@ -17,7 +17,7 @@ LOG_MODULE_DECLARE(net_config, CONFIG_NET_CONFIG_LOG_LEVEL);
 #include <net/net_mgmt.h>
 #include <net/ieee802154_mgmt.h>
 
-int _net_config_ieee802154_setup(void)
+int z_net_config_ieee802154_setup(void)
 {
 	u16_t channel = CONFIG_NET_CONFIG_IEEE802154_CHANNEL;
 	u16_t pan_id = CONFIG_NET_CONFIG_IEEE802154_PAN_ID;

--- a/subsys/net/lib/config/ieee802154_settings.h
+++ b/subsys/net/lib/config/ieee802154_settings.h
@@ -7,7 +7,7 @@
  */
 
 #if defined(CONFIG_NET_L2_IEEE802154) && defined(CONFIG_NET_CONFIG_SETTINGS)
-int _net_config_ieee802154_setup(void);
+int z_net_config_ieee802154_setup(void);
 #else
-#define _net_config_ieee802154_setup(...) 0
+#define z_net_config_ieee802154_setup(...) 0
 #endif

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -350,12 +350,12 @@ static int init_app(struct device *device)
 
 #if defined(CONFIG_NET_IPV6)
 	/* IEEE 802.15.4 is only usable if IPv6 is enabled */
-	ret = _net_config_ieee802154_setup();
+	ret = z_net_config_ieee802154_setup();
 	if (ret < 0) {
 		NET_ERR("Cannot setup IEEE 802.15.4 interface (%d)", ret);
 	}
 
-	ret = _net_config_bt_setup();
+	ret = z_net_config_bt_setup();
 	if (ret < 0) {
 		NET_ERR("Cannot setup Bluetooth interface (%d)", ret);
 	}

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -49,7 +49,7 @@ static void zsock_received_cb(struct net_context *ctx,
 			      int status,
 			      void *user_data);
 
-static inline int _k_fifo_wait_non_empty(struct k_fifo *fifo, int32_t timeout)
+static inline int k_fifo_wait_non_empty(struct k_fifo *fifo, int32_t timeout)
 {
 	struct k_poll_event events[] = {
 		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE,
@@ -631,7 +631,7 @@ static inline ssize_t zsock_recv_dgram(struct net_context *ctx,
 	if (flags & ZSOCK_MSG_PEEK) {
 		int res;
 
-		res = _k_fifo_wait_non_empty(&ctx->recv_q, timeout);
+		res = k_fifo_wait_non_empty(&ctx->recv_q, timeout);
 		/* EAGAIN when timeout expired, EINTR when cancelled */
 		if (res && res != -EAGAIN && res != -EINTR) {
 			errno = -res;
@@ -719,7 +719,7 @@ static inline ssize_t zsock_recv_stream(struct net_context *ctx,
 			return 0;
 		}
 
-		res = _k_fifo_wait_non_empty(&ctx->recv_q, timeout);
+		res = k_fifo_wait_non_empty(&ctx->recv_q, timeout);
 		/* EAGAIN when timeout expired, EINTR when cancelled */
 		if (res && res != -EAGAIN && res != -EINTR) {
 			errno = -res;

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -26,7 +26,7 @@ extern const struct socket_op_vtable sock_fd_op_vtable;
 
 static const struct socket_op_vtable can_sock_fd_op_vtable;
 
-static inline int _k_fifo_wait_non_empty(struct k_fifo *fifo, int32_t timeout)
+static inline int k_fifo_wait_non_empty(struct k_fifo *fifo, int32_t timeout)
 {
 	struct k_poll_event events[] = {
 		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE,
@@ -211,7 +211,7 @@ static ssize_t zcan_recvfrom_ctx(struct net_context *ctx, void *buf,
 	if (flags & ZSOCK_MSG_PEEK) {
 		int ret;
 
-		ret = _k_fifo_wait_non_empty(&ctx->recv_q, timeout);
+		ret = k_fifo_wait_non_empty(&ctx->recv_q, timeout);
 		/* EAGAIN when timeout expired, EINTR when cancelled */
 		if (ret && ret != -EAGAIN && ret != -EINTR) {
 			errno = -ret;

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -26,7 +26,7 @@ extern const struct socket_op_vtable sock_fd_op_vtable;
 
 static const struct socket_op_vtable packet_sock_fd_op_vtable;
 
-static inline int _k_fifo_wait_non_empty(struct k_fifo *fifo, int32_t timeout)
+static inline int k_fifo_wait_non_empty(struct k_fifo *fifo, int32_t timeout)
 {
 	struct k_poll_event events[] = {
 		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE,
@@ -191,7 +191,7 @@ ssize_t zpacket_recvfrom_ctx(struct net_context *ctx, void *buf, size_t max_len,
 	if (flags & ZSOCK_MSG_PEEK) {
 		int res;
 
-		res = _k_fifo_wait_non_empty(&ctx->recv_q, timeout);
+		res = k_fifo_wait_non_empty(&ctx->recv_q, timeout);
 		/* EAGAIN when timeout expired, EINTR when cancelled */
 		if (res && res != -EAGAIN && res != -EINTR) {
 			errno = -res;

--- a/subsys/random/rand32_timestamp.c
+++ b/subsys/random/rand32_timestamp.c
@@ -31,5 +31,5 @@
 
 u32_t sys_rand32_get(void)
 {
-	return _do_read_cpu_timestamp32();
+	return z_do_read_cpu_timestamp32();
 }

--- a/subsys/shell/shell_fprintf.c
+++ b/subsys/shell/shell_fprintf.c
@@ -9,9 +9,9 @@
 
 #ifdef CONFIG_NEWLIB_LIBC
 typedef int (*out_func_t)(int c, void *ctx);
-extern void _vprintk(out_func_t out, void *ctx, const char *fmt, va_list ap);
+extern void z_vprintk(out_func_t out, void *ctx, const char *fmt, va_list ap);
 #else
-extern int _prf(int (*func)(), void *dest, char *format, va_list vargs);
+extern int z_prf(int (*func)(), void *dest, char *format, va_list vargs);
 #endif
 
 static int out_func(int c, void *ctx)
@@ -40,9 +40,9 @@ void shell_fprintf_fmt(const struct shell_fprintf *sh_fprintf,
 		       const char *fmt, va_list args)
 {
 #if !defined(CONFIG_NEWLIB_LIBC) && !defined(CONFIG_ARCH_POSIX)
-	(void)_prf(out_func, (void *)sh_fprintf, (char *)fmt, args);
+	(void)z_prf(out_func, (void *)sh_fprintf, (char *)fmt, args);
 #else
-	_vprintk(out_func, (void *)sh_fprintf, fmt, args);
+	z_vprintk(out_func, (void *)sh_fprintf, fmt, args);
 #endif
 
 	if (sh_fprintf->ctrl_blk->autoflush) {

--- a/subsys/testsuite/include/tc_util.h
+++ b/subsys/testsuite/include/tc_util.h
@@ -77,13 +77,13 @@ static __unused const char *TC_RESULT_STR[] = {
 #define TC_END(result, fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__)
 
 /* prints result and the function name */
-#define _TC_END_RESULT(result, func)					\
+#define Z_TC_END_RESULT(result, func)					\
 	do {								\
 		TC_END(result, "%s - %s\n", TC_RESULT_TO_STR(result), func); \
 		PRINT_LINE;						\
 	} while (0)
 #define TC_END_RESULT(result)                           \
-	_TC_END_RESULT((result), __func__)
+	Z_TC_END_RESULT((result), __func__)
 
 #if defined(CONFIG_ARCH_POSIX)
 #define TC_END_POST(result) posix_exit(result)

--- a/subsys/testsuite/ztest/include/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/ztest_assert.h
@@ -22,7 +22,7 @@
 void ztest_test_fail(void);
 #if CONFIG_ZTEST_ASSERT_VERBOSE == 0
 
-static inline void _zassert_(int cond, const char *file, int line)
+static inline void z_zassert_(int cond, const char *file, int line)
 {
 	if (!(cond)) {
 		PRINT("\n    Assertion failed at %s:%d\n",
@@ -31,12 +31,12 @@ static inline void _zassert_(int cond, const char *file, int line)
 	}
 }
 
-#define _zassert(cond, default_msg, file, line, func, msg, ...)	\
-	_zassert_(cond, file, line)
+#define z_zassert(cond, default_msg, file, line, func, msg, ...)	\
+	z_zassert_(cond, file, line)
 
 #else /* CONFIG_ZTEST_ASSERT_VERBOSE != 0 */
 
-static inline void _zassert(int cond,
+static inline void z_zassert(int cond,
 			    const char *default_msg,
 			    const char *file,
 			    int line, const char *func,
@@ -85,7 +85,7 @@ static inline void _zassert(int cond,
  */
 
 #define zassert(cond, default_msg, msg, ...)			    \
-	_zassert(cond, msg ? ("(" default_msg ")") : (default_msg), \
+	z_zassert(cond, msg ? ("(" default_msg ")") : (default_msg), \
 		 __FILE__, __LINE__, __func__, msg ? msg : "", ##__VA_ARGS__)
 
 /**

--- a/subsys/testsuite/ztest/include/ztest_mock.h
+++ b/subsys/testsuite/ztest/include/ztest_mock.h
@@ -34,7 +34,7 @@
  * @param value Value for @a param
  */
 #define ztest_expect_value(func, param, value) \
-	_ztest_expect_value(STRINGIFY(func), STRINGIFY(param), \
+	z_ztest_expect_value(STRINGIFY(func), STRINGIFY(param), \
 			    (uintptr_t)(value))
 
 /**
@@ -49,7 +49,7 @@
  * @param param Parameter to check
  */
 #define ztest_check_expected_value(param) \
-	_ztest_check_expected_value(__func__, STRINGIFY(param), \
+	z_ztest_check_expected_value(__func__, STRINGIFY(param), \
 				    (uintptr_t)(param))
 
 /**
@@ -59,7 +59,7 @@
  * @param value Value to return from @a func
  */
 #define ztest_returns_value(func, value) \
-	_ztest_returns_value(STRINGIFY(func), (uintptr_t)(value))
+	z_ztest_returns_value(STRINGIFY(func), (uintptr_t)(value))
 
 /**
  * @brief Get the return value for current function
@@ -70,7 +70,7 @@
  * @returns The value the current function should return
  */
 #define ztest_get_return_value() \
-	_ztest_get_return_value(__func__)
+	z_ztest_get_return_value(__func__)
 
 /**
  * @brief Get the return value as a pointer for current function
@@ -81,7 +81,7 @@
  * @returns The value the current function should return as a `void *`
  */
 #define ztest_get_return_value_ptr() \
-	((void *)_ztest_get_return_value(__func__))
+	((void *)z_ztest_get_return_value(__func__))
 
 /**
  * @}
@@ -91,20 +91,20 @@
 
 #include <zephyr/types.h>
 
-void _init_mock(void);
-int _cleanup_mock(void);
+void z_init_mock(void);
+int z_cleanup_mock(void);
 
-void _ztest_expect_value(const char *fn, const char *name, uintptr_t value);
-void _ztest_check_expected_value(const char *fn, const char *param,
+void z_ztest_expect_value(const char *fn, const char *name, uintptr_t value);
+void z_ztest_check_expected_value(const char *fn, const char *param,
 				 uintptr_t value);
 
-void _ztest_returns_value(const char *fn, uintptr_t value);
-uintptr_t _ztest_get_return_value(const char *fn);
+void z_ztest_returns_value(const char *fn, uintptr_t value);
+uintptr_t z_ztest_get_return_value(const char *fn);
 
 #else /* !CONFIG_ZTEST_MOCKING */
 
-#define _init_mock()
-#define _cleanup_mock() 0
+#define z_init_mock()
+#define z_cleanup_mock() 0
 
 #endif  /* CONFIG_ZTEST_MOCKING */
 

--- a/subsys/testsuite/ztest/include/ztest_test.h
+++ b/subsys/testsuite/ztest/include/ztest_test.h
@@ -23,7 +23,7 @@ struct unit_test {
 	u32_t thread_options;
 };
 
-void _ztest_run_test_suite(const char *name, struct unit_test *suite);
+void z_ztest_run_test_suite(const char *name, struct unit_test *suite);
 
 /**
  * @defgroup ztest_test Ztest testing macros
@@ -164,7 +164,7 @@ extern struct k_mem_domain ztest_mem_domain;
  * @param suite Test suite to run.
  */
 #define ztest_run_test_suite(suite) \
-	_ztest_run_test_suite(#suite, _##suite)
+	z_ztest_run_test_suite(#suite, _##suite)
 
 /**
  * @}

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -31,7 +31,7 @@ static int cleanup_test(struct unit_test *test)
 	int ret = TC_PASS;
 	int mock_status;
 
-	mock_status = _cleanup_mock();
+	mock_status = z_cleanup_mock();
 
 #ifdef KERNEL
 	/* we need to remove the ztest_thread information from the timeout_q.
@@ -138,7 +138,7 @@ static int run_test(struct unit_test *test)
 	run_test_functions(test);
 out:
 	ret |= cleanup_test(test);
-	_TC_END_RESULT(ret, test->name);
+	Z_TC_END_RESULT(ret, test->name);
 
 	return ret;
 }
@@ -234,9 +234,9 @@ static int run_test(struct unit_test *test)
 	}
 
 	if (test_result == -2) {
-		_TC_END_RESULT(TC_SKIP, test->name);
+		Z_TC_END_RESULT(TC_SKIP, test->name);
 	} else {
-		_TC_END_RESULT(ret, test->name);
+		Z_TC_END_RESULT(ret, test->name);
 	}
 
 	return ret;
@@ -244,7 +244,7 @@ static int run_test(struct unit_test *test)
 
 #endif /* !KERNEL */
 
-void _ztest_run_test_suite(const char *name, struct unit_test *suite)
+void z_ztest_run_test_suite(const char *name, struct unit_test *suite)
 {
 	int fail = 0;
 
@@ -290,7 +290,7 @@ K_APPMEM_PARTITION_DEFINE(ztest_mem_partition);
 #ifndef KERNEL
 int main(void)
 {
-	_init_mock();
+	z_init_mock();
 	test_main();
 	end_report();
 
@@ -320,7 +320,7 @@ void main(void)
 	k_mem_domain_add_thread(&ztest_mem_domain, k_current_get());
 #endif /* CONFIG_USERSPACE */
 
-	_init_mock();
+	z_init_mock();
 	test_main();
 	end_report();
 }

--- a/subsys/testsuite/ztest/src/ztest_mock.c
+++ b/subsys/testsuite/ztest/src/ztest_mock.c
@@ -39,7 +39,7 @@ static struct parameter *alloc_parameter(void)
 	return param;
 }
 
-void _init_mock(void)
+void z_init_mock(void)
 {
 
 }
@@ -126,7 +126,7 @@ struct parameter *alloc_parameter(void)
 	return param;
 }
 
-void _init_mock(void)
+void z_init_mock(void)
 {
 }
 
@@ -176,12 +176,12 @@ static void insert_value(struct parameter *param, const char *fn,
 static struct parameter parameter_list = { NULL, "", "", 0 };
 static struct parameter return_value_list = { NULL, "", "", 0 };
 
-void _ztest_expect_value(const char *fn, const char *name, uintptr_t val)
+void z_ztest_expect_value(const char *fn, const char *name, uintptr_t val)
 {
 	insert_value(&parameter_list, fn, name, val);
 }
 
-void _ztest_check_expected_value(const char *fn, const char *name,
+void z_ztest_check_expected_value(const char *fn, const char *name,
 				 uintptr_t val)
 {
 	struct parameter *param;
@@ -206,13 +206,13 @@ void _ztest_check_expected_value(const char *fn, const char *name,
 	}
 }
 
-void  _ztest_returns_value(const char *fn, uintptr_t value)
+void  z_ztest_returns_value(const char *fn, uintptr_t value)
 {
 	insert_value(&return_value_list, fn, "", value);
 }
 
 
-uintptr_t _ztest_get_return_value(const char *fn)
+uintptr_t z_ztest_get_return_value(const char *fn)
 {
 	uintptr_t value;
 	struct parameter *param = find_and_delete_value(&return_value_list,
@@ -240,7 +240,7 @@ static void free_param_list(struct parameter *param)
 	}
 }
 
-int _cleanup_mock(void)
+int z_cleanup_mock(void)
 {
 	int fail = 0;
 

--- a/tests/boards/altera_max10/msgdma/src/dma.c
+++ b/tests/boards/altera_max10/msgdma/src/dma.c
@@ -77,7 +77,7 @@ void test_msgdma(void)
 						"DMA config error");
 
 	/* Make sure all the data is written out to memory */
-	_nios2_dcache_flush_all();
+	z_nios2_dcache_flush_all();
 
 	/* Start DMA operation */
 	zassert_true(dma_start(dma, chan_id) == 0, "DMA start error");
@@ -87,7 +87,7 @@ void test_msgdma(void)
 	}
 
 	/* Invalidate the data cache */
-	_nios2_dcache_flush_no_writeback(rx_data, DMA_BUFF_SIZE);
+	z_nios2_dcache_flush_no_writeback(rx_data, DMA_BUFF_SIZE);
 
 	zassert_true(dma_stat == DMA_OP_STAT_SUCCESS,
 			"Nios-II DMA operation failed!!");

--- a/tests/kernel/arm_runtime_nmi/src/arm_runtime_nmi.c
+++ b/tests/kernel/arm_runtime_nmi/src/arm_runtime_nmi.c
@@ -16,7 +16,7 @@
 #define SCB_ICSR_NMIPENDSET_Msk SCB_ICSR_PENDNMISET_Msk
 #endif
 
-extern void _NmiHandlerSet(void (*pHandler)(void));
+extern void z_NmiHandlerSet(void (*pHandler)(void));
 
 static void nmi_test_isr(void)
 {
@@ -37,13 +37,13 @@ static void nmi_test_isr(void)
 /**
  * @brief test the behavior of CONFIG_RUNTIME_NMI at run time
  *
- * @details this test is to validate _NmiHandlerSet() api.
- * First we configure the NMI isr using _NmiHandlerSet() api.
+ * @details this test is to validate z_NmiHandlerSet() api.
+ * First we configure the NMI isr using z_NmiHandlerSet() api.
  * After wait for some time, and set the  Interrupt Control and
  * State Register(ICSR) of System control block (SCB).
  * The registered NMI isr should fire immediately.
  *
- * @see _NmiHandlerSet()
+ * @see z_NmiHandlerSet()
  */
 void test_arm_runtime_nmi(void)
 {
@@ -51,7 +51,7 @@ void test_arm_runtime_nmi(void)
 
 	TC_START("nmi_test_isr");
 	/* Configure the NMI isr */
-	_NmiHandlerSet(nmi_test_isr);
+	z_NmiHandlerSet(nmi_test_isr);
 
 	for (i = 0U; i < 10; i++) {
 		printk("Trigger NMI in 10s: %d s\n", i);

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -676,7 +676,7 @@ static void access_other_memdomain(void)
 
 
 #if defined(CONFIG_ARM)
-extern u8_t *_k_priv_stack_find(void *obj);
+extern u8_t *z_priv_stack_find(void *obj);
 extern k_thread_stack_t ztest_thread_stack[];
 #endif
 
@@ -1095,7 +1095,7 @@ void test_main(void)
 	k_mem_domain_add_thread(&dom0, k_current_get());
 
 #if defined(CONFIG_ARM)
-	priv_stack_ptr = (int *)_k_priv_stack_find(ztest_thread_stack) -
+	priv_stack_ptr = (int *)z_priv_stack_find(ztest_thread_stack) -
 		MPU_GUARD_ALIGN_AND_SIZE;
 
 #endif


### PR DESCRIPTION
Rename reserved function names in drivers/ subdirectory. Update
function macros concatenatenating function names with '##'. As
there is a conflict between the existing gpio_sch_manage_callback()
and _gpio_sch_manage_callback() names, leave the latter unmodified.

While waiting for the prefix discussion to conclude, add also renaming for arch/.

The reserved function names are discussed in #9882
