### PR TITLE
bluetooth: controller: Moved library source for lll_test.c

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -125,13 +125,13 @@ if(CONFIG_BT_LL_SW_SPLIT)
     CONFIG_BT_HCI_MESH_EXT
     ll_sw/ll_mesh.c
     )
-  zephyr_library_sources_ifdef(
-    CONFIG_BT_CTLR_DTM
-    ll_sw/nordic/lll/lll_test.c
-    )
   if(CONFIG_BT_LLL_VENDOR_NORDIC)
     zephyr_library_include_directories(
       ll_sw/nordic/lll
+      )
+    zephyr_library_sources_ifdef(
+      CONFIG_BT_CTLR_DTM
+      ll_sw/nordic/lll/lll_test.c
       )
     zephyr_library_sources_ifdef(
       CONFIG_BT_CTLR_PROFILE_ISR


### PR DESCRIPTION
Moved library source for nordic/lll/lll_test.c under
CONFIG_BT_LLL_VENDOR_NORDIC condition.

Signed-off-by: Morten Priess <mtpr@oticon.com>