### PR TITLE
tests: minor FCB re-ordering not to leave a random flash.bin behind

### DIFF
--- a/tests/subsys/fs/fcb/src/main.c
+++ b/tests/subsys/fs/fcb/src/main.c
@@ -162,9 +162,6 @@ void test_main(void)
 			 ztest_unit_test_setup_teardown(fcb_test_append_fill,
 							fcb_pretest_2_sectors,
 							teardown_nothing),
-			 ztest_unit_test_setup_teardown(fcb_test_reset,
-							fcb_pretest_2_sectors,
-							teardown_nothing),
 			 ztest_unit_test_setup_teardown(fcb_test_rotate,
 							fcb_pretest_2_sectors,
 							teardown_nothing),
@@ -173,6 +170,11 @@ void test_main(void)
 							teardown_nothing),
 			 ztest_unit_test_setup_teardown(fcb_test_last_of_n,
 							fcb_pretest_4_sectors,
+							teardown_nothing),
+			 /* Finally, run one that leaves behind a
+			  * flash.bin file without any random content */
+			 ztest_unit_test_setup_teardown(fcb_test_reset,
+							fcb_pretest_2_sectors,
 							teardown_nothing)
 			 );
 


### PR DESCRIPTION
The last FCB test to run (fcb_test_last_of_n) uses uninitialized
test_data[] and leaves behind a flash.bin with random content. Pick
another one (fcb_test_reset) that leaves a deterministic flash.bin
behind and run that last instead.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>