### PR TITLE
Fix16177 STM32: Could not compile with CONFIG_PINMUX=n

### DIFF
--- a/boards/arm/96b_argonkey/CMakeLists.txt
+++ b/boards/arm/96b_argonkey/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/96b_carbon/CMakeLists.txt
+++ b/boards/arm/96b_carbon/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/96b_neonkey/CMakeLists.txt
+++ b/boards/arm/96b_neonkey/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/96b_stm32_sensor_mez/CMakeLists.txt
+++ b/boards/arm/96b_stm32_sensor_mez/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/96b_wistrio/CMakeLists.txt
+++ b/boards/arm/96b_wistrio/CMakeLists.txt
@@ -1,3 +1,5 @@
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/b_l072z_lrwan1/CMakeLists.txt
+++ b/boards/arm/b_l072z_lrwan1/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/disco_l475_iot1/CMakeLists.txt
+++ b/boards/arm/disco_l475_iot1/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/dragino_lsn50/CMakeLists.txt
+++ b/boards/arm/dragino_lsn50/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/mikroe_mini_m4_for_stm32/CMakeLists.txt
+++ b/boards/arm/mikroe_mini_m4_for_stm32/CMakeLists.txt
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f030r8/CMakeLists.txt
+++ b/boards/arm/nucleo_f030r8/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f070rb/CMakeLists.txt
+++ b/boards/arm/nucleo_f070rb/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f091rc/CMakeLists.txt
+++ b/boards/arm/nucleo_f091rc/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f103rb/CMakeLists.txt
+++ b/boards/arm/nucleo_f103rb/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f207zg/CMakeLists.txt
+++ b/boards/arm/nucleo_f207zg/CMakeLists.txt
@@ -3,5 +3,5 @@
 if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/nucleo_f207zg/CMakeLists.txt
+++ b/boards/arm/nucleo_f207zg/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+endif()

--- a/boards/arm/nucleo_f302r8/CMakeLists.txt
+++ b/boards/arm/nucleo_f302r8/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f334r8/CMakeLists.txt
+++ b/boards/arm/nucleo_f334r8/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f401re/CMakeLists.txt
+++ b/boards/arm/nucleo_f401re/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f411re/CMakeLists.txt
+++ b/boards/arm/nucleo_f411re/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f412zg/CMakeLists.txt
+++ b/boards/arm/nucleo_f412zg/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f413zh/CMakeLists.txt
+++ b/boards/arm/nucleo_f413zh/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f429zi/CMakeLists.txt
+++ b/boards/arm/nucleo_f429zi/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f446re/CMakeLists.txt
+++ b/boards/arm/nucleo_f446re/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f746zg/CMakeLists.txt
+++ b/boards/arm/nucleo_f746zg/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_f756zg/CMakeLists.txt
+++ b/boards/arm/nucleo_f756zg/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_l053r8/CMakeLists.txt
+++ b/boards/arm/nucleo_l053r8/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_l073rz/CMakeLists.txt
+++ b/boards/arm/nucleo_l073rz/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_l432kc/CMakeLists.txt
+++ b/boards/arm/nucleo_l432kc/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_l476rg/CMakeLists.txt
+++ b/boards/arm/nucleo_l476rg/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_l496zg/CMakeLists.txt
+++ b/boards/arm/nucleo_l496zg/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/nucleo_l4r5zi/CMakeLists.txt
+++ b/boards/arm/nucleo_l4r5zi/CMakeLists.txt
@@ -3,5 +3,5 @@
 if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/nucleo_l4r5zi/CMakeLists.txt
+++ b/boards/arm/nucleo_l4r5zi/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+endif()

--- a/boards/arm/nucleo_wb55rg/CMakeLists.txt
+++ b/boards/arm/nucleo_wb55rg/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/nucleo_wb55rg/CMakeLists.txt
+++ b/boards/arm/nucleo_wb55rg/CMakeLists.txt
@@ -1,3 +1,5 @@
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+endif()

--- a/boards/arm/olimex_stm32_e407/CMakeLists.txt
+++ b/boards/arm/olimex_stm32_e407/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/olimex_stm32_h407/CMakeLists.txt
+++ b/boards/arm/olimex_stm32_h407/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/olimex_stm32_p405/CMakeLists.txt
+++ b/boards/arm/olimex_stm32_p405/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/olimexino_stm32/CMakeLists.txt
+++ b/boards/arm/olimexino_stm32/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm3210c_eval/CMakeLists.txt
+++ b/boards/arm/stm3210c_eval/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32373c_eval/CMakeLists.txt
+++ b/boards/arm/stm32373c_eval/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32_min_dev/CMakeLists.txt
+++ b/boards/arm/stm32_min_dev/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32f072_eval/CMakeLists.txt
+++ b/boards/arm/stm32f072_eval/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32f072b_disco/CMakeLists.txt
+++ b/boards/arm/stm32f072b_disco/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32f0_disco/CMakeLists.txt
+++ b/boards/arm/stm32f0_disco/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32f3_disco/CMakeLists.txt
+++ b/boards/arm/stm32f3_disco/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32f411e_disco/CMakeLists.txt
+++ b/boards/arm/stm32f411e_disco/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32f412g_disco/CMakeLists.txt
+++ b/boards/arm/stm32f412g_disco/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32f429i_disc1/CMakeLists.txt
+++ b/boards/arm/stm32f429i_disc1/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32f469i_disco/CMakeLists.txt
+++ b/boards/arm/stm32f469i_disco/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32f4_disco/CMakeLists.txt
+++ b/boards/arm/stm32f4_disco/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32f723e_disco/CMakeLists.txt
+++ b/boards/arm/stm32f723e_disco/CMakeLists.txt
@@ -3,5 +3,5 @@
 if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/stm32f723e_disco/CMakeLists.txt
+++ b/boards/arm/stm32f723e_disco/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+endif()

--- a/boards/arm/stm32f746g_disco/CMakeLists.txt
+++ b/boards/arm/stm32f746g_disco/CMakeLists.txt
@@ -3,5 +3,5 @@
 if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/stm32f746g_disco/CMakeLists.txt
+++ b/boards/arm/stm32f746g_disco/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+endif()

--- a/boards/arm/stm32f769i_disco/CMakeLists.txt
+++ b/boards/arm/stm32f769i_disco/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+endif()

--- a/boards/arm/stm32l476g_disco/CMakeLists.txt
+++ b/boards/arm/stm32l476g_disco/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32l496g_disco/CMakeLists.txt
+++ b/boards/arm/stm32l496g_disco/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/stm32mp157c_dk2/CMakeLists.txt
+++ b/boards/arm/stm32mp157c_dk2/CMakeLists.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_PINMUX)
+zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
 endif()

--- a/boards/arm/stm32mp157c_dk2/CMakeLists.txt
+++ b/boards/arm/stm32mp157c_dk2/CMakeLists.txt
@@ -5,5 +5,5 @@
 if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/stm32mp157c_dk2/CMakeLists.txt
+++ b/boards/arm/stm32mp157c_dk2/CMakeLists.txt
@@ -2,5 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_PINMUX)
 zephyr_library_sources(pinmux.c)
 zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+endif()

--- a/samples/basic/minimal/sample.yaml
+++ b/samples/basic/minimal/sample.yaml
@@ -5,23 +5,23 @@ tests:
   sample.minimal.mt.arm:
     build_only: true
     extra_args: CONF_FILE='common.conf;mt.conf;arm.conf'
-    platform_whitelist: reel_board frdm_k64f mps2_an385 nrf51_pca10028
+    platform_whitelist: reel_board frdm_k64f mps2_an385 nrf51_pca10028 nucleo_f429zi disco_l475_iot1
   sample.minimal.mt-no-preempt.arm:
     build_only: true
     extra_args: CONF_FILE='common.conf;mt.conf;no-preempt.conf;arm.conf'
-    platform_whitelist: reel_board frdm_k64f mps2_an385 nrf51_pca10028
+    platform_whitelist: reel_board frdm_k64f mps2_an385 nrf51_pca10028 nucleo_f429zi disco_l475_iot1
   sample.minimal.mt-no-preempt-no-timers.arm:
     build_only: true
     extra_args: CONF_FILE='common.conf;mt.conf;no-preempt.conf;no-timers.conf;arm.conf'
-    platform_whitelist: reel_board frdm_k64f mps2_an385 nrf51_pca10028
+    platform_whitelist: reel_board frdm_k64f mps2_an385 nrf51_pca10028 nucleo_f429zi disco_l475_iot1
   sample.minimal.no-mt.arm:
     build_only: true
     extra_args: CONF_FILE='common.conf;no-mt.conf;arm.conf'
-    platform_whitelist: reel_board frdm_k64f mps2_an385 nrf51_pca10028
+    platform_whitelist: reel_board frdm_k64f mps2_an385 nrf51_pca10028 nucleo_f429zi disco_l475_iot1
   sample.minimal.no-mt-no-timers.arm:
     build_only: true
     extra_args: CONF_FILE='common.conf;no-mt.conf;no-timers.conf;arm.conf'
-    platform_whitelist: reel_board frdm_k64f mps2_an385 nrf51_pca10028
+    platform_whitelist: reel_board frdm_k64f mps2_an385 nrf51_pca10028 nucleo_f429zi disco_l475_iot1
   sample.minimal.mt.x86:
     build_only: true
     extra_args: CONF_FILE='common.conf;mt.conf;x86.conf'


### PR DESCRIPTION
Fix #16177 STM32: Could not compile with CONFIG_PINMUX=n
By the way, fix also minor misalignment within STM32 boards.