### PR TITLE
wifi: eswifi: add UDP support

### DIFF
--- a/drivers/wifi/eswifi/eswifi_offload.h
+++ b/drivers/wifi/eswifi/eswifi_offload.h
@@ -34,7 +34,9 @@ struct eswifi_off_socket {
 	net_context_recv_cb_t recv_cb;
 	net_context_connect_cb_t conn_cb;
 	net_context_send_cb_t send_cb;
-	void *user_data;
+	void *recv_data;
+	void *conn_data;
+	void *send_data;
 	struct net_pkt *tx_pkt;
 	struct k_work connect_work;
 	struct k_work send_work;


### PR DESCRIPTION
Add UDP support for eswifi driver. eswifi now can co-exist
with TCP and UDP functionality with 4 as max socket connection.

Tested UDP with custom DNS sample (wifi connect + DNS)

Signed-off-by: Parthiban Nallathambi <parthitce@gmail.com>