### PR TITLE
tests: net: socket: register: Do not close if fd < 0

### DIFF
--- a/tests/net/socket/register/src/main.c
+++ b/tests/net/socket/register/src/main.c
@@ -247,7 +247,9 @@ void test_create_sockets(void)
 			failed_tests++;
 		}
 
-		close(fd);
+		if (fd >= 0) {
+			close(fd);
+		}
 	}
 
 	zassert_equal(ok_tests + failed_tests - failed_family, func_called,


### PR DESCRIPTION
If the socket descriptor is invalid, there is no need to try
to close it.

Coverity-CID: 198949
Fixes #16785

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>