### PR TITLE
Bluetooth: Allow disconnected state connections to be reconnected

### DIFF
--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -153,7 +153,7 @@ static inline int bt_conn_send(struct bt_conn *conn, struct net_buf *buf)
 }
 
 /* Add a new LE connection */
-struct bt_conn *bt_conn_add_le(const bt_addr_le_t *peer);
+struct bt_conn *bt_conn_add_le(u8_t id, const bt_addr_le_t *peer);
 
 /* Add a new BR/EDR connection */
 struct bt_conn *bt_conn_add_br(const bt_addr_t *peer);

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -53,9 +53,6 @@ struct bt_conn_le {
 	u8_t			features[8];
 
 	struct bt_keys		*keys;
-
-	/* Delayed work for connection update and timeout handling */
-	struct k_delayed_work	update_work;
 };
 
 #if defined(CONFIG_BT_BREDR)
@@ -130,6 +127,9 @@ struct bt_conn {
 	sys_slist_t		channels;
 
 	atomic_t		ref;
+
+	/* Delayed work for connection update and other deferred tasks */
+	struct k_delayed_work	update_work;
 
 	union {
 		struct bt_conn_le	le;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1124,7 +1124,7 @@ static void enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 
 		/* for slave we may need to add new connection */
 		if (!conn) {
-			conn = bt_conn_add_le(&id_addr);
+			conn = bt_conn_add_le(bt_dev.adv_id, &id_addr);
 		}
 	}
 
@@ -1133,7 +1133,7 @@ static void enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 	    evt->role == BT_HCI_ROLE_MASTER) {
 		/* for whitelist initiator me may need to add new connection. */
 		if (!conn) {
-			conn = bt_conn_add_le(&id_addr);
+			conn = bt_conn_add_le(BT_ID_DEFAULT, &id_addr);
 		}
 	}
 
@@ -1157,7 +1157,6 @@ static void enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 	 */
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
 	    conn->role == BT_HCI_ROLE_SLAVE) {
-		conn->id = bt_dev.adv_id;
 		bt_addr_le_copy(&conn->le.init_addr, &peer_addr);
 
 		if (IS_ENABLED(CONFIG_BT_PRIVACY)) {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -989,7 +989,7 @@ static void slave_update_conn_param(struct bt_conn *conn)
 	 * The Peripheral device should not perform a Connection Parameter
 	 * Update procedure within 5 s after establishing a connection.
 	 */
-	k_delayed_work_submit(&conn->le.update_work, CONN_UPDATE_TIMEOUT);
+	k_delayed_work_submit(&conn->update_work, CONN_UPDATE_TIMEOUT);
 }
 
 #if defined(CONFIG_BT_SMP)


### PR DESCRIPTION
Make it possible to initiate new connections from within the
disconnect callback. This wasn't completely trivial since there was
connection cleanup done through deferred action using the CONN_CLEANUP
flag.
    
This patch moves the disconnected callbacks to be run after all
cleanup is done. We can't directly do this in the TX thread, since
that's internal, so we instead take advantage of the deferred work
support and do it using the update_work callback. Since the same
cleanup is needed also for BR/EDR connections the work definition is
moved from the LE-specific struct to the generic struct bt_conn.
    
A valid bt_conn object in disconnected state is a likely indication of
a connection reference leak, so there's a new BT_WARN() for this case
in bt_conn_create_le().

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>