### PR TITLE
dts: Remove all 'device_type = "cpu"' properties

### DIFF
--- a/boards/arc/nsim/nsim_em.dtsi
+++ b/boards/arc/nsim/nsim_em.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "snps,arcem";
 			reg = <0>;
 		};

--- a/boards/arc/nsim/nsim_hs.dts
+++ b/boards/arc/nsim/nsim_hs.dts
@@ -17,7 +17,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "snps,archs";
 			reg = <0>;
 		};

--- a/boards/arm/mps2_an521/mps2_an521.dts
+++ b/boards/arm/mps2_an521/mps2_an521.dts
@@ -26,7 +26,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			#address-cells = <1>;

--- a/boards/arm/mps2_an521/mps2_an521_nonsecure.dts
+++ b/boards/arm/mps2_an521/mps2_an521_nonsecure.dts
@@ -26,7 +26,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			#address-cells = <1>;

--- a/boards/arm/v2m_musca/v2m_musca.dts
+++ b/boards/arm/v2m_musca/v2m_musca.dts
@@ -25,7 +25,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			#address-cells = <1>;

--- a/boards/arm/v2m_musca/v2m_musca_nonsecure.dts
+++ b/boards/arm/v2m_musca/v2m_musca_nonsecure.dts
@@ -25,7 +25,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			#address-cells = <1>;

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1.dts
@@ -25,7 +25,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			#address-cells = <1>;

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_nonsecure.dts
@@ -25,7 +25,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			#address-cells = <1>;

--- a/dts/arc/arc_iot.dtsi
+++ b/dts/arc/arc_iot.dtsi
@@ -15,7 +15,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "snps,arcem";
 			reg = <0>;
 		};

--- a/dts/arc/emsk.dtsi
+++ b/dts/arc/emsk.dtsi
@@ -16,7 +16,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "snps,arcem";
 			reg = <0>;
 		};

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -13,7 +13,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};

--- a/dts/arm/atmel/samd.dtsi
+++ b/dts/arm/atmel/samd.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -15,7 +15,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m7";
 			reg = <0>;
 			#address-cells = <1>;

--- a/dts/arm/cypress/psoc6.dtsi
+++ b/dts/arm/cypress/psoc6.dtsi
@@ -12,12 +12,10 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};
 		cpu@1 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <1>;
 		};

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};

--- a/dts/arm/microchip/mec1701qsz.dtsi
+++ b/dts/arm/microchip/mec1701qsz.dtsi
@@ -12,7 +12,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0";
 			reg = <0>;
 		};

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};

--- a/dts/arm/nordic/nrf9160.dtsi
+++ b/dts/arm/nordic/nrf9160.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33f";
 			reg = <0>;
 			#address-cells = <1>;

--- a/dts/arm/nordic/nrf9160ns.dtsi
+++ b/dts/arm/nordic/nrf9160ns.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33f";
 			reg = <0>;
 			#address-cells = <1>;

--- a/dts/arm/nxp/nxp_imx6sx_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx6sx_m4.dtsi
@@ -14,14 +14,12 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-a9";
 			reg = <0>;
 			status = "disabled";
 		};
 
 		cpu@1 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <1>;
 		};

--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -15,7 +15,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -40,7 +40,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -15,7 +15,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m7";
 			reg = <0>;
 			#address-cells = <1>;

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -16,7 +16,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0";
 			reg = <0>;
 		};

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -16,7 +16,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m3";
 			reg = <0>;
 		};

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -15,7 +15,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m3";
 			reg = <0>;
 		};

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -16,7 +16,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -16,7 +16,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -16,7 +16,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m7";
 			reg = <0>;
 			#address-cells = <1>;

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -16,7 +16,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m7";
 			reg = <0>;
 			#address-cells = <1>;
@@ -27,7 +26,6 @@
 			};
 		};
 		cpu@1 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <1>;
 		};

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -16,7 +16,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
 		};

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -16,7 +16,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m3";
 			reg = <0>;
 		};

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -17,7 +17,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -17,7 +17,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -15,7 +15,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 		};

--- a/dts/arm/ti/cc13x2_cc26x2.dtsi
+++ b/dts/arm/ti/cc13x2_cc26x2.dtsi
@@ -14,7 +14,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};

--- a/dts/arm/ti/cc2650.dtsi
+++ b/dts/arm/ti/cc2650.dtsi
@@ -12,7 +12,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m3";
 			reg = <0>;
 		};

--- a/dts/arm/ti/cc32xx.dtsi
+++ b/dts/arm/ti/cc32xx.dtsi
@@ -25,7 +25,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
 		};

--- a/dts/arm/ti/lm3s6965.dtsi
+++ b/dts/arm/ti/lm3s6965.dtsi
@@ -8,7 +8,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m3";
 			reg = <0>;
 		};

--- a/dts/nios2/nios2-qemu.dtsi
+++ b/dts/nios2/nios2-qemu.dtsi
@@ -8,7 +8,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "qemu,nios2";
 			reg = <0>;
 		};

--- a/dts/nios2/nios2f.dtsi
+++ b/dts/nios2/nios2f.dtsi
@@ -9,7 +9,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "altera,nios2f";
 			reg = <0>;
 		};

--- a/dts/riscv32/microsemi-miv.dtsi
+++ b/dts/riscv32/microsemi-miv.dtsi
@@ -14,7 +14,6 @@
 		cpu@0 {
 			clock-frequency = <0>;
 			compatible = "microsemi,miv", "riscv";
-			device_type = "cpu";
 			reg = <0>;
 			riscv,isa = "rv32imac";
 			hlic: interrupt-controller {

--- a/dts/riscv32/riscv32-fe310.dtsi
+++ b/dts/riscv32/riscv32-fe310.dtsi
@@ -13,7 +13,6 @@
 		cpu@0 {
 			clock-frequency = <0>;
 			compatible = "sifive,rocket0", "riscv";
-			device_type = "cpu";
 			i-cache-block-size = <64>;
 			i-cache-sets = <128>;
 			i-cache-size = <16384>;

--- a/dts/riscv32/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv32/riscv32-litex-vexriscv.dtsi
@@ -15,7 +15,6 @@
 		cpu@0 {
 			clock-frequency = <100000000>;
 			compatible = "spinalhdl,vexriscv", "riscv";
-			device_type = "cpu";
 			reg = <0>;
 			riscv,isa = "rv32imac";
 			status = "okay";

--- a/dts/riscv32/rv32m1.dtsi
+++ b/dts/riscv32/rv32m1.dtsi
@@ -38,13 +38,11 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "riscv";
 			reg = <0>;
 		};
 
 		cpu@1 {
-			device_type = "cpu";
 			compatible = "riscv";
 			reg = <1>;
 		};

--- a/dts/x86/apollo_lake.dtsi
+++ b/dts/x86/apollo_lake.dtsi
@@ -15,7 +15,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "apollo_lake";
 			reg = <0>;
 		};

--- a/dts/x86/atom.dtsi
+++ b/dts/x86/atom.dtsi
@@ -13,7 +13,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "atom";
 			reg = <0>;
 		};

--- a/dts/x86/ia32.dtsi
+++ b/dts/x86/ia32.dtsi
@@ -13,7 +13,6 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			device_type = "cpu";
 			compatible = "qemu32";
 			reg = <0>;
 		};

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -11,13 +11,11 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "cadence,tensilica-xtensa-lx6";
 			reg = <0>;
 		};
 
 		cpu1: cpu@1 {
-			device_type = "cpu";
 			compatible = "cadence,tensilica-xtensa-lx6";
 			reg = <1>;
 		};

--- a/dts/xtensa/intel/intel_s1000.dtsi
+++ b/dts/xtensa/intel/intel_s1000.dtsi
@@ -13,13 +13,11 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "cadence,tensilica-xtensa-lx6";
 			reg = <0>;
 		};
 
 		cpu1: cpu@1 {
-			device_type = "cpu";
 			compatible = "cadence,tensilica-xtensa-lx6";
 			reg = <1>;
 		};

--- a/dts/xtensa/sample_controller.dtsi
+++ b/dts/xtensa/sample_controller.dtsi
@@ -12,7 +12,6 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "sample_controller";
 			reg = <0>;
 		};


### PR DESCRIPTION
These are unused in Zephyr. The devicetree spec. does not require
'device_type' anywhere.

Maybe they were put in to copy Linux, under the assumption that it's
required there, but there are lots of CPU nodes in Linux that don't have
'device_type = "cpu"'. See these files for example (randomly picked from
'git grep cpu@'):

 - arch/openrisc/boot/dts/simple_smp.dts
 - arch/xtensa/boot/dts/xtfpga.dtsi
 - arch/xtensa/boot/dts/csp.dts

The cpus.yaml schema from the dt-schema project just says that CPU nodes
should have at least 'compatible', 'reg', or 'device_type' (i.e., one or
more of them).