### PR TITLE
soc: k64f MPU configured to always allow USB

### DIFF
--- a/include/arch/arm/cortex_m/mpu/nxp_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/nxp_mpu.h
@@ -118,11 +118,12 @@
 #define REGION_USER_RO_ATTR {(MPU_REGION_READ | \
 			     MPU_REGION_SU)}
 
-/* ENET device (Master 3) will not be able to access RAM when
-ram region is dynamically disabled in NXP MPU.
+/* ENET (Master 3) and USB (Master 4) devices will not be able
+to access RAM when the region is dynamically disabled in NXP MPU.
 DEBUGGER (Master 1) can't be disabled in Region 0. */
 #define REGION_DEBUGGER_AND_DEVICE_ATTR  {((MPU_REGION_SU) | \
-				((UM_READ | UM_WRITE) << BM3_UM_SHIFT))}
+				((UM_READ | UM_WRITE) << BM3_UM_SHIFT) | \
+				(BM4_PERMISSIONS))}
 
 #define REGION_DEBUG_ATTR  {MPU_REGION_SU}
 

--- a/soc/arm/nxp_kinetis/k6x/nxp_mpu_regions.c
+++ b/soc/arm/nxp_kinetis/k6x/nxp_mpu_regions.c
@@ -8,8 +8,8 @@
 
 static const struct nxp_mpu_region mpu_regions[] = {
 	/* Region 0 */
-	/* Debugger access can't be disabled; ENET devices will not be able to
-	 * access RAM when it's region is dynamically disabled in NXP MPU.
+	/* Debugger access can't be disabled; ENET and USB devices will not be able
+	 * to access RAM when their regions are dynamically disabled in NXP MPU.
 	 */
 	MPU_REGION_ENTRY("DEBUGGER_0",
 			 0,


### PR DESCRIPTION
Because NXP MPU's regions are dynamically enabled/disabled, USB
device's access maybe restricted when switching out of a task.
Background DMA transfers to/from RAM may happen during MPU region
reconfiguration or core idling.
Enabled USB (Kinetis MPU Master 4) to always have access to RAM address
space.

Signed-off-by: Andrei Gansari <andrei.gansari@nxp.com>

Fixes #17007