### PR TITLE
tests: kernel: fp_sharing: minor fix in #ifdef expression

### DIFF
--- a/tests/kernel/fp_sharing/src/main.c
+++ b/tests/kernel/fp_sharing/src/main.c
@@ -237,7 +237,7 @@ void load_store_low(void)
 		if ((load_store_low_count % 1000) == 0U) {
 			k_float_disable(k_current_get());
 		}
-#elif defined(CONFIG_CPU_CORTEX_M4)
+#elif defined(CONFIG_ARMV7_M_ARMV8_M_FP)
 		/*
 		 * The routine k_float_disable() allows for thread-level
 		 * granularity for disabling floating point. Furthermore, it


### PR DESCRIPTION
We need to use the ARMV7_M_ARMV8_M_FP Kconfig symbol,
which denotes the Floating-Point capabilities, instead
of the option that signifies the Cortex-M variant. Fix
is of minor importance, as long as the #ifdef block
remains empty.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>