### PR TITLE
cmake: Don't use -nostdinc with CXX

### DIFF
--- a/cmake/compiler/gcc/target_baremetal.cmake
+++ b/cmake/compiler/gcc/target_baremetal.cmake
@@ -6,6 +6,7 @@ macro(toolchain_cc_nostdinc)
 
   if (NOT CONFIG_NEWLIB_LIBC AND
     NOT COMPILER STREQUAL "xcc" AND
+    NOT CONFIG_CPLUSPLUS AND
     NOT CONFIG_NATIVE_APPLICATION)
     zephyr_compile_options( -nostdinc)
     zephyr_system_include_directories(${NOSTDINC})


### PR DESCRIPTION
It is observed that the C++ standard library headers can not be found
when -nostdinc is used. To fix this we omit -nostdinc when building
for C++.

To reproduce the issue use the latest zephyr master and add

` #include <vector>`

to the list of includes in samples/cpp_synchronization.

Without this fix the sample will not build for for gnuarmemb or the
Zephyr SDK.

This fixes #15603 and uses the fix suggested here: https://github.com/zephyrproject-rtos/zephyr/issues/15603#issuecomment-486820609

