### PR TITLE
scripts: enhancements to gen_cfb_font_header

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -329,6 +329,7 @@
 /subsys/disk/disk_access_spi_sdhc.c       @JunYangNXP
 /subsys/disk/disk_access_sdhc.h           @JunYangNXP
 /subsys/disk/disk_access_usdhc.c          @JunYangNXP
+/subsys/fb/                               @jfischer-phytec-iot
 /subsys/fs/                               @nashif
 /subsys/fs/fcb/                           @nvlsianpu
 /subsys/fs/fuse_fs_access.c               @vanwinkeljan

--- a/include/display/cfb.h
+++ b/include/display/cfb.h
@@ -48,9 +48,9 @@ enum cfb_font_caps {
 
 struct cfb_font {
 	const void *data;
+	enum cfb_font_caps caps;
 	u8_t width;
 	u8_t height;
-	enum cfb_font_caps caps;
 	u8_t first_char;
 	u8_t last_char;
 };
@@ -69,10 +69,10 @@ struct cfb_font {
 #define FONT_ENTRY_DEFINE(_name, _width, _height, _caps, _data, _fc, _lc)      \
 	static const Z_STRUCT_SECTION_ITERABLE(cfb_font, _name) =	       \
 	{								       \
+		.data = _data,						       \
+		.caps = _caps,						       \
 		.width = _width,					       \
 		.height = _height,					       \
-		.caps = _caps,						       \
-		.data = _data,						       \
 		.first_char = _fc,					       \
 		.last_char = _lc,					       \
 	}

--- a/scripts/gen_cfb_font_header.py
+++ b/scripts/gen_cfb_font_header.py
@@ -65,8 +65,6 @@ def extract_image_glyphs():
 
 def generate_header():
     """Generate CFB font header file"""
-    guard = "__CFB_FONT_{:s}_{:d}{:d}_H__".format(args.name.upper(), args.width,
-                                                  args.height)
 
     zephyr_base = os.environ.get('ZEPHYR_BASE', "")
 
@@ -89,15 +87,11 @@ def generate_header():
  *
  */
 
-#ifndef {guard}
-#define {guard}
-
 #include <zephyr.h>
 #include <display/cfb.h>
 
-const u8_t cfb_font_{name:s}_{width:d}{height:d}[{elem:d}][{b:.0f}] = {{\n"""
+static const u8_t cfb_font_{name:s}_{width:d}{height:d}[{elem:d}][{b:.0f}] = {{\n"""
                       .format(cmd=" ".join(clean_cmd),
-                              guard=guard,
                               name=args.name,
                               width=args.width,
                               height=args.height,
@@ -124,10 +118,8 @@ FONT_ENTRY_DEFINE({name}_{width}{height},
 		  {first},
 		  {last}
 );
-
-#endif /* {guard} */""" .format(name=args.name, width=args.width,
-                                height=args.height, first=args.first,
-                                last=args.last, guard=guard))
+""" .format(name=args.name, width=args.width, height=args.height,
+            first=args.first, last=args.last))
 
 def parse_args():
     """Parse arguments"""

--- a/scripts/gen_cfb_font_header.py
+++ b/scripts/gen_cfb_font_header.py
@@ -20,6 +20,7 @@ def generate_element(image, charcode):
     blackwhite = image.convert("1", dither=Image.NONE)
     pixels = blackwhite.load()
 
+    width, height = image.size
     if args.dump:
         blackwhite.save("{}_{}.png".format(args.name, charcode))
 
@@ -30,9 +31,9 @@ def generate_element(image, charcode):
 
     args.output.write("""\t/* {:d}{} */\n\t{{\n""".format(charcode, char))
 
-    for col in range(0, args.width):
+    for col in range(0, width):
         args.output.write("\t\t")
-        for octet in range(0, int(args.height / 8)):
+        for octet in range(0, int(height / 8)):
             value = ""
             for bit in range(0, 8):
                 row = octet * 8 + bit
@@ -47,10 +48,39 @@ def generate_element(image, charcode):
 def extract_font_glyphs():
     """Extract font glyphs from a TrueType/OpenType font file"""
     font = ImageFont.truetype(args.input, args.size)
+
+    # Figure out the bounding box for the desired glyphs
+    fw_max = 0
+    fh_max = 0
     for i in range(args.first, args.last + 1):
-        image = Image.new("RGB", (args.width, args.height), (255, 255, 255))
+        fw, fh = font.getsize(chr(i))
+        if fw > fw_max:
+            fw_max = fw
+        if fh > fh_max:
+            fh_max = fh
+
+    # Round the vtiled length up to pack into bytes.
+    width = fw_max
+    height = 8 * int((fh_max + args.y_offset + 7) / 8)
+
+    # Diagnose inconsistencies with arguments
+    if width != args.width:
+        raise Exception('text width {} mismatch with -x {}'.format(width, args.width))
+    if height != args.height:
+        raise Exception('text height {} mismatch with -y {}'.format(height, args.height))
+
+    for i in range(args.first, args.last + 1):
+        image = Image.new('1', (width, height), 'white')
         draw = ImageDraw.Draw(image)
-        draw.text((0, 0), chr(i), (0, 0, 0), font=font)
+
+        fw, fh = draw.textsize(chr(i), font=font)
+
+        xpos = 0
+        if args.center_x:
+            xpos = (width - fw) / 2 + 1
+        ypos = args.y_offset
+
+        draw.text((xpos, ypos), chr(i), font=font)
         generate_element(image, i)
 
 def extract_image_glyphs():
@@ -167,6 +197,12 @@ def parse_args():
     group.add_argument(
         "--last", type=int, default=PRINTABLE_MAX, metavar="CHARCODE",
         help="character code mapped to the last CFB font element (default: %(default)s)")
+    group.add_argument(
+        "--center-x", action='store_true',
+        help="center character glyphs horizontally")
+    group.add_argument(
+        "--y-offset", type=int, default=0,
+        help="vertical offset for character glyphs (default: %(default)s)")
 
     args = parser.parse_args()
 

--- a/subsys/fb/README_fonts.txt
+++ b/subsys/fb/README_fonts.txt
@@ -1,0 +1,19 @@
+The DroidSansMono.ttf font used to generate the cfb_fonts bitmaps can be
+obtained from:
+
+https://android.googlesource.com/platform/frameworks/base/+/master/data/fonts/DroidSansMono.ttf
+
+To reproduce the font bitmaps use these commands:
+
+${ZEPHYR_BASE}/scripts/gen_cfb_font_header.py \
+  -i DroidSansMono.ttf \
+  -x 10 -y 16 -s 14 --center-x \
+  -o cfbv_1016
+${ZEPHYR_BASE}/scripts/gen_cfb_font_header.py \
+  -i DroidSansMono.ttf \
+  -x 15 -y 24 -s 22 --center-x --y-offset -2 \
+  -o cfbv_1524
+${ZEPHYR_BASE}/scripts/gen_cfb_font_header.py \
+  -i DroidSansMono.ttf \
+  -x 20 -y 32 -s 30 --center-x --y-offset -3 \
+  -o cfbv_2032

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -12,8 +12,8 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(cfb);
 
-extern const struct cfb_font __font_entry_start[0];
-extern const struct cfb_font __font_entry_end[0];
+extern const struct cfb_font __font_entry_start[];
+extern const struct cfb_font __font_entry_end[];
 
 struct char_framebuffer {
 	/** Pointer to a buffer in RAM */


### PR DESCRIPTION
### scripts: gen_cfb_font_header: modify to replicate cfb fonts

The content of subsys/fb/cfb_fonts cannot be replicated by the existing
script due to lack of positioning options and use of a full-color frame
buffer, which affects the generated bitmap.  Switch to the solution used
in the original script, add the required options, and document the
process of regenerating the fonts.

This commit also determines the required bounding box for the glyphs to
be sure that the user-provided value is sufficient to avoid partial
characters.  Ideally the calculated width and height would be used for
font characters, but this would require significant restructuring of the
script to make calculated values available at the point where the
arguments are used to produce output.

### scripts: gen_cfb_font_header: extend to additional representations

The default vertical tiling is designed for displays that are rotated 90
or 270 degrees from normal orientation.  Devices where pixel data
advances first horizontally then vertically requires horizontally-tiled
data.

Similarly when generating upright text on a row-major-order monochrome
display the most significant bit may encode the pixel at the lowest
horizontal position.

Add options to control horizontal vs vertical tiling, and msb vs lsb
pixel order.

The commit also generates the representation of the glyph in comments at
each row.