### PR TITLE
Arch arm float configurable mpu guards

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -212,6 +212,14 @@ void z_arch_configure_dynamic_mpu_regions(struct k_thread *thread)
 
 	/* Privileged stack guard */
 	u32_t guard_start;
+	u32_t guard_size = MPU_GUARD_ALIGN_AND_SIZE;
+
+#if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING)
+	if ((thread->base.user_options & K_FP_REGS) != 0) {
+		guard_size = MPU_GUARD_ALIGN_AND_SIZE_FLOAT;
+	}
+#endif
+
 #if defined(CONFIG_USERSPACE)
 	if (thread->arch.priv_stack_start) {
 		guard_start = thread->arch.priv_stack_start -
@@ -220,15 +228,14 @@ void z_arch_configure_dynamic_mpu_regions(struct k_thread *thread)
 		"Guard start: (0x%x) below privilege stacks boundary: (0x%x)",
 		guard_start, (u32_t)&z_priv_stacks_ram_start);
 	} else {
-		guard_start = thread->stack_info.start -
-			MPU_GUARD_ALIGN_AND_SIZE;
+		guard_start = thread->stack_info.start - guard_size;
+
 		__ASSERT((u32_t)thread->stack_obj == guard_start,
 		"Guard start (0x%x) not beginning at stack object (0x%x)\n",
 		guard_start, (u32_t)thread->stack_obj);
 	}
 #else
-	guard_start = thread->stack_info.start -
-		MPU_GUARD_ALIGN_AND_SIZE;
+	guard_start = thread->stack_info.start - guard_size;
 #endif /* CONFIG_USERSPACE */
 
 	__ASSERT(region_num < _MAX_DYNAMIC_MPU_REGIONS_NUM,
@@ -236,7 +243,7 @@ void z_arch_configure_dynamic_mpu_regions(struct k_thread *thread)
 	guard = (const struct k_mem_partition)
 	{
 		guard_start,
-		MPU_GUARD_ALIGN_AND_SIZE,
+		guard_size,
 		K_MEM_PARTITION_P_RO_U_NA
 	};
 	dynamic_regions[region_num] = &guard;

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -94,6 +94,24 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	 */
 	stackSize -= MPU_GUARD_ALIGN_AND_SIZE;
 #endif
+
+#if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING) \
+	&& defined(CONFIG_MPU_STACK_GUARD)
+	/* For a thread which intends to use the FP services, it is required to
+	 * allocate a wider MPU guard region, to always successfully detect an
+	 * overflow of the stack.
+	 *
+	 * Note that the wider MPU regions requires re-adjusting the stack_info
+	 * .start and .size.
+	 *
+	 */
+	if ((options & K_FP_REGS) != 0) {
+		pStackMem += MPU_GUARD_ALIGN_AND_SIZE_FLOAT
+			- MPU_GUARD_ALIGN_AND_SIZE;
+		stackSize -= MPU_GUARD_ALIGN_AND_SIZE_FLOAT
+			- MPU_GUARD_ALIGN_AND_SIZE;
+	}
+#endif
 	stackEnd = pStackMem + stackSize;
 
 	struct __esf *pInitCtx;

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -180,7 +180,13 @@ FUNC_NORETURN void z_arch_user_mode_enter(k_thread_entry_t user_entry,
 	 * privileged stack. Adjust the available (writable) stack
 	 * buffer area accordingly.
 	 */
+#if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING)
+	 _current->arch.priv_stack_start +=
+		(_current->base.user_options & K_FP_REGS) ?
+		MPU_GUARD_ALIGN_AND_SIZE_FLOAT : MPU_GUARD_ALIGN_AND_SIZE;
+#else
 	 _current->arch.priv_stack_start += MPU_GUARD_ALIGN_AND_SIZE;
+#endif /* CONFIG_FLOAT && CONFIG_FP_SHARING */
 #endif /* CONFIG_MPU_STACK_GUARD */
 
 	z_arm_userspace_enter(user_entry, p1, p2, p3,

--- a/doc/reference/kernel/other/float.rst
+++ b/doc/reference/kernel/other/float.rst
@@ -77,6 +77,19 @@ This means that any thread is allowed to access the floating point registers.
 The ARM kernel automatically detects that a given thread is using the floating
 point registers the first time the thread accesses them.
 
+Pretag a thread that intends to use the FP registers by
+using one of the techniques listed below.
+
+* A statically-created ARM thread can be pretagged by passing the
+  :c:macro:`K_FP_REGS` option to :c:macro:`K_THREAD_DEFINE`.
+
+* A dynamically-created ARM thread can be pretagged by passing the
+  :c:macro:`K_FP_REGS` option to :cpp:func:`k_thread_create()`.
+
+Pretagging a thread with the :c:macro:`K_FP_REGS` option instructs the
+MPU-based stack protection mechanism to properly configure the size of
+the thread's guard region to always guarantee stack overflow detection.
+
 During thread context switching the ARM kernel saves the *callee-saved*
 floating point registers, if the switched-out thread has been using them.
 Additionally, the *caller-saved* floating point registers are saved on

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -308,6 +308,15 @@ void test_fatal(void)
 
 	TC_PRINT("test stack HW-based overflow - supervisor 2\n");
 	check_stack_overflow(stack_hw_overflow, 0);
+
+#if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING)
+	TC_PRINT("test stack HW-based overflow (FPU thread) - supervisor 1\n");
+	check_stack_overflow(stack_hw_overflow, K_FP_REGS);
+
+	TC_PRINT("test stack HW-based overflow (FPU thread) - supervisor 2\n");
+	check_stack_overflow(stack_hw_overflow, K_FP_REGS);
+#endif /* CONFIG_FLOAT && CONFIG_FP_SHARING */
+
 #endif /* CONFIG_HW_STACK_PROTECTION */
 
 #ifdef CONFIG_USERSPACE
@@ -323,6 +332,15 @@ void test_fatal(void)
 
 	TC_PRINT("test stack HW-based overflow - user priv stack 2\n");
 	check_stack_overflow(user_priv_stack_hw_overflow, K_USER);
+
+#if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING)
+	TC_PRINT("test stack HW-based overflow (FPU thread) - user 1\n");
+	check_stack_overflow(stack_hw_overflow, K_USER | K_FP_REGS);
+
+	TC_PRINT("test stack HW-based overflow (FPU thread) - user 2\n");
+	check_stack_overflow(stack_hw_overflow, K_USER | K_FP_REGS);
+#endif /* CONFIG_FLOAT && CONFIG_FP_SHARING */
+
 #endif /* CONFIG_USERSPACE */
 
 #endif /* !CONFIG_ARCH_POSIX */


### PR DESCRIPTION
Closes #16360
Closes #15074  
Fixes #14828

This is the final patch of the rework of Floating Point services for ARM, adding:
- support for MPU stack guards of configurable size, for threads that are pre-tagged as FPU Capable
- the corresponding documentation
- test coverage in tests/kernel/fatal for FPU capable threads
- atomic clearing of thread option flag and CONTROL register in z_arch_float_disable() for ARM (as previously suggested by @andyross in #16058, and documented in #16360 )

More details in #16360