### PR TITLE
i2c_ll_stm32: Use macros to add I2C instances

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -245,96 +245,84 @@ static int i2c_stm32_init(struct device *dev)
 	return 0;
 }
 
-#ifdef CONFIG_I2C_1
+/* Macros for I2C instance declaration */
 
 #ifdef CONFIG_I2C_STM32_INTERRUPT
-static void i2c_stm32_irq_config_func_1(struct device *port);
-#endif
 
-static const struct i2c_stm32_config i2c_stm32_cfg_1 = {
-	.i2c = (I2C_TypeDef *)DT_I2C_1_BASE_ADDRESS,
-	.pclken = {
-		.enr = DT_I2C_1_CLOCK_BITS,
-		.bus = DT_I2C_1_CLOCK_BUS,
-	},
-#ifdef CONFIG_I2C_STM32_INTERRUPT
-	.irq_config_func = i2c_stm32_irq_config_func_1,
-#endif
-	.bitrate = DT_I2C_1_BITRATE,
-};
-
-static struct i2c_stm32_data i2c_stm32_dev_data_1;
-
-DEVICE_AND_API_INIT(i2c_stm32_1, CONFIG_I2C_1_NAME, &i2c_stm32_init,
-		    &i2c_stm32_dev_data_1, &i2c_stm32_cfg_1,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		    &api_funcs);
-
-#ifdef CONFIG_I2C_STM32_INTERRUPT
-static void i2c_stm32_irq_config_func_1(struct device *dev)
-{
 #ifdef CONFIG_I2C_STM32_COMBINED_INTERRUPT
-	IRQ_CONNECT(DT_I2C_1_COMBINED_IRQ, DT_I2C_1_COMBINED_IRQ_PRI,
-		   stm32_i2c_combined_isr, DEVICE_GET(i2c_stm32_1), 0);
-	irq_enable(DT_I2C_1_COMBINED_IRQ);
+#define STM32_I2C_IRQ_CONNECT_AND_ENABLE(name)				\
+	do {								\
+		IRQ_CONNECT(DT_##name##_COMBINED_IRQ,			\
+			    DT_##name##_COMBINED_IRQ_PRI,		\
+			    stm32_i2c_combined_isr,			\
+			    DEVICE_GET(i2c_stm32_##name), 0);		\
+		irq_enable(DT_##name##_COMBINED_IRQ);			\
+	} while (0)
 #else
-	IRQ_CONNECT(DT_I2C_1_EVENT_IRQ, DT_I2C_1_EVENT_IRQ_PRI,
-		   stm32_i2c_event_isr, DEVICE_GET(i2c_stm32_1), 0);
-	irq_enable(DT_I2C_1_EVENT_IRQ);
+#define STM32_I2C_IRQ_CONNECT_AND_ENABLE(name)				\
+	do {								\
+		IRQ_CONNECT(DT_##name##_EVENT_IRQ,			\
+			    DT_##name##_EVENT_IRQ_PRI,			\
+			    stm32_i2c_event_isr,			\
+			    DEVICE_GET(i2c_stm32_##name), 0);		\
+		irq_enable(DT_##name##_EVENT_IRQ);			\
+									\
+		IRQ_CONNECT(DT_##name##_ERROR_IRQ,			\
+			    DT_##name##_ERROR_IRQ_PRI,			\
+			    stm32_i2c_error_isr,			\
+			    DEVICE_GET(i2c_stm32_##name), 0);		\
+		irq_enable(DT_##name##_ERROR_IRQ);			\
+	} while (0)
+#endif /* CONFIG_I2C_STM32_COMBINED_INTERRUPT */
 
-	IRQ_CONNECT(DT_I2C_1_ERROR_IRQ, DT_I2C_1_ERROR_IRQ_PRI,
-		   stm32_i2c_error_isr, DEVICE_GET(i2c_stm32_1), 0);
-	irq_enable(DT_I2C_1_ERROR_IRQ);
-#endif
+#define STM32_I2C_IRQ_HANDLER_DECL(name)				\
+static void i2c_stm32_irq_config_func_##name(struct device *dev)
+#define STM32_I2C_IRQ_HANDLER_FUNCTION(name)				\
+	.irq_config_func = i2c_stm32_irq_config_func_##name,
+#define STM32_I2C_IRQ_HANDLER(name)					\
+static void i2c_stm32_irq_config_func_##name(struct device *dev)	\
+{									\
+	STM32_I2C_IRQ_CONNECT_AND_ENABLE(name);				\
 }
-#endif
+#else
 
+#define STM32_I2C_IRQ_HANDLER_DECL(name)
+#define STM32_I2C_IRQ_HANDLER_FUNCTION(name)
+#define STM32_I2C_IRQ_HANDLER(name)
+
+#endif /* CONFIG_I2C_STM32_INTERRUPT */
+
+#define STM32_I2C_INIT(name)						\
+STM32_I2C_IRQ_HANDLER_DECL(name);					\
+									\
+static const struct i2c_stm32_config i2c_stm32_cfg_##name = {		\
+	.i2c = (I2C_TypeDef *)DT_##name##_BASE_ADDRESS,			\
+	.pclken = {							\
+		.enr = DT_##name##_CLOCK_BITS,				\
+		.bus = DT_##name##_CLOCK_BUS,				\
+	},								\
+	STM32_I2C_IRQ_HANDLER_FUNCTION(name)				\
+	.bitrate = DT_##name##_BITRATE,					\
+};									\
+									\
+static struct i2c_stm32_data i2c_stm32_dev_data_##name;			\
+									\
+DEVICE_AND_API_INIT(i2c_stm32_##name, CONFIG_##name##_NAME,		\
+		    &i2c_stm32_init, &i2c_stm32_dev_data_##name,	\
+		    &i2c_stm32_cfg_##name,				\
+		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+		    &api_funcs);					\
+									\
+STM32_I2C_IRQ_HANDLER(name)
+
+/* I2C instances declaration */
+
+#ifdef CONFIG_I2C_1
+STM32_I2C_INIT(I2C_1);
 #endif /* CONFIG_I2C_1 */
 
 #ifdef CONFIG_I2C_2
-
-#ifdef CONFIG_I2C_STM32_INTERRUPT
-static void i2c_stm32_irq_config_func_2(struct device *port);
-#endif
-
-static const struct i2c_stm32_config i2c_stm32_cfg_2 = {
-	.i2c = (I2C_TypeDef *)DT_I2C_2_BASE_ADDRESS,
-	.pclken = {
-		.enr = DT_I2C_2_CLOCK_BITS,
-		.bus = DT_I2C_2_CLOCK_BUS,
-	},
-#ifdef CONFIG_I2C_STM32_INTERRUPT
-	.irq_config_func = i2c_stm32_irq_config_func_2,
-#endif
-	.bitrate = DT_I2C_2_BITRATE,
-};
-
-static struct i2c_stm32_data i2c_stm32_dev_data_2;
-
-DEVICE_AND_API_INIT(i2c_stm32_2, CONFIG_I2C_2_NAME, &i2c_stm32_init,
-		    &i2c_stm32_dev_data_2, &i2c_stm32_cfg_2,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		    &api_funcs);
-
-#ifdef CONFIG_I2C_STM32_INTERRUPT
-static void i2c_stm32_irq_config_func_2(struct device *dev)
-{
-#ifdef CONFIG_I2C_STM32_COMBINED_INTERRUPT
-	IRQ_CONNECT(DT_I2C_2_COMBINED_IRQ, DT_I2C_2_COMBINED_IRQ_PRI,
-		   stm32_i2c_combined_isr, DEVICE_GET(i2c_stm32_2), 0);
-	irq_enable(DT_I2C_2_COMBINED_IRQ);
-#else
-	IRQ_CONNECT(DT_I2C_2_EVENT_IRQ, DT_I2C_2_EVENT_IRQ_PRI,
-		   stm32_i2c_event_isr, DEVICE_GET(i2c_stm32_2), 0);
-	irq_enable(DT_I2C_2_EVENT_IRQ);
-
-	IRQ_CONNECT(DT_I2C_2_ERROR_IRQ, DT_I2C_2_ERROR_IRQ_PRI,
-		   stm32_i2c_error_isr, DEVICE_GET(i2c_stm32_2), 0);
-	irq_enable(DT_I2C_2_ERROR_IRQ);
-#endif
-}
-#endif
-
+STM32_I2C_INIT(I2C_2);
 #endif /* CONFIG_I2C_2 */
 
 #ifdef CONFIG_I2C_3
@@ -343,42 +331,7 @@ static void i2c_stm32_irq_config_func_2(struct device *dev)
 #error "I2C_3 is not available on the platform that you selected"
 #endif /* I2C3_BASE */
 
-#ifdef CONFIG_I2C_STM32_INTERRUPT
-static void i2c_stm32_irq_config_func_3(struct device *port);
-#endif
-
-static const struct i2c_stm32_config i2c_stm32_cfg_3 = {
-	.i2c = (I2C_TypeDef *)DT_I2C_3_BASE_ADDRESS,
-	.pclken = {
-		.enr = DT_I2C_3_CLOCK_BITS,
-		.bus = DT_I2C_3_CLOCK_BUS,
-	},
-#ifdef CONFIG_I2C_STM32_INTERRUPT
-	.irq_config_func = i2c_stm32_irq_config_func_3,
-#endif
-	.bitrate = DT_I2C_3_BITRATE,
-};
-
-static struct i2c_stm32_data i2c_stm32_dev_data_3;
-
-DEVICE_AND_API_INIT(i2c_stm32_3, CONFIG_I2C_3_NAME, &i2c_stm32_init,
-		    &i2c_stm32_dev_data_3, &i2c_stm32_cfg_3,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		    &api_funcs);
-
-#ifdef CONFIG_I2C_STM32_INTERRUPT
-static void i2c_stm32_irq_config_func_3(struct device *dev)
-{
-	IRQ_CONNECT(DT_I2C_3_EVENT_IRQ, DT_I2C_3_EVENT_IRQ_PRI,
-		   stm32_i2c_event_isr, DEVICE_GET(i2c_stm32_3), 0);
-	irq_enable(DT_I2C_3_EVENT_IRQ);
-
-	IRQ_CONNECT(DT_I2C_3_ERROR_IRQ, DT_I2C_3_ERROR_IRQ_PRI,
-		   stm32_i2c_error_isr, DEVICE_GET(i2c_stm32_3), 0);
-	irq_enable(DT_I2C_3_ERROR_IRQ);
-}
-#endif
-
+STM32_I2C_INIT(I2C_3);
 #endif /* CONFIG_I2C_3 */
 
 #ifdef CONFIG_I2C_4
@@ -387,40 +340,5 @@ static void i2c_stm32_irq_config_func_3(struct device *dev)
 #error "I2C_4 is not available on the platform that you selected"
 #endif /* I2C4_BASE */
 
-#ifdef CONFIG_I2C_STM32_INTERRUPT
-static void i2c_stm32_irq_config_func_4(struct device *port);
-#endif
-
-static const struct i2c_stm32_config i2c_stm32_cfg_4 = {
-	.i2c = (I2C_TypeDef *)DT_I2C_4_BASE_ADDRESS,
-	.pclken = {
-		.enr = DT_I2C_4_CLOCK_BITS,
-		.bus = DT_I2C_4_CLOCK_BUS,
-	},
-#ifdef CONFIG_I2C_STM32_INTERRUPT
-	.irq_config_func = i2c_stm32_irq_config_func_4,
-#endif
-	.bitrate = DT_I2C_4_BITRATE,
-};
-
-static struct i2c_stm32_data i2c_stm32_dev_data_4;
-
-DEVICE_AND_API_INIT(i2c_stm32_4, CONFIG_I2C_4_NAME, &i2c_stm32_init,
-		    &i2c_stm32_dev_data_4, &i2c_stm32_cfg_4,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		    &api_funcs);
-
-#ifdef CONFIG_I2C_STM32_INTERRUPT
-static void i2c_stm32_irq_config_func_4(struct device *dev)
-{
-	IRQ_CONNECT(DT_I2C_4_EVENT_IRQ, DT_I2C_4_EVENT_IRQ_PRI,
-		   stm32_i2c_event_isr, DEVICE_GET(i2c_stm32_4), 0);
-	irq_enable(DT_I2C_4_EVENT_IRQ);
-
-	IRQ_CONNECT(DT_I2C_4_ERROR_IRQ, DT_I2C_4_ERROR_IRQ_PRI,
-		   stm32_i2c_error_isr, DEVICE_GET(i2c_stm32_4), 0);
-	irq_enable(DT_I2C_4_ERROR_IRQ);
-}
-#endif
-
+STM32_I2C_INIT(I2C_4);
 #endif /* CONFIG_I2C_4 */


### PR DESCRIPTION
Use macros to add I2C instances

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>