### PR TITLE
drivers: serial: sam0: Add DMA async mode

### DIFF
--- a/drivers/serial/Kconfig.sam0
+++ b/drivers/serial/Kconfig.sam0
@@ -9,5 +9,6 @@ menuconfig UART_SAM0
 	depends on SOC_FAMILY_SAM0
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
+	select DMA if UART_ASYNC_API
 	help
 	  This option enables the SERCOMx USART driver for Atmel SAM0 MCUs.

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -10,6 +10,7 @@
 #include <misc/__assert.h>
 #include <soc.h>
 #include <uart.h>
+#include <dma.h>
 
 /* Device constant configuration parameters */
 struct uart_sam0_dev_cfg {
@@ -18,8 +19,14 @@ struct uart_sam0_dev_cfg {
 	u32_t pads;
 	u32_t pm_apbcmask;
 	u16_t gclk_clkctrl_id;
-#if CONFIG_UART_INTERRUPT_DRIVEN
+#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API
 	void (*irq_config_func)(struct device *dev);
+#endif
+#if CONFIG_UART_ASYNC_API
+	u8_t tx_dma_request;
+	u8_t tx_dma_channel;
+	u8_t rx_dma_request;
+	u8_t rx_dma_channel;
 #endif
 };
 
@@ -28,6 +35,29 @@ struct uart_sam0_dev_data {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t cb;
 	void *cb_data;
+#endif
+#if CONFIG_UART_ASYNC_API
+	const struct uart_sam0_dev_cfg *cfg;
+	struct device *dma;
+
+	uart_callback_t async_cb;
+	void *async_cb_data;
+
+	struct k_delayed_work tx_timeout_work;
+	const u8_t *tx_buf;
+	size_t tx_len;
+
+	struct k_delayed_work rx_timeout_work;
+	size_t rx_timeout_time;
+	size_t rx_timeout_chunk;
+	u32_t rx_timeout_start;
+	u8_t *rx_buf;
+	size_t rx_len;
+	size_t rx_processed_len;
+	u8_t *rx_next_buf;
+	size_t rx_next_len;
+	bool rx_waiting_for_irq;
+	bool rx_timeout_from_isr;
 #endif
 };
 
@@ -71,6 +101,272 @@ static int uart_sam0_set_baudrate(SercomUsart *const usart, u32_t baudrate,
 	return 0;
 }
 
+#if CONFIG_UART_ASYNC_API
+
+static void uart_sam0_dma_tx_done(void *arg, u32_t id, int error_code)
+{
+	ARG_UNUSED(id);
+	ARG_UNUSED(error_code);
+
+	struct device *dev = arg;
+	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+
+	k_delayed_work_cancel(&dev_data->tx_timeout_work);
+
+	int key = irq_lock();
+
+	struct uart_event evt = {
+		.type = UART_TX_DONE,
+		.data.tx = {
+			.buf = dev_data->tx_buf,
+			.len = dev_data->tx_len,
+		},
+	};
+
+	dev_data->tx_buf = NULL;
+	dev_data->tx_len = 0U;
+
+	if (evt.data.tx.len != 0U && dev_data->async_cb) {
+		dev_data->async_cb(&evt, dev_data->async_cb_data);
+	}
+
+	irq_unlock(key);
+}
+
+static int uart_sam0_tx_halt(struct uart_sam0_dev_data *dev_data)
+{
+	const struct uart_sam0_dev_cfg *const cfg = dev_data->cfg;
+	int key = irq_lock();
+	size_t tx_active = dev_data->tx_len;
+	struct dma_status st;
+
+	struct uart_event evt = {
+		.type = UART_TX_ABORTED,
+		.data.tx = {
+			.buf = dev_data->tx_buf,
+			.len = 0U,
+		},
+	};
+
+	dev_data->tx_buf = NULL;
+	dev_data->tx_len = 0U;
+
+	dma_stop(dev_data->dma, cfg->tx_dma_channel);
+
+	irq_unlock(key);
+
+	if (dma_get_status(dev_data->dma, cfg->tx_dma_channel, &st) == 0) {
+		evt.data.tx.len = tx_active - st.pending_length;
+	}
+
+	if (tx_active) {
+		if (dev_data->async_cb) {
+			dev_data->async_cb(&evt, dev_data->async_cb_data);
+		}
+	} else {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static void uart_sam0_tx_timeout(struct k_work *work)
+{
+	struct uart_sam0_dev_data *dev_data = CONTAINER_OF(work,
+							   struct uart_sam0_dev_data, tx_timeout_work);
+
+	uart_sam0_tx_halt(dev_data);
+}
+
+static void uart_sam0_notify_rx_processed(struct uart_sam0_dev_data *dev_data,
+					  size_t processed)
+{
+	if (!dev_data->async_cb) {
+		return;
+	}
+
+	if (dev_data->rx_processed_len == processed) {
+		return;
+	}
+
+	struct uart_event evt = {
+		.type = UART_RX_RDY,
+		.data.rx = {
+			.buf = dev_data->rx_buf,
+			.offset = dev_data->rx_processed_len,
+			.len = processed - dev_data->rx_processed_len,
+		},
+	};
+
+	dev_data->rx_processed_len = processed;
+
+	dev_data->async_cb(&evt, dev_data->async_cb_data);
+}
+
+static void uart_sam0_dma_rx_done(void *arg, u32_t id, int error_code)
+{
+	ARG_UNUSED(id);
+	ARG_UNUSED(error_code);
+
+	struct device *dev = arg;
+	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+	const struct uart_sam0_dev_cfg *const cfg = dev_data->cfg;
+	SercomUsart * const regs = cfg->regs;
+	int key = irq_lock();
+
+	if (dev_data->rx_len == 0U) {
+		irq_unlock(key);
+		return;
+	}
+
+	uart_sam0_notify_rx_processed(dev_data, dev_data->rx_len);
+
+	if (dev_data->async_cb) {
+		struct uart_event evt = {
+			.type = UART_RX_BUF_RELEASED,
+			.data.rx_buf = {
+				.buf = dev_data->rx_buf,
+			},
+		};
+
+		dev_data->async_cb(&evt, dev_data->async_cb_data);
+	}
+
+	/* No next buffer, so end the transfer */
+	if (!dev_data->rx_next_len) {
+		dev_data->rx_buf = NULL;
+		dev_data->rx_len = 0U;
+
+		if (dev_data->async_cb) {
+			struct uart_event evt = {
+				.type = UART_RX_DISABLED,
+			};
+
+			dev_data->async_cb(&evt, dev_data->async_cb_data);
+		}
+
+		irq_unlock(key);
+		return;
+	}
+
+	dev_data->rx_buf = dev_data->rx_next_buf;
+	dev_data->rx_len = dev_data->rx_next_len;
+	dev_data->rx_next_buf = NULL;
+	dev_data->rx_next_len = 0U;
+	dev_data->rx_processed_len = 0U;
+
+	dma_reload(dev_data->dma, cfg->rx_dma_channel,
+		   (u32_t)(&(regs->DATA.reg)),
+		   (u32_t)dev_data->rx_buf, dev_data->rx_len);
+
+	/*
+	 * If there should be a timeout, handle starting the DMA in the
+	 * ISR, since reception resets it and DMA completion implies
+	 * reception.  This also catches the case of DMA completion during
+	 * timeout handling.
+	 */
+	if (dev_data->rx_timeout_time != K_FOREVER) {
+		dev_data->rx_waiting_for_irq = true;
+		regs->INTENSET.reg = SERCOM_USART_INTENSET_RXC;
+		irq_unlock(key);
+		return;
+	}
+
+	/* Otherwise, start the transfer immediately. */
+	dma_start(dev_data->dma, cfg->rx_dma_channel);
+
+	struct uart_event evt = {
+		.type = UART_RX_BUF_REQUEST,
+	};
+
+	dev_data->async_cb(&evt, dev_data->async_cb_data);
+
+	irq_unlock(key);
+}
+
+static void uart_sam0_rx_timeout(struct k_work *work)
+{
+	struct uart_sam0_dev_data *dev_data = CONTAINER_OF(work,
+							   struct uart_sam0_dev_data, rx_timeout_work);
+	const struct uart_sam0_dev_cfg *const cfg = dev_data->cfg;
+	SercomUsart * const regs = cfg->regs;
+	struct dma_status st;
+	int key = irq_lock();
+
+	if (dev_data->rx_len == 0U) {
+		irq_unlock(key);
+		return;
+	}
+
+	/*
+	 * Stop the DMA transfer and restart the interrupt read
+	 * component (so the timeout restarts if there's still data).
+	 * However, just ignore it if the transfer has completed (nothing
+	 * pending) that means the DMA ISR is already pending, so just let
+	 * it handle things instead when we re-enable IRQs.
+	 */
+	dma_stop(dev_data->dma, cfg->rx_dma_channel);
+	if (dma_get_status(dev_data->dma, cfg->rx_dma_channel,
+			   &st) == 0 && st.pending_length == 0U) {
+		irq_unlock(key);
+		return;
+	}
+
+	u8_t *rx_dma_start = dev_data->rx_buf + dev_data->rx_len -
+			     st.pending_length;
+	size_t rx_processed = rx_dma_start - dev_data->rx_buf;
+
+	/*
+	 * We know we still have space, since the above will catch the
+	 * empty buffer, so always restart the transfer.
+	 */
+	dma_reload(dev_data->dma, cfg->rx_dma_channel,
+		   (u32_t)(&(regs->DATA.reg)),
+		   (u32_t)rx_dma_start,
+		   dev_data->rx_len - rx_processed);
+
+	dev_data->rx_waiting_for_irq = true;
+	regs->INTENSET.reg = SERCOM_USART_INTENSET_RXC;
+
+	/*
+	 * Never do a notify on a timeout started from the ISR: timing
+	 * granularity means the first timeout can be in the middle
+	 * of reception but still have the total elapsed time exhausted.
+	 * So we require a timeout chunk with no data seen at all
+	 * (i.e. no ISR entry).
+	 */
+	if (dev_data->rx_timeout_from_isr) {
+		dev_data->rx_timeout_from_isr = false;
+		k_delayed_work_submit(&dev_data->rx_timeout_work,
+				      dev_data->rx_timeout_chunk);
+		irq_unlock(key);
+		return;
+	}
+
+	u32_t now = k_uptime_get_32();
+	u32_t elapsed = now - dev_data->rx_timeout_start;
+
+	if (elapsed >= dev_data->rx_timeout_time) {
+		/*
+		 * No time left, so call the handler, and let the ISR
+		 * restart the timeout when it sees data.
+		 */
+		uart_sam0_notify_rx_processed(dev_data, rx_processed);
+	} else {
+		/*
+		 * Still have time left, so start another timeout.
+		 */
+		u32_t remaining = MIN(dev_data->rx_timeout_time - elapsed,
+				      dev_data->rx_timeout_chunk);
+
+		k_delayed_work_submit(&dev_data->rx_timeout_work, remaining);
+	}
+
+	irq_unlock(key);
+}
+
+#endif
+
 static int uart_sam0_init(struct device *dev)
 {
 	int retval;
@@ -112,8 +408,76 @@ static int uart_sam0_init(struct device *dev)
 		return retval;
 	}
 
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API
 	cfg->irq_config_func(dev);
+#endif
+
+#ifdef CONFIG_UART_ASYNC_API
+
+	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+
+	dev_data->cfg = cfg;
+	dev_data->dma = device_get_binding(CONFIG_DMA_0_NAME);
+
+	k_delayed_work_init(&dev_data->tx_timeout_work, uart_sam0_tx_timeout);
+	k_delayed_work_init(&dev_data->rx_timeout_work, uart_sam0_rx_timeout);
+
+	if (cfg->tx_dma_channel != 0xFFU) {
+		struct dma_config dma_cfg = { 0 };
+		struct dma_block_config dma_blk = { 0 };
+
+		if (!dev_data->dma) {
+			return -ENOTSUP;
+		}
+
+		dma_cfg.channel_direction = MEMORY_TO_PERIPHERAL;
+		dma_cfg.source_data_size = 1;
+		dma_cfg.dest_data_size = 1;
+		dma_cfg.callback_arg = dev;
+		dma_cfg.dma_callback = uart_sam0_dma_tx_done;
+		dma_cfg.block_count = 1;
+		dma_cfg.head_block = &dma_blk;
+		dma_cfg.dma_slot = cfg->tx_dma_request;
+
+		dma_blk.block_size = 1;
+		dma_blk.dest_address = (u32_t)(&(usart->DATA.reg));
+		dma_blk.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+
+		retval = dma_config(dev_data->dma, cfg->tx_dma_channel,
+				    &dma_cfg);
+		if (retval != 0) {
+			return retval;
+		}
+	}
+
+	if (cfg->rx_dma_channel != 0xFFU) {
+		struct dma_config dma_cfg = { 0 };
+		struct dma_block_config dma_blk = { 0 };
+
+		if (!dev_data->dma) {
+			return -ENOTSUP;
+		}
+
+		dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
+		dma_cfg.source_data_size = 1;
+		dma_cfg.dest_data_size = 1;
+		dma_cfg.callback_arg = dev;
+		dma_cfg.dma_callback = uart_sam0_dma_rx_done;
+		dma_cfg.block_count = 1;
+		dma_cfg.head_block = &dma_blk;
+		dma_cfg.dma_slot = cfg->rx_dma_request;
+
+		dma_blk.block_size = 1;
+		dma_blk.source_address = (u32_t)(&(usart->DATA.reg));
+		dma_blk.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+
+		retval = dma_config(dev_data->dma, cfg->rx_dma_channel,
+				    &dma_cfg);
+		if (retval != 0) {
+			return retval;
+		}
+	}
+
 #endif
 
 	usart->CTRLA.bit.ENABLE = 1;
@@ -145,17 +509,57 @@ static void uart_sam0_poll_out(struct device *dev, unsigned char c)
 	usart->DATA.reg = c;
 }
 
-#if CONFIG_UART_INTERRUPT_DRIVEN
+#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API
 
 static void uart_sam0_isr(void *arg)
 {
 	struct device *dev = arg;
 	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
 
+#if CONFIG_UART_INTERRUPT_DRIVEN
 	if (dev_data->cb) {
 		dev_data->cb(dev_data->cb_data);
 	}
+#endif
+
+#if CONFIG_UART_ASYNC_API
+	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);
+	SercomUsart * const regs = cfg->regs;
+
+	if (dev_data->rx_len && regs->INTFLAG.bit.RXC &&
+	    dev_data->rx_waiting_for_irq) {
+		dev_data->rx_waiting_for_irq = false;
+		regs->INTENCLR.reg = SERCOM_USART_INTENCLR_RXC;
+
+		/* Receive started, so request the next buffer */
+		if (dev_data->rx_next_len == 0U && dev_data->async_cb) {
+			struct uart_event evt = {
+				.type = UART_RX_BUF_REQUEST,
+			};
+
+			dev_data->async_cb(&evt, dev_data->async_cb_data);
+		}
+
+		/*
+		 * If we have a timeout, restart the time remaining whenever
+		 * we see data.
+		 */
+		if (dev_data->rx_timeout_time != K_FOREVER) {
+			dev_data->rx_timeout_from_isr = true;
+			dev_data->rx_timeout_start = k_uptime_get_32();
+			k_delayed_work_submit(&dev_data->rx_timeout_work,
+					      dev_data->rx_timeout_chunk);
+		}
+
+		/* DMA will read the currently ready byte out */
+		dma_start(dev_data->dma, cfg->rx_dma_channel);
+	}
+#endif
 }
+
+#endif
+
+#if CONFIG_UART_INTERRUPT_DRIVEN
 
 static int uart_sam0_fifo_fill(struct device *dev, const u8_t *tx_data, int len)
 {
@@ -249,6 +653,231 @@ static void uart_sam0_irq_callback_set(struct device *dev,
 }
 #endif
 
+#ifdef CONFIG_UART_ASYNC_API
+
+static int uart_sam0_callback_set(struct device *dev, uart_callback_t callback,
+				  void *user_data)
+{
+	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+
+	dev_data->async_cb = callback;
+	dev_data->async_cb_data = user_data;
+
+	return 0;
+}
+
+static int uart_sam0_tx(struct device *dev, const u8_t *buf, size_t len,
+			u32_t timeout)
+{
+	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);
+	SercomUsart *regs = DEV_CFG(dev)->regs;
+	int retval;
+
+	if (!dev_data->dma || cfg->tx_dma_channel == 0xFFU) {
+		return -ENOTSUP;
+	}
+
+	if (len > 0xFFFFU) {
+		return -EINVAL;
+	}
+
+	int key = irq_lock();
+
+	if (dev_data->tx_len != 0U) {
+		retval = -EBUSY;
+		goto err;
+	}
+
+	dev_data->tx_buf = buf;
+	dev_data->tx_len = len;
+
+	irq_unlock(key);
+
+	retval = dma_reload(dev_data->dma, cfg->tx_dma_channel, (u32_t)buf,
+			    (u32_t)(&(regs->DATA.reg)), len);
+	if (retval != 0U) {
+		return retval;
+	}
+
+	if (timeout != K_FOREVER) {
+		k_delayed_work_submit(&dev_data->tx_timeout_work, timeout);
+	}
+
+	return dma_start(dev_data->dma, cfg->tx_dma_channel);
+err:
+	irq_unlock(key);
+	return retval;
+}
+
+static int uart_sam0_tx_abort(struct device *dev)
+{
+	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);
+
+	if (!dev_data->dma || cfg->tx_dma_channel == 0xFFU) {
+		return -ENOTSUP;
+	}
+
+	k_delayed_work_cancel(&dev_data->tx_timeout_work);
+
+	return uart_sam0_tx_halt(dev_data);
+}
+
+static int uart_sam0_rx_enable(struct device *dev, u8_t *buf, size_t len,
+			       u32_t timeout)
+{
+	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);
+	SercomUsart *regs = DEV_CFG(dev)->regs;
+	int retval;
+
+	if (!dev_data->dma || cfg->rx_dma_channel == 0xFFU) {
+		return -ENOTSUP;
+	}
+
+	if (len > 0xFFFFU) {
+		return -EINVAL;
+	}
+
+	int key = irq_lock();
+
+	if (dev_data->rx_len != 0U) {
+		retval = -EBUSY;
+		goto err;
+	}
+
+	/* Read off anything that was already there */
+	while (regs->INTFLAG.bit.RXC) {
+		char discard = regs->DATA.reg;
+
+		(void)discard;
+	}
+
+	retval = dma_reload(dev_data->dma, cfg->rx_dma_channel,
+			    (u32_t)(&(regs->DATA.reg)),
+			    (u32_t)buf, len);
+	if (retval != 0) {
+		return retval;
+	}
+
+	dev_data->rx_buf = buf;
+	dev_data->rx_len = len;
+	dev_data->rx_processed_len = 0U;
+	dev_data->rx_waiting_for_irq = true;
+	dev_data->rx_timeout_from_isr = true;
+	dev_data->rx_timeout_time = timeout;
+	dev_data->rx_timeout_chunk = MAX(timeout / 4U, 1);
+
+	regs->INTENSET.reg = SERCOM_USART_INTENSET_RXC;
+
+	irq_unlock(key);
+	return 0;
+
+err:
+	irq_unlock(key);
+	return retval;
+}
+
+static int uart_sam0_rx_buf_rsp(struct device *dev, u8_t *buf, size_t len)
+{
+	if (len > 0xFFFFU) {
+		return -EINVAL;
+	}
+
+	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+	int key = irq_lock();
+	int retval = 0;
+
+	if (dev_data->rx_len == 0U) {
+		retval = -EACCES;
+		goto err;
+	}
+
+	if (dev_data->rx_next_len != 0U) {
+		retval = -EBUSY;
+		goto err;
+	}
+
+	dev_data->rx_next_buf = buf;
+	dev_data->rx_next_len = len;
+
+	irq_unlock(key);
+	return 0;
+
+err:
+	irq_unlock(key);
+	return retval;
+}
+
+static int uart_sam0_rx_disable(struct device *dev)
+{
+	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
+	const struct uart_sam0_dev_cfg *const cfg = DEV_CFG(dev);
+	SercomUsart *const regs = cfg->regs;
+	struct dma_status st;
+
+	k_delayed_work_cancel(&dev_data->rx_timeout_work);
+
+	int key = irq_lock();
+
+	if (dev_data->rx_len == 0U) {
+		irq_unlock(key);
+		return -EINVAL;
+	}
+
+	regs->INTENCLR.reg = SERCOM_USART_INTENCLR_RXC;
+	dma_stop(dev_data->dma, cfg->rx_dma_channel);
+
+	if (dev_data->rx_next_len) {
+		struct uart_event evt = {
+			.type = UART_RX_BUF_RELEASED,
+			.data.rx_buf = {
+				.buf = dev_data->rx_next_buf,
+			},
+		};
+
+		dev_data->rx_next_buf = NULL;
+		dev_data->rx_next_len = 0U;
+
+		if (dev_data->async_cb) {
+			dev_data->async_cb(&evt, dev_data->async_cb_data);
+		}
+	}
+
+	if (dma_get_status(dev_data->dma, cfg->rx_dma_channel,
+			   &st) == 0 && st.pending_length != 0U) {
+		size_t rx_processed = dev_data->rx_len - st.pending_length;
+
+		uart_sam0_notify_rx_processed(dev_data, rx_processed);
+	}
+
+	struct uart_event evt = {
+		.type = UART_RX_BUF_RELEASED,
+		.data.rx_buf = {
+			.buf = dev_data->rx_buf,
+		},
+	};
+
+	dev_data->rx_buf = NULL;
+	dev_data->rx_len = 0U;
+
+	if (dev_data->async_cb) {
+		dev_data->async_cb(&evt, dev_data->async_cb_data);
+	}
+
+	evt.type = UART_RX_DISABLED;
+	if (dev_data->async_cb) {
+		dev_data->async_cb(&evt, dev_data->async_cb_data);
+	}
+
+	irq_unlock(key);
+
+	return 0;
+}
+
+#endif
+
 static const struct uart_driver_api uart_sam0_driver_api = {
 	.poll_in = uart_sam0_poll_in,
 	.poll_out = uart_sam0_poll_out,
@@ -265,9 +894,17 @@ static const struct uart_driver_api uart_sam0_driver_api = {
 	.irq_update = uart_sam0_irq_update,
 	.irq_callback_set = uart_sam0_irq_callback_set,
 #endif
+#if CONFIG_UART_ASYNC_API
+	.callback_set = uart_sam0_callback_set,
+	.tx = uart_sam0_tx,
+	.tx_abort = uart_sam0_tx_abort,
+	.rx_enable = uart_sam0_rx_enable,
+	.rx_buf_rsp = uart_sam0_rx_buf_rsp,
+	.rx_disable = uart_sam0_rx_disable,
+#endif
 };
 
-#if CONFIG_UART_INTERRUPT_DRIVEN
+#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API
 #define UART_SAM0_IRQ_HANDLER_DECL(n)					\
 static void uart_sam0_irq_config_##n(struct device *dev)
 #define UART_SAM0_IRQ_HANDLER_FUNC(n)					\
@@ -287,6 +924,53 @@ static void uart_sam0_irq_config_##n(struct device *dev)		\
 #define UART_SAM0_IRQ_HANDLER(n)
 #endif
 
+#if CONFIG_UART_ASYNC_API
+#ifndef DT_ATMEL_SAM0_UART_SERCOM_0_TXDMA
+#define DT_ATMEL_SAM0_UART_SERCOM_0_TXDMA 0xFFU
+#endif
+#ifndef DT_ATMEL_SAM0_UART_SERCOM_0_RXDMA
+#define DT_ATMEL_SAM0_UART_SERCOM_0_RXDMA 0xFFU
+#endif
+#ifndef DT_ATMEL_SAM0_UART_SERCOM_1_TXDMA
+#define DT_ATMEL_SAM0_UART_SERCOM_1_TXDMA 0xFFU
+#endif
+#ifndef DT_ATMEL_SAM0_UART_SERCOM_1_RXDMA
+#define DT_ATMEL_SAM0_UART_SERCOM_1_RXDMA 0xFFU
+#endif
+#ifndef DT_ATMEL_SAM0_UART_SERCOM_2_TXDMA
+#define DT_ATMEL_SAM0_UART_SERCOM_2_TXDMA 0xFFU
+#endif
+#ifndef DT_ATMEL_SAM0_UART_SERCOM_2_RXDMA
+#define DT_ATMEL_SAM0_UART_SERCOM_2_RXDMA 0xFFU
+#endif
+#ifndef DT_ATMEL_SAM0_UART_SERCOM_3_TXDMA
+#define DT_ATMEL_SAM0_UART_SERCOM_3_TXDMA 0xFFU
+#endif
+#ifndef DT_ATMEL_SAM0_UART_SERCOM_3_RXDMA
+#define DT_ATMEL_SAM0_UART_SERCOM_3_RXDMA 0xFFU
+#endif
+#ifndef DT_ATMEL_SAM0_UART_SERCOM_4_TXDMA
+#define DT_ATMEL_SAM0_UART_SERCOM_4_TXDMA 0xFFU
+#endif
+#ifndef DT_ATMEL_SAM0_UART_SERCOM_4_RXDMA
+#define DT_ATMEL_SAM0_UART_SERCOM_4_RXDMA 0xFFU
+#endif
+#ifndef DT_ATMEL_SAM0_UART_SERCOM_5_TXDMA
+#define DT_ATMEL_SAM0_UART_SERCOM_5_TXDMA 0xFFU
+#endif
+#ifndef DT_ATMEL_SAM0_UART_SERCOM_5_RXDMA
+#define DT_ATMEL_SAM0_UART_SERCOM_5_RXDMA 0xFFU
+#endif
+
+#define UART_SAM0_DMA_CHANNELS(n)				 \
+	.tx_dma_request = SERCOM##n##_DMAC_ID_TX,		 \
+	.tx_dma_channel = DT_ATMEL_SAM0_UART_SERCOM_##n##_TXDMA, \
+	.rx_dma_request = SERCOM##n##_DMAC_ID_RX,		 \
+	.rx_dma_channel = DT_ATMEL_SAM0_UART_SERCOM_##n##_RXDMA
+#else
+#define UART_SAM0_DMA_CHANNELS(n)
+#endif
+
 #define UART_SAM0_SERCOM_PADS(n) \
 	(DT_ATMEL_SAM0_UART_SERCOM_##n##_RXPO << SERCOM_USART_CTRLA_RXPO_Pos) |\
 	(DT_ATMEL_SAM0_UART_SERCOM_##n##_TXPO << SERCOM_USART_CTRLA_TXPO_Pos)
@@ -299,6 +983,7 @@ static const struct uart_sam0_dev_cfg uart_sam0_config_##n = {		       \
 	.gclk_clkctrl_id = GCLK_CLKCTRL_ID_SERCOM##n##_CORE,		       \
 	.pads = UART_SAM0_SERCOM_PADS(n),				       \
 	UART_SAM0_IRQ_HANDLER_FUNC(n)					       \
+	UART_SAM0_DMA_CHANNELS(n)					       \
 }
 
 #define UART_SAM0_DEVICE_INIT(n)					       \

--- a/dts/bindings/serial/atmel,sam0-uart.yaml
+++ b/dts/bindings/serial/atmel,sam0-uart.yaml
@@ -35,4 +35,16 @@ properties:
       category: required
       description: Transmit Data Pinout
       generation: define
+
+    rxdma:
+      type: int
+      category: optional
+      description: Receive DMA channel
+      generation: define
+
+    txdma:
+      type: int
+      category: optional
+      description: Transmit DMA channel
+      generation: define
 ...


### PR DESCRIPTION
This adds support for the async API for SAM0 SERCOM UARTs using DMA to drive the device.  

Tested on SAMD21 with a few trivial programs and with `tests/drivers/uart/uart_async_api`.