### PR TITLE
[TOPIC: DTS] dts: edtlib: Fix checking of 'const: 0' and 'const: ""'

### DIFF
--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -547,14 +547,17 @@ class Device:
 
         enum = options.get("enum")
         if enum and val not in enum:
-            _err("value {} for property {} is not in enumerated "
-                 "list {} for node {}".format(val, name, enum, self.path))
+            _err("value of property '{}' on {} in {} ({!r}) is not in 'enum' "
+                 "list in {} ({!r})"
+                 .format(name, self.path, self.edt.dts_path, val,
+                         self.binding_path, enum))
 
         const = options.get("const")
-        if const and val != const:
-            _err("value {} for property {} is not in equal to const "
-                 "value {} expected for node {}"
-                 .format(val, name, const, self.path))
+        if const is not None and val != const:
+            _err("value of property '{}' on {} in {} ({!r}) is different from "
+                 "the 'const' value specified in {} ({!r})"
+                 .format(name, self.path, self.edt.dts_path, val,
+                         self.binding_path, const))
 
         # Skip properties that start with '#', like '#size-cells', and mapping
         # properties like 'gpio-map'/'interrupt-map'

--- a/scripts/dts/test-bindings/props.yaml
+++ b/scripts/dts/test-bindings/props.yaml
@@ -16,6 +16,7 @@ properties:
 
     int:
         type: int
+        const: 1
 
     array:
         type: array
@@ -25,6 +26,7 @@ properties:
 
     string:
         type: string
+        const: "foo"
 
     string-array:
         type: string-array


### PR DESCRIPTION
0 and "" are falsy in Python, so the check needs to be

    if const is not None and val != const:

instead of

    if const and val != const:

Also make the error messages for failed 'enum' and 'const' checks more
informative by including the paths to the .dts file and the binding for
the node.