### PR TITLE
Bluetooth: gatt: Fix foreach iteration of static attributes

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -979,7 +979,7 @@ void bt_gatt_foreach_attr(u16_t start_handle, u16_t end_handle,
 	struct bt_gatt_service *svc;
 	int i;
 
-	if (start_handle < last_static_handle) {
+	if (start_handle <= last_static_handle) {
 		const struct bt_gatt_service_static *static_svc;
 		u16_t handle;
 


### PR DESCRIPTION
Fix calling bt_gatt_foreach_attr with start handle parameter set
to last static attribute handle.

Fixes #15924

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>