### PR TITLE
git.cmake: let the environment override BUILD_VERSION

### DIFF
--- a/cmake/git.cmake
+++ b/cmake/git.cmake
@@ -2,7 +2,7 @@
 
 # https://cmake.org/cmake/help/latest/module/FindGit.html
 find_package(Git QUIET)
-if(GIT_FOUND)
+if(NOT BUILD_VERSION AND GIT_FOUND)
   execute_process(
     COMMAND ${GIT_EXECUTABLE} describe --abbrev=12
     WORKING_DIRECTORY                ${ZEPHYR_BASE}


### PR DESCRIPTION
This is needed to remove noise when comparing binaries across git
commits and more generally for anyone who wants to manual
control/override the version number when building with or without a
.git/ subdirectory.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>