### PR TITLE
tests: getaddrinfo: set newlib heap size

### DIFF
--- a/tests/net/socket/getaddrinfo/prj.conf
+++ b/tests/net/socket/getaddrinfo/prj.conf
@@ -32,6 +32,7 @@ CONFIG_ZTEST=y
 # User mode requirements
 CONFIG_TEST_USERSPACE=y
 CONFIG_HEAP_MEM_POOL_SIZE=128
+CONFIG_NEWLIB_LIBC_ALIGNED_HEAP_SIZE=256
 
 # We do not need neighbor discovery etc for this test
 CONFIG_NET_IPV6_DAD=n


### PR DESCRIPTION
Some MPU systems require region power-of-two alignment
and can't automatically use remaining RAM for the newlib
heap. Set it for this case. Fixes this test on mps2_an385.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>