### PR TITLE
ext: lib: mcumgr: Remove 'External Sources -> Management' menu

### DIFF
--- a/ext/lib/mgmt/Kconfig
+++ b/ext/lib/mgmt/Kconfig
@@ -17,8 +17,4 @@
 # under the License.
 #
 
-menu "Management"
-
 source "ext/lib/mgmt/mcumgr/Kconfig"
-
-endmenu

--- a/ext/lib/mgmt/mcumgr/Kconfig
+++ b/ext/lib/mgmt/mcumgr/Kconfig
@@ -22,6 +22,7 @@ config MCUMGR
       This option enables the mcumgr management library.
 
 if MCUMGR
+
 source "ext/lib/mgmt/mcumgr/cmd/Kconfig"
 
 config APP_LINK_WITH_MCUMGR


### PR DESCRIPTION
This menu contains just the MCUMGR symbol and its children. Get rid of
one menu level by removing it.

Makes the 'External Sources' menu look like this:

```
      HALs  --->
      Cryptography  --->
  [ ] Fnmatch Support
  [ ] OpenAMP Support
  (open-amp) OpenAMP library source path
  [ ] mcumgr Support
```

('OpenAMP library source path' being visible there might be a separate
issue.)