### PR TITLE
doc: add orphaned crypto docs

### DIFF
--- a/doc/guides/crypto/index.rst
+++ b/doc/guides/crypto/index.rst
@@ -1,4 +1,4 @@
-:orphan:
+.. _cryptography:
 
 Cryptography
 ############
@@ -11,6 +11,6 @@ The following crypto libraries have been included:
 
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    tinycrypt.rst

--- a/doc/guides/crypto/tinycrypt.rst
+++ b/doc/guides/crypto/tinycrypt.rst
@@ -2,7 +2,6 @@
 
 TinyCrypt Cryptographic Library
 ###############################
-Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
 
 Overview
 ********

--- a/doc/guides/index.rst
+++ b/doc/guides/index.rst
@@ -11,6 +11,7 @@ User and Developer Guides
    ../README.rst
    coccinelle.rst
    code-relocation.rst
+   crypto/index
    debugging/index
    device_mgmt/index
    device_mgmt/dfu


### PR DESCRIPTION
tinycrypt documentation wasn't included in the table of contents so add
it into the guides section.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>