### PR TITLE
dts/bindings: Add uint8-array type for ethernet mac address

### DIFF
--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -26,7 +26,7 @@ properties:
 #
 #   <name of the property in the device tree - regexes are supported>:
 #     category: <required | optional>
-#     type: <string | int | boolean | array | string-array | compound>
+#     type: <string | int | boolean | array | uint8-array | string-array | compound>
 #     description: <description of property>
 #     generation: define
 #

--- a/dts/bindings/ethernet/ethernet.yaml
+++ b/dts/bindings/ethernet/ethernet.yaml
@@ -14,7 +14,7 @@ inherits:
     !include base.yaml
 properties:
     local-mac-address:
-      type: array
+      type: uint8-array
       category: optional
       description: mac address
       generation: define


### PR DESCRIPTION
Introduce uint8-array type for local-mac-address as we need to
distinguish it from 'array' meaning a uint32 array.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>