### PR TITLE
yaml: Remove redundant document separators

### DIFF
--- a/boards/riscv32/litex_vexriscv/litex_vexriscv.yaml
+++ b/boards/riscv32/litex_vexriscv/litex_vexriscv.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 identifier: litex_vexriscv
 name: LiteX SoC with VexRiscV softcore CPU
 type: mcu

--- a/dts/bindings/arc/arc,dccm.yaml
+++ b/dts/bindings/arc/arc,dccm.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ARC DCCM
 version: 0.1
 
@@ -19,4 +19,3 @@ properties:
 
     reg:
       category: required
-...

--- a/dts/bindings/arc/arc,iccm.yaml
+++ b/dts/bindings/arc/arc,iccm.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ARC ICCM
 version: 0.1
 
@@ -19,4 +19,3 @@ properties:
 
     reg:
       category: required
-...

--- a/dts/bindings/arm/arm,scc.yaml
+++ b/dts/bindings/arm/arm,scc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ARM Serial Configuration Control
 version: 0.1
 
@@ -19,5 +19,3 @@ properties:
 
     reg:
       category: required
-
-...

--- a/dts/bindings/arm/atmel,sam0-device_id.yaml
+++ b/dts/bindings/arm/atmel,sam0-device_id.yaml
@@ -1,4 +1,4 @@
----
+
 title: Atmel Device ID (Serial Number) binding
 version: 0.1
 
@@ -14,4 +14,3 @@ properties:
 
     reg:
       category: required
-...

--- a/dts/bindings/arm/atmel,sam0-dmac.yaml
+++ b/dts/bindings/arm/atmel,sam0-dmac.yaml
@@ -1,4 +1,4 @@
----
+
 title: Atmel DMAC binding
 version: 0.1
 
@@ -17,4 +17,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/arm/atmel,sam0-sercom.yaml
+++ b/dts/bindings/arm/atmel,sam0-sercom.yaml
@@ -1,4 +1,4 @@
----
+
 title: Atmel SERCOM binding
 version: 0.1
 
@@ -17,4 +17,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/arm/nordic,nrf-dppic.yaml
+++ b/dts/bindings/arm/nordic,nrf-dppic.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic DPPIC
 version: 0.1
 
@@ -20,4 +20,3 @@ properties:
 
     reg:
       category: required
-...

--- a/dts/bindings/arm/nordic,nrf-ficr.yaml
+++ b/dts/bindings/arm/nordic,nrf-ficr.yaml
@@ -1,4 +1,4 @@
----
+
 title: Nordic FICR (Factory Information Configuration Registers)
 version: 0.1
 
@@ -14,5 +14,3 @@ properties:
 
     reg:
       category: required
-
-...

--- a/dts/bindings/arm/nordic,nrf-spu.yaml
+++ b/dts/bindings/arm/nordic,nrf-spu.yaml
@@ -1,4 +1,4 @@
----
+
 title: Nordic SPU (System Protection Unit)
 version: 0.1
 
@@ -17,5 +17,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/arm/nxp,imx-dtcm.yaml
+++ b/dts/bindings/arm/nxp,imx-dtcm.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: i.MX DTCM (Data Tightly Coupled Memory)
 version: 0.1
 
@@ -19,5 +19,3 @@ properties:
 
     reg:
       category: required
-
-...

--- a/dts/bindings/arm/nxp,imx-epit.yaml
+++ b/dts/bindings/arm/nxp,imx-epit.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: IMX EPIT COUNTER
 version: 0.1
 
@@ -37,5 +37,3 @@ properties:
      category: required
      description: Set the RDC permission for this peripheral
      generation: define
-
-...

--- a/dts/bindings/arm/nxp,imx-itcm.yaml
+++ b/dts/bindings/arm/nxp,imx-itcm.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: i.MX ITCM (Instruction Tightly Coupled Memory)
 version: 0.1
 
@@ -19,5 +19,3 @@ properties:
 
     reg:
       category: required
-
-...

--- a/dts/bindings/arm/nxp,imx-mu.yaml
+++ b/dts/bindings/arm/nxp,imx-mu.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: IMX MESSAGING UNIT
 version: 0.1
 
@@ -31,5 +31,3 @@ properties:
      category: required
      description: Set the RDC permission for this peripheral
      generation: define
-
-...

--- a/dts/bindings/arm/nxp,kinetis-pcc.yaml
+++ b/dts/bindings/arm/nxp,kinetis-pcc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP Kinetis PCC (Peripheral Clock Controller)
 version: 0.1
 
@@ -26,4 +26,3 @@ properties:
 "#cells":
   - name
   - offset
-...

--- a/dts/bindings/arm/nxp,kinetis-scg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-scg.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP Kinetis SCG (System Clock Generator)
 version: 0.1
 
@@ -142,5 +142,3 @@ properties:
       description: clockout clock source
       generation: define
       category: optional
-
-...

--- a/dts/bindings/arm/nxp,kinetis-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-sim.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Kinetis System Integration Module (SIM)
 version: 0.1
 
@@ -39,4 +39,3 @@ properties:
   - name
   - offset
   - bits
-...

--- a/dts/bindings/arm/nxp,lpc-mailbox.yaml
+++ b/dts/bindings/arm/nxp,lpc-mailbox.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: LPC MAILBOX
 version: 0.1
 
@@ -25,5 +25,3 @@ properties:
 
   label:
       category: required
-
-...

--- a/dts/bindings/arm/st,stm32-ccm.yaml
+++ b/dts/bindings/arm/st,stm32-ccm.yaml
@@ -1,4 +1,4 @@
----
+
 # SPDX-License-Identifier: Apache-2.0
 title: STM32 CCM
 version: 0.1
@@ -15,5 +15,3 @@ properties:
 
     reg:
       category: required
-
-...

--- a/dts/bindings/arm/ti,cc2650-prcm.yaml
+++ b/dts/bindings/arm/ti,cc2650-prcm.yaml
@@ -1,4 +1,4 @@
----
+
 # SPDX-License-Identifier: Apache-2.0
 title: TI CC2650 PRCM
 version: 0.1
@@ -16,4 +16,3 @@ properties:
 
     reg:
       category: required
-...

--- a/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
+++ b/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ST Microelectronics MPXXDTYY digital pdm microphone family
 version: 0.1
 
@@ -18,5 +18,3 @@ properties:
       constraint: "st,mpxxdtyy"
     label:
       category: required
-
-...

--- a/dts/bindings/audio/ti,tlv320dac.yaml
+++ b/dts/bindings/audio/ti,tlv320dac.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Texas Instruments TLV320DAC Audio DAC
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -1,4 +1,4 @@
----
+
 title: base device binding
 version: 0.1
 
@@ -41,5 +41,3 @@ properties:
         category: optional
         description: Human readable string describing the device (used by Zephyr for API name)
         generation: define
-
-...

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Bluetooth controller that provides Host Controller Interface over SPI
 version: 0.1
 
@@ -25,4 +25,3 @@ properties:
       type: compound
       category: required
       generation: define
-...

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Bluetooth module based on Zephyr's Bluetooth HCI SPI driver
 version: 0.1
 
@@ -27,4 +27,3 @@ properties:
       type: compound
       category: required
       generation: define
-...

--- a/dts/bindings/can/can-device.yaml
+++ b/dts/bindings/can/can-device.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: CAN Device Base Structure
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
       category: required
     label:
       category: required
-...

--- a/dts/bindings/can/can.yaml
+++ b/dts/bindings/can/can.yaml
@@ -1,4 +1,4 @@
----
+
 title: CAN Base Structure
 version: 0.1
 
@@ -46,4 +46,3 @@ properties:
       type: array
       category: optional
       description: pinmux information for RX, TX
-...

--- a/dts/bindings/can/microchip,mcp2515.yaml
+++ b/dts/bindings/can/microchip,mcp2515.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: MCP2515 CAN
 version: 0.1
 
@@ -20,4 +20,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/can/st,stm32-can.yaml
+++ b/dts/bindings/can/st,stm32-can.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 CAN
 version: 0.1
 
@@ -41,4 +41,3 @@ properties:
       category: required
       description: Clock gate control information
       generation: define
-...

--- a/dts/bindings/clock/nordic,nrf-clock.yaml
+++ b/dts/bindings/clock/nordic,nrf-clock.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic nRF clock control
 version: 0.1
 
@@ -25,4 +25,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/clock/nxp,imx-ccm.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: i.MX Clock Controller Module (CCM)
 version: 0.1
 
@@ -27,4 +27,3 @@ properties:
   - name
   - offset
   - bits
-...

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 RCC
 version: 0.1
 
@@ -18,5 +18,3 @@ properties:
 "#cells":
   - bus
   - bits
-
-...

--- a/dts/bindings/crypto/arm,cryptocell-310.yaml
+++ b/dts/bindings/crypto/arm,cryptocell-310.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ARM TrustZone CryptoCell 310
 version: 0.1
 

--- a/dts/bindings/crypto/nordic,nrf-cc310.yaml
+++ b/dts/bindings/crypto/nordic,nrf-cc310.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic Control Interface for ARM TrustZone CryptoCell 310
 version: 0.1
 

--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -1,4 +1,3 @@
----
 title: <short description of the node>
 version: 0.1
 
@@ -70,5 +69,3 @@ properties:
   - cell1    # name of second cell
   - cell2    # name of third cell
   - and so on and so forth
-
-...

--- a/dts/bindings/display/fsl,imx6sx-lcdif.yaml
+++ b/dts/bindings/display/fsl,imx6sx-lcdif.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP Enhanced LCD Interface (eLCDIF) controller
 version: 0.1
 
@@ -25,4 +25,3 @@ properties:
 
     label:
       category: required
-...

--- a/dts/bindings/display/ilitek,ili9340.yaml
+++ b/dts/bindings/display/ilitek,ili9340.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ILI9340 320x240 Display Controller
 version: 0.1
 
@@ -26,5 +26,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-
-...

--- a/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
+++ b/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Rocktech LCD Module
 version: 0.1
 
@@ -17,4 +17,3 @@ inherits:
 properties:
     compatible:
       constraint: "rocktech,rk043fn02h-ct"
-...

--- a/dts/bindings/display/solomon,ssd1306fb.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: SSD1306 128x64 Dot Matrix Display Controller
 version: 0.1
 
@@ -69,5 +69,3 @@ properties:
       type: compound
       category: optional
       generation: define, use-prop-name
-
-...

--- a/dts/bindings/display/solomon,ssd1673fb.yaml
+++ b/dts/bindings/display/solomon,ssd1673fb.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: SSD1673 250x150 EPD Display Controller
 version: 0.1
 
@@ -109,5 +109,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-
-...

--- a/dts/bindings/ethernet/ethernet.yaml
+++ b/dts/bindings/ethernet/ethernet.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Ethernet Base Structure
 version: 0.1
 
@@ -20,4 +20,3 @@ properties:
       generation: define
     label:
       category: required
-...

--- a/dts/bindings/ethernet/intel,e1000.yaml
+++ b/dts/bindings/ethernet/intel,e1000.yaml
@@ -21,4 +21,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/ethernet/microchip,enc28j60.yaml
+++ b/dts/bindings/ethernet/microchip,enc28j60.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: 10Base-T Ethernet Controller with SPI Interface
 version: 0.1
 
@@ -19,4 +19,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
+++ b/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP Kinetis Ethernet
 version: 0.1
 
@@ -19,4 +19,3 @@ properties:
       category: required
     interrupts:
       category: required
-...

--- a/dts/bindings/ethernet/nxp.kinetis-ptp.yaml
+++ b/dts/bindings/ethernet/nxp.kinetis-ptp.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP Kinetis Ethernet PTP
 version: 0.1
 
@@ -18,4 +18,3 @@ properties:
       constraint: "nxp,kinetis-ptp"
     interrupts:
       category: required
-...

--- a/dts/bindings/ethernet/ti,stellaris-ethernet.yaml
+++ b/dts/bindings/ethernet/ti,stellaris-ethernet.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2018 Zilogic Systems
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: TI Stellaris Ethernet
 version: 0.1
 
@@ -19,4 +19,3 @@ properties:
       category: required
     interrupts:
       category: required
-...

--- a/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
+++ b/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel SAM Flash Controller
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
       description: peripheral ID
       generation: define
       category: required
-...

--- a/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
+++ b/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
@@ -1,4 +1,4 @@
----
+
 title: Atmel SAM0 Non-Volatile Memory Controller
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "atmel,sam0-nvmctrl"
-
-...

--- a/dts/bindings/flash_controller/cypress,psoc6-flash-controller.yaml
+++ b/dts/bindings/flash_controller/cypress,psoc6-flash-controller.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Cypress Flash Controller
 version: 0.1
 
@@ -16,5 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "cypress,psoc6-flash-controller"
-
-...

--- a/dts/bindings/flash_controller/flash-controller.yaml
+++ b/dts/bindings/flash_controller/flash-controller.yaml
@@ -1,4 +1,4 @@
----
+
 title: flash controller Base Structure
 version: 0.1
 
@@ -14,4 +14,3 @@ properties:
 
     reg:
       category: required
-...

--- a/dts/bindings/flash_controller/nordic,nrf51-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf51-flash-controller.yaml
@@ -1,4 +1,4 @@
----
+
 title: Nordic NVMC
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "nordic,nrf51-flash-controller"
-
-...

--- a/dts/bindings/flash_controller/nordic,nrf52-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf52-flash-controller.yaml
@@ -1,4 +1,4 @@
----
+
 title: Nordic NVMC
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "nordic,nrf52-flash-controller"
-
-...

--- a/dts/bindings/flash_controller/nordic,nrf91-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf91-flash-controller.yaml
@@ -1,4 +1,4 @@
----
+
 title: Nordic NVMC
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "nordic,nrf91-flash-controller"
-
-...

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfa.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfa.yaml
@@ -1,4 +1,4 @@
----
+
 title: NXP Kinetis Flash Memory Module (FTFA)
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "nxp,kinetis-ftfa"
-
-...

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfe.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfe.yaml
@@ -1,4 +1,4 @@
----
+
 title: NXP Kinetis Flash Memory Module (FTFE)
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "nxp,kinetis-ftfe"
-
-...

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfl.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfl.yaml
@@ -1,4 +1,4 @@
----
+
 title: NXP Kinetis Flash Memory Module (FTFL)
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "nxp,kinetis-ftfl"
-
-...

--- a/dts/bindings/flash_controller/openisa,rv32m1-ftfe.yaml
+++ b/dts/bindings/flash_controller/openisa,rv32m1-ftfe.yaml
@@ -1,4 +1,4 @@
----
+
 title: OpenISA Flash Memory Module (FTFE)
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "openisa,rv32m1-ftfe"
-
-...

--- a/dts/bindings/flash_controller/silabs,gecko-flash-controller.yaml
+++ b/dts/bindings/flash_controller/silabs,gecko-flash-controller.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Silicon Labs Gecko Flash Controller
 version: 0.1
 
@@ -16,5 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "silabs,gecko-flash-controller"
-
-...

--- a/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 F0 Flash Controller
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,stm32f0-flash-controller"
-
-...

--- a/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 F2 Flash Controller
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,stm32f2-flash-controller"
-
-...

--- a/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 F3 Flash Controller
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,stm32f3-flash-controller"
-
-...

--- a/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 F4 Flash Controller
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,stm32f4-flash-controller"
-
-...

--- a/dts/bindings/flash_controller/st,stm32f7-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f7-flash-controller.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 F7 Flash Controller
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,stm32f7-flash-controller"
-
-...

--- a/dts/bindings/flash_controller/st,stm32l1-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32l1-flash-controller.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 L1 Flash Controller
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,stm32l1-flash-controller"
-
-...

--- a/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 L4 Flash Controller
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,stm32l4-flash-controller"
-
-...

--- a/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 WB Flash Controller
 version: 0.1
 
@@ -23,4 +23,3 @@ properties:
       description: dual-bank mode enabled (page erase 2048k)
       generation: define
       category: optional
-...

--- a/dts/bindings/flash_controller/zephyr,native-posix-flash-controller.yaml
+++ b/dts/bindings/flash_controller/zephyr,native-posix-flash-controller.yaml
@@ -1,4 +1,4 @@
----
+
 title: Native POSIX Flash Controller
 version: 0.1
 
@@ -12,5 +12,3 @@ inherits:
 properties:
     compatible:
       constraint: "zephyr,native-posix-flash-controller"
-
-...

--- a/dts/bindings/flash_controller/zephyr,sim-flash.yaml
+++ b/dts/bindings/flash_controller/zephyr,sim-flash.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
----
+
 title: simulated flash
 version: 0.1
 
@@ -15,5 +15,3 @@ properties:
 
     label:
       category: required
-
-...

--- a/dts/bindings/gpio/arduino-header-r3.yaml
+++ b/dts/bindings/gpio/arduino-header-r3.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ARDUINO GPIO HEADER
 version: 0.1
 
@@ -20,5 +20,3 @@ properties:
     gpio-map:
       type: compound
       category: required
-
-...

--- a/dts/bindings/gpio/arm,cmsdk-gpio.yaml
+++ b/dts/bindings/gpio/arm,cmsdk-gpio.yaml
@@ -1,4 +1,4 @@
----
+
 title: ARM CMSDK GPIO
 version: 0.1
 
@@ -17,4 +17,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/gpio/atmel,sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam-gpio.yaml
@@ -1,4 +1,4 @@
----
+
 title: Atmel SAM GPIO PORT driver
 version: 0.1
 
@@ -30,4 +30,3 @@ properties:
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/atmel,sam0-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam0-gpio.yaml
@@ -1,4 +1,4 @@
----
+
 title: Atmel SAM0 GPIO PORT driver
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/gpio-keys.yaml
+++ b/dts/bindings/gpio/gpio-keys.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: GPIO KEYS
 version: 0.1
 
@@ -24,5 +24,3 @@ properties:
 
     label:
       category: required
-
-...

--- a/dts/bindings/gpio/gpio-leds.yaml
+++ b/dts/bindings/gpio/gpio-leds.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: GPIO LED
 version: 0.1
 
@@ -24,5 +24,3 @@ properties:
 
     label:
       category: required
-
-...

--- a/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
+++ b/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
@@ -1,4 +1,4 @@
----
+
 title: Holtek HT16K33 LED Driver With Keyscan
 version: 0.1
 
@@ -23,5 +23,3 @@ cell_string: GPIO
 "#cells":
   - pin
   - flags
-
-...

--- a/dts/bindings/gpio/intel,apl-gpio.yaml
+++ b/dts/bindings/gpio/intel,apl-gpio.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Intel Apollo Lake GPIO controller
 version: 0.1
 
@@ -31,4 +31,3 @@ cell_string: GPIO
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/intel,qmsi-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-gpio.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Intel QMSI GPIO
 version: 0.1
 
@@ -31,4 +31,3 @@ cell_string: GPIO
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Intel QMSI SS GPIO
 version: 0.1
 
@@ -31,4 +31,3 @@ cell_string: GPIO
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/microchip,xec-gpio.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
----
+
 title: MICROCHIP GPIO
 version: 0.1
 
@@ -30,4 +30,3 @@ properties:
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NRF5 GPIO
 version: 0.1
 
@@ -28,4 +28,3 @@ cell_string: GPIO
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/nordic,nrf-gpiote.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpiote.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NRF5 GPIOTE
 version: 0.1
 
@@ -25,5 +25,3 @@ properties:
 
     label:
       category: required
-
-...

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: i.MX GPIO
 version: 0.1
 
@@ -35,4 +35,3 @@ properties:
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -1,4 +1,4 @@
----
+
 title: Kinetis GPIO
 version: 0.1
 
@@ -24,4 +24,3 @@ properties:
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
+++ b/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
@@ -1,4 +1,4 @@
----
+
 title: OpenISA GPIO
 version: 0.1
 
@@ -30,4 +30,3 @@ properties:
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Semtech SX1509B I2C GPIO
 version: 0.1
 
@@ -25,4 +25,3 @@ cell_string: GPIO
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/sifive,gpio0.yaml
+++ b/dts/bindings/gpio/sifive,gpio0.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: SiFive GPIO
 version: 0.1
 
@@ -31,4 +31,3 @@ cell_string: GPIO
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
@@ -1,4 +1,4 @@
----
+
 title: EFM32 GPIO
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/silabs,efm32-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio.yaml
@@ -1,4 +1,4 @@
----
+
 title: EFM32 GPIO
 version: 0.1
 
@@ -26,4 +26,3 @@ properties:
       category: optional
       description: Serial Wire Output (SWO) PIN location
       generation: define
-...

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
@@ -1,4 +1,4 @@
----
+
 title: EFR32MG GPIO
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
@@ -1,4 +1,4 @@
----
+
 title: EFR32MG GPIO
 version: 0.1
 
@@ -26,4 +26,3 @@ properties:
       category: optional
       description: Serial Wire Output (SWO) PIN location
       generation: define
-...

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
@@ -1,4 +1,4 @@
----
+
 title: EFR32XG1 GPIO
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
@@ -1,4 +1,4 @@
----
+
 title: EFR32XG1 GPIO
 version: 0.1
 
@@ -26,4 +26,3 @@ properties:
       category: optional
       description: Serial Wire Output (SWO) PIN location
       generation: define
-...

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Synopsys Designware GPIO controller
 version: 0.1
 
@@ -37,4 +37,3 @@ cell_string: GPIO
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STM32 GPIO
 version: 0.1
 
@@ -35,4 +35,3 @@ properties:
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: TI SimpleLink CC13xx / CC26xx GPIO
 version: 0.1
 
@@ -31,4 +31,3 @@ cell_string: GPIO
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/ti,cc2650-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc2650-gpio.yaml
@@ -1,4 +1,4 @@
----
+
 # SPDX-License-Identifier: Apache-2.0
 title: TI CC2650 GPIO
 version: 0.1
@@ -18,4 +18,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/gpio/ti,cc32xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc32xx-gpio.yaml
@@ -1,4 +1,4 @@
----
+
 # SPDX-License-Identifier: Apache-2.0
 title: TI CC32XX GPIO
 version: 0.1
@@ -27,4 +27,3 @@ cell_string: GPIO
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/gpio/ti,stellaris-gpio.yaml
+++ b/dts/bindings/gpio/ti,stellaris-gpio.yaml
@@ -1,4 +1,4 @@
----
+
 # SPDX-License-Identifier: Apache-2.0
 title: TI Stellaris GPIO
 version: 0.1
@@ -25,4 +25,3 @@ properties:
 "#cells":
   - pin
   - flags
-...

--- a/dts/bindings/i2c/arm,versatile-i2c.yaml
+++ b/dts/bindings/i2c/arm,versatile-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ARM SBCon two-wire serial bus interface
 version: 0.1
 
@@ -19,5 +19,3 @@ properties:
 
     reg:
       category: required
-
-...

--- a/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel SAM Family I2C (TWI) node
 version: 0.1
 
@@ -28,4 +28,3 @@ properties:
       description: peripheral ID
       generation: define
       category: required
-...

--- a/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel SAM Family I2C (TWIHS) node
 version: 0.1
 
@@ -28,4 +28,3 @@ properties:
       description: peripheral ID
       generation: define
       category: required
-...

--- a/dts/bindings/i2c/atmel,sam0-i2c.yaml
+++ b/dts/bindings/i2c/atmel,sam0-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel SAM0 series SERCOM I2C controller
 version: 0.1
 
@@ -28,4 +28,3 @@ properties:
       category: optional
       description: DMA channel
       generation: define
-...

--- a/dts/bindings/i2c/fsl,imx7d-i2c.yaml
+++ b/dts/bindings/i2c/fsl,imx7d-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: i.MX I2C Controller
 version: 0.1
 

--- a/dts/bindings/i2c/i2c-device.yaml
+++ b/dts/bindings/i2c/i2c-device.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: I2C Device Base Structure
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
       category: required
     label:
       category: required
-...

--- a/dts/bindings/i2c/i2c.yaml
+++ b/dts/bindings/i2c/i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: I2C Base Structure
 version: 0.1
 
@@ -37,4 +37,3 @@ properties:
       generation: define
     label:
       category: required
-...

--- a/dts/bindings/i2c/intel,qmsi-i2c.yaml
+++ b/dts/bindings/i2c/intel,qmsi-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Intel QMSI i2c
 version: 0.1
 
@@ -22,5 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
+++ b/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Intel QMSI SS i2c
 version: 0.1
 
@@ -22,5 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/i2c/microchip,xec-i2c.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: MICROCHIP I2C
 version: 0.1
 
@@ -25,5 +25,3 @@ properties:
       description: soc block mapping to pin
       generation: define
       category: define
-
-...

--- a/dts/bindings/i2c/nios2,i2c.yaml
+++ b/dts/bindings/i2c/nios2,i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NIOS2 i2c
 version: 0.1
 
@@ -22,5 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/i2c/nordic,nrf-i2c.yaml
+++ b/dts/bindings/i2c/nordic,nrf-i2c.yaml
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic nRF Family I2C Master node
 version: 0.1
 
@@ -35,4 +35,3 @@ properties:
       description: SCL pin
       generation: define
       category: required
-...

--- a/dts/bindings/i2c/nxp,imx-lpi2c.yaml
+++ b/dts/bindings/i2c/nxp,imx-lpi2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP LPI2C
 version: 0.1
 

--- a/dts/bindings/i2c/nxp,kinetis-i2c.yaml
+++ b/dts/bindings/i2c/nxp,kinetis-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Kinetis I2C Controller
 version: 0.1
 

--- a/dts/bindings/i2c/openisa,rv32m1-lpi2c.yaml
+++ b/dts/bindings/i2c/openisa,rv32m1-lpi2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: OpenISA LPI2C
 version: 0.1
 

--- a/dts/bindings/i2c/sifive,i2c0.yaml
+++ b/dts/bindings/i2c/sifive,i2c0.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: SiFive Freedom I2C
 version: 0.1
 
@@ -25,5 +25,3 @@ properties:
 
     reg:
       category: required
-
-...

--- a/dts/bindings/i2c/silabs,gecko-i2c.yaml
+++ b/dts/bindings/i2c/silabs,gecko-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Silabs Gecko I2C Controller
 version: 0.1
 
@@ -37,4 +37,3 @@ properties:
       category: required
       description: SCL pin configuration defined as <location port pin>
       generation: define
-...

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Synopys DesignWare I2C controller
 version: 0.1
 
@@ -28,4 +28,3 @@ properties:
       category: optional
       description: attached via PCI(e) bus
       generation: define
-...

--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STM32 I2C V1
 version: 0.1
 
@@ -22,5 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STM32 I2C V2
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: TI CC13xx / CC26xx I2C
 version: 0.1
 
@@ -34,4 +34,3 @@ properties:
       category: required
       description: SCL pin
       generation: define
-...

--- a/dts/bindings/i2c/ti,cc32xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc32xx-i2c.yaml
@@ -1,4 +1,4 @@
----
+
 title: CC32XX I2C
 version: 0.1
 
@@ -17,5 +17,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/i2s/i2s-device.yaml
+++ b/dts/bindings/i2s/i2s-device.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: I2S Device Base Structure
 version: 0.1
 
@@ -21,5 +21,3 @@ properties:
       category: required
     label:
       category: required
-
-...

--- a/dts/bindings/i2s/i2s.yaml
+++ b/dts/bindings/i2s/i2s.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: I2S Base Structure
 version: 0.1
 
@@ -32,5 +32,3 @@ properties:
       category: optional
       description: Clock gate information
       generation: define
-
-...

--- a/dts/bindings/i2s/st,stm32-i2s.yaml
+++ b/dts/bindings/i2s/st,stm32-i2s.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STM32 I2S
 version: 0.1
 
@@ -22,5 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/ieee802154/nxp,mcr20a.yaml
+++ b/dts/bindings/ieee802154/nxp,mcr20a.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP MCR20A 802.15.4 Wireless Transceiver
 version: 0.1
 
@@ -26,4 +26,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/ieee802154/ti,cc1200.yaml
+++ b/dts/bindings/ieee802154/ti,cc1200.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: CC1200 802.15.4 Wireless Transceiver
 version: 0.1
 
@@ -16,5 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "ti,cc1200"
-
-...

--- a/dts/bindings/ieee802154/ti,cc2520.yaml
+++ b/dts/bindings/ieee802154/ti,cc2520.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: CC2520 802.15.4 Wireless Transceiver
 version: 0.1
 
@@ -46,4 +46,3 @@ properties:
       type: compound
       category: optional
       generation: define, use-prop-name
-...

--- a/dts/bindings/iio/adc/adc.yaml
+++ b/dts/bindings/iio/adc/adc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ADC Base Structure
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     label:
       category: required
-...

--- a/dts/bindings/iio/adc/atmel,sam-afec.yaml
+++ b/dts/bindings/iio/adc/atmel,sam-afec.yaml
@@ -1,4 +1,4 @@
----
+
 title: Atmel SAM Family AFEC
 version: 0.1
 
@@ -23,4 +23,3 @@ properties:
       description: peripheral ID
       generation: define
       category: required
-...

--- a/dts/bindings/iio/adc/atmel,sam0-adc.yaml
+++ b/dts/bindings/iio/adc/atmel,sam0-adc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel SAM0 Family ADC
 version: 0.1
 
@@ -34,4 +34,3 @@ properties:
       category: required
       description: clock prescaler divisor applied to the generic clock
       generation: define
-...

--- a/dts/bindings/iio/adc/intel,quark-d2000-adc.yaml
+++ b/dts/bindings/iio/adc/intel,quark-d2000-adc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Intel Quark D2000 ADC
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/iio/adc/nordic,nrf-adc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-adc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic Semiconductor nRF Family ADC
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic Semiconductor nRF Family SAADC
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/iio/adc/nxp,kinetis-adc12.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc12.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP Kinetis ADC12
 version: 0.1
 
@@ -46,4 +46,3 @@ properties:
       category: required
       description: sample time in clock cycles
       generation: define
-...

--- a/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Kinetis ADC16
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/iio/adc/snps,dw-adc.yaml
+++ b/dts/bindings/iio/adc/snps,dw-adc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: DesignWare ADC
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/iio/adc/st,stm32-adc.yaml
+++ b/dts/bindings/iio/adc/st,stm32-adc.yaml
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ST STM32 family ADC
 version: 0.1
 
@@ -29,4 +29,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
@@ -1,4 +1,4 @@
----
+
 title: ARMv6-M NVIC Interrupt Controller
 version: 0.1
 
@@ -24,4 +24,3 @@ properties:
 "#cells":
   - irq
   - priority
-...

--- a/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
@@ -1,4 +1,4 @@
----
+
 title: ARMv7-M NVIC Interrupt Controller
 version: 0.1
 
@@ -24,4 +24,3 @@ properties:
 "#cells":
   - irq
   - priority
-...

--- a/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
@@ -1,4 +1,4 @@
----
+
 title: ARMv8-M NVIC Interrupt Controller
 version: 0.1
 
@@ -24,4 +24,3 @@ properties:
 "#cells":
   - irq
   - priority
-...

--- a/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
+++ b/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
@@ -1,4 +1,4 @@
----
+
 title: Atmel SAM0 External Interrupt Controller
 version: 0.1
 
@@ -20,4 +20,3 @@ properties:
 
   label:
     category: required
-...

--- a/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
@@ -1,4 +1,4 @@
----
+
 title: CAVS Interrupt Controller
 version: 0.1
 
@@ -30,4 +30,3 @@ cell_string: IRQ
   - irq
   - sense
   - priority
-...

--- a/dts/bindings/interrupt-controller/intel,ioapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,ioapic.yaml
@@ -1,4 +1,4 @@
----
+
 title: Intel I/O Advanced Programmable Interrupt Controller
 version: 0.1
 
@@ -26,4 +26,3 @@ properties:
   - irq
   - sense
   - priority
-...

--- a/dts/bindings/interrupt-controller/intel,mvic.yaml
+++ b/dts/bindings/interrupt-controller/intel,mvic.yaml
@@ -1,4 +1,4 @@
----
+
 title: Intel Quark D2000 Interrupt Controller
 version: 0.1
 
@@ -25,4 +25,3 @@ properties:
 "#cells":
   - irq
   - sense
-...

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: RV32M1 Event Unit
 version: 0.1
 
@@ -23,4 +23,3 @@ properties:
 
 "#cells":
   - irq
-...

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: RV32M1 INTMUX
 version: 0.1
 
@@ -35,4 +35,3 @@ properties:
 "#cells":
   - irq
   - pri
-...

--- a/dts/bindings/interrupt-controller/riscv,plic0.yaml
+++ b/dts/bindings/interrupt-controller/riscv,plic0.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: RISC-V PLIC
 version: 0.1
 
@@ -28,4 +28,3 @@ properties:
 
 "#cells":
   - irq
-...

--- a/dts/bindings/interrupt-controller/shared-irq.yaml
+++ b/dts/bindings/interrupt-controller/shared-irq.yaml
@@ -1,4 +1,4 @@
----
+
 title: Shared IRQ interrupt dispatcher
 version: 0.1
 
@@ -17,5 +17,3 @@ properties:
 
   label:
       category: required
-
-...

--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ARCV2 Interrupt Controller
 version: 0.1
 
@@ -29,4 +29,3 @@ properties:
 "#cells":
   - irq
   - priority
-...

--- a/dts/bindings/interrupt-controller/snps,designware-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,designware-intc.yaml
@@ -1,4 +1,4 @@
----
+
 title: DesignWare Interrupt Controller
 version: 0.1
 
@@ -30,4 +30,3 @@ cell_string: IRQ
   - irq
   - sense
   - priority
-...

--- a/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
+++ b/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: LiteX VexRiscV Interrupt Controller
 version: 0.1
 
@@ -29,4 +29,3 @@ properties:
 "#cells":
   - irq
   - priority
-...

--- a/dts/bindings/interrupt-controller/xtensa,intc.yaml
+++ b/dts/bindings/interrupt-controller/xtensa,intc.yaml
@@ -1,4 +1,4 @@
----
+
 title: Xtensa Core Interrupt Controller
 version: 0.1
 
@@ -27,4 +27,3 @@ cell_string: IRQ
   - irq
   - sense
   - priority
-...

--- a/dts/bindings/led/holtek,ht16k33.yaml
+++ b/dts/bindings/led/holtek,ht16k33.yaml
@@ -1,4 +1,4 @@
----
+
 title: Holtek HT16K33 LED Driver
 version: 0.1
 
@@ -28,5 +28,3 @@ properties:
       category: optional
       description: IRQ pin
       generation: define, use-prop-name
-
-...

--- a/dts/bindings/led/nxp,pca9633.yaml
+++ b/dts/bindings/led/nxp,pca9633.yaml
@@ -1,4 +1,4 @@
----
+
 title: NXP PCA9633 LED Driver
 version: 0.1
 
@@ -10,4 +10,3 @@ inherits:
 properties:
     compatible:
       constraint: "nxp,pca9633"
-...

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: PWM LED
 version: 0.1
 
@@ -24,5 +24,3 @@ properties:
 
     label:
       category: required
-
-...

--- a/dts/bindings/led/ti,lp3943.yaml
+++ b/dts/bindings/led/ti,lp3943.yaml
@@ -1,4 +1,4 @@
----
+
 title: TI LP3943 LED Driver
 version: 0.1
 
@@ -10,4 +10,3 @@ inherits:
 properties:
     compatible:
       constraint: "ti,lp3943"
-...

--- a/dts/bindings/led/ti,lp5562.yaml
+++ b/dts/bindings/led/ti,lp5562.yaml
@@ -1,4 +1,4 @@
----
+
 title: TI LP5562 LED Driver
 version: 0.1
 
@@ -10,4 +10,3 @@ inherits:
 properties:
     compatible:
       constraint: "ti,lp5562"
-...

--- a/dts/bindings/led_strip/apa,apa-102.yaml
+++ b/dts/bindings/led_strip/apa,apa-102.yaml
@@ -1,4 +1,4 @@
----
+
 title: APA102 SPI LED strip
 version: 0.1
 
@@ -10,4 +10,3 @@ inherits:
 properties:
     compatible:
       constraint: "apa,apa102"
-...

--- a/dts/bindings/led_strip/colorway,lpd8803.yaml
+++ b/dts/bindings/led_strip/colorway,lpd8803.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Colorway LPD8803 SPI LED strip
 version: 0.1
 
@@ -15,4 +15,3 @@ inherits:
 properties:
     compatible:
       constraint: "colorway,lpd8803"
-...

--- a/dts/bindings/led_strip/colorway,lpd8806.yaml
+++ b/dts/bindings/led_strip/colorway,lpd8806.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Colorway LPD8806 SPI LED strip
 version: 0.1
 
@@ -15,4 +15,3 @@ inherits:
 properties:
     compatible:
       constraint: "colorway,lpd8806"
-...

--- a/dts/bindings/led_strip/worldsemi,ws2812.yaml
+++ b/dts/bindings/led_strip/worldsemi,ws2812.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Worldsemi WS2812 SPI LED strip
 version: 0.1
 
@@ -15,4 +15,3 @@ inherits:
 properties:
     compatible:
       constraint: "worldsemi,ws2812"
-...

--- a/dts/bindings/memory-controllers/nxp,imx-semc.yaml
+++ b/dts/bindings/memory-controllers/nxp,imx-semc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP SEMC
 version: 0.1
 
@@ -26,4 +26,3 @@ properties:
 
     label:
       category: required
-...

--- a/dts/bindings/mhu/arm,mhu.yaml
+++ b/dts/bindings/mhu/arm,mhu.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ARM MHU
 version: 0.1
 
@@ -25,4 +25,3 @@ properties:
 
     label:
       category: required
-...

--- a/dts/bindings/misc/skyworks,sky13351.yaml
+++ b/dts/bindings/misc/skyworks,sky13351.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Skyworks SKY13351 GaAs FET I/C switch
 version: 0.1
 

--- a/dts/bindings/mmc/mmc-spi-slot.yaml
+++ b/dts/bindings/mmc/mmc-spi-slot.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: MMC/SD/SDIO slot connected via SPI
 version: 0.1
 
@@ -15,5 +15,3 @@ inherits:
 properties:
     compatible:
       constraint: "zephyr,mmc-spi-slot"
-
-...

--- a/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
@@ -1,4 +1,4 @@
----
+
 title: ARMv7-M Memory Protection Unit
 version: 0.1
 
@@ -20,5 +20,3 @@ properties:
       type: int
       description: number of MPU regions supported by hardware
       generation: define
-
-...

--- a/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
@@ -1,4 +1,4 @@
----
+
 title: ARMv8-M Memory Protection Unit
 version: 0.1
 
@@ -20,5 +20,3 @@ properties:
       type: int
       description: number of MPU regions supported by hardware
       generation: define
-
-...

--- a/dts/bindings/modem/ublox,sara-r4.yaml
+++ b/dts/bindings/modem/ublox,sara-r4.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: u-blox SARA-R4 modem
 version: 0.1
 
@@ -29,4 +29,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: WNC-M14A2A LTE-M Modem
 version: 0.1
 
@@ -50,4 +50,3 @@ properties:
       category: optional
       description: UART RTS pin if no HW flow control (set to always enabled)
       generation: define, use-prop-name
-...

--- a/dts/bindings/mtd/atmel,at24.yaml
+++ b/dts/bindings/mtd/atmel,at24.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Virtual I2C slave eeprom
 version: 0.1
 
@@ -21,5 +21,3 @@ properties:
       category: required
       description: I2C Slave EEPROM Size in KiB
       generation: define
-
-...

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: SPI NOR flash devices (JEDEC CFI interface)
 version: 0.1
 
@@ -58,4 +58,3 @@ properties:
     category: optional
     description: RESETn pin
     generation: define, use-prop-name
-...

--- a/dts/bindings/mtd/partition.yaml
+++ b/dts/bindings/mtd/partition.yaml
@@ -1,4 +1,4 @@
----
+
 title: Flash Partitions
 version: 0.1
 
@@ -11,5 +11,3 @@ inherits:
 properties:
     compatible:
       constraint: "fixed-partitions"
-
-...

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -1,4 +1,4 @@
----
+
 title: Flash base node description
 version: 0.1
 
@@ -28,5 +28,3 @@ properties:
      generation: define
      category: optional
      label: alignment
-
-...

--- a/dts/bindings/mtd/winbond,w25q16.yaml
+++ b/dts/bindings/mtd/winbond,w25q16.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: SPI NOR FLASH
 version: 0.1
 
@@ -16,5 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "winbond,w25q16"
-
-...

--- a/dts/bindings/phy/phy.yaml
+++ b/dts/bindings/phy/phy.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: PHY Base Structure
 version: 0.1
 
@@ -19,4 +19,3 @@ properties:
         category: required
         description: Number of cells in a PHY provider. The meaning those
                      cells is defined by the binding for the phy node.
-...

--- a/dts/bindings/phy/st,stm32-usbphyc.yaml
+++ b/dts/bindings/phy/st,stm32-usbphyc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STM32 USB HS PHY
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     "#phy-cells":
       description: should be 0
-...

--- a/dts/bindings/phy/usb-nop-xceiv.yaml
+++ b/dts/bindings/phy/usb-nop-xceiv.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NOP USB Transceiver
 version: 0.1
 
@@ -20,4 +20,3 @@ properties:
 
     "#phy-cells":
       description: should be 0
-...

--- a/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
+++ b/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
@@ -1,4 +1,4 @@
----
+
 title: Atmel SAM0 PINMUX
 version: 0.1
 
@@ -21,5 +21,3 @@ properties:
 "#cells":
   - pin
   - function
-
-...

--- a/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
+++ b/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
@@ -1,4 +1,4 @@
----
+
 # SPDX-License-Identifier: Apache-2.0
 title: Intel S1000 Pinmux
 version: 0.1
@@ -19,4 +19,3 @@ properties:
 "#cells":
   - pin
   - function
-...

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -1,4 +1,4 @@
----
+
 title: Kinetis Pinmux
 version: 0.1
 
@@ -24,4 +24,3 @@ properties:
 "#cells":
   - pin
   - function
-...

--- a/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
+++ b/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
@@ -1,4 +1,4 @@
----
+
 title: RV32M1 Pinmux
 version: 0.1
 
@@ -24,4 +24,3 @@ properties:
 "#cells":
   - pin
   - function
-...

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 PINMUX
 version: 0.1
 
@@ -18,5 +18,3 @@ properties:
 "#cells":
   - pin
   - function
-
-...

--- a/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: TI SimpleLink CC13xx / CC26xx Pinmux
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     label:
       category: required
-...

--- a/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
@@ -1,4 +1,4 @@
----
+
 # SPDX-License-Identifier: Apache-2.0
 title: TI CC2650 Pinmux
 version: 0.1
@@ -19,4 +19,3 @@ properties:
 "#cells":
   - pin
   - function
-...

--- a/dts/bindings/power/nordic,nrf-power.yaml
+++ b/dts/bindings/power/nordic,nrf-power.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic nRF power control
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/pwm/atmel,sam-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam-pwm.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel SAM PWM
 version: 0.1
 
@@ -45,4 +45,3 @@ properties:
   - channel
 # period in terms of nanoseconds
   - period
-...

--- a/dts/bindings/pwm/fsl,imx7d-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx7d-pwm.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: i.MX7D PWM
 version: 0.1
 
@@ -39,4 +39,3 @@ properties:
   - channel
 # period in terms of nanoseconds
   - period
-...

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -1,4 +1,4 @@
----
+
 title: nRF PWM
 version: 0.1
 
@@ -65,4 +65,3 @@ properties:
       description: Channel 3 inverted
       category: optional
       generation: define
-...

--- a/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
@@ -1,4 +1,4 @@
----
+
 title: nRF SW PWM
 version: 0.1
 
@@ -44,4 +44,3 @@ properties:
       description: GPIOTE base used for GPIOTE index calculation used for PWM output generation
       category: required
       generation: define
-...

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Kinetis FTM
 version: 0.1
 
@@ -27,4 +27,3 @@ properties:
   - channel
 # period in terms of nanoseconds
   - period
-...

--- a/dts/bindings/pwm/pwm.yaml
+++ b/dts/bindings/pwm/pwm.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: PWM Base Structure
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     label:
       category: required
-...

--- a/dts/bindings/pwm/sifive,pwm0.yaml
+++ b/dts/bindings/pwm/sifive,pwm0.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: SiFive PWM
 version: 0.1
 
@@ -39,4 +39,3 @@ properties:
   - channel
 # period in terms of nanoseconds
   - period
-...

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 PWM
 version: 0.1
 
@@ -25,4 +25,3 @@ properties:
   - channel
 # period in terms of nanoseconds
   - period
-...

--- a/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
+++ b/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: RV32M1 PCC (Peripheral Clock Control)
 version: 0.1
 
@@ -26,4 +26,3 @@ properties:
 "#cells":
   - name
   - offset
-...

--- a/dts/bindings/rng/atmel,sam-trng.yaml
+++ b/dts/bindings/rng/atmel,sam-trng.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel SAM TRNG (True Random Number Generator)
 version: 0.1
 
@@ -31,5 +31,3 @@ properties:
 
     label:
       category: required
-
-...

--- a/dts/bindings/rng/nxp,kinetis-rnga.yaml
+++ b/dts/bindings/rng/nxp,kinetis-rnga.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Kinetis RNGA (Random Number Generator Accelerator)
 version: 0.1
 
@@ -25,5 +25,3 @@ properties:
 
     label:
       category: required
-
-...

--- a/dts/bindings/rng/nxp,kinetis-trng.yaml
+++ b/dts/bindings/rng/nxp,kinetis-trng.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Kinetis TRNG (True Random Number Generator)
 version: 0.1
 
@@ -25,5 +25,3 @@ properties:
 
     label:
       category: required
-
-...

--- a/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
+++ b/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: TI SimpleLink CC13xx / CC26xx True Random Number Generator (TRNG)
 version: 0.1
 
@@ -25,5 +25,3 @@ properties:
 
     label:
       category: required
-
-...

--- a/dts/bindings/rtc/atmel,sam0-rtc.yaml
+++ b/dts/bindings/rtc/atmel,sam0-rtc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel SAM0 RTC
 version: 0.1
 
@@ -25,4 +25,3 @@ properties:
       description: clock generator index
       generation: define
       category: required
-...

--- a/dts/bindings/rtc/intel,qmsi-rtc.yaml
+++ b/dts/bindings/rtc/intel,qmsi-rtc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Intel QMSI RTC
 version: 0.1
 
@@ -19,5 +19,3 @@ properties:
 
     reg:
       category: required
-
-...

--- a/dts/bindings/rtc/nordic,nrf-rtc.yaml
+++ b/dts/bindings/rtc/nordic,nrf-rtc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic nRF Real Time Counter
 version: 0.1
 
@@ -29,4 +29,3 @@ properties:
       description: Enable wrapping with PPI
       generation: define
       category: required
-...

--- a/dts/bindings/rtc/nxp,kinetis-rtc.yaml
+++ b/dts/bindings/rtc/nxp,kinetis-rtc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Kinetis RTC
 version: 0.1
 
@@ -19,4 +19,3 @@ properties:
 
     reg:
       category: required
-...

--- a/dts/bindings/rtc/rtc.yaml
+++ b/dts/bindings/rtc/rtc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: RTC Base Structure
 version: 0.1
 
@@ -29,4 +29,3 @@ properties:
       category: required
       description: RTC frequency equals clock-frequency divided by the prescaler value
       generation: define
-...

--- a/dts/bindings/rtc/silabs,gecko-rtcc.yaml
+++ b/dts/bindings/rtc/silabs,gecko-rtcc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Silabs Gecko Real Time Counter
 version: 0.1
 
@@ -19,4 +19,3 @@ properties:
 
     reg:
       category: required
-...

--- a/dts/bindings/rtc/st,stm32-rtc.yaml
+++ b/dts/bindings/rtc/st,stm32-rtc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STM32 RTC
 version: 0.1
 
@@ -25,4 +25,3 @@ properties:
       category: optional
       description: Clock gate information
       generation: define
-...

--- a/dts/bindings/sensor/adi,adt7420.yaml
+++ b/dts/bindings/sensor/adi,adt7420.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ADT7420 16-Bit Digital I2C Temperature Sensor
 version: 0.1
 
@@ -21,5 +21,3 @@ properties:
       type: compound
       category: optional
       generation: define, use-prop-name
-
-...

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ADXL362 Three Axis SPI accelerometer
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
       type: compound
       category: optional
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/adi,adxl372-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl372-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ADXL372 Three Axis High-g I2C/SPI accelerometer
 version: 0.1
 
@@ -21,5 +21,3 @@ properties:
       type: compound
       category: optional
       generation: define, use-prop-name
-
-...

--- a/dts/bindings/sensor/adi,adxl372-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl372-spi.yaml
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: ADXL372 Three Axis High-g I2C/SPI accelerometer
 version: 0.1
 
@@ -23,5 +23,3 @@ properties:
       type: compound
       category: optional
       generation: define, use-prop-name
-
-...

--- a/dts/bindings/sensor/ams,ccs811.yaml
+++ b/dts/bindings/sensor/ams,ccs811.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: AMS (Austria Mikro Systeme) Digital Air Quality Sensor CCS811
 version: 0.1
 
@@ -17,5 +17,3 @@ inherits:
 properties:
     compatible:
       constraint: "ams,ccs811"
-
-...

--- a/dts/bindings/sensor/ams,ens210.yaml
+++ b/dts/bindings/sensor/ams,ens210.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: AMS (Austria Mikro Systeme) Relative Humidity and Temperature Sensor
 version: 0.1
 
@@ -17,5 +17,3 @@ inherits:
 properties:
     compatible:
       constraint: "ams,ens210"
-
-...

--- a/dts/bindings/sensor/ams,iaqcore.yaml
+++ b/dts/bindings/sensor/ams,iaqcore.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: AMS (Austria Mikro Systeme) Indoor Air Quality Sensor iAQ-core
 version: 0.1
 
@@ -17,5 +17,3 @@ inherits:
 properties:
     compatible:
       constraint: "ams,iaqcore"
-
-...

--- a/dts/bindings/sensor/avago,apds9960.yaml
+++ b/dts/bindings/sensor/avago,apds9960.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: APDS9960 Digital Proximity, Ambient Light, RGB and Gesture Sensor
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/bosch,bme280-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bme280-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: BME280 Integrated environmental sensor
 version: 0.1
 
@@ -16,5 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "bosch,bme280"
-
-...

--- a/dts/bindings/sensor/bosch,bme280-spi.yaml
+++ b/dts/bindings/sensor/bosch,bme280-spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: BME280 Integrated environmental sensor
 version: 0.1
 
@@ -16,5 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "bosch,bme280"
-
-...

--- a/dts/bindings/sensor/bosch,bme680-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bme680-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: BME680 integrated environmental sensor
 version: 0.1
 
@@ -17,4 +17,3 @@ inherits:
 properties:
     compatible:
       constraint: "bosch,bme680"
-...

--- a/dts/bindings/sensor/bosch,bmi160.yaml
+++ b/dts/bindings/sensor/bosch,bmi160.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: BMI160 Inertial measurement unit
 version: 0.1
 
@@ -21,5 +21,3 @@ properties:
       type: compound
       category: optional
       generation: define, use-prop-name
-
-...

--- a/dts/bindings/sensor/max,max30101.yaml
+++ b/dts/bindings/sensor/max,max30101.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: MAX30101 heart rate sensor
 version: 0.1
 
@@ -16,5 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "max,max30101"
-
-...

--- a/dts/bindings/sensor/meas,ms5837.yaml
+++ b/dts/bindings/sensor/meas,ms5837.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: TE Connectivity digital pressure sensor MS5837
 version: 0.1
 
@@ -17,5 +17,3 @@ inherits:
 properties:
     compatible:
       constraint: "meas,ms5837"
-
-...

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic nRF Family QDEC node
 version: 0.1
 
@@ -61,4 +61,3 @@ properties:
 
     label:
       category: required
-...

--- a/dts/bindings/sensor/nordic,nrf-temp.yaml
+++ b/dts/bindings/sensor/nordic,nrf-temp.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic nRF Family TEMP node
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/sensor/nxp,fxas21002.yaml
+++ b/dts/bindings/sensor/nxp,fxas21002.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: FXAS21002 3-axis gyroscope
 version: 0.1
 
@@ -26,4 +26,3 @@ properties:
       type: compound
       category: optional
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/nxp,fxos8700.yaml
+++ b/dts/bindings/sensor/nxp,fxos8700.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: FXOS8700 6-axis accelerometer/magnetometer
 version: 0.1
 
@@ -32,4 +32,3 @@ properties:
       type: compound
       category: optional
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/sensirion,sht3xd.yaml
+++ b/dts/bindings/sensor/sensirion,sht3xd.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Sensirion Humidity Sensor SHT-3x-DIS
 version: 0.1
 
@@ -22,5 +22,3 @@ properties:
       category: optional
       description: ALERT pin
       generation: define, use-prop-name
-
-...

--- a/dts/bindings/sensor/st,hts221.yaml
+++ b/dts/bindings/sensor/st,hts221.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors HTS221
 version: 0.1
 
@@ -23,5 +23,3 @@ properties:
       category: optional
       description: DRDY pin
       generation: define, use-prop-name
-
-...

--- a/dts/bindings/sensor/st,lis2dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dh-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LIS2DH
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/st,lis2dh-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dh-spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LIS2DH SPI
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/st,lis2ds12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LIS2DS12
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/st,lis2ds12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LIS2DS12 SPI
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/st,lis2dw12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LIS2DW12
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/st,lis2dw12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LIS2DW12 SPI
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/st,lis2mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-magn.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LIS2MDL
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/st,lis3dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis3dh-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LIS3DH
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/st,lis3mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis3mdl-magn.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LIS3MDL
 version: 0.1
 
@@ -16,5 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,lis3mdl-magn"
-
-...

--- a/dts/bindings/sensor/st,lps22hb-press.yaml
+++ b/dts/bindings/sensor/st,lps22hb-press.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LPS22HB
 version: 0.1
 
@@ -16,5 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,lps22hb-press"
-
-...

--- a/dts/bindings/sensor/st,lps25hb-press.yaml
+++ b/dts/bindings/sensor/st,lps25hb-press.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LPS25HB
 version: 0.1
 
@@ -16,5 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,lps25hb-press"
-
-...

--- a/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
+++ b/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LSM303DLHC
 version: 0.1
 
@@ -16,6 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,lsm303dlhc-accel"
-
-...
-

--- a/dts/bindings/sensor/st,lsm303dlhc-magn.yaml
+++ b/dts/bindings/sensor/st,lsm303dlhc-magn.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LSM303DLHC
 version: 0.1
 
@@ -16,6 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,lsm303dlhc-magn"
-
-...
-

--- a/dts/bindings/sensor/st,lsm6ds0.yaml
+++ b/dts/bindings/sensor/st,lsm6ds0.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LSM6DS0
 version: 0.1
 
@@ -17,5 +17,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,lsm6ds0"
-
-...

--- a/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LSM6DSL
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/st,lsm6dsl-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LSM6DSL SPI
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LSM9DS0-GYRO
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors LSM9DS0-MFD
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-...

--- a/dts/bindings/sensor/st,vl53l0x.yaml
+++ b/dts/bindings/sensor/st,vl53l0x.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics MEMS sensors VL53L0X
 version: 0.1
 
@@ -16,5 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,vl53l0x"
-
-...

--- a/dts/bindings/sensor/ti,hdc.yaml
+++ b/dts/bindings/sensor/ti,hdc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Texas Instruments Temperature and Humidity Sensor
 version: 0.1
 
@@ -21,4 +21,3 @@ properties:
       type: compound
       category: optional
       generation: define, use-prop-name
-...

--- a/dts/bindings/serial/altera,jtag-uart.yaml
+++ b/dts/bindings/serial/altera,jtag-uart.yaml
@@ -1,4 +1,4 @@
----
+
 title: Altera JTAG UART
 version: 0.1
 
@@ -17,4 +17,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/serial/arm,cmsdk-uart.yaml
+++ b/dts/bindings/serial/arm,cmsdk-uart.yaml
@@ -1,4 +1,4 @@
----
+
 title: ARM CMSDK UART
 version: 0.1
 
@@ -17,4 +17,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/serial/arm,pl011.yaml
+++ b/dts/bindings/serial/arm,pl011.yaml
@@ -1,4 +1,4 @@
----
+
 title: ARM PL011 UART
 version: 0.1
 
@@ -17,4 +17,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/serial/atmel,sam-uart.yaml
+++ b/dts/bindings/serial/atmel,sam-uart.yaml
@@ -1,4 +1,4 @@
----
+
 title: SAM Family UART
 version: 0.1
 
@@ -23,4 +23,3 @@ properties:
       description: peripheral ID
       generation: define
       category: required
-...

--- a/dts/bindings/serial/atmel,sam-usart.yaml
+++ b/dts/bindings/serial/atmel,sam-usart.yaml
@@ -1,4 +1,4 @@
----
+
 title: Atmel SAM Family USART
 version: 0.1
 
@@ -23,4 +23,3 @@ properties:
       description: peripheral ID
       generation: define
       category: required
-...

--- a/dts/bindings/serial/atmel,sam0-uart.yaml
+++ b/dts/bindings/serial/atmel,sam0-uart.yaml
@@ -1,4 +1,4 @@
----
+
 title: Atmel SAM0 SERCOM UART driver
 version: 0.1
 
@@ -41,4 +41,3 @@ properties:
       category: optional
       description: Transmit DMA channel
       generation: define
-...

--- a/dts/bindings/serial/cypress,psoc6-uart.yaml
+++ b/dts/bindings/serial/cypress,psoc6-uart.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: CYPRESS UART
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/serial/intel,qmsi-uart.yaml
+++ b/dts/bindings/serial/intel,qmsi-uart.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Intel QMSI Uart
 version: 0.1
 
@@ -27,5 +27,3 @@ properties:
       type: array
       category: optional
       description: pinmux information for RX, TX, CTS, RTS
-
-...

--- a/dts/bindings/serial/litex,uart0.yaml
+++ b/dts/bindings/serial/litex,uart0.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: LiteX UART
 version: 0.1
 
@@ -22,5 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/serial/microsemi,coreuart.yaml
+++ b/dts/bindings/serial/microsemi,coreuart.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: SIFIVE UART
 version: 0.1
 
@@ -22,5 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/serial/nordic,nrf-uart.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart.yaml
@@ -1,4 +1,4 @@
----
+
 title: Nordic UART
 version: 0.1
 
@@ -41,4 +41,3 @@ properties:
       description: CTS pin
       generation: define
       category: optional
-...

--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -1,4 +1,4 @@
----
+
 title: Nordic UARTE
 version: 0.1
 
@@ -41,4 +41,3 @@ properties:
       description: CTS pin
       generation: define
       category: optional
-...

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -1,4 +1,4 @@
----
+
 title: ns16550
 version: 0.1
 
@@ -41,4 +41,3 @@ properties:
       category: optional
       description: attached via PCI(e) bus
       generation: define
-...

--- a/dts/bindings/serial/nxp,imx-uart.yaml
+++ b/dts/bindings/serial/nxp,imx-uart.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: iMX Uart
 version: 0.1
 
@@ -45,5 +45,3 @@ properties:
      category: required
      description: Set the RDC permission for this peripheral
      generation: define
-
-...

--- a/dts/bindings/serial/nxp,kinetis-lpsci.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpsci.yaml
@@ -1,4 +1,4 @@
----
+
 title: Kinetis LPSCI UART
 version: 0.1
 
@@ -17,5 +17,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/serial/nxp,kinetis-lpuart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpuart.yaml
@@ -1,4 +1,4 @@
----
+
 title: Kinetis LPUART
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
       type: array
       category: optional
       description: pinmux information for RX, TX, CTS, RTS
-...

--- a/dts/bindings/serial/nxp,kinetis-uart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-uart.yaml
@@ -1,4 +1,4 @@
----
+
 title: Kinetis UART
 version: 0.1
 
@@ -34,4 +34,3 @@ properties:
       category: required
       description: Clock gate information
       generation: define
-...

--- a/dts/bindings/serial/nxp,lpc-usart.yaml
+++ b/dts/bindings/serial/nxp,lpc-usart.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: LPC USART
 version: 0.1
 
@@ -33,4 +33,3 @@ properties:
       category: required
       description: Clock gate information
       generation: define
-...

--- a/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
+++ b/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
@@ -1,4 +1,4 @@
----
+
 title: OpenISA LPUART
 version: 0.1
 
@@ -28,4 +28,3 @@ properties:
       category: optional
       description: use hw flow control
       generation: define
-...

--- a/dts/bindings/serial/sifive,uart0.yaml
+++ b/dts/bindings/serial/sifive,uart0.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: SIFIVE UART
 version: 0.1
 
@@ -22,5 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/serial/silabs,gecko-leuart.yaml
+++ b/dts/bindings/serial/silabs,gecko-leuart.yaml
@@ -1,4 +1,4 @@
----
+
 title: GECKO LEUART
 version: 0.1
 
@@ -32,4 +32,3 @@ properties:
       category: required
       description: TX pin configuration defined as <location port pin>
       generation: define
-...

--- a/dts/bindings/serial/silabs,gecko-uart.yaml
+++ b/dts/bindings/serial/silabs,gecko-uart.yaml
@@ -1,4 +1,4 @@
----
+
 title: GECKO UART
 version: 0.1
 
@@ -32,4 +32,3 @@ properties:
       category: required
       description: TX pin configuration defined as <location port pin>
       generation: define
-...

--- a/dts/bindings/serial/silabs,gecko-usart.yaml
+++ b/dts/bindings/serial/silabs,gecko-usart.yaml
@@ -1,4 +1,4 @@
----
+
 title: GECKO USART
 version: 0.1
 
@@ -32,4 +32,3 @@ properties:
       category: required
       description: TX pin configuration defined as <location port pin>
       generation: define
-...

--- a/dts/bindings/serial/snps,nsim-uart.yaml
+++ b/dts/bindings/serial/snps,nsim-uart.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Synopsys ARC nSIM UART
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/serial/st,stm32-lpuart.yaml
+++ b/dts/bindings/serial/st,stm32-lpuart.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 LPUART
 version: 0.1
 
@@ -29,4 +29,3 @@ properties:
       category: optional
       description: Set to enable RTS/CTS flow control at boot time
       generation: define
-...

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 UART
 version: 0.1
 
@@ -23,4 +23,3 @@ properties:
       category: optional
       description: Set to enable RTS/CTS flow control at boot time
       generation: define
-...

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 USART
 version: 0.1
 
@@ -23,4 +23,3 @@ properties:
       category: optional
       description: Set to enable RTS/CTS flow control at boot time
       generation: define
-...

--- a/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: TI SimpleLink CC13xx / CC26xx UART
 version: 0.1
 
@@ -34,4 +34,3 @@ properties:
       category: required
       description: RX pin
       generation: define
-...

--- a/dts/bindings/serial/ti,cc32xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc32xx-uart.yaml
@@ -1,4 +1,4 @@
----
+
 title: TI CC32XX Uart
 version: 0.1
 
@@ -17,4 +17,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/serial/ti,msp432p4xx-uart.yaml
+++ b/dts/bindings/serial/ti,msp432p4xx-uart.yaml
@@ -1,4 +1,4 @@
----
+
 title: TI MSP432P4XX UART
 version: 0.1
 
@@ -17,4 +17,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/serial/ti,stellaris-uart.yaml
+++ b/dts/bindings/serial/ti,stellaris-uart.yaml
@@ -1,4 +1,4 @@
----
+
 title: TI Stellaris UART
 version: 0.1
 
@@ -17,4 +17,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/serial/uart-device.yaml
+++ b/dts/bindings/serial/uart-device.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: UART Device Base Structure
 version: 0.1
 
@@ -19,4 +19,3 @@ parent:
 properties:
     label:
       category: required
-...

--- a/dts/bindings/serial/uart.yaml
+++ b/dts/bindings/serial/uart.yaml
@@ -1,4 +1,4 @@
----
+
 title: Uart Base Structure
 version: 0.1
 
@@ -33,4 +33,3 @@ properties:
       type: array
       category: optional
       description: pinmux information for RX, TX, CTS, RTS
-...

--- a/dts/bindings/serial/xtensa,esp32-uart.yaml
+++ b/dts/bindings/serial/xtensa,esp32-uart.yaml
@@ -1,4 +1,4 @@
----
+
 title: ESP32 Uart
 version: 0.1
 
@@ -23,4 +23,3 @@ properties:
       category: required
       description: Clock gate control information
       generation: structures
-...

--- a/dts/bindings/serial/zephyr,native-posix-uart.yaml
+++ b/dts/bindings/serial/zephyr,native-posix-uart.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Native POSIX UART
 version: 0.1
 
@@ -16,4 +16,3 @@ inherits:
 properties:
     compatible:
       constraint: "zephyr,native-posix-uart"
-...

--- a/dts/bindings/spi/atmel,sam-spi.yaml
+++ b/dts/bindings/spi/atmel,sam-spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel SAM SPI driver
 version: 0.1
 
@@ -28,4 +28,3 @@ properties:
       description: peripheral ID
       generation: define
       category: required
-...

--- a/dts/bindings/spi/atmel,sam0-spi.yaml
+++ b/dts/bindings/spi/atmel,sam0-spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel SAM0 SERCOM SPI driver
 version: 0.1
 
@@ -43,4 +43,3 @@ properties:
       category: optional
       description: Transmit DMA channel
       generation: define
-...

--- a/dts/bindings/spi/intel,intel-spi.yaml
+++ b/dts/bindings/spi/intel,intel-spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Intel SPI Controller
 version: 0.1
 
@@ -22,5 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/spi/nordic,nrf-spi.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
----
+
 title: Nordic nRF Family SPI Master node
 version: 0.1
 
@@ -40,4 +40,3 @@ properties:
       category: required
       description: MISO pin
       generation: define
-...

--- a/dts/bindings/spi/nordic,nrf-spis.yaml
+++ b/dts/bindings/spi/nordic,nrf-spis.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic nRF Family SPIS (SPI Slave)
 version: 0.1
 
@@ -54,4 +54,3 @@ properties:
           Default character. Character clocked out when the slave was not
           provided with buffers and is ignoring the transaction.
       generation: define
-...

--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP FlexSPI
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/spi/nxp,imx-lpspi.yaml
+++ b/dts/bindings/spi/nxp,imx-lpspi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP LPSPI
 version: 0.1
 
@@ -28,4 +28,3 @@ properties:
       category: required
       description: Clock gate information
       generation: define
-...

--- a/dts/bindings/spi/nxp,kinetis-dspi.yaml
+++ b/dts/bindings/spi/nxp,kinetis-dspi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP DSPI
 version: 0.1
 
@@ -28,4 +28,3 @@ properties:
       category: required
       description: Clock gate information
       generation: define
-...

--- a/dts/bindings/spi/sifive,spi0.yaml
+++ b/dts/bindings/spi/sifive,spi0.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Sifive SPI driver
 version: 0.1
 
@@ -19,5 +19,3 @@ properties:
 
     reg:
       category: required
-
-...

--- a/dts/bindings/spi/snps,designware-spi.yaml
+++ b/dts/bindings/spi/snps,designware-spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Synopsys Designware SPI Controller
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: SPI Device Base Structure
 version: 0.1
 
@@ -26,4 +26,3 @@ properties:
       generation: define
     label:
       category: required
-...

--- a/dts/bindings/spi/spi.yaml
+++ b/dts/bindings/spi/spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: SPI Base Structure
 version: 0.1
 
@@ -41,6 +41,3 @@ properties:
       type: compound
       category: optional
       generation: define, use-prop-name
-
-
-...

--- a/dts/bindings/spi/st,stm32-spi-fifo.yaml
+++ b/dts/bindings/spi/st,stm32-spi-fifo.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STM32 SPI FIFO
 version: 0.1
 
@@ -23,5 +23,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/spi/st,stm32-spi.yaml
+++ b/dts/bindings/spi/st,stm32-spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STM32 SPI
 version: 0.1
 
@@ -22,5 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/spi/ti,cc13xx-cc26xx-spi.yaml
+++ b/dts/bindings/spi/ti,cc13xx-cc26xx-spi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: TI SimpleLink CC13xx / CC26xx SPI
 version: 0.1
 
@@ -43,4 +43,3 @@ properties:
       category: optional
       description: CS pin
       generation: define
-...

--- a/dts/bindings/sram/mmio-sram.yaml
+++ b/dts/bindings/sram/mmio-sram.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Generic on-chip SRAM
 version: 0.1
 
@@ -22,5 +22,3 @@ properties:
 
     label:
       category: optional
-
-...

--- a/dts/bindings/sram/sifive,dtim0.yaml
+++ b/dts/bindings/sram/sifive,dtim0.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Data Tightly-Integrated Memory
 version: 0.1
 
@@ -19,5 +19,3 @@ properties:
 
     reg:
       category: required
-
-...

--- a/dts/bindings/timer/arm,cmsdk-dtimer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-dtimer.yaml
@@ -1,4 +1,4 @@
----
+
 title: ARM CMSDK DUALTIMER
 version: 0.1
 
@@ -20,4 +20,3 @@ properties:
 
     label:
       category: required
-...

--- a/dts/bindings/timer/arm,cmsdk-timer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-timer.yaml
@@ -1,4 +1,4 @@
----
+
 title: ARM CMSDK TIMER
 version: 0.1
 
@@ -20,4 +20,3 @@ properties:
 
     label:
       category: required
-...

--- a/dts/bindings/timer/atmel,sam0-tc32.yaml
+++ b/dts/bindings/timer/atmel,sam0-tc32.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel SAM0 32-bit Basic Timer
 version: 0.1
 
@@ -26,4 +26,3 @@ properties:
 
   label:
     category: required
-...

--- a/dts/bindings/timer/litex,timer0.yaml
+++ b/dts/bindings/timer/litex,timer0.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: LiteX timer
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/timer/nordic,nrf-timer.yaml
+++ b/dts/bindings/timer/nordic,nrf-timer.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic nRF timer
 version: 0.1
 
@@ -31,4 +31,3 @@ properties:
       category: required
       description: Prescaler value determines frequency (16MHz/2^prescaler)
       generation: define
-...

--- a/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
+++ b/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
@@ -1,4 +1,4 @@
----
+
 title: OpenISA RV32M1 LPTMR
 version: 0.1
 
@@ -20,5 +20,3 @@ properties:
 
     label:
       category: required
-
-...

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -1,4 +1,4 @@
----
+
 title: STM32 TIMERS
 version: 0.1
 
@@ -32,5 +32,3 @@ properties:
       category: required
       description: Clock gate information
       generation: define
-
-...

--- a/dts/bindings/usb/atmel,sam-usbhs.yaml
+++ b/dts/bindings/usb/atmel,sam-usbhs.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel SAM USBHS
 version: 0.1
 
@@ -28,4 +28,3 @@ properties:
       category: required
       description: peripheral ID
       generation: define
-...

--- a/dts/bindings/usb/atmel,sam0-usb.yaml
+++ b/dts/bindings/usb/atmel,sam0-usb.yaml
@@ -1,4 +1,4 @@
----
+
 title: Atmel SAM0 USB device
 version: 0.1
 
@@ -17,4 +17,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/usb/nordic,nrf-usbd.yaml
+++ b/dts/bindings/usb/nordic,nrf-usbd.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic nRF52 USBD
 version: 0.1
 
@@ -34,4 +34,3 @@ properties:
       category: required
       description: Number of ISOOUT endpoints supported by hardware
       generation: define
-...

--- a/dts/bindings/usb/nxp,kinetis-usbd.yaml
+++ b/dts/bindings/usb/nxp,kinetis-usbd.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP Kinetis USBD
 version: 0.1
 
@@ -22,5 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-...

--- a/dts/bindings/usb/st,stm32-otgfs.yaml
+++ b/dts/bindings/usb/st,stm32-otgfs.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STM32 OTGFS
 version: 0.1
 
@@ -35,4 +35,3 @@ properties:
       category: optional
       generation: define
       description: PHY provider specifier
-...

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STM32 OTGHS
 version: 0.1
 
@@ -35,4 +35,3 @@ properties:
       category: optional
       generation: define
       description: PHY provider specifier
-...

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STM32 USB
 version: 0.1
 
@@ -49,4 +49,3 @@ properties:
       description: For STM32F0 series SoCs on QFN28 and TSSOP20 packages
                    enable PIN pair PA11/12 mapped instead of PA9/10 (e.g. stm32f070x6)
       generation: define, use-prop-name
-...

--- a/dts/bindings/usb/usb-ep.yaml
+++ b/dts/bindings/usb/usb-ep.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: USB Endpoints' properties
 version: 0.1
 
@@ -34,4 +34,3 @@ properties:
       description: Number of OUT endpoints supported by hardware
                    (including EP0 OUT)
       generation: define
-...

--- a/dts/bindings/usb/usb.yaml
+++ b/dts/bindings/usb/usb.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: USB Base Structure
 version: 0.1
 
@@ -31,4 +31,3 @@ properties:
 
     label:
       category: required
-...

--- a/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
+++ b/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
@@ -1,4 +1,4 @@
----
+
 title: ARM CMSDK WATCHDOG
 version: 0.1
 
@@ -14,4 +14,3 @@ properties:
 
     reg:
       category: required
-...

--- a/dts/bindings/watchdog/atmel,sam-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam-watchdog.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel SAM watchdog driver
 version: 0.1
 
@@ -31,4 +31,3 @@ properties:
       description: peripheral ID
       generation: define
       category: required
-...

--- a/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
@@ -1,4 +1,4 @@
----
+
 title: Atmel SAM0 watchdog driver
 version: 0.1
 
@@ -20,4 +20,3 @@ properties:
 
     interrupts:
       category: required
-...

--- a/dts/bindings/watchdog/intel,qmsi-watchdog.yaml
+++ b/dts/bindings/watchdog/intel,qmsi-watchdog.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: QMSI watchdog driver
 version: 0.1
 
@@ -31,4 +31,3 @@ properties:
       category: required
       description: Clock gate control information
       generation: structures
-...

--- a/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
+++ b/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Nordic Semiconductor NRF watchdog driver
 version: 0.1
 

--- a/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP Kinetis watchdog driver
 version: 0.1
 
@@ -31,4 +31,3 @@ properties:
       category: required
       description: Clock gate control information
       generation: structures
-...

--- a/dts/bindings/watchdog/st,stm32-watchdog.yaml
+++ b/dts/bindings/watchdog/st,stm32-watchdog.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: STMicroelectronics STM32 watchdog driver
 version: 0.1
 

--- a/dts/bindings/wifi/atmel,winc1500.yaml
+++ b/dts/bindings/wifi/atmel,winc1500.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Atmel WINC1500 Wifi module
 version: 0.1
 
@@ -31,5 +31,3 @@ properties:
       type: compound
       category: required
       generation: define, use-prop-name
-
-...

--- a/dts/bindings/wifi/inventek,eswifi.yaml
+++ b/dts/bindings/wifi/inventek,eswifi.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Inventek eS-WiFi WiFi module
 version: 0.1
 

--- a/samples/basic/minimal/sample.yaml
+++ b/samples/basic/minimal/sample.yaml
@@ -42,4 +42,3 @@ tests:
     build_only: true
     extra_args: CONF_FILE='common.conf;no-mt.conf;no-timers.conf;x86.conf'
     platform_whitelist: qemu_x86
-

--- a/samples/bluetooth/peripheral_hr/sample.yaml
+++ b/samples/bluetooth/peripheral_hr/sample.yaml
@@ -11,4 +11,3 @@ tests:
     platform_whitelist: mimxrt1020_evk mimxrt1050_evk mimxrt1060_evk frdm_k64f
     tags: bluetooth
     extra_args: SHIELD=frdm_kw41z
-

--- a/samples/boards/olimex_stm32_e407/ccm/sample.yaml
+++ b/samples/boards/olimex_stm32_e407/ccm/sample.yaml
@@ -4,4 +4,3 @@ tests:
   sample.board.olimex_stm32_e407.ccm:
     platform_whitelist: olimex_stm32_e407
     tags: board
-

--- a/samples/sensor/fxas21002/sample.yaml
+++ b/samples/sensor/fxas21002/sample.yaml
@@ -5,4 +5,3 @@ tests:
     harness: sensor
     tags: sensors
     platform_whitelist: hexiwear_k64 warp7_m4
-

--- a/samples/subsys/fs/sample.yaml
+++ b/samples/subsys/fs/sample.yaml
@@ -5,4 +5,3 @@ tests:
     build_only: true
     platform_whitelist: nrf52840_blip olimexino_stm32
     tags: filesystem
-

--- a/tests/drivers/build_all/testcase.yaml
+++ b/tests/drivers/build_all/testcase.yaml
@@ -53,4 +53,3 @@ tests:
     extra_args: CONF_FILE=gpio.conf
     min_ram: 32
     depends_on: gpio
-

--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -9,4 +9,3 @@ tests:
     extra_configs:
       - CONFIG_DEVICE_POWER_MANAGEMENT=y
     platform_whitelist: native_posix qemu_x86 #cannot run on qemu_x86_64 yet
-

--- a/tests/subsys/logging/log_msg/testcase.yaml
+++ b/tests/subsys/logging/log_msg/testcase.yaml
@@ -1,4 +1,3 @@
 tests:
   logging.log_msg:
     tags: log_msg logging
-

--- a/tests/subsys/logging/log_output/testcase.yaml
+++ b/tests/subsys/logging/log_output/testcase.yaml
@@ -1,4 +1,3 @@
 tests:
   logging.log_output:
     tags: log_output logging
-


### PR DESCRIPTION
YAML document separators are needed e.g. when doing

    $ cat doc1.yaml doc2.yaml | <parser>

For the bindings, we never parse concatenated documents. Assume we don't
for any other .yaml files either.

Having document separators in e.g. base.yaml makes !include a bit
confusing, since the !included files are merged and not separate
documents (the merging is done in Python code though, so it makes no
difference for behavior).

The replacement was done with

    $ git ls-files '*.yaml' | \
        xargs sed -i -e '${/\s*\.\.\.\s*/d;}' -e 's/^\s*---\s*$//'

First pattern removes ... at the end of files, second pattern clears a
line with a lone --- on it.

Some redundant blank lines at the end of files were cleared with

    $ git ls-files '*.yaml' | xargs sed -i '${/^\s*$/d}'

This is more about making sure people can understand why every part of a
binding is there than about removing some text.