### PR TITLE
boards: enable i2c on the SAM R21 Xplained Pro board

### DIFF
--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -49,6 +49,13 @@
 	txpo = <0>;
 };
 
+&sercom1 {
+	status = "ok";
+	compatible = "atmel,sam0-i2c";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	label = "I2C_0";
+};
+
 &sercom5 {
 	status = "ok";
 	compatible = "atmel,sam0-spi";

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.yaml
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.yaml
@@ -13,4 +13,5 @@ toolchain:
 supported:
   - gpio
   - spi
+  - i2c
   - usb_device

--- a/boards/arm/atsamr21_xpro/doc/index.rst
+++ b/boards/arm/atsamr21_xpro/doc/index.rst
@@ -49,6 +49,8 @@ features:
 +-----------+------------+--------------------------------------+
 | SPI       | on-chip    | Serial Peripheral Interface ports    |
 +-----------+------------+--------------------------------------+
+| I2C       | on-chip    | I2C Peripheral Interface ports       |
++-----------+------------+--------------------------------------+
 
 Other hardware features are not currently supported by Zephyr.
 
@@ -73,6 +75,8 @@ Default Zephyr Peripheral Mapping:
 ----------------------------------
 - SERCOM0 USART TX : PA5
 - SERCOM0 USART RX : PA4
+- SERCOM1 I2C SDA  : PA16
+- SERCOM1 I2C SCL  : PA17
 - SERCOM5 SPI MISO : PB02
 - SERCOM5 SPI MOSI : PB22
 - SERCOM5 SPI SCK  : PB23
@@ -108,6 +112,7 @@ time, the internal pull-up resistors are not sufficient for stable bus
 operation. You probably have to connect external pull-ups to both bus lines. 10K
 is a good value to start with.
 
+- SERCOM1 is exposed via Xplained Pro Standard Extension Header
 
 Radio
 =====

--- a/boards/arm/atsamr21_xpro/pinmux.c
+++ b/boards/arm/atsamr21_xpro/pinmux.c
@@ -59,6 +59,27 @@ static int board_pinmux_init(struct device *dev)
 	pinmux_pin_set(muxb, 23, PINMUX_FUNC_D);
 #endif
 
+#if DT_ATMEL_SAM0_I2C_SERCOM_0_BASE_ADDRESS
+#error Pin mapping is not configured
+#endif
+#if DT_ATMEL_SAM0_I2C_SERCOM_1_BASE_ADDRESS
+	/* SERCOM1 on SDA=PA16, SCL=PA17 */
+	pinmux_pin_set(muxa, 16, PINMUX_FUNC_C);
+	pinmux_pin_set(muxa, 17, PINMUX_FUNC_C);
+#endif
+#if DT_ATMEL_SAM0_I2C_SERCOM_2_BASE_ADDRESS
+#error Pin mapping is not configured
+#endif
+#if DT_ATMEL_SAM0_I2C_SERCOM_3_BASE_ADDRESS
+#error Pin mapping is not configured
+#endif
+#if DT_ATMEL_SAM0_I2C_SERCOM_4_BASE_ADDRESS
+#error Pin mapping is not configured
+#endif
+#if DT_ATMEL_SAM0_I2C_SERCOM_5_BASE_ADDRESS
+#error Pin mapping is not configured
+#endif
+
 #ifdef CONFIG_USB_DC_SAM0
 	/* USB DP on PA25, USB DM on PA24 */
 	pinmux_pin_set(muxa, 25, PINMUX_FUNC_G);


### PR DESCRIPTION
Now that I2C support was merged, we can hook up SERCOM1 to I2C. It is connected to the EXT3 header and the EDBG embedded debugging interface.