### PR TITLE
doc: add missing doc top labels

### DIFF
--- a/doc/404.rst
+++ b/doc/404.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _page-not-found:
+
 Sorry, Page Not Found
 #####################
 

--- a/doc/copyright.rst
+++ b/doc/copyright.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _doc-copyrights:
+
 Documentation Copyrights
 ########################
 

--- a/doc/development_process/code_flow.rst
+++ b/doc/development_process/code_flow.rst
@@ -1,3 +1,4 @@
+.. _code-flow-and-branches:
 
 Code Flow and Branches
 ######################

--- a/doc/development_process/communication.rst
+++ b/doc/development_process/communication.rst
@@ -1,14 +1,16 @@
-
+.. _communication-and-collaboration:
 
 Communication and Collaboration
 ################################
 
-The `Zephyr project mailing lists <https://lists.zephyrproject.org/g/main/subgroups>`_ are used as the primary
-communication tool by project members, contributors, and the community. The
-mailing list is open for topics related to the project and should be used for
-collaboration among team members working on the same feature or subsystem or for
-discussing project direction and daily development of the code base. In general,
-bug reports and issues should be entered and tracked in the bug tracking system
-(`GitHub Issues <https://github.com/zephyrproject-rtos/zephyr/issues>`_) and not broadcasted to the mailing list, the same applies to
-code reviews. Code should be submitted to GitHub using the appropriate tools.
-
+The `Zephyr project mailing lists
+<https://lists.zephyrproject.org/g/main/subgroups>`_ are used as the
+primary communication tool by project members, contributors, and the
+community. The mailing list is open for topics related to the project
+and should be used for collaboration among team members working on the
+same feature or subsystem or for discussing project direction and daily
+development of the code base. In general, bug reports and issues should
+be entered and tracked in the bug tracking system (`GitHub Issues
+<https://github.com/zephyrproject-rtos/zephyr/issues>`_) and not
+broadcasted to the mailing list, the same applies to code reviews. Code
+should be submitted to GitHub using the appropriate tools.

--- a/doc/development_process/dev_env_and_tools.rst
+++ b/doc/development_process/dev_env_and_tools.rst
@@ -1,4 +1,4 @@
-
+.. _dev-environment-and-tools:
 
 Development Environment and Tools
 #################################

--- a/doc/development_process/documentation.rst
+++ b/doc/development_process/documentation.rst
@@ -1,3 +1,4 @@
+.. _code-documentation:
 
 Code Documentation
 ###################
@@ -40,7 +41,7 @@ Test Code
 **********
 
 The Zephyr project uses several test methodologies, the most common being the
-:ref:`Ztest framework <testing>`. The documentation of tests should only be done
+:ref:`Ztest framework <test-framework>`. Test documentation should only be done
 on the entry test functions (usually prefixed with test\_) and those that are
 called directly by the Ztest framework. Those tests are going to appear in test
 reports and using their name and identifier is the best way to identify them and

--- a/doc/development_process/proposals.rst
+++ b/doc/development_process/proposals.rst
@@ -1,3 +1,4 @@
+.. _feature-tracking:
 
 Feature Tracking
 #################

--- a/doc/guides/bluetooth/gap-pics.rst
+++ b/doc/guides/bluetooth/gap-pics.rst
@@ -1,3 +1,5 @@
+.. _gap-pics:
+
 GAP PICS
 ********
 

--- a/doc/guides/bluetooth/gatt-pics.rst
+++ b/doc/guides/bluetooth/gatt-pics.rst
@@ -1,3 +1,5 @@
+.. _gatt-pics:
+
 GATT PICS
 =========
 

--- a/doc/guides/bluetooth/l2cap-pics.rst
+++ b/doc/guides/bluetooth/l2cap-pics.rst
@@ -1,3 +1,5 @@
+.. _l2cap-pics:
+
 L2CAP PICS
 ==========
 

--- a/doc/guides/bluetooth/rfcomm-pics.rst
+++ b/doc/guides/bluetooth/rfcomm-pics.rst
@@ -1,3 +1,5 @@
+.. _rfcomm-pics:
+
 RFCOMM PICS
 ***********
 

--- a/doc/guides/bluetooth/sm-pics.rst
+++ b/doc/guides/bluetooth/sm-pics.rst
@@ -1,3 +1,5 @@
+.. _sm-pics:
+
 SM PICS
 *******
 

--- a/doc/guides/test/index.rst
+++ b/doc/guides/test/index.rst
@@ -1,3 +1,5 @@
+.. _testing:
+
 Testing
 #######
 

--- a/doc/guides/test/ztest.rst
+++ b/doc/guides/test/ztest.rst
@@ -1,4 +1,4 @@
-.. _testing:
+.. _test-framework:
 
 Test Framework
 ###############

--- a/doc/guides/west/planned.rst
+++ b/doc/guides/west/planned.rst
@@ -1,3 +1,5 @@
+.. _west-planned-features:
+
 Planned Features
 ================
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,6 +1,8 @@
 ..
     Zephyr Project documentation master file
 
+.. _zephyr-home:
+
 Zephyr Project Documentation
 ############################
 


### PR DESCRIPTION
All docs should have a label at the top that would
permit cross-document linking via ``:ref:`labelname` ``.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>