### PR TITLE
lvgl: kconfig: Remove menu and use a 'menuconfig' symbol

### DIFF
--- a/lib/gui/Kconfig
+++ b/lib/gui/Kconfig
@@ -4,8 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-menu "Graphical user interface"
-
 rsource "lvgl/Kconfig"
-
-endmenu

--- a/lib/gui/lvgl/Kconfig
+++ b/lib/gui/lvgl/Kconfig
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-config LVGL
-	bool "LittlevGL Support"
+menuconfig LVGL
+	bool "LittlevGL GUI library"
 	help
 	  This option enables the LittlevGL GUI library.
 


### PR DESCRIPTION
The 'Graphical user interface' menu currently contains just the
'LittlevGL Support' symbol and its indented children.

To remove one menu level, remove the 'Graphical user interface' menu,
rename the symbol to 'LittlevGL GUI library' (consistent with e.g.
'Logging' and 'Bluetooth'), and turn it into a 'menuconfig' symbol.