### PR TITLE
drivers: can: mcp2515: Fix interrupt bit tests for empty TX buffers

### DIFF
--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -461,11 +461,11 @@ static void mcp2515_handle_interrupts(struct device *dev)
 			mcp2515_tx_done(dev, 0);
 		}
 
-		if (canintf & MCP2515_CANINTF_TX0IF) {
+		if (canintf & MCP2515_CANINTF_TX1IF) {
 			mcp2515_tx_done(dev, 1);
 		}
 
-		if (canintf & MCP2515_CANINTF_TX0IF) {
+		if (canintf & MCP2515_CANINTF_TX2IF) {
 			mcp2515_tx_done(dev, 2);
 		}
 


### PR DESCRIPTION
TX1 and TX2 buffer empty busy flags would have been cleared only for
TX0 empty interrupts and there would have been extra unwarranted
TX callbacks for TX1 and TX2 if the callbacks had previously been used.

Signed-off-by: Nick Ward <nick.ward@setec.com.au>