### PR TITLE
dts: silabs: fix gpio address

### DIFF
--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -139,7 +139,7 @@
 
 			gpiof: gpio@4000a0f0 {
 				compatible = "silabs,efr32xg1-gpio-port";
-				reg = <0x4000af0 0x30>;
+				reg = <0x4000a0f0 0x30>;
 				label = "GPIO_F";
 				gpio-controller;
 				#gpio-cells = <2>;

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -168,7 +168,7 @@
 
 			gpiof: gpio@4000a0f0 {
 				compatible = "silabs,efr32mg-gpio-port";
-				reg = <0x4000af0 0x30>;
+				reg = <0x4000a0f0 0x30>;
 				label = "GPIO_F";
 				gpio-controller;
 				#gpio-cells = <2>;


### PR DESCRIPTION
There are a few cases in which the reg address for the GPIO block was
wrong.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>