### PR TITLE
tests: kernel: userspace: correct address of thread priv stack start

### DIFF
--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -1095,8 +1095,7 @@ void test_main(void)
 	k_mem_domain_add_thread(&dom0, k_current_get());
 
 #if defined(CONFIG_ARM)
-	priv_stack_ptr = (int *)z_priv_stack_find(ztest_thread_stack) -
-		MPU_GUARD_ALIGN_AND_SIZE;
+	priv_stack_ptr = (int *)z_priv_stack_find(ztest_thread_stack);
 
 #endif
 	k_thread_access_grant(k_current_get(),


### PR DESCRIPTION
In ARM architecture z_priv_stack_find() returns the start of a
thread's privilege stack; we do not need to subtract the length
of a (possible) stack guard. This commit corrects the assigning
of the start address of a thread privilege stack in
test/kerne/mem_protect/mem_protect/userspace.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>