### PR TITLE
drivers : timer : Add MEC1501 32KHz kernel timer driver

### DIFF
--- a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
@@ -18,5 +18,8 @@ config NUM_IRQS
 	# All NVIC external sources.
 	default 174
 
+config ARCH_HAS_CUSTOM_BUSY_WAIT
+	default y
+
 source "soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501*"
 endif # SOC_SERIES_MEC1501X


### PR DESCRIPTION
Add a kernel timer driver for the MEC1501 32KHz RTOS timer.
This timer is a count down 32-bit counter clocked at a fixed
32768 Hz. It features one-shot, auto-reload, and halt count down
while the Cortex-M is halted by JTAG/SWD. This driver is based
on the new Intel local APIC driver. The driver was tuned for
accuracy at small sleep values. Added a work-around for RTOS
timer restart issue. RTOS timer driver requires board ticks per
second to be 32768 if tickless operation is configured. Because a
32KHz timer cannot provide the 1us resolution for the kernel's
busy wait API we use a 32-bit high speed peripheral timer for
this purpose in the SoC layer.

Signed-off-by: Scott Worley <scott.worley@microchip.com>