### PR TITLE
dts: bindings: Have 'required: true/false' instead of 'category: ...'

### DIFF
--- a/dts/bindings/arc/arc,dccm.yaml
+++ b/dts/bindings/arc/arc,dccm.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "arc,dccm"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/arc/arc,iccm.yaml
+++ b/dts/bindings/arc/arc,iccm.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "arc,iccm"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/arm/arm,dtcm.yaml
+++ b/dts/bindings/arm/arm,dtcm.yaml
@@ -12,4 +12,4 @@ properties:
       constraint: "arm,dtcm"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/arm/arm,scc.yaml
+++ b/dts/bindings/arm/arm,scc.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "arm,scc"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/arm/atmel,sam0-device_id.yaml
+++ b/dts/bindings/arm/atmel,sam0-device_id.yaml
@@ -11,4 +11,4 @@ properties:
       constraint: "atmel,sam0-id"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/arm/atmel,sam0-dmac.yaml
+++ b/dts/bindings/arm/atmel,sam0-dmac.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "atmel,sam0-dmac"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/arm/atmel,sam0-sercom.yaml
+++ b/dts/bindings/arm/atmel,sam0-sercom.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "atmel,sam0-sercom"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/arm/nordic,nrf-dppic.yaml
+++ b/dts/bindings/arm/nordic,nrf-dppic.yaml
@@ -18,4 +18,4 @@ properties:
       constraint: "nordic,nrf-dppic"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/arm/nordic,nrf-ficr.yaml
+++ b/dts/bindings/arm/nordic,nrf-ficr.yaml
@@ -11,4 +11,4 @@ properties:
       constraint: "nordic,nrf-ficr"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/arm/nordic,nrf-spu.yaml
+++ b/dts/bindings/arm/nordic,nrf-spu.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "nordic,nrf-spu"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/arm/nxp,imx-dtcm.yaml
+++ b/dts/bindings/arm/nxp,imx-dtcm.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "nxp,imx-dtcm"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/arm/nxp,imx-epit.yaml
+++ b/dts/bindings/arm/nxp,imx-epit.yaml
@@ -17,20 +17,20 @@ properties:
       constraint: "nxp,imx-epit"
 
   reg:
-      category: required
+      required: true
 
   interrupts:
-      category: required
+      required: true
 
   label:
-      category: required
+      required: true
 
   prescaler:
      type: int
-     category: required
+     required: true
      description: Set the EPIT prescaler between 0 and 4095
 
   rdc:
      type: int
-     category: required
+     required: true
      description: Set the RDC permission for this peripheral

--- a/dts/bindings/arm/nxp,imx-itcm.yaml
+++ b/dts/bindings/arm/nxp,imx-itcm.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "nxp,imx-itcm"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/arm/nxp,imx-mu.yaml
+++ b/dts/bindings/arm/nxp,imx-mu.yaml
@@ -17,15 +17,15 @@ properties:
       constraint: "nxp,imx-mu"
 
   reg:
-      category: required
+      required: true
 
   interrupts:
-      category: required
+      required: true
 
   label:
-      category: required
+      required: true
 
   rdc:
      type: int
-     category: required
+     required: true
      description: Set the RDC permission for this peripheral

--- a/dts/bindings/arm/nxp,kinetis-pcc.yaml
+++ b/dts/bindings/arm/nxp,kinetis-pcc.yaml
@@ -17,14 +17,14 @@ properties:
       constraint: "nxp,kinetis-pcc"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     "#clock-cells":
       type: int
-      category: required
+      required: true
       description: should be 1.
 
 "#cells":

--- a/dts/bindings/arm/nxp,kinetis-scg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-scg.yaml
@@ -17,114 +17,114 @@ properties:
       constraint: "nxp,kinetis-scg"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     clk-divider-slow:
       type: int
       description: system clock to slow clock divider
-      category: required
+      required: true
 
     clk-divider-bus:
       type: int
       description: system clock to bus clock divider
-      category: required
+      required: true
 
     clk-divider-core:
       type: int
       description: system clock to core clock divider
-      category: required
+      required: true
 
     clk-source:
       type: int
       description: system clock source
-      category: optional
+      required: false
 
     sosc-freq:
       type: int
       description: system oscillator (e.g. xtal) frequency
-      category: optional
+      required: false
 
     sosc-mode:
       type: int
       description: system oscillator mode
-      category: optional
+      required: false
 
     sosc-divider-1:
       type: int
       description: system oscillator divider 1
-      category: optional
+      required: false
 
     sosc-divider-2:
       type: int
       description: system oscillator divider 2
-      category: optional
+      required: false
 
     sirc-range:
       type: int
       description: slow internal reference clock range in MHz
-      category: required
+      required: true
 
     sirc-divider-1:
       type: int
       description: slow internal reference clock divider 1
-      category: required
+      required: true
 
     sirc-divider-2:
       type: int
       description: slow internal reference clock divider 2
-      category: required
+      required: true
 
     firc-range:
       type: int
       description: fast internal reference clock range in MHz
-      category: required
+      required: true
 
     firc-divider-1:
       type: int
       description: fast internal reference clock divider 1
-      category: required
+      required: true
 
     firc-divider-2:
       type: int
       description: fast internal reference clock divider 2
-      category: required
+      required: true
 
     spll-source:
       type: int
       description: system phase-locked loop clock source
-      category: required
+      required: true
 
     spll-divider-pre:
       type: int
       description: system phase-locked loop reference clock divider
-      category: required
+      required: true
 
     spll-multiplier:
       type: int
       description: system phase-locked loop reference clock multiplier
-      category: required
+      required: true
 
     spll-divider-1:
       type: int
       description: system phase-locked loop divider 1
-      category: required
+      required: true
 
     spll-divider-2:
       type: int
       description: system phase-locked loop divider 2
-      category: required
+      required: true
 
     clkout-source:
       type: int
       description: clockout clock source
-      category: optional
+      required: false
 
     "#clock-cells":
       type: int
-      category: required
+      required: true
       description: should be 1.
 
 "#cells":

--- a/dts/bindings/arm/nxp,kinetis-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-sim.yaml
@@ -17,24 +17,24 @@ properties:
       constraint: "nxp,kinetis-sim"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     clkout-source:
       type: int
-      category: optional
+      required: false
       description: clkout clock source
 
     clkout-divider:
       type: int
-      category: optional
+      required: false
       description: clkout divider
 
     "#clock-cells":
       type: int
-      category: required
+      required: true
       description: should be 3.
 
 "#cells":

--- a/dts/bindings/arm/nxp,lpc-mailbox.yaml
+++ b/dts/bindings/arm/nxp,lpc-mailbox.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "nxp,lpc-mailbox"
 
   reg:
-      category: required
+      required: true
 
   interrupts:
-      category: required
+      required: true
 
   label:
-      category: required
+      required: true

--- a/dts/bindings/arm/st,stm32-ccm.yaml
+++ b/dts/bindings/arm/st,stm32-ccm.yaml
@@ -12,4 +12,4 @@ properties:
       constraint: "st,stm32-ccm"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/arm/ti,cc2650-prcm.yaml
+++ b/dts/bindings/arm/ti,cc2650-prcm.yaml
@@ -13,4 +13,4 @@ properties:
       constraint: "ti,cc2650-prcm"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
+++ b/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
@@ -16,4 +16,4 @@ properties:
     compatible:
       constraint: "st,mpxxdtyy"
     label:
-      category: required
+      required: true

--- a/dts/bindings/audio/ti,tlv320dac.yaml
+++ b/dts/bindings/audio/ti,tlv320dac.yaml
@@ -18,4 +18,4 @@ properties:
 
     reset-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -6,35 +6,35 @@ description: >
 properties:
     compatible:
         type: string-array
-        category: required
+        required: true
         description: compatible strings
 
     reg:
         type: array
         description: register space
-        category: optional
+        required: false
 
     reg-names:
         type: string-array
         description: name of each register space
-        category: optional
+        required: false
 
     interrupts:
         type: array
-        category: optional
+        required: false
         description: interrupts for device
 
     interrupt-names:
         type: string-array
-        category: optional
+        required: false
         description: name of each interrupt
 
     label:
         type: string
-        category: optional
+        required: false
         description: Human readable string describing the device (used by Zephyr for API name)
 
     clocks:
         type: array
-        category: optional
+        required: false
         description: Clock gate information

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
@@ -22,4 +22,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
@@ -19,8 +19,8 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true
 
     reset-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/can/can-device.yaml
+++ b/dts/bindings/can/can-device.yaml
@@ -17,6 +17,6 @@ parent:
 
 properties:
     reg:
-      category: required
+      required: true
     label:
-      category: required
+      required: true

--- a/dts/bindings/can/can.yaml
+++ b/dts/bindings/can/can.yaml
@@ -12,31 +12,31 @@ child:
 properties:
     "#address-cells":
       type: int
-      category: required
+      required: true
       description: should be 1.
     "#size-cells":
       type: int
-      category: required
+      required: true
       description: should be 0.
     label:
-      category: required
+      required: true
     bus-speed:
       type: int
-      category: required
+      required: true
       description: bus speed in Baud/s
     sjw:
       type: int
-      category: required
+      required: true
       description: Resynchronization jump width (ISO 11898-1)
     prop-seg:
       type: int
-      category: required
+      required: true
       description: Time quantums of propagation segment (ISO 11898-1)
     phase-seg1:
       type: int
-      category: required
+      required: true
       description: Time quantums of phase buffer 1 segment (ISO 11898-1)
     phase-seg2:
       type: int
-      category: required
+      required: true
       description: Time quantums of phase buffer 2 segment (ISO 11898-1)

--- a/dts/bindings/can/microchip,mcp2515.yaml
+++ b/dts/bindings/can/microchip,mcp2515.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "microchip,mcp2515"
     int-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/can/nxp,kinetis-flexcan.yaml
+++ b/dts/bindings/can/nxp,kinetis-flexcan.yaml
@@ -17,15 +17,15 @@ properties:
       constraint: "nxp,kinetis-flexcan"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true
 
     clk-source:
       type: int
-      category: required
+      required: true
       description: CAN engine clock source

--- a/dts/bindings/can/st,stm32-can.yaml
+++ b/dts/bindings/can/st,stm32-can.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "st,stm32-can"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true

--- a/dts/bindings/clock/fixed-clock.yaml
+++ b/dts/bindings/clock/fixed-clock.yaml
@@ -12,26 +12,26 @@ description: >
 properties:
     compatible:
       type: string
-      category: required
+      required: true
       description: compatible strings
       constraint: "fixed-clock"
 
     label:
       type: string
-      category: optional
+      required: false
       description: Human readable string describing the device (used by Zephyr for API name)
 
     clock-frequency:
       type: int
       description: output clock frequency (Hz)
-      category: required
+      required: true
 
     clocks:
       type: array
-      category: optional
+      required: false
       description: input clock source
 
     "#clock-cells":
       type: int
-      category: required
+      required: true
       description: should be 0.

--- a/dts/bindings/clock/nordic,nrf-clock.yaml
+++ b/dts/bindings/clock/nordic,nrf-clock.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "nordic,nrf-clock"
 
     label:
-      category: required
+      required: true
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/clock/nxp,imx-ccm.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm.yaml
@@ -17,14 +17,14 @@ properties:
       constraint: "nxp,imx-ccm"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     "#clock-cells":
       type: int
-      category: required
+      required: true
       description: should be 3.
 
 "#cells":

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -11,11 +11,11 @@ properties:
       constraint: "st,stm32-rcc"
 
     reg:
-      category: required
+      required: true
 
     "#clock-cells":
       type: int
-      category: required
+      required: true
       description: should be 2.
 
 "#cells":

--- a/dts/bindings/cpu/cpu.yaml
+++ b/dts/bindings/cpu/cpu.yaml
@@ -15,5 +15,5 @@ inherits:
 properties:
     clock-frequency:
       type: int
-      category: optional
+      required: false
       description: Clock frequency in Hz

--- a/dts/bindings/crypto/arm,cryptocell-310.yaml
+++ b/dts/bindings/crypto/arm,cryptocell-310.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "arm,cryptocell-310"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/crypto/nordic,nrf-cc310.yaml
+++ b/dts/bindings/crypto/nordic,nrf-cc310.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "nordic,nrf-cc310"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -30,14 +30,14 @@ sub-node:
     properties:
         pwms:
           type: compound
-          category: required
+          required: true
 
 properties:
 
 # A typical property entry looks like this:
 #
 #   <name of the property in the device tree - regexes are supported>:
-#     category: <required | optional>
+#     required: <true | false>
 #     type: <string | int | boolean | array | uint8-array | string-array | compound>
 #     description: <description of property>
 #
@@ -50,19 +50,19 @@ properties:
 # At a minimum, an entry for the 'compatible' property is required, for
 # matching nodes
     compatible: <list of string compatible matches>
-      category: required
+      required: true
       type: string
       description: compatible of node
 
 # 'reg' describes mmio registers
     reg:
-      category: required
+      required: true
       type: array
       description: mmio register space
 
 # 'interrupts' specifies the interrupts that the driver may use
     interrupts:
-      category: required
+      required: true
       type: array
       description: required interrupts
 

--- a/dts/bindings/display/fsl,imx6sx-lcdif.yaml
+++ b/dts/bindings/display/fsl,imx6sx-lcdif.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "fsl,imx6sx-lcdif"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/display/ilitek,ili9340.yaml
+++ b/dts/bindings/display/ilitek,ili9340.yaml
@@ -18,8 +18,8 @@ properties:
 
     reset-gpios:
       type: compound
-      category: required
+      required: true
 
     cmd-data-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/display/solomon,ssd1306fb.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb.yaml
@@ -18,44 +18,44 @@ properties:
 
     height:
       type: int
-      category: required
+      required: true
       description: Height in pixel of the panel driven by the controller
 
     width:
       type: int
-      category: required
+      required: true
       description: Width in pixel of the panel driven by the controller
 
     segment-offset:
       type: int
-      category: required
+      required: true
       description: 8-bit column start address for Page Addressing Mode
 
     page-offset:
       type: int
-      category: required
+      required: true
       description: Start address for Page Addressing Mode
 
     display-offset:
       type: int
-      category: required
+      required: true
       description: mapping of the display start line to one of COM0 .. COM63
 
     segment-remap:
       type: boolean
-      category: optional
+      required: false
       description: Last column address is mapped to first segment
 
     com-invdir:
       type: boolean
-      category: optional
+      required: false
       description: Scan direction is from last COM output to first COM output
 
     prechargep:
       type: int
-      category: required
+      required: true
       description: Duration of the pre-charge period
 
     reset-gpios:
       type: compound
-      category: optional
+      required: false

--- a/dts/bindings/display/solomon,ssd1673fb.yaml
+++ b/dts/bindings/display/solomon,ssd1673fb.yaml
@@ -18,77 +18,77 @@ properties:
 
     height:
       type: int
-      category: required
+      required: true
       description: Height in pixel of the panel driven by the controller
 
     width:
       type: int
-      category: required
+      required: true
       description: Width in pixel of the panel driven by the controller
 
     pp-height-bits:
       type: int
-      category: required
+      required: true
       description: Number of bits used for the height parameters
 
     pp-width-bits:
       type: int
-      category: required
+      required: true
       description: Number of bits used for the width parameters
 
     gdv-a:
       type: int
-      category: required
+      required: true
       description: Gate driving voltage (A value)
 
     gdv-b:
       type: int
-      category: optional
+      required: false
       description: Gate driving voltage (B value)
 
     sdv:
       type: int
-      category: required
+      required: true
       description: Source driving voltage
 
     vcom:
       type: int
-      category: required
+      required: true
       description: VCOM voltage
 
     border-waveform:
       type: int
-      category: required
+      required: true
       description: Border waveform
 
     softstart-1:
       type: int
-      category: optional
+      required: false
       description: Booster soft start phase 1
 
     softstart-2:
       type: int
-      category: optional
+      required: false
       description: Booster soft start phase 2
 
     softstart-3:
       type: int
-      category: optional
+      required: false
       description: Booster soft start phase 3
 
     orientation-flipped:
       type: boolean
-      category: optional
+      required: false
       description: Last column address is mapped to first segment
 
     reset-gpios:
       type: compound
-      category: required
+      required: true
 
     dc-gpios:
       type: compound
-      category: required
+      required: true
 
     busy-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/ethernet/ethernet.yaml
+++ b/dts/bindings/ethernet/ethernet.yaml
@@ -14,7 +14,7 @@ inherits:
 properties:
     local-mac-address:
       type: uint8-array
-      category: optional
+      required: false
       description: mac address
     label:
-      category: required
+      required: true

--- a/dts/bindings/ethernet/intel,e1000.yaml
+++ b/dts/bindings/ethernet/intel,e1000.yaml
@@ -16,7 +16,7 @@ properties:
       constraint: "intel,e1000"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/ethernet/litex,eth0.yaml
+++ b/dts/bindings/ethernet/litex,eth0.yaml
@@ -17,7 +17,7 @@ properties:
         constraint: "litex,eth0"
 
     reg:
-        category: required
+        required: true
 
     interrupts:
-        category: required
+        required: true

--- a/dts/bindings/ethernet/microchip,enc28j60.yaml
+++ b/dts/bindings/ethernet/microchip,enc28j60.yaml
@@ -16,4 +16,4 @@ properties:
       constraint: "microchip,enc28j60"
     int-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
+++ b/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
@@ -15,6 +15,6 @@ properties:
     compatible:
       constraint: "nxp,kinetis-ethernet"
     reg:
-      category: required
+      required: true
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/ethernet/nxp.kinetis-ptp.yaml
+++ b/dts/bindings/ethernet/nxp.kinetis-ptp.yaml
@@ -16,4 +16,4 @@ properties:
     compatible:
       constraint: "nxp,kinetis-ptp"
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/ethernet/smsc,lan9220.yaml
+++ b/dts/bindings/ethernet/smsc,lan9220.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "smsc,lan9220"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/ethernet/ti,stellaris-ethernet.yaml
+++ b/dts/bindings/ethernet/ti,stellaris-ethernet.yaml
@@ -15,6 +15,6 @@ properties:
     compatible:
       constraint: "ti,stellaris-ethernet"
     reg:
-      category: required
+      required: true
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
+++ b/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
@@ -19,4 +19,4 @@ properties:
     peripheral-id:
       type: int
       description: peripheral ID
-      category: required
+      required: true

--- a/dts/bindings/flash_controller/flash-controller.yaml
+++ b/dts/bindings/flash_controller/flash-controller.yaml
@@ -8,7 +8,7 @@ inherits:
 
 properties:
     label:
-      category: required
+      required: true
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
@@ -13,9 +13,9 @@ properties:
     single-bank:
       type: boolean
       description: dual-bank mode not enabled (page erase 4096k)
-      category: optional
+      required: false
 
     dual-bank:
       type: boolean
       description: dual-bank mode enabled (page erase 2048k)
-      category: optional
+      required: false

--- a/dts/bindings/flash_controller/zephyr,sim-flash.yaml
+++ b/dts/bindings/flash_controller/zephyr,sim-flash.yaml
@@ -13,4 +13,4 @@ properties:
       constraint: "zephyr,sim-flash"
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/gpio/arduino-header-r3.yaml
+++ b/dts/bindings/gpio/arduino-header-r3.yaml
@@ -18,4 +18,4 @@ properties:
 
     gpio-map:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/gpio/arm,cmsdk-gpio.yaml
+++ b/dts/bindings/gpio/arm,cmsdk-gpio.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "arm,cmsdk-gpio"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/gpio/atmel,sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam-gpio.yaml
@@ -11,18 +11,18 @@ properties:
       constraint: "atmel,sam-gpio"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     peripheral-id:
       type: int
       description: peripheral ID
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/atmel,sam0-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam0-gpio.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "atmel,sam0-gpio"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/gpio-keys.yaml
+++ b/dts/bindings/gpio/gpio-keys.yaml
@@ -13,15 +13,15 @@ properties:
     compatible:
       constraint: "gpio-keys"
       type: string-array
-      category: required
+      required: true
       description: compatible strings
 
 sub-node:
     properties:
        gpios:
           type: compound
-          category: required
+          required: true
        label:
-          category: required
+          required: true
           type: string
           description: Human readable string describing the device (used by Zephyr for API name)

--- a/dts/bindings/gpio/gpio-leds.yaml
+++ b/dts/bindings/gpio/gpio-leds.yaml
@@ -13,15 +13,15 @@ properties:
     compatible:
       constraint: "gpio-leds"
       type: string-array
-      category: required
+      required: true
       description: compatible strings
 
 sub-node:
     properties:
        gpios:
           type: compound
-          category: required
+          required: true
        label:
-          category: required
+          required: true
           type: string
           description: Human readable string describing the device (used by Zephyr for API name)

--- a/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
+++ b/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
@@ -12,9 +12,9 @@ properties:
     compatible:
       constraint: "holtek,ht16k33-keyscan"
     reg:
-      category: required
+      required: true
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/intel,apl-gpio.yaml
+++ b/dts/bindings/gpio/intel,apl-gpio.yaml
@@ -17,13 +17,13 @@ properties:
       constraint: "intel,apl-gpio"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/intel,qmsi-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-gpio.yaml
@@ -17,13 +17,13 @@ properties:
       constraint: "intel,qmsi-gpio"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
@@ -17,13 +17,13 @@ properties:
       constraint: "intel,qmsi-ss-gpio"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/microchip,xec-gpio.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio.yaml
@@ -18,13 +18,13 @@ properties:
       constraint: "microchip,xec-gpio"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: optional
+      required: false
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "nordic,nrf-gpio"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/nordic,nrf-gpiote.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpiote.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "nordic,nrf-gpiote"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -17,17 +17,17 @@ properties:
       constraint: "nxp,imx-gpio"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     rdc:
      type: int
-     category: optional
+     required: false
      description: Set the RDC permission for this peripheral
 
 "#cells":

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "nxp,kinetis-gpio"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
+++ b/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
@@ -11,13 +11,13 @@ properties:
       constraint: "openisa,rv32m1-gpio"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "semtech,sx1509b"
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/sifive,gpio0.yaml
+++ b/dts/bindings/gpio/sifive,gpio0.yaml
@@ -17,13 +17,13 @@ properties:
       constraint: "sifive,gpio0"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "silabs,efm32-gpio-port"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/silabs,efm32-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio.yaml
@@ -11,15 +11,15 @@ properties:
       constraint: "silabs,efm32-gpio"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     location-swo:
       type: int
-      category: optional
+      required: false
       description: Serial Wire Output (SWO) PIN location

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "silabs,efr32mg-gpio-port"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
@@ -11,15 +11,15 @@ properties:
       constraint: "silabs,efr32mg-gpio"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     location-swo:
       type: int
-      category: optional
+      required: false
       description: Serial Wire Output (SWO) PIN location

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "silabs,efr32xg1-gpio-port"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
@@ -11,15 +11,15 @@ properties:
       constraint: "silabs,efr32xg1-gpio"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     location-swo:
       type: int
-      category: optional
+      required: false
       description: Serial Wire Output (SWO) PIN location

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -17,18 +17,18 @@ properties:
       constraint: "snps,designware-gpio"
 
     reg:
-      category: required
+      required: true
 
     bits:
       type: int
       description: gpio bits
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -17,13 +17,13 @@ properties:
       constraint: "st,stm32-gpio"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
@@ -17,13 +17,13 @@ properties:
       constraint: "ti,cc13xx-cc26xx-gpio"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/ti,cc2650-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc2650-gpio.yaml
@@ -12,7 +12,7 @@ properties:
       constraint: "ti,cc2650-gpio"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/gpio/ti,cc32xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc32xx-gpio.yaml
@@ -12,13 +12,13 @@ properties:
       constraint: "ti,cc32xx-gpio"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/gpio/ti,stellaris-gpio.yaml
+++ b/dts/bindings/gpio/ti,stellaris-gpio.yaml
@@ -12,13 +12,13 @@ properties:
       constraint: "ti,stellaris-gpio"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/i2c/arm,versatile-i2c.yaml
+++ b/dts/bindings/i2c/arm,versatile-i2c.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "arm,versatile-i2c"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
@@ -17,12 +17,12 @@ properties:
       constraint: "atmel,sam-i2c-twi"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     peripheral-id:
       type: int
       description: peripheral ID
-      category: required
+      required: true

--- a/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
@@ -17,12 +17,12 @@ properties:
       constraint: "atmel,sam-i2c-twihs"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     peripheral-id:
       type: int
       description: peripheral ID
-      category: required
+      required: true

--- a/dts/bindings/i2c/atmel,sam0-i2c.yaml
+++ b/dts/bindings/i2c/atmel,sam0-i2c.yaml
@@ -17,12 +17,12 @@ properties:
       constraint: "atmel,sam0-i2c"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     dma:
       type: int
-      category: optional
+      required: false
       description: DMA channel

--- a/dts/bindings/i2c/fsl,imx7d-i2c.yaml
+++ b/dts/bindings/i2c/fsl,imx7d-i2c.yaml
@@ -17,12 +17,12 @@ properties:
       constraint: "fsl,imx7d-i2c"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     rdc:
      type: int
-     category: required
+     required: true
      description: Set the RDC permission for this peripheral

--- a/dts/bindings/i2c/i2c-device.yaml
+++ b/dts/bindings/i2c/i2c-device.yaml
@@ -17,6 +17,6 @@ parent:
 
 properties:
     reg:
-      category: required
+      required: true
     label:
-      category: required
+      required: true

--- a/dts/bindings/i2c/i2c.yaml
+++ b/dts/bindings/i2c/i2c.yaml
@@ -18,15 +18,15 @@ child:
 properties:
     "#address-cells":
       type: int
-      category: required
+      required: true
       description: should be 1.
     "#size-cells":
       type: int
-      category: required
+      required: true
       description: should be 0.
     clock-frequency :
       type: int
-      category: optional
+      required: false
       description: Initial clock frequency in Hz
     label:
-      category: required
+      required: true

--- a/dts/bindings/i2c/intel,qmsi-i2c.yaml
+++ b/dts/bindings/i2c/intel,qmsi-i2c.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "intel,qmsi-i2c"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
+++ b/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "intel,qmsi-ss-i2c"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/i2c/microchip,xec-i2c.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
@@ -17,9 +17,9 @@ properties:
       constraint: "microchip,xec-i2c"
 
     reg:
-      category: required
+      required: true
 
     port_sel:
       type: int
       description: soc block mapping to pin
-      category: required
+      required: true

--- a/dts/bindings/i2c/nios2,i2c.yaml
+++ b/dts/bindings/i2c/nios2,i2c.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "nios2,i2c"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/i2c/nordic,nrf-i2c.yaml
+++ b/dts/bindings/i2c/nordic,nrf-i2c.yaml
@@ -18,17 +18,17 @@ properties:
       constraint: "nordic,nrf-i2c"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     sda-pin:
       type: int
       description: SDA pin
-      category: required
+      required: true
 
     scl-pin:
       type: int
       description: SCL pin
-      category: required
+      required: true

--- a/dts/bindings/i2c/nxp,imx-lpi2c.yaml
+++ b/dts/bindings/i2c/nxp,imx-lpi2c.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "nxp,imx-lpi2c"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/i2c/nxp,kinetis-i2c.yaml
+++ b/dts/bindings/i2c/nxp,kinetis-i2c.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "nxp,kinetis-i2c"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/i2c/openisa,rv32m1-lpi2c.yaml
+++ b/dts/bindings/i2c/openisa,rv32m1-lpi2c.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "openisa,rv32m1-lpi2c"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/i2c/sifive,i2c0.yaml
+++ b/dts/bindings/i2c/sifive,i2c0.yaml
@@ -18,8 +18,8 @@ properties:
 
     input-frequency:
       type: int
-      category: optional
+      required: false
       description: Frequency of the peripheral input clock.
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/i2c/silabs,gecko-i2c.yaml
+++ b/dts/bindings/i2c/silabs,gecko-i2c.yaml
@@ -17,20 +17,20 @@ properties:
       constraint: "silabs,gecko-i2c"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     # Note: Not all SoC series support setting individual pin location. If this
     # is a case all location-* properties need to have identical value.
 
     location-sda:
       type: array
-      category: required
+      required: true
       description: SDA pin configuration defined as <location port pin>
 
     location-scl:
       type: array
-      category: required
+      required: true
       description: SCL pin configuration defined as <location port pin>

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -17,12 +17,12 @@ properties:
       constraint: "snps,designware-i2c"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     pcie:
       type: boolean
-      category: optional
+      required: false
       description: attached via PCI(e) bus

--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "st,stm32-i2c-v1"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "st,stm32-i2c-v2"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
@@ -17,17 +17,17 @@ properties:
       constraint: "ti,cc13xx-cc26xx-i2c"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     sda-pin:
       type: int
-      category: required
+      required: true
       description: SDA pin
 
     scl-pin:
       type: int
-      category: required
+      required: true
       description: SCL pin

--- a/dts/bindings/i2c/ti,cc32xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc32xx-i2c.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "ti,cc32xx-i2c"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/i2s/i2s-device.yaml
+++ b/dts/bindings/i2s/i2s-device.yaml
@@ -17,6 +17,6 @@ parent:
 
 properties:
     reg:
-      category: required
+      required: true
     label:
-      category: required
+      required: true

--- a/dts/bindings/i2s/i2s.yaml
+++ b/dts/bindings/i2s/i2s.yaml
@@ -18,11 +18,11 @@ child:
 properties:
     "#address-cells":
       type: int
-      category: required
+      required: true
       description: should be 1.
     "#size-cells":
       type: int
-      category: required
+      required: true
       description: should be 0.
     label:
-      category: required
+      required: true

--- a/dts/bindings/i2s/st,stm32-i2s.yaml
+++ b/dts/bindings/i2s/st,stm32-i2s.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "st,stm32-i2s"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/ieee802154/nxp,mcr20a.yaml
+++ b/dts/bindings/ieee802154/nxp,mcr20a.yaml
@@ -18,8 +18,8 @@ properties:
 
     irqb-gpios:
       type: compound
-      category: required
+      required: true
 
     reset-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/ieee802154/ti,cc2520.yaml
+++ b/dts/bindings/ieee802154/ti,cc2520.yaml
@@ -18,24 +18,24 @@ properties:
 
     vreg-en-gpios:
       type: compound
-      category: optional
+      required: false
 
     reset-gpios:
       type: compound
-      category: optional
+      required: false
 
     fifo-gpios:
       type: compound
-      category: optional
+      required: false
 
     cca-gpios:
       type: compound
-      category: optional
+      required: false
 
     sfd-gpios:
       type: compound
-      category: optional
+      required: false
 
     fifop-gpios:
       type: compound
-      category: optional
+      required: false

--- a/dts/bindings/iio/adc/adc.yaml
+++ b/dts/bindings/iio/adc/adc.yaml
@@ -14,4 +14,4 @@ inherits:
 
 properties:
     label:
-      category: required
+      required: true

--- a/dts/bindings/iio/adc/atmel,sam-afec.yaml
+++ b/dts/bindings/iio/adc/atmel,sam-afec.yaml
@@ -11,12 +11,12 @@ properties:
       constraint: "atmel,sam-afec"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     peripheral-id:
       type: int
       description: peripheral ID
-      category: required
+      required: true

--- a/dts/bindings/iio/adc/atmel,sam0-adc.yaml
+++ b/dts/bindings/iio/adc/atmel,sam0-adc.yaml
@@ -17,17 +17,17 @@ properties:
       constraint: "atmel,sam0-adc"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     gclk:
       type: int
-      category: required
+      required: true
       description: generic clock generator source
 
     prescaler:
       type: int
-      category: required
+      required: true
       description: clock prescaler divisor applied to the generic clock

--- a/dts/bindings/iio/adc/nordic,nrf-adc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-adc.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "nordic,nrf-adc"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "nordic,nrf-saadc"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/iio/adc/nxp,kinetis-adc12.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc12.yaml
@@ -17,27 +17,27 @@ properties:
       constraint: "nxp,kinetis-adc12"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     clk-source:
       type: int
-      category: required
+      required: true
       description: converter clock source
 
     clk-divider:
       type: int
-      category: required
+      required: true
       description: clock divider for the converter
 
     alternate-voltage-reference:
       type: boolean
-      category: optional
+      required: false
       description: use alternate voltage reference source
 
     sample-time:
       type: int
-      category: required
+      required: true
       description: sample time in clock cycles

--- a/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "nxp,kinetis-adc16"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/iio/adc/snps,dw-adc.yaml
+++ b/dts/bindings/iio/adc/snps,dw-adc.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "snps,dw-adc"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/iio/adc/st,stm32-adc.yaml
+++ b/dts/bindings/iio/adc/st,stm32-adc.yaml
@@ -18,10 +18,10 @@ properties:
       constraint: "st,stm32-adc"
 
     reg:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "arm,v6m-nvic"
 
     reg:
-      category: required
+      required: true
 
     arm,num-irq-priority-bits:
-      category: required
+      required: true
       type: int
       description: number of bits of IRQ priorities
 

--- a/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "arm,v7m-nvic"
 
     reg:
-      category: required
+      required: true
 
     arm,num-irq-priority-bits:
-      category: required
+      required: true
       type: int
       description: number of bits of IRQ priorities
 

--- a/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "arm,v8m-nvic"
 
     reg:
-      category: required
+      required: true
 
     arm,num-irq-priority-bits:
-      category: required
+      required: true
       type: int
       description: number of bits of IRQ priorities
 

--- a/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
+++ b/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "atmel,sam0-eic"
 
   reg:
-    category: required
+    required: true
 
   interrupts:
-    category: required
+    required: true
 
   label:
-    category: required
+    required: true

--- a/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "intel,cavs-intc"
 
   reg:
-      category: required
+      required: true
 
   interrupts:
-      category: required
+      required: true
 
 "#cells":
   - irq

--- a/dts/bindings/interrupt-controller/intel,ioapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,ioapic.yaml
@@ -12,7 +12,7 @@ properties:
       constraint: "intel,ioapic"
 
   reg:
-      category: required
+      required: true
 
 "#cells":
   - irq

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
@@ -18,7 +18,7 @@ properties:
       constraint: "openisa,rv32m1-event-unit"
 
   reg:
-      category: required
+      required: true
 
 "#cells":
   - irq

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
@@ -17,13 +17,13 @@ properties:
       constraint: "openisa,rv32m1-intmux"
 
   reg:
-      category: required
+      required: true
 
   label:
-      category: required
+      required: true
 
   interrupts:
-      category: required
+      required: true
 
 "#cells":
   - irq

--- a/dts/bindings/interrupt-controller/riscv,plic0.yaml
+++ b/dts/bindings/interrupt-controller/riscv,plic0.yaml
@@ -17,12 +17,12 @@ properties:
       constraint: "riscv,plic0"
 
   reg:
-      category: required
+      required: true
 
   riscv,max-priority:
       type: int
       description: maximum interrupt priority
-      category: required
+      required: true
 
 "#cells":
   - irq

--- a/dts/bindings/interrupt-controller/shared-irq.yaml
+++ b/dts/bindings/interrupt-controller/shared-irq.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "shared-irq"
 
   interrupts:
-      category: required
+      required: true
 
   label:
-      category: required
+      required: true

--- a/dts/bindings/interrupt-controller/snps,designware-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,designware-intc.yaml
@@ -11,15 +11,15 @@ properties:
       constraint: "snps,designware-intc"
 
   reg:
-      category: required
+      required: true
 
   snps,num-irq-priority-bits:
-      category: required
+      required: true
       type: int
       description: number of bits of IRQ priorities
 
   interrupts:
-      category: required
+      required: true
 
 "#cells":
   - irq

--- a/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
+++ b/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
@@ -17,12 +17,12 @@ properties:
       constraint: "vexriscv,intc0"
 
   reg:
-      category: required
+      required: true
 
   riscv,max-priority:
       type: int
       description: maximum interrupt priority
-      category: required
+      required: true
 
 "#cells":
   - irq

--- a/dts/bindings/interrupt-controller/xtensa,intc.yaml
+++ b/dts/bindings/interrupt-controller/xtensa,intc.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "xtensa,core-intc"
 
   reg:
-      category: required
+      required: true
 
   snps,num-irq-priority-bits:
-      category: required
+      required: true
       type: int
       description: number of bits of IRQ priorities
 

--- a/dts/bindings/led/holtek,ht16k33.yaml
+++ b/dts/bindings/led/holtek,ht16k33.yaml
@@ -13,15 +13,15 @@ properties:
       constraint: "holtek,ht16k33"
     "#address-cells":
       type: int
-      category: required
+      required: true
       description: should be 1.
     "#size-cells":
       type: int
-      category: required
+      required: true
       description: should be 0.
     label:
-      category: required
+      required: true
     irq-gpios:
       type: compound
-      category: optional
+      required: false
       description: IRQ pin

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -13,16 +13,16 @@ properties:
     compatible:
       constraint: "pwm-leds"
       type: string-array
-      category: required
+      required: true
       description: compatible strings
 
 sub-node:
     properties:
         pwms:
           type: compound
-          category: required
+          required: true
 
         label:
-          category: optional
+          required: false
           type: string
           description: Human readable string describing the device (used by Zephyr for API name)

--- a/dts/bindings/memory-controllers/nxp,imx-semc.yaml
+++ b/dts/bindings/memory-controllers/nxp,imx-semc.yaml
@@ -18,10 +18,10 @@ properties:
       constraint: "nxp,imx-semc"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/mhu/arm,mhu.yaml
+++ b/dts/bindings/mhu/arm,mhu.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "arm,mhu"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/misc/skyworks,sky13351.yaml
+++ b/dts/bindings/misc/skyworks,sky13351.yaml
@@ -18,9 +18,9 @@ properties:
         constraint: "skyworks,sky13351"
     vctl1-gpios:
         type: compound
-        category: required
+        required: true
         description: VCTL1 pin
     vctl2-gpios:
         type: compound
-        category: required
+        required: true
         description: VCTL2 pin

--- a/dts/bindings/mmc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/mmc/nxp,imx-usdhc.yaml
@@ -17,17 +17,17 @@ properties:
       constraint: "nxp,imx-usdhc"
 
     clocks:
-      category: required
+      required: true
 
     pwr-gpios:
       type: compound
-      category: optional
+      required: false
       description: Power pin
 
     cd-gpios:
       type: compound
-      category: optional
+      required: false
       description: Detect pin
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
@@ -11,9 +11,9 @@ properties:
       constraint: "arm,armv7m-mpu"
 
     reg:
-      category: required
+      required: true
 
     arm,num-mpu-regions:
-      category: required
+      required: true
       type: int
       description: number of MPU regions supported by hardware

--- a/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
@@ -11,9 +11,9 @@ properties:
       constraint: "arm,armv8m-mpu"
 
     reg:
-      category: required
+      required: true
 
     arm,num-mpu-regions:
-      category: required
+      required: true
       type: int
       description: number of MPU regions supported by hardware

--- a/dts/bindings/modem/ublox,sara-r4.yaml
+++ b/dts/bindings/modem/ublox,sara-r4.yaml
@@ -17,12 +17,12 @@ properties:
       constraint: "ublox,sara-r4"
 
     label:
-      category: required
+      required: true
 
     mdm-power-gpios:
       type: compound
-      category: required
+      required: true
 
     mdm-reset-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -17,29 +17,29 @@ properties:
       constraint: "wnc,m14a2a"
 
     label:
-      category: required
+      required: true
 
     mdm-boot-mode-sel-gpios:
       type: compound
-      category: required
+      required: true
 
     mdm-power-gpios:
       type: compound
-      category: required
+      required: true
 
     mdm-keep-awake-gpios:
       type: compound
-      category: required
+      required: true
 
     mdm-reset-gpios:
       type: compound
-      category: required
+      required: true
 
     mdm-shld-trans-ena-gpios:
       type: compound
-      category: required
+      required: true
 
     mdm-send-ok-gpios:
       type: compound
-      category: optional
+      required: false
       description: UART RTS pin if no HW flow control (set to always enabled)

--- a/dts/bindings/mtd/atmel,at24.yaml
+++ b/dts/bindings/mtd/atmel,at24.yaml
@@ -17,5 +17,5 @@ properties:
       constraint: "atmel,at24"
     size:
       type: int
-      category: required
+      required: true
       description: I2C Slave EEPROM Size in KiB

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -23,23 +23,23 @@ properties:
 
   has-be32k:
     type: boolean
-    category: optional
+    required: false
     description: Indicates the device supports the BE32K command
 
   size:
     type: int
-    category: optional
+    required: false
     description: flash capacity in bits
 
   wp-gpios:
     type: compound
-    category: optional
+    required: false
     description: WPn pin
   hold-gpios:
     type: compound
-    category: optional
+    required: false
     description: HOLDn pin
   reset-gpios:
     type: compound
-    category: optional
+    required: false
     description: RESETn pin

--- a/dts/bindings/mtd/partition.yaml
+++ b/dts/bindings/mtd/partition.yaml
@@ -7,21 +7,21 @@ properties:
     compatible:
       constraint: "fixed-partitions"
       type: string-array
-      category: required
+      required: true
       description: compatible strings
 
 sub-node:
     properties:
        label:
-          category: required
+          required: true
           type: string
-          category: optional
+          required: false
           description: Human readable string describing the device (used by Zephyr for API name)
        read-only:
           type: boolean
-          category: optional
+          required: false
           description: if the partition is read-only or not
        reg:
           type: array
           description: register space
-          category: required
+          required: true

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -11,14 +11,14 @@ properties:
       constraint: "soc-nv-flash"
 
     label:
-      category: optional
+      required: false
 
     erase-block-size:
      type: int
      description: address alignment required by flash erase operations
-     category: optional
+     required: false
 
     write-block-size:
      type: int
      description: address alignment required by flash write operations
-     category: optional
+     required: false

--- a/dts/bindings/phy/phy.yaml
+++ b/dts/bindings/phy/phy.yaml
@@ -15,6 +15,6 @@ inherits:
 properties:
     "#phy-cells":
         type: int
-        category: required
+        required: true
         description: Number of cells in a PHY provider. The meaning those
                      cells is defined by the binding for the phy node.

--- a/dts/bindings/phy/st,stm32-usbphyc.yaml
+++ b/dts/bindings/phy/st,stm32-usbphyc.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "st,stm32-usbphyc"
 
     reg:
-      category: required
+      required: true
 
     "#phy-cells":
       description: should be 0

--- a/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
+++ b/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "atmel,sam0-pinmux"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
+++ b/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
@@ -12,7 +12,7 @@ properties:
       constraint: "intel,s1000-pinmux"
 
     reg:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "nxp,kinetis-pinmux"
 
     reg:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
+++ b/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "openisa,rv32m1-pinmux"
 
     reg:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "st,stm32-pinmux"
 
     reg:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "ti,cc13xx-cc26xx-pinmux"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
@@ -12,7 +12,7 @@ properties:
       constraint: "ti,cc2650-pinmux"
 
     reg:
-      category: required
+      required: true
 
 "#cells":
   - pin

--- a/dts/bindings/power/nordic,nrf-power.yaml
+++ b/dts/bindings/power/nordic,nrf-power.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "nordic,nrf-power"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/pwm/atmel,sam-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam-pwm.yaml
@@ -17,24 +17,24 @@ properties:
       constraint: "atmel,sam-pwm"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     peripheral-id:
       type: int
       description: peripheral ID
-      category: required
+      required: true
 
     prescaler:
       type: int
-      category: required
+      required: true
       description: Clock prescaler at the input of the PWM (0 to 10)
 
     divider:
       type: int
-      category: required
+      required: true
       description: Clock divider at the input of the PWM (1 to 255)
 
 "#cells":

--- a/dts/bindings/pwm/fsl,imx7d-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx7d-pwm.yaml
@@ -17,19 +17,19 @@ properties:
       constraint: "fsl,imx7d-pwm"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     prescaler:
      type: int
-     category: required
+     required: true
      description: Set the PWM prescale between 0 and 4096
 
     rdc:
      type: int
-     category: required
+     required: true
      description: Set the RDC permission for this peripheral
 
 "#cells":

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -11,47 +11,47 @@ properties:
       constraint: "nordic,nrf-pwm"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     ch0-pin:
       type: int
       description: Channel 0 pin
-      category: optional
+      required: false
 
     ch0-inverted:
       type: boolean
       description: Channel 0 inverted
-      category: optional
+      required: false
 
     ch1-pin:
       type: int
       description: Channel 1 pin
-      category: optional
+      required: false
 
     ch1-inverted:
       type: boolean
       description: Channel 1 inverted
-      category: optional
+      required: false
 
     ch2-pin:
       type: int
       description: Channel 2 pin
-      category: optional
+      required: false
 
     ch2-inverted:
       type: boolean
       description: Channel 2 inverted
-      category: optional
+      required: false
 
     ch3-pin:
       type: int
       description: Channel 3 pin
-      category: optional
+      required: false
 
     ch3-inverted:
       type: boolean
       description: Channel 3 inverted
-      category: optional
+      required: false

--- a/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
@@ -11,29 +11,29 @@ properties:
       constraint: "nordic,nrf-sw-pwm"
 
     label:
-      category: required
+      required: true
 
     timer-instance:
       type: int
       description: Timer instance to use for generating the PWM output signals
-      category: required
+      required: true
 
     channel-count:
       type: int
       description: Number of PWM channels. Limited by timer instance compare registers minus 1.
-      category: required
+      required: true
 
     clock-prescaler:
       type: int
       description: Clock prescaler for timer used for generating the PWM output signals with frequency = 16 MHz / 2^prescaler
-      category: required
+      required: true
 
     ppi-base:
       type: int
       description: PPI base used for PPI index calculation used for PWM output generation
-      category: required
+      required: true
 
     gpiote-base:
       type: int
       description: GPIOTE base used for GPIOTE index calculation used for PWM output generation
-      category: required
+      required: true

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "nxp,kinetis-ftm"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
 "#cells":
   - channel

--- a/dts/bindings/pwm/pwm.yaml
+++ b/dts/bindings/pwm/pwm.yaml
@@ -14,4 +14,4 @@ inherits:
 
 properties:
     label:
-      category: required
+      required: true

--- a/dts/bindings/pwm/sifive,pwm0.yaml
+++ b/dts/bindings/pwm/sifive,pwm0.yaml
@@ -18,18 +18,18 @@ properties:
 
     clock-frequency:
       type: int
-      category: optional
+      required: false
       description: Clock frequency information for PWM operation
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     sifive,compare-width:
       type: int
-      category: required
+      required: true
       description: Width of the PWM comparator in bits
 
 "#cells":

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -11,11 +11,11 @@ properties:
       constraint: "st,stm32-pwm"
 
     label:
-      category: required
+      required: true
 
     st,prescaler:
       type: int
-      category: required
+      required: true
       description: Clock prescaler at the input of the timer
 
 "#cells":

--- a/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
+++ b/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "openisa,rv32m1-pcc"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
 "#cells":
   - name

--- a/dts/bindings/rng/atmel,sam-trng.yaml
+++ b/dts/bindings/rng/atmel,sam-trng.yaml
@@ -17,15 +17,15 @@ properties:
       constraint: "atmel,sam-trng"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     peripheral-id:
       type: int
       description: peripheral ID
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/rng/nxp,kinetis-rnga.yaml
+++ b/dts/bindings/rng/nxp,kinetis-rnga.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "nxp,kinetis-rnga"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/rng/nxp,kinetis-trng.yaml
+++ b/dts/bindings/rng/nxp,kinetis-trng.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "nxp,kinetis-trng"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
+++ b/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "ti,cc13xx-cc26xx-trng"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/rtc/atmel,sam0-rtc.yaml
+++ b/dts/bindings/rtc/atmel,sam0-rtc.yaml
@@ -17,9 +17,9 @@ properties:
       constraint: "atmel,sam0-rtc"
 
     reg:
-      category: required
+      required: true
 
     clock-generator:
       type: int
       description: clock generator index
-      category: required
+      required: true

--- a/dts/bindings/rtc/intel,qmsi-rtc.yaml
+++ b/dts/bindings/rtc/intel,qmsi-rtc.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "intel,qmsi-rtc"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/rtc/nordic,nrf-rtc.yaml
+++ b/dts/bindings/rtc/nordic,nrf-rtc.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "nordic,nrf-rtc"
 
     reg:
-      category: required
+      required: true
 
     #If enabled, overflow different than full range (24 bits) is handled
     #through PPI channel which ensures precise timing. If disabled then
@@ -26,4 +26,4 @@ properties:
     ppi-wrap:
       type: boolean
       description: Enable wrapping with PPI
-      category: required
+      required: true

--- a/dts/bindings/rtc/nxp,kinetis-rtc.yaml
+++ b/dts/bindings/rtc/nxp,kinetis-rtc.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "nxp,kinetis-rtc"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/rtc/rtc.yaml
+++ b/dts/bindings/rtc/rtc.yaml
@@ -15,14 +15,14 @@ inherits:
 properties:
     clock-frequency:
       type: int
-      category: optional
+      required: false
       description: Clock frequency information for RTC operation
     label:
-      category: required
+      required: true
     interrupts:
-      category: required
+      required: true
 
     prescaler:
       type: int
-      category: optional
+      required: false
       description: RTC frequency equals clock-frequency divided by the prescaler value

--- a/dts/bindings/rtc/silabs,gecko-rtcc.yaml
+++ b/dts/bindings/rtc/silabs,gecko-rtcc.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "silabs,gecko-rtcc"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/rtc/st,stm32-rtc.yaml
+++ b/dts/bindings/rtc/st,stm32-rtc.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "st,stm32-rtc"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/sensor/adi,adt7420.yaml
+++ b/dts/bindings/sensor/adi,adt7420.yaml
@@ -18,4 +18,4 @@ properties:
 
     int-gpios:
       type: compound
-      category: optional
+      required: false

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -18,4 +18,4 @@ properties:
 
     int1-gpios:
       type: compound
-      category: optional
+      required: false

--- a/dts/bindings/sensor/adi,adxl372-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl372-i2c.yaml
@@ -18,4 +18,4 @@ properties:
 
     int1-gpios:
       type: compound
-      category: optional
+      required: false

--- a/dts/bindings/sensor/adi,adxl372-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl372-spi.yaml
@@ -20,4 +20,4 @@ properties:
 
     int1-gpios:
       type: compound
-      category: optional
+      required: false

--- a/dts/bindings/sensor/avago,apds9960.yaml
+++ b/dts/bindings/sensor/avago,apds9960.yaml
@@ -18,4 +18,4 @@ properties:
 
     int-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/bosch,bmi160.yaml
+++ b/dts/bindings/sensor/bosch,bmi160.yaml
@@ -18,4 +18,4 @@ properties:
 
     int-gpios:
       type: compound
-      category: optional
+      required: false

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -17,40 +17,40 @@ properties:
       constraint: "nordic,nrf-qdec"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     a-pin:
       type: int
       description: A pin
-      category: required
+      required: true
 
     b-pin:
       type: int
       description: B pin
-      category: required
+      required: true
 
     led-pin:
       type: int
       description: LED pin for light based QDEC device
-      category: optional
+      required: false
 
     enable-pin:
       type: int
       description: Enables connected QDEC device
-      category: optional
+      required: false
 
     led-pre:
       type: int
       description: Time LED is enabled prior to sampling event (in us)
-      category: required
+      required: true
 
     steps:
       type: int
       description: Number of steps on the rotating wheel
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/sensor/nordic,nrf-temp.yaml
+++ b/dts/bindings/sensor/nordic,nrf-temp.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "nordic,nrf-temp"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/sensor/nxp,fxas21002.yaml
+++ b/dts/bindings/sensor/nxp,fxas21002.yaml
@@ -18,8 +18,8 @@ properties:
 
     int1-gpios:
       type: compound
-      category: optional
+      required: false
 
     int2-gpios:
       type: compound
-      category: optional
+      required: false

--- a/dts/bindings/sensor/nxp,fxos8700.yaml
+++ b/dts/bindings/sensor/nxp,fxos8700.yaml
@@ -19,12 +19,12 @@ properties:
 
     reset-gpios:
       type: compound
-      category: optional
+      required: false
 
     int1-gpios:
       type: compound
-      category: optional
+      required: false
 
     int2-gpios:
       type: compound
-      category: optional
+      required: false

--- a/dts/bindings/sensor/sensirion,sht3xd.yaml
+++ b/dts/bindings/sensor/sensirion,sht3xd.yaml
@@ -18,5 +18,5 @@ properties:
       constraint: "sensirion,sht3xd"
     alert-gpios:
       type: compound
-      category: optional
+      required: false
       description: ALERT pin

--- a/dts/bindings/sensor/st,hts221.yaml
+++ b/dts/bindings/sensor/st,hts221.yaml
@@ -19,5 +19,5 @@ properties:
 
     drdy-gpios:
       type: compound
-      category: optional
+      required: false
       description: DRDY pin

--- a/dts/bindings/sensor/st,lis2dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dh-i2c.yaml
@@ -18,4 +18,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/st,lis2dh-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dh-spi.yaml
@@ -19,4 +19,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/st,lis2ds12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-i2c.yaml
@@ -18,4 +18,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/st,lis2ds12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-spi.yaml
@@ -19,4 +19,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/st,lis2dw12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-i2c.yaml
@@ -18,4 +18,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/st,lis2dw12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-spi.yaml
@@ -19,4 +19,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/st,lis2mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-magn.yaml
@@ -18,4 +18,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/st,lis3dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis3dh-i2c.yaml
@@ -18,4 +18,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/st,lps22hh-i2c.yaml
+++ b/dts/bindings/sensor/st,lps22hh-i2c.yaml
@@ -19,5 +19,5 @@ properties:
 
     drdy-gpios:
       type: compound
-      category: optional
+      required: false
       description: DRDY pin

--- a/dts/bindings/sensor/st,lps22hh-spi.yaml
+++ b/dts/bindings/sensor/st,lps22hh-spi.yaml
@@ -19,5 +19,5 @@ properties:
 
     drdy-gpios:
       type: compound
-      category: optional
+      required: false
       description: DRDY pin

--- a/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
@@ -19,4 +19,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/st,lsm6dsl-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-spi.yaml
@@ -19,4 +19,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/st,lsm6dso-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-i2c.yaml
@@ -19,4 +19,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/st,lsm6dso-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-spi.yaml
@@ -19,4 +19,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
@@ -18,4 +18,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
@@ -18,4 +18,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/sensor/ti,hdc.yaml
+++ b/dts/bindings/sensor/ti,hdc.yaml
@@ -18,4 +18,4 @@ properties:
 
     drdy-gpios:
       type: compound
-      category: optional
+      required: false

--- a/dts/bindings/serial/altera,jtag-uart.yaml
+++ b/dts/bindings/serial/altera,jtag-uart.yaml
@@ -11,4 +11,4 @@ properties:
       constraint: "altera,jtag-uart"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/serial/arm,cmsdk-uart.yaml
+++ b/dts/bindings/serial/arm,cmsdk-uart.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "arm,cmsdk-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/serial/arm,pl011.yaml
+++ b/dts/bindings/serial/arm,pl011.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "arm,pl011"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/serial/atmel,sam-uart.yaml
+++ b/dts/bindings/serial/atmel,sam-uart.yaml
@@ -11,12 +11,12 @@ properties:
       constraint: "atmel,sam-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     peripheral-id:
       type: int
       description: peripheral ID
-      category: required
+      required: true

--- a/dts/bindings/serial/atmel,sam-usart.yaml
+++ b/dts/bindings/serial/atmel,sam-usart.yaml
@@ -11,12 +11,12 @@ properties:
       constraint: "atmel,sam-usart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     peripheral-id:
       type: int
       description: peripheral ID
-      category: required
+      required: true

--- a/dts/bindings/serial/atmel,sam0-uart.yaml
+++ b/dts/bindings/serial/atmel,sam0-uart.yaml
@@ -11,27 +11,27 @@ properties:
       constraint: "atmel,sam0-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     rxpo:
       type: int
-      category: required
+      required: true
       description: Receive Data Pinout
 
     txpo:
       type: int
-      category: required
+      required: true
       description: Transmit Data Pinout
 
     rxdma:
       type: int
-      category: optional
+      required: false
       description: Receive DMA channel
 
     txdma:
       type: int
-      category: optional
+      required: false
       description: Transmit DMA channel

--- a/dts/bindings/serial/cypress,psoc6-uart.yaml
+++ b/dts/bindings/serial/cypress,psoc6-uart.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "cypress,psoc6-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/serial/intel,qmsi-uart.yaml
+++ b/dts/bindings/serial/intel,qmsi-uart.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "intel,qmsi-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/serial/litex,uart0.yaml
+++ b/dts/bindings/serial/litex,uart0.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "litex,uart0"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/serial/microsemi,coreuart.yaml
+++ b/dts/bindings/serial/microsemi,coreuart.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "microsemi,coreuart"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/serial/nordic,nrf-uart.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart.yaml
@@ -11,27 +11,27 @@ properties:
       constraint: "nordic,nrf-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     tx-pin:
       type: int
       description: TX pin
-      category: required
+      required: true
 
     rx-pin:
       type: int
       description: RX pin
-      category: required
+      required: true
 
     rts-pin:
       type: int
       description: RTS pin
-      category: optional
+      required: false
 
     cts-pin:
       type: int
       description: CTS pin
-      category: optional
+      required: false

--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -11,27 +11,27 @@ properties:
       constraint: "nordic,nrf-uarte"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     tx-pin:
       type: int
       description: TX pin
-      category: required
+      required: true
 
     rx-pin:
       type: int
       description: RX pin
-      category: required
+      required: true
 
     rts-pin:
       type: int
       description: RTS pin
-      category: optional
+      required: false
 
     cts-pin:
       type: int
       description: CTS pin
-      category: optional
+      required: false

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -11,24 +11,24 @@ properties:
       constraint: "ns16550"
 
     reg:
-      category: required
+      required: true
 
     reg-shift:
       type: int
-      category: optional
+      required: false
       description: quantity to shift the register offsets by
 
     pcp:
       type: int
-      category: optional
+      required: false
       description: custom clock (PRV_CLOCK_PARAMS, if supported)
 
     dlf:
       type: int
-      category: optional
+      required: false
       description: divisor latch fraction (DLF, if supported)
 
     pcie:
       type: boolean
-      category: optional
+      required: false
       description: attached via PCI(e) bus

--- a/dts/bindings/serial/nxp,imx-uart.yaml
+++ b/dts/bindings/serial/nxp,imx-uart.yaml
@@ -17,17 +17,17 @@ properties:
       constraint: "nxp,imx-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     modem-mode:
      type: int
-     category: required
+     required: true
      description: Set the UART Port to modem mode 0 (dce) 64 (dte)
 
     rdc:
      type: int
-     category: required
+     required: true
      description: Set the RDC permission for this peripheral

--- a/dts/bindings/serial/nxp,kinetis-lpsci.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpsci.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "nxp,kinetis-lpsci"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/serial/nxp,kinetis-lpuart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpuart.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "nxp,kinetis-lpuart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/serial/nxp,kinetis-uart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-uart.yaml
@@ -11,15 +11,15 @@ properties:
       constraint: "nxp,kinetis-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     hw-flow-control:
       type: boolean
-      category: optional
+      required: false
       description: use hw flow control
 
     clocks:
-      category: required
+      required: true

--- a/dts/bindings/serial/nxp,lpc-usart.yaml
+++ b/dts/bindings/serial/nxp,lpc-usart.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "nxp,lpc-usart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
+++ b/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
@@ -11,12 +11,12 @@ properties:
       constraint: "openisa,rv32m1-lpuart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     hw-flow-control:
       type: boolean
-      category: optional
+      required: false
       description: use hw flow control

--- a/dts/bindings/serial/sifive,uart0.yaml
+++ b/dts/bindings/serial/sifive,uart0.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "sifive,uart0"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/serial/silabs,gecko-leuart.yaml
+++ b/dts/bindings/serial/silabs,gecko-leuart.yaml
@@ -11,20 +11,20 @@ properties:
       constraint: "silabs,gecko-leuart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     # Note: Not all SoC series support setting individual pin location. If this
     # is a case all location-* properties need to have identical value.
 
     location-rx:
       type: array
-      category: required
+      required: true
       description: RX pin configuration defined as <location port pin>
 
     location-tx:
       type: array
-      category: required
+      required: true
       description: TX pin configuration defined as <location port pin>

--- a/dts/bindings/serial/silabs,gecko-uart.yaml
+++ b/dts/bindings/serial/silabs,gecko-uart.yaml
@@ -11,20 +11,20 @@ properties:
       constraint: "silabs,gecko-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     # Note: Not all SoC series support setting individual pin location. If this
     # is a case all location-* properties need to have identical value.
 
     location-rx:
       type: array
-      category: required
+      required: true
       description: RX pin configuration defined as <location port pin>
 
     location-tx:
       type: array
-      category: required
+      required: true
       description: TX pin configuration defined as <location port pin>

--- a/dts/bindings/serial/silabs,gecko-usart.yaml
+++ b/dts/bindings/serial/silabs,gecko-usart.yaml
@@ -11,20 +11,20 @@ properties:
       constraint: "silabs,gecko-usart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     # Note: Not all SoC series support setting individual pin location. If this
     # is a case all location-* properties need to have identical value.
 
     location-rx:
       type: array
-      category: required
+      required: true
       description: RX pin configuration defined as <location port pin>
 
     location-tx:
       type: array
-      category: required
+      required: true
       description: TX pin configuration defined as <location port pin>

--- a/dts/bindings/serial/snps,nsim-uart.yaml
+++ b/dts/bindings/serial/snps,nsim-uart.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "snps,nsim-uart"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/serial/st,stm32-lpuart.yaml
+++ b/dts/bindings/serial/st,stm32-lpuart.yaml
@@ -11,15 +11,15 @@ properties:
       constraint: "st,stm32-lpuart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true
 
     hw-flow-control:
       type: boolean
-      category: optional
+      required: false
       description: Set to enable RTS/CTS flow control at boot time

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -11,12 +11,12 @@ properties:
       constraint: "st,stm32-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     hw-flow-control:
       type: boolean
-      category: optional
+      required: false
       description: Set to enable RTS/CTS flow control at boot time

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -11,12 +11,12 @@ properties:
       constraint: "st,stm32-usart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     hw-flow-control:
       type: boolean
-      category: optional
+      required: false
       description: Set to enable RTS/CTS flow control at boot time

--- a/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
@@ -17,17 +17,17 @@ properties:
       constraint: "ti,cc13xx-cc26xx-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     tx-pin:
       type: int
-      category: required
+      required: true
       description: TX pin
 
     rx-pin:
       type: int
-      category: required
+      required: true
       description: RX pin

--- a/dts/bindings/serial/ti,cc32xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc32xx-uart.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "ti,cc32xx-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/serial/ti,msp432p4xx-uart.yaml
+++ b/dts/bindings/serial/ti,msp432p4xx-uart.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "ti,msp432p4xx-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/serial/ti,stellaris-uart.yaml
+++ b/dts/bindings/serial/ti,stellaris-uart.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "ti,stellaris-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/serial/uart-device.yaml
+++ b/dts/bindings/serial/uart-device.yaml
@@ -17,4 +17,4 @@ parent:
 
 properties:
     label:
-      category: required
+      required: true

--- a/dts/bindings/serial/uart.yaml
+++ b/dts/bindings/serial/uart.yaml
@@ -12,11 +12,11 @@ child:
 properties:
     clock-frequency:
       type: int
-      category: optional
+      required: false
       description: Clock frequency information for UART operation
     current-speed:
       type: int
-      category: optional
+      required: false
       description: Initial baud rate setting for UART
     label:
-      category: required
+      required: true

--- a/dts/bindings/serial/xtensa,esp32-uart.yaml
+++ b/dts/bindings/serial/xtensa,esp32-uart.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "xtensa,esp32-uart"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true

--- a/dts/bindings/spi/atmel,sam-spi.yaml
+++ b/dts/bindings/spi/atmel,sam-spi.yaml
@@ -17,12 +17,12 @@ properties:
       constraint: "atmel,sam-spi"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     peripheral-id:
       type: int
       description: peripheral ID
-      category: required
+      required: true

--- a/dts/bindings/spi/atmel,sam0-spi.yaml
+++ b/dts/bindings/spi/atmel,sam0-spi.yaml
@@ -17,24 +17,24 @@ properties:
       constraint: "atmel,sam0-spi"
 
     reg:
-      category: required
+      required: true
 
     dipo:
       type: int
-      category: required
+      required: true
       description: Data In Pinout
 
     dopo:
       type: int
-      category: required
+      required: true
       description: Data Out Pinout
 
     rxdma:
       type: int
-      category: optional
+      required: false
       description: Receive DMA channel
 
     txdma:
       type: int
-      category: optional
+      required: false
       description: Transmit DMA channel

--- a/dts/bindings/spi/intel,intel-spi.yaml
+++ b/dts/bindings/spi/intel,intel-spi.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "intel,intel-spi"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/spi/nordic,nrf-spi.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi.yaml
@@ -17,22 +17,22 @@ properties:
       constraint: "nordic,nrf-spi"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     sck-pin:
       type: int
-      category: required
+      required: true
       description: SCK pin
 
     mosi-pin:
       type: int
-      category: required
+      required: true
       description: MOSI pin
 
     miso-pin:
       type: int
-      category: required
+      required: true
       description: MISO pin

--- a/dts/bindings/spi/nordic,nrf-spis.yaml
+++ b/dts/bindings/spi/nordic,nrf-spis.yaml
@@ -17,34 +17,34 @@ properties:
       constraint: "nordic,nrf-spis"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     sck-pin:
       type: int
-      category: required
+      required: true
       description: SCK pin
 
     mosi-pin:
       type: int
-      category: required
+      required: true
       description: MOSI pin
 
     miso-pin:
       type: int
-      category: required
+      required: true
       description: MISO pin
 
     csn-pin:
       type: int
-      category: required
+      required: true
       description: CSN pin
 
     def-char:
       type: int
-      category: required
+      required: true
       description: >
           Default character. Character clocked out when the slave was not
           provided with buffers and is ignoring the transaction.

--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "nxp,imx-flexspi"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/spi/nxp,imx-lpspi.yaml
+++ b/dts/bindings/spi/nxp,imx-lpspi.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "nxp,imx-lpspi"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true

--- a/dts/bindings/spi/nxp,kinetis-dspi.yaml
+++ b/dts/bindings/spi/nxp,kinetis-dspi.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "nxp,kinetis-dspi"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true

--- a/dts/bindings/spi/sifive,spi0.yaml
+++ b/dts/bindings/spi/sifive,spi0.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "sifive,spi0"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/spi/snps,designware-spi.yaml
+++ b/dts/bindings/spi/snps,designware-spi.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "snps,designware-spi"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -17,10 +17,10 @@ parent:
 
 properties:
     reg:
-      category: required
+      required: true
     spi-max-frequency:
       type: int
-      category: required
+      required: true
       description: Maximum clock frequency of device's SPI interface in Hz
     label:
-      category: required
+      required: true

--- a/dts/bindings/spi/spi.yaml
+++ b/dts/bindings/spi/spi.yaml
@@ -18,18 +18,18 @@ child:
 properties:
     clock-frequency:
       type: int
-      category: optional
+      required: false
       description: Clock frequency the SPI peripheral is being driven at
     "#address-cells":
       type: int
-      category: required
+      required: true
       description: should be 1.
     "#size-cells":
       type: int
-      category: required
+      required: true
       description: should be 0.
     label:
-      category: required
+      required: true
     cs-gpios:
       type: compound
-      category: optional
+      required: false

--- a/dts/bindings/spi/st,stm32-spi-fifo.yaml
+++ b/dts/bindings/spi/st,stm32-spi-fifo.yaml
@@ -18,7 +18,7 @@ properties:
       constraint: "st,stm32-spi-fifo"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/spi/st,stm32-spi.yaml
+++ b/dts/bindings/spi/st,stm32-spi.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "st,stm32-spi"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/spi/ti,cc13xx-cc26xx-spi.yaml
+++ b/dts/bindings/spi/ti,cc13xx-cc26xx-spi.yaml
@@ -17,24 +17,24 @@ properties:
       constraint: "ti,cc13xx-cc26xx-spi"
 
     reg:
-      category: required
+      required: true
 
     sck-pin:
       type: int
-      category: required
+      required: true
       description: SCK pin
 
     mosi-pin:
       type: int
-      category: required
+      required: true
       description: MOSI pin
 
     miso-pin:
       type: int
-      category: required
+      required: true
       description: MISO pin
 
     cs-pin:
       type: int
-      category: optional
+      required: false
       description: CS pin

--- a/dts/bindings/sram/mmio-sram.yaml
+++ b/dts/bindings/sram/mmio-sram.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "mmio-sram"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: optional
+      required: false

--- a/dts/bindings/sram/sifive,dtim0.yaml
+++ b/dts/bindings/sram/sifive,dtim0.yaml
@@ -17,4 +17,4 @@ properties:
       constraint: "sifive,dtim0"
 
     reg:
-      category: required
+      required: true

--- a/dts/bindings/timer/arm,cmsdk-dtimer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-dtimer.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "arm,cmsdk-dtimer"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/timer/arm,cmsdk-timer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-timer.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "arm,cmsdk-timer"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/timer/atmel,sam0-tc32.yaml
+++ b/dts/bindings/timer/atmel,sam0-tc32.yaml
@@ -18,10 +18,10 @@ properties:
     constraint: "atmel,sam0-tc32"
 
   reg:
-    category: required
+    required: true
 
   interrupts:
-    category: required
+    required: true
 
   label:
-    category: required
+    required: true

--- a/dts/bindings/timer/litex,timer0.yaml
+++ b/dts/bindings/timer/litex,timer0.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "litex,timer0"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/timer/nordic,nrf-timer.yaml
+++ b/dts/bindings/timer/nordic,nrf-timer.yaml
@@ -17,15 +17,15 @@ properties:
       constraint: "nordic,nrf-timer"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     prescaler:
       type: int
-      category: required
+      required: true
       description: Prescaler value determines frequency (16MHz/2^prescaler)

--- a/dts/bindings/timer/nxp,imx-gpt.yaml
+++ b/dts/bindings/timer/nxp,imx-gpt.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "nxp,imx-gpt"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
+++ b/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "openisa,rv32m1-lptmr"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -9,21 +9,21 @@ inherits:
 properties:
     "#address-cells":
       type: int
-      category: required
+      required: true
       description: should be 1.
     "#size-cells":
       type: int
-      category: required
+      required: true
       description: should be 0.
 
     compatible:
       constraint: "st,stm32-timers"
 
     label:
-      category: required
+      required: true
 
     reg:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true

--- a/dts/bindings/usb/atmel,sam-usbhs.yaml
+++ b/dts/bindings/usb/atmel,sam-usbhs.yaml
@@ -17,12 +17,12 @@ properties:
       constraint: "atmel,sam-usbhs"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     peripheral-id:
       type: int
-      category: required
+      required: true
       description: peripheral ID

--- a/dts/bindings/usb/atmel,sam0-usb.yaml
+++ b/dts/bindings/usb/atmel,sam0-usb.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "atmel,sam0-usb"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/usb/nordic,nrf-usbd.yaml
+++ b/dts/bindings/usb/nordic,nrf-usbd.yaml
@@ -17,17 +17,17 @@ properties:
       constraint: "nordic,nrf-usbd"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     num-isoin-endpoints:
       type: int
-      category: required
+      required: true
       description: Number of ISOIN endpoints supported by hardware
 
     num-isoout-endpoints:
       type: int
-      category: required
+      required: true
       description: Number of ISOOUT endpoints supported by hardware

--- a/dts/bindings/usb/nxp,kinetis-usbd.yaml
+++ b/dts/bindings/usb/nxp,kinetis-usbd.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "nxp,kinetis-usbd"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/usb/st,stm32-otgfs.yaml
+++ b/dts/bindings/usb/st,stm32-otgfs.yaml
@@ -17,21 +17,21 @@ properties:
       constraint: "st,stm32-otgfs"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     ram-size:
       type: int
-      category: required
+      required: true
       description: Size of USB dedicated RAM. STM32 SOC's reference
                    manual defines a shared FIFO size.
 
     phys:
       type: array
-      category: optional
+      required: false
       description: PHY provider specifier
 
     clocks:
-      category: required
+      required: true

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -17,21 +17,21 @@ properties:
       constraint: "st,stm32-otghs"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     ram-size:
       type: int
-      category: required
+      required: true
       description: Size of USB dedicated RAM. STM32 SOC's reference
                    manual defines a shared FIFO size.
 
     phys:
       type: array
-      category: optional
+      required: false
       description: PHY provider specifier
 
     clocks:
-      category: required
+      required: true

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -17,33 +17,33 @@ properties:
       constraint: "st,stm32-usb"
 
     reg:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     ram-size:
       type: int
-      category: required
+      required: true
       description: Size of USB dedicated RAM. STM32 SOC's reference
                    manual defines USB packet SRAM size.
 
     disconnect-gpios:
       type: compound
-      category: optional
+      required: false
       description: Some boards use a USB DISCONNECT pin to enable
                    the pull-up resistor on USB Data Positive signal.
 
     phys:
       type: array
-      category: optional
+      required: false
       description: PHY provider specifier
 
     enable-pin-remap:
       type: boolean
-      category: optional
+      required: false
       description: For STM32F0 series SoCs on QFN28 and TSSOP20 packages
                    enable PIN pair PA11/12 mapped instead of PA9/10 (e.g. stm32f070x6)
 
     clocks:
-      category: required
+      required: true

--- a/dts/bindings/usb/usb-ep.yaml
+++ b/dts/bindings/usb/usb-ep.yaml
@@ -15,18 +15,18 @@ inherits:
 properties:
     num-bidir-endpoints:
       type: int
-      category: required
+      required: true
       description: Number of bi-directional endpoints supported by hardware
                    (including EP0)
 
     num-in-endpoints:
       type: int
-      category: optional
+      required: false
       description: Number of IN endpoints supported by hardware
                    (including EP0 IN)
 
     num-out-endpoints:
       type: int
-      category: optional
+      required: false
       description: Number of OUT endpoints supported by hardware
                    (including EP0 OUT)

--- a/dts/bindings/usb/usb.yaml
+++ b/dts/bindings/usb/usb.yaml
@@ -15,7 +15,7 @@ inherits:
 properties:
     maximum-speed:
       type: string
-      category: optional
+      required: false
       description: Configures USB controllers to work up to a specific
                    speed. Valid arguments are "super-speed", "high-speed",
                    "full-speed" and "low-speed". If this is not passed
@@ -28,4 +28,4 @@ properties:
          - "super-speed"
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
+++ b/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
@@ -11,7 +11,7 @@ properties:
       constraint: "arm,cmsdk-watchdog"
 
     reg:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true

--- a/dts/bindings/watchdog/atmel,sam-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam-watchdog.yaml
@@ -17,15 +17,15 @@ properties:
       constraint: "atmel,sam-watchdog"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     peripheral-id:
       type: int
       description: peripheral ID
-      category: required
+      required: true

--- a/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
@@ -11,10 +11,10 @@ properties:
       constraint: "atmel,sam0-watchdog"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/watchdog/intel,qmsi-watchdog.yaml
+++ b/dts/bindings/watchdog/intel,qmsi-watchdog.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "intel,qmsi-watchdog"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
+++ b/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
@@ -17,10 +17,10 @@ properties:
       constraint: "nordic,nrf-watchdog"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true

--- a/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
@@ -17,13 +17,13 @@ properties:
       constraint: "nxp,kinetis-wdog"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true

--- a/dts/bindings/watchdog/nxp,kinetis-wdog32.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog32.yaml
@@ -17,23 +17,23 @@ properties:
       constraint: "nxp,kinetis-wdog32"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     interrupts:
-      category: required
+      required: true
 
     clocks:
-      category: required
+      required: true
 
     clk-source:
       type: int
-      category: required
+      required: true
       description: Watchdog counter clock source
 
     clk-divider:
       type: int
       description: Watchdog counter clock divider
-      category: required
+      required: true

--- a/dts/bindings/watchdog/st,stm32-watchdog.yaml
+++ b/dts/bindings/watchdog/st,stm32-watchdog.yaml
@@ -17,7 +17,7 @@ properties:
       constraint: "st,stm32-watchdog"
 
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true

--- a/dts/bindings/wifi/atmel,winc1500.yaml
+++ b/dts/bindings/wifi/atmel,winc1500.yaml
@@ -18,12 +18,12 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      required: true
 
     reset-gpios:
       type: compound
-      category: required
+      required: true
 
     enable-gpios:
       type: compound
-      category: required
+      required: true

--- a/dts/bindings/wifi/inventek,eswifi.yaml
+++ b/dts/bindings/wifi/inventek,eswifi.yaml
@@ -18,16 +18,16 @@ properties:
 
     resetn-gpios:
       type: compound
-      category: required
+      required: true
 
     data-gpios:
       type: compound
-      category: required
+      required: true
 
     wakeup-gpios:
       type: compound
-      category: optional
+      required: false
 
     boot0-gpios:
       type: compound
-      category: optional
+      required: false

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -204,10 +204,9 @@ def merge_properties(parent, fname, to_dict, from_dict):
                 # ...unless it's the 'title', 'description', or 'version'
                 # property. These are overridden deliberately.
                 not k in {'title', 'version', 'description'} and
-                # Also allow the category to be changed from 'optional' to
-                # 'required' without a warning
-                not (k == "category" and to_dict[k] == "optional" and
-                     from_dict[k] == "required")):
+                # Also allow 'required' to be changed from false to true
+                # without a warning
+                not (k == "required" and not to_dict[k] and from_dict[k])):
 
                 print("extract_dts_includes.py: {}('{}') merge of property "
                       "'{}': '{}' overwrites '{}'"
@@ -247,6 +246,15 @@ def check_binding_properties(node):
     if 'id' in node:
         print("extract_dts_includes.py: WARNING: id field set "
               "in '{}', should be removed.".format(node['title']))
+
+    if 'properties' in node:
+        for prop_name, keys in node['properties'].items():
+            if 'category' in keys:
+                print("extract_dts_includes.py: WARNING: please replace "
+                      "'category: required/optional' with "
+                      "'required: true/false' in the settings for the "
+                      "property '{}' in the binding titled '{}'"
+                      .format(prop_name, node['title']))
 
 
 def define_str(name, value, value_tabs, is_deprecated=False):


### PR DESCRIPTION
The `category: required/optional` setting for properties is just a
yes/no thing. Using a boolean makes it clearer, so have
`required: true/false` instead.

The scripts in `scripts/dts/` ignore this setting, and only print a
warning if `category: required` in an inherited binding is changed
to `category: optional`. Update the code for that warning.

Print a warning if `category: ...` appears in the settings for a
property, along with a hint to replace it with `required: true/false`.
The new device tree parser will turn it into an error, and will keep the
hint.

The replacement was done with

    git ls-files 'dts/bindings/*.yaml' | xargs sed -i \
        -e 's/category:\s*required/required: true/' \
        -e 's/category:\s*optional/required: false/'

`dts/bindings/device_node.yaml.template` was updated as well.