### PR TITLE
DTS: Generate USB maximum speed enum defines.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -223,6 +223,7 @@
 /include/drivers/serial/uart_ns16550.h    @gnuless
 /include/dt-bindings/clock/kinetis_scg.h  @henrikbrixandersen
 /include/dt-bindings/pcie/                @gnuless
+/include/dt-bindings/usb/usb.h            @galak @finikorg
 /include/fs.h                             @nashif @wentongwu
 /include/fs/                              @nashif @wentongwu
 /include/hwinfo.h                         @alexanderwachter

--- a/dts/bindings/usb/usb.yaml
+++ b/dts/bindings/usb/usb.yaml
@@ -26,6 +26,11 @@ properties:
                    via DT, USB controllers should use their maximum
                    hardware capability.
       generation: define
+      enum:
+         - "low-speed"
+         - "full-speed"
+         - "high-speed"
+         - "super-speed"
 
     label:
       type: string

--- a/include/dt-bindings/usb/usb.h
+++ b/include/dt-bindings/usb/usb.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_USB_USB_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_USB_USB_H_
+
+/* Ideally we'd generate this enum to match what's coming out of the YAML,
+ * however, we dont have a good way to know how to name such an enum from
+ * the generation point of view, so for now we just hand code the enum.  This
+ * enum is expected to match the order in the yaml (dts/bindings/usb/usb.yaml)
+ */
+
+enum dt_usb_maximum_speed {
+	DT_USB_MAXIMUM_SPEED_LOW_SPEED,
+	DT_USB_MAXIMUM_SPEED_FULL_SPEED,
+	DT_USB_MAXIMUM_SPEED_HIGH_SPEED,
+	DT_USB_MAXIMUM_SPEED_SUPER_SPEED,
+};
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_USB_USB_H_ */

--- a/scripts/dts/extract/default.py
+++ b/scripts/dts/extract/default.py
@@ -11,6 +11,21 @@ from extract.directive import DTDirective
 # @brief Manage directives in a default way.
 #
 class DTDefault(DTDirective):
+    def _extract_enum(self, node_path, prop, prop_values, label):
+        cell_yaml = get_binding(node_path)['properties'][prop]
+        if 'enum' in cell_yaml:
+            if prop_values in cell_yaml['enum']:
+                if isinstance(cell_yaml['enum'], list):
+                   value = cell_yaml['enum'].index(prop_values)
+                if isinstance(cell_yaml['enum'], dict):
+                   value = cell_yaml['enum'][prop_values]
+                label = label + "_ENUM"
+                return {label:value}
+            else:
+                print("ERROR")
+        return {}
+
+
     ##
     # @brief Extract directives in a default way
     #
@@ -49,6 +64,9 @@ class DTDefault(DTDirective):
             if prop_values == 'parent-label':
                 prop_values = find_parent_prop(node_path, 'label')
 
+            prop_def = self._extract_enum(node_path, prop, prop_values, label)
+            if prop_def:
+                add_compat_alias(node_path, prop_name + "_ENUM" , label + "_ENUM", prop_alias)
             if isinstance(prop_values, str):
                 prop_values = "\"" + prop_values + "\""
             prop_def[label] = prop_values


### PR DESCRIPTION
This is meant to superseded the DT change in:

https://github.com/zephyrproject-rtos/zephyr/pull/15249

It still requires that the USB code update to use this enum.
