### PR TITLE
counter: Update counter API in order to provide more flexibility

### DIFF
--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -197,17 +197,13 @@ static u32_t rtc_stm32_get_top_value(struct device *dev)
 }
 
 
-static int rtc_stm32_set_top_value(struct device *dev, u32_t ticks,
-				counter_top_callback_t callback,
-				void *user_data)
+static int rtc_stm32_set_top_value(struct device *dev,
+				   const struct counter_top_cfg *cfg)
 {
 	const struct counter_config_info *info = dev->config->config_info;
 
-	ARG_UNUSED(dev);
-	ARG_UNUSED(callback);
-	ARG_UNUSED(user_data);
-
-	if (ticks != info->max_top_value) {
+	if ((cfg->ticks != info->max_top_value) ||
+		!(cfg->flags & COUNTER_TOP_CFG_DONT_RESET)) {
 		return -ENOTSUP;
 	} else {
 		return 0;

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -141,13 +141,13 @@ static int counter_nrfx_cancel_alarm(struct device *dev, u8_t chan_id)
 	return 0;
 }
 
-static int counter_nrfx_set_top_value(struct device *dev, u32_t ticks,
-				      counter_top_callback_t callback,
-				      void *user_data)
+static int counter_nrfx_set_top_value(struct device *dev,
+				      const struct counter_top_cfg *cfg)
 {
 	const struct counter_nrfx_config *nrfx_config = get_nrfx_config(dev);
 	const nrfx_rtc_t *rtc = &nrfx_config->rtc;
 	struct counter_nrfx_data *dev_data = get_dev_data(dev);
+	int err = 0;
 
 	for (int i = 0; i < counter_get_num_of_channels(dev); i++) {
 		/* Overflow can be changed only when all alarms are
@@ -159,14 +159,26 @@ static int counter_nrfx_set_top_value(struct device *dev, u32_t ticks,
 	}
 
 	nrfx_rtc_cc_disable(rtc, TOP_CH);
-	nrfx_rtc_counter_clear(rtc);
 
-	dev_data->top_cb = callback;
-	dev_data->top_user_data = user_data;
-	dev_data->top = ticks;
-	nrfx_rtc_cc_set(rtc, TOP_CH, ticks, callback ? true : false);
+	dev_data->top_cb = cfg->callback;
+	dev_data->top_user_data = cfg->user_data;
+	dev_data->top = cfg->ticks;
+	nrfx_rtc_cc_set(rtc, TOP_CH, cfg->ticks, false);
 
-	return 0;
+	if (!(cfg->flags & COUNTER_TOP_CFG_DONT_RESET)) {
+		nrfx_rtc_counter_clear(rtc);
+	} else if (counter_nrfx_read(dev) >= cfg->ticks) {
+		err = -ETIME;
+		if (cfg->flags & COUNTER_TOP_CFG_RESET_WHEN_LATE) {
+			nrfx_rtc_counter_clear(rtc);
+		}
+	}
+
+	if (cfg->callback) {
+		nrfx_rtc_int_enable(rtc, COUNTER_TOP_INT);
+	}
+
+	return err;
 }
 
 static u32_t counter_nrfx_get_pending_int(struct device *dev)

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -156,13 +156,13 @@ static int counter_nrfx_cancel_alarm(struct device *dev, u8_t chan_id)
 }
 
 
-static int counter_nrfx_set_top_value(struct device *dev, u32_t ticks,
-				      counter_top_callback_t callback,
-				      void *user_data)
+static int counter_nrfx_set_top_value(struct device *dev,
+				      const struct counter_top_cfg *cfg)
 {
 	const struct counter_nrfx_config *nrfx_config = get_nrfx_config(dev);
 	const nrfx_timer_t *timer = &nrfx_config->timer;
 	struct counter_nrfx_data *data = get_dev_data(dev);
+	int err = 0;
 
 	for (int i = 0; i < counter_get_num_of_channels(dev); i++) {
 		/* Overflow can be changed only when all alarms are
@@ -174,15 +174,27 @@ static int counter_nrfx_set_top_value(struct device *dev, u32_t ticks,
 	}
 
 	nrfx_timer_compare_int_disable(timer, TOP_CH);
-	nrfx_timer_clear(timer);
 
-	data->top_cb = callback;
-	data->top_user_data = user_data;
+	data->top_cb = cfg->callback;
+	data->top_user_data = cfg->user_data;
 	nrfx_timer_extended_compare(timer, TOP_CH,
-				    ticks, COUNTER_OVERFLOW_SHORT,
-				    callback ? true : false);
+				    cfg->ticks, COUNTER_OVERFLOW_SHORT,
+				    false);
 
-	return 0;
+	if (!(cfg->flags & COUNTER_TOP_CFG_DONT_RESET)) {
+		nrfx_timer_clear(timer);
+	} else if (counter_nrfx_read(dev) >= cfg->ticks) {
+		err = -ETIME;
+		if (cfg->flags & COUNTER_TOP_CFG_RESET_WHEN_LATE) {
+			nrfx_timer_clear(timer);
+		}
+	}
+
+	if (cfg->callback) {
+		nrfx_timer_compare_int_enable(timer, TOP_CH);
+	}
+
+	return err;
 }
 
 static u32_t counter_nrfx_get_pending_int(struct device *dev)

--- a/drivers/counter/counter_qmsi_aon.c
+++ b/drivers/counter/counter_qmsi_aon.c
@@ -39,9 +39,7 @@ static u32_t aon_counter_qmsi_read(struct device *dev)
 }
 
 static int aon_counter_qmsi_set_top(struct device *dev,
-				      u32_t ticks,
-				      counter_top_callback_t callback,
-				      void *user_data)
+				    const struct counter_top_cfg *cfg)
 
 {
 	return -ENODEV;

--- a/drivers/counter/counter_qmsi_aonpt.c
+++ b/drivers/counter/counter_qmsi_aonpt.c
@@ -113,19 +113,22 @@ static u32_t aon_timer_qmsi_read(struct device *dev)
 }
 
 static int aon_timer_qmsi_set_top(struct device *dev,
-				    u32_t ticks,
-				    counter_top_callback_t callback,
-				    void *user_data)
+				  const struct counter_top_cfg *cfg)
 {
 	qm_aonpt_config_t qmsi_cfg;
 	int result = 0;
 
-	user_cb = callback;
+	/* Counter is always reset when top value is updated. */
+	if (cfg->flags & COUNTER_TOP_CFG_DONT_RESET) {
+		return -ENOTSUP;
+	}
+
+	user_cb = cfg->callback;
 
 	qmsi_cfg.callback = aonpt_int_callback;
 	qmsi_cfg.int_en = true;
-	qmsi_cfg.count = ticks;
-	qmsi_cfg.callback_data = user_data;
+	qmsi_cfg.count = cfg->ticks;
+	qmsi_cfg.callback_data = cfg->user_data;
 
 	if (IS_ENABLED(CONFIG_AON_API_REENTRANCY)) {
 		k_sem_take(RP_GET(dev), K_FOREVER);

--- a/drivers/counter/counter_rtc_qmsi.c
+++ b/drivers/counter/counter_rtc_qmsi.c
@@ -90,17 +90,13 @@ static int rtc_qmsi_cancel_alarm(struct device *dev, u8_t chan_id)
 	return 0;
 }
 
-static int rtc_qmsi_set_top(struct device *dev, u32_t ticks,
-			     counter_top_callback_t callback,
-			     void *user_data)
+static int rtc_qmsi_set_top(struct device *dev,
+			    const struct counter_top_cfg *cfg)
 {
 	const struct counter_config_info *info = dev->config->config_info;
 
-	ARG_UNUSED(dev);
-	ARG_UNUSED(callback);
-	ARG_UNUSED(user_data);
-
-	if (ticks != info->max_top_value) {
+	if ((cfg->ticks != info->max_top_value) ||
+		!(cfg->flags & COUNTER_TOP_CFG_DONT_RESET)) {
 		return -ENOTSUP;
 	} else {
 		return 0;

--- a/drivers/counter/counter_sam0_tc32.c
+++ b/drivers/counter/counter_sam0_tc32.c
@@ -226,14 +226,13 @@ static int counter_sam0_tc32_cancel_alarm(struct device *dev, u8_t chan_id)
 	return 0;
 }
 
-static int counter_sam0_tc32_set_top_value(struct device *dev, u32_t ticks,
-					   counter_top_callback_t callback,
-					   void *user_data)
+static int counter_sam0_tc32_set_top_value(struct device *dev,
+					 const struct counter_top_cfg *top_cfg)
 {
-	bool reset = true;
 	struct counter_sam0_tc32_data *data = DEV_DATA(dev);
 	const struct counter_sam0_tc32_config *const cfg = DEV_CFG(dev);
 	TcCount32 *tc = cfg->regs;
+	int err = 0;
 	int key = irq_lock();
 
 	if (data->ch.callback) {
@@ -241,33 +240,36 @@ static int counter_sam0_tc32_set_top_value(struct device *dev, u32_t ticks,
 		return -EBUSY;
 	}
 
-	if (callback) {
-		data->top_cb = callback;
-		data->top_user_data = user_data;
+	if (top_cfg->callback) {
+		data->top_cb = top_cfg->callback;
+		data->top_user_data = top_cfg->user_data;
 		tc->INTENSET.reg = TC_INTFLAG_MC0;
 	} else {
 		tc->INTENCLR.reg = TC_INTFLAG_MC0;
 	}
 
-	tc->CC[0].reg = ticks;
+	tc->CC[0].reg = top_cfg->ticks;
 
-	if (reset) {
-		tc->CTRLBSET.reg = TC_CTRLBSET_CMD_RETRIGGER;
-	} else {
+	if (top_cfg->flags & COUNTER_TOP_CFG_DONT_RESET) {
 		/*
 		 * Top trigger is on equality of the rising edge only, so
 		 * manually reset it if the counter has missed the new top.
 		 */
-		if (counter_sam0_tc32_read(dev) >= ticks) {
-			tc->CTRLBSET.reg = TC_CTRLBSET_CMD_RETRIGGER;
+		if (counter_sam0_tc32_read(dev) >= top_cfg->ticks) {
+			err = -ETIME;
+			if (top_cfg->flags & COUNTER_TOP_CFG_RESET_WHEN_LATE) {
+				tc->CTRLBSET.reg = TC_CTRLBSET_CMD_RETRIGGER;
+			}
 		}
+	} else {
+		tc->CTRLBSET.reg = TC_CTRLBSET_CMD_RETRIGGER;
 	}
 
 	wait_synchronization(tc);
 
 	tc->INTFLAG.reg = TC_INTFLAG_MC0;
 	irq_unlock(key);
-	return 0;
+	return err;
 }
 
 static u32_t counter_sam0_tc32_get_pending_int(struct device *dev)

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -69,22 +69,32 @@ static u32_t dtmr_cmsdk_apb_read(struct device *dev)
 }
 
 static int dtmr_cmsdk_apb_set_top_value(struct device *dev,
-					       u32_t ticks,
-					       counter_top_callback_t callback,
-					       void *user_data)
+					const struct counter_top_cfg *top_cfg)
 {
 	const struct dtmr_cmsdk_apb_cfg * const cfg =
 						dev->config->config_info;
 	struct dtmr_cmsdk_apb_dev_data *data = dev->driver_data;
 
-	data->top_callback = callback;
-	data->top_user_data = user_data;
+	data->top_callback = top_cfg->callback;
+	data->top_user_data = top_cfg->user_data;
 
 	/* Store the reload value */
-	data->load = ticks;
+	data->load = top_cfg->ticks;
 
 	/* Set the timer to count */
-	cfg->dtimer->timer1load = ticks;
+	if (top_cfg->flags & COUNTER_TOP_CFG_DONT_RESET) {
+		/*
+		 * Write to background load register will not affect
+		 * the current value of the counter.
+		 */
+		cfg->dtimer->timer1bgload = top_cfg->ticks;
+	} else {
+		/*
+		 * Write to load register will also set
+		 * the current value of the counter.
+		 */
+		cfg->dtimer->timer1load = top_cfg->ticks;
+	}
 
 	/* Enable IRQ */
 	cfg->dtimer->timer1ctrl |= (DUALTIMER_CTRL_INTEN

--- a/include/counter.h
+++ b/include/counter.h
@@ -39,6 +39,28 @@ extern "C" {
 
 /**@} */
 
+/**@defgroup COUNTER_TOP_FLAGS Flags used by @ref counter_top_cfg.
+ * @{
+ */
+
+/**
+ * @brief Flag preventing counter reset when top value is changed.
+ *
+ * If flags is set then counter is free running while top value is updated,
+ * otherwise counter is reset (see @ref counter_set_top_value()).
+ */
+#define COUNTER_TOP_CFG_DONT_RESET BIT(0)
+
+/**
+ * @brief Flag instructing counter to reset itself if changing top value
+ *	  results in counter going out of new top value bound.
+ *
+ * See @ref COUNTER_TOP_CFG_DONT_RESET.
+ */
+#define COUNTER_TOP_CFG_RESET_WHEN_LATE BIT(1)
+
+/**@} */
+
 /** @brief Alarm callback
  *
  * @param dev       Pointer to the device structure for the driver instance.
@@ -80,6 +102,21 @@ struct counter_alarm_cfg {
  */
 typedef void (*counter_top_callback_t)(struct device *dev, void *user_data);
 
+/** @brief Top value configuration structure.
+ *
+ * @param ticks		Top value.
+ * @param callback	Callback function. Can be NULL.
+ * @param user_data	User data passed to callback function. Not valid if
+ *			callback is NULL.
+ * @param flags		Flags. See @ref COUNTER_TOP_FLAGS.
+ */
+struct counter_top_cfg {
+	u32_t ticks;
+	counter_top_callback_t callback;
+	void *user_data;
+	u32_t flags;
+};
+
 /** @brief Structure with generic counter features.
  *
  * @param max_top_value Maximal (default) top value on which counter is reset
@@ -103,9 +140,8 @@ typedef u32_t (*counter_api_read)(struct device *dev);
 typedef int (*counter_api_set_alarm)(struct device *dev, u8_t chan_id,
 				const struct counter_alarm_cfg *alarm_cfg);
 typedef int (*counter_api_cancel_alarm)(struct device *dev, u8_t chan_id);
-typedef int (*counter_api_set_top_value)(struct device *dev, u32_t ticks,
-				    counter_top_callback_t callback,
-				    void *user_data);
+typedef int (*counter_api_set_top_value)(struct device *dev,
+					 const struct counter_top_cfg *cfg);
 typedef u32_t (*counter_api_get_pending_int)(struct device *dev);
 typedef u32_t (*counter_api_get_top_value)(struct device *dev);
 typedef u32_t (*counter_api_get_max_relative_alarm)(struct device *dev);
@@ -332,34 +368,38 @@ static inline int counter_cancel_channel_alarm(struct device *dev,
 /**
  * @brief Set counter top value.
  *
- * Function sets top value and resets the counter to 0 or top value
- * depending on counter direction. On turnaround, counter is reset and optional
- * callback is periodically called. Top value can only be changed when there
- * is no active channel alarm.
+ * Function sets top value and optionally resets the counter to 0 or top value
+ * depending on counter direction. On turnaround, counter can be reset and
+ * optional callback is periodically called. Top value can only be changed when
+ * there is no active channel alarm.
+ *
+ * @ref COUNTER_TOP_CFG_DONT_RESET prevents counter reset. When counter is
+ * running while top value is updated, it is possible that counter progresses
+ * outside the new top value. In that case, error is returned and optionally
+ * driver can reset the counter (see @ref COUNTER_TOP_CFG_RESET_WHEN_LATE).
  *
  * @param dev		Pointer to the device structure for the driver instance.
- * @param ticks		Top value.
- * @param callback	Callback function. Can be NULL.
- * @param user_data	User data passed to callback function. Not valid if
- *			callback is NULL.
+ * @param cfg		Configuration. Cannot be NULL.
  *
  * @retval 0 If successful.
  * @retval -ENOTSUP if request is not supported (e.g. top value cannot be
- *		    changed).
+ *		    changed or counter cannot/must be reset during top value
+		    update).
  * @retval -EBUSY if any alarm is active.
+ * @retval -ETIME if @ref COUNTER_TOP_CFG_DONT_RESET was set and new top value
+ *		  is smaller than current counter value (counter counting up).
  */
-static inline int counter_set_top_value(struct device *dev, u32_t ticks,
-					counter_top_callback_t callback,
-					void *user_data)
+static inline int counter_set_top_value(struct device *dev,
+					const struct counter_top_cfg *cfg)
 {
 	const struct counter_driver_api *api =
 				(struct counter_driver_api *)dev->driver_api;
 
-	if (ticks > counter_get_max_top_value(dev)) {
+	if (cfg->ticks > counter_get_max_top_value(dev)) {
 		return -EINVAL;
 	}
 
-	return api->set_top_value(dev, ticks, callback, user_data);
+	return api->set_top_value(dev, cfg);
 }
 
 /**
@@ -430,7 +470,14 @@ __deprecated static inline int counter_set_alarm(struct device *dev,
 						 counter_callback_t callback,
 						 u32_t count, void *user_data)
 {
-	return counter_set_top_value(dev, count, callback, user_data);
+	struct counter_top_cfg cfg = {
+		.ticks = count,
+		.callback = callback,
+		.user_data = user_data,
+		.flags = 0
+	};
+
+	return counter_set_top_value(dev, &cfg);
 }
 
 /**

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -88,11 +88,16 @@ static void counter_tear_down_instance(const char *dev_name)
 {
 	int err;
 	struct device *dev;
+	struct counter_top_cfg top_cfg = {
+		.callback = NULL,
+		.user_data = NULL,
+		.flags = 0
+	};
 
 	dev = device_get_binding(dev_name);
 
-	err = counter_set_top_value(dev, counter_get_max_top_value(dev),
-				    NULL, NULL);
+	top_cfg.ticks = counter_get_max_top_value(dev);
+	err = counter_set_top_value(dev, &top_cfg);
 	zassert_equal(0, err,
 			"%s: Setting top value to default failed", dev_name);
 
@@ -124,13 +129,17 @@ void test_set_top_value_with_alarm_instance(const char *dev_name)
 	struct device *dev;
 	int err;
 	u32_t cnt;
-	u32_t ticks;
 	u32_t tmp_top_cnt;
+	struct counter_top_cfg top_cfg = {
+		.callback = top_handler,
+		.user_data = exp_user_data,
+		.flags = 0
+	};
 
 	top_cnt = 0U;
 
 	dev = device_get_binding(dev_name);
-	ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
+	top_cfg.ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
 
 	err = counter_start(dev);
 	zassert_equal(0, err, "%s: Counter failed to start", dev_name);
@@ -140,7 +149,7 @@ void test_set_top_value_with_alarm_instance(const char *dev_name)
 	cnt = counter_read(dev);
 	zassert_true(cnt > 0, "%s: Counter should progress", dev_name);
 
-	err = counter_set_top_value(dev, ticks, top_handler, exp_user_data);
+	err = counter_set_top_value(dev, &top_cfg);
 	zassert_equal(0, err, "%s: Counter failed to set top value",
 			dev_name);
 
@@ -181,9 +190,15 @@ void test_single_shot_alarm_instance(const char *dev_name, bool set_top)
 	int err;
 	u32_t ticks;
 	u32_t tmp_alarm_cnt;
+	struct counter_top_cfg top_cfg = {
+		.callback = top_handler,
+		.user_data = exp_user_data,
+		.flags = 0
+	};
 
 	dev = device_get_binding(dev_name);
 	ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
+	top_cfg.ticks = ticks;
 
 	alarm_cfg.absolute = false;
 	alarm_cfg.ticks = ticks;
@@ -201,8 +216,7 @@ void test_single_shot_alarm_instance(const char *dev_name, bool set_top)
 	zassert_equal(0, err, "%s: Counter failed to start", dev_name);
 
 	if (set_top) {
-		err = counter_set_top_value(dev, ticks, top_handler,
-					    exp_user_data);
+		err = counter_set_top_value(dev, &top_cfg);
 
 		zassert_equal(0, err,
 			     "%s: Counter failed to set top value", dev_name);
@@ -231,10 +245,12 @@ void test_single_shot_alarm_instance(const char *dev_name, bool set_top)
 	err = counter_cancel_channel_alarm(dev, 0);
 	zassert_equal(0, err, "%s: Counter disabling alarm failed", dev_name);
 
-	err = counter_set_top_value(dev, counter_get_max_top_value(dev),
-				    NULL, NULL);
-	zassert_equal(0, err,
-			"%s: Setting top value to default failed", dev_name);
+	top_cfg.ticks = counter_get_max_top_value(dev);
+	top_cfg.callback = NULL;
+	top_cfg.user_data = NULL;
+	err = counter_set_top_value(dev, &top_cfg);
+	zassert_equal(0, err, "%s: Setting top value to default failed",
+			dev_name);
 
 	err = counter_stop(dev);
 	zassert_equal(0, err, "%s: Counter failed to stop", dev_name);
@@ -286,9 +302,15 @@ void test_multiple_alarms_instance(const char *dev_name)
 	int err;
 	u32_t ticks;
 	u32_t tmp_alarm_cnt;
+	struct counter_top_cfg top_cfg = {
+		.callback = top_handler,
+		.user_data = exp_user_data,
+		.flags = 0
+	};
 
 	dev = device_get_binding(dev_name);
 	ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
+	top_cfg.ticks = ticks;
 
 	alarm_cfg.absolute = true;
 	alarm_cfg.ticks = counter_us_to_ticks(dev, 2000);
@@ -310,7 +332,7 @@ void test_multiple_alarms_instance(const char *dev_name)
 	err = counter_start(dev);
 	zassert_equal(0, err, "%s: Counter failed to start", dev_name);
 
-	err = counter_set_top_value(dev, ticks, top_handler, exp_user_data);
+	err = counter_set_top_value(dev, &top_cfg);
 	zassert_equal(0, err,
 			"%s: Counter failed to set top value", dev_name);
 


### PR DESCRIPTION
This PR introduces new "reset" parameter to the set_top_value()
making resetting counter optional during change of top value.

Such change allows for #12068 implementation on hardware which
does not provide alarms.