### PR TITLE
USB: drivers: usb_dc_stm32: Fix coverity issue

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -963,6 +963,8 @@ void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd)
 	LOG_DBG("");
 
 	ep_state = usb_dc_stm32_get_ep_state(EP0_OUT); /* can't fail for ep0 */
+	__ASSERT(ep_state, "No corresponding ep_state for EP0");
+
 	ep_state->read_count = SETUP_SIZE;
 	ep_state->read_offset = 0U;
 	memcpy(&usb_dc_stm32_state.ep_buf[EP0_IDX],

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -1009,6 +1009,8 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, u8_t epnum)
 
 	LOG_DBG("epnum 0x%02x", epnum);
 
+	__ASSERT(ep_state, "No corresponding ep_state for ep");
+
 	k_sem_give(&ep_state->write_sem);
 
 	if (ep_state->cb) {


### PR DESCRIPTION
Add __ASSERT() for coverity issue CID: 198874. Assert is used instead
of check since this is callback we get from stm32cube.

Fixes #16573
Fixes #16582