### PR TITLE
zephyr_module.cmake: restore ability to build without modules

### DIFF
--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -16,6 +16,8 @@ if(ZEPHYR_EXTRA_MODULES)
   set(ZEPHYR_EXTRA_MODULES_ARG "--extra-modules" ${ZEPHYR_EXTRA_MODULES})
 endif()
 
+set(KCONFIG_MODULES_FILE ${CMAKE_BINARY_DIR}/Kconfig.modules)
+
 if(WEST OR ZEPHYR_MODULES)
   # Zephyr module uses west, so only call it if west is installed or
   # ZEPHYR_MODULES was provided as argument to CMake.
@@ -24,7 +26,7 @@ if(WEST OR ZEPHYR_MODULES)
     ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/zephyr_module.py
     ${ZEPHYR_MODULES_ARG}
     ${ZEPHYR_EXTRA_MODULES_ARG}
-    --kconfig-out ${CMAKE_BINARY_DIR}/Kconfig.modules
+    --kconfig-out ${KCONFIG_MODULES_FILE}
     --cmake-out ${CMAKE_BINARY_DIR}/zephyr_modules.txt
     ERROR_VARIABLE
     zephyr_module_error_text
@@ -35,4 +37,11 @@ if(WEST OR ZEPHYR_MODULES)
  if(${zephyr_module_return})
       message(FATAL_ERROR "${zephyr_module_error_text}")
   endif()
+
+else()
+
+  file(WRITE ${KCONFIG_MODULES_FILE}
+    "# No west and no modules\n"
+    )
+
 endif()


### PR DESCRIPTION
Kconfig.modules used to be an empty file when no modules. PR #14667 /
commit bd7569f27288 "cmake: Extracted Zephyr module processing into
python script" unintentionally changed that to no Kconfig.modules file
at all when no west and no modules. kconfig.py doesn't like that and
crashes. Restore the empty file.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>