### PR TITLE
sys/sem.h: fix path to atomic.h

### DIFF
--- a/include/sys/sem.h
+++ b/include/sys/sem.h
@@ -20,7 +20,7 @@
  */
 
 #include <kernel.h>
-#include <atomic.h>
+#include <sys/atomic.h>
 #include <zephyr/types.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Use of old location produces a compiler warning.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>