### PR TITLE
drivers: timer: nrf: remove unnecessary event feature

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -89,7 +89,6 @@ int z_clock_driver_init(struct device *device)
 	/* TODO: replace with counter driver to access RTC */
 	nrf_rtc_prescaler_set(RTC, 0);
 	nrf_rtc_cc_set(RTC, 0, CYC_PER_TICK);
-	nrf_rtc_event_enable(RTC, RTC_EVTENSET_COMPARE0_Msk);
 	nrf_rtc_int_enable(RTC, RTC_INTENSET_COMPARE0_Msk);
 
 	/* Clear the event flag and possible pending interrupt */


### PR DESCRIPTION
Enabling the RTC event is intended to support peripheral-to-peripheral
interconnects, so introduces a request for HFCLK and PCLK16M when the
event is triggered.  This specific event is never used with PPI so
enabling events apparently does nothing but increase power consumption.

Closes #15513

Signed-off-by: Peter A. Bigot <pab@pabigot.com>