### PR TITLE
Fix sample_basic_disco no LED blinking issue.

### DIFF
--- a/samples/basic/disco/prj.conf
+++ b/samples/basic/disco/prj.conf
@@ -1,1 +1,1 @@
-# nothing here
+CONFIG_GPIO=y

--- a/samples/basic/disco/sample.yaml
+++ b/samples/basic/disco/sample.yaml
@@ -4,4 +4,5 @@ tests:
   test:
     filter: DT_GPIO_LEDS_LED0_GPIO_CONTROLLER and DT_GPIO_LEDS_LED1_GPIO_CONTROLLER
     tags: LED gpio
+    depends_on: gpio
     harness: led


### PR DESCRIPTION
This sample did not enable gpio driver, so nothing happens after flash it into a board. 
By enabling gpio driver to fix it.