### PR TITLE
doc: fix ACRN board list format

### DIFF
--- a/boards/x86/acrn/doc/index.rst
+++ b/boards/x86/acrn/doc/index.rst
@@ -40,7 +40,7 @@ On the Zephyr Build System
 --------------------------
 
 #. The build process for the ACRN UOS target is similar to other boards. We
-will build the :ref:`hello_world` sample for ACRN with:
+   will build the :ref:`hello_world` sample for ACRN with:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world


### PR DESCRIPTION
One of the bullet list items didn't get rendered properly because
continuation line wasn't indented.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>