### PR TITLE
arch: all: Remove legacy code

### DIFF
--- a/arch/arc/include/kernel_arch_data.h
+++ b/arch/arc/include/kernel_arch_data.h
@@ -162,19 +162,6 @@ struct _callee_saved_stack {
 
 typedef struct _callee_saved_stack _callee_saved_stack_t;
 
-struct _kernel_arch {
-
-	char *rirq_sp; /* regular IRQ stack pointer base */
-
-	/*
-	 * FIRQ stack pointer is installed once in the second bank's SP, so
-	 * there is no need to track it in _kernel.
-	 */
-
-};
-
-typedef struct _kernel_arch _kernel_arch_t;
-
 #endif /* _ASMLANGUAGE */
 
 /* stacks */

--- a/arch/arc/include/kernel_arch_thread.h
+++ b/arch/arc/include/kernel_arch_thread.h
@@ -12,7 +12,6 @@
  *
  *  struct _thread_arch
  *  struct _callee_saved
- *  struct _caller_saved
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -31,15 +30,6 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
-
-struct _caller_saved {
-	/*
-	 * Saved on the stack as part of handling a regular IRQ or by the
-	 * kernel when calling the FIRQ return code.
-	 */
-};
-
-typedef struct _caller_saved _caller_saved_t;
 
 struct _callee_saved {
 	u32_t sp; /* r28 */

--- a/arch/arm/include/kernel_arch_data.h
+++ b/arch/arm/include/kernel_arch_data.h
@@ -55,12 +55,6 @@ typedef struct __esf _esf_t;
 
 #ifndef _ASMLANGUAGE
 
-struct _kernel_arch {
-	/* empty */
-};
-
-typedef struct _kernel_arch _kernel_arch_t;
-
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/arch/arm/include/kernel_arch_thread.h
+++ b/arch/arm/include/kernel_arch_thread.h
@@ -12,8 +12,7 @@
  *
  *  struct _thread_arch
  *  struct _callee_saved
- *  struct _caller_saved
- *
+  *
  * necessary to instantiate instances of struct k_thread.
  */
 
@@ -22,26 +21,6 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
-
-struct _caller_saved {
-	/*
-	 * Unused for Cortex-M, which automatically saves the necessary
-	 * registers in its exception stack frame.
-	 *
-	 * For Cortex-A, this may be:
-	 *
-	 * u32_t a1;       r0
-	 * u32_t a2;       r1
-	 * u32_t a3;       r2
-	 * u32_t a4;       r3
-	 * u32_t ip;       r12
-	 * u32_t lr;       r14
-	 * u32_t pc;       r15
-	 * u32_t xpsr;
-	 */
-};
-
-typedef struct _caller_saved _caller_saved_t;
 
 struct _callee_saved {
 	u32_t v1;  /* r4 */

--- a/arch/nios2/include/kernel_arch_data.h
+++ b/arch/nios2/include/kernel_arch_data.h
@@ -47,12 +47,6 @@ extern "C" {
 
 #ifndef _ASMLANGUAGE
 
-struct _kernel_arch {
-	/* nothing for now */
-};
-
-typedef struct _kernel_arch _kernel_arch_t;
-
 extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
 
 #endif /* _ASMLANGUAGE */

--- a/arch/nios2/include/kernel_arch_thread.h
+++ b/arch/nios2/include/kernel_arch_thread.h
@@ -12,7 +12,6 @@
  *
  *  struct _thread_arch
  *  struct _callee_saved
- *  struct _caller_saved
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -22,15 +21,6 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
-
-struct _caller_saved {
-	/*
-	 * Nothing here, the exception code puts all the caller-saved
-	 * registers onto the stack.
-	 */
-};
-
-typedef struct _caller_saved _caller_saved_t;
 
 struct _callee_saved {
 	/* General purpose callee-saved registers */

--- a/arch/posix/include/kernel_arch_data.h
+++ b/arch/posix/include/kernel_arch_data.h
@@ -27,12 +27,6 @@ extern "C" {
 
 #ifndef _ASMLANGUAGE
 
-struct _kernel_arch {
-	/* empty */
-};
-
-typedef struct _kernel_arch _kernel_arch_t;
-
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/arch/posix/include/kernel_arch_thread.h
+++ b/arch/posix/include/kernel_arch_thread.h
@@ -13,7 +13,6 @@
  *
  *  struct _thread_arch
  *  struct _callee_saved
- *  struct _caller_saved
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -23,13 +22,6 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
-
-struct _caller_saved {
-	/*
-	 * Nothing here
-	 */
-};
-
 
 struct _callee_saved {
 	/* IRQ status before irq_lock() and call to z_swap() */

--- a/arch/riscv32/include/kernel_arch_data.h
+++ b/arch/riscv32/include/kernel_arch_data.h
@@ -31,12 +31,6 @@ extern "C" {
 #include <misc/dlist.h>
 #include <kernel_internal.h>
 
-struct _kernel_arch {
-	/* nothing for now */
-};
-
-typedef struct _kernel_arch _kernel_arch_t;
-
 extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
 
 #endif /* _ASMLANGUAGE */

--- a/arch/riscv32/include/kernel_arch_thread.h
+++ b/arch/riscv32/include/kernel_arch_thread.h
@@ -12,7 +12,6 @@
  *
  *  struct _thread_arch
  *  struct _callee_saved
- *  struct _caller_saved
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -44,15 +43,6 @@ struct _callee_saved {
 	u32_t s11;      /* saved register */
 };
 typedef struct _callee_saved _callee_saved_t;
-
-struct _caller_saved {
-	/*
-	 * Nothing here, the exception code puts all the caller-saved
-	 * registers onto the stack.
-	 */
-};
-
-typedef struct _caller_saved _caller_saved_t;
 
 struct _thread_arch {
 	u32_t swap_return_value; /* Return value of z_swap() */

--- a/arch/x86/include/kernel_arch_data.h
+++ b/arch/x86/include/kernel_arch_data.h
@@ -413,12 +413,6 @@ extern void z_x86_thread_entry_wrapper(k_thread_entry_t entry,
 extern "C" {
 #endif
 
-
-struct _kernel_arch {
-};
-
-typedef struct _kernel_arch _kernel_arch_t;
-
 #ifdef __cplusplus
 }
 #endif

--- a/arch/x86/include/kernel_arch_thread.h
+++ b/arch/x86/include/kernel_arch_thread.h
@@ -12,7 +12,6 @@
  *
  *  struct _thread_arch
  *  struct _callee_saved
- *  struct _caller_saved
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -36,32 +35,6 @@
 
 #ifndef _ASMLANGUAGE
 #include <stdint.h>
-
-/*
- * The following structure defines the set of 'volatile' integer registers.
- * These registers need not be preserved by a called C function.  Given that
- * they are not preserved across function calls, they must be save/restored
- * (along with the struct _caller_saved) when a preemptive context switch
- * occurs.
- */
-
-struct _caller_saved {
-
-	/*
-	 * The volatile registers 'eax', 'ecx' and 'edx' area not included in
-	 * the definition of 'tPreempReg' since the interrupt and exception
-	 * handling routunes use the stack to save and restore the values of
-	 * these registers in order to support interrupt nesting.  The stubs
-	 * do _not_ copy the saved values from the stack into the TCS.
-	 *
-	 * unsigned long eax;
-	 * unsigned long ecx;
-	 * unsigned long edx;
-	 */
-
-};
-
-typedef struct _caller_saved _caller_saved_t;
 
 /*
  * The following structure defines the set of 'non-volatile' integer registers.

--- a/arch/x86_64/include/kernel_arch_data.h
+++ b/arch/x86_64/include/kernel_arch_data.h
@@ -6,6 +6,4 @@
 #ifndef _KERNEL_ARCH_DATA_H
 #define _KERNEL_ARCH_DATA_H
 
-struct _kernel_arch { };
-
 #endif /* _KERNEL_ARCH_DATA_H */

--- a/arch/x86_64/include/kernel_arch_thread.h
+++ b/arch/x86_64/include/kernel_arch_thread.h
@@ -11,7 +11,6 @@
  * Zephyr thread struct.  But we don't need that for this arch.
  */
 
-struct _caller_saved { };
 struct _callee_saved { };
 struct _thread_arch { };
 

--- a/arch/xtensa/core/offsets/offsets.c
+++ b/arch/xtensa/core/offsets/offsets.c
@@ -50,9 +50,6 @@ GEN_OFFSET_SYM(__esf_t, pc);
 /* size of the entire __esf_t structure */
 GEN_ABSOLUTE_SYM(____esf_t_SIZEOF, sizeof(__esf_t));
 
-/* size of the entire preempt registers structure */
-GEN_ABSOLUTE_SYM(__tPreempt_SIZEOF, sizeof(_caller_saved_t));
-
 /* size of the struct k_thread structure without save area for coproc regs */
 GEN_ABSOLUTE_SYM(_K_THREAD_NO_FLOAT_SIZEOF,
 		 sizeof(struct k_thread) - sizeof(tCoopCoprocReg) -

--- a/arch/xtensa/include/kernel_arch_data.h
+++ b/arch/xtensa/include/kernel_arch_data.h
@@ -47,11 +47,6 @@ extern "C" {
 
 typedef struct __esf __esf_t;
 
-struct _kernel_arch {
-};
-
-typedef struct _kernel_arch _kernel_arch_t;
-
 #endif /*! _ASMLANGUAGE && ! __ASSEMBLER__ */
 
 #ifdef CONFIG_USE_SWITCH

--- a/arch/xtensa/include/kernel_arch_thread.h
+++ b/arch/xtensa/include/kernel_arch_thread.h
@@ -12,7 +12,6 @@
  *
  *  struct _thread_arch
  *  struct _callee_saved
- *  struct _caller_saved
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -23,28 +22,6 @@
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
 #include <xtensa_context.h>
-
-/*
- * The following structure defines the set of 'volatile' integer registers.
- * These registers need not be preserved by a called C function.  Given that
- * they are not preserved across function calls, they must be save/restored
- * (along with the struct _caller_saved) when a preemptive context switch
- * occurs.
- */
-
-struct _caller_saved {
-
-	/*
-	 * The volatile registers area not included in the definition of
-	 * 'tPreempReg' since the interrupt stubs (_IntEnt/_IntExit)
-	 * and exception stubs (_ExcEnt/_ExcEnter) use the stack to save and
-	 * restore the values of these registers in order to support interrupt
-	 * nesting.  The stubs do _not_ copy the saved values from the stack
-	 * into the k_thread.
-	 */
-};
-
-typedef struct _caller_saved _caller_saved_t;
 
 /*
  * The following structure defines the set of 'non-volatile' integer registers.

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -514,8 +514,6 @@ struct k_thread {
 	struct _thread_base base;
 
 	/** defined by the architecture, but all archs need these */
-	struct _caller_saved caller_saved;
-	/** defined by the architecture, but all archs need these */
 	struct _callee_saved callee_saved;
 
 	/** static thread init data */

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -36,7 +36,6 @@ GEN_OFFSET_SYM(_kernel_t, idle);
 #endif
 
 GEN_OFFSET_SYM(_kernel_t, ready_q);
-GEN_OFFSET_SYM(_kernel_t, arch);
 
 #ifndef CONFIG_SMP
 GEN_OFFSET_SYM(_ready_q_t, cache);

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -55,7 +55,6 @@ GEN_OFFSET_SYM(_thread_base_t, preempt);
 GEN_OFFSET_SYM(_thread_base_t, swap_data);
 
 GEN_OFFSET_SYM(_thread_t, base);
-GEN_OFFSET_SYM(_thread_t, caller_saved);
 GEN_OFFSET_SYM(_thread_t, callee_saved);
 GEN_OFFSET_SYM(_thread_t, arch);
 

--- a/kernel/include/kernel_structs.h
+++ b/kernel/include/kernel_structs.h
@@ -167,9 +167,6 @@ struct z_kernel {
 #if defined(CONFIG_THREAD_MONITOR)
 	struct k_thread *threads; /* singly linked list of ALL threads */
 #endif
-
-	/* arch-specific part of _kernel */
-	struct _kernel_arch arch;
 };
 
 typedef struct z_kernel _kernel_t;

--- a/subsys/testsuite/ztest/include/kernel_arch_thread.h
+++ b/subsys/testsuite/ztest/include/kernel_arch_thread.h
@@ -12,7 +12,6 @@
  *
  *  struct _thread_arch
  *  struct _callee_saved
- *  struct _caller_saved
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -22,11 +21,6 @@
 #define _kernel_arch_thread__h_
 
 #ifndef _ASMLANGUAGE
-
-struct _caller_saved {
-};
-
-typedef struct _caller_saved _caller_saved_t;
 
 struct _callee_saved {
 };


### PR DESCRIPTION
The struct _kernel_ach exists only because ARC' s port needed it, in
all other ports this was defined as an empty struct. Turns out that
this struct is not required even for ARC anymore, this is a legacy
code from nanokernel time.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>