### PR TITLE
when recevied disconnect request, local can not find corresponding ch…

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -858,7 +858,7 @@ static struct bt_l2cap_le_chan *l2cap_remove_tx_cid(struct bt_conn *conn,
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&conn->channels, chan, node) {
-		if (BT_L2CAP_LE_CHAN(chan)->rx.cid == cid) {
+		if (BT_L2CAP_LE_CHAN(chan)->tx.cid == cid) {
 			sys_slist_remove(&conn->channels, prev, &chan->node);
 			return BT_L2CAP_LE_CHAN(chan);
 		}

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -1053,7 +1053,7 @@ static struct bt_l2cap_br_chan *l2cap_br_remove_tx_cid(struct bt_conn *conn,
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&conn->channels, chan, node) {
-		if (BR_CHAN(chan)->rx.cid == cid) {
+		if (BR_CHAN(chan)->tx.cid == cid) {
 			sys_slist_remove(&conn->channels, prev, &chan->node);
 			return BR_CHAN(chan);
 		}


### PR DESCRIPTION
…annel
 hi ：
     in recently  i am debugging my bluetooth software based on zephyr,  when I disconnected acl link from my smart moblie phone , my software always fail to send disconnect rsp successfully . i looked up my log , i  
found  software can not find corresponding channel based on cid , so i modified code , pls reveiew it