### PR TITLE
boards: twr_ke18f: list hwinfo as supported feature

### DIFF
--- a/boards/arm/twr_ke18f/twr_ke18f.yaml
+++ b/boards/arm/twr_ke18f/twr_ke18f.yaml
@@ -12,3 +12,4 @@ supported:
   - rtc
   - counter
   - i2c
+  - hwinfo


### PR DESCRIPTION
List hwinfo as a supported feature on the NXP TWR-KE18F development
board.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>