### PR TITLE
arc: logging: fix logging expression

### DIFF
--- a/arch/arc/core/mpu/arc_mpu_v2_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v2_internal.h
@@ -325,7 +325,7 @@ void arc_core_mpu_configure_mem_domain(struct k_thread *thread)
 
 	for (; region_index >= 0; region_index--) {
 		if (num_partitions) {
-			LOG_DBG("set region 0x%x 0x%x 0x%x",
+			LOG_DBG("set region 0x%x 0x%lx 0x%x",
 				region_index, pparts->start, pparts->size);
 			_region_init(region_index, pparts->start,
 			 pparts->size, pparts->attr);


### PR DESCRIPTION
Fix log expressions to use %lx instead of %x for uintptr_t variables.