### PR TITLE
boards: nrf52840_pca10059: Configure NFC pins as GPIOs by default

### DIFF
--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059_defconfig
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059_defconfig
@@ -22,3 +22,4 @@ CONFIG_CONSOLE=y
 
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y
+CONFIG_NFCT_PINS_AS_GPIOS=y


### PR DESCRIPTION
Since there is no NFC antenna connector on the dongle and the pins
P0.09 and P0.10 that are dedicated to NFC functionality are in the
group of just a few ones available for external connections, it seems
more reasonable to configure these pins by default as regular GPIOs,
as users will most likely want to use them in this way.
