### PR TITLE
kernel/sched: Flag DEAD on correct thread in cross-CPU abort

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1030,7 +1030,7 @@ void z_sched_abort(struct k_thread *thread)
 	while ((thread->base.thread_state & _THREAD_DEAD) == 0) {
 		LOCKED(&sched_spinlock) {
 			if (z_is_thread_queued(thread)) {
-				_current->base.thread_state |= _THREAD_DEAD;
+				thread->base.thread_state |= _THREAD_DEAD;
 				_priq_run_remove(&_kernel.ready_q.runq, thread);
 				z_mark_thread_as_not_queued(thread);
 			}


### PR DESCRIPTION
Daniel Leung caught a good one: In the (SMP) case where we were
aborting a thread that was not currently scheduled, we were flagging
the DEAD state on _current and not the thread we were aborting!  This
wasn't as fatal as it seems, as the thread that called z_sched_abort()
would effectively go on living (as a zombie?) in a state where it
would always be preempted, but would otherwise remain scheduleable.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>