### PR TITLE
Bluetooth: Use bt_addr_le_copy() instead of direct assignment

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -5316,7 +5316,8 @@ int bt_le_adv_start_internal(const struct bt_le_adv_param *param,
 			} else {
 				set_param.type = BT_LE_ADV_DIRECT_IND;
 			}
-			set_param.direct_addr = *peer;
+
+			bt_addr_le_copy(&set_param.direct_addr, peer);
 		} else {
 			set_param.type = BT_LE_ADV_IND;
 		}


### PR DESCRIPTION
The convention in the code is to use the appropriate address copying
functions instead of direct assignments. Even when a specific copying
function doesn't exist the convention is to use memcpy.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>