### PR TITLE
scripts: elf_helper: Tidy up get_symbols() to eliminate pylint warning

### DIFF
--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -532,8 +532,8 @@ class ElfHelper:
     def get_symbols(self):
         for section in self.elf.iter_sections():
             if isinstance(section, SymbolTableSection):
-                return {self.sym.name: self.sym.entry.st_value
-                        for self.sym in section.iter_symbols()}
+                return {sym.name: sym.entry.st_value
+                        for sym in section.iter_symbols()}
 
         raise LookupError("Could not find symbol table")
 


### PR DESCRIPTION
Using a member variable in the dict comprehension was probably a typo
(can't see `sym` referenced elsewhere). Use a local variable instead.

Made pylint spit out these warnings (which might be spurious though):

    scripts/elf_helper.py:535:24: E0203: Access to member 'sym' before its
    definition line 536 (access-member-before-definition)

    scripts/elf_helper.py:535:39: E0203: Access to member 'sym' before its
    definition line 536 (access-member-before-definition)