### PR TITLE
LwM2M: remove IP CONFIG checks in engine

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -4096,21 +4096,15 @@ int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls)
 	(void)memset(addr, 0, sizeof(*addr));
 
 	/* try and set IP address directly */
-	ret = -EINVAL;
-
-#if defined(CONFIG_NET_IPV6)
 	addr->sa_family = AF_INET6;
 	ret = net_addr_pton(AF_INET6, url + off,
 			    &((struct sockaddr_in6 *)addr)->sin6_addr);
-#endif /* CONFIG_NET_IPV6 */
-
-#if defined(CONFIG_NET_IPV4)
+	/* Try to parse again using AF_INET */
 	if (ret < 0) {
 		addr->sa_family = AF_INET;
 		ret = net_addr_pton(AF_INET, url + off,
 				    &((struct sockaddr_in *)addr)->sin_addr);
 	}
-#endif /* CONFIG_NET_IPV4 */
 
 	if (ret < 0) {
 #if defined(CONFIG_DNS_RESOLVER)
@@ -4118,8 +4112,10 @@ int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls)
 		hints.ai_family = AF_UNSPEC;
 #elif defined(CONFIG_NET_IPV6)
 		hints.ai_family = AF_INET6;
-#else
+#elif defined(CONFIG_NET_IPV4)
 		hints.ai_family = AF_INET;
+#else
+		hints.ai_family = AF_UNSPEC;
 #endif /* defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_IPV4) */
 		hints.ai_socktype = SOCK_DGRAM;
 		ret = getaddrinfo(url + off, NULL, &hints, &res);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -178,21 +178,19 @@ char *lwm2m_sprint_ip_addr(const struct sockaddr *addr)
 {
 	static char buf[NET_IPV6_ADDR_LEN];
 
-#if defined(CONFIG_NET_IPV6)
 	if (addr->sa_family == AF_INET6) {
 		return net_addr_ntop(AF_INET6, &net_sin6(addr)->sin6_addr,
 				     buf, sizeof(buf));
 	}
-#endif
-#if defined(CONFIG_NET_IPV4)
+
 	if (addr->sa_family == AF_INET) {
 		return net_addr_ntop(AF_INET, &net_sin(addr)->sin_addr,
 				     buf, sizeof(buf));
 	}
-#endif
 
 	LOG_ERR("Unknown IP address family:%d", addr->sa_family);
-	return NULL;
+	strcpy(buf, "unk");
+	return buf;
 }
 
 static u8_t to_hex_digit(u8_t digit)


### PR DESCRIPTION
Some of the CONFIG_NET_IPV* checks are not needed in the LwM2M engine.   The functions used are always available.  Worse, having these checks forces the need to enable CONFIG_NET_IPV4 or IPV6 when it's not really needed (LwM2M could be using an offloaded IP stack).

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/17401