### PR TITLE
scripts: Remove accidental semicolons in Python scripts

### DIFF
--- a/arch/x86/gen_mmu_x86.py
+++ b/arch/x86/gen_mmu_x86.py
@@ -199,7 +199,7 @@ class PageMode_PAE:
 
         # L1TF mitigation: map non-present pages to the NULL page
         if present:
-            binary_value |= page_table;
+            binary_value |= page_table
 
         return binary_value
 

--- a/boards/xtensa/intel_s1000_crb/support/create_board_img.py
+++ b/boards/xtensa/intel_s1000_crb/support/create_board_img.py
@@ -64,11 +64,11 @@ def set_partition_table_pointer(value):
     flash_content.append(value)
 
 def ipc_load_fw(fw_size, fw_offset):
-    dword_count = 3;
-    load_flags = 0;
-    clock_sel = 0;
+    dword_count = 3
+    load_flags = 0
+    clock_sel = 0
 
-    dword_count = 0x3ff & dword_count;
+    dword_count = 0x3ff & dword_count
 
     debug("Creating flash image with following options:")
 

--- a/samples/net/google_iot_mqtt/src/private_info/create_keys.py
+++ b/samples/net/google_iot_mqtt/src/private_info/create_keys.py
@@ -97,7 +97,7 @@ def main():
         except subprocess.CalledProcessError as e:
             print(e.output)
 
-        der_fd = open(der_file, "r");
+        der_fd = open(der_file, "r")
         o = subprocess.Popen(["xxd", "-i"], stdin=der_fd, stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT)
 
@@ -112,7 +112,7 @@ def main():
     fd.write(output)
     fd.write("};\n\n")
 
-    fd.write("unsigned int zepfull_private_der_len = " + str(key_len) + ";\n");
+    fd.write("unsigned int zepfull_private_der_len = " + str(key_len) + ";\n")
 
 if __name__ == "__main__":
     main()

--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -508,10 +508,10 @@ class ElfHelper:
             if apiaddr not in all_objs:
                 if apiaddr == 0:
                     self.debug("device instance at 0x%x has no associated subsystem"
-                            % addr);
+                            % addr)
                 else:
                     self.debug("device instance at 0x%x has unknown API 0x%x"
-                            % (addr, apiaddr));
+                            % (addr, apiaddr))
                 # API struct does not correspond to a known subsystem, skip it
                 continue
 


### PR DESCRIPTION
Making a clean slate for some pylint CI tests. Only enabling relatively uncontroversial stuff.

zephyrproject-rtos/ci-tools#37 (just to link)