### PR TITLE
uart: Async API clarification and test fix

### DIFF
--- a/include/uart.h
+++ b/include/uart.h
@@ -174,13 +174,18 @@ struct uart_event_tx {
 	size_t len;
 };
 
-/** @brief UART RX event data. */
+/**
+ * @brief UART RX event data.
+ *
+ * The data represented by the event is stored in rx.buf[rx.offset] to
+ * rx.buf[rx.offset+rx.len].  That is, the length is relative to the offset.
+ */
 struct uart_event_rx {
 	/** @brief Pointer to current buffer. */
 	u8_t *buf;
-	/** @brief Offset from buffer start to currently received data. */
+	/** @brief Currently received data offset in bytes. */
 	size_t offset;
-	/** @brief Number of bytes received. */
+	/** @brief Number of new bytes received. */
 	size_t len;
 };
 

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -292,7 +292,6 @@ void test_write_abort(void)
 	uart_tx(uart_dev, tx_buf, 5, 100);
 	zassert_equal(k_sem_take(&tx_done, 100), 0, "TX_DONE timeout");
 	zassert_equal(k_sem_take(&rx_rdy, 100), 0, "RX_RDY timeout");
-	zassert_equal(received, 5, "Incorrect number of bytes received.");
 	zassert_equal(memcmp(tx_buf, rx_buf, 5), 0, "Buffers not equal");
 
 	uart_tx(uart_dev, tx_buf, 95, 100);
@@ -300,10 +299,7 @@ void test_write_abort(void)
 	zassert_equal(k_sem_take(&tx_aborted, 100), 0, "TX_ABORTED timeout");
 	if (sent != 0) {
 		zassert_equal(k_sem_take(&rx_rdy, 100), 0, "RX_RDY timeout");
-		zassert_equal(sent, received - 5,
-			      "Sent is not equal to received.");
-		zassert_equal(memcmp(tx_buf, rx_buf, received), 0,
-			      "Buffers not equal");
+		zassert_equal(sent, received, "Sent is not equal to received.");
 	}
 	uart_rx_disable(uart_dev);
 	zassert_equal(k_sem_take(&rx_buf_released, 100),

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -77,6 +77,7 @@ u8_t chained_read_buf1[20];
 u8_t chained_read_buf2[30];
 u8_t buf_num = 1U;
 u8_t *read_ptr;
+volatile size_t read_len;
 
 void test_chained_read_callback(struct uart_event *evt, void *user_data)
 {
@@ -88,6 +89,7 @@ void test_chained_read_callback(struct uart_event *evt, void *user_data)
 		break;
 	case UART_RX_RDY:
 		read_ptr = evt->data.rx.buf + evt->data.rx.offset;
+		read_len = evt->data.rx.len;
 		k_sem_give(&rx_rdy);
 		break;
 	case UART_RX_BUF_REQUEST:
@@ -130,6 +132,8 @@ void test_chained_read(void)
 		uart_tx(uart_dev, tx_buf, sizeof(tx_buf), 100);
 		zassert_equal(k_sem_take(&tx_done, 100), 0, "TX_DONE timeout");
 		zassert_equal(k_sem_take(&rx_rdy, 1000), 0, "RX_RDY timeout");
+		zassert_equal(read_len, sizeof(tx_buf),
+			      "Incorrect read length");
 		zassert_equal(memcmp(tx_buf, read_ptr, sizeof(tx_buf)),
 			      0,
 			      "Buffers not equal");


### PR DESCRIPTION
In #16024 my interpretation of the API was [incorrect](https://github.com/zephyrproject-rtos/zephyr/pull/16024#issuecomment-491811940).  

However, this highlights that the API could be interpreted a different, incompatible, way and that there was no existing test code that would explicitly fail in that interpretation.  The only case where it was checked was in a path that the existing implementation didn't take.  So this reverts d09b91f to restore the previous logic, then adds an explicit test that is taken in the existing implementation to catch this (i.e. it depends on the correct behavior and the current nrfx implementation actually hits it).  Finally, it also adds to the documentation of the API slightly to make the meaning of the problematic field explicit.