### PR TITLE
extensions.cmake: don't leak absolute paths in snippets-*.ld comment

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -835,7 +835,9 @@ function(zephyr_linker_sources location)
 
     # Append the file contents to the relevant destination file.
     file(READ ${path} snippet)
-    file(APPEND ${snippet_path} "\n/* From ${path}: */\n" "${snippet}\n")
+    file(RELATIVE_PATH relpath ${ZEPHYR_BASE} ${path})
+    file(APPEND ${snippet_path}
+             "\n/* From \${ZEPHYR_BASE}/${relpath}: */\n" "${snippet}\n")
   endforeach()
 endfunction(zephyr_linker_sources)
 


### PR DESCRIPTION
Make headers look like this instead:

     /* From ${ZEPHYR_BASE}/arch/common/isr_tables.ld: */

Besides being shorter and more "private", this makes the content of
snippets-*.ld files the same no matter who built them and where.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>