### PR TITLE
i2c_ll_stm32_v2: Set slave_attached to false on slave unregister

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -246,6 +246,8 @@ int i2c_stm32_slave_unregister(struct device *dev,
 
 	LL_I2C_Disable(i2c);
 
+	data->slave_attached = false;
+
 	LOG_DBG("i2c: slave unregistered");
 
 	return 0;


### PR DESCRIPTION
Set slave_attached to false before exit
i2c_stm32_slave_unregister().

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>