### PR TITLE
dts: Remove all 'device_type = ...' properties

### DIFF
--- a/boards/arc/nsim/nsim.dtsi
+++ b/boards/arc/nsim/nsim.dtsi
@@ -21,13 +21,11 @@
 	};
 
 	iccm0: iccm@0 {
-		device_type = "memory";
 		compatible = "arc,iccm";
 		reg = <0x0 0x80000>;
 	};
 
 	dccm0: dccm@80000000 {
-		device_type = "memory";
 		compatible = "arc,dccm";
 		reg = <0x80000000 0x80000>;
 	};

--- a/boards/arc/nsim/nsim_em.dtsi
+++ b/boards/arc/nsim/nsim_em.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "snps,arcem";
 			reg = <0>;
 		};

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -33,7 +33,6 @@
 
 	sdram0: memory@80000000 {
 		/* ISSI IS42S16160J-6TLI */
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x80000000 0x2000000>;
 	};

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -34,7 +34,6 @@
 
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x80000000 0x2000000>;
 	};

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -30,7 +30,6 @@
 
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x80000000 0x2000000>;
 	};

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -31,7 +31,6 @@
 
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x80000000 0x2000000>;
 	};

--- a/boards/arm/mps2_an521/mps2_an521.dts
+++ b/boards/arm/mps2_an521/mps2_an521.dts
@@ -26,7 +26,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			#address-cells = <1>;

--- a/boards/arm/mps2_an521/mps2_an521_nonsecure.dts
+++ b/boards/arm/mps2_an521/mps2_an521_nonsecure.dts
@@ -26,7 +26,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			#address-cells = <1>;

--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
@@ -168,13 +168,11 @@
 / {
 	/* SRAM allocated and used by the BSD library */
 	sram0_bsd: memory@20010000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 
 	/* SRAM allocated to the Non-Secure image */
 	sram0_ns: memory@20020000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 };

--- a/boards/arm/v2m_musca/v2m_musca.dts
+++ b/boards/arm/v2m_musca/v2m_musca.dts
@@ -25,7 +25,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			#address-cells = <1>;

--- a/boards/arm/v2m_musca/v2m_musca_nonsecure.dts
+++ b/boards/arm/v2m_musca/v2m_musca_nonsecure.dts
@@ -25,7 +25,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			#address-cells = <1>;

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1.dts
@@ -25,7 +25,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			#address-cells = <1>;

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.dts
@@ -25,7 +25,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			#address-cells = <1>;

--- a/boards/riscv32/litex_vexriscv/litex_vexriscv.dts
+++ b/boards/riscv32/litex_vexriscv/litex_vexriscv.dts
@@ -19,7 +19,6 @@
 	};
 
 	ram0: memory@40000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x40000000 0x10000000>;
 	};

--- a/dts/arc/arc_iot.dtsi
+++ b/dts/arc/arc_iot.dtsi
@@ -15,7 +15,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "snps,arcem";
 			reg = <0>;
 		};
@@ -28,20 +27,17 @@
 	};
 
 	iccm0: iccm@20000000 {
-		device_type = "memory";
 		compatible = "arc,iccm";
 		reg = <0x20000000 0x40000>;
 	};
 
 	dccm0: dccm@80000000 {
-		device_type = "memory";
 		compatible = "arc,dccm";
 		reg = <0x80000000 0x20000>;
 	};
 
 
 	sram: memory@30000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x30000000 0x20000>;
 	};

--- a/dts/arc/emsk.dtsi
+++ b/dts/arc/emsk.dtsi
@@ -16,7 +16,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "snps,arcem";
 			reg = <0>;
 		};
@@ -29,12 +28,10 @@
 	};
 
 	iccm0: iccm@0 {
-		device_type = "memory";
 		compatible = "arc,iccm";
 	};
 
 	dccm0: dccm@80000000 {
-		device_type = "memory";
 		compatible = "arc,dccm";
 	};
 
@@ -51,7 +48,6 @@
 		ranges;
 
 		ddr0: memory@10000000 {
-			device_type = "memory";
 			compatible = "mmio-sram";
 			reg = <0x10000000 0x8000000>;
 		};

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -13,14 +13,12 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20070000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20070000 0x18000>;
 	};

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -14,14 +14,12 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20100000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/atmel/samd.dtsi
+++ b/dts/arm/atmel/samd.dtsi
@@ -14,14 +14,12 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x8000>;
 	};

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -15,7 +15,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m7";
 			reg = <0>;
 			#address-cells = <1>;
@@ -30,7 +29,6 @@
 	};
 
 	sram0: memory@20400000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/cypress/psoc6.dtsi
+++ b/dts/arm/cypress/psoc6.dtsi
@@ -12,12 +12,10 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};
 		cpu@1 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <1>;
 		};
@@ -48,19 +46,16 @@
 	};
 
 	sram0: memory@8000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x08000000 DT_SIZE_K(140)>;
 	};
 
 	sram1: memory@8023000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x08023000 DT_SIZE_K(4)>;
 	};
 
 	sram2: memory@8024000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x08024000 DT_SIZE_K(112)>;
 	};

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};

--- a/dts/arm/microchip/mec1701qsz.dtsi
+++ b/dts/arm/microchip/mec1701qsz.dtsi
@@ -12,7 +12,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0";
 			reg = <0>;
 		};
@@ -55,7 +54,6 @@
 		};
 
 		sram0: memory@20000000 {
-			device_type = "memory";
 			compatible = "mmio-sram";
 		};
 

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};
@@ -54,7 +53,6 @@
 		};
 
 		sram0: memory@20000000 {
-			device_type = "memory";
 			compatible = "mmio-sram";
 		};
 

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};
@@ -58,7 +57,6 @@
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};
@@ -62,7 +61,6 @@
 		};
 
 		sram0: memory@20000000 {
-			device_type = "memory";
 			compatible = "mmio-sram";
 		};
 

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};
@@ -69,7 +68,6 @@
 		};
 
 		sram0: memory@20000000 {
-			device_type = "memory";
 			compatible = "mmio-sram";
 		};
 

--- a/dts/arm/nordic/nrf9160.dtsi
+++ b/dts/arm/nordic/nrf9160.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33f";
 			reg = <0>;
 			#address-cells = <1>;
@@ -64,7 +63,6 @@
 
 	soc {
 		sram0: memory@20000000 {
-			device_type = "memory";
 			compatible = "mmio-sram";
 		};
 

--- a/dts/arm/nordic/nrf9160ns.dtsi
+++ b/dts/arm/nordic/nrf9160ns.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33f";
 			reg = <0>;
 			#address-cells = <1>;
@@ -62,7 +61,6 @@
 
 	soc {
 		sram0: memory@20000000 {
-			device_type = "memory";
 			compatible = "mmio-sram";
 		};
 

--- a/dts/arm/nxp/nxp_imx6sx_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx6sx_m4.dtsi
@@ -14,14 +14,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-a9";
 			reg = <0>;
 			status = "disabled";
 		};
 
 		cpu@1 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <1>;
 		};
@@ -40,21 +38,18 @@
 	};
 
 	ocram_s:memory@208f8000 {
-		device_type = "memory";
 		compatible = "nxp,imx-sys-bus";
 		reg = <0x208f8000 0x00004000>;
 		label = "OCRAM_S";
 	};
 
 	ocram:memory@20900000 {
-		device_type = "memory";
 		compatible = "nxp,imx-sys-bus";
 		reg = <0x20900000 0x00020000>;
 		label = "OCRAM";
 	};
 
 	ddr:memory@80000000 {
-		device_type = "memory";
 		compatible = "nxp,imx-sys-bus";
 		reg = <0x80000000 0x60000000>;
 		label = "DDR";

--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -15,7 +15,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};
@@ -30,7 +29,6 @@
 		};
 
 		ddr_sys: memory@80000000 {
-			device_type = "memory";
 			compatible = "nxp,imx-sys-bus";
 			reg = <0x80000000 0x60000000>;
 			label = "DDR SYSTEM";
@@ -55,7 +53,6 @@
 		};
 
 		ocram_sys: memory@20200000 {
-			device_type = "memory";
 			compatible = "nxp,imx-sys-bus";
 			reg = <0x20200000 0x20000>;
 			label = "OCRAM SYSTEM";
@@ -68,7 +65,6 @@
 		};
 
 		ocram_s_sys: memory@180000 {
-			device_type = "memory";
 			compatible = "nxp,imx-sys-bus";
 			reg = <0x00180000 0x8000>;
 			label = "OCRAM_S SYSTEM";

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};
@@ -27,13 +26,11 @@
 	 * https://sourceware.org/ml/binutils/2017-02/msg00250.html
 	 */
 	sram_l: memory@1fff0000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x1fff0000 0x10000>;
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x30000>;
 	};

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -40,7 +40,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};

--- a/dts/arm/nxp/nxp_ke1xf256vlx16.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf256vlx16.dtsi
@@ -18,13 +18,11 @@
 	 * https://sourceware.org/ml/binutils/2017-02/msg00250.html
 	 */
 	sram_l: memory@1fffc000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x1fffc000 DT_SIZE_K(16)>;
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SIZE_K(16)>;
 	};

--- a/dts/arm/nxp/nxp_ke1xf512vlx16.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf512vlx16.dtsi
@@ -18,13 +18,11 @@
 	 * https://sourceware.org/ml/binutils/2017-02/msg00250.html
 	 */
 	sram_l: memory@1fff8000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x1fff8000 DT_SIZE_K(32)>;
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SIZE_K(32)>;
 	};

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -11,14 +11,12 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@1FFFF000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x1FFFF000 0x4000>;
 	};

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -11,14 +11,12 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x8000>;
 	};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -11,14 +11,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x4000>;
 	};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -11,14 +11,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x20000>;
 	};

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -15,7 +15,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m7";
 			reg = <0>;
 			#address-cells = <1>;

--- a/dts/arm/silabs/efm32hg.dtsi
+++ b/dts/arm/silabs/efm32hg.dtsi
@@ -17,7 +17,6 @@
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/silabs/efm32pg12b.dtsi
+++ b/dts/arm/silabs/efm32pg12b.dtsi
@@ -21,7 +21,6 @@
 	};
 
 	sram0: memory@20000000 {
-	       device_type = "memory";
 	       compatible = "mmio-sram";
 	};
 

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -17,7 +17,6 @@
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -17,7 +17,6 @@
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -17,7 +17,6 @@
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -16,14 +16,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -16,7 +16,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m3";
 			reg = <0>;
 		};
@@ -28,7 +27,6 @@
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -15,14 +15,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m3";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -16,14 +16,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -16,14 +16,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -16,7 +16,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m7";
 			reg = <0>;
 			#address-cells = <1>;

--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -10,7 +10,6 @@
 	/* 64KB DTCM @ 0x20000000, 176KB SRAM1 @ 0x20010000, 16KB SRAM2 @ 0x2003C00 */
 
 	sram0: memory@20010000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20010000 DT_SIZE_K(192)>;
 	};

--- a/dts/arm/st/f7/stm32f746.dtsi
+++ b/dts/arm/st/f7/stm32f746.dtsi
@@ -10,7 +10,6 @@
 	/* 64KB DTCM @ 20000000, 240KB SRAM1 @ 20010000, 16KB SRAM2 @ 2004C000 */
 
 	sram0: memory@20010000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20010000 DT_SIZE_K(256)>;
 	};

--- a/dts/arm/st/f7/stm32f769.dtsi
+++ b/dts/arm/st/f7/stm32f769.dtsi
@@ -10,7 +10,6 @@
 	/* 128KB DTCM @ 20000000, 368KB SRAM1 @ 20020000, 16KB SRAM2 @ 2007C000 */
 
 	sram0: memory@20020000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20020000 DT_SIZE_K(384)>;
 	};

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -16,14 +16,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m7";
 			reg = <0>;
 			#address-cells = <1>;
@@ -27,7 +26,6 @@
 			};
 		};
 		cpu@1 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <1>;
 		};

--- a/dts/arm/st/h7/stm32h747Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h747Xi_m4.dtsi
@@ -14,7 +14,6 @@
 
 	/* system data RAM accessible over over AXI bus */
 	sram1: memory@10000000 {
-		device_type = "memory";
 		reg = <0x10000000 DT_SIZE_K(288)>;
 		compatible = "mmio-sram";
 	};

--- a/dts/arm/st/h7/stm32h747Xi_m7.dtsi
+++ b/dts/arm/st/h7/stm32h747Xi_m7.dtsi
@@ -14,7 +14,6 @@
 
 	/* system data RAM accessible over over AXI bus */
 	sram0: memory@24000000 {
-		device_type = "memory";
 		reg = <0x24000000 DT_SIZE_K(512)>;
 		compatible = "mmio-sram";
 	};

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -16,14 +16,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -16,14 +16,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m3";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -17,14 +17,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -16,19 +16,16 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};
 	};
 
 	retram: memory0@0 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x00000000 DT_SIZE_K(64)>;
 	};
 	mcusram: memory1@10000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x10000000 DT_SIZE_K(256)>;
 	};

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -15,14 +15,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/ti/cc13x2_cc26x2.dtsi
+++ b/dts/arm/ti/cc13x2_cc26x2.dtsi
@@ -14,20 +14,17 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 
 	/* VIMS RAM configurable in CCFG as GPRAM or cache for FLASH (default) */
 	sram1: memory@11000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x11000000 0x2000>;
 	};

--- a/dts/arm/ti/cc2650.dtsi
+++ b/dts/arm/ti/cc2650.dtsi
@@ -12,14 +12,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m3";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x5000>;
 	};

--- a/dts/arm/ti/cc32xx.dtsi
+++ b/dts/arm/ti/cc32xx.dtsi
@@ -25,14 +25,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 	};
 

--- a/dts/arm/ti/lm3s6965.dtsi
+++ b/dts/arm/ti/lm3s6965.dtsi
@@ -8,14 +8,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m3";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 (64*1024)>;
 	};

--- a/dts/nios2/nios2-qemu.dtsi
+++ b/dts/nios2/nios2-qemu.dtsi
@@ -8,7 +8,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "qemu,nios2";
 			reg = <0>;
 		};
@@ -21,7 +20,6 @@
 	};
 
 	sram0: memory@400000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x400000 0x20000>;
 	};

--- a/dts/nios2/nios2f.dtsi
+++ b/dts/nios2/nios2f.dtsi
@@ -9,7 +9,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "altera,nios2f";
 			reg = <0>;
 		};
@@ -22,7 +21,6 @@
 	};
 
 	sram0: memory@400000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x400000 0x20000>;
 	};

--- a/dts/riscv32/microsemi-miv.dtsi
+++ b/dts/riscv32/microsemi-miv.dtsi
@@ -14,7 +14,6 @@
 		cpu@0 {
 			clock-frequency = <0>;
 			compatible = "microsemi,miv", "riscv";
-			device_type = "cpu";
 			reg = <0>;
 			riscv,isa = "rv32imac";
 			hlic: interrupt-controller {
@@ -37,7 +36,6 @@
 		};
 
 		sram0: memory@80040000 {
-			device_type = "memory";
 			compatible = "mmio-sram";
 			reg = <0x80040000 0x40000>;
 		};

--- a/dts/riscv32/riscv32-fe310.dtsi
+++ b/dts/riscv32/riscv32-fe310.dtsi
@@ -13,7 +13,6 @@
 		cpu@0 {
 			clock-frequency = <0>;
 			compatible = "sifive,rocket0", "riscv";
-			device_type = "cpu";
 			i-cache-block-size = <64>;
 			i-cache-sets = <128>;
 			i-cache-size = <16384>;

--- a/dts/riscv32/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv32/riscv32-litex-vexriscv.dtsi
@@ -15,7 +15,6 @@
 		cpu@0 {
 			clock-frequency = <100000000>;
 			compatible = "spinalhdl,vexriscv", "riscv";
-			device_type = "cpu";
 			reg = <0>;
 			riscv,isa = "rv32imac";
 			status = "okay";

--- a/dts/riscv32/rv32m1.dtsi
+++ b/dts/riscv32/rv32m1.dtsi
@@ -38,26 +38,22 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "riscv";
 			reg = <0>;
 		};
 
 		cpu@1 {
-			device_type = "cpu";
 			compatible = "riscv";
 			reg = <1>;
 		};
 	};
 
 	m4_dtcm: memory@20000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x30000>;
 	};
 
 	m0_tcm: memory@9000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x09000000 0x20000>;
 	};

--- a/dts/x86/apollo_lake.dtsi
+++ b/dts/x86/apollo_lake.dtsi
@@ -15,7 +15,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "apollo_lake";
 			reg = <0>;
 		};
@@ -28,7 +27,6 @@
 	};
 
 	sram0: memory@400000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x00400000 DT_SRAM_SIZE>;
 	};

--- a/dts/x86/atom.dtsi
+++ b/dts/x86/atom.dtsi
@@ -13,7 +13,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "atom";
 			reg = <0>;
 		};
@@ -25,7 +24,6 @@
 	};
 
 	sram0: memory@400000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x00400000 DT_SRAM_SIZE>;
 	};

--- a/dts/x86/ia32.dtsi
+++ b/dts/x86/ia32.dtsi
@@ -13,7 +13,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "qemu32";
 			reg = <0>;
 		};
@@ -34,7 +33,6 @@
 	};
 
 	sram0: memory@400000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x00400000 DT_SRAM_SIZE>;
 	};

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -11,13 +11,11 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "cadence,tensilica-xtensa-lx6";
 			reg = <0>;
 		};
 
 		cpu1: cpu@1 {
-			device_type = "cpu";
 			compatible = "cadence,tensilica-xtensa-lx6";
 			reg = <1>;
 		};
@@ -25,7 +23,6 @@
 	};
 
 	sram0: memory@3ffb0000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x3FFB0000 0x50000>;
 	};

--- a/dts/xtensa/intel/intel_s1000.dtsi
+++ b/dts/xtensa/intel/intel_s1000.dtsi
@@ -13,26 +13,22 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "cadence,tensilica-xtensa-lx6";
 			reg = <0>;
 		};
 
 		cpu1: cpu@1 {
-			device_type = "cpu";
 			compatible = "cadence,tensilica-xtensa-lx6";
 			reg = <1>;
 		};
 	};
 
 	sram0: memory@be000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0xbe000000 DT_SIZE_M(4)>;
 	};
 
 	sram1: memory@be800000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0xbe800000 DT_SIZE_K(64)>;
 	};

--- a/dts/xtensa/sample_controller.dtsi
+++ b/dts/xtensa/sample_controller.dtsi
@@ -12,14 +12,12 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "sample_controller";
 			reg = <0>;
 		};
 	};
 
 	sram0: memory@60000000 {
-		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x60000000 0x4000000>;
 	};


### PR DESCRIPTION
Unused in Zephyr. There's some documentation for device_type at
https://elinux.org/Device_Tree_Linux, which says that it's deprecated.

Trying to get rid of properties that appear on device tree nodes but
aren't declared in bindings.

Removal was done with

    git ls-files '*.dts' '*.dtsi' | xargs sed -i '/device_type/d'