### PR TITLE
libc: minimal: fix realloc function

### DIFF
--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -102,6 +102,10 @@ void *realloc(void *ptr, size_t requested_size)
 	size_t block_size, total_requested_size;
 	void *new_ptr;
 
+	if (ptr == NULL) {
+		return malloc(requested_size);
+	}
+
 	if (requested_size == 0) {
 		return NULL;
 	}


### PR DESCRIPTION
Excerpt from the manual:

  If ptr is NULL, then the call is equivalent to malloc(size) [...]

Without this commit, such calls end with a BUS FAULT.

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>