### PR TITLE
Bluetooth: controller: split: Fix Conn Param Req procedure stall issue

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2752,6 +2752,11 @@ static inline void event_phy_req_prep(struct ll_conn *conn)
 
 	case LLCP_PHY_STATE_UPD:
 	{
+		/* Defer if another procedure in progress */
+		if (conn->llcp_ack != conn->llcp_req) {
+			return;
+		}
+
 		/* Procedure complete */
 		conn->llcp_phy.ack = conn->llcp_phy.req;
 


### PR DESCRIPTION
Fix an issue wherein local or remote initiated Connection
Parameter Request procedure would stall without generation
of LE Connection Update Complete HCI event because a local
or remote initiated PHY Update procedure has overwritten the
currently active Link Layer Control Procedure type.

Related to #12139

Signed-off-by: Alexander Svensen <alsv@nordicsemi.no>