### PR TITLE
subsys/fs/littlefs: Protect littlefs Kconfig options

### DIFF
--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -128,9 +128,10 @@ config NFFS_FILESYSTEM_MAX_BLOCK_SIZE
 
 endmenu
 
+source "subsys/fs/Kconfig.littlefs"
+
 endif # FILE_SYSTEM
 
-source "subsys/fs/Kconfig.littlefs"
 source "subsys/fs/fcb/Kconfig"
 source "subsys/fs/nvs/Kconfig"
 


### PR DESCRIPTION
Move the inclusion of the littefs Kconfig options inside the
'if FILESYSTEM' block so we don't leak Kconfig symbols if FILESYSTEM
support isn't enabled.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>