### PR TITLE
drivers: clock_control: nrf: add SYNTH LFCLK clock source

### DIFF
--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -33,6 +33,10 @@ config CLOCK_CONTROL_NRF_K32SRC_RC
 config CLOCK_CONTROL_NRF_K32SRC_XTAL
 	bool "Crystal Oscillator"
 
+config CLOCK_CONTROL_NRF_K32SRC_SYNTH
+	depends on !SOC_SERIES_NRF91X
+	bool "Synthesized from HFCLK"
+
 endchoice
 
 config CLOCK_CONTROL_NRF_K32SRC_BLOCKING

--- a/include/drivers/clock_control/nrf_clock_control.h
+++ b/include/drivers/clock_control/nrf_clock_control.h
@@ -10,6 +10,7 @@
 #if defined(CONFIG_USB) && defined(CONFIG_SOC_NRF52840)
 #include <device.h>
 #endif
+#include <nrf_clock.h>
 
 /* TODO: move all these to clock_control.h ? */
 
@@ -19,6 +20,9 @@
 #endif
 #ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL
 #define CLOCK_CONTROL_NRF_K32SRC 1
+#endif
+#ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_SYNTH
+#define CLOCK_CONTROL_NRF_K32SRC NRF_CLOCK_LFCLK_Synth
 #endif
 
 /* Define 32KHz clock accuracy */


### PR DESCRIPTION
Added option to have LFCLK synthesized from HFCLK. It is not low
power but ensures constant relation between HFCLK and LFCLK and
might be useful in certain scenarios (e.g. testing).

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>