### PR TITLE
cmake: Build HEX files if flash runner is openocd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1250,7 +1250,7 @@ if(CONFIG_OUTPUT_PRINT_MEMORY_USAGE)
     )
 endif()
 
-if(CONFIG_BUILD_OUTPUT_HEX)
+if(CONFIG_BUILD_OUTPUT_HEX OR BOARD_FLASH_RUNNER STREQUAL openocd)
   set(out_hex_cmd    "")
   set(out_hex_byprod "")
   set(out_hex_sections_remove


### PR DESCRIPTION
The openocd flash runner now expects a hex file, so always build a HEX
image if the runner is set to openocd.

Fixes #18181

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>