### PR TITLE
nrf52_bsim: Minor fix in time coversion

### DIFF
--- a/boards/posix/nrf52_bsim/time_machine.c
+++ b/boards/posix/nrf52_bsim/time_machine.c
@@ -195,11 +195,17 @@ bs_time_t tm_get_next_timer_abstime(void)
 
 bs_time_t tm_hw_time_to_abs_time(bs_time_t hwtime)
 {
+	if (hwtime == TIME_NEVER) {
+		return TIME_NEVER;
+	}
 	return hwtime + hw_time_delta;
 }
 
 bs_time_t tm_abs_time_to_hw_time(bs_time_t abstime)
 {
+	if (abstime == TIME_NEVER) {
+		return TIME_NEVER;
+	}
 	return abstime - hw_time_delta;
 }
 


### PR DESCRIPTION
(This could not be triggered in the nrf52_bsim yet, so just so it is fixed for the future)
Properly handle converting back and forth from absolute to HW
time when either of those is set to TIME_NEVER

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>