### PR TITLE
drivers: ieee802154: New API for ACK configuration

### DIFF
--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -54,6 +54,42 @@ struct ieee802154_filter {
 /* @endcond */
 };
 
+/** IEEE802.15.4 driver configuration types. */
+enum ieee802154_config_type {
+	/** Indicates how radio driver should set Frame Pending bit in ACK
+	 *  responses for Data Requests. If enabled, radio driver should
+	 *  determine whether to set the bit or not based on the information
+	 *  provided with ``IEEE802154_CONFIG_ACK_FPB`` config. Otherwise,
+	 *  Frame Pending bit should be set to ``1``(see IEEE Std 802.15.4-2006,
+	 *  7.2.2.3.1).
+	 */
+	IEEE802154_CONFIG_AUTO_ACK_FPB,
+
+	/** Indicates whether to set ACK Frame Pending bit for specific address
+	 *  or not. Disabling the Frame Pending bit with no address provided
+	 *  (NULL pointer) should disable it for all enabled addresses.
+	 */
+	IEEE802154_CONFIG_ACK_FPB,
+};
+
+/** IEEE802.15.4 driver configuration data. */
+struct ieee802154_config {
+	/** Configuration data. */
+	union {
+		/** ``IEEE802154_CONFIG_AUTO_ACK_FPB`` */
+		struct {
+			bool enabled;
+		} auto_ack_fpb;
+
+		/** ``IEEE802154_CONFIG_ACK_FPB`` */
+		struct {
+			u8_t *addr;
+			bool extended;
+			bool enabled;
+		} ack_fpb;
+	};
+};
+
 /**
  * @brief IEEE 802.15.4 radio interface API.
  *
@@ -95,6 +131,11 @@ struct ieee802154_radio_api {
 
 	/** Stop the device */
 	int (*stop)(struct device *dev);
+
+	/** Set specific radio driver configuration. */
+	int (*configure)(struct device *dev,
+			 enum ieee802154_config_type type,
+			 const struct ieee802154_config *config);
 
 #ifdef CONFIG_NET_L2_IEEE802154_SUB_GHZ
 	/** Get the available amount of Sub-GHz channels */


### PR DESCRIPTION
### Introduction

In order to support more OpenThread features, some extensions to Zephyr 802.15.4 driver API are needed.

802.15.4 ACK frame fields are not static and can carry valuable information for the recipient. For instance Frame Pending bit notifies the recipient whether it should expect more data or not. This mechanism is used by Threads Sleepy End Devices. Moreover, 802.15.4 standard in version 2015 introduces Enhanced ACKs, which can yield even more data. 

As we do support drivers with automatic ACK response mechanism, we need a way to configure such responses.

### Proposed change

<s>
The API extension proposal consists of two functions:

1. `int (*config_ack)(struct device *dev, struct ieee802154_ack_config *config);`<br>
This function will be used for global ACK configuration in the driver, e.g. whether to perform Frame Pending bit lookup or not.

2. `int (*set_ack_data)(struct device *dev, struct ieee802154_ack_data *data, u8_t *addr, bool extended);`<br>
This function will be used for setting ACK data for specific targets. The driver will be responsible to store this data and to search its internal database before sending the actual ACK for a specific target.
</s>

Now we have a single function:
```
int (*set_config)(struct device *dev,
                  enum ieee802154_config_type type,
                  struct ieee802154_config *config);
```

which covers both global, and target-specific ACK configuration.

The API should be easily extensible by providing new configuration/data types, once need arises (for instance to implement already mentioned Enhanced Acks).

I won't hide, that the API is strongly inspired by OpenThread needs. But the fact is, OpenThread is out for some time now, and many drivers provided with OpenThread implement them. And just to be clear - there are no OpenThread specific extensions here - Frame Pending bit and Enhanced ACKs are covered by 15.4 standard.