### PR TITLE
CODEOWNERS: update code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,22 +21,22 @@
 /soc/arm/st_stm32/stm32f4/                @rsalveti @idlethread
 /soc/arm/ti_simplelink/cc32xx/            @vanti
 /soc/arm/ti_simplelink/msp432p4xx/        @Mani-Sadhasivam
-/soc/xtensa/intel_s1000/                  @sathishkuttan @dcpleung @rgundi
-/arch/nios2/                              @andrewboie @ramakrishnapallala
+/soc/xtensa/intel_s1000/                  @sathishkuttan @dcpleung
+/arch/nios2/                              @andrewboie @wentongwu
 /arch/posix/                              @aescolar
 /arch/riscv32/                            @kgugala @pgielda @nategraff-sifive
 /soc/posix/                               @aescolar
 /soc/riscv32/                             @kgugala @pgielda @nategraff-sifive
-/arch/x86/                                @andrewboie @ramakrishnapallala
+/arch/x86/                                @andrewboie @wentongwu
 /arch/x86/core/                           @andrewboie
-/arch/x86/core/crt0.S                     @ramakrishnapallala @nashif
+/arch/x86/core/crt0.S                     @wentongwu @nashif
 /arch/x86/core/pcie.c                     @gnuless
-/soc/x86/                                 @andrewboie @ramakrishnapallala
+/soc/x86/                                 @andrewboie @wentongwu
 /soc/x86/intel_quark/quark_d2000/         @nashif
 /soc/x86/intel_quark/quark_se/            @nashif
 /soc/x86/intel_quark/quark_x1000/         @nashif
-/arch/xtensa/                             @andrewboie @rgundi @andyross
-/soc/xtensa/                              @andrewboie @rgundi @andyross
+/arch/xtensa/                             @andrewboie @dcpleung @andyross
+/soc/xtensa/                              @andrewboie @dcpleung @andyross
 /boards/arc/                              @vonhust @ruuddw
 /boards/arc/arduino_101_sss/              @nashif
 /boards/arc/em_starterkit/                @vonhust
@@ -78,8 +78,8 @@
 /boards/arm/stm32*_disco/                 @erwango
 /boards/arm/stm32f3_disco/                @ydamigos
 /boards/arm/stm32*_eval/                  @erwango
-/boards/nios2/                            @ramakrishnapallala
-/boards/nios2/altera_max10/               @ramakrishnapallala
+/boards/nios2/                            @wentongwu
+/boards/nios2/altera_max10/               @wentongwu
 /boards/posix/                            @aescolar
 /boards/riscv32/                          @kgugala @pgielda @nategraff-sifive
 /boards/shields/                          @erwango
@@ -133,13 +133,13 @@
 /drivers/sensor/lis*/                     @avisconti
 /drivers/sensor/lps*/                     @avisconti
 /drivers/sensor/lsm*/                     @avisconti
-/drivers/serial/uart_altera_jtag_hal.c    @ramakrishnapallala
+/drivers/serial/uart_altera_jtag_hal.c    @wentongwu
 /drivers/serial/*ns16550*                 @gnuless
 /drivers/net/slip.c                       @jukkar @tbursztyka
 /drivers/spi/                             @tbursztyka
 /drivers/spi/spi_ll_stm32.*               @superna9999
 /drivers/timer/cortex_m_systick.c         @ioannisg
-/drivers/timer/altera_avalon_timer_hal.c  @ramakrishnapallala
+/drivers/timer/altera_avalon_timer_hal.c  @wentongwu
 /drivers/timer/riscv_machine_timer.c      @nategraff-sifive @kgugala @pgielda
 /drivers/usb/                             @jfischer-phytec-iot @finikorg
 /drivers/usb/device/usb_dc_stm32.c        @ydamigos @loicpoulain
@@ -157,7 +157,7 @@
 /dts/bindings/*/nxp*                      @MaureenHelm
 /dts/bindings/sensor/ams,ens210.yaml      @alexanderwachter
 /dts/bindings/sensor/ams,iaqcore.yaml     @alexanderwachter
-/ext/fs/                                  @nashif @ramakrishnapallala
+/ext/fs/                                  @nashif @wentongwu
 /ext/hal/cmsis/                           @MaureenHelm @galak
 /ext/hal/libmetal/                        @galak
 /ext/hal/nordic/                          @carlescufi @anangl
@@ -178,7 +178,7 @@
 /include/arch/nios2/arch.h                @andrewboie
 /include/arch/posix/                      @aescolar
 /include/arch/riscv32/                    @nategraff-sifive @kgugala @pgielda
-/include/arch/x86/                        @andrewboie @ramakrishnapallala
+/include/arch/x86/                        @andrewboie @wentongwu
 /include/arch/x86/arch.h                  @andrewboie
 /include/arch/xtensa/                     @andrewboie
 /include/atomic.h                         @andrewboie @andyross
@@ -186,7 +186,7 @@
 /include/cache.h                          @andrewboie @andyross
 /include/can.h                            @alexanderwachter
 /include/counter.h                        @nordic-krch
-/include/device.h                         @ramakrishnapallala @nashif
+/include/device.h                         @wentongwu @nashif
 /include/display.h                        @vanwinkeljan
 /include/display/                         @vanwinkeljan
 /include/drivers/bluetooth/               @sjanc @jhedberg @Vudentz
@@ -197,8 +197,8 @@
 /include/drivers/pcie/                    @gnuless
 /include/drivers/serial/uart_ns16550.h    @gnuless
 /include/dt-bindings/pcie/                @gnuless
-/include/fs.h                             @nashif @ramakrishnapallala
-/include/fs/                              @nashif @ramakrishnapallala
+/include/fs.h                             @nashif @wentongwu
+/include/fs/                              @nashif @wentongwu
 /include/hwinfo.h                         @alexanderwachter
 /include/init.h                           @andrewboie @andyross
 /include/irq.h                            @andrewboie @andyross
@@ -218,7 +218,7 @@
 /include/net/                             @jukkar @tbursztyka @pfalcon
 /include/net/buf.h                        @jukkar @jhedberg @tbursztyka @pfalcon
 /include/posix/                           @pfalcon
-/include/power.h                          @ramakrishnapallala @nashif
+/include/power.h                          @wentongwu @nashif
 /include/sensor.h                         @bogdan-davidoaia
 /include/shared_irq.h                     @andrewboie @andyross
 /include/shell/                           @jarz-nordic @nordic-krch
@@ -237,7 +237,7 @@
 /kernel/idle.c                            @andrewboie @andyross @nashif
 /samples/basic/servo_motor/*microbit*     @jhe
 /samples/bluetooth/                       @sjanc @jhedberg @Vudentz
-/samples/boards/intel_s1000_crb/          @sathishkuttan @rgundi @nashif
+/samples/boards/intel_s1000_crb/          @sathishkuttan @dcpleung @nashif
 /samples/display/                         @vanwinkeljan
 /samples/drivers/CAN/                     @alexanderwachter
 /samples/gui/                             @vanwinkeljan
@@ -252,7 +252,7 @@
 /samples/subsys/logging/                  @nordic-krch @jarz-nordic
 /samples/subsys/shell/                    @jarz-nordic @nordic-krch
 /samples/subsys/usb/                      @jfischer-phytec-iot @finikorg
-/samples/subsys/power/                    @ramakrishnapallala @pizi-nordic
+/samples/subsys/power/                    @wentongwu @pizi-nordic
 /scripts/coccicheck                       @himanshujha199640 @JuliaLawall
 /scripts/coccinelle/                      @himanshujha199640 @JuliaLawall
 /scripts/elf_helper.py                    @andrewboie
@@ -287,13 +287,13 @@
 /subsys/net/lib/mqtt/                     @jukkar @tbursztyka
 /subsys/net/lib/coap/                     @rveerama1
 /subsys/net/lib/sockets/                  @jukkar @tbursztyka @pfalcon
-/subsys/power/                            @ramakrishnapallala @pizi-nordic
+/subsys/power/                            @wentongwu @pizi-nordic
 /subsys/settings/                         @nvlsianpu
 /subsys/shell/                            @jarz-nordic @nordic-krch
 /subsys/storage/                          @nvlsianpu
 /subsys/usb/                              @jfischer-phytec-iot @finikorg
 /tests/boards/native_posix/               @aescolar
-/tests/boards/intel_s1000_crb/            @rgundi @dcpleung @sathishkuttan
+/tests/boards/intel_s1000_crb/            @dcpleung @sathishkuttan
 /tests/bluetooth/                         @sjanc @jhedberg @Vudentz
 /tests/posix/                             @pfalcon
 /tests/crypto/                            @ceolin
@@ -310,7 +310,7 @@
 /tests/net/lib/mqtt_packet/               @jukkar @tbursztyka
 /tests/net/lib/coap/                      @rveerama1
 /tests/net/socket/                        @jukkar @tbursztyka @pfalcon
-/tests/subsys/fs/                         @nashif @ramakrishnapallala
+/tests/subsys/fs/                         @nashif @wentongwu
 /tests/subsys/settings/                   @nvlsianpu
 
 # Get all docs reviewed


### PR DESCRIPTION
Replace owners who are not working on Zephyr anymore.