### PR TITLE
net: openthread: Fix utilsFlashErasePage function

### DIFF
--- a/subsys/net/lib/openthread/platform/flash.c
+++ b/subsys/net/lib/openthread/platform/flash.c
@@ -60,6 +60,7 @@ u32_t utilsFlashGetSize(void)
 
 otError utilsFlashErasePage(u32_t aAddress)
 {
+	otError err = OT_ERROR_NONE;
 	struct flash_pages_info info;
 	u32_t address;
 
@@ -68,11 +69,17 @@ otError utilsFlashErasePage(u32_t aAddress)
 		return OT_ERROR_FAILED;
 	}
 
-	if (flash_erase(flash_dev, address, info.size)) {
+	if (flash_write_protection_set(flash_dev, false) < 0) {
 		return OT_ERROR_FAILED;
 	}
 
-	return OT_ERROR_NONE;
+	if (flash_erase(flash_dev, address, info.size) < 0) {
+		err = OT_ERROR_FAILED;
+	}
+
+	(void)flash_write_protection_set(flash_dev, true);
+
+	return err;
 }
 
 otError utilsFlashStatusWait(u32_t aTimeout)


### PR DESCRIPTION
Zephyr implementation of OpenThreads utilsFlashErasePage platform
function did not disable flash protection before calling `flash_erase`
function. This resulted in an error instead of actual flash erase on
platforms that properly implement flash write protection.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>