### PR TITLE
bluetooth: host: Added support for unregistering bt_conn callbacks

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -427,6 +427,14 @@ struct bt_conn_cb {
  */
 void bt_conn_cb_register(struct bt_conn_cb *cb);
 
+/** @brief Unregister connection callbacks.
+ *
+ *  Unregister callbacks from monitoring the state of connections.
+ *
+ *  @param ucb Callback struct to unregister.
+ */
+void bt_conn_cb_unregister(struct bt_conn_cb *ucb);
+
 /** Enable/disable bonding.
  *
  *  Set/clear the Bonding flag in the Authentication Requirements of

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1062,6 +1062,24 @@ void bt_conn_cb_register(struct bt_conn_cb *cb)
 	callback_list = cb;
 }
 
+void bt_conn_cb_unregister(struct bt_conn_cb *ucb)
+{
+	struct bt_conn_cb *cb, *prev_cb;
+
+	for (cb = callback_list, prev_cb = NULL; cb; cb = cb->_next) {
+		if (cb == ucb) {
+			/* Remove cb from the list */
+			if (prev_cb) {
+				prev_cb->_next = cb->_next;
+			} else {
+				callback_list = cb->_next;
+			}
+			break;
+		}
+		prev_cb = cb;
+	}
+}
+
 static void bt_conn_reset_rx_state(struct bt_conn *conn)
 {
 	if (!conn->rx_len) {


### PR DESCRIPTION
Added function bt_conn_cb_unregister for unregistering callback from
monitoring the state of a connection.

Signed-off-by: Morten Priess <mtpr@oticon.com>