### PR TITLE
doc: dts: Remove orphan section

### DIFF
--- a/doc/guides/dts/flash_partitions.inc
+++ b/doc/guides/dts/flash_partitions.inc
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _flash_partitions:
 
 Flash Partitions


### PR DESCRIPTION
'orphan:' appears before Flash Partitions section on
https://docs.zephyrproject.org/latest/guides/dts/index.html page.
Fix this

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>