### PR TITLE
Bluetooth: GATT: Fixes

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -866,6 +866,8 @@ typedef void (*bt_gatt_indicate_func_t)(struct bt_conn *conn,
 /** @brief GATT Indicate Value parameters */
 struct bt_gatt_indicate_params {
 	struct bt_att_req _req;
+	/** Notification Attribute UUID type */
+	const struct bt_uuid *uuid;
 	/** Indicate Attribute object*/
 	const struct bt_gatt_attr *attr;
 	/** Indicate Value callback */
@@ -878,9 +880,21 @@ struct bt_gatt_indicate_params {
 
 /** @brief Indicate attribute value change.
  *
- *  Send an indication of attribute value change.
- *  Note: This function should only be called if CCC is declared with
- *  BT_GATT_CCC otherwise it cannot find a valid peer configuration.
+ *  Send an indication of attribute value change. if connection is NULL
+ *  indicate all peer that have notification enabled via CCC otherwise do a
+ *  direct indication only the given connection.
+ *
+ *  The attribute object on the parameters can be the so called Characteristic
+ *  Declaration, which is usually declared with BT_GATT_CHARACTERISTIC followed
+ *  by BT_GATT_CCC, or the Characteristic Value Declaration which is
+ *  automatically created after the Characteristic Declaration when using
+ *  BT_GATT_CHARACTERISTIC.
+ *
+ *  The callback is run from System Workqueue context.
+ *
+ *  Alternatively it is possible to indicate by UUID by setting it on the
+ *  parameters, when using this method the attribute given is used as the
+ *  start range when looking up for possible matches.
  *
  *  Note: This procedure is asynchronous therefore the parameters need to
  *  remains valid while it is active.

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -802,7 +802,7 @@ struct bt_gatt_notify_params {
  *  The callback is run from System Workqueue context.
  *
  *  Alternatively it is possible to notify by UUID by setting it on the
- *  parameters, when using this method the attribute given when be used as the
+ *  parameters, when using this method the attribute given is used as the
  *  start range when looking up for possible matches.
  *
  *  @param conn Connection object.

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -568,8 +568,7 @@ struct bt_gatt_ccc_cfg {
 
 /* Internal representation of CCC value */
 struct _bt_gatt_ccc {
-	struct bt_gatt_ccc_cfg	*cfg;
-	size_t			cfg_len;
+	struct bt_gatt_ccc_cfg	cfg[BT_GATT_CCC_MAX];
 	u16_t			value;
 	void			(*cfg_changed)(const struct bt_gatt_attr *attr,
 					       u16_t value);
@@ -623,31 +622,29 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
  *
  *  Helper macro to declare a Managed CCC attribute.
  *
- *  @param _cfg Initial configuration.
  *  @param _changed Configuration changed callback.
  *  @param _write Configuration write callback.
  *  @param _match Configuration match callback.
  */
-#define BT_GATT_CCC_MANAGED(_cfg, _changed, _write, _match)		\
+#define BT_GATT_CCC_MANAGED(_changed, _write, _match)			\
 	BT_GATT_ATTRIBUTE(BT_UUID_GATT_CCC,				\
 			BT_GATT_PERM_READ | BT_GATT_PERM_WRITE,		\
 			bt_gatt_attr_read_ccc, bt_gatt_attr_write_ccc,	\
-			(&(struct _bt_gatt_ccc) { .cfg = _cfg,		\
-					       .cfg_len = ARRAY_SIZE(_cfg), \
-					       .cfg_changed = _changed, \
-					       .cfg_write = _write, \
-					       .cfg_match = _match }))
+			(&(struct _bt_gatt_ccc) {			\
+				.cfg = {},				\
+				.cfg_changed = _changed,		\
+				.cfg_write = _write,			\
+				.cfg_match = _match }))
 
 /** @def BT_GATT_CCC
  *  @brief Client Characteristic Configuration Declaration Macro.
  *
  *  Helper macro to declare a CCC attribute.
  *
- *  @param _cfg Initial configuration.
  *  @param _cfg_changed Configuration changed callback.
  */
-#define BT_GATT_CCC(_cfg, _cfg_changed)					\
-	BT_GATT_CCC_MANAGED(_cfg, _cfg_changed, NULL, NULL)
+#define BT_GATT_CCC(_cfg_changed)					\
+	BT_GATT_CCC_MANAGED(_cfg_changed, NULL, NULL)
 
 /** @brief Read Characteristic Extended Properties Attribute helper
  *

--- a/samples/bluetooth/peripheral/src/cts.c
+++ b/samples/bluetooth/peripheral/src/cts.c
@@ -22,7 +22,6 @@
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt.h>
 
-static struct bt_gatt_ccc_cfg ct_ccc_cfg[BT_GATT_CCC_MAX] = {};
 static u8_t ct[10];
 static u8_t ct_update;
 
@@ -63,7 +62,7 @@ BT_GATT_SERVICE_DEFINE(cts_cvs,
 			       BT_GATT_CHRC_NOTIFY | BT_GATT_CHRC_WRITE,
 			       BT_GATT_PERM_READ | BT_GATT_PERM_WRITE,
 			       read_ct, write_ct, ct),
-	BT_GATT_CCC(ct_ccc_cfg, ct_ccc_cfg_changed),
+	BT_GATT_CCC(ct_ccc_cfg_changed),
 );
 
 static void generate_current_time(u8_t *buf)

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -65,7 +65,6 @@ static ssize_t write_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 	return len;
 }
 
-static struct bt_gatt_ccc_cfg vnd_ccc_cfg[BT_GATT_CCC_MAX] = {};
 static u8_t simulate_vnd;
 static u8_t indicating;
 static struct bt_gatt_indicate_params ind_params;
@@ -195,7 +194,7 @@ BT_GATT_SERVICE_DEFINE(vnd_svc,
 			       BT_GATT_PERM_READ_ENCRYPT |
 			       BT_GATT_PERM_WRITE_ENCRYPT,
 			       read_vnd, write_vnd, vnd_value),
-	BT_GATT_CCC(vnd_ccc_cfg, vnd_ccc_cfg_changed),
+	BT_GATT_CCC(vnd_ccc_cfg_changed),
 	BT_GATT_CHARACTERISTIC(&vnd_auth_uuid.uuid,
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE,
 			       BT_GATT_PERM_READ_AUTHEN |

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -76,8 +76,6 @@
 
 /* Cycling Speed and Cadence Service declaration */
 
-static struct bt_gatt_ccc_cfg csc_meas_ccc_cfg[BT_GATT_CCC_MAX];
-static struct bt_gatt_ccc_cfg ctrl_point_ccc_cfg[BT_GATT_CCC_MAX];
 static u32_t cwr; /* Cumulative Wheel Revolutions */
 static u8_t supported_locations[] = CSC_SUPPORTED_LOCATIONS;
 static u8_t sensor_location; /* Current Sensor Location */
@@ -204,7 +202,7 @@ BT_GATT_SERVICE_DEFINE(csc_svc,
 	BT_GATT_PRIMARY_SERVICE(BT_UUID_CSC),
 	BT_GATT_CHARACTERISTIC(BT_UUID_CSC_MEASUREMENT, BT_GATT_CHRC_NOTIFY,
 			       0x00, NULL, NULL, NULL),
-	BT_GATT_CCC(csc_meas_ccc_cfg, csc_meas_ccc_cfg_changed),
+	BT_GATT_CCC(csc_meas_ccc_cfg_changed),
 	BT_GATT_CHARACTERISTIC(BT_UUID_SENSOR_LOCATION, BT_GATT_CHRC_READ,
 			       BT_GATT_PERM_READ, read_location, NULL,
 			       &sensor_location),
@@ -214,7 +212,7 @@ BT_GATT_SERVICE_DEFINE(csc_svc,
 			       BT_GATT_CHRC_WRITE | BT_GATT_CHRC_INDICATE,
 			       BT_GATT_PERM_WRITE, NULL, write_ctrl_point,
 			       &sensor_location),
-	BT_GATT_CCC(ctrl_point_ccc_cfg, ctrl_point_ccc_cfg_changed),
+	BT_GATT_CCC(ctrl_point_ccc_cfg_changed),
 );
 
 struct sc_ctrl_point_ind {

--- a/samples/bluetooth/peripheral_esp/src/main.c
+++ b/samples/bluetooth/peripheral_esp/src/main.c
@@ -96,7 +96,6 @@ struct temperature_sensor {
 		s16_t ref_val; /* Reference temperature */
 	};
 
-	struct bt_gatt_ccc_cfg  ccc_cfg[BT_GATT_CCC_MAX];
 	struct es_measurement meas;
 };
 
@@ -299,7 +298,7 @@ BT_GATT_SERVICE_DEFINE(ess_svc,
 	BT_GATT_DESCRIPTOR(BT_UUID_ES_TRIGGER_SETTING,
 			   BT_GATT_PERM_READ, read_temp_trigger_setting,
 			   NULL, &sensor_1),
-	BT_GATT_CCC(sensor_1.ccc_cfg, temp_ccc_cfg_changed),
+	BT_GATT_CCC(temp_ccc_cfg_changed),
 
 	/* Temperature Sensor 2 */
 	BT_GATT_CHARACTERISTIC(BT_UUID_TEMPERATURE,
@@ -314,7 +313,7 @@ BT_GATT_SERVICE_DEFINE(ess_svc,
 	BT_GATT_DESCRIPTOR(BT_UUID_ES_TRIGGER_SETTING,
 			   BT_GATT_PERM_READ, read_temp_trigger_setting,
 			   NULL, &sensor_2),
-	BT_GATT_CCC(sensor_2.ccc_cfg, temp_ccc_cfg_changed),
+	BT_GATT_CCC(temp_ccc_cfg_changed),
 
 	/* Humidity Sensor */
 	BT_GATT_CHARACTERISTIC(BT_UUID_HUMIDITY, BT_GATT_CHRC_READ,

--- a/samples/bluetooth/peripheral_hids/src/hog.c
+++ b/samples/bluetooth/peripheral_hids/src/hog.c
@@ -55,7 +55,6 @@ static struct hids_report input = {
 	.type = HIDS_INPUT,
 };
 
-static struct bt_gatt_ccc_cfg input_ccc_cfg[BT_GATT_CCC_MAX] = {};
 static u8_t simulate_input;
 static u8_t ctrl_point;
 static u8_t report_map[] = {
@@ -151,7 +150,7 @@ BT_GATT_SERVICE_DEFINE(hog_svc,
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
 			       BT_GATT_PERM_READ_AUTHEN,
 			       read_input_report, NULL, NULL),
-	BT_GATT_CCC(input_ccc_cfg, input_ccc_changed),
+	BT_GATT_CCC(input_ccc_changed),
 	BT_GATT_DESCRIPTOR(BT_UUID_HIDS_REPORT_REF, BT_GATT_PERM_READ,
 			   read_report, NULL, &input),
 	BT_GATT_CHARACTERISTIC(BT_UUID_HIDS_CTRL_POINT,

--- a/samples/bluetooth/peripheral_ht/src/hts.c
+++ b/samples/bluetooth/peripheral_ht/src/hts.c
@@ -22,7 +22,6 @@
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt.h>
 
-static struct bt_gatt_ccc_cfg htmc_ccc_cfg[BT_GATT_CCC_MAX] = {};
 static u8_t simulate_htm;
 static u8_t indicating;
 static struct bt_gatt_indicate_params ind_params;
@@ -47,7 +46,7 @@ BT_GATT_SERVICE_DEFINE(hts_svc,
 	BT_GATT_PRIMARY_SERVICE(BT_UUID_HTS),
 	BT_GATT_CHARACTERISTIC(BT_UUID_HTS_MEASUREMENT, BT_GATT_CHRC_INDICATE,
 			       BT_GATT_PERM_NONE, NULL, NULL, NULL),
-	BT_GATT_CCC(htmc_ccc_cfg, htmc_ccc_cfg_changed),
+	BT_GATT_CCC(htmc_ccc_cfg_changed),
 	/* more optional Characteristics */
 );
 

--- a/samples/boards/bbc_microbit/pong/src/ble.c
+++ b/samples/boards/bbc_microbit/pong/src/ble.c
@@ -496,8 +496,6 @@ static void ble_timeout(struct k_work *work)
 	}
 }
 
-static struct bt_gatt_ccc_cfg pong_ccc_cfg[BT_GATT_CCC_MAX];
-
 static void pong_ccc_cfg_changed(const struct bt_gatt_attr *attr, u16_t val)
 {
 	printk("val %u\n", val);
@@ -514,7 +512,7 @@ BT_GATT_SERVICE_DEFINE(pong_svc,
 	BT_GATT_PRIMARY_SERVICE(&pong_svc_uuid.uuid),
 	BT_GATT_CHARACTERISTIC(&pong_chr_uuid.uuid, BT_GATT_CHRC_NOTIFY,
 			       BT_GATT_PERM_NONE, NULL, NULL, NULL),
-	BT_GATT_CCC(pong_ccc_cfg, pong_ccc_cfg_changed),
+	BT_GATT_CCC(pong_ccc_cfg_changed),
 );
 
 void ble_init(void)

--- a/subsys/bluetooth/mesh/proxy.c
+++ b/subsys/bluetooth/mesh/proxy.c
@@ -636,8 +636,6 @@ static bool prov_ccc_write(struct bt_conn *conn,
 	return true;
 }
 
-static struct bt_gatt_ccc_cfg prov_ccc_cfg[BT_GATT_CCC_MAX] = {};
-
 /* Mesh Provisioning Service Declaration */
 static struct bt_gatt_attr prov_attrs[] = {
 	BT_GATT_PRIMARY_SERVICE(BT_UUID_MESH_PROV),
@@ -650,8 +648,7 @@ static struct bt_gatt_attr prov_attrs[] = {
 	BT_GATT_CHARACTERISTIC(BT_UUID_MESH_PROV_DATA_OUT,
 			       BT_GATT_CHRC_NOTIFY, BT_GATT_PERM_NONE,
 			       NULL, NULL, NULL),
-	BT_GATT_CCC_MANAGED(prov_ccc_cfg, prov_ccc_changed, prov_ccc_write,
-			    NULL),
+	BT_GATT_CCC_MANAGED(prov_ccc_changed, prov_ccc_write, NULL),
 };
 
 static struct bt_gatt_service prov_svc = BT_GATT_SERVICE(prov_attrs);
@@ -754,8 +751,6 @@ static bool proxy_ccc_write(struct bt_conn *conn,
 	return true;
 }
 
-static struct bt_gatt_ccc_cfg proxy_ccc_cfg[BT_GATT_CCC_MAX] = {};
-
 /* Mesh Proxy Service Declaration */
 static struct bt_gatt_attr proxy_attrs[] = {
 	BT_GATT_PRIMARY_SERVICE(BT_UUID_MESH_PROXY),
@@ -769,8 +764,7 @@ static struct bt_gatt_attr proxy_attrs[] = {
 			       BT_GATT_CHRC_NOTIFY,
 			       BT_GATT_PERM_NONE,
 			       NULL, NULL, NULL),
-	BT_GATT_CCC_MANAGED(proxy_ccc_cfg, proxy_ccc_changed, proxy_ccc_write,
-			    NULL),
+	BT_GATT_CCC_MANAGED(proxy_ccc_changed, proxy_ccc_write, NULL),
 };
 
 static struct bt_gatt_service proxy_svc = BT_GATT_SERVICE(proxy_attrs);

--- a/subsys/bluetooth/services/bas.c
+++ b/subsys/bluetooth/services/bas.c
@@ -25,8 +25,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(bas);
 
-static struct bt_gatt_ccc_cfg  blvl_ccc_cfg[BT_GATT_CCC_MAX] = {};
-
 static u8_t battery_level = 100U;
 
 static void blvl_ccc_cfg_changed(const struct bt_gatt_attr *attr,
@@ -55,7 +53,7 @@ BT_GATT_SERVICE_DEFINE(bas,
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
 			       BT_GATT_PERM_READ, read_blvl, NULL,
 			       &battery_level),
-	BT_GATT_CCC(blvl_ccc_cfg, blvl_ccc_cfg_changed),
+	BT_GATT_CCC(blvl_ccc_cfg_changed),
 );
 
 static int bas_init(struct device *dev)

--- a/subsys/bluetooth/services/hrs.c
+++ b/subsys/bluetooth/services/hrs.c
@@ -25,7 +25,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(hrs);
 
-static struct bt_gatt_ccc_cfg hrmc_ccc_cfg[BT_GATT_CCC_MAX] = {};
 static u8_t hrs_blsc;
 
 static void hrmc_ccc_cfg_changed(const struct bt_gatt_attr *attr, u16_t value)
@@ -49,7 +48,7 @@ BT_GATT_SERVICE_DEFINE(hrs_svc,
 	BT_GATT_PRIMARY_SERVICE(BT_UUID_HRS),
 	BT_GATT_CHARACTERISTIC(BT_UUID_HRS_MEASUREMENT, BT_GATT_CHRC_NOTIFY,
 			       BT_GATT_PERM_NONE, NULL, NULL, NULL),
-	BT_GATT_CCC(hrmc_ccc_cfg, hrmc_ccc_cfg_changed),
+	BT_GATT_CCC(hrmc_ccc_cfg_changed),
 	BT_GATT_CHARACTERISTIC(BT_UUID_HRS_BODY_SENSOR, BT_GATT_CHRC_READ,
 			       BT_GATT_PERM_READ, read_blsc, NULL, NULL),
 	BT_GATT_CHARACTERISTIC(BT_UUID_HRS_CONTROL_POINT, BT_GATT_CHRC_WRITE,

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -524,7 +524,6 @@ static struct db_stats {
 	u16_t attr_count;
 	u16_t chrc_count;
 	u16_t ccc_count;
-	size_t ccc_cfg;
 } stats;
 
 static u8_t print_attr(const struct bt_gatt_attr *attr, void *user_data)
@@ -544,10 +543,7 @@ static u8_t print_attr(const struct bt_gatt_attr *attr, void *user_data)
 
 	if (!bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CCC) &&
 	    attr->write == bt_gatt_attr_write_ccc) {
-		struct _bt_gatt_ccc *cfg = attr->user_data;
-
 		stats.ccc_count++;
-		stats.ccc_cfg += cfg->cfg_len;
 	}
 
 	shell_print(shell, "attr %p handle 0x%04x uuid %s perm 0x%02x",
@@ -590,7 +586,6 @@ static int cmd_show_db(const struct shell *shell, size_t argc, char *argv[])
 	total_len += stats.chrc_count * sizeof(struct bt_gatt_chrc);
 	total_len += stats.attr_count * sizeof(struct bt_gatt_attr);
 	total_len += stats.ccc_count * sizeof(struct _bt_gatt_ccc);
-	total_len += stats.ccc_cfg * sizeof(struct bt_gatt_ccc_cfg);
 
 	shell_print(shell, "=================================================");
 	shell_print(shell, "Total: %u services %u attributes (%u bytes)",
@@ -624,7 +619,6 @@ static const struct bt_uuid_128 vnd1_echo_uuid = BT_UUID_INIT_128(
 	0xf5, 0xde, 0xbc, 0x9a, 0x78, 0x56, 0x34, 0x12,
 	0x78, 0x56, 0x34, 0x12, 0x78, 0x56, 0x34, 0x12);
 
-static struct bt_gatt_ccc_cfg vnd1_ccc_cfg[BT_GATT_CCC_MAX] = {};
 static u8_t echo_enabled;
 
 static void vnd1_ccc_cfg_changed(const struct bt_gatt_attr *attr, u16_t value)
@@ -737,7 +731,7 @@ static struct bt_gatt_attr vnd1_attrs[] = {
 			       BT_GATT_CHRC_WRITE_WITHOUT_RESP |
 			       BT_GATT_CHRC_NOTIFY,
 			       BT_GATT_PERM_WRITE, NULL, write_vnd1, NULL),
-	BT_GATT_CCC(vnd1_ccc_cfg, vnd1_ccc_cfg_changed),
+	BT_GATT_CCC(vnd1_ccc_cfg_changed),
 };
 
 static struct bt_gatt_service vnd1_svc = BT_GATT_SERVICE(vnd1_attrs);

--- a/subsys/mgmt/smp_bt.c
+++ b/subsys/mgmt/smp_bt.c
@@ -69,7 +69,6 @@ static void smp_bt_ccc_changed(const struct bt_gatt_attr *attr, u16_t value)
 {
 }
 
-static struct bt_gatt_ccc_cfg smp_bt_ccc[BT_GATT_CCC_MAX] = {};
 static struct bt_gatt_attr smp_bt_attrs[] = {
 	/* SMP Primary Service Declaration */
 	BT_GATT_PRIMARY_SERVICE(&smp_bt_svc_uuid),
@@ -79,7 +78,7 @@ static struct bt_gatt_attr smp_bt_attrs[] = {
 			       BT_GATT_CHRC_NOTIFY,
 			       BT_GATT_PERM_WRITE,
 			       NULL, smp_bt_chr_write, NULL),
-	BT_GATT_CCC(smp_bt_ccc, smp_bt_ccc_changed),
+	BT_GATT_CCC(smp_bt_ccc_changed),
 };
 
 static struct bt_gatt_service smp_bt_svc = BT_GATT_SERVICE(smp_bt_attrs);

--- a/tests/bluetooth/gatt/src/main.c
+++ b/tests/bluetooth/gatt/src/main.c
@@ -32,7 +32,6 @@ static const struct bt_uuid_128 test1_nfy_uuid = BT_UUID_INIT_128(
 	0xf5, 0xde, 0xbc, 0x9a, 0x78, 0x56, 0x34, 0x12,
 	0x78, 0x56, 0x34, 0x12, 0x78, 0x56, 0x34, 0x12);
 
-static struct bt_gatt_ccc_cfg test1_ccc_cfg[BT_GATT_CCC_MAX] = {};
 static u8_t nfy_enabled;
 
 static void test1_ccc_cfg_changed(const struct bt_gatt_attr *attr, u16_t value)
@@ -84,7 +83,7 @@ static struct bt_gatt_attr test1_attrs[] = {
 	BT_GATT_CHARACTERISTIC(&test1_nfy_uuid.uuid,
 			       BT_GATT_CHRC_NOTIFY, BT_GATT_PERM_NONE,
 			       NULL, NULL, &nfy_enabled),
-	BT_GATT_CCC(test1_ccc_cfg, test1_ccc_cfg_changed),
+	BT_GATT_CCC(test1_ccc_cfg_changed),
 };
 
 static struct bt_gatt_service test1_svc = BT_GATT_SERVICE(test1_attrs);

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -463,7 +463,6 @@ fail:
 
 static bool ccc_added;
 
-static struct bt_gatt_ccc_cfg ccc_cfg[BT_GATT_CCC_MAX] = {};
 static u8_t ccc_value;
 
 static void ccc_cfg_changed(const struct bt_gatt_attr *attr, u16_t value)
@@ -471,7 +470,7 @@ static void ccc_cfg_changed(const struct bt_gatt_attr *attr, u16_t value)
 	ccc_value = value;
 }
 
-static struct bt_gatt_attr ccc = BT_GATT_CCC(ccc_cfg, ccc_cfg_changed);
+static struct bt_gatt_attr ccc = BT_GATT_CCC(ccc_cfg_changed);
 
 static struct bt_gatt_attr *add_ccc(const struct bt_gatt_attr *attr)
 {


### PR DESCRIPTION
Some small fixes to BT_GATT_CCC to actually the declare its storage internally and bt_gatt_indicate to allow indicating by UUID.

Fixes #18547 #18572 