### PR TITLE
Fix compilation error when logger is disabled

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -415,7 +415,8 @@ char *log_strdup(const char *str);
  *
  */
 #define LOG_LEVEL_SET(level) \
-	static const u32_t __log_level __attribute__((unused)) = level
+	static const u32_t __log_level __attribute__((unused)) = \
+			_LOG_LEVEL_RESOLVE(level)
 
 /**
  * @}

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -12,7 +12,7 @@ menu "Shell Options"
 
 menuconfig SHELL
 	bool "Enable shell"
-	select LOG_RUNTIME_FILTERING
+	imply LOG_RUNTIME_FILTERING
 	select POLL
 
 if SHELL


### PR DESCRIPTION
2 issues spotted:
- use of `LOG_LEVEL_SET(level)` was evaluating `level` even when log was disabled. If `level` was defined
that depended on log being enabled, it lead to compilation error.
- shell is forcing `LOG_LEVEL_RUNTIME_FILTERING` option and that lead to generation of define even if log is disabled. Logger code didn't expect that and that resulted in compilation failure. 