### PR TITLE
linker: add custom align size to reduce alignment memory wasting 

### DIFF
--- a/arch/arm/core/cortex_m/mpu/Kconfig
+++ b/arch/arm/core/cortex_m/mpu/Kconfig
@@ -61,6 +61,25 @@ config MPU_ALLOW_FLASH_WRITE
 	help
 	  Enable this to allow MPU RWX access to flash memory
 
+config CUSTOM_SECTION_ALIGN
+	bool "Custom Section Align"
+	depends on ARM_MPU
+	help
+	  MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT(ARMv7-M) sometimes cause memory
+	  wasting in linker scripts defined memory sections. Use this symbol
+	  to guarantee user custom section align size to avoid more memory used
+	  for respect alignment. But that needs carefully configure MPU region
+	  and sub-regions(ARMv7-M) to cover this feature.
+
+config CUSTOM_SECTION_MIN_ALIGN_SIZE
+	int "Custom Section Align Size"
+	default 32
+	help
+	  Custom algin size of memory section in linker scripts. Usually
+	  it should consume less alignment memory. Alougth this alignment
+	  size is configured by users, it must also respect the power of
+	  two regulation if hardware requires.
+
 endif # ARM_MPU
 
 endif # CPU_HAS_MPU

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -69,6 +69,9 @@
 	#define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
 #endif
 
+#if defined(CONFIG_CUSTOM_SECTION_ALIGN)
+_region_min_align = CONFIG_CUSTOM_SECTION_MIN_ALIGN_SIZE;
+#else
 /* Set alignment to CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE
  * to make linker section alignment comply with MPU granularity.
  */
@@ -78,8 +81,9 @@ _region_min_align = CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE;
 /* If building without MPU support, use default 4-byte alignment. */
 _region_min_align = 4;
 #endif
+#endif
 
-#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
+#if !defined(CONFIG_CUSTOM_SECTION_ALIGN) && defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
 #define MPU_ALIGN(region_size) \
     . = ALIGN(_region_min_align); \
     . = ALIGN( 1 << LOG2CEIL(region_size))

--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -84,7 +84,11 @@ LINKER_SECTION_SEQ_MPU = """
         {{
                 __{0}_{1}_start = .;
                 {4}
+#if {6}
+                . = ALIGN({6});
+#else
                 MPU_ALIGN(__{0}_{1}_size);
+#endif
                 __{0}_{1}_end = .;
 	}} {5}
         __{0}_{1}_size = __{0}_{1}_end - __{0}_{1}_start;
@@ -187,6 +191,12 @@ def assign_to_correct_mem_region(memory_type,
             iteration_sections["text"] or iteration_sections["rodata"]):
         all_regions = True
 
+    pos = memory_type.find('_')
+    if pos in range(len(memory_type)):
+        align_size = int(memory_type[pos+1:])
+        memory_type = memory_type[:pos]
+        mpu_align[memory_type] = align_size
+
     if memory_type in complete_list_of_sections:
         for iter_sec in ["text", "rodata", "data", "bss"]:
             if ((iteration_sections[iter_sec] or all_regions) and
@@ -229,8 +239,12 @@ def string_create_helper(region, memory_type,
             linker_string += tmp
         else:
             if memory_type != 'SRAM' and region == 'rodata':
+                align_size = 0
+                if memory_type in mpu_align.keys():
+                    align_size = mpu_align[memory_type]
+
                 linker_string += LINKER_SECTION_SEQ_MPU.format(memory_type.lower(), region, memory_type.upper(),
-                                                               region.upper(), tmp, load_address_string)
+                                                               region.upper(), tmp, load_address_string, align_size)
             else:
                 linker_string += LINKER_SECTION_SEQ.format(memory_type.lower(), region, memory_type.upper(),
                                                            region.upper(), tmp, load_address_string)
@@ -389,6 +403,8 @@ def create_dict_wrt_mem():
 
 
 def main():
+    global mpu_align
+    mpu_align = {}
     parse_args()
     searchpath = args.directory
     linker_file = args.output


### PR DESCRIPTION
```
1) When enable CONFIG_CUSTOM_SECTION_ALIGN, it need less alignment memory
for image rom region. But it will consume one more MPU region. For example somehow
we can know the size of .text and .rodata section, 512k+4B, with current code and
CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT enabled, the size of .text
and .rodata section in RAM (suppose only RAM) will be 1M.
But if with CONFIG_CUSTOM_SECTION_ALIGN(for example 64k), the size of .text and 
.rodata section will be 512k+64k(MPU_SUB_REGION_SIZE), that saved memory. 
For MPU configuration, 512k will be in MPU region1 and 64k will be in MPU region 2,
it will waste one more MPU region. 
The trade off for enable CONFIG_CUSTOM_SECTION_ALIGN or not should be decided by
end users according their applications, but Zephyr should provide this option.

2) Add custom align size for code relocation to reduce alignment memory wasting.
```

Fixes: #17337 

Signed-off-by: Wentong Wu <wentong.wu@intel.com>