### PR TITLE
kconfig: Remove blank line at end of Kconfig file

### DIFF
--- a/soc/x86/intel_quark/quark_se/Kconfig.soc
+++ b/soc/x86/intel_quark/quark_se/Kconfig.soc
@@ -15,4 +15,3 @@ config SOC_QUARK_SE_CURIE
 	select HAS_SPI_DW
 
 endchoice
-


### PR DESCRIPTION
This one got away in
https://github.com/zephyrproject-rtos/zephyr/pull/14452. Didn't spot that
there were two blank lines.