### PR TITLE
drivers: added break in function stm32_clock_control_get_subsys_rate

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_mp1x.c
+++ b/drivers/clock_control/clock_stm32_ll_mp1x.c
@@ -274,6 +274,7 @@ static int stm32_clock_control_get_subsys_rate(struct device *clock,
 		case LL_APB5_GRP1_PERIPH_I2C4:
 		case LL_APB5_GRP1_PERIPH_I2C6:
 			*rate = LL_RCC_GetI2CClockFreq(LL_RCC_I2C46_CLKSOURCE);
+			break;
 		case LL_APB5_GRP1_PERIPH_USART1:
 			*rate = LL_RCC_GetUARTClockFreq(
 					LL_RCC_USART1_CLKSOURCE);


### PR DESCRIPTION
Added a new break statement in switch. Now case 
`case LL_APB5_GRP1_PERIPH_I2C4:
case LL_APB5_GRP1_PERIPH_I2C6:`
can be terminated by `break` statement.

Coverity-CID: 198021
Fixes: #15763
Signed-off-by: Maksim Masalski <maxxliferobot@gmail.com>