### PR TITLE
print format: adjust specifiers to be compatible with a 64-bit build

### DIFF
--- a/samples/net/lldp/src/main.c
+++ b/samples/net/lldp/src/main.c
@@ -140,7 +140,7 @@ static int init_vlan(void)
 
 static enum net_verdict parse_lldp(struct net_if *iface, struct net_pkt *pkt)
 {
-	LOG_DBG("iface %p Parsing LLDP, len %u", iface, net_pkt_get_len(pkt));
+	LOG_DBG("iface %p Parsing LLDP, len %zu", iface, net_pkt_get_len(pkt));
 
 	net_pkt_cursor_init(pkt);
 

--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -32,7 +32,7 @@ static int netusb_send(struct device *dev, struct net_pkt *pkt)
 
 	ARG_UNUSED(dev);
 
-	LOG_DBG("Send pkt, len %u", net_pkt_get_len(pkt));
+	LOG_DBG("Send pkt, len %zu", net_pkt_get_len(pkt));
 
 	if (!netusb_enabled()) {
 		LOG_ERR("interface disabled");
@@ -54,7 +54,7 @@ struct net_if *netusb_net_iface(void)
 
 void netusb_recv(struct net_pkt *pkt)
 {
-	LOG_DBG("Recv pkt, len %u", net_pkt_get_len(pkt));
+	LOG_DBG("Recv pkt, len %zu", net_pkt_get_len(pkt));
 
 	if (net_recv_data(netusb.iface, pkt) < 0) {
 		LOG_ERR("Packet %p dropped by NET stack", pkt);

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -164,8 +164,8 @@ static void ascii7_to_utf16le(void *descriptor)
 	int ascii_idx_max = USB_BSTRING_ASCII_IDX_MAX(str_descr->bLength);
 	u8_t *buf = (u8_t *)&str_descr->bString;
 
-	LOG_DBG("idx_max %d, ascii_idx_max %d, buf %x",
-		idx_max, ascii_idx_max, (u32_t)buf);
+	LOG_DBG("idx_max %d, ascii_idx_max %d, buf %p",
+		idx_max, ascii_idx_max, buf);
 
 	for (int i = idx_max; i >= 0; i -= 2) {
 		LOG_DBG("char %c : %x, idx %d -> %d",
@@ -409,7 +409,7 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 					return -1;
 				}
 
-				LOG_DBG("Now the wTotalLength is %d",
+				LOG_DBG("Now the wTotalLength is %zd",
 					(u8_t *)head - (u8_t *)cfg_descr);
 				sys_put_le16((u8_t *)head - (u8_t *)cfg_descr,
 					     (u8_t *)&cfg_descr->wTotalLength);

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -1170,7 +1170,7 @@ done:
 			return;
 		}
 
-		LOG_DBG("transfer done, ep=%02x, status=%d, size=%u",
+		LOG_DBG("transfer done, ep=%02x, status=%d, size=%zu",
 			trans->ep, trans->status, trans->tsize);
 
 		trans->cb = NULL;
@@ -1226,7 +1226,8 @@ int usb_transfer(u8_t ep, u8_t *data, size_t dlen, unsigned int flags,
 	struct usb_transfer_data *trans = NULL;
 	int i, key, ret = 0;
 
-	LOG_DBG("transfer start, ep=%02x, data=%p, dlen=%d", ep, data, dlen);
+	LOG_DBG("transfer start, ep=%02x, data=%p, dlen=%zd",
+		ep, data, dlen);
 
 	key = irq_lock();
 

--- a/tests/kernel/mutex/sys_mutex/src/main.c
+++ b/tests/kernel/mutex/sys_mutex/src/main.c
@@ -85,8 +85,7 @@ void thread_05(void)
 	rv = sys_mutex_lock(&mutex_4, K_SECONDS(1));
 	if (rv != -EAGAIN) {
 		tc_rc = TC_FAIL;
-		TC_ERROR("Failed to timeout on mutex 0x%x\n",
-			 (u32_t)&mutex_4);
+		TC_ERROR("Failed to timeout on mutex %p\n", &mutex_4);
 		return;
 	}
 }
@@ -117,7 +116,7 @@ void thread_06(void)
 	rv = sys_mutex_lock(&mutex_4, K_SECONDS(2));
 	if (rv != 0) {
 		tc_rc = TC_FAIL;
-		TC_ERROR("Failed to take mutex 0x%x\n", (u32_t)&mutex_4);
+		TC_ERROR("Failed to take mutex %p\n", &mutex_4);
 		return;
 	}
 
@@ -148,8 +147,7 @@ void thread_07(void)
 	rv = sys_mutex_lock(&mutex_3, K_SECONDS(3));
 	if (rv != -EAGAIN) {
 		tc_rc = TC_FAIL;
-		TC_ERROR("Failed to timeout on mutex 0x%x\n",
-			 (u32_t)&mutex_3);
+		TC_ERROR("Failed to timeout on mutex %p\n", &mutex_3);
 		return;
 	}
 
@@ -172,7 +170,7 @@ void thread_08(void)
 	rv = sys_mutex_lock(&mutex_2, K_FOREVER);
 	if (rv != 0) {
 		tc_rc = TC_FAIL;
-		TC_ERROR("Failed to take mutex 0x%x\n", (u32_t)&mutex_2);
+		TC_ERROR("Failed to take mutex %p\n", &mutex_2);
 		return;
 	}
 
@@ -197,8 +195,7 @@ void thread_09(void)
 	if (rv != -EBUSY) {	/* This attempt to lock the mutex */
 		/* should not succeed. */
 		tc_rc = TC_FAIL;
-		TC_ERROR("Failed to NOT take locked mutex 0x%x\n",
-			 (u32_t)&mutex_1);
+		TC_ERROR("Failed to NOT take locked mutex %p\n", &mutex_1);
 		return;
 	}
 
@@ -206,7 +203,7 @@ void thread_09(void)
 	rv = sys_mutex_lock(&mutex_1, K_FOREVER);
 	if (rv != 0) {
 		tc_rc = TC_FAIL;
-		TC_ERROR("Failed to take mutex 0x%x\n", (u32_t)&mutex_1);
+		TC_ERROR("Failed to take mutex %p\n", &mutex_1);
 		return;
 	}
 
@@ -228,7 +225,7 @@ void thread_11(void)
 	rv = sys_mutex_lock(&mutex_3, K_FOREVER);
 	if (rv != 0) {
 		tc_rc = TC_FAIL;
-		TC_ERROR("Failed to take mutex 0x%x\n", (u32_t)&mutex_2);
+		TC_ERROR("Failed to take mutex %p\n", &mutex_2);
 		return;
 	}
 	sys_mutex_unlock(&mutex_3);
@@ -284,8 +281,7 @@ void test_mutex(void)
 
 	for (i = 0; i < 4; i++) {
 		rv = sys_mutex_lock(mutexes[i], K_NO_WAIT);
-		zassert_equal(rv, 0, "Failed to lock mutex 0x%x\n",
-			      (u32_t)mutexes[i]);
+		zassert_equal(rv, 0, "Failed to lock mutex %p\n", mutexes[i]);
 		k_sleep(K_SECONDS(1));
 
 		rv = k_thread_priority_get(k_current_get());

--- a/tests/subsys/usb/bos/src/test_bos.c
+++ b/tests/subsys/usb/bos/src/test_bos.c
@@ -196,7 +196,7 @@ static void test_usb_bos_macros(void)
 	const struct usb_bos_descriptor *hdr = usb_bos_get_header();
 	size_t len = usb_bos_get_length();
 
-	TC_PRINT("length %u\n", len);
+	TC_PRINT("length %zu\n", len);
 
 	usb_bos_register_cap((void *)&cap_webusb);
 	usb_bos_register_cap((void *)&cap_msosv2);


### PR DESCRIPTION
The size_t type is either compatible with an int on 32-bit target, or
a long on 64-bit targets. It could even be a long even on some 32-bit
targets. Let's use the z qualifier in the printf format to be compatible
with whatever flavor in use.

In case of pointers, let's just use %p with pointers directly and
avoid casts altogether.