### PR TITLE
drivers: adxl362: use Kconfig for interrupt mode

### DIFF
--- a/drivers/sensor/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adxl362/adxl362_trigger.c
@@ -152,8 +152,7 @@ int adxl362_init_interrupt(struct device *dev)
 		return -EINVAL;
 	}
 
-	/* Configures the inactivity and activity interrupts to be linked. */
-	ret = adxl362_set_interrupt_mode(dev, ADXL362_MODE_LINK);
+	ret = adxl362_set_interrupt_mode(dev, CONFIG_ADXL362_INTERRUPT_MODE);
 
 	if (ret) {
 		return -EFAULT;


### PR DESCRIPTION
Commit 11295c1 from #14290 added Kconfig options for interrupt mode, but then hard coded the interrupt mode. This commit uses the Kconfig option to set the interrupt mode.

Applications expecting the interrupt mode to be something other than the default will need to be updated.