### PR TITLE
Simplify building when civetweb module is present

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -22,7 +22,7 @@ manifest:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
     - name: civetweb
-      url-base: https://github.com/antmicro
+      url-base: https://github.com/civetweb
 
   #
   # Please add items below based on alphabetical order

--- a/west.yml
+++ b/west.yml
@@ -32,7 +32,7 @@ manifest:
       path: tools/ci-tools
     - name: civetweb
       remote: civetweb
-      revision: 7ffad765f9a63a7bab3432ca45248981f559d559
+      revision: 99129c5efc907ea613c4b73ccff07581feb58a7a
       path: modules/lib/civetweb
     - name: esp-idf
       revision: 6835bfc741bf15e98fb7971293913f770df6081f


### PR DESCRIPTION
It was reported that Civetweb build is too complicated when we're building unrelated apps.

It is already fixed on civetweb master, this PR only bumps the module.

This PR is possibly related to #17996