### PR TITLE
driver: modem: add simple power management to modem receiver

### DIFF
--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -193,6 +193,25 @@ int mdm_receiver_send(struct mdm_receiver_context *ctx,
 	return 0;
 }
 
+int mdm_receiver_sleep(struct mdm_receiver_context *ctx)
+{
+	uart_irq_rx_disable(ctx->uart_dev);
+#ifdef DEVICE_PM_LOW_POWER_STATE
+	device_set_power_state(ctx->uart_dev, DEVICE_PM_LOW_POWER_STATE, NULL, NULL);
+#endif
+	return 0;
+}
+
+int mdm_receiver_wake(struct mdm_receiver_context *ctx)
+{
+#ifdef DEVICE_PM_LOW_POWER_STATE
+	device_set_power_state(ctx->uart_dev, DEVICE_PM_ACTIVE_STATE, NULL, NULL);
+#endif
+	uart_irq_rx_enable(ctx->uart_dev);
+
+	return 0;
+}
+
 int mdm_receiver_register(struct mdm_receiver_context *ctx,
 			  const char *uart_dev_name,
 			  u8_t *buf, size_t size)

--- a/drivers/modem/modem_receiver.h
+++ b/drivers/modem/modem_receiver.h
@@ -86,6 +86,10 @@ int mdm_receiver_register(struct mdm_receiver_context *ctx,
 			  const char *uart_dev_name,
 			  u8_t *buf, size_t size);
 
+int mdm_receiver_sleep(struct mdm_receiver_context *ctx);
+
+int mdm_receiver_wake(struct mdm_receiver_context *ctx);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
As modem receiver is using UART, it requires disabling of the UART and its callbacks.
This adds simple sleep/wake functions which should be called from defined device_pm functions in modem drivers later.

Signed-off-by: Christoph Schramm <schramm@makaio.com>