### PR TITLE
api: dma: fix issue of non-implemented reload

### DIFF
--- a/include/dma.h
+++ b/include/dma.h
@@ -220,7 +220,11 @@ static inline int dma_reload(struct device *dev, u32_t channel,
 	const struct dma_driver_api *api =
 		(const struct dma_driver_api *)dev->driver_api;
 
-	return api->reload(dev, channel, src, dst, size);
+	if (api->reload) {
+		return api->reload(dev, channel, src, dst, size);
+	}
+
+	return -ENOSYS;
 }
 
 /**


### PR DESCRIPTION
reload function is not implemented by every DMA driver.
So, add api's NULL check to make sure it is protected if not
implemented.

Signed-off-by: Jun Li <jun.r.li@intel.com>