### PR TITLE
dts/bindings: Make pwm-leds label optional

### DIFF
--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -23,6 +23,6 @@ sub-node:
           category: required
 
         label:
-          category: required
+          category: optional
           type: string
           description: Human readable string describing the device (used by Zephyr for API name)


### PR DESCRIPTION
The label property in the pwm-leds sub-node is optional, so mark it as
such.

Fixes: #17665

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>