### PR TITLE
ext: segger: update to SystemView v2.52h

### DIFF
--- a/ext/debug/segger/rtt/SEGGER_RTT_printf.c
+++ b/ext/debug/segger/rtt/SEGGER_RTT_printf.c
@@ -3,13 +3,13 @@
 *                        The Embedded Experts                        *
 **********************************************************************
 *                                                                    *
-*            (c) 1995 - 2018 SEGGER Microcontroller GmbH             *
+*            (c) 1995 - 2019 SEGGER Microcontroller GmbH             *
 *                                                                    *
 *       www.segger.com     Support: support@segger.com               *
 *                                                                    *
 **********************************************************************
 *                                                                    *
-*       SEGGER RTT * Real Time Transfer for embedded targets         *
+*       SEGGER SystemView * Real-time application analysis           *
 *                                                                    *
 **********************************************************************
 *                                                                    *
@@ -52,17 +52,17 @@
 *                                                                    *
 **********************************************************************
 *                                                                    *
-*       RTT version: 6.32d                                           *
+*       SystemView version: V2.52h                                    *
 *                                                                    *
 **********************************************************************
 ---------------------------END-OF-HEADER------------------------------
 File    : SEGGER_RTT_printf.c
 Purpose : Replacement for printf to write formatted data via RTT
-Revision: $Rev: 9599 $
+Revision: $Rev: 12360 $
 ----------------------------------------------------------------------
 */
 #include "SEGGER_RTT.h"
-#include <SEGGER_RTT_Conf.h>
+#include "SEGGER_RTT_Conf.h"
 
 /*********************************************************************
 *
@@ -107,7 +107,6 @@ typedef struct {
 *
 **********************************************************************
 */
-int SEGGER_RTT_vprintf(unsigned BufferIndex, const char * sFormat, va_list * pParamList);
 
 /*********************************************************************
 *

--- a/ext/debug/segger/systemview/SEGGER.h
+++ b/ext/debug/segger/systemview/SEGGER.h
@@ -1,9 +1,9 @@
 /*********************************************************************
-*                SEGGER Microcontroller GmbH & Co. KG                *
+*                    SEGGER Microcontroller GmbH                     *
 *                        The Embedded Experts                        *
 **********************************************************************
 *                                                                    *
-*       (c) 2015 - 2017  SEGGER Microcontroller GmbH & Co. KG        *
+*            (c) 1995 - 2019 SEGGER Microcontroller GmbH             *
 *                                                                    *
 *       www.segger.com     Support: support@segger.com               *
 *                                                                    *
@@ -31,7 +31,7 @@
 *   disclaimer in the documentation and/or other materials provided  *
 *   with the distribution.                                           *
 *                                                                    *
-* o Neither the name of SEGGER Microcontroller GmbH & Co. KG         *
+* o Neither the name of SEGGER Microcontroller GmbH         *
 *   nor the names of its contributors may be used to endorse or      *
 *   promote products derived from this software without specific     *
 *   prior written permission.                                        *
@@ -52,18 +52,16 @@
 *                                                                    *
 **********************************************************************
 *                                                                    *
-*       SystemView version: V2.42                                    *
+*       SystemView version: V2.52h                                    *
 *                                                                    *
 **********************************************************************
-----------------------------------------------------------------------
-File    : SEGGER.h
-Purpose : Global types etc & general purpose utility functions
----------------------------END-OF-HEADER------------------------------
+-------------------------- END-OF-HEADER -----------------------------
 */
 
 #ifndef SEGGER_H            // Guard against multiple inclusion
 #define SEGGER_H
 
+#include <stdarg.h>
 #include "Global.h"         // Type definitions: U8, U16, U32, I8, I16, I32
 
 #if defined(__cplusplus)
@@ -84,8 +82,20 @@ extern "C" {     /* Make sure we have C-declarations in C++ programs */
     // Force inlining without cost checking.
     //
     #define INLINE  __forceinline
+  #elif (defined(__ZEPHYR__))
+    #include <toolchain.h>
   #else
-    #if (defined(__ICCARM__) || defined(__CC_ARM) || defined(__GNUC__) || defined(__RX) || defined(__ICCRX__))
+    #if (defined(__GNUC__))
+      //
+      // Force inlining with GCC
+      //
+      #define INLINE inline __attribute__((always_inline))
+    #elif (defined(__CC_ARM))
+      //
+      // Force inlining with ARMCC (Keil)
+      //
+      #define INLINE  __inline
+    #elif (defined(__ICCARM__) || defined(__RX) || defined(__ICCRX__))
       //
       // Other known compilers.
       //
@@ -110,6 +120,24 @@ extern "C" {     /* Make sure we have C-declarations in C++ programs */
 #define SEGGER_MIN(a,b)            (((a) < (b)) ? (a) : (b))
 #define SEGGER_MAX(a,b)            (((a) > (b)) ? (a) : (b))
 
+#ifndef   SEGGER_USE_PARA                   // Some compiler complain about unused parameters.
+  #define SEGGER_USE_PARA(Para) (void)Para  // This works for most compilers.
+#endif
+
+/*********************************************************************
+*
+*       Defines
+*
+**********************************************************************
+*/
+
+#define SEGGER_PRINTF_FLAG_ADJLEFT    (1 << 0)
+#define SEGGER_PRINTF_FLAG_SIGNFORCE  (1 << 1)
+#define SEGGER_PRINTF_FLAG_SIGNSPACE  (1 << 2)
+#define SEGGER_PRINTF_FLAG_PRECEED    (1 << 3)
+#define SEGGER_PRINTF_FLAG_ZEROPAD    (1 << 4)
+#define SEGGER_PRINTF_FLAG_NEGATIVE   (1 << 5)
+
 /*********************************************************************
 *
 *       Types
@@ -118,17 +146,39 @@ extern "C" {     /* Make sure we have C-declarations in C++ programs */
 */
 
 typedef struct {
-  char *pBuffer;
+  char* pBuffer;
   int   BufferSize;
   int   Cnt;
 } SEGGER_BUFFER_DESC;
 
 typedef struct {
-  int  CacheLineSize;                                // 0: No Cache. Most Systems such as ARM9 use a 32 bytes cache line size.
-  void (*pfDMB)       (void);                        // Optional DMB function for Data Memory Barrier to make sure all memory operations are completed.
-  void (*pfClean)     (void *p, unsigned NumBytes);  // Optional clean function for cached memory.
-  void (*pfInvalidate)(void *p, unsigned NumBytes);  // Optional invalidate function for cached memory.
+  unsigned int CacheLineSize;                         // 0: No Cache. Most Systems such as ARM9 use a 32 bytes cache line size.
+  void (*pfDMB)       (void);                         // Optional DMB function for Data Memory Barrier to make sure all memory operations are completed.
+  void (*pfClean)     (void *p, unsigned NumBytes);   // Optional clean function for cached memory.
+  void (*pfInvalidate)(void *p, unsigned NumBytes);   // Optional invalidate function for cached memory.
 } SEGGER_CACHE_CONFIG;
+
+typedef struct SEGGER_SNPRINTF_CONTEXT_struct SEGGER_SNPRINTF_CONTEXT;
+
+struct SEGGER_SNPRINTF_CONTEXT_struct {
+  void*               pContext;                       // Application specific context.
+  SEGGER_BUFFER_DESC* pBufferDesc;                    // Buffer descriptor to use for output.
+  void (*pfFlush)(SEGGER_SNPRINTF_CONTEXT* pContext); // Callback executed once the buffer is full. Callback decides if the buffer gets cleared to store more or not.
+};
+
+typedef struct {
+  void (*pfStoreChar)       (SEGGER_BUFFER_DESC* pBufferDesc, SEGGER_SNPRINTF_CONTEXT* pContext, char c);
+  int  (*pfPrintUnsigned)   (SEGGER_BUFFER_DESC* pBufferDesc, SEGGER_SNPRINTF_CONTEXT* pContext, U32 v, unsigned Base, char Flags, int Width, int Precision);
+  int  (*pfPrintInt)        (SEGGER_BUFFER_DESC* pBufferDesc, SEGGER_SNPRINTF_CONTEXT* pContext, I32 v, unsigned Base, char Flags, int Width, int Precision);
+} SEGGER_PRINTF_API;
+
+typedef void (*SEGGER_pFormatter)(SEGGER_BUFFER_DESC* pBufferDesc, SEGGER_SNPRINTF_CONTEXT* pContext, const SEGGER_PRINTF_API* pApi, va_list* pParamList, char Lead, int Width, int Precision);
+
+typedef struct SEGGER_PRINTF_FORMATTER {
+  struct SEGGER_PRINTF_FORMATTER* pNext;              // Pointer to next formatter.
+  SEGGER_pFormatter               pfFormatter;        // Formatter function.
+  char                            Specifier;          // Format specifier.
+} SEGGER_PRINTF_FORMATTER;
 
 /*********************************************************************
 *
@@ -137,14 +187,37 @@ typedef struct {
 **********************************************************************
 */
 
-void SEGGER_ARM_memcpy   (void *pDest, const void *pSrc, int NumBytes);
-void SEGGER_memcpy       (void *pDest, const void *pSrc, int NumBytes);
-void SEGGER_memxor       (void *pDest, const void *pSrc, unsigned NumBytes);
-void SEGGER_StoreChar    (SEGGER_BUFFER_DESC *p, char c);
-void SEGGER_PrintUnsigned(SEGGER_BUFFER_DESC *pBufferDesc, U32 v, unsigned Base, int NumDigits);
-void SEGGER_PrintInt     (SEGGER_BUFFER_DESC *pBufferDesc, I32 v, unsigned Base, unsigned NumDigits);
-int  SEGGER_snprintf     (char *pBuffer, int BufferSize, const char *sFormat, ...);
+//
+// Memory operations.
+//
+void SEGGER_ARM_memcpy(void* pDest, const void* pSrc, int NumBytes);
+void SEGGER_memcpy    (void* pDest, const void* pSrc, unsigned NumBytes);
+void SEGGER_memxor    (void* pDest, const void* pSrc, unsigned NumBytes);
 
+//
+// String functions.
+//
+int      SEGGER_atoi      (const char* s);
+int      SEGGER_isalnum   (int c);
+int      SEGGER_isalpha   (int c);
+unsigned SEGGER_strlen    (const char* s);
+int      SEGGER_tolower   (int c);
+int      SEGGER_strcasecmp(const char* sText1, const char* sText2);
+
+//
+// Buffer/printf related.
+//
+void SEGGER_StoreChar    (SEGGER_BUFFER_DESC* pBufferDesc, char c);
+void SEGGER_PrintUnsigned(SEGGER_BUFFER_DESC* pBufferDesc, U32 v, unsigned Base, int Precision);
+void SEGGER_PrintInt     (SEGGER_BUFFER_DESC* pBufferDesc, I32 v, unsigned Base, int Precision);
+int  SEGGER_snprintf     (char* pBuffer, int BufferSize, const char* sFormat, ...);
+int  SEGGER_vsnprintf    (char* pBuffer, int BufferSize, const char* sFormat, va_list ParamList);
+int  SEGGER_vsnprintfEx  (SEGGER_SNPRINTF_CONTEXT* pContext, const char* sFormat, va_list ParamList);
+
+int  SEGGER_PRINTF_AddFormatter      (SEGGER_PRINTF_FORMATTER* pFormatter, SEGGER_pFormatter pfFormatter, char c);
+void SEGGER_PRINTF_AddDoubleFormatter(void);
+void SEGGER_PRINTF_AddIPFormatter    (void);
+void SEGGER_PRINTF_AddHTMLFormatter  (void);
 
 #if defined(__cplusplus)
 }                /* Make sure we have C-declarations in C++ programs */

--- a/ext/debug/segger/systemview/SEGGER_SYSVIEW.h
+++ b/ext/debug/segger/systemview/SEGGER_SYSVIEW.h
@@ -1,9 +1,9 @@
 /*********************************************************************
-*                SEGGER Microcontroller GmbH & Co. KG                *
+*                    SEGGER Microcontroller GmbH                     *
 *                        The Embedded Experts                        *
 **********************************************************************
 *                                                                    *
-*       (c) 2015 - 2017  SEGGER Microcontroller GmbH & Co. KG        *
+*            (c) 1995 - 2019 SEGGER Microcontroller GmbH             *
 *                                                                    *
 *       www.segger.com     Support: support@segger.com               *
 *                                                                    *
@@ -31,7 +31,7 @@
 *   disclaimer in the documentation and/or other materials provided  *
 *   with the distribution.                                           *
 *                                                                    *
-* o Neither the name of SEGGER Microcontroller GmbH & Co. KG         *
+* o Neither the name of SEGGER Microcontroller GmbH         *
 *   nor the names of its contributors may be used to endorse or      *
 *   promote products derived from this software without specific     *
 *   prior written permission.                                        *
@@ -52,13 +52,13 @@
 *                                                                    *
 **********************************************************************
 *                                                                    *
-*       SystemView version: V2.42                                    *
+*       SystemView version: V2.52h                                    *
 *                                                                    *
 **********************************************************************
 -------------------------- END-OF-HEADER -----------------------------
 File    : SEGGER_SYSVIEW.h
 Purpose : System visualization API.
-Revision: $Rev: 5626 $
+Revision: $Rev: 12706 $
 */
 
 #ifndef SEGGER_SYSVIEW_H
@@ -230,6 +230,7 @@ void SEGGER_SYSVIEW_GetSysDesc                    (void);
 void SEGGER_SYSVIEW_SendTaskList                  (void);
 void SEGGER_SYSVIEW_SendTaskInfo                  (const SEGGER_SYSVIEW_TASKINFO* pInfo);
 void SEGGER_SYSVIEW_SendSysDesc                   (const char* sSysDesc);
+int  SEGGER_SYSVIEW_IsStarted                     (void);
 
 /*********************************************************************
 *

--- a/ext/debug/segger/systemview/SEGGER_SYSVIEW_ConfDefaults.h
+++ b/ext/debug/segger/systemview/SEGGER_SYSVIEW_ConfDefaults.h
@@ -1,9 +1,9 @@
 /*********************************************************************
-*                SEGGER Microcontroller GmbH & Co. KG                *
+*                    SEGGER Microcontroller GmbH                     *
 *                        The Embedded Experts                        *
 **********************************************************************
 *                                                                    *
-*       (c) 2015 - 2017  SEGGER Microcontroller GmbH & Co. KG        *
+*            (c) 1995 - 2019 SEGGER Microcontroller GmbH             *
 *                                                                    *
 *       www.segger.com     Support: support@segger.com               *
 *                                                                    *
@@ -31,7 +31,7 @@
 *   disclaimer in the documentation and/or other materials provided  *
 *   with the distribution.                                           *
 *                                                                    *
-* o Neither the name of SEGGER Microcontroller GmbH & Co. KG         *
+* o Neither the name of SEGGER Microcontroller GmbH         *
 *   nor the names of its contributors may be used to endorse or      *
 *   promote products derived from this software without specific     *
 *   prior written permission.                                        *
@@ -52,14 +52,14 @@
 *                                                                    *
 **********************************************************************
 *                                                                    *
-*       SystemView version: V2.42                                    *
+*       SystemView version: V2.52h                                    *
 *                                                                    *
 **********************************************************************
 -------------------------- END-OF-HEADER -----------------------------
 File    : SEGGER_SYSVIEW_ConfDefaults.h
 Purpose : Defines defaults for configurable defines used in
           SEGGER SystemView.
-Revision: $Rev: 3734 $
+Revision: $Rev: 12706 $
 */
 
 #ifndef SEGGER_SYSVIEW_CONFDEFAULTS_H
@@ -137,6 +137,10 @@ extern "C" {
 
 #ifndef   SEGGER_SYSVIEW_MAX_STRING_LEN
   #define SEGGER_SYSVIEW_MAX_STRING_LEN     128
+#endif
+
+#ifndef   SEGGER_SYSVIEW_PRINTF_IMPLICIT_FORMAT
+  #define SEGGER_SYSVIEW_PRINTF_IMPLICIT_FORMAT 0
 #endif
 
 // Use a static buffer instead of a buffer on the stack for packets

--- a/ext/debug/segger/systemview/SEGGER_SYSVIEW_Int.h
+++ b/ext/debug/segger/systemview/SEGGER_SYSVIEW_Int.h
@@ -1,9 +1,9 @@
 /*********************************************************************
-*                SEGGER Microcontroller GmbH & Co. KG                *
+*                    SEGGER Microcontroller GmbH                     *
 *                        The Embedded Experts                        *
 **********************************************************************
 *                                                                    *
-*       (c) 2015 - 2017  SEGGER Microcontroller GmbH & Co. KG        *
+*            (c) 1995 - 2019 SEGGER Microcontroller GmbH             *
 *                                                                    *
 *       www.segger.com     Support: support@segger.com               *
 *                                                                    *
@@ -31,7 +31,7 @@
 *   disclaimer in the documentation and/or other materials provided  *
 *   with the distribution.                                           *
 *                                                                    *
-* o Neither the name of SEGGER Microcontroller GmbH & Co. KG         *
+* o Neither the name of SEGGER Microcontroller GmbH         *
 *   nor the names of its contributors may be used to endorse or      *
 *   promote products derived from this software without specific     *
 *   prior written permission.                                        *
@@ -52,13 +52,13 @@
 *                                                                    *
 **********************************************************************
 *                                                                    *
-*       SystemView version: V2.42                                    *
+*       SystemView version: V2.52h                                    *
 *                                                                    *
 **********************************************************************
 -------------------------- END-OF-HEADER -----------------------------
 File    : SEGGER_SYSVIEW_Int.h
 Purpose : SEGGER SystemView internal header.
-Revision: $Rev: 5626 $
+Revision: $Rev: 12706 $
 */
 
 #ifndef SEGGER_SYSVIEW_INT_H
@@ -71,9 +71,9 @@ Revision: $Rev: 5626 $
 **********************************************************************
 */
 
-#include "SEGGER_SYSVIEW_ConfDefaults.h"
 #include "SEGGER_SYSVIEW.h"
 #include "SEGGER_SYSVIEW_Conf.h"
+#include "SEGGER_SYSVIEW_ConfDefaults.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Update the external Segger RTT and SystemView libraries to version
2.52h.

This fixes #14082.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>