### PR TITLE
drivers: watchdog: Pass timeout in ms if iwdg is started at boot

### DIFF
--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -151,7 +151,7 @@ static int iwdg_stm32_init(struct device *dev)
 #ifdef CONFIG_IWDG_STM32_START_AT_BOOT
 	IWDG_TypeDef *iwdg = IWDG_STM32_STRUCT(dev);
 	struct wdt_timeout_cfg config = {
-		.window.max = CONFIG_IWDG_STM32_TIMEOUT * USEC_PER_MSEC,
+		.window.max = CONFIG_IWDG_STM32_TIMEOUT / USEC_PER_MSEC,
 	};
 
 	LL_IWDG_Enable(iwdg);


### PR DESCRIPTION
	iwdg_stm32_install_timeout expects a timeout passed in
	milli seconds. As the timeout is defined in micro
	seconds in Kconfig.stm32, we need to divide by
	USEC_PER_MSEC when CONFIG_IWDG_START_AT_BOOT is
	activated because iwdg_stm32_install_timeout makes
	the multiplication by USEC_PER_MSEC.

Signed-off-by: Philémon Jaermann <p.jaermann@gmail.com>