### PR TITLE
Restore app partitions order

### DIFF
--- a/scripts/gen_app_partitions.py
+++ b/scripts/gen_app_partitions.py
@@ -220,8 +220,14 @@ def main():
         else:
             partitions[ptn][LIB].append(lib)
 
-    partsorted = OrderedDict(sorted(partitions.items(),
-                                     key=lambda x: x[1][SZ], reverse=True))
+
+    # Sample partitions.items() list before sorting:
+    #   [ ('part1', {'size': 64}), ('part3', {'size': 64}, ...
+    #     ('part0', {'size': 334}) ]
+    decreasing_tuples = sorted(partitions.items(),
+                           key=lambda x: (x[1][SZ], x[0]), reverse=True)
+
+    partsorted = OrderedDict(decreasing_tuples)
 
     generate_final_linker(args.output, partsorted)
     if args.verbose:

--- a/scripts/gen_app_partitions.py
+++ b/scripts/gen_app_partitions.py
@@ -162,7 +162,7 @@ def parse_elf_file(partitions):
 def generate_final_linker(linker_file, partitions):
     string = linker_start_seq
     size_string = ''
-    for partition, item in sorted(partitions.items()):
+    for partition, item in partitions.items():
         string += data_template.format(partition)
         if LIB in item:
             for lib in item[LIB]:


### PR DESCRIPTION
This reverts commit 725abdf4304d which did get rid of randomness in the
order of the partition _names_ as claimed but regressed commit
212ec9a29a / feature #14121 and broke the previous size order which I
missed. Huge thanks to Sigvart Hovland for spotting this in a post-merge
but prompt code review.

Commit 212ec9a29a / feature #14121 already ordered partitions by
decreasing size, however it was common in samples/userspace/shared_mem/
/sample.kernel.memory_protection.shared_mem for two partitions to have
the same size and be randomly ordered between them. This adds the
partition name as a second sort key.