### PR TITLE
drivers: ieee802154: nrf5: Support when LOG is off

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -7,7 +7,11 @@
  */
 
 #define LOG_MODULE_NAME ieee802154_nrf5
+#if defined(CONFIG_IEEE802154_DRIVER_LOG_LEVEL)
 #define LOG_LEVEL CONFIG_IEEE802154_DRIVER_LOG_LEVEL
+#else
+#define LOG_LEVEL LOG_LEVEL_NONE
+#endif
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
@@ -118,7 +122,7 @@ static void nrf5_rx_thread(void *arg1, void *arg2, void *arg3)
 		nrf_802154_buffer_free_raw(rx_frame->psdu);
 		rx_frame->psdu = NULL;
 
-		if (CONFIG_IEEE802154_DRIVER_LOG_LEVEL >= LOG_LEVEL_DBG) {
+		if (LOG_LEVEL >= LOG_LEVEL_DBG) {
 			net_analyze_stack(
 				"nRF5 rx stack",
 				Z_THREAD_STACK_BUFFER(nrf5_radio->rx_stack),


### PR DESCRIPTION
ieee802154_nrf5 checks if IEEE802154_DRIVER_LOG_LEVEL is set to debug
before initializing the "nRF5 rx stack". This leads to an undefined
reference error in case of the LOG module being disabled.

Avoids this behavior by using the LOG_LEVEL macro and setting it as
LOG_LEVEL_NONE in case of IEEE802154_DRIVER_LOG_LEVEL not defined.

Fixes #16103

Signed-off-by: Joao Cordeiro <jvcc@cesar.org.br>