### PR TITLE
flash_gecko: add support for page layout

### DIFF
--- a/drivers/flash/Kconfig.gecko
+++ b/drivers/flash/Kconfig.gecko
@@ -8,6 +8,7 @@ config SOC_FLASH_GECKO
 	bool "Silicon Labs Gecko flash driver"
 	depends on SOC_FAMILY_EXX32
 	select FLASH_HAS_DRIVER_ENABLED
+	select FLASH_HAS_PAGE_LAYOUT
 	select SOC_GECKO_MSC
 	help
 	  Enable Silicon Labs Gecko series internal flash driver.

--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -159,6 +159,22 @@ static int erase_flash_block(off_t offset, size_t size)
 	return ret;
 }
 
+#if CONFIG_FLASH_PAGE_LAYOUT
+static const struct flash_pages_layout flash_gecko_0_pages_layout = {
+	.pages_count = (CONFIG_FLASH_SIZE * 1024) /
+			DT_SOC_NV_FLASH_0_ERASE_BLOCK_SIZE,
+	.pages_size = DT_SOC_NV_FLASH_0_ERASE_BLOCK_SIZE,
+};
+
+void flash_gecko_page_layout(struct device *dev,
+			     const struct flash_pages_layout **layout,
+			     size_t *layout_size)
+{
+	*layout = &flash_gecko_0_pages_layout;
+	*layout_size = 1;
+}
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+
 static int flash_gecko_init(struct device *dev)
 {
 	struct flash_gecko_data *const dev_data = DEV_DATA(dev);
@@ -180,6 +196,9 @@ static const struct flash_driver_api flash_gecko_driver_api = {
 	.write = flash_gecko_write,
 	.erase = flash_gecko_erase,
 	.write_protection = flash_gecko_write_protection,
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+	.page_layout = flash_gecko_page_layout,
+#endif
 	.write_block_size = DT_SOC_NV_FLASH_0_WRITE_BLOCK_SIZE,
 };
 

--- a/dts/arm/silabs/efm32hg.dtsi
+++ b/dts/arm/silabs/efm32hg.dtsi
@@ -35,6 +35,7 @@
 				compatible = "soc-nv-flash";
 				label = "FLASH_0";
 				write-block-size = <4>;
+				erase-block-size = <1024>;
 			};
 		};
 

--- a/dts/arm/silabs/efm32pg12b.dtsi
+++ b/dts/arm/silabs/efm32pg12b.dtsi
@@ -39,6 +39,7 @@
 				compatible = "soc-nv-flash";
 				label = "FLASH_0";
 				write-block-size = <4>;
+				erase-block-size = <2048>;
 			};
 		};
 

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -35,6 +35,7 @@
 				compatible = "soc-nv-flash";
 				label = "FLASH_0";
 				write-block-size = <4>;
+				erase-block-size = <2048>;
 			};
 		};
 

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -35,6 +35,7 @@
 				compatible = "soc-nv-flash";
 				label = "FLASH_0";
 				write-block-size = <4>;
+				erase-block-size = <2048>;
 			};
 		};
 

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -35,6 +35,7 @@
 				compatible = "soc-nv-flash";
 				label = "FLASH_0";
 				write-block-size = <4>;
+				erase-block-size = <2048>;
 			};
 		};
 


### PR DESCRIPTION
This commit adds support for FLASH_PAGE_LAYOUT Kconfig option in the flash_gecko driver.
