### PR TITLE
bluetooth: controller: Fix for uninitialized data causing compile error

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
@@ -120,6 +120,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 					       &lll->data_chan_map[0],
 					       lll->data_chan_count);
 #else /* !CONFIG_BT_CTLR_CHAN_SEL_2 */
+		data_chan_use = 0;
 		LL_ASSERT(0);
 #endif /* !CONFIG_BT_CTLR_CHAN_SEL_2 */
 	} else {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
@@ -131,6 +131,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 					       &lll->data_chan_map[0],
 					       lll->data_chan_count);
 #else /* !CONFIG_BT_CTLR_CHAN_SEL_2 */
+		data_chan_use = 0;
 		LL_ASSERT(0);
 #endif /* !CONFIG_BT_CTLR_CHAN_SEL_2 */
 	} else {


### PR DESCRIPTION
Due to conditional compile path ending in LL_ASSERT(0), the compiler sees
code following the assert as using uninitialized variables.

Signed-off-by: Morten Priess <mtpr@oticon.com>