### PR TITLE
extensions.cmake: need unique strings, not random ones

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -397,8 +397,8 @@ function(zephyr_library_compile_options item)
   # zephyr_interface will be the first interface library that flags
   # are taken from.
 
-  string(RANDOM random)
-  set(lib_name options_interface_lib_${random})
+  string(MD5 uniqueness ${item})
+  set(lib_name options_interface_lib_${uniqueness})
 
   add_library(           ${lib_name} INTERFACE)
   target_compile_options(${lib_name} INTERFACE ${item} ${ARGN})
@@ -1219,7 +1219,7 @@ function(generate_unique_target_name_from_filename filename target_name)
   string(REPLACE "." "_" x ${basename})
   string(REPLACE "@" "_" x ${x})
 
-  string(RANDOM LENGTH 8 random_chars)
+  string(MD5 unique_chars ${filename})
 
-  set(${target_name} gen_${x}_${random_chars} PARENT_SCOPE)
+  set(${target_name} gen_${x}_${unique_chars} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
1. To support being called multiple times, the function
zephyr_library_compile_options() uses unique
options_interface_lib_${random} names. These only need to be unique, not
random. So replace them with a simple MD5 hash of the ${item} argument.

To reproduce quickly run:
  sanitycheck -b -p qemu_xtensa --tag shell
... a few times and compare the output directories.

This bug sits for now at the top of the list of build reproducibility
issues the most bizarre and difficult to root cause. When running
sanitycheck over a large sample of configurations it was affecting
only qemu_xtensa/**/zephyr/arch/arch/xtensa/core/startup/Makefile
files (and their corresponding CMakeFiles/TargetDirectories.txt),
randomly ordering the following three Make targets and only these
three: rebuild_cache, edit_cache, arch__xtensa__core__startup.

The key to root causing was cmake --trace-expand which prints the random
string.

2. generate_unique_target_name_from_filename() also generated a random
string for the same uniqueness reason. This one was easier to root cause
and reproduce with: sanitycheck --tag gen_inc_file

Signed-off-by: Marc Herbert <marc.herbert@intel.com>