### PR TITLE
Bluetooth: controller: Fix transaction collision

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -11346,7 +11346,12 @@ u8_t ll_enc_req_send(u16_t handle, u8_t *rand, u8_t *ediv, u8_t *ltk)
 		return BT_HCI_ERR_UNKNOWN_CONN_ID;
 	}
 
+#if defined(CONFIG_BT_CTLR_PHY)
+	if ((conn->llcp_req != conn->llcp_ack) ||
+	    (conn->llcp_phy.req != conn->llcp_phy.ack)) {
+#else /* CONFIG_BT_CTLR_PHY */
 	if (conn->llcp_req != conn->llcp_ack) {
+#endif /* CONFIG_BT_CTLR_PHY */
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 


### PR DESCRIPTION
Fixes: #14635

Peer side will disconnect if controller initiates
Encryption procedure before PHY update procedure
has finished.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>