### PR TITLE
cmake: LD: Allow input sections to remain unsorted

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,7 +386,8 @@ zephyr_ld_options(
 
 # Sort the common symbols and each input section by alignment
 # in descending order to minimize padding between these symbols.
-zephyr_ld_options(
+zephyr_ld_option_ifdef(
+  CONFIG_LINKER_SORT_BY_ALIGNMENT
   ${LINKERFLAGPREFIX},--sort-common=descending
   ${LINKERFLAGPREFIX},--sort-section=alignment
   )

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -180,6 +180,14 @@ config CHECK_LINK_MAP
 	  Run a linker address generation validity checker at the end of the
 	  build.
 
+config LINKER_SORT_BY_ALIGNMENT
+	bool "Sort input sections by alignment"
+	default y
+	help
+	  This turns on the linker flag to sort sections by alignment
+	  in decreasing size of symbols. This helps to minimize
+	  padding between symbols.
+
 endmenu
 
 menu "Compiler Options"


### PR DESCRIPTION
We have users that have problems in their linker scripts where the
order of input sections matters.

To allow users to use the latest Zephyr while working on a fix to
their linker scripts we add an option to allow leaving the sections
unsorted.

See discussion here for more details
https://github.com/zephyrproject-rtos/zephyr/pull/14183

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>