### PR TITLE
 west: build: Construct CalledProcessError with positional args

### DIFF
--- a/scripts/west_commands/zcmake.py
+++ b/scripts/west_commands/zcmake.py
@@ -49,8 +49,7 @@ def run_cmake(args, cwd=None, capture_output=False):
             return None
     else:
         # A real error occurred, raise an exception
-        raise subprocess.CalledProcessError(cmd=p.args,
-                                            returncode=p.returncode)
+        raise subprocess.CalledProcessError(p.returncode, p.args)
 
 
 def run_build(build_directory, extra_args=(), cwd=None, capture_output=False):


### PR DESCRIPTION
Since west's main.py relies on the args tuple with the returncode and the
cmd, create the CalledProcessError using the correct positional args.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>