### PR TITLE
Sensor: MPU die temperature sensor as default

### DIFF
--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -22,4 +22,11 @@ config ARCH_HAS_CUSTOM_BUSY_WAIT
 config SYS_POWER_MANAGEMENT
 	default y
 
+if SENSOR
+
+config TEMP_NRF5
+	def_bool y
+
+endif # SENSOR
+
 endif # SOC_SERIES_NRF52X


### PR DESCRIPTION
The nrf51 SOC series has the die temp sensor as default if CONFIG_SENSOR=y, therefore for consistency have added to nrf52 series config.