### PR TITLE
sanitycheck: update sections whitelist

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -917,7 +917,8 @@ class SizeCalculator:
     # These get copied into RAM only on non-XIP
     ro_sections = ["text", "ctors", "init_array", "reset", "object_access",
                    "rodata", "devconfig", "net_l2", "vector", "sw_isr_table",
-                   "_bt_settings_area", "_bt_channels_area","_bt_services_area",
+                   "_settings_handlers_area", "_bt_channels_area",
+                   "_bt_services_area",
                    "vectors", "net_socket_register"]
 
     def __init__(self, filename, extra_sections):


### PR DESCRIPTION
In c20ff1150f717d79374997ed3b429b2449d2c3b8
and 5f19c8160ade6d5ef5ef5e440e86cf4468210542
(PR #16897)
_bt_settings_area was replaced with _settings_handlers_area

Update sanitycheck sections whitelist accordingly

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

Fixes #17485