### PR TITLE
net: make __net_buf_align 64-bit compatible

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -27,7 +27,7 @@ extern "C" {
  */
 
 /* Alignment needed for various parts of the buffer definition */
-#define __net_buf_align __aligned(sizeof(int))
+#define __net_buf_align __aligned(sizeof(void *))
 
 /**
  *  @def NET_BUF_SIMPLE_DEFINE


### PR DESCRIPTION
Structures to which this applies contain pointers. So the alignment
should depend on pointer width. On 32-bit builds this remains the same.