### PR TITLE
dts: update memory regions for nrf chips

### DIFF
--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -17,7 +17,7 @@
 
 	flash-controller@4001E000 {
 			compatible = "nordic,nrf51-flash-controller";
-			reg = <0x4001E000 0x518>;
+			reg = <0x4001E000 0x1000>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -91,7 +91,7 @@
 		gpio0: gpio@50000000 {
 			compatible = "nordic,nrf-gpio";
 			gpio-controller;
-			reg = <0x50000000 0x800>;
+			reg = <0x50000000 0x1000>;
 			#gpio-cells = <2>;
 			label = "GPIO_0";
 			status = "disabled";

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -17,7 +17,7 @@
 
 	flash-controller@4001E000 {
 			compatible = "nordic,nrf52-flash-controller";
-			reg = <0x4001E000 0x550>;
+			reg = <0x4001E000 0x1000>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -90,8 +90,7 @@
 		gpio0: gpio@50000000 {
 			compatible = "nordic,nrf-gpio";
 			gpio-controller;
-			reg = <0x50000000 0x200
-			       0x50000500 0x300>;
+			reg = <0x50000000 0x1000>;
 			#gpio-cells = <2>;
 			label = "GPIO_0";
 			status = "disabled";

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -17,7 +17,7 @@
 
 	flash-controller@4001E000 {
 			compatible = "nordic,nrf52-flash-controller";
-			reg = <0x4001E000 0x550>;
+			reg = <0x4001E000 0x1000>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -99,8 +99,7 @@
 		gpio0: gpio@50000000 {
 			compatible = "nordic,nrf-gpio";
 			gpio-controller;
-			reg = <0x50000000 0x200
-			       0x50000500 0x300>;
+			reg = <0x50000000 0x1000>;
 			#gpio-cells = <2>;
 			label = "GPIO_0";
 			status = "disabled";

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -17,7 +17,7 @@
 
 	flash-controller@4001E000 {
 			compatible = "nordic,nrf52-flash-controller";
-			reg = <0x4001E000 0x550>;
+			reg = <0x4001E000 0x1000>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;


### PR DESCRIPTION
According to nrf51 and nrf52 specifaction every peripheral is assigned a fixed block of 0x1000 bytes. Due to that dts for nrf51 and nrf52 chips have been updated. The only exception is gpio for nrf52840 where gpio0 and gpio1 share the same memory regions. For this reason, the definition of gpio for series No.f52 chips is different from the others.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>