### PR TITLE
tests: kernel: critical: alternative test-case for SAM SoCs with WDT

### DIFF
--- a/tests/kernel/critical/testcase.yaml
+++ b/tests/kernel/critical/testcase.yaml
@@ -4,6 +4,11 @@ common:
 tests:
   kernel.common:
     platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    filter: not CONFIG_WDT_SAM
+  kernel.common.sam:
+    filter: CONFIG_WDT_SAM
+    extra_configs:
+     - CONFIG_WDT_DISABLE_AT_BOOT=y
   kernel.common.nsim:
     platform_whitelist: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
     extra_configs:


### PR DESCRIPTION
In SAM SoCs Watchdog is selected by default and runs
with some default configuration, unless the build sets
CONFIG_WDT_DISABLE_AT_BOOT. As the tests/kernel/critical
takes relatively large amount of time to complete, the
watchdog (that is never fed in the test) will eventually
trigger a reset. As a result the test keeps restarting
continuously and never completes. We want to run the
test on SAM SoCs, so we do the following:
- filter our the SAM SoCs with the SAM WDT from the
  default build
- introduce an alternative test-case for these SoCs
  with the additional CONFIG_WDT_DISABLE_AT_BOOT
  option set.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Closes #15411 