### PR TITLE
test/msgq: adjust overflow test for 64-bit targets

### DIFF
--- a/tests/kernel/msgq/msgq_api/src/test_msgq.h
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq.h
@@ -10,6 +10,7 @@
 #include <zephyr.h>
 #include <irq_offload.h>
 #include <ztest.h>
+#include <limits.h>
 
 #define TIMEOUT 100
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
@@ -17,5 +18,5 @@
 #define MSGQ_LEN 2
 #define MSG0 0xABCD
 #define MSG1 0x1234
-#define OVERFLOW_SIZE_MSG 0xDEADBEEF
+#define OVERFLOW_SIZE_MSG SIZE_MAX
 #endif /* __TEST_MSGQ_H__ */


### PR DESCRIPTION
This is testing size_mul_overflow() in z_impl_k_msgq_alloc_init() so
make sure OVERFLOW_SIZE_MSG is large enough even on 64-bit targets.