### PR TITLE
scripts/dts: Remove DT_CHOSEN generation

### DIFF
--- a/doc/guides/dts/index.rst
+++ b/doc/guides/dts/index.rst
@@ -316,14 +316,6 @@ The full set of Zephyr-specific ``chosen`` nodes follows:
    * - ``zephyr,uart-mcumgr``
      - ``DT_UART_MCUMGR_ON_DEV_NAME``
 
-As chosen properties tend to be related to software configuration, it can be
-useful for the build system to know if a chosen property was defined. We
-generate a define for each chosen property, for example:
-
-``zephyr,flash`` will generate: ``#define DT_CHOSEN_ZEPHYR_FLASH 1``
-
-As a consequence ``zephyr,flash`` related code could safely be implemented
-under ``#ifdef DT_CHOSEN_ZEPHYR_FLASH`` instruction.
 
 Adding support for device tree in drivers
 *****************************************

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -447,10 +447,6 @@ def generate_defines():
     flash.extract_flash()
     flash.extract_code_partition()
 
-    # Add DT_CHOSEN_<X> defines
-    for c in sorted(chosen):
-        insert_defs('chosen', {'DT_CHOSEN_' + str_to_label(c): '1'}, {})
-
 
 def parse_arguments():
     rdh = argparse.RawDescriptionHelpFormatter


### PR DESCRIPTION
We never used DT_CHOSEN so lets remove this and add it back if/when
there's an actual need for it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>