### PR TITLE
samples: LSM6DSL accel fix unchecked return value sensor_trigger_set()

### DIFF
--- a/samples/sensor/lsm6dsl/src/main.c
+++ b/samples/sensor/lsm6dsl/src/main.c
@@ -128,7 +128,11 @@ void main(void)
 
 	trig.type = SENSOR_TRIG_DATA_READY;
 	trig.chan = SENSOR_CHAN_ACCEL_XYZ;
-	sensor_trigger_set(lsm6dsl_dev, &trig, lsm6dsl_trigger_handler);
+
+	if (sensor_trigger_set(lsm6dsl_dev, &trig, lsm6dsl_trigger_handler) != 0) {
+		printk("Could not set sensor type and channel\n");
+		return;
+	}
 #endif
 
 	if (sensor_sample_fetch(lsm6dsl_dev) < 0) {


### PR DESCRIPTION
Inside void main(void) result of function sensor_trigger_set() is not
checked which might result that function can't set sensor type
and that error can't be handled.

Coverity-CID: 186196
Fixes #15743
Signed-off-by: Maksim Masalski <maxxliferobot@gmail.com>