### PR TITLE
dts: bindings: Fix missing "zephyr" vendor name

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -456,6 +456,7 @@ xunlong	Shenzhen Xunlong Software CO.,Limited
 ysoft	Y Soft Corporation a.s.
 zarlink	Zarlink Semiconductor
 zeitec	ZEITEC Semiconductor Co., LTD.
+zephyr	Zephyr-specific binding
 zidoo	Shenzhen Zidoo Technology Co., Ltd.
 zii	Zodiac Inflight Innovations
 zte	ZTE Corp.


### PR DESCRIPTION
Fix missing "zephyr" vendor name, currently used with `zephyr,sim-flash`, `zephyr,bt-hci-spi` and `zephyr,bt-hci-spi-slave`.
This avoid checkpatch warning : _DT compatible string vendor "zephyr" appears un-documented_
    
Signed-off-by: Yaël Boutreux <yael.boutreux@st.com>