### PR TITLE
net: Move the chksum offload verification to relevant places

### DIFF
--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -120,24 +120,23 @@ int net_ipv4_finalize(struct net_pkt *pkt, u8_t next_header_proto)
 	ipv4_hdr->len   = htons(net_pkt_get_len(pkt));
 	ipv4_hdr->proto = next_header_proto;
 
-	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt)) ||
-	    next_header_proto == IPPROTO_ICMP) {
+	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt))) {
 		ipv4_hdr->chksum = net_calc_chksum_ipv4(pkt);
-
-		net_pkt_set_data(pkt, &ipv4_access);
-
-		if (IS_ENABLED(CONFIG_NET_UDP) &&
-		    next_header_proto == IPPROTO_UDP) {
-			return net_udp_finalize(pkt);
-		} else if (IS_ENABLED(CONFIG_NET_TCP) &&
-			   next_header_proto == IPPROTO_TCP) {
-			return net_tcp_finalize(pkt);
-		} else if (next_header_proto == IPPROTO_ICMP) {
-			return net_icmpv4_finalize(pkt);
-		}
 	}
 
-	return net_pkt_set_data(pkt, &ipv4_access);
+	net_pkt_set_data(pkt, &ipv4_access);
+
+	if (IS_ENABLED(CONFIG_NET_UDP) &&
+	    next_header_proto == IPPROTO_UDP) {
+		return net_udp_finalize(pkt);
+	} else if (IS_ENABLED(CONFIG_NET_TCP) &&
+		   next_header_proto == IPPROTO_TCP) {
+		return net_tcp_finalize(pkt);
+	} else if (next_header_proto == IPPROTO_ICMP) {
+		return net_icmpv4_finalize(pkt);
+	}
+
+	return 0;
 }
 
 const struct in_addr *net_ipv4_unspecified_address(void)

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -162,17 +162,14 @@ int net_ipv6_finalize(struct net_pkt *pkt, u8_t next_header_proto)
 		return -ENOBUFS;
 	}
 
-	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt)) ||
-	    next_header_proto == IPPROTO_ICMPV6) {
-		if (IS_ENABLED(CONFIG_NET_UDP) &&
-		    next_header_proto == IPPROTO_UDP) {
-			return net_udp_finalize(pkt);
-		} else if (IS_ENABLED(CONFIG_NET_TCP) &&
-			   next_header_proto == IPPROTO_TCP) {
-			return net_tcp_finalize(pkt);
-		} else if (next_header_proto == IPPROTO_ICMPV6) {
-			return net_icmpv6_finalize(pkt);
-		}
+	if (IS_ENABLED(CONFIG_NET_UDP) &&
+	    next_header_proto == IPPROTO_UDP) {
+		return net_udp_finalize(pkt);
+	} else if (IS_ENABLED(CONFIG_NET_TCP) &&
+		   next_header_proto == IPPROTO_TCP) {
+		return net_tcp_finalize(pkt);
+	} else if (next_header_proto == IPPROTO_ICMPV6) {
+		return net_icmpv6_finalize(pkt);
 	}
 
 	return 0;

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1276,7 +1276,10 @@ int net_tcp_finalize(struct net_pkt *pkt)
 	}
 
 	tcp_hdr->chksum = 0;
-	tcp_hdr->chksum = net_calc_chksum_tcp(pkt);
+
+	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt))) {
+		tcp_hdr->chksum = net_calc_chksum_tcp(pkt);
+	}
 
 	return net_pkt_set_data(pkt, &tcp_access);
 }

--- a/subsys/net/ip/udp.c
+++ b/subsys/net/ip/udp.c
@@ -49,9 +49,11 @@ int net_udp_finalize(struct net_pkt *pkt)
 	length = net_pkt_get_len(pkt) -
 		net_pkt_ip_hdr_len(pkt) -
 		net_pkt_ipv6_ext_len(pkt);
+	udp_hdr->len = htons(length);
 
-	udp_hdr->len    = htons(length);
-	udp_hdr->chksum = net_calc_chksum_udp(pkt);
+	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt))) {
+		udp_hdr->chksum = net_calc_chksum_udp(pkt);
+	}
 
 	return net_pkt_set_data(pkt, &udp_access);
 }


### PR DESCRIPTION
Since the new packet flow came in, payload comes at the end so udp
length for instance is known only when we "finalize" the packet.
However such finalization was still under the condition of chksum
offload, like it used to be in the former flow (udp headers were
inserted). This is obviously wrong but that was not caugth with
existing driver in master as none of these offload chksum calculation.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>