### PR TITLE
boards: nrf9160_pca10090: add default uart2 pins

### DIFF
--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
@@ -98,6 +98,11 @@
 	cts-pin = <15>;
 };
 
+&uart2 {
+	tx-pin = <24>;
+	rx-pin = <23>;
+};
+
 &i2c2 {
 	status = "okay";
 	sda-pin = <30>;


### PR DESCRIPTION
Route these to the equivalent pins for RXD1 and TXD1 on the Arduino
Mega.

Note that uart0 is routed to the debug probe IC on the nRF9160
DK, and uart1 is routed to where the RXD0 and TXD0 Arduino pins are on
the DK.  This makes RXD1/TXD1 a logical place to put these UART pins,
since the header layout for the DK board matches the Arduino mega.

This is also necessary to keep some downstream code compiling which
needs to enable the UART2 but doesn't have a good place to put these
pins, since the new DTS parser is enforcing that all required
properties (like tx-pin and rx-pin in this case) are set for nodes
with status = "okay".

Signed-off-by: Marti Bolivar <marti.bolivar@nordicsemi.no>