### PR TITLE
dts/bindings: Remove unused property num-irq-priority-bits

### DIFF
--- a/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
@@ -15,11 +15,6 @@ properties:
   reg:
       category: required
 
-  intel,num-irq-priority-bits:
-      category: required
-      type: int
-      description: number of bits of IRQ priorities
-
   interrupts:
       category: required
 

--- a/dts/bindings/interrupt-controller/intel,ioapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,ioapic.yaml
@@ -16,11 +16,6 @@ properties:
   reg:
       category: required
 
-  intel,num-irq-priority-bits:
-      category: required
-      type: int
-      description: number of bits of IRQ priorities
-
 "#cells":
   - irq
   - sense

--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -20,11 +20,6 @@ properties:
     reg:
       category: required
 
-    arc,num-irq-priority-bits:
-      category: required
-      type: int
-      description: number of bits of IRQ priorities
-
 "#cells":
   - irq
   - priority


### PR DESCRIPTION
We define "arc,num-irq-priority-bits" and "intel,num-irq-priority-bits"
as required properties in the bindings for the interrupt controllers
however we never specify these properties in any .dts files or use them
in any code.

Remove them as stale properties in the binding files.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>