### PR TITLE
boards: minor fixes in board configs for Electronut Labs boards

### DIFF
--- a/boards/arm/nrf52840_blip/Kconfig.defconfig
+++ b/boards/arm/nrf52840_blip/Kconfig.defconfig
@@ -29,4 +29,25 @@ endif # IEEE802154
 config BT_CTLR
 	default BT
 
+if PWM
+
+config PWM_0
+	default y
+
+endif # PWM
+
+if I2C
+
+config I2C_0
+	default y
+
+endif # I2C
+
+if SPI
+
+config SPI_1
+	default y
+
+endif # SPI
+
 endif # BOARD_NRF52840_BLIP

--- a/boards/arm/nrf52840_papyr/Kconfig.defconfig
+++ b/boards/arm/nrf52840_papyr/Kconfig.defconfig
@@ -47,4 +47,7 @@ config SPI_1
 
 endif # SPI
 
+config BT_CTLR
+	default BT
+
 endif # BOARD_NRF52840_PAPYR

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,uart-mcumgr = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr_defconfig
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr_defconfig
@@ -14,6 +14,7 @@ CONFIG_GPIO=y
 
 # enable uart driver
 CONFIG_SERIAL=y
+CONFIG_UART_NRFX=y
 CONFIG_UART_0_NRF_UART=y
 
 # enable console


### PR DESCRIPTION
Minor fixes for Blip and Papyr boards. Enables default instances of peripherals if the drivers are enabled for blip, and connects shell-uart to uart0 instance in device tree for Papyr.