### PR TITLE
dts: stm32l4r5: (FIX) Provide clock info for spi3 controller

### DIFF
--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -126,6 +126,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
 			status = "disabled";
 			label = "SPI_3";


### PR DESCRIPTION
SPI3 clock info were missing and following macros were
not generated:

 - DT_ST_STM32_SPI_FIFO_40003C00_CLOCK_BITS
 - DT_ST_STM32_SPI_FIFO_40003C00_CLOCK_BUS

Signed-off-by: Armando Visconti <armando.visconti@st.com>