### PR TITLE
scripts: gen_priv_stacks: remove unused variable

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -303,7 +303,7 @@
 /arch/x86/gen_idt.py                      @andrewboie
 /scripts/gen_kobject_list.py              @andrewboie
 /arch/x86/gen_mmu_x86.py                  @andrewboie
-/scripts/gen_priv_stacks.py               @agross-linaro
+/scripts/gen_priv_stacks.py               @andrewboie @agross-oss @ioannisg
 /scripts/gen_syscall_header.py            @andrewboie
 /scripts/gen_syscalls.py                  @andrewboie
 /scripts/process_gperf.py                 @andrewboie

--- a/scripts/gen_priv_stacks.py
+++ b/scripts/gen_priv_stacks.py
@@ -42,7 +42,6 @@ header = """%compare-lengths
 priv_stack_decl_temp = ("static u8_t __used"
                         " __aligned(CONFIG_PRIVILEGED_STACK_SIZE)"
                         " priv_stack_%x[CONFIG_PRIVILEGED_STACK_SIZE];\n")
-priv_stack_decl_size = "CONFIG_PRIVILEGED_STACK_SIZE"
 
 
 includes = """#include <kernel.h>


### PR DESCRIPTION
Variable `priv_stack_decl_size` is not used by the script,
so we can remove it.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>