### PR TITLE
kconfig: cpp: Have LIB_CPLUSPLUS depend on NEWLIB_LIBC

### DIFF
--- a/subsys/cpp/Kconfig
+++ b/subsys/cpp/Kconfig
@@ -47,25 +47,25 @@ config STD_CPP2A
 
 endchoice
 
+if ! MINIMAL_LIBC
+
 config LIB_CPLUSPLUS
 	bool "Link with STD C++ library"
 	help
 	  Link with STD C++ Library.
 
+if LIB_CPLUSPLUS
+
 config EXCEPTIONS
 	bool "Enable C++ exceptions support"
-	select LIB_CPLUSPLUS
-	depends on !MINIMAL_LIBC
 	help
 	  This option enables support of C++ exceptions.
 
 config RTTI
 	bool "Enable C++ RTTI support"
-	select LIB_CPLUSPLUS
 	help
 	  This option enables support of C++ RTTI.
 
-if LIB_CPLUSPLUS
 
 config ZEPHYR_CPLUSPLUS
 	bool "Use Zephyr C++ Implementation"
@@ -74,5 +74,7 @@ config ZEPHYR_CPLUSPLUS
 	  functions and vtables.
 
 endif # LIB_CPLUSPLUS
+
+endif # ! MINIMAL_LIBC
 
 endif # CPLUSPLUS


### PR DESCRIPTION
The C++ STD library is not compatible with the minimal C library. To
ensure that users do not accidentally enable LIB_CPLUSPLUS while also
enabling a minimal libc library we add a dependency in Kconfig.

Also, use depends instead of select between EXCEPTIONS, RTTI, and
LIB_CPLUSPLUS as use of select is discouraged in this situation.