### PR TITLE
dts/bindings: Move common properties into a base.yaml

### DIFF
--- a/dts/bindings/arc/arc,dccm.yaml
+++ b/dts/bindings/arc/arc,dccm.yaml
@@ -10,17 +10,13 @@ version: 0.1
 description: >
     This binding gives a base representation of the ARC DCCM
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "arc,dccm"
-      generation: define
 
     reg:
-      type: array
-      description: DCCM memory mapped address space
-      generation: define
       category: required
 ...

--- a/dts/bindings/arc/arc,iccm.yaml
+++ b/dts/bindings/arc/arc,iccm.yaml
@@ -10,17 +10,13 @@ version: 0.1
 description: >
     This binding gives a base representation of the ARC ICCM
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "arc,iccm"
-      generation: define
 
     reg:
-      type: array
-      description: ICCM memory mapped address space
-      generation: define
       category: required
 ...

--- a/dts/bindings/arm/arm,scc.yaml
+++ b/dts/bindings/arm/arm,scc.yaml
@@ -10,17 +10,14 @@ version: 0.1
 description: >
     This binding gives a base representation of the ARM SCC
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "arm,scc"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
 ...

--- a/dts/bindings/arm/atmel,sam0-device_id.yaml
+++ b/dts/bindings/arm/atmel,sam0-device_id.yaml
@@ -5,17 +5,13 @@ version: 0.1
 description: >
     Binding for locating the Device ID (serial number) on Atmel SAM0 devices.
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam0-id"
-      generation: define
 
     reg:
-      type: array
       category: required
-      description: Location of Device ID words in memory
-      generation: define
 ...

--- a/dts/bindings/arm/atmel,sam0-dmac.yaml
+++ b/dts/bindings/arm/atmel,sam0-dmac.yaml
@@ -5,23 +5,16 @@ version: 0.1
 description: >
     Binding for the Atmel SAM0 DMA controller.
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam0-dmac"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/arm/atmel,sam0-sercom.yaml
+++ b/dts/bindings/arm/atmel,sam0-sercom.yaml
@@ -5,23 +5,16 @@ version: 0.1
 description: >
     Binding for the Atmel SAM0 multi-protocol (UART, SPI, I2C) SERCOM unit.
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam0-sercom"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/arm/nordic,nrf-dppic.yaml
+++ b/dts/bindings/arm/nordic,nrf-dppic.yaml
@@ -11,17 +11,13 @@ description: >
     Binding for the Nordic DPPIC
     Distributed Programmable Peripheral Interconnect Controller
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-dppic"
-      generation: define
 
     reg:
-      type: array
       category: required
-      description: mmio register space
-      generation: define
 ...

--- a/dts/bindings/arm/nordic,nrf-ficr.yaml
+++ b/dts/bindings/arm/nordic,nrf-ficr.yaml
@@ -5,18 +5,14 @@ version: 0.1
 description: >
     Binding for the Nordic FICR (Factory Information Configuration Registers)
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-ficr"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
 ...

--- a/dts/bindings/arm/nordic,nrf-spu.yaml
+++ b/dts/bindings/arm/nordic,nrf-spu.yaml
@@ -5,24 +5,17 @@ version: 0.1
 description: >
     Binding for the Nordic SPU (System Protection Unit)
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-spu"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
 ...

--- a/dts/bindings/arm/nxp,imx-dtcm.yaml
+++ b/dts/bindings/arm/nxp,imx-dtcm.yaml
@@ -10,17 +10,14 @@ version: 0.1
 description: >
   This binding gives a base representation of the i.MX DTCM
 
+inherits:
+  !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
       constraint: "nxp,imx-dtcm"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
 ...

--- a/dts/bindings/arm/nxp,imx-epit.yaml
+++ b/dts/bindings/arm/nxp,imx-epit.yaml
@@ -10,30 +10,21 @@ version: 0.1
 description: >
     This binding gives a base representation of the i.MX Enhanced Periodic Interrupt Timer (EPIT)
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,imx-epit"
 
   reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
   interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
   label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
   prescaler:
      type: int

--- a/dts/bindings/arm/nxp,imx-itcm.yaml
+++ b/dts/bindings/arm/nxp,imx-itcm.yaml
@@ -10,17 +10,14 @@ version: 0.1
 description: >
   This binding gives a base representation of the i.MX ITCM
 
+inherits:
+  !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
       constraint: "nxp,imx-itcm"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
 ...

--- a/dts/bindings/arm/nxp,imx-mu.yaml
+++ b/dts/bindings/arm/nxp,imx-mu.yaml
@@ -10,30 +10,21 @@ version: 0.1
 description: >
     This binding gives a base representation of the i.MX Messaging Unit
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,imx-mu"
 
   reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
   interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
   label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
   rdc:
      type: int

--- a/dts/bindings/arm/nxp,kinetis-pcc.yaml
+++ b/dts/bindings/arm/nxp,kinetis-pcc.yaml
@@ -10,25 +10,18 @@ version: 0.1
 description: >
     This is a representation of the NXP Kinetis PCC IP node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-pcc"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 "#cells":
   - name

--- a/dts/bindings/arm/nxp,kinetis-scg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-scg.yaml
@@ -10,25 +10,18 @@ version: 0.1
 description: >
     This is a representation of the NXP Kinetis SCG IP node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-scg"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     clk-divider-slow:
       type: int

--- a/dts/bindings/arm/nxp,kinetis-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-sim.yaml
@@ -10,25 +10,18 @@ version: 0.1
 description: >
     This is a representation of the Kinetis SIM IP node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-sim"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     clkout-source:
       type: int

--- a/dts/bindings/arm/nxp,lpc-mailbox.yaml
+++ b/dts/bindings/arm/nxp,lpc-mailbox.yaml
@@ -10,30 +10,20 @@ version: 0.1
 description: >
     This binding gives a base representation of the LPC MAILBOX
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,lpc-mailbox"
-      generation: define
 
   reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
   interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
   label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/arm/st,stm32-ccm.yaml
+++ b/dts/bindings/arm/st,stm32-ccm.yaml
@@ -6,17 +6,14 @@ version: 0.1
 description: >
   This binding gives a base representation of the STM32 CCM (Core Coupled Memory)
 
+inherits:
+  !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
       constraint: "st,stm32-ccm"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
 ...

--- a/dts/bindings/arm/ti,cc2650-prcm.yaml
+++ b/dts/bindings/arm/ti,cc2650-prcm.yaml
@@ -7,17 +7,13 @@ description: >
     This binding gives a base representation of the TI CC2650
     Power, Reset, and Clock control Module.
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,cc2650-prcm"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 ...

--- a/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
+++ b/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
@@ -17,9 +17,6 @@ properties:
     compatible:
       constraint: "st,mpxxdtyy"
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -1,0 +1,45 @@
+---
+title: base device binding
+version: 0.1
+
+description: >
+    Binding for device
+
+properties:
+    compatible:
+        type: string
+        category: required
+        description: compatible strings
+        generation: define
+
+    reg:
+        type: array
+        description: register space
+        generation: define
+        category: optional
+
+    reg-names:
+        type: stringlist
+        description: name of each register space
+        generation: define
+        category: optional
+
+    interrupts:
+        type: array
+        category: optional
+        description: interrupts for device
+        generation: define
+
+    interrupt-names:
+        type: stringlist
+        category: optional
+        description: name of each interrupt
+        generation: define
+
+    label:
+        type: string
+        category: optional
+        description: Human readable string describing the device (used by Zephyr for API name)
+        generation: define
+
+...

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
@@ -11,16 +11,15 @@ description: >
     This binding gives the base representation of a bluetooth controller node
     that provides HCI over SPI.
 
+inherits:
+    !include base.yaml
+
 parent:
     bus: spi
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "zephyr,bt-hci-spi-slave"
-      generation: define
 
     irq-gpios:
       type: compound

--- a/dts/bindings/can/can-device.yaml
+++ b/dts/bindings/can/can-device.yaml
@@ -10,23 +10,15 @@ version: 0.1
 description: >
     This binding gives the base structures for all can devices
 
+inherits:
+    !include base.yaml
+
 parent:
     bus: can
 
 properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
     reg:
-      type: array
-      description: register base address
-      generation: define
       category: required
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/can/can.yaml
+++ b/dts/bindings/can/can.yaml
@@ -5,15 +5,13 @@ version: 0.1
 description: >
     This binding gives the base structures for all CAN devices
 
+inherits:
+    !include base.yaml
+
 child:
     bus: can
 
 properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
     "#address-cells":
       type: int
       category: required
@@ -23,10 +21,7 @@ properties:
       category: required
       description: should be 0.
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
     bus-speed:
       type: int
       category: required

--- a/dts/bindings/can/microchip,mcp2515.yaml
+++ b/dts/bindings/can/microchip,mcp2515.yaml
@@ -15,9 +15,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "microchip,mcp2515"
     int-gpios:
       type: compound

--- a/dts/bindings/can/st,stm32-can.yaml
+++ b/dts/bindings/can/st,stm32-can.yaml
@@ -13,21 +13,10 @@ properties:
       constraint: "st,stm32-can"
 
     reg:
-      type: array
-      description: register base address
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
-
-    interrupt-names:
-      type: array
-      category: optional
-      description: names off the interrupt lines
 
     gpio-port:
       type: string

--- a/dts/bindings/clock/nordic,nrf-clock.yaml
+++ b/dts/bindings/clock/nordic,nrf-clock.yaml
@@ -10,28 +10,19 @@ version: 0.1
 description: >
     This is a representation of the Nordic nRF clock control node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-clock"
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     reg:
-      type: array
       category: required
-      description: mmio register space
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/clock/nxp,imx-ccm.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm.yaml
@@ -10,25 +10,18 @@ version: 0.1
 description: >
     This is a representation of the i.MX CCM IP node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,imx-ccm"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 "#cells":
   - name

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -5,18 +5,14 @@ version: 0.1
 description: >
     This binding gives a base representation of the STM32 Clock control
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-rcc"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
 "#cells":

--- a/dts/bindings/crypto/arm,cryptocell-310.yaml
+++ b/dts/bindings/crypto/arm,cryptocell-310.yaml
@@ -10,33 +10,18 @@ version: 0.1
 description: >
     This is a representation of the ARM TrustZone CryptoCell 310
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "arm,cryptocell-310"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
-
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: readable string describing the interrupts

--- a/dts/bindings/crypto/nordic,nrf-cc310.yaml
+++ b/dts/bindings/crypto/nordic,nrf-cc310.yaml
@@ -10,22 +10,15 @@ version: 0.1
 description: >
     This is a representation of the Nordic Control Interface for ARM TrustZone CryptoCell 310
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-cc310"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define

--- a/dts/bindings/display/fsl,imx6sx-lcdif.yaml
+++ b/dts/bindings/display/fsl,imx6sx-lcdif.yaml
@@ -10,28 +10,19 @@ version: 0.1
 description: >
     This binding gives a base representation of the NXP i.MX eLCDIF controller
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "fsl,imx6sx-lcdif"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
+++ b/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
@@ -11,10 +11,10 @@ description: >
     This binding gives a base representation of the Rocktech LCD module with
     LED backlight and capacitive touch panel.
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "rocktech,rk043fn02h-ct"
 ...

--- a/dts/bindings/ethernet/ethernet.yaml
+++ b/dts/bindings/ethernet/ethernet.yaml
@@ -9,6 +9,9 @@ version: 0.1
 
 description: >
     This binding gives a base structures for all Ethernet devices
+
+inherits:
+    !include base.yaml
 properties:
     local-mac-address:
       type: array
@@ -16,8 +19,5 @@ properties:
       description: mac address
       generation: define
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/ethernet/intel,e1000.yaml
+++ b/dts/bindings/ethernet/intel,e1000.yaml
@@ -9,22 +9,16 @@ version: 0.1
 description: >
      This is a representation of the Intel E1000 Ethernet controller
 
+inherits:
+     !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "intel,e1000"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/ethernet/microchip,enc28j60.yaml
+++ b/dts/bindings/ethernet/microchip,enc28j60.yaml
@@ -14,9 +14,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "microchip,enc28j60"
     int-gpios:
       type: compound

--- a/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
+++ b/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
@@ -14,18 +14,9 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-ethernet"
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/ethernet/nxp.kinetis-ptp.yaml
+++ b/dts/bindings/ethernet/nxp.kinetis-ptp.yaml
@@ -10,15 +10,12 @@ version: 0.1
 description: >
     This binding gives a base representation of the NXP Kinetis Ethernet PTP
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-ptp"
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/ethernet/smsc,lan9220.yaml
+++ b/dts/bindings/ethernet/smsc,lan9220.yaml
@@ -10,21 +10,15 @@ description: >
      This is a representation of the formerly SMSC, now Microchip, LAN9220
      Ethernet controller.
 
+inherits:
+     !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "smsc,lan9220"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define

--- a/dts/bindings/ethernet/ti,stellaris-ethernet.yaml
+++ b/dts/bindings/ethernet/ti,stellaris-ethernet.yaml
@@ -14,18 +14,9 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,stellaris-ethernet"
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/flash_controller/flash-controller.yaml
+++ b/dts/bindings/flash_controller/flash-controller.yaml
@@ -5,34 +5,13 @@ version: 0.1
 description: >
     This binding gives the base structures for all flash controller devices
 
-properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
+inherits:
+    !include base.yaml
 
+properties:
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
-
-    interrupts:
-      type: array
-      category: optional
-      description: required interrupts
-      generation: define
-
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: names of required interrupts
-
 ...

--- a/dts/bindings/flash_controller/zephyr,sim-flash.yaml
+++ b/dts/bindings/flash_controller/zephyr,sim-flash.yaml
@@ -6,17 +6,14 @@ version: 0.1
 description: >
     This binding gives a base representation of a simulated flash memory
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "zephyr,sim-flash"
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/gpio/arduino-header-r3.yaml
+++ b/dts/bindings/gpio/arduino-header-r3.yaml
@@ -10,13 +10,12 @@ version: 0.1
 description: >
     This is a representation of GPIO pin nodes exposed as headers on Arduino R3
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "arduino-header-r3"
-      generation: define
 
     gpio-map:
       type: compound

--- a/dts/bindings/gpio/arm,cmsdk-gpio.yaml
+++ b/dts/bindings/gpio/arm,cmsdk-gpio.yaml
@@ -5,23 +5,16 @@ version: 0.1
 description: >
     This binding gives a base representation of the ARM CMSDK GPIO
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "arm,cmsdk-gpio"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/gpio/atmel,sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam-gpio.yaml
@@ -5,31 +5,21 @@ version: 0.1
 description: >
     This is a representation of the SAM GPIO PORT nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     peripheral-id:
       type: int

--- a/dts/bindings/gpio/atmel,sam0-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam0-gpio.yaml
@@ -5,25 +5,18 @@ version: 0.1
 description: >
     This is a representation of the SAM0 GPIO PORT nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam0-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/gpio-keys.yaml
+++ b/dts/bindings/gpio/gpio-keys.yaml
@@ -10,13 +10,12 @@ version: 0.1
 description: >
     This is a representation of the GPIO KEYS nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "gpio-keys"
-      generation: define
 
     gpios:
       type: compound
@@ -24,9 +23,6 @@ properties:
       generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/gpio/gpio-leds.yaml
+++ b/dts/bindings/gpio/gpio-leds.yaml
@@ -10,13 +10,12 @@ version: 0.1
 description: >
     This is a representation of the LED GPIO nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "gpio-leds"
-      generation: define
 
     gpios:
       type: compound
@@ -24,9 +23,6 @@ properties:
       generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
+++ b/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
@@ -4,26 +4,19 @@ version: 0.1
 
 description: Holtek HT16K33 Keyscan binding
 
+inherits:
+    !include base.yaml
+
 parent:
     bus: ht16k33
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "holtek,ht16k33-keyscan"
-      generation: define
     reg:
-      type: array
-      description: Keyscan row on the HT16K33 (KSx)
-      generation: define
       category: required
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 cell_string: GPIO
 

--- a/dts/bindings/gpio/intel,apl-gpio.yaml
+++ b/dts/bindings/gpio/intel,apl-gpio.yaml
@@ -10,29 +10,20 @@ version: 0.1
 description: >
     This is a representation of the Intel Apollo Lake GPIO node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "intel,apl-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     interrupts:
-      type: int
-      generation: define
       category: required
 
 cell_string: GPIO

--- a/dts/bindings/gpio/intel,qmsi-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-gpio.yaml
@@ -10,31 +10,21 @@ version: 0.1
 description: >
     This is a representation of the Intel QMSI GPIO nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "intel,qmsi-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 cell_string: GPIO
 

--- a/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
@@ -10,31 +10,21 @@ version: 0.1
 description: >
     This is a representation of the Intel QMSI SS GPIO nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "intel,qmsi-ss-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 cell_string: GPIO
 

--- a/dts/bindings/gpio/microchip,xec-gpio.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio.yaml
@@ -11,31 +11,21 @@ version: 0.1
 description: >
     This is a representation of the CEC/MEC GPIO nodes for Microchip
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "microchip,xec-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: optional
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -10,25 +10,18 @@ version: 0.1
 description: >
     This is a representation of the NRF GPIO nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 cell_string: GPIO
 

--- a/dts/bindings/gpio/nordic,nrf-gpiote.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpiote.yaml
@@ -10,30 +10,20 @@ version: 0.1
 description: >
     This is a representation of the NRF GPIOTE node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-gpiote"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -10,31 +10,21 @@ version: 0.1
 description: >
     This is a representation of the i.MX GPIO nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,imx-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     rdc:
      type: int

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -5,31 +5,21 @@ version: 0.1
 description: >
     This is a representation of the Kinetis GPIO nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
+++ b/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
@@ -5,31 +5,21 @@ version: 0.1
 description: >
     This is a representation of the OpenISA GPIO nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "openisa,rv32m1-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     clocks:
       type: array

--- a/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
@@ -18,10 +18,7 @@ properties:
       constraint: "semtech,sx1509b"
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 cell_string: GPIO
 

--- a/dts/bindings/gpio/sifive,gpio0.yaml
+++ b/dts/bindings/gpio/sifive,gpio0.yaml
@@ -10,29 +10,20 @@ version: 0.1
 description: >
     This is a representation of the SiFive GPIO nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "sifive,gpio0"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     interrupts:
-      type: int
-      generation: define
       category: required
 
 cell_string: GPIO

--- a/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
@@ -5,25 +5,18 @@ version: 0.1
 description: >
     This is a representation of the EFM32 GPIO Port nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "silabs,efm32-gpio-port"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/silabs,efm32-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio.yaml
@@ -5,31 +5,21 @@ version: 0.1
 description: >
     This is a representation of the EFM32 GPIO nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "silabs,efm32-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     location-swo:
       type: int

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
@@ -5,25 +5,18 @@ version: 0.1
 description: >
     This is a representation of the EFR32MG GPIO Port nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "silabs,efr32mg-gpio-port"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
@@ -5,31 +5,21 @@ version: 0.1
 description: >
     This is a representation of the EFR32MG GPIO nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "silabs,efr32mg-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     location-swo:
       type: int

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
@@ -5,25 +5,18 @@ version: 0.1
 description: >
     This is a representation of the EFR32XG1 GPIO Port nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "silabs,efr32xg1-gpio-port"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
@@ -5,31 +5,21 @@ version: 0.1
 description: >
     This is a representation of the EFR32XG1 GPIO nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "silabs,efr32xg1-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     location-swo:
       type: int

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -10,18 +10,14 @@ version: 0.1
 description: >
     This is a representation of the Synopsys DesignWare gpio node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "snps,designware-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     bits:
@@ -31,16 +27,10 @@ properties:
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 cell_string: GPIO
 

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -10,31 +10,21 @@ version: 0.1
 description: >
     This is a representation of the STM32 GPIO nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     clocks:
       type: array

--- a/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
@@ -10,31 +10,21 @@ version: 0.1
 description: >
     This is a representation of the TI SimpleLink CC13xx / CC26xx GPIO node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,cc13xx-cc26xx-gpio"
-      generation: define
 
     reg:
-      type: int
       category: required
-      description: mmio register space
-      generation: define
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 cell_string: GPIO
 

--- a/dts/bindings/gpio/ti,cc2650-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc2650-gpio.yaml
@@ -6,23 +6,16 @@ version: 0.1
 description: >
     This is a representation of the TI CC2650 GPIO node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,cc2650-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/gpio/ti,cc32xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc32xx-gpio.yaml
@@ -6,31 +6,21 @@ version: 0.1
 description: >
     This is a representation of the TI CC32XX GPIO node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,cc32xx-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 cell_string: GPIO
 

--- a/dts/bindings/gpio/ti,stellaris-gpio.yaml
+++ b/dts/bindings/gpio/ti,stellaris-gpio.yaml
@@ -6,31 +6,21 @@ version: 0.1
 description: >
     This is a representation of the TI Stellaris GPIO node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,stellaris-gpio"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
 "#cells":
   - pin

--- a/dts/bindings/i2c/arm,versatile-i2c.yaml
+++ b/dts/bindings/i2c/arm,versatile-i2c.yaml
@@ -18,9 +18,6 @@ properties:
       constraint: "arm,versatile-i2c"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
 ...

--- a/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "atmel,sam-i2c-twi"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     peripheral-id:
       type: int

--- a/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "atmel,sam-i2c-twihs"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     peripheral-id:
       type: int

--- a/dts/bindings/i2c/atmel,sam0-i2c.yaml
+++ b/dts/bindings/i2c/atmel,sam0-i2c.yaml
@@ -15,22 +15,13 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam0-i2c"
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     dma:
       type: int

--- a/dts/bindings/i2c/fsl,imx7d-i2c.yaml
+++ b/dts/bindings/i2c/fsl,imx7d-i2c.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "fsl,imx7d-i2c"
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     rdc:
      type: int

--- a/dts/bindings/i2c/i2c-device.yaml
+++ b/dts/bindings/i2c/i2c-device.yaml
@@ -10,23 +10,15 @@ version: 0.1
 description: >
     This binding gives the base structures for all i2c devices
 
+inherits:
+    !include base.yaml
+
 parent:
     bus: i2c
 
 properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
     reg:
-      type: array
-      description: address on i2c bus
-      generation: define
       category: required
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/i2c/i2c.yaml
+++ b/dts/bindings/i2c/i2c.yaml
@@ -10,15 +10,13 @@ version: 0.1
 description: >
     This binding gives the base structures for all I2C devices
 
+inherits:
+    !include base.yaml
+
 child:
     bus: i2c
 
 properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
     "#address-cells":
       type: int
       category: required
@@ -38,8 +36,5 @@ properties:
       description: Clock gate information
       generation: define
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/i2c/intel,qmsi-i2c.yaml
+++ b/dts/bindings/i2c/intel,qmsi-i2c.yaml
@@ -18,15 +18,9 @@ properties:
       constraint: "intel,qmsi-i2c"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
 ...

--- a/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
+++ b/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
@@ -18,20 +18,9 @@ properties:
       constraint: "intel,qmsi-ss-i2c"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
-
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: readable string describing the interrupts
 
 ...

--- a/dts/bindings/i2c/microchip,xec-i2c.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
@@ -15,16 +15,9 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "microchip,xec-i2c"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     port_sel:

--- a/dts/bindings/i2c/nios2,i2c.yaml
+++ b/dts/bindings/i2c/nios2,i2c.yaml
@@ -18,15 +18,9 @@ properties:
       constraint: "nios2,i2c"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
 ...

--- a/dts/bindings/i2c/nordic,nrf-i2c.yaml
+++ b/dts/bindings/i2c/nordic,nrf-i2c.yaml
@@ -16,22 +16,13 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-i2c"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     sda-pin:
       type: int

--- a/dts/bindings/i2c/nxp,imx-lpi2c.yaml
+++ b/dts/bindings/i2c/nxp,imx-lpi2c.yaml
@@ -18,13 +18,7 @@ properties:
       constraint: "nxp,imx-lpi2c"
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define

--- a/dts/bindings/i2c/nxp,kinetis-i2c.yaml
+++ b/dts/bindings/i2c/nxp,kinetis-i2c.yaml
@@ -18,13 +18,7 @@ properties:
       constraint: "nxp,kinetis-i2c"
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define

--- a/dts/bindings/i2c/openisa,rv32m1-lpi2c.yaml
+++ b/dts/bindings/i2c/openisa,rv32m1-lpi2c.yaml
@@ -18,13 +18,7 @@ properties:
       constraint: "openisa,rv32m1-lpi2c"
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define

--- a/dts/bindings/i2c/sifive,i2c0.yaml
+++ b/dts/bindings/i2c/sifive,i2c0.yaml
@@ -15,11 +15,7 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "sifive,i2c0"
-      generation: define
 
     input-frequency:
       type: int
@@ -28,9 +24,6 @@ properties:
       generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
 ...

--- a/dts/bindings/i2c/silabs,gecko-i2c.yaml
+++ b/dts/bindings/i2c/silabs,gecko-i2c.yaml
@@ -15,22 +15,13 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "silabs,gecko-i2c"
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     # Note: Not all SoC series support setting individual pin location. If this
     # is a case all location-* properties need to have identical value.

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "snps,designware-i2c"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     pcie:
       type: boolean

--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -18,19 +18,9 @@ properties:
       constraint: "st,stm32-i2c-v1"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: readable string describing the interrupts
 ...

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -18,19 +18,8 @@ properties:
       constraint: "st,stm32-i2c-v2"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
-
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: readable string describing the interrupts
 ...

--- a/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
@@ -15,22 +15,13 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,cc13xx-cc26xx-i2c"
 
     reg:
-      type: array
       category: required
-      description: mmio register space
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     sda-pin:
       type: int

--- a/dts/bindings/i2c/ti,cc32xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc32xx-i2c.yaml
@@ -13,15 +13,9 @@ properties:
       constraint: "ti,cc32xx-i2c"
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
 ...

--- a/dts/bindings/i2s/i2s-device.yaml
+++ b/dts/bindings/i2s/i2s-device.yaml
@@ -10,24 +10,16 @@ version: 0.1
 description: >
     This binding gives the base structures for all i2s devices
 
+inherits:
+    !include base.yaml
+
 parent:
     bus: i2s
 
 properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
     reg:
-      type: array
-      description: Logic number of device
-      generation: define
       category: required
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/i2s/i2s.yaml
+++ b/dts/bindings/i2s/i2s.yaml
@@ -10,15 +10,13 @@ version: 0.1
 description: >
     This binding gives the base structures for all I2S devices
 
+inherits:
+    !include base.yaml
+
 child:
     bus: i2s
 
 properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
     "#address-cells":
       type: int
       category: required
@@ -28,15 +26,11 @@ properties:
       category: required
       description: should be 0.
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
     clocks:
       type: array
       category: optional
       description: Clock gate information
       generation: define
-
 
 ...

--- a/dts/bindings/i2s/st,stm32-i2s.yaml
+++ b/dts/bindings/i2s/st,stm32-i2s.yaml
@@ -18,20 +18,9 @@ properties:
       constraint: "st,stm32-i2s"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
-
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: readable string describing the interrupts
 
 ...

--- a/dts/bindings/ieee802154/ti,cc1200.yaml
+++ b/dts/bindings/ieee802154/ti,cc1200.yaml
@@ -15,9 +15,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,cc1200"
 
 ...

--- a/dts/bindings/ieee802154/ti,cc2520.yaml
+++ b/dts/bindings/ieee802154/ti,cc2520.yaml
@@ -15,9 +15,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,cc2520"
 
     vreg-en-gpios:

--- a/dts/bindings/iio/adc/adc.yaml
+++ b/dts/bindings/iio/adc/adc.yaml
@@ -10,13 +10,10 @@ version: 0.1
 description: >
     This binding gives the base structures for all ADC devices
 
-properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
+inherits:
+    !include base.yaml
 
+properties:
     clocks:
       type: array
       category: required
@@ -24,8 +21,5 @@ properties:
       generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/iio/adc/atmel,sam-afec.yaml
+++ b/dts/bindings/iio/adc/atmel,sam-afec.yaml
@@ -10,22 +10,13 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam-afec"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     peripheral-id:
       type: int

--- a/dts/bindings/iio/adc/atmel,sam0-adc.yaml
+++ b/dts/bindings/iio/adc/atmel,sam0-adc.yaml
@@ -15,22 +15,13 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam0-adc"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     gclk:
       type: int

--- a/dts/bindings/iio/adc/intel,quark-d2000-adc.yaml
+++ b/dts/bindings/iio/adc/intel,quark-d2000-adc.yaml
@@ -15,20 +15,11 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "intel,quark-d2000-adc"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/iio/adc/nordic,nrf-adc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-adc.yaml
@@ -15,20 +15,11 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-adc"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
@@ -15,20 +15,11 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-saadc"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
@@ -18,14 +18,8 @@ properties:
       constraint: "nxp,kinetis-adc16"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/iio/adc/snps,dw-adc.yaml
+++ b/dts/bindings/iio/adc/snps,dw-adc.yaml
@@ -15,20 +15,11 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "snps,dw-adc"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/iio/adc/st,stm32-adc.yaml
+++ b/dts/bindings/iio/adc/st,stm32-adc.yaml
@@ -16,15 +16,9 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-adc"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     clocks:
@@ -34,8 +28,5 @@ properties:
       generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
@@ -5,19 +5,15 @@ version: 0.1
 description: >
     This binding describes the ARMv6-M Nested Vectored Interrupt Controller.
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "arm,v6m-nvic"
-      generation: define
 
     reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
     arm,num-irq-priority-bits:
       category: required

--- a/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
@@ -5,19 +5,15 @@ version: 0.1
 description: >
     This binding describes the ARMv7-M Nested Vectored Interrupt Controller.
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "arm,v7m-nvic"
-      generation: define
 
     reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
     arm,num-irq-priority-bits:
       category: required

--- a/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
@@ -5,19 +5,15 @@ version: 0.1
 description: >
     This binding describes the ARMv8-M Nested Vectored Interrupt Controller.
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "arm,v8m-nvic"
-      generation: define
 
     reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
     arm,num-irq-priority-bits:
       category: required

--- a/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
+++ b/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
@@ -5,29 +5,19 @@ version: 0.1
 description: >
     This binding describes the Atmel SAM0 series External Interrupt Controller
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "atmel,sam0-eic"
-      generation: define
 
   reg:
-    type: array
-    description: mmio register space
-    generation: define
     category: required
 
   interrupts:
-    type: array
     category: required
-    description: required interrupts
-    generation: define
 
   label:
-    type: string
     category: required
-    description: Human readable string describing the device (used by Zephyr for API name)
-    generation: define
 ...

--- a/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
@@ -5,19 +5,15 @@ version: 0.1
 description: >
     This binding describes CAVS Interrupt controller
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "intel,cavs-intc"
-      generation: define
 
   reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
   intel,num-irq-priority-bits:
       category: required
@@ -26,10 +22,7 @@ properties:
       generation: define
 
   interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
 cell_string: IRQ
 

--- a/dts/bindings/interrupt-controller/intel,ioapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,ioapic.yaml
@@ -6,19 +6,15 @@ description: >
     This binding describes the Intel I/O Advanced Programmable Interrupt
     controller
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "intel,ioapic"
-      generation: define
 
   reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
   intel,num-irq-priority-bits:
       category: required

--- a/dts/bindings/interrupt-controller/intel,mvic.yaml
+++ b/dts/bindings/interrupt-controller/intel,mvic.yaml
@@ -6,19 +6,15 @@ description: >
     This binding describes the Intel Quark D2000 Interrupt
     Controller
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "intel,mvic"
-      generation: define
 
   reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
   intel,num-irq-priority-bits:
       category: required

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
@@ -11,19 +11,15 @@ version: 0.1
 description: >
     This binding describes the RV32M1 Event Unit
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "openisa,rv32m1-event-unit"
-      generation: define
 
   reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
 "#cells":
   - irq

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
@@ -10,19 +10,15 @@ version: 0.1
 description: >
     This binding describes the RV32M1 INTMUX IP
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "openisa,rv32m1-intmux"
-      generation: define
 
   reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
   clocks:
       type: array
@@ -31,16 +27,10 @@ properties:
       generation: define
 
   label:
-      type: string
       category: required
-      description: Human readable string naming the device (used by Zephyr for API name)
-      generation: define
 
   interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
 "#cells":
   - irq

--- a/dts/bindings/interrupt-controller/riscv,plic0.yaml
+++ b/dts/bindings/interrupt-controller/riscv,plic0.yaml
@@ -10,19 +10,15 @@ version: 0.1
 description: >
     This binding describes the RISC-V Platform-Local Interrupt Controller
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "riscv,plic0"
-      generation: define
 
   reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
   riscv,max-priority:
       type: int

--- a/dts/bindings/interrupt-controller/shared-irq.yaml
+++ b/dts/bindings/interrupt-controller/shared-irq.yaml
@@ -5,24 +5,17 @@ version: 0.1
 description: >
     This binding describes Shared IRQ interrupt dispatcher
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "shared-irq"
-      generation: define
 
   interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
   label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -10,19 +10,15 @@ version: 0.1
 description: >
     This binding describes the ARCV2 IRQ controller
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "snps,arcv2-intc"
-      generation: define
 
     reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
     arc,num-irq-priority-bits:
       category: required

--- a/dts/bindings/interrupt-controller/snps,designware-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,designware-intc.yaml
@@ -5,19 +5,15 @@ version: 0.1
 description: >
     This binding describes DesignWare Programmable Interrupt controller
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "snps,designware-intc"
-      generation: define
 
   reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
   snps,num-irq-priority-bits:
       category: required
@@ -26,10 +22,7 @@ properties:
       generation: define
 
   interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
 cell_string: IRQ
 

--- a/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
+++ b/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
@@ -10,19 +10,15 @@ version: 0.1
 description: >
     This binding describes LiteX VexRiscV Interrupt Controller
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "vexriscv,intc0"
-      generation: define
 
   reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
   riscv,max-priority:
       type: int

--- a/dts/bindings/interrupt-controller/xtensa,intc.yaml
+++ b/dts/bindings/interrupt-controller/xtensa,intc.yaml
@@ -5,19 +5,15 @@ version: 0.1
 description: >
     This binding describes Xtensa Core Interrupt controller
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "xtensa,core-intc"
-      generation: define
 
   reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
   snps,num-irq-priority-bits:
       category: required

--- a/dts/bindings/led/holtek,ht16k33.yaml
+++ b/dts/bindings/led/holtek,ht16k33.yaml
@@ -12,11 +12,7 @@ child:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "holtek,ht16k33"
-      generation: define
     "#address-cells":
       type: int
       category: required
@@ -26,10 +22,7 @@ properties:
       category: required
       description: should be 0.
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
     irq-gpios:
       type: compound
       category: optional

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -10,13 +10,12 @@ version: 0.1
 description: >
     This is a representation of the PWM GPIO nodes
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "pwm-leds"
-      generation: define
 
     pwms:
       type: compound
@@ -24,9 +23,6 @@ properties:
       generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/led/ti,lp5562.yaml
+++ b/dts/bindings/led/ti,lp5562.yaml
@@ -9,8 +9,5 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,lp5562"
 ...

--- a/dts/bindings/memory-controllers/nxp,imx-semc.yaml
+++ b/dts/bindings/memory-controllers/nxp,imx-semc.yaml
@@ -11,29 +11,19 @@ description: >
     This binding gives a base representation of the NXP smart external memory
     controller (SEMC)
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,imx-semc"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/mhu/arm,mhu.yaml
+++ b/dts/bindings/mhu/arm,mhu.yaml
@@ -10,29 +10,19 @@ version: 0.1
 description: >
     This binding gives a base representation of the ARM MHU
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "arm,mhu"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/misc/skyworks,sky13351.yaml
+++ b/dts/bindings/misc/skyworks,sky13351.yaml
@@ -11,6 +11,9 @@ description: >
     This binding allows control of the output selectors of the SKY13351
     SPDT switch.
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
         constraint: "skyworks,sky13351"

--- a/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
@@ -5,19 +5,15 @@ version: 0.1
 description: >
     This binding describes the ARMv7-M Memory Protection Unit (MPU).
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "arm,armv7m-mpu"
-      generation: define
 
     reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
     arm,num-mpu-regions:
       category: required

--- a/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
@@ -5,19 +5,15 @@ version: 0.1
 description: >
     This binding describes the ARMv8-M Memory Protection Unit (MPU).
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      category: required
-      type: string
-      description: compatible strings
       constraint: "arm,armv8m-mpu"
-      generation: define
 
     reg:
       category: required
-      type: int
-      description: mmio register space
-      generation: define
 
     arm,num-mpu-regions:
       category: required

--- a/dts/bindings/modem/ublox,sara-r4.yaml
+++ b/dts/bindings/modem/ublox,sara-r4.yaml
@@ -15,15 +15,10 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
       constraint: "ublox,sara-r4"
-      generation: define
 
     label:
-      type: string
       category: required
-      generation: define
 
     mdm-power-gpios:
       type: compound

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -15,15 +15,10 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
       constraint: "wnc,m14a2a"
-      generation: define
 
     label:
-      type: string
       category: required
-      generation: define
 
     mdm-boot-mode-sel-gpios:
       type: compound

--- a/dts/bindings/mtd/partition.yaml
+++ b/dts/bindings/mtd/partition.yaml
@@ -5,12 +5,11 @@ version: 0.1
 description: >
     This binding gives a base FLASH partition description
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "fixed-partitions"
-      generation: define
 
 ...

--- a/dts/bindings/phy/phy.yaml
+++ b/dts/bindings/phy/phy.yaml
@@ -10,20 +10,15 @@ version: 0.1
 description: >
     This binding gives the base structures for all PHY providers
 
+inherits:
+    !include base.yaml
+
 properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
     "#phy-cells":
       type: int
       category: required
       description: Number of cells in a PHY provider. The meaning those
                    cells is defined by the binding for the phy node.
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/phy/st,stm32-usbphyc.yaml
+++ b/dts/bindings/phy/st,stm32-usbphyc.yaml
@@ -18,9 +18,6 @@ properties:
       constraint: "st,stm32-usbphyc"
 
     reg:
-      type: array
-      description: address and length of the usb phy control register set
-      generation: define
       category: required
 
     "phy-cells":

--- a/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
+++ b/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
@@ -5,25 +5,18 @@ version: 0.1
 description: >
     This binding gives a base representation of the Atmel SAM0 PINMUX
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam0-pinmux"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 "#cells":
   - pin

--- a/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
+++ b/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
@@ -6,18 +6,14 @@ version: 0.1
 description: >
     This is a representation of the Intel S1000 SoC's pinmux node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "intel,s1000-pinmux"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
 "#cells":

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -5,18 +5,14 @@ version: 0.1
 description: >
     This is a representation of the Kinetis Pinmux node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-pinmux"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     clocks:

--- a/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
+++ b/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
@@ -5,18 +5,14 @@ version: 0.1
 description: >
     This is a representation of the RV32M1 Pinmux node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "openisa,rv32m1-pinmux"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     clocks:

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -5,18 +5,14 @@ version: 0.1
 description: >
     This binding gives a base representation of the STM32 PINMUX
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-pinmux"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
 "#cells":

--- a/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
@@ -10,23 +10,16 @@ version: 0.1
 description: >
     This is a representation of the TI SimpleLink CC13xx / CC26xx pinmux node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,cc13xx-cc26xx-pinmux"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
@@ -6,18 +6,14 @@ version: 0.1
 description: >
     This is a representation of the TI CC2650 pinmux node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,cc2650-pinmux"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
 "#cells":

--- a/dts/bindings/power/nordic,nrf-power.yaml
+++ b/dts/bindings/power/nordic,nrf-power.yaml
@@ -10,22 +10,16 @@ version: 0.1
 description: >
     This is a representation of the Nordic nRF power control node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-power"
 
     reg:
-      type: array
       category: required
-      description: mmio register space
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/pwm/atmel,sam-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam-pwm.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "atmel,sam-pwm"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     peripheral-id:
       type: int

--- a/dts/bindings/pwm/fsl,imx7d-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx7d-pwm.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "fsl,imx7d-pwm"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     prescaler:
      type: int

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -5,21 +5,18 @@ version: 0.1
 description: >
     This binding gives a base representation of the nRF PWM
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
       constraint: "nordic,nrf-pwm"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     ch0-pin:
       type: int

--- a/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
@@ -5,15 +5,15 @@ version: 0.1
 description: >
     This binding gives a base representation of the nRFx S/W PWM
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
       constraint: "nordic,nrf-sw-pwm"
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     timer-instance:
       type: int

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "nxp,kinetis-ftm"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
 "#cells":
   - channel

--- a/dts/bindings/pwm/pwm.yaml
+++ b/dts/bindings/pwm/pwm.yaml
@@ -10,13 +10,10 @@ version: 0.1
 description: >
     This binding gives the base structures for all PWM devices
 
-properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
+inherits:
+    !include base.yaml
 
+properties:
     clocks:
       type: array
       category: required
@@ -24,8 +21,5 @@ properties:
       generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/pwm/sifive,pwm0.yaml
+++ b/dts/bindings/pwm/sifive,pwm0.yaml
@@ -15,11 +15,7 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "sifive,pwm0"
-      generation: define
 
     clock-frequency:
       type: int
@@ -28,16 +24,10 @@ properties:
       generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     sifive,compare-width:
       type: int

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -5,15 +5,15 @@ version: 0.1
 description: >
     This binding gives a base representation of the STM32 PWM
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
       constraint: "st,stm32-pwm"
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     st,prescaler:
       type: int

--- a/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
+++ b/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
@@ -10,25 +10,18 @@ version: 0.1
 description: >
     This is a representation of the RV32M1 PCC IP node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "openisa,rv32m1-pcc"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 "#cells":
   - name

--- a/dts/bindings/rng/atmel,sam-trng.yaml
+++ b/dts/bindings/rng/atmel,sam-trng.yaml
@@ -10,25 +10,18 @@ version: 0.1
 description: >
     This binding gives a base representation of the Atmel SAM RNG
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam-trng"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     peripheral-id:
       type: int
@@ -37,9 +30,6 @@ properties:
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/rng/nxp,kinetis-rnga.yaml
+++ b/dts/bindings/rng/nxp,kinetis-rnga.yaml
@@ -10,30 +10,20 @@ version: 0.1
 description: >
     This binding gives a base representation of the Kinetis RNGA
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-rnga"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/rng/nxp,kinetis-trng.yaml
+++ b/dts/bindings/rng/nxp,kinetis-trng.yaml
@@ -10,30 +10,20 @@ version: 0.1
 description: >
     This binding gives a base representation of the Kinetis RNGA
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-trng"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
+++ b/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
@@ -10,30 +10,20 @@ version: 0.1
 description: >
     This is a representation of the TI SimpleLink CC13xx / CC26xx TRNG node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,cc13xx-cc26xx-trng"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/rtc/atmel,sam0-rtc.yaml
+++ b/dts/bindings/rtc/atmel,sam0-rtc.yaml
@@ -18,9 +18,6 @@ properties:
       constraint: "atmel,sam0-rtc"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     clock-generator:

--- a/dts/bindings/rtc/intel,qmsi-rtc.yaml
+++ b/dts/bindings/rtc/intel,qmsi-rtc.yaml
@@ -18,9 +18,6 @@ properties:
       constraint: "intel,qmsi-rtc"
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
 ...

--- a/dts/bindings/rtc/nordic,nrf-rtc.yaml
+++ b/dts/bindings/rtc/nordic,nrf-rtc.yaml
@@ -18,9 +18,6 @@ properties:
       constraint: "nordic,nrf-rtc"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     #If enabled, overflow different than full range (24 bits) is handled

--- a/dts/bindings/rtc/nxp,kinetis-rtc.yaml
+++ b/dts/bindings/rtc/nxp,kinetis-rtc.yaml
@@ -18,8 +18,5 @@ properties:
       constraint: "nxp,kinetis-rtc"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 ...

--- a/dts/bindings/rtc/rtc.yaml
+++ b/dts/bindings/rtc/rtc.yaml
@@ -10,32 +10,19 @@ version: 0.1
 description: >
     This binding gives the base structures for all RTC devices
 
+inherits:
+    !include base.yaml
 
 properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
     clock-frequency:
       type: int
       category: optional
       description: Clock frequency information for RTC operation
       generation: define
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: names of required interrupts
 
     prescaler:
       type: int

--- a/dts/bindings/rtc/st,stm32-rtc.yaml
+++ b/dts/bindings/rtc/st,stm32-rtc.yaml
@@ -15,15 +15,9 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-rtc"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     clocks:

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -10,24 +10,18 @@ version: 0.1
 description: >
     This is a representation of the Nordic nRF QDEC node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-qdec"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     a-pin:
       type: int
@@ -66,8 +60,5 @@ properties:
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/sensor/nordic,nrf-temp.yaml
+++ b/dts/bindings/sensor/nordic,nrf-temp.yaml
@@ -10,22 +10,16 @@ version: 0.1
 description: >
     This is a representation of the Nordic nRF TEMP node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-temp"
 
     reg:
-      type: array
       category: required
-      description: mmio register space
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/serial/altera,jtag-uart.yaml
+++ b/dts/bindings/serial/altera,jtag-uart.yaml
@@ -13,14 +13,8 @@ properties:
       constraint: "altera,jtag-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/serial/arm,cmsdk-uart.yaml
+++ b/dts/bindings/serial/arm,cmsdk-uart.yaml
@@ -13,14 +13,8 @@ properties:
       constraint: "arm,cmsdk-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/serial/arm,pl011.yaml
+++ b/dts/bindings/serial/arm,pl011.yaml
@@ -10,20 +10,11 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "arm,pl011"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/serial/atmel,sam-uart.yaml
+++ b/dts/bindings/serial/atmel,sam-uart.yaml
@@ -13,16 +13,10 @@ properties:
       constraint: "atmel,sam-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     peripheral-id:
       type: int

--- a/dts/bindings/serial/atmel,sam-usart.yaml
+++ b/dts/bindings/serial/atmel,sam-usart.yaml
@@ -13,16 +13,10 @@ properties:
       constraint: "atmel,sam-usart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     peripheral-id:
       type: int

--- a/dts/bindings/serial/atmel,sam0-uart.yaml
+++ b/dts/bindings/serial/atmel,sam0-uart.yaml
@@ -13,16 +13,10 @@ properties:
       constraint: "atmel,sam0-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     rxpo:
       type: int

--- a/dts/bindings/serial/cypress,psoc6-uart.yaml
+++ b/dts/bindings/serial/cypress,psoc6-uart.yaml
@@ -18,14 +18,8 @@ properties:
       constraint: "cypress,psoc6-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/serial/intel,qmsi-uart.yaml
+++ b/dts/bindings/serial/intel,qmsi-uart.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "intel,qmsi-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     pinctrl-\d+:
       type: array

--- a/dts/bindings/serial/litex,uart0.yaml
+++ b/dts/bindings/serial/litex,uart0.yaml
@@ -15,22 +15,12 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "litex,uart0"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
 ...

--- a/dts/bindings/serial/microsemi,coreuart.yaml
+++ b/dts/bindings/serial/microsemi,coreuart.yaml
@@ -15,22 +15,12 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "microsemi,coreuart"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
 ...

--- a/dts/bindings/serial/nordic,nrf-uart.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart.yaml
@@ -13,16 +13,10 @@ properties:
       constraint: "nordic,nrf-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     tx-pin:
       type: int

--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -13,16 +13,10 @@ properties:
       constraint: "nordic,nrf-uarte"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     tx-pin:
       type: int

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -13,9 +13,6 @@ properties:
       constraint: "ns16550"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     reg-shift:
@@ -25,10 +22,7 @@ properties:
       generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     pcp:
       type: int

--- a/dts/bindings/serial/nxp,imx-uart.yaml
+++ b/dts/bindings/serial/nxp,imx-uart.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "nxp,imx-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     pinctrl-\d+:
       type: array

--- a/dts/bindings/serial/nxp,kinetis-lpsci.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpsci.yaml
@@ -13,15 +13,9 @@ properties:
       constraint: "nxp,kinetis-lpsci"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
 ...

--- a/dts/bindings/serial/nxp,kinetis-lpuart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpuart.yaml
@@ -13,16 +13,10 @@ properties:
       constraint: "nxp,kinetis-lpuart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     pinctrl-*:
       type: array

--- a/dts/bindings/serial/nxp,kinetis-uart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-uart.yaml
@@ -13,16 +13,10 @@ properties:
       constraint: "nxp,kinetis-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     pinctrl-\d+:
       type: array

--- a/dts/bindings/serial/nxp,lpc-usart.yaml
+++ b/dts/bindings/serial/nxp,lpc-usart.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "nxp,lpc-usart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     pinctrl-\d+:
       type: array

--- a/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
+++ b/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
@@ -13,16 +13,10 @@ properties:
       constraint: "openisa,rv32m1-lpuart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     pinctrl-*:
       type: array

--- a/dts/bindings/serial/sifive,uart0.yaml
+++ b/dts/bindings/serial/sifive,uart0.yaml
@@ -15,22 +15,12 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "sifive,uart0"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
 ...

--- a/dts/bindings/serial/silabs,gecko-leuart.yaml
+++ b/dts/bindings/serial/silabs,gecko-leuart.yaml
@@ -10,22 +10,13 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "silabs,gecko-leuart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     # Note: Not all SoC series support setting individual pin location. If this
     # is a case all location-* properties need to have identical value.

--- a/dts/bindings/serial/silabs,gecko-uart.yaml
+++ b/dts/bindings/serial/silabs,gecko-uart.yaml
@@ -13,16 +13,10 @@ properties:
       constraint: "silabs,gecko-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     # Note: Not all SoC series support setting individual pin location. If this
     # is a case all location-* properties need to have identical value.

--- a/dts/bindings/serial/silabs,gecko-usart.yaml
+++ b/dts/bindings/serial/silabs,gecko-usart.yaml
@@ -13,16 +13,10 @@ properties:
       constraint: "silabs,gecko-usart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: compound
       category: required
-      description: required interrupts
-      generation: define
 
     # Note: Not all SoC series support setting individual pin location. If this
     # is a case all location-* properties need to have identical value.

--- a/dts/bindings/serial/snps,nsim-uart.yaml
+++ b/dts/bindings/serial/snps,nsim-uart.yaml
@@ -18,14 +18,8 @@ properties:
       constraint: "snps,nsim-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/serial/st,stm32-lpuart.yaml
+++ b/dts/bindings/serial/st,stm32-lpuart.yaml
@@ -13,16 +13,10 @@ properties:
       constraint: "st,stm32-lpuart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     clocks:
       type: array

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -13,16 +13,10 @@ properties:
       constraint: "st,stm32-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     hw-flow-control:
       type: boolean

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -13,16 +13,10 @@ properties:
       constraint: "st,stm32-usart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     hw-flow-control:
       type: boolean

--- a/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "ti,cc13xx-cc26xx-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     tx-pin:
       type: int

--- a/dts/bindings/serial/ti,cc32xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc32xx-uart.yaml
@@ -13,14 +13,8 @@ properties:
       constraint: "ti,cc32xx-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/serial/ti,msp432p4xx-uart.yaml
+++ b/dts/bindings/serial/ti,msp432p4xx-uart.yaml
@@ -13,14 +13,8 @@ properties:
       constraint: "ti,msp432p4xx-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/serial/ti,stellaris-uart.yaml
+++ b/dts/bindings/serial/ti,stellaris-uart.yaml
@@ -13,14 +13,8 @@ properties:
       constraint: "ti,stellaris-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/serial/uart-device.yaml
+++ b/dts/bindings/serial/uart-device.yaml
@@ -10,18 +10,13 @@ version: 0.1
 description: >
     This binding gives the base structures for all uart devices
 
+inherits:
+    !include base.yaml
+
 parent:
     bus: uart
 
 properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/serial/uart.yaml
+++ b/dts/bindings/serial/uart.yaml
@@ -5,15 +5,13 @@ version: 0.1
 description: >
     This binding gives the base structures for all UART devices
 
+inherits:
+    !include base.yaml
+
 child:
     bus: uart
 
 properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
     clock-frequency:
       type: int
       category: optional
@@ -30,14 +28,7 @@ properties:
       description: Clock gate information
       generation: define
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: names of required interrupts
     pinctrl-\d+:
       type: array
       category: optional

--- a/dts/bindings/serial/xtensa,esp32-uart.yaml
+++ b/dts/bindings/serial/xtensa,esp32-uart.yaml
@@ -10,22 +10,13 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "xtensa,esp32-uart"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     clocks:
       type: array

--- a/dts/bindings/spi/atmel,sam-spi.yaml
+++ b/dts/bindings/spi/atmel,sam-spi.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "atmel,sam-spi"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     peripheral-id:
       type: int

--- a/dts/bindings/spi/atmel,sam0-spi.yaml
+++ b/dts/bindings/spi/atmel,sam0-spi.yaml
@@ -18,9 +18,6 @@ properties:
       constraint: "atmel,sam0-spi"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     dipo:

--- a/dts/bindings/spi/intel,intel-spi.yaml
+++ b/dts/bindings/spi/intel,intel-spi.yaml
@@ -18,15 +18,9 @@ properties:
       constraint: "intel,intel-spi"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
 ...

--- a/dts/bindings/spi/nordic,nrf-spi.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "nordic,nrf-spi"
 
     reg:
-      type: array
       category: required
-      description: mmio register space
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     sck-pin:
       type: int

--- a/dts/bindings/spi/nordic,nrf-spis.yaml
+++ b/dts/bindings/spi/nordic,nrf-spis.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "nordic,nrf-spis"
 
     reg:
-      type: array
       category: required
-      description: mmio register space
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     sck-pin:
       type: int

--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -18,14 +18,8 @@ properties:
       constraint: "nxp,imx-flexspi"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/spi/nxp,imx-lpspi.yaml
+++ b/dts/bindings/spi/nxp,imx-lpspi.yaml
@@ -15,22 +15,13 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,imx-lpspi"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     clocks:
       type: array

--- a/dts/bindings/spi/nxp,kinetis-dspi.yaml
+++ b/dts/bindings/spi/nxp,kinetis-dspi.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "nxp,kinetis-dspi"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     clocks:
       type: array

--- a/dts/bindings/spi/sifive,spi0.yaml
+++ b/dts/bindings/spi/sifive,spi0.yaml
@@ -15,16 +15,9 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "sifive,spi0"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
 ...

--- a/dts/bindings/spi/snps,designware-spi.yaml
+++ b/dts/bindings/spi/snps,designware-spi.yaml
@@ -18,14 +18,8 @@ properties:
       constraint: "snps,designware-spi"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -10,19 +10,14 @@ version: 0.1
 description: >
     This binding gives the base structures for all spi devices
 
+inherits:
+    !include base.yaml
+
 parent:
     bus: spi
 
 properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
     reg:
-      type: array
-      description: Chip select address of device
-      generation: define
       category: required
     spi-max-frequency:
       type: int
@@ -30,8 +25,5 @@ properties:
       description: Maximum clock frequency of device's SPI interface in Hz
       generation: define
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/spi/spi.yaml
+++ b/dts/bindings/spi/spi.yaml
@@ -10,15 +10,13 @@ version: 0.1
 description: >
     This binding gives the base structures for all SPI devices
 
+inherits:
+    !include base.yaml
+
 child:
     bus: spi
 
 properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
     clock-frequency:
       type: int
       category: optional
@@ -33,10 +31,7 @@ properties:
       category: required
       description: should be 0.
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
     clocks:
       type: array
       category: optional

--- a/dts/bindings/spi/st,stm32-spi-fifo.yaml
+++ b/dts/bindings/spi/st,stm32-spi-fifo.yaml
@@ -19,20 +19,9 @@ properties:
       constraint: "st,stm32-spi-fifo"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
-
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: readable string describing the interrupts
 
 ...

--- a/dts/bindings/spi/st,stm32-spi.yaml
+++ b/dts/bindings/spi/st,stm32-spi.yaml
@@ -18,20 +18,9 @@ properties:
       constraint: "st,stm32-spi"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
-
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: readable string describing the interrupts
 
 ...

--- a/dts/bindings/spi/ti,cc13xx-cc26xx-spi.yaml
+++ b/dts/bindings/spi/ti,cc13xx-cc26xx-spi.yaml
@@ -18,10 +18,7 @@ properties:
       constraint: "ti,cc13xx-cc26xx-spi"
 
     reg:
-      type: array
       category: required
-      description: mmio register space
-      generation: define
 
     sck-pin:
       type: int

--- a/dts/bindings/sram/mmio-sram.yaml
+++ b/dts/bindings/sram/mmio-sram.yaml
@@ -10,24 +10,17 @@ version: 0.1
 description: >
     This binding gives a generic on-chip SRAM description
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "mmio-sram"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: optional
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/sram/sifive,dtim0.yaml
+++ b/dts/bindings/sram/sifive,dtim0.yaml
@@ -10,18 +10,14 @@ version: 0.1
 description: >
     This bindings describes the SiFive Data Tightly-Integrated Memory
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "sifive,dtim0"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
 ...

--- a/dts/bindings/timer/arm,cmsdk-dtimer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-dtimer.yaml
@@ -5,29 +5,19 @@ version: 0.1
 description: >
     This binding gives a base representation of the ARM CMSDK DUALTIMER
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "arm,cmsdk-dtimer"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/timer/arm,cmsdk-timer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-timer.yaml
@@ -5,29 +5,19 @@ version: 0.1
 description: >
     This binding gives a base representation of the ARM CMSDK TIMER
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "arm,cmsdk-timer"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/timer/atmel,sam0-tc32.yaml
+++ b/dts/bindings/timer/atmel,sam0-tc32.yaml
@@ -11,28 +11,19 @@ description: >
     This binding gives a base representation of the Atmel SAM0 timer
     counter (TC) operating in 32-bit wide mode.
 
+inherits:
+    !include base.yaml
+
 properties:
   compatible:
-    type: string
-    category: required
-    description: compatible strings
     constraint: "atmel,sam0-tc32"
 
   reg:
-    type: array
     category: required
-    description: mmio register space
-    generation: define
 
   interrupts:
-    type: array
     category: required
-    description: required interrupts
-    generation: define
 
   label:
-    type: string
     category: required
-    description: Human readable string describing the device (used by Zephyr for API name)
-    generation: define
 ...

--- a/dts/bindings/timer/litex,timer0.yaml
+++ b/dts/bindings/timer/litex,timer0.yaml
@@ -10,22 +10,16 @@ version: 0.1
 description: >
     This binding gives a base representation of the LiteX timer
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "litex,timer0"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/timer/nordic,nrf-timer.yaml
+++ b/dts/bindings/timer/nordic,nrf-timer.yaml
@@ -10,30 +10,21 @@ version: 0.1
 description: >
     This is a representation of the Nordic nRF timer node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-timer"
 
     reg:
-      type: array
       category: required
-      description: mmio register space
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     prescaler:
       type: int

--- a/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
+++ b/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
@@ -5,30 +5,20 @@ version: 0.1
 description: >
     This binding represents the OpenISA RV32M1 LPTMR peripheral.
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "openisa,rv32m1-lptmr"
-      generation: define
 
     reg:
-      type: array
-      description: MMIO register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: interrupt configuration
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
 ...

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -5,6 +5,9 @@ version: 0.1
 description: >
     This binding gives a base representation of the STM32 TIMERS
 
+inherits:
+    !include base.yaml
+
 properties:
     "#address-cells":
       type: int
@@ -16,22 +19,12 @@ properties:
       description: should be 0.
 
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-timers"
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     clocks:

--- a/dts/bindings/usb/atmel,sam-usbhs.yaml
+++ b/dts/bindings/usb/atmel,sam-usbhs.yaml
@@ -18,16 +18,10 @@ properties:
       constraint: "atmel,sam-usbhs"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     peripheral-id:
       type: int

--- a/dts/bindings/usb/atmel,sam0-usb.yaml
+++ b/dts/bindings/usb/atmel,sam0-usb.yaml
@@ -13,14 +13,8 @@ properties:
       constraint: "atmel,sam0-usb"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/usb/nordic,nrf-usbd.yaml
+++ b/dts/bindings/usb/nordic,nrf-usbd.yaml
@@ -18,21 +18,10 @@ properties:
       constraint: "nordic,nrf-usbd"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
-
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: readable string describing the interrupts
 
     num-isoin-endpoints:
       type: int

--- a/dts/bindings/usb/nxp,kinetis-usbd.yaml
+++ b/dts/bindings/usb/nxp,kinetis-usbd.yaml
@@ -18,19 +18,9 @@ properties:
       constraint: "nxp,kinetis-usbd"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: readable string describing the interrupts
 ...

--- a/dts/bindings/usb/st,stm32-otgfs.yaml
+++ b/dts/bindings/usb/st,stm32-otgfs.yaml
@@ -18,21 +18,10 @@ properties:
       constraint: "st,stm32-otgfs"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
-
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: readable string describing the interrupts
 
     ram-size:
       type: int

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -18,21 +18,10 @@ properties:
       constraint: "st,stm32-otghs"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
-
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: readable string describing the interrupts
 
     ram-size:
       type: int

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -18,21 +18,10 @@ properties:
       constraint: "st,stm32-usb"
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
-
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: readable string describing the interrupts
 
     ram-size:
       type: int

--- a/dts/bindings/usb/usb.yaml
+++ b/dts/bindings/usb/usb.yaml
@@ -10,13 +10,10 @@ version: 0.1
 description: >
     This binding gives the base structures for all USB devices
 
-properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
+inherits:
+    !include base.yaml
 
+properties:
     maximum-speed:
       type: string
       category: optional
@@ -33,8 +30,5 @@ properties:
          - "super-speed"
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...

--- a/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
+++ b/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
@@ -5,17 +5,13 @@ version: 0.1
 description: >
     This binding gives a base representation of the ARM CMSDK WATCHDOG
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "arm,cmsdk-watchdog"
-      generation: define
 
     reg:
-      type: array
-      description: mmio register space
-      generation: define
       category: required
 ...

--- a/dts/bindings/watchdog/atmel,sam-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam-watchdog.yaml
@@ -10,30 +10,21 @@ version: 0.1
 description: >
     This is a representation of the SAM0 watchdog
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam-watchdog"
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     peripheral-id:
       type: int

--- a/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
@@ -5,29 +5,19 @@ version: 0.1
 description: >
     This is a representation of the SAM0 watchdog
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam0-watchdog"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 ...

--- a/dts/bindings/watchdog/intel,qmsi-watchdog.yaml
+++ b/dts/bindings/watchdog/intel,qmsi-watchdog.yaml
@@ -10,31 +10,21 @@ version: 0.1
 description: >
     This is a representation of the QMSI watchdog
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "intel,qmsi-watchdog"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     clocks:
       type: array

--- a/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
+++ b/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
@@ -10,33 +10,18 @@ version: 0.1
 description: >
     This is a representation of the NRF watchdog
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-watchdog"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
-
-    interrupt-names:
-      type: stringlist
-      category: optional
-      description: readable string describing the interrupts

--- a/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
@@ -10,31 +10,21 @@ version: 0.1
 description: >
     This is a representation of the Kinetis watchdog
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-wdog"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     clocks:
       type: array

--- a/dts/bindings/watchdog/st,stm32-watchdog.yaml
+++ b/dts/bindings/watchdog/st,stm32-watchdog.yaml
@@ -10,22 +10,15 @@ version: 0.1
 description: >
     This is a representation of the STM32 watchdog
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-watchdog"
-      generation: define
 
     reg:
-      type: int
-      description: mmio register space
-      generation: define
       category: required
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define


### PR DESCRIPTION
Move common properties like 'compatible', 'reg', 'reg-names',
'interrupts', 'interrupt-names', and 'label' into one common base.yaml
that all the other yaml's can inherit from.  This removes both
duplication and inconsistent definition.

The device specific yamls just need to say if a property is 'required'
or not.

NOTE: due to some generation conflicts we did not covert
'soc-nv-flash.yaml' to use base.yaml.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>