### PR TITLE
fs/nvs: fix NVS of 2-sectors configuration

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -536,13 +536,15 @@ static int nvs_startup(struct nvs_fs *fs)
 	 * Coverity and GCC believe the contrary.
 	 */
 	u32_t addr = 0U;
-
+	u16_t i;
 
 	k_mutex_lock(&fs->nvs_lock, K_FOREVER);
 
 	ate_size = nvs_al_size(fs, sizeof(struct nvs_ate));
-	/* step through the sectors to find the last sector */
-	for (u16_t i = 0; i < fs->sector_count; i++) {
+	/* step through the sectors to find a open sector following
+	 * a closed sector, this is where NVS can to write.
+	 */
+	for (i = 0; i < fs->sector_count; i++) {
 		addr = (i << ADDR_SECT_SHIFT) + fs->sector_size - ate_size;
 		rc = nvs_flash_cmp_const(fs, addr, 0xff,
 					  sizeof(struct nvs_ate));
@@ -556,12 +558,25 @@ static int nvs_startup(struct nvs_fs *fs)
 				break;
 			}
 		}
-		/* none of the sectors where closed, set the address to
-		 * the first sector
-		 */
-		nvs_sector_advance(fs, &addr);
 	}
-	/* search for the first ate containing all 0xff) */
+
+	if (i == fs->sector_count) {
+		/* none of the sectors where closed, in most cases we can set
+		 * the address to the first sector, except when there are only
+		 * two sectors. Then we can only set it to the first sector if
+		 * the last sector contains no ate's. So we check this first
+		 */
+		rc = nvs_flash_cmp_const(fs, addr - ate_size, 0xff,
+				  sizeof(struct nvs_ate));
+		if (!rc) {
+			/* empty ate */
+			nvs_sector_advance(fs, &addr);
+		}
+	}
+
+	/* addr contains address of the last ate in the most recent sector
+	 * search for the first ate containing all 0xff
+	 */
 	while (1) {
 		addr -= ate_size;
 		rc = nvs_flash_cmp_const(fs, addr, 0xff,

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -66,6 +66,9 @@ void test_nvs_write(void)
 	char pattern[] = {0xDE, 0xAD, 0xBE, 0xEF};
 	size_t len;
 
+	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+
 	err = nvs_read(&fs, TEST_DATA_ID, rd_buf, sizeof(rd_buf));
 	zassert_true(err == -ENOENT,  "nvs_read unexpected failure: %d", err);
 
@@ -83,7 +86,8 @@ void test_nvs_write(void)
 	zassert_mem_equal(wr_buf, rd_buf, sizeof(rd_buf),
 			"RD buff should be equal to the WR buff");
 
-	nvs_delete(&fs, TEST_DATA_ID);
+	err = nvs_clear(&fs);
+	zassert_true(err == 0,  "nvs_clear call failure: %d", err);
 }
 
 static int flash_sim_write_calls_find(struct stats_hdr *hdr, void *arg,
@@ -119,6 +123,9 @@ void test_nvs_corrupted_write(void)
 	char pattern_2[] = {0x03, 0xAA, 0x85, 0x6F};
 	u32_t *flash_write_stat;
 	u32_t *flash_max_write_calls;
+
+	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	zassert_true(err == 0,  "nvs_init call failure: %d", err);
 
 	err = nvs_read(&fs, TEST_DATA_ID, rd_buf, sizeof(rd_buf));
 	zassert_true(err == -ENOENT,  "nvs_read unexpected failure: %d", err);
@@ -172,6 +179,9 @@ void test_nvs_corrupted_write(void)
 	zassert_mem_equal(wr_buf_1, rd_buf, sizeof(rd_buf),
 			"RD buff should be equal to the first WR buff because subsequent "
 			"write operation has failed");
+
+	err = nvs_clear(&fs);
+	zassert_true(err == 0,  "nvs_clear call failure: %d", err);
 }
 
 void test_main(void)


### PR DESCRIPTION
merge after: #16255

This patch fixes following bug:

After first GC operation the 1st sector had become scratch
and the 2nd sector had became write sector. After that NVS
was initialize (via reboot) again - it recognized the 1st
sector as write sector and 2nd as undone GC destination sector,
therefore it cleared 2nd sector and  re-run GC, which implied data loss.