### PR TITLE
tests: net: iface: Handle pkt allocation failure

### DIFF
--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -422,6 +422,10 @@ static bool send_iface(struct net_if *iface, int val, bool expect_fail)
 
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(data),
 					AF_UNSPEC, 0, K_FOREVER);
+	if (!pkt) {
+		DBG("Cannot allocate pkt\n");
+		return false;
+	}
 
 	net_pkt_write_new(pkt, data, sizeof(data));
 	net_pkt_cursor_init(pkt);


### PR DESCRIPTION
This patch handles null pointer when packet allocation fails.

Fixes: #14390
Coverity-CID: 195903

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>