### PR TITLE
Extending ztest to allow test spawning, refactor counter to use test spawning

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -655,7 +655,7 @@ static inline s64_t arithmetic_shift_right(s64_t value, u8_t shift)
 #define UTIL_LISTIFY(LEN, F, F_ARG) UTIL_EVAL(UTIL_REPEAT(LEN, F, F_ARG))
 
 /**@brief Implementation details for NUM_VAR_ARGS */
-#define NUM_VA_ARGS_LESS_1_IMPL(				\
+#define NUM_VA_ARGS_IMPL(					\
 	_ignored,						\
 	_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10,		\
 	_11, _12, _13, _14, _15, _16, _17, _18, _19, _20,	\
@@ -673,12 +673,29 @@ static inline s64_t arithmetic_shift_right(s64_t value, u8_t shift)
  * @retval  Number of variadic arguments in the argument list
  */
 #define NUM_VA_ARGS_LESS_1(...) \
-	NUM_VA_ARGS_LESS_1_IMPL(__VA_ARGS__, 63, 62, 61, \
-	60, 59, 58, 57, 56, 55, 54, 53, 52, 51,		 \
-	50, 49, 48, 47, 46, 45, 44, 43, 42, 41,		 \
-	40, 39, 38, 37, 36, 35, 34, 33, 32, 31,		 \
-	30, 29, 28, 27, 26, 25, 24, 23, 22, 21,		 \
-	20, 19, 18, 17, 16, 15, 14, 13, 12, 11,		 \
+	NUM_VA_ARGS_IMPL(__VA_ARGS__, 63, 62, 61,	\
+	60, 59, 58, 57, 56, 55, 54, 53, 52, 51,		\
+	50, 49, 48, 47, 46, 45, 44, 43, 42, 41,		\
+	40, 39, 38, 37, 36, 35, 34, 33, 32, 31,		\
+	30, 29, 28, 27, 26, 25, 24, 23, 22, 21,		\
+	20, 19, 18, 17, 16, 15, 14, 13, 12, 11,		\
+	10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, ~)
+
+
+/**@brief Macro to get the number of arguments in a call variadic macro call.
+ * First and second argument are not counted.
+ *
+ * param[in]    ...     List of arguments
+ *
+ * @retval  Number of variadic arguments in the argument list
+ */
+#define NUM_VA_ARGS_LESS_2(...) \
+	NUM_VA_ARGS_IMPL(__VA_ARGS__, 62, 61,	\
+	60, 59, 58, 57, 56, 55, 54, 53, 52, 51,	\
+	50, 49, 48, 47, 46, 45, 44, 43, 42, 41,	\
+	40, 39, 38, 37, 36, 35, 34, 33, 32, 31,	\
+	30, 29, 28, 27, 26, 25, 24, 23, 22, 21,	\
+	20, 19, 18, 17, 16, 15, 14, 13, 12, 11,	\
 	10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, ~)
 
 /**

--- a/tests/misc/util/src/main.c
+++ b/tests/misc/util/src/main.c
@@ -76,13 +76,50 @@ void test_UTIL_LISTIFY(void)
 	zassert_equal(i, 0 + 1 + 2 + 3, NULL);
 }
 
+void test_NUM_VA_ARGS_LESS_1(void)
+{
+	zassert_equal(NUM_VA_ARGS_LESS_1(1), 0, NULL);
+	zassert_equal(NUM_VA_ARGS_LESS_1(1, 1), 1, NULL);
+	zassert_equal(NUM_VA_ARGS_LESS_1(1, 1, 1), 2, NULL);
+	zassert_equal(NUM_VA_ARGS_LESS_1(1, 1, 1, 1), 3, NULL);
+	zassert_equal(NUM_VA_ARGS_LESS_1(1, 1, 1, 1, 1), 4, NULL);
+	zassert_equal(NUM_VA_ARGS_LESS_1(1, 1, 1, 1, 1, 1), 5, NULL);
+	zassert_equal(NUM_VA_ARGS_LESS_1(1, 1, 1, 1, 1, 1, 1), 6, NULL);
+	zassert_equal(
+		NUM_VA_ARGS_LESS_1(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+		14, NULL);
+	zassert_equal(
+		NUM_VA_ARGS_LESS_1(1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+				   1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+		19, NULL);
+}
+
+void test_NUM_VA_ARGS_LESS_2(void)
+{
+	zassert_equal(NUM_VA_ARGS_LESS_2(1, 1), 0, NULL);
+	zassert_equal(NUM_VA_ARGS_LESS_2(1, 1, 1), 1, NULL);
+	zassert_equal(NUM_VA_ARGS_LESS_2(1, 1, 1, 1), 2, NULL);
+	zassert_equal(NUM_VA_ARGS_LESS_2(1, 1, 1, 1, 1), 3, NULL);
+	zassert_equal(NUM_VA_ARGS_LESS_2(1, 1, 1, 1, 1, 1), 4, NULL);
+	zassert_equal(NUM_VA_ARGS_LESS_2(1, 1, 1, 1, 1, 1, 1), 5, NULL);
+	zassert_equal(
+		NUM_VA_ARGS_LESS_2(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+		13, NULL);
+	zassert_equal(
+		NUM_VA_ARGS_LESS_2(1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+			    1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+		18, NULL);
+}
+
 /*test case main entry*/
 void test_main(void)
 {
 	ztest_test_suite(test_util_api,
 			 ztest_unit_test(test_COND_CODE_1),
 			 ztest_unit_test(test_COND_CODE_0),
-			 ztest_unit_test(test_UTIL_LISTIFY)
+			 ztest_unit_test(test_UTIL_LISTIFY),
+			 ztest_unit_test(test_NUM_VA_ARGS_LESS_1),
+			 ztest_unit_test(test_NUM_VA_ARGS_LESS_2)
 			 );
 	ztest_run_test_suite(test_util_api);
 }


### PR DESCRIPTION
PR contains changes in 3 areas:
- extending `util.h` with macro `NUM_VA_ARGS_LESS_2`
- extending ztest with test spawning. The idea is that there is a list of instances on which same test has to be performed (e.g. device instances). So far, a solution was to do single test function which was iterating over the list of objects. This approach has some drawbacks: failure terminates full tests, some instances may not support all features thus test should be skipped for those instances. There is no option to communicate that if all instances are tested in single test function. Proposed solution is using preprocessor  to create set of functions based on provided list of objects.
- refactoring counter test to use new ztest feature

Example:
```
 #define DEVICE_LIST DT_TIMER_0_LABEL, DT_TIMER_1_LABEL, DT_TIMER_2_LABEL,
 const char *devlist[] = { DEVICE_LIST }
 
void foo(u32_t idx) {
 	const char *name = devlist[idx];
 	test_foo_on_instance(name);
 }
 
ztest_unit_tests_from_list_create(foo, DEVICE_LIST)

void test_main(void)
{
	ztest_test_suite(test_foo ,
		ztest_unit_tests_from_list(foo, DEVICE_LIST)
	);
	ztest_run_test_suite(test_foo);
}
```
Preprocessor will resolve to:
```
 #define DEVICE_LIST DT_TIMER_0_LABEL, DT_TIMER_1_LABEL, DT_TIMER_2_LABEL,
 const char *devlist[] = { DEVICE_LIST };
 
void foo(u32_t idx) {
 	const char *name = devlist[idx];
 	test_foo_on_instance(name);
}

void test_foo_0(void) {
 	foo(0);
}
void test_foo_1(void) {
 	foo(1);
}
void test_foo_2(void) {
 	foo(2);
}

void test_main(void)
{
        ztest_test_suite(test_foo ,
            ztest_unit_tests_(test_foo_0),
            ztest_unit_tests_(test_foo_1),
            ztest_unit_tests_(test_foo_2)
        );
        ztest_run_test_suite(test_foo);
}
```
