### PR TITLE
sample: nffs_fs_api: basic: Increase time for testing

### DIFF
--- a/tests/subsys/fs/nffs_fs_api/basic/testcase.yaml
+++ b/tests/subsys/fs/nffs_fs_api/basic/testcase.yaml
@@ -4,3 +4,4 @@ tests:
   filesystem.nffs.basic:
     extra_args: TEST=basic
     platform_whitelist: qemu_x86 nrf52840_pca10056
+    timeout: 500


### PR DESCRIPTION
Increase test timeout to 500s because it was noticed
that the default of 60s has truncated the test
suite run for nrf52840_pca10056

Signed-off-by: Cinly Ooi <cinly.ooi@intel.com>