### PR TITLE
driver/sensor/lsm6dso: Fix deprecated macros CS_GPIO_* to CS_GPIOS_*

### DIFF
--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -758,9 +758,9 @@ static const struct lsm6dso_config lsm6dso_config = {
 			       SPI_MODE_CPHA | SPI_WORD_SET(8) |
 			       SPI_LINES_SINGLE),
 	.spi_conf.slave     = DT_INST_0_ST_LSM6DSO_BASE_ADDRESS,
-#if defined(DT_INST_0_ST_LSM6DSO_CS_GPIO_CONTROLLER)
-	.gpio_cs_port	    = DT_INST_0_ST_LSM6DSO_CS_GPIO_CONTROLLER,
-	.cs_gpio	    = DT_INST_0_ST_LSM6DSO_CS_GPIO_PIN,
+#if defined(DT_INST_0_ST_LSM6DSO_CS_GPIOS_CONTROLLER)
+	.gpio_cs_port	    = DT_INST_0_ST_LSM6DSO_CS_GPIOS_CONTROLLER,
+	.cs_gpio	    = DT_INST_0_ST_LSM6DSO_CS_GPIOS_PIN,
 
 	.spi_conf.cs        =  &lsm6dso_data.cs_ctrl,
 #else

--- a/drivers/sensor/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/lsm6dso/lsm6dso.h
@@ -93,10 +93,10 @@ struct lsm6dso_config {
 	u16_t i2c_slv_addr;
 #elif DT_ST_LSM6DSO_BUS_SPI
 	struct spi_config spi_conf;
-#if defined(DT_INST_0_ST_LSM6DSO_CS_GPIO_CONTROLLER)
+#if defined(DT_INST_0_ST_LSM6DSO_CS_GPIOS_CONTROLLER)
 	const char *gpio_cs_port;
 	u8_t cs_gpio;
-#endif /* DT_INST_0_ST_LSM6DSO_CS_GPIO_CONTROLLER */
+#endif /* DT_INST_0_ST_LSM6DSO_CS_GPIOS_CONTROLLER */
 #endif /* DT_ST_LSM6DSO_BUS_I2C */
 };
 
@@ -176,7 +176,7 @@ struct lsm6dso_data {
 #endif
 #endif /* CONFIG_LSM6DSO_TRIGGER */
 
-#if defined(DT_INST_0_ST_LSM6DSO_CS_GPIO_CONTROLLER)
+#if defined(DT_INST_0_ST_LSM6DSO_CS_GPIOS_CONTROLLER)
 	struct spi_cs_control cs_ctrl;
 #endif
 };

--- a/drivers/sensor/lsm6dso/lsm6dso_spi.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_spi.c
@@ -105,7 +105,7 @@ int lsm6dso_spi_init(struct device *dev)
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = dev;
 
-#if defined(DT_INST_0_ST_LSM6DSO_CS_GPIO_CONTROLLER)
+#if defined(DT_INST_0_ST_LSM6DSO_CS_GPIOS_CONTROLLER)
 	const struct lsm6dso_config *cfg = dev->config->config_info;
 
 	/* handle SPI CS thru GPIO if it is the case */


### PR DESCRIPTION
The lsm6dso driver was in pre-merging state when a614a026
was committed. So, let's make the modification manually.

Signed-off-by: Armando Visconti <armando.visconti@st.com>