### PR TITLE
soc/arm/st_stm32: Replace STM32 specific core selection option

### DIFF
--- a/ext/hal/st/stm32cube/CMakeLists.txt
+++ b/ext/hal/st/stm32cube/CMakeLists.txt
@@ -32,7 +32,7 @@ set(stm_socs
   stm32wbx
   )
 
-if(CONFIG_STM32_CORE_CM4)
+if(CONFIG_CPU_CORTEX_M4)
   zephyr_compile_definitions( -DCORE_CM4 )
 endif()
 

--- a/soc/arm/st_stm32/stm32mp1/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32mp1/Kconfig.defconfig.series
@@ -12,10 +12,6 @@ source "soc/arm/st_stm32/stm32mp1/Kconfig.defconfig.stm32mp15_m4"
 config SOC_SERIES
 	default "stm32mp1"
 
-config STM32_CORE_CM4
-	bool "define stm32 core"
-	default y
-
 if GPIO_STM32
 
 config GPIO_STM32_PORTD


### PR DESCRIPTION
stm32mp1 was adding a STM32 specific Core selection Kconfig
symbol while zephyr generic CPU_CORTEX_M4 could be used for the
same purpose.
Remove STM32 specific symbol and use generic one.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>