### PR TITLE
arch/riscv: rearrange for standard use of extern "C"

### DIFF
--- a/arch/riscv/include/kernel_arch_data.h
+++ b/arch/riscv/include/kernel_arch_data.h
@@ -15,10 +15,6 @@
 #ifndef ZEPHYR_ARCH_RISCV_INCLUDE_KERNEL_ARCH_DATA_H_
 #define ZEPHYR_ARCH_RISCV_INCLUDE_KERNEL_ARCH_DATA_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <arch/cpu.h>
@@ -31,7 +27,15 @@ extern "C" {
 #include <sys/dlist.h>
 #include <kernel_internal.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ASMLANGUAGE */
 

--- a/include/arch/riscv/arch.h
+++ b/include/arch/riscv/arch.h
@@ -24,10 +24,6 @@
 #include <soc.h>
 #include <generated_dts_board.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* stacks, for RISCV architecture stack should be 16byte-aligned */
 #define STACK_ALIGN  16
 
@@ -45,6 +41,10 @@ extern "C" {
 
 #ifndef _ASMLANGUAGE
 #include <sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define STACK_ROUND_UP(x) ROUND_UP(x, STACK_ALIGN)
 #define STACK_ROUND_DOWN(x) ROUND_DOWN(x, STACK_ALIGN)
@@ -157,14 +157,15 @@ static ALWAYS_INLINE void arch_nop(void)
 extern u32_t z_timer_cycle_get_32(void);
 #define z_arch_k_cycle_get_32()	z_timer_cycle_get_32()
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /*_ASMLANGUAGE */
 
 #if defined(CONFIG_SOC_FAMILY_RISCV_PRIVILEGE)
 #include <arch/riscv/riscv-privilege/asm_inline.h>
 #endif
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/arch/riscv/exp.h
+++ b/include/arch/riscv/exp.h
@@ -15,16 +15,16 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_RISCV_EXP_H_
 #define ZEPHYR_INCLUDE_ARCH_RISCV_EXP_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
 #include <toolchain.h>
 
 #ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
 #include <soc_context.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 /*
@@ -75,10 +75,11 @@ typedef struct __esf z_arch_esf_t;
 #ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
 typedef struct soc_esf soc_esf_t;
 #endif
-#endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* _ASMLANGUAGE */
 
 #endif /* ZEPHYR_INCLUDE_ARCH_RISCV_EXP_H_ */

--- a/include/arch/riscv/riscv-privilege/asm_inline_gcc.h
+++ b/include/arch/riscv/riscv-privilege/asm_inline_gcc.h
@@ -7,10 +7,6 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_RISCV_RISCV_PRIVILEGE_ASM_INLINE_GCC_H_
 #define ZEPHYR_INCLUDE_ARCH_RISCV_RISCV_PRIVILEGE_ASM_INLINE_GCC_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /*
  * The file must not be included directly
  * Include arch/cpu.h instead
@@ -21,11 +17,6 @@ extern "C" {
 
 #include <toolchain.h>
 
-
 #endif /* _ASMLANGUAGE */
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* ZEPHYR_INCLUDE_ARCH_RISCV_RISCV_PRIVILEGE_ASM_INLINE_GCC_H_ */


### PR DESCRIPTION
Consistently place C++ use of extern "C" after all include directives,
within the negative branch of _ASMLANGUAGE if used.

Remove extern "C" support from files that don't declare objects or
functions.

Background from issue #17997:

Declarations that use C linkage should be placed within extern "C"
so the language linkage is correct when the header is included by
a C++ compiler.

Similarly #include directives should be outside the extern "C" to
ensure the language-specific default linkage is applied to any
declarations provided by the included header.

See: https://en.cppreference.com/w/cpp/language/language_linkage
Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>