### PR TITLE
mempool corruption fixes for the v1.14 branch

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4033,13 +4033,13 @@ struct k_mem_pool {
  * @req K-MPOOL-001
  */
 #define K_MEM_POOL_DEFINE(name, minsz, maxsz, nmax, align)		\
-	char __aligned(align) _mpool_buf_##name[_ALIGN4(maxsz * nmax)	\
+	char __aligned(align) _mpool_buf_##name[_ALIGN4(maxsz) * nmax	\
 				  + _MPOOL_BITS_SIZE(maxsz, minsz, nmax)]; \
 	struct sys_mem_pool_lvl _mpool_lvls_##name[Z_MPOOL_LVLS(maxsz, minsz)]; \
 	struct k_mem_pool name __in_section(_k_mem_pool, static, name) = { \
 		.base = {						\
 			.buf = _mpool_buf_##name,			\
-			.max_sz = maxsz,				\
+			.max_sz = _ALIGN4(maxsz),			\
 			.n_max = nmax,					\
 			.n_levels = Z_MPOOL_LVLS(maxsz, minsz),		\
 			.levels = _mpool_lvls_##name,			\

--- a/include/misc/mempool.h
+++ b/include/misc/mempool.h
@@ -48,14 +48,14 @@ struct sys_mem_pool_block {
  */
 #define SYS_MEM_POOL_DEFINE(name, ignored, minsz, maxsz, nmax, align, section) \
 	char __aligned(align) Z_GENERIC_SECTION(section)		\
-		_mpool_buf_##name[_ALIGN4(maxsz * nmax)			\
+		_mpool_buf_##name[_ALIGN4(maxsz) * nmax			\
 				  + _MPOOL_BITS_SIZE(maxsz, minsz, nmax)]; \
 	struct sys_mem_pool_lvl Z_GENERIC_SECTION(section)		\
 		_mpool_lvls_##name[Z_MPOOL_LVLS(maxsz, minsz)];		\
 	Z_GENERIC_SECTION(section) struct sys_mem_pool name = {		\
 		.base = {						\
 			.buf = _mpool_buf_##name,			\
-			.max_sz = maxsz,				\
+			.max_sz = _ALIGN4(maxsz),			\
 			.n_max = nmax,					\
 			.n_levels = Z_MPOOL_LVLS(maxsz, minsz),		\
 			.levels = _mpool_lvls_##name,			\

--- a/lib/os/mempool.c
+++ b/lib/os/mempool.c
@@ -72,9 +72,23 @@ static size_t buf_size(struct sys_mem_pool_base *p)
 	return p->n_max * p->max_sz;
 }
 
-static bool block_fits(struct sys_mem_pool_base *p, void *block, size_t bsz)
+static bool block_fits(struct sys_mem_pool_base *p,
+		       int lvl, int bn, size_t *lsizes)
 {
-	return ((u8_t *)block + bsz - 1 - (u8_t *)p->buf) < buf_size(p);
+	u8_t *parent, *block_end;
+	size_t parent_sz;
+
+	block_end = (u8_t *)block_ptr(p, lsizes[lvl], bn) + lsizes[lvl];
+
+	if (lvl == 0) {
+		parent_sz = buf_size(p);
+		parent = p->buf;
+	} else {
+		parent_sz = lsizes[lvl - 1];
+		parent = block_ptr(p, lsizes[lvl - 1], bn / 4);
+	}
+
+	return block_end <= (parent + parent_sz);
 }
 
 void z_sys_mem_pool_base_init(struct sys_mem_pool_base *p)
@@ -161,7 +175,7 @@ static unsigned int bfree_recombine(struct sys_mem_pool_base *p, int level,
 		int i, lsz = lsizes[level];
 		void *block = block_ptr(p, lsz, bn);
 
-		__ASSERT(block_fits(p, block, lsz), "");
+		__ASSERT(block_fits(p, level, bn, lsizes), "");
 
 		/* Put it back */
 		set_free_bit(p, level, bn);
@@ -179,7 +193,7 @@ static unsigned int bfree_recombine(struct sys_mem_pool_base *p, int level,
 		for (i = 0; i < 4; i++) {
 			int b = (bn & ~3) + i;
 
-			if (block_fits(p, block_ptr(p, lsz, b), lsz)) {
+			if (block_fits(p, level, b, lsizes)) {
 				clear_free_bit(p, level, b);
 				sys_dlist_remove(block_ptr(p, lsz, b));
 			}
@@ -220,7 +234,7 @@ static void *block_break(struct sys_mem_pool_base *p, void *block, int l,
 		void *block2 = (lsz * i) + (char *)block;
 
 		set_free_bit(p, l + 1, lbn);
-		if (block_fits(p, block2, lsz)) {
+		if (block_fits(p, l + 1, lbn, lsizes)) {
 			sys_dlist_append(&p->levels[l + 1].free_list, block2);
 		}
 	}

--- a/lib/os/mempool.c
+++ b/lib/os/mempool.c
@@ -242,7 +242,7 @@ int z_sys_mem_pool_block_alloc(struct sys_mem_pool_base *p, size_t size,
 	 * way, we populate an array of sizes for each level so we
 	 * don't need to waste RAM storing it.
 	 */
-	lsizes[0] = _ALIGN4(p->max_sz);
+	lsizes[0] = p->max_sz;
 	for (i = 0; i < p->n_levels; i++) {
 		if (i > 0) {
 			lsizes[i] = _ALIGN4(lsizes[i-1] / 4);
@@ -315,7 +315,7 @@ void z_sys_mem_pool_block_free(struct sys_mem_pool_base *p, u32_t level,
 	 * doesn't inherently need to traverse all the larger
 	 * sublevels.
 	 */
-	lsizes[0] = _ALIGN4(p->max_sz);
+	lsizes[0] = p->max_sz;
 	for (i = 1; i <= level; i++) {
 		lsizes[i] = _ALIGN4(lsizes[i-1] / 4);
 	}


### PR DESCRIPTION
This is a backport of #16966 and #16996 for the v1.14 branch (backport-v1.14).