### PR TITLE
Bluetooth: controller: Convert benign BT_WARN() messages to BT_DBG()

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2596,8 +2596,8 @@ static void le_adv_ext_report(struct pdu_data *pdu_data, u8_t *b,
 	rssi = -b[offsetof(struct node_rx_pdu, pdu) +
 		  offsetof(struct pdu_adv, payload) + adv->len];
 
-	BT_WARN("phy= 0x%x, type= 0x%x, len= %u, tat= %u, rat= %u, rssi=%d dB",
-		phy, adv->type, adv->len, adv->tx_addr, adv->rx_addr, rssi);
+	BT_DBG("phy= 0x%x, type= 0x%x, len= %u, tat= %u, rat= %u, rssi=%d dB",
+	       phy, adv->type, adv->len, adv->tx_addr, adv->rx_addr, rssi);
 
 	if ((adv->type == PDU_ADV_TYPE_EXT_IND) && adv->len) {
 		struct pdu_adv_com_ext_adv *p;
@@ -2608,8 +2608,8 @@ static void le_adv_ext_report(struct pdu_data *pdu_data, u8_t *b,
 		h = (void *)p->ext_hdr_adi_adv_data;
 		ptr = (u8_t *)h + sizeof(*h);
 
-		BT_WARN("Ext. adv mode= 0x%x, hdr len= %u", p->adv_mode,
-			p->ext_hdr_len);
+		BT_DBG("Ext. adv mode= 0x%x, hdr len= %u", p->adv_mode,
+		       p->ext_hdr_len);
 
 		if (!p->ext_hdr_len) {
 			goto no_ext_hdr;
@@ -2625,7 +2625,7 @@ static void le_adv_ext_report(struct pdu_data *pdu_data, u8_t *b,
 
 			bt_addr_le_to_str(&addr, addr_str, sizeof(addr_str));
 
-			BT_WARN("AdvA: %s", addr_str);
+			BT_DBG("AdvA: %s", addr_str);
 
 		}
 
@@ -2635,7 +2635,7 @@ static void le_adv_ext_report(struct pdu_data *pdu_data, u8_t *b,
 			tx_pwr = *(s8_t *)ptr;
 			ptr++;
 
-			BT_WARN("Tx pwr= %d dB", tx_pwr);
+			BT_DBG("Tx pwr= %d dB", tx_pwr);
 		}
 
 		/* TODO: length check? */
@@ -2685,8 +2685,8 @@ static void le_scan_req_received(struct pdu_data *pdu_data, u8_t *b,
 
 		bt_addr_le_to_str(&addr, addr_str, sizeof(addr_str));
 
-		BT_WARN("handle: %d, addr: %s, rssi: %d dB.",
-			handle, addr_str, rssi);
+		BT_DBG("handle: %d, addr: %s, rssi: %d dB.",
+		       handle, addr_str, rssi);
 
 		return;
 	}
@@ -2886,7 +2886,7 @@ static void le_chan_sel_algo(struct pdu_data *pdu_data, u16_t handle,
 
 	if (!(event_mask & BT_EVT_MASK_LE_META_EVENT) ||
 	    !(le_event_mask & BT_EVT_MASK_LE_CHAN_SEL_ALGO)) {
-		BT_WARN("handle: 0x%04x, CSA: %x.", handle, cs->csa);
+		BT_DBG("handle: 0x%04x, CSA: %x.", handle, cs->csa);
 		return;
 	}
 


### PR DESCRIPTION
BT_WARN() should only be used for log messages that may indicate a
problem. However, the controller HCI code was using it for messages
that were of a pure debugging/informational nature. Convert these to
BT_DBG() instead - this should hopefully also help avoid unnecessary
user questions of seemingly alarming log messages.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>