### PR TITLE
drivers/flash/spi-nor: fix error in write and pessimization in read

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -229,6 +229,7 @@ static int spi_nor_write(struct device *dev, off_t addr, const void *src,
 
 		size -= to_write;
 		src = (const u8_t *)src + to_write;
+		addr += to_write;
 
 		spi_nor_wait_until_ready(dev);
 	}

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -158,7 +158,6 @@ static int spi_nor_read(struct device *dev, off_t addr, void *dest,
 	struct spi_nor_data *const driver_data = dev->driver_data;
 	const struct spi_nor_config *params = dev->config->config_info;
 	int ret;
-	int to_read;
 
 	/* should be between 0 and flash size */
 	if ((addr < 0) || ((addr + size) > params->size)) {
@@ -169,26 +168,10 @@ static int spi_nor_read(struct device *dev, off_t addr, void *dest,
 
 	spi_nor_wait_until_ready(dev);
 
-	while (size) {
-		to_read = size;
-		if (size > SPI_NOR_PAGE_SIZE) {
-			to_read = SPI_NOR_PAGE_SIZE;
-		}
-
-		ret = spi_nor_cmd_addr_read(dev, SPI_NOR_CMD_READ, addr,
-					    dest, to_read);
-		if (ret != 0) {
-			SYNC_UNLOCK();
-			return ret;
-		}
-
-		size -= to_read;
-		addr += to_read;
-		dest = (u8_t *)dest + to_read;
-	}
+	ret = spi_nor_cmd_addr_read(dev, SPI_NOR_CMD_READ, addr, dest, size);
 
 	SYNC_UNLOCK();
-	return 0;
+	return ret;
 }
 
 static int spi_nor_write(struct device *dev, off_t addr, const void *src,


### PR DESCRIPTION
## drivers/spi_nor: fix writes across page boundaries

The code failed to increment the address after completing a partial
write, causing writes that cross a page boundary overwrite at a page
level.

## drivers/spi_nor: de-pessimize reads

SPI NOR devices require that writes be performed within only one page at
a time.  There is no such limitation on reads.  Remove the code that
forced reads to be performed in 256-byte chunks.
