### PR TITLE
Bluetooth: SMP: MITM security possible without IO when OOB data present

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -2338,9 +2338,12 @@ static bool sec_level_reachable(struct bt_conn *conn)
 	case BT_SECURITY_MEDIUM:
 		return true;
 	case BT_SECURITY_HIGH:
-		return get_io_capa() != BT_SMP_IO_NO_INPUT_OUTPUT;
+		return get_io_capa() != BT_SMP_IO_NO_INPUT_OUTPUT ||
+		       (bt_auth && bt_auth->oob_data_request && oobd_present);
 	case BT_SECURITY_FIPS:
-		return get_io_capa() != BT_SMP_IO_NO_INPUT_OUTPUT &&
+		return (get_io_capa() != BT_SMP_IO_NO_INPUT_OUTPUT ||
+			(bt_auth && bt_auth->oob_data_request &&
+			 oobd_present)) &&
 		       sc_supported;
 	default:
 		return false;


### PR DESCRIPTION
Allow Security level HIGH and FIPS to be initiated when we have received
OOB data for the remote device. The security property of MITM is allowed
if out of band authentication data is available.