### PR TITLE
Arch arm userspace syscalls stack fix

### DIFF
--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -451,7 +451,7 @@ _do_syscall:
     ldr r1, =z_arm_do_syscall
     str r1, [r0, #24]   /* overwrite the PC to point to z_arm_do_syscall */
 
-    /* validate syscall limit, only set priv mode if valid */
+    /* validate syscall limit */
     ldr ip, =K_SYSCALL_LIMIT
     cmp r6, ip
     blt valid_syscall_id
@@ -459,6 +459,8 @@ _do_syscall:
     /* bad syscall id.  Set arg1 to bad id and set call_id to SYSCALL_BAD */
     str r6, [r0, #0]
     ldr r6, =K_SYSCALL_BAD
+
+    /* Bad syscalls treated as valid syscalls with ID K_SYSCALL_BAD. */
 
 valid_syscall_id:
     push {r0, r1}

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -426,7 +426,7 @@ _oops:
 
 #if defined(CONFIG_USERSPACE)
     /*
-     * System call will setup a jump to the _do_arm_syscall function
+     * System call will setup a jump to the z_arm_do_syscall() function
      * when the SVC returns via the bx lr.
      *
      * There is some trickery involved here because we have to preserve
@@ -456,7 +456,7 @@ _do_syscall:
     cmp r6, ip
     blt valid_syscall_id
 
-    /* bad syscall id.  Set arg0 to bad id and set call_id to SYSCALL_BAD */
+    /* bad syscall id.  Set arg1 to bad id and set call_id to SYSCALL_BAD */
     str r6, [r0, #0]
     ldr r6, =K_SYSCALL_BAD
 

--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -174,6 +174,44 @@ SECTION_FUNC(TEXT,z_arm_userspace_enter)
  *
  */
 SECTION_FUNC(TEXT, z_arm_do_syscall)
+
+    /* The function is executing in privileged mode. This implies that we
+     * shall not be allowed to use the thread's default unprivileged stack,
+     * (i.e push to or pop from it), to avoid a possible stack corruption.
+     *
+     * Rationale: since we execute in PRIV mode and no MPU guard or PSPLIM
+     * register is guarding the end of the default stack, we won't be able
+     * to detect any stack overflows.
+     */
+
+#if defined(CONFIG_BUILTIN_STACK_GUARD)
+    /* clear stack pointer limit before setting the PSP */
+    mov ip, #0
+    msr PSPLIM, ip
+#endif
+
+    /* setup privileged stack */
+    ldr ip, =_kernel
+    ldr ip, [ip, #_kernel_offset_to_current]
+    ldr ip, [ip, #_thread_offset_to_priv_stack_start]    /* priv stack ptr */
+    add ip, #CONFIG_PRIVILEGED_STACK_SIZE
+
+    /* Store current SP and LR at the beginning of the priv stack */
+    subs ip, #8
+    str sp, [ip, #0]
+    str lr, [ip, #4]
+
+    /* switch to privileged stack */
+    msr PSP, ip
+
+#if defined(CONFIG_BUILTIN_STACK_GUARD)
+    /* Set stack pointer limit (needed in privileged mode) */
+    ldr ip, =_kernel
+    ldr ip, [ip, #_kernel_offset_to_current]
+    ldr ip, [ip, #_thread_offset_to_priv_stack_start]    /* priv stack ptr */
+    msr PSPLIM, ip
+#endif
+
     /*
      * r0-r5 contain arguments
      * r6 contains call_id
@@ -184,45 +222,12 @@ SECTION_FUNC(TEXT, z_arm_do_syscall)
     bne valid_syscall
 
     /* BAD SYSCALL path */
-    /* fixup stack frame on unprivileged stack, adding ssf */
+    /* fixup stack frame on the privileged stack, adding ssf */
     mov ip, sp
     push {r4,r5,ip,lr}
     b dispatch_syscall
 
 valid_syscall:
-    /* setup privileged stack */
-    push {r6}
-    ldr r6, =_kernel
-    ldr r6, [r6, #_kernel_offset_to_current]
-    ldr ip, [r6, #_thread_offset_to_priv_stack_start]    /* priv stack ptr */
-    ldr r6, =CONFIG_PRIVILEGED_STACK_SIZE
-    add ip, r6
-    pop {r6}
-    subs ip, #8
-    str sp, [ip, #0]
-    str lr, [ip, #4]
-
-#if defined(CONFIG_BUILTIN_STACK_GUARD)
-    /* clear stack pointer limit before setting the PSP */
-    push {r3}
-    mov r3, #0
-    msr PSPLIM, r3
-    pop {r3}
-#endif
-
-    /* switch to privileged stack */
-    msr PSP, ip
-
-#if defined(CONFIG_BUILTIN_STACK_GUARD)
-    /* Set stack pointer limit (needed in privileged mode) */
-    push {r6}
-    ldr r6, =_kernel
-    ldr r6, [r6, #_kernel_offset_to_current]
-    ldr r6, [r6, #_thread_offset_to_priv_stack_start]    /* priv stack ptr */
-    msr PSPLIM, r6
-    pop {r6}
-#endif
-
     /* push args to complete stack frame */
     push {r4,r5}
 

--- a/kernel/include/syscall_handler.h
+++ b/kernel/include/syscall_handler.h
@@ -519,7 +519,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
  * the bolierplate. The macros ensure that the seventh argument is named
  * "ssf" as this is now referenced by various other Z_SYSCALL macros.
  *
- * Use the Z_SYSCALL_HANDLER(name_, arg0, ..., arg6) variant, as it will
+ * Use the Z_SYSCALL_HANDLER(name_, arg1, ..., arg6) variant, as it will
  * automatically deduce the correct version of Z__SYSCALL_HANDLERn() to
  * use depending on the number of arguments.
  */


### PR DESCRIPTION
In addition to some minor typo fixes, this patch forces z_arm_do_syscall to only use the privilege stack for system calls.

Fixes #17177