### PR TITLE
scripts: kconfig: normalize paths to avoid duplicate

### DIFF
--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -184,6 +184,7 @@ def promptless(sym):
 
     return not any(node.prompt for node in sym.nodes)
 
+
 def write_kconfig_filenames(paths, root_path, output_file_path):
     # 'paths' is a list of paths. The list has duplicates and the
     # paths are either absolute or relative to 'root_path'.
@@ -191,24 +192,20 @@ def write_kconfig_filenames(paths, root_path, output_file_path):
     # We need to write this list, in a format that CMake can easily
     # parse, to the output file at 'output_file_path'.
 
-    # The written list should also have absolute paths instead of
-    # relative paths, and it should not have duplicates.
+    # The written list has sorted real (absolute) paths, and it does not have
+    # duplicates. The list is sorted to be deterministic. It is realpath()'d
+    # to ensure that different representations of the same path does not end
+    # up with two entries, as that could cause the build system to fail.
 
-    # Remove duplicates
-    paths_uniq = set(paths)
+    paths_uniq = sorted({os.path.realpath(os.path.join(root_path, path)) for path in paths})
 
     with open(output_file_path, 'w') as out:
-        # sort to be deterministic
-        for path in sorted(paths_uniq):
-            # Change from relative to absolute path (do nothing for
-            # absolute paths)
-            abs_path = os.path.join(root_path, path)
-
+        for path in paths_uniq:
             # Assert that the file exists, since it was sourced, it
             # must surely also exist.
-            assert os.path.isfile(abs_path), "Internal error"
+            assert os.path.isfile(path), "Internal error: '{}' does not exist".format(path)
 
-            out.write("{}\n".format(abs_path))
+            out.write("{}\n".format(path))
 
 
 def parse_args():


### PR DESCRIPTION
There is a bug where non-normalized paths can introduce multiple entries
for the same file. E.g. '/1/2/../2.file' and '/1/2/3/../../2.file' would
both be listed, and end in a ninja error because multiple targets
generate the same file.

This commit fixes this issue by normalizing the paths.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>