### PR TITLE
Bluetooth: controller: BT_CTLR_USER_EXT depends on BT_LL_SW_SPLIT

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -624,6 +624,7 @@ config BT_MAYFLY_YIELD_AFTER_CALL
 
 config BT_CTLR_USER_EXT
 	prompt "Enable proprietary extensions in Controller"
+	depends on BT_LL_SW_SPLIT
 	bool
 	help
 	  Catch-all for enabling proprietary event types in Controller behavior.


### PR DESCRIPTION
Make the Kconfig option BT_CTLR_USER_EXT depend on
BT_LL_SW_SPLIT.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>