### PR TITLE
arch: arm: add internal structure to ESF

### DIFF
--- a/arch/arm/core/cortex_m/exc_manage.c
+++ b/arch/arm/core/cortex_m/exc_manage.c
@@ -15,23 +15,24 @@
 #include <misc/printk.h>
 void sys_exc_esf_dump(NANO_ESF *esf)
 {
-	printk("r0/a1:  %x  ", esf->a1);
-	printk("r1/a2:  %x  ", esf->a2);
-	printk("r2/a3:  %x\n", esf->a3);
-	printk("r3/a4:  %x  ", esf->a4);
-	printk("r12/ip: %x  ", esf->ip);
-	printk("r14/lr: %x\n", esf->lr);
-	printk("r15/pc: %x  ", esf->pc);
-	printk("xpsr:   %x\n", esf->xpsr);
+	printk("r0/a1:  0x%08x  ", esf->basic.a1);
+	printk("r1/a2:  0x%08x  ", esf->basic.a2);
+	printk("r2/a3:  0x%08x\n", esf->basic.a3);
+	printk("r3/a4:  0x%08x  ", esf->basic.a4);
+	printk("r12/ip: 0x%08x  ", esf->basic.ip);
+	printk("r14/lr: 0x%08x\n", esf->basic.lr);
+	printk("r15/pc: 0x%08x  ", esf->basic.pc);
+	printk("xpsr:   0x%08x\n", esf->basic.xpsr);
 #if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING)
 	for (int i = 0; i < 16; i += 4) {
-		printk("s[%d]:  %x  s[%d]:  %x  s[%d]:  %x  s[%d]:  %x\n",
+		printk("s[%d]:  0x%08x  s[%d]:  0x%08x"
+			"  s[%d]:  0x%08x  s[%d]:  0x%08x\n",
 		       i, (u32_t)esf->s[i],
 		       i + 1, (u32_t)esf->s[i + 1],
 		       i + 2, (u32_t)esf->s[i + 2],
 		       i + 3, (u32_t)esf->s[i + 3]);
 	}
-	printk("fpscr:  %x\n", esf->fpscr);
+	printk("fpscr:  0x%08x\n", esf->fpscr);
 #endif
 }
 

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -79,7 +79,7 @@ void z_NanoFatalErrorHandler(unsigned int reason,
 	}
 	printk("Current thread ID = %p\n"
 	       "Faulting instruction address = 0x%x\n",
-	       k_current_get(), pEsf->pc);
+	       k_current_get(), pEsf->basic.pc);
 
 	/*
 	 * Now that the error has been reported, call the user implemented
@@ -94,7 +94,7 @@ void z_NanoFatalErrorHandler(unsigned int reason,
 
 void z_do_kernel_oops(const NANO_ESF *esf)
 {
-	z_NanoFatalErrorHandler(esf->r0, esf);
+	z_NanoFatalErrorHandler(esf->basic.r0, esf);
 }
 
 FUNC_NORETURN void z_arch_syscall_oops(void *ssf_ptr)
@@ -104,7 +104,7 @@ FUNC_NORETURN void z_arch_syscall_oops(void *ssf_ptr)
 
 	LOG_PANIC();
 
-	oops_esf.pc = ssf_contents[3];
+	oops_esf.basic.pc = ssf_contents[3];
 
 	z_do_kernel_oops(&oops_esf);
 	CODE_UNREACHABLE;

--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -184,8 +184,8 @@ static int MemoryFaultIsRecoverable(NANO_ESF *esf)
 		u32_t start = (u32_t)exceptions[i].start & ~0x1;
 		u32_t end = (u32_t)exceptions[i].end & ~0x1;
 
-		if (esf->pc >= start && esf->pc < end) {
-			esf->pc = (u32_t)(exceptions[i].fixup);
+		if (esf->basic.pc >= start && esf->basic.pc < end) {
+			esf->basic.pc = (u32_t)(exceptions[i].fixup);
 			return 1;
 		}
 	}

--- a/arch/arm/core/offsets/offsets.c
+++ b/arch/arm/core/offsets/offsets.c
@@ -38,14 +38,14 @@ GEN_OFFSET_SYM(_thread_arch_t, priv_stack_start);
 GEN_OFFSET_SYM(_thread_arch_t, preempt_float);
 #endif
 
-GEN_OFFSET_SYM(_esf_t, a1);
-GEN_OFFSET_SYM(_esf_t, a2);
-GEN_OFFSET_SYM(_esf_t, a3);
-GEN_OFFSET_SYM(_esf_t, a4);
-GEN_OFFSET_SYM(_esf_t, ip);
-GEN_OFFSET_SYM(_esf_t, lr);
-GEN_OFFSET_SYM(_esf_t, pc);
-GEN_OFFSET_SYM(_esf_t, xpsr);
+GEN_OFFSET_SYM(_basic_sf_t, a1);
+GEN_OFFSET_SYM(_basic_sf_t, a2);
+GEN_OFFSET_SYM(_basic_sf_t, a3);
+GEN_OFFSET_SYM(_basic_sf_t, a4);
+GEN_OFFSET_SYM(_basic_sf_t, ip);
+GEN_OFFSET_SYM(_basic_sf_t, lr);
+GEN_OFFSET_SYM(_basic_sf_t, pc);
+GEN_OFFSET_SYM(_basic_sf_t, xpsr);
 
 #if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING)
 GEN_OFFSET_SYM(_esf_t, s);

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -106,22 +106,22 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 
 #if CONFIG_USERSPACE
 	if ((options & K_USER) != 0) {
-		pInitCtx->pc = (u32_t)z_arch_user_mode_enter;
+		pInitCtx->basic.pc = (u32_t)z_arch_user_mode_enter;
 	} else {
-		pInitCtx->pc = (u32_t)z_thread_entry;
+		pInitCtx->basic.pc = (u32_t)z_thread_entry;
 	}
 #else
-	pInitCtx->pc = (u32_t)z_thread_entry;
+	pInitCtx->basic.pc = (u32_t)z_thread_entry;
 #endif
 
 	/* force ARM mode by clearing LSB of address */
-	pInitCtx->pc &= 0xfffffffe;
+	pInitCtx->basic.pc &= 0xfffffffe;
 
-	pInitCtx->a1 = (u32_t)pEntry;
-	pInitCtx->a2 = (u32_t)parameter1;
-	pInitCtx->a3 = (u32_t)parameter2;
-	pInitCtx->a4 = (u32_t)parameter3;
-	pInitCtx->xpsr =
+	pInitCtx->basic.a1 = (u32_t)pEntry;
+	pInitCtx->basic.a2 = (u32_t)parameter1;
+	pInitCtx->basic.a3 = (u32_t)parameter2;
+	pInitCtx->basic.a4 = (u32_t)parameter3;
+	pInitCtx->basic.xpsr =
 		0x01000000UL; /* clear all, thumb bit is 1, even if RO */
 #if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING)
 	pInitCtx->fpscr = (u32_t)0; /* clears FPU status/control register*/

--- a/arch/arm/include/kernel_arch_data.h
+++ b/arch/arm/include/kernel_arch_data.h
@@ -40,6 +40,7 @@ extern "C" {
 #ifndef _ASMLANGUAGE
 
 typedef struct __esf _esf_t;
+typedef struct __basic_sf _basic_sf_t;
 
 #endif /* _ASMLANGUAGE */
 

--- a/include/arch/arm/cortex_m/exc.h
+++ b/include/arch/arm/cortex_m/exc.h
@@ -45,14 +45,16 @@ GTEXT(z_ExcExit);
 #include <zephyr/types.h>
 
 struct __esf {
-	sys_define_gpr_with_alias(a1, r0);
-	sys_define_gpr_with_alias(a2, r1);
-	sys_define_gpr_with_alias(a3, r2);
-	sys_define_gpr_with_alias(a4, r3);
-	sys_define_gpr_with_alias(ip, r12);
-	sys_define_gpr_with_alias(lr, r14);
-	sys_define_gpr_with_alias(pc, r15);
-	u32_t xpsr;
+	struct __basic_sf {
+		sys_define_gpr_with_alias(a1, r0);
+		sys_define_gpr_with_alias(a2, r1);
+		sys_define_gpr_with_alias(a3, r2);
+		sys_define_gpr_with_alias(a4, r3);
+		sys_define_gpr_with_alias(ip, r12);
+		sys_define_gpr_with_alias(lr, r14);
+		sys_define_gpr_with_alias(pc, r15);
+		u32_t xpsr;
+	} basic;
 #if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING)
 	float s[16];
 	u32_t fpscr;


### PR DESCRIPTION
The ARM Cortex-M Exception Stack Frame (ESF) may consist of
several stack frame contexts (basic state context, additional
state context, FP context, etc.). To reflect this structural
properties, this commit re-factors the ESF, splitting out the
basic stack frame, holding the state context, into its own
struct container. The commit does not introduce behavioral
changes.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>