### PR TITLE
Arch arm userspace fix bad syscall dispatch

### DIFF
--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -451,7 +451,7 @@ _do_syscall:
     ldr r1, =z_arm_do_syscall
     str r1, [r0, #24]   /* overwrite the PC to point to z_arm_do_syscall */
 
-    /* validate syscall limit, only set priv mode if valid */
+    /* validate syscall limit */
     ldr ip, =K_SYSCALL_LIMIT
     cmp r6, ip
     blt valid_syscall_id
@@ -459,6 +459,8 @@ _do_syscall:
     /* bad syscall id.  Set arg0 to bad id and set call_id to SYSCALL_BAD */
     str r6, [r0, #0]
     ldr r6, =K_SYSCALL_BAD
+
+    /* Bad syscalls treated as valid syscalls with ID K_SYSCALL_BAD. */
 
 valid_syscall_id:
     push {r0, r1}

--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -187,7 +187,6 @@ SECTION_FUNC(TEXT, z_arm_do_syscall)
     /* fixup stack frame on unprivileged stack, adding ssf */
     mov ip, sp
     push {r4,r5,ip,lr}
-    b dispatch_syscall
 
 valid_syscall:
     /* setup privileged stack */
@@ -226,7 +225,6 @@ valid_syscall:
     /* push args to complete stack frame */
     push {r4,r5}
 
-dispatch_syscall:
     ldr ip, =_k_syscall_table
     lsl r6, #2
     add ip, r6


### PR DESCRIPTION
We need to treat bad system calls as a normal syscall with ID K_SYSCALL_BAD. This means we need to switch to PRIV stack as usual. Currently a bad sys call may lead to stack overflow in Armv8m under certain conditions. This was discovered when we added test coverage for bad system calls in the Userspace kernel test.