### PR TITLE
sanitycheck: add "ASSERTION FAIL" to list of error messages caught

### DIFF
--- a/include/sys/__assert.h
+++ b/include/sys/__assert.h
@@ -83,6 +83,7 @@
 #include <sys/printk.h>
 void assert_post_action(const char *file, unsigned int line);
 
+/* Message spelling must be kept identical to sanity_chk/harness.py */
 #define __ASSERT_LOC(test)                               \
 	printk("ASSERTION FAIL [%s] @ %s:%d\n",    \
 	       Z_STRINGIFY(test),                         \

--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -13,6 +13,8 @@ class Harness:
             "Kernel Panic",
             "Kernel OOPS",
             "BUS FAULT",
+    # Spelling must be kept identical to include/sys/__assert.h
+            "ASSERTION FAIL",
             "CPU Page Fault"
             ]
 


### PR DESCRIPTION
Assertions should not be just for developers, CI should catch them too.

This would have caught earlier issue #17555 (fixed by PR ~#17585~ #17599)

As usual, invidual tests can opt out with the "ignore_faults" tag.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>