### PR TITLE
mqtt: Allow client to override keepalive

### DIFF
--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -476,6 +476,11 @@ struct mqtt_client {
 	/** Size of transmit buffer. */
 	u32_t tx_buf_size;
 
+	/** Keepalive interval for this client in seconds.
+	 *  Default is CONFIG_MQTT_KEEPALIVE.
+	 */
+	u16_t keepalive;
+
 	/** MQTT protocol version. */
 	u8_t protocol_version;
 

--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -168,6 +168,7 @@ void mqtt_client_init(struct mqtt_client *client)
 
 	client->protocol_version = MQTT_VERSION_3_1_1;
 	client->clean_session = 1U;
+	client->keepalive = MQTT_KEEPALIVE;
 }
 
 int mqtt_connect(struct mqtt_client *client)
@@ -562,8 +563,8 @@ int mqtt_live(struct mqtt_client *client)
 		elapsed_time = mqtt_elapsed_time_in_ms_get(
 					client->internal.last_activity);
 
-		if ((MQTT_KEEPALIVE > 0) &&
-		    (elapsed_time >= (MQTT_KEEPALIVE * 1000))) {
+		if ((client->keepalive > 0) &&
+		    (elapsed_time >= (client->keepalive * 1000))) {
 			(void)mqtt_ping(client);
 		}
 	}

--- a/subsys/net/lib/mqtt/mqtt_encoder.c
+++ b/subsys/net/lib/mqtt/mqtt_encoder.c
@@ -325,8 +325,8 @@ int connect_request_encode(const struct mqtt_client *client,
 		return err_code;
 	}
 
-	MQTT_TRC("Encoding Keep Alive Time %04x.", MQTT_KEEPALIVE);
-	err_code = pack_uint16(MQTT_KEEPALIVE, buf);
+	MQTT_TRC("Encoding Keep Alive Time %04x.", client->keepalive);
+	err_code = pack_uint16(client->keepalive, buf);
 	if (err_code != 0) {
 		return err_code;
 	}


### PR DESCRIPTION
This change will allow an MQTT client to override the compile-time
keepalive if desired.  The change is structured such that the
compile-time default will still be setup by calling mqtt_client_init,
but can be changed by the application before calling mqtt_connect if
desired.

Signed-off-by: Justin Brzozoski <justin.brzozoski@signal-fire.com>