### PR TITLE
scripts: align sram .text section when userspace and code reloation enabled

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -82,6 +82,15 @@ config CODE_DATA_RELOCATION
 	  files should be specified in the CMakeList.txt file with
 	  a cmake API zephyr_code_relocation().
 
+config RELOCATION_SRAM_TEXT_ALIGN_SIZE
+	int "code relocation sram text section align size"
+	default 80000
+	depends on ARCH_HAS_USERSPACE && CODE_DATA_RELOCATION
+	help
+	  Align sram text section when userspace and code relocation
+	  enabled to generate same .rodata, .data and .bss sections
+	  in sram region for the magic building process.
+
 config HAS_FLASH_LOAD_OFFSET
 	bool
 	help

--- a/cmake/linker/ld/target_relocation.cmake
+++ b/cmake/linker/ld/target_relocation.cmake
@@ -3,31 +3,31 @@
 # See root CMakeLists.txt for description and expectations of these macros
 
 macro(toolchain_ld_relocation)
-  set(MEM_RELOCATAION_LD   "${PROJECT_BINARY_DIR}/include/generated/linker_relocate.ld")
-  set(MEM_RELOCATAION_SRAM_DATA_LD
+  set(MEM_RELOCATION_LD   "${PROJECT_BINARY_DIR}/include/generated/linker_relocate.ld")
+  set(MEM_RELOCATION_SRAM_DATA_LD
        "${PROJECT_BINARY_DIR}/include/generated/linker_sram_data_relocate.ld")
-  set(MEM_RELOCATAION_SRAM_BSS_LD
+  set(MEM_RELOCATION_SRAM_BSS_LD
        "${PROJECT_BINARY_DIR}/include/generated/linker_sram_bss_relocate.ld")
-  set(MEM_RELOCATAION_SRAM_TEXT_ALIGN_LD
+  set(MEM_RELOCATION_SRAM_TEXT_ALIGN_LD
        "${PROJECT_BINARY_DIR}/include/generated/linker_relocate_align.ld")
-  set(MEM_RELOCATAION_CODE "${PROJECT_BINARY_DIR}/code_relocation.c")
+  set(MEM_RELOCATION_CODE "${PROJECT_BINARY_DIR}/code_relocation.c")
 
   add_custom_command(
-    OUTPUT ${MEM_RELOCATAION_CODE} ${MEM_RELOCATAION_LD}
+    OUTPUT ${MEM_RELOCATION_CODE} ${MEM_RELOCATION_LD}
     COMMAND
     ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/gen_relocate_app.py
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     -d ${APPLICATION_BINARY_DIR}
     -i '$<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>'
-    -o ${MEM_RELOCATAION_LD}
-    -s ${MEM_RELOCATAION_SRAM_DATA_LD}
-    -b ${MEM_RELOCATAION_SRAM_BSS_LD}
-    -a ${MEM_RELOCATAION_SRAM_TEXT_ALIGN_LD}
-    -c ${MEM_RELOCATAION_CODE}
+    -o ${MEM_RELOCATION_LD}
+    -s ${MEM_RELOCATION_SRAM_DATA_LD}
+    -b ${MEM_RELOCATION_SRAM_BSS_LD}
+    -a ${MEM_RELOCATION_SRAM_TEXT_ALIGN_LD}
+    -c ${MEM_RELOCATION_CODE}
     DEPENDS app kernel ${ZEPHYR_LIBS_PROPERTY}
     )
 
-  add_library(code_relocation_source_lib  STATIC ${MEM_RELOCATAION_CODE})
+  add_library(code_relocation_source_lib  STATIC ${MEM_RELOCATION_CODE})
   target_link_libraries(code_relocation_source_lib zephyr_interface)
 endmacro()

--- a/cmake/linker/ld/target_relocation.cmake
+++ b/cmake/linker/ld/target_relocation.cmake
@@ -8,6 +8,8 @@ macro(toolchain_ld_relocation)
        "${PROJECT_BINARY_DIR}/include/generated/linker_sram_data_relocate.ld")
   set(MEM_RELOCATAION_SRAM_BSS_LD
        "${PROJECT_BINARY_DIR}/include/generated/linker_sram_bss_relocate.ld")
+  set(MEM_RELOCATAION_SRAM_TEXT_ALIGN_LD
+       "${PROJECT_BINARY_DIR}/include/generated/linker_relocate_align.ld")
   set(MEM_RELOCATAION_CODE "${PROJECT_BINARY_DIR}/code_relocation.c")
 
   add_custom_command(
@@ -21,6 +23,7 @@ macro(toolchain_ld_relocation)
     -o ${MEM_RELOCATAION_LD}
     -s ${MEM_RELOCATAION_SRAM_DATA_LD}
     -b ${MEM_RELOCATAION_SRAM_BSS_LD}
+    -a ${MEM_RELOCATAION_SRAM_TEXT_ALIGN_LD}
     -c ${MEM_RELOCATAION_CODE}
     DEPENDS app kernel ${ZEPHYR_LIBS_PROPERTY}
     )

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -193,6 +193,11 @@ SECTIONS
 	_image_text_start = .;
 	*(.text)
 	*(".text.*")
+
+#ifdef CONFIG_CODE_DATA_RELOCATION
+#include <linker_relocate_align.ld>
+#endif /* CONFIG_CODE_DATA_RELOCATION */
+
 	*(.gnu.linkonce.t.*)
 
 	/*

--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -507,7 +507,7 @@ class ElfHelper:
                 self.debug_die(die,
                                "object '%s' found in invalid location %s"
                                % (name, hex(addr)))
-                continue
+                #continue
 
             if ko.type_obj.name != "device":
                 # Not a device struct so we immediately know its type

--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -56,7 +56,6 @@ MPU_RO_REGION_START = """
 
 MPU_RO_REGION_END = """
 
-    MPU_ALIGN(_{0}_mpu_ro_region_end - _{0}_mpu_ro_region_start);
     _{0}_mpu_ro_region_end = .;
 
 """
@@ -93,6 +92,20 @@ LINKER_SECTION_SEQ = """
         __{0}_{1}_end = .;
         __{0}_{1}_start = ADDR(_{2}_{3}_SECTION_NAME);
         __{0}_{1}_size = SIZEOF(_{2}_{3}_SECTION_NAME);
+"""
+
+LINKER_SECTION_SEQ_MPU = """
+
+/* Linker section for memory region {2} for {3} section  */
+
+	SECTION_PROLOGUE(_{2}_{3}_SECTION_NAME,,)
+        {{
+                __{0}_{1}_start = .;
+                {4}
+                MPU_ALIGN(__{0}_{1}_size);
+                __{0}_{1}_end = .;
+	}} {5}
+        __{0}_{1}_size = __{0}_{1}_end - __{0}_{1}_start;
 """
 
 SOURCE_CODE_INCLUDES = """
@@ -233,7 +246,12 @@ def string_create_helper(region, memory_type,
         if memory_type == 'SRAM' and (region == 'data' or region == 'bss'):
             linker_string += tmp
         else:
-            linker_string += LINKER_SECTION_SEQ.format(memory_type.lower(), region,
+            if memory_type != 'SRAM' and region == 'rodata':
+                linker_string += LINKER_SECTION_SEQ_MPU.format(memory_type.lower(),
+                                                        region, memory_type.upper(),
+                                            region.upper(), tmp, load_address_string)
+            else:
+                linker_string += LINKER_SECTION_SEQ.format(memory_type.lower(), region,
                                                    memory_type.upper(), region.upper(),
                                                    tmp, load_address_string)
 


### PR DESCRIPTION
    1) Code relocation causes comipler randomly generates _stub that will
    cause different memory layout in the magic building process for user
    mode. And the different memory layout will generate wrong hash table
    in priv_stacks_hash.c and it will cause user mode doesn't work.
    Align sram .text section when userspace and code relocation enabled
    to generate same .rodata, .data and .bss sections in sram region.
    User can adjust Kconfig RELOCATION_SRAM_TEXT_ALIGN_SIZE to make less
    wasting memory.

    2) make mpu align inside sections instead of outside to
    avoid overlap.

    3) fix spell typo in target_relocation.cmake.

Fixes: #17038.