### PR TITLE
subsys/settings: Cleanup the initialisation of the subsys

### DIFF
--- a/subsys/settings/src/settings.c
+++ b/subsys/settings/src/settings.c
@@ -19,19 +19,15 @@ LOG_MODULE_REGISTER(settings, CONFIG_SETTINGS_LOG_LEVEL);
 
 sys_slist_t settings_handlers;
 
-static u8_t settings_cmd_inited;
 
 static struct settings_handler *settings_handler_lookup(char *name);
+
 void settings_store_init(void);
 
 void settings_init(void)
 {
-	if (!settings_cmd_inited) {
-		sys_slist_init(&settings_handlers);
-		settings_store_init();
-
-		settings_cmd_inited = 1U;
-	}
+	sys_slist_init(&settings_handlers);
+	settings_store_init();
 }
 
 int settings_register(struct settings_handler *handler)

--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -15,6 +15,9 @@
 #include "settings/settings_file.h"
 #include <zephyr.h>
 
+
+bool settings_subsys_initialized;
+
 void settings_init(void);
 
 int settings_backend_init(void);
@@ -123,10 +126,10 @@ int settings_backend_init(void)
 
 int settings_subsys_init(void)
 {
-	static bool settings_initialized;
+
 	int err = 0;
 
-	if (settings_initialized) {
+	if (settings_subsys_initialized) {
 		return 0;
 	}
 
@@ -135,7 +138,7 @@ int settings_subsys_init(void)
 	err = settings_backend_init(); /* func rises kernel panic once error */
 
 	if (!err) {
-		settings_initialized = true;
+		settings_subsys_initialized = true;
 	}
 
 	return err;


### PR DESCRIPTION
This commit removes redundant checks if the module
was already initialized.
The variable to mark the fact of initialization is
moved as a global module variable.
This allows creating more sophisticated unit tests
of the settings subsystem by giving a possibility to modify
the internal mark of the fact the system was initialized.

The problem I am trying to solve here is something I experienced during unit tests where I am trying to clear the settings module state between unit tests.