### PR TITLE
drivers: counter: Extend set channel alarm flags (late-to-set)

### DIFF
--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -172,7 +172,7 @@ static int counter_gecko_set_alarm(struct device *dev, u8_t chan_id,
 		return -EBUSY;
 	}
 
-	if (alarm_cfg->absolute) {
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) != 0) {
 		ccv = alarm_cfg->ticks;
 	} else {
 		if (top_value == 0) {

--- a/drivers/counter/counter_handlers.c
+++ b/drivers/counter/counter_handlers.c
@@ -23,3 +23,16 @@ COUNTER_HANDLER(stop)
 COUNTER_HANDLER(start)
 COUNTER_HANDLER(get_top_value)
 COUNTER_HANDLER(get_max_relative_alarm)
+
+Z_SYSCALL_HANDLER(counter_get_guard_period, dev, flags)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_COUNTER(dev, get_guard_period));
+	return z_impl_counter_get_guard_period((struct device *)dev, flags);
+}
+
+Z_SYSCALL_HANDLER(counter_set_guard_period, dev, ticks, flags)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_COUNTER(dev, set_guard_period));
+	return z_impl_counter_set_guard_period((struct device *)dev, ticks,
+						flags);
+}

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -42,7 +42,6 @@ struct rtc_stm32_data {
 	counter_alarm_callback_t callback;
 	u32_t ticks;
 	void *user_data;
-	bool absolute;
 };
 
 
@@ -129,9 +128,8 @@ static int rtc_stm32_set_alarm(struct device *dev, u8_t chan_id,
 
 	data->callback = alarm_cfg->callback;
 	data->user_data = alarm_cfg->user_data;
-	data->absolute = alarm_cfg->absolute;
 
-	if (!alarm_cfg->absolute) {
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
 		ticks += now;
 	}
 

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -63,7 +63,7 @@ static int mcux_gpt_set_alarm(struct device *dev, u8_t chan_id,
 		return -EINVAL;
 	}
 
-	if (!alarm_cfg->absolute) {
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
 		ticks += current;
 	}
 

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -101,7 +101,7 @@ static int mcux_rtc_set_alarm(struct device *dev, u8_t chan_id,
 		return -EBUSY;
 	}
 
-	if (!alarm_cfg->absolute) {
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
 		ticks += current;
 	}
 

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -101,7 +101,7 @@ static int counter_nrfx_set_alarm(struct device *dev, u8_t chan_id,
 		return -EBUSY;
 	}
 
-	if (alarm_cfg->absolute) {
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) != 0) {
 		cc_val = alarm_cfg->ticks;
 	} else {
 		/* As RTC is 24 bit there is no risk of overflow. */

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -99,7 +99,7 @@ static inline u32_t counter_nrfx_get_cc_value(struct device *dev,
 	u32_t cc_val;
 	u32_t ticks = alarm_cfg->ticks;
 
-	if (alarm_cfg->absolute) {
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) != 0) {
 		return ticks;
 	}
 

--- a/drivers/counter/counter_sam0_tc32.c
+++ b/drivers/counter/counter_sam0_tc32.c
@@ -194,7 +194,7 @@ static int counter_sam0_tc32_set_alarm(struct device *dev, u8_t chan_id,
 	data->ch.callback = alarm_cfg->callback;
 	data->ch.user_data = alarm_cfg->user_data;
 
-	if (alarm_cfg->absolute) {
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) != 0) {
 		tc->CC[1].reg = alarm_cfg->ticks;
 		wait_synchronization(tc);
 		tc->INTFLAG.reg = TC_INTFLAG_MC1;

--- a/include/drivers/counter.h
+++ b/include/drivers/counter.h
@@ -61,6 +61,19 @@ extern "C" {
 
 /**@} */
 
+/**@defgroup COUNTER_ALARM_FLAGS Counter device capabilities
+ * @{ */
+
+/**
+ * @brief Counter alarm absolute value flag.
+ *
+ * Ticks relation to counter value. If set ticks are treated as absolute value,
+ * else it is relative to the counter reading performed during the call.
+ */
+#define COUNTER_ALARM_CFG_ABSOLUTE BIT(0)
+
+/**@} */
+
 /** @brief Alarm callback
  *
  * @param dev       Pointer to the device structure for the driver instance.
@@ -84,15 +97,13 @@ typedef void (*counter_alarm_callback_t)(struct device *dev,
  *		Alternatively, counter implementation may count asynchronous
  *		events.
  * @param user_data User data returned in callback.
- * @param absolute Ticks relation to counter value. If true ticks are treated as
- *		absolute value, else it is relative to the counter reading
- *		performed during the call.
+ * @param flags	Alarm flags.
  */
 struct counter_alarm_cfg {
 	counter_alarm_callback_t callback;
 	u32_t ticks;
 	void *user_data;
-	bool absolute;
+	u32_t flags;
 };
 
 /** @brief Callback called when counter turns around.

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -47,7 +47,7 @@ void main(void)
 
 	counter_start(counter_dev);
 
-	alarm_cfg.absolute = false;
+	alarm_cfg.flags = 0;
 	alarm_cfg.ticks = counter_us_to_ticks(counter_dev, DELAY);
 	alarm_cfg.callback = test_counter_interrupt_fn;
 	alarm_cfg.user_data = &alarm_cfg;

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -200,7 +200,7 @@ void test_single_shot_alarm_instance(const char *dev_name, bool set_top)
 	ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
 	top_cfg.ticks = ticks;
 
-	alarm_cfg.absolute = false;
+	alarm_cfg.flags = 0;
 	alarm_cfg.ticks = ticks;
 	alarm_cfg.callback = alarm_handler;
 	alarm_cfg.user_data = &alarm_cfg;
@@ -312,12 +312,12 @@ void test_multiple_alarms_instance(const char *dev_name)
 	ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
 	top_cfg.ticks = ticks;
 
-	alarm_cfg.absolute = true;
+	alarm_cfg.flags = COUNTER_ALARM_CFG_ABSOLUTE;
 	alarm_cfg.ticks = counter_us_to_ticks(dev, 2000);
 	alarm_cfg.callback = alarm_handler2;
 	alarm_cfg.user_data = &alarm_cfg;
 
-	alarm_cfg2.absolute = false;
+	alarm_cfg2.flags = 0;
 	alarm_cfg2.ticks = counter_us_to_ticks(dev, 2000);
 	alarm_cfg2.callback = alarm_handler2;
 	alarm_cfg2.user_data = &alarm_cfg2;
@@ -382,7 +382,7 @@ void test_all_channels_instance(const char *dev_name)
 	dev = device_get_binding(dev_name);
 	ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
 
-	alarm_cfgs.absolute = false;
+	alarm_cfgs.flags = 0;
 	alarm_cfgs.ticks = ticks;
 	alarm_cfgs.callback = alarm_handler2;
 	alarm_cfgs.user_data = NULL;


### PR DESCRIPTION
Added flags for controling detection of setting alarm to late.
Updated drivers to return -ENOTSUP when new option is requested.
