### PR TITLE
USB: fix status callback in composite configuration and crash in wpanusb sample

### DIFF
--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -190,12 +190,9 @@ struct usb_cfg_data {
 	/** Function for interface runtime configuration */
 	usb_interface_config interface_config;
 	/** Callback to be notified on USB connection status change */
-	usb_dc_status_callback cb_usb_status;
-	/** Composite callback */
-	void (*cb_usb_status_composite)(struct usb_cfg_data *cfg,
-					enum usb_dc_status_code cb_status,
-					const u8_t *param);
-
+	void (*cb_usb_status)(struct usb_cfg_data *cfg,
+			      enum usb_dc_status_code cb_status,
+			      const u8_t *param);
 	/** USB interface (Class) handler and storage space */
 	struct usb_interface_cfg_data interface;
 	/** Number of individual endpoints in the device configuration */

--- a/samples/net/wpanusb/CMakeLists.txt
+++ b/samples/net/wpanusb/CMakeLists.txt
@@ -3,6 +3,7 @@ include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(wpanusb)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
+target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/l2)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -136,11 +136,14 @@ static struct usb_ep_cfg_data wpanusb_ep[] = {
 	},
 };
 
-static void wpanusb_status_cb(enum usb_dc_status_code status, const u8_t *param)
+static void wpanusb_status_cb(struct usb_cfg_data *cfg,
+			      enum usb_dc_status_code status,
+			      const u8_t *param)
 {
 	struct wpanusb_dev_data_t * const dev_data = DEV_DATA(wpanusb_dev);
 
 	ARG_UNUSED(param);
+	ARG_UNUSED(cfg);
 
 	/* Store the new status */
 	dev_data->usb_status = status;

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -312,7 +312,9 @@ static int wpanusb_vendor_handler(struct usb_setup_packet *setup,
 {
 	struct net_pkt *pkt;
 
-	pkt = net_pkt_alloc_with_buffer(NULL, *len, AF_UNSPEC, 0, K_NO_WAIT);
+	/* Maximum 2 bytes are added to the len */
+	pkt = net_pkt_alloc_with_buffer(NULL, *len + 2, AF_UNSPEC, 0,
+					K_NO_WAIT);
 	if (!pkt) {
 		return -ENOMEM;
 	}

--- a/samples/net/wpanusb/src/wpanusb.h
+++ b/samples/net/wpanusb/src/wpanusb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2016-2019 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/samples/subsys/usb/webusb/src/webusb_serial.c
+++ b/samples/subsys/usb/webusb/src/webusb_serial.c
@@ -283,12 +283,12 @@ done:
  *
  * @return  N/A.
  */
-static void webusb_serial_dev_status_cb(enum usb_dc_status_code status,
+static void webusb_serial_dev_status_cb(struct usb_cfg_data *cfg,
+					enum usb_dc_status_code status,
 					const u8_t *param)
 {
 	ARG_UNUSED(param);
-
-	LOG_DBG("");
+	ARG_UNUSED(cfg);
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -206,9 +206,12 @@ static void acl_read_cb(u8_t ep, int size, void *priv)
 		     BT_BUF_ACL_SIZE, USB_TRANS_READ, acl_read_cb, buf);
 }
 
-static void bluetooth_status_cb(enum usb_dc_status_code status,
+static void bluetooth_status_cb(struct usb_cfg_data *cfg,
+				enum usb_dc_status_code status,
 				const u8_t *param)
 {
+	ARG_UNUSED(cfg);
+
 	/* Check the USB status and do needed action if required */
 	switch (status) {
 	case USB_DC_ERROR:

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -384,10 +384,9 @@ static void hid_do_status_cb(struct hid_device_info *dev_data,
 	}
 }
 
-#ifdef CONFIG_USB_COMPOSITE_DEVICE
-static void hid_status_composite_cb(struct usb_cfg_data *cfg,
-				    enum usb_dc_status_code status,
-				    const u8_t *param)
+static void hid_status_cb(struct usb_cfg_data *cfg,
+			  enum usb_dc_status_code status,
+			  const u8_t *param)
 {
 	struct hid_device_info *dev_data;
 	struct usb_dev_data *common;
@@ -404,25 +403,6 @@ static void hid_status_composite_cb(struct usb_cfg_data *cfg,
 
 	hid_do_status_cb(dev_data, status, param);
 }
-#else
-static void hid_status_cb(enum usb_dc_status_code status, const u8_t *param)
-{
-	struct hid_device_info *dev_data;
-	struct usb_dev_data *common;
-
-	/* Should be the only one element in the list */
-	common = CONTAINER_OF(sys_slist_peek_head(&usb_hid_devlist),
-			      struct usb_dev_data, node);
-	if (common == NULL) {
-		LOG_WRN("Device data not found");
-		return;
-	}
-
-	dev_data = CONTAINER_OF(common, struct hid_device_info, common);
-
-	hid_do_status_cb(dev_data, status, param);
-}
-#endif
 
 static int hid_class_handle_req(struct usb_setup_packet *setup,
 				s32_t *len, u8_t **data)
@@ -653,23 +633,6 @@ static void hid_interface_config(struct usb_desc_header *head,
 #endif
 }
 
-#ifdef CONFIG_USB_COMPOSITE_DEVICE
-#define DEFINE_HID_CFG_DATA(x)						\
-	USBD_CFG_DATA_DEFINE(hid)					\
-	struct usb_cfg_data hid_config_##x = {				\
-		.usb_device_description = NULL,				\
-		.interface_config = hid_interface_config,		\
-		.interface_descriptor = &hid_cfg_##x.if0,		\
-		.cb_usb_status_composite = hid_status_composite_cb,	\
-		.interface = {						\
-			.class_handler = hid_class_handle_req,		\
-			.custom_handler = hid_custom_handle_req,	\
-			.payload_data = NULL,				\
-		},							\
-		.num_endpoints = ARRAY_SIZE(hid_ep_data_##x),		\
-		.endpoint = hid_ep_data_##x,				\
-	}
-#else
 #define DEFINE_HID_CFG_DATA(x)						\
 	USBD_CFG_DATA_DEFINE(hid)					\
 	struct usb_cfg_data hid_config_##x = {				\
@@ -684,8 +647,7 @@ static void hid_interface_config(struct usb_desc_header *head,
 		},							\
 		.num_endpoints = ARRAY_SIZE(hid_ep_data_##x),		\
 		.endpoint = hid_ep_data_##x,				\
-	}
-#endif
+	};
 
 #if !defined(CONFIG_USB_COMPOSITE_DEVICE)
 static u8_t interface_data[CONFIG_USB_HID_MAX_PAYLOAD_SIZE];

--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -102,9 +102,12 @@ static struct usb_ep_cfg_data ep_cfg[] = {
 };
 /* usb.rst endpoint configuration end */
 
-static void loopback_status_cb(enum usb_dc_status_code status,
+static void loopback_status_cb(struct usb_cfg_data *cfg,
+			       enum usb_dc_status_code status,
 			       const u8_t *param)
 {
+	ARG_UNUSED(cfg);
+
 	switch (status) {
 	case USB_DC_CONFIGURED:
 		loopback_in_cb(ep_cfg[LOOPBACK_IN_EP_IDX].ep_addr, 0);

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -801,10 +801,12 @@ static void mass_storage_bulk_in(u8_t ep,
  *
  * @return  N/A.
  */
-static void mass_storage_status_cb(enum usb_dc_status_code status,
+static void mass_storage_status_cb(struct usb_cfg_data *cfg,
+				   enum usb_dc_status_code status,
 				   const u8_t *param)
 {
 	ARG_UNUSED(param);
+	ARG_UNUSED(cfg);
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -351,8 +351,12 @@ static inline void ecm_status_interface(const u8_t *iface)
 	netusb_enable(&ecm_function);
 }
 
-static void ecm_do_cb(enum usb_dc_status_code status, const u8_t *param)
+static void ecm_status_cb(struct usb_cfg_data *cfg,
+			  enum usb_dc_status_code status,
+			  const u8_t *param)
 {
+	ARG_UNUSED(cfg);
+
 	/* Check the USB status and do needed action if required */
 	switch (status) {
 	case USB_DC_DISCONNECTED:
@@ -383,21 +387,6 @@ static void ecm_do_cb(enum usb_dc_status_code status, const u8_t *param)
 		break;
 	}
 }
-
-#ifdef CONFIG_USB_COMPOSITE_DEVICE
-static void ecm_status_composite_cb(struct usb_cfg_data *cfg,
-				    enum usb_dc_status_code status,
-				    const u8_t *param)
-{
-	ARG_UNUSED(cfg);
-	ecm_do_cb(status, param);
-}
-#else
-static void ecm_status_cb(enum usb_dc_status_code status, const u8_t *param)
-{
-	ecm_do_cb(status, param);
-}
-#endif
 
 struct usb_cdc_ecm_mac_descr {
 	u8_t bLength;
@@ -438,11 +427,7 @@ USBD_CFG_DATA_DEFINE(netusb) struct usb_cfg_data netusb_config = {
 	.usb_device_description = NULL,
 	.interface_config = ecm_interface_config,
 	.interface_descriptor = &cdc_ecm_cfg.if0,
-#ifdef CONFIG_USB_COMPOSITE_DEVICE
-	.cb_usb_status_composite = ecm_status_composite_cb,
-#else
 	.cb_usb_status = ecm_status_cb,
-#endif
 	.interface = {
 		.class_handler = ecm_class_handler,
 		.custom_handler = NULL,

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -232,8 +232,12 @@ static inline void eem_status_interface(const u8_t *iface)
 	netusb_enable(&eem_function);
 }
 
-static void eem_do_cb(enum usb_dc_status_code status, const u8_t *param)
+static void eem_status_cb(struct usb_cfg_data *cfg,
+			  enum usb_dc_status_code status,
+			  const u8_t *param)
 {
+	ARG_UNUSED(cfg);
+
 	/* Check the USB status and do needed action if required */
 	switch (status) {
 	case USB_DC_DISCONNECTED:
@@ -265,21 +269,6 @@ static void eem_do_cb(enum usb_dc_status_code status, const u8_t *param)
 	}
 }
 
-#ifdef CONFIG_USB_COMPOSITE_DEVICE
-static void eem_status_composite_cb(struct usb_cfg_data *cfg,
-				    enum usb_dc_status_code status,
-				    const u8_t *param)
-{
-	ARG_UNUSED(cfg);
-	eem_do_cb(status, param);
-}
-#else
-static void eem_status_cb(enum usb_dc_status_code status, const u8_t *param)
-{
-	eem_do_cb(status, param);
-}
-#endif
-
 static void eem_interface_config(struct usb_desc_header *head,
 				 u8_t bInterfaceNumber)
 {
@@ -292,11 +281,7 @@ USBD_CFG_DATA_DEFINE(netusb) struct usb_cfg_data netusb_config = {
 	.usb_device_description = NULL,
 	.interface_config = eem_interface_config,
 	.interface_descriptor = &cdc_eem_cfg.if0,
-#ifdef CONFIG_USB_COMPOSITE_DEVICE
-	.cb_usb_status_composite = eem_status_composite_cb,
-#else
 	.cb_usb_status = eem_status_cb,
-#endif
 	.interface = {
 		.class_handler = NULL,
 		.custom_handler = NULL,

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -1113,8 +1113,12 @@ static struct netusb_function rndis_function = {
 	.send_pkt = rndis_send,
 };
 
-static void rndis_do_cb(enum usb_dc_status_code status, const u8_t *param)
+static void rndis_status_cb(struct usb_cfg_data *cfg,
+			    enum usb_dc_status_code status,
+			    const u8_t *param)
 {
+	ARG_UNUSED(cfg);
+
 	/* Check the USB status and do needed action if required */
 	switch (status) {
 	case USB_DC_CONFIGURED:
@@ -1146,21 +1150,6 @@ static void rndis_do_cb(enum usb_dc_status_code status, const u8_t *param)
 	}
 }
 
-#ifdef CONFIG_USB_COMPOSITE_DEVICE
-static void rndis_status_composite_cb(struct usb_cfg_data *cfg,
-				      enum usb_dc_status_code status,
-				      const u8_t *param)
-{
-	ARG_UNUSED(cfg);
-	rndis_do_cb(status, param);
-}
-#else
-static void rndis_status_cb(enum usb_dc_status_code status, const u8_t *param)
-{
-	rndis_do_cb(status, param);
-}
-#endif
-
 static void netusb_interface_config(struct usb_desc_header *head,
 				    u8_t bInterfaceNumber)
 {
@@ -1179,11 +1168,7 @@ USBD_CFG_DATA_DEFINE(netusb) struct usb_cfg_data netusb_config = {
 	.usb_device_description = NULL,
 	.interface_config = netusb_interface_config,
 	.interface_descriptor = &rndis_cfg.if0,
-#ifdef CONFIG_USB_COMPOSITE_DEVICE
-	.cb_usb_status_composite = rndis_status_composite_cb,
-#else
 	.cb_usb_status = rndis_status_cb,
-#endif
 	.interface = {
 		.class_handler = rndis_class_handler,
 		.custom_handler = NULL,

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -592,9 +592,12 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
  *
  * @return  N/A.
  */
-static void dfu_status_cb(enum usb_dc_status_code status, const u8_t *param)
+static void dfu_status_cb(struct usb_cfg_data *cfg,
+			  enum usb_dc_status_code status,
+			  const u8_t *param)
 {
 	ARG_UNUSED(param);
+	ARG_UNUSED(cfg);
 
 	/* Check the USB status and do needed action if required */
 	switch (status) {

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -88,8 +88,13 @@ static const struct dev_common_descriptor {
 
 struct usb_desc_header *__usb_descriptor_start = (void *)&desc;
 
-static void status_cb(enum usb_dc_status_code status, const u8_t *param)
+static void status_cb(struct usb_cfg_data *cfg,
+		      enum usb_dc_status_code status,
+		      const u8_t *param)
 {
+	ARG_UNUSED(cfg);
+	ARG_UNUSED(status);
+	ARG_UNUSED(param);
 }
 
 /* EP Bulk IN handler, used to send data to the Host */


### PR DESCRIPTION
Fixes wpanusb, use usb_transfer()
Fixes #14882 