### PR TITLE
Fix flashing the adafruit_trinket_m0 board

### DIFF
--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
@@ -11,6 +11,14 @@
 	model = "Adafruit Trinket M0";
 	compatible = "adafruit,trinket-m0", "atmel,samd21e18a", "atmel,samd21";
 
+	soc {
+		nvmctrl: nvmctrl@41004000  {
+			flash0: flash@0 {
+				reg = <0x2000 0x3E000>;
+			};
+		};
+	};
+
 	chosen {
 		zephyr,console = &sercom0;
 		zephyr,shell-uart = &sercom0;

--- a/boards/arm/adafruit_trinket_m0/board.cmake
+++ b/boards/arm/adafruit_trinket_m0/board.cmake
@@ -1,4 +1,6 @@
 # Copyright (c) 2018 Google LLC.
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(bossac "--offset=0x2000")
+
 include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/16052

Note that the flash address change is due to https://github.com/zephyrproject-rtos/zephyr/issues/13151