### PR TITLE
Qemu mps2 an521

### DIFF
--- a/boards/arm/mps2_an521/board.cmake
+++ b/boards/arm/mps2_an521/board.cmake
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+set(EMU_PLATFORM qemu)
+
+set(QEMU_CPU_TYPE_${ARCH} cortex-m33)
+set(QEMU_FLAGS_${ARCH}
+  -cpu ${QEMU_CPU_TYPE_${ARCH}}
+  -machine mps2-an521
+  -nographic
+  -m 16
+  -vga none
+  )
+
+board_set_debugger_ifnset(qemu)

--- a/boards/arm/mps2_an521/mps2_an521.dts
+++ b/boards/arm/mps2_an521/mps2_an521.dts
@@ -35,7 +35,7 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
+				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/boards/arm/mps2_an521/mps2_an521.yaml
+++ b/boards/arm/mps2_an521/mps2_an521.yaml
@@ -2,6 +2,7 @@ identifier: mps2_an521
 name: ARM V2M MPS2-AN521
 type: mcu
 arch: arm
+simulation: qemu
 toolchain:
   - gnuarmemb
   - zephyr

--- a/boards/arm/mps2_an521/mps2_an521_nonsecure.dts
+++ b/boards/arm/mps2_an521/mps2_an521_nonsecure.dts
@@ -35,7 +35,7 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
+				arm,num-mpu-regions = <16>;
 			};
 		};
 	};


### PR DESCRIPTION
Setting up QEMU for ARMv8-M, including support for MPU and USERSPACE.

Closes #15305 

Depends on SDK-ng moving Qemu version to 4.0, see related PR.

Fixes the number of MPU regions, which appears to be 16 instead of 4 (but needs to be checked, whether it is a QEMU issue).

Do not merge yet.