### PR TITLE
doc: remove next/previous chapter buttons

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -190,6 +190,9 @@ rst_epilog = """
 import sphinx_rtd_theme
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme_options = {
+    'prev_next_buttons_location': None
+}
 
 if tags.has('release'):
     is_release = True


### PR DESCRIPTION
The Next/Previous chapter buttons have been confusing in the past and
recent DX studies still show that folks read these as the "Next"
document to read in some defined order.  These buttons are simply
another way to navigate through the document tree to the "Next" doc in
the table of contents.  Let's remove these buttons (again).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>