### PR TITLE
linker: fix the bug in common-rom.ld

### DIFF
--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -41,7 +41,7 @@
 		__object_access_start = .;
 		KEEP(*(".object_access.*"))
 		__object_access_end = .;
-	}
+	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif
 
 	SECTION_PROLOGUE(app_shmem_regions,,)


### PR DESCRIPTION
.object_access.* sections should be with

GROUP_LINK_IN(ROMABLE_REGION) as other sections in
common-rom.ld

Fixes #15481

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>