### PR TITLE
CODEOWNERS: Fix missing '/' in codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,7 @@
 /arch/common/                             @andrewboie @ioannisg @andyross
 /arch/x86_64/                             @andyross
 /soc/arc/snps_*/                          @vonhust @ruuddw
-/soc/nios2                                @nashif @wentongwu
+/soc/nios2/                               @nashif @wentongwu
 /soc/arm/                                 @MaureenHelm @galak
 /soc/arm/arm/mps2/                        @fvincenzo
 /soc/arm/atmel_sam/sam3x/                 @ioannisg


### PR DESCRIPTION
Fix error "Expected '/' after directory 'soc/nios2' in CODEOWNERS"

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>