### PR TITLE
ci: Bump to image 0.6.4 for west

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -21,7 +21,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.6.3
+        image_tag: v0.6.4
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
Move to using CI image to 0.6.4 for west version 0.5.6

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>