### PR TITLE
userspace: add kobject flag for drivers

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -195,6 +195,7 @@ struct _k_object_assignment {
 #define K_OBJ_FLAG_INITIALIZED	BIT(0)
 #define K_OBJ_FLAG_PUBLIC	BIT(1)
 #define K_OBJ_FLAG_ALLOC	BIT(2)
+#define K_OBJ_FLAG_DRIVER	BIT(3)
 
 /**
  * Lookup a kernel object and init its metadata if it exists

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -196,6 +196,7 @@ def write_gperf_table(fp, eh, objs, static_begin, static_end):
         # either completely initialized at build time, or done automatically
         # at boot during some PRE_KERNEL_* phase
         initialized = obj_addr >= static_begin and obj_addr < static_end
+        is_driver = obj_type.startswith("K_OBJ_DRIVER_")
 
         byte_str = struct.pack("<I" if eh.little_endian else ">I", obj_addr)
         fp.write("\"")
@@ -203,11 +204,13 @@ def write_gperf_table(fp, eh, objs, static_begin, static_end):
             val = "\\x%02x" % byte
             fp.write(val)
 
-        fp.write(
-            "\",{},%s,%s,%s\n" %
-            (obj_type,
-             "K_OBJ_FLAG_INITIALIZED" if initialized else "0",
-             str(ko.data)))
+        flags = "0"
+        if (initialized):
+            flags += " | K_OBJ_FLAG_INITIALIZED"
+        if (is_driver):
+            flags += " | K_OBJ_FLAG_DRIVER"
+
+        fp.write("\", {}, %s, %s, %s\n" % (obj_type, flags, str(ko.data)))
 
         if obj_type == "K_OBJ_THREAD":
             idx = math.floor(ko.data / 8)


### PR DESCRIPTION
This new flag will indicate that the kernel object represents
an instance of a device driver object.

Fixes: #14037

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>