### PR TITLE
Bluetooth: controller: split: Dequeue done event from pipeline

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -10,7 +10,7 @@
 #define TICKER_USER_ID_ULL_LOW  MAYFLY_CALL_ID_2
 #define TICKER_USER_ID_THREAD   MAYFLY_CALL_ID_PROGRAM
 
-#define EVENT_PIPELINE_MAX            5
+#define EVENT_PIPELINE_MAX 4
 
 #define HDR_ULL(p)     ((void *)((u8_t *)(p) + sizeof(struct evt_hdr)))
 #define HDR_ULL2LLL(p) ((struct lll_hdr *)((u8_t *)(p) + \

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1584,12 +1584,16 @@ static inline void rx_demux_event_done(memq_link_t *link,
 	release = done_release(link, done);
 	LL_ASSERT(release == done);
 
-	/* dequeue prepare pipeline */
+	/* get reference to head event in the pipeline */
 	next = ull_prepare_dequeue_get();
+
+	/* dequeue prepare pipeline */
 	while (next) {
 		u8_t is_resume = next->is_resume;
 
-		if (!next->is_aborted) {
+		if (!next->is_aborted &&
+		    (!ull_hdr ||
+		     (HDR_ULL2LLL(ull_hdr) != next->prepare_param.param))) {
 			static memq_link_t link;
 			static struct mayfly mfy = {0, 0, &link, NULL,
 						    lll_resume};


### PR DESCRIPTION
Dequeue done events that where added as part of being added
to invoke the pre-empt timeout. Without this fix, pipeline
overflow was eventually observed.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>