### PR TITLE
[DNM] net/pkt: Optimize length computation on a net_pkt

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -110,6 +110,8 @@ struct net_pkt {
 	sys_snode_t sent_list;
 #endif
 
+	u16_t length; /* length of data stored in buffer */
+
 	u8_t ip_hdr_len;	/* pre-filled in order to avoid func call */
 
 	u8_t overwrite  : 1;	/* Is packet content being overwritten? */
@@ -701,7 +703,7 @@ static inline void net_pkt_set_timestamp(struct net_pkt *pkt,
 
 static inline size_t net_pkt_get_len(struct net_pkt *pkt)
 {
-	return net_buf_frags_len(pkt->frags);
+	return pkt->length;
 }
 
 static inline u8_t *net_pkt_data(struct net_pkt *pkt)

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -1614,6 +1614,16 @@ int net_pkt_update_length(struct net_pkt *pkt, size_t length);
 int net_pkt_remove(struct net_pkt *pkt, size_t length);
 
 /**
+ * @brief Remove data from beginning of the packet
+ *
+ * @param pkt    Network packet
+ * @param length Number of bytes to be removed
+ *
+ * @return 0 on success, negative errno code otherwise.
+ */
+int net_pkt_pull(struct net_pkt *pkt, size_t length);
+
+/**
  * @brief Get the actual offset in the packet from its cursor
  *
  * @param pkt Network packet.

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -1589,7 +1589,7 @@ size_t net_pkt_remaining_data(struct net_pkt *pkt);
 /**
  * @brief Update the overall length of a packet
  *
- * @details Unlike net_pkt_pull() below, this does not take packet cursor
+ * @details Unlike net_pkt_remove() below, this does not take packet cursor
  *          into account. It's mainly a helper dedicated for ipv4 and ipv6
  *          input functions. It shrinks the overall length by given parameter.
  *
@@ -1611,7 +1611,7 @@ int net_pkt_update_length(struct net_pkt *pkt, size_t length);
  *
  * @return 0 on success, negative errno code otherwise.
  */
-int net_pkt_pull(struct net_pkt *pkt, size_t length);
+int net_pkt_remove(struct net_pkt *pkt, size_t length);
 
 /**
  * @brief Get the actual offset in the packet from its cursor

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -259,7 +259,7 @@ static void reassemble_packet(struct net_ipv6_reassembly *reass)
 		NET_DBG("Removing %d bytes from start of pkt %p",
 			removed_len, pkt->buffer);
 
-		if (net_pkt_pull(pkt, removed_len)) {
+		if (net_pkt_remove(pkt, removed_len)) {
 			NET_ERR("Failed to pull headers");
 			reassembly_cancel(reass->id, &reass->src, &reass->dst);
 			return;
@@ -297,7 +297,7 @@ static void reassemble_packet(struct net_ipv6_reassembly *reass)
 
 	next_hdr = ipv6.frag_hdr->nexthdr;
 
-	if (net_pkt_pull(pkt, sizeof(struct net_ipv6_frag_hdr))) {
+	if (net_pkt_remove(pkt, sizeof(struct net_ipv6_frag_hdr))) {
 		NET_ERR("Failed to remove fragment header");
 		goto error;
 	}

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1749,7 +1749,7 @@ int net_pkt_update_length(struct net_pkt *pkt, size_t length)
 	return !length ? 0 : -EINVAL;
 }
 
-int net_pkt_pull(struct net_pkt *pkt, size_t length)
+int net_pkt_remove(struct net_pkt *pkt, size_t length)
 {
 	struct net_pkt_cursor *c_op = &pkt->cursor;
 	struct net_pkt_cursor backup;
@@ -1779,7 +1779,7 @@ int net_pkt_pull(struct net_pkt *pkt, size_t length)
 
 		/* For now, empty buffer are not freed, and there is no
 		 * compaction done either.
-		 * net_pkt_pull() is currently used only in very specific
+		 * net_pkt_remove() is currently used only in very specific
 		 * places where such memory optimization would not make
 		 * that much sense. Let's see in future if it's worth do to it.
 		 */

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1797,6 +1797,16 @@ int net_pkt_remove(struct net_pkt *pkt, size_t length)
 	return 0;
 }
 
+int net_pkt_pull(struct net_pkt *pkt, size_t length)
+{
+	if (pkt->buffer) {
+		net_buf_pull(pkt->buffer, length);
+		net_pkt_cursor_init(pkt);
+	}
+
+	return 0;
+}
+
 u16_t net_pkt_get_current_offset(struct net_pkt *pkt)
 {
 	struct net_buf *buf = pkt->buffer;

--- a/subsys/net/ip/udp.c
+++ b/subsys/net/ip/udp.c
@@ -154,6 +154,13 @@ struct net_udp_hdr *net_udp_input(struct net_pkt *pkt,
 		goto drop;
 	}
 
+	if (ntohs(udp_hdr->len) != (net_pkt_get_len(pkt) -
+				    net_pkt_ip_hdr_len(pkt) -
+				    net_pkt_ipv6_ext_len(pkt))) {
+		NET_DBG("DROP: Invalid hdr length");
+		goto drop;
+	}
+
 	if (IS_ENABLED(CONFIG_NET_UDP_CHECKSUM) &&
 	    net_if_need_calc_rx_checksum(net_pkt_iface(pkt))) {
 		if (IS_ENABLED(CONFIG_NET_UDP_MISSING_CHECKSUM) &&

--- a/subsys/net/ip/udp.c
+++ b/subsys/net/ip/udp.c
@@ -163,9 +163,13 @@ struct net_udp_hdr *net_udp_input(struct net_pkt *pkt,
 
 	if (IS_ENABLED(CONFIG_NET_UDP_CHECKSUM) &&
 	    net_if_need_calc_rx_checksum(net_pkt_iface(pkt))) {
-		if (IS_ENABLED(CONFIG_NET_UDP_MISSING_CHECKSUM) &&
-		    net_pkt_family(pkt) == AF_INET && !udp_hdr->chksum) {
-			goto out;
+		if (!udp_hdr->chksum) {
+			if (IS_ENABLED(CONFIG_NET_UDP_MISSING_CHECKSUM) &&
+			    net_pkt_family(pkt) == AF_INET) {
+				goto out;
+			}
+
+			goto drop;
 		}
 
 		if (net_calc_verify_chksum_udp(pkt) != 0U) {

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -200,7 +200,7 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 #endif
 	case NET_ETH_PTYPE_LLDP:
 #if defined(CONFIG_NET_LLDP)
-		net_buf_pull(pkt->frags, hdr_len);
+		net_pkt_pull(pkt, hdr_len);
 		return net_lldp_recv(iface, pkt);
 #else
 		NET_DBG("LLDP Rx agent not enabled");
@@ -257,7 +257,7 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 		goto drop;
 	}
 
-	net_buf_pull(pkt->frags, hdr_len);
+	net_pkt_pull(pkt, hdr_len);
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && type == NET_ETH_PTYPE_IP &&
 	    ethernet_check_ipv4_bcast_addr(pkt, hdr) == NET_DROP) {

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -218,7 +218,7 @@ static enum net_verdict ieee802154_recv(struct net_if *iface,
 	pkt_hexdump(RX_PKT_TITLE " (with ll)", pkt, true);
 
 	hdr_len = (u8_t *)mpdu.payload - net_pkt_data(pkt);
-	net_buf_pull(pkt->buffer, hdr_len);
+	net_pkt_pull(pkt, hdr_len);
 
 	return ieee802154_manage_recv_packet(iface, pkt, hdr_len);
 

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -177,6 +177,7 @@ static void prepare_ra_message(struct net_pkt *pkt)
 
 	net_buf_unref(pkt->buffer);
 	pkt->buffer = NULL;
+	pkt->length = 0;
 
 	net_pkt_alloc_buffer(pkt, sizeof(struct net_eth_hdr) +
 			     sizeof(icmpv6_ra), AF_UNSPEC, 0);

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -303,6 +303,9 @@ static bool send_ipv6_udp_long_msg(struct net_if *iface,
 		zassert_true(0, "exiting");
 	}
 
+	net_pkt_set_ipv6_ext_len(pkt, sizeof(ipv6_hop_by_hop_ext_hdr));
+	net_pkt_set_ipv6_next_hdr(pkt, NET_IPV6_NEXTHDR_HBHO);
+
 	if (net_udp_create(pkt, htons(src_port), htons(dst_port))) {
 		printk("Cannot create IPv6  pkt %p", pkt);
 		zassert_true(0, "exiting");
@@ -314,7 +317,7 @@ static bool send_ipv6_udp_long_msg(struct net_if *iface,
 	}
 
 	net_pkt_cursor_init(pkt);
-	net_ipv6_finalize(pkt, 0);
+	net_ipv6_finalize(pkt, IPPROTO_UDP);
 
 	ret = net_recv_data(iface, pkt);
 	if (ret < 0) {


### PR DESCRIPTION
I had this for quite a while. In fact, when reworking the net_pkt API, at first, I added this attribute. But it was growing the net_pkt, and was out of scope of the rework anyway.

Sending it to see CI's result.