### PR TITLE
scripts/dts: Remove alias defines for labels

### DIFF
--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -71,12 +71,6 @@ def create_aliases(root):
         for name, node_path in root['children']['aliases']['props'].items():
             aliases[node_path].append(name)
 
-    # Treat alternate names as aliases
-    for node_path, node in reduced.items():
-        if 'alt_name' in node:
-            aliases[node_path].append(node['alt_name'])
-
-
 def get_compat(node_path):
     # Returns the value of the 'compatible' property for the node at
     # 'node_path'. Also checks the node's parent.


### PR DESCRIPTION
We added generation of aliases for "alt-label" (which was the outer
label of a node) for use with shields and connectors.  However we've
never used these defines and the generation is a bit inconsistent.

This removes generation of defines like for label 'arduino_spi':
	#define ARDUINO_SPI_BASE_ADDRESS ... (already deprecated)
	#define DT_ST_STM32_SPI_FIFO_ARDUINO_SPI_BASE_ADDRESS ...

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>