### PR TITLE
[TOPIC: DTS] dts: edtlib: Sanity-check contents of 'sub-node:'

### DIFF
--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -1230,7 +1230,18 @@ def _check_binding(binding, binding_path):
                 _err("malformed '{}: bus:' value in {}, expected string"
                      .format(pc, binding_path))
 
-    # Check properties
+    _check_binding_properties(binding, binding_path)
+
+    if "sub-node" in binding:
+        if binding["sub-node"].keys() != {"properties"}:
+            _err("expected (just) 'properties:' in 'sub-node:' in {}"
+                 .format(binding_path))
+
+        _check_binding_properties(binding["sub-node"], binding_path)
+
+
+def _check_binding_properties(binding, binding_path):
+    # _check_binding() helper for checking the contents of 'properties:'
 
     if "properties" not in binding:
         return

--- a/scripts/dts/test-bindings/sub-node-parent.yaml
+++ b/scripts/dts/test-bindings/sub-node-parent.yaml
@@ -11,9 +11,9 @@ properties:
 sub-node:
     properties:
         foo:
-            required: true
+            category: required
             type: int
 
         bar:
-            required: True
+            category: required
             type: int


### PR DESCRIPTION
The contents of 'sub-node:' was assigned as-is as the binding, bypassing
_check_binding(). This also hid an error in
test-bindings/sub-node-parent.yaml.

Require 'sub-node:' to just have 'properties:' in it, and sanity-check
the properties like for regular bindings.