### PR TITLE
dts: bindings: gpio: added generic gpio for input and output

### DIFF
--- a/dts/bindings/gpio/gpio-in.yaml
+++ b/dts/bindings/gpio/gpio-in.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2019, Prevas A/S
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: GPIO IN
+version: 0.1
+
+description: >
+    This is a representation of generic GPIO input nodes
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "gpio-in"
+      generation: define
+
+    gpios:
+      type: compound
+      category: required
+      generation: define
+
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device (used by Zephyr for API name)
+      generation: define
+
+...

--- a/dts/bindings/gpio/gpio-out.yaml
+++ b/dts/bindings/gpio/gpio-out.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2019, Prevas A/S
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: GPIO OUT
+version: 0.1
+
+description: >
+    This is a representation of generic GPIO output nodes
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "gpio-out"
+      generation: define
+
+    gpios:
+      type: compound
+      category: required
+      generation: define
+
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device (used by Zephyr for API name)
+      generation: define
+
+...


### PR DESCRIPTION
This change enables configuration of generic gpio for inputs and outputs similar to gpio-leds and gpio-keys.

Signed-off-by: Bo Kragelund <bokr@prevas.dk>