### PR TITLE
modules: move module kconfig to main tree

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -262,6 +262,7 @@
 /lib/cmsis_rtos_v2/                       @nashif
 /lib/cmsis_rtos_v1/                       @nashif
 /lib/libc/                                @nashif @andrewboie
+/modules/                                 @nashif
 /kernel/device.c                          @andrewboie @andyross @nashif
 /kernel/idle.c                            @andrewboie @andyross @nashif
 /samples/                                 @nashif

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -10,6 +10,7 @@
 menu "Modules"
 
 source "$(CMAKE_BINARY_DIR)/Kconfig.modules"
+source "modules/Kconfig"
 
 endmenu
 
@@ -43,6 +44,7 @@ source "lib/Kconfig"
 source "subsys/Kconfig"
 
 source "ext/Kconfig"
+
 
 menu "Build and Link Features"
 

--- a/modules/Kconfig
+++ b/modules/Kconfig
@@ -1,0 +1,8 @@
+
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+comment "Optional modules. Make sure they're installed, via the project manifest."
+
+osource "modules/Kconfig.*"

--- a/modules/Kconfig.qmsi
+++ b/modules/Kconfig.qmsi
@@ -1,0 +1,20 @@
+# Kconfig - QMSI drivers configuration options
+
+#
+# Copyright (c) 2015 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menu "QMSI"
+
+config HAS_QMSI
+	bool
+
+config QMSI
+	bool "QMSI driver support"
+	depends on HAS_QMSI
+	help
+	  Enable QMSI driver support.
+
+endmenu

--- a/modules/Kconfig.tinycbor
+++ b/modules/Kconfig.tinycbor
@@ -1,0 +1,61 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config TINYCBOR
+	bool "tinyCBOR Support"
+	help
+	  This option enables the tinyCBOR library.
+
+if TINYCBOR
+
+config CBOR_NO_DFLT_WRITER
+	bool "No default writer support"
+	help
+	  This option specifies whether a default writer exists.
+
+config CBOR_NO_DFLT_READER
+	bool "No default reader support"
+	help
+	  This option specifies whether a default reader exists.
+
+config CBOR_ENCODER_NO_CHECK_USER
+	bool "No encoder checks for user args for validity"
+	help
+	  This option specifies whether a check user exists for a cbor encoder.
+
+config CBOR_PARSER_MAX_RECURSIONS
+	int "Parser max recursions"
+	default 1024
+	help
+	  This option specifies max recursions for the parser.
+
+config CBOR_PARSER_NO_STRICT_CHECKS
+	bool "No strict parser checks"
+	help
+	  This option enables the strict parser checks.
+
+config CBOR_FLOATING_POINT
+	bool "Floating point support"
+	select NEWLIB_LIBC
+	help
+	  This option enables floating point support.
+
+config CBOR_HALF_FLOAT_TYPE
+	bool "Half float type support"
+	select NEWLIB_LIBC
+	help
+	  This option enables half float type support.
+
+config CBOR_WITHOUT_OPEN_MEMSTREAM
+	bool "Without open memstream"
+	default y
+	help
+	  This option enables open memstream support.
+
+config CBOR_PRETTY_PRINTING
+	bool "Implement pretty printing functionality"
+	help
+	  This option enables cbor_value_to_pretty_stream function.
+
+endif #TINYCBOR

--- a/west.yml
+++ b/west.yml
@@ -37,9 +37,9 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: tinycbor
       path: modules/lib/tinycbor
-      revision: 111f7a215cc4efa49fd03a7835719adca83b4388
+      revision: 31ae89e4b768612722620cb6cb173a0de4a19cc9
     - name: hal_qmsi
-      revision: 3179a8e44912a5a05b1cb467870b7e91aedff8d6
+      revision: 9195fe6f97e4f7f25a3fc9e5a515f1b7af13762c
       path: modules/hal/qmsi
     - name: esp-idf
       revision: 6835bfc741bf15e98fb7971293913f770df6081f


### PR DESCRIPTION
Due to in-tree dependencies on Kconfig options defined in modules we end
up having warnings and errors when those modules are not part of the
manifest.

Users should be able to remove unwanted modules from their downstream
manifest and still build any board configurations.

Related:

https://github.com/zephyrproject-rtos/tinycbor/pull/6
https://github.com/zephyrproject-rtos/hal_qmsi/pull/1
