### PR TITLE
Fixed IPv6 neighbor table related issues

### DIFF
--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -106,6 +106,13 @@ struct net_ipv6_nbr_data {
 
 	/** Is the neighbor a router */
 	bool is_router;
+
+#if defined(CONFIG_NET_IPV6_NBR_CACHE) || defined(CONFIG_NET_IPV6_ND)
+	/** Stale counter used to removed oldest nbr in STALE state,
+	 *  when table is full.
+	 */
+	u32_t stale_counter;
+#endif
 };
 
 static inline struct net_ipv6_nbr_data *net_ipv6_nbr_data(struct net_nbr *nbr)

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -410,7 +410,40 @@ static void test_add_neighbor(void)
 			       false, NET_IPV6_NBR_STATE_REACHABLE);
 	zassert_not_null(nbr, "Cannot add peer %s to neighbor cache\n",
 			 net_sprint_ipv6_addr(&peer_addr));
+}
 
+/**
+ * @brief IPv6 add more than max neighbors
+ */
+static void test_add_max_neighbors(void)
+{
+	struct in6_addr dst_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+					 0, 0, 0, 0, 0, 0, 0, 0x3 } } };
+	struct net_nbr *nbr;
+	struct net_linkaddr_storage llstorage;
+	struct net_linkaddr lladdr;
+	u8_t i;
+
+	llstorage.addr[0] = 0x01;
+	llstorage.addr[1] = 0x02;
+	llstorage.addr[2] = 0x33;
+	llstorage.addr[3] = 0x44;
+	llstorage.addr[4] = 0x05;
+	llstorage.addr[5] = 0x07;
+
+	lladdr.len = 6;
+	lladdr.addr = llstorage.addr;
+	lladdr.type = NET_LINK_ETHERNET;
+
+	for (i = 0; i < CONFIG_NET_IPV6_MAX_NEIGHBORS + 1; i++) {
+		llstorage.addr[5] += i;
+		dst_addr.s6_addr[15] += i;
+		nbr = net_ipv6_nbr_add(net_if_get_default(), &dst_addr,
+				       &lladdr, false,
+				       NET_IPV6_NBR_STATE_STALE);
+		zassert_not_null(nbr, "Cannot add peer %s to neighbor cache\n",
+				 net_sprint_ipv6_addr(&dst_addr));
+	}
 }
 
 /**
@@ -1324,6 +1357,7 @@ void test_main(void)
 			 ztest_unit_test(test_cmp_prefix),
 			 ztest_unit_test(test_nbr_lookup_fail),
 			 ztest_unit_test(test_add_neighbor),
+			 ztest_unit_test(test_add_max_neighbors),
 			 ztest_unit_test(test_nbr_lookup_ok),
 			 ztest_unit_test(test_send_ns_extra_options),
 			 ztest_unit_test(test_send_ns_no_options),


### PR DESCRIPTION
    This PR fixes following issues.
    
      * If IPv6 neighbor table is full, stack can not add any new
        neighbors. So stale counter is introduced. Whenever neighbor
        enters into STALE state, stale counter will be incremented
        by one. When table is full and if stack wants to add new
        neighbor, oldest neighbor in STALE state will be removed
        and new neighbor will be added.
    
      * When neighbor is in PROBE state and when it exceeds max
        number of PROBEs, only neighbor with router is removed.
        As per RFC 4861 Appendix C, entry can be discarded. Now
        neighbor will be removed from the table.
    
      * Reachability timer has an issue. e.g. if a first entry timer
        is 10 seconds, after 3 seconds, a new entry added with
        only 3 seconds. But current implementation does not check
        whether remaining time of current left over timeout is more
        than new entry timeout or not. In this example, when new entry
        timeout is 3 seconds, left over timeout from first etnry is
        still 7 seconds. If k_delayed_work_remaining_get() returns
        some value then new entry time out was not considered.
        Which is bad. It fixed now.
    
      * nbr_free is used sometimes to remove the neighbor. Which does
        not remove route if that particulat neighbor is route to some
        other neighbor. net_ipv6_nbr_rm() should be used in such places.
    
      * Trivial changes which does not affect functionality.