### PR TITLE
ci: send email to builds@ mailing list if master fails

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -71,8 +71,6 @@ integrations:
       branches:
         only:
           - master
-          - net
-          - bluetooth
-          - arm
       on_success: never
-      on_failure: never
+      on_failure: always
+      on_pull_request: never


### PR DESCRIPTION
CI always runs after new PRs are merged into master. Report failures to
mailing list to get more attention if master fails to build.