### PR TITLE
tests: mbox: Check k_mbox_get return

### DIFF
--- a/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
+++ b/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
@@ -378,7 +378,8 @@ static void tmbox_get(struct k_mbox *pmbox)
 	case BLOCK_GET_INVALID_POOL:
 		/* To dispose of the rx msg using block get */
 		mmsg.rx_source_thread = K_ANY;
-		k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER);
+		zassert_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
+			     NULL);
 		zassert_true(k_mbox_data_block_get
 			     (&mmsg, NULL, NULL, K_FOREVER) == 0,
 			     NULL);


### PR DESCRIPTION
Coverity was complaining that this function was not being checked only
in a specific case.

Coverity CID: 183066

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>