### PR TITLE
dts: bindings: fixed-clock: Make label optional

### DIFF
--- a/dts/bindings/clock/fixed-clock.yaml
+++ b/dts/bindings/clock/fixed-clock.yaml
@@ -19,7 +19,7 @@ properties:
 
     label:
       type: string
-      category: required
+      category: optional
       description: Human readable string describing the device (used by Zephyr for API name)
 
     clock-frequency:


### PR DESCRIPTION
In most of the cases the fixed-clock node is not referenced by the
Zephyr code, making the label property just a burden.

Fixes: #17663