### PR TITLE
drivers/gpio: specify whether driver is ISR-safe

### DIFF
--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -379,6 +379,7 @@ static const struct gpio_driver_api gpio_sx1509b_drv_api_funcs = {
 	.config	= gpio_sx1509b_config,
 	.write	= gpio_sx1509b_write,
 	.read	= gpio_sx1509b_read,
+	.not_isr_safe = true,
 };
 
 DEVICE_AND_API_INIT(gpio_sx1509b, CONFIG_GPIO_SX1509B_DEV_NAME,


### PR DESCRIPTION
At least one GPIO driver (SX1509B) is outside the SOC and requires I2C transactions for its basic operations.  That fact could not be detected from a generic GPIO driver reference, potentially causing problems if a pin was written or reconfigured from within an ISR.

Add a flag to the driver API that specifies that ISR operations are unsafe, and set the flag in the SX1509B driver API structure.  Add API that allows querying the state of this flag, to be used in concert with `k_is_in_isr()`.

**NOTE** GPIOs are only one type of driver where this capability is needed.  It should also be supported in `counter` to avoid misuse of the counter implementation in #17631.