### PR TITLE
boards: arm: particle_boron: fix SARA-R4 gpio definitions

### DIFF
--- a/boards/arm/particle_boron/particle_boron.dts
+++ b/boards/arm/particle_boron/particle_boron.dts
@@ -37,7 +37,7 @@
 		label = "ublox-sara-r4";
 		status = "ok";
 
-		mdm-power-gpios-gpio = <&gpio0 16 0>;
-		mdm-reset-gpios-gpio = <&gpio0 12 0>;
+		mdm-power-gpios = <&gpio0 16 0>;
+		mdm-reset-gpios = <&gpio0 12 0>;
 	};
 };


### PR DESCRIPTION
These definitions were left incorrect after a gpio-map change was
added to the PR introducing the boron support for the SARA-R4 modem.

Correct the gpio defintions here so that the boron build doesn't
break.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/16289

Signed-off-by: Michael Scott <mike@foundries.io>