### PR TITLE
include: arch: arc: Minor punctuation fix

### DIFF
--- a/include/arch/arc/arch.h
+++ b/include/arch/arc/arch.h
@@ -114,7 +114,7 @@ extern "C" {
 /*
  * MPUv3, no-mpu and no USERSPACE share the same macro definitions.
  * For MPU STACK_GUARD  kernel stacks do not need a MPU region to protect,
- * only guard needs to be protected and aligned. For MPUv3,MPU_STACK_GUARD
+ * only guard needs to be protected and aligned. For MPUv3, MPU_STACK_GUARD
  * requires start 32 bytes aligned, also for size which is decided by stack
  * array and USERSPACE; For MPUv2, MPU_STACK_GUARD requires
  * start 2048 bytes aligned, also for size which is decided by stack array.


### PR DESCRIPTION
Add missing space after comma.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>