### PR TITLE
west: Update hal_stm32 module for stm32l1 series cube update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -51,7 +51,7 @@ manifest:
       revision: b6c9262eed68000e69c92bef6e820cdbd5b0a32b
       path: modules/hal/st
     - name: hal_stm32
-      revision: b454ad819f4f10cb82ce5eb1d7f709a680bc61c5
+      revision: pull/8/head
       path: modules/hal/stm32
     - name: libmetal
       revision: 45e630d6152824f807d3f919958605c4626cbdff


### PR DESCRIPTION
Update Cube version for STM32L1XX series
from version: V1.8.0
to version: V1.9.0

Requires zephyrproject-rtos/hal_stm32#8

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>