### PR TITLE
net: arp: No need to check pkt for NULL

### DIFF
--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -297,7 +297,7 @@ static inline struct net_pkt *arp_prepare(struct net_if *iface,
 	memcpy(hdr->src_hwaddr.addr, net_pkt_lladdr_src(pkt)->addr,
 	       sizeof(struct net_eth_addr));
 
-	if (!entry || (pkt != NULL && net_pkt_ipv4_auto(pkt))) {
+	if (!entry || net_pkt_ipv4_auto(pkt)) {
 		my_addr = current_ip;
 	} else {
 		my_addr = if_get_addr(entry->iface, current_ip);


### PR DESCRIPTION
The pkt variable cannot be NULL at this point so the check for
nullness is not needed.

Coverity-CID: 198002
Fixes #15777

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>