### PR TITLE
net: sockets: Make NET_SOCKETS_POSIX_NAMES depend on !POSIX_API

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -15,6 +15,7 @@ if NET_SOCKETS
 
 config NET_SOCKETS_POSIX_NAMES
 	bool "Standard POSIX names for Sockets API"
+	depends on !POSIX_API
 	help
 	  By default, Sockets API function are prefixed with ``zsock_`` to avoid
 	  namespacing issues. If this option is enabled, they will be provided


### PR DESCRIPTION
These options are mutually exclusive, or more specifically,
CONFIG_POSIX_API has wider scope and supersedes
CONFIG_NET_SOCKETS_POSIX_NAMES. Implementation-wise, the two
options should not be defined at the same time, as that may
lead to declaration conflicts.

Fixes: #16141

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>