### PR TITLE
posix: Clean up of struct timeval define and related functions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -228,9 +228,9 @@
 /include/zephyr.h                         @andrewboie @andyross
 /kernel/                                  @andrewboie @andyross
 /lib/gui/                                 @vanwinkeljan
+/lib/libc/                                @nashif
 /lib/os/                                  @andrewboie @andyross
 /lib/posix/                               @pfalcon
-/lib/libc/minimal/source/stdlib/bsearch.c @balajikulkarni
 /kernel/device.c                          @andrewboie @andyross @nashif
 /kernel/idle.c                            @andrewboie @andyross @nashif
 /samples/                                 @nashif

--- a/include/posix/sys/time.h
+++ b/include/posix/sys/time.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_POSIX_SYS_TIME_H_
+#define ZEPHYR_INCLUDE_POSIX_SYS_TIME_H_
+
+#include <sys/_timeval.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int gettimeofday(struct timeval *tv, const void *tz);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* ZEPHYR_INCLUDE_POSIX_SYS_TIME_H_ */

--- a/include/posix/sys/time.h
+++ b/include/posix/sys/time.h
@@ -7,7 +7,23 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_TIME_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_TIME_H_
 
+#ifdef CONFIG_NEWLIB_LIBC
+/* Kludge to support outdated newlib version as used in SDK 0.10 for Xtensa */
+#include <newlib.h>
+
+#ifdef __NEWLIB__
 #include <sys/_timeval.h>
+#else
+#include <sys/types.h>
+struct timeval {
+	time_t tv_sec;
+	suseconds_t tv_usec;
+};
+#endif
+
+#else
+#include <sys/_timeval.h>
+#endif /* CONFIG_NEWLIB_LIBC */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/posix/time.h
+++ b/include/posix/time.h
@@ -34,11 +34,6 @@ struct itimerspec {
 };
 #endif
 
-struct timeval {
-	signed int  tv_sec;
-	signed int  tv_usec;
-};
-
 #include <kernel.h>
 #include <errno.h>
 #include "posix_types.h"
@@ -71,8 +66,6 @@ int timer_delete(timer_t timerid);
 int timer_gettime(timer_t timerid, struct itimerspec *its);
 int timer_settime(timer_t timerid, int flags, const struct itimerspec *value,
 		  struct itimerspec *ovalue);
-
-int gettimeofday(struct timeval *tv, const void *tz);
 
 #ifdef __cplusplus
 }

--- a/lib/libc/minimal/include/sys/_timeval.h
+++ b/lib/libc/minimal/include/sys/_timeval.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS__TIMEVAL_H_
+#define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS__TIMEVAL_H_
+
+#include <sys/types.h>
+
+struct timeval {
+	time_t tv_sec;
+	suseconds_t tv_usec;
+};
+
+#endif /* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS__TIMEVAL_H_ */

--- a/lib/libc/minimal/include/sys/types.h
+++ b/lib/libc/minimal/include/sys/types.h
@@ -40,4 +40,7 @@ typedef int off_t;
 
 #endif
 
+typedef long long time_t;
+typedef long suseconds_t;
+
 #endif /* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_TYPES_H_ */

--- a/lib/posix/clock.c
+++ b/lib/posix/clock.c
@@ -6,6 +6,7 @@
 #include <kernel.h>
 #include <errno.h>
 #include <posix/time.h>
+#include <posix/sys/time.h>
 
 /*
  * `k_uptime_get` returns a timestamp based on an always increasing

--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -5,6 +5,7 @@
  */
 #include <ztest.h>
 #include <posix/time.h>
+#include <posix/sys/time.h>
 #include <posix/unistd.h>
 
 #define SLEEP_SECONDS 1


### PR DESCRIPTION
We mutual conflicts with definition of `struct timeval` among minlibs, newlib, and POSIX spec. This patchset fixes them.
