### PR TITLE
riscv: isr.S: fix a missing lw to LR conversion

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -253,7 +253,7 @@ call_irq:
 	LR a0, 0x00(t0)
 
 	/* Load ISR function address in register t1 */
-	lw t1, RV_REGSIZE(t0)
+	LR t1, RV_REGSIZE(t0)
 
 #ifdef CONFIG_EXECUTION_BENCHMARKING
 	addi sp, sp, -16


### PR DESCRIPTION
This loads a pointer and therefore has to use LR to be 64-bit
compatible.