### PR TITLE
ext/hal/st: stm32cube Kconfig fix

### DIFF
--- a/ext/hal/st/stm32cube/Kconfig
+++ b/ext/hal/st/stm32cube/Kconfig
@@ -122,9 +122,6 @@ config USE_STM32_HAL_I2C_EX
 config USE_STM32_HAL_I2S
 	bool
 
-config USE_STM32_HAL_IPCC
-	bool
-
 config USE_STM32_HAL_I2S_EX
 	bool
 
@@ -215,10 +212,10 @@ config USE_STM32_HAL_SAI_EX
 config USE_STM32_HAL_SD
 	bool
 
-config USE_STM32_HAL_SDADC
+config USE_STM32_HAL_SD_EX
 	bool
 
-config USE_STM32_HAL_SD_EX
+config USE_STM32_HAL_SDADC
 	bool
 
 config USE_STM32_HAL_SDRAM
@@ -249,9 +246,6 @@ config USE_STM32_HAL_SWPMI
 	bool
 
 config USE_STM32_HAL_TIM
-	bool
-
-config USE_STM32_HAL_TIME_EX
 	bool
 
 config USE_STM32_HAL_TIM_EX

--- a/ext/hal/st/stm32cube/stm32f0xx/CMakeLists.txt
+++ b/ext/hal/st/stm32cube/stm32f0xx/CMakeLists.txt
@@ -37,7 +37,7 @@ zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_SMBUS drivers/src/stm32f0xx_hal_smbus.
 zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_SPI drivers/src/stm32f0xx_hal_spi.c)
 zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_SPI_EX drivers/src/stm32f0xx_hal_spi_ex.c)
 zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_TIM drivers/src/stm32f0xx_hal_tim.c)
-zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_TIME_EX drivers/src/stm32f0xx_hal_tim_ex.c)
+zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_TIM_EX drivers/src/stm32f0xx_hal_tim_ex.c)
 zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_TSC drivers/src/stm32f0xx_hal_tsc.c)
 zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_UART drivers/src/stm32f0xx_hal_uart.c)
 zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_UART_EX drivers/src/stm32f0xx_hal_uart_ex.c)
@@ -59,4 +59,3 @@ zephyr_sources_ifdef(CONFIG_USE_STM32_LL_SPI drivers/src/stm32f0xx_ll_spi.c)
 zephyr_sources_ifdef(CONFIG_USE_STM32_LL_TIM drivers/src/stm32f0xx_ll_tim.c)
 zephyr_sources_ifdef(CONFIG_USE_STM32_LL_USART drivers/src/stm32f0xx_ll_usart.c)
 zephyr_sources_ifdef(CONFIG_USE_STM32_LL_UTILS drivers/src/stm32f0xx_ll_utils.c)
-

--- a/ext/hal/st/stm32cube/stm32f2xx/CMakeLists.txt
+++ b/ext/hal/st/stm32cube/stm32f2xx/CMakeLists.txt
@@ -43,7 +43,7 @@ zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_SMARTCARD drivers/src/stm32f2xx_hal_sm
 zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_SPI drivers/src/stm32f2xx_hal_spi.c)
 zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_SRAM drivers/src/stm32f2xx_hal_sram.c)
 zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_TIM drivers/src/stm32f2xx_hal_tim.c)
-zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_TIME_EX drivers/src/stm32f2xx_hal_tim_ex.c)
+zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_TIM_EX drivers/src/stm32f2xx_hal_tim_ex.c)
 zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_UART drivers/src/stm32f2xx_hal_uart.c)
 zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_USART drivers/src/stm32f2xx_hal_usart.c)
 zephyr_sources_ifdef(CONFIG_USE_STM32_HAL_WWDG drivers/src/stm32f2xx_hal_wwdg.c)


### PR DESCRIPTION
Fix inconsistencies (spelling, duplicates, ordering) in stm32cube Kconfig file.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>