### PR TITLE
scripts/dts: Sort output of DT_COMPAT_ defines

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -72,7 +72,7 @@ def main():
             active_compats.update(dev.compats)
 
     out_comment("Active compatibles (mentioned in DTS + binding found)")
-    for compat in active_compats:
+    for compat in sorted(active_compats):
         #define DT_COMPAT_<COMPAT> 1
         out("COMPAT_{}".format(str2ident(compat)), 1)
 


### PR DESCRIPTION
Sort the DT_COMPAT_ defines so comparing them from different builds is
easier.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>