### PR TITLE
driver: timer: loapic_timer: fix compile issue

### DIFF
--- a/drivers/timer/loapic_timer.c
+++ b/drivers/timer/loapic_timer.c
@@ -667,7 +667,7 @@ int z_clock_device_ctrl(struct device *port, u32_t ctrl_command,
 	}
 
 	if (cb) {
-		cb(dev, ret, context, arg);
+		cb(port, ret, context, arg);
 	}
 
 	return ret;


### PR DESCRIPTION
fix compile issue when DEVICE_POWER_MANAGEMENT enabled.

Signed-off-by: Wentong Wu <wentong.wu@intel.com>