### PR TITLE
logging: Workaround build warning with clang

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -355,8 +355,11 @@ static void thread_set(k_tid_t process_tid)
 {
 	proc_tid = process_tid;
 
-	if (!IS_ENABLED(CONFIG_LOG_IMMEDIATE) &&
-	    CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD &&
+	if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) {
+		return;
+	}
+
+	if (CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD &&
 	    process_tid &&
 	    buffered_cnt >= CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD) {
 		k_wakeup(proc_tid);


### PR DESCRIPTION
when building with clang we get the following warning:

log_core.c:358:40: error: use of logical '&&' with constant operand
[-Werror,-Wconstant-logical-operand]

This is because we are mix a constant IS_ENABLED(CONFIG_LOG_IMMEDIATE)
with non-constants.

Split out the check into its own statement to workaround the warning.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>