### PR TITLE
drivers: counter: Add flags to counter_config_info structure

### DIFF
--- a/drivers/counter/counter_imx_epit.c
+++ b/drivers/counter/counter_imx_epit.c
@@ -156,7 +156,7 @@ static const struct imx_epit_config imx_epit_##idx##z_config = {		       \
 	.info = {							       \
 			.max_top_value = COUNTER_MAX_RELOAD,		       \
 			.freq = 1U,					       \
-			.count_up = false,				       \
+			.flags = 0,					       \
 			.channels = 0U,					       \
 		},							       \
 	.base = (EPIT_Type *)DT_COUNTER_IMX_EPIT_##idx##_BASE_ADDRESS,	       \

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -324,7 +324,7 @@ static const struct rtc_stm32_config rtc_config = {
 	.counter_info = {
 		.max_top_value = UINT32_MAX,
 		.freq = 1,
-		.count_up = true,
+		.flags = COUNTER_CONFIG_INFO_COUNT_UP,
 		.channels = 1,
 	},
 	.pclken = {

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -254,7 +254,7 @@ static struct mcux_rtc_config mcux_rtc_config_0 = {
 		.max_top_value = UINT32_MAX,
 		.freq = DT_NXP_KINETIS_RTC_0_CLOCK_FREQUENCY /
 				DT_NXP_KINETIS_RTC_0_PRESCALER,
-		.count_up = true,
+		.flags = COUNTER_CONFIG_INFO_COUNT_UP,
 		.channels = 1,
 	},
 };

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -344,7 +344,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 			.max_top_value = COUNTER_MAX_TOP_VALUE,		       \
 			.freq = DT_NORDIC_NRF_RTC_RTC_##idx##_CLOCK_FREQUENCY /\
 				(DT_NORDIC_NRF_RTC_RTC_##idx##_PRESCALER),     \
-			.count_up = true,				       \
+			.flags = COUNTER_CONFIG_INFO_COUNT_UP,		       \
 			.channels = CC_TO_ID(RTC##idx##_CC_NUM)		       \
 		},							       \
 		.ch_data = counter##idx##_ch_data,			       \

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -281,7 +281,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 					0xffffffff : 0x0000ffff,	       \
 			.freq = TIMER_CLOCK /				       \
 			   (1 << DT_NORDIC_NRF_TIMER_TIMER_##idx##_PRESCALER), \
-			.count_up = true,				       \
+			.flags = COUNTER_CONFIG_INFO_COUNT_UP,		       \
 			.channels = CC_TO_ID(TIMER##idx##_CC_NUM),	       \
 		},							       \
 		.ch_data = counter##idx##_ch_data,			       \

--- a/drivers/counter/counter_qmsi_aonpt.c
+++ b/drivers/counter/counter_qmsi_aonpt.c
@@ -247,7 +247,7 @@ static const struct aonpt_config aonpt_conf_info = {
 	.info = {
 		.max_top_value = UINT32_MAX,
 		.freq = 32768,
-		.count_up = false,
+		.flags = 0,
 		.channels = 0,
 	}
 };

--- a/drivers/counter/counter_rtc_qmsi.c
+++ b/drivers/counter/counter_rtc_qmsi.c
@@ -243,7 +243,7 @@ static const struct rtc_config  rtc_conf_info = {
 	.info = {
 		.max_top_value = UINT32_MAX,
 		.freq = 32768,
-		.count_up = true,
+		.flags = COUNTER_CONFIG_INFO_COUNT_UP,
 		.channels = 1,
 	}
 };

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -162,7 +162,7 @@ static const struct dtmr_cmsdk_apb_cfg dtmr_cmsdk_apb_cfg_0 = {
 	.info = {
 			.max_top_value = UINT32_MAX,
 			.freq = 24000000U,
-			.count_up = false,
+			.flags = 0,
 			.channels = 0U,
 	},
 	.dtimer = ((volatile struct dualtimer_cmsdk_apb *)DT_ARM_CMSDK_DTIMER_0_BASE_ADDRESS),

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -164,7 +164,7 @@ static const struct tmr_cmsdk_apb_cfg tmr_cmsdk_apb_cfg_0 = {
 	.info = {
 			.max_top_value = UINT32_MAX,
 			.freq = 24000000U,
-			.count_up = false,
+			.flags = 0,
 			.channels = 0U,
 	},
 	.timer = ((volatile struct timer_cmsdk_apb *)DT_ARM_CMSDK_TIMER_0_BASE_ADDRESS),
@@ -205,7 +205,7 @@ static const struct tmr_cmsdk_apb_cfg tmr_cmsdk_apb_cfg_1 = {
 	.info = {
 			.max_top_value = UINT32_MAX,
 			.freq = 24000000U,
-			.count_up = false,
+			.flags = 0,
 			.channels = 0U,
 	},
 	.timer = ((volatile struct timer_cmsdk_apb *)DT_ARM_CMSDK_TIMER_1_BASE_ADDRESS),

--- a/include/counter.h
+++ b/include/counter.h
@@ -29,6 +29,16 @@
 extern "C" {
 #endif
 
+/**@defgroup COUNTER_FLAGS Counter device capabilities
+ * @{ */
+
+/**
+ * @brief Counter count up flag.
+ */
+#define COUNTER_CONFIG_INFO_COUNT_UP BIT(0)
+
+/**@} */
+
 /** @brief Alarm callback
  *
  * @param dev       Pointer to the device structure for the driver instance.
@@ -76,15 +86,14 @@ typedef void (*counter_top_callback_t)(struct device *dev, void *user_data);
  *			(cleared or reloaded).
  * @param freq		Frequency of the source clock if synchronous events are
  *			counted.
- * @param count_up	Flag indicating direction of the counter. If true
- *			counter is counting up else counting down.
+ * @param flags		Flags. See @ref COUNTER_FLAGS.
  * @param channels	Number of channels that can be used for setting alarm,
  *			see @ref counter_set_alarm.
  */
 struct counter_config_info {
 	u32_t max_top_value;
 	u32_t freq;
-	bool count_up;
+	u8_t flags;
 	u8_t channels;
 };
 
@@ -129,7 +138,7 @@ static inline bool counter_is_counting_up(const struct device *dev)
 	const struct counter_config_info *config =
 			(struct counter_config_info *)dev->config->config_info;
 
-	return config->count_up;
+	return config->flags & COUNTER_CONFIG_INFO_COUNT_UP;
 }
 
 /**


### PR DESCRIPTION
Allow further extention of counter API by replacing count_up bool in
the structure with u8_t flags where one bit is used for count up
feature.

Change is not breaking API as count up property is read using
counter_is_counting_up() that didn't change.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>