### PR TITLE
arm: fix thread's FPU initialization

### DIFF
--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -123,6 +123,9 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	pInitCtx->a4 = (u32_t)parameter3;
 	pInitCtx->xpsr =
 		0x01000000UL; /* clear all, thumb bit is 1, even if RO */
+#ifdef CONFIG_FLOAT
+	pInitCtx->fpscr = (u32_t)0; /* clears FPU status/control register*/
+#endif
 
 	thread->callee_saved.psp = (u32_t)pInitCtx;
 	thread->arch.basepri = 0;


### PR DESCRIPTION
FPU's control and status register (FPCSR) for a thread is not initialized.
Random values are written to this register and this leads to failure on
fp_sharing test.
FPCSR register is set to 0 according to the value of FPDSCR.

Signed-off-by: Andrei Gansari <“andrei.gansari@nxp.com”>

Fixes: #14606 #9656