### PR TITLE
Bluetooth: controller: Fix assert during DLE

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -7135,10 +7135,6 @@ static inline u32_t event_conn_upd_prep(struct connection *conn,
 			conn->procedure_expire = 0U;
 		}
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
-		/* Reset ticker_id_prepare as role is not continued further
-		 * due to conn update at this event.
-		 */
-		_radio.ticker_id_prepare = 0U;
 
 		/* reset mutex */
 		if (_radio.conn_upd == conn) {
@@ -8524,8 +8520,13 @@ static void event_connection_prepare(u32_t ticks_at_expire,
 
 		switch (conn->llcp_type) {
 		case LLCP_CONN_UPD:
-			if (event_conn_upd_prep(conn, event_counter,
-						ticks_at_expire) == 0) {
+			if (!event_conn_upd_prep(conn, event_counter,
+						 ticks_at_expire)) {
+				/* Reset ticker_id_prepare as role is not
+				 * continued further due to conn update at
+				 * this event.
+				 */
+				_radio.ticker_id_prepare = 0U;
 				return;
 			}
 			break;

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -8504,6 +8504,7 @@ static void event_connection_prepare(u32_t ticks_at_expire,
 				 * lets skip this event and try in the next
 				 * event.
 				 */
+				_radio.ticker_id_prepare = 0U;
 				return;
 			}
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */


### PR DESCRIPTION
Fix assert in controller checking ticker_id_prepare = 0 when
a scanner and connection are active, and the connection is
skipping events in order to resize Rx buffers.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>