### PR TITLE
net: sockets: Remove TI conditional from offloaded fcntl implementation

### DIFF
--- a/subsys/net/lib/sockets/socket_offload.c
+++ b/subsys/net/lib/sockets/socket_offload.c
@@ -20,7 +20,6 @@ void socket_offload_register(const struct socket_offload *ops)
 	socket_ops = ops;
 }
 
-#ifdef CONFIG_SOC_FAMILY_TISIMPLELINK
 int fcntl(int fd, int cmd, ...)
 {
 	__ASSERT_NO_MSG(socket_ops);
@@ -35,4 +34,3 @@ int fcntl(int fd, int cmd, ...)
 
 	return res;
 }
-#endif


### PR DESCRIPTION
Offloaded `fcntl` implementation should be available for all offloaded implementations, not specific for TI. `socket_offload.c` is already conditionally compiled based on `CONFIG_NET_SOCKETS_OFFLOAD` option, so there should not be conflicts for non-offloaded interfaces.

@vanti I might miss something, but I don't see why this conditional was actually needed in there. If this change breaks something for the TI Simplelink though, we'll need to find some other, less intrusive solution.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>