### PR TITLE
kernel: delete k_futex_init()

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2127,17 +2127,6 @@ struct z_futex_data {
  */
 
 /**
- * @brief Initialize a futex.
- *
- * This routine initializes a futex object, prior to its first use.
- *
- * @param futex Address of the k_futex.
- *
- * @return N/A
- */
-__syscall void k_futex_init(struct k_futex *futex);
-
-/**
  * @brief Pend the current thread on a futex
  *
  * Tests that the supplied futex contains the expected value, and if so,

--- a/kernel/futex.c
+++ b/kernel/futex.c
@@ -24,23 +24,6 @@ static struct z_futex_data *k_futex_find_data(struct k_futex *futex)
 	return (struct z_futex_data *)obj->data;
 }
 
-void z_impl_k_futex_init(struct k_futex *futex)
-{
-	futex->val = 0U;
-	z_object_init(futex);
-}
-
-Z_SYSCALL_HANDLER(k_futex_init, futex)
-{
-	if (Z_SYSCALL_MEMORY_WRITE(futex, sizeof(struct k_futex)) != 0) {
-		return -EACCES;
-	}
-
-	z_impl_k_futex_init((struct k_futex *)futex);
-
-	return 0;
-}
-
 int z_impl_k_futex_wake(struct k_futex *futex, bool wake_all)
 {
 	k_spinlock_key_t key;

--- a/tests/kernel/mem_protect/futex/src/main.c
+++ b/tests/kernel/mem_protect/futex/src/main.c
@@ -157,8 +157,7 @@ void test_futex_wait_forever(void)
 {
 	timeout = K_FOREVER;
 
-	k_futex_init(&simple_futex);
-	atomic_inc(&simple_futex.val);
+	atomic_set(&simple_futex.val, 1);
 
 	k_thread_create(&futex_tid, stack_1, STACK_SIZE,
 			futex_wait_task, &timeout, NULL, NULL,
@@ -178,8 +177,7 @@ void test_futex_wait_timeout(void)
 {
 	timeout = K_MSEC(50);
 
-	k_futex_init(&simple_futex);
-	atomic_inc(&simple_futex.val);
+	atomic_set(&simple_futex.val, 1);
 
 	k_thread_create(&futex_tid, stack_1, STACK_SIZE,
 			futex_wait_task, &timeout, NULL, NULL,
@@ -199,8 +197,7 @@ void test_futex_wait_nowait(void)
 {
 	timeout = K_NO_WAIT;
 
-	k_futex_init(&simple_futex);
-	atomic_inc(&simple_futex.val);
+	atomic_set(&simple_futex.val, 1);
 
 	k_thread_create(&futex_tid, stack_1, STACK_SIZE,
 			futex_wait_task, &timeout, NULL, NULL,
@@ -223,8 +220,7 @@ void test_futex_wait_forever_wake(void)
 	woken = 1;
 	timeout = K_FOREVER;
 
-	k_futex_init(&simple_futex);
-	atomic_inc(&simple_futex.val);
+	atomic_set(&simple_futex.val, 1);
 
 	k_thread_create(&futex_tid, stack_1, STACK_SIZE,
 			futex_wait_wake_task, &timeout, NULL, NULL,
@@ -257,8 +253,7 @@ void test_futex_wait_timeout_wake(void)
 	woken = 1;
 	timeout = K_MSEC(100);
 
-	k_futex_init(&simple_futex);
-	atomic_inc(&simple_futex.val);
+	atomic_set(&simple_futex.val, 1);
 
 	k_thread_create(&futex_tid, stack_1, STACK_SIZE,
 			futex_wait_wake_task, &timeout, NULL, NULL,
@@ -291,8 +286,7 @@ void test_futex_wait_nowait_wake(void)
 	woken = 0;
 	timeout = K_NO_WAIT;
 
-	k_futex_init(&simple_futex);
-	atomic_inc(&simple_futex.val);
+	atomic_set(&simple_futex.val, 1);
 
 	k_thread_create(&futex_tid, stack_1, STACK_SIZE,
 			futex_wait_wake_task, &timeout, NULL, NULL,
@@ -318,8 +312,7 @@ void test_futex_wait_forever_wake_from_isr(void)
 {
 	timeout = K_FOREVER;
 
-	k_futex_init(&simple_futex);
-	atomic_inc(&simple_futex.val);
+	atomic_set(&simple_futex.val, 1);
 
 	k_thread_create(&futex_tid, stack_1, STACK_SIZE,
 			futex_wait_wake_task, &timeout, NULL, NULL,
@@ -345,7 +338,7 @@ void test_futex_multiple_threads_wait_wake(void)
 	timeout = K_FOREVER;
 	woken = TOTAL_THREADS_WAITING;
 
-	k_futex_init(&simple_futex);
+	atomic_clear(&simple_futex.val);
 
 	for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {
 		atomic_inc(&simple_futex.val);
@@ -382,8 +375,7 @@ void test_multiple_futex_wait_wake(void)
 
 	for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {
 		index[i] = i;
-		k_futex_init(&multiple_futex[i]);
-		atomic_inc(&multiple_futex[i].val);
+		atomic_set(&multiple_futex[i].val, 1);
 		k_thread_create(&multiple_tid[i], multiple_stack[i],
 				STACK_SIZE, futex_multiple_wait_wake_task,
 				&timeout, &index[i], NULL, PRIO_WAIT,


### PR DESCRIPTION
There's no need for a system call for this; futexes live in
user memory and the initialization bit is ignored.

It's sufficient to just do an atomic_set().

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>