### PR TITLE
ARRAY_SIZE(): make it usable on 64-bit systems

### DIFF
--- a/include/misc/util.h
+++ b/include/misc/util.h
@@ -58,8 +58,7 @@ constexpr size_t ARRAY_SIZE(T(&)[N]) { return N; }
  * an array (e.g. pointer)
  */
 #define ARRAY_SIZE(array) \
-	((unsigned long) (IS_ARRAY(array) + \
-		(sizeof(array) / sizeof((array)[0]))))
+	((long) (IS_ARRAY(array) + (sizeof(array) / sizeof((array)[0]))))
 #endif
 
 /* Evaluates to 1 if ptr is part of array, 0 otherwise; compile error if


### PR DESCRIPTION
With code that looks like this:

	for (int i = ARRAY_SIZfoo) - 1; i >= 0; i--) ...

If foo is empty, ARRAY_SIZfoo) will return 0. But since it is
implemented using an unsigned long, the answer to 0UL - 1 is
18446744073709551615 on a 64-bit system, and that doesn't fit into
an int. The compiler complains with:

warning: overflow in conversion from ‘long unsigned int’ to ‘int’ changes value from ‘18446744073709551615’ to ‘-1’ [-Woverflow]

Let's fix that and get the expected behavior simply by turning the
unsigned long into a signed long.