### PR TITLE
dts: dtlib/edtlib: Add a syntax-based type-checking system

### DIFF
--- a/dts/bindings/binding-template.yaml
+++ b/dts/bindings/binding-template.yaml
@@ -56,7 +56,7 @@ sub-node:
 #
 #   <property name>:
 #     category: <required | optional>
-#     type: <string | int | boolean | array | uint8-array | string-array | compound>
+#     type: <string | int | boolean | array | uint8-array | string-array | phandle | compound>
 #     description: <description of the property>
 #     enum:
 #       - <item1>
@@ -64,12 +64,20 @@ sub-node:
 #       ...
 #       - <itemN>
 #
-# 'uint8-array' is our name for what the device tree specification calls
+# 'type: uint8-array' is for what the device tree specification calls
 # 'bytestring'. Properties of type 'uint8-array' should be set like this:
 #
 #   foo = [89 AB CD];
 #
 # Each value is a byte in hex.
+#
+# 'phandle' is for properties that are assigned a single phandle, like this:
+#
+#   foo = <&label>;
+#
+# 'compound' is a catch-all for more complex types, e.g.
+#
+#   foo = <&label1 1 2 &label2 7>;
 properties:
     # An entry for 'compatible' must appear, as it's used to map nodes to
     # bindings

--- a/dts/bindings/usb/st,stm32-otgfs.yaml
+++ b/dts/bindings/usb/st,stm32-otgfs.yaml
@@ -29,7 +29,7 @@ properties:
                    manual defines a shared FIFO size.
 
     phys:
-      type: array
+      type: phandle
       category: optional
       description: PHY provider specifier
 

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -29,7 +29,7 @@ properties:
                    manual defines a shared FIFO size.
 
     phys:
-      type: array
+      type: phandle
       category: optional
       description: PHY provider specifier
 

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -35,7 +35,7 @@ properties:
                    the pull-up resistor on USB Data Positive signal.
 
     phys:
-      type: array
+      type: phandle
       category: optional
       description: PHY provider specifier
 

--- a/scripts/dts/dtlib.py
+++ b/scripts/dts/dtlib.py
@@ -1069,15 +1069,8 @@ class DT:
                                   "include only characters from [0-9a-z-]"
                                   .format(prop.name))
 
-                # Any errors this generates will already point to the property
-                # and /aliases
-                path = prop.to_string()
-
-                try:
-                    alias2node[prop.name] = self.get_node(path)
-                except DTError as e:
-                    raise DTError("/aliases: bad path for '{}': {}"
-                                  .format(prop.name, e))
+                # Property.to_path() already checks that the node exists
+                alias2node[prop.name] = prop.to_path()
 
         self.alias2node = alias2node
 
@@ -1354,6 +1347,32 @@ class Property:
 
       See the to_*() methods for converting the value to other types.
 
+    type:
+      The type of the property, inferred from the syntax used in the
+      assignment. This is one of the following constants (with example
+      assignments):
+
+        Assignment         | Property.type
+        -------------------+------------------------
+        foo;               | dtlib.TYPE_EMPTY
+        foo = []           | dtlib.TYPE_BYTES
+        foo = [01 02]      | dtlib.TYPE_BYTES
+        foo = /bits/ 8 <1> | dtlib.TYPE_BYTES
+        foo = <1>          | dtlib.TYPE_NUM
+        foo = <>           | dtlib.TYPE_NUMS
+        foo = <1 2 3>      | dtlib.TYPE_NUMS
+        foo = <1 2>, <3>   | dtlib.TYPE_NUMS
+        foo = "foo"        | dtlib.TYPE_STRING
+        foo = "foo", "bar" | dtlib.TYPE_STRINGS
+        foo = <&label>     | dtlib.TYPE_PHANDLE
+        foo = &label       | dtlib.TYPE_PATH
+        *Anything else*    | dtlib.TYPE_COMPOUND
+
+      *Anything else* includes properties mixing (<&label>) and node path
+      (&label) references with other data.
+
+      Data labels in the property value do not influence the type.
+
     labels:
       A list with all labels pointing to the property, in the same order as the
       labels appear, but with duplicates removed.
@@ -1394,87 +1413,216 @@ class Property:
         # to be patched in after parsing.
         self._markers = []
 
-    def to_num(self, length=4, signed=False):
+    def to_num(self, signed=False):
         """
-        Returns the property value interpreted as a number.
+        Returns the value of the property as a number.
 
-        length (default: 4):
-          The expected length of the value in bytes. Raises DTError if it has a
-          different length. This is provided as a simple type check.
+        Raises DTError if the property was not assigned with this syntax (has
+        Property.type TYPE_NUM):
 
-          Four bytes is the length of a cell, so the value of e.g.
-          'x = < 73 >;' can be fetched with a plain prop.to_num().
-
-          If 'length' is None, the entire property value is used, with no
-          length check.
+            foo = < 1 >;
 
         signed (default: False):
           If True, the value will be interpreted as signed rather than
           unsigned.
         """
-        try:
-            return to_num(self.value, length, signed)
-        except DTError as e:
-            self._err_with_context(e)
+        if self.type is not TYPE_NUM:
+            raise DTError("expected property '{0}' on {1} in {2} to be "
+                          "assigned with '{0} = < (number) >;', not '{3}'"
+                          .format(self.name, self.node.path,
+                                  self.node.dt.filename, self))
 
-    def to_nums(self, length=4, signed=False):
+        return int.from_bytes(self.value, "big", signed=signed)
+
+    def to_nums(self, signed=False):
         """
-        Returns the property value interpreted as a list of numbers.
+        Returns the value of the property as a list of numbers.
 
-        length (default: 4):
-          The length in bytes of each number. Raises DTError if the length of
-          the value is not a multiple of 'length'.
+        Raises DTError if the property was not assigned with this syntax (has
+        Property.type TYPE_NUM or TYPE_NUMS):
+
+            foo = < 1 2 ... >;
 
         signed (default: False):
           If True, the values will be interpreted as signed rather than
           unsigned.
         """
-        try:
-            return to_nums(self.value, length, signed)
-        except DTError as e:
-            self._err_with_context(e)
+        if self.type not in (TYPE_NUM, TYPE_NUMS):
+            raise DTError("expected property '{0}' on {1} in {2} to be "
+                          "assigned with '{0} = < (number) (number) ... >', "
+                          "not '{3}'"
+                          .format(self.name, self.node.path,
+                                  self.node.dt.filename, self))
+
+        return [int.from_bytes(self.value[i:i + 4], "big", signed=signed)
+                for i in range(0, len(self.value), 4)]
+
+    def to_bytes(self):
+        """
+        Returns the value of the property as a raw 'bytes', like
+        Property.value, except with added type checking.
+
+        Raises DTError if the property was not assigned with this syntax (has
+        Property.type TYPE_BYTES):
+
+            foo = [ 01 ... ];
+        """
+        if self.type is not TYPE_BYTES:
+            raise DTError("expected property '{0}' on {1} in {2} to be "
+                          "assigned with '{0} = [ (byte) (byte) ... ]', "
+                          "not '{3}'".format(self.name, self.node.path,
+                                             self.node.dt.filename, self))
+
+        return self.value
 
     def to_string(self):
         """
-        Returns the property value interpreted as a string.
+        Returns the value of the property as a string.
 
-        Raises DTError if the value is not valid UTF-8, is not null-terminated,
-        or if contains more than one null terminator (the null terminator is
-        stripped from the returned string). Strings in Device Tree (e.g., 'x =
-        "foo"') are implicitly null-terminated.
+        Raises DTError if the property was not assigned with this syntax (has
+        Property.type TYPE_STRING):
+
+            foo = "string";
+
+        This function might also raise UnicodeDecodeError if the string is
+        not valid UTF-8.
         """
+        if self.type is not TYPE_STRING:
+            raise DTError("expected property '{0}' on {1} in {2} to be "
+                          "assigned with '{0} = \"string\"', not '{3}'"
+                          .format(self.name, self.node.path,
+                                  self.node.dt.filename, self))
+
         try:
-            return to_string(self.value)
-        except DTError as e:
-            self._err_with_context(e)
+            return self.value.decode("utf-8")[:-1]  # Strip null
+        except UnicodeDecodeError:
+            raise DTError("value of property '{}' ({}) on {} in {} is not "
+                          "valid UTF-8"
+                          .format(self.name, self.value, self.node.path,
+                                  self.node.dt.filename))
 
     def to_strings(self):
         """
-        Returns the property value interpreted as a list of strings.
+        Returns the value of the property as a list of strings.
 
-        Raises DTError if the value is not valid UTF-8 or is not
-        null-terminated (the null terminators are stripped from the returned
-        string). Strings in Device Tree (e.g., 'x = "foo"') are implicitly
-        null-terminated.
+        Raises DTError if the property was not assigned with this syntax (has
+        Property.type TYPE_STRING or TYPE_STRINGS):
+
+            foo = "string", "string", ... ;
+
+        Also raises DTError if any of the strings are not valid UTF-8.
         """
+        if self.type not in (TYPE_STRING, TYPE_STRINGS):
+            raise DTError("expected property '{0}' on {1} in {2} to be "
+                          "assigned with '{0} = \"string\", \"string\", ...', "
+                          "not {3}"
+                          .format(self.name, self.node.path,
+                                  self.node.dt.filename, self))
+
         try:
-            return to_strings(self.value)
-        except DTError as e:
-            self._err_with_context(e)
+            return self.value.decode("utf-8").split("\0")[:-1]
+        except UnicodeDecodeError:
+            raise DTError("value of property '{}' ({}) on {} in {} is not "
+                          "valid UTF-8"
+                          .format(self.name, self.value, self.node.path,
+                                  self.node.dt.filename))
 
     def to_node(self):
         """
-        Interprets the property value as a phandle and returns the
-        corresponding Node.
+        Returns the Node the phandle in the property points to.
 
-        Raises DTError if the value is not a valid phandle or if no node with
-        that phandle exists.
+        Raises DTError if the property was not assigned with either of these
+        syntaxes (has Property.type TYPE_PHANDLE or TYPE_NUM).
+
+            foo = < &bar >;
+            foo = < 1 >;
+
+        For the second case, DTError is raised if the phandle does not exist.
         """
-        phandle = self.to_num()
+        if self.type not in (TYPE_PHANDLE, TYPE_NUM):
+            raise DTError("expected property '{0}' on {1} in {2} to be "
+                          "assigned with either '{0} = < &foo >' or "
+                          "'{0} = < (valid phandle number) >', not {3}"
+                          .format(self.name, self.node.path,
+                                  self.node.dt.filename, self))
+
+        phandle = int.from_bytes(self.value, "big")
         node = self.node.dt.phandle2node.get(phandle)
         if not node:
-            self._err_with_context("non-existent phandle " + str(phandle))
+            raise DTError("the phandle given in property '{}' ({}) on {} in "
+                          "{} does not exist"
+                          .format(self.name, phandle, self.node.path,
+                                  self.node.dt.filename))
         return node
+
+    def to_path(self):
+        """
+        Returns the Node referenced by the path stored in the property.
+
+        Raises DTError if the property was not assigned with either of these
+        syntaxes (has Property.type TYPE_PATH or TYPE_STRING):
+
+            foo = &bar;
+            foo = "/bar";
+
+        For the second case, DTError is raised if the path does not exist.
+        """
+        if self.type not in (TYPE_PATH, TYPE_STRING):
+            raise DTError("expected property '{0}' on {1} in {2} to be "
+                          "assigned with either '{0} = &foo' or "
+                          "'{0} = \"/path/to/node\"', not '{3}'"
+                          .format(self.name, self.node.path,
+                                  self.node.dt.filename, self))
+
+        try:
+            path = self.value.decode("utf-8")[:-1]
+        except UnicodeDecodeError:
+            raise DTError("value of property '{}' ({}) on {} in {} is not "
+                          "valid UTF-8"
+                          .format(self.name, self.value, self.node.path,
+                                  self.node.dt.filename))
+
+        try:
+            return self.node.dt.get_node(path)
+        except DTError:
+            raise DTError("property '{}' on {} in {} points to the "
+                          'non-existent node "{}"'
+                          .format(self.name, self.node.path,
+                                  self.node.dt.filename, path))
+
+    @property
+    def type(self):
+        """
+        See the class docstring.
+        """
+        # Data labels (e.g. 'foo = label: <3>') are irrelevant, so filter them
+        # out
+        types = [marker[1] for marker in self._markers
+                 if marker[1] != _REF_LABEL]
+
+        if not types:
+            return TYPE_EMPTY
+
+        if types == [_TYPE_UINT8]:
+            return TYPE_BYTES
+
+        if types == [_TYPE_UINT32]:
+            return TYPE_NUM if len(self.value) == 4 else TYPE_NUMS
+
+        # Treat 'foo = <1 2 3>, <4 5>, ...' as TYPE_NUMS too
+        if set(types) == {_TYPE_UINT32}:
+            return TYPE_NUMS
+
+        if set(types) == {_TYPE_STRING}:
+            return TYPE_STRING if len(types) == 1 else TYPE_STRINGS
+
+        if types == [_REF_PATH]:
+            return TYPE_PATH
+
+        if types == [_TYPE_UINT32, _REF_PHANDLE] and len(self.value) == 4:
+            return TYPE_PHANDLE
+
+        return TYPE_COMPOUND
 
     def __str__(self):
         s = "".join(label + ": " for label in self.labels) + self.name
@@ -1492,19 +1640,27 @@ class Property:
             # End of current marker
             end = next_marker[0] if next_marker else len(self.value)
 
-            if marker_type in (_TYPE_STRING, _REF_PATH):
+            if marker_type is _TYPE_STRING:
                 # end - 1 to strip off the null terminator
                 s += ' "{}"'.format(_decode_and_escape(
                     self.value[pos:end - 1]))
                 if end != len(self.value):
                     s += ","
+            elif marker_type is _REF_PATH:
+                s += " &" + ref
+                if end != len(self.value):
+                    s += ","
             else:
-                # Raw data (<>/[])
+                # <> or []
 
                 if marker_type is _REF_LABEL:
                     s += " {}:".format(ref)
-                elif marker_type is not _REF_PHANDLE:
-                    # marker_type is _TYPE_UINT_*
+                elif marker_type is _REF_PHANDLE:
+                    s += " &" + ref
+                    pos += 4
+                    # Subtle: There might be more data between the phandle and
+                    # the next marker, so we can't 'continue' here
+                else:  # marker_type is _TYPE_UINT*
                     elm_size = _TYPE_TO_N_BYTES[marker_type]
                     s += _N_BYTES_TO_START_STR[elm_size]
 
@@ -1525,7 +1681,6 @@ class Property:
                     s += _N_BYTES_TO_END_STR[elm_size]
                     if pos != len(self.value):
                         s += ","
-
 
         return s + ";"
 
@@ -1566,14 +1721,15 @@ class Property:
 
 def to_num(data, length=None, signed=False):
     """
-    Like Property.to_num(), but takes an arbitrary 'bytes' array. The value is
-    assumed to be in big-endian format, which is standard in Device Tree.
+    Converts the 'bytes' array 'data' to a number. The value is expected to be
+    in big-endian format, which is standard in Device Tree.
 
     length (default: None):
-      The expected length of the value in bytes. See Property.to_num().
+      The expected length of the value in bytes, as a simple type check. If
+      None, the length check is skipped.
 
-      Unlike for Property.to_num(), 'length' defaults to None, meaning to skip
-      the length check and use the entire property value.
+    signed (default: False):
+      If True, the value will be interpreted as signed rather than unsigned.
     """
     _check_is_bytes(data)
     if length is not None:
@@ -1601,35 +1757,20 @@ def to_nums(data, length=4, signed=False):
             for i in range(0, len(data), length)]
 
 
-def to_string(data):
-    """
-    Like Property.to_string(), but takes an arbitrary 'bytes' array. The string
-    should be null-terminated, which is standard in Device Tree. The
-    null terminator is stripped from the returned value.
-    """
-    strings = to_strings(data)
-    if len(strings) != 1:
-        raise DTError("{} contains more than one string".format(data))
-    return strings[0]
+#
+# Public constants
+#
 
-
-def to_strings(data):
-    """
-    Like Property.to_strings(), but takes an arbitrary 'bytes' array. The
-    strings should be null-terminated, which is standard in Device Tree. The
-    null terminators are stripped from the returned value.
-    """
-    _check_is_bytes(data)
-
-    try:
-        s = data.decode("utf-8")
-    except UnicodeDecodeError:
-        raise DTError("{} is not valid UTF-8".format(data))
-
-    if not s.endswith("\0"):
-        raise DTError("{} is not null-terminated".format(data))
-
-    return s.split("\0")[:-1]
+# See Property.type
+TYPE_EMPTY = 0
+TYPE_BYTES = 1
+TYPE_NUM = 2
+TYPE_NUMS = 3
+TYPE_STRING = 4
+TYPE_STRINGS = 5
+TYPE_PATH = 6
+TYPE_PHANDLE = 7
+TYPE_COMPOUND = 8
 
 
 def _check_is_bytes(data):
@@ -1640,7 +1781,7 @@ def _check_is_bytes(data):
 
 def _check_length_positive(length):
     if length < 1:
-        raise DTError("'size' must be greater than zero, was " + str(length))
+        raise DTError("'length' must be greater than zero, was " + str(length))
 
 
 def _append_no_dup(lst, elm):

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -212,7 +212,7 @@ class EDT:
 
     def _init_devices(self):
         # Creates a list of devices (Device objects) from the DT nodes, in
-        # self.devices. 'dt' is the dtlib.DT instance for the device tree.
+        # self.devices
 
         # Maps dtlib.Node's to their corresponding Devices
         self._node2dev = {}

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -154,6 +154,10 @@ def write_props(dev):
         if prop.name[0] == "#" or prop.name.endswith("-map"):
             continue
 
+        # Skip phandles
+        if isinstance(prop.val, edtlib.Device):
+            continue
+
         # Skip properties that we handle elsewhere
         if prop.name in {"reg", "interrupts", "compatible", "interrupt-controller",
                 "gpio-controller"}:

--- a/scripts/dts/test-bindings/props.yaml
+++ b/scripts/dts/test-bindings/props.yaml
@@ -8,6 +8,12 @@ properties:
         constraint: "props"
         type: string-array
 
+    nonexistent-boolean:
+        type: boolean
+
+    existent-boolean:
+        type: boolean
+
     int:
         type: int
 
@@ -22,3 +28,6 @@ properties:
 
     string-array:
         type: string-array
+
+    phandle-ref:
+        type: phandle

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -290,14 +290,19 @@
 
 	props {
 		compatible = "props";
+		existent-boolean;
 		int = <1>;
 		array = <1 2 3>;
 		uint8-array = [ 12 34 ];
 		string = "foo";
 		string-array = "foo", "bar", "baz";
+		phandle-ref = < &{/props/node} >;
 		// Does not appear in the binding, so won't create an entry in
 		// Device.props
 		not-speced = <0>;
+
+		node {
+		};
 	};
 
 	//

--- a/scripts/dts/testdtlib.py
+++ b/scripts/dts/testdtlib.py
@@ -77,15 +77,17 @@ def run():
 /dts-v1/;
 
 / {
-	a = < >;
-	b = < 10 20 >;
-	c = < 0U 1L 2UL 3LL 4ULL >;
-	d = < 0x10 0x20 >;
-	e = < 010 020 >;
-	f = /bits/ 8 < 0x10 0x20 (-1) >;
-	g = /bits/ 16 < 0x10 0x20 (-1) >;
-	h = /bits/ 32 < 0x10 0x20 (-1) >;
-	i = /bits/ 64 < 0x10 0x20 (-1) >;
+	a;
+	b = < >;
+	c = [ ];
+	d = < 10 20 >;
+	e = < 0U 1L 2UL 3LL 4ULL >;
+	f = < 0x10 0x20 >;
+	g = < 010 020 >;
+	h = /bits/ 8 < 0x10 0x20 (-1) >;
+	i = /bits/ 16 < 0x10 0x20 (-1) >;
+	j = /bits/ 32 < 0x10 0x20 (-1) >;
+	k = /bits/ 64 < 0x10 0x20 (-1) >;
 };
 """,
 """
@@ -93,14 +95,16 @@ def run():
 
 / {
 	a;
-	b = [ 00 00 00 0A 00 00 00 14 ];
-	c = [ 00 00 00 00 00 00 00 01 00 00 00 02 00 00 00 03 00 00 00 04 ];
-	d = [ 00 00 00 10 00 00 00 20 ];
-	e = [ 00 00 00 08 00 00 00 10 ];
-	f = [ 10 20 FF ];
-	g = [ 00 10 00 20 FF FF ];
-	h = [ 00 00 00 10 00 00 00 20 FF FF FF FF ];
-	i = [ 00 00 00 00 00 00 00 10 00 00 00 00 00 00 00 20 FF FF FF FF FF FF FF FF ];
+	b;
+	c;
+	d = < 0xa 0x14 >;
+	e = < 0x0 0x1 0x2 0x3 0x4 >;
+	f = < 0x10 0x20 >;
+	g = < 0x8 0x10 >;
+	h = [ 10 20 FF ];
+	i = /bits/ 16 < 0x10 0x20 0xffff >;
+	j = < 0x10 0x20 0xffffffff >;
+	k = /bits/ 64 < 0x10 0x20 0xffffffffffffffff >;
 };
 """)
 
@@ -173,16 +177,16 @@ def run():
 / {
 	a = "";
 	b = "ABC";
-	c = "\\\"\xAB\377\a\b\t\n\v\f\r";
+	c = "\\\"\xab\377\a\b\t\n\v\f\r";
 };
 """,
-"""
+r"""
 /dts-v1/;
 
 / {
-	a = [ 00 ];
-	b = [ 41 42 43 00 ];
-	c = [ 5C 22 AB FF 07 08 09 0A 0B 0C 0D 00 ];
+	a = "";
+	b = "ABC";
+	c = "\\\"\xab\xff\a\b\t\n\v\f\r";
 };
 """)
 
@@ -377,7 +381,7 @@ l3: &l1 {
 	a;
 	l1: b;
 	l2: l3: c;
-	l4: l5: l6: d = [ 00 00 00 00 ];
+	l4: l5: l6: d = < 0x0 >;
 };
 """)
 
@@ -405,9 +409,8 @@ l3: &l1 {
 /dts-v1/;
 
 / {
-    a = l01: l02: < l03: l04: &node l05: l06: 2 l07: l08: > l09: l10:,
-        l11: l12: [ l13: l14: 03 l15: l16: 04 l17: l18: ] l19: l20:,
-        l21: l22: "A";
+    a = l01: l02: < l03: &node l04: l05: 2 l06: >,
+        l07: l08: [ l09: 03 l10: l11: 04 l12: l13: ] l14:, "A";
 
     b = < 0 > l23: l24:;
 
@@ -419,20 +422,21 @@ l3: &l1 {
 /dts-v1/;
 
 / {
-	a = [ l01: l02: l03: l04: 00 00 00 01 l05: l06: 00 00 00 02 l07: l08: l09: l10: l11: l12: l13: l14: 03 l15: l16: 04 l17: l18: l19: l20: l21: l22: 41 00 ];
-	b = [ 00 00 00 00 l23: l24: ];
+	a = l01: l02: < l03: 0x1 l04: l05: 0x2 l06: l07: l08: >, [ l09: 03 l10: l11: 04 l12: l13: l14: ], "A";
+	b = < 0x0 l23: l24: >;
 	node: node {
-		phandle = [ 00 00 00 01 ];
+		phandle = < 0x1 >;
 	};
 };
 """)
 
     verify_label2offset("l01", "a", 0)
-    verify_label2offset("l04", "a", 0)
+    verify_label2offset("l02", "a", 0)
+    verify_label2offset("l04", "a", 4)
     verify_label2offset("l05", "a", 4)
-    verify_label2offset("l14", "a", 8)
-    verify_label2offset("l15", "a", 9)
-    verify_label2offset("l22", "a", 10)
+    verify_label2offset("l06", "a", 8)
+    verify_label2offset("l09", "a", 8)
+    verify_label2offset("l10", "a", 9)
 
     verify_label2offset("l23", "b", 4)
     verify_label2offset("l24", "b", 4)
@@ -487,10 +491,12 @@ l3: &l1 {
 
 / {
 	a = &label;
-	b = &{/abc};
+	b = [ 01 ], &label;
+	c = [ 01 ], &label, <2>;
+	d = &{/abc};
 	label: abc {
-		c = &label;
-		d = &{/abc};
+		e = &label;
+		f = &{/abc};
 	};
 };
 """,
@@ -498,11 +504,13 @@ l3: &l1 {
 /dts-v1/;
 
 / {
-	a = [ 2F 61 62 63 00 ];
-	b = [ 2F 61 62 63 00 ];
+	a = "/abc";
+	b = [ 01 ], "/abc";
+	c = [ 01 ], "/abc", < 0x2 >;
+	d = "/abc";
 	label: abc {
-		c = [ 2F 61 62 63 00 ];
-		d = [ 2F 61 62 63 00 ];
+		e = "/abc";
+		f = "/abc";
 	};
 };
 """)
@@ -563,21 +571,21 @@ l3: &l1 {
 /dts-v1/;
 
 / {
-	x = [ 00 00 00 02 00 00 00 04 00 00 00 FF ];
+	x = < 0x2 0x4 0xff >;
 	dummy1 {
-		phandle = [ 00 00 00 01 ];
+		phandle = < 0x1 >;
 	};
 	dummy2 {
-		phandle = [ 00 00 00 03 ];
+		phandle = < 0x3 >;
 	};
 	a: a {
-		phandle = [ 00 00 00 02 ];
+		phandle = < 0x2 >;
 	};
 	b {
-		phandle = [ 00 00 00 04 ];
+		phandle = < 0x4 >;
 	};
 	c: c {
-		phandle = [ 00 00 00 FF ];
+		phandle = < 0xff >;
 	};
 };
 """)
@@ -606,13 +614,13 @@ l3: &l1 {
 
 / {
 	dummy {
-		phandle = [ 00 00 00 01 ];
+		phandle = < 0x1 >;
 	};
 	a {
-		foo: phandle = [ 00 00 00 02 ];
+		foo: phandle = < 0x2 >;
 	};
 	label: b {
-		bar: phandle = [ 00 00 00 03 ];
+		bar: phandle = < 0x3 >;
 	};
 };
 """)
@@ -757,9 +765,9 @@ l3: &l1 {
 /dts-v1/;
 
 / {
-	x = [ FF FF 2F 61 62 63 00 00 00 00 FF 00 00 00 01 00 00 00 FF 00 00 00 01 2F 61 62 63 00 FF FF 61 62 63 00 ];
+	x = [ FF FF ], "/abc", < 0xff 0x1 0xff 0x1 >, "/abc", [ FF FF ], "abc";
 	abc: abc {
-		phandle = [ 00 00 00 01 ];
+		phandle = < 0x1 >;
 	};
 };
 """)
@@ -789,7 +797,7 @@ l3: &l1 {
 /dts-v1/;
 
 / {
-	keep = [ 00 00 00 01 ];
+	keep = < 0x1 >;
 	sub: sub {
 	};
 };
@@ -828,7 +836,7 @@ l3: &l1 {
 
 / {
 	sub1 {
-		x = [ 00 00 00 01 ];
+		x = < 0x1 >;
 	};
 };
 """)
@@ -904,8 +912,8 @@ y /include/ "via-include-path-1"
 /dts-v1/;
 
 / {
-	x = [ 00 00 00 01 ];
-	y = [ 00 00 00 02 ];
+	x = < 0x1 >;
+	y = < 0x2 >;
 };
 """,
     include_path=(".tmp", ".tmp2",))
@@ -999,9 +1007,9 @@ y /include/ "via-include-path-1"
 /dts-v1/;
 
 / {
-	x = [ 00 00 00 01 2F 72 65 66 65 72 65 6E 63 65 64 32 00 ];
+	x = < 0x1 >, "/referenced2";
 	referenced {
-		phandle = [ 00 00 00 01 ];
+		phandle = < 0x1 >;
 	};
 	referenced2: referenced2 {
 	};
@@ -1114,51 +1122,51 @@ y /include/ "via-include-path-1"
 /dts-v1/;
 
 / {
-	ter1 = [ 00 00 00 03 ];
-	ter2 = [ 00 00 00 02 ];
-	ter3 = [ 00 00 00 01 ];
-	ter4 = [ 00 00 00 01 ];
-	or1 = [ 00 00 00 00 ];
-	or2 = [ 00 00 00 01 ];
-	or3 = [ 00 00 00 01 ];
-	or4 = [ 00 00 00 01 ];
-	and1 = [ 00 00 00 00 ];
-	and2 = [ 00 00 00 00 ];
-	and3 = [ 00 00 00 00 ];
-	and4 = [ 00 00 00 01 ];
-	bitor = [ 00 00 00 03 ];
-	bitxor = [ 00 00 00 05 ];
-	bitand = [ 00 00 00 02 ];
-	eq1 = [ 00 00 00 00 ];
-	eq2 = [ 00 00 00 01 ];
-	neq1 = [ 00 00 00 01 ];
-	neq2 = [ 00 00 00 00 ];
-	lt1 = [ 00 00 00 01 ];
-	lt2 = [ 00 00 00 00 ];
-	lt3 = [ 00 00 00 00 ];
-	lteq1 = [ 00 00 00 01 ];
-	lteq2 = [ 00 00 00 01 ];
-	lteq3 = [ 00 00 00 00 ];
-	gt1 = [ 00 00 00 00 ];
-	gt2 = [ 00 00 00 00 ];
-	gt3 = [ 00 00 00 01 ];
-	gteq1 = [ 00 00 00 00 ];
-	gteq2 = [ 00 00 00 01 ];
-	gteq3 = [ 00 00 00 01 ];
-	lshift = [ 00 00 00 10 ];
-	rshift = [ 00 00 00 02 ];
-	add = [ 00 00 00 07 ];
-	sub = [ 00 00 00 03 ];
-	mul = [ 00 00 00 0C ];
-	div = [ 00 00 00 03 ];
-	mod = [ 00 00 00 02 ];
-	unary_minus = [ FF FF FF FD ];
-	bitnot = [ FF FF FF FE ];
-	not0 = [ 00 00 00 00 ];
-	not1 = [ 00 00 00 01 ];
-	not2 = [ 00 00 00 00 ];
-	not3 = [ 00 00 00 00 ];
-	nest = [ FF FF FF FE ];
+	ter1 = < 0x3 >;
+	ter2 = < 0x2 >;
+	ter3 = < 0x1 >;
+	ter4 = < 0x1 >;
+	or1 = < 0x0 >;
+	or2 = < 0x1 >;
+	or3 = < 0x1 >;
+	or4 = < 0x1 >;
+	and1 = < 0x0 >;
+	and2 = < 0x0 >;
+	and3 = < 0x0 >;
+	and4 = < 0x1 >;
+	bitor = < 0x3 >;
+	bitxor = < 0x5 >;
+	bitand = < 0x2 >;
+	eq1 = < 0x0 >;
+	eq2 = < 0x1 >;
+	neq1 = < 0x1 >;
+	neq2 = < 0x0 >;
+	lt1 = < 0x1 >;
+	lt2 = < 0x0 >;
+	lt3 = < 0x0 >;
+	lteq1 = < 0x1 >;
+	lteq2 = < 0x1 >;
+	lteq3 = < 0x0 >;
+	gt1 = < 0x0 >;
+	gt2 = < 0x0 >;
+	gt3 = < 0x1 >;
+	gteq1 = < 0x0 >;
+	gteq2 = < 0x1 >;
+	gteq3 = < 0x1 >;
+	lshift = < 0x10 >;
+	rshift = < 0x2 >;
+	add = < 0x7 >;
+	sub = < 0x3 >;
+	mul = < 0xc >;
+	div = < 0x3 >;
+	mod = < 0x2 >;
+	unary_minus = < 0xfffffffd >;
+	bitnot = < 0xfffffffe >;
+	not0 = < 0x0 >;
+	not1 = < 0x1 >;
+	not2 = < 0x0 >;
+	not3 = < 0x0 >;
+	nest = < 0xfffffffe >;
 };
 """)
 
@@ -1197,7 +1205,7 @@ foo
 /dts-v1/;
 
 / {
-	x = [ 00 00 00 01 ];
+	x = < 0x1 >;
 };
 """)
 
@@ -1788,7 +1796,7 @@ r"b'\xff\x00' is not valid UTF-8 (for property 'a' on /aliases)")
 /dts-v1/;
 
 / {
-	x = [ 00 00 00 01 ];
+	x = < 0x1 >;
 	foo: foo {
 	};
 };
@@ -1812,8 +1820,8 @@ r"b'\xff\x00' is not valid UTF-8 (for property 'a' on /aliases)")
 
 / {
 	label: foo {
-		x = [ 2F 66 6F 6F 00 2F 66 6F 6F 00 00 00 00 01 ];
-		phandle = [ 00 00 00 01 ];
+		x = "/foo", "/foo", < 0x1 >;
+		phandle = < 0x1 >;
 	};
 };
 """)
@@ -1899,7 +1907,7 @@ l1: l2: /memreserve/ 0x0000000000000002 0x0000000000000004;
 /dts-v1/;
 
 / {
-	aA0,._+*#?- = [ 2F 61 41 30 2C 2E 5F 2B 2A 23 3F 40 2D 00 2F 61 41 30 2C 2E 5F 2B 2A 23 3F 40 2D 00 ];
+	aA0,._+*#?- = "/aA0,._+*#?@-", "/aA0,._+*#?@-";
 	+ = [ 00 ];
 	* = [ 02 ];
 	- = [ 01 ];
@@ -1950,7 +1958,7 @@ l1: l2: /memreserve/ 0x0000000000000002 0x0000000000000004;
 / {
 	l1: l2: foo {
 		l3: l4: bar {
-			l5: x = [ l6: l7: 01 l8: 02 l9: 03 61 00 ];
+			l5: x = l6: [ l7: 01 l8: 02 l9: ], [ 03 ], "a";
 		};
 	};
 };

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -120,7 +120,7 @@ def run():
     #
 
     verify_streq(edt.get_dev("/props").props,
-                 r"{'compatible': <Property, name: compatible, value: ['props']>, 'int': <Property, name: int, value: 1>, 'array': <Property, name: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, value: b'\x124'>, 'string': <Property, name: string, value: 'foo'>, 'string-array': <Property, name: string-array, value: ['foo', 'bar', 'baz']>}")
+                 r"{'compatible': <Property, name: compatible, value: ['props']>, 'nonexistent-boolean': <Property, name: nonexistent-boolean, value: False>, 'existent-boolean': <Property, name: existent-boolean, value: True>, 'int': <Property, name: int, value: 1>, 'array': <Property, name: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, value: b'\x124'>, 'string': <Property, name: string, value: 'foo'>, 'string-array': <Property, name: string-array, value: ['foo', 'bar', 'baz']>, 'phandle-ref': <Property, name: phandle-ref, value: <Device /props/node in 'test.dts', no binding>>}")
 
     #
     # Test having multiple directories with bindings, with a different .dts file


### PR DESCRIPTION
Main commits:

```
dts: dtlib: Remember the format of assignments

Previously, dtlib just stored the raw 'bytes' value for each property,
along with some markers in Property._markers for phandle and path
references.

Extend Property._markers to also remember where different data blocks
start, so that e.g.

    foo = <1 2 3>, "bar", [00 01];

can be reproduced as written.

Use the new information to reproduce properties as written in
Property.__str__(). This gives good test coverage as well, since the
test suite checks literal __str__() output.
```

```
dts: dtlib/edtlib: Add a syntax-based type-checking system

Property type-checking has been pretty rudimentary until now, only
checking things like the length being divisible by 4 for 'type: array',
and strings being null-terminated. In particular, no checking was done
for 'type: uint8-array', letting

  jedec-id = < 0xc8 0x28 0x17 >;

slip through when

  jedec-id = [ 0xc8 0x28 0x17 ];

was intended.

Fix it by adding a syntax-based type checker:

  1. Add Property.type, which gives a high-level type for the property,
     derived from the markers added in the previous commit.

     This includes types like TYPE_EMPTY ('foo;'),
     TYPE_NUM ('foo = < 3 >;'), TYPE_BYTES ('foo = [ 01 02 ];'),
     TYPE_STRINGS ('foo = "bar", "baz"'),
     TYPE_PHANDLE ('foo = < &bar >;'), and TYPE_COMPOUND (everything not
     recognized).

     See the Property.type docstring in dtlib for more info.

  2. Use the high-level type in
     Property.to_num()/to_string()/to_node()/etc. to verify that the
     property was assigned in an expected way for the type.

     If the assignment looks bad, give a helpful error:

       expected property 'nums' on /foo/bar in some.dts to be assigned
       with 'nums = < (number) (number) ... >', not 'nums = "oops";'

Some other related changes are included as well:

  - There's a new Property.to_bytes() function that works like accessing
    Property.bytes, except with an added check for the value being
    assigned like 'foo = [ ... ]'.

    This function solves problems like the jedec-id one.

  - There's a new Property.to_path() function for fetching the string
    referenced node for assignments like 'foo = &node;', with type
    checking. (Strings are accepted too, as long as they give the path
    to an existing node.)

  - A new 'type: phandle' type can now be given in bindings, for
    properties that are assigned like 'foo = < &node >;'.

  - Property.__str__() now displays phandles and path references as they
    were written (e.g. '< &foo >' instead of '< 0x1 >', if the
    allocated phandle happened to be 1).

  - Property.to_num() and Property.to_nums() no longer take a 'length'
    parameter, because it makes no sense with the type checking.

  - The global dtlib.to_string() and dtlib.to_strings() functions were
    removed, because they're not that useful.

  - More tests were added, along with misc. minor cleanup in varios
    places.

  - Probably other stuff I forgot.

The more strict type checking in dtlib indirectly makes some parts of
edtlib more strict as well (wherever Property.to_*() is used).
```

Small cleanup:

```
dts: edtlib: Fix outdated doc comment for _init_devices()
    
No longer takes the DT instance as a parameter.
```