### PR TITLE
dts/bindings: Cleanup st,stm32-ipm-mailbox binding

### DIFF
--- a/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
+++ b/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STM32 MAILBOX
-version: 0.1
 
 description: >
   This binding gives a base representation of the STM32 IPCC
@@ -18,7 +17,4 @@ properties:
       constraint: "st,stm32-ipcc-mailbox"
 
   clocks:
-    type: array
     category: required
-    description: Clock gate control information
-    generation: define


### PR DESCRIPTION
* Remove version field
* Utilize base.yaml to reduce duplication (clocks)

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>