### PR TITLE
net: Move include files outside of extern "C" block

### DIFF
--- a/drivers/wifi/simplelink/simplelink_log.h
+++ b/drivers/wifi/simplelink/simplelink_log.h
@@ -7,17 +7,9 @@
 #ifndef ZEPHYR_DRIVERS_WIFI_SIMPLELINK_SIMPLELINK_LOG_H_
 #define ZEPHYR_DRIVERS_WIFI_SIMPLELINK_SIMPLELINK_LOG_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #define LOG_MODULE_NAME wifi_simplelink
 #define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
 
 #include <logging/log.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* ZEPHYR_DRIVERS_WIFI_SIMPLELINK_SIMPLELINK_LOG_H_ */

--- a/drivers/wifi/simplelink/simplelink_support.h
+++ b/drivers/wifi/simplelink/simplelink_support.h
@@ -8,11 +8,11 @@
 #ifndef ZEPHYR_DRIVERS_WIFI_SIMPLELINK_SIMPLELINK_SUPPORT_H_
 #define ZEPHYR_DRIVERS_WIFI_SIMPLELINK_SIMPLELINK_SUPPORT_H_
 
+#include <net/wifi_mgmt.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <net/wifi_mgmt.h>
 
 #define SSID_LEN_MAX	 (32)
 #define BSSID_LEN_MAX	 (6)

--- a/include/net/dhcpv4.h
+++ b/include/net/dhcpv4.h
@@ -11,6 +11,9 @@
 #ifndef ZEPHYR_INCLUDE_NET_DHCPV4_H_
 #define ZEPHYR_INCLUDE_NET_DHCPV4_H_
 
+#include <sys/slist.h>
+#include <zephyr/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -21,9 +24,6 @@ extern "C" {
  * @ingroup networking
  * @{
  */
-
-#include <sys/slist.h>
-#include <zephyr/types.h>
 
 /** @cond INTERNAL_HIDDEN */
 

--- a/include/net/http_parser.h
+++ b/include/net/http_parser.h
@@ -20,9 +20,6 @@
  */
 #ifndef ZEPHYR_INCLUDE_NET_HTTP_PARSER_H_
 #define ZEPHYR_INCLUDE_NET_HTTP_PARSER_H_
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /* Also update SONAME in the Makefile whenever you change these. */
 #define HTTP_PARSER_VERSION_MAJOR 2
@@ -48,6 +45,10 @@ typedef unsigned __int64 u64_t;
 #endif
 #include <net/http_parser_state.h>
 #include <net/http_parser_url.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Maximium header size allowed. If the macro is not defined
  * before including this header then the default is used. To

--- a/include/net/http_parser_url.h
+++ b/include/net/http_parser_url.h
@@ -20,14 +20,15 @@
  */
 #ifndef ZEPHYR_INCLUDE_NET_HTTP_PARSER_URL_H_
 #define ZEPHYR_INCLUDE_NET_HTTP_PARSER_URL_H_
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <sys/types.h>
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <net/http_parser_state.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 enum http_parser_url_fields {
 	  UF_SCHEMA           = 0

--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -13,11 +13,11 @@
 #ifndef ZEPHYR_INCLUDE_NET_NET_CORE_H_
 #define ZEPHYR_INCLUDE_NET_NET_CORE_H_
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdbool.h>
 
 /**
  * @brief Networking

--- a/include/net/net_event.h
+++ b/include/net/net_event.h
@@ -12,11 +12,11 @@
 #ifndef ZEPHYR_INCLUDE_NET_NET_EVENT_H_
 #define ZEPHYR_INCLUDE_NET_NET_EVENT_H_
 
+#include <net/net_ip.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <net/net_ip.h>
 
 /**
  * @addtogroup net_mgmt

--- a/include/net/net_mgmt.h
+++ b/include/net/net_mgmt.h
@@ -12,6 +12,9 @@
 #ifndef ZEPHYR_INCLUDE_NET_NET_MGMT_H_
 #define ZEPHYR_INCLUDE_NET_NET_MGMT_H_
 
+#include <sys/__assert.h>
+#include <net/net_core.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -22,9 +25,6 @@ extern "C" {
  * @ingroup networking
  * @{
  */
-
-#include <sys/__assert.h>
-#include <net/net_core.h>
 
 struct net_if;
 

--- a/include/net/socket_can.h
+++ b/include/net/socket_can.h
@@ -13,14 +13,14 @@
 #ifndef ZEPHYR_INCLUDE_NET_SOCKET_CAN_H_
 #define ZEPHYR_INCLUDE_NET_SOCKET_CAN_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <zephyr/types.h>
 #include <net/net_ip.h>
 #include <net/net_if.h>
 #include <drivers/can.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Socket CAN library

--- a/include/net/socket_net_mgmt.h
+++ b/include/net/socket_net_mgmt.h
@@ -13,14 +13,14 @@
 #ifndef ZEPHYR_INCLUDE_NET_SOCKET_NET_MGMT_H_
 #define ZEPHYR_INCLUDE_NET_SOCKET_NET_MGMT_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <zephyr/types.h>
 #include <net/net_ip.h>
 #include <net/net_if.h>
 #include <net/net_mgmt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Socket NET_MGMT library

--- a/include/net/socket_offload.h
+++ b/include/net/socket_offload.h
@@ -12,11 +12,11 @@
 #ifndef ZEPHYR_INCLUDE_NET_SOCKET_OFFLOAD_H_
 #define ZEPHYR_INCLUDE_NET_SOCKET_OFFLOAD_H_
 
+#include <net/socket_offload_ops.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <net/socket_offload_ops.h>
 
 extern const struct socket_offload *socket_ops;
 

--- a/include/net/socket_offload_ops.h
+++ b/include/net/socket_offload_ops.h
@@ -12,20 +12,20 @@
 #ifndef ZEPHYR_INCLUDE_NET_SOCKET_OFFLOAD_OPS_H_
 #define ZEPHYR_INCLUDE_NET_SOCKET_OFFLOAD_OPS_H_
 
+#include <sys/types.h>
+#include <net/net_ip.h>
+#include <net/socket.h>  /* needed for struct pollfd */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Socket Offload Redirect API
  * @defgroup socket_offload Socket offloading interface
  * @ingroup networking
  * @{
  */
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include <sys/types.h>
-#include <net/net_ip.h>
-#include <net/socket.h>  /* needed for struct pollfd */
 
 /**
  * @brief An offloaded Socket API interface
@@ -68,12 +68,12 @@ struct socket_offload {
  */
 extern void socket_offload_register(const struct socket_offload *ops);
 
-#ifdef __cplusplus
-}
-#endif
-
 /**
  * @}
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_NET_SOCKET_OFFLOAD_OPS_H_ */

--- a/subsys/net/l2/ethernet/arp.h
+++ b/subsys/net/l2/ethernet/arp.h
@@ -7,14 +7,14 @@
 #ifndef __ARP_H
 #define __ARP_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if defined(CONFIG_NET_ARP)
 
 #include <sys/slist.h>
 #include <net/ethernet.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Address resolution (ARP) library
@@ -71,6 +71,10 @@ void net_arp_init(void);
  * @}
  */
 
+#ifdef __cplusplus
+}
+#endif
+
 #else /* CONFIG_NET_ARP */
 #define net_arp_prepare(_kt, _u1, _u2) _kt
 #define net_arp_input(...) NET_OK
@@ -78,9 +82,5 @@ void net_arp_init(void);
 #define net_arp_init(...)
 
 #endif /* CONFIG_NET_ARP */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* __ARP_H */

--- a/subsys/net/l2/ethernet/gptp/gptp_data_set.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_data_set.h
@@ -14,14 +14,14 @@
 #ifndef __GPTP_DS_H
 #define __GPTP_DS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if defined(CONFIG_NET_GPTP)
 
 #include <net/gptp.h>
 #include "gptp_state.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Parameters for PTP data sets. */
 #define GPTP_ALLOWED_LOST_RESP 3
@@ -592,10 +592,10 @@ int gptp_get_port_data(struct gptp_domain *domain, int port,
 		       struct gptp_port_bmca_data **port_bmca_data,
 		       struct net_if **iface);
 
-#endif /* CONFIG_NET_GPTP */
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* CONFIG_NET_GPTP */
 
 #endif /* __GPTP_DS_H */

--- a/subsys/net/l2/ethernet/gptp/gptp_md.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.h
@@ -14,11 +14,11 @@
 #ifndef __GPTP_MD_H
 #define __GPTP_MD_H
 
+#include <net/gptp.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <net/gptp.h>
 
 /**
  * @brief Media Dependent Sync Information.

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.h
@@ -14,13 +14,13 @@
 #ifndef __GPTP_MESSAGES_H
 #define __GPTP_MESSAGES_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <net/net_pkt.h>
 #include <net/ethernet.h>
 #include <net/gptp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Helpers to access gPTP messages. */
 #define GPTP_HDR(pkt) gptp_get_hdr(pkt)

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.h
@@ -14,11 +14,11 @@
 #ifndef __GPTP_MI_H
 #define __GPTP_MI_H
 
+#include "gptp_md.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "gptp_md.h"
 
 /**
  * @brief Media Independent Sync Information.

--- a/subsys/net/l2/ethernet/gptp/gptp_private.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_private.h
@@ -14,11 +14,11 @@
 #ifndef __GPTP_PRIVATE_H
 #define __GPTP_PRIVATE_H
 
+#include <net/gptp.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <net/gptp.h>
 
 /* Common defines for the gPTP stack. */
 #define GPTP_THREAD_WAIT_TIMEOUT_MS 1

--- a/subsys/net/l2/ethernet/gptp/gptp_state.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_state.h
@@ -13,11 +13,11 @@
 #ifndef __GPTP_STATE_H
 #define __GPTP_STATE_H
 
+#include "gptp_mi.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "gptp_mi.h"
 
 /* PDelayRequest states. */
 enum gptp_pdelay_req_states {


### PR DESCRIPTION
This is related to findings in #17997 and changes network
related header files to have include files outside of
extern "C" { } block.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>