### PR TITLE
shell_history_test: make the test succeed on 64-bit targets

### DIFF
--- a/tests/subsys/shell/shell_history/src/shell_history_test.c
+++ b/tests/subsys/shell/shell_history/src/shell_history_test.c
@@ -14,7 +14,7 @@
 
 #include <shell/shell_history.h>
 
-#define HIST_BUF_SIZE 128
+#define HIST_BUF_SIZE 160
 SHELL_HISTORY_DEFINE(history, HIST_BUF_SIZE);
 
 static void init_test_buf(u8_t *buf, size_t len, u8_t offset)


### PR DESCRIPTION
A buffer size of 128 bytes is just not quite big enough on 64-bit
targets.