### PR TITLE
lib/posix: correct the meaning of CONFIG_MAX_PTHREAD_COUNT

### DIFF
--- a/include/posix/pthread.h
+++ b/include/posix/pthread.h
@@ -18,14 +18,14 @@
 #include <string.h>
 
 enum pthread_state {
+	/* The thread structure is unallocated and available for reuse. */
+	PTHREAD_TERMINATED = 0,
 	/* The thread is running and joinable. */
-	PTHREAD_JOINABLE = 0,
+	PTHREAD_JOINABLE,
 	/* The thread is running and detached. */
 	PTHREAD_DETACHED,
 	/* A joinable thread exited and its return code is available. */
-	PTHREAD_EXITED,
-	/* The thread structure is unallocated and available for reuse. */
-	PTHREAD_TERMINATED
+	PTHREAD_EXITED
 };
 
 struct posix_thread {
@@ -49,8 +49,8 @@ struct posix_thread {
 };
 
 /* Pthread detach/joinable */
-#define PTHREAD_CREATE_JOINABLE     0
-#define PTHREAD_CREATE_DETACHED     1
+#define PTHREAD_CREATE_JOINABLE     PTHREAD_JOINABLE
+#define PTHREAD_CREATE_DETACHED     PTHREAD_DETACHED
 
 /* Pthread cancellation */
 #define _PTHREAD_CANCEL_POS	0

--- a/lib/posix/Kconfig
+++ b/lib/posix/Kconfig
@@ -30,11 +30,11 @@ config PTHREAD_IPC
 
 if PTHREAD_IPC
 config MAX_PTHREAD_COUNT
-	int "Maximum pthread count in POSIX application"
+	int "Maximum simultaneously active pthread count in POSIX application"
 	default 5
 	range 0 255
 	help
-	  Mention maximum number of threads in POSIX compliant application.
+	  Maximum number of simultaneously active threads in a POSIX application.
 
 config SEM_VALUE_MAX
 	int "Maximum semaphore limit"


### PR DESCRIPTION
CONFIG_MAX_PTHREAD_COUNT seems to be implemented as the maximum number
of POSIX threads that can ever be created, rather than the maximum
number of active POSIX threads. Create an array to mark usage of
posix_thread_pool. On thread creation, use this array to find free pool
element and on thread exit mark posix_thread_pool element as free.

Fixes #15516.

Signed-off-by: Wentong Wu <wentong.wu@intel.com>