### PR TITLE
arch: POSIX: Do not assume 32bit pointers

### DIFF
--- a/arch/posix/core/thread.c
+++ b/arch/posix/core/thread.c
@@ -75,7 +75,7 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	thread_status->aborted = 0;
 #endif
 
-	thread->callee_saved.thread_status = (u32_t)thread_status;
+	thread->callee_saved.thread_status = thread_status;
 
 	posix_new_thread(thread_status);
 }

--- a/arch/posix/include/kernel_arch_thread.h
+++ b/arch/posix/include/kernel_arch_thread.h
@@ -30,11 +30,8 @@ struct _callee_saved {
 	/* Return value of z_swap() */
 	u32_t retval;
 
-	/*
-	 * Thread status pointer
-	 * (We need to compile as 32bit binaries in POSIX)
-	 */
-	u32_t thread_status;
+	/* Thread status pointer */
+	void *thread_status;
 };
 
 


### PR DESCRIPTION
Correct the storage type of the thread status pointer
not assuming 32bit pointer and integer size

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>