### PR TITLE
logging: Duplicate only strings from rw memory

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -753,7 +753,7 @@ char *log_strdup(const char *str)
 	struct log_strdup_buf *dup;
 	int err;
 
-	if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) {
+	if (IS_ENABLED(CONFIG_LOG_IMMEDIATE) || is_rodata(str)) {
 		return (char *)str;
 	}
 


### PR DESCRIPTION
If argument for log_strdup is from ro memory then there is
no point to duplicate it. This may happen if function logs
variables coming from outside, e.g. function argument.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>