### PR TITLE
doc: guides: porting: fix nRF51 Cortex-m core

### DIFF
--- a/doc/guides/porting/board_porting.rst
+++ b/doc/guides/porting/board_porting.rst
@@ -59,7 +59,7 @@ Hierarchy Example
 +------------+-----------+--------------+------------+--------------+---------+
 |SOC Family  |NXP Kinetis|Nordic NRF5   |Nordic NRF5 |Quark         |Quark    |
 +------------+-----------+--------------+------------+--------------+---------+
-|CPU Core    |Cortex-M4  |Cortex-M4     |Cortex-M0+  |Lakemont      |Lakemont |
+|CPU Core    |Cortex-M4  |Cortex-M4     |Cortex-M0   |Lakemont      |Lakemont |
 +------------+-----------+--------------+------------+--------------+---------+
 |Architecture|ARM        |ARM           |ARM         |x86           |x86      |
 +------------+-----------+--------------+------------+--------------+---------+


### PR DESCRIPTION
nRF51xx SoCs have an ARM Cortex-M0 core, not an ARM Cortex-M0+.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>