### PR TITLE
boards: nrf9160_pca10090: Fix LEDs active state

### DIFF
--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
@@ -18,19 +18,19 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio0 2 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 2 GPIO_INT_ACTIVE_HIGH>;
 			label = "Green LED 0";
 		};
 		led1: led_1 {
-			gpios = <&gpio0 3 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 3 GPIO_INT_ACTIVE_HIGH>;
 			label = "Green LED 1";
 		};
 		led2: led_2 {
-			gpios = <&gpio0 4 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 4 GPIO_INT_ACTIVE_HIGH>;
 			label = "Green LED 2";
 		};
 		led3: led_3 {
-			gpios = <&gpio0 5 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "Green LED 3";
 		};
 	};


### PR DESCRIPTION
The nRF91 DK User Guide clearly says "the LEDs are active high,
meaning that writing a logical one ('1') to the output pin will
illuminate the LED".

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>