### PR TITLE
Bluetooth: controller: Remove BT_HCI_RAW dependency

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -733,7 +733,6 @@ comment "BLE Controller debug configuration"
 
 config BT_CTLR_ASSERT_HANDLER
 	bool "Bluetooth Controller Assertion Handler"
-	depends on BT_HCI_RAW
 	help
 	  This option enables an application-defined sink for the
 	  controller assertion mechanism. This must be defined in

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -732,7 +732,7 @@ config BT_CTLR_PA_LNA_GPIOTE_CHAN
 comment "BLE Controller debug configuration"
 
 config BT_CTLR_ASSERT_HANDLER
-	bool "Bluetooth Controller Assertion Handler"
+	bool "Application Defined Assertion Handler"
 	help
 	  This option enables an application-defined sink for the
 	  controller assertion mechanism. This must be defined in


### PR DESCRIPTION
Removes the dependency on BT_HCI_RAW from BT_CTLR_ASSERT_HANDLER.

For example, when testing the full stack in CI it is useful to re-define the assert handler to get additional system information when an assert is triggered. In this case, BT_HCI_RAW is not necessarily set, since the application is usually running the full host+controller on a single chip.