### PR TITLE
boards: arm: atsamd21: enable USB in dts

### DIFF
--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
@@ -62,3 +62,7 @@
 	dipo = <0>;
 	dopo = <2>;
 };
+
+&usb0 {
+	status = "ok";
+};


### PR DESCRIPTION
USB is already being configured in pinmux.c, but for it to be
availiable it also needs to be enabled in the device tree.

Signed-off-by: Benjamin Valentin <benjamin.valentin@ml-pa.com>