### PR TITLE
net: sockets: Update setsockopt to handle IPV6_V6ONLY

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1133,6 +1133,16 @@ int zsock_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 			return 0;
 		}
 		break;
+
+	case IPPROTO_IPV6:
+		switch (optname) {
+		case IPV6_V6ONLY:
+			/* Ignore for now. Provided to let port
+			 * existing apps.
+			 */
+			return 0;
+		}
+		break;
 	}
 
 	errno = ENOPROTOOPT;


### PR DESCRIPTION
This patch removes the IPV6_V6ONLY option since the current socket
implementation doesn't support this option.

Fix Bugs: #14657

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>