### PR TITLE
boards: rv32m1_vega_ri5cy: add STS LED to DTS

### DIFF
--- a/boards/riscv32/rv32m1_vega/rv32m1_vega_ri5cy.dts
+++ b/boards/riscv32/rv32m1_vega/rv32m1_vega_ri5cy.dts
@@ -15,6 +15,7 @@
 		led0 = &green_led;
 		led1 = &blue_led;
 		led2 = &red_led;
+		led3 = &sts_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
 		sw2 = &user_button_4;
@@ -40,6 +41,10 @@
 		red_led: led_2 {
 			gpios = <&gpioa 24 0>;
 			label = "User LD3";
+		};
+		sts_led: led_3 {
+			gpios = <&gpioe 0 0>;
+			label = "User LD4";
 		};
 	};
 


### PR DESCRIPTION
Add the status LED to the DTS of the RV32M1 Vegaboard RI5CY device
tree.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>