### PR TITLE
Settings: Fix incorrect return of -EINVAL for deleted entries

### DIFF
--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -315,9 +315,14 @@ int settings_line_val_read(off_t val_off, off_t off, char *out, size_t len_req,
 		enc_buf[read_size] = 0; /* breaking guaranteed */
 		read_size = strlen(enc_buf);
 
-		if (read_size == 0 || read_size % 4) {
-			/* unexpected use case - a NULL value or an encoding */
-			/* problem */
+		if (read_size == 0) {
+			/* a NULL value (deleted entry) */
+			*len_read = 0;
+			return 0;
+		}
+
+		if (read_size % 4) {
+			/* unexpected use case - an encoding problem */
 			return -EINVAL;
 		}
 

--- a/tests/subsys/settings/fcb/src/settings_test.h
+++ b/tests/subsys/settings/fcb/src/settings_test.h
@@ -22,6 +22,8 @@
 #define SETTINGS_TEST_FCB_VAL_STR_CNT   64
 #define SETTINGS_TEST_FCB_FLASH_CNT   4
 
+#define VAL8_DELETED 255U
+
 extern u8_t val8;
 extern u8_t val8_un;
 extern u32_t val32;

--- a/tests/subsys/settings/fcb/src/settings_test_delete_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_delete_fcb.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "settings_test.h"
+#include "settings/settings_fcb.h"
+
+void test_config_delete_fcb(void)
+{
+	int rc;
+	struct settings_fcb cf;
+
+	config_wipe_srcs();
+
+	cf.cf_fcb.f_magic = CONFIG_SETTINGS_FCB_MAGIC;
+	cf.cf_fcb.f_sectors = fcb_sectors;
+	cf.cf_fcb.f_sector_cnt = ARRAY_SIZE(fcb_sectors);
+
+	rc = settings_fcb_src(&cf);
+	zassert_true(rc == 0, "can't register FCB as configuration source");
+
+	settings_mount_fcb_backend(&cf);
+
+	rc = settings_fcb_dst(&cf);
+	zassert_true(rc == 0,
+		     "can't register FCB as configuration destination");
+
+	val8 = 153U;
+	rc = settings_save();
+	zassert_true(rc == 0, "fcb write error");
+
+	val8 = 0U;
+
+	rc = settings_load();
+	zassert_true(rc == 0, "fcb redout error");
+	zassert_true(val8 == 153U, "bad value read");
+
+	settings_delete("myfoo/mybar");
+	rc = settings_load();
+	zassert_true(rc == 0, "fcb redout error");
+	zassert_true(val8 == VAL8_DELETED, "bad value read");
+}

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -101,6 +101,9 @@ int c1_handle_set(const char *name, size_t len, settings_read_cb read_cb,
 	if (settings_name_steq(name, "mybar", &next) && !next) {
 		rc = read_cb(cb_arg, &val8, sizeof(val8));
 		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
+		if (rc == 0) {
+			val8 = VAL8_DELETED;
+		}
 		return 0;
 	}
 
@@ -365,6 +368,7 @@ void test_config_commit(void);
 
 void test_config_empty_fcb(void);
 void test_config_save_1_fcb(void);
+void test_config_delete_fcb(void);
 void test_config_insert2(void);
 void test_config_save_2_fcb(void);
 void test_config_insert3(void);
@@ -396,6 +400,7 @@ void test_main(void)
 			 ztest_unit_test(test_config_save_fcb_unaligned),
 			 ztest_unit_test(test_config_empty_fcb),
 			 ztest_unit_test(test_config_save_1_fcb),
+			 ztest_unit_test(test_config_delete_fcb),
 			 ztest_unit_test(test_config_insert2),
 			 ztest_unit_test(test_config_save_2_fcb),
 			 ztest_unit_test(test_config_insert3),


### PR DESCRIPTION
Fixes #17415
For settings_line_val_read function with following .conf setting:
CONFIG_SETTINGS_USE_BASE64=y

Signed-off-by: Declan Traill <declan.traill@setec.com.au>