### PR TITLE
counter: minor improvements in test and nRF RTC driver

### DIFF
--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -18,6 +18,11 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 
+#define ERR(...) LOG_INST_ERR(get_nrfx_config(dev)->log, __VA_ARGS__)
+#define WRN(...) LOG_INST_WRN(get_nrfx_config(dev)->log, __VA_ARGS__)
+#define INF(...) LOG_INST_INF(get_nrfx_config(dev)->log, __VA_ARGS__)
+#define DBG(...) LOG_INST_DBG(get_nrfx_config(dev)->log, __VA_ARGS__)
+
 #define COUNTER_MAX_TOP_VALUE RTC_COUNTER_COUNTER_Msk
 
 #define CC_TO_ID(cc) ((cc) - 1)
@@ -113,8 +118,7 @@ static int counter_nrfx_set_alarm(struct device *dev, u8_t chan_id,
 		/* From Product Specification: If a CC register value is 0 when
 		 * a CLEAR task is set, this will not trigger a COMPARE event.
 		 */
-		LOG_INST_INF(nrfx_config->log,
-				"Attempt to set CC to 0, delayed to 1.");
+		INF("Attempt to set CC to 0, delayed to 1.");
 		cc_val++;
 	}
 	nrfx_rtc_cc_set(rtc, ID_TO_CC(chan_id), cc_val, true);
@@ -228,8 +232,7 @@ static int ppi_setup(struct device *dev)
 #ifdef DPPI_PRESENT
 	result = nrfx_dppi_channel_alloc(&data->ppi_ch);
 	if (result != NRFX_SUCCESS) {
-		LOG_INST_ERR(nrfx_config->log,
-			     "Failed to allocate PPI channel.");
+		ERR("Failed to allocate PPI channel.");
 		return -ENODEV;
 	}
 
@@ -245,8 +248,7 @@ static int ppi_setup(struct device *dev)
 
 	result = nrfx_ppi_channel_alloc(&data->ppi_ch);
 	if (result != NRFX_SUCCESS) {
-		LOG_INST_ERR(nrfx_config->log,
-			     "Failed to allocate PPI channel.");
+		ERR("Failed to allocate PPI channel.");
 		return -ENODEV;
 	}
 
@@ -277,7 +279,7 @@ static int init_rtc(struct device *dev,
 	nrfx_err_t result = nrfx_rtc_init(rtc, config, handler);
 
 	if (result != NRFX_SUCCESS) {
-		LOG_INST_ERR(nrfx_config->log, "Failed to initialize device.");
+		ERR("Failed to initialize device.");
 		return -EBUSY;
 	}
 
@@ -288,7 +290,7 @@ static int init_rtc(struct device *dev,
 
 	data->top = COUNTER_MAX_TOP_VALUE;
 
-	LOG_INST_DBG(nrfx_config->log, "Initialized");
+	DBG("Initialized");
 	return 0;
 }
 

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -93,10 +93,11 @@ static void counter_tear_down_instance(const char *dev_name)
 
 	err = counter_set_top_value(dev, counter_get_max_top_value(dev),
 				    NULL, NULL);
-	zassert_equal(0, err, "Setting top value to default failed\n");
+	zassert_equal(0, err,
+			"%s: Setting top value to default failed", dev_name);
 
 	err = counter_stop(dev);
-	zassert_equal(0, err, "Counter failed to stop\n");
+	zassert_equal(0, err, "%s: Counter failed to stop", dev_name);
 
 }
 
@@ -106,12 +107,15 @@ static void test_all_instances(counter_test_func_t func)
 		counter_setup_instance(devices[i]);
 		func(devices[i]);
 		counter_tear_down_instance(devices[i]);
+		/* Allow logs to be printed. */
+		k_sleep(100);
 	}
 }
 
 static void top_handler(struct device *dev, void *user_data)
 {
-	zassert_true(user_data == exp_user_data, "Unexpected callback\n");
+	zassert_true(user_data == exp_user_data,
+			"%s: Unexpected callback", dev->config->name);
 	top_cnt++;
 }
 
@@ -129,23 +133,23 @@ void test_set_top_value_with_alarm_instance(const char *dev_name)
 	ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
 
 	err = counter_start(dev);
-	zassert_equal(0, err, "Counter failed to start\n");
+	zassert_equal(0, err, "%s: Counter failed to start", dev_name);
 
 	k_busy_wait(5000);
 
 	cnt = counter_read(dev);
-	zassert_true(cnt > 0, "Counter should progress (dev:%s)\n", dev_name);
+	zassert_true(cnt > 0, "%s: Counter should progress", dev_name);
 
 	err = counter_set_top_value(dev, ticks, top_handler, exp_user_data);
-	zassert_equal(0, err, "Counter failed to set top value (dev:%s)\n",
+	zassert_equal(0, err, "%s: Counter failed to set top value",
 			dev_name);
 
 	k_busy_wait(5.2*COUNTER_PERIOD_US);
 
 	tmp_top_cnt = top_cnt; /* to avoid passing volatile to the macro */
 	zassert_true(tmp_top_cnt == 5U,
-			"Unexpected number of turnarounds (%d) (dev: %s).\n",
-			tmp_top_cnt, dev_name);
+			"%s: Unexpected number of turnarounds (%d).",
+			dev_name, tmp_top_cnt);
 }
 
 void test_set_top_value_with_alarm(void)
@@ -161,7 +165,13 @@ void test_set_top_value_with_alarm(void)
 static void alarm_handler(struct device *dev, u8_t chan_id, u32_t counter,
 			  void *user_data)
 {
-	zassert_true(&alarm_cfg == user_data, "Unexpected callback\n");
+	u32_t now = counter_read(dev);
+
+	zassert_true(&alarm_cfg == user_data,
+			"%s: Unexpected callback", dev->config->name);
+	zassert_true(now >= counter,
+			"%s: Alarm (%d) too early now:%d.",
+			dev->config->name, counter);
 	alarm_cnt++;
 }
 
@@ -188,42 +198,46 @@ void test_single_shot_alarm_instance(const char *dev_name, bool set_top)
 	}
 
 	err = counter_start(dev);
-	zassert_equal(0, err, "Counter failed to start\n");
+	zassert_equal(0, err, "%s: Counter failed to start", dev_name);
 
 	if (set_top) {
 		err = counter_set_top_value(dev, ticks, top_handler,
 					    exp_user_data);
 
-		zassert_equal(0, err, "Counter failed to set top value\n");
+		zassert_equal(0, err,
+			     "%s: Counter failed to set top value", dev_name);
 
 		alarm_cfg.ticks = ticks + 1;
 		err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
 		zassert_equal(-EINVAL, err,
-			      "Counter should return error because ticks"
-			      " exceeded the limit set alarm\n");
+			      "%s: Counter should return error because ticks"
+			      " exceeded the limit set alarm", dev_name);
 		alarm_cfg.ticks = ticks - 1;
 	}
 
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
-	zassert_equal(0, err, "Counter set alarm failed\n");
+	zassert_equal(0, err, "%s: Counter set alarm failed", dev_name);
 
 	k_busy_wait(1.5*counter_ticks_to_us(dev, ticks));
 	tmp_alarm_cnt = alarm_cnt; /* to avoid passing volatile to the macro */
-	zassert_equal(1, tmp_alarm_cnt, "Expecting alarm callback\n");
+	zassert_equal(1, tmp_alarm_cnt,
+			"%s: Expecting alarm callback", dev_name);
 
 	k_busy_wait(1.5*counter_ticks_to_us(dev, ticks));
 	tmp_alarm_cnt = alarm_cnt; /* to avoid passing volatile to the macro */
-	zassert_equal(1, tmp_alarm_cnt, "Expecting alarm callback\n");
+	zassert_equal(1, tmp_alarm_cnt,
+			"%s: Expecting alarm callback", dev_name);
 
 	err = counter_cancel_channel_alarm(dev, 0);
-	zassert_equal(0, err, "Counter disabling alarm failed\n");
+	zassert_equal(0, err, "%s: Counter disabling alarm failed", dev_name);
 
 	err = counter_set_top_value(dev, counter_get_max_top_value(dev),
 				    NULL, NULL);
-	zassert_equal(0, err, "Setting top value to default failed\n");
+	zassert_equal(0, err,
+			"%s: Setting top value to default failed", dev_name);
 
 	err = counter_stop(dev);
-	zassert_equal(0, err, "Counter failed to stop\n");
+	zassert_equal(0, err, "%s: Counter failed to stop", dev_name);
 }
 
 void test_single_shot_alarm_notop_instance(const char *dev_name)
@@ -294,33 +308,37 @@ void test_multiple_alarms_instance(const char *dev_name)
 	}
 
 	err = counter_start(dev);
-	zassert_equal(0, err, "Counter failed to start\n");
+	zassert_equal(0, err, "%s: Counter failed to start", dev_name);
 
 	err = counter_set_top_value(dev, ticks, top_handler, exp_user_data);
-	zassert_equal(0, err, "Counter failed to set top value\n");
+	zassert_equal(0, err,
+			"%s: Counter failed to set top value", dev_name);
 
 	k_busy_wait(1.4*counter_ticks_to_us(dev, alarm_cfg.ticks));
 
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
-	zassert_equal(0, err, "Counter set alarm failed\n");
+	zassert_equal(0, err, "%s: Counter set alarm failed", dev_name);
 
 	err = counter_set_channel_alarm(dev, 1, &alarm_cfg2);
-	zassert_equal(0, err, "Counter set alarm failed\n");
+	zassert_equal(0, err, "%s: Counter set alarm failed", dev_name);
 
 	k_busy_wait(1.2*counter_ticks_to_us(dev, ticks * 2U));
 	tmp_alarm_cnt = alarm_cnt; /* to avoid passing volatile to the macro */
-	zassert_equal(2, tmp_alarm_cnt, "Counter set alarm failed\n");
+	zassert_equal(2, tmp_alarm_cnt, "%s: Counter set alarm failed",
+			dev_name);
 	zassert_equal(&alarm_cfg2, clbk_data[0],
-			"Expected different order or callbacks\n");
+			"%s: Expected different order or callbacks",
+			dev_name);
 	zassert_equal(&alarm_cfg, clbk_data[1],
-			"Expected different order or callbacks\n");
+			"%s: Expected different order or callbacks",
+			dev_name);
 
 	/* tear down */
 	err = counter_cancel_channel_alarm(dev, 0);
-	zassert_equal(0, err, "Counter disabling alarm failed\n");
+	zassert_equal(0, err, "%s: Counter disabling alarm failed", dev_name);
 
 	err = counter_cancel_channel_alarm(dev, 1);
-	zassert_equal(0, err, "Counter disabling alarm failed\n");
+	zassert_equal(0, err, "%s: Counter disabling alarm failed", dev_name);
 }
 
 void test_multiple_alarms(void)
@@ -328,7 +346,7 @@ void test_multiple_alarms(void)
 	test_all_instances(test_multiple_alarms_instance);
 }
 
-void test_all_channels_instance(const char *str)
+void test_all_channels_instance(const char *dev_name)
 {
 	struct device *dev;
 	int err;
@@ -339,7 +357,7 @@ void test_all_channels_instance(const char *str)
 	u32_t ticks;
 	u32_t tmp_alarm_cnt;
 
-	dev = device_get_binding(str);
+	dev = device_get_binding(dev_name);
 	ticks = counter_us_to_ticks(dev, COUNTER_PERIOD_US);
 
 	alarm_cfgs.absolute = false;
@@ -348,7 +366,7 @@ void test_all_channels_instance(const char *str)
 	alarm_cfgs.user_data = NULL;
 
 	err = counter_start(dev);
-	zassert_equal(0, err, "Counter failed to start");
+	zassert_equal(0, err, "%s: Counter failed to start", dev_name);
 
 	for (int i = 0; i < n; i++) {
 		err = counter_set_channel_alarm(dev, i, &alarm_cfgs);
@@ -358,23 +376,25 @@ void test_all_channels_instance(const char *str)
 			limit_reached = true;
 		} else {
 			zassert_equal(0, 1,
-					"Unexpected error on setting alarm");
+			   "%s: Unexpected error on setting alarm", dev_name);
 		}
 	}
 
 	k_busy_wait(1.5*counter_ticks_to_us(dev, ticks));
 	tmp_alarm_cnt = alarm_cnt; /* to avoid passing volatile to the macro */
-	zassert_equal(nchan, tmp_alarm_cnt, "Expecting alarm callback\n");
+	zassert_equal(nchan, tmp_alarm_cnt,
+			"%s: Expecting alarm callback", dev_name);
 
 	for (int i = 0; i < nchan; i++) {
 		err = counter_cancel_channel_alarm(dev, i);
-		zassert_equal(0, err, "Unexpected error on disabling alarm");
+		zassert_equal(0, err,
+			"%s: Unexpected error on disabling alarm", dev_name);
 	}
 
 	for (int i = nchan; i < n; i++) {
 		err = counter_cancel_channel_alarm(dev, i);
 		zassert_equal(-ENOTSUP, err,
-				"Unexpected error on disabling alarm\n");
+			"%s: Unexpected error on disabling alarm", dev_name);
 	}
 }
 


### PR DESCRIPTION
**tests: drivers: counter: Add device name to zassert strings**
Prefix strings printed on zassert failure with device name.

**drivers: counter: Add helper macros for logging**
Added macros to simplify logging in the counter driver.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>