### PR TITLE
net: Allow to disable native IP stack with socket offloading

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -43,7 +43,7 @@ LOG_MODULE_REGISTER(net_pkt, CONFIG_NET_PKT_LOG_LEVEL);
 
 /* Find max header size of IP protocol (IPv4 or IPv6) */
 #if defined(CONFIG_NET_IPV6) || defined(CONFIG_NET_RAW_MODE) || \
-	defined(CONFIG_NET_SOCKETS_PACKET)
+    defined(CONFIG_NET_SOCKETS_PACKET) || defined(CONFIG_NET_SOCKETS_OFFLOAD)
 #define MAX_IP_PROTO_LEN NET_IPV6H_LEN
 #else
 #if defined(CONFIG_NET_IPV4)


### PR DESCRIPTION
In case socket offloading is used, one might want to disable native IP
stack, both IPv4 and IPv6, to save memory. Currently it is not possible
due to preprocessor check. Prevent that by adding additional exception
for socket offloading.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>