### PR TITLE
[DNM][brokencase] Posix zephyr interface library broken inc order

### DIFF
--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_include_directories(include)
+zephyr_system_include_directories(include)
 
 zephyr_library()
 zephyr_library_sources(

--- a/lib/posix/CMakeLists.txt
+++ b/lib/posix/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-add_library(PTHREAD INTERFACE)
+zephyr_interface_library_named(PTHREAD)
 
 target_include_directories(PTHREAD INTERFACE ${ZEPHYR_BASE}/include/posix)
 

--- a/lib/posix/Kconfig
+++ b/lib/posix/Kconfig
@@ -96,4 +96,12 @@ config	POSIX_MAX_OPEN_FILES
 endif
 endif # FILE_SYSTEM
 
+# The name of this option is mandated by zephyr_interface_library_named
+# cmake directive.
+config APP_LINK_WITH_PTHREAD
+        bool "Make POSIX headers available to application"
+        default y
+        help
+          Add POSIX header files to the 'app' include path.
+
 endif # POSIX_API

--- a/tests/posix/common/CMakeLists.txt
+++ b/tests/posix/common/CMakeLists.txt
@@ -4,6 +4,5 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(posix_common)
 
-target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/include/posix)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/posix/fs/CMakeLists.txt
+++ b/tests/posix/fs/CMakeLists.txt
@@ -4,7 +4,5 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(fs)
 
-target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/include/)
-
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
This is variant of https://github.com/zephyrproject-rtos/zephyr/pull/15937 without the important "CMakeLists.txt: Call toolchain_cc_nostdinc() at the end" patch, submitted so @SebastianBoe can see the problem that patch fixes.