### PR TITLE
kconfiglib/menuconfig: Various behavior/UI improvements

### DIFF
--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -522,27 +522,31 @@ Send bug reports, suggestions, and questions to ulfalizer a.t Google's email
 service, or open a ticket on the GitHub page.
 """
 import errno
-import glob
 import importlib
 import os
-import platform
 import re
-import subprocess
 import sys
+
+# Get rid of some attribute lookups. These are obvious in context.
+from glob import iglob
+from os.path import dirname, exists, expandvars, isabs, islink, join, \
+                    relpath, split
+
 
 # File layout:
 #
 # Public classes
 # Public functions
 # Internal functions
-# Public global constants
-# Internal global constants
+# Global constants
 
 # Line length: 79 columns
+
 
 #
 # Public classes
 #
+
 
 class Kconfig(object):
     """
@@ -609,7 +613,7 @@ class Kconfig(object):
       A list with the filenames of all Kconfig files included in the
       configuration, relative to $srctree (or relative to the current directory
       if $srctree isn't set), except absolute paths (e.g.
-      'source "/foo/Kconfig") are kept as-is.
+      'source "/foo/Kconfig"') are kept as-is.
 
       The files are listed in the order they are source'd, starting with the
       top-level Kconfig file. If a file is source'd multiple times, it will
@@ -965,8 +969,7 @@ class Kconfig(object):
 
         # Open the top-level Kconfig file. Store the readline() method directly
         # as a small optimization.
-        self._readline = \
-            self._open(os.path.join(self.srctree, filename), "r").readline
+        self._readline = self._open(join(self.srctree, filename), "r").readline
 
         try:
             # Parse everything
@@ -986,7 +989,7 @@ class Kconfig(object):
         self.unique_defined_syms = _ordered_unique(self.defined_syms)
         self.unique_choices = _ordered_unique(self.choices)
 
-        # Do various post-processing of the menu tree
+        # Do various post-processing on the menu tree
         self._finalize_tree(self.top_node, self.y)
 
 
@@ -1097,7 +1100,7 @@ class Kconfig(object):
         loaded_existing = True
         if filename is None:
             filename = standard_config_filename()
-            if os.path.exists(filename):
+            if exists(filename):
                 if verbose:
                     print("Using existing configuration '{}' as base"
                           .format(filename))
@@ -1496,7 +1499,7 @@ class Kconfig(object):
         In case you need a different scheme for your project, the sync_deps()
         implementation can be used as a template.
         """
-        if not os.path.exists(path):
+        if not exists(path):
             os.mkdir(path, 0o755)
 
         # This setup makes sure that at least the current working directory
@@ -1578,7 +1581,7 @@ class Kconfig(object):
         for sym in self.unique_defined_syms:
             sym._old_val = None
 
-        if not os.path.exists("auto.conf"):
+        if not exists("auto.conf"):
             # No old values
             return
 
@@ -1820,7 +1823,7 @@ class Kconfig(object):
             # This will try opening the same file twice if $srctree is unset,
             # but it's not a big deal
             try:
-                return self._open(os.path.join(self.srctree, filename), "r")
+                return self._open(join(self.srctree, filename), "r")
             except IOError as e2:
                 # This is needed for Python 3, because e2 is deleted after
                 # the try block:
@@ -2084,6 +2087,14 @@ class Kconfig(object):
                     #       tristate unquoted_prompt
                     #
                     #   endmenu
+                    #
+                    # Named choices ('choice FOO') also end up here.
+
+                    if token is not _T_CHOICE:
+                        self._warn("style: quotes recommended around '{}' in '{}'"
+                                   .format(name, self._line.strip()),
+                                   self._filename, self._linenr)
+
                     token = name
                     i = match.end()
 
@@ -2114,9 +2125,9 @@ class Kconfig(object):
                         #
                         # The preprocessor functionality changed how
                         # environment variables are referenced, to $(FOO).
-                        val = os.path.expandvars(
-                            s[i + 1:end_i - 1].replace("$UNAME_RELEASE",
-                                                       platform.uname()[2]))
+                        val = expandvars(s[i + 1:end_i - 1]
+                                         .replace("$UNAME_RELEASE",
+                                                  _UNAME_RELEASE))
 
                         i = end_i
 
@@ -2614,18 +2625,16 @@ class Kconfig(object):
                 # Check if the pattern is absolute and avoid stripping srctree
                 # from it below in that case. We must do the check before
                 # join()'ing, as srctree might be an absolute path.
-                isabs = os.path.isabs(pattern)
+                pattern_is_abs = isabs(pattern)
 
                 if t0 in _REL_SOURCE_TOKENS:
                     # Relative source
-                    pattern = os.path.join(os.path.dirname(self._filename),
-                                           pattern)
+                    pattern = join(dirname(self._filename), pattern)
 
                 # Sort the glob results to ensure a consistent ordering of
                 # Kconfig symbols, which indirectly ensures a consistent
                 # ordering in e.g. .config files
-                filenames = \
-                    sorted(glob.iglob(os.path.join(self.srctree, pattern)))
+                filenames = sorted(iglob(join(self.srctree, pattern)))
 
                 if not filenames and t0 in _OBL_SOURCE_TOKENS:
                     raise KconfigError(
@@ -2646,8 +2655,8 @@ class Kconfig(object):
                         # appears without a $srctree prefix in
                         # MenuNode.filename, which is nice e.g. when generating
                         # documentation.
-                        filename if isabs else
-                            os.path.relpath(filename, self.srctree))
+                        filename if pattern_is_abs else
+                            relpath(filename, self.srctree))
 
                     prev = self._parse_block(None, parent, prev)
 
@@ -2811,6 +2820,7 @@ class Kconfig(object):
             t0 = self._tokens[0]
 
             if t0 in _TYPE_TOKENS:
+                # Relies on '_T_BOOL is BOOL', etc., to save a conversion
                 self._set_type(node, t0)
                 if self._tokens[1] is not None:
                     self._parse_prompt(node)
@@ -2840,8 +2850,8 @@ class Kconfig(object):
                 node.defaults.append((self._parse_expr(False),
                                       self._parse_cond()))
 
-            elif t0 in _DEF_TYPE_TOKENS:
-                self._set_type(node, t0)
+            elif t0 in _DEF_TOKEN_TO_TYPE:
+                self._set_type(node, _DEF_TOKEN_TO_TYPE[t0])
                 node.defaults.append((self._parse_expr(False),
                                       self._parse_cond()))
 
@@ -2942,14 +2952,9 @@ class Kconfig(object):
                 self._reuse_tokens = True
                 return
 
-    def _set_type(self, node, type_token):
-        new_type = _TOKEN_TO_TYPE[type_token]
-
-        # The 'is not UNKNOWN' comparison will usually fail, since single-def
-        # symbols/choices are more common
-        if node.item.orig_type is not UNKNOWN and \
-           node.item.orig_type is not new_type:
-
+    def _set_type(self, node, new_type):
+        # Note: UNKNOWN == 0, which is falsy
+        if node.item.orig_type and node.item.orig_type is not new_type:
             self._warn("{} defined with multiple types, {} will be used"
                        .format(_name_and_loc(node.item),
                                TYPE_TO_STR[new_type]))
@@ -3662,6 +3667,7 @@ class Kconfig(object):
 
         if self._warn_for_redun_assign:
             self._warn(msg, filename, linenr)
+
 
 class Symbol(object):
     """
@@ -4428,7 +4434,6 @@ class Symbol(object):
         # Warning: See Symbol._rec_invalidate(), and note that this is a hidden
         # function call (property magic)
         vis = self.visibility
-
         if not vis:
             return ()
 
@@ -4597,6 +4602,7 @@ class Symbol(object):
                                TRI_TO_STR[expr_value(select[2])])
 
         self.kconfig._warn(msg)
+
 
 class Choice(object):
     """
@@ -5043,6 +5049,7 @@ class Choice(object):
             if item._cached_vis is not None:
                 item._rec_invalidate()
 
+
 class MenuNode(object):
     """
     Represents a menu node in the configuration. This corresponds to an entry
@@ -5393,6 +5400,7 @@ class MenuNode(object):
 
         return "\n".join(lines)
 
+
 class Variable(object):
     """
     Represents a preprocessor variable/function.
@@ -5447,13 +5455,16 @@ class Variable(object):
                        "recursive" if self.is_recursive else "immediate",
                        self.value)
 
+
 class KconfigError(Exception):
     "Exception raised for Kconfig-related errors"
 
 KconfigSyntaxError = KconfigError  # Backwards compatibility
 
+
 class InternalError(Exception):
     "Never raised. Kept around for backwards compatibility."
+
 
 # Workaround:
 #
@@ -5470,9 +5481,11 @@ class _KconfigIOError(IOError):
     def __str__(self):
         return self.msg
 
+
 #
 # Public functions
 #
+
 
 def expr_value(expr):
     """
@@ -5530,6 +5543,7 @@ def expr_value(expr):
     if rel is GREATER:    return 2*(comp > 0)
     return 2*(comp >= 0)  # rel is GREATER_EQUAL
 
+
 def standard_sc_expr_str(sc):
     """
     Standard symbol/choice printing function. Uses plain Kconfig syntax, and
@@ -5542,6 +5556,7 @@ def standard_sc_expr_str(sc):
 
     # Choice
     return "<choice {}>".format(sc.name) if sc.name else "<choice>"
+
 
 def expr_str(expr, sc_expr_str_fn=standard_sc_expr_str):
     """
@@ -5586,6 +5601,7 @@ def expr_str(expr, sc_expr_str_fn=standard_sc_expr_str):
     return "{} {} {}".format(sc_expr_str_fn(expr[1]), _REL_TO_STR[expr[0]],
                              sc_expr_str_fn(expr[2]))
 
+
 def expr_items(expr):
     """
     Returns a set() of all items (symbols and choices) that appear in the
@@ -5610,6 +5626,7 @@ def expr_items(expr):
 
     rec(expr)
     return res
+
 
 def split_expr(expr, op):
     """
@@ -5655,6 +5672,7 @@ def split_expr(expr, op):
     rec(expr)
     return res
 
+
 def escape(s):
     r"""
     Escapes the string 's' in the same fashion as is done for display in
@@ -5664,8 +5682,6 @@ def escape(s):
     # \ must be escaped before " to avoid double escaping
     return s.replace("\\", r"\\").replace('"', r'\"')
 
-# unescape() helper
-_unescape_sub = re.compile(r"\\(.)").sub
 
 def unescape(s):
     r"""
@@ -5673,6 +5689,10 @@ def unescape(s):
     that character. Used internally when reading .config files.
     """
     return _unescape_sub(r"\1", s)
+
+# unescape() helper
+_unescape_sub = re.compile(r"\\(.)").sub
+
 
 def standard_kconfig():
     """
@@ -5694,6 +5714,7 @@ def standard_kconfig():
         # formatting when reported as an unhandled exception. Strip them here.
         sys.exit(str(e).strip())
 
+
 def standard_config_filename():
     """
     Helper for tools. Returns the value of KCONFIG_CONFIG (which specifies the
@@ -5703,6 +5724,7 @@ def standard_config_filename():
     want, without having to use this function.
     """
     return os.environ.get("KCONFIG_CONFIG", ".config")
+
 
 def load_allconfig(kconf, filename):
     """
@@ -5759,9 +5781,11 @@ def load_allconfig(kconf, filename):
     kconf.enable_override_warnings()
     kconf.enable_redun_warnings()
 
+
 #
 # Internal functions
 #
+
 
 def _visibility(sc):
     # Symbols and Choices have a "visibility" that acts as an upper bound on
@@ -5792,6 +5816,7 @@ def _visibility(sc):
 
     return vis
 
+
 def _make_depend_on(sc, expr):
     # Adds 'sc' (symbol or choice) as a "dependee" to all symbols in 'expr'.
     # Constant symbols in 'expr' are skipped as they can never change value
@@ -5810,12 +5835,14 @@ def _make_depend_on(sc, expr):
         # Non-constant symbol, or choice
         expr._dependents.add(sc)
 
+
 def _parenthesize(expr, type_, sc_expr_str_fn):
     # expr_str() helper. Adds parentheses around expressions of type 'type_'.
 
     if expr.__class__ is tuple and expr[0] is type_:
         return "({})".format(expr_str(expr, sc_expr_str_fn))
     return expr_str(expr, sc_expr_str_fn)
+
 
 def _ordered_unique(lst):
     # Returns 'lst' with any duplicates removed, preserving order. This hacky
@@ -5826,6 +5853,7 @@ def _ordered_unique(lst):
     seen_add = seen.add
     return [x for x in lst if x not in seen and not seen_add(x)]
 
+
 def _is_base_n(s, n):
     try:
         int(s, n)
@@ -5833,10 +5861,12 @@ def _is_base_n(s, n):
     except ValueError:
         return False
 
+
 def _strcmp(s1, s2):
     # strcmp()-alike that returns -1, 0, or 1
 
     return (s1 > s2) - (s1 < s2)
+
 
 def _sym_to_num(sym):
     # expr_value() helper for converting a symbol to a number. Raises
@@ -5848,36 +5878,39 @@ def _sym_to_num(sym):
     return sym.tri_value if sym.orig_type in _BOOL_TRISTATE else \
            int(sym.str_value, _TYPE_TO_BASE[sym.orig_type])
 
+
 def _touch_dep_file(sym_name):
     # If sym_name is MY_SYM_NAME, touches my/sym/name.h. See the sync_deps()
     # docstring.
 
     sym_path = sym_name.lower().replace("_", os.sep) + ".h"
-    sym_path_dir = os.path.dirname(sym_path)
-    if sym_path_dir and not os.path.exists(sym_path_dir):
+    sym_path_dir = dirname(sym_path)
+    if sym_path_dir and not exists(sym_path_dir):
         os.makedirs(sym_path_dir, 0o755)
 
     # A kind of truncating touch, mirroring the C tools
     os.close(os.open(
         sym_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644))
 
+
 def _save_old(path):
     # See write_config()
 
-    dirname, basename = os.path.split(path)
-    backup = os.path.join(dirname,
-                          basename + ".old" if basename.startswith(".") else
-                              "." + basename + ".old")
+    dirname, basename = split(path)
+    backup = join(dirname,
+                  basename + ".old" if basename.startswith(".")
+                      else "." + basename + ".old")
 
     # os.replace() would be nice here, but it's Python 3 (3.3+) only
     try:
         # Use copyfile() if 'path' is a symlink. The intention is probably to
         # overwrite the target in that case.
-        if os.name == "posix" and not os.path.islink(path):
+        if os.name == "posix" and not islink(path):
             # Will remove .<filename>.old if it already exists on POSIX
             # systems
             os.rename(path, backup)
         else:
+            # Only import as needed, to save some startup time
             import shutil
             shutil.copyfile(path, backup)
     except:
@@ -5885,6 +5918,7 @@ def _save_old(path):
         # backup file is more of a nice-to-have, and not worth erroring out
         # over e.g. if .<filename>.old happens to be a directory.
         pass
+
 
 def _decoding_error(e, filename, macro_linenr=None):
     # Gives the filename and context for UnicodeDecodeError's, which are a pain
@@ -5907,6 +5941,7 @@ def _decoding_error(e, filename, macro_linenr=None):
             e.object[e.start:e.end],
             e.reason))
 
+
 def _name_and_loc(sc):
     # Helper for giving the symbol/choice name and location(s) in e.g. warnings
 
@@ -5924,6 +5959,7 @@ def _name_and_loc(sc):
 
 
 # Menu manipulation
+
 
 def _expr_depends_on(expr, sym):
     # Reimplementation of expr_depends_symbol() from mconf.c. Used to determine
@@ -5952,6 +5988,7 @@ def _expr_depends_on(expr, sym):
            (_expr_depends_on(expr[1], sym) or
             _expr_depends_on(expr[2], sym))
 
+
 def _auto_menu_dep(node1, node2):
     # Returns True if node2 has an "automatic menu dependency" on node1. If
     # node2 has a prompt, we check its condition. Otherwise, we look directly
@@ -5960,6 +5997,7 @@ def _auto_menu_dep(node1, node2):
     # If node2 has no prompt, use its menu node dependencies instead
     return _expr_depends_on(node2.prompt[1] if node2.prompt else node2.dep,
                             node1.item)
+
 
 def _flatten(node):
     # "Flattens" menu nodes without prompts (e.g. 'if' nodes and non-visible
@@ -5989,6 +6027,7 @@ def _flatten(node):
 
         node = node.next
 
+
 def _remove_ifs(node):
     # Removes 'if' nodes (which can be recognized by MenuNode.item being None),
     # which are assumed to already have been flattened. The C implementation
@@ -6013,6 +6052,7 @@ def _remove_ifs(node):
         #
         # due to tricky Python semantics. The order matters.
         cur.next = cur = next
+
 
 def _finalize_choice(node):
     # Finalizes a choice, marking each symbol whose menu node has the choice as
@@ -6040,6 +6080,7 @@ def _finalize_choice(node):
     for sym in choice.syms:
         if not sym.orig_type:
             sym.orig_type = choice.orig_type
+
 
 def _check_dep_loop_sym(sym, ignore_choice):
     # Detects dependency loops using depth-first search on the dependency graph
@@ -6115,6 +6156,7 @@ def _check_dep_loop_sym(sym, ignore_choice):
     # first element in it.
     return (sym,)
 
+
 def _check_dep_loop_choice(choice, skip):
     if not choice._visited:
         # choice._visited == 0, unvisited
@@ -6147,6 +6189,7 @@ def _check_dep_loop_choice(choice, skip):
     # choice._visited == 1, found a dependency loop. Return the choice as the
     # first element in it.
     return (choice,)
+
 
 def _found_dep_loop(loop, cur):
     # Called "on the way back" when we know we have a loop
@@ -6199,22 +6242,27 @@ def _found_dep_loop(loop, cur):
 
 # Predefined preprocessor functions
 
+
 def _filename_fn(kconf, _):
     return kconf._filename
 
+
 def _lineno_fn(kconf, _):
     return str(kconf._linenr)
+
 
 def _info_fn(kconf, _, msg):
     print("{}:{}: {}".format(kconf._filename, kconf._linenr, msg))
 
     return ""
 
+
 def _warning_if_fn(kconf, _, cond, msg):
     if cond == "y":
         kconf._warn(msg, kconf._filename, kconf._linenr)
 
     return ""
+
 
 def _error_if_fn(kconf, _, cond, msg):
     if cond == "y":
@@ -6223,7 +6271,11 @@ def _error_if_fn(kconf, _, cond, msg):
 
     return ""
 
+
 def _shell_fn(kconf, _, command):
+    # Only import as needed, to save some startup time
+    import subprocess
+
     stdout, stderr = subprocess.Popen(
         command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     ).communicate()
@@ -6250,30 +6302,8 @@ def _shell_fn(kconf, _, command):
     return "\n".join(stdout.splitlines()).rstrip("\n").replace("\n", " ")
 
 #
-# Public global constants
+# Global constants
 #
-
-# Integers representing symbol types. UNKNOWN is 0 (falsy) to simplify some
-# checks, though client code shouldn't rely on it (it was non-zero in older
-# versions).
-(
-    UNKNOWN,
-    BOOL,
-    TRISTATE,
-    STRING,
-    INT,
-    HEX,
-) = range(6)
-
-# Converts a symbol/choice type to a string
-TYPE_TO_STR = {
-    UNKNOWN:  "unknown",
-    BOOL:     "bool",
-    TRISTATE: "tristate",
-    STRING:   "string",
-    INT:      "int",
-    HEX:      "hex",
-}
 
 TRI_TO_STR = {
     0: "n",
@@ -6287,28 +6317,29 @@ STR_TO_TRI = {
     "y": 2,
 }
 
-#
-# Internal global constants (plus public expression type
-# constants)
-#
-
-# Note:
-#
-# The token and type constants below are safe to test with 'is', which is a bit
-# faster (~30% faster in a microbenchmark with Python 3 on my machine, and a
-# few % faster for total parsing time), even without assuming Python's small
-# integer optimization (which caches small integer objects). The constants end
-# up pointing to unique integer objects, and since we consistently refer to
-# them via the names below, we always get the same object.
-#
-# Client code would also need to use the names below, because the integer
-# values can change e.g. when tokens get added. Client code would usually test
-# with == too, which would be safe even in super obscure cases involving e.g.
-# pickling (where 'is' would be a bad idea anyway) and no small-integer
-# optimization.
+# Constant representing that there's no cached choice selection. This is
+# distinct from a cached None (no selection). Any object that's not None or a
+# Symbol will do. We test this with 'is'.
+_NO_CACHED_SELECTION = 0
 
 # Are we running on Python 2?
 _IS_PY2 = sys.version_info[0] < 3
+
+try:
+    _UNAME_RELEASE = os.uname()[2]
+except AttributeError:
+    # Only import as needed, to save some startup time
+    import platform
+    _UNAME_RELEASE = platform.uname()[2]
+
+# Note: The token and type constants below are safe to test with 'is', which is
+# a bit faster (~30% faster on my machine, and a few % faster for total parsing
+# time), even without assuming Python's small integer optimization (which
+# caches small integer objects). The constants end up pointing to unique
+# integer objects, and since we consistently refer to them via the names below,
+# we always get the same object.
+#
+# Client code should use == though.
 
 # Tokens, with values 1, 2, ... . Avoiding 0 simplifies some checks by making
 # all tokens except empty strings truthy.
@@ -6365,25 +6396,6 @@ _IS_PY2 = sys.version_info[0] < 3
     _T_VISIBLE,
 ) = range(1, 51)
 
-# Public integers representing expression types and menu and comment menu
-# nodes
-#
-# Having these match the value of the corresponding tokens removes the need
-# for conversion
-
-AND           = _T_AND
-OR            = _T_OR
-NOT           = _T_NOT
-EQUAL         = _T_EQUAL
-UNEQUAL       = _T_UNEQUAL
-LESS          = _T_LESS
-LESS_EQUAL    = _T_LESS_EQUAL
-GREATER       = _T_GREATER
-GREATER_EQUAL = _T_GREATER_EQUAL
-
-MENU          = _T_MENU
-COMMENT       = _T_COMMENT
-
 # Keyword to token map, with the get() method assigned directly as a small
 # optimization
 _get_keyword = {
@@ -6432,6 +6444,70 @@ _get_keyword = {
     "visible":        _T_VISIBLE,
 }.get
 
+# The constants below match the value of the corresponding tokens to remove the
+# need for conversion
+
+# Node types
+MENU    = _T_MENU
+COMMENT = _T_COMMENT
+
+# Expression types
+AND           = _T_AND
+OR            = _T_OR
+NOT           = _T_NOT
+EQUAL         = _T_EQUAL
+UNEQUAL       = _T_UNEQUAL
+LESS          = _T_LESS
+LESS_EQUAL    = _T_LESS_EQUAL
+GREATER       = _T_GREATER
+GREATER_EQUAL = _T_GREATER_EQUAL
+
+_REL_TO_STR = {
+    EQUAL:         "=",
+    UNEQUAL:       "!=",
+    LESS:          "<",
+    LESS_EQUAL:    "<=",
+    GREATER:       ">",
+    GREATER_EQUAL: ">=",
+}
+
+# Symbol/choice types. UNKNOWN is 0 (falsy) to simplify some checks.
+# Client code shouldn't rely on it though, as it was non-zero in
+# older versions.
+UNKNOWN  = 0
+BOOL     = _T_BOOL
+TRISTATE = _T_TRISTATE
+STRING   = _T_STRING
+INT      = _T_INT
+HEX      = _T_HEX
+
+TYPE_TO_STR = {
+    UNKNOWN:  "unknown",
+    BOOL:     "bool",
+    TRISTATE: "tristate",
+    STRING:   "string",
+    INT:      "int",
+    HEX:      "hex",
+}
+
+# Used in comparisons. 0 means the base is inferred from the format of the
+# string.
+_TYPE_TO_BASE = {
+    HEX:      16,
+    INT:      10,
+    STRING:   0,
+    UNKNOWN:  0,
+}
+
+# def_bool -> BOOL, etc.
+_DEF_TOKEN_TO_TYPE = {
+    _T_DEF_BOOL:     BOOL,
+    _T_DEF_HEX:      HEX,
+    _T_DEF_INT:      INT,
+    _T_DEF_STRING:   STRING,
+    _T_DEF_TRISTATE: TRISTATE,
+}
+
 # Tokens after which strings are expected. This is used to tell strings from
 # constant symbol references during tokenization, both of which are enclosed in
 # quotes.
@@ -6456,8 +6532,8 @@ _STRING_LEX = frozenset((
     _T_TRISTATE,
 ))
 
-# Various sets, for quick membership tests. This gives us a single global
-# lookup and avoids creating temporary dicts/tuples.
+# Various sets for quick membership tests. Gives a single global lookup and
+# avoids creating temporary dicts/tuples.
 
 _TYPE_TOKENS = frozenset((
     _T_BOOL,
@@ -6483,14 +6559,6 @@ _REL_SOURCE_TOKENS = frozenset((
 _OBL_SOURCE_TOKENS = frozenset((
     _T_SOURCE,
     _T_RSOURCE,
-))
-
-_DEF_TYPE_TOKENS = frozenset((
-    _T_DEF_BOOL,
-    _T_DEF_TRISTATE,
-    _T_DEF_INT,
-    _T_DEF_HEX,
-    _T_DEF_STRING,
 ))
 
 _BOOL_TRISTATE = frozenset((
@@ -6530,13 +6598,24 @@ _EQUAL_UNEQUAL = frozenset((
     UNEQUAL,
 ))
 
+_RELATIONS = frozenset((
+    EQUAL,
+    UNEQUAL,
+    LESS,
+    LESS_EQUAL,
+    GREATER,
+    GREATER_EQUAL,
+))
+
 # Helper functions for getting compiled regular expressions, with the needed
 # matching function returned directly as a small optimization.
 #
 # Use ASCII regex matching on Python 3. It's already the default on Python 2.
 
+
 def _re_match(regex):
     return re.compile(regex, 0 if _IS_PY2 else re.ASCII).match
+
 
 def _re_search(regex):
     return re.compile(regex, 0 if _IS_PY2 else re.ASCII).search
@@ -6580,52 +6659,3 @@ _name_special_search = _re_search(r'[^$A-Za-z0-9_/.-]|\$\(|$')
 # A valid right-hand side for an assignment to a string symbol in a .config
 # file, including escaped characters. Extracts the contents.
 _conf_string_match = _re_match(r'"((?:[^\\"]|\\.)*)"')
-
-
-# Token to type mapping
-_TOKEN_TO_TYPE = {
-    _T_BOOL:         BOOL,
-    _T_DEF_BOOL:     BOOL,
-    _T_DEF_HEX:      HEX,
-    _T_DEF_INT:      INT,
-    _T_DEF_STRING:   STRING,
-    _T_DEF_TRISTATE: TRISTATE,
-    _T_HEX:          HEX,
-    _T_INT:          INT,
-    _T_STRING:       STRING,
-    _T_TRISTATE:     TRISTATE,
-}
-
-# Constant representing that there's no cached choice selection. This is
-# distinct from a cached None (no selection). We create a unique object (any
-# will do) for it so we can test with 'is'.
-_NO_CACHED_SELECTION = object()
-
-# Used in comparisons. 0 means the base is inferred from the format of the
-# string.
-_TYPE_TO_BASE = {
-    HEX:      16,
-    INT:      10,
-    STRING:   0,
-    UNKNOWN:  0,
-}
-
-# Note: These constants deliberately equal the corresponding tokens (_T_EQUAL,
-# _T_UNEQUAL, etc.), which removes the need for conversion
-_RELATIONS = frozenset((
-    EQUAL,
-    UNEQUAL,
-    LESS,
-    LESS_EQUAL,
-    GREATER,
-    GREATER_EQUAL,
-))
-
-_REL_TO_STR = {
-    EQUAL:         "=",
-    UNEQUAL:       "!=",
-    LESS:          "<",
-    LESS_EQUAL:    "<=",
-    GREATER:       ">",
-    GREATER_EQUAL: ">=",
-}

--- a/scripts/kconfig/menuconfig.py
+++ b/scripts/kconfig/menuconfig.py
@@ -178,15 +178,16 @@ Limitations
 
   - Doesn't work out of the box on Windows
 
-    Has been tested to work with the wheels provided at
-    https://www.lfd.uci.edu/~gohlke/pythonlibs/#curses though.
-"""
+    Can be made to work with 'pip install windows-curses' though. See the
+    https://github.com/zephyrproject-rtos/windows-curses repository.
 
+    'pip install kconfiglib' on Windows automatically installs windows-curses
+    to make the menuconfig usable.
+"""
 import curses
 import errno
 import locale
 import os
-import platform
 import re
 import sys
 import textwrap
@@ -331,9 +332,10 @@ _STYLE_STD_COLORS = {
     "brightpurple":  curses.COLOR_MAGENTA + 8,
 }
 
+
 def _rgb_to_6cube(rgb):
     # Converts an 888 RGB color to a 3-tuple (nice in that it's hashable)
-    # representing the closests xterm 256-color 6x6x6 color cube color.
+    # representing the closest xterm 256-color 6x6x6 color cube color.
     #
     # The xterm 256-color extension uses a RGB color palette with components in
     # the range 0-5 (a 6x6x6 cube). The catch is that the mapping is nonlinear.
@@ -346,10 +348,12 @@ def _rgb_to_6cube(rgb):
     # 48 is the middle ground between 0 and 95.
     return tuple(0 if x < 48 else int(round(max(1, (x - 55)/40))) for x in rgb)
 
+
 def _6cube_to_rgb(r6g6b6):
     # Returns the 888 RGB color for a 666 xterm color cube index
 
     return tuple(0 if x == 0 else 40*x + 55 for x in r6g6b6)
+
 
 def _rgb_to_gray(rgb):
     # Converts an 888 RGB color to the index of an xterm 256-color grayscale
@@ -361,17 +365,19 @@ def _rgb_to_gray(rgb):
     #   https://www.w3.org/TR/AERT/#color-contrast
     luma = 0.299*rgb[0] + 0.587*rgb[1] + 0.114*rgb[2]
 
-    # Closests index in the grayscale palette, which starts at RGB 0x080808,
+    # Closest index in the grayscale palette, which starts at RGB 0x080808,
     # with stepping 0x0A0A0A
     index = int(round((luma - 8)/10))
 
     # Clamp the index to 0-23, corresponding to 232-255
     return max(0, min(index, 23))
 
+
 def _gray_to_rgb(index):
     # Convert a grayscale index to its closet single RGB component
 
     return 3*(10*index + 8,)  # Returns a 3-tuple
+
 
 # Obscure Python: We never pass a value for rgb2index, and it keeps pointing to
 # the same dict. This avoids a global.
@@ -406,6 +412,7 @@ def _alloc_rgb(rgb, rgb2index={}):
 
     return color_index
 
+
 def _color_from_num(num):
     # Returns the index of a color that looks like color 'num' in the xterm
     # 256-color palette (but that might not be 'num', if we're redefining
@@ -430,6 +437,7 @@ def _color_from_num(num):
         return _alloc_rgb(_6cube_to_rgb(((num//36)%6, (num//6)%6, num%6)))
 
     return _alloc_rgb(_gray_to_rgb(num - 232))
+
 
 def _color_from_rgb(rgb):
     # Returns the index of a color matching the 888 RGB color 'rgb'. The
@@ -477,9 +485,6 @@ def _color_from_rgb(rgb):
 
     return best
 
-# Dictionary mapping element types to the curses attributes used to display
-# them
-_style = {}
 
 def _parse_style(style_str, parsing_default):
     # Parses a string with '<element>=<style>' assignments. Anything not
@@ -514,6 +519,11 @@ def _parse_style(style_str, parsing_default):
 
         else:
             _warn("Ignoring non-existent style template", sline)
+
+# Dictionary mapping element types to the curses attributes used to display
+# them
+_style = {}
+
 
 def _style_to_curses(style_def):
     # Parses a style definition string (<element>=<style>), returning
@@ -574,6 +584,7 @@ def _style_to_curses(style_def):
 
     return _style_attr(fg_color, bg_color, attrs)
 
+
 def _init_styles():
     if curses.has_colors():
         curses.use_default_colors()
@@ -585,6 +596,7 @@ def _init_styles():
     # Add any user-defined style from the environment
     if "MENUCONFIG_STYLE" in os.environ:
         _parse_style(os.environ["MENUCONFIG_STYLE"], False)
+
 
 # color_attribs holds the color pairs we've already created, indexed by a
 # (<foreground color>, <background color>) tuple.
@@ -610,13 +622,16 @@ def _style_attr(fg_color, bg_color, attribs, color_attribs={}):
 
     return color_attribs[(fg_color, bg_color)] | attribs
 
+
 #
 # Main application
 #
 
+
 # Used as the entry point in setup.py
 def _main():
     menuconfig(standard_kconfig())
+
 
 def menuconfig(kconf):
     """
@@ -626,13 +641,21 @@ def menuconfig(kconf):
       Kconfig instance to be configured
     """
     global _kconf
-    global _show_all
+    global _conf_filename
     global _conf_changed
+    global _minconf_filename
+    global _show_all
 
     _kconf = kconf
 
     # Load existing configuration and set _conf_changed True if it is outdated
     _conf_changed = _load_config()
+
+    # Filename to save configuration to
+    _conf_filename = standard_config_filename()
+
+    # Filename to save minimal configuration to
+    _minconf_filename = "defconfig"
 
     # Any visible items in the top menu?
     _show_all = False
@@ -678,15 +701,26 @@ def menuconfig(kconf):
     # curses has been de-initialized.
     print(curses.wrapper(_menuconfig))
 
+
 def _load_config():
     # Loads any existing .config file. See the Kconfig.load_config() docstring.
     #
     # Returns True if .config is missing or outdated. We always prompt for
     # saving the configuration in that case.
 
-    if not _kconf.load_config() or _kconf.missing_syms:
-        # Either no .config, or assignments to undefined symbols in the
-        # existing .config (which would get removed when saving)
+    if not _kconf.load_config():
+        # No .config
+        return True
+
+    return _needs_save()
+
+
+def _needs_save():
+    # Returns True if a just-loaded .config file is outdated (would get
+    # modified when saving)
+
+    if _kconf.missing_syms:
+        # Assignments to undefined symbols in the .config
         return True
 
     for sym in _kconf.unique_defined_syms:
@@ -704,6 +738,7 @@ def _load_config():
 
     # No need to prompt for save
     return False
+
 
 # Global variables used below:
 #
@@ -733,6 +768,12 @@ def _load_config():
 #   _show_help/_show_name/_show_all:
 #     If True, the corresponding mode is on. See the module docstring.
 #
+#   _conf_filename:
+#     .config file to save the configuration to
+#
+#   _minconf_filename:
+#     File to save minimal configurations to
+#
 #   _conf_changed:
 #     True if the configuration has been changed. If False, we don't bother
 #     showing the save-and-quit dialog.
@@ -740,11 +781,14 @@ def _load_config():
 #     We reset this to False whenever the configuration is saved explicitly
 #     from the save dialog.
 
+
 def _menuconfig(stdscr):
     # Logic for the main display, with the list of symbols, etc.
 
     global _stdscr
+    global _conf_filename
     global _conf_changed
+    global _minconf_filename
     global _show_help
     global _show_name
 
@@ -825,30 +869,20 @@ def _menuconfig(stdscr):
                 _leave_menu()
 
         elif c in ("o", "O"):
-            if _conf_changed:
-                c = _key_dialog(
-                    "Load",
-                    "You have unsaved changes. Load new\n"
-                    "configuration anyway?\n"
-                    "\n"
-                    "        (Y)es  (C)ancel",
-                    "yc")
-
-                if c is None or c == "c":
-                    continue
-
-            if _load_dialog():
-                _conf_changed = True
+            _load_dialog()
 
         elif c in ("s", "S"):
-            if _save_dialog(_kconf.write_config, standard_config_filename(),
-                            "configuration"):
-
+            filename = _save_dialog(_kconf.write_config, _conf_filename,
+                                    "configuration")
+            if filename:
+                _conf_filename = filename
                 _conf_changed = False
 
         elif c in ("d", "D"):
-            _save_dialog(_kconf.write_min_config, "defconfig",
-                         "minimal configuration")
+            filename = _save_dialog(_kconf.write_min_config, _minconf_filename,
+                                    "minimal configuration")
+            if filename:
+                _minconf_filename = filename
 
         elif c == "/":
             _jump_to_dialog()
@@ -878,9 +912,10 @@ def _menuconfig(stdscr):
             if res:
                 return res
 
+
 def _quit_dialog():
     if not _conf_changed:
-        return "No changes to save"
+        return "No changes to save (for '{}')".format(_conf_filename)
 
     while True:
         c = _key_dialog(
@@ -894,14 +929,12 @@ def _quit_dialog():
             return None
 
         if c == "y":
-            if _try_save(_kconf.write_config, standard_config_filename(),
-                         "configuration"):
-
-                return "Configuration saved to '{}'" \
-                       .format(standard_config_filename())
+            if _try_save(_kconf.write_config, _conf_filename, "configuration"):
+                return "Configuration saved to '{}'".format(_conf_filename)
 
         elif c == "n":
-            return "Configuration was not saved"
+            return "Configuration ({}) was not saved".format(_conf_filename)
+
 
 def _init():
     # Initializes the main display with the list of symbols, etc. Also does
@@ -971,6 +1004,7 @@ def _init():
     # Give windows their initial size
     _resize_main()
 
+
 def _resize_main():
     # Resizes the main display, with the list of symbols, etc., to fill the
     # terminal
@@ -984,7 +1018,7 @@ def _resize_main():
     _bot_sep_win.resize(1, screen_width)
 
     help_win_height = _SHOW_HELP_HEIGHT if _show_help else \
-                          len(_MAIN_HELP_LINES)
+        len(_MAIN_HELP_LINES)
 
     menu_win_height = screen_height - help_win_height - 3
 
@@ -1012,10 +1046,18 @@ def _resize_main():
     if _sel_node_i - _menu_scroll >= menu_win_height:
         _menu_scroll = _sel_node_i - menu_win_height + 1
 
-def _menu_win_height():
-    # Returns the height of the menu display
 
-    return _menu_win.getmaxyx()[0]
+def _height(win):
+    # Returns the height of 'win'
+
+    return win.getmaxyx()[0]
+
+
+def _width(win):
+    # Returns the width of 'win'
+
+    return win.getmaxyx()[1]
+
 
 def _prefer_toggle(item):
     # For nodes with menus, determines whether Space should change the value of
@@ -1025,6 +1067,7 @@ def _prefer_toggle(item):
 
     return isinstance(item, Symbol) or \
            (isinstance(item, Choice) and len(item.assignable) > 1)
+
 
 def _enter_menu(menu):
     # Makes 'menu' the currently displayed menu. "Menu" here includes choices
@@ -1050,6 +1093,7 @@ def _enter_menu(menu):
         if isinstance(menu.item, Choice):
             _select_selected_choice_sym()
 
+
 def _select_selected_choice_sym():
     # Puts the cursor on the currently selected (y-valued) choice symbol, if
     # any. Does nothing if if the choice has no selection (is not visible/in y
@@ -1065,6 +1109,8 @@ def _select_selected_choice_sym():
             if node in _shown:
                 _sel_node_i = _shown.index(node)
                 _center_vertically()
+                return
+
 
 def _jump_to(node):
     # Jumps directly to the menu node 'node'
@@ -1114,6 +1160,7 @@ def _jump_to(node):
     if jump_into and isinstance(_cur_menu.item, Choice):
         _select_selected_choice_sym()
 
+
 def _leave_menu():
     # Jumps to the parent menu of the current menu. Does nothing if we're in
     # the top menu.
@@ -1137,12 +1184,13 @@ def _leave_menu():
 
     if _parent_screen_rows:
         # The terminal might have shrunk since we were last in the parent menu
-        screen_row = min(_parent_screen_rows.pop(), _menu_win_height() - 1)
+        screen_row = min(_parent_screen_rows.pop(), _height(_menu_win) - 1)
         _menu_scroll = max(_sel_node_i - screen_row, 0)
     else:
         # No saved parent menu locations, meaning we jumped directly to some
         # node earlier
         _center_vertically()
+
 
 def _select_next_menu_entry():
     # Selects the menu entry after the current one, adjusting the scroll if
@@ -1158,11 +1206,12 @@ def _select_next_menu_entry():
         # If the new node is sufficiently close to the edge of the menu window
         # (as determined by _SCROLL_OFFSET), increase the scroll by one. This
         # gives nice and non-jumpy behavior even when
-        # _SCROLL_OFFSET >= _menu_win_height().
-        if _sel_node_i >= _menu_scroll + _menu_win_height() - _SCROLL_OFFSET \
+        # _SCROLL_OFFSET >= _height(_menu_win).
+        if _sel_node_i >= _menu_scroll + _height(_menu_win) - _SCROLL_OFFSET \
            and _menu_scroll < _max_scroll(_shown, _menu_win):
 
             _menu_scroll += 1
+
 
 def _select_prev_menu_entry():
     # Selects the menu entry before the current one, adjusting the scroll if
@@ -1179,6 +1228,7 @@ def _select_prev_menu_entry():
         if _sel_node_i <= _menu_scroll + _SCROLL_OFFSET:
             _menu_scroll = max(_menu_scroll - 1, 0)
 
+
 def _select_last_menu_entry():
     # Selects the last menu entry in the current menu
 
@@ -1188,6 +1238,7 @@ def _select_last_menu_entry():
     _sel_node_i = len(_shown) - 1
     _menu_scroll = _max_scroll(_shown, _menu_win)
 
+
 def _select_first_menu_entry():
     # Selects the first menu entry in the current menu
 
@@ -1195,6 +1246,7 @@ def _select_first_menu_entry():
     global _menu_scroll
 
     _sel_node_i = _menu_scroll = 0
+
 
 def _toggle_show_all():
     # Toggles show-all mode on/off. If turning it off would give no visible
@@ -1216,10 +1268,9 @@ def _toggle_show_all():
     # Find a good node to select. The selected node might disappear if show-all
     # mode is turned off.
 
-    # If there are visible nodes before the previously selected node, select
-    # the closest one. This will select the previously selected node itself if
-    # it is still visible.
-    for node in reversed(_shown[:_sel_node_i + 1]):
+    # Select the previously selected node itself if it is still visible. If
+    # there are visible nodes before it, select the closest one.
+    for node in _shown[_sel_node_i::-1]:
         if node in new_shown:
             _sel_node_i = new_shown.index(node)
             break
@@ -1235,7 +1286,6 @@ def _toggle_show_all():
             # an invisible menu. Don't allow that, as the implementation relies
             # on always having a selected node.
             _show_all = True
-
             return
 
     _shown = new_shown
@@ -1244,13 +1294,15 @@ def _toggle_show_all():
     # might be impossible if too many nodes have disappeared above the node.
     _menu_scroll = max(_sel_node_i - old_row, 0)
 
+
 def _center_vertically():
     # Centers the selected node vertically, if possible
 
     global _menu_scroll
 
-    _menu_scroll = min(max(_sel_node_i - _menu_win_height()//2, 0),
+    _menu_scroll = min(max(_sel_node_i - _height(_menu_win)//2, 0),
                        _max_scroll(_shown, _menu_win))
+
 
 def _draw_main():
     # Draws the "main" display, with the list of symbols, the header, and the
@@ -1259,7 +1311,7 @@ def _draw_main():
     # This could be optimized to only update the windows that have actually
     # changed, but keep it simple for now and let curses sort it out.
 
-    term_width = _stdscr.getmaxyx()[1]
+    term_width = _width(_stdscr)
 
 
     #
@@ -1291,7 +1343,7 @@ def _draw_main():
     # Draw the _shown nodes starting from index _menu_scroll up to either as
     # many as fit in the window, or to the end of _shown
     for i in range(_menu_scroll,
-                   min(_menu_scroll + _menu_win_height(), len(_shown))):
+                   min(_menu_scroll + _height(_menu_win), len(_shown))):
 
         node = _shown[i]
 
@@ -1299,7 +1351,7 @@ def _draw_main():
         # outside show-all mode, which could look confusing/broken. Invisible
         # symbols show up outside show-all mode if an invisible symbol has
         # visible children in an implicit (indented) menu.
-        if not _show_all or (node.prompt and expr_value(node.prompt[1])):
+        if _visible(node) or not _show_all:
             style = _style["selection" if i == _sel_node_i else "list"]
         else:
             style = _style["inv-selection" if i == _sel_node_i else "inv-list"]
@@ -1343,9 +1395,8 @@ def _draw_main():
     if _show_help:
         node = _shown[_sel_node_i]
         if isinstance(node.item, (Symbol, Choice)) and node.help:
-            help_win_height, help_win_width = _help_win.getmaxyx()
-            help_lines = textwrap.wrap(node.help, help_win_width)
-            for i in range(min(help_win_height, len(help_lines))):
+            help_lines = textwrap.wrap(node.help, _width(_help_win))
+            for i in range(min(_height(_help_win), len(help_lines))):
                 _safe_addstr(_help_win, i, 0, help_lines[i])
         else:
             _safe_addstr(_help_win, 0, 0, "(no help)")
@@ -1378,12 +1429,12 @@ def _draw_main():
         # '<choice (name if any)>'.
         menu_prompts.append(menu.prompt[0] if menu.prompt else
                             standard_sc_expr_str(menu.item))
-        menu = _parent_menu(menu)
+        menu = menu.parent
     menu_prompts.append("(top menu)")
     menu_prompts.reverse()
 
     # Hack: We can't put ACS_RARROW directly in the string. Temporarily
-    # represent it with NULL. Maybe using a Unicode character would be better.
+    # represent it with NULL.
     menu_path_str = " \0 ".join(menu_prompts)
 
     # Scroll the menu path to the right if needed to make the current menu's
@@ -1400,6 +1451,7 @@ def _draw_main():
 
     _path_win.noutrefresh()
 
+
 def _parent_menu(node):
     # Returns the menu node of the menu that contains 'node'. In addition to
     # proper 'menu's, this might also be a 'menuconfig' symbol or a 'choice'.
@@ -1410,6 +1462,7 @@ def _parent_menu(node):
         menu = menu.parent
     return menu
 
+
 def _shown_nodes(menu):
     # Returns the list of menu nodes from 'menu' (see _parent_menu()) that
     # would be shown when entering it
@@ -1418,31 +1471,35 @@ def _shown_nodes(menu):
         res = []
 
         while node:
-            # If a node has children but doesn't have the is_menuconfig flag
-            # set, the children come from a submenu created implicitly from
-            # dependencies, and are shown (indented) in the same menu as the
-            # parent node
-            shown_children = \
-                rec(node.list) if node.list and not node.is_menuconfig else []
+            # This code is minorly performance-sensitive. Make it too slow
+            # (e.g., by always recursing the entire tree), and going in and out
+            # of menus no longer feels instant.
 
-            # Always show the node if it is the root of an implicit submenu
-            # with visible items, even if the node itself is invisible. This
-            # can happen e.g. if the symbol has an optional prompt
-            # ('prompt "foo" if COND') that is currently invisible.
-            if shown(node) or shown_children:
+            if _visible(node) or _show_all:
                 res.append(node)
-                res += shown_children
+                if node.list and not node.is_menuconfig:
+                    # Nodes from implicit menu created from dependencies. Will
+                    # be shown indented. Note that is_menuconfig is True for
+                    # menus and choices as well as 'menuconfig' symbols.
+                    res += rec(node.list)
+
+            elif node.list and isinstance(node.item, Symbol) and \
+                 expr_value(node.dep):
+                # Show invisible symbols if they have visible children. This
+                # can happen for an m/y-valued symbol with an optional prompt
+                # ('prompt "foo" is COND') that is currently disabled. The
+                # expr_value(node.dep) check safely prunes the search: A node
+                # with unsatisfied direct dependencies can never have visible
+                # children.
+                shown_children = rec(node.list)
+                if shown_children:
+                    res.append(node)
+                    if not node.is_menuconfig:
+                        res += shown_children
 
             node = node.next
 
         return res
-
-    def shown(node):
-        # Show the node if its prompt is visible. For menus, also check
-        # 'visible if'. In show-all mode, show everything.
-        return _show_all or \
-            (node.prompt and expr_value(node.prompt[1]) and not
-             (node.item == MENU and not expr_value(node.visibility)))
 
     if isinstance(menu.item, Choice):
         # For named choices defined in multiple locations, entering the choice
@@ -1483,6 +1540,15 @@ def _shown_nodes(menu):
 
     return rec(menu.list)
 
+
+def _visible(node):
+    # Returns True if the node should appear in the menu (outside show-all
+    # mode)
+
+    return node.prompt and expr_value(node.prompt[1]) and not \
+        (node.item == MENU and not expr_value(node.visibility))
+
+
 def _change_node(node):
     # Changes the value of the menu node 'node' if it is a symbol. Bools and
     # tristates are toggled, while other symbol types pop up a text entry
@@ -1504,9 +1570,9 @@ def _change_node(node):
         s = sc.str_value
 
         while True:
-            s = _input_dialog("{} ({})".format(
-                                  node.prompt[0], TYPE_TO_STR[sc.type]),
-                              s, _range_info(sc))
+            s = _input_dialog(
+                "{} ({})".format(node.prompt[0], TYPE_TO_STR[sc.type]),
+                s, _range_info(sc))
 
             if s is None:
                 break
@@ -1519,7 +1585,7 @@ def _change_node(node):
                 if sc.type == HEX and not s.startswith(("0x", "0X")):
                     s = "0x" + s
 
-            if _check_validity(sc, s):
+            if _check_valid(sc, s):
                 _set_val(sc, s)
                 break
 
@@ -1534,6 +1600,7 @@ def _change_node(node):
         val_index = sc.assignable.index(sc.tri_value)
         _set_val(sc, sc.assignable[(val_index + 1) % len(sc.assignable)])
 
+
 def _set_sel_node_tri_val(tri_val):
     # Sets the value of the currently selected menu entry to 'tri_val', if that
     # value can be assigned
@@ -1541,6 +1608,7 @@ def _set_sel_node_tri_val(tri_val):
     sc = _shown[_sel_node_i].item
     if isinstance(sc, (Symbol, Choice)) and tri_val in sc.assignable:
         _set_val(sc, tri_val)
+
 
 def _set_val(sc, val):
     # Wrapper around Symbol/Choice.set_value() for updating the menu state and
@@ -1561,13 +1629,14 @@ def _set_val(sc, val):
         # current menu are visible. Recalculate the state.
         _update_menu()
 
+
 def _update_menu():
     # Updates the current menu after the value of a symbol or choice has been
     # changed. Changing a value might change which items in the menu are
     # visible.
     #
-    # Tries to preserve the location of the cursor when items disappear above
-    # it.
+    # If possible, preserves the location of the cursor on the screen when
+    # items are added/removed above the selected item.
 
     global _shown
     global _sel_node_i
@@ -1587,6 +1656,7 @@ def _update_menu():
     # Try to make the cursor stay on the same row in the menu window. This
     # might be impossible if too many nodes have disappeared above the node.
     _menu_scroll = max(_sel_node_i - old_row, 0)
+
 
 def _input_dialog(title, initial_text, info_text=None):
     # Pops up a dialog that prompts the user for a string
@@ -1618,7 +1688,7 @@ def _input_dialog(title, initial_text, info_text=None):
     i = len(initial_text)
 
     def edit_width():
-        return win.getmaxyx()[1] - 4
+        return _width(win) - 4
 
     # Horizontal scroll offset
     hscroll = max(i - edit_width() + 1, 0)
@@ -1650,6 +1720,7 @@ def _input_dialog(title, initial_text, info_text=None):
         else:
             s, i, hscroll = _edit_text(c, s, i, hscroll, edit_width())
 
+
 def _resize_input_dialog(win, title, info_lines):
     # Resizes the input dialog to a size appropriate for the terminal size
 
@@ -1669,8 +1740,9 @@ def _resize_input_dialog(win, title, info_lines):
     win.mvwin((screen_height - win_height)//2,
               (screen_width - win_width)//2)
 
+
 def _draw_input_dialog(win, title, info_lines, s, i, hscroll):
-    edit_width = win.getmaxyx()[1] - 4
+    edit_width = _width(win) - 4
 
     win.erase()
 
@@ -1689,37 +1761,50 @@ def _draw_input_dialog(win, title, info_lines, s, i, hscroll):
 
     win.noutrefresh()
 
+
 def _load_dialog():
     # Dialog for loading a new configuration
-    #
-    # Return value:
-    #   True if a new configuration was loaded, and False if the user canceled
-    #   the dialog
 
+    global _conf_changed
+    global _conf_filename
     global _show_all
 
-    filename = ""
+    if _conf_changed:
+        c = _key_dialog(
+            "Load",
+            "You have unsaved changes. Load new\n"
+            "configuration anyway?\n"
+            "\n"
+            "         (O)K  (C)ancel",
+            "oc")
+
+        if c is None or c == "c":
+            return
+
+    filename = _conf_filename
     while True:
         filename = _input_dialog("File to load", filename, _load_save_info())
-
         if filename is None:
-            return False
+            return
 
         filename = os.path.expanduser(filename)
 
         if _try_load(filename):
-            sel_node = _shown[_sel_node_i]
+            _conf_filename = filename
+            _conf_changed = _needs_save()
 
-            # Turn on show-all mode if the current node is (no longer) visible
-            if not (sel_node.prompt and expr_value(sel_node.prompt[1])):
+            # Turn on show-all mode if the selected node is not visible after
+            # loading the new configuration. _shown still holds the old state.
+            if _shown[_sel_node_i] not in _shown_nodes(_cur_menu):
                 _show_all = True
 
             _update_menu()
 
             # The message dialog indirectly updates the menu display, so _msg()
             # must be called after the new state has been initialized
-            _msg("Success", "Loaded {}".format(filename))
-            return True
+            _msg("Success", "Loaded " + filename)
+            return
+
 
 def _try_load(filename):
     # Tries to load a configuration file. Pops up an error and returns False on
@@ -1736,6 +1821,7 @@ def _try_load(filename):
                .format(filename, e.strerror, errno.errorcode[e.errno]))
         return False
 
+
 def _save_dialog(save_fn, default_filename, description):
     # Dialog for saving the current configuration
     #
@@ -1749,22 +1835,21 @@ def _save_dialog(save_fn, default_filename, description):
     #   String describing the thing being saved
     #
     # Return value:
-    #   True if the configuration was saved, and False if the user canceled the
-    #   dialog
+    #   The path to the saved file, or None if no file was saved
 
     filename = default_filename
     while True:
         filename = _input_dialog("Filename to save {} to".format(description),
                                  filename, _load_save_info())
-
         if filename is None:
-            return False
+            return None
 
         filename = os.path.expanduser(filename)
 
         if _try_save(save_fn, filename, description):
             _msg("Success", "{} saved to {}".format(description, filename))
-            return True
+            return filename
+
 
 def _try_save(save_fn, filename, description):
     # Tries to save a configuration file. Pops up an error and returns False on
@@ -1784,6 +1869,7 @@ def _try_save(save_fn, filename, description):
                .format(description, e.filename, e.strerror,
                        errno.errorcode[e.errno]))
         return False
+
 
 def _key_dialog(title, text, keys):
     # Pops up a dialog that can be closed by pressing a key
@@ -1831,6 +1917,7 @@ def _key_dialog(title, text, keys):
             if c in keys:
                 return c
 
+
 def _resize_key_dialog(win, text):
     # Resizes the key dialog to a size appropriate for the terminal size
 
@@ -1845,6 +1932,7 @@ def _resize_key_dialog(win, text):
     win.mvwin((screen_height - win_height)//2,
               (screen_width - win_width)//2)
 
+
 def _draw_key_dialog(win, title, text):
     win.erase()
 
@@ -1855,6 +1943,7 @@ def _draw_key_dialog(win, title, text):
     _draw_frame(win, title)
 
     win.noutrefresh()
+
 
 def _draw_frame(win, title):
     # Draw a frame around the inner edges of 'win', with 'title' at the top
@@ -1876,6 +1965,7 @@ def _draw_frame(win, title):
 
     win.attroff(_style["frame"])
 
+
 def _jump_to_dialog():
     # Implements the jump-to dialog, where symbols can be looked up via
     # incremental search and jumped to.
@@ -1883,19 +1973,13 @@ def _jump_to_dialog():
     # Returns True if the user jumped to a symbol, and False if the dialog was
     # canceled.
 
-    # Search text
-    s = ""
-    # Previous search text
-    prev_s = None
-    # Search text cursor position
-    s_i = 0
-    # Horizontal scroll offset
-    hscroll = 0
+    s = ""  # Search text
+    prev_s = None  # Previous search text
+    s_i = 0  # Search text cursor position
+    hscroll = 0  # Horizontal scroll offset
 
-    # Index of selected row
-    sel_node_i = 0
-    # Index in 'matches' of the top row of the list
-    scroll = 0
+    sel_node_i = 0  # Index of selected row
+    scroll = 0  # Index in 'matches' of the top row of the list
 
     # Edit box at the top
     edit_box = _styled_win("jump-edit")
@@ -1926,7 +2010,7 @@ def _jump_to_dialog():
         if sel_node_i < len(matches) - 1:
             sel_node_i += 1
 
-            if sel_node_i >= scroll + matches_win.getmaxyx()[0] - _SCROLL_OFFSET \
+            if sel_node_i >= scroll + _height(matches_win) - _SCROLL_OFFSET \
                and scroll < _max_scroll(matches, matches_win):
 
                 scroll += 1
@@ -1963,6 +2047,7 @@ def _jump_to_dialog():
 
                 # List of matching nodes
                 matches = []
+                add_match = matches.append
 
                 # Search symbols and choices
 
@@ -1985,7 +2070,7 @@ def _jump_to_dialog():
                             break
 
                     else:
-                        matches.append(node)
+                        add_match(node)
 
                 # Search menus and comments
 
@@ -1994,7 +2079,7 @@ def _jump_to_dialog():
                         if not search(node.prompt[0].lower()):
                             break
                     else:
-                        matches.append(node)
+                        add_match(node)
 
             except re.error as e:
                 # Bad regex. Remember the error message so we can show it.
@@ -2070,7 +2155,8 @@ def _jump_to_dialog():
 
         else:
             s, s_i, hscroll = _edit_text(c, s, s_i, hscroll,
-                                         edit_box.getmaxyx()[1] - 2)
+                                         _width(edit_box) - 2)
+
 
 # Obscure Python: We never pass a value for cached_nodes, and it keeps pointing
 # to the same list. This avoids a global.
@@ -2099,6 +2185,7 @@ def _sorted_sc_nodes(cached_nodes=[]):
 
     return cached_nodes
 
+
 def _sorted_menu_comment_nodes(cached_nodes=[]):
     # Returns a list of menu and comment nodes to search, sorted by prompt,
     # with the menus first
@@ -2111,6 +2198,7 @@ def _sorted_menu_comment_nodes(cached_nodes=[]):
         cached_nodes += sorted(_kconf.comments, key=prompt_text)
 
     return cached_nodes
+
 
 def _resize_jump_to_dialog(edit_box, matches_win, bot_sep_win, help_win,
                            sel_node_i, scroll):
@@ -2152,11 +2240,12 @@ def _resize_jump_to_dialog(edit_box, matches_win, bot_sep_win, help_win,
         return sel_node_i - matches_win_height + 1
     return scroll
 
+
 def _draw_jump_to_dialog(edit_box, matches_win, bot_sep_win, help_win,
                          s, s_i, hscroll,
                          bad_re, matches, sel_node_i, scroll):
 
-    edit_width = edit_box.getmaxyx()[1] - 2
+    edit_width = _width(edit_box) - 2
 
 
     #
@@ -2167,7 +2256,7 @@ def _draw_jump_to_dialog(edit_box, matches_win, bot_sep_win, help_win,
 
     if matches:
         for i in range(scroll,
-                       min(scroll + matches_win.getmaxyx()[0], len(matches))):
+                       min(scroll + _height(matches_win), len(matches))):
 
             node = matches[i]
 
@@ -2236,6 +2325,7 @@ def _draw_jump_to_dialog(edit_box, matches_win, bot_sep_win, help_win,
     _safe_move(edit_box, 1, 1 + s_i - hscroll)
 
     edit_box.noutrefresh()
+
 
 def _info_dialog(node, from_jump_to_dialog):
     # Shows a fullscreen window with information about 'node'.
@@ -2321,6 +2411,7 @@ def _info_dialog(node, from_jump_to_dialog):
 
             return
 
+
 def _resize_info_dialog(top_line_win, text_win, bot_sep_win, help_win):
     # Resizes the info dialog to fill the terminal
 
@@ -2347,6 +2438,7 @@ def _resize_info_dialog(top_line_win, text_win, bot_sep_win, help_win):
 
         for win in text_win, bot_sep_win, help_win:
             win.mvwin(0, 0)
+
 
 def _draw_info_dialog(node, lines, scroll, top_line_win, text_win,
                       bot_sep_win, help_win):
@@ -2414,6 +2506,7 @@ def _draw_info_dialog(node, lines, scroll, top_line_win, text_win,
 
     top_line_win.noutrefresh()
 
+
 def _info_str(node):
     # Returns information about the menu node 'node' as a string.
     #
@@ -2453,11 +2546,13 @@ def _info_str(node):
     # node.item in (MENU, COMMENT)
     return _kconfig_def_info(node)
 
+
 def _name_info(sc):
     # Returns a string with the name of the symbol/choice. Names are optional
     # for choices.
 
     return "Name: {}\n".format(sc.name) if sc.name else ""
+
 
 def _prompt_info(sc):
     # Returns a string listing the prompts of 'sc' (Symbol or Choice)
@@ -2470,6 +2565,7 @@ def _prompt_info(sc):
 
     return s
 
+
 def _value_info(sym):
     # Returns a string showing 'sym's value
 
@@ -2478,6 +2574,7 @@ def _value_info(sym):
         '"{}"'.format(sym.str_value)
         if sym.orig_type == STRING
         else sym.str_value)
+
 
 def _choice_syms_info(choice):
     # Returns a string listing the choice symbols in 'choice'. Adds
@@ -2493,6 +2590,7 @@ def _choice_syms_info(choice):
 
     return s + "\n"
 
+
 def _help_info(sc):
     # Returns a string with the help text(s) of 'sc' (Symbol or Choice).
     # Symbols and choices defined in multiple locations can have multiple help
@@ -2507,18 +2605,18 @@ def _help_info(sc):
 
     return s
 
+
 def _direct_dep_info(sc):
     # Returns a string describing the direct dependencies of 'sc' (Symbol or
     # Choice). The direct dependencies are the OR of the dependencies from each
     # definition location. The dependencies at each definition location come
     # from 'depends on' and dependencies inherited from parent items.
 
-    if sc.direct_dep is _kconf.y:
-        return ""
+    return "" if sc.direct_dep is _kconf.y else \
+        'Direct dependencies (={}):\n{}\n' \
+        .format(TRI_TO_STR[expr_value(sc.direct_dep)],
+                _split_expr_info(sc.direct_dep, 2))
 
-    return 'Direct dependencies (={}):\n{}\n' \
-           .format(TRI_TO_STR[expr_value(sc.direct_dep)],
-                   _split_expr_info(sc.direct_dep, 2))
 
 def _defaults_info(sc):
     # Returns a string describing the defaults of 'sc' (Symbol or Choice)
@@ -2553,6 +2651,7 @@ def _defaults_info(sc):
 
     return s + "\n"
 
+
 def _split_expr_info(expr, indent):
     # Returns a string with 'expr' split into its top-level && or || operands,
     # with one operand per line, together with the operand's value. This is
@@ -2584,6 +2683,7 @@ def _split_expr_info(expr, indent):
 
     return s
 
+
 def _select_imply_info(sym):
     # Returns a string with information about which symbols 'select' or 'imply'
     # 'sym'. The selecting/implying symbols are grouped according to which
@@ -2596,7 +2696,6 @@ def _select_imply_info(sym):
 
         # sis = selects/implies
         sis = [si for si in split_expr(expr, OR) if expr_value(si) == val]
-
         if sis:
             s += title
             for si in sis:
@@ -2621,6 +2720,7 @@ def _select_imply_info(sym):
 
     return s
 
+
 def _kconfig_def_info(item):
     # Returns a string with the definition of 'item' in Kconfig syntax,
     # together with the definition location(s) and their include and menu paths
@@ -2644,6 +2744,7 @@ def _kconfig_def_info(item):
 
     return s
 
+
 def _include_path_info(node):
     if not node.include_path:
         # In the top-level Kconfig file
@@ -2653,21 +2754,23 @@ def _include_path_info(node):
         " -> ".join("{}:{}".format(filename, linenr)
                     for filename, linenr in node.include_path))
 
+
 def _menu_path_info(node):
     # Returns a string describing the menu path leading up to 'node'
 
     path = ""
 
-    node = _parent_menu(node)
-    while node is not _kconf.top_node:
+    while node.parent is not _kconf.top_node:
+        node = node.parent
+
         # Promptless choices might appear among the parents. Use
         # standard_sc_expr_str() for them, so that they show up as
         # '<choice (name if any)>'.
         path = " -> " + (node.prompt[0] if node.prompt else
                          standard_sc_expr_str(node.item)) + path
-        node = _parent_menu(node)
 
     return "(top menu)" + path
+
 
 def _name_and_val_str(sc):
     # Custom symbol/choice printer that shows symbol values after symbols
@@ -2686,9 +2789,11 @@ def _name_and_val_str(sc):
     # For other items, use the standard format
     return standard_sc_expr_str(sc)
 
+
 def _expr_str(expr):
     # Custom expression printer that shows symbol values
     return expr_str(expr, _name_and_val_str)
+
 
 def _styled_win(style):
     # Returns a new curses window with style 'style' and space as the fill
@@ -2699,17 +2804,20 @@ def _styled_win(style):
     _set_style(win, style)
     return win
 
+
 def _set_style(win, style):
     # Changes the style of an existing window
 
     win.bkgdset(" ", _style[style])
+
 
 def _max_scroll(lst, win):
     # Assuming 'lst' is a list of items to be displayed in 'win',
     # returns the maximum number of steps 'win' can be scrolled down.
     # We stop scrolling when the bottom item is visible.
 
-    return max(0, len(lst) - win.getmaxyx()[0])
+    return max(0, len(lst) - _height(win))
+
 
 def _edit_text(c, s, i, hscroll, width):
     # Implements text editing commands for edit boxes. Takes a character (which
@@ -2772,7 +2880,6 @@ def _edit_text(c, s, i, hscroll, width):
 
     elif isinstance(c, str):
         # Insert character
-
         s = s[:i] + c + s[i:]
         i += 1
 
@@ -2788,21 +2895,25 @@ def _edit_text(c, s, i, hscroll, width):
 
     return s, i, hscroll
 
+
 def _load_save_info():
     # Returns an information string for load/save dialog boxes
 
     return "(Relative to {})\n\nRefer to your home directory with ~" \
            .format(os.path.join(os.getcwd(), ""))
 
+
 def _msg(title, text):
     # Pops up a message dialog that can be dismissed with Space/Enter/ESC
 
     _key_dialog(title, text, " \n")
 
+
 def _error(text):
     # Pops up an error dialog that can be dismissed with Space/Enter/ESC
 
     _msg("Error", text)
+
 
 def _node_str(node):
     # Returns the complete menu entry text for a menu node.
@@ -2874,6 +2985,7 @@ def _node_str(node):
 
     return s
 
+
 def _should_show_name(node):
     # Returns True if 'node' is a symbol or choice whose name should shown (if
     # any, as names are optional for choices)
@@ -2882,6 +2994,7 @@ def _should_show_name(node):
     # symbols and choices
     return not node.prompt or \
            (_show_name and isinstance(node.item, (Symbol, Choice)))
+
 
 def _value_str(node):
     # Returns the value part ("[*]", "<M>", "(foo)" etc.) of a menu node
@@ -2917,13 +3030,15 @@ def _value_str(node):
         return "{{{}}}".format(tri_val_str)  # {M}/{*}
     return "<{}>".format(tri_val_str)
 
+
 def _is_y_mode_choice_sym(item):
     # The choice mode is an upper bound on the visibility of choice symbols, so
     # we can check the choice symbols' own visibility to see if the choice is
     # in y mode
     return isinstance(item, Symbol) and item.choice and item.visibility == 2
 
-def _check_validity(sym, s):
+
+def _check_valid(sym, s):
     # Returns True if the string 's' is a well-formed value for 'sym'.
     # Otherwise, displays an error and returns False.
 
@@ -2932,7 +3047,6 @@ def _check_validity(sym, s):
         return True
 
     base = 10 if sym.type == INT else 16
-
     try:
         int(s, base)
     except ValueError:
@@ -2956,6 +3070,7 @@ def _check_validity(sym, s):
 
     return True
 
+
 def _range_info(sym):
     # Returns a string with information about the valid range for the symbol
     # 'sym', or None if 'sym' doesn't have a range
@@ -2966,6 +3081,7 @@ def _range_info(sym):
                 return "Range: {}-{}".format(low.str_value, high.str_value)
 
     return None
+
 
 def _is_num(name):
     # Heuristic to see if a symbol name looks like a number, for nicer output
@@ -2985,14 +3101,15 @@ def _is_num(name):
 
     return True
 
+
 def _get_wch_compat(win):
     # Decent resizing behavior on PDCurses requires calling resize_term(0, 0)
-    # after receiving KEY_RESIZE, while NCURSES (usually) handles terminal
+    # after receiving KEY_RESIZE, while ncurses (usually) handles terminal
     # resizing automatically in get(_w)ch() (see the end of the
     # resizeterm(3NCURSES) man page).
     #
-    # resize_term(0, 0) reliably fails and does nothing on NCURSES, so this
-    # hack gives NCURSES/PDCurses compatibility for resizing. I don't know
+    # resize_term(0, 0) reliably fails and does nothing on ncurses, so this
+    # hack gives ncurses/PDCurses compatibility for resizing. I don't know
     # whether it would cause trouble for other implementations.
 
     c = win.get_wch()
@@ -3004,6 +3121,7 @@ def _get_wch_compat(win):
 
     return c
 
+
 def _warn(*args):
     # Temporarily returns from curses to shell mode and prints a warning to
     # stderr. The warning would get lost in curses mode.
@@ -3012,14 +3130,17 @@ def _warn(*args):
     print(*args, file=sys.stderr)
     curses.doupdate()
 
+
 # Ignore exceptions from some functions that might fail, e.g. for small
 # windows. They usually do reasonable things anyway.
+
 
 def _safe_curs_set(visibility):
     try:
         curses.curs_set(visibility)
     except curses.error:
         pass
+
 
 def _safe_addstr(win, *args):
     # Clip the line to avoid wrapping to the next line, which looks glitchy.
@@ -3037,7 +3158,7 @@ def _safe_addstr(win, *args):
         if len(args) == 4:
             attr = args[3]
 
-    maxlen = win.getmaxyx()[1] - x
+    maxlen = _width(win) - x
     s = s.expandtabs()
 
     try:
@@ -3051,11 +3172,13 @@ def _safe_addstr(win, *args):
     except curses.error:
         pass
 
+
 def _safe_addch(win, *args):
     try:
         win.addch(*args)
     except curses.error:
         pass
+
 
 def _safe_hline(win, *args):
     try:
@@ -3063,17 +3186,20 @@ def _safe_hline(win, *args):
     except curses.error:
         pass
 
+
 def _safe_vline(win, *args):
     try:
         win.vline(*args)
     except curses.error:
         pass
 
+
 def _safe_move(win, *args):
     try:
         win.move(*args)
     except curses.error:
         pass
+
 
 def _convert_c_lc_ctype_to_utf8():
     # See _CONVERT_C_LC_CTYPE_TO_UTF8
@@ -3084,7 +3210,7 @@ def _convert_c_lc_ctype_to_utf8():
         # supported from some quick testing either. Play it safe.
         return
 
-    def _try_set_locale(loc):
+    def try_set_locale(loc):
         try:
             locale.setlocale(locale.LC_CTYPE, loc)
             return True
@@ -3096,14 +3222,15 @@ def _convert_c_lc_ctype_to_utf8():
         # This list was taken from the PEP 538 implementation in the CPython
         # code, in Python/pylifecycle.c
         for loc in "C.UTF-8", "C.utf8", "UTF-8":
-            if _try_set_locale(loc):
+            if try_set_locale(loc):
                 print("Note: Your environment is configured to use ASCII. To "
                       "avoid Unicode issues, LC_CTYPE was changed from the "
                       "C locale to the {} locale.".format(loc))
                 break
 
+
 # Are we running on Windows?
-_IS_WINDOWS = (platform.system() == "Windows")
+_IS_WINDOWS = os.name == "nt"
 
 if __name__ == "__main__":
     _main()

--- a/soc/arm/atmel_sam0/Kconfig
+++ b/soc/arm/atmel_sam0/Kconfig
@@ -13,6 +13,7 @@ config SOC_FAMILY
 	string
 	default "atmel_sam0"
 
-source soc/arm/atmel_sam0/common/Kconfig.samd2x
+source "soc/arm/atmel_sam0/common/Kconfig.samd2x"
 source "soc/arm/atmel_sam0/*/Kconfig.soc"
+
 endif

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-menu Testing
+menu "Testing"
 
 source "subsys/testsuite/ztest/Kconfig"
 
@@ -104,4 +104,5 @@ config TEST_FLASH_DRIVERS
 	help
 	  This option will help test the flash drivers. This should be enabled
 	  only when using qemu_x86.
+
 endmenu


### PR DESCRIPTION
Fix some missing quotes that are only accepted for compatibility reasons, and add a warning afterwards.

Some minor optimizations and style consistency cleanups are included as well.

```
kconfig: Add missing quotes after 'source' and 'menu'

Missing quotes are accepted in some places for compatibility with the C
tools, e.g.

  source no/quotes/Kconfig
  menu Title

It looks broken though. Fix the two places in Zephyr that skip the
quotes. A style warning will be added.
```

```
kconfiglib/menuconfig: Various behavior/UI improvements

Update Kconfiglib and menuconfig to upstream revision 90c5573c19, to get
these commits in:

    Warn for unquoted argument to 'source', etc.

    Print a warning suggesting to add quotes for things like

      source foo/bar/Kconfig
      menu title
      prompt unquoted

    Example warning:

      Kconfig:32: warning: style: quotes recommended around
      'lib/Kconfig.debug' in 'source lib/Kconfig.debug'

    That quoteless syntax is supported for compatibility with old
    versions of the C tools. It only works for a single word.

    ==================================================================

    menuconfig: Include all parents in menu paths

    Previously, symbols not defined with 'menuconfig' with children
    weren't listed in the children's menu paths. It was deliberate, but
    it's probably an anti-feature in retrospect, because it can make it
    harder to find stuff by following the menu path.

    Don't try to be clever and just list all the parent nodes in the
    menu path.

    ==================================================================

    menuconfig: Fix display issue for optional-prompt menuconfigs

    _shown_nodes() needs to check whether invisible 'menuconfig' symbols
    with optional prompts have visible children, so that they can be
    shown outside show-all mode. Previously, only 'config' symbols were
    checked.

    ==================================================================

    menuconfig: Remember last saved/loaded path and improve
    _conf_changed

    Remember the last path that was manually saved/loaded instead of
    reverting back to standard_config_filename() (e.g. .config).

    Remember the path to the last saved minimal configuration separately
    as well.

    Also improve the _conf_changed behavior when loading a .config
    within the interface. Instead of always treating it as needing to be
    saved, check if it's outdated, like for the .config file loaded on
    startup.

    Also make the exit message ("No changes to save", etc.) always
    include the target .config file, which is helpful. Previously, only
    the save message did.
```