### PR TITLE
sanitycheck: add more info during processing

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2133,6 +2133,7 @@ class TestSuite:
         info("Building testcase defconfigs...")
         results = mg.execute(defconfig_cb)
 
+        info("Filtering test cases...")
         for name, goal in results.items():
             try:
                 if goal.failed:


### PR DESCRIPTION
After the testcase configs are built, there is a step to
filter all the test case information to determine the set
of tests to run.

As this step takes a nontrivial amount of time, add an
informational message about it.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>