### PR TITLE
xtensa: Use cache writeback with invalidation

### DIFF
--- a/soc/xtensa/intel_s1000/soc.h
+++ b/soc/xtensa/intel_s1000/soc.h
@@ -208,7 +208,7 @@ struct soc_global_regs {
 #define SOC_DCACHE_FLUSH(addr, size)		\
 	xthal_dcache_region_writeback((addr), (size))
 #define SOC_DCACHE_INVALIDATE(addr, size)	\
-	xthal_dcache_region_invalidate((addr), (size))
+	xthal_dcache_region_writeback_inv((addr), (size))
 
 extern void z_soc_irq_enable(u32_t irq);
 extern void z_soc_irq_disable(u32_t irq);


### PR DESCRIPTION
When data cache is invalidated, the data structure contents that
have not been written back to memory will be evicted and replaced
by the contents of memory. Since the whole of SRAM memory is mapped
to a single cache in s1000, invalidating the cache to satisfy some
requirement of one program may turn out to be unintended and
non-determinstic for another program running alongside. Hence, it
is better to use "writeback with invalidate" in order to overcome
this issue.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>