### PR TITLE
Fix reschedule so that it won't break nested locks

### DIFF
--- a/arch/posix/include/posix_soc_if.h
+++ b/arch/posix/include/posix_soc_if.h
@@ -37,6 +37,15 @@ void posix_irq_full_unlock(void);
 int  posix_get_current_irq(void);
 /* irq_offload() from irq_offload.h must also be defined by the SOC or board */
 
+/**
+ * Returns true if interrupts were unlocked prior to the
+ * z_arch_irq_lock() call that produced the key argument.
+ */
+static inline bool z_arch_irq_unlocked(unsigned int key)
+{
+	return key == false;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/arch/x86_64/include/kernel_arch_func.h
+++ b/arch/x86_64/include/kernel_arch_func.h
@@ -42,6 +42,15 @@ static inline void z_arch_irq_unlock(unsigned int key)
 	}
 }
 
+/**
+ * Returns true if interrupts were unlocked prior to the
+ * z_arch_irq_lock() call that produced the key argument.
+ */
+static inline bool z_arch_irq_unlocked(unsigned int key)
+{
+	return (key & 0x200) != 0;
+}
+
 static inline void arch_nop(void)
 {
 	__asm__ volatile("nop");

--- a/include/arch/arc/v2/irq.h
+++ b/include/arch/arc/v2/irq.h
@@ -127,6 +127,19 @@ static ALWAYS_INLINE void z_arch_irq_unlock(unsigned int key)
 	__asm__ volatile("seti %0" : : "ir"(key) : "memory");
 }
 
+/**
+ * Returns true if interrupts were unlocked prior to the
+ * z_arch_irq_lock() call that produced the key argument.
+ */
+static ALWAYS_INLINE bool z_arch_irq_unlocked(unsigned int key)
+{
+	/* ARC irq lock uses instruction "clri r0",
+	 * r0 ==  {26’d0, 1’b1, STATUS32.IE, STATUS32.E[3:0] }
+	 * bit4 is used to record IE (Interrupt Enable) bit
+	 */
+	return (key & 0x10)  ==  0x10;
+}
+
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/include/arch/arm/cortex_m/asm_inline_gcc.h
+++ b/include/arch/arm/cortex_m/asm_inline_gcc.h
@@ -184,6 +184,15 @@ static ALWAYS_INLINE void z_arch_irq_unlock(unsigned int key)
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 }
 
+/**
+ * Returns true if interrupts were unlocked prior to the
+ * z_arch_irq_lock() call that produced the key argument.
+ */
+static ALWAYS_INLINE bool z_arch_irq_unlocked(unsigned int key)
+{
+	/* This convention works for both PRIMASK and BASEPRI */
+	return key == 0;
+}
 
 #endif /* _ASMLANGUAGE */
 

--- a/include/arch/nios2/arch.h
+++ b/include/arch/nios2/arch.h
@@ -124,6 +124,15 @@ static ALWAYS_INLINE void z_arch_irq_unlock(unsigned int key)
 #endif
 }
 
+/**
+ * Returns true if interrupts were unlocked prior to the
+ * z_arch_irq_lock() call that produced the key argument.
+ */
+static ALWAYS_INLINE bool z_arch_irq_unlocked(unsigned int key)
+{
+	return key & 1;
+}
+
 void z_arch_irq_enable(unsigned int irq);
 void z_arch_irq_disable(unsigned int irq);
 

--- a/include/arch/riscv32/arch.h
+++ b/include/arch/riscv32/arch.h
@@ -116,6 +116,22 @@ static ALWAYS_INLINE void z_arch_irq_unlock(unsigned int key)
 }
 
 /**
+ * Returns true if interrupts were unlocked prior to the
+ * z_arch_irq_lock() call that produced the key argument.
+ */
+static ALWAYS_INLINE bool z_arch_irq_unlocked(unsigned int key)
+{
+	/* FIXME: looking at z_arch_irq_lock, this should be reducable
+	 * to just testing that key is nonzero (because it should only
+	 * have the single bit set).  But there is a mask applied to
+	 * the argument in z_arch_irq_unlock() that has me worried
+	 * that something elseswhere might try to set a bit?  Do it
+	 * the safe way for now.
+	 */
+	return (key & SOC_MSTATUS_IEN) == SOC_MSTATUS_IEN;
+}
+
+/**
  * @brief Explicitly nop operation.
  */
 static ALWAYS_INLINE void arch_nop(void)

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -454,6 +454,15 @@ static ALWAYS_INLINE void z_arch_irq_unlock(unsigned int key)
 }
 
 /**
+ * Returns true if interrupts were unlocked prior to the
+ * z_arch_irq_lock() call that produced the key argument.
+ */
+static ALWAYS_INLINE bool z_arch_irq_unlocked(unsigned int key)
+{
+	return (key & 0x200) != 0;
+}
+
+/**
  * @brief Explicitly nop operation.
  */
 static ALWAYS_INLINE void arch_nop(void)

--- a/include/arch/xtensa/xtensa_irq.h
+++ b/include/arch/xtensa/xtensa_irq.h
@@ -73,6 +73,15 @@ static ALWAYS_INLINE void z_arch_irq_unlock(unsigned int key)
 	XTOS_RESTORE_INTLEVEL(key);
 }
 
+/**
+ * Returns true if interrupts were unlocked prior to the
+ * z_arch_irq_lock() call that produced the key argument.
+ */
+static ALWAYS_INLINE bool z_arch_irq_unlocked(unsigned int key)
+{
+	return (key & 0xf) == 0; /* INTLEVEL field */
+}
+
 #include <irq.h>
 
 #endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_XTENSA_IRQ_H_ */

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4522,7 +4522,7 @@ extern void z_sys_power_save_idle_exit(s32_t ticks);
 #define z_except_reason(reason) do { \
 		printk("@ %s:%d:\n", __FILE__,  __LINE__); \
 		z_NanoFatalErrorHandler(reason, &_default_esf); \
-		CODE_UNREACHABLE; \
+		k_thread_abort(k_current_get()); \
 	} while (false)
 
 #endif /* _ARCH__EXCEPT */

--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -40,6 +40,20 @@ static void offload_function(void *param)
  */
 void test_irq_offload(void)
 {
+	/* Simple validation of nested locking. */
+	unsigned int key1, key2;
+
+	key1 = z_arch_irq_lock();
+	zassert_true(z_arch_irq_unlocked(key1),
+		     "IRQs should have been unlocked, but key is 0x%x\n",
+		     key1);
+	key2 = z_arch_irq_lock();
+	zassert_false(z_arch_irq_unlocked(key2),
+		      "IRQs should have been locked, but key is 0x%x\n",
+		      key2);
+	z_arch_irq_unlock(key2);
+	z_arch_irq_unlock(key1);
+
 	/**TESTPOINT: Offload to IRQ context*/
 	irq_offload(offload_function, (void *)SENTINEL_VALUE);
 

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -140,24 +140,17 @@ void blow_up_stack(void)
 
 void stack_sentinel_timer(void)
 {
-	u32_t cur_tick;
-
-	/* Test that stack overflow check due to timer interrupt works */
-	blow_up_stack();
-	TC_PRINT("waiting for tick advance...\n");
-
-	/* This test has tickless kernel disabled, z_tick_get_32() returns
-	 * the current tick count without trying to offset it by checking
-	 * time elapsed in the driver since last update
+	/* We need to guarantee that we receive an interrupt, so set a
+	 * k_timer and spin until we die.  Spinning alone won't work
+	 * on a tickless kernel.
 	 */
-	cur_tick = z_tick_get_32();
+	struct k_timer timer;
 
-	while (cur_tick == z_tick_get_32()) {
-		/* spin */
+	blow_up_stack();
+	k_timer_init(&timer, NULL, NULL);
+	k_timer_start(&timer, 1, 0);
+	while (true) {
 	}
-
-	TC_ERROR("should never see this\n");
-	rv = TC_FAIL;
 }
 
 void stack_sentinel_swap(void)


### PR DESCRIPTION
First cut at a fix for #16273.  I managed to convince myself that the original suggested fix (check interrupt state always and only ever call swap when an irq_unlock of the current key would unmask interrupts) was correct in all cases, and that the original behavior can only be seen as a bug.  My concerns about compatible behavior live on only as an editorial comment in the commit message.

NOTE THAT THIS CAN'T MERGE YET.  The new z_arch_irq_unlocked() predicate isn't implemented yet on ARC, because I can't find docs and don't want to write the code blindly to simulator behavior (and, to be fair, don't want to go through the trouble of getting nsim working).  Someone expert (@ruuddw? @vonhust?) should really look at this.  As it ARC code will build and match the pre-existing (buggy!) behavior, but the new test case in kernel/common will fail by design.