### PR TITLE
spi_nor: devicetree, driver, and sample cleanup

### DIFF
--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -132,7 +132,7 @@
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		label = "MX25R64";
-		jedec-id = <0xc2 0x28 0x17>;
+		jedec-id = [c2 28 17];
 		size = <67108864>;
 		wp-gpios = <&gpio0 22 0>;
 		hold-gpios = <&gpio0 23 0>;

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -57,7 +57,7 @@ arduino_serial: &uart4 {};
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
-		jedec-id = <0x1f 0x89 0x01>;
+		jedec-id = [1f 89 01];
 	};
 };
 

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -65,7 +65,7 @@ arduino_serial: &uart2 {};
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
-		jedec-id = <0x9d 0x70 0x17>;
+		jedec-id = [9d 70 17];
 	};
 };
 

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -16,6 +16,6 @@
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
-		jedec-id = <0x9d 0x70 0x17>;
+		jedec-id = [9d 70 17];
 	};
 };

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -71,7 +71,7 @@ arduino_serial: &uart3 {};
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
-		jedec-id = <0x9d 0x70 0x17>;
+		jedec-id = [9d 70 17];
 	};
 };
 

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -174,7 +174,7 @@
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		label = "MX25R64";
-		jedec-id = <0xc2 0x28 0x17>;
+		jedec-id = [c2 28 17];
 		size = <67108864>;
 		has-be32k;
 		wp-gpios = <&gpio0 22 0>;

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -176,6 +176,7 @@
 		label = "MX25R64";
 		jedec-id = <0xc2 0x28 0x17>;
 		size = <67108864>;
+		has-be32k;
 		wp-gpios = <&gpio0 22 0>;
 		hold-gpios = <&gpio0 23 0>;
 	};

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -169,7 +169,7 @@
 	mosi-pin = <20>;
 	miso-pin = <21>;
 	cs-gpios = <&gpio0 17 0>, <&gpio1 5 0>;
-	mx25r6435f@0 {
+	mx25r64: mx25r6435f@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <80000000>;

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -131,13 +131,15 @@
 	mosi-pin = <20>;
 	miso-pin = <21>;
 	cs-gpios = <&gpio0 17 0>;
-	gd25q32c@0 {
+	mx25l32: mx25l3233f@0 {
 		compatible = "jedec,spi-nor";
-		label = "GD25Q32C";
+		label = "MX25L3233F";
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		wp-gpios = <&gpio0 22 0>;
 		hold-gpios = <&gpio0 23 0>;
+		size = <0x2000000>;
+		has-be32k;
 		jedec-id = <0xc2 0x20 0x16>;
 	};
 };

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -140,7 +140,7 @@
 		hold-gpios = <&gpio0 23 0>;
 		size = <0x2000000>;
 		has-be32k;
-		jedec-id = <0xc2 0x20 0x16>;
+		jedec-id = [c2 20 16];
 	};
 };
 

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -131,13 +131,15 @@
 	mosi-pin = <20>;
 	miso-pin = <21>;
 	cs-gpios = <&gpio0 17 0>;
-	gd25q32c@0 {
+	mx25l32: mx25l3233f@0 {
 		compatible = "jedec,spi-nor";
-		label = "GD25Q32C";
+		label = "MX25L3233F";
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		wp-gpios = <&gpio0 22 0>;
 		hold-gpios = <&gpio0 23 0>;
+		size = <0x2000000>;
+		has-be32k;
 		jedec-id = <0xc2 0x20 0x16>;
 	};
 };

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -140,7 +140,7 @@
 		hold-gpios = <&gpio0 23 0>;
 		size = <0x2000000>;
 		has-be32k;
-		jedec-id = <0xc2 0x20 0x16>;
+		jedec-id = [c2 20 16];
 	};
 };
 

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -131,13 +131,15 @@
 	mosi-pin = <20>;
 	miso-pin = <21>;
 	cs-gpios = <&gpio0 17 0>;
-	gd25q32c@0 {
+	mx25l32: mx25l3233f@0 {
 		compatible = "jedec,spi-nor";
-		label = "GD25Q32C";
+		label = "MX25L3233F";
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		wp-gpios = <&gpio0 22 0>;
 		hold-gpios = <&gpio0 23 0>;
+		size = <0x2000000>;
+		has-be32k;
 		jedec-id = <0xc2 0x20 0x16>;
 	};
 };

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -140,7 +140,7 @@
 		hold-gpios = <&gpio0 23 0>;
 		size = <0x2000000>;
 		has-be32k;
-		jedec-id = <0xc2 0x20 0x16>;
+		jedec-id = [c2 20 16];
 	};
 };
 

--- a/boards/riscv32/hifive1/hifive1.dts
+++ b/boards/riscv32/hifive1/hifive1.dts
@@ -64,7 +64,7 @@
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";
 		label = "FLASH0";
-		jedec-id = <0x96 0x60 0x18>;
+		jedec-id = [96 60 18];
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 	};

--- a/boards/riscv32/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv32/hifive1_revb/hifive1_revb.dts
@@ -62,7 +62,7 @@
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";
 		label = "FLASH0";
-		jedec-id = <0x96 0x60 0x18>;
+		jedec-id = [96 60 18];
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 	};

--- a/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
+++ b/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
@@ -40,7 +40,7 @@
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";
 		label = "FLASH0";
-		jedec-id = <0x96 0x60 0x18>;
+		jedec-id = [96 60 18];
 		reg = <0>;
 		// Dummy entry
 		spi-max-frequency = <0>;

--- a/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
@@ -174,12 +174,6 @@ config SPI
 config SPI_NOR
 	default y
 
-config SPI_NOR_PAGE_SIZE
-	default 256
-
-config SPI_NOR_SECTOR_SIZE
-	default 4096
-
 config FLASH_HAS_PAGE_LAYOUT
 	default y
 

--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
@@ -55,7 +55,6 @@
 		label = "MX25UM512";
 		jedec-id = <0xc2 0x80 0x3a>;
 		size = <0x2000000>;
-		erase-block-size = <0x10000>;
 		write-block-size = <1>;
 	};
 };

--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
@@ -55,7 +55,6 @@
 		label = "MX25UM512";
 		jedec-id = <0xc2 0x80 0x3a>;
 		size = <0x2000000>;
-		write-block-size = <1>;
 	};
 };
 

--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
@@ -53,7 +53,7 @@
 		reg = <0>;
 		spi-max-frequency = <2000000>;
 		label = "MX25UM512";
-		jedec-id = <0xc2 0x80 0x3a>;
+		jedec-id = [c2 80 3a];
 		size = <0x2000000>;
 	};
 };

--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -30,12 +30,14 @@ config SPI_NOR_PAGE_SIZE
 	int "Page size of SPI flash"
 	default 0
 	help
-	This option specifies page size of SPI flash
+	  Note: This option is deprecated and is ignored.  Page size is
+	  always 256.
 
 config SPI_NOR_SECTOR_SIZE
 	int "Sector size of SPI flash"
 	default 0
 	help
-	This option specifies sector size of SPI flash
+	  Note: This option is deprecated and is ignored.  Sector size
+	  is always 4096.
 
 endif # SPI_NOR

--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -26,6 +26,15 @@ config SPI_NOR_CS_WAIT_DELAY
 	help
 	This is the wait delay (in us) to allow for CS switching to take effect
 
+config SPI_NOR_FLASH_LAYOUT_PAGE_SIZE
+	int "Page size to use for FLASH_LAYOUT feature"
+	default 65536
+	help
+	  When CONFIG_FLASH_PAGE_LAYOUT is used this driver will support
+	  that API.  By default the page size corresponds to the block
+	  size (65536).  Other options include the 32K-byte erase size
+	  (32768), and the sector size (4096).
+
 config SPI_NOR_PAGE_SIZE
 	int "Page size of SPI flash"
 	default 0

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -358,14 +358,26 @@ static int spi_nor_init(struct device *dev)
 }
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
+
+/* instance 0 size in bytes */
+#define INST_0_BYTES (DT_INST_0_JEDEC_SPI_NOR_SIZE / 8)
+
+/* instance 0 page count */
+#define LAYOUT_PAGES_COUNT (INST_0_BYTES / CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE)
+
+BUILD_ASSERT_MSG((CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE * LAYOUT_PAGES_COUNT)
+		 == INST_0_BYTES,
+		 "SPI_NOR_FLASH_LAYOUT_PAGE_SIZE incompatible with flash size");
+
 static const struct flash_pages_layout dev_layout = {
-	.pages_count = DT_INST_0_JEDEC_SPI_NOR_SIZE / 8 / SPI_NOR_BLOCK_SIZE,
-	.pages_size = SPI_NOR_BLOCK_SIZE,
+	.pages_count = LAYOUT_PAGES_COUNT,
+	.pages_size = CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE,
 };
+#undef LAYOUT_PAGES_COUNT
 
 static void spi_nor_pages_layout(struct device *dev,
-				const struct flash_pages_layout **layout,
-				size_t *layout_size)
+				 const struct flash_pages_layout **layout,
+				 size_t *layout_size)
 {
 	*layout = &dev_layout;
 	*layout_size = 1;

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -380,7 +380,7 @@ static const struct flash_driver_api spi_nor_api = {
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 	.page_layout = spi_nor_pages_layout,
 #endif
-	.write_block_size = DT_JEDEC_SPI_NOR_0_WRITE_BLOCK_SIZE,
+	.write_block_size = 1,
 };
 
 static const struct spi_nor_config flash_id = {

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -396,11 +396,7 @@ static const struct flash_driver_api spi_nor_api = {
 };
 
 static const struct spi_nor_config flash_id = {
-	.id = {
-		DT_INST_0_JEDEC_SPI_NOR_JEDEC_ID_0,
-		DT_INST_0_JEDEC_SPI_NOR_JEDEC_ID_1,
-		DT_INST_0_JEDEC_SPI_NOR_JEDEC_ID_2,
-	},
+	.id = DT_INST_0_JEDEC_SPI_NOR_JEDEC_ID,
 #ifdef DT_INST_0_JEDEC_SPI_NOR_HAS_BE32K
 	.has_be32k = true,
 #endif /* DT_INST_0_JEDEC_SPI_NOR_HAS_BE32K */

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -11,8 +11,12 @@
 #include <drivers/spi.h>
 #include <init.h>
 #include <string.h>
+#include <logging/log.h>
+
 #include "spi_nor.h"
 #include "flash_priv.h"
+
+LOG_MODULE_REGISTER(spi_nor, CONFIG_FLASH_LOG_LEVEL);
 
 #define SPI_NOR_MAX_ADDR_WIDTH 4
 
@@ -277,6 +281,7 @@ static int spi_nor_erase(struct device *dev, off_t addr, size_t size)
 		} else {
 			/* minimal erase size is at least a sector size */
 			SYNC_UNLOCK();
+			LOG_DBG("unsupported at %x size %u", (u32_t)addr, size);
 			return -EINVAL;
 		}
 

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -12,10 +12,14 @@
 #define SPI_NOR_MAX_ID_LEN	3
 
 struct spi_nor_config {
+	/* JEDEC id from devicetree */
 	u8_t id[SPI_NOR_MAX_ID_LEN];
-	u32_t page_size;
-	u32_t sector_size;
-	u32_t n_sectors;
+
+	/* Indicates support for BE32K */
+	bool has_be32k;
+
+	/* Size from devicetree, in bytes */
+	u32_t size;
 };
 
 /* Status register bits */
@@ -34,5 +38,21 @@ struct spi_nor_config {
 #define SPI_NOR_CMD_BE          0xD8    /* Block erase */
 #define SPI_NOR_CMD_CE          0xC7    /* Chip erase */
 #define SPI_NOR_CMD_RDID        0x9F    /* Read JEDEC ID */
+
+/* Page, sector, and block size are standard, not configurable. */
+#define SPI_NOR_PAGE_SIZE    0x0100U
+#define SPI_NOR_SECTOR_SIZE  0x1000U
+#define SPI_NOR_BLOCK_SIZE   0x10000U
+
+/* Some devices support erase operations on 32 KiBy blocks.
+ * Support is indicated by the has-be32k property.
+ */
+#define SPI_NOR_BLOCK32_SIZE 0x8000
+
+/* Test whether offset is aligned. */
+#define SPI_NOR_IS_PAGE_ALIGNED(_ofs) (((_ofs) & (SPI_NOR_PAGE_SIZE - 1U)) == 0)
+#define SPI_NOR_IS_SECTOR_ALIGNED(_ofs) (((_ofs) & (SPI_NOR_SECTOR_SIZE - 1U)) == 0)
+#define SPI_NOR_IS_BLOCK_ALIGNED(_ofs) (((_ofs) & (SPI_NOR_BLOCK_SIZE - 1U)) == 0)
+#define SPI_NOR_IS_BLOCK32_ALIGNED(_ofs) (((_ofs) & (SPI_NOR_BLOCK32_SIZE - 1U)) == 0)
 
 #endif /*__SPI_NOR_H__*/

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -15,6 +15,6 @@
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
-		jedec-id = <0xef 0x40 0x16>;
+		jedec-id = [ef 40 16];
 	};
 };

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -22,10 +22,10 @@ properties:
     category: required
     description: JEDEC ID as manufacturer ID, memory type, memory density
 
-  erase-block-size:
-   type: int
-   description: address alignment required by flash erase operations
-   category: optional
+  has-be32k:
+    type: boolean
+    category: optional
+    description: Indicates the device supports the BE32K command
 
   write-block-size:
    type: int

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -18,7 +18,7 @@ properties:
     constraint: "jedec,spi-nor"
 
   jedec-id:
-    type: array
+    type: uint8-array
     category: required
     description: JEDEC ID as manufacturer ID, memory type, memory density
 

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -27,11 +27,6 @@ properties:
     category: optional
     description: Indicates the device supports the BE32K command
 
-  write-block-size:
-   type: int
-   description: address alignment required by flash write operations
-   category: optional
-
   size:
     type: int
     category: optional

--- a/samples/drivers/spi_flash/boards/nrf52840_pca10056.conf
+++ b/samples/drivers/spi_flash/boards/nrf52840_pca10056.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2019 Peter Bigot Consulting, LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI_NOR=y

--- a/samples/drivers/spi_flash/boards/particle_xenon.conf
+++ b/samples/drivers/spi_flash/boards/particle_xenon.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2019 Peter Bigot Consulting, LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI_NOR=y

--- a/samples/drivers/spi_flash/sample.yaml
+++ b/samples/drivers/spi_flash/sample.yaml
@@ -3,7 +3,7 @@ sample:
 tests:
   sample.driver.spi_flash:
     tags: spi flash
-    filter: DT_INST_0_JEDEC_SPI_NOR_BUS_NAME
+    filter: DT_INST_0_JEDEC_SPI_NOR_LABEL
     harness: console
     harness_config:
         type: multi_line

--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -9,6 +9,17 @@
 #include <device.h>
 #include <stdio.h>
 
+#if (CONFIG_SPI_FLASH_W25QXXDV - 0)
+/* NB: W25Q16DV is a JEDEC spi-nor device, but has a separate driver. */
+#define FLASH_DEVICE CONFIG_SPI_FLASH_W25QXXDV_DRV_NAME
+#define FLASH_NAME "W25QXXDV"
+#elif (CONFIG_SPI_NOR - 0) || defined(DT_INST_0_JEDEC_SPI_NOR_LABEL)
+#define FLASH_DEVICE DT_INST_0_JEDEC_SPI_NOR_LABEL
+#define FLASH_NAME "JEDEC SPI-NOR"
+#else
+#error Unsupported flash driver
+#endif
+
 #define FLASH_TEST_REGION_OFFSET 0xff000
 #define FLASH_SECTOR_SIZE        4096
 #define TEST_DATA_BYTE_0         0x55
@@ -20,20 +31,20 @@ void main(void)
 	struct device *flash_dev;
 	u8_t buf[TEST_DATA_LEN];
 
-	printf("\nW25QXXDV SPI flash testing\n");
+	printf("\n" FLASH_NAME " SPI flash testing\n");
 	printf("==========================\n");
 
-	flash_dev = device_get_binding(DT_INST_0_JEDEC_SPI_NOR_BUS_NAME);
+	flash_dev = device_get_binding(FLASH_DEVICE);
 
 	if (!flash_dev) {
-		printf("SPI flash driver was not found!\n");
+		printf("SPI flash driver %s was not found!\n", FLASH_DEVICE);
 		return;
 	}
 
-	/* Write protection needs to be disabled in w25qxxdv flash before
-	 * each write or erase. This is because the flash component turns
-	 * on write protection automatically after completion of write and
-	 * erase operations.
+	/* Write protection needs to be disabled before each write or
+	 * erase, since the flash component turns on write protection
+	 * automatically after completion of write and erase
+	 * operations.
 	 */
 	printf("\nTest 1: Flash erase\n");
 	flash_write_protection_set(flash_dev, false);

--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -80,7 +80,9 @@ int settings_backend_init(void)
 
 	rc = flash_area_get_sectors(DT_FLASH_AREA_STORAGE_ID, &cnt,
 				    settings_fcb_area);
-	if (rc != 0 && rc != -ENOMEM) {
+	if (rc == -ENODEV) {
+		return rc;
+	} else if (rc != 0 && rc != -ENOMEM) {
 		k_panic();
 	}
 

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -139,6 +139,9 @@ flash_page_cb cb, struct layout_data *cb_data)
 	cb_data->status = 0;
 
 	flash_dev = device_get_binding(fa->fa_dev_name);
+	if (flash_dev == NULL) {
+		return -ENODEV;
+	}
 
 	flash_page_foreach(flash_dev, cb, cb_data);
 

--- a/tests/subsys/settings/functional/boards/particle_xenon.conf
+++ b/tests/subsys/settings/functional/boards/particle_xenon.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2019 Peter Bigot Consulting, LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_SPI=y
+CONFIG_SPI_NOR=y
+CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096

--- a/tests/subsys/settings/functional/particle_xenon.overlay
+++ b/tests/subsys/settings/functional/particle_xenon.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Peter Bigot Consulting, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&mx25l32 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		littlefs_partition: partition@0 {
+			label = "littlefs";
+			reg = <0x00000000 0x00200000>;
+		};
+		storage_partition: partition@200000 {
+			label = "storage";
+			reg = <0x00200000 0x00004000>;
+		};
+		partition@220000 {
+			label = "scratch2";
+			reg = <0x00204000 0x001fc000>;
+		};
+	};
+};


### PR DESCRIPTION
This PR addresses a variety of problems with the spi-nor infrastructure and samples.  It supersedes #17652, an earlier attempt that didn't address all the problems.

The devicetree binding and driver were designed to allow several sizes to be configurable.  The page, sector, erase, and write sizes are all fixed for any device implementing the JEDEC command set; they cannot and should not be configurable.  Driver, devicetree, and bindings have been updated correspondingly.

A couple existing boards have been extended with the pieces necessary to actually use their on-board flash devices in Zephyr.

Samples have been updated to confirm that they work, including the necessary board overrides.  This includes the standard spi_flash sample, and the use of a SPI NOR flash partition as a FCB-based settings store.

Finally, the JEDEC id DTS type has been changed to be a bytestring `[c2 28 17]` rather than an array `<0xc2 0x28 0x17>`.

I can see only two targets--`intel_s1000_crb` and `arduino_101`--that I believe have probably been using the SPI NOR driver.  These should still work correctly, but I don't have the hardware to test them.