### PR TITLE
dts: nxp: mimxrt: Add missing jedec-id property to flash nodes

### DIFF
--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -55,6 +55,7 @@ arduino_serial: &uart4 {};
 		compatible = "adesto,at25sf128a", "jedec,spi-nor";
 		reg = <0>;
 		status = "okay";
+		jedec-id = <0x1f 0x89 0x01>;
 	};
 };
 

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -63,6 +63,7 @@ arduino_serial: &uart2 {};
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		reg = <0>;
 		status = "okay";
+		jedec-id = <0x9d 0x70 0x17>;
 	};
 };
 

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -14,5 +14,6 @@
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		reg = <0>;
 		status = "okay";
+		jedec-id = <0x9d 0x70 0x17>;
 	};
 };

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -69,6 +69,7 @@ arduino_serial: &uart3 {};
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		reg = <0>;
 		status = "okay";
+		jedec-id = <0x9d 0x70 0x17>;
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -13,5 +13,6 @@
 		compatible = "winbond,w25q32jvwj", "jedec,spi-nor";
 		reg = <0>;
 		status = "okay";
+		jedec-id = <0xef 0x40 0x16>;
 	};
 };


### PR DESCRIPTION
The spi-nor flash nodes require a jedec-id property as per the binding.
We add the jedec-id's as best we can determine based on the data sheets
for the various flash modules on these boards.

However these id's should be validated by actually reading the value to
ensure they are correct.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>