### PR TITLE
Musca b1 mhu support

### DIFF
--- a/boards/arm/v2m_musca_b1/doc/index.rst
+++ b/boards/arm/v2m_musca_b1/doc/index.rst
@@ -256,7 +256,7 @@ The ARM Musca B1 test chip implements a Serial Configuration Control (SCC)
 register. The purpose of this register is to allow individual control of
 clocks, reset-signals and interrupts to peripherals, and pin-muxing.
 
-QSPI boot memory
+Boot memory
 ================
 Normal Musca-B1 test chip boot operation is from 4MB eFlash by default, and
 it offers the fastest boot method.
@@ -348,38 +348,28 @@ Follow the build steps for AN521 target while replacing the platform with
 ``-DTARGET_PLATFORM=MUSCA_B1`` and compiler (if required) with ``-DCOMPILER=GNUARM``
 
 Copy over tfm as a library to the Zephyr project source and create a shortcut
-for the secure veneers.
-
-.. code-block:: bash
-
-   cp -r install/ $ZEPHYR_PROJECT/src/ext
-   cp $ZEPHYR_PROJECT/src/ext/install/export/tfm/veneers/s_veneers.o $ZEPHYR_PROJECT/src/ext
-
-
-Build the Zephyr app in the usual way.
+for the secure veneers and necessary header files. All files are in the install
+folder after TF-M built.
 
 Uploading an application to V2M Musca B1
 ----------------------------------------
 
 Applications must be converted to Intel's hex format before being flashed to a
 V2M Musca B1. An optional bootloader can be prepended to the image.
-The QSPI flash base address alias is 0x0.
-
+The QSPI flash base address alias is 0x0, and the eFlash base address alias is
+0xA000000.
 The image offset is calculated by adding the flash offset to the
 bootloader partition size.
 
-A third-party tool (srecord) is used to generate the Intel formatted hex image. For more information
-refer to the `Srecord Manual`_.
+A third-party tool (srecord) is used to generate the Intel formatted hex image.
+For more information refer to the `Srecord Manual`_.
 
 .. code-block:: bash
 
-   srec_cat $BIN_BOOLOADER -Binary -offset $QSPI_FLASH_OFFSET $BIN_SNS -Binary -offset $IMAGE_OFFSET -o $HEX_FLASHABLE -Intel
+   srec_cat $BIN_BOOLOADER -Binary -offset $FLASH_OFFSET $BIN_SNS -Binary -offset $IMAGE_OFFSET -o $HEX_FLASHABLE -Intel
 
-   # For a 64K bootloader IMAGE_OFFSET = $QSPI_FLASH_OFFSET + 0x10000
-   srec_cat $BIN_BOOLOADER -Binary -offset 0x0 $BIN_SNS -Binary -offset 0x10000 -o $HEX_FLASHABLE -Intel
-
-   # For a 256K bootloader IMAGE_OFFSET = $QSPI_FLASH_OFFSET + 0x40000
-   srec_cat $BIN_BOOLOADER -Binary -offset 0x0 $BIN_SNS -Binary -offset 0x40000 -o $HEX_FLASHABLE -Intel
+   # For a 128K bootloader IMAGE_OFFSET = $FLASH_OFFSET + 0x20000
+   srec_cat $BIN_BOOLOADER -Binary -offset 0xA000000 $BIN_SNS -Binary -offset 0xA020000 -o $HEX_FLASHABLE -Intel
 
 Connect the V2M Musca B1 to your host computer using the USB port. You should
 see a USB connection exposing a Mass Storage (MUSCA_B) and a USB Serial Port.

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1.dts
@@ -39,9 +39,9 @@
 		};
 	};
 
-	flash0: flash@10000000 {
-		/* QSPI flash */
-		reg = <0x10000000 0x2000000>;
+	flash0: flash@1a000000 {
+		/* Embedded flash */
+		reg = <0x1a000000 0x200000>;
 	};
 
 	sram0: memory@30000000 {

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.dts
@@ -39,9 +39,9 @@
 		};
 	};
 
-	flash0: flash@30400 {
-		/* QSPI flash */
-		reg = <0x00030400 0x1fcfc00>;
+	flash0: flash@0a060400 {
+		/* Embedded flash */
+		reg = <0x0a060400 0x19fc00>;
 	};
 
 	sram0: memory@20070000 {

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.yaml
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.yaml
@@ -7,4 +7,4 @@ toolchain:
   - gnuarmemb
   - xtools
 ram: 64
-flash: 32575
+flash: 1663

--- a/samples/subsys/ipc/ipm_mhu_dual_core/README.rst
+++ b/samples/subsys/ipc/ipm_mhu_dual_core/README.rst
@@ -18,6 +18,9 @@ steps are:
 Building and Running
 ********************
 
+On Musca A1
+-----------
+
 This project outputs 'IPM MHU sample on musca_a' to the console.
 It can be built and executed on Musca A1 CPU 0 as follows:
 
@@ -35,6 +38,40 @@ It can be built and executed on Musca A1 CPU 1 as follows:
    :board: v2m_musca_nonsecure
    :goals: run
    :compact:
+
+On Musca B1
+-----------
+
+This project outputs 'IPM MHU sample on musca_b1' to the console.
+It can be built and executed on Musca B1 CPU 0 as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/ipc/ipm_mhu_dual_core
+   :board: v2m_musca_b1
+   :goals: run
+   :compact:
+
+This project outputs 'IPM MHU sample on v2m_musca_b1_nonsecure' to the console.
+It can be built and executed on Musca B1 CPU 1 as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/ipc/ipm_mhu_dual_core
+   :board: v2m_musca_b1_nonsecure
+   :goals: run
+   :compact:
+
+Combine images for Musca
+========================
+
+A third-party tool (srecord) is used to generate the Intel formatted hex image.
+For more information refer to the `Srecord Manual`_.
+
+.. code-block:: bash
+
+   srec_cat zephyr.bin -Binary -offset $IMAGE_OFFSET zephyr_nonsecure.bin -Binary -offset $IMAGE_NS_OFFSET -o dual_core_zephyr.hex -Intel
+
+   # This command is an example for Musca B1
+   srec_cat zephyr.bin -Binary -offset 0xA000000 zephyr_nonsecure.bin -Binary -offset 0xA060400 -o dual_core_zephyr.hex -Intel
 
 Open a serial terminal (minicom, putty, etc.) and connect the board with the
 following settings:
@@ -61,3 +98,7 @@ Sample Output
    MHU ISR on CPU 0
    MHU ISR on CPU 1
    MHU Test Done.
+
+
+.. _Srecord Manual:
+   http://srecord.sourceforge.net/man/man1/srec_cat.html

--- a/samples/subsys/ipc/ipm_mhu_dual_core/sample.yaml
+++ b/samples/subsys/ipc/ipm_mhu_dual_core/sample.yaml
@@ -5,4 +5,4 @@ sample:
 tests:
   test:
     tags: ipm
-    platform_whitelist: v2m_musca v2m_musca_nonsecure
+    platform_whitelist: v2m_musca v2m_musca_nonsecure v2m_musca_b1 v2m_musca_b1_nonsecure

--- a/soc/arm/arm/musca_b1/soc.c
+++ b/soc/arm/arm/musca_b1/soc.c
@@ -8,6 +8,45 @@
 #include <init.h>
 #include <soc.h>
 
+/* (Secure System Control) Base Address */
+#define SSE_200_SYSTEM_CTRL_S_BASE	(0x50021000UL)
+#define SSE_200_SYSTEM_CTRL_INITSVTOR1	(SSE_200_SYSTEM_CTRL_S_BASE + 0x114)
+#define SSE_200_SYSTEM_CTRL_CPU_WAIT	(SSE_200_SYSTEM_CTRL_S_BASE + 0x118)
+#define SSE_200_CPU_ID_UNIT_BASE	(0x5001F000UL)
+
+#define NON_SECURE_FLASH_ADDRESS	(0x60000)
+#define NON_SECURE_FLASH_OFFSET	(0x10000000)
+#define BL2_HEADER_SIZE		(0x400)
+
+/**
+ * @brief Wake up CPU 1 from another CPU, this is plaform specific.
+ *
+ */
+void wakeup_cpu1(void)
+{
+	/* Set the Initial Secure Reset Vector Register for CPU 1 */
+	*(u32_t *)(SSE_200_SYSTEM_CTRL_INITSVTOR1) =
+					CONFIG_FLASH_BASE_ADDRESS +
+					BL2_HEADER_SIZE +
+					NON_SECURE_FLASH_ADDRESS -
+					NON_SECURE_FLASH_OFFSET;
+
+	/* Set the CPU Boot wait control after reset */
+	*(u32_t *)(SSE_200_SYSTEM_CTRL_CPU_WAIT) = 0;
+}
+
+/**
+ * @brief Get the current CPU ID, this is plaform specific.
+ *
+ * @return Current CPU ID
+ */
+u32_t sse_200_platform_get_cpu_id(void)
+{
+	volatile u32_t *p_cpu_id = (volatile u32_t *)SSE_200_CPU_ID_UNIT_BASE;
+
+	return (u32_t)*p_cpu_id;
+}
+
 /**
  * @brief Perform basic hardware initialization at boot.
  *

--- a/soc/arm/arm/musca_b1/soc.h
+++ b/soc/arm/arm/musca_b1/soc.h
@@ -13,4 +13,8 @@
 #include <sys/util.h>
 #endif
 
+extern void wakeup_cpu1(void);
+
+extern u32_t sse_200_platform_get_cpu_id(void);
+
 #endif /* _SOC_H_ */


### PR DESCRIPTION
Enable MHU on Musca B1 support for ipm_mhu_dual_core sample.

As we have put the platform specific functions into soc.c (sse_200_platform_get_cpu_id () and wakeup_cpu1()). The 2nd core image address can be different with the existing platforms.

Migrate to eFlash due to it's advantages compare to QSPI and Musca B1 has 2 x 2MB embedded flash memories connected to the AHB Master Expansion “Code Interface”.