### PR TITLE
Add timeout to socket connect call

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -30,6 +30,15 @@ config NET_SOCKETS_POLL_MAX
 	help
 	  Maximum number of entries supported for poll() call.
 
+config NET_SOCKETS_CONNECT_TIMEOUT
+	int "Timeout value in milliseconds to CONNECT"
+	default 3000
+	range 0 60000
+	help
+	 This variable specifies time in milliseconds after connect()
+	 API call will timeout if we have not received SYN-ACK from
+	 peer.
+
 config NET_SOCKETS_DNS_TIMEOUT
 	int "Timeout value in milliseconds for DNS queries"
 	default 2000

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -325,8 +325,9 @@ Z_SYSCALL_HANDLER(zsock_bind, sock, addr, addrlen)
 int zsock_connect_ctx(struct net_context *ctx, const struct sockaddr *addr,
 		      socklen_t addrlen)
 {
-	SET_ERRNO(net_context_connect(ctx, addr, addrlen, NULL, K_FOREVER,
-				      NULL));
+	SET_ERRNO(net_context_connect(ctx, addr, addrlen, NULL,
+			      K_MSEC(CONFIG_NET_SOCKETS_CONNECT_TIMEOUT),
+			      NULL));
 	SET_ERRNO(net_context_recv(ctx, zsock_received_cb, K_NO_WAIT,
 				   ctx->user_data));
 


### PR DESCRIPTION
Current socket connect call implementation always takes K_FOREVER timeout value, which blocks TCP connections in case failure. TCP connections waits until it receives SYN ACK. If there is no SYC ACK means, connect call is blocked forever.

Added a Kconfig option to define timeout value. Default value is 3000 milliseconds. User can modify it.

There are issues reported on this behavior. https://github.com/zephyrproject-rtos/zephyr/issues/9944

I tried to refer to this RFC https://tools.ietf.org/html/rfc5482. But there is no such specific timeout value mentioned here. 