### PR TITLE
arc: fix off-by-one in mpu_buffer_validate()

### DIFF
--- a/arch/arc/core/mpu/arc_mpu_v3_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v3_internal.h
@@ -594,7 +594,7 @@ int arc_core_mpu_buffer_validate(void *addr, size_t size, int write)
 	 */
 	r_index = _mpu_probe((u32_t)addr);
 	/*  match and the area is in one region */
-	if (r_index >= 0 && r_index == _mpu_probe((u32_t)addr + size)) {
+	if (r_index >= 0 && r_index == _mpu_probe((u32_t)addr + (size - 1))) {
 		if (_is_user_accessible_region(r_index, write)) {
 			return 0;
 		} else {


### PR DESCRIPTION
The code was probing the byte immediately after the last byte
of the buffer, instead of the last byte of the buffer.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>