### PR TITLE
testsuite: coverage: port GCOV linker code to CMake for X86

### DIFF
--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -196,21 +196,6 @@ SECTIONS
 	/* RAMABLE_REGION */
 	GROUP_START(RAMABLE_REGION)
 
-#ifdef CONFIG_COVERAGE_GCOV
-	SECTION_PROLOGUE(_GCOV_BSS_SECTION_NAME, (NOLOAD),)
-	{
-		MMU_PAGE_ALIGN
-		__gcov_bss_start = .;
-		*(".bss.__gcov0.*");
-		. = ALIGN(4);
-		MMU_PAGE_ALIGN
-		__gcov_bss_end = .;
-	}GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
-
-	__gcov_bss_num_words = ((__gcov_bss_end - __gcov_bss_start) >> 2);
-	__gcov_bss_size = __gcov_bss_end - __gcov_bss_start;
-#endif /* CONFIG_COVERAGE_GCOV */
-
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */

--- a/subsys/testsuite/coverage/coverage_ram.ld
+++ b/subsys/testsuite/coverage/coverage_ram.ld
@@ -6,6 +6,7 @@
 
 /* Copied from linker.ld */
 
+#ifdef CONFIG_ARM
 SECTION_DATA_PROLOGUE(_GCOV_BSS_SECTION_NAME,(NOLOAD),)
 {
 #ifdef CONFIG_USERSPACE
@@ -28,3 +29,19 @@ SECTION_DATA_PROLOGUE(_GCOV_BSS_SECTION_NAME,(NOLOAD),)
 
 __gcov_bss_num_words = ((__gcov_bss_end - __gcov_bss_start) >> 2);
 __gcov_bss_size = __gcov_bss_end - __gcov_bss_start;
+#endif
+
+#ifdef CONFIG_X86
+SECTION_PROLOGUE(_GCOV_BSS_SECTION_NAME, (NOLOAD),)
+{
+	MMU_PAGE_ALIGN
+	__gcov_bss_start = .;
+	*(".bss.__gcov0.*");
+	. = ALIGN(4);
+	MMU_PAGE_ALIGN
+	__gcov_bss_end = .;
+}GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+
+__gcov_bss_num_words = ((__gcov_bss_end - __gcov_bss_start) >> 2);
+__gcov_bss_size = __gcov_bss_end - __gcov_bss_start;
+#endif


### PR DESCRIPTION
port GCOV linker code to CMake for X86 platfrom, from linker.ld
to coverage_ram.ld.

Fixes: #16501.

Signed-off-by: Wentong Wu <wentong.wu@intel.com>