### PR TITLE
cmake: Toolchain abstraction: Linker abstraction Part 3 (base, bare metal)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,32 +388,6 @@ get_property(TOPT GLOBAL PROPERTY TOPT)
 set_ifndef(  TOPT -Wl,-T) # clang doesn't pick -T for some reason and complains,
                           # while -Wl,-T works for both, gcc and clang
 
-if(NOT CONFIG_NATIVE_APPLICATION)
-  # Funny thing is if this is set to =error, some architectures will
-  # skip this flag even though the compiler flag check passes
-  # (e.g. ARC and Xtensa). So warning should be the default for now.
-  #
-  # Skip this for native application as Zephyr only provides
-  # additions to the host toolchain linker script. The relocation
-  # sections (.rel*) requires us to override those provided
-  # by host toolchain. As we can't account for all possible
-  # combination of compiler and linker on all machines used
-  # for development, it is better to turn this off.
-  #
-  # CONFIG_LINKER_ORPHAN_SECTION_PLACE is to place the orphan sections
-  # without any warnings or errors, which is the default behavior.
-  # So there is no need to explicity set a linker flag.
-  if(CONFIG_LINKER_ORPHAN_SECTION_WARN)
-    zephyr_ld_options(
-      ${LINKERFLAGPREFIX},--orphan-handling=warn
-      )
-  elseif(CONFIG_LINKER_ORPHAN_SECTION_ERROR)
-    zephyr_ld_options(
-      ${LINKERFLAGPREFIX},--orphan-handling=error
-      )
-  endif()
-endif()
-
 if(CONFIG_HAVE_CUSTOM_LINKER_SCRIPT)
   set(LINKER_SCRIPT ${APPLICATION_SOURCE_DIR}/${CONFIG_CUSTOM_LINKER_SCRIPT})
   if(NOT EXISTS ${LINKER_SCRIPT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,11 +376,6 @@ if(CONFIG_USERSPACE)
   endif()
 endif()
 
-zephyr_ld_options(
-  ${LINKERFLAGPREFIX},--gc-sections
-  ${LINKERFLAGPREFIX},--build-id=none
-  )
-
 # Sort the common symbols and each input section by alignment
 # in descending order to minimize padding between these symbols.
 zephyr_ld_option_ifdef(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,14 +376,6 @@ if(CONFIG_USERSPACE)
   endif()
 endif()
 
-# Sort the common symbols and each input section by alignment
-# in descending order to minimize padding between these symbols.
-zephyr_ld_option_ifdef(
-  CONFIG_LINKER_SORT_BY_ALIGNMENT
-  ${LINKERFLAGPREFIX},--sort-common=descending
-  ${LINKERFLAGPREFIX},--sort-section=alignment
-  )
-
 get_property(TOPT GLOBAL PROPERTY TOPT)
 set_ifndef(  TOPT -Wl,-T) # clang doesn't pick -T for some reason and complains,
                           # while -Wl,-T works for both, gcc and clang

--- a/cmake/linker/ld/target_baremetal.cmake
+++ b/cmake/linker/ld/target_baremetal.cmake
@@ -13,4 +13,28 @@ macro(toolchain_ld_baremetal)
     ${LINKERFLAGPREFIX},-N
   )
 
+  # Funny thing is if this is set to =error, some architectures will
+  # skip this flag even though the compiler flag check passes
+  # (e.g. ARC and Xtensa). So warning should be the default for now.
+  #
+  # Skip this for native application as Zephyr only provides
+  # additions to the host toolchain linker script. The relocation
+  # sections (.rel*) requires us to override those provided
+  # by host toolchain. As we can't account for all possible
+  # combination of compiler and linker on all machines used
+  # for development, it is better to turn this off.
+  #
+  # CONFIG_LINKER_ORPHAN_SECTION_PLACE is to place the orphan sections
+  # without any warnings or errors, which is the default behavior.
+  # So there is no need to explicity set a linker flag.
+  if(CONFIG_LINKER_ORPHAN_SECTION_WARN)
+    zephyr_ld_options(
+      ${LINKERFLAGPREFIX},--orphan-handling=warn
+    )
+  elseif(CONFIG_LINKER_ORPHAN_SECTION_ERROR)
+    zephyr_ld_options(
+      ${LINKERFLAGPREFIX},--orphan-handling=error
+    )
+  endif()
+
 endmacro()

--- a/cmake/linker/ld/target_baremetal.cmake
+++ b/cmake/linker/ld/target_baremetal.cmake
@@ -4,6 +4,7 @@
 
 macro(toolchain_ld_baremetal)
 
+  # LINKERFLAGPREFIX comes from linker/ld/target.cmake
   zephyr_ld_options(
     -nostdlib
     -static

--- a/cmake/linker/ld/target_base.cmake
+++ b/cmake/linker/ld/target_base.cmake
@@ -5,8 +5,11 @@
 macro(toolchain_ld_base)
 
   # TOOLCHAIN_LD_FLAGS comes from compiler/gcc/target.cmake
+  # LINKERFLAGPREFIX comes from linker/ld/target.cmake
   zephyr_ld_options(
     ${TOOLCHAIN_LD_FLAGS}
+    ${LINKERFLAGPREFIX},--gc-sections
+    ${LINKERFLAGPREFIX},--build-id=none
   )
 
 endmacro()

--- a/cmake/linker/ld/target_base.cmake
+++ b/cmake/linker/ld/target_base.cmake
@@ -12,4 +12,12 @@ macro(toolchain_ld_base)
     ${LINKERFLAGPREFIX},--build-id=none
   )
 
+  # Sort the common symbols and each input section by alignment
+  # in descending order to minimize padding between these symbols.
+  zephyr_ld_option_ifdef(
+    CONFIG_LINKER_SORT_BY_ALIGNMENT
+    ${LINKERFLAGPREFIX},--sort-common=descending
+    ${LINKERFLAGPREFIX},--sort-section=alignment
+  )
+
 endmacro()


### PR DESCRIPTION
This is Part 3 of Linker abstraction, which includes Part 2 (sequentially dependent).
Part 2 PR: #15693.
Part 1 PR: #15686.

No functional change expected.

This is motivated by the wish to abstract Zephyr's usage of toolchains,
permitting non-intrusive porting to other (commercial) toolchains.

Zephyr's cmake build system currently assumes GNU ld is used as the linker.
This is not the case for Oticon which uses another incompatible linker, and our own custom linker scripts.
Without these PRs, Oticon and others will have to keep patching Zephyr Cmake code.

Signed-off-by: Mark Ruvald Pedersen mped@oticon.com

-------------

Part of #16031