### PR TITLE
tests: add nsim special cases for two tests

### DIFF
--- a/tests/kernel/critical/testcase.yaml
+++ b/tests/kernel/critical/testcase.yaml
@@ -1,3 +1,12 @@
+common:
+  tags: kernel
+
 tests:
   kernel.common:
-    tags: kernel
+    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+  kernel.common.nsim:
+    platform_whitelist: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    extra_configs:
+      - CONFIG_TEST_USERSPACE=n
+      - CONFIG_TEST_HW_STACK_PROTECTION=n
+

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -2,11 +2,27 @@ common:
   tags: posix
   min_ram: 64
   arch_exclude: posix
+
 tests:
   portability.posix:
+    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
   portability.posix.newlib:
+    platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
+  portability.posix.nsim:
+    platform_whitelist: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=n
+      - CONFIG_TEST_USERSPACE=n
+      - CONFIG_TEST_HW_STACK_PROTECTION=n
+  portability.posix.newlib.nsim:
+    platform_whitelist: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y
+      - CONFIG_TEST_USERSPACE=n
+      - CONFIG_TEST_HW_STACK_PROTECTION=n


### PR DESCRIPTION
The NSIM emulator has severe performance issues when
the MPU registers are reprogrammed on context switch.
Disable runtime reprogramming of the MPU for these
platforms on these two tests, which have a lot of context
switch thrashing. This is done by ensuring userspace
and hardware stack overflow detection via guard areas
is disabled.

I have assurances from the ARC team that the tests run fine
on real hardware and this is an emulation issue. We're only
changing the test parameters for these emulated targets.

For 1.15, this will be completely resolved by optimizing
MPU region gap-filling to not take place during context
switch time, which will drastically reduce the number of
MPU registers poked during context switch on nsim_sem/
nsim/em. See #15223 

Meanwhile, for 1.14 we ensure that no runtime reprogramming
of the MPU is done for these tests.

Fixes: #14642

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>