### PR TITLE
usb: device: limit interface bits in setup message to 8

### DIFF
--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -1398,7 +1398,7 @@ static int class_handler(struct usb_setup_packet *pSetup,
 
 		if ((iface->class_handler) &&
 		    (if_descr->bInterfaceNumber ==
-		     sys_le16_to_cpu(pSetup->wIndex))) {
+		     (sys_le16_to_cpu(pSetup->wIndex) & 0xFF))) {
 			return iface->class_handler(pSetup, len, data);
 		}
 	}


### PR DESCRIPTION
In setup messages addressing classes, USB standard defines that wIndex
constains interface number encoded in bits 0..7. Bits 8..15
are reserved and normally set to 0. However, in Audio Class they contain
entity number. Hence the need to filter 8 bits for getting interface
number.

