### PR TITLE
doc: dfu: Fix module links

### DIFF
--- a/doc/guides/device_mgmt/dfu.rst
+++ b/doc/guides/device_mgmt/dfu.rst
@@ -10,8 +10,8 @@ The Device Firmware Upgrade subsystem provides the necessary frameworks to
 upgrade the image of a Zephyr-based application at run time. It currently
 consists of two different modules:
 
-* :file:`boot/`: Interface code to bootloaders
-* :file:`img_util/`: Image management code
+* :zephyr_file:`subsys/dfu/boot/`: Interface code to bootloaders
+* :zephyr_file:`subsys/dfu/img_util/`: Image management code
 
 The DFU subsystem deals with image management, but not with the transport
 or management protocols themselves required to send the image to the target


### PR DESCRIPTION
Link modules to their respective code directory.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>