### PR TITLE
fix endless crash loops in some tests

### DIFF
--- a/include/fatal.h
+++ b/include/fatal.h
@@ -32,6 +32,16 @@ enum k_fatal_error_reason {
 };
 
 /**
+ * @brief Halt the system on a fatal error
+ *
+ * Invokes architecture-specific code to power off or halt the system in
+ * a low power state. Lacking that, lock interupts and sit in an idle loop.
+ *
+ * @param reason Fatal exception reason code
+ */
+FUNC_NORETURN void k_fatal_halt(unsigned int reason);
+
+/**
  * @brief Fatal error policy handler
  *
  * This function is not invoked by application code, but is declared as a

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -95,6 +95,11 @@ void z_fatal_print(const char *fmt, ...)
 }
 #endif /* CONFIG_LOG || CONFIG_PRINTK */
 
+FUNC_NORETURN void k_fatal_halt(unsigned int reason)
+{
+	z_arch_system_halt(reason);
+}
+
 void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 {
 	struct k_thread *thread = k_current_get();

--- a/tests/arch/x86/static_idt/src/main.c
+++ b/tests/arch/x86/static_idt/src/main.c
@@ -50,8 +50,14 @@ static volatile int spur_handler_aborted_thread = 1;
 
 void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
 {
-	zassert_equal(reason, K_ERR_SPURIOUS_IRQ, "wrong error reason");
-	zassert_equal(k_current_get(), &my_thread, "wrong thread crashed");
+	if (reason != K_ERR_SPURIOUS_IRQ) {
+		printk("wrong error reason\n");
+		k_fatal_halt(reason);
+	}
+	if (k_current_get() != &my_thread) {
+		printk("wrong thread crashed\n");
+		k_fatal_halt(reason);
+	}
 }
 
 /**

--- a/tests/kernel/mem_protect/mem_protect/src/common.c
+++ b/tests/kernel/mem_protect/mem_protect/src/common.c
@@ -26,10 +26,6 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		valid_fault = false; /* reset back to normal */
 		ztest_test_pass();
 	} else {
-		ztest_test_fail();
+		k_fatal_halt(reason);
 	}
-
-#if !(defined(CONFIG_ARM) || defined(CONFIG_ARC))
-	CODE_UNREACHABLE;
-#endif
 }

--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -17,21 +17,10 @@
 
 #define INFO(fmt, ...) printk(fmt, ##__VA_ARGS__)
 
-/* ARM is a special case, in that k_thread_abort() does indeed return
- * instead of calling z_swap() directly. The PendSV exception is queued
- * and immediately fires upon completing the exception path; the faulting
- * thread is never run again.
- */
-#if !(defined(CONFIG_ARM) || defined(CONFIG_ARC))
-FUNC_NORETURN
-#endif
 void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 {
 	INFO("Caught system error -- reason %d\n", reason);
 	ztest_test_pass();
-#if !(defined(CONFIG_ARM) || defined(CONFIG_ARC))
-	CODE_UNREACHABLE;
-#endif
 }
 
 #ifdef CONFIG_CPU_CORTEX_M

--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -17,7 +17,10 @@ ZTEST_BMEM static int ret = TC_PASS;
 
 void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
 {
-	zassert_equal(reason, K_ERR_STACK_CHK_FAIL, "wrong error type");
+	if (reason != K_ERR_STACK_CHK_FAIL) {
+		printk("wrong error type\n");
+		k_fatal_halt(reason);
+	}
 }
 
 void check_input(const char *name, const char *input);

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -66,37 +66,27 @@ K_APP_BMEM(part0) static volatile unsigned int expected_reason;
  */
 #define BARRIER() k_sem_give(&expect_fault_sem)
 
-/* ARM is a special case, in that k_thread_abort() does indeed return
- * instead of calling z_swap() directly. The PendSV exception is queued
- * and immediately fires upon completing the exception path; the faulting
- * thread is never run again.
- */
-#if !(defined(CONFIG_ARM) || defined(CONFIG_ARC))
-FUNC_NORETURN
-#endif
 void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 {
 	INFO("Caught system error -- reason %d\n", reason);
-	/*
-	 * If there is a user thread waiting for notification to exit,
-	 * give it that notification.
-	 */
-	if (give_uthread_end_sem) {
-		give_uthread_end_sem = false;
-		k_sem_give(&uthread_end_sem);
-	}
 
 	if (expect_fault && expected_reason == reason) {
+		/*
+		 * If there is a user thread waiting for notification to exit,
+		 * give it that notification.
+		 */
+		if (give_uthread_end_sem) {
+			give_uthread_end_sem = false;
+			k_sem_give(&uthread_end_sem);
+		}
 		expect_fault = false;
 		expected_reason = 0;
 		BARRIER();
 		ztest_test_pass();
 	} else {
-		zassert_unreachable("Unexpected fault during test");
+		printk("Unexpected fault during test");
+		k_fatal_halt(reason);
 	}
-#if !(defined(CONFIG_ARM) || defined(CONFIG_ARC))
-	CODE_UNREACHABLE;
-#endif
 }
 
 /**

--- a/tests/kernel/pipe/pipe/src/test_pipe.c
+++ b/tests/kernel/pipe/pipe/src/test_pipe.c
@@ -682,12 +682,8 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		valid_fault = false; /* reset back to normal */
 		ztest_test_pass();
 	} else {
-		ztest_test_fail();
+		k_fatal_halt(reason);
 	}
-#if !(defined(CONFIG_ARM) || defined(CONFIG_ARC))
-	CODE_UNREACHABLE;
-#endif
-
 }
 /******************************************************************************/
 /* Test case entry points */

--- a/tests/kernel/threads/dynamic_thread/src/main.c
+++ b/tests/kernel/threads/dynamic_thread/src/main.c
@@ -17,8 +17,14 @@ static ZTEST_BMEM struct k_thread *dyn_thread;
 
 void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
 {
-	zassert_equal(reason, K_ERR_KERNEL_OOPS, "wrong error reason");
-	zassert_equal(k_current_get(), dyn_thread, "wrong thread crashed");
+	if (reason != K_ERR_KERNEL_OOPS) {
+		printk("wrong error reason\n");
+		k_fatal_halt(reason);
+	}
+	if (k_current_get() != dyn_thread) {
+		printk("wrong thread crashed\n");
+		k_fatal_halt(reason);
+	}
 }
 
 static void dyn_thread_entry(void *p1, void *p2, void *p3)


### PR DESCRIPTION
Custom k_sys_fatal_error_handler() in tests that validate which faults were expected, now hang the system if the fault wasn't expected.

Fixes issues where the system could enter a loop of crashing over and over, overflowing CI logs.