### PR TITLE
arch: arc: the caculation of exception stack is wrong

### DIFF
--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -65,9 +65,9 @@ _exc_entry:
 	 * and exception is raised, then here it's guaranteed that
 	 * exception handling has necessary stack to use
 	 */
-	mov_s ilink, sp
+	mov ilink, sp
 	_get_curr_cpu_irq_stack sp
-	add sp, sp, EXCEPTION_STACK_SIZE
+	sub sp, sp, (CONFIG_ISR_STACK_SIZE - EXCEPTION_STACK_SIZE)
 
 	/*
 	 * save caller saved registers


### PR DESCRIPTION
after appling the new "_get_curr_cpu_irq_stack" in _exc_entry,
the caculation of exception stack is wrong, this will
cause stack overflow, make the exception handling corrupt.

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>

Fixes #18141 

I ran full sanitycheck tests on nsim_em and nsim_sem.
The results are expected 

