### PR TITLE
boards: nucleo_wb55rg: Add link to reference manual

### DIFF
--- a/boards/arm/nucleo_wb55rg/doc/nucleowb55rg.rst
+++ b/boards/arm/nucleo_wb55rg/doc/nucleowb55rg.rst
@@ -142,6 +142,7 @@ More information about STM32WB55RG can be found here:
 
 - `STM32WB55RG on www.st.com`_
 - `STM32WB5RG datasheet`_
+- `STM32WB5RG reference manual`_
 
 Supported Features
 ==================
@@ -278,3 +279,6 @@ You can debug an application in the usual way.  Here is an example for the
 
 .. _STM32WB5RG datasheet:
    https://www.st.com/resource/en/datasheet/stm32wb55rg.pdf
+
+.. _STM32WB5RG reference manual:
+   https://www.st.com/resource/en/reference_manual/dm00318631.pdf


### PR DESCRIPTION
This was missing from board documentation.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>