### PR TITLE
env: ignore unset var

### DIFF
--- a/zephyr-env.sh
+++ b/zephyr-env.sh
@@ -12,7 +12,7 @@
 #
 # Note: The version of zsh need to be 5.0.6 or above. Any versions below
 # 5.0.6 maybe encoutner errors when sourcing this script.
-if [ -n "$ZSH_VERSION" ]; then
+if [ -n "${ZSH_VERSION:-}" ]; then
 	DIR="${(%):-%N}"
 	if [ $options[posixargzero] != "on" ]; then
 		setopt posixargzero


### PR DESCRIPTION
Ignore the ZSH_VERSION variable is unset or null when substituted.

This commit fixes #16227.
See https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion and https://ss64.com/bash/set.html for more details on this patch.