### PR TITLE
Bluetooth: ipsp: Fix not checking return of build_reply

### DIFF
--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -217,6 +217,10 @@ static void udp_received(struct net_context *context,
 	set_dst_addr(family, pkt, ip_hdr->ipv6, proto_hdr->udp, &dst_addr);
 
 	ret = build_reply(dbg, pkt, buf_tx);
+	if (ret < 0) {
+		LOG_ERR("Cannot send data to peer (%d)", ret);
+		return;
+	}
 
 	net_pkt_unref(pkt);
 
@@ -262,6 +266,10 @@ static void tcp_received(struct net_context *context,
 		 family == AF_INET6 ? '6' : '4');
 
 	ret = build_reply(dbg, pkt, buf_tx);
+	if (ret < 0) {
+		LOG_ERR("Cannot send data to peer (%d)", ret);
+		return;
+	}
 
 	net_pkt_unref(pkt);
 


### PR DESCRIPTION
net_pkt_sendto uses size_t as parameter for len so the value would be
treat as unsigned which may cause and invalid memory to be read.

Fixes #14950
Fixes #14955

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>