### PR TITLE
arch: x86: Remove not used fp struct

### DIFF
--- a/arch/posix/include/offsets_short_arch.h
+++ b/arch/posix/include/offsets_short_arch.h
@@ -24,9 +24,6 @@
 #define _thread_offset_to_esp \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_esp_OFFSET)
 
-#define _thread_offset_to_coopFloatReg \
-	(___thread_t_arch_OFFSET + ___thread_arch_t_coopFloatReg_OFFSET)
-
 #define _thread_offset_to_preempFloatReg \
 	(___thread_t_arch_OFFSET + ___thread_arch_t_preempFloatReg_OFFSET)
 

--- a/arch/x86/core/offsets/offsets.c
+++ b/arch/x86/core/offsets/offsets.c
@@ -36,7 +36,6 @@
 GEN_OFFSET_SYM(_thread_arch_t, excNestCount);
 #endif
 
-GEN_OFFSET_SYM(_thread_arch_t, coopFloatReg);
 GEN_OFFSET_SYM(_thread_arch_t, preempFloatReg);
 
 /**
@@ -45,8 +44,7 @@ GEN_OFFSET_SYM(_thread_arch_t, preempFloatReg);
  */
 
 GEN_ABSOLUTE_SYM(_K_THREAD_NO_FLOAT_SIZEOF,
-		 sizeof(struct k_thread) - sizeof(tCoopFloatReg) -
-			 sizeof(tPreempFloatReg));
+		 sizeof(struct k_thread) - sizeof(tPreempFloatReg));
 
 GEN_OFFSET_SYM(_callee_saved_t, esp);
 

--- a/arch/x86/include/kernel_arch_thread.h
+++ b/arch/x86/include/kernel_arch_thread.h
@@ -200,22 +200,6 @@ typedef struct s_FpRegSetEx {
 #endif /* CONFIG_LAZY_FP_SHARING || CONFIG_EAGER_FP_SHARING */
 
 /*
- * The following structure defines the set of 'non-volatile' x87 FPU/MMX/SSE
- * registers. These registers must be preserved by a called C function.
- * These are the only registers that need to be saved/restored when a
- * cooperative context switch occurs.
- */
-
-typedef struct s_coopFloatReg {
-
-	/*
-	 * This structure intentionally left blank, i.e. the ST[0] -> ST[7] and
-	 * XMM0 -> XMM7 registers are all 'volatile'.
-	 */
-
-} tCoopFloatReg;
-
-/*
  * The following structure defines the set of 'volatile' x87 FPU/MMX/SSE
  * registers.  These registers need not be preserved by a called C function.
  * Given that they are not preserved across function calls, they must be
@@ -260,11 +244,9 @@ struct _thread_arch {
 	 * Given that stacks "grow down" on IA-32, and the TCS is located
 	 * at the start of a thread's "workspace" memory, the stacks of
 	 * threads that do not utilize floating point instruction can
-	 * effectively consume the memory occupied by the 'tCoopFloatReg' and
-	 * 'tPreempFloatReg' structures without ill effect.
+	 * effectively consume the memory occupied by the 'tPreempFloatReg'
+	 * struct without ill effect.
 	 */
-
-	tCoopFloatReg coopFloatReg; /* non-volatile float register storage */
 	tPreempFloatReg preempFloatReg; /* volatile float register storage */
 };
 

--- a/arch/x86/include/offsets_short_arch.h
+++ b/arch/x86/include/offsets_short_arch.h
@@ -24,9 +24,6 @@
 #define _thread_offset_to_esp \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_esp_OFFSET)
 
-#define _thread_offset_to_coopFloatReg \
-	(___thread_t_arch_OFFSET + ___thread_arch_t_coopFloatReg_OFFSET)
-
 #define _thread_offset_to_preempFloatReg \
 	(___thread_t_arch_OFFSET + ___thread_arch_t_preempFloatReg_OFFSET)
 

--- a/subsys/debug/openocd.c
+++ b/subsys/debug/openocd.c
@@ -77,8 +77,7 @@ size_t _kernel_openocd_offsets[] = {
 #elif defined(CONFIG_FLOAT) && defined(CONFIG_X86)
 	[OPENOCD_OFFSET_T_PREEMPT_FLOAT] = offsetof(struct _thread_arch,
 						    preempFloatReg),
-	[OPENOCD_OFFSET_T_COOP_FLOAT] = offsetof(struct _thread_arch,
-						 coopFloatReg),
+	[OPENOCD_OFFSET_T_COOP_FLOAT] = OPENOCD_UNIMPLEMENTED,
 #else
 	[OPENOCD_OFFSET_T_PREEMPT_FLOAT] = OPENOCD_UNIMPLEMENTED,
 	[OPENOCD_OFFSET_T_COOP_FLOAT] = OPENOCD_UNIMPLEMENTED,


### PR DESCRIPTION
The legacy struct s_coopFloatReg was not being used, though it was
an empty struct (not wasting space), some symbols were being generate
for it.

Nevertheless, either C99 and C11 does not allow empty struct, so this
was also a violation to C standard.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>