### PR TITLE
net/socket: use the iterable section object constructor/iterator

### DIFF
--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -70,10 +70,9 @@
 #if defined(CONFIG_NET_SOCKETS)
 	SECTION_PROLOGUE(net_socket_register,,)
 	{
-		__net_socket_register_start = .;
-		*(".net_socket_register.init")
-		KEEP(*(SORT_BY_NAME(".net_socket_register.init*")))
-		__net_socket_register_end = .;
+		_net_socket_register_list_start = .;
+		KEEP(*(SORT_BY_NAME("._net_socket_register.*")))
+		_net_socket_register_list_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif
 

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -760,9 +760,8 @@ struct net_socket_register {
 	(__net_socket_register_##socket_name)
 
 #define NET_SOCKET_REGISTER(socket_name, _family, _is_supported, _handler) \
-	static const struct net_socket_register				\
-			(NET_SOCKET_GET_NAME(socket_name)) __used	\
-	__attribute__((__section__(".net_socket_register.init"))) = {	\
+	static const Z_STRUCT_SECTION_ITERABLE(net_socket_register,	\
+			NET_SOCKET_GET_NAME(socket_name)) = {		\
 		.family = _family,					\
 		.is_supported = _is_supported,				\
 		.handler = _handler,					\

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -21,9 +21,6 @@ LOG_MODULE_REGISTER(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include "sockets_internal.h"
 
-extern struct net_socket_register __net_socket_register_start[];
-extern struct net_socket_register __net_socket_register_end[];
-
 #define SET_ERRNO(x) \
 	{ int _err = x; if (_err < 0) { errno = -_err; return -1; } }
 
@@ -133,11 +130,7 @@ int zsock_socket_internal(int family, int type, int proto)
 
 int z_impl_zsock_socket(int family, int type, int proto)
 {
-	struct net_socket_register *sock_family;
-
-	for (sock_family = __net_socket_register_start;
-	     sock_family != __net_socket_register_end;
-	     sock_family++) {
+	Z_STRUCT_SECTION_FOREACH(net_socket_register, sock_family) {
 		if (sock_family->family != family &&
 		    sock_family->family != AF_UNSPEC) {
 			continue;


### PR DESCRIPTION
The handcrafted allocation falls victim of misaligned structures due to
toolchain padding which crashes the socket test code on 64-bit targets.
Let's move it to the iterable section utility where those issues are
already taken care of.