### PR TITLE
userspace: private identifier naming fixes

### DIFF
--- a/kernel/include/syscall_handler.h
+++ b/kernel/include/syscall_handler.h
@@ -516,14 +516,14 @@ static inline int z_obj_validation_check(struct _k_object *ko,
  *
  * These make it much simpler to define handlers instead of typing out
  * the bolierplate. The macros ensure that the seventh argument is named
- * "ssf" as this is now referenced by various other _SYSCALL macros.
+ * "ssf" as this is now referenced by various other Z_SYSCALL macros.
  *
- * Use the _SYSCALL_HANDLER(name_, arg0, ..., arg6) variant, as it will
- * automatically deduce the correct version of __SYSCALL_HANDLERn() to
+ * Use the Z_SYSCALL_HANDLER(name_, arg0, ..., arg6) variant, as it will
+ * automatically deduce the correct version of Z__SYSCALL_HANDLERn() to
  * use depending on the number of arguments.
  */
 
-#define __SYSCALL_HANDLER0(name_) \
+#define Z__SYSCALL_HANDLER0(name_) \
 	u32_t hdlr_ ## name_(u32_t arg1 __unused, \
 				 u32_t arg2 __unused, \
 				 u32_t arg3 __unused, \
@@ -532,7 +532,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 				 u32_t arg6 __unused, \
 				 void *ssf)
 
-#define __SYSCALL_HANDLER1(name_, arg1_) \
+#define Z__SYSCALL_HANDLER1(name_, arg1_) \
 	u32_t hdlr_ ## name_(u32_t arg1_, \
 				 u32_t arg2 __unused, \
 				 u32_t arg3 __unused, \
@@ -541,7 +541,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 				 u32_t arg6 __unused, \
 				 void *ssf)
 
-#define __SYSCALL_HANDLER2(name_, arg1_, arg2_) \
+#define Z__SYSCALL_HANDLER2(name_, arg1_, arg2_) \
 	u32_t hdlr_ ## name_(u32_t arg1_, \
 				 u32_t arg2_, \
 				 u32_t arg3 __unused, \
@@ -550,7 +550,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 				 u32_t arg6 __unused, \
 				 void *ssf)
 
-#define __SYSCALL_HANDLER3(name_, arg1_, arg2_, arg3_) \
+#define Z__SYSCALL_HANDLER3(name_, arg1_, arg2_, arg3_) \
 	u32_t hdlr_ ## name_(u32_t arg1_, \
 				 u32_t arg2_, \
 				 u32_t arg3_, \
@@ -559,7 +559,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 				 u32_t arg6 __unused, \
 				 void *ssf)
 
-#define __SYSCALL_HANDLER4(name_, arg1_, arg2_, arg3_, arg4_) \
+#define Z__SYSCALL_HANDLER4(name_, arg1_, arg2_, arg3_, arg4_) \
 	u32_t hdlr_ ## name_(u32_t arg1_, \
 				 u32_t arg2_, \
 				 u32_t arg3_, \
@@ -568,7 +568,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 				 u32_t arg6 __unused, \
 				 void *ssf)
 
-#define __SYSCALL_HANDLER5(name_, arg1_, arg2_, arg3_, arg4_, arg5_) \
+#define Z__SYSCALL_HANDLER5(name_, arg1_, arg2_, arg3_, arg4_, arg5_) \
 	u32_t hdlr_ ## name_(u32_t arg1_, \
 				 u32_t arg2_, \
 				 u32_t arg3_, \
@@ -577,7 +577,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 				 u32_t arg6 __unused, \
 				 void *ssf)
 
-#define __SYSCALL_HANDLER6(name_, arg1_, arg2_, arg3_, arg4_, arg5_, arg6_) \
+#define Z__SYSCALL_HANDLER6(name_, arg1_, arg2_, arg3_, arg4_, arg5_, arg6_) \
 	u32_t hdlr_ ## name_(u32_t arg1_, \
 				 u32_t arg2_, \
 				 u32_t arg3_, \
@@ -586,18 +586,18 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 				 u32_t arg6_, \
 				 void *ssf)
 
-#define Z_SYSCALL_CONCAT(arg1, arg2) __SYSCALL_CONCAT(arg1, arg2)
-#define __SYSCALL_CONCAT(arg1, arg2) ___SYSCALL_CONCAT(arg1, arg2)
-#define ___SYSCALL_CONCAT(arg1, arg2) arg1##arg2
+#define Z_SYSCALL_CONCAT(arg1, arg2) Z__SYSCALL_CONCAT(arg1, arg2)
+#define Z__SYSCALL_CONCAT(arg1, arg2) Z___SYSCALL_CONCAT(arg1, arg2)
+#define Z___SYSCALL_CONCAT(arg1, arg2) arg1##arg2
 
-#define Z_SYSCALL_NARG(...) __SYSCALL_NARG(__VA_ARGS__, __SYSCALL_RSEQ_N())
-#define __SYSCALL_NARG(...) __SYSCALL_ARG_N(__VA_ARGS__)
-#define __SYSCALL_ARG_N(_1, _2, _3, _4, _5, _6, _7, N, ...) N
-#define __SYSCALL_RSEQ_N() 6, 5, 4, 3, 2, 1, 0
+#define Z_SYSCALL_NARG(...) Z__SYSCALL_NARG(__VA_ARGS__, Z__SYSCALL_RSEQ_N())
+#define Z__SYSCALL_NARG(...) Z__SYSCALL_ARG_N(__VA_ARGS__)
+#define Z__SYSCALL_ARG_N(_1, _2, _3, _4, _5, _6, _7, N, ...) N
+#define Z__SYSCALL_RSEQ_N() 6, 5, 4, 3, 2, 1, 0
 
 #define Z_SYSCALL_HANDLER(...) \
-	Z_SYSCALL_CONCAT(__SYSCALL_HANDLER, \
-			Z_SYSCALL_NARG(__VA_ARGS__))(__VA_ARGS__)
+	Z_SYSCALL_CONCAT(Z__SYSCALL_HANDLER, \
+			 Z_SYSCALL_NARG(__VA_ARGS__))(__VA_ARGS__)
 
 /*
  * Helper macros for a very common case: calls which just take one argument
@@ -606,25 +606,25 @@ static inline int z_obj_validation_check(struct _k_object *ko,
  */
 
 #define Z_SYSCALL_HANDLER1_SIMPLE(name_, obj_enum_, obj_type_) \
-	__SYSCALL_HANDLER1(name_, arg1) { \
+	Z__SYSCALL_HANDLER1(name_, arg1) { \
 		Z_OOPS(Z_SYSCALL_OBJ(arg1, obj_enum_)); \
 		return (u32_t)z_impl_ ## name_((obj_type_)arg1); \
 	}
 
 #define Z_SYSCALL_HANDLER1_SIMPLE_VOID(name_, obj_enum_, obj_type_) \
-	__SYSCALL_HANDLER1(name_, arg1) { \
+	Z__SYSCALL_HANDLER1(name_, arg1) { \
 		Z_OOPS(Z_SYSCALL_OBJ(arg1, obj_enum_)); \
 		z_impl_ ## name_((obj_type_)arg1); \
 		return 0; \
 	}
 
 #define Z_SYSCALL_HANDLER0_SIMPLE(name_) \
-	__SYSCALL_HANDLER0(name_) { \
+	Z__SYSCALL_HANDLER0(name_) { \
 		return (u32_t)z_impl_ ## name_(); \
 	}
 
 #define Z_SYSCALL_HANDLER0_SIMPLE_VOID(name_) \
-	__SYSCALL_HANDLER0(name_) { \
+	Z__SYSCALL_HANDLER0(name_) { \
 		z_impl_ ## name_(); \
 		return 0; \
 	}

--- a/kernel/include/syscall_handler.h
+++ b/kernel/include/syscall_handler.h
@@ -524,7 +524,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
  */
 
 #define Z__SYSCALL_HANDLER0(name_) \
-	u32_t hdlr_ ## name_(u32_t arg1 __unused, \
+	u32_t z_hdlr_ ## name_(u32_t arg1 __unused, \
 				 u32_t arg2 __unused, \
 				 u32_t arg3 __unused, \
 				 u32_t arg4 __unused, \
@@ -533,7 +533,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 				 void *ssf)
 
 #define Z__SYSCALL_HANDLER1(name_, arg1_) \
-	u32_t hdlr_ ## name_(u32_t arg1_, \
+	u32_t z_hdlr_ ## name_(u32_t arg1_, \
 				 u32_t arg2 __unused, \
 				 u32_t arg3 __unused, \
 				 u32_t arg4 __unused, \
@@ -542,7 +542,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 				 void *ssf)
 
 #define Z__SYSCALL_HANDLER2(name_, arg1_, arg2_) \
-	u32_t hdlr_ ## name_(u32_t arg1_, \
+	u32_t z_hdlr_ ## name_(u32_t arg1_, \
 				 u32_t arg2_, \
 				 u32_t arg3 __unused, \
 				 u32_t arg4 __unused, \
@@ -551,7 +551,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 				 void *ssf)
 
 #define Z__SYSCALL_HANDLER3(name_, arg1_, arg2_, arg3_) \
-	u32_t hdlr_ ## name_(u32_t arg1_, \
+	u32_t z_hdlr_ ## name_(u32_t arg1_, \
 				 u32_t arg2_, \
 				 u32_t arg3_, \
 				 u32_t arg4 __unused, \
@@ -560,7 +560,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 				 void *ssf)
 
 #define Z__SYSCALL_HANDLER4(name_, arg1_, arg2_, arg3_, arg4_) \
-	u32_t hdlr_ ## name_(u32_t arg1_, \
+	u32_t z_hdlr_ ## name_(u32_t arg1_, \
 				 u32_t arg2_, \
 				 u32_t arg3_, \
 				 u32_t arg4_, \
@@ -569,7 +569,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 				 void *ssf)
 
 #define Z__SYSCALL_HANDLER5(name_, arg1_, arg2_, arg3_, arg4_, arg5_) \
-	u32_t hdlr_ ## name_(u32_t arg1_, \
+	u32_t z_hdlr_ ## name_(u32_t arg1_, \
 				 u32_t arg2_, \
 				 u32_t arg3_, \
 				 u32_t arg4_, \
@@ -578,7 +578,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 				 void *ssf)
 
 #define Z__SYSCALL_HANDLER6(name_, arg1_, arg2_, arg3_, arg4_, arg5_, arg6_) \
-	u32_t hdlr_ ## name_(u32_t arg1_, \
+	u32_t z_hdlr_ ## name_(u32_t arg1_, \
 				 u32_t arg2_, \
 				 u32_t arg3_, \
 				 u32_t arg4_, \

--- a/scripts/gen_syscall_header.py
+++ b/scripts/gen_syscall_header.py
@@ -81,7 +81,7 @@ def gen_make_syscall(ret, argc, tabcount):
     # from gc-sections; these references will not consume space.
 
     sys.stdout.write(
-        "static Z_GENERIC_SECTION(hndlr_ref) __used void *href = (void *)&hdlr_##name; \\\n")
+        "static Z_GENERIC_SECTION(hndlr_ref) __used void *href = (void *)&z_hdlr_##name; \\\n")
     tabs(tabcount)
     if (ret != Retval.VOID):
         sys.stdout.write("return (ret)")

--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -168,7 +168,7 @@ def analyze_fn(match_group):
 
     invocation = "%s(%s)" % (macro, argslist)
 
-    handler = "hdlr_" + func_name
+    handler = "z_hdlr_" + func_name
 
     # Entry in _k_syscall_table
     table_entry = "[%s] = %s" % (sys_id, handler)


### PR DESCRIPTION
- Some private macros for userspace were prefixed by underscores, with number of underscores indicating indirection levels. These all now start with Z_

- Syscall handler functions now are prefixed with z_hdlr_ instead of hdlr_

Fixes: #14447 