### PR TITLE
samples: driver: i2c_scanner: correct i2c message length

### DIFF
--- a/samples/drivers/i2c_scanner/src/main.c
+++ b/samples/drivers/i2c_scanner/src/main.c
@@ -38,7 +38,7 @@ void main(void)
 
 		/* Send the address to read from */
 		msgs[0].buf = &dst;
-		msgs[0].len = 0U;
+		msgs[0].len = 1U;
 		msgs[0].flags = I2C_MSG_WRITE | I2C_MSG_STOP;
 
 		if (i2c_transfer(i2c_dev, &msgs[0], 1, i) == 0) {


### PR DESCRIPTION
Some SoC i2c driver doesn't support zero length of I2C message, and they will ignore this transaction if so. Then the sample will fail.

Fixes  #14749 for STM32 and ATSAM boards

Signed-off-by: Aaron Tsui <aaron.tsui@outlook.com>