### PR TITLE
ext: mbedtls: Enable easy integration with POSIX API

### DIFF
--- a/ext/lib/crypto/mbedtls/configs/config-tls-generic.h
+++ b/ext/lib/crypto/mbedtls/configs/config-tls-generic.h
@@ -26,6 +26,12 @@
 #define MBEDTLS_HAVE_ASM
 #endif
 
+/* If we build with POSIX API, automatically use time(), etc. */
+#if defined(CONFIG_POSIX_API)
+#define MBEDTLS_HAVE_TIME
+#define MBEDTLS_HAVE_TIME_DATE
+#endif
+
 #if defined(CONFIG_MBEDTLS_TEST)
 #define MBEDTLS_SELF_TEST
 #define MBEDTLS_DEBUG_C


### PR DESCRIPTION
If CONFIG_POSIX_API is defined, automatically use time() function.
The alternative to that is to explicitly configure mbedTLS' timing
source via API, as required for "raw code", but if user enables
POSIX API, we as well might use existing mbedTLS integration.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>