### PR TITLE
USB: Fix warning in DFU class

### DIFF
--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -748,7 +748,9 @@ static void dfu_work_handler(struct k_work *item)
 
 static int usb_dfu_init(struct device *dev)
 {
+#ifndef CONFIG_USB_COMPOSITE_DEVICE
 	int ret;
+#endif
 
 	ARG_UNUSED(dev);
 


### PR DESCRIPTION
Move unused variable to scope where it is used.

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>