### PR TITLE
sensors: lis2dh: support high resolution mode

### DIFF
--- a/drivers/sensor/lis2dh/Kconfig
+++ b/drivers/sensor/lis2dh/Kconfig
@@ -76,16 +76,20 @@ config LIS2DH_ACCEL_RANGE_16G
 endchoice
 
 choice
-	prompt "Power mode"
-	default LIS2DH_POWER_MODE_NORMAL
+	prompt "Operation mode"
+	default LIS2DH_OPER_MODE_NORMAL
 	help
-	  Choose between normal or low power operation mode for chip at init.
+	  Choose between high resolution, normal or low power operation
+	  mode for chip at init.
 
-config LIS2DH_POWER_MODE_NORMAL
-	bool "normal"
+config LIS2DH_OPER_MODE_HIGH_RES
+	bool "high resolution (12 bit)"
 
-config LIS2DH_POWER_MODE_LOW
-	bool "low"
+config LIS2DH_OPER_MODE_NORMAL
+	bool "normal (10 bit)"
+
+config LIS2DH_OPER_MODE_LOW_POWER
+	bool "low power (8 bit)"
 
 endchoice
 
@@ -125,15 +129,15 @@ config LIS2DH_ODR_7
 
 config LIS2DH_ODR_8
 	bool "1.6KHz"
-	depends on LIS2DH_POWER_MODE_LOW
+	depends on LIS2DH_OPER_MODE_LOW_POWER
 
 config LIS2DH_ODR_9_NORMAL
 	bool "1.25KHz"
-	depends on LIS2DH_POWER_MODE_NORMAL
+	depends on LIS2DH_OPER_MODE_NORMAL || LIS2DH_OPER_MODE_HIGH_RES
 
 config LIS2DH_ODR_9_LOW
 	bool "5KHz"
-	depends on LIS2DH_POWER_MODE_LOW
+	depends on LIS2DH_OPER_MODE_LOW_POWER
 
 endchoice
 

--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -341,7 +341,7 @@ int lis2dh_init(struct device *dev)
 	/* set full scale range and store it for later conversion */
 	lis2dh->scale = LIS2DH_ACCEL_SCALE(1 << (LIS2DH_FS_IDX + 1));
 	status = lis2dh_reg_write_byte(dev, LIS2DH_REG_CTRL4,
-				       LIS2DH_FS_BITS);
+				       LIS2DH_FS_BITS | LIS2DH_HR_BIT);
 	if (status < 0) {
 		LOG_ERR("Failed to set full scale ctrl register.");
 		return status;

--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -47,9 +47,9 @@
 #define LIS2DH_ACCEL_XYZ_MASK		BIT_MASK(3)
 
 #define LIS2DH_LP_EN_BIT_MASK		BIT(3)
-#if defined(CONFIG_LIS2DH_POWER_MODE_LOW)
+#if defined(CONFIG_LIS2DH_OPER_MODE_LOW_POWER)
 	#define LIS2DH_LP_EN_BIT	BIT(3)
-#elif defined(CONFIG_LIS2DH_POWER_MODE_NORMAL)
+#else
 	#define LIS2DH_LP_EN_BIT	0
 #endif
 
@@ -114,6 +114,11 @@
 #define LIS2DH_FS_SELECT(fs)		((fs) << LIS2DH_FS_SHIFT)
 #define LIS2DH_FS_BITS			(LIS2DH_FS_SELECT(LIS2DH_FS_IDX))
 #define LIS2DH_ACCEL_SCALE(range_g)	((SENSOR_G * 2 * (range_g)) / 65636LL)
+#if defined(CONFIG_LIS2DH_OPER_MODE_HIGH_RES)
+	#define LIS2DH_HR_BIT		BIT(3)
+#else
+	#define LIS2DH_HR_BIT		0
+#endif
 
 #define LIS2DH_REG_CTRL5		0x24
 #define LIS2DH_LIR_INT2_SHIFT		1


### PR DESCRIPTION
So far we supported normal (10 bit) and low-power (8 bit) modes. Add
support for high-resolution mode as a third option.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>