### PR TITLE
drivers/timer: cortex_m_systick: (FIX) fix LOAD value rounding issue

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -103,9 +103,7 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	cycle_count += elapsed();
 
 	/* Round delay up to next tick boundary */
-	delay = delay + (cycle_count - announced_cycles);
-	delay = ((delay + CYC_PER_TICK - 1) / CYC_PER_TICK) * CYC_PER_TICK;
-	last_load = delay - (cycle_count - announced_cycles);
+	last_load = ((delay + CYC_PER_TICK - 1) / CYC_PER_TICK) * CYC_PER_TICK;
 
 	SysTick->LOAD = last_load;
 	SysTick->VAL = 0; /* resets timer to last_load */


### PR DESCRIPTION
---
The SysTick load value should get rounded up to next tick boundary,
but current implementation, which subctracts from the rounded total
the same value used for rounding up, may result in a lower value.

I noticed that in some particular cases, e.g. with some sensor trigger
enabled, that the k_sleep() was lasting much less than it should.

Signed-off-by: Armando Visconti <armando.visconti@st.com>
----

EDIT::
My  further observation is that when using a sample code I prepared, which is using sensor triggers
at 200Hz, there is a much higher rate of z_clock_set_timeout() calls with last_load < CYC_PER_TICK.
I'm not sure whether last_load should be >= CYC_PER_TICK or not. But for sure the k_sleep() in my
main test thread was lasting much less than expected.