### PR TITLE
LD: Support building without --gc-sections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,8 +379,16 @@ zephyr_ld_options(
   )
 endif()
 
+if(CONFIG_RETAIN_UNUSED_SECTIONS)
+  # For special circumstances
+  set(gc_sections_flag --no-gc-sections)
+else()
+  # The default
+  set(gc_sections_flag --gc-sections)
+endif()
+
 zephyr_ld_options(
-  ${LINKERFLAGPREFIX},--gc-sections
+  ${LINKERFLAGPREFIX},${gc_sections_flag}
   ${LINKERFLAGPREFIX},--build-id=none
   )
 

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -67,6 +67,20 @@ config LINKER_ORPHAN_SECTION_ERROR
 
 endchoice
 
+config RETAIN_UNUSED_SECTIONS
+	bool "Retain unused sections"
+	help
+	  Instruct the linker to retain unused sections.
+
+	  Note that usually each piece of code and data is given it's own
+	  section so this in effect retains all unused functions and
+	  variables.
+
+	  Note also that enabling this incurs a significant size increase
+	  and should therefore only be done when it is impractical to
+	  explicitly retain the specific functions and variables that
+	  actually need to be retained.
+
 config CODE_DATA_RELOCATION
        bool "Relocate code/data sections"
        depends on ARM


### PR DESCRIPTION
Support configuring the build to not use --gc-sections.

The linker defaults, and will still default, to using --gc-sections to
remove unused sections. Usually each piece of code and data is given
it's own section so this in effect removes all unused functions and
variables.

In certain remote procedure call (RPC) testing scenarios the linker
will be removing more code than it should when --gc-sections is
enabled. To support advanced testing such as this we make it
configurable whether or not to use --gc-sections.

Note that --gc-sections is still enabled by default so this change is
safe and backwards-compatible.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>