### PR TITLE
[TOPIC: GPIO] dts/bindings: Introduce __DT_DEPRECATE_MACRO

### DIFF
--- a/arch/posix/include/kernel_arch_data.h
+++ b/arch/posix/include/kernel_arch_data.h
@@ -14,23 +14,10 @@
 #ifndef ZEPHYR_ARCH_POSIX_INCLUDE_KERNEL_ARCH_DATA_H_
 #define ZEPHYR_ARCH_POSIX_INCLUDE_KERNEL_ARCH_DATA_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <kernel_internal.h>
 
 /* stacks */
 #define STACK_ROUND_UP(x) ROUND_UP(x, STACK_ALIGN_SIZE)
 #define STACK_ROUND_DOWN(x) ROUND_DOWN(x, STACK_ALIGN_SIZE)
-
-
-#ifndef _ASMLANGUAGE
-
-#endif /* _ASMLANGUAGE */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* ZEPHYR_ARCH_POSIX_INCLUDE_KERNEL_ARCH_DATA_H_ */

--- a/arch/posix/include/kernel_arch_thread.h
+++ b/arch/posix/include/kernel_arch_thread.h
@@ -23,6 +23,10 @@
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct _callee_saved {
 	/* IRQ status before irq_lock() and call to z_swap() */
 	u32_t key;
@@ -40,6 +44,10 @@ struct _thread_arch {
 };
 
 typedef struct _thread_arch _thread_arch_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ASMLANGUAGE */
 

--- a/arch/posix/include/posix_soc_if.h
+++ b/arch/posix/include/posix_soc_if.h
@@ -15,6 +15,7 @@
  */
 
 #include "posix_trace.h"
+#include "soc_irq.h" /* Must exist and define _ARCH_IRQ/ISR_* macros */
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,9 +23,6 @@ extern "C" {
 
 void posix_halt_cpu(void);
 void posix_atomic_halt_cpu(unsigned int imask);
-
-
-#include "soc_irq.h" /* Must exist and define _ARCH_IRQ/ISR_* macros */
 
 unsigned int z_arch_irq_lock(void);
 void z_arch_irq_unlock(unsigned int key);

--- a/boards/posix/native_posix/native_rtc.h
+++ b/boards/posix/native_posix/native_rtc.h
@@ -15,12 +15,11 @@
 
 #include "hw_models_top.h"
 #include <stdbool.h>
+#include "zephyr/types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "zephyr/types.h"
 
 /*
  * Types of clocks this RTC provides:

--- a/boards/posix/nrf52_bsim/cmdline.h
+++ b/boards/posix/nrf52_bsim/cmdline.h
@@ -17,10 +17,23 @@
  * command line arguments is passed to the nrf52_bsim one
  */
 
+#ifndef BOARDS_POSIX_NRF52_BSIM_CMDLINE_H
+#define BOARDS_POSIX_NRF52_BSIM_CMDLINE_H
+
 #include "../native_posix/cmdline_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 static inline void native_add_command_line_opts(struct args_struct_t *args)
 {
 	void bs_add_extra_dynargs(struct args_struct_t *args);
 	bs_add_extra_dynargs(args);
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARDS_POSIX_NRF52_BSIM_CMDLINE_H */

--- a/include/arch/posix/asm_inline_gcc.h
+++ b/include/arch/posix/asm_inline_gcc.h
@@ -19,11 +19,6 @@
  * Include kernel.h instead
  */
 
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef _ASMLANGUAGE
 
 #include <toolchain/common.h>
@@ -32,11 +27,6 @@ extern "C" {
 #include <arch/common/ffs.h>
 #include "posix_soc_if.h"
 
-
 #endif /* _ASMLANGUAGE */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* ZEPHYR_INCLUDE_ARCH_POSIX_ASM_INLINE_GCC_H_ */

--- a/include/dt-bindings/deprecate.h
+++ b/include/dt-bindings/deprecate.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_DEPRECATE_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_DEPRECATE_H_
+
+#if defined(__GNUC__)
+#define __DT_DEPRECATED_MACRO _Pragma("GCC warning \"DTS Macro is deprecated\"")
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_DEPRECATE_H_ */

--- a/include/settings/settings.h
+++ b/include/settings/settings.h
@@ -34,6 +34,19 @@ extern "C" {
  */
 #define SETTINGS_EXTRA_LEN ((SETTINGS_MAX_DIR_DEPTH - 1) + 2)
 
+/**
+ * Function used to read the data from the settings storage in
+ * h_set handler implementations.
+ *
+ * @param[in] cb_arg  arguments for the read function. Appropriate cb_arg is
+ *                    transferred to h_set handler implementation by
+ *                    the backend.
+ * @param[out] data  the destination buffer
+ * @param[in] len    length of read
+ *
+ * @return positive: Number of bytes read, 0: key-value pair is deleted.
+ *                   On error returns -ERRNO code.
+ */
 typedef ssize_t (*settings_read_cb)(void *cb_arg, void *data, size_t len);
 
 /**

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -32,10 +32,18 @@ static struct settings_store_itf settings_nvs_itf = {
 static ssize_t settings_nvs_read_fn(void *back_end, void *data, size_t len)
 {
 	struct settings_nvs_read_fn_arg *rd_fn_arg;
+	ssize_t rc;
 
 	rd_fn_arg = (struct settings_nvs_read_fn_arg *)back_end;
 
-	return nvs_read(rd_fn_arg->fs, rd_fn_arg->id, data, len);
+	rc = nvs_read(rd_fn_arg->fs, rd_fn_arg->id, data, len);
+	if (rc > len) {
+		/* nvs_read signals that not all bytes were read
+		 * align read len to what was requested
+		 */
+		rc = len;
+	}
+	return rc;
 }
 
 int settings_nvs_src(struct settings_nvs *cf)


### PR DESCRIPTION
We need a DT specific deprecate macro to be used in headers under
include/dt-bindings as these headers are allowed to be used in .dts{i}
files.  So we mimic the __DEPRECATE_MACRO found in toolchain/gcc.h.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>