### PR TITLE
dfu: fix printf formatting in img_util

### DIFF
--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -46,15 +46,15 @@ static bool flash_verify(const struct flash_area *fa, off_t offset,
 		size = (len >= sizeof(temp)) ? sizeof(temp) : len;
 		rc = flash_area_read(fa, offset, &temp, size);
 		if (rc) {
-			LOG_ERR("flash_read error %d offset=0x%08x",
-				rc, (u32_t)offset);
+			LOG_ERR("flash_read error %d offset=0x%08lx",
+				rc, (long)offset);
 			break;
 		}
 
 		if (memcmp(data, &temp, size)) {
-			LOG_ERR("offset=0x%08x VERIFY FAIL. "
+			LOG_ERR("offset=0x%08lx VERIFY FAIL. "
 				"expected: 0x%08x, actual: 0x%08x",
-				(u32_t)offset, temp, UNALIGNED_GET(data));
+				(long)offset, temp, UNALIGNED_GET(data));
 			break;
 		}
 		len -= size;
@@ -108,7 +108,8 @@ static int flash_progressive_erase(struct flash_img_context *ctx, off_t off)
 	} else {
 		if (ctx->off_last != sector.fs_off) {
 			ctx->off_last = sector.fs_off;
-			LOG_INF("Erasing sector at offset 0x%x", sector.fs_off);
+			LOG_INF("Erasing sector at offset 0x%08lx",
+				(long)sector.fs_off);
 			rc = flash_area_erase(ctx->flash_area, sector.fs_off,
 					      sector.fs_size);
 			if (rc) {
@@ -139,8 +140,8 @@ static int flash_sync(struct flash_img_context *ctx)
 	rc = flash_area_write(ctx->flash_area, ctx->bytes_written, ctx->buf,
 			      CONFIG_IMG_BLOCK_BUF_SIZE);
 	if (rc) {
-		LOG_ERR("flash_write error %d offset=0x%08x", rc,
-			(u32_t)ctx->bytes_written);
+		LOG_ERR("flash_write error %d offset=0x%08zx", rc,
+			ctx->bytes_written);
 		return rc;
 	}
 


### PR DESCRIPTION
Compiling flash_img.c file with Newlib and CONFIG_IMG_ERASE_PROGRESSIVELY generates a compiler warning due to incorrect formatting of off_t parameter in printf format string.

In flash drivers code located in `drivers/flash/` we always cast `off_t` to `long`. This seems appropriate since all the drivers work on 32-bit systems. However, flash_img.c is supposed to be platform independent. The portable and more appropriate approach would be to cast `off_t` to `intmax_t` and print it as follows
```
printf("0x%jx\n", (intmax_t)offset);
```
That's not very efficient on 32 bit systems though. For now the commit changes casting of all `off_t` parameters to `long`to match the code in `drivers/flash/`.

Detailed list of changes:
- cast values of type off_t to long to remove warnings generated when
  compiling with Newlib and CONFIG_IMG_ERASE_PROGRESSIVELY is enabled
- cast values of type off_t always to long and not u32_t
- use 'z' modifier (as in "%zu") to print values of type size_t