### PR TITLE
net: lib: Fix MDNS RESPONDER

### DIFF
--- a/subsys/net/lib/CMakeLists.txt
+++ b/subsys/net/lib/CMakeLists.txt
@@ -5,11 +5,16 @@ add_subdirectory_if_kconfig(coap)
 add_subdirectory_if_kconfig(lwm2m)
 add_subdirectory_if_kconfig(socks)
 add_subdirectory_if_kconfig(sntp)
-add_subdirectory_ifdef(CONFIG_DNS_RESOLVER      dns)
 add_subdirectory_ifdef(CONFIG_MQTT_LIB          mqtt)
 add_subdirectory_ifdef(CONFIG_NET_CONFIG_SETTINGS config)
 add_subdirectory_ifdef(CONFIG_NET_SOCKETS       sockets)
 add_subdirectory_ifdef(CONFIG_TLS_CREDENTIALS   tls_credentials)
+
+if (CONFIG_DNS_RESOLVER
+    OR CONFIG_MDNS_RESPONDER
+    OR CONFIG_LLMNR_RESPONDER)
+  add_subdirectory(dns)
+endif()
 
 if(CONFIG_HTTP_PARSER_URL
     OR CONFIG_HTTP_PARSER)

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -154,6 +154,9 @@ static void add_answer(struct net_buf *query, enum dns_rr_type qtype,
 		*prev = strlen(prev) - 1;
 	}
 
+	/* terminator byte (0x00) */
+	query->len += 1;
+
 	offset = DNS_MSG_HEADER_SIZE + query->len;
 	UNALIGNED_PUT(htons(qtype), (u16_t *)(query->data+offset));
 


### PR DESCRIPTION
1. Fix malformed MDNS response

2. The dns directory was not included when building with
DNS_RESONDER or LLMR_RESPONDER configs.