### PR TITLE
drivers: eth: gmac: Fix invalid signed to unsigned comparison

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2097,7 +2097,8 @@ static int ptp_clock_sam_gmac_adjust(struct device *dev, int increment)
 	Gmac *gmac = cfg->regs;
 	GMAC_TA_Type gmac_ta;
 
-	if ((increment <= -NSEC_PER_SEC) || (increment >= NSEC_PER_SEC)) {
+	if ((increment <= -(int)NSEC_PER_SEC) ||
+	    (increment >= (int)NSEC_PER_SEC)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
The macro NSEC_PER_SEC is updated with the U suffix, this caused
invalid comparison when comparing signed int type against the macro.

Signed-off-by: Wong Vee Khee <vee.khee.wong@intel.com>