### PR TITLE
posix arch/native_posix/nrf52_bsim: Move include files outside of extern "C" block

### DIFF
--- a/arch/posix/include/kernel_arch_data.h
+++ b/arch/posix/include/kernel_arch_data.h
@@ -14,23 +14,10 @@
 #ifndef ZEPHYR_ARCH_POSIX_INCLUDE_KERNEL_ARCH_DATA_H_
 #define ZEPHYR_ARCH_POSIX_INCLUDE_KERNEL_ARCH_DATA_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <kernel_internal.h>
 
 /* stacks */
 #define STACK_ROUND_UP(x) ROUND_UP(x, STACK_ALIGN_SIZE)
 #define STACK_ROUND_DOWN(x) ROUND_DOWN(x, STACK_ALIGN_SIZE)
-
-
-#ifndef _ASMLANGUAGE
-
-#endif /* _ASMLANGUAGE */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* ZEPHYR_ARCH_POSIX_INCLUDE_KERNEL_ARCH_DATA_H_ */

--- a/arch/posix/include/kernel_arch_thread.h
+++ b/arch/posix/include/kernel_arch_thread.h
@@ -23,6 +23,10 @@
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct _callee_saved {
 	/* IRQ status before irq_lock() and call to z_swap() */
 	u32_t key;
@@ -40,6 +44,10 @@ struct _thread_arch {
 };
 
 typedef struct _thread_arch _thread_arch_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ASMLANGUAGE */
 

--- a/arch/posix/include/posix_soc_if.h
+++ b/arch/posix/include/posix_soc_if.h
@@ -15,6 +15,7 @@
  */
 
 #include "posix_trace.h"
+#include "soc_irq.h" /* Must exist and define _ARCH_IRQ/ISR_* macros */
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,9 +23,6 @@ extern "C" {
 
 void posix_halt_cpu(void);
 void posix_atomic_halt_cpu(unsigned int imask);
-
-
-#include "soc_irq.h" /* Must exist and define _ARCH_IRQ/ISR_* macros */
 
 unsigned int z_arch_irq_lock(void);
 void z_arch_irq_unlock(unsigned int key);

--- a/boards/posix/native_posix/native_rtc.h
+++ b/boards/posix/native_posix/native_rtc.h
@@ -15,12 +15,11 @@
 
 #include "hw_models_top.h"
 #include <stdbool.h>
+#include "zephyr/types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "zephyr/types.h"
 
 /*
  * Types of clocks this RTC provides:

--- a/boards/posix/nrf52_bsim/cmdline.h
+++ b/boards/posix/nrf52_bsim/cmdline.h
@@ -17,10 +17,23 @@
  * command line arguments is passed to the nrf52_bsim one
  */
 
+#ifndef BOARDS_POSIX_NRF52_BSIM_CMDLINE_H
+#define BOARDS_POSIX_NRF52_BSIM_CMDLINE_H
+
 #include "../native_posix/cmdline_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 static inline void native_add_command_line_opts(struct args_struct_t *args)
 {
 	void bs_add_extra_dynargs(struct args_struct_t *args);
 	bs_add_extra_dynargs(args);
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARDS_POSIX_NRF52_BSIM_CMDLINE_H */

--- a/include/arch/posix/asm_inline_gcc.h
+++ b/include/arch/posix/asm_inline_gcc.h
@@ -19,11 +19,6 @@
  * Include kernel.h instead
  */
 
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef _ASMLANGUAGE
 
 #include <toolchain/common.h>
@@ -32,11 +27,6 @@ extern "C" {
 #include <arch/common/ffs.h>
 #include "posix_soc_if.h"
 
-
 #endif /* _ASMLANGUAGE */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* ZEPHYR_INCLUDE_ARCH_POSIX_ASM_INLINE_GCC_H_ */


### PR DESCRIPTION
Related to #17997, for the POSIX arch/nrf52_bsim/native_posix:

* Remove some unnecessary extern "C" and ifdef blocks
* Move an include out of one of these blocks
* Add a missing extern "C" block