### PR TITLE
arc: fix build failure missing arc_exc_saved_sp

### DIFF
--- a/arch/arc/core/fault.c
+++ b/arch/arc/core/fault.c
@@ -21,7 +21,7 @@
 #include <exc_handle.h>
 #include <logging/log_ctrl.h>
 
-extern u32_t arc_exc_saved_sp;
+u32_t arc_exc_saved_sp;
 
 #ifdef CONFIG_USERSPACE
 Z_EXC_DECLARE(z_arch_user_string_nlen);

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -41,10 +41,6 @@ GTEXT(_irq_do_offload);
 GDATA(exc_nest_count)
 GDATA(arc_exc_saved_sWWp)
 
-SECTION_VAR(BSS, arc_exc_saved_sp)
-	.balign 4
-	.word 0
-
 /* the necessary stack size for exception handling */
 #define EXCEPTION_STACK_SIZE 384
 


### PR DESCRIPTION
Instantiate this in C domain instead.

Fixes: #15035

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>