### PR TITLE
boards: frdm_k64f: Enable pullup for CAN0_RX pin

### DIFF
--- a/boards/arm/frdm_k64f/pinmux.c
+++ b/boards/arm/frdm_k64f/pinmux.c
@@ -151,7 +151,8 @@ static int frdm_k64f_pinmux_init(struct device *dev)
 #if CONFIG_CAN_0
 	/* FlexCAN0 RX, TX */
 	pinmux_pin_set(portb, 18, PORT_PCR_MUX(kPORT_MuxAlt2));
-	pinmux_pin_set(portb, 19, PORT_PCR_MUX(kPORT_MuxAlt2));
+	pinmux_pin_set(portb, 19, PORT_PCR_MUX(kPORT_MuxAlt2) |
+		       PORT_PCR_PE_MASK | PORT_PCR_PS_MASK);
 #endif
 
 	return 0;


### PR DESCRIPTION
This commit enables the pullup on CAN0_RX pin (PORTB 19).
The pullup ensures that the CAN controller initializes even
without a transceiver connected.

Fixes #18320.