### PR TITLE
logging: Add option to automatically duplicate transient strings

### DIFF
--- a/doc/reference/logging/index.rst
+++ b/doc/reference/logging/index.rst
@@ -137,6 +137,9 @@ which handles log processing.
 message pool. Single message capable of storing standard log with up to 3
 arguments or hexdump message with 12 bytes of data take 32 bytes.
 
+:option:`CONFIG_LOG_AUTO_STRDUP`: Enable automatic handling of transient strings
+used as log message string arguments.
+
 :option:`CONFIG_LOG_STRDUP_MAX_STRING`: Longest string that can be duplicated
 using log_strdup().
 
@@ -418,6 +421,7 @@ copies of strings.  The buffer size and count is configurable
 (see :option:`CONFIG_LOG_STRDUP_MAX_STRING` and
 :option:`CONFIG_LOG_STRDUP_BUF_COUNT`).
 
+
 If a string argument is transient, the user must call cpp:func:`log_strdup` to
 duplicate the passed string into a buffer from the pool. See the examples below.
 If a strdup buffer cannot be allocated, a warning message is logged and an error
@@ -430,6 +434,16 @@ increased. Buffers are freed together with the log message.
 
    LOG_INF("logging transient string: %s", log_strdup(local_str));
    local_str[0] = '\0'; /* String can be modified, logger will use duplicate."
+
+Alternatively, when :option:`CONFIG_LOG_AUTO_STRDUP` is enabled logger will
+implicitly duplicate transient strings. Logger is clasifying string argument as
+transient if string address is not located in read only memory and does not
+belong to the pool used for string duplicates. This feature requires initial
+scanning of log message string in search for string format specifier (%s) in the
+context of the log message call thus it impacts logger performance. If
+cpp:func:`log_strdup` is used explicitly everywhere, feature can be disabled.
+Number of implicit string duplications can be checked using shell
+(``log strdup_cnt`` command).
 
 Logger backends
 ===============

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -535,7 +535,7 @@ void log_generic(struct log_msg_ids src_level, const char *fmt, va_list ap);
  *
  * @return True if address within the pool, false otherwise.
  */
-bool log_is_strdup(void *buf);
+bool log_is_strdup(const void *buf);
 
 /** @brief Free allocated buffer.
  *
@@ -546,6 +546,13 @@ void log_free(void *buf);
 /** @brief Indicate to the log core that one log message has been dropped.
  */
 void log_dropped(void);
+
+/**
+ * @brief Get number of automatic string duplications.
+ *
+ * @return Number of automatic string duplications.
+ */
+u32_t log_get_auto_strdup_cnt(void);
 
 #ifdef __cplusplus
 }

--- a/include/logging/log_msg.h
+++ b/include/logging/log_msg.h
@@ -263,6 +263,14 @@ u32_t log_msg_nargs_get(struct log_msg *msg);
  */
 u32_t log_msg_arg_get(struct log_msg *msg, u32_t arg_idx);
 
+/** @brief Set argument in standard log message.
+ *
+ * @param msg		Standard log message.
+ * @param arg_idx	Argument index.
+ * @param arg		Argument.
+ */
+void log_msg_arg_set(struct log_msg *msg, u32_t arg_idx, u32_t arg);
+
 
 /** @brief Gets pointer to the unformatted string from standard log message.
  *

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -175,6 +175,18 @@ config LOG_BUFFER_SIZE
 	help
 	  Number of bytes dedicated for the logger internal buffer.
 
+config LOG_AUTO_STRDUP
+	bool "Enable automatic handling of transient strings"
+	default y if !LOG_IMMEDIATE
+	help
+	  If enabled, log message string is scanned in search for %s format
+	  specifier. Any string argument which is in read-write memory and not
+	  yet explicitly duplicated using log_strdup() is duplicated. Enabling
+	  this feature degrades logger performance so ideally log_strdup()
+	  should be used explicitly and feature should be disabled. Dedicated
+	  shell log command can be used to check how many implicit string
+	  duplications occured in the system.
+
 config LOG_STRDUP_MAX_STRING
 	int "Longest string that can be duplicated using log_strdup()"
 	default 46 if NETWORKING

--- a/subsys/logging/log_cmds.c
+++ b/subsys/logging/log_cmds.c
@@ -363,6 +363,13 @@ static int cmd_log_backends_list(const struct shell *shell,
 	return 0;
 }
 
+static int cmd_log_auto_strdup_cnt(const struct shell *shell,
+			      size_t argc, char **argv)
+{
+	shell_print(shell, "Number of automatic string duplications: %d",
+			log_get_auto_strdup_cnt());
+	return 0;
+}
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_log_backend,
 	SHELL_CMD_ARG(disable, &dsub_module_name,
@@ -413,6 +420,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_log_stat,
 	SHELL_CMD_ARG(list_backends, NULL, "Lists logger backends.",
 		      cmd_log_backends_list, 1, 0),
 	SHELL_CMD(status, NULL, "Logger status", cmd_log_self_status),
+	SHELL_COND_CMD_ARG(CONFIG_LOG_AUTO_STRDUP, strdup_cnt, NULL,
+			"Get number of automatic string duplications",
+			cmd_log_auto_strdup_cnt, 1, 0),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
Added CONFIG_LOG_AUTO_STRDUP (by default on) which enables scanning of
log message strings in search for %s and performs string duplication
(log_strdup()) if string address is not from strdup buffer pool and
outside read only memory section.
    
Added shell command which can be used to check number of performed
string duplications. It can be used to determine if feature can be
disabled since it degrades performance of the logger (+5us for
scanning 20 characters @64MHz cortex-m4).

This should solve the problem with using %s in the logger messages.