### PR TITLE
 Compiler: Adds "-Wc++-compat" compiler option

### DIFF
--- a/cmake/compiler/clang/target_warnings.cmake
+++ b/cmake/compiler/clang/target_warnings.cmake
@@ -34,6 +34,7 @@ macro(toolchain_cc_warning_dw_1)
     -Wmissing-include-dirs
     -Wunused-but-set-variable
     -Wno-missing-field-initializers
+    -Wc++-compat
     )
 
 endmacro()

--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -34,6 +34,7 @@ macro(toolchain_cc_warning_dw_1)
     -Wmissing-include-dirs
     -Wunused-but-set-variable
     -Wno-missing-field-initializers
+    -Wc++-compat
     )
 
 endmacro()

--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -61,6 +61,11 @@ struct k_spinlock {
 	 */
 	size_t thread_cpu;
 #endif
+
+#if !defined(CONFIG_SMP) && !defined(SPIN_VALIDATE)
+	/* Empty struct has size 0 in C, size 1 in C++ */
+	char dummy;
+#endif
 };
 
 static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)


### PR DESCRIPTION
Adds "-Wc++-compat" compiler option to W1 warning level.
This option warn about ISO C constructs that are outside of the common subset of ISO C and ISO C++.

One of the biggest issue is the size of the empty structure.
An empty struct (or union) has size 0 in C, but size 1 in C++.

For example, in some case struct k_spinlock can be empty. k_spinlock is used in Message Queue Structure (struct k_msgq), and the struct k_msgq doesn't have the same size. That generates an alignment mismatch beetween C and C++.