### PR TITLE
drivers: timer: nrf_rtc_timer: Fix set_comparator corner case

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -166,7 +166,7 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 			}
 		} else if (dt == 1) {
 			/* Too soon, interrupt won't arrive. */
-			set_comparator(cyc + 1);
+			set_comparator(cyc + 2);
 		}
 		/* Otherwise it was two cycles out, we're fine */
 	}


### PR DESCRIPTION
Update the logic in a corner case, when the target comparator value is
one cycle ahead of the counter value.

Experiments have shown, that `set_comparator(cyc + 1);` might be not
enough in that case, and we still may (rarely) miss the interrupt.
This could happen when the counter incremented its value after the `dt`
variable was set. As we should set the comparator value two cycles
ahead to be on the safe side, increment the target comparator value
by 2 instead of 1.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>