### PR TITLE
dts: add label property to all jedec,spi-nor nodes

### DIFF
--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -53,6 +53,7 @@ arduino_serial: &uart4 {};
 	reg = <0x402a8000 0x4000>, <0x60000000 0x1000000>;
 	at25sf128a: at25sf128a@0 {
 		compatible = "adesto,at25sf128a", "jedec,spi-nor";
+		label = "AT25SF128A";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -61,6 +61,7 @@ arduino_serial: &uart2 {};
 	reg = <0x402a8000 0x4000>, <0x60000000 0x800000>;
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
+		label = "IS25WP064";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -12,6 +12,7 @@
 	reg = <0x402a8000 0x4000>, <0x60000000 0x800000>;
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
+		label = "IS25WP064";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -67,6 +67,7 @@ arduino_serial: &uart3 {};
 	reg = <0x402a8000 0x4000>, <0x60000000 0x800000>;
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
+		label = "IS25WP064";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/riscv32/hifive1/hifive1.dts
+++ b/boards/riscv32/hifive1/hifive1.dts
@@ -63,6 +63,7 @@
 	reg = <0x10014000 0x1000 0x20400000 0xc00000>;
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";
+		label = "FLASH0";
 		jedec-id = <0x96 0x60 0x18>;
 		reg = <0>;
 		spi-max-frequency = <133000000>;

--- a/boards/riscv32/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv32/hifive1_revb/hifive1_revb.dts
@@ -61,6 +61,7 @@
 	reg = <0x10014000 0x1000 0x20010000 0x3c0900>;
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";
+		label = "FLASH0";
 		jedec-id = <0x96 0x60 0x18>;
 		reg = <0>;
 		spi-max-frequency = <133000000>;

--- a/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
+++ b/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
@@ -39,6 +39,7 @@
 	reg = <0x10014000 0x1000 0x20400000 0xc00000>;
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";
+		label = "FLASH0";
 		jedec-id = <0x96 0x60 0x18>;
 		reg = <0>;
 		// Dummy entry

--- a/boards/x86/arduino_101/arduino_101.dts
+++ b/boards/x86/arduino_101/arduino_101.dts
@@ -66,6 +66,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "winbond,w25q16", "jedec,spi-nor";
+		label = "W25Q16";
 		reg = <0>;
 		spi-max-frequency = <8000000>;
 	};

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -11,6 +11,7 @@
 	/* WINBOND */
 	w25q32jvwj0: w25q32jvwj@0 {
 		compatible = "winbond,w25q32jvwj", "jedec,spi-nor";
+		label = "W25Q32JVWJ0";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";


### PR DESCRIPTION
The property is required on all SPI clients, but was missing from
several devicetree nodes.  Set it, using the capitalized version of the
node alias when present, with "jedec,spi-nor#0" as the fallback.

Closes #17662

Signed-off-by: Peter A. Bigot <pab@pabigot.com>