### PR TITLE
kernel: do not use  k_busy_wait when on single thread

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -41,7 +41,8 @@
 LOG_MODULE_REGISTER(kernel);
 
 /* boot banner items */
-#if defined(CONFIG_BOOT_DELAY) && CONFIG_BOOT_DELAY > 0
+#if defined(CONFIG_MULTITHREADING) && defined(CONFIG_BOOT_DELAY) \
+	&& CONFIG_BOOT_DELAY > 0
 #define BOOT_DELAY_BANNER " (delayed boot "	\
 	STRINGIFY(CONFIG_BOOT_DELAY) "ms)"
 #else
@@ -242,7 +243,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #if CONFIG_STACK_POINTER_RANDOM
 	z_stack_adjust_initialized = 1;
 #endif
-	if (boot_delay > 0) {
+	if (boot_delay > 0 && IS_ENABLED(CONFIG_MULTITHREADING)) {
 		printk("***** delaying boot " STRINGIFY(CONFIG_BOOT_DELAY)
 		       "ms (per build configuration) *****\n");
 		k_busy_wait(CONFIG_BOOT_DELAY * USEC_PER_MSEC);

--- a/tests/kernel/threads/no-multithreading/src/main.c
+++ b/tests/kernel/threads/no-multithreading/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr.h>
-#include <ztest.h>
 
 /* The only point to CONFIG_MULTITHREADING=n is to use Zephyr's
  * multiplatform toolchain, linkage and boostrap integration to arrive
@@ -15,6 +14,5 @@
  */
 void test_main(void)
 {
-	TC_PRINT("It works\n");
-	TC_END_REPORT(TC_PASS);
+	printk("It works\n");
 }


### PR DESCRIPTION
k_busy_wait() does not work when multithreading is disabled, so do not try
to wait during boot.

Fixes #14454