### PR TITLE
tests: pipe: fix error with optimization disabled

### DIFF
--- a/tests/kernel/pipe/pipe/src/test_pipe.c
+++ b/tests/kernel/pipe/pipe/src/test_pipe.c
@@ -51,7 +51,7 @@ struct pipe_sequence {
 	int return_value;
 };
 
-static struct pipe_sequence single_elements[] = {
+static const struct pipe_sequence single_elements[] = {
 	{ 0, ALL_BYTES, 0, 0 },
 	{ 1, ALL_BYTES, 1, RETURN_SUCCESS },
 	{ PIPE_SIZE - 1, ALL_BYTES, PIPE_SIZE - 1, RETURN_SUCCESS },
@@ -71,7 +71,7 @@ static struct pipe_sequence single_elements[] = {
 	{ PIPE_SIZE + 1, NO_CONSTRAINT, PIPE_SIZE, RETURN_SUCCESS }
 };
 
-static struct pipe_sequence multiple_elements[] = {
+static const struct pipe_sequence multiple_elements[] = {
 	{ PIPE_SIZE / 3, ALL_BYTES, PIPE_SIZE / 3, RETURN_SUCCESS, },
 	{ PIPE_SIZE / 3, ALL_BYTES, PIPE_SIZE / 3, RETURN_SUCCESS, },
 	{ PIPE_SIZE / 3, ALL_BYTES, PIPE_SIZE / 3, RETURN_SUCCESS, },
@@ -90,7 +90,7 @@ static struct pipe_sequence multiple_elements[] = {
 	{ PIPE_SIZE / 3, NO_CONSTRAINT, 0, RETURN_SUCCESS }
 };
 
-static struct pipe_sequence wait_elements[] = {
+static const struct pipe_sequence wait_elements[] = {
 	{            1, ALL_BYTES,             1, RETURN_SUCCESS },
 	{ PIPE_SIZE - 1, ALL_BYTES, PIPE_SIZE - 1, RETURN_SUCCESS },
 	{    PIPE_SIZE, ALL_BYTES,     PIPE_SIZE, RETURN_SUCCESS },
@@ -101,7 +101,7 @@ static struct pipe_sequence wait_elements[] = {
 	{ PIPE_SIZE + 1, ATLEAST_1, PIPE_SIZE + 1, RETURN_SUCCESS }
 };
 
-static struct pipe_sequence timeout_elements[] = {
+static const struct pipe_sequence timeout_elements[] = {
 	{            0, ALL_BYTES, 0, 0 },
 	{            1, ALL_BYTES, 0, -EAGAIN },
 	{ PIPE_SIZE - 1, ALL_BYTES, 0, -EAGAIN },


### PR DESCRIPTION
The various struct pipe_sequence were not located in memory
accessible to user mode. With optimization turned on, they
weren't in memory at all, but with code coverage enabled
the arrays were actually being read, resulting in memory
access failures from user mode.

Fix them by placing in ROM, they never get modified.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>