### PR TITLE
CODEOWNERS: Add joerchan and remove sjanc for Bluetooth host paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -92,15 +92,15 @@
 /doc/guides/coccinelle.rst                @himanshujha199640 @JuliaLawall
 /doc/CMakeLists.txt                       @carlescufi
 /doc/scripts/                             @carlescufi
-/doc/guides/bluetooth/                    @sjanc @jhedberg @Vudentz
-/doc/reference/bluetooth/                 @sjanc @jhedberg @Vudentz
+/doc/guides/bluetooth/                    @joerchan @jhedberg @Vudentz
+/doc/reference/bluetooth/                 @joerchan @jhedberg @Vudentz
 /drivers/*/*cc13xx_cc26xx*                @bwitherspoon
 /drivers/*/*mcux*                         @MaureenHelm
 /drivers/*/*qmsi*                         @nashif
 /drivers/*/*stm32*                        @erwango
 /drivers/*/*native_posix*                 @aescolar
 /drivers/adc/                             @anangl
-/drivers/bluetooth/                       @sjanc @jhedberg @Vudentz
+/drivers/bluetooth/                       @joerchan @jhedberg @Vudentz
 /drivers/can/                             @alexanderwachter
 /drivers/can/*mcp2515*                    @karstenkoenig
 /drivers/clock_control/*stm32f4*          @rsalveti @idlethread
@@ -186,14 +186,14 @@
 /include/arch/x86/arch.h                  @andrewboie
 /include/arch/xtensa/                     @andrewboie
 /include/atomic.h                         @andrewboie @andyross
-/include/bluetooth/                       @sjanc @jhedberg @Vudentz
+/include/bluetooth/                       @joerchan @jhedberg @Vudentz
 /include/cache.h                          @andrewboie @andyross
 /include/can.h                            @alexanderwachter
 /include/counter.h                        @nordic-krch
 /include/device.h                         @wentongwu @nashif
 /include/display.h                        @vanwinkeljan
 /include/display/                         @vanwinkeljan
-/include/drivers/bluetooth/               @sjanc @jhedberg @Vudentz
+/include/drivers/bluetooth/               @joerchan @jhedberg @Vudentz
 /include/drivers/modem/                   @mike-scott
 /include/drivers/ioapic.h                 @andrewboie
 /include/drivers/loapic.h                 @andrewboie
@@ -239,7 +239,7 @@
 /kernel/idle.c                            @andrewboie @andyross @nashif
 /samples/                                 @nashif
 /samples/basic/servo_motor/*microbit*     @jhe
-/samples/bluetooth/                       @sjanc @jhedberg @Vudentz
+/samples/bluetooth/                       @joerchan @jhedberg @Vudentz
 /samples/boards/intel_s1000_crb/          @sathishkuttan @dcpleung @nashif
 /samples/display/                         @vanwinkeljan
 /samples/drivers/CAN/                     @alexanderwachter
@@ -274,7 +274,7 @@
 /scripts/west_commands/                   @mbolivar
 /scripts/west-commands.yml                @mbolivar
 /scripts/zephyr_module.py                 @tejlmand
-/subsys/bluetooth/                        @sjanc @jhedberg @Vudentz
+/subsys/bluetooth/                        @joerchan @jhedberg @Vudentz
 /subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot
 /subsys/fs/                               @nashif
 /subsys/fs/fcb/                           @nvlsianpu
@@ -300,7 +300,7 @@
 /tests/                                   @nashif
 /tests/boards/native_posix/               @aescolar
 /tests/boards/intel_s1000_crb/            @dcpleung @sathishkuttan
-/tests/bluetooth/                         @sjanc @jhedberg @Vudentz
+/tests/bluetooth/                         @joerchan @jhedberg @Vudentz
 /tests/posix/                             @pfalcon
 /tests/crypto/                            @ceolin
 /tests/crypto/mbedtls/                    @nashif @ceolin


### PR DESCRIPTION
Szymon is no longer actively looking at Bluetooth code, whereas Joakim
from Nordic has been assigned for Bluetooth host support.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>