### PR TITLE
soc: k64f MPU configured to always allow ENET

### DIFF
--- a/include/arch/arm/cortex_m/mpu/nxp_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/nxp_mpu.h
@@ -118,6 +118,12 @@
 #define REGION_USER_RO_ATTR {(MPU_REGION_READ | \
 			     MPU_REGION_SU)}
 
+/* ENET device (Master 3) will not be able to access RAM when
+ram region is dynamically disabled in NXP MPU.
+DEBUGGER (Master 1) can't be disabled in Region 0. */
+#define REGION_DEBUGGER_AND_DEVICE_ATTR  {((MPU_REGION_SU) | \
+				((UM_READ | UM_WRITE) << BM3_UM_SHIFT))}
+
 #define REGION_DEBUG_ATTR  {MPU_REGION_SU}
 
 #define REGION_BACKGROUND_ATTR	{MPU_REGION_SU_RW}

--- a/soc/arm/nxp_kinetis/k6x/nxp_mpu_regions.c
+++ b/soc/arm/nxp_kinetis/k6x/nxp_mpu_regions.c
@@ -8,10 +8,13 @@
 
 static const struct nxp_mpu_region mpu_regions[] = {
 	/* Region 0 */
+	/* Debugger access can't be disabled; ENET devices will not be able to
+	 * access RAM when it's region is dynamically disabled in NXP MPU.
+	 */
 	MPU_REGION_ENTRY("DEBUGGER_0",
 			 0,
 			 0xFFFFFFFF,
-			 REGION_DEBUG_ATTR),
+			 REGION_DEBUGGER_AND_DEVICE_ATTR),
 
 	/* The NXP MPU does not give precedence to memory regions like the ARM
 	 * MPU, which means that if one region grants access then another


### PR DESCRIPTION
Because NXP MPU's regions are dynamically enabled/disabled, ENET
device's access maybe restricted when switching out of a task.
Background DMA transfers from RAM to MAC/PHY may happen during MPU
region reconfiguration or core idling.
Enabled ENET (Kinetis MPU Master 3) to always have access to RAM address
space.

Fixes #16639

Signed-off-by: Andrei Gansari <andrei.gansari@nxp.com>