### PR TITLE
dts/arm/st: l0: Fix gpioe reg address

### DIFF
--- a/dts/arm/st/l0/stm32l072.dtsi
+++ b/dts/arm/st/l0/stm32l072.dtsi
@@ -14,7 +14,7 @@
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
-				reg = <0x48001000 0x400>;
+				reg = <0x50001000 0x400>;
 				clocks = <&rcc STM32_CLOCK_BUS_IOP 0x00000010>;
 				label = "GPIOE";
 			};


### PR DESCRIPTION
Fix reg to 0x50001000.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>