### PR TITLE
cmake: Bump min SDK version to 0.10.0

### DIFF
--- a/cmake/toolchain/zephyr/host-tools.cmake
+++ b/cmake/toolchain/zephyr/host-tools.cmake
@@ -15,7 +15,7 @@ if(NOT ZEPHYR_SDK_INSTALL_DIR)
   return()
 endif()
 
-set(REQUIRED_SDK_VER 0.9.5)
+set(REQUIRED_SDK_VER 0.10.0)
 set(TOOLCHAIN_VENDOR zephyr)
 set(TOOLCHAIN_ARCH x86_64)
 


### PR DESCRIPTION
We need the 0.10.0 release for new support for the ARM-v8m SoCs and
RISC-V.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>