### PR TITLE
sanitycheck: fix priority of --extra-args=CONFIG_ over testcase.yaml

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -94,7 +94,7 @@ get_cmake_property(cache_variable_names CACHE_VARIABLES)
 foreach (name ${cache_variable_names})
   if("${name}" MATCHES "^CONFIG_")
     # When a cache variable starts with 'CONFIG_', it is assumed to be
-    # a CLI Kconfig symbol assignment.
+    # a Kconfig symbol assignment from the CMake command line.
     set(EXTRA_KCONFIG_OPTIONS
       "${EXTRA_KCONFIG_OPTIONS}\n${name}=${${name}}"
       )

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1332,7 +1332,8 @@ class MakeGenerator:
 
         if len(ti.test.extra_configs) > 0 or options.coverage:
             args.append("OVERLAY_CONFIG=\"%s %s\"" %(overlays,
-                        os.path.join(ti.outdir, "overlay.conf")))
+                        os.path.join(ti.outdir,
+                                     "sanitycheck", "testcase_extra.conf")))
 
         if ti.test.type == "unit" and options.enable_coverage:
             args.append("COVERAGE=1")
@@ -1883,8 +1884,13 @@ class TestInstance:
         return build_only
 
     def create_overlay(self, platform):
-        file = os.path.join(self.outdir, "overlay.conf")
-        os.makedirs(self.outdir, exist_ok=True)
+        # Create this in a "sanitycheck/" subdirectory otherwise this
+        # will pass this overlay to kconfig.py *twice* and kconfig.cmake
+        # will silently give that second time precedence over any
+        # --extra-args=CONFIG_*
+        subdir = os.path.join(self.outdir, "sanitycheck")
+        os.makedirs(subdir, exist_ok=True)
+        file = os.path.join(subdir, "testcase_extra.conf")
         with open(file, "w") as f:
             content = ""
 


### PR DESCRIPTION
sanitycheck takes any "extra_config" lines found in the testcase.yaml
file and generates an "overlay" file from them. This file is placed in
the per-test build directory and passed to cmake/kconfig.cmake through a
-DOVERLAY_CONF= option set in the (also) generated sanity-out/Makefile.

This fix merely renames this generated config overlay to remove the
.conf suffix from its filename, otherwise kconfig.cmake picks it
up *twice*: once from the -DOVERLAY_CONF= option already mentioned above
and a second time because kconfig.cmake scans the build directory and
blindly picks up ALL files ending with .conf. The second pickup is
problematic because kconfig.cmake currently gives it the top precedence,
even higher than anything the user espressed with --extra-args=CONFIG_*

Here's a quick and simple demonstration of the issue fixed by this
commit:
```
  cd $ZEPHYR_BASE/samples/net/sockets/net_mgmt/
  sanitycheck -T. -p qemu_x86 -b -v # --extra-args=CONFIG_USERSPACE=y|n
  grep CONFIG_USERSPACE $(find sanity-out/ -name .config)

  .net_mgmt.kernelmode/zephyr/.config: # CONFIG_USERSPACE is not set
    .net_mgmt.usermode/zephyr/.config: CONFIG_USERSPACE=y

  grep 'Merged configuration' $(find sanity-out/ -name build.log)
```
Without this commit, attemps to override anything with
--extra-args=CONFIG_ are silently dropped on the floor.

For more background this issue was found while using the recipe in
commit message 4afcc0f8af2b

Signed-off-by: Marc Herbert <marc.herbert@intel.com>