### PR TITLE
CODEOWNERS: add owner for /dts/bindings/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -139,6 +139,7 @@
 /dts/arm/st/                              @erwango
 /dts/arm/nordic/                          @ioannisg @carlescufi
 /dts/arm/nxp/                             @MaureenHelm
+/dts/bindings/                            @galak
 /dts/bindings/can/                        @alexanderwachter
 /dts/bindings/*/nordic*                   @anangl
 /dts/bindings/*/nxp*                      @MaureenHelm


### PR DESCRIPTION
@galak is now the proud owner of /dts/bindings/.