### PR TITLE
Bluetooth: Mesh: Fix starting IV Update when not on primary subnet

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -722,6 +722,14 @@ u32_t bt_mesh_next_seq(void)
 		bt_mesh_store_seq();
 	}
 
+	if (!atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS) &&
+	    bt_mesh.seq > IV_UPDATE_SEQ_LIMIT &&
+	    bt_mesh_subnet_get(BT_MESH_KEY_PRIMARY)) {
+		bt_mesh_beacon_ivu_initiator(true);
+		bt_mesh_net_iv_update(bt_mesh.iv_index + 1, true);
+		bt_mesh_net_sec_update(NULL);
+	}
+
 	return seq;
 }
 
@@ -778,13 +786,6 @@ int bt_mesh_net_resend(struct bt_mesh_subnet *sub, struct net_buf *buf,
 		net_buf_unref(buf);
 	} else {
 		bt_mesh_adv_send(buf, cb, cb_data);
-	}
-
-	if (!atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS) &&
-	    bt_mesh.seq > IV_UPDATE_SEQ_LIMIT) {
-		bt_mesh_beacon_ivu_initiator(true);
-		bt_mesh_net_iv_update(bt_mesh.iv_index + 1, true);
-		bt_mesh_net_sec_update(NULL);
 	}
 
 	return 0;


### PR DESCRIPTION
The Mesh Profile Specification states in section 3.10.5 IV Update
procedure: "The IV Update procedure is initiated by any node that is a
member of a primary subnet", meaning if we're not on the primary
subnet we should not try to initiate the procedure.

Additionally this fixes initiating IV Update in all cases where the
sequence is updated, by putting the code into bt_mesh_next_seq().

Fixes #17977

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>