### PR TITLE
ieee802154_kw41z: Fix build error with SYS_LOG_INFO

### DIFF
--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -445,13 +445,13 @@ static int kw41z_filter(struct device *dev,
 static int kw41z_set_txpower(struct device *dev, s16_t dbm)
 {
 	if (dbm < KW41Z_OUTPUT_POWER_MIN) {
-		SYS_LOG_INF("TX-power %d dBm below min of %d dBm, using %d dBm",
+		LOG_INF("TX-power %d dBm below min of %d dBm, using %d dBm",
 			    dbm,
 			    KW41Z_OUTPUT_POWER_MIN,
 			    KW41Z_OUTPUT_POWER_MIN);
 		dbm = KW41Z_OUTPUT_POWER_MIN;
 	} else if (dbm > KW41Z_OUTPUT_POWER_MAX) {
-		SYS_LOG_INF("TX-power %d dBm above max of %d dBm, using %d dBm",
+		LOG_INF("TX-power %d dBm above max of %d dBm, using %d dBm",
 			    dbm,
 			    KW41Z_OUTPUT_POWER_MAX,
 			    KW41Z_OUTPUT_POWER_MAX);


### PR DESCRIPTION
The following fix:

commit c8b17ec40398cb6b296481af63c9ab607c1c1988
Author: Tobias Aschenbrenner <tobias.aschenbrenner@blik.io>
Date:   Tue Dec 18 14:16:00 2018 +0100

    fix: kw41z: Use correct mapping for dBm

Was using SYS_LOG_INFO and should be using LOG_INFO.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>