### PR TITLE
board: Musca b1 nonsecure sanity check

### DIFF
--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.dts
@@ -33,7 +33,7 @@
 
 	flash0: flash@30400 {
 		/* QSPI flash */
-		reg = <0x00030400 0x8000>;
+		reg = <0x00030400 0x1fcfc00>;
 	};
 
 	sram0: memory@20070000 {

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.yaml
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.yaml
@@ -7,5 +7,5 @@ toolchain:
   - gnuarmemb
   - xtools
 ram: 64
-flash: 32
+flash: 32575
 sanitycheck: false

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.yaml
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.yaml
@@ -8,4 +8,3 @@ toolchain:
   - xtools
 ram: 64
 flash: 32575
-sanitycheck: false


### PR DESCRIPTION
Increase flash size of musca b1 nonsecure to pass the sanitycheck.