### PR TITLE
boards: cc3220sf_launchxl: Use SDK OpenOCD

### DIFF
--- a/boards/arm/cc3220sf_launchxl/board.cmake
+++ b/boards/arm/cc3220sf_launchxl/board.cmake
@@ -1,8 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Use the TI OpenOCD (by default in /usr/local/openocd)
-# See the Zephyr project CC3220SF_LAUNCHXL documentation on
-# flashing prerequisites.
-set(OPENOCD "/usr/local/bin/openocd" CACHE FILEPATH "" FORCE)
-set(OPENOCD_DEFAULT_PATH ${OPENOCD}/scripts)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/cc3220sf_launchxl/support/openocd.cfg
+++ b/boards/arm/cc3220sf_launchxl/support/openocd.cfg
@@ -1,10 +1,8 @@
 #
-# TI CC3220SF-LaunchXL Evaluation Kit
+# TI CC3220SF-LaunchXL LaunchPad Evaluation Kit
 #
-source [find interface/xds110.cfg]
-transport select swd
-source [find target/ti_cc3220sf.cfg]
-if { ![using_hla] } {
-	cortex_m reset_config srst_only
-}
-adapter_khz 2500
+# Copyright (c) 2019 Linaro Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+source [find board/ti_cc3220sf_launchpad.cfg]


### PR DESCRIPTION
The zephyr SDK 0.10.1 works well for the CC3220 so lets use it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>