### PR TITLE
Count sample tests into reports and fix misc. test identifiers

### DIFF
--- a/samples/bluetooth/hci_usb/sample.yaml
+++ b/samples/bluetooth/hci_usb/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Bluetooth over USB sample
 tests:
-  usb.bluetooth:
+  sample.bluetooth.hci_usb:
     harness: bluetooth
     depends_on: usb_device
     platform_whitelist: quark_se_c1000_devboard nrf52840_pca10056

--- a/samples/boards/nrf52/mesh/onoff-app/sample.yaml
+++ b/samples/boards/nrf52/mesh/onoff-app/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Bluetooth Mesh
 tests:
-  bluetooth.mesh:
+  sample.bluetooth.mesh.onoff:
     platform_whitelist: nrf52840_pca10056
     tags: bluetooth
     harness: bluetooth

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/sample.yaml
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Bluetooth Mesh
 tests:
-  bluetooth.mesh:
+  sample.bluetooth.mesh.onoff_level_lighting_vnd:
     platform_whitelist: nrf52840_pca10056
     tags: bluetooth
     harness: bluetooth

--- a/samples/boards/nrf52/power_mgr/sample.yaml
+++ b/samples/boards/nrf52/power_mgr/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Low Power State Sample for nRF5x
 tests:
-  pm.low_power_state:
+  sample.board.nrf52.pm.low_power_state:
     platform_whitelist: nrf52840_pca10056 nrf52_pca10040 nrf51_pca10028
     tags: power
     harness: console

--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -8,7 +8,7 @@ common:
   min_ram: 20
   arch_exclude: xtensa x86_64
 tests:
-  test-mbedtls:
+  sample.driver.crypto.mbedtls:
     min_flash: 34
     extra_args: CONF_FILE=prj_mtls_shim.conf
     harness_config:
@@ -18,7 +18,7 @@ tests:
         - ".*main: CBC Mode"
         - ".*main: CTR Mode"
         - ".*main: CCM Mode"
-  test-micro:
+  sample.driver.crypto.mbedtls.micro:
     tags: crypto
     harness_config:
       type: multi_line

--- a/samples/mpu/mem_domain_apis_test/sample.yaml
+++ b/samples/mpu/mem_domain_apis_test/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Memory Domain APIs Test
 tests:
-  kernel.memory_protection.memory_domains:
+  sample.kernel.memory_protection.memory_domains:
     filter: CONFIG_ARCH_HAS_USERSPACE
     tags: userspace mpu
     harness: console

--- a/samples/sensor/apds9960/sample.yaml
+++ b/samples/sensor/apds9960/sample.yaml
@@ -13,7 +13,7 @@ tests:
             - "APDS9960 sample application"
             - "ambient light intensity (.*), proximity (.*)"
         fixture: fixture_i2c_apds9960
-  test-trigger:
+  sample.sensor.apds9960.trigger:
     harness: console
     platform_whitelist: reel_board
     tags: sensors

--- a/samples/sensor/fxos8700-hid/sample.yaml
+++ b/samples/sensor/fxos8700-hid/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: USB HID accelerometer mouse sample
 tests:
-  usb.hid-mouse:
+  sample.usb.hid-mouse:
     depends_on: usb_device
     platform_whitelist: frdm_k64f
     harness: usb

--- a/samples/subsys/power/device_pm/sample.yaml
+++ b/samples/subsys/power/device_pm/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   name: Device Idle Power Management
 tests:
-  ospm.dev_idle_pm:
+  sample.power.ospm.dev_idle_pm:
     platform_whitelist: nrf52840_pca10056 nrf52_pca10040
     tags: power

--- a/samples/subsys/usb/cdc_acm/sample.yaml
+++ b/samples/subsys/usb/cdc_acm/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: CDC ACM USB
 tests:
-  usb.cdc-acm:
+  sample.usb.cdc-acm:
     depends_on: usb_device
     tags: usb
     harness: console
@@ -9,7 +9,7 @@ tests:
       type: one_line
       regex:
         - "Wait for DTR"
-  usb.cdc-acm_comp:
+  sample.usb.cdc-acm.comp:
     depends_on: usb_device
     tags: usb
     extra_args: "-DOVERLAY_CONFIG=overlay-composite-cdc-msc.conf"

--- a/samples/subsys/usb/cdc_acm_composite/sample.yaml
+++ b/samples/subsys/usb/cdc_acm_composite/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   name: CDC ACM Composite USB
 tests:
-  usb.cdc-acm-composite:
+  sample.usb.cdc-acm-composite:
     depends_on: usb_device
     tags: usb

--- a/samples/subsys/usb/hid-cdc/sample.yaml
+++ b/samples/subsys/usb/hid-cdc/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: USB HID CDC ACM sample
 tests:
-  usb.hid-cdc:
+  sample.usb.hid-cdc:
     depends_on: usb_device
     platform_whitelist: nrf52840_pca10056 nrf52840_pca10059
     harness: button

--- a/samples/subsys/usb/hid-mouse/sample.yaml
+++ b/samples/subsys/usb/hid-mouse/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: USB HID mouse sample
 tests:
-  usb.hid-mouse:
+  sample.usb.hid-mouse:
     depends_on: usb_device
     platform_exclude: arduino_101 96b_carbon tinytile
     harness: button

--- a/samples/subsys/usb/testusb/sample.yaml
+++ b/samples/subsys/usb/testusb/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   name: USB loopback sample
 tests:
-  usb.loopback:
+  sample.usb.loopback:
     depends_on: usb_device
     tags: usb

--- a/samples/userspace/shared_mem/sample.yaml
+++ b/samples/userspace/shared_mem/sample.yaml
@@ -10,5 +10,5 @@ common:
       regex:
         - "MSG"
 tests:
-  kernel.memory_protection.userspace:
+  sample.kernel.memory_protection.shared_mem:
     filter: CONFIG_ARCH_HAS_USERSPACE

--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -41,6 +41,7 @@ class Harness:
 class Console(Harness):
 
     def handle(self, line):
+
         if self.type == "one_line":
             pattern = re.compile(self.regex[0])
             if pattern.search(line):
@@ -77,6 +78,11 @@ class Console(Harness):
             self.capture_coverage = True
         elif self.GCOV_END in line:
             self.capture_coverage = False
+
+        if self.state == "passed":
+            self.tests[self.id] = "PASS"
+        else:
+            self.tests[self.id] = "FAIL"
 
 class Test(Harness):
     RUN_PASSED = "PROJECT EXECUTION SUCCESSFUL"

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1776,6 +1776,9 @@ class TestCase:
             name = "{}.{}".format(self.id, sub)
             self.cases.append(name)
 
+        if not results:
+            self.cases.append(self.id)
+
 
     def __str__(self):
         return self.name

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2451,12 +2451,6 @@ class TestSuite:
                                 lower_better))
         return results
 
-
-
-    def encode_for_xml(self, unicode_data, encoding='ascii'):
-        unicode_data = unicode_data.replace('\x00', '')
-        return unicode_data
-
     def testcase_target_report(self, report_file):
 
         run = "Sanitycheck"
@@ -2512,12 +2506,13 @@ class TestSuite:
                             type="failure",
                             message="failed")
                     p = os.path.join(options.outdir, ti.platform.name, ti.test.name)
-                    bl = os.path.join(p, "handler.log")
+                    log_file = os.path.join(p, "handler.log")
 
-                    if os.path.exists(bl):
-                        with open(bl, "rb") as f:
+                    if os.path.exists(log_file):
+                        with open(log_file, "rb") as f:
                             log = f.read().decode("utf-8")
-                            el.text = self.encode_for_xml(log)
+                            filtered_string = ''.join(filter(lambda x: x in string.printable, log))
+                            el.text = filtered_string
 
                 elif ti.results[k] == 'SKIP':
                     el = ET.SubElement(


### PR DESCRIPTION
We can now run sanitycheck on devices and include tests and samples in the report.

Fixes #15085