### PR TITLE
cmake: strip_nondeterminism_if_found() on all .a library files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -819,6 +819,7 @@ if(CONFIG_ARM AND CONFIG_USERSPACE)
   add_library(priv_stacks_output_lib STATIC
     ${CMAKE_CURRENT_BINARY_DIR}/${PRIV_STACKS_OUTPUT_SRC}
     )
+  strip_nondeterminism_if_found(priv_stacks_output_lib)
 
   # Turn off -ffunction-sections, etc.
   # NB: Using a library instead of target_compile_options(priv_stacks_output_lib
@@ -937,6 +938,7 @@ if(CONFIG_USERSPACE)
   add_library(output_lib STATIC
     ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_SRC}
     )
+  strip_nondeterminism_if_found(output_lib)
 
   set_source_files_properties(${OUTPUT_SRC} PROPERTIES COMPILE_FLAGS
     "${NO_COVERAGE_FLAGS} -fno-function-sections -fno-data-sections")

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -363,6 +363,19 @@ macro(zephyr_library_get_current_dir_lib_name lib_name)
   set(${lib_name} ${name})
 endmacro()
 
+find_program(STRIP_NONDETERMINISM strip-nondeterminism)
+
+if (NOT ${STRIP_NONDETERMINISM} STREQUAL STRIP_NONDETERMINISM-NOTFOUND)
+  macro(strip_nondeterminism_if_found name)
+    add_custom_command(TARGET ${name}
+      COMMAND ${STRIP_NONDETERMINISM} $<TARGET_FILE:${name}>
+      )
+  endmacro()
+else()
+  macro(strip_nondeterminism_if_found name)
+  endmacro()
+endif()
+
 # Constructor with an explicitly given name.
 macro(zephyr_library_named name)
   # This is a macro because we need add_library() to be executed
@@ -373,6 +386,8 @@ macro(zephyr_library_named name)
   zephyr_append_cmake_library(${name})
 
   target_link_libraries(${name} PUBLIC zephyr_interface)
+  strip_nondeterminism_if_found(${name})
+
 endmacro()
 
 

--- a/cmake/linker/ld/target_relocation.cmake
+++ b/cmake/linker/ld/target_relocation.cmake
@@ -26,5 +26,6 @@ macro(toolchain_ld_relocation)
     )
 
   add_library(code_relocation_source_lib  STATIC ${MEM_RELOCATAION_CODE})
+  strip_nondeterminism_if_found(code_relocation_source_lib)
   target_link_libraries(code_relocation_source_lib zephyr_interface)
 endmacro()

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(kernel
   work_q.c
   smp.c
   )
+strip_nondeterminism_if_found(kernel)
 
 # Kernel files has the macro __ZEPHYR_SUPERVISOR__ set so that it
 # optimizes the code when userspace is enabled.


### PR DESCRIPTION
Post process libraries if find_program(strip-nondeterminism) succeeds,
do nothing otherwise.

This has been successfully tested on Ubuntu 18.04 with a full
sanitycheck run including all the default samples/ and tests/

Two very important caveats:

1. This required a couple of fixes on top of "apt-get install
   non-determinism" version 0.040-1.1~build1. These fixes are available
   at https://salsa.debian.org/reproducible-builds/strip-nondeterminism/merge_requests/4

2. The entire ar.pm handler has been removed in more recent (1.0.0+)
   strip-nondeterminism releases! The commit message 366d60c9cc16 says:
   "Drop .ar handler; binutils is reproducible". The corresponding bugs
   and discussions seem to show a concern than ar.pm could hide bugs in
   binutils or llvm-ar. Supporting older or non-debian systems doesn't
   seem to be desired.

So the preferred alternative is to use a toolchain like the Zephyr SDK
that supports creating deterministic .a files and (if not the default)
pass the -D option to (GNU) ar thanks to
CMAKE_LANG_CREATE_STATIC_LIBRARY

Signed-off-by: Marc Herbert <marc.herbert@intel.com>