### PR TITLE
cmake: Instruct Python to use UTF-8 on Windows

### DIFF
--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -1,5 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# On Windows, instruct Python to output UTF-8 even when not
+# interacting with a terminal. This is required since Python scripts
+# are invoked by CMake code and, on Windows, standard I/O encoding defaults
+# to the current code page if not connected to a terminal, which is often
+# not what we want.
+if (WIN32)
+  set(ENV{PYTHONIOENCODING} "utf-8")
+endif()
+
 # The 'FindPythonInterp' that is distributed with CMake 3.8 has a bug
 # that we need to work around until we upgrade to 3.13. Until then we
 # maintain a patched copy in our repo. Bug:


### PR DESCRIPTION
In order for CMake and Python to interact correctly when the former
invokes the latter, ensure that Python uses UTF-8 encodings when
interacting with stdout and stdin on Windows.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>