### PR TITLE
cmake: Make git describe handle non-annotated tags

### DIFF
--- a/cmake/git.cmake
+++ b/cmake/git.cmake
@@ -4,7 +4,7 @@
 find_package(Git QUIET)
 if(GIT_FOUND)
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --abbrev=12
+    COMMAND ${GIT_EXECUTABLE} describe --abbrev=12 --tags
     WORKING_DIRECTORY                ${ZEPHYR_BASE}
     OUTPUT_VARIABLE                  BUILD_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
If we tag via github a pre-release we don't get an annotated tag.  So
the BUILD_VERSION isn't reported correctly.  We can fix this via adding
--tags to 'git describe'.

Fixes #14985

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>