### PR TITLE
sanitycheck: CONFIG_TEST_USERSPACE / userspace tag cleanup

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -437,7 +437,8 @@ k_tid_t z_impl_k_thread_create(struct k_thread *new_thread,
 	/* Special case, only for unit tests */
 #if defined(CONFIG_TEST) && defined(CONFIG_ARCH_HAS_USERSPACE) && !defined(CONFIG_USERSPACE)
 	__ASSERT((options & K_USER) == 0,
-		 "Platform is capable of user mode, and test thread created with K_USER option, but CONFIG_TEST_USERSPACE or CONFIG_USERSPACE is not set\n");
+		 "Platform is capable of user mode, and test thread created with K_USER option,"
+		 " but neither CONFIG_TEST_USERSPACE nor CONFIG_USERSPACE is set\n");
 #endif
 
 	z_setup_new_thread(new_thread, stack, stack_size, entry, p1, p2, p3,

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -64,8 +64,11 @@ config TEST_USERSPACE
 	bool "Indicate that this test exercises user mode"
 	help
 	  This option indicates that a test case puts threads in user mode,
-	  and that the build system should enable userspace if the platform
-	  supports it. It should be set on a per-test basis.
+	  and that the build system will [override and] enable USERSPACE
+	  if the platform supports it. It should be set in a .conf file on
+	  a per-test basis and is not meant to be used outside test cases.
+	  Tests with this option should also have the "userspace" filtering
+	  tag in their testcase.yaml file.
 
 	  The userspace APIs are no-ops if userspace is not enabled, so it is
 	  OK to enable this even if the test will run on platforms which do
@@ -73,7 +76,7 @@ config TEST_USERSPACE
 	  just with all threads in supervisor mode.
 
 	  If a test *requires* that userspace be enabled in order to
-	  function, CONFIG_ARCH_HAS_USERSPACE should be filtered in its
+	  pass, CONFIG_ARCH_HAS_USERSPACE should be filtered in its
 	  testcase.yaml.
 
 config TEST_ENABLE_USERSPACE
@@ -84,8 +87,8 @@ config TEST_ENABLE_USERSPACE
 	select DYNAMIC_OBJECTS
 	default y
 	help
-	  This hidden option will help test the userspace mode. This will be
-	  enabled only when CONFIG_ARCH_HAS_USERSPACE is set, and that the test
+	  This hidden option implements the TEST_USERSPACE logic. It turns on
+	  USERSPACE when CONFIG_ARCH_HAS_USERSPACE is set and the test
 	  case itself indicates that it exercises user mode via
 	  CONFIG_TEST_USERSPACE.
 

--- a/tests/kernel/critical/testcase.yaml
+++ b/tests/kernel/critical/testcase.yaml
@@ -7,6 +7,4 @@ tests:
   kernel.common.nsim:
     platform_whitelist: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
     extra_configs:
-      - CONFIG_TEST_USERSPACE=n
       - CONFIG_TEST_HW_STACK_PROTECTION=n
-

--- a/tests/kernel/fatal/testcase.yaml
+++ b/tests/kernel/fatal/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     tags: kernel ignore_faults userspace
   kernel.common.stack_sentinel:
     extra_args: CONF_FILE=sentinel.conf
-    tags: kernel ignore_faults userspace
+    tags: kernel ignore_faults

--- a/tests/kernel/lifo/lifo_usage/testcase.yaml
+++ b/tests/kernel/lifo/lifo_usage/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   kernel.lifo.usage:
     min_ram: 32
-    tags: kernel userspace
+    tags: kernel
     platform_exclude: m2gl025_miv

--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     build_only: true
     extra_args: CONF_FILE="prj_tickless.conf"
     arch_exclude: riscv32 nios2 posix
-    tags: kernel userspace
+    tags: kernel

--- a/tests/net/socket/getaddrinfo/testcase.yaml
+++ b/tests/net/socket/getaddrinfo/testcase.yaml
@@ -4,4 +4,4 @@ common:
 tests:
   net.socket:
     min_ram: 21
-    tags: net socket getaddrinfo
+    tags: net socket getaddrinfo userspace

--- a/tests/net/socket/register/prj.conf
+++ b/tests/net/socket/register/prj.conf
@@ -1,5 +1,4 @@
 CONFIG_ZTEST=y
-CONFIG_TEST_USERSPACE=n
 
 # Asserts must be disabled as we are feeding invalid values to various
 # functions and want that those do not cause abort.

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -17,12 +17,10 @@ tests:
     platform_whitelist: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
-      - CONFIG_TEST_USERSPACE=n
       - CONFIG_TEST_HW_STACK_PROTECTION=n
   portability.posix.newlib.nsim:
     platform_whitelist: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
-      - CONFIG_TEST_USERSPACE=n
       - CONFIG_TEST_HW_STACK_PROTECTION=n


### PR DESCRIPTION
- Delete CONFIG_TEST_USERSPACE=n no-ops because it's the default
since commit 7b1ee5cf13dc4

- Some tests have a "userspace" tag pretending to TEST_USERSPACE but
don't and vice versa: fix missing or spurious "userspace" tags in
testcase.yaml files.

Tests have a _spurious_ "userspace" tag when they PASS this command
cause none should pass:

  ./scripts/sanitycheck --tag=userspace -p qemu_x86 \
      --extra-args=CONFIG_TEST_USERSPACE=n  \
      --extra-args=CONFIG_USERSPACE=n | tee userspace.log

All tests run by this command must either fail to build or fail to run
with some userspace related error. Shortcut to look at all test
failures:

 zephyr_failure_logs() {
     awk '/see.*log/ {print $2}' "$@"
 }

Tests _missing_ "userspace" tag FAIL to either build or to run with some
userspace related error when running this:

  ./scripts/sanitycheck --exclude=userspace -p qemu_x86 \
      --extra-args=CONFIG_TEST_USERSPACE=n  \
      --extra-args=CONFIG_USERSPACE=n | tee excludeuserspace.log

Note the detection methods above are not 100% perfect because some
flexible tests like tests/kernel/queue/src/main.c evade them with #ifdef
CONFIG_USERSPACE smarts. Considering they never break, it is purely the
test author's decision to include or not such flexible tests in the
"userspace" subset.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>