### PR TITLE
kernel: timeout: do not active time slicing if idle thread ready

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -297,6 +297,8 @@ void z_time_slice(int ticks)
 		} else {
 			_current_cpu->slice_ticks -= ticks;
 		}
+	} else {
+		_current_cpu->slice_ticks = 0;
 	}
 }
 #else


### PR DESCRIPTION
In one time slicing interval, there is a swap from the only working thread to idle thread, so the _current will be _idle_thread, when the timer interrupt comes later, in function z_time_slice, _current_cpu->slice_ticks will not be zero, so in next_timeout it will always return the current value of _current_cpu->slice_ticks and that will cause time slicing wake up system periodically,  the value of _current_cpu->slice_ticks in the idle thread condition and resume it appropriately, so that system can stay low power state longer time.

Fixes: #17368.

Signed-off-by: Wentong Wu <wentong.wu@intel.com>