### PR TITLE
Enclose module Kconfig and build directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,7 +430,7 @@ if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
     string(REGEX REPLACE "\"(.*)\":\".*\"" "\\1" module_name ${module})
     string(REGEX REPLACE "\".*\":\"(.*)\"" "\\1" module_path ${module})
     message("Including module: ${module_name} in path: ${module_path}")
-    add_subdirectory(${module_path} ${CMAKE_BINARY_DIR}/${module_name})
+    add_subdirectory(${module_path} ${CMAKE_BINARY_DIR}/modules/${module_name})
   endforeach()
 endif()
 

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -7,7 +7,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+menu "Modules"
+
 source "$(CMAKE_BINARY_DIR)/Kconfig.modules"
+
+endmenu
 
 # Include these first so that any properties (e.g. defaults) below can be
 # overriden in *.defconfig files (by defining symbols in multiple locations).


### PR DESCRIPTION
As we start adding more modules, all of them end up in
${CMAKE_BINARY_DIR}/ and this is getting too busy. We have a module 
directory created for each module and the interesting build data is getting
lost in the crowd.

Solve the issue of having all module Kconfig land in the top level Kconfig
menu when viewed in menuconfig.