### PR TITLE
drivers: console: Add support for log level option

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -298,4 +298,8 @@ config NATIVE_POSIX_CONSOLE_INIT_PRIORITY
 	help
 	  Device driver initialization priority.
 
+module = UART_CONSOLE
+module-str = UART console
+source "subsys/logging/Kconfig.template.log_config"
+
 endif

--- a/drivers/console/uart_pipe.c
+++ b/drivers/console/uart_pipe.c
@@ -11,6 +11,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <logging/log.h>
+LOG_MODULE_REGISTER(uart_pipe, CONFIG_UART_CONSOLE_LOG_LEVEL);
+
 #include <kernel.h>
 
 #include <uart.h>
@@ -39,6 +42,8 @@ static void uart_pipe_rx(struct device *dev)
 			break;
 		}
 
+		LOG_HEXDUMP_DBG(recv_buf + recv_off, got, "RX");
+
 		/*
 		 * Call application callback with received data. Application
 		 * may provide new buffer or alter data offset.
@@ -61,6 +66,8 @@ static void uart_pipe_isr(struct device *dev)
 
 int uart_pipe_send(const u8_t *data, int len)
 {
+	LOG_HEXDUMP_DBG(data, len, "TX");
+
 	while (len--)  {
 		uart_poll_out(uart_pipe_dev, *data++);
 	}


### PR DESCRIPTION
Allow user to set log level for UART console drivers. Add
log level option to UART pipe driver in order to see what it
is sending and receiving.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>