### PR TITLE
Bluetooth: Mesh: Fix RPL storage timeout handling

### DIFF
--- a/subsys/bluetooth/host/mesh/net.h
+++ b/subsys/bluetooth/host/mesh/net.h
@@ -200,7 +200,7 @@ enum {
 	BT_MESH_IVU_TEST,        /* IV Update test mode */
 	BT_MESH_IVU_PENDING,     /* Update blocked by SDU in progress */
 
-	/* pending storage actions */
+	/* pending storage actions, must reside within first 32 flags */
 	BT_MESH_RPL_PENDING,
 	BT_MESH_KEYS_PENDING,
 	BT_MESH_NET_PENDING,

--- a/subsys/bluetooth/host/mesh/settings.c
+++ b/subsys/bluetooth/host/mesh/settings.c
@@ -821,7 +821,7 @@ BT_SETTINGS_DEFINE(mesh, mesh_set, mesh_commit, NULL);
 
 static void schedule_store(int flag)
 {
-	s32_t timeout;
+	s32_t timeout, remaining;
 
 	atomic_set_bit(bt_mesh.flags, flag);
 
@@ -834,6 +834,12 @@ static void schedule_store(int flag)
 		timeout = K_SECONDS(CONFIG_BT_MESH_RPL_STORE_TIMEOUT);
 	} else {
 		timeout = K_SECONDS(CONFIG_BT_MESH_STORE_TIMEOUT);
+	}
+
+	remaining = k_delayed_work_remaining_get(&pending_store);
+	if (remaining && remaining < timeout) {
+		BT_DBG("Not rescheduling due to existing earlier deadline");
+		return;
 	}
 
 	BT_DBG("Waiting %d seconds", timeout / MSEC_PER_SEC);


### PR DESCRIPTION
The default values for the timeouts, as well as non-defaults in most
Mesh samples, use a higher value for the RPL than then generic mesh
storage timeout. This hasn't had any effect in practice since the code
only uses the RPL timeout if it is *smaller* than the generic one.

The original intention of the code was to use the RPL timeout,
regardless of what the generic one is, whenever the RPL is the only
thing that needs updating. Add some helper macros to track the various
groups of pending flags, and perform the appropriate checks to apply
the RPL timeout whenever it's smaller than the generic timeout, or if
there are no other items to store besides the RPL.

Fixes #15904

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>