### PR TITLE
native_posix: New timer driver aligned with new API

### DIFF
--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -196,6 +196,7 @@ config NATIVE_POSIX_TIMER
 	bool "(POSIX) native_posix timer driver"
 	default y
 	depends on BOARD_NATIVE_POSIX
+	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the native_posix HW timer
 	  model


### PR DESCRIPTION
The native_posix timer driver was still using the legacy timer API.
So, align it with the new kernel<->system timer driver API.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>