### PR TITLE
dts/bindings: remove required clock from intel,qmsi-watchdog

### DIFF
--- a/dts/bindings/watchdog/intel,qmsi-watchdog.yaml
+++ b/dts/bindings/watchdog/intel,qmsi-watchdog.yaml
@@ -25,6 +25,3 @@ properties:
 
     interrupts:
       category: required
-
-    clocks:
-      category: required


### PR DESCRIPTION
The dts that have intel,qmsi-watchdog don't sent a clock property so its
not required.  Change it from being required to optional.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>