### PR TITLE
kernel: mem_domain: fix warning in ASSERT expression

### DIFF
--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -47,7 +47,7 @@ static bool sane_partition(const struct k_mem_partition *part,
 		}
 #if defined(CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS)
 		/* Partitions overlap */
-		__ASSERT(false, "overlapping partitions <%x...%x>, <%x...%x>",
+		__ASSERT(false, "overlapping partitions <%lx...%x>, <%lx...%x>",
 			part->start, last,
 			parts[i].start, cur_last);
 		return false;


### PR DESCRIPTION
While fixing the ASSERT expressions in mem_domain.c to use
%lx instead of %x for uintptr_t variables, commit
f32330b22c333012cf5f771b0eae9ef378e446d4 has overlooked
one ASSERT expression specific to ARMv8-M. This causes
printk compilation warnings for ARMv8-M builds, so we
provide a fix here.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>