### PR TITLE
drivers/i2s_ll_stm32.c: (FIX) Avoid warning in LOG_ERR

### DIFF
--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -609,7 +609,7 @@ static void i2s_stm32_isr(void *arg)
 	struct i2s_stm32_data *const dev_data = DEV_DATA(dev);
 	struct stream *stream = &dev_data->rx;
 
-	LOG_ERR("%s: err=%d", __func__, LL_I2S_ReadReg(cfg->i2s, SR));
+	LOG_ERR("%s: err=%d", __func__, (int)LL_I2S_ReadReg(cfg->i2s, SR));
 	stream->state = I2S_STATE_ERROR;
 
 	/* OVR error must be explicitly cleared */


### PR DESCRIPTION
The LL_I2S_ReadReg() function returns uint32_t, while %d requires 'int' as a type.

This PR fixes following warning:

zephyr/drivers/i2s/i2s_ll_stm32.c: In function 'i2s_stm32_isr':
zephyr/drivers/i2s/i2s_ll_stm32.c:612:28: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'volatile long unsigned int'} [-Wformat=]
  LOG_ERR("%s: err=%d", __func__, LL_I2S_ReadReg(cfg->i2s, SR));
                            ^~~~~~~~~~~~            ~~~~~~~~~~~~    

It has been noted when CONFIG_NEWLIB_LIBC is enabled.
It should fix  #15566 (@overheat) and potentially #14111
