### PR TITLE
ztest: make priority of testing thread configurable

### DIFF
--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -47,3 +47,10 @@ config ZTEST_PARAMETER_COUNT
 	default 1
 	help
 	  Maximum amount of concurrent return values / expected parameters.
+
+config ZTEST_THREAD_PRIORITY
+	int "Testing thread priority"
+	depends on ZTEST
+	default -1
+	help
+	  Set priority of the testing thread. Default is -1 (cooperative).

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -209,8 +209,8 @@ static int run_test(struct unit_test *test)
 	k_thread_create(&ztest_thread, ztest_thread_stack,
 			K_THREAD_STACK_SIZEOF(ztest_thread_stack),
 			(k_thread_entry_t) test_cb, (struct unit_test *)test,
-			NULL, NULL, -1, test->thread_options | K_INHERIT_PERMS,
-			0);
+			NULL, NULL, CONFIG_ZTEST_THREAD_PRIORITY,
+			test->thread_options | K_INHERIT_PERMS,	0);
 	/*
 	 * There is an implicit expectation here that the thread that was
 	 * spawned is still higher priority than the current thread.


### PR DESCRIPTION
CONFIG_ZTEST_THREAD_PRIORITY can be now used to modify
the ztest thread priority.

Signed-off-by: Marcin Szymczyk <Marcin.Szymczyk@nordicsemi.no>