### PR TITLE
Update transport.c

### DIFF
--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -402,7 +402,8 @@ static int send_seg(struct bt_mesh_net_tx *net_tx, struct net_buf_simple *sdu,
 				 * out through the Friend Queue.
 				 */
 				net_buf_unref(seg);
-				return 0;
+				//return 0;
+				continue;
 			}
 		}
 


### PR DESCRIPTION
**BLE Mesh When Friend Send Seg Message To LPN #17932**

***Disc:***
When a friend node needs to send large message, it is reasonable to send all the segment message of high transport layer message, but as shown in the code below, only the first packet is stored in the friend queue, and then the program terminates inexplicably, then the other Where did the data packet go?