### PR TITLE
tests/drivers/ipm: Support ipm test case in SMP

### DIFF
--- a/include/drivers/console/ipm_console.h
+++ b/include/drivers/console/ipm_console.h
@@ -12,6 +12,8 @@
 #include <kernel.h>
 #include <device.h>
 #include <ring_buffer.h>
+#include <spinlock.h>
+#include <atomic.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -61,6 +63,8 @@ struct ipm_console_receiver_config_info {
 	 * IPM_CONSOLE_STDOUT or IPM_CONSOLE_PRINTK
 	 */
 	unsigned int flags;
+
+	atomic_t *print_num;
 };
 
 struct ipm_console_receiver_runtime_data {
@@ -80,6 +84,11 @@ struct ipm_console_receiver_runtime_data {
 
 	/** Receiver worker thread */
 	struct k_thread rx_thread;
+
+	/**
+	 * Ring buffer spinlock
+	 */
+	struct k_spinlock rb_spinlock;
 };
 
 struct ipm_console_sender_config_info {

--- a/include/ring_buffer.h
+++ b/include/ring_buffer.h
@@ -25,8 +25,8 @@ extern "C" {
  * @brief A structure to represent a ring buffer
  */
 struct ring_buf {
-	u32_t head;	 /**< Index in buf for the head element */
-	u32_t tail;	 /**< Index in buf for the tail element */
+	volatile u32_t head;	 /**< Index in buf for the head element */
+	volatile u32_t tail;	 /**< Index in buf for the tail element */
 	union ring_buf_misc {
 		struct ring_buf_misc_item_mode {
 			u32_t dropped_put_count; /**< Running tally of the
@@ -39,7 +39,7 @@ struct ring_buf {
 			u32_t tmp_head;
 		} byte_mode;
 	} misc;
-	u32_t size;   /**< Size of buf in 32-bit chunks */
+	volatile u32_t size;   /**< Size of buf in 32-bit chunks */
 
 	union ring_buf_buffer {
 		u32_t *buf32;	 /**< Memory region for stored entries */

--- a/tests/drivers/ipm/src/ipm_dummy.c
+++ b/tests/drivers/ipm/src/ipm_dummy.c
@@ -69,13 +69,8 @@ static int ipm_dummy_send(struct device *d, int wait, u32_t id,
 	driver_data->regs.id = id;
 	driver_data->regs.busy = 1U;
 
-	irq_offload(ipm_dummy_isr, d);
+	ipm_dummy_isr(d);
 
-	if (wait) {
-		while (driver_data->regs.busy) {
-			/* busy-wait */
-		}
-	}
 	return 0;
 }
 

--- a/tests/drivers/ipm/testcase.yaml
+++ b/tests/drivers/ipm/testcase.yaml
@@ -2,5 +2,4 @@ tests:
   peripheral.mailbox:
     filter: not CONFIG_SOC_QUARK_SE_C1000_SS
     arch_exclude: posix xtensa
-    platform_exclude: qemu_x86_64 # see issue #12478
     tags: drivers ipc


### PR DESCRIPTION
    tests/drivers/ipm: support ipm test case in SMP
    
    Current design of ipm test doesn't consider SMP, there is the
    possibility that offload_irq and rx_thread run at different
    cpu core at the same time, it will cause state(enabled and
    channel_disable) disorder if two different context access them concurrently.
    
    Fixes #12478.
    
    Signed-off-by: Wentong Wu <wentong.wu@intel.com>
