### PR TITLE
soc: stm32: add SWO logger backend support

### DIFF
--- a/soc/arm/st_stm32/stm32f1/Kconfig.series
+++ b/soc/arm/st_stm32/stm32f1/Kconfig.series
@@ -11,5 +11,6 @@ config SOC_SERIES_STM32F1X
 	select SOC_FAMILY_STM32
 	select HAS_STM32CUBE
 	select CLOCK_CONTROL_STM32_CUBE if CLOCK_CONTROL
+	select HAS_SWO
 	help
 	 Enable support for STM32F1 MCU series

--- a/soc/arm/st_stm32/stm32f2/Kconfig.series
+++ b/soc/arm/st_stm32/stm32f2/Kconfig.series
@@ -11,5 +11,6 @@ config SOC_SERIES_STM32F2X
 	select SOC_FAMILY_STM32
 	select HAS_STM32CUBE
 	select CLOCK_CONTROL_STM32_CUBE if CLOCK_CONTROL
+	select HAS_SWO
 	help
 	  Enable support for stm32f2 MCU series

--- a/soc/arm/st_stm32/stm32f3/Kconfig.series
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.series
@@ -12,5 +12,6 @@ config SOC_SERIES_STM32F3X
 	select CPU_HAS_FPU
 	select HAS_STM32CUBE
 	select CLOCK_CONTROL_STM32_CUBE if CLOCK_CONTROL
+	select HAS_SWO
 	help
 	 Enable support for STM32F3 MCU series

--- a/soc/arm/st_stm32/stm32f4/Kconfig.series
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.series
@@ -13,5 +13,6 @@ config SOC_SERIES_STM32F4X
 	select HAS_STM32CUBE
 	select CPU_HAS_ARM_MPU
 	select CLOCK_CONTROL_STM32_CUBE if CLOCK_CONTROL
+	select HAS_SWO
 	help
 	 Enable support for STM32F4 MCU series

--- a/soc/arm/st_stm32/stm32f7/Kconfig.series
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.series
@@ -13,5 +13,6 @@ config SOC_SERIES_STM32F7X
 	select HAS_STM32CUBE
 	select CPU_HAS_ARM_MPU
 	select CLOCK_CONTROL_STM32_CUBE if CLOCK_CONTROL
+	select HAS_SWO
 	help
 	 Enable support for STM32F7 MCU series

--- a/soc/arm/st_stm32/stm32l1/Kconfig.series
+++ b/soc/arm/st_stm32/stm32l1/Kconfig.series
@@ -11,5 +11,6 @@ config SOC_SERIES_STM32L1X
 	select SOC_FAMILY_STM32
 	select HAS_STM32CUBE
 	select CLOCK_CONTROL_STM32_CUBE if CLOCK_CONTROL
+	select HAS_SWO
 	help
 	  Enable support for STM32L1 MCU series

--- a/soc/arm/st_stm32/stm32l4/Kconfig.series
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.series
@@ -14,5 +14,6 @@ config SOC_SERIES_STM32L4X
 	select HAS_STM32CUBE
 	select CPU_HAS_ARM_MPU
 	select CLOCK_CONTROL_STM32_CUBE if CLOCK_CONTROL
+	select HAS_SWO
 	help
 		Enable support for STM32L4 MCU series

--- a/soc/arm/st_stm32/stm32wb/Kconfig.series
+++ b/soc/arm/st_stm32/stm32wb/Kconfig.series
@@ -13,5 +13,6 @@ config SOC_SERIES_STM32WBX
 	select HAS_STM32CUBE
 	select CPU_HAS_ARM_MPU
 	select CLOCK_CONTROL_STM32_CUBE if CLOCK_CONTROL
+	select HAS_SWO
 	help
 	  Enable support for STM32WB MCU series


### PR DESCRIPTION
This patch adds HAS_SWO selections to all STM32 SoCs supporting Serial
Wire Output via the Trace Port Interface Unit (TPIU).

Signed-off-by: Markus Fuchs <markus.fuchs@de.sauter-bc.com>