### PR TITLE
net: ethernet: Fix build issue with C++

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -486,10 +486,10 @@ static inline
 enum ethernet_hw_caps net_eth_get_hw_capabilities(struct net_if *iface)
 {
 	const struct ethernet_api *eth =
-		net_if_get_device(iface)->driver_api;
+		(struct ethernet_api *)net_if_get_device(iface)->driver_api;
 
 	if (!eth->get_capabilities) {
-		return 0;
+		return (enum ethernet_hw_caps)0;
 	}
 
 	return eth->get_capabilities(net_if_get_device(iface));


### PR DESCRIPTION
When compiling with CPP, compiler complains about implicit type
conversions. Fix them.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>