### PR TITLE
arch: arc: fix the offset generation of accl_regs

### DIFF
--- a/arch/arc/core/offsets/offsets.c
+++ b/arch/arc/core/offsets/offsets.c
@@ -94,9 +94,11 @@ GEN_OFFSET_SYM(_callee_saved_stack_t, user_sp);
 #endif
 #endif
 GEN_OFFSET_SYM(_callee_saved_stack_t, r30);
-#ifdef CONFIG_FP_SHARING
+#ifdef CONFIG_ARC_HAS_ACCL_REGS
 GEN_OFFSET_SYM(_callee_saved_stack_t, r58);
 GEN_OFFSET_SYM(_callee_saved_stack_t, r59);
+#endif
+#ifdef CONFIG_FP_SHARING
 GEN_OFFSET_SYM(_callee_saved_stack_t, fpu_status);
 GEN_OFFSET_SYM(_callee_saved_stack_t, fpu_ctrl);
 #ifdef CONFIG_FP_FPU_DA


### PR DESCRIPTION
* the offset generation of accl_regs should
  rely on CONFIG_ARC_HAS_ACCL_REGS not CONFIG_FP_SHARING

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>

It's my bad, i forget it

Fixes #18011 