### PR TITLE
drivers: counter: fix to allow LSE clock source for not F4 SoC

### DIFF
--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -36,7 +36,7 @@ if !SOC_SERIES_STM32F4X
 
 choice COUNTER_RTC_STM32_LSE_DRIVE
 	prompt "LSE oscillator drive capability"
-	depends on RTC_STM32_CLOCK_LSE
+	depends on COUNTER_RTC_STM32_CLOCK_LSE
 
 config COUNTER_RTC_STM32_LSE_DRIVE_LOW
 	bool "Low"

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -275,10 +275,14 @@ static int rtc_stm32_init(struct device *dev)
 
 #else /* CONFIG_COUNTER_RTC_STM32_CLOCK_LSE */
 
-#ifndef(CONFIG_SOC_SERIES_STM32F4X)
+#if !defined(CONFIG_SOC_SERIES_STM32F4X) &&	\
+	!defined(CONFIG_SOC_SERIES_STM32F2X)
+
 	LL_RCC_LSE_SetDriveCapability(
 		CONFIG_COUNTER_RTC_STM32_LSE_DRIVE_STRENGTH);
-#endif /* !CONFIG_SOC_SERIES_STM32F4X */
+
+#endif /* !CONFIG_SOC_SERIES_STM32F4X && !CONFIG_SOC_SERIES_STM32F2X */
+
 	LL_RCC_LSE_Enable();
 
 	/* Wait until LSE is ready */


### PR DESCRIPTION
Fixes the STM32 counter driver when LSE is the clock source and SoC is not F4.

Fixes #15354