### PR TITLE
interrupt_controller: rv32m1: fix intmux driver initialization priority

### DIFF
--- a/drivers/interrupt_controller/Kconfig.rv32m1
+++ b/drivers/interrupt_controller/Kconfig.rv32m1
@@ -18,7 +18,7 @@ if RV32M1_INTMUX
 
 config RV32M1_INTMUX_INIT_PRIORITY
 	int "INTMUX driver initialization priority"
-	default 60
+	default 40
 	help
 	  Boot time initialization priority for INTMUX driver.
 	  Don't change the default unless you know what you are doing.

--- a/drivers/interrupt_controller/rv32m1_intmux.c
+++ b/drivers/interrupt_controller/rv32m1_intmux.c
@@ -194,4 +194,4 @@ static int rv32m1_intmux_init(struct device *dev)
 DEVICE_AND_API_INIT(intmux, DT_OPENISA_RV32M1_INTMUX_INTMUX_LABEL,
 		    &rv32m1_intmux_init, NULL,
 		    &rv32m1_intmux_cfg, PRE_KERNEL_1,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &rv32m1_intmux_apis);
+		    CONFIG_RV32M1_INTMUX_INIT_PRIORITY, &rv32m1_intmux_apis);


### PR DESCRIPTION
Use the RV32M1 SoC intmux driver initialization priority set by
Kconfig.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>