### PR TITLE
CODEOWNERS: Add reviewer for native_posix docs and flash driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -116,7 +116,7 @@
 /drivers/dma/*sam0*                       @Sizurka
 /drivers/ethernet/                        @jukkar @tbursztyka @pfalcon
 /drivers/flash/                           @nashif
-/drivers/flash/*native_posix*             @vanwinkeljan
+/drivers/flash/*native_posix*             @vanwinkeljan @aescolar
 /drivers/flash/*stm32*                    @superna9999
 /drivers/gpio/*ht16k33*                   @henrikbrixandersen
 /drivers/gpio/*stm32*                     @rsalveti @idlethread
@@ -367,3 +367,4 @@
 /tests/subsys/shell/                      @jakub-uC @nordic-krch
 # Get all docs reviewed
 *.rst                                     @dbkinder
+*posix*.rst                               @dbkinder @aescolar


### PR DESCRIPTION
Add aescolar as reviewer for the posix arch boards and flash driver

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>