### PR TITLE
scripts: elf_helper: Remove undefined var ref. in ArrayType.__repr__()

### DIFF
--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -95,7 +95,7 @@ class ArrayType:
         self.offset = offset
 
     def __repr__(self):
-        return "<array of %d, size %d>" % (self.member_type, self.num_members)
+        return "<array of %d>" % self.member_type
 
     def has_kobject(self):
         if self.member_type not in type_env:


### PR DESCRIPTION
`self.num_members` doesn't exist. This commit just removes the reference,
because I didn't want to guess a proper fix.

zephyrproject-rtos/ci-tools#37 (just to link)