### PR TITLE
dts: Add concept of sub-nodes to YAML and generator

### DIFF
--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -19,6 +19,21 @@ inherits:
 # parent and child should share same bus-type value.
    bus: <bus-type>
 
+sub-node:
+# Used for cases in which a dts node has children, and the children dont
+# require/specify a 'compatible' property.  The sub-node is effective the
+# binding for the child.
+#
+# Here's an example for a pwm-leds binding in which the child nodes
+# would be required to have 'pwms' properties.
+
+sub-node:
+    properties:
+        pwms:
+          type: compound
+          category: required
+          generation: define
+
 properties:
 
 # A typical property entry looks like this:

--- a/dts/bindings/gpio/gpio-keys.yaml
+++ b/dts/bindings/gpio/gpio-keys.yaml
@@ -10,17 +10,22 @@ version: 0.1
 description: >
     This is a representation of the GPIO KEYS nodes
 
-inherits:
-    !include base.yaml
-
 properties:
     compatible:
       constraint: "gpio-keys"
-
-    gpios:
-      type: compound
+      type: string-array
       category: required
+      description: compatible strings
       generation: define
 
-    label:
-      category: required
+sub-node:
+    properties:
+       gpios:
+          type: compound
+          category: required
+          generation: define
+       label:
+          category: required
+          type: string
+          description: Human readable string describing the device (used by Zephyr for API name)
+          generation: define

--- a/dts/bindings/gpio/gpio-leds.yaml
+++ b/dts/bindings/gpio/gpio-leds.yaml
@@ -10,17 +10,22 @@ version: 0.1
 description: >
     This is a representation of the LED GPIO nodes
 
-inherits:
-    !include base.yaml
-
 properties:
     compatible:
       constraint: "gpio-leds"
-
-    gpios:
-      type: compound
+      type: string-array
       category: required
+      description: compatible strings
       generation: define
 
-    label:
-      category: required
+sub-node:
+    properties:
+       gpios:
+          type: compound
+          category: required
+          generation: define
+       label:
+          category: required
+          type: string
+          description: Human readable string describing the device (used by Zephyr for API name)
+          generation: define

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -10,17 +10,23 @@ version: 0.1
 description: >
     This is a representation of the PWM GPIO nodes
 
-inherits:
-    !include base.yaml
-
 properties:
     compatible:
       constraint: "pwm-leds"
-
-    pwms:
-      type: compound
+      type: string-array
       category: required
+      description: compatible strings
       generation: define
 
-    label:
-      category: required
+sub-node:
+    properties:
+        pwms:
+          type: compound
+          category: required
+          generation: define
+
+        label:
+          category: required
+          type: string
+          description: Human readable string describing the device (used by Zephyr for API name)
+          generation: define

--- a/dts/bindings/mtd/partition.yaml
+++ b/dts/bindings/mtd/partition.yaml
@@ -5,9 +5,29 @@ version: 0.1
 description: >
     This binding gives a base FLASH partition description
 
-inherits:
-    !include base.yaml
-
 properties:
     compatible:
       constraint: "fixed-partitions"
+      type: string-array
+      category: required
+      description: compatible strings
+      generation: define
+
+sub-node:
+    properties:
+       label:
+          category: required
+          type: string
+          category: optional
+          description: Human readable string describing the device (used by Zephyr for API name)
+          generation: define
+       read-only:
+          type: boolean
+          category: optional
+          description: if the partition is read-only or not
+          generation: define
+       reg:
+          type: array
+          description: register space
+          generation: define
+          category: required

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -286,19 +286,28 @@ def add_prop_aliases(node_path,
             prop_aliases[old_alias_label] = prop_label
 
 def get_binding(node_path):
-    compat = get_compat(node_path)
+    compat = reduced[node_path]['props'].get('compatible')
+    if isinstance(compat, list):
+        compat = compat[0]
 
-    # First look for a bus-specific binding
     parent_path = get_parent_path(node_path)
     parent_compat = get_compat(parent_path)
+
     if parent_compat in bindings:
         parent_binding = bindings[parent_compat]
+        # see if we're a sub-node
+        if compat is None and 'sub-node' in parent_binding:
+            return parent_binding['sub-node']
+
+        # look for a bus-specific binding
         if 'child' in parent_binding and 'bus' in parent_binding['child']:
             bus = parent_binding['child']['bus']
             return bus_bindings[bus][compat]
 
     # No bus-specific binding found, look in the main dict.
-    return bindings[compat]
+    if compat:
+        return bindings[compat]
+    return None
 
 def get_binding_compats():
     return binding_compats

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -105,6 +105,9 @@ def generate_node_defines(node_path):
         flash.extract_partition(node_path)
         return
 
+    if get_binding(node_path) is None:
+        return
+
     generate_bus_defines(node_path)
 
     # Generate per-property ('foo = <1 2 3>', etc.) #defines


### PR DESCRIPTION
Several bindings have an expectation of sub-nodes that describe the
actual infomation.  The sub-nodes don't have any compatiable so we can't
key on that.

So we can add the concept of a sub-node to the YAML to handle cases like
'gpio-keys', 'gpio-leds', 'pwm-leds', etc..

The sub-node in the YAML is effective the "binding" params that describe
what properties should exist in the sub-node.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>