### PR TITLE
[Backport v1.14-branch] net-mgmt event needs length of info element

### DIFF
--- a/include/net/net_mgmt.h
+++ b/include/net/net_mgmt.h
@@ -140,6 +140,7 @@ struct net_mgmt_event_callback {
 
 #ifdef CONFIG_NET_MGMT_EVENT_INFO
 	const void *info;
+	size_t info_length;
 #endif
 
 	/** A mask of network events on which the above handler should be
@@ -242,6 +243,8 @@ static inline void net_mgmt_event_notify(u32_t mgmt_event, struct net_if *iface)
  *        the caller wants to listen to.
  * @param info a valid pointer if user wants to get the information the
  *        event might bring along. NULL otherwise.
+ * @param info_length tells how long the info memory area is. Only valid if
+ *        the info is not NULL.
  * @param timeout a delay in milliseconds. K_FOREVER can be used to wait
  *        indefinitely.
  *
@@ -254,12 +257,14 @@ int net_mgmt_event_wait(u32_t mgmt_event_mask,
 			u32_t *raised_event,
 			struct net_if **iface,
 			const void **info,
+			size_t *info_length,
 			int timeout);
 #else
 static inline int net_mgmt_event_wait(u32_t mgmt_event_mask,
 				      u32_t *raised_event,
 				      struct net_if **iface,
 				      const void **info,
+				      size_t *info_length,
 				      int timeout)
 {
 	return 0;
@@ -277,6 +282,8 @@ static inline int net_mgmt_event_wait(u32_t mgmt_event_mask,
  *        interested in that information.
  * @param info a valid pointer if user wants to get the information the
  *        event might bring along. NULL otherwise.
+ * @param info_length tells how long the info memory area is. Only valid if
+ *        the info is not NULL.
  * @param timeout a delay in milliseconds. K_FOREVER can be used to wait
  *        indefinitely.
  *
@@ -289,12 +296,14 @@ int net_mgmt_event_wait_on_iface(struct net_if *iface,
 				 u32_t mgmt_event_mask,
 				 u32_t *raised_event,
 				 const void **info,
+				 size_t *info_length,
 				 int timeout);
 #else
 static inline int net_mgmt_event_wait_on_iface(struct net_if *iface,
 					       u32_t mgmt_event_mask,
 					       u32_t *raised_event,
 					       const void **info,
+					       size_t *info_length,
 					       int timeout)
 {
 	return 0;

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -203,14 +203,22 @@ int net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr)
 
 	net_if_mcast_monitor(iface, addr, true);
 
-	net_mgmt_event_notify(NET_EVENT_IPV6_MCAST_JOIN, iface);
+	net_mgmt_event_notify_with_info(NET_EVENT_IPV6_MCAST_JOIN, iface,
+					&maddr->address.in6_addr,
+					sizeof(struct in6_addr));
 
 	return ret;
 }
 
 int net_ipv6_mld_leave(struct net_if *iface, const struct in6_addr *addr)
 {
+	struct net_if_mcast_addr *maddr;
 	int ret;
+
+	maddr = net_if_ipv6_maddr_lookup(addr, &iface);
+	if (!maddr) {
+		return -ENOENT;
+	}
 
 	if (!net_if_ipv6_maddr_rm(iface, addr)) {
 		return -EINVAL;
@@ -223,7 +231,9 @@ int net_ipv6_mld_leave(struct net_if *iface, const struct in6_addr *addr)
 
 	net_if_mcast_monitor(iface, addr, false);
 
-	net_mgmt_event_notify(NET_EVENT_IPV6_MCAST_LEAVE, iface);
+	net_mgmt_event_notify_with_info(NET_EVENT_IPV6_MCAST_LEAVE, iface,
+					&maddr->address.in6_addr,
+					sizeof(struct in6_addr));
 
 	return ret;
 }

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -181,8 +181,10 @@ static inline void mgmt_run_callbacks(struct mgmt_event_entry *mgmt_event)
 #ifdef CONFIG_NET_MGMT_EVENT_INFO
 		if (mgmt_event->info_length) {
 			cb->info = (void *)mgmt_event->info;
+			cb->info_length = mgmt_event->info_length;
 		} else {
 			cb->info = NULL;
+			cb->info_length = 0;
 		}
 #endif /* CONFIG_NET_MGMT_EVENT_INFO */
 
@@ -260,6 +262,7 @@ static int mgmt_event_wait_call(struct net_if *iface,
 				u32_t *raised_event,
 				struct net_if **event_iface,
 				const void **info,
+				size_t *info_length,
 				int timeout)
 {
 	struct mgmt_event_wait sync_data = {
@@ -295,6 +298,10 @@ static int mgmt_event_wait_call(struct net_if *iface,
 #ifdef CONFIG_NET_MGMT_EVENT_INFO
 			if (info) {
 				*info = sync.info;
+
+				if (info_length) {
+					*info_length = sync.info_length;
+				}
 			}
 #endif /* CONFIG_NET_MGMT_EVENT_INFO */
 		}
@@ -347,23 +354,27 @@ int net_mgmt_event_wait(u32_t mgmt_event_mask,
 			u32_t *raised_event,
 			struct net_if **iface,
 			const void **info,
+			size_t *info_length,
 			int timeout)
 {
 	return mgmt_event_wait_call(NULL, mgmt_event_mask,
-				    raised_event, iface, info, timeout);
+				    raised_event, iface, info, info_length,
+				    timeout);
 }
 
 int net_mgmt_event_wait_on_iface(struct net_if *iface,
 				 u32_t mgmt_event_mask,
 				 u32_t *raised_event,
 				 const void **info,
+				 size_t *info_length,
 				 int timeout)
 {
 	NET_ASSERT(NET_MGMT_ON_IFACE(mgmt_event_mask));
 	NET_ASSERT(iface);
 
 	return mgmt_event_wait_call(iface, mgmt_event_mask,
-				    raised_event, NULL, info, timeout);
+				    raised_event, NULL, info, info_length,
+				    timeout);
 }
 
 void net_mgmt_event_init(void)

--- a/tests/net/mgmt/src/mgmt.c
+++ b/tests/net/mgmt/src/mgmt.c
@@ -18,10 +18,13 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_MGMT_EVENT_LOG_LEVEL);
 #include <net/net_pkt.h>
 #include <ztest.h>
 
+#define TEST_INFO_STRING "mgmt event info"
+
 #define TEST_MGMT_REQUEST		0x17AB1234
 #define TEST_MGMT_EVENT			0x97AB1234
 #define TEST_MGMT_EVENT_UNHANDLED	0x97AB4321
-#define TEST_MGMT_EVENT_INFO_SIZE	sizeof("mgmt event info")
+#define TEST_MGMT_EVENT_INFO_SIZE	\
+	MAX(sizeof(TEST_INFO_STRING), sizeof(struct in6_addr))
 
 /* Notifier infra */
 static u32_t event2throw;
@@ -35,12 +38,14 @@ static struct k_sem thrower_lock;
 /* Receiver infra */
 static u32_t rx_event;
 static u32_t rx_calls;
+static size_t info_length_in_test;
 static struct net_mgmt_event_callback rx_cb;
+static char *info_string = TEST_INFO_STRING;
 
 static struct in6_addr addr6 = { { { 0xfe, 0x80, 0, 0, 0, 0, 0, 0,
 				     0, 0, 0, 0, 0, 0, 0, 0x1 } } };
 
-static char info_data[TEST_MGMT_EVENT_INFO_SIZE] = "mgmt event info";
+static char info_data[TEST_MGMT_EVENT_INFO_SIZE];
 
 static int test_mgmt_request(u32_t mgmt_request,
 			     struct net_if *iface, void *data, u32_t len)
@@ -129,8 +134,12 @@ static void receiver_cb(struct net_mgmt_event_callback *cb,
 	TC_PRINT("\t\tReceived event 0x%08X\n", nm_event);
 
 	if (with_info && cb->info) {
-		if (memcmp(info_data, cb->info,
-			   TEST_MGMT_EVENT_INFO_SIZE)) {
+		if (cb->info_length != info_length_in_test) {
+			rx_calls = (u32_t) -1;
+			return;
+		}
+
+		if (memcmp(info_data, cb->info, info_length_in_test)) {
 			rx_calls = (u32_t) -1;
 			return;
 		}
@@ -230,6 +239,9 @@ static void initialize_event_tests(void)
 
 	k_sem_init(&thrower_lock, 0, UINT_MAX);
 
+	info_length_in_test = TEST_MGMT_EVENT_INFO_SIZE;
+	memcpy(info_data, info_string, strlen(info_string) + 1);
+
 	net_mgmt_init_event_callback(&rx_cb, receiver_cb, TEST_MGMT_EVENT);
 
 	k_thread_create(&thrower_thread_data, thrower_stack,
@@ -242,6 +254,9 @@ static int test_core_event(u32_t event, bool (*func)(void))
 {
 	TC_PRINT("- Triggering core event: 0x%08X\n", event);
 
+	info_length_in_test = sizeof(struct in6_addr);
+	memcpy(info_data, &addr6, sizeof(addr6));
+
 	net_mgmt_init_event_callback(&rx_cb, receiver_cb, event);
 
 	net_mgmt_add_event_callback(&rx_cb);
@@ -250,8 +265,9 @@ static int test_core_event(u32_t event, bool (*func)(void))
 
 	k_yield();
 
-	zassert_true(rx_calls, "rx_calls empty");
-	zassert_equal(rx_event, event, "rx_event check failed");
+	zassert_true(rx_calls > 0 && rx_calls != -1, "rx_calls empty");
+	zassert_equal(rx_event, event, "rx_event check failed, "
+		      "0x%08x vs 0x%08x", rx_event, event);
 
 	net_mgmt_del_event_callback(&rx_cb);
 	rx_event = rx_calls = 0U;

--- a/tests/net/mgmt/src/mgmt.c
+++ b/tests/net/mgmt/src/mgmt.c
@@ -201,9 +201,9 @@ static int test_synchronous_event_listener(u32_t times, bool on_iface)
 	if (on_iface) {
 		ret = net_mgmt_event_wait_on_iface(net_if_get_default(),
 						   event_mask, NULL, NULL,
-						   K_SECONDS(1));
+						   NULL, K_SECONDS(1));
 	} else {
-		ret = net_mgmt_event_wait(event_mask, NULL, NULL, NULL,
+		ret = net_mgmt_event_wait(event_mask, NULL, NULL, NULL, NULL,
 					  K_SECONDS(1));
 	}
 


### PR DESCRIPTION
This PR backports relevant parts from #16743 to 1.14

Fixes #17190
