### PR TITLE
kernel: Add device linking API

### DIFF
--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -59,6 +59,13 @@
 		__devconfig_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
+	SECTION_PROLOGUE (devlink,,)
+	{
+		__devlink_start = .;
+		KEEP(*(".devlink"))
+		__devlink_end = .;
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
 	SECTION_PROLOGUE(net_l2,,)
 	{
 		__net_l2_start = .;

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -908,9 +908,9 @@ class SizeCalculator:
 
     # These get copied into RAM only on non-XIP
     ro_sections = ["text", "ctors", "init_array", "reset", "object_access",
-                   "rodata", "devconfig", "net_l2", "vector", "sw_isr_table",
-                   "_bt_settings_area", "_bt_channels_area","_bt_services_area",
-                   "vectors", "net_socket_register"]
+                   "rodata", "devconfig", "devlink", "net_l2", "vector",
+                   "sw_isr_table", "_bt_settings_area", "_bt_channels_area",
+                   "_bt_services_area", "vectors", "net_socket_register"]
 
     def __init__(self, filename, extra_sections):
         """Constructor

--- a/tests/kernel/device/src/dummy_driver.c
+++ b/tests/kernel/device/src/dummy_driver.c
@@ -38,6 +38,7 @@ int dummy_init(struct device *dev)
 DEVICE_AND_API_INIT(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,
 		    NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &funcs);
+DEVICE_LINK_CLOCK(dummy_driver, DUMMY_DRIVER_NAME, 0);
 
 /**
  * @endcond

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -56,6 +56,33 @@ void test_dummy_device(void)
 }
 
 /**
+ * @brief Test device object link lookup
+ *
+ * Validates device link lookup for an existing and a non-existing device
+ * link.
+ *
+ * @see device_get_linked()
+ */
+void test_linked_device(void)
+{
+	struct device *dev;
+	struct device *linked;
+
+	linked = device_get_linked(NULL, DEVICE_LINK_TYPE_CLOCK, 0);
+	zassert_equal(linked, NULL, NULL);
+
+	dev = device_get_binding(DUMMY_PORT_2);
+	zassert_false((dev == NULL), NULL);
+
+	linked = device_get_linked(dev, DEVICE_LINK_TYPE_DMA, 0);
+	zassert_equal(linked, NULL, NULL);
+	linked = device_get_linked(dev, DEVICE_LINK_TYPE_CLOCK, 1);
+	zassert_equal(linked, NULL, NULL);
+	linked = device_get_linked(dev, DEVICE_LINK_TYPE_CLOCK, 0);
+	zassert_false((linked == NULL), NULL);
+}
+
+/**
  * @brief Test device binding for existing device
  *
  * Validates device binding for an existing device object.
@@ -176,6 +203,7 @@ void test_main(void)
 			 ztest_unit_test(test_dummy_device_pm),
 			 ztest_unit_test(build_suspend_device_list),
 			 ztest_unit_test(test_dummy_device),
+			 ztest_unit_test(test_linked_device),
 			 ztest_unit_test(test_bogus_dynamic_name),
 			 ztest_unit_test(test_dynamic_name));
 	ztest_run_test_suite(device);


### PR DESCRIPTION
This adds an API for creating links between devices (really between a device and a label for another device).  This arose from a [request](https://github.com/zephyrproject-rtos/zephyr/pull/15585#discussion_r286867684) by @pizi-nordic related to how to attach clock controllers/providers to devices.

Here the idea is generalized into a link type rather than being clocks only.  Currently only a clock and DMA types are defined, since those are the two I've come across in my own usage.  However, it could also be extended to provide another means to implement "parent" devices (e.g. an alternative to changing to device definition macros like #13129 is doing: add a new link type and link devices to their parent that way).

For a concrete example of how this would be used, see Sizurka/zephyr#5 (which would be merged into #15585 if this API is accepted).  Simplified, it's just adding a macro like:
```C
DEVICE_LINK_CLOCK(sam0_eic, DT_ATMEL_SAM0_EIC_0_CLOCK_CONTROLLER, 0);
```
After the device definition macro, then using code like:
```C
struct device *clk = device_get_clock(dev, 0);
```
To access the clock.