### PR TITLE
net: gptp: Rename z_gptp_pow2() to gptp_pow2()

### DIFF
--- a/include/net/gptp.h
+++ b/include/net/gptp.h
@@ -68,7 +68,7 @@ struct gptp_uscaled_ns {
 #define GPTP_POW2(exp) pow(2, exp)
 #else
 
-static inline double z_gptp_pow2(int exp)
+static inline double gptp_pow2(int exp)
 {
 	double res;
 
@@ -85,7 +85,7 @@ static inline double z_gptp_pow2(int exp)
 	return res;
 }
 
-#define GPTP_POW2(exp) z_gptp_pow2(exp)
+#define GPTP_POW2(exp) gptp_pow2(exp)
 #endif
 
 /* Pre-calculated constants */


### PR DESCRIPTION
The earlier removal of _ prefix went and renamed this func
and added z_ prefix. This is useless as the relevant macro
is called GPTP_POW2() so call the helper function as gptp_pow2().

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>