### PR TITLE
Make generated *.ld files deterministic

### DIFF
--- a/scripts/gen_app_partitions.py
+++ b/scripts/gen_app_partitions.py
@@ -162,7 +162,7 @@ def parse_elf_file(partitions):
 def generate_final_linker(linker_file, partitions):
     string = linker_start_seq
     size_string = ''
-    for partition, item in partitions.items():
+    for partition, item in sorted(partitions.items()):
         string += data_template.format(partition)
         if LIB in item:
             for lib in item[LIB]:

--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -197,7 +197,7 @@ def assign_to_correct_mem_region(memory_type,
 
 def print_linker_sections(list_sections):
     print_string = ''
-    for section in list_sections:
+    for section in sorted(list_sections):
         print_string += PRINT_TEMPLATE.format(section)
     return print_string
 
@@ -233,7 +233,9 @@ def generate_linker_script(linker_file, sram_data_linker_file,
     gen_string = ''
     gen_string_sram_data = ''
     gen_string_sram_bss = ''
-    for memory_type, full_list_of_sections in complete_list_of_sections.items():
+
+    for memory_type, full_list_of_sections in \
+            sorted(complete_list_of_sections.items()):
 
         if memory_type != "SRAM":
             gen_string += MPU_RO_REGION_START.format(memory_type.lower(),
@@ -393,7 +395,6 @@ def main():
     # Create/or trucate file contents if it already exists
     # raw = open(linker_file, "w")
 
-    code_generation = {"copy_code": '', "zero_code":'', "extern":''}
     #for each memory_type, create text/rodata/data/bss sections for all obj files
     for  memory_type, files in rel_dict.items():
         full_list_of_sections = {"text":[], "rodata":[], "data":[], "bss":[]}
@@ -413,7 +414,10 @@ def main():
 
     generate_linker_script(linker_file, sram_data_linker_file,
                        sram_bss_linker_file, complete_list_of_sections)
-    for mem_type, list_of_sections in complete_list_of_sections.items():
+
+    code_generation = {"copy_code": '', "zero_code":'', "extern":''}
+    for mem_type, list_of_sections in \
+        sorted(complete_list_of_sections.items()):
         code_generation = generate_memcpy_code(mem_type,
                                                list_of_sections, code_generation)
 


### PR DESCRIPTION
gen_app_partitions.py: make generated/app_smem_*.ld files deterministic
gen_relocate_app.py: make generated/linker_relocate.ld deterministic

Dictionaries are not ordered in Python 3.5 and before, so building twice
in a row could lead to a different sections/partitions order, different
build/zephyr/include/generated/linker_relocate.d, code_relocation.c,
build/zephyr/include/generated/app_smem_*.ld and different binaries.

