### PR TITLE
Bluetooth: Mesh: Fix send segment to LPN

### DIFF
--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -402,7 +402,9 @@ static int send_seg(struct bt_mesh_net_tx *net_tx, struct net_buf_simple *sdu,
 				 * out through the Friend Queue.
 				 */
 				net_buf_unref(seg);
-				return 0;
+				
+				/*save the rest of the Seg message to Friend queue*/
+				continue;
 			}
 		}
 


### PR DESCRIPTION
When a friend node needs to send large message,
it is reasonable to send all the segment message of
high transport layer message,  only the first packet
is stored in the friend queue, and then the program
terminates inexplicably.

Fixes: #17932
Signed-off-by: Lingao Meng mengabc1086@gmail.com