### PR TITLE
Settings: align NVS read calback return value to the expectation

### DIFF
--- a/include/settings/settings.h
+++ b/include/settings/settings.h
@@ -34,6 +34,19 @@ extern "C" {
  */
 #define SETTINGS_EXTRA_LEN ((SETTINGS_MAX_DIR_DEPTH - 1) + 2)
 
+/**
+ * Function used to read the data from the settings storage in
+ * h_set handler implementations.
+ *
+ * @param[in] cb_arg  arguments for the read function. Appropriate cb_arg is
+ *                    transferred to h_set handler implementation by
+ *                    the backend.
+ * @param[out] data  the destination buffer
+ * @param[in] len    length of read
+ *
+ * @return positive: Number of bytes read, 0: key-value pair is deleted.
+ *                   On error returns -ERRNO code.
+ */
 typedef ssize_t (*settings_read_cb)(void *cb_arg, void *data, size_t len);
 
 /**

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -32,10 +32,18 @@ static struct settings_store_itf settings_nvs_itf = {
 static ssize_t settings_nvs_read_fn(void *back_end, void *data, size_t len)
 {
 	struct settings_nvs_read_fn_arg *rd_fn_arg;
+	ssize_t rc;
 
 	rd_fn_arg = (struct settings_nvs_read_fn_arg *)back_end;
 
-	return nvs_read(rd_fn_arg->fs, rd_fn_arg->id, data, len);
+	rc = nvs_read(rd_fn_arg->fs, rd_fn_arg->id, data, len);
+	if (rc > len) {
+		/* nvs_read signals that not all bytes were read
+		 * align read len to what was requested
+		 */
+		rc = len;
+	}
+	return rc;
 }
 
 int settings_nvs_src(struct settings_nvs *cf)


### PR DESCRIPTION
- clarify expectation by doxygen addition
- align NVS backend implementation to the expectation.