### PR TITLE
west build enhancements

### DIFF
--- a/doc/guides/west/build-flash-debug.rst
+++ b/doc/guides/west/build-flash-debug.rst
@@ -27,16 +27,31 @@ directly delegate to West.
 Building: ``west build``
 ************************
 
-.. tip:: Run ``west build -h`` for additional help.
+.. tip:: Run ``west build -h`` for a quick overview.
 
 The ``build`` command helps you build Zephyr applications from source. You can
 use :ref:`west config <west-config-cmd>` to configure its behavior.
 
+This command attempts to "do what you mean" when run from a Zephyr application
+source or build directory:
+
+- When you run ``west build`` in an existing build directory, the board, source
+  directory, etc. are obtained from the CMake cache, and that build directory
+  is re-compiled.
+
+- The same is true if a Zephyr build directory named :file:`build` exists in
+  your current working directory.
+
+- Otherwise, the source directory defaults to the current working directory, so
+  running ``west build`` from a Zephyr application's source directory compiles
+  it.
+
 Basics
 ======
 
-The easiest way to use it is to go to an application's root directory (i.e. the
-folder containing its :file:`CMakeLists.txt`) and then run::
+The easiest way to use ``west build`` is to go to an application's root
+directory (i.e. the folder containing the application's :file:`CMakeLists.txt`)
+and then run::
 
   west build -b <BOARD>
 
@@ -52,12 +67,13 @@ exactly the same name you would supply to CMake if you were to invoke it with:
 A build directory named :file:`build` will be created, and the application will
 be compiled there after ``west build`` runs CMake to create a build system in
 that directory. If you run ``west build`` with an existing build directory, the
-application is incrementally re-compiled without re-running CMake.
+application is incrementally re-compiled without re-running CMake (you can
+force CMake to run again with ``--cmake``).
 
-You don't need to give ``-b`` if you've already got an existing build
-directory; ``west build`` can figure out the board from the CMake cache. For
-new builds, the :envvar:`BOARD` environment variable and ``build.board``
-configuration option can also be used to set the board.
+You don't need to use the ``--board`` option if you've already got an existing
+build directory; ``west build`` can figure out the board from the CMake cache.
+For new builds, the ``--board`` option, :envvar:`BOARD` environment variable,
+or ``build.board`` configuration option are checked (in that order).
 
 To configure ``west build`` to build for the ``reel_board`` by default::
 
@@ -108,6 +124,7 @@ To let west decide for you if a pristine build is needed, use ``-p auto``::
 
    You can run ``west config build.pristine auto`` to make this setting
    permanent.
+
 
 .. _west-building-generator:
 

--- a/doc/guides/west/build-flash-debug.rst
+++ b/doc/guides/west/build-flash-debug.rst
@@ -61,7 +61,7 @@ exactly the same name you would supply to CMake if you were to invoke it with:
 
 .. tip::
 
-   You can use the :ref:```west boards`` <west-boards>` command to list all
+   You can use the :ref:`west boards <west-boards>` command to list all
    supported boards.
 
 A build directory named :file:`build` will be created, and the application will

--- a/doc/guides/west/build-flash-debug.rst
+++ b/doc/guides/west/build-flash-debug.rst
@@ -109,6 +109,8 @@ To let west decide for you if a pristine build is needed, use ``-p auto``::
    You can run ``west config build.pristine auto`` to make this setting
    permanent.
 
+.. _west-building-generator:
+
 To add additional arguments to the CMake invocation performed by ``west
 build``, pass them after a ``--`` at the end of the command line.
 
@@ -160,6 +162,10 @@ You can :ref:`configure <west-config-cmd>` ``west build`` using these options.
    * - ``build.board_warn``
      - Boolean, default ``true``. If ``false``, disables warnings when
        ``west build`` can't figure out the target board.
+   * - ``build.generator``
+     - String, default ``Ninja``. The `CMake Generator`_ to use to create a
+       build system. (To set a generator for a single build, see the
+       :ref:`above example <west-building-generator>`)
    * - ``build.pristine``
      - String. Controls the way in which ``west build`` may clean the build
        folder before building. Can take the following values:
@@ -443,3 +449,6 @@ commands do it).
 
 .. _CMAKE_VERBOSE_MAKEFILE:
    https://cmake.org/cmake/help/latest/variable/CMAKE_VERBOSE_MAKEFILE.html
+
+.. _CMake Generator:
+   https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html

--- a/doc/guides/west/build-flash-debug.rst
+++ b/doc/guides/west/build-flash-debug.rst
@@ -29,85 +29,150 @@ Building: ``west build``
 
 .. tip:: Run ``west build -h`` for additional help.
 
-The ``build`` command allows you to build any source tree from any directory
-in your file system, placing the build results in a folder of your choice.
+The ``build`` command helps you build Zephyr applications from source. You can
+use :ref:`west config <west-config-cmd>` to configure its behavior.
 
-In its simplest form, the command can be run by navigating to the root folder
-(i.e. the folder containing a :file:`CMakeLists.txt` file) of the Zephyr
-application of your choice and running::
+Basics
+======
+
+The easiest way to use it is to go to an application's root directory (i.e. the
+folder containing its :file:`CMakeLists.txt`) and then run::
 
   west build -b <BOARD>
 
 Where ``<BOARD>`` is the name of the board you want to build for. This is
 exactly the same name you would supply to CMake if you were to invoke it with:
 ``cmake -DBOARD=<BOARD>``.
-A build folder named :file:`build` (default name) will be created and the
-build output will be placed in it.
 
-To specify the build directory, use ``--build-dir`` (or ``-d``)::
+.. tip::
+
+   You can use the :ref:```west boards`` <west-boards>` command to list all
+   supported boards.
+
+A build directory named :file:`build` will be created, and the application will
+be compiled there after ``west build`` runs CMake to create a build system in
+that directory. If you run ``west build`` with an existing build directory, the
+application is incrementally re-compiled without re-running CMake.
+
+You don't need to give ``-b`` if you've already got an existing build
+directory; ``west build`` can figure out the board from the CMake cache. For
+new builds, the :envvar:`BOARD` environment variable and ``build.board``
+configuration option can also be used to set the board.
+
+To configure ``west build`` to build for the ``reel_board`` by default::
+
+  west config build.board reel_board
+
+(You can use any other board supported by Zephyr here; it doesn't have to be
+``reel_board``.)
+
+To use another build directory, use ``--build-dir`` (or ``-d``)::
 
   west build -b <BOARD> --build-dir path/to/build/directory
 
-Since the build directory defaults to :file:`build`, if you do not specify
-a build directory but a folder named :file:`build` is present, that will be used,
-allowing you to incrementally build from outside the :file:`build` folder with
-no additional parameters.
-
-.. note::
-  The ``-b <BOARD>`` parameter is only required when there is no CMake cache
-  present at all, usually when you are building from scratch or creating a
-  brand new build directory. After that you can rebuild (even with additional
-  parameters) without having to specify the board again. If you're unsure
-  whether ``-b`` is required, just try leaving it out. West will print an
-  error if the option is required and was not given.
-
-.. tip::
-  You can use the :ref:`west boards <west-boards>` command to list all
-  supported boards.
-
-Specify the source directory path as the first positional argument::
+To specify the application source directory explicitly, give its path as a
+positional argument::
 
   west build -b <BOARD> path/to/source/directory
 
-Additionally you can specify the build system target using the ``--target``
-(or ``-t``) option. For example, to run the ``clean`` target::
+To specify the build system target to run, use ``--target`` (or ``-t``).
 
-  west build -t clean
+For example, on host platforms with QEMU, you can use the ``run`` target to
+build and run the :ref:`hello_world` sample for the emulated :ref:`qemu_x86
+<qemu_x86>` board in one command::
 
-You can list all targets with ``ninja help`` (or ``west build -t help``) inside
-the build folder.
+  west build -b qemu_x86 -t run samples/hello_world
 
-A clean build can be triggered by using the ``--pristine`` (or ``-p``) option.
-This is particularly handy if you want to switch source dirs or boards without
-using a different build dir::
+As another example, to use ``-t`` to list all build system targets::
+
+  west build -t help
+
+As a final example, to use ``-t`` to run the ``pristine`` target, which deletes
+all the files in the build directory::
+
+  west build -t pristine
+
+To have ``west build`` run the ``pristine`` target before re-running CMake to
+generate a build system, use the ``--pristine`` (or ``-p``) option. For
+example, to switch board and application (which requires a pristine build
+directory) in one command::
 
   west build -b qemu_x86 samples/philosophers
   west build -p -b reel_board samples/hello_world
 
-If you are unsure about whether the command-line parameters you supply to
-``west build`` require a clean build you can let west decide for you by using
-the ``auto`` setting in the ``--pristine`` option::
+To let west decide for you if a pristine build is needed, use ``-p auto``::
 
   west build -p auto -b reel_board samples/hello_world
 
-Finally, you can add additional arguments to the CMake invocation performed by
-``west build`` by supplying additional parameters (after a ``--``) to the
-command. For example, to use the Unix Makefiles CMake generator instead of
-Ninja (which ``west build`` uses by default), run::
+.. tip::
 
-  west build -b reel_board samples/hello_world -- -G'Unix Makefiles'
+   You can run ``west config build.pristine auto`` to make this setting
+   permanent.
 
-As another example, and assuming you have already built a sample, the following
-command adds the ``file.conf`` Kconfig fragment to the files which are merged
-into your final build configuration::
+To add additional arguments to the CMake invocation performed by ``west
+build``, pass them after a ``--`` at the end of the command line.
+
+For example, to use the Unix Makefiles CMake generator instead of Ninja (which
+``west build`` uses by default), run::
+
+  west build -b reel_board -- -G'Unix Makefiles'
+
+.. note::
+
+   Passing additional CMake arguments like this forces ``west build`` to re-run
+   CMake, even if a build system has already been generated.
+
+As another example, to use Unix Makefiles and enable the
+`CMAKE_VERBOSE_MAKEFILE`_ option::
+
+  west build -b reel_board -- -G'Unix Makefiles' -DCMAKE_VERBOSE_MAKEFILE=ON
+
+Notice how the ``--`` only appears once, even though multiple CMake arguments
+are given. All command-line arguments to ``west build`` after a ``--`` are
+passed to CMake.
+
+As a final example, to merge the :file:`file.conf` Kconfig fragment into your
+build's :file:`.config`::
 
   west build -- -DOVERLAY_CONFIG=file.conf
 
-Passing additional CMake arguments like this forces ``west build`` to re-run
-CMake, even if a build system has already been generated. You can also force
-a CMake re-run using the ``-c`` (or ``--cmake``) option::
+To force a CMake re-run, use the ``--cmake`` (or ``--c``) option::
 
   west build -c
+
+Configuration Options
+=====================
+
+You can :ref:`configure <west-config-cmd>` ``west build`` using these options.
+
+.. NOTE: docs authors: keep this table sorted alphabetically
+
+.. list-table::
+   :widths: 10 30
+   :header-rows: 1
+
+   * - Option
+     - Description
+   * - ``build.board``
+     - String. If given, this the board used by :ref:`west build
+       <west-building>` when ``--board`` is not given and :envvar:`BOARD`
+       is unset in the environment.
+   * - ``build.board_warn``
+     - Boolean, default ``true``. If ``false``, disables warnings when
+       ``west build`` can't figure out the target board.
+   * - ``build.pristine``
+     - String. Controls the way in which ``west build`` may clean the build
+       folder before building. Can take the following values:
+
+         - ``never`` (default): Never automatically make the build folder
+           pristine.
+         - ``auto``:  ``west build`` will automatically make the build folder
+           pristine before building, if a build system is present and the build
+           would fail otherwise (e.g. the user has specified a different board
+           or application from the one previously used to make the build
+           directory).
+         - ``always``: Always make the build folder pristine before building, if
+           a build system is present.
 
 .. _west-flashing:
 
@@ -376,5 +441,5 @@ commands do it).
 .. _cmake(1):
    https://cmake.org/cmake/help/latest/manual/cmake.1.html
 
-.. _namespace package:
-   https://www.python.org/dev/peps/pep-0420/
+.. _CMAKE_VERBOSE_MAKEFILE:
+   https://cmake.org/cmake/help/latest/variable/CMAKE_VERBOSE_MAKEFILE.html

--- a/doc/guides/west/config.rst
+++ b/doc/guides/west/config.rst
@@ -118,8 +118,9 @@ To undo the above change:
 Built-in Configuration Options
 ------------------------------
 
-The following table documents configuration options supported by west's built-in
-commands.
+The following table documents configuration options supported by west's
+built-in commands. Configuration options supported by Zephyr's extension
+commands are documented in the pages for those commands.
 
 .. NOTE: docs authors: keep this table sorted by section, then option.
 
@@ -150,38 +151,3 @@ commands.
        environment overrides the value of the ``zephyr.base`` configuration
        option. If set to ``"configfile"``, the configuration option wins
        instead.
-
-Zephyr Extension Commands Configuration Options
------------------------------------------------
-
-The following table documents configuration options supported by zephyr's
-extension commands (found in :file:`scripts/west_commands`).
-
-.. NOTE: docs authors: keep this table sorted by section, then option.
-
-.. list-table::
-   :widths: 10 30
-   :header-rows: 1
-
-   * - Option
-     - Description
-   * - ``build.board``
-     - String. If given, this the board used by :ref:`west build
-       <west-building>` when ``--board`` is not given and :envvar:`BOARD`
-       is unset in the environment.
-   * - ``build.board_warn``
-     - Boolean, default ``true``. If ``false``, disables warnings when
-       ``west build`` can't figure out the target board.
-   * - ``build.pristine``
-     - String. Controls the way in which ``west build`` may clean the build
-       folder before building. Can take the following values:
-
-         - ``never`` (default): Never automatically make the build folder
-           pristine.
-         - ``auto``:  ``west build`` will automatically make the build folder
-           pristine before building, if a build system is present and the build
-           would fail otherwise (e.g. the user has specified a different board
-           or application from the one previously used to make the build
-           directory).
-         - ``always``: Always make the build folder pristine before building, if
-           a build system is present.

--- a/doc/guides/west/config.rst
+++ b/doc/guides/west/config.rst
@@ -156,6 +156,7 @@ Zephyr Extension Commands Configuration Options
 
 The following table documents configuration options supported by zephyr's
 extension commands (found in :file:`scripts/west_commands`).
+
 .. NOTE: docs authors: keep this table sorted by section, then option.
 
 .. list-table::
@@ -164,6 +165,13 @@ extension commands (found in :file:`scripts/west_commands`).
 
    * - Option
      - Description
+   * - ``build.board``
+     - String. If given, this the board used by :ref:`west build
+       <west-building>` when ``--board`` is not given and :envvar:`BOARD`
+       is unset in the environment.
+   * - ``build.board_warn``
+     - Boolean, default ``true``. If ``false``, disables warnings when
+       ``west build`` can't figure out the target board.
    * - ``build.pristine``
      - String. Controls the way in which ``west build`` may clean the build
        folder before building. Can take the following values:

--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -23,7 +23,7 @@ class Boards(WestCommand):
             accepts_unknown_args=False)
 
     def do_add_parser(self, parser_adder):
-        default_fmt = '{name} ({arch})'
+        default_fmt = '{name}'
         parser = parser_adder.add_parser(
             self.name,
             help=self.help,
@@ -75,7 +75,8 @@ class Boards(WestCommand):
             match = board_re.match(line)
             if match:
                 if not arch:
-                    log.die('Invalid board output from CMake: {}'.format(lines))
+                    log.die('Invalid board output from CMake: {}'.
+                            format(lines))
                 board = match.group(1)
                 boards[arch].append(board)
 

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -54,6 +54,12 @@ positional arguments:
   cmake_opt             Extra options to pass to CMake; implies -c
 '''
 
+def config_get(option, fallback):
+    return config.get('build', option, fallback=fallback)
+
+def config_getboolean(option, fallback):
+    return config.getboolean('build', option, fallback=fallback)
+
 class AlwaysIfMissing(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
@@ -149,7 +155,7 @@ class Build(Forceable):
             pristine = args.pristine
         else:
             # Load the pristine={auto, always, never} configuration value
-            pristine = config.get('build', 'pristine', fallback='never')
+            pristine = config_get('pristine', 'never')
             if pristine not in ['auto', 'always', 'never']:
                 log.wrn(
                     'treating unknown build.pristine value "{}" as "never"'.

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -18,7 +18,7 @@ _ARG_SEPARATOR = '--'
 BUILD_USAGE = '''\
 west build [-h] [-b BOARD] [-d BUILD_DIR]
            [-t TARGET] [-p {auto, always, never}] [-c] [--cmake-only]
-           [-f] [source_dir] -- [cmake_opt [cmake_opt ...]]
+           [-n] [-f] [source_dir] -- [cmake_opt [cmake_opt ...]]
 '''
 
 BUILD_DESCRIPTION = '''\
@@ -139,6 +139,10 @@ class Build(Forceable):
                             help='Force CMake to run')
         parser.add_argument('--cmake-only', action='store_true',
                             help="Just run CMake; don't build. Implies -c.")
+        parser.add_argument('-n', '--just-print', '--dry-run', '--recon',
+                            dest='dry_run', action='store_true',
+                            help='''Just print the build commands which would
+                            have run, without actually running them.''')
         self.add_force_arg(parser)
         return parser
 
@@ -409,7 +413,7 @@ class Build(Forceable):
                                                      DEFAULT_CMAKE_GENERATOR))]
         if cmake_opts:
             final_cmake_args.extend(cmake_opts)
-        run_cmake(final_cmake_args)
+        run_cmake(final_cmake_args, dry_run=self.args.dry_run)
 
     def _run_pristine(self):
         log.inf('Making build dir {} pristine'.format(self.build_dir))
@@ -424,8 +428,9 @@ class Build(Forceable):
                     'Zephyr build system')
 
         cmake_args = ['-P', '{}/cmake/pristine.cmake'.format(zb)]
-        run_cmake(cmake_args, cwd=self.build_dir)
+        run_cmake(cmake_args, cwd=self.build_dir, dry_run=self.args.dry_run)
 
     def _run_build(self, target):
         extra_args = ['--target', target] if target else []
-        run_build(self.build_dir, extra_args=extra_args)
+        run_build(self.build_dir, extra_args=extra_args,
+                  dry_run=self.args.dry_run)

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -144,8 +144,8 @@ class Build(Forceable):
 
     def do_run(self, args, remainder):
         self.args = args        # Avoid having to pass them around
-        log.dbg('args: {} remainder: {}'.format(args, remainder,
-                                                level=log.VERBOSE_EXTREME))
+        log.dbg('args: {} remainder: {}'.format(args, remainder),
+                level=log.VERBOSE_EXTREME)
         # Store legacy -s option locally
         source_dir = self.args.source_dir
         self._parse_remainder(remainder)
@@ -155,7 +155,8 @@ class Build(Forceable):
                                             source_dir, self.args.source_dir))
             self.args.source_dir = source_dir
         log.dbg('source_dir: {} cmake_opts: {}'.format(self.args.source_dir,
-                                                       self.args.cmake_opts))
+                                                       self.args.cmake_opts),
+                level=log.VERBOSE_EXTREME)
         self._sanity_precheck()
         self._setup_build_dir()
 
@@ -172,7 +173,8 @@ class Build(Forceable):
         self.auto_pristine = (pristine == 'auto')
 
         log.dbg('pristine: {} auto_pristine: {}'.format(pristine,
-                                                        self.auto_pristine))
+                                                        self.auto_pristine),
+                level=log.VERBOSE_VERY)
         if is_zephyr_build(self.build_dir):
             if pristine == 'always':
                 self._run_pristine()
@@ -385,7 +387,7 @@ class Build(Forceable):
                     "'west config build.board_warn false'")
 
         if not self.run_cmake:
-            log.dbg('not running cmake; build system is present')
+            log.dbg('Not generating a build system; one is present.')
             return
 
         if board is not None and origin != 'CMakeCache.txt':

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -4,13 +4,12 @@
 
 import argparse
 import os
-import shutil
-import subprocess
 
 from west import log
 from west.configuration import config
 from zcmake import DEFAULT_CMAKE_GENERATOR, run_cmake, run_build, CMakeCache
-from build_helpers import is_zephyr_build, find_build_dir, BUILD_DIR_DESCRIPTION
+from build_helpers import is_zephyr_build, find_build_dir, \
+    BUILD_DIR_DESCRIPTION
 
 from zephyr_ext_common import Forceable
 
@@ -57,8 +56,8 @@ positional arguments:
 
 class AlwaysIfMissing(argparse.Action):
 
-        def __call__(self, parser, namespace, values, option_string=None):
-                    setattr(namespace, self.dest, values or 'always')
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values or 'always')
 
 class Build(Forceable):
 
@@ -152,8 +151,9 @@ class Build(Forceable):
             # Load the pristine={auto, always, never} configuration value
             pristine = config.get('build', 'pristine', fallback='never')
             if pristine not in ['auto', 'always', 'never']:
-                log.wrn('treating unknown build.pristine value "{}" as "never"'.
-                        format(pristine))
+                log.wrn(
+                    'treating unknown build.pristine value "{}" as "never"'.
+                    format(pristine))
                 pristine = 'never'
         self.auto_pristine = (pristine == 'auto')
 
@@ -348,10 +348,9 @@ class Build(Forceable):
             # there was one in the CMake cache. Since this is going to be
             # invalidated, reset to CWD and re-run the basic tests.
             if ((boards_mismatched and not apps_mismatched) and
-                (not source_abs and cached_abs)):
+                    (not source_abs and cached_abs)):
                 self._setup_source_dir()
                 self._sanity_check_source_dir()
-
 
     def _run_cmake(self, cmake_opts):
         if not self.run_cmake:
@@ -382,8 +381,8 @@ class Build(Forceable):
                     'and should have been by the main script')
 
         if not is_zephyr_build(self.build_dir):
-            log.die('Refusing to run pristine on a folder that is not a Zephyr '
-                    'build system')
+            log.die('Refusing to run pristine on a folder that is not a '
+                    'Zephyr build system')
 
         cmake_args = ['-P', '{}/cmake/pristine.cmake'.format(zb)]
         run_cmake(cmake_args, cwd=self.build_dir)

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -18,7 +18,8 @@ _ARG_SEPARATOR = '--'
 BUILD_USAGE = '''\
 west build [-h] [-b BOARD] [-d BUILD_DIR]
            [-t TARGET] [-p {auto, always, never}] [-c] [--cmake-only]
-           [-n] [-f] [source_dir] -- [cmake_opt [cmake_opt ...]]
+           [-n] [-o BUILD_OPT] [-f]
+           [source_dir] -- [cmake_opt [cmake_opt ...]]
 '''
 
 BUILD_DESCRIPTION = '''\
@@ -143,6 +144,10 @@ class Build(Forceable):
                             dest='dry_run', action='store_true',
                             help='''Just print the build commands which would
                             have run, without actually running them.''')
+        parser.add_argument('-o', '--build-opt', default=[], action='append',
+                            help='''Options to pass to the build tool.
+                            May be given more than once to append multiple
+                            values.''')
         self.add_force_arg(parser)
         return parser
 
@@ -432,5 +437,8 @@ class Build(Forceable):
 
     def _run_build(self, target):
         extra_args = ['--target', target] if target else []
+        if self.args.build_opt:
+            extra_args.append('--')
+            extra_args.extend(self.args.build_opt)
         run_build(self.build_dir, extra_args=extra_args,
                   dry_run=self.args.dry_run)

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -403,7 +403,8 @@ class Build(Forceable):
         # west build -- -DOVERLAY_CONFIG=relative-path.conf
         final_cmake_args = ['-B{}'.format(self.build_dir),
                             '-S{}'.format(self.source_dir),
-                            '-G{}'.format(DEFAULT_CMAKE_GENERATOR)]
+                            '-G{}'.format(config_get('generator',
+                                                     DEFAULT_CMAKE_GENERATOR))]
         if cmake_opts:
             final_cmake_args.extend(cmake_opts)
         run_cmake(final_cmake_args)

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -250,13 +250,13 @@ class Build(Forceable):
         if self.args.source_dir:
             source_dir = self.args.source_dir
         elif self.cmake_cache:
-            source_dir = self.cmake_cache.get('APPLICATION_SOURCE_DIR')
+            source_dir = self.cmake_cache.get('CMAKE_HOME_DIRECTORY')
             if not source_dir:
-                # Maybe Zephyr changed the key? Give the user a way
-                # to retry, at least.
-                log.die("can't determine application from build directory "
-                        "{}, please specify an application to build".
-                        format(self.build_dir))
+                # This really ought to be there. The build directory
+                # must be corrupted somehow. Let's see what we can do.
+                log.die('build directory', self.build_dir,
+                        'CMake cache has no CMAKE_HOME_DIRECTORY;',
+                        'please give a source_dir')
         else:
             source_dir = os.getcwd()
         self.source_dir = os.path.abspath(source_dir)

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -25,43 +25,8 @@ west build [-h] [-b BOARD] [-d BUILD_DIR]
 BUILD_DESCRIPTION = '''\
 Convenience wrapper for building Zephyr applications.
 
-This command attempts to do what you mean when run from a Zephyr
-application source or a pre-existing build directory:
-
-- When the build directory ('./build' by default, see below) exists and is
-  already a Zephyr build directory, the source directory is obtained from the
-  CMake cache, and that build directory is re-compiled.
-
-- Otherwise, the source directory defaults to the current working
-  directory, so running "west build" from a Zephyr application's
-  source directory compiles it.
-
-The source and build directories can be explicitly set with the
---source-dir and --build-dir options. The build directory defaults to
-'build' if it is not auto-detected. The build directory is always
-created if it does not exist.
-
-The board to build for is taken from the CACHED_BOARD CMake cache
-variable, --board option, BOARD environment variable, or build.board
-configuration option, in decreasing order of precedence.
-
-This command runs CMake to generate a build system if one is not
-present in the build directory, then builds the application.
-Subsequent builds try to avoid re-running CMake; you can force it
-to run by setting --cmake.
-
-To pass additional options to CMake, give them as extra arguments
-after a '--'. For example, this sets an overlay config file:
-
-west build [...] -- -DOVERLAY_CONFIG=some.conf
-
-(Doing this forces a CMake run.)
-
 positional arguments:
-  source_dir            Explicitly set the source directory. If not given and
-                        rebuilding an existing Zephyr build directory, this is
-                        taken from the CMake cache. Otherwise, the current
-                        directory is assumed.
+  source_dir            Use this path as the source directory
   cmake_opt             Extra options to pass to CMake; implies -c
 '''
 
@@ -121,29 +86,23 @@ class Build(Forceable):
         parser.add_argument('-s', '--source-dir', help=argparse.SUPPRESS)
         parser.add_argument('-d', '--build-dir',
                             help=BUILD_DIR_DESCRIPTION +
-                            "The directory is created if it doesn't exist.")
+                            " Always created if it doesn't exist.")
         parser.add_argument('-t', '--target',
-                            help='''Override the build system target (e.g.
-                            'clean', 'pristine', etc.)''')
+                            help='''Build system target to run''')
         parser.add_argument('-p', '--pristine', choices=['auto', 'always',
                             'never'], action=AlwaysIfMissing, nargs='?',
                             help='''Control whether the build folder is made
-                            pristine before building if a build system is
-                            present in the build dir. --pristine is the same as
-                            --pristine=always. If set to auto, the build folder
-                            will be made pristine only if required based on the
-                            existing build system and the options provided.
-                            This allows for reusing a build folder even if it
-                            contains build files for a different board or
-                            application.''')
+                            pristine before running CMake. --pristine is the
+                            same as --pristine=always. If 'auto', it will
+                            be made pristine only if needed.''')
         parser.add_argument('-c', '--cmake', action='store_true',
                             help='Force CMake to run')
         parser.add_argument('--cmake-only', action='store_true',
                             help="Just run CMake; don't build. Implies -c.")
         parser.add_argument('-n', '--just-print', '--dry-run', '--recon',
                             dest='dry_run', action='store_true',
-                            help='''Just print the build commands which would
-                            have run, without actually running them.''')
+                            help='''Just print the build commands; don't run
+                            them''')
         parser.add_argument('-o', '--build-opt', default=[], action='append',
                             help='''Options to pass to the build tool.
                             May be given more than once to append multiple

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -21,9 +21,9 @@ DEFAULT_CMAKE_GENERATOR = 'Ninja'
 '''Name of the default CMake generator.'''
 
 BUILD_DIR_DESCRIPTION = '''\
-Explicitly sets the build directory.  If not given and the current
-directory is a Zephyr build directory, it will be used; otherwise,
-"{}" is assumed.'''.format(DEFAULT_BUILD_DIR)
+Build directory. If missing and run in a Zephyr build directory, it is
+used; otherwise, it's "{}".'''.format(
+    DEFAULT_BUILD_DIR)
 
 
 def find_build_dir(dir):


### PR DESCRIPTION
This implements some of the west build enhancements requested the day after the TSC F2F and discussed a bit since then:

- Fixes https://github.com/zephyrproject-rtos/west/issues/252 (via build.generator config option, not a command line option)
- Fixes https://github.com/zephyrproject-rtos/west/issues/253
- Fixes https://github.com/zephyrproject-rtos/west/issues/254
- Fixes https://github.com/zephyrproject-rtos/west/issues/255
- Fixes https://github.com/zephyrproject-rtos/west/issues/256

This also implements a `build.board` config option to set a default board (which is used as a fallback after CACHED_BOARD in the CMake cache, BOARD in the environment, and --board on the command line), which I think is a better idea than what's proposed in https://github.com/zephyrproject-rtos/west/issues/251.
