### PR TITLE
Fix IPv4 connection management

### DIFF
--- a/subsys/net/lib/conn_mgr/conn_mgr.c
+++ b/subsys/net/lib/conn_mgr/conn_mgr.c
@@ -95,7 +95,7 @@ static void conn_mgr_act_on_changes(void)
 			}
 
 			if (IS_ENABLED(CONFIG_NET_IPV4)) {
-				state |= conn_mgr_ipv4_status(idx);
+				ip_state |= conn_mgr_ipv4_status(idx);
 			}
 
 			state &= ip_state;


### PR DESCRIPTION
IPv4 connection management status is stored in wrong variable. ip_state should hold the status and then it should be stored in state variable.

Fixes #18253
