### PR TITLE
ext/hal/st/stm32cube/stm32l1xx: rename SVC_IRQn -> SVCall_IRQn

### DIFF
--- a/ext/hal/st/stm32cube/stm32l1xx/README
+++ b/ext/hal/st/stm32cube/stm32l1xx/README
@@ -33,3 +33,46 @@ License:
 
 License Link:
    http://www.st.com/resource/en/license_agreement/dm00218346.pdf
+
+Patch List:
+
+    *ext/hal/st/stm32cube/stm32l1xx: rename SVC_IRQn -> SVCall_IRQn
+
+     SVCall_IRQn is used as enum value for SV Call Interrupt for Cortex-M
+     based SoCs for which CPU_CORTEX_M_HAS_BASEPRI=y. However stm32cube
+     for stm32l1xx uses SVC_IRQn enum value for this purpose.
+     This leads to this error:
+
+       arch/arm/include/cortex_m/exc.h:101:19: error: 'SVCall_IRQn'
+         undeclared (first use in this function); did you mean 'SVC_IRQn'?
+
+         NVIC_SetPriority(SVCall_IRQn, _EXC_SVC_PRIO);
+                          ^~~~~~~~~~~
+                          SVC_IRQn
+
+     NB: ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xb.h file was already
+     fixed in 9f8260457b86 ('ext: hal: st: stm32cube: Add HAL for
+     the STM32L1x series').
+     Impacted files:
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l100xb.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l100xba.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l100xc.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xba.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xc.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xca.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xd.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xdx.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xe.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xb.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xba.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xc.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xca.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xd.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xdx.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xe.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xc.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xca.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xd.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xdx.h
+      ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xe.h
+     ST Bug tracker ID: 66029

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l100xb.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l100xb.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l100xba.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l100xba.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l100xc.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l100xc.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xba.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xba.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xc.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xc.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xca.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xca.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xd.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xd.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xdx.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xdx.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xe.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xe.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xb.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xb.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xba.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xba.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xc.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xc.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xca.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xca.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xd.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xd.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xdx.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xdx.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xe.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l152xe.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xc.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xc.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xca.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xca.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xd.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xd.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xdx.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xdx.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xe.h
+++ b/ext/hal/st/stm32cube/stm32l1xx/soc/stm32l162xe.h
@@ -90,7 +90,7 @@ typedef enum
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */


### PR DESCRIPTION
SVCall_IRQn is used as enum value for SV Call Interrupt for Cortex-M
based SoCs for which ```CPU_CORTEX_M_HAS_BASEPRI=y```. However stm32cube
for stm32l1xx uses SVC_IRQn enum value for this purpose.
This leads to this error:

```
  arch/arm/include/cortex_m/exc.h:101:19: error: 'SVCall_IRQn'
    undeclared (first use in this function); did you mean 'SVC_IRQn'?

    NVIC_SetPriority(SVCall_IRQn, _EXC_SVC_PRIO);
                     ^~~~~~~~~~~
                     SVC_IRQn
```

NB: ext/hal/st/stm32cube/stm32l1xx/soc/stm32l151xb.h file was already
fixed in 9f8260457b86 ('ext: hal: st: stm32cube: Add HAL for the STM32L1x series').
