### PR TITLE
Settings: Fixes for compiler warnings

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -249,7 +249,7 @@ static int settings_fcb_save(struct settings_store *cs, const char *name,
 	struct settings_fcb *cf = (struct settings_fcb *)cs;
 	struct fcb_entry_ctx loc;
 	int len;
-	int rc;
+	int rc = -EINVAL;
 	int i;
 	u8_t wbs;
 

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -226,7 +226,7 @@ static int settings_line_raw_read_until(off_t seek, char *out, size_t len_req,
 	size_t exp_size, read_size;
 	u8_t rbs = settings_io_cb.rwbs;
 	off_t off;
-	int rc;
+	int rc = -EINVAL;
 
 	rem_size = len_req;
 
@@ -414,7 +414,7 @@ int settings_line_name_read(char *out, size_t len_req, size_t *len_read,
 int settings_entry_copy(void *dst_ctx, off_t dst_off, void *src_ctx,
 			off_t src_off, size_t len)
 {
-	int rc;
+	int rc = -EINVAL;
 	char buf[16];
 	size_t chunk_size;
 

--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -86,7 +86,7 @@ static int settings_cmp(char const *val, size_t val_len, void *val_read_cb_ctx,
 	size_t len_read, exp_len;
 	size_t rem;
 	char buf[16];
-	int rc;
+	int rc = -EINVAL;
 	off_t off = 0;
 
 	for (rem = val_len; rem > 0; rem -= len_read) {


### PR DESCRIPTION
@nvlsianpu
Fixes #17031:
Compiler warnings in settings module in Zephyr 1.14