### PR TITLE
doc: use @rst/@endrst for ReST in comments

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -220,12 +220,8 @@ TAB_SIZE               = 8
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                = "rst=\verbatim embed:rst" \
-                         "endrst=\endverbatim" \
-                         "rststar=\verbatim embed:rst:leading-asterisk" \
-                         "endrststar=\endverbatim" \
-                         "r=\verbatim embed:rst:leading-asterisk" \
-                         "er=\endverbatim"
+ALIASES                = "rst=\verbatim embed:rst:leading-asterisk" \
+                         "endrst=\endverbatim"
 
 ALIASES 	       += "req=\xrefitem req \"Requirement\" \"Requirements\" "
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1045,10 +1045,10 @@ __syscall void k_thread_priority_set(k_tid_t thread, int prio);
  * logic.
  *
  * @note
- *    @rststar
+ *    @rst
  *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
  *    configuration.
- *    @endrststar
+ *    @endrst
  *
  * @param thread A thread on which to set the deadline
  * @param deadline A time delta, in cycle units
@@ -1066,10 +1066,10 @@ __syscall void k_thread_deadline_set(k_tid_t thread, int deadline);
  * CPUs.  The thread must not be currently runnable.
  *
  * @note
- *    @rststar
+ *    @rst
  *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
  *    configuration.
- *    @endrststar
+ *    @endrst
  *
  * @param thread Thread to operate upon
  * @return Zero on success, otherwise error code
@@ -1083,10 +1083,10 @@ int k_thread_cpu_mask_clear(k_tid_t thread);
  * thread must not be currently runnable.
  *
  * @note
- *    @rststar
+ *    @rst
  *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
  *    configuration.
- *    @endrststar
+ *    @endrst
  *
  * @param thread Thread to operate upon
  * @return Zero on success, otherwise error code
@@ -1099,10 +1099,10 @@ int k_thread_cpu_mask_enable_all(k_tid_t thread);
  * The thread must not be currently runnable.
  *
  * @note
- *    @rststar
+ *    @rst
  *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
  *    configuration.
- *    @endrststar
+ *    @endrst
  *
  * @param thread Thread to operate upon
  * @param cpu CPU index
@@ -1116,10 +1116,10 @@ int k_thread_cpu_mask_enable(k_tid_t thread, int cpu);
  * The thread must not be currently runnable.
  *
  * @note
- *    @rststar
+ *    @rst
  *    You should enable :option:`CONFIG_SCHED_DEADLINE` in your project
  *    configuration.
- *    @endrststar
+ *    @endrst
  *
  * @param thread Thread to operate upon
  * @param cpu CPU index
@@ -1658,12 +1658,12 @@ static inline void *z_impl_k_timer_user_data_get(struct k_timer *timer)
  * in milliseconds.
  *
  * @note
- *    @rststar
+ *    @rst
  *    While this function returns time in milliseconds, it does
  *    not mean it has millisecond resolution. The actual resolution depends on
  *    :option:`CONFIG_SYS_CLOCK_TICKS_PER_SEC` config option, and with the
  *    default setting of 100, system time is updated in increments of 10ms.
- *    @endrststar
+ *    @endrst
  *
  * @return Current uptime in milliseconds.
  */
@@ -1705,12 +1705,12 @@ void k_disable_sys_clock_always_on(void);
  * caller must handle possible rollovers.
  *
  * @note
- *    @rststar
+ *    @rst
  *    While this function returns time in milliseconds, it does
  *    not mean it has millisecond resolution. The actual resolution depends on
  *    :option:`CONFIG_SYS_CLOCK_TICKS_PER_SEC` config option, and with the
  *    default setting of 100, system time is updated in increments of 10ms.
- *    @endrststar
+ *    @endrst
  *
  * @return Current uptime in milliseconds.
  */

--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -515,10 +515,10 @@ void mqtt_client_init(struct mqtt_client *client);
  * @note Default protocol revision used for connection request is 3.1.1. Please
  *       set client.protocol_version = MQTT_VERSION_3_1_0 to use protocol 3.1.0.
  * @note
- *       @rststar
+ *       @rst
  *          Please modify :option:`CONFIG_MQTT_KEEPALIVE` time to override
  *          default of 1 minute.
- *       @endrststar
+ *       @endrst
  */
 int mqtt_connect(struct mqtt_client *client);
 

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -140,13 +140,13 @@ struct zsock_addrinfo {
  * @brief Create a network socket
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>`__
  * for normative description.
  * This function is also exposed as ``socket()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 __syscall int zsock_socket(int family, int type, int proto);
 
@@ -154,12 +154,12 @@ __syscall int zsock_socket(int family, int type, int proto);
  * @brief Close a network socket
  *
  * @details
- * @rststar
+ * @rst
  * Close a network socket.
  * This function is also exposed as ``close()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined (in which case it
  * may conflict with generic POSIX ``close()`` function).
- * @endrststar
+ * @endrst
  */
 __syscall int zsock_close(int sock);
 
@@ -167,14 +167,14 @@ __syscall int zsock_close(int sock);
  * @brief Shutdown socket send/receive operations
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>`__
  * for normative description, but currently this function has no effect in
  * Zephyr and provided solely for compatibility with existing code.
  * This function is also exposed as ``shutdown()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 __syscall int zsock_shutdown(int sock, int how);
 
@@ -182,13 +182,13 @@ __syscall int zsock_shutdown(int sock, int how);
  * @brief Bind a socket to a local network address
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>`__
  * for normative description.
  * This function is also exposed as ``bind()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 __syscall int zsock_bind(int sock, const struct sockaddr *addr,
 			 socklen_t addrlen);
@@ -197,13 +197,13 @@ __syscall int zsock_bind(int sock, const struct sockaddr *addr,
  * @brief Connect a socket to a peer network address
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>`__
  * for normative description.
  * This function is also exposed as ``connect()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 __syscall int zsock_connect(int sock, const struct sockaddr *addr,
 			    socklen_t addrlen);
@@ -212,13 +212,13 @@ __syscall int zsock_connect(int sock, const struct sockaddr *addr,
  * @brief Set up a STREAM socket to accept peer connections
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>`__
  * for normative description.
  * This function is also exposed as ``listen()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 __syscall int zsock_listen(int sock, int backlog);
 
@@ -226,13 +226,13 @@ __syscall int zsock_listen(int sock, int backlog);
  * @brief Accept a connection on listening socket
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>`__
  * for normative description.
  * This function is also exposed as ``accept()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 __syscall int zsock_accept(int sock, struct sockaddr *addr, socklen_t *addrlen);
 
@@ -240,13 +240,13 @@ __syscall int zsock_accept(int sock, struct sockaddr *addr, socklen_t *addrlen);
  * @brief Send data to an arbitrary network address
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>`__
  * for normative description.
  * This function is also exposed as ``sendto()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 __syscall ssize_t zsock_sendto(int sock, const void *buf, size_t len,
 			       int flags, const struct sockaddr *dest_addr,
@@ -256,13 +256,13 @@ __syscall ssize_t zsock_sendto(int sock, const void *buf, size_t len,
  * @brief Send data to a connected peer
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/send.html>`__
  * for normative description.
  * This function is also exposed as ``send()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 static inline ssize_t zsock_send(int sock, const void *buf, size_t len,
 				 int flags)
@@ -274,13 +274,13 @@ static inline ssize_t zsock_send(int sock, const void *buf, size_t len,
  * @brief Receive data from an arbitrary network address
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>`__
  * for normative description.
  * This function is also exposed as ``recvfrom()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 __syscall ssize_t zsock_recvfrom(int sock, void *buf, size_t max_len,
 				 int flags, struct sockaddr *src_addr,
@@ -290,13 +290,13 @@ __syscall ssize_t zsock_recvfrom(int sock, void *buf, size_t max_len,
  * @brief Receive data from a connected peer
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html>`__
  * for normative description.
  * This function is also exposed as ``recv()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 static inline ssize_t zsock_recv(int sock, void *buf, size_t max_len,
 				 int flags)
@@ -308,13 +308,13 @@ static inline ssize_t zsock_recv(int sock, void *buf, size_t max_len,
  * @brief Control blocking/non-blocking mode of a socket
  *
  * @details
- * @rststar
+ * @rst
  * This functions allow to (only) configure a socket for blocking or
  * non-blocking operation (O_NONBLOCK).
  * This function is also exposed as ``fcntl()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined (in which case
  * it may conflict with generic POSIX ``fcntl()`` function).
- * @endrststar
+ * @endrst
  */
 __syscall int zsock_fcntl(int sock, int cmd, int flags);
 
@@ -322,7 +322,7 @@ __syscall int zsock_fcntl(int sock, int cmd, int flags);
  * @brief Efficiently poll multiple sockets for events
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html>`__
  * for normative description. (In Zephyr this function works only with
@@ -330,7 +330,7 @@ __syscall int zsock_fcntl(int sock, int cmd, int flags);
  * This function is also exposed as ``poll()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined (in which case
  * it may conflict with generic POSIX ``poll()`` function).
- * @endrststar
+ * @endrst
  */
 __syscall int zsock_poll(struct zsock_pollfd *fds, int nfds, int timeout);
 
@@ -338,7 +338,7 @@ __syscall int zsock_poll(struct zsock_pollfd *fds, int nfds, int timeout);
  * @brief Get various socket options
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html>`__
  * for normative description. In Zephyr this function supports a subset of
@@ -347,7 +347,7 @@ __syscall int zsock_poll(struct zsock_pollfd *fds, int nfds, int timeout);
  * of existing code).
  * This function is also exposed as ``getsockopt()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 int zsock_getsockopt(int sock, int level, int optname,
 		     void *optval, socklen_t *optlen);
@@ -356,7 +356,7 @@ int zsock_getsockopt(int sock, int level, int optname,
  * @brief Set various socket options
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html>`__
  * for normative description. In Zephyr this function supports a subset of
@@ -365,7 +365,7 @@ int zsock_getsockopt(int sock, int level, int optname,
  * of existing code).
  * This function is also exposed as ``setsockopt()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 int zsock_setsockopt(int sock, int level, int optname,
 		     const void *optval, socklen_t optlen);
@@ -374,13 +374,13 @@ int zsock_setsockopt(int sock, int level, int optname,
  * @brief Get socket name
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>`__
  * for normative description.
  * This function is also exposed as ``getsockname()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 __syscall int zsock_getsockname(int sock, struct sockaddr *addr,
 				socklen_t *addrlen);
@@ -389,13 +389,13 @@ __syscall int zsock_getsockname(int sock, struct sockaddr *addr,
  * @brief Get local host name
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/gethostname.html>`__
  * for normative description.
  * This function is also exposed as ``gethostname()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 __syscall int zsock_gethostname(char *buf, size_t len);
 
@@ -403,13 +403,13 @@ __syscall int zsock_gethostname(char *buf, size_t len);
  * @brief Convert network address from internal to numeric ASCII form
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/inet_ntop.html>`__
  * for normative description.
  * This function is also exposed as ``inet_ntop()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 static inline char *zsock_inet_ntop(sa_family_t family, const void *src,
 				    char *dst, size_t size)
@@ -421,13 +421,13 @@ static inline char *zsock_inet_ntop(sa_family_t family, const void *src,
  * @brief Convert network address from numeric ASCII form to internal representation
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/inet_pton.html>`__
  * for normative description.
  * This function is also exposed as ``inet_pton()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 __syscall int zsock_inet_pton(sa_family_t family, const char *src, void *dst);
 
@@ -459,13 +459,13 @@ __syscall int z_zsock_getaddrinfo_internal(const char *host,
  * @brief Resolve a domain name to one or more network addresses
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>`__
  * for normative description.
  * This function is also exposed as ``getaddrinfo()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 int zsock_getaddrinfo(const char *host, const char *service,
 		      const struct zsock_addrinfo *hints,
@@ -475,13 +475,13 @@ int zsock_getaddrinfo(const char *host, const char *service,
  * @brief Free results returned by zsock_getaddrinfo()
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/freeaddrinfo.html>`__
  * for normative description.
  * This function is also exposed as ``freeaddrinfo()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 static inline void zsock_freeaddrinfo(struct zsock_addrinfo *ai)
 {
@@ -492,13 +492,13 @@ static inline void zsock_freeaddrinfo(struct zsock_addrinfo *ai)
  * @brief Convert zsock_getaddrinfo() error code to textual message
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/gai_strerror.html>`__
  * for normative description.
  * This function is also exposed as ``gai_strerror()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 const char *zsock_gai_strerror(int errcode);
 
@@ -524,13 +524,13 @@ const char *zsock_gai_strerror(int errcode);
  * @brief Resolve a network address to a domain name or ASCII address
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/getnameinfo.html>`__
  * for normative description.
  * This function is also exposed as ``getnameinfo()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 int zsock_getnameinfo(const struct sockaddr *addr, socklen_t addrlen,
 		      char *host, socklen_t hostlen,

--- a/include/net/socket_select.h
+++ b/include/net/socket_select.h
@@ -35,7 +35,7 @@ typedef struct zsock_fd_set {
  * @brief Legacy function to poll multiple sockets for events
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/select.html>`__
  * for normative description. This function is provided to ease porting of
@@ -45,7 +45,7 @@ typedef struct zsock_fd_set {
  * This function is also exposed as ``select()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined (in which case
  * it may conflict with generic POSIX ``select()`` function).
- * @endrststar
+ * @endrst
  */
 int zsock_select(int nfds, zsock_fd_set *readfds, zsock_fd_set *writefds,
 		 zsock_fd_set *exceptfds, struct zsock_timeval *timeout);
@@ -57,13 +57,13 @@ int zsock_select(int nfds, zsock_fd_set *readfds, zsock_fd_set *writefds,
  * @brief Initialize (clear) fd_set
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/select.html>`__
  * for normative description.
  * This function is also exposed as ``FD_ZERO()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 void ZSOCK_FD_ZERO(zsock_fd_set *set);
 
@@ -71,13 +71,13 @@ void ZSOCK_FD_ZERO(zsock_fd_set *set);
  * @brief Check whether socket is a member of fd_set
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/select.html>`__
  * for normative description.
  * This function is also exposed as ``FD_ISSET()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 int ZSOCK_FD_ISSET(int fd, zsock_fd_set *set);
 
@@ -85,13 +85,13 @@ int ZSOCK_FD_ISSET(int fd, zsock_fd_set *set);
  * @brief Remove socket from fd_set
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/select.html>`__
  * for normative description.
  * This function is also exposed as ``FD_CLR()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 void ZSOCK_FD_CLR(int fd, zsock_fd_set *set);
 
@@ -99,13 +99,13 @@ void ZSOCK_FD_CLR(int fd, zsock_fd_set *set);
  * @brief Add socket to fd_set
  *
  * @details
- * @rststar
+ * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/select.html>`__
  * for normative description.
  * This function is also exposed as ``FD_SET()``
  * if :option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
- * @endrststar
+ * @endrst
  */
 void ZSOCK_FD_SET(int fd, zsock_fd_set *set);
 

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -852,11 +852,11 @@ void shell_help(const struct shell *shell);
 
  *
  * @param[in] shell	Pointer to the shell instance.
- *			@rststar
+ *			@rst
  *			It can be NULL when
  *			the :option:`CONFIG_SHELL_BACKEND_DUMMY` option is
  *			enabled.
- *			@endrststar
+ *			@endrst
  * @param[in] cmd	Command to be executed.
  *
  * @returns		Result of the execution


### PR DESCRIPTION
Folks found the use of ``@rststar``/``@endrststar`` non-intuitive (wanted to
use ``@rststart``).  The "star" was there indicating the doxygen comment
lines had a leading asterisk that needed to be stripped, but since our
commenting convention is to use the leading asterisk on continuation
lines, the leading asterisk is always there.  So, change the doxygen
alias to the more expected ``@rst``/``@endrst``.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>