### PR TITLE
stm32f407Xg: RAM is 128K + 64K CCM

### DIFF
--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.yaml
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 256
+ram: 192
 flash: 2048
 supported:
   - arduino_i2c

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.yaml
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.yaml
@@ -6,6 +6,8 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+ram: 128
+flash: 1024
 supported:
   - rtc
   - counter

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.yaml
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.yaml
@@ -6,6 +6,8 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+ram: 128
+flash: 1024
 supported:
   - rtc
   - counter

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.yaml
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.yaml
@@ -6,6 +6,8 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+ram: 128
+flash: 1024
 supported:
   - rtc
   - counter

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -16,6 +16,7 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,ccm = &ccm0;
 	};
 
 	leds {

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
@@ -6,6 +6,8 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+ram: 192
+flash: 2048
 supported:
   - rtc
   - counter

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -16,6 +16,7 @@
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,ccm = &ccm0;
 	};
 
 	leds {

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.yaml
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.yaml
@@ -6,6 +6,8 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+ram: 320
+flash: 2048
 supported:
   - arduino_i2c
   - rtc

--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -16,6 +16,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,ccm = &ccm0;
 	};
 
 	leds {

--- a/boards/arm/stm32f4_disco/stm32f4_disco.yaml
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.yaml
@@ -6,6 +6,8 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+ram: 320
+flash: 1024
 supported:
   - pwm
   - rtc

--- a/dts/arm/st/f4/stm32f405Xg.dtsi
+++ b/dts/arm/st/f4/stm32f405Xg.dtsi
@@ -14,7 +14,7 @@
 	};
 
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(192)>;
+		reg = <0x20000000 DT_SIZE_K(128)>;
 	};
 
 	soc {

--- a/dts/arm/st/f4/stm32f407Xg.dtsi
+++ b/dts/arm/st/f4/stm32f407Xg.dtsi
@@ -14,7 +14,7 @@
 	};
 
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(192)>;
+		reg = <0x20000000 DT_SIZE_K(128)>;
 	};
 
 	soc {

--- a/dts/arm/st/f4/stm32f417Xe.dtsi
+++ b/dts/arm/st/f4/stm32f417Xe.dtsi
@@ -14,7 +14,7 @@
 	};
 
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(192)>;
+		reg = <0x20000000 DT_SIZE_K(128)>;
 	};
 
 	soc {

--- a/dts/arm/st/f4/stm32f417Xg.dtsi
+++ b/dts/arm/st/f4/stm32f417Xg.dtsi
@@ -14,7 +14,7 @@
 	};
 
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(192)>;
+		reg = <0x20000000 DT_SIZE_K(128)>;
 	};
 
 	soc {

--- a/dts/arm/st/f4/stm32f429Xi.dtsi
+++ b/dts/arm/st/f4/stm32f429Xi.dtsi
@@ -14,7 +14,7 @@
 	};
 
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(256)>;
+		reg = <0x20000000 DT_SIZE_K(192)>;
 	};
 
 	soc {

--- a/dts/arm/st/f4/stm32f469Xi.dtsi
+++ b/dts/arm/st/f4/stm32f469Xi.dtsi
@@ -14,7 +14,7 @@
 	};
 
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(384)>;
+		reg = <0x20000000 DT_SIZE_K(320)>;
 	};
 
 	soc {


### PR DESCRIPTION
stm32f407Xg package was defined with 192K RAM + 64K CCM.
This is wrong as total RAM is 192, including 64K CCM.

Fix RAM size definition

Fixes #14779