### PR TITLE
drivers: sensor: adxl362: use correct driver configuration data

### DIFF
--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -204,8 +204,8 @@ struct adxl362_data {
 	struct k_thread thread;
 #elif defined(CONFIG_ADXL362_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
-	struct device *dev;
 #endif
+	struct device *dev;
 #endif /* CONFIG_ADXL362_TRIGGER */
 };
 

--- a/drivers/sensor/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adxl362/adxl362_trigger.c
@@ -51,7 +51,7 @@ static void adxl362_gpio_callback(struct device *dev,
 {
 	struct adxl362_data *drv_data =
 		CONTAINER_OF(cb, struct adxl362_data, gpio_cb);
-	const struct adxl362_config *cfg = dev->config->config_info;
+	const struct adxl362_config *cfg = drv_data->dev->config->config_info;
 
 	gpio_pin_disable_callback(dev, cfg->int_gpio);
 
@@ -182,8 +182,8 @@ int adxl362_init_interrupt(struct device *dev)
 			0, 0);
 #elif defined(CONFIG_ADXL362_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = adxl362_work_cb;
-	drv_data->dev = dev;
 #endif
+	drv_data->dev = dev;
 
 	return 0;
 }


### PR DESCRIPTION
The device passed to the GPIO callback is the GPIO device and not the
ADXL362 device. A pointer to the ADXL362 device is kept in the drivers
runtime data, so use it to retrieve the correct configuration data.

This bug is repeated in the adt7420 and adxl372 drivers and needs to be fixed there too.