### PR TITLE
dts: Replace status = "ok" with status = "okay"

### DIFF
--- a/boards/arc/arduino_101_sss/arduino_101_sss.dts
+++ b/boards/arc/arduino_101_sss/arduino_101_sss.dts
@@ -39,36 +39,36 @@
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c3 {
-	status = "ok";
+	status = "okay";
 };
 
 &adc0 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 
 	bmi160@1 {
 		compatible = "bosch,bmi160";
@@ -76,6 +76,6 @@
 		label = "bmi160";
 		spi-max-frequency = <640000>;
 		int-gpios = <&gpio1 4 0>;
-		status = "ok";
+		status = "okay";
 	};
 };

--- a/boards/arc/em_starterkit/em_starterkit.dts
+++ b/boards/arc/em_starterkit/em_starterkit.dts
@@ -37,6 +37,6 @@
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/arc/em_starterkit/em_starterkit_em11d.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em11d.dts
@@ -37,6 +37,6 @@
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/arc/em_starterkit/em_starterkit_em7d.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em7d.dts
@@ -37,14 +37,14 @@
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arc/em_starterkit/em_starterkit_em7d_v22.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em7d_v22.dts
@@ -37,14 +37,14 @@
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arc/iotdk/iotdk.dts
+++ b/boards/arc/iotdk/iotdk.dts
@@ -26,6 +26,6 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/arc/quark_se_c1000_ss_devboard/quark_se_c1000_ss_devboard.dts
+++ b/boards/arc/quark_se_c1000_ss_devboard/quark_se_c1000_ss_devboard.dts
@@ -57,34 +57,34 @@
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c3 {
-	status = "ok";
+	status = "okay";
 };
 
 &adc0 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -49,15 +49,15 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 
 	/* ST Microelectronics LSM6DSL accel/gyro sensor */
 	lsm6dsl@1 {
@@ -70,7 +70,7 @@
 };
 
 &i2s5 {
-	status = "ok";
+	status = "okay";
 
 	mp34dt05@0 {
 		compatible = "st,mpxxdtyy";
@@ -80,12 +80,12 @@
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
 	hts221@5f {
@@ -109,7 +109,7 @@
 };
 
 &i2c3 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
 	lp3943@60 {
@@ -120,5 +120,5 @@
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -55,35 +55,35 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart6 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart6_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 
 	/* Nordic nRF51822-QFAC */
 	bt-hci@0 {
@@ -97,11 +97,11 @@
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };
 
 &flash0 {
@@ -142,5 +142,5 @@
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
+++ b/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
@@ -22,29 +22,29 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <28>;
 	scl-pin = <2>;
 };
 
 &uart0 {
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <29>;
 	rx-pin = <11>;
 };
 
 &spi1 {
 	compatible = "nordic,nrf-spis";
-	status = "ok";
+	status = "okay";
 	sck-pin = <7>;
 	mosi-pin = <0>;
 	miso-pin = <30>;

--- a/boards/arm/96b_neonkey/96b_neonkey.dts
+++ b/boards/arm/96b_neonkey/96b_neonkey.dts
@@ -59,21 +59,21 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c3 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 
 	lp3943@60 {
@@ -84,9 +84,9 @@
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -54,17 +54,17 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <13>;
 	rx-pin = <15>;
 	rts-pin = <12>;
@@ -72,13 +72,13 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <20>;
 	scl-pin = <22>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <26>;
 	mosi-pin = <23>;
 	miso-pin = <25>;

--- a/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
+++ b/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
@@ -51,7 +51,7 @@
 };
 
 &i2s2 {
-	status = "ok";
+	status = "okay";
 
 	mp34dt01@0 {
 		compatible = "st,mpxxdtyy";
@@ -61,7 +61,7 @@
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
 	/* ST Microelectronics LIS3MDL magnetic field sensor */
@@ -80,43 +80,43 @@
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2s2 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 };
 
 &timers3 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &timers4 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &timers9 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
@@ -124,23 +124,23 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &uart4 {
 	current-speed = <115200>;
 	pinctrl-0 = <&uart4_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/96b_wistrio/96b_wistrio.dts
+++ b/boards/arm/96b_wistrio/96b_wistrio.dts
@@ -39,18 +39,18 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart3 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 
 	lis3dh@32 {
 		compatible = "st,lis3dh";

--- a/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
+++ b/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
@@ -35,7 +35,7 @@
 };
 
 &sercom0 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-uart";
 	current-speed = <115200>;
 	rxpo = <3>;
@@ -43,7 +43,7 @@
 };
 
 &sercom4 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-spi";
 	#address-cells = <1>;
 	#size-cells = <0>;
@@ -81,5 +81,5 @@
 };
 
 &usb0 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
@@ -42,7 +42,7 @@
 };
 
 &sercom0 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-uart";
 	current-speed = <115200>;
 	rxpo = <3>;
@@ -50,7 +50,7 @@
 };
 
 &sercom2 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-uart";
 	current-speed = <115200>;
 	rxpo = <1>;
@@ -59,7 +59,7 @@
 
 /* Drives the on-board DotStar LED */
 &sercom1 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-spi";
 	dipo = <2>;
 	dopo = <0>;
@@ -104,5 +104,5 @@
 };
 
 &usb0 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/arduino_due/arduino_due.dts
+++ b/boards/arm/arduino_due/arduino_due.dts
@@ -24,19 +24,19 @@
 };
 
 &wdog {
-	status = "ok";
+	status = "okay";
 };
 
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/arm/arduino_zero/arduino_zero.dts
+++ b/boards/arm/arduino_zero/arduino_zero.dts
@@ -44,7 +44,7 @@
 };
 
 &sercom0 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-uart";
 	current-speed = <115200>;
 	rxpo = <3>;
@@ -52,7 +52,7 @@
 };
 
 &sercom5 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-uart";
 	current-speed = <115200>;
 	rxpo = <3>;
@@ -60,7 +60,7 @@
 };
 
 &sercom4 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-spi";
 	dipo = <0>;
 	dopo = <1>;
@@ -84,5 +84,5 @@
 };
 
 &usb0 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
@@ -41,14 +41,14 @@
 };
 
 &sercom0 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-spi";
 	dipo = <0>;
 	dopo = <2>;
 };
 
 &sercom3 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-uart";
 	current-speed = <115200>;
 	rxpo = <3>;
@@ -56,7 +56,7 @@
 };
 
 &sercom4 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-uart";
 	current-speed = <115200>;
 	rxpo = <1>;
@@ -81,5 +81,5 @@
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
@@ -42,7 +42,7 @@
 };
 
 &sercom0 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-uart";
 	current-speed = <9600>;
 	rxpo = <3>;
@@ -50,7 +50,7 @@
 };
 
 &sercom1 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-uart";
 	current-speed = <115200>;
 	rxpo = <3>;
@@ -58,7 +58,7 @@
 };
 
 &sercom3 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-uart";
 	current-speed = <115200>;
 	rxpo = <1>;
@@ -66,12 +66,12 @@
 };
 
 &sercom5 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-spi";
 	dipo = <0>;
 	dopo = <2>;
 };
 
 &usb0 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -42,7 +42,7 @@
 };
 
 &sercom0 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-uart";
 	current-speed = <115200>;
 	rxpo = <1>;
@@ -50,14 +50,14 @@
 };
 
 &sercom1 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-i2c";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	label = "I2C_0";
 };
 
 &sercom5 {
-	status = "ok";
+	status = "okay";
 	compatible = "atmel,sam0-spi";
 	dipo = <0>;
 	dopo = <2>;
@@ -65,9 +65,9 @@
 };
 
 &usb0 {
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -64,25 +64,25 @@ arduino_i2c: &i2c1 {};
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -42,22 +42,22 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	tx-pin = <24>;
 	rx-pin = <25>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <30>;
 	scl-pin = <0>;

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -56,19 +56,19 @@
 };
 
 &adc {
-	status ="ok";
+	status = "okay";
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	tx-pin = <6>;
@@ -78,18 +78,18 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &pwm0 {
-	status = "ok";
+	status = "okay";
 	ch0-pin = <17>;
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <25>;
 	mosi-pin = <23>;
 	miso-pin = <24>;
@@ -97,7 +97,7 @@
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <16>;
 	mosi-pin = <20>;
 	miso-pin = <14>;

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -76,25 +76,25 @@
 };
 
 &adc {
-	status ="ok";
+	status = "okay";
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio1 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <6>;
 	rx-pin = <8>;
 	rts-pin = <5>;
@@ -102,18 +102,18 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &pwm0 {
-	status = "ok";
+	status = "okay";
 	ch0-pin = <13>;
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <41>;
 	mosi-pin = <40>;
 	miso-pin = <4>;
@@ -121,7 +121,7 @@
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;
@@ -180,5 +180,5 @@
 
 &usbd {
 	compatible = "nordic,nrf-usbd";
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
+++ b/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
@@ -54,28 +54,28 @@
 };
 
 &trng {
-	status = "ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	tx-pin = <13>;
 	rx-pin = <12>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	scl-pin = <4>;
 	sda-pin = <5>;
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <10>;
 	mosi-pin = <9>;
 	miso-pin = <8>;

--- a/boards/arm/cc2650_sensortag/cc2650_sensortag.dts
+++ b/boards/arm/cc2650_sensortag/cc2650_sensortag.dts
@@ -25,15 +25,15 @@
 };
 
 &gpioa {
-	status = "ok";
+	status = "okay";
 };
 
 &trng0 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 

--- a/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
+++ b/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
@@ -54,28 +54,28 @@
 };
 
 &trng {
-	status = "ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	tx-pin = <3>;
 	rx-pin = <2>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	scl-pin = <4>;
 	sda-pin = <5>;
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <10>;
 	mosi-pin = <9>;
 	miso-pin = <8>;

--- a/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
+++ b/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
@@ -59,11 +59,11 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
+++ b/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
@@ -48,27 +48,27 @@
 };
 
 &uart2 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	modem-mode = <64>;
 };
 
 &gpio1 {
-	status = "ok";
+	status = "okay";
 };
 
 &gpio2 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c4 {
-	status = "ok";
+	status = "okay";
 };
 
 &pwm1 {
-	status = "ok";
+	status = "okay";
 };
 
 &mub {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/curie_ble/curie_ble.dts
+++ b/boards/arm/curie_ble/curie_ble.dts
@@ -21,16 +21,16 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	current-speed = <1000000>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <9>;
 	rx-pin = <11>;
 	rts-pin = <12>;

--- a/boards/arm/cy8ckit_062_wifi_bt_m0/cy8ckit_062_wifi_bt_m0.dts
+++ b/boards/arm/cy8ckit_062_wifi_bt_m0/cy8ckit_062_wifi_bt_m0.dts
@@ -25,6 +25,6 @@
 };
 
 &uart6 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/arm/cy8ckit_062_wifi_bt_m4/cy8ckit_062_wifi_bt_m4.dts
+++ b/boards/arm/cy8ckit_062_wifi_bt_m4/cy8ckit_062_wifi_bt_m4.dts
@@ -25,6 +25,6 @@
 };
 
 &uart5 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -53,30 +53,30 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &uart4 {
 	current-speed = <115200>;
 	pinctrl-0 = <&uart4_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
 	lis3mdl-magn@1e {
@@ -112,11 +112,11 @@
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi3 {
-	status = "ok";
+	status = "okay";
 
 	cs-gpios = <&gpiod 13 0>, <&gpioe 0 0>;
 
@@ -185,21 +185,21 @@
 };
 
 &timers2 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/dragino_lsn50/dragino_lsn50.dts
+++ b/boards/arm/dragino_lsn50/dragino_lsn50.dts
@@ -23,6 +23,6 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 

--- a/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.dts
+++ b/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.dts
@@ -58,5 +58,5 @@
 	current-speed = <115200>;
 	location-rx = <GECKO_LOCATION(4) GECKO_PORT_A GECKO_PIN(0)>;
 	location-tx = <GECKO_LOCATION(4) GECKO_PORT_F GECKO_PIN(2)>;
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.dts
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.dts
@@ -57,28 +57,28 @@
 	current-speed = <115200>;
 	location-rx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(1)>;
 	location-tx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(0)>;
-	status = "ok";
+	status = "okay";
 };
 
 &leuart0 {
 	current-speed = <9600>;
 	location-rx = <GECKO_LOCATION(18) GECKO_PORT_D GECKO_PIN(11)>;
 	location-tx = <GECKO_LOCATION(18) GECKO_PORT_D GECKO_PIN(10)>;
-	status = "ok";
+	status = "okay";
 };
 
 &i2c0 {
 	location-sda = <GECKO_LOCATION(15) GECKO_PORT_C GECKO_PIN(10)>;
 	location-scl = <GECKO_LOCATION(15) GECKO_PORT_C GECKO_PIN(11)>;
-	status = "ok";
+	status = "okay";
 };
 
 &rtcc0 {
 	prescaler = <1>;
-	status = "ok";
+	status = "okay";
 };
 
 &gpio {
 	location-swo = <0>;
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/efm32wg_stk3800/efm32wg_stk3800.dts
+++ b/boards/arm/efm32wg_stk3800/efm32wg_stk3800.dts
@@ -57,5 +57,5 @@
 	current-speed = <115200>;
 	location-rx = <GECKO_LOCATION(1) GECKO_PORT_E GECKO_PIN(1)>;
 	location-tx = <GECKO_LOCATION(1) GECKO_PORT_E GECKO_PIN(0)>;
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.dts
+++ b/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.dts
@@ -59,17 +59,17 @@
 	current-speed = <115200>;
 	location-rx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(1)>;
 	location-tx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(0)>;
-	status = "ok";
+	status = "okay";
 };
 
 &rtcc0 {
 	prescaler = <1>;
-	status = "ok";
+	status = "okay";
 };
 
 &gpio {
 	location-swo = <0>;
-	status = "ok";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -56,34 +56,34 @@
 	current-speed = <115200>;
 	location-rx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(1)>;
 	location-tx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(0)>;
-	status = "ok";
+	status = "okay";
 };
 
 &leuart0 {
 	current-speed = <9600>;
 	location-rx = <GECKO_LOCATION(27) GECKO_PORT_F GECKO_PIN(4)>;
 	location-tx = <GECKO_LOCATION(27) GECKO_PORT_F GECKO_PIN(3)>;
-	status = "ok";
+	status = "okay";
 };
 
 &i2c0 {
 	location-sda = <GECKO_LOCATION(15) GECKO_PORT_C GECKO_PIN(10)>;
 	location-scl = <GECKO_LOCATION(15) GECKO_PORT_C GECKO_PIN(11)>;
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
 	location-sda = <GECKO_LOCATION(17) GECKO_PORT_C GECKO_PIN(4)>;
 	location-scl = <GECKO_LOCATION(17) GECKO_PORT_C GECKO_PIN(5)>;
-	status = "ok";
+	status = "okay";
 };
 
 &rtcc0 {
 	prescaler = <1>;
-	status = "ok";
+	status = "okay";
 };
 
 &gpio {
 	location-swo = <0>;
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -109,15 +109,15 @@
 arduino_serial: &uart3 {};
 
 &adc0 {
-	status = "ok";
+	status = "okay";
 };
 
 &adc1 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 
 	fxos8700@1d {
 		compatible = "nxp,fxos8700";
@@ -129,7 +129,7 @@ arduino_serial: &uart3 {};
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 
 	mcr20a@0 {
 		compatible = "nxp,mcr20a";
@@ -138,22 +138,22 @@ arduino_serial: &uart3 {};
 		spi-max-frequency = <4000000>;
 		irqb-gpios = <&gpiob 9 0>;
 		reset-gpios = <&gpioa 2 0>;
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &pwm3 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &usbd {
 	compatible = "nxp,kinetis-usbd";
-	status = "ok";
+	status = "okay";
 	num-bidir-endpoints = <8>;
 };
 
@@ -199,8 +199,8 @@ arduino_serial: &uart3 {};
 };
 
 &eth {
-	status = "ok";
+	status = "okay";
 	ptp {
-		status = "ok";
+		status = "okay";
 	};
 };

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -62,11 +62,11 @@
 };
 
 &adc0 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	mma8451q@1d {
 		compatible = "nxp,fxos8700","nxp,mma8451q";
 		reg = <0x1d>;
@@ -77,12 +77,12 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &usbd {
 	compatible = "nxp,kinetis-usbd";
-	status = "ok";
+	status = "okay";
 	num-bidir-endpoints = <8>;
 };

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -64,11 +64,11 @@
 };
 
 &adc0 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 
 	fxos8700@1f {
 		compatible = "nxp,fxos8700";
@@ -79,6 +79,6 @@
 };
 
 &lpuart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -80,19 +80,19 @@
 };
 
 &adc0 {
-	status = "ok";
+	status = "okay";
 };
 
 &adc1 {
-	status = "ok";
+	status = "okay";
 };
 
 &pwm3 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 
 	max30101@57 {
 		compatible = "max,max30101";
@@ -102,7 +102,7 @@
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 
 	fxos8700@1e {
 		compatible = "nxp,fxos8700";
@@ -122,12 +122,12 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &uart4 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 

--- a/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
+++ b/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
@@ -28,14 +28,14 @@
 };
 
 &adc0 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 };
 
 &lpuart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/arm/holyiot_yj16019/holyiot_yj16019.dts
+++ b/boards/arm/holyiot_yj16019/holyiot_yj16019.dts
@@ -42,15 +42,15 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &pwm0 {
-	status = "ok";
+	status = "okay";
 	ch0-pin = <29>;
 };
 

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114_m0.dts
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114_m0.dts
@@ -22,5 +22,5 @@
 };
 
 &mailbox0 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114_m4.dts
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114_m4.dts
@@ -44,22 +44,22 @@
 };
 
 &usart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &mailbox0 {
-	status = "ok";
+	status = "okay";
 };
 
 &red_led {
-	status = "ok";
+	status = "okay";
 };
 
 &green_led {
-	status = "ok";
+	status = "okay";
 };
 
 &blue_led {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -44,26 +44,26 @@
 };
 
 &usart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &gpio0 {
-	status = "ok";
+	status = "okay";
 };
 
 &gpio1 {
-	status = "ok";
+	status = "okay";
 };
 
 &green_led {
-	status = "ok";
+	status = "okay";
 };
 
 &blue_led {
-	status = "ok";
+	status = "okay";
 };
 
 &red_led {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -20,21 +20,21 @@
 };
 
 &uart2 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	port_sel = <0>;
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	port_sel = <1>;
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	port_sel = <7>;
 };

--- a/boards/arm/mec2016evb_assy6797/mec2016evb_assy6797.dts
+++ b/boards/arm/mec2016evb_assy6797/mec2016evb_assy6797.dts
@@ -20,6 +20,6 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
+++ b/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
@@ -41,25 +41,25 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &timers3 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -54,15 +54,15 @@ arduino_serial: &uart4 {};
 	at25sf128a: at25sf128a@0 {
 		compatible = "adesto,at25sf128a", "jedec,spi-nor";
 		reg = <0>;
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -62,26 +62,26 @@ arduino_serial: &uart2 {};
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		reg = <0>;
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c4 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &eth {
-	status = "ok";
+	status = "okay";
 	ptp {
-		status = "ok";
+		status = "okay";
 	};
 };

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -72,12 +72,12 @@ arduino_serial: &uart3 {};
 	hyperflash0: hyperflash@0 {
 		compatible = "cypress,s26ks512s";
 		reg = <0>;
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &lcdif1 {
-	status = "ok";
+	status = "okay";
 	port {
 		lcd_panel_out: endpoint {
 			remote-endpoint = <&lcd_panel_in>;
@@ -86,7 +86,7 @@ arduino_serial: &uart3 {};
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 
 	fxos8700@1f {
 		compatible = "nxp,fxos8700";
@@ -104,21 +104,21 @@ arduino_serial: &uart3 {};
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &spi3 {
-	status = "ok";
+	status = "okay";
 };
 
 &eth {
-	status = "ok";
+	status = "okay";
 	ptp {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &usbd1 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -13,6 +13,6 @@
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		reg = <0>;
-		status = "ok";
+		status = "okay";
 	};
 };

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -68,12 +68,12 @@ arduino_serial: &uart3 {};
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		reg = <0>;
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &lcdif1 {
-	status = "ok";
+	status = "okay";
 	port {
 		lcd_panel_out: endpoint {
 			remote-endpoint = <&lcd_panel_in>;
@@ -82,10 +82,10 @@ arduino_serial: &uart3 {};
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
@@ -12,6 +12,6 @@
 	hyperflash0: hyperflash@0 {
 		compatible = "cypress,s26ks512s";
 		reg = <0>;
-		status = "ok";
+		status = "okay";
 	};
 };

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -65,7 +65,7 @@
 arduino_i2c: &i2c1 {};
 
 &lcdif1 {
-	status = "ok";
+	status = "okay";
 	port {
 		lcd_panel_out: endpoint {
 			remote-endpoint = <&lcd_panel_in>;
@@ -74,17 +74,17 @@ arduino_i2c: &i2c1 {};
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &eth {
-	status = "ok";
+	status = "okay";
 	ptp {
-		status = "ok";
+		status = "okay";
 	};
 };

--- a/boards/arm/msp_exp432p401r_launchxl/msp_exp432p401r_launchxl.dts
+++ b/boards/arm/msp_exp432p401r_launchxl/msp_exp432p401r_launchxl.dts
@@ -22,7 +22,7 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 

--- a/boards/arm/nrf51_ble400/nrf51_ble400.dts
+++ b/boards/arm/nrf51_ble400/nrf51_ble400.dts
@@ -75,22 +75,22 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <0>;
 	scl-pin = <1>;
 	/* smba-pin = <2>; */
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <25>;
 	mosi-pin = <24>;
 	miso-pin = <23>;
@@ -99,7 +99,7 @@
 
 &uart0 {
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <9>;
 	rx-pin = <11>;
 	rts-pin = <8>;

--- a/boards/arm/nrf51_blenano/nrf51_blenano.dts
+++ b/boards/arm/nrf51_blenano/nrf51_blenano.dts
@@ -34,16 +34,16 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <9>;
 	rx-pin = <11>;
 	rts-pin = <8>;

--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -76,20 +76,20 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &adc {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <9>;
 	rx-pin = <11>;
 	rts-pin = <8>;
@@ -97,28 +97,28 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <30>;
 	scl-pin = <7>;
 };
 
 &i2c1 {
 	/* Cannot be used together with spi1. */
-	/* status = "ok"; */
+	/* status = "okay"; */
 	sda-pin = <5>;
 	scl-pin = <6>;
 };
 
 &spi0 {
 	/* Cannot be used together with i2c0. */
-	/* status = "ok"; */
+	/* status = "okay"; */
 	sck-pin = <7>;
 	mosi-pin = <29>;
 	miso-pin = <30>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <6>;
 	mosi-pin = <5>;
 	miso-pin = <4>;

--- a/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
+++ b/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
@@ -47,16 +47,16 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <10>;
 	rx-pin = <11>;
 	rts-pin = <12>;
@@ -64,7 +64,7 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <29>;
 	scl-pin = <30>;

--- a/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
+++ b/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
@@ -78,20 +78,20 @@
 };
 
 &adc {
-	status = "ok";
+	status = "okay";
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uarte";
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	tx-pin = <6>;
 	rx-pin = <8>;
@@ -100,13 +100,13 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <29>;
 	mosi-pin = <31>;
 	miso-pin = <30>;

--- a/boards/arm/nrf52811_pca10056/nrf52811_pca10056.dts
+++ b/boards/arm/nrf52811_pca10056/nrf52811_pca10056.dts
@@ -76,21 +76,21 @@
 };
 
 &adc {
-	status ="ok";
+	status = "okay";
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <6>;
 	rx-pin = <8>;
 	rts-pin = <5>;
@@ -99,19 +99,19 @@
 
 &i2c0 {
 	/* Arduino compatible PINs */
-	status = "ok";
+	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &pwm0 {
-	status = "ok";
+	status = "okay";
 	ch0-pin = <13>;
 	ch0-inverted;
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <0>;
 	mosi-pin = <1>;
 	miso-pin = <9>;

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -61,15 +61,15 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	tx-pin = <20>;
@@ -79,19 +79,19 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <30>;
 	scl-pin = <31>;
 };
 
 &pwm0 {
-	status = "ok";
+	status = "okay";
 	ch0-pin = <22>;
 	ch0-inverted;
 };

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -58,25 +58,25 @@
 };
 
 &adc {
-	status ="ok";
+	status = "okay";
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio1 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <6>;
 	rx-pin = <8>;
 	rts-pin = <5>;
@@ -84,42 +84,42 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <12>;
 	scl-pin = <11>;
 };
 
 &i2c1 {
 	/* Cannot be used together with spi1. */
-	/* status = "ok"; */
+	/* status = "okay"; */
 	sda-pin = <2>;
 	scl-pin = <3>;
 };
 
 &spi0 {
 	/* Cannot be used together with i2c0. */
-	/* status = "ok"; */
+	/* status = "okay"; */
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <25>;
 	mosi-pin = <34>;
 	miso-pin = <24>;
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <26>;
 	mosi-pin = <23>;
 	miso-pin = <27>;
 };
 
 &spi3 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <29>;
 	mosi-pin = <30>;
 	miso-pin = <31>;
@@ -167,5 +167,5 @@
 
 &usbd {
 	compatible = "nordic,nrf-usbd";
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -59,21 +59,21 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio1 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <20>;
 	rx-pin = <19>;
 	rts-pin = <5>;
@@ -81,19 +81,19 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <30>;
 	scl-pin = <31>;
 };
 
 &pwm0 {
-	status = "ok";
+	status = "okay";
 	ch0-pin = <22>;
 	ch0-inverted;
 };
@@ -140,5 +140,5 @@
 
 &usbd {
 	compatible = "nordic,nrf-usbd";
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -55,44 +55,44 @@
 };
 
 &adc {
-	status ="ok";
+	status = "okay";
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio1 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <8>;
 	rx-pin = <7>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <5>;
 	scl-pin = <6>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <31>;
 	mosi-pin = <29>;
 	miso-pin = <33>;
 };
 
 &pwm0 {
-	status = "ok";
+	status = "okay";
 	ch0-pin = <13>;
 	ch0-inverted;
 };
@@ -139,5 +139,5 @@
 
 &usbd {
 	compatible = "nordic,nrf-usbd";
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nrf52840_pca10056/doc/index.rst
+++ b/boards/arm/nrf52840_pca10056/doc/index.rst
@@ -180,7 +180,7 @@ more than one UART for connecting peripheral devices:
       &uart1 {
         compatible = "nordic,nrf-uarte";
         current-speed = <115200>;
-        status = "ok";
+        status = "okay";
         tx-pin = <14>;
         rx-pin = <16>;
       };

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -103,25 +103,25 @@
 };
 
 &adc {
-	status ="ok";
+	status = "okay";
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio1 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <6>;
 	rx-pin = <8>;
 	rts-pin = <5>;
@@ -129,41 +129,41 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &i2c1 {
 	/* Cannot be used together with spi1. */
-	/* status = "ok"; */
+	/* status = "okay"; */
 	sda-pin = <30>;
 	scl-pin = <31>;
 };
 
 &pwm0 {
-	status = "ok";
+	status = "okay";
 	ch0-pin = <13>;
 	ch0-inverted;
 };
 
 &spi0 {
 	/* Cannot be used together with i2c0. */
-	/* status = "ok"; */
+	/* status = "okay"; */
 	sck-pin = <27>;
 	mosi-pin = <26>;
 	miso-pin = <29>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <31>;
 	mosi-pin = <30>;
 	miso-pin = <40>;
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;
@@ -181,7 +181,7 @@
 };
 
 &spi3 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <41>;
 	mosi-pin = <42>;
 	miso-pin = <43>;
@@ -229,5 +229,5 @@
 
 &usbd {
 	compatible = "nordic,nrf-usbd";
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -66,21 +66,21 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio1 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <20>;
 	rx-pin = <24>;
 	rts-pin = <17>;
@@ -88,14 +88,14 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &i2c1 {
 	/* Cannot be used together with spi1. */
-	/* status = "ok"; */
+	/* status = "okay"; */
 	sda-pin = <30>;
 	scl-pin = <31>;
 };
@@ -106,14 +106,14 @@
  */
 &spi0 {
 	/* Cannot be used together with i2c0. */
-	/* status = "ok"; */
+	/* status = "okay"; */
 	sck-pin = <27>;
 	mosi-pin = <26>;
 	miso-pin = <42>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <31>;
 	mosi-pin = <30>;
 	miso-pin = <45>;
@@ -128,5 +128,5 @@
 
 &usbd {
 	compatible = "nordic,nrf-usbd";
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nrf52840_pca10090/nrf52840_pca10090.dts
+++ b/boards/arm/nrf52840_pca10090/nrf52840_pca10090.dts
@@ -24,15 +24,15 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio1 {
-	status ="ok";
+	status = "okay";
 };
 
 /* The nRF52840 SoC does not have any connection to the any of the LEDs,
@@ -42,7 +42,7 @@
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <5>;
 	rx-pin = <3>;
 	rts-pin = <40>;

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -53,17 +53,17 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <6>;
 	rx-pin = <8>;
 };

--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
@@ -36,17 +36,17 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <29>;
 	rx-pin = <30>;
 	rts-pin = <2>;
@@ -54,7 +54,7 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <28>;
 	scl-pin = <2>;
 };

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -77,19 +77,19 @@
 };
 
 &adc {
-	status ="ok";
+	status = "okay";
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 arduino_serial: &uart0 {
-	status = "ok";
+	status = "okay";
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	tx-pin = <6>;
@@ -99,41 +99,41 @@ arduino_serial: &uart0 {
 };
 
 arduino_i2c: &i2c0 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &i2c1 {
 	/* Cannot be used together with spi1. */
-	/* status = "ok"; */
+	/* status = "okay"; */
 	sda-pin = <30>;
 	scl-pin = <31>;
 };
 
 &pwm0 {
-	status = "ok";
+	status = "okay";
 	ch0-pin = <17>;
 	ch0-inverted;
 };
 
 &spi0 {
 	/* Cannot be used together with i2c0. */
-	/* status = "ok"; */
+	/* status = "okay"; */
 	sck-pin = <27>;
 	mosi-pin = <26>;
 	miso-pin = <25>;
 };
 
 arduino_spi: &spi1 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <31>;
 	mosi-pin = <30>;
 	miso-pin = <29>;
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <22>;
 	mosi-pin = <23>;
 	miso-pin = <24>;

--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
@@ -57,19 +57,19 @@
 };
 
 &adc {
-	status = "ok";
+	status = "okay";
 };
 
 &gpiote {
-	status = "ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	tx-pin = <3>;
@@ -77,7 +77,7 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <7>;
 	scl-pin = <8>;
@@ -111,7 +111,7 @@
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <14>;
 	scl-pin = <15>;

--- a/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
+++ b/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
@@ -47,17 +47,17 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <27>;
 	rx-pin = <26>;
 };

--- a/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
+++ b/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
@@ -46,15 +46,15 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 	tx-pin = <6>;
@@ -64,7 +64,7 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <26>;
 	scl-pin = <27>;

--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
@@ -69,19 +69,19 @@
 };
 
 &adc {
-	status ="ok";
+	status = "okay";
 };
 
 &gpiote {
-	status = "ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	tx-pin = <29>;
 	rx-pin = <28>;
@@ -90,7 +90,7 @@
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	tx-pin = <1>;
 	rx-pin = <0>;
@@ -99,33 +99,33 @@
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	sda-pin = <30>;
 	scl-pin = <31>;
 };
 
 &pwm0 {
-	status = "ok";
+	status = "okay";
 	ch0-pin = <2>;
 };
 
 &spi3 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <19>;
 	mosi-pin = <18>;
 	miso-pin = <17>;
 };
 
 &timer0 {
-	status = "ok";
+	status = "okay";
 };
 
 &timer1 {
-	status = "ok";
+	status = "okay";
 };
 
 &timer2 {
-	status = "ok";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -44,35 +44,35 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 arduino_i2c: &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 arduino_spi: &spi1 {
-      status = "ok";
+      status = "okay";
 };
 
 &spi2 {
-      status = "ok";
+      status = "okay";
 };
 
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -44,35 +44,35 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 arduino_i2c: &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 arduino_spi: &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 };
 
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -50,30 +50,30 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 arduino_i2c: &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 arduino_spi: &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 };
 
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };
 
 &flash0 {
@@ -95,5 +95,5 @@ arduino_spi: &spi1 {
 };
 
 &adc1 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -50,7 +50,7 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart3 {
@@ -60,25 +60,25 @@
 };
 
 arduino_spi: &spi1 {
-      status = "ok";
+      status = "okay";
 };
 
 &spi2 {
-      status = "ok";
+      status = "okay";
 };
 
 &timers1 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };
 
 &adc1 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -56,23 +56,23 @@ arduino_serial: &usart6 {};
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart6 {
 	current-speed = <115200>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };
 
 &adc1 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
@@ -44,45 +44,45 @@ arduino_i2c: &i2c1 {};
 arduino_spi: &spi2 {};
 
 &i2c1 {
-      status = "ok";
+      status = "okay";
       clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 };
 
 &usart1 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 &usart3 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &timers2 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };
 
 &adc1 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -44,14 +44,14 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart3 {
@@ -61,28 +61,28 @@
 };
 
 arduino_i2c: &i2c1 {
-      status = "ok";
+      status = "okay";
       clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 arduino_spi: &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &timers1 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -45,27 +45,27 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 arduino_i2c: &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 arduino_spi: &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 };
 
 &flash0 {
@@ -107,17 +107,17 @@ arduino_spi: &spi1 {
 };
 
 &timers2 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };
 
 &adc1 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -44,18 +44,18 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 arduino_i2c: &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
@@ -68,9 +68,9 @@ arduino_i2c: &i2c1 {
 };
 
 arduino_spi: &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -58,37 +58,37 @@ arduino_serial: &usart6 {};
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart6 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart6_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };
 
 &timers2 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -58,37 +58,37 @@ arduino_serial: &usart6 {};
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart6 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart6_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };
 
 &timers2 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -57,45 +57,45 @@ arduino_spi: &spi1 {};
 arduino_serial: &usart6 {};
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &usart3 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 &usart6 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart6_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };
 
 &timers1 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -44,35 +44,35 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 arduino_i2c: &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c3 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 arduino_spi: &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -58,30 +58,30 @@ arduino_spi: &spi1 {};
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart6 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart6_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &timers1 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
@@ -90,15 +90,15 @@ arduino_spi: &spi1 {};
 	 * WARNING: The pin PA7 will conflict on selection of SPI_1 and
 	 *          ETH_STM32_HAL. See pinmux.c for further details.
 	 */
-	status = "ok";
+	status = "okay";
 };
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };
 
 &can1 {
@@ -106,9 +106,9 @@ arduino_spi: &spi1 {};
 	sjw = <1>;
 	prop_seg_phase_seg1 = <6>;
 	phase_seg2 = <5>;
-	status = "ok";
+	status = "okay";
 };
 
 &adc1 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
@@ -58,37 +58,37 @@ arduino_spi: &spi1 {};
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart3 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart6 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart6_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &timers1 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
@@ -97,5 +97,5 @@ arduino_spi: &spi1 {};
 	 * WARNING: The pin PA7 will conflict on selection of SPI_1 and
 	 *          ETH_STM32_HAL. See pinmux.c for further details.
 	 */
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
@@ -50,14 +50,14 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 arduino_i2c: &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 arduino_spi: &spi1 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -50,22 +50,22 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 arduino_i2c: &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 arduino_spi: &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };
 
 &adc1 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -41,18 +41,18 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &timers2 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
@@ -60,11 +60,11 @@
 	pinctrl-0 = <&can_pins_a>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -44,42 +44,42 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 arduino_i2c: &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c3 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &timers2 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };
 
 &adc1 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
+++ b/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
@@ -67,64 +67,64 @@ arduino_serial: &lpuart1 {};
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_d>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart3 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &lpuart1 {
 	current-speed = <115200>;
 	pinctrl-0 = <&lpuart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &timers1 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &timers2 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &timers4 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &timers15 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -60,50 +60,50 @@ arduino_serial: &usart3 {};
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart3 {
 	current-speed = <115200>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &lpuart1 {
 	current-speed = <115200>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };
 
 &timers2 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -60,22 +60,22 @@
 
 &usart1 {
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 };
 
 arduino_i2c: &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c3 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 arduino_serial: &lpuart1 {
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
@@ -45,25 +45,25 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart3 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart6 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart6_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };
 
 /* Only one interface should be enabled at a time: usbotg_fs or usbotg_hs */
@@ -72,5 +72,5 @@ usb_otg1: &usbotg_fs {
 };
 
 usb_otg2: &usbotg_hs {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
@@ -45,23 +45,23 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart3 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart6 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart6_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
@@ -45,9 +45,9 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -53,7 +53,7 @@ uext_serial: &usart1 {};
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
@@ -69,40 +69,40 @@ uext_serial: &usart1 {};
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 	cs-gpios = <&gpiod 2 0>;
 
 	sdhc0: sdhc@0 {
 		compatible = "zephyr,mmc-spi-slot";
 		reg = <0>;
-		status = "ok";
+		status = "okay";
 		label = "SDHC0";
 		spi-max-frequency = <24000000>;
 	};
 };
 
 &usb {
-	status = "ok";
+	status = "okay";
 	disconnect-gpios = <&gpioc 12 0>;
 };
 
 &timers1 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/particle_argon/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/mesh_feather.dtsi
@@ -64,7 +64,7 @@
 };
 
 &adc { /* feather ADC */
-	status = "ok";
+	status = "okay";
 };
 
 
@@ -105,19 +105,19 @@
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio1 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &i2c0 { /* feather I2C */
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <26>;
 	scl-pin = <27>;
@@ -126,7 +126,7 @@
 /* TWI1 used on Boron; also see mesh_feather_spi1_spi1.dtsi */
 
 &spi2 { /* dedicated MX25L */
-	status = "ok";
+	status = "okay";
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;
@@ -147,7 +147,7 @@
 &uart0 { /* feather UART1 */
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <6>;
 	rx-pin = <8>;
 	/* optional mesh_feather_uart1_rtscts.dtsi */
@@ -155,5 +155,5 @@
 
 &usbd {
 	compatible = "nordic,nrf-usbd";
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/particle_argon/mesh_feather_i2c1_twi1.dtsi
+++ b/boards/arm/particle_argon/mesh_feather_i2c1_twi1.dtsi
@@ -9,7 +9,7 @@
  * NOTE: This file is replicated in particle_{argon,xenon}.
  * Changes should be made in all instances. */
 &i2c1 { /* feather I2C1 */
-	status = "ok";
+	status = "okay";
 	sda-pin = <33>;
 	scl-pin = <34>;
 };

--- a/boards/arm/particle_argon/mesh_feather_spi1_spi3.dtsi
+++ b/boards/arm/particle_argon/mesh_feather_spi1_spi3.dtsi
@@ -10,7 +10,7 @@
  * Changes should be made in all instances. */
 
 &spi3 { /* feather SPI */
-	status = "ok";
+	status = "okay";
 	sck-pin = <33>;
 	mosi-pin = <34>;
 	miso-pin = <40>;

--- a/boards/arm/particle_argon/mesh_feather_spi_spi1.dtsi
+++ b/boards/arm/particle_argon/mesh_feather_spi_spi1.dtsi
@@ -10,7 +10,7 @@
  * Changes should be made in all instances. */
 
 &spi1 { /* feather SPI */
-	status = "ok";
+	status = "okay";
 	sck-pin = <47>;
 	mosi-pin = <45>;
 	miso-pin = <46>;

--- a/boards/arm/particle_argon/mesh_feather_spi_spi3.dtsi
+++ b/boards/arm/particle_argon/mesh_feather_spi_spi3.dtsi
@@ -10,7 +10,7 @@
  * Changes should be made in all instances. */
 
 &spi3 { /* feather SPI */
-	status = "ok";
+	status = "okay";
 	sck-pin = <47>;
 	mosi-pin = <45>;
 	miso-pin = <46>;

--- a/boards/arm/particle_argon/particle_argon.dts
+++ b/boards/arm/particle_argon/particle_argon.dts
@@ -24,7 +24,7 @@
 &uart1 { /* ESP32 */
 	compatible = "nordic,nrf-uarte";
 	current-speed = <921600>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <37>;
 	rx-pin = <36>;
 	rts-pin = <39>;

--- a/boards/arm/particle_boron/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/mesh_feather.dtsi
@@ -64,7 +64,7 @@
 };
 
 &adc { /* feather ADC */
-	status = "ok";
+	status = "okay";
 };
 
 
@@ -105,19 +105,19 @@
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio1 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &i2c0 { /* feather I2C */
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <26>;
 	scl-pin = <27>;
@@ -126,7 +126,7 @@
 /* TWI1 used on Boron; also see mesh_feather_spi1_spi1.dtsi */
 
 &spi2 { /* dedicated MX25L */
-	status = "ok";
+	status = "okay";
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;
@@ -147,7 +147,7 @@
 &uart0 { /* feather UART1 */
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <6>;
 	rx-pin = <8>;
 	/* optional mesh_feather_uart1_rtscts.dtsi */
@@ -155,5 +155,5 @@
 
 &usbd {
 	compatible = "nordic,nrf-usbd";
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/particle_boron/mesh_feather_spi1_spi3.dtsi
+++ b/boards/arm/particle_boron/mesh_feather_spi1_spi3.dtsi
@@ -10,7 +10,7 @@
  * Changes should be made in all instances. */
 
 &spi3 { /* feather SPI */
-	status = "ok";
+	status = "okay";
 	sck-pin = <33>;
 	mosi-pin = <34>;
 	miso-pin = <40>;

--- a/boards/arm/particle_boron/mesh_feather_spi_spi3.dtsi
+++ b/boards/arm/particle_boron/mesh_feather_spi_spi3.dtsi
@@ -10,7 +10,7 @@
  * Changes should be made in all instances. */
 
 &spi3 { /* feather SPI */
-	status = "ok";
+	status = "okay";
 	sck-pin = <47>;
 	mosi-pin = <45>;
 	miso-pin = <46>;

--- a/boards/arm/particle_boron/particle_boron.dts
+++ b/boards/arm/particle_boron/particle_boron.dts
@@ -25,7 +25,7 @@
 };
 
 &i2c1 { /* power monitoring */
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <24>;
 	scl-pin = <41>;
@@ -34,7 +34,7 @@
 &uart1 { /* u-blox SARA-U2 or SARA-R4 */
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 
 	tx-pin = <37>;
 	rx-pin = <36>;
@@ -44,7 +44,7 @@
 	sara_r4 {
 		compatible = "ublox,sara-r4";
 		label = "ublox-sara-r4";
-		status = "ok";
+		status = "okay";
 
 		mdm-power-gpios = <&gpio0 16 0>;
 		mdm-reset-gpios = <&gpio0 12 0>;

--- a/boards/arm/particle_xenon/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/mesh_feather.dtsi
@@ -64,7 +64,7 @@
 };
 
 &adc { /* feather ADC */
-	status = "ok";
+	status = "okay";
 };
 
 
@@ -105,19 +105,19 @@
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio1 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &i2c0 { /* feather I2C */
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <26>;
 	scl-pin = <27>;
@@ -126,7 +126,7 @@
 /* TWI1 used on Boron; also see mesh_feather_spi1_spi1.dtsi */
 
 &spi2 { /* dedicated MX25L */
-	status = "ok";
+	status = "okay";
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;
@@ -147,7 +147,7 @@
 &uart0 { /* feather UART1 */
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <6>;
 	rx-pin = <8>;
 	/* optional mesh_feather_uart1_rtscts.dtsi */
@@ -155,5 +155,5 @@
 
 &usbd {
 	compatible = "nordic,nrf-usbd";
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/particle_xenon/mesh_feather_i2c1_twi1.dtsi
+++ b/boards/arm/particle_xenon/mesh_feather_i2c1_twi1.dtsi
@@ -9,7 +9,7 @@
  * NOTE: This file is replicated in particle_{argon,xenon}.
  * Changes should be made in all instances. */
 &i2c1 { /* feather I2C1 */
-	status = "ok";
+	status = "okay";
 	sda-pin = <33>;
 	scl-pin = <34>;
 };

--- a/boards/arm/particle_xenon/mesh_feather_spi1_spi3.dtsi
+++ b/boards/arm/particle_xenon/mesh_feather_spi1_spi3.dtsi
@@ -10,7 +10,7 @@
  * Changes should be made in all instances. */
 
 &spi3 { /* feather SPI */
-	status = "ok";
+	status = "okay";
 	sck-pin = <33>;
 	mosi-pin = <34>;
 	miso-pin = <40>;

--- a/boards/arm/particle_xenon/mesh_feather_spi_spi1.dtsi
+++ b/boards/arm/particle_xenon/mesh_feather_spi_spi1.dtsi
@@ -10,7 +10,7 @@
  * Changes should be made in all instances. */
 
 &spi1 { /* feather SPI */
-	status = "ok";
+	status = "okay";
 	sck-pin = <47>;
 	mosi-pin = <45>;
 	miso-pin = <46>;

--- a/boards/arm/particle_xenon/mesh_feather_spi_spi3.dtsi
+++ b/boards/arm/particle_xenon/mesh_feather_spi_spi3.dtsi
@@ -10,7 +10,7 @@
  * Changes should be made in all instances. */
 
 &spi3 { /* feather SPI */
-	status = "ok";
+	status = "okay";
 	sck-pin = <47>;
 	mosi-pin = <45>;
 	miso-pin = <46>;

--- a/boards/arm/particle_xenon/mesh_xenon_uart2.dtsi
+++ b/boards/arm/particle_xenon/mesh_xenon_uart2.dtsi
@@ -8,7 +8,7 @@
 &uart1 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
-	status ="ok";
+	status = "okay";
 	tx-pin = <40>;
 	rx-pin = <42>;
 	rts-pin = <35>;

--- a/boards/arm/qemu_cortex_m3/qemu_cortex_m3.dts
+++ b/boards/arm/qemu_cortex_m3/qemu_cortex_m3.dts
@@ -26,48 +26,48 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &uart2 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &eth {
-	status = "ok";
+	status = "okay";
 };
 
 &gpio0 {
-       status = "ok";
+       status = "okay";
 };
 
 &gpio1 {
-       status = "ok";
+       status = "okay";
 };
 
 &gpio2 {
-       status = "ok";
+       status = "okay";
 };
 
 &gpio3 {
-       status = "ok";
+       status = "okay";
 };
 
 &gpio4 {
-       status = "ok";
+       status = "okay";
 };
 
 &gpio5 {
-       status = "ok";
+       status = "okay";
 };
 
 &gpio6 {
-       status = "ok";
+       status = "okay";
 };

--- a/boards/arm/quark_se_c1000_ble/quark_se_c1000_ble.dts
+++ b/boards/arm/quark_se_c1000_ble/quark_se_c1000_ble.dts
@@ -21,15 +21,15 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <1000000>;
 	tx-pin = <9>;
 	rx-pin = <11>;

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -61,27 +61,27 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio1 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <6>;
 	rx-pin = <8>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <26>;
 	scl-pin = <27>;
@@ -110,7 +110,7 @@
 };
 
 &spi3 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <19>;
 	mosi-pin = <20>;
 	miso-pin = <21>;
@@ -178,5 +178,5 @@
 
 &usbd {
 	compatible = "nordic,nrf-usbd";
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/sam4s_xplained/sam4s_xplained.dts
+++ b/boards/arm/sam4s_xplained/sam4s_xplained.dts
@@ -50,19 +50,19 @@
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart0 {
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 };
 
 &uart1 {
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 };
 
 &wdog {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
@@ -53,40 +53,40 @@
 };
 
 &adc0 {
-	status = "ok";
+	status = "okay";
 };
 
 &adc1 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 };
 
 &usart1 {
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 };
 
 &wdog {
-	status = "ok";
+	status = "okay";
 };
 
 &usbhs {
-	status = "ok";
+	status = "okay";
 };
 
 &pwm0 {
-	status = "ok";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/arm/stm3210c_eval/stm3210c_eval.dts
+++ b/boards/arm/stm3210c_eval/stm3210c_eval.dts
@@ -44,9 +44,9 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32373c_eval/stm32373c_eval.dts
+++ b/boards/arm/stm32373c_eval/stm32373c_eval.dts
@@ -44,13 +44,13 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_d>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
@@ -35,7 +35,7 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
@@ -51,26 +51,26 @@
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 };
 
 &timers1 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &usb {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32f072_eval/stm32f072_eval.dts
+++ b/boards/arm/stm32f072_eval/stm32f072_eval.dts
@@ -80,9 +80,9 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_d>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
@@ -59,30 +59,30 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &can1 {
 	pinctrl-0 = <&can_pins_a>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
-	status = "ok";
+	status = "okay";
 };
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/arm/stm32f0_disco/stm32f0_disco.dts
@@ -50,14 +50,14 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &flash0 {
@@ -93,5 +93,5 @@
 };
 
 &iwdg {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -73,18 +73,18 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_d>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
 	lsm303dlhc-magn@1e {
@@ -102,24 +102,24 @@
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 };
 
 &usb {
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -59,9 +59,9 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -75,9 +75,9 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -49,16 +49,16 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -61,28 +61,28 @@ arduino_serial: &usart6 {};
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart6 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart6_pins_b>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -60,28 +60,28 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &timers2 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
@@ -57,32 +57,32 @@ arduino_serial: &usart2 {};
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart6 {
 	current-speed = <115200>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c2 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c3 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -45,38 +45,38 @@ arduino_spi: &spi2 {};
 arduino_serial: &usart6 {};
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 };
 
 &usart1 {
 	current-speed = <115200>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart6 {
 	current-speed = <115200>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usbotg_fs {
-	status = "ok";
+	status = "okay";
 };
 
 &timers1 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -62,20 +62,20 @@ arduino_serial: &usart6 {};
 &usart1 {
 	current-speed = <115200>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart6 {
 	current-speed = <115200>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
@@ -68,9 +68,9 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_d>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -64,40 +64,40 @@ arduino_serial: &lpuart1 {};
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_c>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &usart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_c>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &lpuart1 {
 	current-speed = <115200>;
 	pinctrl-0 = <&lpuart1_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &timers2 {
-	status = "ok";
+	status = "okay";
 
 	pwm {
-		status = "ok";
+		status = "okay";
 	};
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &rtc {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.dts
+++ b/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.dts
@@ -31,12 +31,12 @@ arduino_serial: &uart7 {};
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &uart7 {
 	current-speed = <115200>;
 	pinctrl-0 = <&uart7_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -114,12 +114,12 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 
 	fxos8700: fxos8700@1d {
 		compatible = "nxp,fxos8700";
@@ -130,19 +130,19 @@
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &adc0 {
-	status = "ok";
+	status = "okay";
 	sample-time = <12>;
 };
 

--- a/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.dts
+++ b/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.dts
@@ -58,31 +58,31 @@
 };
 
 &uart5 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	modem-mode = <0>;
 };
 
 &gpio4 {
-	status = "ok";
+	status = "okay";
 };
 
 &gpio5 {
-	status = "ok";
+	status = "okay";
 };
 
 &gpio6 {
-	status = "ok";
+	status = "okay";
 };
 
 &mub {
-	status = "ok";
+	status = "okay";
 };
 
 &epit1 {
-	status = "ok";
+	status = "okay";
 };
 
 &epit2 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -56,24 +56,24 @@
 };
 
 &adc0 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 };
 
 &pwm1 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &usbd {
 	compatible = "nxp,kinetis-usbd";
-	status = "ok";
+	status = "okay";
 	num-bidir-endpoints = <8>;
 };

--- a/boards/arm/warp7_m4/warp7_m4.dts
+++ b/boards/arm/warp7_m4/warp7_m4.dts
@@ -38,23 +38,23 @@
 };
 
 &uart2 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	modem-mode = <0>;
 };
 
 &uart6 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	modem-mode = <0>;
 };
 
 &gpio7 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c4 {
-	status = "ok";
+	status = "okay";
 
 	fxos8700@1e {
 		compatible = "nxp,fxos8700";
@@ -73,5 +73,5 @@
 };
 
 &mub {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/nios2/altera_max10/altera_max10.dts
+++ b/boards/nios2/altera_max10/altera_max10.dts
@@ -21,11 +21,11 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_ULTRA>;
 };

--- a/boards/nios2/qemu_nios2/qemu_nios2.dts
+++ b/boards/nios2/qemu_nios2/qemu_nios2.dts
@@ -22,11 +22,11 @@
 };
 
 &jtag_uart {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &ns16550_uart {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/posix/native_posix/native_posix.dts
+++ b/boards/posix/native_posix/native_posix.dts
@@ -29,7 +29,7 @@
 		label = "flash_ctrl";
 
 		flash0: flash@0 {
-			status = "ok";
+			status = "okay";
 			compatible = "soc-nv-flash";
 			label = "flash";
 			erase-block-size = <1>;
@@ -66,7 +66,7 @@
 	};
 
 	uart0: uart@1 {
-		status = "ok";
+		status = "okay";
 		compatible = "zephyr,native-posix-uart";
 		reg = <1 0>;
 		label = "UART_0";

--- a/boards/riscv32/hifive1/hifive1.dts
+++ b/boards/riscv32/hifive1/hifive1.dts
@@ -39,11 +39,11 @@
 };
 
 &gpio0 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	clock-frequency = <16000000>;
 };
@@ -53,7 +53,7 @@
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <16000000>;
 
 	#address-cells = <1>;
@@ -67,27 +67,27 @@
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <16000000>;
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <16000000>;
 };
 
 &pwm0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <16000000>;
 };
 
 &pwm1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <16000000>;
 };
 
 &pwm2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <16000000>;
 };
 

--- a/boards/riscv32/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv32/hifive1_revb/hifive1_revb.dts
@@ -39,23 +39,23 @@
 };
 
 &gpio0 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	clock-frequency = <16000000>;
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	clock-frequency = <16000000>;
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <16000000>;
 
 	#address-cells = <1>;
@@ -69,32 +69,32 @@
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <16000000>;
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <16000000>;
 };
 
 &pwm0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <16000000>;
 };
 
 &pwm1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <16000000>;
 };
 
 &pwm2 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <16000000>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	input-frequency = <16000000>;
 	clock-frequency = <100000>;
 };

--- a/boards/riscv32/litex_vexriscv/litex_vexriscv.dts
+++ b/boards/riscv32/litex_vexriscv/litex_vexriscv.dts
@@ -26,10 +26,10 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &timer0 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/riscv32/m2gl025_miv/m2gl025_miv.dts
+++ b/boards/riscv32/m2gl025_miv/m2gl025_miv.dts
@@ -23,7 +23,7 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	clock-frequency = <66000000>;
 };

--- a/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
+++ b/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
@@ -18,11 +18,11 @@
 };
 
 &gpio0 {
-	status = "ok";
+	status = "okay";
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 	clock-frequency = <16000000>;
 };
@@ -32,7 +32,7 @@
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/boards/riscv32/rv32m1_vega/rv32m1_vega.dtsi
+++ b/boards/riscv32/rv32m1_vega/rv32m1_vega.dtsi
@@ -87,15 +87,15 @@ arduino_serial: &uart1 {};
 
 &uart0 {
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 };
 
 arduino_i2c: &i2c0 {
-	status = "ok";
+	status = "okay";
 };
 
 &i2c3 {
-	status = "ok";
+	status = "okay";
 
 	fxos8700@1e {
 		compatible = "nxp,fxos8700";

--- a/boards/shields/frdm_kw41z/frdm_kw41z.overlay
+++ b/boards/shields/frdm_kw41z/frdm_kw41z.overlay
@@ -11,6 +11,6 @@
 };
 
 &arduino_serial {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/shields/sparkfun_sara_r4/sparkfun_sara_r4.overlay
+++ b/boards/shields/sparkfun_sara_r4/sparkfun_sara_r4.overlay
@@ -6,13 +6,13 @@
 
 &arduino_serial {
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 
 	sara_r4 {
 		compatible = "ublox,sara-r4";
 		label = "ublox-sara-r4";
 		mdm-power-gpios = <&arduino_header 11 0>; /* D5 */
 		mdm-reset-gpios = <&arduino_header 12 0>; /* D6 */
-		status = "ok";
+		status = "okay";
 	};
 };

--- a/boards/shields/wnc_m14a2a/boards/frdm_k64f.overlay
+++ b/boards/shields/wnc_m14a2a/boards/frdm_k64f.overlay
@@ -11,10 +11,10 @@
 &uart2 {
 	current-speed = <115200>;
 	hw-flow-control;
-	status = "ok";
+	status = "okay";
 
 	wnc_m14a2a: wncm14a2a {
-		status = "ok";
+		status = "okay";
 		compatible = "wnc,m14a2a";
 		label = "wnc-m14a2a";
 		mdm-boot-mode-sel-gpios = <&arduino_header 7 0>;   /* D1 */

--- a/boards/shields/wnc_m14a2a/boards/nrf52840_pca10056.overlay
+++ b/boards/shields/wnc_m14a2a/boards/nrf52840_pca10056.overlay
@@ -11,7 +11,7 @@
 &uart1 {
 	current-speed = <115200>;
 	hw-flow-control;
-	status = "ok";
+	status = "okay";
 
 	tx-pin = <46>;
 	rx-pin = <45>;
@@ -19,7 +19,7 @@
 	cts-pin = <47>;
 
 	wnc_m14a2a: wncm14a2a {
-		status = "ok";
+		status = "okay";
 		compatible = "wnc,m14a2a";
 		label = "wnc-m14a2a";
 		mdm-boot-mode-sel-gpios = <&arduino_header 7 0>;   /* D1 */

--- a/boards/x86/acrn/acrn.dts
+++ b/boards/x86/acrn/acrn.dts
@@ -31,12 +31,12 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 

--- a/boards/x86/arduino_101/arduino_101.dts
+++ b/boards/x86/arduino_101/arduino_101.dts
@@ -39,27 +39,27 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <1000000>;
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 	cs-gpios = <&gpio0 24 0>;
 
 	spi-flash@0 {
@@ -72,9 +72,9 @@
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi2 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/x86/galileo/galileo.dts
+++ b/boards/x86/galileo/galileo.dts
@@ -27,24 +27,24 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 };
 
 &sharedirq0 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/x86/minnowboard/minnowboard.dts
+++ b/boards/x86/minnowboard/minnowboard.dts
@@ -30,12 +30,12 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 

--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -37,7 +37,7 @@
 			interrupts = <11 IRQ_TYPE_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 
-			status = "ok";
+			status = "okay";
 		};
 	};
 
@@ -59,12 +59,12 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 

--- a/boards/x86/quark_d2000_crb/quark_d2000_crb.dts
+++ b/boards/x86/quark_d2000_crb/quark_d2000_crb.dts
@@ -46,24 +46,24 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &adc0 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 };

--- a/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.dts
+++ b/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.dts
@@ -56,31 +56,31 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <1000000>;
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 };
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	cs-gpios = <&gpio0 11 0>;
 
 	cc2520@0 {
@@ -88,7 +88,7 @@
 		reg = <0x0>;
 		label = "cc2520";
 		spi-max-frequency = <8000000>;
-		status = "ok";
+		status = "okay";
 		vreg-en-gpios = <&gpio1 0 0>;
 		reset-gpios = <&gpio1 1 0>;
 		fifo-gpios = <&gpio0 4 0>;

--- a/boards/x86/tinytile/tinytile.dts
+++ b/boards/x86/tinytile/tinytile.dts
@@ -39,21 +39,21 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <1000000>;
 };
 
 &uart1 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/xtensa/esp32/esp32.dts
+++ b/boards/xtensa/esp32/esp32.dts
@@ -22,6 +22,6 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };

--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
@@ -21,12 +21,12 @@
 };
 
 &uart0 {
-	status = "ok";
+	status = "okay";
 	current-speed = <115200>;
 };
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
 	codec0: tlv320dac@18 {
@@ -38,7 +38,7 @@
 };
 
 &spi0 {
-	status = "ok";
+	status = "okay";
 
 	flash0: flash@0 {
 		compatible = "jedec,spi-nor";

--- a/doc/reference/storage/disk/sdhc.rst
+++ b/doc/reference/storage/disk/sdhc.rst
@@ -31,13 +31,13 @@ SDHC card has been initialized:
 .. code-block:: none
 
     &spi1 {
-            status = "ok";
+            status = "okay";
             cs-gpios = <&porta 27 0>;
 
             sdhc0: sdhc@0 {
                     compatible = "zephyr,mmc-spi-slot";
                     reg = <0>;
-                    status = "ok";
+                    status = "okay";
                     label = "SDHC0";
                     spi-max-frequency = <24000000>;
             };

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -305,7 +305,7 @@
 			reg = <0x40070000 0x4000>;
 			interrupts = <57 0>;
 			peripheral-id = <57>;
-			status = "ok";
+			status = "okay";
 			label = "TRNG";
 		};
 	};

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -71,7 +71,7 @@
 			compatible = "nordic,nrf-clock";
 			reg = <0x40000000 0x1000>;
 			interrupts = <0 1>;
-			status = "ok";
+			status = "okay";
 			label = "CLOCK";
 		};
 
@@ -154,7 +154,7 @@
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
 			interrupts = <11 1>;
-			status = "ok";
+			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			label = "RTC_0";
@@ -164,7 +164,7 @@
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
 			interrupts = <17 1>;
-			status = "ok";
+			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			label = "RTC_1";
@@ -172,7 +172,7 @@
 
 		timer0: timer@40008000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x40008000 0x1000>;
 			interrupts = <8 1>;
 			prescaler = <0>;
@@ -181,7 +181,7 @@
 
 		timer1: timer@40009000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x40009000 0x1000>;
 			interrupts = <9 1>;
 			prescaler = <0>;
@@ -190,7 +190,7 @@
 
 		timer2: timer@4000a000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x4000a000 0x1000>;
 			interrupts = <10 1>;
 			prescaler = <0>;
@@ -201,7 +201,7 @@
 			compatible = "nordic,nrf-temp";
 			reg = <0x4000c000 0x1000>;
 			interrupts = <12 1>;
-			status = "ok";
+			status = "okay";
 			label = "TEMP_0";
 		};
 
@@ -209,7 +209,7 @@
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
 			interrupts = <16 1>;
-			status = "ok";
+			status = "okay";
 			label = "WDT";
 		};
 	};
@@ -228,5 +228,5 @@
 	clock-prescaler = <0>;
 	ppi-base = <7>;
 	gpiote-base = <0>;
-	status = "ok";
+	status = "okay";
 };

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -70,7 +70,7 @@
 			compatible = "nordic,nrf-clock";
 			reg = <0x40000000 0x1000>;
 			interrupts = <0 1>;
-			status = "ok";
+			status = "okay";
 			label = "CLOCK";
 		};
 
@@ -141,7 +141,7 @@
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
 			interrupts = <11 1>;
-			status = "ok";
+			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			label = "RTC_0";
@@ -151,7 +151,7 @@
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
 			interrupts = <17 1>;
-			status = "ok";
+			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			label = "RTC_1";
@@ -159,7 +159,7 @@
 
 		timer0: timer@40008000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x40008000 0x1000>;
 			interrupts = <8 1>;
 			prescaler = <0>;
@@ -168,7 +168,7 @@
 
 		timer1: timer@40009000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x40009000 0x1000>;
 			interrupts = <9 1>;
 			prescaler = <0>;
@@ -177,7 +177,7 @@
 
 		timer2: timer@4000a000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x4000a000 0x1000>;
 			interrupts = <10 1>;
 			prescaler = <0>;
@@ -188,7 +188,7 @@
 			compatible = "nordic,nrf-temp";
 			reg = <0x4000c000 0x1000>;
 			interrupts = <12 1>;
-			status = "ok";
+			status = "okay";
 			label = "TEMP_0";
 		};
 
@@ -196,7 +196,7 @@
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
 			interrupts = <16 1>;
-			status = "ok";
+			status = "okay";
 			label = "WDT";
 		};
 	};

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -74,7 +74,7 @@
 			compatible = "nordic,nrf-clock";
 			reg = <0x40000000 0x1000>;
 			interrupts = <0 1>;
-			status = "ok";
+			status = "okay";
 			label = "CLOCK";
 		};
 
@@ -159,7 +159,7 @@
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
 			interrupts = <11 1>;
-			status = "ok";
+			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			label = "RTC_0";
@@ -169,7 +169,7 @@
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
 			interrupts = <17 1>;
-			status = "ok";
+			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			label = "RTC_1";
@@ -177,7 +177,7 @@
 
 		timer0: timer@40008000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x40008000 0x1000>;
 			interrupts = <8 1>;
 			prescaler = <0>;
@@ -186,7 +186,7 @@
 
 		timer1: timer@40009000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x40009000 0x1000>;
 			interrupts = <9 1>;
 			prescaler = <0>;
@@ -195,7 +195,7 @@
 
 		timer2: timer@4000a000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x4000a000 0x1000>;
 			interrupts = <10 1>;
 			prescaler = <0>;
@@ -206,7 +206,7 @@
 			compatible = "nordic,nrf-temp";
 			reg = <0x4000c000 0x1000>;
 			interrupts = <12 1>;
-			status = "ok";
+			status = "okay";
 			label = "TEMP_0";
 		};
 
@@ -214,7 +214,7 @@
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
 			interrupts = <16 1>;
-			status = "ok";
+			status = "okay";
 			label = "WDT";
 		};
 	};

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -78,7 +78,7 @@
 			compatible = "nordic,nrf-clock";
 			reg = <0x40000000 0x1000>;
 			interrupts = <0 1>;
-			status = "ok";
+			status = "okay";
 			label = "CLOCK";
 		};
 
@@ -196,7 +196,7 @@
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
 			interrupts = <11 1>;
-			status = "ok";
+			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			label = "RTC_0";
@@ -206,7 +206,7 @@
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
 			interrupts = <17 1>;
-			status = "ok";
+			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			label = "RTC_1";
@@ -216,7 +216,7 @@
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40024000 0x1000>;
 			interrupts = <36 1>;
-			status = "ok";
+			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			label = "RTC_2";
@@ -224,7 +224,7 @@
 
 		timer0: timer@40008000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x40008000 0x1000>;
 			interrupts = <8 1>;
 			prescaler = <0>;
@@ -233,7 +233,7 @@
 
 		timer1: timer@40009000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x40009000 0x1000>;
 			interrupts = <9 1>;
 			prescaler = <0>;
@@ -242,7 +242,7 @@
 
 		timer2: timer@4000a000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x4000a000 0x1000>;
 			interrupts = <10 1>;
 			prescaler = <0>;
@@ -251,7 +251,7 @@
 
 		timer3: timer@4001a000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x4001a000 0x1000>;
 			interrupts = <26 1>;
 			prescaler = <0>;
@@ -260,7 +260,7 @@
 
 		timer4: timer@4001b000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x4001b000 0x1000>;
 			interrupts = <27 1>;
 			prescaler = <0>;
@@ -271,7 +271,7 @@
 			compatible = "nordic,nrf-temp";
 			reg = <0x4000c000 0x1000>;
 			interrupts = <12 1>;
-			status = "ok";
+			status = "okay";
 			label = "TEMP_0";
 		};
 
@@ -279,7 +279,7 @@
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
 			interrupts = <16 1>;
-			status = "ok";
+			status = "okay";
 			label = "WDT";
 		};
 	};

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -85,7 +85,7 @@
 			compatible = "nordic,nrf-clock";
 			reg = <0x40000000 0x1000>;
 			interrupts = <0 1>;
-			status = "ok";
+			status = "okay";
 			label = "CLOCK";
 		};
 
@@ -240,7 +240,7 @@
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
 			interrupts = <11 1>;
-			status = "ok";
+			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			label = "RTC_0";
@@ -250,7 +250,7 @@
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
 			interrupts = <17 1>;
-			status = "ok";
+			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			label = "RTC_1";
@@ -260,7 +260,7 @@
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40024000 0x1000>;
 			interrupts = <36 1>;
-			status = "ok";
+			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			label = "RTC_2";
@@ -268,7 +268,7 @@
 
 		timer0: timer@40008000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x40008000 0x1000>;
 			interrupts = <8 1>;
 			prescaler = <0>;
@@ -277,7 +277,7 @@
 
 		timer1: timer@40009000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x40009000 0x1000>;
 			interrupts = <9 1>;
 			prescaler = <0>;
@@ -286,7 +286,7 @@
 
 		timer2: timer@4000a000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x4000a000 0x1000>;
 			interrupts = <10 1>;
 			prescaler = <0>;
@@ -295,7 +295,7 @@
 
 		timer3: timer@4001a000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x4001a000 0x1000>;
 			interrupts = <26 1>;
 			prescaler = <0>;
@@ -304,7 +304,7 @@
 
 		timer4: timer@4001b000 {
 			compatible = "nordic,nrf-timer";
-			status = "ok";
+			status = "okay";
 			reg = <0x4001b000 0x1000>;
 			interrupts = <27 1>;
 			prescaler = <0>;
@@ -315,7 +315,7 @@
 			compatible = "nordic,nrf-temp";
 			reg = <0x4000c000 0x1000>;
 			interrupts = <12 1>;
-			status = "ok";
+			status = "okay";
 			label = "TEMP_0";
 		};
 
@@ -341,7 +341,7 @@
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
 			interrupts = <16 1>;
-			status = "ok";
+			status = "okay";
 			label = "WDT";
 		};
 
@@ -349,7 +349,7 @@
 			compatible = "nordic,nrf-cc310";
 			reg = <0x5002A000 0x1000>;
 			label = "CRYPTOCELL";
-			status = "ok";
+			status = "okay";
 			#address-cells = <1>;
 			#size-cells = <1>;
 			cryptocell310: crypto@5002b000 {

--- a/dts/arm/nordic/nrf9160.dtsi
+++ b/dts/arm/nordic/nrf9160.dtsi
@@ -90,13 +90,13 @@
 			compatible = "nordic,nrf-spu";
 			reg = <0x50003000 0x1000>;
 			interrupts = <3 1>;
-			status = "ok";
+			status = "okay";
 		};
 
 		ficr: ficr@ff0000 {
 			compatible = "nordic,nrf-ficr";
 			reg = <0xff0000 0x1000>;
-			status = "ok";
+			status = "okay";
 		};
 	};
 };

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -32,7 +32,7 @@ adc: adc@e000 {
 dppic: dppic@17000 {
 	compatible = "nordic,nrf-dppic";
 	reg = <0x17000 0x1000>;
-	status = "ok";
+	status = "okay";
 	label = "DPPIC";
 };
 
@@ -197,7 +197,7 @@ rtc0: rtc@14000 {
 	compatible = "nordic,nrf-rtc";
 	reg = <0x14000 0x1000>;
 	interrupts = <20 1>;
-	status = "ok";
+	status = "okay";
 	clock-frequency = <32768>;
 	prescaler = <1>;
 	label = "RTC_0";
@@ -207,7 +207,7 @@ rtc1: rtc@15000 {
 	compatible = "nordic,nrf-rtc";
 	reg = <0x15000 0x1000>;
 	interrupts = <21 1>;
-	status = "ok";
+	status = "okay";
 	clock-frequency = <32768>;
 	prescaler = <1>;
 	label = "RTC_1";
@@ -217,7 +217,7 @@ clock: clock@5000 {
 	compatible = "nordic,nrf-clock";
 	reg = <0x5000 0x1000>;
 	interrupts = <5 1>;
-	status = "ok";
+	status = "okay";
 	label = "CLOCK";
 };
 
@@ -225,14 +225,14 @@ power: power@5000 {
 	compatible = "nordic,nrf-power";
 	reg = <0x5000 0x1000>;
 	interrupts = <5 1>;
-	status = "ok";
+	status = "okay";
 };
 
 wdt: watchdog@18000 {
 	compatible = "nordic,nrf-watchdog";
 	reg = <0x18000 0x1000>;
 	interrupts = <24 1>;
-	status = "ok";
+	status = "okay";
 	label = "WDT";
 };
 

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -429,7 +429,7 @@
 		rnga: random@40029000 {
 			compatible = "nxp,kinetis-rnga";
 			reg = <0x40029000 0x1000>;
-			status = "ok";
+			status = "okay";
 			interrupts = <23 0>;
 			label = "RNGA";
 		};

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -267,7 +267,7 @@
 				spi-max-frequency = <8000000>;
 				irqb-gpios = <&gpiob 3 0>;
 				reset-gpios = <&gpiob 19 0>;
-				status = "ok";
+				status = "okay";
 			};
 		};
 
@@ -331,7 +331,7 @@
 		rnga: random@40029000 {
 			compatible = "nxp,kinetis-rnga";
 			reg = <0x40029000 0x1000>;
-			status = "ok";
+			status = "okay";
 			interrupts = <23 0>;
 			label = "RNGA";
 		};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -248,7 +248,7 @@
 		trng: random@40029000 {
 			compatible = "nxp,kinetis-trng";
 			reg = <0x40029000 0x1000>;
-			status = "ok";
+			status = "okay";
 			interrupts = <13 0>;
 			label = "TRNG";
 		};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -251,7 +251,7 @@
 		trng: random@40029000 {
 			compatible = "nxp,kinetis-trng";
 			reg = <0x40029000 0x1000>;
-			status = "ok";
+			status = "okay";
 			interrupts = <13 0>;
 			label = "TRNG";
 		};

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -331,7 +331,7 @@
 		trng: random@400cc000 {
 			compatible = "nxp,kinetis-trng";
 			reg = <0x400cc000 0x4000>;
-			status = "ok";
+			status = "okay";
 			interrupts = <53 0>;
 			label = "TRNG";
 		};

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -12,6 +12,6 @@
 	w25q32jvwj0: w25q32jvwj@0 {
 		compatible = "winbond,w25q32jvwj", "jedec,spi-nor";
 		reg = <0>;
-		status = "ok";
+		status = "okay";
 	};
 };

--- a/dts/x86/apollo_lake.dtsi
+++ b/dts/x86/apollo_lake.dtsi
@@ -56,7 +56,7 @@
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			status = "ok";
+			status = "okay";
 			current-speed = <115200>;
 		};
 
@@ -71,7 +71,7 @@
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			status = "ok";
+			status = "okay";
 			current-speed = <115200>;
 		};
 
@@ -86,7 +86,7 @@
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			status = "ok";
+			status = "okay";
 			current-speed = <115200>;
 		};
 
@@ -101,7 +101,7 @@
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			status = "ok";
+			status = "okay";
 			current-speed = <115200>;
 		};
 
@@ -116,7 +116,7 @@
 			interrupt-parent = <&intc>;
 			label = "I2C_0";
 
-			status = "ok";
+			status = "okay";
 		};
 
 		i2c1: i2c@1 {
@@ -130,7 +130,7 @@
 			interrupt-parent = <&intc>;
 			label = "I2C_1";
 
-			status = "ok";
+			status = "okay";
 		};
 
 		i2c2: i2c@2 {
@@ -144,7 +144,7 @@
 			interrupt-parent = <&intc>;
 			label = "I2C_2";
 
-			status = "ok";
+			status = "okay";
 		};
 
 		i2c3: i2c@3 {
@@ -158,7 +158,7 @@
 			interrupt-parent = <&intc>;
 			label = "I2C_3";
 
-			status = "ok";
+			status = "okay";
 		};
 
 		i2c4: i2c@4 {
@@ -172,7 +172,7 @@
 			interrupt-parent = <&intc>;
 			label = "I2C_4";
 
-			status = "ok";
+			status = "okay";
 		};
 
 		i2c5: i2c@5 {
@@ -186,7 +186,7 @@
 			interrupt-parent = <&intc>;
 			label = "I2C_5";
 
-			status = "ok";
+			status = "okay";
 		};
 
 		i2c6: i2c@6 {
@@ -200,7 +200,7 @@
 			interrupt-parent = <&intc>;
 			label = "I2C_6";
 
-			status = "ok";
+			status = "okay";
 		};
 
 		i2c7: i2c@7 {
@@ -214,7 +214,7 @@
 			interrupt-parent = <&intc>;
 			label = "I2C_7";
 
-			status = "ok";
+			status = "okay";
 		};
 
 		gpio: gpio@d0c50000 {
@@ -230,7 +230,7 @@
 			gpio-controller ;
 			#gpio-cells = <2>;
 
-			status = "ok";
+			status = "okay";
 		};
 	};
 };

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -22,21 +22,21 @@
 };
 
 &gpiote {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio0 {
-	status ="ok";
+	status = "okay";
 };
 
 &gpio1 {
-	status ="ok";
+	status = "okay";
 };
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <6>;
 	rx-pin = <8>;
 	rts-pin = <5>;
@@ -85,5 +85,5 @@
 
 &usbd {
 	compatible = "nordic,nrf-usbd";
-	status = "ok";
+	status = "okay";
 };

--- a/samples/bluetooth/hci_uart/96b_nitrogen.overlay
+++ b/samples/bluetooth/hci_uart/96b_nitrogen.overlay
@@ -3,5 +3,5 @@
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <1000000>;
-	status = "ok";
+	status = "okay";
 };

--- a/samples/bluetooth/hci_uart/nrf51_blenano.overlay
+++ b/samples/bluetooth/hci_uart/nrf51_blenano.overlay
@@ -3,5 +3,5 @@
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <1000000>;
-	status = "ok";
+	status = "okay";
 };

--- a/samples/bluetooth/hci_uart/nrf51_pca10028.overlay
+++ b/samples/bluetooth/hci_uart/nrf51_pca10028.overlay
@@ -3,5 +3,5 @@
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <1000000>;
-	status = "ok";
+	status = "okay";
 };

--- a/samples/bluetooth/hci_uart/nrf52840_pca10056.overlay
+++ b/samples/bluetooth/hci_uart/nrf52840_pca10056.overlay
@@ -3,5 +3,5 @@
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <1000000>;
-	status = "ok";
+	status = "okay";
 };

--- a/samples/bluetooth/hci_uart/nrf52840_pca10090.overlay
+++ b/samples/bluetooth/hci_uart/nrf52840_pca10090.overlay
@@ -9,7 +9,7 @@
 &uart1 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <1000000>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <17>;
 	rx-pin = <20>;
 	rts-pin = <15>;

--- a/samples/bluetooth/hci_uart/nrf52_blenano2.overlay
+++ b/samples/bluetooth/hci_uart/nrf52_blenano2.overlay
@@ -3,5 +3,5 @@
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <1000000>;
-	status = "ok";
+	status = "okay";
 };

--- a/samples/bluetooth/hci_uart/nrf52_pca10040.overlay
+++ b/samples/bluetooth/hci_uart/nrf52_pca10040.overlay
@@ -3,5 +3,5 @@
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <1000000>;
-	status = "ok";
+	status = "okay";
 };

--- a/samples/display/cfb/frdm_k64f.overlay
+++ b/samples/display/cfb/frdm_k64f.overlay
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 
 	ssd1306@3c {
 		compatible = "solomon,ssd1306fb";

--- a/samples/display/cfb_shell/frdm_k64f.overlay
+++ b/samples/display/cfb_shell/frdm_k64f.overlay
@@ -5,7 +5,7 @@
  */
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 
 	ssd1306@3c {
 		compatible = "solomon,ssd1306fb";

--- a/samples/display/ili9340/nrf52840_pca10056.overlay
+++ b/samples/display/ili9340/nrf52840_pca10056.overlay
@@ -5,7 +5,7 @@
  */
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <47>;
 	mosi-pin = <45>;
 	miso-pin = <46>;

--- a/samples/display/ili9340/nrf52_pca10040.overlay
+++ b/samples/display/ili9340/nrf52_pca10040.overlay
@@ -5,7 +5,7 @@
  */
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	sck-pin = <25>;
 	mosi-pin = <23>;
 	miso-pin = <24>;

--- a/samples/display/ili9340/nucleo_l476rg.overlay
+++ b/samples/display/ili9340/nucleo_l476rg.overlay
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 
 	ili9340@0 {
 		compatible = "ilitek,ili9340";

--- a/samples/drivers/CAN/mcp2515-dts.overlay
+++ b/samples/drivers/CAN/mcp2515-dts.overlay
@@ -5,14 +5,14 @@
  */
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	cs-gpios = <&gpioa 4 GPIO_DIR_OUT>;
 	mcp2515@0 {
 		compatible = "microchip,mcp2515";
 		spi-port-name = "SPI_1";
 		spi-max-frequency = <1000000>;
 		int-gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
-		status = "ok";
+		status = "okay";
 		label = "CAN_1";
 		reg = <0>;
 		bus-speed = <250000>;

--- a/samples/drivers/led_lp5562/nrf52840_pca10056.overlay
+++ b/samples/drivers/led_lp5562/nrf52840_pca10056.overlay
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &i2c0 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 
 	lp5562@30 {

--- a/samples/drivers/led_pca9633/stm32373c_eval.overlay
+++ b/samples/drivers/led_pca9633/stm32373c_eval.overlay
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 
 	pca9633@62 {

--- a/samples/gui/lvgl/nrf52840_pca10056.overlay
+++ b/samples/gui/lvgl/nrf52840_pca10056.overlay
@@ -5,7 +5,7 @@
  */
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	cs-gpios = <&gpio0 4 0>;
 
 	ili9340@0 {

--- a/samples/net/sockets/echo_client/arduino_101.overlay
+++ b/samples/net/sockets/echo_client/arduino_101.overlay
@@ -5,7 +5,7 @@
  */
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	cs-gpios = <&gpio0 0 0>;
 
 	enc28j60@0 {
@@ -14,7 +14,7 @@
 		local-mac-address = [00 00 00 00 00 00];
 		spi-max-frequency = <128000>;
 		int-gpios = <&gpio0 19 1>;
-		status = "ok";
+		status = "okay";
 		label = "ETH_0";
 		reg = <0>;
 	};

--- a/samples/net/sockets/echo_server/arduino_101.overlay
+++ b/samples/net/sockets/echo_server/arduino_101.overlay
@@ -5,7 +5,7 @@
  */
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	cs-gpios = <&gpio0 0 0>;
 
 	enc28j60@0 {
@@ -14,7 +14,7 @@
 		local-mac-address = [00 00 00 00 00 00];
 		spi-max-frequency = <128000>;
 		int-gpios = <&gpio0 19 1>;
-		status = "ok";
+		status = "okay";
 		label = "ETH_0";
 		reg = <0>;
 	};

--- a/samples/net/wifi/quark_se_c1000_devboard.overlay
+++ b/samples/net/wifi/quark_se_c1000_devboard.overlay
@@ -2,12 +2,12 @@
 
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 
 	cs-gpios = <&gpio0 13 0>;
 
 	winc1500@0 {
-		status = "ok";
+		status = "okay";
 		compatible = "atmel,winc1500";
 		reg = <0x0>;
 		label = "winc1500";

--- a/samples/sensor/adt7420/frdm_k64f.overlay
+++ b/samples/sensor/adt7420/frdm_k64f.overlay
@@ -5,7 +5,7 @@
  */
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	adt7420@13 {
 		compatible = "adi,adt7420";

--- a/samples/sensor/adxl372/frdm_k64f.overlay
+++ b/samples/sensor/adxl372/frdm_k64f.overlay
@@ -5,7 +5,7 @@
  */
 
 &i2c1 {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	adxl372@11 {
 		compatible = "adi,adxl372";

--- a/samples/sensor/ams_iAQcore/iaq_core.overlay
+++ b/samples/sensor/ams_iAQcore/iaq_core.overlay
@@ -4,7 +4,7 @@
  */
 
 &arduino_i2c {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 
 	iaqcore: iaqcore@5a {

--- a/samples/sensor/ens210/ens210.overlay
+++ b/samples/sensor/ens210/ens210.overlay
@@ -4,7 +4,7 @@
  */
 
 &arduino_i2c {
-	status = "ok";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
 	ens210: ens210@43 {

--- a/samples/sensor/ms5837/nrf52840_pca10056.overlay
+++ b/samples/sensor/ms5837/nrf52840_pca10056.overlay
@@ -5,7 +5,7 @@
  */
 
 &i2c1 {
-    status = "ok";
+    status = "okay";
     clock-frequency = <I2C_BITRATE_STANDARD>;
     ms5837@76 {
         compatible = "meas,ms5837";

--- a/samples/subsys/fs/nrf52840_blip.overlay
+++ b/samples/subsys/fs/nrf52840_blip.overlay
@@ -5,13 +5,13 @@
  */
 
 &spi1 {
-        status = "ok";
+        status = "okay";
         cs-gpios = <&gpio0 17 0>;
 
         sdhc0: sdhc@0 {
                 compatible = "zephyr,mmc-spi-slot";
                 reg = <0>;
-                status = "ok";
+                status = "okay";
                 label = "SDHC0";
                 spi-max-frequency = <24000000>;
         };

--- a/tests/bluetooth/tester/nrf52840_pca10056.overlay
+++ b/tests/bluetooth/tester/nrf52840_pca10056.overlay
@@ -9,5 +9,5 @@
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 };

--- a/tests/bluetooth/tester/nrf52_pca10040.overlay
+++ b/tests/bluetooth/tester/nrf52_pca10040.overlay
@@ -9,5 +9,5 @@
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 };

--- a/tests/bluetooth/tester/reel_board.overlay
+++ b/tests/bluetooth/tester/reel_board.overlay
@@ -9,5 +9,5 @@
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 };

--- a/tests/drivers/uart/uart_async_api/nrf52840_pca10056.overlay
+++ b/tests/drivers/uart/uart_async_api/nrf52840_pca10056.overlay
@@ -8,7 +8,7 @@
 
 &uart1 {
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <6>;
 	rx-pin = <8>;
 	rts-pin = <0>;
@@ -18,7 +18,7 @@
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
-	status = "ok";
+	status = "okay";
 	tx-pin = <33>;
 	rx-pin = <34>;
 	rts-pin = <5>;

--- a/tests/drivers/uart/uart_async_api/nrf9160_pca10090.overlay
+++ b/tests/drivers/uart/uart_async_api/nrf9160_pca10090.overlay
@@ -3,7 +3,7 @@
 &uart1 {
 	current-speed = <115200>;
 	compatible = "nordic,nrf-uarte";
-	status = "ok";
+	status = "okay";
 	tx-pin = <10>;
 	rx-pin = <11>;
 };


### PR DESCRIPTION
The DT spec. only has "okay" and not "ok". The Linux kernel has around
12k "okay"s and 300 "ok"s.

The scripts/dts scripts only check for "disabled", so should be safe re.
those at least.

The replacement was done with

    git ls-files | xargs sed -i 's/status\s*=\s*"ok"/status = "okay"/'