### PR TITLE
dts/bindings: remove 'use-prop-name' from bindings

### DIFF
--- a/dts/bindings/audio/ti,tlv320dac.yaml
+++ b/dts/bindings/audio/ti,tlv320dac.yaml
@@ -20,4 +20,4 @@ properties:
     reset-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/can/microchip,mcp2515.yaml
+++ b/dts/bindings/can/microchip,mcp2515.yaml
@@ -19,4 +19,4 @@ properties:
     int-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -44,10 +44,6 @@ properties:
 #     description: <description of property>
 #     generation: define
 #
-# The 'generation' attribute can be set to 'define, use-prop-name' to use the
-# property name instead of a generic controller name, e.g. *_CS_GPIO_* instead
-# of *_GPIOS_*.
-#
 # The exact value of the 'generation' attribute is ignored otherwise. The
 # output is always #define's.
 #

--- a/dts/bindings/display/ilitek,ili9340.yaml
+++ b/dts/bindings/display/ilitek,ili9340.yaml
@@ -20,9 +20,9 @@ properties:
     reset-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     cmd-data-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/display/solomon,ssd1306fb.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb.yaml
@@ -68,4 +68,4 @@ properties:
     reset-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/display/solomon,ssd1673fb.yaml
+++ b/dts/bindings/display/solomon,ssd1673fb.yaml
@@ -98,14 +98,14 @@ properties:
     reset-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     dc-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     busy-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/ethernet/microchip,enc28j60.yaml
+++ b/dts/bindings/ethernet/microchip,enc28j60.yaml
@@ -18,4 +18,4 @@ properties:
     int-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/ieee802154/nxp,mcr20a.yaml
+++ b/dts/bindings/ieee802154/nxp,mcr20a.yaml
@@ -20,9 +20,9 @@ properties:
     irqb-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     reset-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/ieee802154/ti,cc2520.yaml
+++ b/dts/bindings/ieee802154/ti,cc2520.yaml
@@ -20,29 +20,29 @@ properties:
     vreg-en-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define
 
     reset-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define
 
     fifo-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define
 
     cca-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define
 
     sfd-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define
 
     fifop-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/led/holtek,ht16k33.yaml
+++ b/dts/bindings/led/holtek,ht16k33.yaml
@@ -27,4 +27,4 @@ properties:
       type: compound
       category: optional
       description: IRQ pin
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/misc/skyworks,sky13351.yaml
+++ b/dts/bindings/misc/skyworks,sky13351.yaml
@@ -21,9 +21,9 @@ properties:
         type: compound
         category: required
         description: VCTL1 pin
-        generation: define, use-prop-name
+        generation: define
     vctl2-gpios:
         type: compound
         category: required
         description: VCTL2 pin
-        generation: define, use-prop-name
+        generation: define

--- a/dts/bindings/modem/ublox,sara-r4.yaml
+++ b/dts/bindings/modem/ublox,sara-r4.yaml
@@ -23,9 +23,9 @@ properties:
     mdm-power-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     mdm-reset-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -23,30 +23,30 @@ properties:
     mdm-boot-mode-sel-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     mdm-power-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     mdm-keep-awake-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     mdm-reset-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     mdm-shld-trans-ena-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     mdm-send-ok-gpios:
       type: compound
       category: optional
       description: UART RTS pin if no HW flow control (set to always enabled)
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -41,20 +41,20 @@ properties:
     type: int
     category: optional
     description: flash capacity in bits
-    generation: define, use-prop-name
+    generation: define
 
   wp-gpios:
     type: compound
     category: optional
     description: WPn pin
-    generation: define, use-prop-name
+    generation: define
   hold-gpios:
     type: compound
     category: optional
     description: HOLDn pin
-    generation: define, use-prop-name
+    generation: define
   reset-gpios:
     type: compound
     category: optional
     description: RESETn pin
-    generation: define, use-prop-name
+    generation: define

--- a/dts/bindings/sensor/adi,adt7420.yaml
+++ b/dts/bindings/sensor/adi,adt7420.yaml
@@ -20,4 +20,4 @@ properties:
     int-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -20,4 +20,4 @@ properties:
     int1-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/adi,adxl372-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl372-i2c.yaml
@@ -20,4 +20,4 @@ properties:
     int1-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/adi,adxl372-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl372-spi.yaml
@@ -22,4 +22,4 @@ properties:
     int1-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/avago,apds9960.yaml
+++ b/dts/bindings/sensor/avago,apds9960.yaml
@@ -20,4 +20,4 @@ properties:
     int-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/bosch,bmi160.yaml
+++ b/dts/bindings/sensor/bosch,bmi160.yaml
@@ -20,4 +20,4 @@ properties:
     int-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/nxp,fxas21002.yaml
+++ b/dts/bindings/sensor/nxp,fxas21002.yaml
@@ -20,9 +20,9 @@ properties:
     int1-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define
 
     int2-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/nxp,fxos8700.yaml
+++ b/dts/bindings/sensor/nxp,fxos8700.yaml
@@ -21,14 +21,14 @@ properties:
     reset-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define
 
     int1-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define
 
     int2-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/sensirion,sht3xd.yaml
+++ b/dts/bindings/sensor/sensirion,sht3xd.yaml
@@ -21,4 +21,4 @@ properties:
       type: compound
       category: optional
       description: ALERT pin
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/st,hts221.yaml
+++ b/dts/bindings/sensor/st,hts221.yaml
@@ -22,4 +22,4 @@ properties:
       type: compound
       category: optional
       description: DRDY pin
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/st,lis2dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dh-i2c.yaml
@@ -20,4 +20,4 @@ properties:
     irq-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/st,lis2dh-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dh-spi.yaml
@@ -21,4 +21,4 @@ properties:
     irq-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/st,lis2ds12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-i2c.yaml
@@ -20,4 +20,4 @@ properties:
     irq-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/st,lis2ds12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-spi.yaml
@@ -21,4 +21,4 @@ properties:
     irq-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/st,lis2dw12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-i2c.yaml
@@ -20,4 +20,4 @@ properties:
     irq-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/st,lis2dw12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-spi.yaml
@@ -21,4 +21,4 @@ properties:
     irq-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/st,lis2mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-magn.yaml
@@ -20,4 +20,4 @@ properties:
     irq-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/st,lis3dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis3dh-i2c.yaml
@@ -20,4 +20,4 @@ properties:
     irq-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
@@ -21,4 +21,4 @@ properties:
     irq-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/st,lsm6dsl-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-spi.yaml
@@ -21,4 +21,4 @@ properties:
     irq-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
@@ -20,4 +20,4 @@ properties:
     irq-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
@@ -20,4 +20,4 @@ properties:
     irq-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/sensor/ti,hdc.yaml
+++ b/dts/bindings/sensor/ti,hdc.yaml
@@ -20,4 +20,4 @@ properties:
     drdy-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/spi/spi.yaml
+++ b/dts/bindings/spi/spi.yaml
@@ -40,4 +40,4 @@ properties:
     cs-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -35,7 +35,7 @@ properties:
       category: optional
       description: Some boards use a USB DISCONNECT pin to enable
                    the pull-up resistor on USB Data Positive signal.
-      generation: define, use-prop-name
+      generation: define
 
     phys:
       type: array
@@ -48,4 +48,4 @@ properties:
       category: optional
       description: For STM32F0 series SoCs on QFN28 and TSSOP20 packages
                    enable PIN pair PA11/12 mapped instead of PA9/10 (e.g. stm32f070x6)
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/wifi/atmel,winc1500.yaml
+++ b/dts/bindings/wifi/atmel,winc1500.yaml
@@ -20,14 +20,14 @@ properties:
     irq-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     reset-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     enable-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define

--- a/dts/bindings/wifi/inventek,eswifi.yaml
+++ b/dts/bindings/wifi/inventek,eswifi.yaml
@@ -20,19 +20,19 @@ properties:
     resetn-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     data-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name
+      generation: define
 
     wakeup-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define
 
     boot0-gpios:
       type: compound
       category: optional
-      generation: define, use-prop-name
+      generation: define


### PR DESCRIPTION
Now that the generation code doesnt look at 'use-prop-name' we can
remove it from the binding files.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>