### PR TITLE
drivers: watchdog: disable atmel watchdog on boot [REVERTME]

### DIFF
--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -25,6 +25,7 @@ endif # HAS_DTS_WDT
 
 config WDT_DISABLE_AT_BOOT
 	bool "Disable at boot"
+	default y
 	help
 	  Disable watchdog at Zephyr system startup.
 


### PR DESCRIPTION
Disable watchdog on Atmel boards to deal with a timing issue causing the
board to reboot continously.

Workaround for #15411.