### PR TITLE
cmake: Mark post_build files as BYPRODUCTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1214,58 +1214,108 @@ set(logical_target_for_zephyr_elf ${logical_target_for_zephyr_elf} PARENT_SCOPE)
 set_target_properties(${logical_target_for_zephyr_elf} PROPERTIES OUTPUT_NAME ${KERNEL_NAME})
 
 set(post_build_commands "")
-
-list_append_ifdef(CONFIG_CHECK_LINK_MAP
-  post_build_commands
-  COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/check_link_map.py ${KERNEL_MAP_NAME}
-  )
+set(post_build_byproducts "")
 
 if(NOT CONFIG_BUILD_NO_GAP_FILL)
   # Use ';' as separator to get proper space in resulting command.
   set(GAP_FILL "--gap-fill;0xff")
 endif()
 
-list_append_ifdef(
-  CONFIG_BUILD_OUTPUT_HEX
-  post_build_commands
-  COMMAND ${CMAKE_OBJCOPY} -S -Oihex ${GAP_FILL}  -R .comment -R COMMON -R .eh_frame  ${KERNEL_ELF_NAME}    ${KERNEL_HEX_NAME}
-  )
+if(CONFIG_CHECK_LINK_MAP)
+  list(APPEND
+    post_build_commands
+    COMMAND
+    ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/check_link_map.py ${KERNEL_MAP_NAME}
+    )
+  list(APPEND
+    post_build_byproducts
+    ${KERNEL_MAP_NAME}
+    )
+endif()
 
-list_append_ifdef(
-  CONFIG_BUILD_OUTPUT_BIN
-  post_build_commands
-  COMMAND ${CMAKE_OBJCOPY} -S -Obinary ${GAP_FILL} -R .comment -R COMMON -R .eh_frame  ${KERNEL_ELF_NAME}    ${KERNEL_BIN_NAME}
-  )
+if(CONFIG_BUILD_OUTPUT_HEX)
+  list(APPEND
+    post_build_commands
+    COMMAND
+    ${CMAKE_OBJCOPY} -S -Oihex ${GAP_FILL}  -R .comment -R COMMON -R .eh_frame  ${KERNEL_ELF_NAME} ${KERNEL_HEX_NAME}
+    )
+  list(APPEND
+    post_build_byproducts
+    ${KERNEL_HEX_NAME}
+    )
+endif()
 
-list_append_ifdef(
-  CONFIG_BUILD_OUTPUT_S19
-  post_build_commands
-  COMMAND ${CMAKE_OBJCOPY} ${GAP_FILL} --srec-len 1 --output-target=srec ${KERNEL_ELF_NAME} ${KERNEL_S19_NAME}
-  )
+if(CONFIG_BUILD_OUTPUT_BIN)
+  list(APPEND
+    post_build_commands
+    COMMAND
+    ${CMAKE_OBJCOPY} -S -Obinary ${GAP_FILL} -R .comment -R COMMON -R .eh_frame  ${KERNEL_ELF_NAME} ${KERNEL_BIN_NAME}
+    )
+  list(APPEND
+    post_build_byproducts
+    ${KERNEL_BIN_NAME}
+    )
+endif()
 
-list_append_ifdef(
-  CONFIG_OUTPUT_DISASSEMBLY
-  post_build_commands
-  COMMAND ${CMAKE_OBJDUMP} -S ${KERNEL_ELF_NAME} >  ${KERNEL_LST_NAME}
-  )
+if(CONFIG_BUILD_OUTPUT_S19)
+  list(APPEND
+    post_build_commands
+    COMMAND
+    ${CMAKE_OBJCOPY} ${GAP_FILL} --srec-len 1 --output-target=srec ${KERNEL_ELF_NAME} ${KERNEL_S19_NAME}
+    )
+  list(APPEND
+    post_build_byproducts
+    ${KERNEL_S19_NAME}
+    )
+endif()
 
-list_append_ifdef(
-  CONFIG_OUTPUT_STAT
-  post_build_commands
-  COMMAND ${CMAKE_READELF} -e ${KERNEL_ELF_NAME} >  ${KERNEL_STAT_NAME}
-  )
+if(CONFIG_OUTPUT_DISASSEMBLY)
+  list(APPEND
+    post_build_commands
+    COMMAND
+    ${CMAKE_OBJDUMP} -S ${KERNEL_ELF_NAME} > ${KERNEL_LST_NAME}
+    )
+  list(APPEND
+    post_build_byproducts
+    ${KERNEL_LST_NAME}
+    )
+endif()
 
-list_append_ifdef(
-  CONFIG_BUILD_OUTPUT_STRIPPED
-  post_build_commands
-  COMMAND ${CMAKE_STRIP}   --strip-all ${KERNEL_ELF_NAME} -o ${KERNEL_STRIP_NAME}
-  )
+if(CONFIG_OUTPUT_STAT)
+  list(APPEND
+    post_build_commands
+    COMMAND
+    ${CMAKE_READELF} -e ${KERNEL_ELF_NAME} > ${KERNEL_STAT_NAME}
+    )
+  list(APPEND
+    post_build_byproducts
+    ${KERNEL_STAT_NAME}
+    )
+endif()
 
-list_append_ifdef(
-  CONFIG_BUILD_OUTPUT_EXE
-  post_build_commands
-  COMMAND ${CMAKE_COMMAND} -E copy ${KERNEL_ELF_NAME}    ${KERNEL_EXE_NAME}
-  )
+if(CONFIG_BUILD_OUTPUT_STRIPPED)
+  list(APPEND
+    post_build_commands
+    COMMAND
+    ${CMAKE_STRIP} --strip-all ${KERNEL_ELF_NAME} -o ${KERNEL_STRIP_NAME}
+    )
+  list(APPEND
+    post_build_byproducts
+    ${KERNEL_STRIP_NAME}
+    )
+endif()
+
+if(CONFIG_BUILD_OUTPUT_EXE)
+  list(APPEND
+    post_build_commands
+    COMMAND
+    ${CMAKE_COMMAND} -E copy ${KERNEL_ELF_NAME} ${KERNEL_EXE_NAME}
+    )
+  list(APPEND
+    post_build_byproducts
+    ${KERNEL_EXE_NAME}
+    )
+endif()
 
 get_property(extra_post_build_commands
   GLOBAL PROPERTY
@@ -1277,6 +1327,16 @@ list(APPEND
   ${extra_post_build_commands}
   )
 
+get_property(extra_post_build_byproducts
+  GLOBAL PROPERTY
+  extra_post_build_byproducts
+  )
+
+list(APPEND
+  post_build_byproducts
+  ${extra_post_build_byproducts}
+  )
+
 # Add post_build_commands to post-process the final .elf file produced by
 # either the ZEPHYR_PREBUILT_EXECUTABLE or the KERNEL_ELF executable
 # targets above.
@@ -1284,6 +1344,8 @@ add_custom_command(
   TARGET ${logical_target_for_zephyr_elf}
   POST_BUILD
   ${post_build_commands}
+  BYPRODUCTS
+  ${post_build_byproducts}
   COMMENT "Generating files from ${KERNEL_ELF_NAME} for board: ${BOARD}"
   # NB: COMMENT only works for some CMake-Generators
   )


### PR DESCRIPTION
Mark post_build files as BYPRODUCTS to allow custom commands to depend
on them.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>