### PR TITLE
file2hex.py: switch from gzip.compress() to GzipFile()

### DIFF
--- a/scripts/file2hex.py
+++ b/scripts/file2hex.py
@@ -41,8 +41,13 @@ def main():
     parse_args()
 
     if args.gzip:
-        with open(args.file, 'rb') as fg:
-            content = io.BytesIO(gzip.compress(fg.read(), compresslevel=9))
+        with io.BytesIO() as content:
+            with open(args.file, 'rb') as fg:
+                with gzip.GzipFile(fileobj=content, mode='w',
+                                   compresslevel=9) as gz_obj:
+                    gz_obj.write(fg.read())
+
+            content.seek(0)
             for chunk in iter(lambda: content.read(8), b''):
                 make_hex(chunk)
     else:


### PR DESCRIPTION
Zero functional change, this is pure refactoring and preparation for
using the mtime= parameter which the gzip.compress() shortcut does not
make available.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>