### PR TITLE
scripts: gen_app_partition: Fix broken typo'd sys.exit()

### DIFF
--- a/scripts/gen_app_partitions.py
+++ b/scripts/gen_app_partitions.py
@@ -104,8 +104,7 @@ def find_obj_file_partitions(filename, partitions):
     with open(filename, 'rb') as f:
         full_lib = ELFFile( f)
         if not full_lib:
-            print("Error parsing file: ",filename)
-            os.exit(1)
+            sys.exit("Error parsing file: " + filename)
 
         sections = [x for x in full_lib.iter_sections()]
         for section in sections:


### PR DESCRIPTION
`os.exit()` doesn't exist.

Also use the nifty `sys.exit(msg)` feature, which prints `msg` to stderr
and exits with status 1.

https://github.com/zephyrproject-rtos/ci-tools/pull/37 (just to link)