### PR TITLE
net: mgmt: Remove L1 layer as that is useless

### DIFF
--- a/include/net/net_event.h
+++ b/include/net/net_event.h
@@ -26,7 +26,7 @@ extern "C" {
 /** @cond INTERNAL_HIDDEN */
 
 /* Network Interface events */
-#define _NET_IF_LAYER		NET_MGMT_LAYER_L1
+#define _NET_IF_LAYER		NET_MGMT_LAYER_L2
 #define _NET_IF_CORE_CODE	0x001
 #define _NET_EVENT_IF_BASE	(NET_MGMT_EVENT_BIT |			\
 				 NET_MGMT_IFACE_BIT |			\

--- a/include/net/net_mgmt.h
+++ b/include/net/net_mgmt.h
@@ -66,9 +66,8 @@ struct net_if;
 
 
 /* Useful generic definitions */
-#define NET_MGMT_LAYER_L1		1
-#define NET_MGMT_LAYER_L2		2
-#define NET_MGMT_LAYER_L3		3
+#define NET_MGMT_LAYER_L2		1
+#define NET_MGMT_LAYER_L3		2
 
 /** @endcond */
 


### PR DESCRIPTION
The network interface events should be in L2 layer so there
is no one that would emit L1 events so no need for it.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>