### PR TITLE
usb: enforce byte alignment on USB records

### DIFF
--- a/include/usb/bos.h
+++ b/include/usb/bos.h
@@ -9,9 +9,9 @@
 
 #if defined(CONFIG_USB_DEVICE_BOS)
 #define USB_DEVICE_BOS_DESC_DEFINE_HDR \
-	static __in_section(usb, bos_desc_area, 0) __used
+	static __in_section(usb, bos_desc_area, 0) __aligned(1) __used
 #define USB_DEVICE_BOS_DESC_DEFINE_CAP \
-	static __in_section(usb, bos_desc_area, 1) __used
+	static __in_section(usb, bos_desc_area, 1) __aligned(1) __used
 
 /* BOS descriptor type */
 #define DESCRIPTOR_TYPE_BOS		0x0F

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -49,17 +49,17 @@ extern "C" {
  * in predetermined order in the RAM.
  */
 #define USBD_DEVICE_DESCR_DEFINE(p) \
-	static __in_section(usb, descriptor_##p, 0) __used
+	static __in_section(usb, descriptor_##p, 0) __used __aligned(1)
 #define USBD_CLASS_DESCR_DEFINE(p, instance) \
-	static __in_section(usb, descriptor_##p.1, instance) __used
+	static __in_section(usb, descriptor_##p.1, instance) __used __aligned(1)
 #define USBD_MISC_DESCR_DEFINE(p) \
-	static __in_section(usb, descriptor_##p, 2) __used
+	static __in_section(usb, descriptor_##p, 2) __used __aligned(1)
 #define USBD_USER_DESCR_DEFINE(p) \
-	static __in_section(usb, descriptor_##p, 3) __used
+	static __in_section(usb, descriptor_##p, 3) __used __aligned(1)
 #define USBD_STRING_DESCR_DEFINE(p) \
-	static __in_section(usb, descriptor_##p, 4) __used
+	static __in_section(usb, descriptor_##p, 4) __used __aligned(1)
 #define USBD_TERM_DESCR_DEFINE(p) \
-	static __in_section(usb, descriptor_##p, 5) __used
+	static __in_section(usb, descriptor_##p, 5) __used __aligned(1)
 
 /*
  * This macro should be used to place the struct usb_cfg_data


### PR DESCRIPTION
As seen previously, some toolchain are willing to insert padding
at section changes to apply greater alignments by default. This is
especially true with 64-bit builds. USB structures are marked with the
packed attribute and therefore the linker section they land into
must also be byte aligned.