### PR TITLE
dts: Restructure xtensa dts directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -169,6 +169,7 @@
 /dts/arm/microchip/                       @franciscomunoz @albertofloyd @scottwcpg
 /dts/riscv32/rv32m1*                      @MaureenHelm
 /dts/riscv32/riscv32-litex-vexriscv.dtsi  @mateusz-holenko @kgugala @pgielda
+/dts/xtensa/xtensa.dtsi                   @ydamigos
 /dts/bindings/                            @galak
 /dts/bindings/can/                        @alexanderwachter
 /dts/bindings/iio/adc/st*stm32-adc.yaml   @cybertale

--- a/boards/xtensa/esp32/esp32.dts
+++ b/boards/xtensa/esp32/esp32.dts
@@ -5,11 +5,11 @@
  */
 /dts-v1/;
 
-#include "esp32.dtsi"
+#include <espressif/esp32.dtsi>
 
 / {
 	model = "esp32";
-	compatible = "xtensa,esp32";
+	compatible = "espressif,esp32";
 
 	aliases {
 		uart-0 = &uart0;

--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
@@ -2,7 +2,7 @@
 
 /dts-v1/;
 
-#include "intel_s1000.dtsi"
+#include <intel/intel_s1000.dtsi>
 
 / {
 	model = "intel_s1000_crb";

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -128,6 +128,7 @@ engicam	Engicam S.r.l.
 epcos	EPCOS AG
 epfl	Ecole Polytechnique Fédérale de Lausanne
 epson	Seiko Epson Corp.
+espressif	Espressif Systems
 est	ESTeem Wireless Modems
 ettus	NI Ettus Research
 eukrea  Eukréa Electromatique

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "skeleton.dtsi"
+#include <xtensa/xtensa.dtsi>
 
 / {
 	cpus {
@@ -31,13 +31,8 @@
 	};
 
 	soc {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		compatible = "simple-bus";
-		ranges;
-
 		uart0: uart@40008fd0 {
-			compatible = "xtensa,esp32-uart";
+			compatible = "espressif,esp32-uart";
 			reg = <0x40008fd0 0x400>;
 			label = "ROMUART";
 

--- a/dts/xtensa/intel/intel_s1000.dtsi
+++ b/dts/xtensa/intel/intel_s1000.dtsi
@@ -23,14 +23,6 @@
 			compatible = "cadence,tensilica-xtensa-lx6";
 			reg = <1>;
 		};
-
-		core_intc: core_intc@0 {
-			compatible = "xtensa,core-intc";
-			reg = <0x00 0x400>;
-			interrupt-controller;
-			#interrupt-cells = <3>;
-		};
-
 	};
 
 	sram0: memory@be000000 {
@@ -46,6 +38,13 @@
 	};
 
 	soc {
+		core_intc: core_intc@0 {
+			compatible = "xtensa,core-intc";
+			reg = <0x00 0x400>;
+			interrupt-controller;
+			#interrupt-cells = <3>;
+		};
+
 		cavs0: cavs@78800  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78800 0x10>;

--- a/dts/xtensa/intel/intel_s1000.dtsi
+++ b/dts/xtensa/intel/intel_s1000.dtsi
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include "skeleton.dtsi"
+#include <xtensa/xtensa.dtsi>
 #include <dt-bindings/i2c/i2c.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <mem.h>
@@ -46,11 +46,6 @@
 	};
 
 	soc {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		compatible = "simple-bus";
-		ranges;
-
 		cavs0: cavs@78800  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78800 0x10>;

--- a/dts/xtensa/xtensa.dtsi
+++ b/dts/xtensa/xtensa.dtsi
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2019, Yannis Damigos
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "skeleton.dtsi"
+
+/ {
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "simple-bus";
+		ranges;
+	};
+};
+


### PR DESCRIPTION
Restructure xtensa dts directory

```
dts/xtensa
├── espressif
│   └── esp32.dtsi
├── intel
│   └── intel_s1000.dtsi
├── sample_controller.dtsi
└── xtensa.dtsi
```