### PR TITLE
shell: kconfig: Put 'menuconfig SHELL' in top-level menu

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -8,10 +8,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-menu "Shell Options"
-
 menuconfig SHELL
-	bool "Enable shell"
+	bool "Shell"
 	imply LOG_RUNTIME_FILTERING
 	select POLL
 
@@ -149,5 +147,4 @@ config SHELL_LOG_BACKEND
 
 source "subsys/shell/modules/Kconfig"
 
-endif #SHELL
-endmenu
+endif # SHELL


### PR DESCRIPTION
The 'Shell Options' menu contains just the 'menuconfig SHELL' menu in
the menuconfig interface.

Remove the 'Shell Options' menu and put 'menuconfig SHELL' directly in
the top-level menu instead. Also change the prompt from "Enable shell"
to just "Shell", to make it consistent with "Logging".