### PR TITLE
Bluetooth: Mesh: Fix not updating health publication message

### DIFF
--- a/subsys/bluetooth/host/mesh/health_srv.c
+++ b/subsys/bluetooth/host/mesh/health_srv.c
@@ -358,6 +358,8 @@ int bt_mesh_fault_update(struct bt_mesh_elem *elem)
 		return -EINVAL;
 	}
 
+	health_pub_update(mod);
+
 	return bt_mesh_model_publish(mod);
 }
 


### PR DESCRIPTION
The bt_mesh_fault_update() API is meant for updating the publication
message and sending it out to the network, however it was missing the
necessary call to health_pub_update() which is responsible for
updating the publication message.

Fixes #15300

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>