### PR TITLE
genrest: De-spam docs by skipping direct deps. in more places

### DIFF
--- a/doc/scripts/genrest.py
+++ b/doc/scripts/genrest.py
@@ -211,7 +211,7 @@ def direct_deps_rst(sc):
     return "Direct dependencies\n" \
            "===================\n\n" \
            "{}\n\n" \
-           "*(Includes any dependencies from if's and menus.)*\n\n" \
+           "*(Includes any dependencies from ifs and menus.)*\n\n" \
            .format(expr_str(sc.direct_dep))
 
 
@@ -228,7 +228,7 @@ def defaults_rst(sc):
           "========\n\n"
 
     if sc.defaults:
-        for value, cond in sc.defaults:
+        for value, cond in sc.orig_defaults:
             rst += "- " + expr_str(value)
             if cond is not sc.kconfig.y:
                 rst += " if " + expr_str(cond)
@@ -289,8 +289,8 @@ def select_imply_rst(sym):
 
             rst += "\n"
 
-    add_select_imply_rst("selected", sym.selects)
-    add_select_imply_rst("implied", sym.implies)
+    add_select_imply_rst("selected", sym.orig_selects)
+    add_select_imply_rst("implied", sym.orig_implies)
 
     return rst
 
@@ -389,7 +389,7 @@ def kconfig_definition_rst(sc):
             rst += "\n\n----"
 
     rst += "\n\n*(The 'depends on' condition includes propagated " \
-           "dependencies from if's and menus.)*"
+           "dependencies from ifs and menus.)*"
 
     return rst
 

--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -1308,15 +1308,13 @@ def _check_valid(dialog, entry, sym, s):
 
     for low_sym, high_sym, cond in sym.ranges:
         if expr_value(cond):
-            low = int(low_sym.str_value, base)
-            val = int(s, base)
-            high = int(high_sym.str_value, base)
+            low_s = low_sym.str_value
+            high_s = high_sym.str_value
 
-            if not low <= val <= high:
+            if not int(low_s, base) <= int(s, base) <= int(high_s, base):
                 messagebox.showerror(
                     "Value out of range",
-                    "{} is outside the range {}-{}".format(
-                        s, low_sym.str_value, high_sym.str_value),
+                    "{} is outside the range {}-{}".format(s, low_s, high_s),
                     parent=dialog)
                 entry.focus_set()
                 return False
@@ -2123,7 +2121,7 @@ def _defaults_info(sc):
 
     s = "Defaults:\n"
 
-    for val, cond in sc.defaults:
+    for val, cond in sc.orig_defaults:
         s += "  - "
         if isinstance(sc, Symbol):
             s += _expr_str(val)


### PR DESCRIPTION
Similar deal to commit cc14c40a2d ("kconfiglib: Unclutter symbol
strings, avoid redundant writes, misc.").

Hide the direct dependencies in the defaults, selects, and implies
sections. Do the same in menuconfig/guiconfig as well.

This uses a new Kconfiglib API, so update Kconfiglib to upstream
revision 164ef007a8. This also includes some minor optimizations and
cleanups.