### PR TITLE
 ext: nrfx: Reserve PPI channels and groups used by pwm_nrf5_sw driver and Bluetooth controller

### DIFF
--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -244,14 +244,6 @@ static int pwm_nrf5_sw_init(struct device *dev)
 	return 0;
 }
 
-/* NOTE: nRF51x BLE controller use HW tIFS hence using only PPI channels 1-6.
- * nRF52x BLE controller implements SW tIFS and uses addition 6 PPI channels.
- * Also, nRF52x requires one additional PPI channel for decryption rate boost.
- * Hence, nRF52x BLE controller uses PPI channels 1-13.
- *
- * NOTE: If PA/LNA feature is enabled for nRF52x, then additional two PPI
- * channels 14-15 are used by BLE controller.
- */
 static const struct pwm_config pwm_nrf5_sw_0_config = {
 	.timer = _CONCAT(NRF_TIMER, DT_NORDIC_NRF_SW_PWM_0_TIMER_INSTANCE),
 	.ppi_base = DT_NORDIC_NRF_SW_PWM_0_PPI_BASE,

--- a/ext/hal/nordic/nrfx_glue.h
+++ b/ext/hal/nordic/nrfx_glue.h
@@ -233,13 +233,21 @@ extern "C" {
 //------------------------------------------------------------------------------
 
 /** @brief Bitmask that defines DPPI channels that are reserved for use outside of the nrfx library. */
-#define NRFX_DPPI_CHANNELS_USED  0
+#define NRFX_DPPI_CHANNELS_USED 0
 
 /** @brief Bitmask that defines DPPI groups that are reserved for use outside of the nrfx library. */
-#define NRFX_DPPI_GROUPS_USED    0
+#define NRFX_DPPI_GROUPS_USED   0
 
 /** @brief Bitmask that defines PPI channels that are reserved for use outside of the nrfx library. */
-#define NRFX_PPI_CHANNELS_USED  0
+#define NRFX_PPI_CHANNELS_USED  NRFX_PPI_CHANNELS_USED_BY_PWM_SW
+
+#if IS_ENABLED(CONFIG_PWM_NRF5_SW)
+#define NRFX_PPI_CHANNELS_USED_BY_PWM_SW \
+    (BIT_MASK(DT_NORDIC_NRF_SW_PWM_0_CHANNEL_COUNT * 2) \
+         << DT_NORDIC_NRF_SW_PWM_0_PPI_BASE)
+#else
+#define NRFX_PPI_CHANNELS_USED_BY_PWM_SW    0
+#endif
 
 /** @brief Bitmask that defines PPI groups that are reserved for use outside of the nrfx library. */
 #define NRFX_PPI_GROUPS_USED    0

--- a/ext/hal/nordic/nrfx_glue.h
+++ b/ext/hal/nordic/nrfx_glue.h
@@ -239,7 +239,15 @@ extern "C" {
 #define NRFX_DPPI_GROUPS_USED   0
 
 /** @brief Bitmask that defines PPI channels that are reserved for use outside of the nrfx library. */
-#define NRFX_PPI_CHANNELS_USED  NRFX_PPI_CHANNELS_USED_BY_PWM_SW
+#define NRFX_PPI_CHANNELS_USED  (NRFX_PPI_CHANNELS_USED_BY_BT_CTLR | \
+                                 NRFX_PPI_CHANNELS_USED_BY_PWM_SW)
+
+#if IS_ENABLED(CONFIG_BT_CTLR)
+extern const u32_t z_bt_ctlr_used_nrf_ppi_channels;
+#define NRFX_PPI_CHANNELS_USED_BY_BT_CTLR   z_bt_ctlr_used_nrf_ppi_channels
+#else
+#define NRFX_PPI_CHANNELS_USED_BY_BT_CTLR   0
+#endif
 
 #if IS_ENABLED(CONFIG_PWM_NRF5_SW)
 #define NRFX_PPI_CHANNELS_USED_BY_PWM_SW \
@@ -250,7 +258,14 @@ extern "C" {
 #endif
 
 /** @brief Bitmask that defines PPI groups that are reserved for use outside of the nrfx library. */
-#define NRFX_PPI_GROUPS_USED    0
+#define NRFX_PPI_GROUPS_USED    NRFX_PPI_GROUPS_USED_BY_BT_CTLR
+
+#if IS_ENABLED(CONFIG_BT_CTLR)
+extern const u32_t z_bt_ctlr_used_nrf_ppi_groups;
+#define NRFX_PPI_GROUPS_USED_BY_BT_CTLR     z_bt_ctlr_used_nrf_ppi_groups
+#else
+#define NRFX_PPI_GROUPS_USED_BY_BT_CTLR     0
+#endif
 
 /** @brief Bitmask that defines SWI instances that are reserved for use outside of the nrfx library. */
 #define NRFX_SWI_USED           0

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -29,6 +29,12 @@
 #error "Platform not defined."
 #endif
 
+/* The following two constants are used in nrfx_glue.h for marking these PPI
+ * channels and groups as occupied and thus unavailable to other modules.
+ */
+const u32_t z_bt_ctlr_used_nrf_ppi_channels = HAL_USED_PPI_CHANNELS;
+const u32_t z_bt_ctlr_used_nrf_ppi_groups   = HAL_USED_PPI_GROUPS;
+
 static radio_isr_cb_t isr_cb;
 static void           *isr_cb_param;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -421,4 +421,74 @@ static inline void hal_radio_rxen_on_sw_switch(u8_t ppi)
 
 #endif /* CONFIG_SOC_NRF52840 */
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
+
+/******************************************************************************/
+
+#define HAL_USED_PPI_CHANNELS \
+	(BIT(HAL_RADIO_ENABLE_TX_ON_TICK_PPI) | \
+	 BIT(HAL_RADIO_ENABLE_RX_ON_TICK_PPI) | \
+	 BIT(HAL_RADIO_RECV_TIMEOUT_CANCEL_PPI) | \
+	 BIT(HAL_RADIO_DISABLE_ON_HCTO_PPI) | \
+	 BIT(HAL_RADIO_END_TIME_CAPTURE_PPI) | \
+	 BIT(HAL_EVENT_TIMER_START_PPI) | \
+	 BIT(HAL_RADIO_READY_TIME_CAPTURE_PPI) | \
+	 BIT(HAL_TRIGGER_CRYPT_PPI) | \
+	 BIT(HAL_TRIGGER_AAR_PPI) | \
+	 HAL_USED_PPI_CHANNELS_2 | HAL_USED_PPI_CHANNELS_3 | \
+	 HAL_USED_PPI_CHANNELS_4 | HAL_USED_PPI_CHANNELS_5)
+
+#if defined(HAL_TRIGGER_RATEOVERRIDE_PPI)
+#define HAL_USED_PPI_CHANNELS_2 \
+	BIT(HAL_TRIGGER_RATEOVERRIDE_PPI)
+#else
+#define HAL_USED_PPI_CHANNELS_2 0
+#endif
+
+#if defined(HAL_ENABLE_PALNA_PPI)
+#define HAL_USED_PPI_CHANNELS_3 \
+	(BIT(HAL_ENABLE_PALNA_PPI) | \
+	 BIT(HAL_DISABLE_PALNA_PPI))
+#else
+#define HAL_USED_PPI_CHANNELS_3 0
+#endif
+
+#if defined(HAL_SW_SWITCH_TIMER_CLEAR_PPI)
+#define HAL_USED_PPI_CHANNELS_4 \
+	(BIT(HAL_SW_SWITCH_TIMER_CLEAR_PPI) | \
+	 BIT(HAL_SW_SWITCH_GROUP_TASK_DISABLE_PPI_BASE) | \
+	 BIT(HAL_SW_SWITCH_GROUP_TASK_DISABLE_PPI_BASE+1) | \
+	 BIT(HAL_SW_SWITCH_GROUP_TASK_ENABLE_PPI) | \
+	 BIT(HAL_SW_SWITCH_RADIO_ENABLE_PPI_BASE) | \
+	 BIT(HAL_SW_SWITCH_RADIO_ENABLE_PPI_BASE+1))
+#else
+#define HAL_USED_PPI_CHANNELS_4 0
+#endif
+
+#if defined(HAL_SW_SWITCH_RADIO_ENABLE_S2_PPI)
+#define HAL_USED_PPI_CHANNELS_5 \
+	(BIT(HAL_SW_SWITCH_RADIO_ENABLE_S2_PPI) | \
+	 BIT(HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI))
+#else
+#define HAL_USED_PPI_CHANNELS_5 0
+#endif
+
+#if defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
+/* When the build is targeting an NRF board simulated with BabbleSim,
+ * nrfx_glue.h is not processed and the following symbol is not defined.
+ */
+#define NRFX_PPI_CHANNELS_USED_BY_PWM_SW  0
+#endif
+BUILD_ASSERT_MSG(
+	(HAL_USED_PPI_CHANNELS & NRFX_PPI_CHANNELS_USED_BY_PWM_SW) == 0,
+	"PPI channels used by the Bluetooth controller overlap with those "
+	"assigned to the pwm_nrf5_sw driver.");
+
+#if defined(SW_SWITCH_TIMER_TASK_GROUP_BASE)
+#define HAL_USED_PPI_GROUPS \
+	(BIT(SW_SWITCH_TIMER_TASK_GROUP_BASE) | \
+	 BIT(SW_SWITCH_TIMER_TASK_GROUP_BASE+1))
+#else
+#define HAL_USED_PPI_GROUPS 0
+#endif
+
 #endif /* CONFIG_SOC_SERIES_NRF51X || CONFIG_SOC_SERIES_NRF52X */


### PR DESCRIPTION
This patch marks the PPI channels and groups used by the pwm_nrf5_sw driver and the Bluetooth controller as occupied and thus unavailable for allocation through nrfx_ppi.

It also adds a build time assertion that checks if the PPI channels used by the Bluetooth controller do not overlap with those assigned to the pwm_nrf5_sw driver (to replace the comments in this driver that were supposed to warn about this threat but had in fact little chance to be read by users).