### PR TITLE
doc: fix Kconfig misspellings

### DIFF
--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -27,7 +27,7 @@ config ARCH_POSIX_STOP_ON_FATAL_ERROR
 	depends on ARCH_POSIX
 	help
 	  If set, when a fatal error occurs, the execution will stop immediately with
-	  an error. If not set, the default Zephyr behaviour will be followed:
+	  an error. If not set, the default Zephyr behavior will be followed:
 	  terminate only if the fault was triggered in an ISR or essential thread,
 	  otherwise abort the current thread and attempt to continue.
 	  Enabling this option may simplify locating and debugging faults

--- a/arch/x86/core/Kconfig.ia32
+++ b/arch/x86/core/Kconfig.ia32
@@ -272,7 +272,7 @@ config LAZY_FP_SHARING
 	  registers, using logic to lazily save/restore the floating point
 	  register state on context switch.
 
-	  On Intel Core procesors, may be vulnerable to exploits which allows
+	  On Intel Core processors, may be vulnerable to exploits which allows
 	  malware to read the contents of all floating point registers, see
 	  CVE-2018-3665.
 

--- a/drivers/can/Kconfig.mcp2515
+++ b/drivers/can/Kconfig.mcp2515
@@ -25,21 +25,21 @@ config CAN_PROP_SEG
 	default 2
 	range 1 8
 	help
-	  Time quantums of propagation segment (ISO 11898-1)
+	  Time quanta of propagation segment (ISO 11898-1)
 
 config CAN_PHASE_SEG1
 	int "Phase_Seg1"
 	default 7
 	range 1 8
 	help
-	  Time quantums of phase buffer 1 segment (ISO 11898-1)
+	  Time quanta of phase buffer 1 segment (ISO 11898-1)
 
 config CAN_PHASE_SEG2
 	int "Phase_Seg2"
 	default 6
 	range 2 8
 	help
-	  Time quantums of phase buffer 2 segment (ISO 11898-1)
+	  Time quanta of phase buffer 2 segment (ISO 11898-1)
 
 config CAN_SJW
 	int "SJW"

--- a/drivers/gpio/Kconfig.ht16k33
+++ b/drivers/gpio/Kconfig.ht16k33
@@ -25,6 +25,6 @@ config GPIO_HT16K33_INIT_PRIORITY
 	default 99
 	help
 	  Device driver initialization priority. This driver must be
-	  initilized after the HT16K33 LED driver.
+	  initialized after the HT16K33 LED driver.
 
 endif #GPIO_HT16K33

--- a/lib/updatehub/Kconfig
+++ b/lib/updatehub/Kconfig
@@ -25,7 +25,7 @@ menuconfig UPDATEHUB
 	select HWINFO
 	help
 	  UpdateHub is an enterprise-grade solution which makes simple to
-	  remotely update all your embbeded devices in the field. It
+	  remotely update all your embedded devices in the field. It
 	  handles all aspects related to sending Firmware Over-the-Air
 	  (FOTA) updates with maximum security and efficiency, while you
 	  focus in adding value to your product.

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -630,7 +630,7 @@ config BT_CTLR_USER_EXT
 	  Catch-all for enabling proprietary event types in Controller behavior.
 
 config BT_CTLR_USER_EVT_RANGE
-	int "Range of event contants reserved for proprietary event types"
+	int "Range of event constants reserved for proprietary event types"
 	depends on BT_CTLR_USER_EXT
 	default 5
 	range 0 10

--- a/subsys/bluetooth/services/Kconfig.dis
+++ b/subsys/bluetooth/services/Kconfig.dis
@@ -64,9 +64,9 @@ config BT_GATT_DIS_PNP_VID
 	 device. This field is used in conjunction with Vendor ID Source field,
 	 which determines which organization assigned the Vendor ID field value.
 	 Note: The Bluetooth Special Interest Group assigns Device ID Vendor ID,
-	 and the USB Implementer’s Forum assigns Vendor IDs,
+	 and the USB Implementers Forum assigns Vendor IDs,
 	 either of which can be used for the Vendor ID field value.
-	 Device providers should procure the Vendor ID from the USB Implementer’s
+	 Device providers should procure the Vendor ID from the USB Implementers
 	 Forum or the Company Identifier from the Bluetooth SIG.
 
 config BT_GATT_DIS_PNP_PID
@@ -89,8 +89,8 @@ config BT_GATT_DIS_PNP_VER
 	 Product ID fields. This field is intended to differentiate between
 	 versions of products with identical Vendor IDs and Product IDs.
 	 The value of the field value is 0xJJMN for version JJ.M.N
-	 (JJ – major version number, M – minor version number,
-	 N – sub-minor version number); e.g., version 2.1.3 is represented with
+	 (JJ - major version number, M - minor version number,
+	 N - sub-minor version number); e.g., version 2.1.3 is represented with
 	 value 0x0213 and version 2.0.0 is represented with a value of 0x0200.
 	 When upward-compatible changes are made to the device, it is recommended
 	 that the minor version number be incremented. If incompatible changes are
@@ -135,7 +135,7 @@ config BT_GATT_DIS_HW_REV_STR
 config BT_GATT_DIS_SW_REV
 	bool "Enable DIS Software Revision characteristic"
 	help
-	 Enable Softwar Revision characteristic in Device Information Service.
+	 Enable Software Revision characteristic in Device Information Service.
 
 config BT_GATT_DIS_SW_REV_STR
 	string "Software revision"

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -370,7 +370,7 @@ config NET_CONTEXT_PRIORITY
 	  also traffic class support to work as expected.
 
 config NET_CONTEXT_TIMESTAMP
-	bool "Add timepstamp support to net_context"
+	bool "Add timestamp support to net_context"
 	select NET_PKT_TIMESTAMP
 	help
 	  It is possible to timestamp outgoing packets.


### PR DESCRIPTION
Fix misspellings in Kconfig files missed during regular reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>