### PR TITLE
Bluetooth: Host: Fix wrong init address when controller resolved address

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1953,6 +1953,7 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 				  const struct bt_le_conn_param *param)
 {
 	struct bt_conn *conn;
+	bt_addr_le_t dst;
 
 	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
 		return NULL;
@@ -1981,16 +1982,21 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 		}
 	}
 
-	conn = bt_conn_add_le(peer);
+	if (peer->type == BT_ADDR_LE_PUBLIC_ID ||
+	    peer->type == BT_ADDR_LE_RANDOM_ID) {
+		bt_addr_le_copy(&dst, peer);
+		dst.type -= BT_ADDR_LE_PUBLIC_ID;
+	} else {
+		bt_addr_le_copy(&dst, bt_lookup_id_addr(BT_ID_DEFAULT, peer));
+	}
+
+	conn = bt_conn_add_le(&dst);
 	if (!conn) {
 		return NULL;
 	}
 
 	/* Only default identity supported for now */
 	conn->id = BT_ID_DEFAULT;
-
-	/* Set initial address - will be updated later if necessary. */
-	bt_addr_le_copy(&conn->le.resp_addr, peer);
 
 	bt_conn_set_param_le(conn, param);
 

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -186,6 +186,7 @@ bool bt_le_conn_params_valid(const struct bt_le_conn_param *param);
 int bt_le_scan_update(bool fast_scan);
 
 bool bt_addr_le_is_bonded(u8_t id, const bt_addr_le_t *addr);
+const bt_addr_le_t *bt_lookup_id_addr(u8_t id, const bt_addr_le_t *addr);
 
 int bt_send(struct net_buf *buf);
 


### PR DESCRIPTION
The init addr should contain the on-air address used to establish the
connection. The dst address contains either the current RPA of the
unknown peer, or the identity address after identity information has
been exchanged.

Fixes: #17802
Fixes: #17979 