### PR TITLE
Bluetooth: gatt: Fix GATT database service re-register

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -823,6 +823,14 @@ int bt_gatt_service_unregister(struct bt_gatt_service *svc)
 
 	db_changed();
 
+	/*
+	 * Reset the handles to force their reassignment when adding the
+	 * same service again
+	 */
+	for (size_t i = 0; i < svc->attr_count; i++) {
+		svc->attrs[i].handle = 0;
+	}
+
 	return 0;
 }
 #endif /* CONFIG_BT_GATT_DYNAMIC_DB */


### PR DESCRIPTION
Reset the service's attributes handles when unregistering it in order to
force the gatt_register routine to reassign new handles.

When removing a service using bt_gatt_service_unregister, its attributes
handles will keep their value which can cause a problem when adding the
service again to the GATT database.
When re-adding, the gatt_register routine is taking the last handle of the GATT
database to compare it with the handles of the service to be added.
If a service has handles with a lower value than the last handle of the database
an error will occur. If we add/remove/add the last service, no error will
occur as its handles are always greater than the last one of the database.

Example:

0x0001 Service1
  0x0002 Char1.1
0x0003 Service 2
  0x0004 Char2.1
0x0005 Service 3
  0x0006 Char3.1

The last handle is 6.

If we remove Service 1 and try to add it again it will fail because its handle 
is 1 < 6.
If we remove Service 3 the last handle becomes 4 and adding the Service 
again will work because 6 > 4.
Resetting the handles to 0 will fix the issue because any service re-added
will end up at the en of the database with a new handle higher than the last
one.
