### PR TITLE
[#18034] Update the error message when not in west dir

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -130,7 +130,8 @@ def main():
         out, err = p.communicate()
         if p.returncode == 0:
             projects = out.decode(sys.getdefaultencoding()).splitlines()
-        elif re.match(r'Error: .* is not in a west installation\..*',
+        elif re.match((r'Error: .* is not in a west installation\.'
+                        '|FATAL ERROR: no west installation found from .*'),
                       err.decode(sys.getdefaultencoding())):
             # Only accept the error from bootstrapper in the event we are
             # outside a west managed project.


### PR DESCRIPTION
Zephyr verifies if it is built from a west-initialized directory.
The message changed in west@c08061cef1c7b0e19a58a82db731098e2f4bba4a.

Closes #18034.

Signed-off-by: Piotr Zierhoffer <pzierhoffer@antmicro.com>