### PR TITLE
doc: relnotes: 1.14 nrf 802.15.4 radio driver update

### DIFF
--- a/doc/releases/release-notes-1.14.rst
+++ b/doc/releases/release-notes-1.14.rst
@@ -389,6 +389,7 @@ HALs
 ****
 
 * ext/hal/nordic: Updated nrfx to version 1.6.2
+* ext/hal/nordic: Updated nrf ieee802154 radio driver to version 1.2.3
 
 Documentation
 *************


### PR DESCRIPTION
nRF 802.15.4 radio driver was updated, hence mention it in release
notes.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>