### PR TITLE
edtlib: Check that 'status' has one of the values from the DT spec.

### DIFF
--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -45,5 +45,5 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -46,11 +46,11 @@
 &usart1 {
 	current-speed = <115200>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &uart8 {
 	current-speed = <115200>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };


### PR DESCRIPTION
dtlib is meant to be general and anything-goes re. property values, but
edtlib can be pickier. Check that all `status` properties have one of
the values listed in the devicetree specification
(https://www.devicetree.org/specifications/), and error out otherwise.

This will get rid of the `status = "ok"`s (should be "okay") that keep
cropping up.