### PR TITLE
bluetooth: host: Fix Kconfig error

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -26,7 +26,7 @@ config BT_HCI_CMD_COUNT
 config BT_RX_BUF_COUNT
 	int "Number of HCI RX buffers"
 	default 3 if BT_RECV_IS_RX_THREAD
-	default 20 if (BT_MESH && !BT_DISCARDABLE_BUF_COUNT)
+	default 20 if (BT_MESH && !(BT_DISCARDABLE_BUF_COUNT > 0))
 	default 10
 	range 2 255
 	help


### PR DESCRIPTION
Fixed error 'The int symbol BT_DISCARDABLE_BUF_COUNT is being evaluated
in a logical context somewhere'.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>

Without this change `tests/bluetooth/mesh_shell` fails to compile for nrf52_pca10040. CI is checking only nrf51 and for some reason there is no compilation failure.