### PR TITLE
logging: use os as a domain for low level system debugging

### DIFF
--- a/include/misc/stack.h
+++ b/include/misc/stack.h
@@ -64,7 +64,7 @@ static inline void stack_analyze(const char *name, const char *stack,
 				 unsigned int size)
 {
 	if (IS_ENABLED(CONFIG_INIT_STACKS)) {
-		LOG_MODULE_DECLARE(kernel, CONFIG_KERNEL_LOG_LEVEL);
+		LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 		unsigned int unused = stack_unused_space_get(stack, size);
 		unsigned int pcnt = ((size - unused) * 100U) / size;

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -38,7 +38,7 @@
 #define IDLE_THREAD_NAME	"idle"
 #define LOG_LEVEL CONFIG_KERNEL_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(kernel);
+LOG_MODULE_REGISTER(os);
 
 /* boot banner items */
 #if defined(CONFIG_MULTITHREADING) && defined(CONFIG_BOOT_DELAY) \

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -36,7 +36,7 @@ K_APPMEM_PARTITION_DEFINE(k_mbedtls_partition);
 
 #define LOG_LEVEL CONFIG_KERNEL_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_DECLARE(kernel);
+LOG_MODULE_DECLARE(os);
 
 /* The originally synchronization strategy made heavy use of recursive
  * irq_locking, which ports poorly to spinlocks which are


### PR DESCRIPTION
We had both kernel and os as domains covering low level layers, just use
one and fix the issue of the os domain not being registered.