### PR TITLE
Kconfig: introduce CONFIG_64BIT

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -83,6 +83,15 @@ config BIG_ENDIAN
          is used to select linker script OUTPUT_FORMAT and command
          line option for gen_isr_tables.py.
 
+config 64BIT
+	bool
+	help
+	  This option tells the build system that the target system is
+	  using a 64-bit address space, meaning that pointer and long types
+	  are 64 bits wide. This option is selected by arch/$ARCH/Kconfig,
+	  soc/**/Kconfig, or boards/**/Kconfig and the user should generally
+	  avoid modifying it.
+
 if ARC || ARM || NIOS2 || X86
 
 config SRAM_SIZE

--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -41,7 +41,7 @@ def endian_prefix():
     else:
         return "<"
 
-def read_intlist(intlist_path):
+def read_intlist(intlist_path, syms):
     """read a binary file containing the contents of the kernel's .intList
     section. This is an instance of a header created by
     include/linker/intlist.ld:
@@ -71,7 +71,10 @@ def read_intlist(intlist_path):
     prefix = endian_prefix()
 
     intlist_header_fmt = prefix + "II"
-    intlist_entry_fmt = prefix + "iiII"
+    if "CONFIG_64BIT" in syms:
+        intlist_entry_fmt = prefix + "iiQQ"
+    else:
+        intlist_entry_fmt = prefix + "iiII"
 
     with open(intlist_path, "rb") as fp:
         intdata = fp.read()
@@ -220,7 +223,7 @@ def main():
 
                 debug('3rd level offsets: {}'.format(list_3rd_lvl_offsets))
 
-    intlist = read_intlist(args.intlist)
+    intlist = read_intlist(args.intlist, syms)
     nvec = intlist["num_vectors"]
     offset = intlist["offset"]
 

--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -84,8 +84,11 @@ volatile size_t size_of_long_variable = sizeof(long_variable);
 
 void test_stddef(void)
 {
-
+#ifdef CONFIG_64BIT
+	zassert_true((size_of_long_variable == 8), "sizeof");
+#else
 	zassert_true((size_of_long_variable == 4), "sizeof");
+#endif
 }
 
 /*


### PR DESCRIPTION
This is the generic symbol to select or otherwise test for when 64-bit
compilation is desired. Two trivial usages of this symbol are also
included.