### PR TITLE
Bluetooth: mesh: Fix net_id net_buf_pull in secure_beacon_recv

### DIFF
--- a/subsys/bluetooth/host/mesh/beacon.c
+++ b/subsys/bluetooth/host/mesh/beacon.c
@@ -283,7 +283,7 @@ static void secure_beacon_recv(struct net_buf_simple *buf)
 	data = buf->data;
 
 	flags = net_buf_simple_pull_u8(buf);
-	net_id = net_buf_simple_pull(buf, 8);
+	net_id = net_buf_simple_pull_mem(buf, 8);
 	iv_index = net_buf_simple_pull_be32(buf);
 	auth = buf->data;
 


### PR DESCRIPTION
This fixes usage of net_buf_simple_pull_mem to pull the net_id
from network buffer.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>