### PR TITLE
Bluetooth: controller: Fix pin or key missing response

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -1921,6 +1921,13 @@ static inline u32_t isr_rx_conn_pkt_ack(struct pdu_data *pdu_data_tx,
 		}
 		break;
 
+	case PDU_DATA_LLCTRL_TYPE_REJECT_EXT_IND:
+		if (pdu_data_tx->llctrl.reject_ext_ind.reject_opcode !=
+		    PDU_DATA_LLCTRL_TYPE_ENC_REQ) {
+			break;
+		}
+		/* Pass through */
+
 	case PDU_DATA_LLCTRL_TYPE_REJECT_IND:
 		/* resume data packet rx and tx */
 		_radio.conn_curr->pause_rx = 0U;


### PR DESCRIPTION
Fix the missing reset of Encryption Procedure state when the
peripheral responded with error reason as pin or key missing
which otherwise caused connection disconnection on next
reception of data or control packet.

Relates to #15570.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>