### PR TITLE
Freeze west and zephyr versions installed for LTS

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -42,10 +42,13 @@ First, install the ``west`` binary and bootstrapper:
 .. code-block:: console
 
    # Linux
-   pip3 install --user west
+   pip3 install --user west~=0.5.8
 
    # macOS and Windows
    pip3 install west
+
+(Later versions of west than v0.5.x may also work with Zephyr v1.14, but that
+was the version in use at the time of release.)
 
 .. note::
    See :ref:`gs_python_deps` for additional clarfication on using the

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -74,7 +74,7 @@ Next, clone the Zephyr source code repositories from GitHub using the
 
 .. code-block:: console
 
-   west init zephyrproject
+   west init zephyrproject --mr v1.14.1
    cd zephyrproject
    west update
 


### PR DESCRIPTION
Commit logs say it all:

```
doc: getting_started: recommend west v0.5.x

West is moving on. While later versions of west will remain compatible
with Zephyr LTS as long as it's supported, let's still recommend the
best tested version.
```

and:

```
doc: getting_started: west init --mr v1.14.1

That is, specifically fetch v1.14.1, which will be the release tag to
check out on the LTS branch the next time a point release is cut.
```
