### PR TITLE
sanitycheck: Fix an error in scan_path exception

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1767,7 +1767,7 @@ class TestCase:
                 if _subcases:
                     subcases += _subcases
             except ValueError as e:
-                error("%s: can't find: %s", filename, e)
+                error("%s: can't find: %s" % (filename, e))
         return subcases
 
 


### PR DESCRIPTION
The function error expects only one parameter. The excpetion handler in
scan_path was calling this function with multiple parameters instead of
formatting the string.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>