### PR TITLE
dts/bindings: Fix build issues with bindings

### DIFF
--- a/dts/bindings/can/microchip,mcp2515.yaml
+++ b/dts/bindings/can/microchip,mcp2515.yaml
@@ -10,7 +10,7 @@ description: >
     This binding gives a base representation of the MCP2515 SPI CAN controller
 
 inherits:
-    !include [can.yaml, spi-device.yaml]
+    !include [spi-device.yaml, can.yaml]
 
 properties:
     compatible:

--- a/dts/bindings/ethernet/microchip,enc28j60.yaml
+++ b/dts/bindings/ethernet/microchip,enc28j60.yaml
@@ -9,7 +9,7 @@ title: 10Base-T Ethernet Controller with SPI Interface
 description: >
     This binding gives a base representation of the standalone ENC28J60 chip
 inherits:
-  !include [ethernet.yaml, spi-device.yaml]
+  !include [spi-device.yaml, ethernet.yaml]
 
 properties:
     compatible:


### PR DESCRIPTION
the microchip,mcp2515 and microchip,enc28j60 bindings would hit the
following build error:

device tree error: dts/bindings/can/microchip,mcp2515.yaml (in 'reg'):
'category' from !included file overwritten
('required' replaced with 'optional')

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>