### PR TITLE
Atmel SAMD hwinfo cleanup

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.yaml
+++ b/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.yaml
@@ -8,3 +8,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - hwinfo

--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.yaml
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.yaml
@@ -8,3 +8,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - hwinfo

--- a/boards/arm/arduino_zero/arduino_zero.yaml
+++ b/boards/arm/arduino_zero/arduino_zero.yaml
@@ -8,3 +8,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - hwinfo

--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.yaml
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.yaml
@@ -8,3 +8,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - hwinfo

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.yaml
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.yaml
@@ -15,3 +15,4 @@ supported:
   - spi
   - i2c
   - usb_device
+  - hwinfo

--- a/dts/arm/atmel/samd.dtsi
+++ b/dts/arm/atmel/samd.dtsi
@@ -26,7 +26,7 @@
 		reg = <0x20000000 0x8000>;
 	};
 
-	id: device_id@0 {
+	id: device_id@80a00c {
 		compatible = "atmel,sam0-id";
 		reg =	<0x0080A00C 0x4>,
 			<0x0080A040 0x4>,


### PR DESCRIPTION
Minor cleanups for the atmel hwinfo / device_id support.
* Fix DTS node name
* Enable hwinfo for boards that support it on the SAMD family.