### PR TITLE
Bluetooth: Mesh: Fix canceling publication retransmission timer

### DIFF
--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -231,11 +231,6 @@ static void mod_publish(struct k_work *work)
 	if (err) {
 		BT_ERR("Publishing failed (err %d)", err);
 	}
-
-	if (pub->count) {
-		/* Retransmissions also control the timer */
-		k_delayed_work_cancel(&pub->timer);
-	}
 }
 
 struct bt_mesh_elem *bt_mesh_model_elem(struct bt_mesh_model *mod)


### PR DESCRIPTION
This branch is inherited from old code that used to start the timer as
soon as a message was queued for transmission rather than when it was
actually transmitted (the case today). It'll also cause a race in case
the publication goes over the GATT layer since the "sent" callback
happens synchronously in that case.

Fixes #17821

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>