### PR TITLE
mcumgr: fix type of pointer passed to base64_decode

### DIFF
--- a/subsys/mgmt/serial_util.c
+++ b/subsys/mgmt/serial_util.c
@@ -59,7 +59,7 @@ static int mcumgr_serial_extract_len(struct mcumgr_serial_rx_ctxt *rx_ctxt)
 static int mcumgr_serial_decode_frag(struct mcumgr_serial_rx_ctxt *rx_ctxt,
 				     const u8_t *frag, int frag_len)
 {
-	int dec_len;
+	size_t dec_len;
 	int rc;
 
 	rc = base64_decode(rx_ctxt->nb->data + rx_ctxt->nb->len,


### PR DESCRIPTION
base64_decode requires 'size_t *olen', but '*int' was passed
instead. This caused a -Wincompatible-pointer-types "note: expected
'size_t *' {aka 'long unsigned int *'} but argument is of type 'int *'"
warning in qemu_x86 build. Fix that by using correct variable type.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>