### PR TITLE
samples: net: can: initialize the variables

### DIFF
--- a/samples/net/sockets/can/src/main.c
+++ b/samples/net/sockets/can/src/main.c
@@ -23,8 +23,8 @@ static struct k_thread tx_data;
 static void tx(int *can_fd)
 {
 	int fd = POINTER_TO_INT(can_fd);
-	struct zcan_frame msg;
-	struct can_frame frame;
+	struct zcan_frame msg = {0};
+	struct can_frame frame = {0};
 	int ret, i;
 
 	msg.dlc = 8;


### PR DESCRIPTION
Initialize the variables.

Fix Bug: #14819
Coverity CID: 196637

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>