### PR TITLE
nrf52_bsim: doc: Clarify how to fetch and compile BabbleSim

### DIFF
--- a/boards/posix/nrf52_bsim/doc/index.rst
+++ b/boards/posix/nrf52_bsim/doc/index.rst
@@ -53,14 +53,18 @@ Building and running
    does not support native 32-bit binaries.
 
 To target this board you need to have `BabbleSim`_ compiled in your system.
-If you do not have it yet, you can fetch and build it in this way:
+If you do not have it yet, in `its webpage <https://BabbleSim.github.io>`_
+you can find instructions on how to
+`fetch <https://babblesim.github.io/fetching.html>`_ and
+`build <https://babblesim.github.io/building.html>`_ it.
+In short, you can do:
 
 .. code-block:: console
 
    mkdir -p ${HOME}/bsim && cd ${HOME}/bsim
-   repo init -u git@github.com:BabbleSim/manifest.git -m everything.xml \
-     -b master
-   repo sync
+   curl https://storage.googleapis.com/git-repo-downloads/repo > ./repo  && chmod a+x ./repo
+   ./repo init -u git@github.com:BabbleSim/manifest.git -m everything.xml -b master
+   ./repo sync
    make everything -j 8
 
 Define two environment variables to point to your BabbleSim
@@ -71,6 +75,12 @@ If you followed the previous steps, you can just do:
 
    export BSIM_OUT_PATH=${HOME}/bsim/
    export BSIM_COMPONENTS_PATH=${HOME}/bsim/components/
+
+.. note::
+
+   You can add these two lines to your ``~/.zephyrrc`` file, or to your shell
+   initialization script (``~/.bashrc``), so you won't need to rerun them
+   manually for each new shell.
 
 You're now ready to build applications targeting this board, for example:
 


### PR DESCRIPTION
Clarify a little bit how to fetch and compile Babblesim.
So users will not need to have repo installed,
and to guide them to add the variables to their shell init
script

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

----
Rendered version:
https://builds.zephyrproject.org/zephyrproject-rtos/zephyr/17696/docs/boards/posix/nrf52_bsim/doc/index.html#building-and-running 