### PR TITLE
drivers: counter: nrfx_timer: Add detection of late alarm request

### DIFF
--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -13,6 +13,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 
 #define TIMER_CLOCK 16000000
 
+#define MS2TICKS(ms, prescaler) (((ms) * TIMER_CLOCK/(1 << (prescaler))) / 1000)
+
 #define CC_TO_ID(cc_num) (cc_num - 2)
 
 #define ID_TO_CC(idx) (nrf_timer_cc_channel_t)(idx + 2)
@@ -24,6 +26,12 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 #define COUNTER_TOP_INT NRF_TIMER_EVENT_COMPARE0
 #define COUNTER_OVERFLOW_SHORT NRF_TIMER_SHORT_COMPARE0_CLEAR_MASK
 #define COUNTER_READ_CC NRF_TIMER_CC_CHANNEL1
+
+/* helper log macros */
+#define ERR(...) LOG_INST_ERR(get_nrfx_config(dev)->log, __VA_ARGS__)
+#define WRN(...) LOG_INST_WRN(get_nrfx_config(dev)->log, __VA_ARGS__)
+#define INF(...) LOG_INST_INF(get_nrfx_config(dev)->log, __VA_ARGS__)
+#define DBG(...) LOG_INST_DBG(get_nrfx_config(dev)->log, __VA_ARGS__)
 
 struct counter_nrfx_data {
 	counter_top_callback_t top_cb;
@@ -39,6 +47,7 @@ struct counter_nrfx_config {
 	struct counter_config_info info;
 	struct counter_nrfx_ch_data *ch_data;
 	nrfx_timer_t timer;
+	u32_t guard_window;
 
 	LOG_INSTANCE_PTR_DECLARE(log);
 };
@@ -76,7 +85,8 @@ static u32_t counter_nrfx_get_top_value(struct device *dev)
 
 static u32_t counter_nrfx_get_max_relative_alarm(struct device *dev)
 {
-	return nrfx_timer_capture_get(&get_nrfx_config(dev)->timer, TOP_CH);
+	return counter_nrfx_get_top_value(dev) -
+			get_nrfx_config(dev)->guard_window;;
 }
 
 static u32_t counter_nrfx_read(struct device *dev)
@@ -115,11 +125,60 @@ static inline u32_t counter_nrfx_get_cc_value(struct device *dev,
 	return cc_val;
 }
 
+/* Function calculates distance between to values assuming that one first
+ * argument is in front and that values wrap.
+ */
+static u32_t tick_diff(u32_t new, u32_t old, u32_t top)
+{
+	if (top & (top + 1)) {
+		/* if top is not 2^n-1 */
+		u32_t diff;
+
+		diff = (new > old) ? (new - old) : new + top + 1 - old;
+
+		return diff;
+	}
+
+	return (new - old) & top;
+}
+
+static int set_cc(struct device *dev, u8_t chan_id, u32_t val)
+{
+	const struct counter_nrfx_config *nrfx_config = get_nrfx_config(dev);
+	const nrfx_timer_t *tmr = &nrfx_config->timer;
+	NRF_TIMER_Type  *reg = tmr->p_reg;
+	u32_t now;
+	u32_t top = counter_get_top_value(dev);
+	nrf_timer_task_t read_tsk =
+		   offsetof(NRF_TIMER_Type, TASKS_CAPTURE[COUNTER_READ_CC]);
+	nrf_timer_event_t evt =
+			offsetof(NRF_TIMER_Type, EVENTS_COMPARE[chan_id]);
+	u32_t int_mask = NRF_TIMER_INT_COMPARE0_MASK << chan_id;
+
+	nrf_timer_cc_write(reg, chan_id, val);
+	nrf_timer_event_clear(reg, evt);
+
+	nrf_timer_task_trigger(reg, read_tsk);
+	now = nrf_timer_cc_read(reg, COUNTER_READ_CC);
+
+	if (tick_diff(val - 1, now, top) > (top - nrfx_config->guard_window)) {
+		WRN("late setting CC%d to %d (now %d)", chan_id, val, now);
+		nrf_timer_event_clear(reg, evt);
+		return -1;
+	} else {
+		DBG("setting CC%d to %d (now %d)", chan_id, val, now);
+	}
+
+	nrf_timer_int_enable(reg, int_mask);
+	return 0;
+}
+
 static int counter_nrfx_set_alarm(struct device *dev, u8_t chan_id,
 				  const struct counter_alarm_cfg *alarm_cfg)
 {
 	const struct counter_nrfx_config *nrfx_config = get_nrfx_config(dev);
 	const nrfx_timer_t *timer = &nrfx_config->timer;
+	struct counter_nrfx_ch_data *chdata = &nrfx_config->ch_data[chan_id];
 	u32_t cc_val;
 
 	if (alarm_cfg->ticks > nrfx_timer_capture_get(timer, TOP_CH)) {
@@ -131,11 +190,15 @@ static int counter_nrfx_set_alarm(struct device *dev, u8_t chan_id,
 	}
 
 	cc_val = counter_nrfx_get_cc_value(dev, alarm_cfg);
+	chdata->callback = alarm_cfg->callback;
+	chdata->user_data = alarm_cfg->user_data;
 
-	nrfx_config->ch_data[chan_id].callback = alarm_cfg->callback;
-	nrfx_config->ch_data[chan_id].user_data = alarm_cfg->user_data;
+	if (set_cc(dev, ID_TO_CC(chan_id), cc_val) != 0) {
+		counter_alarm_callback_t clbk = chdata->callback;
 
-	nrfx_timer_compare(timer, ID_TO_CC(chan_id), cc_val, true);
+		chdata->callback = NULL;
+		clbk(dev, chan_id, cc_val, chdata->user_data);
+	}
 
 	return 0;
 }
@@ -286,6 +349,9 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 		},							       \
 		.ch_data = counter##idx##_ch_data,			       \
 		.timer = NRFX_TIMER_INSTANCE(idx),			       \
+		.guard_window = MS2TICKS(				       \
+				DT_NORDIC_NRF_TIMER_TIMER_##idx##_GUARD_PERIOD,\
+				DT_NORDIC_NRF_TIMER_TIMER_##idx##_PRESCALER),  \
 		LOG_INSTANCE_PTR_INIT(log, LOG_MODULE_NAME, idx)	       \
 	};								       \
 	DEVICE_AND_API_INIT(timer_##idx,				       \

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -175,6 +175,7 @@
 			reg = <0x40008000 0x1000>;
 			interrupts = <8 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_0";
 		};
 
@@ -184,6 +185,7 @@
 			reg = <0x40009000 0x1000>;
 			interrupts = <9 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_1";
 		};
 
@@ -193,6 +195,7 @@
 			reg = <0x4000a000 0x1000>;
 			interrupts = <10 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_2";
 		};
 

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -161,6 +161,7 @@
 			reg = <0x40008000 0x1000>;
 			interrupts = <8 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_0";
 		};
 
@@ -170,6 +171,7 @@
 			reg = <0x40009000 0x1000>;
 			interrupts = <9 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_1";
 		};
 
@@ -179,6 +181,7 @@
 			reg = <0x4000a000 0x1000>;
 			interrupts = <10 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_2";
 		};
 

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -179,6 +179,7 @@
 			reg = <0x40008000 0x1000>;
 			interrupts = <8 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_0";
 		};
 
@@ -188,6 +189,7 @@
 			reg = <0x40009000 0x1000>;
 			interrupts = <9 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_1";
 		};
 
@@ -197,6 +199,7 @@
 			reg = <0x4000a000 0x1000>;
 			interrupts = <10 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_2";
 		};
 

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -227,6 +227,7 @@
 			reg = <0x40008000 0x1000>;
 			interrupts = <8 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_0";
 		};
 
@@ -236,6 +237,7 @@
 			reg = <0x40009000 0x1000>;
 			interrupts = <9 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_1";
 		};
 
@@ -245,6 +247,7 @@
 			reg = <0x4000a000 0x1000>;
 			interrupts = <10 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_2";
 		};
 
@@ -254,6 +257,7 @@
 			reg = <0x4001a000 0x1000>;
 			interrupts = <26 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_3";
 		};
 
@@ -263,6 +267,7 @@
 			reg = <0x4001b000 0x1000>;
 			interrupts = <27 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_4";
 		};
 

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -271,6 +271,7 @@
 			reg = <0x40008000 0x1000>;
 			interrupts = <8 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_0";
 		};
 
@@ -280,6 +281,7 @@
 			reg = <0x40009000 0x1000>;
 			interrupts = <9 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_1";
 		};
 
@@ -289,6 +291,7 @@
 			reg = <0x4000a000 0x1000>;
 			interrupts = <10 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_2";
 		};
 
@@ -298,6 +301,7 @@
 			reg = <0x4001a000 0x1000>;
 			interrupts = <26 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_3";
 		};
 
@@ -307,6 +311,7 @@
 			reg = <0x4001b000 0x1000>;
 			interrupts = <27 1>;
 			prescaler = <0>;
+			guard-period = <10>;
 			label = "TIMER_4";
 		};
 

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -242,6 +242,7 @@ timer0: timer@f000 {
 	reg = <0xf000 0x1000>;
 	interrupts = <15 1>;
 	prescaler = <0>;
+	guard-period = <10>;
 	label = "TIMER_0";
 };
 
@@ -251,6 +252,7 @@ timer1: timer@10000 {
 	reg = <0x10000 0x1000>;
 	interrupts = <16 1>;
 	prescaler = <0>;
+	guard-period = <10>;
 	label = "TIMER_1";
 };
 
@@ -260,5 +262,6 @@ timer2: timer@11000 {
 	reg = <0x11000 0x1000>;
 	interrupts = <17 1>;
 	prescaler = <0>;
+	guard-period = <10>;
 	label = "TIMER_2";
 };

--- a/dts/bindings/timer/nordic,nrf-timer.yaml
+++ b/dts/bindings/timer/nordic,nrf-timer.yaml
@@ -40,4 +40,18 @@ properties:
       category: required
       description: Prescaler value determines frequency (16MHz/2^prescaler)
       generation: define
+
+    # Guard period should be set to the maximal latency that can occur when
+    # controlling the counter (e.g. for how long operation may be
+    # interrupted). Guard period limits maximal alarm value that can be set
+    # to <top value> - <guard period in ticks> from now. Limitation applies
+    # to relative and absolute alarms. Longer alarm values will be
+    # interpretted as set too late and will expire immediately. If instance
+    # is used only from interrupt context value probably can be decreased.
+    # However, if used from low priority thread it may need to be increased.
+    guard-period:
+      type: int
+      description: Guard window in milliseconds
+      generation: define
+      category: required
 ...

--- a/tests/drivers/counter/counter_basic_api/nrf51_pca10028.overlay
+++ b/tests/drivers/counter/counter_basic_api/nrf51_pca10028.overlay
@@ -1,11 +1,14 @@
 &timer0 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer1 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer2 {
 	prescaler = <4>;
+	guard-period = <1>;
 };

--- a/tests/drivers/counter/counter_basic_api/nrf52810_pca10040.overlay
+++ b/tests/drivers/counter/counter_basic_api/nrf52810_pca10040.overlay
@@ -1,11 +1,14 @@
 &timer0 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer1 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer2 {
 	prescaler = <4>;
+	guard-period = <1>;
 };

--- a/tests/drivers/counter/counter_basic_api/nrf52811_pca10056.overlay
+++ b/tests/drivers/counter/counter_basic_api/nrf52811_pca10056.overlay
@@ -1,11 +1,14 @@
 &timer0 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer1 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer2 {
 	prescaler = <4>;
+	guard-period = <1>;
 };

--- a/tests/drivers/counter/counter_basic_api/nrf52840_pca10056.overlay
+++ b/tests/drivers/counter/counter_basic_api/nrf52840_pca10056.overlay
@@ -1,19 +1,24 @@
 &timer0 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer1 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer2 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer3 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer4 {
 	prescaler = <4>;
+	guard-period = <1>;
 };

--- a/tests/drivers/counter/counter_basic_api/nrf52_pca10040.overlay
+++ b/tests/drivers/counter/counter_basic_api/nrf52_pca10040.overlay
@@ -1,19 +1,24 @@
 &timer0 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer1 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer2 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer3 {
 	prescaler = <4>;
+	guard-period = <1>;
 };
 
 &timer4 {
 	prescaler = <4>;
+	guard-period = <1>;
 };

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -299,7 +299,7 @@ void test_multiple_alarms_instance(const char *dev_name)
 	err = counter_set_top_value(dev, ticks, top_handler, exp_user_data);
 	zassert_equal(0, err, "Counter failed to set top value\n");
 
-	k_busy_wait(1.4*counter_ticks_to_us(dev, alarm_cfg.ticks));
+	k_busy_wait(3*counter_ticks_to_us(dev, alarm_cfg.ticks));
 
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
 	zassert_equal(0, err, "Counter set alarm failed\n");


### PR DESCRIPTION
Report when requested timeout is too late.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>