### PR TITLE
doc: fix broken references to zephyr files

### DIFF
--- a/boards/arc/nsim/doc/index.rst
+++ b/boards/arc/nsim/doc/index.rst
@@ -19,8 +19,8 @@ There are two sub configurations in board:
 * nsim_sem which includes secure em features and ARC MPUv3
 
 For detailed arc features, please refer to
-:zephyr_file:`boards/arc/nsim_em/support/nsim.props` and
-:zephyr_file:`boards/arc/nsim_em/support/nsim_sem.props`.
+:zephyr_file:`boards/arc/nsim/support/nsim_em.props` and
+:zephyr_file:`boards/arc/nsim/support/nsim_sem.props`.
 
 
 Hardware

--- a/doc/guides/device_mgmt/index.rst
+++ b/doc/guides/device_mgmt/index.rst
@@ -26,7 +26,8 @@ systems.
 
 The management subsystem is split in two different locations in the Zephyr tree:
 
-* :zephyr_file:`ext/lib/mgmt/mcumgr/` contains a clean import of the MCUmgr project
+* `zephyrproject-rtos/mcumgr repo <https://github.com/zephyrproject-rtos/mcumgr>`_
+  contains a clean import of the MCUmgr project
 * :zephyr_file:`subsys/mgmt/` contains the Zephyr-specific bindings to MCUmgr
 
 Additionally there is a :ref:`sample <smp_svr_sample>` that provides management


### PR DESCRIPTION
The zephyr_file role creates a link to the GitHub copy of a file.  Some
files have been moved so update the file references in the documentation
(found by scanning for uses of :zephyr_file:)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>