### PR TITLE
arc: snps_nsim: Fix -mfpu compiler flag for NSIM_HS build

### DIFF
--- a/soc/arc/snps_nsim/CMakeLists.txt
+++ b/soc/arc/snps_nsim/CMakeLists.txt
@@ -2,7 +2,11 @@
 zephyr_compile_options(-mcpu=${GCC_M_CPU} -mno-sdata)
 zephyr_compile_options_ifdef(CONFIG_CPU_ARCEM -mmpy-option=wlh1)
 zephyr_compile_options_ifdef(CONFIG_CPU_ARCHS -mmpy-option=plus_qmacw)
+if(CONFIG_CPU_ARCHS)
+zephyr_compile_options_ifdef(CONFIG_FLOAT -mfpu=fpud_all)
+else()
 zephyr_compile_options_ifdef(CONFIG_FLOAT -mfpu=fpuda_all)
+endif()
 
 zephyr_sources(
   soc.c


### PR DESCRIPTION
The NSIM_HS target should have had the fpu flag to the compiler be:
-mfpu=fpud_all.  Otherwise we get a build error.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>