### PR TITLE
subsys/testsuite/ztest: Fix zassert_mem_equal user message printing

### DIFF
--- a/subsys/testsuite/ztest/include/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/ztest_assert.h
@@ -206,8 +206,8 @@ static inline void z_zassert(int cond,
  * @param size Size of buffers
  * @param msg Optional message to print if the assertion fails
  */
-#define zassert_mem_equal__(buf, exp, size, msg, ...)                        \
-	zassert_equal(memcmp(buf, exp, size), 0, #buf " not equal to " #exp, \
+#define zassert_mem_equal__(buf, exp, size, msg, ...)                    \
+	zassert(memcmp(buf, exp, size) == 0, #buf " not equal to " #exp, \
 	msg, ##__VA_ARGS__)
 
 /**


### PR DESCRIPTION
This commit fixes the zassert_mem_equal macro to properly print
the formatting string is given as a parameter by the user.
There is an error that is an effect of directly copying the
previous implementation that was using the inline function.

Sorry for that - this actually upgrades #16504.
It would be nice to have a feature to test ztest with failing messages too.
In the previous implementation, there was no user message printed.