### PR TITLE
fs/nvs: operate on filled up storage bugfixes

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -537,7 +537,7 @@ static int nvs_startup(struct nvs_fs *fs)
 	 * Coverity and GCC believe the contrary.
 	 */
 	u32_t addr = 0U;
-	u16_t i;
+	u16_t i, closed_sectors = 0;
 
 	k_mutex_lock(&fs->nvs_lock, K_FOREVER);
 
@@ -551,6 +551,7 @@ static int nvs_startup(struct nvs_fs *fs)
 					  sizeof(struct nvs_ate));
 		if (rc) {
 			/* closed sector */
+			closed_sectors++;
 			nvs_sector_advance(fs, &addr);
 			rc = nvs_flash_cmp_const(fs, addr, 0xff,
 						  sizeof(struct nvs_ate));
@@ -559,6 +560,10 @@ static int nvs_startup(struct nvs_fs *fs)
 				break;
 			}
 		}
+	}
+	/* all sectors are closed, this is not a nvs fs */
+	if (closed_sectors == fs->sector_count) {
+		return -EDEADLK;
 	}
 
 	if (i == fs->sector_count) {
@@ -578,42 +583,43 @@ static int nvs_startup(struct nvs_fs *fs)
 	/* addr contains address of the last ate in the most recent sector
 	 * search for the first ate containing all 0xff
 	 */
-	while (1) {
-		addr -= ate_size;
-		rc = nvs_flash_cmp_const(fs, addr, 0xff,
-					  sizeof(struct nvs_ate));
+	fs->ate_wra = addr - ate_size;
+	fs->data_wra = addr & ADDR_SECT_MASK;
+
+	while (fs->ate_wra >= fs->data_wra) {
+		rc = nvs_flash_ate_rd(fs, fs->ate_wra, &last_ate);
+		if (rc) {
+			goto end;
+		}
+
+		rc = nvs_ate_cmp_const(&last_ate, 0xff);
 		if (!rc) {
 			/* found ff empty location */
 			break;
 		}
-	}
 
-	fs->ate_wra = addr;
-	fs->data_wra = addr & ADDR_SECT_MASK;
-
-	/* read the last ate to update data_wra, only do this if the ate_wra
-	 * is not at the start of a sector
-	 */
-
-	if ((addr & ADDR_OFFS_MASK) != fs->sector_size - 2 * ate_size) {
-		addr += ate_size;
-		rc = nvs_flash_ate_rd(fs, addr, &last_ate);
-		if (rc) {
-			goto end;
-		}
 		if (!nvs_ate_crc8_check(&last_ate)) {
 			/* crc8 is ok, complete write of ate was performed */
+			fs->data_wra = addr & ADDR_SECT_MASK;
 			fs->data_wra += last_ate.offset;
 			fs->data_wra += nvs_al_size(fs, last_ate.len);
+
+			/* ate on the last possition within the sector is
+			 * reserved for deletion an entry
+			 */
+			if (fs->ate_wra == fs->data_wra && last_ate.len) {
+				/* not a delete ate */
+				return -ESPIPE;
+			}
 		}
+
+		fs->ate_wra -= ate_size;
 	}
 
 	/* possible data write after last ate write, update data_wra */
-	while (1) {
+	while (fs->ate_wra > fs->data_wra) {
 		empty_len = fs->ate_wra - fs->data_wra;
-		if (!empty_len) {
-			break;
-		}
+
 		rc = nvs_flash_cmp_const(fs, fs->data_wra, 0xff, empty_len);
 		if (rc < 0) {
 			goto end;
@@ -621,6 +627,7 @@ static int nvs_startup(struct nvs_fs *fs)
 		if (!rc) {
 			break;
 		}
+
 		fs->data_wra += fs->write_block_size;
 	}
 

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -738,7 +738,7 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 	size_t ate_size, data_size;
 	struct nvs_ate wlk_ate;
 	u32_t wlk_addr, rd_addr;
-	u16_t sector_freespace;
+	u16_t required_space = 0U; /* no space, appropriate for delete ate */
 
 	if (!fs->ready) {
 		LOG_ERR("NVS not initialized");
@@ -794,6 +794,12 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 		}
 	}
 
+	/* calculate required space if the entry contains data */
+	if (data_size) {
+		/* Leave space for delete ate */
+		required_space = data_size + ate_size;
+	}
+
 	k_mutex_lock(&fs->nvs_lock, K_FOREVER);
 
 	gc_count = 0;
@@ -806,10 +812,7 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 			goto end;
 		}
 
-		sector_freespace = fs->ate_wra - fs->data_wra;
-
-		/* Leave space for delete ate */
-		if (sector_freespace >= data_size + ate_size) {
+		if (fs->ate_wra >= fs->data_wra + required_space) {
 
 			rc = nvs_flash_wrt_entry(fs, id, data, len);
 			if (rc) {
@@ -817,6 +820,7 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 			}
 			break;
 		}
+
 
 		rc = nvs_sector_close(fs);
 		if (rc) {

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -790,6 +790,9 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 		if (len == 0) {
 			/* do not try to compare with empty data */
 			if (wlk_ate.len == 0U) {
+				/* skip delete entry as it is already the
+				 * last one
+				 */
 				return 0;
 			}
 		} else {
@@ -798,6 +801,11 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 			if (rc <= 0) {
 				return rc;
 			}
+		}
+	} else {
+		/* skip delete entry for non-existing entry */
+		if (len == 0) {
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
backport without test as nvs test suite is unavailable in 1.14


    test case for filled up fiesystem
    fix for bug: unable to delete anything from filled up system
    fix for bug: initialization can hang/assert on filled up sector
    skip deletion of non-existing entry
    test case for deletion entry behaviour
