### PR TITLE
subsys/settings: Use strncpy instead of strcpy in settings_runtime

### DIFF
--- a/subsys/settings/src/settings_runtime.c
+++ b/subsys/settings/src/settings_runtime.c
@@ -22,7 +22,7 @@ int settings_runtime_set(const char *name, void *data, size_t len)
 	char *name_argv[SETTINGS_MAX_DIR_DEPTH];
 	int name_argc;
 
-	strcpy(name1, name);
+	strncpy(name1, name, sizeof(name1));
 	ch = settings_parse_and_lookup(name1, &name_argc, name_argv);
 	if (!ch) {
 		return -EINVAL;
@@ -39,7 +39,7 @@ int settings_runtime_get(const char *name, void *data, size_t len)
 	char *name_argv[SETTINGS_MAX_DIR_DEPTH];
 	int name_argc;
 
-	strcpy(name1, name);
+	strncpy(name1, name, sizeof(name1));
 	ch = settings_parse_and_lookup(name1, &name_argc, name_argv);
 	if (!ch) {
 		return -EINVAL;
@@ -55,7 +55,7 @@ int settings_runtime_commit(const char *name)
 	char *name_argv[SETTINGS_MAX_DIR_DEPTH];
 	int name_argc;
 
-	strcpy(name1, name);
+	strncpy(name1, name, sizeof(name1));
 	ch = settings_parse_and_lookup(name1, &name_argc, name_argv);
 	if (!ch) {
 		return -EINVAL;


### PR DESCRIPTION
This fixes some Coverity warnings.

Coverity-CID: 198022
Coverity-CID: 198019
Coverity-CID: 198016
Fixes #15762
Fixes #15764
Fixes #15766

Signed-off-by: François Delawarde <fnde@oticon.com>