### PR TITLE
ext: open-amp: Fix broken typo'd sys.exit()

### DIFF
--- a/ext/lib/ipc/open-amp/open-amp/docs/img-src/gen-graph.py
+++ b/ext/lib/ipc/open-amp/open-amp/docs/img-src/gen-graph.py
@@ -40,7 +40,7 @@ else:
             img_files.append(img_src_dir + "/" + f)
 
 if not img_files:
-    sys.exist("ERROR: no found image files.")
+    sys.exit("ERROR: no found image files.")
 
 oformat = args.outformat
 


### PR DESCRIPTION
s/exist/exit/

zephyrproject-rtos/ci-tools#37 (just to link)