### PR TITLE
driver: api: uart: remove exclusive limit on async api

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -33,14 +33,12 @@ config UART_ASYNC_API
 	help
 	  This option enables new asynchronous UART API.
 
-if UART_ASYNC_API=n
 config UART_INTERRUPT_DRIVEN
 	bool "Enable UART Interrupt support"
 	depends on SERIAL_SUPPORT_INTERRUPT
 	help
 	  This option enables interrupt support for UART allowing console
 	  input and other UART based drivers.
-endif
 
 config UART_LINE_CTRL
 	bool "Enable Serial Line Control API"

--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -53,7 +53,7 @@ config UART_0_INTERRUPT_DRIVEN
 
 config UART_0_ASYNC
 	bool "Enable Asynchronous API support on port 0"
-	depends on UART_ASYNC_API
+	depends on UART_ASYNC_API && !UART_0_INTERRUPT_DRIVEN
 	default y
 	help
 	  This option enables UART Asynchronous API support on port 0.
@@ -117,7 +117,7 @@ config UART_1_INTERRUPT_DRIVEN
 
 config UART_1_ASYNC
 	bool "Enable Asynchronous API support on port 1"
-	depends on UART_ASYNC_API
+	depends on UART_ASYNC_API && !UART_1_INTERRUPT_DRIVEN
 	default y
 	help
 	  This option enables UART Asynchronous API support on port 1.
@@ -180,7 +180,7 @@ config UART_2_INTERRUPT_DRIVEN
 
 config UART_2_ASYNC
 	bool "Enable Asynchronous API support on port 2"
-	depends on UART_ASYNC_API
+	depends on UART_ASYNC_API && !UART_2_INTERRUPT_DRIVEN
 	default y
 	help
 	  This option enables UART Asynchronous API support on port 2.
@@ -242,7 +242,7 @@ config UART_3_INTERRUPT_DRIVEN
 
 config UART_3_ASYNC
 	bool "Enable Asynchronous API support on port 3"
-	depends on UART_ASYNC_API
+	depends on UART_ASYNC_API && !UART_3_INTERRUPT_DRIVEN
 	default y
 	help
 	  This option enables UART Asynchronous API support on port 3.

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -38,7 +38,7 @@ static inline const struct uart_nrfx_config *get_dev_config(struct device *dev)
 	return dev->config->config_info;
 }
 
-#ifdef CONFIG_UART_ASYNC_API
+#ifdef CONFIG_UART_0_ASYNC
 static struct {
 	uart_callback_t callback;
 	void *user_data;
@@ -63,7 +63,7 @@ static struct {
 	struct k_delayed_work tx_timeout_work;
 #endif
 } uart0_cb;
-#endif /* CONFIG_UART_ASYNC_API */
+#endif /* CONFIG_UART_0_ASYNC */
 
 #ifdef CONFIG_UART_0_INTERRUPT_DRIVEN
 
@@ -319,7 +319,7 @@ static int uart_nrfx_config_get(struct device *dev, struct uart_config *cfg)
 }
 
 
-#ifdef CONFIG_UART_ASYNC_API
+#ifdef CONFIG_UART_0_ASYNC
 
 static void user_callback(struct uart_event *event)
 {
@@ -656,7 +656,7 @@ static void tx_timeout(struct k_work *work)
 }
 #endif
 
-#endif /* CONFIG_UART_ASYNC_API */
+#endif /* CONFIG_UART_0_ASYNC */
 
 
 #ifdef CONFIG_UART_0_INTERRUPT_DRIVEN
@@ -895,7 +895,7 @@ static int uart_nrfx_init(struct device *dev)
 	uart_sw_event_txdrdy = 1U;
 #endif
 
-#if defined(CONFIG_UART_ASYNC_API) || defined(CONFIG_UART_0_INTERRUPT_DRIVEN)
+#if defined(CONFIG_UART_0_ASYNC) || defined(CONFIG_UART_0_INTERRUPT_DRIVEN)
 
 	IRQ_CONNECT(DT_NORDIC_NRF_UART_UART_0_IRQ,
 		    DT_NORDIC_NRF_UART_UART_0_IRQ_PRIORITY,
@@ -905,7 +905,7 @@ static int uart_nrfx_init(struct device *dev)
 	irq_enable(DT_NORDIC_NRF_UART_UART_0_IRQ);
 #endif
 
-#ifdef CONFIG_UART_ASYNC_API
+#ifdef CONFIG_UART_0_ASYNC
 	k_delayed_work_init(&uart0_cb.rx_timeout_work, rx_timeout);
 #if	defined(DT_NORDIC_NRF_UART_UART_0_RTS_PIN) && \
 	defined(DT_NORDIC_NRF_UART_UART_0_CTS_PIN)
@@ -919,14 +919,14 @@ static int uart_nrfx_init(struct device *dev)
  * because Nordic hardware does not distinguish between them.
  */
 static const struct uart_driver_api uart_nrfx_uart_driver_api = {
-#ifdef CONFIG_UART_ASYNC_API
+#ifdef CONFIG_UART_0_ASYNC
 	.callback_set	  = uart_nrfx_callback_set,
 	.tx		  = uart_nrfx_tx,
 	.tx_abort	  = uart_nrfx_tx_abort,
 	.rx_enable	  = uart_nrfx_rx_enable,
 	.rx_buf_rsp	  = uart_nrfx_rx_buf_rsp,
 	.rx_disable	  = uart_nrfx_rx_disable,
-#endif /* CONFIG_UART_ASYNC_API */
+#endif /* CONFIG_UART_0_ASYNC */
 	.poll_in          = uart_nrfx_poll_in,
 	.poll_out         = uart_nrfx_poll_out,
 	.err_check        = uart_nrfx_err_check,

--- a/include/uart.h
+++ b/include/uart.h
@@ -328,7 +328,7 @@ struct uart_device_config {
 
 	u32_t sys_clk_freq;
 
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 	uart_irq_config_func_t	irq_config_func;
 #endif
 };


### PR DESCRIPTION
The PR removes the exclusive limit on enabling both UART_ASYNC_API
and UART_INTERRUPT_DRIVEN so that both options can be enabled
together for same UART driver. 

The reason to enable both is that a UART driver could
need to support multiple UART ports. One port could be configured as the one
with ASYNC API enabled while the other one could support SHELL which requires
UART_INTERRUPT_DRIVEN enabled. In that case, the driver needs to support
both features. 

Also, the interrupt handler will be used for both cases. So, enable
definition of interrupt handler for both.

However, nRF UART driver still wants to enable only one of them.
So, a new config is added to disable the code for UART_ASYNC_API
when the option UART_INTERRUPT_DRIVEN is enabled.

This PR is part of efforts to resolve the issue 
https://github.com/zephyrproject-rtos/zephyr/issues/13955. 
