### PR TITLE
drivers: sensors: Remove 'version:' field in Si7006 binding

### DIFF
--- a/dts/bindings/sensor/silabs,si7006.yaml
+++ b/dts/bindings/sensor/silabs,si7006.yaml
@@ -3,9 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
----
+
 title: Si7006 Temperature and Humidity sensor
-version: 0.1
 
 description: >
     This is a representation of Si7006 Temperature and Humidity sensor


### PR DESCRIPTION
Breaks CI, because it's flagged as an error. See
https://github.com/zephyrproject-rtos/zephyr/pull/17681.

Also remove a redundant document separator.