### PR TITLE
console: kconfig: Put 'menuconfig CONSOLE_SUBSYS' in top-level menu

### DIFF
--- a/subsys/console/Kconfig
+++ b/subsys/console/Kconfig
@@ -4,14 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-menu "Console"
-
-config CONSOLE_SUBSYS
+menuconfig CONSOLE_SUBSYS
 	bool "Console subsystem/support routines [EXPERIMENTAL]"
 	help
 	  Console subsystem and helper functions
 
 if CONSOLE_SUBSYS
+
 choice
 	prompt "Console 'get' function selection"
 	optional
@@ -50,4 +49,3 @@ config CONSOLE_PUTCHAR_BUFSIZE
 endif # CONSOLE_GETCHAR
 
 endif # CONSOLE_SUBSYS
-endmenu


### PR DESCRIPTION
The 'Console' menu contains just 'config CONSOLE_SUBSYS' and its
indented children.

Remove one menu level by removing the 'Console' menu and turning
CONSOLE_SUBSYS into a 'menuconfig' symbol.