### PR TITLE
Bluetooth: kconfig: Put 'menuconfig BT' in top-level menu

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -3,12 +3,9 @@
 # Copyright (c) 2016 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
-menu "Bluetooth"
-
-config BT
-	bool "Bluetooth support"
+menuconfig BT
+	bool "Bluetooth"
 	select NET_BUF
 	help
 	  This option enables Bluetooth support.
@@ -148,5 +145,3 @@ source "subsys/bluetooth/shell/Kconfig"
 endif # BT_HCI
 
 endif # BT
-
-endmenu


### PR DESCRIPTION
The 'Bluetooth' menu contains just 'config BT' and its indented
children.

Remove one menu level by removing the 'Bluetooth' menu and turning BT
into a 'menuconfig' symbol. Also change the prompt from "Bluetooth
support" to just "Bluetooth", to make it consistent with e.g. "Logging".