### PR TITLE
dts/extract: Mark DT_FLASH_AREA_*_LABEL defines as deprecated

### DIFF
--- a/scripts/dts/extract/flash.py
+++ b/scripts/dts/extract/flash.py
@@ -40,6 +40,7 @@ class DTFlash(DTDirective):
 
         partition_label = str_to_label(node['props']['label'])
         prop_def["DT_FLASH_AREA_{}_LABEL".format(area_id)] = partition_label
+        deprecated_main.append("DT_FLASH_AREA_{}_LABEL".format(area_id))
         prop_def["DT_FLASH_AREA_{}_ID".format(partition_label)] = area_id
 
         reg = node['props']['reg']
@@ -71,6 +72,7 @@ class DTFlash(DTDirective):
         partition_label = str_to_label(node['props']['label'])
 
         label = "DT_FLASH_AREA_{}_LABEL".format(partition_label)
+        deprecated_main.append(label)
         prop_def[label] = '"' + node['props']['label'] + '"'
         add_legacy_alias(prop_alias, label)
 


### PR DESCRIPTION
We don't use the DT_FLASH_AREA_*_LABEL defines today so lets mark them
deprecated until we actually need something.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>