### PR TITLE
lib/libc/min: Handle duplicate time definitions

### DIFF
--- a/lib/libc/minimal/include/sys/types.h
+++ b/lib/libc/minimal/include/sys/types.h
@@ -42,8 +42,15 @@ typedef int off_t;
 
 #endif
 
+#if !defined(__time_t_defined)
+#define __time_t_defined
 typedef int64_t time_t;
+#endif
+
+#if !defined(__suseconds_t_defined)
+#define __suseconds_t_defined
 typedef int32_t suseconds_t;
+#endif
 
 #if !defined(__mem_word_t_defined)
 #define __mem_word_t_defined

--- a/lib/libc/minimal/include/time.h
+++ b/lib/libc/minimal/include/time.h
@@ -31,8 +31,15 @@ struct tm {
 	int tm_isdst;
 };
 
+#if !defined(__time_t_defined)
+#define __time_t_defined
 typedef int64_t time_t;
+#endif
+
+#if !defined(__suseconds_t_defined)
+#define __suseconds_t_defined
 typedef int32_t suseconds_t;
+#endif
 
 #include <sys/_timespec.h>
 


### PR DESCRIPTION
time_t and suseconds_t are defined in time.h and sys/types.h.  Handle
the duplication by adding ifdef protection around them similar to what
is being done for other types.    

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>