### PR TITLE
wifi: eswifi: init net_pkt cursor after net_pkt_write

### DIFF
--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -97,6 +97,7 @@ static void eswifi_off_read_work(struct k_work *work)
 		LOG_WRN("Incomplete buffer copy");
 	}
 
+	net_pkt_cursor_init(pkt);
 	socket->recv_cb(socket->context, pkt,
 			NULL, NULL, 0, socket->user_data);
 	k_sem_give(&socket->read_sem);


### PR DESCRIPTION
Initialize the net_pkt cursor to begining after net_pkt_write.
Without which recv_cb can't peek/get net_pkt

Signed-off-by: Parthiban Nallathambi <parthitce@gmail.com>