### PR TITLE
drivers/usb/device: stm32: Remove reference to unsupported low speed

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -322,8 +322,6 @@ static u32_t usb_dc_stm32_get_maximum_speed(void)
 #else
 		speed = USB_OTG_SPEED_FULL;
 #endif /* DT_COMPAT_ST_STM32_USBPHYC && DT_USB_HS_BASE_ADDRESS */
-	} else if (!strncmp(DT_USB_MAXIMUM_SPEED, "low-speed", 9)) {
-		speed = USB_OTG_SPEED_LOW;
 	} else {
 		LOG_DBG("Unsupported maximum speed defined in device tree. "
 			"USB controller will default to its maximum HW "


### PR DESCRIPTION
Low speed isn't supported in device mode for any of the STM32
references.
Remove the code that refer to it.

Fixes #17114

Signed-off-by: Johann Fischer <j.fischer@phytec.de>
Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>