### PR TITLE
[TOPIC: DTS] dtlib: Refactor node fetching + add _err() helper

### DIFF
--- a/scripts/dts/dtlib.py
+++ b/scripts/dts/dtlib.py
@@ -1739,10 +1739,6 @@ class Property:
         if marker_type is _REF_PHANDLE:
             self.value += b"\0\0\0\0"
 
-    def _err_with_context(self, e):
-        raise DTError("{} (for property '{}' on {})"
-                      .format(e, self.name, self.node.path))
-
 
 #
 # Public functions

--- a/scripts/dts/testdtlib.py
+++ b/scripts/dts/testdtlib.py
@@ -1844,8 +1844,10 @@ r"value of property 'a' (b'\xff\x00') on /aliases in .tmp.dts is not valid UTF-8
 
     verify_raw_to_num_error(dtlib.to_num, 0, 0, "'0' has type 'int', expected 'bytes'")
     verify_raw_to_num_error(dtlib.to_num, b"", 0, "'length' must be greater than zero, was 0")
+    verify_raw_to_num_error(dtlib.to_num, b"foo", 2, "b'foo' is 3 bytes long, expected 2")
     verify_raw_to_num_error(dtlib.to_nums, 0, 0, "'0' has type 'int', expected 'bytes'")
     verify_raw_to_num_error(dtlib.to_nums, b"", 0, "'length' must be greater than zero, was 0")
+    verify_raw_to_num_error(dtlib.to_nums, b"foooo", 2, "b'foooo' is 5 bytes long, expected a length that's a a multiple of 2")
 
     #
     # Test duplicate label error

--- a/scripts/dts/testdtlib.py
+++ b/scripts/dts/testdtlib.py
@@ -386,7 +386,7 @@ l3: &l1 {
 &{foo} {
 };
 """,
-".tmp.dts:6 (column 1): parse error: node path does not start with '/'")
+".tmp.dts:6 (column 1): parse error: node path 'foo' does not start with '/'")
 
     verify_error("""
 /dts-v1/;
@@ -397,7 +397,7 @@ l3: &l1 {
 &{/foo} {
 };
 """,
-".tmp.dts:6 (column 1): parse error: component 1 ('foo') in path '/foo' does not exist")
+".tmp.dts:6 (column 1): parse error: component 'foo' in path '/foo' does not exist")
 
     #
     # Test property labels
@@ -586,7 +586,7 @@ l3: &l1 {
 	};
 };
 """,
-"/sub: component 2 ('missing') in path '/sub/missing' does not exist")
+"/sub: component 'missing' in path '/sub/missing' does not exist")
 
     #
     # Test phandles
@@ -901,6 +901,13 @@ l3: &l1 {
 """,
 ".tmp.dts:6 (column 15): parse error: undefined node label 'missing'")
 
+    verify_error("""
+/dts-v1/;
+
+/delete-node/ {
+""",
+".tmp.dts:3 (column 15): parse error: expected label (&foo) or path (&{/foo/bar}) reference")
+
     #
     # Test /include/ (which is handled in the lexer)
     #
@@ -1113,6 +1120,13 @@ y /include/ "via-include-path-1"
 """,
 ".tmp.dts:6 (column 18): parse error: undefined node label 'missing'")
 
+    verify_error("""
+/dts-v1/;
+
+/omit-if-no-ref/ {
+""",
+".tmp.dts:3 (column 18): parse error: expected label (&foo) or path (&{/foo/bar}) reference")
+
     #
     # Test expressions
     #
@@ -1321,8 +1335,8 @@ foo
 
     verify_path_error("", "no alias '' found -- did you forget the leading '/' in the node path?")
     verify_path_error("missing", "no alias 'missing' found -- did you forget the leading '/' in the node path?")
-    verify_path_error("/missing", "component 1 ('missing') in path '/missing' does not exist")
-    verify_path_error("/foo/missing", "component 2 ('missing') in path '/foo/missing' does not exist")
+    verify_path_error("/missing", "component 'missing' in path '/missing' does not exist")
+    verify_path_error("/foo/missing", "component 'missing' in path '/foo/missing' does not exist")
 
     verify_path_exists("/")
     verify_path_exists("/foo")
@@ -1378,7 +1392,7 @@ foo
     verify_path_is("alias4/node5", "node5")
 
     verify_path_error("alias4/node5/node6",
-                      "component 3 ('node6') in path 'alias4/node5/node6' does not exist")
+                      "component 'node6' in path 'alias4/node5/node6' does not exist")
 
     verify_error("""
 /dts-v1/;


### PR DESCRIPTION
Some code maintenance:

```
dts: dtlib: Remove unused Property._err_with_context() function

Leftover.
```

```
dts: dtlib: Refactor to get rid of _is_parsing flag

The public DT.get_node() function was used during parsing to look up
paths in references like &{/foo/bar}, along with an ugly
'DT._is_parsing' flag to adapt its behavior (to not mention aliases in
error messages).

Split out common node lookup code needed during parsing and by
get_node() instead, and stop using get_node() during parsing. This
allows '_is_parsing' to be removed and untangles things a bit.

Piggyback some other small reference-related cleanups, and fix an issue
with the filename/linenr being given twice in some error messages.

This commit also removes the index of path components from error
messages, but just the string is probably good enough.
```

```
dts: dtlib: Add an _err() helper for error reporting

Similar to edtlib._err(). Just saves a bunch of 'raise DTError'.

Also add tests for some errors from the global to_num() and to_nums()
functions that were untested.
```