### PR TITLE
memslab/mempool: make tests 64-bit compatible

### DIFF
--- a/tests/kernel/mem_pool/mem_pool_api/src/test_mpool.h
+++ b/tests/kernel/mem_pool/mem_pool_api/src/test_mpool.h
@@ -8,8 +8,8 @@
 #define __TEST_MPOOL_H__
 
 #define TIMEOUT 100
-#define BLK_SIZE_MIN 8
-#define BLK_SIZE_MAX 128
+#define BLK_SIZE_MIN 16
+#define BLK_SIZE_MAX 256
 #define BLK_NUM_MIN 32
 #define BLK_NUM_MAX 2
 #define BLK_ALIGN BLK_SIZE_MIN

--- a/tests/kernel/mem_pool/mem_pool_api/src/test_mpool_api.c
+++ b/tests/kernel/mem_pool/mem_pool_api/src/test_mpool_api.c
@@ -109,7 +109,7 @@ void test_mpool_alloc_size(void)
 		zassert_true(k_mem_pool_alloc(&kmpool, &block[i], size,
 					      K_NO_WAIT) == 0, NULL);
 		zassert_not_null(block[i].data, NULL);
-		zassert_true((u32_t)(block[i].data) % BLK_ALIGN == 0, NULL);
+		zassert_true((uintptr_t)(block[i].data) % BLK_ALIGN == 0, NULL);
 		i++;
 		size = size >> 2;
 	}
@@ -127,7 +127,7 @@ void test_mpool_alloc_size(void)
 		zassert_true(k_mem_pool_alloc(&kmpool, &block[i], size,
 					      K_NO_WAIT) == 0, NULL);
 		zassert_not_null(block[i].data, NULL);
-		zassert_true((u32_t)(block[i].data) % BLK_ALIGN == 0, NULL);
+		zassert_true((uintptr_t)(block[i].data) % BLK_ALIGN == 0, NULL);
 		i++;
 		size = size << 2;
 	}

--- a/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool.h
+++ b/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool.h
@@ -10,8 +10,8 @@
 #else
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
 #endif
-#define BLK_SIZE_MIN 8
-#define BLK_SIZE_MAX 32
+#define BLK_SIZE_MIN 16
+#define BLK_SIZE_MAX 64
 #define BLK_NUM_MIN 8
 #define BLK_NUM_MAX 2
 #define BLK_ALIGN BLK_SIZE_MIN

--- a/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_merge_fail_diff_size.c
+++ b/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_merge_fail_diff_size.c
@@ -6,9 +6,9 @@
 
 #include <ztest.h>
 #define TIMEOUT 2000
-#define BLK_SIZE_MIN 8
-#define BLK_SIZE_MID 16
-#define BLK_SIZE_MAX 128
+#define BLK_SIZE_MIN 16
+#define BLK_SIZE_MID 32
+#define BLK_SIZE_MAX 256
 #define BLK_NUM_MIN 32
 #define BLK_NUM_MAX 2
 #define BLK_ALIGN BLK_SIZE_MIN

--- a/tests/kernel/mem_pool/mem_pool_threadsafe/src/main.c
+++ b/tests/kernel/mem_pool/mem_pool_threadsafe/src/main.c
@@ -11,8 +11,8 @@
 #define POOL_NUM 2
 #define LOOPS 10
 #define TIMEOUT 200
-#define BLK_SIZE_MIN 4
-#define BLK_SIZE_MAX 16
+#define BLK_SIZE_MIN 8
+#define BLK_SIZE_MAX 32
 #define BLK_NUM_MIN 8
 #define BLK_NUM_MAX 2
 #define BLK_ALIGN BLK_SIZE_MIN

--- a/tests/kernel/mem_pool/sys_mem_pool/src/main.c
+++ b/tests/kernel/mem_pool/sys_mem_pool/src/main.c
@@ -71,12 +71,12 @@ void test_sys_mem_pool_alloc_align4(void)
 
 	/**
 	 * TESTPOINT: The address of the allocated chunk is guaranteed to be
-	 * aligned on a multiple of 4 bytes.
+	 * aligned on a word boundary (4 or 8 bytes).
 	 */
 	for (int i = 0; i < BLK_NUM_MAX; i++) {
 		block[i] = sys_mem_pool_alloc(&pool, i);
 		zassert_not_null(block[i], NULL);
-		zassert_false((int)block[i] % 4, NULL);
+		zassert_false((uintptr_t)block[i] % sizeof(void *), NULL);
 	}
 
 	/* test case tear down*/

--- a/tests/kernel/mem_slab/mslab_api/src/test_mslab.h
+++ b/tests/kernel/mem_slab/mslab_api/src/test_mslab.h
@@ -9,8 +9,8 @@
 
 #define TIMEOUT 2000
 #define BLK_NUM 3
-#define BLK_ALIGN 4
-#define BLK_SIZE 8
+#define BLK_ALIGN 8
+#define BLK_SIZE 16
 
 extern void tmslab_alloc_free(void *data);
 

--- a/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
+++ b/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
@@ -51,7 +51,7 @@ static void tmslab_alloc_align(void *data)
 		 * TESTPOINT: To ensure that each memory block is similarly
 		 * aligned to this boundary
 		 */
-		zassert_true((u32_t)block[i] % BLK_ALIGN == 0U, NULL);
+		zassert_true((uintptr_t)block[i] % BLK_ALIGN == 0U, NULL);
 	}
 	for (int i = 0; i < BLK_NUM; i++) {
 		k_mem_slab_free(pslab, &block[i]);

--- a/tests/kernel/mem_slab/mslab_concept/src/test_mslab.h
+++ b/tests/kernel/mem_slab/mslab_concept/src/test_mslab.h
@@ -9,7 +9,7 @@
 
 #define TIMEOUT 2000
 #define BLK_NUM 3
-#define BLK_ALIGN 4
-#define BLK_SIZE 8
+#define BLK_ALIGN 8
+#define BLK_SIZE 16
 
 #endif /*__TEST_MSLAB_H__*/

--- a/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
+++ b/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
@@ -12,9 +12,9 @@
 #define SLAB_NUM 2
 #define TIMEOUT 200
 #define BLK_NUM 3
-#define BLK_ALIGN 4
-#define BLK_SIZE1 8
-#define BLK_SIZE2 4
+#define BLK_ALIGN 8
+#define BLK_SIZE1 16
+#define BLK_SIZE2 8
 
 /* Blocks per slab.  Note this number carefully, because if it is
  * smaller than this the test can deadlock.  There are 4 threads

--- a/tests/kernel/obj_tracing/src/trace_obj.c
+++ b/tests/kernel/obj_tracing/src/trace_obj.c
@@ -30,7 +30,7 @@ static inline void stop_dummy_fn(struct k_timer *timer)
 }
 
 K_TIMER_DEFINE(ktimer, expiry_dummy_fn, stop_dummy_fn);
-K_MEM_SLAB_DEFINE(kmslab, 4, 2, 4);
+K_MEM_SLAB_DEFINE(kmslab, 8, 2, 8);
 K_SEM_DEFINE(ksema, 0, 1);
 K_MUTEX_DEFINE(kmutex);
 K_STACK_DEFINE(kstack, 512);
@@ -49,10 +49,10 @@ static struct k_mbox mbox;
 static struct k_pipe pipe;
 static struct k_queue queue;
 
-#define BLOCK_SIZE 4
+#define BLOCK_SIZE 8
 #define NUM_BLOCKS 4
 
-static char slab[BLOCK_SIZE * NUM_BLOCKS];
+static char __aligned(8) slab[BLOCK_SIZE * NUM_BLOCKS];
 static u32_t sdata[BLOCK_SIZE * NUM_BLOCKS];
 static char buffer[BLOCK_SIZE * NUM_BLOCKS];
 static char data[] = "test";


### PR DESCRIPTION
Minimum block size is 2x larger on 64-bit systems, so let's simply
double all size params. This won't change the validity of those tests
on 32-bit systems. Alignment tests are also adjusted for wider pointers.