### PR TITLE
Bluetooth: controller: split: Fix PHY update proc symmetric rsp

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -5243,6 +5243,11 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 				conn->llcp_phy.tx &= p->rx_phys;
 				conn->llcp_phy.rx &= p->tx_phys;
 
+				if (!conn->llcp_phy.tx || !conn->llcp_phy.rx) {
+					conn->llcp_phy.tx = 0;
+					conn->llcp_phy.rx = 0;
+				}
+
 				/* pause data packet tx */
 				conn->llcp_phy.pause_tx = 1U;
 
@@ -5270,6 +5275,11 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 
 			conn->llcp_phy.tx &= p->rx_phys;
 			conn->llcp_phy.rx &= p->tx_phys;
+
+			if (!conn->llcp_phy.tx || !conn->llcp_phy.rx) {
+				conn->llcp_phy.tx = 0;
+				conn->llcp_phy.rx = 0;
+			}
 
 			/* pause data packet tx */
 			conn->llcp_phy.pause_tx = 1U;


### PR DESCRIPTION
Fix PHY update procedure to correctly handle master
requesting asymmetrical and slave symmetrical.

Fixes BT LL TS 5.1.0 conformance test:
LL/CON/MAS/BV-117-C [PHY Update Procedure - Master
Requests Asymmetrical, Slave Symmetrical]

Relates to #17097.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>