### PR TITLE
usb: do not disable endpoints at USB_DC_SUSPEND event

### DIFF
--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -942,8 +942,10 @@ static void forward_status_cb(enum usb_dc_status_code status, const u8_t *param)
 	if (status == USB_DC_DISCONNECTED || status == USB_DC_SUSPEND) {
 		if (usb_dev.configured) {
 			usb_cancel_transfers();
-			foreach_ep(disable_interface_ep);
-			usb_dev.configured = false;
+			if (status == USB_DC_DISCONNECTED) {
+				foreach_ep(disable_interface_ep);
+				usb_dev.configured = false;
+			}
 		}
 	}
 


### PR DESCRIPTION
Do not disable endpoints at USB_DC_SUSPEND event.

Possible fix for #16599 and #17488, but needs more examination. I will update the commit message.

Background: #15917 and #16193