### PR TITLE
dts/bindings: Fix openisa,rv32m1-intmux binding

### DIFF
--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
@@ -34,4 +34,3 @@ properties:
 
 "#cells":
   - irq
-  - pri


### PR DESCRIPTION
The binding specified 2 cells for an interrupt, but in reality we only
have an IRQ number.  Remove the 'pri' cell from the binding to match
what the dts files are doing.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>