### PR TITLE
tests: cmsis_rtos_v2: fix thread checks

### DIFF
--- a/tests/cmsis_rtos_v2/src/thread_apis.c
+++ b/tests/cmsis_rtos_v2/src/thread_apis.c
@@ -83,13 +83,11 @@ static void thread2(void *argument)
 		      "Incorrect number of cmsis rtos v2 threads");
 
 	for (i = 0U; i < num_threads; i++) {
-		zassert_true(
-			osThreadGetStackSize(thread_array[i]) <= STACKSZ,
-			"stack size allocated is not what is expected");
+		u32_t size = osThreadGetStackSize(thread_array[i]);
+		u32_t space = osThreadGetStackSpace(thread_array[i]);
 
-		zassert_true(
-			osThreadGetStackSpace(thread_array[i]) <= STACKSZ - 4,
-			"stack size remaining is not what is expected");
+		zassert_true(space < size,
+			     "stack size remaining is not what is expected");
 	}
 
 	zassert_equal(osThreadGetState(thread_array[1]), osThreadReady,


### PR DESCRIPTION
It's really not possible to design a test where we can
enforce expectations on real vs. expected stack size:

- Some platforms may increase stack size over what is expected
  due to rounding up the stack buffer area to the next power
  of two.

- Some configuration options like CONFIG_STACK_RANDOM
  carve out space in the stack buffer, resulting in a stack
  size less than what is expected.

Best we can do is just assert that the amount of space
available should be less than the total size reported.

Fixes: #14640

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>