### PR TITLE
boards: mimxrt*: Temporarily disable Ethernet [REVERT ME]

### DIFF
--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
@@ -18,6 +18,5 @@ supported:
   - display
   - i2c
   - spi
-  - netif:eth
   - hwinfo
   - usb_device

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
@@ -16,5 +16,4 @@ ram: 32768
 flash: 8192
 supported:
   - spi
-  - netif:eth
   - hwinfo

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -17,5 +17,4 @@ flash: 4096
 supported:
   - display
   - hwinfo
-  - netif:eth
   - i2c


### PR DESCRIPTION
Many of the networking PRs are failing in these boards because
of this build error:

ERROR: section nocache is 128 bytes in the virtual/runtime address \
space, but only 0 in the loaded/XIP section!

See #16778 for details.

So temporarily disable Ethernet support so that unrelated PRs can
be merged. This should be reverted after the root cause is found
and #16778 is fixed.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>