### PR TITLE
Bluetooth: Fix building of broadcaster or observer only

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3857,7 +3857,7 @@ static int common_init(void)
 	if (err) {
 		return err;
 	}
-#endif /* CONFIG_BT_CONN */
+#endif /* CONFIG_BT_HCI_ACL_FLOW_CONTROL */
 
 	return 0;
 }
@@ -5066,7 +5066,8 @@ int bt_id_reset(u8_t id, bt_addr_le_t *addr, u8_t *irk)
 		return -EBUSY;
 	}
 
-	if (bt_addr_le_cmp(&bt_dev.id_addr[id], BT_ADDR_LE_ANY)) {
+	if (IS_ENABLED(CONFIG_BT_CONN) &&
+	    bt_addr_le_cmp(&bt_dev.id_addr[id], BT_ADDR_LE_ANY)) {
 		int err;
 
 		err = bt_unpair(id, NULL);
@@ -5082,8 +5083,6 @@ int bt_id_reset(u8_t id, bt_addr_le_t *addr, u8_t *irk)
 
 int bt_id_delete(u8_t id)
 {
-	int err;
-
 	if (id == BT_ID_DEFAULT || id >= bt_dev.id_count) {
 		return -EINVAL;
 	}
@@ -5097,9 +5096,13 @@ int bt_id_delete(u8_t id)
 		return -EBUSY;
 	}
 
-	err = bt_unpair(id, NULL);
-	if (err) {
-		return err;
+	if (IS_ENABLED(CONFIG_BT_CONN)) {
+		int err;
+
+		err = bt_unpair(id, NULL);
+		if (err) {
+			return err;
+		}
 	}
 
 #if defined(CONFIG_BT_PRIVACY)

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -229,7 +229,6 @@ static struct bt_conn_cb conn_callbacks = {
 };
 #endif /* CONFIG_BT_CONN */
 
-#if defined(CONFIG_BT_BREDR) || defined(CONFIG_BT_CONN)
 static int char2hex(const char *c, u8_t *x)
 {
 	if (*c >= '0' && *c <= '9') {
@@ -279,7 +278,6 @@ int str2bt_addr(const char *str, bt_addr_t *addr)
 	return hexstr2array(str, addr->val, 6);
 }
 
-#if defined(CONFIG_BT_CONN)
 static int str2bt_addr_le(const char *str, const char *type, bt_addr_le_t *addr)
 {
 	int err;
@@ -299,8 +297,6 @@ static int str2bt_addr_le(const char *str, const char *type, bt_addr_le_t *addr)
 
 	return 0;
 }
-#endif /* CONFIG_BT_CONN */
-#endif /* CONFIG_BT_BREDR || CONFIG_BT_CONN */
 
 static void bt_ready(int err)
 {


### PR DESCRIPTION
Fix conditional compilations to allow building broadcaster
and/or observer only applications.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>