### PR TITLE
net: ieee802154_nrf: Fix SoC header inclusion

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -37,7 +37,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <net/ieee802154_radio.h>
 
-#include "nrf52840.h"
 #include "ieee802154_nrf5.h"
 #include "nrf_802154.h"
 


### PR DESCRIPTION
The nRF 802.15.4 radio driver should not include nRF52840 header directly,
but rely on soc.h instead. Otherwise, it will not work with different
SoCs supporting 802.15.4.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>