### PR TITLE
MISRA-C Use gcc flags to enforce some rules

### DIFF
--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -8,8 +8,10 @@ macro(toolchain_cc_warning_base)
     -Wall
     -Wformat
     -Wformat-security
+    -Wmissing-parameter-type
     -Wno-format-zero-length
     -Wno-main
+    -Wold-style-declaration
     -Woverride-init
   )
 

--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -10,6 +10,7 @@ macro(toolchain_cc_warning_base)
     -Wformat-security
     -Wno-format-zero-length
     -Wno-main
+    -Woverride-init
   )
 
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "9.1.0")

--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -13,6 +13,12 @@ macro(toolchain_cc_warning_base)
     -Woverride-init
   )
 
+if(CMAKE_C_COMPILER_VERSION VERSION_GREATER "7.1.0")
+  zephyr_compile_options(
+    -Wimplicit-fallthrough=2
+    )
+endif()
+
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "9.1.0")
   zephyr_compile_options(
     # FIXME: Remove once #16587 is fixed

--- a/cmake/compiler/gcc/target_warnings.cmake
+++ b/cmake/compiler/gcc/target_warnings.cmake
@@ -6,6 +6,7 @@ macro(toolchain_cc_warning_base)
 
   zephyr_compile_options(
     -Wall
+    -Wempty-body
     -Wformat
     -Wformat-security
     -Wmissing-parameter-type

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -285,6 +285,7 @@ static inline void handle_rxne(struct device *dev)
 		case 2:
 			LL_I2C_AcknowledgeNextData(i2c, LL_I2C_NACK);
 			LL_I2C_EnableBitPOS(i2c);
+			/* Fallthrough */
 		case 3:
 			/*
 			 * 2-byte, 3-byte reception and for N-2, N-1,

--- a/drivers/timer/apic_timer.c
+++ b/drivers/timer/apic_timer.c
@@ -217,6 +217,8 @@ int z_clock_driver_init(struct device *device)
 {
 	u32_t val;
 
+	ARG_UNUSED(device);
+
 	val = x86_read_loapic(LOAPIC_TIMER_CONFIG);	/* set divider */
 	val &= ~DCR_DIVIDER_MASK;
 	val |= DCR_DIVIDER;

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -101,6 +101,8 @@ void z_clock_isr(void *arg)
 
 int z_clock_driver_init(struct device *device)
 {
+	ARG_UNUSED(device);
+
 	NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
 	last_load = CYC_PER_TICK - 1;
 	overflow_cyc = 0U;

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -69,6 +69,8 @@ int z_clock_driver_init(struct device *device)
 	extern int z_clock_hw_cycles_per_sec;
 	u32_t hz;
 
+	ARG_UNUSED(device);
+
 	IRQ_CONNECT(CONFIG_HPET_TIMER_IRQ, CONFIG_HPET_TIMER_IRQ_PRIORITY,
 		    hpet_isr, 0, 0);
 	set_timer0_irq(CONFIG_HPET_TIMER_IRQ);

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -73,6 +73,8 @@ static void timer_isr(void *arg)
 
 int z_clock_driver_init(struct device *device)
 {
+	ARG_UNUSED(device);
+
 	IRQ_CONNECT(RISCV_MACHINE_TIMER_IRQ, 0, timer_isr, NULL, 0);
 	set_mtimecmp(mtime() + CYC_PER_TICK);
 	irq_enable(RISCV_MACHINE_TIMER_IRQ);

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -25,6 +25,8 @@ void __weak z_clock_isr(void *arg)
 
 int __weak z_clock_driver_init(struct device *device)
 {
+	ARG_UNUSED(device);
+
 	return 0;
 }
 

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -70,6 +70,8 @@ void timer_int_handler(void *arg)
 
 int z_clock_driver_init(struct device *device)
 {
+	ARG_UNUSED(device);
+
 	IRQ_CONNECT(TIMER_IRQ, 0, ccompare_isr, 0, 0);
 	set_ccompare(ccount() + CYC_PER_TICK);
 	irq_enable(TIMER_IRQ);

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1821,11 +1821,18 @@ struct k_queue {
 	_OBJECT_TRACING_NEXT_PTR(k_queue)
 };
 
+#ifndef CONFIG_POLL
+#define _INIT_K_QUEUE_ENUM(obj) \
+	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q),
+#else
+#define _INIT_K_QUEUE_ENUM(obj) \
+	_POLL_EVENT_OBJ_INIT(obj)
+#endif
+
 #define _K_QUEUE_INITIALIZER(obj) \
 	{ \
 	.data_q = SYS_SLIST_STATIC_INIT(&obj.data_q), \
-	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q), \
-	_POLL_EVENT_OBJ_INIT(obj) \
+	_INIT_K_QUEUE_ENUM(obj) \
 	_OBJECT_TRACING_INIT \
 	}
 

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -28,6 +28,14 @@
 #define BUILD_ASSERT_MSG(EXPR, MSG) _Static_assert(EXPR, MSG)
 #endif
 
+#if (__GNUC__ >= 7 && __GNUC_MINOR__ >= 1)
+#define DISABLE_FALLTHROUGH \
+	_Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"")
+#else
+#define DISABLE_FALLTHROUGH
+#endif
+
+
 #include <toolchain/common.h>
 #include <stdbool.h>
 

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -22,7 +22,7 @@ extern "C" {
 
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 
-static inline void z_init_timeout(struct _timeout *t, _timeout_func_t fn)
+static inline void z_init_timeout(struct _timeout *t)
 {
 	sys_dnode_init(&t->node);
 }
@@ -38,7 +38,7 @@ static inline bool z_is_inactive_timeout(struct _timeout *t)
 
 static inline void z_init_thread_timeout(struct _thread_base *thread_base)
 {
-	z_init_timeout(&thread_base->timeout, NULL);
+	z_init_timeout(&thread_base->timeout);
 }
 
 extern void z_thread_timeout(struct _timeout *to);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -95,7 +95,7 @@ void k_timer_init(struct k_timer *timer,
 	timer->status = 0U;
 
 	z_waitq_init(&timer->wait_q);
-	z_init_timeout(&timer->timeout, z_timer_expiration_handler);
+	z_init_timeout(&timer->timeout);
 	SYS_TRACING_OBJ_INIT(k_timer, timer);
 
 	timer->user_data = NULL;

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -48,7 +48,7 @@ static void work_timeout(struct _timeout *t)
 void k_delayed_work_init(struct k_delayed_work *work, k_work_handler_t handler)
 {
 	k_work_init(&work->work, handler);
-	z_init_timeout(&work->timeout, work_timeout);
+	z_init_timeout(&work->timeout);
 	work->work_q = NULL;
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -12533,7 +12533,7 @@ void ll_rx_mem_release(void **node_rx)
 					break;
 				}
 			}
-			/* passthrough */
+			/* fallthrough */
 		case NODE_RX_TYPE_DC_PDU:
 #endif /* CONFIG_BT_CONN */
 

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -1918,7 +1918,7 @@ static inline u32_t isr_rx_conn_pkt_ack(struct pdu_data *pdu_data_tx,
 		    PDU_DATA_LLCTRL_TYPE_ENC_REQ) {
 			break;
 		}
-		/* Pass through */
+		/* Fall through */
 
 	case PDU_DATA_LLCTRL_TYPE_REJECT_IND:
 		/* resume data packet rx and tx */

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -724,7 +724,7 @@ void ll_rx_mem_release(void **node_rx)
 			}
 		}
 #endif /* CONFIG_BT_CENTRAL */
-		/* passthrough */
+		/* fallthrough */
 		case NODE_RX_TYPE_DC_PDU:
 #endif /* CONFIG_BT_CONN */
 

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -473,6 +473,12 @@ void ll_rx_dequeue(void)
 
 	mem_release(link, &mem_link_rx.free);
 
+	/* GCC is not able to recognize comments in clause under ifdef.
+	 * Disabling -Wimplicit-fallthrough warning in this switch.
+	 */
+#pragma GCC diagnostic push
+	DISABLE_FALLTHROUGH;
+
 	/* handle object specific clean up */
 	switch (rx->type) {
 #if defined(CONFIG_BT_OBSERVER) || \
@@ -580,6 +586,7 @@ void ll_rx_dequeue(void)
 		LL_ASSERT(0);
 		break;
 	}
+#pragma GCC diagnostic pop
 
 	if (0) {
 #if defined(CONFIG_BT_CONN)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4290,7 +4290,7 @@ static inline void ctrl_tx_pre_ack(struct ll_conn *conn,
 		if (!conn->lll.role) {
 			break;
 		}
-		/* Pass Through */
+		/* Fall through */
 
 	case PDU_DATA_LLCTRL_TYPE_ENC_REQ:
 	case PDU_DATA_LLCTRL_TYPE_ENC_RSP:

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4395,7 +4395,7 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 		    PDU_DATA_LLCTRL_TYPE_ENC_REQ) {
 			break;
 		}
-		/* Pass through */
+		/* Falls through */
 
 	case PDU_DATA_LLCTRL_TYPE_REJECT_IND:
 		/* resume data packet rx and tx */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2270,7 +2270,7 @@ struct bt_conn *bt_conn_create_slave_le(const bt_addr_le_t *peer,
 				bt_conn_unref(conn);
 				return NULL;
 			}
-
+			/* fallthrough */
 		case BT_CONN_CONNECT:
 		case BT_CONN_CONNECTED:
 			return conn;

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1064,6 +1064,7 @@ static void le_conn_rsp(struct bt_l2cap *l2cap, u8_t ident,
 			return;
 		}
 		bt_l2cap_chan_remove(conn, &chan->chan);
+		/* fallthrough */
 	default:
 		bt_l2cap_chan_del(&chan->chan);
 	}

--- a/subsys/disk/disk_access_usdhc.c
+++ b/subsys/disk/disk_access_usdhc.c
@@ -1953,6 +1953,7 @@ static int usdhc_select_bus_timing(struct usdhc_priv *priv)
 						SDMMCHOST_SUPPORT_SDR104_FREQ);
 				break;
 			}
+			/* fallthrough */
 		case SD_TIMING_DDR50_MODE:
 			error = usdhc_select_fun(priv, SD_GRP_TIMING_MODE,
 				SD_TIMING_DDR50_MODE);

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -194,7 +194,7 @@ static void ipv4_autoconf_send(struct net_if_ipv4_autoconf *ipv4auto)
 			ipv4_autoconf_send_probe(ipv4auto);
 			break;
 		}
-	/* passthrough */
+	/* fallthrough */
 	case NET_IPV4_AUTOCONF_ANNOUNCE:
 		if (ipv4auto->announce_cnt <=
 		    (IPV4_AUTOCONF_ANNOUNCE_NUM - 1)) {

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -163,7 +163,7 @@ static inline bool ipv6_drop_on_unknown_option(struct net_pkt *pkt,
 			break;
 		}
 
-		/* passthrough */
+		/* fallthrough */
 	case 0x80:
 		net_icmpv6_send_error(pkt, NET_ICMPV6_PARAM_PROBLEM,
 				      NET_ICMPV6_PARAM_PROB_OPTION,

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1456,7 +1456,7 @@ static void ipv6_nd_reachable_timeout(struct k_work *work)
 				log_strdup(net_sprint_ipv6_addr(&data->addr)),
 				data->state);
 
-			/* Intentionally continuing to probe state */
+			/* Intentionally fallthrough to probe state */
 
 		case NET_IPV6_NBR_STATE_PROBE:
 			if (data->ns_count >= MAX_UNICAST_SOLICIT) {

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1001,6 +1001,18 @@ void dns_init_resolver(void)
 		count = 5;
 	}
 
+	/* GCC is not recognizing the comments in clause under
+	 * ifdef. Disabling this check in this switch statment to
+	 * avoid warning messages.
+	 * There are other two solutions but they seem more intrusive:
+	 * a) use __attribute__(fallthrough)
+	 * b) ask the preprocessor to keep all comments using -C option.
+	 *    But this can cause some side effects because causes the
+	 *    preprocessor to treat comments as tokens in their own right.
+	 */
+#pragma GCC diagnostic push
+	DISABLE_FALLTHROUGH;
+
 	switch (count) {
 #if DNS_SERVER_COUNT > 4
 	case 5:
@@ -1030,6 +1042,8 @@ void dns_init_resolver(void)
 	case 0:
 		break;
 	}
+
+#pragma GCC diagnostic pop
 
 #if defined(CONFIG_MDNS_RESOLVER) && (MDNS_SERVER_COUNT > 0)
 #if defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_IPV4)

--- a/subsys/net/lib/http/http_parser.c
+++ b/subsys/net/lib/http/http_parser.c
@@ -1858,6 +1858,7 @@ reexecute:
 
 				case 2:
 					parser->upgrade = 1U;
+					/* fallthrough */
 
 				case 1:
 					parser->flags |= F_SKIPBODY;

--- a/subsys/net/lib/http/http_parser_url.c
+++ b/subsys/net/lib/http/http_parser_url.c
@@ -502,7 +502,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
 		case s_req_server_with_at:
 			found_at = 1;
 
-		/* FALLTROUGH */
+		/* FALLTHROUGH */
 		case s_req_server:
 			uf = UF_HOST;
 			break;

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -490,6 +490,8 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 		case dfuIDLE:
 			dfu_reset_counters();
 			LOG_DBG("DFU_UPLOAD start");
+			/* fallthrough */
+
 		case dfuUPLOAD_IDLE:
 			if (!pSetup->wLength ||
 			    dfu_data.block_nr != pSetup->wValue) {
@@ -743,6 +745,7 @@ static void dfu_work_handler(struct k_work *item)
 			break;
 		}
 #endif
+		/* fallthrough */
 	case dfuDNLOAD_IDLE:
 		dfu_flash_write(dfu_data_worker.buf,
 				dfu_data_worker.worker_len);


### PR DESCRIPTION
GCC contains warning flags that can partially help spot MISRA-C violations. This pr is enforcing checks for rules:

8.2, 8.3, 8.4, 16.1 and 16.3