### PR TITLE
samples: net: sockets: echo_client : Fix tcp_stop() error

### DIFF
--- a/samples/net/sockets/echo_client/src/tcp.c
+++ b/samples/net/sockets/echo_client/src/tcp.c
@@ -242,13 +242,13 @@ int process_tcp(void)
 void stop_tcp(void)
 {
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
-		if (conf.ipv6.tcp.sock > 0) {
+		if (conf.ipv6.tcp.sock >= 0) {
 			(void)close(conf.ipv6.tcp.sock);
 		}
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
-		if (conf.ipv4.tcp.sock > 0) {
+		if (conf.ipv4.tcp.sock >= 0) {
 			(void)close(conf.ipv4.tcp.sock);
 		}
 	}


### PR DESCRIPTION
The tcp_stop routine doesn't close pending connection if echo_server is offline

Signed-off-by: Marcio Montenegro <msam@cesar.org.br>