### PR TITLE
tests: uart: blacklist atsamd20_xpro from async test

### DIFF
--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -3,3 +3,5 @@ tests:
     tags: drivers
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
+    # samd20 has no DMA
+    platform_exclude: atsamd20_xpro


### PR DESCRIPTION
After #14867 was merged, the build of `tests/drivers/uart/uart_async_api` would always fail for samd20-xpro, since that MCU does not contain a DMA controller.

It would probably be better to introduce some `HAS_SERIAL_ASYNC` config option that this test then can depend on.

To make CI happy again, blacklist the samd20 board for now.