### PR TITLE
cmake: no-address-of-packed-member is not supported in older compilers

### DIFF
--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -9,10 +9,15 @@ macro(toolchain_cc_warning_base)
     -Wformat
     -Wformat-security
     -Wno-format-zero-length
-    # FIXME: Remove once #16587 is fixed
-    -Wno-address-of-packed-member
     -Wno-main
   )
+
+if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "9.1.0")
+  zephyr_compile_options(
+    # FIXME: Remove once #16587 is fixed
+    -Wno-address-of-packed-member
+  )
+endif()
 
   zephyr_cc_option(-Wno-pointer-sign)
 


### PR DESCRIPTION
Add a version check to allow building with older GCC versions that did
not support this option.

Fixes #16607