### PR TITLE
dts: bindings: Remove unused 'version' field

### DIFF
--- a/dts/bindings/arc/arc,dccm.yaml
+++ b/dts/bindings/arc/arc,dccm.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARC DCCM
-version: 0.1
 
 description: >
     This binding gives a base representation of the ARC DCCM

--- a/dts/bindings/arc/arc,iccm.yaml
+++ b/dts/bindings/arc/arc,iccm.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARC ICCM
-version: 0.1
 
 description: >
     This binding gives a base representation of the ARC ICCM

--- a/dts/bindings/arm/arm,dtcm.yaml
+++ b/dts/bindings/arm/arm,dtcm.yaml
@@ -1,7 +1,5 @@
-
 # SPDX-License-Identifier: Apache-2.0
 title: DTCM
-version: 0.1
 
 description: >
   This binding gives a base representation of the Cortex M7 DTCM (Data Tightly Coupled Memory)

--- a/dts/bindings/arm/arm,scc.yaml
+++ b/dts/bindings/arm/arm,scc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARM Serial Configuration Control
-version: 0.1
 
 description: >
     This binding gives a base representation of the ARM SCC

--- a/dts/bindings/arm/atmel,sam0-device_id.yaml
+++ b/dts/bindings/arm/atmel,sam0-device_id.yaml
@@ -1,6 +1,4 @@
-
 title: Atmel Device ID (Serial Number) binding
-version: 0.1
 
 description: >
     Binding for locating the Device ID (serial number) on Atmel SAM0 devices.

--- a/dts/bindings/arm/atmel,sam0-dmac.yaml
+++ b/dts/bindings/arm/atmel,sam0-dmac.yaml
@@ -1,6 +1,4 @@
-
 title: Atmel DMAC binding
-version: 0.1
 
 description: >
     Binding for the Atmel SAM0 DMA controller.

--- a/dts/bindings/arm/atmel,sam0-sercom.yaml
+++ b/dts/bindings/arm/atmel,sam0-sercom.yaml
@@ -1,6 +1,4 @@
-
 title: Atmel SERCOM binding
-version: 0.1
 
 description: >
     Binding for the Atmel SAM0 multi-protocol (UART, SPI, I2C) SERCOM unit.

--- a/dts/bindings/arm/nordic,nrf-dppic.yaml
+++ b/dts/bindings/arm/nordic,nrf-dppic.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic DPPIC
-version: 0.1
 
 description: >
     Binding for the Nordic DPPIC

--- a/dts/bindings/arm/nordic,nrf-ficr.yaml
+++ b/dts/bindings/arm/nordic,nrf-ficr.yaml
@@ -1,6 +1,4 @@
-
 title: Nordic FICR (Factory Information Configuration Registers)
-version: 0.1
 
 description: >
     Binding for the Nordic FICR (Factory Information Configuration Registers)

--- a/dts/bindings/arm/nordic,nrf-spu.yaml
+++ b/dts/bindings/arm/nordic,nrf-spu.yaml
@@ -1,6 +1,4 @@
-
 title: Nordic SPU (System Protection Unit)
-version: 0.1
 
 description: >
     Binding for the Nordic SPU (System Protection Unit)

--- a/dts/bindings/arm/nxp,imx-dtcm.yaml
+++ b/dts/bindings/arm/nxp,imx-dtcm.yaml
@@ -5,7 +5,6 @@
 #
 
 title: i.MX DTCM (Data Tightly Coupled Memory)
-version: 0.1
 
 description: >
   This binding gives a base representation of the i.MX DTCM

--- a/dts/bindings/arm/nxp,imx-epit.yaml
+++ b/dts/bindings/arm/nxp,imx-epit.yaml
@@ -5,7 +5,6 @@
 #
 
 title: IMX EPIT COUNTER
-version: 0.1
 
 description: >
     This binding gives a base representation of the i.MX Enhanced Periodic Interrupt Timer (EPIT)

--- a/dts/bindings/arm/nxp,imx-itcm.yaml
+++ b/dts/bindings/arm/nxp,imx-itcm.yaml
@@ -5,7 +5,6 @@
 #
 
 title: i.MX ITCM (Instruction Tightly Coupled Memory)
-version: 0.1
 
 description: >
   This binding gives a base representation of the i.MX ITCM

--- a/dts/bindings/arm/nxp,imx-mu.yaml
+++ b/dts/bindings/arm/nxp,imx-mu.yaml
@@ -5,7 +5,6 @@
 #
 
 title: IMX MESSAGING UNIT
-version: 0.1
 
 description: >
     This binding gives a base representation of the i.MX Messaging Unit

--- a/dts/bindings/arm/nxp,kinetis-pcc.yaml
+++ b/dts/bindings/arm/nxp,kinetis-pcc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP Kinetis PCC (Peripheral Clock Controller)
-version: 0.1
 
 description: >
     This is a representation of the NXP Kinetis PCC IP node

--- a/dts/bindings/arm/nxp,kinetis-scg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-scg.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP Kinetis SCG (System Clock Generator)
-version: 0.1
 
 description: >
     This is a representation of the NXP Kinetis SCG IP node

--- a/dts/bindings/arm/nxp,kinetis-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-sim.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Kinetis System Integration Module (SIM)
-version: 0.1
 
 description: >
     This is a representation of the Kinetis SIM IP node

--- a/dts/bindings/arm/nxp,lpc-mailbox.yaml
+++ b/dts/bindings/arm/nxp,lpc-mailbox.yaml
@@ -5,7 +5,6 @@
 #
 
 title: LPC MAILBOX
-version: 0.1
 
 description: >
     This binding gives a base representation of the LPC MAILBOX

--- a/dts/bindings/arm/st,stm32-ccm.yaml
+++ b/dts/bindings/arm/st,stm32-ccm.yaml
@@ -1,7 +1,5 @@
-
 # SPDX-License-Identifier: Apache-2.0
 title: STM32 CCM
-version: 0.1
 
 description: >
   This binding gives a base representation of the STM32 CCM (Core Coupled Memory)

--- a/dts/bindings/arm/ti,cc2650-prcm.yaml
+++ b/dts/bindings/arm/ti,cc2650-prcm.yaml
@@ -1,7 +1,5 @@
-
 # SPDX-License-Identifier: Apache-2.0
 title: TI CC2650 PRCM
-version: 0.1
 
 description: >
     This binding gives a base representation of the TI CC2650

--- a/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
+++ b/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ST Microelectronics MPXXDTYY digital pdm microphone family
-version: 0.1
 
 description: >
     This binding gives a base representation of MPXXDTYY digital microphone family

--- a/dts/bindings/audio/ti,tlv320dac.yaml
+++ b/dts/bindings/audio/ti,tlv320dac.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Texas Instruments TLV320DAC Audio DAC
-version: 0.1
 
 description: >
     This binding gives a base representation of TLV320DAC310x Audio DAC

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -1,6 +1,4 @@
-
 title: base device binding
-version: 0.1
 
 description: >
     Binding for device

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Bluetooth controller that provides Host Controller Interface over SPI
-version: 0.1
 
 description: >
     This binding gives the base representation of a bluetooth controller node

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Bluetooth module based on Zephyr's Bluetooth HCI SPI driver
-version: 0.1
 
 description: >
     This binding gives the base representation of a bluetooth module which use

--- a/dts/bindings/can/can-device.yaml
+++ b/dts/bindings/can/can-device.yaml
@@ -5,7 +5,6 @@
 #
 
 title: CAN Device Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all can devices

--- a/dts/bindings/can/can.yaml
+++ b/dts/bindings/can/can.yaml
@@ -1,6 +1,4 @@
-
 title: CAN Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all CAN devices

--- a/dts/bindings/can/microchip,mcp2515.yaml
+++ b/dts/bindings/can/microchip,mcp2515.yaml
@@ -5,7 +5,6 @@
 #
 
 title: MCP2515 CAN
-version: 0.1
 
 description: >
     This binding gives a base representation of the MCP2515 SPI CAN controller

--- a/dts/bindings/can/nxp,kinetis-flexcan.yaml
+++ b/dts/bindings/can/nxp,kinetis-flexcan.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP FlexCAN
-version: 0.1
 
 description: >
     This binding gives a base representation of the NXP FlexCAN controller

--- a/dts/bindings/can/st,stm32-can.yaml
+++ b/dts/bindings/can/st,stm32-can.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 CAN
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 CAN controller

--- a/dts/bindings/clock/fixed-clock.yaml
+++ b/dts/bindings/clock/fixed-clock.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Generic fixed rate clock provider
-version: 0.1
 
 description: >
     This is a representation of a generic fixed rate clock provider.

--- a/dts/bindings/clock/nordic,nrf-clock.yaml
+++ b/dts/bindings/clock/nordic,nrf-clock.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic nRF clock control
-version: 0.1
 
 description: >
     This is a representation of the Nordic nRF clock control node

--- a/dts/bindings/clock/nxp,imx-ccm.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm.yaml
@@ -5,7 +5,6 @@
 #
 
 title: i.MX Clock Controller Module (CCM)
-version: 0.1
 
 description: >
     This is a representation of the i.MX CCM IP node

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 RCC
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 Clock control

--- a/dts/bindings/cpu/arm,cortex-m0+.yaml
+++ b/dts/bindings/cpu/arm,cortex-m0+.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARM Cortex-M0+ CPU
-version: 0.1
 
 description: >
     This binding gives a base representation for ARM Cortex-M0+ CPU.

--- a/dts/bindings/cpu/arm,cortex-m0.yaml
+++ b/dts/bindings/cpu/arm,cortex-m0.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARM Cortex-M0 CPU
-version: 0.1
 
 description: >
     This binding gives a base representation for ARM Cortex-M0 CPU.

--- a/dts/bindings/cpu/arm,cortex-m23.yaml
+++ b/dts/bindings/cpu/arm,cortex-m23.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARM Cortex-M23 CPU
-version: 0.1
 
 description: >
     This binding gives a base representation for ARM Cortex-M23 CPU.

--- a/dts/bindings/cpu/arm,cortex-m3.yaml
+++ b/dts/bindings/cpu/arm,cortex-m3.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARM Cortex-M3 CPU
-version: 0.1
 
 description: >
     This binding gives a base representation for ARM Cortex-M3 CPU.

--- a/dts/bindings/cpu/arm,cortex-m33.yaml
+++ b/dts/bindings/cpu/arm,cortex-m33.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARM Cortex-M33 CPU
-version: 0.1
 
 description: >
     This binding gives a base representation for ARM Cortex-M33 CPU.

--- a/dts/bindings/cpu/arm,cortex-m4.yaml
+++ b/dts/bindings/cpu/arm,cortex-m4.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARM Cortex-M4 CPU
-version: 0.1
 
 description: >
     This binding gives a base representation for ARM Cortex-M4 CPU.

--- a/dts/bindings/cpu/arm,cortex-m4f.yaml
+++ b/dts/bindings/cpu/arm,cortex-m4f.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARM Cortex-M4F CPU
-version: 0.1
 
 description: >
     This binding gives a base representation for ARM Cortex-M4F CPU.

--- a/dts/bindings/cpu/arm,cortex-m7.yaml
+++ b/dts/bindings/cpu/arm,cortex-m7.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARM Cortex-M7 CPU
-version: 0.1
 
 description: >
     This binding gives a base representation for ARM Cortex-M7 CPU.

--- a/dts/bindings/cpu/cadence,tensilica-xtensa-lx6.yaml
+++ b/dts/bindings/cpu/cadence,tensilica-xtensa-lx6.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Cadence Tensilica Xtensa LX6 CPU
-version: 0.1
 
 description: >
     This binding gives a base representation for Cadence Tensilica Xtensa LX6 CPU.

--- a/dts/bindings/cpu/cpu.yaml
+++ b/dts/bindings/cpu/cpu.yaml
@@ -5,7 +5,6 @@
 #
 
 title: CPU Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all CPUs

--- a/dts/bindings/cpu/sample_controller.yaml
+++ b/dts/bindings/cpu/sample_controller.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Sample Controller CPU
-version: 0.1
 
 description: >
     This binding gives a base representation for Sample Controller CPU.

--- a/dts/bindings/cpu/snps,arcem.yaml
+++ b/dts/bindings/cpu/snps,arcem.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Synopsys ARC EM CPU
-version: 0.1
 
 description: >
     This binding gives a base representation for Synopsys ARC EM CPU.

--- a/dts/bindings/crypto/arm,cryptocell-310.yaml
+++ b/dts/bindings/crypto/arm,cryptocell-310.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARM TrustZone CryptoCell 310
-version: 0.1
 
 description: >
     This is a representation of the ARM TrustZone CryptoCell 310

--- a/dts/bindings/crypto/nordic,nrf-cc310.yaml
+++ b/dts/bindings/crypto/nordic,nrf-cc310.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic Control Interface for ARM TrustZone CryptoCell 310
-version: 0.1
 
 description: >
     This is a representation of the Nordic Control Interface for ARM TrustZone CryptoCell 310

--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -1,5 +1,4 @@
 title: <short description of the node>
-version: 0.1
 
 description: >
     Longer free-form description of the node, with spanning

--- a/dts/bindings/display/fsl,imx6sx-lcdif.yaml
+++ b/dts/bindings/display/fsl,imx6sx-lcdif.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP Enhanced LCD Interface (eLCDIF) controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the NXP i.MX eLCDIF controller

--- a/dts/bindings/display/ilitek,ili9340.yaml
+++ b/dts/bindings/display/ilitek,ili9340.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ILI9340 320x240 Display Controller
-version: 0.1
 
 description: >
     This is a representation of the ILI9340 320x240 Display Controller

--- a/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
+++ b/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Rocktech LCD Module
-version: 0.1
 
 description: >
     This binding gives a base representation of the Rocktech LCD module with

--- a/dts/bindings/display/solomon,ssd1306fb.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb.yaml
@@ -5,7 +5,6 @@
 #
 
 title: SSD1306 128x64 Dot Matrix Display Controller
-version: 0.1
 
 description: >
     This is a representation of the SSD1306 128x64 Dot Matrix Display Controller

--- a/dts/bindings/display/solomon,ssd1673fb.yaml
+++ b/dts/bindings/display/solomon,ssd1673fb.yaml
@@ -5,7 +5,6 @@
 #
 
 title: SSD16XX 250x150 EPD Display Controller
-version: 0.1
 
 description: >
     This is a representation of the SSD16XX 250x150 EPD Display Controller

--- a/dts/bindings/ethernet/ethernet.yaml
+++ b/dts/bindings/ethernet/ethernet.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Ethernet Base Structure
-version: 0.1
 
 description: >
     This binding gives a base structures for all Ethernet devices

--- a/dts/bindings/ethernet/intel,e1000.yaml
+++ b/dts/bindings/ethernet/intel,e1000.yaml
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 title: Intel E1000 Ethernet controller
-version: 0.1
 
 description: >
      This is a representation of the Intel E1000 Ethernet controller

--- a/dts/bindings/ethernet/microchip,enc28j60.yaml
+++ b/dts/bindings/ethernet/microchip,enc28j60.yaml
@@ -5,7 +5,6 @@
 #
 
 title: 10Base-T Ethernet Controller with SPI Interface
-version: 0.1
 
 description: >
     This binding gives a base representation of the standalone ENC28J60 chip

--- a/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
+++ b/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP Kinetis Ethernet
-version: 0.1
 
 description: >
     This binding gives a base representation of the NXP Kinetis Ethernet

--- a/dts/bindings/ethernet/nxp.kinetis-ptp.yaml
+++ b/dts/bindings/ethernet/nxp.kinetis-ptp.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP Kinetis Ethernet PTP
-version: 0.1
 
 description: >
     This binding gives a base representation of the NXP Kinetis Ethernet PTP

--- a/dts/bindings/ethernet/smsc,lan9220.yaml
+++ b/dts/bindings/ethernet/smsc,lan9220.yaml
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 title: SMSC/Microchip LAN9220 Ethernet controller
-version: 0.1
 
 description: >
      This is a representation of the formerly SMSC, now Microchip, LAN9220

--- a/dts/bindings/ethernet/ti,stellaris-ethernet.yaml
+++ b/dts/bindings/ethernet/ti,stellaris-ethernet.yaml
@@ -4,7 +4,6 @@
 #
 
 title: TI Stellaris Ethernet
-version: 0.1
 
 description: >
     This binding gives a base representation of the TI Stellaris Ethernet

--- a/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
+++ b/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel SAM Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the Atmel SAM Enhanced Embedded Flash Controller

--- a/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
+++ b/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
@@ -1,6 +1,4 @@
-
 title: Atmel SAM0 Non-Volatile Memory Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the Atmel SAM0 NVMC

--- a/dts/bindings/flash_controller/cypress,psoc6-flash-controller.yaml
+++ b/dts/bindings/flash_controller/cypress,psoc6-flash-controller.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Cypress Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the Cypress Flash Controller

--- a/dts/bindings/flash_controller/flash-controller.yaml
+++ b/dts/bindings/flash_controller/flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: flash controller Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all flash controller devices

--- a/dts/bindings/flash_controller/nordic,nrf51-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf51-flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: Nordic NVMC
-version: 0.1
 
 description: >
     This binding gives a base representation of the Nordic NVMC

--- a/dts/bindings/flash_controller/nordic,nrf52-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf52-flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: Nordic NVMC
-version: 0.1
 
 description: >
     This binding gives a base representation of the Nordic NVMC

--- a/dts/bindings/flash_controller/nordic,nrf91-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf91-flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: Nordic NVMC
-version: 0.1
 
 description: >
     This binding gives a base representation of the Nordic NVMC

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfa.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfa.yaml
@@ -1,6 +1,4 @@
-
 title: NXP Kinetis Flash Memory Module (FTFA)
-version: 0.1
 
 description: >
     This binding gives for the NXP Kinetis Flash Memory Module A (FTFA)

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfe.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfe.yaml
@@ -1,6 +1,4 @@
-
 title: NXP Kinetis Flash Memory Module (FTFE)
-version: 0.1
 
 description: >
     This binding gives for the NXP Kinetis Flash Memory Module E (FTFE)

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfl.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfl.yaml
@@ -1,6 +1,4 @@
-
 title: NXP Kinetis Flash Memory Module (FTFL)
-version: 0.1
 
 description: >
     This binding gives for the NXP Kinetis Flash Memory Module L (FTFL)

--- a/dts/bindings/flash_controller/openisa,rv32m1-ftfe.yaml
+++ b/dts/bindings/flash_controller/openisa,rv32m1-ftfe.yaml
@@ -1,6 +1,4 @@
-
 title: OpenISA Flash Memory Module (FTFE)
-version: 0.1
 
 description: >
     This binding gives for the OpenISA Flash Memory Module E (FTFE)

--- a/dts/bindings/flash_controller/silabs,gecko-flash-controller.yaml
+++ b/dts/bindings/flash_controller/silabs,gecko-flash-controller.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Silicon Labs Gecko Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the Silicon Labs Gecko Flash Controller

--- a/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 F0 Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 F0 Flash Controller

--- a/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 F2 Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 F2 Flash Controller

--- a/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 F3 Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 F3 Flash Controller

--- a/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 F4 Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 F4 Flash Controller

--- a/dts/bindings/flash_controller/st,stm32f7-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f7-flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 F7 Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 F7 Flash Controller

--- a/dts/bindings/flash_controller/st,stm32g0-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32g0-flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 G0 Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 G0 Flash Controller

--- a/dts/bindings/flash_controller/st,stm32h7-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32h7-flash-controller.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 H7 Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 H7 Flash Controller

--- a/dts/bindings/flash_controller/st,stm32l1-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32l1-flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 L1 Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 L1 Flash Controller

--- a/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 L4 Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 L4 Flash Controller

--- a/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 WB Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 wb Flash Controller

--- a/dts/bindings/flash_controller/zephyr,native-posix-flash-controller.yaml
+++ b/dts/bindings/flash_controller/zephyr,native-posix-flash-controller.yaml
@@ -1,6 +1,4 @@
-
 title: Native POSIX Flash Controller
-version: 0.1
 
 description: >
     This binding gives a base representation of the Native POSIX flash

--- a/dts/bindings/flash_controller/zephyr,sim-flash.yaml
+++ b/dts/bindings/flash_controller/zephyr,sim-flash.yaml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 title: simulated flash
-version: 0.1
 
 description: >
     This binding gives a base representation of a simulated flash memory

--- a/dts/bindings/gpio/arduino-header-r3.yaml
+++ b/dts/bindings/gpio/arduino-header-r3.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARDUINO GPIO HEADER
-version: 0.1
 
 description: >
     This is a representation of GPIO pin nodes exposed as headers on Arduino R3

--- a/dts/bindings/gpio/arm,cmsdk-gpio.yaml
+++ b/dts/bindings/gpio/arm,cmsdk-gpio.yaml
@@ -1,6 +1,4 @@
-
 title: ARM CMSDK GPIO
-version: 0.1
 
 description: >
     This binding gives a base representation of the ARM CMSDK GPIO

--- a/dts/bindings/gpio/atmel,sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam-gpio.yaml
@@ -1,6 +1,4 @@
-
 title: Atmel SAM GPIO PORT driver
-version: 0.1
 
 description: >
     This is a representation of the SAM GPIO PORT nodes

--- a/dts/bindings/gpio/atmel,sam0-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam0-gpio.yaml
@@ -1,6 +1,4 @@
-
 title: Atmel SAM0 GPIO PORT driver
-version: 0.1
 
 description: >
     This is a representation of the SAM0 GPIO PORT nodes

--- a/dts/bindings/gpio/gpio-keys.yaml
+++ b/dts/bindings/gpio/gpio-keys.yaml
@@ -5,7 +5,6 @@
 #
 
 title: GPIO KEYS
-version: 0.1
 
 description: >
     This is a representation of the GPIO KEYS nodes

--- a/dts/bindings/gpio/gpio-leds.yaml
+++ b/dts/bindings/gpio/gpio-leds.yaml
@@ -5,7 +5,6 @@
 #
 
 title: GPIO LED
-version: 0.1
 
 description: >
     This is a representation of the LED GPIO nodes

--- a/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
+++ b/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
@@ -1,6 +1,4 @@
-
 title: Holtek HT16K33 LED Driver With Keyscan
-version: 0.1
 
 description: Holtek HT16K33 Keyscan binding
 

--- a/dts/bindings/gpio/intel,apl-gpio.yaml
+++ b/dts/bindings/gpio/intel,apl-gpio.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Intel Apollo Lake GPIO controller
-version: 0.1
 
 description: >
     This is a representation of the Intel Apollo Lake GPIO node

--- a/dts/bindings/gpio/intel,qmsi-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-gpio.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Intel QMSI GPIO
-version: 0.1
 
 description: >
     This is a representation of the Intel QMSI GPIO nodes

--- a/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Intel QMSI SS GPIO
-version: 0.1
 
 description: >
     This is a representation of the Intel QMSI SS GPIO nodes

--- a/dts/bindings/gpio/microchip,xec-gpio.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio.yaml
@@ -6,7 +6,6 @@
 
 
 title: MICROCHIP GPIO
-version: 0.1
 
 description: >
     This is a representation of the CEC/MEC GPIO nodes for Microchip

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NRF5 GPIO
-version: 0.1
 
 description: >
     This is a representation of the NRF GPIO nodes

--- a/dts/bindings/gpio/nordic,nrf-gpiote.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpiote.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NRF5 GPIOTE
-version: 0.1
 
 description: >
     This is a representation of the NRF GPIOTE node

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -5,7 +5,6 @@
 #
 
 title: i.MX GPIO
-version: 0.1
 
 description: >
     This is a representation of the i.MX GPIO nodes

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -1,6 +1,4 @@
-
 title: Kinetis GPIO
-version: 0.1
 
 description: >
     This is a representation of the Kinetis GPIO nodes

--- a/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
+++ b/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
@@ -1,6 +1,4 @@
-
 title: OpenISA GPIO
-version: 0.1
 
 description: >
     This is a representation of the OpenISA GPIO nodes

--- a/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Semtech SX1509B I2C GPIO
-version: 0.1
 
 description: >
         This is a representation of the SX1509B GPIO node

--- a/dts/bindings/gpio/sifive,gpio0.yaml
+++ b/dts/bindings/gpio/sifive,gpio0.yaml
@@ -5,7 +5,6 @@
 #
 
 title: SiFive GPIO
-version: 0.1
 
 description: >
     This is a representation of the SiFive GPIO nodes

--- a/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
@@ -1,6 +1,4 @@
-
 title: EFM32 GPIO
-version: 0.1
 
 description: >
     This is a representation of the EFM32 GPIO Port nodes

--- a/dts/bindings/gpio/silabs,efm32-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio.yaml
@@ -1,6 +1,4 @@
-
 title: EFM32 GPIO
-version: 0.1
 
 description: >
     This is a representation of the EFM32 GPIO nodes

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
@@ -1,6 +1,4 @@
-
 title: EFR32MG GPIO
-version: 0.1
 
 description: >
     This is a representation of the EFR32MG GPIO Port nodes

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
@@ -1,6 +1,4 @@
-
 title: EFR32MG GPIO
-version: 0.1
 
 description: >
     This is a representation of the EFR32MG GPIO nodes

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
@@ -1,6 +1,4 @@
-
 title: EFR32XG1 GPIO
-version: 0.1
 
 description: >
     This is a representation of the EFR32XG1 GPIO Port nodes

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
@@ -1,6 +1,4 @@
-
 title: EFR32XG1 GPIO
-version: 0.1
 
 description: >
     This is a representation of the EFR32XG1 GPIO nodes

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Synopsys Designware GPIO controller
-version: 0.1
 
 description: >
     This is a representation of the Synopsys DesignWare gpio node

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STM32 GPIO
-version: 0.1
 
 description: >
     This is a representation of the STM32 GPIO nodes

--- a/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
@@ -5,7 +5,6 @@
 #
 
 title: TI SimpleLink CC13xx / CC26xx GPIO
-version: 0.1
 
 description: >
     This is a representation of the TI SimpleLink CC13xx / CC26xx GPIO node

--- a/dts/bindings/gpio/ti,cc2650-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc2650-gpio.yaml
@@ -1,7 +1,5 @@
-
 # SPDX-License-Identifier: Apache-2.0
 title: TI CC2650 GPIO
-version: 0.1
 
 description: >
     This is a representation of the TI CC2650 GPIO node

--- a/dts/bindings/gpio/ti,cc32xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc32xx-gpio.yaml
@@ -1,7 +1,5 @@
-
 # SPDX-License-Identifier: Apache-2.0
 title: TI CC32XX GPIO
-version: 0.1
 
 description: >
     This is a representation of the TI CC32XX GPIO node

--- a/dts/bindings/gpio/ti,stellaris-gpio.yaml
+++ b/dts/bindings/gpio/ti,stellaris-gpio.yaml
@@ -1,7 +1,5 @@
-
 # SPDX-License-Identifier: Apache-2.0
 title: TI Stellaris GPIO
-version: 0.1
 
 description: >
     This is a representation of the TI Stellaris GPIO node

--- a/dts/bindings/i2c/arm,versatile-i2c.yaml
+++ b/dts/bindings/i2c/arm,versatile-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARM SBCon two-wire serial bus interface
-version: 0.1
 
 description: >
     This is a representation of the ARM SBCon two-wire serial bus interface

--- a/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel SAM Family I2C (TWI) node
-version: 0.1
 
 description: >
     This is a representation of the Atmel SAM Family I2C (TWI) node

--- a/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel SAM Family I2C (TWIHS) node
-version: 0.1
 
 description: >
     This is a representation of the Atmel SAM Family I2C (TWIHS) node

--- a/dts/bindings/i2c/atmel,sam0-i2c.yaml
+++ b/dts/bindings/i2c/atmel,sam0-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel SAM0 series SERCOM I2C controller
-version: 0.1
 
 description: >
     This is a representation of the Atmel SAM0 series SERCOM I2C nodes

--- a/dts/bindings/i2c/fsl,imx7d-i2c.yaml
+++ b/dts/bindings/i2c/fsl,imx7d-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: i.MX I2C Controller
-version: 0.1
 
 description: >
     This is a representation of the i.MX I2C nodes

--- a/dts/bindings/i2c/i2c-device.yaml
+++ b/dts/bindings/i2c/i2c-device.yaml
@@ -5,7 +5,6 @@
 #
 
 title: I2C Device Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all i2c devices

--- a/dts/bindings/i2c/i2c.yaml
+++ b/dts/bindings/i2c/i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: I2C Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all I2C devices

--- a/dts/bindings/i2c/intel,qmsi-i2c.yaml
+++ b/dts/bindings/i2c/intel,qmsi-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Intel QMSI i2c
-version: 0.1
 
 description: >
     This binding gives a base representation of the Intel QMSI i2c

--- a/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
+++ b/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Intel QMSI SS i2c
-version: 0.1
 
 description: >
     This binding gives a base representation of the Intel QMSI SS i2c

--- a/dts/bindings/i2c/microchip,xec-i2c.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: MICROCHIP I2C
-version: 0.1
 
 description: >
     This binding gives a base representation for I2C/SMB controller for Microchip

--- a/dts/bindings/i2c/nios2,i2c.yaml
+++ b/dts/bindings/i2c/nios2,i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NIOS2 i2c
-version: 0.1
 
 description: >
     This binding gives a base representation of the NIOS2 i2c

--- a/dts/bindings/i2c/nordic,nrf-i2c.yaml
+++ b/dts/bindings/i2c/nordic,nrf-i2c.yaml
@@ -6,7 +6,6 @@
 #
 
 title: Nordic nRF Family I2C Master node
-version: 0.1
 
 description: >
     This is a representation of the Nordic nRF I2C node

--- a/dts/bindings/i2c/nxp,imx-lpi2c.yaml
+++ b/dts/bindings/i2c/nxp,imx-lpi2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP LPI2C
-version: 0.1
 
 description: >
     This binding gives a base representation of the NXP i.MX LPI2C controller

--- a/dts/bindings/i2c/nxp,kinetis-i2c.yaml
+++ b/dts/bindings/i2c/nxp,kinetis-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Kinetis I2C Controller
-version: 0.1
 
 description: >
     This is a representation of the Kinetis I2C nodes

--- a/dts/bindings/i2c/openisa,rv32m1-lpi2c.yaml
+++ b/dts/bindings/i2c/openisa,rv32m1-lpi2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: OpenISA LPI2C
-version: 0.1
 
 description: >
     This binding gives a base representation of the OpenISA LPI2C controller

--- a/dts/bindings/i2c/sifive,i2c0.yaml
+++ b/dts/bindings/i2c/sifive,i2c0.yaml
@@ -5,7 +5,6 @@
 #
 
 title: SiFive Freedom I2C
-version: 0.1
 
 description: >
     This is a binding for the SiFive Freedom I2C interface

--- a/dts/bindings/i2c/silabs,gecko-i2c.yaml
+++ b/dts/bindings/i2c/silabs,gecko-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Silabs Gecko I2C Controller
-version: 0.1
 
 description: >
     This is a representation of the Silabs Gecko I2C nodes

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Synopys DesignWare I2C controller
-version: 0.1
 
 description: >
     This is a representation of the Synopsys DesignWare i2c node

--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STM32 I2C V1
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 I2C V1 controller

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STM32 I2C V2
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 I2C V2 controller

--- a/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: TI CC13xx / CC26xx I2C
-version: 0.1
 
 description: >
     This is a representation of the TI CC13xx / CC26xx I2C node

--- a/dts/bindings/i2c/ti,cc32xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc32xx-i2c.yaml
@@ -1,6 +1,4 @@
-
 title: CC32XX I2C
-version: 0.1
 
 description: >
     This binding gives a base representation of the TI CC32XX I2C controller

--- a/dts/bindings/i2s/i2s-device.yaml
+++ b/dts/bindings/i2s/i2s-device.yaml
@@ -5,7 +5,6 @@
 #
 
 title: I2S Device Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all i2s devices

--- a/dts/bindings/i2s/i2s.yaml
+++ b/dts/bindings/i2s/i2s.yaml
@@ -5,7 +5,6 @@
 #
 
 title: I2S Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all I2S devices

--- a/dts/bindings/i2s/st,stm32-i2s.yaml
+++ b/dts/bindings/i2s/st,stm32-i2s.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STM32 I2S
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 I2S controller

--- a/dts/bindings/ieee802154/nxp,mcr20a.yaml
+++ b/dts/bindings/ieee802154/nxp,mcr20a.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP MCR20A 802.15.4 Wireless Transceiver
-version: 0.1
 
 description: >
     This is a representation of the NXP MCR20A wireless transceiver.

--- a/dts/bindings/ieee802154/ti,cc1200.yaml
+++ b/dts/bindings/ieee802154/ti,cc1200.yaml
@@ -5,7 +5,6 @@
 #
 
 title: CC1200 802.15.4 Wireless Transceiver
-version: 0.1
 
 description: >
     This is a representation of the CC1200 wireless transceiver.

--- a/dts/bindings/ieee802154/ti,cc2520.yaml
+++ b/dts/bindings/ieee802154/ti,cc2520.yaml
@@ -5,7 +5,6 @@
 #
 
 title: CC2520 802.15.4 Wireless Transceiver
-version: 0.1
 
 description: >
     This is a representation of the CC2520 wireless transceiver.

--- a/dts/bindings/iio/adc/adc.yaml
+++ b/dts/bindings/iio/adc/adc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ADC Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all ADC devices

--- a/dts/bindings/iio/adc/atmel,sam-afec.yaml
+++ b/dts/bindings/iio/adc/atmel,sam-afec.yaml
@@ -1,6 +1,4 @@
-
 title: Atmel SAM Family AFEC
-version: 0.1
 
 description: >
     This binding gives a base representation of the Atmel SAM AFEC

--- a/dts/bindings/iio/adc/atmel,sam0-adc.yaml
+++ b/dts/bindings/iio/adc/atmel,sam0-adc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel SAM0 Family ADC
-version: 0.1
 
 description: >
     This binding gives a base representation of the Atmel SAM0 ADC

--- a/dts/bindings/iio/adc/nordic,nrf-adc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-adc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic Semiconductor nRF Family ADC
-version: 0.1
 
 description: >
     This is a representation of the nRF ADC node

--- a/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic Semiconductor nRF Family SAADC
-version: 0.1
 
 description: >
     This is a representation of the nRF SAADC node

--- a/dts/bindings/iio/adc/nxp,kinetis-adc12.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc12.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP Kinetis ADC12
-version: 0.1
 
 description: >
     This binding gives a base representation of the NXP Kinetis ADC12

--- a/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Kinetis ADC16
-version: 0.1
 
 description: >
     This binding gives a base representation of the Kinetis ADC16

--- a/dts/bindings/iio/adc/snps,dw-adc.yaml
+++ b/dts/bindings/iio/adc/snps,dw-adc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: DesignWare ADC
-version: 0.1
 
 description: >
     This is a representation of the DesignWare ADC node

--- a/dts/bindings/iio/adc/st,stm32-adc.yaml
+++ b/dts/bindings/iio/adc/st,stm32-adc.yaml
@@ -6,7 +6,6 @@
 #
 
 title: ST STM32 family ADC
-version: 0.1
 
 description: >
     This binding gives a base representation of the ST STM32 ADC

--- a/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
@@ -1,6 +1,4 @@
-
 title: ARMv6-M NVIC Interrupt Controller
-version: 0.1
 
 description: >
     This binding describes the ARMv6-M Nested Vectored Interrupt Controller.

--- a/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
@@ -1,6 +1,4 @@
-
 title: ARMv7-M NVIC Interrupt Controller
-version: 0.1
 
 description: >
     This binding describes the ARMv7-M Nested Vectored Interrupt Controller.

--- a/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
@@ -1,6 +1,4 @@
-
 title: ARMv8-M NVIC Interrupt Controller
-version: 0.1
 
 description: >
     This binding describes the ARMv8-M Nested Vectored Interrupt Controller.

--- a/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
+++ b/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
@@ -1,6 +1,4 @@
-
 title: Atmel SAM0 External Interrupt Controller
-version: 0.1
 
 description: >
     This binding describes the Atmel SAM0 series External Interrupt Controller

--- a/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
@@ -1,6 +1,4 @@
-
 title: CAVS Interrupt Controller
-version: 0.1
 
 description: >
     This binding describes CAVS Interrupt controller

--- a/dts/bindings/interrupt-controller/intel,ioapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,ioapic.yaml
@@ -1,6 +1,4 @@
-
 title: Intel I/O Advanced Programmable Interrupt Controller
-version: 0.1
 
 description: >
     This binding describes the Intel I/O Advanced Programmable Interrupt

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
@@ -6,7 +6,6 @@
 #
 
 title: RV32M1 Event Unit
-version: 0.1
 
 description: >
     This binding describes the RV32M1 Event Unit

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
@@ -5,7 +5,6 @@
 #
 
 title: RV32M1 INTMUX
-version: 0.1
 
 description: >
     This binding describes the RV32M1 INTMUX IP

--- a/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
+++ b/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: RISC-V CPU INTC
-version: 0.1
 
 description: >
     This binding describes the RISC-V CPU Interrupt Controller

--- a/dts/bindings/interrupt-controller/riscv,plic0.yaml
+++ b/dts/bindings/interrupt-controller/riscv,plic0.yaml
@@ -5,7 +5,6 @@
 #
 
 title: RISC-V PLIC
-version: 0.1
 
 description: >
     This binding describes the RISC-V Platform-Local Interrupt Controller

--- a/dts/bindings/interrupt-controller/shared-irq.yaml
+++ b/dts/bindings/interrupt-controller/shared-irq.yaml
@@ -1,6 +1,4 @@
-
 title: Shared IRQ interrupt dispatcher
-version: 0.1
 
 description: >
     This binding describes Shared IRQ interrupt dispatcher

--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARCV2 Interrupt Controller
-version: 0.1
 
 description: >
     This binding describes the ARCV2 IRQ controller

--- a/dts/bindings/interrupt-controller/snps,designware-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,designware-intc.yaml
@@ -1,6 +1,4 @@
-
 title: DesignWare Interrupt Controller
-version: 0.1
 
 description: >
     This binding describes DesignWare Programmable Interrupt controller

--- a/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
+++ b/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
@@ -5,7 +5,6 @@
 #
 
 title: LiteX VexRiscV Interrupt Controller
-version: 0.1
 
 description: >
     This binding describes LiteX VexRiscV Interrupt Controller

--- a/dts/bindings/interrupt-controller/xtensa,intc.yaml
+++ b/dts/bindings/interrupt-controller/xtensa,intc.yaml
@@ -1,6 +1,4 @@
-
 title: Xtensa Core Interrupt Controller
-version: 0.1
 
 description: >
     This binding describes Xtensa Core Interrupt controller

--- a/dts/bindings/led/holtek,ht16k33.yaml
+++ b/dts/bindings/led/holtek,ht16k33.yaml
@@ -1,6 +1,4 @@
-
 title: Holtek HT16K33 LED Driver
-version: 0.1
 
 description: Holtek HT16K33 LEDs binding
 

--- a/dts/bindings/led/nxp,pca9633.yaml
+++ b/dts/bindings/led/nxp,pca9633.yaml
@@ -1,6 +1,4 @@
-
 title: NXP PCA9633 LED Driver
-version: 0.1
 
 description: NXP PCA9633 LED binding
 

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -5,7 +5,6 @@
 #
 
 title: PWM LED
-version: 0.1
 
 description: >
     This is a representation of the PWM GPIO nodes

--- a/dts/bindings/led/ti,lp3943.yaml
+++ b/dts/bindings/led/ti,lp3943.yaml
@@ -1,6 +1,4 @@
-
 title: TI LP3943 LED Driver
-version: 0.1
 
 description: TI LP3943 LED binding
 

--- a/dts/bindings/led/ti,lp5562.yaml
+++ b/dts/bindings/led/ti,lp5562.yaml
@@ -1,6 +1,4 @@
-
 title: TI LP5562 LED Driver
-version: 0.1
 
 description: TI LP5562 LED binding
 

--- a/dts/bindings/led_strip/apa,apa-102.yaml
+++ b/dts/bindings/led_strip/apa,apa-102.yaml
@@ -1,6 +1,4 @@
-
 title: APA102 SPI LED strip
-version: 0.1
 
 description: APA102 SPI LED strip binding
 

--- a/dts/bindings/led_strip/colorway,lpd8803.yaml
+++ b/dts/bindings/led_strip/colorway,lpd8803.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Colorway LPD8803 SPI LED strip
-version: 0.1
 
 description: Colorway LPD8803 SPI LED strip binding
 

--- a/dts/bindings/led_strip/colorway,lpd8806.yaml
+++ b/dts/bindings/led_strip/colorway,lpd8806.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Colorway LPD8806 SPI LED strip
-version: 0.1
 
 description: Colorway LPD8806 SPI LED strip binding
 

--- a/dts/bindings/led_strip/worldsemi,ws2812.yaml
+++ b/dts/bindings/led_strip/worldsemi,ws2812.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Worldsemi WS2812 SPI LED strip
-version: 0.1
 
 description: Worldsemi WS2812 SPI LED strip binding
 

--- a/dts/bindings/memory-controllers/nxp,imx-semc.yaml
+++ b/dts/bindings/memory-controllers/nxp,imx-semc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP SEMC
-version: 0.1
 
 description: >
     This binding gives a base representation of the NXP smart external memory

--- a/dts/bindings/mhu/arm,mhu.yaml
+++ b/dts/bindings/mhu/arm,mhu.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ARM MHU
-version: 0.1
 
 description: >
     This binding gives a base representation of the ARM MHU

--- a/dts/bindings/misc/skyworks,sky13351.yaml
+++ b/dts/bindings/misc/skyworks,sky13351.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Skyworks SKY13351 GaAs FET I/C switch
-version: 0.1
 
 description: >
     This binding allows control of the output selectors of the SKY13351

--- a/dts/bindings/mmc/mmc-spi-slot.yaml
+++ b/dts/bindings/mmc/mmc-spi-slot.yaml
@@ -5,7 +5,6 @@
 #
 
 title: MMC/SD/SDIO slot connected via SPI
-version: 0.1
 
 description: MMC/SD/SDIO slot connected via SPI
 

--- a/dts/bindings/mmc/mmc.yaml
+++ b/dts/bindings/mmc/mmc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: MMC/SDHC module
-version: 0.1
 
 description: >
     This binding specifies the MMC/SDHC module.

--- a/dts/bindings/mmc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/mmc/nxp,imx-usdhc.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: NXP i.MXRT USDHC module
-version: 0.1
 
 description: >
     This binding specifies the NXP i.MXRT USDHC module.

--- a/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
@@ -1,6 +1,4 @@
-
 title: ARMv7-M Memory Protection Unit
-version: 0.1
 
 description: >
     This binding describes the ARMv7-M Memory Protection Unit (MPU).

--- a/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
@@ -1,6 +1,4 @@
-
 title: ARMv8-M Memory Protection Unit
-version: 0.1
 
 description: >
     This binding describes the ARMv8-M Memory Protection Unit (MPU).

--- a/dts/bindings/modem/ublox,sara-r4.yaml
+++ b/dts/bindings/modem/ublox,sara-r4.yaml
@@ -5,7 +5,6 @@
 #
 
 title: u-blox SARA-R4 modem
-version: 0.1
 
 description: >
     This is a representation of the u-blox SARA-R4 modem.

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -5,7 +5,6 @@
 #
 
 title: WNC-M14A2A LTE-M Modem
-version: 0.1
 
 description: >
     This is a representation of the WNC-M14A2A LTE-M modem.

--- a/dts/bindings/mtd/atmel,at24.yaml
+++ b/dts/bindings/mtd/atmel,at24.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Virtual I2C slave eeprom
-version: 0.1
 
 description: >
     This binding gives a base representation of a generic I2C slave EEPROM

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -5,7 +5,6 @@
 #
 
 title: SPI NOR flash devices (JEDEC CFI interface)
-version: 0.1
 
 description: >
   Any SPI NOR flash that supports the JEDEC CFI interface.

--- a/dts/bindings/mtd/partition.yaml
+++ b/dts/bindings/mtd/partition.yaml
@@ -1,6 +1,4 @@
-
 title: Flash Partitions
-version: 0.1
 
 description: >
     This binding gives a base FLASH partition description

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -1,6 +1,4 @@
-
 title: Flash base node description
-version: 0.1
 
 description: >
     This binding gives a base FLASH description

--- a/dts/bindings/mtd/winbond,w25q16.yaml
+++ b/dts/bindings/mtd/winbond,w25q16.yaml
@@ -5,7 +5,6 @@
 #
 
 title: SPI NOR FLASH
-version: 0.1
 
 description: >
     This binding gives a base representation of SPI slave NOR FLASH

--- a/dts/bindings/phy/phy.yaml
+++ b/dts/bindings/phy/phy.yaml
@@ -5,7 +5,6 @@
 #
 
 title: PHY Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all PHY providers

--- a/dts/bindings/phy/st,stm32-usbphyc.yaml
+++ b/dts/bindings/phy/st,stm32-usbphyc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STM32 USB HS PHY
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 USB HS PHY controller

--- a/dts/bindings/phy/usb-nop-xceiv.yaml
+++ b/dts/bindings/phy/usb-nop-xceiv.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NOP USB Transceiver
-version: 0.1
 
 description: >
     This binding is to be used by all the usb transceivers which are built-in

--- a/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
+++ b/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
@@ -1,6 +1,4 @@
-
 title: Atmel SAM0 PINMUX
-version: 0.1
 
 description: >
     This binding gives a base representation of the Atmel SAM0 PINMUX

--- a/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
+++ b/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
@@ -1,7 +1,5 @@
-
 # SPDX-License-Identifier: Apache-2.0
 title: Intel S1000 Pinmux
-version: 0.1
 
 description: >
     This is a representation of the Intel S1000 SoC's pinmux node

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -1,6 +1,4 @@
-
 title: Kinetis Pinmux
-version: 0.1
 
 description: >
     This is a representation of the Kinetis Pinmux node

--- a/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
+++ b/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
@@ -1,6 +1,4 @@
-
 title: RV32M1 Pinmux
-version: 0.1
 
 description: >
     This is a representation of the RV32M1 Pinmux node

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 PINMUX
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 PINMUX

--- a/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
@@ -5,7 +5,6 @@
 #
 
 title: TI SimpleLink CC13xx / CC26xx Pinmux
-version: 0.1
 
 description: >
     This is a representation of the TI SimpleLink CC13xx / CC26xx pinmux node

--- a/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
@@ -1,7 +1,5 @@
-
 # SPDX-License-Identifier: Apache-2.0
 title: TI CC2650 Pinmux
-version: 0.1
 
 description: >
     This is a representation of the TI CC2650 pinmux node

--- a/dts/bindings/power/nordic,nrf-power.yaml
+++ b/dts/bindings/power/nordic,nrf-power.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic nRF power control
-version: 0.1
 
 description: >
     This is a representation of the Nordic nRF power control node

--- a/dts/bindings/pwm/atmel,sam-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam-pwm.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel SAM PWM
-version: 0.1
 
 description: >
     This binding gives a base representation of the Atmel SAM PWM

--- a/dts/bindings/pwm/fsl,imx7d-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx7d-pwm.yaml
@@ -5,7 +5,6 @@
 #
 
 title: i.MX7D PWM
-version: 0.1
 
 description: >
     This binding gives a base representation of the i.MX7D PWM

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -1,6 +1,4 @@
-
 title: nRF PWM
-version: 0.1
 
 description: >
     This binding gives a base representation of the nRF PWM

--- a/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
@@ -1,6 +1,4 @@
-
 title: nRF SW PWM
-version: 0.1
 
 description: >
     This binding gives a base representation of the nRFx S/W PWM

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Kinetis FTM
-version: 0.1
 
 description: >
     This binding gives a base representation of the Kinetis FTM

--- a/dts/bindings/pwm/pwm.yaml
+++ b/dts/bindings/pwm/pwm.yaml
@@ -5,7 +5,6 @@
 #
 
 title: PWM Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all PWM devices

--- a/dts/bindings/pwm/sifive,pwm0.yaml
+++ b/dts/bindings/pwm/sifive,pwm0.yaml
@@ -5,7 +5,6 @@
 #
 
 title: SiFive PWM
-version: 0.1
 
 description: >
     This binding gives a base representation of the SiFive PWM

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 PWM
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 PWM

--- a/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
+++ b/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: RV32M1 PCC (Peripheral Clock Control)
-version: 0.1
 
 description: >
     This is a representation of the RV32M1 PCC IP node

--- a/dts/bindings/rng/atmel,sam-trng.yaml
+++ b/dts/bindings/rng/atmel,sam-trng.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel SAM TRNG (True Random Number Generator)
-version: 0.1
 
 description: >
     This binding gives a base representation of the Atmel SAM RNG

--- a/dts/bindings/rng/nxp,kinetis-rnga.yaml
+++ b/dts/bindings/rng/nxp,kinetis-rnga.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Kinetis RNGA (Random Number Generator Accelerator)
-version: 0.1
 
 description: >
     This binding gives a base representation of the Kinetis RNGA

--- a/dts/bindings/rng/nxp,kinetis-trng.yaml
+++ b/dts/bindings/rng/nxp,kinetis-trng.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Kinetis TRNG (True Random Number Generator)
-version: 0.1
 
 description: >
     This binding gives a base representation of the Kinetis RNGA

--- a/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
+++ b/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
@@ -5,7 +5,6 @@
 #
 
 title: TI SimpleLink CC13xx / CC26xx True Random Number Generator (TRNG)
-version: 0.1
 
 description: >
     This is a representation of the TI SimpleLink CC13xx / CC26xx TRNG node

--- a/dts/bindings/rtc/atmel,sam0-rtc.yaml
+++ b/dts/bindings/rtc/atmel,sam0-rtc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel SAM0 RTC
-version: 0.1
 
 description: >
     This binding gives a base representation of the Atmel SAM0 RTC

--- a/dts/bindings/rtc/intel,qmsi-rtc.yaml
+++ b/dts/bindings/rtc/intel,qmsi-rtc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Intel QMSI RTC
-version: 0.1
 
 description: >
     This is a representation of the Intel QMSI RTC nodes

--- a/dts/bindings/rtc/nordic,nrf-rtc.yaml
+++ b/dts/bindings/rtc/nordic,nrf-rtc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic nRF Real Time Counter
-version: 0.1
 
 description: >
     This is a representation of the Nordic nRF RTC node

--- a/dts/bindings/rtc/nxp,kinetis-rtc.yaml
+++ b/dts/bindings/rtc/nxp,kinetis-rtc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Kinetis RTC
-version: 0.1
 
 description: >
     This binding gives a base representation of the Kinetis RTC

--- a/dts/bindings/rtc/rtc.yaml
+++ b/dts/bindings/rtc/rtc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: RTC Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all RTC devices

--- a/dts/bindings/rtc/silabs,gecko-rtcc.yaml
+++ b/dts/bindings/rtc/silabs,gecko-rtcc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Silabs Gecko Real Time Counter
-version: 0.1
 
 description: >
     This is a representation of the Silabs Gecko RTCC node

--- a/dts/bindings/rtc/st,stm32-rtc.yaml
+++ b/dts/bindings/rtc/st,stm32-rtc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STM32 RTC
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 RTC

--- a/dts/bindings/sensor/adi,adt7420.yaml
+++ b/dts/bindings/sensor/adi,adt7420.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ADT7420 16-Bit Digital I2C Temperature Sensor
-version: 0.1
 
 description: >
     This is a representation of the ADT7420 16-Bit Digital I2C Temperature Sensor

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ADXL362 Three Axis SPI accelerometer
-version: 0.1
 
 description: >
     This is a representation of the ADXL362 Three Axis SPI accelerometer

--- a/dts/bindings/sensor/adi,adxl372-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl372-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: ADXL372 Three Axis High-g I2C/SPI accelerometer
-version: 0.1
 
 description: >
     This is a representation of the ADXL372 Three Axis High-g I2C/SPI accelerometer

--- a/dts/bindings/sensor/adi,adxl372-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl372-spi.yaml
@@ -6,7 +6,6 @@
 #
 
 title: ADXL372 Three Axis High-g I2C/SPI accelerometer
-version: 0.1
 
 description: >
     This is a representation of the ADXL372 Three Axis High-g accelerometer,

--- a/dts/bindings/sensor/ams,ccs811.yaml
+++ b/dts/bindings/sensor/ams,ccs811.yaml
@@ -5,7 +5,6 @@
 #
 
 title: AMS (Austria Mikro Systeme) Digital Air Quality Sensor CCS811
-version: 0.1
 
 description: >
     This binding gives a base representation of CCS811 digital air quality

--- a/dts/bindings/sensor/ams,ens210.yaml
+++ b/dts/bindings/sensor/ams,ens210.yaml
@@ -5,7 +5,6 @@
 #
 
 title: AMS (Austria Mikro Systeme) Relative Humidity and Temperature Sensor
-version: 0.1
 
 description: >
     This binding gives a base representation of ens210 Relative Humidity and

--- a/dts/bindings/sensor/ams,iaqcore.yaml
+++ b/dts/bindings/sensor/ams,iaqcore.yaml
@@ -5,7 +5,6 @@
 #
 
 title: AMS (Austria Mikro Systeme) Indoor Air Quality Sensor iAQ-core
-version: 0.1
 
 description: >
     This binding gives a base representation of iAQ-core indoor air quality

--- a/dts/bindings/sensor/avago,apds9960.yaml
+++ b/dts/bindings/sensor/avago,apds9960.yaml
@@ -5,7 +5,6 @@
 #
 
 title: APDS9960 Digital Proximity, Ambient Light, RGB and Gesture Sensor
-version: 0.1
 
 description: >
     This is a representation of the APDS9960 sensor

--- a/dts/bindings/sensor/bosch,bme280-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bme280-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: BME280 Integrated environmental sensor
-version: 0.1
 
 description: >
     This is a representation of the BME280 Integrated environmental sensor

--- a/dts/bindings/sensor/bosch,bme280-spi.yaml
+++ b/dts/bindings/sensor/bosch,bme280-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: BME280 Integrated environmental sensor
-version: 0.1
 
 description: >
     This is a representation of the BME280 Integrated environmental sensor

--- a/dts/bindings/sensor/bosch,bme680-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bme680-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: BME680 integrated environmental sensor
-version: 0.1
 
 description: >
     The BME680 is an integrated environmental sensor that measures

--- a/dts/bindings/sensor/bosch,bmi160.yaml
+++ b/dts/bindings/sensor/bosch,bmi160.yaml
@@ -5,7 +5,6 @@
 #
 
 title: BMI160 Inertial measurement unit
-version: 0.1
 
 description: >
     This is a representation of the BMI160 Inertial measurement unit

--- a/dts/bindings/sensor/max,max30101.yaml
+++ b/dts/bindings/sensor/max,max30101.yaml
@@ -5,7 +5,6 @@
 #
 
 title: MAX30101 heart rate sensor
-version: 0.1
 
 description: >
     This is a representation of the MAX30101 heart rate sensor

--- a/dts/bindings/sensor/meas,ms5837.yaml
+++ b/dts/bindings/sensor/meas,ms5837.yaml
@@ -5,7 +5,6 @@
 #
 
 title: TE Connectivity digital pressure sensor MS5837
-version: 0.1
 
 description: >
     This binding gives a base representation of the MS5837 digital pressure

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic nRF Family QDEC node
-version: 0.1
 
 description: >
     This is a representation of the Nordic nRF QDEC node

--- a/dts/bindings/sensor/nordic,nrf-temp.yaml
+++ b/dts/bindings/sensor/nordic,nrf-temp.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic nRF Family TEMP node
-version: 0.1
 
 description: >
     This is a representation of the Nordic nRF TEMP node

--- a/dts/bindings/sensor/nxp,fxas21002.yaml
+++ b/dts/bindings/sensor/nxp,fxas21002.yaml
@@ -5,7 +5,6 @@
 #
 
 title: FXAS21002 3-axis gyroscope
-version: 0.1
 
 description: >
     This is a representation of the FXAS21002 3-axis gyroscope sensor

--- a/dts/bindings/sensor/nxp,fxos8700.yaml
+++ b/dts/bindings/sensor/nxp,fxos8700.yaml
@@ -5,7 +5,6 @@
 #
 
 title: FXOS8700 6-axis accelerometer/magnetometer
-version: 0.1
 
 description: >
     This is a representation of the FXOS8700 6-axis accelerometer/magnetometer

--- a/dts/bindings/sensor/sensirion,sht3xd.yaml
+++ b/dts/bindings/sensor/sensirion,sht3xd.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Sensirion Humidity Sensor SHT-3x-DIS
-version: 0.1
 
 description: >
     This binding gives a base representation of SHT3x-DIS humidity and temperature

--- a/dts/bindings/sensor/st,hts221.yaml
+++ b/dts/bindings/sensor/st,hts221.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors HTS221
-version: 0.1
 
 description: >
     This binding gives a base representation of HTS221 humidity and temperature

--- a/dts/bindings/sensor/st,lis2dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dh-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LIS2DH
-version: 0.1
 
 description: >
     This binding gives a base representation of LIS2DH 3-axis accelerometer

--- a/dts/bindings/sensor/st,lis2dh-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dh-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LIS2DH SPI
-version: 0.1
 
 description: >
     This binding gives a base representation of LIS2DH 3-axis accelerometer

--- a/dts/bindings/sensor/st,lis2ds12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LIS2DS12
-version: 0.1
 
 description: >
     This binding gives a base representation of LIS2DS12 3-axis accelerometer

--- a/dts/bindings/sensor/st,lis2ds12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LIS2DS12 SPI
-version: 0.1
 
 description: >
     This binding gives a base representation of LIS2DS12 3-axis accelerometer

--- a/dts/bindings/sensor/st,lis2dw12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LIS2DW12
-version: 0.1
 
 description: >
     This binding gives a base representation of LIS2DW12 3-axis accelerometer

--- a/dts/bindings/sensor/st,lis2dw12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LIS2DW12 SPI
-version: 0.1
 
 description: >
     This binding gives a base representation of LIS2DW12 3-axis accelerometer

--- a/dts/bindings/sensor/st,lis2mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-magn.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LIS2MDL
-version: 0.1
 
 description: >
     This binding gives a base representation of LIS2MDL magnetometer

--- a/dts/bindings/sensor/st,lis3dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis3dh-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LIS3DH
-version: 0.1
 
 description: >
     This binding gives a base representation of LIS3DH 3-axis accelerometer

--- a/dts/bindings/sensor/st,lis3mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis3mdl-magn.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LIS3MDL
-version: 0.1
 
 description: >
     This binding gives a base representation of LIS3MDL magnetometer

--- a/dts/bindings/sensor/st,lps22hb-press.yaml
+++ b/dts/bindings/sensor/st,lps22hb-press.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LPS22HB
-version: 0.1
 
 description: >
     This binding gives a base representation of LPS22HB pressure sensor

--- a/dts/bindings/sensor/st,lps22hh-i2c.yaml
+++ b/dts/bindings/sensor/st,lps22hh-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LPS22HH
-version: 0.1
 
 description: >
     This binding gives a base representation of LPS22HH pressure and

--- a/dts/bindings/sensor/st,lps22hh-spi.yaml
+++ b/dts/bindings/sensor/st,lps22hh-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LPS22HH
-version: 0.1
 
 description: >
     This binding gives a base representation of LPS22HH pressure and

--- a/dts/bindings/sensor/st,lps25hb-press.yaml
+++ b/dts/bindings/sensor/st,lps25hb-press.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LPS25HB
-version: 0.1
 
 description: >
     This binding gives a base representation of LPS25HB pressure sensor

--- a/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
+++ b/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LSM303DLHC
-version: 0.1
 
 description: >
     This binding gives a base representation of LSM303DLHC acceleration sensor

--- a/dts/bindings/sensor/st,lsm303dlhc-magn.yaml
+++ b/dts/bindings/sensor/st,lsm303dlhc-magn.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LSM303DLHC
-version: 0.1
 
 description: >
     This binding gives a base representation of LSM303DLHC magnetometer sensor

--- a/dts/bindings/sensor/st,lsm6ds0.yaml
+++ b/dts/bindings/sensor/st,lsm6ds0.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LSM6DS0
-version: 0.1
 
 description: >
     This binding gives a base representation of LSM6DS0 6-axis accelerometer

--- a/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LSM6DSL
-version: 0.1
 
 description: >
     This binding gives a base representation of LSM6DSL 6-axis accelerometer

--- a/dts/bindings/sensor/st,lsm6dsl-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LSM6DSL SPI
-version: 0.1
 
 description: >
     This binding gives a base representation of LSM6DSL 6-axis accelerometer

--- a/dts/bindings/sensor/st,lsm6dso-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LSM6DSO
-version: 0.1
 
 description: >
     This binding gives a base representation of LSM6DSO 6-axis IMU

--- a/dts/bindings/sensor/st,lsm6dso-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LSM6DSO SPI
-version: 0.1
 
 description: >
     This binding gives a base representation of LSM6DSO 6-axis IMU

--- a/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LSM9DS0-GYRO
-version: 0.1
 
 description: >
     This binding gives a base representation of LSM9DS0 3-axis gyro

--- a/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors LSM9DS0-MFD
-version: 0.1
 
 description: >
     This binding gives a base representation of LSM9DS0 3-axis accelerometer + magnetometer

--- a/dts/bindings/sensor/st,vl53l0x.yaml
+++ b/dts/bindings/sensor/st,vl53l0x.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors VL53L0X
-version: 0.1
 
 description: >
     This binding gives a base representation of VL53L0X Time Of Flight sensor

--- a/dts/bindings/sensor/ti,hdc.yaml
+++ b/dts/bindings/sensor/ti,hdc.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Texas Instruments Temperature and Humidity Sensor
-version: 0.1
 
 description: >
     This is a representation of the TI Temperature and Humidity sensor (e.g. HDC1008)

--- a/dts/bindings/serial/altera,jtag-uart.yaml
+++ b/dts/bindings/serial/altera,jtag-uart.yaml
@@ -1,6 +1,4 @@
-
 title: Altera JTAG UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the Altera Jtag UART

--- a/dts/bindings/serial/arm,cmsdk-uart.yaml
+++ b/dts/bindings/serial/arm,cmsdk-uart.yaml
@@ -1,6 +1,4 @@
-
 title: ARM CMSDK UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the ARM CMSDK UART

--- a/dts/bindings/serial/arm,pl011.yaml
+++ b/dts/bindings/serial/arm,pl011.yaml
@@ -1,6 +1,4 @@
-
 title: ARM PL011 UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the ARM PL011 UART

--- a/dts/bindings/serial/atmel,sam-uart.yaml
+++ b/dts/bindings/serial/atmel,sam-uart.yaml
@@ -1,6 +1,4 @@
-
 title: SAM Family UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the SAM UART

--- a/dts/bindings/serial/atmel,sam-usart.yaml
+++ b/dts/bindings/serial/atmel,sam-usart.yaml
@@ -1,6 +1,4 @@
-
 title: Atmel SAM Family USART
-version: 0.1
 
 description: >
     This binding gives a base representation of the Atmel SAM USART

--- a/dts/bindings/serial/atmel,sam0-uart.yaml
+++ b/dts/bindings/serial/atmel,sam0-uart.yaml
@@ -1,6 +1,4 @@
-
 title: Atmel SAM0 SERCOM UART driver
-version: 0.1
 
 description: >
     This binding gives a base representation of the Atmel SAM0 SERCOM UART driver

--- a/dts/bindings/serial/cypress,psoc6-uart.yaml
+++ b/dts/bindings/serial/cypress,psoc6-uart.yaml
@@ -5,7 +5,6 @@
 #
 
 title: CYPRESS UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the Cypress UART

--- a/dts/bindings/serial/intel,qmsi-uart.yaml
+++ b/dts/bindings/serial/intel,qmsi-uart.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Intel QMSI Uart
-version: 0.1
 
 description: >
     This binding gives a base representation of the INTEL QMSI UART

--- a/dts/bindings/serial/litex,uart0.yaml
+++ b/dts/bindings/serial/litex,uart0.yaml
@@ -5,7 +5,6 @@
 #
 
 title: LiteX UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the LiteX UART

--- a/dts/bindings/serial/microsemi,coreuart.yaml
+++ b/dts/bindings/serial/microsemi,coreuart.yaml
@@ -5,7 +5,6 @@
 #
 
 title: SIFIVE UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the SIFIVE UART

--- a/dts/bindings/serial/nordic,nrf-uart.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart.yaml
@@ -1,6 +1,4 @@
-
 title: Nordic UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the Nordic UART

--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -1,6 +1,4 @@
-
 title: Nordic UARTE
-version: 0.1
 
 description: >
     This binding gives a base representation of the Nordic UARTE

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -1,6 +1,4 @@
-
 title: ns16550
-version: 0.1
 
 description: >
     This binding gives a base representation of the ns16550 UART

--- a/dts/bindings/serial/nxp,imx-uart.yaml
+++ b/dts/bindings/serial/nxp,imx-uart.yaml
@@ -5,7 +5,6 @@
 #
 
 title: iMX Uart
-version: 0.1
 
 description: >
     This binding gives a base representation of the iMX UART

--- a/dts/bindings/serial/nxp,kinetis-lpsci.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpsci.yaml
@@ -1,6 +1,4 @@
-
 title: Kinetis LPSCI UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the LPSCI UART

--- a/dts/bindings/serial/nxp,kinetis-lpuart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpuart.yaml
@@ -1,6 +1,4 @@
-
 title: Kinetis LPUART
-version: 0.1
 
 description: >
     This binding gives a base representation of the Kinetis LPUART

--- a/dts/bindings/serial/nxp,kinetis-uart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-uart.yaml
@@ -1,6 +1,4 @@
-
 title: Kinetis UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the Kinetis UART

--- a/dts/bindings/serial/nxp,lpc-usart.yaml
+++ b/dts/bindings/serial/nxp,lpc-usart.yaml
@@ -5,7 +5,6 @@
 #
 
 title: LPC USART
-version: 0.1
 
 description: >
     This binding gives a base representation of the LPC USART

--- a/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
+++ b/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
@@ -1,6 +1,4 @@
-
 title: OpenISA LPUART
-version: 0.1
 
 description: >
     This binding gives a base representation of the OpenISA LPUART

--- a/dts/bindings/serial/sifive,uart0.yaml
+++ b/dts/bindings/serial/sifive,uart0.yaml
@@ -5,7 +5,6 @@
 #
 
 title: SIFIVE UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the SIFIVE UART

--- a/dts/bindings/serial/silabs,gecko-leuart.yaml
+++ b/dts/bindings/serial/silabs,gecko-leuart.yaml
@@ -1,6 +1,4 @@
-
 title: GECKO LEUART
-version: 0.1
 
 description: >
     This binding gives a base representation of the Gecko LEUART

--- a/dts/bindings/serial/silabs,gecko-uart.yaml
+++ b/dts/bindings/serial/silabs,gecko-uart.yaml
@@ -1,6 +1,4 @@
-
 title: GECKO UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the GECKO UART

--- a/dts/bindings/serial/silabs,gecko-usart.yaml
+++ b/dts/bindings/serial/silabs,gecko-usart.yaml
@@ -1,6 +1,4 @@
-
 title: GECKO USART
-version: 0.1
 
 description: >
     This binding gives a base representation of the Gecko USART

--- a/dts/bindings/serial/snps,nsim-uart.yaml
+++ b/dts/bindings/serial/snps,nsim-uart.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Synopsys ARC nSIM UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the Synopsys ARC nSIM UART

--- a/dts/bindings/serial/st,stm32-lpuart.yaml
+++ b/dts/bindings/serial/st,stm32-lpuart.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 LPUART
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 LPUART

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 UART

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 USART
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 USART

--- a/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
@@ -5,7 +5,6 @@
 #
 
 title: TI SimpleLink CC13xx / CC26xx UART
-version: 0.1
 
 description: >
     This is a representation of the TI SimpleLink CC13xx / CC26xx UART node

--- a/dts/bindings/serial/ti,cc32xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc32xx-uart.yaml
@@ -1,6 +1,4 @@
-
 title: TI CC32XX Uart
-version: 0.1
 
 description: >
     This binding gives a base representation of the TI CC32XX UART

--- a/dts/bindings/serial/ti,msp432p4xx-uart.yaml
+++ b/dts/bindings/serial/ti,msp432p4xx-uart.yaml
@@ -1,6 +1,4 @@
-
 title: TI MSP432P4XX UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the TI MSP432P4XX UART

--- a/dts/bindings/serial/ti,stellaris-uart.yaml
+++ b/dts/bindings/serial/ti,stellaris-uart.yaml
@@ -1,6 +1,4 @@
-
 title: TI Stellaris UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the TI Stellaris UART

--- a/dts/bindings/serial/uart-device.yaml
+++ b/dts/bindings/serial/uart-device.yaml
@@ -5,7 +5,6 @@
 #
 
 title: UART Device Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all uart devices

--- a/dts/bindings/serial/uart.yaml
+++ b/dts/bindings/serial/uart.yaml
@@ -1,6 +1,4 @@
-
 title: Uart Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all UART devices

--- a/dts/bindings/serial/xtensa,esp32-uart.yaml
+++ b/dts/bindings/serial/xtensa,esp32-uart.yaml
@@ -1,6 +1,4 @@
-
 title: ESP32 Uart
-version: 0.1
 
 description: >
     This binding gives a base representation of the ESP32 UART

--- a/dts/bindings/serial/zephyr,native-posix-uart.yaml
+++ b/dts/bindings/serial/zephyr,native-posix-uart.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Native POSIX UART
-version: 0.1
 
 description: >
     This binding gives a base representation of the Native POSIX UART

--- a/dts/bindings/spi/atmel,sam-spi.yaml
+++ b/dts/bindings/spi/atmel,sam-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel SAM SPI driver
-version: 0.1
 
 description: >
     This binding gives a base representation of the Atmel SAM SPI controller

--- a/dts/bindings/spi/atmel,sam0-spi.yaml
+++ b/dts/bindings/spi/atmel,sam0-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel SAM0 SERCOM SPI driver
-version: 0.1
 
 description: >
     This binding gives a base representation of the Atmel SAM0 SERCOM SPI controller

--- a/dts/bindings/spi/intel,intel-spi.yaml
+++ b/dts/bindings/spi/intel,intel-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Intel SPI Controller
-version: 0.1
 
 description: >
      This is a representation of the Intel SPI controller found on quark x1000.

--- a/dts/bindings/spi/nordic,nrf-spi.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic nRF Family SPI Master node
-version: 0.1
 
 description: >
     This is a representation of the Nordic nRF SPI node

--- a/dts/bindings/spi/nordic,nrf-spis.yaml
+++ b/dts/bindings/spi/nordic,nrf-spis.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic nRF Family SPIS (SPI Slave)
-version: 0.1
 
 description: >
     This is a representation of the Nordic nRF SPIS node

--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP FlexSPI
-version: 0.1
 
 description: >
     This binding gives a base representation of the NXP FlexSPI controller

--- a/dts/bindings/spi/nxp,imx-lpspi.yaml
+++ b/dts/bindings/spi/nxp,imx-lpspi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP LPSPI
-version: 0.1
 
 description: >
     This binding gives a base representation of the NXP i.MX LPSPI controller

--- a/dts/bindings/spi/nxp,kinetis-dspi.yaml
+++ b/dts/bindings/spi/nxp,kinetis-dspi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP DSPI
-version: 0.1
 
 description: >
     This binding gives a base representation of the NXP Kinetis DSPI controller

--- a/dts/bindings/spi/sifive,spi0.yaml
+++ b/dts/bindings/spi/sifive,spi0.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Sifive SPI driver
-version: 0.1
 
 description: >
     This binding gives a base representation of the Sifive SPI controller

--- a/dts/bindings/spi/snps,designware-spi.yaml
+++ b/dts/bindings/spi/snps,designware-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Synopsys Designware SPI Controller
-version: 0.1
 
 description: >
      This is a representation of the Synopsys DesignWare spi node

--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -5,7 +5,6 @@
 #
 
 title: SPI Device Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all spi devices

--- a/dts/bindings/spi/spi.yaml
+++ b/dts/bindings/spi/spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: SPI Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all SPI devices

--- a/dts/bindings/spi/st,stm32-spi-fifo.yaml
+++ b/dts/bindings/spi/st,stm32-spi-fifo.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STM32 SPI FIFO
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 SPI controller with

--- a/dts/bindings/spi/st,stm32-spi.yaml
+++ b/dts/bindings/spi/st,stm32-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STM32 SPI
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 SPI controller

--- a/dts/bindings/spi/ti,cc13xx-cc26xx-spi.yaml
+++ b/dts/bindings/spi/ti,cc13xx-cc26xx-spi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: TI SimpleLink CC13xx / CC26xx SPI
-version: 0.1
 
 description: >
     This is a representation of the TI SimpleLink CC13xx / CC26xx SPI node

--- a/dts/bindings/sram/mmio-sram.yaml
+++ b/dts/bindings/sram/mmio-sram.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Generic on-chip SRAM
-version: 0.1
 
 description: >
     This binding gives a generic on-chip SRAM description

--- a/dts/bindings/sram/sifive,dtim0.yaml
+++ b/dts/bindings/sram/sifive,dtim0.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Data Tightly-Integrated Memory
-version: 0.1
 
 description: >
     This bindings describes the SiFive Data Tightly-Integrated Memory

--- a/dts/bindings/timer/arm,cmsdk-dtimer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-dtimer.yaml
@@ -1,6 +1,4 @@
-
 title: ARM CMSDK DUALTIMER
-version: 0.1
 
 description: >
     This binding gives a base representation of the ARM CMSDK DUALTIMER

--- a/dts/bindings/timer/arm,cmsdk-timer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-timer.yaml
@@ -1,6 +1,4 @@
-
 title: ARM CMSDK TIMER
-version: 0.1
 
 description: >
     This binding gives a base representation of the ARM CMSDK TIMER

--- a/dts/bindings/timer/atmel,sam0-tc32.yaml
+++ b/dts/bindings/timer/atmel,sam0-tc32.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel SAM0 32-bit Basic Timer
-version: 0.1
 
 description: >
     This binding gives a base representation of the Atmel SAM0 timer

--- a/dts/bindings/timer/litex,timer0.yaml
+++ b/dts/bindings/timer/litex,timer0.yaml
@@ -5,7 +5,6 @@
 #
 
 title: LiteX timer
-version: 0.1
 
 description: >
     This binding gives a base representation of the LiteX timer

--- a/dts/bindings/timer/nordic,nrf-timer.yaml
+++ b/dts/bindings/timer/nordic,nrf-timer.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic nRF timer
-version: 0.1
 
 description: >
     This is a representation of the Nordic nRF timer node

--- a/dts/bindings/timer/nxp,imx-gpt.yaml
+++ b/dts/bindings/timer/nxp,imx-gpt.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: NXP MCUX General Purpose Timer
-version: 0.1
 
 description: >
     This is a representation of the NXP MCUX General Purpose Timer (GPT)

--- a/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
+++ b/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
@@ -1,6 +1,4 @@
-
 title: OpenISA RV32M1 LPTMR
-version: 0.1
 
 description: >
     This binding represents the OpenISA RV32M1 LPTMR peripheral.

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -1,6 +1,4 @@
-
 title: STM32 TIMERS
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 TIMERS

--- a/dts/bindings/usb/atmel,sam-usbhs.yaml
+++ b/dts/bindings/usb/atmel,sam-usbhs.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel SAM USBHS
-version: 0.1
 
 description: >
     Atmel SAM Family USB (USBHS) in device mode

--- a/dts/bindings/usb/atmel,sam0-usb.yaml
+++ b/dts/bindings/usb/atmel,sam0-usb.yaml
@@ -1,6 +1,4 @@
-
 title: Atmel SAM0 USB device
-version: 0.1
 
 description: >
     Atmel SAM0 USB in device mode

--- a/dts/bindings/usb/nordic,nrf-usbd.yaml
+++ b/dts/bindings/usb/nordic,nrf-usbd.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic nRF52 USBD
-version: 0.1
 
 description: >
     This binding gives a base representation of the Nordic nRF52 USB device controller

--- a/dts/bindings/usb/nxp,kinetis-usbd.yaml
+++ b/dts/bindings/usb/nxp,kinetis-usbd.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP Kinetis USBD
-version: 0.1
 
 description: >
     NPX Kinetis USBFSOTG Controller in device mode

--- a/dts/bindings/usb/st,stm32-otgfs.yaml
+++ b/dts/bindings/usb/st,stm32-otgfs.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STM32 OTGFS
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 OTGFS controller

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STM32 OTGHS
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 OTG HS controller

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STM32 USB
-version: 0.1
 
 description: >
     This binding gives a base representation of the STM32 USB controller

--- a/dts/bindings/usb/usb-ep.yaml
+++ b/dts/bindings/usb/usb-ep.yaml
@@ -5,7 +5,6 @@
 #
 
 title: USB Endpoints' properties
-version: 0.1
 
 description: >
     This binding gives number of endpoints that the USB hardware supports

--- a/dts/bindings/usb/usb.yaml
+++ b/dts/bindings/usb/usb.yaml
@@ -5,7 +5,6 @@
 #
 
 title: USB Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all USB devices

--- a/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
+++ b/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
@@ -1,6 +1,4 @@
-
 title: ARM CMSDK WATCHDOG
-version: 0.1
 
 description: >
     This binding gives a base representation of the ARM CMSDK WATCHDOG

--- a/dts/bindings/watchdog/atmel,sam-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam-watchdog.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel SAM watchdog driver
-version: 0.1
 
 description: >
     This is a representation of the SAM0 watchdog

--- a/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
@@ -1,6 +1,4 @@
-
 title: Atmel SAM0 watchdog driver
-version: 0.1
 
 description: >
     This is a representation of the SAM0 watchdog

--- a/dts/bindings/watchdog/intel,qmsi-watchdog.yaml
+++ b/dts/bindings/watchdog/intel,qmsi-watchdog.yaml
@@ -5,7 +5,6 @@
 #
 
 title: QMSI watchdog driver
-version: 0.1
 
 description: >
     This is a representation of the QMSI watchdog

--- a/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
+++ b/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Nordic Semiconductor NRF watchdog driver
-version: 0.1
 
 description: >
     This is a representation of the NRF watchdog

--- a/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP Kinetis watchdog driver
-version: 0.1
 
 description: >
     This is a representation of the Kinetis watchdog

--- a/dts/bindings/watchdog/nxp,kinetis-wdog32.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog32.yaml
@@ -5,7 +5,6 @@
 #
 
 title: NXP Kinetis watchdog (WDOG32) driver
-version: 0.1
 
 description: >
     This is a representation of the Kinetis watchdog (WDOG32)

--- a/dts/bindings/watchdog/st,stm32-watchdog.yaml
+++ b/dts/bindings/watchdog/st,stm32-watchdog.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics STM32 watchdog driver
-version: 0.1
 
 description: >
     This is a representation of the STM32 watchdog

--- a/dts/bindings/wifi/atmel,winc1500.yaml
+++ b/dts/bindings/wifi/atmel,winc1500.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Atmel WINC1500 Wifi module
-version: 0.1
 
 description: >
     This binding gives the base representation of the Atmel WINC1500 Wifi module

--- a/dts/bindings/wifi/inventek,eswifi.yaml
+++ b/dts/bindings/wifi/inventek,eswifi.yaml
@@ -5,7 +5,6 @@
 #
 
 title: Inventek eS-WiFi WiFi module
-version: 0.1
 
 description: >
     This binding gives the base representation of es-WiFi module

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -237,7 +237,7 @@ def check_binding_properties(node):
     if 'title' not in node:
         print("extract_dts_includes.py: node without 'title' -", node)
 
-    for prop in 'title', 'version', 'description':
+    for prop in 'title', 'description':
         if prop not in node:
             node[prop] = "<unknown {}>".format(prop)
             print("extract_dts_includes.py: '{}' property missing "


### PR DESCRIPTION
No binding has anything but `version: 0.1`, and the code in `scripts/dts/`
never does anything with it except print a warning if it isn't there.
It's undocumented what it means.

I suspect it's overkill if it's meant to be the binding format version.
If we'd need to tell different versions from each other, we could change
some other minor thing in the format, and it probably won't be needed.

Remove the `version` fields from the bindings and the warning from the
`scripts/dts/` scripts.

The new device tree script will give an error when unknown fields appear
in bindings.

The deletion was done with

    git ls-files 'dts/bindings/*.yaml' | xargs sed -i '/^\s*version: /d'

Some blank lines at the beginning of bindings were removed as well.