### PR TITLE
genrest: Include all parents in menu paths

### DIFF
--- a/doc/scripts/genrest.py
+++ b/doc/scripts/genrest.py
@@ -353,18 +353,8 @@ def kconfig_definition_rst(sc):
     def menu_path(node):
         path = ""
 
-        while True:
-            # This excludes indented submenus created in the menuconfig
-            # interface when items depend on the preceding symbol.
-            # is_menuconfig means anything that would be shown as a separate
-            # menu (not indented): proper 'menu's, menuconfig symbols, and
-            # choices.
+        while node.parent is not node.kconfig.top_node:
             node = node.parent
-            while not node.is_menuconfig:
-                node = node.parent
-
-            if node is node.kconfig.top_node:
-                break
 
             # Promptless choices can show up as parents, e.g. when people
             # define choices in multiple locations to add symbols. Use


### PR DESCRIPTION
Previously, symbols not defined with `menuconfig` with children weren't
listed in the children's menu paths. It was deliberate, but it's
probably an anti-feature in retrospect, because it can make it harder to
find stuff by following the menu path.

Don't try to be clever and just list all the parent nodes in the menu
path.