### PR TITLE
drivers: spi: spi_ll_stm32: Fix uncleared MODF flag

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -196,6 +196,10 @@ static void spi_stm32_complete(struct spi_stm32_data *data, SPI_TypeDef *spi,
 			/* NOP */
 		}
 	}
+	/* BSY flag is cleared when MODF flag is raised */
+	if (LL_SPI_IsActiveFlag_MODF(spi)) {
+		LL_SPI_ClearFlag_MODF(spi);
+	}
 
 	LL_SPI_Disable(spi);
 


### PR DESCRIPTION
Clear raised MODF flag, if not done the flag stay set forever.
    
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/17363