### PR TITLE
net/pkt: Fix a few left over cases of net_pkt_read_new

### DIFF
--- a/drivers/ethernet/eth_smsc911x.c
+++ b/drivers/ethernet/eth_smsc911x.c
@@ -484,7 +484,7 @@ static int eth_tx(struct device *dev, struct net_pkt *pkt)
 	SMSC9220->TX_DATA_PORT = txcmd_a;
 	SMSC9220->TX_DATA_PORT = txcmd_b;
 
-	if (net_pkt_read_new(pkt, tx_buf, total_len)) {
+	if (net_pkt_read(pkt, tx_buf, total_len)) {
 		goto error;
 	}
 

--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -329,7 +329,7 @@ static int __eswifi_off_send_pkt(struct eswifi_dev *eswifi,
 	offset = strlen(eswifi->buf);
 
 	/* copy payload */
-	if (net_pkt_read_new(pkt, &eswifi->buf[offset], bytes)) {
+	if (net_pkt_read(pkt, &eswifi->buf[offset], bytes)) {
 		return -ENOBUFS;
 	}
 


### PR DESCRIPTION
In the conversion of net_pkt_read_new to net_pkt_read, we misse
changing the function in the eth_smsc911x and eswifi_offload.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>