### PR TITLE
bluetooth: controller: Allow out-of-tree vendor specific HCI commands

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -158,6 +158,7 @@ zephyr_library_include_directories(
 if(CONFIG_SOC_COMPATIBLE_NRF)
   zephyr_library_include_directories(
     ll_sw/nordic
+    hci/nordic
     )
 endif()
 

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -33,6 +33,7 @@
 #include "ll.h"
 #include "ll_feat.h"
 #include "hci_internal.h"
+#include "hci_vendor.h"
 
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 #include "ll_sw/ll_mesh.h"
@@ -102,7 +103,7 @@ static void le_conn_complete(struct pdu_data *pdu_data, u16_t handle,
 			     struct net_buf *buf);
 #endif /* CONFIG_BT_CONN */
 
-static void evt_create(struct net_buf *buf, u8_t evt, u8_t len)
+void hci_evt_create(struct net_buf *buf, u8_t evt, u8_t len)
 {
 	struct bt_hci_evt_hdr *hdr;
 
@@ -111,13 +112,13 @@ static void evt_create(struct net_buf *buf, u8_t evt, u8_t len)
 	hdr->len = len;
 }
 
-static void *cmd_complete(struct net_buf **buf, u8_t plen)
+void *hci_cmd_complete(struct net_buf **buf, u8_t plen)
 {
 	struct bt_hci_evt_cmd_complete *cc;
 
 	*buf = bt_buf_get_cmd_complete(K_FOREVER);
 
-	evt_create(*buf, BT_HCI_EVT_CMD_COMPLETE, sizeof(*cc) + plen);
+	hci_evt_create(*buf, BT_HCI_EVT_CMD_COMPLETE, sizeof(*cc) + plen);
 
 	cc = net_buf_add(*buf, sizeof(*cc));
 	cc->ncmd = 1U;
@@ -133,7 +134,7 @@ static struct net_buf *cmd_status(u8_t status)
 	struct net_buf *buf;
 
 	buf = bt_buf_get_cmd_complete(K_FOREVER);
-	evt_create(buf, BT_HCI_EVT_CMD_STATUS, sizeof(*cs));
+	hci_evt_create(buf, BT_HCI_EVT_CMD_STATUS, sizeof(*cs));
 
 	cs = net_buf_add(buf, sizeof(*cs));
 	cs->status = status;
@@ -148,7 +149,7 @@ static void *meta_evt(struct net_buf *buf, u8_t subevt, u8_t melen)
 {
 	struct bt_hci_evt_le_meta_event *me;
 
-	evt_create(buf, BT_HCI_EVT_LE_META_EVENT, sizeof(*me) + melen);
+	hci_evt_create(buf, BT_HCI_EVT_LE_META_EVENT, sizeof(*me) + melen);
 	me = net_buf_add(buf, sizeof(*me));
 	me->subevent = subevt;
 
@@ -160,7 +161,7 @@ static void *mesh_evt(struct net_buf *buf, u8_t subevt, u8_t melen)
 {
 	struct bt_hci_evt_mesh *me;
 
-	evt_create(buf, BT_HCI_EVT_VENDOR, sizeof(*me) + melen);
+	hci_evt_create(buf, BT_HCI_EVT_VENDOR, sizeof(*me) + melen);
 	me = net_buf_add(buf, sizeof(*me));
 	me->prefix = BT_HCI_MESH_EVT_PREFIX;
 	me->subevent = subevt;
@@ -221,7 +222,7 @@ static void set_event_mask(struct net_buf *buf, struct net_buf **evt)
 
 	event_mask = sys_get_le64(cmd->events);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = 0x00;
 }
 
@@ -232,7 +233,7 @@ static void set_event_mask_page_2(struct net_buf *buf, struct net_buf **evt)
 
 	event_mask_page_2 = sys_get_le64(cmd->events_page_2);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = 0x00;
 }
 
@@ -260,7 +261,7 @@ static void reset(struct net_buf *buf, struct net_buf **evt)
 
 	if (buf) {
 		ll_reset();
-		ccst = cmd_complete(evt, sizeof(*ccst));
+		ccst = hci_cmd_complete(evt, sizeof(*ccst));
 		ccst->status = 0x00;
 	}
 
@@ -284,7 +285,7 @@ static void set_ctl_to_host_flow(struct net_buf *buf, struct net_buf **evt)
 	u8_t flow_enable = cmd->flow_enable;
 	struct bt_hci_evt_cc_status *ccst;
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 
 	/* require host buffer size before enabling flow control, and
 	 * disallow if any connections are up
@@ -327,7 +328,7 @@ static void host_buffer_size(struct net_buf *buf, struct net_buf **evt)
 	u16_t acl_mtu = sys_le16_to_cpu(cmd->acl_mtu);
 	struct bt_hci_evt_cc_status *ccst;
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 
 	if (hci_hbuf_total) {
 		ccst->status = BT_HCI_ERR_CMD_DISALLOWED;
@@ -355,11 +356,11 @@ static void host_num_completed_packets(struct net_buf *buf,
 
 	/* special case, no event returned except for error conditions */
 	if (hci_hbuf_total <= 0) {
-		ccst = cmd_complete(evt, sizeof(*ccst));
+		ccst = hci_cmd_complete(evt, sizeof(*ccst));
 		ccst->status = BT_HCI_ERR_CMD_DISALLOWED;
 		return;
 	} else if (!conn_count) {
-		ccst = cmd_complete(evt, sizeof(*ccst));
+		ccst = hci_cmd_complete(evt, sizeof(*ccst));
 		ccst->status = BT_HCI_ERR_INVALID_PARAM;
 		return;
 	}
@@ -371,7 +372,7 @@ static void host_num_completed_packets(struct net_buf *buf,
 
 		if ((h >= ARRAY_SIZE(hci_hbuf_pend)) ||
 		    (c > hci_hbuf_pend[h])) {
-			ccst = cmd_complete(evt, sizeof(*ccst));
+			ccst = hci_cmd_complete(evt, sizeof(*ccst));
 			ccst->status = BT_HCI_ERR_INVALID_PARAM;
 			return;
 		}
@@ -399,7 +400,7 @@ static void read_auth_payload_timeout(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_apto_get(handle, &auth_payload_timeout);
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
 	rp->handle = sys_cpu_to_le16(handle);
 	rp->auth_payload_timeout = sys_cpu_to_le16(auth_payload_timeout);
@@ -419,7 +420,7 @@ static void write_auth_payload_timeout(struct net_buf *buf,
 
 	status = ll_apto_set(handle, auth_payload_timeout);
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
 	rp->handle = sys_cpu_to_le16(handle);
 }
@@ -437,7 +438,7 @@ static void read_tx_power_level(struct net_buf *buf, struct net_buf **evt)
 	handle = sys_le16_to_cpu(cmd->handle);
 	type = cmd->type;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	status = ll_tx_pwr_lvl_get(handle, type, &rp->tx_power_level);
 
@@ -503,7 +504,7 @@ static void read_local_version_info(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_read_local_version_info *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
 	rp->hci_version = LL_VERSION_NUMBER;
@@ -517,7 +518,7 @@ static void read_supported_commands(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_read_supported_commands *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
 	(void)memset(&rp->commands[0], 0, sizeof(rp->commands));
@@ -660,7 +661,7 @@ static void read_local_features(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_read_local_features *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
 	(void)memset(&rp->features[0], 0x00, sizeof(rp->features));
@@ -672,7 +673,7 @@ static void read_bd_addr(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_read_bd_addr *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
 
@@ -715,7 +716,7 @@ static void read_rssi(struct net_buf *buf, struct net_buf **evt)
 
 	handle = sys_le16_to_cpu(cmd->handle);
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = ll_rssi_get(handle, &rp->rssi);
 
@@ -749,7 +750,7 @@ static void le_set_event_mask(struct net_buf *buf, struct net_buf **evt)
 
 	le_event_mask = sys_get_le64(cmd->events);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = 0x00;
 }
 
@@ -757,7 +758,7 @@ static void le_read_buffer_size(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_le_read_buffer_size *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
 
@@ -769,7 +770,7 @@ static void le_read_local_features(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_le_read_local_features *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
 
@@ -787,7 +788,7 @@ static void le_set_random_address(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_addr_set(1, &cmd->bdaddr.val[0]);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -796,7 +797,7 @@ static void le_read_wl_size(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_le_read_wl_size *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = 0x00;
 
 	rp->wl_size = ll_wl_size_get();
@@ -806,7 +807,7 @@ static void le_clear_wl(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_evt_cc_status *ccst;
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = ll_wl_clear();
 }
 
@@ -818,7 +819,7 @@ static void le_add_dev_to_wl(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_wl_add(&cmd->addr);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -830,7 +831,7 @@ static void le_rem_dev_from_wl(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_wl_remove(&cmd->addr);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 #endif /* CONFIG_BT_CTLR_FILTER */
@@ -843,7 +844,7 @@ static void le_encrypt(struct net_buf *buf, struct net_buf **evt)
 
 	ecb_encrypt(cmd->key, cmd->plaintext, enc_data, NULL);
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
 	memcpy(rp->enc_data, enc_data, 16);
@@ -854,7 +855,7 @@ static void le_rand(struct net_buf *buf, struct net_buf **evt)
 	struct bt_hci_rp_le_rand *rp;
 	u8_t count = sizeof(rp->rand);
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = 0x00;
 
 	bt_rand(rp->rand, count);
@@ -865,7 +866,7 @@ static void le_read_supp_states(struct net_buf *buf, struct net_buf **evt)
 	struct bt_hci_rp_le_read_supp_states *rp;
 	u64_t states = 0U;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = 0x00;
 
 #define ST_ADV (BIT64(0)  | BIT64(1)  | BIT64(8)  | BIT64(9)  | BIT64(12) | \
@@ -940,7 +941,7 @@ static void le_set_adv_param(struct net_buf *buf, struct net_buf **evt)
 				   cmd->filter_policy);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -948,7 +949,7 @@ static void le_read_adv_chan_tx_power(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_le_read_chan_tx_power *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
 
@@ -967,7 +968,7 @@ static void le_set_adv_data(struct net_buf *buf, struct net_buf **evt)
 	status = ll_adv_data_set(cmd->len, &cmd->data[0]);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -983,7 +984,7 @@ static void le_set_scan_rsp_data(struct net_buf *buf, struct net_buf **evt)
 	status = ll_adv_scan_rsp_set(cmd->len, &cmd->data[0]);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -1003,7 +1004,7 @@ static void le_set_adv_enable(struct net_buf *buf, struct net_buf **evt)
 	status = ll_adv_enable(cmd->enable);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT || !CONFIG_BT_HCI_MESH_EXT */
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 #endif /* CONFIG_BT_BROADCASTER */
@@ -1023,7 +1024,7 @@ static void le_set_scan_param(struct net_buf *buf, struct net_buf **evt)
 	status = ll_scan_params_set(cmd->scan_type, interval, window,
 				    cmd->addr_type, cmd->filter_policy);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -1044,7 +1045,7 @@ static void le_set_scan_enable(struct net_buf *buf, struct net_buf **evt)
 #endif
 	status = ll_scan_enable(cmd->enable);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 #endif /* CONFIG_BT_OBSERVER */
@@ -1085,7 +1086,7 @@ static void le_create_conn_cancel(struct net_buf *buf, struct net_buf **evt,
 
 	status = ll_connect_disable(node_rx);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -1097,7 +1098,7 @@ static void le_set_host_chan_classif(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_chm_update(&cmd->ch_map[0]);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -1131,7 +1132,7 @@ static void le_ltk_req_reply(struct net_buf *buf, struct net_buf **evt)
 	handle = sys_le16_to_cpu(cmd->handle);
 	status = ll_start_enc_req_send(handle, 0x00, &cmd->ltk[0]);
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
 	rp->handle = sys_cpu_to_le16(handle);
 }
@@ -1147,7 +1148,7 @@ static void le_ltk_req_neg_reply(struct net_buf *buf, struct net_buf **evt)
 	status = ll_start_enc_req_send(handle, BT_HCI_ERR_PIN_OR_KEY_MISSING,
 				       NULL);
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
 	rp->handle = sys_le16_to_cpu(handle);
 }
@@ -1175,7 +1176,7 @@ static void le_read_chan_map(struct net_buf *buf, struct net_buf **evt)
 
 	handle = sys_le16_to_cpu(cmd->handle);
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	status = ll_chm_get(handle, rp->ch_map);
 
@@ -1227,7 +1228,7 @@ static void le_conn_param_req_reply(struct net_buf *buf, struct net_buf **evt)
 	status = ll_conn_update(handle, 2, 0, interval_min, interval_max,
 				latency, timeout);
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
 	rp->handle = sys_cpu_to_le16(handle);
 }
@@ -1243,7 +1244,7 @@ static void le_conn_param_req_neg_reply(struct net_buf *buf,
 	handle = sys_le16_to_cpu(cmd->handle);
 	status = ll_conn_update(handle, 2, cmd->reason, 0, 0, 0, 0);
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
 	rp->handle = sys_cpu_to_le16(handle);
 }
@@ -1264,7 +1265,7 @@ static void le_set_data_len(struct net_buf *buf, struct net_buf **evt)
 	tx_time = sys_le16_to_cpu(cmd->tx_time);
 	status = ll_length_req_send(handle, tx_octets, tx_time);
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
 	rp->handle = sys_cpu_to_le16(handle);
 }
@@ -1273,7 +1274,7 @@ static void le_read_default_data_len(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_le_read_default_data_len *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	ll_length_default_get(&rp->max_tx_octets, &rp->max_tx_time);
 
@@ -1289,7 +1290,7 @@ static void le_write_default_data_len(struct net_buf *buf,
 
 	status = ll_length_default_set(cmd->max_tx_octets, cmd->max_tx_time);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -1297,7 +1298,7 @@ static void le_read_max_data_len(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_le_read_max_data_len *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	ll_length_max_get(&rp->max_tx_octets, &rp->max_tx_time,
 			  &rp->max_rx_octets, &rp->max_rx_time);
@@ -1315,7 +1316,7 @@ static void le_read_phy(struct net_buf *buf, struct net_buf **evt)
 
 	handle = sys_le16_to_cpu(cmd->handle);
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	status = ll_phy_get(handle, &rp->tx_phy, &rp->rx_phy);
 
@@ -1340,7 +1341,7 @@ static void le_set_default_phy(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_phy_default_set(cmd->tx_phys, cmd->rx_phys);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -1407,7 +1408,7 @@ static void le_add_dev_to_rl(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_rl_add(&cmd->peer_id_addr, cmd->peer_irk, cmd->local_irk);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -1419,14 +1420,14 @@ static void le_rem_dev_from_rl(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_rl_remove(&cmd->peer_id_addr);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
 static void le_clear_rl(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_evt_cc_status *ccst;
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 
 	ccst->status = ll_rl_clear();
 }
@@ -1435,7 +1436,7 @@ static void le_read_rl_size(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_le_read_rl_size *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->rl_size = ll_rl_size_get();
 	rp->status = 0x00;
@@ -1448,7 +1449,7 @@ static void le_read_peer_rpa(struct net_buf *buf, struct net_buf **evt)
 	bt_addr_le_t peer_id_addr;
 
 	bt_addr_le_copy(&peer_id_addr, &cmd->peer_id_addr);
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = ll_rl_crpa_get(&peer_id_addr, &rp->peer_rpa);
 }
@@ -1460,7 +1461,7 @@ static void le_read_local_rpa(struct net_buf *buf, struct net_buf **evt)
 	bt_addr_le_t peer_id_addr;
 
 	bt_addr_le_copy(&peer_id_addr, &cmd->peer_id_addr);
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = ll_rl_lrpa_get(&peer_id_addr, &rp->local_rpa);
 }
@@ -1471,7 +1472,7 @@ static void le_set_addr_res_enable(struct net_buf *buf, struct net_buf **evt)
 	struct bt_hci_evt_cc_status *ccst;
 	u8_t enable = cmd->enable;
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = ll_rl_enable(enable);
 }
 
@@ -1483,7 +1484,7 @@ static void le_set_rpa_timeout(struct net_buf *buf, struct net_buf **evt)
 
 	ll_rl_timeout_set(timeout);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = 0x00;
 }
 
@@ -1495,7 +1496,7 @@ static void le_set_privacy_mode(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_priv_mode_set(&cmd->id_addr, cmd->mode);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 #endif /* CONFIG_BT_CTLR_PRIVACY */
@@ -1504,7 +1505,7 @@ static void le_read_tx_power(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_le_read_tx_power *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = 0x00;
 	ll_tx_pwr_get(&rp->min_tx_power, &rp->max_tx_power);
 }
@@ -1518,7 +1519,7 @@ static void le_rx_test(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_test_rx(cmd->rx_ch, 0x01, 0);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -1531,7 +1532,7 @@ static void le_tx_test(struct net_buf *buf, struct net_buf **evt)
 	status = ll_test_tx(cmd->tx_ch, cmd->test_data_len, cmd->pkt_payload,
 			    0x01);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -1542,7 +1543,7 @@ static void le_test_end(struct net_buf *buf, struct net_buf **evt)
 
 	ll_test_end(&rx_pkt_count);
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = 0x00;
 	rp->rx_pkt_count = sys_cpu_to_le16(rx_pkt_count);
 }
@@ -1555,7 +1556,7 @@ static void le_enh_rx_test(struct net_buf *buf, struct net_buf **evt)
 
 	status = ll_test_rx(cmd->rx_ch, cmd->phy, cmd->mod_index);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 
@@ -1568,7 +1569,7 @@ static void le_enh_tx_test(struct net_buf *buf, struct net_buf **evt)
 	status = ll_test_tx(cmd->tx_ch, cmd->test_data_len, cmd->pkt_payload,
 			    cmd->phy);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = status;
 }
 #endif /* CONFIG_BT_CTLR_DTM_HCI */
@@ -1807,7 +1808,7 @@ static void vs_read_version_info(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_vs_read_version_info *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
 	rp->hw_platform = sys_cpu_to_le16(BT_HCI_VS_HW_PLAT);
@@ -1824,7 +1825,7 @@ static void vs_read_supported_commands(struct net_buf *buf,
 {
 	struct bt_hci_rp_vs_read_supported_commands *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
 	(void)memset(&rp->commands[0], 0, sizeof(rp->commands));
@@ -1844,7 +1845,7 @@ static void vs_read_supported_features(struct net_buf *buf,
 {
 	struct bt_hci_rp_vs_read_supported_features *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
 	(void)memset(&rp->features[0], 0x00, sizeof(rp->features));
@@ -1858,7 +1859,7 @@ static void vs_write_bd_addr(struct net_buf *buf, struct net_buf **evt)
 
 	ll_addr_set(0, &cmd->bdaddr.val[0]);
 
-	ccst = cmd_complete(evt, sizeof(*ccst));
+	ccst = hci_cmd_complete(evt, sizeof(*ccst));
 	ccst->status = 0x00;
 }
 
@@ -1878,7 +1879,7 @@ static void vs_read_build_info(struct net_buf *buf, struct net_buf **evt)
 
 	BUILD_ASSERT(CONFIG_BT_RX_BUF_LEN >= BUILD_INFO_EVT_LEN);
 
-	rp = cmd_complete(evt, sizeof(*rp) + sizeof(build_info));
+	rp = hci_cmd_complete(evt, sizeof(*rp) + sizeof(build_info));
 	rp->status = 0x00;
 	memcpy(rp->info, build_info, sizeof(build_info));
 }
@@ -1898,7 +1899,7 @@ static void vs_read_static_addrs(struct net_buf *buf, struct net_buf **evt)
 	      (NRF_FICR->DEVICEADDRTYPE & 0x01)) {
 		struct bt_hci_vs_static_addr *addr;
 
-		rp = cmd_complete(evt, sizeof(*rp) + sizeof(*addr));
+		rp = hci_cmd_complete(evt, sizeof(*rp) + sizeof(*addr));
 		rp->status = 0x00;
 		rp->num_addrs = 1U;
 
@@ -1918,7 +1919,7 @@ static void vs_read_static_addrs(struct net_buf *buf, struct net_buf **evt)
 	}
 #endif /* CONFIG_SOC_FAMILY_NRF */
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = 0x00;
 	rp->num_addrs = 0U;
 }
@@ -1928,7 +1929,7 @@ static void vs_read_key_hierarchy_roots(struct net_buf *buf,
 {
 	struct bt_hci_rp_vs_read_key_hierarchy_roots *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = 0x00;
 
 #if defined(CONFIG_SOC_COMPATIBLE_NRF)
@@ -1975,7 +1976,7 @@ static void mesh_get_opts(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_mesh_get_opts *rp;
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
 	rp->opcode = BT_HCI_OC_MESH_GET_OPTS;
@@ -2034,7 +2035,7 @@ static void mesh_set_scan_filter(struct net_buf *buf, struct net_buf **evt)
 	f->count = cmd->num_patterns;
 
 exit:
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
 	rp->opcode = BT_HCI_OC_MESH_SET_SCAN_FILTER;
 	rp->scan_filter = filter + 1;
@@ -2059,7 +2060,7 @@ static void mesh_advertise(struct net_buf *buf, struct net_buf **evt)
 		sf_curr = cmd->scan_filter - 1;
 	}
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
 	rp->opcode = BT_HCI_OC_MESH_ADVERTISE;
 	rp->adv_slot = adv_slot;
@@ -2078,7 +2079,7 @@ static void mesh_advertise_cancel(struct net_buf *buf, struct net_buf **evt)
 		sf_curr = 0xFF;
 	}
 
-	rp = cmd_complete(evt, sizeof(*rp));
+	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
 	rp->opcode = BT_HCI_OC_MESH_ADVERTISE_CANCEL;
 	rp->adv_slot = adv_slot;
@@ -2122,8 +2123,8 @@ static int mesh_cmd_handle(struct net_buf *cmd, struct net_buf **evt)
 }
 #endif /* CONFIG_BT_HCI_MESH_EXT */
 
-static int vendor_cmd_handle(u16_t ocf, struct net_buf *cmd,
-			     struct net_buf **evt)
+int hci_vendor_cmd_handle_common(u16_t ocf, struct net_buf *cmd,
+				 struct net_buf **evt)
 {
 	switch (ocf) {
 	case BT_OCF(BT_HCI_OP_VS_READ_VERSION_INFO):
@@ -2236,7 +2237,7 @@ struct net_buf *hci_cmd_handle(struct net_buf *cmd, void **node_rx)
 		break;
 #if defined(CONFIG_BT_HCI_VS)
 	case BT_OGF_VS:
-		err = vendor_cmd_handle(ocf, cmd, &evt);
+		err = hci_vendor_cmd_handle(ocf, cmd, &evt);
 		break;
 #endif
 	default:
@@ -2245,7 +2246,7 @@ struct net_buf *hci_cmd_handle(struct net_buf *cmd, void **node_rx)
 	}
 
 	if (err == -EINVAL) {
-		ccst = cmd_complete(&evt, sizeof(*ccst));
+		ccst = hci_cmd_complete(&evt, sizeof(*ccst));
 		ccst->status = BT_HCI_ERR_UNKNOWN_CMD;
 	}
 
@@ -2262,7 +2263,7 @@ static void data_buf_overflow(struct net_buf **buf)
 	}
 
 	*buf = bt_buf_get_rx(BT_BUF_EVT, K_FOREVER);
-	evt_create(*buf, BT_HCI_EVT_DATA_BUF_OVERFLOW, sizeof(*ep));
+	hci_evt_create(*buf, BT_HCI_EVT_DATA_BUF_OVERFLOW, sizeof(*ep));
 	ep = net_buf_add(*buf, sizeof(*ep));
 
 	ep->link_type = BT_OVERFLOW_LINK_ACL;
@@ -2802,7 +2803,7 @@ static void disconn_complete(struct pdu_data *pdu_data, u16_t handle,
 		return;
 	}
 
-	evt_create(buf, BT_HCI_EVT_DISCONN_COMPLETE, sizeof(*ep));
+	hci_evt_create(buf, BT_HCI_EVT_DISCONN_COMPLETE, sizeof(*ep));
 	ep = net_buf_add(buf, sizeof(*ep));
 
 	ep->status = 0x00;
@@ -2850,7 +2851,8 @@ static void enc_refresh_complete(struct pdu_data *pdu_data, u16_t handle,
 		return;
 	}
 
-	evt_create(buf, BT_HCI_EVT_ENCRYPT_KEY_REFRESH_COMPLETE, sizeof(*ep));
+	hci_evt_create(buf, BT_HCI_EVT_ENCRYPT_KEY_REFRESH_COMPLETE,
+		       sizeof(*ep));
 	ep = net_buf_add(buf, sizeof(*ep));
 
 	ep->status = 0x00;
@@ -2868,7 +2870,7 @@ static void auth_payload_timeout_exp(struct pdu_data *pdu_data, u16_t handle,
 		return;
 	}
 
-	evt_create(buf, BT_HCI_EVT_AUTH_PAYLOAD_TIMEOUT_EXP, sizeof(*ep));
+	hci_evt_create(buf, BT_HCI_EVT_AUTH_PAYLOAD_TIMEOUT_EXP, sizeof(*ep));
 	ep = net_buf_add(buf, sizeof(*ep));
 
 	ep->handle = sys_cpu_to_le16(handle);
@@ -3081,7 +3083,7 @@ static void encrypt_change(u8_t err, u16_t handle,
 		return;
 	}
 
-	evt_create(buf, BT_HCI_EVT_ENCRYPT_CHANGE, sizeof(*ep));
+	hci_evt_create(buf, BT_HCI_EVT_ENCRYPT_CHANGE, sizeof(*ep));
 	ep = net_buf_add(buf, sizeof(*ep));
 
 	ep->status = err;
@@ -3139,7 +3141,7 @@ static void remote_version_info(struct pdu_data *pdu_data, u16_t handle,
 		return;
 	}
 
-	evt_create(buf, BT_HCI_EVT_REMOTE_VERSION_INFO, sizeof(*ep));
+	hci_evt_create(buf, BT_HCI_EVT_REMOTE_VERSION_INFO, sizeof(*ep));
 	ep = net_buf_add(buf, sizeof(*ep));
 
 	ver_ind = &pdu_data->llctrl.version_ind;
@@ -3321,7 +3323,7 @@ void hci_num_cmplt_encode(struct net_buf *buf, u16_t handle, u8_t num)
 	num_handles = 1U;
 
 	len = (sizeof(*ep) + (sizeof(*hc) * num_handles));
-	evt_create(buf, BT_HCI_EVT_NUM_COMPLETED_PACKETS, len);
+	hci_evt_create(buf, BT_HCI_EVT_NUM_COMPLETED_PACKETS, len);
 
 	ep = net_buf_add(buf, len);
 	ep->num_handles = num_handles;

--- a/subsys/bluetooth/controller/hci/hci_internal.h
+++ b/subsys/bluetooth/controller/hci/hci_internal.h
@@ -19,18 +19,6 @@ extern atomic_t hci_state_mask;
 #define HCI_CLASS_EVT_CONNECTION  2
 #define HCI_CLASS_ACL_DATA        3
 
-#if defined(CONFIG_SOC_COMPATIBLE_NRF)
-#define BT_HCI_VS_HW_PLAT BT_HCI_VS_HW_PLAT_NORDIC
-#if defined(CONFIG_SOC_SERIES_NRF51X)
-#define BT_HCI_VS_HW_VAR  BT_HCI_VS_HW_VAR_NORDIC_NRF51X
-#elif defined(CONFIG_SOC_COMPATIBLE_NRF52X)
-#define BT_HCI_VS_HW_VAR  BT_HCI_VS_HW_VAR_NORDIC_NRF52X
-#endif
-#else
-#define BT_HCI_VS_HW_PLAT 0
-#define BT_HCI_VS_HW_VAR  0
-#endif /* CONFIG_SOC_FAMILY_NRF */
-
 void hci_init(struct k_poll_signal *signal_host_buf);
 struct net_buf *hci_cmd_handle(struct net_buf *cmd, void **node_rx);
 void hci_evt_encode(struct node_rx_pdu *node_rx, struct net_buf *buf);
@@ -40,3 +28,9 @@ int hci_acl_handle(struct net_buf *acl, struct net_buf **evt);
 void hci_acl_encode(struct node_rx_pdu *node_rx, struct net_buf *buf);
 void hci_num_cmplt_encode(struct net_buf *buf, u16_t handle, u8_t num);
 #endif
+int hci_vendor_cmd_handle(u16_t ocf, struct net_buf *cmd,
+			  struct net_buf **evt);
+int hci_vendor_cmd_handle_common(u16_t ocf, struct net_buf *cmd,
+			     struct net_buf **evt);
+void *hci_cmd_complete(struct net_buf **buf, u8_t plen);
+void hci_evt_create(struct net_buf *buf, u8_t evt, u8_t len);

--- a/subsys/bluetooth/controller/hci/nordic/hci_vendor.h
+++ b/subsys/bluetooth/controller/hci/nordic/hci_vendor.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF)
+#define BT_HCI_VS_HW_PLAT BT_HCI_VS_HW_PLAT_NORDIC
+#if defined(CONFIG_SOC_SERIES_NRF51X)
+#define BT_HCI_VS_HW_VAR  BT_HCI_VS_HW_VAR_NORDIC_NRF51X
+#elif defined(CONFIG_SOC_COMPATIBLE_NRF52X)
+#define BT_HCI_VS_HW_VAR  BT_HCI_VS_HW_VAR_NORDIC_NRF52X
+#endif
+#else
+#define BT_HCI_VS_HW_PLAT 0
+#define BT_HCI_VS_HW_VAR  0
+#endif /* CONFIG_SOC_FAMILY_NRF */
+
+/* Map vendor command handler directly to common implementation */
+inline int hci_vendor_cmd_handle(u16_t ocf, struct net_buf *cmd,
+				 struct net_buf **evt)
+{
+	return hci_vendor_cmd_handle_common(ocf, cmd, evt);
+}


### PR DESCRIPTION
Renamed function vendor_cmd_handle to vendor_cmd_handle_common for
shared vendor commands. This allows vendor to implement vendor_cmd_handle
containing both common and specific handling.

Signed-off-by: Morten Priess <mtpr@oticon.com>