### PR TITLE
sanitycheck: workaround file limits

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -189,6 +189,7 @@ import serial
 import concurrent
 import concurrent.futures
 import xml.etree.ElementTree as ET
+import resource
 from xml.sax.saxutils import escape
 from collections import OrderedDict
 from itertools import islice
@@ -3249,6 +3250,9 @@ def main():
     global VERBOSE, INLINE_LOGS, JOBS, log_file
     global options
     global run_individual_tests
+
+    # XXX: Workaround for #17239
+    resource.setrlimit(resource.RLIMIT_NOFILE, (4096, 4096))
     options = parse_arguments()
 
     if options.coverage:


### PR DESCRIPTION
sanitycheck is opening an insane number of file descriptors
simultaneously as it opens up communication pipes with
every test that supports emulation, on every emulated
board target.

Increase the resource limit on open files until this code
can be properly refactored.

Workaround for: #17239

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>