### PR TITLE
posix: Fix handling of timeouts

### DIFF
--- a/include/posix/pthread.h
+++ b/include/posix/pthread.h
@@ -124,7 +124,7 @@ int pthread_cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut);
  * See IEEE 1003.1
  */
 int pthread_cond_timedwait(pthread_cond_t *cv, pthread_mutex_t *mut,
-			   const struct timespec *to);
+			   const struct timespec *abstime);
 
 /**
  * @brief POSIX threading compatibility API
@@ -224,7 +224,7 @@ int pthread_mutex_unlock(pthread_mutex_t *m);
  */
 
 int pthread_mutex_timedlock(pthread_mutex_t *m,
-			    const struct timespec *to);
+			    const struct timespec *abstime);
 
 /**
  * @brief POSIX threading compatibility API

--- a/include/posix/time.h
+++ b/include/posix/time.h
@@ -69,6 +69,8 @@ struct itimerspec {
 #define TIMER_ABSTIME 4
 #endif
 
+s64_t _timespec_to_timeoutms(const struct timespec *abstime);
+
 static inline s32_t _ts_to_ms(const struct timespec *to)
 {
 	return (to->tv_sec * MSEC_PER_SEC) + (to->tv_nsec / NSEC_PER_MSEC);

--- a/lib/posix/mqueue.c
+++ b/lib/posix/mqueue.c
@@ -30,7 +30,6 @@ K_SEM_DEFINE(mq_sem, 1, 1);
 /* Initialize the list */
 sys_slist_t mq_list = SYS_SLIST_STATIC_INIT(&mq_list);
 
-s64_t timespec_to_timeoutms(const struct timespec *abstime);
 static mqueue_object *find_in_list(const char *name);
 static s32_t send_message(mqueue_desc *mqd, const char *msg_ptr, size_t msg_len,
 			  s32_t timeout);
@@ -251,7 +250,10 @@ int mq_timedsend(mqd_t mqdes, const char *msg_ptr, size_t msg_len,
 	mqueue_desc *mqd = (mqueue_desc *)mqdes;
 	s32_t  timeout;
 
-	timeout = (s32_t) timespec_to_timeoutms(abstime);
+	timeout = (s32_t) _timespec_to_timeoutms(abstime);
+	if (timeout <= 0)
+		return ETIMEDOUT;
+
 	return send_message(mqd, msg_ptr, msg_len, timeout);
 }
 
@@ -285,7 +287,10 @@ int mq_timedreceive(mqd_t mqdes, char *msg_ptr, size_t msg_len,
 	mqueue_desc *mqd = (mqueue_desc *)mqdes;
 	s32_t  timeout = K_NO_WAIT;
 
-	timeout = (s32_t) timespec_to_timeoutms(abstime);
+	timeout = (s32_t) _timespec_to_timeoutms(abstime);
+	if (timeout <= 0)
+		return ETIMEDOUT;
+
 	return receive_message(mqd, msg_ptr, msg_len, timeout);
 }
 

--- a/lib/posix/pthread_common.c
+++ b/lib/posix/pthread_common.c
@@ -9,7 +9,7 @@
 #include <wait_q.h>
 #include <posix/time.h>
 
-s64_t timespec_to_timeoutms(const struct timespec *abstime)
+s64_t _timespec_to_timeoutms(const struct timespec *abstime)
 {
 	s64_t milli_secs, secs, nsecs;
 	struct timespec curtime;

--- a/lib/posix/pthread_cond.c
+++ b/lib/posix/pthread_cond.c
@@ -9,7 +9,7 @@
 #include <wait_q.h>
 #include <posix/pthread.h>
 
-static int cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut, int timeout)
+static int cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut, s32_t timeout)
 {
 	__ASSERT(mut->lock_count == 1U, "");
 
@@ -73,8 +73,11 @@ int pthread_cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut)
 }
 
 int pthread_cond_timedwait(pthread_cond_t *cv, pthread_mutex_t *mut,
-			   const struct timespec *to)
-{
-	return cond_wait(cv, mut, _ts_to_ms(to));
-}
+			   const struct timespec *abstime)
 
+{
+	s32_t timeout = (s32_t) _timespec_to_timeoutms(abstime);
+	if (timeout <= 0)
+		return ETIMEDOUT;
+	return cond_wait(cv, mut, timeout);
+}

--- a/lib/posix/pthread_mutex.c
+++ b/lib/posix/pthread_mutex.c
@@ -18,7 +18,7 @@ static const pthread_mutexattr_t def_attr = {
 	.type = PTHREAD_MUTEX_DEFAULT,
 };
 
-static int acquire_mutex(pthread_mutex_t *m, int timeout)
+static int acquire_mutex(pthread_mutex_t *m, s32_t timeout)
 {
 	int rc = 0, key = irq_lock();
 
@@ -73,9 +73,12 @@ int pthread_mutex_trylock(pthread_mutex_t *m)
  * See IEEE 1003.1
  */
 int pthread_mutex_timedlock(pthread_mutex_t *m,
-			    const struct timespec *to)
+			    const struct timespec *abstime)
 {
-	return acquire_mutex(m, _ts_to_ms(to));
+	s32_t timeout = (s32_t) _timespec_to_timeoutms(abstime);
+	if (timeout <= 0)
+		return ETIMEDOUT;
+	return acquire_mutex(m, timeout);
 }
 
 /**

--- a/lib/posix/pthread_rwlock.c
+++ b/lib/posix/pthread_rwlock.c
@@ -13,7 +13,6 @@
 
 #define CONCURRENT_READER_LIMIT  (CONFIG_MAX_PTHREAD_COUNT + 1)
 
-s64_t timespec_to_timeoutms(const struct timespec *abstime);
 static u32_t read_lock_acquire(pthread_rwlock_t *rwlock, s32_t timeout);
 static u32_t write_lock_acquire(pthread_rwlock_t *rwlock, s32_t timeout);
 
@@ -93,9 +92,9 @@ int pthread_rwlock_timedrdlock(pthread_rwlock_t *rwlock,
 		return EINVAL;
 	}
 
-	timeout = (s32_t) timespec_to_timeoutms(abstime);
+	timeout = (s32_t) _timespec_to_timeoutms(abstime);
 
-	if (read_lock_acquire(rwlock, timeout) != 0U) {
+	if (timeout <= 0 || read_lock_acquire(rwlock, timeout) != 0U) {
 		ret = ETIMEDOUT;
 	}
 
@@ -155,9 +154,9 @@ int pthread_rwlock_timedwrlock(pthread_rwlock_t *rwlock,
 		return EINVAL;
 	}
 
-	timeout = (s32_t) timespec_to_timeoutms(abstime);
+	timeout = (s32_t) _timespec_to_timeoutms(abstime);
 
-	if (write_lock_acquire(rwlock, timeout) != 0U) {
+	if (timeout <= 0 || write_lock_acquire(rwlock, timeout) != 0U) {
 		ret = ETIMEDOUT;
 	}
 
@@ -253,5 +252,3 @@ static u32_t write_lock_acquire(pthread_rwlock_t *rwlock, s32_t timeout)
 	}
 	return ret;
 }
-
-


### PR DESCRIPTION
The timeout parameter is absolute, not relative.  Addresses #17812

This is based on the [implementation](https://github.com/espressif/esp-idf/blob/master/components/pthread/pthread_cond_var.c) in esp-idf, with an inlined `timercmp`/`timersub` since we don't have those.