### PR TITLE
Bluetooth: controller: split: Fix packet timing restrict reset

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4122,6 +4122,9 @@ static inline u8_t phy_upd_ind_recv(struct ll_conn *conn, memq_link_t *link,
 		conn->llcp_phy.pause_tx = 0U;
 		conn->procedure_expire = 0U;
 
+		/* Reset packet timing restrictions */
+		conn->lll.phy_tx_time = conn->lll.phy_tx;
+
 		/* Ignore event generation if not local cmd initiated */
 		if (!conn->llcp_phy.cmd) {
 			/* Mark for buffer for release */


### PR DESCRIPTION
Fixed a bug related to missing reset of packet timing
restriction variable.

Fixes BT LL TS 5.1.0 test:
LL/CON/SLA/BV-55-C [Initiating PHY Update Procedure - Packet
Time Restrictions, LE Coded]

Related to #17097.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>