### PR TITLE
drivers: counter: mcux_rtc: allow setting a new alarm from the callback

### DIFF
--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -181,13 +181,17 @@ static void mcux_rtc_isr(void *arg)
 	const struct mcux_rtc_config *config =
 		CONTAINER_OF(info, struct mcux_rtc_config, info);
 	struct mcux_rtc_data *data = dev->driver_data;
+	counter_alarm_callback_t cb;
 	u32_t current = mcux_rtc_read(dev);
+
 
 	LOG_DBG("Current time is %d ticks", current);
 
 	if ((RTC_GetStatusFlags(config->base) & RTC_SR_TAF_MASK) &&
 	    (data->alarm_callback)) {
-		data->alarm_callback(dev, 0, current, data->alarm_user_data);
+		cb = data->alarm_callback;
+		data->alarm_callback = NULL;
+		cb(dev, 0, current, data->alarm_user_data);
 	}
 
 	if ((RTC_GetStatusFlags(config->base) & RTC_SR_TOF_MASK) &&


### PR DESCRIPTION
Allow setting a new alarm from the callback context of the just expired alarm.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>