### PR TITLE
net: lwm2m: add custom TLS credential load function pointer

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -71,6 +71,11 @@ struct lwm2m_ctx {
 	 *  LwM2M engine calls tls_credential_(add|delete)
 	 */
 	int tls_tag;
+
+	/** Client can set load_credentials function as a way of overriding
+	 *  the default behavior of load_tls_credential() in lwm2m_engine.c
+	 */
+	int (*load_credentials)(struct lwm2m_ctx *client_ctx);
 #endif
 	/** Flag to indicate if context should use DTLS.
 	 *  Enabled via the use of coaps:// protocol prefix in connection

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3994,14 +3994,21 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 #if defined(CONFIG_LWM2M_DTLS_SUPPORT)
 	int ret;
 
-	ret = load_tls_credential(client_ctx, 3, TLS_CREDENTIAL_PSK_ID);
-	if (ret < 0) {
-		return ret;
-	}
+	if (client_ctx->load_credentials) {
+		ret = client_ctx->load_credentials(client_ctx);
+		if (ret < 0) {
+			return ret;
+		}
+	} else {
+		ret = load_tls_credential(client_ctx, 3, TLS_CREDENTIAL_PSK_ID);
+		if (ret < 0) {
+			return ret;
+		}
 
-	ret = load_tls_credential(client_ctx, 5, TLS_CREDENTIAL_PSK);
-	if (ret < 0) {
-		return ret;
+		ret = load_tls_credential(client_ctx, 5, TLS_CREDENTIAL_PSK);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	if (client_ctx->use_dtls) {


### PR DESCRIPTION
Current implementation of LwM2M engine doesn't allow users a way
of overriding TLS credential load with custom function.  This
would be needed by an offloaded TLS stack where we don't want
to use standard Zephyr functions.

Let's add a load_credential function pointer to the LwM2M client
context which will be called when it's available.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/17408

Signed-off-by: Michael Scott <mike@foundries.io>