### PR TITLE
Add boards and drivers to 1.14 release notes

### DIFF
--- a/doc/releases/release-notes-1.14.rst
+++ b/doc/releases/release-notes-1.14.rst
@@ -146,6 +146,56 @@ Drivers and Sensors
 
 * nRF5 flash driver support UICR operations
 
+* adc: Overhauled adc_dw and renamed it to adc_intel_quark_se_c1000_ss
+* can: Add socket CAN support
+* clock_control: Added RV32M1 driver
+* console: Removed telnet driver
+* counter: Converted rtc drivers to new counter API
+* display: Introduced mcux elcdif shim driver
+* display: Added support for ssd16xx monochrome controllers
+* display: Added support for ssd1608, gde029a1, and hink e0154a05
+* display: Added SDL based display emulation driver
+* display: Added SSD1673 EPD controller driver
+* display: Added SSD1306 display controller driver
+* entropy: Added Atmel SAM entropy generator driver
+* flash: Added driver for STM32F7x series
+* flash: Added flash driver support for Atmel SAM E70
+* flash: Added a generic spi nor flash driver
+* flash: Added flash driver for SiLabs Gecko SoCs
+* ethernet: Extended mcux driver for i.mx rt socs
+* ethernet: Added driver for Intel PRO/1000 Ethernet controller
+* gpio: Added RV32M1 driver
+* hwinfo: Added new hwinfo API and drivers
+* i2c: Added mcux lpi2c shim driver
+* i2c: Removed deprecated i2c_atmel_sam3 driver
+* i2c: Introduced Silabs i2c shim driver
+* i2s: Added support for I2S stm32
+* ipm: Added IMX IPM driver for i.MX socs
+* interrupt_controller: Added RV32M1 driver
+* interrupt_controller: Add support for STM32F302x8 EXTI_LINES
+* neural_net: Added Intel GNA driver
+* pinmux: Added RV32M1 driver
+* pinmux: add pinmux driver for Intel S1000
+* pinmux: Add support for STM32F302x8
+* pwm: Added SiFive PWM driver
+* pwm: Added Atmel SAM PWM driver
+* sensor: Added lis2ds12, lis2dw12, lis2mdl, and lsm303dlhc drivers
+* sensor: Added ms5837 driver
+* sensor: Added support for Nordic QDEC
+* sensor: Converted drivers to use device tree
+* serial: Added RV32M1 driver
+* serial: Add new asynchronous UART API
+* serial: Added support for ARM PL011 UART
+* serial: Introduced Silabs leuart shim serial driver
+* serial: Adapted gecko uart driver for Silabs EFM32HG
+* timer: Added/reworked Xtensa, RISV-V, NRF, HPET, and Arm systick drivers
+* usb: Added native_posix USB driver
+* usb: Added usb device driver for Atmel SAM E70 family
+* usb: Added nRF52840 USBD driver
+* watchdog: Converted drivers to new API
+* wifi: simplelink: Implemented setsockopt() for TLS offload
+* wifi: Added inventek es-WiFi driver
+
 Networking
 **********
 

--- a/doc/releases/release-notes-1.14.rst
+++ b/doc/releases/release-notes-1.14.rst
@@ -91,9 +91,42 @@ Boards & SoC Support
 
 * Added support for the following Arm boards:
 
-  * v2m_musca
-  * nrf9160_pca10090
+  * 96b_stm32_sensor_mez
+  * b_l072z_lrwan1
+  * bl652_dvk
+  * bl654_dvk
+  * cy8ckit_062_wifi_bt_m0
+  * cy8ckit_062_wifi_bt_m4
+  * efm32hg_slstk3400a
+  * efm32pg_stk3402a
+  * efr32mg_sltb004a
+  * mimxrt1020_evk
+  * mimxrt1060_evk
+  * mimxrt1064_evk
+  * nrf52832_mdk
+  * nrf52840_blip
+  * nrf52840_mdk
+  * nrf52840_papyr
   * nrf52840_pca10090
+  * nrf9160_pca10090
+  * nucleo_f302r8
+  * nucleo_f746zg
+  * nucleo_f756zg
+  * nucleo_l496zg
+  * nucleo_l4r5zi
+  * particle_argon
+  * particle_xenon
+  * v2m_musca
+
+* Added support for the following RISC-V boards:
+
+  * rv32m1_vega
+
+* Added support for the following shield boards:
+
+  * frdm_kw41z
+  * x_nucleo_iks01a1
+  * x_nucleo_iks01a2
 
 .. _BabbleSim:
    https://BabbleSim.github.io


### PR DESCRIPTION
- Adds all the new Arm, RISC-V, and shield boards to the 1.14 release
notes.
- Adds new and significantly modified drivers to the 1.14 release notes.