### PR TITLE
drivers: usb_dc_nrfx: Make USB3CV Chapter 9 Tests pass

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -64,7 +64,6 @@ menuconfig USB_NRF52840
 	select USB_DEVICE_DRIVER
 	select HAS_DTS_USB
 	select NRFX_USBD
-	select USB_DEVICE_REMOTE_WAKEUP
 	help
 	  nRF52840 USB Device Controller Driver
 

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1640,6 +1640,10 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 		return -EINVAL;
 	}
 
+	if (!ep_ctx->cfg.en) {
+		LOG_ERR("Endpoint 0x%02x is not enabled", ep);
+		return -EINVAL;
+	}
 
 	k_mutex_lock(&ctx->drv_lock, K_FOREVER);
 
@@ -1723,6 +1727,11 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 		return -EINVAL;
 	}
 
+	if (!ep_ctx->cfg.en) {
+		LOG_ERR("Endpoint 0x%02x is not enabled", ep);
+		return -EINVAL;
+	}
+
 	k_mutex_lock(&ctx->drv_lock, K_FOREVER);
 
 	bytes_to_copy = MIN(max_data_len, ep_ctx->buf.len);
@@ -1762,6 +1771,11 @@ int usb_dc_ep_read_continue(u8_t ep)
 
 	ep_ctx = endpoint_ctx(ep);
 	if (!ep_ctx) {
+		return -EINVAL;
+	}
+
+	if (!ep_ctx->cfg.en) {
+		LOG_ERR("Endpoint 0x%02x is not enabled", ep);
 		return -EINVAL;
 	}
 

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -637,8 +637,6 @@ static void ep_ctx_reset(struct nrf_usbd_ep_ctx *ep_ctx)
 	ep_ctx->buf.curr = ep_ctx->buf.data;
 	ep_ctx->buf.len  = 0U;
 
-	ep_ctx->cfg.en = false;
-
 	ep_ctx->read_complete = true;
 	ep_ctx->read_pending = false;
 	ep_ctx->write_in_progress = false;

--- a/samples/subsys/usb/hid-mouse/Kconfig
+++ b/samples/subsys/usb/hid-mouse/Kconfig
@@ -7,4 +7,7 @@
 config USB_DEVICE_PID
 	default USB_PID_HID_MOUSE_SAMPLE
 
+config USB_DEVICE_REMOTE_WAKEUP
+	default SOC_NRF52840
+
 source "Kconfig.zephyr"


### PR DESCRIPTION
This PR contains three patches that make it possible to pass USB3CV Chapter 9 Tests also with the `hid` sample.

Fixes #16326.

**usb: kconfig: nrf52840: Enable REMOTE_WAKEUP option only when needed**

This patch removes the "hard" selection of the USB_DEVICE_REMOTE_WAKEUP Kconfig option for USB devices made on the nRF52840 SoC. Now it's up to the application to decide if it wants to enable the option. This change makes it possible to pass the USB3CV Chapter 9 Tests for applications that don't use the remote wakeup feature, since when a USB device only reports that it supports this feature, and the mentioned option makes it to do so, one of the test cases expects the USB device to actually
perform the remote wakeup. And when the feature is not reported as supported, the test case is skipped.

**Revert "drivers: usb: usb_dc_nrfx: Set cfg.en to false on Reset"**

This reverts commit 03ef375.

The cfg.en flag contains only the state of the endpoint as seen by the shim. It is mainly used to enable the endpoints when the USB peripheral becomes ready for operation (and the USB stack may want to enable some endpoints earlier, especially the control ones, so the operation must be sometimes deferred). In particular, setting this flag to false has no effect on the actual state of the endpoint in the hardware. Moreover, this flag was set to false for all the endpoints, including the control ones which should not be disabled, so such operation actually fooled the shim.

**drivers: usb_dc_nrfx: Add pre-transfer checks if endpoint is enabled**

The shim didn't check if a given endpoint was enabled before requesting the nrfx_usbd driver to perform a read or write operation on it. In certain circumstances this led to nrfx_usbd driver being stuck in a loop waiting for the associated DMA transfer to complete.
