### PR TITLE
tests: watchdog: Update test to support ATSAMxxxx based board

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -78,6 +78,11 @@
 #define TIMEOUTS                   2
 #elif defined(CONFIG_IWDG_STM32)
 #define TIMEOUTS                   0
+#elif defined(CONFIG_WDT_SAM)
+#ifdef CONFIG_SOC_SERIES_SAME70
+#error SAME70 series chip NOT supports this test.
+#endif
+#define TIMEOUTS                   0
 #else
 #define TIMEOUTS                   1
 #endif

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   peripheral.watchdog:
     depends_on: watchdog
     tags: drivers watchdog
+    platform_exclude: sam_e70_xplained


### PR DESCRIPTION
ATSAM watchdog driver does not support callback which is not expected by
the test. Update to make testing able to run on ATSAM watchdog drivers.

Fixes #13468 for Arduino_due and so on.

Signed-off-by: Aaron Tsui <aaron.tsui@outlook.com>