### PR TITLE
arch: arm: move stack switching back to ASM code

### DIFF
--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -19,6 +19,8 @@
 _ASM_FILE_PROLOGUE
 
 GTEXT(__reset)
+GTEXT(memset)
+GDATA(_interrupt_stack)
 #if defined(CONFIG_PLATFORM_SPECIFIC_INIT)
 GTEXT(_PlatformInit)
 #endif
@@ -61,11 +63,45 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 #endif
 
     /* lock interrupts: will get unlocked when switch to main task */
-    bl	lock_interrupts
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+    cpsid i
+#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+    movs.n r0, #_EXC_IRQ_DEFAULT_PRIO
+    msr BASEPRI, r0
+#else
+#error Unknown ARM architecture
+#endif
+
 #ifdef CONFIG_WDOG_INIT
     /* board-specific watchdog initialization is necessary */
     bl _WdogInit
 #endif
+
+#ifdef CONFIG_INIT_STACKS
+    ldr r0, =_interrupt_stack
+    ldr r1, =0xaa
+    ldr r2, =CONFIG_ISR_STACK_SIZE
+    bl memset
+#endif
+
+    /*
+     * Set PSP and use it to boot without using MSP, so that it
+     * gets set to _interrupt_stack during initialization.
+     */
+    ldr r0, =_interrupt_stack
+    ldr r1, =CONFIG_ISR_STACK_SIZE
+    adds r0, r0, r1
+    msr PSP, r0
+    mrs r0, CONTROL
+    movs r1, #2
+    orrs r0, r1 /* CONTROL_SPSEL_Msk */
+    msr CONTROL, r0
+    /*
+     * When changing the stack pointer, software must use an ISB instruction
+     * immediately after the MSR instruction. This ensures that instructions
+     * after the ISB instruction execute using the new stack pointer.
+     */
+    isb
 
     /*
      * 'bl' jumps the furthest of the branch instructions that are

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -903,7 +903,7 @@ static void domain_remove_part_context_switch(void)
  */
 
 #define NUM_STACKS	3
-#define STEST_STACKSIZE	1024
+#define STEST_STACKSIZE	(1024 + CONFIG_TEST_EXTRA_STACKSIZE)
 K_THREAD_STACK_DEFINE(stest_stack, STEST_STACKSIZE);
 K_THREAD_STACK_ARRAY_DEFINE(stest_stack_array, NUM_STACKS, STEST_STACKSIZE);
 


### PR DESCRIPTION
    With -O0 optimizion, gcc compiler doesn't inline "static inline"
    marked function. So when function call return from function
    set_and_switch_to_psp which is to switch sp from MSP to PSP, the
    ending "mov sp, r7" instruction will overwrite the just updated
    sp value(PSP) with the beginning stack pointer(should be MSP)
    stored in r7 register, so the switch doesn't happen. And it causes
    unpredictable problems in the initialization process, the backward
    analysis for this problem can be found on Github issue #15794.
    
    Also increase stack buffer when code coverage enabled.

Fixes: #15794.
