### PR TITLE
samples: net: zperf: Add __packed for zperf_udp_datagram

### DIFF
--- a/samples/net/zperf/src/zperf_internal.h
+++ b/samples/net/zperf/src/zperf_internal.h
@@ -67,7 +67,7 @@ struct zperf_udp_datagram {
 	s32_t id;
 	u32_t tv_sec;
 	u32_t tv_usec;
-};
+} __packed;
 
 struct zperf_client_hdr_v1 {
 	s32_t flags;


### PR DESCRIPTION
UDP packet from net is not 4-byte aligned.
So we have to add __packed for zperf_udp_datagram.

Fixes #15605.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>