### PR TITLE
[DNM] cmake: STATIC_LIBRARY_OPTIONS = "-D"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -819,6 +819,9 @@ if(CONFIG_ARM AND CONFIG_USERSPACE)
   add_library(priv_stacks_output_lib STATIC
     ${CMAKE_CURRENT_BINARY_DIR}/${PRIV_STACKS_OUTPUT_SRC}
     )
+  set_target_properties(priv_stacks_output_lib PROPERTIES
+    STATIC_LIBRARY_OPTIONS "${DETERMINISTIC_AR_OPTION}"
+    )
 
   # Turn off -ffunction-sections, etc.
   # NB: Using a library instead of target_compile_options(priv_stacks_output_lib
@@ -936,6 +939,9 @@ if(CONFIG_USERSPACE)
   # generated data into special section names
   add_library(output_lib STATIC
     ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_SRC}
+    )
+  set_target_properties(output_lib PROPERTIES
+    STATIC_LIBRARY_OPTIONS "${DETERMINISTIC_AR_OPTION}"
     )
 
   set_source_files_properties(${OUTPUT_SRC} PROPERTIES COMPILE_FLAGS

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -373,6 +373,10 @@ macro(zephyr_library_named name)
   zephyr_append_cmake_library(${name})
 
   target_link_libraries(${name} PUBLIC zephyr_interface)
+  set_target_properties(${name} PROPERTIES
+    STATIC_LIBRARY_OPTIONS "${DETERMINISTIC_AR_OPTION}"
+    )
+
 endmacro()
 
 

--- a/cmake/linker/ld/target_relocation.cmake
+++ b/cmake/linker/ld/target_relocation.cmake
@@ -26,5 +26,8 @@ macro(toolchain_ld_relocation)
     )
 
   add_library(code_relocation_source_lib  STATIC ${MEM_RELOCATAION_CODE})
+  set_target_properties(code_relocation_source_lib PROPERTIES
+    STATIC_LIBRARY_OPTIONS "${DETERMINISTIC_AR_OPTION}"
+    )
   target_link_libraries(code_relocation_source_lib zephyr_interface)
 endmacro()

--- a/cmake/toolchain/zephyr/target.cmake
+++ b/cmake/toolchain/zephyr/target.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 include(${ZEPHYR_BASE}/cmake/toolchain/zephyr/${SDK_VERSION}/target.cmake)
+
+set(DETERMINISTIC_AR_OPTION "-D" CACHE STRING
+  "Makes static libraries deterministic, see 'ar' documentation")

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -32,6 +32,7 @@ set_target_properties(
   PROPERTIES
   COMPILE_DEFINITIONS
   __ZEPHYR_SUPERVISOR__
+  STATIC_LIBRARY_OPTIONS "${DETERMINISTIC_AR_OPTION}"
   )
 
 target_sources_ifdef(CONFIG_STACK_CANARIES        kernel PRIVATE compiler_stack_protect.c)


### PR DESCRIPTION
As reported in https://gitlab.kitware.com/cmake/cmake/issues/19474, this
commit... almost works. It seems flawless as far as 'ar' is concerned,
but then ranlib runs without "-D" and timestamps the table of symbols
right after 'ar', this "spoils" the entire .a file.

diffoscope lib_before_ranlib.a lib_after_ranlib.a
--- lib_before_ranlib.a
+++ lib_after_ranlib.a
├── file list
│ @@ -1,2 +1,2 @@
│ - ----------   0   0   0     14 1970-01-01 00:00:00.000000 /
│ + ----------   0   0   0     14 2019-07-16 02:05:07.000000 /
│   ?rw-r--r--   0   0   0   8868 1970-01-01 00:00:00.000000 main.c.obj

Running ranlib is most likely pointless when using GNU bintutils and
simple cases like this, however CMake is unlikely to ever make a
particular case and optimize this away, the added complexity wouldn't
save much time.

See discussion in PR #17549 (commit 2371679528f8) for more background
and details.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>