### PR TITLE
soc: nordic: nrf9160: add IPC capabilities

### DIFF
--- a/soc/arm/nordic_nrf/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/Kconfig.peripherals
@@ -62,6 +62,9 @@ config HAS_HW_NRF_GPIOTE
 config HAS_HW_NRF_I2S
 	bool
 
+config HAS_HW_NRF_IPC
+	bool
+
 config HAS_HW_NRF_LPCOMP
 	bool
 

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.soc
@@ -20,6 +20,7 @@ config SOC_NRF9160
 	select HAS_HW_NRF_GPIO0
 	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_I2S
+	select HAS_HW_NRF_IPC
 	select HAS_HW_NRF_PDM
 	select HAS_HW_NRF_POWER
 	select HAS_HW_NRF_PWM0


### PR DESCRIPTION
The IPC peripheral is missing from the list of
supported HW for nRF9160, so this commit adds
that.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>