### PR TITLE
Document building with west by default 

### DIFF
--- a/boards/arm/frdm_k64f/doc/index.rst
+++ b/boards/arm/frdm_k64f/doc/index.rst
@@ -235,11 +235,12 @@ the `OpenSDA J-Link Generic Firmware for V3.2 Bootloader`_. Note that Segger
 does provide an OpenSDA J-Link Board-Specific Firmware for this board, however
 it is not compatible with the DAPLink bootloader.
 
-Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``cmake`` or ``west
-build`` to override the default runner from pyOCD to J-Link:
+Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``west build`` or
+``cmake`` to override the default runner from pyOCD to J-Link:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
+   :tool: all
    :board: frdm_k64f
    :gen-args: -DOPENSDA_FW=jlink
    :goals: build

--- a/boards/arm/frdm_kl25z/doc/index.rst
+++ b/boards/arm/frdm_kl25z/doc/index.rst
@@ -149,11 +149,12 @@ path.
 Follow the instructions in :ref:`opensda-jlink-onboard-debug-probe` to program
 the `OpenSDA J-Link FRDM-KL25Z Firmware`_.
 
-Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``cmake`` or ``west
-build`` to override the default runner from pyOCD to J-Link:
+Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``west build`` or
+``cmake`` to override the default runner from pyOCD to J-Link:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
+   :tool: all
    :board: frdm_kl25z
    :gen-args: -DOPENSDA_FW=jlink
    :goals: build

--- a/boards/arm/frdm_kw41z/doc/index.rst
+++ b/boards/arm/frdm_kw41z/doc/index.rst
@@ -168,11 +168,12 @@ path.
 Follow the instructions in :ref:`opensda-jlink-onboard-debug-probe` to program
 the `OpenSDA J-Link FRDM-KW41Z Firmware`_.
 
-Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``cmake`` or ``west
-build`` to override the default runner from pyOCD to J-Link:
+Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``west build`` or
+``cmake`` to override the default runner from pyOCD to J-Link:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
+   :tool: all
    :board: frdm_kw41z
    :gen-args: -DOPENSDA_FW=jlink
    :goals: build

--- a/boards/arm/hexiwear_k64/doc/index.rst
+++ b/boards/arm/hexiwear_k64/doc/index.rst
@@ -189,11 +189,12 @@ program the `OpenSDA DAPLink Hexiwear Firmware`_. Check that switches SW1 and
 SW2 are **on**, and SW3 and SW4 are **off**  to ensure K64F SWD signals are
 connected to the OpenSDA microcontroller.
 
-Add the argument ``-DOPENSDA_FW=daplink`` when you invoke ``cmake`` or ``west
-build`` to override the default runner from J-Link to pyOCD:
+Add the argument ``-DOPENSDA_FW=daplink`` when you invoke ``west build`` or
+``cmake`` to override the default runner from J-Link to pyOCD:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
+   :tool: all
    :board: hexiwear_k64
    :gen-args: -DOPENSDA_FW=daplink
    :goals: build

--- a/boards/arm/stm32mp157c_dk2/doc/stm32mp157_dk2.rst
+++ b/boards/arm/stm32mp157c_dk2/doc/stm32mp157_dk2.rst
@@ -260,17 +260,11 @@ install `stm32mp1 developer package`_.
 
 2) run gdb in Zephyr environment
 
-   .. code-block:: console
-
-      # On Linux
-      cd $ZEPHYR_BASE/samples/hello_world
-      mkdir -p build && cd build
-
-      # Use cmake to configure a Ninja-based build system:
-      cmake -GNinja -DBOARD=stm32mp157_dk2 ..
-
-      # Now run ninja on the generated build system:
-      ninja debug
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :tool: all
+      :board: stm32mp157_dk2
+      :goals: debug
 
 .. _STM32P157C Discovery website:
    https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-mpu-eval-tools/stm32-mcu-mpu-eval-tools/stm32-discovery-kits/stm32mp157c-dk2.html

--- a/boards/arm/twr_ke18f/doc/index.rst
+++ b/boards/arm/twr_ke18f/doc/index.rst
@@ -155,11 +155,12 @@ path.
 Follow the instructions in :ref:`opensda-jlink-onboard-debug-probe` to program
 the `OpenSDA J-Link Firmware for TWR-KE18F`_.
 
-Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``cmake`` or ``west
-build`` to override the default runner from pyOCD to J-Link:
+Add the argument ``-DOPENSDA_FW=jlink`` when you invoke ``west build`` or
+``cmake`` to override the default runner from pyOCD to J-Link:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
+   :tool: all
    :board: twr_ke18f
    :gen-args: -DOPENSDA_FW=jlink
    :goals: build

--- a/boards/posix/native_posix/doc/index.rst
+++ b/boards/posix/native_posix/doc/index.rst
@@ -160,7 +160,7 @@ Run the zephyr.exe executable as you would any other Linux console application.
 
 .. code-block:: console
 
-   $ zephyr/zephyr.exe
+   $ ./build/zephyr/zephyr.exe
    # Press Ctrl+C to exit
 
 This executable accepts several command line options depending on the
@@ -168,7 +168,7 @@ compilation configuration.
 You can run it with the ``--help`` command line switch to get a list of
 available options::
 
-   $ zephyr/zephyr.exe --help
+   $ ./build/zephyr/zephyr.exe --help
 
 Note that the Zephyr kernel does not actually exit once the application is
 finished. It simply goes into the idle loop forever.
@@ -202,7 +202,7 @@ Address Sanitizer (ASan)
 
 You can also build Zephyr with `Address Sanitizer`_. To do this, set
 :option:`CONFIG_ASAN`, for example, in the application project file, or in the
-cmake command line invocation.
+``west build`` or ``cmake`` command line invocation.
 
 Note that you will need the ASan library installed in your system.
 In Debian/Ubuntu this is ``libasan1``.

--- a/boards/posix/nrf52_bsim/doc/index.rst
+++ b/boards/posix/nrf52_bsim/doc/index.rst
@@ -85,7 +85,7 @@ Then you can execute your application using:
 
 .. code-block:: console
 
-   $ zephyr/zephyr.exe -nosim
+   $ ./build/zephyr/zephyr.exe -nosim
    # Press Ctrl+C to exit
 
 Note that the executable is a BabbleSim executable. The ``-nosim`` command line
@@ -110,7 +110,7 @@ executable to the simulator bin folder with a sensible name:
 
 .. code-block:: console
 
-   $ cp zephyr/zephyr.exe \
+   $ cp build/zephyr/zephyr.exe \
      ${BSIM_OUT_PATH}/bin/bs_nrf52_bsim_samples_bluetooth_central_hr
 
 Do the same for the ``peripheral`` sample app:
@@ -124,7 +124,7 @@ Do the same for the ``peripheral`` sample app:
 
 .. code-block:: console
 
-   $ cp zephyr/zephyr.exe \
+   $ cp build/zephyr/zephyr.exe \
      ${BSIM_OUT_PATH}/bin/bs_nrf52_bsim_samples_bluetooth_peripheral
 
 And then run them together with BabbleSim's 2G4 physical layer simulation:

--- a/boards/riscv32/rv32m1_vega/doc/index.rst
+++ b/boards/riscv32/rv32m1_vega/doc/index.rst
@@ -555,14 +555,14 @@ Linux and macOS (run this in a terminal from the Zephyr directory)::
 
   # Set up environment and create build directory:
   source zephyr-env.sh
-  cd samples/hello_world
-  mkdir build && cd build
 
-  # Use CMake to generate a Ninja-based build system:
-  cmake -GNinja -DBOARD=rv32m1_vega_ri5cy -DCMAKE_REQUIRED_FLAGS=-Wl,-dT=/dev/null ..
-
-  # Build the sample
-  ninja
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :tool: cmake
+   :cd-into:
+   :board: rv32m1_vega_ri5cy
+   :gen-args: -DCMAKE_REQUIRED_FLAGS=-Wl,-dT=/dev/null
+   :goals: build
 
 Windows (run this in a ``cmd`` prompt, from the Zephyr directory)::
 

--- a/boards/shields/frdm_kw41z/doc/index.rst
+++ b/boards/shields/frdm_kw41z/doc/index.rst
@@ -53,11 +53,12 @@ host controller interface (HCI):
 #. Attach the FRDM-KW41Z to the Arduino header on your selected main board,
    such as :ref:`mimxrt1050_evk` or :ref:`frdm_k64f`.
 
-#. Set ``-DSHIELD=frdm_kw41z`` when you invoke cmake in your Zephyr bluetooth
-   application. For example,
+#. Set ``-DSHIELD=frdm_kw41z`` when you invoke ``west build`` or ``cmake`` in
+   your Zephyr bluetooth application. For example,
 
    .. zephyr-app-commands::
       :zephyr-app: samples/bluetooth/peripheral_hr
+      :tool: all
       :board: frdm_k64f
       :shield: frdm_kw41z
       :goals: build

--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -33,12 +33,15 @@ class ZephyrAppCommandsDirective(Directive):
       The default is 'cmake'.
 
     \:app:
-      if set, the commands will change directories to this path to the
-      application.
+      path to the application to build.
 
     \:zephyr-app:
-      like \:app:, but includes instructions from the Zephyr base
-      directory. Cannot be given with \:app:.
+      path to the application to build, this is an app present in the upstream
+      zephyr repository. Mutually exclusive with \:app:.
+
+    \:cd-into:
+      if set, build instructions are given from within the \:app: folder,
+      instead of outside of it.
 
     \:generator:
       which build system to generate. Valid options are
@@ -95,6 +98,7 @@ class ZephyrAppCommandsDirective(Directive):
         'tool': directives.unchanged,
         'app': directives.unchanged,
         'zephyr-app': directives.unchanged,
+        'cd-into': directives.flag,
         'generator': directives.unchanged,
         'host-os': directives.unchanged,
         'board': directives.unchanged,
@@ -111,6 +115,7 @@ class ZephyrAppCommandsDirective(Directive):
     TOOLS = ['cmake', 'west', 'all']
     GENERATORS = ['make', 'ninja']
     HOST_OS = ['unix', 'win', 'all']
+    IN_TREE_STR = '# From the root of the zephyr repository'
 
     def run(self):
         # Re-run on the current document if this directive's source changes.
@@ -121,6 +126,7 @@ class ZephyrAppCommandsDirective(Directive):
         tool = self.options.get('tool', 'cmake').lower()
         app = self.options.get('app', None)
         zephyr_app = self.options.get('zephyr-app', None)
+        cd_into = 'cd-into' in self.options
         generator = self.options.get('generator', 'ninja').lower()
         host_os = self.options.get('host-os', 'all').lower()
         board = self.options.get('board', None)
@@ -151,10 +157,11 @@ class ZephyrAppCommandsDirective(Directive):
         if compact and skip_config:
             raise self.error('Both compact and maybe-skip-config options were given.')
 
+        app = app or zephyr_app
+        in_tree = self.IN_TREE_STR if zephyr_app else None
         # Allow build directories which are nested.
         build_dir = ('build' + '/' + build_dir_append).rstrip('/')
         num_slashes = build_dir.count('/')
-        source_dir = '/'.join(['..' for i in range(num_slashes + 1)])
 
         # Create host_os array
         host_os = [host_os] if host_os != "all" else [v for v in self.HOST_OS
@@ -164,22 +171,21 @@ class ZephyrAppCommandsDirective(Directive):
                                                 if v != 'all']
         # Build the command content as a list, then convert to string.
         content = []
-        cd_to = zephyr_app or app
         tool_comment = None
         if len(tools) > 1:
             tool_comment = 'Using {}:'
 
         run_config = {
             'host_os': host_os,
-            'cd_to': cd_to,
+            'app': app,
+            'in_tree': in_tree,
+            'cd_into': cd_into,
             'board': board,
             'shield': shield,
             'conf': conf,
             'gen_args': gen_args,
-            'source_dir': source_dir,
             'build_args': build_args,
             'build_dir': build_dir,
-            'zephyr_app': zephyr_app,
             'goals': goals,
             'compact': compact,
             'skip_config': skip_config,
@@ -225,24 +231,31 @@ class ZephyrAppCommandsDirective(Directive):
     def _generate_west(self, **kwargs):
         content = []
         board = kwargs['board']
+        app = kwargs['app']
+        in_tree = kwargs['in_tree']
         goals = kwargs['goals']
-        cd_to = kwargs['cd_to']
+        cd_into = kwargs['cd_into']
         build_dir = kwargs['build_dir']
+        compact = kwargs['compact']
         kwargs['board'] = None
         cmake_args = self._cmake_args(**kwargs)
         cmake_args = ' --{}'.format(cmake_args) if cmake_args != '' else ''
         # ignore zephyr_app since west needs to run within
         # the installation. Instead rely on relative path.
-        src = ' {}'.format(cd_to) if cd_to else ''
+        src = ' {}'.format(app) if app and not cd_into else ''
         dst = ' -d {}'.format(build_dir) if build_dir != 'build' else ''
 
-        goal_args = ' -b {}{}{}{}'.format(board, dst, src, cmake_args)
-        if 'build' in goals:
-            content.append('west build{}'.format(goal_args))
-            # No longer need to specify additional args, they are in the
-            # CMake cache
-            goal_args = '{}'.format(dst)
+        if in_tree and not compact:
+            content.append(in_tree)
 
+        if cd_into and app:
+            content.append('cd {}'.format(app))
+
+        if 'build' in goals:
+            build_args = ' -b {}{}{}{}'.format(board, dst, src, cmake_args)
+            content.append('west build{}'.format(build_args))
+
+        goal_args = '{}'.format(dst)
         if 'sign' in goals:
             content.append('west sign{}'.format(goal_args))
 
@@ -266,6 +279,8 @@ class ZephyrAppCommandsDirective(Directive):
         content = []
         if skip_config:
             content.append("# If you already made a build directory ({}) and ran cmake, just 'cd {}' instead.".format(build_dir, build_dir))  # noqa: E501
+        if host_os == 'all':
+            content.append('mkdir {} && cd {}'.format(build_dir, build_dir))
         if host_os == "unix":
             content.append('{} {} && cd {}'.format(mkdir, build_dir, build_dir))
         elif host_os == "win":
@@ -274,6 +289,7 @@ class ZephyrAppCommandsDirective(Directive):
         return content
 
     def _cmake_args(self, **kwargs):
+        generator = kwargs['generator']
         board = kwargs['board']
         shield = kwargs['shield']
         conf = kwargs['conf']
@@ -285,91 +301,102 @@ class ZephyrAppCommandsDirective(Directive):
 
         return '{}{}{}{}'.format(board_arg, shield_arg, conf_arg, gen_args)
 
-    def _generate_make(self, **kwargs):
-        build_args = kwargs['build_args']
-        source_dir = kwargs['source_dir']
-        goals = kwargs['goals']
-        compact = kwargs['compact']
-
-        build_args = ' {}'.format(build_args) if build_args else ''
-        cmake_args = self._cmake_args(**kwargs)
-
-        content = []
-        content.extend(['cmake{} {}'.format(cmake_args, source_dir)])
-        if not compact:
-            content.extend(['',
-                            '# Now run make on the generated build system:'])
-        if 'build' in goals:
-            content.append('make{}'.format(build_args))
-        for goal in goals:
-            if goal == 'build':
-                continue
-            content.append('make {}'.format(goal))
-        return content
-
-    def _generate_ninja(self, **kwargs):
-        build_args = kwargs['build_args']
-        source_dir = kwargs['source_dir']
-        goals = kwargs['goals']
-        compact = kwargs['compact']
-
-        build_args = ' {}'.format(build_args) if build_args else ''
-        cmake_args = self._cmake_args(**kwargs)
-
-        content = []
-        content.extend(['cmake -GNinja{} {}'.format(cmake_args, source_dir)])
-        if not compact:
-            content.extend(['',
-                            '# Now run ninja on the generated build system:'])
-        if 'build' in goals:
-            content.append('ninja{}'.format(build_args))
-        for goal in goals:
-            if goal == 'build':
-                continue
-            content.append('ninja {}'.format(goal))
-        return content
-
-    def _generate_cmake(self, **kwargs):
+    def _cd_into(self, mkdir, **kwargs):
+        app = kwargs['app']
         host_os = kwargs['host_os']
-        cd_to = kwargs['cd_to']
-        zephyr_app = kwargs['zephyr_app']
-        host_os = kwargs['host_os']
+        compact = kwargs['compact']
         build_dir = kwargs['build_dir']
         skip_config = kwargs['skip_config']
-        compact = kwargs['compact']
-        generator = kwargs['generator']
-
-        num_slashes = build_dir.count('/')
-        mkdir = 'mkdir' if num_slashes == 0 else 'mkdir -p'
         content = []
         os_comment = None
         if len(host_os) > 1:
             os_comment = '# On {}'
-
+            num_slashes = build_dir.count('/')
+            if not app and mkdir and num_slashes == 0:
+                # When there's no app and a single level deep build dir,
+                # simplify output
+                content.extend(self._mkdir(mkdir, build_dir, 'all',
+                               skip_config))
+                if not compact:
+                    content.append('')
+                return content
         for host in host_os:
             if host == "unix":
                 if os_comment:
                     content.append(os_comment.format('Linux/macOS'))
-                if cd_to:
-                    prefix = '$ZEPHYR_BASE/' if zephyr_app else ''
-                    content.append('cd {}{}'.format(prefix, cd_to))
+                if app:
+                    content.append('cd {}'.format(app))
             elif host == "win":
                 if os_comment:
                     content.append(os_comment.format('Windows'))
-                if cd_to:
-                    prefix = '%ZEPHYR_BASE%\\' if zephyr_app else ''
-                    backslashified = cd_to.replace('/', '\\')
-                    content.append('cd {}{}'.format(prefix, backslashified))
-            content.extend(self._mkdir(mkdir, build_dir, host, skip_config))
+                if app:
+                    backslashified = app.replace('/', '\\')
+                    content.append('cd {}'.format(backslashified))
+            if mkdir:
+                content.extend(self._mkdir(mkdir, build_dir, host, skip_config))
             if not compact:
                 content.append('')
+        return content
+
+    def _generate_cmake(self, **kwargs):
+        generator = kwargs['generator']
+        host_os = kwargs['host_os']
+        cd_into = kwargs['cd_into']
+        app = kwargs['app']
+        in_tree = kwargs['in_tree']
+        host_os = kwargs['host_os']
+        build_dir = kwargs['build_dir']
+        build_args = kwargs['build_args']
+        skip_config = kwargs['skip_config']
+        goals = kwargs['goals']
+        compact = kwargs['compact']
+
+        content = []
+
+        if in_tree and not compact:
+            content.append(in_tree)
+
+        if cd_into:
+            num_slashes = build_dir.count('/')
+            mkdir = 'mkdir' if num_slashes == 0 else 'mkdir -p'
+            content.extend(self._cd_into(mkdir, **kwargs))
+            # Prepare cmake/ninja/make variables
+            source_dir = ' ' + '/'.join(['..' for i in range(num_slashes + 1)])
+            cmake_build_dir = ''
+            tool_build_dir = ''
+        else:
+            source_dir = ' {}'.format(app) if app else ' .'
+            cmake_build_dir = ' -B{}'.format(build_dir)
+            tool_build_dir = ' -C{}'.format(build_dir)
+
+        # Now generate the actual cmake and make/ninja commands
+        gen_arg = ' -GNinja' if generator == 'ninja' else ''
+        build_args = ' {}'.format(build_args) if build_args else ''
+        cmake_args = self._cmake_args(**kwargs)
 
         if not compact:
-            content.append('# Use cmake to configure a {}-based build system:'.format(generator.capitalize()))  # noqa: E501
-        if generator == 'make':
-            content.extend(self._generate_make(**kwargs))
-        elif generator == 'ninja':
-            content.extend(self._generate_ninja(**kwargs))
+            if not cd_into and skip_config:
+                content.append("# If you already ran cmake with -B{}, you " \
+                               "can skip this step and run {} directly.".
+                               format(build_dir, generator))  # noqa: E501
+            else:
+                content.append('# Use cmake to configure a {}-based build' \
+                               'system:'.format(generator.capitalize()))  # noqa: E501
+
+        content.append('cmake{}{}{}{}'.format(cmake_build_dir, gen_arg,
+                                              cmake_args, source_dir))
+        if not compact:
+            content.extend(['',
+                            '# Now run ninja on the generated build system:'])
+
+        if 'build' in goals:
+            content.append('{}{}{}'.format(generator, tool_build_dir,
+                                           build_args))
+        for goal in goals:
+            if goal == 'build':
+                continue
+            content.append('{}{} {}'.format(generator, tool_build_dir, goal))
+
         return content
 
 

--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -30,7 +30,7 @@ class ZephyrAppCommandsDirective(Directive):
 
     \:tool:
       which tool to use. Valid options are currently 'cmake', 'west' and 'all'.
-      The default is 'cmake'.
+      The default is 'all'.
 
     \:app:
       path to the application to build.
@@ -123,7 +123,7 @@ class ZephyrAppCommandsDirective(Directive):
 
         # Parse directive options.  Don't use os.path.sep or os.path.join here!
         # That would break if building the docs on Windows.
-        tool = self.options.get('tool', 'cmake').lower()
+        tool = self.options.get('tool', 'all').lower()
         app = self.options.get('app', None)
         zephyr_app = self.options.get('zephyr-app', None)
         cd_into = 'cd-into' in self.options

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -182,10 +182,6 @@ inside the ``zephyrproject`` directory for a list of supported boards.
 
 #. Build the Hello World sample for the ``reel_board``:
 
-   .. Note: we don't use :zephyr-app: here because we just told the user to cd
-      to ZEPHYR_BASE, so it's not necessary for clarity and would clutter the
-      instructions a bit.
-
    .. zephyr-app-commands::
       :tool: all
       :app: samples/hello_world
@@ -279,15 +275,15 @@ Next, run the application.
    # With west:
    west build -t run
 
-   # With ninja, from the build directory:
-   ninja run
+   # With ninja:
+   ninja -Cbuild run
 
    # or just run zephyr.exe directly:
-   ./zephyr/zephyr.exe
+   ./build/zephyr/zephyr.exe
 
 Press :kbd:`Ctrl-C` to exit.
 
-You can run ``./zephyr/zephyr.exe --help`` to get a list of available
+You can run ``./build/zephyr/zephyr.exe --help`` to get a list of available
 options.
 
 This executable can be instrumented using standard tools, such as gdb or

--- a/doc/getting_started/toolchain_custom_cmake.rst
+++ b/doc/getting_started/toolchain_custom_cmake.rst
@@ -28,6 +28,10 @@ variables when generating a build system for a Zephyr application, like so:
 
 .. code-block:: console
 
+   west build ... -- -DZEPHYR_TOOLCHAIN_VARIANT=... -DTOOLCHAIN_ROOT=...
+
+.. code-block:: console
+
    cmake -DZEPHYR_TOOLCHAIN_VARIANT=... -DTOOLCHAIN_ROOT=...
 
 If you do this, ``-C <initial-cache>`` `cmake option`_ may useful. If you save

--- a/doc/guides/bluetooth/bluetooth-tools.rst
+++ b/doc/guides/bluetooth/bluetooth-tools.rst
@@ -149,7 +149,7 @@ building and running a sample:
 
   And then run it with::
 
-     $ sudo zephyr/zephyr.exe --bt-dev=hci0
+     $ sudo ./build/zephyr/zephyr.exe --bt-dev=hci0
 
 Using a Zephyr-based BLE Controller
 ===================================

--- a/doc/guides/coverage.rst
+++ b/doc/guides/coverage.rst
@@ -48,16 +48,28 @@ These steps will produce an HTML coverage report for a single application.
 
 1. Build the code with CONFIG_COVERAGE=y. Some boards like qemu_x86_coverage
    automatically enable this, but for boards that do not you will need to
-   enable the configuration manually::
+   enable the configuration manually:
 
-     $ cmake -DBOARD=mps2_an385 -DCONFIG_COVERAGE=y ..
-     $ make
+   .. zephyr-app-commands::
+      :tool: all
+      :board: mps2_an385
+      :gen-args: -DCONFIG_COVERAGE=y
+      :goals: build
+      :compact:
 
 #. Capture the emulator output into a log file. You may need to terminate
    the emulator with :kbd:`Ctrl-A X` for this to complete after the coverage dump
-   has been printed::
+   has been printed:
 
-     $ make run | tee log.log
+   .. code-block:: console
+
+      ninja -Cbuild run | tee log.log
+
+   or
+
+   .. code-block:: console
+
+      ninja -Cbuild run | tee log.log
 
 #. Generate the gcov ``.gcda`` and ``.gcno`` files from the log file that was
    saved::
@@ -107,7 +119,7 @@ You may postprocess these with your preferred tools. For example:
 
 .. code-block:: console
 
-   $ zephyr/zephyr.exe
+   $ ./build/zephyr/zephyr.exe
    # Press Ctrl+C to exit
    lcov --capture --directory ./ --output-file lcov.info -q --rc lcov_branch_coverage=1
    genhtml lcov.info --output-directory lcov_html -q --ignore-errors source --branch-coverage --highlight --legend

--- a/doc/guides/networking/qemu_setup.rst
+++ b/doc/guides/networking/qemu_setup.rst
@@ -245,7 +245,7 @@ Terminal #1:
    $ZEPHYR_BASE/../net-tools/tunslip6 -t tapMAIN -T -s /tmp/slip.devMAIN \
         2001:db8::1/64
    # Now run Zephyr
-   make run QEMU_INSTANCE=MAIN
+   make -Cbuild run QEMU_INSTANCE=MAIN
 
 Terminal #2:
 ============
@@ -255,4 +255,4 @@ Terminal #2:
    socat PTY,link=/tmp/slip.devOTHER UNIX-LISTEN:/tmp/slip.sockOTHER
    $ZEPHYR_BASE/../net-tools/tunslip6 -t tapOTHER -T -s /tmp/slip.devOTHER \
         2001:db8::1/64
-   make run QEMU_INSTANCE=OTHER
+   make -Cbuild run QEMU_INSTANCE=OTHER

--- a/doc/guides/test/sanitycheck.rst
+++ b/doc/guides/test/sanitycheck.rst
@@ -201,9 +201,13 @@ required for best test coverage for this specific board:
 
 identifier:
   A string that matches how the board is defined in the build system. This same
-  string is used when building, for example when calling 'cmake'::
+  string is used when building, for example when calling ``west build`` or
+  ``cmake``::
 
-  # cmake -DBOARD=quark_d2000_crb ..
+     # with west
+     west build -b quark_d2000_crb
+     # with cmake
+     cmake -DBOARD=quark_d2000_crb ..
 
 name:
   The actual name of the board as it appears in marketing material.

--- a/doc/reference/usb/index.rst
+++ b/doc/reference/usb/index.rst
@@ -123,7 +123,7 @@ Run built sample with:
 
 .. code-block:: console
 
-   $ make run
+   make -Cbuild run
 
 In a terminal window, run the following command to list USB devices:
 

--- a/samples/boards/intel_s1000_crb/i2s/i2s_app.rst
+++ b/samples/boards/intel_s1000_crb/i2s/i2s_app.rst
@@ -22,7 +22,7 @@ The host is a slave on the I2S and is expected to send a stereo audio at a
 sampling frequency of 48KHz, 32 bits per sample.
 
 The app can be built in one of two modes and the mode selection is done by
-providing a command line flag to ``cmake``.
+providing a command line flag to ``west build`` or ``cmake``.
 
 1. **Audio Playback from Host**
 
@@ -34,7 +34,7 @@ providing a command line flag to ``cmake``.
    A copy of the same audio is also looped back to the host.
 
    This mode is chosen when ``-DAUDIO_PLAY_FROM_HOST=Y`` is specified in the
-   ``cmake`` command.
+   ``west build`` or ``cmake`` command.
 
    In this mode, the app forwards the audio forever, and does not exit.
    After the app starts, one may use the ALSA aplay command on a Linux host
@@ -48,7 +48,7 @@ providing a command line flag to ``cmake``.
    the I2S bus connected to the codec.
 
    This mode is chosen when ``-DAUDIO_PLAY_FROM_HOST=N`` is specified in the
-   ``cmake`` command.
+   ``west build`` or ``cmake`` command.
 
    In this mode, the app exits after the tone sequence is played.
    For the duration of tone playback, the app uses the I2S interface connected
@@ -86,6 +86,7 @@ Audio Playback from a Host
 
 .. zephyr-app-commands::
    :zephyr-app: samples/boards/intel_s1000_crb/i2s
+   :tool: all
    :board:
    :goals: build
    :gen-args: -DAUDIO_PLAY_FROM_HOST=Y
@@ -96,6 +97,7 @@ Tone Sequence Playback
 
 .. zephyr-app-commands::
    :zephyr-app: samples/boards/intel_s1000_crb/i2s
+   :tool: all
    :board:
    :goals: build
    :gen-args: -DAUDIO_PLAY_FROM_HOST=N

--- a/samples/net/eth_native_posix/README.rst
+++ b/samples/net/eth_native_posix/README.rst
@@ -35,7 +35,7 @@ with admin privileges, like this:
 
 .. code-block:: console
 
-    sudo --preserve-env=ZEPHYR_BASE make run
+    sudo --preserve-env=ZEPHYR_BASE make -Cbuild run
 
 If the ``sudo --preserve-env=ZEPHYR_BASE`` gives an error,
 just use ``sudo --preserve-env`` instead.
@@ -105,15 +105,13 @@ just use ``sudo --preserve-env`` instead):
 
 .. code-block:: console
 
-    mkdir -p build1/native_posix
-    cmake -DCONF_FILE=prj1.conf -DBOARD=native_posix -Bbuild1/native_posix -H.
+    cmake -DCONF_FILE=prj1.conf -DBOARD=native_posix -Bbuild1/native_posix .
     make -s -C build1/native_posix
     sudo --preserve-env=ZEPHYR_BASE make -s -C build1/native_posix run
 
 .. code-block:: console
 
-    mkdir -p build2/native_posix
-    cmake -DCONF_FILE=prj2.conf -DBOARD=native_posix -Bbuild2/native_posix -H.
+    cmake -DCONF_FILE=prj2.conf -DBOARD=native_posix -Bbuild2/native_posix .
     make -s -C build2/native_posix
     sudo --preserve-env=ZEPHYR_BASE make -s -C build2/native_posix run
 

--- a/samples/net/mqtt_publisher/README.rst
+++ b/samples/net/mqtt_publisher/README.rst
@@ -136,8 +136,8 @@ try this sample with TLS enabled, by following these steps:
 - In :file:`src/main.c`, set TLS_SNI_HOSTNAME to ``"test.mosquitto.org"``
   to match the Common Name (CN) in the downloaded certificate.
 - Build the sample by specifying ``-DOVERLAY_CONFIG=overlay-tls.conf``
-  when running cmake (or refer to the TLS offloading section below if
-  your platform uses the offloading feature).
+  when running ``west build`` or ``cmake`` (or refer to the TLS offloading
+  section below if your platform uses the offloading feature).
 - Flash the binary onto the device to run the sample:
 
 .. code-block:: console
@@ -148,7 +148,8 @@ TLS offloading
 ==============
 
 For boards that support this feature, TLS offloading is used by
-specifying ``-DOVERLAY_CONFIG=overlay-tls-offload.conf`` when running cmake.
+specifying ``-DOVERLAY_CONFIG=overlay-tls-offload.conf`` when running ``west
+build`` or ``cmake``.
 
 Using this overlay enables TLS without bringing in mbedtls.
 
@@ -156,7 +157,8 @@ SOCKS5 proxy support
 ====================
 
 It is also possible to connect to the MQTT broker through a SOCKS5 proxy.
-To enable it, use ``-DOVERLAY_CONFIG=overlay-socks5.conf`` when running cmake.
+To enable it, use ``-DOVERLAY_CONFIG=overlay-socks5.conf`` when running ``west
+build`` or  ``cmake``.
 
 By default, to make the testing easier, the proxy is expected to run on the
 same host as the MQTT broker.

--- a/samples/net/sockets/big_http_download/README.rst
+++ b/samples/net/sockets/big_http_download/README.rst
@@ -81,7 +81,7 @@ Enable TLS support in the sample by building the project with the
    :compact:
 
 An alternative way is to specify ``-DOVERLAY_CONFIG=overlay-tls.conf`` when
-running cmake.
+running ``west build`` or ``cmake``.
 
 The TLS version of this sample downloads a file from
 https://www.7-zip.org/a/7z1805.exe (1.1MB). The certificate

--- a/samples/net/sockets/echo_client/README.rst
+++ b/samples/net/sockets/echo_client/README.rst
@@ -83,7 +83,7 @@ Enable TLS support in the sample by building the project with the
    :compact:
 
 An alternative way is to specify ``-DOVERLAY_CONFIG=overlay-tls.conf`` when
-running cmake.
+running ``west build`` or ``cmake``.
 
 The certificate and private key used by the sample can be found in the sample's
 ``src`` directory. The default certificates used by Socket Echo Client and

--- a/samples/net/sockets/echo_server/README.rst
+++ b/samples/net/sockets/echo_server/README.rst
@@ -84,7 +84,7 @@ Enable TLS support in the sample by building the project with the
    :compact:
 
 An alternative way is to specify ``-DOVERLAY_CONFIG=overlay-tls.conf`` when
-running cmake.
+running ``west build`` or ``cmake``.
 
 The certificate used by the sample can be found in the sample's ``src``
 directory. The default certificates used by Socket Echo Server and

--- a/samples/net/sockets/http_get/README.rst
+++ b/samples/net/sockets/http_get/README.rst
@@ -59,7 +59,7 @@ Enable TLS support in the sample by building the project with the
    :compact:
 
 An alternative way is to specify ``-DOVERLAY_CONFIG=overlay-tls.conf`` when
-running cmake.
+running ``west build`` or ``cmake``.
 
 The certificate used by the sample can be found in the sample's ``src``
 directory. The certificate was selected to enable access to the default website


### PR DESCRIPTION
This PR intends to make `west build` a first-class citizen in our documentation. This involves rewriting parts of the zephyr app extension so that we make use of modern CMake features and we do not rely on environment variables anymore, cleaning up the documentation that still refers to `cmake` as an executable directly and finally turn on the option to make west always present in build instructions.
 
See commit messages for additional details.

Fixes #15315