### PR TITLE
RFC: Bluetooth: controller: Workaround checking MIC at Enc Setup

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl_internal.h
@@ -102,13 +102,13 @@ struct connection {
 
 	union {
 		struct {
-			u8_t reserved:5;
+			u8_t reserved:6;
 			u8_t fex_valid:1;
 		} common;
 
 		struct {
 			u8_t terminate_ack:1;
-			u8_t rfu:4;
+			u8_t rfu:5;
 			u8_t fex_valid:1;
 		} master;
 
@@ -116,6 +116,7 @@ struct connection {
 			u8_t  latency_enabled:1;
 			u8_t  latency_cancel:1;
 			u8_t  sca:3;
+			u8_t  enc_wa:1;
 			u8_t  fex_valid:1;
 			u32_t window_widening_periodic_us;
 			u32_t window_widening_max_us;


### PR DESCRIPTION
Add workaround to avoid checking MIC of unexpected PDUs
during an Encryption Setup Procedure.

Fixes #14044.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>