### PR TITLE
cmake: Fix dependency between offset.c.obj and offsets.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,7 +634,9 @@ add_custom_command(
   COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/gen_offset_header.py
   -i $<TARGET_OBJECTS:${OFFSETS_LIB}>
   -o ${OFFSETS_H_PATH}
-  DEPENDS ${OFFSETS_LIB}
+  DEPENDS
+  ${OFFSETS_LIB}
+  $<TARGET_OBJECTS:${OFFSETS_LIB}>
 )
 add_custom_target(${OFFSETS_H_TARGET} DEPENDS ${OFFSETS_H_PATH})
 


### PR DESCRIPTION
The command for generating offsets.h has only been depending on the
target for offsets.c.obj, and not the file offsets.c.obj itself. Both
are needed, as explained in "CMake: dependencies between targets and
files and custom commands"[0].

This patch adds the dependency and fixes #18301

[0] https://tinyurl.com/y2hgzjhx

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>