### PR TITLE
samples/**/external_lib: invoke $(MAKE) instead of make

### DIFF
--- a/samples/application_development/external_lib/CMakeLists.txt
+++ b/samples/application_development/external_lib/CMakeLists.txt
@@ -34,6 +34,13 @@ set(mylib_build_dir ${CMAKE_CURRENT_BINARY_DIR}/mylib)
 set(MYLIB_LIB_DIR     ${mylib_build_dir}/lib)
 set(MYLIB_INCLUDE_DIR ${mylib_src_dir}/include)
 
+if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+# https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html
+set(submake "$(MAKE)")
+else() # Obviously no MAKEFLAGS. Let's hope a "make" can be found somewhere.
+set(submake "make")
+endif()
+
 ExternalProject_Add(
   mylib_project                 # Name for custom target
   PREFIX     ${mylib_build_dir} # Root dir for entire project
@@ -41,7 +48,7 @@ ExternalProject_Add(
   BINARY_DIR ${mylib_src_dir} # This particular build system is invoked from the root
   CONFIGURE_COMMAND ""    # Skip configuring the project, e.g. with autoconf
   BUILD_COMMAND
-  make
+  ${submake}
   PREFIX=${mylib_build_dir}
   CC=${CMAKE_C_COMPILER}
   AR=${CMAKE_AR}


### PR DESCRIPTION
Recursive make should be invoked as $(MAKE) and not "make" for reasons
documented at
 https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html

$(MAKE) is what CMake puts in all the CMakeFiles/Makefile2 it generates,
it doesn't use "make" either.

Issue found thanks to the following warning:
```
 build.log:make[4]: warning: jobserver unavailable: using -j1.
                    Add '+' to parent make rule.
```
If CMake is invoked with -GNinja or other then fall back on "make" as
before and pray that it's available.

Fast reproduction with:
   make -j2 -C build clean mylib_project VERBOSE=1

Build directories have been compared before/after this change and
there's zero difference except the generated
mylib_project.dir/build.make file (and the warning above) when using
make.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>