### PR TITLE
Bluetooth: Host: Fix bluetooth address string length

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -641,7 +641,7 @@ int bt_br_oob_get_local(struct bt_br_oob *oob);
  *  conversion will not lose valuable information about address being
  *  processed.
  */
-#define BT_ADDR_LE_STR_LEN 27
+#define BT_ADDR_LE_STR_LEN 30
 
 /** @brief Converts binary Bluetooth address to string.
  *


### PR DESCRIPTION
The string "xx:xx:xx:xx:xx:xx (random-id)" is 30 characters including
zero termination.
