### PR TITLE
[DNM] [RFC] usb: interface: set interface may require deleting endpoints

### DIFF
--- a/ext/hal/nordic/nrfx/drivers/src/nrfx_usbd.c
+++ b/ext/hal/nordic/nrfx/drivers/src/nrfx_usbd.c
@@ -2039,6 +2039,9 @@ void nrfx_usbd_ep_enable(nrfx_usbd_ep_t ep)
         m_ep_dma_waiting &= ~(1U << ep2bit(ep));
         NRFX_CRITICAL_SECTION_EXIT();
     }
+
+    usbd_ep_state_t * p_state = ep_state_access(ep);
+    p_state->status = NRFX_USBD_EP_OK;
 }
 
 void nrfx_usbd_ep_disable(nrfx_usbd_ep_t ep)


### PR DESCRIPTION
**Headline:** To implement USB Audio class, I need the possibility to switch interfaces which includes removing/adding endpoints on the fly.

I am not familiar with the community's development plans hence this request for comments.

What USB Audio does is it creates one configuration with two interfaces: one with iso stream when sound is actively sent, and another one without any endpoint when there is silence for a while. This is not supported by Zephyr by now.

I have implemented a chunk of code which:
1. removes endpoints of the current interface prior to switching to the new one. 
2. allowes enabling previously disabled endpoints without reconfiguration (ep state machine does not allow this transition). 

Please comment why this transition is not allowed and how you would recommend changing of the interfaces. Thank you. :) 