### PR TITLE
USB: netusb: Use standard frame size and cleanup

### DIFF
--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -253,7 +253,9 @@ static int ecm_send(struct net_pkt *pkt)
 	size_t len = net_pkt_get_len(pkt);
 	int ret;
 
-	net_pkt_hexdump(pkt, "<");
+	if (IS_ENABLED(VERBOSE_DEBUG)) {
+		net_pkt_hexdump(pkt, "<");
+	}
 
 	if (len > sizeof(tx_buf)) {
 		LOG_WRN("Trying to send too large packet, drop");
@@ -306,6 +308,10 @@ static void ecm_read_cb(u8_t ep, int size, void *priv)
 		LOG_ERR("Unable to write into pkt\n");
 		net_pkt_unref(pkt);
 		goto done;
+	}
+
+	if (IS_ENABLED(VERBOSE_DEBUG)) {
+		net_pkt_hexdump(pkt, ">");
 	}
 
 	netusb_recv(pkt);

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -11,23 +11,16 @@ LOG_MODULE_REGISTER(usb_ecm);
 /* Enable verbose debug printing extra hexdumps */
 #define VERBOSE_DEBUG	0
 
-/* This enables basic hexdumps */
-#define NET_LOG_ENABLED	0
-#include <net_private.h>
-
-#include <zephyr.h>
-
-#include <usb_device.h>
-#include <usb_common.h>
-
 #include <net/net_pkt.h>
 #include <net/ethernet.h>
+#include <net_private.h>
 
+#include <usb/usb_device.h>
+#include <usb/usb_common.h>
+#include <usb/class/usb_cdc.h>
 #include <usb_descriptor.h>
-#include <class/usb_cdc.h>
-#include "netusb.h"
 
-#define ECM_FRAME_SIZE 1522
+#include "netusb.h"
 
 #define USB_CDC_ECM_REQ_TYPE		0x21
 #define USB_CDC_SET_ETH_PKT_FILTER	0x43
@@ -35,6 +28,10 @@ LOG_MODULE_REGISTER(usb_ecm);
 #define ECM_INT_EP_IDX			0
 #define ECM_OUT_EP_IDX			1
 #define ECM_IN_EP_IDX			2
+
+#define ECM_FRAME_SIZE			1522
+
+static u8_t tx_buf[ECM_FRAME_SIZE], rx_buf[ECM_FRAME_SIZE];
 
 struct usb_cdc_ecm_config {
 #ifdef CONFIG_USB_COMPOSITE_DEVICE
@@ -195,8 +192,6 @@ static struct usb_ep_cfg_data ecm_ep_data[] = {
 		.ep_addr = CDC_ECM_IN_EP_ADDR
 	},
 };
-
-static u8_t tx_buf[ECM_FRAME_SIZE], rx_buf[ECM_FRAME_SIZE];
 
 static int ecm_class_handler(struct usb_setup_packet *setup, s32_t *len,
 			     u8_t **data)

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -255,6 +255,11 @@ static int ecm_send(struct net_pkt *pkt)
 
 	net_pkt_hexdump(pkt, "<");
 
+	if (len > sizeof(tx_buf)) {
+		LOG_WRN("Trying to send too large packet, drop");
+		return -ENOMEM;
+	}
+
 	if (net_pkt_read(pkt, tx_buf, len)) {
 		return -ENOBUFS;
 	}

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -29,9 +29,8 @@ LOG_MODULE_REGISTER(usb_ecm);
 #define ECM_OUT_EP_IDX			1
 #define ECM_IN_EP_IDX			2
 
-#define ECM_FRAME_SIZE			1522
 
-static u8_t tx_buf[ECM_FRAME_SIZE], rx_buf[ECM_FRAME_SIZE];
+static u8_t tx_buf[NET_ETH_MAX_FRAME_SIZE], rx_buf[NET_ETH_MAX_FRAME_SIZE];
 
 struct usb_cdc_ecm_config {
 #ifdef CONFIG_USB_COMPOSITE_DEVICE
@@ -98,7 +97,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 		.bDescriptorSubtype = ETHERNET_FUNC_DESC,
 		.iMACAddress = 4,
 		.bmEthernetStatistics = sys_cpu_to_le32(0), /* None */
-		.wMaxSegmentSize = sys_cpu_to_le16(ECM_FRAME_SIZE),
+		.wMaxSegmentSize = sys_cpu_to_le16(NET_ETH_MAX_FRAME_SIZE),
 		.wNumberMCFilters = sys_cpu_to_le16(0), /* None */
 		.bNumberPowerFilters = 0, /* No wake up */
 	},

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -8,15 +8,13 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(usb_eem);
 
-#include <net_private.h>
-#include <zephyr.h>
-#include <usb_device.h>
-#include <usb_common.h>
-
 #include <net/net_pkt.h>
+#include <net_private.h>
 
-#include <usb_descriptor.h>
-#include <class/usb_cdc.h>
+#include <usb/usb_device.h>
+#include <usb/usb_common.h>
+#include <usb/class/usb_cdc.h>
+
 #include "netusb.h"
 
 #define EEM_FRAME_SIZE 1522
@@ -51,8 +49,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_eem_config cdc_eem_cfg = {
 		.bEndpointAddress = CDC_EEM_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
-			sys_cpu_to_le16(
-			CONFIG_CDC_EEM_BULK_EP_MPS),
+			sys_cpu_to_le16(CONFIG_CDC_EEM_BULK_EP_MPS),
 		.bInterval = 0x00,
 	},
 
@@ -63,8 +60,7 @@ USBD_CLASS_DESCR_DEFINE(primary, 0) struct usb_cdc_eem_config cdc_eem_cfg = {
 		.bEndpointAddress = CDC_EEM_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
-			sys_cpu_to_le16(
-			CONFIG_CDC_EEM_BULK_EP_MPS),
+			sys_cpu_to_le16(CONFIG_CDC_EEM_BULK_EP_MPS),
 		.bInterval = 0x00,
 	},
 };

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -109,6 +109,11 @@ static int eem_send(struct net_pkt *pkt)
 	 */
 	len = net_pkt_get_len(pkt) + sizeof(sentinel);
 
+	if (len + sizeof(u16_t) > sizeof(tx_buf)) {
+		LOG_WRN("Trying to send too large packet, drop");
+		return -ENOMEM;
+	}
+
 	/* Add EEM header */
 	*hdr = sys_cpu_to_le16(0x3FFF & len);
 	b_idx += sizeof(u16_t);

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -216,7 +216,8 @@ static struct __rndis {
 static u8_t manufacturer[] = CONFIG_USB_DEVICE_MANUFACTURER;
 static u32_t drv_version = 1U;
 
-static u8_t tx_buf[NETUSB_MTU + sizeof(struct rndis_payload_packet)];
+static u8_t tx_buf[NET_ETH_MAX_FRAME_SIZE +
+				sizeof(struct rndis_payload_packet)];
 
 static u32_t object_id_supported[] = {
 	RNDIS_OBJECT_ID_GEN_SUPP_LIST,

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -1015,6 +1015,11 @@ static int rndis_send(struct net_pkt *pkt)
 		net_pkt_hexdump(pkt, "<");
 	}
 
+	if (len + sizeof(struct rndis_payload_packet) > sizeof(tx_buf)) {
+		LOG_WRN("Trying to send too large packet, drop");
+		return -ENOMEM;
+	}
+
 	rndis_hdr_add(tx_buf, len);
 
 	ret = net_pkt_read(pkt,

--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -189,4 +189,4 @@ static int netusb_init_dev(struct device *dev)
 
 NET_DEVICE_INIT(eth_netusb, "eth_netusb", netusb_init_dev, NULL, NULL,
 		CONFIG_ETH_INIT_PRIORITY, &netusb_api_funcs, ETHERNET_L2,
-		NET_L2_GET_CTX_TYPE(ETHERNET_L2), NETUSB_MTU);
+		NET_L2_GET_CTX_TYPE(ETHERNET_L2), NET_ETH_MTU);

--- a/subsys/usb/class/netusb/netusb.h
+++ b/subsys/usb/class/netusb/netusb.h
@@ -8,8 +8,6 @@
  * USB definitions
  */
 
-#define NETUSB_MTU 1500
-
 #define CDC_ECM_INT_EP_ADDR		0x83
 #define CDC_ECM_IN_EP_ADDR		0x82
 #define CDC_ECM_OUT_EP_ADDR		0x01


### PR DESCRIPTION
Use standard frame size, correct buffer sizes and cleanup.

Fixes #14780 