### PR TITLE
Remove direct usage of CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC

### DIFF
--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -37,17 +37,7 @@
 #define T_BUF		T_LOW
 
 #define NS_TO_SYS_CLOCK_HW_CYCLES(ns) \
-	((u64_t)CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC * (ns) / NSEC_PER_SEC + 1)
-
-static const u32_t delays_fast[] = {
-	[T_LOW] = NS_TO_SYS_CLOCK_HW_CYCLES(1300),
-	[T_HIGH] = NS_TO_SYS_CLOCK_HW_CYCLES(600),
-};
-
-static const u32_t delays_standard[] = {
-	[T_LOW] = NS_TO_SYS_CLOCK_HW_CYCLES(4700),
-	[T_HIGH] = NS_TO_SYS_CLOCK_HW_CYCLES(4000),
-};
+	((u64_t)sys_clock_hw_cycles_per_sec() * (ns) / NSEC_PER_SEC + 1)
 
 int i2c_bitbang_configure(struct i2c_bitbang *context, u32_t dev_config)
 {
@@ -59,10 +49,12 @@ int i2c_bitbang_configure(struct i2c_bitbang *context, u32_t dev_config)
 	/* Setup speed to use */
 	switch (I2C_SPEED_GET(dev_config)) {
 	case I2C_SPEED_STANDARD:
-		context->delays = delays_standard;
+		context->delays[T_LOW]  = NS_TO_SYS_CLOCK_HW_CYCLES(4700);
+		context->delays[T_HIGH] = NS_TO_SYS_CLOCK_HW_CYCLES(4000);
 		break;
 	case I2C_SPEED_FAST:
-		context->delays = delays_fast;
+		context->delays[T_LOW]  = NS_TO_SYS_CLOCK_HW_CYCLES(1300);
+		context->delays[T_HIGH] = NS_TO_SYS_CLOCK_HW_CYCLES(600);
 		break;
 	default:
 		return -ENOTSUP;

--- a/drivers/i2c/i2c_bitbang.h
+++ b/drivers/i2c/i2c_bitbang.h
@@ -28,7 +28,7 @@ struct i2c_bitbang_io {
 struct i2c_bitbang {
 	const struct i2c_bitbang_io	*io;
 	void				*io_context;
-	const u32_t			*delays;
+	u32_t				delays[2];
 };
 
 /**

--- a/drivers/pwm/pwm_qmsi.c
+++ b/drivers/pwm/pwm_qmsi.c
@@ -16,7 +16,7 @@
 #include "qm_pwm.h"
 #include "clk.h"
 
-#define HW_CLOCK_CYCLES_PER_USEC  (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / \
+#define HW_CLOCK_CYCLES_PER_USEC  (sys_clock_hw_cycles_per_sec() / \
 				   USEC_PER_SEC)
 
 /* pwm uses 32 bits counter to control low and high period */

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -25,7 +25,7 @@
 #define MIN_DELAY 512
 #define COUNTER_MAX 0xffffffff
 #define TIMER_STOPPED 0x0
-#define CYC_PER_TICK (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC	\
+#define CYC_PER_TICK (sys_clock_hw_cycles_per_sec()	\
 		      / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 
 #define MAX_TICKS ((COUNTER_MAX / CYC_PER_TICK) - 1)

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -13,7 +13,7 @@ void z_ExcExit(void);
 #define COUNTER_MAX 0x00ffffff
 #define TIMER_STOPPED 0xff000000
 
-#define CYC_PER_TICK (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC	\
+#define CYC_PER_TICK (sys_clock_hw_cycles_per_sec()	\
 		      / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 #define MAX_TICKS ((COUNTER_MAX / CYC_PER_TICK) - 1)
 #define MAX_CYCLES (MAX_TICKS * CYC_PER_TICK)

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -16,7 +16,7 @@
 #define RTC NRF_RTC1
 
 #define COUNTER_MAX 0x00ffffff
-#define CYC_PER_TICK (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC	\
+#define CYC_PER_TICK (sys_clock_hw_cycles_per_sec()	\
 		      / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 #define MAX_TICKS ((COUNTER_MAX - CYC_PER_TICK) / CYC_PER_TICK)
 

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -8,7 +8,7 @@
 #include <spinlock.h>
 #include <soc.h>
 
-#define CYC_PER_TICK ((u32_t)((u64_t)CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC	\
+#define CYC_PER_TICK ((u32_t)((u64_t)sys_clock_hw_cycles_per_sec()	\
 			      / (u64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
 #define MAX_TICKS ((0xffffffffu - CYC_PER_TICK) / CYC_PER_TICK)
 #define MIN_DELAY 1000

--- a/drivers/timer/rv32m1_lptmr_timer.c
+++ b/drivers/timer/rv32m1_lptmr_timer.c
@@ -19,14 +19,15 @@
  * - no tickless
  */
 
-#define CYCLES_PER_SEC  CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC
+#define CYCLES_PER_SEC  sys_clock_hw_cycles_per_sec()
 #define CYCLES_PER_TICK (CYCLES_PER_SEC / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 
 /*
  * As a simplifying assumption, we only support a clock ticking at the
  * SIRC reset rate of 8MHz.
  */
-#if MHZ(8) != CYCLES_PER_SEC
+#if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME) || \
+    (MHZ(8) != CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC)
 #error "system timer misconfiguration; unsupported clock rate"
 #endif
 

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -23,7 +23,7 @@
 #define RTC0 ((RtcMode0 *) DT_RTC_SAM0_BASE_ADDRESS)
 
 /* Number of sys timer cycles per on tick. */
-#define CYCLES_PER_TICK (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC \
+#define CYCLES_PER_TICK (SOC_ATMEL_SAM0_GCLK0_FREQ_HZ \
 			 / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 
 /* Maximum number of ticks. */

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -11,7 +11,7 @@
 #define TIMER_IRQ UTIL_CAT(XCHAL_TIMER,		\
 			   UTIL_CAT(CONFIG_XTENSA_TIMER_ID, _INTERRUPT))
 
-#define CYC_PER_TICK (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC	\
+#define CYC_PER_TICK (sys_clock_hw_cycles_per_sec()	\
 		      / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 #define MAX_TICKS ((0xffffffffu - CYC_PER_TICK) / CYC_PER_TICK)
 #define MIN_DELAY 1000

--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -46,7 +46,7 @@ static u32_t timestamp_freq(void)
 #ifdef CONFIG_SOC_FAMILY_NRF
 	return 32768 / (NRF_RTC1->PRESCALER + 1);
 #else
-	return CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
+	return sys_clock_hw_cycles_per_sec();
 #endif
 }
 

--- a/subsys/debug/tracing/sysview_config.c
+++ b/subsys/debug/tracing/sysview_config.c
@@ -17,8 +17,8 @@ static void cbSendSystemDesc(void)
 
 void SEGGER_SYSVIEW_Conf(void)
 {
-	SEGGER_SYSVIEW_Init(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
-			    CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
+	SEGGER_SYSVIEW_Init(sys_clock_hw_cycles_per_sec(),
+			    sys_clock_hw_cycles_per_sec(),
 			    &SYSVIEW_X_OS_TraceAPI, cbSendSystemDesc);
 
 #if defined(DT_PHYS_RAM_ADDR)       /* x86 */

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -280,19 +280,18 @@ void log_hexdump_sync(struct log_msg_ids src_level, const char *metadata,
 	}
 }
 
-static u32_t timestamp_get(void)
+static u32_t k_cycle_get_32_wrapper(void)
 {
-	if (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC > 1000000) {
-		return k_uptime_get_32();
-	} else {
-		return k_cycle_get_32();
-	}
+	/*
+	 * The k_cycle_get_32() is a define which cannot be referenced
+	 * by timestamp_func. Instead, this wrapper is used.
+	 */
+	return k_cycle_get_32();
 }
 
 void log_core_init(void)
 {
-	u32_t freq = (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC > 1000000) ?
-			1000 : CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
+	u32_t freq;
 
 	if (!IS_ENABLED(CONFIG_LOG_IMMEDIATE)) {
 		log_msg_pool_init();
@@ -304,7 +303,14 @@ void log_core_init(void)
 	}
 
 	/* Set default timestamp. */
-	timestamp_func = timestamp_get;
+	if (sys_clock_hw_cycles_per_sec() > 1000000) {
+		timestamp_func = k_uptime_get_32;
+		freq = 1000;
+	} else {
+		timestamp_func = k_cycle_get_32_wrapper;
+		freq = sys_clock_hw_cycles_per_sec();
+	}
+
 	log_output_timestamp_freq_set(freq);
 
 	/*

--- a/tests/benchmarks/boot_time/src/main.c
+++ b/tests/benchmarks/boot_time/src/main.c
@@ -43,7 +43,7 @@ void main(void)
 	 */
 	k_sleep(1);
 
-	int freq = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / 1000000;
+	int freq = sys_clock_hw_cycles_per_sec() / 1000000;
 
 	_start_us  =  __start_time_stamp / freq;
 	s_main_time_stamp =  __main_time_stamp - __start_time_stamp;

--- a/tests/benchmarks/timing_info/src/timing_info.h
+++ b/tests/benchmarks/timing_info/src/timing_info.h
@@ -138,7 +138,7 @@ static inline void benchmark_timer_start(void) {       }
 /* Get Core Frequency in MHz */
 static inline u32_t get_core_freq_MHz(void)
 {
-	return  (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC/1000000);
+	return  (sys_clock_hw_cycles_per_sec() / 1000000);
 }
 
 #define PRINT_STATS(x, y, z)   PRINT_F(x, y, z)


### PR DESCRIPTION
On some SoCs the frequency of the system clock is obtained at run time
as the exact configuration of the hardware is not known at compile time.
On such platforms using CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC define directly
introduces timing errors.

This PR replaces CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC by the call to
inline function sys_clock_hw_cycles_per_sec() which always returns correct
frequency of the system clock.

Brings us closer to: #15363