### PR TITLE
drivers: usb: nordic: Do not log an error if HFCLK is busy

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -557,6 +557,13 @@ static int hf_clock_enable(bool on, bool blocking)
 			return 0;
 		}
 		ret = clock_control_off(clock, (void *)blocking);
+		if (ret == -EBUSY) {
+			/* This is an expected behaviour.
+			 * -EBUSY means that some other module has also
+			 * requested the clock to run.
+			 */
+			ret = 0;
+		}
 	}
 
 	if (ret && (blocking || (ret != -EINPROGRESS))) {


### PR DESCRIPTION
HFCLK may be requested for multiple modules, i.e. Bluetooth stack.
When any other module has requested HFCLK to run, the driver will
return -EBUSY on free attempt which is not an error - thie means
that free request has been processed, but someone else is still
requiring the clock to run. When all clock users free the clock,
is is then stopped to save power. Driver may also return -EAGAIN
when any other module is accesing the driver at the same time.
A proper reaction to -EAGAIN has been implemented here (wait and
try again).

Fixes: #15145

Signed-off-by: Paweł Zadrożniak <pawel.zadrozniak@nordicsemi.no>