### PR TITLE
Fixes for undefined macro warnings

### DIFF
--- a/boards/posix/native_posix/timer_model.c
+++ b/boards/posix/native_posix/timer_model.c
@@ -73,7 +73,7 @@ static u64_t tick_p; /* Period of the ticker */
 static s64_t silent_ticks;
 
 static bool real_time_mode =
-#if (CONFIG_NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME)
+#if defined(CONFIG_NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME)
 	true;
 #else
 	false;

--- a/include/logging/log_ctrl.h
+++ b/include/logging/log_ctrl.h
@@ -168,7 +168,7 @@ void log_backend_enable(struct log_backend const *const backend,
  */
 void log_backend_disable(struct log_backend const *const backend);
 
-#if CONFIG_LOG
+#if defined(CONFIG_LOG)
 #define LOG_INIT() log_init()
 #define LOG_PANIC() log_panic()
 #define LOG_PROCESS() log_process(false)

--- a/include/logging/log_instance.h
+++ b/include/logging/log_instance.h
@@ -73,7 +73,7 @@ struct log_source_dynamic_data {
 #define LOG_INSTANCE_FULL_NAME(_module_name, _inst_name) \
 	UTIL_CAT(_module_name, UTIL_CAT(_, _inst_name))
 
-#if CONFIG_LOG_RUNTIME_FILTERING
+#if defined(CONFIG_LOG_RUNTIME_FILTERING)
 #define LOG_INSTANCE_PTR_DECLARE(_name)	\
 	struct log_source_dynamic_data *_name
 

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1409,7 +1409,7 @@ int shell_execute_cmd(const struct shell *shell, const char *cmd)
 	}
 
 	if (shell == NULL) {
-#if CONFIG_SHELL_BACKEND_DUMMY
+#if defined(CONFIG_SHELL_BACKEND_DUMMY)
 		shell = shell_backend_dummy_get_ptr();
 #else
 		return -EINVAL;

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -284,7 +284,7 @@ static int cmd_help(const struct shell *shell, size_t argc, char **argv)
 		" all commands or its subcommands.\n"
 		"You can try to call commands with <-h> or <--help> parameter"
 		" for more information.");
-#if CONFIG_SHELL_METAKEYS
+#if defined(CONFIG_SHELL_METAKEYS)
 	shell_print(shell,
 		"Shell supports following meta-keys:\n"
 		"Ctrl+a, Ctrl+b, Ctrl+c, Ctrl+d, Ctrl+e, Ctrl+f, Ctrl+k,"

--- a/subsys/testsuite/include/tc_util.h
+++ b/subsys/testsuite/include/tc_util.h
@@ -107,7 +107,7 @@ static inline const char *TC_RESULT_TO_STR(int result)
 		TC_END_POST(result);                                    \
 	} while (0)
 
-#if CONFIG_SHELL
+#if defined(CONFIG_SHELL)
 #define TC_CMD_DEFINE(name)						\
 	static int cmd_##name(const struct shell *shell, size_t argc,	\
 			      char **argv) \


### PR DESCRIPTION
A few mixed fixes for undefined macro warnings (for native_posix, logger and shell)