### PR TITLE
Bluetooth: controller: split: Port Enc setup to be queueable

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -564,11 +564,6 @@ u8_t ll_adv_enable(u8_t enable)
 		conn_lll->nesn = 0;
 		conn_lll->empty = 0;
 
-#if defined(CONFIG_BT_CTLR_LE_ENC)
-		conn_lll->enc_rx = 0;
-		conn_lll->enc_tx = 0;
-#endif /* CONFIG_BT_CTLR_LE_ENC */
-
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 		conn_lll->max_tx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
 		conn_lll->max_rx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
@@ -627,7 +622,10 @@ u8_t ll_adv_enable(u8_t enable)
 		conn->llcp_terminate.node_rx.hdr.link = link;
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
-		conn->pause_tx = conn->pause_rx = conn->refresh = 0;
+		conn_lll->enc_rx = conn_lll->enc_tx = 0U;
+		conn->llcp_enc.req = conn->llcp_enc.ack = 0U;
+		conn->llcp_enc.pause_tx = conn->llcp_enc.pause_rx = 0U;
+		conn->llcp_enc.refresh = 0U;
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -87,9 +87,6 @@ struct ll_conn {
 		struct {
 			u8_t  initiate;
 			u8_t  error_code;
-			u8_t  rand[8];
-			u8_t  ediv[2];
-			u8_t  ltk[16];
 			u8_t  skd[16];
 		} encryption;
 #endif /* CONFIG_BT_CTLR_LE_ENC */
@@ -117,6 +114,19 @@ struct ll_conn {
 			u8_t reason;
 		} node_rx;
 	} llcp_terminate;
+
+#if defined(CONFIG_BT_CTLR_LE_ENC)
+	struct {
+		u8_t req;
+		u8_t ack;
+		u8_t pause_rx:1;
+		u8_t pause_tx:1;
+		u8_t refresh:1;
+		u8_t ediv[2];
+		u8_t rand[8];
+		u8_t ltk[16];
+	} llcp_enc;
+#endif /* CONFIG_BT_CTLR_LE_ENC */
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 	struct {
@@ -190,12 +200,6 @@ struct ll_conn {
 	u8_t phy_pref_flags:1;
 	u8_t phy_pref_rx:3;
 #endif /* CONFIG_BT_CTLR_PHY */
-
-#if defined(CONFIG_BT_CTLR_LE_ENC)
-	u8_t  pause_rx:1;
-	u8_t  pause_tx:1;
-	u8_t  refresh:1;
-#endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	struct node_tx *tx_head;
 	struct node_tx *tx_ctrl;

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -118,11 +118,6 @@ u8_t ll_create_connection(u16_t scan_interval, u16_t scan_window,
 	conn_lll->nesn = 0;
 	conn_lll->empty = 0;
 
-#if defined(CONFIG_BT_CTLR_LE_ENC)
-	conn_lll->enc_rx = 0;
-	conn_lll->enc_tx = 0;
-#endif /* CONFIG_BT_CTLR_LE_ENC */
-
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	conn_lll->max_tx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
 	conn_lll->max_rx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
@@ -197,7 +192,10 @@ u8_t ll_create_connection(u16_t scan_interval, u16_t scan_window,
 	conn->llcp_terminate.node_rx.hdr.link = link;
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
-	conn->pause_tx = conn->pause_rx = conn->refresh = 0U;
+	conn_lll->enc_rx = conn_lll->enc_tx = 0U;
+	conn->llcp_enc.req = conn->llcp_enc.ack = 0U;
+	conn->llcp_enc.pause_tx = conn->llcp_enc.pause_rx = 0U;
+	conn->llcp_enc.refresh = 0U;
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
@@ -337,16 +335,14 @@ u8_t ll_enc_req_send(u16_t handle, u8_t *rand, u8_t *ediv, u8_t *ltk)
 {
 	struct ll_conn *conn;
 	struct node_tx *tx;
-	u8_t ret;
 
 	conn = ll_connected_get(handle);
 	if (!conn) {
 		return BT_HCI_ERR_UNKNOWN_CONN_ID;
 	}
 
-	ret = ull_conn_llcp_req(conn);
-	if (ret) {
-		return ret;
+	if (conn->llcp_enc.req != conn->llcp_enc.ack) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
 	tx = ll_tx_mem_acquire();
@@ -355,8 +351,7 @@ u8_t ll_enc_req_send(u16_t handle, u8_t *rand, u8_t *ediv, u8_t *ltk)
 
 		pdu_data_tx = (void *)tx->pdu;
 
-		memcpy(&conn->llcp.encryption.ltk[0], ltk,
-		       sizeof(conn->llcp.encryption.ltk));
+		memcpy(&conn->llcp_enc.ltk[0], ltk, sizeof(conn->llcp_enc.ltk));
 
 		if ((conn->lll.enc_rx == 0) && (conn->lll.enc_tx == 0)) {
 			struct pdu_data_llctrl_enc_req *enc_req;
@@ -375,11 +370,11 @@ u8_t ll_enc_req_send(u16_t handle, u8_t *rand, u8_t *ediv, u8_t *ltk)
 			bt_rand(enc_req->skdm, sizeof(enc_req->skdm));
 			bt_rand(enc_req->ivm, sizeof(enc_req->ivm));
 		} else if ((conn->lll.enc_rx != 0) && (conn->lll.enc_tx != 0)) {
-			memcpy(&conn->llcp.encryption.rand[0], rand,
-			       sizeof(conn->llcp.encryption.rand));
+			memcpy(&conn->llcp_enc.rand[0], rand,
+			       sizeof(conn->llcp_enc.rand));
 
-			conn->llcp.encryption.ediv[0] = ediv[0];
-			conn->llcp.encryption.ediv[1] = ediv[1];
+			conn->llcp_enc.ediv[0] = ediv[0];
+			conn->llcp_enc.ediv[1] = ediv[1];
 
 			pdu_data_tx->ll_id = PDU_DATA_LLID_CTRL;
 			pdu_data_tx->len = offsetof(struct pdu_data_llctrl,
@@ -398,10 +393,7 @@ u8_t ll_enc_req_send(u16_t handle, u8_t *rand, u8_t *ediv, u8_t *ltk)
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}
 
-		conn->llcp.encryption.initiate = 1U;
-
-		conn->llcp_type = LLCP_ENCRYPTION;
-		conn->llcp_req++;
+		conn->llcp_enc.req++;
 
 		return 0;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -393,7 +393,7 @@ u8_t ll_start_enc_req_send(u16_t handle, u8_t error_code,
 	}
 
 	if (error_code) {
-		if (conn->refresh == 0U) {
+		if (conn->llcp_enc.refresh == 0U) {
 			ret = ull_conn_llcp_req(conn);
 			if (ret) {
 				return ret;
@@ -415,13 +415,12 @@ u8_t ll_start_enc_req_send(u16_t handle, u8_t error_code,
 			conn->llcp_terminate.req++;
 		}
 	} else {
-		memcpy(&conn->llcp.encryption.ltk[0], ltk,
-		       sizeof(conn->llcp.encryption.ltk));
-
 		ret = ull_conn_llcp_req(conn);
 		if (ret) {
 			return ret;
 		}
+
+		memcpy(&conn->llcp_enc.ltk[0], ltk, sizeof(conn->llcp_enc.ltk));
 
 		conn->llcp.encryption.error_code = 0U;
 		conn->llcp.encryption.initiate = 0U;


### PR DESCRIPTION
Port the fix for the controller implementation to make start
encryption queueable if there is any control procedure in
progress.

Refer to #15335.
Relates to #15335, #15186, #15958 and #14636.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>