### PR TITLE
arch: arc: make the boot time more accurate

### DIFF
--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -49,7 +49,16 @@ SECTION_FUNC(TEXT,__start)
 	 */
 	mov r0, 0
 	kflag r0
-
+#if defined(CONFIG_BOOT_TIME_MEASUREMENT) && defined(CONFIG_ARCV2_TIMER)
+	/*
+	 * ARCV2 timer (timer0) is a free run timer, let it start to count
+	 * here.
+	 */
+	mov r0, 0xffffffff
+	sr r0, [_ARC_V2_TMR0_LIMIT]
+	mov r0, 0
+	sr r0, [_ARC_V2_TMR0_COUNT]
+#endif
 	/* interrupt related init */
 	sr r0, [_ARC_V2_AUX_IRQ_ACT]
 	sr r0, [_ARC_V2_AUX_IRQ_CTRL]

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -167,6 +167,9 @@ int z_clock_driver_init(struct device *device)
 		    _timer_int_handler, NULL, 0);
 
 	timer0_limit_register_set(last_load - 1);
+#ifdef CONFIG_BOOT_TIME_MEASUREMENT
+	cycle_count = timer0_count_register_get();
+#endif
 	timer0_count_register_set(0);
 	timer0_control_register_set(_ARC_V2_TMR_CTRL_NH | _ARC_V2_TMR_CTRL_IE);
 


### PR DESCRIPTION
* start timer0 when cpu runs at __start
* add an offset to cycle_count

fixes #3198

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>