### PR TITLE
net: ip: Demonstrate that CODEOWNERS assignment is broken

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -1,3 +1,4 @@
+CODEOWNERS auto-assignment is broken.
 # Kconfig - IP stack config
 
 #


### PR DESCRIPTION
Demonstrate that CODEOWNERS assignment is broken

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>