### PR TITLE
realloc(): fix possible memory leak

### DIFF
--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -96,6 +96,7 @@ void *realloc(void *ptr, size_t requested_size)
 	}
 
 	if (requested_size == 0) {
+		free(ptr);
 		return NULL;
 	}
 


### PR DESCRIPTION
If size is equal to zero, and ptr is not NULL, then the call must be
equivalent to free(ptr).