### PR TITLE
drivers: modem: socket: sock_fd isn't an index in modem_socket_put()

### DIFF
--- a/drivers/modem/modem_socket.c
+++ b/drivers/modem/modem_socket.c
@@ -208,15 +208,17 @@ struct modem_socket *modem_socket_from_newid(struct modem_socket_config *cfg)
 
 void modem_socket_put(struct modem_socket_config *cfg, int sock_fd)
 {
-	if (sock_fd < 0 || sock_fd >= cfg->sockets_len) {
+	struct modem_socket *sock = modem_socket_from_fd(cfg, sock_fd);
+
+	if (!sock) {
 		return;
 	}
 
-	z_free_fd(sock_fd);
-	cfg->sockets[sock_fd].id = cfg->base_socket_num - 1;
-	cfg->sockets[sock_fd].sock_fd = -1;
-	(void)memset(&cfg->sockets[sock_fd].src, 0, sizeof(struct sockaddr));
-	(void)memset(&cfg->sockets[sock_fd].dst, 0, sizeof(struct sockaddr));
+	z_free_fd(sock->sock_fd);
+	sock->id = cfg->base_socket_num - 1;
+	sock->sock_fd = -1;
+	(void)memset(&sock->src, 0, sizeof(struct sockaddr));
+	(void)memset(&sock->dst, 0, sizeof(struct sockaddr));
 }
 
 /*


### PR DESCRIPTION
modem_socket_put() originally took an index as a parameter and was
later swapped to sock_fd as the reference.

The internal code was never updated to reflect that sock_fd isn't an
index -- it's a separate reference generated via z_reserve_fd().

Let's correct the modem_socket_put() logic.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/18238

Reported-by: Tobias Svehagen <tobias.svehagen@gmail.com>
Signed-off-by: Michael Scott <mike@foundries.io>