### PR TITLE
kernel/sched: Rework prio validity assertion

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -12,13 +12,16 @@
 #include <tracing.h>
 #include <stdbool.h>
 
+BUILD_ASSERT(K_LOWEST_APPLICATION_THREAD_PRIO
+	     >= K_HIGHEST_APPLICATION_THREAD_PRIO);
+
 #ifdef CONFIG_MULTITHREADING
-#define Z_VALID_PRIO(prio, entry_point) \
+#define Z_VALID_PRIO(prio, entry_point)				     \
 	(((prio) == K_IDLE_PRIO && z_is_idle_thread(entry_point)) || \
-		 (z_is_prio_higher_or_equal((prio), \
-			K_LOWEST_APPLICATION_THREAD_PRIO) && \
-		  z_is_prio_lower_or_equal((prio), \
-			K_HIGHEST_APPLICATION_THREAD_PRIO)))
+	 ((K_LOWEST_APPLICATION_THREAD_PRIO			     \
+	   >= K_HIGHEST_APPLICATION_THREAD_PRIO)		     \
+	  && (prio) >= K_HIGHEST_APPLICATION_THREAD_PRIO	     \
+	  && (prio) <= K_LOWEST_APPLICATION_THREAD_PRIO))
 
 #define Z_ASSERT_VALID_PRIO(prio, entry_point) do { \
 	__ASSERT(Z_VALID_PRIO((prio), (entry_point)), \


### PR DESCRIPTION
This is throwing errors in static analysis, complaining that comparing
that a prior is higher and lower is impossible.  That is wrong per my
eyes (I swear I think it might be cueing off the names of the
functions, which invert "higher" and "lower" to match our reversed
priority numbers).

But frankly this was never a very readable macro to begin with.
Refactor to put the bounds into the term, so the static analyzer can
prove it locally, and add a build assertion to catch any errors (there
are none currently) where the low<->high priority range is invalid.

Long term, we should probably remove this macro, it doesn't provide
much value.  But removing it in response to a static analysis failure
is... not very responsible as a development practice.

Fixes #14816
Fixes #14820

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>