### PR TITLE
tests: kernel: mem_protect: protection: fix test-case filter

### DIFF
--- a/tests/kernel/mem_protect/protection/testcase.yaml
+++ b/tests/kernel/mem_protect/protection/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.memory_protection.protection:
-    filter: CONFIG_CPU_HAS_MPU or CONFIG_X86_MMU
+    filter: CONFIG_MEMORY_PROTECTION
     tags: kernel security ignore_faults


### PR DESCRIPTION
The test is to run for boards that have memory protection
enabled; having MPU capabilities on the SoC level is not
sufficient (the user, or the board itself, might not enable
memory protection support). This commit applies that policy
to the mem_protect/protection test suite.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

This fixes #15546 