### PR TITLE
dts/bindings: Remove generation property from st,stm32-usb

### DIFF
--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -45,7 +45,6 @@ properties:
       category: optional
       description: For STM32F0 series SoCs on QFN28 and TSSOP20 packages
                    enable PIN pair PA11/12 mapped instead of PA9/10 (e.g. stm32f070x6)
-      generation: define
 
     clocks:
       category: required


### PR DESCRIPTION
We've removed the need for the 'generation:' property in the binding
files.  Remove use in st,stm32-usb.yaml.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>