### PR TITLE
Bluetooth: Fix expiring RPA when different local identities are used

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -5348,6 +5348,10 @@ int bt_le_adv_start_internal(const struct bt_le_adv_param *param,
 	set_param.max_interval = sys_cpu_to_le16(param->interval_max);
 	set_param.channel_map  = 0x07;
 
+	if (bt_dev.adv_id != param->id) {
+		atomic_clear_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	}
+
 	/* Set which local identity address we're advertising with */
 	bt_dev.adv_id = param->id;
 	id_addr = &bt_dev.id_addr[param->id];


### PR DESCRIPTION
When advertising with different identities we need to flag any
programmed RPA as invalid if it was generated using a different
identity.

Fixes #16893

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>