### PR TITLE
tests/fs/nvs: GC full round test

### DIFF
--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -4,6 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/*
+ * This test is designed to be run using flash-simulator which provide
+ * functionality for flash property customization and emulating errors in
+ * flash opperation in parallel to regular flash API.
+ * Test should be run on qemu_x86 target.
+ */
+
+#ifndef CONFIG_BOARD_QEMU_X86
+#error "Run on qemu_x86 only"
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <ztest.h>
@@ -12,6 +23,7 @@
 #include "flash_map.h"
 #include "stats.h"
 #include "nvs/nvs.h"
+#include "nvs_priv.h"
 
 #define TEST_FLASH_AREA_STORAGE_OFFSET	DT_FLASH_AREA_STORAGE_OFFSET
 #define TEST_DATA_ID			1
@@ -245,6 +257,131 @@ void test_nvs_gc(void)
 	zassert_true(err == 0,  "nvs_clear call failure: %d", err);
 }
 
+static void write_content(u16_t max_id, u16_t begin, u16_t end,
+			     struct nvs_fs *fs)
+{
+	u8_t buf[32];
+	ssize_t len;
+
+	for (u16_t i = begin; i < end; i++) {
+		u8_t id = (i % max_id);
+		u8_t id_data = id + max_id * (i / max_id);
+
+		memset(buf, id_data, sizeof(buf));
+
+		len = nvs_write(fs, id, buf, sizeof(buf));
+		zassert_true(len == sizeof(buf), "nvs_write failed: %d", len);
+	}
+}
+
+static void check_content(u16_t max_id, struct nvs_fs *fs)
+{
+	u8_t rd_buf[32];
+	u8_t buf[32];
+	ssize_t len;
+
+	for (u16_t id = 0; id < max_id; id++) {
+		len = nvs_read(fs, id, rd_buf, sizeof(buf));
+		zassert_true(len == sizeof(rd_buf),
+			     "nvs_read unexpected failure: %d", len);
+
+		for (u16_t i = 0; i < ARRAY_SIZE(rd_buf); i++) {
+			rd_buf[i] = rd_buf[i] % max_id;
+			buf[i] = id;
+		}
+		zassert_mem_equal(buf, rd_buf, sizeof(rd_buf),
+				  "RD buff should be equal to the WR buff");
+
+	}
+}
+
+/**
+ * Full round of GC over 3 sectors
+ */
+void test_nvs_gc_3sectors(void)
+{
+	int err;
+
+	const u16_t max_id = 10;
+	/* 50th write will trigger 1st GC. */
+	const u16_t max_writes = 51;
+	/* 75th write will trigger 2st GC. */
+	const u16_t max_writes_2 = 51 + 25;
+	/* 100th write will trigger 3st GC. */
+	const u16_t max_writes_3 = 51 + 25 + 25;
+	/* 125th write will trigger 4st GC. */
+	const u16_t max_writes_4 = 51 + 25 + 25 + 25;
+
+	fs.sector_count = 3;
+
+	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
+		     "unexpected write sector");
+
+	/* Trigger 1st GC */
+	write_content(max_id, 0, max_writes, &fs);
+
+	/* sector sequence: empty,closed, write */
+	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
+		     "unexpected write sector");
+	check_content(max_id, &fs);
+
+	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+
+	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
+		     "unexpected write sector");
+	check_content(max_id, &fs);
+
+	/* Trigger 2nd GC */
+	write_content(max_id, max_writes, max_writes_2, &fs);
+
+	/* sector sequence: write, empty, closed */
+	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
+		     "unexpected write sector");
+	check_content(max_id, &fs);
+
+	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+
+	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 0,
+		     "unexpected write sector");
+	check_content(max_id, &fs);
+
+	/* Trigger 3rd GC */
+	write_content(max_id, max_writes_2, max_writes_3, &fs);
+
+	/* sector sequence: closed, write, empty */
+	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 1,
+		     "unexpected write sector");
+	check_content(max_id, &fs);
+
+	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+
+	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 1,
+		     "unexpected write sector");
+	check_content(max_id, &fs);
+
+	/* Trigger 4th GC */
+	write_content(max_id, max_writes_3, max_writes_4, &fs);
+
+	/* sector sequence: empty,closed, write */
+	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
+		     "unexpected write sector");
+	check_content(max_id, &fs);
+
+	err = nvs_init(&fs, DT_FLASH_DEV_NAME);
+	zassert_true(err == 0,  "nvs_init call failure: %d", err);
+
+	zassert_equal(fs.ate_wra >> ADDR_SECT_SHIFT, 2,
+		     "unexpected write sector");
+	check_content(max_id, &fs);
+
+	err = nvs_clear(&fs);
+	zassert_true(err == 0,  "nvs_clear call failure: %d", err);
+}
 
 void test_main(void)
 {
@@ -255,8 +392,10 @@ void test_main(void)
 				 teardown),
 			 ztest_unit_test_setup_teardown(
 				 test_nvs_corrupted_write, setup, teardown),
+			ztest_unit_test_setup_teardown(
+				 test_nvs_gc, setup, teardown),
 			 ztest_unit_test_setup_teardown(
-				 test_nvs_gc, setup, teardown)
+				 test_nvs_gc_3sectors, setup, teardown)
 			 );
 
 	ztest_run_test_suite(test_nvs);


### PR DESCRIPTION
Added a test for testing full round GC on 3-sectors
configuration. In this case all kind off sector can
appeared so this test covers well more numerous
sectors configurations.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>