### PR TITLE
flash: fix #18263

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -329,24 +329,25 @@ static int stm32_flash_init(struct device *dev)
 	LL_AHB3_GRP1_EnableClock(LL_AHB3_GRP1_PERIPH_HSEM);
 #endif /* CONFIG_SOC_SERIES_STM32WBX */
 
-#if defined(CONFIG_SOC_SERIES_STM32F4X)
-	// make sure that user options are disabled
-	// they affecting if flash read/write operations
-	// are allowed on the flash for spezific sectors
+#ifdef CONFIG_SOC_SERIES_STM32F4X
+	/*
+	 * make sure that user options are disabled
+	 * they affecting if flash read/write operations
+	 * are allowed on the flash for spezific sectors
+	 */
 	struct stm32f4x_flash *regs = FLASH_STM32_REGS(dev);
 
-	// check if we are not in the typical rest config
-	if (regs->optcr!=0x0FFFFFED) {
-		// clear OPTLOCK
-		regs->optkeyr=0x08192A3B;
-		regs->optkeyr=0x4C5D6E7F;
+	/* check if we are not in the typical reset config*/
+	if (regs->optcr != 0x0FFFFFED) {
+		/* clear OPTLOCK */
+		regs->optkeyr = 0x08192A3B;
+		regs->optkeyr = 0x4C5D6E7F;
 		if (regs->optkeyr & 1) {
-			// still locked
-			// we failed
+			/* still locked so we failed*/
 			return -EIO;
 		}
-		// now write rest config
-		regs->optcr=0x0FFFFFED;
+		/* write reset config register content*/
+		regs->optcr = 0x0FFFFFED;
 	}
 #endif
 


### PR DESCRIPTION
stm32f4 flash code assumes that it is run after reset. In case of having a bootloader run before it may changes the flash registers. This can lead to failed read/write/erase operations.

This fix addresses the stm32f4 flash driver. It clears the OPTCR register and take care, that the driver resets the flash settings to the reset defaults.