### PR TITLE
doc: fix watchdog API documentation

### DIFF
--- a/include/watchdog.h
+++ b/include/watchdog.h
@@ -57,9 +57,6 @@ struct wdt_config {
 	u32_t timeout;
 	void (*interrupt_fn)(struct device *dev);
 };
-/**
- * @}
- */
 
 
 /**


### PR DESCRIPTION
There was a stray close group comment @} that was causing a large chunk
of the watchdoc API documentation to be missing.

Fixes: #15678

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>