### PR TITLE
scripts/dts: Clarify extract/flash.py some more

### DIFF
--- a/scripts/dts/extract/flash.py
+++ b/scripts/dts/extract/flash.py
@@ -14,36 +14,29 @@ from extract.default import default
 #
 class DTFlash(DTDirective):
     def __init__(self):
-        self._flash_area = {}
+        self._area_id = 0
 
-    def _extract_partition(self, node_path):
+    def extract_partition(self, node_path):
+        self._add_partition_index_entries(node_path)
+        self._add_partition_label_entries(node_path)
+
+    def _add_partition_index_entries(self, node_path):
+        # Adds DT_FLASH_AREA_<index>_... entries, to the '# DT_FLASH_AREA'
+        # section
+
         prop_def = {}
         prop_alias = {}
         node = reduced[node_path]
 
-        # Build Index based partition IDs
-        if node_path not in self._flash_area:
-            self._flash_area[node_path] = len(self._flash_area)
-        area_id = self._flash_area[node_path]
+        # Index-based partition ID
+        area_id = self._area_id
+        self._area_id += 1
 
-        # Extract a per partition dev name, something like:
-        # #define DT_FLASH_AREA_1_DEV             "FLASH_CTRL"
-
-        # For now assume node_path is something like:
-        # /flash-controller@4001E000/flash@0/partitions/partition@fc000
-        # first we go up 2 levels to get the flash, check its compat
+        # Extract a per partition dev name. Something like
         #
-        # The flash controller might be the flash itself (for cases like NOR
-        # flashes), for the case of 'soc-nv-flash' we assume its the parent
-        # of the flash node.
-        controller_path = '/' + '/'.join(node_path.split('/')[1:-2])
-        if get_compat(controller_path) == "soc-nv-flash":
-            controller_path = '/' + '/'.join(node_path.split('/')[1:-3])
-
-        for flash_path in self._flash_area:
-            if controller_path in flash_path:
-                prop_def["DT_FLASH_AREA_{}_DEV".format(area_id)] = \
-                    '"' + reduced[controller_path]['props']['label'] + '"'
+        #   #define DT_FLASH_AREA_1_DEV "FLASH_CTRL"
+        prop_def["DT_FLASH_AREA_{}_DEV".format(area_id)] = \
+            '"' + reduced[controller_path(node_path)]['props']['label'] + '"'
 
         partition_label = str_to_label(node['props']['label'])
         prop_def["DT_FLASH_AREA_{}_LABEL".format(area_id)] = partition_label
@@ -54,7 +47,8 @@ class DTFlash(DTDirective):
             prop_def["DT_FLASH_AREA_{}_OFFSET_{}".format(area_id, i)] = reg[2*i]
             prop_def["DT_FLASH_AREA_{}_SIZE_{}".format(area_id, i)] = reg[2*i + 1]
 
-        prop_def["DT_FLASH_AREA_NUM"] = len(self._flash_area)
+        # Number of flash areas defined
+        prop_def["DT_FLASH_AREA_NUM"] = self._area_id
 
         # Alias sector 0
         prop_alias[
@@ -66,45 +60,43 @@ class DTFlash(DTDirective):
 
         insert_defs("DT_FLASH_AREA", prop_def, prop_alias)
 
-    def _create_legacy_label(self, prop_alias, label):
-        prop_alias[label.lstrip('DT_')] = label
+    def _add_partition_label_entries(self, node_path):
+        # Adds DT_FLASH_AREA_<label>_... entries, to the '# partition@...'
+        # section
 
-    def extract_partition(self, node_path):
         prop_def = {}
         prop_alias = {}
         node = reduced[node_path]
-
-        self._extract_partition(node_path)
 
         partition_label = str_to_label(node['props']['label'])
 
         label = "DT_FLASH_AREA_{}_LABEL".format(partition_label)
         prop_def[label] = '"' + node['props']['label'] + '"'
-        self._create_legacy_label(prop_alias, label)
+        add_legacy_alias(prop_alias, label)
 
         label = "DT_FLASH_AREA_{}_READ_ONLY".format(partition_label)
         prop_def[label] = 1 if 'read-only' in node['props'] else 0
-        self._create_legacy_label(prop_alias, label)
+        add_legacy_alias(prop_alias, label)
 
         reg = node['props']['reg']
         for i in range(len(reg)//2):
             label = "DT_FLASH_AREA_{}_OFFSET_{}".format(partition_label, i)
             prop_def[label] = reg[2*i]
-            self._create_legacy_label(prop_alias, label)
+            add_legacy_alias(prop_alias, label)
 
             label = "DT_FLASH_AREA_{}_SIZE_{}".format(partition_label, i)
             prop_def[label] = reg[2*i + 1]
-            self._create_legacy_label(prop_alias, label)
+            add_legacy_alias(prop_alias, label)
 
         # Alias sector 0
 
         label = "DT_FLASH_AREA_{}_OFFSET".format(partition_label)
         prop_alias[label] = "DT_FLASH_AREA_{}_OFFSET_0".format(partition_label)
-        self._create_legacy_label(prop_alias, label)
+        add_legacy_alias(prop_alias, label)
 
         label = "DT_FLASH_AREA_{}_SIZE".format(partition_label)
         prop_alias[label] = "DT_FLASH_AREA_{}_SIZE_0".format(partition_label)
-        self._create_legacy_label(prop_alias, label)
+        add_legacy_alias(prop_alias, label)
 
         insert_defs(node_path, prop_def, prop_alias)
 
@@ -125,14 +117,13 @@ class DTFlash(DTDirective):
         # if the nr_size_cells is 0, assume a SPI flash, need to look at parent
         # for addr/size info, and the second reg property (assume first is mmio
         # register for the controller itself)
-        is_spi_flash = False
-        if nr_size_cells == 0:
-            is_spi_flash = True
+        is_spi_flash = nr_size_cells == 0
+        if is_spi_flash:
             node_path = get_parent_path(node_path)
-            (nr_address_cells, nr_size_cells) = get_addr_size_cells(node_path)
+            nr_address_cells, nr_size_cells = get_addr_size_cells(node_path)
 
         reg = reduced[node_path]['props']['reg']
-        if type(reg) is not list: reg = [ reg, ]
+        if type(reg) is not list: reg = [reg]
         props = list(reg)
 
         num_reg_elem = len(props)/(nr_address_cells + nr_size_cells)
@@ -194,6 +185,27 @@ class DTFlash(DTDirective):
                     {'DT_CODE_PARTITION_OFFSET': load_offset,
                      'DT_CODE_PARTITION_SIZE': load_size},
                     {})
+
+
+def controller_path(partition_path):
+    # Returns the DT path to the flash controller for the
+    # partition at 'partition_path'.
+    #
+    # For now assume node_path is something like
+    # /flash-controller@4001E000/flash@0/partitions/partition@fc000. First, we
+    # go up two levels to get the flash and check its compat.
+    #
+    # The flash controller might be the flash itself (for cases like NOR
+    # flashes). For the case of 'soc-nv-flash', we assume its the parent of the
+    # flash node.
+    controller_path = '/' + '/'.join(partition_path.split('/')[1:-2])
+    if get_compat(controller_path) == "soc-nv-flash":
+        return '/' + '/'.join(partition_path.split('/')[1:-3])
+    return controller_path
+
+
+def add_legacy_alias(prop_alias, label):
+    prop_alias[label.lstrip('DT_')] = label
 
 
 ##


### PR DESCRIPTION
Think I understand it now, and that was the goal.

 - _extract_partition() adds index-based entries. extract_partition()
   adds label-based entries.

   Rename them to _add_partition_index_entries() and
   _add_partition_label_entries(), and call them from a top-level
   extract_partition() function.

   This makes the logic clearer. It took me a long time to spot it.

 - Generate indicies with a simple counter and remove the _flash_area
   logic. This would break if partitions were extracted more than once,
   but they aren't, and now you know that they can't be.

 - Rename _create_legacy_label() to add_legacy_alias() and make it
   global. It doesn't use 'self'.

 - Break the logic for finding the flash controller into a separate
   helper function

 - Add doc-comments for the new functions

 - Misc. other small clean-ups

generated_dts_board.conf and generated_dts_board_unfixed.h were verified
to be identical for disco_l475_iot1 and frdm_kw41z before and after the
cleanup.