### PR TITLE
boards: stm32f4_disco: Fix yaml ram size

### DIFF
--- a/boards/arm/stm32f4_disco/stm32f4_disco.yaml
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 320
+ram: 128
 flash: 1024
 supported:
   - pwm


### PR DESCRIPTION
Total RAM is 192, including 64K CCM.

