### PR TITLE
samples: net: zperf: Remove unnecessary main

### DIFF
--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -1203,7 +1203,3 @@ SHELL_STATIC_SUBCMD_SET_CREATE(zperf_commands,
 );
 
 SHELL_CMD_REGISTER(zperf, &zperf_commands, "Zperf commands", NULL);
-
-void main(void)
-{
-}


### PR DESCRIPTION
main function is not necessary.
And without main here, it is possible to import these
samples zperf files in another project.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>