### PR TITLE
dts: stm32f7: Remove DTCM from sram0

### DIFF
--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.yaml
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 320
+ram: 256
 flash: 1024
 supported:
   - arduino_i2c

--- a/boards/arm/nucleo_f756zg/nucleo_f756zg.yaml
+++ b/boards/arm/nucleo_f756zg/nucleo_f756zg.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 320
+ram: 256
 flash: 1024
 supported:
   - arduino_i2c

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.yaml
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 256
+ram: 192
 flash: 512
 supported:
   - arduino_i2c

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 320
+ram: 256
 flash: 1024
 supported:
   - arduino_i2c

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.yaml
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 512
+ram: 384
 flash: 2048
 supported:
   - arduino_i2c

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -22,11 +22,6 @@
 		};
 	};
 
-	sram0: memory@20000000 {
-		device_type = "memory";
-		compatible = "mmio-sram";
-	};
-
 	soc {
 		flash-controller@40023c00 {
 			compatible = "st,stm32f7-flash-controller";

--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -7,6 +7,14 @@
 #include <st/f7/stm32f7.dtsi>
 
 / {
+	/* 64KB DTCM @ 0x20000000, 176KB SRAM1 @ 0x20010000, 16KB SRAM2 @ 0x2003C00 */
+
+	sram0: memory@20010000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
+		reg = <0x20010000 DT_SIZE_K(192)>;
+	};
+
 	soc {
 		usbphyc: usbphyc@40017c00 {
 			compatible = "st,stm32-usbphyc";

--- a/dts/arm/st/f7/stm32f723Xe.dtsi
+++ b/dts/arm/st/f7/stm32f723Xe.dtsi
@@ -8,10 +8,6 @@
 #include <st/f7/stm32f723.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(256)>;
-	};
-
 	soc {
 		flash-controller@40023c00 {
 			flash0: flash@8000000 {

--- a/dts/arm/st/f7/stm32f746.dtsi
+++ b/dts/arm/st/f7/stm32f746.dtsi
@@ -7,6 +7,14 @@
 #include <st/f7/stm32f7.dtsi>
 
 / {
+	/* 64KB DTCM @ 20000000, 240KB SRAM1 @ 20010000, 16KB SRAM2 @ 2004C000 */
+
+	sram0: memory@20010000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
+		reg = <0x20010000 DT_SIZE_K(256)>;
+	};
+
 	soc {
 		pinctrl: pin-controller@40020000 {
 			reg = <0x40020000 0x2C00>;

--- a/dts/arm/st/f7/stm32f746Xg.dtsi
+++ b/dts/arm/st/f7/stm32f746Xg.dtsi
@@ -8,10 +8,6 @@
 #include <st/f7/stm32f746.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(320)>;
-	};
-
 	soc {
 		flash-controller@40023c00 {
 			flash0: flash@8000000 {

--- a/dts/arm/st/f7/stm32f756Xg.dtsi
+++ b/dts/arm/st/f7/stm32f756Xg.dtsi
@@ -8,10 +8,6 @@
 #include <st/f7/stm32f756.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(320)>;
-	};
-
 	soc {
 		flash-controller@40023c00 {
 			flash0: flash@8000000 {

--- a/dts/arm/st/f7/stm32f769.dtsi
+++ b/dts/arm/st/f7/stm32f769.dtsi
@@ -1,7 +1,54 @@
 /*
- * Copyright (c)  2018 Yong Jin
+ * Copyright (c) 2018 Yurii Hamann
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/f7/stm32f746.dtsi>
+#include <st/f7/stm32f7.dtsi>
+
+/ {
+	/* 128KB DTCM @ 20000000, 368KB SRAM1 @ 20020000, 16KB SRAM2 @ 2007C000 */
+
+	sram0: memory@20020000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
+		reg = <0x20020000 DT_SIZE_K(384)>;
+	};
+
+	soc {
+		pinctrl: pin-controller@40020000 {
+			reg = <0x40020000 0x2C00>;
+
+			gpioj: gpio@40022400 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x40022400 0x400>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000200>;
+				label = "GPIOJ";
+			};
+
+			gpiok: gpio@40022800 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x40022800 0x400>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000400>;
+				label = "GPIOK";
+			};
+		};
+
+		i2c4: i2c@40006000 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40006000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x01000000>;
+			interrupts = <95 0>, <96 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label = "I2C_4";
+		};
+	};
+};

--- a/dts/arm/st/f7/stm32f769Xi.dtsi
+++ b/dts/arm/st/f7/stm32f769Xi.dtsi
@@ -8,10 +8,6 @@
 #include <st/f7/stm32f769.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(512)>;
-	};
-
 	soc {
 		flash-controller@40023c00 {
 			flash0: flash@8000000 {


### PR DESCRIPTION
Change sram0 start address to SRAM1 from DTCM.

Fixes: #15909 

Signed-off-by: Matthew Koch <koch.matthew@gmail.com>