### PR TITLE
Kernel mem domain add api fixes

### DIFF
--- a/arch/arc/core/mpu/arc_core_mpu.c
+++ b/arch/arc/core/mpu/arc_core_mpu.c
@@ -62,7 +62,7 @@ void z_arch_mem_domain_destroy(struct k_mem_domain *domain)
 	arc_core_mpu_enable();
 }
 
-void _arch_mem_domain_partition_add(struct k_mem_domain *domain,
+void z_arch_mem_domain_partition_add(struct k_mem_domain *domain,
 				    u32_t partition_id)
 {
 	/* No-op on this architecture */

--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -331,7 +331,7 @@ void z_arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 		&domain->partitions[partition_id], &reset_attr);
 }
 
-void _arch_mem_domain_partition_add(struct k_mem_domain *domain,
+void z_arch_mem_domain_partition_add(struct k_mem_domain *domain,
 				    u32_t partition_id)
 {
 	/* No-op on this architecture */

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -121,7 +121,7 @@ int z_arch_buffer_validate(void *addr, size_t size, int write)
 			/* loop over all the possible page tables for the
 			 * required size. If the pde is not the last one
 			 * then the last pte would be 511. So each pde
-			 * will be using all the page table entires except
+			 * will be using all the page table entries except
 			 * for the last pde. For the last pde, pte is
 			 * calculated using the last memory address
 			 * of the buffer.
@@ -281,7 +281,7 @@ static inline void x86_mem_domain_pages_update(struct k_mem_domain *mem_domain,
 	total_partitions = mem_domain->num_partitions;
 
 	/* Iterate over all the partitions for the given mem_domain
-	 * For x86: interate over all the partitions and set the
+	 * For x86: iterate over all the partitions and set the
 	 * required flags in the correct MMU page tables.
 	 */
 	partitions_count = 0U;
@@ -321,7 +321,7 @@ void z_arch_mem_domain_destroy(struct k_mem_domain *domain)
 	x86_mem_domain_pages_update(domain, X86_MEM_DOMAIN_RESET_PAGES);
 }
 
-/* Reset/destroy one partition spcified in the argument of the API. */
+/* Reset/destroy one partition specified in the argument of the API. */
 void z_arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 					u32_t partition_id)
 {
@@ -335,7 +335,7 @@ void z_arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 	z_x86_reset_pages((void *)partition->start, partition->size);
 }
 
-/* Reset/destroy one partition spcified in the argument of the API. */
+/* Reset/destroy one partition specified in the argument of the API. */
 void _arch_mem_domain_partition_add(struct k_mem_domain *domain,
 				    u32_t partition_id)
 {

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -335,8 +335,8 @@ void z_arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 	z_x86_reset_pages((void *)partition->start, partition->size);
 }
 
-/* Reset/destroy one partition specified in the argument of the API. */
-void _arch_mem_domain_partition_add(struct k_mem_domain *domain,
+/* Add one partition specified in the argument of the API. */
+void z_arch_mem_domain_partition_add(struct k_mem_domain *domain,
 				    u32_t partition_id)
 {
 	struct k_mem_partition *partition;

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -94,7 +94,7 @@ extern void z_arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 					       u32_t partition_id);
 
 /**
- * @brief Remove a partition from the memory domain
+ * @brief Add a partition to the memory domain
  *
  * A memory domain contains multiple partitions and this API provides the
  * freedom to add an additional partition to a memory domain.
@@ -104,7 +104,7 @@ extern void z_arch_mem_domain_partition_remove(struct k_mem_domain *domain,
  * @param domain The memory domain structure
  * @param partition_id The partition that needs to be added
  */
-extern void _arch_mem_domain_partition_add(struct k_mem_domain *domain,
+extern void z_arch_mem_domain_partition_add(struct k_mem_domain *domain,
 					    u32_t partition_id);
 
 /**

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -181,11 +181,11 @@ void k_mem_domain_add_partition(struct k_mem_domain *domain,
 
 	domain->num_partitions++;
 
-	/* Handle architecture-specific remove
+	/* Handle architecture-specific add
 	 * only if it is the current thread.
 	 */
 	if (_current->mem_domain_info.mem_domain == domain) {
-		_arch_mem_domain_partition_add(domain, p_idx);
+		z_arch_mem_domain_partition_add(domain, p_idx);
 	}
 
 	k_spin_unlock(&lock, key);


### PR DESCRIPTION
It looks like the internal api function for adding a partition to a mem-domain does not follow the "z_" prefix compliance. Also, the documentation seems not to reflect the functionality.

The PR fixes this, along with some typos in arch/x86/mmu.h.
