### PR TITLE
gitlint: match max title length restriction with checkpatch

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -13,7 +13,7 @@ debug = false
 extra-path=scripts/gitlint
 
 [title-max-length-no-revert]
-line-length=72
+line-length=75
 
 [body-min-line-count]
 min-line-count=1


### PR DESCRIPTION
Match the restriction on title length with checkpatch, since we document
that we follow the Linux style and checkpatch was there before gitlint.

Fixes #14652