### PR TITLE
assorted fixes to cfb font support

### DIFF
--- a/scripts/gen_cfb_font_header.py
+++ b/scripts/gen_cfb_font_header.py
@@ -75,7 +75,7 @@ def generate_header():
         if arg.startswith("--bindir"):
             # Drop. Assumes --bindir= was passed with '=' sign.
             continue
-        if arg.startswith(args.bindir):
+        if args.bindir and arg.startswith(args.bindir):
             # +1 to also strip '/' or '\' separator
             striplen = min(len(args.bindir)+1, len(arg))
             clean_cmd.append(arg[striplen:])
@@ -158,7 +158,7 @@ def parse_args():
         "-o", "--output", type=argparse.FileType('w'), default="-", metavar="FILE",
         help="CFB font header file (default: stdout)")
     group.add_argument(
-        "--bindir", type=str, default="",
+        "--bindir", type=str,
         help="CMAKE_BINARY_DIR for pure logging purposes. No trailing slash.")
     group.add_argument(
         "-x", "--width", required=True, type=int,

--- a/scripts/gen_cfb_font_header.py
+++ b/scripts/gen_cfb_font_header.py
@@ -13,7 +13,7 @@ from PIL import Image
 from PIL import ImageDraw
 
 PRINTABLE_MIN = 32
-PRINTABLE_MAX = 127
+PRINTABLE_MAX = 126
 
 def generate_element(image, charcode):
     """Generate CFB font element for a given character code from an image"""

--- a/subsys/fb/cfb_fonts.c
+++ b/subsys/fb/cfb_fonts.c
@@ -12,7 +12,7 @@
 #include <display/cfb.h>
 
 #define CFB_FONTS_FIRST_CHAR	32
-#define CFB_FONTS_LAST_CHAR	127
+#define CFB_FONTS_LAST_CHAR	126
 
 const u8_t cfb_font_1016[95][20] = {
 	/*   */


### PR DESCRIPTION
The last character index was wrong in two locations, and sanitization code corrupted the command reconstruction in a comment describing how fonts were generated in cases where the context didn't include specifying `--bindir`.