### PR TITLE
cmake: remove spurious IS_ABSOLUTE logic in zephyr_sources()

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -65,17 +65,10 @@
 # https://cmake.org/cmake/help/latest/command/target_sources.html
 function(zephyr_sources)
   foreach(arg ${ARGV})
-    if(IS_ABSOLUTE ${arg})
-      set(path ${arg})
-    else()
-      set(path ${CMAKE_CURRENT_SOURCE_DIR}/${arg})
-    endif()
-
-    if(IS_DIRECTORY ${path})
+    if(IS_DIRECTORY ${arg})
       message(FATAL_ERROR "zephyr_sources() was called on a directory")
     endif()
-
-    target_sources(zephyr PRIVATE ${path})
+    target_sources(zephyr PRIVATE ${arg})
   endforeach()
 endfunction()
 


### PR DESCRIPTION
target_sources() documentation states:

  Relative source file paths are interpreted as being relative to the
  current source directory (i.e. CMAKE_CURRENT_SOURCE_DIR).

Remove spurious code duplicating cmake's behaviour. It proved to be a
time-consuming red herring while debugging some path-related issue and
"less is more".

Signed-off-by: Marc Herbert <marc.herbert@intel.com>