### PR TITLE
sanitycheck: replace cmake -H "not meant for public use" with -S

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1117,7 +1117,7 @@ class MakeGenerator:
     MAKE_RULE_TMPL_CMAKE = """\t@echo sanity_test_{phase} {goal} >&2
 \tcmake  \\
 \t\t-G"{generator}"\\
-\t\t-H{directory}\\
+\t\t-S{directory}\\
 \t\t-B{outdir}\\
 \t\t-DEXTRA_CFLAGS="-Werror {cflags}"\\
 \t\t-DEXTRA_AFLAGS=-Wa,--fatal-warnings\\


### PR DESCRIPTION
https://www.mail-archive.com/cmake-developers@cmake.org/msg16769.html

Signed-off-by: Marc Herbert <marc.herbert@intel.com>