### PR TITLE
boards: reel_board: enable pull-up on UART TX pin

### DIFF
--- a/boards/arm/reel_board/board.c
+++ b/boards/arm/reel_board/board.c
@@ -37,6 +37,11 @@ static int board_reel_board_init(struct device *dev)
 		(GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos) |
 		(GPIO_PIN_CNF_PULL_Pullup << GPIO_PIN_CNF_PULL_Pos) |
 		(GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos);
+	gpio->PIN_CNF[DT_NORDIC_NRF_UART_0_TX_PIN] =
+		(GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos) |
+		(GPIO_PIN_CNF_PULL_Pullup << GPIO_PIN_CNF_PULL_Pos) |
+		(GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos);
+
 
 	return 0;
 }


### PR DESCRIPTION
Enable pull-up on UART TX pin to reduce power consumption.
If the board is powered by battery the SoC consumes more
power than expected.
The consumption increases because TX pin is floating
(High-Impedance state of pin B from Dual-Supply Bus Transceiver).

Similar to commit b5b728495b04
("boards: reel_board: enable pull-up on UART RX pin")