### PR TITLE
Fix #17790 MEC1501 dts warnings in eSPI

### DIFF
--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -41,7 +41,6 @@
 
 &espi0 {
 	status = "okay";
-	reg = <0x400f3800 0x400>;
 	agg_io_irq = <11>;
 	agg_vw_irq = <15>;
 	agg_pc_irq = <7>;


### PR DESCRIPTION
Remove incorrect override in board dts for eSPI