### PR TITLE
dts/bindings: Fix 'required' for interrupts

### DIFF
--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -15,9 +15,6 @@ properties:
     reg:
       category: required
 
-    interrupts:
-      category: required
-
     label:
       category: required
 

--- a/dts/bindings/i2c/nios2,i2c.yaml
+++ b/dts/bindings/i2c/nios2,i2c.yaml
@@ -19,6 +19,3 @@ properties:
 
     reg:
       category: required
-
-    interrupts:
-      category: required

--- a/dts/bindings/serial/altera,jtag-uart.yaml
+++ b/dts/bindings/serial/altera,jtag-uart.yaml
@@ -14,6 +14,3 @@ properties:
 
     reg:
       category: required
-
-    interrupts:
-      category: required

--- a/dts/bindings/serial/microsemi,coreuart.yaml
+++ b/dts/bindings/serial/microsemi,coreuart.yaml
@@ -19,6 +19,3 @@ properties:
 
     reg:
       category: required
-
-    interrupts:
-      category: required

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -20,9 +20,6 @@ properties:
       category: optional
       description: quantity to shift the register offsets by
 
-    interrupts:
-      category: required
-
     pcp:
       type: int
       category: optional

--- a/dts/bindings/serial/snps,nsim-uart.yaml
+++ b/dts/bindings/serial/snps,nsim-uart.yaml
@@ -19,6 +19,3 @@ properties:
 
     reg:
       category: required
-
-    interrupts:
-      category: required


### PR DESCRIPTION
A number of dts bindings mark 'interrupts' as a required property when
in fact they are not for those devices.  Remove the 'required' setting
and just have 'interrupts' as 'optional'.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>