### PR TITLE
scripts: west: Run pristine.cmake directly

### DIFF
--- a/doc/guides/west/config.rst
+++ b/doc/guides/west/config.rst
@@ -165,14 +165,15 @@ extension commands (found in :file:`scripts/west_commands`).
    * - Option
      - Description
    * - ``build.pristine``
-     - String. Controls the way in which ``west build`` may run the ``pristine``
-       target before building. Can take the following values:
+     - String. Controls the way in which ``west build`` may clean the build
+       folder before building. Can take the following values:
 
-         - ``never`` (default): Never automatically run the ``pristine`` target.
-         - ``auto``:  ``west build`` will automatically run the ``pristine``
-           target before building, if a build system is present and the build
-           will fail otherwise (e.g. the user has specified a different board or
-           application from the one previously used to make the build
+         - ``never`` (default): Never automatically make the build folder
+           pristine.
+         - ``auto``:  ``west build`` will automatically make the build folder
+           pristine before building, if a build system is present and the build
+           would fail otherwise (e.g. the user has specified a different board
+           or application from the one previously used to make the build
            directory).
-         - ``always``: Always run the ``pristine`` target before building, if
+         - ``always``: Always make the build folder pristine before building, if
            a build system is present.


### PR DESCRIPTION
When making a build folder pristine until now we were running the
'pristine' build target. The issue with that is that ninja/make or
whatever build tool is being used might decide to re-run CMake itself if
some of the dependencies have changes. This might trigger an error that
is unfriendly and unnecessary, since the user is explicitly asking for
the build folder to be wiped before starting a fresh build.
To avoid this issue restor to running directly the CMake script that the
'pristine' build target itself uses, so as to make sure that the build
folder is wiped unconditionally regardless of changes made to the tree.
