### PR TITLE
samples: net: mqtt_publisher: fix printk invoked with an undefined argument

### DIFF
--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -107,9 +107,12 @@ static void clear_fds(void)
 
 static void wait(int timeout)
 {
+	int err;
+
 	if (nfds > 0) {
-		if (poll(fds, nfds, timeout) < 0) {
-			printk("poll error: %d\n", errno);
+		err = poll(fds, nfds, timeout);
+		if (err < 0) {
+			printk("poll error: %d\n", err);
 		}
 	}
 }


### PR DESCRIPTION
Printk is invoked with an undefined argument.