### PR TITLE
net: Avoid calling L2 functions on offloaded interface

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2846,11 +2846,10 @@ int net_if_up(struct net_if *iface)
 		return 0;
 	}
 
-#if defined(CONFIG_NET_OFFLOAD)
-	if (net_if_is_ip_offloaded(iface)) {
-		goto done;
+	if (IS_ENABLED(CONFIG_NET_OFFLOAD) && net_if_is_ip_offloaded(iface)) {
+		net_if_flag_set(iface, NET_IF_UP);
+		goto exit;
 	}
-#endif
 
 	/* If the L2 does not support enable just set the flag */
 	if (!net_if_l2(iface)->enable) {
@@ -2888,6 +2887,7 @@ done:
 	net_ipv4_autoconf_start(iface);
 #endif
 
+exit:
 	net_mgmt_event_notify(NET_EVENT_IF_UP, iface);
 
 	return 0;


### PR DESCRIPTION
Calling functions like `net_if_start_dad`, `join_mcast_nodes` or
`net_if_start_rs` lead to L2 API function calls, which is not correct
for offloaded interfaces and leads to a crash. This is especially
problematic, as they are called in the default configuration.

Avoid calling these functions while an offloaded interface is brought up
by adding an extra jump label.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>