### PR TITLE
boards: arm: particle_*: default-enable SPI_2 when SPI enabled

### DIFF
--- a/boards/arm/particle_argon/Kconfig.defconfig
+++ b/boards/arm/particle_argon/Kconfig.defconfig
@@ -23,6 +23,13 @@ config I2C_0
 
 endif # I2C
 
+if SPI
+
+config SPI_2
+       default y
+
+endif # SPI
+
 if USB
 
 config USB_NRF52840

--- a/boards/arm/particle_boron/Kconfig.defconfig
+++ b/boards/arm/particle_boron/Kconfig.defconfig
@@ -23,6 +23,13 @@ config I2C_0
 
 endif # I2C
 
+if SPI
+
+config SPI_2
+       default y
+
+endif # SPI
+
 if USB
 
 config USB_NRF52840

--- a/boards/arm/particle_xenon/Kconfig.defconfig
+++ b/boards/arm/particle_xenon/Kconfig.defconfig
@@ -24,6 +24,13 @@ config I2C_0
 
 endif # I2C
 
+if SPI
+
+config SPI_2
+       default y
+
+endif # SPI
+
 if USB
 
 config USB_NRF52840


### PR DESCRIPTION
SPI is not normally enabled, but some tests assume that there's a device
available.  Conditionally enable SPI_2 which is associated with the
on-board flash.

Closes #15374

Signed-off-by: Peter A. Bigot <pab@pabigot.com>