### PR TITLE
Bluetooth: controller: Fix completion of rejected LLCP request

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -3391,29 +3391,26 @@ static inline void reject_ind_conn_upd_recv(struct ll_conn *conn,
 
 		goto reject_ind_conn_upd_recv_exit;
 	}
-	/* Same Procedure or Different Procedure Collision */
-
-	/* If not same procedure, stop procedure timeout, else
-	 * continue timer until phy upd ind is received.
-	 */
+	/* FIXME: handle unsupported LL parameters error */
 	else if (rej_ext_ind->error_code != BT_HCI_ERR_LL_PROC_COLLISION) {
+		/* update to next ticks offset */
+		if (lll->role) {
+			conn->slave.ticks_to_offset =
+			    conn->llcp_conn_param.ticks_to_offset_next;
+		}
+	}
+
+	if (conn->llcp_conn_param.state == LLCP_CPR_STATE_RSP_WAIT) {
 		LL_ASSERT(conn_upd_curr == conn);
 
 		/* reset mutex */
 		conn_upd_curr = NULL;
 
 		/* Procedure complete */
-		conn->llcp_conn_param.ack =
-			conn->llcp_conn_param.req;
+		conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
 
 		/* Stop procedure timeout */
 		conn->procedure_expire = 0U;
-
-		/* update to next ticks offsets */
-		if (lll->role) {
-			conn->slave.ticks_to_offset =
-			    conn->llcp_conn_param.ticks_to_offset_next;
-		}
 	}
 
 	/* skip event generation if not cmd initiated */


### PR DESCRIPTION
This fixes LLCP procedure completition in case when remote rejected
LLCP Slave Connection Parameter Request with LMP Error Transaction
Collision error code.

The link was disconnected after 40 seconds after receiving the
LLCP Reject Extended Indication of Connection Parameter Update
with the reason LMP Error Transaction Collision.
This patch resets the timer upon reject is received.

Relates to: #15366 

Signed-off-by: Alexander Svensen alsv@nordicsemi.no