### PR TITLE
x86: Make .rodata readonly

### DIFF
--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -88,7 +88,7 @@ function(add_bin_file_to_the_next_link target_dependency bin)
     -I binary
     -B ${OUTPUT_ARCH}
     -O ${OUTPUT_FORMAT}
-    --rename-section .data=${bin}
+    --rename-section .data=${bin},CONTENTS,ALLOC,LOAD,READONLY,DATA
     ${bin}.bin
     ${bin}.o
     DEPENDS ${target_dependency} ${bin}.bin


### PR DESCRIPTION
During the conversion of .bin to .o objcopy was not setting the
section to be readonly causing the .rodata in the final image has
write permission.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>