### PR TITLE
Bluetooth: Mesh: LPN: Clear sent_req on failure

### DIFF
--- a/subsys/bluetooth/host/mesh/lpn.c
+++ b/subsys/bluetooth/host/mesh/lpn.c
@@ -761,6 +761,7 @@ static void lpn_timeout(struct k_work *work)
 		}
 		lpn->counter++;
 		lpn_set_state(BT_MESH_LPN_ENABLED);
+		lpn->sent_req = 0U;
 		k_delayed_work_submit(&lpn->timer, FRIEND_REQ_RETRY_TIMEOUT);
 		break;
 	case BT_MESH_LPN_ESTABLISHED:


### PR DESCRIPTION
When trying to establish friendship the Friend must respond to the
initial Friend Poll with a Friend Update. If this initial Friend Update
response is not received the Friendship establishment process must start
again.

When starting a second Friendship establishment processes the `sent_req`
field of the `lpn` struct was left set to `TRANS_CTL_OP_FRIEND_POLL`.
This prevented the initial Friend Poll being sent out on the second
attempt. Since the Friend Poll was not sent, no timeout is set and
nothing happens ever again. No more Friendship Requests are sent.

This commit clears `sent_req` back to zero when no Friend Update
response has been received after the initial Friend Poll.

Fixes #16678

Signed-off-by: Rich Barlow <rich@bennellick.com>