### PR TITLE
boards: nucleo_wb55rg: configure LPUART

### DIFF
--- a/boards/arm/nucleo_wb55rg/Kconfig.defconfig
+++ b/boards/arm/nucleo_wb55rg/Kconfig.defconfig
@@ -26,9 +26,9 @@ endif # SERIAL
 
 if BT_DEBUG_MONITOR
 
-config UART_1
+config LPUART_1
 	default y
 
-endif
+endif # BT_DEBUG_MONITOR
 
 endif # BOARD_NUCLEO_WB55RG

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -12,8 +12,9 @@
 	compatible = "st,stm32wb55rg-nucleo", "st,stm32wb55rg";
 
 	chosen {
-		zephyr,console = &lpuart1;
+		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;
+		zephyr,bt-mon-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/drivers/serial/Kconfig.stm32
+++ b/drivers/serial/Kconfig.stm32
@@ -97,7 +97,7 @@ config UART_10
 	  Enable support for UART10 port in the driver.
 	  Say y here if you want to use UART10 device.
 
-if SOC_SERIES_STM32L0X || SOC_SERIES_STM32L4X
+if SOC_SERIES_STM32L0X || SOC_SERIES_STM32L4X || SOC_SERIES_STM32WBX
 
 # --- low power port 1 ---
 
@@ -107,6 +107,6 @@ config LPUART_1
 	  Enable support for LPUART1 port in the driver.
 	  Say y here if you want to use LPUART1 device.
 
-endif # SOC_SERIES_STM32L0X || SOC_SERIES_STM32L4X
+endif # SOC_SERIES_STM32L0X || SOC_SERIES_STM32L4X || SOC_SERIES_STM32WBX
 
 endif # UART_STM32


### PR DESCRIPTION
Configure LPUART as btmon interface and
re-instantiate usart1 as console output (using ST-Link VCP)


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>