### PR TITLE
Shorten getting started

### DIFF
--- a/boards/posix/native_posix/doc/index.rst
+++ b/boards/posix/native_posix/doc/index.rst
@@ -22,6 +22,8 @@ target hardware in the early phases of development.
 This board provides a few peripherals such as an Ethernet driver and UART.
 See `Peripherals`_ for more information.
 
+.. _native_posix_deps:
+
 Host system dependencies
 ========================
 

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -501,11 +501,12 @@ Each time you execute the run command, your application is rebuilt and run
 again.
 
 
-.. note:: The ``run`` target will use the QEMU binary available from the Zephyr
-          SDK by default. To use an alternate version of QEMU, for example the
-          version installed on your host or a custom version, :ref:`set the
-          environment variable <env_vars>` ``QEMU_BIN_PATH`` to the alternate
-          path.
+.. note::
+
+   If the (Linux only) :ref:`Zephyr SDK <zephyr_sdk>` is installed, the ``run``
+   target will use the SDK's QEMU binary by default. To use another version of
+   QEMU, :ref:`set the environment variable <env_vars>` :envvar:`QEMU_BIN_PATH`
+   to the path of the QEMU binary you want to use instead.
 
 .. _application_debugging:
 .. _custom_board_definition:

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -260,8 +260,7 @@ should know about.
 
    * As a parameter to the ``cmake`` invocation via the ``-D`` command-line
      switch
-   * As an environment variables (``export`` on Linux/macOS and ``set`` on
-     Windows)
+   * As :ref:`env_vars`.
    * As a ``set(<VARIABLE> <VALUE>)`` statement in your :file:`CMakeLists.txt`
 
 * :makevar:`ZEPHYR_BASE`: Sets the path to the directory containing Zephyr,
@@ -504,8 +503,9 @@ again.
 
 .. note:: The ``run`` target will use the QEMU binary available from the Zephyr
           SDK by default. To use an alternate version of QEMU, for example the
-          version installed on your host or a custom version, set the
-          environment variable ``QEMU_BIN_PATH`` to the alternate path.
+          version installed on your host or a custom version, :ref:`set the
+          environment variable <env_vars>` ``QEMU_BIN_PATH`` to the alternate
+          path.
 
 .. _application_debugging:
 .. _custom_board_definition:
@@ -737,7 +737,8 @@ The :file:`.gdbinit` file contains the following lines:
 
 .. note::
 
-   Substitute ZEPHYR_BASE for the current kernel's root directory.
+   Substitute the correct :ref:`ZEPHYR_BASE <env_vars_important>` for your
+   system.
 
 Execute the application to debug from the same directory that you chose for
 the :file:`gdbinit` file. The command can include the ``--tui`` option
@@ -813,8 +814,8 @@ Set Up the Eclipse Development Environment
 Generate and Import an Eclipse Project
 ======================================
 
-#. At a command line, configure your environment to use the GCC ARM Embedded
-   compiler as shown in :ref:`third_party_x_compilers`.
+#. Set up a GNU Arm Embedded toolchain as described in
+   :ref:`third_party_x_compilers`.
 
 #. Navigate to a folder outside of the Zephyr tree to build your application.
 
@@ -877,7 +878,7 @@ Create a Debugger Configuration
 
      - GDB Client Setup
 
-       - Executable path:
+       - Executable path example (use your :envvar:`GNUARMEMB_TOOLCHAIN_PATH`):
          :file:`C:\\gcc-arm-none-eabi-6_2017-q2-update\\bin\\arm-none-eabi-gdb.exe`
 
    - In the SVD Path tab:
@@ -973,7 +974,8 @@ Make sure to follow these steps in order.
    - Any value given on the CMake command line using ``-DBOARD=YOUR_BOARD``
      will be checked for and used next.
 
-   - If an environment variable ``BOARD`` is set, its value will then be used.
+   - If an :ref:`environment variable <env_vars>` ``BOARD`` is set, its value
+     will then be used.
 
    - Finally, if you set ``BOARD`` in your application :file:`CMakeLists.txt`
      as described in this step, this value will be used.
@@ -1436,8 +1438,8 @@ follows:
   passed to the the CMake command line, or present in the CMake variable cache,
   takes precedence.
 
-- The environment variable :envvar:`DTC_OVERLAY_FILE` is checked
-  next. This mechanism is now deprecated; users should set this
+- The :ref:`environment variable <env_vars>` :envvar:`DTC_OVERLAY_FILE` is
+  checked next. This mechanism is now deprecated; users should set this
   variable using CMake instead of the environment.
 
 - If the file :file:`BOARD.overlay` exists in your application directory,

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -50,9 +50,9 @@ See :ref:`west-install` for additional details on installing west. See
 `Installing Packages`_ in the Python Packaging User Guide for more information
 about pip\ [#pip]_, including this `information on -\\-user`_.
 
-- On Linux, verify that ``~/.local/bin`` is on your :envvar:`PATH` environment
-  variable, or programs installed with this option (like west) won't be
-  found\ [#linux_user]_.
+- On Linux, make sure ``~/.local/bin`` is on your :envvar:`PATH`
+  :ref:`environment variable <env_vars>`, or programs installed with ``--user``
+  -- like west -- won't be found\ [#linux_user]_.
 
 - On macOS, `Homebrew disables -\\-user`_.
 
@@ -97,6 +97,8 @@ Install Python packages required by Zephyr:
    # macOS and Windows
    pip3 install -r zephyr/scripts/requirements.txt
 
+.. _gs_toolchain:
+
 Set Up a Toolchain
 ******************
 
@@ -106,9 +108,9 @@ Toolchains are *installed* in the usual ways you get programs: with installer
 programs or system package managers, by downloading and extracting a zip
 archive, etc.
 
-You *configure* the toolchain to use by setting environment variables. You need
-to set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to a supported value, along with
-additional variable(s) specific to the toolchain variant.
+You *configure* the toolchain to use by setting :ref:`environment variables
+<env_vars>`. You need to set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to a supported
+value, along with additional variable(s) specific to the toolchain variant.
 
 The following choices are available. If you're not sure what to use, check your
 :ref:`board-level documentation <boards>`. If you're targeting an Arm Cortex-M,
@@ -124,16 +126,6 @@ you set up the :ref:`Zephyr SDK <zephyr_sdk>` toolchains or if you want to
    toolchain_other_x_compilers.rst
    toolchain_host.rst
    toolchain_custom_cmake.rst
-
-To use the same toolchain in new sessions in the future, make sure the
-variables are set persistently.
-
-On macOS and Linux, you can set the variables by putting the ``export`` lines
-setting environment variables in a file :file:`~/.zephyrrc`. On Windows, you
-can put the ``set`` lines in :file:`%userprofile%\\zephyrrc.cmd`. These files
-are used to modify your environment when you run ``zephyr-env.sh`` (Linux,
-macOS) and ``zephyr-env.cmd`` (Windows), which you will learn about in the next
-step.
 
 .. _getting_started_run_sample:
 

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -4,7 +4,7 @@ Getting Started Guide
 #####################
 
 Follow this guide to set up a :ref:`Zephyr <introducing_zephyr>` development
-environment on your system, and then build and run a sample application.
+environment, then build and run a sample application.
 
 .. tip::
 
@@ -12,10 +12,10 @@ environment on your system, and then build and run a sample application.
 
 .. _host_setup:
 
-Set Up a Development System
-***************************
+Install Host Dependencies
+*************************
 
-Follow one of the following guides for your host operating system.
+Follow an operating system specific guide, then come back to this page.
 
 .. toctree::
    :maxdepth: 1
@@ -29,50 +29,42 @@ Follow one of the following guides for your host operating system.
 Get the source code
 *******************
 
-Zephyr's multi-purpose :ref:`west` tool lets you easily get the Zephyr project
-source code, instead of manually cloning the Zephyr repos along with west
-itself.
-
-.. warning::
-
-   It's possible to use Zephyr without installing west, but you have
-   to **really** know :ref:`what you are doing <no-west>`.
+Zephyr's multi-purpose :ref:`west <west>` tool lets you easily get the Zephyr
+project repositories. (While it's easiest to develop with Zephyr using west,
+we also have :ref:`documentation for doing without it <no-west>`.)
 
 Bootstrap west
 ==============
 
-First, install the ``west`` binary and bootstrapper:
+First, install the ``west`` binary and bootstrapper using ``pip3``:
 
 .. code-block:: console
 
    # Linux
    pip3 install --user west
 
-   # macOS and Windows
+   # macOS (Terminal) and Windows (cmd.exe)
    pip3 install west
 
-.. note::
-   See :ref:`west-install` for additional details on installing west.
+See :ref:`west-install` for additional details on installing west. See
+`Installing Packages`_ in the Python Packaging User Guide for more information
+about pip\ [#pip]_, including this `information on -\\-user`_.
+
+- On Linux, verify that ``~/.local/bin`` is on your :envvar:`PATH` environment
+  variable, or programs installed with this option (like west) won't be
+  found\ [#linux_user]_.
+
+- On macOS, `Homebrew disables -\\-user`_.
+
+- On Windows, see the Installing Packages information on ``--user`` if you
+  require using this option.
 
 .. _clone-zephyr:
 
 Clone the Zephyr Repositories
 =============================
 
-.. warning::
-   If you have run ``source zephyr-env.sh`` (on Linux or macOS) or
-   ``zephyr-env.cmd`` (on Windows) on a clone of zephyr that predates the
-   introduction of west, then the copy of west included in the clone will
-   override the bootstrapper installed with ``pip``. In that case close the
-   shell and open a new one in order to remove it from the ``PATH``. You
-   can check which ``west`` is being executed by running::
-
-      west --version
-
-   You should see ``West bootstrapper version: v0.5.0`` (or higher).
-
-Next, clone the Zephyr source code repositories from GitHub using the
-``west`` tool you just installed:
+Clone all of Zephyr's repositories in a new :file:`zephyrproject` directory:
 
 .. code-block:: console
 
@@ -80,34 +72,12 @@ Next, clone the Zephyr source code repositories from GitHub using the
    cd zephyrproject
    west update
 
-.. note::
-   You can replace :file:`zephyrproject` with the folder name of your choice.
-   West will create the named folder if it doesn't already exist.
-   If no folder name is specified, west initializes the current
-   working directory.
-
-.. note::
-   If you had previously cloned the zephyr repository manually using Git,
-   create an empty enclosing folder (for example :file:`zephyrproject/`),
-   and move the cloned repository into it. From the enclosing folder run::
-
-      west init -l zephyr/
-      west update
-
-   The ``-l <path to zephyr>`` parameter instructs ``west`` to use an existing
-   local copy instead of cloning a remote repository. This will create a full
-   Zephyr installation (see below).
-
-Running ``west init`` will clone west itself into ``./.west/west`` and
-initialize a local installation. Running ``west update`` will pull all the
-projects referenced by the manifest file (:file:`zephyr/west.yml`) into the
-folders specified in it. See :ref:`west-multi-repo` for additional details, a
-list of the folders and files that west will create as part of the process,
-and more on how ``west`` helps manage multiple repositories.
+You can replace :file:`zephyrproject` with another directory name. West creates
+the directory if it doesn't exist. See :ref:`west-multi-repo` for more details.
 
 .. warning::
 
-   Don't clone Zephyr to a directory with spaces anywhere in the path.
+   Don't clone into a directory with spaces anywhere in the path.
    For example, on Windows, :file:`C:\\Users\\YourName\\zephyrproject` will
    work, but :file:`C:\\Users\\Your Name\\zephyrproject` will cause cryptic
    errors when you try to build an application.
@@ -117,8 +87,7 @@ and more on how ``west`` helps manage multiple repositories.
 Install Python Dependencies
 ***************************
 
-Next, install additional Python packages required by Zephyr in a shell or
-``cmd.exe`` prompt:
+Install Python packages required by Zephyr:
 
 .. code-block:: console
 
@@ -128,77 +97,36 @@ Next, install additional Python packages required by Zephyr in a shell or
    # macOS and Windows
    pip3 install -r zephyr/scripts/requirements.txt
 
-Some notes on pip's ``--user`` option:
-
-- Installing with ``--user`` is the default behavior on Debian-based
-  distributions and is generally recommended on Linux to avoid conflicts with
-  Python packages installed using the system package manager.
-
-- On Linux, verify the Python user install directory ``~/.local/bin`` is at the front of
-  your PATH environment variable, otherwise installed packages won't be
-  found.
-
-- On macOS, Homebrew disables the ``--user`` flag\ [#homebrew_user]_.
-
-- On Windows using ``cmd.exe``, although it's possible to use the ``--user``
-  flag, it makes it harder for the command prompt to find executables installed
-  by pip.
-
-
 Set Up a Toolchain
 ******************
 
-.. note::
+Zephyr binaries are compiled and linked by a *toolchain*\
+[#tools_native_posix]_. You now need to *install* and *configure* a toolchain.
+Toolchains are *installed* in the usual ways you get programs: with installer
+programs or system package managers, by downloading and extracting a zip
+archive, etc.
 
-   On Linux, you can skip this step if you installed the :ref:`Zephyr SDK
-   <zephyr_sdk>`, which includes toolchains for all supported Zephyr
-   architectures.
+You *configure* the toolchain to use by setting environment variables. You need
+to set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to a supported value, along with
+additional variable(s) specific to the toolchain variant.
 
-   In some specific configurations like non-MCU x86 targets on Linux,
-   you may be able to re-use the native development tools provided by
-   your operating system instead of an SDK by setting
-   ``ZEPHYR_TOOLCHAIN_VARIANT=host`` for gcc or
-   ``ZEPHYR_TOOLCHAIN_VARIANT=llvm`` for clang.
+The following choices are available. If you're not sure what to use, check your
+:ref:`board-level documentation <boards>`. If you're targeting an Arm Cortex-M,
+:ref:`toolchain_gnuarmemb` is a safe bet.  On Linux, you can skip this step if
+you set up the :ref:`Zephyr SDK <zephyr_sdk>` toolchains or if you want to
+:ref:`gs_posix`.
 
-   If you want, you can use the SDK host tools (such as OpenOCD) with a
-   different toolchain by keeping the :envvar:`ZEPHYR_SDK_INSTALL_DIR`
-   environment variable set to the Zephyr SDK installation directory, while
-   setting :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` appropriately for a non-SDK
-   toolchain.
-
-Zephyr binaries are compiled using software called a *toolchain*. You need to
-*install* and *configure* a toolchain to develop Zephyr applications\
-[#tools_native_posix]_.
-
-Toolchains can be *installed* in different ways, including using installer
-programs, system package managers, or simply downloading a zip file or other
-archive and extracting the files somewhere on your computer.  You *configure*
-the toolchain by setting the environment variable
-:envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to a recognized value, along with some
-additional variable(s) specific to that toolchain (usually, this is just one
-more variable which contains the path where you installed the toolchain on your
-file system).
-
-.. note::
-
-   In previous releases of Zephyr, the ``ZEPHYR_TOOLCHAIN_VARIANT`` variable
-   was called ``ZEPHYR_GCC_VARIANT``.
-
-The following toolchain installation options are available. The right choice
-for you depends on where you want to run Zephyr and any other requirements you
-may have. Check your :ref:`board-level documentation <boards>` if you are
-unsure about what choice to use.
 
 .. toctree::
    :maxdepth: 2
 
    toolchain_3rd_party_x_compilers.rst
    toolchain_other_x_compilers.rst
+   toolchain_host.rst
    toolchain_custom_cmake.rst
 
-
-To use the same toolchain in new sessions in the future you can make
-sure the variables are set persistently.
+To use the same toolchain in new sessions in the future, make sure the
+variables are set persistently.
 
 On macOS and Linux, you can set the variables by putting the ``export`` lines
 setting environment variables in a file :file:`~/.zephyrrc`. On Windows, you
@@ -216,6 +144,9 @@ Next, build a sample Zephyr application. You can then flash and run it on real
 hardware using any supported host system. Depending on your operating system,
 you can also run it in emulation with QEMU or as a native POSIX application.
 
+You can build applications by either running ``cmake`` directly or using the
+:ref:`west build <west-building>` convenience wrapper.
+
 .. _getting_started_cmake:
 
 A Brief Note on the Zephyr Build System
@@ -227,37 +158,21 @@ formats, called `generators`_. Zephyr supports the following generators:
  * ``Unix Makefiles``: Supported on UNIX-like platforms (Linux, macOS).
  * ``Ninja``: Supported on all platforms.
 
-This documentation and Zephyr's continuous integration system mainly use
-``Ninja``, but you should be able to use any supported generator to build
-Zephyr applications, both when using ``cmake`` directly or ``west``.
+You can use any supported generator when running ``cmake`` directly or using
+``west build``.
 
-Build the Application
-=====================
+Build Hello World
+=================
 
-Follow these steps to build the :ref:`hello_world` sample application provided
-with Zephyr.
+Let's build the :ref:`hello_world` sample application.
 
-As mentioned earlier, Zephyr's build system is based on
-:ref:`CMake <application>`. You can build an application either by using
-``cmake`` directly or by using :ref:`west <west>`, Zephyr's meta-tool that is
-also used to :ref:`manage the repositories <west-multi-repo>`. You can find
-additional information about west's build capabilities in
-:ref:`west-build-flash-debug`.
+Zephyr applications are built to run on specific hardware, which is
+called a "board"\ [#board_misnomer]_. We'll use the :ref:`reel_board
+<reel_board>` here, but you can change ``reel_board`` to another value if you
+have a different board. See :ref:`boards` or run ``west boards`` from anywhere
+inside the ``zephyrproject`` directory for a list of supported boards.
 
-Zephyr applications have to be configured and built to run on some hardware
-configuration, which is called a "board"\ [#board_misnomer]_. These steps show
-how to build the Hello World application for the :ref:`reel_board` board.  You
-can build for a different board by changing ``reel_board`` to another
-supported value. See :ref:`boards` for more information, or use the ``usage``
-build target from an initialized build directory to get a list.
-
-.. note::
-
-   If you want to re-use your existing build directory to build for another
-   board, you must delete that directory's contents first by using the
-   ``pristine`` build target.
-
-#. Navigate to the main project directory:
+#. Go to the zephyr repository:
 
    .. code-block:: console
 
@@ -267,9 +182,10 @@ build target from an initialized build directory to get a list.
 
    .. code-block:: console
 
-      # On Linux/macOS
+      # Linux and macOS
       source zephyr-env.sh
-      # On Windows
+
+      # Windows
       zephyr-env.cmd
 
 #. Build the Hello World sample for the ``reel_board``:
@@ -284,8 +200,17 @@ build target from an initialized build directory to get a list.
       :board: reel_board
       :goals: build
 
-   On Linux/macOS you can also use ``cmake`` to build with ``make`` instead
-   of ``ninja``:
+   On Linux and macOS, you can also build with ``make`` instead of ``ninja``.
+
+   Using west:
+
+   - to use ``make`` just once, add ``-- -G"Unix Makefiles"`` to the west build
+     command line; see the :ref:`west build <west-building-generator>`
+     documentation for an example.
+   - to use ``make`` by default from now on, run ``west config build.generator
+     "Unix Makefiles"``.
+
+   Using CMake directly:
 
    .. zephyr-app-commands::
       :tool: cmake
@@ -295,30 +220,32 @@ build target from an initialized build directory to get a list.
       :board: reel_board
       :goals: build
 
-The main build products are in :file:`samples/hello_world/build/zephyr`.
-The final application binary in ELF format is named :file:`zephyr.elf` by
-default. Other binary formats and byproducts such as disassembly and map files
-will be present depending on the target and build system configuration.
+Either way, the main build products will be in :file:`build/zephyr`;
+:file:`build/zephyr/zephyr.elf` is the Hello World application binary in ELF
+format. Other binary formats, disassembly, and map files may be present
+depending on your board.
 
-Other sample projects demonstrating Zephyr's features are located in
-:zephyr_file:`samples` and are documented in :ref:`samples-and-demos`.
+The other sample applications in :zephyr_file:`samples` are documented in
+:ref:`samples-and-demos`. If you want to re-use an existing build directory for
+another board or application, you need to run the ``pristine`` build system
+target or pass ``-p=auto`` to ``west build``.
 
 Run the Application by Flashing to a Board
 ==========================================
 
 Most "real hardware" boards supported by Zephyr can be flashed by running
-``west flash`` or ``ninja flash`` from the build directory. However, this may
-require board-specific tool installation and configuration to work properly.
+``west flash``, or by running ``ninja flash`` from the build
+directory. However, this may require board-specific tool installation and
+configuration to work properly.
 
-See :ref:`application_run` in the Application Development Primer and the
-documentation provided with your board at :ref:`boards` for additional details
-if you get an error.
+See :ref:`application_run` in the Application Development Primer and your
+board's documentation in :ref:`boards` for additional details.
 
 Run the Application in QEMU
 ===========================
 
 On Linux and macOS, you can run Zephyr applications in emulation on your host
-system using QEMU when targeting either the X86 or ARM Cortex-M3 architectures.
+system using QEMU when targeting either the x86 or ARM Cortex-M3 architectures.
 
 To build and run Hello World using the x86 emulation board configuration
 (``qemu_x86``), type:
@@ -332,20 +259,19 @@ To build and run Hello World using the x86 emulation board configuration
 
 To exit, type :kbd:`Ctrl-a`, then :kbd:`x`.
 
-Use the ``qemu_cortex_m3`` board configuration to run on an emulated Arm
-Cortex-M3.
+Use ``qemu_cortex_m3`` to target an emulated Arm Cortex-M3 instead.
+
+.. _gs_posix:
 
 Run a Sample Application natively (POSIX OS)
 ============================================
 
-Finally, it is also possible to compile some samples to run as native processes
-on a POSIX OS. This is currently only tested on Linux hosts.
+Finally, it is also possible to compile some samples to run as host processes
+on a POSIX OS. This is currently only tested on Linux hosts. See
+:ref:`native_posix` for more information. On 64 bit host operating systems, you
+need to install a 32 bit C library; see :ref:`native_posix_deps` for details.
 
-On 64 bit host operating systems, you will also need a 32 bit C library
-installed. See the :ref:`native_posix` section on host dependencies for more
-information.
-
-To compile and run Hello World in this way, type:
+First, build Hello World for ``native_posix``.
 
 .. zephyr-app-commands::
    :tool: all
@@ -354,43 +280,50 @@ To compile and run Hello World in this way, type:
    :board: native_posix
    :goals: build
 
-and then:
+Next, run the application.
 
 .. code-block:: console
 
-   # With west
+   # With west:
    west build -t run
 
-   # With ninja
+   # With ninja, from the build directory:
    ninja run
 
-   # or just:
-   zephyr/zephyr.exe
-   # Press Ctrl+C to exit
+   # or just run zephyr.exe directly:
+   ./zephyr/zephyr.exe
 
-You can run ``zephyr/zephyr.exe --help`` to get a list of available
-options.  See the :ref:`native_posix` document for more information.
+Press :kbd:`Ctrl-C` to exit.
+
+You can run ``./zephyr/zephyr.exe --help`` to get a list of available
+options.
 
 This executable can be instrumented using standard tools, such as gdb or
 valgrind.
 
 .. rubric:: Footnotes
 
-.. [#homebrew_user]
+.. [#pip]
 
-   For details, see
-   https://docs.brew.sh/Homebrew-and-Python#note-on-pip-install---user.
+   pip is Python's package installer. Its ``install`` command first tries to
+   re-use packages and package dependencies already installed on your computer.
+   If that is not possible, ``pip install`` downloads them from the Python
+   Package Index (PyPI) on the Internet.
+
+   The package versions requested by Zephyr's :file:`requirements.txt` may
+   conflict with other requirements on your system, in which case you may
+   want to set up a virtualenv for Zephyr development.
+
+.. [#linux_user]
+
+   Installing with ``--user`` avoids conflicts between pip and the system
+   package manager, and is the default on Debian-based distributions.
 
 .. [#tools_native_posix]
 
    Usually, the toolchain is a cross-compiler and related tools which are
    different than the host compilers and other programs available for
    developing software to run natively on your operating system.
-
-   One exception is when building Zephyr as a host binary to run on a POSIX
-   operating system. In this case, you still need to set up a toolchain, but it
-   will provide host compilers instead of cross compilers. For details on this
-   option, see :ref:`native_posix`.
 
 .. [#board_misnomer]
 
@@ -404,6 +337,8 @@ valgrind.
    configurations is called a "board," even though that doesn't always make
    perfect sense in context.
 
-.. _Manifest repository: https://github.com/zephyrproject-rtos/manifest
+.. _information on -\\-user: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+.. _Homebrew disables -\\-user: https://docs.brew.sh/Homebrew-and-Python#note-on-pip-install---user
 .. _CMake: https://cmake.org
 .. _generators: https://cmake.org/cmake/help/v3.8/manual/cmake-generators.7.html
+.. _Installing Packages: https://packaging.python.org/tutorials/installing-packages/

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -169,13 +169,14 @@ Follow these steps to install the Zephyr SDK:
    Zephyr's dependencies were installed as described in `Install Requirements
    and Dependencies`_.
 
-#. To use the Zephyr SDK, export the following environment variables and
-   use the target location where SDK was installed:
+#. Set these :ref:`environment variables <env_vars>`:
 
-   .. code-block:: console
+   - set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``zephyr``
+   - set :envvar:`ZEPHYR_SDK_INSTALL_DIR` to :file:`$HOME/zephyr-sdk-0.10.0`
+     (or wherever you chose to install the SDK)
 
-      export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-      export ZEPHYR_SDK_INSTALL_DIR=<sdk installation directory>
+If you ever want to uninstall the SDK, just remove the directory where you
+installed it and unset these environment variables.
 
 .. _sdkless_builds:
 

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -1,54 +1,44 @@
 .. _installation_linux:
 
-Development Environment Setup on Linux
-######################################
+Install Linux Host Dependencies
+###############################
 
 .. important::
 
-   This section only describes OS-specific setup instructions; it is the first step in the
-   complete Zephyr :ref:`getting_started`.
+   Go back to the main :ref:`getting_started` when you're done here.
 
-This section describes how to set up a Zephyr development environment on the
-following Linux distributions:
+Documentation is available for these Linux distributions:
 
 * Ubuntu 16.04 LTS or 18.04 LTS 64-bit
 * Fedora 28 64-bit
 * Clear Linux
 * Arch Linux
 
-Where needed, instructions are given which only apply to specific Linux
-distributions.
-
 Update Your Operating System
 ****************************
 
-Ensure your host system is up to date before proceeding.
+Ensure your host system is up to date.
 
-On Ubuntu:
+Ubuntu:
 
 .. code-block:: console
 
    sudo apt-get update
    sudo apt-get upgrade
 
-On Fedora:
+Fedora:
 
 .. code-block:: console
 
    sudo dnf upgrade
 
-Note that having a newer version available for an installed package
-(as reported by ``dnf check-update``) does not imply a subsequent
-``dnf upgrade`` will install it, because it must also ensure dependencies
-and other restrictions are satisfied.
-
-On Clear Linux:
+Clear Linux:
 
 .. code-block:: console
 
    sudo swupd update
 
-On Arch Linux:
+Arch Linux:
 
 .. code-block:: console
 
@@ -67,10 +57,10 @@ Install Requirements and Dependencies
    introduction of LaTeX->PDF support for the docs, as the texlive footprint is
    massive and not needed by users not building PDF documentation.)
 
-Install the following packages using your system's package manager. Note that
-both Ninja and Make are installed; you may prefer only to install one.
+Note that both Ninja and Make are installed with these instructions; you only
+need one.
 
-On Ubuntu:
+Ubuntu:
 
 .. code-block:: console
 
@@ -79,7 +69,7 @@ On Ubuntu:
      python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
      make gcc gcc-multilib
 
-On Fedora:
+Fedora:
 
 .. code-block:: console
 
@@ -88,27 +78,22 @@ On Fedora:
    dnf install git cmake ninja-build gperf ccache dfu-util dtc wget \
      python3-pip python3-tkinter xz file glibc-devel.i686 libstdc++-devel.i686
 
-On Clear Linux:
+Clear Linux:
 
 .. code-block:: console
 
    sudo swupd bundle-add c-basic dev-utils dfu-util dtc \
      os-core-dev python-basic python3-basic python3-tcl
 
-On Arch:
+Arch Linux:
 
 .. code-block:: console
 
    sudo pacman -S git cmake ninja gperf ccache dfu-util dtc wget \
        python-pip python-setuptools python-wheel tk xz file make
 
-.. important::
-   Zephyr requires a recent version of CMake. Read through
-   the rest of the section below to verify the version you have
-   installed is recent enough to build Zephyr.
-
-CMake version 3.13.1 or higher is required. Check what version you have by using
-``cmake --version``. If you have an older version, there are several ways
+**CMake version 3.13.1 or higher is required**. Check what version you have by
+using ``cmake --version``. If you have an older version, there are several ways
 of obtaining a more recent one:
 
 * Use ``pip``:
@@ -131,27 +116,20 @@ of obtaining a more recent one:
 * Check your distribution's beta or unstable release package library for an
   update.
 
-.. note::
-   If you have installed a recent version of CMake using one of the approaches
-   listed above, you might want to uninstall the one provided by your
-   distribution's package manager (``apt``, ``dnf``, ``swupd``, ``pacman``,
-   etc.) in order to avoid version conflicts.
+You might also want to uninstall the CMake provided by your package manager to
+avoid conflicts.
 
 .. _zephyr_sdk:
 
 Install the Zephyr Software Development Kit (SDK)
 *************************************************
 
-.. note::
+Use of the Zephyr SDK is optional, but recommended. Some of the dependencies
+installed above are only needed for installing the SDK.
 
-   Use of the Zephyr SDK is optional, but recommended. Some of the requirements
-   and dependencies in the previous section are only needed for installing the
-   SDK.
-
-Zephyr's :abbr:`SDK (Software Development Kit)` contains all necessary tools
-and cross-compilers needed to build Zephyr on all supported
-architectures. Additionally, it includes host tools such as custom QEMU binaries
-and a host compiler for building host tools if necessary. The SDK supports the
+Zephyr's :abbr:`SDK (Software Development Kit)` contains all necessary tools to
+build Zephyr on all supported architectures. Additionally, it includes host
+tools such as custom QEMU binaries and a host compiler. The SDK supports the
 following target architectures:
 
 * :abbr:`X86 (Intel Architecture 32 bits)`
@@ -168,7 +146,7 @@ following target architectures:
 
 * :abbr:`RISC-V`
 
-Follow these steps to install the SDK on your Linux host system.
+Follow these steps to install the Zephyr SDK:
 
 #. Download the latest SDK as a self-extracting installation binary:
 
@@ -179,23 +157,17 @@ Follow these steps to install the SDK on your Linux host system.
    (You can change *0.10.0* to another version if needed; the `Zephyr
    Downloads`_ page contains all available SDK releases.)
 
-#. Run the installation binary:
+#. Run the installation binary, installing the SDK at
+   :file:`~/zephyr-sdk-0.10.0`:
 
    .. code-block:: console
 
       cd <sdk download directory>
-      sh zephyr-sdk-0.10.0-setup.run
+      ./zephyr-sdk-0.10.0-setup.run -- -d ~/zephyr-sdk-0.10.0
 
-   .. important::
-      If this fails, make sure Zephyr's dependencies were installed
-      as described in `Install Requirements and Dependencies`_.
-
-#. Follow the installation instructions on the screen. The toolchain's
-   default installation location is :file:`/opt/zephyr-sdk/`, but it
-   is recommended to install the SDK under your home directory instead.
-
-   To install the SDK in the default location, you need to run the
-   installation binary as root.
+   You can pick another directory if you want. If this fails, make sure
+   Zephyr's dependencies were installed as described in `Install Requirements
+   and Dependencies`_.
 
 #. To use the Zephyr SDK, export the following environment variables and
    use the target location where SDK was installed:

--- a/doc/getting_started/installation_mac.rst
+++ b/doc/getting_started/installation_mac.rst
@@ -1,12 +1,11 @@
 .. _installing_zephyr_mac:
 
-Development Environment Setup on macOS
-######################################
+Install macOS Host Dependencies
+###############################
 
 .. important::
 
-   This section only describes OS-specific setup instructions; it is the first step in the
-   complete Zephyr :ref:`getting_started`.
+   Go back to the main :ref:`getting_started` when you're done here.
 
 This section describes how to set up a Zephyr development environment on macOS.
 
@@ -33,12 +32,10 @@ Install Requirements and Dependencies
    introduction of LaTeX->PDF support for the docs, as the texlive footprint is
    massive and not needed by users not building PDF documentation.)
 
-.. note::
-
-   Zephyr requires Python 3, while macOS only provides a Python 2
-   installation. After following these instructions, the version of Python 2
-   provided by macOS in ``/usr/bin/`` will sit alongside the Python 3
-   installation from Homebrew in ``/usr/local/bin``.
+Zephyr requires Python 3, while macOS only provides a Python 2
+installation. After following these instructions, the version of Python 2
+provided by macOS in ``/usr/bin/`` will sit alongside the Python 3 installation
+from Homebrew in ``/usr/local/bin``.
 
 First, install :program:`Homebrew` by following instructions on the `Homebrew
 site`_. Homebrew is a free and open-source package management system that
@@ -46,8 +43,7 @@ simplifies the installation of software on macOS.  While installing Homebrew,
 you may be prompted to install additional missing dependencies; please follow
 any such instructions as well.
 
-After Homebrew is successfully installed, install the following tools using
-the ``brew`` command line tool in the Terminal application.
+Now install these host dependencies with the ``brew`` command:
 
 .. code-block:: console
 

--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -1,18 +1,13 @@
 .. _installing_zephyr_win:
 
-Development Environment Setup on Windows
-########################################
+Install Windows Host Dependencies
+#################################
 
 .. important::
 
-   This section only describes OS-specific setup instructions; it is the first step in the
-   complete Zephyr :ref:`getting_started`.
+   Go back to the main :ref:`getting_started` when you're done here.
 
-This section describes how to configure your development environment
-to build Zephyr applications in a Microsoft Windows environment.
-
-This guide was tested by building the Zephyr :ref:`hello_world` sample
-application on Windows versions 7, 8.1, and 10.
+This guide was tested on Windows versions 7, 8.1, and 10.
 
 Update Your Operating System
 ****************************
@@ -35,14 +30,11 @@ Install Requirements and Dependencies
 
 There are 2 different ways of developing for Zephyr on Microsoft Windows:
 
-#. :ref:`windows_install_native`
+#. :ref:`windows_install_native` (recommended)
 #. :ref:`windows_install_wsl`
 
 The first option is fully Windows native; the other requires emulation layers
-that may result in slower build times. Both are included for completeness,
-but unless you have a particular requirement for a UNIX tool that is not
-available on Windows, we strongly recommend you use the Windows Command Prompt
-option for performance and minimal dependency set.
+that may result in slower build times.
 
 .. _windows_install_native:
 

--- a/doc/getting_started/toolchain_3rd_party_x_compilers.rst
+++ b/doc/getting_started/toolchain_3rd_party_x_compilers.rst
@@ -6,6 +6,8 @@
 A "3rd party toolchain" is an officially supported toolchain provided by an
 external organization. Several of these are available.
 
+.. _toolchain_gnuarmemb:
+
 GNU ARM Embedded
 ****************
 

--- a/doc/getting_started/toolchain_3rd_party_x_compilers.rst
+++ b/doc/getting_started/toolchain_3rd_party_x_compilers.rst
@@ -26,24 +26,29 @@ GNU ARM Embedded
 	  has a `critical bug <https://github.com/zephyrproject-rtos/zephyr/issues/12257>`_
 	  and should not be used. Toolchain version **7-2018-q2-update** is known to work.
 
-#. Configure the environment variables needed to inform the Zephyr build system
-   to use this toolchain:
+#. :ref:`Set these environment variables <env_vars>`:
 
    - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``gnuarmemb``.
    - Set :envvar:`GNUARMEMB_TOOLCHAIN_PATH` to the toolchain installation
      directory.
 
-   For example:
+#. To check that you have set these variables correctly in your current
+   environment, follow these example shell sessions (the
+   :envvar:`GNUARMEMB_TOOLCHAIN_PATH` values may be different on your system):
 
    .. code-block:: console
 
-      # Linux or macOS
-      export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-      export GNUARMEMB_TOOLCHAIN_PATH="~/gnu_arm_embedded"
+      # Linux, macOS:
+      $ echo $ZEPHYR_TOOLCHAIN_VARIANT
+      gnuarmemb
+      $ echo $GNUARMEMB_TOOLCHAIN_PATH
+      /home/you/Downloads/gnu_arm_embedded
 
-      # Windows in cmd.exe
-      set ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-      set GNUARMEMB_TOOLCHAIN_PATH=C:\gnu_arm_embedded
+      # Windows
+      > echo %ZEPHYR_TOOLCHAIN_VARIANT%
+      gnuarmemb
+      > echo %GNUARMEMB_TOOLCHAIN_PATH%
+      C:\gnu_arm_embedded
 
 Intel ISSM
 **********
@@ -65,24 +70,29 @@ Intel ISSM
       Like the Zephyr repository, do not install the toolchain in a directory
       with spaces anywhere in the path.
 
-#. Configure the environment variables needed to inform the Zephyr build system
-   to use this toolchain:
+#. :ref:`Set these environment variables <env_vars>`:
 
    - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``issm``.
    - Set :envvar:`ISSM_INSTALLATION_PATH` to the directory containing the
      extracted files.
 
-   For example:
+#. To check that you have set these variables correctly in your current
+   environment, follow these example shell sessions (the
+   :envvar:`ISSM_INSTALLATION_PATH` values may be different on your system):
 
    .. code-block:: console
 
       # Linux
-      export ZEPHYR_TOOLCHAIN_VARIANT=issm
-      export ISSM_INSTALLATION_PATH=/home/you/Downloads/issm0-toolchain-windows-2017-02-07
+      $ echo $ZEPHYR_TOOLCHAIN_VARIANT
+      issm
+      $ echo $ISSM_INSTALLATION_PATH
+      /home/you/Downloads/issm0-toolchain-windows-2017-02-07
 
-      # Windows in cmd.exe
-      set ZEPHYR_TOOLCHAIN_VARIANT=issm
-      set ISSM_INSTALLATION_PATH=c:\issm0-toolchain-windows-2017-01-25
+      # Windows
+      > echo %ZEPHYR_TOOLCHAIN_VARIANT%
+      issm
+      > echo %ISSM_INSTALLATION_PATH%
+      c:\issm0-toolchain-windows-2017-01-25
 
 .. _xtools_x_compilers:
 
@@ -109,18 +119,22 @@ You can build toolchains from source code using crosstool-NG.
 
       Currently, only i586 and Arm toolchain builds are verified.
 
-#. Configure the environment variables needed to inform the Zephyr build system
-   to use this toolchain:
+#. :ref:`Set these environment variables <env_vars>`:
 
    - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``xtools``.
    - Set :envvar:`XTOOLS_TOOLCHAIN_PATH` to the toolchain build directory.
 
-   For example:
+#. To check that you have set these variables correctly in your current
+   environment, follow these example shell sessions (the
+   :envvar:`XTOOLS_TOOLCHAIN_PATH` values may be different on your system):
 
    .. code-block:: console
 
-      export ZEPHYR_TOOLCHAIN_VARIANT=xtools
-      export XTOOLS_TOOLCHAIN_PATH=/Volumes/CrossToolNGNew/build/output/
+      # Linux, macOS:
+      $ echo $ZEPHYR_TOOLCHAIN_VARIANT
+      xtools
+      $ echo $XTOOLS_TOOLCHAIN_PATH
+      /Volumes/CrossToolNGNew/build/output/
 
 .. _GNU ARM Embedded: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm
 .. _ISSM Toolchain: https://software.intel.com/en-us/articles/issm-toolchain-only-download

--- a/doc/getting_started/toolchain_custom_cmake.rst
+++ b/doc/getting_started/toolchain_custom_cmake.rst
@@ -3,25 +3,29 @@
 Custom CMake Toolchains
 #######################
 
-To use a custom toolchain defined in an external CMake file, export the
-following environment variables:
+To use a custom toolchain defined in an external CMake file, :ref:`set these
+environment variables <env_vars>`:
 
-.. code-block:: console
+- Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to your toolchain's name
+- Set :envvar:`TOOLCHAIN_ROOT` to the path to the directory containing your
+  toolchain's CMake configuration files.
 
-   # Linux and macOS
-   export ZEPHYR_TOOLCHAIN_VARIANT=<toolchain name>
-   export TOOLCHAIN_ROOT=<path to toolchain>
+Zephyr will then include the toolchain cmake files located in the
+:file:`TOOLCHAIN_ROOT` directory:
 
-   # Windows
-   set ZEPHYR_TOOLCHAIN_VARIANT=<toolchain name>
-   set TOOLCHAIN_ROOT=<path to toolchain>
+- :file:`cmake/toolchain/generic.cmake`: configures the toolchain for "generic"
+  use (mostly to run the C preprocessor on the generated :ref:`device-tree`
+  file).
+- :file:`cmake/toolchain/target.cmake`: configures the toolchain for use
+  building Zephyr and your application's source code.
 
-You can also set them as CMake variables when generating a build
-system for a Zephyr application, like so:
+See the zephyr files :zephyr_file:`cmake/generic_toolchain.cmake` and
+:zephyr_file:`cmake/target_toolchain.cmake` for more details on what your
+:file:`generic.cmake` and :file:`target.cmake` files should contain.
+
+You can also set ``ZEPHYR_TOOLCHAIN_VARIANT`` and ``TOOLCHAIN_ROOT`` as CMake
+variables when generating a build system for a Zephyr application, like so:
 
 .. code-block:: console
 
    cmake -DZEPHYR_TOOLCHAIN_VARIANT=... -DTOOLCHAIN_ROOT=...
-
-Zephyr will then include the toolchain cmake file located in:
-``<path to toolchain>/cmake/toolchain/<toolchain name>.cmake``.

--- a/doc/getting_started/toolchain_custom_cmake.rst
+++ b/doc/getting_started/toolchain_custom_cmake.rst
@@ -14,10 +14,10 @@ Zephyr will then include the toolchain cmake files located in the
 :file:`TOOLCHAIN_ROOT` directory:
 
 - :file:`cmake/toolchain/generic.cmake`: configures the toolchain for "generic"
-  use (mostly to run the C preprocessor on the generated :ref:`device-tree`
-  file).
-- :file:`cmake/toolchain/target.cmake`: configures the toolchain for use
-  building Zephyr and your application's source code.
+  use, which mostly means running the C preprocessor on the generated
+  :ref:`device-tree` file.
+- :file:`cmake/toolchain/target.cmake`: configures the toolchain for "target"
+  use, i.e. building Zephyr and your application's source code.
 
 See the zephyr files :zephyr_file:`cmake/generic_toolchain.cmake` and
 :zephyr_file:`cmake/target_toolchain.cmake` for more details on what your
@@ -29,3 +29,11 @@ variables when generating a build system for a Zephyr application, like so:
 .. code-block:: console
 
    cmake -DZEPHYR_TOOLCHAIN_VARIANT=... -DTOOLCHAIN_ROOT=...
+
+If you do this, ``-C <initial-cache>`` `cmake option`_ may useful. If you save
+your :makevar:`ZEPHYR_TOOLCHAIN_VARIANT`, :makevar:`TOOLCHAIN_ROOT`, and other
+settings in a file named :file:`my-toolchain.cmake`, you can then invoke cmake
+as ``cmake -C my-toolchain.cmake ...`` to save typing.
+
+.. _cmake option:
+   https://cmake.org/cmake/help/latest/manual/cmake.1.html#options

--- a/doc/getting_started/toolchain_host.rst
+++ b/doc/getting_started/toolchain_host.rst
@@ -1,0 +1,12 @@
+.. _host_toolchains:
+
+Host Toolchains
+###############
+
+In some specific configurations, like when building for non-MCU x86 targets on
+a Linux host, you may be able to re-use the native development tools provided
+by your operating system.
+
+To use your host gcc, set the :envvar:`ZEPHYR_TOOLCHAIN_VARIANT`
+:ref:`environment variable <env_vars>` to ``host``. To use clang, set
+:envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``clang``.

--- a/doc/getting_started/toolchain_other_x_compilers.rst
+++ b/doc/getting_started/toolchain_other_x_compilers.rst
@@ -29,20 +29,24 @@ Follow these steps to use one of these toolchains.
       # On Fedora or Red Hat
       sudo dnf install arm-none-eabi-newlib
 
-#. Configure the environment variables needed to inform the Zephyr build system
-   to use this toolchain:
+#. :ref:`Set these environment variables <env_vars>`:
 
    - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``cross-compile``.
    - Set :envvar:`CROSS_COMPILE` to the common path prefix which your
      toolchain's binaries have, e.g. the path to the directory containing the
      compiler binaries plus the target triplet and trailing dash.
 
-   Continuing the above Debian or Ubuntu example:
+#. To check that you have set these variables correctly in your current
+   environment, follow these example shell sessions (the
+   :envvar:`CROSS_COMPILE` value may be different on your system):
 
    .. code-block:: console
 
-      export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile
-      export CROSS_COMPILE=/usr/bin/arm-none-eabi-
+      # Linux, macOS:
+      $ echo $ZEPHYR_TOOLCHAIN_VARIANT
+      cross-compile
+      $ echo $CROSS_COMPILE
+      /usr/bin/arm-none-eabi-
 
    You can also set ``CROSS_COMPILE`` as a CMake variable.
 

--- a/doc/guides/env_vars.rst
+++ b/doc/guides/env_vars.rst
@@ -1,0 +1,157 @@
+.. _env_vars:
+
+Environment Variables
+=====================
+
+Various pages in this documentation refer to setting Zephyr-specific
+environment variables. This page describes how.
+
+Setting Variables
+*****************
+
+Option 1: Just Once
+-------------------
+
+To set the environment variable :envvar:`MY_VARIABLE` to ``foo`` for the
+lifetime of your current terminal window:
+
+.. code-block:: console
+
+   # Linux and macOS
+   export MY_VARIABLE=foo
+
+   # Windows
+   set MY_VARIABLE=foo
+
+.. warning::
+
+  This is best for experimentation. If you close your terminal window, use
+  another terminal window or tab, restart your computer, etc., this setting
+  will be lost forever.
+
+  Using options 2 or 3 is recommended if you want to keep using the setting.
+
+Option 2: In all Terminals
+--------------------------
+
+**macOS and Linux**:
+
+Add the ``export MY_VARIABLE=foo`` line to your shell's startup script in your
+home directory. For Bash, this is usually :file:`~/.bashrc` on Linux or
+:file:`~/.bash_profile` on macOS.  Changes in these startup scripts don't
+affect shell instances already started; try opening a new terminal window to get
+the new settings.
+
+**Windows**:
+
+You can use the ``setx`` program in ``cmd.exe`` or the third-party
+RapidEE program.
+
+To use ``setx``, type this command, then close the terminal window. Any new
+``cmd.exe`` windows will have :envvar:`MY_VARIABLE` set to ``foo``.
+
+.. code-block:: console
+
+   setx MY_VARIABLE foo
+
+To install RapidEE, a freeware graphical environment variable
+editor, `using Chocolatey`_ in an Administrator command prompt:
+
+.. code-block:: console
+
+   choco install rapidee
+
+You can then run ``rapidee`` from your terminal to launch the program and set
+environment variables. Make sure to use the "User" environment variables area
+-- otherwise, you have to run RapidEE as administrator. Also make sure to save
+your changes by clicking the Save button at top left before exiting.Settings
+you make in RapidEE will be available whenever you open a new terminal window.
+
+.. _env_vars_zephyrrc:
+
+Option 3: Using ``zephyrrc`` files
+----------------------------------
+
+Choose this option if you don't want to make the variable's setting available
+to all of your terminals, but still want to save the value for loading into
+your environment when you are using Zephyr.
+
+**macOS and Linux**:
+
+Create a file named :file:`~/.zephyrrc` if it doesn't exist, then add this line
+to it:
+
+.. code-block:: console
+
+   export MY_VARIABLE=foo
+
+To get this value back into your current terminal environment, **you must run**
+``source zephyr-env.sh`` from the main ``zephyr`` repository. Among other
+things, this script sources :file:`~/.zephyrrc`.
+
+The value will be lost if you close the window, etc.; run ``source
+zephyr-env.sh`` again to get it back.
+
+**Windows**:
+
+Add the line ``set MY_VARIABLE=foo`` to the file
+:file:`%userprofile%\\zephyrrc.cmd` using a text editor such as Notepad to save
+the value.
+
+To get this value back into your current terminal environment, **you must run**
+``zephyr-env.cmd`` in a ``cmd.exe`` window after changing directory to the main
+``zephyr`` repository.  Among other things, this script runs
+:file:`%userprofile%\\zephyrrc.cmd`.
+
+The value will be lost if you close the window, etc.; run ``zephyr-env.cmd``
+again to get it back.
+
+.. _zephyr-env:
+
+Zephyr Environment Scripts
+**************************
+
+You can use the zephyr repository scripts ``zephyr-env.sh`` (for macOS and
+Linux) and ``zephyr-env.cmd`` (for Windows) to load Zephyr-specific settings
+into your current terminal's environment. To do so, run this command from the
+zephyr repository::
+
+  # macOS and Linux
+  source zephyr-env.sh
+
+  # Windows
+  zephyr-env.cmd
+
+These scripts:
+
+- set :envvar:`ZEPHYR_BASE` (see below) to the location of the zephyr
+  repository
+- adds some Zephyr-specific locations (such as zephyr's :file:`scripts`
+  directory) to your :envvar:`PATH` environment variable
+- loads any settings from the ``zephyrrc`` files described above in
+  :file:`env_vars_zephyrrc`.
+
+You can thus use them any time you need any of these settings.
+
+.. _env_vars_important:
+
+Important Environment Variables
+*******************************
+
+Here are some important environment variables and what they contain. This is
+not a comprehensive index to the environment variables which affect Zephyr's
+behavior.
+
+- :envvar:`BOARD`: allows set the board when building an application; see
+  :ref:`important-build-vars`.
+- :envvar:`CONF_FILE`: allows adding Kconfig fragments to an application build;
+  see :ref:`important-build-vars`.
+- :envvar:`DTC_OVERLAY_FILE`: allows adding device tree overlays to an
+  application build; see :ref:`important-build-vars`.
+- :envvar:`ZEPHYR_BASE`: the absolute path to the main ``zephyr`` repository.
+  This is set whenever you run the ``zephyr-env.sh`` or ``zephyr-env.cmd``
+  scripts mentioned above.
+- :envvar:`ZEPHYR_TOOLCHAIN_VARIANT`: the current :ref:`toolchain
+  <gs_toolchain>` used to build Zephyr applications.
+
+.. _using Chocolatey: https://chocolatey.org/packages/RapidEE

--- a/doc/guides/index.rst
+++ b/doc/guides/index.rst
@@ -18,6 +18,7 @@ User and Developer Guides
    device_mgmt/dfu
    documentation/index
    dts/index
+   env_vars.rst
    coverage.rst
    kconfig/index
    modules.rst


### PR DESCRIPTION
The main purpose of this PR is to make the getting started guide shorter and easier to follow for new users, especially now that we have gotten over the conversion to west.

Along the way, I add a generic page on managing environment variables and link to it from pages (including getting started ones) instead of reproducing bits and pieces of the relevant information.

