### PR TITLE
tests: socket_helpers: Use zsock_ prefixed socket functions

### DIFF
--- a/tests/net/socket/socket_helpers.h
+++ b/tests/net/socket/socket_helpers.h
@@ -37,13 +37,13 @@ static inline void prepare_sock_udp_v6(const char *addr, u16_t port,
 	zassert_not_null(sock, "null sock");
 	zassert_not_null(sockaddr, "null sockaddr");
 
-	*sock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+	*sock = zsock_socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
 	zassert_true(*sock >= 0, "socket open failed");
 
 	(void)memset(sockaddr, 0, sizeof(*sockaddr));
 	sockaddr->sin6_family = AF_INET6;
 	sockaddr->sin6_port = htons(port);
-	rv = inet_pton(AF_INET6, addr, &sockaddr->sin6_addr);
+	rv = zsock_inet_pton(AF_INET6, addr, &sockaddr->sin6_addr);
 	zassert_equal(rv, 1, "inet_pton failed");
 }
 
@@ -56,12 +56,12 @@ static inline void prepare_sock_tcp_v4(const char *addr, u16_t port,
 	zassert_not_null(sock, "null sock");
 	zassert_not_null(sockaddr, "null sockaddr");
 
-	*sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+	*sock = zsock_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 	zassert_true(*sock >= 0, "socket open failed");
 
 	sockaddr->sin_family = AF_INET;
 	sockaddr->sin_port = htons(port);
-	rv = inet_pton(AF_INET, addr, &sockaddr->sin_addr);
+	rv = zsock_inet_pton(AF_INET, addr, &sockaddr->sin_addr);
 	zassert_equal(rv, 1, "inet_pton failed");
 }
 
@@ -74,11 +74,11 @@ static inline void prepare_sock_tcp_v6(const char *addr, u16_t port,
 	zassert_not_null(sock, "null sock");
 	zassert_not_null(sockaddr, "null sockaddr");
 
-	*sock = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
+	*sock = zsock_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
 	zassert_true(*sock >= 0, "socket open failed");
 
 	sockaddr->sin6_family = AF_INET6;
 	sockaddr->sin6_port = htons(port);
-	rv = inet_pton(AF_INET6, addr, &sockaddr->sin6_addr);
+	rv = zsock_inet_pton(AF_INET6, addr, &sockaddr->sin6_addr);
 	zassert_equal(rv, 1, "inet_pton failed");
 }


### PR DESCRIPTION
Don't depend on CONFIG_NET_SOCKETS_POSIX_NAMES being defined (e.g.,
it's going to conflict with POSIX API).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>