### PR TITLE
libc: fix memchr() prototype

### DIFF
--- a/lib/libc/minimal/include/string.h
+++ b/lib/libc/minimal/include/string.h
@@ -35,7 +35,7 @@ extern void  *memmove(void *d, const void *s, size_t n);
 extern void  *memcpy(void *_MLIBC_RESTRICT d, const void *_MLIBC_RESTRICT s,
 		     size_t n);
 extern void  *memset(void *buf, int c, size_t n);
-extern void  *memchr(const void *s, unsigned char c, size_t n);
+extern void  *memchr(const void *s, int c, size_t n);
 
 #ifdef __cplusplus
 }

--- a/lib/libc/minimal/source/string/string.c
+++ b/lib/libc/minimal/source/string/string.c
@@ -338,13 +338,13 @@ void *memset(void *buf, int c, size_t n)
  * @return pointer to start of found byte
  */
 
-void *memchr(const void *s, unsigned char c, size_t n)
+void *memchr(const void *s, int c, size_t n)
 {
 	if (n != 0) {
 		const unsigned char *p = s;
 
 		do {
-			if (*p++ == c) {
+			if (*p++ == (unsigned char)c) {
 				return ((void *)(p - 1));
 			}
 


### PR DESCRIPTION
The standard memchr() uses an int for its second argument.