### PR TITLE
dts: bindings: Remove some YAML document separators

### DIFF
--- a/dts/bindings/ethernet/litex,eth0.yaml
+++ b/dts/bindings/ethernet/litex,eth0.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: LiteX Ethernet
 version: 0.1
 
@@ -22,4 +22,3 @@ properties:
 
     interrupts:
         category: required
-...

--- a/dts/bindings/flash_controller/st,stm32h7-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32h7-flash-controller.yaml
@@ -1,4 +1,3 @@
----
 title: STM32 H7 Flash Controller
 
 description: >
@@ -10,5 +9,3 @@ inherits:
 properties:
     compatible:
       constraint: "st,stm32h7-flash-controller"
-
-...

--- a/dts/bindings/mmc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/mmc/nxp,imx-usdhc.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP i.MXRT USDHC module
 
 description: >
@@ -31,4 +31,3 @@ properties:
 
     label:
       category: required
-...

--- a/dts/bindings/timer/nxp,imx-gpt.yaml
+++ b/dts/bindings/timer/nxp,imx-gpt.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: NXP MCUX General Purpose Timer
 
 description: >


### PR DESCRIPTION
Same deal as in commit eba81c6e54 ("yaml: Remove redundant document
separators"), for some newly added stuff.