### PR TITLE
drivers: flash: Remove redundant FLASH dep. from FLASH_NATIVE_POSIX

### DIFF
--- a/drivers/flash/Kconfig.native_posix
+++ b/drivers/flash/Kconfig.native_posix
@@ -9,7 +9,6 @@ menuconfig FLASH_NATIVE_POSIX
 	prompt "Native POSIX Flash driver"
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_PAGE_LAYOUT
-	depends on FLASH
 	help
 	  Enable Native POSIX flash driver.
 


### PR DESCRIPTION
FLASH_NATIVE_POSIX is defined in drivers/flash/Kconfig.native_posix,
which is source'd within an 'if FLASH' in drivers/flash/Kconfig.