### PR TITLE
Bluetooth: controller: Fix conn RSSI initial value

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -722,9 +722,9 @@ static inline void isr_radio_state_tx(void)
 		 */
 		radio_tmr_end_capture();
 
-#if defined(CONFIG_BT_CTLR_SCAN_REQ_RSSI)
+#if defined(CONFIG_BT_CTLR_SCAN_REQ_RSSI) || defined(CONFIG_BT_CTLR_CONN_RSSI)
 		radio_rssi_measure();
-#endif /* CONFIG_BT_CTLR_SCAN_REQ_RSSI */
+#endif /* CONFIG_BT_CTLR_SCAN_REQ_RSSI || CONFIG_BT_CTLR_CONN_RSSI */
 
 #if defined(CONFIG_BT_CTLR_GPIO_LNA_PIN)
 		radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() +
@@ -1077,6 +1077,11 @@ static inline u32_t isr_rx_adv(u8_t devmatch_ok, u8_t devmatch_id,
 				     (conn->apto_reload - (conn->latency + 6)) :
 				     conn->apto_reload;
 #endif /* CONFIG_BT_CTLR_LE_PING */
+
+#if defined(CONFIG_BT_CTLR_CONN_RSSI)
+		conn->rssi_latest = (rssi_ready) ? (radio_rssi_get() & 0x7f) :
+						   0x7f;
+#endif /* CONFIG_BT_CTLR_CONN_RSSI */
 
 		/* Prepare the rx packet structure */
 		node_rx->hdr.handle = conn->handle;
@@ -1474,6 +1479,11 @@ static inline u32_t isr_rx_scan(u8_t devmatch_ok, u8_t devmatch_id,
 		/* acquire the master context from scanner */
 		conn = _radio.scanner.conn;
 		_radio.scanner.conn = NULL;
+
+#if defined(CONFIG_BT_CTLR_CONN_RSSI)
+		conn->rssi_latest = (rssi_ready) ? (radio_rssi_get() & 0x7f) :
+						   0x7f;
+#endif /* CONFIG_BT_CTLR_CONN_RSSI */
 
 		/* Tx the connect request packet */
 		pdu_adv_tx = (void *)radio_pkt_scratch_get();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -27,6 +27,7 @@
 #include "lll.h"
 #include "lll_vendor.h"
 #include "lll_adv.h"
+#include "lll_conn.h"
 #include "lll_chan.h"
 #include "lll_filter.h"
 
@@ -361,7 +362,8 @@ static void isr_tx(void *param)
 	 */
 	radio_tmr_end_capture();
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_SCAN_REQ_RSSI)) {
+	if (IS_ENABLED(CONFIG_BT_CTLR_SCAN_REQ_RSSI) ||
+	    IS_ENABLED(CONFIG_BT_CTLR_CONN_RSSI)) {
 		radio_rssi_measure();
 	}
 
@@ -715,6 +717,12 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 			lll_prof_cputime_capture();
 		}
+
+#if defined(CONFIG_BT_CTLR_CONN_RSSI)
+		if (rssi_ready) {
+			lll->conn->rssi_latest =  radio_rssi_get();
+		}
+#endif /* CONFIG_BT_CTLR_CONN_RSSI */
 
 		/* Stop further LLL radio events */
 		ret = lll_stop(lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -803,6 +803,12 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 					 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
 
+#if defined(CONFIG_BT_CTLR_CONN_RSSI)
+		if (rssi_ready) {
+			lll_conn->rssi_latest =  radio_rssi_get();
+		}
+#endif /* CONFIG_BT_CTLR_CONN_RSSI */
+
 		/* block CPU so that there is no CRC error on pdu tx,
 		 * this is only needed if we want the CPU to sleep.
 		 * while(!radio_has_disabled())


### PR DESCRIPTION
On connection callback generated by host, application
reading the RSSI value by using HCI LE Read RSSI Command
received -127 dB as the first connection event has not
occured yet in order to measure the RSSI value.

Fix this by using the RSSI value of received advertising
PDU by the initiator, and using the RSSI value of the
received CONNECT_REQ PDU by the connectable advertiser as
the initial value at connection setup.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>