### PR TITLE
dts/bindings: Mark uart current-speed as optional

### DIFF
--- a/dts/bindings/serial/uart.yaml
+++ b/dts/bindings/serial/uart.yaml
@@ -18,7 +18,7 @@ properties:
       description: Clock frequency information for UART operation
     current-speed:
       type: int
-      category: required
+      category: optional
       description: Initial baud rate setting for UART
     label:
       category: required


### PR DESCRIPTION
Not all serial devices need the current-speed property so mark it as
optional.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>