### PR TITLE
Fix nested sched unlock

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -555,7 +555,7 @@ void k_sched_unlock(void)
 
 	LOCKED(&sched_spinlock) {
 		++_current->base.sched_locked;
-		update_cache(1);
+		update_cache(0);
 	}
 
 	K_DEBUG("scheduler unlocked (%p:%d)\n",

--- a/tests/kernel/sched/schedule_api/src/main.c
+++ b/tests/kernel/sched/schedule_api/src/main.c
@@ -65,6 +65,7 @@ void test_main(void)
 			 ztest_unit_test(test_time_slicing_disable_preemptible),
 			 ztest_unit_test(test_lock_preemptible),
 			 ztest_unit_test(test_unlock_preemptible),
+			 ztest_unit_test(test_unlock_nested_sched_lock),
 			 ztest_unit_test(test_sched_is_preempt_thread),
 			 ztest_unit_test(test_slice_reset),
 			 ztest_unit_test(test_slice_scheduling),

--- a/tests/kernel/sched/schedule_api/src/test_sched.h
+++ b/tests/kernel/sched/schedule_api/src/test_sched.h
@@ -37,6 +37,7 @@ void test_time_slicing_preemptible(void);
 void test_time_slicing_disable_preemptible(void);
 void test_lock_preemptible(void);
 void test_unlock_preemptible(void);
+void test_unlock_nested_sched_lock(void);
 void test_sched_is_preempt_thread(void);
 void test_slice_reset(void);
 void test_slice_scheduling(void);

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -366,6 +366,55 @@ void test_unlock_preemptible(void)
 }
 
 /**
+ * @brief Validate nested k_sched_lock() and k_sched_unlock()
+ *
+ * @details In a preemptive thread, lock the scheduler twice and
+ * create a cooperative thread.  Call k_sched_unlock() and check the
+ * cooperative thread haven't executed.  Unlock it again to see the
+ * thread have executed this time.
+ *
+ * @see k_sched_lock(), k_sched_unlock()
+ *
+ * @ingroup kernel_sched_tests
+ */
+void test_unlock_nested_sched_lock(void)
+{
+	/* set current thread to a preemptible priority */
+	init_prio = 0;
+	setup_threads();
+
+	/* take the scheduler lock twice */
+	k_sched_lock();
+	k_sched_lock();
+
+	/* spawn threads without wait */
+	spawn_threads(0);
+
+	/* do critical thing */
+	k_busy_wait(100000);
+
+	/* unlock once; this shouldn't let other threads to run */
+	k_sched_unlock();
+
+	/* checkpoint: no threads get executed */
+	for (int i = 0; i < THREADS_NUM; i++) {
+		zassert_true(tdata[i].executed == 0, NULL);
+	}
+
+	/* unlock another; this let the higher thread to run */
+	k_sched_unlock();
+
+	/* checkpoint: higher threads NOT get executed */
+	zassert_true(tdata[0].executed == 1, NULL);
+	for (int i = 1; i < THREADS_NUM; i++) {
+		zassert_true(tdata[i].executed == 0, NULL);
+	}
+
+	/* restore environment */
+	teardown_threads();
+}
+
+/**
  * @brief validate k_wakeup() in some corner scenario
  * @details trigger a timer and after expiration of timer
  * call k_wakeup(), even the thread is not in sleep state neither


### PR DESCRIPTION
This PR is to fix #17869.  It has two commits, one to fix the bug and the other to add a test.  I've converted my test program to align with the tests we have under tests/kernel/sched/schedule_api.

I haven't added any __deprecated tag yet.  If we deprecate the API, I'm sure we must fix the documentation as well.
https://docs.zephyrproject.org/latest/reference/kernel/scheduling/index.html#scheduler-locking