### PR TITLE
bluetooth: use the iterable section object constructor/iterator

### DIFF
--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -79,9 +79,9 @@
 
 	SECTION_DATA_PROLOGUE(_bt_channels_area,,SUBALIGN(4))
 	{
-		_bt_channels_start = .;
-		KEEP(*(SORT_BY_NAME("._bt_channels.static.*")))
-		_bt_channels_end = .;
+		_bt_l2cap_fixed_chan_list_start = .;
+		KEEP(*(SORT_BY_NAME("._bt_l2cap_fixed_chan.*")))
+		_bt_l2cap_fixed_chan_list_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 #if defined(CONFIG_BT_BREDR)

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -50,10 +50,6 @@
 #define L2CAP_CONN_TIMEOUT	K_SECONDS(40)
 #define L2CAP_DISC_TIMEOUT	K_SECONDS(2)
 
-/* Linker-defined symbols bound to the bt_l2cap_fixed_chan structs */
-extern const struct bt_l2cap_fixed_chan _bt_channels_start[];
-extern const struct bt_l2cap_fixed_chan _bt_channels_end[];
-
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 /* Size of MTU is based on the maximum amount of data the buffer can hold
  * excluding ACL and driver headers.
@@ -323,7 +319,6 @@ static bool l2cap_chan_add(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 
 void bt_l2cap_connected(struct bt_conn *conn)
 {
-	const struct bt_l2cap_fixed_chan *fchan;
 	struct bt_l2cap_chan *chan;
 
 	if (IS_ENABLED(CONFIG_BT_BREDR) &&
@@ -332,7 +327,7 @@ void bt_l2cap_connected(struct bt_conn *conn)
 		return;
 	}
 
-	for (fchan = _bt_channels_start; fchan < _bt_channels_end; fchan++) {
+	Z_STRUCT_SECTION_FOREACH(bt_l2cap_fixed_chan, fchan) {
 		struct bt_l2cap_le_chan *ch;
 
 		if (fchan->accept(conn, &chan) < 0) {

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -205,8 +205,7 @@ struct bt_l2cap_fixed_chan {
 };
 
 #define BT_L2CAP_CHANNEL_DEFINE(_name, _cid, _accept)		\
-	const struct bt_l2cap_fixed_chan _name __aligned(4)	\
-			__in_section(_bt_channels, static, _name) = { \
+	const Z_STRUCT_SECTION_ITERABLE(bt_l2cap_fixed_chan, _name) = {	\
 				.cid = _cid,			\
 				.accept = _accept,		\
 			}


### PR DESCRIPTION
Use the iterable section object constructor with BT_L2CAP_CHANNEL_DEFINE
to simplify the code and avoid common pitfalls on 64-bit targets.

I also wanted to convert _bt_br_channels_start/_bt_br_channels_end but
nothing appears to allocate anything in the ._bt_br_channels.static.*
linker section so I left it alone. Someone familiar with this code would
need to figure out if related code is still relevant. And a different
struct type name would be needed too if it needs to stay separate.