### PR TITLE
fs/nvs: fix the sector size check

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -701,7 +701,7 @@ int nvs_init(struct nvs_fs *fs, const char *dev_name)
 		LOG_ERR("Unable to get page info");
 		return -EINVAL;
 	}
-	if (fs->sector_size % info.size) {
+	if (!fs->sector_size || fs->sector_size % info.size) {
 		LOG_ERR("Invalid sector size");
 		return -EINVAL;
 	}


### PR DESCRIPTION
The sector size is 0 will pass "fs->sector_size % info.size" then start
a loop in nvs_startup() and never return. So retrun an error if the
sector size is 0.

Signed-off-by: Harry Jiang <explora26@gmail.com>