### PR TITLE
boards: nrf9160_pca10090: Fix polarity of pwm0/ch0

### DIFF
--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
@@ -107,7 +107,6 @@
 &pwm0 {
 	status = "ok";
 	ch0-pin = <2>;
-	ch0-inverted;
 };
 
 &spi3 {


### PR DESCRIPTION
This is a follow up to commit 436c4262da794791a86281342031656799145ade (PR #14981).
By default the channel 0 of pwm0 is set to the pin that drives led0.
Since the LED is active high, the inversion of polarity is incorrect.

Fixes another incarnation of #10038.