### PR TITLE
USB: Webusb refactor stripping 'serial' and fix vendor reqs

### DIFF
--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2016-2019 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -20,14 +20,13 @@ LOG_MODULE_REGISTER(main);
 #include <stdio.h>
 #include <string.h>
 #include <device.h>
-#include <uart.h>
 #include <zephyr.h>
 #include <misc/byteorder.h>
 #include <usb/usb_common.h>
 #include <usb/usb_device.h>
 #include <usb/bos.h>
 
-#include "webusb_serial.h"
+#include "webusb.h"
 
 /* Predefined response to control commands related to MS OS 2.0 descriptors */
 static const u8_t msos2_descriptor[] = {
@@ -285,5 +284,5 @@ void main(void)
 	usb_bos_register_cap((void *)&bos_cap_webusb);
 	usb_bos_register_cap((void *)&bos_cap_msosv2);
 
-	webusb_serial_init();
+	webusb_init();
 }

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -207,6 +207,8 @@ int custom_handle_req(struct usb_setup_packet *pSetup,
 		*data = (u8_t *)(&msos1_string_descriptor);
 		*len = sizeof(msos1_string_descriptor);
 
+		LOG_DBG("Get MS OS Descriptor v1 string");
+
 		return 0;
 	}
 
@@ -224,12 +226,14 @@ int custom_handle_req(struct usb_setup_packet *pSetup,
  * @return  0 on success, negative errno code on fail.
  */
 int vendor_handle_req(struct usb_setup_packet *pSetup,
-		s32_t *len, u8_t **data)
+		      s32_t *len, u8_t **data)
 {
 	/* Get Allowed origins request */
 	if (pSetup->bRequest == 0x01 && pSetup->wIndex == 0x01) {
 		*data = (u8_t *)(&webusb_allowed_origins);
 		*len = sizeof(webusb_allowed_origins);
+
+		LOG_DBG("Get webusb_allowed_origins");
 
 		return 0;
 	} else if (pSetup->bRequest == 0x01 && pSetup->wIndex == 0x02) {
@@ -242,12 +246,16 @@ int vendor_handle_req(struct usb_setup_packet *pSetup,
 		*data = (u8_t *)(&webusb_origin_url);
 		*len = sizeof(webusb_origin_url);
 
+		LOG_DBG("Get webusb_origin_url");
+
 		return 0;
 	} else if (pSetup->bRequest == 0x02 && pSetup->wIndex == 0x07) {
 		/* Get MS OS 2.0 Descriptors request */
 		/* 0x07 means "MS_OS_20_DESCRIPTOR_INDEX" */
 		*data = (u8_t *)(&msos2_descriptor);
 		*len = sizeof(msos2_descriptor);
+
+		LOG_DBG("Get MS OS Descriptors v2");
 
 		return 0;
 	} else if (pSetup->bRequest == 0x03 && pSetup->wIndex == 0x04) {
@@ -257,6 +265,8 @@ int vendor_handle_req(struct usb_setup_packet *pSetup,
 		 */
 		*data = (u8_t *)(&msos1_compatid_descriptor);
 		*len = sizeof(msos1_compatid_descriptor);
+
+		LOG_DBG("Get MS OS Descriptors CompatibeID");
 
 		return 0;
 	}

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -13,7 +13,7 @@
  * the browser at host.
  */
 
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
+#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
 #include <logging/log.h>
 LOG_MODULE_REGISTER(main);
 

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -17,10 +17,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(main);
 
-#include <stdio.h>
-#include <string.h>
-#include <device.h>
-#include <zephyr.h>
 #include <misc/byteorder.h>
 #include <usb/usb_common.h>
 #include <usb/usb_device.h>

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -12,9 +12,9 @@
  * to support the WebUSB.
  */
 
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
+#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_DECLARE(main);
+LOG_MODULE_REGISTER(webusb);
 
 #include <zephyr.h>
 #include <init.h>

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -1,34 +1,8 @@
-/*******************************************************************************
+/*
+ * Copyright (c) 2015-2019 Intel Corporation
  *
- * Copyright(c) 2015,2016 Intel Corporation.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * * Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- * * Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in
- * the documentation and/or other materials provided with the
- * distribution.
- * * Neither the name of Intel Corporation nor the names of its
- * contributors may be used to endorse or promote products derived
- * from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- ******************************************************************************/
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /**
  * @file

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -312,7 +312,8 @@ static struct usb_cfg_data webusb_config = {
 		.class_handler = NULL,
 		.custom_handler = webusb_custom_handle_req,
 		.vendor_handler = webusb_vendor_handle_req,
-		.payload_data = NULL,
+		.vendor_data = interface_data,
+		.payload_data = interface_data,
 	},
 	.num_endpoints = ARRAY_SIZE(webusb_ep_data),
 	.endpoint = webusb_ep_data
@@ -323,8 +324,6 @@ int webusb_init(void)
 	int ret;
 
 	LOG_DBG("");
-
-	webusb_config.interface.payload_data = interface_data;
 
 	/* Initialize the WebUSB driver with the right configuration */
 	ret = usb_set_config(&webusb_config);

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -16,9 +16,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(webusb);
 
-#include <zephyr.h>
-#include <init.h>
-#include <string.h>
 #include <misc/byteorder.h>
 #include <usb/usb_device.h>
 #include <usb/usb_common.h>

--- a/samples/subsys/usb/webusb/src/webusb.h
+++ b/samples/subsys/usb/webusb/src/webusb.h
@@ -69,6 +69,6 @@ struct webusb_req_handlers {
  */
 void webusb_register_request_handlers(struct webusb_req_handlers *handlers);
 
-int webusb_serial_init(void);
+int webusb_init(void);
 
 #endif /* __WEBUSB_SERIAL_H__ */

--- a/samples/subsys/usb/webusb/src/webusb.h
+++ b/samples/subsys/usb/webusb/src/webusb.h
@@ -14,9 +14,6 @@
 #ifndef __WEBUSB_SERIAL_H__
 #define __WEBUSB_SERIAL_H__
 
-#include <device.h>
-#include <usb/usb_device.h>
-
 /**
  * WebUSB request handlers
  */

--- a/samples/subsys/usb/webusb/src/webusb.h
+++ b/samples/subsys/usb/webusb/src/webusb.h
@@ -1,34 +1,8 @@
-/***************************************************************************
+/*
+ * Copyright (c) 2015-2019 Intel Corporation
  *
- * Copyright(c) 2015,2016 Intel Corporation.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * * Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- * * Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in
- * the documentation and/or other materials provided with the
- * distribution.
- * * Neither the name of Intel Corporation nor the names of its
- * contributors may be used to endorse or promote products derived
- * from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- ***************************************************************************/
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /**
  * @file


### PR DESCRIPTION
Strip `serial` name since we do not depend on serial anymore, fix vendor requests, fix logging.