### PR TITLE
Revert "net: sockets: Make NET_SOCKETS_POSIX_NAMES depend on !POSIX_API"

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -15,7 +15,6 @@ if NET_SOCKETS
 
 config NET_SOCKETS_POSIX_NAMES
 	bool "Standard POSIX names for Sockets API"
-	depends on !POSIX_API
 	help
 	  By default, Sockets API function are prefixed with ``zsock_`` to avoid
 	  namespacing issues. If this option is enabled, they will be provided


### PR DESCRIPTION
This reverts commit 0fb8a917e6cfd2d93711cd1e06074315800e6c95.
Our system is not yet ready for this change and it is causing
issues if one wishes to use both generic Posix APIs and
BSD networking APIs.

Fixes #17353

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>