### PR TITLE
usb: tests: exclude reel_board platform.

### DIFF
--- a/tests/subsys/usb/device/testcase.yaml
+++ b/tests/subsys/usb/device/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   usb.device:
+    platform_exclude: reel_board
     depends_on: usb_device
     tags: usb


### PR DESCRIPTION
USB device test fails on reel_board. It does not like that it can work
on reel_board. So disable it on reel_board for now.

Signed-off-by: Steven Wang <steven.l.wang@linux.intel.com>