### PR TITLE
Bluetooth: Add read remote version on startup and added to bt_conn_get_info

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -171,7 +171,7 @@ struct bt_conn_info {
 		struct bt_conn_le_info le;
 
 		struct bt_conn_br_info br;
-		
+
 		struct bt_conn_rv_info rv;
 	};
 };

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -129,11 +129,19 @@ struct bt_conn_le_info {
 	u16_t interval; /** Connection interval */
 	u16_t latency; /** Connection slave latency */
 	u16_t timeout; /** Connection supervision timeout */
+	u8_t features[8]; /** Remote device's ble features */
 };
 
 /** BR/EDR Connection Info Structure */
 struct bt_conn_br_info {
 	const bt_addr_t *dst; /** Destination (Remote) BR/EDR address */
+};
+
+/** Remote Version Info Structure */
+struct bt_conn_rv_info {
+	u8_t  version;
+	u16_t manufacturer;
+	u16_t subversion;
 };
 
 /** Connection role (master or slave) */
@@ -150,6 +158,7 @@ enum {
  *  @param id Which local identity the connection was created with
  *  @param le LE Connection specific Info
  *  @param br BR/EDR Connection specific Info
+ *  @param rv Remote Version Info
  */
 struct bt_conn_info {
 	u8_t type;
@@ -162,6 +171,8 @@ struct bt_conn_info {
 		struct bt_conn_le_info le;
 
 		struct bt_conn_br_info br;
+		
+		struct bt_conn_rv_info rv;
 	};
 };
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1812,7 +1812,8 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 		info->le.interval = conn->le.interval;
 		info->le.latency = conn->le.latency;
 		info->le.timeout = conn->le.timeout;
-		memcpy(info->le.features, conn->le.features, sizeof(info->le.features));	
+		memcpy(info->le.features, conn->le.features,
+			sizeof(info->le.features));
 #if defined(CONFIG_BT_TESTING)
 		info->rv.version = conn->rv.version;
 		info->rv.manufacturer = conn->rv.manufacturer;

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1812,6 +1812,12 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 		info->le.interval = conn->le.interval;
 		info->le.latency = conn->le.latency;
 		info->le.timeout = conn->le.timeout;
+		memcpy(info->le.features, conn->le.features, sizeof(info->le.features));	
+#if defined(CONFIG_BT_TESTING)
+		info->rv.version = conn->rv.version;
+		info->rv.manufacturer = conn->rv.manufacturer;
+		info->rv.subversion = conn->rv.subversion;
+#endif /* CONFIG_BT_TESTING */
 		return 0;
 #if defined(CONFIG_BT_BREDR)
 	case BT_CONN_TYPE_BR:

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -82,12 +82,11 @@ struct bt_conn_sco {
 #if defined(CONFIG_BT_TESTING)
 
 struct bt_conn_rv {
-	/* Remote version info */
-	u8_t  			status;
-	u16_t 			handle;
-	u8_t  			version;
-	u16_t 			manufacturer;
-	u16_t 			subversion;
+	u8_t			status;
+	u16_t			handle;
+	u8_t			version;
+	u16_t			manufacturer;
+	u16_t			subversion;
 };
 
 #endif /* CONFIG_BT_TESTING */

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -79,6 +79,19 @@ struct bt_conn_sco {
 };
 #endif
 
+#if defined(CONFIG_BT_TESTING)
+
+struct bt_conn_rv {
+	/* Remote version info */
+	u8_t  			status;
+	u16_t 			handle;
+	u8_t  			version;
+	u16_t 			manufacturer;
+	u16_t 			subversion;
+};
+
+#endif /* CONFIG_BT_TESTING */
+
 typedef void (*bt_conn_tx_cb_t)(struct bt_conn *conn, void *user_data);
 
 struct bt_conn_tx_data {
@@ -135,7 +148,10 @@ struct bt_conn {
 #if defined(CONFIG_BT_BREDR)
 		struct bt_conn_br	br;
 		struct bt_conn_sco	sco;
-#endif
+#endif /* CONFIG_BT_BREDR */
+#if defined(CONFIG_BT_TESTING)
+		struct bt_conn_rv rv;
+#endif /* CONFIG_BT_TESTING */
 	};
 };
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2960,9 +2960,10 @@ static void hci_encrypt_key_refresh_complete(struct net_buf *buf)
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR */
 
 #if defined(CONFIG_BT_TESTING)
-static void bt_hci_evt_read_remote_version_complete(struct net_buf *buf){
+static void bt_hci_evt_read_remote_version_complete(struct net_buf *buf)
+{
 	struct bt_hci_evt_remote_version_info *evt;
-    evt = net_buf_pull_mem(buf, sizeof(*evt));
+	evt = net_buf_pull_mem(buf, sizeof(*evt));
 
 	u16_t handle = sys_le16_to_cpu(evt->handle);
 	struct bt_conn *conn;


### PR DESCRIPTION
Add read remote version on startup and added to bt_conn_get_info.

Added remote features to bt_get_conn_info (and to the bt_conn_le_info struct)
Added remote version struct to bt_conn_info union.

If CONFIG_BT_TESTING is enabled:
  -read_remote_version is called on connection
  -bt_conn has an extra remote_version struct in the union
  -bt_conn_get_info also gives remote version information

note: read_remote_features is already called on connection

Signed-off-by: Sverre Storvold Sverre.Storvold@nordicsemi.no