### PR TITLE
subsys tracing: remove (uintptr_t) casts in snprintk and use %p

### DIFF
--- a/subsys/debug/tracing/include/tracing_sysview.h
+++ b/subsys/debug/tracing/include/tracing_sysview.h
@@ -56,8 +56,7 @@ static inline void sys_trace_thread_info(struct k_thread *thread)
 {
 	char name[20];
 
-	snprintk(name, sizeof(name), "T%xE%x", (uintptr_t)thread,
-		 (uintptr_t)&thread->entry);
+	snprintk(name, sizeof(name), "T%pE%p", thread, &thread->entry);
 
 	SEGGER_SYSVIEW_TASKINFO Info;
 

--- a/subsys/debug/tracing/sysview.c
+++ b/subsys/debug/tracing/sysview.c
@@ -65,8 +65,7 @@ static void send_task_list_cb(void)
 			continue;
 		}
 
-		snprintk(name, sizeof(name), "T%xE%x", (uintptr_t)thread,
-			 (uintptr_t)&thread->entry);
+		snprintk(name, sizeof(name), "T%pE%p", thread, &thread->entry);
 		SEGGER_SYSVIEW_SendTaskInfo(&(SEGGER_SYSVIEW_TASKINFO) {
 			.TaskID = (u32_t)(uintptr_t)thread,
 		      .sName = tname?tname:name,


### PR DESCRIPTION
Fixes -Werror=format: '%x' expects argument of type 'unsigned int', but
argument N has type 'long unsigned int'

Reproduced with sanitycheck -p bl652_dvk (or -p any other
HAS_SEGGER_RTT) and by adding CONFIG_SEGGER_SYSTEMVIEW=y to
samples/philosophers/prj.conf. sanitycheck adds -Werror.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>