### PR TITLE
drivers: adxl362: reenable callbacks and check interrupt status

### DIFF
--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -157,6 +157,7 @@
 #define ADXL362_RESET_KEY               0x52
 
 /* ADXL362 Status check */
+#define ADXL362_STATUS_CHECK_DATA_READY(x)	(((x) >> 0) & 0x1)
 #define ADXL362_STATUS_CHECK_INACT(x)		(((x) >> 5) & 0x1)
 #define ADXL362_STATUS_CHECK_ACTIVITY(x)	(((x) >> 4) & 0x1)
 

--- a/drivers/sensor/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adxl362/adxl362_trigger.c
@@ -127,7 +127,7 @@ int adxl362_trigger_set(struct device *dev,
 				     int_mask, int_en);
 
 	if (ret) {
-		return -EFAULT;
+		goto out;
 	}
 
 	ret = adxl362_get_status(dev, &status_buf);

--- a/drivers/sensor/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adxl362/adxl362_trigger.c
@@ -22,27 +22,28 @@ static void adxl362_thread_cb(void *arg)
 	struct adxl362_data *drv_data = dev->driver_data;
 	const struct adxl362_config *cfg = dev->config->config_info;
 	u8_t status_buf;
-	int ret;
+
+	/* Clears activity and inactivity interrupt */
+	if (adxl362_get_status(dev, &status_buf)) {
+		LOG_ERR("Unable to get status from ADXL362.\n");
+		goto out_reenable_callbacks;
+	}
 
 	k_mutex_lock(&drv_data->trigger_mutex, K_FOREVER);
 	if (drv_data->th_handler != NULL) {
-		ret = adxl362_get_status(dev, &status_buf);
-
-		if (ret) {
-			LOG_ERR("Unable to get status from ADXL362.\n");
-		}
-
 		if (ADXL362_STATUS_CHECK_INACT(status_buf) ||
 		    ADXL362_STATUS_CHECK_ACTIVITY(status_buf)) {
 			drv_data->th_handler(dev, &drv_data->th_trigger);
 		}
 	}
 
-	if (drv_data->drdy_handler != NULL) {
+	if (drv_data->drdy_handler != NULL &&
+			ADXL362_STATUS_CHECK_DATA_READY(status_buf)) {
 		drv_data->drdy_handler(dev, &drv_data->drdy_trigger);
 	}
 	k_mutex_unlock(&drv_data->trigger_mutex);
 
+out_reenable_callbacks:
 	gpio_pin_enable_callback(drv_data->gpio, cfg->int_gpio);
 }
 


### PR DESCRIPTION
The GPIO callbacks should be reenabled on error. Use the centralized
exit pattern in this function to handle this exit path correctly.