### PR TITLE
arch: arc: optimize the push and pop of fast irq

### DIFF
--- a/arch/arc/core/fast_irq.S
+++ b/arch/arc/core/fast_irq.S
@@ -175,37 +175,8 @@ _firq_no_reschedule:
 	 * instruction instead of a pair of cmp and bxx
 	 */
 #if CONFIG_RGF_NUM_BANKS == 1
-	add sp,sp,4 /* don't need r0 from stack */
-	pop_s r1
-	pop_s r2
-	pop_s r3
-	pop r4
-	pop r5
-	pop r6
-	pop r7
-	pop r8
-	pop r9
-	pop r10
-	pop r11
-	pop_s r12
-	pop_s r13
-	pop_s blink
-	pop_s r0
-	sr r0, [_ARC_V2_LP_END]
-	pop_s r0
-	sr r0, [_ARC_V2_LP_START]
-	pop_s r0
-	mov lp_count,r0
-#ifdef CONFIG_CODE_DENSITY
-	pop_s r0
-	sr r0, [_ARC_V2_EI_BASE]
-	pop_s r0
-	sr r0, [_ARC_V2_LDI_BASE]
-	pop_s r0
-	sr r0, [_ARC_V2_JLI_BASE]
-#endif
+	_pop_irq_stack_frame
 	ld r0,[saved_r0]
-	add sp,sp,8 /* don't need ilink & status32_po from stack */
 #endif
 	rtie
 

--- a/arch/arc/core/isr_wrapper.S
+++ b/arch/arc/core/isr_wrapper.S
@@ -81,9 +81,6 @@ IRQ stack frame layout:
   low address
 
 Registers not taken into account in the current implementation.
-          jli_base
-          ldi_base
-          ei_base
           accl
           acch
 
@@ -240,40 +237,13 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 #if CONFIG_RGF_NUM_BANKS == 1
 	bnz rirq_path
 	/* 1-register bank FIRQ handling must save registers on stack */
-	lr r0,[_ARC_V2_STATUS32_P0]
-	push_s r0
+	_create_irq_stack_frame
+	lr r0, [_ARC_V2_STATUS32_P0]
+	st_s r0, [sp, ___isf_t_status32_OFFSET]
 	mov r0,ilink
-	push_s r0
-#ifdef CONFIG_CODE_DENSITY
-	lr r0, [_ARC_V2_JLI_BASE]
-	push_s r0
-	lr r0, [_ARC_V2_LDI_BASE]
-	push_s r0
-	lr r0, [_ARC_V2_EI_BASE]
-	push_s r0
-#endif
-	mov r0,lp_count
-	push_s r0
-	lr r0, [_ARC_V2_LP_START]
-	push_s r0
-	lr r0, [_ARC_V2_LP_END]
-	push_s r0
-	push_s blink
-	push_s r13
-	push_s r12
-	push r11
-	push r10
-	push r9
-	push r8
-	push r7
-	push r6
-	push r5
-	push r4
-	push_s r3
-	push_s r2
-	push_s r1
+	st_s r0, [sp, ___isf_t_pc_OFFSET]
 	ld r0,[saved_r0]
-	push_s r0
+	st_s r0, [sp, ___isf_t_r0_OFFSET]
 	mov r3, _firq_exit
 	mov r2, _firq_enter
 	j_s [r2]


### PR DESCRIPTION
use macro to replace pop/push instructions

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>