### PR TITLE
drivers: watchdog: sam0: check if timeout is valid

### DIFF
--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -117,6 +117,11 @@ static int wdt_sam0_install_timeout(struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (cfg->window.max == 0) {
+		LOG_ERR("Upper limit timeout out of range");
+		return -EINVAL;
+	}
+
 	per = wdt_sam0_timeout_to_wdt_period(cfg->window.max);
 	if (per > WDT_CONFIG_PER_16K_Val) {
 		LOG_ERR("Upper limit timeout out of range");


### PR DESCRIPTION
The upper limit of the timeout should not be 0.
`tests/drivers/watchdog/wdt_basic_api` tests this and fails as the driver currently only checks that the timout does not exceed the upper bound.

This also makes it check the lower bound, so that the test passes.

Fixes #16418

