### PR TITLE
net: buf: Remove wrong alignment annotation from NET_BUF_SIMPLE()

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -115,7 +115,7 @@ struct net_buf_simple {
 #define NET_BUF_SIMPLE(_size)                        \
 	((struct net_buf_simple *)(&(struct {        \
 		struct net_buf_simple buf;           \
-		u8_t data[_size] __net_buf_align;    \
+		u8_t data[_size];                    \
 	}) {                                         \
 		.buf.size = _size,                   \
 	}))


### PR DESCRIPTION
The code (net_buf_simple_init in particular) expects the data buffer
to immediately follow the net_buf_simple struct, so it's wrong to
request any specific alignment for this buffer. In practice this
doesn't make any difference since the net_buf_simple struct itself is
4-bytes aligned and a multiple of 4 bytes, however the extra
__net_buf_align makes it look like its location in memory doesn't need
to immediately follow the net_buf_simple struct.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>