### PR TITLE
scripts: Remove extra trailing newlines from Python scripts

### DIFF
--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -307,4 +307,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/arch/xtensa/core/xtensa_intgen.py
+++ b/arch/xtensa/core/xtensa_intgen.py
@@ -139,4 +139,3 @@ for lvl in ints_by_lvl:
     cprint("return mask;")
     cprint("}")
     cprint("")
-

--- a/doc/extensions/local_util.py
+++ b/doc/extensions/local_util.py
@@ -62,4 +62,3 @@ def copy_if_modified(src_path, dst_path):
             src_file_path = os.path.join(root, src_file_name)
             dst_file_path = os.path.join(dst_path + root[src_path_len:], src_file_name)
             copy_file_if_modified(src_file_path, dst_file_path)
-

--- a/scripts/ci/get_modified_boards.py
+++ b/scripts/ci/get_modified_boards.py
@@ -73,4 +73,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/scripts/ci/get_modified_tests.py
+++ b/scripts/ci/get_modified_tests.py
@@ -72,4 +72,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/scripts/sanity_chk/expr_parser.py
+++ b/scripts/sanity_chk/expr_parser.py
@@ -246,7 +246,3 @@ if __name__ == "__main__":
         print(parser.parse(line))
 
         print(parse(line, local_env))
-
-
-
-

--- a/scripts/support/quartus-flash.py
+++ b/scripts/support/quartus-flash.py
@@ -137,4 +137,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/scripts/west_commands/tests/test_build.py
+++ b/scripts/west_commands/tests/test_build.py
@@ -56,4 +56,3 @@ def test_parse_remainder(test_case):
     b._parse_remainder(test_case['r'])
     assert b.args.source_dir == test_case['s']
     assert b.args.cmake_opts == test_case['c']
-


### PR DESCRIPTION
Fixing all instances so that it can be flagged in a pylint CI check later.

zephyrproject-rtos/ci-tools#37 (just to link)