### PR TITLE
Bluetooth: GATT: Fix registering on static service area

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -566,7 +566,7 @@ static int gatt_register(struct bt_gatt_service *svc)
 	u16_t count = svc->attr_count;
 
 	if (sys_slist_is_empty(&db)) {
-		handle = 0;
+		handle = last_static_handle;
 		last_handle = 0;
 		goto populate;
 	}


### PR DESCRIPTION
When registering a new service it has to account the area used by static
services.

This fixes a bug introduced by #16593

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>