### PR TITLE
drivers: adc: add API to support calibration

### DIFF
--- a/include/adc.h
+++ b/include/adc.h
@@ -253,6 +253,16 @@ struct adc_sequence {
 	 * a specific mode (e.g. when sampling multiple channels).
 	 */
 	u8_t oversampling;
+
+	/**
+	 * Perform calibration before the reading is taken if requested.
+	 *
+	 * The impact of channel configuration on the calibration
+	 * process is specific to the underlying hardware.  ADC
+	 * implementations that do not support calibration should
+	 * ignore this flag.
+	 */
+	bool calibrate;
 };
 
 


### PR DESCRIPTION
Add a flag to the sequence structure that tells the driver it should
calibrate the ADC prior to initiating the sample.

Implement this for nRF SAADC.  The implementation supports the
workarounds for PAN-86 and PAN-178.

Relates-to: issue #11922
Signed-off-by: Peter A. Bigot <pab@pabigot.com>