### PR TITLE
ethernet: eth_stellaris: data_len should not include header size

### DIFF
--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -65,10 +65,11 @@ static int eth_stellaris_send(struct device *dev, struct net_pkt *pkt)
 	u16_t i, data_len;
 
 	/* Frame transmission
-	 * First two bytes are data_len for frame,
-	 * Initially send the data_len
+	 *
+	 * First two bytes is the length of the frame, exclusive of
+	 * the header length.
 	 */
-	data_len = net_pkt_get_len(pkt);
+	data_len = net_pkt_get_len(pkt) - sizeof(struct net_eth_hdr);
 	eth_stellaris_send_byte(dev, data_len & 0xff);
 	eth_stellaris_send_byte(dev, (data_len & 0xff00) >> 8);
 


### PR DESCRIPTION
As part of the ll_reserve refactoring effort, the packet length now
includes header size as well. Before the refactor, when the packet
length was written to the device, it did not include the header size,
which is the required value as per the LM3S6965 datasheet. After the
refactor the packet length includes the header size as well. The
header size has to subtracted from the packet length before writing to
the device.

Fixes #13943

Signed-off-by: Vijay Kumar B. <vijaykumar@zilogic.com>