### PR TITLE
samples: watchdog: Confirm that reset occured

### DIFF
--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -11,4 +11,5 @@ tests:
             - "Watchdog sample application"
             - "Feeding watchdog..."
             - "Waiting for reset..."
+            - "Watchdog sample application"
     depends_on: watchdog


### PR DESCRIPTION
Updated test harness to check for a second instance of
"Watchdog sample application". This is to confirm the
board did reset itself.

Signed-off-by: Cinly Ooi <cinly.ooi@intel.com>