### PR TITLE
arch: arm: remove redundant definitions of typeof

### DIFF
--- a/arch/arm/include/cortex_m/cmse.h
+++ b/arch/arm/include/cortex_m/cmse.h
@@ -136,11 +136,6 @@ int arm_cmse_addr_range_read_ok(u32_t addr, u32_t size, int force_npriv);
  */
 int arm_cmse_addr_range_readwrite_ok(u32_t addr, u32_t size, int force_npriv);
 
-/* Required for C99 compilation */
-#ifndef typeof
-#define typeof  __typeof__
-#endif
-
 /**
  * @brief Read accessibility of an object
  *

--- a/arch/arm/include/cortex_m/tz.h
+++ b/arch/arm/include/cortex_m/tz.h
@@ -283,9 +283,6 @@ int tz_sau_region_configure(tz_sau_conf_t *p_sau_conf);
  */
 typedef void __attribute__((cmse_nonsecure_call)) (*tz_ns_func_ptr_t) (void);
 
-/* Required for C99 compilation */
-#define typeof  __typeof__
-
 #if defined(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
 /**
  * @brief Non-Secure entry function attribute.


### PR DESCRIPTION
The typeof definitions in tz.h and cmse.h are not required
any more, as the ARM GCC toolchain intrinsics have been
modified to use `__typeof__` directly.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>