### PR TITLE
west: Fix unused import and variable

### DIFF
--- a/scripts/west_commands/zcmake.py
+++ b/scripts/west_commands/zcmake.py
@@ -57,7 +57,7 @@ def run_cmake(args, cwd=None, capture_output=False, dry_run=False):
 
     log.dbg('Running CMake:', quote_sh_list(cmd), level=log.VERBOSE_NORMAL)
     p = subprocess.Popen(cmd, **kwargs)
-    out, err = p.communicate()
+    out, _ = p.communicate()
     if p.returncode == 0:
         if out:
             return out.decode(sys.getdefaultencoding()).splitlines()

--- a/scripts/west_commands/zephyr_ext_common.py
+++ b/scripts/west_commands/zephyr_ext_common.py
@@ -8,8 +8,6 @@ Note that common helpers used by the flash and debug extension
 commands are in run_common -- that's for common code used by
 commands which specifically execute runners.'''
 
-import os
-
 from west import log
 from west.commands import WestCommand
 


### PR DESCRIPTION
Making a clean slate for a pylint test in CI.

'_' is a common name for non-problematic unused variables in Python.
pylint knows not to flag it.