### PR TITLE
Bluetooth: Mesh: Fix qualification test MESH/SR/HM/CFS/BV-02-C

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -280,6 +280,7 @@ struct bt_mesh_model_pub {
 	u8_t  period;       /**< Publish Period. */
 	u8_t  period_div:4, /**< Divisor for the Period. */
 	      cred:1,       /**< Friendship Credentials Flag. */
+	      fast_period:1,/**< Use FastPeriodDivisor */
 	      count:3;      /**< Retransmissions left. */
 
 	u32_t period_start; /**< Start of the current period. */

--- a/subsys/bluetooth/host/mesh/access.c
+++ b/subsys/bluetooth/host/mesh/access.c
@@ -98,7 +98,11 @@ s32_t bt_mesh_model_pub_period_get(struct bt_mesh_model *mod)
 		CODE_UNREACHABLE;
 	}
 
-	return period >> mod->pub->period_div;
+	if (mod->pub->fast_period) {
+		return period >> mod->pub->period_div;
+	} else {
+		return period;
+	}
 }
 
 static s32_t next_period(struct bt_mesh_model *mod)

--- a/subsys/bluetooth/host/mesh/health_srv.c
+++ b/subsys/bluetooth/host/mesh/health_srv.c
@@ -342,8 +342,10 @@ static int health_pub_update(struct bt_mesh_model *mod)
 	BT_DBG("");
 
 	count = health_get_current(mod, pub->msg);
-	if (!count) {
-		pub->period_div = 0U;
+	if (count) {
+		pub->fast_period = 1U;
+	} else {
+		pub->fast_period = 0U;
 	}
 
 	return 0;
@@ -356,6 +358,13 @@ int bt_mesh_fault_update(struct bt_mesh_elem *elem)
 	mod = bt_mesh_model_find(elem, BT_MESH_MODEL_ID_HEALTH_SRV);
 	if (!mod) {
 		return -EINVAL;
+	}
+
+	/* Let periodic publishing, if enabled, take care of sending the
+	 * Health Current Status.
+	 */
+	if (bt_mesh_model_pub_period_get(mod)) {
+		return 0;
 	}
 
 	health_pub_update(mod);


### PR DESCRIPTION
The commit 8d0ef1eb8503c45f029802545eb6f14b863463f8 attempted to fix
test case MESH/SR/HM/CFS/BV-02-C, however inadvertently ended up
introducing a hidden bug. This bug was unearthed thanks to commit
686f5c79cff51d268d93ab87102a04578d3062aa. We have to keep always track
of the FastPeriodDivisor state whether we're using it (faults > 0) or
not (faults == 0). Introduce a boolean field to the model publication
that's used to indicate whether the FastPeriodDivisor should be
applied or not, instead of zeroing the divisor when there are no
faults (this would cause wrong behavior when faults appear again).

Additionally, the PTS seems to require that we wait until the end of
the existing period before sending the next Health Current Status,
rather than sending it immediately when the fault count changes.

Fixes #15365

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>