### PR TITLE
stm32f7: Kconfig: soc: Enable GPIO ports F & G by default

### DIFF
--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.series
@@ -24,6 +24,12 @@ config GPIO_STM32_PORTD
 config GPIO_STM32_PORTE
 	default y
 
+config GPIO_STM32_PORTF
+	default y
+
+config GPIO_STM32_PORTG
+	default y
+
 config GPIO_STM32_PORTH
 	default y
 

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f756xx
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f756xx
@@ -13,12 +13,6 @@ config SOC
 
 if GPIO_STM32
 
-config GPIO_STM32_PORTF
-	default y
-
-config GPIO_STM32_PORTG
-	default y
-
 config GPIO_STM32_PORTJ
 	default y
 


### PR DESCRIPTION
Enable GPIO ports F & G (follow the pattern of H, I, J & K)

Fixes: #15918

Signed-off-by: Matthew Koch <koch.matthew@gmail.com>