### PR TITLE
net: lwm2m: Add COAP-HTTP proxy URI configuration at runtime support.

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -323,6 +323,20 @@ void lwm2m_firmware_set_update_cb(lwm2m_engine_user_cb_t cb);
  * @return A registered callback function to receive the execute event.
  */
 lwm2m_engine_user_cb_t lwm2m_firmware_get_update_cb(void);
+
+#if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT)
+/**
+ * @brief Set URI of COAP-HTTP proxy for firmware pull.
+ *
+ * LwM2M clients use this function to configure the URI of the COAP-HTTP
+ * proxy if such support is enabled for firmware pull. If not null the URI
+ * will superseed LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_ADDR set through
+ * kconfig.
+ *
+ * @param[in] in_cfg_proxy_uri Proxy URI to configure
+ */
+void lwm2m_firmware_set_proxy(char *in_cfg_proxy_uri);
+#endif
 #endif
 #endif
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -38,6 +38,7 @@ static struct coap_block_context firmware_block_ctx;
 #define COAP2HTTP_PROXY_URI_PATH	"coap2http"
 
 static char proxy_uri[URI_LEN];
+static char *cfg_proxy_uri;
 #endif
 
 static void do_transmit_timeout_cb(struct lwm2m_message *msg);
@@ -394,7 +395,11 @@ static void firmware_transfer(struct k_work *work)
 	char *server_addr;
 
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT)
-	server_addr = CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_ADDR;
+	if (cfg_proxy_uri == NULL) {
+		server_addr = CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_ADDR;
+	} else {
+		server_addr = cfg_proxy_uri;
+	}
 	if (strlen(server_addr) >= URI_LEN) {
 		LOG_ERR("Invalid Proxy URI: %s", server_addr);
 		ret = -ENOTSUP;
@@ -464,3 +469,10 @@ int lwm2m_firmware_start_transfer(char *package_uri)
 
 	return 0;
 }
+
+#if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT)
+void lwm2m_firmware_set_proxy(char *in_cfg_proxy_uri)
+{
+	cfg_proxy_uri = in_cfg_proxy_uri;
+}
+#endif


### PR DESCRIPTION
Fixes #16150 by adding lwm2m_firmware_set_proxy to the API.

Signed-off-by: Louis Dupont <dupont.louis@ireq.ca>