### PR TITLE
gitignore: ignore Emacs TAGS file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ bsim_bt_out
 scripts/grub
 doc/reference/kconfig/*.rst
 doc/doc.warnings
-tags
 .*project
 .settings
 .envrc
@@ -45,5 +44,7 @@ hide-defaults-note
 GPATH
 GRTAGS
 GTAGS
+TAGS
+tags
 
 .idea


### PR DESCRIPTION
Ignore the Emacs TAGS file generated by scripts/tags.sh. Move the entry for the lower-case tags file to the correct section.
