### PR TITLE
debug: tracing: add sys_trace_thread_name_set

### DIFF
--- a/include/debug/tracing.h
+++ b/include/debug/tracing.h
@@ -95,6 +95,12 @@ void z_sys_trace_thread_switched_out(void);
 #define sys_trace_thread_info(thread)
 
 /**
+ * @brief Called when a thread name is set
+ * @param thread Thread structure
+ */
+#define sys_trace_thread_name_set(thread)
+
+/**
  * @brief Called when entering an ISR
  */
 #define sys_trace_isr_enter()

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -187,6 +187,7 @@ int z_impl_k_thread_name_set(struct k_thread *thread, const char *value)
 
 	strncpy(thread->name, value, CONFIG_THREAD_MAX_NAME_LEN);
 	thread->name[CONFIG_THREAD_MAX_NAME_LEN - 1] = '\0';
+	sys_trace_thread_name_set(thread);
 	return 0;
 #else
 	ARG_UNUSED(thread);

--- a/subsys/debug/tracing/ctf/ctf_middle.h
+++ b/subsys/debug/tracing/ctf/ctf_middle.h
@@ -64,6 +64,7 @@ typedef enum {
 	CTF_EVENT_THREAD_READY          =  0x17,
 	CTF_EVENT_THREAD_PENDING        =  0x18,
 	CTF_EVENT_THREAD_INFO           =  0x19,
+	CTF_EVENT_THREAD_NAME_SET       =  0x1A,
 	CTF_EVENT_ISR_ENTER             =  0x20,
 	CTF_EVENT_ISR_EXIT              =  0x21,
 	CTF_EVENT_ISR_EXIT_TO_SCHEDULER =  0x22,
@@ -167,6 +168,18 @@ static inline void ctf_middle_thread_info(
 		thread_id,
 		stack_base,
 		stack_size
+		);
+}
+
+static inline void ctf_middle_thread_name_set(
+	u32_t thread_id,
+	ctf_bounded_string_t name
+	)
+{
+	CTF_EVENT(
+		CTF_LITERAL(u8_t, CTF_EVENT_THREAD_NAME_SET),
+		thread_id,
+		name
 		);
 }
 

--- a/subsys/debug/tracing/ctf/ctf_top.c
+++ b/subsys/debug/tracing/ctf/ctf_top.c
@@ -42,7 +42,7 @@ void sys_trace_thread_switched_in(void)
 void sys_trace_thread_priority_set(struct k_thread *thread)
 {
 	ctf_middle_thread_priority_set((u32_t)(uintptr_t)thread,
-				       thread->base.prio);
+					   thread->base.prio);
 }
 
 void sys_trace_thread_create(struct k_thread *thread)
@@ -104,6 +104,23 @@ void sys_trace_thread_info(struct k_thread *thread)
 		(u32_t)(uintptr_t)thread,
 		thread->stack_info.size,
 		thread->stack_info.start
+		);
+#endif
+}
+
+void sys_trace_thread_name_set(struct k_thread *thread)
+{
+#if defined(CONFIG_THREAD_NAME)
+	ctf_bounded_string_t name = { "Unnamed thread" };
+
+	if (thread->name != NULL) {
+		strncpy(name.buf, thread->name, sizeof(name.buf));
+		/* strncpy may not always null-terminate */
+		name.buf[sizeof(name.buf) - 1] = 0;
+	}
+	ctf_middle_thread_name_set(
+		(u32_t)(uintptr_t)thread,
+		name
 		);
 #endif
 }

--- a/subsys/debug/tracing/ctf/tsdl/metadata
+++ b/subsys/debug/tracing/ctf/tsdl/metadata
@@ -114,6 +114,15 @@ event {
 };
 
 event {
+	name = thread_name_set;
+	id = 0x1a;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
 	name = isr_enter;
 	id = 0x20;
 };

--- a/subsys/debug/tracing/include/tracing_cpu_stats.h
+++ b/subsys/debug/tracing/include/tracing_cpu_stats.h
@@ -36,6 +36,7 @@ void cpu_stats_reset_counters(void);
 #define sys_trace_thread_resume(thread)
 #define sys_trace_thread_ready(thread)
 #define sys_trace_thread_pend(thread)
+#define sys_trace_thread_name_set(thread)
 
 #define sys_trace_void(id)
 #define sys_trace_end_call(id)

--- a/subsys/debug/tracing/include/tracing_ctf.h
+++ b/subsys/debug/tracing/include/tracing_ctf.h
@@ -25,6 +25,7 @@ void sys_trace_thread_resume(struct k_thread *thread);
 void sys_trace_thread_ready(struct k_thread *thread);
 void sys_trace_thread_pend(struct k_thread *thread);
 void sys_trace_thread_info(struct k_thread *thread);
+void sys_trace_thread_name_set(struct k_thread *thread);
 void sys_trace_isr_enter(void);
 void sys_trace_isr_exit(void);
 void sys_trace_isr_exit_to_scheduler(void);

--- a/subsys/debug/tracing/include/tracing_sysview.h
+++ b/subsys/debug/tracing/include/tracing_sysview.h
@@ -74,6 +74,8 @@ static inline void sys_trace_thread_info(struct k_thread *thread)
 		sys_trace_thread_info(thread);			       \
 	} while (0)
 
+#define sys_trace_thread_name_set(thread)
+
 #define sys_trace_thread_abort(thread)
 
 #define sys_trace_thread_suspend(thread)


### PR DESCRIPTION
Initial thread creation and tracing information
occurs with empty thread names.  For better tracing information,
we need to a way to get actual thread names if they are set
in order to better track thread names and their IDs.

Signed-off-by: Nicholas Lowell <nlowell@lexmark.com>

Fixes #17548 