### PR TITLE
drivers: counter: stm32: Fix possible overflow

### DIFF
--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -101,9 +101,7 @@ static u32_t rtc_stm32_read(struct device *dev)
 	ts -= T_TIME_OFFSET;
 
 	__ASSERT(sizeof(time_t) == 8, "unexpected time_t definition");
-	/* Since SDK 0.10.0, newlib defines sizeof(time_t) = 8, */
-	/* so ts requires cast to u32_t before conversion from s to us. */
-	ticks = counter_us_to_ticks(dev, (u64_t)((u32_t)ts * USEC_PER_SEC));
+	ticks = counter_us_to_ticks(dev, ts * USEC_PER_SEC);
 
 	return ticks;
 }


### PR DESCRIPTION
Cast ts to u32_t could cause an overflow in that multiplication, since
time_t is 8 bytes it is not necessary to cast the multiplication's
result too.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>