### PR TITLE
arc: necessary bug fixes and optimizations

### DIFF
--- a/arch/arc/core/arc_smp.c
+++ b/arch/arc/core/arc_smp.c
@@ -77,18 +77,16 @@ volatile struct {
  */
 volatile u32_t arc_cpu_wake_flag;
 /*
- * _curr_irq_stack is used to record the irq stack pointer
- * of per_cpu. _kernel.cpus[CONFIG_MP_NUM_CPUS].irq_stack also
- * has a copy of irq stack pointer, but not efficient to use in assembly
+ * _curr_cpu is used to record the struct of _cpu_t of each cpu.
+ * for efficient usage in assembly
  */
-volatile u32_t _curr_irq_stack[CONFIG_MP_NUM_CPUS];
+volatile _cpu_t *_curr_cpu[CONFIG_MP_NUM_CPUS];
 
 /* Called from Zephyr initialization */
 void z_arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 		     void (*fn)(int, void *), void *arg)
 {
-
-	_curr_irq_stack[cpu_num] = (u32_t)(sz + (char *)stack);
+	_curr_cpu[cpu_num] = &(_kernel.cpus[cpu_num]);
 	arc_cpu_init[cpu_num].fn = fn;
 	arc_cpu_init[cpu_num].arg = arg;
 
@@ -139,7 +137,7 @@ static int arc_smp_init(struct device *dev)
 	_kernel.cpus[0].id = 0;
 	_kernel.cpus[0].irq_stack = Z_THREAD_STACK_BUFFER(_interrupt_stack)
 		+ CONFIG_ISR_STACK_SIZE;
-	_curr_irq_stack[0] = (u32_t)(_kernel.cpus[0].irq_stack);
+	_curr_cpu[0] = &(_kernel.cpus[0]);
 
 	bcr.val = z_arc_v2_aux_reg_read(_ARC_V2_CONNECT_BCR);
 

--- a/arch/arc/core/fast_irq.S
+++ b/arch/arc/core/fast_irq.S
@@ -178,7 +178,6 @@ _firq_no_reschedule:
 #if CONFIG_RGF_NUM_BANKS == 1
 	_pop_irq_stack_frame
 #endif
-	lr ilink, [_ARC_V2_ERET]
 	rtie
 
 #ifdef CONFIG_PREEMPT_ENABLED
@@ -219,7 +218,6 @@ _firq_reschedule:
 	lr r0, [_ARC_V2_STATUS32_P0]
 	st_s r0, [sp, ___isf_t_status32_OFFSET]
 
-	lr ilink, [_ARC_V2_ERET]
 	st ilink, [sp, ___isf_t_pc_OFFSET] /* ilink into pc */
 #ifdef CONFIG_SMP
 /*

--- a/arch/arc/core/fast_irq.S
+++ b/arch/arc/core/fast_irq.S
@@ -76,7 +76,8 @@ SECTION_FUNC(TEXT, _firq_enter)
 	lr r25, [_ARC_V2_LP_END]
 #endif
 
-	_check_nest_int_by_irq_act r0, r1
+	/* check whether irq stack is used */
+	_check_and_inc_int_nest_counter r0, r1
 
 	bne.d firq_nest
 	mov r0, sp
@@ -138,6 +139,7 @@ SECTION_FUNC(TEXT, _firq_exit)
 	sr r24, [_ARC_V2_LP_START]
 	sr r25, [_ARC_V2_LP_END]
 #endif
+	_dec_int_nest_counter r0, r1
 
 	_check_nest_int_by_irq_act r0, r1
 

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -246,9 +246,9 @@ _do_non_syscall_trap:
 	st_s r0, [sp, ___isf_t_pc_OFFSET] /* eret into pc */
 
 
-	lr r0, [_ARC_V2_AUX_IRQ_ACT]
-	and r0, r0, 0xffff
-	cmp r0, 0
+	/* check whether irq stack is used */
+	_check_and_inc_int_nest_counter r0, r1
+
 	bne.d exc_nest_handle
 	mov r0, sp
 
@@ -259,6 +259,8 @@ exc_nest_handle:
 	jl z_irq_do_offload
 
 	pop sp
+
+	_dec_int_nest_counter r0, r1
 
 	lr  r0, [_ARC_V2_AUX_IRQ_ACT]
 	and r0, r0, 0xffff

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -295,6 +295,9 @@ exc_nest_handle:
 	bset.nz r3, r3, _ARC_V2_SEC_STAT_IRM_BIT
 	bclr.z r3, r3, _ARC_V2_SEC_STAT_IRM_BIT
 	sflag r3
+	/* save  _ARC_V2_SEC_STAT */
+	and r3, r3, 0xff
+	push r3
 #endif
 
 	_save_callee_saved_regs

--- a/arch/arc/core/offsets/offsets.c
+++ b/arch/arc/core/offsets/offsets.c
@@ -85,9 +85,6 @@ GEN_OFFSET_SYM(_callee_saved_stack_t, r24);
 GEN_OFFSET_SYM(_callee_saved_stack_t, r25);
 GEN_OFFSET_SYM(_callee_saved_stack_t, r26);
 GEN_OFFSET_SYM(_callee_saved_stack_t, fp);
-#ifdef CONFIG_ARC_SECURE_FIRMWARE
-GEN_OFFSET_SYM(_callee_saved_stack_t, sec_stat);
-#endif
 #ifdef CONFIG_USERSPACE
 #ifdef CONFIG_ARC_HAS_SECURE
 GEN_OFFSET_SYM(_callee_saved_stack_t, kernel_sp);

--- a/arch/arc/core/regular_irq.S
+++ b/arch/arc/core/regular_irq.S
@@ -94,7 +94,7 @@ SECTION_FUNC(TEXT, _rirq_exit)
 
 	_check_nest_int_by_irq_act r0, r1
 
-	jne _rirq_return_from_rirq
+	jne _rirq_no_reschedule
 
 #ifdef CONFIG_STACK_SENTINEL
 	bl z_check_stack_sentinel
@@ -137,6 +137,11 @@ SECTION_FUNC(TEXT, _rirq_exit)
 .balign 4
 _rirq_reschedule:
 
+#ifdef CONFIG_ARC_SECURE_FIRMWARE
+	/* here need to remember SEC_STAT.IRM bit */
+	lr r3, [_ARC_V2_SEC_STAT]
+	push r3
+#endif
 	/* _save_callee_saved_regs expects outgoing thread in r2 */
 	_save_callee_saved_regs
 
@@ -219,19 +224,20 @@ _rirq_return_from_coop:
 	 */
 	st_s r13, [sp, ___isf_t_r13_OFFSET]
 
-	/* stack now has the IRQ stack frame layout, pointing to r0 */
-
-	/* fall through to rtie instruction */
-
+	/* stack now has the IRQ stack frame layout, pointing to sp */
 	/* rtie will pop the rest from the stack */
-
-	/* fall through to rtie instruction */
+	rtie
 
 #endif /* CONFIG_PREEMPT_ENABLED */
 
 .balign 4
 _rirq_return_from_firq:
 _rirq_return_from_rirq:
+#ifdef CONFIG_ARC_SECURE_FIRMWARE
+	/* here need to recover SEC_STAT.IRM bit */
+	pop r3
+	sflag r3
+#endif
 _rirq_no_reschedule:
 
 	rtie

--- a/arch/arc/core/regular_irq.S
+++ b/arch/arc/core/regular_irq.S
@@ -67,7 +67,8 @@ SECTION_FUNC(TEXT, _rirq_enter)
 #endif
 	clri
 
-	_check_nest_int_by_irq_act r0, r1
+	/* check whether irq stack is used */
+	_check_and_inc_int_nest_counter r0, r1
 
 	bne.d rirq_nest
 	mov r0, sp
@@ -91,6 +92,8 @@ SECTION_FUNC(TEXT, _rirq_exit)
 	clri
 
 	pop sp
+
+	_dec_int_nest_counter r0, r1
 
 	_check_nest_int_by_irq_act r0, r1
 

--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -50,6 +50,11 @@ SECTION_FUNC(TEXT,__start)
 	 */
 	mov r0, 0
 	kflag r0
+
+#ifdef CONFIG_ARC_SECURE_FIRMWARE
+	sflag r0
+#endif
+
 #if defined(CONFIG_BOOT_TIME_MEASUREMENT) && defined(CONFIG_ARCV2_TIMER)
 	/*
 	 * ARCV2 timer (timer0) is a free run timer, let it start to count
@@ -67,8 +72,6 @@ SECTION_FUNC(TEXT,__start)
 	sr r0, [_ARC_V2_AUX_IRQ_CTRL]
 #endif
 	sr r0, [_ARC_V2_AUX_IRQ_HINT]
-
-	/* \todo: MPU init, gp for small data? */
 
 	/* set the vector table base early,
 	 * so that exception vectors can be handled.

--- a/arch/arc/core/switch.S
+++ b/arch/arc/core/switch.S
@@ -164,6 +164,11 @@ return_loc:
 _switch_return_from_rirq:
 _switch_return_from_firq:
 
+#ifdef CONFIG_ARC_SECURE_FIRMWARE
+	/* here need to recover SEC_STAT.IRM bit */
+	pop r3
+	sflag r3
+#endif
 	lr r3, [_ARC_V2_STATUS32]
 	bbit1 r3, _ARC_V2_STATUS32_AE_BIT, _return_from_exc_irq
 

--- a/arch/arc/core/switch.S
+++ b/arch/arc/core/switch.S
@@ -140,9 +140,6 @@ _switch_to_target_thread:
 .balign 4
 _switch_return_from_coop:
 
-	lr ilink, [_ARC_V2_STATUS32]
-	bbit1 ilink, _ARC_V2_STATUS32_AE_BIT, _return_from_exc
-
 	pop_s blink /* pc into blink */
 #ifdef CONFIG_ARC_HAS_SECURE
 	pop_s r3    /* pop SEC_STAT */
@@ -169,15 +166,15 @@ _switch_return_from_firq:
 	pop r3
 	sflag r3
 #endif
-	lr r3, [_ARC_V2_STATUS32]
-	bbit1 r3, _ARC_V2_STATUS32_AE_BIT, _return_from_exc_irq
 
-	/* pretend interrupt happened to use rtie instruction */
 	lr r3, [_ARC_V2_AUX_IRQ_ACT]
-	brne r3, 0, _switch_already_in_irq
-
 	/* use lowest interrupt priority */
-	or r3, r3, (1 << (CONFIG_NUM_IRQ_PRIO_LEVELS-1))
+#ifdef CONFIG_ARC_SECURE_FIRMWARE
+	or r3, r3, (1 << (ARC_N_IRQ_START_LEVEL - 1))
+#else
+	or r3, r3, (1 << (CONFIG_NUM_IRQ_PRIO_LEVELS - 1))
+#endif
+
 #ifdef CONFIG_ARC_NORMAL_FIRMWARE
 	mov r0, _ARC_V2_AUX_IRQ_ACT
 	mov r1, r3
@@ -186,30 +183,7 @@ _switch_return_from_firq:
 #else
 	sr r3, [_ARC_V2_AUX_IRQ_ACT]
 #endif
-
-_switch_already_in_irq:
 	rtie
-
-.balign 4
-_return_from_exc_irq:
-	_pop_irq_stack_frame
-	sub_s sp, sp, ___isf_t_status32_OFFSET - ___isf_t_pc_OFFSET + 4
-
-_return_from_exc:
-
-	/* put the return address to eret */
-	ld ilink, [sp] /* pc into ilink */
-	sr ilink, [_ARC_V2_ERET]
-
-	/* SEC_STAT is bypassed when CONFIG_ARC_HAS_SECURE */
-
-	/* put status32 into estatus */
-	ld ilink, [sp, ___isf_t_status32_OFFSET - ___isf_t_pc_OFFSET]
-	sr ilink, [_ARC_V2_ERSTATUS]
-	add_s sp, sp, ___isf_t_status32_OFFSET - ___isf_t_pc_OFFSET + 4
-
-	rtie
-
 
 #ifdef CONFIG_EXECUTION_BENCHMARKING
 	.balign 4

--- a/arch/arc/include/kernel_arch_data.h
+++ b/arch/arc/include/kernel_arch_data.h
@@ -130,10 +130,6 @@ struct _callee_saved_stack {
 	u32_t r26;
 	u32_t fp; /* r27 */
 
-#ifdef CONFIG_ARC_SECURE_FIRMWARE
-	u32_t sec_stat;
-#endif
-
 #ifdef CONFIG_USERSPACE
 #ifdef CONFIG_ARC_HAS_SECURE
 	u32_t user_sp;

--- a/arch/arc/include/swap_macros.h
+++ b/arch/arc/include/swap_macros.h
@@ -304,7 +304,11 @@ extern "C" {
  */
 .macro _check_nest_int_by_irq_act  reg1, reg2
 	lr \reg1, [_ARC_V2_AUX_IRQ_ACT]
+#ifdef CONFIG_ARC_SECURE_FIRMWARE
+	and \reg1, \reg1, ((1 << ARC_N_IRQ_START_LEVEL) - 1)
+#else
 	and \reg1, \reg1, 0xffff
+#endif
 	ffs \reg2, \reg1
 	fls \reg1, \reg1
 	cmp \reg1, \reg2

--- a/arch/arc/include/swap_macros.h
+++ b/arch/arc/include/swap_macros.h
@@ -318,7 +318,8 @@ extern "C" {
 .macro _get_curr_cpu_irq_stack irq_sp
 #ifdef CONFIG_SMP
 	_get_cpu_id \irq_sp
-	ld.as \irq_sp, [@_curr_irq_stack, \irq_sp]
+	ld.as \irq_sp, [@_curr_cpu, \irq_sp]
+	ld \irq_sp, [\irq_sp, ___cpu_t_irq_stack_OFFSET]
 #else
 	mov \irq_sp, _kernel
 	ld \irq_sp, [\irq_sp, _kernel_offset_to_irq_stack]

--- a/arch/arc/include/swap_macros.h
+++ b/arch/arc/include/swap_macros.h
@@ -42,11 +42,6 @@ extern "C" {
 	st r26, [sp, ___callee_saved_stack_t_r26_OFFSET]
 	st fp,  [sp, ___callee_saved_stack_t_fp_OFFSET]
 
-#ifdef CONFIG_ARC_SECURE_FIRMWARE
-	lr r13, [_ARC_V2_SEC_STAT]
-	st_s r13, [sp, ___callee_saved_stack_t_sec_stat_OFFSET]
-#endif
-
 #ifdef CONFIG_USERSPACE
 #ifdef CONFIG_ARC_HAS_SECURE
 #ifdef CONFIG_ARC_SECURE_FIRMWARE
@@ -148,12 +143,6 @@ extern "C" {
 	ld r13, [sp, ___callee_saved_stack_t_user_sp_OFFSET]
 	sr r13, [_ARC_V2_USER_SP]
 #endif
-#endif
-
-#ifdef CONFIG_ARC_SECURE_FIRMWARE
-	ld r13, [sp, ___callee_saved_stack_t_sec_stat_OFFSET]
-
-	sflag r13
 #endif
 
 	ld_s r13, [sp, ___callee_saved_stack_t_r13_OFFSET]

--- a/arch/arc/include/swap_macros.h
+++ b/arch/arc/include/swap_macros.h
@@ -298,6 +298,45 @@ extern "C" {
 #endif /* CONFIG_ARC_SECURE_FIRMWARE */
 .endm
 
+/* check and increase the interrupt nest counter
+ * after increase, check whether nest counter == 1
+ * the result will be EQ bit of status32
+ */
+.macro _check_and_inc_int_nest_counter reg1 reg2
+#ifdef CONFIG_SMP
+	_get_cpu_id \reg1
+	ld.as \reg1, [@_curr_cpu, \reg1]
+	ld \reg2, [\reg1, ___cpu_t_nested_OFFSET]
+#else
+	mov \reg1, _kernel
+	ld \reg2, [\reg1, ___kernel_t_nested_OFFSET]
+#endif
+	add \reg2, \reg2, 1
+#ifdef CONFIG_SMP
+	st \reg2, [\reg1, ___cpu_t_nested_OFFSET]
+#else
+	st \reg2, [\reg1, ___kernel_t_nested_OFFSET]
+#endif
+	cmp \reg2, 1
+.endm
+
+/* decrease interrupt nest counter */
+.macro _dec_int_nest_counter reg1 reg2
+#ifdef CONFIG_SMP
+	_get_cpu_id \reg1
+	ld.as \reg1, [@_curr_cpu, \reg1]
+	ld \reg2, [\reg1, ___cpu_t_nested_OFFSET]
+#else
+	mov \reg1, _kernel
+	ld \reg2, [\reg1, ___kernel_t_nested_OFFSET]
+#endif
+	sub \reg2, \reg2, 1
+#ifdef CONFIG_SMP
+	st \reg2, [\reg1, ___cpu_t_nested_OFFSET]
+#else
+	st \reg2, [\reg1, ___kernel_t_nested_OFFSET]
+#endif
+.endm
 
 /* If multi bits in IRQ_ACT are set, i.e. last bit != fist bit, it's
  * in nest interrupt. The result will be EQ bit of status32


### PR DESCRIPTION
After zephyr 2.0 RC1 release, we found a bunch of test failures in sanitycheck tests for arc supported targets (nsim_em, nsim_sem, nsim_hs, em starterkit, iotdk).

This PR includes necessary bug fixes and optimizations related to found test failures. To avoid the possible confilcts of separate PR,  I use one single PR to include all commits. 

**So pls review the code in the unit of commit**

Note that there are some known exceptions:
  * failure on cmsis_rtos_v2 , related to PR #17935 
  * failure on kernel/mem_protect/syscalls for secureshield enable targets (nsim_sem, em_starterkti_em7d). 
    Because for  secure em targets,   to save mpu entries for normal applicaiton,  the backgroud mpu 
    entry is set to allow R&W&E in kernel mode, so "nonsense string address did not fault"
the backgroud 

This PR:
  Fixes #18726
  Fixes #18725 
  Fixes #18724
