### PR TITLE
Includes: #ifdef CONFIG_USE_SWITCH instead of #if to avoid undef warning

### DIFF
--- a/kernel/include/kernel_structs.h
+++ b/kernel/include/kernel_structs.h
@@ -185,7 +185,7 @@ extern struct z_kernel _kernel;
 
 #include <kernel_arch_func.h>
 
-#if CONFIG_USE_SWITCH
+#ifdef CONFIG_USE_SWITCH
 /* This is a arch function traditionally, but when the switch-based
  * z_swap() is in use it's a simple inline provided by the kernel.
  */


### PR DESCRIPTION
Signed-off-by: Nicholas Lowell <nlowell@lexmark.com>