### PR TITLE
scripts: west build: fix pristine builds

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -4,6 +4,8 @@
 
 import argparse
 import os
+import shutil
+import subprocess
 
 from west import log
 from west import cmake


### PR DESCRIPTION
There's a couple of missing imports from when the
203021bedb3ed5b841d21cd71e10e43122315b41 backport was added to the LTS
branch. Without this patch, pristine builds fail.