### PR TITLE
native_posix & nrf52_bsim: Add z_arch_irq_connect_dynamic()

### DIFF
--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -263,6 +263,30 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 	hw_irq_ctrl_prio_set(irq, prio);
 }
 
+#ifdef CONFIG_DYNAMIC_INTERRUPTS
+/**
+ * Configure a dynamic interrupt.
+ *
+ * Use this instead of IRQ_CONNECT() if arguments cannot be known at build time.
+ *
+ * @param irq IRQ line number
+ * @param priority Interrupt priority
+ * @param routine Interrupt service routine
+ * @param parameter ISR parameter
+ * @param flags Arch-specific IRQ configuration flags
+ *
+ * @return The vector assigned to this interrupt
+ */
+int z_arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
+			     void (*routine)(void *parameter), void *parameter,
+			     u32_t flags)
+{
+	z_isr_declare(irq, (int)flags, routine, parameter);
+	z_irq_priority_set(irq, priority, flags);
+	return irq;
+}
+#endif /* CONFIG_DYNAMIC_INTERRUPTS */
+
 /**
  * Similar to ARM's NVIC_SetPendingIRQ
  * set a pending IRQ from SW

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -327,6 +327,30 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 	hw_irq_ctrl_prio_set(irq, prio);
 }
 
+#ifdef CONFIG_DYNAMIC_INTERRUPTS
+/**
+ * Configure a dynamic interrupt.
+ *
+ * Use this instead of IRQ_CONNECT() if arguments cannot be known at build time.
+ *
+ * @param irq IRQ line number
+ * @param priority Interrupt priority
+ * @param routine Interrupt service routine
+ * @param parameter ISR parameter
+ * @param flags Arch-specific IRQ configuration flags
+ *
+ * @return The vector assigned to this interrupt
+ */
+int z_arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
+			     void (*routine)(void *parameter), void *parameter,
+			     u32_t flags)
+{
+	z_isr_declare(irq, (int)flags, routine, parameter);
+	z_irq_priority_set(irq, priority, flags);
+	return irq;
+}
+#endif /* CONFIG_DYNAMIC_INTERRUPTS */
+
 /**
  * Similar to ARM's NVIC_SetPendingIRQ
  * set a pending IRQ from SW


### PR DESCRIPTION
For some reason I missed adding support for CONFIG_DYNAMIC_INTERRUPTS in the POSIX ARCH boards. So adding it now.

Add support for CONFIG_DYNAMIC_INTERRUPTS
in both native_posix and the nrf52_bsim

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>