### PR TITLE
net/pkt: Redefine the necessary fifo attribute

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -58,8 +58,18 @@ struct net_pkt_cursor {
  * net_pkt_clone() function.
  */
 struct net_pkt {
-	/** Internal variable that is used when packet is sent */
-	struct k_work work;
+	union {
+		/** Internal variable that is used when packet is sent
+		 * or received.
+		 */
+		struct k_work work;
+		/** Socket layer will queue received net_pkt into a k_fifo.
+		 * Since this happens after consuming net_pkt's k_work on
+		 * RX path, it is then fine to have both attributes sharing
+		 * the same memory area.
+		 */
+		int sock_recv_fifo;
+	};
 
 	/** Slab pointer from where it belongs to */
 	struct k_mem_slab *slab;


### PR DESCRIPTION
commit 79672d16 was missing the fact socket layer is putting net_pkt
into a k_fifo. However, it's on receiving side only: at this point the
k_fifo_put is using the k_work area which is then useless at this
point Thus why it did not break anything, as k_fifo only needs 4 bytes
while the k_work attribute takes 12 bytes.

Thus adding a union on the k_work attribute with another new attribute
that describes the behavior.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>