### PR TITLE
lib: posix: Switch to use zephyr_interface_library_named cmake directive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,9 +214,6 @@ if(CONFIG_MISRA_SANE)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:${CPP_MISRA_SANE_FLAG}>)
 endif()
 
-# @Intent: Set compiler specific flags for standard C includes
-toolchain_cc_nostdinc()
-
 # @Intent: Set compiler specific macro inclusion of AUTOCONF_H
 toolchain_cc_imacros(${AUTOCONF_H})
 
@@ -1497,3 +1494,8 @@ if(CONFIG_BOARD_DEPRECATED)
       removed in version ${CONFIG_BOARD_DEPRECATED}"
   )
 endif()
+
+# @Intent: Set compiler specific flags for standard C includes
+# Done at the very end, so any other system includes which may
+# be added by Zephyr components were first in list.
+toolchain_cc_nostdinc()

--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_include_directories(include)
+zephyr_system_include_directories(include)
 
 zephyr_library()
 zephyr_library_sources(

--- a/lib/posix/CMakeLists.txt
+++ b/lib/posix/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-add_library(posix_subsys INTERFACE)
+zephyr_interface_library_named(posix_subsys)
 
 target_include_directories(posix_subsys INTERFACE ${ZEPHYR_BASE}/include/posix)
 

--- a/lib/posix/CMakeLists.txt
+++ b/lib/posix/CMakeLists.txt
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-add_library(PTHREAD INTERFACE)
+add_library(posix_subsys INTERFACE)
 
-target_include_directories(PTHREAD INTERFACE ${ZEPHYR_BASE}/include/posix)
+target_include_directories(posix_subsys INTERFACE ${ZEPHYR_BASE}/include/posix)
 
 zephyr_library()
 zephyr_library_sources(pthread_common.c)
@@ -21,5 +21,5 @@ zephyr_library_sources_ifdef(CONFIG_PTHREAD_IPC pthread_key.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_MQUEUE mqueue.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_FS fs.c)
 
-zephyr_library_link_libraries(PTHREAD)
-target_link_libraries(PTHREAD INTERFACE zephyr_interface)
+zephyr_library_link_libraries(posix_subsys)
+target_link_libraries(posix_subsys INTERFACE zephyr_interface)

--- a/lib/posix/Kconfig
+++ b/lib/posix/Kconfig
@@ -96,4 +96,12 @@ config	POSIX_MAX_OPEN_FILES
 endif
 endif # FILE_SYSTEM
 
+# The name of this option is mandated by zephyr_interface_library_named
+# cmake directive.
+config APP_LINK_WITH_POSIX_SUBSYS
+        bool "Make POSIX headers available to application"
+        default y
+        help
+          Add POSIX subsystem header files to the 'app' include path.
+
 endif # POSIX_API

--- a/tests/posix/common/CMakeLists.txt
+++ b/tests/posix/common/CMakeLists.txt
@@ -4,6 +4,5 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(posix_common)
 
-target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/include/posix)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/posix/fs/CMakeLists.txt
+++ b/tests/posix/fs/CMakeLists.txt
@@ -4,7 +4,5 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(fs)
 
-target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/include/)
-
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
Similar to how other sub-libraries are defined in Zephyr tree, e.g.
"fs", "lgvl", etc. This is supposed to help with the need to
explicitly add posix include path to each and every application using
POSIX subsys.

Fixes: #15627
