### PR TITLE
boards: acrn: remove duplicated Kconfig HAS_DTS

### DIFF
--- a/boards/x86/acrn/Kconfig.board
+++ b/boards/x86/acrn/Kconfig.board
@@ -7,6 +7,5 @@
 config BOARD_ACRN
 	bool "ACRN User OS"
 	depends on SOC_IA32
-	select HAS_DTS
 	select CPU_HAS_FPU if !X86_IAMCU
 	select SET_GDT


### PR DESCRIPTION
We already select HAS_DTS at the arch level for X86 so we don't need to
duplicate it at the board level.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>