### PR TITLE
doc: generate documentation of ifdef`ed APIs

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1973,6 +1973,8 @@ INCLUDE_FILE_PATTERNS  =
 
 PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "CONFIG_THREAD_MONITOR=y" \
+                         "CONFIG_SCHED_CPU_MASK=y" \
+                         "CONFIG_SCHED_DEADLINE=y" \
                          "CONFIG_NET_MGMT_EVENT=y" \
 			 "CONFIG_NET_UDP=y" \
 			 "CONFIG_NET_TCP=y" \

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1043,6 +1043,12 @@ __syscall void k_thread_priority_set(k_tid_t thread, int prio);
  * above this call, which is simply input to the priority selection
  * logic.
  *
+ * @note
+ *    @rststar
+ *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
+ *    configuration.
+ *    @endrststar
+ *
  * @param thread A thread on which to set the deadline
  * @param deadline A time delta, in cycle units
  *
@@ -1058,6 +1064,12 @@ __syscall void k_thread_deadline_set(k_tid_t thread, int deadline);
  * After this returns, the thread will no longer be schedulable on any
  * CPUs.  The thread must not be currently runnable.
  *
+ * @note
+ *    @rststar
+ *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
+ *    configuration.
+ *    @endrststar
+ *
  * @param thread Thread to operate upon
  * @return Zero on success, otherwise error code
  */
@@ -1069,6 +1081,12 @@ int k_thread_cpu_mask_clear(k_tid_t thread);
  * After this returns, the thread will be schedulable on any CPU.  The
  * thread must not be currently runnable.
  *
+ * @note
+ *    @rststar
+ *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
+ *    configuration.
+ *    @endrststar
+ *
  * @param thread Thread to operate upon
  * @return Zero on success, otherwise error code
  */
@@ -1078,6 +1096,12 @@ int k_thread_cpu_mask_enable_all(k_tid_t thread);
  * @brief Enable thread to run on specified CPU
  *
  * The thread must not be currently runnable.
+ *
+ * @note
+ *    @rststar
+ *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
+ *    configuration.
+ *    @endrststar
  *
  * @param thread Thread to operate upon
  * @param cpu CPU index
@@ -1089,6 +1113,12 @@ int k_thread_cpu_mask_enable(k_tid_t thread, int cpu);
  * @brief Prevent thread to run on specified CPU
  *
  * The thread must not be currently runnable.
+ *
+ * @note
+ *    @rststar
+ *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
+ *    configuration.
+ *    @endrststar
  *
  * @param thread Thread to operate upon
  * @param cpu CPU index


### PR DESCRIPTION
Enable generation of doxygen documentation for kernel APIs that are
behind Kconfig options and add a note about the option needed to enable
the APIs.