### PR TITLE
boards: rv32m1_vega_ri5cy: set shell UART in DTS

### DIFF
--- a/boards/riscv32/rv32m1_vega/rv32m1_vega_ri5cy.dts
+++ b/boards/riscv32/rv32m1_vega/rv32m1_vega_ri5cy.dts
@@ -16,6 +16,7 @@
 		zephyr,sram = &m4_dtcm;
 		zephyr,flash = &ri5cy_code_partition;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 	};
 };


### PR DESCRIPTION
This fixes any sample which enabled CONFIG_SHELL.

Signed-off-by: Michael Scott <mike@foundries.io>