### PR TITLE
fs: implemented unmount function to fatfs

### DIFF
--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -354,6 +354,15 @@ static int fatfs_mount(struct fs_mount_t *mountp)
 
 }
 
+static int fatfs_unmount(struct fs_mount_t *mountp)
+{
+	FRESULT res;
+
+	res = f_mount(NULL, &mountp->mnt_point[1], 1);
+
+	return translate_error(res);
+}
+
 /* File system interface */
 static struct fs_file_system_t fatfs_fs = {
 	.open = fatfs_open,
@@ -368,6 +377,7 @@ static struct fs_file_system_t fatfs_fs = {
 	.readdir = fatfs_readdir,
 	.closedir = fatfs_closedir,
 	.mount = fatfs_mount,
+	.unmount = fatfs_unmount,
 	.unlink = fatfs_unlink,
 	.rename = fatfs_rename,
 	.mkdir = fatfs_mkdir,


### PR DESCRIPTION
There isn't a function to handle the unmount, so I implemented based
in f_mount comments. In the comments of f_mount we actually have
that f_mount is used to mount/unmount logic, is just necessary use
NULL pointer to fs argument.

Please, I would like that this PR was label it as a backport to 
v1-14-branch as well.

Signed-off-by: Lucas Peixoto <lucaspeixotoac@gmail.com>