### PR TITLE
kernel/smp: Rename smp_init()

### DIFF
--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -235,7 +235,7 @@ extern void z_thread_monitor_exit(struct k_thread *thread);
 	} while (false)
 #endif /* CONFIG_THREAD_MONITOR */
 
-extern void smp_init(void);
+extern void z_smp_init(void);
 
 extern void smp_timer_init(void);
 

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -263,7 +263,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	z_init_static_threads();
 
 #ifdef CONFIG_SMP
-	smp_init();
+	z_smp_init();
 #endif
 
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -89,7 +89,7 @@ static void smp_init_top(int key, void *arg)
 }
 #endif
 
-void smp_init(void)
+void z_smp_init(void)
 {
 	(void)atomic_clear(&start_flag);
 


### PR DESCRIPTION
This name collides with one in the bt subsystem, and wasn't named in
proper zephyrese anyway.

Fixes #16604

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>