### PR TITLE
Bluetooth: GATT: Add support to notify by UUID

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -339,6 +339,24 @@ enum {
 typedef u8_t (*bt_gatt_attr_func_t)(const struct bt_gatt_attr *attr,
 				       void *user_data);
 
+/** @brief Attribute iterator by type.
+ *
+ *  Iterate attributes in the given range matching given UUID and/or data.
+ *
+ *  @param start_handle Start handle.
+ *  @param end_handle End handle.
+ *  @param uuid UUID to match, passing NULL skips UUID matching.
+ *  @param attr_data Attribute data to match, passing NULL skips data matching.
+ *  @param num_matches Number matches, passing 0 makes it unlimited.
+ *  @param func Callback function.
+ *  @param user_data Data to pass to the callback.
+ */
+void bt_gatt_foreach_attr_type(u16_t start_handle, u16_t end_handle,
+			       const struct bt_uuid *uuid,
+			       const void *attr_data, uint16_t num_matches,
+			       bt_gatt_attr_func_t func,
+			       void *user_data);
+
 /** @brief Attribute iterator.
  *
  *  Iterate attributes in the given range.
@@ -348,8 +366,13 @@ typedef u8_t (*bt_gatt_attr_func_t)(const struct bt_gatt_attr *attr,
  *  @param func Callback function.
  *  @param user_data Data to pass to the callback.
  */
-void bt_gatt_foreach_attr(u16_t start_handle, u16_t end_handle,
-			  bt_gatt_attr_func_t func, void *user_data);
+static inline void bt_gatt_foreach_attr(u16_t start_handle, u16_t end_handle,
+					bt_gatt_attr_func_t func,
+					void *user_data)
+{
+	bt_gatt_foreach_attr_type(start_handle, end_handle, NULL, NULL, 0, func,
+				  user_data);
+}
 
 /** @brief Iterate to the next attribute
  *

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -790,7 +790,9 @@ struct bt_gatt_notify_params {
  *  With the addition that after sending the notification the
  *  callback function will be called and can dispatch multiple
  *  notifications at once.
-
+ *
+ *  The callback is run from System Workqueue context.
+ *
  *  Alternatively it is possible to notify by UUID by setting it on the
  *  parameters, when using this method the attribute given when be used as the
  *  start range when looking up for possible matches.
@@ -1146,6 +1148,8 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
  * This function works in the same way as @ref bt_gatt_write_without_response.
  * With the addition that after sending the write the callback function will be
  * called.
+ *
+ * The callback is run from System Workqueue context.
  *
  * Note: By using a callback it also disable the internal flow control
  * which would prevent sending multiple commands without waiting for their

--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -10,7 +10,7 @@ menu "ATT and GATT Options"
 
 config BT_ATT_ENFORCE_FLOW
 	bool "Enforce strict flow control semantics for incoming PDUs"
-	default y if !(BOARD_QEMU_CORTEX_M3 || BOARD_QEMU_X86 || BOARD_NATIVE_POSIX)
+	default y if !(BOARD_QEMU_CORTEX_M3 || BOARD_QEMU_X86 || ARCH_POSIX)
 	help
 	  Enforce flow control rules on incoming PDUs, preventing a peer
 	  from sending new requests until a previous one has been responded

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -88,6 +88,8 @@ struct bt_conn_tx_data {
 
 struct bt_conn_tx {
 	sys_snode_t node;
+	struct bt_conn *conn;
+	struct k_work work;
 	struct bt_conn_tx_data data;
 };
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1440,14 +1440,6 @@ static u8_t notify_cb(const struct bt_gatt_attr *attr, void *user_data)
 	struct _bt_gatt_ccc *ccc;
 	size_t i;
 
-	if (bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CCC)) {
-		/* Stop if we reach the next characteristic */
-		if (!bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CHRC)) {
-			return BT_GATT_ITER_STOP;
-		}
-		return BT_GATT_ITER_CONTINUE;
-	}
-
 	/* Check attribute user_data must be of type struct _bt_gatt_ccc */
 	if (attr->write != bt_gatt_attr_write_ccc) {
 		return BT_GATT_ITER_CONTINUE;
@@ -1546,7 +1538,8 @@ int bt_gatt_notify_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 	nfy.data = data;
 	nfy.len = len;
 
-	bt_gatt_foreach_attr(handle, 0xffff, notify_cb, &nfy);
+	bt_gatt_foreach_attr_type(handle, 0xffff, BT_UUID_GATT_CCC, NULL, 1,
+				  notify_cb, &nfy);
 
 	return nfy.err;
 }
@@ -1573,7 +1566,8 @@ int bt_gatt_indicate(struct bt_conn *conn,
 	nfy.type = BT_GATT_CCC_INDICATE;
 	nfy.params = params;
 
-	bt_gatt_foreach_attr(handle, 0xffff, notify_cb, &nfy);
+	bt_gatt_foreach_attr_type(handle, 0xffff, BT_UUID_GATT_CCC, NULL, 1,
+				  notify_cb, &nfy);
 
 	return nfy.err;
 }

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -958,6 +958,8 @@ ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn,
 
 static u8_t gatt_foreach_iter(const struct bt_gatt_attr *attr,
 			      u16_t start_handle, u16_t end_handle,
+			      const struct bt_uuid *uuid,
+			      const void *attr_data, uint16_t *num_matches,
 			      bt_gatt_attr_func_t func, void *user_data)
 {
 	/* Stop if over the requested range */
@@ -970,14 +972,34 @@ static u8_t gatt_foreach_iter(const struct bt_gatt_attr *attr,
 		return BT_GATT_ITER_CONTINUE;
 	}
 
+	/* Match attribute UUID if set */
+	if (uuid && bt_uuid_cmp(uuid, attr->uuid)) {
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	/* Match attribute user_data if set */
+	if (attr_data && attr_data != attr->user_data) {
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	if (*num_matches) {
+		*num_matches -= 1;
+	}
+
 	return func(attr, user_data);
 }
 
-void bt_gatt_foreach_attr(u16_t start_handle, u16_t end_handle,
-			  bt_gatt_attr_func_t func, void *user_data)
+void bt_gatt_foreach_attr_type(u16_t start_handle, u16_t end_handle,
+			       const struct bt_uuid *uuid,
+			       const void *attr_data, uint16_t num_matches,
+			       bt_gatt_attr_func_t func, void *user_data)
 {
 	struct bt_gatt_service *svc;
 	int i;
+
+	if (!num_matches) {
+		num_matches = UINT16_MAX;
+	}
 
 	if (start_handle <= last_static_handle) {
 		const struct bt_gatt_service_static *static_svc;
@@ -1000,11 +1022,17 @@ void bt_gatt_foreach_attr(u16_t start_handle, u16_t end_handle,
 				attr.handle = handle;
 
 				if (gatt_foreach_iter(&attr, start_handle,
-						      end_handle, func,
-						      user_data) ==
+						      end_handle, uuid,
+						      attr_data, &num_matches,
+						      func, user_data) ==
 				    BT_GATT_ITER_STOP) {
 					return;
 				}
+			}
+
+			/* Stop if number of matches has reached 0 */
+			if (!num_matches) {
+				return;
 			}
 		}
 	}
@@ -1023,11 +1051,17 @@ void bt_gatt_foreach_attr(u16_t start_handle, u16_t end_handle,
 		for (i = 0; i < svc->attr_count; i++) {
 			struct bt_gatt_attr *attr = &svc->attrs[i];
 
-			if (gatt_foreach_iter(attr, start_handle,
-					      end_handle, func, user_data) ==
+			if (gatt_foreach_iter(attr, start_handle, end_handle,
+					      uuid, attr_data, &num_matches,
+					      func, user_data) ==
 			    BT_GATT_ITER_STOP) {
 				return;
 			}
+		}
+
+		/* Stop if number of matches has reached 0 */
+		if (!num_matches) {
+			return;
 		}
 	}
 }

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -1004,10 +1004,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(gatt_cmds,
 	SHELL_CMD_ARG(unregister, NULL,
 		      "unregister pre-predefined test service",
 		      cmd_unregister_test_svc, 1, 0),
-
-	SHELL_CMD_ARG(unregister, NULL,
-		      "unregister pre-predefined test service",
-		      cmd_unregister_test_svc, 1, 0),
 #endif /* CONFIG_BT_GATT_DYNAMIC_DB */
 	SHELL_SUBCMD_SET_END
 );

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -752,6 +752,41 @@ static int cmd_unregister_test_svc(const struct shell *shell,
 	return 0;
 }
 
+static void notify_cb(struct bt_conn *conn, void *user_data)
+{
+	const struct shell *shell = user_data;
+
+	shell_print(shell, "Nofication sent to conn %p", conn);
+}
+
+static int cmd_notify(const struct shell *shell, size_t argc, char *argv[])
+{
+	struct bt_gatt_notify_params params;
+	u8_t data = 0;
+
+	if (!echo_enabled) {
+		shell_error(shell, "Nofication not enabled");
+		return -ENOEXEC;
+	}
+
+	if (argc > 1) {
+		data = strtoul(argv[1], NULL, 16);
+	}
+
+	memset(&params, 0, sizeof(params));
+
+	params.uuid = &vnd1_echo_uuid.uuid;
+	params.attr = vnd1_attrs;
+	params.data = &data;
+	params.len = sizeof(data);
+	params.func = notify_cb;
+	params.user_data = (void *)shell;
+
+	bt_gatt_notify_cb(NULL, 1, &params);
+
+	return 0;
+}
+
 static struct bt_uuid_128 met_svc_uuid = BT_UUID_INIT_128(
 	0x01, 0xde, 0xbc, 0x9a, 0x78, 0x56, 0x34, 0x12,
 	0x78, 0x56, 0x34, 0x12, 0x78, 0x56, 0x34, 0x12);
@@ -1004,6 +1039,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(gatt_cmds,
 	SHELL_CMD_ARG(unregister, NULL,
 		      "unregister pre-predefined test service",
 		      cmd_unregister_test_svc, 1, 0),
+	SHELL_CMD_ARG(notify, NULL, "[data]", cmd_notify, 1, 1),
 #endif /* CONFIG_BT_GATT_DYNAMIC_DB */
 	SHELL_SUBCMD_SET_END
 );


### PR DESCRIPTION
This adds support to notify by UUID which can now be passed as parameter to bt_gatt_notify_cb, in addition to that bt_gatt_notify_cb can notify multiple values at once.

To test the notifications a new shell command is introduced, gatt notify, which test using bt_gatt_notify_cb with a callback and user_data but while doing this it uncover a problem with current design of TX callbacks which run in TX thread which has very limited stack size causing the shell to crash when printing something from within the callback, so this introduces a config option to defer the execution of TX callbacks to the system wq.