### PR TITLE
mailmap: Fix entry needing both name and email replace

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -27,4 +27,4 @@ Johann Fischer <j.fischer@phytec.de>
 Jun Li <jun.r.li@intel.com>
 Xiaorui Hu <xiaorui.hu@linaro.org>
 Yannis Damigos <giannis.damigos@gmail.com> <ydamigos@iccs.gr>
-Vinayak Kariappa Chettimada <vinayak.kariappa.chettimada@nordicsemi.no> <vich@nordicsemi.no> <vinayak.kariappa@gmail.com>
+Vinayak Kariappa Chettimada <vinayak.kariappa.chettimada@nordicsemi.no> <vinayak.kariappa.chettimada@nordicsemi.no> <vich@nordicsemi.no> <vinayak.kariappa@gmail.com>


### PR DESCRIPTION
Fix mailmap entry to replace both name and multiple email
aliases.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>