### PR TITLE
net: pkt: Put back reserved fifo variable

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -58,18 +58,15 @@ struct net_pkt_cursor {
  * net_pkt_clone() function.
  */
 struct net_pkt {
-	union {
-		/** Internal variable that is used when packet is sent
-		 * or received.
-		 */
-		struct k_work work;
-		/** Socket layer will queue received net_pkt into a k_fifo.
-		 * Since this happens after consuming net_pkt's k_work on
-		 * RX path, it is then fine to have both attributes sharing
-		 * the same memory area.
-		 */
-		int sock_recv_fifo;
-	};
+	/** FIFO uses first 4 bytes itself, reserve space. Do not remove
+	 * this as this is needed if net_pkt is placed to a fifo.
+	 */
+	int _reserved;
+
+	/** Internal variable that is used when packet is sent
+	 * or received.
+	 */
+	struct k_work work;
 
 	/** Slab pointer from where it belongs to */
 	struct k_mem_slab *slab;


### PR DESCRIPTION
The reserved variable needs to be there if net_pkt is placed into
a fifo. In TX path this can happen if TX timestamping is enabled.
In RX path this can happen in BSD socket receive queue.

This commit reverts both 79a25a6fff328d5a36db085b2c6ace0445f2d0f5
and 79672d1647d9d005cd295cb63b10f801ca97dea2

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>