### PR TITLE
Add LaunchPad connector

### DIFF
--- a/boards/arm/cc1352r1_launchxl/boosterpack_connector.dtsi
+++ b/boards/arm/cc1352r1_launchxl/boosterpack_connector.dtsi
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Brett Witherspoon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	boosterpack_header: connector {
+		compatible = "ti,boosterpack-header";
+		#gpio-cells = <2>;
+		gpio-map = <2 0 &gpio0 23 0>,
+			   <3 0 &gpio0 12 0>,
+			   <4 0 &gpio0 13 0>,
+			   <5 0 &gpio0 22 0>,
+			   <6 0 &gpio0 24 0>,
+			   <7 0 &gpio0 10 0>,
+			   <8 0 &gpio0 21 0>,
+			   <9 0 &gpio0 4 0>,
+			   <10 0 &gpio0 5 0>,
+			   <12 0 &gpio0 14 0>,
+			   <13 0 &gpio0 15 0>,
+			   <14 0 &gpio0 8 0>,
+			   <15 0 &gpio0 9 0>,
+			   <18 0 &gpio0 11 0>,
+			   <19 0 &gpio0 3 0>,
+			   <23 0 &gpio0 25 0>,
+			   <24 0 &gpio0 26 0>,
+			   <25 0 &gpio0 27 0>,
+			   <26 0 &gpio0 28 0>,
+			   <27 0 &gpio0 29 0>,
+			   <28 0 &gpio0 30 0>,
+			   <31 0 &gpio0 17 0>,
+			   <32 0 &gpio0 16 0>,
+			   <36 0 &gpio0 18 0>,
+			   <37 0 &gpio0 19 0>,
+			   <38 0 &gpio0 20 0>,
+			   <39 0 &gpio0 6 0>,
+			   <40 0 &gpio0 7 0>;
+	};
+};
+
+boosterpack_i2c: &i2c0 {};
+boosterpack_spi: &spi0 {};
+boosterpack_serial: &uart0 {};

--- a/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
+++ b/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <ti/cc1352r.dtsi>
+#include "boosterpack_connector.dtsi"
 
 #define BTN_GPIO_FLAGS (GPIO_INT_ACTIVE_LOW | GPIO_PUD_PULL_UP)
 

--- a/boards/arm/cc26x2r1_launchxl/boosterpack_connector.dtsi
+++ b/boards/arm/cc26x2r1_launchxl/boosterpack_connector.dtsi
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019 Brett Witherspoon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	boosterpack_header: connector {
+		compatible = "ti,boosterpack-header";
+		#gpio-cells = <2>;
+		gpio-map = <2 0 &gpio0 23 0>,
+			   <3 0 &gpio0 2 0>,
+			   <4 0 &gpio0 3 0>,
+			   <5 0 &gpio0 22 0>,
+			   <6 0 &gpio0 24 0>,
+			   <7 0 &gpio0 10 0>,
+			   <8 0 &gpio0 21 0>,
+			   <9 0 &gpio0 4 0>,
+			   <10 0 &gpio0 5 0>,
+			   <11 0 &gpio0 15 0>,
+			   <12 0 &gpio0 14 0>,
+			   <13 0 &gpio0 13 0>,
+			   <14 0 &gpio0 8 0>,
+			   <15 0 &gpio0 9 0>,
+			   <18 0 &gpio0 11 0>,
+			   <19 0 &gpio0 12 0>,
+			   <23 0 &gpio0 25 0>,
+			   <24 0 &gpio0 26 0>,
+			   <25 0 &gpio0 27 0>,
+			   <26 0 &gpio0 28 0>,
+			   <27 0 &gpio0 29 0>,
+			   <28 0 &gpio0 30 0>,
+			   <29 0 &gpio0 0 0>,
+			   <30 0 &gpio0 1 0>,
+			   <31 0 &gpio0 17 0>,
+			   <32 0 &gpio0 16 0>,
+			   <36 0 &gpio0 18 0>,
+			   <37 0 &gpio0 19 0>,
+			   <38 0 &gpio0 20 0>,
+			   <39 0 &gpio0 6 0>,
+			   <40 0 &gpio0 7 0>;
+	};
+};
+
+boosterpack_i2c: &i2c0 {};
+boosterpack_spi: &spi0 {};
+boosterpack_serial: &uart0 {};

--- a/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
+++ b/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <ti/cc2652r.dtsi>
+#include "boosterpack_connector.dtsi"
 
 #define BTN_GPIO_FLAGS (GPIO_INT_ACTIVE_LOW | GPIO_PUD_PULL_UP)
 

--- a/dts/bindings/gpio/ti,boosterpack-header.yaml
+++ b/dts/bindings/gpio/ti,boosterpack-header.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) 2019 Brett Witherspoon
+# SPDX-License-Identifier: Apache-2.0
+
+title: TI BoosterPack GPIO header
+
+description: |
+    GPIO pins exposed as BoosterPack headers on TI LaunchPads.
+
+    BoosterPack plug-in modules are available in 20 and 40 pin variants. The
+    20 pin variant has two 10 x 1 pin headers and the 40 pin variant has two
+    10 x 2 pin headers. Both variants are compatible and stackable.
+
+    The pins of the 20 pin variant and the outer row of the 40 pin variant are
+    numbered 1 through 20. The inner rows of the 40 pin variant are numbered 21
+    through 40. The BoosterPack pinout is depicted below:
+
+    1  3.3V     21 5V                    40 GPIO 20 GND
+    2  Analog   22 GND                   39 GPIO 19 GPIO
+    3  UART RXD 23 Analog                38 GPIO 18 GPIO / SPI CS
+    4  UART TXD 24 Analog                37 GPIO 17 GPIO
+    5  GPIO     25 Analog                36 GPIO 16 RESET
+    6  Analog   26 Analog                35 GPIO 15 SPI MOSI
+    7  SPI CLK  27 Analog                34 GPIO 14 SPI MISO
+    8  GPIO     28 Analog                33 GPIO 13 GPIO / SPI CS
+    9  I2C SCL  29                       32 GPIO 12 GPIO / SPI CS
+    10 I2C SDA  30                       31 GPIO 11 GPIO
+
+    Additional information about the BoosterPack pinout can be found at
+    http://processors.wiki.ti.com/index.php/BYOB or in the documentation for
+    a TI LaunchPad development kit,
+
+compatible: "ti,boosterpack-header"
+
+include: [gpio-nexus.yaml, base.yaml]


### PR DESCRIPTION
The LaunchPad / BoosterPack connector is found on TI LaunchPad development kits and BoosterPack expansion modules. This PR adds support for the LaunchPad connector which allows shields (e.g. BoosterPacks) to use aliases for the connector interfaces and mappings for the GPIOs. This is similar to what is being done for the Arduino connectors.