### PR TITLE
logging: Clarify contract of log_output_func_t

### DIFF
--- a/include/logging/log_output.h
+++ b/include/logging/log_output.h
@@ -50,7 +50,11 @@ extern "C" {
  * @param length Data length.
  * @param ctx  User context.
  *
- * @return Number of bytes processed.
+ * @return Number of bytes processed, dropped or discarded.
+ *
+ * @note If the log output function cannot process all of the data, it is
+ *       its responsibility to mark them as dropped or discarded by returning
+ *       the corresponding number of bytes dropped or discarded to the caller.
  */
 typedef int (*log_output_func_t)(u8_t *buf, size_t size, void *ctx);
 


### PR DESCRIPTION
The log_output_func_t backend function is supposed to either process or
drop bytes and return the amount of those to the caller. Clarify this in
the documentation.

Fixes #12241

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>