### PR TITLE
tests: net: socket: register: Close socket after test

### DIFF
--- a/tests/net/socket/register/src/main.c
+++ b/tests/net/socket/register/src/main.c
@@ -246,6 +246,8 @@ void test_create_sockets(void)
 		} else {
 			failed_tests++;
 		}
+
+		close(fd);
 	}
 
 	zassert_equal(ok_tests + failed_tests - failed_family, func_called,


### PR DESCRIPTION
The file descriptor was not closed after the test which caused
Coverity to complain about resource leak.

Coverity-CID: 198640
Fixes #16493

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>