### PR TITLE
Bluetooth: Mesh: Fix heartbeat sending on Friendship established/lost

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -763,7 +763,6 @@ static void gatt_proxy_set(struct bt_mesh_model *model,
 			   struct net_buf_simple *buf)
 {
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
-	struct bt_mesh_subnet *sub;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
@@ -820,8 +819,7 @@ static void gatt_proxy_set(struct bt_mesh_model *model,
 
 	bt_mesh_adv_update();
 
-	sub = bt_mesh_subnet_get(cfg->hb_pub.net_idx);
-	if ((cfg->hb_pub.feat & BT_MESH_FEAT_PROXY) && sub) {
+	if (cfg->hb_pub.feat & BT_MESH_FEAT_PROXY) {
 		bt_mesh_heartbeat_send();
 	}
 
@@ -917,7 +915,6 @@ static void relay_set(struct bt_mesh_model *model,
 	if (!cfg) {
 		BT_WARN("No Configuration Server context available");
 	} else if (buf->data[0] == 0x00 || buf->data[0] == 0x01) {
-		struct bt_mesh_subnet *sub;
 		bool change;
 
 		if (cfg->relay == BT_MESH_RELAY_NOT_SUPPORTED) {
@@ -938,8 +935,7 @@ static void relay_set(struct bt_mesh_model *model,
 		       BT_MESH_TRANSMIT_COUNT(cfg->relay_retransmit),
 		       BT_MESH_TRANSMIT_INT(cfg->relay_retransmit));
 
-		sub = bt_mesh_subnet_get(cfg->hb_pub.net_idx);
-		if ((cfg->hb_pub.feat & BT_MESH_FEAT_RELAY) && sub && change) {
+		if ((cfg->hb_pub.feat & BT_MESH_FEAT_RELAY) && change) {
 			bt_mesh_heartbeat_send();
 		}
 	} else {
@@ -2660,7 +2656,6 @@ static void friend_set(struct bt_mesh_model *model,
 		       struct net_buf_simple *buf)
 {
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
-	struct bt_mesh_subnet *sub;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
@@ -2694,8 +2689,7 @@ static void friend_set(struct bt_mesh_model *model,
 		}
 	}
 
-	sub = bt_mesh_subnet_get(cfg->hb_pub.net_idx);
-	if ((cfg->hb_pub.feat & BT_MESH_FEAT_FRIEND) && sub) {
+	if (cfg->hb_pub.feat & BT_MESH_FEAT_FRIEND) {
 		bt_mesh_heartbeat_send();
 	}
 

--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -199,6 +199,7 @@ static int send_friend_clear(void)
 
 static void clear_friendship(bool force, bool disable)
 {
+	struct bt_mesh_cfg_srv *cfg = bt_mesh_cfg_get();
 	struct bt_mesh_lpn *lpn = &bt_mesh.lpn;
 
 	BT_DBG("force %u disable %u", force, disable);
@@ -245,6 +246,10 @@ static void clear_friendship(bool force, bool disable)
 	 * modified meanwhile.
 	 */
 	lpn->groups_changed = 1U;
+
+	if (cfg->hb_pub.feat & BT_MESH_FEAT_LOW_POWER) {
+		bt_mesh_heartbeat_send();
+	}
 
 	if (disable) {
 		lpn_set_state(BT_MESH_LPN_DISABLED);
@@ -944,6 +949,8 @@ int bt_mesh_lpn_friend_update(struct bt_mesh_net_rx *rx,
 	}
 
 	if (!lpn->established) {
+		struct bt_mesh_cfg_srv *cfg = bt_mesh_cfg_get();
+
 		/* This is normally checked on the transport layer, however
 		 * in this state we're also still accepting master
 		 * credentials so we need to ensure the right ones (Friend
@@ -957,6 +964,10 @@ int bt_mesh_lpn_friend_update(struct bt_mesh_net_rx *rx,
 		lpn->established = 1U;
 
 		BT_INFO("Friendship established with 0x%04x", lpn->frnd);
+
+		if (cfg->hb_pub.feat & BT_MESH_FEAT_LOW_POWER) {
+			bt_mesh_heartbeat_send();
+		}
 
 		if (lpn_cb) {
 			lpn_cb(lpn->frnd, true);

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1547,11 +1547,9 @@ void bt_mesh_heartbeat_send(void)
 		feat |= BT_MESH_FEAT_FRIEND;
 	}
 
-#if defined(CONFIG_BT_MESH_LOW_POWER)
-	if (bt_mesh.lpn.state != BT_MESH_LPN_DISABLED) {
+	if (bt_mesh_lpn_established()) {
 		feat |= BT_MESH_FEAT_LOW_POWER;
 	}
-#endif
 
 	hb.feat = sys_cpu_to_be16(feat);
 

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1528,6 +1528,11 @@ void bt_mesh_heartbeat_send(void)
 		.xmit = bt_mesh_net_transmit_get(),
 	};
 
+	/* Do nothing if heartbeat publication is not enabled */
+	if (cfg->hb_pub.dst == BT_MESH_ADDR_UNASSIGNED) {
+		return;
+	}
+
 	hb.init_ttl = cfg->hb_pub.ttl;
 
 	if (bt_mesh_relay_get() == BT_MESH_RELAY_ENABLED) {

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1506,3 +1506,52 @@ void bt_mesh_rpl_clear(void)
 	BT_DBG("");
 	(void)memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
 }
+
+void bt_mesh_heartbeat_send(void)
+{
+	struct bt_mesh_cfg_srv *cfg = bt_mesh_cfg_get();
+	u16_t feat = 0U;
+	struct __packed {
+		u8_t  init_ttl;
+		u16_t feat;
+	} hb;
+	struct bt_mesh_msg_ctx ctx = {
+		.net_idx = cfg->hb_pub.net_idx,
+		.app_idx = BT_MESH_KEY_UNUSED,
+		.addr = cfg->hb_pub.dst,
+		.send_ttl = cfg->hb_pub.ttl,
+	};
+	struct bt_mesh_net_tx tx = {
+		.sub = bt_mesh_subnet_get(cfg->hb_pub.net_idx),
+		.ctx = &ctx,
+		.src = bt_mesh_model_elem(cfg->model)->addr,
+		.xmit = bt_mesh_net_transmit_get(),
+	};
+
+	hb.init_ttl = cfg->hb_pub.ttl;
+
+	if (bt_mesh_relay_get() == BT_MESH_RELAY_ENABLED) {
+		feat |= BT_MESH_FEAT_RELAY;
+	}
+
+	if (bt_mesh_gatt_proxy_get() == BT_MESH_GATT_PROXY_ENABLED) {
+		feat |= BT_MESH_FEAT_PROXY;
+	}
+
+	if (bt_mesh_friend_get() == BT_MESH_FRIEND_ENABLED) {
+		feat |= BT_MESH_FEAT_FRIEND;
+	}
+
+#if defined(CONFIG_BT_MESH_LOW_POWER)
+	if (bt_mesh.lpn.state != BT_MESH_LPN_DISABLED) {
+		feat |= BT_MESH_FEAT_LOW_POWER;
+	}
+#endif
+
+	hb.feat = sys_cpu_to_be16(feat);
+
+	BT_DBG("InitTTL %u feat 0x%04x", cfg->hb_pub.ttl, feat);
+
+	bt_mesh_ctl_send(&tx, TRANS_CTL_OP_HEARTBEAT, &hb, sizeof(hb),
+			 NULL, NULL, NULL);
+}

--- a/subsys/bluetooth/mesh/transport.h
+++ b/subsys/bluetooth/mesh/transport.h
@@ -94,3 +94,5 @@ int bt_mesh_trans_recv(struct net_buf_simple *buf, struct bt_mesh_net_rx *rx);
 void bt_mesh_trans_init(void);
 
 void bt_mesh_rpl_clear(void);
+
+void bt_mesh_heartbeat_send(void);


### PR DESCRIPTION
Mesh Profile 3.6.7.2 Publishing Heartbeat messages:
    
```
Triggered publishing of Heartbeat messages is enabled by
the Heartbeat Publication Features state (see Section 4.2.17.5):
...
- If the Low Power bit is set to 1, a Heartbeat message shall be
published when the node establishes or loses Friendship (see Section 3.6.6.1).
```
  
Fixes #18194

