### PR TITLE
board: nsim_em: fix the bug in nsim host timer

### DIFF
--- a/boards/arc/nsim_em/support/nsim.props
+++ b/boards/arc/nsim_em/support/nsim.props
@@ -16,8 +16,6 @@
 	nsim_isa_bitscan_option=1
 	nsim_isa_mpy_option=8
 	nsim_isa_shift_option=3
-	nsim_isa_host_timer=1
-	nsim_isa_host_timer_mhz=10
 	mpu_regions=16
 	mpu_version=2
 	nsim_isa_dsp_option=2

--- a/boards/arc/nsim_em/support/nsim_sem.props
+++ b/boards/arc/nsim_em/support/nsim_sem.props
@@ -15,8 +15,6 @@
 	nsim_isa_bitscan_option=1
 	nsim_isa_mpy_option=8
 	nsim_isa_shift_option=3
-	nsim_isa_host_timer=1
-	nsim_isa_host_timer_mhz=10
 	nsim_isa_dsp_option=2
 	nsim_isa_dsp_complex_option=1
 	nsim_isa_dsp_divsqrt_option=1

--- a/soc/arc/snps_nsim/Kconfig.defconfig.em
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.em
@@ -25,7 +25,7 @@ config RGF_NUM_BANKS
 	default 2
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 10000000
+	default 5000000
 
 config HARVARD
 	default y

--- a/soc/arc/snps_nsim/Kconfig.defconfig.sem
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.sem
@@ -25,7 +25,7 @@ config RGF_NUM_BANKS
 	default 1
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 10000000
+	default 5000000
 
 config HARVARD
 	default y


### PR DESCRIPTION
* the nsim host timer does not work as expected,
  disable it, use cycle count to simulate timer tick

* optmize the freq definition of nsim_em

tests/kernel/critical test still may time out,  one possible fix is to increase its timeout value.

Fixes: #14641 

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>