### PR TITLE
optimize and bug fix arc compile options

### DIFF
--- a/soc/arc/snps_arc_iot/CMakeLists.txt
+++ b/soc/arc/snps_arc_iot/CMakeLists.txt
@@ -1,13 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
-
-zephyr_cc_option(-mcpu=${GCC_M_CPU})
-zephyr_cc_option(-mno-sdata -mdiv-rem -mswap -mnorm)
-zephyr_cc_option(-mmpy-option=6 -mbarrel-shifter)
-zephyr_cc_option_ifdef(CONFIG_CODE_DENSITY -mcode-density)
-zephyr_cc_option_ifdef(CONFIG_FLOAT -mfpu=fpuda_all)
-
+zephyr_compile_options(-mcpu=${GCC_M_CPU} -mno-sdata -mmpy-option=6)
+zephyr_compile_options_ifdef(CONFIG_FLOAT -mfpu=fpuda_all)
 
 zephyr_sources(
   soc.c

--- a/soc/arc/snps_emsk/CMakeLists.txt
+++ b/soc/arc/snps_emsk/CMakeLists.txt
@@ -1,17 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
+zephyr_compile_options(-mcpu=${GCC_M_CPU} -mno-sdata -mmpy-option=6)
 
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
-
-zephyr_cc_option(-mcpu=${GCC_M_CPU})
-zephyr_cc_option(-mno-sdata -mdiv-rem -mswap -mnorm)
-zephyr_cc_option(-mmpy-option=6 -mbarrel-shifter)
-zephyr_cc_option_ifdef(CONFIG_SOC_EMSK_EM7D --param l1-cache-size=16384)
-zephyr_cc_option_ifdef(CONFIG_SOC_EMSK_EM7D --param l1-cache-line-size=32)
-zephyr_cc_option_ifdef(CONFIG_SOC_EMSK_EM11D --param l1-cache-size=16384)
-zephyr_cc_option_ifdef(CONFIG_SOC_EMSK_EM11D --param l1-cache-line-size=32)
-zephyr_cc_option_ifdef(CONFIG_CODE_DENSITY -mcode-density)
-zephyr_cc_option_ifdef(CONFIG_FLOAT -mfpu=fpuda_all)
-
+if(CONFIG_SOC_EMSK_EM9D)
+zephyr_compile_options_ifdef(CONFIG_FLOAT -mfpu=fpus_all)
+elseif(CONFIG_SOC_EMSK_EM11D)
+zephyr_compile_options_ifdef(CONFIG_FLOAT -mfpu=fpuda_all)
+endif()
 
 zephyr_sources(
   soc.c

--- a/soc/arc/snps_nsim/CMakeLists.txt
+++ b/soc/arc/snps_nsim/CMakeLists.txt
@@ -1,14 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
-
-zephyr_cc_option(-mcpu=${GCC_M_CPU})
-zephyr_cc_option(-mno-sdata -mdiv-rem -mswap -mnorm)
-zephyr_cc_option(-mmpy-option=6 -mbarrel-shifter)
-zephyr_cc_option(--param l1-cache-size=16384)
-zephyr_cc_option(--param l1-cache-line-size=32)
-zephyr_cc_option_ifdef(CONFIG_CODE_DENSITY -mcode-density)
-zephyr_cc_option_ifdef(CONFIG_FLOAT -mfpu=fpuda_all)
+zephyr_compile_options(-mcpu=${GCC_M_CPU} -mno-sdata -mmpy-option=6)
+zephyr_compile_options_ifdef(CONFIG_FLOAT -mfpu=fpuda_all)
 
 zephyr_sources(
   soc.c

--- a/soc/arc/snps_nsim/Kconfig.defconfig.em
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.em
@@ -6,7 +6,7 @@
 
 if SOC_NSIM_EM
 
-config CPU_EM4_DMIPS
+config CPU_EM4_FPUDA
 	def_bool y
 
 config NUM_IRQ_PRIO_LEVELS

--- a/soc/arc/snps_nsim/Kconfig.defconfig.sem
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.sem
@@ -6,7 +6,7 @@
 
 if SOC_NSIM_SEM
 
-config CPU_EM4_DMIPS
+config CPU_EM4_FPUDA
 	def_bool y
 
 config NUM_IRQ_PRIO_LEVELS


### PR DESCRIPTION
This PR make an optimization and bug fixes of snps arc soc compile options

1. nsim em targets in zephyr are configured as CPU_EM4_FPUDA
2. optimize and bug fix  snps arc soc compile options
  * when -mcpu is given, e.g. -mcpu=em4_dmips,-mnorm,-mdiv_em
     etc. are already given, no need to duplicate
   * use zephyr_compiler_options to replace zephyr_cc_option
      zephyr_cc_option will do compile option check first then add
      the checked options into option list. It's too strict that makes
      options like -mfpu, -mmpy-option cannot be added.

Fixes #16862
