### PR TITLE
Bluetooth: controller: split: Fix master role RSSI measurement

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -392,10 +392,10 @@ void lll_conn_isr_tx(void *param)
 	radio_tmr_hcto_configure(hcto);
 
 #if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_CTLR_CONN_RSSI)
-	if (!lll->role) {
+	if (!trx_cnt && !lll->role) {
 		radio_rssi_measure();
 	}
-#endif /* iCONFIG_BT_CENTRAL && CONFIG_BT_CTLR_CONN_RSSI */
+#endif /* CONFIG_BT_CENTRAL && CONFIG_BT_CTLR_CONN_RSSI */
 
 #if defined(CONFIG_BT_CTLR_PROFILE_ISR) || \
 	defined(CONFIG_BT_CTLR_GPIO_PA_PIN)


### PR DESCRIPTION
Fix broken master role RSSI measurement. Since the original
contribution clean up into Zephyr, the radio shorts that was
set for measuring the RSSI for master role has been broken,
as it was cleared by the radio switching code further in the
Tx ISR.

Related to: #10566

Signed-off-by: Alexander Svensen <alsv@nordicsemi.no>