### PR TITLE
subsys/fs: remove FS_FLASH_STORAGE_PARTITION

### DIFF
--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -4,10 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# Hidden. Automatically selected by file systems or FCB that need it
-config FS_FLASH_STORAGE_PARTITION
-	bool
-
 menu "File Systems"
 
 config FILE_SYSTEM
@@ -38,7 +34,6 @@ config FAT_FILESYSTEM_ELM
 config FILE_SYSTEM_NFFS
 	bool "NFFS file system support"
 	depends on FLASH_PAGE_LAYOUT
-	select FS_FLASH_STORAGE_PARTITION
 	help
 	  Enables NFFS file system support.
 	  Note: NFFS requires 1-byte unaligned access to flash thus it

--- a/subsys/fs/fcb/Kconfig
+++ b/subsys/fs/fcb/Kconfig
@@ -12,6 +12,5 @@
 config FCB
 	bool "Flash Circular Buffer support"
 	depends on FLASH_MAP
-	select FS_FLASH_STORAGE_PARTITION
 	help
 	  Enable support of Flash Circular Buffer.

--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -8,7 +8,6 @@
 
 config NVS
 	bool "Non-volatile Storage"
-	select FS_FLASH_STORAGE_PARTITION
 	help
 	  Enable support of Non-volatile Storage.
 


### PR DESCRIPTION
The last reference to this symbol was removed when flash area management
moved to devicetree.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>