### PR TITLE
samples: mesh: single timer to handle all transitions, upgrade the implementation of Gen. Move Message handlers & bug fixes

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -197,10 +197,13 @@ void main(void)
 	ps_settings_init();
 
 	/* Initialize the Bluetooth Subsystem */
-	err = bt_enable(bt_ready);
+	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
+		return;
 	}
+
+	bt_ready();
 
 	light_default_status_init();
 

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -110,8 +110,8 @@ static void light_default_status_init(void)
 
 	default_tt = gen_def_trans_time_srv_user_data.tt;
 
-	target_lightness = lightness;
-	target_temperature = temperature;
+	init_lightness_target_values();
+	init_temp_target_values();
 }
 
 void update_led_gpio(void)

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -11,7 +11,6 @@
 #include "ble_mesh.h"
 #include "device_composition.h"
 #include "no_transition_work_handler.h"
-#include "publisher.h"
 #include "state_binding.h"
 #include "storage.h"
 #include "transition.h"
@@ -206,8 +205,6 @@ void main(void)
 	light_default_status_init();
 
 	update_light_state();
-
-	randomize_publishers_TID();
 
 	short_time_multireset_bt_mesh_unprovisioning();
 	k_timer_start(&reset_counter_timer, K_MSEC(7000), 0);

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/ble_mesh.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/ble_mesh.c
@@ -51,14 +51,10 @@ static const struct bt_mesh_prov prov = {
 	.reset = prov_reset,
 };
 
-void bt_ready(int err)
+void bt_ready(void)
 {
+	int err;
 	struct bt_le_oob oob;
-
-	if (err) {
-		printk("Bluetooth init failed (err %d)\n", err);
-		return;
-	}
 
 	printk("Bluetooth initialized\n");
 

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/ble_mesh.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/ble_mesh.h
@@ -50,7 +50,7 @@
 #define BT_MESH_MODEL_LIGHT_CTL_TEMP_STATUS	BT_MESH_MODEL_OP_2(0x82, 0x66)
 #define BT_MESH_MODEL_LIGHT_CTL_DEFAULT_STATUS	BT_MESH_MODEL_OP_2(0x82, 0x68)
 
-void bt_ready(int err);
+void bt_ready(void);
 
 #endif
 

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -213,8 +213,13 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	if (state->target_onoff != state->onoff) {
 		onoff_tt_values(state);
 	} else {
-		gen_onoff_publish(model);
-		return;
+		if (lightness != light_lightness_srv_user_data.def &&
+		    state->onoff == STATE_ON) {
+			onoff_tt_values(state);
+		} else {
+			gen_onoff_publish(model);
+			return;
+		}
 	}
 
 	/* For Instantaneous Transition */
@@ -282,9 +287,14 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	if (state->target_onoff != state->onoff) {
 		onoff_tt_values(state);
 	} else {
-		gen_onoff_get(model, ctx, buf);
-		gen_onoff_publish(model);
-		return;
+		if (lightness != light_lightness_srv_user_data.def &&
+		    state->onoff == STATE_ON) {
+			onoff_tt_values(state);
+		} else {
+			gen_onoff_get(model, ctx, buf);
+			gen_onoff_publish(model);
+			return;
+		}
 	}
 
 	/* For Instantaneous Transition */
@@ -2148,6 +2158,8 @@ static bool light_ctl_default_setunack(struct bt_mesh_model *model,
 		state->lightness_def = lightness;
 		state->temp_def = temp;
 		state->delta_uv_def = delta_uv;
+
+		light_lightness_srv_user_data.def = lightness;
 
 		save_on_flash(LIGHTNESS_TEMP_DEF_STATE);
 	}

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -209,6 +209,7 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	state->target_onoff = onoff;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = ONOFF_TT;
 
 	if (state->target_onoff != state->onoff) {
 		onoff_tt_values(state);
@@ -283,6 +284,7 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	state->target_onoff = onoff;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = ONOFF_TT;
 
 	if (state->target_onoff != state->onoff) {
 		onoff_tt_values(state);
@@ -338,9 +340,15 @@ static void gen_level_get(struct bt_mesh_model *model,
 	}
 
 	if (state->transition->counter) {
-		calculate_rt(state->transition);
-		net_buf_simple_add_le16(msg, state->target_level);
-		net_buf_simple_add_u8(msg, state->transition->rt);
+		if (state->transition->type == LEVEL_TT_MOVE ||
+		    state->transition->type == LEVEL_TEMP_TT_MOVE) {
+			net_buf_simple_add_le16(msg, state->target_level);
+			net_buf_simple_add_u8(msg, UNKNOWN_VALUE);
+		} else {
+			calculate_rt(state->transition);
+			net_buf_simple_add_le16(msg, state->target_level);
+			net_buf_simple_add_u8(msg, state->transition->rt);
+		}
 	}
 
 send:
@@ -367,9 +375,15 @@ void gen_level_publish(struct bt_mesh_model *model)
 	}
 
 	if (state->transition->counter) {
-		calculate_rt(state->transition);
-		net_buf_simple_add_le16(msg, state->target_level);
-		net_buf_simple_add_u8(msg, state->transition->rt);
+		if (state->transition->type == LEVEL_TT_MOVE ||
+		    state->transition->type == LEVEL_TEMP_TT_MOVE) {
+			net_buf_simple_add_le16(msg, state->target_level);
+			net_buf_simple_add_u8(msg, UNKNOWN_VALUE);
+		} else {
+			calculate_rt(state->transition);
+			net_buf_simple_add_le16(msg, state->target_level);
+			net_buf_simple_add_u8(msg, state->transition->rt);
+		}
 	}
 
 publish:
@@ -426,6 +440,7 @@ static void gen_level_set_unack(struct bt_mesh_model *model,
 	state->target_level = level;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = UNKNOWN_TT;
 
 	if (state->target_level != state->level) {
 		level_tt_values(state);
@@ -444,11 +459,11 @@ static void gen_level_set_unack(struct bt_mesh_model *model,
 
 	if (bt_mesh_model_elem(model)->addr == elements[0].addr) {
 		/* Root element */
-		transition_type = LEVEL_TT;
+		state->transition->type = LEVEL_TT;
 		level_lightness_handler(state);
 	} else if (bt_mesh_model_elem(model)->addr == elements[1].addr) {
 		/* Secondary element */
-		transition_type = LEVEL_TEMP_TT;
+		state->transition->type = LEVEL_TEMP_TT;
 		level_temp_handler(state);
 	}
 }
@@ -501,6 +516,7 @@ static void gen_level_set(struct bt_mesh_model *model,
 	state->target_level = level;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = UNKNOWN_TT;
 
 	if (state->target_level != state->level) {
 		level_tt_values(state);
@@ -521,11 +537,11 @@ static void gen_level_set(struct bt_mesh_model *model,
 
 	if (bt_mesh_model_elem(model)->addr == elements[0].addr) {
 		/* Root element */
-		transition_type = LEVEL_TT;
+		state->transition->type = LEVEL_TT;
 		level_lightness_handler(state);
 	} else if (bt_mesh_model_elem(model)->addr == elements[1].addr) {
 		/* Secondary element */
-		transition_type = LEVEL_TEMP_TT;
+		state->transition->type = LEVEL_TEMP_TT;
 		level_temp_handler(state);
 	}
 }
@@ -593,6 +609,7 @@ static void gen_delta_set_unack(struct bt_mesh_model *model,
 	state->target_level = tmp32;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = UNKNOWN_TT;
 
 	if (state->target_level != state->level) {
 		level_tt_values(state);
@@ -611,12 +628,11 @@ static void gen_delta_set_unack(struct bt_mesh_model *model,
 
 	if (bt_mesh_model_elem(model)->addr == elements[0].addr) {
 		/* Root element */
-		transition_type = LEVEL_TT_DELTA;
+		state->transition->type = LEVEL_TT_DELTA;
 		level_lightness_handler(state);
-	} else if (bt_mesh_model_elem(model)->addr ==
-		   elements[1].addr) {
+	} else if (bt_mesh_model_elem(model)->addr == elements[1].addr) {
 		/* Secondary element */
-		transition_type = LEVEL_TEMP_TT_DELTA;
+		state->transition->type = LEVEL_TEMP_TT_DELTA;
 		level_temp_handler(state);
 	}
 }
@@ -685,6 +701,7 @@ static void gen_delta_set(struct bt_mesh_model *model,
 	state->target_level = tmp32;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = UNKNOWN_TT;
 
 	if (state->target_level != state->level) {
 		level_tt_values(state);
@@ -705,66 +722,12 @@ static void gen_delta_set(struct bt_mesh_model *model,
 
 	if (bt_mesh_model_elem(model)->addr == elements[0].addr) {
 		/* Root element */
-		transition_type = LEVEL_TT_DELTA;
+		state->transition->type = LEVEL_TT_DELTA;
 		level_lightness_handler(state);
 	} else if (bt_mesh_model_elem(model)->addr == elements[1].addr) {
 		/* Secondary element */
-		transition_type = LEVEL_TEMP_TT_DELTA;
+		state->transition->type = LEVEL_TEMP_TT_DELTA;
 		level_temp_handler(state);
-	}
-}
-
-static void gen_level_move_get(struct bt_mesh_model *model,
-			       struct bt_mesh_msg_ctx *ctx,
-			       struct net_buf_simple *buf)
-{
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 5 + 4);
-	struct generic_level_state *state = model->user_data;
-
-	bt_mesh_model_msg_init(msg, BT_MESH_MODEL_OP_GEN_LEVEL_STATUS);
-	net_buf_simple_add_le16(msg, state->level);
-
-	if (state->transition->counter) {
-		if (state->last_delta < 0) {
-			net_buf_simple_add_le16(msg, INT16_MIN);
-		} else { /* 0 should not be possible */
-			net_buf_simple_add_le16(msg, INT16_MAX);
-		}
-
-		net_buf_simple_add_u8(msg, UNKNOWN_VALUE);
-	}
-
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
-		printk("Unable to send GEN_LEVEL_SRV Status response\n");
-	}
-}
-
-static void gen_level_move_publish(struct bt_mesh_model *model)
-{
-	int err;
-	struct net_buf_simple *msg = model->pub->msg;
-	struct generic_level_state *state = model->user_data;
-
-	if (model->pub->addr == BT_MESH_ADDR_UNASSIGNED) {
-		return;
-	}
-
-	bt_mesh_model_msg_init(msg, BT_MESH_MODEL_OP_GEN_LEVEL_STATUS);
-	net_buf_simple_add_le16(msg, state->level);
-
-	if (state->transition->counter) {
-		if (state->last_delta < 0) {
-			net_buf_simple_add_le16(msg, INT16_MIN);
-		} else { /* 0 should not be possible */
-			net_buf_simple_add_le16(msg, INT16_MAX);
-		}
-
-		net_buf_simple_add_u8(msg, UNKNOWN_VALUE);
-	}
-
-	err = bt_mesh_model_publish(model);
-	if (err) {
-		printk("bt_mesh_model_publish err %d\n", err);
 	}
 }
 
@@ -774,7 +737,6 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 {
 	u8_t tid, tt, delay;
 	s16_t delta;
-	s32_t tmp32;
 	s64_t now;
 	struct generic_level_state *state = model->user_data;
 
@@ -815,21 +777,22 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 	state->last_msg_timestamp = now;
 	state->last_delta = delta;
 
-	tmp32 = state->level + delta;
-	if (tmp32 < INT16_MIN) {
-		tmp32 = INT16_MIN;
-	} else if (tmp32 > INT16_MAX) {
-		tmp32 = INT16_MAX;
+	if (delta < 0) {
+		state->target_level = INT16_MIN;
+	} else if (delta > 0) {
+		state->target_level = INT16_MAX;
+	} else if (delta == 0) {
+		state->target_level = state->level;
 	}
 
-	state->target_level = tmp32;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = UNKNOWN_TT;
 
 	if (state->target_level != state->level) {
-		level_tt_values(state);
+		level_move_tt_values(state);
 	} else {
-		gen_level_move_publish(model);
+		gen_level_publish(model);
 		return;
 	}
 
@@ -838,15 +801,16 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 	}
 
 	state->transition->just_started = true;
-	gen_level_move_publish(model);
 
 	if (bt_mesh_model_elem(model)->addr == elements[0].addr) {
 		/* Root element */
-		transition_type = LEVEL_TT_MOVE;
+		state->transition->type = LEVEL_TT_MOVE;
+		gen_level_publish(model);
 		level_lightness_handler(state);
 	} else if (bt_mesh_model_elem(model)->addr == elements[1].addr) {
 		/* Secondary element */
-		transition_type = LEVEL_TEMP_TT_MOVE;
+		state->transition->type = LEVEL_TEMP_TT_MOVE;
+		gen_level_publish(model);
 		level_temp_handler(state);
 	}
 }
@@ -857,7 +821,6 @@ static void gen_move_set(struct bt_mesh_model *model,
 {
 	u8_t tid, tt, delay;
 	s16_t delta;
-	s32_t tmp32;
 	s64_t now;
 	struct generic_level_state *state = model->user_data;
 
@@ -869,7 +832,7 @@ static void gen_move_set(struct bt_mesh_model *model,
 	    state->last_src_addr == ctx->addr &&
 	    state->last_dst_addr == ctx->recv_dst &&
 	    (now - state->last_msg_timestamp <= K_SECONDS(6))) {
-		gen_level_move_get(model, ctx, buf);
+		gen_level_get(model, ctx, buf);
 		return;
 	}
 
@@ -899,22 +862,23 @@ static void gen_move_set(struct bt_mesh_model *model,
 	state->last_msg_timestamp = now;
 	state->last_delta = delta;
 
-	tmp32 = state->level + delta;
-	if (tmp32 < INT16_MIN) {
-		tmp32 = INT16_MIN;
-	} else if (tmp32 > INT16_MAX) {
-		tmp32 = INT16_MAX;
+	if (delta < 0) {
+		state->target_level = INT16_MIN;
+	} else if (delta > 0) {
+		state->target_level = INT16_MAX;
+	} else if (delta == 0) {
+		state->target_level = state->level;
 	}
 
-	state->target_level = tmp32;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = UNKNOWN_TT;
 
 	if (state->target_level != state->level) {
-		level_tt_values(state);
+		level_move_tt_values(state);
 	} else {
-		gen_level_move_get(model, ctx, buf);
-		gen_level_move_publish(model);
+		gen_level_get(model, ctx, buf);
+		gen_level_publish(model);
 		return;
 	}
 
@@ -923,16 +887,18 @@ static void gen_move_set(struct bt_mesh_model *model,
 	}
 
 	state->transition->just_started = true;
-	gen_level_move_get(model, ctx, buf);
-	gen_level_move_publish(model);
 
 	if (bt_mesh_model_elem(model)->addr == elements[0].addr) {
 		/* Root element */
-		transition_type = LEVEL_TT_MOVE;
+		state->transition->type = LEVEL_TT_MOVE;
+		gen_level_get(model, ctx, buf);
+		gen_level_publish(model);
 		level_lightness_handler(state);
 	} else if (bt_mesh_model_elem(model)->addr == elements[1].addr) {
 		/* Secondary element */
-		transition_type = LEVEL_TEMP_TT_MOVE;
+		state->transition->type = LEVEL_TEMP_TT_MOVE;
+		gen_level_get(model, ctx, buf);
+		gen_level_publish(model);
 		level_temp_handler(state);
 	}
 }
@@ -1313,6 +1279,7 @@ static void light_lightness_set_unack(struct bt_mesh_model *model,
 	state->target_actual = actual;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = LIGHT_ACTUAL_TT;
 
 	if (state->target_actual != state->actual) {
 		light_lightness_actual_tt_values(state);
@@ -1386,6 +1353,7 @@ static void light_lightness_set(struct bt_mesh_model *model,
 	state->target_actual = actual;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = LIGHT_ACTUAL_TT;
 
 	if (state->target_actual != state->actual) {
 		light_lightness_actual_tt_values(state);
@@ -1511,6 +1479,7 @@ static void light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	state->target_linear = linear;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = LIGHT_LINEAR_TT;
 
 	if (state->target_linear != state->linear) {
 		light_lightness_linear_tt_values(state);
@@ -1577,6 +1546,7 @@ static void light_lightness_linear_set(struct bt_mesh_model *model,
 	state->target_linear = linear;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = LIGHT_LINEAR_TT;
 
 	if (state->target_linear != state->linear) {
 		light_lightness_linear_tt_values(state);
@@ -1960,6 +1930,7 @@ static void light_ctl_set_unack(struct bt_mesh_model *model,
 	state->target_delta_uv = delta_uv;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = LIGHT_CTL_TT;
 
 	if (state->target_lightness != state->lightness ||
 	    state->target_temp != state->temp ||
@@ -2046,6 +2017,7 @@ static void light_ctl_set(struct bt_mesh_model *model,
 	state->target_delta_uv = delta_uv;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = LIGHT_CTL_TT;
 
 	if (state->target_lightness != state->lightness ||
 	    state->target_temp != state->temp ||
@@ -2446,6 +2418,7 @@ static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	state->target_delta_uv = delta_uv;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = LIGHT_CTL_TEMP_TT;
 
 	if (state->target_temp != state->temp ||
 	    state->target_delta_uv != state->delta_uv) {
@@ -2528,6 +2501,7 @@ static void light_ctl_temp_set(struct bt_mesh_model *model,
 	state->target_delta_uv = delta_uv;
 	state->transition->tt = tt;
 	state->transition->delay = delay;
+	state->transition->type = LIGHT_CTL_TEMP_TT;
 
 	if (state->target_temp != state->temp ||
 	    state->target_delta_uv != state->delta_uv) {

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -72,11 +72,11 @@ BT_MESH_MODEL_PUB_DEFINE(gen_level_cli_pub_s0, NULL, 2 + 7);
 
 /* Definitions of models user data (Start) */
 struct generic_onoff_state gen_onoff_srv_root_user_data = {
-	.transition = &lightness_transition,
+	.transition = &transition,
 };
 
 struct generic_level_state gen_level_srv_root_user_data = {
-	.transition = &lightness_transition,
+	.transition = &transition,
 };
 
 struct gen_def_trans_time_state gen_def_trans_time_srv_user_data;
@@ -84,17 +84,17 @@ struct gen_def_trans_time_state gen_def_trans_time_srv_user_data;
 struct generic_onpowerup_state gen_power_onoff_srv_user_data;
 
 struct light_lightness_state light_lightness_srv_user_data = {
-	.transition = &lightness_transition,
+	.transition = &transition,
 };
 
 struct light_ctl_state light_ctl_srv_user_data = {
-	.transition = &lightness_transition,
+	.transition = &transition,
 };
 
 struct vendor_state vnd_user_data;
 
 struct generic_level_state gen_level_srv_s0_user_data = {
-	.transition = &temp_transition,
+	.transition = &transition,
 };
 /* Definitions of models user data (End) */
 
@@ -113,12 +113,17 @@ static void gen_onoff_get(struct bt_mesh_model *model,
 	bt_mesh_model_msg_init(msg, BT_MESH_MODEL_OP_GEN_ONOFF_STATUS);
 	net_buf_simple_add_u8(msg, state->onoff);
 
+	if (lightness == target_lightness) {
+		goto send;
+	}
+
 	if (state->transition->counter) {
 		calculate_rt(state->transition);
 		net_buf_simple_add_u8(msg, state->target_onoff);
 		net_buf_simple_add_u8(msg, state->transition->rt);
 	}
 
+send:
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send GEN_ONOFF_SRV Status response\n");
 	}
@@ -137,12 +142,17 @@ void gen_onoff_publish(struct bt_mesh_model *model)
 	bt_mesh_model_msg_init(msg, BT_MESH_MODEL_OP_GEN_ONOFF_STATUS);
 	net_buf_simple_add_u8(msg, state->onoff);
 
+	if (lightness == target_lightness) {
+		goto publish;
+	}
+
 	if (state->transition->counter) {
 		calculate_rt(state->transition);
 		net_buf_simple_add_u8(msg, state->target_onoff);
 		net_buf_simple_add_u8(msg, state->transition->rt);
 	}
 
+publish:
 	err = bt_mesh_model_publish(model);
 	if (err) {
 		printk("bt_mesh_model_publish err %d\n", err);
@@ -197,9 +207,11 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_onoff = onoff;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_onoff != state->onoff) {
-		onoff_tt_values(state, tt, delay);
+		onoff_tt_values(state);
 	} else {
 		gen_onoff_publish(model);
 		return;
@@ -264,9 +276,11 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_onoff = onoff;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_onoff != state->onoff) {
-		onoff_tt_values(state, tt, delay);
+		onoff_tt_values(state);
 	} else {
 		gen_onoff_get(model, ctx, buf);
 		gen_onoff_publish(model);
@@ -309,12 +323,17 @@ static void gen_level_get(struct bt_mesh_model *model,
 	bt_mesh_model_msg_init(msg, BT_MESH_MODEL_OP_GEN_LEVEL_STATUS);
 	net_buf_simple_add_le16(msg, state->level);
 
+	if (state->level == state->target_level) {
+		goto send;
+	}
+
 	if (state->transition->counter) {
 		calculate_rt(state->transition);
 		net_buf_simple_add_le16(msg, state->target_level);
 		net_buf_simple_add_u8(msg, state->transition->rt);
 	}
 
+send:
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send GEN_LEVEL_SRV Status response\n");
 	}
@@ -333,12 +352,17 @@ void gen_level_publish(struct bt_mesh_model *model)
 	bt_mesh_model_msg_init(msg, BT_MESH_MODEL_OP_GEN_LEVEL_STATUS);
 	net_buf_simple_add_le16(msg, state->level);
 
+	if (state->level == state->target_level) {
+		goto publish;
+	}
+
 	if (state->transition->counter) {
 		calculate_rt(state->transition);
 		net_buf_simple_add_le16(msg, state->target_level);
 		net_buf_simple_add_u8(msg, state->transition->rt);
 	}
 
+publish:
 	err = bt_mesh_model_publish(model);
 	if (err) {
 		printk("bt_mesh_model_publish err %d\n", err);
@@ -390,9 +414,11 @@ static void gen_level_set_unack(struct bt_mesh_model *model,
 	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_level = level;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_level != state->level) {
-		level_tt_values(state, tt, delay);
+		level_tt_values(state);
 	} else {
 		gen_level_publish(model);
 		return;
@@ -463,9 +489,11 @@ static void gen_level_set(struct bt_mesh_model *model,
 	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_level = level;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_level != state->level) {
-		level_tt_values(state, tt, delay);
+		level_tt_values(state);
 	} else {
 		gen_level_get(model, ctx, buf);
 		gen_level_publish(model);
@@ -553,9 +581,11 @@ static void gen_delta_set_unack(struct bt_mesh_model *model,
 	}
 
 	state->target_level = tmp32;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_level != state->level) {
-		level_tt_values(state, tt, delay);
+		level_tt_values(state);
 	} else {
 		gen_level_publish(model);
 		return;
@@ -643,9 +673,11 @@ static void gen_delta_set(struct bt_mesh_model *model,
 	}
 
 	state->target_level = tmp32;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_level != state->level) {
-		level_tt_values(state, tt, delay);
+		level_tt_values(state);
 	} else {
 		gen_level_get(model, ctx, buf);
 		gen_level_publish(model);
@@ -781,9 +813,11 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 	}
 
 	state->target_level = tmp32;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_level != state->level) {
-		level_tt_values(state, tt, delay);
+		level_tt_values(state);
 	} else {
 		gen_level_move_publish(model);
 		return;
@@ -863,9 +897,11 @@ static void gen_move_set(struct bt_mesh_model *model,
 	}
 
 	state->target_level = tmp32;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_level != state->level) {
-		level_tt_values(state, tt, delay);
+		level_tt_values(state);
 	} else {
 		gen_level_move_get(model, ctx, buf);
 		gen_level_move_publish(model);
@@ -1167,12 +1203,17 @@ static void light_lightness_get(struct bt_mesh_model *model,
 	bt_mesh_model_msg_init(msg, BT_MESH_MODEL_LIGHT_LIGHTNESS_STATUS);
 	net_buf_simple_add_le16(msg, state->actual);
 
+	if (state->actual == state->target_actual) {
+		goto send;
+	}
+
 	if (state->transition->counter) {
 		calculate_rt(state->transition);
 		net_buf_simple_add_le16(msg, state->target_actual);
 		net_buf_simple_add_u8(msg, state->transition->rt);
 	}
 
+send:
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send LightLightnessAct Status response\n");
 	}
@@ -1191,12 +1232,17 @@ void light_lightness_publish(struct bt_mesh_model *model)
 	bt_mesh_model_msg_init(msg, BT_MESH_MODEL_LIGHT_LIGHTNESS_STATUS);
 	net_buf_simple_add_le16(msg, state->actual);
 
+	if (state->actual == state->target_actual) {
+		goto publish;
+	}
+
 	if (state->transition->counter) {
 		calculate_rt(state->transition);
 		net_buf_simple_add_le16(msg, state->target_actual);
 		net_buf_simple_add_u8(msg, state->transition->rt);
 	}
 
+publish:
 	err = bt_mesh_model_publish(model);
 	if (err) {
 		printk("bt_mesh_model_publish err %d\n", err);
@@ -1255,9 +1301,11 @@ static void light_lightness_set_unack(struct bt_mesh_model *model,
 	}
 
 	state->target_actual = actual;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_actual != state->actual) {
-		light_lightness_actual_tt_values(state, tt, delay);
+		light_lightness_actual_tt_values(state);
 	} else {
 		light_lightness_publish(model);
 		return;
@@ -1326,9 +1374,11 @@ static void light_lightness_set(struct bt_mesh_model *model,
 	}
 
 	state->target_actual = actual;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_actual != state->actual) {
-		light_lightness_actual_tt_values(state, tt, delay);
+		light_lightness_actual_tt_values(state);
 	} else {
 		light_lightness_get(model, ctx, buf);
 		light_lightness_publish(model);
@@ -1357,12 +1407,17 @@ static void light_lightness_linear_get(struct bt_mesh_model *model,
 			       BT_MESH_MODEL_LIGHT_LIGHTNESS_LINEAR_STATUS);
 	net_buf_simple_add_le16(msg, state->linear);
 
+	if (state->linear == state->target_linear) {
+		goto send;
+	}
+
 	if (state->transition->counter) {
 		calculate_rt(state->transition);
 		net_buf_simple_add_le16(msg, state->target_linear);
 		net_buf_simple_add_u8(msg, state->transition->rt);
 	}
 
+send:
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send LightLightnessLin Status response\n");
 	}
@@ -1382,12 +1437,17 @@ void light_lightness_linear_publish(struct bt_mesh_model *model)
 			       BT_MESH_MODEL_LIGHT_LIGHTNESS_LINEAR_STATUS);
 	net_buf_simple_add_le16(msg, state->linear);
 
+	if (state->linear == state->target_linear) {
+		goto publish;
+	}
+
 	if (state->transition->counter) {
 		calculate_rt(state->transition);
 		net_buf_simple_add_le16(msg, state->target_linear);
 		net_buf_simple_add_u8(msg, state->transition->rt);
 	}
 
+publish:
 	err = bt_mesh_model_publish(model);
 	if (err) {
 		printk("bt_mesh_model_publish err %d\n", err);
@@ -1439,9 +1499,11 @@ static void light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_linear = linear;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_linear != state->linear) {
-		light_lightness_linear_tt_values(state, tt, delay);
+		light_lightness_linear_tt_values(state);
 	} else {
 		light_lightness_linear_publish(model);
 		return;
@@ -1503,9 +1565,11 @@ static void light_lightness_linear_set(struct bt_mesh_model *model,
 	state->last_dst_addr = ctx->recv_dst;
 	state->last_msg_timestamp = now;
 	state->target_linear = linear;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_linear != state->linear) {
-		light_lightness_linear_tt_values(state, tt, delay);
+		light_lightness_linear_tt_values(state);
 	} else {
 		light_lightness_linear_get(model, ctx, buf);
 		light_lightness_linear_publish(model);
@@ -1768,6 +1832,11 @@ static void light_ctl_get(struct bt_mesh_model *model,
 	net_buf_simple_add_le16(msg, state->lightness);
 	net_buf_simple_add_le16(msg, state->temp);
 
+	if (state->lightness == state->target_lightness &&
+	    state->temp == state->target_temp) {
+		goto send;
+	}
+
 	if (state->transition->counter) {
 		calculate_rt(state->transition);
 		net_buf_simple_add_le16(msg, state->target_lightness);
@@ -1775,6 +1844,7 @@ static void light_ctl_get(struct bt_mesh_model *model,
 		net_buf_simple_add_u8(msg, state->transition->rt);
 	}
 
+send:
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send LightCTL Status response\n");
 	}
@@ -1798,6 +1868,11 @@ void light_ctl_publish(struct bt_mesh_model *model)
 	net_buf_simple_add_le16(msg, state->lightness);
 	net_buf_simple_add_le16(msg, state->temp);
 
+	if (state->lightness == state->target_lightness &&
+	    state->temp == state->target_temp) {
+		goto publish;
+	}
+
 	if (state->transition->counter) {
 		calculate_rt(state->transition);
 		net_buf_simple_add_le16(msg, state->target_lightness);
@@ -1805,6 +1880,7 @@ void light_ctl_publish(struct bt_mesh_model *model)
 		net_buf_simple_add_u8(msg, state->transition->rt);
 	}
 
+publish:
 	err = bt_mesh_model_publish(model);
 	if (err) {
 		printk("bt_mesh_model_publish err %d\n", err);
@@ -1872,11 +1948,13 @@ static void light_ctl_set_unack(struct bt_mesh_model *model,
 
 	state->target_temp = temp;
 	state->target_delta_uv = delta_uv;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_lightness != state->lightness ||
 	    state->target_temp != state->temp ||
 	    state->target_delta_uv != state->delta_uv) {
-		light_ctl_tt_values(state, tt, delay);
+		light_ctl_tt_values(state);
 	} else {
 		light_ctl_publish(model);
 		return;
@@ -1956,11 +2034,13 @@ static void light_ctl_set(struct bt_mesh_model *model,
 
 	state->target_temp = temp;
 	state->target_delta_uv = delta_uv;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_lightness != state->lightness ||
 	    state->target_temp != state->temp ||
 	    state->target_delta_uv != state->delta_uv) {
-		light_ctl_tt_values(state, tt, delay);
+		light_ctl_tt_values(state);
 	} else {
 		light_ctl_get(model, ctx, buf);
 		light_ctl_publish(model);
@@ -2242,6 +2322,11 @@ static void light_ctl_temp_get(struct bt_mesh_model *model,
 	net_buf_simple_add_le16(msg, state->temp);
 	net_buf_simple_add_le16(msg, state->delta_uv);
 
+	if (state->temp == state->target_temp &&
+	    state->delta_uv == state->target_delta_uv) {
+		goto send;
+	}
+
 	if (state->transition->counter) {
 		calculate_rt(state->transition);
 		net_buf_simple_add_le16(msg, state->target_temp);
@@ -2249,6 +2334,7 @@ static void light_ctl_temp_get(struct bt_mesh_model *model,
 		net_buf_simple_add_u8(msg, state->transition->rt);
 	}
 
+send:
 	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
 		printk("Unable to send LightCTL Temp. Status response\n");
 	}
@@ -2268,6 +2354,11 @@ void light_ctl_temp_publish(struct bt_mesh_model *model)
 	net_buf_simple_add_le16(msg, state->temp);
 	net_buf_simple_add_le16(msg, state->delta_uv);
 
+	if (state->temp == state->target_temp &&
+	    state->delta_uv == state->target_delta_uv) {
+		goto publish;
+	}
+
 	if (state->transition->counter) {
 		calculate_rt(state->transition);
 		net_buf_simple_add_le16(msg, state->target_temp);
@@ -2275,6 +2366,7 @@ void light_ctl_temp_publish(struct bt_mesh_model *model)
 		net_buf_simple_add_u8(msg, state->transition->rt);
 	}
 
+publish:
 	err = bt_mesh_model_publish(model);
 	if (err) {
 		printk("bt_mesh_model_publish err %d\n", err);
@@ -2340,10 +2432,12 @@ static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
 
 	state->target_temp = temp;
 	state->target_delta_uv = delta_uv;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_temp != state->temp ||
 	    state->target_delta_uv != state->delta_uv) {
-		light_ctl_temp_tt_values(state, tt, delay);
+		light_ctl_temp_tt_values(state);
 	} else {
 		light_ctl_temp_publish(model);
 		return;
@@ -2420,10 +2514,12 @@ static void light_ctl_temp_set(struct bt_mesh_model *model,
 
 	state->target_temp = temp;
 	state->target_delta_uv = delta_uv;
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	if (state->target_temp != state->temp ||
 	    state->target_delta_uv != state->delta_uv) {
-		light_ctl_temp_tt_values(state, tt, delay);
+		light_ctl_temp_tt_values(state);
 	} else {
 		light_ctl_temp_get(model, ctx, buf);
 		light_ctl_temp_publish(model);

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
@@ -16,8 +16,6 @@
 #define ONOFF
 #define GENERIC_LEVEL
 
-static bool is_randomization_of_TIDs_done;
-
 #if (defined(ONOFF) || defined(ONOFF_TT))
 static u8_t tid_onoff;
 #elif defined(VND_MODEL_TEST)
@@ -25,19 +23,6 @@ static u8_t tid_vnd;
 #endif
 
 static u8_t tid_level;
-
-void randomize_publishers_TID(void)
-{
-#if (defined(ONOFF) || defined(ONOFF_TT))
-	bt_rand(&tid_onoff, sizeof(tid_onoff));
-#elif defined(VND_MODEL_TEST)
-	bt_rand(&tid_vnd, sizeof(tid_vnd));
-#endif
-
-	bt_rand(&tid_level, sizeof(tid_level));
-
-	is_randomization_of_TIDs_done = true;
-}
 
 static u32_t button_read(struct device *port, u32_t pin)
 {
@@ -50,10 +35,6 @@ static u32_t button_read(struct device *port, u32_t pin)
 void publish(struct k_work *work)
 {
 	int err = 0;
-
-	if (is_randomization_of_TIDs_done == false) {
-		return;
-	}
 
 	if (button_read(button_device[0], SW0_GPIO_PIN) == 0U) {
 #if defined(ONOFF)

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
@@ -53,14 +53,14 @@ static u16_t actual_to_linear(u16_t val)
 {
 	float tmp;
 
-	tmp = ((float) val / 65535);
+	tmp = ((float) val / UINT16_MAX);
 
-	return (u16_t) ceiling(65535 * tmp * tmp);
+	return (u16_t) ceiling(UINT16_MAX * tmp * tmp);
 }
 
 static u16_t linear_to_actual(u16_t val)
 {
-	return (u16_t) (65535 * sqrt(((float) val / 65535)));
+	return (u16_t) (UINT16_MAX * sqrt(((float) val / UINT16_MAX)));
 }
 
 static void constrain_lightness(u16_t var)
@@ -108,12 +108,12 @@ static s16_t light_ctl_temp_to_level(u16_t temp)
 
 	/* Mesh Model Specification 6.1.3.1.1 2nd formula start */
 
-	tmp = (temp - light_ctl_srv_user_data.temp_range_min) * 65535U;
+	tmp = (temp - light_ctl_srv_user_data.temp_range_min) * UINT16_MAX;
 
 	tmp = tmp / (light_ctl_srv_user_data.temp_range_max -
 		     light_ctl_srv_user_data.temp_range_min);
 
-	return (s16_t) (tmp - 32768);
+	return (s16_t) (tmp + INT16_MIN);
 
 	/* 6.1.3.1.1 2nd formula end */
 }
@@ -125,10 +125,10 @@ static u16_t level_to_light_ctl_temp(s16_t level)
 
 	/* Mesh Model Specification 6.1.3.1.1 1st formula start */
 	diff = (float) (light_ctl_srv_user_data.temp_range_max -
-			light_ctl_srv_user_data.temp_range_min) / 65535;
+			light_ctl_srv_user_data.temp_range_min) / UINT16_MAX;
 
 
-	tmp = (u16_t) ((level + 32768) * diff);
+	tmp = (u16_t) ((level - INT16_MIN) * diff);
 
 	return (light_ctl_srv_user_data.temp_range_min + tmp);
 
@@ -147,7 +147,7 @@ void readjust_lightness(void)
 		gen_onoff_srv_root_user_data.onoff = STATE_OFF;
 	}
 
-	gen_level_srv_root_user_data.level = lightness - 32768;
+	gen_level_srv_root_user_data.level = lightness + INT16_MIN;
 	light_lightness_srv_user_data.actual = lightness;
 	light_lightness_srv_user_data.linear = actual_to_linear(lightness);
 	light_ctl_srv_user_data.lightness = lightness;
@@ -198,10 +198,10 @@ void state_binding(u8_t light, u8_t temp)
 		}
 		break;
 	case LEVEL:
-		lightness = gen_level_srv_root_user_data.level + 32768;
+		lightness = gen_level_srv_root_user_data.level - INT16_MIN;
 		break;
 	case DELTA_LEVEL:
-		lightness = gen_level_srv_root_user_data.level + 32768;
+		lightness = gen_level_srv_root_user_data.level - INT16_MIN;
 		constrain_lightness2(lightness);
 		goto jump;
 	case ACTUAL:
@@ -234,7 +234,7 @@ void init_lightness_target_values(void)
 		gen_onoff_srv_root_user_data.target_onoff = STATE_OFF;
 	}
 
-	gen_level_srv_root_user_data.target_level = target_lightness - 32768;
+	gen_level_srv_root_user_data.target_level = target_lightness + INT16_MIN;
 
 	light_lightness_srv_user_data.target_actual = target_lightness;
 
@@ -261,7 +261,7 @@ void calculate_lightness_target_values(u8_t type)
 		}
 		break;
 	case LEVEL:
-		tmp = gen_level_srv_root_user_data.target_level + 32768;
+		tmp = gen_level_srv_root_user_data.target_level - INT16_MIN;
 		break;
 	case ACTUAL:
 		tmp = light_lightness_srv_user_data.target_actual;
@@ -287,7 +287,7 @@ void calculate_lightness_target_values(u8_t type)
 		gen_onoff_srv_root_user_data.target_onoff = STATE_OFF;
 	}
 
-	gen_level_srv_root_user_data.target_level = target_lightness - 32768;
+	gen_level_srv_root_user_data.target_level = target_lightness + INT16_MIN;
 
 	light_lightness_srv_user_data.target_actual = target_lightness;
 

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
@@ -224,6 +224,26 @@ jump:
 	readjust_lightness();
 }
 
+void init_lightness_target_values(void)
+{
+	target_lightness = lightness;
+
+	if (target_lightness) {
+		gen_onoff_srv_root_user_data.target_onoff = STATE_ON;
+	} else {
+		gen_onoff_srv_root_user_data.target_onoff = STATE_OFF;
+	}
+
+	gen_level_srv_root_user_data.target_level = target_lightness - 32768;
+
+	light_lightness_srv_user_data.target_actual = target_lightness;
+
+	light_lightness_srv_user_data.target_linear =
+		actual_to_linear(target_lightness);
+
+	light_ctl_srv_user_data.target_lightness = target_lightness;
+}
+
 void calculate_lightness_target_values(u8_t type)
 {
 	u16_t tmp;
@@ -275,6 +295,14 @@ void calculate_lightness_target_values(u8_t type)
 		actual_to_linear(target_lightness);
 
 	light_ctl_srv_user_data.target_lightness = target_lightness;
+}
+
+void init_temp_target_values(void)
+{
+	target_temperature = temperature;
+	gen_level_srv_s0_user_data.target_level = target_temperature;
+	light_ctl_srv_user_data.target_temp =
+			level_to_light_ctl_temp(target_temperature);
 }
 
 void calculate_temp_target_values(u8_t type)

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.h
@@ -30,7 +30,11 @@ extern s16_t temperature, target_temperature;
 void readjust_lightness(void);
 void readjust_temperature(void);
 void state_binding(u8_t lightness, u8_t temperature);
+
+void init_lightness_target_values(void);
 void calculate_lightness_target_values(u8_t type);
+
+void init_temp_target_values(void);
 void calculate_temp_target_values(u8_t type);
 
 #endif

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
@@ -17,7 +17,7 @@ u8_t transition_type, default_tt;
 u32_t *ptr_counter;
 struct k_timer *ptr_timer = &dummy_timer;
 
-struct transition lightness_transition, temp_transition;
+struct transition transition;
 
 /* Function to calculate Remaining Time (Start) */
 
@@ -61,29 +61,6 @@ void calculate_rt(struct transition *transition)
 
 /* Function to calculate Remaining Time (End) */
 
-static void bound_states_transition_type_reassignment(u8_t type)
-{
-	switch (type) {
-	case ONOFF:
-	case LEVEL:
-	case ACTUAL:
-	case LINEAR:
-		light_ctl_srv_user_data.transition = &lightness_transition;
-		break;
-	case CTL:
-		light_ctl_srv_user_data.transition = &lightness_transition;
-		gen_level_srv_s0_user_data.transition = &lightness_transition;
-		break;
-	case LEVEL_TEMP:
-	case CTL_TEMP:
-		gen_level_srv_s0_user_data.transition = &temp_transition;
-		light_ctl_srv_user_data.transition = &temp_transition;
-		break;
-	default:
-		break;
-	}
-}
-
 static bool tt_values_calculator(struct transition *transition)
 {
 	u8_t steps_multiplier, resolution;
@@ -119,12 +96,9 @@ static bool tt_values_calculator(struct transition *transition)
 	return true;
 }
 
-void onoff_tt_values(struct generic_onoff_state *state, u8_t tt, u8_t delay)
+void onoff_tt_values(struct generic_onoff_state *state)
 {
-	bound_states_transition_type_reassignment(ONOFF);
 	calculate_lightness_target_values(ONOFF);
-	state->transition->tt = tt;
-	state->transition->delay = delay;
 
 	if (!tt_values_calculator(state->transition)) {
 		return;
@@ -137,17 +111,13 @@ void onoff_tt_values(struct generic_onoff_state *state, u8_t tt, u8_t delay)
 			   state->transition->counter);
 }
 
-void level_tt_values(struct generic_level_state *state, u8_t tt, u8_t delay)
+void level_tt_values(struct generic_level_state *state)
 {
 	if (state == &gen_level_srv_root_user_data) {
-		bound_states_transition_type_reassignment(LEVEL);
 		calculate_lightness_target_values(LEVEL);
 	} else if (state == &gen_level_srv_s0_user_data) {
-		bound_states_transition_type_reassignment(LEVEL_TEMP);
 		calculate_temp_target_values(LEVEL_TEMP);
 	}
-	state->transition->tt = tt;
-	state->transition->delay = delay;
 
 	if (!tt_values_calculator(state->transition)) {
 		return;
@@ -160,13 +130,9 @@ void level_tt_values(struct generic_level_state *state, u8_t tt, u8_t delay)
 			   state->transition->counter);
 }
 
-void light_lightness_actual_tt_values(struct light_lightness_state *state,
-				      u8_t tt, u8_t delay)
+void light_lightness_actual_tt_values(struct light_lightness_state *state)
 {
-	bound_states_transition_type_reassignment(ACTUAL);
 	calculate_lightness_target_values(ACTUAL);
-	state->transition->tt = tt;
-	state->transition->delay = delay;
 
 	if (!tt_values_calculator(state->transition)) {
 		return;
@@ -180,13 +146,9 @@ void light_lightness_actual_tt_values(struct light_lightness_state *state,
 		 state->transition->counter);
 }
 
-void light_lightness_linear_tt_values(struct light_lightness_state *state,
-				      u8_t tt, u8_t delay)
+void light_lightness_linear_tt_values(struct light_lightness_state *state)
 {
-	bound_states_transition_type_reassignment(LINEAR);
 	calculate_lightness_target_values(LINEAR);
-	state->transition->tt = tt;
-	state->transition->delay = delay;
 
 	if (!tt_values_calculator(state->transition)) {
 		return;
@@ -200,12 +162,9 @@ void light_lightness_linear_tt_values(struct light_lightness_state *state,
 		 state->transition->counter);
 }
 
-void light_ctl_tt_values(struct light_ctl_state *state, u8_t tt, u8_t delay)
+void light_ctl_tt_values(struct light_ctl_state *state)
 {
-	bound_states_transition_type_reassignment(CTL);
 	calculate_lightness_target_values(CTL);
-	state->transition->tt = tt;
-	state->transition->delay = delay;
 
 	if (!tt_values_calculator(state->transition)) {
 		return;
@@ -227,13 +186,9 @@ void light_ctl_tt_values(struct light_ctl_state *state, u8_t tt, u8_t delay)
 		 state->transition->counter);
 }
 
-void light_ctl_temp_tt_values(struct light_ctl_state *state,
-			      u8_t tt, u8_t delay)
+void light_ctl_temp_tt_values(struct light_ctl_state *state)
 {
-	bound_states_transition_type_reassignment(CTL_TEMP);
 	calculate_temp_target_values(CTL_TEMP);
-	state->transition->tt = tt;
-	state->transition->delay = delay;
 
 	if (!tt_values_calculator(state->transition)) {
 		return;

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.h
@@ -12,17 +12,24 @@
 #define DEVICE_SPECIFIC_RESOLUTION 10
 
 enum level_transition_types {
+	UNKNOWN_TT,
+	ONOFF_TT,
 	LEVEL_TT,
 	LEVEL_TT_DELTA,
 	LEVEL_TT_MOVE,
+	LIGHT_ACTUAL_TT,
+	LIGHT_LINEAR_TT,
+	LIGHT_CTL_TT,
 
 	LEVEL_TEMP_TT,
 	LEVEL_TEMP_TT_DELTA,
 	LEVEL_TEMP_TT_MOVE,
+	LIGHT_CTL_TEMP_TT,
 };
 
 struct transition {
 	bool just_started;
+	u8_t type;
 	u8_t tt;
 	u8_t rt;
 	u8_t delay;
@@ -34,7 +41,7 @@ struct transition {
 	struct k_timer timer;
 };
 
-extern u8_t transition_type, default_tt;
+extern u8_t default_tt;
 extern u32_t *ptr_counter;
 extern struct k_timer *ptr_timer;
 
@@ -47,6 +54,7 @@ void calculate_rt(struct transition *transition);
 
 void onoff_tt_values(struct generic_onoff_state *state);
 void level_tt_values(struct generic_level_state *state);
+void level_move_tt_values(struct generic_level_state *state);
 void light_lightness_actual_tt_values(struct light_lightness_state *state);
 void light_lightness_linear_tt_values(struct light_lightness_state *state);
 void light_ctl_tt_values(struct light_ctl_state *state);

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.h
@@ -38,22 +38,19 @@ extern u8_t transition_type, default_tt;
 extern u32_t *ptr_counter;
 extern struct k_timer *ptr_timer;
 
-extern struct transition lightness_transition, temp_transition;
+extern struct transition transition;
 
 extern struct k_timer dummy_timer;
 
 void calculate_rt(struct transition *transition);
 
 
-void onoff_tt_values(struct generic_onoff_state *state, u8_t tt, u8_t delay);
-void level_tt_values(struct generic_level_state *state, u8_t tt, u8_t delay);
-void light_lightness_actual_tt_values(struct light_lightness_state *state,
-				      u8_t tt, u8_t delay);
-void light_lightness_linear_tt_values(struct light_lightness_state *state,
-				      u8_t tt, u8_t delay);
-void light_ctl_tt_values(struct light_ctl_state *state, u8_t tt, u8_t delay);
-void light_ctl_temp_tt_values(struct light_ctl_state *state,
-			      u8_t tt, u8_t delay);
+void onoff_tt_values(struct generic_onoff_state *state);
+void level_tt_values(struct generic_level_state *state);
+void light_lightness_actual_tt_values(struct light_lightness_state *state);
+void light_lightness_linear_tt_values(struct light_lightness_state *state);
+void light_ctl_tt_values(struct light_ctl_state *state);
+void light_ctl_temp_tt_values(struct light_ctl_state *state);
 
 void onoff_handler(struct generic_onoff_state *state);
 void level_lightness_handler(struct generic_level_state *state);


### PR DESCRIPTION
Commit 1:
This commit upgrade the implementation to reduce complexity in
algorithm. Previously there was different timers for lightness
as well as temperature transitions. But at time only single
transition is remain activated & hence there is no need
of multiple timer for each entity.

commit 2:
If Node Lightness is in downward transition & received Generic
onoff message to set state equal to 1 then Node transaction get
stopped in between. Ideally it should reach to default lightness
value if it is non-zero. This commit has solved this bug.

commit 3:
Remove redundant code from implementation.

commit 4:
After receiving Generic Level Move set/set_unack message, generic
level state should move towards positive or negative extreme end
(which is depend upon sign of delta value) till it not get interruped.
This commit has introduced this feature.

commit 5:
Replaced magic numbers with constant defined in stdint.h

commit 6:
Synchronizing the init procedure to initialize the mesh state only after
the settings have been loaded.

Signed-off-by: Vikrant More vikrant8051@gmail.com