### PR TITLE
96b_nitrogen: Increase size of boot partition.

### DIFF
--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -97,15 +97,15 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x8000>;
+			reg = <0x00000000 0xa000>;
 		};
-		slot0_partition: partition@8000 {
+		slot0_partition: partition@a000 {
 			label = "image-0";
-			reg = <0x00008000 0x34000>;
+			reg = <0x0000a000 0x33000>;
 		};
-		slot1_partition: partition@3c000 {
+		slot1_partition: partition@3d000 {
 			label = "image-1";
-			reg = <0x0003c000 0x34000>;
+			reg = <0x0003d000 0x33000>;
 		};
 		scratch_partition: partition@70000 {
 			label = "image-scratch";


### PR DESCRIPTION
MCUboot needs nearly all 8 pages, on some commits even more. This leads
to a overwrite of parts of mcuboot code when an application is flashed.
By improving the size of the boot partition to 10 pages (from 8) and
decrease both application slots by 1 page, MCUboot fits in the boot
loader partition. This is also fixable by an extra .dts, but having an
out of the box working configuration is preferable.