### PR TITLE
Decouple system timer and drivers: Watchdog

### DIFF
--- a/boards/arm/mps2_an385/mps2_an385.dts
+++ b/boards/arm/mps2_an385/mps2_an385.dts
@@ -98,6 +98,7 @@
 
 		wdog0: wdog@40008000 {
 			compatible = "arm,cmsdk-watchdog";
+			clock-frequency = <25000000>;
 			reg = <0x40008000 0x1000>;
 		};
 

--- a/boards/arm/v2m_beetle/v2m_beetle.dts
+++ b/boards/arm/v2m_beetle/v2m_beetle.dts
@@ -76,6 +76,7 @@
 
 		wdog0: wdog@40008000 {
 			compatible = "arm,cmsdk-watchdog";
+			clock-frequency = <24000000>;
 			reg = <0x40008000 0x1000>;
 		};
 

--- a/boards/arm/v2m_musca/v2m_musca-common.dtsi
+++ b/boards/arm/v2m_musca/v2m_musca-common.dtsi
@@ -27,6 +27,7 @@ dtimer0: dtimer@2000 {
 
 wdog0: wdog@81000 {
 	compatible = "arm,cmsdk-watchdog";
+	clock-frequency = <50000000>;
 	reg = <0x81000 0x1000>;
 };
 

--- a/drivers/watchdog/wdog_cmsdk_apb.c
+++ b/drivers/watchdog/wdog_cmsdk_apb.c
@@ -110,7 +110,7 @@ static int wdog_cmsdk_apb_install_timeout(struct device *dev,
 	ARG_UNUSED(dev);
 
 	/* Reload value */
-	reload_s = config->window.max * CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
+	reload_s = config->window.max * DT_ARM_CMSDK_WATCHDOG_0_CLOCK_FREQUENCY;
 	flags = config->flags;
 
 	wdog->load = reload_s;

--- a/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
+++ b/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
@@ -18,4 +18,10 @@ properties:
       description: mmio register space
       generation: define
       category: required
+
+    clock-frequency:
+      type: int
+      category: optional
+      description: Clock frequency the Watchdog peripheral is being driven at
+      generation: define
 ...


### PR DESCRIPTION
During our work in timer area, we found that system clock frequency is used incorrectly in several drivers.
For example, it is used to obtain bus frequency needed to calculate watchdog timeout.
If we select different system timer device, all these calculations become invalid.

This PR fixes the problem by obtaining all needed information directly from the DTS.
Brings us closer to: #15363