### PR TITLE
sanitycheck: make verbose output fit screen

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3099,7 +3099,9 @@ def chatty_test_cb(instances, goals, goal):
 
     info("{:>{}}/{} {:<25} {:<50} {} ({})".format(
         total_done, total_tests_width, total_tests, i.platform.name,
-        i.test.name, status, handler_type))
+        i.test.id, status, handler_type))
+    local_path = "/".join(i.test.name.split("/")[0:-1])
+    info("{:>{}} {}".format(" ", 27 + 2 *total_tests_width, local_path))
     if goal.failed:
         log_info(goal.get_error_log())
 


### PR DESCRIPTION
Split verbose test results into two lines to make it fit into screen.

Example output:
```

 35/776 em_starterkit_em7d        kernel.memory_protection                           PASSED (build)
                                  tests/kernel/mem_protect/stackprot
 36/776 em_starterkit_em7d        kernel.memory_protection.userspace                 PASSED (build)
                                  tests/kernel/mem_protect/userspace
 37/776 em_starterkit_em7d        kernel.mutex                                       PASSED (build)
                                  tests/kernel/mutex/mutex_api
 38/776 em_starterkit_em7d        kernel.message_queue                               PASSED (build)
                                  tests/kernel/msgq/msgq_api
```