### PR TITLE
dts: riscv32: rv32m1: fix reg value for cpu@1

### DIFF
--- a/dts/riscv32/rv32m1.dtsi
+++ b/dts/riscv32/rv32m1.dtsi
@@ -46,7 +46,7 @@
 		cpu@1 {
 			device_type = "cpu";
 			compatible = "riscv";
-			reg = <0>;
+			reg = <1>;
 		};
 	};
 


### PR DESCRIPTION
@nashif @MaureenHelm

The second cpu core has to have reg = <1>.

See, for example, dts/xtensa/esp32.dtsi.
