### PR TITLE
tests: cmsis_rtos_v1: remove cast abuses

### DIFF
--- a/tests/cmsis_rtos_v1/src/signal.c
+++ b/tests/cmsis_rtos_v1/src/signal.c
@@ -163,13 +163,13 @@ void test_signal_events_signalled(void)
 /* IRQ offload function handler to set signal flag */
 static void offload_function(void *param)
 {
-	u32_t tid = (u32_t)param;
+	osThreadId tid = param;
 	int signals;
 
 	/* Make sure we're in IRQ context */
 	zassert_true(k_is_in_isr(), "Not in IRQ context!");
 
-	signals = osSignalSet((osThreadId)tid, ISR_SIGNAL);
+	signals = osSignalSet(tid, ISR_SIGNAL);
 	zassert_not_equal(signals, 0x80000000, "signal set failed in ISR");
 }
 


### PR DESCRIPTION
Casting the tid variable from a void* into an u32_t just to cast it
back to a pointer is pointless. Let's make it a osThreadId variable
upfront and get rid of those casts around it. This also makes it
64-bit compatible.