### PR TITLE
tests: thread_apis: fix failure on ARC

### DIFF
--- a/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
+++ b/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
@@ -17,7 +17,6 @@ extern struct k_thread tdata;
 
 static int tcount;
 static bool thread_flag;
-static bool stack_flag;
 
 static void thread_entry(void *p1, void *p2, void *p3)
 {
@@ -34,16 +33,6 @@ static void thread_callback(const struct k_thread *thread, void *user_data)
 				str, thread, thread->base.prio);
 		thread_flag = true;
 	}
-
-	if ((char *)thread->stack_info.start ==
-			K_THREAD_STACK_BUFFER(tstack)) {
-		TC_PRINT("%s: Newly added thread stack found\n", str);
-		TC_PRINT("%s: stack:%p, size:%u\n", str,
-					(char *)thread->stack_info.start,
-					thread->stack_info.size);
-		stack_flag = true;
-	}
-
 	tcount++;
 }
 
@@ -67,7 +56,7 @@ void test_k_thread_foreach(void)
 	/* Check thread_count non-zero, thread_flag
 	 * and stack_flag are not set.
 	 */
-	zassert_true(tcount && !thread_flag && !stack_flag,
+	zassert_true(tcount && !thread_flag,
 				"thread_callback() not getting called");
 	/* Save the initial thread count */
 	count = tcount;
@@ -86,7 +75,7 @@ void test_k_thread_foreach(void)
 	k_thread_foreach(thread_callback, TEST_STRING);
 
 	/* Check thread_count > temp, thread_flag and stack_flag are set */
-	zassert_true((tcount > count) && thread_flag && stack_flag,
+	zassert_true((tcount > count) && thread_flag,
 					"thread_callback() not getting called");
 	k_thread_abort(tid);
 }


### PR DESCRIPTION
This test is only trying to prove that k_thread_foreach() works,
it has nothing to do with stacks. Remove the stack checks
completely.

Fixes: #15044

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>