### PR TITLE
power: add DEVICE_PM_LOW_POWER_STATE for device power management

### DIFF
--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -66,6 +66,24 @@ int sys_pm_suspend_devices(void)
 	return 0;
 }
 
+int sys_pm_low_power_devices(void)
+{
+	for (int i = device_count - 1; i >= 0; i--) {
+		int idx = device_ordered_list[i];
+
+		device_retval[i] = device_set_power_state(&pm_device_list[idx],
+						DEVICE_PM_LOW_POWER_STATE,
+						NULL, NULL);
+		if (device_retval[i]) {
+			LOG_ERR("%s low power operation failed\n",
+					pm_device_list[idx].config->name);
+			return device_retval[i];
+		}
+	}
+
+	return 0;
+}
+
 int sys_pm_force_suspend_devices(void)
 {
 	for (int i = device_count - 1; i >= 0; i--) {

--- a/subsys/power/policy/pm_policy.h
+++ b/subsys/power/policy/pm_policy.h
@@ -24,6 +24,11 @@ extern  void sys_pm_create_device_list(void);
 extern int sys_pm_suspend_devices(void);
 
 /**
+ * @brief Function to low power the devices in PM device list
+ */
+extern int sys_pm_low_power_devices(void);
+
+/**
  * @brief Function to force suspend the devices in PM device list
  */
 extern int sys_pm_force_suspend_devices(void);

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -106,6 +106,7 @@ enum power_states _sys_suspend(s32_t ticks)
 		/* Suspend peripherals. */
 		if (sys_pm_suspend_devices()) {
 			LOG_ERR("System level device suspend failed!");
+			sys_pm_resume_devices();
 			sys_pm_notify_power_state_exit(pm_state);
 			pm_state = SYS_POWER_STATE_ACTIVE;
 			return pm_state;


### PR DESCRIPTION
when system going to sleep state(not deep sleep), make peripherals
go to DEVICE_PM_LOW_POWER_STATE state which need less time than
DEVICE_PM_SUSPEND_STATE to save more power in the sleep state.

Fixes: #17838.

Signed-off-by: Wentong Wu <wentong.wu@intel.com>