### PR TITLE
subsys: random: Hide 'Random generator' choice when empty

### DIFF
--- a/subsys/random/Kconfig
+++ b/subsys/random/Kconfig
@@ -18,6 +18,7 @@ config TEST_RANDOM_GENERATOR
 choice
 	prompt "Random generator"
 	default ENTROPY_DEVICE_RANDOM_GENERATOR
+	depends on ENTROPY_HAS_DRIVER || TEST_RANDOM_GENERATOR
 
 config X86_TSC_RANDOM_GENERATOR
 	bool "x86 timestamp counter based number generator"


### PR DESCRIPTION
Prevent the choice from showing up in the menu when none of the choice
symbols are visible.