### PR TITLE
dts: Add base binding for interrupt-controller, clock, gpio, gpio-nexus, and fixup pwm base

### DIFF
--- a/dts/bindings/arm/nxp,kinetis-mcg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-mcg.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the NXP Kinetis MCG IP node
 
 inherits:
-    !include base.yaml
+    !include [clock.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/arm/nxp,kinetis-pcc.yaml
+++ b/dts/bindings/arm/nxp,kinetis-pcc.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the NXP Kinetis PCC IP node
 
 inherits:
-    !include base.yaml
+    !include [clock.yaml, base.yaml]
 
 properties:
     compatible:
@@ -23,8 +23,6 @@ properties:
       category: required
 
     "#clock-cells":
-      type: int
-      category: required
       description: should be 1.
 
 "#cells":

--- a/dts/bindings/arm/nxp,kinetis-scg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-scg.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the NXP Kinetis SCG IP node
 
 inherits:
-    !include base.yaml
+    !include [clock.yaml, base.yaml]
 
 properties:
     compatible:
@@ -123,8 +123,6 @@ properties:
       category: optional
 
     "#clock-cells":
-      type: int
-      category: required
       description: should be 1.
 
 "#cells":

--- a/dts/bindings/clock/clock.yaml
+++ b/dts/bindings/clock/clock.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2019, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+title: Clock Controller Base Structure
+
+description: >
+    This binding gives the base structure for all Clock Controller devices
+
+properties:
+    "#clock-cells":
+      type: int
+      category: required
+      description: Number of items to expect in a Clock specifier

--- a/dts/bindings/clock/fixed-clock.yaml
+++ b/dts/bindings/clock/fixed-clock.yaml
@@ -9,6 +9,9 @@ title: Generic fixed rate clock provider
 description: >
     This is a representation of a generic fixed rate clock provider.
 
+inherits:
+    !include clock.yaml
+
 properties:
     compatible:
       type: string
@@ -32,6 +35,4 @@ properties:
       description: input clock source
 
     "#clock-cells":
-      type: int
-      category: required
       description: should be 0.

--- a/dts/bindings/clock/nxp,imx-ccm.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the i.MX CCM IP node
 
 inherits:
-    !include base.yaml
+    !include [clock.yaml, base.yaml]
 
 properties:
     compatible:
@@ -23,8 +23,6 @@ properties:
       category: required
 
     "#clock-cells":
-      type: int
-      category: required
       description: should be 3.
 
 "#cells":

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -4,7 +4,7 @@ description: >
     This binding gives a base representation of the STM32 Clock control
 
 inherits:
-    !include base.yaml
+    !include [clock.yaml, base.yaml]
 
 properties:
     compatible:
@@ -14,8 +14,6 @@ properties:
       category: required
 
     "#clock-cells":
-      type: int
-      category: required
       description: should be 2.
 
 "#cells":

--- a/dts/bindings/gpio/arduino-header-r3.yaml
+++ b/dts/bindings/gpio/arduino-header-r3.yaml
@@ -10,12 +10,8 @@ description: >
     This is a representation of GPIO pin nodes exposed as headers on Arduino R3
 
 inherits:
-    !include base.yaml
+    !include [gpio-nexus.yaml, base.yaml]
 
 properties:
     compatible:
       constraint: "arduino-header-r3"
-
-    gpio-map:
-      type: compound
-      category: required

--- a/dts/bindings/gpio/arm,cmsdk-gpio.yaml
+++ b/dts/bindings/gpio/arm,cmsdk-gpio.yaml
@@ -4,7 +4,7 @@ description: >
     This binding gives a base representation of the ARM CMSDK GPIO
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/atmel,sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam-gpio.yaml
@@ -4,7 +4,7 @@ description: >
     This is a representation of the SAM GPIO PORT nodes
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/atmel,sam0-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam0-gpio.yaml
@@ -4,7 +4,7 @@ description: >
     This is a representation of the SAM0 GPIO PORT nodes
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/gpio-controller.yaml
+++ b/dts/bindings/gpio/gpio-controller.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2019, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+title: GPIO Controller Base Structure
+
+description: >
+    This binding gives the base structure for all GPIO Controller devices
+
+properties:
+    "gpio-controller":
+      type: boolean
+      category: required
+      description: Convey's this node is a GPIO controller
+    "#gpio-cells":
+      type: int
+      category: required
+      description: Number of items to expect in a GPIO specifier

--- a/dts/bindings/gpio/gpio-nexus.yaml
+++ b/dts/bindings/gpio/gpio-nexus.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2019, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+title: GPIO Nexus Base Structure
+
+description: >
+    This binding gives the base structure for all GPIO nexus nodes
+
+properties:
+    gpio-map:
+      type: compound
+      category: required
+
+    gpio-map-mask:
+      type: compound
+      category: optional
+
+    gpio-map-pass-thru:
+      type: compound
+      category: optional
+
+    "#gpio-cells":
+      type: int
+      category: required
+      description: Number of items to expect in a GPIO specifier

--- a/dts/bindings/gpio/intel,apl-gpio.yaml
+++ b/dts/bindings/gpio/intel,apl-gpio.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the Intel Apollo Lake GPIO node
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/intel,qmsi-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-gpio.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the Intel QMSI GPIO nodes
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the Intel QMSI SS GPIO nodes
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/microchip,xec-gpio.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio.yaml
@@ -11,7 +11,7 @@ description: >
     This is a representation of the CEC/MEC GPIO nodes for Microchip
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the NRF GPIO nodes
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the i.MX GPIO nodes
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -4,7 +4,7 @@ description: >
     This is a representation of the Kinetis GPIO nodes
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
+++ b/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
@@ -4,7 +4,7 @@ description: >
     This is a representation of the OpenISA GPIO nodes
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
@@ -10,7 +10,7 @@ description: >
         This is a representation of the SX1509B GPIO node
 
 inherits:
-    !include i2c-device.yaml
+    !include [i2c-device.yaml, gpio-controller.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/sifive,gpio0.yaml
+++ b/dts/bindings/gpio/sifive,gpio0.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the SiFive GPIO nodes
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
@@ -4,7 +4,7 @@ description: >
     This is a representation of the EFM32 GPIO Port nodes
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
@@ -4,7 +4,7 @@ description: >
     This is a representation of the EFR32MG GPIO Port nodes
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
@@ -4,7 +4,7 @@ description: >
     This is a representation of the EFR32XG1 GPIO Port nodes
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the Synopsys DesignWare gpio node
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the STM32 GPIO nodes
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the TI SimpleLink CC13xx / CC26xx GPIO node
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/ti,cc2650-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc2650-gpio.yaml
@@ -5,7 +5,7 @@ description: >
     This is a representation of the TI CC2650 GPIO node
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/ti,cc32xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc32xx-gpio.yaml
@@ -5,7 +5,7 @@ description: >
     This is a representation of the TI CC32XX GPIO node
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/gpio/ti,stellaris-gpio.yaml
+++ b/dts/bindings/gpio/ti,stellaris-gpio.yaml
@@ -5,7 +5,7 @@ description: >
     This is a representation of the TI Stellaris GPIO node
 
 inherits:
-    !include base.yaml
+    !include [gpio-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
@@ -4,7 +4,7 @@ description: >
     This binding describes the ARMv6-M Nested Vectored Interrupt Controller.
 
 inherits:
-    !include base.yaml
+    !include [interrupt-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
@@ -4,7 +4,7 @@ description: >
     This binding describes the ARMv7-M Nested Vectored Interrupt Controller.
 
 inherits:
-    !include base.yaml
+    !include [interrupt-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
@@ -4,7 +4,7 @@ description: >
     This binding describes the ARMv8-M Nested Vectored Interrupt Controller.
 
 inherits:
-    !include base.yaml
+    !include [interrupt-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/interrupt-controller/intel,ioapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,ioapic.yaml
@@ -5,7 +5,7 @@ description: >
     controller
 
 inherits:
-    !include base.yaml
+    !include [interrupt-controller.yaml, base.yaml]
 
 properties:
   compatible:

--- a/dts/bindings/interrupt-controller/interrupt-controller.yaml
+++ b/dts/bindings/interrupt-controller/interrupt-controller.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2019, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+title: Interrupt Controller Base Structure
+
+description: >
+    This binding gives the base structure for all Interrupt Controller devices
+
+properties:
+    "interrupt-controller":
+      type: boolean
+      category: required
+      description: Convey's this node is an interrupt controller
+    "#interrupt-cells":
+      type: int
+      category: required
+      description: Number of items to expect in an interrupt specifier

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
@@ -11,7 +11,7 @@ description: >
     This binding describes the RV32M1 Event Unit
 
 inherits:
-    !include base.yaml
+    !include [interrupt-controller.yaml, base.yaml]
 
 properties:
   compatible:

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
@@ -10,7 +10,7 @@ description: >
     This binding describes the RV32M1 INTMUX IP
 
 inherits:
-    !include base.yaml
+    !include [interrupt-controller.yaml, base.yaml]
 
 properties:
   compatible:

--- a/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
+++ b/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
@@ -10,7 +10,7 @@ description: >
     This binding describes the RISC-V CPU Interrupt Controller
 
 inherits:
-    !include base.yaml
+    !include [interrupt-controller.yaml, base.yaml]
 
 properties:
   compatible:

--- a/dts/bindings/interrupt-controller/riscv,plic0.yaml
+++ b/dts/bindings/interrupt-controller/riscv,plic0.yaml
@@ -10,7 +10,7 @@ description: >
     This binding describes the RISC-V Platform-Local Interrupt Controller
 
 inherits:
-    !include base.yaml
+    !include [interrupt-controller.yaml, base.yaml]
 
 properties:
   reg:

--- a/dts/bindings/interrupt-controller/shared-irq.yaml
+++ b/dts/bindings/interrupt-controller/shared-irq.yaml
@@ -4,7 +4,7 @@ description: >
     This binding describes Shared IRQ interrupt dispatcher
 
 inherits:
-    !include base.yaml
+    !include [interrupt-controller.yaml, base.yaml]
 
 properties:
   compatible:

--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -10,7 +10,7 @@ description: >
     This binding describes the ARCV2 IRQ controller
 
 inherits:
-    !include base.yaml
+    !include [interrupt-controller.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/interrupt-controller/snps,designware-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,designware-intc.yaml
@@ -4,7 +4,7 @@ description: >
     This binding describes DesignWare Programmable Interrupt controller
 
 inherits:
-    !include base.yaml
+    !include [interrupt-controller.yaml, base.yaml]
 
 properties:
   compatible:

--- a/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
+++ b/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
@@ -10,7 +10,7 @@ description: >
     This binding describes LiteX VexRiscV Interrupt Controller
 
 inherits:
-    !include base.yaml
+    !include [interrupt-controller.yaml, base.yaml]
 
 properties:
   compatible:

--- a/dts/bindings/interrupt-controller/xtensa,intc.yaml
+++ b/dts/bindings/interrupt-controller/xtensa,intc.yaml
@@ -4,7 +4,7 @@ description: >
     This binding describes Xtensa Core Interrupt controller
 
 inherits:
-    !include base.yaml
+    !include [interrupt-controller.yaml, base.yaml]
 
 properties:
   compatible:

--- a/dts/bindings/pwm/atmel,sam-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam-pwm.yaml
@@ -10,7 +10,7 @@ description: >
     This binding gives a base representation of the Atmel SAM PWM
 
 inherits:
-    !include pwm.yaml
+    !include [pwm.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/pwm/fsl,imx7d-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx7d-pwm.yaml
@@ -10,7 +10,7 @@ description: >
     This binding gives a base representation of the i.MX7D PWM
 
 inherits:
-    !include pwm.yaml
+    !include [pwm.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/pwm/nxp,imx-pwm.yaml
+++ b/dts/bindings/pwm/nxp,imx-pwm.yaml
@@ -10,7 +10,7 @@ description: >
     This binding gives a base representation of the NXP MCUX PWM
 
 inherits:
-    !include base.yaml
+    !include [pwm.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -10,7 +10,7 @@ description: >
     This binding gives a base representation of the Kinetis FTM
 
 inherits:
-    !include pwm.yaml
+    !include [pwm.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/pwm/pwm.yaml
+++ b/dts/bindings/pwm/pwm.yaml
@@ -9,9 +9,6 @@ title: PWM Base Structure
 description: >
     This binding gives the base structures for all PWM devices
 
-inherits:
-    !include base.yaml
-
 properties:
     label:
       category: required

--- a/dts/bindings/pwm/pwm.yaml
+++ b/dts/bindings/pwm/pwm.yaml
@@ -15,3 +15,8 @@ inherits:
 properties:
     label:
       category: required
+
+    "#pwm-cells":
+      type: int
+      category: required
+      description: Number of items to expect in a pwm specifier

--- a/dts/bindings/pwm/sifive,pwm0.yaml
+++ b/dts/bindings/pwm/sifive,pwm0.yaml
@@ -10,7 +10,7 @@ description: >
     This binding gives a base representation of the SiFive PWM
 
 inherits:
-    !include pwm.yaml
+    !include [pwm.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -4,7 +4,7 @@ description: >
     This binding gives a base representation of the STM32 PWM
 
 inherits:
-    !include base.yaml
+    !include [pwm.yaml, base.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
+++ b/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
@@ -10,7 +10,7 @@ description: >
     This is a representation of the RV32M1 PCC IP node
 
 inherits:
-    !include base.yaml
+    !include [clock.yaml, base.yaml]
 
 properties:
     compatible:

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -154,7 +154,7 @@ def write_props(dev):
             continue
 
         # Skip properties that we handle elsewhere
-        if prop.name in {"reg", "interrupts", "compatible"}:
+        if prop.name in {"reg", "interrupts", "compatible", "interrupt-controller"}:
             continue
 
         if prop.description is not None:

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -154,7 +154,8 @@ def write_props(dev):
             continue
 
         # Skip properties that we handle elsewhere
-        if prop.name in {"reg", "interrupts", "compatible", "interrupt-controller"}:
+        if prop.name in {"reg", "interrupts", "compatible", "interrupt-controller",
+                "gpio-controller"}:
             continue
 
         if prop.description is not None:


### PR DESCRIPTION
Add base bindings "classes" for interrupt-controller, clock, gpio, and gpio-nexus.  Update the pwm base to match style of the new base bindings and cleanup some additional properties in pwm.