### PR TITLE
soc : arm : microchip_mec Fix MEC1501 SoC ECIA initialization

### DIFF
--- a/soc/arm/microchip_mec/mec1501/soc.c
+++ b/soc/arm/microchip_mec/mec1501/soc.c
@@ -112,7 +112,7 @@ static int soc_ecia_init(void)
 
 	/* Clear all GIRQn source enables and source status */
 	pg = &ECIA_REGS->GIRQ08;
-	for (n = 0u; n < MCHP_GIRQ_ZID_MAX; n++) {
+	for (n = MCHP_FIRST_GIRQ; n <= MCHP_LAST_GIRQ; n++) {
 		pg->EN_CLR = 0xFFFFFFFFul;
 		pg->SRC = 0xFFFFFFFFul;
 		pg++;


### PR DESCRIPTION
Changes to MEC1501 HAL for eSPI changed loop constant used by SoC
code initializing the ECIA registers. Fixed by using HAL constants
that are invariant.

Signed-off-by: Scott Worley <scott.worley@microchip.com>

Fixes #15985 