### PR TITLE
dts: lpc55s6x: Fix memory node name

### DIFF
--- a/dts/arm/nxp/nxp_lpc55S6x.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x.dtsi
@@ -43,9 +43,9 @@
 		reg = <0x30030000 DT_SIZE_K(64)>;
 	};
 
-	sramx:memory@50000000{
+	sramx:memory@14000000{
 		compatible = "mmio-sram";
-		reg = <0x40000000 DT_SIZE_K(32)>;
+		reg = <0x14000000 DT_SIZE_K(32)>;
 	};
 
 	soc {


### PR DESCRIPTION
Fix the memory node name to match the reg.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>