### PR TITLE
boards/x86: scripts: build_grub.sh to use grub-2.04-rc1-17-g8e8723a6b

### DIFF
--- a/boards/x86/common/scripts/build_grub.sh
+++ b/boards/x86/common/scripts/build_grub.sh
@@ -22,7 +22,7 @@ prepare() {
   fi
 
   pushd src
-  git checkout grub-2.02-285-g5bc41db75
+  git checkout grub-2.04-rc1-17-g8e8723a6b
   git clean -fdx
   popd
 }


### PR DESCRIPTION
Newer versions of GCC (e.g. gcc 9.1.1) fail to compile the version of
Grub that is used by the Zephyr build_grub.sh script. This patch updates
the version of Grub to the latest (as of June 4 2019) which includes a
number of fixes that solve the problem.

Fixes: #16624
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>