### PR TITLE
Kconfig: Introducing ARCH_CHOICE symbol for Architecture choice group

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -14,7 +14,7 @@
 # Note: $ARCH might be a glob pattern
 source "$(ARCH_DIR)/$(ARCH)/Kconfig"
 
-choice
+choice ARCH_CHOICE
 	prompt "Architecture"
 	default X86
 


### PR DESCRIPTION
The ARCH_CHOICE symbol on the arch/Kconfig choice for Architecture
selection, allows for multiple definitions of the choice group which
makes it possible for out-of-tree architectures to add entries to the
list as needed.

Relates to PR #13130
