### PR TITLE
dts: bindings: Do not require a 'reg' property for snps,arcv2-intc

### DIFF
--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -17,9 +17,6 @@ properties:
     compatible:
       constraint: "snps,arcv2-intc"
 
-    reg:
-      category: required
-
 "#cells":
   - irq
   - priority


### PR DESCRIPTION
None of the interrupt controller nodes that use this binding in the
device tree files set 'reg' (or have a unit address).

Fixes a bunch of errors in
https://github.com/zephyrproject-rtos/zephyr/issues/17532.