### PR TITLE
drivers: ethernet: Remove redundant NET_L2_ETHERNET dep. from ETH_LITETH

### DIFF
--- a/drivers/ethernet/Kconfig.liteeth
+++ b/drivers/ethernet/Kconfig.liteeth
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+
 menuconfig ETH_LITEETH
 	bool "LiteEth Ethernet core driver"
-	depends on NET_L2_ETHERNET
 
 if ETH_LITEETH
 


### PR DESCRIPTION
ETH_LITEETH is defined in drivers/ethernet/Kconfig.liteeth, which is
source'd within a menu that has 'depends on ETH_LITEETH', in
drivers/ethernet/Kconfig.