### PR TITLE
tests: ringbuffer: avoid unaligned mem access

### DIFF
--- a/tests/lib/ringbuffer/src/main.c
+++ b/tests/lib/ringbuffer/src/main.c
@@ -56,7 +56,7 @@ void test_ring_buffer_main(void)
 	u8_t getsize, getval;
 	u16_t gettype;
 	int dsize = INITIAL_SIZE;
-	char rb_data[] = "ABCDEFGHIJKLMNOPQRSTUVWX";
+	__aligned(sizeof(u32_t)) char rb_data[] = "ABCDEFGHIJKLMNOPQRSTUVWX";
 	put_count = 0;
 
 	while (1) {


### PR DESCRIPTION
Casting the rb_data character array to a u32_t can result
in an unaligned u32_t * pointer being passed to
ring_buf_item_put(), since rb_data is only byte-aligned.

Our Altera Max10 CPU build is not configured to detect
unaligned memory access and throw an exception, it is
instead rounding down the memory address
of the data pointer to the nearest 4-byte value, causing
the wrong data to be copied into the ring buffer.

It appears that in the C standard this is considered
Undefined Behavior so the approach this patch takes is
to fix the test, by ensuring that rb_data is aligned to
u32_t.

Fixes: #14869

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>