### PR TITLE
net: lwm2m: Ignore `close` return value

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -450,7 +450,7 @@ int lwm2m_firmware_start_transfer(char *package_uri)
 	/* close old socket */
 	if (firmware_ctx.sock_fd > 0) {
 		lwm2m_socket_del(&firmware_ctx);
-		close(firmware_ctx.sock_fd);
+		(void)close(firmware_ctx.sock_fd);
 	}
 
 	(void)memset(&firmware_ctx, 0, sizeof(struct lwm2m_ctx));


### PR DESCRIPTION
Explicitly ignore return value from `close` call.

Coverity-CID: 198870

Fixes #16577.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>