### PR TITLE
ext: open-amp: kconfig: Add missing OPENAMP dep. to OPENAMP_SRC_PATH

### DIFF
--- a/ext/lib/ipc/open-amp/Kconfig
+++ b/ext/lib/ipc/open-amp/Kconfig
@@ -13,5 +13,6 @@ config OPENAMP
 config OPENAMP_SRC_PATH
 	string "OpenAMP library source path"
 	default "open-amp"
+	depends on OPENAMP
 	help
 	  This option specifies the path to the source for the open-amp library


### PR DESCRIPTION
Prevents the OPENAMP_SRC_PATH symbol from showing up in the menu when
OPENAMP is disabled.