### PR TITLE
shell: fs: add dependency on kernel allocator

### DIFF
--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -47,6 +47,7 @@ config FILE_SYSTEM_NFFS
 config FILE_SYSTEM_SHELL
 	bool "Enable file system shell"
 	depends on SHELL
+	depends on HEAP_MEM_POOL_SIZE > 0
 	help
 	  This shell provides basic browsing of the contents of the
 	  file system.


### PR DESCRIPTION
Fix k_malloc linkage error, when filesystem shell is selected,
but no heap allocator is enabled.

Signed-off-by: Pavel Kral <pavel.kral@omsquare.com>