### PR TITLE
WIP: implement sys_sem residing in user memory with the help of futex

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4844,6 +4844,12 @@ extern void k_mem_domain_remove_thread(k_tid_t thread);
  */
 __syscall void k_str_out(char *c, size_t n);
 
+enum futex_op {
+	FUTEX_WAIT,
+	FUTEX_WAKE
+};
+
+__syscall int k_futex(atomic_t *addr, int op, int val, s32_t timeout);
 /**
  * @brief Start a numbered CPU on a MP-capable system
 

--- a/include/misc/sem.h
+++ b/include/misc/sem.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_MISC_SEM_H_
+#define ZEPHYR_INCLUDE_MISC_SEM_H_
+#ifdef CONFIG_USERSPACE
+#include <atomic.h>
+#include <zephyr/types.h>
+
+struct sys_sem {
+	atomic_t count;
+	atomic_val_t limit;
+};
+
+#define SYS_SEM_DEFINE(name, initial_count, count_limit) \
+	struct sys_sem name = \
+	{\
+		.count = initial_count,\
+		.limit = count_limit\
+	}
+
+void sys_sem_init(struct sys_sem *sem, int initial_count, unsigned int limit);
+int sys_sem_give(struct sys_sem *sem);
+int sys_sem_take(struct sys_sem *sem, s32_t timeout);
+
+#else
+#include <kernel.h>
+#include <kernel_structs.h>
+
+struct sys_sem {
+	struct k_sem kernel_sem;
+};
+
+#define SYS_SEM_DEFINE(name, initial_count, count_limit) \
+	struct sys_sem name = \
+	{\
+		.kernel_sem = Z_SEM_INITIALIZER(name.kernel_sem, \
+				initial_count, count_limit) \
+	}
+
+void sys_sem_init(struct sys_sem *sem, int initial_count, unsigned int limit);
+int sys_sem_give(struct sys_sem *sem);
+int sys_sem_take(struct sys_sem *sem, s32_t timeout);
+
+#endif
+#endif

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources_ifdef(
   mem_domain.c
   userspace_handler.c
   userspace.c
+  futex.c
   )
 
 

--- a/kernel/futex.c
+++ b/kernel/futex.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019 Intel corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <kernel_structs.h>
+#include <spinlock.h>
+#include <kswap.h>
+#include <wait_q.h>
+#include <syscall_handler.h>
+#include <init.h>
+#include <ksched.h>
+
+static struct k_spinlock lock;
+
+static _wait_q_t *futex_find(atomic_t *addr)
+{
+	struct _k_object *obj;
+
+	obj = z_object_find(addr);
+	if (obj == NULL || obj->type != K_OBJ_SYS_MUTEX) {
+		return NULL;
+	}
+
+	return (_wait_q_t *)obj->data;
+}
+
+static int futex_wake(atomic_t *addr, int val)
+{
+	k_spinlock_key_t key;
+	_wait_q_t *thread_q;
+	struct k_thread *thread;
+	int woken = 0;
+
+	key = k_spin_lock(&lock);
+
+	thread_q = futex_find(addr);
+	if (thread_q == NULL) {
+		k_spin_unlock(&lock, key);
+		return woken;
+	}
+
+	while (woken < val && (thread = z_unpend_first_thread(thread_q))) {
+		z_ready_thread(thread);
+		woken++;
+	}
+
+	z_reschedule(&lock, key);
+
+	return woken;
+}
+
+static int futex_wait(atomic_t *addr, int val, s32_t timeout)
+{
+	k_spinlock_key_t key;
+	_wait_q_t *thread_q;
+
+	if (atomic_get(addr) != (atomic_val_t)val) {
+		return -EAGAIN;
+	}
+
+	key = k_spin_lock(&lock);
+
+	thread_q = futex_find(addr);
+	if (thread_q == NULL) {
+		k_spin_unlock(&lock, key);
+		return -ENOMEM;
+	}
+
+	return z_pend_curr(&lock, key, thread_q, timeout);
+}
+
+int z_impl_k_futex(atomic_t *addr, int op, int val, s32_t timeout)
+{
+	switch ((enum futex_op)op) {
+	case FUTEX_WAIT:
+		return futex_wait(addr, val, timeout);
+	case FUTEX_WAKE:
+		return futex_wake(addr, val);
+	default:
+		return -EINVAL;
+	}
+}
+
+#ifdef CONFIG_USERSPACE
+Z_SYSCALL_HANDLER(k_futex, addr, op, val, timeout)
+{
+	Z_OOPS(Z_SYSCALL_VERIFY(addr != 0));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(addr, sizeof(atomic_val_t)));
+
+	return z_impl_k_futex((atomic_t *)addr,
+			(int)op, (int)val, (s32_t)timeout);
+}
+#endif

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -20,6 +20,7 @@
 #include <app_memory/app_memdomain.h>
 #include <misc/libc-hooks.h>
 #include <misc/mutex.h>
+#include <misc/sem.h>
 
 #ifdef Z_LIBC_PARTITION_EXISTS
 K_APPMEM_PARTITION_DEFINE(z_libc_partition);

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -12,6 +12,7 @@ zephyr_sources(
   rb.c
   thread_entry.c
   work_q.c
+  sem.c
   )
 
 zephyr_sources_ifdef(CONFIG_JSON_LIBRARY json.c)

--- a/lib/os/sem.c
+++ b/lib/os/sem.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifdef CONFIG_USERSPACE
+#include <misc/sem.h>
+#include <syscall_handler.h>
+
+void sys_sem_init(struct sys_sem *sem, int initial_count, unsigned int limit)
+{
+	sem->count = initial_count;
+	sem->limit = limit;
+}
+
+int sys_sem_give(struct sys_sem *sem)
+{
+	atomic_val_t oldvalue;
+
+	do {
+		oldvalue = atomic_get(&sem->count);
+
+		if (oldvalue >= sem->limit) {
+			break;
+		}
+	} while (atomic_cas(&sem->count, oldvalue, oldvalue + 1) == 0);
+
+	k_futex(&sem->count, FUTEX_WAKE, 1,  K_NO_WAIT);
+
+	return 0;
+}
+
+int sys_sem_take(struct sys_sem *sem, s32_t timeout)
+{
+	atomic_val_t oldvalue;
+
+	do {
+		oldvalue = atomic_get(&sem->count);
+
+		if (oldvalue <= 0) {
+			break;
+		}
+	} while (atomic_cas(&sem->count, oldvalue, oldvalue - 1) == 0);
+
+	if (oldvalue > 0) {
+		return 0;
+	}
+
+	k_futex(&sem->count, FUTEX_WAIT, 0, timeout);
+
+	return 0;
+}
+#else
+#include <misc/sem.h>
+
+void sys_sem_init(struct sys_sem *sem, int initial_count, unsigned int limit)
+{
+	k_sem_init(&sem->kernel_sem, initial_count, limit);
+}
+
+int sys_sem_give(struct sys_sem *sem)
+{
+	k_sem_give(&sem->kernel_sem);
+
+	return 0;
+}
+
+int sys_sem_take(struct sys_sem *sem, s32_t timeout)
+{
+	k_sem_take(&sem->kernel_sem, timeout);
+
+	return 0;
+}
+#endif

--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -38,6 +38,7 @@ DW_OP_fbreg = 0x91
 STACK_TYPE = "_k_thread_stack_element"
 thread_counter = 0
 sys_mutex_counter = 0
+sys_sem_counter = 0
 
 # Global type environment. Populated by pass 1.
 type_env = {}
@@ -56,6 +57,7 @@ class KobjectInstance:
     def __init__(self, type_obj, addr):
         global thread_counter
         global sys_mutex_counter
+        global sys_sem_counter
 
         self.addr = addr
         self.type_obj = type_obj
@@ -72,6 +74,9 @@ class KobjectInstance:
         elif self.type_obj.name == "sys_mutex":
             self.data = "(u32_t)(&kernel_mutexes[%d])" % sys_mutex_counter
             sys_mutex_counter += 1
+        elif self.type_obj.name == "sys_sem":
+            self.data = "(u32_t)(&sys_sem_wait_q[%d])" % sys_sem_counter
+            sys_sem_counter += 1
         else:
             self.data = 0
 
@@ -566,3 +571,6 @@ class ElfHelper:
 
     def get_sys_mutex_counter(self):
         return sys_mutex_counter
+
+    def get_sys_sem_counter(self):
+        return sys_sem_counter

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -86,7 +86,8 @@ kobjects = OrderedDict ([
     ("k_timer", (None, False)),
     ("_k_thread_stack_element", (None, False)),
     ("device", (None, False)),
-    ("sys_mutex", (None, True))
+    ("sys_mutex", (None, True)),
+    ("sys_sem", (None, True))
 ])
 
 
@@ -124,6 +125,7 @@ header = """%compare-lengths
 #include <toolchain.h>
 #include <syscall_handler.h>
 #include <string.h>
+#include <wait_q.h>
 %}
 struct _k_object;
 """
@@ -158,7 +160,6 @@ void z_object_wordlist_foreach(_wordlist_cb_func_t func, void *context)
 #endif
 """
 
-
 def write_gperf_table(fp, eh, objs, static_begin, static_end):
     fp.write(header)
     num_mutexes = eh.get_sys_mutex_counter()
@@ -167,6 +168,15 @@ def write_gperf_table(fp, eh, objs, static_begin, static_end):
         for i in range(num_mutexes):
             fp.write("_K_MUTEX_INITIALIZER(kernel_mutexes[%d])" % i)
             if (i != num_mutexes - 1):
+                fp.write(", ")
+        fp.write("};\n")
+
+    num_sem = eh.get_sys_sem_counter()
+    if (num_sem != 0):
+        fp.write("static _wait_q_t sys_sem_wait_q[%d] = {\n" % num_sem)
+        for i in range(num_sem):
+            fp.write("Z_WAIT_Q_INIT(&sys_sem_wait_q[%d])" % i)
+            if (i != num_sem - 1):
                 fp.write(", ")
         fp.write("};\n")
 


### PR DESCRIPTION
implement kernel side futex when enable user mode, two operations are
implemented, FUTEX_WAIT and FUTEX_WAKE.

based on futex mechanism, implement sys_sem. When user mode enabled,
sys_sem rside in user memory with the help of futex. On system with only
kernel space, sys_sem just wraps k_sem APIs.

Fixes: #15139

Signed-off-by: Wentong Wu <wentong.wu@intel.com>