### PR TITLE
disk: kconfig: Remove redundant DISK_ACCESS_SDHC dependency

### DIFF
--- a/subsys/disk/Kconfig
+++ b/subsys/disk/Kconfig
@@ -135,7 +135,6 @@ endif # DISK_ACCESS_USDHC
 config DISK_SDHC_VOLUME_NAME
 	string "SDHC Disk mount point or drive name"
 	default "SDHC"
-	depends on DISK_ACCESS_SDHC
 	help
 	  Disk name as per file system naming guidelines.
 


### PR DESCRIPTION
DISK_SDHC_VOLUME_NAME is already defined within an 'if DISK_ACCESS_SDHC'
block, so the 'depends on DISK_ACCESS' is redundant.