### PR TITLE
C++: Fix compilation error "invalid conversion"

### DIFF
--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -69,7 +69,7 @@ z_arch_switch_to_main_thread(struct k_thread *main_thread,
 	start_of_main_stack =
 		Z_THREAD_STACK_BUFFER(main_stack) + main_stack_size;
 #endif
-	start_of_main_stack = (void *)STACK_ROUND_DOWN(start_of_main_stack);
+	start_of_main_stack = (char *)STACK_ROUND_DOWN(start_of_main_stack);
 
 #ifdef CONFIG_TRACING
 	z_sys_trace_thread_switched_out();

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -227,7 +227,7 @@ void spi_context_buffers_setup(struct spi_context *ctx,
 	if (tx_bufs) {
 		ctx->current_tx = tx_bufs->buffers;
 		ctx->tx_count = tx_bufs->count;
-		ctx->tx_buf = ctx->current_tx->buf;
+		ctx->tx_buf = (const u8_t *)ctx->current_tx->buf;
 		ctx->tx_len = ctx->current_tx->len / dfs;
 	} else {
 		ctx->current_tx = NULL;
@@ -239,7 +239,7 @@ void spi_context_buffers_setup(struct spi_context *ctx,
 	if (rx_bufs) {
 		ctx->current_rx = rx_bufs->buffers;
 		ctx->rx_count = rx_bufs->count;
-		ctx->rx_buf = ctx->current_rx->buf;
+		ctx->rx_buf = (u8_t *)ctx->current_rx->buf;
 		ctx->rx_len = ctx->current_rx->len / dfs;
 	} else {
 		ctx->current_rx = NULL;
@@ -278,7 +278,7 @@ void spi_context_update_tx(struct spi_context *ctx, u8_t dfs, u32_t len)
 		ctx->tx_count--;
 		if (ctx->tx_count) {
 			ctx->current_tx++;
-			ctx->tx_buf = ctx->current_tx->buf;
+			ctx->tx_buf = (const u8_t *)ctx->current_tx->buf;
 			ctx->tx_len = ctx->current_tx->len / dfs;
 		} else {
 			ctx->tx_buf = NULL;
@@ -326,7 +326,7 @@ void spi_context_update_rx(struct spi_context *ctx, u8_t dfs, u32_t len)
 		ctx->rx_count--;
 		if (ctx->rx_count) {
 			ctx->current_rx++;
-			ctx->rx_buf = ctx->current_rx->buf;
+			ctx->rx_buf = (u8_t *)ctx->current_rx->buf;
 			ctx->rx_len = ctx->current_rx->len / dfs;
 		} else {
 			ctx->rx_buf = NULL;

--- a/include/can.h
+++ b/include/can.h
@@ -269,7 +269,8 @@ static inline int z_impl_can_send(struct device *dev,
 				 const struct zcan_frame *msg,
 				 s32_t timeout, can_tx_callback_t callback_isr)
 {
-	const struct can_driver_api *api = dev->driver_api;
+	const struct can_driver_api *api =
+		(const struct can_driver_api *)dev->driver_api;
 
 	return api->send(dev, msg, timeout, callback_isr);
 }
@@ -344,7 +345,8 @@ static inline int z_impl_can_attach_msgq(struct device *dev,
 					struct k_msgq *msg_q,
 					const struct zcan_filter *filter)
 {
-	const struct can_driver_api *api = dev->driver_api;
+	const struct can_driver_api *api =
+		(const struct can_driver_api *)dev->driver_api;
 
 	return api->attach_msgq(dev, msg_q, filter);
 }
@@ -371,7 +373,8 @@ static inline int can_attach_isr(struct device *dev,
 				       can_rx_callback_t isr,
 				       const struct zcan_filter *filter)
 {
-	const struct can_driver_api *api = dev->driver_api;
+	const struct can_driver_api *api =
+		(const struct can_driver_api *)dev->driver_api;
 
 	return api->attach_isr(dev, isr, filter);
 }
@@ -391,7 +394,8 @@ __syscall void can_detach(struct device *dev, int filter_id);
 
 static inline void z_impl_can_detach(struct device *dev, int filter_id)
 {
-	const struct can_driver_api *api = dev->driver_api;
+	const struct can_driver_api *api =
+		(const struct can_driver_api *)dev->driver_api;
 
 	return api->detach(dev, filter_id);
 }
@@ -412,7 +416,8 @@ __syscall int can_configure(struct device *dev, enum can_mode mode,
 static inline int z_impl_can_configure(struct device *dev, enum can_mode mode,
 				      u32_t bitrate)
 {
-	const struct can_driver_api *api = dev->driver_api;
+	const struct can_driver_api *api =
+		(const struct can_driver_api *)dev->driver_api;
 
 	return api->configure(dev, mode, bitrate);
 }

--- a/include/clock_control.h
+++ b/include/clock_control.h
@@ -51,7 +51,8 @@ struct clock_control_driver_api {
 static inline int clock_control_on(struct device *dev,
 				   clock_control_subsys_t sys)
 {
-	const struct clock_control_driver_api *api = dev->driver_api;
+	const struct clock_control_driver_api *api =
+		(const struct clock_control_driver_api *)dev->driver_api;
 
 	return api->on(dev, sys);
 }
@@ -65,7 +66,8 @@ static inline int clock_control_on(struct device *dev,
 static inline int clock_control_off(struct device *dev,
 				    clock_control_subsys_t sys)
 {
-	const struct clock_control_driver_api *api = dev->driver_api;
+	const struct clock_control_driver_api *api =
+		(const struct clock_control_driver_api *)dev->driver_api;
 
 	return api->off(dev, sys);
 }
@@ -81,7 +83,8 @@ static inline int clock_control_get_rate(struct device *dev,
 					 clock_control_subsys_t sys,
 					 u32_t *rate)
 {
-	const struct clock_control_driver_api *api = dev->driver_api;
+	const struct clock_control_driver_api *api =
+		(const struct clock_control_driver_api *)dev->driver_api;
 
 	__ASSERT(api->get_rate != NULL, "%s not implemented for device %s",
 		__func__, dev->config->name);

--- a/include/entropy.h
+++ b/include/entropy.h
@@ -69,7 +69,8 @@ static inline int z_impl_entropy_get_entropy(struct device *dev,
 					    u8_t *buffer,
 					    u16_t length)
 {
-	const struct entropy_driver_api *api = dev->driver_api;
+	const struct entropy_driver_api *api =
+		(const struct entropy_driver_api *)dev->driver_api;
 
 	__ASSERT(api->get_entropy != NULL,
 		"Callback pointer should not be NULL");
@@ -94,7 +95,8 @@ static inline int entropy_get_entropy_isr(struct device *dev,
 					  u16_t length,
 					  u32_t flags)
 {
-	const struct entropy_driver_api *api = dev->driver_api;
+	const struct entropy_driver_api *api =
+		(const struct entropy_driver_api *)dev->driver_api;
 
 	if (unlikely(!api->get_entropy_isr)) {
 		return -ENOTSUP;

--- a/include/misc/rb.h
+++ b/include/misc/rb.h
@@ -159,8 +159,9 @@ struct _rb_foreach {
 }
 #else
 #define _RB_FOREACH_INIT(tree, node) {					\
-	.stack   = alloca((tree)->max_depth * sizeof(struct rbnode *)), \
-	.is_left = alloca((tree)->max_depth * sizeof(char)),		\
+	.stack   = (struct rbnode **)					\
+			alloca((tree)->max_depth * sizeof(struct rbnode *)), \
+	.is_left = (char *)alloca((tree)->max_depth * sizeof(char)),		\
 	.top     = -1							\
 }
 #endif

--- a/include/pinmux.h
+++ b/include/pinmux.h
@@ -75,21 +75,24 @@ struct pinmux_driver_api {
 
 static inline int pinmux_pin_set(struct device *dev, u32_t pin, u32_t func)
 {
-	const struct pinmux_driver_api *api = dev->driver_api;
+	const struct pinmux_driver_api *api =
+		(const struct pinmux_driver_api *)dev->driver_api;
 
 	return api->set(dev, pin, func);
 }
 
 static inline int pinmux_pin_get(struct device *dev, u32_t pin, u32_t *func)
 {
-	const struct pinmux_driver_api *api = dev->driver_api;
+	const struct pinmux_driver_api *api =
+		(const struct pinmux_driver_api *)dev->driver_api;
 
 	return api->get(dev, pin, func);
 }
 
 static inline int pinmux_pin_pullup(struct device *dev, u32_t pin, u8_t func)
 {
-	const struct pinmux_driver_api *api = dev->driver_api;
+	const struct pinmux_driver_api *api =
+		(const struct pinmux_driver_api *)dev->driver_api;
 
 	return api->pullup(dev, pin, func);
 }
@@ -97,7 +100,8 @@ static inline int pinmux_pin_pullup(struct device *dev, u32_t pin, u8_t func)
 static inline int pinmux_pin_input_enable(struct device *dev, u32_t pin,
 					  u8_t func)
 {
-	const struct pinmux_driver_api *api = dev->driver_api;
+	const struct pinmux_driver_api *api =
+		(const struct pinmux_driver_api *)dev->driver_api;
 
 	return api->input(dev, pin, func);
 }

--- a/include/ring_buffer.h
+++ b/include/ring_buffer.h
@@ -148,7 +148,7 @@ static inline void ring_buf_init(struct ring_buf *buf, u32_t size, void *data)
 {
 	memset(buf, 0, sizeof(struct ring_buf));
 	buf->size = size;
-	buf->buf.buf32 = data;
+	buf->buf.buf32 = (u32_t *)data;
 	if (is_power_of_two(size)) {
 		buf->mask = size - 1;
 	} else {

--- a/kernel/include/wait_q.h
+++ b/kernel/include/wait_q.h
@@ -36,7 +36,7 @@ static inline void z_waitq_init(_wait_q_t *w)
 
 static inline struct k_thread *z_waitq_head(_wait_q_t *w)
 {
-	return (void *)rb_get_min(&w->waitq.tree);
+	return (struct k_thread *)rb_get_min(&w->waitq.tree);
 }
 
 #else /* !CONFIG_WAITQ_SCALABLE: */
@@ -52,7 +52,7 @@ static inline void z_waitq_init(_wait_q_t *w)
 
 static inline struct k_thread *z_waitq_head(_wait_q_t *w)
 {
-	return (void *)sys_dlist_peek_head(&w->waitq);
+	return (struct k_thread *)sys_dlist_peek_head(&w->waitq);
 }
 
 #endif /* !CONFIG_WAITQ_SCALABLE */


### PR DESCRIPTION
When some header are included into C++ source file, this kind of compilations errors are generated:
error: invalid conversion from 'void*' to 'u32_t*' {aka 'unsigned int*'} [-fpermissive]
error: invalid conversion from 'const void*' to 'const pinmux_driver_api*' [-fpermissive]
