### PR TITLE
dts/gen_defines.py: Use err() instead of _err()

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -188,7 +188,7 @@ def write_bus(dev):
         return
 
     if dev.parent.label is None:
-        _err("missing 'label' property on {!r}".format(dev.parent))
+        err("missing 'label' property on {!r}".format(dev.parent))
 
     # #define DT_<DEV-IDENT>_BUS_NAME <BUS-LABEL>
     out_dev_s(dev, "BUS_NAME", str2ident(dev.parent.label))


### PR DESCRIPTION
_err comes from edtlib and we should be using err() inside of
gen_defines.py.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>