### PR TITLE
dts/bindings: Fix ilitek,ili9340 reset-gpios property being required

### DIFF
--- a/dts/bindings/display/ilitek,ili9340.yaml
+++ b/dts/bindings/display/ilitek,ili9340.yaml
@@ -18,7 +18,7 @@ properties:
 
     reset-gpios:
       type: compound
-      category: required
+      category: optional
 
     cmd-data-gpios:
       type: compound


### PR DESCRIPTION
Mark the 'reset-gpios' property as optional.  It was incorrectly set
as required and its not required for the driver to function.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>