### PR TITLE
net: sntp: add missing __cplusplus check

### DIFF
--- a/include/net/sntp.h
+++ b/include/net/sntp.h
@@ -10,6 +10,10 @@
 
 #include <net/socket.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Simple Network Time Protocol API
  * @defgroup sntp SNTP
@@ -97,6 +101,10 @@ void sntp_close(struct sntp_ctx *ctx);
  */
 int sntp_simple(const char *server, u32_t timeout,
 		struct sntp_time *time);
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}


### PR DESCRIPTION
This patch adds an `extern "C"` linkage directive so sntp.h can be
included by C++ source files.

Signed-off-by: Markus Fuchs <markus.fuchs@de.sauter-bc.com>