### PR TITLE
CODEWONERS: syntax fix: Remove comma

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -197,7 +197,7 @@
 /ext/hal/atmel/asf/sam/include/same70*/   @aurel32
 /ext/hal/atmel/asf/sam0/include/samr21/   @benpicco
 /dts/bindings/sensor/*bme680*             @BoschSensortec
-/dts/bindings/sensor/st,*                 @avisconti
+/dts/bindings/sensor/st*                  @avisconti
 /ext/hal/cmsis/                           @MaureenHelm @galak
 /ext/hal/microchip/                       @franciscomunoz @albertofloyd @scottwcpg
 /ext/hal/nordic/                          @carlescufi @anangl


### PR DESCRIPTION
A comma was added to a new path in
9dbdd81abe22dcbc671ea066cfdfc041d71f3c83

But GitHub's CODEOWNERS parsing cannot handle commas in paths
=> Remove it

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

--------------
Related to #16000
Fixes #17342