### PR TITLE
scripts: dts: Consistently open text files with utf-8.

### DIFF
--- a/scripts/dts/devicetree.py
+++ b/scripts/dts/devicetree.py
@@ -208,7 +208,7 @@ def parse_file(fd, ignore_dts_version=False):
 
         if line.startswith('/include/ '):
             _, filename = line.split()
-            with open(filename.strip()[1:-1], "r") as new_fd:
+            with open(filename.strip()[1:-1], encoding="utf-8") as new_fd:
                 nodes.update(parse_file(new_fd, True))
         elif line == '/dts-v1/;':
             has_v1_tag = True
@@ -300,7 +300,7 @@ def main(args):
     else:
         formatter = lambda nodes: pprint.pprint(nodes, indent=2)
 
-    with open(args[1], "r") as fd:
+    with open(args[1], encoding="utf-8") as fd:
         formatter(parse_file(fd))
 
     return 0

--- a/scripts/dts/dtlib.py
+++ b/scripts/dts/dtlib.py
@@ -886,7 +886,7 @@ class DT:
         except UnicodeDecodeError:
             self._parse_error("filename is not valid UTF-8")
 
-        with self._open(filename, "r") as f:
+        with self._open(filename, encoding="utf-8") as f:
             try:
                 self._file_contents = f.read()
             except OSError as e:
@@ -1156,9 +1156,10 @@ class DT:
 
         return _unescape_re.sub(sub, b)
 
-    def _open(self, filename, mode):
-        # Opens 'filename' in mode 'mode', returning the 'file' object.
-        # Searches the directory of the current file and the include path.
+    def _open(self, filename, mode="r", **kwargs):
+        # Wrapper around standard Python open(), accepting the same params.
+        # But searches for a 'filename' file in the directory of the current
+        # file and the include path.
 
         # The C tools support specifying stdin with '-' too
         if filename == "-":
@@ -1167,7 +1168,7 @@ class DT:
         # Try the directory of the current file first
         dirname = os.path.dirname(self.filename)
         try:
-            return open(os.path.join(dirname, filename), mode)
+            return open(os.path.join(dirname, filename), mode, **kwargs)
         except OSError as e:
             if e.errno != errno.ENOENT:
                 self._parse_error(e)
@@ -1175,7 +1176,7 @@ class DT:
             # Try each directory from the include path
             for path in self._include_path:
                 try:
-                    return open(os.path.join(path, filename), mode)
+                    return open(os.path.join(path, filename), mode, **kwargs)
                 except OSError as e:
                     if e.errno != errno.ENOENT:
                         self._parse_error(e)

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -1029,7 +1029,7 @@ def _binding_compat(binding_path):
     # Uses a regex to avoid having to parse the bindings, which is slow when
     # done for all bindings.
 
-    with open(binding_path) as binding:
+    with open(binding_path, encoding="utf-8") as binding:
         for line in binding:
             match = re.match(r'\s+constraint:\s*"([^"]*)"', line)
             if match:


### PR DESCRIPTION
Zephyr codebase standardizes in UTF-8 as file encoding. To
accommodate this, we explicitly pass encoding="utf-8" to Python's
open() function, to be independent of any locale setting of a
particular system (e.g., CI/build systems oftentimes have "C",
i.e. ASCII-only, locale). In a few places, we lacked this parameter,
so add it consistently.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>