### PR TITLE
net: ipv4: Allow UDP packets with broadcast dst address

### DIFF
--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -43,6 +43,12 @@ config NET_ICMPV4_ACCEPT_BROADCAST
 	  If set, then respond to ICMPv4 echo-request that is sent to
 	  broadcast address.
 
+config NET_IPV4_ACCEPT_ZERO_BROADCAST
+	bool "Accept 0.0.0.0 broadcast destination address"
+	help
+	  If set, then accept UDP packets destined to non-standard
+	  0.0.0.0 broadcast address as described in RFC 1122 ch. 3.3.6
+
 config NET_DHCPV4
 	bool "Enable DHCPv4 client"
 

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -166,12 +166,15 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 	}
 
 	if ((!net_ipv4_is_my_addr(&hdr->dst) &&
-	    !net_ipv4_is_addr_mcast(&hdr->dst)) ||
-	    ((hdr->proto == IPPROTO_UDP &&
-	      net_ipv4_addr_cmp(&hdr->dst, net_ipv4_broadcast_address()) &&
-	      !IS_ENABLED(CONFIG_NET_DHCPV4)) ||
-	     (hdr->proto == IPPROTO_TCP &&
-	      net_ipv4_is_addr_bcast(net_pkt_iface(pkt), &hdr->dst)))) {
+	     !net_ipv4_is_addr_mcast(&hdr->dst) &&
+	     !(hdr->proto == IPPROTO_UDP &&
+	       (net_ipv4_addr_cmp(&hdr->dst, net_ipv4_broadcast_address()) ||
+		/* RFC 1122 ch. 3.3.6 The 0.0.0.0 is non-standard bcast addr */
+		(IS_ENABLED(CONFIG_NET_IPV4_ACCEPT_ZERO_BROADCAST) &&
+		 net_ipv4_addr_cmp(&hdr->dst,
+				   net_ipv4_unspecified_address()))))) ||
+	    (hdr->proto == IPPROTO_TCP &&
+	     net_ipv4_is_addr_bcast(net_pkt_iface(pkt), &hdr->dst))) {
 		NET_DBG("DROP: not for me");
 		goto drop;
 	}


### PR DESCRIPTION
Make sure we are able to receive UDP packets with broadcast
destination address.

Fixes #11617

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>