### PR TITLE
Bluetooth: Shell: Fix unregister GATT Metrics vendor service

### DIFF
--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -881,14 +881,8 @@ static int cmd_metrics(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	if (!strcmp(argv[1], "on")) {
-		static bool registered;
-
-		if (!registered) {
-			shell_print(shell, "Registering GATT metrics test "
-			      "Service.");
-			err = bt_gatt_service_register(&met_svc);
-			registered = true;
-		}
+		shell_print(shell, "Registering GATT metrics test Service.");
+		err = bt_gatt_service_register(&met_svc);
 	} else if (!strcmp(argv[1], "off")) {
 		shell_print(shell, "Unregistering GATT metrics test Service.");
 		err = bt_gatt_service_unregister(&met_svc);


### PR DESCRIPTION
The 'registered' flag was not cleared when 'gatt metrics off'
was called so that one was unable to register the service again.
Remove 'registered' variable that is actually not needed as there
is no tracking if service is already registered in similar
cmd_register_test_svc command. If the service is already registered,
the host will log an error.

Fixes: #17882
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>