### PR TITLE
soc: intel_s1000: change cached regions to write-through

### DIFF
--- a/soc/xtensa/intel_s1000/linker.ld
+++ b/soc/xtensa/intel_s1000/linker.ld
@@ -166,15 +166,15 @@ _memmap_cacheattr_bp_allvalid = 0x22222222;
  * 0x40000000 - 0x5FFFFFFF (bit  8 - 11) : No access
  * 0x60000000 - 0x7FFFFFFF (bit 12 - 15) : No access
  * 0x80000000 - 0x9FFFFFFF (bit 16 - 19) : Bypass cache
- * 0xA0000000 - 0xBFFFFFFF (bit 20 - 23) : Cached, write-back
+ * 0xA0000000 - 0xBFFFFFFF (bit 20 - 23) : Cached, write-through
  * 0xC0000000 - 0xDFFFFFFF (bit 24 - 27) : Bypass cache
- * 0xE0000000 - 0xFFFFFFFF (bit 28 - 31) : Cached, write-back
+ * 0xE0000000 - 0xFFFFFFFF (bit 28 - 31) : Cached, write-through
  *
  * Note that this is both for instruction and data caches,
  * as cacheattr_set macro sets them both to the same set of
  * attributes.
  */
-_memmap_cacheattr_intel_s1000 = 0x4242fff2;
+_memmap_cacheattr_intel_s1000 = 0x1212fff2;
 
 PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_intel_s1000);
 SECTIONS


### PR DESCRIPTION
The i2s_cavs.c driver manipulates cache lines before commencing
any DMA transfers. With write-back cache, if the DMA receive
buffer is not aligned to the cache lines, the data around
the buffer will be invalidated and may never written to memory.
Since the driver takes an external memory slab as buffer and
there is no easy way to force cache line alignment on
the application side, set the cached region to write-through
to avoid potential issue.

Fixes #13223

Signed-off-by: Daniel Leung <daniel.leung@intel.com>