### PR TITLE
subsys/settings: Correct size in strncpy to avoid unterminated strings

### DIFF
--- a/subsys/settings/src/settings_runtime.c
+++ b/subsys/settings/src/settings_runtime.c
@@ -22,7 +22,9 @@ int settings_runtime_set(const char *name, void *data, size_t len)
 	char *name_argv[SETTINGS_MAX_DIR_DEPTH];
 	int name_argc;
 
-	strncpy(name1, name, sizeof(name1));
+	strncpy(name1, name, sizeof(name1) - 1);
+	name1[sizeof(name1) - 1] = '\0';
+
 	ch = settings_parse_and_lookup(name1, &name_argc, name_argv);
 	if (!ch) {
 		return -EINVAL;
@@ -39,7 +41,9 @@ int settings_runtime_get(const char *name, void *data, size_t len)
 	char *name_argv[SETTINGS_MAX_DIR_DEPTH];
 	int name_argc;
 
-	strncpy(name1, name, sizeof(name1));
+	strncpy(name1, name, sizeof(name1) - 1);
+	name1[sizeof(name1) - 1] = '\0';
+
 	ch = settings_parse_and_lookup(name1, &name_argc, name_argv);
 	if (!ch) {
 		return -EINVAL;
@@ -55,7 +59,9 @@ int settings_runtime_commit(const char *name)
 	char *name_argv[SETTINGS_MAX_DIR_DEPTH];
 	int name_argc;
 
-	strncpy(name1, name, sizeof(name1));
+	strncpy(name1, name, sizeof(name1) - 1);
+	name1[sizeof(name1) - 1] = '\0';
+
 	ch = settings_parse_and_lookup(name1, &name_argc, name_argv);
 	if (!ch) {
 		return -EINVAL;


### PR DESCRIPTION
This fixes some Coverity warnings.

Coverity-CID: 198391
Coverity-CID: 198390
Coverity-CID: 198389
Fixes #15989
Fixes #15990
Fixes #15991

Signed-off-by: François Delawarde <fnde@oticon.com>