### PR TITLE
shell: Consume all input data

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -882,7 +882,7 @@ static void state_collect(const struct shell *shell)
 				 * on received NL.
 				 */
 				state_set(shell, SHELL_STATE_ACTIVE);
-				return;
+				continue;
 			}
 
 			switch (data) {
@@ -950,7 +950,7 @@ static void state_collect(const struct shell *shell)
 			receive_state_change(shell, SHELL_RECEIVE_DEFAULT);
 
 			if (!flag_echo_get(shell)) {
-				return;
+				continue;
 			}
 
 			switch (data) {


### PR DESCRIPTION
A transport may receive multiple bytes of data between shell_thread wakeups, but state_collect is only called once per wakeup.  So it must process all data, and only return when all data from the transport has been consumed.  This is mostly handled correctly, but there were two places where state_collect would return early instead.

Since one of those places was after executing a command, this bug was easy to reproduce by pasting multiple lines of data at once.  The actual behavior is messy depending on timing and whether the shell_uart RX buffer overflows -- basically it hangs without processing all input, then processes old input when new input comes in, etc.

With this I can now paste multiple line commands into the shell.

Fixes #15260