### PR TITLE
fix linker-built array padding issues on 64-bit targets

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -107,9 +107,8 @@ extern "C" {
 		.name = drv_name, .init = (init_fn),			  \
 		.config_info = (cfg_info)				  \
 	};								  \
-	static struct device _CONCAT(__device_, dev_name) __used	  \
-	__attribute__((__section__(".init_" #level STRINGIFY(prio)),	  \
-		       aligned(__alignof(struct device)))) = {		  \
+	static Z_DECL_ALIGN(struct device) _CONCAT(__device_, dev_name) __used \
+	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
 		.config = &_CONCAT(__config_, dev_name),		  \
 		.driver_api = api,					  \
 		.driver_data = data					  \
@@ -165,9 +164,8 @@ extern "C" {
 		.pm  = &_CONCAT(__pm_, dev_name),                         \
 		.config_info = (cfg_info)				  \
 	};								  \
-	static struct device _CONCAT(__device_, dev_name) __used	  \
-	__attribute__((__section__(".init_" #level STRINGIFY(prio)),	  \
-		       aligned(__alignof(struct device)))) = {		  \
+	static Z_DECL_ALIGN(struct device) _CONCAT(__device_, dev_name) __used \
+	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
 		.config = &_CONCAT(__config_, dev_name),		  \
 		.driver_api = api,					  \
 		.driver_data = data,					  \

--- a/include/device.h
+++ b/include/device.h
@@ -108,7 +108,8 @@ extern "C" {
 		.config_info = (cfg_info)				  \
 	};								  \
 	static struct device _CONCAT(__device_, dev_name) __used	  \
-	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
+	__attribute__((__section__(".init_" #level STRINGIFY(prio)),	  \
+		       aligned(__alignof(struct device)))) = {		  \
 		.config = &_CONCAT(__config_, dev_name),		  \
 		.driver_api = api,					  \
 		.driver_data = data					  \
@@ -165,7 +166,8 @@ extern "C" {
 		.config_info = (cfg_info)				  \
 	};								  \
 	static struct device _CONCAT(__device_, dev_name) __used	  \
-	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
+	__attribute__((__section__(".init_" #level STRINGIFY(prio)),	  \
+		       aligned(__alignof(struct device)))) = {		  \
 		.config = &_CONCAT(__config_, dev_name),		  \
 		.driver_api = api,					  \
 		.driver_data = data,					  \
@@ -276,14 +278,6 @@ struct device {
 	struct device_config *config;
 	const void *driver_api;
 	void *driver_data;
-#if defined(__x86_64) && __SIZEOF_POINTER__ == 4
-	/* The x32 ABI hits an edge case.  This is a 12 byte struct,
-	 * but the x86_64 linker will pack them only in units of 8
-	 * bytes, leading to alignment problems when iterating over
-	 * the link-time array.
-	 */
-	void *padding;
-#endif
 };
 
 void z_sys_device_do_config_level(s32_t level);

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -187,7 +187,7 @@ struct _k_object_assignment {
 	static void * const _CONCAT(_object_list_, name_)[] = \
 		{ __VA_ARGS__, NULL }; \
 	static __used __in_section_unique(object_access) \
-		const struct _k_object_assignment \
+		const Z_DECL_ALIGN(struct _k_object_assignment) \
 		_CONCAT(_object_access_, name_) = \
 			{ (&_k_thread_obj_ ## name_), \
 			  (_CONCAT(_object_list_, name_)) }
@@ -969,7 +969,7 @@ struct _static_thread_data {
 			prio, options, delay)                            \
 	K_THREAD_STACK_DEFINE(_k_thread_stack_##name, stack_size);	 \
 	struct k_thread _k_thread_obj_##name;			 \
-	struct _static_thread_data _k_thread_data_##name __aligned(4)    \
+	Z_DECL_ALIGN(struct _static_thread_data) _k_thread_data_##name   \
 		__in_section(_static_thread_data, static, name) =        \
 		_THREAD_INITIALIZER(&_k_thread_obj_##name,		 \
 				    _k_thread_stack_##name, stack_size,  \
@@ -1468,7 +1468,7 @@ typedef void (*k_timer_stop_t)(struct k_timer *timer);
  * @param stop_fn   Function to invoke if the timer is stopped while running.
  */
 #define K_TIMER_DEFINE(name, expiry_fn, stop_fn) \
-	struct k_timer name \
+	Z_DECL_ALIGN(struct k_timer) name \
 		__in_section(_k_timer, static, name) = \
 		Z_TIMER_INITIALIZER(name, expiry_fn, stop_fn)
 
@@ -2050,7 +2050,7 @@ static inline void *z_impl_k_queue_peek_tail(struct k_queue *queue)
  * @param name Name of the queue.
  */
 #define K_QUEUE_DEFINE(name) \
-	struct k_queue name \
+	Z_DECL_ALIGN(struct k_queue) name \
 		__in_section(_k_queue, static, name) = \
 		_K_QUEUE_INITIALIZER(name)
 
@@ -2266,7 +2266,7 @@ struct k_fifo {
  * @req K-FIFO-002
  */
 #define K_FIFO_DEFINE(name) \
-	struct k_fifo name \
+	Z_DECL_ALIGN(struct k_fifo) name \
 		__in_section(_k_queue, static, name) = \
 		Z_FIFO_INITIALIZER(name)
 
@@ -2378,7 +2378,7 @@ struct k_lifo {
  * @req K-LIFO-002
  */
 #define K_LIFO_DEFINE(name) \
-	struct k_lifo name \
+	Z_DECL_ALIGN(struct k_lifo) name \
 		__in_section(_k_queue, static, name) = \
 		_K_LIFO_INITIALIZER(name)
 
@@ -2514,7 +2514,7 @@ __syscall int k_stack_pop(struct k_stack *stack, u32_t *data, s32_t timeout);
 #define K_STACK_DEFINE(name, stack_num_entries)                \
 	u32_t __noinit                                      \
 		_k_stack_buf_##name[stack_num_entries];        \
-	struct k_stack name                                    \
+	Z_DECL_ALIGN(struct k_stack) name                                    \
 		__in_section(_k_stack, static, name) =    \
 		_K_STACK_INITIALIZER(name, _k_stack_buf_##name, \
 				    stack_num_entries)
@@ -2949,7 +2949,7 @@ struct k_mutex {
  * @req K-MUTEX-001
  */
 #define K_MUTEX_DEFINE(name) \
-	struct k_mutex name \
+	Z_DECL_ALIGN(struct k_mutex) name \
 		__in_section(_k_mutex, static, name) = \
 		_K_MUTEX_INITIALIZER(name)
 
@@ -3150,7 +3150,7 @@ static inline unsigned int z_impl_k_sem_count_get(struct k_sem *sem)
  * @req K-SEM-002
  */
 #define K_SEM_DEFINE(name, initial_count, count_limit) \
-	struct k_sem name \
+	Z_DECL_ALIGN(struct k_sem) name \
 		__in_section(_k_sem, static, name) = \
 		Z_SEM_INITIALIZER(name, initial_count, count_limit); \
 	BUILD_ASSERT(((count_limit) != 0) && \
@@ -3240,7 +3240,7 @@ struct k_msgq_attrs {
 #define K_MSGQ_DEFINE(q_name, q_msg_size, q_max_msgs, q_align)      \
 	static char __noinit __aligned(q_align)              \
 		_k_fifo_buf_##q_name[(q_max_msgs) * (q_msg_size)];  \
-	struct k_msgq q_name                                        \
+	Z_DECL_ALIGN(struct k_msgq) q_name                                        \
 		__in_section(_k_msgq, static, q_name) =        \
 	       _K_MSGQ_INITIALIZER(q_name, _k_fifo_buf_##q_name,     \
 				  q_msg_size, q_max_msgs)
@@ -3504,7 +3504,7 @@ struct k_mbox {
  * @req K-MBOX-001
  */
 #define K_MBOX_DEFINE(name) \
-	struct k_mbox name \
+	Z_DECL_ALIGN(struct k_mbox) name \
 		__in_section(_k_mbox, static, name) = \
 		_K_MBOX_INITIALIZER(name) \
 
@@ -3707,7 +3707,7 @@ struct k_pipe {
 #define K_PIPE_DEFINE(name, pipe_buffer_size, pipe_align)		\
 	static unsigned char __noinit __aligned(pipe_align)	\
 		_k_pipe_buf_##name[pipe_buffer_size];			\
-	struct k_pipe name						\
+	Z_DECL_ALIGN(struct k_pipe) name						\
 		__in_section(_k_pipe, static, name) =			\
 		_K_PIPE_INITIALIZER(name, _k_pipe_buf_##name, pipe_buffer_size)
 
@@ -3888,7 +3888,7 @@ struct k_mem_slab {
 #define K_MEM_SLAB_DEFINE(name, slab_block_size, slab_num_blocks, slab_align) \
 	char __noinit __aligned(slab_align) \
 		_k_mem_slab_buf_##name[(slab_num_blocks) * (slab_block_size)]; \
-	struct k_mem_slab name \
+	Z_DECL_ALIGN(struct k_mem_slab) name \
 		__in_section(_k_mem_slab, static, name) = \
 		_K_MEM_SLAB_INITIALIZER(name, _k_mem_slab_buf_##name, \
 				      slab_block_size, slab_num_blocks)
@@ -4025,7 +4025,8 @@ struct k_mem_pool {
 	char __aligned(align) _mpool_buf_##name[_ALIGN4(maxsz * nmax)	\
 				  + _MPOOL_BITS_SIZE(maxsz, minsz, nmax)]; \
 	struct sys_mem_pool_lvl _mpool_lvls_##name[Z_MPOOL_LVLS(maxsz, minsz)]; \
-	struct k_mem_pool name __in_section(_k_mem_pool, static, name) = { \
+	Z_DECL_ALIGN(struct k_mem_pool) name \
+		__in_section(_k_mem_pool, static, name) = { \
 		.base = {						\
 			.buf = _mpool_buf_##name,			\
 			.max_sz = maxsz,				\

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -186,9 +186,8 @@ struct _k_object_assignment {
 #define K_THREAD_ACCESS_GRANT(name_, ...) \
 	static void * const _CONCAT(_object_list_, name_)[] = \
 		{ __VA_ARGS__, NULL }; \
-	static __used __in_section_unique(object_access) \
-		const Z_DECL_ALIGN(struct _k_object_assignment) \
-		_CONCAT(_object_access_, name_) = \
+	static const Z_STRUCT_SECTION_ITERABLE(_k_object_assignment, \
+					_CONCAT(_object_access_, name_)) = \
 			{ (&_k_thread_obj_ ## name_), \
 			  (_CONCAT(_object_list_, name_)) }
 
@@ -968,9 +967,8 @@ struct _static_thread_data {
 			entry, p1, p2, p3,                               \
 			prio, options, delay)                            \
 	K_THREAD_STACK_DEFINE(_k_thread_stack_##name, stack_size);	 \
-	struct k_thread _k_thread_obj_##name;			 \
-	Z_DECL_ALIGN(struct _static_thread_data) _k_thread_data_##name   \
-		__in_section(_static_thread_data, static, name) =        \
+	struct k_thread _k_thread_obj_##name;				 \
+	Z_STRUCT_SECTION_ITERABLE(_static_thread_data, _k_thread_data_##name) =\
 		_THREAD_INITIALIZER(&_k_thread_obj_##name,		 \
 				    _k_thread_stack_##name, stack_size,  \
 				entry, p1, p2, p3, prio, options, delay, \
@@ -1468,8 +1466,7 @@ typedef void (*k_timer_stop_t)(struct k_timer *timer);
  * @param stop_fn   Function to invoke if the timer is stopped while running.
  */
 #define K_TIMER_DEFINE(name, expiry_fn, stop_fn) \
-	Z_DECL_ALIGN(struct k_timer) name \
-		__in_section(_k_timer, static, name) = \
+	Z_STRUCT_SECTION_ITERABLE(k_timer, name) = \
 		Z_TIMER_INITIALIZER(name, expiry_fn, stop_fn)
 
 /**
@@ -2050,8 +2047,7 @@ static inline void *z_impl_k_queue_peek_tail(struct k_queue *queue)
  * @param name Name of the queue.
  */
 #define K_QUEUE_DEFINE(name) \
-	Z_DECL_ALIGN(struct k_queue) name \
-		__in_section(_k_queue, static, name) = \
+	Z_STRUCT_SECTION_ITERABLE(k_queue, name) = \
 		_K_QUEUE_INITIALIZER(name)
 
 /** @} */
@@ -2266,8 +2262,7 @@ struct k_fifo {
  * @req K-FIFO-002
  */
 #define K_FIFO_DEFINE(name) \
-	Z_DECL_ALIGN(struct k_fifo) name \
-		__in_section(_k_queue, static, name) = \
+	Z_STRUCT_SECTION_ITERABLE(k_fifo, name) = \
 		Z_FIFO_INITIALIZER(name)
 
 /** @} */
@@ -2378,8 +2373,7 @@ struct k_lifo {
  * @req K-LIFO-002
  */
 #define K_LIFO_DEFINE(name) \
-	Z_DECL_ALIGN(struct k_lifo) name \
-		__in_section(_k_queue, static, name) = \
+	Z_STRUCT_SECTION_ITERABLE(k_lifo, name) = \
 		_K_LIFO_INITIALIZER(name)
 
 /** @} */
@@ -2514,8 +2508,7 @@ __syscall int k_stack_pop(struct k_stack *stack, u32_t *data, s32_t timeout);
 #define K_STACK_DEFINE(name, stack_num_entries)                \
 	u32_t __noinit                                      \
 		_k_stack_buf_##name[stack_num_entries];        \
-	Z_DECL_ALIGN(struct k_stack) name                                    \
-		__in_section(_k_stack, static, name) =    \
+	Z_STRUCT_SECTION_ITERABLE(k_stack, name) = \
 		_K_STACK_INITIALIZER(name, _k_stack_buf_##name, \
 				    stack_num_entries)
 
@@ -2949,8 +2942,7 @@ struct k_mutex {
  * @req K-MUTEX-001
  */
 #define K_MUTEX_DEFINE(name) \
-	Z_DECL_ALIGN(struct k_mutex) name \
-		__in_section(_k_mutex, static, name) = \
+	Z_STRUCT_SECTION_ITERABLE(k_mutex, name) = \
 		_K_MUTEX_INITIALIZER(name)
 
 /**
@@ -3150,8 +3142,7 @@ static inline unsigned int z_impl_k_sem_count_get(struct k_sem *sem)
  * @req K-SEM-002
  */
 #define K_SEM_DEFINE(name, initial_count, count_limit) \
-	Z_DECL_ALIGN(struct k_sem) name \
-		__in_section(_k_sem, static, name) = \
+	Z_STRUCT_SECTION_ITERABLE(k_sem, name) = \
 		Z_SEM_INITIALIZER(name, initial_count, count_limit); \
 	BUILD_ASSERT(((count_limit) != 0) && \
 		     ((initial_count) <= (count_limit)));
@@ -3237,12 +3228,11 @@ struct k_msgq_attrs {
  *
  * @req K-MSGQ-001
  */
-#define K_MSGQ_DEFINE(q_name, q_msg_size, q_max_msgs, q_align)      \
-	static char __noinit __aligned(q_align)              \
-		_k_fifo_buf_##q_name[(q_max_msgs) * (q_msg_size)];  \
-	Z_DECL_ALIGN(struct k_msgq) q_name                                        \
-		__in_section(_k_msgq, static, q_name) =        \
-	       _K_MSGQ_INITIALIZER(q_name, _k_fifo_buf_##q_name,     \
+#define K_MSGQ_DEFINE(q_name, q_msg_size, q_max_msgs, q_align)		\
+	static char __noinit __aligned(q_align)				\
+		_k_fifo_buf_##q_name[(q_max_msgs) * (q_msg_size)];	\
+	Z_STRUCT_SECTION_ITERABLE(k_msgq, q_name) =			\
+	       _K_MSGQ_INITIALIZER(q_name, _k_fifo_buf_##q_name,	\
 				  q_msg_size, q_max_msgs)
 
 /**
@@ -3504,8 +3494,7 @@ struct k_mbox {
  * @req K-MBOX-001
  */
 #define K_MBOX_DEFINE(name) \
-	Z_DECL_ALIGN(struct k_mbox) name \
-		__in_section(_k_mbox, static, name) = \
+	Z_STRUCT_SECTION_ITERABLE(k_mbox, name) = \
 		_K_MBOX_INITIALIZER(name) \
 
 /**
@@ -3707,8 +3696,7 @@ struct k_pipe {
 #define K_PIPE_DEFINE(name, pipe_buffer_size, pipe_align)		\
 	static unsigned char __noinit __aligned(pipe_align)	\
 		_k_pipe_buf_##name[pipe_buffer_size];			\
-	Z_DECL_ALIGN(struct k_pipe) name						\
-		__in_section(_k_pipe, static, name) =			\
+	Z_STRUCT_SECTION_ITERABLE(k_pipe, name) = \
 		_K_PIPE_INITIALIZER(name, _k_pipe_buf_##name, pipe_buffer_size)
 
 /**
@@ -3888,8 +3876,7 @@ struct k_mem_slab {
 #define K_MEM_SLAB_DEFINE(name, slab_block_size, slab_num_blocks, slab_align) \
 	char __noinit __aligned(slab_align) \
 		_k_mem_slab_buf_##name[(slab_num_blocks) * (slab_block_size)]; \
-	Z_DECL_ALIGN(struct k_mem_slab) name \
-		__in_section(_k_mem_slab, static, name) = \
+	Z_STRUCT_SECTION_ITERABLE(k_mem_slab, name) = \
 		_K_MEM_SLAB_INITIALIZER(name, _k_mem_slab_buf_##name, \
 				      slab_block_size, slab_num_blocks)
 
@@ -4025,8 +4012,7 @@ struct k_mem_pool {
 	char __aligned(align) _mpool_buf_##name[_ALIGN4(maxsz * nmax)	\
 				  + _MPOOL_BITS_SIZE(maxsz, minsz, nmax)]; \
 	struct sys_mem_pool_lvl _mpool_lvls_##name[Z_MPOOL_LVLS(maxsz, minsz)]; \
-	Z_DECL_ALIGN(struct k_mem_pool) name \
-		__in_section(_k_mem_pool, static, name) = { \
+	Z_STRUCT_SECTION_ITERABLE(k_mem_pool, name) = { \
 		.base = {						\
 			.buf = _mpool_buf_##name,			\
 			.max_sz = maxsz,				\

--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -33,9 +33,9 @@
 
 	SECTION_DATA_PROLOGUE(_static_thread_area,,SUBALIGN(4))
 	{
-		_static_thread_data_list_start = .;
+		__static_thread_data_list_start = .;
 		KEEP(*(SORT_BY_NAME(".__static_thread_data.static.*")))
-		_static_thread_data_list_end = .;
+		__static_thread_data_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 #ifdef CONFIG_USERSPACE

--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -34,7 +34,7 @@
 	SECTION_DATA_PROLOGUE(_static_thread_area,,SUBALIGN(4))
 	{
 		_static_thread_data_list_start = .;
-		KEEP(*(SORT_BY_NAME("._static_thread_data.static.*")))
+		KEEP(*(SORT_BY_NAME(".__static_thread_data.static.*")))
 		_static_thread_data_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
@@ -88,6 +88,8 @@
 	{
 		_k_queue_list_start = .;
 		KEEP(*("._k_queue.static.*"))
+		KEEP(*("._k_fifo.static.*"))
+		KEEP(*("._k_lifo.static.*"))
 		_k_queue_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -38,9 +38,9 @@
 	 */
 	SECTION_PROLOGUE(object_access,,)
 	{
-		__object_access_start = .;
+		__k_object_assignment_list_start = .;
 		KEEP(*(".__k_object_assignment.*"))
-		__object_access_end = .;
+		__k_object_assignment_list_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif
 

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -39,7 +39,7 @@
 	SECTION_PROLOGUE(object_access,,)
 	{
 		__object_access_start = .;
-		KEEP(*(".object_access.*"))
+		KEEP(*(".__k_object_assignment.*"))
 		__object_access_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif
@@ -104,7 +104,7 @@
 	SECTION_DATA_PROLOGUE(_bt_settings_area,,SUBALIGN(4))
 	{
 		_bt_settings_start = .;
-		KEEP(*(SORT_BY_NAME("._bt_settings.static.*")))
+		KEEP(*(SORT_BY_NAME("._bt_settings_handler.static.*")))
 		_bt_settings_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -172,4 +172,20 @@
 	Z_DECL_ALIGN(struct struct_type) name \
 	__in_section(_##struct_type, static, name) __used
 
+/*
+ * Itterator for structure instances gathered by Z_STRUCT_SECTION_ITERABLE().
+ * The linker must provide a _<struct_type>_list_start symbol and a
+ * _<struct_type>_list_end symbol to mark the start and the end of the
+ * list of struct objects to iterate over.
+ */
+#define Z_STRUCT_SECTION_FOREACH(struct_type, iterator) \
+	extern struct struct_type _CONCAT(_##struct_type, _list_start)[]; \
+	extern struct struct_type _CONCAT(_##struct_type, _list_end)[]; \
+	for (struct struct_type *iterator = \
+			_CONCAT(_##struct_type, _list_start); \
+	     ({ __ASSERT(iterator <= _CONCAT(_##struct_type, _list_end), \
+			 "unexpected list end location"); \
+		iterator < _CONCAT(_##struct_type, _list_end); }); \
+	     iterator++)
+
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_COMMON_H_ */

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -144,4 +144,23 @@
 #define BUILD_ASSERT_MSG(EXPR, MSG) BUILD_ASSERT(EXPR)
 #endif
 
+/*
+ * This is meant to be used in conjonction with __in_section() and similar
+ * where scattered structure instances are concatened together by the linker
+ * and walked by the code at run time just like a contiguous array of such
+ * structures.
+ *
+ * Assemblers and linkers may insert alignment padding by default whose
+ * size is larger than the natural alignment for those structures when
+ * gathering various section segments together, messing up the array walk.
+ * To prevent this, we need to provide an explicit alignment not to rely
+ * on the default that might just work by luck.
+ *
+ * Alignment statements in  linker scripts are not sufficient as
+ * the assembler may add padding by itself to each segment when switching
+ * between sections within the same file even if it merges many such segments
+ * into a single section in the end.
+ */
+#define Z_DECL_ALIGN(type) __aligned(__alignof(type)) type
+
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_COMMON_H_ */

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -163,4 +163,13 @@
  */
 #define Z_DECL_ALIGN(type) __aligned(__alignof(type)) type
 
+/*
+ * Convenience helper combining __in_section() and Z_DECL_ALIGN().
+ * The section name is the struct type prepended with an underscore.
+ * The subsection is "static" and the subsubsection is the variable name.
+ */
+#define Z_STRUCT_SECTION_ITERABLE(struct_type, name) \
+	Z_DECL_ALIGN(struct struct_type) name \
+	__in_section(_##struct_type, static, name) __used
+
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_COMMON_H_ */

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -43,9 +43,6 @@ static inline void mbox_async_free(struct k_mbox_async *async)
 
 #endif /* CONFIG_NUM_MBOX_ASYNC_MSGS > 0 */
 
-extern struct k_mbox _k_mbox_list_start[];
-extern struct k_mbox _k_mbox_list_end[];
-
 #ifdef CONFIG_OBJECT_TRACING
 struct k_mbox *_trace_list_k_mbox;
 #endif	/* CONFIG_OBJECT_TRACING */
@@ -87,9 +84,7 @@ static int init_mbox_module(struct device *dev)
 	/* Complete initialization of statically defined mailboxes. */
 
 #ifdef CONFIG_OBJECT_TRACING
-	struct k_mbox *mbox;
-
-	for (mbox = _k_mbox_list_start; mbox < _k_mbox_list_end; mbox++) {
+	Z_STRUCT_SECTION_FOREACH(k_mbox, mbox) {
 		SYS_TRACING_OBJ_INIT(k_mbox, mbox);
 	}
 #endif /* CONFIG_OBJECT_TRACING */

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -14,9 +14,6 @@
 #include <ksched.h>
 #include <init.h>
 
-extern struct k_mem_slab _k_mem_slab_list_start[];
-extern struct k_mem_slab _k_mem_slab_list_end[];
-
 static struct k_spinlock lock;
 
 #ifdef CONFIG_OBJECT_TRACING
@@ -57,11 +54,7 @@ static int init_mem_slab_module(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	struct k_mem_slab *slab;
-
-	for (slab = _k_mem_slab_list_start;
-	     slab < _k_mem_slab_list_end;
-	     slab++) {
+	Z_STRUCT_SECTION_FOREACH(k_mem_slab, slab) {
 		create_free_list(slab);
 		SYS_TRACING_OBJ_INIT(k_mem_slab, slab);
 		z_object_init(slab);

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -13,19 +13,17 @@
 #include <misc/math_extras.h>
 #include <stdbool.h>
 
-/* Linker-defined symbols bound the static pool structs */
-extern struct k_mem_pool _k_mem_pool_list_start[];
-extern struct k_mem_pool _k_mem_pool_list_end[];
-
 static struct k_spinlock lock;
 
 static struct k_mem_pool *get_pool(int id)
 {
+	extern struct k_mem_pool _k_mem_pool_list_start[];
 	return &_k_mem_pool_list_start[id];
 }
 
 static int pool_id(struct k_mem_pool *pool)
 {
+	extern struct k_mem_pool _k_mem_pool_list_start[];
 	return pool - &_k_mem_pool_list_start[0];
 }
 
@@ -38,9 +36,8 @@ static void k_mem_pool_init(struct k_mem_pool *p)
 int init_static_pools(struct device *unused)
 {
 	ARG_UNUSED(unused);
-	struct k_mem_pool *p;
 
-	for (p = _k_mem_pool_list_start; p < _k_mem_pool_list_end; p++) {
+	Z_STRUCT_SECTION_FOREACH(k_mem_pool, p) {
 		k_mem_pool_init(p);
 	}
 

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -23,9 +23,6 @@
 #include <syscall_handler.h>
 #include <kernel_internal.h>
 
-extern struct k_msgq _k_msgq_list_start[];
-extern struct k_msgq _k_msgq_list_end[];
-
 #ifdef CONFIG_OBJECT_TRACING
 
 struct k_msgq *_trace_list_k_msgq;
@@ -37,9 +34,7 @@ static int init_msgq_module(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	struct k_msgq *msgq;
-
-	for (msgq = _k_msgq_list_start; msgq < _k_msgq_list_end; msgq++) {
+	Z_STRUCT_SECTION_FOREACH(k_msgq, msgq) {
 		SYS_TRACING_OBJ_INIT(k_msgq, msgq);
 	}
 	return 0;

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -38,9 +38,6 @@
 #include <syscall_handler.h>
 #include <tracing.h>
 
-extern struct k_mutex _k_mutex_list_start[];
-extern struct k_mutex _k_mutex_list_end[];
-
 /* We use a global spinlock here because some of the synchronization
  * is protecting things like owner thread priorities which aren't
  * "part of" a single k_mutex.  Should move those bits of the API
@@ -59,9 +56,7 @@ static int init_mutex_module(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	struct k_mutex *mutex;
-
-	for (mutex = _k_mutex_list_start; mutex < _k_mutex_list_end; mutex++) {
+	Z_STRUCT_SECTION_FOREACH(k_mutex, mutex) {
 		SYS_TRACING_OBJ_INIT(k_mutex, mutex);
 	}
 	return 0;

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -37,9 +37,6 @@ struct k_pipe_async {
 	struct k_pipe_desc  desc;     /* Pipe message descriptor */
 };
 
-extern struct k_pipe _k_pipe_list_start[];
-extern struct k_pipe _k_pipe_list_end[];
-
 #ifdef CONFIG_OBJECT_TRACING
 struct k_pipe *_trace_list_k_pipe;
 #endif	/* CONFIG_OBJECT_TRACING */
@@ -118,9 +115,7 @@ static int init_pipes_module(struct device *dev)
 	/* Complete initialization of statically defined mailboxes. */
 
 #ifdef CONFIG_OBJECT_TRACING
-	struct k_pipe *pipe;
-
-	for (pipe = _k_pipe_list_start; pipe < _k_pipe_list_end; pipe++) {
+	Z_STRUCT_SECTION_FOREACH(k_pipe, pipe) {
 		SYS_TRACING_OBJ_INIT(k_pipe, pipe);
 	}
 #endif /* CONFIG_OBJECT_TRACING */

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -23,9 +23,6 @@
 #include <syscall_handler.h>
 #include <kernel_internal.h>
 
-extern struct k_queue _k_queue_list_start[];
-extern struct k_queue _k_queue_list_end[];
-
 struct alloc_node {
 	sys_sfnode_t node;
 	void *data;
@@ -70,9 +67,7 @@ static int init_queue_module(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	struct k_queue *queue;
-
-	for (queue = _k_queue_list_start; queue < _k_queue_list_end; queue++) {
+	Z_STRUCT_SECTION_FOREACH(k_queue, queue) {
 		SYS_TRACING_OBJ_INIT(k_queue, queue);
 	}
 	return 0;

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -29,9 +29,6 @@
 #include <syscall_handler.h>
 #include <tracing.h>
 
-extern struct k_sem _k_sem_list_start[];
-extern struct k_sem _k_sem_list_end[];
-
 /* We use a system-wide lock to synchronize semaphores, which has
  * unfortunate performance impact vs. using a per-object lock
  * (semaphores are *very* widely used).  But per-object locks require
@@ -52,9 +49,7 @@ static int init_sem_module(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	struct k_sem *sem;
-
-	for (sem = _k_sem_list_start; sem < _k_sem_list_end; sem++) {
+	Z_STRUCT_SECTION_FOREACH(k_sem, sem) {
 		SYS_TRACING_OBJ_INIT(k_sem, sem);
 	}
 	return 0;

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -20,9 +20,6 @@
 #include <syscall_handler.h>
 #include <kernel_internal.h>
 
-extern struct k_stack _k_stack_list_start[];
-extern struct k_stack _k_stack_list_end[];
-
 #ifdef CONFIG_OBJECT_TRACING
 
 struct k_stack *_trace_list_k_stack;
@@ -34,9 +31,7 @@ static int init_stack_module(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	struct k_stack *stack;
-
-	for (stack = _k_stack_list_start; stack < _k_stack_list_end; stack++) {
+	Z_STRUCT_SECTION_FOREACH(k_stack, stack) {
 		SYS_TRACING_OBJ_INIT(k_stack, stack);
 	}
 	return 0;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -32,16 +32,10 @@
 #include <tracing.h>
 #include <stdbool.h>
 
-extern struct _static_thread_data _static_thread_data_list_start[];
-extern struct _static_thread_data _static_thread_data_list_end[];
-
 static struct k_spinlock lock;
 
 #define _FOREACH_STATIC_THREAD(thread_data)              \
-	for (struct _static_thread_data *thread_data =   \
-	     _static_thread_data_list_start;             \
-	     thread_data < _static_thread_data_list_end; \
-	     thread_data++)
+	Z_STRUCT_SECTION_FOREACH(_static_thread_data, thread_data)
 
 void k_thread_foreach(k_thread_user_cb_t user_cb, void *user_data)
 {
@@ -614,16 +608,10 @@ void z_thread_single_abort(struct k_thread *thread)
 
 #ifdef CONFIG_MULTITHREADING
 #ifdef CONFIG_USERSPACE
-extern char __object_access_start[];
-extern char __object_access_end[];
 
 static void grant_static_access(void)
 {
-	struct _k_object_assignment *pos;
-
-	for (pos = (struct _k_object_assignment *)__object_access_start;
-	     pos < (struct _k_object_assignment *)__object_access_end;
-	     pos++) {
+	Z_STRUCT_SECTION_FOREACH(_k_object_assignment, pos) {
 		for (int i = 0; pos->objects[i] != NULL; i++) {
 			k_object_access_grant(pos->objects[i],
 					      pos->thread);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -12,9 +12,6 @@
 #include <stdbool.h>
 #include <spinlock.h>
 
-extern struct k_timer _k_timer_list_start[];
-extern struct k_timer _k_timer_list_end[];
-
 static struct k_spinlock lock;
 
 #ifdef CONFIG_OBJECT_TRACING
@@ -28,9 +25,7 @@ static int init_timer_module(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	struct k_timer *timer;
-
-	for (timer = _k_timer_list_start; timer < _k_timer_list_end; timer++) {
+	Z_STRUCT_SECTION_FOREACH(k_timer, timer) {
 		SYS_TRACING_OBJ_INIT(k_timer, timer);
 	}
 	return 0;

--- a/subsys/bluetooth/host/settings.h
+++ b/subsys/bluetooth/host/settings.h
@@ -14,8 +14,7 @@ struct bt_settings_handler {
 };
 
 #define BT_SETTINGS_DEFINE(_name, _set, _commit, _export)               \
-	const Z_DECL_ALIGN(struct bt_settings_handler) _name            \
-			__in_section(_bt_settings, static, _name) = {   \
+	const Z_STRUCT_SECTION_ITERABLE(bt_settings_handler, _name) = { \
 				.name = STRINGIFY(_name),               \
 				.set = _set,                            \
 				.commit = _commit,                      \

--- a/subsys/bluetooth/host/settings.h
+++ b/subsys/bluetooth/host/settings.h
@@ -14,7 +14,7 @@ struct bt_settings_handler {
 };
 
 #define BT_SETTINGS_DEFINE(_name, _set, _commit, _export)               \
-	const struct bt_settings_handler _name __aligned(4)             \
+	const Z_DECL_ALIGN(struct bt_settings_handler) _name            \
 			__in_section(_bt_settings, static, _name) = {   \
 				.name = STRINGIFY(_name),               \
 				.set = _set,                            \


### PR DESCRIPTION
Please see individual commits for the details. The second one depends
on the first so I'm submitting them together.