### PR TITLE
cmake: check ZEPHYR_SDK_INSTALL_DIR is set

### DIFF
--- a/cmake/toolchain/zephyr/generic.cmake
+++ b/cmake/toolchain/zephyr/generic.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT DEFINED SDK_VERSION)
-  message(FATAL_ERROR "SDK_VERSION must be set")
+if (NOT ZEPHYR_SDK_INSTALL_DIR)
+  message(FATAL_ERROR "ZEPHYR_SDK_INSTALL_DIR must be set")
 endif()
 
 include(${ZEPHYR_BASE}/cmake/toolchain/zephyr/${SDK_VERSION}/generic.cmake)


### PR DESCRIPTION
Check for ZEPHYR_SDK_INSTALL_DIR being invalid instead of
checking for SDK_VERSION being not defined. This change
relates to commit bb09c458c18f ("cmake: Prevent infinite
recursion").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>