### PR TITLE
Fix and improve 'west sign'

### DIFF
--- a/doc/guides/west/sign.rst
+++ b/doc/guides/west/sign.rst
@@ -35,8 +35,13 @@ Some additional notes follow. See ``west sign -h`` for detailed help.
 - If you don't have your own signing key and have a default MCUboot build, use
   ``--key path/to/mcuboot/root-rsa-2048.pem``.
 - By default, the output files produced by ``west sign`` are named
-  :file:`zephyr.signed.bin` and :file:`zephyr.signed.hex`. You can control this
-  using the ``-B`` and ``-H`` options, e.g.:
+  :file:`zephyr.signed.bin` and :file:`zephyr.signed.hex` and are created in the
+  build directory next to the unsigned :file:`zephyr.bin` and :file:`zephyr.hex`
+  versions.
+
+  You can control this using the ``-B`` and ``-H`` options, e.g. this would
+  create :file:`my-signed.bin` and :file:`my-signed.hex` in the current working
+  directory instead:
 
   .. code-block:: console
 
@@ -44,6 +49,7 @@ Some additional notes follow. See ``west sign -h`` for detailed help.
 
 Example build flow
 ******************
+
 For reference, here is an example showing how to build :ref:`hello_world` for
 MCUboot using ``west``:
 
@@ -51,9 +57,11 @@ MCUboot using ``west``:
 
    west build -b YOUR_BOARD samples/hello_world -- -DCONFIG_BOOTLOADER_MCUBOOT=y
    west sign -t imgtool -- --key YOUR_SIGNING_KEY.pem
-   west flash --hex-file zephyr.signed.hex
+   west flash --hex-file build/zephyr/zephyr.signed.hex
 
-Availability of a hex file depends on your build configuration.
+The availability of a hex file, and whether ``west flash`` uses it to flash,
+depends on your board and build configuration. At least the west flash runners
+using ``nrfjprog`` and ``pyocd`` work with the above flow.
 
 .. _MCUboot:
    https://mcuboot.com/

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -122,6 +122,9 @@ class BuildConfiguration:
         self.options = {}
         self._init()
 
+    def __contains__(self, item):
+        return item in self.options
+
     def __getitem__(self, item):
         return self.options[item]
 

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -16,7 +16,7 @@ from west.util import quote_sh_list
 from runners.core import BuildConfiguration
 
 from build_helpers import find_build_dir, \
-    BUILD_DIR_DESCRIPTION
+    FIND_BUILD_DIR_DESCRIPTION
 
 from zephyr_ext_common import Forceable, \
     cached_runner_config
@@ -81,7 +81,8 @@ class Sign(Forceable):
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description=self.description)
 
-        parser.add_argument('-d', '--build-dir', help=BUILD_DIR_DESCRIPTION)
+        parser.add_argument('-d', '--build-dir',
+                            help=FIND_BUILD_DIR_DESCRIPTION)
         self.add_force_arg(parser)
 
         # general options

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -102,9 +102,9 @@ class Sign(Forceable):
                            help='''produce a signed .bin file?
                             (default: yes, if supported)''')
         group.add_argument('-B', '--sbin', metavar='BIN',
-                           default='zephyr.signed.bin',
                            help='''signed .bin file name
-                           (default: zephyr.signed.bin)''')
+                           (default: zephyr.signed.bin in the build
+                           directory, next to zephyr.bin)''')
 
         # hex file options
         group = parser.add_argument_group('Intel HEX (.hex) file options')
@@ -113,9 +113,9 @@ class Sign(Forceable):
                            help='''produce a signed .hex file?
                            (default: yes, if supported)''')
         group.add_argument('-H', '--shex', metavar='HEX',
-                           default='zephyr.signed.hex',
                            help='''signed .hex file name
-                           (default: zephyr.signed.hex)''')
+                           (default: zephyr.signed.hex in the build
+                           directory, next to zephyr.hex)''')
 
         # defaults for hex/bin generation
         parser.set_defaults(gen_bin=True, gen_hex=True)
@@ -171,15 +171,19 @@ class ImgtoolSigner(Signer):
 
         # Build a signed .bin
         if args.gen_bin and runner_config.bin_file:
+            sbin = args.sbin or os.path.join(build_dir, 'zephyr',
+                                             'zephyr.signed.bin')
             sign_bin = self.sign_cmd(command, bcfg, runner_config.bin_file,
-                                     args.sbin)
+                                     sbin)
             log.dbg(quote_sh_list(sign_bin))
             subprocess.check_call(sign_bin)
 
         # Build a signed .hex
         if args.gen_hex and runner_config.hex_file:
+            shex = args.shex or os.path.join(build_dir, 'zephyr',
+                                             'zephyr.signed.hex')
             sign_hex = self.sign_cmd(command, bcfg, runner_config.hex_file,
-                                     args.shex)
+                                     shex)
             log.dbg(quote_sh_list(sign_hex))
             subprocess.check_call(sign_hex)
 


### PR DESCRIPTION
West sign was broken when build.dir-fmt was added.

Fix that and add some improvements while we are here.

This change breaks backwards compatibility; the default output
locations are now in the build directory.