### PR TITLE
boards: arm: mps2_an521: force secure firmware image by default

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -105,6 +105,13 @@ comment "Secure firmware"
 comment "Non-secure firmware"
 	depends on !ARM_SECURE_FIRMWARE
 
+config ARM_SECURE_BUSFAULT_HARDFAULT_NMI
+	bool "BusFault, HardFault, and NMI target Secure state"
+	depends on ARM_SECURE_FIRMWARE
+	help
+	  Force NMI, HardFault, and BusFault (in Mainline ARMv8-M)
+	  exceptions as Secure exceptions.
+
 config ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS
 	bool "Secure Firmware has Secure Entry functions"
 	depends on ARM_SECURE_FIRMWARE

--- a/arch/arm/include/cortex_m/exc.h
+++ b/arch/arm/include/cortex_m/exc.h
@@ -112,7 +112,8 @@ static ALWAYS_INLINE void z_ExcSetup(void)
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 #endif /* CONFIG_CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS */
 
-#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+#if defined(CONFIG_ARM_SECURE_FIRMWARE) && \
+	!defined(CONFIG_ARM_SECURE_BUSFAULT_HARDFAULT_NMI)
 	/* Set NMI, Hard, and Bus Faults as Non-Secure.
 	 * NMI and Bus Faults targeting the Secure state will
 	 * escalate to a SecureFault or SecureHardFault.
@@ -126,7 +127,7 @@ static ALWAYS_INLINE void z_ExcSetup(void)
 	 * in a PE with the Main Extension instead generate a
 	 * SecureHardFault in a PE without the Main Extension.
 	 */
-#endif /* CONFIG_ARM_SECURE_FIRMWARE */
+#endif /* ARM_SECURE_FIRMWARE && !ARM_SECURE_BUSFAULT_HARDFAULT_NMI */
 }
 
 /**

--- a/boards/arm/mps2_an521/mps2_an521_defconfig
+++ b/boards/arm/mps2_an521/mps2_an521_defconfig
@@ -29,4 +29,7 @@ CONFIG_UART_CMSDK_APB=y
 # Watchdog
 CONFIG_WATCHDOG=y
 
+# Build a Secure firmware image
+CONFIG_TRUSTED_EXECUTION_SECURE=y
+
 CONFIG_I2C=y

--- a/soc/arm/arm/mps2/soc.h
+++ b/soc/arm/arm/mps2/soc.h
@@ -16,6 +16,7 @@
 #endif
 
 #include <soc_devices.h>
+#include <generated_dts_board.h>
 
 extern void wakeup_cpu1(void);
 

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -111,4 +111,19 @@ config TEST_FLASH_DRIVERS
 	  This option will help test the flash drivers. This should be enabled
 	  only when using qemu_x86.
 
+config TEST_ARM_CORTEX_M
+	bool
+	depends on CPU_CORTEX_M
+	default y
+	select ARM_SECURE_BUSFAULT_HARDFAULT_NMI if ARM_SECURE_FIRMWARE
+	help
+	  ARM Cortex-M configuration required when testing.
+
+	  Currently, this option is only utilized, to force routing
+	  BusFault, HardFault, and NMI exceptions to Secure State,
+	  when building a Secure ARMv8-M firmware. This will allow
+	  the testing suite to utilize these exceptions, in tests.
+	  Note that by default, when building with ARM_SECURE_FIRMWARE
+	  set, these exceptions are set to target the Non-Secure state.
+
 endmenu


### PR DESCRIPTION
In order to increase code coverage, we force building a Secure
Firmware image by default (i.e. with option
CONFIG_TRUSTED_EXECUTION_SECURE set), when building for
mps2_an521 board. CONFIG_TRUSTED_EXECUTION_SECURE enables
compiling-in all TrustZone-related code in the tree, that is,
all ARM-specific code inside #ifdef CONFIG_ARM_SECURE_FIRMWARE.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Closes #16148 