### PR TITLE
drivers: i2c: sam0: Fix missing break in speed setup

### DIFF
--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -616,6 +616,7 @@ static int i2c_sam0_set_apply_bitrate(struct device *dev, u32_t config)
 #else
 		return -ENOTSUP;
 #endif
+		break;
 
 	default:
 		return -ENOTSUP;


### PR DESCRIPTION
There was a missing break at the end of the high speed setup case, so it would always return `-ENOTSUP` even when the high speed baud was available.

This was based entirely on inspection: I don't have any hardware that actually supports this speed to test on.