### PR TITLE
boards: intel_s1000_crb: declare some variables as global

### DIFF
--- a/boards/xtensa/intel_s1000_crb/support/create_board_img.py
+++ b/boards/xtensa/intel_s1000_crb/support/create_board_img.py
@@ -161,6 +161,7 @@ def parse_args():
     args = parser.parse_args()
 
 def main():
+    global flash_content, write_buf
     parse_args()
 
     in_file_size = os.path.getsize(args.in_file)


### PR DESCRIPTION
write_buf and flash_content should be defined as global inside
main. Otherwise Python treats them as local variables and ends
up throwing an error because it thinks they are being used
without being defined.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>