### PR TITLE
drivers: flash: Remove redundant FLASH dep. from FLASH_SIMULATOR

### DIFF
--- a/drivers/flash/Kconfig.simulator
+++ b/drivers/flash/Kconfig.simulator
@@ -6,7 +6,6 @@
 menuconfig FLASH_SIMULATOR
 	bool
 	prompt "Flash simulator"
-	depends on FLASH
 	select STATS
 	select STATS_NAMES
 	select FLASH_HAS_PAGE_LAYOUT


### PR DESCRIPTION
FLASH_SIMULATOR is defined in drivers/flash/Kconfig.simulator, which is
source'd within an 'if FLASH' in drivers/flash/Kconfig.