### PR TITLE
driver: usb: nordic: Enable USB DC when VBUS is Hi

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1316,6 +1316,10 @@ int usb_dc_attach(void)
 		usbd_work_schedule();
 	}
 
+	if (nrf_power_usbregstatus_vbusdet_get()) {
+		usb_dc_nrfx_power_event_callback(NRF_POWER_EVENT_USBDETECTED);
+	}
+
 	return ret;
 }
 


### PR DESCRIPTION
We want to enable USB DC at not only VBUS detection event
but also it has been already high.
For example, when we use MCUboot with something USB DC,
we need this patch.