### PR TITLE
kconfig: Increase the size of KOBJECT_TEXT_AREA when NO_OPTIMIZATION

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -200,6 +200,7 @@ config PRIVILEGED_STACK_TEXT_AREA
 config KOBJECT_TEXT_AREA
 	int "Size if kobject text area"
 	default 512 if COVERAGE_GCOV
+	default 512 if NO_OPTIMIZATIONS
 	default 256
 	depends on ARCH_HAS_USERSPACE
 	help


### PR DESCRIPTION
Since #14545 was merged, building with USERSPACE and NO_OPTIMIZATIONS
has been broken due to #5226.

To fix #5226 we increase the size of KOBJECT_TEXT_AREA when
NO_OPTIMIZATIONS.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>