### PR TITLE
tests: net: udp: We need to reserve enough space for the data

### DIFF
--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -853,7 +853,7 @@ void test_v6_sendmsg_with_txtime(void)
 	struct iovec io_vector[1];
 	union {
 		struct cmsghdr hdr;
-		unsigned char  buf[CMSG_SPACE(sizeof(int))];
+		unsigned char  buf[CMSG_SPACE(sizeof(u64_t))];
 	} cmsgbuf;
 
 	prepare_sock_udp_v6(MY_IPV6_ADDR, ANY_PORT, &client_sock,


### PR DESCRIPTION
We are trying to pass 64-bit value to the driver, but we only
allocate space for an integer. This will not work and will cause
invalid memory access.

Fixes #18205

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>