### PR TITLE
net: Fix net_pkt_hexdump() to print pkt address properly

### DIFF
--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -156,7 +156,7 @@ static inline void net_pkt_hexdump(struct net_pkt *pkt, const char *str)
 	snprintk(pkt_str, sizeof(pkt_str), "%p", pkt);
 
 	while (buf) {
-		LOG_HEXDUMP_DBG(buf->data, buf->len, pkt_str);
+		LOG_HEXDUMP_DBG(buf->data, buf->len, log_strdup(pkt_str));
 		buf = buf->frags;
 	}
 }


### PR DESCRIPTION
If immediate logging is disabled, then we must use log_strdup()
when printing log string allocated from stack.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>