### PR TITLE
scripts: process_gperf: Fix broken module docstring

### DIFF
--- a/scripts/process_gperf.py
+++ b/scripts/process_gperf.py
@@ -4,14 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-import argparse
-import os
-import re
-from distutils.version import LooseVersion
-
-# --- debug stuff ---
-
 """
 gperf C file post-processor
 
@@ -25,6 +17,13 @@ the generated code so that we work with pointers directly and not strings.
 This saves a considerable amount of space.
 """
 
+import sys
+import argparse
+import os
+import re
+from distutils.version import LooseVersion
+
+# --- debug stuff ---
 
 def debug(text):
     if not args.verbose:


### PR DESCRIPTION
Needs to be at the beginning of the file. Fixes a pylint warning:

    scripts/process_gperf.py:26:-1: W0105: String statement has no
    effect (pointless-string-statement)