### PR TITLE
net: mqtt: add mqtt_readall_publish_payload()

### DIFF
--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -715,6 +715,21 @@ int mqtt_read_publish_payload(struct mqtt_client *client, void *buffer,
 int mqtt_read_publish_payload_blocking(struct mqtt_client *client, void *buffer,
 				       size_t length);
 
+/**
+ * @brief Blocking version of @ref mqtt_read_publish_payload function which
+ *        runs until the required number of bytes are read.
+ *
+ * @param[in] client Client instance for which the procedure is requested.
+ *                   Shall not be NULL.
+ * @param[out] buffer Buffer where payload should be stored.
+ * @param[in] length Number of bytes to read.
+ *
+ * @return 0 if success, otherwise a negative error code (errno.h) indicating
+ *         reason of failure.
+ */
+int mqtt_readall_publish_payload(struct mqtt_client *client, u8_t *buffer,
+				 size_t length);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -647,3 +647,25 @@ int mqtt_read_publish_payload_blocking(struct mqtt_client *client, void *buffer,
 {
 	return read_publish_payload(client, buffer, length, true);
 }
+
+int mqtt_readall_publish_payload(struct mqtt_client *client, u8_t *buffer,
+				 size_t length)
+{
+	u8_t *end = buffer + length;
+
+	while (buffer < end) {
+		int ret = mqtt_read_publish_payload_blocking(client, buffer,
+							     end - buffer);
+
+		if (ret < 0) {
+			return ret;
+		} else if (ret == 0) {
+			return -EIO;
+		}
+
+		buffer += ret;
+	}
+
+	return 0;
+}
+


### PR DESCRIPTION
This function uses mqtt_read_publish_payload_blocking to perform a
blocking read of the specified number of bytes.

When reading out a payload, the normal use case is to read the
entire payload. This function facilitates that use case.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>