### PR TITLE
dts: bindings: st,stts751-i2c.yaml: (FIX) Remove unused 'version' field

### DIFF
--- a/dts/bindings/sensor/st,stts751-i2c.yaml
+++ b/dts/bindings/sensor/st,stts751-i2c.yaml
@@ -5,7 +5,6 @@
 #
 
 title: STMicroelectronics MEMS sensors STTS751
-version: 0.1
 
 description: >
     This binding gives a base representation of STTS751


### PR DESCRIPTION
This dts binding file remained out from 0ec0c84808 commit, because
it was still in the pre-merging status.

Signed-off-by: Armando Visconti <armando.visconti@st.com>