### PR TITLE
BOOT_BANNER: show KERNEL_VERSION and BUILD_VERSION differently

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -50,10 +50,10 @@ LOG_MODULE_REGISTER(os);
 #endif
 
 #ifdef BUILD_VERSION
-#define BOOT_BANNER "Booting Zephyr OS "	\
+#define BOOT_BANNER "Booting Zephyr OS build "		\
 	 STRINGIFY(BUILD_VERSION) BOOT_DELAY_BANNER
 #else
-#define BOOT_BANNER "Booting Zephyr OS "	\
+#define BOOT_BANNER "Booting Zephyr OS version "	\
 	 KERNEL_VERSION_STRING BOOT_DELAY_BANNER
 #endif
 


### PR DESCRIPTION
Zephyr has to unrelated build _VERSIONs: KERNEL_VERSION and
BUILD_VERSION. Prefix them slightly differently in BOOT_BANNER so anyone
can instantly zoom in on which one is being used without having to
compare the implementation details of both.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>