### PR TITLE
log: net: Fix CONFIG_LOG_IMMEDIATE typo in comment

### DIFF
--- a/subsys/logging/log_backend_net.c
+++ b/subsys/logging/log_backend_net.c
@@ -236,7 +236,7 @@ const struct log_backend_api log_backend_net_api = {
 	.put_sync_string = IS_ENABLED(CONFIG_LOG_IMMEDIATE) ?
 							sync_string : NULL,
 	/* Currently we do not send hexdumps over network to remote server
-	 * in CONFIG_LOG_IMMEDIATE_MODE. This is just to save resources,
+	 * in CONFIG_LOG_IMMEDIATE mode. This is just to save resources,
 	 * this can be revisited if needed.
 	 */
 	.put_sync_hexdump = NULL,


### PR DESCRIPTION
CONFIG_LOG_IMMEDIATE_MODE doesn't exist, only CONFIG_LOG_IMMEDIATE.