### PR TITLE
tests: flash_map: configure MPU to allow flash writes on twr_ke18f

### DIFF
--- a/tests/subsys/storage/flash_map/testcase.yaml
+++ b/tests/subsys/storage/flash_map/testcase.yaml
@@ -5,4 +5,5 @@ tests:
   storage.flash_map_mpu:
     extra_args: OVERLAY_CONFIG=overlay-mpu.conf
     platform_whitelist: nrf52840_pca10056 nrf52_pca10040 frdm_k64f hexiwear_k64
+                        twr_ke18f
     tags: flash_map


### PR DESCRIPTION
Configure the NXP MPU to allow flash writes when running the flash_map
test.

This fixes #16224.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>