### PR TITLE
doc: add doc home link in left nav

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -107,6 +107,7 @@ licensing, as described in :ref:`Zephyr_Licensing`.
 .. toctree::
    :maxdepth: 1
 
+   Documentation Home <self>
    introduction/index.rst
    getting_started/index.rst
    contribute/index.rst


### PR DESCRIPTION
It's been annoying that there was no convenient way to get back to the
documentation home page.  There is a link in the breadcrumb trail at the
top of the page, but folks didn't notice that.  This PR adds a
"Documentation Home" link at the top of the left-nav menu.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>