### PR TITLE
net: nbr: Set the link address type when saving neighbor data

### DIFF
--- a/subsys/net/ip/nbr.c
+++ b/subsys/net/ip/nbr.c
@@ -126,6 +126,7 @@ int net_nbr_link(struct net_nbr *nbr, struct net_if *iface,
 	net_linkaddr_set(&net_neighbor_lladdr[avail].lladdr, lladdr->addr,
 			 lladdr->len);
 	net_neighbor_lladdr[avail].lladdr.len = lladdr->len;
+	net_neighbor_lladdr[avail].lladdr.type = lladdr->type;
 
 	nbr->iface = iface;
 


### PR DESCRIPTION
The neighbor cache did not contain link address type. This is not
causing problems atm but good to fix anyway.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>