### PR TITLE
Settings: Enable ROM registration of handlers

### DIFF
--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -109,15 +109,6 @@
 	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif
 
-#if defined(CONFIG_BT_SETTINGS)
-	SECTION_DATA_PROLOGUE(_bt_settings_area,,SUBALIGN(4))
-	{
-		_bt_settings_start = .;
-		KEEP(*(SORT_BY_NAME("._bt_settings_handler.static.*")))
-		_bt_settings_end = .;
-	} GROUP_LINK_IN(ROMABLE_REGION)
-#endif
-
 	SECTION_DATA_PROLOGUE(log_const_sections,,)
 	{
 		__log_const_start = .;

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -100,6 +100,15 @@
 		_bt_services_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
+#if defined(CONFIG_SETTINGS)
+	SECTION_DATA_PROLOGUE(_settings_handlers_area,,SUBALIGN(4))
+	{
+		_settings_handler_static_list_start = .;
+		KEEP(*(SORT_BY_NAME("._settings_handler_static.static.*")))
+		_settings_handler_static_list_end = .;
+	} GROUP_LINK_IN(ROMABLE_REGION)
+#endif
+
 #if defined(CONFIG_BT_SETTINGS)
 	SECTION_DATA_PROLOGUE(_bt_settings_area,,SUBALIGN(4))
 	{

--- a/include/settings/settings.h
+++ b/include/settings/settings.h
@@ -150,17 +150,29 @@ struct settings_handler_static {
 };
 
 /**
- * Register a static handler for settings items
+ * Define a static handler for settings items
  *
- * @param _handler Structure containing registration info, this must be const
- *	  The handler name in ROM needs to be unique, it is generated from
- *	  _handler and the linenumber of SETTINGS_REGISTER_STATIC()
+ * @param _hname handler name
+ * @param _tree subtree name
+ * @param _get get routine (can be NULL)
+ * @param _set set routine (can be NULL)
+ * @param _commit commit routine (can be NULL)
+ * @param _export export routine (can be NULL)
+ *
+ * This createa a variable _hname prepended by settings_handler_.
  *
  */
-#define SETTINGS_STATIC_HANDLER_DEFINE(_handler)	\
-	const Z_STRUCT_SECTION_ITERABLE(settings_handler_static, \
-					_CONCAT(_handler, __LINE__))\
-					= _handler
+
+#define SETTINGS_STATIC_HANDLER_DEFINE(_hname, _tree, _get, _set, _commit,   \
+				       _export)				     \
+	const Z_STRUCT_SECTION_ITERABLE(settings_handler_static,	     \
+					settings_handler_ ## _hname) = {     \
+		.name = _tree,						     \
+		.h_get = _get,						     \
+		.h_set = _set,						     \
+		.h_commit = _commit,					     \
+		.h_export = _export,					     \
+	}
 
 /**
  * Initialization of settings and backend

--- a/include/settings/settings.h
+++ b/include/settings/settings.h
@@ -42,8 +42,64 @@ typedef ssize_t (*settings_read_cb)(void *cb_arg, void *data, size_t len);
  * These are registered using a call to @ref settings_register.
  */
 struct settings_handler {
+
+	char *name;
+	/**< Name of subtree. */
+
+	int (*h_get)(const char *key, char *val, int val_len_max);
+	/**< Get values handler of settings items identified by keyword names.
+	 *
+	 * Parameters:
+	 *  - key[in] the name with skipped part that was used as name in
+	 *    handler registration
+	 *  - val[out] buffer to receive value.
+	 *  - val_len_max[in] size of that buffer.
+	 */
+
+	int (*h_set)(const char *key, size_t len, settings_read_cb read_cb,
+		     void *cb_arg);
+	/**< Set value handler of settings items identified by keyword names.
+	 *
+	 * Parameters:
+	 *  - key[in] the name with skipped part that was used as name in
+	 *    handler registration
+	 *  - len[in] the size of the data found in the backend.
+	 *  - read_cb[in] function provided to read the data from the backend.
+	 *  - cb_arg[in] arguments for the read function provided by the
+	 *    backend.
+	 */
+
+	int (*h_commit)(void);
+	/**< This handler gets called after settings has been loaded in full.
+	 * User might use it to apply setting to the application.
+	 */
+
+	int (*h_export)(int (*export_func)(const char *name, const void *val,
+					   size_t val_len));
+	/**< This gets called to dump all current settings items.
+	 *
+	 * This happens when @ref settings_save tries to save the settings.
+	 * Parameters:
+	 *  - export_func: the pointer to the internal function which appends
+	 *   a single key-value pair to persisted settings. Don't store
+	 *   duplicated value. The name is subtree/key string, val is the string
+	 *   with value.
+	 *
+	 * @remarks The User might limit a implementations of handler to serving
+	 * only one keyword at one call - what will impose limit to get/set
+	 * values using full subtree/key name.
+	 */
+
 	sys_snode_t node;
 	/**< Linked list node info for module internal usage. */
+};
+
+/**
+ * @struct settings_handler_static
+ * Config handlers without the node element, used for static handlers.
+ * These are registered using a call to SETTINGS_REGISTER_STATIC().
+ */
+struct settings_handler_static {
 
 	char *name;
 	/**< Name of subtree. */
@@ -94,6 +150,19 @@ struct settings_handler {
 };
 
 /**
+ * Register a static handler for settings items
+ *
+ * @param _handler Structure containing registration info, this must be const
+ *	  The handler name in ROM needs to be unique, it is generated from
+ *	  _handler and the linenumber of SETTINGS_REGISTER_STATIC()
+ *
+ */
+#define SETTINGS_STATIC_HANDLER_DEFINE(_handler)	\
+	const Z_STRUCT_SECTION_ITERABLE(settings_handler_static, \
+					_CONCAT(_handler, __LINE__))\
+					= _handler
+
+/**
  * Initialization of settings and backend
  *
  * Can be called at application startup.
@@ -105,7 +174,7 @@ struct settings_handler {
 int settings_subsys_init(void);
 
 /**
- * Register a handler for settings items.
+ * Register a handler for settings items stored in RAM.
  *
  * @param cf Structure containing registration info.
  *
@@ -274,10 +343,10 @@ void settings_dst_register(struct settings_store *cs);
  * @param[in] name in string format
  * @param[out] next remaining of name after matched handler
  *
- * @return settings_handler node on success, NULL on failure.
+ * @return settings_handler_static on success, NULL on failure.
  */
-struct settings_handler *settings_parse_and_lookup(const char *name,
-						   const char **next);
+struct settings_handler_static *settings_parse_and_lookup(const char *name,
+							const char **next);
 
 
 /*

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3606,7 +3606,7 @@ static int ccc_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	return 0;
 }
 
-BT_SETTINGS_DEFINE(ccc, ccc_set, NULL, NULL);
+SETTINGS_STATIC_HANDLER_DEFINE(bt_ccc, "bt/ccc", NULL, ccc_set, NULL, NULL);
 
 #if defined(CONFIG_BT_GATT_CACHING)
 static int cf_set(const char *name, size_t len_rd, settings_read_cb read_cb,
@@ -3653,7 +3653,7 @@ static int cf_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	return 0;
 }
 
-BT_SETTINGS_DEFINE(cf, cf_set, NULL, NULL);
+SETTINGS_STATIC_HANDLER_DEFINE(bt_cf, "bt/cf", NULL, cf_set, NULL, NULL);
 
 static u8_t stored_hash[16];
 
@@ -3696,6 +3696,7 @@ static int db_hash_commit(void)
 	return 0;
 }
 
-BT_SETTINGS_DEFINE(hash, db_hash_set, db_hash_commit, NULL);
+SETTINGS_STATIC_HANDLER_DEFINE(bt_hash, "bt/hash", NULL, db_hash_set,
+			       db_hash_commit, NULL);
 #endif /*CONFIG_BT_GATT_CACHING */
 #endif /* CONFIG_BT_SETTINGS */

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -365,5 +365,7 @@ static int keys_commit(void)
 	return 0;
 }
 
-BT_SETTINGS_DEFINE(keys, keys_set, keys_commit, NULL);
+SETTINGS_STATIC_HANDLER_DEFINE(bt_keys, "bt/keys", NULL, keys_set, keys_commit,
+			       NULL);
+
 #endif /* CONFIG_BT_SETTINGS */

--- a/subsys/bluetooth/host/mesh/settings.c
+++ b/subsys/bluetooth/host/mesh/settings.c
@@ -24,7 +24,6 @@
 #define LOG_MODULE_NAME bt_mesh_settings
 #include "common/log.h"
 
-#include "../settings.h"
 #include "mesh.h"
 #include "net.h"
 #include "crypto.h"
@@ -824,7 +823,8 @@ static int mesh_commit(void)
 	return 0;
 }
 
-BT_SETTINGS_DEFINE(mesh, mesh_set, mesh_commit, NULL);
+SETTINGS_STATIC_HANDLER_DEFINE(bt_mesh, "bt/mesh", NULL, mesh_set, mesh_commit,
+			       NULL);
 
 /* Pending flags that use K_NO_WAIT as the storage timeout */
 #define NO_WAIT_PENDING_BITS (BIT(BT_MESH_NET_PENDING) |           \

--- a/subsys/bluetooth/host/settings.h
+++ b/subsys/bluetooth/host/settings.h
@@ -4,23 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-struct bt_settings_handler {
-	const char *name;
-	int (*set)(const char *name, size_t len, settings_read_cb read_cb,
-		   void *cb_arg);
-	int (*commit)(void);
-	int (*export)(int (*func)(const char *name,
-				  const void *val, size_t val_len));
-};
-
-#define BT_SETTINGS_DEFINE(_name, _set, _commit, _export)               \
-	const Z_STRUCT_SECTION_ITERABLE(bt_settings_handler, _name) = { \
-				.name = STRINGIFY(_name),               \
-				.set = _set,                            \
-				.commit = _commit,                      \
-				.export = _export,                      \
-			}
-
 /* Max settings key length (with all components) */
 #define BT_SETTINGS_KEY_MAX 36
 

--- a/subsys/bluetooth/services/dis.c
+++ b/subsys/bluetooth/services/dis.c
@@ -25,8 +25,6 @@
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt.h>
 
-#include "../host/settings.h"
-
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_SERVICE)
 #define LOG_MODULE_NAME bt_dis
 #include "common/log.h"
@@ -235,5 +233,6 @@ static int dis_set(const char *name, size_t len_rd,
 	return 0;
 }
 
-BT_SETTINGS_DEFINE(dis, dis_set, NULL, NULL);
+SETTINGS_STATIC_HANDLER_DEFINE(bt_dis, "bt/dis", NULL, dis_set, NULL, NULL);
+
 #endif /* CONFIG_BT_GATT_DIS_SETTINGS && CONFIG_BT_SETTINGS*/

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -24,6 +24,13 @@ config SETTINGS_RUNTIME
 	help
 	  Enables runtime storage back-end.
 
+config SETTINGS_DYNAMIC_HANDLERS
+	bool "dynamic settings handlers"
+	depends on SETTINGS
+	default y
+	help
+	  Enables the use of dynamic settings handlers
+
 # Hidden option to enable encoding length into settings entry
 config SETTINGS_ENCODE_LEN
 	depends on SETTINGS

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -534,7 +534,7 @@ void settings_line_load_cb(const char *name, void *val_read_cb_ctx, off_t off,
 			   void *cb_arg)
 {
 	const char *name_key;
-	struct settings_handler *ch;
+	struct settings_handler_static *ch;
 	struct settings_line_read_value_cb_ctx value_ctx;
 	int rc;
 	size_t len;

--- a/subsys/settings/src/settings_runtime.c
+++ b/subsys/settings/src/settings_runtime.c
@@ -17,7 +17,7 @@ static ssize_t settings_runtime_read_cb(void *cb_arg, void *data, size_t len)
 
 int settings_runtime_set(const char *name, void *data, size_t len)
 {
-	struct settings_handler *ch;
+	struct settings_handler_static *ch;
 	const char *name_key;
 
 	ch = settings_parse_and_lookup(name, &name_key);
@@ -30,7 +30,7 @@ int settings_runtime_set(const char *name, void *data, size_t len)
 
 int settings_runtime_get(const char *name, void *data, size_t len)
 {
-	struct settings_handler *ch;
+	struct settings_handler_static *ch;
 	const char *name_key;
 
 	ch = settings_parse_and_lookup(name, &name_key);
@@ -43,7 +43,7 @@ int settings_runtime_get(const char *name, void *data, size_t len)
 
 int settings_runtime_commit(const char *name)
 {
-	struct settings_handler *ch;
+	struct settings_handler_static *ch;
 	const char *name_key;
 
 	ch = settings_parse_and_lookup(name, &name_key);


### PR DESCRIPTION
Add the possibility to register static handlers (in ROM) using a new macro
`SETTINGS_STATIC_HANDLER_DEFINE(hname, name, get, set, commit, export)` an example for settings stored under `ps/data` is:
`SETTINGS_STATIC_HANDLER_DEFINE(ps_data_handler, "ps/data", NULL, ps_set, ps_commit, NULL)`

To maintain support for dynamic handlers
`CONFIG_SETTINGS_RAM_HANDLERS`must be enabled, which is by default.

When using static handlers there is no check if this handler has
been registered earlier, the latest registered static handler will be
considered valid for any set/get routine, while the commit and export
routines will be executed for both registered handlers.

When a dynamic handler is registered a check is done to see if there was
an earlier registration of the name in all static and dynamic handlers, if there was the
registration will fail.

To get to the lowest possible RAM usage it is advised to set
`CONFIG_SETTINGS_DYNAMIC_HANDLERS=n`.
