### PR TITLE
boards: 96b_nitrogen: Remove 'csn-pin' property from SPI master

### DIFF
--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -83,7 +83,6 @@
 	sck-pin = <26>;
 	mosi-pin = <23>;
 	miso-pin = <25>;
-	csn-pin = <24>;
 };
 
 &flash0 {


### PR DESCRIPTION
This property is only declared in bindings/spi/nordic,nrf-spis.yaml ('s'
for 'slave'), not in bindings/spi/nordic,nrf-spi.yaml.