### PR TITLE
dts: nios2: fix flash node name

### DIFF
--- a/dts/nios2/nios2-qemu.dtsi
+++ b/dts/nios2/nios2-qemu.dtsi
@@ -15,7 +15,7 @@
 
 	};
 
-	flash0: flash@0 {
+	flash0: flash@420000 {
 		compatible = "soc-nv-flash";
 		reg = <0x420000 0x20000>;
 	};


### PR DESCRIPTION
Fix the flash node name to match the reg.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>