### PR TITLE
dts/bindings: Remove version from litex,eth0.yaml

### DIFF
--- a/dts/bindings/ethernet/litex,eth0.yaml
+++ b/dts/bindings/ethernet/litex,eth0.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: LiteX Ethernet
-version: 0.1
 
 description: >
     This binding gives a base representation of LiteX Ethernet


### PR DESCRIPTION
We've remove version from all other bindings, so cleanup
litex,eth0.yaml to match.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>