### PR TITLE
doc: Remove prj_single.conf from README.rst

### DIFF
--- a/samples/hello_world/README.rst
+++ b/samples/hello_world/README.rst
@@ -24,17 +24,6 @@ on QEMU as follows:
    :goals: run
    :compact:
 
-To build the single thread version, use the supplied configuration file for
-single thread: :file:`prj_single.conf`:
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :host-os: unix
-   :board: qemu_x86
-   :conf: prj_single.conf
-   :goals: run
-   :compact:
-
 Sample Output
 =============
 


### PR DESCRIPTION
Removed documentation about prj_single.conf from README.rst
as it is no longer needed and was removed.

Signed-off-by: Cinly Ooi <cinly.ooi@intel.com>