### PR TITLE
subsys: console: deprecate console_register_line_input()

### DIFF
--- a/include/console.h
+++ b/include/console.h
@@ -120,7 +120,7 @@ char *console_getline(void);
  *         in the application code.
  *  @param completion callback for tab completion of entered commands
  */
-void console_register_line_input(struct k_fifo *avail_queue,
+__deprecated void console_register_line_input(struct k_fifo *avail_queue,
 				 struct k_fifo *out_queue,
 				 u8_t (*completion)(char *str, u8_t len));
 


### PR DESCRIPTION
console_register_line_input() is a legacy function which forces console subsystem to keep dependency on drivers/console. The two console implementations are meant to be independent.

Console subsystem provides console_getline() function, which should be used instead.

Console subsystem is still marked as experimental. If we decided to remove the function rather than deprecate a more extensive clean up would be possible. E.g. we could remove Kconfig dependencies on CONSOLE_HANDLER, UART_CONSOLE_DEBUG_SERVER_HOOKS.