### PR TITLE
doc: west: Fix west completion docs

### DIFF
--- a/doc/guides/west/install.rst
+++ b/doc/guides/west/install.rst
@@ -41,8 +41,8 @@ completion script and have it sourced every time you enter a new shell session.
 
 To obtain the completion script you can use the ``west completion`` command::
 
-   cd ~
-   west completion bash > west-completion.bash
+   cd /path/to/zephyr/
+   west completion bash > ~/west-completion.bash
 
 .. note::
 


### PR DESCRIPTION
west completion is an extension command, and therefore requires the user
to be in a zephyr installation in order to be available.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>