### PR TITLE
net: lwm2m: fix automatic notification frequency

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3792,7 +3792,7 @@ static int lwm2m_engine_service(void)
 		 * - current timestamp > last_timestamp + max_period_sec
 		 */
 		} else if (timestamp > obs->last_timestamp +
-				K_SECONDS(obs->min_period_sec)) {
+				K_SECONDS(obs->max_period_sec)) {
 			obs->last_timestamp = k_uptime_get();
 			generate_notify_message(obs, false);
 		}


### PR DESCRIPTION
This fixes the issue where observations are automatically reported using
the minimum period instead of the maximum. This causes notifications to
be sent more frequently than configured when the resource does not change.

Signed-off-by: Pieterjan Camerlynck <pieterjan.camerlynck@gmail.com>