### PR TITLE
Bluetooth: L2CAP: Fix Channel required security level

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -953,9 +953,7 @@ static int l2cap_change_security(struct bt_l2cap_le_chan *chan, u16_t err)
 		chan->chan.required_sec_level = BT_SECURITY_MEDIUM;
 		break;
 	case BT_L2CAP_LE_ERR_AUTHENTICATION:
-		if (chan->chan.required_sec_level < BT_SECURITY_MEDIUM) {
-			chan->chan.required_sec_level = BT_SECURITY_MEDIUM;
-		} else if (chan->chan.required_sec_level < BT_SECURITY_HIGH) {
+		if (chan->chan.required_sec_level < BT_SECURITY_HIGH) {
 			chan->chan.required_sec_level = BT_SECURITY_HIGH;
 		} else if (chan->chan.required_sec_level < BT_SECURITY_FIPS) {
 			chan->chan.required_sec_level = BT_SECURITY_FIPS;


### PR DESCRIPTION
In case of receiving insufficient authentication error the least
security level to be used shall be BT_SECURITY_HIGH, since
BT_SECURITY_MEDIUM don't require authentication.

Fixes: #17525
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>