### PR TITLE
doc: fix ztest code samples

### DIFF
--- a/doc/guides/test/ztest.rst
+++ b/doc/guides/test/ztest.rst
@@ -202,7 +202,7 @@ Here is a generic template for a test showing the expected use of
                             ztest_unit_test(test_sometest1),
                             ztest_unit_test(test_sometest2),
                             ztest_unit_test(test_sometest3),
-                            ztest_unit_test(test_sometest4),
+                            ztest_unit_test(test_sometest4)
                    );
    	ztest_run_test_suite(common);
    }
@@ -226,14 +226,16 @@ What to avoid:
              ztest_test_suite(feature1,
                               ztest_unit_test(test_1a),
                               ztest_unit_test(test_1b),
-                              ztest_unit_test(test_1c),
+                              ztest_unit_test(test_1c)
+                              );
              ztest_run_test_suite(feature1);
      #endif
 
      #ifdef TEST_feature2
              ztest_test_suite(feature2,
                               ztest_unit_test(test_2a),
-                              ztest_unit_test(test_2b),
+                              ztest_unit_test(test_2b)
+                              );
              ztest_run_test_suite(feature2);
      #endif
      }


### PR DESCRIPTION
Remove extra commas and close brackets in code samples.

Fixes #14098