### PR TITLE
SPI NOR driver fixes

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -355,7 +355,7 @@ static int spi_nor_configure(struct device *dev)
 		return -ENODEV;
 	}
 
-	data->cs_ctrl.gpio_pin = DT_JEDEC_SPI_NOR_0_HOLD_GPIOS_PIN;
+	data->cs_ctrl.gpio_pin = DT_JEDEC_SPI_NOR_0_CS_GPIO_PIN;
 	data->cs_ctrl.delay = CONFIG_SPI_NOR_CS_WAIT_DELAY;
 
 	data->spi_cfg.cs = &data->cs_ctrl;

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -23,6 +23,20 @@ properties:
     description: JEDEC ID as manufacturer ID, memory type, memory density
     generation: define
 
+  erase-block-size:
+   type: int
+   description: address alignment required by flash erase operations
+   generation: define
+   category: optional
+   label: alignment
+
+  write-block-size:
+   type: int
+   description: address alignment required by flash write operations
+   generation: define
+   category: optional
+   label: alignment
+
   size:
     type: int
     category: optional


### PR DESCRIPTION
Fix a typo, and define missing DT properties so that I can use spi-nor driver in addition to the default "chosen" flash driver for my platform (nrf52).

Fixes #15236