### PR TITLE
dts: pwm: nxp: Fixup bindings and dtsi so they build

### DIFF
--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -341,7 +341,7 @@
 				index = <0>;
 				label = "FLEXPWM1_PWM0";
 				interrupts = <102 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 
 			flexpwm1_pwm1: pwm1 {
@@ -349,7 +349,7 @@
 				index = <1>;
 				label = "FLEXPWM1_PWM1";
 				interrupts = <103 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 
 			flexpwm1_pwm2: pwm2 {
@@ -357,7 +357,7 @@
 				index = <2>;
 				label = "FLEXPWM1_PWM2";
 				interrupts = <104 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 
 			flexpwm1_pwm3: pwm3 {
@@ -365,7 +365,7 @@
 				index = <3>;
 				label = "FLEXPWM1_PWM3";
 				interrupts = <105 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 		};
 
@@ -379,7 +379,7 @@
 				index = <0>;
 				label = "FLEXPWM2_PWM0";
 				interrupts = <137 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 
 			flexpwm2_pwm1: pwm1 {
@@ -387,7 +387,7 @@
 				index = <1>;
 				label = "FLEXPWM2_PWM1";
 				interrupts = <138 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 
 			flexpwm2_pwm2: pwm2 {
@@ -395,7 +395,7 @@
 				index = <2>;
 				label = "FLEXPWM2_PWM2";
 				interrupts = <139 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 
 			flexpwm2_pwm3: pwm3 {
@@ -403,7 +403,7 @@
 				index = <3>;
 				label = "FLEXPWM2_PWM3";
 				interrupts = <140 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 		};
 
@@ -417,7 +417,7 @@
 				index = <0>;
 				label = "FLEXPWM3_PWM0";
 				interrupts = <142 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 
 			flexpwm3_pwm1: pwm1 {
@@ -425,7 +425,7 @@
 				index = <1>;
 				label = "FLEXPWM3_PWM1";
 				interrupts = <143 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 
 			flexpwm3_pwm2: pwm2 {
@@ -433,7 +433,7 @@
 				index = <2>;
 				label = "FLEXPWM3_PWM2";
 				interrupts = <144 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 
 			flexpwm3_pwm3: pwm3 {
@@ -441,7 +441,7 @@
 				index = <3>;
 				label = "FLEXPWM3_PWM3";
 				interrupts = <145 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 		};
 
@@ -455,7 +455,7 @@
 				index = <0>;
 				label = "FLEXPWM4_PWM0";
 				interrupts = <147 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 
 			flexpwm4_pwm1: pwm1 {
@@ -463,7 +463,7 @@
 				index = <1>;
 				label = "FLEXPWM4_PWM1";
 				interrupts = <148 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 
 			flexpwm4_pwm2: pwm2 {
@@ -471,7 +471,7 @@
 				index = <2>;
 				label = "FLEXPWM4_PWM2";
 				interrupts = <149 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 
 			flexpwm4_pwm3: pwm3 {
@@ -479,7 +479,7 @@
 				index = <3>;
 				label = "FLEXPWM4_PWM3";
 				interrupts = <150 0>;
-				#pwm-cells = <2>;
+				#pwm-cells = <1>;
 			};
 		};
 

--- a/dts/bindings/pwm/nxp,flexpwm.yaml
+++ b/dts/bindings/pwm/nxp,flexpwm.yaml
@@ -1,6 +1,4 @@
----
 title: MCUX PWM
-version: 0.1
 
 description: >
     This binding gives a base representation of the NXP eFLEX PWM module which

--- a/dts/bindings/pwm/nxp,imx-pwm.yaml
+++ b/dts/bindings/pwm/nxp,imx-pwm.yaml
@@ -1,6 +1,4 @@
----
 title: MCUX PWM
-version: 0.1
 
 description: >
     This binding gives a base representation of the NXP MCUX PWM
@@ -15,7 +13,6 @@ properties:
     index:
       type: int
       description: flexpwm submodule index
-      generation: define
       category: required
 
     interrupts:


### PR DESCRIPTION
With the new DT checks the dts bindings for "nxp,flexpwm" and
"nxp,imx-pwm" had old conventions that we now treat as build errors.

Additionally fix the number of #pwm-cells for "nxp,imx-pwm" to be 1.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>