### PR TITLE
Added simple and fairly conservative sanity check for interrupt table size

### DIFF
--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -227,6 +227,9 @@ def main():
     nvec = intlist["num_vectors"]
     offset = intlist["offset"]
 
+    if nvec > pow(2, 15):
+        raise ValueError('nvec is too large, check endianness.')
+
     spurious_handler = "&z_irq_spurious"
     sw_irq_handler   = "ISR_WRAPPER"
 


### PR DESCRIPTION
I'm following the documentation and the hello world application failed to compiled because `gen_isr_tables.py` was using more than 10G of memory and getting killed. This just adds a very conservative check to quit early if the endianness is not correct.