### PR TITLE
Bluetooth: Host: Add pairing failed reason to callback

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -672,8 +672,9 @@ struct bt_conn_auth_cb {
 	/** @brief notify that pairing process has failed.
 	 *
 	 * @param conn Connection object.
+	 * @param reason SMP reason for the failure.
 	 */
-	void (*pairing_failed)(struct bt_conn *conn);
+	void (*pairing_failed)(struct bt_conn *conn, u8_t reason);
 };
 
 /** @brief Register authentication callbacks.

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -756,7 +756,7 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, u8_t status)
 		}
 
 		if (bt_auth && bt_auth->pairing_failed) {
-			bt_auth->pairing_failed(smp->chan.chan.conn);
+			bt_auth->pairing_failed(smp->chan.chan.conn, status);
 		}
 	} else {
 		bool bond_flag = atomic_test_bit(smp->flags, SMP_FLAG_BOND);
@@ -1555,7 +1555,7 @@ static void smp_pairing_complete(struct bt_smp *smp, u8_t status)
 						  bond_flag);
 		}
 	} else if (bt_auth && bt_auth->pairing_failed) {
-		bt_auth->pairing_failed(smp->chan.chan.conn);
+		bt_auth->pairing_failed(smp->chan.chan.conn, status);
 	}
 
 	smp_reset(smp);


### PR DESCRIPTION
Forwarding the SMP reason for a pairing failure to the pairing_failed callback so the application can decide what to do next.
I remember that it was proposed to come up with a new err code but I don't see any reason why we can't retain the SMP error codes.
If this gets merged samples and the shell should be updated, too. 