### PR TITLE
net: sntp: Add sntp_query() function with fractional precision

### DIFF
--- a/include/net/sntp.h
+++ b/include/net/sntp.h
@@ -32,6 +32,12 @@ struct sntp_ctx {
 	u32_t expected_orig_ts;
 };
 
+/** Time as returned by SNTP API, fractional seconds since 1 Jan 1970 */
+struct sntp_time {
+	u64_t seconds;
+	u32_t fraction;
+};
+
 /**
  * @brief Initialize SNTP context
  *
@@ -45,7 +51,7 @@ int sntp_init(struct sntp_ctx *ctx, struct sockaddr *addr,
 	      socklen_t addr_len);
 
 /**
- * @brief Send SNTP request
+ * @brief SNTP query with seconds precision (deprecated)
  *
  * @param ctx Address of sntp context.
  * @param timeout Timeout of waiting for sntp response (in milliseconds).
@@ -53,7 +59,21 @@ int sntp_init(struct sntp_ctx *ctx, struct sockaddr *addr,
  *
  * @return 0 if ok, <0 if error.
  */
-int sntp_request(struct sntp_ctx *ctx, u32_t timeout, u64_t *epoch_time);
+__deprecated int sntp_request(struct sntp_ctx *ctx, u32_t timeout,
+			      u64_t *epoch_time);
+
+/**
+ * @brief Perform SNTP query
+ *
+ * @param ctx Address of sntp context.
+ * @param timeout Timeout of waiting for sntp response (in milliseconds).
+ * @param time Timestamp including integer and fractional seconds since
+ * 1 Jan 1970 (output).
+ *
+ * @return 0 if ok, <0 if error (-ETIMEDOUT if timeout).
+ */
+int sntp_query(struct sntp_ctx *ctx, u32_t timeout,
+	       struct sntp_time *time);
 
 /**
  * @brief Release SNTP context

--- a/subsys/net/lib/sntp/sntp.c
+++ b/subsys/net/lib/sntp/sntp.c
@@ -44,7 +44,7 @@ static void sntp_pkt_dump(struct sntp_pkt *pkt)
 }
 
 static s32_t parse_response(u8_t *data, u16_t len, u32_t orig_ts,
-			    u64_t *epoch_time)
+			    struct sntp_time *time)
 {
 	struct sntp_pkt *pkt = (struct sntp_pkt *)data;
 	u32_t ts;
@@ -76,6 +76,7 @@ static s32_t parse_response(u8_t *data, u16_t len, u32_t orig_ts,
 		return -EINVAL;
 	}
 
+	time->fraction = ntohl(pkt->tx_tm_f);
 	ts = ntohl(pkt->tx_tm_s);
 
 	/* Check if most significant bit is set */
@@ -84,7 +85,7 @@ static s32_t parse_response(u8_t *data, u16_t len, u32_t orig_ts,
 		 * on 1 January 1900.
 		 */
 		if (ts >= OFFSET_1970_JAN_1) {
-			*epoch_time = ts - OFFSET_1970_JAN_1;
+			time->seconds = ts - OFFSET_1970_JAN_1;
 		} else {
 			return -EINVAL;
 		}
@@ -92,14 +93,14 @@ static s32_t parse_response(u8_t *data, u16_t len, u32_t orig_ts,
 		/* UTC time is reckoned from 6h 28m 16s UTC
 		 * on 7 February 2036.
 		 */
-		*epoch_time = ts + 0x100000000 - OFFSET_1970_JAN_1;
+		time->seconds = ts + 0x100000000ULL - OFFSET_1970_JAN_1;
 	}
 
 	return 0;
 }
 
 static int sntp_recv_response(struct sntp_ctx *sntp, u32_t timeout,
-			      u64_t *epoch_time)
+			      struct sntp_time *time)
 {
 	struct sntp_pkt buf = { 0 };
 	int status;
@@ -121,7 +122,7 @@ static int sntp_recv_response(struct sntp_ctx *sntp, u32_t timeout,
 
 	status = parse_response((u8_t *)&buf, sizeof(buf),
 				sntp->expected_orig_ts,
-				epoch_time);
+				time);
 	return status;
 }
 
@@ -165,10 +166,20 @@ int sntp_init(struct sntp_ctx *ctx, struct sockaddr *addr, socklen_t addr_len)
 
 int sntp_request(struct sntp_ctx *ctx, u32_t timeout, u64_t *epoch_time)
 {
+	struct sntp_time time;
+	int res = sntp_query(ctx, timeout, &time);
+
+	*epoch_time = time.seconds;
+
+	return res;
+}
+
+int sntp_query(struct sntp_ctx *ctx, u32_t timeout, struct sntp_time *time)
+{
 	struct sntp_pkt tx_pkt = { 0 };
 	int ret = 0;
 
-	if (!ctx || !epoch_time) {
+	if (!ctx || !time) {
 		return -EFAULT;
 	}
 
@@ -185,7 +196,7 @@ int sntp_request(struct sntp_ctx *ctx, u32_t timeout, u64_t *epoch_time)
 		return ret;
 	}
 
-	return sntp_recv_response(ctx, timeout, epoch_time);
+	return sntp_recv_response(ctx, timeout, time);
 }
 
 void sntp_close(struct sntp_ctx *ctx)


### PR DESCRIPTION
Existing sntp_request() function has a coarse integer seconds
precision,  discarding fractional part as returned by SNTP.
Deprecate it, and instead introduce sntp_query() function which
returns both integer and fractional seconds as a newly introduced
structure sntp_tstamp.

Fixes: #15596

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>