### PR TITLE
bluetooth: controller: Added missing variable initializations

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -377,6 +377,8 @@ u8_t ll_rx_get(void **node_rx, u16_t *handle)
 ll_rx_get_again:
 #endif /* CONFIG_BT_CONN */
 
+	*node_rx = NULL;
+
 	link = memq_peek(memq_ll_rx.head, memq_ll_rx.tail, (void **)&rx);
 	if (link) {
 #if defined(CONFIG_BT_CONN)
@@ -416,14 +418,10 @@ ll_rx_get_again:
 			*node_rx = rx;
 
 #if defined(CONFIG_BT_CONN)
-		} else {
-			*node_rx = NULL;
 		}
 	} else {
 		cmplt = tx_cmplt_get(handle, &mfifo_tx_ack.f, mfifo_tx_ack.l);
-		*node_rx = NULL;
 #endif /* CONFIG_BT_CONN */
-
 	}
 
 	return cmplt;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -163,6 +163,7 @@ u8_t ull_scan_enable(struct ll_scan_set *scan)
 	}
 #endif
 
+	lll->chan = 0;
 	lll->init_addr_type = scan->own_addr_type;
 	ll_addr_get(lll->init_addr_type, lll->init_addr);
 


### PR DESCRIPTION
In ull.c ll_rx_get, a configuration without CONFIG_BT_CONN would
sometimes return an uninitialized node_rx.
In ull_scan.c, the scanning channel was not initialized to 0 (37). This
would cause new scanning to start at random index (0,1,2).

Signed-off-by: Morten Priess <mtpr@oticon.com>