### PR TITLE
DFU: progresive image erase

### DIFF
--- a/include/dfu/flash_img.h
+++ b/include/dfu/flash_img.h
@@ -19,6 +19,9 @@ struct flash_img_context {
 	const struct flash_area *flash_area;
 	size_t bytes_written;
 	u16_t buf_bytes;
+#ifdef CONFIG_IMG_ERASE_PROGRESSIVELY
+	off_t off_last;
+#endif
 };
 
 /**

--- a/include/dfu/mcuboot.h
+++ b/include/dfu/mcuboot.h
@@ -30,6 +30,13 @@
 
 #define BOOT_IMG_VER_STRLEN_MAX 25  /* 255.255.65535.4294967295\0 */
 
+/* Trailer: */
+#define BOOT_MAX_ALIGN		8
+#define BOOT_MAGIC_SZ		16
+
+#define BOOT_TRAILER_IMG_STATUS_OFFS(bank_area) ((bank_area)->fa_size -\
+						  BOOT_MAGIC_SZ -\
+						  BOOT_MAX_ALIGN * 2)
 /**
  * @brief MCUboot image header representation for image version
  *

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -41,6 +41,16 @@ config IMG_BLOCK_BUF_SIZE
 	  Size (in Bytes) of buffer for image writer. Must be a multiple of
 	  the access alignment required by used flash driver.
 
+config 	IMG_ERASE_PROGRESSIVELY
+	bool "Erase flash progressively when receiving new firmware"
+	depends on MCUBOOT_IMG_MANAGER
+	select FLASH_PAGE_LAYOUT
+	help
+	 If enabled, flash is erased as necessary when receiving new firmware,
+	 instead of erasing the whole image slot at once. This is necessary
+	 on some hardware that has long erase times, to prevent long wait
+	 times at the beginning of the DFU process.
+
 module = IMG_MANAGER
 module-str = image manager
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -32,8 +32,6 @@
 #define BOOT_HEADER_SIZE_V1 32
 
 /* Trailer: */
-#define BOOT_MAX_ALIGN 8
-#define BOOT_MAGIC_SZ  16
 #define BOOT_FLAG_SET 0x01
 #define BOOT_FLAG_UNSET 0xff
 

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -731,11 +731,17 @@ static void dfu_work_handler(struct k_work *item)
 
 	switch (dfu_data_worker.worker_state) {
 	case dfuIDLE:
+/*
+ * If progressive erase is enabled, then erase take place while
+ * image collection, so not erase whole bank at DFU beginning
+ */
+#ifndef CONFIG_IMG_ERASE_PROGRESSIVELY
 		if (boot_erase_img_bank(DT_FLASH_AREA_IMAGE_1_ID)) {
 			dfu_data.state = dfuERROR;
 			dfu_data.status = errERASE;
 			break;
 		}
+#endif
 	case dfuDNLOAD_IDLE:
 		dfu_flash_write(dfu_data_worker.buf,
 				dfu_data_worker.worker_len);


### PR DESCRIPTION
Patch adds option for progressive erase of firmware image.
Using this flash is erased as necessary when receiving
new firmware, instead of erasing the whole image slot at once.
This is necessary on some hardware that has long erase times,
to prevent long wait times at the beginning of the DFU process.

usb/class/usb_dfu: support progressive image erase

Disable bulk slot image erase when progressive erase is on.
Erase of image bank is performed by image collection procedure
progressively.

For some SoC like nRF52840 bulk erase take too much time, which
cause timeout on tool on existing system out-of-the-box (dfu-util
or just by downloading package from sourceforge for Windows).

~~resolves #8734~~