### PR TITLE
sanitycheck: don't multiply CPU count

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -226,7 +226,6 @@ LAST_SANITY_XUNIT = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk",
                                  "last_sanity.xml")
 RELEASE_DATA = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk",
                             "sanity_last_release.csv")
-JOBS = multiprocessing.cpu_count() * 2
 
 if os.isatty(sys.stdout.fileno()):
     TERMINAL = True
@@ -3259,6 +3258,10 @@ def main():
 
     if options.jobs:
         JOBS = options.jobs
+    elif options.build_only:
+        JOBS = multiprocessing.cpu_count() * 2
+    else:
+        JOBS = multiprocessing.cpu_count()
 
     # Decrease JOBS for Ninja, if jobs weren't explicitly set
     if options.ninja and not options.jobs:


### PR DESCRIPTION
We have a number of timing sensitive tests which run
correctly on a much more frequent basis if the system
is not so heavily loaded. Instead of squeezing a few
more crumbs of performance by doubling the CPU count,
just use the number of CPUs reported by the system.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>