### PR TITLE
sanitycheck: record benchmark results

### DIFF
--- a/scripts/sanity_chk/sanitycheck-tc-schema.yaml
+++ b/scripts/sanity_chk/sanitycheck-tc-schema.yaml
@@ -62,6 +62,13 @@ mapping:
             required: no
             sequence:
               - type: str
+         "record":
+           type: map
+           required: no
+           mapping:
+             "regex":
+               type: str
+               required: no
      "min_ram":
        type: int
        required: no
@@ -175,6 +182,13 @@ mapping:
                     required: no
                     sequence:
                       - type: str
+                 "record":
+                   type: map
+                   required: no
+                   mapping:
+                     "regex":
+                       type: str
+                       required: no
              "min_ram":
                type: int
                required: no

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -500,6 +500,18 @@ class Handler:
         self.lock.release()
         return ret
 
+    def record(self, harness):
+        if harness.recording:
+            filename = os.path.join(options.outdir,
+                    self.instance.platform.name,
+                    self.instance.test.name, "recording.csv")
+            with open(filename, "at") as csvfile:
+                cw = csv.writer(csvfile, harness.fieldnames, lineterminator=os.linesep)
+                cw.writerow(harness.fieldnames)
+                for instance in harness.recording:
+                    cw.writerow(instance)
+
+
 class BinaryHandler(Handler):
     def __init__(self, instance):
         """Constructor
@@ -703,6 +715,7 @@ class DeviceHandler(Handler):
         else:
             self.set_state(out_state, {})
 
+        self.record(harness)
 
 class QEMUHandler(Handler):
     """Spawns a thread to monitor QEMU output from pipes
@@ -794,6 +807,7 @@ class QEMUHandler(Handler):
             # APIs. Add whatever gets reported to the metrics dictionary
             line = ""
 
+        handler.record(harness)
         metrics["handler_time"] = time.time() - start_time
         verbose("QEMU complete (%s) after %f seconds" %
                 (out_state, metrics["handler_time"]))

--- a/tests/benchmarks/timing_info/testcase.yaml
+++ b/tests/benchmarks/timing_info/testcase.yaml
@@ -2,8 +2,16 @@ tests:
   benchmark.timing.default_kernel:
     arch_exclude: posix
     tags: benchmark
+    harness: console
+    harness_config:
+      record:
+        regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
   benchmark.timing.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_args: CONF_FILE=prj_userspace.conf
     arch_whitelist: x86 arm arc
     tags: benchmark
+    harness: console
+    harness_config:
+      record:
+        regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"


### PR DESCRIPTION
Add a method to capture benchmark data and save it as a CSV file for
later prociessing. This will help with tracking benchmark data or any
data generated by test applications.