### PR TITLE
dts: bindings: Make 'clocks' optional in pwm.yaml

### DIFF
--- a/dts/bindings/pwm/pwm.yaml
+++ b/dts/bindings/pwm/pwm.yaml
@@ -14,8 +14,5 @@ inherits:
     !include base.yaml
 
 properties:
-    clocks:
-      category: required
-
     label:
       category: required


### PR DESCRIPTION
Looks like no nodes with bindings that inherit pwm.yaml might be setting
'clocks'.

Fixes some errors in
https://github.com/zephyrproject-rtos/zephyr/issues/17532.