### PR TITLE
drivers: adxl362: clear data ready interrupt

### DIFF
--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -136,6 +136,12 @@ int adxl362_get_status(struct device *dev, u8_t *status)
 {
 	return adxl362_get_reg(dev, status, ADXL362_REG_STATUS, 1);
 }
+
+int adxl362_clear_data_ready(struct device *dev)
+{
+	u8_t buf;
+	return adxl362_get_reg(dev, &buf, ADXL362_REG_XDATA, 1);
+}
 #endif
 
 static int adxl362_software_reset(struct device *dev)

--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -248,6 +248,8 @@ int adxl362_trigger_set(struct device *dev,
 int adxl362_init_interrupt(struct device *dev);
 
 int adxl362_set_interrupt_mode(struct device *dev, u8_t mode);
+
+int adxl362_clear_data_ready(struct device *dev);
 #endif /* CONFIG_ADT7420_TRIGGER */
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ADXL362_ADXL362_H_ */

--- a/drivers/sensor/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adxl362/adxl362_trigger.c
@@ -129,7 +129,13 @@ int adxl362_trigger_set(struct device *dev,
 		return -EFAULT;
 	}
 
+	/* Clear activity and inactivity interrupts */
 	ret = adxl362_get_status(dev, &status_buf);
+	if (ret) {
+		goto out;
+	}
+
+	ret = adxl362_clear_data_ready(dev);
 
 out:
 	gpio_pin_enable_callback(drv_data->gpio, cfg->int_gpio);


### PR DESCRIPTION
The data ready interrupt pin is held high until the interrupt is cleared
by reading a data register. After enabling the data ready interrupt the
interrupt pin will most likely go high before the GPIO callbacks are
re-enabled. Then the callback will never be called unless the interrupt
is cleared. This commit clears the data ready interrupt so the next
rising edge can trigger the callback.