### PR TITLE
ext: mcux: csi: Fix wrong circular queue delta calculation

### DIFF
--- a/ext/hal/nxp/mcux/drivers/imx/fsl_csi.c
+++ b/ext/hal/nxp/mcux/drivers/imx/fsl_csi.c
@@ -146,7 +146,7 @@ static uint32_t CSI_TransferGetQueueDelta(uint32_t startIdx, uint32_t endIdx)
     }
     else
     {
-        return startIdx + CSI_DRIVER_ACTUAL_QUEUE_SIZE - endIdx;
+        return endIdx + CSI_DRIVER_ACTUAL_QUEUE_SIZE - startIdx;
     }
 }
 


### PR DESCRIPTION
This error causes various instabilities during capture.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>