### PR TITLE
dts/binding/sensor: Fix ST sensors irq-gpios property being required

### DIFF
--- a/dts/bindings/sensor/st,lis2dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dh-i2c.yaml
@@ -18,4 +18,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      category: optional

--- a/dts/bindings/sensor/st,lis2dh-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dh-spi.yaml
@@ -19,4 +19,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      category: optional

--- a/dts/bindings/sensor/st,lis3dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis3dh-i2c.yaml
@@ -18,4 +18,4 @@ properties:
 
     irq-gpios:
       type: compound
-      category: required
+      category: optional


### PR DESCRIPTION
Change binding for ST sensors property 'irq-gpios' to optional for the
cases of in which its obvious from the driver that the property is
optional (there's an ifdef based on the #define
DT_INST_0_ST_LIS2DH_IRQ_GPIOS_*).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>