### PR TITLE
dts: xilinx_zynqmp: Remove stray 0 from interrupt-parent

### DIFF
--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -19,7 +19,7 @@
 					<0xf9020000 0x100>;
 			interrupt-controller;
 			#interrupt-cells = <3>;
-			interrupt-parent = <&core_intc 0>;
+			interrupt-parent = <&core_intc>;
 			label = "GIC";
 			status = "okay";
 		};


### PR DESCRIPTION
'interrupt-parent' should contain just the phandle of the node
interrupts are sent to.

This node (gic: interrupt-controller@f9010000) doesn't generate any
interrupts, so the 'interrupt-parent' value is never used (this is why
it wasn't caught). It'll give an error later with 'interrupt-parent'
declared as 'type: phandle' in bindings though.

Don't know what was intended. Just remove the 0.