### PR TITLE
doc: remove note about calling recheck in CI

### DIFF
--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -221,13 +221,6 @@ The CI results must be green indicating "All checks have passed" before
 the Pull Request can be merged.  CI is run when the PR is created, and
 again every time the PR is modified with a commit.
 
-.. note::
-
-   You can also force
-   the CI system to recheck a PR by adding a comment to the PR saying
-   simply ``recheck`` in the message (helpful if the CI system fails
-   unexpectedly).
-
 The current status of the CI run can always be found at the bottom of the
 GitHub PR page, below the review status. Depending on the success or failure
 of the run you will see:


### PR DESCRIPTION
The command `recheck` was always experimental and should not be part of
the contribution guidelines and flow. It is not working now, so remove
it from the docs.