### PR TITLE
scripts/dts: Treat string-list always as a list

### DIFF
--- a/scripts/dts/extract/default.py
+++ b/scripts/dts/extract/default.py
@@ -46,6 +46,9 @@ class DTDefault(DTDirective):
         else:
             prop_values = reduced[node_path]['props'][prop]
 
+        if prop_type == "string-array":
+            if type(prop_values) is not list: prop_values = [ prop_values, ]
+
         if isinstance(prop_values, list):
             for i, prop_value in enumerate(prop_values):
                 prop_name = str_to_label(prop)


### PR DESCRIPTION
If the type of property is a 'string-list' we should generate defines as
if its a list even if theres only a single element in the list.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>