### PR TITLE
CODEOWNERS: add / at the end of a directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -227,7 +227,7 @@
 /include/display/framebuf.h               @gnuless
 /include/drivers/bluetooth/               @joerchan @jhedberg @Vudentz
 /include/drivers/led/ht16k33.h            @henrikbrixandersen
-/include/drivers/interrupt_controller     @andrewboie @gnuless
+/include/drivers/interrupt_controller/    @andrewboie @gnuless
 /include/drivers/pcie/                    @gnuless
 /include/dt-bindings/clock/kinetis_scg.h  @henrikbrixandersen
 /include/dt-bindings/pcie/                @gnuless


### PR DESCRIPTION
missed a trailing slash at the end of what is a directory.