### PR TITLE
doc: guides: tools: Fix URL to nRF Command-line tools

### DIFF
--- a/doc/guides/tools/nordic_segger.rst
+++ b/doc/guides/tools/nordic_segger.rst
@@ -229,7 +229,7 @@ References
 
 .. target-notes::
 
-.. _nRF5x Command-Line Tools: https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF5-Command-Line-Tools
+.. _nRF5x Command-Line Tools: https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Command-Line-Tools
 
 .. _Segger SAM3U Wiki: https://wiki.segger.com/index.php?title=J-Link-OB_SAM3U
 .. _Real-Time Tracing (RTT): https://www.segger.com/jlink-rtt.html


### PR DESCRIPTION
Fix the URL as it has changed on the Nordic website.

Fixes #18009.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>