### PR TITLE
dts/arm/st: Remove nodes i2s4, i2s5 and i2s6

### DIFF
--- a/dts/arm/st/f4/stm32f429.dtsi
+++ b/dts/arm/st/f4/stm32f429.dtsi
@@ -58,18 +58,7 @@
 			label = "SPI_4";
 		};
 
-		i2s4: i2s@40013400 {
-			compatible = "st,stm32-i2s";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40013400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00002000>;
-			interrupts = <84 5>;
-			status = "disabled";
-			label = "I2S_4";
-		};
-
-		/* spi5/i2s5 is present on all STM32F429XX SoCs except
+		/* spi5 is present on all STM32F429XX SoCs except
 		 * STM32F429vX SoCs. Delete node in stm32f429vX.dtsi.
 		 */
 		 spi5: spi@40015000 {
@@ -82,18 +71,7 @@
 			label = "SPI_5";
 		};
 
-		 i2s5: i2s@40015000 {
-			compatible = "st,stm32-i2s";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00100000>;
-			interrupts = <85 5>;
-			status = "disabled";
-			label = "I2S_5";
-		};
-
-		/* spi6/i2s6 is present on all STM32F429XX SoCs except
+		/* spi6 is present on all STM32F429XX SoCs except
 		 * STM32F429vX SoCs. Delete node in stm32f429vX.dtsi.
 		 */
 		spi6: spi@40015400 {
@@ -104,17 +82,6 @@
 			interrupts = <86 5>;
 			status = "disabled";
 			label = "SPI_6";
-		};
-
-		i2s6: i2s@40015400 {
-			compatible = "st,stm32-i2s";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00200000>;
-			interrupts = <86 5>;
-			status = "disabled";
-			label = "I2S_6";
 		};
 	};
 };

--- a/dts/arm/st/f4/stm32f429vX.dtsi
+++ b/dts/arm/st/f4/stm32f429vX.dtsi
@@ -19,7 +19,3 @@
 /delete-node/ &spi5;
 
 /delete-node/ &spi6;
-
-/delete-node/ &i2s5;
-
-/delete-node/ &i2s6;


### PR DESCRIPTION
stm32f429.dtsi wrongly introduced i2s nodes 4, 5 and 6.
Remove them as actually only i2s nodes 2 and 3 are supported on
these socs.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>