### PR TITLE
SNTP: Convert deprecated sntp_request() to sntp_query() in samples

### DIFF
--- a/samples/net/google_iot_mqtt/src/main.c
+++ b/samples/net/google_iot_mqtt/src/main.c
@@ -30,7 +30,7 @@ void do_sntp(struct addrinfo *addr)
 	struct sntp_ctx ctx;
 	int rc;
 	s64_t stamp;
-	u64_t epoch_time;
+	struct sntp_time sntp_time;
 	char time_str[sizeof("1970-01-01T00:00:00")];
 
 	LOG_INF("Sending NTP request for current time:");
@@ -42,13 +42,13 @@ void do_sntp(struct addrinfo *addr)
 		return;
 	}
 
-	rc = sntp_request(&ctx, K_FOREVER, &epoch_time);
+	rc = sntp_query(&ctx, K_FOREVER, &sntp_time);
 	if (rc == 0) {
 		stamp = k_uptime_get();
-		time_base = epoch_time * MSEC_PER_SEC - stamp;
+		time_base = sntp_time.seconds * MSEC_PER_SEC - stamp;
 
 		/* Convert time to make sure. */
-		time_t now = epoch_time;
+		time_t now = sntp_time.seconds;
 		struct tm now_tm;
 
 		gmtime_r(&now, &now_tm);

--- a/samples/net/google_iot_mqtt/src/main.c
+++ b/samples/net/google_iot_mqtt/src/main.c
@@ -77,7 +77,7 @@ top:
 	LOG_DBG("  family  : %d", addr->ai_family);
 	LOG_DBG("  socktype: %d", addr->ai_socktype);
 	LOG_DBG("  protocol: %d", addr->ai_protocol);
-	LOG_DBG("  addrlen : %d", addr->ai_addrlen);
+	LOG_DBG("  addrlen : %d", (int)addr->ai_addrlen);
 
 	/* Assume two words. */
 	LOG_DBG("   addr[0]: 0x%lx", ((uint32_t *)addr->ai_addr)[0]);

--- a/samples/net/sockets/sntp_client/src/main.c
+++ b/samples/net/sockets/sntp_client/src/main.c
@@ -21,7 +21,7 @@ void main(void)
 #if defined(CONFIG_NET_IPV6)
 	struct sockaddr_in6 addr6;
 #endif
-	u64_t epoch_time;
+	struct sntp_time sntp_time;
 	int rv;
 
 	/* ipv4 */
@@ -38,7 +38,7 @@ void main(void)
 	}
 
 	LOG_INF("Sending SNTP IPv4 request...");
-	rv = sntp_request(&ctx, K_SECONDS(4), &epoch_time);
+	rv = sntp_query(&ctx, K_SECONDS(4), &sntp_time);
 	if (rv < 0) {
 		LOG_ERR("SNTP IPv4 request failed: %d", rv);
 		goto end;
@@ -46,7 +46,7 @@ void main(void)
 
 	LOG_INF("status: %d", rv);
 	LOG_INF("time since Epoch: high word: %u, low word: %u",
-		(u32_t)(epoch_time >> 32), (u32_t)epoch_time);
+		(u32_t)(sntp_time.seconds >> 32), (u32_t)sntp_time.seconds);
 
 #if defined(CONFIG_NET_IPV6)
 	sntp_close(&ctx);
@@ -66,7 +66,7 @@ void main(void)
 
 	LOG_INF("Sending SNTP IPv6 request...");
 	/* With such a timeout, this is expected to fail. */
-	rv = sntp_request(&ctx, K_NO_WAIT, &epoch_time);
+	rv = sntp_query(&ctx, K_NO_WAIT, &sntp_time);
 	if (rv < 0) {
 		LOG_ERR("SNTP IPv6 request: %d", rv);
 		goto end;
@@ -74,7 +74,7 @@ void main(void)
 
 	LOG_INF("status: %d", rv);
 	LOG_INF("time since Epoch: high word: %u, low word: %u",
-		(u32_t)(epoch_time >> 32), (u32_t)epoch_time);
+		(u32_t)(sntp_time.seconds >> 32), (u32_t)sntp_time.seconds);
 #endif
 
 end:


### PR DESCRIPTION
To avoid deprecation warnings, which may become errors.
