### PR TITLE
ARC: fix issue with k_thread_create() handler checks for stack size

### DIFF
--- a/include/arch/arc/arch.h
+++ b/include/arch/arc/arch.h
@@ -81,6 +81,9 @@ extern "C" {
 
 #if defined(CONFIG_USERSPACE)
 
+#define Z_ARCH_THREAD_STACK_RESERVED \
+	(STACK_GUARD_SIZE + CONFIG_PRIVILEGED_STACK_SIZE)
+
 #if CONFIG_ARC_MPU_VER == 2
 
 #define Z_ARCH_THREAD_STACK_DEFINE(sym, size) \
@@ -133,6 +136,8 @@ extern "C" {
 		((char *)(sym))
 
 #else /* CONFIG_USERSPACE */
+
+#define Z_ARCH_THREAD_STACK_RESERVED STACK_GUARD_SIZE
 
 #define Z_ARCH_THREAD_STACK_DEFINE(sym, size) \
 	struct _k_thread_stack_element __noinit __aligned(STACK_ALIGN) \

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -120,26 +120,6 @@ extern "C" {
 		1 << (31 - __builtin_clz(x) + 1) : \
 		1 << (31 - __builtin_clz(x)))
 
-/**
- * @brief Declare a top level thread stack memory region
- *
- * This declares a region of memory suitable for use as a thread's stack.
- *
- * This is the generic, historical definition. Align to STACK_ALIGN_SIZE and
- * put in * 'noinit' section so that it isn't zeroed at boot
- *
- * The declared symbol will always be a character array which can be passed to
- * k_thread_create, but should otherwise not be manipulated.
- *
- * It is legal to precede this definition with the 'static' keyword.
- *
- * It is NOT legal to take the sizeof(sym) and pass that to the stackSize
- * parameter of k_thread_create(), it may not be the same as the
- * 'size' parameter. Use K_THREAD_STACK_SIZEOF() instead.
- *
- * @param sym Thread stack symbol name
- * @param size Size of the stack memory region
- */
 #if defined(CONFIG_USERSPACE) && \
 	defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
 #define Z_ARCH_THREAD_STACK_DEFINE(sym, size) \
@@ -151,16 +131,6 @@ extern "C" {
 		sym[size+MPU_GUARD_ALIGN_AND_SIZE]
 #endif
 
-/**
- * @brief Calculate size of stacks to be allocated in a stack array
- *
- * This macro calculates the size to be allocated for the stacks
- * inside a stack array. It accepts the indicated "size" as a parameter
- * and if required, pads some extra bytes (e.g. for MPU scenarios). Refer
- * K_THREAD_STACK_ARRAY_DEFINE definition to see how this is used.
- *
- * @param size Size of the stack memory region
- */
 #if defined(CONFIG_USERSPACE) && \
 	defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
 #define Z_ARCH_THREAD_STACK_LEN(size) (POW2_CEIL(size))
@@ -168,19 +138,6 @@ extern "C" {
 #define Z_ARCH_THREAD_STACK_LEN(size) ((size)+MPU_GUARD_ALIGN_AND_SIZE)
 #endif
 
-/**
- * @brief Declare a top level array of thread stack memory regions
- *
- * Create an array of equally sized stacks. See K_THREAD_STACK_DEFINE
- * definition for additional details and constraints.
- *
- * This is the generic, historical definition. Align to STACK_ALIGN_SIZE and
- * put in * 'noinit' section so that it isn't zeroed at boot
- *
- * @param sym Thread stack symbol name
- * @param nmemb Number of stacks to declare
- * @param size Size of the stack memory region
- */
 #if defined(CONFIG_USERSPACE) && \
 	defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
 #define Z_ARCH_THREAD_STACK_ARRAY_DEFINE(sym, nmemb, size) \
@@ -194,18 +151,6 @@ extern "C" {
 		sym[nmemb][Z_ARCH_THREAD_STACK_LEN(size)]
 #endif
 
-/**
- * @brief Declare an embedded stack memory region
- *
- * Used for stacks embedded within other data structures. Use is highly
- * discouraged but in some cases necessary. For memory protection scenarios,
- * it is very important that any RAM preceding this member not be writable
- * by threads else a stack overflow will lead to silent corruption. In other
- * words, the containing data structure should live in RAM owned by the kernel.
- *
- * @param sym Thread stack symbol name
- * @param size Size of the stack memory region
- */
 #if defined(CONFIG_USERSPACE) && \
 	defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
 #define Z_ARCH_THREAD_STACK_MEMBER(sym, size) \
@@ -217,42 +162,8 @@ extern "C" {
 		sym[size+MPU_GUARD_ALIGN_AND_SIZE]
 #endif
 
-/**
- * @brief Return the size in bytes of a stack memory region
- *
- * Convenience macro for passing the desired stack size to k_thread_create()
- * since the underlying implementation may actually create something larger
- * (for instance a guard area).
- *
- * The value returned here is guaranteed to match the size of the stack that
- * is available for the thread, i.e. excluding the size of areas that are not
- * to be used (for instance the guard area).
- *
- * The value returned here is NOT guaranteed to match the 'size' parameter
- * passed to K_THREAD_STACK_DEFINE and related macros.
- *
- * In the case of CONFIG_USERSPACE=y and
- * CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT=y, the returned size will be
- * smaller than the requested 'size'.
- *
- * In all other configurations, the size will be correct.
- *
- * @param sym Stack memory symbol
- * @return Actual size of the stack available for the thread
- */
 #define Z_ARCH_THREAD_STACK_SIZEOF(sym) (sizeof(sym) - MPU_GUARD_ALIGN_AND_SIZE)
 
-/**
- * @brief Get a pointer to the physical stack buffer
- *
- * Convenience macro to get at the real underlying stack buffer used by
- * the CPU. Guaranteed to be a character pointer of size K_THREAD_STACK_SIZEOF.
- * This is really only intended for diagnostic tools which want to examine
- * stack memory contents.
- *
- * @param sym Declared stack symbol name
- * @return The buffer itself, a char *
- */
 #define Z_ARCH_THREAD_STACK_BUFFER(sym) \
 		((char *)(sym) + MPU_GUARD_ALIGN_AND_SIZE)
 

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -122,6 +122,16 @@ extern "C" {
 
 #if defined(CONFIG_USERSPACE) && \
 	defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
+/* Guard is 'carved-out' of the thread stack region, and the supervisor
+ * mode stack is allocated elsewhere by gen_priv_stack.py
+ */
+#define Z_ARCH_THREAD_STACK_RESERVED 0
+#else
+#define Z_ARCH_THREAD_STACK_RESERVED MPU_GUARD_ALIGN_AND_SIZE
+#endif
+
+#if defined(CONFIG_USERSPACE) && \
+	defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
 #define Z_ARCH_THREAD_STACK_DEFINE(sym, size) \
 	struct _k_thread_stack_element __noinit \
 		__aligned(POW2_CEIL(size)) sym[POW2_CEIL(size)]

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -582,17 +582,17 @@ extern struct task_state_segment _main_tss;
  * to the top of it.
  * All context switches will save/restore the esp0 field in the TSS.
  */
-#define _STACK_GUARD_SIZE	(MMU_PAGE_SIZE * 2)
+#define Z_ARCH_THREAD_STACK_RESERVED	(MMU_PAGE_SIZE * 2)
 #define _STACK_BASE_ALIGN	MMU_PAGE_SIZE
 #elif defined(CONFIG_HW_STACK_PROTECTION) || defined(CONFIG_USERSPACE)
 /* If only one of HW stack protection or userspace is enabled, then the
  * stack will be preceded by one page which is a guard page or a kernel mode
  * stack, respectively.
  */
-#define _STACK_GUARD_SIZE	MMU_PAGE_SIZE
+#define Z_ARCH_THREAD_STACK_RESERVED	MMU_PAGE_SIZE
 #define _STACK_BASE_ALIGN	MMU_PAGE_SIZE
 #else /* Neither feature */
-#define _STACK_GUARD_SIZE	0
+#define Z_ARCH_THREAD_STACK_RESERVED	0
 #define _STACK_BASE_ALIGN	STACK_ALIGN
 #endif
 
@@ -609,12 +609,12 @@ extern struct task_state_segment _main_tss;
 #define Z_ARCH_THREAD_STACK_DEFINE(sym, size) \
 	struct _k_thread_stack_element __noinit \
 		__aligned(_STACK_BASE_ALIGN) \
-		sym[ROUND_UP((size), _STACK_SIZE_ALIGN) + _STACK_GUARD_SIZE]
+		sym[ROUND_UP((size), _STACK_SIZE_ALIGN) + Z_ARCH_THREAD_STACK_RESERVED]
 
 #define Z_ARCH_THREAD_STACK_LEN(size) \
 		(ROUND_UP((size), \
 			  MAX(_STACK_BASE_ALIGN, _STACK_SIZE_ALIGN)) + \
-		_STACK_GUARD_SIZE)
+		Z_ARCH_THREAD_STACK_RESERVED)
 
 #define Z_ARCH_THREAD_STACK_ARRAY_DEFINE(sym, nmemb, size) \
 	struct _k_thread_stack_element __noinit \
@@ -623,13 +623,13 @@ extern struct task_state_segment _main_tss;
 
 #define Z_ARCH_THREAD_STACK_MEMBER(sym, size) \
 	struct _k_thread_stack_element __aligned(_STACK_BASE_ALIGN) \
-		sym[ROUND_UP((size), _STACK_SIZE_ALIGN) + _STACK_GUARD_SIZE]
+		sym[ROUND_UP((size), _STACK_SIZE_ALIGN) + Z_ARCH_THREAD_STACK_RESERVED]
 
 #define Z_ARCH_THREAD_STACK_SIZEOF(sym) \
-	(sizeof(sym) - _STACK_GUARD_SIZE)
+	(sizeof(sym) - Z_ARCH_THREAD_STACK_RESERVED)
 
 #define Z_ARCH_THREAD_STACK_BUFFER(sym) \
-	((char *)((sym) + _STACK_GUARD_SIZE))
+	((char *)((sym) + Z_ARCH_THREAD_STACK_RESERVED))
 
 #if CONFIG_X86_KERNEL_OOPS
 #define Z_ARCH_EXCEPT(reason_p) do { \

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4580,6 +4580,7 @@ extern void z_timer_expiration_handler(struct _timeout *t);
 #define K_THREAD_STACK_LEN(size) Z_ARCH_THREAD_STACK_LEN(size)
 #define K_THREAD_STACK_MEMBER(sym, size) Z_ARCH_THREAD_STACK_MEMBER(sym, size)
 #define K_THREAD_STACK_SIZEOF(sym) Z_ARCH_THREAD_STACK_SIZEOF(sym)
+#define K_THREAD_STACK_RESERVED Z_ARCH_THREAD_STACK_RESERVED
 static inline char *K_THREAD_STACK_BUFFER(k_thread_stack_t *sym)
 {
 	return Z_ARCH_THREAD_STACK_BUFFER(sym);
@@ -4676,6 +4677,18 @@ static inline char *K_THREAD_STACK_BUFFER(k_thread_stack_t *sym)
  * @req K-TSTACK-001
  */
 #define K_THREAD_STACK_SIZEOF(sym) sizeof(sym)
+
+
+/**
+ * @brief Indicate how much additional memory is reserved for stack objects
+ *
+ * Any given stack declaration may have additional memory in it for guard
+ * areas or supervisor mode stacks. This macro indicates how much space
+ * is reserved for this. The memory reserved may not be contiguous within
+ * the stack object, and does not account for additional space used due to
+ * enforce alignment.
+ */
+#define K_THREAD_STACK_RESERVED		0
 
 /**
  * @brief Get a pointer to the physical stack buffer

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -475,7 +475,9 @@ Z_SYSCALL_HANDLER(k_thread_create,
 				    "stack size overflow (%u+%u)", stack_size,
 				    K_THREAD_STACK_RESERVED));
 
-	/* They really ought to be equal, make this more strict? */
+	/* Testing less-than-or-equal since additional room may have been
+	 * allocated for alignment constraints
+	 */
 	Z_OOPS(Z_SYSCALL_VERIFY_MSG(total_size <= stack_object->data,
 				    "stack size %u is too big, max is %u",
 				    total_size, stack_object->data));


### PR DESCRIPTION
We were not accounting for the privileged stack area reserved, which is at the end of the stack buffer on this arch.

Fixes: #14643 