### PR TITLE
Bluetooth: Host: Find by type should accept 128bit UUIDs

### DIFF
--- a/include/bluetooth/uuid.h
+++ b/include/bluetooth/uuid.h
@@ -465,6 +465,38 @@ struct bt_uuid_128 {
  */
 int bt_uuid_cmp(const struct bt_uuid *u1, const struct bt_uuid *u2);
 
+/** @brief Copy UUID from packet data (LE) to internal bt_uuid.
+ *
+ *  Copy UUID from packet data in little endian format to internal bt_uuid
+ *  format. The data_len parameter is used to determine whether the received
+ *  UUID is of 16 or 128 bit format (length 2 or 16). 32 bit format is not
+ *  allowed over the air.
+ *
+ *  @param uuid Pointer to where to write the Bluetooth UUID
+ *  @param data pointer to location of the UUID in the packet
+ *  @param data_len length of the UUID in the packet
+ *
+ *  @return true if the data was valid and the UUID was successfully created.
+ */
+bool bt_uuid_create_le(struct bt_uuid *uuid, const u8_t *data, u8_t data_len);
+
+/** @brief Copy UUID from internal variable to internal bt_uuid.
+ *
+ *  Copy UUID from internal variable pointer to internal bt_uuid format.
+ *  The data parameter points to a variable (originally stored in bt_uuid_128,
+ *  bt_uuid_32 or bt_uuid_16 format) and therefore take into account of
+ *  alignment of the val member.
+ *  The data_len parameter is used to determine whether to copy the UUID from
+ *  16, 32 or 128 bit format (length 2, 4 or 16).
+ *
+ *  @param uuid Pointer to where to write the Bluetooth UUID
+ *  @param data pointer to location of the UUID variable
+ *  @param data_len length of the UUID in the packet
+ *
+ *  @return true if the data was valid and the UUID was successfully created.
+ */
+bool bt_uuid_create(struct bt_uuid *uuid, u8_t *data, u8_t data_len);
+
 #if defined(CONFIG_BT_DEBUG)
 /** @brief Convert Bluetooth UUID to string.
  *

--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -80,6 +80,53 @@ int bt_uuid_cmp(const struct bt_uuid *u1, const struct bt_uuid *u2)
 	return -EINVAL;
 }
 
+bool bt_uuid_create_le(struct bt_uuid *uuid, const u8_t *data, u8_t data_len)
+{
+	/* Copy UUID from packet data to internal bt_uuid */
+	switch (data_len) {
+	case 2:
+		uuid->type = BT_UUID_TYPE_16;
+		BT_UUID_16(uuid)->val = sys_get_le16(data);
+		break;
+	case 16:
+		uuid->type = BT_UUID_TYPE_128;
+		memcpy(&BT_UUID_128(uuid)->val, data, 16);
+		break;
+	default:
+		return false;
+	}
+	return true;
+}
+
+bool bt_uuid_create(struct bt_uuid *uuid, u8_t *data, u8_t data_len)
+{
+	/* Copy UUID from internal variable to internal bt_uuid */
+	union {
+		u16_t *u16;
+		u32_t *u32;
+		u8_t *u128;
+	} v;
+
+	v.u128 = data;
+	switch (data_len) {
+	case 2:
+		uuid->type = BT_UUID_TYPE_16;
+		BT_UUID_16(uuid)->val = *v.u16;
+		break;
+	case 4:
+		uuid->type = BT_UUID_TYPE_32;
+		BT_UUID_32(uuid)->val = *v.u32;
+		break;
+	case 16:
+		uuid->type = BT_UUID_TYPE_128;
+		memcpy(&BT_UUID_128(uuid)->val, v.u128, 16);
+		break;
+	default:
+		return false;
+	}
+	return true;
+}
+
 #if defined(CONFIG_BT_DEBUG)
 void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len)
 {


### PR DESCRIPTION
Find by type does only accept a UUID with the same length as the UUID
which is stored in the internal list. If a UUID is stored in the short
16 bit format then a request with 128 bit UUID will fail.
Add support for the missing formats.

Signed-off-by: Kim Sekkelund <ksek@oticon.com>