### PR TITLE
lib: mempool: Fix issues in mempool allocator

### DIFF
--- a/lib/os/mempool.c
+++ b/lib/os/mempool.c
@@ -299,9 +299,14 @@ int z_sys_mem_pool_block_alloc(struct sys_mem_pool_base *p, size_t size,
 	}
 	pool_irq_unlock(p, key);
 
+	*data_p = data;
+
+	if (data == NULL) {
+		return -ENOMEM;
+	}
+
 	*level_p = alloc_l;
 	*block_p = block_num(p, data, lsizes[alloc_l]);
-	*data_p = data;
 
 	return 0;
 }


### PR DESCRIPTION
This commits fixes three issues:
Fixes: #14504
1. Allocator returning success even if allocation failed

Fixes: #14508
2. Allocator fails to allocate while memory is available
but was hidden by other context calling free.
3. Allocator fails to allocate while memory is available
but was moved to another level.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>