### PR TITLE
make the log facility compatible with 64-bit builds

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -179,22 +179,22 @@ extern "C" {
 	log_0(_str, _src_level)
 
 #define _LOG_INTERNAL_1(_src_level, _str, _arg0) \
-	log_1(_str, (u32_t)(_arg0), _src_level)
+	log_1(_str, (log_arg_t)(_arg0), _src_level)
 
 #define _LOG_INTERNAL_2(_src_level, _str, _arg0, _arg1)	\
-	log_2(_str, (u32_t)(_arg0), (u32_t)(_arg1), _src_level)
+	log_2(_str, (log_arg_t)(_arg0), (log_arg_t)(_arg1), _src_level)
 
 #define _LOG_INTERNAL_3(_src_level, _str, _arg0, _arg1, _arg2) \
-	log_3(_str, (u32_t)(_arg0), (u32_t)(_arg1), (u32_t)(_arg2), _src_level)
+	log_3(_str, (log_arg_t)(_arg0), (log_arg_t)(_arg1), (log_arg_t)(_arg2), _src_level)
 
-#define __LOG_ARG_CAST(_x) (u32_t)(_x),
+#define __LOG_ARG_CAST(_x) (log_arg_t)(_x),
 
 #define __LOG_ARGUMENTS(...) MACRO_MAP(__LOG_ARG_CAST, __VA_ARGS__)
 
-#define _LOG_INTERNAL_LONG(_src_level, _str, ...)		 \
-	do {							 \
-		u32_t args[] = {__LOG_ARGUMENTS(__VA_ARGS__)};	 \
-		log_n(_str, args, ARRAY_SIZE(args), _src_level); \
+#define _LOG_INTERNAL_LONG(_src_level, _str, ...)		  \
+	do {							  \
+		log_arg_t args[] = {__LOG_ARGUMENTS(__VA_ARGS__)};\
+		log_n(_str, args, ARRAY_SIZE(args), _src_level);  \
 	} while (false)
 
 #define Z_LOG_LEVEL_CHECK(_level, _check_level, _default_level) \
@@ -442,7 +442,7 @@ void log_0(const char *str, struct log_msg_ids src_level);
  * @param src_level	Log identification.
  */
 void log_1(const char *str,
-	   u32_t arg1,
+	   log_arg_t arg1,
 	   struct log_msg_ids src_level);
 
 /** @brief Standard log with two arguments.
@@ -453,8 +453,8 @@ void log_1(const char *str,
  * @param src_level	Log identification.
  */
 void log_2(const char *str,
-	   u32_t arg1,
-	   u32_t arg2,
+	   log_arg_t arg1,
+	   log_arg_t arg2,
 	   struct log_msg_ids src_level);
 
 /** @brief Standard log with three arguments.
@@ -466,9 +466,9 @@ void log_2(const char *str,
  * @param src_level	Log identification.
  */
 void log_3(const char *str,
-	   u32_t arg1,
-	   u32_t arg2,
-	   u32_t arg3,
+	   log_arg_t arg1,
+	   log_arg_t arg2,
+	   log_arg_t arg3,
 	   struct log_msg_ids src_level);
 
 /** @brief Standard log with arguments list.
@@ -479,7 +479,7 @@ void log_3(const char *str,
  * @param src_level	Log identification.
  */
 void log_n(const char *str,
-	   u32_t *args,
+	   log_arg_t *args,
 	   u32_t narg,
 	   struct log_msg_ids src_level);
 

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -16,10 +16,6 @@
 extern "C" {
 #endif
 
-#if UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFUL
-#error "Logger does not support 64 bit architecture."
-#endif
-
 #ifndef CONFIG_LOG
 #define CONFIG_LOG_DEFAULT_LEVEL 0
 #define CONFIG_LOG_DOMAIN_ID 0

--- a/include/logging/log_msg.h
+++ b/include/logging/log_msg.h
@@ -22,6 +22,12 @@ extern "C" {
  * @{
  */
 
+/** @brief Log argument type.
+ *
+ * Should preferably be equivalent to a native word size.
+ */
+typedef unsigned long log_arg_t;
+
 /** @brief Maximum number of arguments in the standard log entry.
  *
  * It is limited by 4 bit nargs field in the log message.
@@ -123,7 +129,7 @@ struct log_msg_hdr {
 
 /** @brief Data part of log message. */
 union log_msg_head_data {
-	u32_t args[LOG_MSG_NARGS_SINGLE_CHUNK];
+	log_arg_t args[LOG_MSG_NARGS_SINGLE_CHUNK];
 	u8_t bytes[LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK];
 };
 
@@ -131,7 +137,7 @@ union log_msg_head_data {
 struct log_msg_ext_head_data {
 	struct log_msg_cont *next;
 	union log_msg_ext_head_data_data {
-		u32_t args[LOG_MSG_NARGS_HEAD_CHUNK];
+		log_arg_t args[LOG_MSG_NARGS_HEAD_CHUNK];
 		u8_t bytes[LOG_MSG_HEXDUMP_BYTES_HEAD_CHUNK];
 	} data;
 };
@@ -155,7 +161,7 @@ BUILD_ASSERT_MSG((sizeof(union log_msg_head_data) ==
 struct log_msg_cont {
 	struct log_msg_cont *next; /*!< Pointer to the next chunk. */
 	union log_msg_cont_data {
-		u32_t args[ARGS_CONT_MSG];
+		log_arg_t args[ARGS_CONT_MSG];
 		u8_t bytes[HEXDUMP_BYTES_CONT_MSG];
 	} payload;
 };
@@ -261,7 +267,7 @@ u32_t log_msg_nargs_get(struct log_msg *msg);
  * @return Argument value or 0 if arg_idx exceeds number of arguments in the
  *	   message.
  */
-u32_t log_msg_arg_get(struct log_msg *msg, u32_t arg_idx);
+log_arg_t log_msg_arg_get(struct log_msg *msg, u32_t arg_idx);
 
 
 /** @brief Gets pointer to the unformatted string from standard log message.
@@ -379,7 +385,7 @@ static inline struct log_msg *log_msg_create_0(const char *str)
  *  @return Pointer to allocated head of the message or NULL.
  */
 static inline struct log_msg *log_msg_create_1(const char *str,
-					       u32_t arg1)
+					       log_arg_t arg1)
 {
 	struct  log_msg *msg = z_log_msg_std_alloc();
 
@@ -407,8 +413,8 @@ static inline struct log_msg *log_msg_create_1(const char *str,
  *  @return Pointer to allocated head of the message or NULL.
  */
 static inline struct log_msg *log_msg_create_2(const char *str,
-					       u32_t arg1,
-					       u32_t arg2)
+					       log_arg_t arg1,
+					       log_arg_t arg2)
 {
 	struct  log_msg *msg = z_log_msg_std_alloc();
 
@@ -438,9 +444,9 @@ static inline struct log_msg *log_msg_create_2(const char *str,
  *  @return Pointer to allocated head of the message or NULL.
  */
 static inline struct log_msg *log_msg_create_3(const char *str,
-					       u32_t arg1,
-					       u32_t arg2,
-					       u32_t arg3)
+					       log_arg_t arg1,
+					       log_arg_t arg2,
+					       log_arg_t arg3)
 {
 	struct  log_msg *msg = z_log_msg_std_alloc();
 
@@ -470,7 +476,7 @@ static inline struct log_msg *log_msg_create_3(const char *str,
  *  @return Pointer to allocated head of the message or NULL.
  */
 struct log_msg *log_msg_create_n(const char *str,
-				 u32_t *args,
+				 log_arg_t *args,
 				 u32_t nargs);
 
 /**

--- a/include/logging/log_msg.h
+++ b/include/logging/log_msg.h
@@ -35,15 +35,20 @@ typedef unsigned long log_arg_t;
 #define LOG_MAX_NARGS 15
 
 /** @brief Number of arguments in the log entry which fits in one chunk.*/
+#ifdef CONFIG_64BIT
+#define LOG_MSG_NARGS_SINGLE_CHUNK 4
+#else
 #define LOG_MSG_NARGS_SINGLE_CHUNK 3
+#endif
 
 /** @brief Number of arguments in the head of extended standard log message..*/
-#define LOG_MSG_NARGS_HEAD_CHUNK (LOG_MSG_NARGS_SINGLE_CHUNK - 1)
+#define LOG_MSG_NARGS_HEAD_CHUNK \
+	(LOG_MSG_NARGS_SINGLE_CHUNK - (sizeof(void *)/sizeof(log_arg_t)))
 
 /** @brief Maximal amount of bytes in the hexdump entry which fits in one chunk.
  */
 #define LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK \
-	(LOG_MSG_NARGS_SINGLE_CHUNK * sizeof(u32_t))
+	(LOG_MSG_NARGS_SINGLE_CHUNK * sizeof(log_arg_t))
 
 /** @brief Number of bytes in the first chunk of hexdump message if message
  *         consists of more than one chunk.
@@ -57,7 +62,7 @@ typedef unsigned long log_arg_t;
 #define HEXDUMP_BYTES_CONT_MSG \
 	(sizeof(struct log_msg) - sizeof(void *))
 
-#define ARGS_CONT_MSG (HEXDUMP_BYTES_CONT_MSG / sizeof(u32_t))
+#define ARGS_CONT_MSG (HEXDUMP_BYTES_CONT_MSG / sizeof(log_arg_t))
 
 /** @brief Flag indicating standard log message. */
 #define LOG_MSG_TYPE_STD 0

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -51,7 +51,7 @@ struct log_strdup_buf {
 
 static const char *log_strdup_fail_msg = "<log_strdup alloc failed>";
 struct k_mem_slab log_strdup_pool;
-static u8_t __noinit __aligned(sizeof(u32_t))
+static u8_t __noinit __aligned(sizeof(void *))
 		log_strdup_pool_buf[LOG_STRDUP_POOL_BUFFER_SIZE];
 
 static struct log_list_t list;

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -218,7 +218,7 @@ void log_0(const char *str, struct log_msg_ids src_level)
 }
 
 void log_1(const char *str,
-	   u32_t arg0,
+	   log_arg_t arg0,
 	   struct log_msg_ids src_level)
 {
 	struct log_msg *msg = log_msg_create_1(str, arg0);
@@ -230,8 +230,8 @@ void log_1(const char *str,
 }
 
 void log_2(const char *str,
-	   u32_t arg0,
-	   u32_t arg1,
+	   log_arg_t arg0,
+	   log_arg_t arg1,
 	   struct log_msg_ids src_level)
 {
 	struct log_msg *msg = log_msg_create_2(str, arg0, arg1);
@@ -244,9 +244,9 @@ void log_2(const char *str,
 }
 
 void log_3(const char *str,
-	   u32_t arg0,
-	   u32_t arg1,
-	   u32_t arg2,
+	   log_arg_t arg0,
+	   log_arg_t arg1,
+	   log_arg_t arg2,
 	   struct log_msg_ids src_level)
 {
 	struct log_msg *msg = log_msg_create_3(str, arg0, arg1, arg2);
@@ -259,7 +259,7 @@ void log_3(const char *str,
 }
 
 void log_n(const char *str,
-	   u32_t *args,
+	   log_arg_t *args,
 	   u32_t narg,
 	   struct log_msg_ids src_level)
 {
@@ -355,11 +355,11 @@ void log_generic(struct log_msg_ids src_level, const char *fmt, va_list ap)
 			}
 		}
 	} else {
-		u32_t args[LOG_MAX_NARGS];
+		log_arg_t args[LOG_MAX_NARGS];
 		u32_t nargs = count_args(fmt);
 
 		for (int i = 0; i < nargs; i++) {
-			args[i] = va_arg(ap, u32_t);
+			args[i] = va_arg(ap, log_arg_t);
 		}
 
 		log_n(fmt, args, nargs, src_level);

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -17,7 +17,7 @@
 #define NUM_OF_MSGS (CONFIG_LOG_BUFFER_SIZE / MSG_SIZE)
 
 struct k_mem_slab log_msg_pool;
-static u8_t __noinit __aligned(sizeof(u32_t))
+static u8_t __noinit __aligned(sizeof(void *))
 		log_msg_pool_buf[CONFIG_LOG_BUFFER_SIZE];
 
 void log_msg_pool_init(void)

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -99,7 +99,7 @@ u32_t log_msg_nargs_get(struct log_msg *msg)
 	return msg->hdr.params.std.nargs;
 }
 
-static u32_t cont_arg_get(struct log_msg *msg, u32_t arg_idx)
+static log_arg_t cont_arg_get(struct log_msg *msg, u32_t arg_idx)
 {
 	struct log_msg_cont *cont;
 
@@ -119,9 +119,9 @@ static u32_t cont_arg_get(struct log_msg *msg, u32_t arg_idx)
 	return cont->payload.args[arg_idx];
 }
 
-u32_t log_msg_arg_get(struct log_msg *msg, u32_t arg_idx)
+log_arg_t log_msg_arg_get(struct log_msg *msg, u32_t arg_idx)
 {
-	u32_t arg;
+	log_arg_t arg;
 
 	/* Return early if requested argument not present in the message. */
 	if (arg_idx >= msg->hdr.params.std.nargs) {
@@ -186,18 +186,18 @@ static struct log_msg *msg_alloc(u32_t nargs)
 	return msg;
 }
 
-static void copy_args_to_msg(struct  log_msg *msg, u32_t *args, u32_t nargs)
+static void copy_args_to_msg(struct  log_msg *msg, log_arg_t *args, u32_t nargs)
 {
 	struct log_msg_cont *cont = msg->payload.ext.next;
 
 	if (nargs > LOG_MSG_NARGS_SINGLE_CHUNK) {
 		(void)memcpy(msg->payload.ext.data.args, args,
-		       LOG_MSG_NARGS_HEAD_CHUNK * sizeof(u32_t));
+		       LOG_MSG_NARGS_HEAD_CHUNK * sizeof(log_arg_t));
 		nargs -= LOG_MSG_NARGS_HEAD_CHUNK;
 		args += LOG_MSG_NARGS_HEAD_CHUNK;
 	} else {
 		(void)memcpy(msg->payload.single.args, args,
-			     nargs * sizeof(u32_t));
+			     nargs * sizeof(log_arg_t));
 		nargs  = 0U;
 	}
 
@@ -205,14 +205,14 @@ static void copy_args_to_msg(struct  log_msg *msg, u32_t *args, u32_t nargs)
 		u32_t cpy_args = MIN(nargs, ARGS_CONT_MSG);
 
 		(void)memcpy(cont->payload.args, args,
-			     cpy_args * sizeof(u32_t));
+			     cpy_args * sizeof(log_arg_t));
 		nargs -= cpy_args;
 		args += cpy_args;
 		cont = cont->next;
 	}
 }
 
-struct log_msg *log_msg_create_n(const char *str, u32_t *args, u32_t nargs)
+struct log_msg *log_msg_create_n(const char *str, log_arg_t *args, u32_t nargs)
 {
 	__ASSERT_NO_MSG(nargs < LOG_MAX_NARGS);
 

--- a/tests/subsys/logging/log_msg/src/log_msg_test.c
+++ b/tests/subsys/logging/log_msg/src/log_msg_test.c
@@ -20,137 +20,46 @@ extern struct k_mem_slab log_msg_pool;
 static const char my_string[] = "test_string";
 void test_log_std_msg(void)
 {
-#ifdef CONFIG_64BIT
-	zassert_true(LOG_MSG_NARGS_SINGLE_CHUNK == 4,
-		     "test assumes following setting");
-#else
-	zassert_true(LOG_MSG_NARGS_SINGLE_CHUNK == 3,
-		     "test assumes following setting");
-#endif
+	zassert_equal(LOG_MSG_NARGS_SINGLE_CHUNK,
+		      IS_ENABLED(CONFIG_64BIT) ? 4 : 3,
+		      "test assumes following setting");
 
 	u32_t used_slabs = k_mem_slab_num_used_get(&log_msg_pool);
 	log_arg_t args[] = {1, 2, 3, 4, 5, 6};
 	struct log_msg *msg;
 
-	/* allocation of 0 argument fits in single buffer */
-	msg = log_msg_create_0(my_string);
+	/* Test for expected buffer usage based on number of arguments */
+	for (int i = 0; i <= 6; i++) {
+		switch (i) {
+		case 0:
+			msg = log_msg_create_0(my_string);
+			break;
+		case 1:
+			msg = log_msg_create_1(my_string, 1);
+			break;
+		case 2:
+			msg = log_msg_create_2(my_string, 1, 2);
+			break;
+		case 3:
+			msg = log_msg_create_3(my_string, 1, 2, 3);
+			break;
+		default:
+			msg = log_msg_create_n(my_string, args, i);
+			break;
+		}
 
-	zassert_equal((used_slabs + 1),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs++;
+		used_slabs += (i > LOG_MSG_NARGS_SINGLE_CHUNK) ? 2 : 1;
+		zassert_equal(used_slabs,
+			      k_mem_slab_num_used_get(&log_msg_pool),
+			      "Expected mem slab allocation.");
 
-	log_msg_put(msg);
+		log_msg_put(msg);
 
-	zassert_equal((used_slabs - 1),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs--;
-
-	/* allocation of 1 argument fits in single buffer */
-	msg = log_msg_create_1(my_string, 1);
-	zassert_equal((used_slabs + 1),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs++;
-
-	log_msg_put(msg);
-
-	zassert_equal((used_slabs - 1),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs--;
-
-	/* allocation of 2 argument fits in single buffer */
-	msg = log_msg_create_2(my_string, 1, 2);
-	zassert_equal((used_slabs + 1),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs++;
-
-	log_msg_put(msg);
-
-	zassert_equal((used_slabs - 1),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs--;
-
-	/* allocation of 3 argument fits in single buffer */
-	msg = log_msg_create_3(my_string, 1, 2, 3);
-
-	zassert_equal((used_slabs + 1),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs++;
-
-	log_msg_put(msg);
-
-	zassert_equal((used_slabs - 1),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs--;
-
-#ifdef CONFIG_64BIT
-	/* allocation of 4 argument fits in single buffer */
-	msg = log_msg_create_n(my_string, args, 4);
-
-	zassert_equal((used_slabs + 1),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs++;
-
-	log_msg_put(msg);
-
-	zassert_equal((used_slabs - 1),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs--;
-#else
-	/* allocation of 4 argument fits in 2 buffers */
-	msg = log_msg_create_n(my_string, args, 4);
-
-	zassert_equal((used_slabs + 2U),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs += 2U;
-
-	log_msg_put(msg);
-
-	zassert_equal((used_slabs - 2U),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs -= 2U;
-#endif
-
-	/* allocation of 5 argument fits in 2 buffers */
-	msg = log_msg_create_n(my_string, args, 5);
-
-	zassert_equal((used_slabs + 2U),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs += 2U;
-
-	log_msg_put(msg);
-
-	zassert_equal((used_slabs - 2U),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs -= 2U;
-
-	/* allocation of 5 argument fits in 2 buffers */
-	msg = log_msg_create_n(my_string, args, 6);
-
-	zassert_equal((used_slabs + 2U),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs += 2U;
-
-	log_msg_put(msg);
-
-	zassert_equal((used_slabs - 2U),
-		      k_mem_slab_num_used_get(&log_msg_pool),
-		      "Expected mem slab allocation.");
-	used_slabs -= 2U;
+		used_slabs -= (i > LOG_MSG_NARGS_SINGLE_CHUNK) ? 2 : 1;
+		zassert_equal(used_slabs,
+			      k_mem_slab_num_used_get(&log_msg_pool),
+			      "Expected mem slab allocation.");
+	}
 }
 
 void test_log_hexdump_msg(void)

--- a/tests/subsys/logging/log_msg/src/log_msg_test.c
+++ b/tests/subsys/logging/log_msg/src/log_msg_test.c
@@ -24,7 +24,7 @@ void test_log_std_msg(void)
 		     "test assumes following setting");
 
 	u32_t used_slabs = k_mem_slab_num_used_get(&log_msg_pool);
-	u32_t args[] = {1, 2, 3, 4, 5, 6};
+	log_arg_t args[] = {1, 2, 3, 4, 5, 6};
 	struct log_msg *msg;
 
 	/* allocation of 0 argument fits in single buffer */


### PR DESCRIPTION
To make things clearer, log arguments now have their own type to separate
them from the sea of u32_t, and to allow for a different size on 64-bit
builds. And log records must account for 64-bit pointers, etc.