### PR TITLE
sanitycheck: Execute binary in output directory

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -568,7 +568,7 @@ class BinaryHandler(Handler):
                 generator_cmd = "ninja"
             else:
                 generator_cmd = "make"
-            command = [generator_cmd, "-C", self.outdir, "run"]
+            command = [generator_cmd, "run"]
         else:
             command = [self.binary]
 
@@ -580,8 +580,9 @@ class BinaryHandler(Handler):
                        ] + command
 
         verbose("Spawning process: " +
-                " ".join(shlex.quote(word) for word in command))
-        with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
+                " ".join(shlex.quote(word) for word in command) + os.linesep +
+                "Spawning process in directory: " + self.outdir)
+        with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self.outdir) as proc:
             verbose("Spawning BinaryHandler Thread for %s" % self.name)
             t = threading.Thread(target=self._output_reader, args=(proc, harness, ))
             t.start()


### PR DESCRIPTION
Execute the test binary from the output directory instead of directory
where sanitycheck was started.

This will ensure that any artifact created with a relative path by the
test binary will be placed in the output directory instead of creating
the artifact in the directory where sanitycheck was executed and prevent
any possible conflicts.

One of the use case is the flash support for native posix (PR #12503) which 
will create a binary file that stores the flash contents.