### PR TITLE
re-resolve broken k_busy_wait on Nordic platforms

### DIFF
--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -17,6 +17,9 @@ config SYS_CLOCK_TICKS_PER_SEC
 	int
 	default 128
 
+config ARCH_HAS_CUSTOM_BUSY_WAIT
+	default y
+
 config BUILD_OUTPUT_HEX
 	default y
 

--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -9,6 +9,14 @@ if SOC_FAMILY_NRF
 
 source "soc/arm/nordic_nrf/*/Kconfig.defconfig.series"
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	int
+	default 32768
+
+config SYS_CLOCK_TICKS_PER_SEC
+	int
+	default 128
+
 config BUILD_OUTPUT_HEX
 	default y
 

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
@@ -13,10 +13,6 @@ source "soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51*"
 config SOC_SERIES
 	default "nrf51"
 
-config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
-	default 32768
-
 config SYS_POWER_MANAGEMENT
 	default y
 

--- a/soc/arm/nordic_nrf/nrf51/soc.c
+++ b/soc/arm/nordic_nrf/nrf51/soc.c
@@ -59,4 +59,16 @@ static int nordicsemi_nrf51_init(struct device *arg)
 	return 0;
 }
 
+#define DELAY_CALL_OVERHEAD_US 2
+
+void z_arch_busy_wait(u32_t time_us)
+{
+	if (time_us <= DELAY_CALL_OVERHEAD_US) {
+		return;
+	}
+
+	time_us -= DELAY_CALL_OVERHEAD_US;
+	nrfx_coredep_delay_us(time_us);
+}
+
 SYS_INIT(nordicsemi_nrf51_init, PRE_KERNEL_1, 0);

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -12,10 +12,6 @@ source "soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52*"
 config SOC_SERIES
 	default "nrf52"
 
-config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
-	default 32768
-
 config SYS_POWER_MANAGEMENT
 	default y
 

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -81,4 +81,9 @@ static int nordicsemi_nrf52_init(struct device *arg)
 	return 0;
 }
 
+void z_arch_busy_wait(u32_t time_us)
+{
+	nrfx_coredep_delay_us(time_us);
+}
+
 SYS_INIT(nordicsemi_nrf52_init, PRE_KERNEL_1, 0);

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.series
@@ -12,10 +12,6 @@ source "soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf91*"
 config SOC_SERIES
 	default "nrf91"
 
-config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
-	default 32768
-
 config ARCH_HAS_CUSTOM_BUSY_WAIT
 	default y
 

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.series
@@ -12,9 +12,6 @@ source "soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf91*"
 config SOC_SERIES
 	default "nrf91"
 
-config ARCH_HAS_CUSTOM_BUSY_WAIT
-	default y
-
 config SYS_POWER_MANAGEMENT
 	default y
 


### PR DESCRIPTION
## soc: arm: nordic_nrf: change default SYS_CLOCKS_PER_SEC

The default system clock on all Nordic devices is based on a 32 KiHz
(2^15 Hz) timer.  Scheduling ticks requires that deadlines be specified
with a timer counter that aligns to a system clock.  With the Zephyr
default 100 clocks-per-sec configuration this results in 100 ticks every
32700 ticks of the cycle timer.  This reveals two problems:

* The uptime clock misrepresents elapsed time because it runs 0.208%
  (68/32768) faster than the best available clock;

* Calculation of timer counter compare values often requires an integer
  division and multiply operation to produce a value that's a multiple
  of clock-ticks-per-second.

Integer division on the Cortex-M1 nRF51 is done in software with a
(value-dependent) algorithm with a non-constant runtime that can be
significant.  This can produce missed Bluetooth deadlines as discussed
in upstream #14577 and others.

By changing the default divisor to one that evenly divides the 2^15
clock rate the time interrupts are disabled to manage timers is
significantly reduced, as is the error between uptime and real time.  Do
this at the top level, moving SYS_CLOCK_HW_CYCLES_PER_SEC there as well
since the two parameters are related.

Note that the central_hr configuration described in upstream #13610 does
not distinguish latency due to timer management from other
irq_block/spinlock regions, and the maximum observed latency will still
exceed the nominal 10 us allowed maximum.  However this does occur
much less frequently than changing the timer deadline which can happen
multiple times per tick.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>

:100644 100644 00f3947f39 d0251bbc23 M	soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
:100644 100644 cff0b9fad9 a91e5efc3f M	soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
:100644 100644 d88da8aef2 68f636acc0 M	soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.series

## soc: arm: nordic_nrf: unrevert provide custom busy_wait implementations

This reverts commit bd24b31139c1946bd9fe4c336c697b69608fac5e.

While the test case failure described in #14186 is associated with the
cycle-based busy-wait implementation, that test is fragile, and fails
less frequently once the incongruence between ticks-per-second and the
32 KiHz RTC clock are resolved.  It also assumes that the system clock
is more stable than the infrastructure underlying the the busy-wait
implementation, which is not necessarily true.

The gross inaccuracies in the standard busy-wait on Nordic described in
issue #11626 justify restoring the custom solution.

As this applies to all Nordic devices, move the setting to the top-level
Kconfig.defconfig.

See: https://github.com/zephyrproject-rtos/zephyr/issues/11626#issuecomment-487243369

Signed-off-by: Peter A. Bigot <pab@pabigot.com>

:100644 100644 d0251bbc23 dd6ddbb486 M	soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
:100644 100644 eb235d1cf6 cb3021a748 M	soc/arm/nordic_nrf/nrf51/soc.c
:100644 100644 a91e5efc3f 78a903d659 M	soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
:100644 100644 44e9edbdf8 eb1f979602 M	soc/arm/nordic_nrf/nrf52/soc.c

NB: The reversion did not affect the use of the custom busywait in nrf91.

Closes #11626 