### PR TITLE
net: sockets: Initialize IP socket addresses in getsockname()

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1232,7 +1232,7 @@ int zsock_getsockname_ctx(struct net_context *ctx, struct sockaddr *addr,
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.family == AF_INET) {
-		struct sockaddr_in addr4;
+		struct sockaddr_in addr4 = { 0 };
 
 		addr4.sin_family = AF_INET;
 		addr4.sin_port = net_sin_ptr(&ctx->local)->sin_port;
@@ -1243,7 +1243,7 @@ int zsock_getsockname_ctx(struct net_context *ctx, struct sockaddr *addr,
 		memcpy(addr, &addr4, MIN(*addrlen, newlen));
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		   ctx->local.family == AF_INET6) {
-		struct sockaddr_in6 addr6;
+		struct sockaddr_in6 addr6 = { 0 };
 
 		addr6.sin6_family = AF_INET6;
 		addr6.sin6_port = net_sin6_ptr(&ctx->local)->sin6_port;


### PR DESCRIPTION
Make sure the IPv4 and IPv6 socket addresses are initialized before
copying them. This avoids uninitialized memory access.

Coverity-CID: 199436
Fixes #17202

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>