### PR TITLE
CMakeLists.txt: -fmacro-prefix-map=${CMAKE_SOURCE_DIR}=CMAKE_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,13 @@ zephyr_cc_option_ifdef(CONFIG_STACK_USAGE            -fstack-usage)
 # application code. This saves some memory, stops leaking user locations
 # in binaries, makes failure logs more deterministic and most
 # importantly makes builds more deterministic
-zephyr_cc_option(-fmacro-prefix-map=${ZEPHYR_BASE}=.)
+
+# If both match then the last one wins. This matters for tests/ and
+# samples/ inside *both* CMAKE_SOURCE_DIR and ZEPHYR_BASE: for them
+# let's strip the shortest prefix.
+zephyr_cc_option(-fmacro-prefix-map=${CMAKE_SOURCE_DIR}=CMAKE_SOURCE_DIR)
+zephyr_cc_option(-fmacro-prefix-map=${ZEPHYR_BASE}=ZEPHYR_BASE)
+# TODO: -fmacro-prefix-map=modules/etc. "build/zephyr_modules.txt" might help.
 
 # TODO: Archiver arguments
 # ar_option(D)


### PR DESCRIPTION
In commit 28a5657 we stopped ZEPHYR_BASE from leaking into
\_\_FILE__ and other macros.  This works great for apps inside ZEPHYR_BASE
but does nothing for apps outside ZEPHYR_BASE.
-fmacro-prefix-map=${CMAKE_SOURCE_DIR}=CMAKE_SOURCE_DIR does it.

To avoid collisions and for consistency change:
  -fmacro-prefix-map=${ZEPHYR_BASE}=.
to:
  -fmacro-prefix-map=${ZEPHYR_BASE}=ZEPHYR_BASE

Quickest test/demo:

 - Copy samples/hello_word/ to ~/home_world/
 - Add "%s", \_\_FILE__  to printf in ~/home_world/src/main.c

 cmake -B build  -S ~/home_world/  -DBOARD=qemu_x86
 make  -C build  run

Before:
     ~/home_world/src/main.c says Hello World! qemu_x86

After:
 CMAKE_SOURCE_DIR/src/main.c says Hello World! qemu_x86

objdump -h $(find build -name *.c.obj) | grep noinit

  9 .noinit."ZEPHYR_BASE/kernel/system_work_q.c".0 0000
 17 .noinit."ZEPHYR_BASE/kernel/init.c".2 00000100  000
 18 .noinit."ZEPHYR_BASE/kernel/init.c".1 00000400  000
 19 .noinit."ZEPHYR_BASE/kernel/init.c".3 00000800  000
 16 .noinit."ZEPHYR_BASE/kernel/mailbox.c".2 00000348
 18 .noinit."ZEPHYR_BASE/kernel/mailbox.c".1 00000028
 20 .noinit."ZEPHYR_BASE/kernel/pipes.c".2 00000280  00
 22 .noinit."ZEPHYR_BASE/kernel/pipes.c".1 00000028  00

Signed-off-by: Marc Herbert <marc.herbert@intel.com>
