### PR TITLE
logging: Fix corruption in log panic when scheduler was active

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -84,7 +84,9 @@ static inline void msg_finalize(struct log_msg *msg,
 	irq_unlock(key);
 
 	if (panic_mode) {
+		key = irq_lock();
 		(void)log_process(false);
+		irq_unlock(key);
 	} else if (CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD) {
 		if ((buffered_cnt == CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD) &&
 		    (proc_tid != NULL)) {


### PR DESCRIPTION
Logger had false assumption that once log_panic is called then
context switch will never occur and was not protecting against
reentrancy in panic mode. Added interrupt locking when accessing
unprotected part.

Manual back port of #17304 

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>