### PR TITLE
dfu: make flash_img write to flash on buffer full

### DIFF
--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -162,7 +162,7 @@ int flash_img_buffered_write(struct flash_img_context *ctx, u8_t *data,
 	int rc = 0;
 	int buf_empty_bytes;
 
-	while ((len - processed) >
+	while ((len - processed) >=
 	       (buf_empty_bytes = CONFIG_IMG_BLOCK_BUF_SIZE - ctx->buf_bytes)) {
 		memcpy(ctx->buf + ctx->buf_bytes, data + processed,
 		       buf_empty_bytes);


### PR DESCRIPTION
Writing data to flash takes relatively long time therefore it's important to have good control of when it happens. This is difficult with the current implementation of flash_img subsystem. Currently the data are written to flash only when there is no more space in RAM buffer. E.g. if the RAM buffer has a size of 512 bytes the data will be written to flash only when the 513-th byte is received.

This commit modifies this behavior to write data to flash as soon as the buffer is full. E.g. if the RAM buffer has a size of 512 bytes the data will be written to flash as soon as 512-th byte is received.