### PR TITLE
Bluetooth: L2CAP: Fix inverting of SCID and DCID on disconnect

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -883,7 +883,7 @@ rsp:
 	bt_l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
 }
 
-static struct bt_l2cap_le_chan *l2cap_remove_tx_cid(struct bt_conn *conn,
+static struct bt_l2cap_le_chan *l2cap_remove_rx_cid(struct bt_conn *conn,
 						    u16_t cid)
 {
 	struct bt_l2cap_chan *chan;
@@ -913,18 +913,18 @@ static void le_disconn_req(struct bt_l2cap *l2cap, u8_t ident,
 	struct bt_l2cap_le_chan *chan;
 	struct bt_l2cap_disconn_req *req = (void *)buf->data;
 	struct bt_l2cap_disconn_rsp *rsp;
-	u16_t scid;
+	u16_t dcid;
 
 	if (buf->len < sizeof(*req)) {
 		BT_ERR("Too small LE conn req packet size");
 		return;
 	}
 
-	scid = sys_le16_to_cpu(req->scid);
+	dcid = sys_le16_to_cpu(req->dcid);
 
-	BT_DBG("scid 0x%04x dcid 0x%04x", scid, sys_le16_to_cpu(req->dcid));
+	BT_DBG("dcid 0x%04x scid 0x%04x", dcid, sys_le16_to_cpu(req->scid));
 
-	chan = l2cap_remove_tx_cid(conn, scid);
+	chan = l2cap_remove_rx_cid(conn, dcid);
 	if (!chan) {
 		struct bt_l2cap_cmd_reject_cid_data data;
 
@@ -1053,18 +1053,18 @@ static void le_disconn_rsp(struct bt_l2cap *l2cap, u8_t ident,
 	struct bt_conn *conn = l2cap->chan.chan.conn;
 	struct bt_l2cap_le_chan *chan;
 	struct bt_l2cap_disconn_rsp *rsp = (void *)buf->data;
-	u16_t dcid;
+	u16_t scid;
 
 	if (buf->len < sizeof(*rsp)) {
 		BT_ERR("Too small LE disconn rsp packet size");
 		return;
 	}
 
-	dcid = sys_le16_to_cpu(rsp->dcid);
+	scid = sys_le16_to_cpu(rsp->scid);
 
-	BT_DBG("dcid 0x%04x scid 0x%04x", dcid, sys_le16_to_cpu(rsp->scid));
+	BT_DBG("dcid 0x%04x scid 0x%04x", sys_le16_to_cpu(rsp->dcid), scid);
 
-	chan = l2cap_remove_tx_cid(conn, dcid);
+	chan = l2cap_remove_rx_cid(conn, scid);
 	if (!chan) {
 		return;
 	}
@@ -1824,8 +1824,8 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan)
 				      ch->chan.ident, sizeof(*req));
 
 	req = net_buf_add(buf, sizeof(*req));
-	req->dcid = sys_cpu_to_le16(ch->tx.cid);
-	req->scid = sys_cpu_to_le16(ch->rx.cid);
+	req->dcid = sys_cpu_to_le16(ch->rx.cid);
+	req->scid = sys_cpu_to_le16(ch->tx.cid);
 
 	l2cap_chan_send_req(ch, buf, L2CAP_DISC_TIMEOUT);
 	bt_l2cap_chan_set_state(chan, BT_L2CAP_DISCONNECT);


### PR DESCRIPTION
For the Request:

DCID shall map to rx.cid:
  'This field specifies the endpoint of the channel to be disconnected
  on the device receiving this request.'

SCID shall map to tx.cid:
  'This field specifies the endpoint of the channel to be disconnected
  on the device sending this request.'

For the response when receiving the roles are inverted.

Fixes #16799

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>