### PR TITLE
arch/x86_64: Junk spurious linker-generated code in the 32 bit stub

### DIFF
--- a/arch/x86_64/core/CMakeLists.txt
+++ b/arch/x86_64/core/CMakeLists.txt
@@ -44,7 +44,7 @@ add_custom_command(
     -c ${CMAKE_CURRENT_SOURCE_DIR}/xuk-stub32.c
     -o ${CMAKE_CURRENT_BINARY_DIR}/xuk-stub32.o
   COMMAND ${CMAKE_C_COMPILER} -m32 ${X86_64_BASE_CFLAGS}
-    -Wl,--build-id=none -nostdlib -nodefaultlibs -nostartfiles
+    -Wl,--build-id=none -nostdlib -nodefaultlibs -nostartfiles -no-pie
     -T ${CMAKE_CURRENT_SOURCE_DIR}/xuk-stub32.ld
     ${CMAKE_CURRENT_BINARY_DIR}/xuk-stub32.o
     -o ${CMAKE_CURRENT_BINARY_DIR}/xuk-stub32.elf

--- a/arch/x86_64/core/Makefile.xuk
+++ b/arch/x86_64/core/Makefile.xuk
@@ -28,7 +28,7 @@ stubs: xuk-stub32.bin xuk-stub16.bin
 # image.
 xuk-stub32.bin: xuk-stub32.c *.h xuk-stub32.ld
 	$(CC) -Wall -m32 $(CFLAGS) -c xuk-stub32.c
-	$(CC) -m32 -T xuk-stub32.ld $(LDFLAGS) -o stub32.elf $(CFLAGS) xuk-stub32.o
+	$(CC) -m32 -T xuk-stub32.ld $(LDFLAGS) -no-pie -o stub32.elf $(CFLAGS) xuk-stub32.o
 	$(OBJCOPY) -O binary stub32.elf $@
 
 # This is the main OS image, starting with the 32 bit stub and


### PR DESCRIPTION
Within the past few days, an update to the Ubuntu 18.04 toolchain has
begun emitting code sections during link that are messing with our
stub generation.  They are appearing in the 32 bit stub link despite
not being defined in the single object file, and (worse) being
included in the output segment (i.e. at the start of the bootloader
entry point!) despite not being specifically included by the linker
script.  I don't understand this behavior at all, and it appears to be
directly contrary to the way the linker is documented.

Segregate these sections into a separate segment explicitly that we
can then ignore during the subsequent objcopy of the stub code.

Fixes #15877

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>