### PR TITLE
[TOPIC: DTS] dts: edtlib: Support giving missing properties a default value

### DIFF
--- a/dts/bindings/binding-template.yaml
+++ b/dts/bindings/binding-template.yaml
@@ -57,6 +57,7 @@ sub-node:
 #   <property name>:
 #     category: <required | optional>
 #     type: <string | int | boolean | array | uint8-array | string-array | compound>
+#     default: <default>
 #     description: <description of the property>
 #
 # 'uint8-array' is our name for what the device tree specification calls
@@ -65,6 +66,15 @@ sub-node:
 #   foo = [89 AB CD];
 #
 # Each value is a byte in hex.
+#
+# The optional 'default:' setting gives a value that will be used if the
+# property is missing from the device tree node. If 'default: <default>' is
+# given for a property <prop> and <prop> is missing, then the output will be as
+# if '<prop> = <default>' had appeared (except YAML data types are used for the
+# default value). Note that it only makes sense to combine 'default:' with
+# 'category: optional'.
+#
+# See below for examples of 'default:'.
 properties:
     # An entry for 'compatible' must appear, as it's used to map nodes to
     # bindings
@@ -83,6 +93,31 @@ properties:
         type: string-array
         category: optional
         description: Keys for bar-device
+
+    int-with-default:
+        type: int
+        category: optional
+        default: 123
+
+    array-with-default:
+        type: array
+        category: optional
+        default: [1, 2, 3] # Same as 'array-with-default = <1 2 3>'
+
+    string-with-default:
+        type: string
+        category: optional
+        default: "foo"
+
+    string-array-with-default:
+        type: string-array
+        category: optional
+        default: ["foo", "bar"] # Same as 'string-array-with-default = "foo", "bar"'
+
+    uint8-array-with-default:
+        type: uint8-array
+        category: optional
+        default: [0x12, 0x34] # Same as 'uint8-array-with-default = [12 34]'
 
 # If the binding describes an interrupt controller, GPIO controller, pinmux
 # device, or any other device referenced via a phandle plus a specifier (some

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -1182,22 +1182,22 @@ def _check_binding(binding, binding_path):
                     "constraint", "enum"}
     ok_categories = {"required", "optional"}
 
-    for prop, keys in binding["properties"].items():
-        for key in keys:
+    for prop_name, settings in binding["properties"].items():
+        for key in settings:
             if key not in ok_prop_keys:
                 _err("unknown setting '{}' in 'properties: {}: ...' in {}, "
                      "expected one of {}".format(
-                         key, prop, binding_path, ", ".join(ok_prop_keys)))
+                         key, prop_name, binding_path, ", ".join(ok_prop_keys)))
 
-        if "category" in keys and keys["category"] not in ok_categories:
+        if "category" in settings and settings["category"] not in ok_categories:
             _err("unrecognized category '{}' for '{}' in 'properties:' in {}, "
                  "expected one of {}".format(
-                     keys["category"], prop, binding_path,
+                     settings["category"], prop_name, binding_path,
                      ", ".join(ok_categories)))
 
-        if "description" in keys and not isinstance(keys["description"], str):
+        if "description" in settings and not isinstance(settings["description"], str):
             _err("missing, malformed, or empty 'description' for '{}' in "
-                 "'properties:' in {}".format(prop, binding_path))
+                 "'properties:' in {}".format(prop_name, binding_path))
 
 
 def _translate(addr, node):

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -519,10 +519,10 @@ class Device:
         if not self._binding or "properties" not in self._binding:
             return
 
-        for name, options in self._binding["properties"].items():
-            self._init_prop(name, options)
+        for name, settings in self._binding["properties"].items():
+            self._init_prop(name, settings)
 
-    def _init_prop(self, name, options):
+    def _init_prop(self, name, settings):
         # _init_props() helper for initializing a single property
 
         if _special_prop(name):
@@ -532,12 +532,12 @@ class Device:
         # all entries in 'properties:' to have a 'type: ...'. It might make
         # sense to have gpios in 'properties:' for other reasons, e.g. to set
         # 'category: required'.
-        if options["type"] == "compound":
+        if settings["type"] == "compound":
             return
 
-        val = self._prop_val(name, options["type"],
-                             options.get("category") == "optional",
-                             options.get("default"))
+        val = self._prop_val(name, settings["type"],
+                             settings.get("category") == "optional",
+                             settings.get("default"))
         if val is None:
             # 'category: optional' property that wasn't there
             return
@@ -545,11 +545,11 @@ class Device:
         prop = Property()
         prop.dev = self
         prop.name = name
-        prop.description = options.get("description")
+        prop.description = settings.get("description")
         if prop.description:
             prop.description = prop.description.rstrip()
         prop.val = val
-        enum = options.get("enum")
+        enum = settings.get("enum")
         if enum is None:
             prop.enum_index = None
         else:

--- a/scripts/dts/test-bindings/defaults.yaml
+++ b/scripts/dts/test-bindings/defaults.yaml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+title: Property default value test
+description: Property default value test
+
+properties:
+    compatible:
+        constraint: "defaults"
+        type: string-array
+
+    int:
+        type: int
+        category: optional
+        default: 123
+
+    array:
+        type: array
+        category: optional
+        default: [1, 2, 3]
+
+    uint8-array:
+        type: uint8-array
+        category: optional
+        default: [0x89, 0xAB, 0xCD]
+
+    string:
+        type: string
+        category: optional
+        default: "hello"
+
+    string-array:
+        type: string-array
+        category: optional
+        default: ["hello", "there"]
+
+    default-not-used:
+        type: int
+        category: optional
+        default: 123

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -285,6 +285,16 @@
 	};
 
 	//
+	// For testing Device.props with 'default:' values in binding
+	//
+
+	defaults {
+		compatible = "defaults";
+		// Should override the 'default:' in the binding
+		default-not-used = <234>;
+	};
+
+	//
 	// Parent with 'sub-node:' in binding
 	//
 

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -115,6 +115,13 @@ def run():
     verify_streq(edt.get_dev("/props").props,
                  r"{'compatible': <Property, name: compatible, value: ['props']>, 'int': <Property, name: int, value: 1>, 'array': <Property, name: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, value: b'\x124'>, 'string': <Property, name: string, value: 'foo'>, 'string-array': <Property, name: string-array, value: ['foo', 'bar', 'baz']>}")
 
+    #
+    # Test property default values given in bindings
+    #
+
+    verify_streq(edt.get_dev("/defaults").props,
+                 r"{'compatible': <Property, name: compatible, value: ['defaults']>, 'int': <Property, name: int, value: 123>, 'array': <Property, name: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, value: b'\x89\xab\xcd'>, 'string': <Property, name: string, value: 'hello'>, 'string-array': <Property, name: string-array, value: ['hello', 'there']>, 'default-not-used': <Property, name: default-not-used, value: 234>}")
+
 
     print("all tests passed")
 


### PR DESCRIPTION
First commit implements `default:`, the rest first change some stuff to be able to sanity check bindings in a robust way, and then adds sanity checking for `default:`.

See the `binding-template.yaml` changes for documentation.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/17829.

```
dts: edtlib: Support giving missing properties a default value

For optional properties, it can be handy to generate a default value
instead of no value if the property is missing, to cut down on #ifdefs.

Allow a default value to be specified in the binding, via a new
'default: <default value>' key on properties in 'properties:'.

Suggested by Peter A. Bigot in
https://github.com/zephyrproject-rtos/zephyr/issues/17829.

The documentation changes in binding-template.yaml explain the syntax.

Fixes: #17829
```

```
dts: edtlib: Check the final merged binding instead of each file

It's currently impossible to check that 'type:' is consistent with
'default:' in a robust way, as they might come from different !included
files and be overridden.

Instead of checking each !included file, have _check_binding() check the
final merged binding. This should also make it possible to move some
other checks there.
```

```
dts: edtlib: Improve naming in _check_binding()
    
'keys' is really a dictionary of settings (like {"type": "int", ...})
for a property. Calling it 'settings' makes it clearer.
```

```
dts: edtlib: Check that 'default:' values are okay

'default:' values for properties in bindings need to match the 'type:'
setting.

The check is done in a new _check_prop_type_and_default() helper
function that's called from _check_binding(). The 'type:' value check is
moved there as well.

This relies on that we now only check the final merged binding. It
wouldn't be robust otherwise, since types and defaults might get added
in different files that then get merged.
```

```
dts: edtlib: Make _init_props() naming consistent with _check_binding()
    
_check_binding() calls the per-property settings dict 'settings'. Call
it that in _init_props() too, instead of 'options'.
```