### PR TITLE
dts: bindings: Make 'clocks' optional in i2c.yaml

### DIFF
--- a/dts/bindings/i2c/i2c.yaml
+++ b/dts/bindings/i2c/i2c.yaml
@@ -29,7 +29,5 @@ properties:
       type: int
       category: optional
       description: Initial clock frequency in Hz
-    clocks:
-      category: required
     label:
       category: required


### PR DESCRIPTION
Setting it seems rare. Maybe it could be changed to required on just
some platforms (!including bindings can change 'optional' to
'required').

Fixes a bunch of errors in
https://github.com/zephyrproject-rtos/zephyr/issues/17532.