### PR TITLE
net: openthread: fix off-by-one error in settings offset calculation

### DIFF
--- a/subsys/net/lib/openthread/platform/flash.c
+++ b/subsys/net/lib/openthread/platform/flash.c
@@ -33,7 +33,7 @@ otError utilsFlashInit(void)
 	pages_count = flash_get_page_count(flash_dev);
 
 	if (flash_get_page_info_by_idx(flash_dev,
-		pages_count - CONFIG_OT_PLAT_FLASH_PAGES_COUNT - 1, &info)) {
+		pages_count - CONFIG_OT_PLAT_FLASH_PAGES_COUNT, &info)) {
 
 		return OT_ERROR_FAILED;
 	}


### PR DESCRIPTION
OpenThread uses CONFIG_OT_PLAT_FLASH_PAGES_COUNT to calculate the # of
pages at the end of flash to use for storing OpenThread settings.

This calculation has an off-by-one error which sets the offset for
the storage area as 1 page of flash too low.

For example, on nRF52840:
- default setting for CONFIG_OT_PLAT_FLASH_PAGES_COUNT is 4
- flash size is 1MB (0x100000)
- flash page size is 4096 (0x1000)
- expected offset is 0xfc000

Using the current logic we get an offset of: 0xfb000

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/16339

Signed-off-by: Michael Scott <mike@foundries.io>