### PR TITLE
boards: lpcxpresso55s69: Enable pyocd runner

### DIFF
--- a/boards/arm/lpcxpresso55s69/board.cmake
+++ b/boards/arm/lpcxpresso55s69/board.cmake
@@ -22,4 +22,7 @@ if(CONFIG_BOARD_LPCXPRESSO55S69_CPU1)
 board_runner_args(jlink "--device=LPC55S69_core1")
 endif()
 
+board_runner_args(pyocd "--target=lpc55s69")
+
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Enables the pyocd runner on the lpcxpresso55s69 board. Note that this
currently requires building pycod from source to pick up fixes in
https://github.com/mbedmicro/pyOCD/pull/690

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>