### PR TITLE
Fix preprocessor checks of undefined Kconfig options

### DIFF
--- a/include/arch/arm/cortex_m/irq.h
+++ b/include/arch/arm/cortex_m/irq.h
@@ -48,7 +48,7 @@ extern void z_irq_priority_set(unsigned int irq, unsigned int prio,
 
 
 /* Flags for use with IRQ_CONNECT() */
-#if CONFIG_ZERO_LATENCY_IRQS
+#ifdef CONFIG_ZERO_LATENCY_IRQS
 /**
  * Set this interrupt up as a zero-latency IRQ. It has a fixed hardware
  * priority level (discarding what was supplied in the interrupt's priority

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -20,7 +20,7 @@ extern "C" {
 #error "Logger does not support 64 bit architecture."
 #endif
 
-#if !CONFIG_LOG
+#ifndef CONFIG_LOG
 #define CONFIG_LOG_DEFAULT_LEVEL 0
 #define CONFIG_LOG_DOMAIN_ID 0
 #define CONFIG_LOG_MAX_LEVEL 0
@@ -330,7 +330,7 @@ extern "C" {
 
 #define LOG_FILTER_FIRST_BACKEND_SLOT_IDX 1
 
-#if CONFIG_LOG_RUNTIME_FILTERING
+#ifdef CONFIG_LOG_RUNTIME_FILTERING
 #define LOG_RUNTIME_FILTER(_filter) \
 	LOG_FILTER_SLOT_GET(&(_filter)->filters, LOG_FILTER_AGGR_SLOT_IDX)
 #else

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -500,7 +500,7 @@ struct shell_stats {
 	u32_t log_lost_cnt; /*!< Lost log counter.*/
 };
 
-#if CONFIG_SHELL_STATS
+#ifdef CONFIG_SHELL_STATS
 #define SHELL_STATS_DEFINE(_name) static struct shell_stats _name##_stats
 #define SHELL_STATS_PTR(_name) (&(_name##_stats))
 #else

--- a/include/shell/shell_history.h
+++ b/include/shell/shell_history.h
@@ -29,7 +29,7 @@ struct shell_history_item {
 	char data[];
 };
 
-#if CONFIG_SHELL_HISTORY
+#ifdef CONFIG_SHELL_HISTORY
 #define SHELL_HISTORY_DEFINE(_name, block_size, block_count)	\
 								\
 	K_MEM_SLAB_DEFINE(_name##_history_memslab,		\

--- a/include/shell/shell_log_backend.h
+++ b/include/shell/shell_log_backend.h
@@ -64,7 +64,7 @@ int shell_log_backend_output_func(u8_t *data, size_t length, void *ctx);
  *
  *  @param _name Shell name.
  */
-#if CONFIG_LOG
+#ifdef CONFIG_LOG
 #define SHELL_LOG_BACKEND_DEFINE(_name, _buf, _size, _queue_size, _timeout)  \
 	LOG_BACKEND_DEFINE(_name##_backend, log_backend_shell_api, false);   \
 	K_MSGQ_DEFINE(_name##_msgq, sizeof(struct shell_log_backend_msg),    \

--- a/include/tracing.h
+++ b/include/tracing.h
@@ -18,7 +18,7 @@
 #define SYS_TRACE_ID_SEMA_GIVE               (5u + SYS_TRACE_ID_OFFSET)
 #define SYS_TRACE_ID_SEMA_TAKE               (6u + SYS_TRACE_ID_OFFSET)
 
-#if CONFIG_TRACING
+#ifdef CONFIG_TRACING
 void z_sys_trace_idle(void);
 void z_sys_trace_isr_enter(void);
 void z_sys_trace_isr_exit(void);


### PR DESCRIPTION
Using the -Wundef compiler option, several checks of undefined Kconfig options generates compiler errors.  Use #ifdef/#ifndef for these checks instead of #if.