### PR TITLE
samples: net: nat: Check null before dereferrencing the variable

### DIFF
--- a/samples/net/nats/src/nats.c
+++ b/samples/net/nats/src/nats.c
@@ -552,6 +552,11 @@ static void receive_cb(struct net_context *ctx,
 	}
 
 	tmp = pkt->cursor.buf;
+	if (!tmp) {
+		net_pkt_unref(pkt);
+		return;
+	}
+
 	pos = pkt->cursor.pos - tmp->data;
 
 	while (tmp) {


### PR DESCRIPTION
This patch checks null before deferencing the variable.

Fix Bug: #14815
Coverity CID: 196641

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>