### PR TITLE
bluetooth: conn: Fix bt_gatt_connected call

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -138,7 +138,9 @@ static void notify_connected(struct bt_conn *conn)
 		}
 	}
 
-	bt_gatt_connected(conn);
+	if (!conn->err) {
+		bt_gatt_connected(conn);
+	}
 }
 
 static void notify_disconnected(struct bt_conn *conn)


### PR DESCRIPTION
bt_gatt_connected should be only called, when there is no connection error. 
Change fixes problem with receiving notifications before connection.

Fixes #13316