### PR TITLE
misc: util: Allow conditional macros to depend on whether a property in DTS exists

### DIFF
--- a/include/misc/util.h
+++ b/include/misc/util.h
@@ -392,6 +392,9 @@ static inline s64_t arithmetic_shift_right(s64_t value, u8_t shift)
 
 #define UTIL_IF(c) UTIL_IIF(UTIL_BOOL(c))
 
+#define UTIL_IS_PARENTHESIZED(x) UTIL_CHECK(UTIL_IS_PARENTHESIZED_ x, 0)
+#define UTIL_IS_PARENTHESIZED_(...) 1, 1
+
 #define UTIL_EAT(...)
 #define UTIL_EXPAND(...) __VA_ARGS__
 #define UTIL_WHEN(c) UTIL_IF(c)(UTIL_EXPAND, UTIL_EAT)

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -263,7 +263,14 @@ def define_str(name, value, value_tabs, is_deprecated=False):
     line = "#define " + name
     if is_deprecated:
         line += " __DEPRECATED_MACRO "
-    return line + (value_tabs - len(line)//8)*'\t' + str(value) + '\n'
+
+    try:
+        int(str(value), 0)
+        str_val = '(' + str(value) + ')'
+    except ValueError:
+        str_val = str(value)
+
+    return line + (value_tabs - len(line)//8)*'\t' + str_val + '\n'
 
 
 def write_conf(f):


### PR DESCRIPTION
This implements an idea from [*C Preprocessor tricks, tips, and idioms*](https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms#detection) to allow for conditional compilation of code depending on whether a parametrically assembled macro resolves to a real defined macro (from DTS) or not.

E.g. newer Atmel sam0 parts have 4 interrupts associated with a SERCOM peripheral while older ones only had one. The Interrupt setup code is assembled in a macro already to prevent copy & paste for all SERCOMs. This allows to use a [nested macro](https://github.com/zephyrproject-rtos/zephyr/pull/14685/commits/e8aa736ca8923f267d8d9d60cb8f7c6ed363cc3b) for the actual interrupt enablement.  If the Interrupt exists, the corresponding setup code is inserted. If it doesn't exist, the macro resolves to nothing.

@Sizurka expressed interest in this too - https://github.com/zephyrproject-rtos/zephyr/pull/14685#pullrequestreview-217031740