### PR TITLE
doc: update doc building tools (sphinx/breathe)

### DIFF
--- a/.known-issues/doc/duplicate.conf
+++ b/.known-issues/doc/duplicate.conf
@@ -1,4 +1,8 @@
 #
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]peripherals[/\\]dma.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration, dma_config
+#
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]file_system[/\\]index.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration, fs_statvfs
+#
 ^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]file_system[/\\]index.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
 #
 ^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]peripherals[/\\]dma.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.

--- a/.known-issues/doc/networking.conf
+++ b/.known-issues/doc/networking.conf
@@ -2,6 +2,12 @@
 # Networking
 #
 #
+# mqtt warnings
+#
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]networking[/\\]mqtt.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^[ \t]*mqtt_socket::MQTT_SUBACK_FAILURE = 0x80
+^[- \t]*\^
+#
 # include/net/net_ip.h warnings
 #
 ^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]networking.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
@@ -68,3 +74,5 @@
 # stray duplicate definition warnings
 #
 ^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]networking[/\\]net_if.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+#
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]reference[/\\]networking[/\\]net_if.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration, .*

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,6 +1,6 @@
 wheel==0.30.0
-breathe==4.9.1
-sphinx==1.7.5
+breathe==4.13.0
+sphinx==2.0.1
 docutils==0.14
 sphinx_rtd_theme
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
update to current versions of Sphinx (2.0.1) and Breathe (4.13.0) and update the known-issues filtering to account for error/warning reporting differences (while maintaining previous filtering rules for folks that haven't upgraded to these newer Sphinx/Breathe versions).