### PR TITLE
Bluetooth: GATT: Fix not clearing Client Features

### DIFF
--- a/subsys/bluetooth/host/gatt_internal.h
+++ b/subsys/bluetooth/host/gatt_internal.h
@@ -18,7 +18,8 @@ void bt_gatt_disconnected(struct bt_conn *conn);
 bool bt_gatt_change_aware(struct bt_conn *conn, bool req);
 
 int bt_gatt_store_ccc(u8_t id, const bt_addr_le_t *addr);
-int bt_gatt_clear_ccc(u8_t id, const bt_addr_le_t *addr);
+
+int bt_gatt_clear(u8_t id, const bt_addr_le_t *addr);
 
 #if defined(CONFIG_BT_GATT_CLIENT)
 void bt_gatt_notification(struct bt_conn *conn, u16_t handle,

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1479,7 +1479,7 @@ int bt_unpair(u8_t id, const bt_addr_le_t *addr)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		bt_gatt_clear_ccc(id, addr);
+		bt_gatt_clear(id, addr);
 	}
 
 	return 0;

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -231,7 +231,7 @@ static void keys_clear_id(struct bt_keys *keys, void *data)
 
 	if (*id == keys->id) {
 		if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-			bt_gatt_clear_ccc(*id, &keys->addr);
+			bt_gatt_clear(*id, &keys->addr);
 		}
 
 		bt_keys_clear(keys);


### PR DESCRIPTION
When a device is considered unpaired any configuration set in Client
Features shall also be removed.

Fixes #15329

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>