### PR TITLE
net: sntp: Ignore return value from close

### DIFF
--- a/subsys/net/lib/sntp/sntp.c
+++ b/subsys/net/lib/sntp/sntp.c
@@ -207,6 +207,6 @@ int sntp_query(struct sntp_ctx *ctx, u32_t timeout, struct sntp_time *time)
 void sntp_close(struct sntp_ctx *ctx)
 {
 	if (ctx) {
-		close(ctx->sock.fd);
+		(void)close(ctx->sock.fd);
 	}
 }


### PR DESCRIPTION
Return value from close() can be ignored in sntp_close()
as it is not returning value to caller anyway.

Coverity-CID: 198863
Fixes #16584

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>