### PR TITLE
Bluetooth: GATT: Fix attribute read return parameter type

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -307,7 +307,7 @@ static u8_t gen_hash_m(const struct bt_gatt_attr *attr, void *user_data)
 	struct gen_hash_state *state = user_data;
 	struct bt_uuid_16 *u16;
 	u8_t data[16];
-	size_t len;
+	ssize_t len;
 	u16_t value;
 
 	if (attr->uuid->type != BT_UUID_TYPE_16)


### PR DESCRIPTION
The read() callback of attributes returns ssize_t and not size_t. Fix
this, which also fixes a Coverity warning.

Fixes Coverity CID 197457
Fixes #14958

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>