### PR TITLE
tests: net: ip-addr: Avoid possible null pointer dereference

### DIFF
--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -291,7 +291,8 @@ static void test_ipv6_addresses(void)
 	ifaddr2->addr_state = NET_ADDR_PREFERRED;
 
 	tmp = net_if_ipv6_get_ll(net_if_get_default(), NET_ADDR_PREFERRED);
-	zassert_false(memcmp(tmp, &addr6.s6_addr, sizeof(struct in6_addr)),
+	zassert_false(tmp && memcmp(tmp, &addr6.s6_addr,
+				    sizeof(struct in6_addr)),
 		      "IPv6 ll address fetch failed");
 
 	ifaddr2->addr_state = NET_ADDR_DEPRECATED;

--- a/tests/net/ip-addr/testcase.yaml
+++ b/tests/net/ip-addr/testcase.yaml
@@ -1,7 +1,6 @@
 common:
   depends_on: netif
-  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
+  tags: net ip-addr
 tests:
   net.ip-addr:
     min_ram: 16
-    tags: net ip-addr


### PR DESCRIPTION
Check return value of net_if_ipv6_get_ll() before accessing it.

Coverity-CID: 199437
Fixes #17201

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>