### PR TITLE
Handle SYS_CLOCK_TICKS_PER_SEC != 100 in tests

### DIFF
--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -19,29 +19,53 @@ BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
 #define BUSY_MS (SLICE_SIZE + 20)
 /* a half timeslice*/
 #define HALF_SLICE_SIZE (SLICE_SIZE >> 1)
+#define HALF_SLICE_SIZE_CYCLES \
+	((u64_t)(HALF_SLICE_SIZE) * sys_clock_hw_cycles_per_sec() / 1000)
 
 K_SEM_DEFINE(sema, 0, NUM_THREAD);
 /*elapsed_slice taken by last thread*/
-static s64_t elapsed_slice;
+static u32_t elapsed_slice;
 static int thread_idx;
+
+static u32_t cycles_delta(u32_t *reftime)
+{
+	u32_t now, delta;
+
+	now = k_cycle_get_32();
+	delta = now - *reftime;
+	*reftime = now;
+
+	return delta;
+}
 
 static void thread_tslice(void *p1, void *p2, void *p3)
 {
-	s64_t t = k_uptime_delta(&elapsed_slice);
-	s64_t expected_slice_min, expected_slice_max;
+	u32_t t = cycles_delta(&elapsed_slice);
+	u32_t expected_slice_min, expected_slice_max;
 
 	if (thread_idx == 0) {
-		/*thread number 0 releases CPU after HALF_SLICE_SIZE*/
-		expected_slice_min = HALF_SLICE_SIZE;
-		expected_slice_max = HALF_SLICE_SIZE;
+		/*
+		 * Thread number 0 releases CPU after HALF_SLICE_SIZE,
+		 * and we expect that task switch will not take more than 1 ms.
+		 */
+		expected_slice_min = (u64_t)(HALF_SLICE_SIZE - 1) *
+				     sys_clock_hw_cycles_per_sec() / 1000;
+		expected_slice_max = (u64_t)(HALF_SLICE_SIZE + 1) *
+				     sys_clock_hw_cycles_per_sec() / 1000;
 	} else {
-		/*other threads are sliced with tick granulity*/
-		expected_slice_min = __ticks_to_ms(z_ms_to_ticks(SLICE_SIZE));
-		expected_slice_max = __ticks_to_ms(z_ms_to_ticks(SLICE_SIZE)+1);
+		/*
+		 * Other threads are sliced with tick granulity. Here, we
+		 * also expecting task switch time below 1 ms.
+		 */
+		expected_slice_min = (z_ms_to_ticks(SLICE_SIZE) - 1) *
+				     sys_clock_hw_cycles_per_tick();
+		expected_slice_max = (z_ms_to_ticks(SLICE_SIZE) *
+				     sys_clock_hw_cycles_per_tick()) +
+				     (sys_clock_hw_cycles_per_sec() / 1000);
 	}
 
 	#ifdef CONFIG_DEBUG
-	TC_PRINT("thread[%d] elapsed slice: %lld, expected: <%lld, %lld>\n",
+	TC_PRINT("thread[%d] elapsed slice: %d, expected: <%d, %d>\n",
 		thread_idx, t, expected_slice_min, expected_slice_max);
 	#endif
 
@@ -66,8 +90,8 @@ static void thread_tslice(void *p1, void *p2, void *p3)
  * priorities and few with same priorities and enable the time slice.
  * Ensure that each thread is given the time slice period to execute.
  *
- * @see k_sched_time_slice_set(), k_sem_reset(), k_uptime_delta(),
- * k_uptime_get_32()
+ * @see k_sched_time_slice_set(), k_sem_reset(), k_cycle_get_32(),
+ *      k_uptime_get_32()
  *
  * @ingroup kernel_sched_tests
  */
@@ -94,11 +118,23 @@ void test_slice_reset(void)
 		}
 		/* enable time slice*/
 		k_sched_time_slice_set(SLICE_SIZE, K_PRIO_PREEMPT(0));
-		k_uptime_delta(&elapsed_slice);
+
+		/*synchronize to tick boundary*/
+		t32 = k_uptime_get_32();
+		while (k_uptime_get_32() == t32) {
+#if defined(CONFIG_ARCH_POSIX)
+			k_busy_wait(50);
+#else
+			;
+#endif
+		}
+
+		/*set reference time*/
+		cycles_delta(&elapsed_slice);
 
 		/* current thread (ztest native) consumed a half timeslice*/
-		t32 = k_uptime_get_32();
-		while (k_uptime_get_32() - t32 < HALF_SLICE_SIZE) {
+		t32 = k_cycle_get_32();
+		while (k_cycle_get_32() - t32 < HALF_SLICE_SIZE_CYCLES) {
 #if defined(CONFIG_ARCH_POSIX)
 			k_busy_wait(50);
 #else

--- a/tests/kernel/tickless/tickless_concept/src/main.c
+++ b/tests/kernel/tickless/tickless_concept/src/main.c
@@ -23,9 +23,16 @@ static struct k_thread tdata[NUM_THREAD];
 
 /*slice size is set as half of the sleep duration*/
 #define SLICE_SIZE	 __ticks_to_ms(CONFIG_TICKLESS_IDLE_THRESH >> 1)
+#define SLICE_SIZE_CYCLES \
+	(u32_t)(SLICE_SIZE * sys_clock_hw_cycles_per_sec() / 1000)
 
-/*maximum slice duration accepted by the test*/
-#define SLICE_SIZE_LIMIT __ticks_to_ms((CONFIG_TICKLESS_IDLE_THRESH >> 1) + 1)
+/*mimimum slice duration accepted by the test: (SLICE_SIZE - 1ms) */
+#define SLICE_SIZE_MIN_CYCLES \
+	(u32_t)(SLICE_SIZE_CYCLES - (sys_clock_hw_cycles_per_sec() / 1000))
+
+/*maximum slice duration accepted by the test: (SLICE_SIZE + 1ms) */
+#define SLICE_SIZE_MAX_CYCLES \
+	(u32_t)(SLICE_SIZE_CYCLES + (sys_clock_hw_cycles_per_sec() / 1000))
 
 /*align to millisecond boundary*/
 #if defined(CONFIG_ARCH_POSIX)
@@ -44,19 +51,30 @@ static struct k_thread tdata[NUM_THREAD];
 	} while (0)
 #endif
 K_SEM_DEFINE(sema, 0, NUM_THREAD);
-static s64_t elapsed_slice;
+static u32_t elapsed_slice;
+
+static u32_t cycles_delta(u32_t *reftime)
+{
+	u32_t now, delta;
+
+	now = k_cycle_get_32();
+	delta = now - *reftime;
+	*reftime = now;
+
+	return delta;
+}
+
 
 static void thread_tslice(void *p1, void *p2, void *p3)
 {
-	s64_t t = k_uptime_delta(&elapsed_slice);
+	u32_t t = cycles_delta(&elapsed_slice);
 
-	TC_PRINT("elapsed slice %lld, expected: <%lld, %lld>\n",
-		t, SLICE_SIZE, SLICE_SIZE_LIMIT);
+	TC_PRINT("elapsed slice %d, expected: <%d, %d>\n",
+		t, SLICE_SIZE_MIN_CYCLES, SLICE_SIZE_MAX_CYCLES);
 
 	/**TESTPOINT: verify slicing scheduler behaves as expected*/
-	zassert_true(t >= SLICE_SIZE, NULL);
-	/*less than one tick delay*/
-	zassert_true(t <= SLICE_SIZE_LIMIT, NULL);
+	zassert_true(t >= SLICE_SIZE_MIN_CYCLES, NULL);
+	zassert_true(t <= SLICE_SIZE_MAX_CYCLES, NULL);
 
 	/*keep the current thread busy for more than one slice*/
 	k_busy_wait(1000 * SLEEP_TICKLESS);
@@ -108,13 +126,23 @@ void test_tickless_slice(void)
 	/*enable time slice*/
 	k_sched_time_slice_set(SLICE_SIZE, K_PRIO_PREEMPT(0));
 
+	/*synchronize to tick boundary*/
+	k_sleep(1);
+
 	/*create delayed threads with equal preemptive priority*/
 	for (int i = 0; i < NUM_THREAD; i++) {
 		tid[i] = k_thread_create(&tdata[i], tstack[i], STACK_SIZE,
 					 thread_tslice, NULL, NULL, NULL,
-					 K_PRIO_PREEMPT(0), 0, SLICE_SIZE);
+					 K_PRIO_PREEMPT(0), 0,
+					 SLICE_SIZE + __ticks_to_ms(1));
 	}
-	k_uptime_delta(&elapsed_slice);
+
+	/*synchronize to tick boundary.*/
+	k_sleep(1);
+
+	/*set reference time to last tick boundary*/
+	elapsed_slice = z_tick_get_32() * sys_clock_hw_cycles_per_tick();
+
 	/*relinquish CPU and wait for each thread to complete*/
 	for (int i = 0; i < NUM_THREAD; i++) {
 		k_sem_take(&sema, K_FOREVER);


### PR DESCRIPTION
This PR updates tests to properly handle the SYS_CLOCK_TICKS_PER_SEC != 100 by taking under account effect of tick granularity in tested API. Also, as the measurement become more precise, the timing requirements were tightened.

Details are available in code and description of the commits.

Fixes: #15983
Introduces workaround for #16195
