### PR TITLE
drivers/ieee802154: Fix KW41Z driver fault

### DIFF
--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -1020,6 +1020,12 @@ static void kw41z_iface_init(struct net_if *iface)
 	ieee802154_init(iface);
 }
 
+static int kw41z_configure(struct device *dev, enum ieee802154_config_type type,
+			   const struct ieee802154_config *config)
+{
+	return 0;
+}
+
 static struct ieee802154_radio_api kw41z_radio_api = {
 	.iface_api.init	= kw41z_iface_init,
 
@@ -1031,6 +1037,7 @@ static struct ieee802154_radio_api kw41z_radio_api = {
 	.start			= kw41z_start,
 	.stop			= kw41z_stop,
 	.tx			= kw41z_tx,
+	.configure		= kw41z_configure,
 };
 
 #if defined(CONFIG_NET_L2_IEEE802154)


### PR DESCRIPTION
KW41Z IEEE802154 driver fix, by adding an empty configure function
to resolve HardFault at start up

Signed-off-by: Tobias Schlaepfer <scpf@zhaw.ch>