### PR TITLE
dts: bindings: Make 'clocks' optional in nxp,{imx-uart,lpc-usart}.yaml

### DIFF
--- a/dts/bindings/serial/nxp,imx-uart.yaml
+++ b/dts/bindings/serial/nxp,imx-uart.yaml
@@ -23,9 +23,6 @@ properties:
     interrupts:
       category: required
 
-    clocks:
-      category: required
-
     modem-mode:
      type: int
      category: required

--- a/dts/bindings/serial/nxp,lpc-usart.yaml
+++ b/dts/bindings/serial/nxp,lpc-usart.yaml
@@ -22,6 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-    clocks:
-      category: required


### PR DESCRIPTION
These bindings override the 'category: optional' for 'clocks' from
uart.yaml with 'category: required', but none of the nodes that use the
bindings set 'clocks'.

Maybe it's a copy-paste error. Remove the 'clock' overrides.

Fixes some errors in
https://github.com/zephyrproject-rtos/zephyr/issues/17532.