### PR TITLE
net: arp: Drop request where src hw address is our address

### DIFF
--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -545,6 +545,15 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 
 	switch (ntohs(arp_hdr->opcode)) {
 	case NET_ARP_REQUEST:
+		/* If ARP request sender hw address is our address,
+		 * we must drop the packet.
+		 */
+		if (memcmp(&arp_hdr->src_hwaddr,
+			   net_if_get_link_addr(net_pkt_iface(pkt))->addr,
+			   sizeof(struct net_eth_addr)) == 0) {
+			return NET_DROP;
+		}
+
 		if (IS_ENABLED(CONFIG_NET_ARP_GRATUITOUS)) {
 			if (memcmp(&eth_hdr->dst,
 				   net_eth_broadcast_addr(),


### PR DESCRIPTION
We replied to an ARP request that has the same Sender Hardware Address
than that of ours. Such an ARP request must be discarded, no reply
should be sent and translation table should not be updated.

Fixes #16110

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>