### PR TITLE
dts: Add missing spi-max-frequency for mimxrt/nxp/hifive1/qemu_riscv2

### DIFF
--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -54,6 +54,7 @@ arduino_serial: &uart4 {};
 	at25sf128a: at25sf128a@0 {
 		compatible = "adesto,at25sf128a", "jedec,spi-nor";
 		reg = <0>;
+		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = <0x1f 0x89 0x01>;
 	};

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -62,6 +62,7 @@ arduino_serial: &uart2 {};
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		reg = <0>;
+		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = <0x9d 0x70 0x17>;
 	};

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -13,6 +13,7 @@
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		reg = <0>;
+		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = <0x9d 0x70 0x17>;
 	};

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -68,6 +68,7 @@ arduino_serial: &uart3 {};
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
 		reg = <0>;
+		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = <0x9d 0x70 0x17>;
 	};

--- a/boards/riscv32/hifive1/hifive1.dts
+++ b/boards/riscv32/hifive1/hifive1.dts
@@ -65,6 +65,7 @@
 		compatible = "issi,is25lp128", "jedec,spi-nor";
 		jedec-id = <0x96 0x60 0x18>;
 		reg = <0>;
+		spi-max-frequency = <133000000>;
 	};
 };
 

--- a/boards/riscv32/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv32/hifive1_revb/hifive1_revb.dts
@@ -63,6 +63,7 @@
 		compatible = "issi,is25lp128", "jedec,spi-nor";
 		jedec-id = <0x96 0x60 0x18>;
 		reg = <0>;
+		spi-max-frequency = <133000000>;
 	};
 };
 

--- a/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
+++ b/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
@@ -41,6 +41,8 @@
 		compatible = "issi,is25lp128", "jedec,spi-nor";
 		jedec-id = <0x96 0x60 0x18>;
 		reg = <0>;
+		// Dummy entry
+		spi-max-frequency = <0>;
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -12,6 +12,7 @@
 	w25q32jvwj0: w25q32jvwj@0 {
 		compatible = "winbond,w25q32jvwj", "jedec,spi-nor";
 		reg = <0>;
+		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = <0xef 0x40 0x16>;
 	};


### PR DESCRIPTION
spi-max-frequency is marked as required in
dts/bindings/mtd/jedec,spi-nor.yaml.

I took the value from the datasheets (133 MHz for all), and guessed that
a dummy entry is fine for QEMU.

Fixes some errors in
https://github.com/zephyrproject-rtos/zephyr/issues/17532.