### PR TITLE
drivers: timer: systick: fix off-by-one setting

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -129,6 +129,7 @@
 /drivers/net/slip.c                       @jukkar @tbursztyka
 /drivers/spi/                             @tbursztyka
 /drivers/spi/spi_ll_stm32.*               @superna9999
+/drivers/timer/cortex_m_systick.c         @ioannisg
 /drivers/timer/altera_avalon_timer_hal.c  @ramakrishnapallala
 /drivers/timer/riscv_machine_timer.c      @nategraff-sifive @kgugala @pgielda
 /drivers/usb/                             @jfischer-phytec-iot @finikorg

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -144,7 +144,7 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	last_load = delay - (cycle_count - announced_cycles);
 
 	overflow_cyc = 0U;
-	SysTick->LOAD = last_load;
+	SysTick->LOAD = last_load - 1;
 	SysTick->VAL = 0; /* resets timer to last_load */
 
 	k_spin_unlock(&lock, key);

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -102,7 +102,7 @@ void z_clock_isr(void *arg)
 int z_clock_driver_init(struct device *device)
 {
 	NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
-	last_load = CYC_PER_TICK;
+	last_load = CYC_PER_TICK - 1;
 	overflow_cyc = 0U;
 	SysTick->LOAD = last_load;
 	SysTick->VAL = 0; /* resets timer to last_load */

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -147,6 +147,22 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	SysTick->LOAD = last_load - 1;
 	SysTick->VAL = 0; /* resets timer to last_load */
 
+	/*
+	 * In the unlucky scenario of a SysTick event (wrap) occurring
+	 * while we re-program the last_load value, the SysTick ISR
+	 * will run immediately after we unlock interrupts. In that
+	 * case the timeout we have just configured will expire
+	 * instantaneously, leading to operations being executed
+	 * much earlier than expected. Avoid this by clearing possibly
+	 * pending SysTick exceptions (writing 1 to ICSR.PENDSTCLR).
+	 *
+	 * Side effect: any operations that were scheduled to execute
+	 * upon the expiration of the timeout we may be canceling (by
+	 * writing PENDSTCLR to 1) will be postponed, until the new
+	 * timeout (i.e. the one we are programming now) expires.
+	 */
+	SCB->ICSR |= SCB_ICSR_PENDSTCLR_Msk;
+
 	k_spin_unlock(&lock, key);
 #endif
 }


### PR DESCRIPTION
When the counter reaches zero, it reloads the value in
SYST_RVR on the next clock edge. This means that if the
LOAD value is N, the interrupt ("tick") is triggered
every N+1 cycles. Therefore, when we operate in non-
tickless mode, we need to configure the LOAD value
with CYC_PER_TICK - 1, in order to get an event
every CYC_PER_TICK cycles.

Fixes #15309 

Update: we address the race condition in TICKLESS mode in this pull-request, too.

Fixes #15348 

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>