### PR TITLE
testsuite: fix memory access

### DIFF
--- a/subsys/testsuite/include/tc_util.h
+++ b/subsys/testsuite/include/tc_util.h
@@ -58,13 +58,19 @@
 #define TC_FAIL 1
 #define TC_SKIP 2
 
-static __unused const char *TC_RESULT_STR[] = {
-	[TC_PASS] = "PASS",
-	[TC_FAIL] = "FAIL",
-	[TC_SKIP] = "SKIP",
-};
-
-#define TC_RESULT_TO_STR(result) TC_RESULT_STR[result]
+static inline const char *TC_RESULT_TO_STR(int result)
+{
+	switch (result) {
+	case TC_PASS:
+		return "PASS";
+	case TC_FAIL:
+		return "FAIL";
+	case TC_SKIP:
+		return "SKIP";
+	default:
+		return "?";
+	}
+}
 
 #define TC_ERROR(fmt, ...)                               \
 	do {                                                 \


### PR DESCRIPTION
Depending on optimization level, the TC_RESULT_STR[]
array could actually be placed in memory instead of
being expanded at compile time, resulting in memory
access errors from user mode.

Just replace TC_RESULT_TO_STR() with an inline function
containing a switch statement instead.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>