### PR TITLE
CODEOWNERS: remove non-existing path

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@
 /arch/arc/                                @vonhust @ruuddw
 /arch/arm/                                @MaureenHelm @galak
 /arch/arm/core/cortex_m/cmse/             @ioannisg
-/arch/arm/include/cortex_m/cmse/          @ioannisg
+arch/arm/include/cortex_m/cmse.h          @ioannisg
 /soc/arm/                                 @MaureenHelm @galak
 /soc/arm/arm/mps2/                        @fvincenzo
 /soc/arm/atmel_sam/sam4s/                 @fallrisk


### PR DESCRIPTION
arch/arm/include/cortex_m/cmse/ does not exist in the tree.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>