### PR TITLE
arch: common: nocache: fix linker section definition

### DIFF
--- a/arch/common/nocache.ld
+++ b/arch/common/nocache.ld
@@ -8,7 +8,7 @@
 /* Copied from linker.ld */
 
 /* Non-cached region of RAM */
-SECTION_PROLOGUE(_NOCACHE_SECTION_NAME,(NOLOAD),)
+SECTION_DATA_PROLOGUE(_NOCACHE_SECTION_NAME,(NOLOAD),)
 {
 	MPU_ALIGN(_nocache_ram_size);
 	_nocache_ram_start = .;
@@ -16,5 +16,5 @@ SECTION_PROLOGUE(_NOCACHE_SECTION_NAME,(NOLOAD),)
 	*(".nocache.*")
 	MPU_ALIGN(_nocache_ram_size);
 	_nocache_ram_end = .;
-} GROUP_LINK_IN(RAMABLE_REGION)
+} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 _nocache_ram_size = _nocache_ram_end - _nocache_ram_start;


### PR DESCRIPTION
No-cache SRAM section is currently used for ARM-only builds
with support for no-cacheable memory sections (i.e.
CONFIG_ARCH_HAS_NOCACHE_MEMORY_SUPPORT) and it holds
uninitialized data. This commit properly defines the
corresponding linker section using SECTION_DATA_PROLOGUE
and GROUP_DATA_LINK_IN macros.

The patch fixes mimxrt board compilation.

Fixes #16778 

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>