### PR TITLE
soc: nordic: Add HAS_HW_NRF_RADIO_IEEE802154 Kconfig option

### DIFF
--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -8,7 +8,7 @@
 
 menuconfig IEEE802154_NRF5
 	bool "nRF52 series IEEE 802.15.4 Driver"
-	depends on NETWORKING && SOC_NRF52840
+	depends on NETWORKING && HAS_HW_NRF_RADIO_IEEE802154
 	select HAS_NORDIC_DRIVERS
 
 if IEEE802154_NRF5

--- a/soc/arm/nordic_nrf/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/Kconfig.peripherals
@@ -104,6 +104,9 @@ config HAS_HW_NRF_QDEC
 config HAS_HW_NRF_QSPI
 	bool
 
+config HAS_HW_NRF_RADIO_IEEE802154
+	bool
+
 config HAS_HW_NRF_RNG
 	bool
 

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.soc
@@ -63,6 +63,7 @@ config SOC_NRF52811
 	select HAS_HW_NRF_PPI
 	select HAS_HW_NRF_PWM0
 	select HAS_HW_NRF_QDEC
+	select HAS_HW_NRF_RADIO_IEEE802154
 	select HAS_HW_NRF_RNG
 	select HAS_HW_NRF_RTC0
 	select HAS_HW_NRF_RTC1
@@ -187,6 +188,7 @@ config SOC_NRF52840
 	select HAS_HW_NRF_PWM3
 	select HAS_HW_NRF_QDEC
 	select HAS_HW_NRF_QSPI
+	select HAS_HW_NRF_RADIO_IEEE802154
 	select HAS_HW_NRF_RNG
 	select HAS_HW_NRF_RTC0
 	select HAS_HW_NRF_RTC1


### PR DESCRIPTION
Add a hidden Kconfig option indicating that a given SoC is equipped
with the IEEE 802.15.4 capable radio so that the corresponding driver
configuration can depend on it.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>