### PR TITLE
boards: arm: nrf52840_pca10056/nrf52_pca10040: enable pyocd runner

### DIFF
--- a/boards/arm/nrf52840_pca10056/board.cmake
+++ b/boards/arm/nrf52840_pca10056/board.cmake
@@ -2,5 +2,7 @@
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nrf52_pca10040/board.cmake
+++ b/boards/arm/nrf52_pca10040/board.cmake
@@ -2,5 +2,7 @@
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/board.cmake
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/board.cmake
@@ -2,5 +2,7 @@
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Mbed OS provides a DAPlink firmware update for nRF52840-DK here:
https://os.mbed.com/platforms/Nordic-nRF52840-DK/
and for nRF52-DK here:
https://os.mbed.com/platforms/Nordic-nRF52-DK/

When using this firmware we need to flash the board with the pyocd
runner.  Let's enable the pyocd runner for this purpose.

Signed-off-by: Michael Scott <mike@foundries.io>