### PR TITLE
Bluetooth: controller: Decorrelate address generation from resolution

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -45,6 +45,7 @@ static struct {
 } wl[WL_SIZE];
 
 static u8_t rl_enable;
+
 static struct rl_dev {
 	u8_t      taken:1;
 	u8_t      rpas_ready:1;
@@ -684,20 +685,12 @@ static void rpa_timeout(struct k_work *work)
 
 static void rpa_refresh_start(void)
 {
-	if (!rl_enable) {
-		return;
-	}
-
 	BT_DBG("");
 	k_delayed_work_submit(&rpa_work, rpa_timeout_ms);
 }
 
 static void rpa_refresh_stop(void)
 {
-	if (!rl_enable) {
-		return;
-	}
-
 	k_delayed_work_cancel(&rpa_work);
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -56,6 +56,7 @@ static struct {
 } wl[WL_SIZE];
 
 static u8_t rl_enable;
+
 static struct rl_dev {
 	u8_t      taken:1;
 	u8_t      rpas_ready:1;
@@ -925,20 +926,12 @@ static void rpa_timeout(struct k_work *work)
 
 static void rpa_refresh_start(void)
 {
-	if (!rl_enable) {
-		return;
-	}
-
 	BT_DBG("");
 	k_delayed_work_submit(&rpa_work, rpa_timeout_ms);
 }
 
 static void rpa_refresh_stop(void)
 {
-	if (!rl_enable) {
-		return;
-	}
-
 	k_delayed_work_cancel(&rpa_work);
 }
 


### PR DESCRIPTION
Changes related to Bluetooth TSE 11068.

Fixes BT LL TS 5.1.0 test:
LL/SEC/ADV/BV-03-C [Privacy - Non-connectable Undirected
Advertising, Resolvable Private Address]

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>