### PR TITLE
drivers: hwinfo: add driver support for Atmel SAM0 device ID

### DIFF
--- a/drivers/hwinfo/CMakeLists.txt
+++ b/drivers/hwinfo/CMakeLists.txt
@@ -6,5 +6,6 @@ zephyr_sources_ifdef(CONFIG_HWINFO_NRF        hwinfo_nrf.c)
 zephyr_sources_ifdef(CONFIG_HWINFO_MCUX_SIM   hwinfo_mcux_sim.c)
 zephyr_sources_ifdef(CONFIG_HWINFO_IMXRT      hwinfo_imxrt.c)
 zephyr_sources_ifdef(CONFIG_HWINFO_SAM        hwinfo_sam.c)
+zephyr_sources_ifdef(CONFIG_HWINFO_SAM0       hwinfo_sam0.c)
 
 zephyr_sources_ifdef(CONFIG_HWINFO_SHELL hwinfo_shell.c)

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -55,4 +55,11 @@ config HWINFO_SAM
 	help
 	  Enable Atmel SAM hwinfo driver.
 
+config HWINFO_SAM0
+	bool "Atmel SAM0 device ID"
+	default y
+	depends on SOC_FAMILY_SAM0
+	help
+	  Enable Atmel SAM0 hwinfo driver.
+
 endif

--- a/drivers/hwinfo/hwinfo_sam0.c
+++ b/drivers/hwinfo/hwinfo_sam0.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 ML!PA Consulting GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <soc.h>
+#include <hwinfo.h>
+#include <string.h>
+
+struct sam0_uid {
+	u32_t id[4];
+};
+
+ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
+{
+	struct sam0_uid dev_id;
+
+	dev_id.id[0] = *(const u32_t *) DT_ATMEL_SAM0_ID_0_BASE_ADDRESS_0;
+	dev_id.id[1] = *(const u32_t *) DT_ATMEL_SAM0_ID_0_BASE_ADDRESS_1;
+	dev_id.id[2] = *(const u32_t *) DT_ATMEL_SAM0_ID_0_BASE_ADDRESS_2;
+	dev_id.id[3] = *(const u32_t *) DT_ATMEL_SAM0_ID_0_BASE_ADDRESS_3;
+
+	if (length > sizeof(dev_id.id)) {
+		length = sizeof(dev_id.id);
+	}
+
+	memcpy(buffer, dev_id.id, length);
+
+	return length;
+}

--- a/dts/arm/atmel/samd.dtsi
+++ b/dts/arm/atmel/samd.dtsi
@@ -25,6 +25,14 @@
 		reg = <0x20000000 0x8000>;
 	};
 
+	id: device_id@0 {
+		compatible = "atmel,sam0-id";
+		reg =	<0x0080A00C 0x4>,
+			<0x0080A040 0x4>,
+			<0x0080A044 0x4>,
+			<0x0080A048 0x4>;
+	};
+
 	soc {
 		nvmctrl: nvmctrl@41004000  {
 			compatible = "atmel,sam0-nvmctrl";

--- a/dts/bindings/arm/atmel,sam0-device_id.yaml
+++ b/dts/bindings/arm/atmel,sam0-device_id.yaml
@@ -1,0 +1,21 @@
+---
+title: Atmel Device ID (Serial Number) binding
+version: 0.1
+
+description: >
+    Binding for locating the Device ID (serial number) on Atmel SAM0 devices.
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "atmel,sam0-id"
+      generation: define
+
+    reg:
+      type: array
+      category: required
+      description: Location of Device ID words in memory
+      generation: define
+...


### PR DESCRIPTION
Add driver support for Atmel SAM0 device ID, which is 16-bytes long.
The device ID can simply be read from memory at a known location, but
the location is only described in the data sheet, not in ASF.

For SAMD2x it's `0x0080A00C`, `0x0080A040`, `0x0080A044` & `0x0080A048`.
For SAMD5x it's `0x008061FC`, `0x00806010`, `0x00806014` & `0x00806018`.

This adds a new property to the device tree to define the device ID registers for this SoC family.