### PR TITLE
CMakeLists.txt: Link libkernel.a as whole-archive, like everything else

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -706,8 +706,8 @@ set(zephyr_lnk
   -u_ConfigAbsSyms
   ${LINKERFLAGPREFIX},--whole-archive
   ${ZEPHYR_LIBS_PROPERTY}
-  ${LINKERFLAGPREFIX},--no-whole-archive
   kernel
+  ${LINKERFLAGPREFIX},--no-whole-archive
   $<TARGET_OBJECTS:${OFFSETS_LIB}>
   ${LIB_INCLUDE_DIR}
   -L${PROJECT_BINARY_DIR}


### PR DESCRIPTION
There was a report that a non-trivial application (MicroPython with
experimental LVGL bindings) errors out at link stage:

ld: libmicropython.a(main.o): in function `k_timer_start':
zephyr/include/generated/syscalls/kernel.h:55:
undefined reference to `z_impl_k_timer_start'
ld: libmicropython.a(main.o):(._k_timer.static.lvgl_timer+0xc):
undefined reference to `z_timer_expiration_handler'

These functions are of course defined and available in libkernel.a.

Investigating the link command, turned out that while all other
Zephyr constituent libraries are linked with --whole-archive flag,
libkernel.a isn't. Changing that fixed the issue above. Given that
it is in no way special than any other build process constituent
libs (the only difference is that it's always present, while presence
of other libs depends on configuration), this appears to be a
change which make sense.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>