### PR TITLE
drivers: dma: Add SAM0 DMA driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -107,6 +107,7 @@
 /drivers/clock_control/*stm32f4*          @rsalveti @idlethread
 /drivers/counter/                         @anangl
 /drivers/display/                         @vanwinkeljan
+/drivers/dma/*sam0*                       @nzmichaelh @benpicco
 /drivers/ethernet/                        @jukkar @tbursztyka @pfalcon
 /drivers/flash/                           @nashif
 /drivers/flash/*stm32*                    @superna9999

--- a/drivers/dma/CMakeLists.txt
+++ b/drivers/dma/CMakeLists.txt
@@ -1,6 +1,7 @@
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_DMA_QMSI		dma_qmsi.c)
+zephyr_library_sources_ifdef(CONFIG_DMA_SAM0		dma_sam0.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_SAM_XDMAC	dma_sam_xdmac.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_STM32F4X	dma_stm32f4x.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_CAVS		dma_cavs.c)

--- a/drivers/dma/Kconfig
+++ b/drivers/dma/Kconfig
@@ -63,4 +63,6 @@ source "drivers/dma/Kconfig.cavs"
 
 source "drivers/dma/Kconfig.nios2_msgdma"
 
+source "drivers/dma/Kconfig.sam0"
+
 endif # DMA

--- a/drivers/dma/Kconfig.sam0
+++ b/drivers/dma/Kconfig.sam0
@@ -1,0 +1,11 @@
+# Kconfig - Atmel SAM DMAC configuration options
+#
+# Copyright (c) 2018 Google LLC.
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig DMA_SAM0
+	bool "Atmel SAM0 series DMAC driver"
+	default y
+	depends on SOC_FAMILY_SAM0
+	help
+	DMA driver for Atmel SAM0 series MCUs.

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2018 Google LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define SYS_LOG_LEVEL CONFIG_SYS_LOG_DMA_LEVEL
+#define SYS_LOG_DOMAIN "dma"
+#include <logging/sys_log.h>
+
+#include <soc.h>
+#include <dma.h>
+
+typedef void (*dma_callback)(void *ctx, u32_t channel,
+			     int error_code);
+
+struct dma_sam0_device {
+	__aligned(16) DmacDescriptor descriptors[DMAC_CH_NUM];
+	__aligned(16) DmacDescriptor descriptors_wb[DMAC_CH_NUM];
+	dma_callback cb[DMAC_CH_NUM];
+};
+
+/* Handles DMA channel interrupts and dispatches to the callback */
+static void dma_sam0_channel_isr(struct device *dev,
+				 struct dma_sam0_device *data, int channel)
+{
+	u8_t ints = DMAC->CHINTFLAG.reg & DMAC->CHINTENSET.reg;
+	dma_callback cb = data->cb[channel];
+
+	/* Acknowledge all interrupts */
+	DMAC->CHINTFLAG.reg = ints;
+
+	if (cb != NULL) {
+		if ((ints & DMAC_CHINTFLAG_TCMPL) != 0) {
+			cb(dev, channel, 0);
+		}
+		if ((ints & DMAC_CHINTFLAG_TERR) != 0) {
+			cb(dev, channel, DMAC_CHINTFLAG_TERR);
+		}
+	}
+}
+
+/* Handles DMA interrupts and dispatches to the individual channel */
+static void dma_sam0_isr(void *arg)
+{
+	struct device *dev = arg;
+	struct dma_sam0_device *data = dev->driver_data;
+	int channel;
+	u32_t intstatus = DMAC->INTSTATUS.reg;
+
+	for (channel = 0; intstatus != 0; intstatus >>= 1) {
+		if ((intstatus & 1) != 0) {
+			dma_sam0_channel_isr(dev, data, channel);
+		}
+		channel++;
+	}
+}
+
+/* Configure a channel */
+static int dma_sam0_config(struct device *dev, u32_t channel,
+			   struct dma_config *config)
+{
+	struct dma_sam0_device *data = dev->driver_data;
+	DmacDescriptor *desc = &data->descriptors[channel];
+	struct dma_block_config *block = config->head_block;
+	DMAC_BTCTRL_Type btctrl = {.reg = 0};
+	int key;
+
+	if (channel >= DMAC_CH_NUM) {
+		return -EINVAL;
+	}
+	if (config->block_count > 1) {
+		/* TODO: add support for chained transfers. */
+		return -ENOTSUP;
+	}
+
+	/* Lock and page in the channel configuration */
+	key = irq_lock();
+	DMAC->CHID.reg = channel;
+
+	/* Connect the peripheral trigger */
+	if (config->dma_slot >= DMAC_TRIG_NUM) {
+		goto inval;
+	}
+	if (DMAC->CHCTRLB.bit.TRIGSRC != config->dma_slot) {
+		DMAC->CHCTRLA.reg = 0;
+		DMAC->CHCTRLA.reg = DMAC_CHCTRLA_SWRST;
+		while (DMAC->CHCTRLA.bit.SWRST) {
+		}
+		if (config->channel_direction == MEMORY_TO_MEMORY) {
+			/* A single software trigger will start the
+			 * transfer
+			 */
+			DMAC->CHCTRLB.reg = DMAC_CHCTRLB_TRIGACT_TRANSACTION |
+				DMAC_CHCTRLB_TRIGSRC(config->dma_slot);
+		} else {
+			/* One peripheral trigger per beat */
+			DMAC->CHCTRLB.reg = DMAC_CHCTRLB_TRIGACT_BEAT |
+				DMAC_CHCTRLB_TRIGSRC(config->dma_slot);
+		}
+	}
+
+	/* Set the priority */
+	if (config->channel_priority >= DMAC_LVL_NUM) {
+		goto inval;
+	}
+	DMAC->CHCTRLB.bit.LVL = config->channel_priority;
+
+	/* Set the beat (single transfer) size */
+	if (config->source_data_size != config->dest_data_size) {
+		goto inval;
+	}
+	switch (config->source_data_size) {
+	case 1:
+		btctrl.bit.BEATSIZE = DMAC_BTCTRL_BEATSIZE_BYTE_Val;
+		break;
+	case 2:
+		btctrl.bit.BEATSIZE = DMAC_BTCTRL_BEATSIZE_HWORD_Val;
+		break;
+	case 4:
+		btctrl.bit.BEATSIZE = DMAC_BTCTRL_BEATSIZE_WORD_Val;
+		break;
+	default:
+		goto inval;
+	}
+
+	/* Set up the one and only block */
+	desc->BTCNT.reg = block->block_size / config->source_data_size;
+	desc->DESCADDR.reg = 0;
+
+	/* Set the automatic source / dest increment */
+	switch (block->source_addr_adj) {
+	case DMA_ADDR_ADJ_INCREMENT:
+		desc->SRCADDR.reg = block->source_address + block->block_size;
+		btctrl.bit.SRCINC = 1;
+		break;
+	case DMA_ADDR_ADJ_NO_CHANGE:
+		desc->SRCADDR.reg = block->source_address;
+		break;
+	default:
+		goto inval;
+	}
+
+	switch (block->dest_addr_adj) {
+	case DMA_ADDR_ADJ_INCREMENT:
+		desc->DSTADDR.reg = block->dest_address + block->block_size;
+		btctrl.bit.DSTINC = 1;
+		break;
+	case DMA_ADDR_ADJ_NO_CHANGE:
+		desc->DSTADDR.reg = block->dest_address;
+		break;
+	default:
+		goto inval;
+	}
+
+	btctrl.bit.VALID = 1;
+	desc->BTCTRL = btctrl;
+	data->cb[channel] = config->dma_callback;
+	/* Enable the interrupts */
+	DMAC->CHINTENSET.reg = DMAC_CHINTENSET_TCMPL | DMAC_CHINTENSET_TERR;
+
+	irq_unlock(key);
+	return 0;
+
+inval:
+	irq_unlock(key);
+	return -EINVAL;
+}
+
+static int dma_sam0_start(struct device *dev, u32_t channel)
+{
+	int key = irq_lock();
+
+	DMAC->CHID.reg = channel;
+	DMAC->CHCTRLA.reg = DMAC_CHCTRLA_ENABLE;
+
+	if (DMAC->CHCTRLB.bit.TRIGSRC == 0) {
+		/* Trigger via software */
+		DMAC->SWTRIGCTRL.reg = 1 << channel;
+	}
+
+	irq_unlock(key);
+
+	return 0;
+}
+
+static int dma_sam0_stop(struct device *dev, u32_t channel)
+{
+	int key = irq_lock();
+
+	DMAC->CHID.reg = channel;
+	DMAC->CHCTRLA.reg = 0;
+
+	irq_unlock(key);
+
+	return 0;
+}
+
+DEVICE_DECLARE(dma_sam0_0);
+
+static int dma_sam0_init(struct device *dev)
+{
+	struct dma_sam0_device *data = dev->driver_data;
+
+	/* Enable clocks. */
+	PM->AHBMASK.reg |= PM_AHBMASK_DMAC;
+	PM->APBBMASK.reg |= PM_APBBMASK_DMAC;
+
+	/* Disable and reset. */
+	DMAC->CTRL.bit.DMAENABLE = 0;
+	DMAC->CTRL.bit.SWRST = 1;
+
+	/* Set up the descriptor and write back addresses */
+	DMAC->BASEADDR.reg = (uintptr_t)&data->descriptors;
+	DMAC->WRBADDR.reg = (uintptr_t)&data->descriptors_wb;
+
+	/* Statically map each level to the same numeric priority */
+	DMAC->PRICTRL0.reg =
+		DMAC_PRICTRL0_LVLPRI0(0) | DMAC_PRICTRL0_LVLPRI1(1) |
+		DMAC_PRICTRL0_LVLPRI2(2) | DMAC_PRICTRL0_LVLPRI3(3);
+
+	/* Enable the unit and enable all priorities */
+	DMAC->CTRL.reg = DMAC_CTRL_DMAENABLE | DMAC_CTRL_LVLEN(0x0F);
+
+	IRQ_CONNECT(DT_ATMEL_SAM0_DMA_0_IRQ_0, DT_ATMEL_SAM0_DMA_0_IRQ_0_PRIORITY,
+		    dma_sam0_isr, DEVICE_GET(dma_sam0_0), 0);
+	irq_enable(DT_ATMEL_SAM0_DMA_0_IRQ_0);
+
+	return 0;
+}
+
+static struct dma_sam0_device dma_sam0_device_0;
+
+static const struct dma_driver_api dma_sam0_api = {
+	.config = dma_sam0_config,
+	.start = dma_sam0_start,
+	.stop = dma_sam0_stop,
+};
+
+DEVICE_AND_API_INIT(dma_sam0_0, DT_ATMEL_SAM0_DMA_0_LABEL, &dma_sam0_init,
+		    &dma_sam0_device_0, NULL, POST_KERNEL,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dma_sam0_api);

--- a/dts/arm/atmel/samd.dtsi
+++ b/dts/arm/atmel/samd.dtsi
@@ -43,6 +43,13 @@
 			};
 		};
 
+		dma: dma@41004800 {
+			compatible = "atmel,sam0-dma";
+			reg = <0x41004800 0x50>;
+			interrupts = <6 0>;
+			label = "DMA_0";
+		};
+
 		pinmux_a: pinmux@41004400 {
 			compatible = "atmel,sam0-pinmux";
 			reg = <0x41004400 0x80>;

--- a/dts/bindings/arm/atmel,sam0-dma.yaml
+++ b/dts/bindings/arm/atmel,sam0-dma.yaml
@@ -1,0 +1,33 @@
+---
+title: Atmel DMA binding
+version: 0.1
+
+description: >
+    Binding for the Atmel SAM0 DMA controller.
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "atmel,sam0-dma"
+      generation: define
+
+    reg:
+      type: array
+      description: mmio register space
+      generation: define
+      category: required
+
+    interrupts:
+      type: array
+      category: required
+      description: required interrupts
+      generation: define
+
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device (used by Zephyr for API name)
+      generation: define
+...


### PR DESCRIPTION
This is a dusted-off version of @nzmichaelh's pull-request #6306, rebased and adapted to the latest API changes.

Tested on samr21_xpro with `tests/drivers/dma/loop_transfer`. 