### PR TITLE
scripts/dts: deprecate DT_<COMPAT>_<INSTANCE ID>_BUS_<BUS>

### DIFF
--- a/scripts/dts/extract/compatible.py
+++ b/scripts/dts/extract/compatible.py
@@ -58,6 +58,7 @@ class DTCompatible(DTDirective):
                 insert_defs(node_path,
                             {compat_instance + '_BUS_' + bus.upper(): '1'},
                             {})
+                deprecated_main.append(compat_instance + '_BUS_' + bus.upper())
 
 
 ##


### PR DESCRIPTION
We don't have any uses of this form of define so deprecate it for now.
If needed this should be DT_INST_<INSTANCE ID>_<COMPAT>_BUS_<BUS>.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>