### PR TITLE
tests: socket: misc: Add tests for inet_pton()

### DIFF
--- a/tests/net/socket/misc/src/main.c
+++ b/tests/net/socket/misc/src/main.c
@@ -25,12 +25,37 @@ void test_gethostname(void)
 	zassert_equal(strcmp(buf, "ztest_hostname"), 0, "");
 }
 
+void test_inet_pton(void)
+{
+	int res;
+	u8_t buf[32];
+
+	res = inet_pton(AF_INET, "127.0.0.1", buf);
+	zassert_equal(res, 1, "");
+
+	res = inet_pton(AF_INET, "127.0.0.1a", buf);
+	zassert_equal(res, 0, "");
+
+	res = inet_pton(AF_INET6, "a:b:c:d:0:1:2:3", buf);
+	zassert_equal(res, 1, "");
+
+	res = inet_pton(AF_INET6, "::1", buf);
+	zassert_equal(res, 1, "");
+
+	res = inet_pton(AF_INET6, "1::", buf);
+	zassert_equal(res, 1, "");
+
+	res = inet_pton(AF_INET6, "a:b:c:d:0:1:2:3z", buf);
+	zassert_equal(res, 0, "");
+}
+
 void test_main(void)
 {
 	k_thread_system_pool_assign(k_current_get());
 
 	ztest_test_suite(socket_misc,
-			 ztest_user_unit_test(test_gethostname));
+			 ztest_user_unit_test(test_gethostname),
+			 ztest_user_unit_test(test_inet_pton));
 
 	ztest_run_test_suite(socket_misc);
 }


### PR DESCRIPTION
Basic testcases for accepting correct input and rejecting invalid.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>