### PR TITLE
Bluetooth: GATT: Add support for Read Using Characteristic UUID

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -971,9 +971,14 @@ typedef u8_t (*bt_gatt_read_func_t)(struct bt_conn *conn, u8_t err,
  *  @param handle_count If equals to 1 single.handle and single.offset
  *                      are used.  If >1 Read Multiple Characteristic
  *                      Values is performed and handles are used.
+ *                      If equals to 0 by_uuid is used for Read Using
+ *                      Characteristic UUID.
  *  @param handle Attribute handle
  *  @param offset Attribute data offset
  *  @param handles Handles to read in Read Multiple Characteristic Values
+ *  @param start_handle First requested handle number
+ *  @param end_handle Last requested handle number
+ *  @param uuid 2 or 16 octet UUID
  */
 struct bt_gatt_read_params {
 	struct bt_att_req _req;
@@ -985,6 +990,11 @@ struct bt_gatt_read_params {
 			u16_t offset;
 		} single;
 		u16_t *handles;
+		struct {
+			u16_t start_handle;
+			u16_t end_handle;
+			struct bt_uuid *uuid;
+		} by_uuid;
 	};
 };
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2426,6 +2426,34 @@ static int gatt_read_blob(struct bt_conn *conn,
 	return gatt_send(conn, buf, gatt_read_rsp, params, NULL);
 }
 
+static int gatt_read_uuid(struct bt_conn *conn,
+			  struct bt_gatt_read_params *params)
+{
+	struct net_buf *buf;
+	struct bt_att_read_type_req *req;
+
+	buf = bt_att_create_pdu(conn, BT_ATT_OP_READ_TYPE_REQ, sizeof(*req));
+	if (!buf) {
+		return -ENOMEM;
+	}
+
+	req = net_buf_add(buf, sizeof(*req));
+	req->start_handle = sys_cpu_to_le16(params->by_uuid.start_handle);
+	req->end_handle = sys_cpu_to_le16(params->by_uuid.end_handle);
+
+	if (params->by_uuid.uuid->type == BT_UUID_TYPE_16) {
+		net_buf_add_le16(buf, BT_UUID_16(params->by_uuid.uuid)->val);
+	} else {
+		net_buf_add_mem(buf, BT_UUID_128(params->by_uuid.uuid)->val, 16);
+	}
+
+	BT_DBG("start_handle 0x%04x end_handle 0x%04x uuid %s",
+		params->by_uuid.start_handle, params->by_uuid.end_handle,
+		bt_uuid_str(params->by_uuid.uuid));
+
+	return gatt_send(conn, buf, gatt_read_rsp, params, NULL);
+}
+
 #if defined(CONFIG_BT_GATT_READ_MULTIPLE)
 static void gatt_read_multiple_rsp(struct bt_conn *conn, u8_t err,
 				   const void *pdu, u16_t length,
@@ -2479,10 +2507,13 @@ int bt_gatt_read(struct bt_conn *conn, struct bt_gatt_read_params *params)
 
 	__ASSERT(conn, "invalid parameters\n");
 	__ASSERT(params && params->func, "invalid parameters\n");
-	__ASSERT(params->handle_count, "invalid parameters\n");
 
 	if (conn->state != BT_CONN_CONNECTED) {
 		return -ENOTCONN;
+	}
+
+	if (params->handle_count == 0) {
+		return gatt_read_uuid(conn, params);
 	}
 
 	if (params->handle_count > 1) {

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -277,6 +277,45 @@ static int cmd_mread(const struct shell *shell, size_t argc, char *argv[])
 	return err;
 }
 
+static int cmd_read_uuid(const struct shell *shell, size_t argc, char *argv[])
+{
+	int err;
+
+	if (!default_conn) {
+		shell_error(shell, "Not connected");
+		return -ENOEXEC;
+	}
+
+	read_params.func = read_func;
+	read_params.handle_count = 0;
+	read_params.by_uuid.start_handle = 0x0001;
+	read_params.by_uuid.end_handle = 0xffff;
+
+	if (argc > 1) {
+		uuid.val = strtoul(argv[1], NULL, 16);
+		if (uuid.val) {
+			read_params.by_uuid.uuid = &uuid.uuid;
+		}
+	}
+
+	if (argc > 2) {
+		read_params.by_uuid.start_handle = strtoul(argv[2], NULL, 16);
+		if (argc > 3) {
+			read_params.by_uuid.end_handle = strtoul(argv[3],
+								 NULL, 16);
+		}
+	}
+
+	err = bt_gatt_read(default_conn, &read_params);
+	if (err) {
+		shell_error(shell, "Read failed (err %d)", err);
+	} else {
+		shell_print(shell, "Read pending");
+	}
+
+	return err;
+}
+
 static struct bt_gatt_write_params write_params;
 static u8_t gatt_write_buf[CHAR_SIZE_MAX];
 
@@ -780,6 +819,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(gatt_cmds,
 		      "[UUID] [start handle] [end handle]", cmd_discover, 1, 3),
 	SHELL_CMD_ARG(exchange-mtu, NULL, HELP_NONE, cmd_exchange_mtu, 1, 0),
 	SHELL_CMD_ARG(read, NULL, "<handle> [offset]", cmd_read, 2, 1),
+	SHELL_CMD_ARG(read-uuid, NULL, "<UUID> [start handle] [end handle]",
+		      cmd_read_uuid, 2, 2),
 	SHELL_CMD_ARG(read-multiple, NULL, "<handle 1> <handle 2> ...",
 		      cmd_mread, 2, -1),
 	SHELL_CMD_ARG(signed-write, NULL, "<handle> <data> [length] [repeat]",

--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -457,6 +457,16 @@ struct gatt_read_rp {
 	u8_t data[0];
 } __packed;
 
+#define GATT_READ_UUID			0x12
+struct gatt_read_uuid_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t start_handle;
+	u16_t end_handle;
+	u8_t uuid_length;
+	u8_t uuid[0];
+} __packed;
+
 #define GATT_READ_LONG			0x13
 struct gatt_read_long_cmd {
 	u8_t address_type;


### PR DESCRIPTION
This patch adds support for Read Using Characteristic UUID which is one
of the procedure to read the characteristic value especially when the
client only knows the characteristic UUID and does not know the handle
of the characteristic.

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>