### PR TITLE
[TOPIC: DTS] dts: dtlib/edtlib: Add phandle and phandle+nums array types

### DIFF
--- a/dts/bindings/binding-template.yaml
+++ b/dts/bindings/binding-template.yaml
@@ -56,7 +56,8 @@ sub-node:
 #
 #   <property name>:
 #     category: <required | optional>
-#     type: <string | int | boolean | array | uint8-array | string-array | phandle | compound>
+#     type: <string | int | boolean | array | uint8-array | string-array |
+#            phandle | phandles | phandle-array | compound>
 #     description: <description of the property>
 #     enum:
 #       - <item1>
@@ -72,13 +73,32 @@ sub-node:
 #
 # Each value is a byte in hex.
 #
-# 'phandle' is for properties that are assigned a single phandle, like this:
+# 'type: phandle' is for properties that are assigned a single phandle, like
+# this:
 #
 #   foo = <&label>;
 #
-# 'compound' is a catch-all for more complex types, e.g.
+# 'type: phandles' is for properties that are assigned a list of (just)
+# phandles, like this:
 #
-#   foo = <&label1 1 2 &label2 7>;
+#   foo = <&label1 &label2 ...>;
+#
+# 'type: phandle-array' is for properties that are assigned a list of phandles
+# and (possibly) 32-bit numbers, like this:
+#
+#   foo = <&label1 1 2 &label2 3 4 ...>;
+#
+# 'type: compound' is a catch-all for more complex types, e.g.
+#
+#   foo = <&label1>, [01 02];
+#
+# 'type: array' and the other array types also allow splitting the value into
+# several <> blocks, e.g. like this:
+#
+#   foo = <1 2>, <3 4>;                         // Okay for 'type: array'
+#   foo = <&label1 &label2>, <&label3 &label4>; // Okay for 'type: phandles'
+#   foo = <&label1 1 2>, <&label2 3 4>;         // Okay for 'type: phandle-array'
+#   etc.
 properties:
     # An entry for 'compatible' must appear, as it's used to map nodes to
     # bindings

--- a/scripts/dts/dtlib.py
+++ b/scripts/dts/dtlib.py
@@ -1452,7 +1452,7 @@ class Property:
         """
         if self.type not in (TYPE_NUM, TYPE_NUMS):
             raise DTError("expected property '{0}' on {1} in {2} to be "
-                          "assigned with '{0} = < (number) (number) ... >', "
+                          "assigned with '{0} = < (number) (number) ... >;', "
                           "not '{3}'"
                           .format(self.name, self.node.path,
                                   self.node.dt.filename, self))
@@ -1472,7 +1472,7 @@ class Property:
         """
         if self.type is not TYPE_BYTES:
             raise DTError("expected property '{0}' on {1} in {2} to be "
-                          "assigned with '{0} = [ (byte) (byte) ... ]', "
+                          "assigned with '{0} = [ (byte) (byte) ... ];', "
                           "not '{3}'".format(self.name, self.node.path,
                                              self.node.dt.filename, self))
 
@@ -1492,7 +1492,7 @@ class Property:
         """
         if self.type is not TYPE_STRING:
             raise DTError("expected property '{0}' on {1} in {2} to be "
-                          "assigned with '{0} = \"string\"', not '{3}'"
+                          "assigned with '{0} = \"string\";', not '{3}'"
                           .format(self.name, self.node.path,
                                   self.node.dt.filename, self))
 
@@ -1517,10 +1517,9 @@ class Property:
         """
         if self.type not in (TYPE_STRING, TYPE_STRINGS):
             raise DTError("expected property '{0}' on {1} in {2} to be "
-                          "assigned with '{0} = \"string\", \"string\", ...', "
-                          "not {3}"
-                          .format(self.name, self.node.path,
-                                  self.node.dt.filename, self))
+                          "assigned with '{0} = \"string\", \"string\", ... ;'"
+                          ", not '{3}'".format(self.name, self.node.path,
+                                               self.node.dt.filename, self))
 
         try:
             return self.value.decode("utf-8").split("\0")[:-1]
@@ -1534,30 +1533,18 @@ class Property:
         """
         Returns the Node the phandle in the property points to.
 
-        Raises DTError if the property was not assigned with either of these
-        syntaxes (has Property.type TYPE_PHANDLE or TYPE_NUM).
+        Raises DTError if the property was not assigned with this syntax (has
+        Property.type TYPE_PHANDLE).
 
             foo = < &bar >;
-            foo = < 1 >;
-
-        For the second case, DTError is raised if the phandle does not exist.
         """
-        if self.type not in (TYPE_PHANDLE, TYPE_NUM):
+        if self.type is not TYPE_PHANDLE:
             raise DTError("expected property '{0}' on {1} in {2} to be "
-                          "assigned with either '{0} = < &foo >' or "
-                          "'{0} = < (valid phandle number) >', not {3}"
+                          "assigned with '{0} = < &foo >;', not '{3}'"
                           .format(self.name, self.node.path,
                                   self.node.dt.filename, self))
 
-        phandle = int.from_bytes(self.value, "big")
-        node = self.node.dt.phandle2node.get(phandle)
-        if not node:
-            raise DTError("the phandle given in property '{}' ({}) on {} in "
-                          "{} does not exist"
-                          .format(self.name, phandle, self.node.path,
-                                  self.node.dt.filename))
-        return node
-
+        return self.node.dt.phandle2node[int.from_bytes(self.value, "big")]
 
     def to_path(self):
         """

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -566,6 +566,7 @@ class Device:
         if prop.description:
             prop.description = prop.description.rstrip()
         prop.val = val
+        prop.type = prop_type
         prop.enum_index = None if enum is None else enum.index(val)
 
         self.props[name] = prop
@@ -1037,6 +1038,9 @@ class Property:
       The description string from the property as given in the binding, or None
       if missing. Trailing whitespace (including newlines) is removed.
 
+    type:
+      A string with the type of the property, as given in the binding.
+
     val:
       The value of the property, with the format determined by the 'type:' key
       from the binding.
@@ -1053,6 +1057,7 @@ class Property:
     def __repr__(self):
         fields = ["name: " + self.name,
                   # repr() to deal with lists
+                  "type: " + self.type,
                   "value: " + repr(self.val)]
 
         if self.enum_index is not None:

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -155,7 +155,7 @@ def write_props(dev):
             continue
 
         # Skip phandles
-        if isinstance(prop.val, edtlib.Device):
+        if prop.type in {"phandle", "phandles"}:
             continue
 
         # Skip properties that we handle elsewhere
@@ -170,17 +170,19 @@ def write_props(dev):
 
         ident = str2ident(prop.name)
 
-        if isinstance(prop.val, bool):
+        if prop.type == "boolean":
             out_dev(dev, ident, 1 if prop.val else 0)
-        elif isinstance(prop.val, str):
+        elif prop.type == "string":
             out_dev_s(dev, ident, prop.val)
-        elif isinstance(prop.val, int):
+        elif prop.type == "int":
             out_dev(dev, ident, prop.val)
-        elif isinstance(prop.val, list):
-            for i, elm in enumerate(prop.val):
-                out_fn = out_dev_s if isinstance(elm, str) else out_dev
-                out_fn(dev, "{}_{}".format(ident, i), elm)
-        elif isinstance(prop.val, bytes):
+        elif prop.type == "array":
+            for i, val in enumerate(prop.val):
+                out_dev(dev, "{}_{}".format(ident, i), val)
+        elif prop.type == "string-array":
+            for i, val in enumerate(prop.val):
+                out_dev_s(dev, "{}_{}".format(ident, i), val)
+        elif prop.type == "uint8-array":
             out_dev(dev, ident,
                     "{ " + ", ".join("0x{:02x}".format(b) for b in prop.val) + " }")
 

--- a/scripts/dts/test-bindings/props.yaml
+++ b/scripts/dts/test-bindings/props.yaml
@@ -33,3 +33,9 @@ properties:
 
     phandle-ref:
         type: phandle
+
+    phandle-refs:
+        type: phandles
+
+    phandle-refs-and-vals:
+        type: phandle-array

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -297,11 +297,16 @@
 		string = "foo";
 		string-array = "foo", "bar", "baz";
 		phandle-ref = < &{/props/node} >;
+		phandle-refs = < &{/props/node} &{/props/node2} >;
+		phandle-refs-and-vals = < &{/props/node} 1 &{/props/node2} 2 >;
 		// Does not appear in the binding, so won't create an entry in
 		// Device.props
 		not-speced = <0>;
 
 		node {
+		};
+
+		node2 {
 		};
 	};
 

--- a/scripts/dts/testdtlib.py
+++ b/scripts/dts/testdtlib.py
@@ -1511,8 +1511,6 @@ r"value of property 'a' (b'\xff\x00') on /aliases in .tmp.dts is not valid UTF-8
 	strings = "foo", "bar", "baz";
 	invalid_strings = "foo", "\xff", "bar";
 	ref = <&{/target}>;
-	manualref = < 100 >;
-	missingref = < 123 >;
 	path = &{/target};
 	manualpath = "/target";
 	missingpath = "/missing";
@@ -1595,8 +1593,8 @@ r"value of property 'a' (b'\xff\x00') on /aliases in .tmp.dts is not valid UTF-8
     verify_to_nums("three_u", False, [1, 2, 3])
     verify_to_nums("three_u_split", False, [1, 2, 3])
 
-    verify_to_nums_error("empty", "expected property 'empty' on / in .tmp.dts to be assigned with 'empty = < (number) (number) ... >', not 'empty;'")
-    verify_to_nums_error("string", "expected property 'string' on / in .tmp.dts to be assigned with 'string = < (number) (number) ... >', not 'string = \"foo\\tbar baz\";'")
+    verify_to_nums_error("empty", "expected property 'empty' on / in .tmp.dts to be assigned with 'empty = < (number) (number) ... >;', not 'empty;'")
+    verify_to_nums_error("string", "expected property 'string' on / in .tmp.dts to be assigned with 'string = < (number) (number) ... >;', not 'string = \"foo\\tbar baz\";'")
 
     # Test Property.to_bytes()
 
@@ -1625,8 +1623,8 @@ r"value of property 'a' (b'\xff\x00') on /aliases in .tmp.dts is not valid UTF-8
     verify_to_bytes("u8", b"\x01")
     verify_to_bytes("bytes", b"\x01\x02\x03")
 
-    verify_to_bytes_error("u16", "expected property 'u16' on / in .tmp.dts to be assigned with 'u16 = [ (byte) (byte) ... ]', not 'u16 = /bits/ 16 < 0x1 0x2 >;'")
-    verify_to_bytes_error("empty", "expected property 'empty' on / in .tmp.dts to be assigned with 'empty = [ (byte) (byte) ... ]', not 'empty;'")
+    verify_to_bytes_error("u16", "expected property 'u16' on / in .tmp.dts to be assigned with 'u16 = [ (byte) (byte) ... ];', not 'u16 = /bits/ 16 < 0x1 0x2 >;'")
+    verify_to_bytes_error("empty", "expected property 'empty' on / in .tmp.dts to be assigned with 'empty = [ (byte) (byte) ... ];', not 'empty;'")
 
     # Test Property.to_string()
 
@@ -1655,8 +1653,8 @@ r"value of property 'a' (b'\xff\x00') on /aliases in .tmp.dts is not valid UTF-8
     verify_to_string("empty_string", "")
     verify_to_string("string", "foo\tbar baz")
 
-    verify_to_string_error("u", "expected property 'u' on / in .tmp.dts to be assigned with 'u = \"string\"', not 'u = < 0x1 >;'")
-    verify_to_string_error("strings", "expected property 'strings' on / in .tmp.dts to be assigned with 'strings = \"string\"', not 'strings = \"foo\", \"bar\", \"baz\";'")
+    verify_to_string_error("u", "expected property 'u' on / in .tmp.dts to be assigned with 'u = \"string\";', not 'u = < 0x1 >;'")
+    verify_to_string_error("strings", "expected property 'strings' on / in .tmp.dts to be assigned with 'strings = \"string\";', not 'strings = \"foo\", \"bar\", \"baz\";'")
     verify_to_string_error("invalid_string", r"value of property 'invalid_string' (b'\xff\x00') on / in .tmp.dts is not valid UTF-8")
 
     # Test Property.to_strings()
@@ -1687,7 +1685,7 @@ r"value of property 'a' (b'\xff\x00') on /aliases in .tmp.dts is not valid UTF-8
     verify_to_strings("string", ["foo\tbar baz"])
     verify_to_strings("strings", ["foo", "bar", "baz"])
 
-    verify_to_strings_error("u", "expected property 'u' on / in .tmp.dts to be assigned with 'u = \"string\", \"string\", ...', not u = < 0x1 >;")
+    verify_to_strings_error("u", "expected property 'u' on / in .tmp.dts to be assigned with 'u = \"string\", \"string\", ... ;', not 'u = < 0x1 >;'")
     verify_to_strings_error("invalid_strings", r"value of property 'invalid_strings' (b'foo\x00\xff\x00bar\x00') on / in .tmp.dts is not valid UTF-8")
 
     # Test Property.to_node()
@@ -1715,10 +1713,9 @@ r"value of property 'a' (b'\xff\x00') on /aliases in .tmp.dts is not valid UTF-8
             fail("{} the non-DTError '{}'".format(prefix, e))
 
     verify_to_node("ref", "/target")
-    verify_to_node("manualref", "/target")
 
-    verify_to_node_error("string", "expected property 'string' on / in .tmp.dts to be assigned with either 'string = < &foo >' or 'string = < (valid phandle number) >', not string = \"foo\\tbar baz\";")
-    verify_to_node_error("missingref", "the phandle given in property 'missingref' (123) on / in .tmp.dts does not exist")
+    verify_to_node_error("u", "expected property 'u' on / in .tmp.dts to be assigned with 'u = < &foo >;', not 'u = < 0x1 >;'")
+    verify_to_node_error("string", "expected property 'string' on / in .tmp.dts to be assigned with 'string = < &foo >;', not 'string = \"foo\\tbar baz\";'")
 
     # Test Property.to_path()
 

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -103,7 +103,7 @@ def run():
                  "Parent binding")
 
     verify_streq(edt.get_dev("/binding-include").props,
-                 "{'compatible': <Property, name: compatible, value: ['binding-include-test']>, 'foo': <Property, name: foo, value: 0>, 'bar': <Property, name: bar, value: 1>, 'baz': <Property, name: baz, value: 2>}")
+                 "{'compatible': <Property, name: compatible, type: string-array, value: ['binding-include-test']>, 'foo': <Property, name: foo, type: int, value: 0>, 'bar': <Property, name: bar, type: int, value: 1>, 'baz': <Property, name: baz, type: int, value: 2>}")
 
     #
     # Test 'sub-node:' in binding
@@ -113,14 +113,14 @@ def run():
                  "Sub-node test")
 
     verify_streq(edt.get_dev("/parent-with-sub-node/node").props,
-                 "{'foo': <Property, name: foo, value: 1>, 'bar': <Property, name: bar, value: 2>}")
+                             "{'foo': <Property, name: foo, type: int, value: 1>, 'bar': <Property, name: bar, type: int, value: 2>}")
 
     #
     # Test Device.property (derived from DT and 'properties:' in the binding)
     #
 
     verify_streq(edt.get_dev("/props").props,
-                 r"{'compatible': <Property, name: compatible, value: ['props']>, 'nonexistent-boolean': <Property, name: nonexistent-boolean, value: False>, 'existent-boolean': <Property, name: existent-boolean, value: True>, 'int': <Property, name: int, value: 1>, 'array': <Property, name: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, value: b'\x124'>, 'string': <Property, name: string, value: 'foo'>, 'string-array': <Property, name: string-array, value: ['foo', 'bar', 'baz']>, 'phandle-ref': <Property, name: phandle-ref, value: <Device /props/node in 'test.dts', no binding>>, 'phandle-refs': <Property, name: phandle-refs, value: [<Device /props/node in 'test.dts', no binding>, <Device /props/node2 in 'test.dts', no binding>]>}")
+                 r"{'compatible': <Property, name: compatible, type: string-array, value: ['props']>, 'nonexistent-boolean': <Property, name: nonexistent-boolean, type: boolean, value: False>, 'existent-boolean': <Property, name: existent-boolean, type: boolean, value: True>, 'int': <Property, name: int, type: int, value: 1>, 'array': <Property, name: array, type: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, type: uint8-array, value: b'\x124'>, 'string': <Property, name: string, type: string, value: 'foo'>, 'string-array': <Property, name: string-array, type: string-array, value: ['foo', 'bar', 'baz']>, 'phandle-ref': <Property, name: phandle-ref, type: phandle, value: <Device /props/node in 'test.dts', no binding>>, 'phandle-refs': <Property, name: phandle-refs, type: phandles, value: [<Device /props/node in 'test.dts', no binding>, <Device /props/node2 in 'test.dts', no binding>]>}")
 
     #
     # Test having multiple directories with bindings, with a different .dts file

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -120,7 +120,7 @@ def run():
     #
 
     verify_streq(edt.get_dev("/props").props,
-                 r"{'compatible': <Property, name: compatible, value: ['props']>, 'nonexistent-boolean': <Property, name: nonexistent-boolean, value: False>, 'existent-boolean': <Property, name: existent-boolean, value: True>, 'int': <Property, name: int, value: 1>, 'array': <Property, name: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, value: b'\x124'>, 'string': <Property, name: string, value: 'foo'>, 'string-array': <Property, name: string-array, value: ['foo', 'bar', 'baz']>, 'phandle-ref': <Property, name: phandle-ref, value: <Device /props/node in 'test.dts', no binding>>}")
+                 r"{'compatible': <Property, name: compatible, value: ['props']>, 'nonexistent-boolean': <Property, name: nonexistent-boolean, value: False>, 'existent-boolean': <Property, name: existent-boolean, value: True>, 'int': <Property, name: int, value: 1>, 'array': <Property, name: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, value: b'\x124'>, 'string': <Property, name: string, value: 'foo'>, 'string-array': <Property, name: string-array, value: ['foo', 'bar', 'baz']>, 'phandle-ref': <Property, name: phandle-ref, value: <Device /props/node in 'test.dts', no binding>>, 'phandle-refs': <Property, name: phandle-refs, value: [<Device /props/node in 'test.dts', no binding>, <Device /props/node2 in 'test.dts', no binding>]>}")
 
     #
     # Test having multiple directories with bindings, with a different .dts file


### PR DESCRIPTION
Change `type: phandle` to only allow the `< &foo >` syntax, and add two new types for phandle arrays:

```
dts: dtlib: Ignore manually specified phandles in type checking

Previously, Property.to_node() would allow assignments like

    x = < 1 >;

as long as 1 happened to be a valid phandle. This was deliberate, but
might hide errors, and would make the planned 'phandles' (list of
phandles) and 'phandle-array' (list of phandles and numbers) types a
bit too similar to 'type: array'.

Change Property.to_node() to only accept

    x = < &foo >;

This is probably all we need, and if you really need to accept manually
specified phandles, it can be worked around in other ways.

Piggyback some consistency nits in error messages from the
Property.to_*() functions.
```

```
dts: dtlib/edtlib: Add phandle and phandle+nums array types

Add two new type-checked property types 'phandles' and 'phandle-array'
to edtlib.

'phandles' is for pure lists of phandles, with no other data, like

    foo = < &bar &baz ... >

'phandle-array' is for lists of phandles and (possibly) numbers, like

    foo = < &bar 1 2 &baz 3 4 ... >

dt-schema also has the 'phandle-array' type.

Property.val (in edtlib) is set to an array of Device objects for the
'phandles' type.

For the 'phandle-array' type, no Property object is created. This type
is only used for type checking.

Also refactor how types that do not create a Property object
('phandle-array' and 'compound') are handled. Have _prop_val() return
None for them.

The new types are implemented with two new TYPE_PHANDLES and
TYPE_PHANDLES_AND_NUMS types at the dtlib level. There is also a new
Property.to_nodes() functions for fetching the Nodes for an array of
phandles, with type checking.
```

Also improve we handle types for properties. It was getting awkward.

```
dts: edtlib: Add a Property.type field

Deriving the type from looking at Property.val gets awkward e.g. when
there are many types that make Property.val a list. Instead, save the
type as given in the binding in Property.type.

Let Property.type just be a string. This has typo potential, but is nice
and flexible (and easy to print), and errors will probably be pretty
obvious.

Show the type in Property.__repr__() as well. This automatically gives
some test coverage.
```