### PR TITLE
power: enhance device power management

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -9,6 +9,7 @@
 #define ZEPHYR_INCLUDE_DEVICE_H_
 
 #include <kernel.h>
+#include <power/power.h>
 
 /**
  * @brief Device Driver APIs
@@ -260,6 +261,9 @@ struct device_config {
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 	int (*device_pm_control)(struct device *device, u32_t command,
 				 void *context, device_pm_cb cb, void *arg);
+#ifdef CONFIG_DEVICE_PM_DISTRIBUTED_METHOD
+	int (*device_pm_notify)(struct device *device, enum power_states state);
+#endif
 	struct device_pm *pm;
 #endif
 	const void *config_info;

--- a/kernel/Kconfig.power_mgmt
+++ b/kernel/Kconfig.power_mgmt
@@ -62,3 +62,10 @@ config DEVICE_PM_CENTRAL_METHOD
 	default y
 	help
 	  This option enables the device power management central method.
+
+config DEVICE_PM_DISTRIBUTED_METHOD
+	bool "Device power management distributed method"
+	depends on DEVICE_POWER_MANAGEMENT
+	depends on !DEVICE_PM_CENTRAL_METHOD
+	help
+	  This option enables the device power management distributed method.

--- a/kernel/Kconfig.power_mgmt
+++ b/kernel/Kconfig.power_mgmt
@@ -55,3 +55,10 @@ config DEVICE_POWER_MANAGEMENT
 	  device drivers to do any necessary power management operations
 	  like turning off device clocks and peripherals. The device drivers
 	  may also save and restore states in these hook functions.
+
+config DEVICE_PM_CENTRAL_METHOD
+	bool "Device power management central method"
+	depends on DEVICE_POWER_MANAGEMENT
+	default y
+	help
+	  This option enables the device power management central method.

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -60,6 +60,11 @@ void sys_pm_suspend_devices(void)
 	sys_pm_set_devices_power_state(DEVICE_PM_SUSPEND_STATE);
 }
 
+void sys_pm_clock_gate_devices(void)
+{
+	sys_pm_set_devices_power_state(DEVICE_PM_LOW_POWER_STATE);
+}
+
 void sys_pm_resume_devices(void)
 {
 	sys_pm_set_devices_power_state(DEVICE_PM_ACTIVE_STATE);

--- a/subsys/power/policy/pm_policy.h
+++ b/subsys/power/policy/pm_policy.h
@@ -16,27 +16,27 @@ extern "C" {
 /**
  * @brief Function to create device PM list
  */
-extern  void sys_pm_create_device_list(void);
+void sys_pm_create_device_list(void);
 
 /**
  * @brief Function to suspend the devices in PM device list
  */
-extern int sys_pm_suspend_devices(void);
+int sys_pm_suspend_devices(void);
 
 /**
  * @brief Function to force suspend the devices in PM device list
  */
-extern int sys_pm_force_suspend_devices(void);
+int sys_pm_force_suspend_devices(void);
 
 /**
  * @brief Function to resume the devices in PM device list
  */
-extern void sys_pm_resume_devices(void);
+void sys_pm_resume_devices(void);
 
 /**
  * @brief Function to get the next PM state based on the ticks
  */
-extern enum power_states sys_pm_policy_next_state(s32_t ticks);
+enum power_states sys_pm_policy_next_state(s32_t ticks);
 
 #ifdef __cplusplus
 }

--- a/subsys/power/policy/pm_policy.h
+++ b/subsys/power/policy/pm_policy.h
@@ -25,9 +25,21 @@ void sys_pm_create_device_list(void);
 void sys_pm_suspend_devices(void);
 
 /**
+ * @brief Function to put the devices in PM device list in
+ *        low power state(clock gate device).
+ */
+void sys_pm_clock_gate_devices(void);
+
+/**
  * @brief Function to resume the devices in PM device list
  */
 void sys_pm_resume_devices(void);
+
+/**
+ * @brief Function to determine whether to put devices in low
+ *        power state(clock gate device), given the system PM state.
+ */
+bool sys_pm_policy_clock_gate_devices(enum power_states pm_state);
 #endif
 
 /**

--- a/subsys/power/policy/pm_policy.h
+++ b/subsys/power/policy/pm_policy.h
@@ -18,20 +18,17 @@ extern "C" {
  */
 void sys_pm_create_device_list(void);
 
+#if defined(CONFIG_DEVICE_PM_CENTRAL_METHOD)
 /**
  * @brief Function to suspend the devices in PM device list
  */
-int sys_pm_suspend_devices(void);
-
-/**
- * @brief Function to force suspend the devices in PM device list
- */
-int sys_pm_force_suspend_devices(void);
+void sys_pm_suspend_devices(void);
 
 /**
  * @brief Function to resume the devices in PM device list
  */
 void sys_pm_resume_devices(void);
+#endif
 
 /**
  * @brief Function to get the next PM state based on the ticks

--- a/subsys/power/policy/pm_policy.h
+++ b/subsys/power/policy/pm_policy.h
@@ -40,6 +40,30 @@ void sys_pm_resume_devices(void);
  *        power state(clock gate device), given the system PM state.
  */
 bool sys_pm_policy_clock_gate_devices(enum power_states pm_state);
+#elif defined(CONFIG_DEVICE_PM_DISTRIBUTED_METHOD)
+/**
+ * @brief Function to acquire system suspend lock. Any device
+ *        should acquire suspend lock before any transfer.
+ */
+void sys_pm_suspend_lock_acquire(void);
+
+/**
+ * @brief Function to release system suspend lock. Any device
+ *        should release suspend lock after done any transfer.
+ */
+void sys_pm_suspend_lock_release(void);
+
+/**
+ * @brief Function to determine whether to put whole system in
+ *        suspend state based on suspend lock.
+ */
+bool sys_pm_allow_suspend(void);
+
+/**
+ * @brief Function to notify system pm state to the devices in
+ *        PM device list if no any device hold suspend lock.
+ */
+void sys_pm_power_state_notify_devices(enum power_states state)
 #endif
 
 /**

--- a/subsys/power/policy/policy_dummy.c
+++ b/subsys/power/policy/policy_dummy.c
@@ -38,3 +38,10 @@ enum power_states sys_pm_policy_next_state(s32_t ticks)
 	LOG_DBG("No suitable power state found!");
 	return SYS_POWER_STATE_ACTIVE;
 }
+
+#ifdef CONFIG_DEVICE_PM_CENTRAL_METHOD
+bool sys_pm_policy_clock_gate_devices(enum power_states pm_state)
+{
+	return sys_pm_is_sleep_state(pm_state);
+}
+#endif

--- a/subsys/power/policy/policy_residency.c
+++ b/subsys/power/policy/policy_residency.c
@@ -72,3 +72,10 @@ enum power_states sys_pm_policy_next_state(s32_t ticks)
 	LOG_DBG("No suitable power state found!");
 	return SYS_POWER_STATE_ACTIVE;
 }
+
+#ifdef CONFIG_DEVICE_PM_CENTRAL_METHOD
+bool sys_pm_policy_clock_gate_devices(enum power_states pm_state)
+{
+	return sys_pm_is_sleep_state(pm_state);
+}
+#endif

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -110,6 +110,15 @@ enum power_states _sys_suspend(s32_t ticks)
 			sys_pm_clock_gate_devices();
 		}
 	}
+#elif defined(CONFIG_DEVICE_PM_DISTRIBUTED_METHOD)
+	if (sys_pm_allow_suspend()) {
+		sys_pm_power_state_notify_devices(pm_state);
+	} else {
+		LOG_ERR("some devices don't allow suspend!");
+		sys_pm_notify_power_state_exit(pm_state);
+		pm_state = SYS_POWER_STATE_ACTIVE;
+		return pm_state;
+	}
 #endif
 
 	if (deep_sleep) {
@@ -130,6 +139,8 @@ enum power_states _sys_suspend(s32_t ticks)
 		/* Turn on peripherals and restore device states as necessary */
 		sys_pm_resume_devices();
 	}
+#elif defined(CONFIG_DEVICE_PM_DISTRIBUTED_METHOD)
+	sys_pm_power_state_notify_devices(SYS_POWER_STATE_ACTIVE);
 #endif
 	sys_pm_log_debug_info(pm_state);
 

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -101,16 +101,13 @@ enum power_states _sys_suspend(s32_t ticks)
 	post_ops_done = 0;
 	sys_pm_notify_power_state_entry(pm_state);
 
+#if defined(CONFIG_DEVICE_PM_CENTRAL_METHOD)
 	if (deep_sleep) {
-#if CONFIG_DEVICE_POWER_MANAGEMENT
-		/* Suspend peripherals. */
-		if (sys_pm_suspend_devices()) {
-			LOG_ERR("System level device suspend failed!");
-			sys_pm_notify_power_state_exit(pm_state);
-			pm_state = SYS_POWER_STATE_ACTIVE;
-			return pm_state;
-		}
+		sys_pm_suspend_devices();
+	}
 #endif
+
+	if (deep_sleep) {
 		/*
 		 * Disable idle exit notification as it is not needed
 		 * in deep sleep mode.
@@ -123,7 +120,7 @@ enum power_states _sys_suspend(s32_t ticks)
 	sys_set_power_state(pm_state);
 	sys_pm_debug_stop_timer();
 
-#if CONFIG_DEVICE_POWER_MANAGEMENT
+#if defined(CONFIG_DEVICE_PM_CENTRAL_METHOD)
 	if (deep_sleep) {
 		/* Turn on peripherals and restore device states as necessary */
 		sys_pm_resume_devices();

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -104,6 +104,11 @@ enum power_states _sys_suspend(s32_t ticks)
 #if defined(CONFIG_DEVICE_PM_CENTRAL_METHOD)
 	if (deep_sleep) {
 		sys_pm_suspend_devices();
+	} else {
+		if (sys_pm_policy_clock_gate_devices(pm_state)) {
+			/* clock gate peripherals. */
+			sys_pm_clock_gate_devices();
+		}
 	}
 #endif
 
@@ -121,7 +126,7 @@ enum power_states _sys_suspend(s32_t ticks)
 	sys_pm_debug_stop_timer();
 
 #if defined(CONFIG_DEVICE_PM_CENTRAL_METHOD)
-	if (deep_sleep) {
+	if (deep_sleep || sys_pm_policy_clock_gate_devices(pm_state)) {
 		/* Turn on peripherals and restore device states as necessary */
 		sys_pm_resume_devices();
 	}


### PR DESCRIPTION
For distributed method of device power management, when system going to suspend state, not directly changing the state of device driver, just notify device driver system power management
state, device driver will make their own decisions based on system power management state and their own knowledge accordingly.
And for central method, when system go to sleep state (not deep sleep), make devices go to DEVICE_PM_LOW_POWER_STATE state which needs less time than DEVICE_PM_SUSPEND_STATE to save more power in the sleep state based on the policy which can be defined by the end user accordingly.

Fixes: #17838.

Signed-off-by: Wentong Wu <wentong.wu@intel.com>