### PR TITLE
soc: sam0: Enable generic peripheral selection

### DIFF
--- a/drivers/flash/Kconfig.sam
+++ b/drivers/flash/Kconfig.sam
@@ -7,6 +7,7 @@ if SOC_FAMILY_SAM
 
 menuconfig SOC_FLASH_SAM
 	bool "Atmel SAM flash driver"
+	default y
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
 	help

--- a/drivers/flash/Kconfig.sam0
+++ b/drivers/flash/Kconfig.sam0
@@ -7,6 +7,7 @@ if SOC_FAMILY_SAM0
 
 menuconfig SOC_FLASH_SAM0
 	bool "Atmel SAM0 flash driver"
+	default y
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
 	help

--- a/drivers/gpio/Kconfig.sam
+++ b/drivers/gpio/Kconfig.sam
@@ -5,6 +5,7 @@
 
 menuconfig GPIO_SAM
 	bool "Atmel SAM GPIO (PORT) driver"
+	default y
 	depends on SOC_FAMILY_SAM
 	select HAS_DTS_GPIO
 	help

--- a/drivers/gpio/Kconfig.sam0
+++ b/drivers/gpio/Kconfig.sam0
@@ -5,6 +5,7 @@
 
 menuconfig GPIO_SAM0
 	bool "Atmel SAM0 GPIO (PORT) driver"
+	default y
 	depends on SOC_FAMILY_SAM0
 	select HAS_DTS_GPIO
 	help

--- a/drivers/pinmux/Kconfig.sam0
+++ b/drivers/pinmux/Kconfig.sam0
@@ -5,6 +5,7 @@
 
 menuconfig PINMUX_SAM0
 	bool "Atmel SAM0 pin multiplexer driver"
+	default y
 	depends on SOC_FAMILY_SAM0
 	help
 	  Enable support for the Atmel SAM0 PORT pin multiplexer.

--- a/drivers/serial/Kconfig.sam0
+++ b/drivers/serial/Kconfig.sam0
@@ -5,6 +5,7 @@
 
 menuconfig UART_SAM0
 	bool "Atmel SAM0 series SERCOM USART driver"
+	default y
 	depends on SOC_FAMILY_SAM0
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT

--- a/drivers/spi/Kconfig.sam
+++ b/drivers/spi/Kconfig.sam
@@ -5,6 +5,7 @@
 
 menuconfig SPI_SAM
 	bool "Atmel SAM series SPI driver"
+	default y
 	depends on SOC_FAMILY_SAM
 	help
 	  Enable support for the SAM SPI driver.

--- a/drivers/spi/Kconfig.sam0
+++ b/drivers/spi/Kconfig.sam0
@@ -5,6 +5,7 @@
 
 menuconfig SPI_SAM0
 	bool "Atmel SAM0 series SERCOM SPI driver"
+	default y
 	depends on SOC_FAMILY_SAM0
 	help
 	  Enable support for the SAM0 SERCOM SPI driver.

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -43,6 +43,7 @@ config USB_DC_STM32
 
 config USB_DC_SAM0
 	bool "SAM0 series USB Device Controller driver"
+	default y
 	depends on SOC_FAMILY_SAM0
 	select USB_DEVICE_DRIVER
 	help


### PR DESCRIPTION
Make sure that when e.g. CONFIG_SERIAL is set, CONFIG_UART_SAM0 is
selected automatically when the sam0 SoC family is used.

This fixes several examples & tests that will otherwise only compile after manually tweaking the configuration.