### PR TITLE
dts/bindings: Remove unused snps,num-irq-priority-bits prop

### DIFF
--- a/dts/bindings/interrupt-controller/snps,designware-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,designware-intc.yaml
@@ -13,11 +13,6 @@ properties:
   reg:
       category: required
 
-  snps,num-irq-priority-bits:
-      category: required
-      type: int
-      description: number of bits of IRQ priorities
-
   interrupts:
       category: required
 

--- a/dts/bindings/interrupt-controller/xtensa,intc.yaml
+++ b/dts/bindings/interrupt-controller/xtensa,intc.yaml
@@ -13,11 +13,6 @@ properties:
   reg:
       category: required
 
-  snps,num-irq-priority-bits:
-      category: required
-      type: int
-      description: number of bits of IRQ priorities
-
 "#cells":
   - irq
   - sense


### PR DESCRIPTION
The snps,designware-intc.yaml and xtensa,intc.yaml define a required
property snps,num-irq-priority-bits that isn't defined in any .dts

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>