### PR TITLE
file2hex.py: new --gzip-mtime option that defaults to zero + test

### DIFF
--- a/scripts/file2hex.py
+++ b/scripts/file2hex.py
@@ -24,6 +24,12 @@ def parse_args():
     parser.add_argument("-f", "--file", required=True, help="Input file")
     parser.add_argument("-g", "--gzip", action="store_true",
                         help="Compress the file using gzip before output")
+    parser.add_argument("-t", "--gzip-mtime", type=int, default=0,
+                         nargs='?', const=None,
+                        help="""mtime seconds in the gzip header.
+                        Defaults to zero to keep builds deterministic. For
+                        current date and time (= "now") use this option
+                        without any value.""")
     args = parser.parse_args()
 
 
@@ -44,6 +50,7 @@ def main():
         with io.BytesIO() as content:
             with open(args.file, 'rb') as fg:
                 with gzip.GzipFile(fileobj=content, mode='w',
+                                   mtime=args.gzip_mtime,
                                    compresslevel=9) as gz_obj:
                     gz_obj.write(fg.read())
 

--- a/tests/application_development/gen_inc_file/CMakeLists.txt
+++ b/tests/application_development/gen_inc_file/CMakeLists.txt
@@ -12,3 +12,5 @@ set(source_file src/file.bin)
 
 generate_inc_file_for_target(app ${source_file} ${gen_dir}/file.bin.inc)
 generate_inc_file_for_target(app ${source_file} ${gen_dir}/file.bin.gz.inc --gzip)
+generate_inc_file_for_target(app ${source_file} ${gen_dir}/file.bin.mtime.gz.inc
+  --gzip --gzip-mtime=42)


### PR DESCRIPTION
file2hex.py: new --gzip-mtime option that defaults to zero + test

This makes the output of file2hex.py deterministic by default while also
letting the user set the mtime in the gzip header manually if desired.

Use the option without any argument to restore the previous behavior
that sets the current (and obviously changing) "now" timestamp.

To test:  ./sanitycheck --tag gen_inc_file

Signed-off-by: Marc Herbert <marc.herbert@intel.com>