### PR TITLE
cmake: silence "WARNING: ASSERTs enabled" when CONFIG_TEST is true

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1381,6 +1381,7 @@ add_subdirectory(cmake/flash)
 add_subdirectory(cmake/usage)
 add_subdirectory(cmake/reports)
 
+if(NOT CONFIG_TEST)
 if(CONFIG_ASSERT AND (NOT CONFIG_FORCE_NO_ASSERT))
   message(WARNING "
       ------------------------------------------------------------
@@ -1388,6 +1389,7 @@ if(CONFIG_ASSERT AND (NOT CONFIG_FORCE_NO_ASSERT))
       --- The kernel will run more slowly and use more memory  ---
       ------------------------------------------------------------"
   )
+endif()
 endif()
 
 if(CONFIG_BOARD_DEPRECATED)


### PR DESCRIPTION
TEST configurations don't need to be warned that they're using test
techniques with some side-effects.

On a typical sanitycheck invocation, this warning is one of the only two
that appears in most test runs. In other words this commit gets rid of
half of the entire grep -ri '[[:blank:]]warn' noise that obscures any
work-in-progress warnings or platform specific warnings in the
logs (typically: device tree warnings).

Signed-off-by: Marc Herbert <marc.herbert@intel.com>