### PR TITLE
rework extern "C" blocks in various include files

### DIFF
--- a/drivers/audio/mpxxdtyy.h
+++ b/drivers/audio/mpxxdtyy.h
@@ -7,14 +7,14 @@
 #ifndef MPXXDTYY_H
 #define MPXXDTYY_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <audio/dmic.h>
 #include <zephyr.h>
 #include <device.h>
 #include "OpenPDMFilter.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define MPXXDTYY_MIN_PDM_FREQ		1200000 /* 1.2MHz */
 #define MPXXDTYY_MAX_PDM_FREQ		3250000 /* 3.25MHz */

--- a/drivers/i2c/i2c-priv.h
+++ b/drivers/i2c/i2c-priv.h
@@ -7,13 +7,13 @@
 #ifndef ZEPHYR_DRIVERS_I2C_I2C_PRIV_H_
 #define ZEPHYR_DRIVERS_I2C_I2C_PRIV_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <drivers/i2c.h>
 #include <dt-bindings/i2c/i2c.h>
 #include <logging/log.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 static inline u32_t i2c_map_dt_bitrate(u32_t bitrate)
 {

--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -9,7 +9,10 @@
 #ifndef ZEPHYR_DRIVERS_SPI_SPI_DW_H_
 #define ZEPHYR_DRIVERS_SPI_SPI_DW_H_
 
+#include <string.h>
 #include <drivers/spi.h>
+
+#include "spi_context.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,8 +31,6 @@ struct spi_dw_config {
 	spi_dw_config_t config_func;
 	u8_t op_modes;
 };
-
-#include "spi_context.h"
 
 struct spi_dw_data {
 #ifdef CONFIG_CLOCK_CONTROL
@@ -194,6 +195,10 @@ struct spi_dw_data {
 /*
  * Including the right register definition file
  * SoC SPECIFIC!
+ *
+ * The file included next uses the DEFINE_MM_REG macros above to
+ * declare functions.  In this situation we'll leave the containing
+ * extern "C" active in C++ compilations.
  */
 #include "spi_dw_regs.h"
 
@@ -214,8 +219,6 @@ DEFINE_TEST_BIT_OP(ssienr, DW_SPI_REG_SSIENR, DW_SPI_SSIENR_SSIEN_BIT)
 DEFINE_TEST_BIT_OP(sr_busy, DW_SPI_REG_SR, DW_SPI_SR_BUSY_BIT)
 
 #ifdef CONFIG_CLOCK_CONTROL
-
-#include <string.h>
 
 static inline int clock_config(struct device *dev)
 {
@@ -260,7 +263,8 @@ static inline void clock_off(struct device *dev)
 
 	extra_clock_off(dev);
 }
-#else
+
+#else /* CONFIG_CLOCK_CONTROL */
 #define clock_config(...)
 #define clock_on(...)
 #define clock_off(...)
@@ -269,4 +273,5 @@ static inline void clock_off(struct device *dev)
 #ifdef __cplusplus
 }
 #endif
+
 #endif /* ZEPHYR_DRIVERS_SPI_SPI_DW_H_ */

--- a/include/bluetooth/a2dp.h
+++ b/include/bluetooth/a2dp.h
@@ -10,11 +10,11 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_A2DP_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_A2DP_H_
 
+#include <bluetooth/avdtp.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <bluetooth/avdtp.h>
 
 /** @brief Stream Structure */
 struct bt_a2dp_stream {

--- a/include/bluetooth/att.h
+++ b/include/bluetooth/att.h
@@ -10,11 +10,11 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_ATT_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_ATT_H_
 
+#include <sys/slist.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <sys/slist.h>
 
 /* Error codes for Error response PDU */
 #define BT_ATT_ERR_INVALID_HANDLE		0x01

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -17,14 +17,14 @@
  * @{
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Opaque type representing a connection to a remote device */
 struct bt_conn;

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -17,16 +17,16 @@
  * @{
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stddef.h>
 #include <sys/types.h>
 #include <sys/util.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/uuid.h>
 #include <bluetooth/att.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* GATT attribute permission bit field values */
 enum {

--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -17,14 +17,14 @@
  * @{
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <sys/atomic.h>
 #include <bluetooth/buf.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/hci.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* L2CAP header size, used for buffer size calculations */
 #define BT_L2CAP_HDR_SIZE               4

--- a/include/bluetooth/rfcomm.h
+++ b/include/bluetooth/rfcomm.h
@@ -17,12 +17,12 @@
  * @{
  */
 
+#include <bluetooth/buf.h>
+#include <bluetooth/conn.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <bluetooth/buf.h>
-#include <bluetooth/conn.h>
 
 /* RFCOMM channels (1-30): pre-allocated for profiles to avoid conflicts */
 enum {

--- a/include/bluetooth/sdp.h
+++ b/include/bluetooth/sdp.h
@@ -17,12 +17,12 @@
  * @{
  */
 
+#include <bluetooth/uuid.h>
+#include <bluetooth/conn.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <bluetooth/uuid.h>
-#include <bluetooth/conn.h>
 
 /*
  * All definitions are based on Bluetooth Assigned Numbers
@@ -601,6 +601,7 @@ int bt_sdp_get_profile_version(const struct net_buf *buf, u16_t profile,
  *  @return 0 on success if feature found and valid, negative in case any error
  */
 int bt_sdp_get_features(const struct net_buf *buf, u16_t *features);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/bluetooth/services/bas.h
+++ b/include/bluetooth/services/bas.h
@@ -18,11 +18,11 @@
  * as a part of ongoing development.
  */
 
+#include <zephyr/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <zephyr/types.h>
 
 /** @brief Read battery level value.
  *

--- a/include/device.h
+++ b/include/device.h
@@ -596,9 +596,10 @@ static inline int device_pm_put_sync(struct device *dev) { return -ENOTSUP; }
  * @}
  */
 
-#include <syscalls/device.h>
-
 #ifdef __cplusplus
 }
 #endif
+
+#include <syscalls/device.h>
+
 #endif /* ZEPHYR_INCLUDE_DEVICE_H_ */

--- a/include/dfu/flash_img.h
+++ b/include/dfu/flash_img.h
@@ -8,11 +8,11 @@
 #ifndef ZEPHYR_INCLUDE_DFU_FLASH_IMG_H_
 #define ZEPHYR_INCLUDE_DFU_FLASH_IMG_H_
 
+#include <storage/flash_map.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <storage/flash_map.h>
 
 struct flash_img_context {
 	u8_t buf[CONFIG_IMG_BLOCK_BUF_SIZE];

--- a/include/drivers/adc.h
+++ b/include/drivers/adc.h
@@ -412,8 +412,6 @@ static inline u16_t adc_ref_internal(struct device *dev)
 	return api->ref_internal;
 }
 
-#include <syscalls/adc.h>
-
 /**
  * @}
  */
@@ -421,5 +419,7 @@ static inline u16_t adc_ref_internal(struct device *dev)
 #ifdef __cplusplus
 }
 #endif
+
+#include <syscalls/adc.h>
 
 #endif  /* ZEPHYR_INCLUDE_DRIVERS_ADC_H_ */

--- a/include/drivers/console/uart_console.h
+++ b/include/drivers/console/uart_console.h
@@ -9,11 +9,11 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CONSOLE_UART_CONSOLE_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CONSOLE_UART_CONSOLE_H_
 
+#include <kernel.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <kernel.h>
 
 /** @brief Register uart input processing
  *

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -465,10 +465,10 @@ struct gpio_pin_config {
  * @}
  */
 
-#include <syscalls/gpio.h>
-
 #ifdef __cplusplus
 }
 #endif
+
+#include <syscalls/gpio.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_GPIO_H_ */

--- a/include/drivers/i2s.h
+++ b/include/drivers/i2s.h
@@ -516,14 +516,14 @@ static inline int z_impl_i2s_trigger(struct device *dev, enum i2s_dir dir,
 	return api->trigger(dev, dir, cmd);
 }
 
-#include <syscalls/i2s.h>
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }
 #endif
 
-/**
- * @}
- */
+#include <syscalls/i2s.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_I2S_H_ */

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -19,10 +19,6 @@
  * @{
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #define PWM_ACCESS_BY_PIN	0
 #define PWM_ACCESS_ALL		1
 
@@ -30,6 +26,10 @@ extern "C" {
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @typedef pwm_pin_set_t

--- a/include/drivers/sensor.h
+++ b/include/drivers/sensor.h
@@ -555,14 +555,14 @@ static inline double sensor_value_to_double(struct sensor_value *val)
 	return (double)val->val1 + (double)val->val2 / 1000000;
 }
 
-#include <syscalls/sensor.h>
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }
 #endif
 
-/**
- * @}
- */
+#include <syscalls/sensor.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_H_ */

--- a/include/drivers/timer/system_timer.h
+++ b/include/drivers/timer/system_timer.h
@@ -16,13 +16,13 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SYSTEM_TIMER_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SYSTEM_TIMER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <device.h>
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Initialize system clock driver

--- a/include/fs/fcb.h
+++ b/include/fs/fcb.h
@@ -7,10 +7,6 @@
 #ifndef ZEPHYR_INCLUDE_FS_FCB_H_
 #define ZEPHYR_INCLUDE_FS_FCB_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /*
  * Flash circular buffer.
  */
@@ -20,6 +16,10 @@ extern "C" {
 #include <storage/flash_map.h>
 
 #include <kernel.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup fcb Flash Circular Buffer (FCB)

--- a/include/net/can.h
+++ b/include/net/can.h
@@ -13,14 +13,15 @@
 #ifndef ZEPHYR_INCLUDE_NET_CAN_H_
 #define ZEPHYR_INCLUDE_NET_CAN_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <zephyr/types.h>
 #include <net/net_ip.h>
 #include <net/net_if.h>
 #include <can.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 /**
  * @brief IPv6 over CAN library

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -722,14 +722,14 @@ static inline int net_eth_get_ptp_port(struct net_if *iface)
 void net_eth_set_ptp_port(struct net_if *iface, int port);
 #endif /* CONFIG_NET_GPTP */
 
-#include <syscalls/ethernet.h>
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }
 #endif
 
-/**
- * @}
- */
+#include <syscalls/ethernet.h>
 
 #endif /* ZEPHYR_INCLUDE_NET_ETHERNET_H_ */

--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -14,6 +14,11 @@
 #define ZEPHYR_INCLUDE_NET_NET_CORE_H_
 
 #include <stdbool.h>
+#include <string.h>
+
+#include <logging/log.h>
+#include <sys/__assert.h>
+#include <kernel.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,29 +41,21 @@ extern "C" {
 /** @cond INTERNAL_HIDDEN */
 
 /* Network subsystem logging helpers */
-#include <logging/log.h>
-
 #define NET_DBG(fmt, ...) LOG_DBG("(%p): " fmt, k_current_get(), \
 				  ##__VA_ARGS__)
 #define NET_ERR(fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)
 #define NET_WARN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
 #define NET_INFO(fmt, ...) LOG_INF(fmt,  ##__VA_ARGS__)
 
-#include <sys/__assert.h>
-
 #define NET_ASSERT(cond) __ASSERT_NO_MSG(cond)
 #define NET_ASSERT_INFO(cond, fmt, ...) __ASSERT(cond, fmt, ##__VA_ARGS__)
 
 /** @endcond */
 
-#include <kernel.h>
-
 struct net_buf;
 struct net_pkt;
 struct net_context;
 struct net_if;
-
-#include <string.h>
 
 /**
  * @brief Net Verdict
@@ -187,6 +184,7 @@ struct net_stack_info {
 #define NET_STACK_DEFINE_EMBEDDED(name, size) char name[size]
 
 #if defined(CONFIG_INIT_STACKS)
+/* Legacy case: retain containing extern "C" with C++ */
 #include <debug/stack.h>
 
 static inline void net_analyze_stack_get_values(const char *stack,

--- a/include/net/net_mgmt.h
+++ b/include/net/net_mgmt.h
@@ -14,6 +14,7 @@
 
 #include <sys/__assert.h>
 #include <net/net_core.h>
+#include <net/net_event.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,8 +72,6 @@ struct net_if;
 #define NET_MGMT_LAYER_L4		3
 
 /** @endcond */
-
-#include <net/net_event.h>
 
 
 /**

--- a/include/net/net_stats.h
+++ b/include/net/net_stats.h
@@ -16,6 +16,7 @@
 
 #include <zephyr/types.h>
 #include <net/net_core.h>
+#include <net/net_mgmt.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -392,8 +393,6 @@ struct net_stats_ppp {
 
 #if defined(CONFIG_NET_STATISTICS_USER_API)
 /* Management part definitions */
-
-#include <net/net_mgmt.h>
 
 #define _NET_STATS_LAYER	NET_MGMT_LAYER_L3
 #define _NET_STATS_CODE		0x101

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -697,6 +697,11 @@ struct addrinfo {
 	struct addrinfo *ai_next;
 };
 
+/* Legacy case: retain containing extern "C" with C++
+ *
+ * This header requires aliases defined within this file, and can't
+ * easily be moved to the top.
+ */
 #include <net/socket_offload.h>
 
 static inline int inet_pton(sa_family_t family, const char *src, void *dst)

--- a/include/posix/arpa/inet.h
+++ b/include/posix/arpa/inet.h
@@ -6,11 +6,11 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_ARPA_INET_H_
 #define ZEPHYR_INCLUDE_POSIX_ARPA_INET_H_
 
+#include <net/socket.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <net/socket.h>
 
 static inline char *inet_ntop(sa_family_t family, const void *src, char *dst,
 			      size_t size)

--- a/include/posix/dirent.h
+++ b/include/posix/dirent.h
@@ -6,15 +6,15 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_DIRENT_H_
 #define ZEPHYR_INCLUDE_POSIX_DIRENT_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <limits.h>
 #include "posix_types.h"
 
 #ifdef CONFIG_POSIX_FS
 #include <fs/fs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef void DIR;
 
@@ -28,10 +28,10 @@ extern DIR *opendir(const char *dirname);
 extern int closedir(DIR *dirp);
 extern struct dirent *readdir(DIR *dirp);
 
-#endif
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* CONFIG_POSIX_FS */
 
 #endif	/* ZEPHYR_INCLUDE_POSIX_DIRENT_H_ */

--- a/include/posix/netdb.h
+++ b/include/posix/netdb.h
@@ -6,11 +6,11 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_NETDB_H_
 #define ZEPHYR_INCLUDE_POSIX_NETDB_H_
 
+#include <net/socket.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <net/socket.h>
 
 #define addrinfo zsock_addrinfo
 

--- a/include/posix/posix_types.h
+++ b/include/posix/posix_types.h
@@ -7,15 +7,15 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_TYPES_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_TYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef CONFIG_ARCH_POSIX
 #include <sys/types.h>
 #endif
 
 #include <kernel.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef unsigned long useconds_t;
 

--- a/include/posix/pthread_key.h
+++ b/include/posix/pthread_key.h
@@ -7,13 +7,13 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_PTHREAD_KEY_H_
 #define ZEPHYR_INCLUDE_POSIX_PTHREAD_KEY_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifdef CONFIG_PTHREAD_IPC
 #include <sys/slist.h>
 #include <zephyr/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef u32_t pthread_once_t;
 

--- a/include/posix/semaphore.h
+++ b/include/posix/semaphore.h
@@ -6,12 +6,12 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SEMAPHORE_H_
 #define ZEPHYR_INCLUDE_POSIX_SEMAPHORE_H_
 
+#include <posix/time.h>
+#include "posix_types.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <posix/time.h>
-#include "posix_types.h"
 
 int sem_destroy(sem_t *semaphore);
 int sem_getvalue(sem_t *restrict semaphore, int *restrict value);

--- a/include/posix/signal.h
+++ b/include/posix/signal.h
@@ -6,11 +6,11 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SIGNAL_H_
 #define ZEPHYR_INCLUDE_POSIX_SIGNAL_H_
 
+#include "posix_types.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "posix_types.h"
 
 #ifndef SIGEV_NONE
 #define SIGEV_NONE 1

--- a/include/posix/sys/socket.h
+++ b/include/posix/sys/socket.h
@@ -6,12 +6,12 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_SOCKET_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_SOCKET_H_
 
+#include <sys/types.h>
+#include <net/socket.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <sys/types.h>
-#include <net/socket.h>
 
 static inline int socket(int family, int type, int proto)
 {

--- a/include/posix/time.h
+++ b/include/posix/time.h
@@ -6,10 +6,6 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_TIME_H_
 #define ZEPHYR_INCLUDE_POSIX_TIME_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifdef CONFIG_NEWLIB_LIBC
 /* Kludge to support outdated newlib version as used in SDK 0.10 for Xtensa */
 #include <newlib.h>
@@ -17,20 +13,30 @@ extern "C" {
 #ifdef __NEWLIB__
 /* Newever Newlib 3.x+ */
 #include <sys/_timespec.h>
-#else
+#else /* __NEWLIB__ */
 /* Workaround for older Newlib 2.x, as used by Xtensa. It lacks sys/_timeval.h,
  * so mimic it here.
  */
 #include <sys/types.h>
 #ifndef __timespec_defined
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct timespec {
 	time_t tv_sec;
 	long tv_nsec;
 };
-#endif
+
+#ifdef __cplusplus
+}
 #endif
 
-#else
+#endif /* __timespec_defined */
+#endif /* __NEWLIB__ */
+
+#else /* CONFIG_NEWLIB_LIBC */
 /* Not Newlib */
 #include <sys/_timespec.h>
 #endif /* CONFIG_NEWLIB_LIBC */
@@ -44,16 +50,29 @@ struct timespec {
  */
 #if !defined(__NEWLIB_H__) || (__NEWLIB__ >= 3) || \
     (__NEWLIB__ == 2  && __NEWLIB_MINOR__ >= 2)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct itimerspec {
 	struct timespec it_interval;  /* Timer interval */
 	struct timespec it_value;     /* Timer expiration */
 };
+#ifdef __cplusplus
+}
+#endif
+
 #endif
 
 #include <kernel.h>
 #include <errno.h>
 #include "posix_types.h"
 #include <posix/signal.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef CLOCK_REALTIME
 #define CLOCK_REALTIME 0

--- a/include/posix/unistd.h
+++ b/include/posix/unistd.h
@@ -6,10 +6,6 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_UNISTD_H_
 #define ZEPHYR_INCLUDE_POSIX_UNISTD_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "posix_types.h"
 #include "sys/stat.h"
 #ifdef CONFIG_NETWORKING
@@ -19,6 +15,10 @@ extern "C" {
 
 #ifdef CONFIG_POSIX_API
 #include <fs/fs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* File related operations */
 extern int close(int file);

--- a/include/ptp_clock.h
+++ b/include/ptp_clock.h
@@ -92,10 +92,10 @@ static inline int ptp_clock_rate_adjust(struct device *dev, float rate)
 	return api->rate_adjust(dev, rate);
 }
 
-#include <syscalls/ptp_clock.h>
-
 #ifdef __cplusplus
 }
 #endif
+
+#include <syscalls/ptp_clock.h>
 
 #endif /* ZEPHYR_INCLUDE_PTP_CLOCK_H_ */

--- a/include/storage/flash_map.h
+++ b/include/storage/flash_map.h
@@ -21,10 +21,6 @@
  * @{
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  *
  * Provides abstraction of flash regions for type of use,
@@ -45,6 +41,10 @@ extern "C" {
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define SOC_FLASH_0_ID 0	/** device_id for SoC flash memory driver   */
 #define SPI_FLASH_0_ID 1	/** device_id for external SPI flash driver */

--- a/include/sw_isr_table.h
+++ b/include/sw_isr_table.h
@@ -14,13 +14,13 @@
 #ifndef ZEPHYR_INCLUDE_SW_ISR_TABLE_H_
 #define ZEPHYR_INCLUDE_SW_ISR_TABLE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(_ASMLANGUAGE)
 #include <zephyr/types.h>
 #include <toolchain.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /*
  * Note the order: arg first, then ISR. This allows a table entry to be
@@ -75,10 +75,10 @@ struct _isr_list {
 void z_isr_install(unsigned int irq, void (*routine)(void *), void *param);
 #endif
 
-#endif /* _ASMLANGUAGE */
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* _ASMLANGUAGE */
 
 #endif /* ZEPHYR_INCLUDE_SW_ISR_TABLE_H_ */

--- a/include/sys/atomic.h
+++ b/include/sys/atomic.h
@@ -456,15 +456,16 @@ static inline void atomic_set_bit_to(atomic_t *target, int bit, bool val)
 	}
 }
 
-#ifdef CONFIG_ATOMIC_OPERATIONS_C
-#include <syscalls/atomic.h>
-#endif
 /**
  * @}
  */
 
 #ifdef __cplusplus
 }
+#endif
+
+#ifdef CONFIG_ATOMIC_OPERATIONS_C
+#include <syscalls/atomic.h>
 #endif
 
 #endif /* ZEPHYR_INCLUDE_SYS_ATOMIC_H_ */

--- a/include/sys/sys_io.h
+++ b/include/sys/sys_io.h
@@ -9,12 +9,12 @@
 #ifndef ZEPHYR_INCLUDE_SYS_SYS_IO_H_
 #define ZEPHYR_INCLUDE_SYS_SYS_IO_H_
 
+#include <zephyr/types.h>
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <zephyr/types.h>
-#include <stddef.h>
 
 typedef u32_t io_port_t;
 typedef u32_t mm_reg_t;

--- a/include/sys_clock.h
+++ b/include/sys_clock.h
@@ -19,12 +19,12 @@
 #include <sys/util.h>
 #include <sys/dlist.h>
 
+#include <toolchain.h>
+#include <zephyr/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <toolchain.h>
-#include <zephyr/types.h>
 
 #ifdef CONFIG_TICKLESS_KERNEL
 extern int _sys_clock_always_on;

--- a/lib/gui/lvgl/lvgl_mem.h
+++ b/lib/gui/lvgl/lvgl_mem.h
@@ -7,11 +7,11 @@
 #ifndef ZEPHYR_LIB_GUI_LVGL_MEM_H_
 #define ZEPHYR_LIB_GUI_LVGL_MEM_H_
 
+#include <stdlib.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdlib.h>
 
 void *lvgl_malloc(size_t size);
 

--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -14,6 +14,7 @@
 #include <linker/sections.h>
 #include <offsets.h>
 #include <zephyr.h>
+#include <logging/log.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
@@ -31,8 +32,6 @@ extern "C" {
 #else
 #define LOG_LEVEL CONFIG_BT_LOG_LEVEL
 #endif
-
-#include <logging/log.h>
 
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
@@ -62,4 +61,3 @@ const char *bt_addr_le_str_real(const bt_addr_le_t *addr);
 #endif
 
 #endif /* __BT_LOG_H */
-


### PR DESCRIPTION
This PR collects fixes to #17997 specific to headers in the general include and driver area.  arch, soc, and other headers required to complete the task are not included in this PR to simplify reviewing.