### PR TITLE
arch: arc: fix the handling of stack check exception

### DIFF
--- a/arch/arc/core/fault.c
+++ b/arch/arc/core/fault.c
@@ -74,8 +74,10 @@ void _Fault(NANO_ESF *esf)
 #ifdef CONFIG_ARC_STACK_CHECKING
 	/* Vector 6 = EV_ProV. Regardless of code, parameter 2 means stack
 	 * check violation
+	 * stack check and mpu violation can come out together, then
+	 * parameter = 0x2 | [0x4 | 0x8 | 0x1]
 	 */
-	if (vector == 6 && parameter == 2) {
+	if (vector == 6 && parameter & 0x2) {
 		z_NanoFatalErrorHandler(_NANO_ERR_STACK_CHK_FAIL, esf);
 		return;
 	}

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -279,13 +279,11 @@ void test_fatal(void)
 
 #ifdef CONFIG_USERSPACE
 
-#if !defined(CONFIG_ARC) /* FIXME #13341 */
 	TC_PRINT("test stack HW-based overflow - user 1\n");
 	check_stack_overflow(stack_hw_overflow, K_USER);
 
 	TC_PRINT("test stack HW-based overflow - user 2\n");
 	check_stack_overflow(stack_hw_overflow, K_USER);
-#endif
 #endif /* CONFIG_USERSPACE */
 
 #endif /* !CONFIG_ARCH_POSIX */


### PR DESCRIPTION
stack check exception may come out with other protection
vilation, e.g. MPU read/write. So the possible paramter
will be 0x02 | [0x4 | 0x8].

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>

Fixes #13341 