### PR TITLE
scripts: openocd: Add error if hex file is missing when flashing

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -96,6 +96,10 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             self.do_debugserver(**kwargs)
 
     def do_flash(self, **kwargs):
+        if not path.isfile(self.hex_name):
+            raise ValueError('Cannot flash; hex file is missing. '
+                             'Possibly need to enable CONFIG_BUILD_OUTPUT_HEX '
+                             'in the build')
         if self.load_cmd is None:
             raise ValueError('Cannot flash; load command is missing')
         if self.verify_cmd is None:


### PR DESCRIPTION
Add a check to make sure the hex file exists as that is what we utilize
in openocd to flash.  If its missing we report that its likely due to
not having CONFIG_BUILD_OUTPUT_HEX set.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>