### PR TITLE
doc: net: ppp: Enhance PPP documentation

### DIFF
--- a/doc/reference/networking/ppp.rst
+++ b/doc/reference/networking/ppp.rst
@@ -22,6 +22,26 @@ is similar to how Linux implements PPP.
 
 PPP support must be enabled at compile time by setting option
 :option:`CONFIG_NET_PPP` and :option:`CONFIG_NET_L2_PPP`.
+The PPP support in Zephyr 2.0 is still experimental and the implementation
+supports only these protocols:
+
+* LCP (Link Control Protocol,
+  `RFC1661 <https://tools.ietf.org/html/rfc1661>`__)
+* HDLC (High-level data link control,
+  `RFC1662 <https://tools.ietf.org/html/rfc1662>`__)
+* IPCP (IP Control Protocol,
+  `RFC1332 <https://tools.ietf.org/html/rfc1332>`__)
+* IPV6CP (IPv6 Control Protocol,
+  `RFC5072 <https://tools.ietf.org/html/rfc5072>`__)
 
 See also the :zephyr_file:`samples/net/sockets/echo_server/overlay-ppp.conf`
 file for configuration option examples.
+
+Testing
+*******
+
+See the `net-tools README`_ file for more details on how to test the Zephyr PPP
+against pppd running in Linux.
+
+.. _net-tools README:
+   https://github.com/zephyrproject-rtos/net-tools/blob/master/README.md#ppp-connectivity


### PR DESCRIPTION
Add information about supported protocols in PPP and link to
net-tools that contains information how to test ppp against
pppd running in Linux.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>