### PR TITLE
tests: fp_sharing: Fix build error

### DIFF
--- a/tests/kernel/fp_sharing/src/main.c
+++ b/tests/kernel/fp_sharing/src/main.c
@@ -222,7 +222,7 @@ void load_store_low(void)
 			return;
 		}
 
-#if defined(CONFIG_ISA_IA32)
+#if defined(CONFIG_ISA_IA32) && defined(CONFIG_LAZY_FP_SHARING)
 		/*
 		 * After every 1000 iterations (arbitrarily chosen), explicitly
 		 * disable floating point operations for the task. The


### PR DESCRIPTION
k_disable_float is only available in X86 when LAZY_FP_SHARING is
set. Adding this condition before using this function.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>