### PR TITLE
board: nsim: doc update for debugging section

### DIFF
--- a/boards/arc/nsim/doc/index.rst
+++ b/boards/arc/nsim/doc/index.rst
@@ -84,7 +84,35 @@ nsim, and display the following console output:
 Debugging
 =========
 
-Refer to the detailed overview about :ref:`application_debugging`.
+.. note::
+   The normal ``make debug`` command won't work for debugging
+   applications using nsim because both the nsim simulator and the
+   gdb debugger use the console for output. You need to use separate
+   terminal windows for each tool to avoid intermixing their output.
+
+After building your application, cd to the build folder and open two
+terminal windows. In terminal one, use nsim to start a GDB server
+and wait for a remote connection:
+
+.. code-block:: console
+
+   # for ninja build system:
+   ninja debugserver
+   # for make build system:
+   make debugserver
+
+In terminal two, connect to the GDB server using :file:`arc-elf32-gdb`.
+This command loads the symbol table from the elf binary file, for example
+the :file:`./zephyr/zephyr.elf` file:
+
+.. code-block:: console
+
+   ..../path/to/arc-elf32-gdb zephyr/zephyr.elf
+   (gdb) target remote : 3333
+   (gdb) load
+
+Now the debug environment has been set up, you can debug the application with gdb commands.
+
 
 References
 **********


### PR DESCRIPTION
board: nsim: doc update for debugging section

doc update for debugging dection for #17547 issue.

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>

the simulator wil use console for output, to avoid sharing with the gdb debug console, which will make output promiscuous, we can not directly use the make debug command for debugging.

Fixes #17547 
