### PR TITLE
dts: cleanup missing #{address,size}-cells

### DIFF
--- a/boards/arm/arduino_zero/arduino_zero.dts
+++ b/boards/arm/arduino_zero/arduino_zero.dts
@@ -64,6 +64,8 @@
 	compatible = "atmel,sam0-spi";
 	dipo = <0>;
 	dopo = <1>;
+	#address-cells = <1>;
+	#size-cells = <0>;
 };
 
 &flash0 {

--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
@@ -45,6 +45,8 @@
 	compatible = "atmel,sam0-spi";
 	dipo = <0>;
 	dopo = <2>;
+	#address-cells = <1>;
+	#size-cells = <0>;
 };
 
 &sercom3 {

--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
@@ -70,6 +70,8 @@
 	compatible = "atmel,sam0-spi";
 	dipo = <0>;
 	dopo = <2>;
+	#address-cells = <1>;
+	#size-cells = <0>;
 };
 
 &usb0 {

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -54,6 +54,8 @@
 	compatible = "atmel,sam0-i2c";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	label = "I2C_0";
+	#address-cells = <1>;
+	#size-cells = <0>;
 };
 
 &sercom5 {
@@ -62,6 +64,8 @@
 	dipo = <0>;
 	dopo = <2>;
 	label = "SPI_0";
+	#address-cells = <1>;
+	#size-cells = <0>;
 };
 
 &usb0 {

--- a/boards/riscv32/hifive1/hifive1.dts
+++ b/boards/riscv32/hifive1/hifive1.dts
@@ -56,8 +56,6 @@
 	status = "okay";
 	clock-frequency = <16000000>;
 
-	#address-cells = <1>;
-	#size-cells = <0>;
 	reg = <0x10014000 0x1000 0x20400000 0xc00000>;
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";

--- a/boards/riscv32/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv32/hifive1_revb/hifive1_revb.dts
@@ -58,8 +58,6 @@
 	status = "okay";
 	clock-frequency = <16000000>;
 
-	#address-cells = <1>;
-	#size-cells = <0>;
 	reg = <0x10014000 0x1000 0x20010000 0x3c0900>;
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -49,6 +49,8 @@
 			peripheral-id = <22>;
 			label = "I2C_0";
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		i2c1: i2c@40090000 {
@@ -59,6 +61,8 @@
 			peripheral-id = <23>;
 			label = "I2C_1";
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		uart0: uart@400e0800 {

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -47,6 +47,8 @@
 			peripheral-id = <19>;
 			label = "I2C_0";
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		i2c1: i2c@4001c000 {
@@ -57,6 +59,8 @@
 			peripheral-id = <20>;
 			label = "I2C_1";
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		uart0: uart@400e0600 {

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -107,30 +107,40 @@
 			reg = <0x40004000 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			label = "I2C_0";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 		i2c1: i2c@40004400 {
 			compatible = "microchip,xec-i2c";
 			reg = <0x40004400 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			label = "I2C_1";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 		i2c2: i2c@40004800 {
 			compatible = "microchip,xec-i2c";
 			reg = <0x40004800 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			label = "I2C_2";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 		i2c3: i2c@40004c00 {
 			compatible = "microchip,xec-i2c";
 			reg = <0x40004C00 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			label = "I2C_3";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 		i2c4: i2c@40005000 {
 			compatible = "microchip,xec-i2c";
 			reg = <0x40005000 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			label = "I2C_4";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 	};
 };

--- a/dts/riscv32/riscv32-fe310.dtsi
+++ b/dts/riscv32/riscv32-fe310.dtsi
@@ -86,6 +86,8 @@
 			reg-names = "control";
 			label = "i2c_0";
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 		plic: interrupt-controller@c000000 {
 			#interrupt-cells = <1>;
@@ -183,6 +185,8 @@
 			reg-names = "control", "mem";
 			label = "spi_0";
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 		spi1: spi@10024000 {
 			compatible = "sifive,spi0";
@@ -192,6 +196,8 @@
 			reg-names = "control";
 			label = "spi_1";
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 		spi2: spi@10034000 {
 			compatible = "sifive,spi0";
@@ -201,6 +207,8 @@
 			reg-names = "control";
 			label = "spi_2";
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 		teststatus: teststatus@4000 {
 			compatible = "sifive,test0";


### PR DESCRIPTION
A few i2c and spi bus nodes were missing #address-cells and #size-cells
properties.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>