### PR TITLE
boards: arm: nrf52840_pca10059: correctly set FLASH_LOAD_OFFSET

### DIFF
--- a/boards/arm/nrf52840_pca10059/Kconfig.defconfig
+++ b/boards/arm/nrf52840_pca10059/Kconfig.defconfig
@@ -9,15 +9,23 @@ if BOARD_NRF52840_PCA10059
 config BOARD
 	default "nrf52840_pca10059"
 
-if BOARD_HAS_NRF5_BOOTLOADER && !BOOTLOADER_MCUBOOT
+if BOARD_HAS_NRF5_BOOTLOADER && !USE_CODE_PARTITION
 
-# Link the application after Nordic MBR.
-# When flashing MCUBoot, leave unchanged to link it in its correct partition.
+# To let the nRF5 bootloader load an application, the application
+# must be linked after Nordic MBR, that is factory-programmed on the board.
 
-config TEXT_SECTION_OFFSET
-	default 0x1000
+# Nordic nRF5 booatloader exists outside of the partitions specified in the
+# DTS file, so we manually override FLASH_LOAD_OFFEST to link the application
+# correctly, after Nordic MBR.
 
-endif # BOARD_HAS_NRF5_BOOTLOADER && !BOOTLOADER_MCUBOOT
+# When building MCUBoot, MCUBoot itself will select USE_CODE_PARTITION
+# which will make it link into the correct partition specified in DTS file,
+# so no override is necessary.
+
+config FLASH_LOAD_OFFSET
+        default 0x1000
+
+endif # BOARD_HAS_NRF5_BOOTLOADER && !USE_CODE_PARTITION
 
 if ADC
 


### PR DESCRIPTION
Set `FLASH_LOAD_OFFSET` correctly (accounting for Nordic MBR) when
`BOARD_HAS_NRF5_BOOTLOADER` is defined and we're not compiling MCUboot. 

MCUboot will select `USE_CODE_PARTITION`, which will make it link correctly
regardless of which board DTS is used (stock/debugger).

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/14943, https://github.com/zephyrproject-rtos/zephyr/issues/14945, https://github.com/zephyrproject-rtos/zephyr/issues/14946
FYI: @carlescufi @nvlsianpu