### PR TITLE
tests: common: cover k_cycle_get_32() syscall

### DIFF
--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -82,7 +82,7 @@ void test_main(void)
 			 ztest_unit_test(test_dlist),
 			 ztest_unit_test(test_intmath),
 			 ztest_unit_test(test_timeout_order),
-			 ztest_unit_test(test_clock_uptime),
+			 ztest_user_unit_test(test_clock_uptime),
 			 ztest_unit_test(test_clock_cycle),
 			 ztest_unit_test(test_version),
 			 ztest_unit_test(test_multilib),


### PR DESCRIPTION
We had plenty of coverage for k_cycle_get(), but not its
32-bit variant. Run a case in user mode so that the system
call handler gets covered.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>