### PR TITLE
samples: net: echo-server: Ignore the return value of close()

### DIFF
--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -169,7 +169,7 @@ static int process_tcp(struct data *data)
 #endif
 	} while (true);
 
-	close(client);
+	(void)close(client);
 
 	return ret;
 }


### PR DESCRIPTION
We are not interested in whether the close() call succeeds or
not when the connection is terminated.

Coverity-CID: 198878
Fixes #16569

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>