### PR TITLE
net: fix the bug in init_iface

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -226,7 +226,11 @@ static inline void init_iface(struct net_if *iface)
 
 	NET_DBG("On iface %p", iface);
 
-	api->init(iface);
+	if (api && api->init) {
+		api->init(iface);
+	} else {
+		NET_ERR("init func NULL on iface %p", iface);
+	}
 }
 
 enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt)


### PR DESCRIPTION
before call api->init, should check whether
api and api->init is NULL, as driver_api may be cleared in
z_sys_device_do_config_level because of init failure.
When ASSERT is nof configured,this is necessary.

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>

Fixes #15003 