### PR TITLE
USB: check MPS depending on USB speed and endpoint type (Fix Coverity issues #14977)

### DIFF
--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -72,7 +72,10 @@ extern "C" {
  *  USB configuration
  **************************************************************************/
 
-#define MAX_PACKET_SIZE0    64        /**< maximum packet size for EP 0 */
+#define MAX_PACKET_SIZE0	64        /**< maximum packet size for EP 0 */
+
+#define USB_MAX_BULK_MPS	64
+#define USB_MAX_INT_MPS		64
 
 /*************************************************************************
  *  USB application interface

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -77,6 +77,14 @@ extern "C" {
 #define USB_MAX_BULK_MPS	64
 #define USB_MAX_INT_MPS		64
 
+#define USB_MPS_MAX_CTRL	64        /**< maximum packet size for EP 0 */
+#define USB_MPS_MAX_FS_BULK	64
+#define USB_MPS_MAX_HS_BULK	512
+#define USB_MPS_MAX_FS_INT	64
+#define USB_MPS_MAX_HS_INT	1024
+#define USB_MPS_MAX_FS_ISO	1023
+#define USB_MPS_MAX_HS_ISO	1024
+
 /*************************************************************************
  *  USB application interface
  **************************************************************************/

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -339,12 +339,17 @@ static struct netusb_function ecm_function = {
 	.send_pkt = ecm_send,
 };
 
-static inline void ecm_status_interface(const u8_t *iface)
+static inline void ecm_status_interface(const u8_t *desc)
 {
-	LOG_DBG("iface %u", *iface);
+	const struct usb_if_descriptor *if_desc = (void *)desc;
+	u8_t iface_num = if_desc->bInterfaceNumber;
+	u8_t alt_set = if_desc->bAlternateSetting;
+
+	LOG_DBG("iface %u alt_set %u", iface_num, if_desc->bAlternateSetting);
 
 	/* First interface is CDC Comm interface */
-	if (*iface != ecm_get_first_iface_number() + 1) {
+	if (iface_num != ecm_get_first_iface_number() + 1 || !alt_set) {
+		LOG_DBG("Skip iface_num %u alt_set %u", iface_num, alt_set);
 		return;
 	}
 

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -582,8 +582,6 @@ static bool usb_set_interface(u8_t iface, u8_t alt_setting)
 	LOG_DBG("iface %u alt_setting %u", iface, alt_setting);
 
 	while (p[DESC_bLength] != 0U) {
-		struct usb_dc_ep_cfg_data ep_cfg;
-
 		switch (p[DESC_bDescriptorType]) {
 		case DESC_INTERFACE:
 			/* remember current alternate setting */
@@ -595,8 +593,7 @@ static bool usb_set_interface(u8_t iface, u8_t alt_setting)
 				if_desc = (void *)p;
 			}
 
-			LOG_DBG("iface_num %u alt_set %u",
-				cur_iface, cur_alt_setting);
+			LOG_DBG("iface_num %u alt_set %u", iface, alt_setting);
 			break;
 		case DESC_ENDPOINT:
 			if ((cur_iface != iface) ||
@@ -604,18 +601,7 @@ static bool usb_set_interface(u8_t iface, u8_t alt_setting)
 				break;
 			}
 
-			/* Endpoint is found for desired interface and
-			 * alternate setting
-			 */
-			ep_cfg.ep_type = p[ENDP_DESC_bmAttributes];
-			ep_cfg.ep_mps = (p[ENDP_DESC_wMaxPacketSize]) |
-				(p[ENDP_DESC_wMaxPacketSize + 1] << 8);
-			ep_cfg.ep_addr = p[ENDP_DESC_bEndpointAddress];
-			usb_dc_ep_configure(&ep_cfg);
-			usb_dc_ep_enable(ep_cfg.ep_addr);
-
-			found = true;
-			LOG_DBG("Found: ep_addr 0x%x", ep_cfg.ep_addr);
+			found = set_endpoint((struct usb_ep_descriptor *)p);
 			break;
 		default:
 			break;

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -461,6 +461,45 @@ static bool usb_get_descriptor(u16_t type_index, u16_t lang_id,
 	return found;
 }
 
+static bool set_endpoint(const struct usb_ep_descriptor *ep_desc)
+{
+	struct usb_dc_ep_cfg_data ep_cfg;
+
+	ep_cfg.ep_addr = ep_desc->bEndpointAddress;
+	ep_cfg.ep_mps = sys_le16_to_cpu(ep_desc->wMaxPacketSize);
+
+	if (ep_desc->bmAttributes > USB_DC_EP_INTERRUPT) {
+		return false;
+	}
+
+	ep_cfg.ep_type = ep_desc->bmAttributes;
+
+	switch (ep_cfg.ep_type) {
+	case USB_DC_EP_BULK:
+		if (ep_cfg.ep_mps > USB_MAX_BULK_MPS) {
+			return false;
+		}
+	case USB_DC_EP_CONTROL:
+		if (ep_cfg.ep_mps > MAX_PACKET_SIZE0) {
+			return false;
+		}
+	case USB_DC_EP_INTERRUPT:
+		if (ep_cfg.ep_mps > USB_MAX_INT_MPS) {
+			return false;
+		}
+	default:
+		break;
+	}
+
+	LOG_DBG("Configure endpoint 0x%x type %u MPS %u",
+		ep_cfg.ep_addr, ep_cfg.ep_type, ep_cfg.ep_mps);
+
+	usb_dc_ep_configure(&ep_cfg);
+	usb_dc_ep_enable(ep_cfg.ep_addr);
+
+	return true;
+}
+
 /*
  * @brief set USB configuration
  *
@@ -475,22 +514,18 @@ static bool usb_get_descriptor(u16_t type_index, u16_t lang_id,
  */
 static bool usb_set_configuration(u8_t config_index, u8_t alt_setting)
 {
-	u8_t *p = NULL;
-	u8_t cur_config = 0U;
-	u8_t cur_alt_setting = 0U;
+	u8_t *p = (u8_t *)usb_dev.descriptors;
+	u8_t cur_alt_setting = 0xFF;
+	u8_t cur_config = 0xFF;
+	bool found = false;
 
 	if (config_index == 0U) {
-		/* unconfigure device */
-		LOG_DBG("Device not configured - invalid configuration "
-			"offset");
+		/* TODO: unconfigure device */
+		LOG_DBG("Device not configured - invalid configuration");
 		return true;
 	}
 
 	/* configure endpoints for this configuration/altsetting */
-	p = (u8_t *)usb_dev.descriptors;
-	cur_config = 0xFF;
-	cur_alt_setting = 0xFF;
-
 	while (p[DESC_bLength] != 0U) {
 		switch (p[DESC_bDescriptorType]) {
 		case DESC_CONFIGURATION:
@@ -505,28 +540,18 @@ static bool usb_set_configuration(u8_t config_index, u8_t alt_setting)
 			break;
 
 		case DESC_ENDPOINT:
-			if ((cur_config == config_index) &&
-			    (cur_alt_setting == alt_setting)) {
-				struct usb_dc_ep_cfg_data ep_cfg;
-				/* endpoint found for desired config
-				 * and alternate setting
-				 */
-				ep_cfg.ep_type =
-				    p[ENDP_DESC_bmAttributes];
-				ep_cfg.ep_mps =
-				    (p[ENDP_DESC_wMaxPacketSize]) |
-				    (p[ENDP_DESC_wMaxPacketSize + 1]
-					    << 8);
-				ep_cfg.ep_addr =
-				    p[ENDP_DESC_bEndpointAddress];
-				usb_dc_ep_configure(&ep_cfg);
-				usb_dc_ep_enable(ep_cfg.ep_addr);
+			if ((cur_config != config_index) ||
+			    (cur_alt_setting != alt_setting)) {
+				break;
 			}
+
+			found = set_endpoint((struct usb_ep_descriptor *)p);
 			break;
 
 		default:
 			break;
 		}
+
 		/* skip to next descriptor */
 		p += p[DESC_bLength];
 	}
@@ -535,7 +560,7 @@ static bool usb_set_configuration(u8_t config_index, u8_t alt_setting)
 		usb_dev.status_callback(USB_DC_CONFIGURED, &config_index);
 	}
 
-	return true;
+	return found;
 }
 
 /*


### PR DESCRIPTION
Check MPS depending on USB speed and endpoint type.

This is based on  #14977 and #15140, for a discussion how it could be done.

@finikorg You can cherry-pick or rebase it as you wish.