### PR TITLE
tests: exclude colibri_imx7d_m4 & warp7_m4 due to flash size

### DIFF
--- a/tests/lib/mem_alloc/testcase.yaml
+++ b/tests/lib/mem_alloc/testcase.yaml
@@ -6,5 +6,6 @@ tests:
   libraries.libc.newlib:
     extra_args: CONF_FILE=prj_newlib.conf
     arch_exclude: posix
+    platform_exclude: colibri_imx7d_m4 warp7_m4
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     tags: clib newlib userspace

--- a/tests/misc/test_build/testcase.yaml
+++ b/tests/misc/test_build/testcase.yaml
@@ -8,6 +8,7 @@ tests:
     extra_args: CONF_FILE=newlib.conf
     tags: build_test
     filter: TOOLCHAIN_HAS_NEWLIB == 1
+    platform_exclude: colibri_imx7d_m4 warp7_m4
   test_runtime_nmi:
     arch_whitelist: arm
     build_only: true


### PR DESCRIPTION
The colibri_imx7d_m4 and warp7_m4 boards fail to build the following
tests due to flash size:
- tests/misc/test_build/test_newlib
- tests/lib/mem_alloc/libraries.libc.newlib

We just explicitly exclude these platforms for now since other platforms
with smaller flashes are able to build these tests.

Fixes #15465

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>