### PR TITLE
arch: arm: minor clean-up in interrupt stack size derivation

### DIFF
--- a/arch/arm/include/cortex_m/stack.h
+++ b/arch/arm/include/cortex_m/stack.h
@@ -39,14 +39,8 @@ extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
  */
 static ALWAYS_INLINE void z_InterruptStackSetup(void)
 {
-#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT) && \
-	defined(CONFIG_USERSPACE)
-	u32_t msp = (u32_t)(Z_THREAD_STACK_BUFFER(_interrupt_stack) +
-			    CONFIG_ISR_STACK_SIZE - MPU_GUARD_ALIGN_AND_SIZE);
-#else
-	u32_t msp = (u32_t)(Z_THREAD_STACK_BUFFER(_interrupt_stack) +
-			    CONFIG_ISR_STACK_SIZE);
-#endif
+	u32_t msp = (u32_t)(Z_THREAD_STACK_BUFFER(_interrupt_stack)) +
+			    K_THREAD_STACK_SIZEOF(_interrupt_stack);
 
 	__set_MSP(msp);
 #if defined(CONFIG_BUILTIN_STACK_GUARD)


### PR DESCRIPTION
CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT is taken into
account when allocating the area for the interrupt stack
with the K_THREAD_STACK_DEFINE macro. Therefore, we can
simpllify how the top of the stack is derived during
system initialization.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>