### PR TITLE
subsystem: console: tty init checks and support for polled-only devices

### DIFF
--- a/include/console/console.h
+++ b/include/console/console.h
@@ -23,9 +23,9 @@ extern "C" {
  *  and incompatible with, callback (push-style) console handling
  *  (via console_input_fn callback, etc.).
  *
- *  @return N/A
+ * @return 0 on success, error code (<0) otherwise
  */
-void console_init(void);
+int console_init(void);
 
 /**
  * @brief Read data from console.

--- a/subsys/console/tty.c
+++ b/subsys/console/tty.c
@@ -238,6 +238,10 @@ ssize_t tty_read(struct tty_serial *tty, void *buf, size_t size)
 
 int tty_init(struct tty_serial *tty, struct device *uart_dev)
 {
+	if (!uart_dev) {
+		return -ENODEV;
+	}
+
 	tty->uart_dev = uart_dev;
 
 	/* We start in unbuffer mode. */


### PR DESCRIPTION
This patch add tty runtime initialization check and enables use of UART
devices supporting only polling API.

Signed-off-by: Pavel Kral <pavel.kral@omsquare.com>