### PR TITLE
dts/bindings: Mark rtc prescale as optional

### DIFF
--- a/dts/bindings/rtc/rtc.yaml
+++ b/dts/bindings/rtc/rtc.yaml
@@ -25,5 +25,5 @@ properties:
 
     prescaler:
       type: int
-      category: required
+      category: optional
       description: RTC frequency equals clock-frequency divided by the prescaler value


### PR DESCRIPTION
Not all rtc/counter devices need the prescale property so mark it as
optional.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>