### PR TITLE
west: Move cmake and build functionality to zephyr and add a boards command

### DIFF
--- a/doc/guides/west/build-flash-debug.rst
+++ b/doc/guides/west/build-flash-debug.rst
@@ -3,9 +3,9 @@
 Building, Flashing and Debugging
 ################################
 
-West provides 5 commands for building, flashing, and interacting with Zephyr
-programs running on a board: ``build``, ``flash``, ``debug``, ``debugserver``
-and ``attach``.
+Zephyr provides several :ref:`west extension commands <west-extensions>` for
+building, flashing, and interacting with Zephyr programs running on a board:
+``build``, ``flash``, ``debug``, ``debugserver`` and ``attach``.
 
 These use information stored in the CMake cache [#cmakecache]_ to
 flash or attach a debugger to a board supported by Zephyr. The exception is
@@ -60,6 +60,10 @@ no additional parameters.
   parameters) without having to specify the board again. If you're unsure
   whether ``-b`` is required, just try leaving it out. West will print an
   error if the option is required and was not given.
+
+.. tip::
+  You can use the :ref:`west boards <west-boards>` command to list all
+  supported boards.
 
 Specify the source directory path as the first positional argument::
 

--- a/doc/guides/west/extensions.rst
+++ b/doc/guides/west/extensions.rst
@@ -11,12 +11,14 @@ information on west extension commands, and has a tutorial for writing your
 own.
 
 Some commands you can run when using west with Zephyr, like the ones used to
-:ref:`build, flash, and debug <west-build-flash-debug>`, are extensions. That's
-why help for them shows up like this in ``west --help``:
+:ref:`build, flash, and debug <west-build-flash-debug>` and the
+:ref:`ones described here <west-zephyr-ext-cmds>` , are extensions. That's why
+help for them shows up like this in ``west --help``:
 
 .. code-block:: none
 
    commands from project at "zephyr":
+     boards:               display information about supported boards
      build:                compile a Zephyr application
      sign:                 sign a Zephyr binary for bootloader chain-loading
      flash:                flash and run a binary on a board

--- a/doc/guides/west/index.rst
+++ b/doc/guides/west/index.rst
@@ -38,6 +38,7 @@ context about the tool.
    config.rst
    extensions.rst
    build-flash-debug.rst
+   zephyr-cmds.rst
    sign.rst
    why.rst
    without-west.rst

--- a/doc/guides/west/zephyr-cmds.rst
+++ b/doc/guides/west/zephyr-cmds.rst
@@ -1,0 +1,39 @@
+.. _west-zephyr-ext-cmds:
+
+Additional Zephyr extension commands
+####################################
+
+Aside from the :ref:`build, flash, and debug commands <west-build-flash-debug>`,
+the zephyr tree extends the west command set with additional zephyr-specific
+commands.
+
+.. Add a per-page contents at the top of the page. This page is nested
+   deeply enough that it doesn't have any subheadings in the main nav.
+
+.. only:: html
+
+   .. contents::
+      :local:
+
+.. _west-boards:
+
+Listing boards: ``west boards``
+*******************************
+
+The ``boards`` command can be used to list the boards that are supported by
+Zephyr without having to resort to additional sources of information.
+
+It can be run by typing::
+
+  west boards
+
+This command lists all supported boards in a default format. If you prefer to
+specify the display format yourself you can use the ``--format`` (or ``-f``)
+flag::
+
+  west boards -f "{arch}:{name}"
+
+Additional help about the formatting options can be found by running::
+
+  west boards -h
+

--- a/scripts/west-commands.yml
+++ b/scripts/west-commands.yml
@@ -1,5 +1,10 @@
 # Keep the help strings in sync with the values in the .py files!
 west-commands:
+  - file: scripts/west_commands/boards.py
+    commands:
+      - name: boards
+        class: Boards
+        help: display information about supported boards
   - file: scripts/west_commands/build.py
     commands:
       - name: build

--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import collections
+import os
+import re
+import textwrap
+
+from west import log
+from west.commands import WestCommand
+from cmake import run_cmake
+
+class Boards(WestCommand):
+
+    def __init__(self):
+        super().__init__(
+            'boards',
+            # Keep this in sync with the string in west-commands.yml.
+            'display information about supported boards',
+            'Display information about boards',
+            accepts_unknown_args=False)
+
+    def do_add_parser(self, parser_adder):
+        default_fmt = '{name} ({arch})'
+        parser = parser_adder.add_parser(
+            self.name,
+            help=self.help,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=self.description,
+            epilog=textwrap.dedent('''\
+            FORMAT STRINGS
+
+            Boards are listed using a Python 3 format string. Arguments
+            to the format string are accessed by name.
+
+            The default format string is:
+
+            "{}"
+
+            The following arguments are available:
+
+            - name: board name
+            - arch: board architecture
+            '''.format(default_fmt)))
+
+        # Remember to update scripts/west-completion.bash if you add or remove
+        # flags
+        parser.add_argument('-f', '--format', default=default_fmt,
+                            help='''Format string to use to list each board;
+                                    see FORMAT STRINGS below.'''),
+
+        return parser
+
+    def do_run(self, args, unknown_args):
+        zb = os.environ.get('ZEPHYR_BASE')
+        if not zb:
+            log.die('Internal error: ZEPHYR_BASE not set in the environment, '
+                    'and should have been by the main script')
+
+        cmake_args = ['-DBOARD_ROOT_SPACE_SEPARATED={}'.format(zb),
+                      '-P', '{}/cmake/boards.cmake'.format(zb)]
+        lines = run_cmake(cmake_args, capture_output=True)
+        arch_re = re.compile(r'\s*([\w-]+)\:')
+        board_re = re.compile(r'\s*([\w-]+)\s*')
+        arch = None
+        boards = collections.OrderedDict()
+        for line in lines:
+            match = arch_re.match(line)
+            if match:
+                arch = match.group(1)
+                boards[arch] = []
+                continue
+            match = board_re.match(line)
+            if match:
+                if not arch:
+                    log.die('Invalid board output from CMake: {}'.format(lines))
+                board = match.group(1)
+                boards[arch].append(board)
+
+        for arch in boards:
+            for board in boards[arch]:
+                try:
+                    result = args.format.format(
+                        name=board,
+                        arch=arch)
+                    print(result)
+                except KeyError as e:
+                    # The raised KeyError seems to just put the first
+                    # invalid argument in the args tuple, regardless of
+                    # how many unrecognizable keys there were.
+                    log.die('unknown key "{}" in format string "{}"'.
+                            format(e.args[0], args.format))

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -1,0 +1,65 @@
+# Copyright 2018 (c) Foundries.io.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Common definitions for building Zephyr applications.
+
+This provides some default settings and convenience wrappers for
+building Zephyr applications needed by multiple commands.
+
+See build.py for the build command itself.
+'''
+
+import cmake
+import os
+from west import log
+
+DEFAULT_BUILD_DIR = 'build'
+'''Name of the default Zephyr build directory.'''
+
+DEFAULT_CMAKE_GENERATOR = 'Ninja'
+'''Name of the default CMake generator.'''
+
+BUILD_DIR_DESCRIPTION = '''\
+Explicitly sets the build directory.  If not given and the current
+directory is a Zephyr build directory, it will be used; otherwise,
+"{}" is assumed.'''.format(DEFAULT_BUILD_DIR)
+
+
+def find_build_dir(dir):
+    '''Heuristic for finding a build directory.
+
+    If the given argument is truthy, it is returned. Otherwise, if
+    the current working directory is a build directory, it is
+    returned. Otherwise, DEFAULT_BUILD_DIR is returned.'''
+    if dir:
+        build_dir = dir
+    else:
+        cwd = os.getcwd()
+        if is_zephyr_build(cwd):
+            build_dir = cwd
+        else:
+            build_dir = DEFAULT_BUILD_DIR
+    return os.path.abspath(build_dir)
+
+
+def is_zephyr_build(path):
+    '''Return true if and only if `path` appears to be a valid Zephyr
+    build directory.
+
+    "Valid" means the given path is a directory which contains a CMake
+    cache with a 'ZEPHYR_TOOLCHAIN_VARIANT' key.
+    '''
+    try:
+        cache = cmake.CMakeCache.from_build_dir(path)
+    except FileNotFoundError:
+        cache = {}
+
+    if 'ZEPHYR_TOOLCHAIN_VARIANT' in cache:
+        log.dbg('{} is a zephyr build directory'.format(path),
+                level=log.VERBOSE_EXTREME)
+        return True
+    else:
+        log.dbg('{} is NOT a valid zephyr build directory'.format(path),
+                level=log.VERBOSE_EXTREME)
+        return False

--- a/scripts/west_commands/cmake.py
+++ b/scripts/west_commands/cmake.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2018 Open Source Foundries Limited.
+#
+# SPDX-License-Identifier: Apache-2.0
+'''Common definitions for building Zephyr applications with CMake.
+
+This provides some default settings and convenience wrappers for
+building Zephyr applications needed by multiple commands.
+
+See build.py for the build command itself.
+'''
+
+from collections import OrderedDict
+import os.path
+import re
+import subprocess
+import shutil
+import sys
+
+from west import log
+from west.util import quote_sh_list
+
+DEFAULT_CACHE = 'CMakeCache.txt'
+
+DEFAULT_CMAKE_GENERATOR = 'Ninja'
+'''Name of the default CMake generator.'''
+
+def run_cmake(args, cwd=None, capture_output=False):
+    '''Run cmake to (re)generate a build system.
+    If capture_output is set to True, returns the output of the command instead
+    of displaying it on stdout/stderr..'''
+    cmake = shutil.which('cmake')
+    if cmake is None:
+        log.die('CMake is not installed or cannot be found; cannot build.')
+    cmd = [cmake] + args
+    kwargs = dict()
+    if capture_output:
+        kwargs['stdout'] = subprocess.PIPE
+        # CMake sends the output of message() to stderr unless it's STATUS
+        kwargs['stderr'] = subprocess.STDOUT
+    if cwd:
+        kwargs['cwd'] = cwd
+    log.dbg('Running CMake:', quote_sh_list(cmd), level=log.VERBOSE_NORMAL)
+    p = subprocess.Popen(cmd, **kwargs)
+    out, err = p.communicate()
+    if p.returncode == 0:
+        if out:
+            return out.decode(sys.getdefaultencoding()).splitlines()
+        else:
+            return None
+    else:
+        # A real error occurred, raise an exception
+        raise subprocess.CalledProcessError(cmd=p.args,
+                                            returncode=p.returncode)
+
+
+def run_build(build_directory, extra_args=(), cwd=None, capture_output=False):
+    '''Run cmake in build tool mode in `build_directory`'''
+    run_cmake(['--build', build_directory] + list(extra_args),
+              capture_output=capture_output)
+
+
+def make_c_identifier(string):
+    '''Make a C identifier from a string in the same way CMake does.
+    '''
+    # The behavior of CMake's string(MAKE_C_IDENTIFIER ...)  is not
+    # precisely documented. This behavior matches the test case
+    # that introduced the function:
+    #
+    # https://gitlab.kitware.com/cmake/cmake/commit/0ab50aea4c4d7099b339fb38b4459d0debbdbd85
+    ret = []
+
+    alpha_under = re.compile('[A-Za-z_]')
+    alpha_num_under = re.compile('[A-Za-z0-9_]')
+
+    if not alpha_under.match(string):
+        ret.append('_')
+    for c in string:
+        if alpha_num_under.match(c):
+            ret.append(c)
+        else:
+            ret.append('_')
+
+    return ''.join(ret)
+
+
+class CMakeCacheEntry:
+    '''Represents a CMake cache entry.
+
+    This class understands the type system in a CMakeCache.txt, and
+    converts the following cache types to Python types:
+
+    Cache Type    Python type
+    ----------    -------------------------------------------
+    FILEPATH      str
+    PATH          str
+    STRING        str OR list of str (if ';' is in the value)
+    BOOL          bool
+    INTERNAL      str OR list of str (if ';' is in the value)
+    ----------    -------------------------------------------
+    '''
+
+    # Regular expression for a cache entry.
+    #
+    # CMake variable names can include escape characters, allowing a
+    # wider set of names than is easy to match with a regular
+    # expression. To be permissive here, use a non-greedy match up to
+    # the first colon (':'). This breaks if the variable name has a
+    # colon inside, but it's good enough.
+    CACHE_ENTRY = re.compile(
+        r'''(?P<name>.*?)                               # name
+         :(?P<type>FILEPATH|PATH|STRING|BOOL|INTERNAL)  # type
+         =(?P<value>.*)                                 # value
+        ''', re.X)
+
+    @classmethod
+    def _to_bool(cls, val):
+        # Convert a CMake BOOL string into a Python bool.
+        #
+        #   "True if the constant is 1, ON, YES, TRUE, Y, or a
+        #   non-zero number. False if the constant is 0, OFF, NO,
+        #   FALSE, N, IGNORE, NOTFOUND, the empty string, or ends in
+        #   the suffix -NOTFOUND. Named boolean constants are
+        #   case-insensitive. If the argument is not one of these
+        #   constants, it is treated as a variable."
+        #
+        # https://cmake.org/cmake/help/v3.0/command/if.html
+        val = val.upper()
+        if val in ('ON', 'YES', 'TRUE', 'Y'):
+            return True
+        elif val in ('OFF', 'NO', 'FALSE', 'N', 'IGNORE', 'NOTFOUND', ''):
+            return False
+        elif val.endswith('-NOTFOUND'):
+            return False
+        else:
+            try:
+                v = int(val)
+                return v != 0
+            except ValueError as exc:
+                raise ValueError('invalid bool {}'.format(val)) from exc
+
+    @classmethod
+    def from_line(cls, line, line_no):
+        # Comments can only occur at the beginning of a line.
+        # (The value of an entry could contain a comment character).
+        if line.startswith('//') or line.startswith('#'):
+            return None
+
+        # Whitespace-only lines do not contain cache entries.
+        if not line.strip():
+            return None
+
+        m = cls.CACHE_ENTRY.match(line)
+        if not m:
+            return None
+
+        name, type_, value = (m.group(g) for g in ('name', 'type', 'value'))
+        if type_ == 'BOOL':
+            try:
+                value = cls._to_bool(value)
+            except ValueError as exc:
+                args = exc.args + ('on line {}: {}'.format(line_no, line),)
+                raise ValueError(args) from exc
+        elif type_ == 'STRING' or type_ == 'INTERNAL':
+            # If the value is a CMake list (i.e. is a string which
+            # contains a ';'), convert to a Python list.
+            if ';' in value:
+                value = value.split(';')
+
+        return CMakeCacheEntry(name, value)
+
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+    def __str__(self):
+        fmt = 'CMakeCacheEntry(name={}, value={})'
+        return fmt.format(self.name, self.value)
+
+
+class CMakeCache:
+    '''Parses and represents a CMake cache file.'''
+
+    @staticmethod
+    def from_build_dir(build_dir):
+        return CMakeCache(os.path.join(build_dir, DEFAULT_CACHE))
+
+    def __init__(self, cache_file):
+        self.cache_file = cache_file
+        self.load(cache_file)
+
+    def load(self, cache_file):
+        entries = []
+        with open(cache_file, 'r') as cache:
+            for line_no, line in enumerate(cache):
+                entry = CMakeCacheEntry.from_line(line, line_no)
+                if entry:
+                    entries.append(entry)
+        self._entries = OrderedDict((e.name, e) for e in entries)
+
+    def get(self, name, default=None):
+        entry = self._entries.get(name)
+        if entry is not None:
+            return entry.value
+        else:
+            return default
+
+    def get_list(self, name, default=None):
+        if default is None:
+            default = []
+        entry = self._entries.get(name)
+        if entry is not None:
+            value = entry.value
+            if isinstance(value, list):
+                return value
+            elif isinstance(value, str):
+                return [value] if value else []
+            else:
+                msg = 'invalid value {} type {}'
+                raise RuntimeError(msg.format(value, type(value)))
+        else:
+            return default
+
+    def __contains__(self, name):
+        return name in self._entries
+
+    def __getitem__(self, name):
+        return self._entries[name].value
+
+    def __setitem__(self, name, entry):
+        if not isinstance(entry, CMakeCacheEntry):
+            msg = 'improper type {} for value {}, expecting CMakeCacheEntry'
+            raise TypeError(msg.format(type(entry), entry))
+        self._entries[name] = entry
+
+    def __delitem__(self, name):
+        del self._entries[name]
+
+    def __iter__(self):
+        return iter(self._entries.values())

--- a/scripts/west_commands/zephyr_ext_common.py
+++ b/scripts/west_commands/zephyr_ext_common.py
@@ -11,32 +11,9 @@ commands which specifically execute runners.'''
 import os
 
 from west import log
-from west.build import DEFAULT_BUILD_DIR, is_zephyr_build
 from west.commands import WestCommand
 
 from runners.core import RunnerConfig
-
-BUILD_DIR_DESCRIPTION = '''\
-Explicitly sets the build directory.  If not given and the current
-directory is a Zephyr build directory, it will be used; otherwise,
-"{}" is assumed.'''.format(DEFAULT_BUILD_DIR)
-
-
-def find_build_dir(dir):
-    '''Heuristic for finding a build directory.
-
-    If the given argument is truthy, it is returned. Otherwise, if
-    the current working directory is a build directory, it is
-    returned. Otherwise, west.build.DEFAULT_BUILD_DIR is returned.'''
-    if dir:
-        build_dir = dir
-    else:
-        cwd = os.getcwd()
-        if is_zephyr_build(cwd):
-            build_dir = cwd
-        else:
-            build_dir = DEFAULT_BUILD_DIR
-    return os.path.abspath(build_dir)
 
 
 class Forceable(WestCommand):


### PR DESCRIPTION
This Pull Request contains:

- Changes to move all the cmake and build functionality from the west repo to zephyr/scripts/west_commands
- The addition of a new command to list boards