### PR TITLE
dts: nxp: Disable kw40/41 gpiob interrupts

### DIFF
--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -170,7 +170,6 @@
 		gpiob: gpio@400ff040 {
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff040 0x40>;
-			interrupts = <31 2>;
 			label = "GPIO_2";
 			gpio-controller;
 			#gpio-cells = <2>;

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -173,7 +173,6 @@
 		gpiob: gpio@400ff040 {
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff040 0x40>;
-			interrupts = <31 2>;
 			label = "GPIO_1";
 			gpio-controller;
 			#gpio-cells = <2>;


### PR DESCRIPTION
Ports B and C share a common interrupt vector on kw40 and kw41z socs,
but we don't currently have a way to express this in device tree. A
check was added in commit 77cb942a976a811c0da4aaaa57d75e2915c104bc that
correctly causes build errors on kw40/41 boards when both ports are
enabled.

Disable the port b interrupt for now until we have a better way to
handle this.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #13122. Alternative to #14653, which fixes the build error but doesn't actually work at runtime due to `gpio_mcux_configure` returning an error code.