### PR TITLE
Bluetooth: shell: GATT: Make get command take a handle range

### DIFF
--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -901,11 +901,15 @@ static u8_t get_cb(const struct bt_gatt_attr *attr, void *user_data)
 
 static int cmd_get(const struct shell *shell, size_t argc, char *argv[])
 {
-	u16_t handle;
+	u16_t start, end;
 
-	handle = strtoul(argv[1], NULL, 16);
+	start = strtoul(argv[1], NULL, 16);
+	end = start;
 
-	bt_gatt_foreach_attr(handle, handle, get_cb, (void *)shell);
+	if (argc > 2)
+		end = strtoul(argv[2], NULL, 16);
+
+	bt_gatt_foreach_attr(start, end, get_cb, (void *)shell);
 
 	return 0;
 }
@@ -1001,7 +1005,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(gatt_cmds,
 		      cmd_write_without_rsp, 3, 2),
 	SHELL_CMD_ARG(unsubscribe, NULL, HELP_NONE, cmd_unsubscribe, 1, 0),
 #endif /* CONFIG_BT_GATT_CLIENT */
-	SHELL_CMD_ARG(get, NULL, "<handle>", cmd_get, 2, 0),
+	SHELL_CMD_ARG(get, NULL, "<start handle> [end handle]", cmd_get, 2, 1),
 	SHELL_CMD_ARG(set, NULL, "<handle> [data...]", cmd_set, 2, 255),
 	SHELL_CMD_ARG(show-db, NULL, "[uuid]", cmd_show_db, 1, 1),
 #if defined(CONFIG_BT_GATT_DYNAMIC_DB)


### PR DESCRIPTION
This enables get command to operate on a handle range so multiple
attributes values can be printed out:

uart:~$ gatt get 0x0001 0xffff
attr 0x00506600 uuid 2800 perm 0x01
00000000: 01 18
attr 0x00506600 uuid 2803 perm 0x01
00000000: 20 03 00 05 2A
attr 0x00506600 uuid 2a05 perm 0x00
attr 0x00506600 uuid 2902 perm 0x03
00000000: 00 00
attr 0x00506600 uuid 2803 perm 0x01
00000000: 0A 06 00 29 2B
attr 0x00506600 uuid 2b29 perm 0x03
00000000: 00
attr 0x00506600 uuid 2803 perm 0x01
00000000: 02 08 00 2A 2B
attr 0x00506600 uuid 2b2a perm 0x01
00000000: AA 2D 05 EB E8 1D D0 E5 F7 B9 C1 B6 3F 66 93 15
attr 0x00506600 uuid 2800 perm 0x01
00000000: 00 18
attr 0x00506600 uuid 2803 perm 0x01
00000000: 0A 0B 00 00 2A
attr 0x00506600 uuid 2a00 perm 0x09
00000000: 74 65 73 74 20 73 68 65 6C 6C
attr 0x00506600 uuid 2803 perm 0x01
00000000: 02 0D 00 01 2A
attr 0x00506600 uuid 2a01 perm 0x01
00000000: 00 00
attr 0x00506600 uuid 2803 perm 0x01
00000000: 02 0F 00 A6 2A
attr 0x00506600 uuid 2aa6 perm 0x01
00000000: 01
attr 0x00506600 uuid 2803 perm 0x01
00000000: 02 11 00 04 2A
attr 0x00506600 uuid 2a04 perm 0x01
00000000: 18 00 28 00 00 00 2A 00
attr 0x00506600 uuid 2800 perm 0x01
00000000: 0D 18
attr 0x00506600 uuid 2803 perm 0x01
00000000: 10 14 00 37 2A
attr 0x00506600 uuid 2a37 perm 0x00
attr 0x00506600 uuid 2902 perm 0x03
00000000: 00 00
attr 0x00506600 uuid 2803 perm 0x01
00000000: 02 17 00 38 2A
attr 0x00506600 uuid 2a38 perm 0x01
00000000: 00
attr 0x00506600 uuid 2803 perm 0x01
00000000: 08 19 00 39 2A
attr 0x00506600 uuid 2a39 perm 0x00

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>