### PR TITLE
doc: fix mentions of Wi-Fi trademark name

### DIFF
--- a/boards/arm/cc3220sf_launchxl/doc/index.rst
+++ b/boards/arm/cc3220sf_launchxl/doc/index.rst
@@ -59,7 +59,7 @@ driver support.
 +-----------+------------+-----------------------+
 | I2C       | on-chip    | i2c                   |
 +-----------+------------+-----------------------+
-| SPI_0     | on-chip    | WiFi host driver      |
+| SPI_0     | on-chip    | Wi-Fi host driver     |
 +-----------+------------+-----------------------+
 
 .. note::
@@ -213,46 +213,46 @@ build target:
    :goals: debug
 
 
-WiFi Support
-************
+Wi-Fi Support
+*************
 
 The SimpleLink Host Driver, imported from the SimpleLink SDK, has been ported
 to Zephyr, and communicates over a dedicated SPI to the network co-processor.
-It is available as a Zephyr WiFi device driver in
+It is available as a Zephyr Wi-Fi device driver in
 :zephyr_file:`drivers/wifi/simplelink`.
 
 Usage:
 ======
 
 Set :option:`CONFIG_WIFI_SIMPLELINK` and :option:`CONFIG_WIFI` to ``y``
-to enable WiFi.
+to enable Wi-Fi.
 See :zephyr_file:`samples/net/wifi/boards/cc3220sf_launchxl.conf`.
 
 Provisioning:
 =============
 
-SimpleLink provides a few rather sophisticated WiFi provisioning methods.
+SimpleLink provides a few rather sophisticated Wi-Fi provisioning methods.
 To keep it simple for Zephyr development and demos, the SimpleLink
 "Fast Connect" policy is enabled, with one-shot scanning.
 This enables the cc3220sf_launchxl to automatically reconnect to the last
 good known access point (AP), without having to restart a scan, and
 re-specify the SSID and password.
 
-To connect to an AP, first run the Zephyr WiFi shell sample application,
+To connect to an AP, first run the Zephyr Wi-Fi shell sample application,
 and connect to a known AP with SSID and password.
 
 See :ref:`wifi_sample`
 
 Once the connection succeeds, the network co-processor keeps the AP identity in
-its persistent memory.  Newly loaded WiFi applications then need not explicitly
-execute any WiFi scan or connect operations, until the need to change to a new AP.
+its persistent memory.  Newly loaded Wi-Fi applications then need not explicitly
+execute any Wi-Fi scan or connect operations, until the need to change to a new AP.
 
 Secure Socket Offload
 *********************
 
-The SimpleLink WiFi driver provides socket operations to the Zephyr socket
+The SimpleLink Wi-Fi driver provides socket operations to the Zephyr socket
 offload point, enabling Zephyr BSD socket API calls to be directed to the
-SimpleLink WiFi driver, by setting :option:`CONFIG_NET_SOCKETS_OFFLOAD`
+SimpleLink Wi-Fi driver, by setting :option:`CONFIG_NET_SOCKETS_OFFLOAD`
 to ``y``.
 
 Secure socket (TLS) communication is handled as part of the socket APIs,
@@ -268,7 +268,7 @@ See :ref:`sockets-http-get` and
 :zephyr_file:`samples/net/sockets/http_get/boards/cc3220sf_launchxl.conf` for an
 example.
 
-See the document `Simplelink WiFi Certificates Handling`_ for details on
+See the document `Simplelink Wi-Fi Certificates Handling`_ for details on
 using the TI UniFlash tool for certificate programming.
 
 Limitations
@@ -276,11 +276,11 @@ Limitations
 The following features are not supported in Zephyr v1.14:
 
 - IPv6: While the hardware supports it, it has yet to be fully implemented
-  in the SimpleLink WiFi driver.
+  in the SimpleLink Wi-Fi driver.
 - static IP address: It is not currently possible to set
   :option:`CONFIG_NET_CONFIG_SETTINGS` to ``y`` and assign a static IP
   address to the device via :option:`CONFIG_NET_CONFIG_MY_IPV4_ADDR`. DHCP
-  is automatically handled by the SimpleLink WiFi driver to obtain an
+  is automatically handled by the SimpleLink Wi-Fi driver to obtain an
   address dynamically.
 
 References
@@ -313,5 +313,5 @@ CC32xx Wiki:
 ..  _XDS-110 emulation package:
    http://processors.wiki.ti.com/index.php/XDS_Emulation_Software_Package#XDS_Emulation_Software_.28emupack.29_Download
 
-..  _Simplelink WiFi Certificates Handling:
+..  _Simplelink Wi-Fi Certificates Handling:
    http://www.ti.com/lit/pdf/swpu332

--- a/boards/arm/warp7_m4/doc/index.rst
+++ b/boards/arm/warp7_m4/doc/index.rst
@@ -58,7 +58,7 @@ WaRP7 CPU Board
 
   - Board to board connector (34 configurable pins)
   - Micro USB 2.0 OTG connector (USB_OTG1 interface)
-  - Murata Type 1DX Wifi IEEE 802.11b/g/n and Bluetooth 4.1 plus EDR
+  - Murata Type 1DX Wi-Fi IEEE 802.11b/g/n and Bluetooth 4.1 plus EDR
     (SD1, UART3 SAI2 interfaces)
 - Li-ion/Li-polymer Battery Charger: NXP BC3770 (I2C1 interface)
 - Power management integrated circuit (PMIC): NXP PF3000 (I2C1 interface)

--- a/doc/guides/networking/overview.rst
+++ b/doc/guides/networking/overview.rst
@@ -145,7 +145,7 @@ The networking stack source code tree is organized as follows:
 
 ``subsys/net/l2/``
   This is where the IP stack layer 2 code is located. This includes generic
-  support for Bluetooth IPSP adaptation, Ethernet, IEEE 802.15.4 and WiFI.
+  support for Bluetooth IPSP adaptation, Ethernet, IEEE 802.15.4 and Wi-Fi.
 
 ``subsys/net/lib/``
   Application-level protocols (DNS, MQTT, etc.) and additional stack

--- a/doc/guides/networking/qemu_setup.rst
+++ b/doc/guides/networking/qemu_setup.rst
@@ -133,7 +133,7 @@ any daemons or helpers started in the initial steps, to avoid possible
 networking or routing problems such as address conflicts in local
 network interfaces. For example, stop them if you switch from testing
 networking with QEMU to using real hardware, or to return your host
-laptop to normal WiFi use.
+laptop to normal Wi-Fi use.
 
 To stop the daemons, press Ctrl+C in the corresponding terminal windows
 (you need to stop both ``loop-slip-tap.sh`` and ``loop-socat.sh``).

--- a/doc/guides/porting/board_porting.rst
+++ b/doc/guides/porting/board_porting.rst
@@ -139,7 +139,7 @@ guidelines should be followed when porting a board:
 
 - Provide pin and driver configuration that matches the board's valuable
   components such as sensors, buttons or LEDs, and communication interfaces
-  such as USB, Ethernet connector, or Bluetooth/WiFi chip.
+  such as USB, Ethernet connector, or Bluetooth/Wi-Fi chip.
 
 - When a well-known connector is present (such as used on an Arduino or
   96board), configure pins to fit this connector.

--- a/doc/reference/kernel/index.rst
+++ b/doc/reference/kernel/index.rst
@@ -17,7 +17,7 @@ Examples of such systems include: embedded sensor hubs, environmental sensors,
 simple LED wearable, and store inventory tags.
 
 Applications requiring more memory (50 to 900 KB), multiple communication
-devices (like WiFi and Bluetooth Low Energy), and complex multi-threading,
+devices (like Wi-Fi and Bluetooth Low Energy), and complex multi-threading,
 can also be developed using the Zephyr kernel. Examples of such systems
 include: fitness wearables, smart watches, and IoT wireless gateways.
 

--- a/doc/reference/networking/net_l2.rst
+++ b/doc/reference/networking/net_l2.rst
@@ -26,7 +26,7 @@ specific for that device, and optimized for working together.
 Currently, there are L2 layers for :ref:`Ethernet <ethernet_interface>`,
 :ref:`IEEE 802.15.4 Soft-MAC <ieee802154_interface>`,
 :ref:`Bluetooth IPSP <bluetooth-ipsp-sample>`, :ref:`CANBUS <can_interface>`,
-:ref:`OpenThread <thread_protocol_interface>`, WiFi, and a dummy layer
+:ref:`OpenThread <thread_protocol_interface>`, Wi-Fi, and a dummy layer
 example that can be used as a template for writing a new one.
 
 L2 layer API

--- a/doc/reference/networking/net_mgmt.rst
+++ b/doc/reference/networking/net_mgmt.rst
@@ -14,7 +14,7 @@ The Network Management APIs allow applications, as well as network
 layer code itself, to call defined network routines at any level in
 the IP stack, or receive notifications on relevant network events. For
 example, by using these APIs, code can request a scan be done on a
-WiFi- or Bluetooth-based network interface, or request notification if
+Wi-Fi- or Bluetooth-based network interface, or request notification if
 a network interface IP address changes.
 
 The Network Management API implementation is designed to save memory

--- a/drivers/wifi/Kconfig
+++ b/drivers/wifi/Kconfig
@@ -7,30 +7,30 @@
 #
 
 menuconfig WIFI
-	bool "add support for WiFi Drivers"
+	bool "add support for Wi-Fi Drivers"
 
 if WIFI
 
 module = WIFI
 module-dep = LOG
-module-str = Log level for WiFi driver
-module-help = Sets log level for WiFi Device Drivers.
+module-str = Log level for Wi-Fi driver
+module-help = Sets log level for Wi-Fi Device Drivers.
 source "subsys/net/Kconfig.template.log_config.net"
 
 config WIFI_INIT_PRIORITY
-	int "WiFi driver init priority"
+	int "Wi-Fi driver init priority"
 	default 80
 	help
-	  WiFi device driver initialization priority.
+	  Wi-Fi device driver initialization priority.
 	  Do not mess with it unless you know what you are doing.
 	  Note that the priority needs to be lower than the net stack
 	  so that it can start before the networking sub-system.
 
 config WIFI_OFFLOAD
-	bool "Support offloaded WiFi device drivers"
+	bool "Support offloaded Wi-Fi device drivers"
 	select NET_OFFLOAD
 	help
-	  Enable support for Full-MAC WiFi devices.
+	  Enable support for Full-MAC Wi-Fi devices.
 
 source "drivers/wifi/winc1500/Kconfig.winc1500"
 source "drivers/wifi/simplelink/Kconfig.simplelink"

--- a/drivers/wifi/simplelink/Kconfig.simplelink
+++ b/drivers/wifi/simplelink/Kconfig.simplelink
@@ -7,7 +7,7 @@
 #
 
 menuconfig WIFI_SIMPLELINK
-	bool "SimpleLink WiFi driver support"
+	bool "SimpleLink Wi-Fi driver support"
 	select SIMPLELINK_HOST_DRIVER
 	select WIFI_OFFLOAD
 	select NET_L2_WIFI_MGMT
@@ -31,7 +31,7 @@ config WIFI_SIMPLELINK_SCAN_COUNT
 	int "Number of entries in network scan table: Max: 30"
 	default 20
 	help
-	 The number of results to request on a wifi scan operation.
+	 The number of results to request on a Wi-Fi scan operation.
 	 Actual number returned may be less.  Maximum is 30.
 
 config WIFI_SIMPLELINK_MAX_SCAN_RETRIES
@@ -46,7 +46,7 @@ config WIFI_SIMPLELINK_FAST_CONNECT_TIMEOUT
 	default 7
 	help
 	 SimpleLink uses the "FastConnect" feature to reconnect to the
-	 previously connected AP on startup. Should the WiFi connection
+	 previously connected AP on startup. Should the Wi-Fi connection
 	 timeout, the SimpleLink driver will fail to initialize,
 	 and LOG an error.
 

--- a/samples/net/sockets/echo/README.rst
+++ b/samples/net/sockets/echo/README.rst
@@ -82,7 +82,7 @@ Running on cc3220sf_launchxl
 
 See the note on Provisioning and Fast Connect in :ref:`cc3220sf_launchxl`.
 
-After having connected to an Access Point using the sample WiFi shell,
+After having connected to an Access Point using the sample Wi-Fi shell,
 the IP address will be printed to the console upon running this echo
 application.
 

--- a/subsys/net/l2/Kconfig
+++ b/subsys/net/l2/Kconfig
@@ -76,26 +76,26 @@ source "subsys/net/l2/ieee802154/Kconfig"
 source "subsys/net/l2/openthread/Kconfig"
 
 config NET_L2_WIFI_MGMT
-	bool "Enable WiFi Management support"
+	bool "Enable Wi-Fi Management support"
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	select NET_MGMT_EVENT_INFO
 	help
-	Add support for WiFi Management interface.
+	Add support for Wi-Fi Management interface.
 
 if NET_L2_WIFI_MGMT
 module = NET_L2_WIFI_MGMT
 module-dep = NET_LOG
-module-str = Log level for WiFi management layer
-module-help = Enables WiFi management interface to output debug messages.
+module-str = Log level for Wi-Fi management layer
+module-help = Enables Wi-Fi management interface to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 endif # NET_L2_WIFI_MGMT
 
 config NET_L2_WIFI_SHELL
-	bool "Enable WiFi shell module"
+	bool "Enable Wi-Fi shell module"
 	select NET_L2_WIFI_MGMT
 	help
-	  This can be used for controlling WiFi through the console via
+	  This can be used for controlling Wi-Fi through the console via
 	  exposing a shell module named "wifi".
 
 config NET_L2_CANBUS


### PR DESCRIPTION
The approved trademark name is Wi-Fi so update references to WiFi and
other spellings to Wi-Fi in documentation and Kconfig help strings.
(Note that uses of spelling variations of "wifi" in module names, CONFIG
names, link names and such are untouched.)

https://www.wi-fi.org/

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>