### PR TITLE
dts: nxp_imx6sx_m4: fix cpu reg num

### DIFF
--- a/dts/arm/nxp/nxp_imx6sx_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx6sx_m4.dtsi
@@ -23,7 +23,7 @@
 		cpu@1 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
-			reg = <0>;
+			reg = <1>;
 		};
 	};
 


### PR DESCRIPTION
Fix reg of cpu node to match node name

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>