### PR TITLE
drivers: CAN: Add RX timestamp for CAN frames

### DIFF
--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -38,7 +38,7 @@ config CAN_WORKQ_FRAMES_BUF_CNT
 
 config CAN_RX_TIMESTAMP
 	bool "Enable receiving timestamps"
-	depends on CAN_STM32
+	depends on CAN_STM32 || CAN_MCUX_FLEXCAN
 	help
 	  This option enables a timestamp value of the CAN free running timer.
 	  The value is incremented every bit time and starts when the controller

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -36,6 +36,14 @@ config CAN_WORKQ_FRAMES_BUF_CNT
 	help
 	  Number of frames in the buffer of a zcan_work.
 
+config CAN_RX_TIMESTAMP
+	bool "Enable receiving timestamps"
+	depends on CAN_STM32
+	help
+	  This option enables a timestamp value of the CAN free running timer.
+	  The value is incremented every bit time and starts when the controller
+	  is initialized.
+
 config CAN_0
 	bool "Enable CAN 0"
 	help

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -167,6 +167,9 @@ static void mcux_flexcan_copy_frame_to_zframe(const flexcan_frame_t *src,
 	dest->dlc = src->length;
 	dest->data_32[0] = sys_be32_to_cpu(src->dataWord0);
 	dest->data_32[1] = sys_be32_to_cpu(src->dataWord1);
+#ifdef CONFIG_CAN_RX_TIMESTAMP
+	dest->timestamp = src->timestamp;
+#endif /* CAN_RX_TIMESTAMP */
 }
 
 static void mcux_flexcan_copy_zfilter_to_mbconfig(const struct zcan_filter *src,

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -52,6 +52,9 @@ static void can_stm32_get_msg_fifo(CAN_FIFOMailBox_TypeDef *mbox,
 	msg->dlc = mbox->RDTR & (CAN_RDT0R_DLC >> CAN_RDT0R_DLC_Pos);
 	msg->data_32[0] = mbox->RDLR;
 	msg->data_32[1] = mbox->RDHR;
+#ifdef CONFIG_CAN_RX_TIMESTAMP
+	msg->timestamp = ((mbox->RDTR & CAN_RDT0R_TIME) >> CAN_RDT0R_TIME_Pos);
+#endif
 }
 
 static inline
@@ -363,6 +366,9 @@ static int can_stm32_init(struct device *dev)
 	can->MCR |= CAN_MCR_TXFP;
 	can->MCR &= ~CAN_MCR_TTCM & ~CAN_MCR_TTCM & ~CAN_MCR_ABOM &
 		    ~CAN_MCR_AWUM & ~CAN_MCR_NART & ~CAN_MCR_RFLM;
+#ifdef CONFIG_CAN_RX_TIMESTAMP
+	can->MCR |= CAN_MCR_TTCM;
+#endif
 
 	ret = can_stm32_runtime_configure(dev, CAN_NORMAL_MODE, 0);
 	if (ret) {

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -173,6 +173,13 @@ struct zcan_frame {
 		u8_t data[8];
 		u32_t data_32[2];
 	};
+#if defined(CONFIG_CAN_RX_TIMESTAMP)
+	/** Timer value of the CAN free running timer.
+	 * The timer is incremented every bit time and captured at the start
+	 * of frame bit (SOF).
+	 */
+	u16_t timestamp;
+#endif
 } __packed;
 
 /**


### PR DESCRIPTION
This PR adds an optional receive timestamp. The timestamp is a hardware feature of most CAN controllers. The counter value increments for every bit time of the CAN-bus. For example, a bus configured for 1Mboud increases the value every 1 microsecond. The counter is 16 bit wide.