### PR TITLE
Bluetooth: L2CAP: fix use of Z_STRUCT_SECTION_ITERABLE

### DIFF
--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -210,8 +210,11 @@ struct bt_l2cap_fixed_chan {
 				.accept = _accept,		\
 			}
 
-/* Need a different name for the sections not to conflict */
-#define bt_l2cap_br_fixed_chan bt_l2cap_fixed_chan
+/* Need a name different than bt_l2cap_fixed_chan for a different section */
+struct bt_l2cap_br_fixed_chan {
+	u16_t		cid;
+	int (*accept)(struct bt_conn *conn, struct bt_l2cap_chan **chan);
+};
 
 #define BT_L2CAP_BR_CHANNEL_DEFINE(_name, _cid, _accept)		\
 	const Z_STRUCT_SECTION_ITERABLE(bt_l2cap_br_fixed_chan, _name) = { \


### PR DESCRIPTION
Two sections are needed: bt_l2cap_fixed_chan and bt_l2cap_br_fixed_chan.
However the second one cannot be created using #define as the
preprocessor will expand it to the first before compilation happens,
sending bt_l2cap_br_fixed_chan instances in the wrong section.

This fixes commit 4e8ddfd640f9 ("Bluetooth: L2CAP: Make use of
Z_STRUCT_SECTION_ITERABLE") that was introduced in PR #17197.