### PR TITLE
kernel: Remove k_cpu_idle() from hang_system infinite loop

### DIFF
--- a/arch/arm/core/sys_fatal_error_handler.c
+++ b/arch/arm/core/sys_fatal_error_handler.c
@@ -67,7 +67,8 @@ hang_system:
 #endif
 
 	for (;;) {
-		k_cpu_idle();
+		/* Don't do k_cpu_idle here because it will stop the watchdog
+		 * from triggering when option WDT_OPT_PAUSE_IN_SLEEP is set. */
 	}
 	CODE_UNREACHABLE;
 }


### PR DESCRIPTION
Doing k_cpu_idle() stops the watchdog from triggering when
option WDT_OPT_PAUSE_IN_SLEEP is set.

Signed-off-by: Benjamin Lindqvist <benjamin.lindqvist@endian.se>