### PR TITLE
Bluetooth: controller: Fix handling zero length L2CAP start frame

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -570,6 +570,12 @@ config BT_CTLR_FAST_ENC
 	  Maximum CPU time in Radio ISR will increase if this feature is
 	  selected.
 
+config BT_CTLR_LLID_DATA_START_EMPTY
+	bool "Handle zero length L2CAP start frame"
+	default y if BT_HCI_RAW
+	help
+	  Handle zero length L2CAP start frame.
+
 config BT_CTLR_TX_RETRY_DISABLE
 	bool "Disable Tx Retry"
 	help

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -9177,6 +9177,26 @@ static void packet_tx_enqueue(u8_t max)
 				pdu_data_q_tx->handle);
 
 		if (conn->handle == pdu_data_q_tx->handle) {
+			if (IS_ENABLED(CONFIG_BT_CTLR_LLID_DATA_START_EMPTY)) {
+				struct pdu_data *p;
+
+				p = (void *)node_tx_new->pdu_data;
+				if ((p->ll_id == PDU_DATA_LLID_DATA_START) &&
+				    !p->len) {
+					conn->start_empty = 1U;
+					pdu_node_tx_release(conn->handle,
+							    node_tx_new);
+					goto packet_tx_enqueue_release;
+				} else if (p->len && conn->start_empty) {
+					conn->start_empty = 0U;
+					if (p->ll_id ==
+					    PDU_DATA_LLID_DATA_CONTINUE) {
+						p->ll_id =
+							PDU_DATA_LLID_DATA_START;
+					}
+				}
+			}
+
 			if (conn->pkt_tx_data == 0) {
 				conn->pkt_tx_data = node_tx_new;
 
@@ -9204,6 +9224,7 @@ static void packet_tx_enqueue(u8_t max)
 			pdu_node_tx_release(pdu_data_q_tx->handle, node_tx_new);
 		}
 
+packet_tx_enqueue_release:
 		first = _radio.packet_tx_first + 1;
 		if (first == _radio.packet_tx_count) {
 			first = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ctrl_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl_internal.h
@@ -272,15 +272,6 @@ struct connection {
 	} llcp_phy;
 #endif /* CONFIG_BT_CTLR_PHY */
 
-	u8_t  sn:1;
-	u8_t  nesn:1;
-	u8_t  pause_rx:1;
-	u8_t  pause_tx:1;
-	u8_t  enc_rx:1;
-	u8_t  enc_tx:1;
-	u8_t  refresh:1;
-	u8_t  empty:1;
-
 	struct ccm ccm_rx;
 	struct ccm ccm_tx;
 
@@ -291,6 +282,18 @@ struct connection {
 	struct radio_pdu_node_tx *pkt_tx_last;
 	u8_t  packet_tx_head_len;
 	u8_t  packet_tx_head_offset;
+
+	u8_t  sn:1;
+	u8_t  nesn:1;
+	u8_t  pause_rx:1;
+	u8_t  pause_tx:1;
+	u8_t  enc_rx:1;
+	u8_t  enc_tx:1;
+	u8_t  refresh:1;
+	u8_t  empty:1;
+
+	/* Detect empty L2CAP start frame */
+	u8_t  start_empty:1;
 
 #if defined(CONFIG_BT_CTLR_CONN_RSSI)
 	u8_t  rssi_latest;


### PR DESCRIPTION
Added a fix handling L2CAP start frame with payload length
of zero which otherwise sent zero length data start PDU on
air.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>