### PR TITLE
doc: update coverage documentation

### DIFF
--- a/doc/guides/coverage.rst
+++ b/doc/guides/coverage.rst
@@ -125,29 +125,21 @@ You may postprocess these with your preferred tools. For example:
    genhtml lcov.info --output-directory lcov_html -q --ignore-errors source --branch-coverage --highlight --legend
 
 Sanitycheck coverage reports
-============================
+****************************
 
-When targeting boards based on the POSIX architecture,
 Zephyr's :ref:`sanitycheck script <sanitycheck_script>` can automatically
 generate a coverage report from the tests which were executed.
-You just need to invoke it with the ``-C`` command line option.
+You just need to invoke it with the ``--coverage`` command line option.
 
-For example you may run::
+For example, you may invoke::
 
-    $ sanitycheck -p native_posix -T tests/kernel -C
+    $ sanitycheck --coverage -p qemu_x86 -T tests/kernel
+
+or::
+
+    $ sanitycheck --coverage -p native_posix -T tests/bluetooth
 
 which will produce ``sanity-out/coverage/index.html`` with the report.
-
-For emulated targets you will need to pass the correct ``gcov`` binary from
-the SDK, the default of using the ``gcov`` found in the default path is likely
-not going to work. For example, to produce reports using the
-``qemu_x86_coverage`` target::
-
-    $ sanitycheck --coverage --coverage-platform=qemu_x86_coverage -p qemu_x86_coverage --gcov-tool $ZEPHYR_SDK_INSTALL_DIR/i586-zephyr-elf/bin/i586-zephyr-elf-gcov
-
-You can find the paths to all the ``gcov`` binaries in the SDK with::
-
-    $ find $ZEPHYR_SDK_INSTALL_DIR -iregex ".*gcov"
 
 .. _gcov:
    https://gcc.gnu.org/onlinedocs/gcc/Gcov.html

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3022,17 +3022,9 @@ Artificially long but functional example:
         """
     )
 
-    if "ZEPHYR_SDK_INSTALL_DIR" in os.environ:
-        # Use the x86 build of GCOV from the SDK. This can parse gcov data
-        # from any arch built with the same GCC version.
-        gcov_bin = os.path.join(os.environ["ZEPHYR_SDK_INSTALL_DIR"],
-                "i586-zephyr-elf/bin/i586-zephyr-elf-gcov")
-    else:
-        # No SDK in use, just rely on PATH to find it
-        gcov_bin = "gcov"
-
-    parser.add_argument("--gcov-tool", default=gcov_bin,
-                        help="Path to the gcov tool. Default is %s" % gcov_bin)
+    parser.add_argument("--gcov-tool", default=None,
+                        help="Path to the gcov tool to use for code coverage "
+                        "reports")
 
     parser.add_argument("--enable-coverage", action="store_true",
                         help="Enable code coverage using gcov.")
@@ -3540,6 +3532,20 @@ def main():
             failed += 1
 
     if options.coverage:
+        if options.gcov_tool == None:
+            using_posix = False
+
+            for plat in options.coverage_platform:
+                ts_plat = ts.get_platform(plat)
+                if ts_plat and ts_plat.type == "native":
+                    using_posix = True
+
+            if using_posix or "ZEPHYR_SDK_INSTALL_DIR" not in os.environ:
+                options.gcov_tool = "gcov"
+            else:
+                options.gcov_tool = os.path.join(os.environ["ZEPHYR_SDK_INSTALL_DIR"],
+                    "i586-zephyr-elf/bin/i586-zephyr-elf-gcov")
+
         info("Generating coverage files...")
         generate_coverage(options.outdir, ["*generated*", "tests/*", "samples/*"])
 


### PR DESCRIPTION
- The sanitycheck defaults have changed.

- Sanitycheck attempts to select the right gcov binary based on selected platforms

Fixes: #17366 
Fixes: #17365 

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>