### PR TITLE
sanitycheck: add west-runner parameter and fix-up west-flash handling

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3016,13 +3016,13 @@ Artificially long but functional example:
     parser.add_argument(
         "--west-flash", nargs='?', const=[],
         help="""Uses west instead of ninja or make to flash when running with
-             --device-testing"
+             --device-testing.
 
-        E.g
-         sanitycheck --device-testing --device-serial /dev/ttyACM0 \
-                     --west-flash="--board-id=foobar"
-        will translate to
-         west flash -- --board-id=foobar
+        E.g "sanitycheck --device-testing --device-serial /dev/ttyACM0
+                         --west-flash="--board-id=foobar"
+        will translate to "west flash -- --board-id=foobar"
+
+        NOTE: device-testing must be enabled to use this option.
         """
     )
     parser.add_argument(
@@ -3276,6 +3276,10 @@ def main():
 
     if options.west_runner and not options.west_flash:
         error("west-runner requires west-flash to be enabled")
+        sys.exit(1)
+
+    if options.west_flash and not options.device_testing:
+        error("west-flash requires device-testing to be enabled")
         sys.exit(1)
 
     if options.coverage:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -676,6 +676,9 @@ class DeviceHandler(Handler):
 
         if options.west_flash is not None:
             command = ["west", "flash", "--skip-rebuild", "-d", self.outdir]
+            if options.west_runner is not None:
+                command.append("--runner")
+                command.append(options.west_runner)
             # There are two ways this option is used.
             # 1) bare: --west-flash
             #    This results in options.west_flash == []
@@ -3009,6 +3012,7 @@ Artificially long but functional example:
         which will ultimately disable ccache.
         """
     )
+
     parser.add_argument(
         "--west-flash", nargs='?', const=[],
         help="""Uses west instead of ninja or make to flash when running with
@@ -3019,6 +3023,18 @@ Artificially long but functional example:
                      --west-flash="--board-id=foobar"
         will translate to
          west flash -- --board-id=foobar
+        """
+    )
+    parser.add_argument(
+        "--west-runner",
+        help="""Uses the specified west runner instead of default when running
+             with --west-flash.
+
+        E.g "sanitycheck --device-testing --device-serial /dev/ttyACM0
+                         --west-flash --west-runner=pyocd"
+        will translate to "west flash --runner pyocd"
+
+        NOTE: west-flash must be enabled to use this option.
         """
     )
 
@@ -3257,6 +3273,10 @@ def main():
     # XXX: Workaround for #17239
     resource.setrlimit(resource.RLIMIT_NOFILE, (4096, 4096))
     options = parse_arguments()
+
+    if options.west_runner and not options.west_flash:
+        error("west-runner requires west-flash to be enabled")
+        sys.exit(1)
 
     if options.coverage:
         options.enable_coverage = True


### PR DESCRIPTION
This patch series does the following:
- Several boards have multiple runners.  We need a way to specify which runner to use with sanitycheck.  Introduce --west-runner option for that purpose.
- Generate an error when --west-runner is used w/o the --west-flash option.
- Cleans up the help text of --west-flash.
- Generate an error when --west-flash is used w/o the --device-testing option.