### PR TITLE
tests: disable userspace on two unrelated tests

### DIFF
--- a/tests/kernel/critical/prj.conf
+++ b/tests/kernel/critical/prj.conf
@@ -1,3 +1,6 @@
 CONFIG_ZTEST=y
-
+# This test does a lot of context switch thrashing, which blows up
+# emulation time on nsim_sem. Disable as this test doesn't exercise
+# user mode anyway.
+CONFIG_TEST_USERSPACE=n
 CONFIG_SMP=n

--- a/tests/posix/common/prj.conf
+++ b/tests/posix/common/prj.conf
@@ -6,5 +6,8 @@ CONFIG_SEM_VALUE_MAX=32767
 CONFIG_POSIX_MQUEUE=y
 CONFIG_HEAP_MEM_POOL_SIZE=4096
 CONFIG_MAX_THREAD_BYTES=4
-
+# This test does a lot of context switch thrashing, which blows up
+# emulation time on nsim_sem. Disable as this test doesn't exercise
+# user mode anyway.
+CONFIG_TEST_USERSPACE=n
 CONFIG_SMP=n


### PR DESCRIPTION
The ARC nSIM MPU emulator takes a great deal of time to
emulate MPU region programming, causing test timeouts from
these two tests as they do a great deal of context
switching. Performance of the tests on real hardware is
fine.

Future implementation of lazy MPU state in #15135 may
help with this, but for now just disable userspace for
these two tests, they don't run in user mode anyway.

Fixes: #14642

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>