### PR TITLE
cmake: Prevent infinite recursion

### DIFF
--- a/cmake/toolchain/zephyr/generic.cmake
+++ b/cmake/toolchain/zephyr/generic.cmake
@@ -1,3 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(NOT DEFINED SDK_VERSION)
+  message(FATAL_ERROR "SDK_VERSION must be set")
+endif()
+
 include(${ZEPHYR_BASE}/cmake/toolchain/zephyr/${SDK_VERSION}/generic.cmake)


### PR DESCRIPTION
If SDK_VERSION for whatever reason is unset cmake will end up in an
inifite recursion loop, which for me crashed using cmake version
3.13.4 and exits with an error using 3.14.1.

This may happen if ZEPHYR_TOOLCHAIN_VARIANT is set to "zephyr", but
ZEPHYR_SDK_INSTALL_DIR is invalid (or unset).

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>