### PR TITLE
tests: new sanitycheck tag "emu_time"; increase some timeouts

### DIFF
--- a/samples/portability/cmsis_rtos_v2/timer_synchronization/sample.yaml
+++ b/samples/portability/cmsis_rtos_v2/timer_synchronization/sample.yaml
@@ -2,7 +2,8 @@ sample:
   name: CMSIS_RTOS_V2 Synchronization
 tests:
   sample.portability.cmsis_rtos_v2.timer_synchronization:
-    tags: cmsis_rtos_v2_synchronization
+    timeout: 60
+    tags: cmsis_rtos_v2_synchronization emu_time
     min_ram: 32
     min_flash: 34
     harness: console

--- a/tests/benchmarks/sys_kernel/testcase.yaml
+++ b/tests/benchmarks/sys_kernel/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   benchmark.kernel:
+    timeout: 120
     arch_exclude: nios2 riscv32 xtensa x86_64
     min_ram: 32
     tags: benchmark

--- a/tests/cmsis_rtos_v2/testcase.yaml
+++ b/tests/cmsis_rtos_v2/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   portability.cmsis_rtos_v2:
+    timeout: 90
     platform_exclude: qemu_x86_64
     tags: cmsis_rtos_v2
     min_ram: 32

--- a/tests/kernel/context/testcase.yaml
+++ b/tests/kernel/context/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.common:
-    tags: kernel
+    tags: kernel emu_time
     min_ram: 16

--- a/tests/kernel/critical/testcase.yaml
+++ b/tests/kernel/critical/testcase.yaml
@@ -3,6 +3,7 @@ common:
 
 tests:
   kernel.common:
+    timeout: 120
     platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
   kernel.common.nsim:
     platform_whitelist: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard

--- a/tests/kernel/fifo/fifo_usage/testcase.yaml
+++ b/tests/kernel/fifo/fifo_usage/testcase.yaml
@@ -3,4 +3,4 @@ tests:
     tags: kernel
   kernel.fifo.usage.poll:
     extra_args: CONF_FILE="prj_poll.conf"
-    tags: kernel
+    tags: kernel emu_time

--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -4,4 +4,4 @@ tests:
     platform_exclude: hexiwear_kw40z frdm_kw41z frdm_kl25z nucleo_f103rb
         nucleo_f091rc olimexino_stm32 usb_kw24d512 stm32_min_dev_blue
         stm32_min_dev_black v2m_beetle
-    tags: interrupt
+    tags: interrupt emu_time

--- a/tests/kernel/mem_pool/mem_pool_concept/testcase.yaml
+++ b/tests/kernel/mem_pool/mem_pool_concept/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   kernel.memory_pool:
-    tags: kernel mem_pool
+    timeout: 60
+    tags: kernel mem_pool emu_time
+

--- a/tests/kernel/pending/testcase.yaml
+++ b/tests/kernel/pending/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.common.timing:
     min_ram: 16
-    tags: kernel
+    tags: kernel emu_time

--- a/tests/kernel/sched/preempt/testcase.yaml
+++ b/tests/kernel/sched/preempt/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   kernel.sched.preempt:
-    tags: kernel
+    tags: kernel emu_time
     filter: not CONFIG_SMP
     platform_exclude: nrf52810_pca10040

--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  tags: emu_time
 tests:
   kernel.sched:
     extra_configs:

--- a/tests/kernel/semaphore/semaphore/testcase.yaml
+++ b/tests/kernel/semaphore/semaphore/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.semaphore:
+    timeout: 60
     min_ram: 32
     tags: kernel userspace

--- a/tests/kernel/sleep/testcase.yaml
+++ b/tests/kernel/sleep/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.common.timing:
-    tags: kernel
+    tags: kernel emu_time

--- a/tests/kernel/tickless/tickless_concept/testcase.yaml
+++ b/tests/kernel/tickless/tickless_concept/testcase.yaml
@@ -4,4 +4,4 @@ tests:
     # FIXME: This test fails sporadically on all QEMU platforms, but fails
     # consistently when coverage is enabled. Disable until 14173 is fixed.
     platform_exclude: qemu_x86_coverage
-    tags: kernel
+    tags: kernel emu_time

--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  tags: emu_time
 tests:
   kernel.timer:
     tags: kernel userspace

--- a/tests/kernel/workq/work_queue/testcase.yaml
+++ b/tests/kernel/workq/work_queue/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  tags: emu_time
 tests:
   kernel.workqueue:
     tags: kernel

--- a/tests/net/trickle/testcase.yaml
+++ b/tests/net/trickle/testcase.yaml
@@ -4,4 +4,4 @@ common:
 tests:
   net.trickle:
     min_ram: 12
-    tags: net trickle
+    tags: net trickle emu_time

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -1,5 +1,6 @@
 common:
-  tags: posix
+  timeout: 90
+  tags: posix emu_time
   min_ram: 64
   arch_exclude: posix
 


### PR DESCRIPTION
Quoting bug "Configure QEMU to run independent of the host clock #14173"

>   We have been struggling for years with issues related to how QEMU
>   attempts to synchronize guest timer interrupts with the host clock,
>   for example #12553. The symptom is that heavily loaded sanitycheck
>   runs have tests spuriously failing due to timing related issues.
> 
>   This creates noise in our CI runs which masks true bugs in our system
>   which manifest only intermittently, causing real issues that will
>   happen all the time at scale to be 'swept under the rug'; right now
>   any time a test fails sanitycheck retries it a few times and only
>   consecutive failures produce an error.

There's also a lot of relevant information and more links in:
"List of tests that keep failing sporadically" #12553

This new "emu_time" tag helps by letting users either select or exclude
the tests that really need accurate time to pass and have a high chance
to actually be impacted by this emulation issue. As an example, it's
only with 'sanitycheck --exclude emu_time' that I could spot and file
intermittent but non-emu_time issue #16915. As Andrew predicted above,
it was drown in emu_time noise before that.

Conversely, "--tag emu_time" can be used by developers focusing on
fixing qemu's -icount feature, for instance #14173 or others.

Even before qemu's -icount is fixed, Continuous Integration could be
split in two separate runs: A. --tag emu_time and B. --exclude
emu_time. Only A tests would be allowed retries which would stop hiding
other, unrelated intermittent issues affecting B tests.

This initial commit does not pretend to exhaustively tag all affected
tests. However it's an already functional and useful start of 14 tests
collected from and tested over weeks of local sanitycheck runs and
_partially_ reviewed by qemu clock expert Andy Ross.

This commit also increases the individual timeout of 7 tests that have
been observed to consistently take much longer than the
median (2-3s). This flags how unusually long these are, lets users
temporarily reduce the very long 60s default timeout in their local
workspace and finally should reduce the chance of them timing out on a
heavily loaded system. Set their timeout to 3-4 times the duration
observed in CI and locally.

Signed-off-by: Marc Herbert marc.herbert@intel.com