### PR TITLE
Bluetooth: controller: split: Port random slave event backoff

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1007,16 +1007,13 @@ void ull_conn_done(struct node_rx_event_done *done)
 				if (latency_event) {
 					force = 1U;
 				} else {
-					/* FIXME:*/
-					#if 0
-					force = lll->slave.force & 0x01;
+					force = conn->slave.force & 0x01;
 
 					/* rotate force bits */
-					lll->slave.force >>= 1;
+					conn->slave.force >>= 1;
 					if (force) {
-						lll->slave.force |= BIT(31);
+						conn->slave.force |= BIT(31);
 					}
-					#endif
 				}
 			}
 		} else {

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -37,6 +37,7 @@ struct ll_conn {
 
 		struct {
 			u8_t fex_valid:1;
+			u32_t force;
 			u32_t ticks_to_offset;
 		} slave;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -116,11 +116,8 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 			     conn->apto_reload;
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
-	/* FIXME: */
-	#if 0
-	memcpy((void *)&lll->slave.force, &lll->access_addr[0],
-	       sizeof(lll->slave.force));
-	#endif
+	memcpy((void *)&conn->slave.force, &lll->access_addr[0],
+	       sizeof(conn->slave.force));
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	u8_t own_addr_type = pdu_adv->rx_addr;


### PR DESCRIPTION
Port the implementation that performed random backoff of
forced slave event scheduling.

When peer master implementation skips events, multiple
local overlapping slaves will randomize their forced
scheduling to break out of a round robin pattern increasing
the chance of synchronizing with their masters again.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>