### PR TITLE
tests/benchmarks/sched: Remove testcast.yaml

### DIFF
--- a/tests/benchmarks/sched/testcase.yaml
+++ b/tests/benchmarks/sched/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   benchmark.scheduler:
     tags: benchmark
     slow: true
+    build_only: true


### PR DESCRIPTION
This isn't designed to be run in CI, it's a manual benchmark for
scheduler tuning, and it exercises nothing not already covered by
other tools.  Right now integration testing (but not general CI, which
was prevented by the "slow" tag) tries to run it like a ztest case and
hangs waiting for the completion output that will never arrive.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>