### PR TITLE
Bluetooth: Mesh: Fix re-initializing provisioning state upon reset

### DIFF
--- a/subsys/bluetooth/host/mesh/main.c
+++ b/subsys/bluetooth/host/mesh/main.c
@@ -50,7 +50,7 @@ int bt_mesh_provision(const u8_t net_key[16], u16_t net_idx,
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
-		if (bt_mesh_proxy_prov_disable() == 0) {
+		if (bt_mesh_proxy_prov_disable(false) == 0) {
 			pb_gatt_enabled = true;
 		} else {
 			pb_gatt_enabled = false;
@@ -184,8 +184,7 @@ int bt_mesh_prov_disable(bt_mesh_prov_bearer_t bearers)
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT) &&
 	    (bearers & BT_MESH_PROV_GATT)) {
-		bt_mesh_proxy_prov_disable();
-		bt_mesh_adv_update();
+		bt_mesh_proxy_prov_disable(true);
 	}
 
 	return 0;

--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -1412,9 +1412,9 @@ static void gen_prov_start(struct prov_rx *rx, struct net_buf_simple *buf)
 }
 
 static const struct {
-	void (*const func)(struct prov_rx *rx, struct net_buf_simple *buf);
-	const u8_t require_link;
-	const u8_t min_len;
+	void (*func)(struct prov_rx *rx, struct net_buf_simple *buf);
+	bool require_link;
+	u8_t min_len;
 } gen_prov[] = {
 	{ gen_prov_start, true, 3 },
 	{ gen_prov_ack, true, 0 },

--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -104,7 +104,6 @@
 
 enum {
 	REMOTE_PUB_KEY,        /* Remote key has been received */
-	LOCAL_PUB_KEY,         /* Local public key is available */
 	LINK_ACTIVE,           /* Link has been opened */
 	HAVE_DHKEY,            /* DHKey has been calcualted */
 	SEND_CONFIRM,          /* Waiting to send Confirm value */
@@ -217,10 +216,6 @@ static void reset_state(void)
 #else
 	(void)memset(&link, 0, sizeof(link));
 #endif /* PB_ADV */
-
-	if (bt_pub_key_get()) {
-		atomic_set_bit(link.flags, LOCAL_PUB_KEY);
-	}
 }
 
 #if defined(CONFIG_BT_MESH_PB_ADV)
@@ -917,7 +912,7 @@ static void prov_pub_key(const u8_t *data)
 
 	memcpy(&link.conf_inputs[17], data, 64);
 
-	if (!atomic_test_bit(link.flags, LOCAL_PUB_KEY)) {
+	if (!bt_pub_key_get()) {
 		/* Clear retransmit timer */
 #if defined(CONFIG_BT_MESH_PB_ADV)
 		prov_clear_tx();
@@ -938,8 +933,6 @@ static void pub_key_ready(const u8_t *pkey)
 	}
 
 	BT_DBG("Local public key ready");
-
-	atomic_set_bit(link.flags, LOCAL_PUB_KEY);
 
 	if (atomic_test_and_clear_bit(link.flags, REMOTE_PUB_KEY)) {
 		send_pub_key();

--- a/subsys/bluetooth/host/mesh/proxy.h
+++ b/subsys/bluetooth/host/mesh/proxy.h
@@ -15,7 +15,7 @@ int bt_mesh_proxy_send(struct bt_conn *conn, u8_t type,
 		       struct net_buf_simple *msg);
 
 int bt_mesh_proxy_prov_enable(void);
-int bt_mesh_proxy_prov_disable(void);
+int bt_mesh_proxy_prov_disable(bool disconnect);
 
 int bt_mesh_proxy_gatt_enable(void);
 int bt_mesh_proxy_gatt_disable(void);

--- a/subsys/bluetooth/host/mesh/settings.c
+++ b/subsys/bluetooth/host/mesh/settings.c
@@ -739,7 +739,7 @@ static int mesh_commit(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
-		bt_mesh_proxy_prov_disable();
+		bt_mesh_proxy_prov_disable(true);
 	}
 
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.sub); i++) {


### PR DESCRIPTION
If both PB-ADV and PB-GATT are supported, we need to properly
re-initialize variables such as link.rx.prev_id and (particularly
importantly) link.rx.buf. If we don't do this it may lead to the
following fault when trying to reprovision again:

***** USAGE FAULT *****
  Illegal use of the EPSR
***** Hardware exception *****
Current thread ID = 0x20001f10
Faulting instruction address = 0x0
Fatal fault in thread 0x20001f10! Aborting.

Fixes #14928

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>