### PR TITLE
drivers: adxl362: fix control flow issue

### DIFF
--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -780,14 +780,13 @@ static int adxl362_init(struct device *dev)
 		return -EIO;
 	}
 
-	err = adxl362_interrupt_config(dev,
-				       config->int1_config,
-				       config->int2_config);
-#endif
-
-	if (err) {
-		return err;
+	if (adxl362_interrupt_config(dev,
+				     config->int1_config,
+				     config->int2_config) < 0) {
+		LOG_ERR("Failed to configure interrupt");
+		return -EIO;
 	}
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
The return code check and error return on the interrupt register configuration function should be included in the #if defined region.

Fixes #16159.