### PR TITLE
net/udp: Always drop IPv6 UDP packet if checksum field is 0

### DIFF
--- a/subsys/net/ip/udp.c
+++ b/subsys/net/ip/udp.c
@@ -156,9 +156,13 @@ struct net_udp_hdr *net_udp_input(struct net_pkt *pkt,
 
 	if (IS_ENABLED(CONFIG_NET_UDP_CHECKSUM) &&
 	    net_if_need_calc_rx_checksum(net_pkt_iface(pkt))) {
-		if (IS_ENABLED(CONFIG_NET_UDP_MISSING_CHECKSUM) &&
-		    net_pkt_family(pkt) == AF_INET && !udp_hdr->chksum) {
-			goto out;
+		if (!udp_hdr->chksum) {
+			if (IS_ENABLED(CONFIG_NET_UDP_MISSING_CHECKSUM) &&
+			    net_pkt_family(pkt) == AF_INET) {
+				goto out;
+			}
+
+			goto drop;
 		}
 
 		if (net_calc_verify_chksum_udp(pkt) != 0U) {


### PR DESCRIPTION
Missing checksum is only valid in IPv4 and only on certain context.

Fixes #16483

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>