### PR TITLE
Arch arm main thread init cleanup

### DIFF
--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -74,15 +74,9 @@ z_arch_switch_to_main_thread(struct k_thread *main_thread,
 	/* get high address of the stack, i.e. its start (stack grows down) */
 	char *start_of_main_stack;
 
-#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT) && \
-	defined(CONFIG_USERSPACE)
-	start_of_main_stack =
-		Z_THREAD_STACK_BUFFER(main_stack) + main_stack_size -
-		MPU_GUARD_ALIGN_AND_SIZE;
-#else
 	start_of_main_stack =
 		Z_THREAD_STACK_BUFFER(main_stack) + main_stack_size;
-#endif
+
 	start_of_main_stack = (char *)STACK_ROUND_DOWN(start_of_main_stack);
 
 #ifdef CONFIG_TRACING

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -303,7 +303,7 @@ static void init_idle_thread(struct k_thread *thr, k_thread_stack_t *stack)
 			  K_LOWEST_THREAD_PRIO, K_ESSENTIAL, IDLE_THREAD_NAME);
 	z_mark_thread_as_started(thr);
 }
-#endif
+#endif /* CONFIG_MULTITHREADING */
 
 /**
  *
@@ -347,7 +347,7 @@ static void prepare_multithreading(struct k_thread *dummy_thread)
 #ifdef CONFIG_USERSPACE
 	dummy_thread->mem_domain_info.mem_domain = 0;
 #endif
-#endif
+#endif /* CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN */
 
 	/* _kernel.ready_q is all zeroes */
 	z_sched_init();
@@ -374,11 +374,9 @@ static void prepare_multithreading(struct k_thread *dummy_thread)
 	z_mark_thread_as_started(_main_thread);
 	z_ready_thread(_main_thread);
 
-#ifdef CONFIG_MULTITHREADING
 	init_idle_thread(_idle_thread, _idle_stack);
 	_kernel.cpus[0].idle_thread = _idle_thread;
 	sys_trace_thread_create(_idle_thread);
-#endif
 
 #if defined(CONFIG_SMP) && CONFIG_MP_NUM_CPUS > 1
 	init_idle_thread(_idle_thread1, _idle_stack1);

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -411,7 +411,8 @@ static void prepare_multithreading(struct k_thread *dummy_thread)
 static void switch_to_main_thread(void)
 {
 #ifdef CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN
-	z_arch_switch_to_main_thread(_main_thread, _main_stack, MAIN_STACK_SIZE,
+	z_arch_switch_to_main_thread(_main_thread, _main_stack,
+				    K_THREAD_STACK_SIZEOF(_main_stack),
 				    bg_thread_main);
 #else
 	/*


### PR DESCRIPTION
Two patches for kernel/init.c
- a trivial removal of CONFIG_MULTITHREADING
- a forcing of using K_THREAD_STACK_SIZEOF in switch_to_main_thread

It's a cleanup - no behavioral changes.