### PR TITLE
drivers: spi: sam/sam0: fix the driver

### DIFF
--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -100,9 +100,8 @@ static int spi_sam_configure(struct device *dev,
 	regs->SPI_CSR[config->slave] = spi_csr;
 	regs->SPI_CR = SPI_CR_SPIEN; /* Enable SPI */
 
-	spi_context_cs_configure(&data->ctx);
-
 	data->ctx.config = config;
+	spi_context_cs_configure(&data->ctx);
 
 	return 0;
 }

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -401,9 +401,6 @@ static int spi_sam_transceive_sync(struct device *dev,
 				    const struct spi_buf_set *tx_bufs,
 				    const struct spi_buf_set *rx_bufs)
 {
-	struct spi_sam_data *data = dev->driver_data;
-
-	spi_context_lock(&data->ctx, false, NULL);
 	return spi_sam_transceive(dev, config, tx_bufs, rx_bufs);
 }
 
@@ -414,10 +411,8 @@ static int spi_sam_transceive_async(struct device *dev,
 				     const struct spi_buf_set *rx_bufs,
 				     struct k_poll_signal *async)
 {
-	struct spi_sam_data *data = dev->driver_data;
-
-	spi_context_lock(&data->ctx, true, async);
-	return spi_sam_transceive(dev, config, tx_bufs, rx_bufs);
+	/* TODO: implement asyc transceive */
+	return -ENOTSUP;
 }
 #endif /* CONFIG_SPI_ASYNC */
 

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -111,9 +111,8 @@ static int spi_sam0_configure(struct device *dev,
 		wait_synchronization(regs);
 	}
 
-	spi_context_cs_configure(&data->ctx);
-
 	data->ctx.config = config;
+	spi_context_cs_configure(&data->ctx);
 
 	return 0;
 }

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -408,9 +408,6 @@ static int spi_sam0_transceive_sync(struct device *dev,
 				    const struct spi_buf_set *tx_bufs,
 				    const struct spi_buf_set *rx_bufs)
 {
-	struct spi_sam0_data *data = dev->driver_data;
-
-	spi_context_lock(&data->ctx, false, NULL);
 	return spi_sam0_transceive(dev, config, tx_bufs, rx_bufs);
 }
 
@@ -421,10 +418,8 @@ static int spi_sam0_transceive_async(struct device *dev,
 				     const struct spi_buf_set *rx_bufs,
 				     struct k_poll_signal *async)
 {
-	struct spi_sam0_data *data = dev->driver_data;
-
-	spi_context_lock(&data->ctx, true, async);
-	return spi_sam0_transceive(dev, config, tx_bufs, rx_bufs);
+	/* TODO: implement asyc transceive */
+	return -ENOTSUP;
 }
 #endif /* CONFIG_SPI_ASYNC */
 


### PR DESCRIPTION
The commits that broke the SPI driver for sam0 (eae05d928e0c04b362b9dc28f60e4e96f08140cd, 27195895b1b8161d0d970e8643f17b45c763718b) were also applied to the sam driver.

- set `data->ctx.config`  before accessing it
- don't call `spi_context_lock()` in the wrapper function when it's already being called in `spi_sam_transceive()`
- don't claim support for async mode

I don't have hardware to test this on sam, but it restored sam0 to a working state on samr21-xpro, that is `tests/drivers/spi/spi_loopback` runs successfully again. 

**before:**
```
2019-03-25 14:55:06,125 - INFO # Running test suite test_spi
2019-03-25 14:55:06,130 - INFO # ===================================================================
2019-03-25 14:55:06,134 - INFO # starting test - testing_spi
2019-03-25 14:55:06,141 - INFO # [00:00:00.016,244] <inf> main: SPI test on buffers TX/RX 0x2000140c/0x200000ac
2019-03-25 14:55:06,145 - INFO # [00:00:00.020,122] <inf> main: Start
2019-03-25 14:55:06,351 - INFO # 
2019-03-25 14:55:06,368 - INFO #     Assertion failed at /home/benpicco/dev/zeph-playground/zephyr/tests/drivers/spi/spi_loopback/src/spi.c:341: spi_async_call_cb: (ret is true)
2019-03-25 14:55:06,371 - INFO # one or more events are not ready
2019-03-25 14:55:06,378 - INFO # FAIL - testing_spi
2019-03-25 14:55:06,385 - INFO # ===================================================================
2019-03-25 14:55:06,390 - INFO # Test suite test_spi failed.
2019-03-25 14:55:06,391 - INFO # ===================================================================
2019-03-25 14:55:06,392 - INFO # PROJECT EXECUTION FAILED
```
**after:**
```
2019-03-25 14:52:53,644 - INFO # Running test suite test_spi
2019-03-25 14:52:53,650 - INFO # ===================================================================
2019-03-25 14:52:53,653 - INFO # starting test - testing_spi
2019-03-25 14:52:53,661 - INFO # [00:00:00.010,000] <inf> main: SPI test on buffers TX/RX 0x20001494/0x2000029c
2019-03-25 14:52:53,664 - INFO # [00:00:00.020,000] <inf> main: Start
2019-03-25 14:52:53,672 - INFO # [00:00:00.020,000] <inf> spi_sam0: CS control inhibited (no GPIO device)
2019-03-25 14:52:53,676 - INFO # [00:00:00.030,000] <inf> main: Passed
2019-03-25 14:52:53,682 - INFO # [00:00:00.030,000] <inf> main: Start
2019-03-25 14:52:53,689 - INFO # [00:00:00.030,000] <inf> main: Passed
2019-03-25 14:52:53,723 - INFO # [00:00:00.040,000] <inf> main: Start
2019-03-25 14:52:53,732 - INFO # [00:00:00.040,000] <inf> main: Passed
2019-03-25 14:52:53,759 - INFO # [00:00:00.050,000] <inf> main: Start
2019-03-25 14:52:53,775 - INFO # [00:00:00.050,000] <inf> main: Passed
2019-03-25 14:52:53,780 - INFO # [00:00:00.060,000] <inf> main: Start
2019-03-25 14:52:53,788 - INFO # [00:00:00.060,000] <inf> main: Start
2019-03-25 14:52:53,794 - INFO # [00:00:00.060,000] <inf> spi_sam0: CS control inhibited (no GPIO device)
2019-03-25 14:52:53,803 - INFO # [00:00:00.070,000] <inf> main: Passed
2019-03-25 14:52:53,804 - INFO # [00:00:00.070,000] <inf> main: Start
2019-03-25 14:52:53,805 - INFO # [00:00:00.080,000] <inf> main: Passed
2019-03-25 14:52:53,806 - INFO # [00:00:00.080,000] <inf> main: Start
2019-03-25 14:52:53,807 - INFO # [00:00:00.090,000] <inf> main: Passed
2019-03-25 14:52:53,808 - INFO # [00:00:00.090,000] <inf> main: Start
2019-03-25 14:52:53,810 - INFO # [00:00:00.090,000] <inf> main: Passed
2019-03-25 14:52:53,811 - INFO # [00:00:00.100,000] <inf> main: Start
2019-03-25 14:52:53,812 - INFO # [00:00:00.100,000] <inf> main: Start
2019-03-25 14:52:53,814 - INFO # [00:00:00.110,000] <inf> spi_sam0: CS control inhibited (no GPIO device)
2019-03-25 14:52:53,814 - INFO # [00:00:00.110,000] <inf> main: Passed
2019-03-25 14:52:53,815 - INFO # [00:00:00.120,000] <inf> main: Start
2019-03-25 14:52:53,817 - INFO # [00:00:00.120,000] <inf> spi_sam0: CS control inhibited (no GPIO device)
2019-03-25 14:52:53,818 - INFO # [00:00:00.130,000] <inf> main: Passed
2019-03-25 14:52:53,820 - INFO # [00:00:00.130,000] <inf> main: All tx/rx passed
2019-03-25 14:52:53,820 - INFO # PASS - testing_spi
2019-03-25 14:52:53,821 - INFO # ===================================================================
2019-03-25 14:52:53,822 - INFO # Test suite test_spi succeeded
2019-03-25 14:52:53,823 - INFO # ===================================================================
2019-03-25 14:52:53,823 - INFO # PROJECT EXECUTION SUCCESSFUL
```