### PR TITLE
tests/kernel/context: Fix TICK_IRQ define for RV32M1 lptmr_timer

### DIFF
--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -69,7 +69,7 @@
 #elif defined(CONFIG_LITEX_TIMER)
 #define TICK_IRQ DT_LITEX_TIMER0_E0002800_IRQ_0
 #elif defined(CONFIG_RV32M1_LPTMR_TIMER)
-#define TICK_IRQ DT_OPENISA_RV32M1_LPTMR_SYSTEM_LPTMR_IRQ
+#define TICK_IRQ DT_OPENISA_RV32M1_LPTMR_SYSTEM_LPTMR_IRQ_0
 #elif defined(CONFIG_CPU_CORTEX_M)
 /*
  * The Cortex-M use the SYSTICK exception for the system timer, which is


### PR DESCRIPTION
We missed converting DT_OPENISA_RV32M1_LPTMR_SYSTEM_LPTMR_IRQ to
DT_OPENISA_RV32M1_LPTMR_SYSTEM_LPTMR_IRQ_0.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>