### PR TITLE
nrf52_bsim: Add nrfx path to include path

### DIFF
--- a/boards/posix/nrf52_bsim/CMakeLists.txt
+++ b/boards/posix/nrf52_bsim/CMakeLists.txt
@@ -62,6 +62,7 @@ zephyr_include_directories(
   fake
   $ENV{BSIM_COMPONENTS_PATH}/ext_NRF52_hw_models/src/
   $ENV{BSIM_COMPONENTS_PATH}/ext_NRF52_hw_models/src/nrfx/hal/
+  $ENV{BSIM_COMPONENTS_PATH}/ext_NRF52_hw_models/src/nrfx/
   $ENV{BSIM_COMPONENTS_PATH}/ext_NRF52_hw_models/src/HW_models/
 )
 


### PR DESCRIPTION
To allow NRF drivers to include nrfx HAL or drivers headers
like with the real HAL, include the top nrfx/ folder
just as the real nrfx does.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>