### PR TITLE
sanitycheck: Add missing section to whitelist

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -921,7 +921,7 @@ class SizeCalculator:
     ro_sections = ["text", "ctors", "init_array", "reset", "object_access",
                    "rodata", "devconfig", "net_l2", "vector", "sw_isr_table",
                    "_settings_handlers_area", "_bt_channels_area",
-                   "_bt_services_area",
+                   "_bt_br_channels_area", "_bt_services_area",
                    "vectors", "net_socket_register"]
 
     def __init__(self, filename, extra_sections):


### PR DESCRIPTION
In a3bea8872b2 (PR #16352)
_bt_br_channels_area was added to the code but not the
sanitycheck sections whitelist => Add it

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

See https://github.com/zephyrproject-rtos/zephyr/pull/17500#issuecomment-510916071

Fixes #17511