### PR TITLE
disk: sdhc: Fix use of deprecated DTS defines

### DIFF
--- a/subsys/disk/disk_access_spi_sdhc.c
+++ b/subsys/disk/disk_access_spi_sdhc.c
@@ -704,10 +704,10 @@ static int sdhc_spi_init(struct device *dev)
 	data->cfg.operation = SPI_WORD_SET(8) | SPI_HOLD_ON_CS;
 	data->cfg.slave = DT_INST_0_ZEPHYR_MMC_SPI_SLOT_BASE_ADDRESS;
 	data->cs = device_get_binding(
-		DT_INST_0_ZEPHYR_MMC_SPI_SLOT_CS_GPIO_CONTROLLER);
+		DT_INST_0_ZEPHYR_MMC_SPI_SLOT_CS_GPIOS_CONTROLLER);
 	__ASSERT_NO_MSG(data->cs != NULL);
 
-	data->pin = DT_INST_0_ZEPHYR_MMC_SPI_SLOT_CS_GPIO_PIN;
+	data->pin = DT_INST_0_ZEPHYR_MMC_SPI_SLOT_CS_GPIOS_PIN;
 
 	disk_spi_sdhc_init(dev);
 


### PR DESCRIPTION
We should be using _GPIOS_ instead of _GPIO_ in the code.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>