### PR TITLE
sensor: fxos8700: add support for hardware reset pin

### DIFF
--- a/drivers/sensor/fxos8700/fxos8700.h
+++ b/drivers/sensor/fxos8700/fxos8700.h
@@ -126,6 +126,8 @@ struct fxos8700_config {
 	u8_t gpio_pin;
 #endif
 	u8_t i2c_address;
+	char *reset_name;
+	u8_t reset_pin;
 	enum fxos8700_mode mode;
 	enum fxos8700_power_mode power_mode;
 	enum fxos8700_range range;

--- a/dts/bindings/sensor/nxp,fxos8700.yaml
+++ b/dts/bindings/sensor/nxp,fxos8700.yaml
@@ -18,6 +18,11 @@ properties:
     compatible:
       constraint: "nxp,fxos8700"
 
+    reset-gpios:
+      type: compound
+      category: optional
+      generation: define, use-prop-name
+
     int1-gpios:
       type: compound
       category: optional


### PR DESCRIPTION
Add support for pulsing the hardware reset pin of the FXOS8700 high
during initialization.

According to the datasheet, this is required for the I2C/SPI bus
auto-detection logic to work properly if the VDD/VDDIO power
sequencing order cannot be guaranteed.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>