### PR TITLE
subsys/fs: fix log messages requiring strdup

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -472,7 +472,7 @@ int fs_mount(struct fs_mount_t *mp)
 
 	/*  append to the mount list */
 	sys_dlist_append(&fs_mnt_list, &mp->node);
-	LOG_DBG("fs mouted, mount point:%s", mp->mnt_point);
+	LOG_DBG("fs mounted at %s", log_strdup(mp->mnt_point));
 
 mount_err:
 	k_mutex_unlock(&mutex);
@@ -508,7 +508,7 @@ int fs_unmount(struct fs_mount_t *mp)
 
 	/* remove mount node from the list */
 	sys_dlist_remove(&mp->node);
-	LOG_DBG("fs unmouted, mount point:%s", mp->mnt_point);
+	LOG_DBG("fs unmounted from %s", log_strdup(mp->mnt_point));
 
 unmount_err:
 	k_mutex_unlock(&mutex);


### PR DESCRIPTION
Use log_strdup for mount point paths.  Reduce redundancy in the log
messages.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>