### PR TITLE
kernel: Print thread name in fatal error handler

### DIFF
--- a/arch/arc/core/fatal.c
+++ b/arch/arc/core/fatal.c
@@ -66,7 +66,10 @@ void z_NanoFatalErrorHandler(unsigned int reason, const NANO_ESF *pEsf)
 		break;
 	}
 
-	printk("Current thread ID = %p\n",  k_current_get());
+	printk("Current thread ID = %p (%s)\n",
+	       k_current_get(),
+	       IS_ENABLED(CONFIG_THREAD_NAME) ?
+				k_thread_name_get(k_current_get()) : "?");
 
 	if (reason == _NANO_ERR_HW_EXCEPTION) {
 		printk("Faulting instruction address = 0x%lx\n",

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -77,9 +77,12 @@ void z_NanoFatalErrorHandler(unsigned int reason,
 		printk("**** Unknown Fatal Error %d! ****\n", reason);
 		break;
 	}
-	printk("Current thread ID = %p\n"
+	printk("Current thread ID = %p (%s)\n"
 	       "Faulting instruction address = 0x%x\n",
-	       k_current_get(), pEsf->pc);
+	       k_current_get(),
+	       IS_ENABLED(CONFIG_THREAD_NAME) ?
+				k_thread_name_get(k_current_get()) : "?",
+	       pEsf->pc);
 
 	/*
 	 * Now that the error has been reported, call the user implemented

--- a/arch/nios2/core/fatal.c
+++ b/arch/nios2/core/fatal.c
@@ -88,13 +88,16 @@ FUNC_NORETURN void z_NanoFatalErrorHandler(unsigned int reason,
 	 * We may want to introduce a config option to save and dump all
 	 * registers, at the expense of some stack space.
 	 */
-	printk("Current thread ID: %p\n"
+	printk("Current thread ID: %p (%s)\n"
 	       "Faulting instruction: 0x%x\n"
 	       "  r1: 0x%x  r2: 0x%x  r3: 0x%x  r4: 0x%x\n"
 	       "  r5: 0x%x  r6: 0x%x  r7: 0x%x  r8: 0x%x\n"
 	       "  r9: 0x%x r10: 0x%x r11: 0x%x r12: 0x%x\n"
 	       " r13: 0x%x r14: 0x%x r15: 0x%x  ra: 0x%x\n"
-	       "estatus: %x\n", k_current_get(), esf->instr - 4,
+	       "estatus: %x\n", k_current_get(),
+	       IS_ENABLED(CONFIG_THREAD_NAME) ?
+				k_thread_name_get(k_current_get()) : "?",
+	       esf->instr - 4,
 	       esf->r1, esf->r2, esf->r3, esf->r4,
 	       esf->r5, esf->r6, esf->r7, esf->r8,
 	       esf->r9, esf->r10, esf->r11, esf->r12,

--- a/arch/riscv32/core/fatal.c
+++ b/arch/riscv32/core/fatal.c
@@ -88,7 +88,7 @@ FUNC_NORETURN void z_NanoFatalErrorHandler(unsigned int reason,
 		break;
 	}
 
-	printk("Current thread ID = %p\n"
+	printk("Current thread ID = %p (%s)\n"
 	       "Faulting instruction address = 0x%x\n"
 	       "  ra: 0x%x  gp: 0x%x  tp: 0x%x  t0: 0x%x\n"
 	       "  t1: 0x%x  t2: 0x%x  t3: 0x%x  t4: 0x%x\n"
@@ -96,6 +96,8 @@ FUNC_NORETURN void z_NanoFatalErrorHandler(unsigned int reason,
 	       "  a2: 0x%x  a3: 0x%x  a4: 0x%x  a5: 0x%x\n"
 	       "  a6: 0x%x  a7: 0x%x\n",
 	       k_current_get(),
+	       IS_ENABLED(CONFIG_THREAD_NAME) ?
+				k_thread_name_get(k_current_get()) : "?",
 	       (esf->mepc == 0xdeadbaad) ? 0xdeadbaad : esf->mepc,
 	       esf->ra, esf->gp, esf->tp, esf->t0,
 	       esf->t1, esf->t2, esf->t3, esf->t4,

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -184,7 +184,7 @@ FUNC_NORETURN void z_NanoFatalErrorHandler(unsigned int reason,
 		break;
 	}
 
-	printk("Current thread ID = %p\n"
+	printk("Current thread ID = %p (%s)\n"
 	       "eax: 0x%08x, ebx: 0x%08x, ecx: 0x%08x, edx: 0x%08x\n"
 	       "esi: 0x%08x, edi: 0x%08x, ebp: 0x%08x, esp: 0x%08x\n"
 	       "eflags: 0x%08x cs: 0x%04x\n"
@@ -193,6 +193,8 @@ FUNC_NORETURN void z_NanoFatalErrorHandler(unsigned int reason,
 #endif
 	       "eip: 0x%08x\n",
 	       k_current_get(),
+	       IS_ENABLED(CONFIG_THREAD_NAME) ?
+				k_thread_name_get(k_current_get()) : "?",
 	       pEsf->eax, pEsf->ebx, pEsf->ecx, pEsf->edx,
 	       pEsf->esi, pEsf->edi, pEsf->ebp, pEsf->esp,
 	       pEsf->eflags, pEsf->cs & 0xFFFFU, pEsf->eip);

--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -80,9 +80,11 @@ XTENSA_ERR_NORET void z_NanoFatalErrorHandler(unsigned int reason,
 		printk("**** Unknown Fatal Error %d! ****\n", reason);
 		break;
 	}
-	printk("Current thread ID = %p\n"
+	printk("Current thread ID = %p (%s)\n"
 	       "Faulting instruction address = 0x%x\n",
 	       k_current_get(),
+	       IS_ENABLED(CONFIG_THREAD_NAME) ?
+				k_thread_name_get(k_current_get()) : "?",
 	       pEsf->pc);
 
 	/*


### PR DESCRIPTION
If the thread name support is enabled, then try to print the
name in fatal error handler. This can help to pin point the
thread that caused the fault.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>