### PR TITLE
board: nucleo_f429zi: fix wrong comment

### DIFF
--- a/boards/arm/nucleo_f429zi/nucleo_f429zi_defconfig
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi_defconfig
@@ -31,7 +31,7 @@ CONFIG_CLOCK_STM32_PLL_SRC_HSE=y
 # however, the board does not have an external oscillator, so just use
 # the 8MHz clock signal coming from integrated STLink
 CONFIG_CLOCK_STM32_HSE_BYPASS=y
-# produce 180MHz clock at PLL output
+# produce 168MHz clock at PLL output
 CONFIG_CLOCK_STM32_PLL_M_DIVISOR=8
 CONFIG_CLOCK_STM32_PLL_N_MULTIPLIER=336
 CONFIG_CLOCK_STM32_PLL_P_DIVISOR=2


### PR DESCRIPTION
The clock frequency is 168MHz on Nucleo board instead of 180MHz.

Signed-off-by: Jun Li <jun.r.li@intel.com>