### PR TITLE
Networking zperf fixes

### DIFF
--- a/samples/net/zperf/README.rst
+++ b/samples/net/zperf/README.rst
@@ -12,7 +12,14 @@ evaluate network bandwidth.
 Features
 *********
 
-- Compatible with iPerf_2.0.5.
+- Compatible with iPerf_2.0.9. Note that UDP uploader (client) testing did
+  not work properly in iPerf_2.0.13: an error message like this is printed
+  and the server reported statistics are missing.
+
+.. code-block:: console
+
+   LAST PACKET NOT RECEIVED!!!
+
 - Client or server mode allowed without need to modify the source code.
 
 Supported Boards

--- a/samples/net/zperf/src/zperf_internal.h
+++ b/samples/net/zperf/src/zperf_internal.h
@@ -69,6 +69,15 @@ struct zperf_udp_datagram {
 	u32_t tv_usec;
 };
 
+struct zperf_client_hdr_v1 {
+	s32_t flags;
+	s32_t num_of_threads;
+	s32_t port;
+	s32_t buffer_len;
+	s32_t bandwidth;
+	s32_t num_of_bytes;
+};
+
 struct zperf_server_hdr {
 	s32_t flags;
 	s32_t total_len1;
@@ -97,6 +106,7 @@ struct sockaddr_in *zperf_get_sin(void);
 
 extern void zperf_udp_upload(const struct shell *shell,
 			     struct net_context *context,
+			     int port,
 			     unsigned int duration_in_ms,
 			     unsigned int packet_size,
 			     unsigned int rate_in_kbps,

--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -536,6 +536,7 @@ static int execute_upload(const struct shell *shell,
 			  struct sockaddr_in6 *ipv6,
 			  struct sockaddr_in *ipv4,
 			  bool is_udp,
+			  int port,
 			  char *argv0,
 			  unsigned int duration_in_ms,
 			  unsigned int packet_size,
@@ -584,7 +585,7 @@ static int execute_upload(const struct shell *shell,
 				goto out;
 			}
 
-			zperf_udp_upload(shell, context6, duration_in_ms,
+			zperf_udp_upload(shell, context6, port, duration_in_ms,
 					 packet_size, rate_in_kbps, &results);
 			shell_udp_upload_print_stats(shell, &results);
 		}
@@ -603,7 +604,7 @@ static int execute_upload(const struct shell *shell,
 				goto out;
 			}
 
-			zperf_udp_upload(shell, context4, duration_in_ms,
+			zperf_udp_upload(shell, context4, port, duration_in_ms,
 					 packet_size, rate_in_kbps, &results);
 			shell_udp_upload_print_stats(shell, &results);
 		}
@@ -812,7 +813,7 @@ static int shell_cmd_upload(const struct shell *shell, size_t argc,
 	}
 
 	return execute_upload(shell, context6, context4, family, &ipv6, &ipv4,
-			      is_udp, argv[start], duration_in_ms,
+			      is_udp, port, argv[start], duration_in_ms,
 			      packet_size, rate_in_kbps);
 }
 
@@ -931,7 +932,7 @@ static int shell_cmd_upload2(const struct shell *shell, size_t argc,
 	}
 
 	return execute_upload(shell, context6, context4, family, &in6_addr_dst,
-			      &in4_addr_dst, is_udp, argv[start],
+			      &in4_addr_dst, is_udp, port, argv[start],
 			      duration_in_ms, packet_size, rate_in_kbps);
 }
 


### PR DESCRIPTION
As there is no real documentation for iPerf2 protocol, it is not sure how much these actually help with the issues. At least I am seeing some reasonable output when using iPerf 2.0.9. The iPerf 2.0.13 did not work as expected with zperf.