### PR TITLE
boards: nrf52840_papyr: support nrfjprog flash runner

### DIFF
--- a/boards/arm/nrf52840_papyr/board.cmake
+++ b/boards/arm/nrf52840_papyr/board.cmake
@@ -1,3 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
 include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)


### PR DESCRIPTION
Add JLink via nrfjprog as an alternative to Black Magic.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>