### PR TITLE
samples: net: gptp: Fix compilation instructions

### DIFF
--- a/samples/net/gptp/README.rst
+++ b/samples/net/gptp/README.rst
@@ -34,7 +34,6 @@ Follow these steps to build the gPTP sample application:
 .. zephyr-app-commands::
    :zephyr-app: samples/net/gptp
    :board: <board to use>
-   :conf: prj_base.conf
    :goals: build
    :compact:
 


### PR DESCRIPTION
As the prj_base.conf was renamed to prj.conf by commit
4e5300ba7f30a21862f68c2e4e2b651f1189d84a, the documentation
needs some fixing too.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>