### PR TITLE
make nRF SoC timer source configurable

### DIFF
--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -113,6 +113,7 @@ config NRF_RTC_TIMER
 	default y
 	depends on CLOCK_CONTROL
 	depends on SOC_COMPATIBLE_NRF
+	depends on RTC_AS_TIMER
 	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the nRF Real Time

--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -18,4 +18,24 @@ config SOC_FAMILY
 source "soc/arm/nordic_nrf/Kconfig.peripherals"
 source "soc/arm/nordic_nrf/*/Kconfig.soc"
 
+config NRF_HAS_SYSTICK
+	bool
+	# omit prompt to signify a "hidden" option
+
+choice
+prompt "Timer Source Selection"
+default RTC_AS_TIMER
+
+config RTC_AS_TIMER
+	bool "nRF Real Time Counter (NRF_RTC1)"
+	select NRF_RTC_TIMER
+
+config SYSTICK_AS_TIMER
+	bool "Cortex-M SYSTICK timer"
+	depends on NRF_HAS_SYSTICK
+	select CPU_HAS_SYSTICK
+	select CORTEX_M_SYSTICK
+
+endchoice
+
 endif # SOC_FAMILY_NRF

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.series
@@ -10,7 +10,6 @@ config  SOC_SERIES_NRF51X
 	bool "Nordic Semiconductor nRF51 series MCU"
 	select CPU_CORTEX_M0
 	select SOC_FAMILY_NRF
-	select NRF_RTC_TIMER
 	select CLOCK_CONTROL
 	select HAS_SYS_POWER_STATE_DEEP_SLEEP_1
 	select XIP

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -14,7 +14,8 @@ config SOC_SERIES
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
-	default 32768
+	default 32768 if RTC_AS_TIMER
+	default 64000000 if SYSTICK_AS_TIMER
 
 config SYS_POWER_MANAGEMENT
 	default y

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.series
@@ -11,7 +11,7 @@ config  SOC_SERIES_NRF52X
 	select CPU_CORTEX_M4
 	select CPU_HAS_ARM_MPU
 	select SOC_FAMILY_NRF
-	select NRF_RTC_TIMER
+	select NRF_HAS_SYSTICK
 	select CLOCK_CONTROL
 	select HAS_SYS_POWER_STATE_DEEP_SLEEP_1
 	select XIP

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.series
@@ -14,7 +14,8 @@ config SOC_SERIES
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
-	default 32768
+	default 32768 if RTC_AS_TIMER
+	default 64000000 if SYSTICK_AS_TIMER
 
 config ARCH_HAS_CUSTOM_BUSY_WAIT
 	default y

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.series
@@ -13,7 +13,7 @@ config  SOC_SERIES_NRF91X
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select SOC_FAMILY_NRF
-	select NRF_RTC_TIMER
+	select NRF_HAS_SYSTICK
 	select CLOCK_CONTROL
 	select HAS_SYS_POWER_STATE_DEEP_SLEEP_1
 	select XIP


### PR DESCRIPTION
Only nRF51 does not implement the systick timer.
User can use systick to drive the timer in nRF52/nRF91 series if
they need higher resolution timer.