### PR TITLE
debug: tracing: Rewrite assert on current_thread in CPU stats module

### DIFF
--- a/subsys/debug/tracing/cpu_stats.c
+++ b/subsys/debug/tracing/cpu_stats.c
@@ -123,7 +123,7 @@ void sys_trace_thread_switched_out(void)
 	int key = irq_lock();
 
 	__ASSERT_NO_MSG(nested_interrupts == 0);
-	__ASSERT_NO_MSG(current_thread == k_current_get());
+	__ASSERT_NO_MSG(!current_thread || (current_thread == k_current_get()));
 
 	cpu_stats_update_counters();
 	last_cpu_state = CPU_STATE_SCHEDULER;


### PR DESCRIPTION
The function sys_trace_thread_switched_out asserts in case
sys_trace_thread_switched_in was not called first. This is unintended
as tracing.h describes that out should be called before in, thus the
reverse of what the assert expects.
Removing the assert, also negates the need for the current_thread
variable.
