### PR TITLE
entropy: fix C++ compiler warnings

### DIFF
--- a/include/entropy.h
+++ b/include/entropy.h
@@ -20,12 +20,12 @@
  * @{
  */
 
+#include <zephyr/types.h>
+#include <device.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <zephyr/types.h>
-#include <device.h>
 
 /**
  * @typedef entropy_get_entropy_t


### PR DESCRIPTION
Move includes to outside of the extern "C" statements to fix C linkage
issue.
| /include/misc/util.h:53:1: error: template with C linkage
|  template < class T, size_t N >
|  ^~~~~~~~

Signed-off-by: Greg S. Woods <gwoods@lexmark.com>