### PR TITLE
scripts/dts: Remove 'use-prop-name' from clock generation

### DIFF
--- a/scripts/dts/extract/clocks.py
+++ b/scripts/dts/extract/clocks.py
@@ -126,10 +126,7 @@ class DTClocks(DTDirective):
                             'clocks']['generation']
                     except:
                         generation = ''
-                    if 'use-prop-name' in generation:
-                        clock_cell_name = 'CLOCKS_CONTROLLER'
-                    else:
-                        clock_cell_name = 'CLOCK_CONTROLLER'
+                    clock_cell_name = 'CLOCK_CONTROLLER'
                     if clock_index == 0 and \
                         len(clocks) == (len(clock_cells) + 1):
                         index = ''


### PR DESCRIPTION
We never set 'use-prop-name' on clock bindings so lets just always
use CLOCK_CONTROLLER as the define name we generate.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>