### PR TITLE
boards: dts: cleanup partition node names

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -166,11 +166,11 @@
 			label = "image-0";
 			reg = <0x00020000 0x0006C000>;
 		};
-		slot1_partition: partition@40000 {
+		slot1_partition: partition@8c000 {
 			label = "image-1";
 			reg = <0x0008C000 0x0006C000>;
 		};
-		scratch_partition: partition@60000 {
+		scratch_partition: partition@f8000 {
 			label = "image-scratch";
 			reg = <0x000F8000 0x00006000>;
 		};

--- a/boards/arm/nrf52840_pca10059/fstab-stock.dts
+++ b/boards/arm/nrf52840_pca10059/fstab-stock.dts
@@ -25,7 +25,7 @@
 			label = "image-0";
 			reg = <0x00010000 0x00005e000>;
 		};
-		slot1_partition: partition@6d000 {
+		slot1_partition: partition@6e000 {
 			label = "image-1";
 			reg = <0x006e000 0x00005e000>;
 		};

--- a/boards/arm/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/arm/stm32f0_disco/stm32f0_disco.dts
@@ -81,11 +81,11 @@
 			label = "image-0";
 			reg = <0x00004000 0x00004000>;
 		};
-		slot1_partition: partition@40000 {
+		slot1_partition: partition@8000 {
 			label = "image-1";
 			reg = <0x00008000 0x00004000>;
 		};
-		scratch_partition: partition@60000 {
+		scratch_partition: partition@c000 {
 			label = "image-scratch";
 			reg = <0x0000C000 0x00004000>;
 		};


### PR DESCRIPTION
Fix several board dts in which the partition node name and the reg
didn't match.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>