### PR TITLE
drivers: adxl362: fix sample conversion

### DIFF
--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -161,6 +161,11 @@
 #define ADXL362_STATUS_CHECK_INACT(x)		(((x) >> 5) & 0x1)
 #define ADXL362_STATUS_CHECK_ACTIVITY(x)	(((x) >> 4) & 0x1)
 
+/* ADXL362 scale factors from specifications */
+#define ADXL362_ACCEL_2G_LSB_PER_G	1000
+#define ADXL362_ACCEL_4G_LSB_PER_G	500
+#define ADXL362_ACCEL_8G_LSB_PER_G	235
+
 struct adxl362_config {
 	char *spi_name;
 	u32_t spi_max_frequency;
@@ -183,9 +188,9 @@ struct adxl362_data {
 #if defined(DT_ADI_ADXL362_0_CS_GPIO_CONTROLLER)
 	struct spi_cs_control adxl362_cs_ctrl;
 #endif
-	s32_t acc_x;
-	s32_t acc_y;
-	s32_t acc_z;
+	s16_t acc_x;
+	s16_t acc_y;
+	s16_t acc_z;
 	s32_t temp;
 	u8_t selected_range;
 

--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -166,6 +166,10 @@
 #define ADXL362_ACCEL_4G_LSB_PER_G	500
 #define ADXL362_ACCEL_8G_LSB_PER_G	235
 
+/* ADXL362 temperature sensor specifications */
+#define ADXL362_TEMP_MC_PER_LSB 65
+#define ADXL362_TEMP_BIAS_LSB 350
+
 struct adxl362_config {
 	char *spi_name;
 	u32_t spi_max_frequency;
@@ -191,7 +195,7 @@ struct adxl362_data {
 	s16_t acc_x;
 	s16_t acc_y;
 	s16_t acc_z;
-	s32_t temp;
+	s16_t temp;
 	u8_t selected_range;
 
 #if defined(CONFIG_ADXL362_TRIGGER)


### PR DESCRIPTION
This driver uses magic numbers which are incorrect. A correct conversion for acceleration values is done using the LSB/g scale factors given by Table 1 in the specifications section of the ADXL362 (Rev. F) datasheet. The entire conversion has also been consolidated into a signal function.

The sensitivity and offset of the accelerometer values actually vary with the supply voltage and temperature. Using datasheet provided values for 25 C and 2.0 V is the best we can do. Users will need to apply sensitivity and offset corrections for their application.

The temperature conversion has also been consolidated into a signal function, magic numbers replaced with descriptive macros, and bias removed.