### PR TITLE
usb_dc_stm32: Don't update ret_bytes if send fails in usb_dc_ep_write()

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -767,7 +767,7 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 		irq_enable(DT_USB_IRQ);
 	}
 
-	if (ret_bytes) {
+	if (!ret && ret_bytes) {
 		*ret_bytes = len;
 	}
 


### PR DESCRIPTION
Don't update ret_bytes if send fails in usb_dc_ep_write().

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>