### PR TITLE
Bluetooth: Fix various deadlock issues when running low on buffers

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -77,6 +77,20 @@ config BT_UART_ON_DEV_NAME
 	  This option specifies the name of UART device to be used
 	  for Bluetooth.
 
+if BT_H4
+
+config BT_H4_DISCARD_RX_WAIT
+	int "How many milliseconds to initially wait for RX buffers"
+	range -1 6000000
+	default 100
+	help
+	  This option specifies how many milliseconds the H4 HCI driver
+	  will initially wait for RX buffers to become available before
+	  attempting to discard discardable buffers from the RX queue. Set
+	  to -1 (K_FOREVER) to disable the feature.
+
+endif # BT_H4
+
 if BT_SPI
 
 config BT_BLUENRG_ACI

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -161,16 +161,11 @@ static struct net_buf *get_rx(int timeout)
 {
 	BT_DBG("type 0x%02x, evt 0x%02x", rx.type, rx.evt.evt);
 
-	if (rx.type == H4_EVT && (rx.evt.evt == BT_HCI_EVT_CMD_COMPLETE ||
-				  rx.evt.evt == BT_HCI_EVT_CMD_STATUS)) {
-		return bt_buf_get_cmd_complete(timeout);
+	if (rx.type == H4_EVT) {
+		return bt_buf_get_evt(rx.evt.evt, timeout);
 	}
 
-	if (rx.type == H4_ACL) {
-		return bt_buf_get_rx(BT_BUF_ACL_IN, timeout);
-	} else {
-		return bt_buf_get_rx(BT_BUF_EVT, timeout);
-	}
+	return bt_buf_get_rx(BT_BUF_ACL_IN, timeout);
 }
 
 static void rx_thread(void *p1, void *p2, void *p3)

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -408,16 +408,7 @@ static inline struct net_buf *get_evt_buf(u8_t evt)
 {
 	struct net_buf *buf;
 
-	switch (evt) {
-	case BT_HCI_EVT_CMD_COMPLETE:
-	case BT_HCI_EVT_CMD_STATUS:
-		buf = bt_buf_get_cmd_complete(K_NO_WAIT);
-		break;
-	default:
-		buf = bt_buf_get_rx(BT_BUF_EVT, K_NO_WAIT);
-		break;
-	}
-
+	buf = bt_buf_get_evt(evt, K_NO_WAIT);
 	if (buf) {
 		net_buf_add_u8(h5.rx_buf, evt);
 	}

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -114,12 +114,8 @@ void TM_EvtReceivedCb(TL_EvtPacket_t *hcievt)
 			BT_ERR("Unknown evtcode type 0x%02x",
 			       hcievt->evtserial.evt.evtcode);
 			goto out;
-		case BT_HCI_EVT_CMD_COMPLETE:
-		case BT_HCI_EVT_CMD_STATUS:
-			buf = bt_buf_get_cmd_complete(K_FOREVER);
-			break;
 		default:
-			buf = bt_buf_get_rx(BT_BUF_EVT, K_FOREVER);
+			buf = bt_buf_get_evt(evtserial.evt.evtcode, K_FOREVER);
 			break;
 		}
 		net_buf_add_mem(buf, &hcievt->evtserial.evt,

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -353,12 +353,9 @@ static void bt_spi_rx_thread(void)
 					/* Vendor events are currently unsupported */
 					bt_spi_handle_vendor_evt(rxmsg);
 					continue;
-				case BT_HCI_EVT_CMD_COMPLETE:
-				case BT_HCI_EVT_CMD_STATUS:
-					buf = bt_buf_get_cmd_complete(K_FOREVER);
-					break;
 				default:
-					buf = bt_buf_get_rx(BT_BUF_EVT, K_FOREVER);
+					buf = bt_buf_get_evt(rxmsg[EVT_HEADER_EVENT],
+							     K_FOREVER);
 					break;
 				}
 

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -57,16 +57,11 @@ static int bt_dev_index = -1;
 
 static struct net_buf *get_rx(const u8_t *buf)
 {
-	if (buf[0] == H4_EVT && (buf[1] == BT_HCI_EVT_CMD_COMPLETE ||
-				 buf[1] == BT_HCI_EVT_CMD_STATUS)) {
-		return bt_buf_get_cmd_complete(K_FOREVER);
+	if (buf[0] == H4_EVT) {
+		return bt_buf_get_evt(buf[1], K_FOREVER);
 	}
 
-	if (buf[0] == H4_ACL) {
-		return bt_buf_get_rx(BT_BUF_ACL_IN, K_FOREVER);
-	} else {
-		return bt_buf_get_rx(BT_BUF_EVT, K_FOREVER);
-	}
+	return bt_buf_get_rx(BT_BUF_ACL_IN, K_FOREVER);
 }
 
 static bool uc_ready(void)

--- a/include/bluetooth/buf.h
+++ b/include/bluetooth/buf.h
@@ -64,6 +64,18 @@ struct net_buf *bt_buf_get_rx(enum bt_buf_type type, s32_t timeout);
  */
 struct net_buf *bt_buf_get_cmd_complete(s32_t timeout);
 
+/** Allocate a buffer for an HCI Event
+ *
+ *  This will set the buffer type so bt_buf_set_type() does not need to
+ *  be explicitly called before bt_recv_prio() or bt_recv().
+ *
+ *  @param evt     HCI event code
+ *  @param timeout Timeout in milliseconds, or one of the special values
+ *                 K_NO_WAIT and K_FOREVER.
+ *  @return A new buffer.
+ */
+struct net_buf *bt_buf_get_evt(u8_t evt, s32_t timeout);
+
 /** Set the buffer type
  *
  *  @param buf   Bluetooth buffer

--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -475,6 +475,12 @@ static inline void net_buf_simple_restore(struct net_buf_simple *buf,
 #define NET_BUF_EXTERNAL_DATA  BIT(1)
 
 /**
+ * Bitmask of the lower bits of buf->flags that are reserved for net_buf
+ * internal use.
+ */
+#define NET_BUF_FLAGS_MASK BIT_MASK(5)
+
+/**
  * @brief Network buffer representation.
  *
  * This struct is used to represent network buffers. Such buffers are
@@ -493,7 +499,10 @@ struct net_buf {
 	/** Reference count. */
 	u8_t ref;
 
-	/** Bit-field of buffer flags. */
+	/** Bit-field of buffer flags. Lower 5 bits are reserved for net_buf
+	 *  internal usage. Upper 3 bits can be freely used externally as
+	 *  a form of extended user data.
+	 */
 	u8_t flags;
 
 	/** Where the buffer should go when freed up. */

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -120,7 +120,7 @@ void *hci_cmd_complete(struct net_buf **buf, u8_t plen)
 {
 	struct bt_hci_evt_cmd_complete *cc;
 
-	*buf = bt_buf_get_cmd_complete(K_FOREVER);
+	*buf = bt_buf_get_evt(BT_HCI_EVT_CMD_COMPLETE, K_FOREVER);
 
 	hci_evt_create(*buf, BT_HCI_EVT_CMD_COMPLETE, sizeof(*cc) + plen);
 
@@ -137,7 +137,7 @@ static struct net_buf *cmd_status(u8_t status)
 	struct bt_hci_evt_cmd_status *cs;
 	struct net_buf *buf;
 
-	buf = bt_buf_get_cmd_complete(K_FOREVER);
+	buf = bt_buf_get_evt(BT_HCI_EVT_CMD_STATUS, K_FOREVER);
 	hci_evt_create(buf, BT_HCI_EVT_CMD_STATUS, sizeof(*cs));
 
 	cs = net_buf_add(buf, sizeof(*cs));

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -137,6 +137,16 @@ NET_BUF_POOL_DEFINE(hci_cmd_pool, CONFIG_BT_HCI_CMD_COUNT,
 NET_BUF_POOL_DEFINE(hci_rx_pool, CONFIG_BT_RX_BUF_COUNT,
 		    BT_BUF_RX_SIZE, BT_BUF_USER_DATA_MIN, NULL);
 
+#if defined(CONFIG_BT_CONN)
+/* Dedicated pool for HCI_Number_of_Completed_Packets. This event is always
+ * consumed synchronously by bt_recv_prio() so a single buffer is enough.
+ * Having a dedicated pool for it ensures that exhaustion of the RX pool
+ * cannot block the delivery of this priority event.
+ */
+NET_BUF_POOL_DEFINE(num_complete_pool, 1, BT_BUF_RX_SIZE,
+		    BT_BUF_USER_DATA_MIN, NULL);
+#endif /* CONFIG_BT_CONN */
+
 struct event_handler {
 	u8_t event;
 	u8_t min_len;
@@ -5654,6 +5664,31 @@ struct net_buf *bt_buf_get_cmd_complete(s32_t timeout)
 	}
 
 	return bt_buf_get_rx(BT_BUF_EVT, timeout);
+}
+
+struct net_buf *bt_buf_get_evt(u8_t evt, s32_t timeout)
+{
+	switch (evt) {
+#if defined(CONFIG_BT_CONN)
+	case BT_HCI_EVT_NUM_COMPLETED_PACKETS:
+		{
+			struct net_buf *buf;
+
+			buf = net_buf_alloc(&num_complete_pool, timeout);
+			if (buf) {
+				net_buf_reserve(buf, CONFIG_BT_HCI_RESERVE);
+				bt_buf_set_type(buf, BT_BUF_EVT);
+			}
+
+			return buf;
+		}
+#endif /* CONFIG_BT_CONN */
+	case BT_HCI_EVT_CMD_COMPLETE:
+	case BT_HCI_EVT_CMD_STATUS:
+		return bt_buf_get_cmd_complete(timeout);
+	default:
+		return bt_buf_get_rx(BT_BUF_EVT, timeout);
+	}
 }
 
 #if defined(CONFIG_BT_BREDR)

--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -84,7 +84,7 @@ static void send_cmd_status(u16_t opcode, u8_t status)
 
 	BT_DBG("opcode %x status %x", opcode, status);
 
-	buf = bt_buf_get_cmd_complete(K_FOREVER);
+	buf = bt_buf_get_evt(BT_HCI_EVT_CMD_STATUS, K_FOREVER);
 	bt_buf_set_type(buf, BT_BUF_EVT);
 
 	hdr = net_buf_add(buf, sizeof(*hdr));

--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -72,6 +72,18 @@ struct net_buf *bt_buf_get_cmd_complete(s32_t timeout)
 	return buf;
 }
 
+struct net_buf *bt_buf_get_evt(u8_t evt, s32_t timeout)
+{
+	struct net_buf *buf;
+
+	buf = net_buf_alloc(&hci_rx_pool, timeout);
+	if (buf) {
+		bt_buf_set_type(buf, BT_BUF_EVT);
+	}
+
+	return buf;
+}
+
 int bt_recv(struct net_buf *buf)
 {
 	BT_DBG("buf %p len %u", buf, buf->len);

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -78,7 +78,7 @@ static inline struct net_buf *pool_get_uninit(struct net_buf_pool *pool,
 
 void net_buf_reset(struct net_buf *buf)
 {
-	NET_BUF_ASSERT(buf->flags == 0U);
+	NET_BUF_ASSERT((buf->flags & NET_BUF_FLAGS_MASK) == 0U);
 	NET_BUF_ASSERT(buf->frags == NULL);
 
 	net_buf_simple_reset(&buf->b);

--- a/tests/bluetooth/hci_prop_evt/src/main.c
+++ b/tests/bluetooth/hci_prop_evt/src/main.c
@@ -53,7 +53,7 @@ static void *cmd_complete(struct net_buf **buf, u8_t plen, u16_t opcode)
 {
 	struct bt_hci_evt_cmd_complete *cc;
 
-	*buf = bt_buf_get_cmd_complete(K_FOREVER);
+	*buf = bt_buf_get_evt(BT_HCI_EVT_CMD_COMPLETE, K_FOREVER);
 	evt_create(*buf, BT_HCI_EVT_CMD_COMPLETE, sizeof(*cc) + plen);
 	cc = net_buf_add(*buf, sizeof(*cc));
 	cc->ncmd = 1U;


### PR DESCRIPTION
The first and third patches are for fixing potential deadlocks when running low on buffers. The Number of Completed Packets patch (the first one) affects pretty much all HCI drivers, including the native controller one. The last patch only affects the H:4 HCI driver. The middle patch (second one) is to make it valid to use some of the upper bits of buf->flags as extended user data.

Fixes #16864
