### PR TITLE
[Backport v1.14-branch] Rt1015 rt1020 sram size fix

### DIFF
--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <nxp/nxp_rt.dtsi>
+#include <nxp/nxp_rt1020.dtsi>
 
 / {
 	model = "NXP MIMXRT1020-EVK board";

--- a/dts/arm/nxp/nxp_rt1020.dtsi
+++ b/dts/arm/nxp/nxp_rt1020.dtsi
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019, Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_rt.dtsi>
+
+/* i.MX rt1020 default FlexRAM partition:
+ * ITCM: 64KB
+ * DTCM: 64KB
+ * OCRAM: 128KB
+ */
+&itcm0 {
+	reg = <0x00000000 0x10000>;
+};
+
+&dtcm0 {
+	reg = <0x20000000 0x10000>;
+};
+
+&ocram0 {
+	reg = <0x20200000 0x20000>;
+};


### PR DESCRIPTION
Manual backport of #15562 to pull in rt1020 fixes only. rt1015 fixes are excluded from the backport since that board was added after 1.14 was released.

Fixes #16416