### PR TITLE
posix: Fix calculation of clock base in clock_settime

### DIFF
--- a/lib/posix/clock.c
+++ b/lib/posix/clock.c
@@ -68,20 +68,15 @@ int clock_gettime(clockid_t clock_id, struct timespec *ts)
 int clock_settime(clockid_t clock_id, const struct timespec *tp)
 {
 	struct timespec base;
-	int res;
 
 	if (clock_id != CLOCK_REALTIME) {
 		errno = EINVAL;
 		return -1;
 	}
 
-	res = clock_gettime(clock_id, &base);
-	if (res != 0) {
-		return res;
-	}
-
-	s64_t delta = (s64_t)NSEC_PER_SEC * (tp->tv_sec - base.tv_sec) +
-		(tp->tv_nsec - base.tv_nsec);
+	u64_t elapsed_msecs = k_uptime_get();
+	s64_t delta = (s64_t)NSEC_PER_SEC * tp->tv_sec + tp->tv_nsec
+		- elapsed_msecs * USEC_PER_MSEC * NSEC_PER_USEC;
 
 	base.tv_sec = delta / NSEC_PER_SEC;
 	base.tv_nsec = delta % NSEC_PER_SEC;


### PR DESCRIPTION
Previous version calculated rt_clock_base incorrectly by subtracting
clock_gettime from the specified time. Effectively the following
formula was used.

    rt_clock_base := new_time - clock_gettime()

This is clearly incorrect when we consider what should happen if we
call clock_settime with the result of clock_gettime. It ought to be
approximately a no-op, but instead we end up zeroing the clock.

    rt_clock_base := clock_gettime() - clock_gettime() = 0

This patch fixes clock_settime by instead using k_uptime_get to
calculate rt_clock_base, like so:

    rt_clock_base := new_time - k_uptime_get()

Trying the earlier thought experiment we get:

    rt_clock_base := clock_gettime() - k_uptime_get()

Using the definition of clock_gettime this expands to:

    rt_clock_base := (rt_clock_base + k_uptime_get()) - k_uptime_get()

The two k_uptime_get() terms cancel out, leaving:

    rt_clock_base := rt_clock_base

I.e. the no-op that we expect when calling clock_settime with
the result of clock_gettime.

Fixes: #16143
Signed-off-by: Alexander Mihajlovic <alexander.mihajlovic@endian.se>