### PR TITLE
cmake: zephyr_modules: Add west executable argument

### DIFF
--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -20,12 +20,17 @@ endif()
 
 set(KCONFIG_MODULES_FILE ${CMAKE_BINARY_DIR}/Kconfig.modules)
 
+if(WEST)
+  set(WEST_ARG "--west-path" ${WEST})
+endif()
+
 if(WEST OR ZEPHYR_MODULES)
   # Zephyr module uses west, so only call it if west is installed or
   # ZEPHYR_MODULES was provided as argument to CMake.
   execute_process(
     COMMAND
     ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/zephyr_module.py
+    ${WEST_ARG}
     ${ZEPHYR_MODULES_ARG}
     ${ZEPHYR_EXTRA_MODULES_ARG}
     --kconfig-out ${KCONFIG_MODULES_FILE}

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -119,10 +119,12 @@ def main():
                              'list`')
     parser.add_argument('-x', '--extra-modules', nargs='+',
                         help='List of extra modules to parse')
+    parser.add_argument('-w', '--west-path', default='west',
+                        help='Path to west executable')
     args = parser.parse_args()
 
     if args.modules is None:
-        p = subprocess.Popen(['west', 'list', '--format={posixpath}'],
+        p = subprocess.Popen([args.west_path, 'list', '--format={posixpath}'],
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         out, err = p.communicate()


### PR DESCRIPTION
On some systems where you don't have access to `PATH` and you can't
set the `ENV{PATH}` variable. You need to be able to pass the path
to the west executable down to the python script so it is better
for it to be set explicitly than assuming that it exsists as a
part of the PATH/executables in the shell being called.

Signed-off-by: Sigvart M. Hovland <sigvart.hovland@nordicsemi.no>