### PR TITLE
boards: qemu_x86_nommu is a simulation platform

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86_nommu.yaml
+++ b/boards/x86/qemu_x86/qemu_x86_nommu.yaml
@@ -2,6 +2,7 @@ identifier: qemu_x86_nommu
 name: QEMU Emulation for X86 (MMU disabled)
 type: qemu
 arch: x86
+simulation: qemu
 toolchain:
   - zephyr
   - xtools


### PR DESCRIPTION
For some reason we dropped the simulation keyword and this platform is
not running any tests, we just building the tests.