### PR TITLE
Increase buffer count to build ipv4_autoconf sample for sam_e70_xplained board

### DIFF
--- a/samples/net/ipv4_autoconf/boards/sam_e70_xplained.conf
+++ b/samples/net/ipv4_autoconf/boards/sam_e70_xplained.conf
@@ -1,0 +1,6 @@
+# sam_e70_xplained board need more buffers, otherwise it fails to build
+
+CONFIG_NET_PKT_RX_COUNT=20
+CONFIG_NET_PKT_TX_COUNT=20
+CONFIG_NET_BUF_RX_COUNT=30
+CONFIG_NET_BUF_TX_COUNT=30


### PR DESCRIPTION
More buffers are need to build for sam_e70_xplained board to work out of the box. Added board specific conf file.

Fixes #15096
