### PR TITLE
net: fix errno returned without promiscuous mode support

### DIFF
--- a/include/net/promiscuous.h
+++ b/include/net/promiscuous.h
@@ -60,7 +60,7 @@ static inline int net_promisc_mode_on(struct net_if *iface)
 {
 	ARG_UNUSED(iface);
 
-	return -ENOSUP;
+	return -ENOTSUP;
 }
 #endif /* CONFIG_NET_PROMISCUOUS_MODE */
 
@@ -78,7 +78,7 @@ static inline int net_promisc_mode_off(struct net_if *iface)
 {
 	ARG_UNUSED(iface);
 
-	return -ENOSUP;
+	return -ENOTSUP;
 }
 #endif /* CONFIG_NET_PROMISCUOUS_MODE */
 


### PR DESCRIPTION
If promiscuous mode support is disabled in Kconfig and the promiscuous.h header is included the build will fail. ENOSUP is not a defined errno. This commit changes it to ENOTSUP.