### PR TITLE
tests: mesh: fix function prototype and match declaration

### DIFF
--- a/tests/bluetooth/mesh/src/microbit.c
+++ b/tests/bluetooth/mesh/src/microbit.c
@@ -41,7 +41,7 @@ static void configure_button(void)
 	gpio_add_callback(gpio, &button_cb);
 }
 
-void board_output_number(bt_mesh_output_action_t action, uint32_t number)
+void board_output_number(bt_mesh_output_action_t action, u32_t number)
 {
 	struct mb_display *disp = mb_display_get();
 	struct mb_image arrow = MB_IMAGE({ 0, 0, 1, 0, 0 },


### PR DESCRIPTION
Match function declaration of board_output_number. Use u32_t instead of
uint32_t.