### PR TITLE
logging: kconfig: Make it clearer that SYS_LOG is legacy

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -5,118 +5,14 @@
 #
 menu "Logging Options"
 
-config SYS_LOG
-	bool "Enable Logging"
-	depends on PRINTK
-	help
-	  Global switch for logging, when turned off log calls will not be
-	  executed.
-
-config SYS_LOG_SHOW_TAGS
-	bool "Prepend level tags to logs"
-	depends on SYS_LOG
-	default y
-	help
-	  Prefixes all log lines with an identifier to the log level submitted in
-	  the C code.
-
-config SYS_LOG_SHOW_COLOR
-	bool "Use colored logs"
-	depends on SYS_LOG
-	help
-	  Use color in the logs. This requires an ANSI capable terminal.
-
-config SYS_LOG_DEFAULT_LEVEL
-	int "Default log level"
-	depends on SYS_LOG
-	default 0
-	range 0 4
-	help
-	  Sets log level for modules which don't specify it explicitly. When
-	  set to 0 it means log wont be activated for those modules.
-	  Levels are:
-	  0 OFF, do not write by default
-	  1 ERROR, default to only write SYS_LOG_ERR
-	  2 WARNING, default to write SYS_LOG_WRN in addition to previous level
-	  3 INFO, default to write SYS_LOG_INF in addition to previous levels
-	  4 DEBUG, default to write SYS_LOG_DBG in addition to previous levels
-
-config SYS_LOG_OVERRIDE_LEVEL
-	int "Override lowest log level"
-	depends on SYS_LOG
-	default 0
-	range 0 4
-	help
-	  Forces a minimum log level for all modules. Modules use their
-	  specified level if it is greater than this option, otherwise they use
-	  the level specified by this option instead of their default or
-	  whatever was manually set.
-	  Levels are:
-	  0 OFF, do not override
-	  1 ERROR, override to write SYS_LOG_ERR
-	  2 WARNING, override to write SYS_LOG_WRN in addition to previous level
-	  3 INFO, override to write SYS_LOG_INF in addition to previous levels
-	  4 DEBUG, override to write SYS_LOG_DBG in addition to previous levels
-
-config SYS_LOG_EXT_HOOK
-	bool "Use external hook function for logging"
-	depends on SYS_LOG
-	help
-	  Use external hook function for logging.
-
-config SYS_LOG_BACKEND_NET
-	bool "Networking syslog backend"
-	depends on SYS_LOG && NETWORKING
-	select SYS_LOG_EXT_HOOK
-	select NET_CONTEXT_NET_PKT_POOL
-	help
-	  Send syslog messages to network server.
-	  See RFC 5424 (syslog protocol) and RFC 5426 (syslog over UDP)
-	  specifications for details.
-
-if SYS_LOG_BACKEND_NET
-
-config SYS_LOG_BACKEND_NET_SERVER
-	string "Syslog server IP address"
-	help
-	  This can be either IPv4 or IPv6 address.
-	  Server listen UDP port number can be configured here too.
-	  Following syntax is supported:
-	  192.0.2.1:514
-	  192.0.2.42
-	  [2001:db8::1]:514
-	  [2001:db8::2]
-	  2001:db::42
-
-config SYS_LOG_BACKEND_NET_MAX_BUF
-	int "How many network buffers to allocate for sending messages"
-	range 3 256
-	default 3
-	help
-	  Each syslog message will occupy one network buffer.
-
-config SYS_LOG_BACKEND_NET_MAX_BUF_SIZE
-	int "Max syslog message size"
-	range 64 1180
-	default 256
-	help
-	  As each syslog message needs to fit to UDP packet, set this value
-	  so that messages are not truncated.
-	  The RFC 5426 recommends that for IPv4 the size is 480 octets and for
-	  IPv6 the size is 1180 octets. As each buffer will use RAM, the value
-	  should be selected so that typical messages will fit the buffer.
-	  The total allocated memory will be
-	  SYS_LOG_BACKEND_NET_MAX_BUF * SYS_LOG_BACKEND_NET_MAX_BUF_SIZE
-
-endif
-
 config LOG
-	bool "Enable Logger"
+	bool "Enable logger"
 	help
 	  Global switch for the logger, when turned off log calls will not be
 	  compiled in.
 
 if LOG
+
 config LOG_RUNTIME_FILTERING
 	bool "Enable runtime reconfiguration of the logger"
 	help
@@ -412,7 +308,7 @@ config LOG_BACKEND_RTT_RETRY_DELAY_MS
 	  case of heavy traffic data can be lost and it may be necessary to
 	  increase delay or number of retries.
 
-endif #LOG_BACKEND_RTT_MODE_BLOCK
+endif # LOG_BACKEND_RTT_MODE_BLOCK
 
 config LOG_BACKEND_RTT_BUFFER
 	int "Buffer number used for logger output."
@@ -528,5 +424,114 @@ config LOG_BACKEND_FORMAT_TIMESTAMP
 	help
 	  When enabled timestamp is formatted to hh:mm:ss:ms,us.
 
-endif
+endif # LOG
+
+
+# Legacy logging
+
+config SYS_LOG
+	bool "Enable legacy logging"
+	depends on PRINTK
+	help
+	  Global switch for legacy logging. When turned off, log calls will not be
+	  executed.
+
+config SYS_LOG_SHOW_TAGS
+	bool "Prepend level tags to logs"
+	depends on SYS_LOG
+	default y
+	help
+	  Prefixes all log lines with an identifier to the log level submitted in
+	  the C code.
+
+config SYS_LOG_SHOW_COLOR
+	bool "Use colored logs"
+	depends on SYS_LOG
+	help
+	  Use color in the logs. This requires an ANSI capable terminal.
+
+config SYS_LOG_DEFAULT_LEVEL
+	int "Default log level"
+	depends on SYS_LOG
+	default 0
+	range 0 4
+	help
+	  Sets log level for modules which don't specify it explicitly. When
+	  set to 0 it means log wont be activated for those modules.
+	  Levels are:
+	  0 OFF, do not write by default
+	  1 ERROR, default to only write SYS_LOG_ERR
+	  2 WARNING, default to write SYS_LOG_WRN in addition to previous level
+	  3 INFO, default to write SYS_LOG_INF in addition to previous levels
+	  4 DEBUG, default to write SYS_LOG_DBG in addition to previous levels
+
+config SYS_LOG_OVERRIDE_LEVEL
+	int "Override lowest log level"
+	depends on SYS_LOG
+	default 0
+	range 0 4
+	help
+	  Forces a minimum log level for all modules. Modules use their
+	  specified level if it is greater than this option, otherwise they use
+	  the level specified by this option instead of their default or
+	  whatever was manually set.
+	  Levels are:
+	  0 OFF, do not override
+	  1 ERROR, override to write SYS_LOG_ERR
+	  2 WARNING, override to write SYS_LOG_WRN in addition to previous level
+	  3 INFO, override to write SYS_LOG_INF in addition to previous levels
+	  4 DEBUG, override to write SYS_LOG_DBG in addition to previous levels
+
+config SYS_LOG_EXT_HOOK
+	bool "Use external hook function for logging"
+	depends on SYS_LOG
+	help
+	  Use external hook function for logging.
+
+config SYS_LOG_BACKEND_NET
+	bool "Networking syslog backend"
+	depends on SYS_LOG && NETWORKING
+	select SYS_LOG_EXT_HOOK
+	select NET_CONTEXT_NET_PKT_POOL
+	help
+	  Send syslog messages to network server.
+	  See RFC 5424 (syslog protocol) and RFC 5426 (syslog over UDP)
+	  specifications for details.
+
+if SYS_LOG_BACKEND_NET
+
+config SYS_LOG_BACKEND_NET_SERVER
+	string "Syslog server IP address"
+	help
+	  This can be either IPv4 or IPv6 address.
+	  Server listen UDP port number can be configured here too.
+	  Following syntax is supported:
+	  192.0.2.1:514
+	  192.0.2.42
+	  [2001:db8::1]:514
+	  [2001:db8::2]
+	  2001:db::42
+
+config SYS_LOG_BACKEND_NET_MAX_BUF
+	int "How many network buffers to allocate for sending messages"
+	range 3 256
+	default 3
+	help
+	  Each syslog message will occupy one network buffer.
+
+config SYS_LOG_BACKEND_NET_MAX_BUF_SIZE
+	int "Max syslog message size"
+	range 64 1180
+	default 256
+	help
+	  As each syslog message needs to fit to UDP packet, set this value
+	  so that messages are not truncated.
+	  The RFC 5426 recommends that for IPv4 the size is 480 octets and for
+	  IPv6 the size is 1180 octets. As each buffer will use RAM, the value
+	  should be selected so that typical messages will fit the buffer.
+	  The total allocated memory will be
+	  SYS_LOG_BACKEND_NET_MAX_BUF * SYS_LOG_BACKEND_NET_MAX_BUF_SIZE
+
+endif # SYS_LOG_BACKEND_NET
+
 endmenu


### PR DESCRIPTION
Change the prompt of SYS_LOG from "Enable Logging" to "Enable legacy
logging", and move the SYS_LOG stuff to after the LOG stuff (the new
logger).

Previously, you got "Enable Logging" (legacy logger) followed by "Enable
Logger" in the same menu, with no indication that they're different
systems.

Fixes: #14240