### PR TITLE
dts: rv32m1: Rework interrupt mux dts descriptions

### DIFF
--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux-ch.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux-ch.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2019, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+title: RV32M1 INTMUX Channel
+
+description: >
+    This binding describes the RV32M1 INTMUX Channel
+
+compatible: "openisa,rv32m1-intmux-ch"
+
+include: [interrupt-controller.yaml, base.yaml]
+
+properties:
+  reg:
+      required: true
+
+  label:
+      required: true
+
+  interrupts:
+      required: true
+
+"#cells":
+  - irq

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "openisa,rv32m1-intmux"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: base.yaml
 
 properties:
   reg:
@@ -16,12 +16,3 @@ properties:
 
   label:
       required: true
-
-  interrupts:
-      required: true
-
-  "#interrupt-cells":
-      const: 1
-
-"#cells":
-  - irq

--- a/dts/riscv/rv32m1.dtsi
+++ b/dts/riscv/rv32m1.dtsi
@@ -94,24 +94,188 @@
 			reg = <0x4101f000 0x88>;
 		};
 
-		intmux0: interrupt-controller@4004f000 {
+		intmux0: intmux@4004f000 {
 			compatible = "openisa,rv32m1-intmux";
-			#interrupt-cells = <1>;
-			interrupt-controller;
-			reg = <0x4004f000 0x20>;
+			reg = <0x4004f000 0x200>;
 			clocks = <&pcc0 0x13c>;
 			label = "INTMUX0";
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			ranges = <0x0 0x4004f000 0x200>;
+
+			intmux0_ch0: interrupt-controller@0 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH0_IRQ>;
+				reg = <0x0 0x40>;
+				label = "INTMUX0_CH0";
+				status = "disabled";
+			};
+
+			intmux0_ch1: interrupt-controller@40 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH1_IRQ>;
+				reg = <0x40 0x40>;
+				label = "INTMUX0_CH1";
+				status = "disabled";
+			};
+
+			intmux0_ch2: interrupt-controller@80 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH2_IRQ>;
+				reg = <0x80 0x40>;
+				label = "INTMUX0_CH2";
+				status = "disabled";
+			};
+
+			intmux0_ch3: interrupt-controller@c0 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH3_IRQ>;
+				reg = <0xc0 0x40>;
+				label = "INTMUX0_CH3";
+				status = "disabled";
+			};
+
+			intmux0_ch4: interrupt-controller@100 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH4_IRQ>;
+				reg = <0x100 0x40>;
+				label = "INTMUX0_CH4";
+				status = "disabled";
+			};
+
+			intmux0_ch5: interrupt-controller@140 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH5_IRQ>;
+				reg = <0x140 0x40>;
+				label = "INTMUX0_CH5";
+				status = "disabled";
+			};
+
+			intmux0_ch6: interrupt-controller@180 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH6_IRQ>;
+				reg = <0x180 0x40>;
+				label = "INTMUX0_CH6";
+				status = "disabled";
+			};
+
+			intmux0_ch7: interrupt-controller@1c0 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH7_IRQ>;
+				reg = <0x1c0 0x40>;
+				label = "INTMUX0_CH7";
+				status = "disabled";
+			};
 		};
 
-		intmux1: interrupt-controller@41022000 {
+		intmux1: intmux@41022000 {
 			compatible = "openisa,rv32m1-intmux";
-			#interrupt-cells = <1>;
-			interrupt-controller;
 			reg = <0x41022000 0x20>;
 			clocks = <&pcc1 0x88>;
 			label = "INTMUX1";
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			ranges = <0x0 0x41022000 0x200>;
+
+			intmux1_ch0: interrupt-controller@0 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH0_IRQ>;
+				reg = <0x0 0x40>;
+				label = "INTMUX1_CH0";
+				status = "disabled";
+			};
+
+			intmux1_ch1: interrupt-controller@40 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH1_IRQ>;
+				reg = <0x40 0x40>;
+				label = "INTMUX1_CH1";
+				status = "disabled";
+			};
+
+			intmux1_ch2: interrupt-controller@80 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH2_IRQ>;
+				reg = <0x80 0x40>;
+				label = "INTMUX1_CH2";
+				status = "disabled";
+			};
+
+			intmux1_ch3: interrupt-controller@c0 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH3_IRQ>;
+				reg = <0xc0 0x40>;
+				label = "INTMUX1_CH3";
+				status = "disabled";
+			};
+
+			intmux1_ch4: interrupt-controller@100 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH4_IRQ>;
+				reg = <0x100 0x40>;
+				label = "INTMUX1_CH4";
+				status = "disabled";
+			};
+
+			intmux1_ch5: interrupt-controller@140 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH5_IRQ>;
+				reg = <0x140 0x40>;
+				label = "INTMUX1_CH5";
+				status = "disabled";
+			};
+
+			intmux1_ch6: interrupt-controller@180 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH6_IRQ>;
+				reg = <0x180 0x40>;
+				label = "INTMUX1_CH6";
+				status = "disabled";
+			};
+
+			intmux1_ch7: interrupt-controller@1c0 {
+				compatible = "openisa,rv32m1-intmux-ch";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+				interrupts = <INTMUX_CH7_IRQ>;
+				reg = <0x1c0 0x40>;
+				label = "INTMUX1_CH7";
+				status = "disabled";
+			};
 		};
 
 		lptmr0: timer@40032000 {

--- a/dts/riscv/rv32m1_ri5cy.dtsi
+++ b/dts/riscv/rv32m1_ri5cy.dtsi
@@ -52,23 +52,57 @@
  */
 
 &intmux0 {
-	interrupt-parent = <&event0>;
-	interrupts = <INTMUX_CH0_IRQ>, <INTMUX_CH1_IRQ>, <INTMUX_CH2_IRQ>, <INTMUX_CH3_IRQ>, <INTMUX_CH4_IRQ>, <INTMUX_CH5_IRQ>, <INTMUX_CH6_IRQ>, <INTMUX_CH7_IRQ>;
 	status = "okay";
 };
 
+&intmux0_ch0 {
+	interrupt-parent = <&event0>;
+	status = "okay";
+};
+
+&intmux0_ch1 {
+	interrupt-parent = <&event0>;
+	status = "okay";
+};
+
+&intmux0_ch2 {
+	interrupt-parent = <&event0>;
+};
+
+&intmux0_ch3 {
+	interrupt-parent = <&event0>;
+};
+
+&intmux0_ch4 {
+	interrupt-parent = <&event0>;
+};
+
+&intmux0_ch5 {
+	interrupt-parent = <&event0>;
+};
+
+&intmux0_ch6 {
+	interrupt-parent = <&event0>;
+};
+
+&intmux0_ch7 {
+	interrupt-parent = <&event0>;
+};
+
+/delete-node/ &intmux1;
+
 &lptmr0 {
-	interrupt-parent = <&intmux0>;
+	interrupt-parent = <&intmux0_ch0>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH0, 7)>;
 };
 
 &lptmr1 {
-	interrupt-parent = <&intmux0>;
+	interrupt-parent = <&intmux0_ch1>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH1, 8)>;
 };
 
 &lptmr2 {
-	interrupt-parent = <&intmux0>;
+	interrupt-parent = <&intmux0_ch1>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH1, 22)>;
 };
 
@@ -78,22 +112,22 @@
 };
 
 &gpiob {
-	interrupt-parent = <&intmux0>;
+	interrupt-parent = <&intmux0_ch1>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH1, 15)>;
 };
 
 &gpioc {
-	interrupt-parent = <&intmux0>;
+	interrupt-parent = <&intmux0_ch1>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH1, 16)>;
 };
 
 &gpiod {
-	interrupt-parent = <&intmux0>;
+	interrupt-parent = <&intmux0_ch1>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH1, 17)>;
 };
 
 &gpioe {
-	interrupt-parent = <&intmux0>;
+	interrupt-parent = <&intmux0_ch1>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH1, 27)>;
 };
 
@@ -103,17 +137,17 @@
 };
 
 &uart1 {
-	interrupt-parent = <&intmux0>;
+	interrupt-parent = <&intmux0_ch1>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH1, 13)>;
 };
 
 &uart2 {
-	interrupt-parent = <&intmux0>;
+	interrupt-parent = <&intmux0_ch1>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH1, 14)>;
 };
 
 &uart3 {
-	interrupt-parent = <&intmux0>;
+	interrupt-parent = <&intmux0_ch1>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH1, 26)>;
 };
 
@@ -128,11 +162,11 @@
 };
 
 &i2c2 {
-	interrupt-parent = <&intmux0>;
+	interrupt-parent = <&intmux0_ch1>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH1, 11)>;
 };
 
 &i2c3 {
-	interrupt-parent = <&intmux0>;
+	interrupt-parent = <&intmux0_ch1>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH1, 24)>;
 };

--- a/dts/riscv/rv32m1_zero_riscy.dtsi
+++ b/dts/riscv/rv32m1_zero_riscy.dtsi
@@ -51,19 +51,52 @@
  * disabling channels can add up.
  */
 
+/delete-node/ &intmux0;
+
 &intmux1 {
-	interrupt-parent = <&event1>;
-	interrupts = <INTMUX_CH0_IRQ>, <INTMUX_CH1_IRQ>, <INTMUX_CH2_IRQ>, <INTMUX_CH3_IRQ>, <INTMUX_CH4_IRQ>, <INTMUX_CH5_IRQ>, <INTMUX_CH6_IRQ>, <INTMUX_CH7_IRQ>;
 	status = "okay";
 };
 
+&intmux1_ch0 {
+	interrupt-parent = <&event1>;
+	status = "okay";
+};
+
+&intmux1_ch1 {
+	interrupt-parent = <&event1>;
+};
+
+&intmux1_ch2 {
+	interrupt-parent = <&event1>;
+};
+
+&intmux1_ch3 {
+	interrupt-parent = <&event1>;
+};
+
+&intmux1_ch4 {
+	interrupt-parent = <&event1>;
+};
+
+&intmux1_ch5 {
+	interrupt-parent = <&event1>;
+};
+
+&intmux1_ch6 {
+	interrupt-parent = <&event1>;
+};
+
+&intmux1_ch7 {
+	interrupt-parent = <&event1>;
+};
+
 &lptmr0 {
-	interrupt-parent = <&intmux1>;
+	interrupt-parent = <&intmux1_ch0>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH0, 6)>;
 };
 
 &lptmr1 {
-	interrupt-parent = <&intmux1>;
+	interrupt-parent = <&intmux1_ch0>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH0, 7)>;
 };
 
@@ -73,22 +106,22 @@
 };
 
 &gpioa {
-	interrupt-parent = <&intmux1>;
+	interrupt-parent = <&intmux1_ch0>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH0, 25)>;
 };
 
 &gpiob {
-	interrupt-parent = <&intmux1>;
+	interrupt-parent = <&intmux1_ch0>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH0, 26)>;
 };
 
 &gpioc {
-	interrupt-parent = <&intmux1>;
+	interrupt-parent = <&intmux1_ch0>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH0, 27)>;
 };
 
 &gpiod {
-	interrupt-parent = <&intmux1>;
+	interrupt-parent = <&intmux1_ch0>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH0, 28)>;
 };
 
@@ -98,17 +131,17 @@
 };
 
 &uart0 {
-	interrupt-parent = <&intmux1>;
+	interrupt-parent = <&intmux1_ch0>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH0, 21)>;
 };
 
 &uart1 {
-	interrupt-parent = <&intmux1>;
+	interrupt-parent = <&intmux1_ch0>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH0, 22)>;
 };
 
 &uart2 {
-	interrupt-parent = <&intmux1>;
+	interrupt-parent = <&intmux1_ch0>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH0, 23)>;
 };
 
@@ -118,17 +151,17 @@
 };
 
 &i2c0 {
-	interrupt-parent = <&intmux1>;
+	interrupt-parent = <&intmux1_ch0>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH0, 13)>;
 };
 
 &i2c1 {
-	interrupt-parent = <&intmux1>;
+	interrupt-parent = <&intmux1_ch0>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH0, 14)>;
 };
 
 &i2c2 {
-	interrupt-parent = <&intmux1>;
+	interrupt-parent = <&intmux1_ch0>;
 	interrupts = <INTMUX_LEVEL2_IRQ(INTMUX_CH0, 15)>;
 };
 


### PR DESCRIPTION
Each intmux block acts like 8 interrupt controllers in which we can
have multiple device interrupts on a single channel and that channel
than interrupt than chained to another interrupt controller (in the
case of the RISC-V cores, it is the event unit).

So to describe things better to properly be able to walk the interrupt
chain in the device tree we treat each channel in the interrupt mux as
an interrupt controller rather than the intmux as a single interrupt
controller.

In the future this will allow the device tree generation code to walk
the interrupt chain from the device and up through any interrupt
controllers to generate the IRQ value that Zephyr expects (rather than
us hard coding this into the DTS).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>