### PR TITLE
subsys: kernel_shell: extend thread info

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1339,6 +1339,16 @@ __syscall int k_thread_name_copy(k_tid_t thread_id, char *buf,
 				 size_t size);
 
 /**
+ * @brief Get thread state string
+ *
+ * Get the human friendly thread state string
+ *
+ * @param thread_id Thread ID
+ * @retval Thread state string, empty if no state flag is set
+ */
+const char *k_thread_state_str(k_tid_t thread_id);
+
+/**
  * @}
  */
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -248,6 +248,37 @@ int z_impl_k_thread_name_copy(k_tid_t thread_id, char *buf, size_t size)
 #endif /* CONFIG_THREAD_NAME */
 }
 
+const char *k_thread_state_str(k_tid_t thread_id)
+{
+	switch (thread_id->base.thread_state) {
+	case 0:
+		return "";
+		break;
+	case _THREAD_DUMMY:
+		return "dummy";
+		break;
+	case _THREAD_PENDING:
+		return "pending";
+		break;
+	case _THREAD_PRESTART:
+		return "restart";
+		break;
+	case _THREAD_DEAD:
+		return "dead";
+		break;
+	case _THREAD_SUSPENDED:
+		return "suspended";
+		break;
+	case _THREAD_ABORTING:
+		return "aborting";
+		break;
+	case _THREAD_QUEUED:
+		return "queued";
+		break;
+	}
+	return "unknown";
+}
+
 #ifdef CONFIG_USERSPACE
 Z_SYSCALL_HANDLER(k_thread_name_copy, thread_id, buf, size)
 {


### PR DESCRIPTION
1) Dump time sinse last scheduler call
Could be handy for tickless kernel debug.
Will indicate that no rtc irq is called

2) Dump current timeout of each thread
Could be used to find yout when thread will wake up

3) Dump human friendly thread state

Signed-off-by: Pavlo Hamov <pavlo_hamov@jabil.com>