### PR TITLE
codecov: avoid inlining functions for correct execution counts

### DIFF
--- a/arch/arm/core/CMakeLists.txt
+++ b/arch/arm/core/CMakeLists.txt
@@ -3,6 +3,7 @@ zephyr_library()
 zephyr_compile_options_ifdef(CONFIG_COVERAGE_GCOV
   -ftest-coverage
   -fprofile-arcs
+  -fno-inline
   )
 
 zephyr_library_sources(

--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -12,6 +12,7 @@ zephyr_include_directories(${BOARD_DIR})
 zephyr_compile_options_ifdef(CONFIG_COVERAGE
   -fprofile-arcs
   -ftest-coverage
+  -fno-inline
 )
 zephyr_link_libraries_ifdef(CONFIG_COVERAGE
 	-lgcov

--- a/arch/x86/core/CMakeLists.txt
+++ b/arch/x86/core/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 zephyr_compile_options_ifdef(CONFIG_COVERAGE_GCOV
   -ftest-coverage
   -fprofile-arcs
+  -fno-inline
   )
 
 zephyr_library_sources(

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -89,7 +89,20 @@
 /* force inlining a function */
 
 #if !defined(_ASMLANGUAGE)
-  #define ALWAYS_INLINE inline __attribute__((always_inline))
+  #ifdef CONFIG_COVERAGE
+    /*
+     * The always_inline attribute forces a function to be inlined,
+     * even ignoring -fno-inline. So for code coverage, do not
+     * inline these functions to keep their bodies around so their
+     * number of executions can be counted.
+     *
+     * The unused attribute is here to avoid the compiler complaining
+     * about these functions being unused.
+     */
+    #define ALWAYS_INLINE __attribute__((unused))
+  #else
+    #define ALWAYS_INLINE inline __attribute__((always_inline))
+  #endif
 #endif
 
 #define Z_STRINGIFY(x) #x


### PR DESCRIPTION
This adds a compiler option -fno-inline for code coverage on
architectures which supports doing code coverage. This also
modifies the ALWAYS_INLINE macro to not do any inlining. This
needs to be done so code coverage can count the number of
executions to the correct lines.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>