### PR TITLE
Bluetooth: Mesh: Fix various storage clearing related issues

### DIFF
--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -1210,28 +1210,36 @@ static u8_t va_del(u8_t *label_uuid, u16_t *addr)
 	return STATUS_CANNOT_REMOVE;
 }
 
-static void mod_sub_list_clear(struct bt_mesh_model *mod)
+static size_t mod_sub_list_clear(struct bt_mesh_model *mod)
 {
 	u8_t *label_uuid;
+	size_t clear_count;
 	int i;
 
 	/* Unref stored labels related to this model */
-	for (i = 0; i < ARRAY_SIZE(mod->groups); i++) {
+	for (i = 0, clear_count = 0; i < ARRAY_SIZE(mod->groups); i++) {
 		if (!BT_MESH_ADDR_IS_VIRTUAL(mod->groups[i])) {
+			if (mod->groups[i] != BT_MESH_ADDR_UNASSIGNED) {
+				mod->groups[i] = BT_MESH_ADDR_UNASSIGNED;
+				clear_count++;
+			}
+
 			continue;
 		}
 
 		label_uuid = bt_mesh_label_uuid_get(mod->groups[i]);
-		if (!label_uuid) {
-			BT_ERR("Label UUID not found");
-			continue;
-		}
 
-		va_del(label_uuid, NULL);
+		mod->groups[i] = BT_MESH_ADDR_UNASSIGNED;
+		clear_count++;
+
+		if (label_uuid) {
+			va_del(label_uuid, NULL);
+		} else {
+			BT_ERR("Label UUID not found");
+		}
 	}
 
-	/* Clear all subscriptions (0x0000 is the unassigned address) */
-	(void)memset(mod->groups, 0, sizeof(mod->groups));
+	return clear_count;
 }
 
 static void mod_pub_va_set(struct bt_mesh_model *model,
@@ -1300,10 +1308,20 @@ send_status:
 			    status, mod_id);
 }
 #else
-static void mod_sub_list_clear(struct bt_mesh_model *mod)
+static size_t mod_sub_list_clear(struct bt_mesh_model *mod)
 {
-	/* Clear all subscriptions (0x0000 is the unassigned address) */
-	(void)memset(mod->groups, 0, sizeof(mod->groups));
+	size_t clear_count;
+	int i;
+
+	/* Unref stored labels related to this model */
+	for (i = 0, clear_count = 0; i < ARRAY_SIZE(mod->groups); i++) {
+		if (mod->groups[i] != BT_MESH_ADDR_UNASSIGNED) {
+			mod->groups[i] = BT_MESH_ADDR_UNASSIGNED;
+			clear_count++;
+		}
+	}
+
+	return clear_count;
 }
 
 static void mod_pub_va_set(struct bt_mesh_model *model,
@@ -3315,15 +3333,17 @@ int bt_mesh_cfg_srv_init(struct bt_mesh_model *model, bool primary)
 static void mod_reset(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 		      bool vnd, bool primary, void *user_data)
 {
+	size_t clear_count;
+
 	/* Clear model state that isn't otherwise cleared. E.g. AppKey
 	 * binding and model publication is cleared as a consequence
 	 * of removing all app keys, however model subscription clearing
 	 * must be taken care of here.
 	 */
 
-	mod_sub_list_clear(mod);
+	clear_count = mod_sub_list_clear(mod);
 
-	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+	if (IS_ENABLED(CONFIG_BT_SETTINGS) && clear_count) {
 		bt_mesh_store_mod_sub(mod);
 	}
 }

--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -1428,6 +1428,7 @@ static void mod_sub_add(struct bt_mesh_model *model,
 
 	if (bt_mesh_model_find_group(mod, sub_addr)) {
 		/* Tried to add existing subscription */
+		BT_DBG("found existing subscription");
 		status = STATUS_SUCCESS;
 		goto send_status;
 	}
@@ -3331,6 +3332,8 @@ void bt_mesh_cfg_reset(void)
 {
 	struct bt_mesh_cfg_srv *cfg = conf;
 	int i;
+
+	BT_DBG("");
 
 	if (!cfg) {
 		return;

--- a/subsys/bluetooth/host/mesh/settings.c
+++ b/subsys/bluetooth/host/mesh/settings.c
@@ -439,7 +439,6 @@ static int hb_pub_set(int argc, char **argv, void *val_ctx)
 	}
 
 	if (settings_val_get_len_cb(val_ctx) == 0) {
-		BT_DBG("val (null)");
 		pub->dst = BT_MESH_ADDR_UNASSIGNED;
 		pub->count = 0;
 		pub->ttl = 0;
@@ -483,7 +482,6 @@ static int cfg_set(int argc, char **argv, void *val_ctx)
 	}
 
 	if (settings_val_get_len_cb(val_ctx) == 0) {
-		BT_DBG("val (null)");
 		stored_cfg.valid = false;
 		BT_DBG("Cleared configuration state");
 		return 0;
@@ -512,7 +510,6 @@ static int mod_set_bind(struct bt_mesh_model *mod, void *val_ctx)
 	}
 
 	if (settings_val_get_len_cb(val_ctx) == 0) {
-		BT_DBG("val (null)");
 		BT_DBG("Cleared bindings for model");
 		return 0;
 	}
@@ -536,7 +533,6 @@ static int mod_set_sub(struct bt_mesh_model *mod, void *val_ctx)
 	(void)memset(mod->groups, 0, sizeof(mod->groups));
 
 	if (settings_val_get_len_cb(val_ctx) == 0) {
-		BT_DBG("val (null)");
 		BT_DBG("Cleared subscriptions for model");
 		return 0;
 	}
@@ -563,7 +559,6 @@ static int mod_set_pub(struct bt_mesh_model *mod, void *val_ctx)
 	}
 
 	if (settings_val_get_len_cb(val_ctx) == 0) {
-		BT_DBG("val (null)");
 		mod->pub->addr = BT_MESH_ADDR_UNASSIGNED;
 		mod->pub->key = 0;
 		mod->pub->cred = 0;

--- a/subsys/bluetooth/host/mesh/settings.c
+++ b/subsys/bluetooth/host/mesh/settings.c
@@ -1185,6 +1185,8 @@ static void store_pending_mod_bind(struct bt_mesh_model *mod, bool vnd)
 	u16_t keys[CONFIG_BT_MESH_MODEL_KEY_COUNT];
 	char path[20];
 	int i, count, err;
+	size_t len;
+	void *val;
 
 	for (i = 0, count = 0; i < ARRAY_SIZE(mod->keys); i++) {
 		if (mod->keys[i] != BT_MESH_KEY_UNUSED) {
@@ -1193,9 +1195,17 @@ static void store_pending_mod_bind(struct bt_mesh_model *mod, bool vnd)
 		}
 	}
 
+	if (count) {
+		val = keys;
+		len = count * sizeof(keys[0]);
+	} else {
+		val = NULL;
+		len = 0;
+	}
+
 	encode_mod_path(mod, vnd, "bind", path, sizeof(path));
 
-	err = settings_save_one(path, keys, count * sizeof(keys[0]));
+	err = settings_save_one(path, val, len);
 	if (err) {
 		BT_ERR("Failed to store %s value", log_strdup(path));
 	} else {
@@ -1208,6 +1218,8 @@ static void store_pending_mod_sub(struct bt_mesh_model *mod, bool vnd)
 	u16_t groups[CONFIG_BT_MESH_MODEL_GROUP_COUNT];
 	char path[20];
 	int i, count, err;
+	size_t len;
+	void *val;
 
 	for (i = 0, count = 0; i < ARRAY_SIZE(mod->groups); i++) {
 		if (mod->groups[i] != BT_MESH_ADDR_UNASSIGNED) {
@@ -1215,9 +1227,17 @@ static void store_pending_mod_sub(struct bt_mesh_model *mod, bool vnd)
 		}
 	}
 
+	if (count) {
+		val = groups;
+		len = count * sizeof(groups[0]);
+	} else {
+		val = NULL;
+		len = 0;
+	}
+
 	encode_mod_path(mod, vnd, "sub", path, sizeof(path));
 
-	err = settings_save_one(path, groups, count * sizeof(groups[0]));
+	err = settings_save_one(path, val, len);
 	if (err) {
 		BT_ERR("Failed to store %s value", log_strdup(path));
 	} else {


### PR DESCRIPTION
There were several things broken with the clearing of mesh storage, both with redundant "cleared" entries being stored as well as a failure to store proper "cleared" entries for model subscriptions and bindings. This set of patches fixes these things, and also cleans up a bit related logging (which was necessary for successful debugging of this issue).

Fixes #12574