### PR TITLE
Fix -Wundef warnings

### DIFF
--- a/arch/arc/core/isr_wrapper.S
+++ b/arch/arc/core/isr_wrapper.S
@@ -227,7 +227,7 @@ From RIRQ:
  */
 
 SECTION_FUNC(TEXT, _isr_wrapper)
-#if CONFIG_ARC_FIRQ
+#if defined(CONFIG_ARC_FIRQ)
 #if CONFIG_RGF_NUM_BANKS == 1
 	st r0,[saved_r0]
 #endif

--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -66,7 +66,7 @@ SECTION_FUNC(TEXT,__start)
 
 	/* \todo: MPU init, gp for small data? */
 
-#if CONFIG_USERSPACE
+#if defined(CONFIG_USERSPACE)
 	lr r0, [_ARC_V2_STATUS32]
 	bset r0, r0, _ARC_V2_STATUS32_US_BIT
 	kflag r0

--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -74,7 +74,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	char *stackAdjEnd;
 	struct init_stack_frame *pInitCtx;
 
-#if CONFIG_USERSPACE
+#ifdef CONFIG_USERSPACE
 
 	size_t stackAdjSize;
 	size_t offset = 0;

--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -87,7 +87,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #endif
 	stackEnd = pStackMem + stackAdjSize;
 
-#if CONFIG_STACK_POINTER_RANDOM
+#ifdef CONFIG_STACK_POINTER_RANDOM
 	offset = stackAdjSize - stackSize;
 #endif
 

--- a/arch/arm/core/irq_manage.c
+++ b/arch/arm/core/irq_manage.c
@@ -88,7 +88,7 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags)
 	 * of priority levels reserved by the kernel.
 	 */
 
-#if CONFIG_ZERO_LATENCY_IRQS
+#if defined(CONFIG_ZERO_LATENCY_IRQS)
 	/* If we have zero latency interrupts, those interrupts will
 	 * run at a priority level which is not masked by irq_lock().
 	 * Our policy is to express priority levels with special properties

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -349,7 +349,7 @@ SECTION_FUNC(TEXT, __svc)
     * expand this case.
     */
     ands r1, #0xff
-#if CONFIG_USERSPACE
+#if defined(CONFIG_USERSPACE)
     mrs r2, CONTROL
 
     cmp r1, #3
@@ -381,7 +381,7 @@ _oops:
     bl z_do_kernel_oops
     pop {r0, pc}
 
-#if CONFIG_USERSPACE
+#if defined(CONFIG_USERSPACE)
     /*
      * System call will setup a jump to the _do_arm_syscall function
      * when the SVC returns via the bx lr.

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -301,7 +301,7 @@ _stack_frame_endif:
     cmp r1, #2
     beq _oops
 
-#if CONFIG_IRQ_OFFLOAD
+#if defined(CONFIG_IRQ_OFFLOAD)
     push {r0, lr}
     bl z_irq_do_offload  /* call C routine which executes the offload */
     pop {r0, r1}
@@ -367,7 +367,7 @@ SECTION_FUNC(TEXT, __svc)
     cmp r1, #2
     beq _oops
 
-#if CONFIG_IRQ_OFFLOAD
+#if defined(CONFIG_IRQ_OFFLOAD)
     push {r0, lr}
     bl z_irq_do_offload  /* call C routine which executes the offload */
     pop {r0, lr}

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -85,7 +85,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #endif /* CONFIG_THREAD_USERSPACE_LOCAL_DATA */
 #endif /* CONFIG_USERSPACE */
 
-#if CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT && CONFIG_USERSPACE
+#if CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT && defined(CONFIG_USERSPACE)
 	/* This is required to work-around the case where the thread
 	 * is created without using K_THREAD_STACK_SIZEOF() macro in
 	 * k_thread_create(). If K_THREAD_STACK_SIZEOF() is used, the
@@ -104,7 +104,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	pInitCtx = (struct __esf *)(STACK_ROUND_DOWN(stackEnd -
 		(char *)top_of_stack_offset - sizeof(struct __esf)));
 
-#if CONFIG_USERSPACE
+#if defined(CONFIG_USERSPACE)
 	if ((options & K_USER) != 0) {
 		pInitCtx->basic.pc = (u32_t)z_arch_user_mode_enter;
 	} else {
@@ -130,7 +130,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	thread->callee_saved.psp = (u32_t)pInitCtx;
 	thread->arch.basepri = 0;
 
-#if CONFIG_USERSPACE
+#if defined(CONFIG_USERSPACE)
 	thread->arch.mode = 0;
 	thread->arch.priv_stack_start = 0;
 #endif

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -85,7 +85,8 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #endif /* CONFIG_THREAD_USERSPACE_LOCAL_DATA */
 #endif /* CONFIG_USERSPACE */
 
-#if CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT && defined(CONFIG_USERSPACE)
+#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT) \
+	&& defined(CONFIG_USERSPACE)
 	/* This is required to work-around the case where the thread
 	 * is created without using K_THREAD_STACK_SIZEOF() macro in
 	 * k_thread_create(). If K_THREAD_STACK_SIZEOF() is used, the


### PR DESCRIPTION
This PR fixes several checks of kconfig options in the arc and arm archs.  These checks were using #if on possible undefined config options.  Change these to #if defined() instead.