### PR TITLE
board: suppress useless config in Avenger96 board

### DIFF
--- a/boards/arm/96b_avenger96/96b_avenger96_defconfig
+++ b/boards/arm/96b_avenger96/96b_avenger96_defconfig
@@ -26,6 +26,3 @@ CONFIG_RAM_CONSOLE_BUFFER_SIZE=1024
 
 # uart console (overrides remote proc console)
 CONFIG_UART_CONSOLE=n
-
-# remoteproc resource table
-CONFIG_RPROC_RSC_TABLE=y


### PR DESCRIPTION
The CONFIG_RPROC_RSC_TABLE is selected when RAM_CONSOLE
is activated, no need to declare it. 
Notice that current declaration results in failed tests for PR #16985:
https://app.shippable.com/github/zephyrproject-rtos/zephyr/runs/44550/1/console

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>