### PR TITLE
Invalid wait value in k_busy_wait()

### DIFF
--- a/samples/net/zperf/src/zperf_tcp_uploader.c
+++ b/samples/net/zperf/src/zperf_tcp_uploader.c
@@ -85,7 +85,7 @@ void zperf_tcp_upload(const struct shell *shell,
 		}
 
 #if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(K_MSEC(100));
+		k_busy_wait(K_MSEC(100) * USEC_PER_MSEC);
 #else
 		k_yield();
 #endif

--- a/samples/net/zperf/src/zperf_udp_uploader.c
+++ b/samples/net/zperf/src/zperf_udp_uploader.c
@@ -259,7 +259,7 @@ void zperf_udp_upload(const struct shell *shell,
 
 		/* Wait */
 #if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(K_MSEC(100));
+		k_busy_wait(K_MSEC(100) * USEC_PER_MSEC);
 #else
 		while (time_delta(loop_time, k_cycle_get_32()) < delay) {
 			k_yield();

--- a/samples/subsys/usb/hid-cdc/src/main.c
+++ b/samples/subsys/usb/hid-cdc/src/main.c
@@ -644,7 +644,7 @@ void main(void)
 	LOG_INF("DTR on CDC ACM 1 set");
 
 	/* Wait 1 sec for the host to do all settings */
-	k_busy_wait(K_SECONDS(1));
+	k_busy_wait(K_SECONDS(1) * USEC_PER_MSEC);
 
 	uart_irq_callback_set(cdc0_dev, cdc_mouse_int_handler);
 	uart_irq_callback_set(cdc1_dev, cdc_kbd_int_handler);


### PR DESCRIPTION
@masz-nordic As I was fixing the zperf networking sample, I submitted also fix for the usb stuff in the same go. If the fix is not proper, just let me know so I can drop the commit from this PR.

Fixes #18059