### PR TITLE
drivers: flash: stm32f4: resets OPTCR register

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -329,6 +329,28 @@ static int stm32_flash_init(struct device *dev)
 	LL_AHB3_GRP1_EnableClock(LL_AHB3_GRP1_PERIPH_HSEM);
 #endif /* CONFIG_SOC_SERIES_STM32WBX */
 
+#ifdef CONFIG_SOC_SERIES_STM32F4X
+	/*
+	 * make sure that user options are disabled
+	 * they affecting if flash read/write operations
+	 * are allowed on the flash for spezific sectors
+	 */
+	struct stm32f4x_flash *regs = FLASH_STM32_REGS(dev);
+
+	/* check if we are not in the typical reset config*/
+	if (regs->optcr != 0x0FFFFFED) {
+		/* clear OPTLOCK */
+		regs->optkeyr = 0x08192A3B;
+		regs->optkeyr = 0x4C5D6E7F;
+		if (regs->optkeyr & 1) {
+			/* still locked so we failed*/
+			return -EIO;
+		}
+		/* write reset config register content*/
+		regs->optcr = 0x0FFFFFED;
+	}
+#endif
+
 	k_sem_init(&p->sem, 1, 1);
 
 	return flash_stm32_write_protection(dev, false);


### PR DESCRIPTION
the current stm32f4 flash code assumes that it is run after reset.
If a programm, like a bootloader, runs before the zephyr build firmware
it can happen that the FLASH controller registers are changed. In my
case this lead to failed read/write/erase operations. This fix addresses
the stm32f4 flash driver. It clears the OPTCR register and take care,
that the driver resets the flash settings to the reset defaults.

Fixes #18263

Signed-off-by: Stefan Jaritz <stefan@kokoontech.com>