### PR TITLE
net: lwm2m: cancel pending retransmit work when closing context

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3821,6 +3821,9 @@ int lwm2m_engine_context_close(struct lwm2m_ctx *client_ctx)
 	sys_snode_t *prev_node = NULL;
 	int sock_fd = client_ctx->sock_fd;
 
+	/* Cancel pending retransmit work */
+	k_delayed_work_cancel(&client_ctx->retransmit_work);
+
 	/* Remove observes for this context */
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&engine_observer_list,
 					  obs, tmp, node) {


### PR DESCRIPTION
Currently the retransmit_work is not cancelled when closing a context,
making it operate on an invalid context.

LwM2M RD client also closes the context and initializes it again when
registration with the server fails, overwriting the active timeout and
breaking the timeout dlist.

Signed-off-by: Pieterjan Camerlynck <pieterjan.camerlynck@gmail.com>