### PR TITLE
c++: kconfig: Fix choice dependencies and use 'menuconfig' symbol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,27 +149,29 @@ toolchain_cc_cpp_dialect_std_14_flags(CPP_DIALECT_STD_14_FLAGS)
 toolchain_cc_cpp_dialect_std_17_flags(CPP_DIALECT_STD_17_FLAGS)
 toolchain_cc_cpp_dialect_std_2a_flags(CPP_DIALECT_STD_2A_FLAGS)
 
-# From kconfig choice, pick a single dialect.
-# Kconfig choice ensures only one of these CONFIG_STD_CPP* is set.
-if(CONFIG_STD_CPP98)
-  set(STD_CPP_DIALECT_FLAGS ${CPP_DIALECT_STD_98_FLAGS})
-elseif(CONFIG_STD_CPP11)
-  set(STD_CPP_DIALECT_FLAGS ${CPP_DIALECT_STD_11_FLAGS}) # Default in kconfig
-elseif(CONFIG_STD_CPP14)
-  set(STD_CPP_DIALECT_FLAGS ${CPP_DIALECT_STD_14_FLAGS})
-elseif(CONFIG_STD_CPP17)
-  set(STD_CPP_DIALECT_FLAGS ${CPP_DIALECT_STD_17_FLAGS})
-elseif(CONFIG_STD_CPP2A)
-  set(STD_CPP_DIALECT_FLAGS ${CPP_DIALECT_STD_2A_FLAGS})
-else()
-  assert(0 "Unreachable code. Expected C++ standard to have been chosen. See Kconfig.zephyr.")
-endif()
+if(CONFIG_CPLUSPLUS)
+  # From kconfig choice, pick a single dialect.
+  # Kconfig choice ensures only one of these CONFIG_STD_CPP* is set.
+  if(CONFIG_STD_CPP98)
+    set(STD_CPP_DIALECT_FLAGS ${CPP_DIALECT_STD_98_FLAGS})
+  elseif(CONFIG_STD_CPP11)
+    set(STD_CPP_DIALECT_FLAGS ${CPP_DIALECT_STD_11_FLAGS}) # Default in kconfig
+  elseif(CONFIG_STD_CPP14)
+    set(STD_CPP_DIALECT_FLAGS ${CPP_DIALECT_STD_14_FLAGS})
+  elseif(CONFIG_STD_CPP17)
+    set(STD_CPP_DIALECT_FLAGS ${CPP_DIALECT_STD_17_FLAGS})
+  elseif(CONFIG_STD_CPP2A)
+    set(STD_CPP_DIALECT_FLAGS ${CPP_DIALECT_STD_2A_FLAGS})
+  else()
+    assert(0 "Unreachable code. Expected C++ standard to have been chosen. See Kconfig.zephyr.")
+  endif()
 
-foreach(flag ${STD_CPP_DIALECT_FLAGS})
-  zephyr_compile_options(
-    $<$<COMPILE_LANGUAGE:CXX>:${flag}>
-  )
-endforeach()
+  foreach(flag ${STD_CPP_DIALECT_FLAGS})
+    zephyr_compile_options(
+      $<$<COMPILE_LANGUAGE:CXX>:${flag}>
+    )
+  endforeach()
+endif()
 
 if(NOT CONFIG_EXCEPTIONS)
   # @Intent: Obtain compiler specific flags related to C++ Exceptions

--- a/subsys/cpp/Kconfig
+++ b/subsys/cpp/Kconfig
@@ -6,12 +6,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-menu "C++ Options"
-
-config CPLUSPLUS
-	bool "Enable C++ support for the application"
+menuconfig CPLUSPLUS
+	bool "C++ support for the application"
 	help
 	  This option enables the use of applications built with C++.
+
+if CPLUSPLUS
 
 choice
 	prompt "C++ Standard"
@@ -48,24 +48,21 @@ config STD_CPP2A
 endchoice
 
 config LIB_CPLUSPLUS
-	depends on CPLUSPLUS
 	bool "Link with STD C++ library"
 	help
 	  Link with STD C++ Library.
 
 config EXCEPTIONS
-	depends on CPLUSPLUS
-	depends on NEWLIB_LIBC
-	select LIB_CPLUSPLUS
 	bool "Enable C++ exceptions support"
+	select LIB_CPLUSPLUS
+	depends on NEWLIB_LIBC
 	help
 	  This option enables support of C++ exceptions.
 
 config RTTI
-	depends on CPLUSPLUS
-	select LIB_CPLUSPLUS
 	bool "Enable C++ RTTI support"
+	select LIB_CPLUSPLUS
 	help
 	  This option enables support of C++ RTTI.
 
-endmenu
+endif # CPLUSPLUS


### PR DESCRIPTION
 - Make the 'C++ Standard' choice depend on CPLUSPLUS, so that it only
   shows up when C++ support is enabled.

   Also check that CPLUSPLUS is enabled before checking the standard in
   the top-level CMakeLists.txt, to avoid triggering an assert.

 - The 'C++ Options' menu now contains just CPLUSPLUS and its indented
   children. Remove one menu level by removing the menu and turning
   CPLUSPLUS into a 'menuconfig' symbol. Also change the prompt from
   "Enable C++ support for the application" to just "C++ support for the
   application", to make it consistent with e.g. "Logging".

 - Factor out the common CPLUSPLUS dependency with an 'if CPLUSPLUS'.

 - Order symbol properties more consistently with other Kconfig files,
   with the prompt at the top, etc.