### PR TITLE
boards: arm: nrf52840_pca10090: fix compiler warning

### DIFF
--- a/boards/arm/nrf52840_pca10090/board.c
+++ b/boards/arm/nrf52840_pca10090/board.c
@@ -226,7 +226,7 @@ static void reset_pin_wait_low(struct device *port, u32_t pin)
 static int reset_pin_configure(struct device *p0, struct device *p1)
 {
 	int err;
-	u32_t pin;
+	u32_t pin = 0;
 	struct device *port = NULL;
 
 	static struct gpio_callback gpio_ctx;

--- a/boards/arm/nrf52840_pca10090/board.c
+++ b/boards/arm/nrf52840_pca10090/board.c
@@ -258,9 +258,7 @@ static int reset_pin_configure(struct device *p0, struct device *p1)
 		pin = 2;
 	}
 
-	if (port == NULL) {
-		return -EINVAL;
-	}
+	__ASSERT_NO_MSG(port != NULL);
 
 	err = gpio_pin_configure(port, pin,
 				 GPIO_DIR_IN | GPIO_INT | GPIO_PUD_PULL_DOWN |


### PR DESCRIPTION
Zero a variable to avoid a compiler warning when the reset line functionality is not enabled.