### PR TITLE
Bluetooth: GATT: Fix bt_gatt_foreach_attr_type 

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -999,6 +999,8 @@ static u8_t gatt_foreach_iter(const struct bt_gatt_attr *attr,
 			      const void *attr_data, uint16_t *num_matches,
 			      bt_gatt_attr_func_t func, void *user_data)
 {
+	u8_t result;
+
 	/* Stop if over the requested range */
 	if (attr->handle > end_handle) {
 		return BT_GATT_ITER_STOP;
@@ -1019,11 +1021,15 @@ static u8_t gatt_foreach_iter(const struct bt_gatt_attr *attr,
 		return BT_GATT_ITER_CONTINUE;
 	}
 
-	if (*num_matches) {
-		*num_matches -= 1;
+	*num_matches -= 1;
+
+	result = func(attr, user_data);
+
+	if (!*num_matches) {
+		return BT_GATT_ITER_STOP;
 	}
 
-	return func(attr, user_data);
+	return result;
 }
 
 void bt_gatt_foreach_attr_type(u16_t start_handle, u16_t end_handle,
@@ -1066,11 +1072,6 @@ void bt_gatt_foreach_attr_type(u16_t start_handle, u16_t end_handle,
 					return;
 				}
 			}
-
-			/* Stop if number of matches has reached 0 */
-			if (!num_matches) {
-				return;
-			}
 		}
 	}
 
@@ -1094,11 +1095,6 @@ void bt_gatt_foreach_attr_type(u16_t start_handle, u16_t end_handle,
 			    BT_GATT_ITER_STOP) {
 				return;
 			}
-		}
-
-		/* Stop if number of matches has reached 0 */
-		if (!num_matches) {
-			return;
 		}
 	}
 }

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -562,10 +562,18 @@ static int cmd_show_db(const struct shell *shell, size_t argc, char *argv[])
 	memset(&stats, 0, sizeof(stats));
 
 	if (argc > 1) {
+		u16_t num_matches = 0;
+
 		uuid.uuid.type = BT_UUID_TYPE_16;
 		uuid.val = strtoul(argv[1], NULL, 16);
-		bt_gatt_foreach_attr_type(0x0001, 0xffff, &uuid.uuid, NULL, 0,
-					  print_attr, (void *)shell);
+
+		if (argc > 2) {
+			num_matches = strtoul(argv[2], NULL, 10);
+		}
+
+		bt_gatt_foreach_attr_type(0x0001, 0xffff, &uuid.uuid, NULL,
+					  num_matches, print_attr,
+					  (void *)shell);
 		return 0;
 	}
 
@@ -1029,7 +1037,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(gatt_cmds,
 #endif /* CONFIG_BT_GATT_CLIENT */
 	SHELL_CMD_ARG(get, NULL, "<start handle> [end handle]", cmd_get, 2, 1),
 	SHELL_CMD_ARG(set, NULL, "<handle> [data...]", cmd_set, 2, 255),
-	SHELL_CMD_ARG(show-db, NULL, "[uuid]", cmd_show_db, 1, 1),
+	SHELL_CMD_ARG(show-db, NULL, "[uuid] [num_matches]", cmd_show_db, 1, 2),
 #if defined(CONFIG_BT_GATT_DYNAMIC_DB)
 	SHELL_CMD_ARG(metrics, NULL,
 		      "register vendr char and measure rx <value: on, off>",


### PR DESCRIPTION
This fixes bt_gatt_foreach_attr_type when num_matches is not 0.