### PR TITLE
tests: i2c: remove whitelist

### DIFF
--- a/tests/drivers/i2c/i2c_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_api/testcase.yaml
@@ -3,5 +3,3 @@ tests:
     depends_on: i2c
     tags: drivers i2c
     harness: sensor
-    #FIXME: We should remove those and just rely on depends_on, test now is HW specific
-    platform_whitelist: quark_se_c1000_devboard quark_d2000_crb quark_se_c1000_ss_devboard


### PR DESCRIPTION
The I2C API should not be device specific anymore but work on all supported platforms.

discovered in #16485