### PR TITLE
drivers: sam: entropy: implement get_entropy_isr

### DIFF
--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -35,7 +35,7 @@
  *
  * Due to the first byte in a stream of bytes being more costly on
  * some platforms a "water system" inspired algorithm is used to
- * ammortize the cost of the first byte.
+ * amortize the cost of the first byte.
  *
  * The algorithm will delay generation of entropy until the amount of
  * bytes goes below THRESHOLD, at which point it will generate entropy
@@ -46,7 +46,7 @@
  *
  * The algorithm and HW together has these characteristics:
  *
- * Setting a low threshold will highly ammortize the extra 120us cost
+ * Setting a low threshold will highly amortize the extra 120us cost
  * of the first byte on nRF52.
  *
  * Setting a high threshold will minimize the time spent waiting for


### PR DESCRIPTION
The commit contributes the implementation of
get_entropy_isr API function for the SAM entropy
driver. The implementation is similar to get_entropy,
with the difference that it does not invoke k_yield()
when called with the ENTROPY_BUSYWAIT options flag set.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Fixes #13935 