### PR TITLE
posix: unistd.h: Add gethostname()

### DIFF
--- a/include/posix/unistd.h
+++ b/include/posix/unistd.h
@@ -12,6 +12,10 @@ extern "C" {
 
 #include "posix_types.h"
 #include "sys/stat.h"
+#ifdef CONFIG_NETWORKING
+/* For zsock_gethostname() */
+#include "net/socket.h"
+#endif
 
 #ifdef CONFIG_POSIX_API
 #include <fs.h>
@@ -32,6 +36,13 @@ extern int mkdir(const char *path, mode_t mode);
 
 unsigned sleep(unsigned int seconds);
 int usleep(useconds_t useconds);
+
+#ifdef CONFIG_NETWORKING
+static inline int gethostname(char *buf, size_t len)
+{
+	return zsock_gethostname(buf, len);
+}
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Per POSIX, gethostname() is declared in unistd.h.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>