### PR TITLE
cmake: Toolchain abstraction: Introducing macro toolchain_cc_cstd_flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -984,8 +984,10 @@ get_property(GKSF GLOBAL PROPERTY GENERATED_KERNEL_SOURCE_FILES)
 get_property(CSTD GLOBAL PROPERTY CSTD)
 set_ifndef(CSTD c99)
 
+# @Intent: Obtain compiler specific flag for specifying the c standard
+toolchain_cc_cstd_flag(CC_CSTD ${CSTD})
 zephyr_compile_options(
-  $<$<COMPILE_LANGUAGE:C>:-std=${CSTD}>
+  $<$<COMPILE_LANGUAGE:C>:${CC_CSTD}>
 )
 
 # @Intent: Configure linker scripts, i.e. generate linker scripts with variables substituted

--- a/cmake/compiler/gcc/target_base.cmake
+++ b/cmake/compiler/gcc/target_base.cmake
@@ -12,3 +12,9 @@ macro(toolchain_cc_nocommon)
   zephyr_compile_options(-fno-common)
 
 endmacro()
+
+macro(toolchain_cc_cstd_flag dest_var_name c_std)
+
+  set_ifndef(${dest_var_name} "-std=${c_std}")
+
+endmacro()


### PR DESCRIPTION
The macro obtains the toolchain specific flag and value for
setting of the requested c standard.

The intent here is to abstract Zephyr's dependence on toolchains,
thus allowing for easier porting to other, perhaps commercial,
toolchains and/or usecases.

No functional change expected.

Part of #16031