### PR TITLE
dts: Remove unused virtualcom device node from dts

### DIFF
--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -332,11 +332,6 @@
 			label = "USBD";
 		};
 
-		usb_cdc: virtualcom {
-			compatible = "nordic,nrf-usbd";
-			label = "CDC_ACM_0";
-		};
-
 		wdt: watchdog@40010000 {
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;

--- a/dts/x86/intel_curie.dtsi
+++ b/dts/x86/intel_curie.dtsi
@@ -107,11 +107,6 @@
 			#gpio-cells = <2>;
 		};
 
-		usb_cdc: virtualcom {
-			compatible = "intel,qmsi-usb";
-			label = "CDC_ACM_0";
-		};
-
 		i2c0: i2c@b0002800 {
 			compatible = "intel,qmsi-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;


### PR DESCRIPTION
There doesn't seem to be any use of the virtualcom device in the code,
so lets remove it from the dts as it describes itself as a usb device
controller which it is not.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>