### PR TITLE
Fix linking for nRF52840-PCA10059 with Nordic bootloader.

### DIFF
--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -20,7 +20,7 @@
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,code-partition = &slot0_partition;
+		zephyr,code-partition = &boot_partition;
 	};
 
 	leds {
@@ -124,7 +124,7 @@
  * fstab-stock		-compatible with Nordic nRF5 bootloader, default
  * fstab-debugger	-to use an external debugger, w/o the nRF5 bootloader
  */
-#include "fstab-stock.dts"
+#include "fstab-debugger.dts"
 
 &usbd {
 	compatible = "nordic,nrf-usbd";


### PR DESCRIPTION
### Superseded by #14978, Cunningham's Law.

To make the image work we need to link at 0x0, because the linker inserts an extra 0x1000 bytes of padding for reasons that I don't understand.

Anyway, starting at zero makes the vectors land at 0x1000, which is the right place to make example apps work.

Fixes #14946
Fixes #14943
Fixes #14945.