### PR TITLE
arm: asm: Fix inline asm in Z_ARCH_EXCEPT for clang

### DIFF
--- a/include/arch/arm/cortex_m/error.h
+++ b/include/arch/arm/cortex_m/error.h
@@ -46,7 +46,7 @@ extern void z_SysFatalErrorHandler(unsigned int reason, const NANO_ESF *esf);
 #define Z_ARCH_EXCEPT(reason_p) do { \
 	__asm__ volatile ( \
 		"cpsie i\n\t" \
-		"mov r0, %[reason]\n\t" \
+		"movs r0, %[reason]\n\t" \
 		"svc %[id]\n\t" \
 		: \
 		: [reason] "i" (reason_p), [id] "i" (_SVC_CALL_RUNTIME_EXCEPT) \


### PR DESCRIPTION
The clang ARM assembler is a bit stricter than GNU as.  Change mov to
movs for ARMv6 case of Z_ARCH_EXCEPT.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>