### PR TITLE
net: sockets: Do not call NULL socket callback function

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 	do { \
 		const struct socket_op_vtable *vtable; \
 		void *ctx = get_sock_vtable(sock, &vtable); \
-		if (ctx == NULL) { \
+		if (ctx == NULL || vtable->fn == NULL) { \
 			return -1; \
 		} \
 		return vtable->fn(ctx, __VA_ARGS__); \


### PR DESCRIPTION
Before calling socket callback function, make sure the callback
function exists so that we do not get NULL pointer reference.

Fixes #18021

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>