### PR TITLE
drivers/i2c_rv32m1_lpi2c: Remove accidently added debug code

### DIFF
--- a/drivers/i2c/i2c_rv32m1_lpi2c.c
+++ b/drivers/i2c/i2c_rv32m1_lpi2c.c
@@ -290,7 +290,7 @@ static const struct i2c_driver_api rv32m1_lpi2c_driver_api = {
 	static void rv32m1_lpi2c_irq_config_func_##id(struct device *dev)      \
 	{                                                                      \
 		IRQ_CONNECT(DT_OPENISA_RV32M1_LPI2C_I2C_##id##_IRQ_0,          \
-			    KUMARDT_OPENISA_RV32M1_LPI2C_I2C_##id##_IRQ_0_PRI,      \
+			    DT_OPENISA_RV32M1_LPI2C_I2C_##id##_IRQ_0_PRI,      \
 			    rv32m1_lpi2c_isr, DEVICE_GET(rv32m1_lpi2c_##id),   \
 			    0);                                                \
 		irq_enable(DT_OPENISA_RV32M1_LPI2C_I2C_##id##_IRQ_0);          \
@@ -298,7 +298,6 @@ static const struct i2c_driver_api rv32m1_lpi2c_driver_api = {
 
 #ifdef CONFIG_I2C_0
 RV32M1_LPI2C_DEVICE(0)
-#error KUMAR
 #endif
 
 #ifdef CONFIG_I2C_1


### PR DESCRIPTION
Some stray debug code that causes a build error got added, remove it so
things build propertly.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>