### PR TITLE
Bluetooth: controller: ull/lll: Increase adv random delay resolution

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1073,7 +1073,7 @@ void *ull_event_done(void *param)
 	return evdone;
 }
 
-u8_t ull_entropy_get(u8_t len, u8_t *rand)
+u8_t ull_entropy_get(u8_t len, void *rand)
 {
 	return entropy_get_entropy_isr(dev_entropy, rand, len, 0);
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1011,18 +1011,18 @@ static void ticker_cb(u32_t ticks_at_expire, u32_t remainder, u16_t lazy,
 	if (!lll->is_hdcd)
 #endif /* CONFIG_BT_PERIPHERAL */
 	{
-		u8_t random_delay;
+		u32_t random_delay;
 		u32_t ret;
 
 		ull_entropy_get(sizeof(random_delay), &random_delay);
-		random_delay %= 10;
-		random_delay += 1U;
+		random_delay %= HAL_TICKER_US_TO_TICKS(10000);
+		random_delay += 1;
 
 		ret = ticker_update(TICKER_INSTANCE_ID_CTLR,
 				    TICKER_USER_ID_ULL_HIGH,
 				    (TICKER_ID_ADV_BASE +
 				     ull_adv_handle_get(adv)),
-				    HAL_TICKER_US_TO_TICKS(random_delay * 1000U),
+				    random_delay,
 				    0, 0, 0, 0, 0,
 				    ticker_op_update_cb, adv);
 		LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||

--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -34,4 +34,4 @@ void *ull_disable_mark(void *param);
 void *ull_disable_unmark(void *param);
 void *ull_disable_mark_get(void);
 int ull_disable(void *param);
-u8_t ull_entropy_get(u8_t len, u8_t *rand);
+u8_t ull_entropy_get(u8_t len, void *rand);


### PR DESCRIPTION
Increase the resolution of advertising random delay from
1 ms unit to 1 ticker unit.

Relates to #10289, #10391, and #10398.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>