### PR TITLE
Fix tests/kernel/smp test and whitelist qemu_x86_64

### DIFF
--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -372,7 +372,7 @@ static void wakeup_on_start_thread(int tnum)
 	for (i = 0; i < tnum; i++) {
 		while (thread_started[i] == 0) {
 		}
-		while (!_is_thread_prevented_from_running(tinfo[i].tid)) {
+		while (!z_is_thread_prevented_from_running(tinfo[i].tid)) {
 		}
 	}
 

--- a/tests/kernel/smp/testcase.yaml
+++ b/tests/kernel/smp/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.multiprocessing:
-    platform_whitelist: esp32
+    platform_whitelist: esp32 qemu_x86_64


### PR DESCRIPTION
There was a missing 'z_' renaming to z_is_thread_prevented_from_running which would have caused sanitycheck to fail but it is not being built at the moment.

Also add `qemu_x86_64` to platform whitelist for the test so sanitycheck actually builds and tests it.
