### PR TITLE
Added libfuse requirement to FS shell sample README for native_posix 

### DIFF
--- a/samples/subsys/shell/fs/README.rst
+++ b/samples/subsys/shell/fs/README.rst
@@ -20,7 +20,8 @@ Native Posix
 ============
 
 Before starting a build, make sure that the i386 pkconfig directory is in your
-search path.
+search path and that a 32-bit version of libfuse is installed. For more
+background information on this requirement see :ref:`native_posix`.
 
 .. code-block:: console
 


### PR DESCRIPTION
Updated fs shell sample readme to state the requirement of a 32-bit
version of libfuse while building for native_posix board

Fixes one of the problems raised in issue #17690