### PR TITLE
CODEOWNERS: Add dedicated entry for Bluetooth Mesh

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -336,6 +336,7 @@
 /scripts/zephyr_module.py                 @tejlmand
 /subsys/bluetooth/                        @joerchan @jhedberg @Vudentz
 /subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot
+/subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @joerchan @Vudentz
 /subsys/debug/                            @nashif
 /subsys/disk/disk_access_spi_sdhc.c       @JunYangNXP
 /subsys/disk/disk_access_sdhc.h           @JunYangNXP


### PR DESCRIPTION
Add a dedicated entry for Bluetooth Mesh, and include Trond from
Nordic as an owner, since he will be actively participating in
maintaining & developing the code.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>