### PR TITLE
dts/bindings: Add binding for riscv,cpu-intc

### DIFF
--- a/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
+++ b/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2019, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+title: RISC-V CPU INTC
+version: 0.1
+
+description: >
+    This binding describes the RISC-V CPU Interrupt Controller
+
+inherits:
+    !include base.yaml
+
+properties:
+  compatible:
+      constraint: "riscv,cpu-intc"
+
+"#cells":
+  - irq


### PR DESCRIPTION
The RISC-V CPU interrupt controller didn't have a binding.  Add a simple
one for it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>