### PR TITLE
linker: Align sw_isr_table to double word (8 bytes)

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -302,6 +302,16 @@ config GEN_SW_ISR_TABLE
 	  _isr_table_entry containing the interrupt service routine and supplied
 	  parameter.
 
+config ARCH_SW_ISR_TABLE_ALIGN
+	int "Alignment size of a software ISR table"
+	default 0
+	depends on GEN_SW_ISR_TABLE
+	help
+	  This option controls alignment size of generated
+	  _sw_isr_table.  Some architecture needs a software ISR table
+	  to be aligned to architecture specific size.  The default
+	  size is 0 for no alignment.
+
 config GEN_IRQ_START_VECTOR
 	int
 	default 0

--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -8,6 +8,12 @@
 #if defined(CONFIG_GEN_ISR_TABLES) && defined(CONFIG_DYNAMIC_INTERRUPTS)
 	SECTION_DATA_PROLOGUE(sw_isr_table,,)
 	{
+		/*
+		 * Some arch requires an entry to be aligned to arch
+		 * specific boundary for using double word load
+		 * instruction.  See include/sw_isr_table.h.
+		 */
+		. = ALIGN(CONFIG_ARCH_SW_ISR_TABLE_ALIGN);
 		*(SW_ISR_TABLE)
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -3,6 +3,12 @@
 #if defined(CONFIG_GEN_ISR_TABLES) && !defined(CONFIG_DYNAMIC_INTERRUPTS)
 	SECTION_PROLOGUE(sw_isr_table,,)
 	{
+		/*
+		 * Some arch requires an entry to be aligned to arch
+		 * specific boundary for using double word load
+		 * instruction.  See include/sw_isr_table.h.
+		 */
+		. = ALIGN(CONFIG_ARCH_SW_ISR_TABLE_ALIGN);
 		*(SW_ISR_TABLE)
 	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif


### PR DESCRIPTION
sw_isr_table has two entries, an argument and an ISR function.  The
comment on struct _isr_table_entry in include/sw_isr_table.h says that
"This allows a table entry to be loaded [...] with one ldmia
instruction, on ARM [...]".  Some arch, e.g. SPARC, also has a double
word load instruction, "ldd", but the instruct must have address align
to double word or 8 bytes.

This commit aligns the table at 8 bytes boundary.  Thus, adds yet
another 4 bytes to the final binary but it should be justified.

Signed-off-by: Yasushi SHOJI <y-shoji@ispace-inc.com>