### PR TITLE
assert: generate oops if invoked from usermode

### DIFF
--- a/lib/os/assert.c
+++ b/lib/os/assert.c
@@ -24,8 +24,17 @@
  */
 __weak void assert_post_action(const char *file, unsigned int line)
 {
-  ARG_UNUSED(file);
-  ARG_UNUSED(line);
+	ARG_UNUSED(file);
+	ARG_UNUSED(line);
 
-  k_panic();
+#ifdef CONFIG_USERSPACE
+	/* User threads aren't allowed to induce kernel panics; generate
+	 * an oops instead.
+	 */
+	if (_is_user_context()) {
+		k_oops();
+	}
+#endif
+
+	k_panic();
 }


### PR DESCRIPTION
User mode isn't allowed to generate a panic and this would
lead to a confusing privilege violation exception.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>