### PR TITLE
west_commands: pyocd: issue a warning when falling back to binary file

### DIFF
--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -111,15 +111,20 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
         else:
             self.debug_debugserver(command, **kwargs)
 
-    def flash(self, **kwargs):
+    def _getfname(self):
         if os.path.isfile(self.hex_name):
-            fname = self.hex_name
-        elif os.path.isfile(self.bin_name):
-            fname = self.bin_name
-        else:
-            raise ValueError(
-                'Cannot flash; no hex ({}) or bin ({}) files'.format(
-                    self.hex_name, self.bin_name))
+            return self.hex_name
+
+        if os.path.isfile(self.bin_name):
+            self.logger.warning('Hex file "{}" not found, falling back to binary "{}"'.format(self.hex_name, self.bin_name))
+            return self.bin_name
+
+        raise ValueError(
+            'Cannot flash; no hex ({}) or bin ({}) files'.format(
+                self.hex_name, self.bin_name))
+
+    def flash(self, **kwargs):
+        fname = self._getfname()
 
         cmd = ([self.pyocd] +
                ['flash'] +
@@ -132,7 +137,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                self.flash_extra +
                [fname])
 
-        self.logger.info('Flashing Target Device')
+        self.logger.info('Flashing Target Device ({})'.format(os.path.basename(fname)))
         self.check_call(cmd)
 
     def log_gdbserver_message(self):


### PR DESCRIPTION
Some tutorial told me to do
```
west build
west sign ...
west flash --hex-file zephyr.signed.hex
```

which doesn't work because west doesn't actually infer that you mean `--hex-file build/zephyr/zephyr.signed.hex` when you type `--hex-file zephyr.signed.hex`.  

It can't find the hex file you passed so it silently falls back to the unsigned binary file.

Most of the time, when passing --hex-file, it's because you've signed it or some such. If you typo it, it would be nice to know.
