### PR TITLE
dts: riscv32: rv32m1: Disable unused interrupt multiplexers

### DIFF
--- a/dts/riscv32/rv32m1.dtsi
+++ b/dts/riscv32/rv32m1.dtsi
@@ -103,6 +103,7 @@
 			reg = <0x4004f000 0x20>;
 			clocks = <&pcc0 0x13c>;
 			label = "INTMUX0";
+			status = "disabled";
 		};
 
 		intmux1: interrupt-controller@41022000 {
@@ -112,6 +113,7 @@
 			reg = <0x41022000 0x20>;
 			clocks = <&pcc1 0x88>;
 			label = "INTMUX1";
+			status = "disabled";
 		};
 
 		lptmr0: timer@40032000 {

--- a/dts/riscv32/rv32m1_ri5cy.dtsi
+++ b/dts/riscv32/rv32m1_ri5cy.dtsi
@@ -54,6 +54,7 @@
 &intmux0 {
 	interrupt-parent = <&event0>;
 	interrupts = <INTMUX_CH0_IRQ>, <INTMUX_CH1_IRQ>, <INTMUX_CH2_IRQ>, <INTMUX_CH3_IRQ>, <INTMUX_CH4_IRQ>, <INTMUX_CH5_IRQ>, <INTMUX_CH6_IRQ>, <INTMUX_CH7_IRQ>;
+	status = "okay";
 };
 
 &lptmr0 {

--- a/dts/riscv32/rv32m1_zero_riscy.dtsi
+++ b/dts/riscv32/rv32m1_zero_riscy.dtsi
@@ -54,6 +54,7 @@
 &intmux1 {
 	interrupt-parent = <&event1>;
 	interrupts = <INTMUX_CH0_IRQ>, <INTMUX_CH1_IRQ>, <INTMUX_CH2_IRQ>, <INTMUX_CH3_IRQ>, <INTMUX_CH4_IRQ>, <INTMUX_CH5_IRQ>, <INTMUX_CH6_IRQ>, <INTMUX_CH7_IRQ>;
+	status = "okay";
 };
 
 &lptmr0 {


### PR DESCRIPTION
Commit 948ef47cf4 ("dts: riscv32: Add rv32m1 zero-riscy core") put
common ri5cy and zero_riscy DT parts in rv32m1.dtsi, with two separate
rv32m1_ri5cy.dtsi rv32m1_zero_riscy.dtsi files that #include it.

The two interrupt multiplexers are defined in the common rv32m1.dtsi
file, but rv32m1_ri5cy.dtsi rv32m1_zero_riscy.dtsi each only specify
'interrupts' for one of them. Since 'interrupts' is 'category: required'
in openisa,rv32m1-intmux.yaml, this leads to warnings (or errors with
the new DT parser).

Disable (status = "disabled") the two interrupt multiplexers in the
common rv32m1.dtsi file and enable them in the board-specific files to
fix it. Required props. are only checked for enabled nodes.