### PR TITLE
net: openthread: Verify iface in net_mgmt event handler

### DIFF
--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -69,6 +69,10 @@ static void ipv6_addr_event_handler(struct net_mgmt_event_callback *cb,
 {
 	struct openthread_context *ot_context = net_if_l2_data(iface);
 
+	if (net_if_l2(iface) != &NET_L2_GET_NAME(OPENTHREAD)) {
+		return;
+	}
+
 	if (mgmt_event == NET_EVENT_IPV6_ADDR_ADD) {
 		add_ipv6_addr_to_ot(ot_context);
 	} else if (mgmt_event == NET_EVENT_IPV6_MADDR_ADD) {


### PR DESCRIPTION
OpenThread did not verify if the interface provided in the net_mgmt
handler is actually an OpenThread interface. In result, when multiple
network interfaces were used, different interfaces were processed by the
OpenThread handler, ending up in a crash.

Fixes #15975.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>