### PR TITLE
kernel: Fix CPU exception escalated to kernel panic by log core

### DIFF
--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -117,7 +117,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	 */
 
 	z_fatal_print("Current thread: %p (%s)", thread,
-		      thread_name_get(thread));
+		      log_strdup(thread_name_get(thread)));
 
 	k_sys_fatal_error_handler(reason, esf);
 


### PR DESCRIPTION
The printing of the current thread name causing the exception results
in an assertion failure in log_core.c due to missing string duplication.

```
ASSERTION FAIL [0] @ ZEPHYR_BASE/subsys/logging/log_core.c:180
argument 1 in log message "Current thread: %p (%s)" missing log_strdup()
```