### PR TITLE
dts/bindings: remove stale cell_string

### DIFF
--- a/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
+++ b/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
@@ -18,8 +18,6 @@ properties:
     label:
       category: required
 
-cell_string: GPIO
-
 "#cells":
   - pin
   - flags

--- a/dts/bindings/gpio/intel,apl-gpio.yaml
+++ b/dts/bindings/gpio/intel,apl-gpio.yaml
@@ -26,8 +26,6 @@ properties:
     interrupts:
       category: required
 
-cell_string: GPIO
-
 "#cells":
   - pin
   - flags

--- a/dts/bindings/gpio/intel,qmsi-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-gpio.yaml
@@ -26,8 +26,6 @@ properties:
     label:
       category: required
 
-cell_string: GPIO
-
 "#cells":
   - pin
   - flags

--- a/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
@@ -26,8 +26,6 @@ properties:
     label:
       category: required
 
-cell_string: GPIO
-
 "#cells":
   - pin
   - flags

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -23,8 +23,6 @@ properties:
     label:
       category: required
 
-cell_string: GPIO
-
 "#cells":
   - pin
   - flags

--- a/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
@@ -20,8 +20,6 @@ properties:
     label:
       category: required
 
-cell_string: GPIO
-
 "#cells":
   - pin
   - flags

--- a/dts/bindings/gpio/sifive,gpio0.yaml
+++ b/dts/bindings/gpio/sifive,gpio0.yaml
@@ -26,8 +26,6 @@ properties:
     interrupts:
       category: required
 
-cell_string: GPIO
-
 "#cells":
   - pin
   - flags

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -31,8 +31,6 @@ properties:
     label:
       category: required
 
-cell_string: GPIO
-
 "#cells":
   - pin
   - flags

--- a/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
@@ -26,8 +26,6 @@ properties:
     label:
       category: required
 
-cell_string: GPIO
-
 "#cells":
   - pin
   - flags

--- a/dts/bindings/gpio/ti,cc32xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc32xx-gpio.yaml
@@ -22,8 +22,6 @@ properties:
     label:
       category: required
 
-cell_string: GPIO
-
 "#cells":
   - pin
   - flags

--- a/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
@@ -23,8 +23,6 @@ properties:
   interrupts:
       category: required
 
-cell_string: IRQ
-
 "#cells":
   - irq
   - sense

--- a/dts/bindings/interrupt-controller/snps,designware-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,designware-intc.yaml
@@ -23,8 +23,6 @@ properties:
   interrupts:
       category: required
 
-cell_string: IRQ
-
 "#cells":
   - irq
   - sense

--- a/dts/bindings/interrupt-controller/xtensa,intc.yaml
+++ b/dts/bindings/interrupt-controller/xtensa,intc.yaml
@@ -20,8 +20,6 @@ properties:
       type: int
       description: number of bits of IRQ priorities
 
-cell_string: IRQ
-
 "#cells":
   - irq
   - sense


### PR DESCRIPTION
We removed support for cell_string some time ago, so we have some stale
references in a number of bindings that we can remove.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>