### PR TITLE
arch: arc: fix the unaligned declaration of saved_value

### DIFF
--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -40,8 +40,8 @@ GTEXT(_irq_do_offload);
 
 GDATA(exc_nest_count)
 
-	.balign 4
 SECTION_VAR(BSS, saved_value)
+	.balign 4
 	.word 0
 
 /* the necessary stack size for exception handling */


### PR DESCRIPTION
the original declaration is not aligned to 4 bytes.

Fixes #14767

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>