### PR TITLE
lifo/fifo: first word is not always first 4 bytes

### DIFF
--- a/doc/reference/kernel/data_passing/fifos.rst
+++ b/doc/reference/kernel/data_passing/fifos.rst
@@ -24,11 +24,11 @@ A fifo has the following key properties:
 
 A fifo must be initialized before it can be used. This sets its queue to empty.
 
-FIFO data items must be aligned on a 4-byte boundary, as the kernel reserves
-the first 32 bits of an item for use as a pointer to the next data item in the
-queue. Consequently, a data item that holds N bytes of application data
-requires N+4 bytes of memory. There are no alignment or reserved space
-requirements for data items if they are added with
+FIFO data items must be aligned on a word boundary, as the kernel reserves
+the first word of an item for use as a pointer to the next data item in
+the queue. Consequently, a data item that holds N bytes of application
+data requires N+4 (or N+8) bytes of memory. There are no alignment or
+reserved space requirements for data items if they are added with
 :cpp:func:`k_fifo_alloc_put()`, instead additional memory is temporarily
 allocated from the calling thread's resource pool.
 

--- a/doc/reference/kernel/data_passing/lifos.rst
+++ b/doc/reference/kernel/data_passing/lifos.rst
@@ -24,11 +24,11 @@ A lifo has the following key properties:
 
 A lifo must be initialized before it can be used. This sets its queue to empty.
 
-LIFO data items must be aligned on a 4-byte boundary, as the kernel reserves
-the first 32 bits of an item for use as a pointer to the next data item in the
+LIFO data items must be aligned on a word boundary, as the kernel reserves
+the first word of an item for use as a pointer to the next data item in the
 queue. Consequently, a data item that holds N bytes of application data
-requires N+4 bytes of memory. There are no alignment or reserved space
-requirements for data items if they are added with
+requires N+4 (or N+8) bytes of memory. There are no alignment or reserved
+space requirements for data items if they are added with
 :cpp:func:`k_lifo_alloc_put()`, instead additional memory is temporarily
 allocated from the calling thread's resource pool.
 

--- a/include/drivers/console/console.h
+++ b/include/drivers/console/console.h
@@ -19,8 +19,8 @@ extern "C" {
  * Recorded line must be NULL terminated.
  */
 struct console_input {
-	/** FIFO uses first 4 bytes itself, reserve space */
-	int _unused;
+	/** FIFO uses first word itself, reserve space */
+	intptr_t _unused;
 	/** Whether this is an mcumgr command */
 	u8_t is_mcumgr : 1;
 	/** Buffer where the input line is recorded */

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1842,8 +1842,8 @@ __syscall void k_queue_cancel_wait(struct k_queue *queue);
  * @brief Append an element to the end of a queue.
  *
  * This routine appends a data item to @a queue. A queue data item must be
- * aligned on a 4-byte boundary, and the first 32 bits of the item are
- * reserved for the kernel's use.
+ * aligned on a word boundary, and the first word of the item is reserved
+ * for the kernel's use.
  *
  * @note Can be called by ISRs.
  *
@@ -1876,8 +1876,8 @@ __syscall s32_t k_queue_alloc_append(struct k_queue *queue, void *data);
  * @brief Prepend an element to a queue.
  *
  * This routine prepends a data item to @a queue. A queue data item must be
- * aligned on a 4-byte boundary, and the first 32 bits of the item are
- * reserved for the kernel's use.
+ * aligned on a word boundary, and the first word of the item is reserved
+ * for the kernel's use.
  *
  * @note Can be called by ISRs.
  *
@@ -1910,8 +1910,8 @@ __syscall s32_t k_queue_alloc_prepend(struct k_queue *queue, void *data);
  * @brief Inserts an element to a queue.
  *
  * This routine inserts a data item to @a queue after previous item. A queue
- * data item must be aligned on a 4-byte boundary, and the first 32 bits of the
- * item are reserved for the kernel's use.
+ * data item must be aligned on a word boundary, and the first word of
+ * the item is reserved for the kernel's use.
  *
  * @note Can be called by ISRs.
  *
@@ -1927,7 +1927,7 @@ extern void k_queue_insert(struct k_queue *queue, void *prev, void *data);
  * @brief Atomically append a list of elements to a queue.
  *
  * This routine adds a list of data items to @a queue in one operation.
- * The data items must be in a singly-linked list, with the first 32 bits
+ * The data items must be in a singly-linked list, with the first word
  * in each data item pointing to the next data item; the list must be
  * NULL-terminated.
  *
@@ -1960,8 +1960,8 @@ extern void k_queue_merge_slist(struct k_queue *queue, sys_slist_t *list);
 /**
  * @brief Get an element from a queue.
  *
- * This routine removes first data item from @a queue. The first 32 bits of the
- * data item are reserved for the kernel's use.
+ * This routine removes first data item from @a queue. The first word of the
+ * data item is reserved for the kernel's use.
  *
  * @note Can be called by ISRs, but @a timeout must be set to K_NO_WAIT.
  *
@@ -1977,8 +1977,8 @@ __syscall void *k_queue_get(struct k_queue *queue, s32_t timeout);
 /**
  * @brief Remove an element from a queue.
  *
- * This routine removes data item from @a queue. The first 32 bits of the
- * data item are reserved for the kernel's use. Removing elements from k_queue
+ * This routine removes data item from @a queue. The first word of the
+ * data item is reserved for the kernel's use. Removing elements from k_queue
  * rely on sys_slist_find_and_remove which is not a constant time operation.
  *
  * @note Can be called by ISRs
@@ -1996,8 +1996,8 @@ static inline bool k_queue_remove(struct k_queue *queue, void *data)
 /**
  * @brief Append an element to a queue only if it's not present already.
  *
- * This routine appends data item to @a queue. The first 32 bits of the
- * data item are reserved for the kernel's use. Appending elements to k_queue
+ * This routine appends data item to @a queue. The first word of the data
+ * item is reserved for the kernel's use. Appending elements to k_queue
  * relies on sys_slist_is_node_in_list which is not a constant time operation.
  *
  * @note Can be called by ISRs
@@ -2146,8 +2146,8 @@ struct k_fifo {
  * @brief Add an element to a FIFO queue.
  *
  * This routine adds a data item to @a fifo. A FIFO data item must be
- * aligned on a 4-byte boundary, and the first 32 bits of the item are
- * reserved for the kernel's use.
+ * aligned on a word boundary, and the first word of the item is reserved
+ * for the kernel's use.
  *
  * @note Can be called by ISRs.
  *
@@ -2184,7 +2184,7 @@ struct k_fifo {
  * @brief Atomically add a list of elements to a FIFO.
  *
  * This routine adds a list of data items to @a fifo in one operation.
- * The data items must be in a singly-linked list, with the first 32 bits
+ * The data items must be in a singly-linked list, with the first word of
  * each data item pointing to the next data item; the list must be
  * NULL-terminated.
  *
@@ -2223,7 +2223,7 @@ struct k_fifo {
  * @brief Get an element from a FIFO queue.
  *
  * This routine removes a data item from @a fifo in a "first in, first out"
- * manner. The first 32 bits of the data item are reserved for the kernel's use.
+ * manner. The first word of the data item is reserved for the kernel's use.
  *
  * @note Can be called by ISRs, but @a timeout must be set to K_NO_WAIT.
  *
@@ -2345,7 +2345,7 @@ struct k_lifo {
  * @brief Add an element to a LIFO queue.
  *
  * This routine adds a data item to @a lifo. A LIFO queue data item must be
- * aligned on a 4-byte boundary, and the first 32 bits of the item are
+ * aligned on a word boundary, and the first word of the item is
  * reserved for the kernel's use.
  *
  * @note Can be called by ISRs.
@@ -2383,7 +2383,7 @@ struct k_lifo {
  * @brief Get an element from a LIFO queue.
  *
  * This routine removes a data item from @a lifo in a "last in, first out"
- * manner. The first 32 bits of the data item are reserved for the kernel's use.
+ * manner. The first word of the data item is reserved for the kernel's use.
  *
  * @note Can be called by ISRs, but @a timeout must be set to K_NO_WAIT.
  *

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -68,7 +68,7 @@ struct net_pkt {
 		 * RX path, it is then fine to have both attributes sharing
 		 * the same memory area.
 		 */
-		int sock_recv_fifo;
+		intptr_t sock_recv_fifo;
 	};
 
 	/** Slab pointer from where it belongs to */

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -46,7 +46,7 @@ void *z_queue_node_peek(sys_sfnode_t *node, bool needs_free)
 			k_free(anode);
 		}
 	} else {
-		/* Data was directly placed in the queue, the first 4 bytes
+		/* Data was directly placed in the queue, the first word
 		 * reserved for the linked list. User mode isn't allowed to
 		 * do this, although it can get data sent this way.
 		 */

--- a/tests/benchmarks/sys_kernel/src/lifo.c
+++ b/tests/benchmarks/sys_kernel/src/lifo.c
@@ -39,23 +39,21 @@ void lifo_test_init(void)
 void lifo_thread1(void *par1, void *par2, void *par3)
 {
 	int i;
-	int element_a[2];
-	int element_b[2];
-	int *pelement;
+	intptr_t element_a[2];
+	intptr_t element_b[2];
+	intptr_t *pelement;
 	int num_loops = POINTER_TO_INT(par2);
 
 	ARG_UNUSED(par1);
 
 	for (i = 0; i < num_loops / 2; i++) {
-		pelement = (int *)k_lifo_get(&lifo1,
-						      K_FOREVER);
+		pelement = k_lifo_get(&lifo1, K_FOREVER);
 		if (pelement[1] != 2 * i) {
 			break;
 		}
 		element_a[1] = 2 * i;
 		k_lifo_put(&lifo2, element_a);
-		pelement = (int *)k_lifo_get(&lifo1,
-						      K_FOREVER);
+		pelement = k_lifo_get(&lifo1, K_FOREVER);
 		if (pelement[1] != 2 * i + 1) {
 			break;
 		}
@@ -80,16 +78,15 @@ void lifo_thread1(void *par1, void *par2, void *par3)
 void lifo_thread2(void *par1, void *par2, void *par3)
 {
 	int i;
-	int element[2];
-	int *pelement;
+	intptr_t element[2];
+	intptr_t *pelement;
 	int *pcounter = par1;
 	int num_loops = POINTER_TO_INT(par2);
 
 	for (i = 0; i < num_loops; i++) {
 		element[1] = i;
 		k_lifo_put(&lifo1, element);
-		pelement = (int *)k_lifo_get(&lifo2,
-						      K_FOREVER);
+		pelement = k_lifo_get(&lifo2, K_FOREVER);
 		if (pelement[1] != i) {
 			break;
 		}
@@ -112,16 +109,15 @@ void lifo_thread2(void *par1, void *par2, void *par3)
 void lifo_thread3(void *par1, void *par2, void *par3)
 {
 	int i;
-	int element[2];
-	int *pelement;
+	intptr_t element[2];
+	intptr_t *pelement;
 	int *pcounter = par1;
 	int num_loops = POINTER_TO_INT(par2);
 
 	for (i = 0; i < num_loops; i++) {
 		element[1] = i;
 		k_lifo_put(&lifo1, element);
-		while ((pelement = k_lifo_get(&lifo2,
-							K_NO_WAIT)) == NULL) {
+		while ((pelement = k_lifo_get(&lifo2, K_NO_WAIT)) == NULL) {
 			k_yield();
 		}
 		if (pelement[1] != i) {
@@ -144,7 +140,7 @@ int lifo_test(void)
 	u32_t t;
 	int i = 0;
 	int return_value = 0;
-	int element[2];
+	intptr_t element[2];
 	int j;
 
 	k_fifo_init(&sync_fifo);
@@ -176,7 +172,7 @@ int lifo_test(void)
 
 	/* threads have done their job, they can stop now safely: */
 	for (j = 0; j < 2; j++) {
-		k_fifo_put(&sync_fifo, (void *) element);
+		k_fifo_put(&sync_fifo, element);
 	}
 
 	/* test get/yield & put thread functions between co-op threads */
@@ -210,7 +206,7 @@ int lifo_test(void)
 
 	/* threads have done their job, they can stop now safely: */
 	for (j = 0; j < 2; j++) {
-		k_fifo_put(&sync_fifo, (void *) element);
+		k_fifo_put(&sync_fifo, element);
 	}
 
 	/* test get wait & put functions between co-op and premptive threads */
@@ -232,21 +228,19 @@ int lifo_test(void)
 			 NULL, INT_TO_POINTER(number_of_loops), NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	for (i = 0; i < number_of_loops / 2U; i++) {
-		int element[2];
-		int *pelement;
+		intptr_t element[2];
+		intptr_t *pelement;
 
 		element[1] = 2 * i;
 		k_lifo_put(&lifo1, element);
 		element[1] = 2 * i + 1;
 		k_lifo_put(&lifo1, element);
 
-		pelement = (int *)k_lifo_get(&lifo2,
-						     K_FOREVER);
+		pelement = k_lifo_get(&lifo2, K_FOREVER);
 		if (pelement[1] != 2 * i + 1) {
 			break;
 		}
-		pelement = (int *)k_lifo_get(&lifo2,
-						     K_FOREVER);
+		pelement = k_lifo_get(&lifo2, K_FOREVER);
 		if (pelement[1] != 2 * i) {
 			break;
 		}
@@ -258,7 +252,7 @@ int lifo_test(void)
 
 	/* threads have done their job, they can stop now safely: */
 	for (j = 0; j < 2; j++) {
-		k_fifo_put(&sync_fifo, (void *) element);
+		k_fifo_put(&sync_fifo, element);
 	}
 
 	return return_value;

--- a/tests/benchmarks/sys_kernel/src/mwfifo.c
+++ b/tests/benchmarks/sys_kernel/src/mwfifo.c
@@ -41,15 +41,14 @@ void fifo_test_init(void)
 void fifo_thread1(void *par1, void *par2, void *par3)
 {
 	int i;
-	int element[2];
-	int *pelement;
+	intptr_t element[2];
+	intptr_t *pelement;
 	int num_loops = POINTER_TO_INT(par2);
 
 	ARG_UNUSED(par1);
 	ARG_UNUSED(par3);
 	for (i = 0; i < num_loops; i++) {
-		pelement = (int *)k_fifo_get(&fifo1,
-						      K_FOREVER);
+		pelement = k_fifo_get(&fifo1, K_FOREVER);
 		if (pelement[1] != i) {
 			break;
 		}
@@ -74,8 +73,8 @@ void fifo_thread1(void *par1, void *par2, void *par3)
 void fifo_thread2(void *par1, void *par2, void *par3)
 {
 	int i;
-	int element[2];
-	int *pelement;
+	intptr_t element[2];
+	intptr_t *pelement;
 	int *pcounter = par1;
 	int num_loops = POINTER_TO_INT(par2);
 
@@ -84,8 +83,7 @@ void fifo_thread2(void *par1, void *par2, void *par3)
 	for (i = 0; i < num_loops; i++) {
 		element[1] = i;
 		k_fifo_put(&fifo1, element);
-		pelement = (int *)k_fifo_get(&fifo2,
-						      K_FOREVER);
+		pelement = k_fifo_get(&fifo2, K_FOREVER);
 		if (pelement[1] != i) {
 			break;
 		}
@@ -109,8 +107,8 @@ void fifo_thread2(void *par1, void *par2, void *par3)
 void fifo_thread3(void *par1, void *par2, void *par3)
 {
 	int i;
-	int element[2];
-	int *pelement;
+	intptr_t element[2];
+	intptr_t *pelement;
 	int *pcounter = par1;
 	int num_loops = POINTER_TO_INT(par2);
 
@@ -119,8 +117,7 @@ void fifo_thread3(void *par1, void *par2, void *par3)
 	for (i = 0; i < num_loops; i++) {
 		element[1] = i;
 		k_fifo_put(&fifo1, element);
-		while ((pelement = k_fifo_get(&fifo2,
-							K_NO_WAIT)) == NULL) {
+		while ((pelement = k_fifo_get(&fifo2, K_NO_WAIT)) == NULL) {
 			k_yield();
 		}
 		if (pelement[1] != i) {
@@ -144,7 +141,7 @@ int fifo_test(void)
 	u32_t t;
 	int i = 0;
 	int return_value = 0;
-	int element[2];
+	intptr_t element[2];
 	int j;
 
 	k_fifo_init(&sync_fifo);
@@ -175,7 +172,7 @@ int fifo_test(void)
 
 	/* threads have done their job, they can stop now safely: */
 	for (j = 0; j < 2; j++) {
-		k_fifo_put(&sync_fifo, (void *) element);
+		k_fifo_put(&sync_fifo, element);
 	}
 
 	/* test get/yield & put thread functions between co-op threads */
@@ -207,7 +204,7 @@ int fifo_test(void)
 
 	/* threads have done their job, they can stop now safely: */
 	for (j = 0; j < 2; j++) {
-		k_fifo_put(&sync_fifo, (void *) element);
+		k_fifo_put(&sync_fifo, element);
 	}
 
 	/* test get wait & put functions between co-op and premptive threads */
@@ -232,21 +229,19 @@ int fifo_test(void)
 			 NULL, INT_TO_POINTER(number_of_loops / 2U), NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	for (i = 0; i < number_of_loops / 2U; i++) {
-		int element[2];
-		int *pelement;
+		intptr_t element[2];
+		intptr_t *pelement;
 
 		element[1] = i;
 		k_fifo_put(&fifo1, element);
 		element[1] = i;
 		k_fifo_put(&fifo1, element);
 
-		pelement = (int *)k_fifo_get(&fifo2,
-						     K_FOREVER);
+		pelement = k_fifo_get(&fifo2, K_FOREVER);
 		if (pelement[1] != i) {
 			break;
 		}
-		pelement = (int *)k_fifo_get(&fifo2,
-						     K_FOREVER);
+		pelement = k_fifo_get(&fifo2, K_FOREVER);
 		if (pelement[1] != i) {
 			break;
 		}
@@ -257,7 +252,7 @@ int fifo_test(void)
 
 	/* threads have done their job, they can stop now safely: */
 	for (j = 0; j < 2; j++) {
-		k_fifo_put(&sync_fifo, (void *) element);
+		k_fifo_put(&sync_fifo, element);
 	}
 
 	return return_value;

--- a/tests/bluetooth/tester/src/bttester.c
+++ b/tests/bluetooth/tester/src/bttester.c
@@ -28,7 +28,7 @@ static struct k_thread cmd_thread;
 
 #define CMD_QUEUED 2
 struct btp_buf {
-	u32_t _reserved;
+	intptr_t _reserved;
 	union {
 		u8_t data[BTP_MTU];
 		struct btp_hdr hdr;

--- a/tests/kernel/pending/src/main.c
+++ b/tests/kernel/pending/src/main.c
@@ -35,12 +35,12 @@ static K_THREAD_STACK_DEFINE(offload_work_q_stack,
 			     CONFIG_OFFLOAD_WORKQUEUE_STACK_SIZE);
 
 struct fifo_data {
-	u32_t reserved;
+	intptr_t reserved;
 	u32_t data;
 };
 
 struct lifo_data {
-	u32_t reserved;
+	intptr_t reserved;
 	u32_t data;
 };
 


### PR DESCRIPTION
The first word is used as a pointer, meaning it is 64 bits on 64-bit
systems. To reserve it, it has to be either a pointer or a long, not an
int nor an u32_t.