### PR TITLE
boards: galileo: Fix PINMUX_FUNC_D for io_pin 9.

### DIFF
--- a/boards/x86/galileo/pinmux.c
+++ b/boards/x86/galileo/pinmux.c
@@ -265,7 +265,7 @@ static struct mux_path _galileo_path[PINMUX_NUM_PINS * NUM_PIN_FUNCS] = {
 			    { EXP0,  7,   PIN_LOW, (GPIO_DIR_OUT) },
 			    { NONE,  0, DONT_CARE, (GPIO_DIR_IN)  },
 			    { NONE,  0, DONT_CARE, (GPIO_DIR_IN)  } } },
-	{9, PINMUX_FUNC_C, {{ NONE,  0, DONT_CARE, (GPIO_DIR_IN)  }, /* NONE */
+	{9, PINMUX_FUNC_D, {{ NONE,  0, DONT_CARE, (GPIO_DIR_IN)  }, /* NONE */
 			    { NONE,  0, DONT_CARE, (GPIO_DIR_IN)  },
 			    { NONE,  0, DONT_CARE, (GPIO_DIR_IN)  },
 			    { NONE,  0, DONT_CARE, (GPIO_DIR_IN)  },


### PR DESCRIPTION
Modified PINMUX_FUNC_C (which appears twice in a row for io_pin 9) with
PINMUX_FUNC_D.

Signed-off-by: George Dima <dima331453@gmail.com>