### PR TITLE
drivers: adc: fix functionality gaps

### DIFF
--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -268,6 +268,10 @@ static int init_adc(struct device *dev)
 	return 0;
 }
 
+static const struct adc_config_info adc_nrfx_config_info = {
+	.internal_ref_mV = 1200,
+};
+
 static const struct adc_driver_api adc_nrfx_driver_api = {
 	.channel_setup = adc_nrfx_channel_setup,
 	.read          = adc_nrfx_read,
@@ -278,7 +282,7 @@ static const struct adc_driver_api adc_nrfx_driver_api = {
 
 #ifdef CONFIG_ADC_0
 DEVICE_AND_API_INIT(adc_0, DT_NORDIC_NRF_ADC_ADC_0_LABEL,
-		    init_adc, NULL, NULL,
+		    init_adc, NULL, &adc_nrfx_config_info,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &adc_nrfx_driver_api);
 #endif /* CONFIG_ADC_0 */

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -385,6 +385,10 @@ static int init_saadc(struct device *dev)
 	return 0;
 }
 
+static const struct adc_config_info adc_nrfx_config_info = {
+	.internal_ref_mV = 600,
+};
+
 static const struct adc_driver_api adc_nrfx_driver_api = {
 	.channel_setup = adc_nrfx_channel_setup,
 	.read          = adc_nrfx_read,
@@ -395,7 +399,7 @@ static const struct adc_driver_api adc_nrfx_driver_api = {
 
 #ifdef CONFIG_ADC_0
 DEVICE_AND_API_INIT(adc_0, DT_NORDIC_NRF_SAADC_ADC_0_LABEL,
-		    init_saadc, NULL, NULL,
+		    init_saadc, NULL, &adc_nrfx_config_info,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &adc_nrfx_driver_api);
 #endif /* CONFIG_ADC_0 */

--- a/include/adc.h
+++ b/include/adc.h
@@ -253,6 +253,16 @@ struct adc_sequence {
 	 * a specific mode (e.g. when sampling multiple channels).
 	 */
 	u8_t oversampling;
+
+	/**
+	 * Optionally perform calibration before the reading is taken.
+	 *
+	 * The impact of channel configuration on the calibration
+	 * process is specific to the underlying hardware.  ADC
+	 * implementations that do not support calibration may ignore
+	 * this flag.
+	 */
+	bool calibrate;
 };
 
 

--- a/include/adc.h
+++ b/include/adc.h
@@ -282,6 +282,21 @@ typedef int (*adc_api_read_async)(struct device *dev,
 #endif
 
 /**
+ * @brief ADC driver basic information
+ *
+ * Fixed information relevant to any driver, accessed through the
+ * config_info field of the driver config structure.
+ */
+struct adc_config_info {
+	/** Internal reference voltage in mV.
+	 *
+	 * Store -ENOTSUP if the device does not support a reference
+	 * voltage source.
+	 */
+	int internal_ref_mV;
+};
+
+/**
  * @brief ADC driver API
  *
  * This is the mandatory API any ADC driver needs to expose.
@@ -293,6 +308,26 @@ struct adc_driver_api {
 	adc_api_read_async    read_async;
 #endif
 };
+
+/**
+ * @brief Retrieve the internal reference voltage
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @return The internal reference, in millivolts, or a negative error
+ * code such as `-ENOTSUP` where the reference is not supported.
+ */
+static inline int adc_ref_internal(struct device *dev)
+{
+	int rv = -ENOTSUP;
+
+	const struct adc_config_info *cip
+		= (const struct adc_config_info *)dev->config->config_info;
+	if (cip) {
+		rv = cip->internal_ref_mV;
+	}
+	return rv;
+}
 
 /**
  * @brief Configure an ADC channel.


### PR DESCRIPTION
Two commits:
* Provide API to retrieve the internal reference voltage, which is required to make sense of results that use that reference source.  Support is implemented in Nordic ADC and SAADC; see #11922 for other platforms that might need this functionality.
* Provide API to specify that the ADC should be calibrated before performing the sample.  This functionality is implemented on Nordic SAADC, including workarounds for relevant PANs.

Closes #11922