### PR TITLE
doc: add space after cmake -Bdir and ninja -Cdir options

### DIFF
--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -366,8 +366,8 @@ class ZephyrAppCommandsDirective(Directive):
             tool_build_dir = ''
         else:
             source_dir = ' {}'.format(app) if app else ' .'
-            cmake_build_dir = ' -B{}'.format(build_dir)
-            tool_build_dir = ' -C{}'.format(build_dir)
+            cmake_build_dir = ' -B {}'.format(build_dir)
+            tool_build_dir = ' -C {}'.format(build_dir)
 
         # Now generate the actual cmake and make/ninja commands
         gen_arg = ' -GNinja' if generator == 'ninja' else ''


### PR DESCRIPTION
Let's be consistent with official cmake, ninja and make documentations.

https://cmake.org/cmake/help/latest/manual/cmake.1.html
cmake --help
man cmake

https://ninja-build.org/manual.html#_running_ninja
ninja --help

https://www.gnu.org/software/make/manual/make.html#Options-Summary
info make 'Options Summary'
etc.

Related to issue #15315

Signed-off-by: Marc Herbert <marc.herbert@intel.com>