### PR TITLE
Bluetooth: controller: Fix assert in RPA timeout for advertiser

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -567,6 +567,11 @@ static void rpa_adv_refresh(void)
 		return;
 	}
 
+	idx = ll_rl_find(ll_adv->id_addr_type, ll_adv->id_addr, NULL);
+	if (idx >= ARRAY_SIZE(rl)) {
+		return;
+	}
+
 	radio_adv_data = radio_adv_data_get();
 	prev = (struct pdu_adv *)&radio_adv_data->data[radio_adv_data->last][0];
 	/* use the last index in double buffer, */
@@ -590,8 +595,6 @@ static void rpa_adv_refresh(void)
 		pdu->chan_sel = 0U;
 	}
 
-	idx = ll_rl_find(ll_adv->id_addr_type, ll_adv->id_addr, NULL);
-	LL_ASSERT(idx < ARRAY_SIZE(rl));
 	ll_rl_pdu_adv_update(idx, pdu);
 
 	memcpy(&pdu->adv_ind.data[0], &prev->adv_ind.data[0],

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -872,6 +872,11 @@ static void rpa_adv_refresh(struct ll_adv_set *adv)
 		return;
 	}
 
+	idx = ull_filter_rl_find(adv->id_addr_type, adv->id_addr, NULL);
+	if (idx >= ARRAY_SIZE(rl)) {
+		return;
+	}
+
 	prev = lll_adv_data_peek(&adv->lll);
 	pdu = lll_adv_data_alloc(&adv->lll, &idx);
 	pdu->type = prev->type;
@@ -883,8 +888,6 @@ static void rpa_adv_refresh(struct ll_adv_set *adv)
 		pdu->chan_sel = 0;
 	}
 
-	idx = ull_filter_rl_find(adv->id_addr_type, adv->id_addr, NULL);
-	LL_ASSERT(idx < ARRAY_SIZE(rl));
 	ull_filter_adv_pdu_update(adv, idx, pdu);
 
 	memcpy(&pdu->adv_ind.data[0], &prev->adv_ind.data[0],


### PR DESCRIPTION
Fix assert in the RPA timeout when no resolving entry exists in the
resolving list, and the advertiser was requested to use a local IRK
to generate it's own address.

Fixes: #18092