### PR TITLE
C++ : Fix error: Empty structure

### DIFF
--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -61,6 +61,11 @@ struct k_spinlock {
 	 */
 	size_t thread_cpu;
 #endif
+
+#if !defined(CONFIG_SMP) && !defined(SPIN_VALIDATE)
+	/* Empty struct has size 0 in C, size 1 in C++ */
+	char dummy;
+#endif
 };
 
 static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)


### PR DESCRIPTION
Adds a "dummy" char member to struct k_spinlock to obtain the same behavior in C and C++.
Because a empty struct (or union) has size 0 in C, but size 1 in C++.

In some case struct k_spinlock can be empty.
k_spinlock is used in Message Queue Structure (struct k_msgq), and the struct k_msgq doesn't have the same size. That generates an alignment mismatch beetween C and C++.

Then call of k_msgq_get from C++ to kernel (in C) cause a crash.

Please note that empty struture aren't supported in C99, this is a GNU C extension:
- https://gcc.gnu.org/onlinedocs/gcc/Empty-Structures.html
- https://gcc.gnu.org/onlinedocs/gcc/Zero-Length.html
