### PR TITLE
Bluetooth: L2CAP: Kconfig: Remove redundant BT_CONN dependency

### DIFF
--- a/subsys/bluetooth/host/Kconfig.l2cap
+++ b/subsys/bluetooth/host/Kconfig.l2cap
@@ -59,7 +59,6 @@ config BT_L2CAP_DYNAMIC_CHANNEL
 if BT_DEBUG
 config BT_DEBUG_L2CAP
 	bool "Bluetooth L2CAP debug"
-	depends on BT_CONN
 	help
 	  This option enables debug support for the Bluetooth
 	  L2ACP layer.


### PR DESCRIPTION
subsys/bluetooth/host/Kconfig.l2cap is already sourced within an
'if BT_CONN' in subsys/bluetooth/host/Kconfig, so BT_DEBUG_L2CAP does
not need a 'depends on BT_CONN'.