### PR TITLE
tests: benchmarks: timing_info: add user space tag

### DIFF
--- a/tests/benchmarks/timing_info/testcase.yaml
+++ b/tests/benchmarks/timing_info/testcase.yaml
@@ -6,4 +6,4 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_args: CONF_FILE=prj_userspace.conf
     arch_whitelist: x86 arm arc
-    tags: benchmark
+    tags: benchmark userspace


### PR DESCRIPTION
Adding userspace tag for benchmark.timing.userspace test-case.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>