### PR TITLE
doc: clarify behavior of k_poll_signal_raise on error

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4429,6 +4429,10 @@ __syscall void k_poll_signal_check(struct k_poll_signal *signal,
  * passed again to k_poll() or k_poll() will consider it being signaled, and
  * will return immediately.
  *
+ * @note The result is stored and the 'signaled' field is set even if
+ * this function returns an error indicating that an expiring poll was
+ * not notified.  The next k_poll() will detect the missed raise.
+ *
  * @param signal A poll signal.
  * @param result The value to store in the result field of the signal.
  *


### PR DESCRIPTION
k_poll_signal_raise() returns an error code to indicate that the raise
was too late to notify an expiring poll.  Make clear that this does not
mean that the signal was lost: a subsequent poll will find it and expire
immediately.

(On first reading of this API I assumed the error return meant the signal was not recorded, which would make this API fragile for k_poll() used in a loop.  It does behave as desired, so this change is simply to make that clear.)