### PR TITLE
Improvements for 96Boards Avenger96

### DIFF
--- a/boards/arm/96b_avenger96/96b_avenger96.dts
+++ b/boards/arm/96b_avenger96/96b_avenger96.dts
@@ -24,6 +24,28 @@
 		zephyr,flash = &retram;
 		zephyr,sram = &mcusram;
 	};
+
+	leds {
+		compatible = "gpio-leds";
+		green_led_0: led_0 {
+			gpios = <&gpiof 3 GPIO_INT_ACTIVE_HIGH>;
+			label = "USR0 LED";
+		};
+		green_led_1: led_1 {
+			gpios = <&gpiog 0 GPIO_INT_ACTIVE_HIGH>;
+			label = "USR1 LED";
+		};
+		green_led_2: led_2 {
+			gpios = <&gpiog 1 GPIO_INT_ACTIVE_HIGH>;
+			label = "USR2 LED";
+		};
+	};
+
+	aliases {
+		led0 = &green_led_0;
+		led1 = &green_led_1;
+		led2 = &green_led_2;
+	};
 };
 
 &uart4 {

--- a/boards/arm/96b_avenger96/96b_avenger96.dts
+++ b/boards/arm/96b_avenger96/96b_avenger96.dts
@@ -48,6 +48,10 @@
 	};
 };
 
+&mailbox {
+	status = "okay";
+};
+
 &uart4 {
 	current-speed = <115200>;
 	pinctrl-0 = <&uart4_pins_a>;


### PR DESCRIPTION
Following are the improvements added for 96Boards Avenger96:

Add onboard LEDs support
Add Mailbox support

Signed-off-by: Manivannan Sadhasivam <mani@kernel.org>