### PR TITLE
 drivers: gpio: Add support for daisy-chained irqs in mcux driver

### DIFF
--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -18,10 +18,12 @@ struct gpio_mcux_config {
 	GPIO_Type *gpio_base;
 	PORT_Type *port_base;
 	int (*irq_config_func)(struct device *dev);
+	char *daisy_name;
 	unsigned int flags;
 };
 
 struct gpio_mcux_data {
+	struct device *daisy_dev;
 	/* port ISR callback routine address */
 	sys_slist_t callbacks;
 	/* pin callback routine enable flags, by pin number */
@@ -225,11 +227,20 @@ static void gpio_mcux_port_isr(void *arg)
 
 	/* Clear the port interrupts */
 	config->port_base->ISFR = 0xFFFFFFFF;
+
+	if (data->daisy_dev) {
+		gpio_mcux_port_isr(data->daisy_dev);
+	}
 }
 
 static int gpio_mcux_init(struct device *dev)
 {
 	const struct gpio_mcux_config *config = dev->config->config_info;
+	struct gpio_mcux_data *data = dev->driver_data;
+
+	if (config->daisy_name) {
+		data->daisy_dev = device_get_binding(config->daisy_name);
+	}
 
 	config->irq_config_func(dev);
 
@@ -256,6 +267,9 @@ static const struct gpio_mcux_config gpio_mcux_porta_config = {
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
+#endif
+#ifdef DT_NXP_KINETIS_GPIO_GPIO_A_DAISY_GPIOS_CONTROLLER
+	.daisy_name = DT_NXP_KINETIS_GPIO_GPIO_A_DAISY_GPIOS_CONTROLLER,
 #endif
 };
 
@@ -291,6 +305,9 @@ static const struct gpio_mcux_config gpio_mcux_portb_config = {
 #else
 	.flags = 0,
 #endif
+#ifdef DT_NXP_KINETIS_GPIO_GPIO_B_DAISY_GPIOS_CONTROLLER
+	.daisy_name = DT_NXP_KINETIS_GPIO_GPIO_B_DAISY_GPIOS_CONTROLLER,
+#endif
 };
 
 static struct gpio_mcux_data gpio_mcux_portb_data;
@@ -324,6 +341,9 @@ static const struct gpio_mcux_config gpio_mcux_portc_config = {
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
+#endif
+#ifdef DT_NXP_KINETIS_GPIO_GPIO_C_DAISY_GPIOS_CONTROLLER
+	.daisy_name = DT_NXP_KINETIS_GPIO_GPIO_C_DAISY_GPIOS_CONTROLLER,
 #endif
 };
 
@@ -359,6 +379,9 @@ static const struct gpio_mcux_config gpio_mcux_portd_config = {
 #else
 	.flags = 0,
 #endif
+#ifdef DT_NXP_KINETIS_GPIO_GPIO_D_DAISY_GPIOS_CONTROLLER
+	.daisy_name = DT_NXP_KINETIS_GPIO_GPIO_D_DAISY_GPIOS_CONTROLLER,
+#endif
 };
 
 static struct gpio_mcux_data gpio_mcux_portd_data;
@@ -392,6 +415,9 @@ static const struct gpio_mcux_config gpio_mcux_porte_config = {
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
+#endif
+#ifdef DT_NXP_KINETIS_GPIO_GPIO_E_DAISY_GPIOS_CONTROLLER
+	.daisy_name = DT_NXP_KINETIS_GPIO_GPIO_E_DAISY_GPIOS_CONTROLLER,
 #endif
 };
 

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -17,6 +17,7 @@
 struct gpio_mcux_config {
 	GPIO_Type *gpio_base;
 	PORT_Type *port_base;
+	int (*irq_config_func)(struct device *dev);
 	unsigned int flags;
 };
 
@@ -226,6 +227,14 @@ static void gpio_mcux_port_isr(void *arg)
 	config->port_base->ISFR = 0xFFFFFFFF;
 }
 
+static int gpio_mcux_init(struct device *dev)
+{
+	const struct gpio_mcux_config *config = dev->config->config_info;
+
+	config->irq_config_func(dev);
+
+	return 0;
+}
 
 static const struct gpio_driver_api gpio_mcux_driver_api = {
 	.config = gpio_mcux_configure,
@@ -242,6 +251,7 @@ static int gpio_mcux_porta_init(struct device *dev);
 static const struct gpio_mcux_config gpio_mcux_porta_config = {
 	.gpio_base = (GPIO_Type *) DT_NXP_KINETIS_GPIO_GPIO_A_BASE_ADDRESS,
 	.port_base = PORTA,
+	.irq_config_func = gpio_mcux_porta_init,
 #ifdef DT_NXP_KINETIS_GPIO_GPIO_A_IRQ
 	.flags = GPIO_INT,
 #else
@@ -252,7 +262,7 @@ static const struct gpio_mcux_config gpio_mcux_porta_config = {
 static struct gpio_mcux_data gpio_mcux_porta_data;
 
 DEVICE_AND_API_INIT(gpio_mcux_porta, DT_NXP_KINETIS_GPIO_GPIO_A_LABEL,
-		    gpio_mcux_porta_init,
+		    gpio_mcux_init,
 		    &gpio_mcux_porta_data, &gpio_mcux_porta_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_mcux_driver_api);
@@ -275,6 +285,7 @@ static int gpio_mcux_portb_init(struct device *dev);
 static const struct gpio_mcux_config gpio_mcux_portb_config = {
 	.gpio_base = (GPIO_Type *) DT_NXP_KINETIS_GPIO_GPIO_B_BASE_ADDRESS,
 	.port_base = PORTB,
+	.irq_config_func = gpio_mcux_portb_init,
 #ifdef DT_NXP_KINETIS_GPIO_GPIO_B_IRQ
 	.flags = GPIO_INT,
 #else
@@ -285,7 +296,7 @@ static const struct gpio_mcux_config gpio_mcux_portb_config = {
 static struct gpio_mcux_data gpio_mcux_portb_data;
 
 DEVICE_AND_API_INIT(gpio_mcux_portb, DT_NXP_KINETIS_GPIO_GPIO_B_LABEL,
-		    gpio_mcux_portb_init,
+		    gpio_mcux_init,
 		    &gpio_mcux_portb_data, &gpio_mcux_portb_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_mcux_driver_api);
@@ -308,6 +319,7 @@ static int gpio_mcux_portc_init(struct device *dev);
 static const struct gpio_mcux_config gpio_mcux_portc_config = {
 	.gpio_base = (GPIO_Type *) DT_NXP_KINETIS_GPIO_GPIO_C_BASE_ADDRESS,
 	.port_base = PORTC,
+	.irq_config_func = gpio_mcux_portc_init,
 #ifdef DT_NXP_KINETIS_GPIO_GPIO_C_IRQ
 	.flags = GPIO_INT,
 #else
@@ -318,7 +330,7 @@ static const struct gpio_mcux_config gpio_mcux_portc_config = {
 static struct gpio_mcux_data gpio_mcux_portc_data;
 
 DEVICE_AND_API_INIT(gpio_mcux_portc, DT_NXP_KINETIS_GPIO_GPIO_C_LABEL,
-		    gpio_mcux_portc_init,
+		    gpio_mcux_init,
 		    &gpio_mcux_portc_data, &gpio_mcux_portc_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_mcux_driver_api);
@@ -341,6 +353,7 @@ static int gpio_mcux_portd_init(struct device *dev);
 static const struct gpio_mcux_config gpio_mcux_portd_config = {
 	.gpio_base = (GPIO_Type *) DT_NXP_KINETIS_GPIO_GPIO_D_BASE_ADDRESS,
 	.port_base = PORTD,
+	.irq_config_func = gpio_mcux_portd_init,
 #ifdef DT_NXP_KINETIS_GPIO_GPIO_D_IRQ
 	.flags = GPIO_INT,
 #else
@@ -351,7 +364,7 @@ static const struct gpio_mcux_config gpio_mcux_portd_config = {
 static struct gpio_mcux_data gpio_mcux_portd_data;
 
 DEVICE_AND_API_INIT(gpio_mcux_portd, DT_NXP_KINETIS_GPIO_GPIO_D_LABEL,
-		    gpio_mcux_portd_init,
+		    gpio_mcux_init,
 		    &gpio_mcux_portd_data, &gpio_mcux_portd_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_mcux_driver_api);
@@ -374,6 +387,7 @@ static int gpio_mcux_porte_init(struct device *dev);
 static const struct gpio_mcux_config gpio_mcux_porte_config = {
 	.gpio_base = (GPIO_Type *) DT_NXP_KINETIS_GPIO_GPIO_E_BASE_ADDRESS,
 	.port_base = PORTE,
+	.irq_config_func = gpio_mcux_porte_init,
 #ifdef DT_NXP_KINETIS_GPIO_GPIO_E_IRQ
 	.flags = GPIO_INT,
 #else
@@ -384,7 +398,7 @@ static const struct gpio_mcux_config gpio_mcux_porte_config = {
 static struct gpio_mcux_data gpio_mcux_porte_data;
 
 DEVICE_AND_API_INIT(gpio_mcux_porte, DT_NXP_KINETIS_GPIO_GPIO_E_LABEL,
-		    gpio_mcux_porte_init,
+		    gpio_mcux_init,
 		    &gpio_mcux_porte_data, &gpio_mcux_porte_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_mcux_driver_api);

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -170,7 +170,6 @@
 		gpiob: gpio@400ff040 {
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff040 0x40>;
-			interrupts = <31 2>;
 			label = "GPIO_2";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -180,6 +179,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff080 0x40>;
 			interrupts = <31 2>;
+			daisy-gpios = <&gpiob 0 0>;
 			label = "GPIO_3";
 			gpio-controller;
 			#gpio-cells = <2>;

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -173,7 +173,6 @@
 		gpiob: gpio@400ff040 {
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff040 0x40>;
-			interrupts = <31 2>;
 			label = "GPIO_1";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -183,6 +182,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff080 0x40>;
 			interrupts = <31 2>;
+			daisy-gpios = <&gpiob 0 0>;
 			label = "GPIO_2";
 			gpio-controller;
 			#gpio-cells = <2>;

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -25,6 +25,11 @@ properties:
       description: required interrupts
       generation: define
 
+    daisy-gpios:
+      type: compound
+      category: optional
+      generation: define, use-prop-name
+
     label:
       type: string
       category: required


### PR DESCRIPTION
Typically we manage driver irqs on a per-instance basis, however the
kw40z and kw41z have a shared irq vector for portb and portc instances.
Adds a new optional device tree binding and driver support to allow
daisy chaining the mcux gpio irq handlers together.

Fixes #13122