### PR TITLE
tests: timer_api: Fix timer synchronization

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -245,8 +245,12 @@ void test_timer_periodicity(void)
 	k_timer_start(&periodicity_timer, 0, PERIOD);
 
 	/* clear the expiration that would have happenned due to
-	 * whatever duration that was set.
+	 * whatever duration that was set. Since timer is likely
+	 * to fire before call to k_timer_status_sync(), we have
+	 * to synchronize twice to ensure that the timestamp will
+	 * be fetched as soon as possible after timer firing.
 	 */
+	k_timer_status_sync(&periodicity_timer);
 	k_timer_status_sync(&periodicity_timer);
 	tdata.timestamp = k_uptime_get();
 


### PR DESCRIPTION
The test_timer_periodicity waits for first timer expiration
in order to extract timer firing time. The wait is performed
using k_timer_status_sync() API call, which blocks thread
until timer expiration. However if the timer expired before
call the this function, it will return immediately, triggering
test failure.

This PR adds the second call to the k_timer_status_sync()
to ensure that the following part of the test will be executed
as soon as possible after timer expiration.