### PR TITLE
Power: Fix various spurious LOG_ERR calls

### DIFF
--- a/soc/arm/nordic_nrf/nrf51/power.c
+++ b/soc/arm/nordic_nrf/nrf51/power.c
@@ -22,7 +22,7 @@ void sys_set_power_state(enum power_states state)
  #endif
 #endif
 	default:
-		LOG_ERR("Unsupported power state %u", state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 }
@@ -39,7 +39,7 @@ void _sys_pm_power_state_exit_post_ops(enum power_states state)
  #endif
 #endif
 	default:
-		LOG_ERR("Unsupported power state %u", state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 
@@ -49,4 +49,3 @@ void _sys_pm_power_state_exit_post_ops(enum power_states state)
 	 */
 	irq_unlock(0);
 }
-

--- a/soc/arm/nordic_nrf/nrf52/power.c
+++ b/soc/arm/nordic_nrf/nrf52/power.c
@@ -22,7 +22,7 @@ void sys_set_power_state(enum power_states state)
  #endif
 #endif
 	default:
-		LOG_ERR("Unsupported power state %u", state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 }
@@ -39,7 +39,7 @@ void _sys_pm_power_state_exit_post_ops(enum power_states state)
  #endif
 #endif
 	default:
-		LOG_ERR("Unsupported power state %u", state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 
@@ -49,4 +49,3 @@ void _sys_pm_power_state_exit_post_ops(enum power_states state)
 	 */
 	irq_unlock(0);
 }
-

--- a/soc/arm/silabs_exx32/common/soc_power.c
+++ b/soc/arm/silabs_exx32/common/soc_power.c
@@ -53,7 +53,7 @@ void sys_set_power_state(enum power_states state)
 #endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_3 */
 #endif /* CONFIG_SYS_POWER_SLEEP_STATES */
 	default:
-		LOG_ERR("Unsupported power state %u", state);
+		LOG_DBG("Unsupported power state %u", state);
 		break;
 	}
 

--- a/subsys/power/policy/policy_residency.c
+++ b/subsys/power/policy/policy_residency.c
@@ -50,7 +50,7 @@ enum power_states sys_pm_policy_next_state(s32_t ticks)
 	int i;
 
 	if ((ticks != K_FOREVER) && (ticks < pm_min_residency[0])) {
-		LOG_ERR("Not enough time for PM operations: %d", ticks);
+		LOG_DBG("Not enough time for PM operations: %d", ticks);
 		return SYS_POWER_STATE_ACTIVE;
 	}
 


### PR DESCRIPTION
These events aren't errors at all, but rather part of normal operation.
They shouldn't trigger error messages, especially given that the console
gets absolutely flooded with them if power management is activated.