### PR TITLE
net: socket: userspace: Copy user specified value in getsockopt()

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1119,7 +1119,8 @@ Z_SYSCALL_HANDLER(zsock_getsockopt, sock, level, optname, optval, optlen)
 		return -1;
 	}
 
-	kernel_optval = z_thread_malloc(kernel_optlen);
+	kernel_optval = z_user_alloc_from_copy((const void *)optval,
+					       kernel_optlen);
 	Z_OOPS(!kernel_optval);
 
 	ret = z_impl_zsock_getsockopt(sock, level, optname,


### PR DESCRIPTION
User might have set something to optval in getsockopt() and we
need to copy the data to kernel optval so that the socket family
code can use the value for something.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>