### PR TITLE
x86: gen_mmu_x86: Fix error-reporting code for non-page-aligned region

### DIFF
--- a/arch/x86/gen_mmu_x86.py
+++ b/arch/x86/gen_mmu_x86.py
@@ -470,7 +470,7 @@ def read_mmu_list(mmu_list_data):
             sys.exit(2)
 
         if (size & 0xFFF) != 0:
-            print("Memory region %d size %zu is not page-aligned" %
+            print("Memory region %d size %d is not page-aligned" %
                     (region_index, size))
             sys.exit(2)
 


### PR DESCRIPTION
%z isn't available in Python, and makes the code raise a ValueError. Use
%d instead. Integers in Python 3 are not sized/signed (though it's
probably a typo from C).

zephyrproject-rtos/ci-tools#37 (just to link)