### PR TITLE
dts: remove unused clock-controller property

### DIFF
--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -51,8 +51,6 @@
 			compatible = "nxp,k64f-mcg";
 			reg = <0x40064000 0xd>;
 			system-clock-frequency = <120000000>;
-
-			clock-controller;
 		};
 
 		clock-controller@40065000 {
@@ -78,7 +76,6 @@
 			clk-divider-flexbus = <3>;
 			clk-divider-flash = <5>;
 
-			clock-controller;
 			#clock-cells = <3>;
 		};
 

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -62,7 +62,6 @@
 			compatible = "nxp,kinetis-scg";
 			reg = <0x40064000 0x1000>;
 			label = "SCG";
-			clock-controller;
 			#clock-cells = <1>;
 		};
 
@@ -70,7 +69,6 @@
 			compatible = "nxp,kinetis-pcc";
 			reg = <0x40065000 0x1000>;
 			label = "PCC";
-			clock-controller;
 			#clock-cells = <1>;
 		};
 

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -76,7 +76,6 @@
 			clk-divider-flexbus = <3>;
 			clk-divider-flash = <5>;
 
-			clock-controller;
 			#clock-cells = <3>;
 		};
 

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -29,8 +29,6 @@
 			compatible = "nxp,k64f-mcg";
 			reg = <0x40064000 0xd>;
 			system-clock-frequency = <48000000>;
-
-			clock-controller;
 		};
 
 		clock-controller@40065000 {
@@ -55,7 +53,6 @@
 			clk-divider-bus = <1>;
 			clk-divider-flash = <2>;
 
-			clock-controller;
 			#clock-cells = <3>;
 		};
 

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -28,7 +28,6 @@
 			compatible = "nxp,kw41z-mcg";
 			reg = <0x40064000 0x13>;
 			system-clock-frequency = <48000000>;
-			clock-controller;
 		};
 
 		clock-controller@40065000 {
@@ -48,7 +47,6 @@
 			reg = <0x40047000 0x1060>;
 			label = "SIM";
 
-			clock-controller;
 			#clock-cells = <3>;
 		};
 

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -28,7 +28,6 @@
 			compatible = "nxp,kw41z-mcg";
 			reg = <0x40064000 0x13>;
 			system-clock-frequency = <48000000>;
-			clock-controller;
 		};
 
 		clock-controller@40065000 {
@@ -51,7 +50,6 @@
 			reg = <0x40047000 0x1060>;
 			label = "SIM";
 
-			clock-controller;
 			#clock-cells = <3>;
 		};
 

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -86,7 +86,6 @@
 			reg = <0x400fc000 0x4000>;
 			label = "CCM";
 
-			clock-controller;
 			#clock-cells = <3>;
 		};
 

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -47,7 +47,6 @@
 
 		rcc: rcc@40021000 {
 			compatible = "st,stm32-rcc";
-			clocks-controller;
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
 			label = "STM32_CLK_RCC";

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -35,7 +35,6 @@
 	soc {
 		rcc: rcc@40021000 {
 			compatible = "st,stm32-rcc";
-			clocks-controller;
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
 			label = "STM32_CLK_RCC";

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -46,7 +46,6 @@
 
 		rcc: rcc@40023800 {
 			compatible = "st,stm32-rcc";
-			clocks-controller;
 			#clock-cells = <2>;
 			reg = <0x40023800 0x400>;
 			label = "STM32_CLK_RCC";

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -48,7 +48,6 @@
 
 		rcc: rcc@40021000 {
 			compatible = "st,stm32-rcc";
-			clocks-controller;
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
 			label = "STM32_CLK_RCC";

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -47,7 +47,6 @@
 
 		rcc: rcc@40023800 {
 			compatible = "st,stm32-rcc";
-			clocks-controller;
 			#clock-cells = <2>;
 			reg = <0x40023800 0x400>;
 			label = "STM32_CLK_RCC";

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -49,7 +49,6 @@
 		};
 		rcc: rcc@40023800 {
 			compatible = "st,stm32-rcc";
-			clocks-controller;
 			#clock-cells = <2>;
 			reg = <0x40023800 0x400>;
 			label = "STM32_CLK_RCC";

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -47,7 +47,6 @@
 
 		rcc: rcc@40021000 {
 			compatible = "st,stm32-rcc";
-			clocks-controller;
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
 			label = "STM32_CLK_RCC";

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -144,7 +144,6 @@
 
 		rcc: rcc@40023800 {
 			compatible = "st,stm32-rcc";
-			clocks-controller;
 			#clock-cells = <2>;
 			reg = <0x40023800 0x400>;
 			label = "STM32_CLK_RCC";

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -49,7 +49,6 @@
 
 		rcc: rcc@40021000 {
 			compatible = "st,stm32-rcc";
-			clocks-controller;
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
 			label = "STM32_CLK_RCC";

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -37,7 +37,6 @@
 		rcc: rcc@50000000 {
 			compatible = "st,stm32-rcc";
 			reg = <0x50000000 0x1000>;
-			clocks-controller;
 			#clock-cells = <2>;
 			label = "STM32_CLK_RCC";
 		};

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -47,7 +47,6 @@
 
 		rcc: rcc@58000000 {
 			compatible = "st,stm32-rcc";
-			clocks-controller;
 			#clock-cells = <2>;
 			reg = <0x58000000 0x400>;
 			label = "STM32_CLK_RCC";

--- a/dts/riscv32/rv32m1.dtsi
+++ b/dts/riscv32/rv32m1.dtsi
@@ -70,7 +70,6 @@
 
 		pcc0: clock-controller@4002b000 {
 			compatible = "openisa,rv32m1-pcc";
-			clock-controller;
 			reg = <0x4002b000 0x200>;
 			label = "PCC0";
 			#clock-cells = <1>;
@@ -78,7 +77,6 @@
 
 		pcc1: clock-controller@41027000 {
 			compatible = "openisa,rv32m1-pcc";
-			clock-controller;
 			reg = <0x41027000 0x200>;
 			label = "PCC1";
 			#clock-cells = <1>;


### PR DESCRIPTION
The 'clock-controller' property isn't specified and not used for any
generation.  Lets remove it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>