### PR TITLE
drivers: watchdog: Rename CONFIG_WDT_SAM_DISABLE_AT_BOOT in comments

### DIFF
--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -10,11 +10,11 @@
  * Note:
  * - Once the watchdog disable bit is set, it cannot be cleared till next
  *   power reset, i.e, the watchdog cannot be started once stopped.
- * - Since the MCU boots with WDT enabled,the  CONFIG_WDT_SAM_DISABLE_AT_BOOT
+ * - Since the MCU boots with WDT enabled, the CONFIG_WDT_DISABLE_AT_BOOT
  *   is set default at boot and watchdog module is disabled in the MCU for
  *   systems that don't need watchdog functionality.
  * - If the application needs to use the watchdog in the system, then
- *   CONFIG_WDT_SAM_DISABLE_AT_BOOT must be unset in the app's config file
+ *   CONFIG_WDT_DISABLE_AT_BOOT must be unset in the app's config file
  */
 
 #include <watchdog.h>


### PR DESCRIPTION
CONFIG_WDT_SAM_DISABLE_AT_BOOT was removed in commit 2e01e86bdc
("drivers: watchdog: wdt_sam: use the generic disable option"), but some
comments still talked about it. Replace it with
CONFIG_WDT_DISABLE_AT_BOOT.