### PR TITLE
doc: Bluetooth: Correct how to run native_posix

### DIFF
--- a/doc/guides/bluetooth/bluetooth-tools.rst
+++ b/doc/guides/bluetooth/bluetooth-tools.rst
@@ -144,12 +144,12 @@ building and running a sample:
      :zephyr-app: samples/bluetooth/<sample>
      :host-os: unix
      :board: native_posix
-     :goals: run
+     :goals: build
      :compact:
 
   And then run it with::
 
-     $ zephyr/zephyr.exe --bt-dev=hci0
+     $ sudo zephyr/zephyr.exe --bt-dev=hci0
 
 Using a Zephyr-based BLE Controller
 ===================================


### PR DESCRIPTION
1. The build paragraph was listed with the run option.
   But, we need to pass an argument to the native_posix board,
   so "ninja run" alone is not good enough.
   Plus, it was not coherent with the rest of the text, as
   the paragraph intended to tell people how to build.
2. Added "sudo" to the run line, as the user needs extra
   permissions to connect to a host BT controller.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>