### PR TITLE
dts: nxp: Remove unused 'start-on-boot' properties

### DIFF
--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -339,7 +339,6 @@
 			interrupts = <22 0>;
 			clocks = <&sim KINETIS_SIM_LPO_CLK 0 0>;
 			label = "WDT_0";
-			reload-counter = <40000>;
 			start-on-boot;
 			prescaler = <2>;
 		};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -339,7 +339,6 @@
 			interrupts = <22 0>;
 			clocks = <&sim KINETIS_SIM_LPO_CLK 0 0>;
 			label = "WDT_0";
-			clock-source = <0>;	/* LPO 1kHz or other source */
 			reload-counter = <40000>;
 			start-on-boot;
 			prescaler = <2>;

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -339,7 +339,6 @@
 			interrupts = <22 0>;
 			clocks = <&sim KINETIS_SIM_LPO_CLK 0 0>;
 			label = "WDT_0";
-			start-on-boot;
 			prescaler = <2>;
 		};
 

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -274,7 +274,6 @@
 			interrupts = <22 0>;
 			clocks = <&sim KINETIS_SIM_LPO_CLK 0 0>;
 			label = "WDT_0";
-			clock-source = <0>;	/* LPO 1kHz or other source */
 			reload-counter = <40000>;
 			start-on-boot;
 			prescaler = <2>;

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -274,7 +274,6 @@
 			interrupts = <22 0>;
 			clocks = <&sim KINETIS_SIM_LPO_CLK 0 0>;
 			label = "WDT_0";
-			reload-counter = <40000>;
 			start-on-boot;
 			prescaler = <2>;
 		};

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -274,7 +274,6 @@
 			interrupts = <22 0>;
 			clocks = <&sim KINETIS_SIM_LPO_CLK 0 0>;
 			label = "WDT_0";
-			start-on-boot;
 			prescaler = <2>;
 		};
 

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -213,7 +213,6 @@
 			reg = <0x40038000 0x88>;
 			prescaler = <2>;
 			period = <1000>;
-			clock-source = <0>;
 			/* channel information needed - fixme */
 		};
 
@@ -222,7 +221,6 @@
 			reg = <0x40039000 0x88>;
 			prescaler = <2>;
 			period = <1000>;
-			clock-source = <0>;
 			/* channel information needed - fixme */
 		};
 
@@ -231,7 +229,6 @@
 			reg = <0x4003a000 0x88>;
 			prescaler = <2>;
 			period = <1000>;
-			clock-source = <0>;
 			/* channel information needed - fixme */
 		};
 

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -216,7 +216,6 @@
 			reg = <0x40038000 0x88>;
 			prescaler = <2>;
 			period = <1000>;
-			clock-source = <0>;
 			/* channel information needed - fixme */
 		};
 
@@ -225,7 +224,6 @@
 			reg = <0x40039000 0x88>;
 			prescaler = <2>;
 			period = <1000>;
-			clock-source = <0>;
 			/* channel information needed - fixme */
 		};
 
@@ -234,7 +232,6 @@
 			reg = <0x4003a000 0x88>;
 			prescaler = <2>;
 			period = <1000>;
-			clock-source = <0>;
 			/* channel information needed - fixme */
 		};
 


### PR DESCRIPTION
Trying to get rid of properties that appear on device tree nodes but
aren't declared in bindings.