### PR TITLE
scripts/sanitycheck: fix ZEPHYR_BASE subdir check edge case

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1740,7 +1740,7 @@ class TestCase:
     def get_unique(self, testcase_root, workdir, name):
 
         canonical_testcase_root = os.path.realpath(testcase_root)
-        if canonical_testcase_root.startswith(canonical_zephyr_base):
+        if Path(canonical_zephyr_base) in Path(canonical_testcase_root).parents:
             # This is in ZEPHYR_BASE, so include path in name for uniqueness
             # FIXME: We should not depend on path of test for unique names.
             relative_tc_root = os.path.relpath(canonical_testcase_root,


### PR DESCRIPTION
There is a case where using startswith to determine if a path is a
subdirectory of another path can erroneously match. When using a
testcase root outside of ZEPHYR_BASE, an erroneous match will cause the
relative path containing ".." to get prepended to the test output
directory.

Example:

$HOME/zephyr/zephyr # ZEPHYR_BASE
$HOME/zephyr/zephyr-rust/tests # testcase root

The relative path prepended to the testcase name is ../zephyr-rust/tests
and an example test output dir is
./sanity-out/qemu_x86/../zephyr-rust/tests/rust/rust.main

In this case, the build directory escapes the board directory and is no
longer unique. Parallel tests then clobber each other.

Use pathlib instead of string matching to cover this case.

Signed-off-by: Tyler Hall <tylerwhall@gmail.com>