### PR TITLE
Revert "toolchain/zephyr: invoke ar with -D for deterministic .a files"

### DIFF
--- a/cmake/toolchain/zephyr/target.cmake
+++ b/cmake/toolchain/zephyr/target.cmake
@@ -1,34 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 include(${ZEPHYR_BASE}/cmake/toolchain/zephyr/${SDK_VERSION}/target.cmake)
-
-
-# For toolchains without a deterministic 'ar' option, see
-# less ideal but tested "strip-nondeterminism" alternative at
-#  https://github.com/marc-hb/zephyr/commits/strip-nondeterminism
-
-# TODO: build future versions of the Zephyr SDK with
-#      --enable-deterministic-archives?
-
-# Ideally we'd want to _append_ -D to the list of flags and operations
-# that cmake already uses by default. However as of version 3.14 cmake
-# doesn't support addition, one can only replace the complete AR command.
-
-# To see what the default flags are and find where they're defined
-# in cmake's code:
-# - comment out the end of the foreach line like this:
-#      foreach(lang ) # ASM C CXX
-# - build any sample with:
-#       2>cmake.log  cmake --trace-expand ...
-# - Search cmake.log for:
-#      CMAKE_.*_ARCHIVE and CMAKE_.*CREATE_STATIC
-
-# CMake's documentation is at node: CMAKE_LANG_CREATE_STATIC_LIBRARY
-
-# At least one .a file needs 'ASM': arch/xtensa/core/startup/ because
-# there's no C file there.
-foreach(lang ASM C CXX)
-  # GNU ar always updates the index: no need for CMAKE_RANLIB
-  SET(CMAKE_${lang}_CREATE_STATIC_LIBRARY
-      "<CMAKE_AR> qcD <TARGET> <LINK_FLAGS> <OBJECTS>")
-endforeach()


### PR DESCRIPTION
This reverts commit b4078c5 / #17495

This revert is needed for two reasons:

1. As reported by Lawrence King at
   https://lists.zephyrproject.org/g/users/message/1566
this breaks incremental builds with ninja:
```
  cd sample/hello_world
  west build -b qemu_x86
  touch src/main.c
  west build -b qemu_x86

  hello_world/build/../src/main.c:11: multiple definition of main';
  app/libapp.a(main.c.obj):samples/hello_world/build/../src/main.c:11:
  first defined here
  collect2: error: ld returned 1 exit status

  ar tf build/app/libapp.a
   main.c.obj
   main.c.obj
```
This does NOT break incremental builds with GNU Make, not sure why not.

2. Less urgently, I finally got someone from the CMake team to help me
and point me at an alternative solution that doesn't rely on CMake
internals: https://gitlab.kitware.com/cmake/cmake/issues/19474
I was about to try it when Lawrence reported the regression above.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>