### PR TITLE
build: native: Enable building POSIX ARCH with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1284,7 +1284,7 @@ endif()
 
 # FIXME: Is there any way to get rid of empty_file.c?
 add_executable(       ${ZEPHYR_PREBUILT_EXECUTABLE} misc/empty_file.c)
-target_link_libraries(${ZEPHYR_PREBUILT_EXECUTABLE} ${TOPT} ${PROJECT_BINARY_DIR}/linker.cmd ${PRIV_STACK_LIB} ${zephyr_lnk} ${CODE_RELOCATION_DEP})
+target_link_libraries(${ZEPHYR_PREBUILT_EXECUTABLE} ${LINKERFLAGPREFIX},${TOPT} ${PROJECT_BINARY_DIR}/linker.cmd ${PRIV_STACK_LIB} ${zephyr_lnk} ${CODE_RELOCATION_DEP})
 set_property(TARGET   ${ZEPHYR_PREBUILT_EXECUTABLE} PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker.cmd)
 add_dependencies(     ${ZEPHYR_PREBUILT_EXECUTABLE} ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP} ${LINKER_SCRIPT_TARGET} ${OFFSETS_LIB})
 

--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_compile_options(
-  -fno-freestanding
   -m32
   -MMD
   -MP

--- a/cmake/generic_toolchain.cmake
+++ b/cmake/generic_toolchain.cmake
@@ -49,8 +49,8 @@ set(ZEPHYR_TOOLCHAIN_VARIANT ${ZEPHYR_TOOLCHAIN_VARIANT} CACHE STRING "Zephyr to
 assert(ZEPHYR_TOOLCHAIN_VARIANT "Zephyr toolchain variant invalid: please set the ZEPHYR_TOOLCHAIN_VARIANT-variable")
 
 # Pick host system's toolchain if we are targeting posix
-if((${ARCH} STREQUAL "posix") OR (${ARCH} STREQUAL "x86_64"))
-  set(ZEPHYR_TOOLCHAIN_VARIANT "host")
+if((${ARCH} STREQUAL "posix") OR (${ARCH} STREQUAL "x86_64") AND (NOT ("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "llvm")))
+    set(ZEPHYR_TOOLCHAIN_VARIANT "host")
 endif()
 
 # Configure the toolchain based on what SDK/toolchain is in use.


### PR DESCRIPTION
* Remove hard-coded toolchain on native_posix
* Remove -no-freestanding flag (not available in clang)
* Needed --for-linker flag to pass linker.cmd to clang linker.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>