### PR TITLE
Bluetooth: PPCP: Fix not being able to disable configurations

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -421,12 +421,16 @@ if BT_GAP_PERIPHERAL_PREF_PARAMS
 config BT_PERIPHERAL_PREF_MIN_INT
 	int "Peripheral preferred minimum connection interval in 1.25ms units"
 	default 24
-	range 6 3200
+	range 6 65535
+	help
+	  Range 3200 to 65534 is invalid. 65535 represents no specific value.
 
 config BT_PERIPHERAL_PREF_MAX_INT
 	int "Peripheral preferred maximum connection interval in 1.25ms units"
 	default 40
-	range 6 3200
+	range 6 65535
+	help
+	  Range 3200 to 65534 is invalid. 65535 represents no specific value.
 
 config BT_PERIPHERAL_PREF_SLAVE_LATENCY
 	int "Peripheral preferred slave latency in Connection Intervals"
@@ -436,12 +440,13 @@ config BT_PERIPHERAL_PREF_SLAVE_LATENCY
 config BT_PERIPHERAL_PREF_TIMEOUT
 	int "Peripheral preferred supervision timeout in 10ms units"
 	default 42
-	range 10 3200
+	range 10 65535
 	help
 	  It is up to user to provide valid timeout which pass required minimum
 	  value: in milliseconds it shall be larger than
 	  "(1+ Conn_Latency) * Conn_Interval_Max * 2"
 	  where Conn_Interval_Max is given in milliseconds.
+	  Range 3200 to 65534 is invalid. 65535 represents no specific value.
 endif # BT_GAP_PERIPHERAL_PREF_PARAMS
 
 config BT_CREATE_CONN_TIMEOUT

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -108,6 +108,17 @@ static ssize_t read_appearance(struct bt_conn *conn,
 }
 
 #if defined (CONFIG_BT_GAP_PERIPHERAL_PREF_PARAMS)
+/* This checks if the range entered is valid */
+BUILD_ASSERT(!(CONFIG_BT_PERIPHERAL_PREF_MIN_INT > 3200 &&
+	     CONFIG_BT_PERIPHERAL_PREF_MIN_INT < 0xffff));
+BUILD_ASSERT(!(CONFIG_BT_PERIPHERAL_PREF_MAX_INT > 3200 &&
+	     CONFIG_BT_PERIPHERAL_PREF_MAX_INT < 0xffff));
+BUILD_ASSERT(!(CONFIG_BT_PERIPHERAL_PREF_TIMEOUT > 3200 &&
+	     CONFIG_BT_PERIPHERAL_PREF_TIMEOUT < 0xffff));
+BUILD_ASSERT((CONFIG_BT_PERIPHERAL_PREF_MIN_INT == 0xffff) ||
+	     (CONFIG_BT_PERIPHERAL_PREF_MIN_INT <=
+	     CONFIG_BT_PERIPHERAL_PREF_MAX_INT));
+
 static ssize_t read_ppcp(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, u16_t len, u16_t offset)
 {


### PR DESCRIPTION
The spec allows to disable certain configurations with use of 0xffff,
to restrict the range that can be entered the value 0 is used instead.

As this still enables entering values in the invalid range, 1-5 for
min/max interval, this adds the necessary build checks to prevents
values within this range to be used and at same time check if min
interval is not bigger that max interval.

Fixes #15017

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>