### PR TITLE
mimxrt1060_evk: mimxrt1064_evk: Enable pyocd runner

### DIFF
--- a/boards/arm/mimxrt1060_evk/board.cmake
+++ b/boards/arm/mimxrt1060_evk/board.cmake
@@ -4,5 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set_ifndef(OPENSDA_FW jlink)
+
+if(OPENSDA_FW STREQUAL jlink)
+  set_ifndef(BOARD_DEBUG_RUNNER jlink)
+  set_ifndef(BOARD_FLASH_RUNNER jlink)
+elseif(OPENSDA_FW STREQUAL daplink)
+  set_ifndef(BOARD_DEBUG_RUNNER pyocd)
+  set_ifndef(BOARD_FLASH_RUNNER pyocd)
+endif()
+
+board_runner_args(pyocd "--target=cortex_m")
 board_runner_args(jlink "--device=MIMXRT1062xxx6A")
+
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/mimxrt1064_evk/board.cmake
+++ b/boards/arm/mimxrt1064_evk/board.cmake
@@ -4,5 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set_ifndef(OPENSDA_FW jlink)
+
+if(OPENSDA_FW STREQUAL jlink)
+  set_ifndef(BOARD_DEBUG_RUNNER jlink)
+  set_ifndef(BOARD_FLASH_RUNNER jlink)
+elseif(OPENSDA_FW STREQUAL daplink)
+  set_ifndef(BOARD_DEBUG_RUNNER pyocd)
+  set_ifndef(BOARD_FLASH_RUNNER pyocd)
+endif()
+
+board_runner_args(pyocd "--target=cortex_m")
 board_runner_args(jlink "--device=MIMXRT1064")
+
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Enables the pyocd runner on mimxrt1060_evk and mimxrt1064_evk boards
using the generic cortex_m target. Note that this target is not capable
of programming flash, therefore can only load an application to internal
SRAM (set CONFIG_CODE_ITCM=y and CONFIG_DATA_DTCM=y) or attach to an
application already programmed to flash by other means (e.g., DAPLink
drag-and-drop).

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>