### PR TITLE
drivers: nrf: add support for forcing out-of-tree drivers

### DIFF
--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -4,6 +4,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+config CLOCK_CONTROL_NRF_FORCE_ALT
+	bool
+	depends on SOC_COMPATIBLE_NRF
+	help
+	  This option can be enabled to force an alternative implementation
+	  of the clock control driver.
+
+if !CLOCK_CONTROL_NRF_FORCE_ALT
+
 menuconfig CLOCK_CONTROL_NRF
 	bool "NRF Clock controller support"
 	depends on SOC_COMPATIBLE_NRF
@@ -67,3 +76,5 @@ config CLOCK_CONTROL_NRF_K32SRC_20PPM
 endchoice
 
 endif # CLOCK_CONTROL_NRF
+
+endif #!CLOCK_CONTROL_NRF_FORCE_ALT

--- a/drivers/entropy/Kconfig.nrf5
+++ b/drivers/entropy/Kconfig.nrf5
@@ -5,6 +5,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+config ENTROPY_NRF_FORCE_ALT
+	bool
+	depends on SOC_COMPATIBLE_NRF
+	help
+	  This option can be enabled to force an alternative implementation
+	  of the entropy driver.
+
+if !ENTROPY_NRF_FORCE_ALT
+
 menuconfig ENTROPY_NRF5_RNG
 	bool "nRF5 RNG driver"
 	depends on SOC_COMPATIBLE_NRF
@@ -70,3 +79,5 @@ config ENTROPY_NRF5_PRI
 	  nRF5X RNG IRQ priority.
 
 endif # ENTROPY_NRF5_RNG
+
+endif # !ENTROPY_NRF_FORCE_ALT

--- a/drivers/flash/Kconfig.nrf
+++ b/drivers/flash/Kconfig.nrf
@@ -1,3 +1,12 @@
+config FLASH_NRF_FORCE_ALT
+	bool
+	depends on SOC_COMPATIBLE_NRF
+	help
+	  This option can be enabled to force an alternative implementation
+	  of the flash driver.
+
+if !FLASH_NRF_FORCE_ALT
+
 config SOC_FLASH_NRF
 	bool "Nordic Semiconductor nRF flash driver"
 	depends on SOC_FAMILY_NRF
@@ -20,3 +29,5 @@ config SOC_FLASH_NRF_UICR
 	help
 	  Enable operations on UICR. Once enabled UICR are written or read as
 	  ordinary flash memory. Erase is possible for whole UICR at once.
+
+endif #!FLASH_NRF_FORCE_ALT


### PR DESCRIPTION
An external project extending the Zephyr RTOS and its drivers may have
subsystems that must use its own specific driver(s) when active. One
example is the nRF5x NVMC that must be scheduled in between radio
operations. A subsystem may also be dependent on its own drivers for
security, real-time and/or because of hardware constrains.

In order to not introduce non-Zephyr specific code into the Zephyr tree,
an option is added to disable the in-tree drivers in Zephyr. Because
Kconfig does not support a good way of de-selecting other symbols, a
variable on the form `<DRIVER>_OUT_OF_TREE_DRIVER` is added as a
dependency for each `<DRIVER>`. For example, the out-of-tree subsystem
will select `FLASH_OUT_OF_TREE_DRIVER` to disable the in-tree driver. A
solution for issue #8181 would open up for a more general solution,
however #8181 requires significant effort.

Support for out-of-tree drivers is added to Nordic drivers for
clock_control, entropy and flash.

See https://github.com/zephyrproject-rtos/zephyr/pull/13631 for earlier discussion.

Signed-off-by: Thomas Stenersen <thomas.stenersen@nordicsemi.no>