### PR TITLE
userspace: don't modify optimization options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -951,10 +951,9 @@ if(CONFIG_ARM AND CONFIG_USERSPACE)
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/${PRIV_STACKS_OUTPUT_SRC}
     PROPERTIES COMPILE_DEFINITIONS "${compile_definitions_interface}")
 
-  # always compile priv_stacks_hash.c at optimization -Os
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/${PRIV_STACKS_OUTPUT_SRC}
     PROPERTIES COMPILE_FLAGS
-    "${NO_COVERAGE_FLAGS} -Os -fno-function-sections -fno-data-sections ")
+    "${NO_COVERAGE_FLAGS} -fno-function-sections -fno-data-sections ")
 
   # We need precise control of where generated text/data ends up in the final
   # kernel image. Disable function/data sections and use objcopy to move
@@ -1075,9 +1074,8 @@ if(CONFIG_USERSPACE)
     ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_SRC}
     )
 
-  # always compile kobject_hash.c at optimization -Os
   set_source_files_properties(${OUTPUT_SRC} PROPERTIES COMPILE_FLAGS
-    "${NO_COVERAGE_FLAGS} -Os -fno-function-sections -fno-data-sections")
+    "${NO_COVERAGE_FLAGS} -fno-function-sections -fno-data-sections")
 
   set_source_files_properties(${OUTPUT_SRC}
     PROPERTIES COMPILE_DEFINITIONS "${compile_definitions_interface}")


### PR DESCRIPTION
The gperf hashtables and support functions are created
after the initial zephyr_prebuilt.elf is created, using
data found within it.

A fixed-sized amount of memory is reserved for the
program text of these support functions, as their true
size isn't possible to predict in advance and we don't
want memory addresses after them to shift. To minimize
the amount of space reserved, it seemed reasonable to
hard-code -Os.

However, on ARC, building with -Os can cause various
millicode functions from libgcc to be included in the
binary which would not be present in zephyr_prebuilt.elf
unless zephyr_prebuilt.elf was also built with -Os,
causing anything after them to be shifted, wreaking all
kinds of havoc.

Just build without hardcoding any optimization parameters.
We have checks in the linker scripts to let us know if
we have overflowed the region for the gperf support
functions anyway, so there is no danger of this failing
silently.

Fixes: #14139

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>