### PR TITLE
cmake: Encode and decode in UTF-8 in build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,7 +459,8 @@ add_subdirectory(drivers)
 
 # Include zephyr modules generated CMake file.
 if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
-  file(STRINGS ${CMAKE_BINARY_DIR}/zephyr_modules.txt ZEPHYR_MODULES_TXT)
+	file(STRINGS ${CMAKE_BINARY_DIR}/zephyr_modules.txt ZEPHYR_MODULES_TXT
+		ENCODING UTF-8)
 
   foreach(module ${ZEPHYR_MODULES_TXT})
     # Match "<name>":"<path>" for each line of file, each corresponding to
@@ -517,7 +518,7 @@ execute_process(
   --trigger          ${syscalls_subdirs_trigger} # Trigger file that is used for json generation
   ${syscalls_links}                              # If defined, create symlinks for dependencies
 )
-file(STRINGS ${syscalls_subdirs_txt} PARSE_SYSCALLS_PATHS_DEPENDS)
+file(STRINGS ${syscalls_subdirs_txt} PARSE_SYSCALLS_PATHS_DEPENDS ENCODING UTF-8)
 
 if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Windows)
   # On windows only adding/removing files or folders will be reflected in depends.

--- a/scripts/subfolder_list.py
+++ b/scripts/subfolder_list.py
@@ -63,14 +63,14 @@ def main():
     existing = ''
 
     if os.path.exists(args.out_file):
-        with open(args.out_file, 'r') as fp:
+        with open(args.out_file, 'r', encoding="utf-8") as fp:
             existing = fp.read()
 
         if new != existing:
-            with open(args.out_file, 'w') as fp:
+            with open(args.out_file, 'w', encoding="utf-8") as fp:
                 fp.write(new)
     else:
-        with open(args.out_file, 'w') as fp:
+        with open(args.out_file, 'w', encoding="utf-8") as fp:
             fp.write(new)
 
     # Always touch trigger file to ensure json files are updated

--- a/scripts/west_commands/zcmake.py
+++ b/scripts/west_commands/zcmake.py
@@ -213,7 +213,7 @@ class CMakeCache:
 
     def load(self, cache_file):
         entries = []
-        with open(cache_file, 'r') as cache:
+        with open(cache_file, 'r', encoding="utf-8") as cache:
             for line_no, line in enumerate(cache):
                 entry = CMakeCacheEntry.from_line(line, line_no)
                 if entry:

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -147,10 +147,10 @@ def main():
         projects += args.extra_modules
 
     if args.kconfig_out:
-        kconfig_out_file = open(args.kconfig_out, 'w')
+        kconfig_out_file = open(args.kconfig_out, 'w', encoding="utf-8")
 
     if args.cmake_out:
-        cmake_out_file = open(args.cmake_out, 'w')
+        cmake_out_file = open(args.cmake_out, 'w', encoding="utf-8")
 
     try:
         for project in projects:


### PR DESCRIPTION
In order to make sure that the build works in folders that require a UTF
encoding, make sure that both CMake and the various Python scripts that
interact with each other on files use the same encoding, in this case
UTF-8.

Fixes #17635

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>