### PR TITLE
drivers: can: set default y for stm32 CAN driver

### DIFF
--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -12,7 +12,7 @@ config CAN_STM32
 	default y
 	select USE_STM32_HAL_CAN
 	help
-	  Enable STM32 CAN Driver (tested on stm32F0 series)
+	  Enable STM32 CAN Driver
 
 config CAN_MAX_FILTER
 	int "Maximum number of concurrent active filters"

--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -9,6 +9,7 @@
 config CAN_STM32
 	bool "STM32 CAN Driver"
 	depends on SOC_FAMILY_STM32
+	default y
 	select USE_STM32_HAL_CAN
 	help
 	  Enable STM32 CAN Driver (tested on stm32F0 series)


### PR DESCRIPTION
Set CAN_STM32 default to y.
This makes sense because it anyway depends on SOC_FAMILY_STM32.