### PR TITLE
dts/bindings: Rename stringlist to string-array

### DIFF
--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -19,7 +19,7 @@ properties:
         category: optional
 
     reg-names:
-        type: stringlist
+        type: string-array
         description: name of each register space
         generation: define
         category: optional
@@ -31,7 +31,7 @@ properties:
         generation: define
 
     interrupt-names:
-        type: stringlist
+        type: string-array
         category: optional
         description: name of each interrupt
         generation: define

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -7,7 +7,7 @@ description: >
 
 properties:
     compatible:
-        type: string
+        type: string-array
         category: required
         description: compatible strings
         generation: define

--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -26,7 +26,7 @@ properties:
 #
 #   <name of the property in the device tree - regexes are supported>:
 #     category: <required | optional>
-#     type: <string | int | boolean | array | compound>
+#     type: <string | int | boolean | array | string-array | compound>
 #     description: <description of property>
 #     generation: define
 #


### PR DESCRIPTION
* Rename stringlist to string-array to be closer inline with upstream
  dtschema definitions.
* Add string-array to the device_node.yaml.template

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>