### PR TITLE
doc: additional clarifications on west

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -29,17 +29,15 @@ Zephyr's multi-purpose :ref:`west` tool lets you easily get the Zephyr project
 source code, instead of manually cloning the Zephyr repos along with west
 itself.
 
-.. note::
-   If you prefer to manage the repositories manually or with another tool
-   instead of using ``west``, you can still opt to do so. The documentation
-   section :ref:`no-west` describes how to work with Zephyr without using
-   west to manage its source code.
+.. warning::
+
+   It's possible to use Zephyr without installing west, but you have
+   to **really** know :ref:`what you are doing <no-west>`.
 
 Bootstrap west
 ==============
 
-Install the bootstrapper for Zephyr's command-line tool, :ref:`west <west>` in a
-shell or ``cmd.exe`` prompt:
+First, install the ``west`` binary and bootstrapper:
 
 .. code-block:: console
 
@@ -52,9 +50,6 @@ shell or ``cmd.exe`` prompt:
 .. note::
    See :ref:`gs_python_deps` for additional clarfication on using the
    ``--user`` switch.
-
-Additional information about west's structure can be found
-:ref:`in the relevant west documentation section <west-struct>`.
 
 Clone the Zephyr Repositories
 =============================
@@ -71,7 +66,8 @@ Clone the Zephyr Repositories
 
    You should see ``West bootstrapper version: v0.5.0`` (or higher).
 
-Clone the Zephyr source code repositories from GitHub using the ``west`` tool:
+Next, clone the Zephyr source code repositories from GitHub using the
+``west`` tool you just installed:
 
 .. code-block:: console
 

--- a/doc/guides/west/index.rst
+++ b/doc/guides/west/index.rst
@@ -11,11 +11,17 @@ sub-command::
 
   west [common-opts] <command> [opts] <args>
 
-West's built-in commands provide a multiple repository management system with
-features inspired by Google's Repo tool and Git submodules. West is also
-pluggable: you can write your own west "extension commands" which add
-additional features to west.  Zephyr provides extension commands for building
-applications, debugging them, and more.
+West's built-in commands provide a multiple repository management
+system with features inspired by Google's Repo tool and Git
+submodules. West simplifies configuration and is also pluggable: you
+can write your own west "extension commands" which add additional
+features to west.  Zephyr uses this feature to provide conveniences
+for building applications, flashing and debugging them, and more.
+
+It is possible not to use west for Zephyr development if you do not
+require these features, prefer to use your own tools, or want to
+eliminate the extra layer of indirection. However, this implies extra
+effort and expert knowledge.
 
 You can run ``west --help`` (or ``west -h`` for short) to get top-level help
 for available west commands, and ``west <command> -h`` for detailed help on

--- a/doc/guides/west/repo-tool.rst
+++ b/doc/guides/west/repo-tool.rst
@@ -226,6 +226,8 @@ important to understand.
   By default, ``west update`` also updates the west repository in the
   installation. To prevent this, use ``--exclude-west``.
 
+.. _west-multi-repo-misc:
+
 Miscellaneous Commands
 ======================
 

--- a/doc/guides/west/without-west.rst
+++ b/doc/guides/west/without-west.rst
@@ -3,30 +3,75 @@
 Using Zephyr without west
 #########################
 
-There are many valid usecases to avoid using a meta-tool such as west which has
-been custom-designed for a particular project and its requirements.
-This section applies to Zephyr users who fall into one or more of these
-categories:
+This page provides information on using Zephyr without west. This is
+not recommended for beginners due to the extra effort involved. In
+particular, you will have to do work "by hand" to replace these
+features:
 
-- Already use a multi-repository management system (for example Google repo)
+- cloning the additional source code repositories used by Zephyr in
+  addition to the main zephyr repository, and keeping them up to date
+- specifying the locations of these repositories to the Zephyr build
+  system
+- flashing and debugging without understanding detailed usage of the
+  relevant host tools
 
-- Do not need additional functionality beyond compiling and linking
+.. note::
 
-In order to obtain the Zephyr source code and build it without the help of
-west you will need to manually clone the repositories listed in the
-`manifest file`_ one by one, at the path indicated in it.
+   If you have previously installed west and want to stop using it,
+   uninstall it first:
+
+   .. code-block:: console
+
+      pip3 uninstall west
+
+   Otherwise, Zephyr's build system will find it and may try to use
+   it.
+
+Getting the Source
+------------------
+
+In addition to downloading the zephyr source code repository itself,
+you will need to manually clone the additional projects listed in the
+:term:`west manifest` file inside that repository.
 
 .. code-block:: console
 
    mkdir zephyrproject
    cd zephyrproject
    git clone https://github.com/zephyrproject-rtos/zephyr
-   # clone additional repositories listed in the manifest file,
-   # and check out the specified revisions
+   # clone additional repositories listed in zephyr/west.yml,
+   # and check out the specified revisions as well.
 
-If you want to manage Zephyr's repositories without west but still need to
-use west's additional functionality (flashing, debugging, etc.) it is possible
-to do so by manually creating an installation:
+As you pull changes in the zephyr repository, you will also need to
+maintain those additional repositories, adding new ones as necessary
+and keeping existing ones up to date at the latest revisions.
+
+Specifying Modules
+------------------
+
+If you have west installed, the Zephyr build system will use it to set
+:ref:`ZEPHYR_MODULES <important-build-vars>`. If you don't have west
+installed and your application does not need any of these
+repositories, the build will still work.
+
+If you don't have west installed and your application *does* need one
+of these repositories, you must set :makevar:`ZEPHYR_MODULES`
+yourself. See :ref:`ext-projs` for details.
+
+Flashing and Debugging
+----------------------
+
+Running build system targets like ``ninja flash``, ``ninja debug``,
+etc. is just a call to the corresponding :ref:`west command
+<west-build-flash-debug>`. For example, ``ninja flash`` calls ``west
+flash``\ [#wbninja]_. If you don't have west installed on your system, running
+those targets will fail. You can of course still flash and debug using
+any :ref:`debug-host-tools` which work for your board (and which those
+west commands wrap).
+
+If you want to use these build system targets but do not want to
+install west on your system using ``pip``, it is possible to do so
+by manually creating a :term:`west installation`:
 
 .. code-block:: console
 
@@ -40,11 +85,27 @@ Then create a file :file:`.west/config` with the following contents:
    [manifest]
    path = zephyr
 
+   [zephyr]
+   base = zephyr
+
 After that, and in order for ``ninja`` to be able to invoke ``west``
 to flash and debug, you must specify the west directory. This can be
 done by setting the environment variable ``WEST_DIR`` to point to
 :file:`zephyrproject/.west/west` before running CMake to set up a
 build directory.
 
-.. _manifest file:
-   https://github.com/zephyrproject-rtos/zephyr/blob/master/west.yml
+.. rubric:: Footnotes
+
+.. [#wbninja]
+
+   Note that ``west build`` invokes ``ninja``, among other
+   tools. There's no recursive invocation of either ``west`` or
+   ``ninja`` involved by default, however, as ``west build`` does not
+   invoke ``ninja flash``, ``debug``, etc. The one exception is if you
+   specifically run one of these build system targets with a command
+   line like ``west build -t flash``. In that case, west is run twice:
+   once for ``west build``, and in a subprocess, again for ``west
+   flash``. Even in this case, ``ninja`` is only run once, as ``ninja
+   flash``. This is because these build system targets depend on an
+   up to date build of the Zephyr application, so it's compiled before
+   ``west flash`` is run.


### PR DESCRIPTION
Add a missing reference to how west is used to set ZEPHYR_MODULES in
without-west.rst, augmenting the application development guide a bit
to include this in the list of important variables, cleaning that up a
bit while we are here and adding some more west details.

Add a big fat warning in the getting started guide that using Zephyr
without west is not for the faint of heart.