### PR TITLE
tests: thread_apis: exercise some system calls

### DIFF
--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -214,7 +214,7 @@ void test_main(void)
 			 ztest_unit_test(test_threads_spawn_forever),
 			 ztest_unit_test(test_thread_start),
 			 ztest_unit_test(test_threads_suspend_resume_cooperative),
-			 ztest_unit_test(test_threads_suspend_resume_preemptible),
+			 ztest_user_unit_test(test_threads_suspend_resume_preemptible),
 			 ztest_unit_test(test_threads_priority_set),
 			 ztest_user_unit_test(test_threads_abort_self),
 			 ztest_user_unit_test(test_threads_abort_others),

--- a/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
@@ -10,7 +10,7 @@
 
 K_THREAD_STACK_EXTERN(tstack);
 extern struct k_thread tdata;
-static int last_prio;
+static ZTEST_BMEM int last_prio;
 
 static void thread_entry(void *p1, void *p2, void *p3)
 {
@@ -19,8 +19,6 @@ static void thread_entry(void *p1, void *p2, void *p3)
 
 static void threads_suspend_resume(int prio)
 {
-	int old_prio = k_thread_priority_get(k_current_get());
-
 	/* set current thread */
 	last_prio = prio;
 	k_thread_priority_set(k_current_get(), last_prio);
@@ -30,7 +28,7 @@ static void threads_suspend_resume(int prio)
 
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 				      thread_entry, NULL, NULL, NULL,
-				      create_prio, 0, 0);
+				      create_prio, K_USER, 0);
 	/* checkpoint: suspend current thread */
 	k_thread_suspend(tid);
 	k_sleep(100);
@@ -40,11 +38,6 @@ static void threads_suspend_resume(int prio)
 	k_sleep(100);
 	/* checkpoint: created thread should be executed after resume */
 	zassert_true(last_prio == create_prio, NULL);
-
-	k_thread_abort(tid);
-
-	/* restore environment */
-	k_thread_priority_set(k_current_get(), old_prio);
 }
 
 /*test cases*/


### PR DESCRIPTION
We had no system call coverage for k_thread_suspend
and k_thread_resume.

Some unnecessary cleanup tasks in the test case have
been removed.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>