### PR TITLE
arch: arm: userspace: minor refactor in z_arch_is_user_context

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -8,8 +8,8 @@
 #include <device.h>
 #include <drivers/uart.h>
 #include <drivers/clock_control.h>
-#include <fsl_lpuart.h>
 #include <soc.h>
+#include <fsl_lpuart.h>
 
 struct mcux_lpuart_config {
 	LPUART_Type *base;

--- a/include/arch/arm/syscall.h
+++ b/include/arch/arm/syscall.h
@@ -6,9 +6,9 @@
 
 /**
  * @file
- * @brief ARM specific sycall header
+ * @brief ARM specific syscall header
  *
- * This header contains the ARM specific sycall interface.  It is
+ * This header contains the ARM specific syscall interface.  It is
  * included by the syscall interface architecture-abstraction header
  * (include/arch/syscall.h)
  */
@@ -26,6 +26,7 @@
 
 #include <zephyr/types.h>
 #include <stdbool.h>
+#include <arch/arm/cortex_m/cmsis.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -167,7 +168,7 @@ static inline bool z_arch_is_user_context(void)
 
 	/* if not handler mode, return mode information */
 	__asm__ volatile("mrs %0, CONTROL\n\t" : "=r"(value));
-	return (value & 0x1) ? true : false;
+	return (value & CONTROL_nPRIV_Msk) ? true : false;
 }
 
 #ifdef __cplusplus

--- a/soc/arm/nxp_imx/rt/soc.h
+++ b/soc/arm/nxp_imx/rt/soc.h
@@ -13,11 +13,8 @@
 
 #include <fsl_common.h>
 
-/* ARM CMSIS definitions must be included before kernel_includes.h.
- * Therefore, it is essential to include kernel_includes.h after including
- * core SOC-specific headers.
- */
-#include <kernel_includes.h>
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/arm/nxp_kinetis/k6x/soc.h
+++ b/soc/arm/nxp_kinetis/k6x/soc.h
@@ -30,9 +30,9 @@
 #ifndef _ASMLANGUAGE
 
 #include <fsl_common.h>
-#include <device.h>
-#include <sys/util.h>
-#include <random/rand32.h>
+
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.soc
@@ -80,4 +80,4 @@ config WDOG_INIT
 	  requires that the watchdog be configured during reset
 	  handling.
 
-endif # SOC_SERIES_KINETIS_KV5X
+endif # SOC_SERIES_KINETIS_K8X

--- a/soc/arm/nxp_kinetis/k8x/soc.h
+++ b/soc/arm/nxp_kinetis/k8x/soc.h
@@ -7,7 +7,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <misc/util.h>
+#include <sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -17,11 +17,8 @@ extern "C" {
 
 #include <fsl_common.h>
 
-/* ARM CMSIS definitions must be included before kernel_includes.h.
- * Therefore, it is essential to include kernel_includes.h after including
- * core SOC-specific headers.
- */
-#include <kernel_includes.h>
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_kinetis/ke1xf/soc.h
+++ b/soc/arm/nxp_kinetis/ke1xf/soc.h
@@ -9,4 +9,13 @@
 
 #include <sys/util.h>
 
+#ifndef _ASMLANGUAGE
+
+#include <fsl_common.h>
+
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
+
+#endif /* !_ASMLANGUAGE */
+
 #endif /* _SOC__H_ */

--- a/soc/arm/nxp_kinetis/kl2x/soc.h
+++ b/soc/arm/nxp_kinetis/kl2x/soc.h
@@ -14,9 +14,9 @@
 #ifndef _ASMLANGUAGE
 
 #include <fsl_common.h>
-#include <device.h>
-#include <sys/util.h>
-#include <random/rand32.h>
+
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_kinetis/kwx/soc.h
+++ b/soc/arm/nxp_kinetis/kwx/soc.h
@@ -25,9 +25,9 @@
 #ifndef _ASMLANGUAGE
 
 #include <fsl_common.h>
-#include <device.h>
-#include <sys/util.h>
-#include <random/rand32.h>
+
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_lpc/lpc54xxx/soc.h
+++ b/soc/arm/nxp_lpc/lpc54xxx/soc.h
@@ -19,11 +19,9 @@
 #include <sys/util.h>
 #include <fsl_common.h>
 
-/* ARM CMSIS definitions must be included before kernel_includes.h.
- * Therefore, it is essential to include kernel_includes.h after including
- * core SOC-specific headers.
- */
-#include <kernel_includes.h>
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
+
 #endif /* !_ASMLANGUAGE */
 
 #define IOCON_PIO_DIGITAL_EN	0x80u

--- a/soc/arm/nxp_lpc/lpc55xxx/soc.h
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.h
@@ -16,9 +16,12 @@
 #define _SOC__H_
 
 #ifndef _ASMLANGUAGE
-#include <device.h>
 #include <sys/util.h>
 #include <fsl_common.h>
+
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
+
 #endif /* !_ASMLANGUAGE */
 
 #define IOCON_PIO_DIGITAL_EN 0x0100u  /*!<@brief Enables digital function */


### PR DESCRIPTION
Refactor z_arch_is_user_context() for ARM, so it uses
the CMSIS CONTROL_nPRIV_Msk instead of the hard-coded 0x1.
Fix also some typos.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Trivial. No behavioral change.