### PR TITLE
drivers: sensor: APDS9660 Whoami check

### DIFF
--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -442,7 +442,10 @@ static int apds9960_init(struct device *dev)
 	(void)memset(data->sample_crgb, 0, sizeof(data->sample_crgb));
 	data->pdata = 0U;
 
-	apds9960_sensor_setup(dev);
+	if (apds9960_sensor_setup(dev) <0 ) {
+		LOG_ERR("Failed to setup device!");
+		return -EIO;
+	}
 
 	if (apds9960_init_interrupt(dev) < 0) {
 		LOG_ERR("Failed to initialize interrupt!");

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -22,7 +22,4 @@ config ARCH_HAS_CUSTOM_BUSY_WAIT
 config SYS_POWER_MANAGEMENT
 	default y
 
-config TEMP_NRF5
-	default SENSOR
-
 endif # SOC_SERIES_NRF52X

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -22,4 +22,7 @@ config ARCH_HAS_CUSTOM_BUSY_WAIT
 config SYS_POWER_MANAGEMENT
 	default y
 
+config TEMP_NRF5
+	default SENSOR
+
 endif # SOC_SERIES_NRF52X


### PR DESCRIPTION
APDS9660 sensor driver missing Whoami (Chip_ID)i check therefore does not report error if device not found on I2C bus.

Signed-off-by: William Fish <william.fish@manulytica.com>