### PR TITLE
Added support to SDL display driver to set default pixel format

### DIFF
--- a/drivers/display/Kconfig.sdl
+++ b/drivers/display/Kconfig.sdl
@@ -27,4 +27,24 @@ config SDL_DISPLAY_Y_RES
 	int "Y resolution for SDL display"
 	default 240
 
-endif #SDL_DISPLAY
+choice SDL_DISPLAY_DEFAULT_PIXEL_FORMAT
+	prompt "Default pixel format"
+	default SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ARGB_8888
+	help
+	  Default pixel format to be used by the display
+
+	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ARGB_8888
+		bool "ARGB 8888"
+
+	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_888
+		bool "RGB 888"
+
+	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01
+		bool "Mono Black=0"
+
+	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10
+		bool "Mono Black=1"
+
+endchoice
+
+endif # SDL_DISPLAY

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -33,7 +33,17 @@ static int sdl_display_init(struct device *dev)
 
 	memset(disp_data, 0, sizeof(struct sdl_display_data));
 
-	disp_data->current_pixel_format = PIXEL_FORMAT_ARGB_8888;
+	disp_data->current_pixel_format =
+#if defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_888)
+		PIXEL_FORMAT_RGB_888
+#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01)
+		PIXEL_FORMAT_MONO01
+#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10)
+		PIXEL_FORMAT_MONO10
+#else /* SDL_DISPLAY_DEFAULT_PIXEL_FORMAT */
+		PIXEL_FORMAT_ARGB_8888
+#endif /* SDL_DISPLAY_DEFAULT_PIXEL_FORMAT */
+		;
 
 	disp_data->window =
 	    SDL_CreateWindow("Zephyr Display", SDL_WINDOWPOS_UNDEFINED,


### PR DESCRIPTION
Added support to SDL display driver to set default pixel format through
Kconfig.

This allows to mimic other display driver settings for testing with native posix target