### PR TITLE
sanitycheck: document that --save-tests appends to existing file

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2369,7 +2369,7 @@ class TestSuite:
 
         return self.goals
 
-    def run_report(self, filename):
+    def save_tests(self, filename):
         with open(filename, "at") as csvfile:
             fieldnames = ['path', 'test', 'platform', 'arch']
             cw = csv.DictWriter(csvfile, fieldnames, lineterminator=os.linesep)
@@ -2814,7 +2814,7 @@ Artificially long but functional example:
         "--save-tests",
         metavar="FILENAME",
         action="store",
-        help="Save list of tests and platforms to be run to file.")
+        help="Append list of tests and platforms to be run to file.")
 
     parser.add_argument(
         "-b", "--build-only", action="store_true",
@@ -3300,7 +3300,7 @@ def main():
                                key=cmp_to_key(native_and_unit_first)))
 
     if options.save_tests:
-        ts.run_report(options.save_tests)
+        ts.save_tests(options.save_tests)
         return
 
     if options.subset:


### PR DESCRIPTION
Fix --help message. Also rename run_report() to save_tests() as it's
used only once by --save-tests and nowhere else. Maybe the code was
shared with some --other-report feature in the past but not any more.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>