### PR TITLE
tests: work_queue_api: Fix k_delayed_work_remaining_get() test

### DIFF
--- a/tests/kernel/workq/work_queue_api/src/main.c
+++ b/tests/kernel/workq/work_queue_api/src/main.c
@@ -110,6 +110,7 @@ static void twork_resubmit(void *data)
 static void tdelayed_work_submit(void *data)
 {
 	struct k_work_q *work_q = (struct k_work_q *)data;
+	s32_t time_remaining;
 
 	for (int i = 0; i < NUM_OF_WORK; i++) {
 		/**TESTPOINT: init via k_delayed_work_init*/
@@ -129,9 +130,15 @@ static void tdelayed_work_submit(void *data)
 			zassert_true(k_delayed_work_submit(&delayed_work[i],
 							   TIMEOUT) == 0, NULL);
 		}
-		/**TESTPOINT: check remaining timeout after submit*/
-		zassert_true(k_delayed_work_remaining_get(&delayed_work[i]) >=
-			     TIMEOUT, NULL);
+
+		time_remaining = k_delayed_work_remaining_get(&delayed_work[i]);
+
+		/**TESTPOINT: check remaining timeout after submit */
+		zassert_true(
+		    time_remaining <= __ticks_to_ms(z_ms_to_ticks(TIMEOUT)
+						    + _TICK_ALIGN) &&
+		    time_remaining >= __ticks_to_ms(z_ms_to_ticks(TIMEOUT) -
+						    z_ms_to_ticks(15)), NULL);
 		/**TESTPOINT: check pending after delayed work submit*/
 		zassert_true(k_work_pending((struct k_work *)&delayed_work[i])
 			     == 0, NULL);


### PR DESCRIPTION
Existing test checking value returned by k_delayed_work_remaining_get()
verified two cases:

1) The k_delayed_work_remaining_get() should return 0 for non-submitted
   work.

2) The k_delayed_work_remaining_get() should return value greater or
   equal to the timeout value of just submitted work.

Unfortunately, the second check is not correct. The value returned
by the k_delayed_work_remaining_get() just after submitting delayed
work should be:

- Equal to timeout of the submitted work if no timer interrupt was
  executed between submitting work and checking remaining time.

  OR

- Less than timeout of the submitted work if a timer interrupt was
  executed between submitting work and checking remaining time.

This commit PR the test accordingly taking under account the
error caused by back and forth conversion between ms and ticks.

Signed-off-by: Piotr Zięcik <piotr.ziecik@nordicsemi.no>