### PR TITLE
sys: byteorder: Add support for sys_get_be64()

### DIFF
--- a/include/sys/byteorder.h
+++ b/include/sys/byteorder.h
@@ -230,6 +230,21 @@ static inline u32_t sys_get_be32(const u8_t src[4])
 }
 
 /**
+ *  @brief Get a 64-bit integer stored in big-endian format.
+ *
+ *  Get a 64-bit integer, stored in big-endian format in a potentially
+ *  unaligned memory location, and convert it to the host endianness.
+ *
+ *  @param src Location of the big-endian 64-bit integer to get.
+ *
+ *  @return 64-bit integer in host endianness.
+ */
+static inline u64_t sys_get_be64(const u8_t src[8])
+{
+	return ((u64_t)sys_get_be32(&src[0]) << 32) | sys_get_be32(&src[4]);
+}
+
+/**
  *  @brief Get a 16-bit integer stored in little-endian format.
  *
  *  Get a 16-bit integer, stored in little-endian format in a potentially

--- a/include/sys/byteorder.h
+++ b/include/sys/byteorder.h
@@ -155,6 +155,21 @@ static inline void sys_put_be32(u32_t val, u8_t dst[4])
 }
 
 /**
+ *  @brief Put a 64-bit integer as big-endian to arbitrary location.
+ *
+ *  Put a 64-bit integer, originally in host endianness, to a
+ *  potentially unaligned memory location in big-endian format.
+ *
+ *  @param val 64-bit integer in host endianness.
+ *  @param dst Destination memory address to store the result.
+ */
+static inline void sys_put_be64(u64_t val, u8_t dst[8])
+{
+	sys_put_be32(val >> 32, dst);
+	sys_put_be32(val, &dst[4]);
+}
+
+/**
  *  @brief Put a 16-bit integer as little-endian to arbitrary location.
  *
  *  Put a 16-bit integer, originally in host endianness, to a

--- a/tests/kernel/common/src/byteorder.c
+++ b/tests/kernel/common/src/byteorder.c
@@ -146,5 +146,44 @@ void test_sys_put_be32(void)
 }
 
 /**
+ * @brief Test sys_get_be16() functionality
+ *
+ * @details Test if sys_get_be16() correctly handles endianness.
+ *
+ * @see sys_get_be16()
+ */
+void test_sys_get_be16(void)
+{
+	u32_t val = 0xf0e1, tmp;
+	u8_t buf[] = {
+		0xf0, 0xe1
+	};
+
+	tmp = sys_get_be16(buf);
+
+	zassert_equal(tmp, val, "sys_get_be16() failed");
+}
+
+/**
+ * @brief Test sys_put_be16() functionality
+ *
+ * @details Test if sys_put_be16() correctly handles endianness.
+ *
+ * @see sys_put_be16()
+ */
+void test_sys_put_be16(void)
+{
+	u64_t val = 0xf0e1;
+	u8_t buf[] = {
+		0xf0, 0xe1
+	};
+	u8_t tmp[sizeof(u16_t)];
+
+	sys_put_be16(val, tmp);
+
+	zassert_mem_equal(tmp, buf, sizeof(u16_t), "sys_put_be16() failed");
+}
+
+/**
  * @}
  */

--- a/tests/kernel/common/src/byteorder.c
+++ b/tests/kernel/common/src/byteorder.c
@@ -87,5 +87,25 @@ void test_sys_get_be64(void)
 }
 
 /**
+ * @brief Test sys_put_be64() functionality
+ *
+ * @details Test if sys_put_be64() correctly handles endianness.
+ *
+ * @see sys_put_be64()
+ */
+void test_sys_put_be64(void)
+{
+	u64_t val = 0xf0e1d2c3b4a59687;
+	u8_t buf[] = {
+		0xf0, 0xe1, 0xd2, 0xc3, 0xb4, 0xa5, 0x96, 0x87
+	};
+	u8_t tmp[sizeof(u64_t)];
+
+	sys_put_be64(val, tmp);
+
+	zassert_mem_equal(tmp, buf, sizeof(u64_t), "sys_put_be64() failed");
+}
+
+/**
  * @}
  */

--- a/tests/kernel/common/src/byteorder.c
+++ b/tests/kernel/common/src/byteorder.c
@@ -263,5 +263,44 @@ void test_sys_put_le32(void)
 }
 
 /**
+ * @brief Test sys_get_le64() functionality
+ *
+ * @details Test if sys_get_le64() correctly handles endianness.
+ *
+ * @see sys_get_le64()
+ */
+void test_sys_get_le64(void)
+{
+	u64_t val = 0xf0e1d2c3b4a59687, tmp;
+	u8_t buf[] = {
+		0x87, 0x96, 0xa5, 0xb4, 0xc3, 0xd2, 0xe1, 0xf0
+	};
+
+	tmp = sys_get_le64(buf);
+
+	zassert_equal(tmp, val, "sys_get_le64() failed");
+}
+
+/**
+ * @brief Test sys_put_le64() functionality
+ *
+ * @details Test if sys_put_le64() correctly handles endianness.
+ *
+ * @see sys_put_le64()
+ */
+void test_sys_put_le64(void)
+{
+	u64_t val = 0xf0e1d2c3b4a59687;
+	u8_t buf[] = {
+		0x87, 0x96, 0xa5, 0xb4, 0xc3, 0xd2, 0xe1, 0xf0
+	};
+	u8_t tmp[sizeof(u64_t)];
+
+	sys_put_le64(val, tmp);
+
+	zassert_mem_equal(tmp, buf, sizeof(u64_t), "sys_put_le64() failed");
+}
+
+/**
  * @}
  */

--- a/tests/kernel/common/src/byteorder.c
+++ b/tests/kernel/common/src/byteorder.c
@@ -224,5 +224,44 @@ void test_sys_put_le16(void)
 }
 
 /**
+ * @brief Test sys_get_le32() functionality
+ *
+ * @details Test if sys_get_le32() correctly handles endianness.
+ *
+ * @see sys_get_le32()
+ */
+void test_sys_get_le32(void)
+{
+	u32_t val = 0xf0e1d2c3, tmp;
+	u8_t buf[] = {
+		0xc3, 0xd2, 0xe1, 0xf0
+	};
+
+	tmp = sys_get_le32(buf);
+
+	zassert_equal(tmp, val, "sys_get_le32() failed");
+}
+
+/**
+ * @brief Test sys_put_le32() functionality
+ *
+ * @details Test if sys_put_le32() correctly handles endianness.
+ *
+ * @see sys_put_le32()
+ */
+void test_sys_put_le32(void)
+{
+	u64_t val = 0xf0e1d2c3;
+	u8_t buf[] = {
+		0xc3, 0xd2, 0xe1, 0xf0
+	};
+	u8_t tmp[sizeof(u32_t)];
+
+	sys_put_le32(val, tmp);
+
+	zassert_mem_equal(tmp, buf, sizeof(u32_t), "sys_put_le32() failed");
+}
+
+/**
  * @}
  */

--- a/tests/kernel/common/src/byteorder.c
+++ b/tests/kernel/common/src/byteorder.c
@@ -107,5 +107,44 @@ void test_sys_put_be64(void)
 }
 
 /**
+ * @brief Test sys_get_be32() functionality
+ *
+ * @details Test if sys_get_be32() correctly handles endianness.
+ *
+ * @see sys_get_be32()
+ */
+void test_sys_get_be32(void)
+{
+	u32_t val = 0xf0e1d2c3, tmp;
+	u8_t buf[] = {
+		0xf0, 0xe1, 0xd2, 0xc3
+	};
+
+	tmp = sys_get_be32(buf);
+
+	zassert_equal(tmp, val, "sys_get_be32() failed");
+}
+
+/**
+ * @brief Test sys_put_be32() functionality
+ *
+ * @details Test if sys_put_be32() correctly handles endianness.
+ *
+ * @see sys_put_be32()
+ */
+void test_sys_put_be32(void)
+{
+	u64_t val = 0xf0e1d2c3;
+	u8_t buf[] = {
+		0xf0, 0xe1, 0xd2, 0xc3
+	};
+	u8_t tmp[sizeof(u32_t)];
+
+	sys_put_be32(val, tmp);
+
+	zassert_mem_equal(tmp, buf, sizeof(u32_t), "sys_put_be32() failed");
+}
+
+/**
  * @}
  */

--- a/tests/kernel/common/src/byteorder.c
+++ b/tests/kernel/common/src/byteorder.c
@@ -66,6 +66,26 @@ void test_byteorder_mem_swap(void)
 	zassert_true((memcmp(buf_orig_2, buf_chk_2, 11) == 0),
 		     "Swapping buffer failed");
 }
+
+/**
+ * @brief Test sys_get_be64() functionality
+ *
+ * @details Test if sys_get_be64() correctly handles endianness.
+ *
+ * @see sys_get_be64()
+ */
+void test_sys_get_be64(void)
+{
+	u64_t val = 0xf0e1d2c3b4a59687, tmp;
+	u8_t buf[] = {
+		0xf0, 0xe1, 0xd2, 0xc3, 0xb4, 0xa5, 0x96, 0x87
+	};
+
+	tmp = sys_get_be64(buf);
+
+	zassert_equal(tmp, val, "sys_get_be64() failed");
+}
+
 /**
  * @}
  */

--- a/tests/kernel/common/src/byteorder.c
+++ b/tests/kernel/common/src/byteorder.c
@@ -185,5 +185,44 @@ void test_sys_put_be16(void)
 }
 
 /**
+ * @brief Test sys_get_le16() functionality
+ *
+ * @details Test if sys_get_le16() correctly handles endianness.
+ *
+ * @see sys_get_le16()
+ */
+void test_sys_get_le16(void)
+{
+	u32_t val = 0xf0e1, tmp;
+	u8_t buf[] = {
+		0xe1, 0xf0
+	};
+
+	tmp = sys_get_le16(buf);
+
+	zassert_equal(tmp, val, "sys_get_le16() failed");
+}
+
+/**
+ * @brief Test sys_put_le16() functionality
+ *
+ * @details Test if sys_put_le16() correctly handles endianness.
+ *
+ * @see sys_put_le16()
+ */
+void test_sys_put_le16(void)
+{
+	u64_t val = 0xf0e1;
+	u8_t buf[] = {
+		0xe1, 0xf0
+	};
+	u8_t tmp[sizeof(u16_t)];
+
+	sys_put_le16(val, tmp);
+
+	zassert_mem_equal(tmp, buf, sizeof(u16_t), "sys_put_le16() failed");
+}
+
+/**
  * @}
  */

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -16,6 +16,8 @@ extern void test_sys_get_be64(void);
 extern void test_sys_put_be64(void);
 extern void test_sys_get_be32(void);
 extern void test_sys_put_be32(void);
+extern void test_sys_get_be16(void);
+extern void test_sys_put_be16(void);
 extern void test_atomic(void);
 extern void test_intmath(void);
 extern void test_printk(void);
@@ -103,6 +105,8 @@ void test_main(void)
 			 ztest_unit_test(test_sys_put_be64),
 			 ztest_unit_test(test_sys_get_be32),
 			 ztest_unit_test(test_sys_put_be32),
+			 ztest_unit_test(test_sys_get_be16),
+			 ztest_unit_test(test_sys_put_be16),
 			 ztest_user_unit_test(test_atomic),
 			 ztest_unit_test(test_bitfield),
 			 ztest_unit_test(test_printk),

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -20,6 +20,8 @@ extern void test_sys_get_be16(void);
 extern void test_sys_put_be16(void);
 extern void test_sys_get_le16(void);
 extern void test_sys_put_le16(void);
+extern void test_sys_get_le32(void);
+extern void test_sys_put_le32(void);
 extern void test_atomic(void);
 extern void test_intmath(void);
 extern void test_printk(void);
@@ -111,6 +113,8 @@ void test_main(void)
 			 ztest_unit_test(test_sys_put_be16),
 			 ztest_unit_test(test_sys_get_le16),
 			 ztest_unit_test(test_sys_put_le16),
+			 ztest_unit_test(test_sys_get_le32),
+			 ztest_unit_test(test_sys_put_le32),
 			 ztest_user_unit_test(test_atomic),
 			 ztest_unit_test(test_bitfield),
 			 ztest_unit_test(test_printk),

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -13,6 +13,7 @@
 extern void test_byteorder_memcpy_swap(void);
 extern void test_byteorder_mem_swap(void);
 extern void test_sys_get_be64(void);
+extern void test_sys_put_be64(void);
 extern void test_atomic(void);
 extern void test_intmath(void);
 extern void test_printk(void);
@@ -97,6 +98,7 @@ void test_main(void)
 			 ztest_unit_test(test_byteorder_memcpy_swap),
 			 ztest_unit_test(test_byteorder_mem_swap),
 			 ztest_unit_test(test_sys_get_be64),
+			 ztest_unit_test(test_sys_put_be64),
 			 ztest_user_unit_test(test_atomic),
 			 ztest_unit_test(test_bitfield),
 			 ztest_unit_test(test_printk),

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -18,6 +18,8 @@ extern void test_sys_get_be32(void);
 extern void test_sys_put_be32(void);
 extern void test_sys_get_be16(void);
 extern void test_sys_put_be16(void);
+extern void test_sys_get_le16(void);
+extern void test_sys_put_le16(void);
 extern void test_atomic(void);
 extern void test_intmath(void);
 extern void test_printk(void);
@@ -107,6 +109,8 @@ void test_main(void)
 			 ztest_unit_test(test_sys_put_be32),
 			 ztest_unit_test(test_sys_get_be16),
 			 ztest_unit_test(test_sys_put_be16),
+			 ztest_unit_test(test_sys_get_le16),
+			 ztest_unit_test(test_sys_put_le16),
 			 ztest_user_unit_test(test_atomic),
 			 ztest_unit_test(test_bitfield),
 			 ztest_unit_test(test_printk),

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -14,6 +14,8 @@ extern void test_byteorder_memcpy_swap(void);
 extern void test_byteorder_mem_swap(void);
 extern void test_sys_get_be64(void);
 extern void test_sys_put_be64(void);
+extern void test_sys_get_be32(void);
+extern void test_sys_put_be32(void);
 extern void test_atomic(void);
 extern void test_intmath(void);
 extern void test_printk(void);
@@ -99,6 +101,8 @@ void test_main(void)
 			 ztest_unit_test(test_byteorder_mem_swap),
 			 ztest_unit_test(test_sys_get_be64),
 			 ztest_unit_test(test_sys_put_be64),
+			 ztest_unit_test(test_sys_get_be32),
+			 ztest_unit_test(test_sys_put_be32),
 			 ztest_user_unit_test(test_atomic),
 			 ztest_unit_test(test_bitfield),
 			 ztest_unit_test(test_printk),

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -22,6 +22,8 @@ extern void test_sys_get_le16(void);
 extern void test_sys_put_le16(void);
 extern void test_sys_get_le32(void);
 extern void test_sys_put_le32(void);
+extern void test_sys_get_le64(void);
+extern void test_sys_put_le64(void);
 extern void test_atomic(void);
 extern void test_intmath(void);
 extern void test_printk(void);
@@ -115,6 +117,8 @@ void test_main(void)
 			 ztest_unit_test(test_sys_put_le16),
 			 ztest_unit_test(test_sys_get_le32),
 			 ztest_unit_test(test_sys_put_le32),
+			 ztest_unit_test(test_sys_get_le64),
+			 ztest_unit_test(test_sys_put_le64),
 			 ztest_user_unit_test(test_atomic),
 			 ztest_unit_test(test_bitfield),
 			 ztest_unit_test(test_printk),

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -12,6 +12,7 @@
 
 extern void test_byteorder_memcpy_swap(void);
 extern void test_byteorder_mem_swap(void);
+extern void test_sys_get_be64(void);
 extern void test_atomic(void);
 extern void test_intmath(void);
 extern void test_printk(void);
@@ -95,6 +96,7 @@ void test_main(void)
 			 ztest_unit_test(test_irq_offload),
 			 ztest_unit_test(test_byteorder_memcpy_swap),
 			 ztest_unit_test(test_byteorder_mem_swap),
+			 ztest_unit_test(test_sys_get_be64),
 			 ztest_user_unit_test(test_atomic),
 			 ztest_unit_test(test_bitfield),
 			 ztest_unit_test(test_printk),


### PR DESCRIPTION
There is sys_get_le64() already but nothing for 64-bit
big-endian version.

Fixes #18258

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>