### PR TITLE
cmake: Toolchain abstraction: Introducing toolchain_cc_freestanding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,10 +200,12 @@ endif()
 # @Intent: Set compiler specific flags for standard C includes
 toolchain_cc_nostdinc()
 
+# @Intent: Set compiler specific flag for bare metal freestanding option
+toolchain_cc_freestanding()
+
 zephyr_compile_options(
   -g # TODO: build configuration enough?
   -imacros ${AUTOCONF_H}
-  -ffreestanding
   -fno-common
   ${TOOLCHAIN_C_FLAGS}
 )

--- a/cmake/compiler/gcc/target_baremetal.cmake
+++ b/cmake/compiler/gcc/target_baremetal.cmake
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# See root CMakeLists.txt for description and expectations of these macros
 
 macro(toolchain_cc_nostdinc)
 
@@ -9,5 +10,11 @@ macro(toolchain_cc_nostdinc)
     zephyr_compile_options( -nostdinc)
     zephyr_system_include_directories(${NOSTDINC})
   endif()
+
+endmacro()
+
+macro(toolchain_cc_freestanding)
+
+  zephyr_compile_options(-ffreestanding)
 
 endmacro()


### PR DESCRIPTION
The macro is intended to abstract the -ffreestanding compiler option
which tells the compiler that this is a bare metal env. The option is
compiler and thus toolchain specific, but this macro leaves it up to
the toolchain to decide the value of the option.

The intent here is to abstract Zephyr's dependence on toolchains,
thus allowing for easier porting to other, perhaps commercial,
toolchains and/or usecases.

No functional change expected.

Part of #16031