### PR TITLE
drivers: usb_dc_nrfx: Use dedicated work queue for handling ISR events

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -76,6 +76,15 @@ config USB_NRFX_EVT_QUEUE_SIZE
 	  Size of the driver's internal event queue.
 	  Required size will depend on number of endpoints (class instances) in use.
 
+config USB_NRFX_WORK_QUEUE_STACK_SIZE
+	int "USBD work queue stack size"
+	default 1024
+	depends on USB_NRF52840
+	help
+	  Size of the stack for the work queue thread that is used in the driver
+	  for handling the events from the USBD ISR, i.e. executing endpoint
+	  callbacks and providing proper notifications to the USB device stack.
+
 config USB_KINETIS
 	bool "Kinetis USB Device Controller Driver"
 	select USB_DEVICE_DRIVER


### PR DESCRIPTION
This patch introduces a dedicated work queue for handling the events
from ISR (i.e. for notifying the USB device stack, for executing the
enpoints callbacks, etc.). The system work queue cannot be used for
this purpose as it might be used in applications for scheduling USB
transfers and this could lead to a deadlock when the USB device stack
would not be notified about certain event because of a system work
queue item waiting for a USB transfer to be finished.

The FIFO named so far `work_queue` is renamed to `usbd_evt_fifo`
to better indicate its purpose and to avoid confusion.

Fixes #17697