### PR TITLE
samples/bluetooth/gatt: make it a CMake target and library

### DIFF
--- a/samples/bluetooth/gatt/CMakeLists.txt
+++ b/samples/bluetooth/gatt/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This makes the lower-level, CMake target name available in
+# ${ZEPHYR_CURRENT_LIBRARY}. See /cmake/extensions.cmake.
+zephyr_library_named(samples_bt_gatt)
+
+# We use a number of include/generated/ .h files.
+target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PRIVATE kernel)
+
+zephyr_library_sources(bas.c cts.c hog.c hrs.c ipss.c hts.c)

--- a/samples/bluetooth/peripheral/CMakeLists.txt
+++ b/samples/bluetooth/peripheral/CMakeLists.txt
@@ -6,9 +6,11 @@ project(peripheral)
 
 target_sources(app PRIVATE
   src/main.c
-  ../gatt/hrs.c
-  ../gatt/bas.c
-  ../gatt/cts.c
 )
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)
+
+add_subdirectory(../gatt gatt_bindir)
+
+zephyr_library_cmake_target(samples_bt_gatt gatt_tgt)
+target_link_libraries(app PRIVATE ${gatt_tgt})

--- a/samples/bluetooth/peripheral_csc/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_csc/CMakeLists.txt
@@ -7,7 +7,11 @@ project(peripheral_csc)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE
   ${app_sources}
-  ../gatt/bas.c
   )
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)
+
+add_subdirectory(../gatt gatt_bindir)
+
+zephyr_library_cmake_target(samples_bt_gatt gatt_tgt)
+target_link_libraries(app PRIVATE ${gatt_tgt})

--- a/samples/bluetooth/peripheral_esp/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_esp/CMakeLists.txt
@@ -6,7 +6,11 @@ project(peripheral_esp)
 
 target_sources(app PRIVATE
   src/main.c
-  ../gatt/bas.c
 )
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)
+
+add_subdirectory(../gatt gatt_bindir)
+
+zephyr_library_cmake_target(samples_bt_gatt gatt_tgt)
+target_link_libraries(app PRIVATE ${gatt_tgt})

--- a/samples/bluetooth/peripheral_hids/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hids/CMakeLists.txt
@@ -7,8 +7,11 @@ project(peripheral_hids)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE
   ${app_sources}
-  ../gatt/hog.c
-  ../gatt/bas.c
   )
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)
+
+add_subdirectory(../gatt gatt_bindir)
+
+zephyr_library_cmake_target(samples_bt_gatt gatt_tgt)
+target_link_libraries(app PRIVATE ${gatt_tgt})

--- a/samples/bluetooth/peripheral_hr/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hr/CMakeLists.txt
@@ -8,8 +8,11 @@ project(peripheral_hr)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE
   ${app_sources}
-  ../gatt/hrs.c
-  ../gatt/bas.c
   )
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)
+
+add_subdirectory(../gatt gatt_bindir)
+
+zephyr_library_cmake_target(samples_bt_gatt gatt_tgt)
+target_link_libraries(app PRIVATE ${gatt_tgt})

--- a/samples/bluetooth/peripheral_ht/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_ht/CMakeLists.txt
@@ -8,8 +8,11 @@ project(peripheral_ht)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE
   ${app_sources}
-  ../gatt/hts.c
-  ../gatt/bas.c
   )
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)
+
+add_subdirectory(../gatt gatt_bindir)
+
+zephyr_library_cmake_target(samples_bt_gatt gatt_tgt)
+target_link_libraries(app PRIVATE ${gatt_tgt})


### PR DESCRIPTION
When adding sources outside the current directory using some "`..`", CMake
generates very long, absolute binary_dir output directories. Example
produced by `sanitycheck -T samples/bluetooth/`
````
build
├── CMakeFiles
│   ├── app.dir
│   │   ├── build.make
│   │   ├──
│   │   ├──
│   │   ├── flags.make
│   │   ├── home
│   │   │   └── john
│   │   │       └── zephyrproject
│   │   │           └── zephyr
│   │   │               └── samples
│   │   │                   └── bluetooth
│   │   │                       └── gatt
│   │   │                           └── bas.c.obj
│   │   ├── link.txt
│   │   ├── progress.make
│   │   └── src
│   │       └── main.c.obj
```
This "leaks" absolute and private source paths in output directories and
makes it extremely difficult to compare binaries compiled from different
source locations.

CMake supports a "binary_dir" argument that solves this, it's already
being used for modules in `/CMakeLists.txt`:
```
  add_subdirectory(${module_path}
                   ${CMAKE_BINARY_DIR}/modules/${module_name})
```
However this binary_dir argument requires a CMake target:
  https://cmake.org/pipermail/cmake/2019-June/069608.html
So also add a new "samples_bt_gatt" target and library.

The most common (only?) reason to add code in a _parent_ directory is
when that code is shared by more than one CMake project, as is the case
here. For all the usual software modularity reasons, every CMake guide I
ever saw tells to use targets for shared code.

.obj files are identical before/after this change. Linking in a
different order unfortunately causes address changes and ripple effects
which cause a lot of noise when trying to compare binaries and other
products past the linking stage(s). I looked anyway at the before/after
diff of the .map files and diffoscope of the .elf files and couldn't
find any difference besides the address changes.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>