### PR TITLE
Fix long receptions in NRF UARTE asynchronous API implementation

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -690,9 +690,7 @@ static void endrx_isr(struct device *dev)
 		data->async->rx_buf = data->async->rx_next_buf;
 		data->async->rx_next_buf = NULL;
 
-		data->async->rx_total_byte_cnt += rx_len;
-		data->async->rx_total_user_byte_cnt =
-			data->async->rx_total_byte_cnt;
+		data->async->rx_total_user_byte_cnt += rx_len;
 		data->async->rx_offset = 0;
 	} else {
 		data->async->rx_buf = NULL;

--- a/tests/drivers/uart/uart_async_api/src/main.c
+++ b/tests/drivers/uart/uart_async_api/src/main.c
@@ -21,6 +21,7 @@ void test_main(void)
 			 ztest_unit_test(test_double_buffer),
 			 ztest_unit_test(test_read_abort),
 			 ztest_unit_test(test_chained_write),
+			 ztest_unit_test(test_long_buffers),
 			 ztest_unit_test(test_write_abort));
 	ztest_run_test_suite(uart_async_test);
 }

--- a/tests/drivers/uart/uart_async_api/src/test_uart.h
+++ b/tests/drivers/uart/uart_async_api/src/test_uart.h
@@ -32,6 +32,7 @@ void test_chained_read(void);
 void test_double_buffer(void);
 void test_read_abort(void);
 void test_write_abort(void);
+void test_long_buffers(void);
 void test_chained_write(void);
 
 #endif /* __TEST_UART_H__ */


### PR DESCRIPTION
If reception was longer than rx timeout, UART_RX_RDY event
would provide data with delay, and synchronise at buffer end.

This change makes sure that all data is given to user when timeout
occurs.

Also added test to detect such problems in future.