### PR TITLE
xtensa: mask interrupts earlier

### DIFF
--- a/arch/xtensa/include/xtensa-asm2-s.h
+++ b/arch/xtensa/include/xtensa-asm2-s.h
@@ -291,6 +291,12 @@ _switch_stacks_\@:
 _do_call_\@:
 	CROSS_STACK_CALL
 
+	/* Mask interrupts (which have been unmasked during the handler
+	 * execution) while we muck with the windows and decrement the nested
+	 * count.  The restore will unmask them correctly.
+	 */
+	rsil a0, XCHAL_NMILEVEL
+
 	/* Decrement nest count */
 	rsr.\SR a3
 	l32i a0, a3, \NEST_OFF
@@ -303,13 +309,9 @@ _do_call_\@:
 	 * register spill before restoring, for obvious reasons.
 	 * Remember to restore the A1 stack pointer as it existed at
 	 * interrupt time so the caller of the interrupted function
-	 * spills to the right place.  Also mask interrupts (which
-	 * have been unmasked during the handler execution) while we
-	 * muck with the windows.  The restore will unmask them
-	 * correctly.
+	 * spills to the right place.
 	 */
 	beq a6, a1, _restore_\@
-	rsil a0, XCHAL_NMILEVEL
 	l32i a1, a1, 0
 	addi a1, a1, BASE_SAVE_AREA_SIZE
 	SPILL_ALL_WINDOWS


### PR DESCRIPTION
When coming out of an exception, we need to mask interrupts
to avoid races when decrementing the nested count. Move
the instruction that does this earlier.

Fixes: #16915 

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>