### PR TITLE
qmsi: set type to boolean when selecting QMSI

### DIFF
--- a/soc/arc/quark_se_c1000_ss/Kconfig.defconfig
+++ b/soc/arc/quark_se_c1000_ss/Kconfig.defconfig
@@ -29,7 +29,7 @@ config HARVARD
 	default n
 
 config QMSI
-	default y
+	def_bool y
 
 if COUNTER
 

--- a/soc/x86/intel_quark/quark_d2000/Kconfig.defconfig.series
+++ b/soc/x86/intel_quark/quark_d2000/Kconfig.defconfig.series
@@ -31,7 +31,7 @@ config LOAPIC_TIMER_IRQ_PRIORITY
 	default 2
 
 config QMSI
-	default y
+	def_bool y
 
 if PINMUX
 config PINMUX_QMSI

--- a/soc/x86/intel_quark/quark_se/Kconfig.defconfig.series
+++ b/soc/x86/intel_quark/quark_se/Kconfig.defconfig.series
@@ -28,7 +28,7 @@ config LOAPIC_TIMER_IRQ
 	default 64 if LOAPIC_TIMER
 
 config QMSI
-	default y
+	def_bool y
 
 if PWM
 config PWM_QMSI


### PR DESCRIPTION
If the QMSI is not configured in (in the west manifest) we get kconfig
whitelisting errors because the type is declared within the module
itself.
Change default to def_bool to set the type.