### PR TITLE
samples: Counter alarm should display seconds, not ticks

### DIFF
--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -16,7 +16,8 @@
 struct counter_alarm_cfg alarm_cfg;
 
 static void test_counter_interrupt_fn(struct device *counter_dev,
-				u8_t chan_id, u32_t ticks, void *user_data)
+				      u8_t chan_id, u32_t ticks,
+				      void *user_data)
 {
 	u32_t now_ticks = counter_read(counter_dev);
 	u64_t now_usec = counter_ticks_to_us(counter_dev, now_ticks);
@@ -29,7 +30,10 @@ static void test_counter_interrupt_fn(struct device *counter_dev,
 	/* Set a new alarm with a double length duration */
 	config->ticks = config->ticks * 2U;
 
-	printk("Set alarm in %u sec\n", config->ticks);
+	printk("Set alarm in %u sec (%u ticks)\n",
+	       (u32_t)(counter_ticks_to_us(counter_dev,
+					   config->ticks) / USEC_PER_SEC),
+	       config->ticks);
 	counter_set_channel_alarm(counter_dev, ALARM_CHANNEL_ID, user_data);
 }
 
@@ -54,7 +58,10 @@ void main(void)
 
 	err = counter_set_channel_alarm(counter_dev, ALARM_CHANNEL_ID,
 					&alarm_cfg);
-	printk("Set alarm in %d sec\n", alarm_cfg.ticks);
+	printk("Set alarm in %u sec (%u ticks)\n",
+	       (u32_t)(counter_ticks_to_us(counter_dev,
+					   alarm_cfg.ticks) / USEC_PER_SEC),
+	       alarm_cfg.ticks);
 
 	if (-EINVAL == err) {
 		printk("Alarm settings invalid\n");


### PR DESCRIPTION
The message talks about seconds but displays ticks. Adjusting the
parameter to convert ticks to seconds then. But also adding the ticks
since it is a valuable information when testing counter devices.

Fixing small style issue (parameter indentation) as well.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>