### PR TITLE
Bluetooth: Host: Fix att request queue corruption

### DIFF
--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -245,6 +245,9 @@ struct net_buf *bt_att_create_pdu(struct bt_conn *conn, u8_t op,
 int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb,
 		void *user_data);
 
+/* Check if the ATT request is not already in progress. */
+int bt_att_req_check(struct bt_conn *conn, struct bt_att_req *req);
+
 /* Send ATT Request over a connection */
 int bt_att_req_send(struct bt_conn *conn, struct bt_att_req *req);
 


### PR DESCRIPTION
Fix race-condition in the GATT api, which uses att request information
stored in user-space parameter structures. If the parameter is used
before the att request has been completed, the request structure will
be corrupted causing memory corruption.
Check that the request is not is the att request queue when adding
the request to the ATT request queue.
In the case of bt_gatt_unsubscribe we need to check before we remove the
subscription, otherwise notifications are not delivered but
notifications are still being sent.

Fixes: #17534