### PR TITLE
ci: Update to using SDK 0.10.3

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -4,7 +4,7 @@ compiler: gcc
 
 env:
     global:
-        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.10.2
+        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.10.3
         - ZEPHYR_TOOLCHAIN_VARIANT=zephyr
         - MATRIX_BUILDS="5"
     matrix:
@@ -20,7 +20,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.8.1
+        image_tag: v0.8.2
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
Update SDK version to 0.10.3 to pick up new qemu and risc-v support.
Use Docker image 0.8.2 that includes an install of that SDK version.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>