### PR TITLE
bluetooth: controller: Connection meta property support in LLL

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -535,6 +535,13 @@ config BT_CTLR_LOW_LAT_ULL
 	  Low latency ULL implementation that uses tailchaining instead of while
 	  loop to demux rx messages from LLL.
 
+config BT_CTLR_CONN_META
+	prompt "Enable connection meta data extension"
+	bool
+	help
+	  Enables vendor specific per-connection meta data as part of the
+	  LLL connection object.
+
 endif # BT_LL_SW_SPLIT
 
 config BT_CTLR_RADIO_ENABLE_FAST

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -3,6 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#if defined(CONFIG_BT_CTLR_CONN_META)
+#include "lll_conn_meta.h"
+#endif /* CONFIG_BT_CTLR_CONN_META */
 
 #define LLL_CONN_RSSI_SAMPLE_COUNT 10
 #define LLL_CONN_RSSI_THRESHOLD    4
@@ -136,6 +139,10 @@ struct lll_conn {
 	u8_t  rssi_reported;
 	u8_t  rssi_sample_count;
 #endif /* CONFIG_BT_CTLR_CONN_RSSI */
+
+#if defined(CONFIG_BT_CTLR_CONN_META)
+	struct lll_conn_meta conn_meta;
+#endif /* CONFIG_BT_CTLR_CONN_META */
 };
 
 int lll_conn_init(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn_meta.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn_meta.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2019 Demant
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#if defined(CONFIG_BT_CTLR_CONN_META)
+/*
+ * struct lll_conn_meta { };
+ */
+#error Please define struct lll_conn_meta when enabling BT_CTLR_CONN_META
+#endif /* CONFIG_BT_CTLR_CONN_META */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -605,6 +605,9 @@ u8_t ll_adv_enable(u8_t enable)
 		conn_lll->slave.window_widening_event_us = 0;
 		conn_lll->slave.window_size_prepare_us = 0;
 		/* FIXME: END: Move to ULL? */
+#if defined(CONFIG_BT_CTLR_CONN_META)
+		memset(&conn_lll->conn_meta, 0, sizeof(conn_lll->conn_meta));
+#endif /* CONFIG_BT_CTLR_CONN_META */
 
 		conn->connect_expire = 6;
 		conn->supervision_expire = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2022,7 +2022,11 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, u16_t lazy,
 				     ticks_at_expire, ticks_win_offset,
 				     HAL_TICKER_US_TO_TICKS(periodic_us),
 				     HAL_TICKER_REMAINDER(periodic_us),
+#if defined(CONFIG_BT_CTLR_CONN_META)
+				     TICKER_LAZY_MUST_EXPIRE,
+#else
 				     TICKER_NULL_LAZY,
+#endif /* CONFIG_BT_CTLR_CONN_META */
 				     (ticks_slot_offset + conn->evt.ticks_slot),
 #if defined(CONFIG_BT_PERIPHERAL) && defined(CONFIG_BT_CENTRAL)
 				     lll->role ? ull_slave_ticker_cb :

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -154,6 +154,9 @@ u8_t ll_create_connection(u16_t scan_interval, u16_t scan_window,
 	conn_lll->data_chan_use = 0;
 	conn_lll->role = 0;
 	/* FIXME: END: Move to ULL? */
+#if defined(CONFIG_BT_CTLR_CONN_META)
+	memset(&conn_lll->conn_meta, 0, sizeof(conn_lll->conn_meta));
+#endif /* CONFIG_BT_CTLR_CONN_META */
 
 	conn->connect_expire = 6U;
 	conn->supervision_expire = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -271,7 +271,11 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 				     HAL_TICKER_US_TO_TICKS(conn_offset_us),
 				     HAL_TICKER_US_TO_TICKS(conn_interval_us),
 				     HAL_TICKER_REMAINDER(conn_interval_us),
+#if defined(CONFIG_BT_CTLR_CONN_META)
+				     TICKER_LAZY_MUST_EXPIRE,
+#else
 				     TICKER_NULL_LAZY,
+#endif /* CONFIG_BT_CTLR_CONN_META */
 				     (conn->evt.ticks_slot +
 				      ticks_slot_overhead),
 				     ull_slave_ticker_cb, conn, ticker_op_cb,


### PR DESCRIPTION
Added support for vendor specific meta data in LLL conn object. This
enables vendors to add state data to connection, for supporting
specialized BLE slave features.

Signed-off-by: Morten Priess <mtpr@oticon.com>