### PR TITLE
scripts: Remove unused variables and imports from all Python scripts

### DIFF
--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -223,7 +223,6 @@ def main():
     intlist = read_intlist(args.intlist)
     nvec = intlist["num_vectors"]
     offset = intlist["offset"]
-    prefix = endian_prefix()
 
     spurious_handler = "&z_irq_spurious"
     sw_irq_handler   = "ISR_WRAPPER"

--- a/arch/x86/gen_mmu_x86.py
+++ b/arch/x86/gen_mmu_x86.py
@@ -394,7 +394,7 @@ class PageMode_PAE:
                 self.output_offset += struct.calcsize(page_entry_format)
 
     def page_table_create_binary_file(self):
-        for pdpte, pde_info in sorted(self.list_of_pdpte.items()):
+        for _, pde_info in sorted(self.list_of_pdpte.items()):
             for pde, pte_info in sorted(pde_info.pd_entries.items()):
                 pe_info = pte_info.page_entries_info[0]
                 start_addr = pe_info.start_addr & ~0x1FFFFF

--- a/arch/x86/gen_mmu_x86.py
+++ b/arch/x86/gen_mmu_x86.py
@@ -42,11 +42,9 @@ from reading their contents.
 import os
 import sys
 import struct
-import parser
 from collections import namedtuple
 import ctypes
 import argparse
-import re
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 

--- a/arch/xtensa/core/xtensa_intgen.py
+++ b/arch/xtensa/core/xtensa_intgen.py
@@ -29,8 +29,7 @@ def cprint(s):
         return
     if s.find("}") >= 0:
         cindent -= 1
-    for xx in range(cindent):
-        s = "\t" + s
+    s = cindent*"\t" + s
     print(s)
     if s.find("{") >= 0:
         cindent += 1

--- a/boards/xtensa/intel_s1000_crb/support/create_board_img.py
+++ b/boards/xtensa/intel_s1000_crb/support/create_board_img.py
@@ -188,9 +188,8 @@ def main():
     ipc_load_fw(SRAM_SIZE, FLASH_PART_TABLE_OFFSET)
 
     # pad zeros until FLASH_PART_TABLE_OFFSET
-    num_zero_pad = (FLASH_PART_TABLE_OFFSET / 4) - len(flash_content)
-    for x in range(int(num_zero_pad)):
-        flash_content.append(0)
+    num_zero_pad = FLASH_PART_TABLE_OFFSET // 4 - len(flash_content)
+    flash_content += num_zero_pad * [0]
 
     # read contents of firmware input file and change the endianness
     with open(args.in_file, "rb") as in_fp:
@@ -203,8 +202,7 @@ def main():
             write_buf.append(read_buf[itr*4 + 0])
 
         # pad zeros until the sector boundary
-        for x in range(zeropad_size):
-            write_buf.append(0)
+        write_buf += zeropad_size*[0]
 
     # Generate the file which should be downloaded to Flash
     with open(args.out_file, "wb") as out_fp:

--- a/doc/extensions/local_util.py
+++ b/doc/extensions/local_util.py
@@ -57,7 +57,7 @@ def copy_if_modified(src_path, dst_path):
         return
 
     src_path_len = len(src_path)
-    for root, dirs, files in os.walk(src_path):
+    for root, _, files in os.walk(src_path):
         for src_file_name in files:
             src_file_path = os.path.join(root, src_file_name)
             dst_file_path = os.path.join(dst_path + root[src_path_len:], src_file_name)

--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -164,7 +164,6 @@ class ZephyrAppCommandsDirective(Directive):
                                                 if v != 'all']
         # Build the command content as a list, then convert to string.
         content = []
-        lit = []
         cd_to = zephyr_app or app
         tool_comment = None
         if len(tools) > 1:
@@ -336,7 +335,6 @@ class ZephyrAppCommandsDirective(Directive):
         zephyr_app = kwargs['zephyr_app']
         host_os = kwargs['host_os']
         build_dir = kwargs['build_dir']
-        source_dir = kwargs['source_dir']
         skip_config = kwargs['skip_config']
         compact = kwargs['compact']
         generator = kwargs['generator']

--- a/doc/extensions/zephyr/link-roles.py
+++ b/doc/extensions/zephyr/link-roles.py
@@ -7,7 +7,6 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 import re
-import os
 from docutils import nodes
 from local_util import run_cmd_get_output
 

--- a/ext/hal/nxp/mcux/scripts/import_mcux_sdk.py
+++ b/ext/hal/nxp/mcux/scripts/import_mcux_sdk.py
@@ -65,7 +65,7 @@ def import_sdk(directory):
 
         device_src = os.path.join(directory, 'devices', device)
         device_pattern = "|".join([device, 'fsl_device_registers'])
-        [device_headers, ignore] = get_files(device_src, device_pattern)
+        device_headers, _ = get_files(device_src, device_pattern)
 
         drivers_src = os.path.join(directory, 'devices', device, 'drivers')
         drivers_pattern = "fsl_clock|fsl_iomuxc"
@@ -73,7 +73,7 @@ def import_sdk(directory):
 
         xip_boot_src = os.path.join(directory, 'devices', device, 'xip')
         xip_boot_pattern = ".*"
-        [xip_boot, ignore] = get_files(xip_boot_src, xip_boot_pattern)
+        xip_boot, _ = get_files(xip_boot_src, xip_boot_pattern)
 
         print('Importing {} device headers to {}'.format(device, device_dst))
         copy_files(device_headers, device_dst)
@@ -93,7 +93,7 @@ def import_sdk(directory):
 
         xip_config_src = os.path.join(board_src, 'xip')
         xip_config_pattern = ".*"
-        [xip_config, ignore] = get_files(xip_config_src, xip_config_pattern)
+        xip_config, _ = get_files(xip_config_src, xip_config_pattern)
 
         print('Importing {} xip config to {}'.format(board, board_dst))
         copy_files(xip_config, board_dst)

--- a/ext/lib/ipc/open-amp/open-amp/docs/img-src/gen-graph.py
+++ b/ext/lib/ipc/open-amp/open-amp/docs/img-src/gen-graph.py
@@ -1,4 +1,3 @@
-from graphviz import Digraph
 import argparse
 import os
 import pydot

--- a/samples/net/google_iot_mqtt/src/private_info/create_keys.py
+++ b/samples/net/google_iot_mqtt/src/private_info/create_keys.py
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import sys
-import os
-import re
 import subprocess
 import argparse
 

--- a/scripts/ci/get_modified_boards.py
+++ b/scripts/ci/get_modified_boards.py
@@ -3,9 +3,7 @@
 # A script to generate a list of boards that have changed or added and create an
 # arguemnts file for sanitycheck to allow running more tests for those boards.
 
-import sys
 import re, os
-from email.utils import parseaddr
 import sh
 import logging
 import argparse

--- a/scripts/ci/get_modified_tests.py
+++ b/scripts/ci/get_modified_tests.py
@@ -3,9 +3,7 @@
 # A script to generate a list of tests that have changed or added and create an
 # arguemnts file for sanitycheck to allow running those tests with --all
 
-import sys
-import re, os
-from email.utils import parseaddr
+import os
 import sh
 import logging
 import argparse

--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -385,7 +385,7 @@ class ElfHelper:
 
         # Step 1: collect all type information.
         for CU in di.iter_CUs():
-            for idx, die in enumerate(CU.iter_DIEs()):
+            for die in CU.iter_DIEs():
                 # Unions are disregarded, kernel objects should never be union
                 # members since the memory is not dedicated to that object and
                 # could be something else

--- a/scripts/filter-known-issues.py
+++ b/scripts/filter-known-issues.py
@@ -89,7 +89,7 @@ def config_import_path(path):
     """
     file_regex = re.compile(".*\.conf$")
     try:
-        for dirpath, dirnames, filenames in os.walk(path):
+        for dirpath, _, filenames in os.walk(path):
             for _filename in sorted(filenames):
                 filename = os.path.join(dirpath, _filename)
                 if not file_regex.search(_filename):

--- a/scripts/gen_app_partitions.py
+++ b/scripts/gen_app_partitions.py
@@ -36,13 +36,9 @@ import sys
 import argparse
 import os
 import re
-import string
-import subprocess
 from collections import OrderedDict
-from elf_helper import ElfHelper
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
-from operator import itemgetter
 
 SZ = 'size'
 SRC = 'sources'

--- a/scripts/gen_app_partitions.py
+++ b/scripts/gen_app_partitions.py
@@ -129,7 +129,7 @@ def find_obj_file_partitions(filename, partitions):
 
 def parse_obj_files(partitions):
     # Iterate over all object files to find partitions
-    for dirpath, dirs, files in os.walk(args.directory):
+    for dirpath, _, files in os.walk(args.directory):
         for filename in files:
             if re.match(".*\.obj$",filename):
                 fullname = os.path.join(dirpath, filename)
@@ -144,7 +144,7 @@ def parse_elf_file(partitions):
                        if isinstance(s, SymbolTableSection)]
 
         for section in symbol_tbls:
-            for nsym, symbol in enumerate(section.iter_symbols()):
+            for symbol in section.iter_symbols():
                 if symbol['st_shndx'] != "SHN_ABS":
                     continue
 
@@ -207,7 +207,6 @@ def parse_args():
 
 def main():
     parse_args()
-    linker_file = args.output
     partitions = {}
 
     if args.directory is not None:

--- a/scripts/gen_priv_stacks.py
+++ b/scripts/gen_priv_stacks.py
@@ -79,14 +79,14 @@ def write_gperf_table(fp, eh, objs):
     # priv stack declarations
     fp.write("%{\n")
     fp.write(includes)
-    for obj_addr, ko in objs.items():
+    for obj_addr in objs:
         fp.write(priv_stack_decl_temp % (obj_addr))
     fp.write("%}\n")
 
     # structure declaration
     fp.write(structure)
 
-    for obj_addr, ko in objs.items():
+    for obj_addr in objs:
         byte_str = struct.pack("<I" if eh.little_endian else ">I", obj_addr)
         fp.write("\"")
         for byte in byte_str:

--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -292,7 +292,7 @@ def get_obj_filename(searchpath, filename):
     # get the object file name which is almost always pended with .obj
     obj_filename = filename.split("/")[-1] + ".obj"
 
-    for dirpath, dirs, files in os.walk(searchpath):
+    for dirpath, _, files in os.walk(searchpath):
         for filename1 in files:
             if filename1 == obj_filename:
                 if filename.split("/")[-2] in dirpath.split("/")[-1]:

--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -11,8 +11,8 @@ While every LineRule can be implemented as a CommitRule, it's usually easier and
 that fits your needs.
 """
 
-from gitlint.rules import CommitRule, RuleViolation, TitleRegexMatches, CommitMessageTitle, LineRule, CommitMessageBody
-from gitlint.options import IntOption, BoolOption, StrOption, ListOption
+from gitlint.rules import CommitRule, RuleViolation, CommitMessageTitle, LineRule, CommitMessageBody
+from gitlint.options import IntOption, StrOption
 import re
 
 class BodyMinLineCount(CommitRule):

--- a/scripts/kconfig/checkconfig.py
+++ b/scripts/kconfig/checkconfig.py
@@ -104,7 +104,7 @@ def search_config_in_file(tree, items, completelog, exclude):
             fname.endswith(".S")):
                 with open(os.path.join(dirName, fname), "r", encoding="utf-8", errors="ignore") as f:
                     searchConf = f.readlines()
-                for i, line in enumerate(searchConf):
+                for line in searchConf:
                     if re.search('(^|[\s|(])CONFIG_([a-zA-Z0-9_]+)', line) :
                         configName = re.search('(^|[\s|(])'
                                                +'CONFIG_([a-zA-Z0-9_]+)', line)

--- a/scripts/mergehex.py
+++ b/scripts/mergehex.py
@@ -26,7 +26,7 @@ def merge_hex_files(output, input_hex_files):
 
         try:
             ih.merge(to_merge)
-        except AddressOverlapError as e:
+        except AddressOverlapError:
             raise AddressOverlapError("{} has merge issues".format(hex_file_path))
 
         print("Merged {}".format(hex_file_path))

--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -56,7 +56,7 @@ class Console(Harness):
                 if self.ordered:
                     ordered = True
                     pos = 0
-                    for k,v in self.matches.items():
+                    for k in self.matches:
                         if k != self.regex[pos]:
                             ordered = False
                         pos += 1

--- a/scripts/sanity_chk/scl.py
+++ b/scripts/sanity_chk/scl.py
@@ -6,7 +6,6 @@
 # Zephyr's sanity check testcases.
 
 import logging
-import os
 import yaml
 
 log = logging.getLogger("scl")

--- a/scripts/support/quartus-flash.py
+++ b/scripts/support/quartus-flash.py
@@ -6,7 +6,6 @@ import argparse
 import os
 import string
 import sys
-import shutil
 
 quartus_cpf_template = """<?xml version="1.0" encoding="US-ASCII" standalone="yes"?>
 <cof>

--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -4,10 +4,9 @@
 
 '''bossac-specific runner (flash only) for Atmel SAM microcontrollers.'''
 
-import os
 import platform
 
-from runners.core import ZephyrBinaryRunner, RunnerCaps, BuildConfiguration
+from runners.core import ZephyrBinaryRunner, RunnerCaps
 
 DEFAULT_BOSSAC_PORT = '/dev/ttyACM0'
 

--- a/scripts/west_commands/tests/test_build.py
+++ b/scripts/west_commands/tests/test_build.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from argparse import Namespace
-from unittest.mock import patch
 
 from build import Build
 import pytest

--- a/scripts/yaml_to_cmake.py
+++ b/scripts/yaml_to_cmake.py
@@ -9,7 +9,6 @@ pairs to use within a CMake build file.
 '''
 
 import argparse
-import sys
 import yaml
 import pykwalify.core
 


### PR DESCRIPTION
```
scripts: Remove unused variables in all Python scripts

Discovered with pylint3.

Use the placeholder name '_' for unproblematic unused variables. It's
what I'm used to, and pylint knows not to flag it.

Python tip:

    for i in range(n):
        some_list.append(0)

can be replaced with

    some_list += n*[0]

Similarly, 3*'\t' gives '\t\t\t'.

(Relevant here because pylint flagged the loop index as unused.)

To do integer division in Python 3, use // instead of /.
```

```
scripts: Remove unused imports in all Python scripts

Upstream open-amp PR: https://github.com/OpenAMP/open-amp/pull/168
    
Discovered with pylint3.
```