### PR TITLE
scripts/dts: Treat array always as a list

### DIFF
--- a/scripts/dts/extract/default.py
+++ b/scripts/dts/extract/default.py
@@ -46,7 +46,7 @@ class DTDefault(DTDirective):
         else:
             prop_values = reduced[node_path]['props'][prop]
 
-        if prop_type == "string-array":
+        if prop_type == "string-array" or prop_type == "array":
             if type(prop_values) is not list: prop_values = [ prop_values, ]
 
         if isinstance(prop_values, list):


### PR DESCRIPTION
If the type of property is a 'array' we should generate defines as
if its a list even if theres only a single element in the list.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>