### PR TITLE
net/ipv6: Set the right protocol when finalizing MLD packet

### DIFF
--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -117,7 +117,7 @@ static int mld_create_packet(struct net_pkt *pkt, u16_t count)
 		return -ENOBUFS;
 	}
 
-	net_pkt_set_ipv6_next_hdr(pkt, IPPROTO_ICMPV6);
+	net_pkt_set_ipv6_next_hdr(pkt, NET_IPV6_NEXTHDR_HBHO);
 
 	return 0;
 }
@@ -125,7 +125,7 @@ static int mld_create_packet(struct net_pkt *pkt, u16_t count)
 static int mld_send(struct net_pkt *pkt)
 {
 	net_pkt_cursor_init(pkt);
-	net_ipv6_finalize(pkt, NET_IPV6_NEXTHDR_HBHO);
+	net_ipv6_finalize(pkt, IPPROTO_ICMPV6);
 
 	if (net_send_data(pkt) < 0) {
 		net_stats_update_icmp_drop(net_pkt_iface(pkt));


### PR DESCRIPTION
IPv6 next header might be something else (here NET_IPV6_NEXTHDR_HBHO)
but when finalizing it is mandatory to give the actual last header
protocol type. In this case IPPROTO_ICMPV6, so the checksum can be
computed properly then by net_icmpv6_finalize() called from
net_ipv6_finalize().

Fixes #14663

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>