### PR TITLE
soc: sam0: Fix SAMD20 IRQ assignments

### DIFF
--- a/dts/arm/atmel/samd.dtsi
+++ b/dts/arm/atmel/samd.dtsi
@@ -65,7 +65,6 @@
 		sercom0: sercom@42000800 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42000800 0x40>;
-			interrupts = <9 0>;
 			status = "disabled";
 			label = "SERCOM0";
 		};
@@ -73,7 +72,6 @@
 		sercom1: sercom@42000c00 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42000c00 0x40>;
-			interrupts = <10 0>;
 			status = "disabled";
 			label = "SERCOM1";
 		};
@@ -81,7 +79,6 @@
 		sercom2: sercom@42001000 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42001000 0x40>;
-			interrupts = <11 0>;
 			status = "disabled";
 			label = "SERCOM2";
 		};
@@ -89,7 +86,6 @@
 		sercom3: sercom@42001400 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42001400 0x40>;
-			interrupts = <12 0>;
 			status = "disabled";
 			label = "SERCOM3";
 		};
@@ -97,7 +93,6 @@
 		sercom4: sercom@42001800 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42001800 0x40>;
-			interrupts = <13 0>;
 			status = "disabled";
 			label = "SERCOM4";
 		};
@@ -105,7 +100,6 @@
 		sercom5: sercom@42001c00 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42001c00 0x40>;
-			interrupts = <14 0>;
 			status = "disabled";
 			label = "SERCOM5";
 		};
@@ -124,15 +118,6 @@
 			label = "PORTB";
 			gpio-controller;
 			#gpio-cells = <2>;
-		};
-
-		usb0: usb@41005000 {
-			compatible = "atmel,sam0-usb";
-			status = "disabled";
-			reg = <0x41005000 0x1000>;
-			interrupts = <7 0>;
-			num-bidir-endpoints = <8>;
-			label = "USB0";
 		};
 
 		rtc: rtc@40001400 {

--- a/dts/arm/atmel/samd20.dtsi
+++ b/dts/arm/atmel/samd20.dtsi
@@ -5,3 +5,27 @@
  */
 
 #include <atmel/samd.dtsi>
+
+&sercom0 {
+	interrupts = <7 0>;
+};
+
+&sercom1 {
+	interrupts = <8 0>;
+};
+
+&sercom2 {
+	interrupts = <9 0>;
+};
+
+&sercom3 {
+	interrupts = <10 0>;
+};
+
+&sercom4 {
+	interrupts = <11 0>;
+};
+
+&sercom5 {
+	interrupts = <12 0>;
+};

--- a/dts/arm/atmel/samd21.dtsi
+++ b/dts/arm/atmel/samd21.dtsi
@@ -5,3 +5,40 @@
  */
 
 #include <atmel/samd.dtsi>
+
+/ {
+	soc {
+		usb0: usb@41005000 {
+			compatible = "atmel,sam0-usb";
+			status = "disabled";
+			reg = <0x41005000 0x1000>;
+			interrupts = <7 0>;
+			num-bidir-endpoints = <8>;
+			label = "USB0";
+		};
+	};
+};
+
+&sercom0 {
+	interrupts = <9 0>;
+};
+
+&sercom1 {
+	interrupts = <10 0>;
+};
+
+&sercom2 {
+	interrupts = <11 0>;
+};
+
+&sercom3 {
+	interrupts = <12 0>;
+};
+
+&sercom4 {
+	interrupts = <13 0>;
+};
+
+&sercom5 {
+	interrupts = <14 0>;
+};


### PR DESCRIPTION
SAMD20 does not have the DMA or USB peripherals and as a result the IRQs for all subsequent lines are shifted down from SAMD21.  This splits the interrupt assignment for the SERCOMs into the SoC specific DTS file and moves the USB definition to SAMD21 only.

Tested on SAMD21 but I do not have any SAMD20 hardware to confirm on.  This was based entirely on the definitions in the manuals (section 11 on SAMD20 and 12 on SAMD21: "Peripherals Configuration Summary" in both).  Currently the only peripherals using the shifted lines where the SERCOMs.  I don't think interrupt driven UARTs would have worked at all on SAMD20 before this, but again I can't confirm that.

This is motivated by the need to get the IRQs assigned for the TC peripherals, which intersect on SAMD20 without this fix causing code generation errors.