### PR TITLE
settings: Fix check for duplicate when new value is smaller

### DIFF
--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -155,6 +155,10 @@ int settings_save_one(const char *name, void *value, size_t val_len)
 		return -ENOENT;
 	}
 
+	if (val_len > 0 && value == NULL) {
+		return -EINVAL;
+	}
+
 	/*
 	 * Check if we're writing the same value again.
 	 */

--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -125,16 +125,13 @@ static void settings_dup_check_cb(char *name, void *val_read_cb_ctx, off_t off,
 	}
 
 	len_read = settings_line_val_get_len(off, val_read_cb_ctx);
-	if (len_read == 0) {
-		/* treat as an empty entry */
-		if (!cdca->val || cdca->val_len == 0) {
-			cdca->is_dup = 1;
-		} else {
-			cdca->is_dup = 0;
-		}
+	if (len_read != cdca->val_len) {
+		cdca->is_dup = 0;
+	} else if (len_read == 0) {
+		cdca->is_dup = 1;
 	} else {
-		if (cdca->val && !settings_cmp(cdca->val, cdca->val_len,
-					       val_read_cb_ctx, off)) {
+		if (!settings_cmp(cdca->val, cdca->val_len,
+				  val_read_cb_ctx, off)) {
 			cdca->is_dup = 1;
 		} else {
 			cdca->is_dup = 0;


### PR DESCRIPTION
The code for checking duplicates in the existing settings store was
incorrectly identifying a new value with the same initial content but
shorter length as a duplicate. Fix this by doing an early check on a
new vs old length mismatch, and immediately flag this as not a
duplicate.

Fixes #14840

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>