### PR TITLE
Bluetooth: gatt: Fix infinite read_by_uuid procedure

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2616,6 +2616,14 @@ static void parse_read_by_uuid(struct bt_conn *conn,
 		if (rsp->len > length) {
 			break;
 		}
+
+		/* Stop if it's the last handle to be read */
+		if (params->by_uuid.start_handle == params->by_uuid.end_handle) {
+			params->func(conn, 0, params, NULL, 0);
+			return;
+		}
+
+		params->by_uuid.start_handle++;
 	}
 
 	/* Continue reading the attributes */


### PR DESCRIPTION
The attribute handle used to read next attribute has to be incremented
to not loop reading the same attribute.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>