### PR TITLE
boards: disco_l475_iot1: create .dtsi connector file

### DIFF
--- a/boards/arm/disco_l475_iot1/arduino_r3_connector.dtsi
+++ b/boards/arm/disco_l475_iot1/arduino_r3_connector.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioc 5 0>,	/* A0 */
+			   <1 0 &gpioc 4 0>,	/* A1 */
+			   <2 0 &gpioc 3 0>,	/* A2 */
+			   <3 0 &gpioc 2 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 1 0>,	/* D0 */
+			   <7 0 &gpioa 0 0>,	/* D1 */
+			   <8 0 &gpiod 14 0>,	/* D2 */
+			   <9 0 &gpiob 0 0>,	/* D3 */
+			   <10 0 &gpioa 3 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 1 0>,	/* D6 */
+			   <13 0 &gpioa 4 0>,	/* D7 */
+			   <14 0 &gpiob 2 0>,	/* D8 */
+			   <15 0 &gpioa 15 0>,	/* D9 */
+			   <16 0 &gpioa 2 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};
+arduino_serial: &uart4 {};

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -6,6 +6,8 @@
 
 /dts-v1/;
 #include <st/l4/stm32l475Xg.dtsi>
+#include "arduino_r3_connector.dtsi"
+
 
 / {
 	model = "STMicroelectronics B-L475E-IOT01Ax board";
@@ -45,38 +47,7 @@
 		sw0 = &user_button;
 		eswifi0 = &wifi0;
 	};
-
-	arduino_header: connector {
-		compatible = "arduino-header-r3";
-		#gpio-cells = <2>;
-		gpio-map = <0 0 &gpioc 5 0>,	/* A0 */
-			   <1 0 &gpioc 4 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpioc 2 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 1 0>,	/* D0 */
-			   <7 0 &gpioa 0 0>,	/* D1 */
-			   <8 0 &gpiod 14 0>,	/* D2 */
-			   <9 0 &gpiob 0 0>,	/* D3 */
-			   <10 0 &gpioa 3 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 1 0>,	/* D6 */
-			   <13 0 &gpioa 4 0>,	/* D7 */
-			   <14 0 &gpiob 2 0>,	/* D8 */
-			   <15 0 &gpioa 15 0>,	/* D9 */
-			   <16 0 &gpioa 2 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
-	};
 };
-
-arduino_i2c: &i2c1 {};
-arduino_spi: &spi1 {};
-arduino_serial: &uart4 {};
 
 &usart1 {
 	current-speed = <115200>;


### PR DESCRIPTION
Create a dedicated connector file to hold arduino connector
information for disco_l475_iot board.
This should enhance board dts file readability.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>