### PR TITLE
riscv32: move memory definitions to dts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -164,6 +164,7 @@
 /dts/bindings/*/openisa*                  @MaureenHelm
 /dts/bindings/*/st*                       @erwango
 /dts/bindings/sensor/ams*                 @alexanderwachter
+/dts/bindings/*/sifive*                   @mateusz-holenko @kgugala @pgielda @nategraff-sifive
 /ext/fs/                                  @nashif @wentongwu
 /ext/hal/atmel/asf/sam/include/same70*/   @aurel32
 /ext/hal/atmel/asf/sam0/include/samr21/   @benpicco

--- a/boards/riscv32/hifive1/hifive1.dts
+++ b/boards/riscv32/hifive1/hifive1.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,flash = &flash0;
 	};
 
 	leds {
@@ -52,6 +53,15 @@
 &spi0 {
 	status = "ok";
 	clock-frequency = <16000000>;
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+	reg = <0x10014000 0x1000 0x20400000 0xc00000>;
+	flash0: flash@0 {
+		compatible = "issi,is25lp128", "jedec,spi-nor";
+		jedec-id = <0x96 0x60 0x18>;
+		reg = <0>;
+	};
 };
 
 &spi1 {

--- a/boards/riscv32/hifive1/hifive1.dts
+++ b/boards/riscv32/hifive1/hifive1.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,sram = &dtim;
 		zephyr,flash = &flash0;
 	};
 

--- a/boards/riscv32/m2gl025_miv/m2gl025_miv.dts
+++ b/boards/riscv32/m2gl025_miv/m2gl025_miv.dts
@@ -17,6 +17,8 @@
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,flash = &flash0;
+		zephyr,sram = &sram0;
 	};
 };
 

--- a/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
+++ b/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
@@ -12,6 +12,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &dtim;
+		zephyr,flash = &flash0;
 	};
 
 };
@@ -32,5 +33,14 @@
 
 &spi0 {
 	status = "ok";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+	reg = <0x10014000 0x1000 0x20400000 0xc00000>;
+	flash0: flash@0 {
+		compatible = "issi,is25lp128", "jedec,spi-nor";
+		jedec-id = <0x96 0x60 0x18>;
+		reg = <0>;
+	};
 };
 

--- a/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
+++ b/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
@@ -11,6 +11,7 @@
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,sram = &dtim;
 	};
 
 };

--- a/dts/bindings/sram/sifive,dtim0.yaml
+++ b/dts/bindings/sram/sifive,dtim0.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2019 Antmicro <www.antmicro.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: Data Tightly-Integrated Memory
+version: 0.1
+
+description: >
+    This bindings describes the SiFive Data Tightly-Integrated Memory
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "sifive,dtim0"
+      generation: define
+
+    reg:
+      type: array
+      description: mmio register space
+      generation: define
+      category: required
+
+...

--- a/dts/riscv32/microsemi-miv.dtsi
+++ b/dts/riscv32/microsemi-miv.dtsi
@@ -31,6 +31,17 @@
 		compatible = "microsemi,miv-soc", "simple-bus";
 		ranges;
 
+		flash0: flash@80000000 {
+			compatible = "soc-nv-flash";
+			reg = <0x80000000 0x40000>;
+		};
+
+		sram0: memory@80040000 {
+			device_type = "memory";
+			compatible = "mmio-sram";
+			reg = <0x80040000 0x40000>;
+		};
+
 		plic: interrupt-controller@40000000 {
 			#interrupt-cells = <1>;
 			compatible = "riscv,plic0";

--- a/include/arch/riscv32/common/linker.ld
+++ b/include/arch/riscv32/common/linker.ld
@@ -36,9 +36,9 @@
 MEMORY
 {
 #ifdef CONFIG_XIP
-    ROM (rx)  : ORIGIN = CONFIG_RISCV_ROM_BASE_ADDR, LENGTH = CONFIG_RISCV_ROM_SIZE
+    ROM (rx)  : ORIGIN = DT_FLASH_BASE_ADDRESS, LENGTH = KB(DT_FLASH_SIZE)
 #endif
-    RAM (rwx) : ORIGIN = CONFIG_RISCV_RAM_BASE_ADDR, LENGTH = RISCV_RAM_SIZE
+    RAM (rwx) : ORIGIN = DT_SRAM_BASE_ADDRESS, LENGTH = KB(DT_SRAM_SIZE)
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }

--- a/soc/riscv32/riscv-privilege/miv/Kconfig.defconfig.series
+++ b/soc/riscv32/riscv-privilege/miv/Kconfig.defconfig.series
@@ -30,20 +30,4 @@ config XIP
 	bool
 	default y
 
-config RISCV_ROM_BASE_ADDR
-	hex
-	default 0x80000000
-
-config RISCV_ROM_SIZE
-	hex
-	default 0x40000
-
-config RISCV_RAM_BASE_ADDR
-	hex
-	default	0x80040000
-
-config RISCV_RAM_SIZE
-	hex
-	default 0x40000
-
 endif # SOC_SERIES_RISCV32_MIV

--- a/soc/riscv32/riscv-privilege/miv/soc.h
+++ b/soc/riscv32/riscv-privilege/miv/soc.h
@@ -5,6 +5,7 @@
 #define __RISCV32_MIV_SOC_H_
 
 #include <soc_common.h>
+#include <generated_dts_board.h>
 
 /* GPIO Interrupts */
 #define MIV_GPIO_0_IRQ           (RISCV_MAX_GENERIC_IRQ + 0)
@@ -54,7 +55,7 @@
 #define RISCV_MTIMECMP_BASE          0x44004000
 
 /* lib-c hooks required RAM defined variables */
-#define RISCV_RAM_BASE               CONFIG_RISCV_RAM_BASE_ADDR
-#define RISCV_RAM_SIZE               CONFIG_RISCV_RAM_SIZE
+#define RISCV_RAM_BASE               DT_SRAM_BASE_ADDRESS
+#define RISCV_RAM_SIZE               KB(DT_SRAM_SIZE)
 
 #endif /* __RISCV32_MIV_SOC_H_ */

--- a/soc/riscv32/riscv-privilege/sifive-freedom/Kconfig.defconfig.series
+++ b/soc/riscv32/riscv-privilege/sifive-freedom/Kconfig.defconfig.series
@@ -30,20 +30,4 @@ config XIP
 	bool
 	default y
 
-config RISCV_ROM_BASE_ADDR
-	hex
-	default 0x20400000
-
-config RISCV_ROM_SIZE
-	hex
-	default 0xC00000
-
-config RISCV_RAM_BASE_ADDR
-	hex
-	default	0x80000000
-
-config RISCV_RAM_SIZE
-	hex
-	default 0x4000
-
 endif # SOC_SERIES_RISCV32_SIFIVE_FREEDOM

--- a/soc/riscv32/riscv-privilege/sifive-freedom/soc.h
+++ b/soc/riscv32/riscv-privilege/sifive-freedom/soc.h
@@ -12,6 +12,7 @@
 #define __RISCV32_SIFIVE_FREEDOM_SOC_H_
 
 #include <soc_common.h>
+#include <generated_dts_board.h>
 
 /* PINMUX Configuration */
 #define SIFIVE_PINMUX_0_BASE_ADDR     (DT_SIFIVE_GPIO_0_BASE_ADDR + 0x38)
@@ -40,7 +41,7 @@
 #define SIFIVE_BACKUP_REG_BASE	     0x10000080
 
 /* lib-c hooks required RAM defined variables */
-#define RISCV_RAM_BASE               CONFIG_RISCV_RAM_BASE_ADDR
-#define RISCV_RAM_SIZE               CONFIG_RISCV_RAM_SIZE
+#define RISCV_RAM_BASE               DT_SRAM_BASE_ADDRESS
+#define RISCV_RAM_SIZE               KB(DT_SRAM_SIZE)
 
 #endif /* __RISCV32_SIFIVE_FREEDOM_SOC_H_ */


### PR DESCRIPTION
Currently memory for riscv32 is defined in Kconfig. Move those
definitions to DTS and use defines generated from it in linker script.

Signed-off-by: Filip Kokosinski <fkokosinski@internships.antmicro.com>
Signed-off-by: Mateusz Holenko <mholenko@antmicro.com>