### PR TITLE
west: runners: Guess build folder

### DIFF
--- a/doc/guides/west/build-flash-debug.rst
+++ b/doc/guides/west/build-flash-debug.rst
@@ -219,6 +219,16 @@ You can :ref:`configure <west-config-cmd>` ``west build`` using these options.
      - String, default ``Ninja``. The `CMake Generator`_ to use to create a
        build system. (To set a generator for a single build, see the
        :ref:`above example <west-building-generator>`)
+   * - ``build.guess-dir``
+     - String, instructs west whether to try to guess what build folder to use
+       when ``build.dir-fmt`` is in use and not enough information is available
+       to resolve the build folder name. Can take these values:
+
+         - ``never`` (default): Never try to guess, bail out instead and
+           require the user to provide a build folder with ``-d``.
+         - ``runners``: Try to guess the folder when using any of the 'runner'
+           commands.  These are typically all commands that invoke an external
+           tool, such as ``flash`` and ``debug``.
    * - ``build.pristine``
      - String. Controls the way in which ``west build`` may clean the build
        folder before building. Can take the following values:

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -19,6 +19,7 @@ from west import util
 from build_helpers import find_build_dir, is_zephyr_build, \
     FIND_BUILD_DIR_DESCRIPTION
 from west.commands import CommandError
+from west.configuration import config
 
 from runners import get_runner_cls, ZephyrBinaryRunner, MissingProgram
 
@@ -170,7 +171,9 @@ def _build_dir(args, die_if_none=True):
     if args.build_dir:
         return args.build_dir
 
-    dir = find_build_dir(None)
+    guess = config.get('build', 'guess-dir', fallback='never')
+    guess = True if guess == 'runners' else False
+    dir = find_build_dir(None, guess)
 
     if dir and is_zephyr_build(dir):
         return dir


### PR DESCRIPTION
When using a build folder format with build.dir-fmt that includes any
parameters that need resolving, the west runners cannot find the folder
since the required information (board, source dir or app) is not
available.
Add a very simple heuristic to support the case where a build folder
starts with a hardcoded prefix (for example 'build/') and a single build
is present under that prefix.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>