### PR TITLE
board: nucleo_f429zi: add partitions to support mcuboot

### DIFF
--- a/boards/arm/nucleo_f429zi/doc/index.rst
+++ b/boards/arm/nucleo_f429zi/doc/index.rst
@@ -182,6 +182,22 @@ Programming and Debugging
 The Nucleo F429ZI board includes an ST-LINK/V2-1 embedded debug tool interface.
 This interface is supported by the openocd version included in Zephyr SDK.
 
+Flash partitions for MCUBoot bootloader
+***************************************
+
+The on-board STM32F429ZI MCU has 2MBs of internal flash memory. To use `MCUboot`_,
+define a :ref:`Zephyr partition table <flash_partitions>` for the flash memory in
+its device tree file ``nucleo_f429zi.dts``. As a reference, a partition table for
+MCUBoot is already defined in the device tree file, with these settings:
+
+- `MCUBoot`_ bootloader partition takes 64K bytes.
+- Zephyr settings partition takes 64K bytes.
+- Application image takes 256K bytes in Slot 0 partition.
+- Updating image takes another 256K bytes in Slot 1 partition.
+- A scratch partition with 128K is required for image swap.
+
+A specific application can adjust each partition size based on its needs.
+
 
 .. _Nucleo F429ZI website:
    http://www.st.com/en/evaluation-tools/nucleo-f429zi.html
@@ -197,3 +213,6 @@ This interface is supported by the openocd version included in Zephyr SDK.
 
 .. _STM32F429 datasheet:
    http://www.st.com/resource/en/datasheet/DM00071990.pdf
+
+.. _MCUBoot:
+   https://github.com/JuulLabs-OSS/mcuboot/blob/master/README.md

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,ccm = &ccm0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {
@@ -95,4 +96,48 @@ arduino_serial: &usart6 {};
 
 &iwdg {
 	status = "ok";
+};
+
+&flash0 {
+	/*
+	 * For more information, see:
+	 * http://docs.zephyrproject.org/devices/dts/flash_partitions.html
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* 64KB for bootloader */
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x00010000>;
+			read-only;
+		};
+
+		/* storage: 64KB for settings */
+		storage_partition: partition@10000 {
+			label = "storage";
+			reg = <0x00010000 0x00010000>;
+		};
+
+		/* application image slot: 256KB */
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 0x00040000>;
+		};
+
+		/* backup slot: 256KB */
+		slot1_partition: partition@60000 {
+			label = "image-1";
+			reg = <0x00060000 0x00040000>;
+		};
+
+		/* swap slot: 128KB */
+		scratch_partition: partition@a0000 {
+			label = "image-scratch";
+			reg = <0x000a0000 0x00020000>;
+		};
+
+	};
 };


### PR DESCRIPTION
Add partition table to support MCUBoot.

Signed-off-by: Jun Li <jun.r.li@intel.com>