### PR TITLE
dts/bindings: Fix category field for microchip,xec-i2c

### DIFF
--- a/dts/bindings/i2c/microchip,xec-i2c.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
@@ -23,4 +23,4 @@ properties:
     port_sel:
       type: int
       description: soc block mapping to pin
-      category: define
+      category: required


### PR DESCRIPTION
The port_sel property had the category set to 'define' which isn't a
valid option.  Change it to be 'required'.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>