### PR TITLE
Bluetooth: Fix return type for settings read callback

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/storage.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/storage.c
@@ -117,7 +117,7 @@ void save_on_flash(u8_t id)
 static int ps_set(int argc, char **argv, size_t len_rd,
 		  settings_read_cb read_cb, void *cb_arg)
 {
-	size_t len = 0;
+	ssize_t len = 0;
 
 	if (argc == 1) {
 		if (!strcmp(argv[0], "rc")) {

--- a/subsys/bluetooth/host/mesh/settings.c
+++ b/subsys/bluetooth/host/mesh/settings.c
@@ -128,10 +128,9 @@ static struct {
 static inline int mesh_x_set(settings_read_cb read_cb, void *cb_arg, void *out,
 			     size_t read_len)
 {
-	size_t len;
+	ssize_t len;
 
 	len = read_cb(cb_arg, out, read_len);
-
 	if (len < 0) {
 		BT_ERR("Failed to read value (err %zu)", len);
 		return len;
@@ -513,7 +512,7 @@ static int cfg_set(int argc, char **argv, size_t len_rd,
 static int mod_set_bind(struct bt_mesh_model *mod, size_t len_rd,
 			settings_read_cb read_cb, void *cb_arg)
 {
-	size_t len;
+	ssize_t len;
 	int i;
 
 	/* Start with empty array regardless of cleared or set value */
@@ -540,7 +539,7 @@ static int mod_set_bind(struct bt_mesh_model *mod, size_t len_rd,
 static int mod_set_sub(struct bt_mesh_model *mod, size_t len_rd,
 		       settings_read_cb read_cb, void *cb_arg)
 {
-	size_t len;
+	ssize_t len;
 
 	/* Start with empty array regardless of cleared or set value */
 	(void)memset(mod->groups, 0, sizeof(mod->groups));

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -89,7 +89,7 @@ int bt_settings_decode_key(char *key, bt_addr_le_t *addr)
 static int set(int argc, char **argv, size_t len_rd, settings_read_cb read_cb,
 	       void *cb_arg)
 {
-	size_t len;
+	ssize_t len;
 
 	const struct bt_settings_handler *h;
 
@@ -111,7 +111,6 @@ static int set(int argc, char **argv, size_t len_rd, settings_read_cb read_cb,
 		}
 
 		len = read_cb(cb_arg, &bt_dev.id_addr, sizeof(bt_dev.id_addr));
-
 		if (len < sizeof(bt_dev.id_addr[0])) {
 			if (len < 0) {
 				BT_ERR("Failed to read ID address from storage"


### PR DESCRIPTION
settings_read_cb is defined to return ssize_t and not size_t. This
also eliminates several Coverity warnings.

Fixes #15765
Fixes #15768
Fixes #15771
Fixes #15774
Fixes #15778

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>