### PR TITLE
kconfig: Replace two leftover 'gsource' with 'source'

### DIFF
--- a/drivers/neural_net/Kconfig
+++ b/drivers/neural_net/Kconfig
@@ -16,6 +16,6 @@ module = NEURAL_NET
 module-str = neural_net
 source "subsys/logging/Kconfig.template.log_config"
 
-gsource "drivers/neural_net/Kconfig.*"
+source "drivers/neural_net/Kconfig.*"
 
 endif # NEURAL_NET

--- a/soc/arm/cypress/Kconfig.defconfig
+++ b/soc/arm/cypress/Kconfig.defconfig
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "soc/arm/cypress/*/Kconfig.defconfig.series"
+source "soc/arm/cypress/*/Kconfig.defconfig.series"


### PR DESCRIPTION
Plain `source` is globbing. `gsource` is a leftover from an older
design, and works as a synonym for `source`.