### PR TITLE
Bluetooth: gatt: Reuse existing handles from a previously added service

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -515,6 +515,25 @@ BT_GATT_SERVICE_DEFINE(_1_gatt_svc,
 );
 
 #if defined(CONFIG_BT_GATT_DYNAMIC_DB)
+
+static u8_t found_attr(const struct bt_gatt_attr *attr, void *user_data)
+{
+	const struct bt_gatt_attr **found = user_data;
+
+	*found = attr;
+
+	return BT_GATT_ITER_STOP;
+}
+
+static const struct bt_gatt_attr *find_attr(uint16_t handle)
+{
+	const struct bt_gatt_attr *attr = NULL;
+
+	bt_gatt_foreach_attr(handle, handle, found_attr, &attr);
+
+	return attr;
+}
+
 static int gatt_register(struct bt_gatt_service *svc)
 {
 	struct bt_gatt_service *last;
@@ -539,7 +558,7 @@ populate:
 		} else if (attrs->handle > handle) {
 			/* Use existing handle if valid */
 			handle = attrs->handle;
-		} else {
+		} else if (find_attr(attrs->handle)) {
 			/* Service has conflicting handles */
 			BT_ERR("Unable to register handle 0x%04x",
 			       attrs->handle);


### PR DESCRIPTION
When removing a service using bt_gatt_service_unregister, its attributes
handles will keep their value which can cause a problem when adding the
service again to the GATT database.
When re-adding, the gatt_register routine is taking the last handle of the GATT
database to compare it with the handles of the service to be added.
If a service has handles with a lower value than the last handle of the database
an error will occur. If we add/remove/add the last service, no error will
occur as its handles are always greater than the last one of the database.

Instead of resetting the handles when unregistering a service and
reassign new ones we make sure that the handles of the services are
not in use in the GATT database in order to place the service back
where it used to be.

Thank you to @Vudentz on PR [#16173](https://github.com/zephyrproject-rtos/zephyr/pull/16173)

Signed-off-by: Arthur Crepin-Leblond <arthur.crepin@proglove.de>