### PR TITLE
net: lwm2m: firmware: add log_strdup to remove logging errors

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -231,7 +231,7 @@ static int package_uri_write_cb(u16_t obj_inst_id,
 				u8_t *data, u16_t data_len,
 				bool last_block, size_t total_size)
 {
-	LOG_DBG("PACKAGE_URI WRITE: %s", package_uri);
+	LOG_DBG("PACKAGE_URI WRITE: %s", log_strdup(package_uri));
 
 #ifdef CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
 	u8_t state = lwm2m_firmware_get_update_state();

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -109,7 +109,7 @@ static int transfer_request(struct coap_block_context *ctx,
 	ret = coap_packet_append_option(&msg->cpkt, COAP_OPTION_URI_PATH,
 					cursor, strlen(cursor));
 	if (ret < 0) {
-		LOG_ERR("Error adding URI_PATH '%s'", cursor);
+		LOG_ERR("Error adding URI_PATH '%s'", log_strdup(cursor));
 		goto cleanup;
 	}
 #else
@@ -117,7 +117,7 @@ static int transfer_request(struct coap_block_context *ctx,
 	ret = http_parser_parse_url(firmware_uri, strlen(firmware_uri), 0,
 				    &parser);
 	if (ret < 0) {
-		LOG_ERR("Invalid firmware url: %s", firmware_uri);
+		LOG_ERR("Invalid firmware url: %s", log_strdup(firmware_uri));
 		ret = -ENOTSUP;
 		goto cleanup;
 	}
@@ -167,7 +167,8 @@ static int transfer_request(struct coap_block_context *ctx,
 	ret = coap_packet_append_option(&msg->cpkt, COAP_OPTION_PROXY_URI,
 					firmware_uri, strlen(firmware_uri));
 	if (ret < 0) {
-		LOG_ERR("Error adding PROXY_URI '%s'", firmware_uri);
+		LOG_ERR("Error adding PROXY_URI '%s'",
+			log_strdup(firmware_uri));
 		goto cleanup;
 	}
 #else
@@ -396,7 +397,7 @@ static void firmware_transfer(struct k_work *work)
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT)
 	server_addr = CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_ADDR;
 	if (strlen(server_addr) >= URI_LEN) {
-		LOG_ERR("Invalid Proxy URI: %s", server_addr);
+		LOG_ERR("Invalid Proxy URI: %s", log_strdup(server_addr));
 		ret = -ENOTSUP;
 		goto error;
 	}
@@ -422,7 +423,7 @@ static void firmware_transfer(struct k_work *work)
 		goto error;
 	}
 
-	LOG_INF("Connecting to server %s", firmware_uri);
+	LOG_INF("Connecting to server %s", log_strdup(firmware_uri));
 
 	/* reset block transfer context */
 	coap_block_transfer_init(&firmware_block_ctx,


### PR DESCRIPTION
When performing OTA using the LwM2M subsys, several logging errors
regarding log_strdup were noted.  Let's fix these.

Signed-off-by: Michael Scott <mike@foundries.io>