### PR TITLE
scripts: Remove unnecessary () around if/while conditions in Python

### DIFF
--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -250,8 +250,8 @@ def main():
         swt = None
 
     for irq, flags, func, param in intlist["interrupts"]:
-        if (flags & ISR_FLAG_DIRECT):
-            if (param != 0):
+        if flags & ISR_FLAG_DIRECT:
+            if param != 0:
                 error("Direct irq %d declared, but has non-NULL parameter"
                         % irq)
             vt[irq - offset] = func

--- a/arch/x86/gen_mmu_x86.py
+++ b/arch/x86/gen_mmu_x86.py
@@ -79,9 +79,9 @@ def print_code(val):
     if not val & PAGE_ENTRY_PRESENT:
         ret = '.'
     else:
-        if (val & PAGE_ENTRY_READ_WRITE):
+        if val & PAGE_ENTRY_READ_WRITE:
             # Writable page
-            if (val & PAGE_ENTRY_XD):
+            if val & PAGE_ENTRY_XD:
                 # Readable, writeable, not executable
                 ret = 'w'
             else:
@@ -89,20 +89,20 @@ def print_code(val):
                 ret = 'a'
         else:
             # Read-only
-            if (val & PAGE_ENTRY_XD):
+            if val & PAGE_ENTRY_XD:
                 # Read-only
                 ret = 'r'
             else:
                 # Readable, executable
                 ret = 'x'
 
-        if (val & PAGE_ENTRY_USER_SUPERVISOR):
+        if val & PAGE_ENTRY_USER_SUPERVISOR:
             # User accessible pages are capital letters
             ret = ret.upper()
 
     sys.stdout.write(ret)
     entry_counter = entry_counter + 1
-    if (entry_counter == 128):
+    if entry_counter == 128:
         sys.stdout.write("\n")
         entry_counter = 0
 
@@ -350,7 +350,7 @@ class PageMode_PAE:
         # the pd contents
         #
         # FIXME: This wastes a ton of RAM!!
-        if (args.verbose):
+        if args.verbose:
             print("PDPTE at 0x%x" % self.pd_start_addr)
 
         for pdpte in range(self.total_pages + 1):
@@ -373,7 +373,7 @@ class PageMode_PAE:
 
     def page_directory_create_binary_file(self):
         for pdpte, pde_info in self.list_of_pdpte.items():
-            if (args.verbose):
+            if args.verbose:
                 print("Page directory %d at 0x%x" % (pde_info.pdpte_index,
                         self.pd_start_addr + self.output_offset))
             for pde in range(self.total_pages + 1):
@@ -388,7 +388,7 @@ class PageMode_PAE:
                                  self.output_buffer,
                                  self.output_offset,
                                  binary_value)
-                if (args.verbose):
+                if args.verbose:
                     print_code(binary_value)
 
                 self.output_offset += struct.calcsize(page_entry_format)
@@ -399,7 +399,7 @@ class PageMode_PAE:
                 pe_info = pte_info.page_entries_info[0]
                 start_addr = pe_info.start_addr & ~0x1FFFFF
                 end_addr = start_addr + 0x1FFFFF
-                if (args.verbose):
+                if args.verbose:
                     print("Page table for 0x%08x - 0x%08x at 0x%08x" %
                             (start_addr, end_addr,
                                 self.pd_start_addr + self.output_offset))
@@ -423,7 +423,7 @@ class PageMode_PAE:
                                                                  pte,
                                                                  perm_for_pte)
 
-                    if (args.verbose):
+                    if args.verbose:
                         print_code(binary_value)
                     struct.pack_into(page_entry_format,
                                      self.output_buffer,
@@ -445,7 +445,7 @@ def read_mmu_list(mmu_list_data):
     # a offset used to remember next location to read in the binary
     size_read_from_binary = struct.calcsize(header_values_format)
 
-    if (args.verbose):
+    if args.verbose:
         print("Start address of page tables: 0x%08x" % pd_start_addr)
         print("Build-time memory regions:")
 
@@ -456,7 +456,7 @@ def read_mmu_list(mmu_list_data):
                                                      size_read_from_binary)
         size_read_from_binary += struct.calcsize(struct_mmu_regions_format)
 
-        if (args.verbose):
+        if args.verbose:
             print("    Region %03d: 0x%08x - 0x%08x (0x%016x)" %
                     (region_index, addr, addr + size - 1, flags))
 
@@ -484,7 +484,7 @@ def read_mmu_list(mmu_list_data):
             overlap = ((addr <= other_addr and end_addr > other_addr) or
                        (other_addr <= addr and other_end_addr > addr))
 
-            if (overlap):
+            if overlap:
                 print("Memory region %d (%x:%x) overlaps memory region %d (%x:%x)" %
                         (region_index, addr, end_addr, other_region_index,
                             other_addr, other_end_addr))

--- a/doc/extensions/zephyr/link-roles.py
+++ b/doc/extensions/zephyr/link-roles.py
@@ -14,8 +14,8 @@ from local_util import run_cmd_get_output
 
 def get_github_rev():
     tag = run_cmd_get_output('git describe --exact-match')
-    if len(tag):
-        return(tag)
+    if tag:
+        return tag
     else:
         return 'master'
 

--- a/scripts/check_link_map.py
+++ b/scripts/check_link_map.py
@@ -45,7 +45,7 @@ for line in fileinput.input():
         vma = int(match.group(2), 16)
         size = int(match.group(3), 16)
 
-        if (sec == "bss"):
+        if sec == "bss":
             # Make sure we don't compare the last section of kernel data
             # with the first section of application data, the kernel's bss
             # and noinit are in between.

--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -148,7 +148,7 @@ class AggregateTypeMember:
             if member_offset[0] == 0x23:
                 self.member_offset = member_offset[1] & 0x7f
                 for i in range(1, len(member_offset)-1):
-                    if (member_offset[i] & 0x80):
+                    if member_offset[i] & 0x80:
                         self.member_offset += (
                             member_offset[i+1] & 0x7f) << i*7
             else:

--- a/scripts/gen_app_partitions.py
+++ b/scripts/gen_app_partitions.py
@@ -103,7 +103,7 @@ elf_part_size_regex = re.compile(r'z_data_smem_(.*)_part_size')
 def find_obj_file_partitions(filename, partitions):
     with open(filename, 'rb') as f:
         full_lib = ELFFile( f)
-        if (not full_lib):
+        if not full_lib:
             print("Error parsing file: ",filename)
             os.exit(1)
 

--- a/scripts/gen_syscall_header.py
+++ b/scripts/gen_syscall_header.py
@@ -34,7 +34,7 @@ def gen_macro(ret, argc):
         suffix = ""
 
     sys.stdout.write("K_SYSCALL_DECLARE%d%s(id, name" % (argc, suffix))
-    if (ret != Retval.VOID):
+    if ret != Retval.VOID:
         sys.stdout.write(", ret")
     for i in range(argc):
         sys.stdout.write(", t%d, p%d" % (i, i))
@@ -83,7 +83,7 @@ def gen_make_syscall(ret, argc, tabcount):
     sys.stdout.write(
         "static Z_GENERIC_SECTION(hndlr_ref) __used void *href = (void *)&z_hdlr_##name; \\\n")
     tabs(tabcount)
-    if (ret != Retval.VOID):
+    if ret != Retval.VOID:
         sys.stdout.write("return (ret)")
     else:
         sys.stdout.write("return (void)")
@@ -99,7 +99,7 @@ def gen_make_syscall(ret, argc, tabcount):
 
 
 def gen_call_impl(ret, argc):
-    if (ret != Retval.VOID):
+    if ret != Retval.VOID:
         sys.stdout.write("return ")
     sys.stdout.write("z_impl_##name(")
     for i in range(argc):

--- a/scripts/kconfig/checkconfig.py
+++ b/scripts/kconfig/checkconfig.py
@@ -70,8 +70,8 @@ def search_kconfig_items(items, name, completelog):
     findConfig = False
     for item in items:
         if item.is_symbol():
-            if (item.get_name() == name):
-                if (completelog == True):
+            if item.get_name() == name:
+                if completelog:
                     separate_location_lines(item.get_def_locations())
                 findConfig = True
                 break
@@ -85,9 +85,9 @@ def search_kconfig_items(items, name, completelog):
                 return True
 
         elif item.is_comment():
-            if (item.get_text() == name):
+            if item.get_text() == name:
                 print(completelog)
-                if (completelog == True):
+                if completelog:
                     separate_location_lines(item.get_location())
                 findConfig = True
                 break
@@ -109,19 +109,19 @@ def search_config_in_file(tree, items, completelog, exclude):
                         configName = re.search('(^|[\s|(])'
                                                +'CONFIG_([a-zA-Z0-9_]+)', line)
                         configs = configs + 1
-                        if (completelog == True):
+                        if completelog:
                             print('\n' + configName.group(2) + ' at '
                                    + os.path.join(dirName, fname))
                             print('line: ' + line.rstrip())
                         find = search_kconfig_items(items, configName.group(2),
                                                     completelog)
-                        if (find == False):
+                        if not find:
                             print('\n' + configName.group(2) + ' at '
                                    + os.path.join(dirName, fname)
                                    + ' IS NOT DEFINED')
                             print('line: ' + line.rstrip())
                             notdefConfig = notdefConfig + 1
-    if (completelog == True):
+    if completelog:
         print("\n{} Kconfigs evaluated".format(configs))
         print("{} Kconfigs not defined".format(notdefConfig))
 

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -12,7 +12,7 @@ import os
 doc_mode = os.environ.get('KCONFIG_DOC_MODE') == "1"
 
 dt_defines = {}
-if (not doc_mode):
+if not doc_mode:
     # The env var 'GENERATED_DTS_BOARD_CONF' must be set unless we are in
     # doc mode
     GENERATED_DTS_BOARD_CONF = os.environ['GENERATED_DTS_BOARD_CONF']

--- a/scripts/process_gperf.py
+++ b/scripts/process_gperf.py
@@ -55,7 +55,7 @@ def reformat_str(match_obj):
     ctr = 3
     i = 0
 
-    while (True):
+    while True:
         if i >= len(addr_str):
             break
 

--- a/scripts/subfolder_list.py
+++ b/scripts/subfolder_list.py
@@ -5,7 +5,7 @@ import argparse
 
 def touch(trigger):
     # If no trigger file is provided then do a return.
-    if(trigger is None):
+    if trigger is None:
         return
 
     if os.path.exists(trigger):
@@ -34,7 +34,7 @@ def main():
     args = parser.parse_args()
 
     dirlist = []
-    if(args.create_links is not None):
+    if args.create_links is not None:
         if not os.path.exists(args.create_links):
             os.makedirs(args.create_links)
         directory = args.directory
@@ -48,7 +48,7 @@ def main():
     for root, dirs, _ in os.walk(args.directory, topdown=True):
         dirs.sort()
         for subdir in dirs:
-            if(args.create_links is not None):
+            if args.create_links is not None:
                 directory = os.path.join(root, subdir)
                 symlink   = args.create_links + os.path.sep + directory.replace(os.path.sep, '_')
                 if not os.path.exists(symlink):

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -88,7 +88,7 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
     def do_run(self, command, **kwargs):
         commands = []
-        if (self.snr is None):
+        if self.snr is None:
             board_snr = self.get_board_snr_from_user()
         else:
             board_snr = self.snr.lstrip("0")


### PR DESCRIPTION
Not needed in Python. Detected by check C0325 in pylint3.

Also replace an

    if len(tag):

with just

    if tag:

Empty strings, byte strings, lists, etc., are falsy in Python.