### PR TITLE
Bluetooth: Make RSSI value available to mesh applications

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -137,6 +137,9 @@ struct bt_mesh_msg_ctx {
 	/** Destination address of a received message. Not used for sending. */
 	u16_t recv_dst;
 
+	/** RSSI of received packet. Not used for sending. */
+	s8_t  recv_rssi;
+
 	/** Received TTL value. Not used for sending. */
 	u8_t  recv_ttl:7;
 

--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -141,10 +141,10 @@ struct bt_mesh_msg_ctx {
 	s8_t  recv_rssi;
 
 	/** Received TTL value. Not used for sending. */
-	u8_t  recv_ttl:7;
+	u8_t  recv_ttl;
 
 	/** Force sending reliably by using segment acknowledgement */
-	u8_t  send_rel:1;
+	bool  send_rel;
 
 	/** TTL, or BT_MESH_TTL_DEFAULT for default TTL. */
 	u8_t  send_ttl;

--- a/subsys/bluetooth/host/mesh/friend.c
+++ b/subsys/bluetooth/host/mesh/friend.c
@@ -876,7 +876,7 @@ init_friend:
 	frnd->clear.frnd = sys_be16_to_cpu(msg->prev_addr);
 
 	BT_DBG("LPN 0x%04x rssi %d recv_delay %u poll_to %ums",
-	       frnd->lpn, rx->rssi, frnd->recv_delay, frnd->poll_to);
+	       frnd->lpn, rx->ctx.recv_rssi, frnd->recv_delay, frnd->poll_to);
 
 	if (BT_MESH_ADDR_IS_UNICAST(frnd->clear.frnd) &&
 	    !bt_mesh_elem_find(frnd->clear.frnd)) {
@@ -884,12 +884,13 @@ init_friend:
 	}
 
 	k_delayed_work_submit(&frnd->timer,
-			      offer_delay(frnd, rx->rssi, msg->criteria));
+			      offer_delay(frnd, rx->ctx.recv_rssi,
+					  msg->criteria));
 
 	friend_cred_create(rx->sub, frnd->lpn, frnd->lpn_counter,
 			   frnd->counter);
 
-	enqueue_offer(frnd, rx->rssi);
+	enqueue_offer(frnd, rx->ctx.recv_rssi);
 
 	return 0;
 }

--- a/subsys/bluetooth/host/mesh/net.c
+++ b/subsys/bluetooth/host/mesh/net.c
@@ -1297,7 +1297,7 @@ void bt_mesh_net_recv(struct net_buf_simple *data, s8_t rssi,
 		      enum bt_mesh_net_if net_if)
 {
 	NET_BUF_SIMPLE_DEFINE(buf, 29);
-	struct bt_mesh_net_rx rx = { .rssi = rssi };
+	struct bt_mesh_net_rx rx = { .ctx.recv_rssi = rssi };
 	struct net_buf_simple_state state;
 
 	BT_DBG("rssi %d net_if %u", rssi, net_if);

--- a/subsys/bluetooth/host/mesh/net.h
+++ b/subsys/bluetooth/host/mesh/net.h
@@ -268,7 +268,6 @@ struct bt_mesh_net_rx {
 	       net_if:2,       /* Network interface */
 	       local_match:1,  /* Matched a local element */
 	       friend_match:1; /* Matched an LPN we're friends for */
-	s8_t   rssi;
 };
 
 /* Encoding context for Network/Transport data */

--- a/subsys/bluetooth/host/mesh/transport.c
+++ b/subsys/bluetooth/host/mesh/transport.c
@@ -455,7 +455,7 @@ int bt_mesh_trans_send(struct bt_mesh_net_tx *tx, struct net_buf_simple *msg,
 	}
 
 	if (msg->len > 11) {
-		tx->ctx->send_rel = 1U;
+		tx->ctx->send_rel = true;
 	}
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x dst 0x%04x", tx->sub->net_idx,


### PR DESCRIPTION
Move rssi value from bt_mesh_net_rx to bt_mesh_msg_ctx so that it becomes accessible from an application.