### PR TITLE
drivers: clock_control: nrf: Fix lfclk source settings for nrf9160

### DIFF
--- a/include/drivers/clock_control/nrf_clock_control.h
+++ b/include/drivers/clock_control/nrf_clock_control.h
@@ -10,15 +10,16 @@
 #if defined(CONFIG_USB) && defined(CONFIG_SOC_NRF52840)
 #include <device.h>
 #endif
+#include <nrf_clock.h>
 
 /* TODO: move all these to clock_control.h ? */
 
 /* Define 32KHz clock source */
 #ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC
-#define CLOCK_CONTROL_NRF_K32SRC 0
+#define CLOCK_CONTROL_NRF_K32SRC NRF_CLOCK_LFCLK_RC
 #endif
 #ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL
-#define CLOCK_CONTROL_NRF_K32SRC 1
+#define CLOCK_CONTROL_NRF_K32SRC NRF_CLOCK_LFCLK_Xtal
 #endif
 
 /* Define 32KHz clock accuracy */


### PR DESCRIPTION
Aligned lfclk source values for nrf9160.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>