### PR TITLE
Add strcspn and iscntrl to minimal libc

### DIFF
--- a/lib/libc/minimal/include/string.h
+++ b/lib/libc/minimal/include/string.h
@@ -29,6 +29,7 @@ extern char *strcat(char *_MLIBC_RESTRICT dest,
 extern char  *strncat(char *_MLIBC_RESTRICT d, const char *_MLIBC_RESTRICT s,
 		      size_t n);
 extern char *strstr(const char *s, const char *find);
+extern size_t strcspn(const char *s1, const char *s2);
 
 extern int    memcmp(const void *m1, const void *m2, size_t n);
 extern void  *memmove(void *d, const void *s, size_t n);

--- a/lib/libc/minimal/include/string.h
+++ b/lib/libc/minimal/include/string.h
@@ -30,6 +30,7 @@ extern char  *strncat(char *_MLIBC_RESTRICT d, const char *_MLIBC_RESTRICT s,
 		      size_t n);
 extern char *strstr(const char *s, const char *find);
 extern size_t strcspn(const char *s1, const char *s2);
+extern int    iscntrl(int a);
 
 extern int    memcmp(const void *m1, const void *m2, size_t n);
 extern void  *memmove(void *d, const void *s, size_t n);

--- a/lib/libc/minimal/source/string/string.c
+++ b/lib/libc/minimal/source/string/string.c
@@ -170,6 +170,28 @@ char *strncat(char *_MLIBC_RESTRICT dest, const char *_MLIBC_RESTRICT src,
 }
 
 /**
+ * @brief Get the length of a complementary substring
+ *
+ * @return length of the maximum initial segment of the string pointed to
+ * by s1 which consists entirely of bytes not from the string pointed to by s2.
+ */
+
+size_t strcspn(const char *s1, const char *s2)
+{
+	int i, j;
+
+	for (i = 0; i < strlen(s2); ++i) {
+		for (j = 0; j < strlen(s1); ++j) {
+			if (s1[j] == s2[i]) {
+				return j;
+			}
+		}
+	}
+
+	return strlen(s1);
+}
+
+/**
  *
  * @brief Compare two memory areas
  *

--- a/lib/libc/minimal/source/string/string.c
+++ b/lib/libc/minimal/source/string/string.c
@@ -192,6 +192,20 @@ size_t strcspn(const char *s1, const char *s2)
 }
 
 /**
+ * @brief Test for a control character
+ *
+ * @return non-zero if c is a control character, otherwise 0.
+ */
+
+int iscntrl(int c)
+{
+	/* All the characters placed before the space on the ASCII table
+	 * and the 0x7F character (DEL) are control characters.
+	 */
+	return (int)(c < ' ' || c == 0x7F);
+}
+
+/**
  *
  * @brief Compare two memory areas
  *


### PR DESCRIPTION
This PR adds the definitions for `strcspn` and `iscntrl` to the minimal libc library (strings).