### PR TITLE
soc: nxp: ke1xf: enable code cache

### DIFF
--- a/ext/hal/nxp/mcux/drivers/kinetis/CMakeLists.txt
+++ b/ext/hal/nxp/mcux/drivers/kinetis/CMakeLists.txt
@@ -10,6 +10,7 @@ zephyr_library_compile_definitions_ifdef(
   CONFIG_PTP_CLOCK_MCUX ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
 )
 
+zephyr_sources_ifdef(CONFIG_HAS_MCUX_CACHE    fsl_cache.c)
 zephyr_sources_ifdef(CONFIG_ADC_MCUX_ADC16    fsl_adc16.c)
 zephyr_sources_ifdef(CONFIG_ETH_MCUX          fsl_enet.c)
 zephyr_sources_ifdef(CONFIG_I2C_MCUX          fsl_i2c.c)

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.series
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.series
@@ -13,6 +13,7 @@ config SOC_SERIES_KINETIS_KE1XF
 	select CPU_HAS_FPU
 	select CLOCK_CONTROL
 	select HAS_MCUX
+	select HAS_MCUX_CACHE
 	select HAS_MCUX_FTFX
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_PCC

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.soc
@@ -87,4 +87,8 @@ config WDOG_INIT
 	  requires that the watchdog be configured during reset
 	  handling.
 
+config KINETIS_KE1XF_ENABLE_CODE_CACHE
+        bool "Enable the code cache"
+        default y
+
 endif # SOC_SERIES_KINETIS_KE1XF

--- a/soc/arm/nxp_kinetis/ke1xf/soc.c
+++ b/soc/arm/nxp_kinetis/ke1xf/soc.c
@@ -12,6 +12,7 @@
 #include <device.h>
 #include <init.h>
 #include <fsl_clock.h>
+#include <fsl_cache.h>
 #include <cortex_m/exc.h>
 
 /*
@@ -241,6 +242,9 @@ static int ke1xf_init(struct device *arg)
 	 */
 	NMI_INIT();
 
+#ifdef CONFIG_KINETIS_KE1XF_ENABLE_CODE_CACHE
+	L1CACHE_EnableCodeCache();
+#endif
 	/* Restore interrupt state */
 	irq_unlock(old_level);
 


### PR DESCRIPTION
Add option for enabling the Code Cache present on the NXP Kinetis
KE1xF SoC series and enable it by default.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>