### PR TITLE
scripts: dts: Generate indexed IRQ aliases

### DIFF
--- a/scripts/dts/extract/interrupts.py
+++ b/scripts/dts/extract/interrupts.py
@@ -72,6 +72,13 @@ class DTInterrupts(DTDirective):
                                      l_cell_prefix + name + l_cell_name),
                         full_name,
                         prop_alias)
+                    add_prop_aliases(
+                        node_path,
+                        lambda alias:
+                            '_'.join([str_to_label(alias)] +
+                                     l_cell_prefix + l_idx + l_cell_name),
+                        full_name,
+                        prop_alias)
 
             index += 1
             insert_defs(node_path, prop_def, prop_alias)


### PR DESCRIPTION
This adds generation of IRQ aliases based on their index in the interrupts specification.  Previously, if the IRQ did not have an explicit name set, only the last one in the list was generated for an alias.  This is motivated by the need to support a variable number of IRQs in the SAM0 SERCOM drivers.  For example, SAME54 has four IRQs per SERCOM instance, while SAMD21 only has a single one, so the driver needs to connect all four.  Previously this required a number of lines in `dts_fixup.h` to assign the IRQs to the SERCOM instance, but this allows them to be assigned directly to DTS generated definitions.

For example, before this commit only `DT_ATMEL_SAM0_UART_SERCOM_2_IRQ` was generated, and after `DT_ATMEL_SAM0_UART_SERCOM_2_IRQ_0` and `DT_ATMEL_SAM0_UART_SERCOM_2_IRQ_1`, etc are also generated.