### PR TITLE
Updated lvgl to V6.0.2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
       revision: 45e630d6152824f807d3f919958605c4626cbdff
       path: modules/hal/libmetal
     - name: lvgl
-      revision: 6e3316da412649f02d133231078427e452f65db6
+      revision: d4708d0a432e95f51bdc712591ba5295b751140c
       path: modules/lib/gui/lvgl
     - name: mbedtls
       revision: ca32746072ce3381f1c9ae46ba6cd34c69f8c0ee


### PR DESCRIPTION
Updated west manifest to take in lvgl V6.0.2

This takes in a small amount of bug fixes:
* Prevent chart contents from being drawn outside margin
* Do not add right padding to calendar label's x1 coordinate
* Fix keyboard - Duplicate characters on long press
* Fix keyboard - Certain keys on the numeric keyboard were not auto-repeating
* Corrected warning in theme material
* draw_line: fix skew line draw error

Note that waring in the theme material will fail the test cases proposed in PR #18206 