### PR TITLE
dts: bindings: Make 'clocks' optional in adc.yaml

### DIFF
--- a/dts/bindings/iio/adc/adc.yaml
+++ b/dts/bindings/iio/adc/adc.yaml
@@ -14,8 +14,5 @@ inherits:
     !include base.yaml
 
 properties:
-    clocks:
-      category: required
-
     label:
       category: required


### PR DESCRIPTION
These bindings !include adc.yaml, but their device tree nodes never set
'clocks':

    dts/bindings/iio/adc/atmel,sam-afec.yaml
    dts/bindings/iio/adc/atmel,sam0-adc.yaml
    dts/bindings/iio/adc/nordic,nrf-adc.yaml
    dts/bindings/iio/adc/nordic,nrf-saadc.yaml

The nodes for these bindings do set it (think it's consistent for
st,stm32-adc.yaml):

    dts/bindings/iio/adc/nxp,kinetis-adc12.yaml
    dts/bindings/iio/adc/st,stm32-adc.yaml

Make 'clocks' optional in adc.yaml. Maybe it should be changed to
required on some platforms (!including bindings can change 'optional' to
'required').

Fixes a bunch of errors in
https://github.com/zephyrproject-rtos/zephyr/issues/17532.