### PR TITLE
mcumgr: move Kconfig to main tree

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -312,6 +312,7 @@
 /subsys/fs/fcb/                           @nvlsianpu
 /subsys/fs/nvs/                           @Laczen
 /subsys/logging/                          @nordic-krch
+/subsys/mgmt/                             @carlescufi @nvlsianpu
 /subsys/net/buf.c                         @jukkar @jhedberg @tbursztyka @pfalcon
 /subsys/net/ip/                           @jukkar @tbursztyka @pfalcon
 /subsys/net/lib/                          @jukkar @tbursztyka @pfalcon

--- a/subsys/mgmt/Kconfig
+++ b/subsys/mgmt/Kconfig
@@ -60,6 +60,8 @@ config MCUMGR_SMP_UART_MTU
 
 endif
 
+source "subsys/mgmt/Kconfig.mcumgr"
+
 if MCUMGR
 config MCUMGR_BUF_COUNT
 	int "Number of mcumgr buffers"

--- a/subsys/mgmt/Kconfig.mcumgr
+++ b/subsys/mgmt/Kconfig.mcumgr
@@ -1,0 +1,147 @@
+#
+# Copyright Runtime.io 2018. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+config MCUMGR
+	bool "mcumgr Support"
+	select TINYCBOR
+	help
+	  This option enables the mcumgr management library.
+
+if MCUMGR
+
+menu "Command handlers"
+
+menuconfig MCUMGR_CMD_FS_MGMT
+	bool "Enable mcumgr handlers for file management"
+	depends on FILE_SYSTEM
+	help
+	  Enables mcumgr handlers for file management
+
+if MCUMGR_CMD_FS_MGMT
+config FS_MGMT_UL_CHUNK_SIZE
+	int "Maximum chunk size for file uploads"
+	default 512
+	help
+	  Limits the maximum chunk size for file uploads, in bytes.  A buffer of
+	  this size gets allocated on the stack during handling of a file upload command.
+
+config FS_MGMT_DL_CHUNK_SIZE
+	int "Maximum chunk size for file downloads"
+	default 512
+	help
+	  Limits the maximum chunk size for file downloads, in bytes.  A buffer of
+	  this size gets allocated on the stack during handling of a file download
+	  command.
+
+config FS_MGMT_PATH_SIZE
+	int "Maximum file path length"
+	default 64
+	help
+	  Limits the maximum path length for file operations, in bytes.  A buffer
+	  of this size gets allocated on the stack during handling of file upload
+	  and download commands.
+endif
+
+menuconfig MCUMGR_CMD_IMG_MGMT
+	bool "Enable mcumgr handlers for image management"
+	select FLASH
+	select MPU_ALLOW_FLASH_WRITE if CPU_HAS_MPU
+	select IMG_MANAGER
+	help
+	  Enables mcumgr handlers for image management
+
+if MCUMGR_CMD_IMG_MGMT
+	config IMG_MGMT_UL_CHUNK_SIZE
+	int "Maximum chunk size for image uploads"
+	default 512
+	help
+	  Limits the maximum chunk size for image uploads, in bytes.  A buffer of
+	  this size gets allocated on the stack during handling of a image upload
+	  command.
+endif
+
+menuconfig MCUMGR_CMD_LOG_MGMT
+	bool "Enable mcumgr handlers for log management"
+	help
+	Enables mcumgr handlers for log management
+
+if MCUMGR_CMD_LOG_MGMT
+config LOG_MGMT_CHUNK_SIZE
+	int "Maximum chunk size for log downloads"
+	default 512
+	help
+	  Limits the maximum chunk size for log downloads, in bytes.  A buffer of
+	  this size gets allocated on the stack during handling of the log show command.
+
+config LOG_MGMT_NAME_LEN
+	int "Maximum log name length"
+	default 64
+	help
+	  Limits the maximum length of log names, in bytes.  If a log's name length
+	  exceeds this number, it gets truncated in management responses.  A buffer
+	  of this size gets allocated on the stack during handling of all log
+	  management commands.
+
+config LOG_MGMT_BODY_LEN
+	int "Maximum log body length"
+	default 128
+	help
+	  Limits the maximum length of log entry bodies, in bytes.  If a log
+	  entry's body length exceeds this number, it gets truncated in management
+	  responses.  A buffer of this size gets allocated on the stack during
+	  handling of the log show command.
+endif
+
+menuconfig MCUMGR_CMD_OS_MGMT
+	bool "Enable mcumgr handlers for OS management"
+	select REBOOT
+	help
+	  Enables mcumgr handlers for OS management
+
+if MCUMGR_CMD_OS_MGMT
+config OS_MGMT_RESET_MS
+	int "Delay before executing reset command (ms)"
+	default 250
+	help
+	  When a reset command is received, the system waits this many milliseconds
+	  before performing the reset.  This delay allows time for the mcumgr
+	  response to be delivered.
+
+config OS_MGMT_TASKSTAT
+	bool "Support for taskstat command"
+	default y
+
+config OS_MGMT_ECHO
+	bool "Support for echo command"
+	default y
+endif
+
+
+menuconfig MCUMGR_CMD_STAT_MGMT
+	bool "Enable mcumgr handlers for statistics management"
+	depends on STATS
+	help
+	  Enables mcumgr handlers for statistics management.
+
+if MCUMGR_CMD_STAT_MGMT
+config STAT_MGMT_MAX_NAME_LEN
+	int "Maximum stat group name length"
+	default 32
+	help
+	  Limits the maximum stat group name length in mcumgr requests, in bytes.
+	  A buffer of this size gets allocated on the stack during handling of all
+	  stat read commands.  If a stat group's name exceeds this limit, it will
+	  be impossible to retrieve its values with a stat show command.
+endif
+endmenu
+
+config APP_LINK_WITH_MCUMGR
+	bool "Link 'app' with MCUMGR"
+	default y
+	help
+	  Add MCUMGR header files to the 'app' include path. It may be
+	  disabled if the include paths for MCUMGR are causing aliasing
+	  issues for 'app'.
+
+endif

--- a/west.yml
+++ b/west.yml
@@ -57,7 +57,7 @@ manifest:
       revision: 45e630d6152824f807d3f919958605c4626cbdff
       path: modules/hal/libmetal
     - name: mcumgr
-      revision: a69793cdb4817896b647a3305725b6c2fa699ccb
+      revision: 84934959d2d1722a23b7e7e200191ae4a6f96168
       path: modules/lib/mcumgr
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194


### PR DESCRIPTION
Keep MCUMGR Kconfig in the main tree to maintain dependencies.

Related PR: https://github.com/zephyrproject-rtos/mcumgr/pull/1