### PR TITLE
boards/arm/v2m_musca_b1: Add missing label to timer node

### DIFF
--- a/boards/arm/v2m_musca_b1/v2m_musca_b1-common.dtsi
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1-common.dtsi
@@ -22,6 +22,7 @@ timer: timer@10c000 {
 	compatible = "arm,cmsdk-timer";
 	reg = <0x10c000 0x1000>;
 	interrupts = <3 3>;
+	label = "TIMER_0";
 };
 
 uart0: uart@105000 {


### PR DESCRIPTION
The binding for arm,cmsdk-timer requires a label so add it into the dts
since its missing on v2m_musca_b1.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>