### PR TITLE
subsys: net: lib: lwm2m_engine: add error number report

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3905,7 +3905,7 @@ static void socket_receive_loop(void)
 		 * FIXME: Currently we timeout and restart poll in case fds
 		 *        were modified.
 		 */
-		if (poll(sock_fds, sock_nfds, ENGINE_UPDATE_INTERVAL) < 0) {
+		if ((errno = poll(sock_fds, sock_nfds, ENGINE_UPDATE_INTERVAL)) < 0) {
 			LOG_ERR("Error in poll:%d", errno);
 			errno = 0;
 			k_sleep(ENGINE_UPDATE_INTERVAL);


### PR DESCRIPTION
'errno' is currently always reported as 0 when poll fails, it should
be the error number that poll returns.

Signed-off-by: Song Qiang <songqiang1304521@gmail.com>