### PR TITLE
Openocd improvements

### DIFF
--- a/boards/common/openocd.board.cmake
+++ b/boards/common/openocd.board.cmake
@@ -13,11 +13,8 @@ else()
   set_ifndef(OPENOCD_FLASH "flash write_image erase")
 endif()
 
-# zephyr.elf, or something else?
-set_ifndef(OPENOCD_IMAGE "${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}")
-
-set(OPENOCD_CMD_LOAD_DEFAULT "${OPENOCD_FLASH} ${OPENOCD_IMAGE}")
-set(OPENOCD_CMD_VERIFY_DEFAULT "verify_image ${OPENOCD_IMAGE}")
+set(OPENOCD_CMD_LOAD_DEFAULT "${OPENOCD_FLASH}")
+set(OPENOCD_CMD_VERIFY_DEFAULT "verify_image")
 
 board_finalize_runner_args(openocd
   --cmd-load "${OPENOCD_CMD_LOAD_DEFAULT}"

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -114,9 +114,9 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                 '-c', 'targets'] +
                pre_cmd +
                ['-c', 'reset halt',
-                '-c', self.load_cmd,
+                '-c', self.load_cmd + ' ' + self.elf_name,
                 '-c', 'reset halt',
-                '-c', self.verify_cmd] +
+                '-c', self.verify_cmd + ' ' + self.elf_name] +
                post_cmd +
                ['-c', 'reset run',
                 '-c', 'shutdown'])

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -34,6 +34,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         if cfg.openocd_search is not None:
             search_args = ['-s', cfg.openocd_search]
         self.openocd_cmd = [cfg.openocd] + search_args
+        self.hex_name = cfg.hex_file
         self.elf_name = cfg.elf_file
         self.load_cmd = load_cmd
         self.verify_cmd = verify_cmd
@@ -114,9 +115,9 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                 '-c', 'targets'] +
                pre_cmd +
                ['-c', 'reset halt',
-                '-c', self.load_cmd + ' ' + self.elf_name,
+                '-c', self.load_cmd + ' ' + self.hex_name,
                 '-c', 'reset halt',
-                '-c', self.verify_cmd + ' ' + self.elf_name] +
+                '-c', self.verify_cmd + ' ' + self.hex_name] +
                post_cmd +
                ['-c', 'reset run',
                 '-c', 'shutdown'])


### PR DESCRIPTION
This PR contains two major changes:
- stop concatenating zephyr.elf file to flash commands in cmake files, use cfg.elf_file / cfg.hex_file instead; this allows to overwrite file used with either --elf-file or --hex-file,
- use hex file instead of elf file for flash command, so we can flash signed image, which is only in hex and bin format (but not in elf format).