### PR TITLE
cmake: zephyr_cc_option(-fmacro-prefix-map=${ZEPHYR_BASE}=.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,14 @@ zephyr_cc_option(-Werror=implicit-int)
 # Prohibit void pointer arithmetic. Illegal in C99
 zephyr_cc_option(-Wpointer-arith)
 
+# If the compiler supports it, strip the ${ZEPHYR_BASE} prefix from the
+# __FILE__ macro used in __ASSERT*, in the
+# .noinit."/home/joe/zephyr/fu/bar.c" section names and in any
+# application code. This saves some memory, stops leaking user locations
+# in binaries, makes failure logs more deterministic and most
+# importantly makes builds more deterministic
+zephyr_cc_option(-fmacro-prefix-map=${ZEPHYR_BASE}=.)
+
 # Prohibit date/time macros, which would make the build non-deterministic
 # cc-option(-Werror=date-time)
 


### PR DESCRIPTION
If the compiler supports it, strip the ${ZEPHYR_BASE} prefix from the
``__FILE__`` macro used in __ASSERT* macros, in the
.noinit."/home/joe/zephyr/fu/bar.c" section names and in any application
code. This saves some memory, stops leaking user locations in binaries,
makes failure logs more deterministic and most importantly makes builds
more deterministic.

- .noinit section names now look like this in objdump -h:
```
 17 .noinit."./kernel/init.c".2 00001100  00000000  ...

 18 .noinit."./kernel/init.c".1 00001200  00000000  ...

 19 .noinit."./kernel/init.c".3 00001800  00000000  ...
```
- The output of __ASSERT* macros now looks like this:
```
  ASSERTION FAIL [0] @ ./samples/hello_world/src/main.c:13
    The world comes crashing down
  ***** Kernel Panic! *****
  Current thread ID = 0x00400040
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>