### PR TITLE
Bluetooth: controller: split: Refactor the lll_clock_wait() function

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -14,25 +14,23 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
-#define DRV_NAME DT_NORDIC_NRF_CLOCK_0_LABEL "_32K"
-#define K32SRC   CLOCK_CONTROL_NRF_K32SRC
-
-static u8_t is_k32src_stable;
-
 void lll_clock_wait(void)
 {
-	if (!is_k32src_stable) {
-		struct device *clk_k32;
+	static bool done;
 
-		is_k32src_stable = 1U;
+	if (done) {
+		return;
+	}
+	done = true;
 
-		clk_k32 = device_get_binding(DRV_NAME);
-		LL_ASSERT(clk_k32);
+	struct device *lf_clock = device_get_binding(
+		DT_NORDIC_NRF_CLOCK_0_LABEL "_32K");
 
-		while (clock_control_on(clk_k32, (void *)K32SRC)) {
-			DEBUG_CPU_SLEEP(1);
-			k_cpu_idle();
-			DEBUG_CPU_SLEEP(0);
-		}
+	LL_ASSERT(lf_clock);
+
+	while (clock_control_on(lf_clock, (void *)CLOCK_CONTROL_NRF_K32SRC)) {
+		DEBUG_CPU_SLEEP(1);
+		k_cpu_idle();
+		DEBUG_CPU_SLEEP(0);
 	}
 }


### PR DESCRIPTION
This is a pure refactoring of the k32src_wait function. It used the
following rules when refactoring:

Don't use the preprocessor when unprocessed C language suffices.

Don't undefine macro's.

Avoid global variables when possible.

Use consistent names for similiar things (hf_clock, lf_clock).

Relates to #11021

Signed-off-by: Alexander Svensen <alsv@nordicsemi.no>