### PR TITLE
doc: fix devicetree doc formatting

### DIFF
--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -648,7 +648,7 @@ DeviceTree Definitions
 ======================
 
 Additional DeviceTree directory trees, or DTS_ROOTs, can be added by
-creating this directory tree:
+creating this directory tree::
 
     dts/bindings/
     dts/common/


### PR DESCRIPTION
The directory tree description was missing a code-block shorthand so the
following lines weren't formatted correctly.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>