### PR TITLE
kconfig: Use 'default' instead of 'def_bool' in Kconfig.defconfig files

### DIFF
--- a/boards/arc/iotdk/Kconfig.defconfig
+++ b/boards/arc/iotdk/Kconfig.defconfig
@@ -6,6 +6,6 @@ config BOARD
 	default "iotdk"
 
 config CPU_ARCEM4
-	def_bool y
+	default y
 
 endif # BOARD_IOTDK

--- a/boards/arm/mec2016evb_assy6797/Kconfig.defconfig
+++ b/boards/arm/mec2016evb_assy6797/Kconfig.defconfig
@@ -11,8 +11,8 @@ config BOARD
 if UART_NS16550
 
 config UART_NS16550_PORT_0
-	def_bool y if UART_CONSOLE
+	default y if UART_CONSOLE
 
 endif
 
-endif #BOARD_MEC2016EVB_ASSY6797
+endif # BOARD_MEC2016EVB_ASSY6797

--- a/boards/arm/mimxrt1020_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1020_evk/Kconfig.defconfig
@@ -51,10 +51,10 @@ endif # UART_MCUX_LPUART
 if NETWORKING
 
 config NET_L2_ETHERNET
-	def_bool y
+	default y
 
 config ETH_MCUX_0
-	def_bool y if NET_L2_ETHERNET
+	default y if NET_L2_ETHERNET
 
 endif # NETWORKING
 

--- a/boards/arm/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig.defconfig
@@ -64,10 +64,10 @@ endif # UART_MCUX_LPUART
 if NETWORKING
 
 config NET_L2_ETHERNET
-	def_bool y
+	default y
 
 config ETH_MCUX_0
-	def_bool y if NET_L2_ETHERNET
+	default y if NET_L2_ETHERNET
 
 endif # NETWORKING
 

--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -21,27 +21,27 @@ endchoice
 if GPIO_MCUX_IGPIO
 
 config GPIO_MCUX_IGPIO_1
-	def_bool y
+	default y
 
 config GPIO_MCUX_IGPIO_5
-	def_bool y
+	default y
 
 endif # GPIO_MCUX_IGPIO
 
 if UART_MCUX_LPUART
 
 config UART_MCUX_LPUART_1
-	def_bool y
+	default y
 
 endif # UART_MCUX_LPUART
 
 if NETWORKING
 
 config NET_L2_ETHERNET
-	def_bool y
+	default y
 
 config ETH_MCUX_0
-	def_bool y if NET_L2_ETHERNET
+	default y if NET_L2_ETHERNET
 
 endif # NETWORKING
 

--- a/boards/arm/mps2_an385/Kconfig.defconfig
+++ b/boards/arm/mps2_an385/Kconfig.defconfig
@@ -58,7 +58,7 @@ endif # COUNTER
 if I2C
 
 config I2C_SBCON
-	def_bool y
+	default y
 
 endif # I2C
 

--- a/boards/arm/nrf52840_pca10090/Kconfig.defconfig
+++ b/boards/arm/nrf52840_pca10090/Kconfig.defconfig
@@ -12,7 +12,7 @@ config BOARD
 if IEEE802154
 
 config IEEE802154_NRF5
-	def_bool y
+	default y
 
 endif # IEEE802154
 

--- a/boards/arm/sam_e70_xplained/Kconfig.defconfig
+++ b/boards/arm/sam_e70_xplained/Kconfig.defconfig
@@ -71,7 +71,7 @@ if SPI
 if SPI_SAM_PORT_0
 
 config SPI_SAME70_PORT_0_PIN_CS3
-	def_bool y
+	default y
 
 endif # SPI_SAM_PORT_0
 

--- a/boards/arm/stm32f769i_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f769i_disco/Kconfig.defconfig
@@ -44,10 +44,10 @@ endif # SPI
 if NETWORKING
 
 config NET_L2_ETHERNET
-	def_bool y
+	default y
 
 config ETH_STM32_HAL
-	def_bool y
+	default y
 
 endif # NETWORKING
 

--- a/boards/arm/v2m_musca/Kconfig.defconfig
+++ b/boards/arm/v2m_musca/Kconfig.defconfig
@@ -25,26 +25,26 @@ endif
 if SERIAL
 
 config UART_PL011
-	def_bool y
+	default y
 
 config UART_INTERRUPT_DRIVEN
-	def_bool y
+	default y
 
 config UART_PL011_PORT0
-	def_bool y
+	default y
 
 config UART_PL011_PORT1
-	def_bool y
+	default y
 
 endif # SERIAL
 
 if COUNTER
 
 config TIMER_TMR_CMSDK_APB
-	def_bool y
+	default y
 
 config TIMER_DTMR_CMSDK_APB
-	def_bool y
+	default y
 
 endif # COUNTER
 

--- a/boards/posix/native_posix/Kconfig.defconfig
+++ b/boards/posix/native_posix/Kconfig.defconfig
@@ -92,6 +92,6 @@ endif # BOARD_NATIVE_POSIX
 if USB
 
 config USB_NATIVE_POSIX
-	def_bool y
+	default y
 
 endif # USB

--- a/boards/riscv32/hifive1/Kconfig.defconfig
+++ b/boards/riscv32/hifive1/Kconfig.defconfig
@@ -8,7 +8,7 @@ config BOARD
 if PWM
 
 config PWM_SIFIVE
-	def_bool y
+	default y
 
 endif
 

--- a/boards/riscv32/rv32m1_vega/Kconfig.defconfig
+++ b/boards/riscv32/rv32m1_vega/Kconfig.defconfig
@@ -9,52 +9,52 @@ config BOARD
 if UART_RV32M1_LPUART
 
 config UART_RV32M1_LPUART_0
-	def_bool y if UART_CONSOLE
+	default y if UART_CONSOLE
 
 endif # UART_RV32M1
 
 if PINMUX_RV32M1
 
 config PINMUX_RV32M1_PORTA
-	def_bool y
+	default y
 
 config PINMUX_RV32M1_PORTB
-	def_bool y
+	default y
 
 config PINMUX_RV32M1_PORTC
-	def_bool y
+	default y
 
 config PINMUX_RV32M1_PORTD
-	def_bool y
+	default y
 
 config PINMUX_RV32M1_PORTE
-	def_bool y if RV32M1_INTMUX
+	default y if RV32M1_INTMUX
 
 endif # PINMUX_RV32M1
 
 if GPIO_RV32M1
 
 config GPIO_RV32M1_PORTA
-	def_bool y
+	default y
 
 config GPIO_RV32M1_PORTB
-	def_bool y if RV32M1_INTMUX
+	default y if RV32M1_INTMUX
 
 config GPIO_RV32M1_PORTC
-	def_bool y if RV32M1_INTMUX
+	default y if RV32M1_INTMUX
 
 config GPIO_RV32M1_PORTD
-	def_bool y if RV32M1_INTMUX
+	default y if RV32M1_INTMUX
 
 config GPIO_RV32M1_PORTE
-	def_bool y if RV32M1_INTMUX
+	default y if RV32M1_INTMUX
 
 endif # GPIO_RV32M1
 
 if SERIAL
 
 config UART_RV32M1_LPUART
-	def_bool y
+	default y
 
 endif # SERIAL
 

--- a/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
@@ -174,10 +174,10 @@ endif
 if FLASH
 
 config SPI
-	def_bool y
+	default y
 
 config SPI_NOR
-	def_bool y
+	default y
 
 config SPI_NOR_PAGE_SIZE
 	default 256
@@ -186,27 +186,27 @@ config SPI_NOR_SECTOR_SIZE
 	default 4096
 
 config FLASH_HAS_PAGE_LAYOUT
-	def_bool y
+	default y
 
 config FLASH_PAGE_LAYOUT
-	def_bool y
+	default y
 
 endif
 
 if SPI
 
 config SPI_DW
-	def_bool y
+	default y
 
 config SPI_0
-	def_bool y
+	default y
 
 endif
 
 if PINMUX
 
 config PINMUX_INTEL_S1000
-	def_bool y
+	default y
 
 endif
 

--- a/soc/arc/snps_arc_iot/Kconfig.defconfig
+++ b/soc/arc/snps_arc_iot/Kconfig.defconfig
@@ -30,20 +30,20 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 144000000
 
 config HARVARD
-	def_bool y
+	default y
 
 if SERIAL
 
 config UART_NS16550
-	def_bool y
+	default y
 
 endif # SERIAL
 
 if UART_CONSOLE
 
 config UART_NS16550_PORT_0
-	def_bool y
+	default y
 
 endif # UART_CONSOLE
 
-endif #ARC_IOT
+endif # ARC_IOT

--- a/soc/arm/microchip_mec/mec1701/Kconfig.defconfig.mec1701qsz
+++ b/soc/arm/microchip_mec/mec1701/Kconfig.defconfig.mec1701qsz
@@ -18,7 +18,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 if SERIAL
 
 config UART_NS16550
-	def_bool y
+	default y
 
 endif # SERIAL
 

--- a/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
+++ b/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
@@ -35,7 +35,7 @@ endif # SERIAL
 if IPM
 
 config IPM_IMX
-	def_bool y
+	default y
 
 endif # IPM
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
@@ -24,7 +24,7 @@ config IPG_DIV
 	default 3
 
 config GPIO
-	def_bool y
+	default y
 
 if NET_L2_ETHERNET
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -53,7 +53,7 @@ endif # I2C
 if NET_L2_ETHERNET
 
 config ETH_MCUX
-	def_bool y if HAS_MCUX_ENET
+	default y if HAS_MCUX_ENET
 
 endif # NET_L2_ETHERNET
 

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
@@ -39,7 +39,7 @@ endif # CLOCK_CONTROL
 if COUNTER
 
 config COUNTER_MCUX_RTC
-	def_bool y
+	default y
 
 endif # COUNTER
 

--- a/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.efr32mg12p
+++ b/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.efr32mg12p
@@ -26,7 +26,7 @@ endif # SERIAL
 if I2C
 
 config I2C_GECKO
-	def_bool y
+	default y
 
 endif # I2C
 

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l471xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l471xx
@@ -18,7 +18,7 @@ config NUM_IRQS
 if GPIO_STM32
 
 config GPIO_STM32_PORTD
-	def_bool y
+	default y
 
 config GPIO_STM32_PORTE
 	default y

--- a/soc/riscv32/openisa_rv32m1/Kconfig.defconfig
+++ b/soc/riscv32/openisa_rv32m1/Kconfig.defconfig
@@ -90,7 +90,7 @@ config MAX_IRQ_PER_AGGREGATOR
 	default 32
 
 config 2ND_LEVEL_INTERRUPTS
-	def_bool y
+	default y
 
 config 2ND_LVL_ISR_TBL_OFFSET
 	int
@@ -140,41 +140,41 @@ config 2ND_LVL_INTR_07_OFFSET
 	default 31
 
 config RV32M1_INTMUX
-	def_bool y
+	default y
 
 config RV32M1_INTMUX_CHANNEL_0
-	def_bool y
+	default y
 
 config RV32M1_INTMUX_CHANNEL_1
-	def_bool y
+	default y
 
 config RV32M1_INTMUX_CHANNEL_2
-	def_bool y
+	default y
 
 config RV32M1_INTMUX_CHANNEL_3
-	def_bool y
+	default y
 
 config RV32M1_INTMUX_CHANNEL_4
-	def_bool y
+	default y
 
 config RV32M1_INTMUX_CHANNEL_5
-	def_bool y
+	default y
 
 config RV32M1_INTMUX_CHANNEL_6
-	def_bool y
+	default y
 
 config RV32M1_INTMUX_CHANNEL_7
-	def_bool y
+	default y
 
 endif # MULTI_LEVEL_INTERRUPTS
 
 config PINMUX_RV32M1
-	def_bool y
+	default y
 
 if GPIO
 
 config GPIO_RV32M1
-	def_bool y
+	default y
 
 endif # GPIO
 


### PR DESCRIPTION
Same deal as in commit 4638652214 ("Kconfig: Use 'default' instead of
'def_bool' in Kconfig.defconfig files"), fixing new stuff that got
introduced since then.

Some symbols, like `ALTERA_AVALON_PIO`, are only defined in
`Kconfig.defconfig` files, and so need the `def_bool`.

Motivation (from the note at the end of
https://docs.zephyrproject.org/latest/guides/kconfig/index.html#common-shorthands):

For a symbol defined in multiple locations (e.g., in a `Kconfig.defconfig`
file in Zephyr), it is best to only give the symbol type for the "base"
definition of the symbol, and to use `default` (instead of `def_<type>`
value) for the remaining definitions. That way, if the base definition
of the symbol is removed, the symbol ends up without a type, which
generates a warning that points to the other definitions. That makes the
extra definitions easier to discover and remove.