### PR TITLE
debug: tracing: Fix tracing hooks

### DIFF
--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -79,9 +79,6 @@ z_arch_switch_to_main_thread(struct k_thread *main_thread,
 
 	start_of_main_stack = (char *)STACK_ROUND_DOWN(start_of_main_stack);
 
-#ifdef CONFIG_TRACING
-	z_sys_trace_thread_switched_out();
-#endif
 	_current = main_thread;
 #ifdef CONFIG_TRACING
 	z_sys_trace_thread_switched_in();

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -323,13 +323,6 @@ static void prepare_multithreading(struct k_thread *dummy_thread)
 	ARG_UNUSED(dummy_thread);
 #else
 
-#ifdef CONFIG_TRACING
-	sys_trace_thread_switched_out();
-#endif
-#ifdef CONFIG_TRACING
-	sys_trace_thread_switched_in();
-#endif
-
 	/*
 	 * Initialize the current execution thread to permit a level of
 	 * debugging output if an exception should happen during kernel


### PR DESCRIPTION
Change removes tracing hooks before threads are initialized and thread switched out hook for ARM before first time switching to main thread.

Fixes: #16606