### PR TITLE
west: Update hal_stm32 module to head following cube updates

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -51,7 +51,7 @@ manifest:
       revision: b6c9262eed68000e69c92bef6e820cdbd5b0a32b
       path: modules/hal/st
     - name: hal_stm32
-      revision: b454ad819f4f10cb82ce5eb1d7f709a680bc61c5
+      revision: 8066e1d2477860a106e3c2e6ca841b4abbfbaad2
       path: modules/hal/stm32
     - name: libmetal
       revision: 45e630d6152824f807d3f919958605c4626cbdff


### PR DESCRIPTION
This update contains the following changes

* Introduce STM32G0 Cube V1.2.0
* Update API for STM32MP1 IPCC
* Update Cube version for following series:
STM32F0XX: from version: V1.9.0 to version: V1.10.1
STM32F1XX: from version: V1.6.1 to version: V1.7.0
STM32F4XX: from version: V1.21.0 to version: V1.24.1
STM32F7XX: from version: V1.12.0 to version: V1.15.1
STM32L0XX: from version: V1.10.0 to version: V1.11.2
STM32L1XX: from version: V1.8.0 to version: V1.9.0
STM32L4XX: from version: V1.13.0 to version: V1.14.0
STM32WBXX: from version: V1.0.0 to version: V1.1.1


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>