### PR TITLE
"Dewestize" runners and improve output

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -30,6 +30,9 @@ positional arguments:
   cmake_opt             Extra options to pass to CMake; implies -c
 '''
 
+def _banner(msg):
+    log.inf('-- west build: ' + msg, colorize=True)
+
 def config_get(option, fallback):
     return config.get('build', option, fallback=fallback)
 
@@ -352,14 +355,15 @@ class Build(Forceable):
                 self._sanity_check_source_dir()
 
     def _run_cmake(self, board, origin, cmake_opts):
-        log.inf('source directory: {}'.format(self.source_dir), colorize=True)
-        log.inf('build directory: {}{}'.
-                format(self.build_dir,
-                       ' (created)' if self.created_build_dir else ''),
-                colorize=True)
-        log.inf('BOARD:', ('{} (origin: {})'.format(board, origin) if board
-                           else 'UNKNOWN'),
-                colorize=True)
+        _banner(
+            '''build configuration:
+       source directory: {}
+       build directory: {}{}
+       BOARD: {}'''.
+            format(self.source_dir, self.build_dir,
+                   ' (created)' if self.created_build_dir else '',
+                   ('{} (origin: {})'.format(board, origin) if board
+                    else 'UNKNOWN')))
 
         if board is None and config_getboolean('board_warn', True):
             log.wrn('This looks like a fresh build and BOARD is unknown;',
@@ -371,6 +375,8 @@ class Build(Forceable):
         if not self.run_cmake:
             log.dbg('Not generating a build system; one is present.')
             return
+
+        _banner('generating a build system')
 
         if board is not None and origin != 'CMakeCache.txt':
             cmake_opts = ['-DBOARD={}'.format(board)]
@@ -394,7 +400,7 @@ class Build(Forceable):
         run_cmake(final_cmake_args, dry_run=self.args.dry_run)
 
     def _run_pristine(self):
-        log.inf('Making build dir {} pristine'.format(self.build_dir))
+        _banner('making build dir {} pristine'.format(self.build_dir))
 
         zb = os.environ.get('ZEPHYR_BASE')
         if not zb:
@@ -409,6 +415,10 @@ class Build(Forceable):
         run_cmake(cmake_args, cwd=self.build_dir, dry_run=self.args.dry_run)
 
     def _run_build(self, target):
+        if target:
+            _banner('running target {}'.format(target))
+        else:
+            _banner('building application')
         extra_args = ['--target', target] if target else []
         if self.args.build_opt:
             extra_args.append('--')

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -256,7 +256,7 @@ def _dump_context(command, args, runner_args, cached_runner_var):
     # Load the cache itself, if possible.
     if cache_file is None:
         log.wrn('No build directory (--build-dir) or CMake cache '
-                '(--cache-file) given or found; output will be limited')
+                '(--cmake-cache) given or found; output will be limited')
         cache = None
     else:
         try:

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -36,11 +36,13 @@ if log.VERBOSE >= log.VERBOSE_NORMAL:
 else:
     LOG_LEVEL = logging.INFO
 
+def _banner(msg):
+    log.inf('-- ' + msg, colorize=True)
 
 class WestLogFormatter(logging.Formatter):
 
     def __init__(self):
-        super().__init__(fmt='%(message)s')
+        super().__init__(fmt='%(name)s: %(message)s')
 
 class WestLogHandler(logging.Handler):
 
@@ -59,7 +61,7 @@ class WestLogHandler(logging.Handler):
         elif lvl >= logging.WARNING:
             log.wrn(fmt)
         elif lvl >= logging.INFO:
-            log.inf(fmt)
+            _banner(fmt)
         elif lvl >= logging.DEBUG:
             log.dbg(fmt)
         else:
@@ -192,6 +194,7 @@ def do_run_common(command, args, runner_args, cached_runner_var):
     build_dir = _build_dir(args)
 
     if not args.skip_rebuild:
+        _banner('west {}: rebuilding'.format(command_name))
         try:
             cmake.run_build(build_dir)
         except CalledProcessError:
@@ -226,7 +229,7 @@ def do_run_common(command, args, runner_args, cached_runner_var):
         manually, or check your board's documentation for
         alternative instructions.""".format(command_name, board)))
 
-    log.inf('Using runner:', runner)
+    _banner('west {}: using runner {}'.format(command_name, runner))
     if runner not in available:
         log.wrn('Runner {} is not configured for use with {}, '
                 'this may not work'.format(runner, board))

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -268,7 +268,7 @@ class ZephyrBinaryRunner(abc.ABC):
     (have a breakpoint debugger and program loader on a host
     workstation attached to a running target).
 
-    This is supported by three top-level commands managed by the
+    This is supported by four top-level commands managed by the
     Zephyr build system:
 
     - 'flash': flash a previously configured binary to the board,
@@ -289,18 +289,19 @@ class ZephyrBinaryRunner(abc.ABC):
       the current binary, and block until it exits. Unlike 'debug', this
       command does not program the flash.
 
-    This class provides an API for these commands. Every runner has a
-    name (like 'pyocd'), and declares commands it can handle (like
-    'flash'). Zephyr boards (like 'nrf52_pca10040') declare compatible
-    runner(s) by name to the build system, which makes concrete runner
-    instances to execute commands via this class.
+    This class provides an API for these commands. Every subclass is
+    called a 'runner' for short. Each runner has a name (like
+    'pyocd'), and declares commands it can handle (like
+    'flash'). Boards (like 'nrf52_pca10040') declare which runner(s)
+    are compatible with them to the Zephyr build system, along with
+    information on how to configure the runner to work with the board.
 
-    If your board can use an existing runner, all you have to do is
-    give its name to the build system. How to do that is out of the
-    scope of this documentation, but use the existing boards as a
-    starting point.
+    The build system will then place enough information in the build
+    directory so to create and use runners with this class's create()
+    method, which provides a command line argument parsing API. You
+    can also create runners by instantiating subclasses directly.
 
-    If you want to define and use your own runner:
+    In order to define your own runner, you need to:
 
     1. Define a ZephyrBinaryRunner subclass, and implement its
        abstract methods. You may need to override capabilities().
@@ -310,7 +311,7 @@ class ZephyrBinaryRunner(abc.ABC):
        get_runners() won't work).
 
     3. Give your runner's name to the Zephyr build system in your
-       board's build files.
+       board's board.cmake.
 
     For command-line invocation from the Zephyr build system, runners
     define their own argparse-based interface through the common
@@ -318,11 +319,11 @@ class ZephyrBinaryRunner(abc.ABC):
     to), and provide a way to create instances of themselves from
     a RunnerConfig and parsed runner-specific arguments via create().
 
-    Runners use a variety of target-specific tools and configuration
-    values, the user interface to which is abstracted by this
-    class. Each runner subclass should take any values it needs to
-    execute one of these commands in its constructor.  The actual
-    command execution is handled in the run() method.'''
+    Runners use a variety of host tools and configuration values, the
+    user interface to which is abstracted by this class. Each runner
+    subclass should take any values it needs to execute one of these
+    commands in its constructor.  The actual command execution is
+    handled in the run() method.'''
 
     def __init__(self, cfg):
         '''Initialize core runner state.

--- a/scripts/west_commands/runners/dfu.py
+++ b/scripts/west_commands/runners/dfu.py
@@ -8,8 +8,6 @@ from collections import namedtuple
 import sys
 import time
 
-from west import log
-
 from runners.core import ZephyrBinaryRunner, RunnerCaps, \
     BuildConfiguration
 
@@ -36,6 +34,7 @@ class DfuUtilBinaryRunner(ZephyrBinaryRunner):
         else:
             self.dfuse = True
         self.dfuse_config = dfuse_config
+        self.reset = False
 
     @classmethod
     def name(cls):
@@ -80,8 +79,17 @@ class DfuUtilBinaryRunner(ZephyrBinaryRunner):
         else:
             dcfg = None
 
-        return DfuUtilBinaryRunner(cfg, args.pid, args.alt, args.img,
-                                   exe=args.dfu_util, dfuse_config=dcfg)
+        ret = DfuUtilBinaryRunner(cfg, args.pid, args.alt, args.img,
+                                  exe=args.dfu_util, dfuse_config=dcfg)
+        ret.ensure_device()
+        return ret
+
+    def ensure_device(self):
+        if not self.find_device():
+            self.reset = True
+            print('Please reset your board to switch to DFU mode...')
+            while not self.find_device():
+                time.sleep(0.1)
 
     def find_device(self):
         cmd = list(self.cmd) + ['-l']
@@ -91,17 +99,9 @@ class DfuUtilBinaryRunner(ZephyrBinaryRunner):
 
     def do_run(self, command, **kwargs):
         self.require(self.cmd[0])
-        reset = False
+
         if not self.find_device():
-            reset = True
-            log.dbg('Device not found, waiting for it',
-                    level=log.VERBOSE_EXTREME)
-            # Use of print() here is advised. We don't want to lose
-            # this information in a separate log -- this is
-            # interactive and requires a terminal.
-            print('Please reset your board to switch to DFU mode...')
-            while not self.find_device():
-                time.sleep(0.1)
+            raise RuntimeError('device not found')
 
         cmd = list(self.cmd)
         if self.dfuse:
@@ -118,6 +118,6 @@ class DfuUtilBinaryRunner(ZephyrBinaryRunner):
             #
             # DfuSe targets do as well, except when 'leave' is given
             # as an option.
-            reset = False
-        if reset:
+            self.reset = False
+        if self.reset:
             print('Now reset your board again to switch back to runtime mode.')

--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -6,8 +6,6 @@
 
 from os import path
 
-from west import log
-
 from runners.core import ZephyrBinaryRunner, RunnerCaps
 
 
@@ -95,8 +93,9 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
         else:
             cmd_flash.extend(['0x1000', bin_name])
 
-        log.inf("Converting ELF to BIN")
+        self.logger.info("Converting ELF to BIN")
         self.check_call(cmd_convert)
 
-        log.inf("Flashing ESP32 on {} ({}bps)".format(self.device, self.baud))
+        self.logger.info("Flashing ESP32 on {} ({}bps)".
+                         format(self.device, self.baud))
         self.check_call(cmd_flash)

--- a/scripts/west_commands/runners/intel_s1000.py
+++ b/scripts/west_commands/runners/intel_s1000.py
@@ -7,7 +7,6 @@
 from os import path
 import time
 import signal
-from west import log
 
 from runners.core import ZephyrBinaryRunner
 
@@ -84,7 +83,7 @@ class IntelS1000BinaryRunner(ZephyrBinaryRunner):
         jtag_instr_file = kwargs['ocd-jtag-instr']
         gdb_flash_file = kwargs['gdb-flash-file']
 
-        self.print_gdbserver_message(self.gdb_port)
+        self.log_gdbserver_message(self.gdb_port)
         server_cmd = [self.xt_ocd_dir,
                       '-c', topology_file,
                       '-I', jtag_instr_file]
@@ -122,7 +121,7 @@ class IntelS1000BinaryRunner(ZephyrBinaryRunner):
         topology_file = kwargs['ocd-topology']
         jtag_instr_file = kwargs['ocd-jtag-instr']
 
-        self.print_gdbserver_message(self.gdb_port)
+        self.log_gdbserver_message(self.gdb_port)
         server_cmd = [self.xt_ocd_dir,
                       '-c', topology_file,
                       '-I', jtag_instr_file]
@@ -152,14 +151,11 @@ class IntelS1000BinaryRunner(ZephyrBinaryRunner):
             server_proc.terminate()
             server_proc.wait()
 
-    def print_gdbserver_message(self, gdb_port):
-        log.inf('Intel S1000 GDB server running on port {}'.format(gdb_port))
-
     def debugserver(self, **kwargs):
         topology_file = kwargs['ocd-topology']
         jtag_instr_file = kwargs['ocd-jtag-instr']
 
-        self.print_gdbserver_message(self.gdb_port)
+        self.log_gdbserver_message(self.gdb_port)
         server_cmd = [self.xt_ocd_dir,
                       '-c', topology_file,
                       '-I', jtag_instr_file]
@@ -170,3 +166,7 @@ class IntelS1000BinaryRunner(ZephyrBinaryRunner):
         time.sleep(6)
         server_proc.terminate()
         self.check_call(server_cmd)
+
+    def log_gdbserver_message(self, gdb_port):
+        self.logger.info('Intel S1000 GDB server running on port {}'.
+                         format(gdb_port))

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -7,11 +7,9 @@
 import argparse
 import os
 import shlex
-import shutil
 import sys
 import tempfile
 
-from west import log
 from runners.core import ZephyrBinaryRunner, RunnerCaps, \
     BuildConfiguration
 
@@ -105,7 +103,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                                  tui=args.tui, tool_opt=args.tool_opt)
 
     def print_gdbserver_message(self):
-        log.inf('J-Link GDB server running on port {}'.format(self.gdb_port))
+        self.logger.info('J-Link GDB server running on port {}'.
+                         format(self.gdb_port))
 
     def do_run(self, command, **kwargs):
         server_cmd = ([self.gdbserver] +
@@ -162,8 +161,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         lines.append('g') # Start the CPU
         lines.append('q') # Close the connection and quit
 
-        log.dbg('JLink commander script:')
-        log.dbg('\n'.join(lines))
+        self.logger.debug('JLink commander script:')
+        self.logger.debug('\n'.join(lines))
 
         # Don't use NamedTemporaryFile: the resulting file can't be
         # opened again on Windows.
@@ -179,5 +178,5 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                     '-CommanderScript', fname] +
                    self.tool_opt)
 
-            log.inf('Flashing Target Device')
+            self.logger.info('Flashing Target Device')
             self.check_call(cmd)

--- a/scripts/west_commands/runners/nios2.py
+++ b/scripts/west_commands/runners/nios2.py
@@ -4,7 +4,6 @@
 
 '''Runner for NIOS II, based on quartus-flash.py and GDB.'''
 
-from west import log
 from runners.core import ZephyrBinaryRunner, NetworkPortHelper
 
 
@@ -65,7 +64,8 @@ class Nios2BinaryRunner(ZephyrBinaryRunner):
         self.check_call(cmd)
 
     def print_gdbserver_message(self, gdb_port):
-        log.inf('Nios II GDB server running on port {}'.format(gdb_port))
+        self.logger.info('Nios II GDB server running on port {}'.
+                         format(gdb_port))
 
     def debug_debugserver(self, command, **kwargs):
         # Per comments in the shell script, the NIOSII GDB server

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -7,8 +7,6 @@
 
 import sys
 
-from west import log
-
 from runners.core import ZephyrBinaryRunner, RunnerCaps
 
 
@@ -46,8 +44,14 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def create(cls, cfg, args):
-        return NrfJprogBinaryRunner(cfg, args.nrf_family, args.softreset,
-                                    args.snr, erase=args.erase)
+        ret = NrfJprogBinaryRunner(cfg, args.nrf_family, args.softreset,
+                                   args.snr, erase=args.erase)
+        ret.ensure_snr()
+        return ret
+
+    def ensure_snr(self):
+        if not self.snr:
+            self.snr = self.get_board_snr_from_user()
 
     def get_board_snr_from_user(self):
         snrs = self.check_output(['nrfjprog', '--ids'])
@@ -62,9 +66,6 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
                 raise RuntimeError('"nrfjprog --ids" returned 0; '
                                    'is a debugger already connected?')
             return board_snr
-
-        log.dbg("Refusing the temptation to guess a board",
-                level=log.VERBOSE_EXTREME)
 
         # Use of print() here is advised. We don't want to lose
         # this information in a separate log -- this is
@@ -91,13 +92,13 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
         commands = []
         if self.snr is None:
-            board_snr = self.get_board_snr_from_user()
+            raise ValueError("self.snr must not be None")
         else:
             board_snr = self.snr.lstrip("0")
         program_cmd = ['nrfjprog', '--program', self.hex_, '-f', self.family,
                        '--snr', board_snr]
 
-        print('Flashing file: {}'.format(self.hex_))
+        self.logger.info('Flashing file: {}'.format(self.hex_))
         if self.erase:
             commands.extend([
                 ['nrfjprog',
@@ -129,5 +130,5 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
         for cmd in commands:
             self.check_call(cmd)
 
-        log.inf('Board with serial number {} flashed successfully.'.format(
-                  board_snr))
+        self.logger.info('Board with serial number {} flashed successfully.'.
+                         format(board_snr))

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -210,14 +210,15 @@ def test_nrfjprog_init(cc, get_snr, req, test_case, runner_config):
 
     runner = NrfJprogBinaryRunner(runner_config, family, softreset, snr,
                                   erase=erase)
-    runner.run('flash')
-
-    assert req.called
-    assert cc.call_args_list == [call(x) for x in
-                                 expected_commands(*test_case)]
     if snr is None:
-        get_snr.assert_called_once_with()
+        with pytest.raises(ValueError) as e:
+            runner.run('flash')
+        assert 'snr must not be None' in str(e)
     else:
+        runner.run('flash')
+        assert req.called
+        assert cc.call_args_list == [call(x) for x in
+                                     expected_commands(*test_case)]
         get_snr.assert_not_called()
 
 

--- a/scripts/west_commands/zephyr_ext_common.py
+++ b/scripts/west_commands/zephyr_ext_common.py
@@ -40,12 +40,9 @@ class Forceable(WestCommand):
 def cached_runner_config(build_dir, cache):
     '''Parse the RunnerConfig from a build directory and CMake Cache.'''
     board_dir = cache['ZEPHYR_RUNNER_CONFIG_BOARD_DIR']
-    elf_file = cache.get('ZEPHYR_RUNNER_CONFIG_ELF_FILE',
-                         cache['ZEPHYR_RUNNER_CONFIG_KERNEL_ELF'])
-    hex_file = cache.get('ZEPHYR_RUNNER_CONFIG_HEX_FILE',
-                         cache['ZEPHYR_RUNNER_CONFIG_KERNEL_HEX'])
-    bin_file = cache.get('ZEPHYR_RUNNER_CONFIG_BIN_FILE',
-                         cache['ZEPHYR_RUNNER_CONFIG_KERNEL_BIN'])
+    elf_file = cache.get('ZEPHYR_RUNNER_CONFIG_KERNEL_ELF')
+    hex_file = cache.get('ZEPHYR_RUNNER_CONFIG_KERNEL_HEX')
+    bin_file = cache.get('ZEPHYR_RUNNER_CONFIG_KERNEL_BIN')
     gdb = cache.get('ZEPHYR_RUNNER_CONFIG_GDB')
     openocd = cache.get('ZEPHYR_RUNNER_CONFIG_OPENOCD')
     openocd_search = cache.get('ZEPHYR_RUNNER_CONFIG_OPENOCD_SEARCH')


### PR DESCRIPTION
The first half of this pull request removes the runner package's dependency on west. This makes it possible to use some of these utility classes from other scripts in the code base without requiring anything not in requirements.txt.

The second half takes advantage of some of the outut-related changes in the first half to make the build/flash/debug output a little nicer and match the built-in command output more closely.