### PR TITLE
Bluetooth: controller: split: Add ULL/LLL architecture assert checks

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -634,6 +634,8 @@ static void isr_done(void *param)
 	/* TODO: MOVE ^^ */
 
 	e = ull_event_done_extra_get();
+	LL_ASSERT(e);
+
 	e->type = EVENT_DONE_EXTRA_TYPE_CONN;
 	e->trx_cnt = trx_cnt;
 	e->crc_valid = crc_valid;

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1533,6 +1533,7 @@ static inline void rx_demux_event_done(memq_link_t *link,
 	struct node_rx_event_done *done = (void *)rx;
 	struct ull_hdr *ull_hdr;
 	struct lll_event *next;
+	void *release;
 
 	/* Get the ull instance */
 	ull_hdr = done->param;
@@ -1563,7 +1564,8 @@ static inline void rx_demux_event_done(memq_link_t *link,
 
 	/* release done */
 	done->extra.type = 0U;
-	done_release(link, done);
+	release = done_release(link, done);
+	LL_ASSERT(release == done);
 
 	/* dequeue prepare pipeline */
 	next = ull_prepare_dequeue_get();


### PR DESCRIPTION
Add some missing fatal asserts that need to be caught to
avoid unexpected failures in the implementation of the
architecture.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>