### PR TITLE
tests: benchmark: timing_info: Fixed incorrect results.

### DIFF
--- a/arch/common/timing_info_bench.c
+++ b/arch/common/timing_info_bench.c
@@ -18,6 +18,7 @@ u64_t  __end_drop_to_usermode_time;
 /* location of the time stamps*/
 u32_t __read_swap_end_time_value;
 u64_t __common_var_swap_end_time;
+u64_t __temp_start_swap_time;
 
 #if CONFIG_ARM
 #include <arch/arm/cortex_m/cmsis.h>

--- a/arch/x86/core/swap.S
+++ b/arch/x86/core/swap.S
@@ -413,6 +413,8 @@ skipIntLatencyStop:
 	jne time_read_not_needed
 	movw $0x2,__read_swap_end_time_value
 	read_tsc __common_var_swap_end_time
+	pushl __start_swap_time
+	popl __temp_start_swap_time
 time_read_not_needed:
 #endif
 	ret

--- a/tests/benchmarks/timing_info/src/thread_bench.c
+++ b/tests/benchmarks/timing_info/src/thread_bench.c
@@ -20,6 +20,7 @@ char sline[256];
 
 /* location of the time stamps*/
 extern u32_t __read_swap_end_time_value;
+extern u64_t __temp_start_swap_time;
 extern u64_t __common_var_swap_end_time;
 
 volatile u64_t thread_abort_end_time;
@@ -143,6 +144,7 @@ void system_thread_bench(void)
 	k_sleep(1);
 	thread_abort_end_time = (__common_var_swap_end_time);
 	__end_swap_time = __common_var_swap_end_time;
+	__start_swap_time = __temp_start_swap_time;
 
 	u32_t total_swap_cycles = __end_swap_time - __start_swap_time;
 
@@ -283,6 +285,7 @@ void heap_malloc_free_bench(void)
 	u32_t sum_malloc = 0U;
 	u32_t sum_free = 0U;
 
+	k_sleep(10);
 	while (count++ != 100) {
 		TIMING_INFO_PRE_READ();
 		heap_malloc_start_time = TIMING_INFO_OS_GET_TIME();

--- a/tests/benchmarks/timing_info/src/yield_bench.c
+++ b/tests/benchmarks/timing_info/src/yield_bench.c
@@ -39,7 +39,7 @@ k_tid_t yield1_tid;
 void yield_bench(void)
 {
 	/* Thread yield*/
-
+	k_sleep(10);
 	yield0_tid = k_thread_create(&my_thread, my_stack_area,
 				     STACK_SIZE,
 				     thread_yield0_test,


### PR DESCRIPTION
The results were incorrect because the timer was firing the
interrupts before the measurement was made.

Fixes: GH-14556

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>