### PR TITLE
Arch arm fix sp corrupt in jump to main

### DIFF
--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -94,6 +94,14 @@ z_arch_switch_to_main_thread(struct k_thread *main_thread,
 
 	/* the ready queue cache already contains the main thread */
 
+#ifdef CONFIG_ARM_MPU
+	/*
+	 * If stack protection is enabled, make sure to set it
+	 * before jumping to thread entry function
+	 */
+	z_arch_configure_dynamic_mpu_regions(main_thread);
+#endif
+
 #if defined(CONFIG_BUILTIN_STACK_GUARD)
 	/* Set PSPLIM register for built-in stack guarding of main thread. */
 #if defined(CONFIG_CPU_CORTEX_M_HAS_SPLIM)
@@ -105,13 +113,6 @@ z_arch_switch_to_main_thread(struct k_thread *main_thread,
 
 	__set_PSP((u32_t)start_of_main_stack);
 	unlock_interrupts();
-#ifdef CONFIG_ARM_MPU
-	/*
-	 * If stack protection is enabled, make sure to set it
-	 * before jumping to thread entry function
-	 */
-	z_arch_configure_dynamic_mpu_regions(main_thread);
-#endif
 	z_thread_entry(_main, 0, 0, 0);
 	CODE_UNREACHABLE;
 }


### PR DESCRIPTION
Fixes #14471 

Reverts, partially, the changes introduced in (bbe1a19), concerning moving the implementation into C functions. Apparently, we did not catch issues when compiling without any optimization flags, where local variables are stored, anyways, in the stack (and the stack pointer changes inside the function). We revert using assembly, now. An ISB is also added, before branching to main thread. Finally, the patch is also adding some inline documentation to ease reading.

A second patch is also provided, that moves the MPU re-programming a bit higher in the code, with no functional/behavioral changes.

