### PR TITLE
samples: CAN: select normal mode if loopback is not desired

### DIFF
--- a/samples/drivers/CAN/src/main.c
+++ b/samples/drivers/CAN/src/main.c
@@ -199,6 +199,8 @@ void main(void)
 
 #ifdef CONFIG_LOOPBACK_MODE
 	can_configure(can_dev, CAN_LOOPBACK_MODE, 250000);
+#else
+	can_configure(can_dev, CAN_NORMAL_MODE, 250000);
 #endif
 
 	led_gpio_dev = device_get_binding(CONFIG_GPIO_LED_DEV);


### PR DESCRIPTION
Select normal mode if loopback mode is not desired.