### PR TITLE
bluetooth: controller: Moved ull_entropy_get to LLL

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_internal.h
@@ -14,3 +14,4 @@ u32_t lll_evt_offset_get(struct evt_hdr *evt);
 u32_t lll_preempt_calc(struct evt_hdr *evt, u8_t ticker_id,
 		u32_t ticks_at_event);
 void lll_chan_set(u32_t chan);
+u8_t lll_entropy_get(u8_t len, void *rand);

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -119,10 +119,9 @@ static struct k_sem sem_ticker_api_cb;
 /* Semaphore to wakeup thread on Rx-ed objects */
 static struct k_sem *sem_recv;
 
-/* Entropy device */
-static struct device *dev_entropy;
-
-/* Declare prepare-event FIFO: mfifo_prep: Queue of struct node_rx_event_done */
+/* Declare prepare-event FIFO: mfifo_prep.
+ * Queue of struct node_rx_event_done
+ */
 static MFIFO_DEFINE(prep, sizeof(struct lll_event), EVENT_PIPELINE_MAX);
 
 /* Declare done-event FIFO: mfifo_done.
@@ -225,11 +224,6 @@ int ll_init(struct k_sem *sem_rx)
 
 	/* Store the semaphore to be used to wakeup Thread context */
 	sem_recv = sem_rx;
-	/* Get reference to entropy device */
-	dev_entropy = device_get_binding(CONFIG_ENTROPY_NAME);
-	if (!dev_entropy) {
-		return -ENODEV;
-	}
 
 	/* Initialize counter */
 	/* TODO: Bind and use counter driver? */
@@ -1121,11 +1115,6 @@ void *ull_event_done(void *param)
 	ull_rx_sched();
 
 	return evdone;
-}
-
-u8_t ull_entropy_get(u8_t len, void *rand)
-{
-	return entropy_get_entropy_isr(dev_entropy, rand, len, 0);
 }
 
 static inline int init_reset(void)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -28,6 +28,7 @@
 #include "lll_adv.h"
 #include "lll_scan.h"
 #include "lll_conn.h"
+#include "lll_internal.h"
 #include "lll_filter.h"
 
 #include "ull_adv_types.h"
@@ -1016,7 +1017,7 @@ static void ticker_cb(u32_t ticks_at_expire, u32_t remainder, u16_t lazy,
 		u32_t random_delay;
 		u32_t ret;
 
-		ull_entropy_get(sizeof(random_delay), &random_delay);
+		lll_entropy_get(sizeof(random_delay), &random_delay);
 		random_delay %= HAL_TICKER_US_TO_TICKS(10000);
 		random_delay += 1;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -37,4 +37,3 @@ void *ull_update_mark(void *param);
 void *ull_update_unmark(void *param);
 void *ull_update_mark_get(void);
 int ull_disable(void *param);
-u8_t ull_entropy_get(u8_t len, void *rand);


### PR DESCRIPTION
Moved and renamed ull_entropy_get to lll_entropy_get, placed under
vendor specific ll_sw. This is needed for SW implemented entropy,
to allow vendor implementation of faster, less secure random number
generator for randomizing ADV timing.

Signed-off-by: Morten Priess <mtpr@oticon.com>