### PR TITLE
[DNM] Settings const key

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/storage.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/storage.c
@@ -114,57 +114,43 @@ void save_on_flash(u8_t id)
 	k_work_submit(&storage_work);
 }
 
-static int ps_set(int argc, char **argv, size_t len_rd,
+static int ps_set(const char *key, size_t len_rd,
 		  settings_read_cb read_cb, void *cb_arg)
 {
-	ssize_t len = 0;
+	ssize_t len = -ENOENT;
 
-	if (argc == 1) {
-		if (!strcmp(argv[0], "rc")) {
-			len = read_cb(cb_arg, &reset_counter,
-				      sizeof(reset_counter));
-		}
-
-		if (!strcmp(argv[0], "gdtt")) {
-			len = read_cb(cb_arg,
-			 &gen_def_trans_time_srv_user_data.tt,
-			 sizeof(gen_def_trans_time_srv_user_data.tt));
-		}
-
-		if (!strcmp(argv[0], "gpo")) {
-			len = read_cb(cb_arg,
-			 &gen_power_onoff_srv_user_data.onpowerup,
-			 sizeof(gen_power_onoff_srv_user_data.onpowerup));
-		}
-
-		if (!strcmp(argv[0], "ltd")) {
-			len = read_cb(cb_arg,
-			 &light_ctl_srv_user_data.lightness_temp_def,
-			 sizeof(light_ctl_srv_user_data.lightness_temp_def));
-		}
-
-		if (!strcmp(argv[0], "ltl")) {
-			len = read_cb(cb_arg,
-			 &light_ctl_srv_user_data.lightness_temp_last,
-			 sizeof(light_ctl_srv_user_data.lightness_temp_last));
-		}
-
-		if (!strcmp(argv[0], "lr")) {
-			len = read_cb(cb_arg,
-			 &light_lightness_srv_user_data.lightness_range,
-			 sizeof(light_lightness_srv_user_data.lightness_range));
-		}
-
-		if (!strcmp(argv[0], "tr")) {
-			len = read_cb(cb_arg,
-			 &light_ctl_srv_user_data.temperature_range,
-			 sizeof(light_ctl_srv_user_data.temperature_range));
-		}
-
-		return (len < 0) ? len : 0;
+	if (settings_name_cmp(key, "rc")) {
+		len = read_cb(cb_arg, &reset_counter,
+			      sizeof(reset_counter));
+	} else if (settings_name_cmp(key, "gdtt")) {
+		len = read_cb(cb_arg,
+		 &gen_def_trans_time_srv_user_data.tt,
+		 sizeof(gen_def_trans_time_srv_user_data.tt));
+	} else if (settings_name_cmp(key, "gpo")) {
+		len = read_cb(cb_arg,
+		 &gen_power_onoff_srv_user_data.onpowerup,
+		 sizeof(gen_power_onoff_srv_user_data.onpowerup));
+	} else if (settings_name_cmp(key, "ltd")) {
+		len = read_cb(cb_arg,
+		 &light_ctl_srv_user_data.lightness_temp_def,
+		 sizeof(light_ctl_srv_user_data.lightness_temp_def));
+	} else if (settings_name_cmp(key, "ltl")) {
+		len = read_cb(cb_arg,
+		 &light_ctl_srv_user_data.lightness_temp_last,
+		 sizeof(light_ctl_srv_user_data.lightness_temp_last));
+	} else if (settings_name_cmp(key, "lr")) {
+		len = read_cb(cb_arg,
+		 &light_lightness_srv_user_data.lightness_range,
+		 sizeof(light_lightness_srv_user_data.lightness_range));
+	} else if (settings_name_cmp(key, "tr")) {
+		len = read_cb(cb_arg,
+		 &light_ctl_srv_user_data.temperature_range,
+		 sizeof(light_ctl_srv_user_data.temperature_range));
+	} else {
+		printk("Unsupported setting received: \"%s\".", key);
 	}
 
-	return -ENOENT;
+	return (len < 0) ? len : 0;
 }
 
 static struct settings_handler ps_settings = {

--- a/subsys/bluetooth/host/settings.h
+++ b/subsys/bluetooth/host/settings.h
@@ -6,7 +6,7 @@
 
 struct bt_settings_handler {
 	const char *name;
-	int (*set)(int argc, char **argv, size_t len, settings_read_cb read_cb,
+	int (*set)(const char *key, size_t len, settings_read_cb read_cb,
 		   void *cb_arg);
 	int (*commit)(void);
 	int (*export)(int (*func)(const char *name, void *val,
@@ -31,7 +31,7 @@ struct bt_settings_handler {
 /* Helpers for keys containing a bdaddr */
 void bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
 			    bt_addr_le_t *addr, const char *key);
-int bt_settings_decode_key(char *key, bt_addr_le_t *addr);
+int bt_settings_decode_key(const char *key, bt_addr_le_t *addr);
 
 void bt_settings_save_id(void);
 

--- a/subsys/bluetooth/services/dis.c
+++ b/subsys/bluetooth/services/dis.c
@@ -144,12 +144,12 @@ BT_GATT_SERVICE_DEFINE(dis_svc,
 );
 
 #if defined(CONFIG_BT_SETTINGS) && defined(CONFIG_BT_GATT_DIS_SETTINGS)
-static int dis_set(int argc, char **argv, size_t len_rd,
+static int dis_set(const char *key, size_t len_rd,
 		   settings_read_cb read_cb, void *store)
 {
 	int len;
 
-	if (!strcmp(argv[0], "manuf")) {
+	if (settings_name_cmp(key, "manuf")) {
 		len = read_cb(store, &dis_manuf, sizeof(dis_manuf) - 1);
 		if (len < 0) {
 			BT_ERR("Failed to read manufacturer from storage"
@@ -161,7 +161,7 @@ static int dis_set(int argc, char **argv, size_t len_rd,
 		}
 		return 0;
 	}
-	if (!strcmp(argv[0], "model")) {
+	if (settings_name_cmp(key, "model")) {
 		len = read_cb(store, &dis_model, sizeof(dis_model) - 1);
 		if (len < 0) {
 			BT_ERR("Failed to read model from storage"
@@ -174,7 +174,7 @@ static int dis_set(int argc, char **argv, size_t len_rd,
 		return 0;
 	}
 #if defined(CONFIG_BT_GATT_DIS_SERIAL_NUMBER)
-	if (!strcmp(argv[0], "serial")) {
+	if (settings_name_cmp(key, "serial")) {
 		len = read_cb(store, &dis_serial_number,
 			   sizeof(dis_serial_number) - 1);
 		if (len < 0) {
@@ -189,7 +189,7 @@ static int dis_set(int argc, char **argv, size_t len_rd,
 	}
 #endif
 #if defined(CONFIG_BT_GATT_DIS_FW_REV)
-	if (!strcmp(argv[0], "fw")) {
+	if (settings_name_cmp(key, "fw")) {
 		len = read_cb(store, &dis_fw_rev, sizeof(dis_fw_rev) - 1);
 		if (len < 0) {
 			BT_ERR("Failed to read firmware revision from storage"
@@ -203,7 +203,7 @@ static int dis_set(int argc, char **argv, size_t len_rd,
 	}
 #endif
 #if defined(CONFIG_BT_GATT_DIS_HW_REV)
-	if (!strcmp(argv[0], "hw")) {
+	if (settings_name_cmp(key, "hw")) {
 		len = read_cb(store, &dis_hw_rev, sizeof(dis_hw_rev) - 1);
 		if (len < 0) {
 			BT_ERR("Failed to read hardware revision from storage"
@@ -217,7 +217,7 @@ static int dis_set(int argc, char **argv, size_t len_rd,
 	}
 #endif
 #if defined(CONFIG_BT_GATT_DIS_SW_REV)
-	if (!strcmp(argv[0], "sw")) {
+	if (settings_name_cmp(key,  "sw")) {
 		len = read_cb(store, &dis_sw_rev, sizeof(dis_sw_rev) - 1);
 		if (len < 0) {
 			BT_ERR("Failed to read software revision from storage"

--- a/subsys/settings/src/settings.c
+++ b/subsys/settings/src/settings.c
@@ -21,7 +21,6 @@ sys_slist_t settings_handlers;
 
 static u8_t settings_cmd_inited;
 
-static struct settings_handler *settings_handler_lookup(char *name);
 void settings_store_init(void);
 
 void settings_init(void)
@@ -36,70 +35,137 @@ void settings_init(void)
 
 int settings_register(struct settings_handler *handler)
 {
-	if (settings_handler_lookup(handler->name)) {
-		return -EEXIST;
+	struct settings_handler *ch;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&settings_handlers, ch, node) {
+		if (!strcmp(handler->name, ch->name)) {
+			return -EEXIST;
+		}
 	}
 	sys_slist_prepend(&settings_handlers, &handler->node);
 
 	return 0;
 }
 
-/*
- * Find settings_handler based on name.
- */
-static struct settings_handler *settings_handler_lookup(char *name)
+bool settings_name_split(const char *name, const char *key, const char **next)
+{
+	bool status = false;
+	const char *next_ptr = NULL;
+
+	while (*key) {
+		if (*key != *name) {
+			break;
+		}
+		++key;
+		++name;
+	}
+	if (*key == '\0') {
+		if (*name == SETTINGS_NAME_SEPARATOR) {
+			next_ptr = name + 1;
+			status = true;
+		} else if (*name == '\0') {
+			status = true;
+		} else {
+			/* Nothing to do */
+		}
+	} else {
+		/* Nothing to do */
+	}
+
+	if (next) {
+		*next = next_ptr;
+	}
+	return status;
+}
+
+const char *settings_name_skip(const char *name)
+{
+	bool empty = true;
+
+	while (*name) {
+		if (*name++ == SETTINGS_NAME_SEPARATOR) {
+			break; /* Return character after */
+		}
+		empty = false;
+	}
+	return empty ? NULL : name;
+}
+
+size_t settings_name_elen(const char *name)
+{
+	size_t n = 0;
+
+	while ((*name != '\0') && (*name != SETTINGS_NAME_SEPARATOR)) {
+		++n;
+		++name;
+	}
+	return n;
+}
+
+bool settings_name_cmp(const char *name, const char *patt)
+{
+	LOG_DBG("%s (\"%s\", \"%s\");\n", __func__, name, patt);
+
+	while (*patt) {
+		if (*patt == '*') {
+			++patt;
+			if (*patt == '*') {
+				++patt;
+				if (*patt == SETTINGS_NAME_SEPARATOR) {
+					++patt;
+				}
+				if (*patt == '\0') {
+					/* Optimize this:
+					 * it would be most used case
+					 */
+					LOG_DBG(" \"**\" at the end.\n");
+					return true;
+				}
+				do {
+					if (settings_name_cmp(patt, name))
+						return true;
+					name = settings_name_skip(name);
+				} while (*name);
+			} else {
+				if (*patt == SETTINGS_NAME_SEPARATOR) {
+					++patt;
+				}
+				name = settings_name_skip(name);
+				if (!name) {
+					LOG_DBG("No element to match "
+						"\"*\" pattern\n");
+					return false;
+				}
+				LOG_DBG("  skipped(\"%s\", \"%s\")\n",
+					name, patt);
+				continue;
+			}
+			if (!*patt) {
+				break;
+			}
+		}
+		if (*patt != *name) {
+			break;
+		}
+		++patt;
+		++name;
+	}
+
+	LOG_DBG("  returning(\"%s\", \"%s\")\n", name, patt);
+	return (*patt == '\0' && *name == '\0');
+}
+
+struct settings_handler *settings_parse_and_lookup(const char *name,
+						   const char **key)
 {
 	struct settings_handler *ch;
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&settings_handlers, ch, node) {
-		if (!strcmp(name, ch->name)) {
+		if (settings_name_split(name, ch->name, key)) {
 			return ch;
 		}
 	}
 	return NULL;
-}
-
-/*
- * Separate string into argv array.
- */
-int settings_parse_name(char *name, int *name_argc, char *name_argv[])
-{
-	int i = 0;
-
-	while (name) {
-		name_argv[i++] = name;
-
-		while (1) {
-			if (*name == '\0') {
-				name = NULL;
-				break;
-			}
-
-			if (*name == *SETTINGS_NAME_SEPARATOR) {
-				*name = '\0';
-				name++;
-				break;
-			}
-			name++;
-		}
-	}
-
-	*name_argc = i;
-
-	return 0;
-}
-
-struct settings_handler *settings_parse_and_lookup(char *name,
-						   int *name_argc,
-						   char *name_argv[])
-{
-	int rc;
-
-	rc = settings_parse_name(name, name_argc, name_argv);
-	if (rc) {
-		return NULL;
-	}
-	return settings_handler_lookup(name_argv[0]);
 }
 
 int settings_commit(void)

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -487,7 +487,7 @@ static int settings_line_cmp(char const *val, size_t val_len,
 	return rc;
 }
 
-void settings_line_dup_check_cb(char *name, void *val_read_cb_ctx,
+void settings_line_dup_check_cb(const char *name, void *val_read_cb_ctx,
 				off_t off, void *cb_arg)
 {
 	struct settings_line_dup_check_arg *cdca;
@@ -530,17 +530,16 @@ static ssize_t settings_line_read_cb(void *cb_arg, void *data, size_t len)
 	return -1;
 }
 
-void settings_line_load_cb(char *name, void *val_read_cb_ctx, off_t off,
+void settings_line_load_cb(const char *name, void *val_read_cb_ctx, off_t off,
 			   void *cb_arg)
 {
-	int name_argc;
-	char *name_argv[SETTINGS_MAX_DIR_DEPTH];
+	const char *name_key;
 	struct settings_handler *ch;
 	struct settings_line_read_value_cb_ctx value_ctx;
 	int rc;
 	size_t len;
 
-	ch = settings_parse_and_lookup(name, &name_argc, name_argv);
+	ch = settings_parse_and_lookup(name, &name_key);
 	if (!ch) {
 		return;
 	}
@@ -550,7 +549,7 @@ void settings_line_load_cb(char *name, void *val_read_cb_ctx, off_t off,
 
 	len = settings_line_val_get_len(off, val_read_cb_ctx);
 
-	rc = ch->h_set(name_argc - 1, &name_argv[1], len, settings_line_read_cb,
+	rc = ch->h_set(name_key, len, settings_line_read_cb,
 		       (void *)&value_ctx);
 
 	if (rc != 0) {

--- a/subsys/settings/src/settings_priv.h
+++ b/subsys/settings/src/settings_priv.h
@@ -35,13 +35,13 @@ int settings_line_write(const char *name, const char *value, size_t val_len,
 /* Get len of record without alignment to write-block-size */
 int settings_line_len_calc(const char *name, size_t val_len);
 
-void settings_line_dup_check_cb(char *name, void *val_read_cb_ctx, off_t off,
+void settings_line_dup_check_cb(const char *name, void *val_read_cb_ctx, off_t off,
 				void *cb_arg);
 
-void settings_line_load_cb(char *name, void *val_read_cb_ctx, off_t off,
+void settings_line_load_cb(const char *name, void *val_read_cb_ctx, off_t off,
 			   void *cb_arg);
 
-typedef void (*line_load_cb)(char *name, void *val_read_cb_ctx, off_t off,
+typedef void (*line_load_cb)(const char *name, void *val_read_cb_ctx, off_t off,
 			     void *cb_arg);
 
 struct settings_line_read_value_cb_ctx {

--- a/subsys/settings/src/settings_runtime.c
+++ b/subsys/settings/src/settings_runtime.c
@@ -18,51 +18,38 @@ static ssize_t settings_runtime_read_cb(void *cb_arg, void *data, size_t len)
 int settings_runtime_set(const char *name, void *data, size_t len)
 {
 	struct settings_handler *ch;
-	char name1[SETTINGS_MAX_NAME_LEN + SETTINGS_EXTRA_LEN];
-	char *name_argv[SETTINGS_MAX_DIR_DEPTH];
-	int name_argc;
+	const char *name_key;
 
-	strncpy(name1, name, sizeof(name1) - 1);
-	name1[sizeof(name1) - 1] = '\0';
-
-	ch = settings_parse_and_lookup(name1, &name_argc, name_argv);
+	ch = settings_parse_and_lookup(name, &name_key);
 	if (!ch) {
 		return -EINVAL;
 	}
 
-	return ch->h_set(name_argc - 1, &name_argv[1], len,
-			 settings_runtime_read_cb, data);
+	return ch->h_set(name_key, len, settings_runtime_read_cb, data);
 }
 
 int settings_runtime_get(const char *name, void *data, size_t len)
 {
 	struct settings_handler *ch;
-	char name1[SETTINGS_MAX_NAME_LEN + SETTINGS_EXTRA_LEN];
-	char *name_argv[SETTINGS_MAX_DIR_DEPTH];
-	int name_argc;
+	const char *name_key;
 
-	strncpy(name1, name, sizeof(name1) - 1);
-	name1[sizeof(name1) - 1] = '\0';
-
-	ch = settings_parse_and_lookup(name1, &name_argc, name_argv);
+	ch = settings_parse_and_lookup(name, &name_key);
 	if (!ch) {
 		return -EINVAL;
 	}
+	if (!ch->h_get) {
+		return -EACCES;
+	}
 
-	return ch->h_get(name_argc - 1, &name_argv[1], data, len);
+	return ch->h_get(name_key, data, len);
 }
 
 int settings_runtime_commit(const char *name)
 {
 	struct settings_handler *ch;
-	char name1[SETTINGS_MAX_NAME_LEN + SETTINGS_EXTRA_LEN];
-	char *name_argv[SETTINGS_MAX_DIR_DEPTH];
-	int name_argc;
+	const char *name_key;
 
-	strncpy(name1, name, sizeof(name1) - 1);
-	name1[sizeof(name1) - 1] = '\0';
-
-	ch = settings_parse_and_lookup(name1, &name_argc, name_argv);
+	ch = settings_parse_and_lookup(name, &name_key);
 	if (!ch) {
 		return -EINVAL;
 	}

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -23,19 +23,19 @@ int test_export_block;
 
 int c2_var_count = 1;
 
-int c1_handle_get(int argc, char **argv, char *val, int val_len_max);
-int c1_handle_set(int argc, char **argv, size_t len, settings_read_cb read_cb,
+int c1_handle_get(const char *key, char *val, int val_len_max);
+int c1_handle_set(const char *key, size_t len, settings_read_cb read_cb,
 		  void *cb_arg);
 int c1_handle_commit(void);
 int c1_handle_export(int (*cb)(const char *name, void *value, size_t val_len));
 
-int c2_handle_get(int argc, char **argv, char *val, int val_len_max);
-int c2_handle_set(int argc, char **argv, size_t len, settings_read_cb read_cb,
+int c2_handle_get(const char *key, char *val, int val_len_max);
+int c2_handle_set(const char *key, size_t len, settings_read_cb read_cb,
 		  void *cb_arg);
 int c2_handle_export(int (*cb)(const char *name, void *value, size_t val_len));
 
-int c3_handle_get(int argc, char **argv, char *val, int val_len_max);
-int c3_handle_set(int argc, char **argv, size_t len, settings_read_cb read_cb,
+int c3_handle_get(const char *key, char *val, int val_len_max);
+int c3_handle_set(const char *key, size_t len, settings_read_cb read_cb,
 		  void *cb_arg);
 int c3_handle_export(int (*cb)(const char *name,  void *value, size_t val_len));
 
@@ -66,17 +66,17 @@ struct settings_handler c_test_handlers[] = {
 char val_string[SETTINGS_TEST_FCB_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN];
 char test_ref_value[SETTINGS_TEST_FCB_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN];
 
-int c1_handle_get(int argc, char **argv, char *val, int val_len_max)
+int c1_handle_get(const char *key, char *val, int val_len_max)
 {
 	test_get_called = 1;
 
-	if (argc == 1 && !strcmp(argv[0], "mybar")) {
+	if (settings_name_cmp(key, "mybar")) {
 		val_len_max = MIN(val_len_max, sizeof(val8));
 		memcpy(val, &val8, MIN(val_len_max, sizeof(val8)));
 		return val_len_max;
 	}
 
-	if (argc == 1 && !strcmp(argv[0], "mybar64")) {
+	if (settings_name_cmp(key, "mybar64")) {
 		val_len_max = MIN(val_len_max, sizeof(val64));
 		memcpy(val, &val64, MIN(val_len_max, sizeof(val64)));
 		return val_len_max;
@@ -85,26 +85,26 @@ int c1_handle_get(int argc, char **argv, char *val, int val_len_max)
 	return -ENOENT;
 }
 
-int c1_handle_set(int argc, char **argv, size_t len, settings_read_cb read_cb,
+int c1_handle_set(const char *key, size_t len, settings_read_cb read_cb,
 		  void *cb_arg)
 {
 	size_t val_len;
 	int rc;
 
 	test_set_called = 1;
-	if (argc == 1 && !strcmp(argv[0], "mybar")) {
+	if (settings_name_cmp(key, "mybar")) {
 		rc = read_cb(cb_arg, &val8, sizeof(val8));
 		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 
-	if (argc == 1 && !strcmp(argv[0], "mybar64")) {
+	if (settings_name_cmp(key, "mybar64")) {
 		rc = read_cb(cb_arg, &val64, sizeof(val64));
 		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;
 	}
 
-	if (argc == 1 && !strcmp(argv[0], "unaligned")) {
+	if (settings_name_cmp(key, "unaligned")) {
 		val_len = len;
 		zassert_equal(val_len, sizeof(val8_un),
 			      "value length: %d, ought equal 1", val_len);
@@ -221,13 +221,14 @@ char *c2_var_find(const char *name)
 	return val_string[idx];
 }
 
-int c2_handle_get(int argc, char **argv, char *val, int val_len_max)
+int c2_handle_get(const char *key, char *val, int val_len_max)
 {
 	int len;
 	char *valptr;
 
-	if (argc == 1) {
-		valptr = c2_var_find(argv[0]);
+	/* This is true if the key has only one element */
+	if (settings_name_cmp(key, "*")) {
+		valptr = c2_var_find(key);
 		if (!valptr) {
 			return -ENOENT;
 		}
@@ -245,14 +246,15 @@ int c2_handle_get(int argc, char **argv, char *val, int val_len_max)
 	return -ENOENT;
 }
 
-int c2_handle_set(int argc, char **argv, size_t len, settings_read_cb read_cb,
+int c2_handle_set(const char *key, size_t len, settings_read_cb read_cb,
 		  void *cb_arg)
 {
 	char *valptr;
 	int rc;
 
-	if (argc == 1) {
-		valptr = c2_var_find(argv[0]);
+	/* This is true if the key has only one element */
+	if (settings_name_cmp(key, "*")) {
+		valptr = c2_var_find(key);
 		if (!valptr) {
 			return -ENOENT;
 		}
@@ -282,9 +284,9 @@ int c2_handle_export(int (*cb)(const char *name, void *value, size_t val_len))
 	return 0;
 }
 
-int c3_handle_get(int argc, char **argv, char *val, int val_len_max)
+int c3_handle_get(const char *key, char *val, int val_len_max)
 {
-	if (argc == 1 && !strcmp(argv[0], "v")) {
+	if (settings_name_cmp(key, "v")) {
 		val_len_max = MIN(val_len_max, sizeof(val32));
 		memcpy(val, &val32, MIN(val_len_max, sizeof(val32)));
 		return val_len_max;
@@ -292,13 +294,13 @@ int c3_handle_get(int argc, char **argv, char *val, int val_len_max)
 	return -EINVAL;
 }
 
-int c3_handle_set(int argc, char **argv, size_t len, settings_read_cb read_cb,
+int c3_handle_set(const char *key, size_t len, settings_read_cb read_cb,
 		  void *cb_arg)
 {
 	int rc;
 	size_t val_len;
 
-	if (argc == 1 && !strcmp(argv[0], "v")) {
+	if (settings_name_cmp(key, "v")) {
 		val_len = len;
 		zassert_true(val_len == 4, "bad set-value size");
 

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -203,7 +203,7 @@ test_config_fill_area(char test_value[SETTINGS_TEST_FCB_VAL_STR_CNT]
 	}
 }
 
-char *c2_var_find(char *name)
+char *c2_var_find(const char *name)
 {
 	int idx = 0;
 	int len;

--- a/tests/subsys/settings/fcb_init/src/settings_test_fcb_init.c
+++ b/tests/subsys/settings/fcb_init/src/settings_test_fcb_init.c
@@ -15,12 +15,12 @@
 
 static u32_t val32;
 
-static int c1_set(int argc, char **argv, size_t len, settings_read_cb read_cb,
+static int c1_set(const char *key, size_t len, settings_read_cb read_cb,
 		  void *cb_arg)
 {
 	int rc;
 
-	if (argc == 1 && !strcmp(argv[0], "val32")) {
+	if (settings_name_cmp(key, "val32")) {
 		rc = read_cb(cb_arg, &val32, sizeof(val32));
 		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
 		return 0;

--- a/tests/subsys/settings/nffs/src/settings_test_nffs.c
+++ b/tests/subsys/settings/nffs/src/settings_test_nffs.c
@@ -22,8 +22,8 @@ int test_export_block;
 
 int c2_var_count = 1;
 
-int c1_handle_get(int argc, char **argv, char *val, int val_len_max);
-int c1_handle_set(int argc, char **argv, size_t len, settings_read_cb read_cb,
+int c1_handle_get(const char *key, char *val, int val_len_max);
+int c1_handle_set(const char *key, size_t len, settings_read_cb read_cb,
 		  void *cb_arg);
 int c1_handle_commit(void);
 int c1_handle_export(int (*cb)(const char *name, void *value, size_t val_len));
@@ -40,23 +40,23 @@ struct settings_handler c_test_handlers[] = {
 
 
 
-int c1_handle_get(int argc, char **argv, char *val, int val_len_max)
+int c1_handle_get(const char *key, char *val, int val_len_max)
 {
 	test_get_called = 1;
 
-	if (argc == 1 && !strcmp(argv[0], "mybar")) {
+	if (settings_name_cmp(key, "mybar")) {
 		val_len_max = MIN(val_len_max, sizeof(val8));
 		memcpy(val, &val8, MIN(val_len_max, sizeof(val8)));
 		return val_len_max;
 	}
 
-	if (argc == 1 && !strcmp(argv[0], "mybar16")) {
+	if (settings_name_cmp(key, "mybar16")) {
 		val_len_max = MIN(val_len_max, sizeof(val16));
 		memcpy(val, &val16, MIN(val_len_max, sizeof(val16)));
 		return val_len_max;
 	}
 
-	if (argc == 1 && !strcmp(argv[0], "mybar64")) {
+	if (settings_name_cmp(key, "mybar64")) {
 		val_len_max = MIN(val_len_max, sizeof(val64));
 		memcpy(val, &val64, MIN(val_len_max, sizeof(val64)));
 		return val_len_max;
@@ -65,14 +65,14 @@ int c1_handle_get(int argc, char **argv, char *val, int val_len_max)
 	return -ENOENT;
 }
 
-int c1_handle_set(int argc, char **argv, size_t len, settings_read_cb read_cb,
+int c1_handle_set(const char *key, size_t len, settings_read_cb read_cb,
 		  void *cb_arg)
 {
 	int rc;
 	size_t val_len;
 
 	test_set_called = 1;
-	if (argc == 1 && !strcmp(argv[0], "mybar")) {
+	if (settings_name_cmp(key, "mybar")) {
 		val_len = len;
 		zassert_true(val_len == 1, "bad set-value size");
 
@@ -81,7 +81,7 @@ int c1_handle_set(int argc, char **argv, size_t len, settings_read_cb read_cb,
 		return 0;
 	}
 
-	if (argc == 1 && !strcmp(argv[0], "mybar16")) {
+	if (settings_name_cmp(key, "mybar16")) {
 		val_len = len;
 		zassert_true(val_len == 2, "bad set-value size");
 
@@ -90,7 +90,7 @@ int c1_handle_set(int argc, char **argv, size_t len, settings_read_cb read_cb,
 		return 0;
 	}
 
-	if (argc == 1 && !strcmp(argv[0], "mybar64")) {
+	if (settings_name_cmp(key, "mybar64")) {
 		val_len = len;
 		zassert_true(val_len == 8, "bad set-value size");
 

--- a/tests/subsys/settings/unit/CMakeLists.txt
+++ b/tests/subsys/settings/unit/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+project(crc)
+include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
+

--- a/tests/subsys/settings/unit/main.c
+++ b/tests/subsys/settings/unit/main.c
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <subsys/settings/src/settings.c>
+
+/* *********************************************
+ *  Dummy storage implementation
+ */
+void settings_store_init(void)
+{
+	/* Nothing to do */
+}
+
+int settings_line_val_read(off_t val_off, off_t off, char *out, size_t len_req,
+			   size_t *len_read, void *cb_arg)
+{
+	return 0;
+}
+
+size_t settings_line_val_get_len(off_t val_off, void *read_cb_ctx)
+{
+	return 0;
+}
+
+/* End of dummy storage
+ * *******************************************
+ */
+
+/**
+ * @brief Test simple comparison of the first element
+ *
+ * test verifies if the simplest usage of the key comparison
+ * function works as expected.
+ */
+static void test_settings_name_split(void)
+{
+	static const char sample_patch[] = "it/is/going/to/be/legendary";
+
+	zassert_true (settings_name_split(sample_patch, "it",  NULL), NULL);
+	zassert_false(settings_name_split(sample_patch, "its", NULL), NULL);
+	zassert_false(settings_name_split(sample_patch, "i",   NULL), NULL);
+	zassert_false(settings_name_split(sample_patch, "it/", NULL), NULL);
+}
+
+/**
+ * @brief Test the usage of patch part as a key
+ *
+ * Test verifies if we can safely use a complete patch with backslash
+ * inside as a key to compare.
+ */
+static void test_settings_name_split_keypatch(void)
+{
+	static const char sample_patch[] = "it/is/going";
+	const char *current_pos = sample_patch;
+
+	zassert_true(settings_name_split(sample_patch, "it", NULL), NULL);
+	zassert_true(settings_name_split(sample_patch, "it/is", NULL), NULL);
+	zassert_true(settings_name_split(sample_patch,
+					"it/is/going",
+					&current_pos), NULL);
+	zassert_is_null(current_pos, NULL);
+
+	zassert_false(settings_name_split(sample_patch, "it/", NULL), NULL);
+	zassert_false(settings_name_split(sample_patch, "it/is/", NULL), NULL);
+	zassert_false(settings_name_split(sample_patch, "it/is/g", NULL), NULL);
+	zassert_false(settings_name_split(sample_patch, "it/is/going/", NULL), NULL);
+
+}
+
+/**
+ * @brief Test if the tree can be properly traversed
+ *
+ * Test verifies if the tree can be traversed from the first to the last
+ * key inside the patch.
+ * The current position has to be properly returned by the tested comparison
+ * function.
+ */
+static void test_settings_tree_traverse(void)
+{
+	static const char sample_patch[] = "it/is/going";
+	const char *current_pos = sample_patch;
+
+	/* it */
+	zassert_true (settings_name_split(current_pos, "it", &current_pos), NULL);
+	zassert_equal_ptr(current_pos, sample_patch + strlen("it/"),
+			  "Current pos string: %s", current_pos);
+
+	/* is */
+	zassert_false(settings_name_split(current_pos, "it", NULL), NULL);
+	zassert_false(settings_name_split(current_pos, "is/go", NULL), NULL);
+	zassert_true (settings_name_split(current_pos, "is", &current_pos), NULL);
+	zassert_equal_ptr(current_pos, sample_patch + strlen("it/is/"),
+			  "Current pos string: %s", current_pos);
+
+	/* going */
+	zassert_false(settings_name_split(current_pos, "it", NULL), NULL);
+	zassert_false(settings_name_split(current_pos, "is", NULL), NULL);
+	zassert_true (settings_name_split(current_pos, "going", &current_pos), NULL);
+	zassert_is_null(current_pos, NULL);
+}
+
+
+
+static void test_settings_name_cmp_doc(void)
+{
+	zassert_true(settings_name_cmp("my_key/other/stuff", "my_key/*/stuff"), NULL);
+	zassert_true(settings_name_cmp("my_key/other/stuff", "*/other/stuff"),  NULL);
+	zassert_true(settings_name_cmp("my_key/other/stuff", "my_key/other/*"), NULL);
+
+	zassert_true(settings_name_cmp("my_key/other/stuff", "**"), NULL);
+	zassert_true(settings_name_cmp("my_key/other/stuff", "**/other/stuff"), NULL);
+	zassert_true(settings_name_cmp("my_key/other/stuff", "**/stuff"), NULL);
+	zassert_true(settings_name_cmp("my_key/other/stuff", "my_key/**"), NULL);
+
+	/* Check if there is exactly one element in given name: */
+	zassert_true (settings_name_cmp("element", "*"), NULL);
+	zassert_false(settings_name_cmp("element/other", "*"), NULL);
+	zassert_false(settings_name_cmp("", "*"), NULL);
+
+	/* Check if there is at least one element in given name: */
+	zassert_true (settings_name_cmp("element", "*/**"), NULL);
+	zassert_true (settings_name_cmp("element/other", "*/**"), NULL);
+	zassert_false(settings_name_cmp("", "*/**"), NULL);
+}
+
+
+static void test_settings_name_cmp(void)
+{
+	static const char sample_patch[] = "it/is/going/to/be/legendary";
+
+	zassert_true (settings_name_cmp(sample_patch, "it/*/going/to/be/*"), NULL);
+	zassert_false(settings_name_cmp(sample_patch, "it/*/to/be/*"), NULL);
+	zassert_true (settings_name_cmp(sample_patch, "**"), NULL);
+	zassert_true (settings_name_cmp(sample_patch, "**/legendary"), NULL);
+	zassert_false(settings_name_cmp(sample_patch, "**/legend"), NULL);
+
+}
+
+static void test_settings_name_cmp_single(void)
+{
+	zassert_true (settings_name_cmp("single", "*"), NULL);
+	zassert_false(settings_name_cmp("dual/element", "*"), NULL);
+
+	zassert_true (settings_name_cmp("single", "*/**"), NULL);
+	zassert_true (settings_name_cmp("single/double", "*/**"), NULL);
+	zassert_false(settings_name_cmp("", "*/**"), NULL);
+	zassert_true (settings_name_cmp("", "**"), NULL);
+}
+
+static void test_settings_name_cmp_match_empty(void)
+{
+	zassert_false(settings_name_cmp("it/is/going", "it/*/is/going"), NULL);
+	zassert_true (settings_name_cmp("it/is/going", "it/**/is/going"), NULL);
+}
+
+static void test_settings_name_cmp_partial(void)
+{
+	zassert_true (settings_name_cmp("prefix_0", "prefix_*"), NULL);
+	zassert_false(settings_name_cmp("prefix_", "prefix_*"), NULL);
+
+	zassert_true (settings_name_cmp("prefix_1", "prefix_*"), NULL);
+	zassert_false(settings_name_cmp("prefix_1/a", "prefix_*"), NULL);
+	zassert_true (settings_name_cmp("prefix_1/a", "prefix_*/**"), NULL);
+}
+
+
+void test_main(void)
+{
+	ztest_test_suite(test_settings,
+			 ztest_unit_test(test_settings_name_split),
+			 ztest_unit_test(test_settings_name_split_keypatch),
+			 ztest_unit_test(test_settings_tree_traverse),
+			 ztest_unit_test(test_settings_name_cmp_doc),
+			 ztest_unit_test(test_settings_name_cmp),
+			 ztest_unit_test(test_settings_name_cmp_single),
+			 ztest_unit_test(test_settings_name_cmp_match_empty),
+			 ztest_unit_test(test_settings_name_cmp_partial));
+	ztest_run_test_suite(test_settings);
+}

--- a/tests/subsys/settings/unit/testcase.yaml
+++ b/tests/subsys/settings/unit/testcase.yaml
@@ -1,0 +1,5 @@
+tests:
+  test:
+    tags: settings
+    timeout: 5
+    type: unit


### PR DESCRIPTION
The current version of the PR created to run all automated tests.

Remove the requirement of copying the key value.
The key now is always a pointer to a constant string.

The functions to manipulate key strings are added.
The specialized function is created to compare against a pattern.