### PR TITLE
usb/stm32: Fix missing clock property for usb on stm32f103Xb

### DIFF
--- a/dts/arm/st/f1/stm32f103Xb.dtsi
+++ b/dts/arm/st/f1/stm32f103Xb.dtsi
@@ -42,6 +42,7 @@
 			ram-size = <512>;
 			phys = <&usb_fs_phy>;
 			status = "disabled";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
 			label= "USB";
 		};
 	};


### PR DESCRIPTION
The stm32f103Xb dts was missing the clock property for the usb
controller node.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>