### PR TITLE
Bluetooth: samples: IPSP: Fix not checking return of net_pkt_read

### DIFF
--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -163,14 +163,19 @@ static int build_reply(const char *name,
 		       u8_t *buf)
 {
 	int reply_len = net_pkt_remaining_data(pkt);
+	int ret;
 
 	LOG_DBG("%s received %d bytes", name, reply_len);
 
-	net_pkt_read(pkt, buf, reply_len);
+	ret = net_pkt_read(pkt, buf, reply_len);
+	if (ret < 0) {
+		LOG_ERR("cannot read packet: %d", ret);
+		return ret;
+	}
 
-	LOG_DBG("Received %d bytes, sending %d bytes", reply_len, reply_len);
+	LOG_DBG("sending %d bytes", ret);
 
-	return reply_len;
+	return ret;
 }
 
 static inline void pkt_sent(struct net_context *context,


### PR DESCRIPTION
net_pkt_read may fail in which case the error shall be reported back
instead of always assuming the whole packet was read.

Fixes #14817

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>