### PR TITLE
toolchain/zephyr: CMAKE_<LANG>_ARCHIVE_* -D for deterministic .a

### DIFF
--- a/arch/xtensa/core/startup/CMakeLists.txt
+++ b/arch/xtensa/core/startup/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CONFIG_XTENSA_RESET_VECTOR)
     )
 
   zephyr_library_sources(
+	empty.c
 	reset-vector.S
 	memerror-vector.S
 	memctl_default.S

--- a/arch/xtensa/core/startup/empty.c
+++ b/arch/xtensa/core/startup/empty.c
@@ -1,0 +1,14 @@
+/*
+ *  Copyright (c) 2019 Intel Corporation
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * See CMAKE_ASM_ARCHIVE_CREATE comment in:
+ *  cmake/toolchain/zephyr/target.cmake
+ *
+ * This adds less than 2Kbytes to the file
+ * xtensa/core/startup/libarch__xtensa__core__startup.a (less than 1Kb
+ * with -g0) and makes no change to the final ELF image(s)
+ */
+typedef int placeholder;

--- a/cmake/toolchain/zephyr/target.cmake
+++ b/cmake/toolchain/zephyr/target.cmake
@@ -1,3 +1,49 @@
 # SPDX-License-Identifier: Apache-2.0
 
 include(${ZEPHYR_BASE}/cmake/toolchain/zephyr/${SDK_VERSION}/target.cmake)
+
+
+# For toolchains without a deterministic 'ar' option, see
+# less ideal but tested "strip-nondeterminism" alternative at
+#  https://github.com/marc-hb/zephyr/commits/strip-nondeterminism
+
+# TODO: build future versions of the Zephyr SDK with
+#      --enable-deterministic-archives?
+# https://github.com/zephyrproject-rtos/sdk-ng/issues/81
+
+# Ideally we'd want to _append_ -D to the list of flags and operations
+# that cmake already uses by default. However as of version 3.14 cmake
+# doesn't support addition, one can only replace the complete AR command.
+
+# Quoting https://gitlab.kitware.com/cmake/cmake/issues/19474
+#
+#   The rule variables are actually pseudo-public as described here:
+#   projects can set them but are responsible for keeping up with
+#   changes to CMake.  The main variable(s) documentation could use
+#   updates for this.
+
+# To see what the default flags are and find where they're defined
+# in cmake's code:
+# - comment out the end of the foreach line like this:
+#      foreach(lang ) # ASM C CXX
+# - build any sample with:
+#       2>cmake.log  cmake --trace-expand ...
+# - Search cmake.log for:
+#      CMAKE_.*_ARCHIVE and CMAKE_.*CREATE_STATIC
+
+# CMake's documentation is at node: CMAKE_LANG_ARCHIVE_CREATE
+
+# Unlike CMAKE_ASM_CREATE_STATIC_LIBRARY (which has another issue, see
+# revert 2371679528f8), CMAKE_ASM_ARCHIVE_* do not seem to work, at
+# least not with cmake version 3.14.5. Workaround: add one empty.c file
+# which turns "Linking ASM static library" into "Linking C static
+# library", see example at arch/xtensa/core/startup/empty.c
+
+foreach(lang ASM C CXX)
+  SET(CMAKE_${lang}_ARCHIVE_CREATE
+      "<CMAKE_AR> qcD <TARGET> <LINK_FLAGS> <OBJECTS>")
+  SET(CMAKE_${lang}_ARCHIVE_APPEND # just to be on the safe side
+      "<CMAKE_AR> qD  <TARGET> <LINK_FLAGS> <OBJECTS>")
+  SET(CMAKE_${lang}_ARCHIVE_FINISH
+      "<CMAKE_RANLIB> -D <TARGET>")
+endforeach()


### PR DESCRIPTION
Unlike the previous and reverted attempt that redefined
CMAKE_<LANG>_CREATE_STATIC_LIBRARY (2371679528f8, PR #17549), this one doesn't break incremental
builds.

Warning from: https://gitlab.kitware.com/cmake/cmake/issues/19474

    The rule variables are actually pseudo-public as described here:
    projects can set them but are responsible for keeping up with
    changes to CMake.  The main variable(s) documentation could use
    updates for this.

Quoting GNU man page:

 'D'

    Operate in deterministic mode.  When adding files and the archive
    index use zero for UIDs, GIDs, timestamps, and use consistent file
    modes for all files.  When this option is used, if ar is used with
    identical options and identical input files, multiple runs will
    create identical output files regardless of the input files' owners,
    groups, file modes, or modification times.

    If 'binutils' was configured with '--enable-deterministic-archives',
    then this mode is on by default. It can be disabled with the 'U'
    modifier, below.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>