### PR TITLE
disk: fixing the sending of commands with r1 response

### DIFF
--- a/subsys/disk/disk_access_spi_sdhc.c
+++ b/subsys/disk/disk_access_spi_sdhc.c
@@ -249,7 +249,11 @@ static int sdhc_spi_cmd_r1_raw(struct sdhc_spi_data *data,
 	err = sdhc_spi_skip_until_start(data);
 
 	/* Ensure there's a idle byte between commands */
-	sdhc_spi_rx_u8(data);
+	if (cmd != SDHC_SEND_CSD && cmd != SDHC_SEND_CID &&
+	    cmd != SDHC_READ_SINGLE_BLOCK && cmd != SDHC_READ_MULTIPLE_BLOCK &&
+	    cmd != SDHC_WRITE_BLOCK && cmd != SDHC_WRITE_MULTIPLE_BLOCK) {
+		sdhc_spi_rx_u8(data);
+	}
 
 	return err;
 }


### PR DESCRIPTION
**NOTE** Rebased version of #15790 

The sdhc_cmd_r1_raw() function doesn't take into account the existence
of commands with data response. Because of this, some datas were being
lost.

The commands that return a r1 response and a data are: SDHC_SEND_CSD,
SDHC_SEND_CID, SDHC_READ_SINGLE_BLOCK, SDHC_READ_MULTIPLE_BLOCK,
SDHC_WRITE_BLOCK, SDHC_WRITE_MULTIPLE_BLOCK.

In order to solve this, was juts necessary skip the byte discard when
the command is one of these.

This problem was affecting, for example, the sdhc initialization. The
token returned from SDHC_SEND_CSD was being lost and the initialization
was broken.

Fixes #15444.

Signed-off-by: Lucas Peixoto <lucaspeixotoac@gmail.com>
Signed-off-by: Peter A. Bigot <pab@pabigot.com>