### PR TITLE
mcumgr: select NET_BUF when MCUMGR=y

### DIFF
--- a/subsys/mgmt/Kconfig.mcumgr
+++ b/subsys/mgmt/Kconfig.mcumgr
@@ -4,6 +4,7 @@
 #
 config MCUMGR
 	bool "mcumgr Support"
+	select NET_BUF
 	select TINYCBOR
 	help
 	  This option enables the mcumgr management library.


### PR DESCRIPTION
mcumgr is missing dependency on net_buf, which is used for SMP protocol
implementation. This causes build failure in case when only SMP over
shell is selected (CONFIG_MCUMGR_SMP_SHELL=y).

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>