### PR TITLE
ARM: fix wrong stack bounds stored in thread

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -193,15 +193,9 @@ void z_arch_configure_dynamic_mpu_regions(struct k_thread *thread)
 	LOG_DBG("configure user thread %p's context", thread);
 	if (thread->arch.priv_stack_start) {
 		u32_t base = (u32_t)thread->stack_obj;
-		u32_t size = thread->stack_info.size;
-#if !defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
-		/* In user-mode the thread stack will include the (optional)
-		 * guard area. For MPUs with arbitrary base address and limit
-		 * it is essential to include this size increase, to avoid
-		 * MPU faults.
-		 */
-		size += thread->stack_info.start - base;
-#endif
+		u32_t size = thread->stack_info.size +
+			(thread->stack_info.start - base);
+
 		__ASSERT(region_num < _MAX_DYNAMIC_MPU_REGIONS_NUM,
 			"Out-of-bounds error for dynamic region map.");
 		thread_stack = (const struct k_mem_partition)

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -91,10 +91,10 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	 * k_thread_create(). If K_THREAD_STACK_SIZEOF() is used, the
 	 * Guard size has already been take out of stackSize.
 	 */
-	stackEnd = pStackMem + stackSize - MPU_GUARD_ALIGN_AND_SIZE;
-#else
-	stackEnd = pStackMem + stackSize;
+	stackSize -= MPU_GUARD_ALIGN_AND_SIZE;
 #endif
+	stackEnd = pStackMem + stackSize;
+
 	struct __esf *pInitCtx;
 
 	_new_thread_init(thread, pStackMem, stackSize, priority,


### PR DESCRIPTION
Consider a stack buffer at address 0x10000 with size 1024.
If a thread is created with this stack object, the resulting
fields in thread.stack_info ended up being a base address of
0x10020 with size 1024. The guard size needed to be subtracted
from the size in order for the bounds to be correct.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>