### PR TITLE
Add  min (Z_MIN) and max (Z_MAX) macros with single evaluation of arguments

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -89,10 +89,20 @@ constexpr size_t ARRAY_SIZE(T(&)[N]) { return N; }
 #define INLINE
 #endif
 
+/** @brief Return larger value of two provided expressions.
+ *
+ * @note Arguments are evaluated twice. See Z_MAX for GCC only, single
+ * evaluation version.
+ */
 #ifndef MAX
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #endif
 
+/** @brief Return smaller value of two provided expressions.
+ *
+ * @note Arguments are evaluated twice. See Z_MIN for GCC only, single
+ * evaluation version.
+ */
 #ifndef MIN
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #endif

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -380,4 +380,32 @@ do {                                                                    \
 	__asm__ __volatile__ ("" ::: "memory"); \
 } while (false)
 
+/** @brief Return larger value of two provided expressions.
+ *
+ * Macro ensures that expressions are evaluated only once.
+ *
+ * @note Macro has limited usage compared to the standard macro as it cannot be
+ *	 used:
+ *	 - to generate constant integer, e.g. __aligned(Z_MAX(4,5))
+ *	 - static variable, e.g. array like static u8_t array[Z_MAX(...)];
+ */
+#define Z_MAX(a, b) ({ \
+		/* random suffix to avoid naming conflict */ \
+		__typeof__(a) _value_a_ = (a); \
+		__typeof__(b) _value_b_ = (b); \
+		_value_a_ > _value_b_ ? _value_a_ : _value_b_; \
+	})
+
+/** @brief Return smaller value of two provided expressions.
+ *
+ * Macro ensures that expressions are evaluated only once. See @ref Z_MAX for
+ * macro limitations.
+ */
+#define Z_MIN(a, b) ({ \
+		/* random suffix to avoid naming conflict */ \
+		__typeof__(a) _value_a_ = (a); \
+		__typeof__(b) _value_b_ = (b); \
+		_value_a_ < _value_b_ ? _value_a_ : _value_b_; \
+	})
+
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_GCC_H_ */

--- a/tests/misc/util/src/main.c
+++ b/tests/misc/util/src/main.c
@@ -76,13 +76,35 @@ void test_UTIL_LISTIFY(void)
 	zassert_equal(i, 0 + 1 + 2 + 3, NULL);
 }
 
+static int inc_func(void)
+{
+	static int a = 1;
+
+	return a++;
+}
+
+/* Test checks if @ref Z_MAX and @ref Z_MIN return correct result and perform
+ * single evaluation of input arguments.
+ */
+static void test_z_max_z_min(void)
+{
+	zassert_equal(Z_MAX(inc_func(), 0), 1, "Unexpected macro result");
+	/* Z_MAX should have call inc_func only once */
+	zassert_equal(inc_func(), 2, "Unexpected return value");
+
+	zassert_equal(Z_MIN(inc_func(), 2), 2, "Unexpected macro result");
+	/* Z_MIN should have call inc_func only once */
+	zassert_equal(inc_func(), 4, "Unexpected return value");
+}
+
 /*test case main entry*/
 void test_main(void)
 {
 	ztest_test_suite(test_util_api,
 			 ztest_unit_test(test_COND_CODE_1),
 			 ztest_unit_test(test_COND_CODE_0),
-			 ztest_unit_test(test_UTIL_LISTIFY)
+			 ztest_unit_test(test_UTIL_LISTIFY),
+			 ztest_unit_test(test_z_max_z_min)
 			 );
 	ztest_run_test_suite(test_util_api);
 }


### PR DESCRIPTION
As #17844 revealed usage of `MAX` and `MIN` macros results in bigger code and potential bug because arguments are evaluated twice. PR proposes alternative macros (`Z_MAX` and `Z_MIN`). Due to usage limitations they are not 100% replacements (thus new macros and not new implementation).

`Z_MAX` and `Z_MIN` cannot be used in cases like:
- constant integer generation (e.g. `__aligned(Z_MAX(4,5))`
- static variables (e.g. array for stack `static u8_t array[Z_MAX(...)];`)
