### PR TITLE
boards: match specified jlink swd speed when using pyocd runner

### DIFF
--- a/boards/arm/nrf52840_pca10059/board.cmake
+++ b/boards/arm/nrf52840_pca10059/board.cmake
@@ -2,7 +2,7 @@
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
-board_runner_args(pyocd "--target=nrf52840")
+board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nrf52_adafruit_feather/board.cmake
+++ b/boards/arm/nrf52_adafruit_feather/board.cmake
@@ -2,7 +2,7 @@
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
-board_runner_args(pyocd "--target=nrf52")
+board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/particle_argon/board.cmake
+++ b/boards/arm/particle_argon/board.cmake
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52840")
+board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/particle_boron/board.cmake
+++ b/boards/arm/particle_boron/board.cmake
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52840")
+board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/particle_xenon/board.cmake
+++ b/boards/arm/particle_xenon/board.cmake
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52840")
+board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/reel_board/board.cmake
+++ b/boards/arm/reel_board/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52")
+board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/usb_kw24d512/board.cmake
+++ b/boards/arm/usb_kw24d512/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=MKW24D512xxx5" "--speed=4000")
-board_runner_args(pyocd "--target=kw24d5")
+board_runner_args(pyocd "--target=kw24d5" "--frequency=4000000")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Match the speed speficied for all boards using the jlink runner when
using the pyocd runner on the same board.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>