### PR TITLE
ARM: only allow OOPS and STACK_CHK_FAIL from user mode

### DIFF
--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -1119,6 +1119,37 @@ void test_object_recycle(void)
 	zassert_true(perms_count == 1, "invalid number of thread permissions");
 }
 
+#define test_oops(provided, expected) do { \
+	expect_fault = true; \
+	expected_reason = expected; \
+	z_except_reason(provided); \
+} while (false)
+
+void test_oops_panic(void)
+{
+	test_oops(K_ERR_KERNEL_PANIC, K_ERR_KERNEL_OOPS);
+}
+
+void test_oops_oops(void)
+{
+	test_oops(K_ERR_KERNEL_OOPS, K_ERR_KERNEL_OOPS);
+}
+
+void test_oops_exception(void)
+{
+	test_oops(K_ERR_CPU_EXCEPTION, K_ERR_KERNEL_OOPS);
+}
+
+void test_oops_maxint(void)
+{
+	test_oops(INT_MAX, K_ERR_KERNEL_OOPS);
+}
+
+void test_oops_stackcheck(void)
+{
+	test_oops(K_ERR_STACK_CHK_FAIL, K_ERR_STACK_CHK_FAIL);
+}
+
 void test_main(void)
 {
 	struct k_mem_partition *parts[] = {&part0, &part1,
@@ -1171,6 +1202,13 @@ void test_main(void)
 			 ztest_unit_test(test_stack_buffer),
 			 ztest_user_unit_test(test_unimplemented_syscall),
 			 ztest_user_unit_test(test_bad_syscall),
+#if !defined(CONFIG_ARC) /* FIXME: #17590 */
+			 ztest_user_unit_test(test_oops_panic),
+			 ztest_user_unit_test(test_oops_oops),
+			 ztest_user_unit_test(test_oops_exception),
+			 ztest_user_unit_test(test_oops_maxint),
+			 ztest_user_unit_test(test_oops_stackcheck),
+#endif /* !defined(CONFIG_ARC) */
 			 ztest_unit_test(test_object_recycle)
 			 );
 	ztest_run_test_suite(userspace);


### PR DESCRIPTION
Fixes #17591 

Includes @andrewboie 's commit that implements the respective test (for feature coverage).

Currently implemented for ARM (but an x86 fix is also present in #17587, AFAICS, so that commit could also be added here.)

Update: #17587 is merged, so this should already work for x86 as well.