### PR TITLE
Bluetooth: shell: Add missing include path

### DIFF
--- a/subsys/bluetooth/shell/CMakeLists.txt
+++ b/subsys/bluetooth/shell/CMakeLists.txt
@@ -24,3 +24,7 @@ zephyr_library_sources_ifdef(
   ll.c
   ticker.c
   )
+zephyr_include_directories_ifdef(
+	CONFIG_BT_CTLR
+	${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
+	)


### PR DESCRIPTION
When building ticker.c from the shell, it requires include access to the
Nordic HAL, so add the relevant folder to the include path.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>