### PR TITLE
boards: stm32f4_disco: Update openocd config

### DIFF
--- a/boards/arm/stm32f4_disco/support/openocd.cfg
+++ b/boards/arm/stm32f4_disco/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find board/stm32f4discovery.cfg]
+source [find board/st_nucleo_f4.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"


### PR DESCRIPTION
When using V0.10.0 SDK, flashing is not working anymore on
stm32f4_disco.
Using st_nucleo_f4.cfg instead of stm32f4discovery.cfg solves
the issue.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>