### PR TITLE
DNM: boards: twr_ke18f: exclude board from tests with userspace enabled

### DIFF
--- a/boards/arm/twr_ke18f/twr_ke18f.yaml
+++ b/boards/arm/twr_ke18f/twr_ke18f.yaml
@@ -8,6 +8,9 @@ toolchain:
   - xtools
 ram: 32
 flash: 512
+testing:
+  ignore_tags:
+    - userspace
 supported:
   - rtc
   - counter


### PR DESCRIPTION
Exclude the NXP TWR-KE18F development board from all tests which have
userspace enabled.

The NXP KE1xF SoC has 8 MPU regions of which five are statically
defined, one is used for thread stack protection, and two are used for
stack guard. This leaves zero MPU regions for use by the userspace
privilege separation.

Fixes #16229, #16225.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>