### PR TITLE
dts: posix: Fix 'current-speed' property typo

### DIFF
--- a/boards/posix/native_posix/native_posix.dts
+++ b/boards/posix/native_posix/native_posix.dts
@@ -69,9 +69,9 @@
 		status = "okay";
 		compatible = "zephyr,native-posix-uart";
 		label = "UART_0";
-		/* Dummy current_speed entry to comply with serial
+		/* Dummy current-speed entry to comply with serial
 		 * DTS binding
 		 */
-		current_speed = <0>;
+		current-speed = <0>;
 	};
 };


### PR DESCRIPTION
s/current_speed/current-speed/, just to match the binding. The value is
never used.