### PR TITLE
boards/x86: scripts: unset CFLAGS when running build_grub.sh

### DIFF
--- a/boards/x86/common/scripts/build_grub.sh
+++ b/boards/x86/common/scripts/build_grub.sh
@@ -4,6 +4,7 @@
 # https://github.com/otcshare/contiki-x86
 
 set -e
+unset CFLAGS
 
 JOBS=5
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )


### PR DESCRIPTION
On Clear Linux, the CFLAGS is set and defines a number of aggressive checks and
optimizations. This causes a build failure when generating a GRUB2 boot loader
image using the 'build_grub.sh' script.

Unsetting it within the script allows it to proceed and successfully build a
functional GRUB2 boot loader image to be used with Zephyr.

Fixes: #14289
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>