### PR TITLE
sanitycheck: order results.csv and discards.csv deterministically

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1804,6 +1804,9 @@ class TestInstance:
                 or self.check_dependency()
         self.results = {}
 
+    def __lt__(self, other):
+        return self.name < other.name
+
     def check_dependency(self):
         build_only = False
         if self.test.harness == 'console':
@@ -2401,7 +2404,7 @@ class TestSuite:
             fieldnames = ["test", "arch", "platform", "reason"]
             cw = csv.DictWriter(csvfile, fieldnames, lineterminator=os.linesep)
             cw.writeheader()
-            for instance, reason in self.discards.items():
+            for instance, reason in sorted(self.discards.items()):
                 rowdict = {"test": instance.test.name,
                            "arch": instance.platform.arch,
                            "platform": instance.platform.name,
@@ -2624,7 +2627,7 @@ class TestSuite:
                           "rom_size"]
             cw = csv.DictWriter(csvfile, fieldnames, lineterminator=os.linesep)
             cw.writeheader()
-            for name, goal in self.goals.items():
+            for name, goal in sorted(self.goals.items()):
                 i = self.instances[name]
                 rowdict = {"test": i.test.name,
                            "arch": i.platform.arch,


### PR DESCRIPTION
One of the first things needed when comparing builds of tests across
different environments/systems is to make sure the same (sub)tests were
selected and run in the first place. For that purpose sort the output of
`--testcase-report` and `--discard-report` as they were in random order.

Actually make the entire class TestInstance sortable by adding a
standard `__lt__()` method comparing unique instance names; it could be
useful again.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>