### PR TITLE
minimal-libc: Add define guard around struct timespec

### DIFF
--- a/include/posix/time.h
+++ b/include/posix/time.h
@@ -10,14 +10,7 @@
 extern "C" {
 #endif
 
-
-#ifndef __timespec_defined
-#define __timespec_defined
-struct timespec {
-	signed int tv_sec;
-	signed int tv_nsec;
-};
-#endif
+#include <time.h>
 
 /* Older newlib's like 2.{0-2}.0 don't define any newlib version defines, only
  * __NEWLIB_H__ so we use that to decide if itimerspec was defined in


### PR DESCRIPTION
This allows compilation with the CONFIG_POSIX_API=y.

There was a regression introduced in
https://github.com/zephyrproject-rtos/zephyr/pull/17468
that caused `struct timespec` to be redefined.

I reused the same mechanism that was there to prevent
redefinition with NEWLIB.

Signed-off-by: Piotr Zierhoffer <pzierhoffer@antmicro.com>