### PR TITLE
Bluetooth: Mesh: Increase advertising thread stack size

### DIFF
--- a/subsys/bluetooth/host/mesh/adv.c
+++ b/subsys/bluetooth/host/mesh/adv.c
@@ -45,7 +45,11 @@
 #define ADV_INT_DEFAULT_MS 100
 #define ADV_INT_FAST_MS    20
 
+#if defined(CONFIG_BT_HOST_CRYPTO)
+#define ADV_STACK_SIZE 1024
+#else
 #define ADV_STACK_SIZE 768
+#endif
 
 static K_FIFO_DEFINE(adv_queue);
 static struct k_thread adv_thread_data;


### PR DESCRIPTION
With BT_HOST_CRYPTO, advertising stack size could be overflowed,
increase size to 1024 when BT_HOST_CRYPTO is enabled.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>