### PR TITLE
arch: arm: fix start of MPU guard in stack-fail check (no user mode)

### DIFF
--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -287,11 +287,11 @@ u32_t z_check_thread_stack_fail(const u32_t fault_addr, const u32_t psp)
 		}
 	}
 #else /* CONFIG_USERSPACE */
-	if (IS_MPU_GUARD_VIOLATION(thread->stack_info.start,
+	if (IS_MPU_GUARD_VIOLATION(thread->stack_info.start -
+			MPU_GUARD_ALIGN_AND_SIZE,
 			fault_addr, psp)) {
 		/* Thread stack corruption */
-		return thread->stack_info.start +
-			MPU_GUARD_ALIGN_AND_SIZE;
+		return thread->stack_info.start;
 	}
 #endif /* CONFIG_USERSPACE */
 


### PR DESCRIPTION
When building without support for user mode (CONFIG_USERSPACE=n)
we need to correct the starting address of the MPU Guard, before
passing it to the function that evaluates whether a stack
corruption has occurred. The bug was introduced by 60bae5de38e3aadb70312882cb81bde4e87ffaf9 in
#13619, where the start address of the MPU guard was properly
corrected, but the guard start at the corresponding stack-fail
check was not adjusted accordingly.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>