### PR TITLE
Zephyr library extensions

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -330,19 +330,23 @@ endmacro()
 #
 # A Zephyr library can be constructed by the function zephyr_library
 # or zephyr_library_named. The constructors create a CMake library
-# with a name accessible through the variable ZEPHYR_CURRENT_LIBRARY.
+# which can be manipulated via extensions with zephyr_library in their
+# names.
 #
-# The variable ZEPHYR_CURRENT_LIBRARY should seldomly be needed since
-# the zephyr libraries have methods that modify the libraries. These
-# methods have the signature: zephyr_library_<target-function>
+# The variable ZEPHYR_CURRENT_LIBRARY contains the library name, but
+# this is an implementation detail that should not be relied upon,
+# since this file provides functions for modifying it. These functions
+# have the signatures zephyr_library_<target-function> and
+# <target_function>_zephyr_library.
 #
-# The methods are wrappers around the CMake target_* functions. See
+# The methods are wrappers around CMake functions for manipulating
+# targets. See
 # https://cmake.org/cmake/help/latest/manual/cmake-commands.7.html for
 # documentation on the underlying target_* functions.
 #
 # The methods modify the CMake target_* API to reduce boilerplate;
 #  PRIVATE is assumed
-#  The target is assumed to be ZEPHYR_CURRENT_LIBRARY
+#  The target is assumed to be the current library
 #
 # When a flag that is given through the zephyr_* API conflicts with
 # the zephyr_library_* API then precedence will be given to the

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -390,6 +390,10 @@ endfunction()
 #
 # zephyr_library versions of normal CMake target_<func> functions
 #
+function(zephyr_library_add_dependencies)
+  add_dependencies(${ZEPHYR_CURRENT_LIBRARY} ${ARGN})
+endfunction()
+
 function(zephyr_library_sources source)
   target_sources(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${source} ${ARGN})
 endfunction()
@@ -547,6 +551,23 @@ function(generate_inc_file_for_target
 
   add_custom_target(${generated_target_name} DEPENDS ${generated_file})
   generate_inc_file_for_gen_target(${target} ${source_file} ${generated_file} ${generated_target_name} ${ARGN})
+endfunction()
+
+function(generate_inc_file_for_gen_zephyr_library
+    source_file     # The source file to be converted to hex
+    generated_file  # The generated file
+    gen_target      # The generated file target we depend on
+                    # Any additional arguments are passed on to file2hex.py
+    )
+  generate_inc_file_for_gen_target(${ZEPHYR_CURRENT_LIBRARY} ${source_file} ${generated_file} ${gen_target} ${ARGN})
+endfunction()
+
+function(generate_inc_file_for_zephyr_library
+    source_file     # The source file to be converted to hex
+    generated_file  # The generated file
+                    # Any additional arguments are passed on to file2hex.py
+    )
+  generate_inc_file_for_target(${ZEPHYR_CURRENT_LIBRARY} ${source_file} ${generated_file} ${ARGN})
 endfunction()
 
 # 1.4. board_*

--- a/drivers/ieee802154/CMakeLists.txt
+++ b/drivers/ieee802154/CMakeLists.txt
@@ -13,5 +13,5 @@ if(CONFIG_NET_L2_OPENTHREAD)
   # files so we need express that this driver depends on OpenThread
   # being downloaded to make sure that we don't build this driver
   # before all of it's header file dependencies are met.
-  add_dependencies(${ZEPHYR_CURRENT_LIBRARY} ot)
+  zephyr_library_add_dependencies(ot)
 endif()

--- a/samples/net/updatehub/CMakeLists.txt
+++ b/samples/net/updatehub/CMakeLists.txt
@@ -18,7 +18,7 @@ if(CONFIG_UPDATEHUB_DTLS)
             privkey.der
             )
         generate_inc_file_for_target(
-            ${ZEPHYR_CURRENT_LIBRARY}
+            app
             src/certificates/${inc_file}
             ${gen_dir}/${inc_file}.inc
             )

--- a/soc/arm/nxp_lpc/lpc54xxx/CMakeLists.txt
+++ b/soc/arm/nxp_lpc/lpc54xxx/CMakeLists.txt
@@ -13,8 +13,5 @@ if (CONFIG_SLAVE_CORE_MCUX)
 
   add_custom_target(core_m0_inc_target DEPENDS ${gen_dir}/core-m0.inc)
 
-  generate_inc_file_for_gen_target(${ZEPHYR_CURRENT_LIBRARY}
-				   ${core_m0_image}
-				   ${gen_dir}/core-m0.inc
-				   core_m0_inc_target)
+  generate_inc_file_for_gen_zephyr_library(${core_m0_image} ${gen_dir}/core-m0.inc core_m0_inc_target)
 endif()


### PR DESCRIPTION
This PR adds some missing functions to our CMake extensions that are necessary to properly abstract away manipulating the zephyr library, uses them, and marks the internals of how these functions work "private" in the comments.