### PR TITLE
scripts/dts: Fix detection of a GPIO specifier

### DIFF
--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -35,6 +35,6 @@ properties:
         description: Human readable string describing the device (used by Zephyr for API name)
 
     clocks:
-        type: array
+        type: compound
         category: optional
         description: Clock gate information

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -1352,7 +1352,7 @@ def _gpios(node):
     res = {}
 
     for name, prop in node.props.items():
-        if name.endswith("gpios"):
+        if name.endswith("-gpios") or name == "gpios":
             # Get the prefix from the property name:
             #   - gpios     -> "" (deprecated, should have a prefix)
             #   - foo-gpios -> "foo"

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -84,7 +84,7 @@ def generate_prop_defines(node_path, prop):
         compatible.extract(node_path, prop, def_label)
     elif 'clocks' in prop:
         clocks.extract(node_path, prop, def_label)
-    elif 'pwms' in prop or 'gpios' in prop:
+    elif 'pwms' in prop or '-gpios' in prop or prop == "gpios":
         prop_values = reduced[node_path]['props'][prop]
         generic = prop[:-1]  # Drop the 's' from the prop
 

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -154,8 +154,7 @@ def write_props(dev):
             continue
 
         # Skip properties that we handle elsewhere
-        if prop.name in {"reg", "interrupts", "pwms", "clocks", "compatible"} or \
-           prop.name.endswith("gpios"):
+        if prop.name in {"reg", "interrupts", "compatible"}:
             continue
 
         if prop.description is not None:


### PR DESCRIPTION
We should only assume a GPIO specifier is either named <FOO>-gpios or
gpios.  Any other form like ngpios should not be considered a GPIO
specifier.  especially since 'ngpios' is the standard property name for
the number of gpio's that are implemented.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>