### PR TITLE
sanitycheck: extend coverage timeout

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -816,7 +816,7 @@ class QEMUHandler(Handler):
                 if not timeout_extended or harness.capture_coverage:
                     timeout_extended= True
                     if harness.capture_coverage:
-                        timeout_time = time.time() + 10
+                        timeout_time = time.time() + 30
                     else:
                         timeout_time = time.time() + 2
 


### PR DESCRIPTION
If GCOV coverage is enabled, the coverage dump happens after
"PROJECT EXECUTION SUCCESSFUL" is printed. In some cases,
the additional time added was not enough to capture all the
GCOV output on a heavily loaded system before the emulator
gets killed.

Ideally, the decision to kill the emulator needs to be smarter
and less race-prone, but that can wait for a future
enhancement.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>