### PR TITLE
host-gcc/target.cmake: stop discarding CMAKE_<tool>_FLAGS for x86

### DIFF
--- a/cmake/compiler/host-gcc/target.cmake
+++ b/cmake/compiler/host-gcc/target.cmake
@@ -17,10 +17,10 @@ find_program(CMAKE_GDB          gdb    )
 # Maybe the -m32/-miamcu FLAGS should all be next to -march= in the
 # longer term?
 if(NOT CONFIG_X86_64)
-  set(CMAKE_ASM_FLAGS           -m32 )
-  set(CMAKE_C_FLAGS             -m32 )
-  set(CMAKE_CXX_FLAGS           -m32 )
-  set(CMAKE_SHARED_LINKER_FLAGS -m32 ) # unused?
+  string(PREPEND CMAKE_ASM_FLAGS             "-m32 ")
+  string(PREPEND CMAKE_C_FLAGS               "-m32 ")
+  string(PREPEND CMAKE_CXX_FLAGS             "-m32 ")
+  string(PREPEND CMAKE_SHARED_LINKER_FLAGS   "-m32 ") # unused?
 endif()
 
 if(CONFIG_CPLUSPLUS)
@@ -41,9 +41,11 @@ find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler}     CACHE INTERNAL " " FOR
 # -mx32 --print-libgcc-file-name) so don't fail to build for something
 # that is currently not needed. See comments in compiler/gcc/target.cmake
 if (NOT CONFIG_X86_64)
+  # Convert to list as cmake Modules/*.cmake do it
+  STRING(REGEX REPLACE " +" ";" PRINT_LIBGCC_ARGS ${CMAKE_C_FLAGS})
   # This libgcc code is partially duplicated in compiler/*/target.cmake
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} --print-libgcc-file-name
+    COMMAND ${CMAKE_C_COMPILER} ${PRINT_LIBGCC_ARGS} --print-libgcc-file-name
     OUTPUT_VARIABLE LIBGCC_FILE_NAME
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )


### PR DESCRIPTION
Prepend -m32 to existing flags as opposed to silently override and
discard them:
```patch
- set(CMAKE_<tool>_FLAGS                -m32 )
+ string(PREPEND CMAKE_<tool>_FLAGS   " -m32")
```
This stops discarding additional flags passed with either cmake
`-DCMAKE_<tool>_FLAGS="-fu -bar"` or `cmake -C params.cmake`.

Note this bug was affecting only the combination of x86 and
`CMAKE_<tool>_FLAGS`. x86_64 wasn't affected and other, non-empty
`CMAKE_<tool>_FLAGS_[DEBUG/RELEASE/etc.]` weren't affected either.

Also convert flags string to list when invoking --print-libgcc-file-name
to support more than one CMAKE_C_FLAGS.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>