### PR TITLE
west.yml: add ci-tools project / repository

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,6 +38,8 @@ manifest:
     - name: tinycbor
       path: modules/lib/tinycbor
       revision: 111f7a215cc4efa49fd03a7835719adca83b4388
+    - name: ci-tools
+      revision: master
 
   self:
     path: zephyr


### PR DESCRIPTION
Should make check_compliance.py more popular by removing the steps to
find and clone it and save round-trips to Continous Integration.

Since commit [14e34431dccb](https://github.com/zephyrproject-rtos/ci-tools/commit/14e34431dccb5397) each check prints which repo it is checking
which makes this ready to be thrown into a multi-repo world.

revision=master because it's completely optional and cannot break
local builds even if CI is utterly broken.

While check_compliance.py runs only on Linux for now, in the
context of (unrelated) [PR #54](https://github.com/zephyrproject-rtos/ci-tools/pull/54) I managed to run the Codeowners check
on Windows with a small number of hacks so Windows portability
doesn't seem far away.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>