### PR TITLE
cmake: Don't have users call zephyr_link_interface on mbedTLS

### DIFF
--- a/drivers/crypto/CMakeLists.txt
+++ b/drivers/crypto/CMakeLists.txt
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_link_interface_ifdef(CONFIG_MBEDTLS mbedTLS)
 zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_CRYPTO_TINYCRYPT_SHIM	crypto_tc_shim.c)
 zephyr_library_sources_ifdef(CONFIG_CRYPTO_ATAES132A		crypto_ataes132a.c)

--- a/subsys/jwt/CMakeLists.txt
+++ b/subsys/jwt/CMakeLists.txt
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_link_interface_ifdef(CONFIG_MBEDTLS mbedTLS)
 zephyr_library()
 zephyr_library_sources(jwt.c)
 zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)

--- a/subsys/net/ip/CMakeLists.txt
+++ b/subsys/net/ip/CMakeLists.txt
@@ -35,6 +35,5 @@ zephyr_library_sources_ifdef(CONFIG_NET_PROMISCUOUS_MODE promiscuous.c)
 
 if(CONFIG_NET_SHELL)
 zephyr_library_include_directories(. ${ZEPHYR_BASE}/subsys/net/l2)
-zephyr_link_interface_ifdef(CONFIG_MBEDTLS mbedTLS)
 zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
 endif()

--- a/subsys/net/lib/lwm2m/CMakeLists.txt
+++ b/subsys/net/lib/lwm2m/CMakeLists.txt
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_link_interface_ifdef(CONFIG_MBEDTLS mbedTLS)
 zephyr_library()
 
 zephyr_include_directories(.)

--- a/subsys/net/lib/sockets/CMakeLists.txt
+++ b/subsys/net/lib/sockets/CMakeLists.txt
@@ -16,5 +16,4 @@ zephyr_sources_ifdef(CONFIG_NET_SOCKETS_CAN sockets_can.c)
 endif()
 zephyr_sources_ifdef(CONFIG_NET_SOCKETS_OFFLOAD     socket_offload.c)
 
-zephyr_link_interface_ifdef(CONFIG_MBEDTLS mbedTLS)
 zephyr_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)


### PR DESCRIPTION
Libraries that use mbedTLS have been invoking
zephyr_link_interface(mbedTLS). It is not clear what the intent of
this code has been, but it is redundant with the mbedTLS build
scripts, so it can be safely removed.

In addition to being redundant, it causes problems as it introduces an
ordering dependency, with this code mbedTLS must be declared before
users of mbedTLS are declared. Since this code is redundant, this
ordering dependency is also unnecessary.

This code is believed to have been added early on by accident and
copied through cargo-cult programming since.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>