### PR TITLE
libc: newlib: make sbrk() thread-safe

### DIFF
--- a/tests/kernel/mem_protect/sys_sem/src/main.c
+++ b/tests/kernel/mem_protect/sys_sem/src/main.c
@@ -21,7 +21,7 @@ ZTEST_BMEM struct sys_sem simple_sem;
 ZTEST_BMEM struct sys_sem low_prio_sem;
 ZTEST_BMEM struct sys_sem mid_prio_sem;
 ZTEST_DMEM struct sys_sem high_prio_sem;
-ZTEST_DMEM struct sys_sem multiple_thread_sem;
+ZTEST_DMEM SYS_SEM_DEFINE(multiple_thread_sem, SEM_INIT_VAL, SEM_MAX_VAL);
 
 K_THREAD_STACK_DEFINE(stack_1, STACK_SIZE);
 K_THREAD_STACK_DEFINE(stack_2, STACK_SIZE);
@@ -344,7 +344,6 @@ void test_sem_take_multiple(void)
 	sys_sem_init(&high_prio_sem, SEM_INIT_VAL, SEM_MAX_VAL);
 	sys_sem_init(&mid_prio_sem, SEM_INIT_VAL, SEM_MAX_VAL);
 	sys_sem_init(&low_prio_sem, SEM_INIT_VAL, SEM_MAX_VAL);
-	sys_sem_init(&multiple_thread_sem, SEM_INIT_VAL, SEM_MAX_VAL);
 
 	k_thread_create(&sem_tid, stack_1, STACK_SIZE,
 			sem_take_multiple_low_prio_helper,
@@ -512,7 +511,6 @@ void test_sem_multiple_threads_wait(void)
 #endif
 
 	sys_sem_init(&simple_sem, SEM_INIT_VAL, SEM_MAX_VAL);
-	sys_sem_init(&multiple_thread_sem, SEM_INIT_VAL, SEM_MAX_VAL);
 
 	do {
 		for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {


### PR DESCRIPTION
Concurrent use of this function could lead to corruption.
Add a semaphore to synchronize this.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>