### PR TITLE
misc: memory address type conversions

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -477,7 +477,7 @@ struct _thread_stack_info {
 	/* Stack start - Represents the start address of the thread-writable
 	 * stack area.
 	 */
-	u32_t start;
+	uintptr_t start;
 
 	/* Stack Size - Thread writable stack buffer size. Represents
 	 * the size of the actual area, starting from the start member,
@@ -4743,17 +4743,17 @@ static inline char *Z_THREAD_STACK_BUFFER(k_thread_stack_t *sym)
 #define K_MEM_PARTITION_DEFINE(name, start, size, attr) \
 	_ARCH_MEM_PARTITION_ALIGN_CHECK(start, size); \
 	struct k_mem_partition name =\
-		{ (u32_t)start, size, attr}
+		{ (uintptr_t)start, size, attr}
 #else
 #define K_MEM_PARTITION_DEFINE(name, start, size, attr) \
 	struct k_mem_partition name =\
-		{ (u32_t)start, size, attr}
+		{ (uintptr_t)start, size, attr}
 #endif /* _ARCH_MEM_PARTITION_ALIGN_CHECK */
 
 /* memory partition */
 struct k_mem_partition {
 	/* start address of memory partition */
-	u32_t start;
+	uintptr_t start;
 	/* size of memory partition */
 	u32_t size;
 #if defined(CONFIG_MEMORY_PROTECTION)

--- a/include/sys_io.h
+++ b/include/sys_io.h
@@ -18,7 +18,7 @@ extern "C" {
 
 typedef u32_t io_port_t;
 typedef u32_t mm_reg_t;
-typedef u32_t mem_addr_t;
+typedef uintptr_t mem_addr_t;
 
 /* Port I/O functions */
 

--- a/kernel/include/kernel_structs.h
+++ b/kernel/include/kernel_structs.h
@@ -249,7 +249,7 @@ static ALWAYS_INLINE void z_new_thread_init(struct k_thread *thread,
 #endif /* CONFIG_USERSPACE */
 
 #if defined(CONFIG_THREAD_STACK_INFO)
-	thread->stack_info.start = (u32_t)pStack;
+	thread->stack_info.start = (uintptr_t)pStack;
 	thread->stack_info.size = (u32_t)stackSize;
 #endif /* CONFIG_THREAD_STACK_INFO */
 }


### PR DESCRIPTION
The uintptr_t type is more appropriate to represent memory addresses
than u32_t.