### PR TITLE
drivers/i2c: Add missing HAS_DTS_I2C to sbcon

### DIFF
--- a/boards/nios2/altera_max10/dts_fixup.h
+++ b/boards/nios2/altera_max10/dts_fixup.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2019 Linaro Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file is a temporary workaround for mapping of the generated information
+ * to the current driver definitions.  This will be removed when the drivers
+ * are modified to handle the generated information, or the mapping of
+ * generated data matches the driver definitions.
+ */
+
+#define CONFIG_I2C_0_NAME		DT_NIOS2_I2C_100200_LABEL

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -300,6 +300,7 @@ config I2C_BITBANG
 config I2C_NIOS2
 	bool "Nios-II I2C driver"
 	depends on HAS_ALTERA_HAL
+	select HAS_DTS_I2C
 	help
 	  Enable the Nios-II I2C driver.
 

--- a/drivers/i2c/Kconfig.sbcon
+++ b/drivers/i2c/Kconfig.sbcon
@@ -8,3 +8,4 @@ menuconfig I2C_SBCON
 	bool "I2C driver for ARM's SBCon two-wire serial bus interface"
 	depends on ARM
 	select I2C_BITBANG
+	select HAS_DTS_I2C


### PR DESCRIPTION
The ARM SBCON I2C driver supported DTS, but missed HAS_DTS_I2C in
Kconfig for it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>