### PR TITLE
dts/bindings: Remove pinctrl from bindings

### DIFF
--- a/dts/bindings/can/can.yaml
+++ b/dts/bindings/can/can.yaml
@@ -42,7 +42,3 @@ properties:
       category: required
       description: Time quantums of phase buffer 2 segment (ISO 11898-1)
       generation: define
-    pinctrl-\d+:
-      type: array
-      category: optional
-      description: pinmux information for RX, TX

--- a/dts/bindings/serial/intel,qmsi-uart.yaml
+++ b/dts/bindings/serial/intel,qmsi-uart.yaml
@@ -22,8 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-    pinctrl-\d+:
-      type: array
-      category: optional
-      description: pinmux information for RX, TX, CTS, RTS

--- a/dts/bindings/serial/nxp,imx-uart.yaml
+++ b/dts/bindings/serial/nxp,imx-uart.yaml
@@ -23,11 +23,6 @@ properties:
     interrupts:
       category: required
 
-    pinctrl-\d+:
-      type: array
-      category: optional
-      description: pinmux information for RX, TX, CTS, RTS
-
     clocks:
       type: array
       category: required

--- a/dts/bindings/serial/nxp,kinetis-lpuart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpuart.yaml
@@ -17,8 +17,3 @@ properties:
 
     interrupts:
       category: required
-
-    pinctrl-*:
-      type: array
-      category: optional
-      description: pinmux information for RX, TX, CTS, RTS

--- a/dts/bindings/serial/nxp,kinetis-uart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-uart.yaml
@@ -18,11 +18,6 @@ properties:
     interrupts:
       category: required
 
-    pinctrl-\d+:
-      type: array
-      category: optional
-      description: pinmux information for RX, TX, CTS, RTS
-
     hw-flow-control:
       type: boolean
       category: optional

--- a/dts/bindings/serial/nxp,lpc-usart.yaml
+++ b/dts/bindings/serial/nxp,lpc-usart.yaml
@@ -23,11 +23,6 @@ properties:
     interrupts:
       category: required
 
-    pinctrl-\d+:
-      type: array
-      category: optional
-      description: pinmux information for RX, TX, CTS, RTS
-
     clocks:
       type: array
       category: required

--- a/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
+++ b/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
@@ -18,11 +18,6 @@ properties:
     interrupts:
       category: required
 
-    pinctrl-*:
-      type: array
-      category: optional
-      description: pinmux information for RX, TX, CTS, RTS
-
     hw-flow-control:
       type: boolean
       category: optional

--- a/dts/bindings/serial/uart.yaml
+++ b/dts/bindings/serial/uart.yaml
@@ -29,7 +29,3 @@ properties:
       generation: define
     label:
       category: required
-    pinctrl-\d+:
-      type: array
-      category: optional
-      description: pinmux information for RX, TX, CTS, RTS


### PR DESCRIPTION
The pinctrl property in the bindings is meaningless, lets remove it and
add a proper pinctrl property when we are ready.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>