### PR TITLE
ext: lib: crypto: Extend mbedTLS generic config

### DIFF
--- a/ext/lib/crypto/mbedtls/Kconfig.tls-generic
+++ b/ext/lib/crypto/mbedtls/Kconfig.tls-generic
@@ -29,6 +29,10 @@ config MBEDTLS_DTLS
 	bool "Enable support for DTLS"
 	depends on MBEDTLS_TLS_VERSION_1_1 || MBEDTLS_TLS_VERSION_1_2
 
+config MBEDTLS_SSL_EXPORT_KEYS
+	bool "Enable support for exporting SSL key block and master secret"
+	depends on MBEDTLS_TLS_VERSION_1_0 || MBEDTLS_TLS_VERSION_1_1 || MBEDTLS_TLS_VERSION_1_2
+
 endmenu
 
 menu "Ciphersuite configuration"
@@ -226,6 +230,7 @@ config MBEDTLS_MAC_ALL_ENABLED
 	select MBEDTLS_MAC_SHA256_ENABLED
 	select MBEDTLS_MAC_SHA512_ENABLED
 	select MBEDTLS_MAC_POLY1305_ENABLED
+	select MBEDTLS_MAC_CMAC_ENABLED
 
 config MBEDTLS_MAC_MD4_ENABLED
 	bool "Enable the MD4 hash algorithm"
@@ -242,11 +247,23 @@ config MBEDTLS_MAC_SHA256_ENABLED
 	bool "Enable the SHA-224 and SHA-256 hash algorithms"
 	default y
 
+config MBEDTLS_SHA256_SMALLER
+	bool "Enable smaller SHA-256 implementation"
+	depends on MBEDTLS_MAC_SHA256_ENABLED
+	default y
+	help
+	  Enable an implementation of SHA-256 that has lower ROM footprint but also
+	  lower performance
+
 config MBEDTLS_MAC_SHA512_ENABLED
 	bool "Enable the SHA-384 and SHA-512 hash algorithms"
 
 config MBEDTLS_MAC_POLY1305_ENABLED
 	bool "Enable the Poly1305 MAC algorithm"
+
+config MBEDTLS_MAC_CMAC_ENABLED
+	bool "Enable the CMAC (Cipher-based Message Authentication Code) mode for block ciphers."
+	depends on MBEDTLS_CIPHER_AES_ENABLED || MBEDTLS_CIPHER_DES_ENABLED
 
 endmenu
 
@@ -278,6 +295,10 @@ config MBEDTLS_HAVE_ASM
 	  Enable use of assembly code in mbedTLS. This improves the performances
 	  of asymetric cryptography, however this might have an impact on the
 	  code size.
+
+config MBEDTLS_ENTROPY_ENABLED
+	bool "Enable mbedTLS generic entropy pool"
+	depends on MBEDTLS_MAC_SHA256_ENABLED || MBEDTLS_MAC_SHA512_ENABLED
 
 config MBEDTLS_USER_CONFIG_ENABLE
 	bool "Enable user mbedTLS config file"

--- a/ext/lib/crypto/mbedtls/configs/config-tls-generic.h
+++ b/ext/lib/crypto/mbedtls/configs/config-tls-generic.h
@@ -235,12 +235,20 @@
 #define MBEDTLS_SHA256_C
 #endif
 
+#if defined(CONFIG_MBEDTLS_SHA256_SMALLER)
+#define MBEDTLS_SHA256_SMALLER
+#endif
+
 #if defined(CONFIG_MBEDTLS_MAC_SHA512_ENABLED)
 #define MBEDTLS_SHA512_C
 #endif
 
 #if defined(CONFIG_MBEDTLS_MAC_POLY1305_ENABLED)
 #define MBEDTLS_POLY1305_C
+#endif
+
+#if defined(CONFIG_MBEDTLS_MAC_CMAC_ENABLED)
+#define MBEDTLS_CMAC_C
 #endif
 
 /* mbedTLS modules */
@@ -265,6 +273,14 @@
 
 #if defined(CONFIG_MBEDTLS_GENPRIME_ENABLED)
 #define MBEDTLS_GENPRIME
+#endif
+
+#if defined(CONFIG_MBEDTLS_ENTROPY_ENABLED)
+#define MBEDTLS_ENTROPY_C
+#endif
+
+#if defined(CONFIG_MBEDTLS_SSL_EXPORT_KEYS)
+#define MBEDTLS_SSL_EXPORT_KEYS
 #endif
 
 /* Automatic dependencies */


### PR DESCRIPTION
Extend generic mbedTLS config with entries needed by OpenThread:
* MBEDTLS_CMAC_C
* MBEDTLS_ENTROPY_C
* MBEDTLS_SSL_EXPORT_KEYS
* MBEDTLS_SHA256_SMALLER

A PR actually switching OpenThread to use Zephyrs mbedTLS will follow.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>