### PR TITLE
zephyr_library_compile_options(): de-duplicate

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -400,6 +400,11 @@ function(zephyr_library_compile_options item)
   string(MD5 uniqueness ${item})
   set(lib_name options_interface_lib_${uniqueness})
 
+  if (TARGET ${lib_name})
+    # ${item} already added, ignoring duplicate just like CMake does
+    return()
+  endif()
+
   add_library(           ${lib_name} INTERFACE)
   target_compile_options(${lib_name} INTERFACE ${item} ${ARGN})
 


### PR DESCRIPTION
PR #14776 / commit 915a35325562 changed function
zephyr_library_compile_options() to use MD5 instead of RANDOM for build
reproduction reasons. As later predicted by Sebastian Bøe in the PR
(thx), the names generated for these pseudo-libraries won't be unique
anymore if the exact same flag gets added more than once.

To reproduce the issue, simply add the following two lines in some
CMakeLists.txt file like samples/hello_world/CMakeLists.txt:

zephyr_library_compile_options("-Dfubar=barfu")
zephyr_library_compile_options("-Dfubar=barfu")

cmake will then fail like this:

 CMake Error at zephyr/cmake/extensions.cmake:403 (add_library):
  add_library cannot create target
  "options_interface_lib_e689fdb7eb15d801c2f95dd61301fc5e" because
  another target with the same name already exists.  The existing
  target is an interface library created in source directory
  "zephyr/samples/hello_world".  See documentation for
  policy CMP0002 for more details.
 Call Stack (most recent call first):
  CMakeLists.txt:9 (zephyr_library_compile_options)

As suggested by Sebastian, discard duplicate options. After this fix
cmake succeeds with this warning:

 CMake Warning at zephyr/cmake/extensions.cmake:404 (message):
  -Dfubar=barfu already added, ignoring duplicate
 Call Stack (most recent call first):
  CMakeLists.txt:9 (zephyr_library_compile_options)

Fixes #15093

Signed-off-by: Marc Herbert <marc.herbert@intel.com>