### PR TITLE
soc: nxp_imx: Configure NUM_IRQS independently for each rt soc

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1021
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1021
@@ -11,6 +11,9 @@ config SOC
 	string
 	default "mimxrt1021"
 
+config NUM_IRQS
+	default 142
+
 config ARM_DIV
 	default 0
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
@@ -11,6 +11,9 @@ config SOC
 	string
 	default "mimxrt1052"
 
+config NUM_IRQS
+	default 160
+
 config ARM_DIV
 	default 1
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1062
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1062
@@ -11,6 +11,9 @@ config SOC
 	string
 	default "mimxrt1062"
 
+config NUM_IRQS
+	default 160
+
 config ARM_DIV
 	default 1
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
@@ -11,6 +11,9 @@ config SOC
 	string
 	default "mimxrt1064"
 
+config NUM_IRQS
+	default 160
+
 config ARM_DIV
 	default 1
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -10,11 +10,6 @@ if SOC_SERIES_IMX_RT
 config SOC_SERIES
 	default "rt"
 
-config NUM_IRQS
-	int
-	# must be >= the highest interrupt number used
-	default 160
-
 config TEXT_SECTION_OFFSET
 	default 0x2000 if BOOT_FLEXSPI_NOR || BOOT_SEMC_NOR
 


### PR DESCRIPTION
Not all i.mx rt socs have the same number of irqs, so move the default
configuration from the soc series level to the individual socs. The
rt1020 hardware reference manual (IMXRT1020RM Rev.1 12/2018) incorrectly
documents 160 irqs (#142-159 reserved), but the soc actually has 142
irqs.

Fixes tests/kernel/gen_isr_table for the mimxrt1020_evk board.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #14297