### PR TITLE
boards: stm32h747i_disco: Fix picture size

### DIFF
--- a/boards/arm/stm32h747i_disco/doc/index.rst
+++ b/boards/arm/stm32h747i_disco/doc/index.rst
@@ -34,9 +34,9 @@ Additionally, the board features:
 - Arduino Uno V3 connectors
 
 .. image:: img/stm32h747i_disco.jpg
-     :width: 2362px
+     :width: 472px
      :align: center
-     :height: 1763px
+     :height: 352px
      :alt: STM32H747I-DISCO
 
 More information about the board can be found at the `STM32H747I-DISCO website`_.


### PR DESCRIPTION
Set board picture to a reasonable size.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>