### PR TITLE
augment workaround for time-related types present in multiple libc headers

### DIFF
--- a/lib/libc/minimal/include/sys/_timespec.h
+++ b/lib/libc/minimal/include/sys/_timespec.h
@@ -7,7 +7,17 @@
 #ifndef ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS__TIMESPEC_H_
 #define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS__TIMESPEC_H_
 
-#include <sys/types.h>
+#include <sys/_types.h>
+
+#if !defined(__time_t_defined)
+#define __time_t_defined
+typedef _TIME_T_ time_t;
+#endif
+
+#if !defined(__suseconds_t_defined)
+#define __suseconds_t_defined
+typedef _SUSECONDS_T_ suseconds_t;
+#endif
 
 struct timespec {
 	time_t tv_sec;

--- a/lib/libc/minimal/include/sys/_timeval.h
+++ b/lib/libc/minimal/include/sys/_timeval.h
@@ -7,7 +7,17 @@
 #ifndef ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS__TIMEVAL_H_
 #define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS__TIMEVAL_H_
 
-#include <sys/types.h>
+#include <sys/_types.h>
+
+#if !defined(__time_t_defined)
+#define __time_t_defined
+typedef _TIME_T_ time_t;
+#endif
+
+#if !defined(__suseconds_t_defined)
+#define __suseconds_t_defined
+typedef _SUSECONDS_T_ suseconds_t;
+#endif
 
 struct timeval {
 	time_t tv_sec;

--- a/lib/libc/minimal/include/sys/_types.h
+++ b/lib/libc/minimal/include/sys/_types.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019 Peter Bigot Consulting, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Common header used to define underlying types for typedefs that
+ * must appear in multiple headers independently.
+ */
+#ifndef ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_XTYPES_H_
+#define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_XTYPES_H_
+
+#include <stdint.h>
+
+typedef int64_t _TIME_T_;
+typedef int32_t _SUSECONDS_T_;
+
+#endif /* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_XTYPES_H_ */

--- a/lib/libc/minimal/include/sys/types.h
+++ b/lib/libc/minimal/include/sys/types.h
@@ -9,6 +9,7 @@
 #define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_TYPES_H_
 
 #include <stdint.h>
+#include <sys/_types.h>
 
 typedef unsigned int mode_t;
 
@@ -44,12 +45,12 @@ typedef int off_t;
 
 #if !defined(__time_t_defined)
 #define __time_t_defined
-typedef int64_t time_t;
+typedef _TIME_T_ time_t;
 #endif
 
 #if !defined(__suseconds_t_defined)
 #define __suseconds_t_defined
-typedef int32_t suseconds_t;
+typedef _SUSECONDS_T_ suseconds_t;
 #endif
 
 #if !defined(__mem_word_t_defined)

--- a/lib/libc/minimal/include/sys/types.h
+++ b/lib/libc/minimal/include/sys/types.h
@@ -42,8 +42,15 @@ typedef int off_t;
 
 #endif
 
+#if !defined(__time_t_defined)
+#define __time_t_defined
 typedef int64_t time_t;
+#endif
+
+#if !defined(__suseconds_t_defined)
+#define __suseconds_t_defined
 typedef int32_t suseconds_t;
+#endif
 
 #if !defined(__mem_word_t_defined)
 #define __mem_word_t_defined

--- a/lib/libc/minimal/include/time.h
+++ b/lib/libc/minimal/include/time.h
@@ -9,6 +9,7 @@
 #define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_TIME_H_
 
 #include <stdint.h>
+#include <sys/_types.h>
 #include <bits/restrict.h>
 
 /* Minimal time.h to fulfill the requirements of certain libraries
@@ -33,12 +34,12 @@ struct tm {
 
 #if !defined(__time_t_defined)
 #define __time_t_defined
-typedef int64_t time_t;
+typedef _TIME_T_ time_t;
 #endif
 
 #if !defined(__suseconds_t_defined)
 #define __suseconds_t_defined
-typedef int32_t suseconds_t;
+typedef _SUSECONDS_T_ suseconds_t;
 #endif
 
 #include <sys/_timespec.h>

--- a/lib/libc/minimal/include/time.h
+++ b/lib/libc/minimal/include/time.h
@@ -31,8 +31,15 @@ struct tm {
 	int tm_isdst;
 };
 
+#if !defined(__time_t_defined)
+#define __time_t_defined
 typedef int64_t time_t;
+#endif
+
+#if !defined(__suseconds_t_defined)
+#define __suseconds_t_defined
 typedef int32_t suseconds_t;
+#endif
 
 #include <sys/_timespec.h>
 


### PR DESCRIPTION
This is based on #18062 and is intended to be compatible with the existing POSIX headers that include the underlying `sys/_timespec.h` and `sys/_timeval.h` minimal libc headers.  It also moves the underlying types down to a common header so changes need only be made in one place (e.g. a desire to support only 32-bit `time_t` for space reasons).