### PR TITLE
drivers: usb_dc_nrfx: fix usb device test

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1545,6 +1545,10 @@ int usb_dc_ep_is_stalled(const u8_t ep, u8_t *const stalled)
 		return -EINVAL;
 	}
 
+	if (!stalled) {
+		return -EINVAL;
+	}
+
 	*stalled = (u8_t) nrfx_usbd_ep_stall_check(ep_addr_to_nrfx(ep));
 
 	return 0;

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -310,10 +310,10 @@ static inline uint8_t nrfx_addr_to_ep(nrfx_usbd_ep_t ep)
 
 static inline bool ep_is_valid(const u8_t ep)
 {
-	u8_t ep_num = NRF_USBD_EP_NR_GET(ep);
+	u8_t ep_num = ep & ~USB_EP_DIR_MASK;
 
 	if (NRF_USBD_EPIN_CHECK(ep)) {
-		if (unlikely(NRF_USBD_EPISO_CHECK(ep))) {
+		if (unlikely(ep_num == NRF_USBD_EPISO_FIRST)) {
 			if (CFG_EP_ISOIN_CNT == 0) {
 				return false;
 			}
@@ -323,7 +323,7 @@ static inline bool ep_is_valid(const u8_t ep)
 			}
 		}
 	} else {
-		if (unlikely(NRF_USBD_EPISO_CHECK(ep))) {
+		if (unlikely(ep_num == NRF_USBD_EPISO_FIRST)) {
 			if (CFG_EP_ISOOUT_CNT == 0) {
 				return false;
 			}

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1348,8 +1348,14 @@ int usb_dc_detach(void)
 	usbd_evt_flush();
 	eps_ctx_uninit();
 
-	nrfx_usbd_disable();
-	nrfx_usbd_uninit();
+	if (nrfx_usbd_is_enabled()) {
+		nrfx_usbd_disable();
+	}
+
+	if (nrfx_usbd_is_initialized()) {
+		nrfx_usbd_uninit();
+	}
+
 	(void) hf_clock_enable(false, false);
 	nrf5_power_usb_power_int_enable(false);
 

--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -111,9 +111,6 @@ static void test_usb_dc_api(void)
 	/* Bulk EP is not configured yet */
 	zassert_equal(usb_dc_ep_mps(ENDP_BULK_IN), 0,
 		      "usb_dc_ep_mps(ENDP_BULK_IN) not configured");
-
-	zassert_equal(usb_dc_set_address(0x01), TC_PASS,
-		      "usb_dc_set_address(0x01)");
 }
 
 /* Test USB Device Cotnroller API for invalid parameters */


### PR DESCRIPTION
tests: usb: do not set device address
Forced attempt to set the device address is unpredictable
and also should not be done during testing.


drivers/usb_dc_nrfx: 
Do not use NRF_USBD_EP_NR_GET in ep_is_valid because
it masks the higher nibble. Although this behavior is valid
to get an index from an endpoint, it is not suitable to check
if the address is incorrect, such as: 0x11.

Check the device state before nrfx_usbd_disable and
nrfx_usbd_uninit. Otherwise it may lead to an ASSERT
inside the HAL driver.

Validate pointer argument in usb_dc_ep_is_stalled.

Fixes #17182