### PR TITLE
Bluetooth: Fix clearing conn->le.keys when unpairing

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1448,6 +1448,7 @@ static int bt_clear_all_pairings(u8_t id)
 
 int bt_unpair(u8_t id, const bt_addr_le_t *addr)
 {
+	struct bt_keys *keys = NULL;
 	struct bt_conn *conn;
 
 	if (id >= CONFIG_BT_ID_MAX) {
@@ -1460,6 +1461,15 @@ int bt_unpair(u8_t id, const bt_addr_le_t *addr)
 
 	conn = bt_conn_lookup_addr_le(id, addr);
 	if (conn) {
+		/* Clear the conn->le.keys pointer since we'll invalidate it,
+		 * and don't want any subsequent code (like disconnected
+		 * callbacks) accessing it.
+		 */
+		if (conn->type == BT_CONN_TYPE_LE) {
+			keys = conn->le.keys;
+			conn->le.keys = NULL;
+		}
+
 		bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 		bt_conn_unref(conn);
 	}
@@ -1472,7 +1482,10 @@ int bt_unpair(u8_t id, const bt_addr_le_t *addr)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SMP)) {
-		struct bt_keys *keys = bt_keys_find_addr(id, addr);
+		if (!keys) {
+			keys = bt_keys_find_addr(id, addr);
+		}
+
 		if (keys) {
 			bt_keys_clear(keys);
 		}


### PR DESCRIPTION
When calling bt_unpair() the keys were removed from flash, however a
pointer was left to the invalidated keys in case there was an existing
connection. This would then lead to a bogus entry being stored in
flash for a zero-address peer device. Fix this issue by clearing the
conn->le.keys pointer in the bt_unpair() function.

Fixes #15325

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>