### PR TITLE
boards: stm32f4_disco:  added missing LED aliases

### DIFF
--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -49,6 +49,9 @@
 
 	aliases {
 		led0 = &green_led_4;
+		led1 = &orange_led_3;
+		led2 = &red_led_5;
+		led3 = &blue_led_6;
 		sw0 = &user_button;
 	};
 };


### PR DESCRIPTION
added three missing LEDS for stm32f4_disco, in order to run the
samples/basic/disco application on the stm32f4_disco

Signed-off-by: Jan Sturm <jansturm92@googlemail.com>