### PR TITLE
scripts/dts: Fix bug in dead /memreserve/ code

### DIFF
--- a/scripts/dts/devicetree.py
+++ b/scripts/dts/devicetree.py
@@ -212,7 +212,7 @@ def parse_file(fd, ignore_dts_version=False):
                 'reg': [start, end],
                 'label': label,
                 'addr': start,
-                'name': build_node_name(name, start)
+                'name': '<memreserve>'
             }
         elif line.endswith('{'):
             if not has_v1_tag and not ignore_dts_version:


### PR DESCRIPTION
The `/memreserve/` code would crash if it ever ran, because `name` isn't
defined (seems to be some copy-paste here). There are no `/memreserve/`s
in Zephyr though, so it works out.

`name` seems to be the node name. Not sure what to put for a
`/memreserve/`, but make it `<memreserve>` to make it stand out.

Fixes a pylint warning.

zephyrproject-rtos/ci-tools#37 (just to link)