### PR TITLE
Arch arm mpu fix start index

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -137,7 +137,7 @@ void arm_core_mpu_mem_partition_config_update(
 	u8_t i;
 	u8_t reg_index = _get_num_regions();
 
-	for (i = static_regions_num; i < _get_num_regions(); i++) {
+	for (i = _get_dyn_region_min_index(); i < _get_num_regions(); i++) {
 		if (!_is_enabled_region(i)) {
 			continue;
 		}

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
@@ -109,6 +109,18 @@ static inline void _get_region_attr_from_k_mem_partition_info(
 #if defined(CONFIG_USERSPACE)
 
 /**
+ * This internal function returns the minimum HW MPU region index
+ * that may hold the configuration of a dynamic memory region.
+ *
+ * Trivial for ARMv7-M MPU, where dynamic memory areas are programmed
+ * in MPU regions indices right after the static regions.
+ */
+static inline int _get_dyn_region_min_index(void)
+{
+	return static_regions_num;
+}
+
+/**
  * This internal function converts the SIZE field value of MPU_RASR
  * to the region size (in bytes).
  */

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
@@ -18,7 +18,7 @@
  *        is allowed.
  */
 struct dynamic_region_info {
-	u8_t index;
+	int index;
 	struct arm_mpu_region region_conf;
 };
 

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
@@ -203,6 +203,31 @@ static inline void _get_region_attr_from_k_mem_partition_info(
 
 #if defined(CONFIG_USERSPACE)
 
+/**
+ * This internal function returns the minimum HW MPU region index
+ * that may hold the configuration of a dynamic memory region.
+ *
+ * Browse through the memory areas marked for dynamic MPU programming,
+ * pick the one with the minimum MPU region index. Return that index.
+ *
+ * The function is optimized for the (most common) use-case of a single
+ * marked area for dynamic memory regions.
+ */
+static inline int _get_dyn_region_min_index(void)
+{
+	int dyn_reg_min_index = dyn_reg_info[0].index;
+#if MPU_DYNAMIC_REGION_AREAS_NUM > 1
+	for (int i = 1; i < MPU_DYNAMIC_REGION_AREAS_NUM; i++) {
+		if ((dyn_reg_info[i].index != -EINVAL) &&
+			(dyn_reg_info[i].index < dyn_reg_min_index)
+		) {
+			dyn_reg_min_index = dyn_reg_info[i].index;
+		}
+	}
+#endif
+	return dyn_reg_min_index;
+}
+
 static inline u32_t _mpu_region_get_size(u32_t index)
 {
 	return _mpu_region_get_last_addr(index) + 1


### PR DESCRIPTION
Bug was revealed after recent changes related to app memory partitions that changed the order in which we supply the dynamic memory partitions' map (thread stack, app partitions)  to the MPU driver in run-time.

Affects only ARMv8-M MPU, therefore, the ARMv7-M implementation changes are "transparent".

Fixes `kernel/tests/mem_protect/userspace `for ARMv8-M (verified in `nRF9160_pca10090`)