### PR TITLE
mempool: properly use the inline free block bitmap

### DIFF
--- a/include/misc/mempool_base.h
+++ b/include/misc/mempool_base.h
@@ -78,7 +78,7 @@ struct sys_mem_pool_base {
 
 /* How many bytes for the bitfields of a single level? */
 #define Z_MPOOL_LBIT_BYTES(maxsz, minsz, l, n_max)	\
-	(Z_MPOOL_LVLS((maxsz), (minsz)) >= (l) ?		\
+	(Z_MPOOL_LVLS((maxsz), (minsz)) > (l) ?		\
 	 4 * Z_MPOOL_LBIT_WORDS((n_max), l) : 0)
 
 /* Size of the bitmap array that follows the buffer in allocated memory */

--- a/lib/os/mempool.c
+++ b/lib/os/mempool.c
@@ -90,7 +90,7 @@ void z_sys_mem_pool_base_init(struct sys_mem_pool_base *p)
 
 		sys_dlist_init(&p->levels[i].free_list);
 
-		if (nblocks < 32) {
+		if (nblocks <= 32) {
 			p->max_inline_level = i;
 		} else {
 			p->levels[i].bits_p = bits;


### PR DESCRIPTION
The free block bitmap uses either extra memory specified by a pointer
in struct sys_mem_pool_lvl or the space occupied by that pointer
directly if the bitmap length is small enough to fit it.

But the test is wrong. the inline bitmap should be used if the number
of required bits is smaller or _equal_ to the pointer size. Not doing so
would wrongly bounce the free block bitmap to extra memory when the
number of blocks is exactly 32, which is in disagreement with
Z_MPOOL_LBIT_WORDS() that correctly returns 0 in that case.

In theory that mean that this bug would causes an overflow of the free
block bitmap whenever one level has exactly 32 blocks. But right now
there is a separate bug that over-sizes the extra block bitmap
mitigating this bug.