### PR TITLE
Bluetooth: GATT: Fix byte order for database hash

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -420,6 +420,15 @@ static void db_hash_gen(bool store)
 		return;
 	}
 
+	/**
+	 * Core 5.1 does not state the endianess of the hash.
+	 * However Vol 3, Part F, 3.3.1 says that multi-octet Characteristic
+	 * Values shall be LE unless otherwise defined. PTS expects hash to be
+	 * in little endianess as well. bt_smp_aes_cmac calculates the hash in
+	 * big endianess so we have to swap.
+	 */
+	sys_mem_swap(db_hash, sizeof(db_hash));
+
 	BT_HEXDUMP_DBG(db_hash, sizeof(db_hash), "Hash: ");
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS) && store) {


### PR DESCRIPTION
Core 5.1, Vol 3, Part F, 3.3.1
"Multi-octet fields within the GATT profile shall be sent least
significant octet first (little-endian) with the exception of the
Characteristic Value field. The Characteristic Value and any fields
within it shall be little-endian unless otherwise defined in the
specification which defines the characteristic."

Fixes: GATT/SR/GAS/BV-02-C
Fixes: #17857
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>