### PR TITLE
Bluetooth: GATT: Fix using a wrong handle

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1536,7 +1536,7 @@ int bt_gatt_indicate(struct bt_conn *conn,
 	nfy.type = BT_GATT_CCC_INDICATE;
 	nfy.params = params;
 
-	bt_gatt_foreach_attr(params->attr->handle, 0xffff, notify_cb, &nfy);
+	bt_gatt_foreach_attr(handle, 0xffff, notify_cb, &nfy);
 
 	return nfy.err;
 }


### PR DESCRIPTION
This patch fixes to use the right handle value.

Fixes #16341

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>