### PR TITLE
Kernel runtime error checking

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -257,6 +257,28 @@ config COMPILER_OPT
 
 endmenu
 
+choice
+	prompt "Error checking behavior for CHECK macro"
+	default RUNTIME_ERROR_CHECKS
+
+config ASSERT_ON_ERRORS
+	bool "Assert on all errors"
+	help
+	  Assert on errors covered with the CHECK macro.
+
+config NO_RUNTIME_CHECKS
+	bool "No runtime error checks"
+	help
+	  Do not do any runtime checks or asserts when using the CHECK macro.
+
+config RUNTIME_ERROR_CHECKS
+	bool "Enable runtime error checks"
+	help
+	  Always perform runtime checks covered with the CHECK macro. This
+	  option is the default and the only option used during testing.
+
+endchoice
+
 menu "Build Options"
 
 config KERNEL_BIN_NAME

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -172,6 +172,7 @@ config HW_STACK_PROTECTION
 config USERSPACE
 	bool "User mode threads"
 	depends on ARCH_HAS_USERSPACE
+	depends on RUNTIME_ERROR_CHECKS
 	help
 	  When enabled, threads may be created or dropped down to user mode,
 	  which has significantly restricted permissions and must interact

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3698,8 +3698,10 @@ __syscall int k_msgq_alloc_init(struct k_msgq *msgq, size_t msg_size,
  *
  * @param msgq message queue to cleanup
  *
+ * @retval 0 on success
+ * @retval -EBUSY Queue not empty
  */
-void k_msgq_cleanup(struct k_msgq *msgq);
+int k_msgq_cleanup(struct k_msgq *msgq);
 
 /**
  * @brief Send a message to a message queue.

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4155,9 +4155,11 @@ void k_pipe_init(struct k_pipe *pipe, unsigned char *buffer, size_t size);
  * if the buffer wasn't dynamically allocated.
  *
  * @param pipe Address of the pipe.
+ * @retval 0 on success
+ * @retval -EAGAIN nothing to cleanup
  * @req K-PIPE-002
  */
-void k_pipe_cleanup(struct k_pipe *pipe);
+int k_pipe_cleanup(struct k_pipe *pipe);
 
 /**
  * @brief Initialize a pipe and allocate a buffer for it
@@ -4216,6 +4218,7 @@ __syscall int k_pipe_put(struct k_pipe *pipe, void *data,
  *                and K_FOREVER.
  *
  * @retval 0 At least @a min_xfer bytes of data were read.
+ * @retval -EINVAL invalid parameters supplied
  * @retval -EIO Returned without waiting; zero data bytes were read.
  * @retval -EAGAIN Waiting period timed out; between zero and @a min_xfer
  *                 minus one data bytes were read.

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2708,9 +2708,11 @@ __syscall s32_t k_stack_alloc_init(struct k_stack *stack,
  * if the buffer wasn't dynamically allocated.
  *
  * @param stack Address of the stack.
+ * @retval 0 on success
+ * @retval -EAGAIN when object is still in use
  * @req K-STACK-001
  */
-void k_stack_cleanup(struct k_stack *stack);
+int k_stack_cleanup(struct k_stack *stack);
 
 /**
  * @brief Push an element onto a stack.
@@ -2722,10 +2724,11 @@ void k_stack_cleanup(struct k_stack *stack);
  * @param stack Address of the stack.
  * @param data Value to push onto the stack.
  *
- * @return N/A
+ * @retval 0 on success
+ * @retval -ENOMEM if stack is full
  * @req K-STACK-001
  */
-__syscall void k_stack_push(struct k_stack *stack, stack_data_t data);
+__syscall int k_stack_push(struct k_stack *stack, stack_data_t data);
 
 /**
  * @brief Pop an element from a stack.

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2073,9 +2073,11 @@ extern void k_queue_insert(struct k_queue *queue, void *prev, void *data);
  * @param head Pointer to first node in singly-linked list.
  * @param tail Pointer to last node in singly-linked list.
  *
- * @return N/A
+ * @retval 0 on success
+ * @retval -EINVAL on invalid supplied data
+ *
  */
-extern void k_queue_append_list(struct k_queue *queue, void *head, void *tail);
+extern int k_queue_append_list(struct k_queue *queue, void *head, void *tail);
 
 /**
  * @brief Atomically add a list of elements to a queue.
@@ -2089,9 +2091,10 @@ extern void k_queue_append_list(struct k_queue *queue, void *head, void *tail);
  * @param queue Address of the queue.
  * @param list Pointer to sys_slist_t object.
  *
- * @return N/A
+ * @retval 0 on success
+ * @retval -EINVAL on invalid data
  */
-extern void k_queue_merge_slist(struct k_queue *queue, sys_slist_t *list);
+extern int k_queue_merge_slist(struct k_queue *queue, sys_slist_t *list);
 
 /**
  * @brief Get an element from a queue.

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3443,10 +3443,12 @@ struct k_sem {
  * @param initial_count Initial semaphore count.
  * @param limit Maximum permitted semaphore count.
  *
- * @return N/A
+ * @retval 0 Semaphore created successfully
+ * @retval -EINVAL Invalid values
+ *
  * @req K-SEM-001
  */
-__syscall void k_sem_init(struct k_sem *sem, unsigned int initial_count,
+__syscall int k_sem_init(struct k_sem *sem, unsigned int initial_count,
 			  unsigned int limit);
 
 /**

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3346,10 +3346,12 @@ struct k_mutex {
  *
  * @param mutex Address of the mutex.
  *
- * @return N/A
+ * @retval 0 Mutex object created
+ *
  * @req K-MUTEX-002
  */
-__syscall void k_mutex_init(struct k_mutex *mutex);
+__syscall int k_mutex_init(struct k_mutex *mutex);
+
 
 /**
  * @brief Lock a mutex.
@@ -3385,10 +3387,13 @@ __syscall int k_mutex_lock(struct k_mutex *mutex, s32_t timeout);
  *
  * @param mutex Address of the mutex.
  *
- * @return N/A
+ * @retval 0 Mutex unlocked.
+ * @retval -EPERM The current thread does not own the mutex
+ * @retval -EINVAL The mutex is not locked
+ *
  * @req K-MUTEX-002
  */
-__syscall void k_mutex_unlock(struct k_mutex *mutex);
+__syscall int k_mutex_unlock(struct k_mutex *mutex);
 
 /**
  * @}

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4333,10 +4333,12 @@ struct k_mem_slab {
  * @param block_size Size of each memory block (in bytes).
  * @param num_blocks Number of memory blocks.
  *
- * @return N/A
+ * @retval 0 on success
+ * @retval -EINVAL invalid data supplied
+ *
  * @req K-MSLAB-002
  */
-extern void k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
+extern int k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
 			   size_t block_size, u32_t num_blocks);
 
 /**
@@ -4354,6 +4356,7 @@ extern void k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
  *         is set to the starting address of the memory block.
  * @retval -ENOMEM Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
+ * @retval -EINVAL Invalid data supplied
  * @req K-MSLAB-002
  */
 extern int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem,

--- a/include/sys/check.h
+++ b/include/sys/check.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#ifndef ZEPHYR_INCLUDE_SYS_CHECK_H_
+#define ZEPHYR_INCLUDE_SYS_CHECK_H_
+
+#include <sys/__assert.h>
+
+#if defined(CONFIG_ASSERT_ON_ERRORS)
+#define CHECKIF(expr) \
+	__ASSERT_NO_MSG(!(expr));   \
+	if (0)
+#elif defined(CONFIG_NO_RUNTIME_CHECKS)
+#define CHECKIF(...) \
+	if (0)
+#else
+#define CHECKIF(expr) \
+	if (expr)
+#endif
+
+
+#endif /* ZEPHYR_INCLUDE_SYS_CHECK_H_ */

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -13,6 +13,7 @@
 #include <sys/dlist.h>
 #include <ksched.h>
 #include <init.h>
+#include <sys/check.h>
 
 static struct k_spinlock lock;
 
@@ -28,15 +29,16 @@ struct k_mem_slab *_trace_list_k_mem_slab;
  *
  * @return N/A
  */
-static void create_free_list(struct k_mem_slab *slab)
+static int create_free_list(struct k_mem_slab *slab)
 {
 	u32_t j;
 	char *p;
 
 	/* blocks must be word aligned */
-	__ASSERT(((slab->block_size | (uintptr_t)slab->buffer)
-					& (sizeof(void *) - 1)) == 0,
-		 "slab at %p not word aligned", slab);
+	CHECKIF(((slab->block_size | (uintptr_t)slab->buffer) &
+				(sizeof(void *) - 1)) != 0) {
+		return -EINVAL;
+	}
 
 	slab->free_list = NULL;
 	p = slab->buffer;
@@ -46,6 +48,7 @@ static void create_free_list(struct k_mem_slab *slab)
 		slab->free_list = p;
 		p += slab->block_size;
 	}
+	return 0;
 }
 
 /**
@@ -57,31 +60,45 @@ static void create_free_list(struct k_mem_slab *slab)
  */
 static int init_mem_slab_module(struct device *dev)
 {
+	int rc = 0;
 	ARG_UNUSED(dev);
 
 	Z_STRUCT_SECTION_FOREACH(k_mem_slab, slab) {
-		create_free_list(slab);
+		rc = create_free_list(slab);
+		if (rc < 0) {
+			goto out;
+		}
 		SYS_TRACING_OBJ_INIT(k_mem_slab, slab);
 		z_object_init(slab);
 	}
-	return 0;
+
+out:
+	return rc;
 }
 
 SYS_INIT(init_mem_slab_module, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 
-void k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
+int k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
 		    size_t block_size, u32_t num_blocks)
 {
+	int rc = 0;
+
 	slab->num_blocks = num_blocks;
 	slab->block_size = block_size;
 	slab->buffer = buffer;
 	slab->num_used = 0U;
-	create_free_list(slab);
+	rc = create_free_list(slab);
+	if (rc < 0) {
+		goto out;
+	}
 	z_waitq_init(&slab->wait_q);
 	SYS_TRACING_OBJ_INIT(k_mem_slab, slab);
 
 	z_object_init(slab);
+
+out:
+	return rc;
 }
 
 int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, s32_t timeout)

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -23,6 +23,7 @@
 #include <init.h>
 #include <syscall_handler.h>
 #include <kernel_internal.h>
+#include <sys/check.h>
 
 #ifdef CONFIG_OBJECT_TRACING
 
@@ -98,14 +99,17 @@ int z_vrfy_k_msgq_alloc_init(struct k_msgq *q, size_t msg_size,
 #include <syscalls/k_msgq_alloc_init_mrsh.c>
 #endif
 
-void k_msgq_cleanup(struct k_msgq *msgq)
+int k_msgq_cleanup(struct k_msgq *msgq)
 {
-	__ASSERT_NO_MSG(z_waitq_head(&msgq->wait_q) == NULL);
+	CHECKIF(z_waitq_head(&msgq->wait_q) != NULL) {
+		return -EBUSY;
+	}
 
 	if ((msgq->flags & K_MSGQ_FLAG_ALLOC) != 0) {
 		k_free(msgq->buffer_start);
 		msgq->flags &= ~K_MSGQ_FLAG_ALLOC;
 	}
+	return 0;
 }
 
 

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -70,7 +70,6 @@ int z_impl_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 		return -EINVAL;
 	}
 
-
 	sys_trace_void(SYS_TRACE_ID_SEMA_INIT);
 	sem->count = initial_count;
 	sem->limit = limit;
@@ -106,30 +105,21 @@ static inline void handle_poll_events(struct k_sem *sem)
 #endif
 }
 
-static inline void increment_count_up_to_limit(struct k_sem *sem)
+void z_impl_k_sem_give(struct k_sem *sem)
 {
-	sem->count += (sem->count != sem->limit) ? 1U : 0U;
-}
-
-static void do_sem_give(struct k_sem *sem)
-{
+	k_spinlock_key_t key = k_spin_lock(&lock);
 	struct k_thread *thread = z_unpend_first_thread(&sem->wait_q);
+
+	sys_trace_void(SYS_TRACE_ID_SEMA_GIVE);
 
 	if (thread != NULL) {
 		z_ready_thread(thread);
 		arch_thread_return_value_set(thread, 0);
 	} else {
-		increment_count_up_to_limit(sem);
+		sem->count += (sem->count != sem->limit) ? 1U : 0U;
 		handle_poll_events(sem);
 	}
-}
 
-void z_impl_k_sem_give(struct k_sem *sem)
-{
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	sys_trace_void(SYS_TRACE_ID_SEMA_GIVE);
-	do_sem_give(sem);
 	sys_trace_end_call(SYS_TRACE_ID_SEMA_GIVE);
 	z_reschedule(&lock, key);
 }
@@ -145,6 +135,8 @@ static inline void z_vrfy_k_sem_give(struct k_sem *sem)
 
 int z_impl_k_sem_take(struct k_sem *sem, s32_t timeout)
 {
+	int ret = 0;
+
 	__ASSERT(((arch_is_in_isr() == false) || (timeout == K_NO_WAIT)), "");
 
 	sys_trace_void(SYS_TRACE_ID_SEMA_TAKE);
@@ -153,19 +145,20 @@ int z_impl_k_sem_take(struct k_sem *sem, s32_t timeout)
 	if (likely(sem->count > 0U)) {
 		sem->count--;
 		k_spin_unlock(&lock, key);
-		sys_trace_end_call(SYS_TRACE_ID_SEMA_TAKE);
-		return 0;
+		ret = 0;
+		goto out;
 	}
 
 	if (timeout == K_NO_WAIT) {
 		k_spin_unlock(&lock, key);
-		sys_trace_end_call(SYS_TRACE_ID_SEMA_TAKE);
-		return -EBUSY;
+		ret = -EBUSY;
+		goto out;
 	}
 
-	sys_trace_end_call(SYS_TRACE_ID_SEMA_TAKE);
+	ret = z_pend_curr(&lock, key, &sem->wait_q, timeout);
 
-	int ret = z_pend_curr(&lock, key, &sem->wait_q, timeout);
+out:
+	sys_trace_end_call(SYS_TRACE_ID_SEMA_TAKE);
 	return ret;
 }
 

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -15,7 +15,7 @@
 #include <linker/sections.h>
 #include <ksched.h>
 #include <wait_q.h>
-#include <sys/__assert.h>
+#include <sys/check.h>
 #include <init.h>
 #include <syscall_handler.h>
 #include <kernel_internal.h>
@@ -81,23 +81,28 @@ static inline s32_t z_vrfy_k_stack_alloc_init(struct k_stack *stack,
 #include <syscalls/k_stack_alloc_init_mrsh.c>
 #endif
 
-void k_stack_cleanup(struct k_stack *stack)
+int k_stack_cleanup(struct k_stack *stack)
 {
-	__ASSERT_NO_MSG(z_waitq_head(&stack->wait_q) == NULL);
+	CHECKIF(z_waitq_head(&stack->wait_q) != NULL) {
+		return -EAGAIN;
+	}
 
 	if ((stack->flags & K_STACK_FLAG_ALLOC) != (u8_t)0) {
 		k_free(stack->base);
 		stack->base = NULL;
 		stack->flags &= ~K_STACK_FLAG_ALLOC;
 	}
+	return 0;
 }
 
-void z_impl_k_stack_push(struct k_stack *stack, stack_data_t data)
+int z_impl_k_stack_push(struct k_stack *stack, stack_data_t data)
 {
 	struct k_thread *first_pending_thread;
 	k_spinlock_key_t key;
 
-	__ASSERT(stack->next != stack->top, "stack is full");
+	CHECKIF(stack->next == stack->top) {
+		return -ENOMEM;
+	}
 
 	key = k_spin_lock(&stack->lock);
 
@@ -109,22 +114,21 @@ void z_impl_k_stack_push(struct k_stack *stack, stack_data_t data)
 		z_thread_return_value_set_with_data(first_pending_thread,
 						   0, (void *)data);
 		z_reschedule(&stack->lock, key);
-		return;
 	} else {
 		*(stack->next) = data;
 		stack->next++;
 		k_spin_unlock(&stack->lock, key);
 	}
 
+	return 0;
 }
 
 #ifdef CONFIG_USERSPACE
-static inline void z_vrfy_k_stack_push(struct k_stack *stack, stack_data_t data)
+static inline int z_vrfy_k_stack_push(struct k_stack *stack, stack_data_t data)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(stack, K_OBJ_STACK));
-	Z_OOPS(Z_SYSCALL_VERIFY_MSG(stack->next != stack->top,
-				    "stack is full"));
-	z_impl_k_stack_push(stack, data);
+
+	return z_impl_k_stack_push(stack, data);
 }
 #include <syscalls/k_stack_push_mrsh.c>
 #endif

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -16,6 +16,7 @@
 #include <spinlock.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <sys/check.h>
 
 #define WORKQUEUE_THREAD_NAME	"workqueue"
 
@@ -54,7 +55,9 @@ void k_delayed_work_init(struct k_delayed_work *work, k_work_handler_t handler)
 
 static int work_cancel(struct k_delayed_work *work)
 {
-	__ASSERT(work->work_q != NULL, "");
+	CHECKIF(work->work_q == NULL) {
+		return -EAGAIN;
+	}
 
 	if (k_work_pending(&work->work)) {
 		/* Remove from the queue if already submitted */

--- a/tests/kernel/pipe/pipe/src/test_pipe.c
+++ b/tests/kernel/pipe/pipe/src/test_pipe.c
@@ -813,22 +813,16 @@ void test_pipe_get_timeout(void)
  * @ingroup kernel_pipe_tests
  * @see k_pipe_get()
  */
-#ifdef CONFIG_USERSPACE
-/* userspace invalid size */
 void test_pipe_get_invalid_size(void)
 {
 	size_t read;
+	int ret;
 
 	valid_fault = true;
-	k_pipe_get(&test_pipe, &rx_buffer,
+	ret = k_pipe_get(&test_pipe, &rx_buffer,
 		   0, &read,
 		   1, TIMEOUT_200MSEC);
 
-	zassert_unreachable("fault didn't occur for min_xfer <= bytes_to_read");
+	zassert_equal(ret, -EINVAL,
+		      "fault didn't occur for min_xfer <= bytes_to_read");
 }
-#else
-void test_pipe_get_invalid_size(void)
-{
-	ztest_test_skip();
-}
-#endif

--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -151,8 +151,11 @@ void sem_take_multiple_high_prio_helper(void *p1, void *p2, void *p3)
  */
 void test_sema_thread2thread(void)
 {
+	int ret;
 	/**TESTPOINT: test k_sem_init sema*/
-	k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
+	ret = k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
+
+	zassert_equal(ret, 0, NULL);
 
 	tsema_thread_thread(&sema);
 
@@ -166,8 +169,11 @@ void test_sema_thread2thread(void)
  */
 void test_sema_thread2isr(void)
 {
+	int ret;
 	/**TESTPOINT: test k_sem_init sema*/
-	k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
+	ret = k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
+
+	zassert_equal(ret, 0, NULL);
 	tsema_thread_isr(&sema);
 
 	/**TESTPOINT: test K_SEM_DEFINE sema*/
@@ -175,12 +181,38 @@ void test_sema_thread2isr(void)
 }
 
 /**
+ * @brief Test k_sem_init() API
+ *
+ */
+void test_k_sema_init(void)
+{
+	int ret;
+
+	ret = k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
+	zassert_equal(ret, 0, NULL);
+
+	k_sem_reset(&sema);
+
+	ret = k_sem_init(&sema, SEM_INIT_VAL, 0);
+	zassert_equal(ret, -EINVAL, NULL);
+
+	ret = k_sem_init(&sema, SEM_MAX_VAL + 1, SEM_MAX_VAL);
+	zassert_equal(ret, -EINVAL, NULL);
+
+}
+
+
+/**
  * @brief Test k_sem_reset() API
  * @see k_sem_reset()
  */
 void test_sema_reset(void)
 {
-	k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
+	int ret;
+
+	ret = k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
+	zassert_equal(ret, 0, NULL);
+
 	k_sem_give(&sema);
 	k_sem_reset(&sema);
 	zassert_false(k_sem_count_get(&sema), NULL);
@@ -198,7 +230,11 @@ void test_sema_reset(void)
  */
 void test_sema_count_get(void)
 {
-	k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
+	int ret;
+
+	ret = k_sem_init(&sema, SEM_INIT_VAL, SEM_MAX_VAL);
+	zassert_equal(ret, 0, NULL);
+
 	/**TESTPOINT: sem count get upon init*/
 	zassert_equal(k_sem_count_get(&sema), SEM_INIT_VAL, NULL);
 	k_sem_give(&sema);
@@ -861,6 +897,7 @@ void test_main(void)
 			      &tstack, &tdata);
 
 	ztest_test_suite(test_semaphore,
+			 ztest_user_unit_test(test_k_sema_init),
 			 ztest_user_unit_test(test_sema_thread2thread),
 			 ztest_unit_test(test_sema_thread2isr),
 			 ztest_user_unit_test(test_sema_reset),


### PR DESCRIPTION
Introduce runtime error checking in the kernel where it make sense and remove duplication of asserts and oopses that were used to catch such errors. Propagate errors where needed. 

Ideally we want to use this to check for parameters and permissions and return to the caller to allow recovery, which was not possible in the current approach: when asserts are enabled (not default) we would just crash on every error, even if recoverable or we will get undefined behavior if asserts were not enabled.

Situations which should never happen and disallowed by design, such as running something in an ISR when it should not, remain as asserts where applicable.

-----------------

(Edit by @aescolar) Discussed in #17105