### PR TITLE
boards: nrf9160_pca10090: Clean up default configurations

### DIFF
--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_defconfig
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_defconfig
@@ -22,6 +22,3 @@ CONFIG_UART_0_NRF_UARTE=y
 # enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
-
-# additional board options
-CONFIG_GPIO_AS_PINRESET=y

--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_defconfig
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_defconfig
@@ -25,6 +25,3 @@ CONFIG_UART_CONSOLE=y
 
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y
-
-# entropy driver doesn't support nRF9160 yet
-CONFIG_ENTROPY_NRF5_RNG=n

--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090ns_defconfig
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090ns_defconfig
@@ -28,6 +28,3 @@ CONFIG_UART_CONSOLE=y
 
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y
-
-# entropy driver doesn't support nRF9160 yet
-CONFIG_ENTROPY_NRF5_RNG=n

--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090ns_defconfig
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090ns_defconfig
@@ -25,6 +25,3 @@ CONFIG_UART_0_NRF_UARTE=y
 # enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
-
-# additional board options
-CONFIG_GPIO_AS_PINRESET=y

--- a/boards/posix/nrf52_bsim/Kconfig
+++ b/boards/posix/nrf52_bsim/Kconfig
@@ -2,6 +2,12 @@
 
 if BOARD_NRF52_BSIM
 
+# The following file is normally parsed only for the ARM architecture, which is
+# used by Nordic SoCs, so to make the symbols defined in this file available for
+# the simulated nrf52_bsim board, which uses the POSIX architecture, the file
+# must be read also from here.
+source "soc/arm/nordic_nrf/Kconfig.peripherals"
+
 comment "NRF52_BSIM options"
 
 config PRINTK_HOOK_INIT_PRIORITY

--- a/boards/posix/nrf52_bsim/Kconfig.board
+++ b/boards/posix/nrf52_bsim/Kconfig.board
@@ -10,6 +10,10 @@ config BOARD_NRF52_BSIM
 	select CONSOLE_HAS_DRIVER
 	select NRF_RTC_TIMER
 	select CLOCK_CONTROL
+	# Indicate that the nRF RNG peripheral is present (actually a model
+	# of it), so that the corresponding driver becomes available (see
+	# dependencies of the ENTROPY_NRF5_RNG option).
+	select HAS_HW_NRF_RNG
 	help
 	  Will produce a console Linux process which can be executed natively.
 	  It needs the BabbleSim simulator both in compile time and to execute

--- a/drivers/entropy/Kconfig.nrf5
+++ b/drivers/entropy/Kconfig.nrf5
@@ -16,7 +16,7 @@ if !ENTROPY_NRF_FORCE_ALT
 
 menuconfig ENTROPY_NRF5_RNG
 	bool "nRF5 RNG driver"
-	depends on SOC_COMPATIBLE_NRF
+	depends on HAS_HW_NRF_RNG
 	select ENTROPY_HAS_DRIVER
 	default y
 	help

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.soc
@@ -66,11 +66,6 @@ config SOC_NRF9160_SICA
 
 endchoice
 
-config GPIO_AS_PINRESET
-	bool "GPIO as pin reset (reset button)"
-	depends on SOC_SERIES_NRF91X
-	default y
-
 config NRF_ENABLE_ICACHE
 	bool "Enable the instruction cache (I-Cache)"
 	depends on SOC_NRF9160


### PR DESCRIPTION
This PR contains two patches that remove a couple of entries from default configurations for the `nrf9160_pca10090` board. These entries do not make much sense for this board, as the corresponding features are not present in the nRF9160 chip.

**drivers: entropy: nrf5: Fix dependency of the enabling Kconfig option**

This driver makes use of the nRF RNG peripheral, so it can be used only
for SoCs that are equipped with one, and not all nRF SoCs are.
The option enabling the driver should then depend on `HAS_HW_NRF_RNG`,
which indicates the presence of this peripheral in a given SoC.

This patch removes also entries disabling this driver in default
configurations for nRF9160 SoC, as these were needed only because
of the invalid dependency of the ENTROPY_NRF5_RNG option.

A minor adjustment of Kconfig files of the nrf52_bsim board was
required as well, so that this board's configuration can properly
handle this corrected dependency.

**soc: nrf9160: Remove unsupported Kconfig option GPIO_AS_PINRESET**

In nRF9160 the reset pin is a dedicated one, it cannot be configured
as a regular GPIO pin, so this option should not be presented to users
building for this SoC, to not generate confusion.