### PR TITLE
net: ipv4: Drop pkt if src address is unspecified

### DIFF
--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -150,12 +150,17 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 	}
 
 	if (net_ipv4_is_addr_mcast(&hdr->src)) {
-		NET_DBG("DROP: src addr is mcast");
+		NET_DBG("DROP: src addr is %s", "mcast");
 		goto drop;
 	}
 
 	if (net_ipv4_is_addr_bcast(net_pkt_iface(pkt), &hdr->src)) {
-		NET_DBG("DROP: src addr is bcast");
+		NET_DBG("DROP: src addr is %s", "bcast");
+		goto drop;
+	}
+
+	if (net_ipv4_is_addr_unspecified(&hdr->src)) {
+		NET_DBG("DROP: src addr is %s", "unspecified");
 		goto drop;
 	}
 


### PR DESCRIPTION
If we receive IPv4 packet where source address is unspecified
(all zeros), then we need to drop it.

Fixes #17427

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>