### PR TITLE
Soc nrf introduce platform init

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -359,7 +359,7 @@ config SW_VECTOR_RELAY
 config PLATFORM_SPECIFIC_INIT
 	bool "Enable platform (SOC) specific startup hook"
 	help
-	  The platform specific initialization code (_PlatformInit) is executed
+	  The platform specific initialization code (z_platform_init) is executed
 	  at the beginning of the startup code (__start).
 
 endmenu

--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -22,7 +22,7 @@ GTEXT(__reset)
 GTEXT(memset)
 GDATA(_interrupt_stack)
 #if defined(CONFIG_PLATFORM_SPECIFIC_INIT)
-GTEXT(_PlatformInit)
+GTEXT(z_platform_init)
 #endif
 
 /**
@@ -59,7 +59,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__reset)
 SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 
 #if defined(CONFIG_PLATFORM_SPECIFIC_INIT)
-    bl _PlatformInit
+    bl z_platform_init
 #endif
 
     /* lock interrupts: will get unlocked when switch to main task */

--- a/ext/hal/nxp/mcux/devices/LPC54114/gcc/startup_LPC54114_cm4.S
+++ b/ext/hal/nxp/mcux/devices/LPC54114/gcc/startup_LPC54114_cm4.S
@@ -65,8 +65,8 @@ rel_vals:
     .short  0x0FFF       
     .short  0x0C24
 
-GTEXT(_PlatformInit)
-SECTION_FUNC(TEXT,_PlatformInit)
+GTEXT(z_platform_init)
+SECTION_FUNC(TEXT,z_platform_init)
 
 /* Both the M0+ and M4 core come via this shared startup code,
  * but the M0+ and M4 core have different vector tables.

--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -7,6 +7,7 @@
 
 config SOC_FAMILY_NRF
 	select SOC_COMPATIBLE_NRF
+	select PLATFORM_SPECIFIC_INIT
 	bool
 	# omit prompt to signify a "hidden" option
 

--- a/soc/arm/nordic_nrf/nrf51/soc.c
+++ b/soc/arm/nordic_nrf/nrf51/soc.c
@@ -47,8 +47,6 @@ static int nordicsemi_nrf51_init(struct device *arg)
 
 	key = irq_lock();
 
-	SystemInit();
-
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */
@@ -69,6 +67,11 @@ void z_arch_busy_wait(u32_t time_us)
 
 	time_us -= DELAY_CALL_OVERHEAD_US;
 	nrfx_coredep_delay_us(time_us);
+}
+
+void z_platform_init(void)
+{
+	SystemInit();
 }
 
 SYS_INIT(nordicsemi_nrf51_init, PRE_KERNEL_1, 0);

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -60,8 +60,6 @@ static int nordicsemi_nrf52_init(struct device *arg)
 
 	key = irq_lock();
 
-	SystemInit();
-
 #ifdef CONFIG_NRF_ENABLE_ICACHE
 	/* Enable the instruction cache */
 	NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Msk;
@@ -84,6 +82,11 @@ static int nordicsemi_nrf52_init(struct device *arg)
 void z_arch_busy_wait(u32_t time_us)
 {
 	nrfx_coredep_delay_us(time_us);
+}
+
+void z_platform_init(void)
+{
+	SystemInit();
 }
 
 SYS_INIT(nordicsemi_nrf52_init, PRE_KERNEL_1, 0);

--- a/soc/arm/nordic_nrf/nrf91/soc.c
+++ b/soc/arm/nordic_nrf/nrf91/soc.c
@@ -43,8 +43,6 @@ static int nordicsemi_nrf91_init(struct device *arg)
 
 	key = irq_lock();
 
-	SystemInit();
-
 #ifdef CONFIG_NRF_ENABLE_ICACHE
 	/* Enable the instruction cache */
 	NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Msk;
@@ -63,6 +61,11 @@ static int nordicsemi_nrf91_init(struct device *arg)
 void z_arch_busy_wait(u32_t time_us)
 {
 	nrfx_coredep_delay_us(time_us);
+}
+
+void z_platform_init(void)
+{
+	SystemInit();
 }
 
 


### PR DESCRIPTION
This is mainly a patch for nRF SoCs; it introduces a platform-specific initialization function and calls it immediately after reset handler.

A second commit in this patch refactors the _PlatformInit function by renaming it to z_platform_init, introducing no behavioral changes.