### PR TITLE
Bluetooth: Host: Move BT_DBG out of irq_lock

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -658,8 +658,8 @@ static void hci_num_completed_packets(struct net_buf *buf)
 
 		conn = bt_conn_lookup_handle(handle);
 		if (!conn) {
-			BT_ERR("No connection for handle %u", handle);
 			irq_unlock(key);
+			BT_ERR("No connection for handle %u", handle);
 			continue;
 		}
 


### PR DESCRIPTION
Don't have BT_DBG inside of irq_lock, this will create unnecessary IRQ
delays.
