### PR TITLE
boards: twr_ke18f: configure SPI CS pins as GPIO if not used for SPI

### DIFF
--- a/boards/arm/twr_ke18f/pinmux.c
+++ b/boards/arm/twr_ke18f/pinmux.c
@@ -62,6 +62,8 @@ static int twr_ke18f_pinmux_init(struct device *dev)
 #ifdef CONFIG_BOARD_TWR_KE18F_SPI_0_PCS2
 	/* SPI0 PCS2 */
 	pinmux_pin_set(porte, 6, PORT_PCR_MUX(kPORT_MuxAlt2));
+#else
+	pinmux_pin_set(porte, 6, PORT_PCR_MUX(kPORT_MuxAsGpio));
 #endif
 
 #ifdef CONFIG_SPI_1
@@ -73,10 +75,14 @@ static int twr_ke18f_pinmux_init(struct device *dev)
 #ifdef CONFIG_BOARD_TWR_KE18F_SPI_1_PCS0
 	/* SPI1 PCS0 */
 	pinmux_pin_set(portd, 3, PORT_PCR_MUX(kPORT_MuxAlt3));
+#else
+	pinmux_pin_set(portd, 3, PORT_PCR_MUX(kPORT_MuxAsGpio));
 #endif
 #ifdef CONFIG_BOARD_TWR_KE18F_SPI_1_PCS2
 	/* SPI1 PCS2 */
 	pinmux_pin_set(porta, 16, PORT_PCR_MUX(kPORT_MuxAlt3));
+#else
+	pinmux_pin_set(porta, 16, PORT_PCR_MUX(kPORT_MuxAsGpio));
 #endif
 
 #ifdef CONFIG_BOARD_TWR_KE18F_FLEXIO_CLKOUT


### PR DESCRIPTION
Configure the LPSPI PCSx pins as GPIO if not dedicated to SPI CS. This
allows using them for SPI GPIO CS.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>