### PR TITLE
Bluetooth: Fix missing return statement in le_conn_param_req()

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1263,6 +1263,7 @@ static void le_conn_param_req(struct net_buf *buf)
 	if (!conn) {
 		BT_ERR("Unable to lookup conn for handle %u", handle);
 		le_conn_param_neg_reply(handle, BT_HCI_ERR_UNKNOWN_CONN_ID);
+		return;
 	}
 
 	if (!le_param_req(conn, &param)) {


### PR DESCRIPTION
The le_conn_param_req() function was missing a return statement in
case of a failed connection lookup. This could lead to replying to the
connection parameter request twice as well as passing NULL to
bt_conn_unref(). The latter issue also triggered a Coverity warning.

Fixes CID 196638

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>