### PR TITLE
arch: arm: fix ESF pointer in SecureStackDump()

### DIFF
--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -737,7 +737,7 @@ static void SecureStackDump(const NANO_ESF *secure_esf)
 		 */
 		top_of_sec_stack += ADDITIONAL_STATE_CONTEXT_WORDS;
 		secure_esf = (const NANO_ESF *)top_of_sec_stack;
-		sec_ret_addr = secure_esf->pc;
+		sec_ret_addr = secure_esf->basic.pc;
 	} else {
 		/* Exception during Non-Secure function call.
 		 * The return address is located on top of stack.


### PR DESCRIPTION
This commit fixes a build error, when building with
CONFIG_ARM_SECURE_FIRMWARE=y. The error was introduced
in #15930 (6f19d0), where we added internal structure
to the exception stack frame struct.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>