### PR TITLE
Only build async uart testcase on platforms that support async operation

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -22,6 +22,12 @@ config SERIAL_HAS_DRIVER
 	  to signal that there is a serial driver. This is being used
 	  by other drivers which are dependent on serial.
 
+config SERIAL_SUPPORT_ASYNC
+	bool
+	help
+	  This is an option to be enabled by individual serial driver
+	  to signal that the driver and hardware supports async operation.
+
 config SERIAL_SUPPORT_INTERRUPT
 	bool
 	help
@@ -30,6 +36,7 @@ config SERIAL_SUPPORT_INTERRUPT
 
 config UART_ASYNC_API
 	bool "Enable new asynchronous UART API [EXPERIMENTAL]"
+	depends on SERIAL_SUPPORT_ASYNC
 	help
 	  This option enables new asynchronous UART API.
 

--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -10,6 +10,7 @@ menuconfig UART_NRFX
 	default y
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
+	select SERIAL_SUPPORT_ASYNC
 	depends on SOC_FAMILY_NRF
 	help
 	  Enable support for nrfx UART drivers for nRF MCU series.

--- a/drivers/serial/Kconfig.sam0
+++ b/drivers/serial/Kconfig.sam0
@@ -9,6 +9,8 @@ menuconfig UART_SAM0
 	depends on SOC_FAMILY_SAM0
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
+	# the ASYNC implementation requires a DMA controller
+	select SERIAL_SUPPORT_ASYNC if ($(dt_int_val,DT_ATMEL_SAM0_DMAC_0) != 0)
 	select DMA if UART_ASYNC_API
 	help
 	  This option enables the SERCOMx USART driver for Atmel SAM0 MCUs.

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   peripheral.uart_async_api:
     tags: drivers
-    filter: CONFIG_UART_CONSOLE
+    filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC
     harness: keyboard


### PR DESCRIPTION
Currently the build of `tests/drivers/uart/uart_async_api` will fail always for `atsamd20-xpro`.

This is because SAMD20 does not contain a DMA controller, which is required by the sam0 serial driver for async operation.

This PR does three things:

 - Introduce a `SOC_SAM0_HAS_DMA` option to indicate that a sam0 SoC contains a DMA controller
 - introduce a `SERIAL_SUPPORT_ASYNC` option and make it depend on `SOC_SAM0_HAS_DMA` for the sam0 serial driver
 - Only build the `uart_async_api` test if `SERIAL_SUPPORT_ASYNC` is set.