### PR TITLE
Driver: Manage variable CPU clock

### DIFF
--- a/include/drivers/timer/system_timer.h
+++ b/include/drivers/timer/system_timer.h
@@ -90,6 +90,15 @@ extern int z_clock_device_ctrl(struct device *device, u32_t ctrl_command,
 extern void z_clock_set_timeout(s32_t ticks, bool idle);
 
 /**
+ * @brief Updates system clock driver
+ *
+ * This notifies the timer driver that the system core clock have
+ * changed during program execution. The function calculates and
+ * updates the new tick units from the system core clock.
+ */
+extern void z_clock_update(void);
+
+/**
  * @brief Timer idle exit notification
  *
  * This notifies the timer driver that the system is exiting the idle


### PR DESCRIPTION
Add function z_clock_update() in the system clock driver.
This function is a void function that must be called if the CPU clock frequency is changed.
The function will calculates and updates the new tick units from the system core clock.
The CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME symbol must be defined.