### PR TITLE
ext: hal: nordic: Fix DT symbols in 802154 radio driver

### DIFF
--- a/ext/hal/nordic/drivers/nrf_radio_802154/platform/clock/nrf_802154_clock_zephyr.c
+++ b/ext/hal/nordic/drivers/nrf_radio_802154/platform/clock/nrf_802154_clock_zephyr.c
@@ -60,7 +60,7 @@ void nrf_802154_clock_hfclk_start(void)
 {
     struct device *clk_m16;
 
-    clk_m16 = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_16M");
+    clk_m16 = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL "_16M");
     __ASSERT_NO_MSG(clk_m16 != NULL);
 
     clock_control_on(clk_m16, (void *)1); /* Blocking call. */
@@ -74,7 +74,7 @@ void nrf_802154_clock_hfclk_stop(void)
 {
     struct device *clk_m16;
 
-    clk_m16 = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_16M");
+    clk_m16 = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL "_16M");
     __ASSERT_NO_MSG(clk_m16 != NULL);
 
     hfclk_is_running = false;
@@ -91,7 +91,7 @@ void nrf_802154_clock_lfclk_start(void)
 {
     struct device *clk_k32;
 
-    clk_k32 = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_32K");
+    clk_k32 = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL "_32K");
     __ASSERT_NO_MSG(clk_k32 != NULL);
 
     clock_control_on(clk_k32, (void *)CLOCK_CONTROL_NRF_K32SRC);
@@ -105,7 +105,7 @@ void nrf_802154_clock_lfclk_stop(void)
 {
     struct device *clk_k32;
 
-    clk_k32 = device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_32K");
+    clk_k32 = device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL "_32K");
     __ASSERT_NO_MSG(clk_k32 != NULL);
 
     lfclk_is_running = false;


### PR DESCRIPTION
nRF 802.15.4 radio driver used deprecated DT symbols, causing build warnings.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>