### PR TITLE
struct net_mgmt_socket: use uintptr_t for the nm_pid field

### DIFF
--- a/include/net/socket_net_mgmt.h
+++ b/include/net/socket_net_mgmt.h
@@ -52,7 +52,7 @@ extern "C" {
  * When used with bind(), the nm_pid field of the sockaddr_nm can be
  * filled with the calling thread' own id. The nm_pid serves here as the local
  * address of this net_mgmt socket. The application is responsible for picking
- * a unique 32-bit integer to fill in nm_pid.
+ * a unique integer value to fill in nm_pid.
  */
 struct sockaddr_nm {
 	/** AF_NET_MGMT address family. */
@@ -64,7 +64,7 @@ struct sockaddr_nm {
 	/** Thread id or similar that is used to separate the different
 	 * sockets. Application can decide how the pid is constructed.
 	 */
-	u32_t nm_pid;
+	uintptr_t nm_pid;
 
 	/** net_mgmt mask */
 	u32_t nm_mask;

--- a/samples/net/sockets/net_mgmt/src/main.c
+++ b/samples/net/sockets/net_mgmt/src/main.c
@@ -97,7 +97,7 @@ static void listener(void)
 
 	sockaddr.nm_family = AF_NET_MGMT;
 	sockaddr.nm_ifindex = 0; /* Any network interface */
-	sockaddr.nm_pid = (int)k_current_get();
+	sockaddr.nm_pid = (uintptr_t)k_current_get();
 	sockaddr.nm_mask = NET_EVENT_IPV6_DAD_SUCCEED |
 			    NET_EVENT_IPV6_ADDR_ADD |
 			    NET_EVENT_IPV6_ADDR_DEL;

--- a/subsys/net/lib/sockets/sockets_net_mgmt.c
+++ b/subsys/net/lib/sockets/sockets_net_mgmt.c
@@ -28,7 +28,7 @@ struct net_mgmt_socket {
 	struct net_if *iface;
 
 	/* A way to separate different sockets that listen same events */
-	u32_t pid;
+	uintptr_t pid;
 
 	/* net_mgmt mask */
 	u32_t mask;

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -354,7 +354,7 @@ static void test_net_mgmt_setup(void)
 
 	sockaddr.nm_family = AF_NET_MGMT;
 	sockaddr.nm_ifindex = net_if_get_by_iface(net_if_get_default());
-	sockaddr.nm_pid = (int)k_current_get();
+	sockaddr.nm_pid = (uintptr_t)k_current_get();
 	sockaddr.nm_mask = NET_EVENT_IPV6_DAD_SUCCEED |
 			   NET_EVENT_IPV6_ADDR_ADD |
 			   NET_EVENT_IPV6_ADDR_DEL;


### PR DESCRIPTION
This may contain a pointer so make sure it is sufficiently wide
on 64-bit targets.