### PR TITLE
dts: bindings: Remove dead 'label:' keys on properties

### DIFF
--- a/dts/bindings/mmc/mmc.yaml
+++ b/dts/bindings/mmc/mmc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: MMC/SDHC module
 version: 0.1
 
@@ -18,5 +18,3 @@ properties:
       type: array
       category: optional
       description: Clock gate information
-      generation: define
-...

--- a/dts/bindings/mmc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/mmc/nxp,imx-usdhc.yaml
@@ -24,13 +24,11 @@ properties:
       type: compound
       category: optional
       description: Power pin
-      generation: define
 
     cd-gpios:
       type: compound
       category: optional
       description: Detect pin
-      generation: define
 
     label:
       category: required

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -26,13 +26,11 @@ properties:
    type: int
    description: address alignment required by flash erase operations
    category: optional
-   label: alignment
 
   write-block-size:
    type: int
    description: address alignment required by flash write operations
    category: optional
-   label: alignment
 
   size:
     type: int

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -19,10 +19,8 @@ properties:
      type: int
      description: address alignment required by flash erase operations
      category: optional
-     label: alignment
 
     write-block-size:
      type: int
      description: address alignment required by flash write operations
      category: optional
-     label: alignment


### PR DESCRIPTION
Note that these appear as

    properties: {erase,write}-block-size: label: ...

rather than as

    properties: label: ...

I can't see anything looking at 'label' for individual properties in
bindings, so it's probably dead code. Labels are fetched from the device
tree in extract/flash.py.

Piggyback removal of some 'generation: define's and a redundant pair of
YAML document separators.