### PR TITLE
ext/hal/st: stm32cube: Update License Link for stm23cube packages

### DIFF
--- a/ext/hal/st/stm32cube/stm32f0xx/README
+++ b/ext/hal/st/stm32cube/stm32f0xx/README
@@ -32,7 +32,7 @@ License:
    BSD-3-Clause
 
 License Link:
-   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
+   https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
 

--- a/ext/hal/st/stm32cube/stm32f1xx/README
+++ b/ext/hal/st/stm32cube/stm32f1xx/README
@@ -32,7 +32,7 @@ License:
    BSD-3-Clause
 
 License Link:
-   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
+   https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
 

--- a/ext/hal/st/stm32cube/stm32f2xx/README
+++ b/ext/hal/st/stm32cube/stm32f2xx/README
@@ -32,7 +32,7 @@ License:
    BSD-3-Clause
 
 License Link:
-   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
+   https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
 

--- a/ext/hal/st/stm32cube/stm32f3xx/README
+++ b/ext/hal/st/stm32cube/stm32f3xx/README
@@ -32,7 +32,7 @@ License:
    BSD-3-Clause
 
 License Link:
-   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
+   https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
 

--- a/ext/hal/st/stm32cube/stm32f4xx/README
+++ b/ext/hal/st/stm32cube/stm32f4xx/README
@@ -32,7 +32,7 @@ License:
    BSD-3-Clause
 
 License Link:
-   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
+   https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
 

--- a/ext/hal/st/stm32cube/stm32f7xx/README
+++ b/ext/hal/st/stm32cube/stm32f7xx/README
@@ -32,7 +32,7 @@ License:
    BSD-3-Clause
 
 License Link:
-   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
+   https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
 

--- a/ext/hal/st/stm32cube/stm32l0xx/README
+++ b/ext/hal/st/stm32cube/stm32l0xx/README
@@ -32,7 +32,7 @@ License:
    BSD-3-Clause
 
 License Link:
-   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
+   https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
 

--- a/ext/hal/st/stm32cube/stm32l1xx/README
+++ b/ext/hal/st/stm32cube/stm32l1xx/README
@@ -32,7 +32,7 @@ License:
    BSD-3-Clause
 
 License Link:
-   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
+   https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
 

--- a/ext/hal/st/stm32cube/stm32l4xx/README
+++ b/ext/hal/st/stm32cube/stm32l4xx/README
@@ -32,7 +32,7 @@ License:
    BSD-3-Clause
 
 License Link:
-   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
+   https://opensource.org/licenses/BSD-3-Clause
 
 Patch List:
 


### PR DESCRIPTION
License link provided in stm32cube abstract packages was not
reflecting the actual license in use for these packages.
Update the link to BSD 3-Clause official.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>