### PR TITLE
tests: kernel: mutex: Require 32KB of RAM for userspace test

### DIFF
--- a/tests/kernel/mutex/sys_mutex/testcase.yaml
+++ b/tests/kernel/mutex/sys_mutex/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   sys.mutex:
+    min_ram: 32
+    filter: CONFIG_ARCH_HAS_USERSPACE
     tags: kernel userspace
   sys.mutex.nouser:
     tags: kernel


### PR DESCRIPTION
The sys_mutex test doesn't seem to fit in 24KB of RAM anymore, so
restrict it to platforms that have 32KB or more of RAM, which seems like
a logical minimal RAM size for enabling userspace.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>