### PR TITLE
gpio: stm32: support disabling and reenabling interrupts on pin

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -288,8 +288,11 @@ static int gpio_stm32_config(struct device *dev, int access_op,
 		return -EIO;
 	}
 
-	if (IS_ENABLED(CONFIG_EXTI_STM32) && (flags & GPIO_INT) != 0) {
+	if (!IS_ENABLED(CONFIG_EXTI_STM32)) {
+		goto release_lock;
+	}
 
+	if (flags & GPIO_INT) {
 		if (stm32_exti_set_callback(pin, cfg->port,
 					    gpio_stm32_isr, dev) != 0) {
 			return -EBUSY;
@@ -318,9 +321,12 @@ static int gpio_stm32_config(struct device *dev, int access_op,
 		if (stm32_exti_enable(pin) != 0) {
 			return -ENOSYS;
 		}
-
+	} else {
+		stm32_exti_disable(pin);
+		stm32_exti_unset_callback(pin);
 	}
 
+release_lock:
 #if defined(CONFIG_STM32H7_DUAL_CORE)
 	LL_HSEM_ReleaseLock(HSEM, LL_HSEM_ID_1, 0);
 #endif /* CONFIG_STM32H7_DUAL_CORE */


### PR DESCRIPTION
Up to now interrupts could be only configured once, with no way to
disable them in runtime.

Allow interrupts to be disabled in runtime and then properly reenabled
on user request. This allows to ignore interrupts when software is not
expecting them.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>