### PR TITLE
doc: add google analytics tracking to docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -555,4 +555,7 @@ linkcheck_anchors = False
 
 def setup(app):
     app.add_stylesheet("zephyr-custom.css")
+
+    app.add_javascript("https://www.googletagmanager.com/gtag/js?id=UA-831873-47")
+    app.add_javascript("ga-tracker.js")
     app.add_javascript("zephyr-custom.js")

--- a/doc/static/ga-tracker.js
+++ b/doc/static/ga-tracker.js
@@ -1,0 +1,10 @@
+// <!-- Global site tag (gtag.js) - Google Analytics -->
+
+// Copyright (c) 2019, Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'UA-831873-47');


### PR DESCRIPTION
This adds code to each page needed for gathering google analytics
tracking data to the LF-provided Global site tag.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>