### PR TITLE
dts: bindings: nxp,kinetis-usbd: Make clocks property optional

### DIFF
--- a/dts/bindings/usb/nxp,kinetis-usbd.yaml
+++ b/dts/bindings/usb/nxp,kinetis-usbd.yaml
@@ -22,6 +22,3 @@ properties:
 
     interrupts:
       category: required
-
-    clocks:
-      category: required


### PR DESCRIPTION
This commit makes the clock property optional (through base.yaml),
as clock reference is not used in the code.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/17664