### PR TITLE
boards/arm/olimexino_stm32: register led1

### DIFF
--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -40,6 +40,7 @@
 
 	aliases {
 		led0 = &green_led_1;
+		led1 = &yellow_led_2;
 		sw0 = &user_button;
 	};
 };


### PR DESCRIPTION
Make it possible to run ```basic/disco sample``` on ```olimexino_stm32```.
