### PR TITLE
Bluetooth: GATT: Fix race condition on requests

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1227,14 +1227,16 @@ enum {
 	 * when the client reconnects, it will have to
 	 * issue a new subscription.
 	 */
-	BT_GATT_SUBSCRIBE_FLAG_VOLATILE = BIT(0),
+	BT_GATT_SUBSCRIBE_FLAG_VOLATILE,
 
 	/** Write pending flag
 	 *
 	 * If set, indicates write operation is pending waiting remote end to
 	 * respond.
 	 */
-	BT_GATT_SUBSCRIBE_WRITE_PENDING = BIT(1),
+	BT_GATT_SUBSCRIBE_FLAG_WRITE_PENDING,
+
+	BT_GATT_SUBSCRIBE_NUM_FLAGS
 };
 
 /** @brief GATT Subscribe parameters */
@@ -1250,7 +1252,8 @@ struct bt_gatt_subscribe_params {
 	/** Subscribe value */
 	u16_t value;
 	/** Subscription flags */
-	u8_t flags;
+	ATOMIC_DEFINE(flags, BT_GATT_SUBSCRIBE_NUM_FLAGS);
+
 	sys_snode_t node;
 };
 

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1228,6 +1228,13 @@ enum {
 	 * issue a new subscription.
 	 */
 	BT_GATT_SUBSCRIBE_FLAG_VOLATILE = BIT(0),
+
+	/** Write pending flag
+	 *
+	 * If set, indicates write operation is pending waiting remote end to
+	 * respond.
+	 */
+	BT_GATT_SUBSCRIBE_WRITE_PENDING = BIT(1),
 };
 
 /** @brief GATT Subscribe parameters */

--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -66,6 +66,7 @@ typedef enum bt_l2cap_chan_state {
 	BT_L2CAP_CONNECTED,
 	/** Channel in disconnecting state */
 	BT_L2CAP_DISCONNECT,
+
 } __packed bt_l2cap_chan_state_t;
 
 /** @brief Status of L2CAP channel. */

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -96,6 +96,7 @@ struct bt_att {
 };
 
 static struct bt_att bt_req_pool[CONFIG_BT_MAX_CONN];
+static struct bt_att_req cancel;
 
 static void att_req_destroy(struct bt_att_req *req)
 {
@@ -355,6 +356,12 @@ static u8_t att_handle_rsp(struct bt_att *att, void *pdu, u16_t len, u8_t err)
 
 	if (!att->req) {
 		BT_WARN("No pending ATT request");
+		goto process;
+	}
+
+	/* Check if request has been cancelled */
+	if (att->req == &cancel) {
+		att->req = NULL;
 		goto process;
 	}
 
@@ -1643,7 +1650,8 @@ static u8_t att_error_rsp(struct bt_att *att, struct net_buf *buf)
 	BT_DBG("request 0x%02x handle 0x%04x error 0x%02x", rsp->request,
 	       sys_le16_to_cpu(rsp->handle), rsp->error);
 
-	if (!att->req) {
+	/* Don't retry if there is no req pending or it has been cancelled */
+	if (!att->req || att->req == &cancel) {
 		err = BT_ATT_ERR_UNLIKELY;
 		goto done;
 	}
@@ -2318,7 +2326,7 @@ void bt_att_req_cancel(struct bt_conn *conn, struct bt_att_req *req)
 
 	/* Check if request is outstanding */
 	if (att->req == req) {
-		att->req = NULL;
+		att->req = &cancel;
 	} else {
 		/* Remove request from the list */
 		sys_slist_find_and_remove(&att->reqs, &req->node);


### PR DESCRIPTION
This fixes a race condition where an outstanding request could be canceled and replaced with another request breaking ATT flow and causing memory corruptions.

Fixes #17534