### PR TITLE
net: lwm2m: Remove IPSO objects maximum number of instances limitation

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig.ipso
+++ b/subsys/net/lib/lwm2m/Kconfig.ipso
@@ -23,7 +23,6 @@ config LWM2M_IPSO_TEMP_SENSOR_INSTANCE_COUNT
 	int "Maximum # of IPSO Temperature Sensor object instances"
 	default 1
 	depends on LWM2M_IPSO_TEMP_SENSOR
-	range 1 20
 	help
 	  This setting establishes the total count of IPSO Temperature
 	  Sensor instances available to the LWM2M client.
@@ -40,7 +39,6 @@ config LWM2M_IPSO_LIGHT_CONTROL_INSTANCE_COUNT
 	int "Maximum # of IPSO Light Control object instances"
 	default 1
 	depends on LWM2M_IPSO_LIGHT_CONTROL
-	range 1 20
 	help
 	  This setting establishes the total count of IPSO Light Control
 	  instances available to the LWM2M client.
@@ -54,7 +52,6 @@ config LWM2M_IPSO_TIMER_INSTANCE_COUNT
 	int "Maximum # of IPSO Timer object instances"
 	default 1
 	depends on LWM2M_IPSO_TIMER
-	range 1 20
 	help
 	  This setting establishes the total count of IPSO Timer
 	  instances available to the LWM2M client.


### PR DESCRIPTION
Fixes #16156.

There was a limit (20) on the limit of IPSO objects instances. This commit removes that first constraint from kconfig

Signed-off-by: lodup29 <dupont.louis@ireq.ca>