### PR TITLE
doc: kconfig: Fix accidental SPDX-License-Identifier in generated doc

### DIFF
--- a/doc/guides/kconfig/index.rst
+++ b/doc/guides/kconfig/index.rst
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+.. SPDX-License-Identifier: Apache-2.0
 
 .. _kconfig_tips_and_tricks:
 


### PR DESCRIPTION
RST uses '..' for comments, not '#'. The license line currently shows up
on https://docs.zephyrproject.org/latest/guides/kconfig/index.html