### PR TITLE
api: dma: add circular buffer support

### DIFF
--- a/drivers/dma/dma_stm32f4x.c
+++ b/drivers/dma/dma_stm32f4x.c
@@ -324,6 +324,10 @@ static int dma_stm32_config_devcpy(struct device *dev, u32_t id,
 		return -EINVAL;
 	}
 
+	if (config->buf_cfg == DMA_BUF_CFG_CIRCULAR) {
+		regs->scr |= DMA_STM32_SCR_CIRC;
+	}
+
 	if (src_burst_size == BURST_TRANS_LENGTH_1 &&
 	    dst_burst_size == BURST_TRANS_LENGTH_1) {
 		/* Enable 'direct' mode error IRQ, disable 'FIFO' error IRQ */
@@ -357,6 +361,10 @@ static int dma_stm32_config_memcpy(struct device *dev, u32_t id,
 		DMA_STM32_SCR_PINC |		/* Peripheral increment mode */
 		DMA_STM32_SCR_TCIE |		/* Transfer comp IRQ enable */
 		DMA_STM32_SCR_TEIE;		/* Transfer error IRQ enable */
+
+	if (config->buf_cfg == DMA_BUF_CFG_CIRCULAR) {
+		regs->scr |= DMA_STM32_SCR_CIRC;
+	}
 
 	regs->sfcr = DMA_STM32_SFCR_DMDIS |	/* Direct mode disable */
 		DMA_STM32_SFCR_FTH(DMA_STM32_FIFO_THRESHOLD_FULL) |

--- a/include/dma.h
+++ b/include/dma.h
@@ -41,6 +41,11 @@ enum dma_addr_adj {
 	DMA_ADDR_ADJ_NO_CHANGE,
 };
 
+enum dma_buf_cfg {
+	DMA_BUF_CFG_NORMAL,
+	DMA_BUF_CFG_CIRCULAR,
+};
+
 /**
  * @brief DMA block configuration structure.
  *
@@ -142,7 +147,8 @@ struct dma_config {
 	u32_t  channel_priority :     4;
 	u32_t  source_chaining_en :   1;
 	u32_t  dest_chaining_en :     1;
-	u32_t  reserved :            13;
+	u32_t  buf_cfg :	      2;
+	u32_t  reserved :            11;
 	u32_t  source_data_size :    16;
 	u32_t  dest_data_size :      16;
 	u32_t  source_burst_length : 16;


### PR DESCRIPTION
Add one more bitfield to support buf configuration, thus
to support using circular buffer config.

And implement circular buffer support for STM32 SoCs.

The PR will be the one of dependencies for PR #14916 

Signed-off-by: Jun Li <jun.r.li@intel.com>