### PR TITLE
[Backport v1.14-branch] net: lwm2m: fix error message in load_tls_credential()

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3977,7 +3977,8 @@ static int load_tls_credential(struct lwm2m_ctx *client_ctx, u16_t res_id,
 
 	ret = tls_credential_add(client_ctx->tls_tag, type, cred, cred_len);
 	if (ret < 0) {
-		LOG_ERR("Unable to get resource data for '%s'", pathstr);
+		LOG_ERR("Error setting cred tag %d type %d: Error %d",
+			client_ctx->tls_tag, type, ret);
 	}
 
 	return ret;


### PR DESCRIPTION
Backport: https://github.com/zephyrproject-rtos/zephyr/pull/17405

Copy/paste issue shows the wrong error message when a TLS
credential failed to be added. Let's fix it.