### PR TITLE
shell: Move the call to uart_irq_rx_enable to the enable callback

### DIFF
--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -137,7 +137,6 @@ static void uart_irq_init(const struct shell_uart *sh_uart)
 	struct device *dev = sh_uart->ctrl_blk->dev;
 
 	uart_irq_callback_user_data_set(dev, uart_callback, (void *)sh_uart);
-	uart_irq_rx_enable(dev);
 #endif
 }
 
@@ -194,6 +193,10 @@ static int enable(const struct shell_transport *transport, bool blocking_tx)
 		uart_irq_tx_disable(sh_uart->ctrl_blk->dev);
 #endif
 	}
+
+#ifdef CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
+	uart_irq_rx_enable(sh_uart->ctrl_blk->dev);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
The uart could get an RX interrupt before the main shell init code has
finished initializing.  The race looks like:

shell.c                   shell_uart.c
shell_init()
 ->instance_init()
                          init()
                           ->uart_irq_init()
                            ->uart_irq_callback_user_data_set()

                          RX interrupt
                          uart_rx_handle()
                           ->sh_uart->ctrl_blk->handler

transport_evt_handler()
 ->k_poll_signal_raise()

 ->k_thread_create(shell_thread)

Unfortunately, the code that initializes the signals is not run until
the beginning of shell_thread.  But that comes after
k_poll_signal_raise() has alread been called.

Signed-off-by: Bradley Bolen <bradleybolen@gmail.com>

Fixes #16080 