### PR TITLE
cmake: Toolchain abstraction: Linker abstraction Part 4 (C++)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,9 +230,8 @@ if(NOT CONFIG_NATIVE_APPLICATION)
 endif()
 
 if(CONFIG_LIB_CPLUSPLUS)
-zephyr_ld_options(
-  -lstdc++
-)
+  # @Intent: Set linker specific flags for C++
+  toolchain_ld_cpp()
 endif()
 
 # ==========================================================================

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -7,3 +7,4 @@ set_ifndef(LINKERFLAGPREFIX -Wl)
 # Load toolchain_ld-family macros
 include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_base.cmake)
 include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_baremetal.cmake)
+include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_cpp.cmake)

--- a/cmake/linker/ld/target_cpp.cmake
+++ b/cmake/linker/ld/target_cpp.cmake
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# See root CMakeLists.txt for description and expectations of these macros
+
+macro(toolchain_ld_cpp)
+
+  zephyr_ld_options(
+    -lstdc++
+  )
+
+endmacro()


### PR DESCRIPTION
This is Part 4 of Linker abstraction, which includes Part 3 (sequentially dependent).
Part 3 PR: #15695.
Part 2 PR: #15693.
Part 1 PR: #15686.

No functional change expected.

This is motivated by the wish to abstract Zephyr's usage of toolchains,
permitting non-intrusive porting to other (commercial) toolchains.

Zephyr's cmake build system currently assumes GNU ld is used as the linker.
This is not the case for Oticon which uses another incompatible linker, and our own custom linker scripts.
Without these PRs, Oticon and others will have to keep patching Zephyr Cmake code.

Signed-off-by: Mark Ruvald Pedersen mped@oticon.com

-------------

Part of #16031