### PR TITLE
sensor: lis2dh: Fix stray use of old DT define

### DIFF
--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -14,7 +14,7 @@
 LOG_MODULE_REGISTER(lis2dh);
 #include "lis2dh.h"
 
-#if defined(DT_ST_LIS2DH_0_BUS_SPI)
+#if defined(DT_ST_LIS2DH_BUS_SPI)
 int lis2dh_spi_access(struct lis2dh_data *ctx, u8_t cmd,
 		      void *data, size_t length)
 {


### PR DESCRIPTION
Convert old DT_ST_LIS2DH_0_BUS_SPI to DT_ST_LIS2DH_BUS_SPI.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>