### PR TITLE
net/udp: Check UDP header's length attribute

### DIFF
--- a/subsys/net/ip/udp.c
+++ b/subsys/net/ip/udp.c
@@ -154,6 +154,13 @@ struct net_udp_hdr *net_udp_input(struct net_pkt *pkt,
 		goto drop;
 	}
 
+	if (ntohs(udp_hdr->len) != (net_pkt_get_len(pkt) -
+				    net_pkt_ip_hdr_len(pkt) -
+				    net_pkt_ipv6_ext_len(pkt))) {
+		NET_DBG("DROP: Invalid hdr length");
+		goto drop;
+	}
+
 	if (IS_ENABLED(CONFIG_NET_UDP_CHECKSUM) &&
 	    net_if_need_calc_rx_checksum(net_pkt_iface(pkt))) {
 		if (IS_ENABLED(CONFIG_NET_UDP_MISSING_CHECKSUM) &&

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -303,6 +303,9 @@ static bool send_ipv6_udp_long_msg(struct net_if *iface,
 		zassert_true(0, "exiting");
 	}
 
+	net_pkt_set_ipv6_ext_len(pkt, sizeof(ipv6_hop_by_hop_ext_hdr));
+	net_pkt_set_ipv6_next_hdr(pkt, NET_IPV6_NEXTHDR_HBHO);
+
 	if (net_udp_create(pkt, htons(src_port), htons(dst_port))) {
 		printk("Cannot create IPv6  pkt %p", pkt);
 		zassert_true(0, "exiting");
@@ -314,7 +317,7 @@ static bool send_ipv6_udp_long_msg(struct net_if *iface,
 	}
 
 	net_pkt_cursor_init(pkt);
-	net_ipv6_finalize(pkt, 0);
+	net_ipv6_finalize(pkt, IPPROTO_UDP);
 
 	ret = net_recv_data(iface, pkt);
 	if (ret < 0) {


### PR DESCRIPTION
Length shoudl be at least of UDP header size.

Reported-by: Ruslan Mstoi <ruslan.mstoi@intel.com>

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>