### PR TITLE
slip: Fix compilation without NET_L2_ETHERNET and CONFIG_NET_LLDP

### DIFF
--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -32,7 +32,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/net_core.h>
 #include <console/uart_pipe.h>
 #include <net/ethernet.h>
-#include <net/lldp.h>
 
 #define SLIP_END     0300
 #define SLIP_ESC     0333
@@ -397,7 +396,9 @@ static void slip_iface_init(struct net_if *iface)
 
 	ethernet_init(iface);
 
+#if defined(CONFIG_NET_LLDP)
 	net_lldp_set_lldpdu(iface);
+#endif
 
 	if (slip->init_done) {
 		return;

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -30,8 +30,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/net_pkt.h>
 #include <net/net_if.h>
 #include <net/net_core.h>
+#include <net/dummy.h>
 #include <console/uart_pipe.h>
-#include <net/ethernet.h>
 
 #define SLIP_END     0300
 #define SLIP_ESC     0333
@@ -394,7 +394,9 @@ static void slip_iface_init(struct net_if *iface)
 	struct slip_context *slip = net_if_get_device(iface)->driver_data;
 	struct net_linkaddr *ll_addr;
 
+#if defined(CONFIG_NET_L2_ETHERNET)
 	ethernet_init(iface);
+#endif
 
 #if defined(CONFIG_NET_LLDP)
 	net_lldp_set_lldpdu(iface);
@@ -430,6 +432,7 @@ use_random_mac:
 
 static struct slip_context slip_context_data;
 
+#if defined(CONFIG_SLIP_TAP)
 static enum ethernet_hw_caps eth_capabilities(struct device *dev)
 {
 	ARG_UNUSED(dev);
@@ -441,7 +444,6 @@ static enum ethernet_hw_caps eth_capabilities(struct device *dev)
 		;
 }
 
-#if defined(CONFIG_SLIP_TAP) && defined(CONFIG_NET_L2_ETHERNET)
 static const struct ethernet_api slip_if_api = {
 	.iface_api.init = slip_iface_init,
 
@@ -459,7 +461,7 @@ ETH_NET_DEVICE_INIT(slip, CONFIG_SLIP_DRV_NAME, slip_init, &slip_context_data,
 #else
 
 static const struct dummy_api slip_if_api = {
-	.iface_init.init = slip_iface_init,
+	.iface_api.init = slip_iface_init,
 
 	.send = slip_send,
 };


### PR DESCRIPTION
From reading the source code I believe that doing so was originally intended (at least there are already some `#ifdef`s present to handle compilation without `NET_L2_ETHERNET`). However, this probably broke somewhere down the road. The changes purposed here allow compiling SLIP without  `NET_L2_ETHERNET` and `CONFIG_NET_LLDP`.

The config I used which originally caused compilation to fail can be found [here](https://files.8pit.net/tmp/zephyr-config) (Board: `hifive1`, Sample: `net/sockets/echo_server`).