### PR TITLE
doc: fix path to gdb in documentation

### DIFF
--- a/boards/arc/em_starterkit/doc/index.rst
+++ b/boards/arc/em_starterkit/doc/index.rst
@@ -272,8 +272,7 @@ console, from the build directory containing the output :file:`zephyr.elf`.
 .. code-block:: console
 
    $ cd <my app>
-   $ $ZEPHYR_SDK_INSTALL_DIR/sysroots/x86_64-pokysdk-linux/usr/bin/arc-zephyr-elf/arc-zephyr-elf-gdb \
-      zephyr.elf
+   $ $ZEPHYR_SDK_INSTALL_DIR/arc-zephyr-elf/bin/arc-zephyr-elf-gdb zephyr.elf
    (gdb) target remote localhost:3333
    (gdb) load
    (gdb) b main

--- a/boards/arc/iotdk/doc/index.rst
+++ b/boards/arc/iotdk/doc/index.rst
@@ -152,8 +152,7 @@ console, from the build directory containing the output :file:`zephyr.elf`.
 .. code-block:: console
 
    $ cd <my app>
-   $ $ZEPHYR_SDK_INSTALL_DIR/sysroots/x86_64-pokysdk-linux/usr/bin/ \
-      arc-zephyr-elf/arc-zephyr-elf-gdb zephyr.elf
+   $ $ZEPHYR_SDK_INSTALL_DIR/arc-zephyr-elf/bin/arc-zephyr-elf-gdb zephyr.elf
    (gdb) target remote localhost:3333
    (gdb) load
    (gdb) b main


### PR DESCRIPTION
Documents were still pointing to gdb path of old SDK.