### PR TITLE
cmake: Toolchain abstraction: Abstract compiler flag for add debug info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,8 +226,10 @@ toolchain_cc_freestanding()
 # @Intent: Set compiler specific flag for tentative definitions, no-common
 toolchain_cc_nocommon()
 
+# @Intent: Set compiler specific flag for production of debug information
+toolchain_cc_produce_debug_info()
+
 zephyr_compile_options(
-  -g # TODO: build configuration enough?
   ${TOOLCHAIN_C_FLAGS}
 )
 

--- a/cmake/compiler/gcc/target_base.cmake
+++ b/cmake/compiler/gcc/target_base.cmake
@@ -7,6 +7,12 @@
 #
 # See root CMakeLists.txt for description and expectations of this macro
 
+macro(toolchain_cc_produce_debug_info)
+
+  zephyr_compile_options(-g) # TODO: build configuration enough?
+
+endmacro()
+
 macro(toolchain_cc_nocommon)
 
   zephyr_compile_options(-fno-common)


### PR DESCRIPTION
The macro, toolchain_cc_produce_debug_info, adds the compiler specific
flag for enabling the production of debugging information in the
toolchain native format.

The intent here is to abstract Zephyr's dependence on toolchains,
thus allowing for easier porting to other, perhaps commercial,
toolchains and/or usecases.

No functional change expected.

Part of #16031