### PR TITLE
net: lwm2m: dont use system workqueue for services

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3804,7 +3804,7 @@ static int lwm2m_engine_service(void)
 		service_due_timestamp = srv->last_timestamp +
 					K_MSEC(srv->min_call_period);
 		/* service is due */
-		if (timestamp > service_due_timestamp) {
+		if (timestamp >= service_due_timestamp) {
 			srv->last_timestamp = k_uptime_get();
 			srv->service_work(NULL);
 		}


### PR DESCRIPTION
"It's a Trap!" -- Admiral Ackbar

When moving to the BSD-socket APIs, the original thread running LwM2M
periodic services such as observes and lifetime updates, was replaced
with a re-occuring workqueue job.  To save the overhead of creating a
new thread, I used the system workqueue for these jobs.

This was a mistake.  If these jobs hit a semaphore or wait for some
reason, it cannot be prempted due to the priority of the system work
queue.

Let's instead add this service handling to the thread that we already
use for polling sockets.  This also removes a configuration issue where
the system workqueue stack size needed to be increased.  This can now
be adjusted via the LWM2M_ENGINE_STACK_SIZE knob.

Directly fixes semaphore usage in the socket-based DNS code.
This was introduced as a bugfix for non-responsive DNS server hanging
the Zephyr device forever.  However, this probably fixes randomly
seeming hangs on the device.


Fixes  #15204 

Signed-off-by: Michael Scott <mike@foundries.io>