### PR TITLE
dts: rv32m1_ri5cy: fix comment

### DIFF
--- a/dts/riscv32/rv32m1_ri5cy.dtsi
+++ b/dts/riscv32/rv32m1_ri5cy.dtsi
@@ -92,7 +92,7 @@
 		 *
 		 * The system timer (assumed at LPTMR0) is placed on channel 0,
 		 * and peripherals are in channel 1. This can be overridden with
-		 * overlays, e.g. to manage IRQ priorities, and it'll will Just
+		 * overlays, e.g. to manage IRQ priorities, and it will Just
 		 * Work, but using fewer channels here allows disabling unused
 		 * ones in Kconfig, making the binary smaller.
 		 *


### PR DESCRIPTION
Fix a comment in the rv32m1_ri5cy.dtsi file.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>