### PR TITLE
arc: fix build error when MPU guards are enabled

### DIFF
--- a/arch/arc/core/mpu/arc_mpu_v3_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v3_internal.h
@@ -389,7 +389,7 @@ void arc_core_mpu_configure_thread(struct k_thread *thread)
 	_mpu_reset_dynamic_regions();
 #if defined(CONFIG_MPU_STACK_GUARD)
 #if defined(CONFIG_USERSPACE)
-	if ((thread->thread_base.user_options & K_USER) != 0) {
+	if ((thread->base.user_options & K_USER) != 0) {
 		/* the areas before and after the user stack of thread is
 		 * kernel only. These area can be used as stack guard.
 		 * -----------------------


### PR DESCRIPTION
Incorrect member name of struct k_thread.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>