### PR TITLE
net: context: Check if we run out of mem

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1598,8 +1598,9 @@ static struct net_pkt *context_alloc_pkt(struct net_context *context,
 					net_context_get_family(context),
 					net_context_get_ip_proto(context),
 					timeout);
-
-	net_pkt_set_context(pkt, context);
+	if (pkt) {
+		net_pkt_set_context(pkt, context);
+	}
 
 	return pkt;
 }


### PR DESCRIPTION
The context_alloc_pkt() might run out of memory, and if that
happens we must not try to set the context pointer in it.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>