### PR TITLE
Bluetooth: controller: commentary and readability improvements

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -71,9 +71,12 @@ static s32_t hbuf_count;
 #endif
 
 /**
- * @brief Pull from memq_ll_rx and push up to Host thread recv_thread()
- *   via recv_fifo
+ * @brief Handover from Controller thread to Host thread
  * @details Execution context: Controller thread
+ *   Pull from memq_ll_rx and push up to Host thread recv_thread() via recv_fifo
+ * @param p1  Unused. Required to conform with Zephyr thread protoype
+ * @param p2  Unused. Required to conform with Zephyr thread protoype
+ * @param p3  Unused. Required to conform with Zephyr thread protoype
  */
 static void prio_recv_thread(void *p1, void *p2, void *p3)
 {

--- a/subsys/bluetooth/controller/hci/hci_internal.h
+++ b/subsys/bluetooth/controller/hci/hci_internal.h
@@ -14,10 +14,18 @@ extern atomic_t hci_state_mask;
 #define HCI_STATE_BIT_RESET 0
 #endif
 
-#define HCI_CLASS_EVT_REQUIRED    0
-#define HCI_CLASS_EVT_DISCARDABLE 1
-#define HCI_CLASS_EVT_CONNECTION  2
-#define HCI_CLASS_ACL_DATA        3
+#define HCI_CLASS_EVT_REQUIRED    0 /* Mesh and connection-{established,
+				     * disconnected}
+				     */
+#define HCI_CLASS_EVT_DISCARDABLE 1 /* Best-effort reporting. Discardable
+				     * over HCI in case of overflow
+				     */
+#define HCI_CLASS_EVT_CONNECTION  2 /* Connection management; e.g.
+				     * terminate, update, encryption
+				     */
+#define HCI_CLASS_ACL_DATA        3 /* Asynchronous Connection Less (general
+				     * data)
+				     */
 
 #if defined(CONFIG_SOC_COMPATIBLE_NRF)
 #define BT_HCI_VS_HW_PLAT BT_HCI_VS_HW_PLAT_NORDIC

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -648,11 +648,11 @@ static inline u32_t addr_us_get(u8_t phy)
 {
 	switch (phy) {
 	default:
-	case BIT(0):
+	case BIT(0): /* 1Mbps */
 		return 40;
-	case BIT(1):
+	case BIT(1): /* 2Mbps */
 		return 24;
-	case BIT(2):
+	case BIT(2): /* Coded */
 		return 376;
 	}
 }

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -365,6 +365,9 @@ void ll_reset(void)
  * @brief Peek the next node_rx to send up to Host
  * @details Tightly coupled with prio_recv_thread()
  *   Execution context: Controller thread
+ *
+ * @param node_rx[out]   Pointer to rx node at head of queue
+ * @param handle[out]    Connection handle
  * @return TX completed
  */
 u8_t ll_rx_get(void **node_rx, u16_t *handle)
@@ -1032,14 +1035,14 @@ void *ull_prepare_dequeue_iter(u8_t *idx)
 
 void *ull_event_done_extra_get(void)
 {
-	struct node_rx_event_done *done;
+	struct node_rx_event_done *evdone;
 
-	done = MFIFO_DEQUEUE_PEEK(done);
-	if (!done) {
+	evdone = MFIFO_DEQUEUE_PEEK(done);
+	if (!evdone) {
 		return NULL;
 	}
 
-	return &done->extra;
+	return &evdone->extra;
 }
 
 void *ull_event_done(void *param)

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -346,6 +346,13 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 #endif
 }
 
+/**
+ * @brief Extract timing from completed event
+ *
+ * @param node_rx_event_done[in] Done event containing fresh timing information
+ * @param ticks_drift_plus[out]  Positive part of drift uncertainty window
+ * @param ticks_drift_minus[out] Negative part of drift uncertainty window
+ */
 void ull_slave_done(struct node_rx_event_done *done, u32_t *ticks_drift_plus,
 		    u32_t *ticks_drift_minus)
 {


### PR DESCRIPTION
* Rename the stack local 'done' to 'evdone' so as to disambiguate from
  MFIFO_DEQUEUE_PEEK(done) which is actually 'mfifo_done'.

* add comment on ull_slave_done

* add comments to addr_us_get

* add comments to HCI_CLASS

Signed-off-by: Mark Ruvald Pedersen <mped@oticon.com>