### PR TITLE
samples: sensor: fix hardware fault when no sensor connected

### DIFF
--- a/samples/sensor/bme280/src/main.c
+++ b/samples/sensor/bme280/src/main.c
@@ -13,6 +13,11 @@ void main(void)
 {
 	struct device *dev = device_get_binding("BME280");
 
+	if (dev == NULL) {
+		printf("Could not get BME280 device\n");
+		return;
+	}
+
 	printf("dev %p name %s\n", dev, dev->config->name);
 
 	while (1) {

--- a/samples/sensor/sx9500/src/main.c
+++ b/samples/sensor/sx9500/src/main.c
@@ -7,8 +7,8 @@
 #include <zephyr.h>
 #include <device.h>
 #include <sensor.h>
+#include <stdio.h>
 #include <misc/printk.h>
-
 #ifdef CONFIG_SX9500_TRIGGER
 
 static void sensor_trigger_handler(struct device *dev, struct sensor_trigger *trig)
@@ -76,6 +76,12 @@ void main(void)
 	struct device *dev;
 
 	dev = device_get_binding("SX9500");
+
+	if (dev == NULL) {
+		printk("Could not get SX9500 device\n");
+		return;
+	}
+
 	printk("device is %p, name is %s\n", dev, dev->config->name);
 
 	do_main(dev);


### PR DESCRIPTION
There are two sensor samples be modified for a more explicit log when
no sensor connected or not connected correctly. Rather than a horrible
hardware fault, which may misleading beginner.

1. bme280
2. sx9500

Signed-off-by: Aaron Tsui <aaron.tsui@outlook.com>
![bme280_fault](https://user-images.githubusercontent.com/4322417/55056197-7934be80-50a0-11e9-8101-b670ebf9b6b6.png)
