### PR TITLE
Log: Fix build error on Fedora 30

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -656,13 +656,7 @@ char *log_strdup(const char *str)
 
 bool log_is_strdup(void *buf)
 {
-	struct log_strdup_buf *pool_first, *pool_last;
-
-	pool_first = (struct log_strdup_buf *)log_strdup_pool_buf;
-	pool_last = pool_first + CONFIG_LOG_STRDUP_BUF_COUNT - 1;
-
-	return ((char *)buf >= pool_first->buf) &&
-	       ((char *)buf <= pool_last->buf);
+	return PART_OF_ARRAY(log_strdup_pool_buf, (u8_t *)buf);
 
 }
 


### PR DESCRIPTION
Fedora 30 uses GCC 9.1 which fails to build when loggin is enabled:

zephyr/subsys/logging/log_core.c: In function ‘log_is_strdup’:
zephyr/subsys/logging/log_core.c:665:22:
warning: array subscript -1 is outside array bounds of
‘u8_t[]’ [-Warray-bounds]
  665 |         ((char *)buf <= pool_last->buf);
      |                      ^~
zephyr/subsys/logging/log_core.c:52:3:
note: while referencing ‘log_strdup_pool_buf’
   52 |   log_strdup_pool_buf[LOG_STRDUP_POOL_BUFFER_SIZE];

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>