### PR TITLE
drivers: fix printf formatting in flash drivers

### DIFF
--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -84,12 +84,12 @@ static int flash_gecko_erase(struct device *dev, off_t offset, size_t size)
 	}
 
 	if ((offset % FLASH_PAGE_SIZE) != 0) {
-		LOG_ERR("offset %x: not on a page boundary", offset);
+		LOG_ERR("offset 0x%lx: not on a page boundary", (long)offset);
 		return -EINVAL;
 	}
 
 	if ((size % FLASH_PAGE_SIZE) != 0) {
-		LOG_ERR("size %x: not multiple of a page size", size);
+		LOG_ERR("size %zu: not multiple of a page size", size);
 		return -EINVAL;
 	}
 

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -126,7 +126,7 @@ static int flash_sam_write_page(struct device *dev, off_t offset,
 	const u32_t *src = data;
 	u32_t *dst = (u32_t *)((u8_t *)CONFIG_FLASH_BASE_ADDRESS + offset);
 
-	LOG_DBG("offset = %lx, len = %zu", (long)offset, len);
+	LOG_DBG("offset = 0x%lx, len = %zu", (long)offset, len);
 
 	/* We need to copy the data using 32-bit accesses */
 	for (; len > 0; len -= sizeof(*src)) {
@@ -151,7 +151,7 @@ static int flash_sam_write(struct device *dev, off_t offset,
 	int rc;
 	const u8_t *data8 = data;
 
-	LOG_DBG("offset = %lx, len = %zu", (long)offset, len);
+	LOG_DBG("offset = 0x%lx, len = %zu", (long)offset, len);
 
 	/* Check that the offset is within the flash */
 	if (!flash_sam_valid_range(dev, offset, len)) {
@@ -207,7 +207,7 @@ done:
 static int flash_sam_read(struct device *dev, off_t offset, void *data,
 			  size_t len)
 {
-	LOG_DBG("offset = %lx, len = %zu", (long)offset, len);
+	LOG_DBG("offset = 0x%lx, len = %zu", (long)offset, len);
 
 	if (!flash_sam_valid_range(dev, offset, len)) {
 		return -EINVAL;
@@ -223,7 +223,7 @@ static int flash_sam_erase_block(struct device *dev, off_t offset)
 {
 	Efc *const efc = DEV_CFG(dev)->regs;
 
-	LOG_DBG("offset = %lx", (long)offset);
+	LOG_DBG("offset = 0x%lx", (long)offset);
 
 	efc->EEFC_FCR = EEFC_FCR_FKEY_PASSWD |
 			EEFC_FCR_FARG(flash_sam_get_page(offset) | 2) |
@@ -239,7 +239,7 @@ static int flash_sam_erase(struct device *dev, off_t offset, size_t len)
 	int rc = 0;
 	off_t i;
 
-	LOG_DBG("offset = %lx, len = %zu", (long)offset, len);
+	LOG_DBG("offset = 0x%lx, len = %zu", (long)offset, len);
 
 	if (!flash_sam_valid_range(dev, offset, len)) {
 		return -EINVAL;

--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -71,11 +71,11 @@ static inline void flash_sam0_sem_give(struct device *dev)
 static int flash_sam0_valid_range(off_t offset, size_t len)
 {
 	if (offset < 0) {
-		LOG_WRN("%x: before start of flash", offset);
+		LOG_WRN("0x%lx: before start of flash", (long)offset);
 		return -EINVAL;
 	}
 	if ((offset + len) > CONFIG_FLASH_SIZE * 1024) {
-		LOG_WRN("%x: ends past the end of flash", offset);
+		LOG_WRN("0x%lx: ends past the end of flash", (long)offset);
 		return -EINVAL;
 	}
 
@@ -99,13 +99,13 @@ static int flash_sam0_check_status(off_t offset)
 	NVMCTRL->STATUS = status;
 
 	if (status.bit.PROGE) {
-		LOG_ERR("programming error at 0x%x", offset);
+		LOG_ERR("programming error at 0x%lx", (long)offset);
 		return -EIO;
 	} else if (status.bit.LOCKE) {
-		LOG_ERR("lock error at 0x%x", offset);
+		LOG_ERR("lock error at 0x%lx", (long)offset);
 		return -EROFS;
 	} else if (status.bit.NVME) {
-		LOG_ERR("NVM error at 0x%x", offset);
+		LOG_ERR("NVM error at 0x%lx", (long)offset);
 		return -EIO;
 	}
 
@@ -136,7 +136,7 @@ static int flash_sam0_write_page(struct device *dev, off_t offset,
 	}
 
 	if (memcmp(data, FLASH_MEM(offset), FLASH_PAGE_SIZE) != 0) {
-		LOG_ERR("verify error at offset 0x%x", offset);
+		LOG_ERR("verify error at offset 0x%lx", (long)offset);
 		return -EIO;
 	}
 
@@ -191,7 +191,7 @@ static int flash_sam0_write(struct device *dev, off_t offset,
 	off_t addr;
 	int err;
 
-	LOG_DBG("%x: len %u", offset, len);
+	LOG_DBG("0x%lx: len %zu", (long)offset, len);
 
 	err = flash_sam0_valid_range(offset, len);
 	if (err != 0) {
@@ -234,12 +234,12 @@ static int flash_sam0_write(struct device *dev, off_t offset,
 	}
 
 	if ((offset % FLASH_PAGE_SIZE) != 0) {
-		LOG_WRN("%x: not on a write block boundrary", offset);
+		LOG_WRN("0x%lx: not on a write block boundrary", (long)offset);
 		return -EINVAL;
 	}
 
 	if ((len % FLASH_PAGE_SIZE) != 0) {
-		LOG_WRN("%x: not a integer number of write blocks", len);
+		LOG_WRN("%zu: not a integer number of write blocks", len);
 		return -EINVAL;
 	}
 
@@ -285,12 +285,12 @@ static int flash_sam0_erase(struct device *dev, off_t offset, size_t size)
 	}
 
 	if ((offset % ROW_SIZE) != 0) {
-		LOG_WRN("%x: not on a page boundrary", offset);
+		LOG_WRN("0x%lx: not on a page boundrary", (long)offset);
 		return -EINVAL;
 	}
 
 	if ((size % ROW_SIZE) != 0) {
-		LOG_WRN("%x: not a integer number of pages", size);
+		LOG_WRN("%zu: not a integer number of pages", size);
 		return -EINVAL;
 	}
 

--- a/drivers/flash/soc_flash_nios2_qspi.c
+++ b/drivers/flash/soc_flash_nios2_qspi.c
@@ -79,7 +79,7 @@ static int flash_nios2_qspi_erase(struct device *dev, off_t offset, size_t len)
 	if (((offset + len) > qspi_dev->data_end) ||
 			(0 != (erase_offset &
 			       (NIOS2_WRITE_BLOCK_SIZE - 1)))) {
-		LOG_ERR("erase failed at offset %ld", (long)offset);
+		LOG_ERR("erase failed at offset 0x%lx", (long)offset);
 		rc = -EINVAL;
 		goto qspi_erase_err;
 	}
@@ -138,7 +138,7 @@ static int flash_nios2_qspi_erase(struct device *dev, off_t offset, size_t len)
 
 		if ((flag_status & FLAG_STATUS_ERASE_ERROR) ||
 				(flag_status & FLAG_STATUS_PROTECTION_ERROR)) {
-			LOG_ERR("erase failed, Flag Status Reg:%x",
+			LOG_ERR("erase failed, Flag Status Reg:0x%x",
 								flag_status);
 			rc = -EIO;
 			goto qspi_erase_err;
@@ -237,7 +237,7 @@ static int flash_nios2_qspi_write_block(struct device *dev, int block_offset,
 
 		if ((flag_status & FLAG_STATUS_PROGRAM_ERROR) ||
 			(flag_status & FLAG_STATUS_PROTECTION_ERROR)) {
-			LOG_ERR("write failed, Flag Status Reg:%x",
+			LOG_ERR("write failed, Flag Status Reg:0x%x",
 								flag_status);
 			rc = -EIO; /* sector might be protected */
 			goto qspi_write_block_err;
@@ -272,7 +272,7 @@ static int flash_nios2_qspi_write(struct device *dev, off_t offset,
 	if ((data == NULL) || ((offset + len) > qspi_dev->data_end) ||
 			(0 != (write_offset &
 			       (NIOS2_WRITE_BLOCK_SIZE - 1)))) {
-		LOG_ERR("write failed at offset %ld", (long)offset);
+		LOG_ERR("write failed at offset 0x%lx", (long)offset);
 		rc = -EINVAL;
 		goto qspi_write_err;
 	}
@@ -337,7 +337,7 @@ static int flash_nios2_qspi_read(struct device *dev, off_t offset,
 	 */
 	if ((data == NULL) || ((offset + len) > qspi_dev->data_end) ||
 			(0 != (read_offset & (NIOS2_WRITE_BLOCK_SIZE - 1)))) {
-		LOG_ERR("read failed at offset %ld", (long)offset);
+		LOG_ERR("read failed at offset 0x%lx", (long)offset);
 		rc = -EINVAL;
 		goto qspi_read_err;
 	}

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -281,7 +281,8 @@ static int spi_nor_erase(struct device *dev, off_t addr, size_t size)
 		} else {
 			/* minimal erase size is at least a sector size */
 			SYNC_UNLOCK();
-			LOG_DBG("unsupported at %x size %u", (u32_t)addr, size);
+			LOG_DBG("unsupported at 0x%lx size %zu", (long)addr,
+				size);
 			return -EINVAL;
 		}
 


### PR DESCRIPTION
This commit fixes following issues in printf formatting used by flash drivers:
- cast values of type off_t to long to remove warnings generated when
  compiling with Newlib.
- use 'z' modifier (as in "%zu") to print values of type size_t
- prefix all hex numbers with '0x'
