### PR TITLE
Bluetooth: Fix several issues related to initialization with BT_SETTINGS

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1919,6 +1919,10 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 {
 	struct bt_conn *conn;
 
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return NULL;
+	}
+
 	if (!bt_le_conn_params_valid(param)) {
 		return NULL;
 	}

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -5265,6 +5265,10 @@ int bt_le_adv_start_internal(const struct bt_le_adv_param *param,
 	bool dir_adv = (peer != NULL);
 	int err = 0;
 
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
+
 	if (!valid_adv_param(param, dir_adv)) {
 		return -EINVAL;
 	}
@@ -5456,6 +5460,10 @@ static bool valid_le_scan_param(const struct bt_le_scan_param *param)
 int bt_le_scan_start(const struct bt_le_scan_param *param, bt_le_scan_cb_t cb)
 {
 	int err;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
 
 	/* Check that the parameters have valid values */
 	if (!valid_le_scan_param(param)) {

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -197,8 +197,7 @@ void bt_id_add(struct bt_keys *keys);
 void bt_id_del(struct bt_keys *keys);
 
 int bt_setup_id_addr(void);
-
-void bt_dev_show_info(void);
+void bt_finalize_init(void);
 
 int bt_le_adv_start_internal(const struct bt_le_adv_param *param,
 			     const struct bt_data *ad, size_t ad_len,

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -231,13 +231,15 @@ static int commit(void)
 		}
 	}
 
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		bt_finalize_init();
+	}
+
 	for (h = _bt_settings_start; h < _bt_settings_end; h++) {
 		if (h->commit) {
 			h->commit();
 		}
 	}
-
-	bt_dev_show_info();
 
 	return 0;
 }


### PR DESCRIPTION
These two patches fix several critical details when it comes to initializing the stack when BT_SETTINGS is used.

Fixes #14833 