### PR TITLE
kernel: make the main thread a pthread if CONFIG_PTHREAD_IPC

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -79,7 +79,12 @@ u64_t __noinit __idle_time_stamp;  /* timestamp when CPU goes idle */
 K_THREAD_STACK_DEFINE(_main_stack, MAIN_STACK_SIZE);
 K_THREAD_STACK_DEFINE(_idle_stack, IDLE_STACK_SIZE);
 
+#if defined(CONFIG_PTHREAD_IPC)
+#include <posix/pthread.h>
+static struct posix_thread _main_thread_s;
+#else
 static struct k_thread _main_thread_s;
+#endif
 static struct k_thread _idle_thread_s;
 
 k_tid_t const _main_thread = (k_tid_t)&_main_thread_s;


### PR DESCRIPTION
If pthreads are enabled, it is possible to call `pthread_getspecific` and
`pthread_setspecific` in the main thread.

Doing this, makes Zephyr crash with a bus fault.

This patch changes the structure used for the main thread to a pthread.
It works with this simple change, as by-design, `struct kthread` is the
very first element of `struct posix_thread`.

To be honest it seems that this patch is only touching something that is part of a larger issue. It does fix my use-case, but there are probably other very similar issues (related to other pthread callbacks).

Please let me know what should be the approach here. Should we initialize the rest of the fields properly? Should all of this be handled differently (or in a different place)?