### PR TITLE
posix: Add headers related to BSD Sockets API

### DIFF
--- a/include/posix/arpa/inet.h
+++ b/include/posix/arpa/inet.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_POSIX_ARPA_INET_H_
+#define ZEPHYR_INCLUDE_POSIX_ARPA_INET_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <net/socket.h>
+
+static inline char *inet_ntop(sa_family_t family, const void *src, char *dst,
+			      size_t size)
+{
+	return zsock_inet_ntop(family, src, dst, size);
+}
+
+static inline int inet_pton(sa_family_t family, const char *src, void *dst)
+{
+	return zsock_inet_pton(family, src, dst);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_POSIX_ARPA_INET_H_ */

--- a/include/posix/net/if.h
+++ b/include/posix/net/if.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_POSIX_NET_IF_H_
+#define ZEPHYR_INCLUDE_POSIX_NET_IF_H_
+
+#include <net/socket.h>
+
+#endif /* ZEPHYR_INCLUDE_POSIX_NET_IF_H_ */

--- a/include/posix/netdb.h
+++ b/include/posix/netdb.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_POSIX_NETDB_H_
+#define ZEPHYR_INCLUDE_POSIX_NETDB_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <net/socket.h>
+
+#define addrinfo zsock_addrinfo
+
+static inline int getaddrinfo(const char *host, const char *service,
+			      const struct zsock_addrinfo *hints,
+			      struct zsock_addrinfo **res)
+{
+	return zsock_getaddrinfo(host, service, hints, res);
+}
+
+static inline void freeaddrinfo(struct zsock_addrinfo *ai)
+{
+	zsock_freeaddrinfo(ai);
+}
+
+static inline const char *gai_strerror(int errcode)
+{
+	return zsock_gai_strerror(errcode);
+}
+
+static inline int getnameinfo(const struct sockaddr *addr, socklen_t addrlen,
+			      char *host, socklen_t hostlen,
+			      char *serv, socklen_t servlen, int flags)
+{
+	return zsock_getnameinfo(addr, addrlen, host, hostlen,
+				 serv, servlen, flags);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* ZEPHYR_INCLUDE_POSIX_NETDB_H_ */

--- a/include/posix/netinet/in.h
+++ b/include/posix/netinet/in.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_POSIX_NETINET_IN_H_
+#define ZEPHYR_INCLUDE_POSIX_NETINET_IN_H_
+
+#include <net/socket.h>
+
+#endif /* ZEPHYR_INCLUDE_POSIX_NETINET_IN_H_ */

--- a/include/posix/netinet/tcp.h
+++ b/include/posix/netinet/tcp.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_POSIX_NETINET_TCP_H_
+#define ZEPHYR_INCLUDE_POSIX_NETINET_TCP_H_
+
+#include <net/socket.h>
+
+#endif /* ZEPHYR_INCLUDE_POSIX_NETINET_TCP_H_ */

--- a/include/posix/sys/ioctl.h
+++ b/include/posix/sys/ioctl.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_POSIX_SYS_IOCTL_H_
+#define ZEPHYR_INCLUDE_POSIX_SYS_IOCTL_H_
+
+#define FIONBIO 0x5421
+
+#endif /* ZEPHYR_INCLUDE_POSIX_SYS_IOCTL_H_ */

--- a/include/posix/sys/socket.h
+++ b/include/posix/sys/socket.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_POSIX_SYS_SOCKET_H_
+#define ZEPHYR_INCLUDE_POSIX_SYS_SOCKET_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/types.h>
+#include <net/socket.h>
+
+static inline int socket(int family, int type, int proto)
+{
+	return zsock_socket(family, type, proto);
+}
+
+#define SHUT_RD ZSOCK_SHUT_RD
+#define SHUT_WR ZSOCK_SHUT_WR
+#define SHUT_RDWR ZSOCK_SHUT_RDWR
+
+static inline int shutdown(int sock, int how)
+{
+	return zsock_shutdown(sock, how);
+}
+
+static inline int bind(int sock, const struct sockaddr *addr, socklen_t addrlen)
+{
+	return zsock_bind(sock, addr, addrlen);
+}
+
+static inline int connect(int sock, const struct sockaddr *addr,
+			  socklen_t addrlen)
+{
+	return zsock_connect(sock, addr, addrlen);
+}
+
+static inline int listen(int sock, int backlog)
+{
+	return zsock_listen(sock, backlog);
+}
+
+static inline int accept(int sock, struct sockaddr *addr, socklen_t *addrlen)
+{
+	return zsock_accept(sock, addr, addrlen);
+}
+
+static inline ssize_t send(int sock, const void *buf, size_t len, int flags)
+{
+	return zsock_send(sock, buf, len, flags);
+}
+
+static inline ssize_t recv(int sock, void *buf, size_t max_len, int flags)
+{
+	return zsock_recv(sock, buf, max_len, flags);
+}
+
+static inline ssize_t sendto(int sock, const void *buf, size_t len, int flags,
+			     const struct sockaddr *dest_addr,
+			     socklen_t addrlen)
+{
+	return zsock_sendto(sock, buf, len, flags, dest_addr, addrlen);
+}
+
+static inline ssize_t recvfrom(int sock, void *buf, size_t max_len, int flags,
+			       struct sockaddr *src_addr, socklen_t *addrlen)
+{
+	return zsock_recvfrom(sock, buf, max_len, flags, src_addr, addrlen);
+}
+
+static inline int getsockopt(int sock, int level, int optname,
+			     void *optval, socklen_t *optlen)
+{
+	return zsock_getsockopt(sock, level, optname, optval, optlen);
+}
+
+static inline int setsockopt(int sock, int level, int optname,
+			     const void *optval, socklen_t optlen)
+{
+	return zsock_setsockopt(sock, level, optname, optval, optlen);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* ZEPHYR_INCLUDE_POSIX_SYS_SOCKET_H_ */


### PR DESCRIPTION
A few of these headers are currently just re-export to existing net/socket.h (all of them are useful to avoid compiler errors when building existing software.)

This set of headers is what was required to build
https://github.com/open62541/open62541 with Zephyr, and will be useful for other projects too.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>