### PR TITLE
arch: arc: fixes the case triggering a cpu exception in user mode

### DIFF
--- a/arch/arc/core/fault.c
+++ b/arch/arc/core/fault.c
@@ -386,6 +386,17 @@ void _Fault(z_arch_esf_t *esf, u32_t old_sp)
 
 	/* exception raised by kernel */
 	if (vector == ARC_EV_TRAP && parameter == _TRAP_S_CALL_RUNTIME_EXCEPT) {
+		/*
+		 * in user mode software-triggered system fatal exceptions only allow
+		 * K_ERR_KERNEL_OOPS and K_ERR_STACK_CHK_FAIL
+		 */
+#ifdef CONFIG_USERSPACE
+		if ((esf->status32 & _ARC_V2_STATUS32_U) &&
+			esf->r0 != K_ERR_STACK_CHK_FAIL) {
+			esf->r0 = K_ERR_KERNEL_OOPS;
+		}
+#endif
+
 		z_arc_fatal_error(esf->r0, esf);
 		return;
 	}

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -96,6 +96,13 @@ _exc_entry:
 	jl _Fault
 
 _exc_return:
+/* the exception cause must be fixed in exception handler when exception returns
+ * directly, or exception will be repeated.
+ *
+ * If thread switch is raised in exception handler, the context of old thread will
+ * not be saved, i.e., it cannot be recovered, because we don't know where the
+ * exception comes out,  thread context?irq_context?nest irq context?
+ */
 
 #ifdef CONFIG_PREEMPT_ENABLED
 #ifdef CONFIG_SMP
@@ -129,14 +136,31 @@ _exc_return:
 	/* sflag instruction is not supported in current ARC GNU */
 	.long 0x00ff302f
 #endif
-	/* clear AE bit to forget this was an exception */
+	/* clear AE bit to forget this was an exception, and go to
+	 * register bank0 (if exception is raised in firq with 2 reg
+	 * banks, then we may be bank1)
+	 */
+#if defined(CONFIG_ARC_FIRQ) && CONFIG_RGF_NUM_BANKS != 1
+	/* save r2 in ilink because of the possible following reg
+	 * bank switch
+	 */
+	mov ilink, r2
+#endif
 	lr r3, [_ARC_V2_STATUS32]
-	and r3,r3,(~_ARC_V2_STATUS32_AE)
+	and r3,r3,(~(_ARC_V2_STATUS32_AE | _ARC_V2_STATUS32_RB(7)))
 	kflag r3
-	/* pretend lowest priority interrupt happened to use common handler */
-	lr r3, [_ARC_V2_AUX_IRQ_ACT]
-	or r3,r3,(1 << (CONFIG_NUM_IRQ_PRIO_LEVELS - 1)) /* use lowest */
+	/* pretend lowest priority interrupt happened to use common handler
+	 * if exception is raised in irq, i.e., _ARC_V2_AUX_IRQ_ACT !=0,
+	 * ignore irq handling, we cannot return to irq handling which may
+	 * raise exception again. The ignored interrupts will be re-triggered
+	 * if not cleared, or re-triggered by interrupt sources, or just missed
+	 */
+	mov r3,(1 << (CONFIG_NUM_IRQ_PRIO_LEVELS - 1)) /* use lowest */
 	sr r3, [_ARC_V2_AUX_IRQ_ACT]
+
+#if defined(CONFIG_ARC_FIRQ) && CONFIG_RGF_NUM_BANKS != 1
+	mov r2, ilink
+#endif
 
 	/* Assumption: r2 has current thread */
 	b _rirq_common_interrupt_swap

--- a/include/arch/arc/v2/error.h
+++ b/include/arch/arc/v2/error.h
@@ -23,16 +23,9 @@ extern "C" {
 #endif
 
 /*
- * the exception caused by kernel will be handled in interrupt context
- * when the processor is already in interrupt context, no need to raise
- * a new exception; when the processor is in thread context, the exception
- * will be raised
+ * use trap_s to raise a SW exception
  */
 #define Z_ARCH_EXCEPT(reason_p)	do { \
-	if (z_arc_v2_irq_unit_is_in_isr()) { \
-		printk("@ %s:%d:\n", __FILE__,  __LINE__); \
-		z_fatal_error(reason_p, 0); \
-	} else {\
 		__asm__ volatile ( \
 		"mov r0, %[reason]\n\t" \
 		"trap_s %[id]\n\t" \
@@ -41,7 +34,6 @@ extern "C" {
 		[id] "i" (_TRAP_S_CALL_RUNTIME_EXCEPT) \
 		: "memory"); \
 		CODE_UNREACHABLE; \
-	} \
 	} while (false)
 
 #ifdef __cplusplus

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -1117,47 +1117,27 @@ void test_object_recycle(void)
 
 void test_oops_panic(void)
 {
-#if !defined(CONFIG_ARC)
 	test_oops(K_ERR_KERNEL_PANIC, K_ERR_KERNEL_OOPS);
-#else
-	ztest_test_skip(); /* FIXME: #17590 */
-#endif
 }
 
 void test_oops_oops(void)
 {
-#if !defined(CONFIG_ARC)
 	test_oops(K_ERR_KERNEL_OOPS, K_ERR_KERNEL_OOPS);
-#else
-	ztest_test_skip(); /* FIXME: #17590 */
-#endif
 }
 
 void test_oops_exception(void)
 {
-#if !defined(CONFIG_ARC)
 	test_oops(K_ERR_CPU_EXCEPTION, K_ERR_KERNEL_OOPS);
-#else
-	ztest_test_skip(); /* FIXME: #17590 */
-#endif
 }
 
 void test_oops_maxint(void)
 {
-#if !defined(CONFIG_ARC)
 	test_oops(INT_MAX, K_ERR_KERNEL_OOPS);
-#else
-	ztest_test_skip(); /* FIXME: #17590 */
-#endif
 }
 
 void test_oops_stackcheck(void)
 {
-#if !defined(CONFIG_ARC)
 	test_oops(K_ERR_STACK_CHK_FAIL, K_ERR_STACK_CHK_FAIL);
-#else
-	ztest_test_skip(); /* FIXME: #17590 */
-#endif
 }
 
 void test_main(void)


### PR DESCRIPTION
* raise software triggerd exception unconditionally
* fix the handling when exception raised in irq context
* software-trigger exception only allow oops and stack check fail
* remove the exception of arc in tests/mem_protection/userspace

Fixes #17899 #17590