### PR TITLE
drivers: gpio: fix wrong rename of literal

### DIFF
--- a/drivers/pinmux/pinmux_esp32.c
+++ b/drivers/pinmux/pinmux_esp32.c
@@ -112,7 +112,7 @@ static int pinmux_pullup(struct device *dev, u32_t pin, u8_t func)
 	return -EINVAL;
 }
 
-#define CFG(id)   ((GPIO_ ## id ## Z_REG) & 0xff)
+#define CFG(id)   ((GPIO_ ## id ## _REG) & 0xff)
 static int pinmux_input(struct device *dev, u32_t pin, u8_t func)
 {
 	static const u8_t offs[2][3] = {


### PR DESCRIPTION
_REG here is not a variable, it is a string in the macro. It should have
not been renamed.

Fixes #15240