### PR TITLE
tests: subsys: settings: fix pointer mismatch on 64-bit targets

### DIFF
--- a/tests/subsys/settings/nffs/src/settings_test_compress_file.c
+++ b/tests/subsys/settings/nffs/src/settings_test_compress_file.c
@@ -96,7 +96,7 @@ int file_str_cmp(const char *fname, char const *string, size_t pattern_len)
 {
 	int rc;
 	u32_t len;
-	u32_t rlen;
+	size_t rlen;
 	char *buf;
 	struct fs_dirent entry;
 

--- a/tests/subsys/settings/nffs/src/settings_test_nffs.c
+++ b/tests/subsys/settings/nffs/src/settings_test_nffs.c
@@ -207,7 +207,7 @@ int settings_test_file_strstr(const char *fname, char const *string,
 {
 	int rc;
 	u32_t len;
-	u32_t rlen;
+	size_t rlen;
 	char *buf;
 	struct fs_dirent entry;
 


### PR DESCRIPTION
This fixes the following error:
passing argument 5 of ‘fsutil_read_file’ from incompatible pointer type