### PR TITLE
doc: Update Slack invitation link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Here's a quick summary of resources to help you find your way around:
   tracked separately at https://zephyrprojectsec.atlassian.net.
 * **Zephyr Project Website**: https://zephyrproject.org
 
-.. _Slack Invite: https://tinyurl.com/yarkuemx
+.. _Slack Invite: https://tinyurl.com/y5glwylp
 .. _supported boards: http://docs.zephyrproject.org/latest/boards
 .. _Zephyr Documentation: http://docs.zephyrproject.org
 .. _Introduction to Zephyr: http://docs.zephyrproject.org/latest/introduction/index.html

--- a/doc/guides/getting-help.rst
+++ b/doc/guides/getting-help.rst
@@ -42,6 +42,6 @@ search the archives.
 When copy/pasting more than 5 lines of text into Slack, create a `snippet`_.
 
 .. _Search archives and sign up here: https://lists.zephyrproject.org/g/users
-.. _Slack invite: https://tinyurl.com/yarkuemx
+.. _Slack invite: https://tinyurl.com/y5glwylp
 .. _GitHub issues: https://github.com/zephyrproject-rtos/zephyr/issues
 .. _snippet: https://get.slack.help/hc/en-us/articles/204145658-Create-a-snippet


### PR DESCRIPTION
The old link seems not to work anymore, so instead replace it with an
invitation link freshly generated.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>