### PR TITLE
tests: fatal: make sure the illegal insn occupies a full word

### DIFF
--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -63,7 +63,7 @@ void alt_thread1(void)
 	 * and xtensa
 	 */
 	{
-		int illegal = 0;
+		long illegal = 0;
 		((void(*)(void))&illegal)();
 	}
 #endif


### PR DESCRIPTION
... and is properly aligned. This may make a difference on
64-bit targets.