### PR TITLE
net: llmnr: Check that UDP header can be accessed

### DIFF
--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -68,6 +68,9 @@ static void create_ipv6_dst_addr(struct net_pkt *pkt,
 	struct net_udp_hdr *udp_hdr, hdr;
 
 	udp_hdr = net_udp_get_hdr(pkt, &hdr);
+	if (!udp_hdr) {
+		return;
+	}
 
 	addr->sin6_family = AF_INET6;
 	addr->sin6_port = udp_hdr->src_port;


### PR DESCRIPTION
It is possible that UDP header cannot be accessed so we need
to check that we do not do null pointer dereference.

Coverity-CID: 198866
Fixes #16581

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>