### PR TITLE
dts: arm: nrf9160: minor typo fix

### DIFF
--- a/dts/arm/nordic/nrf9160.dtsi
+++ b/dts/arm/nordic/nrf9160.dtsi
@@ -72,7 +72,7 @@
 			#include "nrf9160_common.dtsi"
 		};
 
-		/* Addditional Secure peripherals */
+		/* Additional Secure peripherals */
 		gpiote: gpiote@5000d000 {
 			compatible = "nordic,nrf-gpiote";
 			reg = <0x5000d000 0x1000>;

--- a/dts/arm/nordic/nrf9160ns.dtsi
+++ b/dts/arm/nordic/nrf9160ns.dtsi
@@ -72,7 +72,7 @@
 			#include "nrf9160_common.dtsi"
 		};
 
-		/* Addditional Non-Secure peripherals */
+		/* Additional Non-Secure peripherals */
 		gpiote: gpiote@40031000 {
 			compatible = "nordic,nrf-gpiote";
 			reg = <0x40031000 0x1000>;


### PR DESCRIPTION
A minor spelling fix in an inline comment in
both nRF9160 Secure and Non-Secure .dtsi headers.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>