### PR TITLE
sanitycheck: only match 1 regex per line

### DIFF
--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -68,6 +68,7 @@ class Console(Harness):
                 r = self.regex[i]
                 if pattern.search(line) and not r in self.matches:
                     self.matches[r] = line
+                    break
             if len(self.matches) == len(self.regex):
                     self.state = "passed"
 


### PR DESCRIPTION
Current logic searches all regex strings for a match to each line,
regardless of whether an existing match has been made.
This makes matching a similar regex later in the list impossible.

Let's only match once and then quit the regex loop.

Signed-off-by: Michael Scott <mike@foundries.io>