### PR TITLE
benchmarks: sched: capture output and evaluate

### DIFF
--- a/tests/benchmarks/sched/testcase.yaml
+++ b/tests/benchmarks/sched/testcase.yaml
@@ -2,3 +2,9 @@ tests:
   benchmark.scheduler:
     tags: benchmark
     slow: true
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "unpend\\s+\\d* ready\\s+\\d* switch\\s+\\d* pend\\s+\\d* tot\\s+\\d* \\(avg\\s+\\d*\\)"
+        - "fin"


### PR DESCRIPTION
We were running this as a test and not evluating the output. Now we
verify the output and stop treating this as a ztest item.