### PR TITLE
Revert "soc: arm: nordic: provide custom busy_wait implementations"

### DIFF
--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
@@ -20,9 +20,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_POWER_MANAGEMENT
 	default y
 
-config ARCH_HAS_CUSTOM_BUSY_WAIT
-	default y
-
 config NUM_IRQS
 	int
 	default 26

--- a/soc/arm/nordic_nrf/nrf51/soc.c
+++ b/soc/arm/nordic_nrf/nrf51/soc.c
@@ -59,16 +59,4 @@ static int nordicsemi_nrf51_init(struct device *arg)
 	return 0;
 }
 
-#define DELAY_CALL_OVERHEAD_US 2
-
-void z_arch_busy_wait(u32_t time_us)
-{
-	if (time_us <= DELAY_CALL_OVERHEAD_US) {
-		return;
-	}
-
-	time_us -= DELAY_CALL_OVERHEAD_US;
-	nrfx_coredep_delay_us(time_us);
-}
-
 SYS_INIT(nordicsemi_nrf51_init, PRE_KERNEL_1, 0);

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -16,9 +16,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
 	default 32768
 
-config ARCH_HAS_CUSTOM_BUSY_WAIT
-	default y
-
 config SYS_POWER_MANAGEMENT
 	default y
 

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -81,9 +81,4 @@ static int nordicsemi_nrf52_init(struct device *arg)
 	return 0;
 }
 
-void z_arch_busy_wait(u32_t time_us)
-{
-	nrfx_coredep_delay_us(time_us);
-}
-
 SYS_INIT(nordicsemi_nrf52_init, PRE_KERNEL_1, 0);


### PR DESCRIPTION
This PR reverts commit d4b4b992725360a95ca1ffa357286be0b16615e5 as it
introduced unwanted side effect: It moved the k_busy_wait() to other
clock that the one driving system timer and k_cycle_get_32(). As result,
delays created using these interfaces not matched each other.

Details: https://github.com/zephyrproject-rtos/zephyr/issues/14186#issuecomment-477623826
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/14186