### PR TITLE
tests/net/ptp/clock: add 'userspace' tag

### DIFF
--- a/tests/net/ptp/clock/testcase.yaml
+++ b/tests/net/ptp/clock/testcase.yaml
@@ -3,4 +3,4 @@ common:
 tests:
   net.ptp.clock:
     min_ram: 32
-    tags: net ptp gptp
+    tags: net ptp gptp userspace


### PR DESCRIPTION
... because this test does use userspace, as seen in the source or
demonstrated by the failure of this command:

  sanitycheck --extra-args=CONFIG_TEST_USERSPACE=n

See commit message of 4afcc0f8af2b for the long story.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>