### PR TITLE
boards: qemu_x86: increase "flash" size

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -4,7 +4,7 @@
 
 #include <mem.h>
 
-#define DT_FLASH_SIZE		DT_SIZE_K(1024)
+#define DT_FLASH_SIZE		DT_SIZE_K(2048)
 
 #if XIP
 	#define DT_SRAM_SIZE		DT_SIZE_K(4096)


### PR DESCRIPTION
Fixes a sample build error when optimization is disabled.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>