### PR TITLE
dts: bindings: simplify !include in jedec,spi-nor

### DIFF
--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -11,7 +11,7 @@ description: >
   Any SPI NOR flash that supports the JEDEC CFI interface.
 
 inherits:
-  !include [spi-device.yaml]
+  !include spi-device.yaml
 
 properties:
   compatible:


### PR DESCRIPTION
No need to use an array when !including a single binding.