### PR TITLE
Z_ISR_DECLARE: ensure proper alignment on 64-bit targets

### DIFF
--- a/include/sw_isr_table.h
+++ b/include/sw_isr_table.h
@@ -65,8 +65,8 @@ struct _isr_list {
  * and/or SW ISR tables.
  */
 #define Z_ISR_DECLARE(irq, flags, func, param) \
-	static struct _isr_list Z_GENERIC_SECTION(.intList) __used \
-		_MK_ISR_NAME(func, __COUNTER__) = \
+	static Z_DECL_ALIGN(struct _isr_list) Z_GENERIC_SECTION(.intList) \
+		__used _MK_ISR_NAME(func, __COUNTER__) = \
 			{irq, flags, &func, (void *)param}
 
 #define IRQ_TABLE_SIZE (CONFIG_NUM_IRQS - CONFIG_GEN_IRQ_START_VECTOR)


### PR DESCRIPTION
Prevent spurious unexpected alignment on 64-bit targets.