### PR TITLE
dts: bindings: Clean up microchip,xec-espi.yaml and espi.yaml

### DIFF
--- a/dts/bindings/espi/espi.yaml
+++ b/dts/bindings/espi/espi.yaml
@@ -1,27 +1,18 @@
 # Copyright (c) 2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-#
----
+
 title: ESPI Base Structure
-version: 0.1
 
 description: >
     This binding gives the base structures for all ESPI devices
+
+inherits:
+    !include base.yaml
 
 child:
     bus: espi
 
 properties:
-    compatible:
-      type: string
-      category: required
-      description: compatible strings
-      generation: define
-
     label:
-      type: string
       category: required
-      description: Human readable string describing the device
-      generation: define
-...

--- a/dts/bindings/espi/microchip,xec-espi.yaml
+++ b/dts/bindings/espi/microchip,xec-espi.yaml
@@ -1,62 +1,49 @@
 # Copyright (c) 2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-#
----
+
 title: MICROCHIP ESPI
-version: 0.1
 
 description: >
     This binding gives a base representation of ESPI controller for Microchip
 
 inherits:
     !include espi.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "microchip,xec-espi"
-      generation: define
 
     reg:
-      type: int
       description: mmio register space
-      generation: define
       category: required
 
     agg_io_irq:
       type: int
       description: soc aggregated nvic irq for eSPI block
-      generation: define
       category: required
 
     agg_vw_irq:
       type: int
       description: soc aggregated nvic irq for eSPI virtual wires channel
-      generation: define
       category: required
 
     agg_pc_irq:
       type: int
       description: soc aggregated nvic irq for eSPI peripheral channel
-      generation: define
       category: required
 
     io_girq:
       type: int
       description: soc group irq for eSPI I/O
-      generation: define
       category: required
 
     vw_girq:
       type: int
       description: soc group irq for eSPI virtual wires channel
-      generation: define
       category: required
 
     pc_girq:
       type: int
       description: soc group irq for eSPI peripheral channel
-      generation: define
       category: required


### PR DESCRIPTION
 - Remove 'generation:' (see https://github.com/zephyrproject-rtos/zephyr/pull/17469)

 - Remove 'version:' (see https://github.com/zephyrproject-rtos/zephyr/pull/17681)

 - Remove redundant document separators (see https://github.com/zephyrproject-rtos/zephyr/pull/16913)

 - Use base.yaml to define common properties and property settings