### PR TITLE
Doc: Use SDK 0.10.1 instead of 0.10.0.

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -170,18 +170,18 @@ Follow these steps to install the Zephyr SDK:
 
    .. code-block:: console
 
-      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.10.0/zephyr-sdk-0.10.0-setup.run
+      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.10.1/zephyr-sdk-0.10.1-setup.run
 
-   (You can change *0.10.0* to another version if needed; the `Zephyr
+   (You can change *0.10.1* to another version if needed; the `Zephyr
    Downloads`_ page contains all available SDK releases.)
 
 #. Run the installation binary, installing the SDK at
-   :file:`~/zephyr-sdk-0.10.0`:
+   :file:`~/zephyr-sdk-0.10.1`:
 
    .. code-block:: console
 
       cd <sdk download directory>
-      ./zephyr-sdk-0.10.0-setup.run -- -d ~/zephyr-sdk-0.10.0
+      ./zephyr-sdk-0.10.1-setup.run -- -d ~/zephyr-sdk-0.10.1
 
    You can pick another directory if you want. If this fails, make sure
    Zephyr's dependencies were installed as described in `Install Requirements
@@ -190,7 +190,7 @@ Follow these steps to install the Zephyr SDK:
 #. Set these :ref:`environment variables <env_vars>`:
 
    - set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``zephyr``
-   - set :envvar:`ZEPHYR_SDK_INSTALL_DIR` to :file:`$HOME/zephyr-sdk-0.10.0`
+   - set :envvar:`ZEPHYR_SDK_INSTALL_DIR` to :file:`$HOME/zephyr-sdk-0.10.1`
      (or wherever you chose to install the SDK)
 
 If you ever want to uninstall the SDK, just remove the directory where you


### PR DESCRIPTION
There are several critical issues with SDK 0.10.0. For the detail,
please refer to the link below.

https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.10.1

Signed-off-by: Steven Wang <steven.l.wang@linux.intel.com>