### PR TITLE
disco_l475_iot: Enable peripheral sample 

### DIFF
--- a/boards/arm/disco_l475_iot1/Kconfig.defconfig
+++ b/boards/arm/disco_l475_iot1/Kconfig.defconfig
@@ -64,6 +64,13 @@ config UART_1
 
 endif # UART_CONSOLE
 
+if BT_DEBUG_MONITOR
+
+config UART_4
+	default y
+
+endif # UART_CONSOLE
+
 if SERIAL
 
 config UART_4
@@ -150,7 +157,6 @@ config BT_HCI_ACL_FLOW_CONTROL
 	default n
 config BT_HCI_VS_EXT
 	default n
-
 endif #BT
 
 if WIFI

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,bt-mon-uart = &uart4;
 	};
 
 	leds {

--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -10,7 +10,7 @@ menu "ATT and GATT Options"
 
 config BT_ATT_ENFORCE_FLOW
 	bool "Enforce strict flow control semantics for incoming PDUs"
-	default y if !(BOARD_QEMU_CORTEX_M3 || BOARD_QEMU_X86 || BOARD_NATIVE_POSIX)
+	default y if !(BOARD_QEMU_CORTEX_M3 || BOARD_QEMU_X86 || BOARD_NATIVE_POSIX || BT_SPI_BLUENRG)
 	help
 	  Enforce flow control rules on incoming PDUs, preventing a peer
 	  from sending new requests until a previous one has been responded


### PR DESCRIPTION
This PR enables peripheral sample on disco_l475_iot1.
Also for convenience, it proposes a default configuration when using btmon

Fixes #15714 