### PR TITLE
tests: lib: sprintf: filter-out MCIMX7 platform with less than 34kB flash

### DIFF
--- a/tests/lib/sprintf/src/main.c
+++ b/tests/lib/sprintf/src/main.c
@@ -28,7 +28,7 @@
 #define DEADBEEF_PTR_STR       "0xdeadbeef"
 
 /*
- * A really long string (330 characters + NUL).
+ * A really long string (330 characters + NULL).
  * The underlying sprintf() architecture will truncate it.
  */
 #define REALLY_LONG_STRING		     \

--- a/tests/lib/sprintf/testcase.yaml
+++ b/tests/lib/sprintf/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   libraries.libc:
+    filter: not CONFIG_SOC_MCIMX7_M4
     tags: libc


### PR DESCRIPTION
Apparently the tests/lib/sprintf test requires more than
34kB of code size, so filter-out platforms which do not
have sufficient code space.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>