### PR TITLE
arch: make more arch files kconfigurable

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -71,6 +71,49 @@ module = MPU
 module-str = mpu
 source "subsys/logging/Kconfig.template.log_config"
 
+config THREAD
+	bool "Thread"
+	default y
+	help
+	  Include arch speficic thread handling.
+
+config CPU_IDLE
+	bool "CPU Idle support"
+	default y
+	help
+	  Include arch specific CPU idle functionality.
+
+config FATAL
+	bool "Fatal"
+	default y
+	help
+	  Include arch specific handlers for fatal errors/faults.
+
+config PREP_C
+	bool "Prep c"
+	default y
+	help
+	  Include arch specific C runtime preparation.
+
+config RESET
+	bool "Reset"
+	default y
+	help
+	  Include arch specific reset handling.
+
+config IRQ_MANAGE
+	bool "IRQ Manage"
+	default y
+	help
+	  Include arch specific IRQ management.
+
+config SWAP
+	bool "Swap"
+	default y
+	help
+	  Include arch specific functionality for swapping/switching  between
+	  threads.
+
 config BIG_ENDIAN
        bool
        help

--- a/arch/arm/core/CMakeLists.txt
+++ b/arch/arm/core/CMakeLists.txt
@@ -8,20 +8,21 @@ zephyr_compile_options_ifdef(CONFIG_COVERAGE_GCOV
   -fno-inline
   )
 
-zephyr_library_sources(
-  exc_exit.S
-  swap.c
-  swap_helper.S
-  irq_manage.c
-  thread.c
-  cpu_idle.S
-  fault_s.S
-  fatal.c
-  nmi.c
-  nmi_on_reset.S
-  prep_c.c
-)
+zephyr_library_sources_if_kconfig(swap.c)
+zephyr_library_sources_ifdef(CONFIG_SWAP swap_helper.S)
 
+zephyr_library_sources_if_kconfig(irq_manage.c)
+zephyr_library_sources_if_kconfig(thread.c)
+zephyr_library_sources_if_kconfig(cpu_idle.S)
+
+zephyr_library_sources_ifdef(CONFIG_FATAL fatal.c)
+zephyr_library_sources_ifdef(CONFIG_FATAL fault_s.S)
+
+zephyr_library_sources_ifdef(CONFIG_ARM_NMI nmi.c)
+zephyr_library_sources_ifdef(CONFIG_ARM_NMI nmi_on_reset.S)
+
+zephyr_library_sources_if_kconfig(prep_c.c)
+zephyr_library_sources_ifdef(CONFIG_ARM_EXC_EXIT exc_exit.S)
 zephyr_library_sources_ifdef(CONFIG_GEN_SW_ISR_TABLE isr_wrapper.S)
 zephyr_library_sources_ifdef(CONFIG_CPLUSPLUS __aeabi_atexit.c)
 zephyr_library_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -119,6 +119,18 @@ config FAULT_DUMP
 
 	  0: Off.
 
+config ARM_NMI
+	bool "NMI handler infrastructure"
+	default y
+	help
+	  Include ARM specific NMI handling infrastructure.
+
+config ARM_EXC_EXIT
+	bool "Excception exit API"
+	default y
+	help
+	  Include ARM specific exception/interrupt exit API.
+
 config BUILTIN_STACK_GUARD
 	bool "Thread Stack Guards based on built-in ARM stack limit checking"
 	depends on CPU_CORTEX_M_HAS_SPLIM

--- a/arch/arm/core/cortex_m/CMakeLists.txt
+++ b/arch/arm/core/cortex_m/CMakeLists.txt
@@ -2,15 +2,12 @@
 
 zephyr_library()
 
-zephyr_library_sources(
-  vector_table.S
-  reset.S
-  fault.c
-  scb.c
-  irq_init.c
-  thread_abort.c
-  )
-
+zephyr_library_sources_ifdef(CONFIG_FATAL fault.c)
+zephyr_library_sources_if_kconfig(reset.S)
+zephyr_library_sources_ifdef(CONFIG_THREAD thread_abort.c)
+zephyr_library_sources_ifdef(CONFIG_ARM_SCB scb.c)
+zephyr_library_sources_ifdef(CONFIG_ARM_IRQ_INIT irq_init.c)
+zephyr_library_sources_ifdef(CONFIG_ARM_VECTOR_TABLE vector_table.S)
 zephyr_linker_sources_ifdef(CONFIG_SW_VECTOR_RELAY
   RAM_SECTIONS
   vt_pointer_section.ld

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -294,4 +294,22 @@ config PLATFORM_SPECIFIC_INIT
 
 endmenu
 
+config ARM_SCB
+	bool "SCB"
+	default y
+	help
+	  Include ARM system block control interface.
+
+config ARM_IRQ_INIT
+	bool "IRQ INIT"
+	default y
+	help
+	  Include ARM interrupt initialization.
+
+config ARM_VECTOR_TABLE
+	bool "VECTOR TABLE"
+	default y
+	help
+	  Include ARM vector table handling.
+
 endif # CPU_CORTEX_M


### PR DESCRIPTION
Make more arch specific files kconfigurable so that the user can opt
out from using them. The motivation for this change is to get better
support for bare metal solutions.

Names shared between the arches is put in the top level kconfig.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>