### PR TITLE
Bluetooth: Mesh: Fix bt_mesh_net_resend()

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -897,15 +897,7 @@ int bt_mesh_net_send(struct bt_mesh_net_tx *tx, struct net_buf *buf,
 			/* Notify completion if this only went
 			 * through the Mesh Proxy.
 			 */
-			if (cb) {
-				if (cb->start) {
-					cb->start(0, 0, cb_data);
-				}
-
-				if (cb->end) {
-					cb->end(0, cb_data);
-				}
-			}
+			send_cb_finalize(cb, cb_data);
 
 			err = 0;
 			goto done;

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -783,7 +783,7 @@ int bt_mesh_net_resend(struct bt_mesh_subnet *sub, struct net_buf *buf,
 
 	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY) &&
 	    bt_mesh_proxy_relay(&buf->b, dst)) {
-		net_buf_unref(buf);
+		send_cb_finalize(cb, cb_data);
 	} else {
 		bt_mesh_adv_send(buf, cb, cb_data);
 	}

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -362,3 +362,19 @@ struct friend_cred *friend_cred_create(struct bt_mesh_subnet *sub, u16_t addr,
 				       u16_t lpn_counter, u16_t frnd_counter);
 void friend_cred_clear(struct friend_cred *cred);
 int friend_cred_del(u16_t net_idx, u16_t addr);
+
+static inline void send_cb_finalize(const struct bt_mesh_send_cb *cb,
+				    void *cb_data)
+{
+	if (!cb) {
+		return;
+	}
+
+	if (cb->start) {
+		cb->start(0, 0, cb_data);
+	}
+
+	if (cb->end) {
+		cb->end(0, cb_data);
+	}
+}

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -426,15 +426,7 @@ static int send_seg(struct bt_mesh_net_tx *net_tx, struct net_buf_simple *sdu,
 		 * there's no other way to track this (at least currently)
 		 * with the Friend Queue.
 		 */
-		if (cb) {
-			if (cb->start) {
-				cb->start(0, 0, cb_data);
-			}
-
-			if (cb->end) {
-				cb->end(0, cb_data);
-			}
-		}
+		send_cb_finalize(cb, cb_data);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER) &&


### PR DESCRIPTION
PR #18221 was incorrect in the buffer reference count handling and incomplete in that it lacked calling the send callbacks. This PR tries to address this. See the discussion started by @menglingao1997 at the end of #17907 for details.

Fixes #17907