### PR TITLE
Bluetooth: tester: Update to recent conn param related changes in BTP

### DIFF
--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -228,6 +228,16 @@ struct gap_passkey_confirm_cmd {
 	u8_t match;
 } __packed;
 
+#define GAP_CONN_PARAM_UPDATE		0x16
+struct gap_conn_param_update_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t interval_min;
+	u16_t interval_max;
+	u16_t latency;
+	u16_t timeout;
+} __packed;
+
 /* events */
 #define GAP_EV_NEW_SETTINGS		0x80
 struct gap_new_settings_ev {
@@ -252,6 +262,9 @@ struct gap_device_found_ev {
 struct gap_device_connected_ev {
 	u8_t address_type;
 	u8_t address[6];
+	u16_t interval;
+	u16_t latency;
+	u16_t timeout;
 } __packed;
 
 #define GAP_EV_DEVICE_DISCONNECTED	0x83
@@ -286,6 +299,15 @@ struct gap_identity_resolved_ev {
 	u8_t address[6];
 	u8_t identity_address_type;
 	u8_t identity_address[6];
+} __packed;
+
+#define GAP_EV_CONN_PARAM_UPDATE	0x88
+struct gap_conn_param_update_ev {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t interval;
+	u16_t latency;
+	u16_t timeout;
 } __packed;
 
 /* GATT Service */


### PR DESCRIPTION
This updates tester application to recent changes in BTP related
to Connection Parameters Update.
Connected event has been extended with connection parameters.
Connection Parameters Update command and event have beend added to
initiate and track current connection parameters.
Needed to automate qualification test GAP/CONN/CPUP/BV-06-C

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>