### PR TITLE
arc: arm: fix support for MPUs on non-XIP systems

### DIFF
--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -51,6 +51,7 @@
 	#endif
 #else
 	#define MPU_MIN_SIZE_ALIGN
+	#define MPU_ALIGN(region_size) . = ALIGN(4)
 #endif
 
 #if defined(CONFIG_XIP)
@@ -128,7 +129,7 @@ SECTIONS {
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 	_image_rodata_end = .;
-	MPU_MIN_SIZE_ALIGN
+	MPU_ALIGN(_image_rodata_end - _image_rom_start);
 	_image_rom_end = .;
 	_image_rom_size = _image_rom_end - _image_rom_start;
 

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -277,6 +277,7 @@ SECTIONS
 #endif /* CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS */
 
 	_image_rodata_end = .;
+	MPU_ALIGN(_image_rodata_end -_image_rom_start);
 	_image_rom_end = .;
 
     GROUP_END(ROMABLE_REGION)


### PR DESCRIPTION
We now use MPU_ALIGN() to set the location counter after the ROM region.
On non-power of two systems, this just rounds the location up to the MPU granularity, the parameter value is ignored.
On power of two systems, this rounds up appropriately based on the size of ROM.

Fixes: #15558

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>