### PR TITLE
west/run_common.py: Fix TypeError when using unknown arguments.

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -222,8 +222,8 @@ def do_run_common(command, args, runner_args, cached_runner_var):
     runner_cls.add_parser(parser)
     parsed_args, unknown = parser.parse_known_args(args=final_runner_args)
     if unknown:
-        raise CommandContextError('Runner', runner,
-                                  'received unknown arguments', unknown)
+        raise CommandContextError(textwrap.dedent("""\
+        Runner {} received unknown arguments {}.""".format(runner, unknown)))
     runner = runner_cls.create(cfg, parsed_args)
     runner.run(command_name)
 


### PR DESCRIPTION
The CommandContextError class expects a string, not the single
arguments. Using a textwrap to concat all arguments leads to a useful
error message which runner arguments where wrong.

Signed-off-by: Stefan Kraus <stefan.kraus@fau.de>