### PR TITLE
Bluetooth: controller: split: Handle zero length L2CAP start frame

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -202,6 +202,11 @@ struct ll_conn {
 	u8_t phy_pref_rx:3;
 #endif /* CONFIG_BT_CTLR_PHY */
 
+#if defined(CONFIG_BT_CTLR_LLID_DATA_START_EMPTY)
+	/* Detect empty L2CAP start frame */
+	u8_t  start_empty:1;
+#endif /* CONFIG_BT_CTLR_LLID_DATA_START_EMPTY */
+
 	struct node_tx *tx_head;
 	struct node_tx *tx_ctrl;
 	struct node_tx *tx_ctrl_last;


### PR DESCRIPTION
Added a fix to handle L2CAP start frame with payload length
of zero which otherwise sent zero length data start PDU on
air.

Relates to #17046.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>