### PR TITLE
[Backport v1.14-branch] linker: move scripts generated code at the beginning of .text

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -188,6 +188,10 @@ SECTIONS
     SECTION_PROLOGUE(_TEXT_SECTION_NAME_2,,)
 	{
 	_image_text_start = .;
+
+#include <linker/priv_stacks-text.ld>
+#include <linker/kobject-text.ld>
+
 	*(.text)
 	*(".text.*")
 	*(.gnu.linkonce.t.*)
@@ -197,9 +201,6 @@ SECTIONS
 	 * after .gnu.linkonce.t.*
 	 */
 	*(.glue_7t) *(.glue_7) *(.vfp11_veneer) *(.v4_bx)
-
-#include <linker/priv_stacks-text.ld>
-#include <linker/kobject-text.ld>
 
 	} GROUP_LINK_IN(ROMABLE_REGION)
 

--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -56,7 +56,6 @@ MPU_RO_REGION_START = """
 
 MPU_RO_REGION_END = """
 
-    MPU_ALIGN(_{0}_mpu_ro_region_end - _{0}_mpu_ro_region_start);
     _{0}_mpu_ro_region_end = .;
 
 """
@@ -75,6 +74,20 @@ LINKER_SECTION_SEQ = """
         __{0}_{1}_end = .;
         __{0}_{1}_start = ADDR(_{2}_{3}_SECTION_NAME);
         __{0}_{1}_size = SIZEOF(_{2}_{3}_SECTION_NAME);
+"""
+
+LINKER_SECTION_SEQ_MPU = """
+
+/* Linker section for memory region {2} for {3} section  */
+
+	SECTION_PROLOGUE(_{2}_{3}_SECTION_NAME,,)
+        {{
+                __{0}_{1}_start = .;
+                {4}
+                MPU_ALIGN(__{0}_{1}_size);
+                __{0}_{1}_end = .;
+	}} {5}
+        __{0}_{1}_size = __{0}_{1}_end - __{0}_{1}_start;
 """
 
 SOURCE_CODE_INCLUDES = """
@@ -215,7 +228,12 @@ def string_create_helper(region, memory_type,
         if memory_type == 'SRAM' and (region == 'data' or region == 'bss'):
             linker_string += tmp
         else:
-            linker_string += LINKER_SECTION_SEQ.format(memory_type.lower(), region,
+            if memory_type != 'SRAM' and region == 'rodata':
+                linker_string += LINKER_SECTION_SEQ_MPU.format(memory_type.lower(),
+                                                        region, memory_type.upper(),
+                                            region.upper(), tmp, load_address_string)
+            else:
+                linker_string += LINKER_SECTION_SEQ.format(memory_type.lower(), region,
                                                    memory_type.upper(), region.upper(),
                                                    tmp, load_address_string)
 


### PR DESCRIPTION


    1) When code relocation enabled, there will be serval regions holding
    text. And then there will be function call between these .text
    regions, when distance between caller and callee is too far, linker
    will automatically generate and insert veneer functions. And these
    veneer functions will be located right after the last instruction
    in the .text region by the linker. So these code will be put in the
    memory reserved for priv_stacks text and kobject text if they don't
    consume all the reserved memory. Or the veneer functions will be put
    before the reserved memory if there isn't code in the reserved
    memory. And then in the user mode building process, there will be
    different memory layout and it will cause usr mode not working.
    And moving the memory reserved for priv_stacks text and kobject text
    at the beginning of .text will avoid above problem. The detailed
    analysis for this issue can be found on Github issue #17038.

    2) make mpu align inside sections instead of outside to avoid
    overlap for code relocation feature.

Fixes: #17038.