### PR TITLE
manifest: add reference to mcuboot project

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -73,6 +73,9 @@ manifest:
     - name: mbedtls
       revision: 4f1e8f5a78dc08aa42a47cc1ad059cce558c26c3
       path: modules/crypto/mbedtls
+    - name: mcuboot
+      revision: c2bd757332bfde11c27019f937b0c61d5e9b9fd9
+      path: bootloader/mcuboot
     - name: mcumgr
       revision: b18b3d16441f40cf983aa034258e8f7c97bfe9bf
       path: modules/lib/mcumgr


### PR DESCRIPTION
MCUBoot is the bootloader on which zephyr DFU solutions
base. It is worth to reference certain compatible version
of this external project. So fare it was expected that
mcuboot works with zephyr in master to master relation. This patch
starts to give the user real information about compatible version.

Fixes #20755

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>