### PR TITLE
scripts: Upgrade pyocd for pack support

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -10,7 +10,7 @@ ply==3.10
 hub==2.0
 gitlint
 pyelftools==0.24
-pyocd==0.19.0
+pyocd==0.21.0
 pyserial
 pykwalify
 # "win32" is used for 64-bit Windows as well


### PR DESCRIPTION
pyocd 0.21.0 provides 'pack support' functionality,
as opposed to current 'buitlin support'.
This new feature enables the possibility to add pyocd support
for any chip that is documented in Keil database. Then one doesn't
need anymore to wait pyocd is updated with a new target to use
pyocd with his target, as long as it is populated in Keil database.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>