### PR TITLE
boards: intel_s1000: Image download scripts

### DIFF
--- a/boards/xtensa/intel_s1000_crb/doc/index.rst
+++ b/boards/xtensa/intel_s1000_crb/doc/index.rst
@@ -173,6 +173,26 @@ application.
 Refer to :ref:`build_an_application` and :ref:`application_run` for
 more details.
 
+Downloading binary image
+========================
+
+A Linux host connected to the SPI interface of the ``intel_s1000_crb`` board
+can download a zephyr binary to RAM and execute the image.
+
+.. code-block:: console
+
+   cd <app-dir>/build
+   sudo -E python3 \
+      $ZEPHYR_BASE/boards/xtensa/intel_s1000_crb/support/download.py \
+      zephyr/zephyr.bin
+
+The script depends on a few python modules. These dependencies can be installed
+on the Linux host using the command below.
+
+.. code-block:: console
+
+   pip3 install --user pyyaml python-periphery hashlib bitstruct
+
 Setting up UART
 ===============
 

--- a/boards/xtensa/intel_s1000_crb/support/.gitignore
+++ b/boards/xtensa/intel_s1000_crb/support/.gitignore
@@ -1,0 +1,1 @@
+config.yml

--- a/boards/xtensa/intel_s1000_crb/support/config.yml
+++ b/boards/xtensa/intel_s1000_crb/support/config.yml
@@ -1,0 +1,17 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Author: Sathish Kuttan <sathish.k.kuttan@intel.com>
+
+general:
+    name:      Sue Creek
+
+spi:
+    device:    /dev/spidev0.0
+    max_speed: 9.6     # Max SPI clock frequency 9.6 MHz
+
+gpio:
+    reset:     22      # GPIO 22 for resetting device
+    wake:      23      # GPIO 23 for wake notification to device
+    irq:       27      # GPIO 27 for interrupt notification from device

--- a/boards/xtensa/intel_s1000_crb/support/device.py
+++ b/boards/xtensa/intel_s1000_crb/support/device.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Author: Sathish Kuttan <sathish.k.kuttan@intel.com>
+
+# This file defines device class that contains functions to
+# setup/cconfigure SPI master device and GPIO pins required
+# to communicate with the target.
+# Member functions are provided to send and receive messages
+# over the SPI bus
+
+import yaml
+import time
+import periphery
+import sys
+import os
+
+class Device:
+    """
+    Device class containing the interface methods for communicating
+    with the target using SPI bus and GPIOs
+    """
+    def __init__(self):
+        """
+        Read config file and determine the SPI device, speed, mode
+        GPIO pin assignments, etc.
+        Initialize data structures accordingly.
+        """
+        config_file = os.path.dirname(__file__)
+        config_file += '/config.yml'
+        with open(config_file, 'r') as ymlfile:
+            config = yaml.safe_load(ymlfile)
+        self.name = config['general']['name']
+        self.spi_device = config['spi']['device']
+        self.spi_speed = config['spi']['max_speed']
+        self.spi_mode = None
+        self.gpio_reset = config['gpio']['reset']
+        self.gpio_wake = config['gpio']['wake']
+        self.gpio_irq = config['gpio']['irq']
+        self.spi = None
+        self.reset_pin = None
+        self.wake_pin = None
+        self.irq_pin = None
+
+    def print_config(self):
+        """
+        Print configuration information that was read from config file
+        """
+        print('%s Device on %s' %(self.name, self.spi_device))
+        print('Max SPI Frequency: %2.1f MHz' % self.spi_speed)
+        print('Reset GPIO: %d' % self.gpio_reset)
+        print('Wake GPIO : %d' % self.gpio_wake)
+        print('IRQ GPIO  : %d' % self.gpio_irq)
+
+    def configure_device(self, spi_mode, order, bits):
+        """
+        Configure the SPI device and GPIOs for communication with target
+        """
+        self.reset_pin = periphery.GPIO(self.gpio_reset, 'out')
+        self.wake_pin = periphery.GPIO(self.gpio_wake, 'out')
+        self.irq_pin = periphery.GPIO(self.gpio_irq, 'in')
+        self.spi = periphery.SPI(self.spi_device, spi_mode,
+                self.spi_speed * 1e6)
+        self.spi.bit_order = order
+        self.spi.bits_per_word = bits
+        print('Configured SPI %s for %s.' % (self.spi_device, self.name))
+        print('Configured GPIO %d for %s Reset.' % (self.gpio_reset, self.name))
+        print('Configured GPIO %d for %s Wake.' % (self.gpio_wake, self.name))
+        print('Configured GPIO %d for %s IRQ.' % (self.gpio_irq, self.name))
+
+    def check_device_ready(self):
+        """
+        Check whether the target is ready to accept a command as follows:
+        Wait a minimum time and check whether IRQ is asserted by the target
+        If IRQ is not asserted, wait maximum time and check again.
+        Device is ready if IRQ is asserted
+        """
+        min_wait = 0.001 #   1 ms
+        max_wait = 0.1 	 # 100 ms
+        time.sleep(min_wait)
+        ready = self.irq_pin.read()
+        if ready == False:
+            time.sleep(max_wait)
+            ready = self.irq_pin.read()
+            if ready == False:
+                print('Error: Device not ready', file=sys.stderr)
+        return ready
+
+    def reset_device(self):
+        """
+        Assert the GPIO and deassert after a short duration to reset
+        the target.
+        """
+        print('Resetting %s ...' % self.name)
+        self.reset_pin.write(False)
+        time.sleep(0.1)
+        self.reset_pin.write(True)
+        self.check_device_ready()
+
+    def send_receive(self, data, wait = True):
+        """
+        Transmit and receive full duplex data over SPI
+        If requested to wait, wait for device to become ready
+        before return.
+        """
+        rx_data = self.spi.transfer(data)
+        if wait == True:
+            self.check_device_ready()
+        return rx_data
+
+    def send_bulk(self, data):
+        """
+        Send a byte stream of data without checking for device readiness.
+        """
+        self.spi.transfer(data)
+
+    def close(self):
+        """
+        Close the device handle
+        """
+        self.spi.close()

--- a/boards/xtensa/intel_s1000_crb/support/download.py
+++ b/boards/xtensa/intel_s1000_crb/support/download.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Author: Sathish Kuttan <sathish.k.kuttan@intel.com>
+
+# This script is the top level script that an user can invoke to
+# download a Zephyr application binary from a Linux host connected
+# over SPI to Intel Sue Creek S1000 target during development.
+
+import os
+import sys
+import hashlib
+import device
+import messenger
+
+sue_creek = device.Device()
+msg = messenger.Message()
+
+def check_arguments():
+    """
+    Check whether file name is provided.
+    If not print usage instruction and exit.
+    """
+    if len(sys.argv) != 2:
+        print('Usage: python3 %s <zephyr.bin>' % sys.argv[0])
+        sys.exit()
+    return sys.argv[1]
+
+def calc_firmware_sha(file):
+    """
+    Open firmware image file and calculate file size
+    Pad file size to a multiple of 64 bytes
+    Caculate SHA256 hash of the padded contents
+    """
+    with open(file, 'rb') as firmware:
+       firmware.seek(0, 2)
+       size = firmware.tell()
+
+       # pad firmware to round upto 64 byte boundary
+       padding = (size % 64)
+       if padding != 0:
+           padding = (64 - padding)
+       size += padding
+
+       firmware.seek(0, 0)
+       sha256 = hashlib.sha256()
+       for block in iter(lambda: firmware.read(4096), b""):
+           sha256.update(block)
+       firmware.close()
+
+       if padding != 0:
+           sha256.update(b'\0' * padding)
+           print('Firmware (%s): %d bytes, will be padded to %d bytes.'
+                   % (os.path.basename(file), size - padding, size))
+       else:
+           print('Firmware file size: %d bytes.' % size)
+       print('SHA: ' + sha256.hexdigest())
+       return (size, padding, sha256.digest())
+
+def setup_device():
+    """
+    Configure SPI master device
+    Reset target and send initialization commands
+    """
+    sue_creek.configure_device(spi_mode = 3, order = 'msb', bits = 8)
+    sue_creek.reset_device()
+
+    command = msg.create_memwrite_cmd((0x71d14, 0, 0x71d24, 0,
+            0x304628, 0xd, 0x71fd0, 0x3))
+    response = sue_creek.send_receive(command)
+    msg.print_response(response)
+
+def load_firmware(file, size, padding, sha):
+    """
+    Send command to load firmware
+    Transfer binary file contents including padding
+    """
+    command = msg.create_loadfw_cmd(size, sha)
+    response = sue_creek.send_receive(command)
+    msg.print_response(response)
+
+    with open(file, 'rb') as firmware:
+        firmware.seek(0, 0)
+        block_size = msg.get_bulk_message_size()
+        transferred = 0
+        for block in iter(lambda: firmware.read(block_size), b""):
+            if len(block) < block_size:
+                block += b'\0' * padding
+            bulk_msg = msg.create_bulk_message(block)
+            sue_creek.send_bulk(bulk_msg)
+            transferred += len(bulk_msg)
+            sys.stdout.write('\r%d of %d bytes transferred to %s.'
+                    % (transferred, size, sue_creek.name))
+        print('')
+        firmware.close()
+
+    sue_creek.check_device_ready()
+
+    command = msg.create_null_cmd()
+    response = sue_creek.send_receive(command)
+    msg.print_response(response)
+
+def execute_firmware():
+    """
+    Send command to start execution
+    """
+    command = msg.create_memwrite_cmd((0x71d10, 0, 0x71d20, 0))
+    response = sue_creek.send_receive(command)
+    msg.print_response(response)
+
+    command = msg.create_execfw_cmd()
+    response = sue_creek.send_receive(command, wait = False)
+    msg.print_response(response)
+
+def main():
+    """
+    Check arguments to ensure binary file is provided.
+    Calculate SHA of the binary image
+    Setup the SPI master device and GPIOs on the host
+    Download Firmware
+    """
+    file = check_arguments()
+    (size, padding, sha) = calc_firmware_sha(file)
+    setup_device()
+    load_firmware(file, size, padding, sha)
+    execute_firmware()
+    sue_creek.close()
+
+if __name__ == '__main__':
+    main()

--- a/boards/xtensa/intel_s1000_crb/support/messenger.py
+++ b/boards/xtensa/intel_s1000_crb/support/messenger.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Author: Sathish Kuttan <sathish.k.kuttan@intel.com>
+
+# This file defines a message class that contains functions to create
+# commands to the target and to parse responses from the target.
+
+import bitstruct
+
+class Message:
+    """
+    Message class containing the methods to create command messages and
+    parse response messages.
+    """
+    message_id = {1: 'Control'}
+    cmd_rsp = {2: 'Load Firmware',
+            4: 'Mode Select',
+            0x10: 'Memory Read',
+            0x11: 'Memory Write',
+            0x12: 'Memory Block Write',
+            0x13: 'Execute',
+            0x14: 'Wait',
+            0x20: 'Ready'}
+    tx_data = None
+    tx_bulk_data = None
+    tx_index = 0
+    cmd_word_fmt = 'u1 u1 u1 u5 u16 u8'
+    cmd_keys = ['cmd', 'rsvd1', 'rsp', 'msg_id', 'rsvd2', 'cmd_rsp']
+
+    def __init__(self):
+        """
+        Intialize a byte array of 64 bytes for command messages
+        Intialize another byte array of 4096 bytes for bulk messages
+        """
+        self.tx_data = bytearray(64)
+        self.tx_bulk_data = bytearray(4096)
+
+    def init_tx_data(self):
+        """
+        Intialize transmit message buffers to zeros
+        """
+        for index in range(len(self.tx_data)):
+            self.tx_data[index] = 0
+        self.tx_index = 0
+
+    def endian_swap(self, dst, dst_offset, src):
+        """
+        Performs a byte swap of a 32-bit word to change it's endianness
+        """
+        for index in range(0, len(src), 4):
+            dst[dst_offset + index + 0] = src[index +  3]
+            dst[dst_offset + index + 1] = src[index +  2]
+            dst[dst_offset + index + 2] = src[index +  1]
+            dst[dst_offset + index + 3] = src[index +  0]
+
+    def print_cmd_message(self):
+        """
+        Prints the contents of the command message buffer
+        """
+        for index in range(0, self.tx_index, 4):
+            offset = index * 8
+            word = bitstruct.unpack_from('u32', self.tx_data, offset)
+            print('Index: %2d Content: 0x%08x' %(index, word[0]))
+
+    def print_response(self, msg, verbose = False):
+        """
+        Parses and prints the contents of the response message
+        """
+        unpacked = bitstruct.unpack_from_dict(self.cmd_word_fmt,
+                self.cmd_keys, msg)
+        msg_id = unpacked['msg_id']
+        rsp = unpacked['cmd_rsp']
+        if msg_id == 0 and rsp == 0:
+            print('RSP <<< NULL.')
+        else:
+            print('RSP <<< %s.' % self.cmd_rsp[rsp])
+            if verbose == True:
+                count = bitstruct.unpack_from('u32', msg, 4 * 8)[0]
+                count &= 0x1ff
+                for index in range(0, 8 + (count * 4), 4):
+                    offset = index * 8
+                    word = bitstruct.unpack_from('u32', msg, offset)
+                    print('Index: %2d Content: 0x%08x' %(index, word[0]))
+
+    def get_cmd_code(self, cmd):
+        """
+        Looks up the command and returns the numeric code
+        """
+        index = list(self.cmd_rsp.values()).index(cmd)
+        return list(self.cmd_rsp.keys())[index]
+
+    def print_cmd_code(self, cmd):
+        """
+        Prints the numeric code for the given command
+        """
+        key = self.get_cmd_code(cmd)
+        print('CMD >>> %s. Command Code: 0x%02x' % (cmd, key))
+
+    def create_null_cmd(self):
+        """
+        Creates a NULL command
+        """
+        print('CMD >>> NULL.')
+        for index in range(len(self.tx_data)):
+            self.tx_data[index] = 0
+        self.tx_index = len(self.tx_data)
+        return self.tx_data
+
+    def create_memwrite_cmd(self, tuple):
+        """
+        Creates a memory write command with memory address and value pairs
+        """
+        cmd = 'Memory Write'
+        print('CMD >>> %s.' % cmd)
+        code = self.get_cmd_code(cmd)
+        self.init_tx_data()
+
+        index = list(self.message_id.values()).index('Control')
+        msg_id = list(self.message_id.keys())[index]
+        bitstruct.pack_into_dict(self.cmd_word_fmt, self.cmd_keys,
+                self.tx_data, 0, {'cmd': 1, 'rsvd1': 0, 'rsp':  0,
+                'msg_id': msg_id, 'rsvd2': 0, 'cmd_rsp': code})
+        self.tx_index += 4
+        bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8,
+                len(tuple))
+        self.tx_index += 4
+        for index in range(len(tuple)):
+            bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8,
+                    tuple[index])
+            self.tx_index += 4
+        return self.tx_data
+
+    def create_memread_cmd(self, tuple):
+        """
+        Creates a memory read command with memory addresses
+        """
+        cmd = 'Memory Read'
+        print('CMD >>> %s.' % cmd)
+        code = self.get_cmd_code(cmd)
+        self.init_tx_data()
+
+        index = list(self.message_id.values()).index('Control')
+        msg_id = list(self.message_id.keys())[index]
+        bitstruct.pack_into_dict(self.cmd_word_fmt, self.cmd_keys,
+                self.tx_data, 0, {'cmd': 1, 'rsvd1': 0, 'rsp':  0,
+                'msg_id': msg_id, 'rsvd2': 0, 'cmd_rsp': code})
+        self.tx_index += 4
+        bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8,
+                len(tuple))
+        self.tx_index += 4
+        for index in range(len(tuple)):
+            bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8,
+                    tuple[index])
+            self.tx_index += 4
+        return self.tx_data
+
+    def create_loadfw_cmd(self, size, sha):
+        """
+        Creates a command to load firmware with associated paramters
+        """
+        cmd = 'Load Firmware'
+        print('CMD >>> %s.' % cmd)
+        code = self.get_cmd_code(cmd)
+
+        FW_NO_EXEC_FLAG = (1 << 26)
+        SEL_HP_CLK = (1 << 21)
+        LD_FW_HEADER_LEN = 3
+
+        count_flags = FW_NO_EXEC_FLAG | SEL_HP_CLK
+        count_flags |= (LD_FW_HEADER_LEN + int(len(sha) / 4))
+
+        self.init_tx_data()
+
+        index = list(self.message_id.values()).index('Control')
+        msg_id = list(self.message_id.keys())[index]
+        bitstruct.pack_into_dict(self.cmd_word_fmt, self.cmd_keys,
+                self.tx_data, 0, {'cmd': 1, 'rsvd1': 0, 'rsp':  0,
+                'msg_id': msg_id, 'rsvd2': 0, 'cmd_rsp': code})
+        self.tx_index += 4
+        bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8, count_flags)
+        self.tx_index += 4
+        bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8, 0xbe000000)
+        self.tx_index += 4
+        bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8, 0)
+        self.tx_index += 4
+        bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8, size)
+        self.tx_index += 4
+        self.endian_swap(self.tx_data, self.tx_index, sha)
+        self.tx_index += len(sha)
+        return self.tx_data
+
+    def create_execfw_cmd(self):
+        """
+        Creates a command to excute firmware
+        """
+        cmd = 'Execute'
+        print('CMD >>> %s.' % cmd)
+        code = self.get_cmd_code(cmd)
+
+        EXE_FW_HEADER_LEN = 1
+
+        count = EXE_FW_HEADER_LEN
+
+        self.init_tx_data()
+
+        index = list(self.message_id.values()).index('Control')
+        msg_id = list(self.message_id.keys())[index]
+        bitstruct.pack_into_dict(self.cmd_word_fmt, self.cmd_keys,
+                self.tx_data, 0, {'cmd': 1, 'rsvd1': 0, 'rsp':  0,
+                'msg_id': msg_id, 'rsvd2': 0, 'cmd_rsp': code})
+        self.tx_index += 4
+        bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8, count)
+        self.tx_index += 4
+        bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8, 0xbe000000)
+        self.tx_index += 4
+        return self.tx_data
+
+    def create_bulk_message(self, data):
+        """
+        Copies the input byte stream to the bulk message buffer
+        """
+        self.endian_swap(self.tx_bulk_data, 0, data)
+        return self.tx_bulk_data[:len(data)]
+
+    def get_bulk_message_size(self):
+        """
+        Returns the size of the bulk message buffer
+        """
+        return len(self.tx_bulk_data)


### PR DESCRIPTION
This PR adds python based scripts to be used on a linux development host that is connected over SPI to Intel S1000 board.
The script accepts a zephyr.bin image and downloads it to the target. The target then executes the image.