### PR TITLE
Bluetooth: drivers: ipm_st32wb: Fix compilation

### DIFF
--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -115,7 +115,7 @@ void TM_EvtReceivedCb(TL_EvtPacket_t *hcievt)
 			       hcievt->evtserial.evt.evtcode);
 			goto out;
 		default:
-			buf = bt_buf_get_evt(evtserial.evt.evtcode, false,
+			buf = bt_buf_get_evt(hcievt->evtserial.evt.evtcode, false,
 					     K_FOREVER);
 			break;
 		}


### PR DESCRIPTION
Issue faced while running bluetooth sample (peripheral, central, ...) on stm32wb55rg with the latest zephyr version
```
user@user:~/local/zephyrproject/zephyr$ west build -b nucleo_wb55rg samples/bluetooth/peripheral
-- west build: build configuration:
       source directory: /home/user/local/zephyrproject/zephyr/samples/bluetooth/peripheral
       build directory: /home/user/local/zephyrproject/zephyr/build
       BOARD: nucleo_wb55rg (origin: CMakeCache.txt)
-- west build: building application
[1/7] Building C object zephyr/CMakeFi...rivers/bluetooth/hci/ipm_stm32wb.c.obj
FAILED: ccache /home/user/local/zephyrsdk/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc -DBUILD_VERSION=zephyr-v1.14.0-2189-g74da4393224b -DCORE_CM4 -DKERNEL -DSTM32WB55xx -DUSE_FULL_LL_DRIVER -DUSE_HAL_DRIVER -D_FORTIFY_SOURCE=2 -D__ZEPHYR__=1 -I../kernel/include -I../arch/arm/include -I../include -I../include/drivers -Izephyr/include/generated -I../soc/arm/st_stm32/stm32wb -I../lib/libc/minimal/include -I../drivers -I../ext/lib/crypto/tinycrypt/include -I../ext/hal/cmsis/Include -I../subsys/settings/include -I../subsys/bluetooth -I/home/user/local/zephyrproject/modules/hal/stm32/stm32cube/stm32wbxx/soc -I/home/user/local/zephyrproject/modules/hal/stm32/stm32cube/stm32wbxx/drivers/include -I/home/user/local/zephyrproject/modules/hal/stm32/stm32cube/stm32wbxx/drivers/include/Legacy -I/home/user/local/zephyrproject/modules/hal/stm32/lib/stm32wb/hci -isystem /home/user/local/zephyrsdk/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/8.3.0/include -isystem /home/user/local/zephyrsdk/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/8.3.0/include-fixed -Os -nostdinc -imacros/home/user/local/zephyrproject/zephyr/build/zephyr/include/generated/autoconf.h -ffreestanding -fno-common -g -mthumb -mcpu=cortex-m4 -imacros/home/user/local/zephyrproject/zephyr/include/toolchain/zephyr_stdint.h -Wall -Wformat -Wformat-security -Wno-format-zero-length -Wno-main -Wno-pointer-sign -Wpointer-arith -Wno-unused-but-set-variable -Werror=implicit-int -fno-asynchronous-unwind-tables -fno-pie -fno-pic -fno-strict-overflow -fno-reorder-functions -fno-defer-pop -fmacro-prefix-map=/home/user/local/zephyrproject/zephyr/samples/bluetooth/peripheral=CMAKE_SOURCE_DIR -fmacro-prefix-map=/home/user/local/zephyrproject/zephyr=ZEPHYR_BASE -ffunction-sections -fdata-sections -mabi=aapcs -march=armv7e-m -std=c99 -MD -MT zephyr/CMakeFiles/zephyr.dir/drivers/bluetooth/hci/ipm_stm32wb.c.obj -MF zephyr/CMakeFiles/zephyr.dir/drivers/bluetooth/hci/ipm_stm32wb.c.obj.d -o zephyr/CMakeFiles/zephyr.dir/drivers/bluetooth/hci/ipm_stm32wb.c.obj   -c /home/user/local/zephyrproject/zephyr/drivers/bluetooth/hci/ipm_stm32wb.c
/home/user/local/zephyrproject/zephyr/drivers/bluetooth/hci/ipm_stm32wb.c: In function 'TM_EvtReceivedCb':
/home/user/local/zephyrproject/zephyr/drivers/bluetooth/hci/ipm_stm32wb.c:118:25: error: 'evtserial' undeclared (first use in this function)
    buf = bt_buf_get_evt(evtserial.evt.evtcode, false,
                         ^~~~~~~~~
/home/user/local/zephyrproject/zephyr/drivers/bluetooth/hci/ipm_stm32wb.c:118:25: note: each undeclared identifier is reported only once for each function it appears in
ninja: build stopped: subcommand failed.
ERROR: command exited with status 1: /usr/local/bin/cmake --build /home/user/local/zephyrproject/zephyr/build
run as "west -v build -b nucleo_wb55rg samples/bluetooth/peripheral" for a stack trace

```