### PR TITLE
tests/subsys/settings/fcb: fix unaligned test

### DIFF
--- a/tests/subsys/settings/fcb/src/settings_test_save_unaligned.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_unaligned.c
@@ -13,6 +13,7 @@ void test_config_save_fcb_unaligned(void)
 	struct settings_fcb cf;
 
 	config_wipe_srcs();
+	config_wipe_fcb(fcb_sectors, ARRAY_SIZE(fcb_sectors));
 
 	cf.cf_fcb.f_magic = CONFIG_SETTINGS_FCB_MAGIC;
 	cf.cf_fcb.f_sectors = fcb_sectors;


### PR DESCRIPTION
Unaligned test might filed in case fcb area was not clen before
run.
The patch insert clean operation before this test.

fixes #15063

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>