### PR TITLE
drivers/interrupt_controller: stm32: Fix table irq reading

### DIFF
--- a/drivers/interrupt_controller/exti_stm32.c
+++ b/drivers/interrupt_controller/exti_stm32.c
@@ -98,7 +98,7 @@ int stm32_exti_enable(int line)
 	}
 
 	/* Get matching exti irq mathcing provided line thanks to irq_table */
-	if (line <= ARRAY_SIZE(exti_irq_table)) {
+	if (line < ARRAY_SIZE(exti_irq_table)) {
 		irqnum = exti_irq_table[line];
 		if (irqnum == 0xFF)
 			return 0;


### PR DESCRIPTION
We allow reading too far in exti_irq_table.
Fix if condition.

Fixes #17200

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>