### PR TITLE
dts/extract: Remove 'use-prop-name' from cell and controller handling

### DIFF
--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -438,10 +438,7 @@ def extract_controller(node_path, prop, prop_values, index,
         except:
             generation = ''
 
-        if 'use-prop-name' in generation:
-            l_cellname = str_to_label(prop + '_' + 'controller')
-        else:
-            l_cellname = str_to_label(generic + '_' + 'controller')
+        l_cellname = str_to_label(generic + '_' + 'controller')
 
         label = l_base + [l_cellname] + l_idx
 
@@ -510,10 +507,7 @@ def extract_cells(node_path, prop, prop_values, names, index,
         except:
             generation = ''
 
-        if 'use-prop-name' in generation:
-            l_cell = [str_to_label(str(prop))]
-        else:
-            l_cell = [str_to_label(str(generic))]
+        l_cell = [str_to_label(str(generic))]
 
         l_base = [def_label]
         # Check if #define should be indexed (_0, _1, ...)

--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -42,7 +42,9 @@ class DTReg(DTDirective):
 
                 if cs_gpios:
                     extract_controller(node_path, "cs-gpios", cs_gpios, reg[0], def_label, "cs-gpio", True)
+                    extract_controller(node_path, "cs-gpios", cs_gpios, reg[0], def_label, "cs-gpios", True)
                     extract_cells(node_path, "cs-gpios", cs_gpios, None, reg[0], def_label, "cs-gpio", True)
+                    extract_cells(node_path, "cs-gpios", cs_gpios, None, reg[0], def_label, "cs-gpios", True)
 
         # generate defines
         l_base = [def_label]

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -84,8 +84,12 @@ def generate_prop_defines(node_path, prop):
 
         extract_controller(node_path, prop, prop_values, 0,
                            def_label, generic)
+        extract_controller(node_path, prop, prop_values, 0,
+                           def_label, prop)
         extract_cells(node_path, prop, prop_values,
                       names, 0, def_label, generic)
+        extract_cells(node_path, prop, prop_values,
+                      names, 0, def_label, prop)
     else:
         default.extract(node_path, prop,
                         binding['properties'][prop]['type'],


### PR DESCRIPTION
We have 'use-prop-name' flag in the bindings which is specifically used
for GPIO properties to control if we get "GPIO" or "GPIOS" as the
generated define name.

Lets remove the inconsistancy and use "GPIOS" as the preferred name as
this matches the DTS property name.  Towards that we will generate both
forms and remove support for 'use-prop-name'.

This also impacts "PWM" generation.  So we'll have "PWM" and "PWMS"

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>