### PR TITLE
scripts/dts: Fix issue in label generation of registers

### DIFF
--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -58,7 +58,7 @@ class DTReg(DTDirective):
             addr = 0
             size = 0
             # Check is defined should be indexed (_0, _1)
-            if index == 0 and len(props) < 3:
+            if index == 0 and len(props) <= (nr_address_cells + nr_size_cells):
                 # 1 element (len 2) or no element (len 0) in props
                 l_idx = []
             else:


### PR DESCRIPTION
If we have something like:

       #address-cells = <1>;
       #size-cells = <0>;

       intc: ioapic@fec00000  {
	       compatible = "intel,ioapic";
	       reg = <0xfec00000 0x100000>;
       };

We should generate:

DT_INTEL_IOAPIC_FEC00000_BASE_ADDRESS_0
DT_INTEL_IOAPIC_FEC00000_BASE_ADDRESS_1

Instead we generated:

DT_INTEL_IOAPIC_FEC00000_BASE_ADDRESS
DT_INTEL_IOAPIC_FEC00000_BASE_ADDRESS_1

This was due to logic deciding if '_0' should be used not taking into
account #address-cells & #size-cells correctly.

Fixes: #16296

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>