### PR TITLE
drivers: gpio_c13xx_cc26xx: fix control flow issue

### DIFF
--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -45,10 +45,10 @@ static int gpio_cc13xx_cc26xx_config(struct device *port, int access_op,
 		if (flags & GPIO_INT_EDGE) {
 			if (flags & GPIO_INT_DOUBLE_EDGE) {
 				config |= IOC_BOTH_EDGES;
-			} else if (flags & GPIO_INT_ACTIVE_LOW) {
-				config |= IOC_FALLING_EDGE;
-			} else {
+			} else if (flags & GPIO_INT_ACTIVE_HIGH) {
 				config |= IOC_RISING_EDGE;
+			} else { /* GPIO_INT_ACTIVE_LOW */
+				config |= IOC_FALLING_EDGE;
 			}
 		} else {
 			return -ENOTSUP;


### PR DESCRIPTION
The value of GPIO_INT_ACTIVE_LOW is 0, so the bit checking if statement
is never executed. Use GPIO_INT_ACTIVE_HIGH when checking this bit.

We should add a mask for this bit.

Fixes #16162