### PR TITLE
shell: Initialize va_list variables portably.

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1327,7 +1327,7 @@ void shell_fprintf(const struct shell *shell, enum shell_vt100_color color,
 	__ASSERT_NO_MSG(shell->fprintf_ctx);
 	__ASSERT_NO_MSG(fmt);
 
-	va_list args = { 0 };
+	va_list args;
 
 	k_mutex_lock(&shell->ctx->wr_mtx, K_FOREVER);
 	if (!flag_cmd_ctx_get(shell)) {

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -474,7 +474,7 @@ void shell_internal_fprintf(const struct shell *shell,
 	__ASSERT_NO_MSG(shell->fprintf_ctx);
 	__ASSERT_NO_MSG(fmt);
 
-	va_list args = { 0 };
+	va_list args;
 
 	va_start(args, fmt);
 	shell_internal_vfprintf(shell, color, fmt, args);


### PR DESCRIPTION
The structure of the `va_list` type is architecture-dependent, and it
doesn't seem possible to initialize `va_list` variables in a portable way
(except by using `va_start()`). In particular, the x86_64 ABI defines the
type like this:

    typedef struct {
        unsigned int gp_offset;
        unsigned int fp_offset;
        void *overflow_arg_area;
        void *reg_save_area;
    } va_list[1];

Fortunately, the `va_start()` macro expects an uninitialized `va_list`
variable, so we can simply remove the initializers to make the code
portable.

Signed-off-by: Jakob Olesen <jolesen@fb.com>