### PR TITLE
Arch arm rework thread arch macros and stack info

### DIFF
--- a/arch/arm/core/cortex_m/mpu/Kconfig
+++ b/arch/arm/core/cortex_m/mpu/Kconfig
@@ -32,16 +32,35 @@ config ARM_MPU_REGION_MIN_ALIGN_AND_SIZE
 	  A minimum 4-byte alignment is enforced in ARM builds without
 	  support for Memory Protection.
 
+if ARM_MPU
+
 config MPU_STACK_GUARD
 	bool "Thread Stack Guards"
-	depends on ARM_MPU
 	help
 	  Enable Thread Stack Guards via MPU
 
+if MPU_STACK_GUARD
+
+config MPU_STACK_GUARD_MIN_SIZE_FLOAT
+	int
+	depends on FP_SHARING
+	default 128
+	help
+	  Minimum size (and alignment when applicable) of an ARM MPU
+	  region, which guards the stack of a thread that is using the
+	  Floating Point (FP) context. The width of the guard is set to
+	  128, to accommodate the length of a Cortex-M exception stack
+	  frame when the floating point context is active. The FP context
+	  is only stacked in sharing FP registers mode, therefore, the
+	  option is applicable only when FP_SHARING is selected.
+
+endif # MPU_STACK_GUARD
+
 config MPU_ALLOW_FLASH_WRITE
 	bool "Add MPU access to write to flash"
-	depends on ARM_MPU
 	help
 	  Enable this to allow MPU RWX access to flash memory
+
+endif # ARM_MPU
 
 endif # CPU_HAS_MPU

--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -214,7 +214,11 @@ void z_arch_configure_dynamic_mpu_regions(struct k_thread *thread)
 	u32_t guard_start;
 #if defined(CONFIG_USERSPACE)
 	if (thread->arch.priv_stack_start) {
-		guard_start = thread->arch.priv_stack_start;
+		guard_start = thread->arch.priv_stack_start -
+			MPU_GUARD_ALIGN_AND_SIZE;
+		__ASSERT((u32_t)&z_priv_stacks_ram_start <= guard_start,
+		"Guard start: (0x%x) below privilege stacks boundary: (0x%x)",
+		guard_start, (u32_t)&z_priv_stacks_ram_start);
 	} else {
 		guard_start = thread->stack_info.start -
 			MPU_GUARD_ALIGN_AND_SIZE;

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -156,6 +156,21 @@ extern "C" {
 #define STACK_ALIGN MAX(Z_THREAD_MIN_STACK_ALIGN, Z_MPU_GUARD_ALIGN)
 
 /**
+ * @brief Define alignment of a privilege stack buffer
+ *
+ * This is used to determine the required alignment of threads'
+ * privilege stacks when building with support for user mode.
+ *
+ * @note
+ * The privilege stacks do not need to respect the minimum MPU
+ * region alignment requirement (unless this is enforced via
+ * the MPU Stack Guard feature).
+ */
+#if defined(CONFIG_USERSPACE)
+#define Z_PRIVILEGE_STACK_ALIGN MAX(STACK_ALIGN_SIZE, Z_MPU_GUARD_ALIGN)
+#endif
+
+/**
  * @brief Calculate power of two ceiling for a buffer size input
  *
  */

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -53,6 +53,21 @@ extern "C" {
 #endif
 
 /**
+ * @brief Declare the minimum alignment for a thread stack
+ *
+ * Denotes the minimum required alignment of a thread stack.
+ *
+ * Note:
+ * User thread stacks must respect the minimum MPU region
+ * alignment requirement.
+ */
+#if defined(CONFIG_USERSPACE)
+#define Z_THREAD_MIN_STACK_ALIGN CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE
+#else
+#define Z_THREAD_MIN_STACK_ALIGN STACK_ALIGN_SIZE
+#endif
+
+/**
  * @brief Declare a minimum MPU guard alignment and size
  *
  * This specifies the minimum MPU guard alignment/size for the MPU. This
@@ -99,6 +114,37 @@ extern "C" {
 #endif
 
 /**
+ * @brief Declare the MPU guard alignment and size for a thread stack
+ *        that is using the Floating Point services.
+ *
+ * For threads that are using the Floating Point services under Shared
+ * Registers (CONFIG_FP_SHARING=y) mode, the exception stack frame may
+ * contain both the basic stack frame and the FP caller-saved context,
+ * upon exception entry. Therefore, a wide guard region is required to
+ * guarantee that stack-overflow detection will always be successful.
+ */
+#if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING) \
+	&& defined(CONFIG_MPU_STACK_GUARD)
+#define MPU_GUARD_ALIGN_AND_SIZE_FLOAT CONFIG_MPU_STACK_GUARD_MIN_SIZE_FLOAT
+#else
+#define MPU_GUARD_ALIGN_AND_SIZE_FLOAT 0
+#endif
+
+/**
+ * @brief Define alignment of an MPU guard
+ *
+ * Minimum alignment of the start address of an MPU guard, depending on
+ * whether the MPU architecture enforces a size (and power-of-two) alignment
+ * requirement.
+ */
+#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
+#define Z_MPU_GUARD_ALIGN (MAX(MPU_GUARD_ALIGN_AND_SIZE, \
+	MPU_GUARD_ALIGN_AND_SIZE_FLOAT))
+#else
+#define Z_MPU_GUARD_ALIGN MPU_GUARD_ALIGN_AND_SIZE
+#endif
+
+/**
  * @brief Define alignment of a stack buffer
  *
  * This is used for two different things:
@@ -107,11 +153,7 @@ extern "C" {
  * 2) Used to determine the alignment of a stack buffer
  *
  */
-#if defined(CONFIG_USERSPACE)
-#define STACK_ALIGN    CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE
-#else
-#define STACK_ALIGN    MAX(STACK_ALIGN_SIZE, MPU_GUARD_ALIGN_AND_SIZE)
-#endif
+#define STACK_ALIGN MAX(Z_THREAD_MIN_STACK_ALIGN, Z_MPU_GUARD_ALIGN)
 
 /**
  * @brief Calculate power of two ceiling for a buffer size input

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -252,6 +252,17 @@ extern char _ramfunc_ram_size[];
 extern char _ramfunc_rom_start[];
 #endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
 
+/* Memory owned by the kernel. Memory region for thread privilege stack buffers,
+ * currently only applicable on ARM Cortex-M architecture when building with
+ * support for User Mode.
+ *
+ * All thread privilege stack buffers will be placed into this section.
+ */
+#ifdef CONFIG_USERSPACE
+extern char z_priv_stacks_ram_start[];
+extern char z_priv_stacks_ram_end[];
+#endif /* CONFIG_USERSPACE */
+
 #endif /* ! _ASMLANGUAGE */
 
 #endif /* ZEPHYR_INCLUDE_LINKER_LINKER_DEFS_H_ */

--- a/include/linker/priv_stacks-noinit.ld
+++ b/include/linker/priv_stacks-noinit.ld
@@ -6,5 +6,7 @@
 
      SECTION_DATA_PROLOGUE(priv_stacks_noinit,,)
         {
+        z_priv_stacks_ram_start = .;
         *(".priv_stacks.noinit")
+        z_priv_stacks_ram_end = .;
         } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)

--- a/scripts/gen_priv_stacks.py
+++ b/scripts/gen_priv_stacks.py
@@ -39,8 +39,10 @@ header = """%compare-lengths
 """
 
 
+# Each privilege stack buffer needs to respect the alignment
+# constraints as specified in arm/arch.h.
 priv_stack_decl_temp = ("static u8_t __used"
-                        " __aligned(CONFIG_PRIVILEGED_STACK_SIZE)"
+                        " __aligned(Z_PRIVILEGE_STACK_ALIGN)"
                         " priv_stack_%x[CONFIG_PRIVILEGED_STACK_SIZE];\n")
 
 

--- a/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
@@ -27,8 +27,10 @@ extern bool valid_fault;
 
 #if defined(CONFIG_X86)
 #define MEM_REGION_ALLOC (4096)
-#elif defined(CONFIG_ARC) || defined(CONFIG_ARM)
+#elif defined(CONFIG_ARC)
 #define MEM_REGION_ALLOC (STACK_ALIGN)
+#elif defined(CONFIG_ARM)
+#define MEM_REGION_ALLOC (Z_THREAD_MIN_STACK_ALIGN)
 #else
 #error "Test suite not compatible for the given architecture"
 #endif


### PR DESCRIPTION
The pull request
- is mostly an enhancement, re-organizing the thread stack macros for ARM, improving the logic behind the generation of each macro
- fixes a bug reported in #16887, by aligning the threads' priv stacks properly
- fixes a minor bug in `tests/kernel/mem_protect/mem_protect/src/mem_protect.h` concerning the alignment of app-mem partitions
- aligns the ways we program the MPU guards for supervisor and user threads (in priv mode), making them follow the same patterns.

- draws the path for solving #16210 and #16360 in upcoming patches.

Fixes #16887 