### PR TITLE
drivers: fix printf formatting in flash_gecko.c

### DIFF
--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -84,12 +84,12 @@ static int flash_gecko_erase(struct device *dev, off_t offset, size_t size)
 	}
 
 	if ((offset % FLASH_PAGE_SIZE) != 0) {
-		LOG_ERR("offset %x: not on a page boundary", offset);
+		LOG_ERR("offset %ld: not on a page boundary", (long)offset);
 		return -EINVAL;
 	}
 
 	if ((size % FLASH_PAGE_SIZE) != 0) {
-		LOG_ERR("size %x: not multiple of a page size", size);
+		LOG_ERR("size %zu: not multiple of a page size", size);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Fix printf formats used for off_t and size_t types to remove warnings generated when compiling with Newlib.