### PR TITLE
Drivers: ARM: SysTick: investigate errors and apply fixes

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -68,7 +68,7 @@ static u32_t elapsed(void)
 	 * VAL was "about to overflow".
 	 */
 	ctrl1 = SysTick->CTRL;
-	val = SysTick->VAL & COUNTER_MAX;
+	val = SysTick->VAL;
 	ctrl2 = SysTick->CTRL;
 
 	overflow_cyc += (ctrl1 & SysTick_CTRL_COUNTFLAG_Msk) ? last_load : 0;

--- a/tests/kernel/early_sleep/testcase.yaml
+++ b/tests/kernel/early_sleep/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.sleep:
-    tags: sleep
+    tags: kernel sleep

--- a/tests/kernel/sleep/testcase.yaml
+++ b/tests/kernel/sleep/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.timing:
-    tags: kernel
+    tags: kernel sleep


### PR DESCRIPTION
Several fixes/improvements in the SysTick timer driver, including
- correct calculation of elapsed cycles in the ISR
- avoiding starving the ISR if timeouts gets re-scheduled all the time
- reworking the way elapsed cycles are calculated

Added some documentation in functions and variables, too.

The fixes are closing several ARM timer-related bugs:

Fixes #18591 which is an instance of #20585
Fixes #20445 which is also an instance of #20585 
Also incorporates the SysTick modification related to #20939

### Mandatory Testing in Hardware

(Purpose is to get confidence on the driver changes.)

**All** platforms run with the **SysTick** timer driver.

| Cortex-M Platform | Test latest PR 633f18d4df89b4e6c06aa75605de721e947c9272 | kernel (76) | benchmark (5) | timer (1) | critical (1) | usermode (54)|
| :---         | :---: |  :---:      |    :---: |  :---: | :---: | :---: |      
| arduino_due (M3, 84MHz) | **yes** | :white_check_mark: | ✔️ | ✔️ | ✔️ | ➖ |
| atsamd21_xpro (M0+, 48MHz)   | **yes** | ✔️ | ✔️ |  ✔️  |  ✔️ | ✔️ |
| atsamr21_xpro (M0+, 48MHz)   | **yes** | ✔️ | ✔️ |  ✔️  |  ✔️ | ⚪️ |
| efr32mg_sltb004a (M4, 38.4 MHz) | **yes** | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
| frdm_k64f (M4, 120MHz) | **yes** | ✔️ | ✔️ | ✔️ | ✔️  | ✔️ |
| lpcxpresso54114_m4 (M4, 48MHz ) | **yes** | ✔️ | ✔️ | ✔️ | ✔️ | ➖ |
| mimxrt1015_evk (M7, 500MHz) | **yes** | ✅ | ✔️ | ✔️ | ✔️ | ➖ |
| mimxrt1064_evk (M7, 600MHz) | **yes** |  ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
| nRF52_pca10040 (M4, 64MHz)  | **yes** | ✔️ | ✔️ | ✔️ | ✔️ | ➖ |
| nRF5340_dk_nrf5340_app (M33, 128MHz) | **yes** | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
| nRF9160_pca10090 (M33, 64MHz)  | **yes** | ✔️❔1 | ✔️ | ✔️ | ✔️ | ✔️ |
| nucleo_g071rb (M0+, 64MHz) | **yes** | ✅ | ✔️ | ✔️ | ✔️ | ➖ |
| nucleo_l476rg (M4, 80 MHz) |**yes**| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
| sam_e70_xplained (M7, 300MHz) | **yes**| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |

Legend

- ⚪️ tests not supported
- ➖ not tested
- ✔️tests passed
- :white_check_mark: selected tests (common, context, fifo, queue, shed, sleep, tickless, timer) passed
- :ballot_box_with_check: tests passed (sporadic failures observed)
- ❔1: timer/timer_api fails sporadically with zephyr_sdk. test passes with gnuarmemb toolchain
- :x: tests failed