### PR TITLE
tests: subsys: fs : Fix coverity issue

### DIFF
--- a/subsys/fs/nffs_fs.c
+++ b/subsys/fs/nffs_fs.c
@@ -219,7 +219,10 @@ static int inode_to_dirent(struct nffs_inode_entry *inode,
 		entry->size = 0;
 	} else {
 		entry->type = FS_DIR_ENTRY_FILE;
-		nffs_inode_data_len(inode, &size);
+		rc = nffs_inode_data_len(inode, &size);
+		if (rc) {
+			return rc;
+		}
 		entry->size = size;
 	}
 


### PR DESCRIPTION
Fix Unchecked return value for nffs_inode_data_len() in
func: inode_to_diren()

Coverity-CID: 190981
Fixes: #13840

Signed-off-by: Varun Sharma <varun.sharma@intel.com>