### PR TITLE
CODEOWNERS: include/cortex_m/csme/ -> include/cortex_m/csme.h

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@
 /arch/arc/                                @vonhust @ruuddw
 /arch/arm/                                @MaureenHelm @galak
 /arch/arm/core/cortex_m/cmse/             @ioannisg
-/arch/arm/include/cortex_m/cmse/          @ioannisg
+/arch/arm/include/cortex_m/cmse.h         @ioannisg
 /soc/arm/                                 @MaureenHelm @galak
 /soc/arm/arm/mps2/                        @fvincenzo
 /soc/arm/atmel_sam/sam3x/                 @ioannisg


### PR DESCRIPTION
Typo fix as discussed in original PR #14475 for commit eb82bdd419b1b

Signed-off-by: Marc Herbert <marc.herbert@intel.com>