### PR TITLE
Bluetooth: Settings: Fix generated identity not persistently stored.

### DIFF
--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -217,6 +217,12 @@ static int commit(void)
 		}
 	}
 
+	/* Make sure that the identities created by bt_id_create after
+	 * bt_enable is saved to persistent storage. */
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_PRESET_ID)) {
+		bt_settings_save_id();
+	}
+
 	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
 		bt_finalize_init();
 	}


### PR DESCRIPTION
Fix an issue where the generated identity was not permanantly stored.
This resulted in being unable to reconnect after bonding when using
privacy, since a new local IRK was generated on reboot.

When settings is enabled the application is responsible for loading
identities and possible creating it's own identities.
When settings_load is called and no identities has been created or found
in persistent storage a new identity will be created.
Since bt init has not been finalized bt_id_create will not make a call
to bt_settings_save_id. So we need to make sure that this identity will
be stored.

Fixes: #17880