### PR TITLE
prf.c: implement the ll length modifiers

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -75,4 +75,12 @@ config MINIMAL_LIBC_MALLOC_ARENA_SIZE
 	  malloc() implementation. This size value must be compatible with
 	  a sys_mem_pool definition with nmax of 1 and minsz of 16.
 
+config MINIMAL_LIBC_LL_PRINTF
+	bool "Build with minimal libc long long printf" if !64BIT
+	depends on !NEWLIB_LIBC
+	default y if 64BIT
+	help
+	  Build with long long printf enabled. This will increase the size of
+	  the image.
+
 endmenu


### PR DESCRIPTION
This allows for printing long long values. Because the code size
increase may be significant, this is made optional on 32-bit targets.
On 64-bit targets this doesn't change the code much as longs and
long longs are the same size so it is always enabled in that case.

The test on MAXFLD has to be adjusted accordingly. Yet, its minimum
value wasn't large enough to store a full-scale octal value, so this
is fixed as well.