### PR TITLE
Settings: Initialize settings_lock mutex

### DIFF
--- a/subsys/settings/src/settings.c
+++ b/subsys/settings/src/settings.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(settings, CONFIG_SETTINGS_LOG_LEVEL);
 sys_slist_t settings_handlers;
 #endif /* CONFIG_SETTINGS_DYNAMIC_HANDLERS */
 
-struct k_mutex settings_lock;
+K_MUTEX_DEFINE(settings_lock);
 
 
 void settings_store_init(void);


### PR DESCRIPTION
The settings_lock mutex was never initialized