### PR TITLE
tests: usb: make 64-bit compatible

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -25,6 +25,9 @@
 #define POINTER_TO_INT(x)  ((intptr_t) (x))
 #define INT_TO_POINTER(x)  ((void *) (intptr_t) (x))
 
+/* Helper to get the difference between two pointers as an int */
+#define PTR_DIFF(y, x) ((int)((intptr_t)(y) - (intptr_t)(x)))
+
 #if !(defined (__CHAR_BIT__) && defined (__SIZEOF_LONG__))
 #	error Missing required predefined macros for BITS_PER_LONG calculation
 #endif

--- a/tests/subsys/usb/desc_sections/src/desc_sections.c
+++ b/tests/subsys/usb/desc_sections/src/desc_sections.c
@@ -205,34 +205,34 @@ static void test_desc_sections(void)
 	TC_PRINT("__usb_descriptor_start %p\n", __usb_descriptor_start);
 	TC_PRINT("__usb_descriptor_end %p\n",  __usb_descriptor_end);
 	TC_PRINT("USB Descriptor table size %d\n",
-		 (int)__usb_descriptor_end - (int)__usb_descriptor_start);
+		 PTR_DIFF(__usb_descriptor_end, __usb_descriptor_start));
 
 	TC_PRINT("__usb_data_start %p\n", __usb_data_start);
 	TC_PRINT("__usb_data_end %p\n", __usb_data_end);
 	TC_PRINT("USB Configuration data size %d\n",
-		 (int)__usb_data_end - (int)__usb_data_start);
+		 PTR_DIFF(__usb_data_end, __usb_data_start));
 
-	TC_PRINT("sizeof usb_cfg_data %u\n", sizeof(struct usb_cfg_data));
+	TC_PRINT("sizeof usb_cfg_data %zu\n", sizeof(struct usb_cfg_data));
 
 	LOG_DBG("Starting logs");
 
 	LOG_HEXDUMP_DBG((u8_t *)__usb_descriptor_start,
-			(int)__usb_descriptor_end - (int)__usb_descriptor_start,
+			PTR_DIFF(__usb_descriptor_end, __usb_descriptor_start),
 			"USB Descriptor table section");
 
 	LOG_HEXDUMP_DBG((u8_t *)__usb_data_start,
-			(int)__usb_data_end - (int)__usb_data_start,
+			PTR_DIFF(__usb_data_end, __usb_data_start),
 			"USB Configuratio structures section");
 
 	head = (struct usb_desc_header *)__usb_descriptor_start;
 	zassert_not_null(head, NULL);
 
-	zassert_equal((int)__usb_descriptor_end - (int)__usb_descriptor_start,
+	zassert_equal(PTR_DIFF(__usb_descriptor_end, __usb_descriptor_start),
 		      133, NULL);
 
 	/* Calculate number of structures */
 	zassert_equal(__usb_data_end - __usb_data_start, NUM_INSTANCES, NULL);
-	zassert_equal((int)__usb_data_end - (int)__usb_data_start,
+	zassert_equal(PTR_DIFF(__usb_data_end, __usb_data_start),
 		      NUM_INSTANCES * sizeof(struct usb_cfg_data), NULL);
 
 	check_endpoint_allocation(head);


### PR DESCRIPTION
Some code casts pointers to ints in order to obtain their difference. The
compiler complains on 64-bit targets as an int is not wide enough to hold a
pointer.

Let's introduce the PTR_DIFF() helper macro to applies the proper cast to
pointers before performing a difference on them, and still return the
result as an int which should be large enough in practice.

Then use it to make some USB test 64-bit compatible.