### PR TITLE
elf_helper: fix debug_die call

### DIFF
--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -152,7 +152,8 @@ class AggregateTypeMember:
                         self.member_offset += (
                             member_offset[i+1] & 0x7f) << i*7
             else:
-                self.debug_die("not yet supported location operation")
+                raise Exception("not yet supported location operation (%s:%d:%d)" %
+                        (self.member_name, self.member_type, member_offset[0]))
         else:
             self.member_offset = member_offset
 


### PR DESCRIPTION
debug_die() is not implemented in this class, and indeed we
don't even have a reference to the DWARF DIE object.

This is a fatal error anyway, just raise an exception.

Fixes #14762

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>