### PR TITLE
Add support for I2C clock stretching in GPIO bitbang driver

### DIFF
--- a/drivers/i2c/Kconfig.gpio
+++ b/drivers/i2c/Kconfig.gpio
@@ -10,6 +10,16 @@ config I2C_GPIO
 	help
 	  Enable software driven (bit banging) I2C support using GPIO pins
 
+# SCL stretching support
+if I2C_GPIO
+config I2C_GPIO_CLOCKSTRETCHING
+	bool "GPIO bit banging I2C clock stretching support"
+	default "y"
+	help
+		Enable Slave clock stretching support
+	
+endif #I2C_GPIO  
+
 # ---------- Port 0 ----------
 
 config I2C_GPIO_0

--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -152,8 +152,9 @@ static bool i2c_read_bit(struct i2c_bitbang *context)
 	/* SDA hold time is zero, so no need for a delay here */
 	i2c_set_sda(context, 1); /* Stop driving low, so slave has control */
 	i2c_delay(context->delays[T_LOW]);
-	bit = i2c_get_sda(context);
+
 	i2c_set_scl(context, 1);
+	bit = i2c_get_sda(context);
 	i2c_delay(context->delays[T_HIGH]);
 	return bit;
 }

--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -45,7 +45,17 @@ static void i2c_gpio_set_scl(void *io_context, int state)
 {
 	struct i2c_gpio_context *context = io_context;
 
+#ifdef CONFIG_I2C_GPIO_CLOCKSTRETCHING
 	gpio_pin_write(context->gpio, context->scl_pin, state);
+	if (state) {
+		// wait for SCL to actually go up, clock stretching
+		u32_t scl_state = 1;
+		do {
+			gpio_pin_read(context->gpio, context->scl_pin, &scl_state);
+		} while (!scl_state);
+	}
+#endif
+
 }
 
 static void i2c_gpio_set_sda(void *io_context, int state)


### PR DESCRIPTION
Wait for SCL to actually read high when setting the gpio pin value.

Also fix bug in i2c_read_bit where the sda line was read too early
when slave uses clock stretching.

Signed-off-by: Joerg Fischer <turboj@turboj.de>