### PR TITLE
Bluetooth: Keys: Fix logging assertions when enabling BT_DEBUG_KEYS.

### DIFF
--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -224,7 +224,7 @@ void bt_keys_clear(struct bt_keys *keys)
 					       &keys->addr, NULL);
 		}
 
-		BT_DBG("Deleting key %s", key);
+		BT_DBG("Deleting key %s", log_strdup(key));
 		settings_delete(key);
 	}
 
@@ -272,7 +272,8 @@ int bt_keys_store(struct bt_keys *keys)
 		return err;
 	}
 
-	BT_DBG("Stored keys for %s (%s)", bt_addr_le_str(&keys->addr), log_strdup(key));
+	BT_DBG("Stored keys for %s (%s)", bt_addr_le_str(&keys->addr),
+	       log_strdup(key));
 
 	return 0;
 }
@@ -299,7 +300,8 @@ static int keys_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 		return -EINVAL;
 	}
 
-	BT_DBG("name %s val %s", name, (len) ? val : "(null)");
+	BT_DBG("name %s val %s", log_strdup(name),
+	       (len) ? bt_hex(val, sizeof(val)) : "(null)");
 
 	err = bt_settings_decode_key(name, &addr);
 	if (err) {


### PR DESCRIPTION
Logging module requires strings to be duplicated using log_strdup.
Enabling CONFIG_BT_DEBUG_KEYS caused runtime assertions in the logging
module.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>