### PR TITLE
drivers: usb: nrfx: initialize local struct to zero

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1116,7 +1116,7 @@ static void usbd_event_transfer_data(nrfx_usbd_evt_t const *const p_event)
 static void usbd_event_handler(nrfx_usbd_evt_t const *const p_event)
 {
 	struct nrf_usbd_ep_ctx *ep_ctx;
-	struct usbd_event evt;
+	struct usbd_event evt = {0};
 	bool put_evt = false;
 
 	switch (p_event->type) {


### PR DESCRIPTION
Initialize a local struct variable to zero, to suppress
un-initialized variable error.

Fixes #14422.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>