### PR TITLE
kconfig: Avoid potential issue parsing generated_dts_board.conf

### DIFF
--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -20,7 +20,7 @@ if not doc_mode:
         with open(GENERATED_DTS_BOARD_CONF, 'r', encoding='utf-8') as fd:
             for line in fd:
                 if '=' in line:
-                    define, val = line.split('=')
+                    define, val = line.split('=', 1)
                     dt_defines[define] = val.strip()
 
 def _dt_units_to_scale(unit):


### PR DESCRIPTION
Splitting a string like `'foo="bar=baz"'` on `=` will give `['foo', '"bar', 'baz"']` instead of the intended `['foo', '"bar=baz"']`. `split()` with `maxsplit=1` to avoid potential issues.

Not seen in practice. Just some future safety.