### PR TITLE
drivers: nrf: Trigger STOP events and wait before disabling UARTE

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1189,6 +1189,21 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 		assert(new_state == DEVICE_PM_LOW_POWER_STATE ||
 		       new_state == DEVICE_PM_SUSPEND_STATE ||
 		       new_state == DEVICE_PM_OFF_STATE);
+
+		/* Disabling UART requires stopping RX, but stop RX event is
+		 * only sent after each RX if async UART API is used.
+		 */
+#ifdef CONFIG_UART_ASYNC_API
+		if (get_dev_data(dev)->async) {
+			nrf_uarte_disable(uarte);
+			return;
+		}
+#endif
+		nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STOPRX);
+		while (!nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_RXTO)) {
+			/* Busy wait for event to register */
+		}
+		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXTO);
 		nrf_uarte_disable(uarte);
 	}
 }


### PR DESCRIPTION
Without first triggering TASKS_STOP{RX,TX}, I observed that the UARTE was never
disabled when using device_set_power_state which resulted in the HFCLK never
being shut down and several hundred microamps in unnecessary current consumption
when idle. This seems to fix the issue.

Signed-off-by: Benjamin Lindqvist <benjamin.lindqvist@endian.se>