### PR TITLE
dts: bindings: pwm: nxp: Fix missing copyright/license

### DIFF
--- a/dts/bindings/pwm/nxp,flexpwm.yaml
+++ b/dts/bindings/pwm/nxp,flexpwm.yaml
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2019, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 title: MCUX PWM
 
 description: >

--- a/dts/bindings/pwm/nxp,imx-pwm.yaml
+++ b/dts/bindings/pwm/nxp,imx-pwm.yaml
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2019, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 title: MCUX PWM
 
 description: >


### PR DESCRIPTION
Fix nxp,flexpwm and imx-pwm yaml files.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>