### PR TITLE
gpio: stm32: fix build for stm32l0x with no GPIOH

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -228,7 +228,7 @@ const int gpio_stm32_enable_int(int port, int pin)
 	line = (0xF << ((pin % 4 * 4) + 16)) | (pin / 4);
 #endif
 
-#ifdef CONFIG_SOC_SERIES_STM32L0X
+#if defined(CONFIG_SOC_SERIES_STM32L0X) && defined(LL_SYSCFG_EXTI_PORTH)
 	/*
 	 * Ports F and G are not present on some STM32L0 parts, so
 	 * for these parts port H external interrupt should be enabled


### PR DESCRIPTION
Some smaller stm32l0x MCUs, such as stm32l011x, do not have GPIOH
port. Fix build for those by checking LL_SYSCFG_EXTI_PORTH macro.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>