### PR TITLE
net: sockets: Make sure that getaddrinfo() cannot hang forever

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -29,6 +29,16 @@ config NET_SOCKETS_POLL_MAX
 	help
 	  Maximum number of entries supported for poll() call.
 
+config NET_SOCKETS_DNS_TIMEOUT
+	int "Timeout value in milliseconds for DNS queries"
+	default 2000
+	range 1000 300000
+	depends on DNS_RESOLVER
+	help
+	  This variable specifies time in milliseconds after which DNS
+	  query is considered timeout. Minimum timeout is 1 second and
+	  maximum timeout is 5 min.
+
 config NET_SOCKETS_SOCKOPT_TLS
 	bool "Enable TCP TLS socket option support [EXPERIMENTAL]"
 	select TLS_CREDENTIALS


### PR DESCRIPTION
If for some reason the DNS resolver callback is not called properly
then make sure that semaphore will not block forever.

Fixes #15197

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>