### PR TITLE
drivers: adc: mcux_adc12: fix compilation

### DIFF
--- a/drivers/adc/adc_mcux_adc12.c
+++ b/drivers/adc/adc_mcux_adc12.c
@@ -255,22 +255,23 @@ static const struct adc_driver_api mcux_adc12_driver_api = {
 #if CONFIG_ADC_0
 static void mcux_adc12_config_func_0(struct device *dev);
 
-ASSERT_WITHIN_RANGE(DT_INST_0_NXP_KINETIS_ADC12_ADC_CLK_SOURCE, 0, 3,
+ASSERT_WITHIN_RANGE(DT_INST_0_NXP_KINETIS_ADC12_CLK_SOURCE, 0, 3,
 		    "Invalid clock source");
-ASSERT_ADC12_CLK_DIV_VALID(DT_INST_0_NXP_KINETIS_ADC12_ADC_CLK_DIVIDER,
+ASSERT_ADC12_CLK_DIV_VALID(DT_INST_0_NXP_KINETIS_ADC12_CLK_DIVIDER,
 			   "Invalid clock divider");
-ASSERT_WITHIN_RANGE(DT_INST_0_NXP_KINETIS_ADC12_ADC_SAMPLE_TIME, 2, 256,
+ASSERT_WITHIN_RANGE(DT_INST_0_NXP_KINETIS_ADC12_SAMPLE_TIME, 2, 256,
 		    "Invalid sample time");
 static const struct mcux_adc12_config mcux_adc12_config_0 = {
-	.base = (ADC_Type *)DT_INST_0_NXP_KINETIS_ADC12_ADC_BASE_ADDRESS,
-	.clock_src = TO_ADC12_CLOCK_SRC(DT_INST_0_NXP_KINETIS_ADC12_ADC_CLK_SOURCE),
-	.clock_div = TO_ADC12_CLOCK_DIV(DT_INST_0_NXP_KINETIS_ADC12_ADC_CLK_DIVIDER),
-#if DT_INST_0_NXP_KINETIS_ADC12_ADC_ALTERNATE_VOLTAGE_REFERENCE == 1
+	.base = (ADC_Type *)DT_INST_0_NXP_KINETIS_ADC12_BASE_ADDRESS,
+	.clock_src = TO_ADC12_CLOCK_SRC(DT_INST_0_NXP_KINETIS_ADC12_CLK_SOURCE),
+	.clock_div =
+		TO_ADC12_CLOCK_DIV(DT_INST_0_NXP_KINETIS_ADC12_CLK_DIVIDER),
+#if DT_INST_0_NXP_KINETIS_ADC12_ALTERNATE_VOLTAGE_REFERENCE == 1
 	.ref_src = kADC12_ReferenceVoltageSourceValt,
 #else
 	.ref_src = kADC12_ReferenceVoltageSourceVref,
 #endif
-	.sample_clk_count = DT_INST_0_NXP_KINETIS_ADC12_ADC_SAMPLE_TIME,
+	.sample_clk_count = DT_INST_0_NXP_KINETIS_ADC12_SAMPLE_TIME,
 	.irq_config_func = mcux_adc12_config_func_0,
 };
 
@@ -280,40 +281,41 @@ static struct mcux_adc12_data mcux_adc12_data_0 = {
 	ADC_CONTEXT_INIT_SYNC(mcux_adc12_data_0, ctx),
 };
 
-DEVICE_AND_API_INIT(mcux_adc12_0, DT_INST_0_NXP_KINETIS_ADC12_ADC_LABEL,
+DEVICE_AND_API_INIT(mcux_adc12_0, DT_INST_0_NXP_KINETIS_ADC12_LABEL,
 		    &mcux_adc12_init, &mcux_adc12_data_0, &mcux_adc12_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_adc12_driver_api);
 
 static void mcux_adc12_config_func_0(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_0_NXP_KINETIS_ADC12_ADC_IRQ,
-		    DT_INST_0_NXP_KINETIS_ADC12_ADC_IRQ_PRIORITY, mcux_adc12_isr,
+	IRQ_CONNECT(DT_INST_0_NXP_KINETIS_ADC12_IRQ_0,
+		    DT_INST_0_NXP_KINETIS_ADC12_IRQ_0_PRIORITY, mcux_adc12_isr,
 		    DEVICE_GET(mcux_adc12_0), 0);
 
-	irq_enable(DT_INST_0_NXP_KINETIS_ADC12_ADC_IRQ);
+	irq_enable(DT_INST_0_NXP_KINETIS_ADC12_IRQ_0);
 }
 #endif /* CONFIG_ADC_0 */
 
 #if CONFIG_ADC_1
 static void mcux_adc12_config_func_1(struct device *dev);
 
-ASSERT_WITHIN_RANGE(DT_INST_1_NXP_KINETIS_ADC12_ADC_CLK_SOURCE, 0, 3,
+ASSERT_WITHIN_RANGE(DT_INST_1_NXP_KINETIS_ADC12_CLK_SOURCE, 0, 3,
 		    "Invalid clock source");
-ASSERT_ADC12_CLK_DIV_VALID(DT_INST_1_NXP_KINETIS_ADC12_ADC_CLK_DIVIDER,
+ASSERT_ADC12_CLK_DIV_VALID(DT_INST_1_NXP_KINETIS_ADC12_CLK_DIVIDER,
 			   "Invalid clock divider");
-ASSERT_WITHIN_RANGE(DT_INST_1_NXP_KINETIS_ADC12_ADC_SAMPLE_TIME, 2, 256,
+ASSERT_WITHIN_RANGE(DT_INST_1_NXP_KINETIS_ADC12_SAMPLE_TIME, 2, 256,
 		    "Invalid sample time");
 static const struct mcux_adc12_config mcux_adc12_config_1 = {
-	.base = (ADC_Type *)DT_INST_1_NXP_KINETIS_ADC12_ADC_BASE_ADDRESS,
-	.clock_src = TO_ADC12_CLOCK_SRC(DT_INST_1_NXP_KINETIS_ADC12_ADC_CLK_SOURCE),
-	.clock_div = TO_ADC12_CLOCK_DIV(DT_INST_1_NXP_KINETIS_ADC12_ADC_CLK_DIVIDER),
-#if DT_INST_1_NXP_KINETIS_ADC12_ADC_ALTERNATE_VOLTAGE_REFERENCE == 1
+	.base = (ADC_Type *)DT_INST_1_NXP_KINETIS_ADC12_BASE_ADDRESS,
+	.clock_src = TO_ADC12_CLOCK_SRC(DT_INST_1_NXP_KINETIS_ADC12_CLK_SOURCE),
+	.clock_div =
+		TO_ADC12_CLOCK_DIV(DT_INST_1_NXP_KINETIS_ADC12_CLK_DIVIDER),
+#if DT_INST_1_NXP_KINETIS_ADC12_ALTERNATE_VOLTAGE_REFERENCE == 1
 	.ref_src = kADC12_ReferenceVoltageSourceValt,
 #else
 	.ref_src = kADC12_ReferenceVoltageSourceVref,
 #endif
-	.sample_clk_count = DT_INST_1_NXP_KINETIS_ADC12_ADC_SAMPLE_TIME,
+	.sample_clk_count = DT_INST_1_NXP_KINETIS_ADC12_SAMPLE_TIME,
 	.irq_config_func = mcux_adc12_config_func_1,
 };
 
@@ -323,18 +325,18 @@ static struct mcux_adc12_data mcux_adc12_data_1 = {
 	ADC_CONTEXT_INIT_SYNC(mcux_adc12_data_1, ctx),
 };
 
-DEVICE_AND_API_INIT(mcux_adc12_1, DT_INST_1_NXP_KINETIS_ADC12_ADC_LABEL,
+DEVICE_AND_API_INIT(mcux_adc12_1, DT_INST_1_NXP_KINETIS_ADC12_LABEL,
 		    &mcux_adc12_init, &mcux_adc12_data_1, &mcux_adc12_config_1,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &mcux_adc12_driver_api);
 
 static void mcux_adc12_config_func_1(struct device *dev)
 {
-	IRQ_CONNECT(DT_INST_1_NXP_KINETIS_ADC12_ADC_IRQ,
-		    DT_INST_1_NXP_KINETIS_ADC12_ADC_IRQ_PRIORITY, mcux_adc12_isr,
+	IRQ_CONNECT(DT_INST_1_NXP_KINETIS_ADC12_IRQ_0,
+		    DT_INST_1_NXP_KINETIS_ADC12_IRQ_0_PRIORITY, mcux_adc12_isr,
 		    DEVICE_GET(mcux_adc12_1), 0);
 
-	irq_enable(DT_INST_1_NXP_KINETIS_ADC12_ADC_IRQ);
+	irq_enable(DT_INST_1_NXP_KINETIS_ADC12_IRQ_0);
 }
 #endif /* CONFIG_ADC_1 */
 


### PR DESCRIPTION
Fix compilation of NXP MCUX ADC12 driver shim after commit
d4a0c3a2aa9b1b99949caa9f0ad34a0e8e3883db.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>