### PR TITLE
libc/minimal: fix reproducibility of gmtime

### DIFF
--- a/lib/libc/minimal/source/time/gmtime.c
+++ b/lib/libc/minimal/source/time/gmtime.c
@@ -84,6 +84,8 @@ struct tm *gmtime_r(const time_t *_MLIBC_RESTRICT timep,
 	bigint_type days = (z >= 0 ? z : z - 86399) / 86400;
 	unsigned int rem = z - days * 86400;
 
+	*tp = (struct tm){ 0 };
+
 	time_civil_from_days(days, tp);
 
 	tp->tm_hour = rem / 60U / 60U;

--- a/tests/lib/timeutil/src/test_gmtime.c
+++ b/tests/lib/timeutil/src/test_gmtime.c
@@ -12,7 +12,10 @@
 
 void test_gmtime(void)
 {
-	struct tm tm;
+	struct tm tm = {
+		/* Initialize an unset field */
+		.tm_isdst = 1234,
+	};
 	time_t time = 1561994005;
 
 	zassert_equal(&tm, gmtime_r(&time, &tm),


### PR DESCRIPTION
struct tm has fields that were not being set by the implementation,
causing the test to fail when the uninitialized values were compared
with a static initialized result.  Zero the structure before filling it.

Closes #17794

Signed-off-by: Peter A. Bigot <pab@pabigot.com>