### PR TITLE
shell: Fix shell uart not waking up shell on mcumgr data

### DIFF
--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -53,9 +53,10 @@ static void uart_rx_handle(const struct shell_uart *sh_uart)
 					break;
 				}
 			}
+
 			rd_len -= i;
+			new_data = true;
 			if (rd_len) {
-				new_data = true;
 				for (u32_t j = 0; j < rd_len; j++) {
 					data[j] = data[i + j];
 				}


### PR DESCRIPTION
When mcumgr smp data was received over shell uart transport
it was not waking up shell thread and thus request was not
processed. Shell thread must be waken up on any incoming
data, even data which is only dedicated for mcumgr smp.

Fixes #16278 

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>