### PR TITLE
CODEOWNERS: remove use of commas

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -156,7 +156,7 @@
 /dts/riscv32/rv32m1*                      @MaureenHelm
 /dts/bindings/                            @galak
 /dts/bindings/can/                        @alexanderwachter
-/dts/bindings/iio/adc/st,stm32-adc.yaml   @cybertale
+/dts/bindings/iio/adc/st*stm32-adc.yaml   @cybertale
 /dts/bindings/serial/ns16550.yaml         @gnuless
 /dts/bindings/*/nordic*                   @anangl
 /dts/bindings/*/nxp*                      @MaureenHelm


### PR DESCRIPTION
Commas are not allowed in this file and prevent parsing by github

Error introduced in
7c7db00a7759a44bbca414d5d1e943f211483190

Fixes #15998

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>