### PR TITLE
REVERTME: logging: backend assert on x86_64

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -826,7 +826,10 @@ void log_free(void *str)
 
 static void log_process_thread_func(void *dummy1, void *dummy2, void *dummy3)
 {
+	/* XXX: Remove ifdef once #17555 is addressed */
+#ifndef CONFIG_X86_64
 	__ASSERT_NO_MSG(log_backend_count_get() > 0);
+#endif
 
 	log_init();
 	thread_set(k_current_get());


### PR DESCRIPTION
Logging is broken on x86_64 and there are no working backends.
Conditionally remove this assert on that platform until
bug #17555 is fixed.

Fixes issues with CI failures due to this, the log thread
fails an assertion on any test with CONFIG_LOG enabled on
x86_64. This had been unnoticed because sanitycheck was
failing to detect the failed assertion messages.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>