### PR TITLE
drivers: Define COUNTER_LOG_LEVEL using template

### DIFF
--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -13,12 +13,9 @@ menuconfig COUNTER
 
 if COUNTER
 
-config COUNTER_LOG_LEVEL
-	int "Counter log level"
-	default 0
-	range 0 4
-	help
-	  Counter logging level.
+module = COUNTER
+module-str = counter
+source "subsys/logging/Kconfig.template.log_config"
 
 source "drivers/counter/Kconfig.gecko"
 


### PR DESCRIPTION
This commit updates counter Kconfig to use logger template to define COUNTER_LOG_LEVEL option.

This seems to be the last driver not using template mechanism.