### PR TITLE
doc: tweak index and release notes index for 1.14

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,15 +6,18 @@ Zephyr Project Documentation
 
 .. only:: release
 
-   Welcome to the Zephyr Project's documentation version |version|!
+   Welcome to the Zephyr Project's documentation for version |version|.
 
-   Documentation for the development branch of Zephyr can be found at
-   https://docs.zephyrproject.org/
+   Documentation for the latest (master) development branch of Zephyr
+   can be found at https://docs.zephyrproject.org/
 
 .. only:: (development or daily)
 
-   Welcome to the Zephyr Project's documentation. This is the documentation of the
-   master tree under development (version |version|).
+   Welcome to the Zephyr Project's documentation
+   for the master tree under development (version |version|).
+
+Use the version selection menu on the left to view
+documentation for a specific version of Zephyr.
 
 For information about the changes and additions for releases, please
 consult the published :ref:`zephyr_release_notes` documentation.
@@ -122,9 +125,3 @@ licensing, as described in :ref:`Zephyr_Licensing`.
 * :ref:`glossary`
 
 * :ref:`genindex`
-
-.. _Zephyr 1.13.0: https://docs.zephyrproject.org/1.13.0/
-.. _Zephyr 1.12.0: https://docs.zephyrproject.org/1.12.0/
-.. _Zephyr 1.11.0: https://docs.zephyrproject.org/1.11.0/
-.. _Zephyr 1.10.0: https://docs.zephyrproject.org/1.10.0/
-.. _Zephyr 1.9.2: https://docs.zephyrproject.org/1.9.0/

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -24,6 +24,7 @@ specific release and can be found at https://docs.zephyrproject.org/.
 .. toctree::
    :maxdepth: 1
 
+   release-notes-1.14
    release-notes-1.13
    release-notes-1.12
    release-notes-1.11


### PR DESCRIPTION
Update the release notes page to include the 1.14 release notes
(currently a draft in progress), and update the main index page to
clarify how to get to documentation for other Zephyr versions.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>