### PR TITLE
power: Fix reference to CONFIG_SYS_PM_LOG_LEVEL

### DIFF
--- a/subsys/power/device_pm.c
+++ b/subsys/power/device_pm.c
@@ -9,7 +9,7 @@
 #include <device.h>
 #include <misc/__assert.h>
 
-#define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
+#define LOG_LEVEL CONFIG_SYS_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
 LOG_MODULE_DECLARE(power);
 


### PR DESCRIPTION
CONFIG_PM_LOG_LEVEL was renamed to CONFIG_SYS_PM_LOG_LEVEL in commit
c45961daae ("power: Rework OS <-> Application interface"), but the old
name is still used here. Fix the name.