### PR TITLE
Net: context cleanup

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -278,12 +278,8 @@ struct sockaddr_storage {
 struct net_addr {
 	sa_family_t family;
 	union {
-#if defined(CONFIG_NET_IPV6)
 		struct in6_addr in6_addr;
-#endif
-#if defined(CONFIG_NET_IPV4)
 		struct in_addr in_addr;
-#endif
 	};
 };
 

--- a/include/net/net_offload.h
+++ b/include/net/net_offload.h
@@ -27,6 +27,8 @@
 extern "C" {
 #endif
 
+#if defined(CONFIG_NET_OFFLOAD)
+
 /** For return parameters and return values of the elements in this
  * struct, see similarly named functions in net_context.h
  */
@@ -419,6 +421,93 @@ static inline int net_offload_put(struct net_if *iface,
 
 	return net_if_offload(iface)->put(context);
 }
+
+#else
+
+/** @cond INTERNAL_HIDDEN */
+
+static inline int net_offload_get(struct net_if *iface,
+				  sa_family_t family,
+				  enum net_sock_type type,
+				  enum net_ip_protocol ip_proto,
+				  struct net_context **context)
+{
+	return 0;
+}
+
+static inline int net_offload_bind(struct net_if *iface,
+				   struct net_context *context,
+				   const struct sockaddr *addr,
+				   socklen_t addrlen)
+{
+	return 0;
+}
+
+static inline int net_offload_listen(struct net_if *iface,
+				     struct net_context *context,
+				     int backlog)
+{
+	return 0;
+}
+
+static inline int net_offload_connect(struct net_if *iface,
+				      struct net_context *context,
+				      const struct sockaddr *addr,
+				      socklen_t addrlen,
+				      net_context_connect_cb_t cb,
+				      s32_t timeout,
+				      void *user_data)
+{
+	return 0;
+}
+
+static inline int net_offload_accept(struct net_if *iface,
+				     struct net_context *context,
+				     net_tcp_accept_cb_t cb,
+				     s32_t timeout,
+				     void *user_data)
+{
+	return 0;
+}
+
+static inline int net_offload_send(struct net_if *iface,
+				   struct net_pkt *pkt,
+				   net_context_send_cb_t cb,
+				   s32_t timeout,
+				   void *user_data)
+{
+	return 0;
+}
+
+static inline int net_offload_sendto(struct net_if *iface,
+				     struct net_pkt *pkt,
+				     const struct sockaddr *dst_addr,
+				     socklen_t addrlen,
+				     net_context_send_cb_t cb,
+				     s32_t timeout,
+				     void *user_data)
+{
+	return 0;
+}
+
+static inline int net_offload_recv(struct net_if *iface,
+				   struct net_context *context,
+				   net_context_recv_cb_t cb,
+				   s32_t timeout,
+				   void *user_data)
+{
+	return 0;
+}
+
+static inline int net_offload_put(struct net_if *iface,
+				  struct net_context *context)
+{
+	return 0;
+}
+
+/** @endcond */
+
+#endif /* CONFIG_NET_OFFLOAD */
 
 #ifdef __cplusplus
 }

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -71,7 +71,8 @@ static int check_used_port(enum net_ip_protocol ip_proto,
 			continue;
 		}
 
-		if (local_addr->sa_family == AF_INET6) {
+		if (IS_ENABLED(CONFIG_NET_IPV6) &&
+		    local_addr->sa_family == AF_INET6) {
 			if (net_ipv6_addr_cmp(
 				    net_sin6_ptr(&contexts[i].local)->
 							     sin6_addr,
@@ -79,7 +80,8 @@ static int check_used_port(enum net_ip_protocol ip_proto,
 				      local_addr)->sin6_addr)) {
 				return -EEXIST;
 			}
-		} else {
+		} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
+			   local_addr->sa_family == AF_INET) {
 			if (net_ipv4_addr_cmp(
 				    net_sin_ptr(&contexts[i].local)->
 							      sin_addr,
@@ -104,12 +106,14 @@ static u16_t find_available_port(struct net_context *context,
 			/* 0 - 1023 ports are reserved */
 			continue;
 		}
-	} while (check_used_port(
-				net_context_get_ip_proto(context),
-				htons(local_port), addr) == -EEXIST);
+	} while (check_used_port(net_context_get_ip_proto(context),
+				 htons(local_port), addr) == -EEXIST);
 
 	return htons(local_port);
 }
+#else
+#define check_used_port(...) 0
+#define find_available_port(...) 0
 #endif
 
 int net_context_get(sa_family_t family,
@@ -119,114 +123,103 @@ int net_context_get(sa_family_t family,
 {
 	int i, ret = -ENOENT;
 
-#if defined(CONFIG_NET_CONTEXT_CHECK)
+	if (IS_ENABLED(CONFIG_NET_CONTEXT_CHECK)) {
+		if (!IS_ENABLED(CONFIG_NET_IPV4) && family == AF_INET) {
+			NET_DBG("IPv4 disabled");
+			return -EPFNOSUPPORT;
+		}
 
-#if !defined(CONFIG_NET_IPV4)
-	if (family == AF_INET) {
-		NET_ASSERT_INFO(family != AF_INET, "IPv4 disabled");
-		return -EPFNOSUPPORT;
-	}
-#endif
+		if (!IS_ENABLED(CONFIG_NET_IPV6) && family == AF_INET6) {
+			NET_DBG("IPv6 disabled");
+			return -EPFNOSUPPORT;
+		}
 
-#if !defined(CONFIG_NET_IPV6)
-	if (family == AF_INET6) {
-		NET_ASSERT_INFO(family != AF_INET6, "IPv6 disabled");
-		return -EPFNOSUPPORT;
-	}
-#endif
+		if (!IS_ENABLED(CONFIG_NET_SOCKETS_CAN) && family == AF_CAN) {
+			NET_DBG("AF_CAN disabled");
+			return -EPFNOSUPPORT;
+		}
 
-	if (!IS_ENABLED(CONFIG_NET_SOCKETS_CAN) && family == AF_CAN) {
-		NET_ASSERT_INFO((family != AF_CAN), "AF_CAN disabled");
-		return -EPFNOSUPPORT;
-	}
-
-	if (type == SOCK_RAW) {
-		if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
-		    IS_ENABLED(CONFIG_NET_SOCKETS_CAN)) {
-			if (family != AF_PACKET && family != AF_CAN) {
-				return -EINVAL;
+		if (type == SOCK_RAW) {
+			if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
+			    IS_ENABLED(CONFIG_NET_SOCKETS_CAN)) {
+				if (family != AF_PACKET && family != AF_CAN) {
+					NET_DBG("Invalid family");
+					return -EINVAL;
+				}
+			} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
+				   !IS_ENABLED(CONFIG_NET_SOCKETS_CAN)) {
+				if (family != AF_PACKET) {
+					NET_DBG("Invalid family");
+					return -EINVAL;
+				}
+			} else if (!IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
+				   IS_ENABLED(CONFIG_NET_SOCKETS_CAN)) {
+				if (family != AF_CAN) {
+					NET_DBG("Invalid family");
+					return -EINVAL;
+				}
 			}
-		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
-			   !IS_ENABLED(CONFIG_NET_SOCKETS_CAN)) {
-			if (family != AF_PACKET) {
-				return -EINVAL;
-			}
-		} else if (!IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
-			   IS_ENABLED(CONFIG_NET_SOCKETS_CAN)) {
-			if (family != AF_CAN) {
-				return -EINVAL;
+		} else {
+			if (family == AF_PACKET || family == AF_CAN) {
+				NET_DBG("Invalid family");
+				return -EPROTOTYPE;
 			}
 		}
-	} else {
-		if (family == AF_PACKET || family == AF_CAN) {
+
+		if (!IS_ENABLED(CONFIG_NET_UDP)) {
+			if (type == SOCK_DGRAM) {
+				NET_DBG("Datagram context disabled");
+				return -EPROTOTYPE;
+			}
+
+			if (ip_proto == IPPROTO_UDP) {
+				NET_DBG("UDP disabled");
+				return -EPROTONOSUPPORT;
+			}
+		}
+
+		if (!IS_ENABLED(CONFIG_NET_TCP)) {
+			if (type == SOCK_STREAM) {
+				NET_DBG("Stream context disabled");
+				return -EPROTOTYPE;
+			}
+
+			if (ip_proto == IPPROTO_TCP) {
+				NET_DBG("TCP disabled");
+				return -EPROTONOSUPPORT;
+			}
+		}
+
+		if (family != AF_INET && family != AF_INET6 &&
+		    family != AF_PACKET && family != AF_CAN) {
+			NET_DBG("Unknown address family %d", family);
+			return -EAFNOSUPPORT;
+		}
+
+		if (type != SOCK_DGRAM && type != SOCK_STREAM &&
+		    type != SOCK_RAW) {
+			NET_DBG("Unknown context type");
 			return -EPROTOTYPE;
 		}
-	}
 
-#if !defined(CONFIG_NET_UDP)
-	if (type == SOCK_DGRAM) {
-		NET_ASSERT_INFO(type != SOCK_DGRAM,
-				"Datagram context disabled");
-		return -EPROTOTYPE;
-	}
+		if (type != SOCK_RAW && ip_proto != IPPROTO_UDP &&
+		    ip_proto != IPPROTO_TCP) {
+			NET_DBG("Unknown IP protocol %d", ip_proto);
+			return -EPROTONOSUPPORT;
+		}
 
-	if (ip_proto == IPPROTO_UDP) {
-		NET_ASSERT_INFO(ip_proto != IPPROTO_UDP, "UDP disabled");
-		return -EPROTONOSUPPORT;
-	}
-#endif
+		if ((type == SOCK_STREAM && ip_proto == IPPROTO_UDP) ||
+		    (type == SOCK_DGRAM && ip_proto == IPPROTO_TCP)) {
+			NET_DBG("Context type and protocol mismatch,"
+				" type %d proto %d", type, ip_proto);
+			return -EOPNOTSUPP;
+		}
 
-#if !defined(CONFIG_NET_TCP)
-	if (type == SOCK_STREAM) {
-		NET_ASSERT_INFO(type != SOCK_STREAM,
-				"Stream context disabled");
-		return -EPROTOTYPE;
+		if (!context) {
+			NET_DBG("Invalid context");
+			return -EINVAL;
+		}
 	}
-
-	if (ip_proto == IPPROTO_TCP) {
-		NET_ASSERT_INFO(ip_proto != IPPROTO_TCP, "TCP disabled");
-		return -EPROTONOSUPPORT;
-	}
-#endif
-
-	if (family != AF_INET && family != AF_INET6 && family != AF_PACKET &&
-	    family != AF_CAN) {
-		NET_ASSERT_INFO(family == AF_INET || family == AF_INET6 ||
-				family == AF_PACKET || family == AF_CAN,
-				"Unknown address family %d", family);
-		return -EAFNOSUPPORT;
-	}
-
-	if (type != SOCK_DGRAM && type != SOCK_STREAM && type != SOCK_RAW) {
-		NET_ASSERT_INFO(type == SOCK_DGRAM || type == SOCK_STREAM ||
-				type == SOCK_RAW,
-				"Unknown context type");
-		return -EPROTOTYPE;
-	}
-
-	if (type != SOCK_RAW && ip_proto != IPPROTO_UDP &&
-	    ip_proto != IPPROTO_TCP) {
-		NET_ASSERT_INFO(ip_proto == IPPROTO_UDP ||
-				ip_proto == IPPROTO_TCP,
-				"Unknown IP protocol %d", ip_proto);
-		return -EPROTONOSUPPORT;
-	}
-
-	if ((type == SOCK_STREAM && ip_proto == IPPROTO_UDP) ||
-	    (type == SOCK_DGRAM && ip_proto == IPPROTO_TCP)) {
-		NET_ASSERT_INFO(\
-			(type != SOCK_STREAM || ip_proto != IPPROTO_UDP) &&
-			(type != SOCK_DGRAM || ip_proto != IPPROTO_TCP),
-			"Context type and protocol mismatch, type %d proto %d",
-			type, ip_proto);
-		return -EOPNOTSUPP;
-	}
-
-	if (!context) {
-		NET_ASSERT_INFO(context, "Invalid context");
-		return -EINVAL;
-	}
-#endif /* CONFIG_NET_CONTEXT_CHECK */
 
 	k_sem_take(&contexts_lock, K_FOREVER);
 
@@ -249,14 +242,15 @@ int net_context_get(sa_family_t family,
 		net_context_set_type(&contexts[i], type);
 		net_context_set_ip_proto(&contexts[i], ip_proto);
 
-#if defined(CONFIG_NET_IPV4) || defined(CONFIG_NET_IPV6)
-		(void)memset(&contexts[i].remote, 0, sizeof(struct sockaddr));
-		(void)memset(&contexts[i].local, 0,
-			     sizeof(struct sockaddr_ptr));
-#endif
+		if (IS_ENABLED(CONFIG_NET_IPV6) ||
+		    IS_ENABLED(CONFIG_NET_IPV4)) {
+			(void)memset(&contexts[i].remote, 0,
+				     sizeof(struct sockaddr));
+			(void)memset(&contexts[i].local, 0,
+				     sizeof(struct sockaddr_ptr));
+		}
 
-#if defined(CONFIG_NET_IPV6)
-		if (family == AF_INET6) {
+		if (IS_ENABLED(CONFIG_NET_IPV6) && family == AF_INET6) {
 			struct sockaddr_in6 *addr6 = (struct sockaddr_in6
 						      *)&contexts[i].local;
 			addr6->sin6_port = find_available_port(&contexts[i],
@@ -267,10 +261,8 @@ int net_context_get(sa_family_t family,
 				break;
 			}
 		}
-#endif
 
-#if defined(CONFIG_NET_IPV4)
-		if (family == AF_INET) {
+		if (IS_ENABLED(CONFIG_NET_IPV4) && family == AF_INET) {
 			struct sockaddr_in *addr = (struct sockaddr_in
 						      *)&contexts[i].local;
 			addr->sin_port = find_available_port(&contexts[i],
@@ -281,7 +273,6 @@ int net_context_get(sa_family_t family,
 				break;
 			}
 		}
-#endif
 
 #if defined(CONFIG_NET_CONTEXT_SYNC_RECV)
 		k_sem_init(&contexts[i].recv_data_wait, 1, UINT_MAX);
@@ -298,11 +289,11 @@ int net_context_get(sa_family_t family,
 
 	k_sem_give(&contexts_lock);
 
-#if defined(CONFIG_NET_OFFLOAD)
 	/* FIXME - Figure out a way to get the correct network interface
 	 * as it is not known at this point yet.
 	 */
-	if (!ret && net_if_is_ip_offloaded(net_if_get_default())) {
+	if (!ret && IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+	    net_if_is_ip_offloaded(net_if_get_default())) {
 		ret = net_offload_get(net_if_get_default(),
 				      family,
 				      type,
@@ -315,7 +306,6 @@ int net_context_get(sa_family_t family,
 
 		return ret;
 	}
-#endif /* CONFIG_NET_OFFLOAD */
 
 	return ret;
 }
@@ -340,9 +330,10 @@ int net_context_unref(struct net_context *context)
 	net_tcp_unref(context);
 
 	if (context->conn_handler) {
-#if defined(CONFIG_NET_TCP) || defined(CONFIG_NET_UDP)
-		net_conn_unregister(context->conn_handler);
-#endif
+		if (IS_ENABLED(CONFIG_NET_TCP) || IS_ENABLED(CONFIG_NET_UDP)) {
+			net_conn_unregister(context->conn_handler);
+		}
+
 		context->conn_handler = NULL;
 	}
 
@@ -369,14 +360,12 @@ int net_context_put(struct net_context *context)
 
 	k_mutex_lock(&context->lock, K_FOREVER);
 
-#if defined(CONFIG_NET_OFFLOAD)
-	if (net_if_is_ip_offloaded(net_context_get_iface(context))) {
+	if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+	    net_if_is_ip_offloaded(net_context_get_iface(context))) {
 		context->flags &= ~NET_CONTEXT_IN_USE;
-		ret = net_offload_put(
-			net_context_get_iface(context), context);
+		ret = net_offload_put(net_context_get_iface(context), context);
 		goto unlock;
 	}
-#endif /* CONFIG_NET_OFFLOAD */
 
 	context->connect_cb = NULL;
 	context->recv_cb = NULL;
@@ -403,8 +392,7 @@ static int bind_default(struct net_context *context)
 {
 	sa_family_t family = net_context_get_family(context);
 
-#if defined(CONFIG_NET_IPV6)
-	if (family == AF_INET6) {
+	if (IS_ENABLED(CONFIG_NET_IPV6) && family == AF_INET6) {
 		struct sockaddr_in6 addr6;
 
 		if (net_sin6_ptr(&context->local)->sin6_addr) {
@@ -421,10 +409,8 @@ static int bind_default(struct net_context *context)
 		return net_context_bind(context, (struct sockaddr *)&addr6,
 					sizeof(addr6));
 	}
-#endif
 
-#if defined(CONFIG_NET_IPV4)
-	if (family == AF_INET) {
+	if (IS_ENABLED(CONFIG_NET_IPV4) && family == AF_INET) {
 		struct sockaddr_in addr4;
 
 		if (net_sin_ptr(&context->local)->sin_addr) {
@@ -440,7 +426,6 @@ static int bind_default(struct net_context *context)
 		return net_context_bind(context, (struct sockaddr *)&addr4,
 					sizeof(addr4));
 	}
-#endif
 
 	if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) && family == AF_PACKET) {
 		struct sockaddr_ll ll_addr;
@@ -500,8 +485,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 		return -EISCONN;
 	}
 
-#if defined(CONFIG_NET_IPV6)
-	if (addr->sa_family == AF_INET6) {
+	if (IS_ENABLED(CONFIG_NET_IPV6) && addr->sa_family == AF_INET6) {
 		struct net_if *iface = NULL;
 		struct in6_addr *ptr;
 		struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)addr;
@@ -547,8 +531,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			return -EADDRNOTAVAIL;
 		}
 
-#if defined(CONFIG_NET_OFFLOAD)
-		if (net_if_is_ip_offloaded(iface)) {
+		if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+		    net_if_is_ip_offloaded(iface)) {
 			net_context_set_iface(context, iface);
 
 			return net_offload_bind(iface,
@@ -556,7 +540,6 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addr,
 						addrlen);
 		}
-#endif /* CONFIG_NET_OFFLOAD */
 
 		net_context_set_iface(context, iface);
 
@@ -587,10 +570,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 
 		return 0;
 	}
-#endif
 
-#if defined(CONFIG_NET_IPV4)
-	if (addr->sa_family == AF_INET) {
+	if (IS_ENABLED(CONFIG_NET_IPV4) && addr->sa_family == AF_INET) {
 		struct sockaddr_in *addr4 = (struct sockaddr_in *)addr;
 		struct net_if *iface = NULL;
 		struct net_if_addr *ifaddr;
@@ -635,8 +616,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			return -EADDRNOTAVAIL;
 		}
 
-#if defined(CONFIG_NET_OFFLOAD)
-		if (net_if_is_ip_offloaded(iface)) {
+		if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+		    net_if_is_ip_offloaded(iface)) {
 			net_context_set_iface(context, iface);
 
 			return net_offload_bind(iface,
@@ -644,7 +625,6 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addr,
 						addrlen);
 		}
-#endif /* CONFIG_NET_OFFLOAD */
 
 		k_mutex_lock(&context->lock, K_FOREVER);
 
@@ -682,7 +662,6 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 
 		return ret;
 	}
-#endif
 
 	if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
 	    addr->sa_family == AF_PACKET) {
@@ -704,8 +683,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			return -EADDRNOTAVAIL;
 		}
 
-#if defined(CONFIG_NET_OFFLOAD)
-		if (net_if_is_ip_offloaded(iface)) {
+		if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+		    net_if_is_ip_offloaded(iface)) {
 			net_context_set_iface(context, iface);
 
 			return net_offload_bind(iface,
@@ -713,7 +692,6 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addr,
 						addrlen);
 		}
-#endif /* CONFIG_NET_OFFLOAD */
 
 		net_context_set_iface(context, iface);
 
@@ -753,8 +731,8 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			return -EADDRNOTAVAIL;
 		}
 
-#if defined(CONFIG_NET_OFFLOAD)
-		if (net_if_is_ip_offloaded(iface)) {
+		if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+		    net_if_is_ip_offloaded(iface)) {
 			net_context_set_iface(context, iface);
 
 			return net_offload_bind(iface,
@@ -762,7 +740,6 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 						addr,
 						addrlen);
 		}
-#endif /* CONFIG_NET_OFFLOAD */
 
 		net_context_set_iface(context, iface);
 		net_context_set_family(context, AF_CAN);
@@ -808,12 +785,11 @@ int net_context_listen(struct net_context *context, int backlog)
 		return -EBADF;
 	}
 
-#if defined(CONFIG_NET_OFFLOAD)
-	if (net_if_is_ip_offloaded(net_context_get_iface(context))) {
-		return net_offload_listen(
-			net_context_get_iface(context), context, backlog);
+	if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+	    net_if_is_ip_offloaded(net_context_get_iface(context))) {
+		return net_offload_listen(net_context_get_iface(context),
+					  context, backlog);
 	}
-#endif /* CONFIG_NET_OFFLOAD */
 
 	k_mutex_lock(&context->lock, K_FOREVER);
 
@@ -889,9 +865,7 @@ int net_context_connect(struct net_context *context,
 			void *user_data)
 {
 	struct sockaddr *laddr = NULL;
-#if defined(CONFIG_NET_IPV4) || defined(CONFIG_NET_IPV6)
-	struct sockaddr local_addr;
-#endif
+	struct sockaddr local_addr __unused;
 	u16_t lport, rport;
 	int ret;
 
@@ -925,8 +899,8 @@ int net_context_connect(struct net_context *context,
 		goto unlock;
 	}
 
-#if defined(CONFIG_NET_IPV6)
-	if (net_context_get_family(context) == AF_INET6) {
+	if (IS_ENABLED(CONFIG_NET_IPV6) &&
+	    net_context_get_family(context) == AF_INET6) {
 		struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)
 							&context->remote;
 
@@ -977,11 +951,8 @@ int net_context_connect(struct net_context *context,
 
 			laddr = &local_addr;
 		}
-	} else
-#endif /* CONFIG_NET_IPV6 */
-
-#if defined(CONFIG_NET_IPV4)
-	if (net_context_get_family(context) == AF_INET) {
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
+		   net_context_get_family(context) == AF_INET) {
 		struct sockaddr_in *addr4 = (struct sockaddr_in *)
 							&context->remote;
 
@@ -1024,16 +995,13 @@ int net_context_connect(struct net_context *context,
 
 			laddr = &local_addr;
 		}
-	} else
-#endif /* CONFIG_NET_IPV4 */
-
-	{
+	} else {
 		ret = -EINVAL; /* Not IPv4 or IPv6 */
 		goto unlock;
 	}
 
-#if defined(CONFIG_NET_OFFLOAD)
-	if (net_if_is_ip_offloaded(net_context_get_iface(context))) {
+	if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+	    net_if_is_ip_offloaded(net_context_get_iface(context))) {
 		ret = net_offload_connect(
 			net_context_get_iface(context),
 			context,
@@ -1044,28 +1012,20 @@ int net_context_connect(struct net_context *context,
 			user_data);
 		goto unlock;
 	}
-#endif /* CONFIG_NET_OFFLOAD */
 
-	switch (net_context_get_type(context)) {
-#if defined(CONFIG_NET_UDP)
-	case SOCK_DGRAM:
+	if (IS_ENABLED(CONFIG_NET_UDP) &&
+	    net_context_get_type(context) == SOCK_DGRAM) {
 		if (cb) {
 			cb(context, 0, user_data);
 		}
 
 		ret = 0;
-		goto unlock;
-
-#endif /* CONFIG_NET_UDP */
-
-	case SOCK_STREAM:
+	} else if (IS_ENABLED(CONFIG_NET_TCP) &&
+		   net_context_get_type(context) == SOCK_STREAM) {
 		ret = net_tcp_connect(context, addr, laddr, rport, lport,
 				      timeout, cb, user_data);
-		goto unlock;
-
-	default:
+	} else {
 		ret = -ENOTSUP;
-		goto unlock;
 	}
 
 unlock:
@@ -1089,8 +1049,8 @@ int net_context_accept(struct net_context *context,
 
 	k_mutex_lock(&context->lock, K_FOREVER);
 
-#if defined(CONFIG_NET_OFFLOAD)
-	if (net_if_is_ip_offloaded(net_context_get_iface(context))) {
+	if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+	    net_if_is_ip_offloaded(net_context_get_iface(context))) {
 		ret = net_offload_accept(
 			net_context_get_iface(context),
 			context,
@@ -1099,7 +1059,6 @@ int net_context_accept(struct net_context *context,
 			user_data);
 		goto unlock;
 	}
-#endif /* CONFIG_NET_OFFLOAD */
 
 	if ((net_context_get_state(context) != NET_CONTEXT_LISTENING) &&
 	    (net_context_get_type(context) != SOCK_STREAM)) {
@@ -1608,8 +1567,8 @@ static int recv_udp(struct net_context *context,
 		return ret;
 	}
 
-#if defined(CONFIG_NET_IPV6)
-	if (net_context_get_family(context) == AF_INET6) {
+	if (IS_ENABLED(CONFIG_NET_IPV6) &&
+	    net_context_get_family(context) == AF_INET6) {
 		if (net_sin6_ptr(&context->local)->sin6_addr) {
 			net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
 				     net_sin6_ptr(&context->local)->sin6_addr);
@@ -1620,11 +1579,8 @@ static int recv_udp(struct net_context *context,
 		net_sin6(&local_addr)->sin6_port =
 			net_sin6((struct sockaddr *)&context->local)->sin6_port;
 		lport = net_sin6((struct sockaddr *)&context->local)->sin6_port;
-	}
-#endif /* CONFIG_NET_IPV6 */
-
-#if defined(CONFIG_NET_IPV4)
-	if (net_context_get_family(context) == AF_INET) {
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
+		   net_context_get_family(context) == AF_INET) {
 		if (net_sin_ptr(&context->local)->sin_addr) {
 			net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
 				      net_sin_ptr(&context->local)->sin_addr);
@@ -1634,7 +1590,6 @@ static int recv_udp(struct net_context *context,
 
 		lport = net_sin((struct sockaddr *)&context->local)->sin_port;
 	}
-#endif /* CONFIG_NET_IPV4 */
 
 	context->recv_cb = cb;
 
@@ -1651,6 +1606,8 @@ static int recv_udp(struct net_context *context,
 
 	return ret;
 }
+#else
+#define recv_udp(...) 0
 #endif /* CONFIG_NET_UDP */
 
 static enum net_verdict net_context_raw_packet_received(
@@ -1730,41 +1687,30 @@ int net_context_recv(struct net_context *context,
 
 	k_mutex_lock(&context->lock, K_FOREVER);
 
-#if defined(CONFIG_NET_OFFLOAD)
-	if (net_if_is_ip_offloaded(net_context_get_iface(context))) {
+	if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+	    net_if_is_ip_offloaded(net_context_get_iface(context))) {
 		ret = net_offload_recv(
 			net_context_get_iface(context),
 			context, cb, timeout, user_data);
 		goto unlock;
 	}
-#endif /* CONFIG_NET_OFFLOAD */
 
-	switch (net_context_get_ip_proto(context)) {
-#if defined(CONFIG_NET_UDP)
-	case IPPROTO_UDP:
+	if (IS_ENABLED(CONFIG_NET_UDP) &&
+	    net_context_get_ip_proto(context) == IPPROTO_UDP) {
 		ret = recv_udp(context, cb, timeout, user_data);
-		break;
-#endif /* CONFIG_NET_UDP */
-
-	case IPPROTO_TCP:
+	} else if (IS_ENABLED(CONFIG_NET_TCP) &&
+		   net_context_get_ip_proto(context) == IPPROTO_TCP) {
 		ret = net_tcp_recv(context, cb, user_data);
-		break;
-
-	default:
+	} else {
 		if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
 		    net_context_get_family(context) == AF_PACKET) {
 			ret = recv_raw(context, cb, timeout, user_data);
-			break;
-		}
-
-		if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) &&
-		    net_context_get_family(context) == AF_CAN) {
+		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) &&
+			   net_context_get_family(context) == AF_CAN) {
 			ret = recv_raw(context, cb, timeout, user_data);
-			break;
+		} else {
+			ret = -EPROTOTYPE;
 		}
-
-		ret = -EPROTOTYPE;
-		break;
 	}
 
 	if (ret < 0) {


### PR DESCRIPTION
I am not going to manipulate net_context's array into a sys_list. It goes through the array only at one place: to get a free net_context. It's enough as it is, and avoids to add sys_node_t attribute into struct net_context.