### PR TITLE
dts: arm: Remove leftover zephyr,irq-prio property from CC2650

### DIFF
--- a/dts/arm/ti/cc2650.dtsi
+++ b/dts/arm/ti/cc2650.dtsi
@@ -40,7 +40,6 @@
 			compatible = "ti,cc2650-gpio";
 			reg = <0x40022000 0xE4>;
 			interrupts = <0 0>;
-			zephyr,irq-prio = <0>;
 			status = "disabled";
 
 			gpio-controller;


### PR DESCRIPTION
Unused since commit 94107bc71d ("dts: arm: Put IRQ priority into the
interrupt property").