### PR TITLE
Bluetooth: controller: Add PA/LNA support on NRF_P1 GPIO pins

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -664,6 +664,8 @@ if BT_CTLR_GPIO_PA
 
 config BT_CTLR_GPIO_PA_PIN
 	int "Power Amplifier GPIO pin number"
+	range 0 47 if SOC_NRF52840
+	range 0 31
 	help
 	  GPIO Pin number connected to a Power Amplifier.
 
@@ -693,6 +695,8 @@ if BT_CTLR_GPIO_LNA
 
 config BT_CTLR_GPIO_LNA_PIN
 	int "Low Noise Amplifier GPIO pin number"
+	range 0 47 if SOC_NRF52840
+	range 0 31
 	help
 	  GPIO Pin number connected to a Low Noise Amplifier.
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -29,6 +29,26 @@
 #error "Platform not defined."
 #endif
 
+#if defined(CONFIG_BT_CTLR_GPIO_PA_PIN)
+#if ((CONFIG_BT_CTLR_GPIO_PA_PIN) > 31)
+#define NRF_GPIO_PA     NRF_P1
+#define NRF_GPIO_PA_PIN ((CONFIG_BT_CTLR_GPIO_PA_PIN) - 32)
+#else
+#define NRF_GPIO_PA     NRF_GPIO
+#define NRF_GPIO_PA_PIN CONFIG_BT_CTLR_GPIO_PA_PIN
+#endif
+#endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
+
+#if defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
+#if ((CONFIG_BT_CTLR_GPIO_LNA_PIN) > 31)
+#define NRF_GPIO_LNA     NRF_P1
+#define NRF_GPIO_LNA_PIN ((CONFIG_BT_CTLR_GPIO_LNA_PIN) - 32)
+#else
+#define NRF_GPIO_LNA     NRF_GPIO
+#define NRF_GPIO_LNA_PIN CONFIG_BT_CTLR_GPIO_LNA_PIN
+#endif
+#endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
+
 /* The following two constants are used in nrfx_glue.h for marking these PPI
  * channels and groups as occupied and thus unavailable to other modules.
  */
@@ -70,16 +90,16 @@ void radio_isr_set(radio_isr_cb_t cb, void *param)
 void radio_setup(void)
 {
 #if defined(CONFIG_BT_CTLR_GPIO_PA_PIN)
-	NRF_GPIO->DIRSET = BIT(CONFIG_BT_CTLR_GPIO_PA_PIN);
+	NRF_GPIO_PA->DIRSET = BIT(NRF_GPIO_PA_PIN);
 #if defined(CONFIG_BT_CTLR_GPIO_PA_POL_INV)
-	NRF_GPIO->OUTSET = BIT(CONFIG_BT_CTLR_GPIO_PA_PIN);
+	NRF_GPIO_PA->OUTSET = BIT(NRF_GPIO_PA_PIN);
 #else
-	NRF_GPIO->OUTCLR = BIT(CONFIG_BT_CTLR_GPIO_PA_PIN);
+	NRF_GPIO_PA->OUTCLR = BIT(NRF_GPIO_PA_PIN);
 #endif
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
 
 #if defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
-	NRF_GPIO->DIRSET = BIT(CONFIG_BT_CTLR_GPIO_LNA_PIN);
+	NRF_GPIO_LNA->DIRSET = BIT(NRF_GPIO_LNA_PIN);
 
 	radio_gpio_lna_off();
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
@@ -894,6 +914,10 @@ u32_t radio_tmr_sample_get(void)
 #if defined(CONFIG_BT_CTLR_GPIO_PA_PIN)
 void radio_gpio_pa_setup(void)
 {
+	/* NOTE: With GPIO Pins above 31, left shift of
+	 *       CONFIG_BT_CTLR_GPIO_PA_PIN by GPIOTE_CONFIG_PSEL_Pos will
+	 *       set the NRF_GPIOTE->CONFIG[n].PORT to 1 (P1 port).
+	 */
 	NRF_GPIOTE->CONFIG[CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN] =
 		(GPIOTE_CONFIG_MODE_Task <<
 		 GPIOTE_CONFIG_MODE_Pos) |
@@ -914,6 +938,10 @@ void radio_gpio_pa_setup(void)
 #if defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
 void radio_gpio_lna_setup(void)
 {
+	/* NOTE: With GPIO Pins above 31, left shift of
+	 *       CONFIG_BT_CTLR_GPIO_LNA_PIN by GPIOTE_CONFIG_PSEL_Pos will
+	 *       set the NRF_GPIOTE->CONFIG[n].PORT to 1 (P1 port).
+	 */
 	NRF_GPIOTE->CONFIG[CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN] =
 		(GPIOTE_CONFIG_MODE_Task <<
 		 GPIOTE_CONFIG_MODE_Pos) |
@@ -933,18 +961,18 @@ void radio_gpio_lna_setup(void)
 void radio_gpio_lna_on(void)
 {
 #if defined(CONFIG_BT_CTLR_GPIO_LNA_POL_INV)
-	NRF_GPIO->OUTCLR = BIT(CONFIG_BT_CTLR_GPIO_LNA_PIN);
+	NRF_GPIO_LNA->OUTCLR = BIT(NRF_GPIO_LNA_PIN);
 #else
-	NRF_GPIO->OUTSET = BIT(CONFIG_BT_CTLR_GPIO_LNA_PIN);
+	NRF_GPIO_LNA->OUTSET = BIT(NRF_GPIO_LNA_PIN);
 #endif
 }
 
 void radio_gpio_lna_off(void)
 {
 #if defined(CONFIG_BT_CTLR_GPIO_LNA_POL_INV)
-	NRF_GPIO->OUTSET = BIT(CONFIG_BT_CTLR_GPIO_LNA_PIN);
+	NRF_GPIO_LNA->OUTSET = BIT(NRF_GPIO_LNA_PIN);
 #else
-	NRF_GPIO->OUTCLR = BIT(CONFIG_BT_CTLR_GPIO_LNA_PIN);
+	NRF_GPIO_LNA->OUTCLR = BIT(NRF_GPIO_LNA_PIN);
 #endif
 }
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */


### PR DESCRIPTION
Added support for using NRF_P1 GPIO pins on nRF52840 SoC.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>