### PR TITLE
cmake: Toolchain abstraction: Allow for out-of-tree cmake includes

### DIFF
--- a/cmake/generic_toolchain.cmake
+++ b/cmake/generic_toolchain.cmake
@@ -65,4 +65,5 @@ include(${TOOLCHAIN_ROOT}/cmake/toolchain/${ZEPHYR_TOOLCHAIN_VARIANT}/generic.cm
 
 # Configure the toolchain based on what toolchain technology is used
 # (gcc, host-gcc etc.)
-include(${ZEPHYR_BASE}/cmake/compiler/${COMPILER}/generic.cmake OPTIONAL)
+include(${TOOLCHAIN_ROOT}/cmake/compiler/${COMPILER}/generic.cmake OPTIONAL)
+include(${TOOLCHAIN_ROOT}/cmake/linker/${LINKER}/generic.cmake OPTIONAL)

--- a/cmake/target_toolchain.cmake
+++ b/cmake/target_toolchain.cmake
@@ -46,8 +46,8 @@ unset(CMAKE_C_COMPILER CACHE)
 # In Zephyr, toolchains require a port under cmake/toolchain/.
 # Each toolchain port must set COMPILER and LINKER.
 # E.g. toolchain/llvm may pick {clang, ld} or {clang, lld}.
-include(${ZEPHYR_BASE}/cmake/compiler/${COMPILER}/target.cmake OPTIONAL)
-include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target.cmake OPTIONAL)
+include(${TOOLCHAIN_ROOT}/cmake/compiler/${COMPILER}/target.cmake OPTIONAL)
+include(${TOOLCHAIN_ROOT}/cmake/linker/${LINKER}/target.cmake OPTIONAL)
 
 # Uniquely identify the toolchain wrt. it's capabilities.
 #


### PR DESCRIPTION
This allows for inclusion of out-of-tree toolchain cmake files
relating to compiler and linker for both target and generic
toolchains.
The base path used was ZEPHYR_BASE, instead of TOOLCHAIN_ROOT, thus
making it impossible to load the out-of-tree toolchain specific
cmake files.
In addition, the generic toolchain may now specify a generic cmake
file for the linker, similar to the target toolchain linker.

The intent here is to abstract Zephyr's dependence on toolchains,
thus allowing for easier porting to other, perhaps commercial,
toolchains and/or usecases.

No functional change expected.

Part of #16031