### PR TITLE
Bluetooth: Mesh: Various fixes impacting qualification

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3065,6 +3065,8 @@ static void le_pkey_complete(struct net_buf *buf)
 	for (cb = pub_key_cb; cb; cb = cb->_next) {
 		cb->func(evt->status ? NULL : evt->key);
 	}
+
+	pub_key_cb = NULL;
 }
 
 static void le_dhkey_complete(struct net_buf *buf)
@@ -5850,7 +5852,6 @@ int bt_br_set_discoverable(bool enable)
 #if defined(CONFIG_BT_ECC)
 int bt_pub_key_gen(struct bt_pub_key_cb *new_cb)
 {
-	struct bt_pub_key_cb *cb;
 	int err;
 
 	/*
@@ -5880,12 +5881,6 @@ int bt_pub_key_gen(struct bt_pub_key_cb *new_cb)
 		atomic_clear_bit(bt_dev.flags, BT_DEV_PUB_KEY_BUSY);
 		pub_key_cb = NULL;
 		return err;
-	}
-
-	for (cb = pub_key_cb; cb; cb = cb->_next) {
-		if (cb != new_cb) {
-			cb->func(NULL);
-		}
 	}
 
 	return 0;

--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -909,6 +909,20 @@ static void send_pub_key(void)
 
 	BT_DBG("Local Public Key: %s", bt_hex(key, 64));
 
+	/* Copy remote key in little-endian for bt_dh_key_gen().
+	 * X and Y halves are swapped independently. Use response
+	 * buffer as a temporary storage location. The bt_dh_key_gen()
+	 * will also take care of validating the remote public key.
+	 */
+	sys_memcpy_swap(buf.data, &link.conf_inputs[17], 32);
+	sys_memcpy_swap(&buf.data[32], &link.conf_inputs[49], 32);
+
+	if (bt_dh_key_gen(buf.data, prov_dh_key_cb)) {
+		BT_ERR("Failed to generate DHKey");
+		prov_send_fail_msg(PROV_ERR_UNEXP_ERR);
+		return;
+	}
+
 	prov_buf_init(&buf, PROV_PUB_KEY);
 
 	/* Swap X and Y halves independently to big-endian */
@@ -917,18 +931,8 @@ static void send_pub_key(void)
 
 	memcpy(&link.conf_inputs[81], &buf.data[1], 64);
 
-	prov_send(&buf);
-
-	/* Copy remote key in little-endian for bt_dh_key_gen().
-	 * X and Y halves are swapped independently.
-	 */
-	net_buf_simple_reset(&buf);
-	sys_memcpy_swap(buf.data, &link.conf_inputs[17], 32);
-	sys_memcpy_swap(&buf.data[32], &link.conf_inputs[49], 32);
-
-	if (bt_dh_key_gen(buf.data, prov_dh_key_cb)) {
-		BT_ERR("Failed to generate DHKey");
-		prov_send_fail_msg(PROV_ERR_UNEXP_ERR);
+	if (prov_send(&buf)) {
+		BT_ERR("Failed to send Public Key");
 		return;
 	}
 

--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -269,7 +269,7 @@ static void prov_clear_tx(void)
 	free_segments();
 }
 
-static void reset_link(void)
+static void reset_adv_link(void)
 {
 	prov_clear_tx();
 
@@ -1150,7 +1150,7 @@ static void prov_retransmit(struct k_work *work)
 
 	if (k_uptime_get() - link.tx.start > TRANSACTION_TIMEOUT) {
 		BT_WARN("Giving up transaction");
-		reset_link();
+		reset_adv_link();
 		return;
 	}
 
@@ -1224,7 +1224,7 @@ static void link_close(struct prov_rx *rx, struct net_buf_simple *buf)
 {
 	BT_DBG("len %u", buf->len);
 
-	reset_link();
+	reset_adv_link();
 }
 
 static void gen_prov_ctl(struct prov_rx *rx, struct net_buf_simple *buf)

--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -53,6 +53,9 @@
 #define INPUT_OOB_NUMBER       0x02
 #define INPUT_OOB_STRING       0x03
 
+#define PUB_KEY_NO_OOB         0x00
+#define PUB_KEY_OOB            0x01
+
 #define PROV_ERR_NONE          0x00
 #define PROV_ERR_NVAL_PDU      0x01
 #define PROV_ERR_NVAL_FMT      0x02
@@ -529,8 +532,8 @@ static void prov_invite(const u8_t *data)
 	/* Supported algorithms - FIPS P-256 Eliptic Curve */
 	net_buf_simple_add_be16(&buf, BIT(PROV_ALG_P256));
 
-	/* Public Key Type */
-	net_buf_simple_add_u8(&buf, 0x00);
+	/* Public Key Type, Only "No OOB" Public Key is supported */
+	net_buf_simple_add_u8(&buf, PUB_KEY_NO_OOB);
 
 	/* Static OOB Type */
 	net_buf_simple_add_u8(&buf, prov->static_val ? BIT(0) : 0x00);
@@ -729,8 +732,8 @@ static void prov_start(const u8_t *data)
 		return;
 	}
 
-	if (data[1] > 0x01) {
-		BT_ERR("Invalid public key value: 0x%02x", data[1]);
+	if (data[1] != PUB_KEY_NO_OOB) {
+		BT_ERR("Invalid public key type: 0x%02x", data[1]);
 		prov_send_fail_msg(PROV_ERR_NVAL_FMT);
 		return;
 	}

--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -522,7 +522,10 @@ static void prov_send_fail_msg(u8_t err)
 
 	prov_buf_init(&buf, PROV_FAILED);
 	net_buf_simple_add_u8(&buf, err);
-	prov_send(&buf);
+
+	if (prov_send(&buf)) {
+		BT_ERR("Failed to send Provisioning Failed message");
+	}
 
 	atomic_set_bit(link.flags, LINK_INVALID);
 }
@@ -569,7 +572,6 @@ static void prov_invite(const u8_t *data)
 
 	if (prov_send(&buf)) {
 		BT_ERR("Failed to send capabilities");
-		prov_send_fail_msg(PROV_ERR_RESOURCES);
 		return;
 	}
 
@@ -808,7 +810,6 @@ static void send_confirm(void)
 
 	if (prov_send(&cfm)) {
 		BT_ERR("Failed to send Provisioning Confirm");
-		prov_send_fail_msg(PROV_ERR_RESOURCES);
 		return;
 	}
 
@@ -820,7 +821,9 @@ static void send_input_complete(void)
 	PROV_BUF(buf, 1);
 
 	prov_buf_init(&buf, PROV_INPUT_COMPLETE);
-	prov_send(&buf);
+	if (prov_send(&buf)) {
+		BT_ERR("Failed to send Provisioning Input Complete");
+	}
 }
 
 int bt_mesh_input_number(u32_t num)
@@ -1019,7 +1022,6 @@ static void prov_random(const u8_t *data)
 
 	if (prov_send(&rnd)) {
 		BT_ERR("Failed to send Provisioning Random");
-		prov_send_fail_msg(PROV_ERR_RESOURCES);
 		return;
 	}
 
@@ -1103,7 +1105,10 @@ static void prov_data(const u8_t *data)
 	       net_idx, iv_index, addr);
 
 	prov_buf_init(&msg, PROV_COMPLETE);
-	prov_send(&msg);
+	if (prov_send(&msg)) {
+		BT_ERR("Failed to send Provisioning Complete");
+		return;
+	}
 
 	/* Ignore any further PDUs on this link */
 	link.expect = 0U;

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -261,8 +261,7 @@ static struct bt_smp bt_smp_pool[CONFIG_BT_MAX_CONN];
 static bool bondable = IS_ENABLED(CONFIG_BT_BONDABLE);
 static bool oobd_present;
 static bool sc_supported;
-static bool sc_local_pkey_valid;
-static u8_t sc_public_key[64];
+static const u8_t *sc_public_key;
 static K_SEM_DEFINE(sc_local_pkey_ready, 0, 1);
 
 static u8_t get_io_capa(void)
@@ -2292,6 +2291,8 @@ static int smp_init(struct bt_smp *smp)
 
 	atomic_set_bit(&smp->allowed_cmds, BT_SMP_CMD_PAIRING_FAIL);
 
+	sc_public_key = bt_pub_key_get();
+
 	return 0;
 }
 
@@ -2666,7 +2667,7 @@ static u8_t smp_pairing_rsp(struct bt_smp *smp, struct net_buf *buf)
 		return 0;
 	}
 
-	if (!sc_local_pkey_valid) {
+	if (!sc_public_key) {
 		atomic_set_bit(smp->flags, SMP_FLAG_PKEY_SEND);
 		return 0;
 	}
@@ -3510,7 +3511,7 @@ static u8_t smp_public_key(struct bt_smp *smp, struct net_buf *buf)
 	}
 
 #if defined(CONFIG_BT_PERIPHERAL)
-	if (!sc_local_pkey_valid) {
+	if (!sc_public_key) {
 		atomic_set_bit(smp->flags, SMP_FLAG_PKEY_SEND);
 		return 0;
 	}
@@ -3678,14 +3679,13 @@ static void bt_smp_pkey_ready(const u8_t *pkey)
 
 	BT_DBG("");
 
+	sc_public_key = pkey;
+
 	if (!pkey) {
 		BT_WARN("Public key not available");
-		sc_local_pkey_valid = false;
 		return;
 	}
 
-	memcpy(sc_public_key, pkey, 64);
-	sc_local_pkey_valid = true;
 	k_sem_give(&sc_local_pkey_ready);
 
 	for (i = 0; i < ARRAY_SIZE(bt_smp_pool); i++) {
@@ -4453,7 +4453,7 @@ int bt_smp_le_oob_generate_sc_data(struct bt_le_oob_sc_data *le_sc_oob)
 {
 	int err;
 
-	if (!sc_local_pkey_valid) {
+	if (!sc_public_key) {
 		err = k_sem_take(&sc_local_pkey_ready, K_FOREVER);
 		if (err) {
 			return err;
@@ -4631,7 +4631,7 @@ int bt_smp_auth_pairing_confirm(struct bt_conn *conn)
 			return legacy_send_pairing_confirm(smp);
 		}
 
-		if (!sc_local_pkey_valid) {
+		if (!sc_public_key) {
 			atomic_set_bit(smp->flags, SMP_FLAG_PKEY_SEND);
 			return 0;
 		}


### PR DESCRIPTION
Most of these are backported from nimble. List of Qualification tests affected: 

MESH/NODE/PROV/BV-10-C
MESH/NODE/PROV/BI-03-C
MESH/NODE/PROV/BV-12-C
MESH/NODE/PROV/BI-13-C

```
Johan Hedberg (8):
      Bluetooth: Mesh: Fix missing protocol error timeout
      Bluetooth: Mesh: Fix Public Key mismatch error handling
      Bluetooth: Mesh: Rename reset_link() to reset_adv_link()
      Bluetooth: SMP: Make public key handling more robust
      Bluetooth: Fix public key callback management
      Bluetooth: Mesh: Generate new public key for each provisioning session
      Bluetooth: Mesh: Fix rejecting invalid remote public key
      Bluetooth: Mesh: Fix provisioning send error handling

 subsys/bluetooth/host/hci_core.c  |   9 +-
 subsys/bluetooth/host/mesh/prov.c | 207 +++++++++++++++++++++----------------
 subsys/bluetooth/host/smp.c       |  18 ++--
 3 files changed, 131 insertions(+), 103 deletions(-)
```

Fixes #17057