### PR TITLE
bluetooth: controller: Mayfly yield after call under Kconfig

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -733,4 +733,12 @@ config BT_CTLR_DEBUG_PINS
 	  when debugging with a logic analyzer or profiling certain sections of
 	  the code.
 
+config BT_MAYFLY_YIELD_AFTER_CALL
+	bool "Yield from mayfly thread after first call"
+	default y
+	help
+	  Only process one mayfly callback per invocation (legacy behavior).
+	  If set to 'n', all pending mayflies for callee are executed before
+	  yielding
+
 endif # BT_CTLR

--- a/subsys/bluetooth/controller/util/mayfly.c
+++ b/subsys/bluetooth/controller/util/mayfly.c
@@ -215,6 +215,17 @@ void mayfly_run(u8_t callee_id)
 					 mft[callee_id][caller_id].tail,
 					 (void **)&m);
 
+/**
+ * When using cooperative thread implementation, an issue has been seen where
+ * pended mayflies are never executed in certain scenarios.
+ * This happens when mayflies with higher caller_id are constantly pended, in
+ * which case lower value caller ids never get to be executed.
+ * By allowing complete traversal of mayfly queues for all caller_ids, this
+ * does not happen, however this means that more than one mayfly function is
+ * potentially executed in a mayfly_run(), with added execution time as
+ * consequence.
+ */
+#if defined(CONFIG_BT_MAYFLY_YIELD_AFTER_CALL)
 			/* yield out of mayfly_run if a mayfly function was
 			 * called.
 			 */
@@ -229,6 +240,7 @@ void mayfly_run(u8_t callee_id)
 					return;
 				}
 			}
+#endif
 		}
 
 		if (mft[callee_id][caller_id].disable_req !=


### PR DESCRIPTION
Added Kconfig BT_MAYFLY_YIELD_AFTER_CALL to support vendor requirement
of invoking all outstanding mayflies for a given callee in
mayfly_run().

Signed-off-by: Morten Priess <mtpr@oticon.com>