### PR TITLE
enable PCB antenna on Particle boards

### DIFF
--- a/boards/arm/particle_argon/CMakeLists.txt
+++ b/boards/arm/particle_argon/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(board.c)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/particle_argon/Kconfig.defconfig
+++ b/boards/arm/particle_argon/Kconfig.defconfig
@@ -23,6 +23,13 @@ config I2C_0
 
 endif # I2C
 
+if SPI
+
+config SPI_2
+       default y
+
+endif # SPI
+
 if USB
 
 config USB_NRF52840

--- a/boards/arm/particle_argon/board.c
+++ b/boards/arm/particle_argon/board.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Peter Bigot Consulting, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <init.h>
+
+#define SKY_UFLn_PIN DT_SKYWORKS_SKY13351_SKY13351_VCTL1_GPIOS_PIN
+#define SKY_PCBn_PIN DT_SKYWORKS_SKY13351_SKY13351_VCTL2_GPIOS_PIN
+
+static inline void external_antenna(bool on)
+{
+	if (on) {
+		NRF_P0->OUTSET = (1U << SKY_PCBn_PIN);
+		NRF_P0->OUTCLR = (1U << SKY_UFLn_PIN);
+	} else {
+		NRF_P0->OUTCLR = (1U << SKY_PCBn_PIN);
+		NRF_P0->OUTSET = (1U << SKY_UFLn_PIN);
+	}
+}
+
+static int board_particle_argon_init(struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	/*
+	 * On power-up the SKY13351 is left uncontrolled, so neither
+	 * PCB nor external antenna is selected.  Select the PCB
+	 * antenna.
+	 */
+	NRF_P0->PIN_CNF[SKY_PCBn_PIN] =
+		(GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos) |
+		(GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+	NRF_P0->PIN_CNF[SKY_UFLn_PIN] =
+		(GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos) |
+		(GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+	external_antenna(false);
+
+	return 0;
+}
+
+SYS_INIT(board_particle_argon_init, PRE_KERNEL_1,
+	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/boards/arm/particle_argon/particle_argon.dts
+++ b/boards/arm/particle_argon/particle_argon.dts
@@ -13,6 +13,12 @@
 	model = "Particle Argon";
 	compatible = "particle,argon", "particle,feather",
 		"nordic,nrf52840-qiaa", "nordic,nrf52840";
+
+	sky13351 {
+		compatible = "skyworks,sky13351";
+		vctl1-gpios = <&gpio0 25 0>;
+		vctl2-gpios = <&gpio0 2 0>;
+	};
 };
 
 &uart1 { /* ESP32 */

--- a/boards/arm/particle_boron/CMakeLists.txt
+++ b/boards/arm/particle_boron/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(board.c)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/particle_boron/Kconfig.defconfig
+++ b/boards/arm/particle_boron/Kconfig.defconfig
@@ -23,6 +23,13 @@ config I2C_0
 
 endif # I2C
 
+if SPI
+
+config SPI_2
+       default y
+
+endif # SPI
+
 if USB
 
 config USB_NRF52840

--- a/boards/arm/particle_boron/board.c
+++ b/boards/arm/particle_boron/board.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Peter Bigot Consulting, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <init.h>
+
+#define SKY_UFLn_PIN 7
+
+static inline void external_antenna(bool on)
+{
+	if (on) {
+		NRF_P0->OUTCLR = (1U << SKY_UFLn_PIN);
+	} else {
+		NRF_P0->OUTSET = (1U << SKY_UFLn_PIN);
+	}
+}
+
+static int board_particle_boron_init(struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	/*
+	 * On power-up the SKY13351 is left uncontrolled, so neither
+	 * PCB nor external antenna is selected.  Select the PCB
+	 * antenna.
+	 */
+	NRF_P0->PIN_CNF[SKY_UFLn_PIN] =
+		(GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos) |
+		(GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+	external_antenna(false);
+
+	return 0;
+}
+
+SYS_INIT(board_particle_boron_init, PRE_KERNEL_1,
+	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/boards/arm/particle_xenon/CMakeLists.txt
+++ b/boards/arm/particle_xenon/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(board.c)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/particle_xenon/Kconfig.defconfig
+++ b/boards/arm/particle_xenon/Kconfig.defconfig
@@ -24,6 +24,13 @@ config I2C_0
 
 endif # I2C
 
+if SPI
+
+config SPI_2
+       default y
+
+endif # SPI
+
 if USB
 
 config USB_NRF52840

--- a/boards/arm/particle_xenon/board.c
+++ b/boards/arm/particle_xenon/board.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Peter Bigot Consulting, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <init.h>
+
+#define SKY_UFLn_PIN DT_SKYWORKS_SKY13351_SKY13351_VCTL1_GPIOS_PIN
+#define SKY_PCBn_PIN DT_SKYWORKS_SKY13351_SKY13351_VCTL2_GPIOS_PIN
+
+static inline void external_antenna(bool on)
+{
+	if (on) {
+		NRF_P0->OUTSET = (1U << SKY_PCBn_PIN);
+		NRF_P0->OUTCLR = (1U << SKY_UFLn_PIN);
+	} else {
+		NRF_P0->OUTCLR = (1U << SKY_PCBn_PIN);
+		NRF_P0->OUTSET = (1U << SKY_UFLn_PIN);
+	}
+}
+
+static int board_particle_xenon_init(struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	/*
+	 * On power-up the SKY13351 is left uncontrolled, so neither
+	 * PCB nor external antenna is selected.  Select the PCB
+	 * antenna.
+	 */
+	NRF_P0->PIN_CNF[SKY_UFLn_PIN] =
+		(GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos) |
+		(GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+	NRF_P0->PIN_CNF[SKY_PCBn_PIN] =
+		(GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos) |
+		(GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+	external_antenna(false);
+
+	return 0;
+}
+
+SYS_INIT(board_particle_xenon_init, PRE_KERNEL_1,
+	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/boards/arm/particle_xenon/particle_xenon.dts
+++ b/boards/arm/particle_xenon/particle_xenon.dts
@@ -13,4 +13,10 @@
 	model = "Particle Xenon";
 	compatible = "particle,xenon", "particle,feather",
 		"nordic,nrf52840-qiaa", "nordic,nrf52840";
+
+	sky13351 {
+		compatible = "skyworks,sky13351";
+		vctl1-gpios = <&gpio0 24 0>;
+		vctl2-gpios = <&gpio0 25 0>;
+	};
 };

--- a/dts/bindings/misc/skyworks,sky13351.yaml
+++ b/dts/bindings/misc/skyworks,sky13351.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2019, Peter Bigot Consulting, LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: Skyworks SKY13351 GaAs FET I/C switch
+version: 0.1
+
+description: >
+    This binding allows control of the output selectors of the SKY13351
+    SPDT switch.
+
+properties:
+    compatible:
+        constraint: "skyworks,sky13351"
+    vctl1-gpios:
+        type: compound
+        category: required
+        description: VCTL1 pin
+        generation: define, use-prop-name
+    vctl2-gpios:
+        type: compound
+        category: required
+        description: VCTL2 pin
+        generation: define, use-prop-name


### PR DESCRIPTION
Without this initialization code no antenna is selected, and Bluetooth signal quality is at least 7 dBi less than it could be.

Also added a patch for the unrelated test failure.

Closes #14123 
Closes #15374 