### PR TITLE
west: Update hal_stm32 module for stm32l4 series cube update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -51,7 +51,7 @@ manifest:
       revision: b6c9262eed68000e69c92bef6e820cdbd5b0a32b
       path: modules/hal/st
     - name: hal_stm32
-      revision: b454ad819f4f10cb82ce5eb1d7f709a680bc61c5
+      revision: c4392ab4dc23110a7985216ba5dc2ea1db39b1f4
       path: modules/hal/stm32
     - name: libmetal
       revision: 45e630d6152824f807d3f919958605c4626cbdff


### PR DESCRIPTION
Update Cube version for STM32L4XX series
from version: V1.13.0
to version: V1.14.0

Requires zephyrproject-rtos/hal_stm32#11
(SHA1: https://github.com/zephyrproject-rtos/hal_stm32/commit/c4392ab4dc23110a7985216ba5dc2ea1db39b1f4)

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>