### PR TITLE
cmake: helper function for importing library

### DIFF
--- a/boards/posix/nrf52_bsim/CMakeLists.txt
+++ b/boards/posix/nrf52_bsim/CMakeLists.txt
@@ -93,21 +93,12 @@ zephyr_ld_options(
   -lm
 )
 
-add_library(bsim_libUtilv1      STATIC IMPORTED GLOBAL)
-add_library(bsim_libPhyComv1    STATIC IMPORTED GLOBAL)
-add_library(bsim_lib2G4PhyComv1 STATIC IMPORTED GLOBAL)
-add_library(bsim_libRandv2      STATIC IMPORTED GLOBAL)
-add_library(bsim_libNRF52_hw    STATIC IMPORTED GLOBAL)
-set_target_properties(bsim_libUtilv1      PROPERTIES IMPORTED_LOCATION $ENV{BSIM_OUT_PATH}/lib/libUtilv1.32.a)
-set_target_properties(bsim_libPhyComv1    PROPERTIES IMPORTED_LOCATION $ENV{BSIM_OUT_PATH}/lib/libPhyComv1.32.a)
-set_target_properties(bsim_lib2G4PhyComv1 PROPERTIES IMPORTED_LOCATION $ENV{BSIM_OUT_PATH}/lib/lib2G4PhyComv1.32.a)
-set_target_properties(bsim_libRandv2      PROPERTIES IMPORTED_LOCATION $ENV{BSIM_OUT_PATH}/lib/libRandv2.32.a)
-set_target_properties(bsim_libNRF52_hw    PROPERTIES IMPORTED_LOCATION $ENV{BSIM_OUT_PATH}/lib/libNRF52_hw_models.32.a)
-zephyr_append_cmake_library(bsim_libUtilv1)
-zephyr_append_cmake_library(bsim_libPhyComv1)
-zephyr_append_cmake_library(bsim_lib2G4PhyComv1)
-zephyr_append_cmake_library(bsim_libRandv2)
-zephyr_append_cmake_library(bsim_libNRF52_hw)
+set(libpath $ENV{BSIM_OUT_PATH}/lib)
+zephyr_library_import(bsim_libUtilv1      ${libpath}/libUtilv1.32.a)
+zephyr_library_import(bsim_libPhyComv1    ${libpath}/libPhyComv1.32.a)
+zephyr_library_import(bsim_lib2G4PhyComv1 ${libpath}/lib2G4PhyComv1.32.a)
+zephyr_library_import(bsim_libRandv2      ${libpath}/libRandv2.32.a)
+zephyr_library_import(bsim_libNRF52_hw    ${libpath}/libNRF52_hw_models.32.a)
 
 # This is due to some tests using _Static_assert which is a 2011 feature, but
 # otherwise relying on compilers supporting it also when set to C99.

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -452,6 +452,17 @@ function(zephyr_append_cmake_library library)
   set_property(GLOBAL APPEND PROPERTY ZEPHYR_LIBS ${library})
 endfunction()
 
+# Add the imported library 'library_name', located at 'library_path' to the
+# global list of Zephyr CMake libraries.
+function(zephyr_library_import library_name library_path)
+  add_library(${library_name} STATIC IMPORTED GLOBAL)
+  set_target_properties(${library_name}
+    PROPERTIES IMPORTED_LOCATION
+    ${library_path}
+    )
+  zephyr_append_cmake_library(${library_name})
+endfunction()
+
 # 1.2.1 zephyr_interface_library_*
 #
 # A Zephyr interface library is a thin wrapper over a CMake INTERFACE

--- a/subsys/net/lib/openthread/CMakeLists.txt
+++ b/subsys/net/lib/openthread/CMakeLists.txt
@@ -257,15 +257,9 @@ ExternalProject_Add_Step(
 
 # Create wrapper CMake libraries
 foreach(ot_lib ${ot_libs})
-  add_library(${ot_lib} STATIC IMPORTED GLOBAL)
-  add_dependencies(   # TODO: Necessary?
-    ${ot_lib}
-    ${ot_name}
-    )
-  set_target_properties(${ot_lib} PROPERTIES IMPORTED_LOCATION
+  zephyr_library_import(${ot_lib}
     ${ot_INSTALL_DIR}/${exec_prefix}/lib/lib${ot_lib}.a
     )
-  zephyr_append_cmake_library(${ot_lib})
 endforeach()
 
 add_subdirectory(platform)


### PR DESCRIPTION
When importing a pre compiled imported library it is currently
required to perform three steps.
This commit introduces a helper function which allows the
user to import a library with a single function call.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>