### PR TITLE
cmake: Toolchain abstraction: Linker abstraction Part 5 (cleanup, configure_linker_script)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,7 +408,8 @@ endif()
 
 configure_file(version.h.in ${PROJECT_BINARY_DIR}/include/generated/version.h)
 
-macro(construct_add_custom_command_for_linker_pass linker_output_name)
+# Run $LINKER_SCRIPT file through the C preprocessor, producing ${linker_output_name}.cmd
+macro(configure_linker_script linker_output_name)
   set(extra_dependencies ${ARGN})
   set(linker_cmd_file_name ${linker_output_name}.cmd)
 
@@ -439,8 +440,6 @@ macro(construct_add_custom_command_for_linker_pass linker_output_name)
   zephyr_get_include_directories_for_lang(C current_includes)
   get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
   get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
-
-  # Run $LINKER_SCRIPT through the C preprocessor, producing $linker_cmd_file_name
 
   add_custom_command(
     OUTPUT ${linker_cmd_file_name}
@@ -731,7 +730,7 @@ if (CONFIG_CODE_DATA_RELOCATION)
   set(CODE_RELOCATION_DEP code_relocation_source_lib)
 endif() # CONFIG_CODE_DATA_RELOCATION
 
-construct_add_custom_command_for_linker_pass(
+configure_linker_script(
   linker
   ${PRIV_STACK_DEP}
   ${APP_SMEM_ALIGNED_DEP}
@@ -1159,7 +1158,7 @@ if(CONFIG_USERSPACE)
     COMMENT "Generating app_smem_unaligned linker section"
     )
 
-  construct_add_custom_command_for_linker_pass(
+  configure_linker_script(
     linker_app_smem_unaligned
     ${CODE_RELOCATION_DEP}
     ${APP_SMEM_UNALIGNED_DEP}
@@ -1203,7 +1202,7 @@ if(CONFIG_USERSPACE)
 endif()
 
 if(CONFIG_USERSPACE AND CONFIG_ARM)
-  construct_add_custom_command_for_linker_pass(
+  configure_linker_script(
     linker_priv_stacks
     ${CODE_RELOCATION_DEP}
     ${APP_SMEM_ALIGNED_DEP}
@@ -1249,7 +1248,7 @@ else()
   # The second linker pass uses the same source linker script of the
   # first pass (LINKER_SCRIPT), but this time with a different output
   # file and preprocessed with the define LINKER_PASS2.
-  construct_add_custom_command_for_linker_pass(
+  configure_linker_script(
     linker_pass_final
     ${PRIV_STACK_DEP}
     ${CODE_RELOCATION_DEP}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,14 +408,13 @@ endif()
 
 configure_file(version.h.in ${PROJECT_BINARY_DIR}/include/generated/version.h)
 
-# Run $LINKER_SCRIPT file through the C preprocessor, producing ${linker_output_name}.cmd
-macro(configure_linker_script linker_output_name)
+# Run $LINKER_SCRIPT file through the C preprocessor, producing ${linker_script_gen}
+macro(configure_linker_script linker_script_gen)
   set(extra_dependencies ${ARGN})
-  set(linker_cmd_file_name ${linker_output_name}.cmd)
 
-  if (${linker_output_name} MATCHES "^linker_pass_final$")
+  if (${linker_script_gen} MATCHES "^linker_pass_final.cmd$")
     set(linker_pass_define -DLINKER_PASS2)
-  elseif (${linker_output_name} MATCHES "^linker_app_smem_unaligned$")
+  elseif (${linker_script_gen} MATCHES "^linker_app_smem_unaligned.cmd$")
     set(linker_pass_define -DLINKER_APP_SMEM_UNALIGNED)
   else()
     set(linker_pass_define "")
@@ -428,7 +427,7 @@ macro(configure_linker_script linker_output_name)
     set(linker_script_dep IMPLICIT_DEPENDS C ${LINKER_SCRIPT})
   elseif(CMAKE_GENERATOR STREQUAL "Ninja")
     # Using DEPFILE with other generators than Ninja is an error.
-    set(linker_script_dep DEPFILE ${PROJECT_BINARY_DIR}/${linker_cmd_file_name}.dep)
+    set(linker_script_dep DEPFILE ${PROJECT_BINARY_DIR}/${linker_script_gen}.dep)
   else()
     # TODO: How would the linker script dependencies work for non-linker
     # script generators.
@@ -442,7 +441,7 @@ macro(configure_linker_script linker_output_name)
   get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
   add_custom_command(
-    OUTPUT ${linker_cmd_file_name}
+    OUTPUT ${linker_script_gen}
     DEPENDS
     ${LINKER_SCRIPT}
     ${extra_dependencies}
@@ -451,13 +450,13 @@ macro(configure_linker_script linker_output_name)
     COMMAND ${CMAKE_C_COMPILER}
     -x assembler-with-cpp
     ${NOSYSDEF_CFLAG}
-    -MD -MF ${linker_cmd_file_name}.dep -MT ${base_name}/${linker_cmd_file_name}
+    -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
     ${current_includes}
     ${current_defines}
     ${linker_pass_define}
     -E ${LINKER_SCRIPT}
     -P # Prevent generation of debug `#line' directives.
-    -o ${linker_cmd_file_name}
+    -o ${linker_script_gen}
     VERBATIM
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
   )
@@ -731,7 +730,7 @@ if (CONFIG_CODE_DATA_RELOCATION)
 endif() # CONFIG_CODE_DATA_RELOCATION
 
 configure_linker_script(
-  linker
+  linker.cmd
   ${PRIV_STACK_DEP}
   ${APP_SMEM_ALIGNED_DEP}
   ${CODE_RELOCATION_DEP}
@@ -1159,7 +1158,7 @@ if(CONFIG_USERSPACE)
     )
 
   configure_linker_script(
-    linker_app_smem_unaligned
+    linker_app_smem_unaligned.cmd
     ${CODE_RELOCATION_DEP}
     ${APP_SMEM_UNALIGNED_DEP}
     ${APP_SMEM_UNALIGNED_LD}
@@ -1203,7 +1202,7 @@ endif()
 
 if(CONFIG_USERSPACE AND CONFIG_ARM)
   configure_linker_script(
-    linker_priv_stacks
+    linker_priv_stacks.cmd
     ${CODE_RELOCATION_DEP}
     ${APP_SMEM_ALIGNED_DEP}
     ${APP_SMEM_ALIGNED_LD}
@@ -1249,7 +1248,7 @@ else()
   # first pass (LINKER_SCRIPT), but this time with a different output
   # file and preprocessed with the define LINKER_PASS2.
   configure_linker_script(
-    linker_pass_final
+    linker_pass_final.cmd
     ${PRIV_STACK_DEP}
     ${CODE_RELOCATION_DEP}
     ${ZEPHYR_PREBUILT_EXECUTABLE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,16 +409,8 @@ endif()
 configure_file(version.h.in ${PROJECT_BINARY_DIR}/include/generated/version.h)
 
 # Run $LINKER_SCRIPT file through the C preprocessor, producing ${linker_script_gen}
-macro(configure_linker_script linker_script_gen)
+macro(configure_linker_script linker_script_gen linker_pass_define)
   set(extra_dependencies ${ARGN})
-
-  if (${linker_script_gen} MATCHES "^linker_pass_final.cmd$")
-    set(linker_pass_define -DLINKER_PASS2)
-  elseif (${linker_script_gen} MATCHES "^linker_app_smem_unaligned.cmd$")
-    set(linker_pass_define -DLINKER_APP_SMEM_UNALIGNED)
-  else()
-    set(linker_pass_define "")
-  endif()
 
   # Different generators deal with depfiles differently.
   if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
@@ -731,6 +723,7 @@ endif() # CONFIG_CODE_DATA_RELOCATION
 
 configure_linker_script(
   linker.cmd
+  ""
   ${PRIV_STACK_DEP}
   ${APP_SMEM_ALIGNED_DEP}
   ${CODE_RELOCATION_DEP}
@@ -1159,6 +1152,7 @@ if(CONFIG_USERSPACE)
 
   configure_linker_script(
     linker_app_smem_unaligned.cmd
+    "-DLINKER_APP_SMEM_UNALIGNED"
     ${CODE_RELOCATION_DEP}
     ${APP_SMEM_UNALIGNED_DEP}
     ${APP_SMEM_UNALIGNED_LD}
@@ -1203,6 +1197,7 @@ endif()
 if(CONFIG_USERSPACE AND CONFIG_ARM)
   configure_linker_script(
     linker_priv_stacks.cmd
+    ""
     ${CODE_RELOCATION_DEP}
     ${APP_SMEM_ALIGNED_DEP}
     ${APP_SMEM_ALIGNED_LD}
@@ -1249,6 +1244,7 @@ else()
   # file and preprocessed with the define LINKER_PASS2.
   configure_linker_script(
     linker_pass_final.cmd
+    "-DLINKER_PASS2"
     ${PRIV_STACK_DEP}
     ${CODE_RELOCATION_DEP}
     ${ZEPHYR_PREBUILT_EXECUTABLE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,52 +408,6 @@ endif()
 
 configure_file(version.h.in ${PROJECT_BINARY_DIR}/include/generated/version.h)
 
-# Run $LINKER_SCRIPT file through the C preprocessor, producing ${linker_script_gen}
-macro(configure_linker_script linker_script_gen linker_pass_define)
-  set(extra_dependencies ${ARGN})
-
-  # Different generators deal with depfiles differently.
-  if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
-    # Note that the IMPLICIT_DEPENDS option is currently supported only
-    # for Makefile generators and will be ignored by other generators.
-    set(linker_script_dep IMPLICIT_DEPENDS C ${LINKER_SCRIPT})
-  elseif(CMAKE_GENERATOR STREQUAL "Ninja")
-    # Using DEPFILE with other generators than Ninja is an error.
-    set(linker_script_dep DEPFILE ${PROJECT_BINARY_DIR}/${linker_script_gen}.dep)
-  else()
-    # TODO: How would the linker script dependencies work for non-linker
-    # script generators.
-    message(STATUS "Warning; this generator is not well supported. The
-  Linker script may not be regenerated when it should.")
-    set(linker_script_dep "")
-  endif()
-
-  zephyr_get_include_directories_for_lang(C current_includes)
-  get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
-  get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
-
-  add_custom_command(
-    OUTPUT ${linker_script_gen}
-    DEPENDS
-    ${LINKER_SCRIPT}
-    ${extra_dependencies}
-    # NB: 'linker_script_dep' will use a keyword that ends 'DEPENDS'
-    ${linker_script_dep}
-    COMMAND ${CMAKE_C_COMPILER}
-    -x assembler-with-cpp
-    ${NOSYSDEF_CFLAG}
-    -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
-    ${current_includes}
-    ${current_defines}
-    ${linker_pass_define}
-    -E ${LINKER_SCRIPT}
-    -P # Prevent generation of debug `#line' directives.
-    -o ${linker_script_gen}
-    VERBATIM
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-  )
-endmacro()
-
 # Error-out when the deprecated naming convention is found (until
 # after 1.14.0 has been released)
 foreach(path

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ assert(toolchain_is_ok "The toolchain is unable to build a dummy C file. See CMa
 set(CMAKE_EXECUTABLE_SUFFIX .elf)
 set(ZEPHYR_PREBUILT_EXECUTABLE zephyr_prebuilt)
 
+# Set some phony targets to collect dependencies
 set(OFFSETS_H_TARGET           offsets_h)
 set(SYSCALL_MACROS_H_TARGET    syscall_macros_h_target)
 set(SYSCALL_LIST_H_TARGET      syscall_list_h_target)
@@ -407,7 +408,7 @@ endif()
 
 configure_file(version.h.in ${PROJECT_BINARY_DIR}/include/generated/version.h)
 
-function(construct_add_custom_command_for_linker_pass linker_output_name output_variable)
+macro(construct_add_custom_command_for_linker_pass linker_output_name)
   set(extra_dependencies ${ARGN})
   set(linker_cmd_file_name ${linker_output_name}.cmd)
 
@@ -439,7 +440,9 @@ function(construct_add_custom_command_for_linker_pass linker_output_name output_
   get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
   get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
-  set(${output_variable}
+  # Run $LINKER_SCRIPT through the C preprocessor, producing $linker_cmd_file_name
+
+  add_custom_command(
     OUTPUT ${linker_cmd_file_name}
     DEPENDS
     ${LINKER_SCRIPT}
@@ -458,10 +461,8 @@ function(construct_add_custom_command_for_linker_pass linker_output_name output_
     -o ${linker_cmd_file_name}
     VERBATIM
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-
-    PARENT_SCOPE
-    )
-endfunction()
+  )
+endmacro()
 
 # Error-out when the deprecated naming convention is found (until
 # after 1.14.0 has been released)
@@ -732,15 +733,11 @@ endif() # CONFIG_CODE_DATA_RELOCATION
 
 construct_add_custom_command_for_linker_pass(
   linker
-  custom_command
   ${PRIV_STACK_DEP}
   ${APP_SMEM_ALIGNED_DEP}
   ${CODE_RELOCATION_DEP}
   ${OFFSETS_H_TARGET}
   )
-add_custom_command(
-  ${custom_command}
-)
 
 add_custom_target(
   ${LINKER_SCRIPT_TARGET}
@@ -1164,14 +1161,10 @@ if(CONFIG_USERSPACE)
 
   construct_add_custom_command_for_linker_pass(
     linker_app_smem_unaligned
-    custom_command
     ${CODE_RELOCATION_DEP}
     ${APP_SMEM_UNALIGNED_DEP}
     ${APP_SMEM_UNALIGNED_LD}
     ${OFFSETS_H_TARGET}
-    )
-  add_custom_command(
-    ${custom_command}
     )
 
   add_custom_target(
@@ -1212,14 +1205,10 @@ endif()
 if(CONFIG_USERSPACE AND CONFIG_ARM)
   construct_add_custom_command_for_linker_pass(
     linker_priv_stacks
-    custom_command
     ${CODE_RELOCATION_DEP}
     ${APP_SMEM_ALIGNED_DEP}
     ${APP_SMEM_ALIGNED_LD}
     ${OFFSETS_H_TARGET}
-    )
-  add_custom_command(
-    ${custom_command}
     )
 
   add_custom_target(
@@ -1262,14 +1251,10 @@ else()
   # file and preprocessed with the define LINKER_PASS2.
   construct_add_custom_command_for_linker_pass(
     linker_pass_final
-    custom_command
     ${PRIV_STACK_DEP}
     ${CODE_RELOCATION_DEP}
     ${ZEPHYR_PREBUILT_EXECUTABLE}
     ${OFFSETS_H_TARGET}
-    )
-  add_custom_command(
-    ${custom_command}
     )
 
   set(LINKER_PASS_FINAL_SCRIPT_TARGET linker_pass_final_script_target)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,7 +552,7 @@ endif()
 set(syscall_macros_h ${ZEPHYR_BINARY_DIR}/include/generated/syscall_macros.h)
 
 add_custom_target(${SYSCALL_MACROS_H_TARGET} DEPENDS ${syscall_macros_h})
-add_custom_command(                       OUTPUT  ${syscall_macros_h}
+add_custom_command(                          OUTPUT  ${syscall_macros_h}
   COMMAND
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_BASE}/scripts/gen_syscall_header.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -733,7 +733,6 @@ endif() # CONFIG_CODE_DATA_RELOCATION
 construct_add_custom_command_for_linker_pass(
   linker
   custom_command
-  ${ALIGN_SIZING_DEP}
   ${PRIV_STACK_DEP}
   ${APP_SMEM_ALIGNED_DEP}
   ${CODE_RELOCATION_DEP}
@@ -1166,7 +1165,6 @@ if(CONFIG_USERSPACE)
   construct_add_custom_command_for_linker_pass(
     linker_app_smem_unaligned
     custom_command
-    ${ALIGN_SIZING_DEP}
     ${CODE_RELOCATION_DEP}
     ${APP_SMEM_UNALIGNED_DEP}
     ${APP_SMEM_UNALIGNED_LD}
@@ -1192,7 +1190,7 @@ if(CONFIG_USERSPACE)
   add_executable(       app_smem_unaligned_prebuilt misc/empty_file.c)
   target_link_libraries(app_smem_unaligned_prebuilt ${TOPT} ${PROJECT_BINARY_DIR}/linker_app_smem_unaligned.cmd ${zephyr_lnk} ${CODE_RELOCATION_DEP})
   set_property(TARGET   app_smem_unaligned_prebuilt PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker_app_smem_unaligned.cmd)
-  add_dependencies(     app_smem_unaligned_prebuilt ${ALIGN_SIZING_DEP} linker_app_smem_unaligned_script ${OFFSETS_LIB})
+  add_dependencies(     app_smem_unaligned_prebuilt linker_app_smem_unaligned_script ${OFFSETS_LIB})
 
   add_custom_command(
     OUTPUT ${APP_SMEM_ALIGNED_LD}
@@ -1215,7 +1213,6 @@ if(CONFIG_USERSPACE AND CONFIG_ARM)
   construct_add_custom_command_for_linker_pass(
     linker_priv_stacks
     custom_command
-    ${ALIGN_SIZING_DEP}
     ${CODE_RELOCATION_DEP}
     ${APP_SMEM_ALIGNED_DEP}
     ${APP_SMEM_ALIGNED_LD}
@@ -1241,14 +1238,14 @@ if(CONFIG_USERSPACE AND CONFIG_ARM)
   add_executable(       priv_stacks_prebuilt misc/empty_file.c)
   target_link_libraries(priv_stacks_prebuilt ${TOPT} ${PROJECT_BINARY_DIR}/linker_priv_stacks.cmd ${zephyr_lnk} ${CODE_RELOCATION_DEP})
   set_property(TARGET   priv_stacks_prebuilt PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker_priv_stacks.cmd)
-  add_dependencies(     priv_stacks_prebuilt ${ALIGN_SIZING_DEP} linker_priv_stacks_script ${OFFSETS_LIB})
+  add_dependencies(     priv_stacks_prebuilt linker_priv_stacks_script ${OFFSETS_LIB})
 endif()
 
 # FIXME: Is there any way to get rid of empty_file.c?
 add_executable(       ${ZEPHYR_PREBUILT_EXECUTABLE} misc/empty_file.c)
 target_link_libraries(${ZEPHYR_PREBUILT_EXECUTABLE} ${TOPT} ${PROJECT_BINARY_DIR}/linker.cmd ${PRIV_STACK_LIB} ${zephyr_lnk} ${CODE_RELOCATION_DEP})
 set_property(TARGET   ${ZEPHYR_PREBUILT_EXECUTABLE} PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker.cmd)
-add_dependencies(     ${ZEPHYR_PREBUILT_EXECUTABLE} ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP} ${LINKER_SCRIPT_TARGET} ${OFFSETS_LIB})
+add_dependencies(     ${ZEPHYR_PREBUILT_EXECUTABLE} ${PRIV_STACK_DEP} ${LINKER_SCRIPT_TARGET} ${OFFSETS_LIB})
 
 
 set(generated_kernel_files ${GKSF} ${GKOF})
@@ -1266,7 +1263,6 @@ else()
   construct_add_custom_command_for_linker_pass(
     linker_pass_final
     custom_command
-    ${ALIGN_SIZING_DEP}
     ${PRIV_STACK_DEP}
     ${CODE_RELOCATION_DEP}
     ${ZEPHYR_PREBUILT_EXECUTABLE}
@@ -1291,7 +1287,7 @@ else()
   add_executable(       ${KERNEL_ELF} misc/empty_file.c ${GKSF})
   target_link_libraries(${KERNEL_ELF} ${GKOF} ${TOPT} ${PROJECT_BINARY_DIR}/linker_pass_final.cmd ${zephyr_lnk} ${CODE_RELOCATION_DEP})
   set_property(TARGET   ${KERNEL_ELF} PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker_pass_final.cmd)
-  add_dependencies(     ${KERNEL_ELF} ${ALIGN_SIZING_DEP} ${PRIV_STACK_DEP} ${LINKER_PASS_FINAL_SCRIPT_TARGET})
+  add_dependencies(     ${KERNEL_ELF} ${PRIV_STACK_DEP} ${LINKER_PASS_FINAL_SCRIPT_TARGET})
 endif()
 
 # Export the variable to the application's scope to allow the

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -4,6 +4,55 @@ find_program(CMAKE_LINKER     ${CROSS_COMPILE}ld      PATH ${TOOLCHAIN_HOME} NO_
 
 set_ifndef(LINKERFLAGPREFIX -Wl)
 
+
+# Run $LINKER_SCRIPT file through the C preprocessor, producing ${linker_script_gen}
+# NOTE: ${linker_script_gen} will be produced at build-time; not at configure-time
+macro(configure_linker_script linker_script_gen linker_pass_define)
+  set(extra_dependencies ${ARGN})
+
+  # Different generators deal with depfiles differently.
+  if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+    # Note that the IMPLICIT_DEPENDS option is currently supported only
+    # for Makefile generators and will be ignored by other generators.
+    set(linker_script_dep IMPLICIT_DEPENDS C ${LINKER_SCRIPT})
+  elseif(CMAKE_GENERATOR STREQUAL "Ninja")
+    # Using DEPFILE with other generators than Ninja is an error.
+    set(linker_script_dep DEPFILE ${PROJECT_BINARY_DIR}/${linker_script_gen}.dep)
+  else()
+    # TODO: How would the linker script dependencies work for non-linker
+    # script generators.
+    message(STATUS "Warning; this generator is not well supported. The
+  Linker script may not be regenerated when it should.")
+    set(linker_script_dep "")
+  endif()
+
+  zephyr_get_include_directories_for_lang(C current_includes)
+  get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
+  get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
+
+  add_custom_command(
+    OUTPUT ${linker_script_gen}
+    DEPENDS
+    ${LINKER_SCRIPT}
+    ${extra_dependencies}
+    # NB: 'linker_script_dep' will use a keyword that ends 'DEPENDS'
+    ${linker_script_dep}
+    COMMAND ${CMAKE_C_COMPILER}
+    -x assembler-with-cpp
+    ${NOSYSDEF_CFLAG}
+    -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
+    ${current_includes}
+    ${current_defines}
+    ${linker_pass_define}
+    -E ${LINKER_SCRIPT}
+    -P # Prevent generation of debug `#line' directives.
+    -o ${linker_script_gen}
+    VERBATIM
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+  )
+endmacro()
+
+
 # Load toolchain_ld-family macros
 include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_base.cmake)
 include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_baremetal.cmake)


### PR DESCRIPTION
This is Part 5 of Linker abstraction.
Part 4 PR: #15722.
Part 3 PR: #15695.
Part 2 PR: #15693.
Part 1 PR: #15686.

No functional change expected.

This is motivated by the wish to abstract Zephyr's usage of toolchains,
permitting non-intrusive porting to other (commercial) toolchains.

Zephyr's cmake build system currently assumes GNU ld is used as the linker.
This is not the case for Oticon which uses another incompatible linker, and our own custom linker scripts.
Without these PRs, Oticon and others will have to keep patching Zephyr Cmake code.

Signed-off-by: Mark Ruvald Pedersen mped@oticon.com

-------------

Part of #16031