### PR TITLE
drivers: flash: w25q: erase operations must be erase-size aligned

### DIFF
--- a/drivers/flash/spi_flash_w25qxxdv.c
+++ b/drivers/flash/spi_flash_w25qxxdv.c
@@ -342,17 +342,19 @@ static int spi_flash_wb_erase(struct device *dev, off_t offset, size_t size)
 			break;
 		}
 
-		if (size_remaining >= W25QXXDV_BLOCK_SIZE) {
+		if ((size_remaining >= W25QXXDV_BLOCK_SIZE) &&
+			((new_offset & (W25QXXDV_BLOCK_SIZE - 1)) == 0)) {
 			ret = spi_flash_wb_erase_internal(dev, new_offset,
-							  W25QXXDV_BLOCK_SIZE);
+							W25QXXDV_BLOCK_SIZE);
 			new_offset += W25QXXDV_BLOCK_SIZE;
 			size_remaining -= W25QXXDV_BLOCK_SIZE;
 			continue;
 		}
 
-		if (size_remaining >= W25QXXDV_BLOCK32K_SIZE) {
+		if ((size_remaining >= W25QXXDV_BLOCK32K_SIZE) &&
+			((new_offset & (W25QXXDV_BLOCK32K_SIZE - 1)) == 0)) {
 			ret = spi_flash_wb_erase_internal(dev, new_offset,
-							  W25QXXDV_BLOCK32K_SIZE);
+							W25QXXDV_BLOCK32K_SIZE);
 			new_offset += W25QXXDV_BLOCK32K_SIZE;
 			size_remaining -= W25QXXDV_BLOCK32K_SIZE;
 			continue;
@@ -360,7 +362,7 @@ static int spi_flash_wb_erase(struct device *dev, off_t offset, size_t size)
 
 		if (size_remaining >= W25QXXDV_SECTOR_SIZE) {
 			ret = spi_flash_wb_erase_internal(dev, new_offset,
-							  W25QXXDV_SECTOR_SIZE);
+							W25QXXDV_SECTOR_SIZE);
 			new_offset += W25QXXDV_SECTOR_SIZE;
 			size_remaining -= W25QXXDV_SECTOR_SIZE;
 			continue;


### PR DESCRIPTION
 - Erase operations must be aligned to the erase-size.
 - Don't need to perform an alignment check on a full erase. The offset
   is not used in this case.
 - Don't need to perform alignment check on a sector sized erase, as
   this alignment is checked on entrance to the function.
 - Removed some whitespace.

Signed-off-by: Ryan C Johnson <ryan.johnson@flex.com>