### PR TITLE
soc: nrf52810 fix memory region for flash controller

### DIFF
--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -17,7 +17,7 @@
 
 	flash-controller@4001E000 {
 			compatible = "nordic,nrf52-flash-controller";
-			reg = <0x4001E000 0x550>;
+			reg = <0x4001E000 0x520>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;


### PR DESCRIPTION
Fixing copy paste error from nrf52832 and nrf52840.

Chip nrf52810 has less registers responsible for handling flash hence it needs less memory reserved for flash controller.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>