### PR TITLE
Bluetooth: controller: ull/lll: Fix pin or key missing response

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4066,6 +4066,13 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 		}
 		break;
 
+	case PDU_DATA_LLCTRL_TYPE_REJECT_EXT_IND:
+		if (pdu_tx->llctrl.reject_ext_ind.reject_opcode !=
+		    PDU_DATA_LLCTRL_TYPE_ENC_REQ) {
+			break;
+		}
+		/* Pass through */
+
 	case PDU_DATA_LLCTRL_TYPE_REJECT_IND:
 		/* resume data packet rx and tx */
 		conn->pause_rx = 0U;


### PR DESCRIPTION
Fix the missing reset of Encryption Procedure state when the
peripheral responded with error reason as pin or key missing
which otherwise caused connection disconnection on next
reception of data or control packet.

Relates to #15570, and #15727.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>