### PR TITLE
cmake: Toolchain abstraction: Abstraction of compiler warning as error flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,9 @@ endif()
 # @Intent: Add extended, more specific, toolchain warning flags
 toolchain_cc_warning_extended()
 
+# @Intent: Trigger an error when a declaration does not specify a type
+toolchain_cc_warning_error_implicit_int()
+
 # Allow the user to inject options when calling cmake, e.g.
 # 'cmake -DEXTRA_CFLAGS="-Werror -Wno-deprecated-declarations" ..'
 include(cmake/extra_flags.cmake)
@@ -292,9 +295,6 @@ endif()
 
 zephyr_cc_option_ifdef(CONFIG_STACK_USAGE            -fstack-usage)
 
-# Force an error when things like SYS_INIT(foo, ...) occur with a missing header.
-zephyr_cc_option(-Werror=implicit-int)
-
 # If the compiler supports it, strip the ${ZEPHYR_BASE} prefix from the
 # __FILE__ macro used in __ASSERT*, in the
 # .noinit."/home/joe/zephyr/fu/bar.c" section names and in any
@@ -302,9 +302,6 @@ zephyr_cc_option(-Werror=implicit-int)
 # in binaries, makes failure logs more deterministic and most
 # importantly makes builds more deterministic
 zephyr_cc_option(-fmacro-prefix-map=${ZEPHYR_BASE}=.)
-
-# Prohibit date/time macros, which would make the build non-deterministic
-# cc-option(-Werror=date-time)
 
 # TODO: Archiver arguments
 # ar_option(D)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,8 +190,11 @@ if(NOT CONFIG_RTTI)
 endif()
 
 if(CONFIG_MISRA_SANE)
-  zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=vla>)
-  zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=vla>)
+  # @Intent: Obtain toolchain compiler flags relating to MISRA.
+  toolchain_cc_warning_error_misra_sane(CC_MISRA_SANE_FLAG)
+  toolchain_cc_cpp_warning_error_misra_sane(CPP_MISRA_SANE_FLAG)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:${CC_MISRA_SANE_FLAG}>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:${CPP_MISRA_SANE_FLAG}>)
 endif()
 
 # @Intent: Set compiler specific flags for standard C includes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,7 @@ if(CONFIG_LIB_CPLUSPLUS)
   toolchain_ld_cpp()
 endif()
 
-# @Intent Add the basic toolchain warning flags
+# @Intent: Add the basic toolchain warning flags
 toolchain_cc_warning_base()
 
 # ==========================================================================
@@ -240,7 +240,7 @@ toolchain_cc_warning_base()
 # W=2 - warnings that occur quite often but may still be relevant
 # W=3 - the more obscure warnings, can most likely be ignored
 # ==========================================================================
-# @Intent Add cmake -DW toolchain supported warnings, if any
+# @Intent: Add cmake -DW toolchain supported warnings, if any
 if(W MATCHES "1")
   toolchain_cc_warning_dw_1()
 endif()
@@ -253,7 +253,7 @@ if(W MATCHES "3")
   toolchain_cc_warning_dw_3()
 endif()
 
-# @Intent Add extended, more specific, toolchain warning flags
+# @Intent: Add extended, more specific, toolchain warning flags
 toolchain_cc_warning_extended()
 
 # Allow the user to inject options when calling cmake, e.g.

--- a/cmake/compiler/clang/target_warnings.cmake
+++ b/cmake/compiler/clang/target_warnings.cmake
@@ -95,6 +95,13 @@ macro(toolchain_cc_warning_extended)
 
 endmacro()
 
+macro(toolchain_cc_warning_error_implicit_int)
+
+  # Force an error when things like SYS_INIT(foo, ...) occur with a missing header
+  zephyr_cc_option(-Werror=implicit-int)
+
+endmacro()
+
 #
 # The following macros leaves it up to the root CMakeLists.txt to choose
 #  the variables in which to put the requested flags, and whether or not

--- a/cmake/compiler/clang/target_warnings.cmake
+++ b/cmake/compiler/clang/target_warnings.cmake
@@ -94,3 +94,17 @@ macro(toolchain_cc_warning_extended)
     )
 
 endmacro()
+
+#
+# The following macros leaves it up to the root CMakeLists.txt to choose
+#  the variables in which to put the requested flags, and whether or not
+#  to call the macros
+#
+
+macro(toolchain_cc_warning_error_misra_sane dest_var_name)
+  set_ifndef(${dest_var_name} "-Werror=vla")
+endmacro()
+
+macro(toolchain_cc_cpp_warning_error_misra_sane dest_var_name)
+  set_ifndef(${dest_var_name} "-Werror=vla")
+endmacro()

--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -80,3 +80,17 @@ macro(toolchain_cc_warning_extended)
     )
 
 endmacro()
+
+#
+# The following macros leaves it up to the root CMakeLists.txt to choose
+#  the variables in which to put the requested flags, and whether or not
+#  to call the macros
+#
+
+macro(toolchain_cc_warning_error_misra_sane dest_var_name)
+  set_ifndef(${dest_var_name} "-Werror=vla")
+endmacro()
+
+macro(toolchain_cc_cpp_warning_error_misra_sane dest_var_name)
+  set_ifndef(${dest_var_name} "-Werror=vla")
+endmacro()

--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -81,6 +81,13 @@ macro(toolchain_cc_warning_extended)
 
 endmacro()
 
+macro(toolchain_cc_warning_error_implicit_int)
+
+  # Force an error when things like SYS_INIT(foo, ...) occur with a missing header
+  zephyr_cc_option(-Werror=implicit-int)
+
+endmacro()
+
 #
 # The following macros leaves it up to the root CMakeLists.txt to choose
 #  the variables in which to put the requested flags, and whether or not


### PR DESCRIPTION
The intent here is to abstract Zephyr's dependence on toolchains,
thus allowing for easier porting to other, perhaps commercial, toolchains
and/or usecases.

No functional change expected.

----

Part of #16031