### PR TITLE
Fix extra rx ftr pointer alias

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -190,6 +190,16 @@ struct node_rx_ftr {
 	u32_t ticks_anchor;
 	u32_t us_radio_end;
 	u32_t us_radio_rdy;
+	u8_t  rssi;
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	u8_t  rl_idx;
+#endif /* CONFIG_BT_CTLR_PRIVACY */
+#if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
+	u8_t  direct;
+#endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
+#if defined(CONFIG_BT_HCI_MESH_EXT)
+	u8_t  chan_idx;
+#endif /* CONFIG_BT_HCI_MESH_EXT */
 };
 
 

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -436,7 +436,7 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	u8_t own_addr_type = pdu_tx->tx_addr;
 	u8_t own_addr[BDADDR_SIZE];
 	u8_t peer_addr[BDADDR_SIZE];
-	u8_t rl_idx;
+	u8_t rl_idx = ftr->rl_idx;
 
 	memcpy(own_addr, &pdu_tx->connect_ind.init_addr[0], BDADDR_SIZE);
 	memcpy(peer_addr, &pdu_tx->connect_ind.adv_addr[0], BDADDR_SIZE);
@@ -452,12 +452,6 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	cc->own_addr_type = own_addr_type;
 	memcpy(&cc->own_addr[0], &own_addr[0], BDADDR_SIZE);
-
-	if (IS_ENABLED(CONFIG_BT_CTLR_CHAN_SEL_2)) {
-		rl_idx = *((u8_t *)ftr->extra);
-	} else {
-		rl_idx = (u8_t)((u32_t)ftr->extra & 0xFF);
-	}
 
 	if (rl_idx != FILTER_IDX_NONE) {
 		/* TODO: store rl_idx instead if safe */

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -125,7 +125,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	u8_t own_addr_type = pdu_adv->rx_addr;
 	u8_t own_addr[BDADDR_SIZE];
-	u8_t rl_idx;
+	u8_t rl_idx = ftr->rl_idx;
 
 	memcpy(own_addr, &pdu_adv->connect_ind.adv_addr[0], BDADDR_SIZE);
 #endif
@@ -142,12 +142,6 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	cc->own_addr_type = own_addr_type;
 	memcpy(&cc->own_addr[0], &own_addr[0], BDADDR_SIZE);
-
-	if (IS_ENABLED(CONFIG_BT_CTLR_CHAN_SEL_2)) {
-		rl_idx = *((u8_t *)ftr->extra);
-	} else {
-		rl_idx = (u8_t)((u32_t)ftr->extra & 0xFF);
-	}
 
 	if (rl_idx != FILTER_IDX_NONE) {
 		/* TODO: store rl_idx instead if safe */


### PR DESCRIPTION
Follow up of change in 58e9ac6811c300a2fdcefd23dd6d6a87c9e20829
And issues seen in #16037

Fix rx_ftr and extra (rssi, rl_idx etc.) memory region overlap.
Move extra bytes into the rx_footer structure for splitt LL, and leave it as is for legacy LL.