### PR TITLE
soc: arm: mcimx6x_m4: Floating Point support required by default

### DIFF
--- a/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
+++ b/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
@@ -11,6 +11,9 @@ config SOC
 	string
 	default "mcimx6x"
 
+config FLOAT
+	default y
+
 if CLOCK_CONTROL
 
 config CLOCK_CONTROL_IMX_CCM


### PR DESCRIPTION
The HAL/SDK code for imx6sx utilizes floating point support in
CCM_ANALOG_GetPllFreq function which is utilized by drivers to determine
clock information.  As such we should enable hardware FP support by
default so we don't get pure soft-float emulation and pull in a bunch of
extra code.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>