### PR TITLE
debug: openocd: Fix building for SMP platforms

### DIFF
--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -273,6 +273,7 @@ config EXCEPTION_STACK_TRACE
 
 config OPENOCD_SUPPORT
 	bool "OpenOCD support [EXPERIMENTAL]"
+	depends on !SMP
 	select THREAD_MONITOR
 	select THREAD_NAME
 	help


### PR DESCRIPTION
struct k_thread *current is only defined for !SMP platforms
leading to the following build-time failure:

| openocd.c:39:35: error: 'struct z_kernel' has no member named 'current'
|  [OPENOCD_OFFSET_K_CURR_THREAD] = offsetof(struct z_kernel, current),
                                   ^~~~~~~~

Disable calculation of meaningless offset then.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/18124.