### PR TITLE
kernel: fatal: Refactor z_fatal_print and add transient string support

### DIFF
--- a/arch/arc/core/fatal.c
+++ b/arch/arc/core/fatal.c
@@ -16,7 +16,8 @@
 #include <offsets_short.h>
 #include <toolchain.h>
 #include <arch/cpu.h>
-#include <logging/log_ctrl.h>
+#include <logging/log.h>
+LOG_MODULE_DECLARE(os);
 
 void z_arc_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 {

--- a/arch/arc/core/fault.c
+++ b/arch/arc/core/fault.c
@@ -18,8 +18,8 @@
 #include <kernel.h>
 #include <kernel_structs.h>
 #include <exc_handle.h>
-#include <logging/log_ctrl.h>
-
+#include <logging/log.h>
+LOG_MODULE_DECLARE(os);
 
 #ifdef CONFIG_USERSPACE
 Z_EXC_DECLARE(z_arch_user_string_nlen);

--- a/arch/arm/core/cortex_m/fault.c
+++ b/arch/arm/core/cortex_m/fault.c
@@ -18,7 +18,8 @@
 #include <kernel_structs.h>
 #include <inttypes.h>
 #include <exc_handle.h>
-#include <logging/log_ctrl.h>
+#include <logging/log.h>
+LOG_MODULE_DECLARE(os);
 
 #if defined(CONFIG_PRINTK) || defined(CONFIG_LOG)
 #define PR_EXC(...) z_fatal_print(__VA_ARGS__)

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -17,7 +17,8 @@
 
 #include <kernel.h>
 #include <kernel_structs.h>
-#include <logging/log_ctrl.h>
+#include <logging/log.h>
+LOG_MODULE_DECLARE(os);
 
 static void esf_dump(const z_arch_esf_t *esf)
 {

--- a/arch/nios2/core/fatal.c
+++ b/arch/nios2/core/fatal.c
@@ -8,7 +8,8 @@
 #include <arch/cpu.h>
 #include <kernel_structs.h>
 #include <inttypes.h>
-#include <logging/log_ctrl.h>
+#include <logging/log.h>
+LOG_MODULE_DECLARE(os);
 
 FUNC_NORETURN void z_nios2_fatal_error(unsigned int reason,
 				       const z_arch_esf_t *esf)

--- a/arch/nios2/core/irq_manage.c
+++ b/arch/nios2/core/irq_manage.c
@@ -19,6 +19,8 @@
 #include <ksched.h>
 #include <kswap.h>
 #include <debug/tracing.h>
+#include <logging/log.h>
+LOG_MODULE_DECLARE(os);
 
 FUNC_NORETURN void z_irq_spurious(void *unused)
 {

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -7,7 +7,8 @@
 #include <kernel.h>
 #include <kernel_structs.h>
 #include <inttypes.h>
-#include <logging/log_ctrl.h>
+#include <logging/log.h>
+LOG_MODULE_DECLARE(os);
 
 FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 				       const z_arch_esf_t *esf)

--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -19,7 +19,8 @@
 #include <ia32/exception.h>
 #include <inttypes.h>
 #include <exc_handle.h>
-#include <logging/log_ctrl.h>
+#include <logging/log.h>
+LOG_MODULE_DECLARE(os);
 
 __weak void z_debug_fatal_hook(const z_arch_esf_t *esf) { ARG_UNUSED(esf); }
 

--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -9,6 +9,8 @@
 #include <inttypes.h>
 #include <kernel_arch_data.h>
 #include <xtensa/specreg.h>
+#include <logging/log.h>
+LOG_MODULE_DECLARE(os);
 
 #ifdef XT_SIMULATOR
 #include <xtensa/simcall.h>

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -74,25 +74,6 @@ static const char *reason_to_str(unsigned int reason)
 	}
 }
 
-void z_fatal_print(const char *fmt, ...)
-{
-	va_list ap;
-
-	va_start(ap, fmt);
-	if (IS_ENABLED(CONFIG_LOG)) {
-		struct log_msg_ids src_level = {
-			.level = LOG_LEVEL_ERR,
-			.source_id = LOG_CURRENT_MODULE_ID(),
-			.domain_id = CONFIG_LOG_DOMAIN_ID
-		};
-		log_generic(src_level, fmt, ap);
-	} else {
-		printk("FATAL: ");
-		vprintk(fmt, ap);
-		printk("\n");
-	}
-	va_end(ap);
-}
 #endif /* CONFIG_LOG || CONFIG_PRINTK */
 
 FUNC_NORETURN void k_fatal_halt(unsigned int reason)
@@ -122,7 +103,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	 */
 
 	z_fatal_print("Current thread: %p (%s)", thread,
-		      thread_name_get(thread));
+		z_fatal_transient_string_handle(thread_name_get(thread)));
 
 	k_sys_fatal_error_handler(reason, esf);
 


### PR DESCRIPTION
This is counter proposal to #18060 with keeping logs option in fatal error handling.
When this is added, we can further clean up the code from many ifdefs which won't be needed.
 
PR include following commits:
- Converted z_fatal_print to macro which conditionally uses
  logger or printk. Added macro which should be used in the
  context of z_fatal_print to handle transient strings.
- Additionally, added log module declarations to architecture specific fatal error
  handlers.

Fixes #18052.