### PR TITLE
Bluetooth: controller: Enable use of proprietary rx demuxing functions

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -750,4 +750,19 @@ config BT_MAYFLY_YIELD_AFTER_CALL
 	  If set to 'n', all pending mayflies for callee are executed before
 	  yielding
 
+config BT_CTLR_USER_EXT
+	prompt "Enable proprietary extensions in Controller"
+	bool
+	help
+	  Catch-all for enabling proprietary event types in Controller behavior.
+
+config BT_CTLR_USER_EVT_RANGE
+	int "Range of event contants reserved for proprietary event types"
+	depends on BT_CTLR_USER_EXT
+	default 5
+	range 0 10
+	help
+	  Number of event types reserved for proprietary use. The range
+	  is typically used when BT_CTLR_USER_EXT is in use.
+
 endif # BT_CTLR

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -173,8 +173,15 @@ enum node_rx_type {
 	NODE_RX_TYPE_MESH_ADV_CPLT = 0x13,
 	NODE_RX_TYPE_MESH_REPORT = 0x14,
 #endif /* CONFIG_BT_HCI_MESH_EXT */
-};
 
+/* Following proprietary defines must be at end of enum range */
+#if defined(CONFIG_BT_CTLR_USER_EXT)
+	NODE_RX_TYPE_USER_START = 0x15,
+	NODE_RX_TYPE_USER_END = NODE_RX_TYPE_USER_START +
+				CONFIG_BT_CTLR_USER_EVT_RANGE,
+#endif /* CONFIG_BT_CTLR_USER_EXT */
+
+};
 
 /* Footer of node_rx_hdr */
 struct node_rx_ftr {
@@ -208,6 +215,13 @@ struct node_rx_pdu {
 enum {
 	EVENT_DONE_EXTRA_TYPE_NONE,
 	EVENT_DONE_EXTRA_TYPE_CONN,
+/* Following proprietary defines must be at end of enum range */
+#if defined(CONFIG_BT_CTLR_USER_EXT)
+	EVENT_DONE_EXTRA_TYPE_USER_START,
+	EVENT_DONE_EXTRA_TYPE_USER_END = EVENT_DONE_EXTRA_TYPE_USER_START +
+		CONFIG_BT_CTLR_USER_EVT_RANGE,
+#endif /* CONFIG_BT_CTLR_USER_EXT */
+
 };
 
 struct event_done_extra_slave {


### PR DESCRIPTION
Code refactored to allow calling of a proprietary rx demux function.
This will enable implementation of proprietary protocols and
functionality that is not yet public, while keeping a common zephyr
code base.

Signed-off-by: Asger Munk Nielsen asmk@oticon.com