### PR TITLE
soc: stm32f3: Delete obsolete FLASH_PAGE_SIZE Kconfig symbol

### DIFF
--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f302x8
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f302x8
@@ -11,10 +11,6 @@ config SOC
 	string
 	default "stm32f302x8"
 
-config FLASH_PAGE_SIZE
-	hex
-	default 0x800
-
 config NUM_IRQS
 	int
 	default 82

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f303xc
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f303xc
@@ -11,10 +11,6 @@ config SOC
 	string
 	default "stm32f303xc"
 
-config FLASH_PAGE_SIZE
-	hex
-	default 0x800
-
 config NUM_IRQS
 	int
 	default 82

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f334x8
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f334x8
@@ -11,10 +11,6 @@ config SOC
 	string
 	default "stm32f334x8"
 
-config FLASH_PAGE_SIZE
-	hex
-	default 0x800
-
 config NUM_IRQS
 	int
 	default 82

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f373xc
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f373xc
@@ -11,10 +11,6 @@ config SOC
 	string
 	default "stm32f373xc"
 
-config FLASH_PAGE_SIZE
-	hex
-	default 0x800
-
 config NUM_IRQS
 	int
 	default 82


### PR DESCRIPTION
Definition of obsolete FLASH_PAGE_SIZE Kconfig symbol was remaining in STM32F3 soc files.
Clean these.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>