### PR TITLE
linker: kobject-text.ld: avoid backwards location counter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -250,6 +250,7 @@
 /scripts/gen_syscall_header.py            @andrewboie
 /scripts/gen_syscalls.py                  @andrewboie
 /scripts/process_gperf.py                 @andrewboie
+/scripts/gen_relocate_app.py              @wentongwu
 /scripts/sanity_chk/                      @andrewboie @nashif
 /scripts/sanitycheck                      @andrewboie @nashif
 /scripts/series-push-hook.sh              @erwango

--- a/include/linker/kobject-text.ld
+++ b/include/linker/kobject-text.ld
@@ -11,6 +11,7 @@
 	_kobject_text_area_start = .;
 	*(".kobject_data.text*")
 	_kobject_text_area_end = .;
+	_kobject_text_area_used = _kobject_text_area_end - _kobject_text_area_start;
 #ifndef LINKER_PASS2
 #ifdef CONFIG_DYNAMIC_OBJECTS
 	PROVIDE(z_object_gperf_find = .);
@@ -20,6 +21,22 @@
 	PROVIDE(z_object_wordlist_foreach = .);
 #endif
 #endif
-	. += CONFIG_KOBJECT_TEXT_AREA - (_kobject_text_area_end - _kobject_text_area_start);
+
+	/* In a valid build the MAX function will always evaluate to the
+	second argument below, but to give the user a good error message
+	when the area overflows we need to temporarily corrupt the
+	location counter, and then detect the overflow with an assertion
+	later on. */
+
+	. = MAX(., _kobject_text_area_start + CONFIG_KOBJECT_TEXT_AREA);
+	ASSERT(
+		CONFIG_KOBJECT_TEXT_AREA >= _kobject_text_area_used,
+"The configuration system has incorrectly set
+'CONFIG_KOBJECT_TEXT_AREA' to
+CONFIG_KOBJECT_TEXT_AREA, which is not big enough. You must
+through Kconfig either disable 'CONFIG_USERSPACE', or set
+'CONFIG_KOBJECT_TEXT_AREA' to a value larger than
+CONFIG_KOBJECT_TEXT_AREA."
+		);
 #endif /* CONFIG_USERSPACE */
 


### PR DESCRIPTION
when kobject text area is greater than CONFIG_KOBJECT_TEXT_AREA, there will be location counterbackwards, change it to assert to prompt configuring CONFIG_KOBJECT_TEXT_AREA larger.

Also add myself as code owner for script gen_relocate_app.py.

Fixes: #16307.