### PR TITLE
scripts: dts: Match alpha numeric property values

### DIFF
--- a/scripts/dts/devicetree.py
+++ b/scripts/dts/devicetree.py
@@ -9,6 +9,7 @@
 
 import sys
 import pprint
+import re
 
 def read_until(line, fd, end):
     out = [line]
@@ -123,6 +124,9 @@ def parse_value(value):
             return int(value, 16)
         if value[0] == '0':
             return int(value, 8)
+        # Match alpha numeric values
+        if re.match("\w", value):
+            return value
         return int(value, 10)
 
     return value


### PR DESCRIPTION
For using alpha numeric property values in a devicetree node, we
need to match the values starts with a number. Current scenario will
return the value as a numeric literal if it starts with a number. This
will not work for a compatible like, "96b-ls-con" which is proposed in
issue #15598.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>