### PR TITLE
soc: stm32: enable outputing hex file

### DIFF
--- a/soc/arm/st_stm32/Kconfig
+++ b/soc/arm/st_stm32/Kconfig
@@ -9,6 +9,7 @@ config SOC_FAMILY_STM32
 	bool
 	# omit prompt to signify a "hidden" option
 	select HAS_SEGGER_RTT
+	select BUILD_OUTPUT_HEX
 
 if SOC_FAMILY_STM32
 


### PR DESCRIPTION
Hex firmware file is convenient in some scenarios, like
generating signed firmware with `west sign`. So, enable
generating hex file.

Signed-off-by: Jun Li <jun.r.li@intel.com>