### PR TITLE
west: boards: Use the new zcmake module name

### DIFF
--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -10,7 +10,7 @@ import textwrap
 
 from west import log
 from west.commands import WestCommand
-from cmake import run_cmake
+from zcmake import run_cmake
 
 class Boards(WestCommand):
 


### PR DESCRIPTION
Switch to the recently renamed zcmake module when importing the
run_cmake function.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>