### PR TITLE
security: kernel: Fix STACK_POINTER_RANDOM dependency

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -645,6 +645,7 @@ config EXECUTE_XOR_WRITE
 config STACK_POINTER_RANDOM
 	int "Initial stack pointer randomization bounds"
 	depends on !STACK_GROWS_UP
+	depends on TEST_RANDOM_GENERATOR || ENTROPY_HAS_DRIVER
 	default 0
 	help
 	  This option performs a limited form of Address Space Layout


### PR DESCRIPTION
STACK_POINTER_RANDOM depends on a random generator, this can be either a
non-random generator (used for testing purpose) or a real random
generator. Make this dependency explicitly in Kconfig to avoid linking
problems.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>