### PR TITLE
logging: Clean up log.h dependencies

### DIFF
--- a/include/logging/log_backend.h
+++ b/include/logging/log_backend.h
@@ -7,7 +7,9 @@
 #define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_H_
 
 #include <logging/log_msg.h>
-#include <assert.h>
+#include <stdarg.h>
+#include <sys/__assert.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -11,6 +11,7 @@
 #include <sys/util.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/logging/log_ctrl.h
+++ b/include/logging/log_ctrl.h
@@ -7,6 +7,7 @@
 #define ZEPHYR_INCLUDE_LOGGING_LOG_CTRL_H_
 
 #include <logging/log_backend.h>
+#include <kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/logging/log_msg.h
+++ b/include/logging/log_msg.h
@@ -6,9 +6,7 @@
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_MSG_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_MSG_H_
 
-#include <kernel.h>
 #include <sys/atomic.h>
-#include <assert.h>
 #include <string.h>
 
 #ifdef __cplusplus
@@ -88,17 +86,11 @@ struct log_msg_ids {
 	u16_t source_id : 10;   /*!< Source ID. */
 };
 
-BUILD_ASSERT_MSG((sizeof(struct log_msg_ids) == sizeof(u16_t)),
-		  "Structure must fit in 2 bytes");
-
 /** Part of log message header common to standard and hexdump log message. */
 struct log_msg_generic_hdr {
 	COMMON_PARAM_HDR();
 	u16_t reserved : 14;
 };
-
-BUILD_ASSERT_MSG((sizeof(struct log_msg_generic_hdr) == sizeof(u16_t)),
-		 "Structure must fit in 2 bytes");
 
 /** Part of log message header specific to standard log message. */
 struct log_msg_std_hdr {
@@ -107,17 +99,11 @@ struct log_msg_std_hdr {
 	u16_t nargs    : 4;
 };
 
-BUILD_ASSERT_MSG((sizeof(struct log_msg_std_hdr) == sizeof(u16_t)),
-		 "Structure must fit in 2 bytes");
-
 /** Part of log message header specific to hexdump log message. */
 struct log_msg_hexdump_hdr {
 	COMMON_PARAM_HDR();
 	u16_t length     : LOG_MSG_HEXDUMP_LENGTH_BITS;
 };
-
-BUILD_ASSERT_MSG((sizeof(struct log_msg_hexdump_hdr) == sizeof(u16_t)),
-		 "Structure must fit in 2 bytes");
 
 /** Log message header structure */
 struct log_msg_hdr {
@@ -158,10 +144,6 @@ struct log_msg {
 	} payload;                 /*!< Message data. */
 };
 
-BUILD_ASSERT_MSG((sizeof(union log_msg_head_data) ==
-		  sizeof(struct log_msg_ext_head_data)),
-		  "Structure must be same size");
-
 /** @brief Chunks following message head when message is extended. */
 struct log_msg_cont {
 	struct log_msg_cont *next; /*!< Pointer to the next chunk. */
@@ -176,8 +158,6 @@ union log_msg_chunk {
 	struct log_msg head;
 	struct log_msg_cont cont;
 };
-
-extern struct k_mem_slab log_msg_pool;
 
 /** @brief Function for initialization of the log message pool. */
 void log_msg_pool_init(void);
@@ -327,17 +307,11 @@ void log_msg_hexdump_data_get(struct log_msg *msg,
 
 union log_msg_chunk *log_msg_no_space_handle(void);
 
-static inline union log_msg_chunk *log_msg_chunk_alloc(void)
-{
-	union log_msg_chunk *msg = NULL;
-	int err = k_mem_slab_alloc(&log_msg_pool, (void **)&msg, K_NO_WAIT);
-
-	if (err != 0) {
-		msg = log_msg_no_space_handle();
-	}
-
-	return msg;
-}
+/** @brief Allocate single chunk from the pool.
+ *
+ * @return Pointer to the allocated chunk or NULL if failed to allocate.
+ */
+union log_msg_chunk *log_msg_chunk_alloc(void);
 
 /** @brief Allocate chunk for standard log message.
  *

--- a/include/logging/log_output.h
+++ b/include/logging/log_output.h
@@ -7,6 +7,8 @@
 #define ZEPHYR_INCLUDE_LOGGING_LOG_OUTPUT_H_
 
 #include <logging/log_msg.h>
+#include <sys/util.h>
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/logging/log_backend_native_posix.c
+++ b/subsys/logging/log_backend_native_posix.c
@@ -11,6 +11,7 @@
 #include <logging/log_core.h>
 #include <logging/log_msg.h>
 #include <logging/log_output.h>
+#include <irq.h>
 #include "posix_trace.h"
 
 #define _STDOUT_BUF_SIZE 256

--- a/subsys/logging/log_backend_std.h
+++ b/subsys/logging/log_backend_std.h
@@ -8,6 +8,7 @@
 
 #include <logging/log_msg.h>
 #include <logging/log_output.h>
+#include <irq.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -8,6 +8,23 @@
 #include <logging/log_ctrl.h>
 #include <logging/log_core.h>
 #include <string.h>
+#include <assert.h>
+
+BUILD_ASSERT_MSG((sizeof(struct log_msg_ids) == sizeof(u16_t)),
+		  "Structure must fit in 2 bytes");
+
+BUILD_ASSERT_MSG((sizeof(struct log_msg_generic_hdr) == sizeof(u16_t)),
+		 "Structure must fit in 2 bytes");
+
+BUILD_ASSERT_MSG((sizeof(struct log_msg_std_hdr) == sizeof(u16_t)),
+		 "Structure must fit in 2 bytes");
+
+BUILD_ASSERT_MSG((sizeof(struct log_msg_hexdump_hdr) == sizeof(u16_t)),
+		 "Structure must fit in 2 bytes");
+
+BUILD_ASSERT_MSG((sizeof(union log_msg_head_data) ==
+		  sizeof(struct log_msg_ext_head_data)),
+		  "Structure must be same size");
 
 #ifndef CONFIG_LOG_BUFFER_SIZE
 #define CONFIG_LOG_BUFFER_SIZE 0
@@ -23,6 +40,18 @@ static u8_t __noinit __aligned(sizeof(void *))
 void log_msg_pool_init(void)
 {
 	k_mem_slab_init(&log_msg_pool, log_msg_pool_buf, MSG_SIZE, NUM_OF_MSGS);
+}
+
+union log_msg_chunk *log_msg_chunk_alloc(void)
+{
+	union log_msg_chunk *msg = NULL;
+	int err = k_mem_slab_alloc(&log_msg_pool, (void **)&msg, K_NO_WAIT);
+
+	if (err != 0) {
+		msg = log_msg_no_space_handle();
+	}
+
+	return msg;
 }
 
 void log_msg_get(struct log_msg *msg)

--- a/subsys/settings/src/settings.c
+++ b/subsys/settings/src/settings.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <errno.h>
+#include <kernel.h>
 
 #include "settings/settings.h"
 #include "settings_priv.h"

--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -12,6 +12,7 @@
 #include <stddef.h>
 #include <sys/types.h>
 #include <errno.h>
+#include <kernel.h>
 
 #include "settings/settings.h"
 #include "settings_priv.h"


### PR DESCRIPTION
Cleaning up log.h include dependencies to allow log.h including in base
headers (e.g. kernel.h, assert.h, fatal.h, etc).

After this change `log.h` depends only on standard headers.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>