### PR TITLE
sanitycheck: when present, point at handler.log instead of run.log

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1052,8 +1052,13 @@ class MakeGoal:
             # Failure when calling the sub-make to build the code
             return self.build_log
         elif self.make_state == "running":
-            # Failure in sub-make for "make run", qemu probably failed to start
-            return self.run_log
+            # Failure in sub-make for "make run", qemu probably failed.
+            # Return qemu's output if there is one, otherwise make's.
+            h = Path(self.handler_log)
+            if h.exists() and h.stat().st_size > 0:
+                return self.handler_log
+            else:
+                return self.run_log
         elif self.make_state == "finished":
             # Execution handler finished, but timed out or otherwise wasn't successful
             return self.handler_log


### PR DESCRIPTION
When Zephyr crashes immediately QEMU reports an error immediately. This
is immediately reported by "make run". Then sanitycheck points the user
at the output of "make run". However the error message(s) are in QEMU's
output which is in a different .log file.

To address this situation point the error message at handler.log
instead of run.log if and only if handler.log is not empty.

To reproduce here's an artificial but very simple crash:

  sanitycheck --extra-args=CONFIG_TEST_USERSPACE=n \
    -p qemu_x86 -T tests/kernel/mem_protect/stackprot/

Signed-off-by: Marc Herbert <marc.herbert@intel.com>