### PR TITLE
Bluetooth: L2CAP improvements

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -744,7 +744,7 @@ ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
  *
  *  @param conn Connection object.
  */
-typedef void (*bt_gatt_complete_func_t) (struct bt_conn *conn);
+typedef void (*bt_gatt_complete_func_t) (struct bt_conn *conn, void *user_data);
 
 /** @brief Notify attribute value change with callback.
  *
@@ -757,10 +757,13 @@ typedef void (*bt_gatt_complete_func_t) (struct bt_conn *conn);
  *  @param data Pointer to Attribute data.
  *  @param len Attribute value length.
  *  @param func Notification value callback.
+ *  @param user_data User data to be passed back to the callback.
+ *
+ *  @return 0 in case of success or negative value in case of error.
  */
 int bt_gatt_notify_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		      const void *data, u16_t len,
-		      bt_gatt_complete_func_t func);
+		      bt_gatt_complete_func_t func, void *user_data);
 
 /** @brief Notify attribute value change.
  *
@@ -778,12 +781,14 @@ int bt_gatt_notify_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
  *  @param attr Characteristic or Characteristic Value attribute.
  *  @param data Pointer to Attribute data.
  *  @param len Attribute value length.
+ *
+ *  @return 0 in case of success or negative value in case of error.
  */
 static inline int bt_gatt_notify(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr,
 				 const void *data, u16_t len)
 {
-	return bt_gatt_notify_cb(conn, attr, data, len, NULL);
+	return bt_gatt_notify_cb(conn, attr, data, len, NULL, NULL);
 }
 
 /** @typedef bt_gatt_indicate_func_t
@@ -1106,12 +1111,14 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
  * @param length Data length.
  * @param sign Whether to sign data
  * @param func Transmission complete callback.
+ * @param user_data User data to be passed back to callback.
  *
  * @return 0 in case of success or negative value in case of error.
  */
 int bt_gatt_write_without_response_cb(struct bt_conn *conn, u16_t handle,
 				      const void *data, u16_t length,
-				      bool sign, bt_gatt_complete_func_t func);
+				      bool sign, bt_gatt_complete_func_t func,
+				      void *user_data);
 
 /** @brief Write Attribute Value by handle without response
  *
@@ -1131,7 +1138,7 @@ static inline int bt_gatt_write_without_response(struct bt_conn *conn,
 						 u16_t length, bool sign)
 {
 	return bt_gatt_write_without_response_cb(conn, handle, data, length,
-						 sign, NULL);
+						 sign, NULL, NULL);
 }
 
 struct bt_gatt_subscribe_params;

--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -68,6 +68,15 @@ typedef enum bt_l2cap_chan_state {
 	BT_L2CAP_DISCONNECT,
 } __packed bt_l2cap_chan_state_t;
 
+/** @brief Status of L2CAP channel. */
+typedef enum bt_l2cap_chan_status {
+	/** Channel output status */
+	BT_L2CAP_STATUS_OUT,
+
+	/* Total number of status - must be at the end of the enum */
+	BT_L2CAP_NUM_STATUS,
+} __packed bt_l2cap_chan_status_t;
+
 /** @brief L2CAP Channel structure. */
 struct bt_l2cap_chan {
 	/** Channel connection reference */
@@ -78,6 +87,7 @@ struct bt_l2cap_chan {
 	bt_l2cap_chan_destroy_t		destroy;
 	/* Response Timeout eXpired (RTX) timer */
 	struct k_delayed_work		rtx_work;
+	ATOMIC_DEFINE(status, BT_L2CAP_NUM_STATUS);
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	bt_l2cap_chan_state_t		state;
 	/** Remote PSM to be connected */
@@ -220,6 +230,16 @@ struct bt_l2cap_chan_ops {
 	 *  @param chan The channel which has sent data.
 	 */
 	void (*sent)(struct bt_l2cap_chan *chan);
+
+	/*  Channel status callback
+	 *
+	 *  If this callback is provided it will be called whenever the
+	 *  channel status changes.
+	 *
+	 *  @param chan The channel which status changed
+	 *  @param status The channel status
+	 */
+	void (*status)(struct bt_l2cap_chan *chan, atomic_t *status);
 };
 
 /** @def BT_L2CAP_CHAN_SEND_RESERVE

--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -211,6 +211,15 @@ struct bt_l2cap_chan_ops {
 	 *  number of segments/credits used by the packet.
 	 */
 	int (*recv)(struct bt_l2cap_chan *chan, struct net_buf *buf);
+
+	/*  Channel sent callback
+	 *
+	 *  If this callback is provided it will be called whenever a SDU has
+	 *  been completely sent.
+	 *
+	 *  @param chan The channel which has sent data.
+	 */
+	void (*sent)(struct bt_l2cap_chan *chan);
 };
 
 /** @def BT_L2CAP_CHAN_SEND_RESERVE

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -77,6 +77,22 @@
 	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif
 
+	SECTION_DATA_PROLOGUE(_bt_channels_area,,SUBALIGN(4))
+	{
+		_bt_channels_start = .;
+		KEEP(*(SORT_BY_NAME("._bt_channels.static.*")))
+		_bt_channels_end = .;
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
+#if defined(CONFIG_BT_BREDR)
+	SECTION_DATA_PROLOGUE(_bt_br_channels_area,,SUBALIGN(4))
+	{
+		_bt_br_channels_start = .;
+		KEEP(*(SORT_BY_NAME("._bt_br_channels.static.*")))
+		_bt_br_channels_end = .;
+	} GROUP_LINK_IN(ROMABLE_REGION)
+#endif
+
 	SECTION_DATA_PROLOGUE(_bt_services_area,,SUBALIGN(4))
 	{
 		_bt_services_start = .;

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/prj_smp_svr.conf
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/prj_smp_svr.conf
@@ -13,9 +13,6 @@ CONFIG_MCUMGR_SMP_BT=y
 #CONFIG_MCUMGR_SMP_SHELL=y
 #CONFIG_MCUMGR_SMP_UART=y
 
-# Bluetooth support requires a net_buf user_data size >= 7.
-CONFIG_NET_BUF_USER_DATA_SIZE=7
-
 # Enable flash operations.
 CONFIG_FLASH=y
 

--- a/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
@@ -16,9 +16,6 @@ CONFIG_MCUMGR_SMP_BT=y
 CONFIG_MCUMGR_SMP_SHELL=y
 #CONFIG_MCUMGR_SMP_UART=y
 
-# Bluetooth support requires a net_buf user_data size >= 7.
-CONFIG_NET_BUF_USER_DATA_SIZE=7
-
 # Enable flash operations.
 CONFIG_FLASH=y
 

--- a/samples/subsys/mgmt/mcumgr/smp_svr/prj_tiny.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/prj_tiny.conf
@@ -23,9 +23,6 @@ CONFIG_MCUMGR_SMP_UART=y
 # Disable Bluetooth unused features
 CONFIG_BT_GATT_READ_MULTIPLE=n
 
-# Bluetooth support requires a net_buf user_data size >= 7.
-CONFIG_NET_BUF_USER_DATA_SIZE=7
-
 # Enable flash operations.
 CONFIG_FLASH=y
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -908,8 +908,8 @@ class SizeCalculator:
     # These get copied into RAM only on non-XIP
     ro_sections = ["text", "ctors", "init_array", "reset", "object_access",
                    "rodata", "devconfig", "net_l2", "vector", "sw_isr_table",
-                   "_bt_settings_area", "_bt_services_area", "vectors",
-                   "net_socket_register"]
+                   "_bt_settings_area", "_bt_channels_area","_bt_services_area",
+                   "vectors", "net_socket_register"]
 
     def __init__(self, filename, extra_sections):
         """Constructor

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -172,46 +172,7 @@ config BT_ACL_RX_COUNT
 	range 1 64
 	help
 	  Number of buffers available for incoming ACL data.
-
-config BT_L2CAP_RX_MTU
-	int "Maximum supported L2CAP MTU for incoming data"
-	default 200 if BT_BREDR
-	default 65 if BT_SMP
-	default 23
-	range 65 1300 if BT_SMP
-	range 23 1300
-	help
-	  Maximum size of each incoming L2CAP PDU.
 endif # BT_HCI_ACL_FLOW_CONTROL
-
-config BT_L2CAP_TX_BUF_COUNT
-	int "Number of L2CAP TX buffers"
-	default 3
-	range 2 255
-	help
-	  Number of buffers available for outgoing L2CAP packets.
-
-config BT_L2CAP_TX_FRAG_COUNT
-	int "Number of L2CAP TX fragment buffers"
-	default 2
-	range 0 255
-	help
-	  Number of buffers available for fragments of TX buffers. Warning:
-	  setting this to 0 means that the application must ensure that
-	  queued TX buffers never need to be fragmented, i.e. that the
-	  controller's buffer size is large enough. If this is not ensured,
-	  and there are no dedicated fragment buffers, a deadlock may occur.
-	  In most cases the default value of 2 is a safe bet.
-
-config BT_L2CAP_TX_MTU
-	int "Maximum supported L2CAP MTU for L2CAP TX buffers"
-	default 253 if BT_BREDR
-	default 65 if BT_SMP
-	default 23
-	range 65 2000 if BT_SMP
-	range 23 2000
-	help
-	  Maximum L2CAP MTU for L2CAP TX buffers.
 
 config BT_CONN_TX_MAX
 	int "Maximum number of pending TX buffers"
@@ -313,13 +274,7 @@ config BT_BONDABLE
 
 endif # BT_SMP
 
-config BT_L2CAP_DYNAMIC_CHANNEL
-	bool "L2CAP Dynamic Channel support"
-	depends on BT_SMP
-	help
-	  This option enables support for LE Connection oriented Channels,
-	  allowing the creation of dynamic L2CAP Channels.
-
+source "subsys/bluetooth/host/Kconfig.l2cap"
 source "subsys/bluetooth/host/Kconfig.gatt"
 
 config BT_MAX_PAIRED
@@ -449,13 +404,6 @@ config BT_DEBUG_KEYS
 	help
 	  This option enables debug support for the handling of
 	  Bluetooth security keys.
-
-config BT_DEBUG_L2CAP
-	bool "Bluetooth L2CAP debug"
-	depends on BT_CONN
-	help
-	  This option enables debug support for the Bluetooth
-	  L2ACP layer.
 
 config BT_DEBUG_SMP
 	bool "Bluetooth Security Manager Protocol (SMP) debug"

--- a/subsys/bluetooth/host/Kconfig.l2cap
+++ b/subsys/bluetooth/host/Kconfig.l2cap
@@ -1,0 +1,68 @@
+# Kconfig - Bluetooth ATT/GATT configuration options
+
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menu "L2CAP Options"
+
+if BT_HCI_ACL_FLOW_CONTROL
+config BT_L2CAP_RX_MTU
+	int "Maximum supported L2CAP MTU for incoming data"
+	default 200 if BT_BREDR
+	default 65 if BT_SMP
+	default 23
+	range 65 1300 if BT_SMP
+	range 23 1300
+	help
+	  Maximum size of each incoming L2CAP PDU.
+endif # BT_HCI_ACL_FLOW_CONTROL
+
+config BT_L2CAP_TX_BUF_COUNT
+	int "Number of L2CAP TX buffers"
+	default 3
+	range 2 255
+	help
+	  Number of buffers available for outgoing L2CAP packets.
+
+config BT_L2CAP_TX_FRAG_COUNT
+	int "Number of L2CAP TX fragment buffers"
+	default 2
+	range 0 255
+	help
+	  Number of buffers available for fragments of TX buffers. Warning:
+	  setting this to 0 means that the application must ensure that
+	  queued TX buffers never need to be fragmented, i.e. that the
+	  controller's buffer size is large enough. If this is not ensured,
+	  and there are no dedicated fragment buffers, a deadlock may occur.
+	  In most cases the default value of 2 is a safe bet.
+
+config BT_L2CAP_TX_MTU
+	int "Maximum supported L2CAP MTU for L2CAP TX buffers"
+	default 253 if BT_BREDR
+	default 65 if BT_SMP
+	default 23
+	range 65 2000 if BT_SMP
+	range 23 2000
+	help
+	  Maximum L2CAP MTU for L2CAP TX buffers.
+
+config BT_L2CAP_DYNAMIC_CHANNEL
+	bool "L2CAP Dynamic Channel support"
+	depends on BT_SMP
+	help
+	  This option enables support for LE Connection oriented Channels,
+	  allowing the creation of dynamic L2CAP Channels.
+
+if BT_DEBUG
+config BT_DEBUG_L2CAP
+	bool "Bluetooth L2CAP debug"
+	depends on BT_CONN
+	help
+	  This option enables debug support for the Bluetooth
+	  L2ACP layer.
+endif # BT_DEBUG
+
+endmenu

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -121,7 +121,7 @@ static struct bt_att *att_get(struct bt_conn *conn)
 	return CONTAINER_OF(chan, struct bt_att, chan);
 }
 
-static void att_cfm_sent(struct bt_conn *conn)
+static void att_cfm_sent(struct bt_conn *conn, void *user_data)
 {
 	struct bt_att *att = att_get(conn);
 
@@ -134,7 +134,7 @@ static void att_cfm_sent(struct bt_conn *conn)
 	k_sem_give(&att->tx_sem);
 }
 
-static void att_rsp_sent(struct bt_conn *conn)
+static void att_rsp_sent(struct bt_conn *conn, void *user_data)
 {
 	struct bt_att *att = att_get(conn);
 
@@ -147,7 +147,7 @@ static void att_rsp_sent(struct bt_conn *conn)
 	k_sem_give(&att->tx_sem);
 }
 
-static void att_req_sent(struct bt_conn *conn)
+static void att_req_sent(struct bt_conn *conn, void *user_data)
 {
 	struct bt_att *att = att_get(conn);
 
@@ -161,7 +161,7 @@ static void att_req_sent(struct bt_conn *conn)
 	}
 }
 
-static void att_pdu_sent(struct bt_conn *conn)
+static void att_pdu_sent(struct bt_conn *conn, void *user_data)
 {
 	struct bt_att *att = att_get(conn);
 
@@ -206,7 +206,7 @@ static void send_err_rsp(struct bt_conn *conn, u8_t req, u16_t handle,
 	rsp->handle = sys_cpu_to_le16(handle);
 	rsp->error = err;
 
-	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, buf, att_rsp_sent);
+	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, buf, att_rsp_sent, NULL);
 }
 
 static u8_t att_mtu_req(struct bt_att *att, struct net_buf *buf)
@@ -240,7 +240,7 @@ static u8_t att_mtu_req(struct bt_att *att, struct net_buf *buf)
 	rsp = net_buf_add(pdu, sizeof(*rsp));
 	rsp->mtu = sys_cpu_to_le16(mtu_server);
 
-	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, pdu, att_rsp_sent);
+	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, pdu, att_rsp_sent, NULL);
 
 	/* BLUETOOTH SPECIFICATION Version 4.2 [Vol 3, Part F] page 484:
 	 *
@@ -282,7 +282,7 @@ static int att_send_req(struct bt_att *att, struct bt_att_req *req)
 
 	/* Keep a reference for resending in case of an error */
 	bt_l2cap_send_cb(att->chan.chan.conn, BT_L2CAP_CID_ATT,
-			 net_buf_ref(req->buf), att_cb(req->buf));
+			 net_buf_ref(req->buf), att_cb(req->buf), NULL);
 
 	return 0;
 }
@@ -484,7 +484,7 @@ static u8_t att_find_info_rsp(struct bt_att *att, u16_t start_handle,
 		return 0;
 	}
 
-	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent);
+	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent, NULL);
 
 	return 0;
 }
@@ -613,7 +613,7 @@ static u8_t att_find_type_rsp(struct bt_att *att, u16_t start_handle,
 		return 0;
 	}
 
-	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent);
+	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent, NULL);
 
 	return 0;
 }
@@ -827,7 +827,7 @@ static u8_t att_read_type_rsp(struct bt_att *att, struct bt_uuid *uuid,
 		return 0;
 	}
 
-	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent);
+	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent, NULL);
 
 	return 0;
 }
@@ -950,7 +950,7 @@ static u8_t att_read_rsp(struct bt_att *att, u8_t op, u8_t rsp, u16_t handle,
 		return 0;
 	}
 
-	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent);
+	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent, NULL);
 
 	return 0;
 }
@@ -1028,7 +1028,7 @@ static u8_t att_read_mult_req(struct bt_att *att, struct net_buf *buf)
 		}
 	}
 
-	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent);
+	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent, NULL);
 
 	return 0;
 }
@@ -1133,7 +1133,7 @@ static u8_t att_read_group_rsp(struct bt_att *att, struct bt_uuid *uuid,
 		return 0;
 	}
 
-	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent);
+	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent, NULL);
 
 	return 0;
 }
@@ -1276,7 +1276,7 @@ static u8_t att_write_rsp(struct bt_conn *conn, u8_t req, u8_t rsp,
 
 	if (data.buf) {
 		bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf,
-				 att_rsp_sent);
+				 att_rsp_sent, NULL);
 	}
 
 	return 0;
@@ -1400,7 +1400,7 @@ static u8_t att_prep_write_rsp(struct bt_att *att, u16_t handle, u16_t offset,
 	net_buf_add(data.buf, len);
 	memcpy(rsp->value, value, len);
 
-	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent);
+	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent, NULL);
 
 	return 0;
 }
@@ -1463,7 +1463,7 @@ static u8_t att_exec_write_rsp(struct bt_att *att, u8_t flags)
 		return BT_ATT_ERR_UNLIKELY;
 	}
 
-	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, buf, att_rsp_sent);
+	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, buf, att_rsp_sent, NULL);
 
 	return 0;
 }
@@ -1732,7 +1732,7 @@ static u8_t att_indicate(struct bt_att *att, struct net_buf *buf)
 		return 0;
 	}
 
-	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, buf, att_cfm_sent);
+	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, buf, att_cfm_sent, NULL);
 
 	return 0;
 }
@@ -2133,7 +2133,7 @@ static void bt_att_encrypt_change(struct bt_l2cap_chan *chan,
 
 	/* Resend buffer */
 	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, att->req->buf,
-			 att_cb(att->req->buf));
+			 att_cb(att->req->buf), NULL);
 	att->req->buf = NULL;
 }
 #endif /* CONFIG_BT_SMP */
@@ -2194,7 +2194,8 @@ u16_t bt_att_get_mtu(struct bt_conn *conn)
 	return att->chan.tx.mtu;
 }
 
-int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb)
+int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb,
+		void *user_data)
 {
 	struct bt_att *att;
 	struct bt_att_hdr *hdr;
@@ -2233,7 +2234,8 @@ int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb)
 		}
 	}
 
-	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, buf, cb ? cb : att_cb(buf));
+	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, buf, cb ? cb : att_cb(buf),
+			 user_data);
 
 	return 0;
 }

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2174,15 +2174,10 @@ static int bt_att_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 	return -ENOMEM;
 }
 
+BT_L2CAP_CHANNEL_DEFINE(att_fixed_chan, BT_L2CAP_CID_ATT, bt_att_accept);
+
 void bt_att_init(void)
 {
-	static struct bt_l2cap_fixed_chan chan = {
-		.cid		= BT_L2CAP_CID_ATT,
-		.accept		= bt_att_accept,
-	};
-
-	bt_l2cap_le_fixed_chan_register(&chan);
-
 	bt_gatt_init();
 }
 

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -242,7 +242,8 @@ struct net_buf *bt_att_create_pdu(struct bt_conn *conn, u8_t op,
 				  size_t len);
 
 /* Send ATT PDU over a connection */
-int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb);
+int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb,
+		void *user_data);
 
 /* Send ATT Request over a connection */
 int bt_att_req_send(struct bt_conn *conn, struct bt_att_req *req);

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -79,11 +79,16 @@ struct bt_conn_sco {
 };
 #endif
 
-typedef void (*bt_conn_tx_cb_t)(struct bt_conn *conn);
+typedef void (*bt_conn_tx_cb_t)(struct bt_conn *conn, void *user_data);
+
+struct bt_conn_tx_data {
+	bt_conn_tx_cb_t cb;
+	void *user_data;
+};
 
 struct bt_conn_tx {
 	sys_snode_t node;
-	bt_conn_tx_cb_t cb;
+	struct bt_conn_tx_data data;
 };
 
 struct bt_conn {
@@ -137,11 +142,11 @@ void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, u8_t flags);
 
 /* Send data over a connection */
 int bt_conn_send_cb(struct bt_conn *conn, struct net_buf *buf,
-		    bt_conn_tx_cb_t cb);
+		    bt_conn_tx_cb_t cb, void *user_data);
 
 static inline int bt_conn_send(struct bt_conn *conn, struct net_buf *buf)
 {
-	return bt_conn_send_cb(conn, buf, NULL);
+	return bt_conn_send_cb(conn, buf, NULL, NULL);
 }
 
 /* Add a new LE connection */

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -447,7 +447,7 @@ struct net_buf *bt_l2cap_create_pdu(struct net_buf_pool *pool, size_t reserve)
 }
 
 void bt_l2cap_send_cb(struct bt_conn *conn, u16_t cid, struct net_buf *buf,
-		      bt_conn_tx_cb_t cb)
+		      bt_conn_tx_cb_t cb, void *user_data)
 {
 	struct bt_l2cap_hdr *hdr;
 
@@ -457,7 +457,7 @@ void bt_l2cap_send_cb(struct bt_conn *conn, u16_t cid, struct net_buf *buf,
 	hdr->len = sys_cpu_to_le16(buf->len - sizeof(*hdr));
 	hdr->cid = sys_cpu_to_le16(cid);
 
-	bt_conn_send_cb(conn, buf, cb);
+	bt_conn_send_cb(conn, buf, cb, user_data);
 }
 
 static void l2cap_send_reject(struct bt_conn *conn, u8_t ident,

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -202,11 +202,14 @@ struct bt_l2cap_le_credits {
 struct bt_l2cap_fixed_chan {
 	u16_t		cid;
 	int (*accept)(struct bt_conn *conn, struct bt_l2cap_chan **chan);
-	sys_snode_t	node;
 };
 
-/* Register a fixed L2CAP channel for L2CAP */
-void bt_l2cap_le_fixed_chan_register(struct bt_l2cap_fixed_chan *chan);
+#define BT_L2CAP_CHANNEL_DEFINE(_name, _cid, _accept)		\
+	const struct bt_l2cap_fixed_chan _name __aligned(4)	\
+			__in_section(_bt_channels, static, _name) = { \
+				.cid = _cid,			\
+				.accept = _accept,		\
+			}
 
 /* Notify L2CAP channels of a new connection */
 void bt_l2cap_connected(struct bt_conn *conn);

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -254,12 +254,12 @@ struct net_buf *bt_l2cap_create_rsp(struct net_buf *buf, size_t reserve);
 
 /* Send L2CAP PDU over a connection */
 void bt_l2cap_send_cb(struct bt_conn *conn, u16_t cid, struct net_buf *buf,
-		      bt_conn_tx_cb_t cb);
+		      bt_conn_tx_cb_t cb, void *user_data);
 
 static inline void bt_l2cap_send(struct bt_conn *conn, u16_t cid,
 				 struct net_buf *buf)
 {
-	bt_l2cap_send_cb(conn, cid, buf, NULL);
+	bt_l2cap_send_cb(conn, cid, buf, NULL, NULL);
 }
 
 /* Receive a new L2CAP PDU from a connection */

--- a/subsys/bluetooth/host/smp_null.c
+++ b/subsys/bluetooth/host/smp_null.c
@@ -93,14 +93,9 @@ static int bt_smp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 	return -ENOMEM;
 }
 
+BT_L2CAP_CHANNEL_DEFINE(smp_fixed_chan, BT_L2CAP_CID_SMP, bt_smp_accept);
+
 int bt_smp_init(void)
 {
-	static struct bt_l2cap_fixed_chan chan = {
-		.cid	= BT_L2CAP_CID_SMP,
-		.accept	= bt_smp_accept,
-	};
-
-	bt_l2cap_le_fixed_chan_register(&chan);
-
 	return 0;
 }

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -376,7 +376,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 	return err;
 }
 
-static void write_without_rsp_cb(struct bt_conn *conn)
+static void write_without_rsp_cb(struct bt_conn *conn, void *user_data)
 {
 	shell_print(ctx_shell, "Write transmission complete");
 }
@@ -430,7 +430,7 @@ static int cmd_write_without_rsp(const struct shell *shell,
 	while (repeat--) {
 		err = bt_gatt_write_without_response_cb(default_conn, handle,
 							gatt_write_buf, len,
-							sign, func);
+							sign, func, NULL);
 		if (err) {
 			break;
 		}

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -116,6 +116,11 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	return 0;
 }
 
+static void l2cap_sent(struct bt_l2cap_chan *chan)
+{
+	shell_print(ctx_shell, "Outgoing data channel %p transmitted", chan);
+}
+
 static void l2cap_connected(struct bt_l2cap_chan *chan)
 {
 	struct l2ch *c = L2CH_CHAN(chan);
@@ -143,6 +148,7 @@ static struct net_buf *l2cap_alloc_buf(struct bt_l2cap_chan *chan)
 static struct bt_l2cap_chan_ops l2cap_ops = {
 	.alloc_buf	= l2cap_alloc_buf,
 	.recv		= l2cap_recv,
+	.sent		= l2cap_sent,
 	.connected	= l2cap_connected,
 	.disconnected	= l2cap_disconnected,
 };

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -121,6 +121,11 @@ static void l2cap_sent(struct bt_l2cap_chan *chan)
 	shell_print(ctx_shell, "Outgoing data channel %p transmitted", chan);
 }
 
+static void l2cap_status(struct bt_l2cap_chan *chan, atomic_t *status)
+{
+	shell_print(ctx_shell, "Channel %p status %u", chan, status);
+}
+
 static void l2cap_connected(struct bt_l2cap_chan *chan)
 {
 	struct l2ch *c = L2CH_CHAN(chan);
@@ -149,6 +154,7 @@ static struct bt_l2cap_chan_ops l2cap_ops = {
 	.alloc_buf	= l2cap_alloc_buf,
 	.recv		= l2cap_recv,
 	.sent		= l2cap_sent,
+	.status		= l2cap_status,
 	.connected	= l2cap_connected,
 	.disconnected	= l2cap_disconnected,
 };

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -18,8 +18,9 @@ if NET_BUF
 
 config NET_BUF_USER_DATA_SIZE
 	int "Size of user_data available in every network buffer"
+	default 8 if BT
 	default 4
-	range 4 65535 if BT
+	range 8 65535 if BT
 	range 0 65535
 	help
 	  Amount of memory reserved in each network buffer for user data. In


### PR DESCRIPTION
A few improvement to L2CAP layer:

1. Move fixed channels to ROM: Similarly to what has been done to static GATT services.
2. Increase net_buf user_data to 8 bytes so it can store a user_data in addition to a callback then use it to implement a sent callback to notify when a SDU has been completely sent per channel.
3. Add a status callback to notify when channel status changes e.g. when more credits has been added notify out status.