### PR TITLE
dts/bindings: Cleanup phy bindings

### DIFF
--- a/dts/bindings/phy/phy.yaml
+++ b/dts/bindings/phy/phy.yaml
@@ -15,10 +15,8 @@ inherits:
 
 properties:
     "#phy-cells":
-      type: int
-      category: required
-      description: Number of cells in a PHY provider. The meaning those
-                   cells is defined by the binding for the phy node.
-    label:
-      category: required
+        type: int
+        category: required
+        description: Number of cells in a PHY provider. The meaning those
+                     cells is defined by the binding for the phy node.
 ...

--- a/dts/bindings/phy/st,stm32-usbphyc.yaml
+++ b/dts/bindings/phy/st,stm32-usbphyc.yaml
@@ -20,6 +20,6 @@ properties:
     reg:
       category: required
 
-    "phy-cells":
+    "#phy-cells":
       description: should be 0
 ...

--- a/dts/bindings/phy/usb-nop-xceiv.yaml
+++ b/dts/bindings/phy/usb-nop-xceiv.yaml
@@ -18,6 +18,6 @@ properties:
     compatible:
       constraint: "usb-nop-xceiv"
 
-    "phy-cells":
+    "#phy-cells":
       description: should be 0
 ...


### PR DESCRIPTION
* Fix white space in phy.yaml
* Fix property name in st,stm32-usbphyc.yaml and usb-nop-xceiv.yaml to
  use "#phy-cells" and not "phy-cells"

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>