### PR TITLE
extensions.cmake: need a unique string, not a random one

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -397,8 +397,8 @@ function(zephyr_library_compile_options item)
   # zephyr_interface will be the first interface library that flags
   # are taken from.
 
-  string(RANDOM random)
-  set(lib_name options_interface_lib_${random})
+  string(MD5 uniqueness ${item})
+  set(lib_name options_interface_lib_${uniqueness})
 
   add_library(           ${lib_name} INTERFACE)
   target_compile_options(${lib_name} INTERFACE ${item} ${ARGN})


### PR DESCRIPTION
To support being called multiple times, the function
zephyr_library_compile_options() uses unique
options_interface_lib_${random} names. These only need to be unique, not
random. So replace them with a simple MD5 hash of the ${item} argument.

To reproduce quickly run:
  sanitycheck -b -p qemu_xtensa --tag shell
... a few times and compare the output directories.

This bug sits for now at the top of the list of build reproducibility
issues the most bizarre and difficult to root cause. When running
sanitycheck over a large sample of configurations it was affecting
only qemu_xtensa/**/zephyr/arch/arch/xtensa/core/startup/Makefile
files (and their corresponding CMakeFiles/TargetDirectories.txt),
randomly ordering the following three Make targets and only these
three: rebuild_cache, edit_cache, arch__xtensa__core__startup.

The key to root causing was cmake --trace-expand which prints the random
string.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>