### PR TITLE
shell_history: align buffer to pointer size

### DIFF
--- a/include/shell/shell_history.h
+++ b/include/shell/shell_history.h
@@ -31,7 +31,7 @@ struct shell_history {
  * @param _size Memory dedicated for shell history.
  */
 #define SHELL_HISTORY_DEFINE(_name, _size) \
-	static u8_t __noinit __aligned(sizeof(u32_t)) \
+	static u8_t __noinit __aligned(sizeof(void *)) \
 			_name##_ring_buf_data[_size]; \
 	static struct ring_buf _name##_ring_buf = \
 		{ \


### PR DESCRIPTION
The code in shell_history_put() adds padding to new entries so they
are pointer aligned. The whole buffer has to be so aligned too.