### PR TITLE
west: zephyr_module: Improved error messaging during west failures

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -134,6 +134,7 @@ def main():
             # outside a west managed project.
             projects = []
         else:
+            print(err.decode(sys.getdefaultencoding()))
             # A real error occurred, raise an exception
             raise subprocess.CalledProcessError(cmd=p.args,
                                                 returncode=p.returncode)


### PR DESCRIPTION
Fixes: #15664

This commit improve error messaging in case `west list` fails.
Previously any error messages and stack trace reported by `west` will
was thrown away by zephyr_module.py.

Now the error, as well as any stack traces, printed by `west` will be
re-printed to the user.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>