### PR TITLE
X86 optimize context switch

### DIFF
--- a/arch/arc/core/mpu/arc_core_mpu.c
+++ b/arch/arc/core/mpu/arc_core_mpu.c
@@ -9,6 +9,7 @@
 #include <kernel.h>
 #include <soc.h>
 #include <arch/arc/v2/mpu/arc_core_mpu.h>
+#include <kernel_structs.h>
 
 /*
  * @brief Configure MPU for the thread
@@ -37,6 +38,10 @@ int z_arch_mem_domain_max_partitions_get(void)
 void z_arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 				       u32_t partition_id)
 {
+	if (_current->mem_domain_info.mem_domain != domain) {
+		return;
+	}
+
 	arc_core_mpu_disable();
 	arc_core_mpu_remove_mem_partition(domain, partition_id);
 	arc_core_mpu_enable();
@@ -45,8 +50,12 @@ void z_arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 /*
  * Configure MPU memory domain
  */
-void z_arch_mem_domain_configure(struct k_thread *thread)
+void z_arch_mem_domain_thread_add(struct k_thread *thread)
 {
+	if (_current != thread) {
+		return;
+	}
+
 	arc_core_mpu_disable();
 	arc_core_mpu_configure_mem_domain(thread);
 	arc_core_mpu_enable();
@@ -57,6 +66,10 @@ void z_arch_mem_domain_configure(struct k_thread *thread)
  */
 void z_arch_mem_domain_destroy(struct k_mem_domain *domain)
 {
+	if (_current->mem_domain_info.mem_domain != domain) {
+		return;
+	}
+
 	arc_core_mpu_disable();
 	arc_core_mpu_remove_mem_domain(domain);
 	arc_core_mpu_enable();
@@ -66,6 +79,15 @@ void z_arch_mem_domain_partition_add(struct k_mem_domain *domain,
 				    u32_t partition_id)
 {
 	/* No-op on this architecture */
+}
+
+void z_arch_mem_domain_thread_remove(struct k_thread *thread)
+{
+	if (_current != thread) {
+		return;
+	}
+
+	z_arch_mem_domain_destroy(thread->mem_domain_info.mem_domain);
 }
 
 /*

--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -136,8 +136,8 @@ FUNC_NORETURN void z_x86_fatal_error(unsigned int reason, const z_arch_esf_t *es
 			      esf->eax, esf->ebx, esf->ecx, esf->edx);
 		z_fatal_print("esi: 0x%08x, edi: 0x%08x, ebp: 0x%08x, esp: 0x%08x",
 			      esf->esi, esf->edi, esf->ebp, esf->esp);
-		z_fatal_print("eflags: 0x%08x cs: 0x%04x", esf->eflags,
-			      esf->cs & 0xFFFFU);
+		z_fatal_print("eflags: 0x%08x cs: 0x%04x cr3: %p", esf->eflags,
+			      esf->cs & 0xFFFFU, z_x86_page_tables_get());
 
 #ifdef CONFIG_EXCEPTION_STACK_TRACE
 		z_fatal_print("call trace:");

--- a/arch/x86/core/ia32/swap.S
+++ b/arch/x86/core/ia32/swap.S
@@ -22,8 +22,8 @@
 	GTEXT(_x86_user_thread_entry_wrapper)
 
 	/* externs */
-#ifdef CONFIG_X86_USERSPACE
-	GTEXT(_x86_swap_update_page_tables)
+#if !defined(CONFIG_X86_KPTI) && defined(CONFIG_X86_USERSPACE)
+	GTEXT(z_x86_swap_update_page_tables)
 #endif
 	GDATA(_k_neg_eagain)
 
@@ -148,21 +148,23 @@ SECTION_FUNC(TEXT, __swap)
 	 * thread to be swapped in, and %edi still contains &_kernel. %edx
 	 * has the pointer to the outgoing thread.
 	 */
-#ifdef CONFIG_X86_USERSPACE
+#if defined(CONFIG_X86_USERSPACE) && !defined(CONFIG_X86_KPTI)
 
 #ifdef CONFIG_X86_IAMCU
 	push	%eax
 #else
-	push	%edx
 	push	%eax
 #endif
-	call	_x86_swap_update_page_tables
+	call	z_x86_swap_update_page_tables
 #ifdef CONFIG_X86_IAMCU
 	pop	%eax
 #else
 	pop	%eax
-	pop	%edx
 #endif
+	/* Page tables updated. All memory access after this point needs to be
+	 * to memory that has the same mappings and access attributes wrt
+	 * supervisor mode!
+	 */
 #endif
 
 #ifdef CONFIG_EAGER_FP_SHARING

--- a/arch/x86/core/ia32/thread.c
+++ b/arch/x86/core/ia32/thread.c
@@ -159,8 +159,10 @@ void _x86_swap_update_page_tables(struct k_thread *incoming,
 		 /* Ensure that the outgoing mem domain configuration
 		  * is set back to default state.
 		  */
-		z_arch_mem_domain_destroy(outgoing->mem_domain_info.mem_domain);
-		z_arch_mem_domain_configure(incoming);
+		z_x86_mem_domain_pages_update(outgoing->mem_domain_info.mem_domain,
+					    X86_MEM_DOMAIN_RESET_PAGES);
+		z_x86_mem_domain_pages_update(incoming->mem_domain_info.mem_domain,
+					    X86_MEM_DOMAIN_SET_PAGES);
 	}
 }
 

--- a/arch/x86/core/ia32/thread.c
+++ b/arch/x86/core/ia32/thread.c
@@ -79,8 +79,8 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #endif /* CONFIG_X86_USERSPACE */
 
 #if CONFIG_X86_STACK_PROTECTION
-	z_x86_mmu_set_flags(&z_x86_kernel_pdpt, stack, MMU_PAGE_SIZE,
-			    MMU_ENTRY_READ, MMU_PTE_RW_MASK);
+	z_x86_mmu_set_flags(&z_x86_kernel_pdpt, stack + Z_X86_THREAD_PT_AREA,
+			    MMU_PAGE_SIZE, MMU_ENTRY_READ, MMU_PTE_RW_MASK);
 #endif
 
 	stack_high = (char *)STACK_ROUND_DOWN(stack_buf + stack_size);

--- a/arch/x86/core/ia32/thread.c
+++ b/arch/x86/core/ia32/thread.c
@@ -38,6 +38,141 @@ struct _x86_initial_frame {
 	void *p3;
 };
 
+#ifdef CONFIG_X86_USERSPACE
+/* Nothing to do here if KPTI is enabled. We are in supervisor mode, so the
+ * active PDPT is the kernel's page tables. If the incoming thread is in user
+ * mode we are going to switch CR3 to the thread- specific tables when we go
+ * through z_x86_trampoline_to_user.
+ *
+ * We don't need to update _main_tss either, privilege elevation always lands
+ * on the trampoline stack and the irq/sycall code has to manually transition
+ * off of it to the thread's kernel stack after switching page tables.
+ */
+#ifndef CONFIG_X86_KPTI
+/* Change to new set of page tables. ONLY intended for use from
+ * z_x88_swap_update_page_tables(). This changes CR3, no memory access
+ * afterwards is legal unless it is known for sure that the relevant
+ * mappings are identical wrt supervisor mode until we iret out.
+ */
+static inline void page_tables_set(struct x86_mmu_pdpt *pdpt)
+{
+	__asm__ volatile("movl %0, %%cr3\n\t" : : "r" (pdpt) : "memory");
+}
+
+/* Update the to the incoming thread's page table, and update the location
+ * of the privilege elevation stack.
+ *
+ * May be called ONLY during context switch and when supervisor
+ * threads drop synchronously to user mode. Hot code path!
+ */
+void z_x86_swap_update_page_tables(struct k_thread *incoming)
+{
+	struct x86_mmu_pdpt *pdpt;
+
+	/* If we're a user thread, we want the active page tables to
+	 * be the per-thread instance.
+	 *
+	 * However, if we're a supervisor thread, use the master
+	 * kernel page tables instead.
+	 */
+	if ((incoming->base.user_options & K_USER) != 0) {
+		pdpt = z_x86_pdpt_get(incoming);
+
+		/* In case of privilege elevation, use the incoming
+		 * thread's kernel stack. This area starts immediately
+		 * before the PDPT.
+		 */
+		_main_tss.esp0 = (uintptr_t)pdpt;
+	} else {
+		pdpt = &z_x86_kernel_pdpt;
+	}
+
+	/* Check first that we actually need to do this, since setting
+	 * CR3 involves an expensive full TLB flush.
+	 */
+	if (pdpt != z_x86_page_tables_get()) {
+		page_tables_set(pdpt);
+	}
+}
+#endif /* CONFIG_X86_KPTI */
+
+static FUNC_NORETURN void drop_to_user(k_thread_entry_t user_entry,
+				       void *p1, void *p2, void *p3)
+{
+	u32_t stack_end;
+
+	/* Transition will reset stack pointer to initial, discarding
+	 * any old context since this is a one-way operation
+	 */
+	stack_end = STACK_ROUND_DOWN(_current->stack_info.start +
+				     _current->stack_info.size);
+
+	z_x86_userspace_enter(user_entry, p1, p2, p3, stack_end,
+			      _current->stack_info.start);
+	CODE_UNREACHABLE;
+}
+
+FUNC_NORETURN void z_arch_user_mode_enter(k_thread_entry_t user_entry,
+					 void *p1, void *p2, void *p3)
+{
+	/* Set up the kernel stack used during privilege elevation */
+	z_x86_mmu_set_flags(&z_x86_kernel_pdpt,
+			    (void *)(_current->stack_info.start -
+				     MMU_PAGE_SIZE),
+			    MMU_PAGE_SIZE, MMU_ENTRY_WRITE, MMU_PTE_RW_MASK,
+			    true);
+
+	/* Initialize per-thread page tables, since that wasn't done when
+	 * the thread was initialized (K_USER was not set at creation time)
+	 */
+	z_x86_thread_pt_init(_current);
+
+	/* Apply memory domain configuration, if assigned */
+	if (_current->mem_domain_info.mem_domain != NULL) {
+		z_x86_apply_mem_domain(z_x86_pdpt_get(_current),
+				       _current->mem_domain_info.mem_domain);
+	}
+
+#ifndef CONFIG_X86_KPTI
+	/* We're synchronously dropping into user mode from a thread that
+	 * used to be in supervisor mode. K_USER flag has now been set, but
+	 * Need to swap from the kernel's page tables to the per-thread page
+	 * tables.
+	 *
+	 * Safe to update page tables from here, all tables are identity-
+	 * mapped and memory areas used before the ring 3 transition all
+	 * have the same attributes wrt supervisor mode access.
+	 */
+	z_x86_swap_update_page_tables(_current);
+#endif
+
+	drop_to_user(user_entry, p1, p2, p3);
+}
+
+/* Implemented in userspace.S */
+extern void z_x86_syscall_entry_stub(void);
+
+/* Syscalls invoked by 'int 0x80'. Installed in the IDT at DPL=3 so that
+ * userspace can invoke it.
+ */
+NANO_CPU_INT_REGISTER(z_x86_syscall_entry_stub, -1, -1, 0x80, 3);
+
+#endif /* CONFIG_X86_USERSPACE */
+
+#if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING)
+
+extern int z_float_disable(struct k_thread *thread);
+
+int z_arch_float_disable(struct k_thread *thread)
+{
+#if defined(CONFIG_LAZY_FP_SHARING)
+	return z_float_disable(thread);
+#else
+	return -ENOSYS;
+#endif /* CONFIG_LAZY_FP_SHARING */
+}
+#endif /* CONFIG_FLOAT && CONFIG_FP_SHARING */
+
 /**
  * @brief Create a new kernel execution thread
  *
@@ -67,20 +202,22 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	stack_buf = Z_THREAD_STACK_BUFFER(stack);
 	z_new_thread_init(thread, stack_buf, stack_size, priority, options);
 
-#if CONFIG_X86_USERSPACE
-	if ((options & K_USER) == 0U) {
-		/* Running in kernel mode, kernel stack region is also a guard
-		 * page */
-		z_x86_mmu_set_flags(&z_x86_kernel_pdpt,
-				    (void *)(stack_buf - MMU_PAGE_SIZE),
-				    MMU_PAGE_SIZE, MMU_ENTRY_READ,
-				    MMU_PTE_RW_MASK);
-	}
+#ifdef CONFIG_X86_USERSPACE
+	/* Set MMU properties for the privilege mode elevation stack.
+	 * If we're not starting in user mode, this functions as a guard
+	 * area.
+	 */
+	z_x86_mmu_set_flags(&z_x86_kernel_pdpt,
+		(void *)(stack_buf - MMU_PAGE_SIZE), MMU_PAGE_SIZE,
+		((options & K_USER) == 0U) ? MMU_ENTRY_READ : MMU_ENTRY_WRITE,
+		MMU_PTE_RW_MASK, true);
 #endif /* CONFIG_X86_USERSPACE */
 
 #if CONFIG_X86_STACK_PROTECTION
+	/* Set guard area to read-only to catch stack overflows */
 	z_x86_mmu_set_flags(&z_x86_kernel_pdpt, stack + Z_X86_THREAD_PT_AREA,
-			    MMU_PAGE_SIZE, MMU_ENTRY_READ, MMU_PTE_RW_MASK);
+			    MMU_PAGE_SIZE, MMU_ENTRY_READ, MMU_PTE_RW_MASK,
+			    true);
 #endif
 
 	stack_high = (char *)STACK_ROUND_DOWN(stack_buf + stack_size);
@@ -96,11 +233,12 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	initial_frame->eflags = EFLAGS_INITIAL;
 #ifdef CONFIG_X86_USERSPACE
 	if ((options & K_USER) != 0U) {
+		z_x86_thread_pt_init(thread);
 #ifdef _THREAD_WRAPPER_REQUIRED
-		initial_frame->edi = (u32_t)z_arch_user_mode_enter;
+		initial_frame->edi = (u32_t)drop_to_user;
 		initial_frame->thread_entry = z_x86_thread_entry_wrapper;
 #else
-		initial_frame->thread_entry = z_arch_user_mode_enter;
+		initial_frame->thread_entry = drop_to_user;
 #endif /* _THREAD_WRAPPER_REQUIRED */
 	} else
 #endif /* CONFIG_X86_USERSPACE */
@@ -121,94 +259,3 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	thread->arch.excNestCount = 0;
 #endif /* CONFIG_LAZY_FP_SHARING */
 }
-
-#ifdef CONFIG_X86_USERSPACE
-void _x86_swap_update_page_tables(struct k_thread *incoming,
-				  struct k_thread *outgoing)
-{
-	/* Outgoing thread stack no longer accessible */
-	z_x86_reset_pages((void *)outgoing->stack_info.start,
-			   ROUND_UP(outgoing->stack_info.size, MMU_PAGE_SIZE));
-
-	/* Userspace can now access the incoming thread's stack */
-	z_x86_mmu_set_flags(&USER_PDPT,
-			   (void *)incoming->stack_info.start,
-			   ROUND_UP(incoming->stack_info.size, MMU_PAGE_SIZE),
-			   MMU_ENTRY_PRESENT | K_MEM_PARTITION_P_RW_U_RW,
-			   K_MEM_PARTITION_PERM_MASK | MMU_PTE_P_MASK);
-
-#ifndef CONFIG_X86_KPTI
-	/* In case of privilege elevation, use the incoming thread's kernel
-	 * stack, the top of the thread stack is the bottom of the kernel
-	 * stack.
-	 *
-	 * If KPTI is enabled, then privilege elevation always lands on the
-	 * trampoline stack and the irq/sycall code has to manually transition
-	 * off of it to the thread's kernel stack after switching page
-	 * tables.
-	 */
-	_main_tss.esp0 = incoming->stack_info.start;
-#endif
-
-	/* If either thread defines different memory domains, efficiently
-	 * switch between them
-	 */
-	if (incoming->mem_domain_info.mem_domain !=
-	   outgoing->mem_domain_info.mem_domain){
-
-		 /* Ensure that the outgoing mem domain configuration
-		  * is set back to default state.
-		  */
-		z_x86_mem_domain_pages_update(outgoing->mem_domain_info.mem_domain,
-					    X86_MEM_DOMAIN_RESET_PAGES);
-		z_x86_mem_domain_pages_update(incoming->mem_domain_info.mem_domain,
-					    X86_MEM_DOMAIN_SET_PAGES);
-	}
-}
-
-
-FUNC_NORETURN void z_arch_user_mode_enter(k_thread_entry_t user_entry,
-					 void *p1, void *p2, void *p3)
-{
-	u32_t stack_end;
-
-	/* Transition will reset stack pointer to initial, discarding
-	 * any old context since this is a one-way operation
-	 */
-	stack_end = STACK_ROUND_DOWN(_current->stack_info.start +
-				     _current->stack_info.size);
-
-	/* Set up the kernel stack used during privilege elevation */
-	z_x86_mmu_set_flags(&z_x86_kernel_pdpt,
-			    (void *)(_current->stack_info.start - MMU_PAGE_SIZE),
-			    MMU_PAGE_SIZE, MMU_ENTRY_WRITE, MMU_PTE_RW_MASK);
-
-	z_x86_userspace_enter(user_entry, p1, p2, p3, stack_end,
-			     _current->stack_info.start);
-	CODE_UNREACHABLE;
-}
-
-
-/* Implemented in userspace.S */
-extern void z_x86_syscall_entry_stub(void);
-
-/* Syscalls invoked by 'int 0x80'. Installed in the IDT at DPL=3 so that
- * userspace can invoke it.
- */
-NANO_CPU_INT_REGISTER(z_x86_syscall_entry_stub, -1, -1, 0x80, 3);
-
-#endif /* CONFIG_X86_USERSPACE */
-
-#if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING)
-
-extern int z_float_disable(struct k_thread *thread);
-
-int z_arch_float_disable(struct k_thread *thread)
-{
-#if defined(CONFIG_LAZY_FP_SHARING)
-	return z_float_disable(thread);
-#else
-	return -ENOSYS;
-#endif /* CONFIG_LAZY_FP_SHARING */
-}
-#endif /* CONFIG_FLOAT && CONFIG_FP_SHARING */

--- a/arch/x86/core/ia32/thread.c
+++ b/arch/x86/core/ia32/thread.c
@@ -72,15 +72,15 @@ void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 		/* Running in kernel mode, kernel stack region is also a guard
 		 * page */
 		z_x86_mmu_set_flags(&z_x86_kernel_pdpt,
-				   (void *)(stack_buf - MMU_PAGE_SIZE),
-				   MMU_PAGE_SIZE, MMU_ENTRY_NOT_PRESENT,
-				   MMU_PTE_P_MASK);
+				    (void *)(stack_buf - MMU_PAGE_SIZE),
+				    MMU_PAGE_SIZE, MMU_ENTRY_READ,
+				    MMU_PTE_RW_MASK);
 	}
 #endif /* CONFIG_X86_USERSPACE */
 
 #if CONFIG_X86_STACK_PROTECTION
 	z_x86_mmu_set_flags(&z_x86_kernel_pdpt, stack, MMU_PAGE_SIZE,
-			   MMU_ENTRY_NOT_PRESENT, MMU_PTE_P_MASK);
+			    MMU_ENTRY_READ, MMU_PTE_RW_MASK);
 #endif
 
 	stack_high = (char *)STACK_ROUND_DOWN(stack_buf + stack_size);
@@ -178,12 +178,8 @@ FUNC_NORETURN void z_arch_user_mode_enter(k_thread_entry_t user_entry,
 
 	/* Set up the kernel stack used during privilege elevation */
 	z_x86_mmu_set_flags(&z_x86_kernel_pdpt,
-			   (void *)(_current->stack_info.start - MMU_PAGE_SIZE),
-			   MMU_PAGE_SIZE,
-			   (MMU_ENTRY_PRESENT | MMU_ENTRY_WRITE |
-			    MMU_ENTRY_SUPERVISOR),
-			   (MMU_PTE_P_MASK | MMU_PTE_RW_MASK |
-			    MMU_PTE_US_MASK));
+			    (void *)(_current->stack_info.start - MMU_PAGE_SIZE),
+			    MMU_PAGE_SIZE, MMU_ENTRY_WRITE, MMU_PTE_RW_MASK);
 
 	z_x86_userspace_enter(user_entry, p1, p2, p3, stack_end,
 			     _current->stack_info.start);

--- a/arch/x86/core/ia32/userspace.S
+++ b/arch/x86/core/ia32/userspace.S
@@ -58,13 +58,14 @@ SECTION_FUNC(TEXT, z_x86_trampoline_to_kernel)
 
 	/* %esp = _kernel->current->stack_info.start
 	 *
-	 * This is the lowest address of the user mode stack, and highest
-	 * address of the kernel stack, they are adjacent.
-	 * We want to transplant context here.
+	 * This is the lowest address of the user mode stack, the PDPT is
+	 * immediately before it, and then the highest address of the kernel
+	 * stack. We want to transplant context here.
 	 */
 	movl	$_kernel, %esi
 	movl	_kernel_offset_to_current(%esi), %esi
 	movl	_thread_offset_to_stack_start(%esi), %esp
+	subl	$Z_X86_PDPT_SIZE, %esp
 
 	/* Transplant stack context and restore ESI/EDI. Taking care to zero
 	 * or put uninteresting values where we stashed ESI/EDI since the
@@ -134,9 +135,15 @@ SECTION_FUNC(TEXT, z_x86_trampoline_to_user_always)
 	xchgl	%edi, (%edi)	/* Exchange old edi to restore it and put
 				   trampoline stack address in its old storage
 				   area */
-	/* Switch to user page table */
+	/* Switch to user page table. The per-thread user page table is
+	 * located at the highest addresses of the privilege mode elevation
+	 * stack, immediately below the thread stack buffer.
+	 */
 	pushl	%eax
-	movl	$z_x86_user_pdpt, %eax
+	movl	$_kernel, %eax
+	movl	_kernel_offset_to_current(%eax), %eax
+	movl	_thread_offset_to_stack_start(%eax), %eax
+	subl	$Z_X86_PDPT_SIZE, %eax
 	movl	%eax, %cr3
 	popl	%eax
 	movl	$0, -4(%esp)	/* Delete stashed EAX data */
@@ -166,13 +173,14 @@ SECTION_FUNC(TEXT, z_x86_syscall_entry_stub)
 
 	/* %esp = _kernel->current->stack_info.start
 	 *
-	 * This is the lowest address of the user mode stack, and highest
-	 * address of the kernel stack, they are adjacent.
-	 * We want to transplant context here.
+	 * This is the lowest address of the user mode stack, the PDPT is
+	 * immediately before it, and then the highest address of the kernel
+	 * stack. We want to transplant context here.
 	 */
 	movl	$_kernel, %esi
 	movl	_kernel_offset_to_current(%esi), %esi
 	movl	_thread_offset_to_stack_start(%esi), %esp
+	subl	$Z_X86_PDPT_SIZE, %esp
 
 	/* Transplant context according to layout above. Variant of logic
 	 * in x86_trampoline_to_kernel */
@@ -324,6 +332,7 @@ SECTION_FUNC(TEXT, z_x86_userspace_enter)
 	 * want to leak any information.
 	 */
 	mov	%edi, %esp
+	subl	$Z_X86_PDPT_SIZE, %esp
 
 	/* Stash some registers we are going to need to erase the user
 	 * stack.

--- a/arch/x86/core/offsets/offsets.c
+++ b/arch/x86/core/offsets/offsets.c
@@ -38,6 +38,10 @@ GEN_OFFSET_SYM(_thread_arch_t, excNestCount);
 
 GEN_OFFSET_SYM(_thread_arch_t, preempFloatReg);
 
+#ifdef CONFIG_USERSPACE
+GEN_ABSOLUTE_SYM(Z_X86_PDPT_SIZE, sizeof(struct x86_mmu_pdpt));
+#endif
+
 /**
  * size of the struct k_thread structure sans save area for floating
  * point regs

--- a/arch/x86/include/ia32/kernel_arch_func.h
+++ b/arch/x86/include/ia32/kernel_arch_func.h
@@ -81,6 +81,13 @@ extern FUNC_NORETURN void z_x86_userspace_enter(k_thread_entry_t user_entry,
 					       u32_t stack_end,
 					       u32_t stack_start);
 
+/* Helper macros needed to be passed to x86_update_mem_domain_pages */
+#define X86_MEM_DOMAIN_SET_PAGES   (0U)
+#define X86_MEM_DOMAIN_RESET_PAGES (1U)
+
+extern void z_x86_mem_domain_pages_update(struct k_mem_domain *mem_domain,
+					  u32_t page_conf);
+
 #include <stddef.h> /* For size_t */
 
 #ifdef __cplusplus

--- a/arch/x86/include/ia32/kernel_arch_func.h
+++ b/arch/x86/include/ia32/kernel_arch_func.h
@@ -89,9 +89,10 @@ void z_x86_apply_mem_domain(struct x86_mmu_pdpt *pdpt,
 
 static inline struct x86_mmu_pdpt *z_x86_pdpt_get(struct k_thread *thread)
 {
-	uintptr_t addr = thread->stack_info.start;
+	struct z_x86_thread_stack_header *header =
+		(struct z_x86_thread_stack_header *)thread->stack_obj;
 
-	return (struct x86_mmu_pdpt *)(addr - sizeof(struct x86_mmu_pdpt));
+	return &header->kernel_data.pdpt;
 }
 #endif /* CONFIG_USERSPACE */
 #include <stddef.h> /* For size_t */

--- a/arch/x86/include/ia32/kernel_arch_func.h
+++ b/arch/x86/include/ia32/kernel_arch_func.h
@@ -49,7 +49,7 @@ static inline void kernel_arch_init(void)
 #endif
 #if CONFIG_X86_STACK_PROTECTION
 	z_x86_mmu_set_flags(&z_x86_kernel_pdpt, _interrupt_stack, MMU_PAGE_SIZE,
-			   MMU_ENTRY_NOT_PRESENT, MMU_PTE_P_MASK);
+			    MMU_ENTRY_READ, MMU_PTE_RW_MASK);
 #endif
 }
 

--- a/arch/x86/include/ia32/kernel_arch_thread.h
+++ b/arch/x86/include/ia32/kernel_arch_thread.h
@@ -35,6 +35,7 @@
 
 #ifndef _ASMLANGUAGE
 #include <stdint.h>
+#include <ia32/mmustructs.h>
 
 /*
  * The following structure defines the set of 'non-volatile' integer registers.
@@ -221,6 +222,24 @@ struct _thread_arch {
 	 * struct without ill effect.
 	 */
 	tPreempFloatReg preempFloatReg; /* volatile float register storage */
+
+#ifdef CONFIG_USERSPACE
+	/* Per-thread page directory pointer table when a thread is running
+	 * in user mode.
+	 *
+	 * With KPTI enabled, any privilege elevation while that thread is
+	 * running, or ISR will switch to the master kernel pdpt at
+	 * z_x86_kernel_pdpt; the memory domain policy will not apply at
+	 * all.
+	 *
+	 * With KPTI disabled, this pdpt will be active at all times when
+	 * the thread is running. This has implications for memory domain
+	 * partitions that are read-only!!
+	 *
+	 * See #17833 for more discussion.
+	 */
+	__aligned(0x20) struct x86_mmu_pdpt user_pdpt;
+#endif /* CONFIG_USERSPACE */
 };
 
 typedef struct _thread_arch _thread_arch_t;

--- a/arch/x86/include/ia32/mmustructs.h
+++ b/arch/x86/include/ia32/mmustructs.h
@@ -526,11 +526,6 @@ struct x86_mmu_pt {
  */
 void z_x86_dump_page_tables(struct x86_mmu_pdpt *pdpt);
 
-static inline void z_x86_page_tables_set(struct x86_mmu_pdpt *pdpt)
-{
-	__asm__ volatile("movl %0, %%cr3\n\t" : : "r" (pdpt));
-}
-
 static inline struct x86_mmu_pdpt *z_x86_page_tables_get(void)
 {
 	struct x86_mmu_pdpt *ret;

--- a/arch/x86/include/ia32/mmustructs.h
+++ b/arch/x86/include/ia32/mmustructs.h
@@ -476,13 +476,21 @@ union x86_mmu_pte {
 	};
 };
 
+#define Z_X86_NUM_PDPT_ENTRIES	4
+#define Z_X86_NUM_PD_ENTRIES	512
+#define Z_X86_NUM_PT_ENTRIES	512
+
+/* Memory range covered by an instance of various table types */
+#define Z_X86_PT_AREA	(MMU_PAGE_SIZE * Z_X86_NUM_PT_ENTRIES)
+#define Z_X86_PD_AREA	(Z_X86_PT_AREA * Z_X86_NUM_PD_ENTRIES)
+#define Z_X86_PDPT_AREA (Z_X86_PD_AREA * Z_X86_NUM_PDPT_ENTRIES)
 
 typedef u64_t x86_page_entry_data_t;
 
 typedef x86_page_entry_data_t k_mem_partition_attr_t;
 
 struct x86_mmu_pdpt {
-	union x86_mmu_pdpte entry[4];
+	union x86_mmu_pdpte entry[Z_X86_NUM_PDPT_ENTRIES];
 };
 
 union x86_mmu_pde {
@@ -491,11 +499,11 @@ union x86_mmu_pde {
 };
 
 struct x86_mmu_pd {
-	union x86_mmu_pde entry[512];
+	union x86_mmu_pde entry[Z_X86_NUM_PD_ENTRIES];
 };
 
 struct x86_mmu_pt {
-	union x86_mmu_pte entry[512];
+	union x86_mmu_pte entry[Z_X86_NUM_PT_ENTRIES];
 };
 
 #endif /* _ASMLANGUAGE */

--- a/arch/x86/include/ia32/mmustructs.h
+++ b/arch/x86/include/ia32/mmustructs.h
@@ -526,6 +526,19 @@ struct x86_mmu_pt {
  */
 void z_x86_dump_page_tables(struct x86_mmu_pdpt *pdpt);
 
+static inline void z_x86_page_tables_set(struct x86_mmu_pdpt *pdpt)
+{
+	__asm__ volatile("movl %0, %%cr3\n\t" : : "r" (pdpt));
+}
+
+static inline struct x86_mmu_pdpt *z_x86_page_tables_get(void)
+{
+	struct x86_mmu_pdpt *ret;
+
+	__asm__ volatile("movl %%cr3, %0\n\t" : "=r" (ret));
+
+	return ret;
+}
 #endif /* _ASMLANGUAGE */
 
 #endif /* ZEPHYR_ARCH_X86_INCLUDE_IA32_MMUSTRUCTS_H_ */

--- a/arch/x86/include/ia32/mmustructs.h
+++ b/arch/x86/include/ia32/mmustructs.h
@@ -506,6 +506,26 @@ struct x86_mmu_pt {
 	union x86_mmu_pte entry[Z_X86_NUM_PT_ENTRIES];
 };
 
+/**
+ * Debug function for dumping out page tables
+ *
+ * Iterates through the entire linked set of page table structures,
+ * dumping out codes for the configuration of each table entry.
+ *
+ * Entry codes:
+ *
+ *   . - not present
+ *   w - present, writable, not executable
+ *   a - present, writable, executable
+ *   r - present, read-only, not executable
+ *   x - present, read-only, executable
+ *
+ * Entry codes in uppercase indicate that user mode may access.
+ *
+ * @param pdpt Top-level pointer to the page tables, as programmed in CR3
+ */
+void z_x86_dump_page_tables(struct x86_mmu_pdpt *pdpt);
+
 #endif /* _ASMLANGUAGE */
 
 #endif /* ZEPHYR_ARCH_X86_INCLUDE_IA32_MMUSTRUCTS_H_ */

--- a/include/arch/x86/ia32/arch.h
+++ b/include/arch/x86/ia32/arch.h
@@ -22,6 +22,7 @@
 #include <ia32/mmustructs.h>
 #include <stdbool.h>
 #include <arch/common/ffs.h>
+#include <misc/util.h>
 
 #ifndef _ASMLANGUAGE
 #include <arch/common/addr_types.h>
@@ -571,41 +572,122 @@ extern u32_t z_timer_cycle_get_32(void);
 extern struct task_state_segment _main_tss;
 #endif
 
+#ifdef CONFIG_USERSPACE
+/* We need a set of page tables for each thread in the system which runs in
+ * user mode. For each thread, we have:
+ *
+ *   - a toplevel PDPT
+ *   - a set of page directories for the memory range covered by system RAM
+ *   - a set of page tbales for the memory range covered by system RAM
+ *
+ * Directories and tables for memory ranges outside of system RAM will be
+ * shared and not thread-specific.
+ *
+ * NOTE: We are operating under the assumption that memory domain partitions
+ * will not be configured which grant permission to address ranges outside
+ * of system RAM.
+ *
+ * Each of these page tables will be programmed to reflect the memory
+ * permission policy for that thread, which will be the union of:
+ *
+ *   - The boot time memory regions (text, rodata, and so forth)
+ *   - The thread's stack buffer
+ *   - Partitions in the memory domain configuration (if a member of a
+ *     memory domain)
+ *
+ * The PDPT is fairly small singleton on x86 PAE (32 bytes) and also must
+ * be aligned to 32 bytes, so we place it at the highest addresses of the
+ * page reserved for the privilege elevation stack.
+ *
+ * The page directories and tables require page alignment so we put them as
+ * additional fields in the stack object, using the below macros to compute how
+ * many pages we need.
+ */
+
+/* Define a range [Z_X86_PT_START, Z_X86_PT_END) which is the memory range
+ * covered by all the page tables needed for system RAM
+ */
+#define Z_X86_PT_START	((u32_t)ROUND_DOWN(DT_PHYS_RAM_ADDR, Z_X86_PT_AREA))
+#define Z_X86_PT_END	((u32_t)ROUND_UP(DT_PHYS_RAM_ADDR + \
+					 (DT_RAM_SIZE * 1024U), \
+					 Z_X86_PT_AREA))
+
+/* Number of page tables needed to cover system RAM. Depends on the specific
+ * bounds of system RAM, but roughly 1 page table per 2MB of RAM */
+#define Z_X86_NUM_PT	((Z_X86_PT_END - Z_X86_PT_START) / Z_X86_PT_AREA)
+
+/* Same semantics as above, but for the page directories needed to cover
+ * system RAM.
+ */
+#define Z_X86_PD_START	((u32_t)ROUND_DOWN(DT_PHYS_RAM_ADDR, Z_X86_PD_AREA))
+#define Z_X86_PD_END	((u32_t)ROUND_UP(DT_PHYS_RAM_ADDR + \
+					 (DT_RAM_SIZE * 1024U), \
+					 Z_X86_PD_AREA))
+/* Number of page directories needed to cover system RAM. Depends on the
+ * specific bounds of system RAM, but roughly 1 page directory per 1GB of RAM */
+#define Z_X86_NUM_PD	((Z_X86_PD_END - Z_X86_PD_START) / Z_X86_PD_AREA)
+
+/* Number of pages we need to reserve in the stack for per-thread page tables */
+#define Z_X86_NUM_TABLE_PAGES	(Z_X86_NUM_PT + Z_X86_NUM_PD)
+#else
+/* If we're not implementing user mode, then the MMU tables don't get changed
+ * on context switch and we don't need any per-thread page tables
+ */
+#define Z_X86_NUM_TABLE_PAGES	0U
+#endif /* CONFIG_USERSPACE */
+
+#define Z_X86_THREAD_PT_AREA	(Z_X86_NUM_TABLE_PAGES * MMU_PAGE_SIZE)
+
 #if defined(CONFIG_HW_STACK_PROTECTION) && defined(CONFIG_USERSPACE)
 /* With both hardware stack protection and userspace enabled, stacks are
  * arranged as follows:
  *
  * High memory addresses
- * +---------------+
- * | Thread stack  |
- * +---------------+
- * | Kernel stack  |
- * +---------------+
- * | Guard page    |
- * +---------------+
+ * +-----------------------------------------+
+ * | Thread stack (varies)                   |
+ * +-----------------------------------------+
+ * | PDPT (32 bytes)		             |
+ * | Privilege elevation stack (4064 bytes)  |
+ * +-----------------------------------------+
+ * | Guard page (4096 bytes)                 |
+ * +-----------------------------------------+
+ * | User page tables (Z_X86_THREAD_PT_AREA) |
+ * +-----------------------------------------+
  * Low Memory addresses
  *
- * Kernel stacks are fixed at 4K. All the pages containing the thread stack
- * are marked as user-accessible.
- * All threads start in supervisor mode, and the kernel stack/guard page
- * are both marked non-present in the MMU.
- * If a thread drops down to user mode, the kernel stack page will be marked
- * as present, supervior-only, and the _main_tss.esp0 field updated to point
- * to the top of it.
- * All context switches will save/restore the esp0 field in the TSS.
+ * Privilege elevation stacks are fixed-size. All the pages containing the
+ * thread stack are marked as user-accessible. The guard page is marked
+ * read-only to catch stack overflows in supervisor mode.
+ *
+ * If a thread starts in supervisor mode, the page containing the PDPT and
+ * privilege elevation stack is also marked read-only.
+ *
+ * If a thread starts in, or drops down to user mode, the privilege stack page
+ * will be marked as present, supervior-only. The PDPT will be initialized and
+ * used as the active page tables when that thread is active.
+ *
+ * If KPTI is not enabled, the _main_tss.esp0 field will always be updated
+ * updated to point to the top of the privilege elevation stack. Otherwise
+ * _main_tss.esp0 always points to the trampoline stack, which handles the
+ * page table switch to the kernel PDPT and transplants context to the
+ * privileged mode stack.
+ *
+ * TODO: The stack object layout is getting rather complex. We should define
+ * its layout in a struct definition, rather than doing math in the kernel
+ * code to find the parts we want or to obtain sizes.
  */
-#define Z_ARCH_THREAD_STACK_RESERVED	(MMU_PAGE_SIZE * 2)
-#define _STACK_BASE_ALIGN	MMU_PAGE_SIZE
+#define Z_ARCH_THREAD_STACK_RESERVED	(MMU_PAGE_SIZE * (2 + Z_X86_NUM_TABLE_PAGES))
+#define _STACK_BASE_ALIGN		MMU_PAGE_SIZE
 #elif defined(CONFIG_HW_STACK_PROTECTION) || defined(CONFIG_USERSPACE)
 /* If only one of HW stack protection or userspace is enabled, then the
  * stack will be preceded by one page which is a guard page or a kernel mode
  * stack, respectively.
  */
-#define Z_ARCH_THREAD_STACK_RESERVED	MMU_PAGE_SIZE
-#define _STACK_BASE_ALIGN	MMU_PAGE_SIZE
+#define Z_ARCH_THREAD_STACK_RESERVED	(MMU_PAGE_SIZE * (1 + Z_X86_NUM_TABLE_PAGES))
+#define _STACK_BASE_ALIGN		MMU_PAGE_SIZE
 #else /* Neither feature */
 #define Z_ARCH_THREAD_STACK_RESERVED	0
-#define _STACK_BASE_ALIGN	STACK_ALIGN
+#define _STACK_BASE_ALIGN		STACK_ALIGN
 #endif
 
 #ifdef CONFIG_USERSPACE

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4917,6 +4917,9 @@ struct k_mem_domain {
  *
  * Initialize a memory domain with given name and memory partitions.
  *
+ * See documentation for k_mem_domain_add_partition() for details about
+ * partition constraints.
+ *
  * @param domain The memory domain to be initialized.
  * @param num_parts The number of array items of "parts" parameter.
  * @param parts An array of pointers to the memory partitions. Can be NULL
@@ -4938,7 +4941,22 @@ extern void k_mem_domain_destroy(struct k_mem_domain *domain);
 /**
  * @brief Add a memory partition into a memory domain.
  *
- * Add a memory partition into a memory domain.
+ * Add a memory partition into a memory domain. Partitions must conform to
+ * the following constraints:
+ *
+ * - Partition bounds must be within system RAM boundaries on MMU-based
+ *   systems.
+ * - Partitions in the same memory domain may not overlap each other.
+ * - Partitions must not be defined which expose private kernel
+ *   data structures or kernel objects.
+ * - The starting address alignment, and the partition size must conform to
+ *   the constraints of the underlying memory management hardware, which
+ *   varies per architecture.
+ * - Memory domain partitions are only intended to control access to memory
+ *   from user mode threads.
+ *
+ * Violating these constraints may lead to CPU exceptions or undefined
+ * behavior.
  *
  * @param domain The memory domain to be added a memory partition.
  * @param part The memory partition to be added

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -148,7 +148,7 @@ config SCHED_CPU_MASK
 config MAIN_STACK_SIZE
 	int "Size of stack for initialization and main thread"
 	default 2048 if COVERAGE_GCOV
-	default 512 if ZTEST && !RISCV
+	default 512 if ZTEST && !(RISCV || X86)
 	default 1024
 	help
 	  When the initialization is complete, the thread executing it then

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -73,40 +73,48 @@ extern int z_arch_float_disable(struct k_thread *thread);
 /**
  * @brief Get the maximum number of partitions for a memory domain
  *
- * A memory domain is a container data structure containing some number of
- * memory partitions, where each partition represents a memory range with
- * access policies.
- *
- * MMU-based systems don't have a limit here, but MPU-based systems will
- * have an upper bound on how many different regions they can manage
- * simultaneously.
- *
- * @return Max number of free regions, or -1 if there is no limit
+ * @return Max number of partitions, or -1 if there is no limit
  */
 extern int z_arch_mem_domain_max_partitions_get(void);
 
 /**
- * @brief Configure the memory domain of the thread.
+ * @brief Add a thread to a memory domain (arch-specific)
  *
- * A memory domain is a container data structure containing some number of
- * memory partitions, where each partition represents a memory range with
- * access policies. This api will configure the appropriate hardware
- * registers to make it work.
+ * Architecture-specific hook to manage internal data structures or hardware
+ * state when the provided thread has been added to a memory domain.
+ *
+ * The thread's memory domain pointer will be set to the domain to be added
+ * to.
  *
  * @param thread Thread which needs to be configured.
  */
-extern void z_arch_mem_domain_configure(struct k_thread *thread);
+extern void z_arch_mem_domain_thread_add(struct k_thread *thread);
 
 /**
- * @brief Remove a partition from the memory domain
+ * @brief Remove a thread from a memory domain (arch-specific)
  *
- * A memory domain contains multiple partitions and this API provides the
- * freedom to remove a particular partition while keeping others intact.
- * This API will handle any arch/HW specific changes that needs to be done.
- * Only called if the active thread's domain was modified.
+ * Architecture-specific hook to manage internal data structures or hardware
+ * state when the provided thread has been removed from a memory domain.
+ *
+ * The thread's memory domain pointer will be the domain that the thread
+ * is being removed from.
+ *
+ * @param thread Thread being removed from its memory domain
+ */
+extern void z_arch_mem_domain_thread_remove(struct k_thread *thread);
+
+/**
+ * @brief Remove a partition from the memory domain (arch-specific)
+ *
+ * Architecture-specific hook to manage internal data structures or hardware
+ * state when a memory domain has had a partition removed.
+ *
+ * The partition index data, and the number of partitions configured, are not
+ * respectively cleared and decremented in the domain until after this function
+ * runs.
  *
  * @param domain The memory domain structure
- * @param partition_id The partition that needs to be deleted
+ * @param partition_id The partition index that needs to be deleted
  */
 extern void z_arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 					       u32_t partition_id);
@@ -114,10 +122,8 @@ extern void z_arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 /**
  * @brief Add a partition to the memory domain
  *
- * A memory domain contains multiple partitions and this API provides the
- * freedom to add an additional partition to a memory domain.
- * This API will handle any arch/HW specific changes that needs to be done.
- * Only called if the active thread's domain was modified.
+ * Architecture-specific hook to manage internal data structures or hardware
+ * state when a memory domain has a partition added.
  *
  * @param domain The memory domain structure
  * @param partition_id The partition that needs to be added
@@ -128,9 +134,11 @@ extern void z_arch_mem_domain_partition_add(struct k_mem_domain *domain,
 /**
  * @brief Remove the memory domain
  *
- * A memory domain contains multiple partitions and this API will traverse
- * all these to reset them back to default setting.
- * This API will handle any arch/HW specific changes that needs to be done.
+ * Architecture-specific hook to manage internal data structures or hardware
+ * state when a memory domain has been destroyed.
+ *
+ * Thread assignments to the memory domain are only cleared after this function
+ * runs.
  *
  * @param domain The memory domain structure which needs to be deleted.
  */

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -129,12 +129,7 @@ void k_mem_domain_destroy(struct k_mem_domain *domain)
 
 	key = k_spin_lock(&lock);
 
-	/* Handle architecture-specific destroy
-	 * only if it is the current thread.
-	 */
-	if (_current->mem_domain_info.mem_domain == domain) {
-		z_arch_mem_domain_destroy(domain);
-	}
+	z_arch_mem_domain_destroy(domain);
 
 	SYS_DLIST_FOR_EACH_NODE_SAFE(&domain->mem_domain_q, node, next_node) {
 		struct k_thread *thread =
@@ -181,13 +176,7 @@ void k_mem_domain_add_partition(struct k_mem_domain *domain,
 
 	domain->num_partitions++;
 
-	/* Handle architecture-specific add
-	 * only if it is the current thread.
-	 */
-	if (_current->mem_domain_info.mem_domain == domain) {
-		z_arch_mem_domain_partition_add(domain, p_idx);
-	}
-
+	z_arch_mem_domain_partition_add(domain, p_idx);
 	k_spin_unlock(&lock, key);
 }
 
@@ -213,12 +202,7 @@ void k_mem_domain_remove_partition(struct k_mem_domain *domain,
 	/* Assert if not found */
 	__ASSERT(p_idx < max_partitions, "no matching partition found");
 
-	/* Handle architecture-specific remove
-	 * only if it is the current thread.
-	 */
-	if (_current->mem_domain_info.mem_domain == domain) {
-		z_arch_mem_domain_partition_remove(domain, p_idx);
-	}
+	z_arch_mem_domain_partition_remove(domain, p_idx);
 
 	/* A zero-sized partition denotes it's a free partition */
 	domain->partitions[p_idx].size = 0U;
@@ -243,9 +227,7 @@ void k_mem_domain_add_thread(struct k_mem_domain *domain, k_tid_t thread)
 			 &thread->mem_domain_info.mem_domain_q_node);
 	thread->mem_domain_info.mem_domain = domain;
 
-	if (_current == thread) {
-		z_arch_mem_domain_configure(thread);
-	}
+	z_arch_mem_domain_thread_add(thread);
 
 	k_spin_unlock(&lock, key);
 }
@@ -258,13 +240,10 @@ void k_mem_domain_remove_thread(k_tid_t thread)
 	__ASSERT(thread->mem_domain_info.mem_domain != NULL, "mem domain set");
 
 	key = k_spin_lock(&lock);
-	if (_current == thread) {
-		z_arch_mem_domain_destroy(thread->mem_domain_info.mem_domain);
-	}
+	z_arch_mem_domain_thread_remove(thread);
 
 	sys_dlist_remove(&thread->mem_domain_info.mem_domain_q_node);
 	thread->mem_domain_info.mem_domain = NULL;
-
 	k_spin_unlock(&lock, key);
 }
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -403,6 +403,14 @@ void z_setup_new_thread(struct k_thread *new_thread,
 		       void *p1, void *p2, void *p3,
 		       int prio, u32_t options, const char *name)
 {
+#ifdef CONFIG_USERSPACE
+	z_object_init(new_thread);
+	z_object_init(stack);
+	new_thread->stack_obj = stack;
+
+	/* Any given thread has access to itself */
+	k_object_access_grant(new_thread, new_thread);
+#endif
 	stack_size = adjust_stack_size(stack_size);
 
 #ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
@@ -446,14 +454,6 @@ void z_setup_new_thread(struct k_thread *new_thread,
 		/* Ensure NULL termination, truncate if longer */
 		new_thread->name[CONFIG_THREAD_MAX_NAME_LEN - 1] = '\0';
 	}
-#endif
-#ifdef CONFIG_USERSPACE
-	z_object_init(new_thread);
-	z_object_init(stack);
-	new_thread->stack_obj = stack;
-
-	/* Any given thread has access to itself */
-	k_object_access_grant(new_thread, new_thread);
 #endif
 #ifdef CONFIG_SCHED_CPU_MASK
 	new_thread->base.cpu_mask = -1;

--- a/tests/kernel/mem_protect/x86_mmu_api/src/userbuffer_validate.c
+++ b/tests/kernel/mem_protect/x86_mmu_api/src/userbuffer_validate.c
@@ -21,12 +21,11 @@ static int status;
 #define BUFF_WRITEABLE ((u32_t) 0x1)
 #define BUFF_USER ((u32_t) 0x2)
 
-int z_arch_buffer_validate(void *addr, size_t size, int write);
 void reset_flag(void);
 void reset_multi_pte_page_flag(void);
 void reset_multi_pde_flag(void);
 
-#define PDPT &USER_PDPT
+#define PDPT (&z_x86_kernel_pdpt)
 
 #define ADDR_PAGE_1 ((u8_t *)__bss_start + SKIP_SIZE * MMU_PAGE_SIZE)
 #define ADDR_PAGE_2 ((u8_t *)__bss_start + (SKIP_SIZE + 1) * MMU_PAGE_SIZE)
@@ -37,12 +36,16 @@ void reset_multi_pde_flag(void);
 static void set_flags(void *ptr, size_t size, x86_page_entry_data_t flags,
 		      x86_page_entry_data_t mask)
 {
-	z_x86_mmu_set_flags(PDPT, ptr, size, flags, mask);
+	z_x86_mmu_set_flags(PDPT, ptr, size, flags, mask, true);
 }
 
+static int buffer_validate(void *addr, size_t size, int write)
+{
+	return z_x86_mmu_validate(PDPT, addr, size, write);
+}
 
 /* if Failure occurs
- * z_arch_buffer_validate return -EPERM
+ * buffer_validate return -EPERM
  * else return 0.
  * Below conditions will be tested accordingly
  *
@@ -58,9 +61,7 @@ static int buffer_rw_read(void)
 			   MMU_ENTRY_READ,
 			   MMU_PDE_RW_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       BUFF_SIZE,
-				       BUFF_WRITEABLE);
+	status = buffer_validate(ADDR_PAGE_1, BUFF_SIZE, BUFF_WRITEABLE);
 
 	if (status != -EPERM) {
 		TC_PRINT("%s failed\n", __func__);
@@ -79,9 +80,7 @@ static int buffer_writeable_write(void)
 			   MMU_ENTRY_WRITE,
 			   MMU_PDE_RW_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       BUFF_SIZE,
-				       BUFF_WRITEABLE);
+	status = buffer_validate(ADDR_PAGE_1, BUFF_SIZE, BUFF_WRITEABLE);
 	if (status != 0) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -99,9 +98,7 @@ static int buffer_readable_read(void)
 			   MMU_ENTRY_READ,
 			   MMU_PDE_RW_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       BUFF_SIZE,
-				       BUFF_READABLE);
+	status = buffer_validate(ADDR_PAGE_1, BUFF_SIZE, BUFF_READABLE);
 	if (status != 0) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -119,10 +116,7 @@ static int buffer_readable_write(void)
 			   MMU_ENTRY_WRITE,
 			   MMU_PDE_RW_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       BUFF_SIZE,
-				       BUFF_READABLE);
-
+	status = buffer_validate(ADDR_PAGE_1, BUFF_SIZE, BUFF_READABLE);
 	if (status != 0) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -141,10 +135,8 @@ static int buffer_supervisor_rw(void)
 			   MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       BUFF_SIZE,
-				       BUFF_READABLE | BUFF_USER);
-
+	status = buffer_validate(ADDR_PAGE_1, BUFF_SIZE, BUFF_READABLE |
+				 BUFF_USER);
 	if (status != -EPERM) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -162,10 +154,7 @@ static int buffer_supervisor_w(void)
 			   MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       BUFF_SIZE,
-				       BUFF_WRITEABLE);
-
+	status = buffer_validate(ADDR_PAGE_1, BUFF_SIZE, BUFF_WRITEABLE);
 	if (status != -EPERM) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -182,9 +171,8 @@ static int buffer_user_rw_user(void)
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_USER,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       BUFF_SIZE,
-				       BUFF_WRITEABLE | BUFF_USER);
+	status = buffer_validate(ADDR_PAGE_1, BUFF_SIZE, BUFF_WRITEABLE |
+				 BUFF_USER);
 	if (status != 0) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -201,9 +189,8 @@ static int buffer_user_rw_supervisor(void)
 			   MMU_PAGE_SIZE,
 			   MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       BUFF_SIZE,
-				       BUFF_WRITEABLE | BUFF_USER);
+	status = buffer_validate(ADDR_PAGE_1, BUFF_SIZE, BUFF_WRITEABLE |
+				 BUFF_USER);
 	if (status != -EPERM) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -228,7 +215,7 @@ static int multi_page_buffer_user(void)
 			   MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
+	status = buffer_validate(ADDR_PAGE_1,
 				       2 * MMU_PAGE_SIZE,
 				       BUFF_WRITEABLE | BUFF_USER);
 	if (status != -EPERM) {
@@ -254,9 +241,8 @@ static int multi_page_buffer_write_user(void)
 			   MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       2 * MMU_PAGE_SIZE,
-				       BUFF_WRITEABLE);
+	status = buffer_validate(ADDR_PAGE_1, 2 * MMU_PAGE_SIZE,
+				 BUFF_WRITEABLE);
 	if (status != -EPERM) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -280,9 +266,8 @@ static int multi_page_buffer_read_user(void)
 			   MMU_ENTRY_READ | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       2 * MMU_PAGE_SIZE,
-				       BUFF_READABLE | BUFF_USER);
+	status = buffer_validate(ADDR_PAGE_1, 2 * MMU_PAGE_SIZE, BUFF_READABLE
+				 | BUFF_USER);
 	if (status != -EPERM) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -306,9 +291,8 @@ static int multi_page_buffer_read(void)
 			   MMU_ENTRY_READ | MMU_ENTRY_SUPERVISOR,
 			   MMU_PTE_RW_MASK | MMU_PTE_US_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       2 * MMU_PAGE_SIZE,
-				       BUFF_WRITEABLE);
+	status = buffer_validate(ADDR_PAGE_1, 2 * MMU_PAGE_SIZE,
+				 BUFF_WRITEABLE);
 	if (status != -EPERM) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -332,10 +316,8 @@ static int multi_pde_buffer_rw(void)
 			   MMU_ENTRY_READ,
 			   MMU_PDE_RW_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       2 * MMU_PAGE_SIZE,
-				       BUFF_WRITEABLE);
-
+	status = buffer_validate(ADDR_PAGE_1, 2 * MMU_PAGE_SIZE,
+				 BUFF_WRITEABLE);
 	if (status != -EPERM) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -359,9 +341,8 @@ static int multi_pde_buffer_writeable_write(void)
 			   MMU_ENTRY_WRITE,
 			   MMU_PDE_RW_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       2 * MMU_PAGE_SIZE,
-				       BUFF_WRITEABLE);
+	status = buffer_validate(ADDR_PAGE_1, 2 * MMU_PAGE_SIZE,
+				 BUFF_WRITEABLE);
 	if (status != 0) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -385,9 +366,8 @@ static int multi_pde_buffer_readable_read(void)
 			   MMU_ENTRY_READ,
 			   MMU_PDE_RW_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       2 * MMU_PAGE_SIZE,
-				       BUFF_READABLE);
+	status = buffer_validate(ADDR_PAGE_1, 2 * MMU_PAGE_SIZE,
+				 BUFF_READABLE);
 	if (status != 0) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -411,10 +391,8 @@ static int multi_pde_buffer_readable_write(void)
 			   MMU_ENTRY_WRITE,
 			   MMU_PDE_RW_MASK);
 
-	status = z_arch_buffer_validate(ADDR_PAGE_1,
-				       2 * MMU_PAGE_SIZE,
-				       BUFF_READABLE);
-
+	status = buffer_validate(ADDR_PAGE_1, 2 * MMU_PAGE_SIZE,
+				 BUFF_READABLE);
 	if (status != 0) {
 		TC_PRINT("%s failed\n", __func__);
 		return TC_FAIL;
@@ -462,7 +440,7 @@ void reset_multi_pde_flag(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_multi_pde_buffer_readable_write(void)
 {
@@ -474,7 +452,7 @@ void test_multi_pde_buffer_readable_write(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see  z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_multi_pde_buffer_readable_read(void)
 {
@@ -486,7 +464,7 @@ void test_multi_pde_buffer_readable_read(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see  z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_multi_pde_buffer_writeable_write(void)
 {
@@ -498,7 +476,7 @@ void test_multi_pde_buffer_writeable_write(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see  z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_multi_pde_buffer_rw(void)
 {
@@ -510,7 +488,7 @@ void test_multi_pde_buffer_rw(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_buffer_rw_read(void)
 {
@@ -522,7 +500,7 @@ void test_buffer_rw_read(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_buffer_writeable_write(void)
 {
@@ -534,7 +512,7 @@ void test_buffer_writeable_write(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_buffer_readable_read(void)
 {
@@ -546,7 +524,7 @@ void test_buffer_readable_read(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_buffer_readable_write(void)
 {
@@ -558,7 +536,7 @@ void test_buffer_readable_write(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_buffer_supervisor_rw(void)
 {
@@ -570,7 +548,7 @@ void test_buffer_supervisor_rw(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_buffer_supervisor_w(void)
 {
@@ -582,7 +560,7 @@ void test_buffer_supervisor_w(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_buffer_user_rw_user(void)
 {
@@ -594,7 +572,7 @@ void test_buffer_user_rw_user(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_buffer_user_rw_supervisor(void)
 {
@@ -606,7 +584,7 @@ void test_buffer_user_rw_supervisor(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_multi_page_buffer_user(void)
 {
@@ -618,7 +596,7 @@ void test_multi_page_buffer_user(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_multi_page_buffer_write_user(void)
 {
@@ -630,7 +608,7 @@ void test_multi_page_buffer_write_user(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_multi_page_buffer_read_user(void)
 {
@@ -642,7 +620,7 @@ void test_multi_page_buffer_read_user(void)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_arch_buffer_validate(), z_x86_mmu_set_flags()
+ * @see z_x86_mmu_validate(), z_x86_mmu_set_flags()
  */
 void test_multi_page_buffer_read(void)
 {


### PR DESCRIPTION
The PR does the following:

Major changes:

- x86 now uses per-thread page tables, with a simple CR3 update on context switch or when trampolining to/from user mode
- memory domain architecture interface no longer makes decisions on whether the arch code needs to be notified, necessary when domain configuration is managed per-thread instead of common data or registers

Minor changes:

- thread->stack_obj is now set when z_new_thread() is called
- stack overflow guard pages on x86 are now read-only instead of non-present, making debugging easier
- added debug functions for dumping page tables at runtime
- added inline functions to get/set active page tables on x86
- fatal exceptions on x86 now report CR3 register (which points to the active page tables)
- memory domain documentation clarification
- some test case adjustments

Please read individual commit messages for more details.

This patch leaves the build-time page table generation alone, although this new code doesn't care how the master page tables were created and when we switch to runtime generated page tables at boot, this code can remain the same.

Addresses https://github.com/zephyrproject-rtos/zephyr/issues/15135 on x86
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/13003
Contains groundwork necessary for: #13441 #13074 #15223