### PR TITLE
net: if: Fix null pointer deref when selecting IPv4 address

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2336,9 +2336,14 @@ static struct in_addr *net_if_ipv4_get_best_match(struct net_if *iface,
 static struct in_addr *if_ipv4_get_addr(struct net_if *iface,
 					enum net_addr_state addr_state, bool ll)
 {
-	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
+	struct net_if_ipv4 *ipv4;
 	int i;
 
+	if (!iface) {
+		return NULL;
+	}
+
+	ipv4 = iface->config.ip.ipv4;
 	if (!ipv4) {
 		return NULL;
 	}


### PR DESCRIPTION
It is possible that iface is NULL when selecting IPv4 destination
address for a sent packet.

Coverity-CID: 198877
Fixes #16570

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>