### PR TITLE
dts: bindings: Do not require 'interrupts' on STM32 GPIO nodes

### DIFF
--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -20,9 +20,6 @@ properties:
     reg:
       category: required
 
-    interrupts:
-      category: required
-
     label:
       category: required
 


### PR DESCRIPTION
I'm guessing STM32 GPIO nodes don't generate interrupts, because I can't
find any device tree nodes with 'compatible = "st,stm32-gpio"' and an
'interrupts' property.

Remove the required 'interrupts' property from the binding. This fixes a
bunch of errors in
https://github.com/zephyrproject-rtos/zephyr/issues/17532.