### PR TITLE
Bluetooth: ATT: Fix deadlock when blocking syswq

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -150,7 +150,7 @@ static int att_send(struct bt_conn *conn, struct net_buf *buf,
 	return 0;
 }
 
-static void att_pdu_sent(struct bt_conn *conn, void *user_data)
+void att_pdu_sent(struct bt_conn *conn, void *user_data)
 {
 	struct bt_att *att = att_get(conn);
 	struct net_buf *buf;
@@ -175,7 +175,7 @@ static void att_pdu_sent(struct bt_conn *conn, void *user_data)
 	k_sem_give(&att->tx_sem);
 }
 
-static void att_cfm_sent(struct bt_conn *conn, void *user_data)
+void att_cfm_sent(struct bt_conn *conn, void *user_data)
 {
 	struct bt_att *att = att_get(conn);
 
@@ -188,7 +188,7 @@ static void att_cfm_sent(struct bt_conn *conn, void *user_data)
 	att_pdu_sent(conn, user_data);
 }
 
-static void att_rsp_sent(struct bt_conn *conn, void *user_data)
+void att_rsp_sent(struct bt_conn *conn, void *user_data)
 {
 	struct bt_att *att = att_get(conn);
 
@@ -201,7 +201,7 @@ static void att_rsp_sent(struct bt_conn *conn, void *user_data)
 	att_pdu_sent(conn, user_data);
 }
 
-static void att_req_sent(struct bt_conn *conn, void *user_data)
+void att_req_sent(struct bt_conn *conn, void *user_data)
 {
 	struct bt_att *att = att_get(conn);
 
@@ -2048,6 +2048,9 @@ struct net_buf *bt_att_create_pdu(struct bt_conn *conn, u8_t op, size_t len)
 	}
 
 	buf = bt_l2cap_create_pdu(NULL, 0);
+	if (!buf) {
+		return NULL;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	hdr->code = op;

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -236,6 +236,14 @@ struct bt_att_signed_write_cmd {
 	u8_t  value[0];
 } __packed;
 
+void att_pdu_sent(struct bt_conn *conn, void *user_data);
+
+void att_cfm_sent(struct bt_conn *conn, void *user_data);
+
+void att_rsp_sent(struct bt_conn *conn, void *user_data);
+
+void att_req_sent(struct bt_conn *conn, void *user_data);
+
 void bt_att_init(void);
 u16_t bt_att_get_mtu(struct bt_conn *conn);
 struct net_buf *bt_att_create_pdu(struct bt_conn *conn, u8_t op,

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2139,10 +2139,18 @@ struct net_buf *bt_conn_create_pdu(struct net_buf_pool *pool, size_t reserve)
 		pool = &acl_tx_pool;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_DEBUG_CONN)) {
+	if (IS_ENABLED(CONFIG_BT_DEBUG_CONN) ||
+	    k_current_get() == &k_sys_work_q.thread) {
 		buf = net_buf_alloc(pool, K_NO_WAIT);
 		if (!buf) {
 			BT_WARN("Unable to allocate buffer");
+			/* Cannot block with K_FOREVER on k_sys_work_q as that
+			 * can cause a deadlock when trying to dispatch TX
+			 * notification.
+			 */
+			if (k_current_get() == &k_sys_work_q.thread) {
+				return NULL;
+			}
 			buf = net_buf_alloc(pool, K_FOREVER);
 		}
 	} else {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1220,7 +1220,16 @@ static struct bt_conn_tx *add_pending_tx(struct bt_conn *conn,
 
 	BT_DBG("conn %p cb %p user_data %p", conn, cb, user_data);
 
-	tx = k_fifo_get(&free_tx, K_FOREVER);
+	if (IS_ENABLED(CONFIG_BT_DEBUG_CONN)) {
+		tx = k_fifo_get(&free_tx, K_NO_WAIT);
+		if (!tx) {
+			BT_WARN("Unable to get a free conn_tx, yielding...");
+			tx = k_fifo_get(&free_tx, K_FOREVER);
+		}
+	} else {
+		tx = k_fifo_get(&free_tx, K_FOREVER);
+	}
+
 	tx->conn = bt_conn_ref(conn);
 	k_work_init(&tx->work, tx_notify_cb);
 	tx->data.cb = cb;
@@ -2130,7 +2139,16 @@ struct net_buf *bt_conn_create_pdu(struct net_buf_pool *pool, size_t reserve)
 		pool = &acl_tx_pool;
 	}
 
-	buf = net_buf_alloc(pool, K_FOREVER);
+	if (IS_ENABLED(CONFIG_BT_DEBUG_CONN)) {
+		buf = net_buf_alloc(pool, K_NO_WAIT);
+		if (!buf) {
+			BT_WARN("Unable to allocate buffer");
+			buf = net_buf_alloc(pool, K_FOREVER);
+		}
+	} else {
+		buf = net_buf_alloc(pool, K_FOREVER);
+	}
+
 	__ASSERT_NO_MSG(buf);
 
 	reserve += sizeof(struct bt_hci_acl_hdr) + CONFIG_BT_HCI_RESERVE;

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1128,7 +1128,7 @@ segment:
 	return seg;
 }
 
-static void l2cap_chan_sdu_sent(struct bt_conn *conn, void *user_data)
+void l2cap_chan_sdu_sent(struct bt_conn *conn, void *user_data)
 {
 	struct bt_l2cap_chan *chan = user_data;
 

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -222,6 +222,8 @@ struct bt_l2cap_br_fixed_chan {
 				.accept = _accept,		\
 			}
 
+void l2cap_chan_sdu_sent(struct bt_conn *conn, void *user_data);
+
 /* Notify L2CAP channels of a new connection */
 void bt_l2cap_connected(struct bt_conn *conn);
 


### PR DESCRIPTION
With the change to TX notify callback running on syswq it is now possible to deadlock Bluetooth transmissions by blocking the syswq when using APIs such as bt_gatt_notify in a recursive fashion which would then exaust the buffer pool causing the syswq to block waiting more buffer to be available which prevents the callbacks to be run as they would use the syswq.

There are other alternatives like having a dedicated wq proposed here: https://github.com/zephyrproject-rtos/zephyr/pull/17867, though that may still deadlock as the TX notify callback can again start using blocking APIs causing the exact same problem, also it is recommended not to block on the syswq in the first place since it can affect other users of k_work.