### PR TITLE
arch: arc:  remove extern variables used in irq and exception handling

### DIFF
--- a/arch/arc/core/fast_irq.S
+++ b/arch/arc/core/fast_irq.S
@@ -22,9 +22,6 @@
 GTEXT(_firq_enter)
 GTEXT(_firq_exit)
 
-GDATA(exc_nest_count)
-
-
 /**
  *
  * @brief Work to be done before handing control to a FIRQ ISR
@@ -81,12 +78,9 @@ SECTION_FUNC(TEXT, _firq_enter)
 	lr r25, [_ARC_V2_LP_END]
 #endif
 
-	ld r1, [exc_nest_count]
-	add r0, r1, 1
-	st r0, [exc_nest_count]
-	cmp r1, 0
+	_check_nest_int_by_irq_act r0, r1
 
-	bgt.d  firq_nest
+	bne.d firq_nest
 	mov r0, sp
 
 	mov r1, _kernel
@@ -147,19 +141,10 @@ SECTION_FUNC(TEXT, _firq_exit)
 	sr r24, [_ARC_V2_LP_START]
 	sr r25, [_ARC_V2_LP_END]
 #endif
-	/* check if we're a nested interrupt: if so, let the interrupted
-	 * interrupt handle the reschedule */
-	mov	r1, exc_nest_count
-	ld	r0, [r1]
-	sub	r0, r0, 1
-	st	r0, [r1]
-/* see comments in _rirq_exit */
-	lr 	r0, [_ARC_V2_AUX_IRQ_ACT]
-	and 	r0, r0, 0xffff
-	ffs	r1, r0
-	fls	r2, r0
-	cmp 	r1, r2
-	jne	_firq_no_reschedule
+
+	_check_nest_int_by_irq_act r0, r1
+
+	jne _firq_no_reschedule
 
 #ifdef CONFIG_STACK_SENTINEL
 	bl z_check_stack_sentinel

--- a/arch/arc/core/fast_irq.S
+++ b/arch/arc/core/fast_irq.S
@@ -23,11 +23,7 @@ GTEXT(_firq_enter)
 GTEXT(_firq_exit)
 
 GDATA(exc_nest_count)
-#if CONFIG_RGF_NUM_BANKS == 1
-GDATA(saved_r0)
-#else
-GDATA(saved_sp)
-#endif
+
 
 /**
  *
@@ -98,19 +94,35 @@ SECTION_FUNC(TEXT, _firq_enter)
 #if CONFIG_RGF_NUM_BANKS != 1
 	b firq_nest_1
 firq_nest:
-	mov r1, ilink
-	lr r0, [_ARC_V2_STATUS32]
-	and r0, r0, ~_ARC_V2_STATUS32_RB(7)
-	kflag r0
+	/*
+	 * because firq and rirq share the same interrupt stack,
+	 * switch back to original register bank to get correct sp.
+	 * to get better firq latency, an approach is to prepare
+	 * separate interrupt stack for firq and do not do thread
+	 * switch in firq.
+	 */
+	lr r1, [_ARC_V2_STATUS32]
+	and r1, r1, ~_ARC_V2_STATUS32_RB(7)
+	kflag r1
 
-	st sp, [saved_sp]
+	/* here use _ARC_V2_USER_SP and ilink to exchange sp
+	 * save original value of _ARC_V2_USER_SP and ilink into
+	 * the stack of interrupted context first, then restore them later
+	 */
+	st ilink, [sp]
+	lr ilink, [_ARC_V2_USER_SP]
+	st ilink, [sp, -4]
+	/* sp here is the sp of interrupted context */
+	sr sp, [_ARC_V2_USER_SP]
 
+	/* switch back to banked reg, only ilink can be used */
 	lr ilink, [_ARC_V2_STATUS32]
 	or ilink, ilink, _ARC_V2_STATUS32_RB(1)
 	kflag ilink
-	mov r0, sp
-	ld sp, [saved_sp]
-	mov ilink, r1
+	lr sp, [_ARC_V2_USER_SP]
+	ld ilink, [sp, -4]
+	sr ilink, [_ARC_V2_USER_SP]
+	ld ilink, [sp]
 firq_nest_1:
 #else
 firq_nest:
@@ -176,8 +188,8 @@ _firq_no_reschedule:
 	 */
 #if CONFIG_RGF_NUM_BANKS == 1
 	_pop_irq_stack_frame
-	ld r0,[saved_r0]
 #endif
+	lr ilink, [_ARC_V2_ERET]
 	rtie
 
 #ifdef CONFIG_PREEMPT_ENABLED

--- a/arch/arc/core/fault.c
+++ b/arch/arc/core/fault.c
@@ -20,7 +20,6 @@
 #include <exc_handle.h>
 #include <logging/log_ctrl.h>
 
-u32_t arc_exc_saved_sp;
 
 #ifdef CONFIG_USERSPACE
 Z_EXC_DECLARE(z_arch_user_string_nlen);
@@ -363,7 +362,7 @@ static void dump_exception_info(u32_t vector, u32_t cause, u32_t parameter)
  * invokes the user provided routine k_sys_fatal_error_handler() which is
  * responsible for implementing the error handling policy.
  */
-void _Fault(z_arch_esf_t *esf)
+void _Fault(z_arch_esf_t *esf, u32_t old_sp)
 {
 	u32_t vector, cause, parameter;
 	u32_t exc_addr = z_arc_v2_aux_reg_read(_ARC_V2_EFA);
@@ -413,7 +412,7 @@ void _Fault(z_arch_esf_t *esf)
 #ifdef CONFIG_MPU_STACK_GUARD
 	if (vector == ARC_EV_PROT_V && ((parameter == 0x4) ||
 					(parameter == 0x24))) {
-		if (z_check_thread_stack_fail(exc_addr, arc_exc_saved_sp)) {
+		if (z_check_thread_stack_fail(exc_addr, old_sp)) {
 			z_arc_fatal_error(K_ERR_STACK_CHK_FAIL, esf);
 			return;
 		}

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -38,8 +38,6 @@ GTEXT(__ev_maligned)
 GTEXT(z_irq_do_offload);
 #endif
 
-GDATA(exc_nest_count)
-
 /* the necessary stack size for exception handling */
 #define EXCEPTION_STACK_SIZE 384
 
@@ -203,12 +201,11 @@ _do_non_syscall_trap:
 	lr r0,[_ARC_V2_ERET]
 	st_s r0, [sp, ___isf_t_pc_OFFSET] /* eret into pc */
 
-	ld r1, [exc_nest_count]
-	add r0, r1, 1
-	st r0, [exc_nest_count]
-	cmp r1, 0
 
-	bgt.d  exc_nest_handle
+	lr r0, [_ARC_V2_AUX_IRQ_ACT]
+	and r0, r0, 0xffff
+	cmp r0, 0
+	bne.d exc_nest_handle
 	mov r0, sp
 
 	mov r1, _kernel
@@ -220,12 +217,10 @@ exc_nest_handle:
 
 	pop sp
 
-	mov	r1, exc_nest_count
-	ld	r0, [r1]
-	sub	r0, r0, 1
-	cmp	r0, 0
-	bne.d	_exc_return_from_exc
-	st 	r0, [r1]
+	lr  r0, [_ARC_V2_AUX_IRQ_ACT]
+	and r0, r0, 0xffff
+	cmp r0, 0
+	bne _exc_return_from_exc
 
 #ifdef CONFIG_PREEMPT_ENABLED
 	mov_s r1, _kernel

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -39,7 +39,6 @@ GTEXT(z_irq_do_offload);
 #endif
 
 GDATA(exc_nest_count)
-GDATA(arc_exc_saved_sWWp)
 
 /* the necessary stack size for exception handling */
 #define EXCEPTION_STACK_SIZE 384
@@ -62,7 +61,7 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_dc_error)
 SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_maligned)
 
 _exc_entry:
-	st sp, [arc_exc_saved_sp]
+	mov_s ilink, sp
 	/*
 	 * re-use the top part of interrupt stack as exception
 	 * stack. If this top part is used by interrupt handling,
@@ -94,6 +93,8 @@ _exc_entry:
 
 	/* sp is parameter of _Fault */
 	mov r0, sp
+	/* ilink is the thread's original sp */
+	mov r1, ilink
 	jl _Fault
 
 _exc_return:
@@ -142,7 +143,7 @@ _exc_return_from_exc:
 	sr r0, [_ARC_V2_ERET]
 
 	_pop_irq_stack_frame
-	ld sp, [arc_exc_saved_sp]
+	mov sp, ilink
 	rtie
 
 

--- a/arch/arc/core/isr_wrapper.S
+++ b/arch/arc/core/isr_wrapper.S
@@ -24,12 +24,6 @@
 GTEXT(_isr_wrapper)
 GTEXT(_isr_demux)
 
-GDATA(exc_nest_count)
-SECTION_VAR(BSS, exc_nest_count)
-	.balign 4
-	.word 0
-
-
 #if defined(CONFIG_SYS_POWER_MANAGEMENT)
 GTEXT(z_sys_power_save_idle_exit)
 #endif

--- a/arch/arc/core/isr_wrapper.S
+++ b/arch/arc/core/isr_wrapper.S
@@ -30,20 +30,6 @@ SECTION_VAR(BSS, exc_nest_count)
 	.word 0
 
 
-#if CONFIG_RGF_NUM_BANKS == 1
-GDATA(saved_r0)
-
-SECTION_VAR(BSS, saved_r0)
-	.balign 4
-	.word 0
-#else
-GDATA(saved_sp)
-
-SECTION_VAR(BSS, saved_sp)
-	.balign 4
-	.word 0
-#endif
-
 #if defined(CONFIG_SYS_POWER_MANAGEMENT)
 GTEXT(z_sys_power_save_idle_exit)
 #endif
@@ -228,21 +214,26 @@ From RIRQ:
 SECTION_FUNC(TEXT, _isr_wrapper)
 #if defined(CONFIG_ARC_FIRQ)
 #if CONFIG_RGF_NUM_BANKS == 1
-	st r0,[saved_r0]
+/* free r0 here, use r0 to check whether irq is firq.
+ * for rirq,  as sp will not change and r0 already saved, this action
+ * in fact is an action like nop.
+ * for firq,  r0 will be restored later
+ */
+  st r0, [sp]
 #endif
 	lr r0, [_ARC_V2_AUX_IRQ_ACT]
 	ffs r0, r0
 	cmp r0, 0
 #if CONFIG_RGF_NUM_BANKS == 1
 	bnz rirq_path
+  ld r0, [sp]
 	/* 1-register bank FIRQ handling must save registers on stack */
 	_create_irq_stack_frame
 	lr r0, [_ARC_V2_STATUS32_P0]
 	st_s r0, [sp, ___isf_t_status32_OFFSET]
-	mov r0,ilink
+  lr r0, [_ARC_V2_ERET]
 	st_s r0, [sp, ___isf_t_pc_OFFSET]
-	ld r0,[saved_r0]
-	st_s r0, [sp, ___isf_t_r0_OFFSET]
+
 	mov r3, _firq_exit
 	mov r2, _firq_enter
 	j_s [r2]

--- a/arch/arc/core/regular_irq.S
+++ b/arch/arc/core/regular_irq.S
@@ -23,7 +23,6 @@
 GTEXT(_rirq_enter)
 GTEXT(_rirq_exit)
 GTEXT(_rirq_common_interrupt_swap)
-GDATA(exc_nest_count)
 
 #if 0 /* TODO: when FIRQ is not present, all would be regular */
 #define NUM_REGULAR_IRQ_PRIO_LEVELS CONFIG_NUM_IRQ_PRIO_LEVELS
@@ -67,12 +66,10 @@ SECTION_FUNC(TEXT, _rirq_enter)
 #endif
 #endif
 	clri
-	ld r1, [exc_nest_count]
-	add r0, r1, 1
-	st r0, [exc_nest_count]
-	cmp r1, 0
 
-	bgt.d  rirq_nest
+	_check_nest_int_by_irq_act r0, r1
+
+	bne.d rirq_nest
 	mov r0, sp
 
 	mov r1, _kernel
@@ -96,27 +93,9 @@ SECTION_FUNC(TEXT, _rirq_exit)
 
 	pop sp
 
-	mov	r1, exc_nest_count
-	ld	r0, [r1]
-	sub	r0, r0, 1
-	st	r0, [r1]
-	/*
-	 * using exc_nest_count to decide whether is nest int is not reliable.
-	 * a better option is to use IRQ_ACT
-	 * A case is:  a high priority int preempts a low priority int before
-	 * rirq_enter/firq_enter, then in _rirq_exit/_firq_exit, it will see
-	 * exc_nest_cout is 0, this will lead to possible thread switch, but
-	 * a low priority int is still pending.
-	 *
-	 * If multi bits in IRQ_ACT are set, i.e. last bit != fist bit, it's
-	 * in nest interrupt
-	 */
-	lr 	r0, [_ARC_V2_AUX_IRQ_ACT]
-	and 	r0, r0, 0xffff
-	ffs	r1, r0
-	fls	r2, r0
-	cmp	r1, r2
-	jne	_rirq_return_from_rirq
+	_check_nest_int_by_irq_act r0, r1
+
+	jne _rirq_return_from_rirq
 
 #ifdef CONFIG_STACK_SENTINEL
 	bl z_check_stack_sentinel

--- a/arch/arc/include/swap_macros.h
+++ b/arch/arc/include/swap_macros.h
@@ -272,6 +272,17 @@ extern "C" {
 #endif /* CONFIG_ARC_HAS_SECURE */
 .endm
 
+/* If multi bits in IRQ_ACT are set, i.e. last bit != fist bit, it's
+ * in nest interrupt. The result will be EQ bit of status32
+ */
+.macro _check_nest_int_by_irq_act  reg1, reg2
+	lr \reg1, [_ARC_V2_AUX_IRQ_ACT]
+	and \reg1, \reg1, 0xffff
+	ffs \reg2, \reg1
+	fls \reg1, \reg1
+	cmp \reg1, \reg2
+.endm
+
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR removes and optmizes the varibalbes used in irq and exception handling
  * **arc_ exc_saved_sp** used in exception handling 
  * **saved_r0/saved_sp** used in fast irq handling
  * **exce_nest_count** used to check nest interrupt

These variables can be replaced by the useage of ilink and IRQ_ACT
   * **arc_ exc_saved_sp** replaced by ilink
   * **saved_r0/saved_sp** replaced by ilink
   * **exce_nest_count** replaced by IRQ_ACT

This PR is required by SMP support （#16661） to avoid per cpu variable

Fixes #17419

