### PR TITLE
Allow DHCP configuration of OpenThread in Zephyr

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -162,6 +162,16 @@ config OPENTHREAD_JOINER_PSKD
 	help
 	  Pre Shared Key for the Device to start joiner
 
+config OPENTHREAD_DHCP6_CLIENT
+       bool "DHCPv6 client support"
+       help
+         Enable DHCPv6 client capability in OpenThread stack
+
+config OPENTHREAD_DHCP6_SERVER
+       bool "DHCPv6 server support"
+       help
+         Enable DHCPv6 server capability in OpenThread stack
+
 config OPENTHREAD_PLATFORM_INFO
 	string "Platform information for OpenThread"
 	default "ZEPHYR"

--- a/subsys/net/lib/openthread/CMakeLists.txt
+++ b/subsys/net/lib/openthread/CMakeLists.txt
@@ -165,6 +165,18 @@ if(CONFIG_OPENTHREAD_JOINER)
     )
 endif()
 
+if(CONFIG_OPENTHREAD_DHCP6_CLIENT)
+  list(APPEND configure_flags
+    --enable-dhcp6-client
+    )
+endif()
+
+if(CONFIG_OPENTHREAD_DHCP6_SERVER)
+  list(APPEND configure_flags
+    --enable-dhcp6-server
+    )
+endif()
+
 if(CONFIG_OPENTHREAD_SHELL)
   list(APPEND configure_flags
     --enable-cli


### PR DESCRIPTION
Certain Thread implementations (notably ARMs) require a DHCPv6 implementation.

This PR allows the usage of the relevant OpenThread configuration parameters in Zephyr.