### PR TITLE
net/context: Unlock the context while allocating a net_pkt

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1926,9 +1926,10 @@ NET_CONN_CB(tcp_established)
 		 * ack # value can/should be sent, so we just force resend.
 		 */
 resend_ack:
+		k_mutex_unlock(&context->lock);
 		send_ack(context, &conn->remote_addr, true);
-		ret = NET_DROP;
-		goto unlock;
+
+		return NET_DROP;
 	}
 
 	if (net_tcp_seq_cmp(sys_get_be32(tcp_hdr->seq),


### PR DESCRIPTION
But reference it once more to make sure it will not disappear during
packet allocation.

That way, the lock is not going to be held during net_pkt allocation.

Fixes #14571

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>