### PR TITLE
LOG_BACKEND_DEFINE(): use Z_STRUCT_SECTION_ITERABLE()

### DIFF
--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -143,7 +143,7 @@
 	SECTION_DATA_PROLOGUE(log_backends_sections,,)
 	{
 		__log_backends_start = .;
-		KEEP(*(".log_backends"));
+		KEEP(*("._log_backend.*"));
 		__log_backends_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 

--- a/include/logging/log_backend.h
+++ b/include/logging/log_backend.h
@@ -78,8 +78,7 @@ extern const struct log_backend __log_backends_end[0];
 		.active = false,					       \
 		.id = 0,						       \
 	};								       \
-	static const struct log_backend _name				       \
-	__attribute__ ((section(".log_backends"))) __attribute__((used)) =     \
+	static const Z_STRUCT_SECTION_ITERABLE(log_backend, _name) =	       \
 	{								       \
 		.api = &_api,						       \
 		.cb = &UTIL_CAT(backend_cb_, _name),			       \


### PR DESCRIPTION
Replace the open coded section attribute by Z_STRUCT_SECTION_ITERABLE()
to properly align structure instances on 64-bit targets.