### PR TITLE
drivers/flash: Protection API clarification

### DIFF
--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -78,7 +78,6 @@ static struct k_sem sem_lock;
 #define SYNC_UNLOCK()
 #endif
 
-static bool write_protect;
 
 static int write(off_t addr, const void *data, size_t len);
 static int erase(u32_t addr, u32_t size);
@@ -148,10 +147,6 @@ static int flash_nrf_write(struct device *dev, off_t addr,
 {
 	int ret;
 
-	if (write_protect) {
-		return -EACCES;
-	}
-
 	if (is_regular_addr_valid(addr, len)) {
 		addr += DT_FLASH_BASE_ADDRESS;
 	} else if (!is_uicr_addr_valid(addr, len)) {
@@ -183,10 +178,6 @@ static int flash_nrf_erase(struct device *dev, off_t addr, size_t size)
 	u32_t pg_size = nrfx_nvmc_flash_page_size_get();
 	u32_t n_pages = size / pg_size;
 	int ret;
-
-	if (write_protect) {
-		return -EACCES;
-	}
 
 	if (is_regular_addr_valid(addr, size)) {
 		/* Erase can only be done per page */
@@ -227,9 +218,6 @@ static int flash_nrf_erase(struct device *dev, off_t addr, size_t size)
 
 static int flash_nrf_write_protection(struct device *dev, bool enable)
 {
-	/* virtual write-erase protection */
-	write_protect = enable;
-
 	return 0;
 }
 
@@ -268,7 +256,6 @@ static int nrf_flash_init(struct device *dev)
 	dev_layout.pages_count = nrfx_nvmc_flash_page_count_get();
 	dev_layout.pages_size = nrfx_nvmc_flash_page_size_get();
 #endif
-	write_protect = true;
 
 	return 0;
 }

--- a/include/drivers/flash.h
+++ b/include/drivers/flash.h
@@ -165,12 +165,29 @@ static inline int z_impl_flash_erase(struct device *dev, off_t offset,
  *  @brief  Enable or disable write protection for a flash memory
  *
  *  This API is required to be called before the invocation of write or erase
- *  API. Please note that on some flash components, the write protection is
+ *  API. Any calls to flash_write() or flash_erase() that do not first disable
+ *  write protection using this function result in undefined behavior.
+ *  Usage Example:
+ *  @code
+ *   flash_write_protection_set(flash_dev, false);
+ *   flash_erase(flash_dev, page_offset, page_size);
+ *
+ *   flash_write_protection_set(flash_dev, false);
+ *   flash_write(flash_dev, offset, data, sizeof(data));
+ *
+ *   flash_write_protection_set(flash_dev, true); // enable is recommended
+ *  @endcode
+ *
+ *  Please note that on some flash components, the write protection is
  *  automatically turned on again by the device after the completion of each
- *  write or erase calls. Therefore, on those flash parts, write protection needs
- *  to be disabled before each invocation of the write or erase API. Please refer
- *  to the sub-driver API or the data sheet of the flash component to get details
- *  on the write protection behavior.
+ *  call to flash_write or flash_erase(). Therefore, portable programs must
+ *  disable write protection using this function before each call to
+ *  flash_erase() or flash_write().
+ *
+ *  For some flash devices, this function may implement a no-operation, as some
+ *  flash hardware does not support write protection, or may not support it in
+ *  a manner that is compatible with this API. For these drivers, this function
+ *  always returns success.
  *
  *  @param  dev             : flash device
  *  @param  enable          : enable or disable flash write protection


### PR DESCRIPTION
### General patch
This changes was discuses on dev-meeting 4th June 2019

On some targets hardware (or middelware) doesn't allow
implement functionality flash protection API -
so fare it have to be emulated by software on such a target.

This patch changes documentation of this API, so on such a targets
API might implements no-operation.

fixes #15729

### Nordic patch

NRF devices hardware has flash protection which doesn't
reflect flash API definition well. So fare protection
mechanism was emulated by the software and the driver deals
with hardware flash protection on its own.
Recent change to protection behavior requirement allows
to remove flash API behavior emulation at all.


