### PR TITLE
tests/kernel/device: extends test for code coverage

### DIFF
--- a/tests/kernel/device/CMakeLists.txt
+++ b/tests/kernel/device/CMakeLists.txt
@@ -4,3 +4,11 @@ project(device)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+
+# device_get_binding() compares pointers first before doing strcmp().
+# However, enabling coverage forces -O0 to disable any compiler
+# optimizations. There would be multiple copies of the same string,
+# and the code pathing doing pointer comparsion would not be tested
+# at all. So add this flag to merge string constants such that
+# the pointer comparison would be exercised.
+zephyr_cc_option_ifdef(CONFIG_COVERAGE -fmerge-constants)

--- a/tests/kernel/device/src/bad_driver.c
+++ b/tests/kernel/device/src/bad_driver.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <device.h>
+
+
+#define BAD_DRIVER_NAME	"bad_driver"
+
+typedef int (*bad_api_configure_t)(struct device *dev,
+				     u32_t dev_config);
+
+
+struct bad_driver_api {
+	bad_api_configure_t configure;
+};
+
+static int bad_configure(struct device *dev, u32_t config)
+{
+	return 0;
+}
+
+static const struct bad_driver_api funcs = {
+	.configure = bad_configure,
+};
+
+int bad_driver_init(struct device *dev)
+{
+	return -EINVAL;
+}
+
+/**
+ * @cond INTERNAL_HIDDEN
+ */
+DEVICE_AND_API_INIT(bad_driver, BAD_DRIVER_NAME, &bad_driver_init,
+		    NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		    &funcs);
+
+/**
+ * @endcond
+ */

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -12,6 +12,7 @@
 
 #define DUMMY_PORT_1    "dummy"
 #define DUMMY_PORT_2    "dummy_driver"
+#define BAD_DRIVER	"bad_driver"
 
 /**
  * @brief Test cases to verify device objects
@@ -46,6 +47,12 @@ void test_dummy_device(void)
 
 	device_busy_set(dev);
 	device_busy_clear(dev);
+
+	/* device_get_binding() returns false for device object
+	 * with failed init.
+	 */
+	dev = device_get_binding(BAD_DRIVER);
+	zassert_true((dev == NULL), NULL);
 }
 
 /**


### PR DESCRIPTION
device_get_binding() compares pointers first before doing strcmp().
However, enabling coverage forces -O0 to disable any compiler
optimizations. There would be multiple copies of the same string,
and the code pathing doing pointer comparsion would not be tested
at all. So add this flag to merge string constants such that
the pointer comparison would be exercised.

This also adds a bad driver which fails initialization. This is
to make sure that execution path is covered.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>