### PR TITLE
scripts/dts: Remove unused variables and imports

### DIFF
--- a/scripts/dts/devicetree.py
+++ b/scripts/dts/devicetree.py
@@ -197,13 +197,13 @@ def parse_file(fd, ignore_dts_version=False):
             continue
 
         if line.startswith('/include/ '):
-            tag, filename = line.split()
+            _, filename = line.split()
             with open(filename.strip()[1:-1], "r") as new_fd:
                 nodes.update(parse_file(new_fd, True))
         elif line == '/dts-v1/;':
             has_v1_tag = True
         elif line.startswith('/memreserve/ ') and line.endswith(';'):
-            tag, start, end = line.split()
+            _, start, end = line.split()
             start = int(start, 16)
             end = int(end[:-1], 16)
             label = "reserved_memory_0x%x_0x%x" % (start, end)
@@ -238,7 +238,7 @@ def dump_refs(name, value, indent=0):
 
 def dump_all_refs(name, props, indent=0):
     out = []
-    for key, value in props.items():
+    for value in props.values():
         out.extend(dump_refs(name, value, indent))
     return out
 
@@ -260,15 +260,16 @@ def dump_to_dot(nodes, indent=0, start_string='digraph devicetree', name=None):
         print("%s\"%s\";" % (spaces, name))
 
     ref_list = []
-    for key, value in nodes.items():
-        if value['children']:
-            refs = dump_to_dot(value['children'], indent + 1, next_subgraph(), get_dot_node_name(value))
+    for node in nodes.values():
+        if node['children']:
+            refs = dump_to_dot(node['children'], indent + 1, next_subgraph(),
+                               get_dot_node_name(node))
             ref_list.extend(refs)
         else:
-            print("%s\"%s\";" % (spaces, get_dot_node_name(value)))
+            print("%s\"%s\";" % (spaces, get_dot_node_name(node)))
 
-    for key, value in nodes.items():
-        refs = dump_all_refs(get_dot_node_name(value), value['props'], indent)
+    for node in nodes.values():
+        refs = dump_all_refs(get_dot_node_name(node), node['props'], indent)
         ref_list.extend(refs)
 
     if start_string.startswith("digraph"):

--- a/scripts/dts/extract/clocks.py
+++ b/scripts/dts/extract/clocks.py
@@ -16,8 +16,6 @@ from extract.directive import DTDirective
 #
 class DTClocks(DTDirective):
     def _extract_consumer(self, node_path, clocks, def_label):
-
-        clock_consumer = reduced[node_path]
         clock_consumer_bindings = get_binding(node_path)
         clock_consumer_label = 'DT_' + node_label(node_path)
 
@@ -39,7 +37,6 @@ class DTClocks(DTDirective):
                 clock_provider = reduced[clock_provider_node_path]
                 clock_provider_bindings = get_binding(
                                             clock_provider_node_path)
-                clock_provider_label = node_label(clock_provider_node_path)
                 nr_clock_cells = int(clock_provider['props'].get(
                                      '#clock-cells', 0))
                 clock_cells_string = clock_provider_bindings.get(

--- a/scripts/dts/extract/compatible.py
+++ b/scripts/dts/extract/compatible.py
@@ -31,7 +31,7 @@ class DTCompatible(DTDirective):
         if not isinstance(compatible, list):
             compatible = [compatible, ]
 
-        for i, comp in enumerate(compatible):
+        for comp in compatible:
             # Generate #define
             insert_defs(node_path,
                         {'DT_COMPAT_' + str_to_label(comp): '1'},

--- a/scripts/dts/extract/flash.py
+++ b/scripts/dts/extract/flash.py
@@ -8,7 +8,6 @@ from extract.globals import *
 from extract.directive import DTDirective
 
 from extract.default import default
-from extract.reg import reg
 
 ##
 # @brief Manage flash directives.
@@ -159,7 +158,6 @@ class DTFlash(DTDirective):
             node_path = get_parent_path(node_path)
             (nr_address_cells, nr_size_cells) = get_addr_size_cells(node_path)
 
-        node_compat = get_compat(node_path)
         reg = reduced[node_path]['props']['reg']
         if type(reg) is not list: reg = [ reg, ]
         props = list(reg)

--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -23,8 +23,6 @@ class DTReg(DTDirective):
     #                  compatible definition.
     #
     def extract(self, node_path, names, def_label, div):
-        node = reduced[node_path]
-        node_compat = get_compat(node_path)
         binding = get_binding(node_path)
 
         reg = reduced[node_path]['props']['reg']

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -8,13 +8,11 @@
 
 # vim: ai:ts=4:sw=4
 
-import sys
 import os, fnmatch
 import re
 import yaml
 import argparse
 from collections import defaultdict
-from collections.abc import Mapping
 
 from devicetree import parse_file
 from extract.globals import *
@@ -149,7 +147,7 @@ def generate_bus_defines(node_path):
     try:
         parent_binding = get_binding(parent_path)
         parent_bus = parent_binding['child']['bus']
-    except (KeyError, TypeError) as e:
+    except (KeyError, TypeError):
         raise Exception("{0} defines parent {1} as bus master, but {1} is not "
                         "configured as bus master in binding"
                         .format(node_path, parent_path))
@@ -202,7 +200,7 @@ def merge_properties(parent, fname, to_dict, from_dict):
     # implement !include. 'parent' is the current parent key being looked at.
     # 'fname' is the top-level .yaml file.
 
-    for k, v in from_dict.items():
+    for k in from_dict:
         if (k in to_dict and isinstance(to_dict[k], dict)
                          and isinstance(from_dict[k], dict)):
             merge_properties(k, fname, to_dict[k], from_dict[k])
@@ -392,7 +390,7 @@ def find_binding_files(binding_dirs):
     binding_files = []
 
     for binding_dir in binding_dirs:
-        for root, dirnames, filenames in os.walk(binding_dir):
+        for root, _, filenames in os.walk(binding_dir):
             for filename in fnmatch.filter(filenames, '*.yaml'):
                 binding_files.append(os.path.join(root, filename))
 


### PR DESCRIPTION
Discovered with pylint3.

Use the placeholder name `_` for unproblematic unused variables. It's
what I'm used to, and pylint knows not to flag it.

Also improve the naming a bit in `devicetree.py`. If a key/value is known
to be a specific thing (like a node), then it's helpful to call it that
instead of something generic like "value".