### PR TITLE
drivers: adxl362: fix issues in trigger support

### DIFF
--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -135,6 +135,13 @@ int adxl362_get_status(struct device *dev, u8_t *status)
 {
 	return adxl362_get_reg(dev, status, ADXL362_REG_STATUS, 1);
 }
+
+int adxl362_clear_data_ready(struct device *dev)
+{
+	u8_t buf;
+	/* Reading any data register clears the data ready interrupt */
+	return adxl362_get_reg(dev, &buf, ADXL362_REG_XDATA, 1);
+}
 #endif
 
 static int adxl362_software_reset(struct device *dev)

--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -157,6 +157,7 @@
 #define ADXL362_RESET_KEY               0x52
 
 /* ADXL362 Status check */
+#define ADXL362_STATUS_CHECK_DATA_READY(x)	(((x) >> 0) & 0x1)
 #define ADXL362_STATUS_CHECK_INACT(x)		(((x) >> 5) & 0x1)
 #define ADXL362_STATUS_CHECK_ACTIVITY(x)	(((x) >> 4) & 0x1)
 

--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -249,6 +249,8 @@ int adxl362_trigger_set(struct device *dev,
 int adxl362_init_interrupt(struct device *dev);
 
 int adxl362_set_interrupt_mode(struct device *dev, u8_t mode);
+
+int adxl362_clear_data_ready(struct device *dev);
 #endif /* CONFIG_ADT7420_TRIGGER */
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ADXL362_ADXL362_H_ */


### PR DESCRIPTION
This series of commits fixes several issues with the ADXL362 sensor driver trigger support. I have included them in a single PR because fixing one issue exacerbates the others, so I suggest they be committed together.

The main issue is that the data ready trigger handler is never executed due to callbacks being disabled and the data ready status not being cleared. There are also mistakes in the error path where the callbacks are not re-enabled before return.

This indirectly fixes #15896 and subsumes #15897 and #15899.