### PR TITLE
scripts: update pyocd in requirements.txt

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -10,7 +10,7 @@ ply==3.10
 hub==2.0
 gitlint
 pyelftools==0.24
-pyocd==0.16.1
+pyocd==0.19.0
 pyserial
 pykwalify
 # "win32" is used for 64-bit Windows as well


### PR DESCRIPTION
This includes a bugfix for a requirement on pyyaml that could not be satisfied using officially supported releases of that dependency.
