### PR TITLE
Perform OTP override for 32KHz internal oscillator

### DIFF
--- a/soc/arm/microchip_mec/mec1501/soc.c
+++ b/soc/arm/microchip_mec/mec1501/soc.c
@@ -84,7 +84,12 @@ static int soc_clk32_init(void)
 	new_clk32 = MCHP_VBATR_USE_32KIN_PIN;
   #endif
 #else
-	/* Use internal 32KHz +/-2% silicon oscillator */
+	/* Use internal 32KHz +/-2% silicon oscillator
+	 * if required performed OTP value override
+	 */
+	if (MCHP_REVISION_ID() == MCHP_GCFG_REV_B0) {
+		VBATR_REGS->CKK32_TRIM = 0x06;
+	}
 	new_clk32 = MCHP_VBATR_USE_SIL_OSC;
 #endif
 	clk32_change(new_clk32);


### PR DESCRIPTION
Perform OTP override when selecting 32Khz internal oscillator via Kconfig.
This is required to ensure 32KHz is enabled.
If 32Khz is not correctly enabled, main clock won't be accurate and will cause garbled UART output among other issues.