### PR TITLE
arch: arm: userspace: don't subtract MPU guard from top of stack

### DIFF
--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -90,10 +90,6 @@ SECTION_FUNC(TEXT,z_arm_userspace_enter)
     ldr r0, [ip]
     ldr ip, [ip, #4]
 
-#ifdef CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
-    /* Guard is taken out of size, so adjust beginning and size of stack */
-    subs ip, #MPU_GUARD_ALIGN_AND_SIZE
-#endif
 
     /* push args to stack */
     push {r0,r1,r2,r3,ip,lr}


### PR DESCRIPTION
ip register holds the stack_info.size (it is passed as argument
into z_arch_user_mode_enter(.)). We trust that the value of
stack_info.size contains the accurate size of the writable
stack buffer, above stack_info.start (as specified in kernel.h).
Therefore, we do not need to subtract any bytes for the MPU
stack guard. This allows us to clean-up one more occurrence of
CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT in userspace.S.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>