### PR TITLE
Settings: Improve error handling of settings load

### DIFF
--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -328,6 +328,11 @@ int settings_line_val_read(off_t val_off, off_t off, char *out, size_t len_req,
 
 		rc = base64_decode(dec_buf, sizeof(dec_buf), &olen, enc_buf,
 				   read_size);
+
+		if (rc) {
+			return rc;
+		}
+
 		dec_buf[olen] = 0;
 
 		clen = MIN(olen + off_begin - off, rem_size);


### PR DESCRIPTION
if base64_decode function returns error, function can't continue
otherwise a fatal error will cause the thread to spin, putting the
system into an unrecoverable state

Signed-off-by: Faisal Saleem <faisal.saleem@setec.com.au>