### PR TITLE
Bluetooth: controller: split: Port radio event abort

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.h
@@ -101,3 +101,5 @@ static inline struct pdu_adv *lll_adv_scan_rsp_peek(struct lll_adv *lll)
 {
 	return (void *)lll->scan_rsp.pdu[lll->scan_rsp.last];
 }
+
+extern u16_t ull_adv_lll_handle_get(struct lll_adv *lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
@@ -80,8 +80,8 @@ static int init_reset(void)
 static int prepare_cb(struct lll_prepare_param *prepare_param)
 {
 	struct lll_conn *lll = prepare_param->param;
+	u32_t ticks_at_event, ticks_at_start;
 	struct pdu_data *pdu_data_tx;
-	u32_t ticks_at_event;
 	struct evt_hdr *evt;
 	u16_t event_counter;
 	u32_t remainder_us;
@@ -162,10 +162,12 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	ticks_at_event = prepare_param->ticks_at_expire;
 	evt = HDR_LLL2EVT(lll);
 	ticks_at_event += lll_evt_offset_get(evt);
-	ticks_at_event += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+
+	ticks_at_start = ticks_at_event;
+	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 
 	remainder = prepare_param->remainder;
-	remainder_us = radio_tmr_start(1, ticks_at_event, remainder);
+	remainder_us = radio_tmr_start(1, ticks_at_start, remainder);
 
 	/* capture end of Tx-ed PDU, used to calculate HCTO. */
 	radio_tmr_end_capture();
@@ -190,7 +192,8 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, TICKER_ID_CONN_BASE, ticks_at_event)) {
+	if (lll_preempt_calc(evt, (TICKER_ID_CONN_BASE + lll->handle),
+			     ticks_at_event)) {
 		radio_isr_set(lll_conn_isr_abort, lll);
 		radio_disable();
 	} else

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.h
@@ -43,3 +43,5 @@ int lll_scan_init(void);
 int lll_scan_reset(void);
 
 void lll_scan_prepare(void *param);
+
+extern u16_t ull_scan_lll_handle_get(struct lll_scan *lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
@@ -80,7 +80,7 @@ static int init_reset(void)
 static int prepare_cb(struct lll_prepare_param *prepare_param)
 {
 	struct lll_conn *lll = prepare_param->param;
-	u32_t ticks_at_event;
+	u32_t ticks_at_event, ticks_at_start;
 	struct evt_hdr *evt;
 	u16_t event_counter;
 	u32_t remainder_us;
@@ -185,10 +185,12 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	ticks_at_event = prepare_param->ticks_at_expire;
 	evt = HDR_LLL2EVT(lll);
 	ticks_at_event += lll_evt_offset_get(evt);
-	ticks_at_event += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+
+	ticks_at_start = ticks_at_event;
+	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 
 	remainder = prepare_param->remainder;
-	remainder_us = radio_tmr_start(0, ticks_at_event, remainder);
+	remainder_us = radio_tmr_start(0, ticks_at_start, remainder);
 
 	radio_tmr_aa_capture();
 	radio_tmr_aa_save(0);
@@ -235,7 +237,8 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
 	(EVENT_OVERHEAD_PREEMPT_US <= EVENT_OVERHEAD_PREEMPT_MIN_US)
 	/* check if preempt to start has changed */
-	if (lll_preempt_calc(evt, TICKER_ID_CONN_BASE, ticks_at_event)) {
+	if (lll_preempt_calc(evt, (TICKER_ID_CONN_BASE + lll->handle),
+			     ticks_at_event)) {
 		radio_isr_set(lll_conn_isr_abort, lll);
 		radio_disable();
 	} else

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -925,6 +925,11 @@ inline u16_t ull_adv_handle_get(struct ll_adv_set *adv)
 	return ((u8_t *)adv - (u8_t *)ll_adv) / sizeof(*adv);
 }
 
+u16_t ull_adv_lll_handle_get(struct lll_adv *lll)
+{
+	return ull_adv_handle_get((void *)lll->hdr.parent);
+}
+
 inline struct ll_adv_set *ull_adv_is_enabled_get(u16_t handle)
 {
 	struct ll_adv_set *adv;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -296,6 +296,11 @@ u16_t ull_scan_handle_get(struct ll_scan_set *scan)
 	return ((u8_t *)scan - (u8_t *)ll_scan) / sizeof(*scan);
 }
 
+u16_t ull_scan_lll_handle_get(struct lll_scan *lll)
+{
+	return ull_scan_handle_get((void *)lll->hdr.parent);
+}
+
 struct ll_scan_set *ull_scan_is_enabled_get(u16_t handle)
 {
 	struct ll_scan_set *scan;


### PR DESCRIPTION
Port the implementation that does radio event abort due to
ISR latencies. The implementation measures if the ISR could
not meet the hard real time deadline and closes the event
early.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>