### PR TITLE
sflist: SYS_SFLIST_FLAGS_MASK must be a long not an int

### DIFF
--- a/include/misc/sflist.h
+++ b/include/misc/sflist.h
@@ -200,7 +200,7 @@ static inline void sys_sflist_init(sys_sflist_t *list)
 }
 
 #define SYS_SFLIST_STATIC_INIT(ptr_to_list) {NULL, NULL}
-#define SYS_SFLIST_FLAGS_MASK	0x3U
+#define SYS_SFLIST_FLAGS_MASK	0x3UL
 
 static inline sys_sfnode_t *z_sfnode_next_peek(sys_sfnode_t *node)
 {
@@ -281,7 +281,7 @@ static inline u8_t sys_sfnode_flags_get(sys_sfnode_t *node)
  */
 static inline void sys_sfnode_init(sys_sfnode_t *node, u8_t flags)
 {
-	__ASSERT((flags & ~SYS_SFLIST_FLAGS_MASK) == 0U, "flags too large");
+	__ASSERT((flags & ~SYS_SFLIST_FLAGS_MASK) == 0UL, "flags too large");
 	node->next_and_flags = flags;
 }
 
@@ -297,7 +297,7 @@ static inline void sys_sfnode_init(sys_sfnode_t *node, u8_t flags)
  */
 static inline void sys_sfnode_flags_set(sys_sfnode_t *node, u8_t flags)
 {
-	__ASSERT((flags & ~SYS_SFLIST_FLAGS_MASK) == 0U, "flags too large");
+	__ASSERT((flags & ~SYS_SFLIST_FLAGS_MASK) == 0UL, "flags too large");
 	node->next_and_flags = (unative_t)(z_sfnode_next_peek(node)) | flags;
 }
 


### PR DESCRIPTION
When splitting the pointer from the flag, ~SYS_SFLIST_FLAGS_MASK remains
a 32-bit value because of the U qualifier. Let's qualify it with UL so
the top half of 64-bit pointers is not truncated.