### PR TITLE
soc: arm: move z_clearfaults() in kernel_arch_init()

### DIFF
--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -40,6 +40,7 @@ static ALWAYS_INLINE void kernel_arch_init(void)
 	z_ExcSetup();
 	z_FaultInit();
 	z_CpuIdleInit();
+	z_clearfaults();
 }
 
 static ALWAYS_INLINE void

--- a/soc/arm/atmel_sam/sam3x/soc.c
+++ b/soc/arm/atmel_sam/sam3x/soc.c
@@ -209,8 +209,6 @@ static int atmel_sam3x_init(struct device *arg)
 
 	key = irq_lock();
 
-	z_clearfaults();
-
 	/*
 	 * Set FWS (Flash Wait State) value before increasing Master Clock
 	 * (MCK) frequency.

--- a/soc/arm/atmel_sam/sam4s/soc.c
+++ b/soc/arm/atmel_sam/sam4s/soc.c
@@ -196,9 +196,6 @@ static int atmel_sam4s_init(struct device *arg)
 
 	key = irq_lock();
 
-	/* Clear all faults. */
-	z_clearfaults();
-
 	/*
 	 * Set FWS (Flash Wait State) value before increasing Master Clock
 	 * (MCK) frequency. Look at table 44.73 in the SAM4S datasheet.

--- a/soc/arm/atmel_sam/same70/soc.c
+++ b/soc/arm/atmel_sam/same70/soc.c
@@ -237,9 +237,6 @@ static int atmel_same70_init(struct device *arg)
 		SCB_EnableDCache();
 	}
 
-	/* Clear all faults */
-	z_clearfaults();
-
 	/*
 	 * Set FWS (Flash Wait State) value before increasing Master Clock
 	 * (MCK) frequency.

--- a/soc/arm/atmel_sam0/common/soc_samd2x.c
+++ b/soc/arm/atmel_sam0/common/soc_samd2x.c
@@ -180,8 +180,6 @@ static int atmel_samd_init(struct device *arg)
 
 	key = irq_lock();
 
-	z_clearfaults();
-
 	flash_waitstates_init();
 	osc8m_init();
 	osc32k_init();

--- a/soc/arm/microchip_mec/mec1501/soc.c
+++ b/soc/arm/microchip_mec/mec1501/soc.c
@@ -136,8 +136,6 @@ static int soc_init(struct device *dev)
 	isave = __get_PRIMASK();
 	__disable_irq();
 
-	z_clearfaults();
-
 	soc_pcr_init();
 
 	soc_clk32_init();

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -71,8 +71,6 @@ static int nordicsemi_nrf52_init(struct device *arg)
 	nrf_power_dcdcen_set(true);
 #endif
 
-	z_clearfaults();
-
 	/* Install default handler that simply resets the CPU
 	* if configured in the kernel, NOP otherwise
 	*/

--- a/soc/arm/nordic_nrf/nrf91/soc.c
+++ b/soc/arm/nordic_nrf/nrf91/soc.c
@@ -50,8 +50,6 @@ static int nordicsemi_nrf91_init(struct device *arg)
 	NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Msk;
 #endif
 
-	z_clearfaults();
-
 	/* Install default handler that simply resets the CPU
 	* if configured in the kernel, NOP otherwise
 	*/

--- a/soc/arm/nxp_imx/mcimx6x_m4/soc.c
+++ b/soc/arm/nxp_imx/mcimx6x_m4/soc.c
@@ -187,8 +187,6 @@ static int mcimx6x_m4_init(struct device *arg)
 	/* Initialize Cache */
 	SOC_CacheInit();
 
-	z_clearfaults();
-
 	/* Initialize clock */
 	SOC_ClockInit();
 

--- a/soc/arm/nxp_imx/rt/soc.c
+++ b/soc/arm/nxp_imx/rt/soc.c
@@ -235,8 +235,6 @@ static int imxrt_init(struct device *arg)
 		SCB_EnableDCache();
 	}
 
-	z_clearfaults();
-
 	/* Initialize system clock */
 	clkInit();
 

--- a/soc/arm/nxp_kinetis/k6x/soc.c
+++ b/soc/arm/nxp_kinetis/k6x/soc.c
@@ -180,8 +180,6 @@ static int fsl_frdm_k64f_init(struct device *arg)
 	SYSMPU->CESR = temp_reg;
 #endif /* !CONFIG_ARM_MPU */
 
-	z_clearfaults();
-
 	/* Initialize PLL/system clock to 120 MHz */
 	clkInit();
 

--- a/soc/arm/nxp_kinetis/ke1xf/soc.c
+++ b/soc/arm/nxp_kinetis/ke1xf/soc.c
@@ -232,8 +232,6 @@ static int ke1xf_init(struct device *arg)
 	SYSMPU->CESR = temp_reg;
 #endif /* !CONFIG_ARM_MPU */
 
-	z_clearfaults();
-
 	/* Initialize system clocks and PLL */
 	clk_init();
 

--- a/soc/arm/nxp_kinetis/kwx/soc_kw2xd.c
+++ b/soc/arm/nxp_kinetis/kwx/soc_kw2xd.c
@@ -189,8 +189,6 @@ static int kw2xd_init(struct device *arg)
 	/* release I/O power hold to allow normal run state */
 	PMC->REGSC |= PMC_REGSC_ACKISO_MASK;
 
-	z_clearfaults();
-
 	/* Initialize PLL/system clock to 48 MHz */
 	clkInit();
 

--- a/soc/arm/nxp_lpc/lpc54xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc54xxx/soc.c
@@ -87,8 +87,6 @@ static int nxp_lpc54114_init(struct device *arg)
 	/* disable interrupts */
 	oldLevel = irq_lock();
 
-	z_clearfaults();
-
 	/* Initialize FRO/system clock to 48 MHz */
 	clkInit();
 

--- a/soc/arm/silabs_exx32/common/soc.c
+++ b/soc/arm/silabs_exx32/common/soc.c
@@ -119,8 +119,6 @@ static int silabs_exx32_init(struct device *arg)
 	/* handle chip errata */
 	CHIP_Init();
 
-	z_clearfaults();
-
 #ifdef CONFIG_SOC_GECKO_EMU_DCDC
 	dcdc_init();
 #endif

--- a/soc/arm/st_stm32/stm32f0/soc.c
+++ b/soc/arm/st_stm32/stm32f0/soc.c
@@ -62,8 +62,6 @@ static int stm32f0_init(struct device *arg)
 
 	key = irq_lock();
 
-	z_clearfaults();
-
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */

--- a/soc/arm/st_stm32/stm32f1/soc.c
+++ b/soc/arm/st_stm32/stm32f1/soc.c
@@ -30,8 +30,6 @@ static int stm32f1_init(struct device *arg)
 
 	key = irq_lock();
 
-	z_clearfaults();
-
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */

--- a/soc/arm/st_stm32/stm32f2/soc.c
+++ b/soc/arm/st_stm32/stm32f2/soc.c
@@ -34,8 +34,6 @@ static int stm32f2_init(struct device *arg)
 
 	key = irq_lock();
 
-	z_clearfaults();
-
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */

--- a/soc/arm/st_stm32/stm32f3/soc.c
+++ b/soc/arm/st_stm32/stm32f3/soc.c
@@ -30,8 +30,6 @@ static int stm32f3_init(struct device *arg)
 
 	key = irq_lock();
 
-	z_clearfaults();
-
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */

--- a/soc/arm/st_stm32/stm32f4/soc.c
+++ b/soc/arm/st_stm32/stm32f4/soc.c
@@ -31,8 +31,6 @@ static int st_stm32f4_init(struct device *arg)
 
 	key = irq_lock();
 
-	z_clearfaults();
-
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */

--- a/soc/arm/st_stm32/stm32f7/soc.c
+++ b/soc/arm/st_stm32/stm32f7/soc.c
@@ -37,8 +37,6 @@ static int st_stm32f7_init(struct device *arg)
 		SCB_EnableDCache();
 	}
 
-	z_clearfaults();
-
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */

--- a/soc/arm/st_stm32/stm32l0/soc.c
+++ b/soc/arm/st_stm32/stm32l0/soc.c
@@ -32,8 +32,6 @@ static int stm32l0_init(struct device *arg)
 
 	key = irq_lock();
 
-	z_clearfaults();
-
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */

--- a/soc/arm/st_stm32/stm32l1/soc.c
+++ b/soc/arm/st_stm32/stm32l1/soc.c
@@ -32,8 +32,6 @@ static int stm32l1_init(struct device *arg)
 
 	key = irq_lock();
 
-	z_clearfaults();
-
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */

--- a/soc/arm/st_stm32/stm32l4/soc.c
+++ b/soc/arm/st_stm32/stm32l4/soc.c
@@ -31,8 +31,6 @@ static int stm32l4_init(struct device *arg)
 
 	key = irq_lock();
 
-	z_clearfaults();
-
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */

--- a/soc/arm/st_stm32/stm32mp1/soc.c
+++ b/soc/arm/st_stm32/stm32mp1/soc.c
@@ -32,8 +32,6 @@ static int stm32m4_init(struct device *arg)
 
 	key = irq_lock();
 
-	z_clearfaults();
-
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */

--- a/soc/arm/st_stm32/stm32wb/soc.c
+++ b/soc/arm/st_stm32/stm32wb/soc.c
@@ -30,8 +30,6 @@ static int stm32wb_init(struct device *arg)
 
 	key = irq_lock();
 
-	z_clearfaults();
-
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */


### PR DESCRIPTION
In kernel_arch_init() we initialize the ARM core (interrupt
setup, fault init, etc.) so we can also move z_clearfaults()
in the same function and skip invoking it in the SoC init
functions.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>