### PR TITLE
cmake: Fix missing dependency

### DIFF
--- a/cmake/kobj.cmake
+++ b/cmake/kobj.cmake
@@ -22,6 +22,7 @@ function(gen_kobj gen_dir_out)
     --kobj-otype-output ${KOBJ_OTYPE}
     --kobj-size-output ${KOBJ_SIZE}
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
+    DEPENDS $ENV{ZEPHYR_BASE}/scripts/gen_kobject_list.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   add_custom_target(${KOBJ_TYPES_H_TARGET} DEPENDS ${KOBJ_TYPES} ${KOBJ_OTYPE})


### PR DESCRIPTION
KOBJ_OTYPE should depend on any changes to the tool that generates it,
gen_kobject_list.py.

Signed-off-by: Phil Erwin <erwin@lexmark.com>