### PR TITLE
doc: Fix typo and markup elements

### DIFF
--- a/doc/guides/porting/board_porting.rst
+++ b/doc/guides/porting/board_porting.rst
@@ -145,7 +145,7 @@ guidelines should be followed when porting a board:
   96board), configure pins to fit this connector.
 
 - Configure components that enable the use of these pins, such as
-  configuring and SPI instance for Arduino SPI.
+  configuring an SPI instance for Arduino SPI.
 
 - Configure an output for the console.
 

--- a/doc/guides/west/build-flash-debug.rst
+++ b/doc/guides/west/build-flash-debug.rst
@@ -33,7 +33,7 @@ The ``build`` command allows you to build any source tree from any directory
 in your file system, placing the build results in a folder of your choice.
 
 In its simplest form, the command can be run by navigating to the root folder
-(i.e. the folder containing a file:`CMakeLists.txt` file) of the Zephyr
+(i.e. the folder containing a :file:`CMakeLists.txt` file) of the Zephyr
 application of your choice and running::
 
   west build -b <BOARD>
@@ -49,8 +49,8 @@ To specify the build directory, use ``--build-dir`` (or ``-d``)::
   west build -b <BOARD> --build-dir path/to/build/directory
 
 Since the build directory defaults to :file:`build`, if you do not specify
-a build directory but a folder named file:`build` is present, that will be used,
-allowing you to incrementally build from outside the file:`build` folder with
+a build directory but a folder named :file:`build` is present, that will be used,
+allowing you to incrementally build from outside the :file:`build` folder with
 no additional parameters.
 
 .. note::
@@ -117,7 +117,7 @@ To specify the build directory, use ``--build-dir`` (or ``-d``)::
 
 Since the build directory defaults to :file:`build`, if you do not specify
 a build directory but a folder named :file:`build` is present, that will be
-used, allowing you to flash from outside the file:`build` folder with no
+used, allowing you to flash from outside the :file:`build` folder with no
 additional parameters.
 
 Choosing a Runner
@@ -213,7 +213,7 @@ To specify the build directory, use ``--build-dir`` (or ``-d``)::
 
 Since the build directory defaults to :file:`build`, if you do not specify
 a build directory but a folder named :file:`build` is present, that will be
-used, allowing you to debug from outside the file:`build` folder with no
+used, allowing you to debug from outside the :file:`build` folder with no
 additional parameters.
 
 Choosing a Runner


### PR DESCRIPTION
Fixes a typo in `board_porting.rst`
Fixes wrong syntax for file markup element
in `build-flash-debug.rst`

Signed-off-by: Suryansh Sharma <suryansh@evilscientist.cc>