### PR TITLE
ci: enable windows 'sanitycheck --build-only'

### DIFF
--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -102,7 +102,7 @@ respective websites.
 
    .. code-block:: console
 
-      choco install git python ninja dtc-msys2 gperf
+      choco install git python ninja dtc-msys2 gperf make
 
 #. Close the Administrator command prompt window.
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -163,12 +163,6 @@ Most everyday users will run with no arguments.
 """
 
 import os
-
-if os.name == 'nt':
-    print("Running sanitycheck on Windows is not supported yet.")
-    print("https://github.com/zephyrproject-rtos/zephyr/issues/2664")
-    exit(1)
-
 import contextlib
 import string
 import mmap
@@ -1404,7 +1398,7 @@ class MakeGenerator:
                         goal.fail("unknown_error")
 
                 else:
-                    goal = self.goals[name]
+                    goal = self.goals[name.strip()]
                     goal.make_state = state
 
                     if state == "finished":
@@ -1771,11 +1765,10 @@ class TestCase:
         achtung_regex = re.compile(
             br"(#ifdef|#endif)",
             re.MULTILINE)
-        warnings = None
 
         with open(inf_name) as inf:
-            with contextlib.closing(mmap.mmap(inf.fileno(), 0, mmap.MAP_PRIVATE,
-                                              mmap.PROT_READ, 0)) as main_c:
+            def mmap_worker(main_c):
+                warnings = None
                 suite_regex_match = suite_regex.search(main_c)
                 if not suite_regex_match:
                     # can't find ztest_test_suite, maybe a client, because
@@ -1799,6 +1792,15 @@ class TestCase:
                     main_c[suite_regex_match.end():suite_run_match.start()])
                 matches = [ match.decode().replace("test_", "") for match in _matches ]
                 return matches, warnings
+
+            if os.name == 'nt':
+                with contextlib.closing(mmap.mmap(inf.fileno(), 0, access=mmap.ACCESS_READ)) as main_c:
+                    return mmap_worker(main_c)
+            else:
+                with contextlib.closing(mmap.mmap(inf.fileno(), 0, mmap.MAP_PRIVATE,
+                                                  mmap.PROT_READ, 0)) as main_c:
+                    return mmap_worker(main_c)
+
 
     def scan_path(self, path):
         subcases = []
@@ -2192,6 +2194,7 @@ class TestSuite:
         for k, out_config in defconfig_list.items():
             test, plat, name = k
             defconfig = {}
+            os.makedirs(os.path.dirname(out_config), exist_ok=True)
             with open(out_config, "r") as fp:
                 for line in fp.readlines():
                     m = TestSuite.config_re.match(line)
@@ -3207,6 +3210,15 @@ def main():
     global options
     global run_individual_tests
     options = parse_arguments()
+
+    if (os.name == 'nt'):
+        print("Running sanitycheck on Windows is not supported yet.")
+        print("https://github.com/zephyrproject-rtos/zephyr/issues/2664")
+        if (not options.build_only) or (not options.disable_size_report):
+            print("Only Building without size report works for now.")
+            print("\t'--build-only --disable-size-report'")
+            print("You may need to enable long-path support in Windows OS.")
+            sys.exit(-1)
 
     if options.coverage:
         options.enable_coverage = True


### PR DESCRIPTION
- Small tweaks to fix paths/memory allocation.
- Still use Make (install with choco)
       - Plan to make WestGenerator class later.

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>