### PR TITLE
tests: benchmarks: latency_measure: use 0.1s sys clk tick for twr_ke18f

### DIFF
--- a/tests/benchmarks/latency_measure/boards/twr_ke18f.conf
+++ b/tests/benchmarks/latency_measure/boards/twr_ke18f.conf
@@ -1,0 +1,4 @@
+# eliminate timer interrupts during the benchmark
+# for platforms that do not allow frequency dividers large enough to get
+# system clock tick period in 1 sec, make system clock tick to 0.1 sec
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=10


### PR DESCRIPTION
Use the small_freq_divider.conf file when running on the NXP TWR-KE18F
development board.

Fixes #16234.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>