### PR TITLE
stats: fix Coverity CID :198875

### DIFF
--- a/subsys/stats/stats.c
+++ b/subsys/stats/stats.c
@@ -281,5 +281,5 @@ stats_init_and_reg(struct stats_hdr *shdr, u8_t size, u16_t cnt,
 void
 stats_reset(struct stats_hdr *hdr)
 {
-	(void)memset(hdr + 1, 0, hdr->s_size * hdr->s_cnt);
+	(void)memset((u8_t *)hdr + sizeof(*hdr), 0, hdr->s_size * hdr->s_cnt);
 }


### PR DESCRIPTION
Issue was caused by pointer arithmetic.
This commit cast pointer of struct data to u8_t pointer
and makes arithmetic explicitly by adding the exact value.

fixes #16572

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>