### PR TITLE
boards/arm/mps2_an521: Add missing timer labels to dts

### DIFF
--- a/boards/arm/mps2_an521/mps2_an521-common.dtsi
+++ b/boards/arm/mps2_an521/mps2_an521-common.dtsi
@@ -14,18 +14,21 @@ timer0: timer@0 {
 	compatible = "arm,cmsdk-timer";
 	reg = <0x0 0x1000>;
 	interrupts = <3 3>;
+	label = "TIMER_0";
 };
 
 timer1: timer@1000 {
 	compatible = "arm,cmsdk-timer";
 	reg = <0x1000 0x1000>;
 	interrupts = <4 3>;
+	label = "TIMER_1";
 };
 
 dtimer0: dtimer@2000 {
 	compatible = "arm,cmsdk-dtimer";
 	reg = <0x2000 0x1000>;
 	interrupts = <5 3>;
+	label = "DTIMER_0";
 };
 
 mhu0: mhu@3000 {


### PR DESCRIPTION
The bindings for arm,cmsdk-{d}timer requires a label so add it into the
dts since its missing on mps2_an521.

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>
Signed-off-by: Kumar Gala <kumar.gala@linaro.org>