### PR TITLE
native_posix: cmdline: Hint user about wrong options

### DIFF
--- a/boards/posix/native_posix/cmdline.c
+++ b/boards/posix/native_posix/cmdline.c
@@ -95,6 +95,15 @@ void native_add_testargs_option(void)
 	native_add_command_line_opts(testargs_options);
 }
 
+static void print_invalid_opt_error(char *argv)
+{
+	posix_print_error_and_exit("Incorrect option '%s'. Did you misspell it?"
+				   " Is that feature supported in this build?"
+				   "\n",
+				   argv);
+
+}
+
 /**
  * Handle possible command line arguments.
  *
@@ -122,8 +131,7 @@ void native_handle_cmd_line(int argc, char *argv[])
 
 		if (!cmd_parse_one_arg(argv[i], args_struct)) {
 			cmd_print_switches_help(args_struct);
-			posix_print_error_and_exit("Incorrect option '%s'\n",
-						   argv[i]);
+			print_invalid_opt_error(argv[i]);
 		}
 	}
 }

--- a/boards/posix/native_posix/cmdline_common.c
+++ b/boards/posix/native_posix/cmdline_common.c
@@ -350,6 +350,8 @@ void cmd_print_long_help(struct args_struct_t args_struct[])
 		count++;
 	}
 	fprintf(stdout, "\n");
+	fprintf(stdout, "Note that which options are available depends on the "
+		"enabled features/drivers\n\n");
 }
 
 /*


### PR DESCRIPTION
Be a bit more friendly to users, by providing some hints
about possible reasons why a command line option was not
understood.
Also describe in the help message that which options are
avaliable depends on what has been selected in this build.

Fixes: #15046

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>