### PR TITLE
doc: application: Correct note about external modules

### DIFF
--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -676,11 +676,11 @@ if the project contains the metadata required in a module.  If the project is
 identified to be a module then CMake will include it in the build.
 
 .. note::
-   Although the build system currently uses :ref:`west` to list the available
+   Although the build system normally uses :ref:`west` to list the available
    external projects for potential inclusion in the build, it is perfectly
-   possible to use any other script or tool instead by modifying the CMake
-   script. A future addition will make this possible even without any
-   modifications to the build scripts.
+   possible to use any other script or tool. By calling cmake as
+   ``cmake --DZEPHYR_MODULES=<oot-path-to-module>[;<additional-oot-module(s)>]``
+   , it will search in those paths instead of invoking ``west list``
 
 The code in :file:`CMakeLists.txt` retrieves the following information for
 each project using ``west list``:


### PR DESCRIPTION
A note in the Modules (External projects) section indicated
that in the future it would be possible to do something that
can be already done.
So, let's clarify the note with how it can be done.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

-------------

If there is any defect, feel free to correct it and push to the branch directly.