### PR TITLE
cmake/dts: Remove import of CONFIG_ prefixed symbols from dts

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -175,7 +175,6 @@ if(SUPPORTS_DTS)
     message(FATAL_ERROR "command failed with return code: ${ret}")
   endif()
 
-  import_kconfig(CONFIG_ ${GENERATED_DTS_BOARD_CONF})
   import_kconfig(DT_     ${GENERATED_DTS_BOARD_CONF})
 
 else()


### PR DESCRIPTION
We don't generate any CONFIG_ prefixed symbols from dts files so we
don't need to try and import them in anymore.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>