### PR TITLE
tests: net: context: Let the net_context cb to run first

### DIFF
--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -389,7 +389,9 @@ static void net_ctx_send_v6(void)
 	test_sending = true;
 
 	ret = net_context_send(udp_v6_ctx, test_data, strlen(test_data),
-			       send_cb, K_NO_WAIT, INT_TO_POINTER(AF_INET6));
+			       send_cb, K_FOREVER, INT_TO_POINTER(AF_INET6));
+	k_yield();
+
 	zassert_false(((ret < 0) || cb_failure),
 		     "Context send IPv6 UDP test failed");
 }
@@ -401,7 +403,9 @@ static void net_ctx_send_v4(void)
 	test_sending = true;
 
 	ret = net_context_send(udp_v4_ctx, test_data, strlen(test_data),
-			       send_cb, K_NO_WAIT, INT_TO_POINTER(AF_INET));
+			       send_cb, K_FOREVER, INT_TO_POINTER(AF_INET));
+	k_yield();
+
 	zassert_false(((ret < 0) || cb_failure),
 		      "Context send IPv4 UDP test failed");
 }


### PR DESCRIPTION
An issue was seen after changes introduced in #17933.
The net_context callback was run after we checked that it
was run ok. This test failed of course in that case. Simple
solution is to call k_yield() after sending the packet so
that the context send callback is able to run first.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>