### PR TITLE
Bluetooth: controller: Fix missing BT_CTLR_FILTER conditional

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -564,7 +564,9 @@ void ll_reset(void)
 	_radio.fc_ack = _radio.fc_req;
 
 	/* reset whitelist and resolving list */
-	ll_filter_reset(false);
+	if (IS_ENABLED(CONFIG_BT_CTLR_FILTER)) {
+		ll_filter_reset(false);
+	}
 
 	/* memory allocations */
 	common_init();
@@ -6490,18 +6492,16 @@ static void event_adv(u32_t ticks_at_expire, u32_t remainder,
 #endif /* CONFIG_BT_HCI_MESH_EXT */
 
 
-#if defined(CONFIG_BT_CTLR_PRIVACY)
-	if (ctrl_rl_enabled()) {
+	/* Setup Radio Filter */
+	if (IS_ENABLED(CONFIG_BT_CTLR_PRIVACY) && ctrl_rl_enabled()) {
 		struct ll_filter *filter =
 			ctrl_filter_get(!!(_radio.advertiser.filter_policy));
 
 		radio_filter_configure(filter->enable_bitmask,
 				       filter->addr_type_bitmask,
 				       (u8_t *)filter->bdaddr);
-	} else
-#endif /* CONFIG_BT_CTLR_PRIVACY */
-	/* Setup Radio Filter */
-	if (_radio.advertiser.filter_policy) {
+	} else if (IS_ENABLED(CONFIG_BT_CTLR_FILTER) &&
+		   _radio.advertiser.filter_policy) {
 
 		struct ll_filter *wl = ctrl_filter_get(true);
 
@@ -6863,8 +6863,8 @@ static void event_scan(u32_t ticks_at_expire, u32_t remainder, u16_t lazy,
 	radio_pkt_rx_set(_radio.packet_rx[_radio.packet_rx_last]->pdu_data);
 	radio_rssi_measure();
 
-#if defined(CONFIG_BT_CTLR_PRIVACY)
-	if (ctrl_rl_enabled()) {
+	/* Setup Radio Filter */
+	if (IS_ENABLED(CONFIG_BT_CTLR_PRIVACY) && ctrl_rl_enabled()) {
 		struct ll_filter *filter =
 			ctrl_filter_get(!!(_radio.scanner.filter_policy & 0x1));
 		u8_t count, *irks = ctrl_irks_get(&count);
@@ -6874,11 +6874,8 @@ static void event_scan(u32_t ticks_at_expire, u32_t remainder, u16_t lazy,
 				       (u8_t *)filter->bdaddr);
 
 		radio_ar_configure(count, irks);
-	} else
-#endif /* CONFIG_BT_CTLR_PRIVACY */
-	/* Setup Radio Filter */
-	if (_radio.scanner.filter_policy) {
-
+	} else if (IS_ENABLED(CONFIG_BT_CTLR_FILTER) &&
+		   _radio.scanner.filter_policy) {
 		struct ll_filter *wl = ctrl_filter_get(true);
 
 		radio_filter_configure(wl->enable_bitmask,

--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -175,7 +175,10 @@ int ll_init(struct k_sem *sem_rx)
 		return -ENOMEM;
 	}
 
-	ll_filter_reset(true);
+	/* reset whitelist, resolving list and initialise RPA timeout*/
+	if (IS_ENABLED(CONFIG_BT_CTLR_FILTER)) {
+		ll_filter_reset(true);
+	}
 
 	IRQ_DIRECT_CONNECT(NRF5_IRQ_RADIO_IRQn, CONFIG_BT_CTLR_WORKER_PRIO,
 			   radio_nrf5_isr, 0);


### PR DESCRIPTION
Fix missing BT_CTLR_FILTER conditional compilations that
cause compile errors when device whitelisting feature is
disabled in builds.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>