### PR TITLE
drivers: i2c: i2c_esp32: fix configuring speed

### DIFF
--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -139,14 +139,15 @@ static int i2c_esp32_configure_speed(const struct i2c_esp32_config *config,
 		return -ENOTSUP;
 	}
 
-	period = (APB_CLK_FREQ / freq_hz) / 2U;
+	period = (APB_CLK_FREQ / freq_hz);
+
+	period /= 2U; /* Set hold and setup times to 1/2th of period */
 
 	esp32_set_mask32(period << I2C_SCL_LOW_PERIOD_S,
 		   I2C_SCL_LOW_PERIOD_REG(config->index));
 	esp32_set_mask32(period << I2C_SCL_HIGH_PERIOD_S,
 		   I2C_SCL_HIGH_PERIOD_REG(config->index));
 
-	period /= 2U; /* Set hold and setup times to 1/2th of period */
 	esp32_set_mask32(period << I2C_SCL_START_HOLD_TIME_S,
 		   I2C_SCL_START_HOLD_REG(config->index));
 	esp32_set_mask32(period << I2C_SCL_RSTART_SETUP_TIME_S,


### PR DESCRIPTION
the driver was actually using 1/4th instead of 1/2th and
1/8th instead of 1/4th periods.

I didn't test this yet but I saw the issue, and found this bug.
This should fix the i2c part of #5934 