### PR TITLE
generated/cfb_font_dice.h: don't leak absolute paths in comment

### DIFF
--- a/cmake/cfb.cmake
+++ b/cmake/cfb.cmake
@@ -15,6 +15,7 @@ function(generate_cfb_font
     ${ZEPHYR_BASE}/scripts/gen_cfb_font_header.py
     --input ${input_file}
     --output ${output_file}
+    --bindir ${CMAKE_BINARY_DIR}
     --width ${width}
     --height ${height}
     ${ARGN} # Extra arguments are passed to gen_cfb_font_header.py


### PR DESCRIPTION
The start of generated/cfb_font_dice.h looked like this:

/*
 * This file was automatically generated using the following command:
 * /home/john/zephyrproject/zephyr/scripts/gen_cfb_font_header.py
 * --input fonts/dice.png --output
 * /home/john/tmp/build/zephyr/include/generated//cfb_font_dice.h
 * --width 32 --height 32 --first 49 --last 54
 */

For build reproduction and "privacy" reasons, change it to this:

/*
 * This file was automatically generated using the following command:
 * ${ZEPHYR_BASE}/scripts/gen_cfb_font_header.py
 * --input fonts/dice.png --output
 * zephyr/include/generated//cfb_font_dice.h
 * --width 32 --height 32 --first 49 --last 54
 */

Test with:
  sanitycheck  -p reel_board \
  -T $ZEPHYR_BASE/samples/display/cfb_custom_font/

Signed-off-by: Marc Herbert <marc.herbert@intel.com>