### PR TITLE
[TOPIC: DTS] dts/bindings: Convert compound to phandle-array type

### DIFF
--- a/dts/bindings/audio/ti,tlv320dac.yaml
+++ b/dts/bindings/audio/ti,tlv320dac.yaml
@@ -17,5 +17,5 @@ properties:
       constraint: "ti,tlv320dac"
 
     reset-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -36,7 +36,7 @@ properties:
         description: interrupts for device
 
     interrupts-extended:
-        type: compound
+        type: phandle-array
         category: optional
         description: extended interrupt specifier for device
 
@@ -56,7 +56,7 @@ properties:
         description: Human readable string describing the device (used by Zephyr for API name)
 
     clocks:
-        type: compound
+        type: phandle-array
         category: optional
         description: Clock gate information
 

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
@@ -21,5 +21,5 @@ properties:
       constraint: "zephyr,bt-hci-spi-slave"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
@@ -18,9 +18,9 @@ properties:
       constraint: "zephyr,bt-hci-spi"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     reset-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/can/microchip,mcp2515.yaml
+++ b/dts/bindings/can/microchip,mcp2515.yaml
@@ -16,5 +16,5 @@ properties:
     compatible:
       constraint: "microchip,mcp2515"
     int-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/display/ilitek,ili9340.yaml
+++ b/dts/bindings/display/ilitek,ili9340.yaml
@@ -17,9 +17,9 @@ properties:
       constraint: "ilitek,ili9340"
 
     reset-gpios:
-      type: compound
+      type: phandle-array
       category: optional
 
     cmd-data-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -17,11 +17,11 @@ properties:
       constraint: "sitronix,st7789v"
 
     reset-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     cmd-data-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     height:

--- a/dts/bindings/display/solomon,ssd1306fb.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb.yaml
@@ -57,5 +57,5 @@ properties:
       description: Duration of the pre-charge period
 
     reset-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/display/solomon,ssd1673fb.yaml
+++ b/dts/bindings/display/solomon,ssd1673fb.yaml
@@ -82,13 +82,13 @@ properties:
       description: Last column address is mapped to first segment
 
     reset-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     dc-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     busy-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/ethernet/microchip,enc28j60.yaml
+++ b/dts/bindings/ethernet/microchip,enc28j60.yaml
@@ -15,5 +15,5 @@ properties:
     compatible:
       constraint: "microchip,enc28j60"
     int-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/gpio/gpio-keys.yaml
+++ b/dts/bindings/gpio/gpio-keys.yaml
@@ -19,7 +19,7 @@ properties:
 sub-node:
     properties:
        gpios:
-          type: compound
+          type: phandle-array
           category: required
        label:
           category: required

--- a/dts/bindings/gpio/gpio-leds.yaml
+++ b/dts/bindings/gpio/gpio-leds.yaml
@@ -19,7 +19,7 @@ properties:
 sub-node:
     properties:
        gpios:
-          type: compound
+          type: phandle-array
           category: required
        label:
           category: required

--- a/dts/bindings/ieee802154/nxp,mcr20a.yaml
+++ b/dts/bindings/ieee802154/nxp,mcr20a.yaml
@@ -17,9 +17,9 @@ properties:
       constraint: "nxp,mcr20a"
 
     irqb-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     reset-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/ieee802154/ti,cc2520.yaml
+++ b/dts/bindings/ieee802154/ti,cc2520.yaml
@@ -17,25 +17,25 @@ properties:
       constraint: "ti,cc2520"
 
     vreg-en-gpios:
-      type: compound
+      type: phandle-array
       category: optional
 
     reset-gpios:
-      type: compound
+      type: phandle-array
       category: optional
 
     fifo-gpios:
-      type: compound
+      type: phandle-array
       category: optional
 
     cca-gpios:
-      type: compound
+      type: phandle-array
       category: optional
 
     sfd-gpios:
-      type: compound
+      type: phandle-array
       category: optional
 
     fifop-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/led/holtek,ht16k33.yaml
+++ b/dts/bindings/led/holtek,ht16k33.yaml
@@ -20,6 +20,6 @@ properties:
     label:
       category: required
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: optional
       description: IRQ pin

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -19,7 +19,7 @@ properties:
 sub-node:
     properties:
         pwms:
-          type: compound
+          type: phandle-array
           category: required
 
         label:

--- a/dts/bindings/misc/skyworks,sky13351.yaml
+++ b/dts/bindings/misc/skyworks,sky13351.yaml
@@ -17,10 +17,10 @@ properties:
     compatible:
         constraint: "skyworks,sky13351"
     vctl1-gpios:
-        type: compound
+        type: phandle-array
         category: required
         description: VCTL1 pin
     vctl2-gpios:
-        type: compound
+        type: phandle-array
         category: required
         description: VCTL2 pin

--- a/dts/bindings/mmc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/mmc/nxp,imx-usdhc.yaml
@@ -20,12 +20,12 @@ properties:
       category: required
 
     pwr-gpios:
-      type: compound
+      type: phandle-array
       category: optional
       description: Power pin
 
     cd-gpios:
-      type: compound
+      type: phandle-array
       category: optional
       description: Detect pin
 

--- a/dts/bindings/modem/ublox,sara-r4.yaml
+++ b/dts/bindings/modem/ublox,sara-r4.yaml
@@ -20,13 +20,13 @@ properties:
       category: required
 
     mdm-power-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     mdm-reset-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     mdm-vint-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -20,26 +20,26 @@ properties:
       category: required
 
     mdm-boot-mode-sel-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     mdm-power-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     mdm-keep-awake-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     mdm-reset-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     mdm-shld-trans-ena-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     mdm-send-ok-gpios:
-      type: compound
+      type: phandle-array
       category: optional
       description: UART RTS pin if no HW flow control (set to always enabled)

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -32,14 +32,14 @@ properties:
     description: flash capacity in bits
 
   wp-gpios:
-    type: compound
+    type: phandle-array
     category: optional
     description: WPn pin
   hold-gpios:
-    type: compound
+    type: phandle-array
     category: optional
     description: HOLDn pin
   reset-gpios:
-    type: compound
+    type: phandle-array
     category: optional
     description: RESETn pin

--- a/dts/bindings/sensor/adi,adt7420.yaml
+++ b/dts/bindings/sensor/adi,adt7420.yaml
@@ -17,5 +17,5 @@ properties:
       constraint: "adi,adt7420"
 
     int-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -17,5 +17,5 @@ properties:
       constraint: "adi,adxl362"
 
     int1-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/sensor/adi,adxl372-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl372-i2c.yaml
@@ -17,5 +17,5 @@ properties:
       constraint: "adi,adxl372"
 
     int1-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/sensor/adi,adxl372-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl372-spi.yaml
@@ -19,5 +19,5 @@ properties:
       constraint: "adi,adxl372"
 
     int1-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/sensor/avago,apds9960.yaml
+++ b/dts/bindings/sensor/avago,apds9960.yaml
@@ -17,5 +17,5 @@ properties:
       constraint: "avago,apds9960"
 
     int-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/sensor/bosch,bmi160.yaml
+++ b/dts/bindings/sensor/bosch,bmi160.yaml
@@ -17,5 +17,5 @@ properties:
       constraint: "bosch,bmi160"
 
     int-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/sensor/nxp,fxas21002.yaml
+++ b/dts/bindings/sensor/nxp,fxas21002.yaml
@@ -17,9 +17,9 @@ properties:
       constraint: "nxp,fxas21002"
 
     int1-gpios:
-      type: compound
+      type: phandle-array
       category: optional
 
     int2-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/sensor/nxp,fxos8700.yaml
+++ b/dts/bindings/sensor/nxp,fxos8700.yaml
@@ -18,13 +18,13 @@ properties:
       constraint: "nxp,fxos8700"
 
     reset-gpios:
-      type: compound
+      type: phandle-array
       category: optional
 
     int1-gpios:
-      type: compound
+      type: phandle-array
       category: optional
 
     int2-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/sensor/sensirion,sht3xd.yaml
+++ b/dts/bindings/sensor/sensirion,sht3xd.yaml
@@ -17,6 +17,6 @@ properties:
     compatible:
       constraint: "sensirion,sht3xd"
     alert-gpios:
-      type: compound
+      type: phandle-array
       category: optional
       description: ALERT pin

--- a/dts/bindings/sensor/st,hts221.yaml
+++ b/dts/bindings/sensor/st,hts221.yaml
@@ -18,6 +18,6 @@ properties:
       constraint: "st,hts221"
 
     drdy-gpios:
-      type: compound
+      type: phandle-array
       category: optional
       description: DRDY pin

--- a/dts/bindings/sensor/st,lis2dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dh-i2c.yaml
@@ -17,5 +17,5 @@ properties:
         constraint: "st,lis2dh"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/sensor/st,lis2dh-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dh-spi.yaml
@@ -18,5 +18,5 @@ properties:
         constraint: "st,lis2dh"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/sensor/st,lis2ds12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-i2c.yaml
@@ -17,5 +17,5 @@ properties:
         constraint: "st,lis2ds12"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/sensor/st,lis2ds12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-spi.yaml
@@ -18,5 +18,5 @@ properties:
         constraint: "st,lis2ds12"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/sensor/st,lis2dw12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-i2c.yaml
@@ -17,5 +17,5 @@ properties:
         constraint: "st,lis2dw12"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/sensor/st,lis2dw12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-spi.yaml
@@ -18,5 +18,5 @@ properties:
         constraint: "st,lis2dw12"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/sensor/st,lis2mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-magn.yaml
@@ -17,5 +17,5 @@ properties:
       constraint: "st,lis2mdl-magn"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/sensor/st,lis3dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis3dh-i2c.yaml
@@ -17,5 +17,5 @@ properties:
         constraint: "st,lis3dh"
 
     irq-gpios:
-      type: compound
       category: optional
+      type: phandle-array

--- a/dts/bindings/sensor/st,lps22hh-i2c.yaml
+++ b/dts/bindings/sensor/st,lps22hh-i2c.yaml
@@ -18,6 +18,6 @@ properties:
       constraint: "st,lps22hh"
 
     drdy-gpios:
-      type: compound
+      type: phandle-array
       category: optional
       description: DRDY pin

--- a/dts/bindings/sensor/st,lps22hh-spi.yaml
+++ b/dts/bindings/sensor/st,lps22hh-spi.yaml
@@ -18,6 +18,6 @@ properties:
       constraint: "st,lps22hh"
 
     drdy-gpios:
-      type: compound
+      type: phandle-array
       category: optional
       description: DRDY pin

--- a/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
@@ -18,5 +18,5 @@ properties:
       constraint: "st,lsm6dsl"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/sensor/st,lsm6dsl-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-spi.yaml
@@ -18,5 +18,5 @@ properties:
         constraint: "st,lsm6dsl"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/sensor/st,lsm6dso-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-i2c.yaml
@@ -18,5 +18,5 @@ properties:
         constraint: "st,lsm6dso"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/sensor/st,lsm6dso-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-spi.yaml
@@ -18,5 +18,5 @@ properties:
         constraint: "st,lsm6dso"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
@@ -17,5 +17,5 @@ properties:
         constraint: "st,lsm9ds0-gyro"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
@@ -17,5 +17,5 @@ properties:
         constraint: "st,lsm9ds0-mfd"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/sensor/st,stts751-i2c.yaml
+++ b/dts/bindings/sensor/st,stts751-i2c.yaml
@@ -18,6 +18,6 @@ properties:
       constraint: "st,stts751"
 
     drdy-gpios:
-      type: compound
+      type: phandle-array
       category: optional
       description: DRDY pin

--- a/dts/bindings/sensor/ti,hdc.yaml
+++ b/dts/bindings/sensor/ti,hdc.yaml
@@ -17,5 +17,5 @@ properties:
       constraint: "ti,hdc"
 
     drdy-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/spi/spi.yaml
+++ b/dts/bindings/spi/spi.yaml
@@ -29,5 +29,5 @@ properties:
     label:
       category: required
     cs-gpios:
-      type: compound
+      type: phandle-array
       category: optional

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -29,7 +29,7 @@ properties:
                    manual defines USB packet SRAM size.
 
     disconnect-gpios:
-      type: compound
+      type: phandle-array
       category: optional
       description: Some boards use a USB DISCONNECT pin to enable
                    the pull-up resistor on USB Data Positive signal.

--- a/dts/bindings/wifi/atmel,winc1500.yaml
+++ b/dts/bindings/wifi/atmel,winc1500.yaml
@@ -17,13 +17,13 @@ properties:
       constraint: "atmel,winc1500"
 
     irq-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     reset-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     enable-gpios:
-      type: compound
+      type: phandle-array
       category: required

--- a/dts/bindings/wifi/inventek,eswifi.yaml
+++ b/dts/bindings/wifi/inventek,eswifi.yaml
@@ -17,17 +17,17 @@ properties:
       constraint: "inventek,eswifi"
 
     resetn-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     data-gpios:
-      type: compound
+      type: phandle-array
       category: required
 
     wakeup-gpios:
-      type: compound
+      type: phandle-array
       category: optional
 
     boot0-gpios:
-      type: compound
+      type: phandle-array
       category: optional


### PR DESCRIPTION
Convert type from compound to phandle-array for various bindings that
have properties like like <FOO>-gpios, pwms, clocks,
interrupt-extended, etc. that are phandle-array's.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>