### PR TITLE
[RFC] zephyr-module: Rename file to _zephyr_modules.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,8 +420,8 @@ add_subdirectory(subsys)
 add_subdirectory(drivers)
 
 # Include zephyr modules generated CMake file.
-if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
-  file(STRINGS ${CMAKE_BINARY_DIR}/zephyr_modules.txt ZEPHYR_MODULES_TXT)
+if(EXISTS ${CMAKE_BINARY_DIR}/_zephyr_modules.txt)
+  file(STRINGS ${CMAKE_BINARY_DIR}/_zephyr_modules.txt ZEPHYR_MODULES_TXT)
 
   foreach(module ${ZEPHYR_MODULES_TXT})
     # Match "<name>":"<path>" for each line of file, each corresponding to

--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -34,7 +34,7 @@ if(WEST OR ZEPHYR_MODULES)
     ${ZEPHYR_MODULES_ARG}
     ${ZEPHYR_EXTRA_MODULES_ARG}
     --kconfig-out ${KCONFIG_MODULES_FILE}
-    --cmake-out ${CMAKE_BINARY_DIR}/zephyr_modules.txt
+    --cmake-out ${CMAKE_BINARY_DIR}/_zephyr_modules.txt
     ERROR_VARIABLE
     zephyr_module_error_text
     RESULT_VARIABLE


### PR DESCRIPTION
To ease tab-completion of zephyr directory.
From build directory: 'z' + TAB currently resolves to 'zephyr'
instead of 'zephyr/'. This commit fixes that.

[RFC] because I don't know if it breaks something important.