### PR TITLE
scripts/dts: Sort instance IDs by reg addr

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -478,6 +478,28 @@ def main():
     create_aliases(root)
     create_chosen(root)
 
+    # Re-sort instance_id by reg addr
+    #
+    # Note: this is a short term fix and should be removed when
+    # generate defines for instance with a prefix like 'DT_INST'
+    #
+    # Build a dict of dicts, first level is index by compat
+    # second level is index by reg addr
+    compat_reg_dict = defaultdict(dict)
+    for node in reduced.values():
+        instance = node.get('instance_id')
+        if instance and node['addr'] is not None:
+            for compat in instance:
+                reg = node['addr']
+                compat_reg_dict[compat][reg] = node
+
+    # Walk the reg addr in sorted order to re-index 'instance_id'
+    for compat in compat_reg_dict:
+        # only update if we have more than one instance
+        if len(compat_reg_dict[compat]) > 1:
+            for idx, reg_addr in enumerate(sorted(compat_reg_dict[compat])):
+                compat_reg_dict[compat][reg_addr]['instance_id'][compat] = idx
+
     # Load any bindings (.yaml files) that match 'compatible' values from the
     # DTS
     load_bindings(root, args.yaml)


### PR DESCRIPTION
Because of how generate defines for instances its possible that we have a
name conflict if the instance ID and reg addr space clash.

For example on qemu_x86 there are current two 'soc-nv-flash' nodes and one
is at reg addr 0, but instance id 1, the other is reg addr 0x1000 and
instance id 0.  We'd possibly get this conflict:

For the 'soc-nv-flash' at 0x1000 (instance 0):
	(instance define)
	#define DT_SOC_NV_FLASH_0_BASE_ADDRESS          0x1000

For the 'soc-nv-flash' at 0x0 (instance 1):
	(address define)
	#define DT_SOC_NV_FLASH_0_BASE_ADDRESS          0x0

To deal with this we make sure that the lower reg address is instance 0,
than things work out ok.  To handle this case, if we sort the instance
IDs based on reg addr than if we have something at reg addr 0, it will
also than be an instand ID 0.

The longer term solution will be to deprecated the old defines and
remove the conflict between instance ID defines and normal DT defines.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>