### PR TITLE
dts: stm32l4: Fix USB phy node for stm32l432 and stm32l452

### DIFF
--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -15,15 +15,15 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
-			phys = <&otgfs_phy>;
+			phys = <&usb_fs_phy>;
 			status = "disabled";
 			label = "USB";
 		};
 	};
 
-	otgfs_phy: otgfs_phy {
+	usb_fs_phy: usbphy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;
-		label = "OTGFS_PHY";
+		label = "USB_FS_PHY";
 	};
 };

--- a/dts/arm/st/l4/stm32l452.dtsi
+++ b/dts/arm/st/l4/stm32l452.dtsi
@@ -35,7 +35,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
-			phys = <&otgfs_phy>;
+			phys = <&usb_fs_phy>;
 			status = "disabled";
 			label = "USB";
 		};
@@ -123,9 +123,9 @@
 		};
 	};
 
-	otgfs_phy: otgfs_phy {
+	usb_fs_phy: usbphy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;
-		label = "OTGFS_PHY";
+		label = "USB_FS_PHY";
 	};
 };


### PR DESCRIPTION
Fix USB phy node for stm32l432 and stm32l452, which contain
a USB controller and not a OTG FS controller.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>