### PR TITLE
cmake: Toolchain abstraction: Linker abstraction Part 2 (bare metal)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,11 +225,8 @@ zephyr_compile_options(
 toolchain_ld_base()
 
 if(NOT CONFIG_NATIVE_APPLICATION)
-zephyr_ld_options(
-  -nostdlib
-  -static
-  -no-pie
-)
+  # @Intent: Set linker specific flags for bare metal target
+  toolchain_ld_baremetal()
 endif()
 
 if(CONFIG_LIB_CPLUSPLUS)
@@ -377,13 +374,6 @@ if(CONFIG_USERSPACE)
   if(CONFIG_ARM)
     set(PRIV_STACK_DEP priv_stacks_prebuilt)
   endif()
-endif()
-
-if(NOT CONFIG_NATIVE_APPLICATION)
-zephyr_ld_options(
-  ${LINKERFLAGPREFIX},-X
-  ${LINKERFLAGPREFIX},-N
-  )
 endif()
 
 zephyr_ld_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,8 +379,6 @@ if(CONFIG_USERSPACE)
   endif()
 endif()
 
-set_ifndef(LINKERFLAGPREFIX -Wl)
-
 if(NOT CONFIG_NATIVE_APPLICATION)
 zephyr_ld_options(
   ${LINKERFLAGPREFIX},-X

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -2,5 +2,7 @@
 
 find_program(CMAKE_LINKER     ${CROSS_COMPILE}ld      PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
+set_ifndef(LINKERFLAGPREFIX -Wl)
+
 # Load toolchain_ld-family macros
 include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_base.cmake)

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -6,3 +6,4 @@ set_ifndef(LINKERFLAGPREFIX -Wl)
 
 # Load toolchain_ld-family macros
 include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_base.cmake)
+include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_baremetal.cmake)

--- a/cmake/linker/ld/target_baremetal.cmake
+++ b/cmake/linker/ld/target_baremetal.cmake
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# See root CMakeLists.txt for description and expectations of these macros
+
+macro(toolchain_ld_baremetal)
+
+  zephyr_ld_options(
+    -nostdlib
+    -static
+    -no-pie
+    ${LINKERFLAGPREFIX},-X
+    ${LINKERFLAGPREFIX},-N
+  )
+
+endmacro()


### PR DESCRIPTION
This is Part 2 of Linker abstraction.
Part 1 PR: https://github.com/zephyrproject-rtos/zephyr/pull/15686.

No functional change expected.

This is motivated by the wish to abstract Zephyr's usage of toolchains,
permitting non-intrusive porting to other (commercial) toolchains.

Zephyr's cmake build system currently assumes GNU ld is used as the linker.
This is not the case for Oticon which uses another incompatible linker, and our own custom linker scripts.
Without these PRs, Oticon and others will have to keep patching Zephyr Cmake code.

Signed-off-by: Mark Ruvald Pedersen mped@oticon.com

-------------

Part of #16031