### PR TITLE
Bluetooth: GATT: Kconfig: Remove redundant BT_CONN dependencies

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -322,6 +322,7 @@ config BT_CREATE_CONN_TIMEOUT
         int "Timeout for pending LE Create Connection command in seconds"
         default 3
         range 1 65535
+
 endif # BT_CONN
 
 if BT_OBSERVER

--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -125,7 +125,7 @@ endif # BT_GAP_PERIPHERAL_PREF_PARAMS
 
 config BT_DEVICE_NAME_GATT_WRITABLE
 	bool "Allow to write name by remote GATT clients"
-	depends on BT_CONN && BT_DEVICE_NAME_DYNAMIC
+	depends on BT_DEVICE_NAME_DYNAMIC
 	default y
 	help
 	  Enabling this option allows remote GATT clients to write to device
@@ -135,14 +135,12 @@ if BT_DEBUG
 
 config BT_DEBUG_ATT
 	bool "Bluetooth Attribute Protocol (ATT) debug"
-	depends on BT_CONN
 	help
 	  This option enables debug support for the Bluetooth
 	  Attribute Protocol (ATT).
 
 config BT_DEBUG_GATT
 	bool "Bluetooth Generic Attribute Profile (GATT) debug"
-	depends on BT_CONN
 	help
 	  This option enables debug support for the Bluetooth
 	  Generic Attribute Profile (GATT).


### PR DESCRIPTION
subsys/bluetooth/host/Kconfig.gatt is already sourced within an
'if BT_CONN' in subsys/bluetooth/host/Kconfig.