### PR TITLE
codeowners: add reviewer for stm32mp1 SoC

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,6 +23,7 @@
 /soc/arm/nordic_nrf/                      @ioannisg
 /soc/arm/st_stm32/                        @erwango
 /soc/arm/st_stm32/stm32f4/                @rsalveti @idlethread
+/soc/arm/st_stm32/stm32mp1/               @arnop2
 /soc/arm/ti_simplelink/cc13x2_cc26x2/     @bwitherspoon
 /soc/arm/ti_simplelink/cc32xx/            @vanti
 /soc/arm/ti_simplelink/msp432p4xx/        @Mani-Sadhasivam


### PR DESCRIPTION
Add new line for /soc/arm/st_stm32/stm32mp1

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>