### PR TITLE
native_posix: Run in real time by default with host BT

### DIFF
--- a/boards/posix/native_posix/Kconfig
+++ b/boards/posix/native_posix/Kconfig
@@ -6,7 +6,7 @@ comment "Native POSIX options"
 
 config NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME
 	bool "Slow down execution to real time"
-	default y if !TEST
+	default y if BT_USERCHAN || !TEST
 	help
 	  When selected the execution of the process will be slowed down to real time.
 	  (if there is a lot of load it may be slower than real time)


### PR DESCRIPTION
For native_posix, set NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME
by default when a host BT adapter is selected even if TEST
was also set. As using host peripherals one normally needs
also to run with the host time.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>