### PR TITLE
fcb: start using errno codes

### DIFF
--- a/include/fs/fcb.h
+++ b/include/fs/fcb.h
@@ -123,18 +123,6 @@ struct fcb {
 	 */
 };
 
-/*
- * Error codes.
- */
-#define FCB_OK		0
-#define FCB_ERR_ARGS	-1
-#define FCB_ERR_FLASH	-2
-#define FCB_ERR_NOVAR   -3
-#define FCB_ERR_NOSPACE	-4
-#define FCB_ERR_NOMEM	-5
-#define FCB_ERR_CRC	-6
-#define FCB_ERR_MAGIC   -7
-
 /**
  * @}
  */

--- a/subsys/fs/fcb/fcb_append.c
+++ b/subsys/fs/fcb/fcb_append.c
@@ -44,7 +44,7 @@ fcb_append_to_scratch(struct fcb *fcb)
 
 	sector = fcb_new_sector(fcb, 0);
 	if (!sector) {
-		return FCB_ERR_NOSPACE;
+		return -ENOSPC;
 	}
 	rc = fcb_sector_hdr_init(fcb, sector, fcb->f_active_id + 1);
 	if (rc) {
@@ -53,7 +53,7 @@ fcb_append_to_scratch(struct fcb *fcb)
 	fcb->f_active.fe_sector = sector;
 	fcb->f_active.fe_elem_off = sizeof(struct fcb_disk_area);
 	fcb->f_active_id++;
-	return FCB_OK;
+	return 0;
 }
 
 int
@@ -74,14 +74,14 @@ fcb_append(struct fcb *fcb, u16_t len, struct fcb_entry *append_loc)
 
 	rc = k_mutex_lock(&fcb->f_mtx, K_FOREVER);
 	if (rc) {
-		return FCB_ERR_ARGS;
+		return -EINVAL;
 	}
 	active = &fcb->f_active;
 	if (active->fe_elem_off + len + cnt > active->fe_sector->fs_size) {
 		sector = fcb_new_sector(fcb, fcb->f_scratch_cnt);
 		if (!sector || (sector->fs_size <
 			sizeof(struct fcb_disk_area) + len + cnt)) {
-			rc = FCB_ERR_NOSPACE;
+			rc = -ENOSPC;
 			goto err;
 		}
 		rc = fcb_sector_hdr_init(fcb, sector, fcb->f_active_id + 1);
@@ -95,7 +95,7 @@ fcb_append(struct fcb *fcb, u16_t len, struct fcb_entry *append_loc)
 
 	rc = fcb_flash_write(fcb, active->fe_sector, active->fe_elem_off, tmp_str, cnt);
 	if (rc) {
-		rc = FCB_ERR_FLASH;
+		rc = -EIO;
 		goto err;
 	}
 	append_loc->fe_sector = active->fe_sector;
@@ -106,7 +106,7 @@ fcb_append(struct fcb *fcb, u16_t len, struct fcb_entry *append_loc)
 
 	k_mutex_unlock(&fcb->f_mtx);
 
-	return FCB_OK;
+	return 0;
 err:
 	k_mutex_unlock(&fcb->f_mtx);
 	return rc;
@@ -129,7 +129,7 @@ fcb_append_finish(struct fcb *fcb, struct fcb_entry *loc)
 
 	rc = fcb_flash_write(fcb, loc->fe_sector, off, crc8, fcb->f_align);
 	if (rc) {
-		return FCB_ERR_FLASH;
+		return -EIO;
 	}
 	return 0;
 }

--- a/subsys/fs/fcb/fcb_elem_info.c
+++ b/subsys/fs/fcb/fcb_elem_info.c
@@ -27,11 +27,11 @@ fcb_elem_crc8(struct fcb *fcb, struct fcb_entry *loc, u8_t *c8p)
 	int rc;
 
 	if (loc->fe_elem_off + 2 > loc->fe_sector->fs_size) {
-		return FCB_ERR_NOVAR;
+		return -ENOTSUP;
 	}
 	rc = fcb_flash_read(fcb, loc->fe_sector, loc->fe_elem_off, tmp_str, 2);
 	if (rc) {
-		return FCB_ERR_FLASH;
+		return -EIO;
 	}
 
 	cnt = fcb_get_len(tmp_str, &len);
@@ -54,7 +54,7 @@ fcb_elem_crc8(struct fcb *fcb, struct fcb_entry *loc, u8_t *c8p)
 
 		rc = fcb_flash_read(fcb, loc->fe_sector, off, tmp_str, blk_sz);
 		if (rc) {
-			return FCB_ERR_FLASH;
+			return -EIO;
 		}
 		crc8 = crc8_ccitt(crc8, tmp_str, blk_sz);
 	}
@@ -78,11 +78,11 @@ int fcb_elem_info(struct fcb *fcb, struct fcb_entry *loc)
 
 	rc = fcb_flash_read(fcb, loc->fe_sector, off, &fl_crc8, sizeof(fl_crc8));
 	if (rc) {
-		return FCB_ERR_FLASH;
+		return -EIO;
 	}
 
 	if (fl_crc8 != crc8) {
-		return FCB_ERR_CRC;
+		return -EBADMSG;
 	}
 	return 0;
 }

--- a/subsys/fs/fcb/fcb_rotate.c
+++ b/subsys/fs/fcb/fcb_rotate.c
@@ -16,12 +16,12 @@ fcb_rotate(struct fcb *fcb)
 
 	rc = k_mutex_lock(&fcb->f_mtx, K_FOREVER);
 	if (rc) {
-		return FCB_ERR_ARGS;
+		return -EINVAL;
 	}
 
 	rc = fcb_erase_sector(fcb, fcb->f_oldest);
 	if (rc) {
-		rc = FCB_ERR_FLASH;
+		rc = -EIO;
 		goto out;
 	}
 	if (fcb->f_oldest == fcb->f_active.fe_sector) {

--- a/subsys/fs/fcb/fcb_walk.c
+++ b/subsys/fs/fcb/fcb_walk.c
@@ -24,10 +24,10 @@ fcb_walk(struct fcb *fcb, struct flash_sector *sector, fcb_walk_cb cb,
 
 	rc = k_mutex_lock(&fcb->f_mtx, K_FOREVER);
 	if (rc < 0) {
-		return FCB_ERR_ARGS;
+		return -EINVAL;
 	}
 	while ((rc = fcb_getnext_nolock(fcb, &entry_ctx.loc)) !=
-	       FCB_ERR_NOVAR) {
+	       -ENOTSUP) {
 		k_mutex_unlock(&fcb->f_mtx);
 		if (sector && entry_ctx.loc.fe_sector != sector) {
 			return 0;
@@ -41,7 +41,7 @@ fcb_walk(struct fcb *fcb, struct flash_sector *sector, fcb_walk_cb cb,
 		}
 		rc = k_mutex_lock(&fcb->f_mtx, K_FOREVER);
 		if (rc < 0) {
-			return FCB_ERR_ARGS;
+			return -EINVAL;
 		}
 	}
 	k_mutex_unlock(&fcb->f_mtx);

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -268,7 +268,7 @@ static int settings_fcb_save_priv(struct settings_store *cs, const char *name,
 
 	for (i = 0; i < cf->cf_fcb.f_sector_cnt - 1; i++) {
 		rc = fcb_append(&cf->cf_fcb, len, &loc.loc);
-		if (rc != FCB_ERR_NOSPACE) {
+		if (rc != -ENOSPC) {
 			break;
 		}
 		settings_fcb_compress(cf);

--- a/tests/subsys/fs/fcb/src/fcb_test.h
+++ b/tests/subsys/fs/fcb/src/fcb_test.h
@@ -14,6 +14,7 @@
 
 #include <fs/fcb.h>
 #include "fcb_priv.h"
+#include <errno.h>
 
 #ifdef __cplusplus
 #extern "C" {

--- a/tests/subsys/fs/fcb/src/fcb_test_append_fill.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_append_fill.c
@@ -32,7 +32,7 @@ void fcb_test_append_fill(void)
 
 	while (1) {
 		rc = fcb_append(fcb, sizeof(test_data), &loc);
-		if (rc == FCB_ERR_NOSPACE) {
+		if (rc == -ENOSPC) {
 			break;
 		}
 		if (loc.fe_sector == &test_fcb_sector[0]) {

--- a/tests/subsys/fs/fcb/src/fcb_test_init.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_init.c
@@ -16,17 +16,17 @@ void fcb_test_init(void)
 	(void)memset(fcb, 0, sizeof(*fcb));
 
 	rc = fcb_init(TEST_FCB_FLASH_AREA_ID, fcb);
-	zassert_true(rc == FCB_ERR_ARGS, "fcb_init call should fail");
+	zassert_true(rc == -EINVAL, "fcb_init call should fail");
 
 	fcb->f_sectors = test_fcb_sector;
 
 	rc = fcb_init(TEST_FCB_FLASH_AREA_ID, fcb);
-	zassert_true(rc == FCB_ERR_ARGS, "fcb_init call should fail");
+	zassert_true(rc == -EINVAL, "fcb_init call should fail");
 
 	fcb->f_sector_cnt = 2U;
 	fcb->f_magic = 0x12345678;
 	rc = fcb_init(TEST_FCB_FLASH_AREA_ID, fcb);
-	zassert_true(rc == FCB_ERR_MAGIC, "fcb_init call should fail");
+	zassert_true(rc == -ENOMSG, "fcb_init call should fail");
 
 	fcb->f_magic = 0U;
 	rc = fcb_init(TEST_FCB_FLASH_AREA_ID, fcb);

--- a/tests/subsys/fs/fcb/src/fcb_test_last_of_n.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_last_of_n.c
@@ -29,7 +29,7 @@ void fcb_test_last_of_n(void)
 	 */
 	for (i = 0U; i < ENTRIES; i++) {
 		rc = fcb_append(fcb, sizeof(test_data), &loc);
-		if (rc == FCB_ERR_NOSPACE) {
+		if (rc == -ENOSPC) {
 			break;
 		}
 

--- a/tests/subsys/fs/fcb/src/fcb_test_multiple_scratch.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_multiple_scratch.c
@@ -30,7 +30,7 @@ void fcb_test_multi_scratch(void)
 	(void)memset(elem_cnts, 0, sizeof(elem_cnts));
 	while (1) {
 		rc = fcb_append(fcb, sizeof(test_data), &loc);
-		if (rc == FCB_ERR_NOSPACE) {
+		if (rc == -ENOSPC) {
 			break;
 		}
 		idx = loc.fe_sector - &test_fcb_sector[0];
@@ -58,7 +58,7 @@ void fcb_test_multi_scratch(void)
 
 	while (1) {
 		rc = fcb_append(fcb, sizeof(test_data), &loc);
-		if (rc == FCB_ERR_NOSPACE) {
+		if (rc == -ENOSPC) {
 			break;
 		}
 		idx = loc.fe_sector - &test_fcb_sector[0];

--- a/tests/subsys/fs/fcb/src/fcb_test_rotate.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_rotate.c
@@ -33,7 +33,7 @@ void fcb_test_rotate(void)
 	 */
 	while (1) {
 		rc = fcb_append(fcb, sizeof(test_data), &loc);
-		if (rc == FCB_ERR_NOSPACE) {
+		if (rc == -ENOSPC) {
 			break;
 		}
 		if (loc.fe_sector == &test_fcb_sector[0]) {


### PR DESCRIPTION
Switch form using privater FCB error codes to
errno codes. FCB private codes convention were compatible
with <errno.h> codes:
- 0 mean success
- negative values mean errors
- similar error types.
There was no sense to kept private FCB error codes.

~~merge after https://github.com/zephyrproject-rtos/zephyr/pull/17425 as need to remove codes from fcb.h~~ merged

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>