### PR TITLE
drivers: spi_nor: support Microchip SPI flash global unblock

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -322,6 +322,12 @@ static int spi_nor_write_protection_set(struct device *dev, bool write_protect)
 	ret = spi_nor_cmd_write(dev, (write_protect) ?
 	      SPI_NOR_CMD_WRDI : SPI_NOR_CMD_WREN);
 
+#if DT_INST_0_JEDEC_SPI_NOR_JEDEC_ID_0 == 0xbf && DT_INST_0_JEDEC_SPI_NOR_JEDEC_ID_1 == 0x26
+	if (ret == 0 && !write_protect) {
+		ret = spi_nor_cmd_write(dev, SPI_NOR_CMD_MCHP_UNLOCK);
+	}
+#endif
+
 	SYNC_UNLOCK();
 
 	return ret;

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -34,5 +34,6 @@ struct spi_nor_config {
 #define SPI_NOR_CMD_BE          0xD8    /* Block erase */
 #define SPI_NOR_CMD_CE          0xC7    /* Chip erase */
 #define SPI_NOR_CMD_RDID        0x9F    /* Read JEDEC ID */
+#define SPI_NOR_CMD_MCHP_UNLOCK 0x98    /* Microchip: Global unblock */
 
 #endif /*__SPI_NOR_H__*/


### PR DESCRIPTION
Microchip SPI flash require Global unblock command before writing is allowed.

--- 

Somehow I would like to have (maybe even work to) the driver to be more dynamic. Read the flash size and page sizes, erase commands supported etc. from the SFDP pages similar to what I did in PR  #5456. Thoughts?