### PR TITLE
west.yml: Update hal_stm32 to fix I2C_SPEED_FAST redefinition

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -51,7 +51,7 @@ manifest:
       revision: 0ec40aed8087f26bd9ac1b70fb5a6c326a6451aa
       path: modules/hal/st
     - name: hal_stm32
-      revision: 8066e1d2477860a106e3c2e6ca841b4abbfbaad2
+      revision: a08f60768042be9b017796e13c5bb7f977d51a92
       path: modules/hal/stm32
     - name: libmetal
       revision: 45e630d6152824f807d3f919958605c4626cbdff


### PR DESCRIPTION
On some STM32 series, I2C HAL defines I2C_SPEED_STANDARD and
I2C_SPEED_FAST. These definitions conflict with Zephyr I2C API.

Since Zephyr I2C STM32 driver uses LL API, we can disable I2C HAL.
Disable I2C HAL for L1 and F2 series. Deactivation is already done
2 other impacted series F1 and F4.

Additionally, on F1 series, add the commented definition line to
make the change more visible.

Requires https://github.com/zephyrproject-rtos/hal_stm32/pull/16

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>