### PR TITLE
DMA: stm32f4: Extend meaning of DMA return value 

### DIFF
--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -477,7 +477,7 @@ static void dma_rx_callback(void *arg, u32_t channel, int status)
 	void *mblk_tmp;
 	int ret;
 
-	if (status != 0) {
+	if (status < 0) {
 		ret = -EIO;
 		stream->state = I2S_STATE_ERROR;
 		goto rx_disable;
@@ -543,7 +543,7 @@ static void dma_tx_callback(void *arg, u32_t channel, int status)
 	size_t mem_block_size;
 	int ret;
 
-	if (status != 0) {
+	if (status < 0) {
 		ret = -EIO;
 		stream->state = I2S_STATE_ERROR;
 		goto tx_disable;

--- a/include/dma.h
+++ b/include/dma.h
@@ -130,7 +130,8 @@ struct dma_block_config {
  *
  * dma_callback is the callback function pointer. If enabled, callback function
  *              will be invoked at transfer completion or when error happens
- *              (error_code: zero-transfer success, non zero-error happens).
+ *              (ret_code: zero-transfer success, non zero-defined by specific driver,
+ *                         maybe meaning error happens).
  */
 struct dma_config {
 	u32_t  dma_slot :             6;
@@ -151,7 +152,7 @@ struct dma_config {
 	struct dma_block_config *head_block;
 	void *callback_arg;
 	void (*dma_callback)(void *callback_arg, u32_t channel,
-			     int error_code);
+			     int ret_code);
 };
 
 /**


### PR DESCRIPTION
Extend the meaning of DMA return value which is fed to user's callback function so that the meaning of non-zero return value will be defined by a specific DMA driver.

Specific to STM32's DMA driver,  redefine the return value so that zero means DMA transfer is successful; positive means not only a successful DMA transfer but also how many bytes received for RX DMA cases; negative still means DMA error. Accordingly, updated STM32's I2S driver to correspond to the change. 

The PR also fixes a waiting issue in STM32's DMA driver by reducing one time wait delay to 50ms and aborting after 5 seconds in total when disabling DMA.

The PR tries to be the first step for addressing the issue https://github.com/zephyrproject-rtos/zephyr/issues/13955.