### PR TITLE
Fix smp oob not available

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -3118,7 +3118,7 @@ static u8_t smp_pairing_random(struct bt_smp *smp, struct net_buf *buf)
 			return BT_SMP_ERR_UNSPECIFIED;
 		}
 
-		if (bt_auth->oob_data_request) {
+		if (bt_auth && bt_auth->oob_data_request) {
 			struct bt_conn_oob_info info = {
 				.type = BT_CONN_OOB_LE_SC,
 				.lesc.oob_config = BT_CONN_OOB_NO_DATA,
@@ -3528,7 +3528,7 @@ static u8_t smp_public_key(struct bt_smp *smp, struct net_buf *buf)
 				return BT_SMP_ERR_UNSPECIFIED;
 			}
 
-			if (bt_auth->oob_data_request) {
+			if (bt_auth && bt_auth->oob_data_request) {
 				struct bt_conn_oob_info info = {
 					.type = BT_CONN_OOB_LE_SC,
 					.lesc.oob_config = BT_CONN_OOB_NO_DATA,

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -3134,7 +3134,7 @@ static u8_t smp_pairing_random(struct bt_smp *smp, struct net_buf *buf)
 
 			return 0;
 		} else {
-			return BT_SMP_ERR_UNSPECIFIED;
+			return BT_SMP_ERR_OOB_NOT_AVAIL;
 		}
 	default:
 		return BT_SMP_ERR_UNSPECIFIED;
@@ -3544,7 +3544,7 @@ static u8_t smp_public_key(struct bt_smp *smp, struct net_buf *buf)
 				bt_auth->oob_data_request(smp->chan.chan.conn,
 							  &info);
 			} else {
-				return BT_SMP_ERR_UNSPECIFIED;
+				return BT_SMP_ERR_OOB_NOT_AVAIL;
 			}
 			break;
 		default:
@@ -4658,6 +4658,7 @@ int bt_smp_auth_cancel(struct bt_conn *conn)
 	case PASSKEY_CONFIRM:
 		return smp_error(smp, BT_SMP_ERR_CONFIRM_FAILED);
 	case LE_SC_OOB:
+		return smp_error(smp, BT_SMP_ERR_OOB_NOT_AVAIL);
 	case JUST_WORKS:
 		return smp_error(smp, BT_SMP_ERR_UNSPECIFIED);
 	default:


### PR DESCRIPTION
 Fix kernel crash if bluetooth authentication handlers has not been
registered. The bt_auth object is then NULL, this dereference caused a
call to an invalid function pointer.

If no callback for oob data request is registered, or the user decided
to abort authentication during OOB data request, we should return the
error code for no OOB data available to indicate that the user does not
have the correct OOB, or no OOB interface at all.
