### PR TITLE
soc: nordic_nrf: MPU temperature sensor default

### DIFF
--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
@@ -24,11 +24,7 @@ config NUM_IRQS
 	int
 	default 26
 
-if SENSOR
-
 config TEMP_NRF5
-	default y
-
-endif # SENSOR
+	default SENSOR
 
 endif # SOC_SERIES_NRF51X

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -19,4 +19,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_POWER_MANAGEMENT
 	default y
 
+config TEMP_NRF5
+	default SENSOR
+
 endif # SOC_SERIES_NRF52X


### PR DESCRIPTION
Consistency: nrf51 & 52 SOC set temp sensor as default if SENSOR=y

Signed-off-by: William Fish <william.fish@manulytica.com>