### PR TITLE
Fix samples/net/sockets/echo_async_select for MCU targets

### DIFF
--- a/samples/net/sockets/echo_async_select/README.rst
+++ b/samples/net/sockets/echo_async_select/README.rst
@@ -70,7 +70,7 @@ To run:
 
 .. code-block:: console
 
-    $ ./socket_echo
+    $ ./socket_echo_select
 
 To test:
 

--- a/samples/net/sockets/echo_async_select/src/socket_echo_select.c
+++ b/samples/net/sockets/echo_async_select/src/socket_echo_select.c
@@ -116,17 +116,18 @@ int main(void)
 		printf("error: socket(AF_INET6): %d\n", errno);
 		exit(1);
 	}
-	#ifdef IPV6_V6ONLY
+#ifndef __ZEPHYR__
 	/* For Linux, we need to make socket IPv6-only to bind it to the
 	 * same port as IPv4 socket above.
 	 */
-	int TRUE = 1;
-	res = setsockopt(serv6, IPPROTO_IPV6, IPV6_V6ONLY, &TRUE, sizeof(TRUE));
+	int optval = 1;
+	res = setsockopt(serv6, IPPROTO_IPV6, IPV6_V6ONLY, &optval,
+				sizeof(optval));
 	if (res < 0) {
 		printf("error: setsockopt: %d\n", errno);
 		exit(1);
 	}
-	#endif
+#endif
 	res = bind(serv6, (struct sockaddr *)&bind_addr6, sizeof(bind_addr6));
 	if (res == -1) {
 		printf("Cannot bind IPv6, errno: %d\n", errno);


### PR DESCRIPTION
The preprocessor definition IPV6_V6ONLY is present, but not implemented
for MCU targets.

In order to make this sample to work for MCU targets, make the
error check of setsockopt(IPV6_V6ONLY) to be non-fatal for MCU targets.

For the native_posix, the behaviour is intact, i.e. the error is fatal.

EDIT:
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/14612
