### PR TITLE
scripts/dts: Remove alias defines for bus parents with an alias

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -158,17 +158,6 @@ def generate_bus_defines(node_path):
                         .format(node_path, parent_path,
                                 binding['parent']['bus'], parent_bus))
 
-    # Generate alias definition if parent has any alias
-    if parent_path in aliases:
-        for i in aliases[parent_path]:
-            # Build an alias name that respects device tree specs
-            node_name = get_compat(node_path) + '-' + node_path.split('@')[-1]
-            node_strip = node_name.replace('@','-').replace(',','-')
-            node_alias = i + '-' + node_strip
-            if node_alias not in aliases[node_path]:
-                # Need to generate alias name for this node:
-                aliases[node_path].append(node_alias)
-
     # Generate *_BUS_NAME #define
     extract_bus_name(
         node_path,


### PR DESCRIPTION
We generated some alias defines for children of a bus in which we had a
path alias for the bus node.  We never used these defines, we don't
recommend they get used (child of busses should use instance defines)
and they were only generated in small handful of cases (for dts that had
path aliases to the bus node - i2c or spi).

Remove this as effectively dead code.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>