### PR TITLE
Improve Arduino interface for board nrf52_pca10040

### DIFF
--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -123,19 +123,19 @@ arduino_i2c: &i2c0 {
 	/* status = "okay"; */
 	sck-pin = <27>;
 	mosi-pin = <26>;
-	miso-pin = <25>;
+	miso-pin = <28>;
 };
 
-arduino_spi: &spi1 {
+&spi1 {
 	status = "okay";
 	sck-pin = <31>;
 	mosi-pin = <30>;
 	miso-pin = <29>;
 };
 
-&spi2 {
+arduino_spi: &spi2 {
 	status = "okay";
-	sck-pin = <22>;
+	sck-pin = <25>;
 	mosi-pin = <23>;
 	miso-pin = <24>;
 };

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -64,6 +64,33 @@
 		};
 	};
 
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
+			   <1 0 &gpio0 4 0>,	/* A1 */
+			   <2 0 &gpio0 28 0>,	/* A2 */
+			   <3 0 &gpio0 29 0>,	/* A3 */
+			   <4 0 &gpio0 30 0>,	/* A4 */
+			   <5 0 &gpio0 31 0>,	/* A5 */
+			   <6 0 &gpio0 11 0>,	/* D0 */
+			   <7 0 &gpio0 12 0>,	/* D1 */
+			   <8 0 &gpio0 13 0>,	/* D2 */
+			   <9 0 &gpio0 14 0>,	/* D3 */
+			   <10 0 &gpio0 15 0>,	/* D4 */
+			   <11 0 &gpio0 16 0>,	/* D5 */
+			   <12 0 &gpio0 17 0>,	/* D6 */
+			   <13 0 &gpio0 18 0>,	/* D7 */
+			   <14 0 &gpio0 19 0>,	/* D8 */
+			   <15 0 &gpio0 20 0>,	/* D9 */
+			   <16 0 &gpio0 22 0>,	/* D10 */
+			   <17 0 &gpio0 23 0>,	/* D11 */
+			   <18 0 &gpio0 24 0>,	/* D12 */
+			   <19 0 &gpio0 25 0>,	/* D13 */
+			   <20 0 &gpio0 26 0>,	/* D14 */
+			   <21 0 &gpio0 27 0>;	/* D15 */
+	};
+
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;


### PR DESCRIPTION
Fixes arduino_spi node and adds header definition adapted from nrf52840_pca10056 board.