### PR TITLE
Samples: echo-client: Add overlay when echo-server is running on Linux

### DIFF
--- a/samples/net/sockets/echo_client/README.rst
+++ b/samples/net/sockets/echo_client/README.rst
@@ -110,6 +110,7 @@ Run echo-client application in QEMU:
    :zephyr-app: samples/net/sockets/echo_client
    :host-os: unix
    :board: qemu_x86
+   :conf: "prj.conf overlay-linux.conf"
    :goals: run
    :compact:
 

--- a/samples/net/sockets/echo_client/overlay-linux.conf
+++ b/samples/net/sockets/echo_client/overlay-linux.conf
@@ -1,0 +1,6 @@
+# Include this overlay when the echo-server is running on Linux and
+# echo-client is running on Qemu.
+CONFIG_NET_CONFIG_MY_IPV6_ADDR="2001:db8::1"
+CONFIG_NET_CONFIG_PEER_IPV6_ADDR="2001:db8::2"
+CONFIG_NET_CONFIG_MY_IPV4_ADDR="192.0.2.1"
+CONFIG_NET_CONFIG_PEER_IPV4_ADDR="192.0.2.2"


### PR DESCRIPTION
This patch adds the overlay when the echo-server is running on Linux and
echo-client is running on Qemu.

Fix: #14654

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>