### PR TITLE
Bluetooth: ATT: Queue buffers on bt_att_send

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2267,7 +2267,9 @@ int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb,
 
 	err = att_send(conn, buf, cb, user_data);
 	if (err) {
-		k_sem_give(&att->tx_sem);
+		if (!cb) {
+			k_sem_give(&att->tx_sem);
+		}
 		return err;
 	}
 


### PR DESCRIPTION
This prevents threads to block which may deadlock when system wq is
used.

Fixes #16803

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>