### PR TITLE
west.yml: update ci-tools to get codeowners renames/deletions fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -30,7 +30,7 @@ manifest:
   # Please add items below based on alphabetical order
   projects:
     - name: ci-tools
-      revision: 672cb7623b89a41370f95881290a97cccdc35cb0
+      revision: pull/70/head
       path: tools/ci-tools
     - name: esp-idf
       revision: 6835bfc741bf15e98fb7971293913f770df6081f


### PR DESCRIPTION
Namely: https://github.com/zephyrproject-rtos/ci-tools/pull/70

Signed-off-by: Marc Herbert <marc.herbert@intel.com>