### PR TITLE
PTHREAD_MUTEX_DEFINE(): don't store into the _k_mutex section

### DIFF
--- a/include/posix/pthread.h
+++ b/include/posix/pthread.h
@@ -160,8 +160,7 @@ static inline int pthread_condattr_destroy(pthread_condattr_t *att)
  * @param name Symbol name of the mutex
  */
 #define PTHREAD_MUTEX_DEFINE(name) \
-	struct pthread_mutex name \
-		__in_section(_k_mutex, static, name) = \
+	struct pthread_mutex name = \
 	{ \
 		.lock_count = 0, \
 		.wait_q = Z_WAIT_Q_INIT(&name.wait_q),	\


### PR DESCRIPTION
The _k_mutex linker section is used to gather instances of
struct k_mutex into a list so that init_mutex_module() could iterate
that list to perform runtime initialization tasks. In this case, we're
not defining a struct k_mutex but rather a struct pthread_mutex which is
a completely different structure. Not only those struct pthread_mutex
would be corrupted with unexpected data, but since they're not the
same size as struct k_mutex, the actual struct k_mutex instances that
follow in the list would be misaligned and get corrupted too.

There is nothing that requires runtime initialization in the static
definition of a struct pthread_mutex so let's remove the section
attribute.