### PR TITLE
fs: implemented unmount function to fatfs

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -48,7 +48,11 @@ build:
         else
           ./scripts/ci/run_ci.sh -s -b ${BRANCH} -r origin -m ${MATRIX_BUILD} -M ${MATRIX_BUILDS};
         fi;
-
+branches:
+  only:
+    - master
+    - v*-branch
+    - topic-*
 integrations:
   notifications:
     - integrationName: slack_integration

--- a/include/net/promiscuous.h
+++ b/include/net/promiscuous.h
@@ -60,7 +60,7 @@ static inline int net_promisc_mode_on(struct net_if *iface)
 {
 	ARG_UNUSED(iface);
 
-	return -ENOSUP;
+	return -ENOTSUP;
 }
 #endif /* CONFIG_NET_PROMISCUOUS_MODE */
 
@@ -78,7 +78,7 @@ static inline int net_promisc_mode_off(struct net_if *iface)
 {
 	ARG_UNUSED(iface);
 
-	return -ENOSUP;
+	return -ENOTSUP;
 }
 #endif /* CONFIG_NET_PROMISCUOUS_MODE */
 

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -354,6 +354,15 @@ static int fatfs_mount(struct fs_mount_t *mountp)
 
 }
 
+static int fatfs_unmount(struct fs_mount_t *mountp)
+{
+	FRESULT res;
+
+	res = f_mount(NULL, &mountp->mnt_point[1], 1);
+
+	return translate_error(res);
+}
+
 /* File system interface */
 static struct fs_file_system_t fatfs_fs = {
 	.open = fatfs_open,
@@ -368,6 +377,7 @@ static struct fs_file_system_t fatfs_fs = {
 	.readdir = fatfs_readdir,
 	.closedir = fatfs_closedir,
 	.mount = fatfs_mount,
+	.unmount = fatfs_unmount,
 	.unlink = fatfs_unlink,
 	.rename = fatfs_rename,
 	.mkdir = fatfs_mkdir,


### PR DESCRIPTION
There isn't a function to handle the unmount, so I implemented based in
f_mount comments. In the comments of f_mount we actually have that f_mount is
used to mount/unmount logic, is just necessary use NULL pointer to fs
argument.

Signed-off-by: Lucas Peixoto <lucaspeixotoac@gmail.com>