### PR TITLE
spi: sam0: make the driver work again

### DIFF
--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -416,7 +416,7 @@ static int spi_sam0_transceive_async(struct device *dev,
 				     struct k_poll_signal *async)
 {
 	/* TODO: actually implement asyc transceive */
-	return spi_sam0_transceive(dev, config, tx_bufs, rx_bufs);
+	return -ENOTSUP;
 }
 #endif /* CONFIG_SPI_ASYNC */
 

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -408,9 +408,6 @@ static int spi_sam0_transceive_sync(struct device *dev,
 				    const struct spi_buf_set *tx_bufs,
 				    const struct spi_buf_set *rx_bufs)
 {
-	struct spi_sam0_data *data = dev->driver_data;
-
-	spi_context_lock(&data->ctx, false, NULL);
 	return spi_sam0_transceive(dev, config, tx_bufs, rx_bufs);
 }
 
@@ -421,9 +418,7 @@ static int spi_sam0_transceive_async(struct device *dev,
 				     const struct spi_buf_set *rx_bufs,
 				     struct k_poll_signal *async)
 {
-	struct spi_sam0_data *data = dev->driver_data;
-
-	spi_context_lock(&data->ctx, true, async);
+	/* TODO: actually implement asyc transceive */
 	return spi_sam0_transceive(dev, config, tx_bufs, rx_bufs);
 }
 #endif /* CONFIG_SPI_ASYNC */


### PR DESCRIPTION
Currently, when running `tests/drivers/spi/spi_loopback` on samr21_xpro, the test will deadlock.

This is because `spi_context_lock()` is being called twice (introduced by eae05d928e0c04b362b9dc28f60e4e96f08140cd)
After fixing this, the driver still crashes as `spi_context_cs_configure()` tries to access `ctx->config` which is only set after the call.

It also changes the behavior of the `spi_sam0_configure()` function. Calling it will always apply the given configuration and it's the responsibility of the caller (`spi_sam0_transceive()`) to check if the device has already been configured. This way it's still possible to change the configuration if this is desired at some point.

eae05d928e0c04b362b9dc28f60e4e96f08140cd also made the driver claim it supported async transceive, which is currently not the case. This breaks the spi_loopback test case.

With this applied, `tests/drivers/spi/spi_loopback` is working again (just bridge the MOSI and MISO pin).