### PR TITLE
scripts: runners: improve hex file detection and output

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -178,5 +178,5 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                     '-CommanderScript', fname] +
                    self.tool_opt)
 
-            self.logger.info('Flashing Target Device')
+            self.logger.info('Flashing file: {}'.format(self.bin_name))
             self.check_call(cmd)

--- a/scripts/west_commands/runners/nios2.py
+++ b/scripts/west_commands/runners/nios2.py
@@ -4,6 +4,8 @@
 
 '''Runner for NIOS II, based on quartus-flash.py and GDB.'''
 
+import os
+
 from runners.core import ZephyrBinaryRunner, NetworkPortHelper
 
 
@@ -56,7 +58,12 @@ class Nios2BinaryRunner(ZephyrBinaryRunner):
             raise ValueError('Cannot flash; --quartus-flash not given.')
         if self.cpu_sof is None:
             raise ValueError('Cannot flash; --cpu-sof not given.')
+        if not os.path.isfile(self.hex_name):
+            raise ValueError('Cannot flash; hex file ({}) does not exist. '.
+                             format(self.hex_name) +
+                             'Try enabling CONFIG_BUILD_OUTPUT_HEX.')
 
+        self.logger.info('Flashing file: {}'.format(self.hex_name))
         cmd = [self.quartus_py,
                '--sof', self.cpu_sof,
                '--kernel', self.hex_name]

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -5,6 +5,7 @@
 
 '''Runner for flashing with nrfjprog.'''
 
+import os
 import sys
 
 from runners.core import ZephyrBinaryRunner, RunnerCaps
@@ -95,9 +96,14 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
             raise ValueError("self.snr must not be None")
         else:
             board_snr = self.snr.lstrip("0")
+
+        if not os.path.isfile(self.hex_):
+            raise ValueError('Cannot flash; hex file ({}) does not exist. '.
+                             format(self.hex_) +
+                             'Try enabling CONFIG_BUILD_OUTPUT_HEX.')
+
         program_cmd = ['nrfjprog', '--program', self.hex_, '-f', self.family,
                        '--snr', board_snr]
-
         self.logger.info('Flashing file: {}'.format(self.hex_))
         if self.erase:
             commands.extend([

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -97,9 +97,9 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
 
     def do_flash(self, **kwargs):
         if not path.isfile(self.hex_name):
-            raise ValueError('Cannot flash; hex file is missing. '
-                             'Possibly need to enable CONFIG_BUILD_OUTPUT_HEX '
-                             'in the build')
+            raise ValueError('Cannot flash; hex file ({}) does not exist. '.
+                             format(self.hex_name) +
+                             'Try enabling CONFIG_BUILD_OUTPUT_HEX.')
         if self.load_cmd is None:
             raise ValueError('Cannot flash; load command is missing')
         if self.verify_cmd is None:
@@ -113,6 +113,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         if self.post_cmd is not None:
             post_cmd = ['-c', self.post_cmd]
 
+        self.logger.info('Flashing file: {}'.format(self.hex_name))
         cmd = (self.openocd_cmd +
                ['-f', self.openocd_config,
                 '-c', 'init',

--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -115,10 +115,14 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
         if os.path.isfile(self.hex_name):
             fname = self.hex_name
         elif os.path.isfile(self.bin_name):
+            self.logger.warning(
+                'hex file ({}) does not exist; falling back on .bin ({}). '.
+                format(self.hex_name, self.bin_name) +
+                'Consider enabling CONFIG_BUILD_OUTPUT_HEX.')
             fname = self.bin_name
         else:
             raise ValueError(
-                'Cannot flash; no hex ({}) or bin ({}) files'.format(
+                'Cannot flash; no hex ({}) or bin ({}) files found. '.format(
                     self.hex_name, self.bin_name))
 
         cmd = ([self.pyocd] +
@@ -132,7 +136,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                self.flash_extra +
                [fname])
 
-        self.logger.info('Flashing Target Device')
+        self.logger.info('Flashing file: {}'.format(fname))
         self.check_call(cmd)
 
     def log_gdbserver_message(self):


### PR DESCRIPTION
This is a band-aid to make it more obvious to potential users of 'west
sign' and 'west flash' which hex file they are flashing, when they are
falling back on a binary file, and erroring out when a hex file does
not exist.

Fixes: #18201