### PR TITLE
Bluetooth: controller: Fix Enc Setup overlap with Length Update

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -9345,7 +9345,16 @@ static bool is_enc_req_pause_tx(struct connection *conn)
 				if (!conn->pkt_tx_last) {
 					conn->pkt_tx_last = node_tx;
 				}
+
+				/* Head now contains a control packet permitted
+				 * to be transmitted to peer.
+				 */
+				return false;
 			}
+
+			/* Head contains ENC_REQ packet deferred due to another
+			 * control procedure in progress.
+			 */
 			return true;
 		}
 
@@ -9355,6 +9364,7 @@ static bool is_enc_req_pause_tx(struct connection *conn)
 		conn->llcp_ack--;
 	}
 
+	/* Head contains a permitted data or control packet. */
 	return false;
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC */
@@ -9363,6 +9373,7 @@ static void prepare_pdu_data_tx(struct connection *conn,
 				struct pdu_data **pdu_data_tx)
 {
 	struct pdu_data *_pdu_data_tx;
+	bool pause_tx = false;
 
 	if (/* empty packet */
 	    conn->empty ||
@@ -9370,14 +9381,17 @@ static void prepare_pdu_data_tx(struct connection *conn,
 	    !conn->pkt_tx_head ||
 	    /* data tx paused, only control packets allowed */
 	    ((
-#if defined(CONFIG_BT_CTLR_LE_ENC)
-	      conn->pause_tx ||
-	      is_enc_req_pause_tx(conn) ||
-#endif /* CONFIG_BT_CTLR_LE_ENC */
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	      conn->llcp_length.pause_tx ||
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
-	      0) && (conn->pkt_tx_head != conn->pkt_tx_ctrl))) {
+#if defined(CONFIG_BT_CTLR_LE_ENC)
+	      conn->pause_tx ||
+	      /* Encryption setup queued */
+	      (pause_tx = is_enc_req_pause_tx(conn)) ||
+#endif /* CONFIG_BT_CTLR_LE_ENC */
+	      0) &&
+	    /* Encryption setup queued or data paused */
+	    (pause_tx || (conn->pkt_tx_head != conn->pkt_tx_ctrl)))) {
 			_pdu_data_tx = empty_tx_enqueue(conn);
 	} else {
 		u16_t max_tx_octets;


### PR DESCRIPTION
Fix the encryption setup queueing implementation to avoid
overlapping with local initiated Length Update Procedure.

Fixes #15733.
Relates to #15335, and #15186.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>