### PR TITLE
drivers: watchdog: stm32: Remove callback checking

### DIFF
--- a/drivers/watchdog/iwdg_stm32.c
+++ b/drivers/watchdog/iwdg_stm32.c
@@ -100,10 +100,6 @@ static int iwdg_stm32_install_timeout(struct device *dev,
 	u32_t reload = 0U;
 	u32_t tickstart;
 
-	if (config->callback != NULL) {
-		return -ENOTSUP;
-	}
-
 	iwdg_stm32_convert_timeout(timeout, &prescaler, &reload);
 
 	if (!(IS_IWDG_TIMEOUT(timeout) && IS_IWDG_PRESCALER(prescaler) &&


### PR DESCRIPTION
Remove callback checking, which cause tests/drivers/watchdog/ and
samples/drivers/watchdog/ fail.

Signed-off-by: Aaron Tsui <aaron.tsui@outlook.com>