### PR TITLE
Bluetooth: GATT: Fix assuming writes to CCC will always contain 2 bytes

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1197,15 +1197,19 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
 	struct bt_gatt_ccc_cfg *cfg;
 	u16_t value;
 
-	if (offset > sizeof(u16_t)) {
+	if (offset) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	if (offset + len > sizeof(u16_t)) {
+	if (!len || len > sizeof(u16_t)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	}
 
-	value = sys_get_le16(buf);
+	if (len < sizeof(u16_t)) {
+		value = *(u8_t *)buf;
+	} else {
+		value = sys_get_le16(buf);
+	}
 
 	cfg = find_ccc_cfg(conn, ccc);
 	if (!cfg) {


### PR DESCRIPTION
Although unlikely it is possible that a remote may attempt to send just
1 byte as the write request allows to do that:

BLUETOOTH CORE SPECIFICATION Version 5.1 | Vol 3, Part F
page 2320:

  'If the attribute value has a fixed length and the Attribute Value
  parameter length is less than or equal to the length of the attribute
  value, the octets of the attribute value parameter length shall be
  written; all other octets in this attribute value shall be
  unchanged.'

Fixes #16734

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>