### PR TITLE
cmake: remove incorrect statement from doc

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -446,8 +446,7 @@ endfunction()
 # Add the existing CMake library 'library' to the global list of
 # Zephyr CMake libraries. This is done automatically by the
 # constructor but must called explicitly on CMake libraries that do
-# not use a zephyr library constructor, but have source files that
-# need to be included in the build.
+# not use a zephyr library constructor.
 function(zephyr_append_cmake_library library)
   set_property(GLOBAL APPEND PROPERTY ZEPHYR_LIBS ${library})
 endfunction()


### PR DESCRIPTION
The function zephyr_append_cmake_library works with
libraries that does not have source files.

This change removes an incorrect statement related
to that.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>