### PR TITLE
cmake: fix support for out of tree shields

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -289,6 +289,7 @@ foreach(root ${BOARD_ROOT})
 
   if(DEFINED SHIELD)
     foreach(s ${SHIELD_AS_LIST})
+      list(REMOVE_ITEM SHIELD ${s})
       list(FIND SHIELD_LIST ${s} _idx)
       if (NOT _idx EQUAL -1)
         list(GET shields_refs_list ${_idx} s_path)


### PR DESCRIPTION
After the rework in #12403, specifying a shield which has overlay
out of the tree causes unnecessary inclusions of overlays.
For every board root, overlays that have same index as
expected overlay are being included.
Fix this by removing already included overlays from SHIELD list.

Signed-off-by: Marcin Szymczyk <Marcin.Szymczyk@nordicsemi.no>