### PR TITLE
cmake: Fix how we set include dirs for userspace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -879,8 +879,6 @@ if(CONFIG_USERSPACE)
 
   get_property(compile_definitions_interface TARGET zephyr_interface
     PROPERTY INTERFACE_COMPILE_DEFINITIONS)
-
-  set(complete_include_dirs ${include_dir_in_interface} ${sys_include_dir_in_interface})
 endif()
 
 
@@ -967,8 +965,12 @@ if(CONFIG_ARM AND CONFIG_USERSPACE)
   # NB: Using a library instead of target_compile_options(priv_stacks_output_lib
   # [...]) because a library's options have precedence
   add_library(priv_stacks_output_lib_interface INTERFACE)
-  foreach(incl ${complete_include_dirs})
+  foreach(incl ${include_dir_in_interface})
     target_include_directories(priv_stacks_output_lib_interface INTERFACE ${incl})
+  endforeach()
+
+  foreach(incl ${sys_include_dir_in_interface})
+    target_include_directories(priv_stacks_output_lib_interface SYSTEM INTERFACE ${incl})
   endforeach()
 
   target_link_libraries(priv_stacks_output_lib priv_stacks_output_lib_interface)
@@ -1089,10 +1091,13 @@ if(CONFIG_USERSPACE)
 
   target_link_libraries(output_lib output_lib_interface)
 
-  foreach(incl ${complete_include_dirs})
+  foreach(incl ${include_dir_in_interface})
     target_include_directories(output_lib_interface INTERFACE ${incl})
   endforeach()
 
+  foreach(incl ${sys_include_dir_in_interface})
+    target_include_directories(output_lib_interface SYSTEM INTERFACE ${incl})
+  endforeach()
 
   set(OUTPUT_OBJ_PATH ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/output_lib.dir/${OUTPUT_OBJ})
 


### PR DESCRIPTION
To ensure the proper flags are specified to the toolchain, we need to
keep system headers and non-system headers seperate and set the SYSTEM
flag to target_include_directories for system headers.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>