### PR TITLE
doc: Add to 1.14 release notes zephyr modules

### DIFF
--- a/doc/releases/release-notes-1.14.rst
+++ b/doc/releases/release-notes-1.14.rst
@@ -387,6 +387,9 @@ Build and Infrastructure
   to be configured based on DeviceTree information.
 * Automatically change the KCONFIG_ROOT when the application directory
   has a Kconfig file.
+* Added :ref:`west <west>` tool for multiple repository management
+* Added support for :ref:`Zephyr modules <ext-projs>`
+* Build system ``flash`` and ``debug`` targets now require west
 
 Libraries / Subsystems
 ***********************


### PR DESCRIPTION
Added information to release notes about Zephyr modules which allow for
splitting ext/ into multi-repo instead using Zephyr modules.

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>