### PR TITLE
cmake: modules: Enclose name and path in quotes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -580,9 +580,12 @@ if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
   file(STRINGS ${CMAKE_BINARY_DIR}/zephyr_modules.txt ZEPHYR_MODULES_TXT)
 
   foreach(module ${ZEPHYR_MODULES_TXT})
-    string(REGEX REPLACE "(.*):.*" "\\1" module_name ${module})
-    string(REGEX REPLACE ".*:(.*)" "\\1" module_path ${module})
-    message("Including module: ${module_name}")
+    # Match "<name>":"<path>" for each line of file, each corresponding to
+    # one module. The use of quotes is required due to CMake not supporting
+    # lazy regexes (it supports greedy only).
+    string(REGEX REPLACE "\"(.*)\":\".*\"" "\\1" module_name ${module})
+    string(REGEX REPLACE "\".*\":\"(.*)\"" "\\1" module_path ${module})
+    message("Including module: ${module_name} in path: ${module_path}")
     add_subdirectory(${module_path} ${CMAKE_BINARY_DIR}/${module_name})
   endforeach()
 endif()

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -90,7 +90,7 @@ def process_module(module, cmake_out=None, kconfig_out=None):
     cmake_path = os.path.join(module, cmake_setting or 'zephyr')
     cmake_file = os.path.join(cmake_path, 'CMakeLists.txt')
     if os.path.isfile(cmake_file) and cmake_out is not None:
-        cmake_out.write('{}:{}\n'.format(os.path.basename(module),
+        cmake_out.write('\"{}\":\"{}\"\n'.format(os.path.basename(module),
                                          os.path.abspath(cmake_path)))
 
     kconfig_file = os.path.join(module, kconfig_setting or 'zephyr/Kconfig')


### PR DESCRIPTION
Due to the fact that CMake only supports greedy regexes,
the ':' in a Windows path ('C:\...') was being matched leading
to an invalid split of the line. Quote both the name and the path
to avoid this issue.

Fixes #15061

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>