### PR TITLE
json: make it 64-bit compatible

### DIFF
--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -493,7 +493,7 @@ static ptrdiff_t get_elem_size(const struct json_obj_descr *descr)
 		for (i = 0; i < descr->object.sub_descr_len; i++) {
 			ptrdiff_t s = get_elem_size(&descr->object.sub_descr[i]);
 
-			total += ROUND_UP(s, descr->alignment + 1);
+			total += ROUND_UP(s, 1 << descr->align_shift);
 		}
 
 		return total;


### PR DESCRIPTION
The struct json_obj_descr definition allocates only 2 bits for type
alignment. Instead of using them literally minus 1 to encode 1, 2, or 4,
let's store the alignment's shift value instead so that 1, 2, 4 or 8 can
be encoded with the same 2 bits to accommodate 64-bit builds.