### PR TITLE
Kernel appmem domain minor fixes

### DIFF
--- a/include/app_memory/app_memdomain.h
+++ b/include/app_memory/app_memdomain.h
@@ -12,15 +12,6 @@
 
 #ifdef CONFIG_USERSPACE
 
-#if defined(CONFIG_X86)
-#define MEM_DOMAIN_ALIGN_SIZE _STACK_BASE_ALIGN
-#elif defined(STACK_ALIGN)
-#define MEM_DOMAIN_ALIGN_SIZE STACK_ALIGN
-#else
-#error "Not implemented for this architecture"
-#endif
-
-
 /**
  * @brief Name of the data section for a particular partition
  *

--- a/include/linker/priv_stacks.ld
+++ b/include/linker/priv_stacks.ld
@@ -8,7 +8,7 @@
 	/* Constraints:
          *
          * - changes to the size of this section between build phases
-         *   *must not* shift the memory address of any kernel obejcts,
+         *   *must not* shift the memory address of any kernel objects,
          *   since it contains a hashtable of the memory addresses of those
          *   kernel objects
          *
@@ -19,7 +19,7 @@
          * The size of the
 	 * gperf tables is both a function of the number of kernel objects,
 	 * *and* the specific memory addresses being hashed. It is not something
-	 * that can be predicted without actually building and compling it.
+	 * that can be predicted without actually building and compiling it.
          */
 	SECTION_DATA_PROLOGUE(priv_stacks,,)
 	{


### PR DESCRIPTION
Remove unused macro definitions from app_memdomain.h API