### PR TITLE
boards: rv32m1_vega: add Arduino header information

### DIFF
--- a/boards/riscv32/rv32m1_vega/rv32m1_vega.dtsi
+++ b/boards/riscv32/rv32m1_vega/rv32m1_vega.dtsi
@@ -54,7 +54,36 @@
 			gpios = <&gpioe 12 GPIO_INT_ACTIVE_LOW>;
 		};
 	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioc 11 0>,	/* A0 */
+			   <1 0 &gpioc 12 0>,	/* A1 */
+			   <2 0 &gpiob 9 0>,	/* A2 */
+			   <3 0 &gpioe 4 0>,	/* A3 */
+			   <4 0 &gpioe 10 0>,	/* A4 */
+			   <5 0 &gpioe 11 0>,	/* A5 */
+			   <6 0 &gpioa 25 0>,	/* D0 */
+			   <7 0 &gpioa 26 0>,	/* D1 */
+			   <8 0 &gpioa 27 0>,	/* D2 */
+			   <9 0 &gpiob 13 0>,	/* D3 */
+			   <10 0 &gpiob 14 0>,	/* D4 */
+			   <11 0 &gpioa 30 0>,	/* D5 */
+			   <12 0 &gpioa 31 0>,	/* D6 */
+			   <13 0 &gpiob 1 0>,	/* D7 */
+			   <14 0 &gpiob 2 0>,	/* D8 */
+			   <15 0 &gpiob 3 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpiob 5 0>,	/* D11 */
+			   <18 0 &gpiob 7 0>,	/* D12 */
+			   <19 0 &gpiob 4 0>,	/* D13 */
+			   <20 0 &gpioc 9 0>,	/* D14 */
+			   <21 0 &gpioc 10 0>;	/* D15 */
+	};
 };
+
+arduino_serial: &uart1 {};
 
 &uart0 {
 	current-speed = <115200>;


### PR DESCRIPTION
OpenISA Vega board has Arduino headers which can be configured for
use with Arduino-compatible shields.  To enable this in Zephyr,
let's define the gpio-map for Vega and set the appropriate
arduino_serial linkage.

Signed-off-by: Michael Scott <mike@foundries.io>