### PR TITLE
net: utils: Print pkt value in net_pkt_hexdump()

### DIFF
--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -147,13 +147,16 @@ static inline void net_hexdump(const char *str,
 static inline void net_pkt_hexdump(struct net_pkt *pkt, const char *str)
 {
 	struct net_buf *buf = pkt->buffer;
+	char pkt_str[sizeof("0x") + sizeof(intptr_t) * 2];
 
 	if (str && str[0]) {
 		LOG_DBG("%s", str);
 	}
 
+	snprintk(pkt_str, sizeof(pkt_str), "%p", pkt);
+
 	while (buf) {
-		LOG_HEXDUMP_DBG(buf->data, buf->len, "");
+		LOG_HEXDUMP_DBG(buf->data, buf->len, pkt_str);
 		buf = buf->frags;
 	}
 }


### PR DESCRIPTION
It is useful in debugging if net_pkt pointer value is printed
in net_pkt_hexdump().

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>