### PR TITLE
soc: riscv32: fix zero-riscy zephyr,flash node

### DIFF
--- a/boards/riscv/rv32m1_vega/rv32m1_vega_zero_riscy.dts
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega_zero_riscy.dts
@@ -14,8 +14,9 @@
 
 	chosen {
 		zephyr,sram = &m0_tcm;
-		zephyr,flash = &zero_riscy_code_partition;
+		zephyr,flash = &m0_flash;
 		zephyr,console = &uart0;
 		zephyr,uart-pipe = &uart0;
+		zephyr,code-partition = &zero_riscy_code_partition;
 	};
 };


### PR DESCRIPTION
The "zephyr,flash" node should point to the m0_flash node.

Signed-off-by: Alex Porosanu <alexandru.porosanu@nxp.com>