### PR TITLE
ext/hal/microchip/mec/mec1501 Header update Port80 capture, timer, eS…

### DIFF
--- a/ext/hal/microchip/mec/mec1501/MEC1501hsz.h
+++ b/ext/hal/microchip/mec/mec1501/MEC1501hsz.h
@@ -303,9 +303,9 @@ typedef enum IRQn {
   */
 
 /* Peripheral and SRAM base address */
-#define CODE_SRAM_BASE          (0x000E0000UL)	/*!< (CODE SRAM ) Base Address */
-#define DATA_SRAM_BASE          (0x00118000UL)	/*!< (DATA SRAM ) Base Address */
-#define PERIPH_BASE             (0x40000000UL)	/*!< (Peripheral) Base Address */
+#define CODE_SRAM_BASE          0x000E0000UL	/*!< (CODE SRAM ) Base Address */
+#define DATA_SRAM_BASE          0x00118000UL	/*!< (DATA SRAM ) Base Address */
+#define PERIPH_BASE             0x40000000UL	/*!< (Peripheral) Base Address */
 
 /* Peripheral memory map */
 #define WDT_BASE            (PERIPH_BASE + 0x0400ul)	/*!< (WDT0   )  Base Address */
@@ -445,8 +445,10 @@ typedef enum IRQn {
 #include "component/led.h"
 #include "component/mailbox.h"
 #include "component/pcr.h"
+#include "component/port80cap.h"
 #include "component/port92.h"
 #include "component/smb.h"
+#include "component/tfdp.h"
 #include "component/timer.h"
 #include "component/uart.h"
 #include "component/vbat.h"
@@ -464,8 +466,8 @@ typedef enum IRQn {
 #define B16TMR0_REGS    ((BTMR_Type *) B16TMR0_BASE)
 #define B16TMR1_REGS    ((BTMR_Type *) B16TMR1_BASE)
 #define B32TMR0_REGS    ((BTMR_Type *) B32TMR0_BASE)
-#define B32TMR1_REGS    ((BTMR_Type *) B32TMR1_BASE)
-#define CCT_REGS        ((CCT_Type *) CCT_BASE)
+#define B32TMR1_REGS	((BTMR_Type *) B32TMR1_BASE)
+#define CCT_REGS	((CCT_Type *) (CCT_BASE))
 
 #define DMAM_REGS       ((DMAM_Type *) DMA_BASE)
 /* Individual DMA channels */
@@ -489,6 +491,8 @@ typedef enum IRQn {
 #define SMB4_REGS       ((I2C_SMB_Type *) SMB4_BASE)
 
 #define RTMR_REGS       ((RTMR_Type *) RTMR_BASE)
+
+#define TFDP_REGS	((TFDP_Type *) TFDP_BASE)
 
 #define HTMR0_REGS      ((HTMR_Type *) HTMR0_BASE)
 #define HTMR1_REGS      ((HTMR_Type *) HTMR1_BASE)
@@ -569,13 +573,16 @@ typedef enum IRQn {
 #define ESPI_MEM_BM_REGS  ((ESPI_MEM_BM_Type *)(ESPI_MEM_BM_BASE))
 
 /* eSPI Virtual Wire registers in IO component */
-#define ESPI_IO_VW_REGS      ((ESPI_IO_VW_Type *) ESPI_IO_VW_BASE)
+#define ESPI_IO_VW_REGS      ((ESPI_IO_VW_Type *) (ESPI_IO_VW_BASE))
 /* eSPI Virtual Wire registers for each group of 4 VWires */
-#define ESPI_M2S_VW_REGS    ((ESPI_M2S_VW_Type *) ESPI_VW_BASE)
+#define ESPI_M2S_VW_REGS    ((ESPI_M2S_VW_Type *) (ESPI_VW_BASE))
 #define ESPI_S2M_VW_REGS    ((ESPI_S2M_VW_Type *) (ESPI_SMVW_BASE))
 
 #define EMI0_REGS       ((EMI_Type *)(EMI0_BASE))
 #define EMI1_REGS       ((EMI_Type *)(EMI0_BASE))
+
+#define PORT80_CAP0_REGS	((PORT80_CAP_Type *)(P80CAP0_BASE))
+#define PORT80_CAP1_REGS	((PORT80_CAP_Type *)(P80CAP1_BASE))
 
 /** @} *//* End of group MEC1501 */
 

--- a/ext/hal/microchip/mec/mec1501/component/pcr.h
+++ b/ext/hal/microchip/mec/mec1501/component/pcr.h
@@ -154,7 +154,7 @@
  * bit[8]==1 system will allow entry to heavy sleep before PLL is locked.
  */
 #define MCHP_PCR_SYS_SLP_CTRL_SLP_PLL_LOCK		(0ul << 8)
-#define MCHP_PCR_SYS_SLP_CTRL_ALLOW_SLP_NO_PLL_LOCK	(0ul << 8)
+#define MCHP_PCR_SYS_SLP_CTRL_ALLOW_SLP_NO_PLL_LOCK	(1ul << 8)
 
 #define MCHP_PCR_SYS_SLP_LIGHT	0x08ul
 #define MCHP_PCR_SYS_SLP_HEAVY	0x09ul
@@ -487,6 +487,18 @@ mchp_pcr_periph_slp_ctrl(PCR_ID pcr_id, uint8_t enable)
 	} else {
 		REG32(raddr) &= ~(1ul << bitpos);
 	}
+}
+
+static __attribute__ ((always_inline)) inline void
+mchp_pcr_periph_reset(PCR_ID pcr_id)
+{
+	uintptr_t raddr = (uintptr_t) (MCHP_PCR_PERIPH_RST0_ADDR);
+	uint32_t bitpos = (uint32_t) pcr_id & 0x1F;
+
+	raddr += ((uint32_t) pcr_id >> 5);
+	REG32(MCHP_PCR_PERIPH_RESET_LOCK_ADDR) = MCHP_PCR_RSTEN_UNLOCK;
+	REG32(raddr) = (1ul << bitpos);
+	REG32(MCHP_PCR_PERIPH_RESET_LOCK_ADDR) = MCHP_PCR_RSTEN_LOCK;
 }
 
 #endif				// #ifndef _DEFS_H

--- a/ext/hal/microchip/mec/mec1501/component/port80cap.h
+++ b/ext/hal/microchip/mec/mec1501/component/port80cap.h
@@ -1,0 +1,152 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file port80cap.h
+ *MEC1501 Port80 Capture Registers
+ */
+/** @defgroup MEC1501 Peripherals Port80 Capture
+ */
+
+#ifndef _PORT80CAP_H
+#define _PORT80CAP_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "regaccess.h"
+
+/* ========================================================================*/
+/* ================		PORT80 Capture			===========*/
+/* ========================================================================*/
+
+#define MCHP_PORT80_CAP_0_BASE_ADDR		0x400F8000ul
+#define MCHP_PORT80_CAP_1_BASE_ADDR		0x400F8000ul
+
+#define MCHP_PORT80_CAP_0_GIRQ			15u
+#define MCHP_PORT80_CAP_0_GIRQ_POS		22u
+#define MCHP_PORT80_CAP_0_GIRQ_VAL		(1ul << 22)
+#define MCHP_PORT80_CAP_0_NVIC_AGGR		7u
+#define MCHP_PORT80_CAP_0_NVIC_DIRECT		62u
+
+#define MCHP_PORT80_CAP_1_GIRQ			15u
+#define MCHP_PORT80_CAP_1_GIRQ_POS		23u
+#define MCHP_PORT80_CAP_1_GIRQ_VAL		(1ul << 23)
+#define MCHP_PORT80_CAP_1_NVIC_AGGR		7u
+#define MCHP_PORT80_CAP_1_NVIC_DIRECT		63u
+
+/* Port80 Capture receive FIFO number of entries */
+#define MCHP_PORT80_CAP_MAX_FIFO_ENTRIES	16u
+
+/*
+ * HOST_DATA - Write-Only
+ */
+#define MCHP_PORT80_CAP_HOST_DATA_REG_MASK	0xFFul
+
+/*
+ * EC_DATA - Read-Only. Read as 32-bit.
+ * b[7:0]  = Read captured data byte from FIFO
+ * b[31:8] = Timestamp if enabled.
+ */
+#define MCHP_PORT80_CAP_EC_DATA_REG_MASK	0xFFFFFFFFul
+#define MCHP_PORT80_CAP_EC_DATA_POS		0u
+#define MCHP_PORT80_CAP_EC_DATA_MASK		0xFFul
+#define MCHP_PORT80_CAP_EC_DATA_TIMESTAMP_POS	8u
+#define MCHP_PORT80_CAP_EC_DATA_TIMESTAMP_MASK0	0x00FFFFFFul
+#define MCHP_PORT80_CAP_EC_DATA_TIMESTAMP_MASK	0xFFFFFF00ul
+
+/*
+ * Configuration
+ */
+#define MCHP_PORT80_CAP_CFG_REG_MASK		0xFFul
+/* Flush FIFO (Write-Only) */
+#define MCHP_PORT80_CAP_CFG_FLUSH_POS		1u
+#define MCHP_PORT80_CAP_CFG_FLUSH		(1ul << 1)
+/* Reset Timestamp (Write-Only) */
+#define MCHP_PORT80_CAP_CFG_TSRST_POS		2u
+#define MCHP_PORT80_CAP_CFG_TSRST		(1ul << 2u)
+/* Timestamp clock divider */
+#define MCHP_PORT80_CAP_CFG_TSDIV_POS		3u
+#define MCHP_PORT80_CAP_CFG_TSDIV_MASK0		0x03ul
+#define MCHP_PORT80_CAP_CFG_TSDIV_MASK		(0x03ul << 3)
+#define MCHP_PORT80_CAP_CFG_TSDIV_6MHZ		(0x00ul << 3)
+#define MCHP_PORT80_CAP_CFG_TSDIV_3MHZ		(0x01ul << 3)
+#define MCHP_PORT80_CAP_CFG_TSDIV_1P5MHZ	(0x02ul << 3)
+#define MCHP_PORT80_CAP_CFG_TSDIV_750KHZ	(0x03ul << 3)
+/* Timestamp Enable */
+#define MCHP_PORT80_CAP_CFG_TSEN_POS		5u
+#define MCHP_PORT80_CAP_CFG_TSEN_MASK		(1ul << 5)
+#define MCHP_PORT80_CAP_CFG_TSEN_ENABLE		(1ul << 5)
+/* FIFO threshold */
+#define MCHP_PORT80_CAP_CFG_FIFO_THR_POS	6u
+#define MCHP_PORT80_CAP_CFG_FIFO_THR_MASK0	0x03ul
+#define MCHP_PORT80_CAP_CFG_FIFO_THR_MASK	(0x03ul << 6)
+#define MCHP_PORT80_CAP_CFG_FIFO_THR_1		(0x00ul << 6)
+#define MCHP_PORT80_CAP_CFG_FIFO_THR_4		(0x01ul << 6)
+#define MCHP_PORT80_CAP_CFG_FIFO_THR_8		(0x02ul << 6)
+#define MCHP_PORT80_CAP_CFG_FIFO_THR_14		(0x03ul << 6)
+
+/*
+ * Status - Read-only does not clear status on read.
+ */
+#define MCHP_PORT80_CAP_STS_REG_MASK		0x03ul;
+/* Bit[0] FIFO not empty. Cleared by FW reading all content from FIFO */
+#define MCHP_PORT80_CAP_STS_NOT_EMPTY_POS	0u
+#define MCHP_PORT80_CAP_STS_NOT_EMPTY		(1ul << 0)
+/* Bit[1] Overrun. Host wrote data when FIFO is full */
+#define MCHP_PORT80_CAP_STS_OVERRUN_POS		1u
+#define MCHP_PORT80_CAP_STS_OVERRUN		(1u << 1)
+
+/*
+ * Count - R/W access to Port 80 counter
+ */
+#define MCHP_PORT80_CAP_CNT_REG_MASK		0xFFFFFF00ul
+#define MCHP_PORT80_CAP_CNT_POS			8u
+
+/*
+ * Port80 Capture Logical Device Activate register
+ */
+#define MCHP_PORT80_CAP_ACTV_MASK		0x01ul
+#define MCHP_PORT80_CAP_ACTV_ENABLE		0x01ul
+
+/**
+  * @brief Fast Port80 Capture Registers (PORT80_CAP_Type)
+  */
+typedef struct port80cap_regs
+ {
+ 	__OM  uint32_t HOST_DATA;	/*!< (@ 0x0000) Host Data b[7:0] write-only */
+	uint8_t RSVD1[0x100u - 0x04u];
+	__IM  uint32_t EC_DATA;		/*!< (@ 0x0100) EC Data. Read-only. */
+	__IOM uint32_t CONFIG;		/*!< (@ 0x0104) Configuration Mix of R/W and WO */
+	__IOM uint32_t STATUS;		/*!< (@ 0x0108) Status. Read-only */
+	__IOM uint32_t COUNT;		/*!< (@ 0x010C) Counter. R/W */
+	uint8_t RSVD3[0x0330ul - 0x0110ul];
+	__IOM uint32_t ACTV;		/*!< (@ 0x0330) Logical device Activate */
+} PORT80_CAP_Type;
+
+#endif	/* #ifndef _PORT80CAP_H */
+/* end port80cap.h */
+/**   @}
+ */

--- a/ext/hal/microchip/mec/mec1501/component/tfdp.h
+++ b/ext/hal/microchip/mec/mec1501/component/tfdp.h
@@ -1,0 +1,91 @@
+/**
+ *
+ * Copyright (c) 2019 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+/** @file tfdp.h
+ *MEC1501 TFDP Trace FIFO Debug Port Registers
+ */
+/** @defgroup MEC1501 Peripherals TFDP
+ */
+
+#ifndef _TFDP_H
+#define _TFDP_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "regaccess.h"
+
+/* =========================================================================*/
+/* ================		TFDP			=================== */
+/* =========================================================================*/
+
+#define MCHP_TFDP_BASE_ADDR	0x40008c00ul
+
+#define MCHP_TFDP_DATA_OUT_ADDR	((MCHP_TFDP_BASE_ADDR) + 0)
+#define MCHP_TFDP_CTRL_ADDR	((MCHP_TFDP_BASE_ADDR) + 4ul)
+
+#define MCHP_TFDP_CTRL_REG_MASK		0x7Ful
+#define MCHP_TFDP_CTRL_EN_POS		0u
+#define MCHP_TFDP_CTRL_EDGE_SEL_POS	1u
+#define MCHP_TFDP_CTRL_DIV_SEL_POS	2u
+#define MCHP_TFDP_CTRL_IP_DLY_POS	4u
+
+#define MCHP_TFDP_CTRL_EN		(1ul << 0)
+
+#define MCHP_TFDP_OUT_ON_RISING_EDGE	(0ul << 1)
+#define MCHP_TFDP_OUT_ON_FALLING_EDGE	(1ul << 1)
+#define MCHP_TFDP_CLK_AHB_DIV_2		(0ul << 2)
+#define MCHP_TFDP_CLK_AHB_DIV_4		(1ul << 2)
+#define MCHP_TFDP_CLK_AHB_DIV_8		(2ul << 2)
+#define MCHP_TFDP_CLK_AHB_DIV_2_ALT	(3ul << 2)
+
+/* Number of AHB clocks between each byte shifted out */
+#define MCHP_TFDP_IP_DLY_1		(0ul << 4)
+#define MCHP_TFDP_IP_DLY_2		(1ul << 4)
+#define MCHP_TFDP_IP_DLY_3		(2ul << 4)
+#define MCHP_TFDP_IP_DLY_4		(3ul << 4)
+#define MCHP_TFDP_IP_DLY_5		(4ul << 4)
+#define MCHP_TFDP_IP_DLY_6		(5ul << 4)
+#define MCHP_TFDP_IP_DLY_7		(6ul << 4)
+#define MCHP_TFDP_IP_DLY_8		(7ul << 4)
+
+/* First byte indicates start of packet */
+#define MCHP_TFDP_PKT_START		0xFDu
+
+/**
+  * @brief Trace FIFO Debug Port Registers (TFDP)
+  */
+typedef struct tfdp_regs
+{
+	__IOM uint8_t  DATA_OUT;	/*!< (@ 0x0000) Data out shift register */
+	uint8_t RSVD1[3];
+	__IOM uint32_t  CTRL;		/*!< (@ 0x0004) Control register */
+} TFDP_Type;
+
+#endif	/* #ifndef _TFDP_H */
+/* end tfdp.h */
+/**   @}
+ */

--- a/ext/hal/microchip/mec/mec1501/component/timer.h
+++ b/ext/hal/microchip/mec/mec1501/component/timer.h
@@ -125,6 +125,35 @@
 #define MCHP_BTMR_CTRL_COUNT_DIR_POS	2u
 #define MCHP_BTMR_CTRL_ENABLE_POS	0u
 
+/* Basic Timer interrupt routing */
+#define MCHP_B16TMR0_GIRQ	23u
+#define MCHP_B16TMR1_GIRQ	23u
+#define MCHP_B32TMR0_GIRQ	23u
+#define MCHP_B32TMR1_GIRQ	23u
+
+/* Bit position in GIRQ Source, Enable-Set/Clr, and Result registers */
+#define MCHP_B16TMR0_GIRQ_POS	0u
+#define MCHP_B16TMR1_GIRQ_POS	1u
+#define MCHP_B32TMR0_GIRQ_POS	4u
+#define MCHP_B32TMR1_GIRQ_POS	5u
+
+#define MCHP_B16TMR0_GIRQ_VAL	(1ul << 0)
+#define MCHP_B16TMR1_GIRQ_VAL	(1ul << 1)
+#define MCHP_B32TMR0_GIRQ_VAL	(1ul << 4)
+#define MCHP_B32TMR1_GIRQ_VAL	(1ul << 5)
+
+/* Basic timer GIRQ aggregated NVIC input */
+#define MCHP_B16TMR0_NVIC_AGGR	14u
+#define MCHP_B16TMR1_NVIC_AGGR	14u
+#define MCHP_B32TMR0_NVIC_AGGR	14u
+#define MCHP_B32TMR1_NVIC_AGGR	14u
+
+/* Basic timer direct NVIC inputs */
+#define MCHP_B16TMR0_NVIC_DIRECT	136u
+#define MCHP_B16TMR1_NVIC_DIRECT	137u
+#define MCHP_B32TMR0_NVIC_DIRECT	140u
+#define MCHP_B32TMR1_NVIC_DIRECT	141u
+
 /* =========================================================================*/
 /* ================   32/16-bit Basic Timer		   ================ */
 /* =========================================================================*/
@@ -134,7 +163,7 @@
   * @note Basic timers 0 & 1 are 16-bit, 2 & 3 are 32-bit.
   */
 typedef struct btmr_regs
-{		/*!< (@ 0x40000C00) BTMR Structure	  */
+{
 	__IOM uint32_t CNT;	/*!< (@ 0x00000000) BTMR Count		  */
 	__IOM uint32_t PRLD;	/*!< (@ 0x00000004) BTMR Preload	  */
 	__IOM uint8_t  STS;	/*!< (@ 0x00000008) BTMR Status		  */
@@ -178,6 +207,25 @@ typedef struct btmr_regs
  */
 #define MCHP_HTMR_CNT_STOP_VALUE	0u
 
+/* Hibernation timer interrupt routing */
+#define MCHP_HTMR0_GIRQ		23u
+#define MCHP_HTMR1_GIRQ		23u
+
+/* Bit position in GIRQ Source, Enable-Set/Clr, and Result registers */
+#define MCHP_HTMR0_GIRQ_POS	16u
+#define MCHP_HTMR1_GIRQ_POS	17u
+
+#define MCHP_HTMR0_GIRQ_VAL	(1ul << 16)
+#define MCHP_HTMR1_GIRQ_VAL	(1ul << 17)
+
+/* Hibernation timer GIRQ aggregated NVIC input */
+#define MCHP_HTMR0_NVIC_AGGR	14u
+#define MCHP_GTMR1_NVIC_AGGR	14u
+
+/* Hibernation timer direct NVIC inputs */
+#define MCHP_HTMR0_NVIC_DIRECT	112u
+#define MCHP_HTMR1_NVIC_DIRECT	113u
+
 /**
   * @brief Hibernation Timer (HTMR)
   */
@@ -216,24 +264,66 @@ typedef struct htmr_regs
 #define MCHP_CCT_CTRL_COMP1_EN		(1ul << 9)
 #define MCHP_CCT_CTRL_COMP1_SET		(1ul << 16)	/* R/WS */
 #define MCHP_CCT_CTRL_COMP0_SET		(1ul << 17)	/* R/WS */
+#define MCHP_CCT_CTRL_COMP1_CLR		(1ul << 24)	/* R/W1C */
+#define MCHP_CCT_CTRL_COMP0_CLR		(1ul << 25)	/* R/W1C */
+
+
+/* Capture Compare timer interrupt routing */
+#define MCHP_CCT_GIRQ		18u
+
+/* Bit position in GIRQ Source, Enable-Set/Clr, and Result registers */
+#define MCHP_CCT_TMR_GIRQ_POS	20u
+#define MCHP_CCT_CAP0_GIRQ_POS	21u
+#define MCHP_CCT_CAP1_GIRQ_POS	22u
+#define MCHP_CCT_CAP2_GIRQ_POS	23u
+#define MCHP_CCT_CAP3_GIRQ_POS	24u
+#define MCHP_CCT_CAP4_GIRQ_POS	25u
+#define MCHP_CCT_CAP5_GIRQ_POS	26u
+#define MCHP_CCT_CMP0_GIRQ_POS	27u
+#define MCHP_CCT_CMP1_GIRQ_POS	28u
+
+#define MCHP_CCT_TMR_GIRQ_VAL	(1ul << 20)
+#define MCHP_CCT_CAP0_GIRQ_VAL	(1ul << 21)
+#define MCHP_CCT_CAP1_GIRQ_VAL	(1ul << 22)
+#define MCHP_CCT_CAP2_GIRQ_VAL	(1ul << 23)
+#define MCHP_CCT_CAP3_GIRQ_VAL	(1ul << 24)
+#define MCHP_CCT_CAP4_GIRQ_VAL	(1ul << 25)
+#define MCHP_CCT_CAP5_GIRQ_VAL	(1ul << 26)
+#define MCHP_CCT_CMP0_GIRQ_VAL	(1ul << 27)
+#define MCHP_CCT_CMP1_GIRQ_VAL	(1ul << 28)
+#define MCHP_CCT_GIRQ_VAL_ALL	0x1FF00000ul
+
+/* Capture Compare timer GIRQ aggregated NVIC input */
+#define MCHP_CCT_NVIC_AGGR	10u
+
+/* Capture Compare timer direct NVIC inputs */
+#define MCHP_CCT_TMR_NVIC_DIRECT	146u
+#define MCHP_CCT_CAP0_NVIC_DIRECT	147u
+#define MCHP_CCT_CAP1_NVIC_DIRECT	148u
+#define MCHP_CCT_CAP2_NVIC_DIRECT	149u
+#define MCHP_CCT_CAP3_NVIC_DIRECT	150u
+#define MCHP_CCT_CAP4_NVIC_DIRECT	151u
+#define MCHP_CCT_CAP5_NVIC_DIRECT	152u
+#define MCHP_CCT_CMP0_NVIC_DIRECT	153u
+#define MCHP_CCT_CMP1_NVIC_DIRECT	154u
 
 /**
   * @brief Capture/Compare Timer (CCT)
   */
 typedef struct cct_regs
-{		/*!< (@ 0x40001000) CCT Structure	  */
-	__IOM uint32_t CTRL;	/*!< (@ 0x00000000) CCT Control		  */
+{
+	__IOM uint32_t CTRL;		/*!< (@ 0x00000000) CCT Control */
 	__IOM uint32_t CAP0_CTRL;	/*!< (@ 0x00000004) CCT Capture 0 Control */
 	__IOM uint32_t CAP1_CTRL;	/*!< (@ 0x00000008) CCT Capture 1 Control */
-	__IOM uint32_t FREE_RUN;	/*!< (@ 0x0000000C) CCT Free run counter  */
-	__IOM uint32_t CAP0;	/*!< (@ 0x00000010) CCT Capture 0	  */
-	__IOM uint32_t CAP1;	/*!< (@ 0x00000014) CCT Capture 1	  */
-	__IOM uint32_t CAP2;	/*!< (@ 0x00000018) CCT Capture 2	  */
-	__IOM uint32_t CAP3;	/*!< (@ 0x0000001C) CCT Capture 3	  */
-	__IOM uint32_t CAP4;	/*!< (@ 0x00000020) CCT Capture 4	  */
-	__IOM uint32_t CAP5;	/*!< (@ 0x00000024) CCT Capture 5	  */
-	__IOM uint32_t COMP0;	/*!< (@ 0x00000028) CCT Compare 0	  */
-	__IOM uint32_t COMP1;	/*!< (@ 0x0000002C) CCT Compare 1	  */
+	__IOM uint32_t FREE_RUN;	/*!< (@ 0x0000000C) CCT Free run counter */
+	__IOM uint32_t CAP0;		/*!< (@ 0x00000010) CCT Capture 0 */
+	__IOM uint32_t CAP1;		/*!< (@ 0x00000014) CCT Capture 1 */
+	__IOM uint32_t CAP2;		/*!< (@ 0x00000018) CCT Capture 2 */
+	__IOM uint32_t CAP3;		/*!< (@ 0x0000001C) CCT Capture 3 */
+	__IOM uint32_t CAP4;		/*!< (@ 0x00000020) CCT Capture 4 */
+	__IOM uint32_t CAP5;		/*!< (@ 0x00000024) CCT Capture 5 */
+	__IOM uint32_t COMP0;		/*!< (@ 0x00000028) CCT Compare 0 */
+	__IOM uint32_t COMP1;		/*!< (@ 0x0000002C) CCT Compare 1 */
 } CCT_Type;
 
 /* =========================================================================*/
@@ -264,6 +354,20 @@ typedef struct cct_regs
 #define MCHP_RTMR_CTRL_FW_HALT_EN_POS	4u
 #define MCHP_RTMR_CTRL_FW_HALT_EN_MASK	(1ul << (MCHP_RTMR_CTRL_FW_HALT_EN_POS))
 #define MCHP_RTMR_CTRL_FW_HALT_EN	(1ul << (MCHP_RTMR_CTRL_FW_HALT_EN_POS))
+
+/* RTOS timer interrupt routing */
+#define MCHP_RTMR_GIRQ		23u
+
+/* Bit position in GIRQ Source, Enable-Set/Clr, and Result registers */
+#define MCHP_RTMR_GIRQ_POS	10u
+
+#define MCHP_RTMR_GIRQ_VAL	(1ul << 10)
+
+/* RTOS timer GIRQ aggregated NVIC input */
+#define MCHP_RTMR_NVIC_AGGR	14u
+
+/* RTOS timer direct NVIC inputs */
+#define MCHP_RTMR_NVIC_DIRECT	111u
 
 /**
   * @brief RTOS Timer (RTMR)
@@ -337,6 +441,32 @@ typedef struct rtmr_regs
 	(1ul << (MCHP_WKTMR_SWKC_AUTO_RELOAD_POS))
 #define MCHP_WKTMR_SWKC_AUTO_RELOAD \
 	(1ul << (MCHP_WKTMR_SWKC_AUTO_RELOAD_POS))
+
+/* Week timer interrupt routing */
+#define MCHP_WKTMR_GIRQ		21u
+
+/* Bit position in GIRQ Source, Enable-Set/Clr, and Result registers */
+#define MCHP_WKTMR_ALARM_GIRQ_POS	3u
+#define MCHP_WKTMR_SUBWK_GIRQ_POS	4u
+#define MCHP_WKTMR_ONESEC_GIRQ_POS	5u
+#define MCHP_WKTMR_SUBSEC_GIRQ_POS	6u
+#define MCHP_WKTMR_SUSPWR_GIRQ_POS	7u
+
+#define MCHP_WKTMR_ALARM_GIRQ_VAL	(1ul << 3)
+#define MCHP_WKTMR_SUBWK_GIRQ_VAL	(1ul << 4)
+#define MCHP_WKTMR_ONESEC_GIRQ_VAL	(1ul << 5)
+#define MCHP_WKTMR_SUBSEC_GIRQ_VAL	(1ul << 6)
+#define MCHP_WKTMR_SUSPWR_GIRQ_VAL	(1ul << 7)
+
+/* Capture Compare timer GIRQ aggregated NVIC input */
+#define MCHP_WKTMR_NVIC_AGGR		13u
+
+/* Capture Compare timer direct NVIC inputs */
+#define MCHP_WKTMR_ALARM_NVIC_DIRECT	114u
+#define MCHP_WKTMR_SUBWK_NVIC_DIRECT	115u
+#define MCHP_WKTMR_ONESEC_NVIC_DIRECT	116u
+#define MCHP_WKTMR_SUBSEC_NVIC_DIRECT	117u
+#define MCHP_WKTMR_SUSPWR_NVIC_DIRECT	118u
 
 /**
   * @brief Week Timer (WKTMR)


### PR DESCRIPTION
…PI, TFDP

Updated MEC1501 HAL headers. Add interrupt routing defines for timers. Fix
eSPI virtual wire source access. Add new headers for Port80 capture and
TFDP.

Signed-off-by: Scott Worley <scott.worley@microchip.com>