### PR TITLE
ext: simplelink: Revert to static memory model in WiFi host driver

### DIFF
--- a/ext/hal/ti/simplelink/source/ti/drivers/net/wifi/porting/user.h
+++ b/ext/hal/ti/simplelink/source/ti/drivers/net/wifi/porting/user.h
@@ -89,7 +89,8 @@ typedef signed int _SlFd_t;
     \warning
 */
 
-#define SL_MEMORY_MGMT_DYNAMIC
+/* Using the static memory model as malloc() is not thread-safe */
+/* #define SL_MEMORY_MGMT_DYNAMIC */
 
 #ifdef SL_MEMORY_MGMT_DYNAMIC
 

--- a/ext/hal/ti/simplelink/source/ti/drivers/net/wifi/source/driver.c
+++ b/ext/hal/ti/simplelink/source/ti/drivers/net/wifi/source/driver.c
@@ -697,8 +697,10 @@ _SlDrvDriverCBDeinit - De init Driver Control Block
 *****************************************************************************/
 _SlReturnVal_t _SlDrvDriverCBDeinit(void)
 {
+#ifdef SL_MEMORY_MGMT_DYNAMIC
     _SlSpawnMsgItem_t* pCurr;
     _SlSpawnMsgItem_t* pNext;
+#endif
 
     /* Flow control de-init */
     g_pCB->FlowContCB.TxPoolCnt = 0;


### PR DESCRIPTION
During the update to TI SimpleLink SDK 2.40 in commit
8476c451c4b47202c3832a7c46578a6d9bfe59ab, a change to the memory model
in the driver was introduced. This commit reverts back to the original
static memory model. This is necessary because malloc() used by the
dynamic memory model is not thread-safe.

Fixes #17550

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>