### PR TITLE
Bluetooth: Fix BT_ATT_ENFORCE_FLOW

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -88,6 +88,10 @@ struct bt_l2cap_chan {
 	/* Response Timeout eXpired (RTX) timer */
 	struct k_delayed_work		rtx_work;
 	ATOMIC_DEFINE(status, BT_L2CAP_NUM_STATUS);
+
+	struct k_work			rx_work;
+	struct k_fifo			rx_queue;
+
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	bt_l2cap_chan_state_t		state;
 	/** Remote PSM to be connected */

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -27,6 +27,7 @@
 #include "l2cap_internal.h"
 
 #define LE_CHAN_RTX(_w) CONTAINER_OF(_w, struct bt_l2cap_le_chan, chan.rtx_work)
+#define CHAN_RX(_w) CONTAINER_OF(_w, struct bt_l2cap_chan, rx_work)
 
 #define L2CAP_LE_MIN_MTU		23
 
@@ -224,6 +225,8 @@ void bt_l2cap_chan_set_state(struct bt_l2cap_chan *chan,
 
 void bt_l2cap_chan_del(struct bt_l2cap_chan *chan)
 {
+	struct net_buf *buf;
+
 	BT_DBG("conn %p chan %p", chan->conn, chan);
 
 	if (!chan->conn) {
@@ -243,6 +246,11 @@ destroy:
 	chan->psm = 0U;
 #endif
 
+	/* Remove buffers on the RX queue */
+	while ((buf = net_buf_get(&chan->rx_queue, K_NO_WAIT))) {
+		net_buf_unref(buf);
+	}
+
 	if (chan->destroy) {
 		chan->destroy(chan);
 	}
@@ -256,6 +264,20 @@ static void l2cap_rtx_timeout(struct k_work *work)
 
 	bt_l2cap_chan_remove(chan->chan.conn, &chan->chan);
 	bt_l2cap_chan_del(&chan->chan);
+}
+
+static void l2cap_chan_recv(struct bt_l2cap_chan *chan, struct net_buf *buf);
+
+static void l2cap_rx_process(struct k_work *work)
+{
+	struct bt_l2cap_chan *chan = CHAN_RX(work);
+	struct net_buf *buf;
+
+	while ((buf = net_buf_get(&chan->rx_queue, K_NO_WAIT))) {
+		BT_DBG("chan %p buf %p", chan, buf);
+		l2cap_chan_recv(chan, buf);
+		net_buf_unref(buf);
+	}
 }
 
 void bt_l2cap_chan_add(struct bt_conn *conn, struct bt_l2cap_chan *chan,
@@ -286,6 +308,8 @@ static bool l2cap_chan_add(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 	}
 
 	k_delayed_work_init(&chan->rtx_work, l2cap_rtx_timeout);
+	k_work_init(&chan->rx_work, l2cap_rx_process);
+	k_fifo_init(&chan->rx_queue);
 
 	bt_l2cap_chan_add(conn, chan, destroy);
 
@@ -1616,6 +1640,13 @@ static void l2cap_chan_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	chan->ops->recv(chan, buf);
 }
 
+static void l2cap_chan_recv_queue(struct bt_l2cap_chan *chan,
+				  struct net_buf *buf)
+{
+	net_buf_put(&chan->rx_queue, buf);
+	k_work_submit(&chan->rx_work);
+}
+
 void bt_l2cap_recv(struct bt_conn *conn, struct net_buf *buf)
 {
 	struct bt_l2cap_hdr *hdr;
@@ -1646,8 +1677,7 @@ void bt_l2cap_recv(struct bt_conn *conn, struct net_buf *buf)
 		return;
 	}
 
-	l2cap_chan_recv(chan, buf);
-	net_buf_unref(buf);
+	l2cap_chan_recv_queue(chan, buf);
 }
 
 int bt_l2cap_update_conn_param(struct bt_conn *conn,


### PR DESCRIPTION
This moves the processing packets of upper layers from RX thread to the
system workqueue so they have the same priority as the TX callbacks
which has the added benefit of making any protocol on top of L2CAP to
be executed using system wq stack.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>