### PR TITLE
debug: tracing: Fix build with renaming of reserved functions.

### DIFF
--- a/subsys/debug/tracing/include/tracing_sysview.h
+++ b/subsys/debug/tracing/include/tracing_sysview.h
@@ -26,7 +26,7 @@ static inline int is_idle_thread(struct k_thread *thread)
 }
 
 
-static inline void z_sys_trace_thread_switched_in(void)
+static inline void z__sys_trace_thread_switched_in(void)
 {
 	struct k_thread *thread;
 
@@ -39,7 +39,7 @@ static inline void z_sys_trace_thread_switched_in(void)
 	}
 }
 
-#define sys_trace_thread_switched_in() z_sys_trace_thread_switched_in()
+#define sys_trace_thread_switched_in() z__sys_trace_thread_switched_in()
 
 #define sys_trace_thread_switched_out() SEGGER_SYSVIEW_OnTaskStopExec()
 


### PR DESCRIPTION
We renamed _sys_trace_thread_switched_in to
z_sys_trace_thread_switched_in, however we already had a function
named z_sys_trace_thread_switched_in.  So rename z_sys_trace... to
z__sys_trace...

Fixes: #15184

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>