### PR TITLE
kernel: fix k_stack_alloc_init()

### DIFF
--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -63,7 +63,7 @@ s32_t z_impl_k_stack_alloc_init(struct k_stack *stack, u32_t num_entries)
 	void *buffer;
 	s32_t ret;
 
-	buffer = z_thread_malloc(num_entries);
+	buffer = z_thread_malloc(num_entries * sizeof(u32_t));
 	if (buffer != NULL) {
 		k_stack_init(stack, buffer, num_entries);
 		stack->flags = K_STACK_FLAG_ALLOC;


### PR DESCRIPTION
k_stack_alloc_init() was creating a buffer that was 4 times
too small to support the requested number of entries, since
each entry in a k_stack is a u32_t.

Fixes: #15911

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>