### PR TITLE
codecov: keep "inline" for ALWAYS_INLINE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -874,6 +874,7 @@ if(CONFIG_USERSPACE)
   zephyr_get_compile_options_for_lang_as_string(C compiler_flags_priv)
   string(REPLACE "-ftest-coverage" "" NO_COVERAGE_FLAGS "${compiler_flags_priv}")
   string(REPLACE "-fprofile-arcs" "" NO_COVERAGE_FLAGS "${NO_COVERAGE_FLAGS}")
+  string(REPLACE "-fno-inline" "" NO_COVERAGE_FLAGS "${NO_COVERAGE_FLAGS}")
 
   get_property(include_dir_in_interface TARGET zephyr_interface
     PROPERTY INTERFACE_INCLUDE_DIRECTORIES)

--- a/drivers/ethernet/eth_smsc911x.c
+++ b/drivers/ethernet/eth_smsc911x.c
@@ -314,7 +314,7 @@ void smsc_establish_link(void)
 	SMSC9220->HW_CFG = hw_cfg;
 }
 
-inline void smsc_enable_xmit(void)
+static inline void smsc_enable_xmit(void)
 {
 	SMSC9220->TX_CFG = 0x2 /*TX_CFG_TX_ON*/;
 }

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -93,13 +93,18 @@
     /*
      * The always_inline attribute forces a function to be inlined,
      * even ignoring -fno-inline. So for code coverage, do not
-     * inline these functions to keep their bodies around so their
-     * number of executions can be counted.
+     * force inlining of these functions to keep their bodies around
+     * so their number of executions can be counted.
      *
-     * The unused attribute is here to avoid the compiler complaining
-     * about these functions being unused.
+     * Note that "inline" is kept here for kobject_hash.c and
+     * priv_stacks_hash.c. These are built without compiler flags
+     * used for coverage. ALWAYS_INLINE cannot be empty as compiler
+     * would complain about unused functions. Attaching unused
+     * attribute would result in their text sections ballon more than
+     * 10 times in size, as those functions are kept in text section.
+     * So just keep "inline" here.
      */
-    #define ALWAYS_INLINE __attribute__((unused))
+    #define ALWAYS_INLINE inline
   #else
     #define ALWAYS_INLINE inline __attribute__((always_inline))
   #endif

--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -42,6 +42,11 @@ void __gcov_merge_add(gcov_type *counters, unsigned int n_counters)
 	/* Unused. */
 }
 
+void __gcov_exit(void)
+{
+	/* Unused. */
+}
+
 /**
  * buff_write_u64 - Store 64 bit data on a buffer and return the size
  */


### PR DESCRIPTION
Previous commit c31e659165e9b55a5712f9298a63782de1725878 changed
the ALWAYS_INLINE macros to avoid functions being inlined for
the purpose of code coverage. This has a side effect of causing
the text sections of kobject_hash.c and priv_stacks_hash.c
to ballon more than 10 times in size. This is caused by
attaching the unused attribute, which results in all those
functions being in the text sections though they are never
used. So just keep the "inline" there.
    
This also removes -fno-inline from NO_COVERAGE_FLAGS so these
two files are not compiled with flags related to code coverage.

Also fixes two other trivial things that came up during sanitycheck.
