### PR TITLE
samples: watchdog: adjust harness regex

### DIFF
--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -9,7 +9,8 @@ tests:
         ordered: true
         regex:
             - "Watchdog sample application"
-            - "Feeding watchdog..."
-            - "Waiting for reset..."
-            - "Watchdog sample application"
+            - "Feeding watchdog\\.\\.\\."
+            - "Waiting for reset\\.\\.\\."
+            # due to harness limitation, 2 matches cannot be the same regex
+            - "Watchdog sample applicati*."
     depends_on: watchdog


### PR DESCRIPTION
- Periods need escaping to match properly.
- Due to sanitycheck harness limitation, no 2 regexes in a list can be
  identical.  If they are, the 2nd one will never be matched due to
  current matching logic.  Instead let's fix the watchdog regex matching
  by slightly altering the 2nd occurance of:
  Watchdog sample application
  to
  Watchdog sample applicati*.

Signed-off-by: Michael Scott <mike@foundries.io>