### PR TITLE
drivers: apic_timer: fix include of system_timer.h

### DIFF
--- a/drivers/timer/apic_timer.c
+++ b/drivers/timer/apic_timer.c
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/system_timer.h>
+#include <drivers/timer/system_timer.h>
 #include <sys_clock.h>
 #include <spinlock.h>
-#include <drivers/loapic.h>
+#include <drivers/interrupt_controller/loapic.h>
 
 BUILD_ASSERT_MSG(!IS_ENABLED(CONFIG_SMP), "APIC timer doesn't support SMP");
 
@@ -40,7 +40,7 @@ BUILD_ASSERT_MSG(!IS_ENABLED(CONFIG_SMP), "APIC timer doesn't support SMP");
  *     found via CPUID 0x15 (n = EBX, m = EAX) on most CPUs.
  */
 
-/* These should be merged into include/drivers/loapic.h. */
+/* These should be merged into include/drivers/interrupt_controller/loapic.h. */
 
 #define DCR_DIVIDER_MASK	0x0000000F	/* divider bits */
 #define DCR_DIVIDER		0x0000000B	/* divide by 1 */

--- a/include/arch/x86/msr.h
+++ b/include/arch/x86/msr.h
@@ -241,7 +241,7 @@
  * MSRs 0x0800 to 0x0BFF are reserved for x2APIC access.
  *
  * We only record the base address here, as the local APIC code
- * knows how to find the registers, see include/drivers/loapic.h.
+ * knows how to find the registers, see include/drivers/interrupt_controller/loapic.h.
  */
 
 #define X86_X2APIC_BASE_MSR 0x0800


### PR DESCRIPTION
Fix path for system_timer.h, we moved it to include/drivers/timer/