### PR TITLE
boards: stm32f469i_disco: add more leds to board

### DIFF
--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -49,6 +49,9 @@
 
 	aliases {
 		led0 = &green_led_1;
+		led1 = &orange_led_2;
+		led2 = &red_led_3;
+		led3 = &blue_led_4;
 		sw0 = &user_button;
 	};
 };


### PR DESCRIPTION
Fixes "basic disco sample fails" #16687

Signed-off-by: francois ramu <francois.ramu@st.com>