### PR TITLE
kernel: fix atomic ops in user mode on some arches

### DIFF
--- a/include/atomic.h
+++ b/include/atomic.h
@@ -10,6 +10,7 @@
 #define ZEPHYR_INCLUDE_ATOMIC_H_
 
 #include <stdbool.h>
+#include <toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,6 +46,10 @@ static inline bool atomic_cas(atomic_t *target, atomic_val_t old_value,
 					   0, __ATOMIC_SEQ_CST,
 					   __ATOMIC_SEQ_CST);
 }
+#elif defined(CONFIG_ATOMIC_OPERATIONS_C)
+__syscall int atomic_cas(atomic_t *target, atomic_val_t old_value,
+			 atomic_val_t new_value);
+
 #else
 extern int atomic_cas(atomic_t *target, atomic_val_t old_value,
 		      atomic_val_t new_value);
@@ -66,6 +71,8 @@ static inline atomic_val_t atomic_add(atomic_t *target, atomic_val_t value)
 {
 	return __atomic_fetch_add(target, value, __ATOMIC_SEQ_CST);
 }
+#elif defined(CONFIG_ATOMIC_OPERATIONS_C)
+__syscall atomic_val_t atomic_add(atomic_t *target, atomic_val_t value);
 #else
 extern atomic_val_t atomic_add(atomic_t *target, atomic_val_t value);
 #endif
@@ -86,6 +93,8 @@ static inline atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value)
 {
 	return __atomic_fetch_sub(target, value, __ATOMIC_SEQ_CST);
 }
+#elif defined(CONFIG_ATOMIC_OPERATIONS_C)
+__syscall atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value);
 #else
 extern atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value);
 #endif
@@ -100,7 +109,7 @@ extern atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value);
  *
  * @return Previous value of @a target.
  */
-#ifdef CONFIG_ATOMIC_OPERATIONS_BUILTIN
+#if defined(CONFIG_ATOMIC_OPERATIONS_BUILTIN) || defined (CONFIG_ATOMIC_OPERATIONS_C)
 static inline atomic_val_t atomic_inc(atomic_t *target)
 {
 	return atomic_add(target, 1);
@@ -119,7 +128,7 @@ extern atomic_val_t atomic_inc(atomic_t *target);
  *
  * @return Previous value of @a target.
  */
-#ifdef CONFIG_ATOMIC_OPERATIONS_BUILTIN
+#if defined(CONFIG_ATOMIC_OPERATIONS_BUILTIN) || defined (CONFIG_ATOMIC_OPERATIONS_C)
 static inline atomic_val_t atomic_dec(atomic_t *target)
 {
 	return atomic_sub(target, 1);
@@ -168,6 +177,8 @@ static inline atomic_val_t atomic_set(atomic_t *target, atomic_val_t value)
 	 */
 	return __atomic_exchange_n(target, value, __ATOMIC_SEQ_CST);
 }
+#elif defined(CONFIG_ATOMIC_OPERATIONS_C)
+__syscall atomic_val_t atomic_set(atomic_t *target, atomic_val_t value);
 #else
 extern atomic_val_t atomic_set(atomic_t *target, atomic_val_t value);
 #endif
@@ -183,7 +194,7 @@ extern atomic_val_t atomic_set(atomic_t *target, atomic_val_t value);
  *
  * @return Previous value of @a target.
  */
-#ifdef CONFIG_ATOMIC_OPERATIONS_BUILTIN
+#if defined(CONFIG_ATOMIC_OPERATIONS_BUILTIN) || defined (CONFIG_ATOMIC_OPERATIONS_C)
 static inline atomic_val_t atomic_clear(atomic_t *target)
 {
 	return atomic_set(target, 0);
@@ -209,6 +220,9 @@ static inline atomic_val_t atomic_or(atomic_t *target, atomic_val_t value)
 {
 	return __atomic_fetch_or(target, value, __ATOMIC_SEQ_CST);
 }
+#elif defined(CONFIG_ATOMIC_OPERATIONS_C)
+__syscall atomic_val_t atomic_or(atomic_t *target, atomic_val_t value);
+
 #else
 extern atomic_val_t atomic_or(atomic_t *target, atomic_val_t value);
 #endif
@@ -230,6 +244,8 @@ static inline atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value)
 {
 	return __atomic_fetch_xor(target, value, __ATOMIC_SEQ_CST);
 }
+#elif defined(CONFIG_ATOMIC_OPERATIONS_C)
+__syscall atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value);
 #else
 extern atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value);
 #endif
@@ -251,6 +267,8 @@ static inline atomic_val_t atomic_and(atomic_t *target, atomic_val_t value)
 {
 	return __atomic_fetch_and(target, value, __ATOMIC_SEQ_CST);
 }
+#elif defined(CONFIG_ATOMIC_OPERATIONS_C)
+__syscall atomic_val_t atomic_and(atomic_t *target, atomic_val_t value);
 #else
 extern atomic_val_t atomic_and(atomic_t *target, atomic_val_t value);
 #endif
@@ -272,6 +290,8 @@ static inline atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value)
 {
 	return __atomic_fetch_nand(target, value, __ATOMIC_SEQ_CST);
 }
+#elif defined(CONFIG_ATOMIC_OPERATIONS_C)
+__syscall atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value);
 #else
 extern atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value);
 #endif
@@ -434,6 +454,9 @@ static inline void atomic_set_bit_to(atomic_t *target, int bit, bool val)
 	}
 }
 
+#ifdef CONFIG_ATOMIC_OPERATIONS_C
+#include <syscalls/atomic.h>
+#endif
 /**
  * @}
  */

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -75,7 +75,7 @@ void test_main(void)
 			 ztest_unit_test(test_irq_offload),
 			 ztest_unit_test(test_byteorder_memcpy_swap),
 			 ztest_unit_test(test_byteorder_mem_swap),
-			 ztest_unit_test(test_atomic),
+			 ztest_user_unit_test(test_atomic),
 			 ztest_unit_test(test_bitfield),
 			 ztest_unit_test(test_printk),
 			 ztest_unit_test(test_slist),


### PR DESCRIPTION
Most CPUs have instructions like LOCK, LDREX/STREX, etc which
allows for atomic operations without locking interrupts that
can be invoked from user mode without complication. They typically
use compiler builtin atomic operations, or custom assembly
to implement them.

However, some CPUs may lack these kinds of instructions, such
as Cortex-M0 or some ARC. They use these C-based atomic
operation implementations instead. Unfortunately these require
grabbing a spinlock to ensure proper concurrency with other
threads and ISRs. Hence, they will trigger an exception when
called from user mode.

For these platforms, which support user mode but not atomic
operation instructions, the atomic API has been exposed as
system calls.

Some of the implementations in atomic_c.c which can be instead
expressed in terms of other atomic operations have been removed.

The kernel test of atomic operations now runs in user mode to
prove that this works.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>