### PR TITLE
Bluetooth: host: Add bt_conn_foreach API to iterate all connections

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -79,6 +79,15 @@ struct bt_conn *bt_conn_ref(struct bt_conn *conn);
  */
 void bt_conn_unref(struct bt_conn *conn);
 
+/** @brief Iterate through all existing connections.
+ *
+ * @param type  Connection Type
+ * @param func  Function to call for each connection.
+ * @param data  Data to pass to the callback function.
+ */
+void bt_conn_foreach(int type, void (*func)(struct bt_conn *conn, void *data),
+		     void *data);
+
 /** @brief Look up an existing connection by address.
  *
  *  Look up an existing connection based on the remote address.
@@ -115,11 +124,13 @@ u8_t bt_conn_index(struct bt_conn *conn);
 /** Connection Type */
 enum {
 	/** LE Connection Type */
-	BT_CONN_TYPE_LE,
+	BT_CONN_TYPE_LE = BIT(0),
 	/** BR/EDR Connection Type */
-	BT_CONN_TYPE_BR,
+	BT_CONN_TYPE_BR = BIT(1),
 	/** SCO Connection Type */
-	BT_CONN_TYPE_SCO,
+	BT_CONN_TYPE_SCO = BIT(2),
+	/** All Connection Type */
+	BT_CONN_TYPE_ALL = BT_CONN_TYPE_LE | BT_CONN_TYPE_BR | BT_CONN_TYPE_SCO,
 };
 
 /** LE Connection Info Structure */


### PR DESCRIPTION
Add iterator function to iterate over all connection objects.
Make type a bitmap so that it can be used as a bitmask to select which
conns to receive foreach callback.
Use foreach function internally where possible.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>