### PR TITLE
samples: buttons: Remove redundant code and documentation

### DIFF
--- a/samples/basic/button/README.rst
+++ b/samples/basic/button/README.rst
@@ -15,14 +15,8 @@ The demo assumes that a push button is connected to one of GPIO lines. The
 sample code is configured to work on boards with user defined buttons and that
 have defined the SW0_* variables.
 
-To use this sample, you will require a board that defines the user switch in its
-header file. The :file:`board.h` must define the following variables:
-
-- SW0_GPIO_NAME (or DT_ALIAS_SW0_GPIOS_CONTROLLER)
-- DT_ALIAS_SW0_GPIOS_PIN
-
-Alternatively, this could also be done by defining 'sw0' alias in the board
-device tree description file.
+This is done by defining 'sw0' alias in the board device tree
+description file.
 
 
 Building and Running

--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -80,9 +80,6 @@ void main(void)
 	gpio_pin_enable_callback(gpiob, PIN);
 
 	while (1) {
-		u32_t val = 0U;
-
-		gpio_pin_read(gpiob, PIN, &val);
 		k_sleep(SLEEP_TIME);
 	}
 }


### PR DESCRIPTION
1. remove redundant GPIO polling code in the main loop,  because this
demo is "showcasing the use of GPIO input with interrupts."
2. remove description part for "board.h", reference on #10981

Signed-off-by: Aaron Tsui <aaron.tsui@outlook.com>