### PR TITLE
Bluetooth: host: Add RPA in directed advertisement support

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -277,6 +277,17 @@ enum {
 	 *  bt_conn_create_slave_le().
 	 */
 	BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY = BIT(4),
+
+	/** Enable use of Resolvable Private Address (RPA) as the target address
+	 *  in directed advertisements when CONFIG_BT_PRIVACY is not enabled.
+	 *  This is required if the remote device is privacy-enabled and
+	 *  supports address resolution of the target address in directed
+	 *  advertisement.
+	 *  It is the responsibility of the application to check that the remote
+	 *  device supports address resolution of directed advertisements by
+	 *  reading its Central Address Resolution characteristic.
+	 */
+	BT_LE_ADV_OPT_DIR_ADDR_RPA = BIT(5),
 };
 
 /** LE Advertising Parameters. */

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -29,6 +29,7 @@ extern "C" {
 /* Special own address types for LL privacy (used in adv & scan parameters) */
 #define BT_HCI_OWN_ADDR_RPA_OR_PUBLIC  0x02
 #define BT_HCI_OWN_ADDR_RPA_OR_RANDOM  0x03
+#define BT_HCI_OWN_ADDR_RPA_MASK       0x02
 
 /** Bluetooth Device Address */
 typedef struct {


### PR DESCRIPTION
In order to advertise directed to a privacy enabled central the
initiator field of the directed adv packet needs to set to an RPA.
To instruct the controller to use an RPA in the initiator field own
address type should be set to either 0x02 or 0x03.
Since it is not certain that a remote device supports address resolution
of the initiator address we add an option to turn this on and give the
application the responsibility to check if peer supports this.

Fixes #14743

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>