### PR TITLE
tests: drivers: uart: Fix async write abort test

### DIFF
--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -292,6 +292,7 @@ void test_write_abort(void)
 	uart_tx(uart_dev, tx_buf, 5, 100);
 	zassert_equal(k_sem_take(&tx_done, 100), 0, "TX_DONE timeout");
 	zassert_equal(k_sem_take(&rx_rdy, 100), 0, "RX_RDY timeout");
+	zassert_equal(received, 5, "Incorrect number of bytes received.");
 	zassert_equal(memcmp(tx_buf, rx_buf, 5), 0, "Buffers not equal");
 
 	uart_tx(uart_dev, tx_buf, 95, 100);
@@ -299,7 +300,10 @@ void test_write_abort(void)
 	zassert_equal(k_sem_take(&tx_aborted, 100), 0, "TX_ABORTED timeout");
 	if (sent != 0) {
 		zassert_equal(k_sem_take(&rx_rdy, 100), 0, "RX_RDY timeout");
-		zassert_equal(sent, received, "Sent is not equal to received.");
+		zassert_equal(sent, received - 5,
+			      "Sent is not equal to received.");
+		zassert_equal(memcmp(tx_buf, rx_buf, received), 0,
+			      "Buffers not equal");
 	}
 	uart_rx_disable(uart_dev);
 	zassert_equal(k_sem_take(&rx_buf_released, 100),


### PR DESCRIPTION
During the write abort test, a second write is started then quickly aborted.  This means that the number of bytes sent is relative to that second write.  So when comparing it against the number of bytes received which is NOT reset, the first (completed) send of five bytes has to be accounted for.  The current nrfx implementations abort quick enough that no bytes are reported sent, so this wasn't currently being exercised (i.e. the short circuit of zero bytes sent was taken).

Tested on nrf52840_pca10056.