### PR TITLE
tests: fp_sharing: emit coverage data

### DIFF
--- a/include/debug/gcov.h
+++ b/include/debug/gcov.h
@@ -11,8 +11,8 @@
 void gcov_coverage_dump(void);
 void gcov_static_init(void);
 #else
-void gcov_coverage_dump(void) { }
-void gcov_static_init(void) { }
+static inline void gcov_coverage_dump(void) { }
+static inline void gcov_static_init(void) { }
 
 #endif	/* CONFIG_COVERAGE */
 

--- a/tests/kernel/fp_sharing/src/main.c
+++ b/tests/kernel/fp_sharing/src/main.c
@@ -69,6 +69,7 @@
 #include "float_context.h"
 #include <stddef.h>
 #include <string.h>
+#include <debug/gcov.h>
 
 #define MAX_TESTS 500
 #define STACKSIZE 2048
@@ -340,6 +341,9 @@ void load_store_high(void)
 		if (load_store_high_count == MAX_TESTS) {
 			TC_END_RESULT(TC_PASS);
 			TC_END_REPORT(TC_PASS);
+#ifdef CONFIG_COVERAGE_GCOV
+			gcov_coverage_dump();
+#endif
 			return;
 		}
 	}
@@ -362,3 +366,14 @@ K_THREAD_DEFINE(pi_low, STACKSIZE, calculate_pi_low, NULL, NULL, NULL,
 
 K_THREAD_DEFINE(pi_high, STACKSIZE, calculate_pi_high, NULL, NULL, NULL,
 		HI_PRI, THREAD_FP_FLAGS, K_NO_WAIT);
+
+void main(void *p1, void *p2, void *p3)
+{
+	/* This very old test didn't have a main() function, and would
+	 * dump gcov data immediately. Sleep forever, we'll invoke
+	 * gcov manually later when the test completes.
+	 */
+	while (true) {
+		k_sleep(1000);
+	}
+}


### PR DESCRIPTION
This ancient test had no main() implementation and was dumping coverage immediately after the stub main() exited.

Place a dummy main which sleeps forever, avoiding immediate coverage printout, and manually invoke the gcov dump once the test completes.

Longer term, this needs to be re-written to use ztest.