### PR TITLE
dts/bindings: Mark 'rdc' as optional in nxp,imx-gpio

### DIFF
--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -28,7 +28,7 @@ properties:
 
     rdc:
      type: int
-     category: required
+     category: optional
      description: Set the RDC permission for this peripheral
 
 "#cells":


### PR DESCRIPTION
Since the nxp,imx-gpio binding is shared between i.MX and i.MX-RT SoC
the 'rdc' property needs to be optional (as it doesn't make sense on the
RT SoCs).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>