### PR TITLE
IP: allow connections with src port == dst port

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -783,18 +783,7 @@ static bool is_invalid_packet(struct net_pkt *pkt,
 		}
 	}
 
-	/* For AF_PACKET family, we are not not parsing headers. */
-	if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
-	    net_pkt_family(pkt) == AF_PACKET) {
-		return false;
-	}
-
-	if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) &&
-	    net_pkt_family(pkt) == AF_CAN) {
-		return false;
-	}
-
-	return true;
+	return false;
 }
 
 enum net_verdict net_conn_input(struct net_pkt *pkt,


### PR DESCRIPTION
The rewrite of is_invalid_packet() in commit 1be2706a93f1 ("net/connection: Modify input function") changed the behavior for packets where the source and destination IP addresses differ but the source and destination ports are the same. The correct behavior is of course to accept these packets. An example where this is required is the zperf sample, which by default binds and connects to port 5001.

As those packets with source and destination IP address and port equal are ruled out early, the default return value can be changed to false. This also allows to drop the code for the AF_PACKET and AF_CAN packets, that returned false for all packets.