### PR TITLE
log: net: use UDP net context sendto

### DIFF
--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -260,6 +260,11 @@ static int eswifi_off_connect(struct net_context *context,
 
 	LOG_DBG("timeout=%d", timeout);
 
+	if (socket->type != ESWIFI_TRANSPORT_TCP) {
+		LOG_ERR("Only TCP needs connection");
+		return -EINVAL;
+	}
+
 	if (addr->sa_family != AF_INET) {
 		LOG_ERR("Only AF_INET is supported!");
 		return -EPFNOSUPPORT;

--- a/subsys/logging/log_backend_net.c
+++ b/subsys/logging/log_backend_net.c
@@ -57,13 +57,21 @@ struct net_buf_pool *get_data_pool(void)
 static int line_out(u8_t *data, size_t length, void *output_ctx)
 {
 	struct net_context *ctx = (struct net_context *)output_ctx;
+	socklen_t server_addr_len;
 	int ret = -ENOMEM;
 
 	if (ctx == NULL) {
 		return length;
 	}
 
-	ret = net_context_send(ctx, data, length, NULL, K_NO_WAIT, NULL);
+	if (server_addr.sa_family == AF_INET) {
+		server_addr_len = sizeof(struct sockaddr_in);
+	} else {
+		server_addr_len = sizeof(struct sockaddr_in6);
+	}
+
+	ret = net_context_sendto(ctx, data, length, &server_addr,
+				 server_addr_len, NULL, K_NO_WAIT, NULL);
 	if (ret < 0) {
 		goto fail;
 	}


### PR DESCRIPTION
Remote logging initializes context for UDP and tries to send
using TCP. Adapted it to use UDP _sendto instead of send.

Also remote logging tries to connect on UDP socket, which will
lead to invalid offloading stack start. TCP connect is now restricted
to TCP socket type alone.

Signed-off-by: Parthiban Nallathambi <parthitce@gmail.com>