### PR TITLE
counter: stm32: Fix RTC overflow

### DIFF
--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -22,7 +22,7 @@
 
 LOG_MODULE_REGISTER(counter_rtc_stm32, CONFIG_COUNTER_LOG_LEVEL);
 
-#define T_TIME_OFFSET 2088656896 /* RTC Date reset value: Jan, 1st, xx00 */
+#define T_TIME_OFFSET 946684800
 
 #if defined(CONFIG_SOC_SERIES_STM32L4X)
 #define RTC_EXTI_LINE	LL_EXTI_LINE_18
@@ -87,8 +87,12 @@ static u32_t rtc_stm32_read(struct device *dev)
 	rtc_date = LL_RTC_DATE_Get(RTC);
 
 	/* Convert calendar datetime to UNIX timestamp */
-	now.tm_year = __LL_RTC_CONVERT_BCD2BIN(__LL_RTC_GET_YEAR(rtc_date));
-	now.tm_mon = __LL_RTC_CONVERT_BCD2BIN(__LL_RTC_GET_MONTH(rtc_date));
+	/* RTC start time: 1st, Jan, 2000 */
+	/* time_t start:   1st, Jan, 1900 */
+	now.tm_year = 100 +
+			__LL_RTC_CONVERT_BCD2BIN(__LL_RTC_GET_YEAR(rtc_date));
+	/* tm_mon allowed values are 0-11 */
+	now.tm_mon = __LL_RTC_CONVERT_BCD2BIN(__LL_RTC_GET_MONTH(rtc_date)) - 1;
 	now.tm_mday = __LL_RTC_CONVERT_BCD2BIN(__LL_RTC_GET_DAY(rtc_date));
 
 	now.tm_hour = __LL_RTC_CONVERT_BCD2BIN(__LL_RTC_GET_HOUR(rtc_time));

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -24,12 +24,12 @@ static void test_counter_interrupt_fn(struct device *counter_dev,
 	struct counter_alarm_cfg *config = user_data;
 
 	printk("!!! Alarm !!!\n");
-	printk("Now: %d\n", now_sec);
+	printk("Now: %u\n", now_sec);
 
 	/* Set a new alarm with a double lenght duration */
 	config->ticks = 2 * config->ticks;
 
-	printk("Set alarm in %d sec\n", config->ticks);
+	printk("Set alarm in %u sec\n", config->ticks);
 	counter_set_channel_alarm(counter_dev, ALARM_CHANNEL_ID, user_data);
 }
 


### PR DESCRIPTION
Following #14799 it appeared that RTC to Unix date conversion was overflowing UINT32_MAX.

Looking to it more in detail, when converted to time_t, RTC init date was missing 100 years offset, as time_t starts in 1900 while RTC starts in 2000. Besides, tm_mon calculation was wrong by 1 month as allowed range is 0-11 and provided in range 1-12.

Using correct offset, overflow disappears.

Additionally, fix printk usage issue in sample/counter/alarm.