### PR TITLE
editorconfig: Set insert_final_newline true

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-insert_final_newline = false
+insert_final_newline = true
 trim_trailing_whitespace = true
 
 # C


### PR DESCRIPTION
This is what checkpatch.pl expects, and GitHub's file viewer flags a
missing trailing newline too.

Note that this is different from a blank line at the end of the file. It
just says whether the last line must end in a newline.