### PR TITLE
board: stm32_min_dev: add the missing usb node

### DIFF
--- a/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
@@ -70,3 +70,7 @@
 		status = "ok";
 	};
 };
+
+&usb {
+	status = "ok";
+};


### PR DESCRIPTION
The stm32_min_dev board blue/black variant support USB device,
but the USB node removed by merge PR #15245, so add it back.