### PR TITLE
usb: class: dfu: fix dfu mode with composite device enabled

### DIFF
--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -140,9 +140,15 @@ struct dev_dfu_mode_descriptor dfu_mode_desc = {
 		.bLength = sizeof(struct usb_device_descriptor),
 		.bDescriptorType = USB_DEVICE_DESC,
 		.bcdUSB = sys_cpu_to_le16(USB_2_0),
+#ifdef CONFIG_USB_COMPOSITE_DEVICE
+		.bDeviceClass = MISC_CLASS,
+		.bDeviceSubClass = 0x02,
+		.bDeviceProtocol = 0x01,
+#else
 		.bDeviceClass = 0,
 		.bDeviceSubClass = 0,
 		.bDeviceProtocol = 0,
+#endif
 		.bMaxPacketSize0 = MAX_PACKET_SIZE0,
 		.idVendor = sys_cpu_to_le16((u16_t)CONFIG_USB_DEVICE_VID),
 		.idProduct = sys_cpu_to_le16((u16_t)CONFIG_USB_DEVICE_PID),


### PR DESCRIPTION
When the device enters DFU mode, the descriptor set is switched
to DFU-specific. Device descriptor must match the previous one,
otherwise dfu-util will report an error. DFU descriptor was
missing a variant for composite device mode (currently composite
device mode has a special implementation in ifdefs - to be
refactored in future) causing a mismatch - composite before
DFU_DETACH and non-composite after.

Fixes #14882

Signed-off-by: Paweł Zadrożniak <pawel.zadrozniak@nordicsemi.no>