### PR TITLE
dts: nxp: Remove clk-* properties from nxp,kinetis-sim nodes

### DIFF
--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -71,11 +71,6 @@
 			reg = <0x40047000 0x1060>;
 			label = "SIM";
 
-			clk-divider-core = <1>;
-			clk-divider-bus = <2>;
-			clk-divider-flexbus = <3>;
-			clk-divider-flash = <5>;
-
 			#clock-cells = <3>;
 		};
 

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -71,11 +71,6 @@
 			reg = <0x40047000 0x1060>;
 			label = "SIM";
 
-			clk-divider-core = <1>;
-			clk-divider-bus = <2>;
-			clk-divider-flexbus = <3>;
-			clk-divider-flash = <5>;
-
 			#clock-cells = <3>;
 		};
 

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -49,10 +49,6 @@
 			reg = <0x40047000 0x1060>;
 			label = "SIM";
 
-			clk-divider-core = <1>;
-			clk-divider-bus = <1>;
-			clk-divider-flash = <2>;
-
 			#clock-cells = <3>;
 		};
 


### PR DESCRIPTION
These are not declared in dts/bindings/arm/nxp,kinetis-sim.yaml and do
not generate any output.

Trying to get rid of properties that appear on device tree nodes but
aren't declared in bindings.