### PR TITLE
dts/bindings: Remove unused required dts props from st,stm32-can

### DIFF
--- a/dts/bindings/can/st,stm32-can.yaml
+++ b/dts/bindings/can/st,stm32-can.yaml
@@ -18,21 +18,6 @@ properties:
     interrupts:
       category: required
 
-    gpio-port:
-      type: string
-      category: required
-      description: gpio port name
-
-    rx-pin:
-      type: string
-      category: required
-      description: rx pin name
-
-    tx-pin:
-      type: string
-      category: required
-      description: tx pin name
-
     clocks:
       type: array
       category: required


### PR DESCRIPTION
The st,stm32-can binding specified several required properties that were
never set in actual .dts files and not used by the code.  Remove them at
this time since they aren't being used.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>