### PR TITLE
include: data: improve C++ compatibility

### DIFF
--- a/include/data/json.h
+++ b/include/data/json.h
@@ -7,7 +7,14 @@
 #ifndef ZEPHYR_INCLUDE_DATA_JSON_H_
 #define ZEPHYR_INCLUDE_DATA_JSON_H_
 
+#include <sys/util.h>
+#include <stddef.h>
+#include <zephyr/types.h>
+#include <sys/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Structured Data
@@ -20,11 +27,6 @@
  * @ingroup structured_data
  * @{
  */
-
-#include <sys/util.h>
-#include <stddef.h>
-#include <zephyr/types.h>
-#include <sys/types.h>
 
 enum json_tokens {
 	/* Before changing this enum, ensure that its maximum
@@ -631,6 +633,10 @@ int json_obj_encode_buf(const struct json_obj_descr *descr, size_t descr_len,
 int json_obj_encode(const struct json_obj_descr *descr, size_t descr_len,
 		    const void *val, json_append_bytes_t append_bytes,
 		    void *data);
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/include/data/json.h
+++ b/include/data/json.h
@@ -130,10 +130,10 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 #define JSON_OBJ_DESCR_PRIM(struct_, field_name_, type_) \
 	{ \
 		.field_name = (#field_name_), \
-		.field_name_len = sizeof(#field_name_) - 1, \
-		.offset = offsetof(struct_, field_name_), \
 		.align_shift = Z_ALIGN_SHIFT(struct_), \
+		.field_name_len = sizeof(#field_name_) - 1, \
 		.type = type_, \
+		.offset = offsetof(struct_, field_name_), \
 	}
 
 /**
@@ -164,10 +164,10 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 #define JSON_OBJ_DESCR_OBJECT(struct_, field_name_, sub_descr_) \
 	{ \
 		.field_name = (#field_name_), \
-		.field_name_len = (sizeof(#field_name_) - 1), \
-		.offset = offsetof(struct_, field_name_), \
 		.align_shift = Z_ALIGN_SHIFT(struct_), \
+		.field_name_len = (sizeof(#field_name_) - 1), \
 		.type = JSON_TOK_OBJECT_START, \
+		.offset = offsetof(struct_, field_name_), \
 		.object = { \
 			.sub_descr = sub_descr_, \
 			.sub_descr_len = ARRAY_SIZE(sub_descr_), \
@@ -203,15 +203,15 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 			     len_field_, elem_type_) \
 	{ \
 		.field_name = (#field_name_), \
-		.field_name_len = sizeof(#field_name_) - 1, \
-		.offset = offsetof(struct_, field_name_), \
 		.align_shift = Z_ALIGN_SHIFT(struct_), \
+		.field_name_len = sizeof(#field_name_) - 1, \
 		.type = JSON_TOK_LIST_START, \
+		.offset = offsetof(struct_, field_name_), \
 		.array = { \
 			.element_descr = &(struct json_obj_descr) { \
+				.align_shift = Z_ALIGN_SHIFT(struct_), \
 				.type = elem_type_, \
 				.offset = offsetof(struct_, len_field_), \
-				.align_shift = Z_ALIGN_SHIFT(struct_), \
 			}, \
 			.n_elements = (max_len_), \
 		}, \
@@ -260,19 +260,19 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 				 len_field_, elem_descr_, elem_descr_len_) \
 	{ \
 		.field_name = (#field_name_), \
-		.field_name_len = sizeof(#field_name_) - 1, \
-		.offset = offsetof(struct_, field_name_), \
 		.align_shift = Z_ALIGN_SHIFT(struct_), \
+		.field_name_len = sizeof(#field_name_) - 1, \
 		.type = JSON_TOK_LIST_START, \
+		.offset = offsetof(struct_, field_name_), \
 		.array = { \
 			.element_descr = &(struct json_obj_descr) { \
+				.align_shift = Z_ALIGN_SHIFT(struct_), \
 				.type = JSON_TOK_OBJECT_START, \
+				.offset = offsetof(struct_, len_field_), \
 				.object = { \
 					.sub_descr = elem_descr_, \
 					.sub_descr_len = elem_descr_len_, \
 				}, \
-				.offset = offsetof(struct_, len_field_), \
-				.align_shift = Z_ALIGN_SHIFT(struct_), \
 			}, \
 			.n_elements = (max_len_), \
 		}, \
@@ -330,19 +330,19 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 				   elem_descr_, elem_descr_len_) \
 	{ \
 		.field_name = (#field_name_), \
-			.field_name_len = sizeof(#field_name_) - 1, \
-			.offset = offsetof(struct_, field_name_), \
-			.align_shift = Z_ALIGN_SHIFT(struct_), \
-			.type = JSON_TOK_LIST_START, \
-			.array = { \
+		.align_shift = Z_ALIGN_SHIFT(struct_), \
+		.field_name_len = sizeof(#field_name_) - 1, \
+		.type = JSON_TOK_LIST_START, \
+		.offset = offsetof(struct_, field_name_), \
+		.array = { \
 			.element_descr = &(struct json_obj_descr) { \
+				.align_shift = Z_ALIGN_SHIFT(struct_), \
 				.type = JSON_TOK_LIST_START, \
+				.offset = offsetof(struct_, len_field_), \
 				.object = { \
 					.sub_descr = elem_descr_, \
 					.sub_descr_len = elem_descr_len_, \
 				}, \
-				.offset = offsetof(struct_, len_field_), \
-				.align_shift = Z_ALIGN_SHIFT(struct_), \
 			}, \
 			.n_elements = (max_len_), \
 		}, \
@@ -369,10 +369,10 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 				  struct_field_name_, type_) \
 	{ \
 		.field_name = (json_field_name_), \
-		.field_name_len = sizeof(json_field_name_) - 1, \
-		.offset = offsetof(struct_, struct_field_name_), \
 		.align_shift = Z_ALIGN_SHIFT(struct_), \
+		.field_name_len = sizeof(json_field_name_) - 1, \
 		.type = type_, \
+		.offset = offsetof(struct_, struct_field_name_), \
 	}
 
 /**
@@ -395,10 +395,10 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 				    struct_field_name_, sub_descr_) \
 	{ \
 		.field_name = (json_field_name_), \
-		.field_name_len = (sizeof(json_field_name_) - 1), \
-		.offset = offsetof(struct_, struct_field_name_), \
 		.align_shift = Z_ALIGN_SHIFT(struct_), \
+		.field_name_len = (sizeof(json_field_name_) - 1), \
 		.type = JSON_TOK_OBJECT_START, \
+		.offset = offsetof(struct_, struct_field_name_), \
 		.object = { \
 			.sub_descr = sub_descr_, \
 			.sub_descr_len = ARRAY_SIZE(sub_descr_), \
@@ -431,15 +431,15 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 				   elem_type_) \
 	{ \
 		.field_name = (json_field_name_), \
-		.field_name_len = sizeof(json_field_name_) - 1, \
-		.offset = offsetof(struct_, struct_field_name_), \
 		.align_shift = Z_ALIGN_SHIFT(struct_), \
+		.field_name_len = sizeof(json_field_name_) - 1, \
 		.type = JSON_TOK_LIST_START, \
+		.offset = offsetof(struct_, struct_field_name_), \
 		.array = { \
 			.element_descr = &(struct json_obj_descr) { \
+				.align_shift = Z_ALIGN_SHIFT(struct_), \
 				.type = elem_type_, \
 				.offset = offsetof(struct_, len_field_), \
-				.align_shift = Z_ALIGN_SHIFT(struct_), \
 			}, \
 			.n_elements = (max_len_), \
 		}, \
@@ -497,18 +497,18 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 				       elem_descr_len_) \
 	{ \
 		.field_name = json_field_name_, \
-		.field_name_len = sizeof(json_field_name_) - 1, \
-		.offset = offsetof(struct_, struct_field_name_), \
 		.align_shift = Z_ALIGN_SHIFT(struct_), \
+		.field_name_len = sizeof(json_field_name_) - 1, \
 		.type = JSON_TOK_LIST_START, \
+		.offset = offsetof(struct_, struct_field_name_), \
 		.element_descr = &(struct json_obj_descr) { \
+			.align_shift = Z_ALIGN_SHIFT(struct_), \
 			.type = JSON_TOK_OBJECT_START, \
+			.offset = offsetof(struct_, len_field_), \
 			.object = { \
 				.sub_descr = elem_descr_, \
 				.sub_descr_len = elem_descr_len_, \
 			}, \
-			.offset = offsetof(struct_, len_field_), \
-			.align_shift = Z_ALIGN_SHIFT(struct_), \
 		}, \
 		.n_elements = (max_len_), \
 	}

--- a/include/data/jwt.h
+++ b/include/data/jwt.h
@@ -10,6 +10,10 @@
 #include <zephyr/types.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief JSON Web Token (JWT)
  * @defgroup jwt JSON Web Token (JWT)
@@ -88,6 +92,10 @@ static inline size_t jwt_payload_len(struct jwt_builder *builder)
 {
 	return (builder->buf - builder->base);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}


### PR DESCRIPTION
This patch improves C++ compatibility of the json library by adding 
`extern "C"` linkage directives and reordering designated initializers 
so they appear in the same order as the members they initialize.

Signed-off-by: Markus Fuchs <markus.fuchs@de.sauter-bc.com>

