### PR TITLE
usb: usb_device: fix set configuration request

### DIFF
--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -519,6 +519,10 @@ static bool usb_set_configuration(u8_t config_index, u8_t alt_setting)
 		case DESC_CONFIGURATION:
 			/* remember current configuration index */
 			cur_config = p[CONF_DESC_bConfigurationValue];
+			if (cur_config == config_index) {
+				found = true;
+			}
+
 			break;
 
 		case DESC_INTERFACE:


### PR DESCRIPTION
Fix set configuration request for a configuration without
specific endpoint like USB DFU class.

The changes introduced in
commit 2b58594e9033 ("usb: device: Use set_endpoint helper for set_config")
does not take into account that a configuration could only contain
control endpoint.
