### PR TITLE
dts/bindings: Cleanup microchip,xec-rtos-timer binding

### DIFF
--- a/dts/bindings/timer/microchip,xec-rtos-timer.yaml
+++ b/dts/bindings/timer/microchip,xec-rtos-timer.yaml
@@ -3,35 +3,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Microchip XEC RTOS timer
-version: 0.1
 
 description: >
     This is a representation of the Microchip XEC RTOS timer node
 
+inherits:
+    !include base.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "microchip,xec-rtos-timer"
 
     reg:
-      type: array
       category: required
-      description: mmio register space
-      generation: define
 
     interrupts:
-      type: array
       category: required
-      description: required interrupts
-      generation: define
 
     label:
-      type: string
       category: required
-      description: Human readable string describing the device (used by Zephyr for API name)
-      generation: define
 ...


### PR DESCRIPTION
* Remove version field
* Utilize base.yaml to reduce duplication
* Remove document separators

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>