### PR TITLE
drivers/gpio: stm32h7: Don't use HSEM_CR_COREID_CURRENT as process id

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -318,7 +318,7 @@ static int gpio_stm32_config(struct device *dev, int access_op,
 	}
 
 #if defined(CONFIG_STM32H7_DUAL_CORE)
-	LL_HSEM_ReleaseLock(HSEM, LL_HSEM_ID_1, HSEM_CR_COREID_CURRENT);
+	LL_HSEM_ReleaseLock(HSEM, LL_HSEM_ID_1, 0);
 #endif /* CONFIG_STM32H7_DUAL_CORE */
 
 	return 0;


### PR DESCRIPTION
HSEM_CR_COREID_CURRENT was used as process number parameter in
LL_HSEM_ReleaseLock function. While this is working, this
define should not be used in this context.
Also, process number parameter is actually proposed in case of HSEM
use in inter-process context but is not required for inter-core
resource lock. Replace HSEM_CR_COREID_CURRENT with 0.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>