### PR TITLE
dts: Add support for io-channel properties

### DIFF
--- a/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
@@ -21,3 +21,6 @@ properties:
 
     interrupts:
       category: required
+
+"#cells":
+    - input

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -235,6 +235,7 @@ class EDT:
             dev._init_interrupts()
             dev._init_gpios()
             dev._init_pwms()
+            dev._init_iochannels()
             dev._init_clocks()
 
     def __repr__(self):
@@ -328,6 +329,11 @@ class Device:
     pwms:
       A list of PWM objects, derived from the 'pwms' property. The list is
       empty if the device has no 'pwms' property.
+
+    iochannels:
+      A list of IOChannel objects, derived from the 'io-channels'
+      property. The list is empty if the device has no 'io-channels'
+      property.
 
     clocks:
       A list of Clock objects, derived from the 'clocks' property. The list is
@@ -436,8 +442,9 @@ class Device:
     def __init__(self, edt, node):
         "Private constructor. Not meant to be called by clients."
 
-        # Interrupts, GPIOs, PWMs, and clocks are initialized separately,
-        # because they depend on all Devices existing
+        # Interrupts, GPIOs, PWMs, io-channels, and clocks are
+        # initialized separately, because they depend on all Devices
+        # existing
 
         self.edt = edt
         self._node = node
@@ -691,6 +698,11 @@ class Device:
         # Initializes self.pwms
 
         self.pwms = self._simple_phandle_val_list("pwm", PWM)
+
+    def _init_iochannels(self):
+        # Initializes self.iochannels
+
+        self.iochannels = self._simple_phandle_val_list("io-channel", IOChannel)
 
     def _simple_phandle_val_list(self, name, cls):
         # Helper for parsing properties like
@@ -948,6 +960,41 @@ class PWM:
         fields.append("specifier: {}".format(self.specifier))
 
         return "<PWM, {}>".format(", ".join(fields))
+
+
+class IOChannel:
+    """
+    Represents an IO channel used by a device, similar to the property used
+    by the Linux IIO bindings and described at:
+      https://www.kernel.org/doc/Documentation/devicetree/bindings/iio/iio-bindings.txt
+
+    These attributes are available on IO channel objects:
+
+    dev:
+      The Device instance that uses the IO channel
+
+    name:
+      The name of the IO channel as given in the 'io-channel-names' property,
+      or the  node name if the 'io-channel-names' property doesn't exist.
+
+    controller:
+      The Device instance for the controller of the IO channel
+
+    specifier:
+      A dictionary that maps names from the #cells portion of the binding to
+      cell values in the io-channel specifier. 'io-channels = <&adc 3>' might
+      give {"input": 3}, for example.
+    """
+    def __repr__(self):
+        fields = []
+
+        if self.name is not None:
+            fields.append("name: " + self.name)
+
+        fields.append("target: {}".format(self.controller))
+        fields.append("specifier: {}".format(self.specifier))
+
+        return "<IOChannel, {}>".format(", ".join(fields))
 
 
 class Property:

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -63,6 +63,7 @@ def main():
             write_irqs(dev)
             write_gpios(dev)
             write_pwms(dev)
+            write_iochannels(dev)
             write_clocks(dev)
             write_spi_dev(dev)
             write_props(dev)
@@ -494,6 +495,18 @@ def write_pwms(dev):
 
         for spec, val in pwm.specifier.items():
             out_dev(dev, "PWMS_" + str2ident(spec), val)
+
+
+def write_iochannels(dev):
+    # Writes IO channel controller and specifier info for the IO
+    # channels in dev's 'io-channels' property
+
+    for iochannel in dev.iochannels:
+        if iochannel.controller.label is not None:
+            out_dev_s(dev, "IO_CHANNELS_CONTROLLER", iochannel.controller.label)
+
+        for spec, val in iochannel.specifier.items():
+            out_dev(dev, "IO_CHANNELS_" + str2ident(spec), val)
 
 
 def write_clocks(dev):

--- a/scripts/dts/test-bindings/io-channel.yaml
+++ b/scripts/dts/test-bindings/io-channel.yaml
@@ -1,0 +1,14 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+title: IO channel with one cell
+description: IO channel with one cell
+
+properties:
+    compatible:
+        constraint: "io-channel"
+        type: string-array
+
+"#cells":
+  - one

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -196,6 +196,22 @@
 	};
 
 	//
+	// IO channels
+	//
+
+	// Lots of common code with PWMs and clocks, so just test the basics
+	io-channel-test {
+		io-channel {
+			compatible = "io-channel";
+			#io-channel-cells = <1>;
+		};
+		node {
+			io-channels = <&{/io-channel-test/io-channel} 1>;
+			io-channel-names = "io-channel";
+		};
+	};
+
+	//
 	// 'reg'
 	//
 

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -73,6 +73,13 @@ def run():
                  "[<PWM, name: zero-cell, target: <Device /pwm-test/pwm-0 in 'test.dts', binding test-bindings/pwm-0-cell.yaml>, specifier: {}>, <PWM, name: one-cell, target: <Device /pwm-test/pwm-1 in 'test.dts', binding test-bindings/pwm-1-cell.yaml>, specifier: {'one': 1}>]")
 
     #
+    # Test IO channels
+    #
+
+    verify_streq(edt.get_dev("/io-channel-test/node").iochannels,
+                 "[<IOChannel, name: io-channel, target: <Device /io-channel-test/io-channel in 'test.dts', binding test-bindings/io-channel.yaml>, specifier: {'one': 1}>]")
+
+    #
     # Test 'reg'
     #
 


### PR DESCRIPTION
This adds support for e.g. `io-channels = <&adc 3>` analogous to existing `pwms = <&pwm 0 10000>`, for referencing a specific IO channel input.  Also adds support to the `nrf-saadc` bindings.  This uses the new shared logic from #18065 

Example of how I'm using it:

`dts/bindings/adc-map.yaml`:
```
title: ADC Map

description: >
    Map ADC input numbers to names

inherits:
    !include base.yaml

properties:
    compatible:
      constraint: "adc-map"

sub-node:
  properties:
    io-channels:
      type: compound
      category: required
```

`boards/arm/foo/foo.dts`:
```
/dts-v1/;
#include <nordic/nrf52832_qfaa.dtsi>

/ {
        model = "Foo";
        compatible = "nordic,nrf52832-qfaa", "nordic,nrf52832";

        adc-map {
                compatible = "adc-map";
                batt_meas {
                        io-channels = <&adc 0>;
                };
        };
};

&adc {
        status = "okay";
        #io-channel-cells = <1>;
};
```

`app/power.c`:
```c
adc_dev = device_get_binding(DT_ADC_MAP_BATT_MEAS_IO_CHANNELS_CONTROLLER);
const struct adc_channel_cfg cfg = {
        .gain             = ADC_GAIN_1_6,
        .reference        = ADC_REF_INTERNAL,
        .acquisition_time = ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 10),
        .channel_id       = 0,
        .input_positive   = (NRF_SAADC_INPUT_AIN0 + DT_ADC_MAP_BATT_MEAS_IO_CHANNELS_INPUT),
};
adc_channel_setup(adc_dev, &cfg);
```



