### PR TITLE
Bluetooth: Fix not accepting string equal to CONFIG_BT_DEVICE_NAME_MAX

### DIFF
--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -172,7 +172,7 @@ struct bt_dev {
 
 	/* Local Name */
 #if defined(CONFIG_BT_DEVICE_NAME_DYNAMIC)
-	char			name[CONFIG_BT_DEVICE_NAME_MAX];
+	char			name[CONFIG_BT_DEVICE_NAME_MAX + 1];
 #endif
 };
 


### PR DESCRIPTION
In order to accept string of the same size entered in
CONFIG_BT_DEVICE_NAME_MAX an extra byte must be allocated to guarantee
it will always be NULL terminated.

Fixes #15067

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>