### PR TITLE
cmake: Toolchain abstraction: move PROPERTY_LINKER_SCRIPT_DEFINES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,6 @@ set(KOBJ_TYPES_H_TARGET        kobj_types_h_target)
 set(LINKER_SCRIPT_TARGET       linker_script_target)
 
 
-if(NOT PROPERTY_LINKER_SCRIPT_DEFINES)
-  set_property(GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__GCC_LINKER_CMD__)
-endif()
-
 define_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT BRIEF_DOCS " " FULL_DOCS " ")
 set_property(   GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-little${ARCH}) # BFD format
 

--- a/cmake/linker/ld/target_base.cmake
+++ b/cmake/linker/ld/target_base.cmake
@@ -4,6 +4,10 @@
 
 macro(toolchain_ld_base)
 
+  if(NOT PROPERTY_LINKER_SCRIPT_DEFINES)
+    set_property(GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__GCC_LINKER_CMD__)
+  endif()
+
   # TOOLCHAIN_LD_FLAGS comes from compiler/gcc/target.cmake
   # LINKERFLAGPREFIX comes from linker/ld/target.cmake
   zephyr_ld_options(


### PR DESCRIPTION
Move `PROPERTY_LINKER_SCRIPT_DEFINES`'s default value of `__GCC_LINKER_CMD__` to `toolchain_ld_base`.

No functional change expected.

This is motivated by the wish to abstract Zephyr's usage of toolchains,
permitting non-intrusive porting to other (commercial) toolchains.

Signed-off-by: Mark Ruvald Pedersen <mped@oticon.com>

-------------

Part of #16031