### PR TITLE
LPC SoC family GPIO interrupts

### DIFF
--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -30,7 +30,7 @@
 		compatible = "gpio-keys";
 		user_button_1: button_0 {
 			label = "User SW1";
-			gpios = <&gpio0 5 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 5 GPIO_INT_ACTIVE_HIGH>;
 		};
 		user_button_2: button_1 {
 			label = "User SW2";

--- a/boards/arm/lpcxpresso55s69/pinmux.c
+++ b/boards/arm/lpcxpresso55s69/pinmux.c
@@ -8,6 +8,7 @@
 #include <fsl_common.h>
 #include <fsl_iocon.h>
 #include <soc.h>
+#include <LPC55S69_cm33_core0.h>
 
 static int lpcxpresso_55s69_pinmux_init(struct device *dev)
 {
@@ -48,8 +49,8 @@ static int lpcxpresso_55s69_pinmux_init(struct device *dev)
 
 #endif
 
-#ifdef CONFIG_GPIO_MCUX_LPC_PORT0
-	const u32_t port0_pin5_config = (
+#ifdef DT_GPIO_KEYS_SW0_GPIO_CONTROLLER
+	const u32_t sw0_config = (
 			IOCON_PIO_FUNC0 |
 			IOCON_PIO_MODE_PULLUP |
 			IOCON_PIO_INV_DI |
@@ -58,12 +59,11 @@ static int lpcxpresso_55s69_pinmux_init(struct device *dev)
 			IOCON_PIO_SLEW_STANDARD |
 			IOCON_PIO_OPENDRAIN_DI
 			);
-
-	pinmux_pin_set(port0, 5, port0_pin5_config);
+	pinmux_pin_set(port0, DT_ALIAS_SW0_GPIOS_PIN, sw0_config);
 #endif
 
-#ifdef CONFIG_GPIO_MCUX_LPC_PORT0
-	const u32_t port1_pin18_config = (
+#ifdef DT_GPIO_KEYS_SW1_GPIO_CONTROLLER
+	const u32_t sw1_config = (
 			IOCON_PIO_FUNC0 |
 			IOCON_PIO_MODE_PULLUP |
 			IOCON_PIO_INV_DI |
@@ -72,10 +72,11 @@ static int lpcxpresso_55s69_pinmux_init(struct device *dev)
 			IOCON_PIO_SLEW_STANDARD |
 			IOCON_PIO_OPENDRAIN_DI
 			);
+	pinmux_pin_set(port1, DT_ALIAS_SW0_GPIOS_PIN, sw1_config);
+#endif
 
-	pinmux_pin_set(port1, 18, port1_pin18_config);
-
-	const u32_t port1_pin9_config = (
+#ifdef DT_GPIO_KEYS_SW2_GPIO_CONTROLLER
+	const u32_t sw2_config = (
 			IOCON_PIO_FUNC0 |
 			IOCON_PIO_MODE_PULLUP |
 			IOCON_PIO_INV_DI |
@@ -84,8 +85,7 @@ static int lpcxpresso_55s69_pinmux_init(struct device *dev)
 			IOCON_PIO_SLEW_STANDARD |
 			IOCON_PIO_OPENDRAIN_DI
 			);
-
-	pinmux_pin_set(port1, 9, port1_pin9_config);
+	pinmux_pin_set(port1, DT_ALIAS_SW0_GPIOS_PIN, sw2_config);
 #endif
 
 	return 0;

--- a/drivers/gpio/Kconfig.mcux_lpc
+++ b/drivers/gpio/Kconfig.mcux_lpc
@@ -8,6 +8,7 @@
 menuconfig GPIO_MCUX_LPC
 	bool "MCUX LPC GPIO driver"
 	depends on HAS_MCUX
+	select HAS_DTS_GPIO
 	help
 	  Enable the MCUX LPC pinmux driver.
 

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -8,9 +8,8 @@
  * @brief GPIO driver for LPC54XXX family
  *
  * Note:
- * - Only basic GPIO features sufficient to blinky functionality
- *   are currently implemented.
- * - Interrupt mode is not implemented.
+ * - fsl_pint internally tries to manage interrupts, but this is not used (e.g.
+ *   s_pintCallback), Zephyr's interrupt management system is used in place.
  */
 
 #include <errno.h>
@@ -20,13 +19,21 @@
 #include <fsl_common.h>
 #include "gpio_utils.h"
 #include <fsl_gpio.h>
+#include <fsl_pint.h>
+#include <fsl_inputmux.h>
 #include <fsl_device_registers.h>
 
-#define PORT0_IDX	0u
-#define PORT1_IDX	1u
+#define PORT0_IDX 0u
+#define PORT1_IDX 1u
+
+#define PIN_TO_INPUT_MUX_CONNECTION(port, pin)                                 \
+	((PINTSEL0 << PMUX_SHIFT) + (32 * port) + (pin))
+
+#define NO_PINT_INT ((1 << sizeof(pint_pin_int_t)) - 1)
 
 struct gpio_mcux_lpc_config {
 	GPIO_Type *gpio_base;
+	PINT_Type *pint_base;
 	u32_t port_no;
 	clock_ip_name_t clock_ip_name;
 };
@@ -36,43 +43,133 @@ struct gpio_mcux_lpc_data {
 	sys_slist_t callbacks;
 	/* pin callback routine enable flags, by pin number */
 	u32_t pin_callback_enables;
+	/* pin association with PINT id */
+	pint_pin_int_t pint_id[32];
+	/* interrupt type */
+	pint_pin_enable_t int_mode[32];
+	/* ISR allocated in device tree to this port */
+	u32_t isr_list[8];
+	/* index to to table above */
+	u32_t isr_list_idx;
 };
 
-static int gpio_mcux_lpc_configure(struct device *dev,
-				   int access_op, u32_t pin, int flags)
+
+static u32_t get_free_isr(struct gpio_mcux_lpc_data *data)
+{
+	u32_t i;
+	u32_t isr;
+
+	for (i = 0; i < data->isr_list_idx; i++) {
+		if (data->isr_list[i] != -1) {
+			isr = data->isr_list[i];
+			data->isr_list[i] = -1;
+			return isr;
+		}
+	}
+
+	return -EINVAL;
+}
+
+/* Function configures INPUTMUX device to route pin interrupts to a certain
+ * PINT. PINT no. is unknown, rather it's determined from ISR no.
+ */
+static u32_t attach_pin_to_isr(u32_t port, u32_t pin, u32_t isr_no)
+{
+	u32_t pint_idx;
+	/* Connect trigger sources to PINT */
+	INPUTMUX_Init(INPUTMUX);
+
+	/* Code asumes PIN_INT values are grouped [0..3] and [4..7].
+	 * This scenario is true in LPC54xxx/LPC55xxx.
+	 */
+	if (isr_no < PIN_INT4_IRQn) {
+		pint_idx = isr_no - PIN_INT0_IRQn;
+	} else {
+		pint_idx = isr_no - PIN_INT4_IRQn;
+	}
+
+	INPUTMUX_AttachSignal(
+		INPUTMUX, pint_idx,
+		PIN_TO_INPUT_MUX_CONNECTION(port, pin));
+
+	/* Turnoff clock to inputmux to save power. Clock is only needed to make
+	 * changes. Can be turned off after.
+	 */
+	INPUTMUX_Deinit(INPUTMUX);
+
+	return pint_idx;
+}
+
+static void gpio_mcux_lpc_port_isr(void *arg);
+
+static int gpio_mcux_lpc_configure(struct device *dev, int access_op, u32_t pin,
+				   int flags)
 {
 	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
+	struct gpio_mcux_lpc_data *data = dev->driver_data;
+	pint_pin_enable_t interruptMode = kPINT_PinIntEnableNone;
 
 	/* Check for an invalid pin configuration */
 	if ((flags & GPIO_INT) && (flags & GPIO_DIR_OUT)) {
 		return -EINVAL;
 	}
 
-	/* Check if GPIO port supports interrupts */
 	if (flags & GPIO_INT) {
-		return -ENOTSUP;
+		if (flags & GPIO_INT_EDGE) {
+			if (flags & GPIO_INT_ACTIVE_HIGH) {
+				interruptMode = kPINT_PinIntEnableRiseEdge;
+			} else if (flags & GPIO_INT_DOUBLE_EDGE) {
+				interruptMode = kPINT_PinIntEnableBothEdges;
+			} else {
+				interruptMode = kPINT_PinIntEnableFallEdge;
+			}
+		} else { /* GPIO_INT_LEVEL */
+			if (flags & GPIO_INT_ACTIVE_HIGH) {
+				interruptMode = kPINT_PinIntEnableHighLevel;
+			} else {
+				interruptMode = kPINT_PinIntEnableLowLevel;
+			}
+		}
+	} else {
+		interruptMode = kPINT_PinIntEnableNone;
 	}
+	data->int_mode[pin] = interruptMode;
 
 	/* supports access by pin now,you can add access by port when needed */
 	if (access_op == GPIO_ACCESS_BY_PIN) {
+		u32_t port = config->port_no;
+
 		/* input-0,output-1 */
 		if ((flags & GPIO_DIR_MASK) == GPIO_DIR_IN) {
-			gpio_base->DIR[config->port_no] &= ~(BIT(pin));
+			u32_t isr;
+			u32_t pint_idx;
+
+			gpio_base->DIR[port] &= ~(BIT(pin));
+
+			isr = get_free_isr(data);
+			if (isr == -EINVAL) {
+				/* Didn't find any free interrupt allocated to the port */
+				return -EINVAL;
+			}
+			pint_idx = attach_pin_to_isr(port, pin, isr);
+			data->pint_id[pin] = pint_idx;
+
+			PINT_PinInterruptConfig(config->pint_base, pint_idx,
+				interruptMode, (pint_cb_t)gpio_mcux_lpc_port_isr);
 		} else {
-			gpio_base->SET[config->port_no] = BIT(pin);
-			gpio_base->DIR[config->port_no] |= BIT(pin);
+			gpio_base->SET[port] = BIT(pin);
+			gpio_base->DIR[port] |= BIT(pin);
 		}
 	} else {
-
 		return -EINVAL;
 	}
 
 	return 0;
 }
 
-static int gpio_mcux_lpc_write(struct device *dev,
-			       int access_op, u32_t pin, u32_t value)
+static int gpio_mcux_lpc_write(struct device *dev, int access_op, u32_t pin,
+			       u32_t value)
 {
 	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
@@ -92,8 +189,8 @@ static int gpio_mcux_lpc_write(struct device *dev,
 	return 0;
 }
 
-static int gpio_mcux_lpc_read(struct device *dev,
-			      int access_op, u32_t pin, u32_t *value)
+static int gpio_mcux_lpc_read(struct device *dev, int access_op, u32_t pin,
+			      u32_t *value)
 {
 	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
 	GPIO_Type *gpio_base = config->gpio_base;
@@ -109,11 +206,99 @@ static int gpio_mcux_lpc_read(struct device *dev,
 	return 0;
 }
 
+static int gpio_mcux_lpc_manage_cb(struct device *port,
+				   struct gpio_callback *callback, bool set)
+{
+	struct gpio_mcux_lpc_data *data = port->driver_data;
+
+	return gpio_manage_callback(&data->callbacks, callback, set);
+}
+
+static int gpio_mcux_lpc_enable_cb(struct device *port, int access_op,
+				   u32_t pin)
+{
+	const struct gpio_mcux_lpc_config *config = port->config->config_info;
+	struct gpio_mcux_lpc_data *data = port->driver_data;
+	u32_t i;
+
+	if (access_op == GPIO_ACCESS_BY_PIN) {
+		data->pin_callback_enables |= BIT(pin);
+		PINT_EnableCallbackByIndex(config->pint_base,
+					   data->pint_id[pin]);
+	} else {
+		data->pin_callback_enables = 0xFFFFFFFF;
+		for (i = 0U; i < 32; i++) {
+			if (data->pint_id[i] != NO_PINT_INT) {
+				PINT_EnableCallbackByIndex(config->pint_base,
+							   data->pint_id[i]);
+			}
+		}
+	}
+
+	return 0;
+}
+
+static int gpio_mcux_lpc_disable_cb(struct device *port, int access_op,
+				    u32_t pin)
+{
+	const struct gpio_mcux_lpc_config *config = port->config->config_info;
+	struct gpio_mcux_lpc_data *data = port->driver_data;
+	u32_t i;
+
+	if (access_op == GPIO_ACCESS_BY_PIN) {
+		PINT_DisableCallbackByIndex(config->pint_base,
+					    data->pint_id[pin]);
+		data->pin_callback_enables &= ~BIT(pin);
+	} else {
+		for (i = 0U; i < 32; i++) {
+			if (data->pint_id[i] != NO_PINT_INT) {
+				PINT_DisableCallbackByIndex(config->pint_base,
+							    data->pint_id[i]);
+			}
+		}
+		data->pin_callback_enables = 0U;
+	}
+
+	return 0;
+}
+
+static void gpio_mcux_lpc_port_isr(void *arg)
+{
+	struct device *dev = (struct device *)arg;
+	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
+	struct gpio_mcux_lpc_data *data = dev->driver_data;
+	u32_t enabled_int;
+	u32_t int_flags;
+	u32_t pin;
+
+	for (pin = 0; pin < 32; pin++) {
+		if (data->pint_id[pin] != NO_PINT_INT) {
+			int_flags = PINT_PinInterruptGetStatus(
+				config->pint_base, data->pint_id[pin]);
+			enabled_int =
+				(int_flags << pin) & data->pin_callback_enables;
+
+			gpio_fire_callbacks(&data->callbacks, dev, enabled_int);
+
+			PINT_PinInterruptClrStatus(config->pint_base,
+						   data->pint_id[pin]);
+		}
+	}
+}
+
 static int gpio_mcux_lpc_init(struct device *dev)
 {
 	const struct gpio_mcux_lpc_config *config = dev->config->config_info;
+	struct gpio_mcux_lpc_data *data = dev->driver_data;
+	int i;
 
 	CLOCK_EnableClock(config->clock_ip_name);
+
+	for (i = 0; i < 32; i++) {
+		data->pint_id[i] = NO_PINT_INT;
+	}
+
+	data->isr_list_idx = 0;
 
 	return 0;
 }
@@ -122,36 +307,101 @@ static const struct gpio_driver_api gpio_mcux_lpc_driver_api = {
 	.config = gpio_mcux_lpc_configure,
 	.write = gpio_mcux_lpc_write,
 	.read = gpio_mcux_lpc_read,
+	.manage_callback = gpio_mcux_lpc_manage_cb,
+	.enable_callback = gpio_mcux_lpc_enable_cb,
+	.disable_callback = gpio_mcux_lpc_disable_cb,
 };
 
 #ifdef CONFIG_GPIO_MCUX_LPC_PORT0
+static int lpc_gpio_0_init(struct device *dev);
+
 static const struct gpio_mcux_lpc_config gpio_mcux_lpc_port0_config = {
 	.gpio_base = GPIO,
+	.pint_base = PINT, /* TODO: SECPINT issue #16330 */
 	.port_no = PORT0_IDX,
 	.clock_ip_name = kCLOCK_Gpio0,
 };
 
 static struct gpio_mcux_lpc_data gpio_mcux_lpc_port0_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_lpc_port0, CONFIG_GPIO_MCUX_LPC_PORT0_NAME,
-		    gpio_mcux_lpc_init,
-		    &gpio_mcux_lpc_port0_data, &gpio_mcux_lpc_port0_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+DEVICE_AND_API_INIT(gpio_mcux_lpc_port0, DT_INST_0_NXP_LPC_GPIO_LABEL,
+		    lpc_gpio_0_init, &gpio_mcux_lpc_port0_data,
+		    &gpio_mcux_lpc_port0_config, POST_KERNEL,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_mcux_lpc_driver_api);
+
+static int lpc_gpio_0_init(struct device *dev)
+{
+#if defined(DT_INST_0_NXP_LPC_GPIO_IRQ_0) || defined(DT_INST_0_NXP_LPC_GPIO_IRQ_1)
+	struct gpio_mcux_lpc_data *data = dev->driver_data;
+#endif
+
+	gpio_mcux_lpc_init(dev);
+
+#ifdef DT_INST_0_NXP_LPC_GPIO_IRQ_0
+	IRQ_CONNECT(DT_INST_0_NXP_LPC_GPIO_IRQ_0,
+			DT_INST_0_NXP_LPC_GPIO_IRQ_0_PRIORITY,
+		    gpio_mcux_lpc_port_isr, DEVICE_GET(gpio_mcux_lpc_port0), 0);
+	irq_enable(DT_INST_0_NXP_LPC_GPIO_IRQ_0);
+	data->isr_list[data->isr_list_idx++] = DT_INST_0_NXP_LPC_GPIO_IRQ_0;
+#endif
+
+#ifdef DT_INST_0_NXP_LPC_GPIO_IRQ_1
+	IRQ_CONNECT(DT_INST_0_NXP_LPC_GPIO_IRQ_1,
+			DT_INST_0_NXP_LPC_GPIO_IRQ_1_PRIORITY,
+		    gpio_mcux_lpc_port_isr, DEVICE_GET(gpio_mcux_lpc_port0), 0);
+	irq_enable(DT_INST_0_NXP_LPC_GPIO_IRQ_1);
+	data->isr_list[data->isr_list_idx++] = DT_INST_0_NXP_LPC_GPIO_IRQ_1;
+#endif
+
+	return 0;
+}
+
 #endif /* CONFIG_GPIO_MCUX_LPC_PORT0 */
 
 #ifdef CONFIG_GPIO_MCUX_LPC_PORT1
+static int lpc_gpio_1_init(struct device *dev);
+
 static const struct gpio_mcux_lpc_config gpio_mcux_lpc_port1_config = {
 	.gpio_base = GPIO,
+	.pint_base = PINT,
 	.port_no = PORT1_IDX,
 	.clock_ip_name = kCLOCK_Gpio1,
 };
 
 static struct gpio_mcux_lpc_data gpio_mcux_lpc_port1_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_lpc_port1, CONFIG_GPIO_MCUX_LPC_PORT1_NAME,
-		    gpio_mcux_lpc_init,
-		    &gpio_mcux_lpc_port1_data, &gpio_mcux_lpc_port1_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+DEVICE_AND_API_INIT(gpio_mcux_lpc_port1, DT_INST_1_NXP_LPC_GPIO_LABEL,
+		    lpc_gpio_1_init, &gpio_mcux_lpc_port1_data,
+		    &gpio_mcux_lpc_port1_config, POST_KERNEL,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_mcux_lpc_driver_api);
+
+static int lpc_gpio_1_init(struct device *dev)
+{
+#if defined(DT_INST_1_NXP_LPC_GPIO_IRQ_0) || defined(DT_INST_1_NXP_LPC_GPIO_IRQ_1)
+	struct gpio_mcux_lpc_data *data = dev->driver_data;
+#endif
+
+	gpio_mcux_lpc_init(dev);
+
+#ifdef DT_INST_1_NXP_LPC_GPIO_IRQ_0
+	IRQ_CONNECT(DT_INST_1_NXP_LPC_GPIO_IRQ_0,
+			DT_INST_1_NXP_LPC_GPIO_IRQ_0_PRIORITY,
+		    gpio_mcux_lpc_port_isr, DEVICE_GET(gpio_mcux_lpc_port1), 0);
+	irq_enable(DT_INST_1_NXP_LPC_GPIO_IRQ_0);
+	data->isr_list[data->isr_list_idx++] = DT_INST_1_NXP_LPC_GPIO_IRQ_0;
+#endif
+
+#ifdef DT_INST_1_NXP_LPC_GPIO_IRQ_1
+	IRQ_CONNECT(DT_INST_1_NXP_LPC_GPIO_IRQ_1,
+			DT_INST_1_NXP_LPC_GPIO_IRQ_1_PRIORITY,
+		    gpio_mcux_lpc_port_isr, DEVICE_GET(gpio_mcux_lpc_port1), 0);
+	irq_enable(DT_INST_1_NXP_LPC_GPIO_IRQ_1);
+	data->isr_list[data->isr_list_idx++] = DT_INST_1_NXP_LPC_GPIO_IRQ_1;
+#endif
+
+	return 0;
+}
+
 #endif /* CONFIG_GPIO_MCUX_LPC_PORT1 */

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -58,7 +58,7 @@
 		};
 
 		gpio0: gpio@0 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,lpc-gpio";
 			reg = <0x4008c000 0x2488>;
 			interrupts = <2 2>;
 			label = "GPIO_0";
@@ -67,7 +67,7 @@
 		};
 
 		gpio1: gpio@1 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,lpc-gpio";
 			reg = <0x4008C000 0x2488>;
 			interrupts = <3 2>;
 			label = "GPIO_1";

--- a/dts/arm/nxp/nxp_lpc55S6x.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x.dtsi
@@ -63,20 +63,36 @@
 			status = "disabled";
 		};
 
-		gpio0: gpio@0 {
-			compatible = "nxp,kinetis-gpio";
+		gpio0:gpio@0 {
+			compatible = "nxp,lpc-gpio";
 			reg = <0x5008c000 0x2488>;
-			interrupts = <2 2>;
+			interrupts = <4 2>;
 			label = "GPIO_0";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
 
-		gpio1: gpio@1 {
-			compatible = "nxp,kinetis-gpio";
+		gpio1:gpio@1 {
+			compatible = "nxp,lpc-gpio";
 			reg = <0x5008c000 0x2488>;
-			interrupts = <3 2>;
+			interrupts = <5 2>,<6 2>;
 			label = "GPIO_1";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpio2:gpio@2 {
+			compatible = "nxp,lpc-gpio";
+			reg = <0x5008c000 0x2488>;
+			label = "GPIO_2";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpio3:gpio@3 {
+			compatible = "nxp,lpc-gpio";
+			reg = <0x5008c000 0x2488>;
+			label = "GPIO_3";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};

--- a/dts/bindings/gpio/nxp,lpc-gpio.yaml
+++ b/dts/bindings/gpio/nxp,lpc-gpio.yaml
@@ -1,0 +1,22 @@
+title: LPC GPIO
+
+description: >
+    This is a representation of the LPC GPIO nodes
+
+inherits:
+    !include base.yaml
+
+properties:
+    compatible:
+      constraint: "nxp,lpc-gpio"
+
+    reg:
+      category: required
+
+    label:
+      category: required
+
+"#cells":
+  - pin
+  - flags
+...

--- a/soc/arm/nxp_lpc/lpc54xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc54xxx/soc.c
@@ -24,6 +24,7 @@
 #include <fsl_clock.h>
 #include <fsl_common.h>
 #include <fsl_device_registers.h>
+#include <fsl_pint.h>
 
 /**
  *
@@ -89,6 +90,11 @@ static int nxp_lpc54114_init(struct device *arg)
 
 	/* Initialize FRO/system clock to 48 MHz */
 	clkInit();
+
+#ifdef CONFIG_GPIO_MCUX_LPC
+	/* Turn on PINT device*/
+	PINT_Init(PINT);
+#endif
 
 	/*
 	 * install default handler that simply resets the CPU if configured in

--- a/soc/arm/nxp_lpc/lpc55xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.c
@@ -24,6 +24,7 @@
 #include <fsl_clock.h>
 #include <fsl_common.h>
 #include <fsl_device_registers.h>
+#include <fsl_pint.h>
 
 /**
  *
@@ -86,6 +87,11 @@ static int nxp_lpc55s69_init(struct device *arg)
 
 	/* Initialize FRO/system clock to 48 MHz */
 	clkInit();
+
+#ifdef CONFIG_GPIO_MCUX_LPC
+	/* Turn on PINT device*/
+	PINT_Init(PINT);
+#endif
 
 	/*
 	 * install default handler that simply resets the CPU if configured in

--- a/west.yml
+++ b/west.yml
@@ -89,7 +89,7 @@ manifest:
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs
     - name: hal_nxp
-      revision: 81d50b7d15340dfa034bfff9c98527f5b661b84e
+      revision: ffa116d53c3e7b6013eaedd6fdbf9d0cbdb574ce
       path: modules/hal/nxp
     - name: open-amp
       revision: 9b591b289e1f37339bd038b5a1f0e6c8ad39c63a


### PR DESCRIPTION
LPC54xxx and LPC55xxx GPIO interrupts enables.
PINT and INPUTMUX devices enabled to route interrupt signal from pin to NVIC.

Tested with GPIO driver sample.

Fixes #16167