### PR TITLE
doc: fix malformed label in shields doc

### DIFF
--- a/samples/shields/shields.rst
+++ b/samples/shields/shields.rst
@@ -1,4 +1,4 @@
-.. shields-samples:
+.. _shields-samples:
 
 Shields Samples
 ###############


### PR DESCRIPTION
Doc label at the top was malformed and couldn't be referenced.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>