### PR TITLE
Add storage partitions to gecko boards

### DIFF
--- a/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.dts
+++ b/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.dts
@@ -64,3 +64,22 @@
 	location-tx = <GECKO_LOCATION(4) GECKO_PORT_F GECKO_PIN(2)>;
 	status = "okay";
 };
+
+&flash0 {
+	/*
+	 * For more information, see:
+	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 4Kb of storage at the end of the 64Kb of flash */
+		storage_partition: partition@f000 {
+			label = "storage";
+			reg = <0x0000f000 0x00001000>;
+		};
+
+	};
+};

--- a/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.yaml
+++ b/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.yaml
@@ -10,6 +10,7 @@ toolchain:
   - xtools
 supported:
   - gpio
+  - nvs
 testing:
   ignore_tags:
     - net

--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.dts
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.dts
@@ -86,3 +86,22 @@
 	location-swo = <0>;
 	status = "okay";
 };
+
+&flash0 {
+	/*
+	 * For more information, see:
+	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 4Kb of storage at the end of the 1024Kb of flash */
+		storage_partition: partition@ff000 {
+			label = "storage";
+			reg = <0x000ff000 0x00001000>;
+		};
+
+	};
+};

--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.yaml
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.yaml
@@ -11,6 +11,7 @@ toolchain:
 supported:
   - i2c
   - gpio
+  - nvs
 testing:
   ignore_tags:
     - net

--- a/boards/arm/efm32wg_stk3800/efm32wg_stk3800.dts
+++ b/boards/arm/efm32wg_stk3800/efm32wg_stk3800.dts
@@ -63,3 +63,22 @@
 	location-tx = <GECKO_LOCATION(1) GECKO_PORT_E GECKO_PIN(0)>;
 	status = "okay";
 };
+
+&flash0 {
+	/*
+	 * For more information, see:
+	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 4Kb of storage at the end of the 256Kb of flash */
+		storage_partition: partition@3f000 {
+			label = "storage";
+			reg = <0x0003f000 0x00001000>;
+		};
+
+	};
+};

--- a/boards/arm/efm32wg_stk3800/efm32wg_stk3800.yaml
+++ b/boards/arm/efm32wg_stk3800/efm32wg_stk3800.yaml
@@ -10,6 +10,7 @@ toolchain:
   - xtools
 supported:
   - gpio
+  - nvs
 testing:
   ignore_tags:
     - net

--- a/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.dts
+++ b/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.dts
@@ -98,22 +98,29 @@
 			read-only;
 		};
 
-		/* Reserve 96 kB for the application in slot 0 */
+		/* Reserve 94 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
 			label = "image-0";
-			reg = <0x0008000 0x00018000>;
+			reg = <0x0008000 0x00017800>;
 		};
 
-		/* Reserve 96 kB for the application in slot 1 */
-		slot1_partition: partition@20000 {
+		/* Reserve 94 kB for the application in slot 1 */
+		slot1_partition: partition@1f800 {
 			label = "image-1";
-			reg = <0x00020000 0x00018000>;
+			reg = <0x0001f800 0x00017800>;
 		};
 
 		/* Reserve 32 kB for the scratch partition */
-		scratch_partition: partition@38000 {
+		scratch_partition: partition@37000 {
 			label = "image-scratch";
-			reg = <0x00038000 0x00008000>;
+			reg = <0x00037000 0x00008000>;
 		};
+
+		/* Set 4Kb of storage at the end of the 256Kb of flash */
+		storage_partition: partition@3f000 {
+			label = "storage";
+			reg = <0x0003f000 0x00001000>;
+		};
+
 	};
 };

--- a/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.yaml
+++ b/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.yaml
@@ -10,6 +10,7 @@ toolchain:
   - xtools
 supported:
   - gpio
+  - nvs
 testing:
   ignore_tags:
     - net

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -91,3 +91,22 @@
 	location-swo = <0>;
 	status = "okay";
 };
+
+&flash0 {
+	/*
+	 * For more information, see:
+	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 4Kb of storage at the end of the 1024Kb of flash */
+		storage_partition: partition@ff000 {
+			label = "storage";
+			reg = <0x000ff000 0x00001000>;
+		};
+
+	};
+};

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.yaml
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.yaml
@@ -8,6 +8,10 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - gpio
+  - i2c
+  - nvs
 testing:
   ignore_tags:
     - net


### PR DESCRIPTION
This adds a  storage partition to all silabs gecko boards.

Fixes part of gecko related flash non covered files in #12860.

Test on target hardware pending, so please do not merge yet.