### PR TITLE
doc: how to unset Clear Linux' CFLAGS and CXXFLAGS

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -85,6 +85,24 @@ Clear Linux:
    sudo swupd bundle-add c-basic dev-utils dfu-util dtc \
      os-core-dev python-basic python3-basic python3-tcl
 
+Clear Linux' focus is *native* performance and security and not
+cross-compilation. For that reason it uniquely exports by default to the
+:ref:`environment <env_vars>` of all users a list of compiler and linker
+flags. Zephyr's CMake build system will either warn or fail because of
+these. To clear the C/C++ flags among these and fix the Zephyr build run
+the following command as root then log out and back in:
+
+.. code-block:: console
+
+   # echo 'unset CFLAGS CXXFLAGS' >> /etc/profile.d/unset_cflags.sh
+
+Note this command unsets the C/C++ flags for *all users on the
+system*. Each Linux distribution has a unique, relatively complex and
+potentially evolving sequence of bash initialization files sourcing each
+other and Clear Linux is no exception. If you need a more flexible
+solution, start by looking at the logic in
+``/usr/share/defaults/etc/profile``.
+
 Arch Linux:
 
 .. code-block:: console


### PR DESCRIPTION
Clear Linux exports to all users a list of "aggressive" compiler and
linker flags. Zephyr's CMake build system will either warn or fail
because of these. Add one magic command that solves the issue.

More background information at https://superuser.com/a/1452523/111302

Signed-off-by: Marc Herbert <marc.herbert@intel.com>