### PR TITLE
libc:types: Remove wrong definition

### DIFF
--- a/lib/libc/minimal/include/sys/types.h
+++ b/lib/libc/minimal/include/sys/types.h
@@ -15,9 +15,7 @@ typedef unsigned int mode_t;
 #if !defined(__ssize_t_defined)
 #define __ssize_t_defined
 
-#define unsigned signed
 typedef __SIZE_TYPE__ ssize_t;
-#undef unsigned
 
 #endif
 


### PR DESCRIPTION
types.h was wrongly defining unsigned as signed and following
undefining it. This definition was not being used anywhere though.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>