### PR TITLE
doc: Fix typos in flashmap.h

### DIFF
--- a/include/flash_map.h
+++ b/include/flash_map.h
@@ -76,9 +76,9 @@ struct flash_sector {
 };
 
 /**
- * @brief Retrieve partitions flash area form the flash_mpa.
+ * @brief Retrieve partitions flash area from the flash_map.
  *
- * Function Retrieves flash_area form flash_map for given partition.
+ * Function Retrieves flash_area from flash_map for given partition.
  *
  * @param[in]  id ID of the flash partition.
  * @param[out] fa Pointer which has to reference flash_area. If


### PR DESCRIPTION
Fix a few typos in docstrings.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>