### PR TITLE
boards: frdm_k64f: button_1 has no callback when button is released

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -71,7 +71,7 @@
 		};
 		user_button_3: button_1 {
 			label = "User SW3";
-			gpios = <&gpioa 4 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 4 (GPIO_INT_ACTIVE_LOW | GPIO_PUD_PULL_UP)>;
 		};
 	};
 };


### PR DESCRIPTION
need set the internal pull-up for the button gpio.

Signed-off-by: Mark Wang <yichang.wang@nxp.com>