### PR TITLE
tests: crc: convert to regular test case

### DIFF
--- a/tests/lib/crc/CMakeLists.txt
+++ b/tests/lib/crc/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(base64)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/crc/prj.conf
+++ b/tests/lib/crc/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/lib/crc/src/main.c
+++ b/tests/lib/crc/src/main.c
@@ -5,11 +5,7 @@
  */
 
 #include <ztest.h>
-
-#include <lib/os/crc32_sw.c>
-#include <lib/os/crc16_sw.c>
-#include <lib/os/crc8_sw.c>
-#include <lib/os/crc7_sw.c>
+#include <sys/crc.h>
 
 void test_crc32_ieee(void)
 {

--- a/tests/lib/crc/testcase.yaml
+++ b/tests/lib/crc/testcase.yaml
@@ -1,5 +1,3 @@
 tests:
   misc.crc:
     tags: net crc
-    timeout: 5
-    type: unit

--- a/tests/unit/lib/crc/CMakeLists.txt
+++ b/tests/unit/lib/crc/CMakeLists.txt
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-project(crc)
-include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)
-


### PR DESCRIPTION
The special 'unittest' target has largely been superseded by
native_posix, and converting this to a regular test will allow
us to see code coverage for the CRC functions in our coverage
reports.

Fixes: #16943

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>