### PR TITLE
sanitycheck: show handler_time for Binary_Handler -v output

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -571,7 +571,7 @@ class BinaryHandler(Handler):
         else:
             command = [self.binary]
 
-        if shutil.which("valgrind") and self.valgrind:
+        if self.valgrind and shutil.which("valgrind"):
             command = ["valgrind", "--error-exitcode=2",
                        "--leak-check=full",
                        "--suppressions="+ZEPHYR_BASE+"/scripts/valgrind.supp",

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -581,6 +581,9 @@ class BinaryHandler(Handler):
         verbose("Spawning process: " +
                 " ".join(shlex.quote(word) for word in command) + os.linesep +
                 "Spawning process in directory: " + self.outdir)
+
+        start_time = time.time();
+
         with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self.outdir) as proc:
             verbose("Spawning BinaryHandler Thread for %s" % self.name)
             t = threading.Thread(target=self._output_reader, args=(proc, harness, ))
@@ -593,6 +596,8 @@ class BinaryHandler(Handler):
                 t.join()
             proc.wait()
             self.returncode = proc.returncode
+
+        self.metrics["handler_time"] = time.time() - start_time;
 
         if options.enable_coverage:
             returncode = subprocess.call(["GCOV_PREFIX=" + self.outdir,


### PR DESCRIPTION
Akin to #16969, save the time it takes for the BinaryHandler main process to execute so it can be reported when sanitycheck is run verbose.
+
A trivial optimization in the BianryHandler