### PR TITLE
ci: only build on specified branches

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -48,7 +48,11 @@ build:
         else
           ./scripts/ci/run_ci.sh -s -b ${BRANCH} -r origin -m ${MATRIX_BUILD} -M ${MATRIX_BUILDS};
         fi;
-
+branches:
+  only:
+    - master
+    - v*-branch
+    - topic-*
 integrations:
   notifications:
     - integrationName: slack_integration


### PR DESCRIPTION
Do not start CI on random branches created in the tree.