### PR TITLE
Bluetooth: Fix not using log_strdup() for bt_uuid_str()

### DIFF
--- a/include/bluetooth/uuid.h
+++ b/include/bluetooth/uuid.h
@@ -471,7 +471,10 @@ int bt_uuid_cmp(const struct bt_uuid *u1, const struct bt_uuid *u2);
  */
 void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len);
 
-/** @brief Convert Bluetooth UUID to string in place.
+const char *bt_uuid_str_real(const struct bt_uuid *uuid);
+
+/** @def bt_uuid_str
+ *  @brief Convert Bluetooth UUID to string in place.
  *
  *  Converts Bluetooth UUID to string in place. UUID has to be in 16 bits or
  *  128 bits format.
@@ -480,7 +483,7 @@ void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len);
  *
  *  @return String representation of the UUID given
  */
-const char *bt_uuid_str(const struct bt_uuid *uuid);
+#define bt_uuid_str(_uuid) log_strdup(bt_uuid_str_real(_uuid))
 #else
 static inline void bt_uuid_to_str(const struct bt_uuid *uuid, char *str,
 				  size_t len)

--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -110,7 +110,7 @@ void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len)
 	}
 }
 
-const char *bt_uuid_str(const struct bt_uuid *uuid)
+const char *bt_uuid_str_real(const struct bt_uuid *uuid)
 {
 	static char str[37];
 


### PR DESCRIPTION
The string returned by bt_uuid_str() is not in ROM so log_strdup()
must be used on it. This also eliminates the following kind of warning
messages: "<err> log: argument 3 in log message "%s: start_handle
0x%04x end_handle 0x%04x type %s" missing log_strdup()."

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>