### PR TITLE
Bluetooth: GATT: Add BTP Discover All Primary Services command handler

### DIFF
--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -409,6 +409,12 @@ struct gatt_descriptor {
 
 #define GATT_EXCHANGE_MTU		0x0a
 
+#define GATT_DISC_ALL_PRIM		0x0b
+struct gatt_disc_all_prim_cmd {
+	u8_t address_type;
+	u8_t address[6];
+} __packed;
+
 #define GATT_DISC_PRIM_UUID		0x0c
 struct gatt_disc_prim_uuid_cmd {
 	u8_t address_type;
@@ -416,7 +422,7 @@ struct gatt_disc_prim_uuid_cmd {
 	u8_t uuid_length;
 	u8_t uuid[0];
 } __packed;
-struct gatt_disc_prim_uuid_rp {
+struct gatt_disc_prim_rp {
 	u8_t services_count;
 	struct gatt_service services[0];
 } __packed;


### PR DESCRIPTION
This will handle BTP Discover All Primary Services command.

Related TC: GATT/CL/GAD/BV-01-C
Fixes: #17861
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>