### PR TITLE
drivers: api: dma: add support for half transfer complete callback

### DIFF
--- a/drivers/dma/dma_cavs.c
+++ b/drivers/dma/dma_cavs.c
@@ -127,6 +127,11 @@ static int dw_dma_config(struct device *dev, u32_t channel,
 		return -EINVAL;
 	}
 
+	if (cfg->dma_ht_callback) {
+		LOG_ERR("Half transfer event is not supported");
+		return -ENOTSUP;
+	}
+
 	__ASSERT_NO_MSG(cfg->source_data_size == cfg->dest_data_size);
 	__ASSERT_NO_MSG(cfg->source_burst_length == cfg->dest_burst_length);
 

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -79,6 +79,11 @@ static int nios2_msgdma_config(struct device *dev, u32_t channel,
 		return -EINVAL;
 	}
 
+	if (cfg->dma_ht_callback) {
+		LOG_ERR("Half transfer event is not supported");
+		return -ENOTSUP;
+	}
+
 #if MSGDMA_0_CSR_PREFETCHER_ENABLE
 	if (cfg->block_count > 1) {
 		LOG_ERR("driver yet add support multiple descriptors");

--- a/drivers/dma/dma_qmsi.c
+++ b/drivers/dma/dma_qmsi.c
@@ -136,6 +136,11 @@ static int dma_qmsi_chan_config(struct device *dev, u32_t channel,
 	u32_t temp = 0U;
 	int ret = 0;
 
+	if (config->dma_ht_callback) {
+		LOG_ERR("Half transfer event is not supported");
+		return -ENOTSUP;
+	}
+
 	if (config->block_count != 1U) {
 		return -ENOTSUP;
 	}

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -191,6 +191,11 @@ static int sam_xdmac_config(struct device *dev, u32_t channel,
 	__ASSERT_NO_MSG(cfg->source_data_size == cfg->dest_data_size);
 	__ASSERT_NO_MSG(cfg->source_burst_length == cfg->dest_burst_length);
 
+	if (cfg->dma_ht_callback) {
+		LOG_ERR("Half transfer event is not supported");
+		return -ENOTSUP;
+	}
+
 	if (cfg->source_data_size != 1U && cfg->source_data_size != 2U &&
 	    cfg->source_data_size != 4U) {
 		LOG_ERR("Invalid 'source_data_size' value");

--- a/include/dma.h
+++ b/include/dma.h
@@ -128,9 +128,14 @@ struct dma_block_config {
  *
  *     callback_arg  private argument from DMA client.
  *
- * dma_callback is the callback function pointer. If enabled, callback function
- *              will be invoked at transfer completion or when error happens
- *              (error_code: zero-transfer success, non zero-error happens).
+ * dma_ht_callback is the callback function pointer of half transfer complete
+ *                 event. If enabled, callback function will be invoked when
+ *                 half of the transfer is completed.
+ *
+ * dma_callback is the main callback function pointer. If enabled, callback
+ *              function will be invoked at transfer completion or when error
+ *              happens (error_code: zero-transfer success, non-zero error
+ *              happens).
  */
 struct dma_config {
 	u32_t  dma_slot :             6;
@@ -150,6 +155,7 @@ struct dma_config {
 	u32_t block_count;
 	struct dma_block_config *head_block;
 	void *callback_arg;
+	void (*dma_ht_callback)(void *callback_arg, u32_t channel);
 	void (*dma_callback)(void *callback_arg, u32_t channel,
 			     int error_code);
 };


### PR DESCRIPTION
Half transfer event of DMA is often used in scenarios with fast I/O
processing.

For example, in receiving result from ADC or SPI, if we process data
after receiving the transfer complete event signal, the ADC or SPI will
fill the buffer with new data as soon as possible, therefore data from
last frame may be replaced with the new coming data when we are
processing them in user space and the old data is lost.

Processing data when half of the transfer has completed solves this
problem, that is, if we start to process data when half transfer event
is triggered then when transfer complete event is triggered, we should
already have processed the front half of the data buffer in most cases,
and then process the left half of the data buffer, so no data is lost.