### PR TITLE
arch: arm: Use z_arch_is_user_context() for portability to R4

### DIFF
--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -300,7 +300,7 @@ u32_t z_check_thread_stack_fail(const u32_t fault_addr, const u32_t psp)
 #if defined(CONFIG_USERSPACE)
 	if (thread->arch.priv_stack_start) {
 		/* User thread */
-		if ((__get_CONTROL() & CONTROL_nPRIV_Msk) == 0) {
+		if (z_arch_is_user_context()) {
 			/* User thread in privilege mode */
 			if (IS_MPU_GUARD_VIOLATION(
 				thread->arch.priv_stack_start - guard_len,


### PR DESCRIPTION
The original code is not portable to R4 due to its mode bits being
much different from M-class CPUs.  By using z_arch_is_user_context(),
this difference is abstracted to the CPU-specific implementation.

Signed-off-by: Phil Erwin <erwin@lexmark.com>