### PR TITLE
thread_cpu: make it 64-bit compatible

### DIFF
--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -59,7 +59,7 @@ struct k_spinlock {
 	/* Stores the thread that holds the lock with the locking CPU
 	 * ID in the bottom two bits.
 	 */
-	size_t thread_cpu;
+	uintptr_t thread_cpu;
 #endif
 };
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -726,7 +726,7 @@ bool z_spin_lock_valid(struct k_spinlock *l)
 
 bool z_spin_unlock_valid(struct k_spinlock *l)
 {
-	if (l->thread_cpu != (_current_cpu->id | (u32_t)_current)) {
+	if (l->thread_cpu != (_current_cpu->id | (uintptr_t)_current)) {
 		return false;
 	}
 	l->thread_cpu = 0;
@@ -735,7 +735,7 @@ bool z_spin_unlock_valid(struct k_spinlock *l)
 
 void z_spin_lock_set_owner(struct k_spinlock *l)
 {
-	l->thread_cpu = _current_cpu->id | (u32_t)_current;
+	l->thread_cpu = _current_cpu->id | (uintptr_t)_current;
 }
 
 #endif


### PR DESCRIPTION
This stores a combination of a pointer and a CPU number in the low
2 bits. On 64-bit systems, the pointer part won't fit in an int.
Let's use uintptr_t for this purpose.