### PR TITLE
Printk coverage fixes

### DIFF
--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -46,6 +46,7 @@ static void _printk_hex_ulong(out_func_t out, void *ctx,
  *
  * @return 0
  */
+/* LCOV_EXCL_START */
  __attribute__((weak)) int z_arch_printk_char_out(int c)
 {
 	ARG_UNUSED(c);
@@ -53,6 +54,7 @@ static void _printk_hex_ulong(out_func_t out, void *ctx,
 	/* do nothing */
 	return 0;
 }
+/* LCOV_EXCL_STOP */
 
 int (*_char_out)(int) = z_arch_printk_char_out;
 

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -524,18 +524,14 @@ static int str_out(int c, struct str_context *ctx)
 
 int snprintk(char *str, size_t size, const char *fmt, ...)
 {
-	struct str_context ctx = { str, size, 0 };
 	va_list ap;
+	int ret;
 
 	va_start(ap, fmt);
-	z_vprintk((out_func_t)str_out, &ctx, fmt, ap);
+	ret = vsnprintk(str, size, fmt, ap);
 	va_end(ap);
 
-	if (ctx.count < ctx.max) {
-		str[ctx.count] = '\0';
-	}
-
-	return ctx.count;
+	return ret;
 }
 
 int vsnprintk(char *str, size_t size, const char *fmt, va_list ap)


### PR DESCRIPTION
Two fixes to the printk code which gets us to 100% function coverage in this C file.