### PR TITLE
misrac: Checking the returned value of a non-void function

### DIFF
--- a/arch/arm/core/cortex_r/stacks.c
+++ b/arch/arm/core/cortex_r/stacks.c
@@ -17,10 +17,10 @@ K_THREAD_STACK_DEFINE(_sys_stack,   CONFIG_ARMV7_SYS_STACK_SIZE);
 #if defined(CONFIG_INIT_STACKS)
 void init_stacks(void)
 {
-	memset(_fiq_stack, 0xAA, CONFIG_ARMV7_FIQ_STACK_SIZE);
-	memset(_svc_stack, 0xAA, CONFIG_ARMV7_SVC_STACK_SIZE);
-	memset(_abort_stack, 0xAA, CONFIG_ARMV7_EXCEPTION_STACK_SIZE);
-	memset(_undef_stack, 0xAA, CONFIG_ARMV7_EXCEPTION_STACK_SIZE);
-	memset(&_interrupt_stack, 0xAA, CONFIG_ISR_STACK_SIZE);
+	(void)memset(_fiq_stack, 0xAA, CONFIG_ARMV7_FIQ_STACK_SIZE);
+	(void)memset(_svc_stack, 0xAA, CONFIG_ARMV7_SVC_STACK_SIZE);
+	(void)memset(_abort_stack, 0xAA, CONFIG_ARMV7_EXCEPTION_STACK_SIZE);
+	(void)memset(_undef_stack, 0xAA, CONFIG_ARMV7_EXCEPTION_STACK_SIZE);
+	(void)memset(&_interrupt_stack, 0xAA, CONFIG_ISR_STACK_SIZE);
 }
 #endif

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -464,7 +464,7 @@ static void bt_uart_isr(struct device *unused)
 				continue;
 			}
 
-			memcpy(&hdr[sizeof(hdr) - remaining], &byte, 1);
+			(void)memcpy(&hdr[sizeof(hdr) - remaining], &byte, 1);
 			remaining--;
 
 			if (remaining) {
@@ -585,7 +585,7 @@ static int h5_queue(struct net_buf *buf)
 		return -1;
 	}
 
-	memcpy(net_buf_push(buf, sizeof(type)), &type, sizeof(type));
+	(void)memcpy(net_buf_push(buf, sizeof(type)), &type, sizeof(type));
 
 	net_buf_put(&h5.tx_queue, buf);
 

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -260,9 +260,9 @@ static int bt_ipm_send(struct net_buf *buf)
 		       buf->len);
 		k_sem_take(&acl_data_ack, K_FOREVER);
 		net_buf_push_u8(buf, HCI_ACL);
-		memcpy((void *)
+		(void)memcpy((void *)
 		       &((TL_AclDataPacket_t *)HciAclDataBuffer)->AclDataSerial,
-		       buf->data, buf->len);
+				buf->data, buf->len);
 		TL_BLE_SendAclData(NULL, 0);
 		break;
 	case BT_BUF_CMD:
@@ -270,8 +270,8 @@ static int bt_ipm_send(struct net_buf *buf)
 		       buf->len);
 		ble_cmd_buff->cmdserial.type = HCI_CMD;
 		ble_cmd_buff->cmdserial.cmd.plen = buf->len;
-		memcpy((void *)&ble_cmd_buff->cmdserial.cmd, buf->data,
-		       buf->len);
+		(void)memcpy((void *)&ble_cmd_buff->cmdserial.cmd, buf->data,
+				buf->len);
 		TL_BLE_SendCmd(NULL, 0);
 		break;
 	default:

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -365,7 +365,8 @@ static void bt_spi_rx_thread(void)
 				break;
 			case HCI_ACL:
 				buf = bt_buf_get_rx(BT_BUF_ACL_IN, K_FOREVER);
-				memcpy(&acl_hdr, &rxmsg[1], sizeof(acl_hdr));
+				(void)memcpy(&acl_hdr, &rxmsg[1],
+					      sizeof(acl_hdr));
 				net_buf_add_mem(buf, &acl_hdr, sizeof(acl_hdr));
 				net_buf_add_mem(buf, &rxmsg[5],
 						sys_le16_to_cpu(acl_hdr.len));

--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -273,7 +273,7 @@ int ataes132a_aes_ccm_decrypt(struct device *dev,
 		param_buffer[1] = 0x0;
 		param_buffer[2] = 0x0;
 		param_buffer[3] = 0x0;
-		memcpy(param_buffer + 4,  nonce_buf, 12);
+		(void)memcpy(param_buffer + 4,  nonce_buf, 12);
 
 		return_code = ataes132a_send_command(dev, ATAES_NONCE_OP,
 						     0x0, param_buffer, 16,
@@ -345,9 +345,9 @@ int ataes132a_aes_ccm_decrypt(struct device *dev,
 	param_buffer[1] = key_id;
 	param_buffer[3] = expected_out_len;
 	if (aead_op->tag) {
-		memcpy(param_buffer + 4,  aead_op->tag, 16);
+		(void)memcpy(param_buffer + 4,  aead_op->tag, 16);
 	}
-	memcpy(param_buffer + 20, aead_op->pkt->in_buf, in_buf_len);
+	(void)memcpy(param_buffer + 20, aead_op->pkt->in_buf, in_buf_len);
 
 	return_code = ataes132a_send_command(dev, ATAES_DECRYPT_OP,
 					     command_mode, param_buffer,
@@ -382,7 +382,7 @@ int ataes132a_aes_ccm_decrypt(struct device *dev,
 		return -EINVAL;
 	}
 
-	memcpy(aead_op->pkt->out_buf, param_buffer + 1, out_len - 1);
+	(void)memcpy(aead_op->pkt->out_buf, param_buffer + 1, out_len - 1);
 
 	k_sem_give(&data->device_sem);
 
@@ -464,7 +464,7 @@ int ataes132a_aes_ccm_encrypt(struct device *dev,
 		param_buffer[1] = 0x0;
 		param_buffer[2] = 0x0;
 		param_buffer[3] = 0x0;
-		memcpy(param_buffer + 4,  nonce_buf, 12);
+		(void)memcpy(param_buffer + 4,  nonce_buf, 12);
 
 		return_code = ataes132a_send_command(dev, ATAES_NONCE_OP,
 						     0x0, param_buffer, 16,
@@ -519,7 +519,7 @@ int ataes132a_aes_ccm_encrypt(struct device *dev,
 
 	param_buffer[0] = key_id;
 	param_buffer[1] = buf_len;
-	memcpy(param_buffer + 2, aead_op->pkt->in_buf, buf_len);
+	(void)memcpy(param_buffer + 2, aead_op->pkt->in_buf, buf_len);
 
 	return_code = ataes132a_send_command(dev, ATAES_ENCRYPT_OP,
 					     command_mode, param_buffer,
@@ -547,9 +547,9 @@ int ataes132a_aes_ccm_encrypt(struct device *dev,
 	}
 
 	if (aead_op->tag) {
-		memcpy(aead_op->tag, param_buffer + 1, 16);
+		(void)memcpy(aead_op->tag, param_buffer + 1, 16);
 	}
-	memcpy(aead_op->pkt->out_buf, param_buffer + 17, out_len - 17U);
+	(void)memcpy(aead_op->pkt->out_buf, param_buffer + 17, out_len - 17U);
 
 	if (mac_mode) {
 		if (mac_mode->include_counter) {
@@ -632,7 +632,7 @@ int ataes132a_aes_ecb_block(struct device *dev,
 	param_buffer[0] = 0x0;
 	param_buffer[1] = key_id;
 	param_buffer[2] = 0x0;
-	memcpy(param_buffer + 3, pkt->in_buf, buf_len);
+	(void)memcpy(param_buffer + 3, pkt->in_buf, buf_len);
 	(void)memset(param_buffer + 3 + buf_len, 0x0, 16 - buf_len);
 
 	return_code = ataes132a_send_command(dev, ATAES_LEGACY_OP, 0x00,
@@ -658,7 +658,7 @@ int ataes132a_aes_ecb_block(struct device *dev,
 		return -EIO;
 	}
 
-	memcpy(pkt->out_buf, param_buffer + 1, 16);
+	(void)memcpy(pkt->out_buf, param_buffer + 1, 16);
 
 	k_sem_give(&data->device_sem);
 

--- a/drivers/crypto/crypto_tc_shim.c
+++ b/drivers/crypto/crypto_tc_shim.c
@@ -83,7 +83,7 @@ static int do_ctr_op(struct cipher_ctx *ctx, struct cipher_pkt *op,
 	/* Tinycrypt takes the last 4 bytes of the counter parameter as the
 	 * true counter start. IV forms the first 12 bytes of the split counter.
 	 */
-	memcpy(ctr, iv, ivlen);
+	(void)memcpy(ctr, iv, ivlen);
 
 	if (tc_ctr_mode(op->out_buf, op->out_buf_max, op->in_buf,
 			op->in_len, ctr,
@@ -126,7 +126,7 @@ static int do_ccm_encrypt_mac(struct cipher_ctx *ctx,
 	 * both encrypted output and hash
 	 */
 	if (aead_op->tag) {
-		memcpy(aead_op->tag, op->out_buf + op->in_len, ccm.mlen);
+		(void)memcpy(aead_op->tag, op->out_buf + op->in_len, ccm.mlen);
 	}
 
 	/* Before returning TC_CRYPTO_SUCCESS, tc_ccm_generation_encryption()

--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -73,7 +73,7 @@ static void dummy_display_get_capabilities(const struct device *dev,
 	struct dummy_display_data *disp_data =
 		(struct dummy_display_data *)dev->driver_data;
 
-	memset(capabilities, 0, sizeof(struct display_capabilities));
+	(void)memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = CONFIG_DUMMY_DISPLAY_X_RES;
 	capabilities->y_resolution = CONFIG_DUMMY_DISPLAY_Y_RES;
 	capabilities->supported_pixel_formats = PIXEL_FORMAT_ARGB_8888 |

--- a/drivers/display/display_ili9340.c
+++ b/drivers/display/display_ili9340.c
@@ -247,7 +247,7 @@ static int ili9340_set_orientation(const struct device *dev,
 static void ili9340_get_capabilities(const struct device *dev,
 				     struct display_capabilities *capabilities)
 {
-	memset(capabilities, 0, sizeof(struct display_capabilities));
+	(void)memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = 320U;
 	capabilities->y_resolution = 240U;
 #ifdef CONFIG_ILI9340_RGB565

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -59,15 +59,15 @@ static int mcux_elcdif_write(const struct device *dev, const u16_t x,
 
 	k_sem_take(&data->sem, K_FOREVER);
 
-	memcpy(data->fb[write_idx].data, data->fb[read_idx].data,
-	       data->fb_bytes);
+	(void)memcpy(data->fb[write_idx].data, data->fb[read_idx].data,
+			data->fb_bytes);
 
 	src = buf;
 	dst = data->fb[data->write_idx].data;
 	dst += data->pixel_bytes * (y * config->rgb_mode.panelWidth + x);
 
 	for (h_idx = 0; h_idx < desc->height; h_idx++) {
-		memcpy(dst, src, data->pixel_bytes * desc->width);
+		(void)memcpy(dst, src, data->pixel_bytes * desc->width);
 		src += data->pixel_bytes * desc->pitch;
 		dst += data->pixel_bytes * config->rgb_mode.panelWidth;
 	}
@@ -154,7 +154,7 @@ static void mcux_elcdif_get_capabilities(const struct device *dev,
 {
 	const struct mcux_elcdif_config *config = dev->config->config_info;
 
-	memset(capabilities, 0, sizeof(struct display_capabilities));
+	(void)memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = config->rgb_mode.panelWidth;
 	capabilities->y_resolution = config->rgb_mode.panelHeight;
 	capabilities->supported_pixel_formats = config->pixel_format;
@@ -194,7 +194,7 @@ static int mcux_elcdif_init(struct device *dev)
 			LOG_ERR("Could not allocate frame buffer %d", i);
 			return -ENOMEM;
 		}
-		memset(data->fb[i].data, 0, data->fb_bytes);
+		(void)memset(data->fb[i].data, 0, data->fb_bytes);
 	}
 	rgb_mode.bufferAddr = (uint32_t) data->fb[0].data;
 

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -85,7 +85,7 @@ static void sdl_display_write_argb8888(void *disp_buf,
 	__ASSERT((desc->pitch * 4U * desc->height) <= desc->buf_size,
 			"Input buffer to small");
 
-	memcpy(disp_buf, buf, desc->pitch * 4U * desc->height);
+	(void)memcpy(disp_buf, buf, desc->pitch * 4U * desc->height);
 }
 
 static void sdl_display_write_rgb888(u8_t *disp_buf,
@@ -277,7 +277,7 @@ static void sdl_display_get_capabilities(
 	struct sdl_display_data *disp_data =
 	    (struct sdl_display_data *)dev->driver_data;
 
-	memset(capabilities, 0, sizeof(struct display_capabilities));
+	(void)memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = CONFIG_SDL_DISPLAY_X_RES;
 	capabilities->y_resolution = CONFIG_SDL_DISPLAY_Y_RES;
 	capabilities->supported_pixel_formats = PIXEL_FORMAT_ARGB_8888 |

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -310,7 +310,7 @@ void st7789v_get_capabilities(const struct device *dev,
 {
 	struct st7789v_data *data = (struct st7789v_data *)dev->driver_data;
 
-	memset(capabilities, 0, sizeof(struct display_capabilities));
+	(void)memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = data->width;
 	capabilities->y_resolution = data->height;
 

--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -332,7 +332,7 @@ int ssd1306_set_contrast(const struct device *dev, const u8_t contrast)
 static void ssd1306_get_capabilities(const struct device *dev,
 				     struct display_capabilities *caps)
 {
-	memset(caps, 0, sizeof(struct display_capabilities));
+	(void)memset(caps, 0, sizeof(struct display_capabilities));
 	caps->x_resolution = DT_INST_0_SOLOMON_SSD1306FB_WIDTH;
 	caps->y_resolution = DT_INST_0_SOLOMON_SSD1306FB_HEIGHT;
 	caps->supported_pixel_formats = PIXEL_FORMAT_MONO10;

--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -387,7 +387,7 @@ static int ssd16xx_set_contrast(const struct device *dev, u8_t contrast)
 static void ssd16xx_get_capabilities(const struct device *dev,
 				     struct display_capabilities *caps)
 {
-	memset(caps, 0, sizeof(struct display_capabilities));
+	(void)memset(caps, 0, sizeof(struct display_capabilities));
 	caps->x_resolution = EPD_PANEL_WIDTH;
 	caps->y_resolution = EPD_PANEL_HEIGHT;
 	caps->supported_pixel_formats = PIXEL_FORMAT_MONO10;
@@ -459,7 +459,7 @@ static int ssd16xx_clear_and_write_buffer(struct device *dev)
 
 	gpio_pin_write(driver->dc, SSD16XX_DC_PIN, 1);
 
-	memset(clear_page, 0xff, sizeof(clear_page));
+	(void)memset(clear_page, 0xff, sizeof(clear_page));
 	sbuf.buf = clear_page;
 	sbuf.len = sizeof(clear_page);
 	for (page = 0U; page <= (SSD16XX_PANEL_LAST_PAGE + 1); ++page) {

--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -31,12 +31,12 @@ static int entropy_esp32_get_entropy(struct device *device, u8_t *buf, u16_t len
 		u32_t v = entropy_esp32_get_u32();
 
 		if (len >= sizeof(v)) {
-			memcpy(buf, &v, sizeof(v));
+			(void)memcpy(buf, &v, sizeof(v));
 
 			buf += sizeof(v);
 			len -= sizeof(v);
 		} else {
-			memcpy(buf, &v, len);
+			(void)memcpy(buf, &v, len);
 			break;
 		}
 	}

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -60,7 +60,7 @@ static int entropy_sam_get_entropy(struct device *dev, u8_t *buffer,
 		value = trng->TRNG_ODATA;
 		to_copy = MIN(length, sizeof(value));
 
-		memcpy(buffer, &value, to_copy);
+		(void)memcpy(buffer, &value, to_copy);
 		buffer += to_copy;
 		length -= to_copy;
 	}

--- a/drivers/entropy/fake_entropy_native_posix.c
+++ b/drivers/entropy/fake_entropy_native_posix.c
@@ -37,7 +37,7 @@ static int entropy_native_posix_get_entropy(struct device *dev, u8_t *buffer,
 
 		size_t to_copy = MIN(length, sizeof(long int));
 
-		memcpy(buffer, &value, to_copy);
+		(void)memcpy(buffer, &value, to_copy);
 		buffer += to_copy;
 		length -= to_copy;
 	}

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -189,8 +189,8 @@ static void e1000_init(struct net_if *iface)
 	ral = ior32(dev, RAL);
 	rah = ior32(dev, RAH);
 
-	memcpy(dev->mac, &ral, 4);
-	memcpy(dev->mac + 4, &rah, 2);
+	(void)memcpy(dev->mac, &ral, 4);
+	(void)memcpy(dev->mac + 4, &rah, 2);
 
 	ethernet_init(iface);
 

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -467,8 +467,8 @@ static bool eth_get_ptp_data(struct net_if *iface, struct net_pkt *pkt,
 		}
 
 		ptpTsData->version = hdr->ptp_version;
-		memcpy(ptpTsData->sourcePortId, &hdr->port_id,
-		       kENET_PtpSrcPortIdLen);
+		(void)memcpy(ptpTsData->sourcePortId, &hdr->port_id,
+				kENET_PtpSrcPortIdLen);
 		ptpTsData->messageType = hdr->message_type;
 		ptpTsData->sequenceId = ntohs(hdr->sequence_id);
 

--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -40,7 +40,7 @@ static int flash_gecko_read(struct device *dev, off_t offset, void *data,
 		return 0;
 	}
 
-	memcpy(data, (u8_t *)CONFIG_FLASH_BASE_ADDRESS + offset, size);
+	(void)memcpy(data, (u8_t *)CONFIG_FLASH_BASE_ADDRESS + offset, size);
 
 	return 0;
 }

--- a/drivers/flash/flash_native_posix.c
+++ b/drivers/flash/flash_native_posix.c
@@ -60,7 +60,7 @@ static int flash_native_posix_read(struct device *dev, off_t offset, void *data,
 		return -EINVAL;
 	}
 
-	memcpy(data, dev_data->flash + offset, size);
+	(void)memcpy(data, dev_data->flash + offset, size);
 
 	return 0;
 }
@@ -81,7 +81,7 @@ static int flash_native_posix_write(struct device *dev, off_t offset,
 		return -EINVAL;
 	}
 
-	memcpy(dev_data->flash + offset, data, size);
+	(void)memcpy(dev_data->flash + offset, data, size);
 
 	return 0;
 }
@@ -102,7 +102,7 @@ static int flash_native_posix_erase(struct device *dev, off_t offset,
 		return -EINVAL;
 	}
 
-	memset(dev_data->flash + offset, 0xff, size);
+	(void)memset(dev_data->flash + offset, 0xff, size);
 
 	return 0;
 }

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -213,7 +213,7 @@ static int flash_sam_read(struct device *dev, off_t offset, void *data,
 		return -EINVAL;
 	}
 
-	memcpy(data, (u8_t *)CONFIG_FLASH_BASE_ADDRESS + offset, len);
+	(void)memcpy(data, (u8_t *)CONFIG_FLASH_BASE_ADDRESS + offset, len);
 
 	return 0;
 }

--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -206,7 +206,7 @@ static int flash_sam0_write(struct device *dev, off_t offset,
 		if (base != ctx->offset) {
 			/* Started a new row.  Flush any pending ones. */
 			flash_sam0_commit(dev);
-			memcpy(ctx->buf, (void *)base, sizeof(ctx->buf));
+			(void)memcpy(ctx->buf, (void *)base, sizeof(ctx->buf));
 			ctx->offset = base;
 		}
 
@@ -270,7 +270,7 @@ static int flash_sam0_read(struct device *dev, off_t offset, void *data,
 		return err;
 	}
 
-	memcpy(data, (u8_t *)CONFIG_FLASH_BASE_ADDRESS + offset, len);
+	(void)memcpy(data, (u8_t *)CONFIG_FLASH_BASE_ADDRESS + offset, len);
 
 	return 0;
 }

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -150,7 +150,7 @@ static int flash_sim_read(struct device *dev, const off_t offset, void *data,
 
 	STATS_INC(flash_sim_stats, flash_read_calls);
 
-	memcpy(data, FLASH(offset), len);
+	(void)memcpy(data, FLASH(offset), len);
 	STATS_INCN(flash_sim_stats, bytes_read, len);
 
 #ifdef CONFIG_FLASH_SIMULATOR_SIMULATE_TIMING
@@ -187,7 +187,7 @@ static int flash_sim_write(struct device *dev, const off_t offset,
 
 		u8_t buf[FLASH_SIMULATOR_PROG_UNIT];
 
-		memset(buf, 0xFF, sizeof(buf));
+		(void)memset(buf, 0xFF, sizeof(buf));
 		if (memcmp(buf, FLASH(offset + i), sizeof(buf))) {
 			STATS_INC(flash_sim_stats, double_writes);
 #if !CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES
@@ -244,8 +244,8 @@ static void unit_erase(const u32_t unit)
 	u8_t byte_pattern = 0xFF;
 
 	/* erase the memory unit by pulling all bits to one */
-	memset(FLASH(unit_addr), byte_pattern,
-	       FLASH_SIMULATOR_ERASE_UNIT);
+	(void)memset(FLASH(unit_addr), byte_pattern,
+			FLASH_SIMULATOR_ERASE_UNIT);
 }
 
 static int flash_sim_erase(struct device *dev, const off_t offset,
@@ -327,7 +327,7 @@ static int flash_init(struct device *dev)
 	STATS_INIT_AND_REG(flash_sim_stats, STATS_SIZE_32, "flash_sim_stats");
 	STATS_INIT_AND_REG(flash_sim_thresholds, STATS_SIZE_32,
 			   "flash_sim_thresholds");
-	memset(mock_flash, 0xFF, ARRAY_SIZE(mock_flash));
+	(void)memset(mock_flash, 0xFF, ARRAY_SIZE(mock_flash));
 
 	return 0;
 }

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -166,7 +166,7 @@ static int flash_stm32_read(struct device *dev, off_t offset, void *data,
 		return 0;
 	}
 
-	memcpy(data, (u8_t *) CONFIG_FLASH_BASE_ADDRESS + offset, len);
+	(void)memcpy(data, (u8_t *) CONFIG_FLASH_BASE_ADDRESS + offset, len);
 
 	return 0;
 }

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -69,7 +69,7 @@ static int flash_mcux_read(struct device *dev, off_t offset,
 	 */
 	addr = offset + priv->pflash_block_base;
 
-	memcpy(data, (void *) addr, len);
+	(void)memcpy(data, (void *) addr, len);
 
 	return 0;
 }

--- a/drivers/flash/soc_flash_nios2_qspi.c
+++ b/drivers/flash/soc_flash_nios2_qspi.c
@@ -219,7 +219,7 @@ static int flash_nios2_qspi_write_block(struct device *dev, int block_offset,
 		}
 
 		/* prepare the word to be written */
-		memcpy((u8_t *)&word_to_write + padding,
+		(void)memcpy((u8_t *)&word_to_write + padding,
 				(const u8_t *)data + buffer_offset,
 				bytes_to_copy);
 
@@ -352,8 +352,8 @@ static int flash_nios2_qspi_read(struct device *dev, off_t offset,
 
 		/* read from flash 32 bits at a time */
 		word_to_read = IORD_32DIRECT(qspi_dev->data_base, read_offset);
-		memcpy((u8_t *)data + buffer_offset, &word_to_read,
-		       bytes_to_copy);
+		(void)memcpy((u8_t *)data + buffer_offset, &word_to_read,
+				bytes_to_copy);
 
 		/* update offset and length variables */
 		read_offset += bytes_to_copy;

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -142,7 +142,7 @@ static int flash_nrf_read(struct device *dev, off_t addr,
 		return 0;
 	}
 
-	memcpy(data, (void *)addr, len);
+	(void)memcpy(data, (void *)addr, len);
 
 	return 0;
 }

--- a/drivers/flash/soc_flash_rv32m1.c
+++ b/drivers/flash/soc_flash_rv32m1.c
@@ -71,7 +71,7 @@ static int flash_mcux_read(struct device *dev, off_t offset,
 	 */
 	addr = offset + priv->pflash_block_base;
 
-	memcpy(data, (void *) addr, len);
+	(void)memcpy(data, (void *) addr, len);
 
 	return 0;
 }

--- a/drivers/hwinfo/hwinfo_esp32.c
+++ b/drivers/hwinfo/hwinfo_esp32.c
@@ -20,7 +20,7 @@ ssize_t _impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 		length = sizeof(fuse_rdata);
 	}
 
-	memcpy(buffer, fuse_rdata, length);
+	(void)memcpy(buffer, fuse_rdata, length);
 
 	return length;
 }

--- a/drivers/hwinfo/hwinfo_imxrt.c
+++ b/drivers/hwinfo/hwinfo_imxrt.c
@@ -23,7 +23,7 @@ ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 		length = sizeof(dev_id.id);
 	}
 
-	memcpy(buffer, dev_id.id, length);
+	(void)memcpy(buffer, dev_id.id, length);
 
 	return length;
 }

--- a/drivers/hwinfo/hwinfo_mcux_sim.c
+++ b/drivers/hwinfo/hwinfo_mcux_sim.c
@@ -47,7 +47,7 @@ ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 		length = sizeof(dev_id.id);
 	}
 
-	memcpy(buffer, dev_id.id, length);
+	(void)memcpy(buffer, dev_id.id, length);
 
 	return length;
 }

--- a/drivers/hwinfo/hwinfo_nrf.c
+++ b/drivers/hwinfo/hwinfo_nrf.c
@@ -23,7 +23,7 @@ ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 		length = sizeof(dev_id.id);
 	}
 
-	memcpy(buffer, dev_id.id, length);
+	(void)memcpy(buffer, dev_id.id, length);
 
 	return length;
 }

--- a/drivers/hwinfo/hwinfo_sam.c
+++ b/drivers/hwinfo/hwinfo_sam.c
@@ -18,7 +18,7 @@ ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 		length = sizeof(sam_uid);
 	}
 
-	memcpy(buffer, sam_uid, length);
+	(void)memcpy(buffer, sam_uid, length);
 
 	return length;
 }

--- a/drivers/hwinfo/hwinfo_sam0.c
+++ b/drivers/hwinfo/hwinfo_sam0.c
@@ -25,7 +25,7 @@ ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 		length = sizeof(dev_id.id);
 	}
 
-	memcpy(buffer, dev_id.id, length);
+	(void)memcpy(buffer, dev_id.id, length);
 
 	return length;
 }

--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -24,7 +24,7 @@ ssize_t z_impl_hwinfo_get_device_id(u8_t *buffer, size_t length)
 		length = sizeof(dev_id.id);
 	}
 
-	memcpy(buffer, dev_id.id, length);
+	(void)memcpy(buffer, dev_id.id, length);
 
 	return length;
 }

--- a/drivers/i2c/i2c_handlers.c
+++ b/drivers/i2c/i2c_handlers.c
@@ -24,7 +24,7 @@ static u32_t copy_msgs_and_transfer(struct device *dev,
 	u8_t i;
 
 	/* Use a local copy to avoid switcheroo attacks. */
-	memcpy(copy, msgs, num_msgs * sizeof(*msgs));
+	(void)memcpy(copy, msgs, num_msgs * sizeof(*msgs));
 
 	/* Validate the buffers in each message struct. Read options require
 	 * that the target buffer be writable

--- a/drivers/i2c/slave/eeprom_slave.c
+++ b/drivers/i2c/slave/eeprom_slave.c
@@ -47,7 +47,7 @@ int eeprom_slave_program(struct device *dev, u8_t *eeprom_data,
 		return -EINVAL;
 	}
 
-	memcpy(data->buffer, eeprom_data, length);
+	(void)memcpy(data->buffer, eeprom_data, length);
 
 	return 0;
 }

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -362,7 +362,7 @@ static int i2s_cavs_configure(struct device *dev, enum i2s_dir dir,
 		return -ENOTSUP;
 	}
 
-	memcpy(&dev_data->cfg, i2s_cfg, sizeof(struct i2s_config));
+	(void)memcpy(&dev_data->cfg, i2s_cfg, sizeof(struct i2s_config));
 
 	/* reset SSP settings */
 	/* sscr0 dynamic settings are DSS, EDSS, SCR, FRDC, ECS */

--- a/drivers/i2s/i2s_common.c
+++ b/drivers/i2s/i2s_common.c
@@ -19,7 +19,7 @@ int z_impl_i2s_buf_read(struct device *dev, void *buf, size_t *size)
 		struct i2s_config *rx_cfg =
 			i2s_config_get((struct device *)dev, I2S_DIR_RX);
 
-		memcpy(buf, mem_block, *size);
+		(void)memcpy(buf, mem_block, *size);
 		k_mem_slab_free(rx_cfg->mem_slab, &mem_block);
 	}
 
@@ -46,7 +46,7 @@ int z_impl_i2s_buf_write(struct device *dev, void *buf, size_t size)
 		return -ENOMEM;
 	}
 
-	memcpy(mem_block, (void *)buf, size);
+	(void)memcpy(mem_block, (void *)buf, size);
 
 	ret = i2s_write((struct device *)dev, mem_block, size);
 	if (ret != 0) {

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -206,12 +206,12 @@ static int i2s_stm32_configure(struct device *dev, enum i2s_dir dir,
 
 	if (i2s_cfg->frame_clk_freq == 0U) {
 		stream->queue_drop(stream);
-		memset(&stream->cfg, 0, sizeof(struct i2s_config));
+		(void)memset(&stream->cfg, 0, sizeof(struct i2s_config));
 		stream->state = I2S_STATE_NOT_READY;
 		return 0;
 	}
 
-	memcpy(&stream->cfg, i2s_cfg, sizeof(struct i2s_config));
+	(void)memcpy(&stream->cfg, i2s_cfg, sizeof(struct i2s_config));
 
 	/* set I2S bitclock */
 	bit_clk_freq = i2s_cfg->frame_clk_freq *
@@ -445,7 +445,7 @@ static int start_dma(struct device *dev_dma, u32_t channel,
 	struct dma_block_config blk_cfg;
 	int ret;
 
-	memset(&blk_cfg, 0, sizeof(blk_cfg));
+	(void)memset(&blk_cfg, 0, sizeof(blk_cfg));
 	blk_cfg.block_size = blk_size / sizeof(u16_t);
 	blk_cfg.source_address = (u32_t)src;
 	blk_cfg.dest_address = (u32_t)dst;

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -585,7 +585,7 @@ static int i2s_sam_configure(struct device *dev, enum i2s_dir dir,
 		return -EINVAL;
 	}
 
-	memcpy(&stream->cfg, i2s_cfg, sizeof(struct i2s_config));
+	(void)memcpy(&stream->cfg, i2s_cfg, sizeof(struct i2s_config));
 
 	bit_clk_freq = i2s_cfg->frame_clk_freq * word_size_bits * num_words;
 	ret = bit_clock_set(ssc, bit_clk_freq);

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -1170,7 +1170,7 @@ static inline void generate_nonce(u8_t *ccm_nonce, u8_t *nonce,
 {
 	nonce[0] = 0 | (apkt->ad_len ? 0x40 : 0) | (m << 3) | 1;
 
-	memcpy(&nonce[1], ccm_nonce, 13);
+	(void)memcpy(&nonce[1], ccm_nonce, 13);
 
 	nonce[14] = (u8_t)(apkt->pkt->in_len >> 8);
 	nonce[15] = (u8_t)(apkt->pkt->in_len);
@@ -1227,9 +1227,9 @@ static int insert_crypto_parameters(struct cipher_ctx *ctx,
 	} else {
 		in_buf = data;
 
-		memcpy(in_buf, apkt->ad, apkt->ad_len);
-		memcpy(in_buf + apkt->ad_len,
-		       apkt->pkt->in_buf, apkt->pkt->in_len);
+		(void)memcpy(in_buf, apkt->ad, apkt->ad_len);
+		(void)memcpy(in_buf + apkt->ad_len,
+				apkt->pkt->in_buf, apkt->pkt->in_len);
 		in_len = apkt->ad_len + apkt->pkt->in_len;
 
 		*auth_crypt = !apkt->tag ? apkt->pkt->in_len :
@@ -1308,8 +1308,9 @@ static int cc2520_crypto_ccm(struct cipher_ctx *ctx,
 	}
 
 	if (apkt->tag) {
-		memcpy(apkt->tag, apkt->pkt->out_buf + apkt->pkt->in_len,
-					ctx->mode_params.ccm_info.tag_len);
+		(void)memcpy(apkt->tag,
+				apkt->pkt->out_buf + apkt->pkt->in_len,
+				ctx->mode_params.ccm_info.tag_len);
 	}
 
 	return 0;

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -411,10 +411,10 @@ static int kw41z_set_ieee_addr(struct device *dev, const u8_t *ieee_addr)
 {
 	u32_t val;
 
-	memcpy(&val, ieee_addr, sizeof(val));
+	(void)memcpy(&val, ieee_addr, sizeof(val));
 	ZLL->MACLONGADDRS0_LSB = val;
 
-	memcpy(&val, ieee_addr + sizeof(val), sizeof(val));
+	(void)memcpy(&val, ieee_addr + sizeof(val), sizeof(val));
 	ZLL->MACLONGADDRS0_MSB = val;
 
 	return 0;
@@ -601,12 +601,12 @@ static int kw41z_tx(struct device *dev, struct net_pkt *pkt,
 
 #if CONFIG_SOC_MKW41Z4
 	((u8_t *)ZLL->PKT_BUFFER_TX)[0] = payload_len + KW41Z_FCS_LENGTH;
-	memcpy(((u8_t *)ZLL->PKT_BUFFER_TX) + 1,
-		(void *)frag->data, payload_len);
+	(void)memcpy(((u8_t *)ZLL->PKT_BUFFER_TX) + 1,
+			(void *)frag->data, payload_len);
 #else /* CONFIG_SOC_MKW40Z4 */
 	((u8_t *)ZLL->PKT_BUFFER)[0] = payload_len + KW41Z_FCS_LENGTH;
-	memcpy(((u8_t *)ZLL->PKT_BUFFER) + 1,
-		(void *)frag->data, payload_len);
+	(void)memcpy(((u8_t *)ZLL->PKT_BUFFER) + 1,
+			(void *)frag->data, payload_len);
 #endif
 
 	/* Set CCA mode */

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -57,7 +57,7 @@ static struct nrf5_802154_data nrf5_data;
 
 static void nrf5_get_eui64(u8_t *mac)
 {
-	memcpy(mac, (const u32_t *)&NRF_FICR->DEVICEID, 8);
+	(void)memcpy(mac, (const u32_t *)&NRF_FICR->DEVICEID, 8);
 }
 
 static void nrf5_rx_thread(void *arg1, void *arg2, void *arg3)
@@ -267,7 +267,7 @@ static int nrf5_tx(struct device *dev,
 	LOG_DBG("%p (%u)", payload, payload_len);
 
 	nrf5_radio->tx_psdu[0] = payload_len + NRF5_FCS_LENGTH;
-	memcpy(nrf5_radio->tx_psdu + 1, payload, payload_len);
+	(void)memcpy(nrf5_radio->tx_psdu + 1, payload, payload_len);
 
 	/* Reset semaphore in case ACK was received after timeout */
 	k_sem_reset(&nrf5_radio->tx_wait);

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -141,7 +141,7 @@ static u8_t *upipe_rx(u8_t *buf, size_t *off)
 
 		net_pkt_frag_insert(pkt, frag);
 
-		memcpy(frag->data, upipe->rx_buf, upipe->rx_len);
+		(void)memcpy(frag->data, upipe->rx_buf, upipe->rx_len);
 		net_buf_add(frag, upipe->rx_len);
 
 #if defined(CONFIG_IEEE802154_UPIPE_HW_FILTER)
@@ -209,7 +209,7 @@ static int upipe_set_pan_id(struct device *dev, u16_t pan_id)
 	ARG_UNUSED(dev);
 
 	sys_put_le16(pan_id, pan_id_le);
-	memcpy(dev_pan_id, pan_id_le, PAN_ID_SIZE);
+	(void)memcpy(dev_pan_id, pan_id_le, PAN_ID_SIZE);
 
 	return 0;
 }
@@ -221,7 +221,7 @@ static int upipe_set_short_addr(struct device *dev, u16_t short_addr)
 	ARG_UNUSED(dev);
 
 	sys_put_le16(short_addr, short_addr_le);
-	memcpy(dev_short_addr, short_addr_le, SHORT_ADDRESS_SIZE);
+	(void)memcpy(dev_short_addr, short_addr_le, SHORT_ADDRESS_SIZE);
 
 	return 0;
 }
@@ -230,7 +230,7 @@ static int upipe_set_ieee_addr(struct device *dev, const u8_t *ieee_addr)
 {
 	ARG_UNUSED(dev);
 
-	memcpy(dev_ext_addr, ieee_addr, EXTENDED_ADDRESS_SIZE);
+	(void)memcpy(dev_ext_addr, ieee_addr, EXTENDED_ADDRESS_SIZE);
 
 	return 0;
 }

--- a/drivers/ipm/ipm_imx.c
+++ b/drivers/ipm/ipm_imx.c
@@ -103,7 +103,7 @@ static int imx_mu_ipm_send(struct device *dev, int wait, u32_t id,
 	}
 
 	/* Actual message is passing using 32 bits registers */
-	memcpy(data32, data, size);
+	(void)memcpy(data32, data, size);
 
 	for (i = 0; i < IMX_IPM_DATA_REGS; i++) {
 		status = MU_TrySendMsg(base, id * IMX_IPM_DATA_REGS + i,

--- a/drivers/ipm/ipm_mcux.c
+++ b/drivers/ipm/ipm_mcux.c
@@ -86,7 +86,7 @@ static int mcux_mailbox_ipm_send(struct device *d, int wait, u32_t id,
 	flags = irq_lock();
 
 	/* Actual message is passing using 32 bits registers */
-	memcpy(data32, data, size);
+	(void)memcpy(data32, data, size);
 
 	for (i = 0; i < ARRAY_SIZE(data32); ++i) {
 		MAILBOX_SetValueBits(base, MAILBOX_ID_OTHER_CPU, data32[i]);

--- a/drivers/led/ht16k33.c
+++ b/drivers/led/ht16k33.c
@@ -331,7 +331,7 @@ static int ht16k33_init(struct device *dev)
 		return -EINVAL;
 	}
 
-	memset(&data->buffer, 0, sizeof(data->buffer));
+	(void)memset(&data->buffer, 0, sizeof(data->buffer));
 
 	/* Hardware specific limits */
 	dev_data->min_period = 0U;
@@ -349,7 +349,7 @@ static int ht16k33_init(struct device *dev)
 	}
 
 	/* Clear display RAM */
-	memset(cmd, 0, sizeof(cmd));
+	(void)memset(cmd, 0, sizeof(cmd));
 	cmd[0] = HT16K33_CMD_DISP_DATA_ADDR;
 	err = i2c_write(data->i2c, cmd, sizeof(cmd), config->i2c_addr);
 	if (err) {
@@ -374,7 +374,7 @@ static int ht16k33_init(struct device *dev)
 	}
 
 #ifdef CONFIG_HT16K33_KEYSCAN
-	memset(&data->children, 0, sizeof(data->children));
+	(void)memset(&data->children, 0, sizeof(data->children));
 	k_mutex_init(&data->lock);
 	k_sem_init(&data->irq_sem, 0, 1);
 

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -147,7 +147,7 @@ static void process_cmd(struct modem_cmd *cmd, size_t match_len,
 	u16_t argc = 0U;
 
 	/* reset params */
-	memset(argv, 0, sizeof(argv[0]) * ARRAY_SIZE(argv));
+	(void)memset(argv, 0, sizeof(argv[0]) * ARRAY_SIZE(argv));
 
 	/* do we need to parse arguments? */
 	if (cmd->arg_count > 0U) {

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -971,7 +971,7 @@ static int offload_bind(int sock_fd, const struct sockaddr *addr,
 	}
 
 	/* save bind address information */
-	memcpy(&sock->src, addr, sizeof(*addr));
+	(void)memcpy(&sock->src, addr, sizeof(*addr));
 
 	/* make sure we've created the socket */
 	if (sock->id == mdata.socket_config.sockets_len + 1) {
@@ -1013,7 +1013,7 @@ static int offload_connect(int sock_fd, const struct sockaddr *addr,
 		}
 	}
 
-	memcpy(&sock->dst, addr, sizeof(*addr));
+	(void)memcpy(&sock->dst, addr, sizeof(*addr));
 	if (addr->sa_family == AF_INET6) {
 		dst_port = ntohs(net_sin6(addr)->sin6_port);
 	} else if (addr->sa_family == AF_INET) {
@@ -1107,7 +1107,7 @@ static ssize_t offload_recvfrom(int sock_fd, void *buf, short int len,
 	/* HACK: use dst address as from */
 	if (from && fromlen) {
 		*fromlen = sizeof(sock->dst);
-		memcpy(from, &sock->dst, *fromlen);
+		(void)memcpy(from, &sock->dst, *fromlen);
 	}
 
 	/* return length of received data */

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -376,7 +376,7 @@ void ppp_driver_feed_data(u8_t *data, int data_len)
 	/* We are expecting that the tests are feeding data in large
 	 * chunks so we can reset the uart buffer here.
 	 */
-	memset(ppp->buf, 0, UART_BUF_LEN);
+	(void)memset(ppp->buf, 0, UART_BUF_LEN);
 
 	ppp_change_state(ppp, STATE_HDLC_FRAME_START);
 
@@ -386,7 +386,7 @@ void ppp_driver_feed_data(u8_t *data, int data_len)
 
 		LOG_DBG("Feeding %d bytes", data_to_copy);
 
-		memcpy(ppp->buf, data, data_to_copy);
+		(void)memcpy(ppp->buf, data, data_to_copy);
 
 		recv_off = data_to_copy;
 
@@ -626,7 +626,7 @@ use_random_mac:
 	net_if_set_link_addr(iface, ll_addr->addr, ll_addr->len,
 			     NET_LINK_ETHERNET);
 
-	memset(ppp->buf, 0, sizeof(ppp->buf));
+	(void)memset(ppp->buf, 0, sizeof(ppp->buf));
 
 	/* We do not use uart_pipe for unit tests as the unit test has its
 	 * own handling of UART. See tests/net/ppp/driver for details.

--- a/drivers/neural_net/intel_gna.c
+++ b/drivers/neural_net/intel_gna.c
@@ -84,7 +84,7 @@ static void intel_gna_interrupt_handler(struct device *dev)
 		SOC_DCACHE_INVALIDATE(pending_req.model->output,
 				pending_req.output_len);
 		/* copy output from the model buffer to applciation buffer */
-		memcpy(pending_req.output, pending_req.model->output,
+		(void)memcpy(pending_req.output, pending_req.model->output,
 				pending_req.output_len);
 		pending_resp.response.output = pending_req.output;
 		pending_resp.response.output_len = pending_req.output_len;
@@ -459,7 +459,7 @@ static int intel_gna_infer(struct device *dev, struct gna_inference_req *req,
 	}
 
 	/* copy input */
-	memcpy(handle->input, req->input, input_size);
+	(void)memcpy(handle->input, req->input, input_size);
 	SOC_DCACHE_FLUSH(handle->input, input_size);
 
 	/* assign layer descriptor base address to configuration descriptor */

--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -148,7 +148,7 @@ static int dht_sample_fetch(struct device *dev, enum sensor_channel chan)
 		LOG_DBG("Invalid checksum in fetched sample");
 		ret = -EIO;
 	} else {
-		memcpy(drv_data->sample, buf, 4);
+		(void)memcpy(drv_data->sample, buf, 4);
 	}
 
 cleanup:

--- a/drivers/sensor/vl53l0x/vl53l0x_platform.c
+++ b/drivers/sensor/vl53l0x/vl53l0x_platform.c
@@ -29,7 +29,7 @@ VL53L0X_Error VL53L0X_WriteMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,
 	uint8_t I2CBuffer[count+1];
 
 	I2CBuffer[0] = index;
-	memcpy(&I2CBuffer[1], pdata, count);
+	(void)memcpy(&I2CBuffer[1], pdata, count);
 
 	status_int = i2c_write(Dev->i2c, I2CBuffer, count+1, Dev->I2cDevAddr);
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -168,7 +168,7 @@ static void transfer_next_chunk(struct device *dev)
 				chunk_len = sizeof(dev_data->buffer);
 			}
 
-			memcpy(dev_data->buffer, tx_buf, chunk_len);
+			(void)memcpy(dev_data->buffer, tx_buf, chunk_len);
 			tx_buf = dev_data->buffer;
 		}
 #endif

--- a/drivers/usb/device/usb_dc_mcux_ehci.c
+++ b/drivers/usb/device/usb_dc_mcux_ehci.c
@@ -161,7 +161,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data *const cfg)
 	}
 
 	if (k_mem_pool_alloc(&ep_buf_pool, block, cfg->ep_mps, 10) == 0) {
-		memset(block->data, 0, cfg->ep_mps);
+		(void)memset(block->data, 0, cfg->ep_mps);
 	} else {
 		LOG_ERR("Memory allocation time-out");
 		return -ENOMEM;

--- a/drivers/usb/device/usb_dc_native_posix.c
+++ b/drivers/usb/device/usb_dc_native_posix.c
@@ -142,7 +142,7 @@ int usb_dc_reset(void)
 	LOG_DBG("");
 
 	/* Clear private data */
-	memset(&usbip_ctrl, 0, sizeof(usbip_ctrl));
+	(void)memset(&usbip_ctrl, 0, sizeof(usbip_ctrl));
 
 	return 0;
 }
@@ -357,7 +357,7 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 		u8_t ep_idx = USBIP_EP_ADDR2IDX(ep);
 		struct usb_ep_ctrl_prv *ctrl = &usbip_ctrl.in_ep_ctrl[ep_idx];
 
-		memcpy(ctrl->buf, data, data_len);
+		(void)memcpy(ctrl->buf, data, data_len);
 		ctrl->buf_len = data_len;
 	}
 

--- a/drivers/usb/device/usb_dc_native_posix_adapt.c
+++ b/drivers/usb/device/usb_dc_native_posix_adapt.c
@@ -122,9 +122,9 @@ static void fill_device(struct devlist_device *dev, const u8_t *desc)
 	struct usb_cfg_descriptor *cfg =
 		(void *)(desc + sizeof(struct usb_device_descriptor));
 
-	memset(dev->path, 0, 256);
+	(void)memset(dev->path, 0, 256);
 	strcpy(dev->path, "/sys/devices/pci0000:00/0000:00:01.2/usb1/1-1");
-	memset(dev->busid, 0, 32);
+	(void)memset(dev->busid, 0, 32);
 	strcpy(dev->busid, "1-1");
 
 	dev->busnum = htonl(1);
@@ -294,7 +294,7 @@ void usbip_start(void)
 		LOG_WRN("setsockopt() failed: %s", strerror(errno));
 	}
 
-	memset(&srv, 0, sizeof(srv));
+	(void)memset(&srv, 0, sizeof(srv));
 	srv.sin_family = AF_INET;
 	srv.sin_addr.s_addr = htonl(INADDR_ANY);
 	srv.sin_port = htons(USBIP_PORT);

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -735,28 +735,28 @@ static void eps_ctx_uninit(void)
 		ep_ctx = in_endpoint_ctx(i);
 		__ASSERT_NO_MSG(ep_ctx);
 		k_mem_pool_free(&ep_ctx->buf.block);
-		memset(ep_ctx, 0, sizeof(*ep_ctx));
+		(void)memset(ep_ctx, 0, sizeof(*ep_ctx));
 	}
 
 	for (i = 0U; i < CFG_EPOUT_CNT; i++) {
 		ep_ctx = out_endpoint_ctx(i);
 		__ASSERT_NO_MSG(ep_ctx);
 		k_mem_pool_free(&ep_ctx->buf.block);
-		memset(ep_ctx, 0, sizeof(*ep_ctx));
+		(void)memset(ep_ctx, 0, sizeof(*ep_ctx));
 	}
 
 	if (CFG_EP_ISOIN_CNT) {
 		ep_ctx = in_endpoint_ctx(NRF_USBD_EPIN(8));
 		__ASSERT_NO_MSG(ep_ctx);
 		k_mem_pool_free(&ep_ctx->buf.block);
-		memset(ep_ctx, 0, sizeof(*ep_ctx));
+		(void)memset(ep_ctx, 0, sizeof(*ep_ctx));
 	}
 
 	if (CFG_EP_ISOOUT_CNT) {
 		ep_ctx = out_endpoint_ctx(NRF_USBD_EPOUT(8));
 		__ASSERT_NO_MSG(ep_ctx);
 		k_mem_pool_free(&ep_ctx->buf.block);
-		memset(ep_ctx, 0, sizeof(*ep_ctx));
+		(void)memset(ep_ctx, 0, sizeof(*ep_ctx));
 	}
 }
 
@@ -836,7 +836,7 @@ static inline void usbd_work_process_setup(struct nrf_usbd_ep_ctx *ep_ctx)
 	 * SETUP packet must be reassembled.
 	 */
 	usbd_setup = (struct usb_setup_packet *)ep_ctx->buf.data;
-	memset(usbd_setup, 0, sizeof(struct usb_setup_packet));
+	(void)memset(usbd_setup, 0, sizeof(struct usb_setup_packet));
 	usbd_setup->bmRequestType = nrf_usbd_setup_bmrequesttype_get();
 	usbd_setup->bRequest = nrf_usbd_setup_brequest_get();
 	usbd_setup->wValue = nrf_usbd_setup_wvalue_get();
@@ -1690,7 +1690,7 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 		bytes_to_copy = data_len;
 		ep_ctx->write_fragmented = false;
 	}
-	memcpy(ep_ctx->buf.data, data, bytes_to_copy);
+	(void)memcpy(ep_ctx->buf.data, data, bytes_to_copy);
 	ep_ctx->buf.len = bytes_to_copy;
 
 	if (ret_bytes) {
@@ -1763,7 +1763,7 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 		return 0;
 	}
 
-	memcpy(data, ep_ctx->buf.curr, bytes_to_copy);
+	(void)memcpy(data, ep_ctx->buf.curr, bytes_to_copy);
 
 	ep_ctx->buf.curr += bytes_to_copy;
 	ep_ctx->buf.len -= bytes_to_copy;

--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -513,7 +513,7 @@ int usb_dc_ep_write(u8_t ep, const u8_t *buf, u32_t len, u32_t *ret_bytes)
 	 * multi-packet and automatic zero-length packet features as
 	 * the upper layers in Zephyr implement these in code.
 	 */
-	memcpy((void *)addr, buf, len);
+	(void)memcpy((void *)addr, buf, len);
 	desc->DeviceDescBank[1].PCKSIZE.bit.MULTI_PACKET_SIZE = 0;
 	desc->DeviceDescBank[1].PCKSIZE.bit.BYTE_COUNT = len;
 	endpoint->EPINTFLAG.reg =
@@ -566,7 +566,7 @@ int usb_dc_ep_read_ex(u8_t ep, u8_t *buf, u32_t max_data_len,
 
 	remain = bytes - data->out_at;
 	take = MIN(max_data_len, remain);
-	memcpy(buf, (u8_t *)addr + data->out_at, take);
+	(void)memcpy(buf, (u8_t *)addr + data->out_at, take);
 
 	if (read_bytes != NULL) {
 		*read_bytes = take;

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -780,8 +780,8 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 	 */
 	if (data) {
 		read_count = MIN(read_count, max_data_len);
-		memcpy(data, usb_dc_stm32_state.ep_buf[EP_IDX(ep)] +
-		       ep_state->read_offset, read_count);
+		(void)memcpy(data, usb_dc_stm32_state.ep_buf[EP_IDX(ep)] +
+				ep_state->read_offset, read_count);
 		ep_state->read_count -= read_count;
 		ep_state->read_offset += read_count;
 	} else if (max_data_len) {
@@ -944,8 +944,8 @@ void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd)
 
 	ep_state->read_count = SETUP_SIZE;
 	ep_state->read_offset = 0U;
-	memcpy(&usb_dc_stm32_state.ep_buf[EP0_IDX],
-	       usb_dc_stm32_state.pcd.Setup, ep_state->read_count);
+	(void)memcpy(&usb_dc_stm32_state.ep_buf[EP0_IDX],
+			usb_dc_stm32_state.pcd.Setup, ep_state->read_count);
 
 	if (ep_state->cb) {
 		ep_state->cb(EP0_OUT, USB_DC_EP_SETUP);

--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -160,7 +160,7 @@ data:
 
 	while (eswifi_spi_cmddata_ready(spi) && to_read) {
 		to_read = MIN(rlen - offset, to_read);
-		memset(rsp + offset, 0, to_read);
+		(void)memset(rsp + offset, 0, to_read);
 		eswifi_spi_read(eswifi, rsp + offset, to_read);
 		offset += to_read;
 		k_yield();

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -392,7 +392,7 @@ static void eswifi_iface_init(struct net_if *iface)
 	LOG_DBG("MAC Address %02X:%02X:%02X:%02X:%02X:%02X",
 		   mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
-	memcpy(eswifi->mac, mac, sizeof(eswifi->mac));
+	(void)memcpy(eswifi->mac, mac, sizeof(eswifi->mac));
 	net_if_set_link_addr(iface, eswifi->mac, sizeof(eswifi->mac),
 			     NET_LINK_ETHERNET);
 
@@ -439,7 +439,7 @@ static int eswifi_mgmt_disconnect(struct device *dev)
 static int __eswifi_sta_config(struct eswifi_dev *eswifi,
 			       struct wifi_connect_req_params *params)
 {
-	memcpy(eswifi->sta.ssid, params->ssid, params->ssid_length);
+	(void)memcpy(eswifi->sta.ssid, params->ssid, params->ssid_length);
 	eswifi->sta.ssid[params->ssid_length] = '\0';
 
 	switch (params->security) {
@@ -448,7 +448,8 @@ static int __eswifi_sta_config(struct eswifi_dev *eswifi,
 		eswifi->sta.security = ESWIFI_SEC_OPEN;
 		break;
 	case WIFI_SECURITY_TYPE_PSK:
-		memcpy(eswifi->sta.pass, params->psk, params->psk_length);
+		(void)memcpy(eswifi->sta.pass, params->psk,
+			      params->psk_length);
 		eswifi->sta.pass[params->psk_length] = '\0';
 		eswifi->sta.security = ESWIFI_SEC_WPA2_MIXED;
 		break;

--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -594,7 +594,7 @@ static int eswifi_off_put(struct net_context *context)
 	__stop_socket(eswifi, socket);
 
 	if (--socket->usage <= 0) {
-		memset(socket, 0, sizeof(*socket));
+		(void)memset(socket, 0, sizeof(*socket));
 	}
 
 	eswifi_unlock(eswifi);
@@ -725,7 +725,7 @@ void eswifi_offload_async_msg(struct eswifi_dev *eswifi, char *msg, size_t len)
 		}
 
 		sin_addr = &net_sin(&socket->peer_addr)->sin_addr;
-		memcpy(&sin_addr->s4_addr, ip, 4);
+		(void)memcpy(&sin_addr->s4_addr, ip, 4);
 		socket->state = ESWIFI_SOCKET_STATE_CONNECTED;
 		socket->usage++;
 

--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -321,9 +321,9 @@ static SlSockAddr_t *translate_z_to_sl_addrs(const struct sockaddr *addr,
 		*sl_addrlen = sizeof(SlSockAddrIn6_t);
 		sl_addr_in6->sin6_family = SL_AF_INET6;
 		sl_addr_in6->sin6_port = z_sockaddr_in6->sin6_port;
-		memcpy(sl_addr_in6->sin6_addr._S6_un._S6_u32,
-		       z_sockaddr_in6->sin6_addr.s6_addr,
-		       sizeof(sl_addr_in6->sin6_addr._S6_un._S6_u32));
+		(void)memcpy(sl_addr_in6->sin6_addr._S6_un._S6_u32,
+				z_sockaddr_in6->sin6_addr.s6_addr,
+				sizeof(sl_addr_in6->sin6_addr._S6_un._S6_u32));
 
 		sl_addr = (SlSockAddr_t *)sl_addr_in6;
 	}
@@ -363,9 +363,9 @@ static void translate_sl_to_z_addr(SlSockAddr_t *sl_addr,
 			z_sockaddr_in6->sin6_port = sl_addr_in6->sin6_port;
 			z_sockaddr_in6->sin6_scope_id =
 				(u8_t)sl_addr_in6->sin6_scope_id;
-			memcpy(z_sockaddr_in6->sin6_addr.s6_addr,
-			       sl_addr_in6->sin6_addr._S6_un._S6_u32,
-			       sizeof(z_sockaddr_in6->sin6_addr.s6_addr));
+			(void)memcpy(z_sockaddr_in6->sin6_addr.s6_addr,
+				    sl_addr_in6->sin6_addr._S6_un._S6_u32,
+				    sizeof(z_sockaddr_in6->sin6_addr.s6_addr));
 			*addrlen = sizeof(struct sockaddr_in6);
 		} else {
 			*addrlen = sl_addrlen;

--- a/drivers/wifi/simplelink/simplelink_support.c
+++ b/drivers/wifi/simplelink/simplelink_support.c
@@ -82,7 +82,7 @@ static s32_t configure_simplelink(void)
 	struct in_addr addr4;
 	SlNetCfgIpV4Args_t ipV4;
 
-	memset(&ipV4, 0, sizeof(ipV4));
+	(void)memset(&ipV4, 0, sizeof(ipV4));
 #endif
 
 	/* Turn on NWP */
@@ -266,10 +266,10 @@ void SimpleLinkWlanEventHandler(SlWlanEvent_t *wlan_event)
 		SET_STATUS_BIT(nwp.status, STATUS_BIT_CONNECTION);
 
 		/* Store new connection SSID and BSSID: */
-		memcpy(sl_conn.ssid, wlan_event->Data.Connect.SsidName,
-		       wlan_event->Data.Connect.SsidLen);
-		memcpy(sl_conn.bssid, wlan_event->Data.Connect.Bssid,
-		       BSSID_LEN_MAX);
+		(void)memcpy(sl_conn.ssid, wlan_event->Data.Connect.SsidName,
+				wlan_event->Data.Connect.SsidLen);
+		(void)memcpy(sl_conn.bssid, wlan_event->Data.Connect.Bssid,
+				BSSID_LEN_MAX);
 
 		LOG_INF("[WLAN EVENT] STA Connected to the AP: %s, "
 			"BSSID: %x:%x:%x:%x:%x:%x",
@@ -325,8 +325,8 @@ void SimpleLinkWlanEventHandler(SlWlanEvent_t *wlan_event)
 		break;
 
 	case SL_WLAN_EVENT_STA_ADDED:
-		memcpy(&(sl_conn.bssid), wlan_event->Data.STAAdded.Mac,
-		       SL_WLAN_BSSID_LENGTH);
+		(void)memcpy(&(sl_conn.bssid), wlan_event->Data.STAAdded.Mac,
+				SL_WLAN_BSSID_LENGTH);
 		LOG_INF("[WLAN EVENT] STA was added to AP: "
 			"BSSID: %x:%x:%x:%x:%x:%x",
 			sl_conn.bssid[0], sl_conn.bssid[1],
@@ -334,8 +334,8 @@ void SimpleLinkWlanEventHandler(SlWlanEvent_t *wlan_event)
 			sl_conn.bssid[4], sl_conn.bssid[5]);
 		break;
 	case SL_WLAN_EVENT_STA_REMOVED:
-		memcpy(&(sl_conn.bssid), wlan_event->Data.STAAdded.Mac,
-		       SL_WLAN_BSSID_LENGTH);
+		(void)memcpy(&(sl_conn.bssid), wlan_event->Data.STAAdded.Mac,
+				SL_WLAN_BSSID_LENGTH);
 		LOG_INF("[WLAN EVENT] STA was removed from AP: "
 			"BSSID: %x:%x:%x:%x:%x:%x",
 			sl_conn.bssid[0], sl_conn.bssid[1],
@@ -553,7 +553,7 @@ void z_simplelink_get_scan_result(int index,
 	(void)memset(scan_result, 0x0, sizeof(struct wifi_scan_result));
 
 	__ASSERT_NO_MSG(net_entry->SsidLen <= WIFI_SSID_MAX_LEN);
-	memcpy(scan_result->ssid, net_entry->Ssid, net_entry->SsidLen);
+	(void)memcpy(scan_result->ssid, net_entry->Ssid, net_entry->SsidLen);
 	scan_result->ssid_length = net_entry->SsidLen;
 	scan_result->channel = net_entry->Channel;
 

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -688,7 +688,7 @@ static void handle_scan_result(void *pvMsg)
 		goto out;
 	}
 
-	memcpy(result.ssid, pstrScanResult->au8SSID, WIFI_SSID_MAX_LEN);
+	(void)memcpy(result.ssid, pstrScanResult->au8SSID, WIFI_SSID_MAX_LEN);
 	result.ssid_length = strlen(result.ssid);
 
 	result.channel = pstrScanResult->u8ch;
@@ -883,7 +883,7 @@ static void handle_socket_msg_accept(struct socket_data *sd, void *pvMsg)
 
 		a_sd = &w1500_data.socket_data[accept_msg->sock];
 
-		memcpy(a_sd, sd, sizeof(struct socket_data));
+		(void)memcpy(a_sd, sd, sizeof(struct socket_data));
 
 		ret = net_context_get(AF_INET, SOCK_STREAM,
 				      IPPROTO_TCP, &a_sd->context);
@@ -983,11 +983,11 @@ static int winc1500_mgmt_connect(struct device *dev,
 	u16_t channel;
 	void *auth;
 
-	memcpy(ssid, params->ssid, params->ssid_length);
+	(void)memcpy(ssid, params->ssid, params->ssid_length);
 	ssid[params->ssid_length] = '\0';
 
 	if (params->security == WIFI_SECURITY_TYPE_PSK) {
-		memcpy(psk.au8PSK, params->psk, params->psk_length);
+		(void)memcpy(psk.au8PSK, params->psk, params->psk_length);
 		psk.au8PSK[params->psk_length] = '\0';
 		auth = &psk;
 

--- a/lib/cmsis_rtos_v2/event_flags.c
+++ b/lib/cmsis_rtos_v2/event_flags.c
@@ -37,7 +37,7 @@ osEventFlagsId_t osEventFlagsNew(const osEventFlagsAttr_t *attr)
 
 	if (k_mem_slab_alloc(&cv2_event_flags_slab, (void **)&events, 100)
 	    == 0) {
-		memset(events, 0, sizeof(struct cv2_event_flags));
+		(void)memset(events, 0, sizeof(struct cv2_event_flags));
 	} else {
 		return NULL;
 	}

--- a/lib/cmsis_rtos_v2/mutex.c
+++ b/lib/cmsis_rtos_v2/mutex.c
@@ -39,7 +39,7 @@ osMutexId_t osMutexNew(const osMutexAttr_t *attr)
 		 "Zephyr does not support osMutexRobust.\n");
 
 	if (k_mem_slab_alloc(&cv2_mutex_slab, (void **)&mutex, 100) == 0) {
-		memset(mutex, 0, sizeof(struct cv2_mutex));
+		(void)memset(mutex, 0, sizeof(struct cv2_mutex));
 	} else {
 		return NULL;
 	}

--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -125,7 +125,7 @@ void *realloc(void *ptr, size_t requested_size)
 		return NULL;
 	}
 
-	memcpy(new_ptr, ptr, block_size - struct_blk_size);
+	(void)memcpy(new_ptr, ptr, block_size - struct_blk_size);
 	free(ptr);
 
 	return new_ptr;

--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -879,7 +879,7 @@ static int append_bytes_to_buf(const char *bytes, size_t len, void *data)
 		return -ENOMEM;
 	}
 
-	memcpy(appender->buffer + appender->used, bytes, len);
+	(void)memcpy(appender->buffer + appender->used, bytes, len);
 	appender->used += len;
 	appender->buffer[appender->used] = '\0';
 

--- a/lib/os/ring_buffer.c
+++ b/lib/os/ring_buffer.c
@@ -148,7 +148,7 @@ u32_t ring_buf_put(struct ring_buf *buf, const u8_t *data, u32_t size)
 
 	do {
 		partial_size = ring_buf_put_claim(buf, &dst, size);
-		memcpy(dst, data, partial_size);
+		(void)memcpy(dst, data, partial_size);
 		total_size += partial_size;
 		size -= partial_size;
 		data += partial_size;
@@ -206,7 +206,7 @@ u32_t ring_buf_get(struct ring_buf *buf, u8_t *data, u32_t size)
 
 	do {
 		partial_size = ring_buf_get_claim(buf, &src, size);
-		memcpy(data, src, partial_size);
+		(void)memcpy(data, src, partial_size);
 		total_size += partial_size;
 		size -= partial_size;
 		data += partial_size;

--- a/lib/updatehub/updatehub.c
+++ b/lib/updatehub/updatehub.c
@@ -99,7 +99,7 @@ static int metadata_hash_get(char *metadata)
 		return -1;
 	}
 
-	memset(update_info.package_uid, 0, TC_SHA256_BLOCK_SIZE + 1);
+	(void)memset(update_info.package_uid, 0, TC_SHA256_BLOCK_SIZE + 1);
 	for (int i = 0; i < TC_SHA256_DIGEST_SIZE; i++) {
 		snprintk(buffer, sizeof(buffer), "%02x",
 			 hash[i]);
@@ -197,7 +197,7 @@ static void cleanup_connection(void)
 		LOG_ERR("Could not close the socket");
 	}
 
-	memset(&ctx.fds[1], 0, sizeof(ctx.fds[1]));
+	(void)memset(&ctx.fds[1], 0, sizeof(ctx.fds[1]));
 	ctx.nfds = 0;
 	ctx.sock = 0;
 }
@@ -384,7 +384,8 @@ static void install_update_cb(void)
 			goto cleanup;
 		}
 
-		memset(&sha256_image_dowloaded, 0, TC_SHA256_BLOCK_SIZE + 1);
+		(void)memset(&sha256_image_dowloaded, 0,
+			      TC_SHA256_BLOCK_SIZE + 1);
 		for (i = 0; i < TC_SHA256_DIGEST_SIZE; i++) {
 			snprintk(buffer, sizeof(buffer), "%02x", image_hash[i]);
 			buffer_len = buffer_len + strlen(buffer);
@@ -495,7 +496,7 @@ static int report(enum updatehub_state state)
 		goto error;
 	}
 
-	memset(&report, 0, sizeof(report));
+	(void)memset(&report, 0, sizeof(report));
 	report.product_uid = CONFIG_UPDATEHUB_PRODUCT_UID;
 	report.device_identity.id = device_id;
 	report.version = firmware_version;
@@ -527,7 +528,7 @@ static int report(enum updatehub_state state)
 		report.error_message = "";
 	}
 
-	memset(&ctx.payload, 0, MAX_PAYLOAD_SIZE);
+	(void)memset(&ctx.payload, 0, MAX_PAYLOAD_SIZE);
 	ret = json_obj_encode_buf(send_report_descr,
 				  ARRAY_SIZE(send_report_descr),
 				  &report, ctx.payload,
@@ -586,10 +587,11 @@ static void probe_cb(char *metadata)
 		return;
 	}
 
-	memset(&tmp, 0, MAX_PAYLOAD_SIZE);
-	memcpy(tmp, reply.data + reply.offset, reply.max_len - reply.offset);
-	memset(metadata, 0, MAX_PAYLOAD_SIZE);
-	memcpy(metadata, tmp, strlen(tmp));
+	(void)memset(&tmp, 0, MAX_PAYLOAD_SIZE);
+	(void)memcpy(tmp, reply.data + reply.offset,
+		      reply.max_len - reply.offset);
+	(void)memset(metadata, 0, MAX_PAYLOAD_SIZE);
+	(void)memcpy(metadata, tmp, strlen(tmp));
 
 	ctx.code_status = UPDATEHUB_OK;
 
@@ -632,13 +634,13 @@ enum updatehub_response updatehub_probe(void)
 		goto error;
 	}
 
-	memset(&request, 0, sizeof(request));
+	(void)memset(&request, 0, sizeof(request));
 	request.product_uid = CONFIG_UPDATEHUB_PRODUCT_UID;
 	request.device_identity.id = device_id;
 	request.version = firmware_version;
 	request.hardware = CONFIG_BOARD;
 
-	memset(&ctx.payload, 0, MAX_PAYLOAD_SIZE);
+	(void)memset(&ctx.payload, 0, MAX_PAYLOAD_SIZE);
 	if (json_obj_encode_buf(send_probe_descr,
 				ARRAY_SIZE(send_probe_descr),
 				&request, ctx.payload,
@@ -658,21 +660,21 @@ enum updatehub_response updatehub_probe(void)
 		goto cleanup;
 	}
 
-	memset(metadata, 0, MAX_PAYLOAD_SIZE);
+	(void)memset(metadata, 0, MAX_PAYLOAD_SIZE);
 	probe_cb(metadata);
 
 	if (ctx.code_status != UPDATEHUB_OK) {
 		goto cleanup;
 	}
 
-	memset(&update_info, 0, sizeof(update_info));
+	(void)memset(&update_info, 0, sizeof(update_info));
 	if (metadata_hash_get(metadata) < 0) {
 		LOG_ERR("Could not get metadata hash");
 		ctx.code_status = UPDATEHUB_METADATA_ERROR;
 		goto cleanup;
 	}
 
-	memcpy(metadata_copy, metadata, strlen(metadata));
+	(void)memcpy(metadata_copy, metadata, strlen(metadata));
 	if (json_obj_parse(metadata, strlen(metadata),
 			   recv_probe_sh_array_descr,
 			   ARRAY_SIZE(recv_probe_sh_array_descr),
@@ -687,9 +689,10 @@ enum updatehub_response updatehub_probe(void)
 			goto cleanup;
 		}
 
-		memcpy(update_info.sha256sum_image,
-		       metadata_any_boards.objects[1].objects.sha256sum,
-		       strlen(metadata_any_boards.objects[1].objects.sha256sum));
+		(void)memcpy(update_info.sha256sum_image,
+			metadata_any_boards.objects[1].objects.sha256sum,
+			strlen(
+			   metadata_any_boards.objects[1].objects.sha256sum));
 		update_info.image_size = metadata_any_boards.objects[1].objects.size;
 	} else {
 		if (!is_compatible_hardware(&metadata_some_boards)) {
@@ -698,10 +701,10 @@ enum updatehub_response updatehub_probe(void)
 				UPDATEHUB_INCOMPATIBLE_HARDWARE;
 			goto cleanup;
 		}
-		memcpy(update_info.sha256sum_image,
-		       metadata_some_boards.objects[1].objects.sha256sum,
-		       strlen(metadata_some_boards.objects[1]
-			      .objects.sha256sum));
+		(void)memcpy(update_info.sha256sum_image,
+			      metadata_some_boards.objects[1].objects.sha256sum,
+			      strlen(metadata_some_boards.objects[1]
+				    .objects.sha256sum));
 		update_info.image_size =
 			metadata_some_boards.objects[1].objects.size;
 	}

--- a/lib/updatehub/updatehub_device.c
+++ b/lib/updatehub/updatehub_device.c
@@ -17,7 +17,7 @@ bool updatehub_get_device_identity(char *id, int id_max_len)
 		return false;
 	}
 
-	memset(id, 0, id_max_len);
+	(void)memset(id, 0, id_max_len);
 
 	for (i = 0; i < length; i++) {
 		snprintk(buf, sizeof(buf), "%02x", hwinfo_id[i]);

--- a/samples/basic/threads/src/main.c
+++ b/samples/basic/threads/src/main.c
@@ -60,7 +60,7 @@ void blink(const char *port, u32_t sleep_ms, u32_t led, u32_t id)
 		char *mem_ptr = k_malloc(size);
 		__ASSERT_NO_MSG(mem_ptr != 0);
 
-		memcpy(mem_ptr, &tx_data, size);
+		(void)memcpy(mem_ptr, &tx_data, size);
 
 		k_fifo_put(&printk_fifo, mem_ptr);
 

--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -55,7 +55,7 @@ static u8_t discover_func(struct bt_conn *conn,
 	printk("[ATTRIBUTE] handle %u\n", attr->handle);
 
 	if (!bt_uuid_cmp(discover_params.uuid, BT_UUID_HRS)) {
-		memcpy(&uuid, BT_UUID_HRS_MEASUREMENT, sizeof(uuid));
+		(void)memcpy(&uuid, BT_UUID_HRS_MEASUREMENT, sizeof(uuid));
 		discover_params.uuid = &uuid.uuid;
 		discover_params.start_handle = attr->handle + 1;
 		discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
@@ -66,7 +66,7 @@ static u8_t discover_func(struct bt_conn *conn,
 		}
 	} else if (!bt_uuid_cmp(discover_params.uuid,
 				BT_UUID_HRS_MEASUREMENT)) {
-		memcpy(&uuid, BT_UUID_GATT_CCC, sizeof(uuid));
+		(void)memcpy(&uuid, BT_UUID_GATT_CCC, sizeof(uuid));
 		discover_params.uuid = &uuid.uuid;
 		discover_params.start_handle = attr->handle + 2;
 		discover_params.type = BT_GATT_DISCOVER_DESCRIPTOR;
@@ -109,7 +109,7 @@ static void connected(struct bt_conn *conn, u8_t conn_err)
 	printk("Connected: %s\n", addr);
 
 	if (conn == default_conn) {
-		memcpy(&uuid, BT_UUID_HRS, sizeof(uuid));
+		(void)memcpy(&uuid, BT_UUID_HRS, sizeof(uuid));
 		discover_params.uuid = &uuid.uuid;
 		discover_params.func = discover_func;
 		discover_params.start_handle = 0x0001;
@@ -144,7 +144,7 @@ static bool eir_found(struct bt_data *data, void *user_data)
 			u16_t u16;
 			int err;
 
-			memcpy(&u16, &data->data[i], sizeof(u16));
+			(void)memcpy(&u16, &data->data[i], sizeof(u16));
 			uuid = BT_UUID_DECLARE_16(sys_le16_to_cpu(u16));
 			if (bt_uuid_cmp(uuid, BT_UUID_HRS)) {
 				continue;

--- a/samples/bluetooth/eddystone/src/main.c
+++ b/samples/bluetooth/eddystone/src/main.c
@@ -203,7 +203,7 @@ static ssize_t write_slot(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	memcpy(&value, buf, len);
+	(void)memcpy(&value, buf, len);
 
 	if (value + 1 > NUMBER_OF_SLOTS) {
 		return BT_GATT_ERR(BT_ATT_ERR_WRITE_NOT_PERMITTED);
@@ -243,7 +243,7 @@ static ssize_t write_tx_power(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	memcpy(&slot->tx_power, buf, len);
+	(void)memcpy(&slot->tx_power, buf, len);
 
 	return len;
 }
@@ -278,7 +278,7 @@ static ssize_t write_adv_tx_power(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	memcpy(&slot->adv_tx_power, buf, len);
+	(void)memcpy(&slot->adv_tx_power, buf, len);
 
 	return len;
 }
@@ -330,7 +330,7 @@ static ssize_t write_lock(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	}
 
-	memcpy(&value, buf, sizeof(value));
+	(void)memcpy(&value, buf, sizeof(value));
 
 	if (value > EDS_UNLOCKED_NO_RELOCKING) {
 		return BT_GATT_ERR(BT_ATT_ERR_WRITE_NOT_PERMITTED);
@@ -478,7 +478,7 @@ static ssize_t write_adv_data(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	}
 
-	memcpy(&type, buf, sizeof(type));
+	(void)memcpy(&type, buf, sizeof(type));
 
 	switch (type) {
 	case EDS_TYPE_URL:
@@ -489,8 +489,8 @@ static ssize_t write_adv_data(struct bt_conn *conn,
 		 */
 		slot->ad[2].data_len = MIN(slot->ad[2].data_len,
 					   len + EDS_URL_WRITE_OFFSET);
-		memcpy(&slot->ad[2].data + EDS_URL_WRITE_OFFSET, buf,
-		       slot->ad[2].data_len - EDS_URL_WRITE_OFFSET);
+		(void)memcpy(&slot->ad[2].data + EDS_URL_WRITE_OFFSET, buf,
+				slot->ad[2].data_len - EDS_URL_WRITE_OFFSET);
 
 		/* Restart slot */
 		if (eds_slot_restart(slot, type) < 0) {
@@ -551,7 +551,7 @@ static ssize_t write_connectable(struct bt_conn *conn,
 	/* If any non-zero value is written, the beacon shall remain in its
 	 * connectable state until any other value is written.
 	 */
-	memcpy(&slot->connectable, buf, len);
+	(void)memcpy(&slot->connectable, buf, len);
 
 	return len;
 }

--- a/samples/bluetooth/hci_spi/src/main.c
+++ b/samples/bluetooth/hci_spi/src/main.c
@@ -216,7 +216,7 @@ static void bt_tx_thread(void *p1, void *p2, void *p3)
 
 		switch (rxmsg[PACKET_TYPE]) {
 		case HCI_CMD:
-			memcpy(&cmd_hdr, &rxmsg[1], sizeof(cmd_hdr));
+			(void)memcpy(&cmd_hdr, &rxmsg[1], sizeof(cmd_hdr));
 
 			buf = net_buf_alloc(&cmd_tx_pool, K_NO_WAIT);
 			if (buf) {
@@ -231,7 +231,7 @@ static void bt_tx_thread(void *p1, void *p2, void *p3)
 			}
 			break;
 		case HCI_ACL:
-			memcpy(&acl_hdr, &rxmsg[1], sizeof(acl_hdr));
+			(void)memcpy(&acl_hdr, &rxmsg[1], sizeof(acl_hdr));
 
 			buf = net_buf_alloc(&acl_tx_pool, K_NO_WAIT);
 			if (buf) {

--- a/samples/bluetooth/peripheral/src/cts.c
+++ b/samples/bluetooth/peripheral/src/cts.c
@@ -50,7 +50,7 @@ static ssize_t write_ct(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	memcpy(value + offset, buf, len);
+	(void)memcpy(value + offset, buf, len);
 	ct_update = 1U;
 
 	return len;
@@ -76,7 +76,7 @@ static void generate_current_time(u8_t *buf)
 	 */
 
 	year = sys_cpu_to_le16(2015);
-	memcpy(buf,  &year, 2); /* year */
+	(void)memcpy(buf,  &year, 2); /* year */
 	buf[2] = 5U; /* months starting from 1 */
 	buf[3] = 30U; /* day */
 	buf[4] = 12U; /* hours */

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -60,7 +60,7 @@ static ssize_t write_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	memcpy(value + offset, buf, len);
+	(void)memcpy(value + offset, buf, len);
 
 	return len;
 }
@@ -116,7 +116,7 @@ static ssize_t write_long_vnd(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	memcpy(value + offset, buf, len);
+	(void)memcpy(value + offset, buf, len);
 
 	return len;
 }
@@ -150,7 +150,7 @@ static ssize_t write_signed(struct bt_conn *conn, const struct bt_gatt_attr *att
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	memcpy(value + offset, buf, len);
+	(void)memcpy(value + offset, buf, len);
 
 	return len;
 }
@@ -181,7 +181,7 @@ static ssize_t write_without_rsp_vnd(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	memcpy(value + offset, buf, len);
+	(void)memcpy(value + offset, buf, len);
 
 	return len;
 }

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -237,7 +237,7 @@ static void ctrl_point_ind(struct bt_conn *conn, u8_t req_op, u8_t status,
 
 	/* Send data (supported locations) if present */
 	if (data && data_len) {
-		memcpy(ind->data, data, data_len);
+		(void)memcpy(ind->data, data, data_len);
 	}
 
 	bt_gatt_notify(conn, &csc_svc.attrs[8], buf, sizeof(buf));
@@ -278,7 +278,7 @@ static void measurement_nfy(struct bt_conn *conn, u32_t cwr, u16_t lwet,
 		data.cwr = sys_cpu_to_le32(cwr);
 		data.lwet = sys_cpu_to_le16(lwet);
 
-		memcpy(nfy->data, &data, sizeof(data));
+		(void)memcpy(nfy->data, &data, sizeof(data));
 		len += sizeof(data);
 	}
 
@@ -290,7 +290,7 @@ static void measurement_nfy(struct bt_conn *conn, u32_t cwr, u16_t lwet,
 		data.ccr = sys_cpu_to_le16(ccr);
 		data.lcet = sys_cpu_to_le16(lcet);
 
-		memcpy(nfy->data + len, &data, sizeof(data));
+		(void)memcpy(nfy->data + len, &data, sizeof(data));
 	}
 
 	bt_gatt_notify(NULL, &csc_svc.attrs[1], buf, sizeof(buf));

--- a/samples/bluetooth/peripheral_hids/src/hog.c
+++ b/samples/bluetooth/peripheral_hids/src/hog.c
@@ -135,7 +135,7 @@ static ssize_t write_ctrl_point(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	memcpy(value + offset, buf, len);
+	(void)memcpy(value + offset, buf, len);
 
 	return len;
 }

--- a/samples/boards/intel_s1000_crb/audio/src/audio_driver.c
+++ b/samples/boards/intel_s1000_crb/audio/src/audio_driver.c
@@ -149,8 +149,8 @@ static int audio_driver_send_zeros_frame(void)
 	}
 
 	/* fill buffer with zeros */
-	memset(spk_out_buf, 0, SPK_FRAME_BYTES);
-	memset(host_out_buf, 0, HOST_FRAME_BYTES);
+	(void)memset(spk_out_buf, 0, SPK_FRAME_BYTES);
+	(void)memset(host_out_buf, 0, HOST_FRAME_BYTES);
 
 	ret = i2s_write(i2s_spk_out_dev, spk_out_buf, SPK_FRAME_BYTES);
 	if (ret) {

--- a/samples/boards/intel_s1000_crb/audio/src/tuning_driver.c
+++ b/samples/boards/intel_s1000_crb/audio/src/tuning_driver.c
@@ -109,7 +109,8 @@ static void tun_drv_process_command(u8_t *data, u32_t len)
 
 	if (len) {
 		/* copy the received data into the tuning packet buffer */
-		memcpy(&command_buffer.buffer[command_buffer.index], data, len);
+		(void)memcpy(&command_buffer.buffer[command_buffer.index],
+			      data, len);
 		command_buffer.index += len;
 	}
 

--- a/samples/boards/intel_s1000_crb/i2s/src/i2s_sample.c
+++ b/samples/boards/intel_s1000_crb/i2s/src/i2s_sample.c
@@ -226,7 +226,7 @@ static void i2s_prepare_audio(struct device *dev)
 				buffer, frame_counter);
 
 		/* fill the buffer with zeros (silence) */
-		memset(buffer, 0, AUDIO_FRAME_BUF_BYTES);
+		(void)memset(buffer, 0, AUDIO_FRAME_BUF_BYTES);
 
 		ret = i2s_write(dev, buffer, AUDIO_FRAME_BUF_BYTES);
 		if (ret) {
@@ -259,7 +259,7 @@ static void i2s_play_audio(void)
 			return;
 		}
 
-		memcpy(copy_buf, in_buf, AUDIO_FRAME_BUF_BYTES);
+		(void)memcpy(copy_buf, in_buf, AUDIO_FRAME_BUF_BYTES);
 
 		/* loop the audio back to the host */
 		ret = i2s_write(host_i2s_dev, copy_buf, AUDIO_FRAME_BUF_BYTES);

--- a/samples/boards/nrf52/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff-app/src/main.c
@@ -581,7 +581,7 @@ static void bt_ready(int err)
 	if (bt_le_oob_get_local(BT_ID_DEFAULT, &oob)) {
 		printk("Identity Address unavailable\n");
 	} else {
-		memcpy(dev_uuid, oob.addr.a.val, 6);
+		(void)memcpy(dev_uuid, oob.addr.a.val, 6);
 	}
 
 	bt_mesh_prov_enable(BT_MESH_PROV_GATT | BT_MESH_PROV_ADV);

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/ble_mesh.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/ble_mesh.c
@@ -72,7 +72,7 @@ void bt_ready(void)
 	if (bt_le_oob_get_local(BT_ID_DEFAULT, &oob)) {
 		printk("Identity Address unavailable\n");
 	} else {
-		memcpy(dev_uuid, oob.addr.a.val, 6);
+		(void)memcpy(dev_uuid, oob.addr.a.val, 6);
 	}
 
 	bt_mesh_prov_enable(BT_MESH_PROV_GATT | BT_MESH_PROV_ADV);

--- a/samples/boards/reel_board/mesh_badge/src/main.c
+++ b/samples/boards/reel_board/mesh_badge/src/main.c
@@ -46,7 +46,7 @@ static ssize_t write_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	}
 
-	memcpy(name, buf, len);
+	(void)memcpy(name, buf, len);
 	name[len] = '\0';
 
 	err = bt_set_name(name);

--- a/samples/boards/reel_board/mesh_badge/src/mesh.c
+++ b/samples/boards/reel_board/mesh_badge/src/mesh.c
@@ -327,7 +327,7 @@ static void vnd_hello(struct bt_mesh_model *model,
 	}
 
 	len = MIN(buf->len, HELLO_MAX);
-	memcpy(str, buf->data, len);
+	(void)memcpy(str, buf->data, len);
 	str[len] = '\0';
 
 	board_add_hello(ctx->addr, str);
@@ -353,7 +353,7 @@ static void vnd_baduser(struct bt_mesh_model *model,
 	}
 
 	len = MIN(buf->len, HELLO_MAX);
-	memcpy(str, buf->data, len);
+	(void)memcpy(str, buf->data, len);
 	str[len] = '\0';
 
 	strcat(str, " is misbehaving!");

--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -86,7 +86,7 @@ static size_t print_line(enum font_size font_size, int row, const char *text,
 	cfb_framebuffer_set_font(epd_dev, font_size);
 
 	len = MIN(len, fonts[font_size].columns);
-	memcpy(line, text, len);
+	(void)memcpy(line, text, len);
 	line[len] = '\0';
 
 	if (center) {

--- a/samples/drivers/CAN/src/main.c
+++ b/samples/drivers/CAN/src/main.c
@@ -64,7 +64,7 @@ void send_string(char *string, struct device *can_dev)
 	for (str_len = strlen(string); str_len; ) {
 		msg.dlc = str_len >= 8 ? 8 : str_len;
 		str_len -= msg.dlc;
-		memcpy(msg.data, string, msg.dlc);
+		(void)memcpy(msg.data, string, msg.dlc);
 		string += msg.dlc;
 		can_send(can_dev, &msg, 10, tx_irq_callback, "send_string");
 	}

--- a/samples/drivers/led_apa102/src/main.c
+++ b/samples/drivers/led_apa102/src/main.c
@@ -74,8 +74,8 @@ void main(void)
 	time = 0;
 	while (1) {
 		for (i = 0; i < STRIP_NUM_LEDS; i++) {
-			memcpy(&strip_colors[i], color_at(time, i),
-			       sizeof(strip_colors[i]));
+			(void)memcpy(&strip_colors[i], color_at(time, i),
+					sizeof(strip_colors[i]));
 		}
 		led_strip_update_rgb(strip, strip_colors, STRIP_NUM_LEDS);
 		k_sleep(DELAY_TIME);

--- a/samples/drivers/led_lpd8806/src/main.c
+++ b/samples/drivers/led_lpd8806/src/main.c
@@ -72,8 +72,8 @@ void main(void)
 	time = 0;
 	while (1) {
 		for (i = 0; i < STRIP_NUM_LEDS; i++) {
-			memcpy(&strip_colors[i], color_at(time, i),
-			       sizeof(strip_colors[i]));
+			(void)memcpy(&strip_colors[i], color_at(time, i),
+					sizeof(strip_colors[i]));
 		}
 		led_strip_update_rgb(strip, strip_colors, STRIP_NUM_LEDS);
 		k_sleep(DELAY_TIME);

--- a/samples/drivers/led_ws2812/src/main.c
+++ b/samples/drivers/led_ws2812/src/main.c
@@ -79,8 +79,8 @@ void main(void)
 	time = 0;
 	while (1) {
 		for (i = 0; i < STRIP_NUM_LEDS; i++) {
-			memcpy(&strip_colors[i], color_at(time, i),
-			       sizeof(strip_colors[i]));
+			(void)memcpy(&strip_colors[i], color_at(time, i),
+					sizeof(strip_colors[i]));
 		}
 		led_strip_update_rgb(strip, strip_colors, STRIP_NUM_LEDS);
 		k_sleep(DELAY_TIME);

--- a/samples/net/gptp/src/main.c
+++ b/samples/net/gptp/src/main.c
@@ -132,7 +132,7 @@ static void gptp_phase_dis_cb(u8_t *gm_identity,
 	static u8_t id[8];
 
 	if (memcmp(id, gm_identity, sizeof(id))) {
-		memcpy(id, gm_identity, sizeof(id));
+		(void)memcpy(id, gm_identity, sizeof(id));
 
 		LOG_DBG("GM %s last phase %d.%lld",
 			log_strdup(gptp_sprint_clock_id(gm_identity, output,

--- a/samples/net/nats/src/nats.c
+++ b/samples/net/nats/src/nats.c
@@ -105,7 +105,7 @@ static int transmitv(struct net_context *conn, int iovcnt,
 	int i, pos;
 
 	for (i = 0, pos = 0; i < iovcnt; pos += iov[i].len, i++) {
-		memcpy(&buf[pos], iov[i].base, iov[i].len);
+		(void)memcpy(&buf[pos], iov[i].base, iov[i].len);
 	}
 
 	return net_context_send(conn, buf, pos, NULL, K_NO_WAIT, NULL);
@@ -243,7 +243,8 @@ static int copy_pkt_to_buf(struct net_buf *src, u16_t offset,
 	for (copied = 0U; src && n_bytes > 0; offset = 0U) {
 		to_copy = MIN(n_bytes, src->len - offset);
 
-		memcpy(dst + copied, (char *)src->data + offset, to_copy);
+		(void)memcpy(dst + copied,
+			      (char *)src->data + offset, to_copy);
 		copied += to_copy;
 
 		n_bytes -= to_copy;

--- a/samples/net/sockets/can/src/main.c
+++ b/samples/net/sockets/can/src/main.c
@@ -113,7 +113,7 @@ static void rx(int *can_fd, int *do_close_period,
 	while (1) {
 		u8_t *data;
 
-		memset(&frame, 0, sizeof(frame));
+		(void)memset(&frame, 0, sizeof(frame));
 		addr_len = sizeof(can_addr);
 
 		ret = recvfrom(fd, &frame, sizeof(struct can_frame),

--- a/samples/net/sockets/civetweb/src/main.c
+++ b/samples/net/sockets/civetweb/src/main.c
@@ -151,7 +151,7 @@ void *main_pthread(void *arg)
 
 	(void)arg;
 
-	memset(&callbacks, 0, sizeof(callbacks));
+	(void)memset(&callbacks, 0, sizeof(callbacks));
 	ctx = mg_start(&callbacks, 0, (const char **)options);
 
 	if (ctx == NULL) {

--- a/samples/net/sockets/coap_client/src/coap-client.c
+++ b/samples/net/sockets/coap_client/src/coap-client.c
@@ -378,7 +378,7 @@ static int get_large_coap_msgs(void)
 
 		/* Received last block */
 		if (r == 1) {
-			memset(&blk_ctx, 0, sizeof(blk_ctx));
+			(void)memset(&blk_ctx, 0, sizeof(blk_ctx));
 			return 0;
 		}
 	}

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -112,7 +112,7 @@ static int start_coap_server(void)
 	struct sockaddr_in6 addr6;
 	int r;
 
-	memset(&addr6, 0, sizeof(addr6));
+	(void)memset(&addr6, 0, sizeof(addr6));
 	addr6.sin6_family = AF_INET6;
 	addr6.sin6_port = htons(MY_COAP_PORT);
 
@@ -138,7 +138,7 @@ static int start_coap_server(void)
 	struct sockaddr_in addr;
 	int r;
 
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(MY_COAP_PORT);
 
@@ -487,7 +487,7 @@ static int query_get(struct coap_resource *resource,
 			break;
 		}
 
-		memcpy(str, options[i].value, options[i].len);
+		(void)memcpy(str, options[i].value, options[i].len);
 		str[options[i].len] = '\0';
 
 		LOG_INF("query[%d]: %s", i + 1, str);
@@ -759,7 +759,7 @@ static int large_get(struct coap_resource *resource,
 	size = MIN(coap_block_size_to_bytes(ctx.block_size),
 		   ctx.total_size - ctx.current);
 
-	memset(payload, 'A', MIN(size, sizeof(payload)));
+	(void)memset(payload, 'A', MIN(size, sizeof(payload)));
 
 	r = coap_packet_append_payload(&response, (u8_t *)payload, size);
 	if (r < 0) {
@@ -769,7 +769,7 @@ static int large_get(struct coap_resource *resource,
 	r = coap_next_block(&response, &ctx);
 	if (!r) {
 		/* Will return 0 when it's the last block. */
-		memset(&ctx, 0, sizeof(ctx));
+		(void)memset(&ctx, 0, sizeof(ctx));
 	}
 
 	r = send_coap_reply(&response, addr, addr_len);

--- a/samples/net/sockets/echo_client/src/vlan.c
+++ b/samples/net/sockets/echo_client/src/vlan.c
@@ -87,7 +87,7 @@ int init_vlan(void)
 	struct ud ud;
 	int ret;
 
-	memset(&ud, 0, sizeof(ud));
+	(void)memset(&ud, 0, sizeof(ud));
 
 	net_if_foreach(iface_cb, &ud);
 

--- a/samples/net/sockets/echo_server/src/vlan.c
+++ b/samples/net/sockets/echo_server/src/vlan.c
@@ -87,7 +87,7 @@ int init_vlan(void)
 	struct ud ud;
 	int ret;
 
-	memset(&ud, 0, sizeof(ud));
+	(void)memset(&ud, 0, sizeof(ud));
 
 	net_if_foreach(iface_cb, &ud);
 

--- a/samples/net/sockets/net_mgmt/src/main.c
+++ b/samples/net/sockets/net_mgmt/src/main.c
@@ -93,7 +93,7 @@ static void listener(void)
 		exit(1);
 	}
 
-	memset(&sockaddr, 0, sizeof(sockaddr));
+	(void)memset(&sockaddr, 0, sizeof(sockaddr));
 
 	sockaddr.nm_family = AF_NET_MGMT;
 	sockaddr.nm_ifindex = 0; /* Any network interface */
@@ -111,7 +111,7 @@ static void listener(void)
 	while (1) {
 		struct net_mgmt_msghdr *hdr;
 
-		memset(buf, 0, sizeof(buf));
+		(void)memset(buf, 0, sizeof(buf));
 		event_addr_len = sizeof(event_addr);
 
 		ret = recvfrom(fd, buf, sizeof(buf), 0,

--- a/samples/net/sockets/sntp_client/src/main.c
+++ b/samples/net/sockets/sntp_client/src/main.c
@@ -25,7 +25,7 @@ void main(void)
 	int rv;
 
 	/* ipv4 */
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(SNTP_PORT);
 	inet_pton(AF_INET, SERVER_ADDR, &addr.sin_addr);
@@ -52,7 +52,7 @@ void main(void)
 	sntp_close(&ctx);
 
 	/* ipv6 */
-	memset(&addr6, 0, sizeof(addr6));
+	(void)memset(&addr6, 0, sizeof(addr6));
 	addr6.sin6_family = AF_INET6;
 	addr6.sin6_port = htons(SNTP_PORT);
 	inet_pton(AF_INET6, SERVER_ADDR6, &addr6.sin6_addr);

--- a/samples/net/zperf/src/zperf_tcp_receiver.c
+++ b/samples/net/zperf/src/zperf_tcp_receiver.c
@@ -187,8 +187,8 @@ void zperf_tcp_receiver_init(const struct shell *shell, int port)
 					      "Unable to get IPv4 by default\n");
 				return;
 			}
-			memcpy(&in4_addr_my->sin_addr, in4_addr,
-				sizeof(struct in_addr));
+			(void)memcpy(&in4_addr_my->sin_addr, in4_addr,
+					sizeof(struct in_addr));
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL, "Binding to %s\n",
@@ -224,8 +224,8 @@ void zperf_tcp_receiver_init(const struct shell *shell, int port)
 					      "Unable to get IPv4 by default\n");
 				return;
 			}
-			memcpy(&in6_addr_my->sin6_addr, in6_addr,
-				sizeof(struct in6_addr));
+			(void)memcpy(&in6_addr_my->sin6_addr, in6_addr,
+					sizeof(struct in6_addr));
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL, "Binding to %s\n",

--- a/samples/net/zperf/src/zperf_udp_receiver.c
+++ b/samples/net/zperf/src/zperf_udp_receiver.c
@@ -58,7 +58,7 @@ static inline void build_reply(struct zperf_udp_datagram *hdr,
 	int pos = 0;
 	struct zperf_server_hdr *stat_hdr;
 
-	memcpy(&buf[pos], hdr, sizeof(struct zperf_udp_datagram));
+	(void)memcpy(&buf[pos], hdr, sizeof(struct zperf_udp_datagram));
 	pos += sizeof(struct zperf_udp_datagram);
 
 	stat_hdr = (struct zperf_server_hdr *)&buf[pos];
@@ -328,8 +328,8 @@ void zperf_udp_receiver_init(const struct shell *shell, int port)
 					      "Unable to get IPv4 by default\n");
 				return;
 			}
-			memcpy(&in4_addr_my->sin_addr, in4_addr,
-				sizeof(struct in_addr));
+			(void)memcpy(&in4_addr_my->sin_addr, in4_addr,
+					sizeof(struct in_addr));
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL, "Binding to %s\n",
@@ -378,8 +378,8 @@ void zperf_udp_receiver_init(const struct shell *shell, int port)
 					      "Unable to get IPv4 by default\n");
 				return;
 			}
-			memcpy(&in6_addr_my->sin6_addr, in6_addr,
-				sizeof(struct in6_addr));
+			(void)memcpy(&in6_addr_my->sin6_addr, in6_addr,
+					sizeof(struct in6_addr));
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL, "Binding to %s\n",

--- a/samples/nfc/nfc_hello/src/main.c
+++ b/samples/nfc/nfc_hello/src/main.c
@@ -60,7 +60,7 @@ void main(void)
 	UNALIGNED_PUT(sys_cpu_to_be32(sizeof(nci_reset)), size);
 
 	/* NFC Controller Interface reset cmd */
-	memcpy(tx_buf + sizeof(u32_t), nci_reset, sizeof(nci_reset));
+	(void)memcpy(tx_buf + sizeof(u32_t), nci_reset, sizeof(nci_reset));
 
 	/*
 	 * Peer will receive: 0x00 0x00 0x00 0x04 0x20 0x00 0x01 0x00

--- a/samples/subsys/usb/hid-cdc/src/main.c
+++ b/samples/subsys/usb/hid-cdc/src/main.c
@@ -384,13 +384,13 @@ static volatile bool data_arrived;
 static void flush_buffer_mouse(void)
 {
 	chr_ptr_mouse = 0U;
-	memset(data_buf_mouse, 0, sizeof(data_buf_mouse));
+	(void)memset(data_buf_mouse, 0, sizeof(data_buf_mouse));
 }
 
 static void flush_buffer_kbd(void)
 {
 	chr_ptr_kbd = 0U;
-	memset(data_buf_kbd, 0, sizeof(data_buf_kbd));
+	(void)memset(data_buf_kbd, 0, sizeof(data_buf_kbd));
 }
 
 static void write_data(struct device *dev, const char *buf, int len)

--- a/samples/userspace/shared_mem/src/main.c
+++ b/samples/userspace/shared_mem/src/main.c
@@ -186,7 +186,7 @@ void enc(void)
 		if (fBUFIN == 1) { /* 1 is process text */
 			printk("ENC Thread Received Data\n");
 			/* copy message form shared mem and clear flag */
-			memcpy(&enc_pt, BUFIN, SAMP_BLOCKSIZE);
+			(void)memcpy(&enc_pt, BUFIN, SAMP_BLOCKSIZE);
 			printk("ENC PT MSG: %s\n", (char *)&enc_pt);
 			fBUFIN = 0;
 			/* reset wheel: probably better as a flag option  */
@@ -194,7 +194,8 @@ void enc(void)
 			IW2 = 2;
 			IW3 = 3;
 			/* encode */
-			memset(&enc_ct, 0, SAMP_BLOCKSIZE); /* clear memory */
+			/* clear memory */
+			(void)memset(&enc_ct, 0, SAMP_BLOCKSIZE);
 			for (index = 0, index_out = 0; index < SAMP_BLOCKSIZE; index++) {
 				if (enc_pt[index] == '\0') {
 					enc_ct[index_out] = '\0';
@@ -210,7 +211,7 @@ void enc(void)
 				k_sleep(100);
 			}
 			/* ct thread has cleared the buffer */
-			memcpy(&BUFOUT, &enc_ct, SAMP_BLOCKSIZE);
+			(void)memcpy(&BUFOUT, &enc_ct, SAMP_BLOCKSIZE);
 			fBUFOUT = 1;
 
 		}
@@ -231,8 +232,8 @@ void pt(void)
 		k_sem_take(&allforone, K_FOREVER);
 		if (fBUFIN == 0) { /* send message to encode */
 			printk("\nPT Sending Message 1\n");
-			memset(&BUFIN, 0, SAMP_BLOCKSIZE);
-			memcpy(&BUFIN, &ptMSG, sizeof(ptMSG));
+			(void)memset(&BUFIN, 0, SAMP_BLOCKSIZE);
+			(void)memcpy(&BUFIN, &ptMSG, sizeof(ptMSG));
 /* strlen should not be used if user provided data, needs a max length set  */
 			fBUFIN = 1;
 		}
@@ -240,8 +241,8 @@ void pt(void)
 		k_sem_take(&allforone, K_FOREVER);
 		if (fBUFIN == 0) { /* send message to decode  */
 			printk("\nPT Sending Message 1'\n");
-			memset(&BUFIN, 0, SAMP_BLOCKSIZE);
-			memcpy(&BUFIN, &ptMSG2, sizeof(ptMSG2));
+			(void)memset(&BUFIN, 0, SAMP_BLOCKSIZE);
+			(void)memcpy(&BUFIN, &ptMSG2, sizeof(ptMSG2));
 			fBUFIN = 1;
 		}
 		k_sem_give(&allforone);
@@ -262,8 +263,8 @@ void ct(void)
 		k_sem_take(&allforone, K_FOREVER);
 		if (fBUFOUT == 1) {
 			printk("CT Thread Receivedd Message\n");
-			memset(&tbuf, 0, sizeof(tbuf));
-			memcpy(&tbuf, BUFOUT, SAMP_BLOCKSIZE);
+			(void)memset(&tbuf, 0, sizeof(tbuf));
+			(void)memcpy(&tbuf, BUFOUT, SAMP_BLOCKSIZE);
 			fBUFOUT = 0;
 			printk("CT MSG: %s\n", (char *)&tbuf);
 		}

--- a/soc/arm/nxp_lpc/lpc54xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc54xxx/soc.c
@@ -131,7 +131,7 @@ int _slave_init(struct device *arg)
 	SYSCON->AHBCLKCTRLSET[0] = SYSCON_AHBCLKCTRL_SRAM2_MASK;
 
 	/* Copy second core image to SRAM */
-	memcpy(CORE_M0_BOOT_ADDRESS, (void *)core_m0, sizeof(core_m0));
+	(void)memcpy(CORE_M0_BOOT_ADDRESS, (void *)core_m0, sizeof(core_m0));
 
 	/* Setup the reset handler pointer (PC) and stack pointer value.
 	 * This is used once the second core runs its startup code.

--- a/soc/arm/st_stm32/stm32f0/soc.c
+++ b/soc/arm/st_stm32/stm32f0/soc.c
@@ -41,7 +41,7 @@ void relocate_vector_table(void)
 
 	size_t vector_size = (size_t)_vector_end - (size_t)_vector_start;
 
-	memcpy(_ram_vector_start, _vector_start, vector_size);
+	(void)memcpy(_ram_vector_start, _vector_start, vector_size);
 	LL_SYSCFG_SetRemapMemory(LL_SYSCFG_REMAP_SRAM);
 #endif
 }

--- a/subsys/bluetooth/common/rpa.c
+++ b/subsys/bluetooth/common/rpa.c
@@ -36,7 +36,7 @@ static int ah(const u8_t irk[16], const u8_t r[3], u8_t out[3])
 	BT_DBG("irk %s, r %s", bt_hex(irk, 16), bt_hex(r, 3));
 
 	/* r' = padding || r */
-	memcpy(res, r, 3);
+	(void)memcpy(res, r, 3);
 	(void)memset(res + 3, 0, 13);
 
 	err = bt_encrypt_le(irk, res, res);
@@ -50,7 +50,7 @@ static int ah(const u8_t irk[16], const u8_t r[3], u8_t out[3])
 	 * by taking the least significant 24 bits of the output of e as the
 	 * result of ah.
 	 */
-	memcpy(out, res, 3);
+	(void)memcpy(out, res, 3);
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/crypto/crypto.c
+++ b/subsys/bluetooth/controller/crypto/crypto.c
@@ -20,12 +20,12 @@ int bt_rand(void *buf, size_t len)
 		u32_t v = sys_rand32_get();
 
 		if (len >= sizeof(v)) {
-			memcpy(buf8, &v, sizeof(v));
+			(void)memcpy(buf8, &v, sizeof(v));
 
 			buf8 += sizeof(v);
 			len -= sizeof(v);
 		} else {
-			memcpy(buf8, &v, len);
+			(void)memcpy(buf8, &v, len);
 			break;
 		}
 	}

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -856,7 +856,7 @@ static void le_encrypt(struct net_buf *buf, struct net_buf **evt)
 	rp = hci_cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
-	memcpy(rp->enc_data, enc_data, 16);
+	(void)memcpy(rp->enc_data, enc_data, 16);
 }
 
 static void le_rand(struct net_buf *buf, struct net_buf **evt)
@@ -1891,7 +1891,7 @@ static void vs_read_build_info(struct net_buf *buf, struct net_buf **evt)
 
 	rp = hci_cmd_complete(evt, sizeof(*rp) + sizeof(build_info));
 	rp->status = 0x00;
-	memcpy(rp->info, build_info, sizeof(build_info));
+	(void)memcpy(rp->info, build_info, sizeof(build_info));
 }
 
 static void vs_read_static_addrs(struct net_buf *buf, struct net_buf **evt)
@@ -2039,7 +2039,8 @@ static void mesh_set_scan_filter(struct net_buf *buf, struct net_buf **evt)
 			goto exit;
 		}
 		f->lengths[i] = cmd->patterns[i].pattern_len;
-		memcpy(f->patterns[i], cmd->patterns[i].pattern, f->lengths[i]);
+		(void)memcpy(f->patterns[i],
+			      cmd->patterns[i].pattern, f->lengths[i]);
 	}
 
 	f->count = cmd->num_patterns;
@@ -2323,7 +2324,7 @@ int hci_acl_handle(struct net_buf *buf, struct net_buf **evt)
 		pdu_data->ll_id = PDU_DATA_LLID_DATA_CONTINUE;
 	}
 	pdu_data->len = len;
-	memcpy(&pdu_data->lldata[0], buf->data, len);
+	(void)memcpy(&pdu_data->lldata[0], buf->data, len);
 
 	if (ll_tx_mem_enqueue(handle, node_tx)) {
 		BT_ERR("Invalid Tx Enqueue");
@@ -2359,8 +2360,8 @@ static inline bool dup_found(struct pdu_adv *adv)
 		}
 
 		/* insert into the duplicate filter */
-		memcpy(&dup_filter[dup_curr].addr.a.val[0],
-		       &adv->adv_ind.addr[0], sizeof(bt_addr_t));
+		(void)memcpy(&dup_filter[dup_curr].addr.a.val[0],
+				&adv->adv_ind.addr[0], sizeof(bt_addr_t));
 		dup_filter[dup_curr].addr.type = adv->tx_addr;
 		dup_filter[dup_curr].mask = BIT(adv->type);
 
@@ -2421,13 +2422,14 @@ static inline void le_dir_adv_report(struct pdu_adv *adv, struct net_buf *buf,
 	if (1) {
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 		dir_info->addr.type = adv->tx_addr;
-		memcpy(&dir_info->addr.a.val[0], &adv->direct_ind.adv_addr[0],
-		       sizeof(bt_addr_t));
+		(void)memcpy(&dir_info->addr.a.val[0],
+				&adv->direct_ind.adv_addr[0],
+				sizeof(bt_addr_t));
 	}
 
 	dir_info->dir_addr.type = 0x1;
-	memcpy(&dir_info->dir_addr.a.val[0],
-	       &adv->direct_ind.tgt_addr[0], sizeof(bt_addr_t));
+	(void)memcpy(&dir_info->dir_addr.a.val[0],
+			&adv->direct_ind.tgt_addr[0], sizeof(bt_addr_t));
 
 	dir_info->rssi = rssi;
 }
@@ -2492,13 +2494,14 @@ static inline void le_mesh_scan_report(struct pdu_adv *adv,
 	mep->num_reports = 1U;
 	sr = (void *)(((u8_t *)mep) + sizeof(*mep));
 	sr->addr.type = adv->tx_addr;
-	memcpy(&sr->addr.a.val[0], &adv->adv_ind.addr[0], sizeof(bt_addr_t));
+	(void)memcpy(&sr->addr.a.val[0],
+		      &adv->adv_ind.addr[0], sizeof(bt_addr_t));
 	sr->chan = chan;
 	sr->rssi = rssi;
 	sys_put_le32(instant, (u8_t *)&sr->instant);
 
 	sr->data_len = data_len;
-	memcpy(&sr->data[0], &adv->adv_ind.data[0], data_len);
+	(void)memcpy(&sr->data[0], &adv->adv_ind.data[0], data_len);
 }
 #endif /* CONFIG_BT_HCI_MESH_EXT */
 
@@ -2613,12 +2616,12 @@ static void le_advertising_report(struct pdu_data *pdu_data,
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
 		adv_info->addr.type = adv->tx_addr;
-		memcpy(&adv_info->addr.a.val[0], &adv->adv_ind.addr[0],
-		       sizeof(bt_addr_t));
+		(void)memcpy(&adv_info->addr.a.val[0], &adv->adv_ind.addr[0],
+				sizeof(bt_addr_t));
 	}
 
 	adv_info->length = data_len;
-	memcpy(&adv_info->data[0], &adv->adv_ind.data[0], data_len);
+	(void)memcpy(&adv_info->data[0], &adv->adv_ind.data[0], data_len);
 	/* RSSI */
 	prssi = &adv_info->data[0] + data_len;
 	*prssi = rssi;
@@ -2666,7 +2669,7 @@ static void le_adv_ext_report(struct pdu_data *pdu_data,
 			bt_addr_le_t addr;
 
 			addr.type = adv->tx_addr;
-			memcpy(&addr.a.val[0], ptr, sizeof(bt_addr_t));
+			(void)memcpy(&addr.a.val[0], ptr, sizeof(bt_addr_t));
 			ptr += BDADDR_SIZE;
 
 			BT_DBG("AdvA: %s", bt_addr_le_str(&addr));
@@ -2725,8 +2728,8 @@ static void le_scan_req_received(struct pdu_data *pdu_data,
 
 		handle = 0U;
 		addr.type = adv->tx_addr;
-		memcpy(&addr.a.val[0], &adv->scan_req.scan_addr[0],
-		       sizeof(bt_addr_t));
+		(void)memcpy(&addr.a.val[0], &adv->scan_req.scan_addr[0],
+				sizeof(bt_addr_t));
 
 #if defined(CONFIG_BT_LL_SW_SPLIT)
 		/* The Link Layer currently returns RSSI as an absolute value */
@@ -2745,8 +2748,8 @@ static void le_scan_req_received(struct pdu_data *pdu_data,
 	sep = meta_evt(buf, BT_HCI_EVT_LE_SCAN_REQ_RECEIVED, sizeof(*sep));
 	sep->handle = 0U;
 	sep->addr.type = adv->tx_addr;
-	memcpy(&sep->addr.a.val[0], &adv->scan_req.scan_addr[0],
-	       sizeof(bt_addr_t));
+	(void)memcpy(&sep->addr.a.val[0], &adv->scan_req.scan_addr[0],
+			sizeof(bt_addr_t));
 }
 #endif /* CONFIG_BT_CTLR_SCAN_REQ_NOTIFY */
 
@@ -2799,8 +2802,9 @@ static void le_conn_complete(struct pdu_data *pdu_data, u16_t handle,
 		leecc->role = node_rx->role;
 
 		leecc->peer_addr.type = node_rx->peer_addr_type;
-		memcpy(&leecc->peer_addr.a.val[0], &node_rx->peer_addr[0],
-		       BDADDR_SIZE);
+		(void)memcpy(&leecc->peer_addr.a.val[0],
+				&node_rx->peer_addr[0],
+				BDADDR_SIZE);
 
 		/* Note: this could be an RPA set as the random address by
 		 * the Host instead of generated by the controller. That said,
@@ -2808,15 +2812,16 @@ static void le_conn_complete(struct pdu_data *pdu_data, u16_t handle,
 		 */
 		if ((node_rx->own_addr_type) &&
 		    ((node_rx->own_addr[5] & 0xc0) == 0x40)) {
-			memcpy(&leecc->local_rpa.val[0], &node_rx->own_addr[0],
-			       BDADDR_SIZE);
+			(void)memcpy(&leecc->local_rpa.val[0],
+					&node_rx->own_addr[0],
+					BDADDR_SIZE);
 		} else {
 			(void)memset(&leecc->local_rpa.val[0], 0x0,
 				     BDADDR_SIZE);
 		}
 
-		memcpy(&leecc->peer_rpa.val[0], &node_rx->peer_rpa[0],
-		       BDADDR_SIZE);
+		(void)memcpy(&leecc->peer_rpa.val[0], &node_rx->peer_rpa[0],
+				BDADDR_SIZE);
 
 		leecc->interval = sys_cpu_to_le16(node_rx->interval);
 		leecc->latency = sys_cpu_to_le16(node_rx->latency);
@@ -2838,7 +2843,8 @@ static void le_conn_complete(struct pdu_data *pdu_data, u16_t handle,
 	lecc->handle = sys_cpu_to_le16(handle);
 	lecc->role = node_rx->role;
 	lecc->peer_addr.type = node_rx->peer_addr_type;
-	memcpy(&lecc->peer_addr.a.val[0], &node_rx->peer_addr[0], BDADDR_SIZE);
+	(void)memcpy(&lecc->peer_addr.a.val[0],
+		      &node_rx->peer_addr[0], BDADDR_SIZE);
 	lecc->interval = sys_cpu_to_le16(node_rx->interval);
 	lecc->latency = sys_cpu_to_le16(node_rx->latency);
 	lecc->supv_timeout = sys_cpu_to_le16(node_rx->timeout);
@@ -3133,8 +3139,8 @@ static void le_ltk_request(struct pdu_data *pdu_data, u16_t handle,
 	sep = meta_evt(buf, BT_HCI_EVT_LE_LTK_REQUEST, sizeof(*sep));
 
 	sep->handle = sys_cpu_to_le16(handle);
-	memcpy(&sep->rand, pdu_data->llctrl.enc_req.rand, sizeof(u64_t));
-	memcpy(&sep->ediv, pdu_data->llctrl.enc_req.ediv, sizeof(u16_t));
+	(void)memcpy(&sep->rand, pdu_data->llctrl.enc_req.rand, sizeof(u64_t));
+	(void)memcpy(&sep->ediv, pdu_data->llctrl.enc_req.ediv, sizeof(u16_t));
 }
 
 static void encrypt_change(u8_t err, u16_t handle,
@@ -3170,9 +3176,9 @@ static void le_remote_feat_complete(u8_t status, struct pdu_data *pdu_data,
 	sep->status = status;
 	sep->handle = sys_cpu_to_le16(handle);
 	if (!status) {
-		memcpy(&sep->features[0],
-		       &pdu_data->llctrl.feature_rsp.features[0],
-		       sizeof(sep->features));
+		(void)memcpy(&sep->features[0],
+				&pdu_data->llctrl.feature_rsp.features[0],
+				sizeof(sep->features));
 	} else {
 		(void)memset(&sep->features[0], 0x00, sizeof(sep->features));
 	}
@@ -3345,7 +3351,7 @@ void hci_acl_encode(struct node_rx_pdu *node_rx, struct net_buf *buf)
 		acl->handle = sys_cpu_to_le16(handle_flags);
 		acl->len = sys_cpu_to_le16(pdu_data->len);
 		data = (void *)net_buf_add(buf, pdu_data->len);
-		memcpy(data, pdu_data->lldata, pdu_data->len);
+		(void)memcpy(data, pdu_data->lldata, pdu_data->len);
 #if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL)
 		if (hci_hbuf_total > 0) {
 			LL_ASSERT((hci_hbuf_sent - hci_hbuf_acked) <

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -861,7 +861,7 @@ static u32_t isr_rx_adv_sr_report(struct pdu_adv *pdu_adv_rx, u8_t rssi_ready)
 	 */
 	pdu_adv = (void *)node_rx->pdu_data;
 	pdu_len = offsetof(struct pdu_adv, payload) + pdu_adv_rx->len;
-	memcpy(pdu_adv, pdu_adv_rx, pdu_len);
+	(void)memcpy(pdu_adv, pdu_adv_rx, pdu_len);
 	((u8_t *)pdu_adv)[pdu_len] =
 		(rssi_ready) ? (radio_rssi_get() & 0x7f) : 0x7f;
 
@@ -1854,10 +1854,10 @@ static inline u32_t isr_rx_conn_pkt_ack(struct pdu_data *pdu_data_tx,
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	case PDU_DATA_LLCTRL_TYPE_ENC_REQ:
 		/* things from master stored for session key calculation */
-		memcpy(&_radio.conn_curr->llcp.encryption.skd[0],
-		       &pdu_data_tx->llctrl.enc_req.skdm[0], 8);
-		memcpy(&_radio.conn_curr->ccm_rx.iv[0],
-		       &pdu_data_tx->llctrl.enc_req.ivm[0], 4);
+		(void)memcpy(&_radio.conn_curr->llcp.encryption.skd[0],
+				&pdu_data_tx->llctrl.enc_req.skdm[0], 8);
+		(void)memcpy(&_radio.conn_curr->ccm_rx.iv[0],
+				&pdu_data_tx->llctrl.enc_req.ivm[0], 4);
 
 		/* pause data packet tx */
 		_radio.conn_curr->pause_tx = 1U;
@@ -2675,10 +2675,10 @@ isr_rx_conn_pkt_ctrl(struct radio_pdu_node_rx *node_rx,
 #endif /* CONFIG_BT_CTLR_FAST_ENC */
 
 		/* things from master stored for session key calculation */
-		memcpy(&_radio.conn_curr->llcp.encryption.skd[0],
-		       &pdu_data_rx->llctrl.enc_req.skdm[0], 8);
-		memcpy(&_radio.conn_curr->ccm_rx.iv[0],
-		       &pdu_data_rx->llctrl.enc_req.ivm[0], 4);
+		(void)memcpy(&_radio.conn_curr->llcp.encryption.skd[0],
+				&pdu_data_rx->llctrl.enc_req.skdm[0], 8);
+		(void)memcpy(&_radio.conn_curr->ccm_rx.iv[0],
+				&pdu_data_rx->llctrl.enc_req.ivm[0], 4);
 
 		/* pause rx data packets */
 		_radio.conn_curr->pause_rx = 1U;
@@ -2701,10 +2701,10 @@ isr_rx_conn_pkt_ctrl(struct radio_pdu_node_rx *node_rx,
 		}
 
 		/* things sent by slave stored for session key calculation */
-		memcpy(&_radio.conn_curr->llcp.encryption.skd[8],
-		       &pdu_data_rx->llctrl.enc_rsp.skds[0], 8);
-		memcpy(&_radio.conn_curr->ccm_rx.iv[4],
-		       &pdu_data_rx->llctrl.enc_rsp.ivs[0], 4);
+		(void)memcpy(&_radio.conn_curr->llcp.encryption.skd[8],
+				&pdu_data_rx->llctrl.enc_rsp.skds[0], 8);
+		(void)memcpy(&_radio.conn_curr->ccm_rx.iv[4],
+				&pdu_data_rx->llctrl.enc_rsp.ivs[0], 4);
 
 		/* pause rx data packets */
 		_radio.conn_curr->pause_rx = 1U;
@@ -3471,9 +3471,9 @@ isr_rx_conn_pkt_ctrl(struct radio_pdu_node_rx *node_rx,
 				break;
 			}
 
-			memcpy(&conn->llcp.chan_map.chm[0],
-			       &_radio.data_chan_map[0],
-			       sizeof(conn->llcp.chan_map.chm));
+			(void)memcpy(&conn->llcp.chan_map.chm[0],
+					&_radio.data_chan_map[0],
+					sizeof(conn->llcp.chan_map.chm));
 			/* conn->llcp.chan_map.instant     = 0; */
 			conn->llcp.chan_map.initiate = 1U;
 
@@ -3644,11 +3644,11 @@ isr_rx_conn_pkt(struct radio_pdu_node_rx *node_rx,
 					if (pdu_len_cmp(
 					     scratch_pkt->llctrl.opcode,
 					     scratch_pkt->len)) {
-						memcpy(pdu_data_rx,
-						       scratch_pkt,
-						       scratch_pkt->len +
-						       offsetof(struct pdu_data,
-							llctrl));
+						(void)memcpy(pdu_data_rx,
+						   scratch_pkt,
+						   scratch_pkt->len +
+						   offsetof(struct pdu_data,
+							    llctrl));
 						mic_failure = false;
 					}
 				} else {
@@ -5625,8 +5625,8 @@ static void mayfly_sched_win_offset_use(void *params)
 				&conn->llcp.conn_upd.win_offset_us);
 
 	win_offset = conn->llcp.conn_upd.win_offset_us / 1250;
-	memcpy(conn->llcp.conn_upd.pdu_win_offset, &win_offset,
-	       sizeof(u16_t));
+	(void)memcpy(conn->llcp.conn_upd.pdu_win_offset, &win_offset,
+			sizeof(u16_t));
 }
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
@@ -5786,9 +5786,10 @@ static void sched_free_win_offset_calc(struct connection *conn_curr,
 						break;
 					}
 
-					memcpy(win_offset +
-					       (sizeof(u16_t) * offset_index),
-					       &_win_offset, sizeof(u16_t));
+					(void)memcpy(win_offset +
+						(sizeof(u16_t) * offset_index),
+						&_win_offset,
+						sizeof(u16_t));
 					offset_index++;
 
 					ticks_to_expire_prev +=
@@ -5824,8 +5825,9 @@ static void sched_free_win_offset_calc(struct connection *conn_curr,
 				break;
 			}
 
-			memcpy(win_offset + (sizeof(u16_t) * offset_index),
-			       &_win_offset, sizeof(u16_t));
+			(void)memcpy(win_offset + (sizeof(u16_t) *
+						    offset_index),
+					&_win_offset, sizeof(u16_t));
 			offset_index++;
 
 			ticks_to_expire_prev += HAL_TICKER_US_TO_TICKS(1250);
@@ -5882,9 +5884,10 @@ static void mayfly_sched_win_offset_select(void *params)
 	while (offset_index_s < OFFSET_S_MAX) {
 		u8_t offset_index_m = 0U;
 
-		memcpy((u8_t *)&win_offset_s,
-		       ((u8_t *)&conn->llcp_conn_param.offset0 +
-			(sizeof(u16_t) * offset_index_s)), sizeof(u16_t));
+		(void)memcpy((u8_t *)&win_offset_s,
+				((u8_t *)&conn->llcp_conn_param.offset0 +
+				 (sizeof(u16_t) * offset_index_s)),
+				sizeof(u16_t));
 
 		while (offset_index_m < offset_m_max) {
 			if (win_offset_s != 0xffff) {
@@ -5909,13 +5912,13 @@ static void mayfly_sched_win_offset_select(void *params)
 	if (offset_index_s < OFFSET_S_MAX) {
 		conn->llcp.conn_upd.win_offset_us =
 			win_offset_s * 1250;
-		memcpy(conn->llcp.conn_upd.pdu_win_offset,
-		       &win_offset_s, sizeof(u16_t));
+		(void)memcpy(conn->llcp.conn_upd.pdu_win_offset,
+				&win_offset_s, sizeof(u16_t));
 	} else if (!has_offset_s) {
 		conn->llcp.conn_upd.win_offset_us =
 			win_offset_m[0] * 1250;
-		memcpy(conn->llcp.conn_upd.pdu_win_offset,
-		       &win_offset_m[0], sizeof(u16_t));
+		(void)memcpy(conn->llcp.conn_upd.pdu_win_offset,
+				&win_offset_m[0], sizeof(u16_t));
 	} else {
 		struct pdu_data *pdu_ctrl_tx;
 
@@ -6578,8 +6581,8 @@ static void adv_setup(void)
 		/* Copy the address from the adv packet we will send into the
 		 * scan response.
 		 */
-		memcpy(&scan_pdu->scan_rsp.addr[0],
-		       &pdu->adv_ind.addr[0], BDADDR_SIZE);
+		(void)memcpy(&scan_pdu->scan_rsp.addr[0],
+				&pdu->adv_ind.addr[0], BDADDR_SIZE);
 	}
 #else
 	ARG_UNUSED(upd);
@@ -7517,9 +7520,9 @@ static inline void event_ch_map_prep(struct connection *conn,
 				sizeof(struct pdu_data_llctrl_chan_map_ind);
 			pdu_ctrl_tx->llctrl.opcode =
 				PDU_DATA_LLCTRL_TYPE_CHAN_MAP_IND;
-			memcpy(&pdu_ctrl_tx->llctrl.chan_map_ind.chm[0],
-			       &conn->llcp.chan_map.chm[0],
-			       sizeof(pdu_ctrl_tx->llctrl.chan_map_ind.chm));
+			(void)memcpy(&pdu_ctrl_tx->llctrl.chan_map_ind.chm[0],
+				  &conn->llcp.chan_map.chm[0],
+				  sizeof(pdu_ctrl_tx->llctrl.chan_map_ind.chm));
 			pdu_ctrl_tx->llctrl.chan_map_ind.instant =
 				conn->llcp.chan_map.instant;
 
@@ -7531,9 +7534,9 @@ static inline void event_ch_map_prep(struct connection *conn,
 		conn->llcp_ack = conn->llcp_req;
 
 		/* copy to active channel map */
-		memcpy(&conn->data_chan_map[0],
-		       &conn->llcp.chan_map.chm[0],
-		       sizeof(conn->data_chan_map));
+		(void)memcpy(&conn->data_chan_map[0],
+				&conn->llcp.chan_map.chm[0],
+				sizeof(conn->data_chan_map));
 		conn->data_chan_count =
 			util_ones_count_get(&conn->data_chan_map[0],
 					    sizeof(conn->data_chan_map));
@@ -10198,9 +10201,9 @@ static u8_t chan_map_update(struct connection *conn,
 	}
 
 
-	memcpy(&conn->llcp.chan_map.chm[0],
-	       &pdu_data_rx->llctrl.chan_map_ind.chm[0],
-	       sizeof(conn->llcp.chan_map.chm));
+	(void)memcpy(&conn->llcp.chan_map.chm[0],
+			&pdu_data_rx->llctrl.chan_map_ind.chm[0],
+			sizeof(conn->llcp.chan_map.chm));
 	conn->llcp.chan_map.instant =
 		pdu_data_rx->llctrl.chan_map_ind.instant;
 	conn->llcp.chan_map.initiate = 0U;
@@ -10304,9 +10307,9 @@ static void enc_req_reused_send(struct connection *conn,
 	pdu_ctrl_tx->len = offsetof(struct pdu_data_llctrl, enc_req) +
 			   sizeof(struct pdu_data_llctrl_enc_req);
 	pdu_ctrl_tx->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_ENC_REQ;
-	memcpy(&pdu_ctrl_tx->llctrl.enc_req.rand[0],
-	       &conn->llcp_enc.rand[0],
-	       sizeof(pdu_ctrl_tx->llctrl.enc_req.rand));
+	(void)memcpy(&pdu_ctrl_tx->llctrl.enc_req.rand[0],
+			&conn->llcp_enc.rand[0],
+			sizeof(pdu_ctrl_tx->llctrl.enc_req.rand));
 	pdu_ctrl_tx->llctrl.enc_req.ediv[0] =
 		conn->llcp_enc.ediv[0];
 	pdu_ctrl_tx->llctrl.enc_req.ediv[1] =
@@ -10361,10 +10364,10 @@ static u8_t enc_rsp_send(struct connection *conn)
 				sizeof(pdu_ctrl_tx->llctrl.enc_rsp.ivs), 0);
 
 	/* things from slave stored for session key calculation */
-	memcpy(&conn->llcp.encryption.skd[8],
-	       &pdu_ctrl_tx->llctrl.enc_rsp.skds[0], 8);
-	memcpy(&conn->ccm_rx.iv[4],
-	       &pdu_ctrl_tx->llctrl.enc_rsp.ivs[0], 4);
+	(void)memcpy(&conn->llcp.encryption.skd[8],
+			&pdu_ctrl_tx->llctrl.enc_rsp.skds[0], 8);
+	(void)memcpy(&conn->ccm_rx.iv[4],
+			&pdu_ctrl_tx->llctrl.enc_rsp.ivs[0], 4);
 
 	ctrl_tx_enqueue(conn, node_tx);
 
@@ -11463,7 +11466,7 @@ u32_t radio_scan_enable(u8_t type, u8_t init_addr_type, u8_t *init_addr,
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
 	_radio.scanner.init_addr_type = init_addr_type;
-	memcpy(&_radio.scanner.init_addr[0], init_addr, BDADDR_SIZE);
+	(void)memcpy(&_radio.scanner.init_addr[0], init_addr, BDADDR_SIZE);
 	_radio.scanner.ticks_window = HAL_TICKER_US_TO_TICKS((u64_t)window *
 							     625);
 	_radio.scanner.filter_policy = filter_policy;
@@ -11614,7 +11617,7 @@ u32_t radio_connect_enable(u8_t adv_addr_type, u8_t *adv_addr, u16_t interval,
 	}
 
 	_radio.scanner.adv_addr_type = adv_addr_type;
-	memcpy(&_radio.scanner.adv_addr[0], adv_addr, BDADDR_SIZE);
+	(void)memcpy(&_radio.scanner.adv_addr[0], adv_addr, BDADDR_SIZE);
 	_radio.scanner.conn_interval = interval;
 	_radio.scanner.conn_latency = latency;
 	_radio.scanner.conn_timeout = timeout;
@@ -11625,10 +11628,11 @@ u32_t radio_connect_enable(u8_t adv_addr_type, u8_t *adv_addr, u16_t interval,
 	conn->handle = 0xFFFF;
 	conn->llcp_features = LL_FEAT;
 	access_addr = access_addr_get();
-	memcpy(&conn->access_addr[0], &access_addr, sizeof(conn->access_addr));
+	(void)memcpy(&conn->access_addr[0], &access_addr,
+		      sizeof(conn->access_addr));
 	bt_rand(&conn->crc_init[0], 3);
-	memcpy(&conn->data_chan_map[0], &_radio.data_chan_map[0],
-	       sizeof(conn->data_chan_map));
+	(void)memcpy(&conn->data_chan_map[0], &_radio.data_chan_map[0],
+			sizeof(conn->data_chan_map));
 	conn->data_chan_count = _radio.data_chan_count;
 	conn->data_chan_sel = 0U;
 	conn->data_chan_hop = 6U;
@@ -11868,8 +11872,8 @@ u8_t ll_chm_update(u8_t *chm)
 {
 	u8_t instance;
 
-	memcpy(&_radio.data_chan_map[0], chm,
-	       sizeof(_radio.data_chan_map));
+	(void)memcpy(&_radio.data_chan_map[0], chm,
+			sizeof(_radio.data_chan_map));
 	_radio.data_chan_count =
 		util_ones_count_get(&_radio.data_chan_map[0],
 				    sizeof(_radio.data_chan_map));
@@ -11887,8 +11891,8 @@ u8_t ll_chm_update(u8_t *chm)
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}
 
-		memcpy(&conn->llcp.chan_map.chm[0], chm,
-		       sizeof(conn->llcp.chan_map.chm));
+		(void)memcpy(&conn->llcp.chan_map.chm[0], chm,
+				sizeof(conn->llcp.chan_map.chm));
 		/* conn->llcp.chan_map.instant     = 0; */
 		conn->llcp.chan_map.initiate = 1U;
 
@@ -11913,7 +11917,8 @@ u8_t ll_chm_get(u16_t handle, u8_t *chm)
 	 */
 	do {
 		conn->chm_update = 0U;
-		memcpy(chm, conn->data_chan_map, sizeof(conn->data_chan_map));
+		(void)memcpy(chm, conn->data_chan_map,
+			      sizeof(conn->data_chan_map));
 	} while (conn->chm_update);
 
 	return 0;
@@ -11940,7 +11945,8 @@ u8_t ll_enc_req_send(u16_t handle, u8_t *rand, u8_t *ediv, u8_t *ltk)
 
 		pdu_data_tx = (void *)node_tx->pdu_data;
 
-		memcpy(&conn->llcp_enc.ltk[0], ltk, sizeof(conn->llcp_enc.ltk));
+		(void)memcpy(&conn->llcp_enc.ltk[0], ltk,
+			      sizeof(conn->llcp_enc.ltk));
 
 		if ((conn->enc_rx == 0) && (conn->enc_tx == 0)) {
 			struct pdu_data_llctrl_enc_req *enc_req;
@@ -11953,14 +11959,15 @@ u8_t ll_enc_req_send(u16_t handle, u8_t *rand, u8_t *ediv, u8_t *ltk)
 				PDU_DATA_LLCTRL_TYPE_ENC_REQ;
 			enc_req = (void *)
 				&pdu_data_tx->llctrl.enc_req;
-			memcpy(enc_req->rand, rand, sizeof(enc_req->rand));
+			(void)memcpy(enc_req->rand, rand,
+				      sizeof(enc_req->rand));
 			enc_req->ediv[0] = ediv[0];
 			enc_req->ediv[1] = ediv[1];
 			bt_rand(enc_req->skdm, sizeof(enc_req->skdm));
 			bt_rand(enc_req->ivm, sizeof(enc_req->ivm));
 		} else if ((conn->enc_rx != 0) && (conn->enc_tx != 0)) {
-			memcpy(&conn->llcp_enc.rand[0], rand,
-			       sizeof(conn->llcp_enc.rand));
+			(void)memcpy(&conn->llcp_enc.rand[0], rand,
+					sizeof(conn->llcp_enc.rand));
 
 			conn->llcp_enc.ediv[0] = ediv[0];
 			conn->llcp_enc.ediv[1] = ediv[1];
@@ -12026,8 +12033,8 @@ u8_t ll_start_enc_req_send(u16_t handle, u8_t error_code,
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}
 
-		memcpy(&conn->llcp_enc.ltk[0], ltk,
-		       sizeof(conn->llcp_enc.ltk));
+		(void)memcpy(&conn->llcp_enc.ltk[0], ltk,
+				sizeof(conn->llcp_enc.ltk));
 
 		conn->llcp.encryption.error_code = 0U;
 		conn->llcp.encryption.initiate = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -40,14 +40,14 @@ u8_t *ll_addr_get(u8_t addr_type, u8_t *bdaddr)
 
 	if (addr_type) {
 		if (bdaddr) {
-			memcpy(bdaddr, rnd_addr, BDADDR_SIZE);
+			(void)memcpy(bdaddr, rnd_addr, BDADDR_SIZE);
 		}
 
 		return rnd_addr;
 	}
 
 	if (bdaddr) {
-		memcpy(bdaddr, pub_addr, BDADDR_SIZE);
+		(void)memcpy(bdaddr, pub_addr, BDADDR_SIZE);
 	}
 
 	return pub_addr;
@@ -66,9 +66,9 @@ u32_t ll_addr_set(u8_t addr_type, u8_t const *const bdaddr)
 	}
 
 	if (addr_type) {
-		memcpy(rnd_addr, bdaddr, BDADDR_SIZE);
+		(void)memcpy(rnd_addr, bdaddr, BDADDR_SIZE);
 	} else {
-		memcpy(pub_addr, bdaddr, BDADDR_SIZE);
+		(void)memcpy(pub_addr, bdaddr, BDADDR_SIZE);
 	}
 
 	return 0;

--- a/subsys/bluetooth/controller/ll_sw/ll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_adv.c
@@ -330,8 +330,9 @@ u8_t ll_adv_data_set(u8_t len, u8_t const *const data)
 
 	pdu->tx_addr = prev->tx_addr;
 	pdu->rx_addr = prev->rx_addr;
-	memcpy(&pdu->adv_ind.addr[0], &prev->adv_ind.addr[0], BDADDR_SIZE);
-	memcpy(&pdu->adv_ind.data[0], data, len);
+	(void)memcpy(&pdu->adv_ind.addr[0],
+		      &prev->adv_ind.addr[0], BDADDR_SIZE);
+	(void)memcpy(&pdu->adv_ind.data[0], data, len);
 	pdu->len = BDADDR_SIZE + len;
 
 	/* commit the update so controller picks it. */
@@ -435,8 +436,9 @@ u8_t ll_adv_enable(u8_t enable)
 
 		/* AdvA, fill here at enable */
 		if (h->adv_addr) {
-			memcpy(ptr, ll_addr_get(pdu_adv->tx_addr, NULL),
-			       BDADDR_SIZE);
+			(void)memcpy(ptr,
+					ll_addr_get(pdu_adv->tx_addr, NULL),
+					BDADDR_SIZE);
 		}
 
 		/* TODO: TargetA, fill here at enable */
@@ -464,12 +466,12 @@ u8_t ll_adv_enable(u8_t enable)
 		}
 #endif /* !CONFIG_BT_CTLR_PRIVACY */
 		if (!priv) {
-			memcpy(&pdu_adv->adv_ind.addr[0],
-			       ll_addr_get(pdu_adv->tx_addr, NULL),
-			       BDADDR_SIZE);
-			memcpy(&pdu_scan->scan_rsp.addr[0],
-			       ll_addr_get(pdu_adv->tx_addr, NULL),
-			       BDADDR_SIZE);
+			(void)memcpy(&pdu_adv->adv_ind.addr[0],
+					ll_addr_get(pdu_adv->tx_addr, NULL),
+					BDADDR_SIZE);
+			(void)memcpy(&pdu_scan->scan_rsp.addr[0],
+					ll_addr_get(pdu_adv->tx_addr, NULL),
+					BDADDR_SIZE);
 		}
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -174,7 +174,7 @@ static void filter_insert(struct ll_filter *filter, int index, u8_t addr_type,
 {
 	filter->enable_bitmask |= BIT(index);
 	filter->addr_type_bitmask |= ((addr_type & 0x01) << index);
-	memcpy(&filter->bdaddr[index][0], bdaddr, BDADDR_SIZE);
+	(void)memcpy(&filter->bdaddr[index][0], bdaddr, BDADDR_SIZE);
 }
 
 #if !defined(CONFIG_BT_CTLR_PRIVACY)
@@ -465,7 +465,7 @@ void ll_rl_id_addr_get(u8_t rl_idx, u8_t *id_addr_type, u8_t *id_addr)
 	LL_ASSERT(rl[rl_idx].taken);
 
 	*id_addr_type = rl[rl_idx].id_addr_type;
-	memcpy(id_addr, rl[rl_idx].id_addr.val, BDADDR_SIZE);
+	(void)memcpy(id_addr, rl[rl_idx].id_addr.val, BDADDR_SIZE);
 }
 
 bool ctrl_rl_addr_allowed(u8_t id_addr_type, u8_t *id_addr, u8_t *rl_idx)
@@ -531,7 +531,7 @@ void ll_rl_pdu_adv_update(u8_t idx, struct pdu_adv *pdu)
 	if (idx < ARRAY_SIZE(rl) && rl[idx].lirk) {
 		LL_ASSERT(rl[idx].rpas_ready);
 		pdu->tx_addr = 1U;
-		memcpy(adva, rl[idx].local_rpa->val, BDADDR_SIZE);
+		(void)memcpy(adva, rl[idx].local_rpa->val, BDADDR_SIZE);
 	} else {
 		pdu->tx_addr = ll_adv->own_addr_type & 0x1;
 		ll_addr_get(ll_adv->own_addr_type & 0x1, adva);
@@ -541,12 +541,12 @@ void ll_rl_pdu_adv_update(u8_t idx, struct pdu_adv *pdu)
 	if (pdu->type == PDU_ADV_TYPE_DIRECT_IND) {
 		if (idx < ARRAY_SIZE(rl) && rl[idx].pirk) {
 			pdu->rx_addr = 1U;
-			memcpy(&pdu->direct_ind.tgt_addr[0],
-			       rl[idx].peer_rpa.val, BDADDR_SIZE);
+			(void)memcpy(&pdu->direct_ind.tgt_addr[0],
+					rl[idx].peer_rpa.val, BDADDR_SIZE);
 		} else {
 			pdu->rx_addr = ll_adv->id_addr_type;
-			memcpy(&pdu->direct_ind.tgt_addr[0],
-			       ll_adv->id_addr, BDADDR_SIZE);
+			(void)memcpy(&pdu->direct_ind.tgt_addr[0],
+					ll_adv->id_addr, BDADDR_SIZE);
 		}
 	}
 }
@@ -597,8 +597,8 @@ static void rpa_adv_refresh(void)
 
 	ll_rl_pdu_adv_update(idx, pdu);
 
-	memcpy(&pdu->adv_ind.data[0], &prev->adv_ind.data[0],
-	       prev->len - BDADDR_SIZE);
+	(void)memcpy(&pdu->adv_ind.data[0], &prev->adv_ind.data[0],
+			prev->len - BDADDR_SIZE);
 	pdu->len = prev->len;
 
 	/* commit the update so controller picks it. */
@@ -755,7 +755,7 @@ u8_t ll_rl_add(bt_addr_le_t *id_addr, const u8_t pirk[16],
 		sys_memcpy_swap(peer_irks[peer_irk_count++], pirk, 16);
 	}
 	if (rl[i].lirk) {
-		memcpy(rl[i].local_irk, lirk, 16);
+		(void)memcpy(rl[i].local_irk, lirk, 16);
 		rl[i].local_rpa = NULL;
 	}
 	(void)memset(rl[i].curr_rpa.val, 0x00, sizeof(rl[i].curr_rpa));
@@ -793,7 +793,7 @@ u8_t ll_rl_remove(bt_addr_le_t *id_addr)
 			u8_t pi = rl[i].pirk_idx, pj = peer_irk_count - 1;
 
 			if (pj && pi != pj) {
-				memcpy(peer_irks[pi], peer_irks[pj], 16);
+				(void)memcpy(peer_irks[pi], peer_irks[pj], 16);
 				for (k = 0U;
 				     k < CONFIG_BT_CTLR_RL_SIZE;
 				     k++) {
@@ -831,8 +831,8 @@ void ll_rl_crpa_set(u8_t id_addr_type, u8_t *id_addr, u8_t rl_idx, u8_t *crpa)
 		}
 
 		if (rl_idx < ARRAY_SIZE(rl) && rl[rl_idx].taken) {
-				memcpy(rl[rl_idx].curr_rpa.val, crpa,
-				       sizeof(bt_addr_t));
+			(void)memcpy(rl[rl_idx].curr_rpa.val, crpa,
+				      sizeof(bt_addr_t));
 		}
 	}
 }

--- a/subsys/bluetooth/controller/ll_sw/ll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_test.c
@@ -222,7 +222,7 @@ u32_t ll_test_tx(u8_t chan, u8_t len, u8_t type, u8_t phy)
 
 	switch (type) {
 	case 0x00:
-		memcpy(payload, prbs9, len);
+		(void)memcpy(payload, prbs9, len);
 		break;
 
 	case 0x01:
@@ -234,7 +234,7 @@ u32_t ll_test_tx(u8_t chan, u8_t len, u8_t type, u8_t phy)
 		break;
 
 	case 0x03:
-		memcpy(payload, prbs15, len);
+		(void)memcpy(payload, prbs15, len);
 		break;
 
 	case 0x04:

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
@@ -53,12 +53,14 @@ void ecb_encrypt_be(u8_t const *const key_be, u8_t const *const clear_text_be,
 {
 	struct ecb_param ecb;
 
-	memcpy(&ecb.key[0], key_be, sizeof(ecb.key));
-	memcpy(&ecb.clear_text[0], clear_text_be, sizeof(ecb.clear_text));
+	(void)memcpy(&ecb.key[0], key_be, sizeof(ecb.key));
+	(void)memcpy(&ecb.clear_text[0], clear_text_be,
+		      sizeof(ecb.clear_text));
 
 	do_ecb(&ecb);
 
-	memcpy(cipher_text_be, &ecb.cipher_text[0], sizeof(ecb.cipher_text));
+	(void)memcpy(cipher_text_be, &ecb.cipher_text[0],
+		      sizeof(ecb.cipher_text));
 }
 
 void ecb_encrypt(u8_t const *const key_le, u8_t const *const clear_text_le,
@@ -77,8 +79,8 @@ void ecb_encrypt(u8_t const *const key_le, u8_t const *const clear_text_le,
 	}
 
 	if (cipher_text_be) {
-		memcpy(cipher_text_be, &ecb.cipher_text[0],
-			 sizeof(ecb.cipher_text));
+		(void)memcpy(cipher_text_be, &ecb.cipher_text[0],
+				sizeof(ecb.cipher_text));
 	}
 }
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -582,8 +582,8 @@ static void chan_prepare(struct lll_adv *lll)
 		/* Copy the address from the adv packet we will send into the
 		 * scan response.
 		 */
-		memcpy(&scan_pdu->scan_rsp.addr[0],
-		       &pdu->adv_ind.addr[0], BDADDR_SIZE);
+		(void)memcpy(&scan_pdu->scan_rsp.addr[0],
+				&pdu->adv_ind.addr[0], BDADDR_SIZE);
 	}
 #else
 	ARG_UNUSED(scan_pdu);
@@ -713,8 +713,9 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		rx->hdr.type = NODE_RX_TYPE_CONNECTION;
 		rx->hdr.handle = 0xffff;
 
-		memcpy(rx->pdu, pdu_rx, (offsetof(struct pdu_adv, connect_ind) +
-					 sizeof(struct pdu_adv_connect_ind)));
+		(void)memcpy(rx->pdu, pdu_rx,
+			      (offsetof(struct pdu_adv, connect_ind) +
+			      sizeof(struct pdu_adv_connect_ind)));
 
 		ftr = &(rx->hdr.rx_ftr);
 		ftr->param = lll;
@@ -789,7 +790,7 @@ static inline int isr_rx_sr_report(struct pdu_adv *pdu_adv_rx,
 	 */
 	pdu_adv = (void *)node_rx->pdu;
 	pdu_len = offsetof(struct pdu_adv, payload) + pdu_adv_rx->len;
-	memcpy(pdu_adv, pdu_adv_rx, pdu_len);
+	(void)memcpy(pdu_adv, pdu_adv_rx, pdu_len);
 
 	node_rx->hdr.rx_ftr.rssi = (rssi_ready) ? (radio_rssi_get() & 0x7f) :
 						  0x7f;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -791,11 +791,11 @@ static int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 
 					if (ctrl_pdu_len_check(
 						scratch_pkt->len)) {
-						memcpy(pdu_data_rx,
+						(void)memcpy(pdu_data_rx,
 						       scratch_pkt,
 						       scratch_pkt->len +
 						       offsetof(struct pdu_data,
-							llctrl));
+								llctrl));
 						mic_failure = false;
 						lll->ccm_rx.counter--;
 					}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -714,22 +714,23 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 		lrpa = ull_filter_lll_lrpa_get(rl_idx);
 		if (lll->rpa_gen && lrpa) {
 			pdu_tx->tx_addr = 1;
-			memcpy(&pdu_tx->connect_ind.init_addr[0], lrpa->val,
-			       BDADDR_SIZE);
+			(void)memcpy(&pdu_tx->connect_ind.init_addr[0],
+				      lrpa->val,
+				      BDADDR_SIZE);
 		} else {
 #else
 		if (1) {
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 			pdu_tx->tx_addr = lll->init_addr_type;
-			memcpy(&pdu_tx->connect_ind.init_addr[0],
-			       &lll->init_addr[0], BDADDR_SIZE);
+			(void)memcpy(&pdu_tx->connect_ind.init_addr[0],
+					&lll->init_addr[0], BDADDR_SIZE);
 		}
-		memcpy(&pdu_tx->connect_ind.adv_addr[0],
-		       &pdu_adv_rx->adv_ind.addr[0], BDADDR_SIZE);
-		memcpy(&pdu_tx->connect_ind.access_addr[0],
-		       &lll_conn->access_addr[0], 4);
-		memcpy(&pdu_tx->connect_ind.crc_init[0],
-		       &lll_conn->crc_init[0], 3);
+		(void)memcpy(&pdu_tx->connect_ind.adv_addr[0],
+				&pdu_adv_rx->adv_ind.addr[0], BDADDR_SIZE);
+		(void)memcpy(&pdu_tx->connect_ind.access_addr[0],
+				&lll_conn->access_addr[0], 4);
+		(void)memcpy(&pdu_tx->connect_ind.crc_init[0],
+				&lll_conn->crc_init[0], 3);
 		pdu_tx->connect_ind.win_size = 1;
 
 		conn_interval_us = (u32_t)lll_conn->interval * 1250U;
@@ -757,9 +758,9 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 			sys_cpu_to_le16(lll_conn->latency);
 		pdu_tx->connect_ind.timeout =
 			sys_cpu_to_le16(lll->conn_timeout);
-		memcpy(&pdu_tx->connect_ind.chan_map[0],
-		       &lll_conn->data_chan_map[0],
-		       sizeof(pdu_tx->connect_ind.chan_map));
+		(void)memcpy(&pdu_tx->connect_ind.chan_map[0],
+				&lll_conn->data_chan_map[0],
+				sizeof(pdu_tx->connect_ind.chan_map));
 		pdu_tx->connect_ind.hop = lll_conn->data_chan_hop;
 		pdu_tx->connect_ind.sca = lll_conn_sca_local_get();
 
@@ -805,8 +806,9 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 		rx->hdr.handle = 0xffff;
 
 		u8_t pdu_adv_rx_chan_sel = pdu_adv_rx->chan_sel;
-		memcpy(rx->pdu, pdu_tx, (offsetof(struct pdu_adv, connect_ind) +
-					  sizeof(struct pdu_adv_connect_ind)));
+		(void)memcpy(rx->pdu, pdu_tx,
+			      (offsetof(struct pdu_adv, connect_ind) +
+					sizeof(struct pdu_adv_connect_ind)));
 
 		/* Overwrite the sent chan sel with received chan sel, when
 		 * giving this PDU to the higher layer. */
@@ -868,18 +870,19 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 		lrpa = ull_filter_lll_lrpa_get(rl_idx);
 		if (lll->rpa_gen && lrpa) {
 			pdu_tx->tx_addr = 1;
-			memcpy(&pdu_tx->scan_req.scan_addr[0], lrpa->val,
-			       BDADDR_SIZE);
+			(void)memcpy(&pdu_tx->scan_req.scan_addr[0],
+				      lrpa->val,
+				      BDADDR_SIZE);
 		} else {
 #else
 		if (1) {
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 			pdu_tx->tx_addr = lll->init_addr_type;
-			memcpy(&pdu_tx->scan_req.scan_addr[0],
-			       &lll->init_addr[0], BDADDR_SIZE);
+			(void)memcpy(&pdu_tx->scan_req.scan_addr[0],
+					&lll->init_addr[0], BDADDR_SIZE);
 		}
-		memcpy(&pdu_tx->scan_req.adv_addr[0],
-		       &pdu_adv_rx->adv_ind.addr[0], BDADDR_SIZE);
+		(void)memcpy(&pdu_tx->scan_req.adv_addr[0],
+				&pdu_adv_rx->adv_ind.addr[0], BDADDR_SIZE);
 
 		/* switch scanner state to active */
 		lll->state = 1U;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -221,35 +221,35 @@ u32_t ll_test_tx(u8_t chan, u8_t len, u8_t type, u8_t phy)
 
 	switch (type) {
 	case 0x00:
-		memcpy(payload, prbs9, len);
+		(void)memcpy(payload, prbs9, len);
 		break;
 
 	case 0x01:
-		memset(payload, 0x0f, len);
+		(void)memset(payload, 0x0f, len);
 		break;
 
 	case 0x02:
-		memset(payload, 0x55, len);
+		(void)memset(payload, 0x55, len);
 		break;
 
 	case 0x03:
-		memcpy(payload, prbs15, len);
+		(void)memcpy(payload, prbs15, len);
 		break;
 
 	case 0x04:
-		memset(payload, 0xff, len);
+		(void)memset(payload, 0xff, len);
 		break;
 
 	case 0x05:
-		memset(payload, 0x00, len);
+		(void)memset(payload, 0x00, len);
 		break;
 
 	case 0x06:
-		memset(payload, 0xf0, len);
+		(void)memset(payload, 0xf0, len);
 		break;
 
 	case 0x07:
-		memset(payload, 0xaa, len);
+		(void)memset(payload, 0xaa, len);
 		break;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1056,7 +1056,8 @@ int ull_prepare_enqueue(lll_is_abort_cb_t is_abort_cb,
 		return -ENOBUFS;
 	}
 
-	memcpy(&e->prepare_param, prepare_param, sizeof(e->prepare_param));
+	(void)memcpy(&e->prepare_param, prepare_param,
+		      sizeof(e->prepare_param));
 	e->prepare_cb = prepare_cb;
 	e->is_abort_cb = is_abort_cb;
 	e->abort_cb = abort_cb;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -363,8 +363,9 @@ u8_t ll_adv_data_set(u8_t len, u8_t const *const data)
 
 	pdu->tx_addr = prev->tx_addr;
 	pdu->rx_addr = prev->rx_addr;
-	memcpy(&pdu->adv_ind.addr[0], &prev->adv_ind.addr[0], BDADDR_SIZE);
-	memcpy(&pdu->adv_ind.data[0], data, len);
+	(void)memcpy(&pdu->adv_ind.addr[0],
+		      &prev->adv_ind.addr[0], BDADDR_SIZE);
+	(void)memcpy(&pdu->adv_ind.data[0], data, len);
 	pdu->len = BDADDR_SIZE + len;
 
 	lll_adv_data_enqueue(&adv->lll, idx);
@@ -464,8 +465,9 @@ u8_t ll_adv_enable(u8_t enable)
 
 		/* AdvA, fill here at enable */
 		if (h->adv_addr) {
-			memcpy(ptr, ll_addr_get(pdu_adv->tx_addr, NULL),
-			       BDADDR_SIZE);
+			(void)memcpy(ptr,
+					ll_addr_get(pdu_adv->tx_addr, NULL),
+					BDADDR_SIZE);
 		}
 
 		/* TODO: TargetA, fill here at enable */
@@ -495,12 +497,12 @@ u8_t ll_adv_enable(u8_t enable)
 #endif /* !CONFIG_BT_CTLR_PRIVACY */
 
 		if (!priv) {
-			memcpy(&pdu_adv->adv_ind.addr[0],
-			       ll_addr_get(pdu_adv->tx_addr, NULL),
-			       BDADDR_SIZE);
-			memcpy(&pdu_scan->scan_rsp.addr[0],
-			       ll_addr_get(pdu_adv->tx_addr, NULL),
-			       BDADDR_SIZE);
+			(void)memcpy(&pdu_adv->adv_ind.addr[0],
+					ll_addr_get(pdu_adv->tx_addr, NULL),
+					BDADDR_SIZE);
+			(void)memcpy(&pdu_scan->scan_rsp.addr[0],
+					ll_addr_get(pdu_adv->tx_addr, NULL),
+					BDADDR_SIZE);
 		}
 	}
 
@@ -1143,7 +1145,7 @@ static void disabled_cb(void *param)
 	rx->hdr.handle = 0xffff;
 
 	cc = (void *)rx->pdu;
-	memset(cc, 0x00, sizeof(struct node_rx_cc));
+	(void)memset(cc, 0x00, sizeof(struct node_rx_cc));
 	cc->status = 0x3c;
 
 	ftr = &(rx->hdr.rx_ftr);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -316,8 +316,8 @@ u8_t ll_chm_get(u16_t handle, u8_t *chm)
 	 */
 	do {
 		conn->chm_updated = 0U;
-		memcpy(chm, conn->lll.data_chan_map,
-		       sizeof(conn->lll.data_chan_map));
+		(void)memcpy(chm, conn->lll.data_chan_map,
+				sizeof(conn->lll.data_chan_map));
 	} while (conn->chm_updated);
 
 	return 0;
@@ -594,14 +594,14 @@ int ull_conn_reset(void)
 
 u8_t ull_conn_chan_map_cpy(u8_t *chan_map)
 {
-	memcpy(chan_map, data_chan_map, sizeof(data_chan_map));
+	(void)memcpy(chan_map, data_chan_map, sizeof(data_chan_map));
 
 	return data_chan_count;
 }
 
 void ull_conn_chan_map_set(u8_t *chan_map)
 {
-	memcpy(data_chan_map, chan_map, sizeof(data_chan_map));
+	(void)memcpy(data_chan_map, chan_map, sizeof(data_chan_map));
 	data_chan_count = util_ones_count_get(data_chan_map,
 					      sizeof(data_chan_map));
 }
@@ -2075,9 +2075,9 @@ static inline void event_ch_map_prep(struct ll_conn *conn,
 				sizeof(struct pdu_data_llctrl_chan_map_ind);
 			pdu_ctrl_tx->llctrl.opcode =
 				PDU_DATA_LLCTRL_TYPE_CHAN_MAP_IND;
-			memcpy(&pdu_ctrl_tx->llctrl.chan_map_ind.chm[0],
-			       &conn->llcp.chan_map.chm[0],
-			       sizeof(pdu_ctrl_tx->llctrl.chan_map_ind.chm));
+			(void)memcpy(&pdu_ctrl_tx->llctrl.chan_map_ind.chm[0],
+				  &conn->llcp.chan_map.chm[0],
+				  sizeof(pdu_ctrl_tx->llctrl.chan_map_ind.chm));
 			pdu_ctrl_tx->llctrl.chan_map_ind.instant =
 				sys_cpu_to_le16(conn->llcp.chan_map.instant);
 
@@ -2091,9 +2091,9 @@ static inline void event_ch_map_prep(struct ll_conn *conn,
 		conn->llcp_ack = conn->llcp_req;
 
 		/* copy to active channel map */
-		memcpy(&lll->data_chan_map[0],
-		       &conn->llcp.chan_map.chm[0],
-		       sizeof(lll->data_chan_map));
+		(void)memcpy(&lll->data_chan_map[0],
+				&conn->llcp.chan_map.chm[0],
+				sizeof(lll->data_chan_map));
 		lll->data_chan_count =
 			util_ones_count_get(&lll->data_chan_map[0],
 					    sizeof(lll->data_chan_map));
@@ -3171,8 +3171,9 @@ static u8_t chan_map_upd_recv(struct ll_conn *conn, struct node_rx_pdu *rx,
 	}
 
 
-	memcpy(&conn->llcp.chan_map.chm[0], &pdu->llctrl.chan_map_ind.chm[0],
-	       sizeof(conn->llcp.chan_map.chm));
+	(void)memcpy(&conn->llcp.chan_map.chm[0],
+			&pdu->llctrl.chan_map_ind.chm[0],
+			sizeof(conn->llcp.chan_map.chm));
 	conn->llcp.chan_map.instant = instant;
 	conn->llcp.chan_map.initiate = 0U;
 
@@ -3227,8 +3228,9 @@ static void enc_req_reused_send(struct ll_conn *conn, struct node_tx **tx)
 	pdu_ctrl_tx->len = offsetof(struct pdu_data_llctrl, enc_req) +
 			   sizeof(struct pdu_data_llctrl_enc_req);
 	pdu_ctrl_tx->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_ENC_REQ;
-	memcpy(&pdu_ctrl_tx->llctrl.enc_req.rand[0], &conn->llcp_enc.rand[0],
-	       sizeof(pdu_ctrl_tx->llctrl.enc_req.rand));
+	(void)memcpy(&pdu_ctrl_tx->llctrl.enc_req.rand[0],
+			&conn->llcp_enc.rand[0],
+			sizeof(pdu_ctrl_tx->llctrl.enc_req.rand));
 	pdu_ctrl_tx->llctrl.enc_req.ediv[0] = conn->llcp_enc.ediv[0];
 	pdu_ctrl_tx->llctrl.enc_req.ediv[1] = conn->llcp_enc.ediv[1];
 
@@ -3284,10 +3286,10 @@ static int enc_rsp_send(struct ll_conn *conn)
 				sizeof(pdu_ctrl_tx->llctrl.enc_rsp.ivs), 0);
 
 	/* things from slave stored for session key calculation */
-	memcpy(&conn->llcp.encryption.skd[8],
-	       &pdu_ctrl_tx->llctrl.enc_rsp.skds[0], 8);
-	memcpy(&conn->lll.ccm_rx.iv[4],
-	       &pdu_ctrl_tx->llctrl.enc_rsp.ivs[0], 4);
+	(void)memcpy(&conn->llcp.encryption.skd[8],
+			&pdu_ctrl_tx->llctrl.enc_rsp.skds[0], 8);
+	(void)memcpy(&conn->lll.ccm_rx.iv[4],
+			&pdu_ctrl_tx->llctrl.enc_rsp.ivs[0], 4);
 
 	ctrl_tx_enqueue(conn, tx);
 
@@ -4251,10 +4253,10 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	case PDU_DATA_LLCTRL_TYPE_ENC_REQ:
 		/* things from master stored for session key calculation */
-		memcpy(&conn->llcp.encryption.skd[0],
-		       &pdu_tx->llctrl.enc_req.skdm[0], 8);
-		memcpy(&conn->lll.ccm_rx.iv[0],
-		       &pdu_tx->llctrl.enc_req.ivm[0], 4);
+		(void)memcpy(&conn->llcp.encryption.skd[0],
+				&pdu_tx->llctrl.enc_req.skdm[0], 8);
+		(void)memcpy(&conn->lll.ccm_rx.iv[0],
+				&pdu_tx->llctrl.enc_req.ivm[0], 4);
 
 		/* pause data packet tx */
 		conn->llcp_enc.pause_tx = 1U;
@@ -4520,10 +4522,10 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 #endif /* CONFIG_BT_CTLR_FAST_ENC */
 
 		/* things from master stored for session key calculation */
-		memcpy(&conn->llcp.encryption.skd[0],
-		       &pdu_rx->llctrl.enc_req.skdm[0], 8);
-		memcpy(&conn->lll.ccm_rx.iv[0],
-		       &pdu_rx->llctrl.enc_req.ivm[0], 4);
+		(void)memcpy(&conn->llcp.encryption.skd[0],
+				&pdu_rx->llctrl.enc_req.skdm[0], 8);
+		(void)memcpy(&conn->lll.ccm_rx.iv[0],
+				&pdu_rx->llctrl.enc_req.ivm[0], 4);
 
 		/* pause rx data packets */
 		conn->llcp_enc.pause_rx = 1U;
@@ -4542,10 +4544,10 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 		}
 
 		/* things sent by slave stored for session key calculation */
-		memcpy(&conn->llcp.encryption.skd[8],
-		       &pdu_rx->llctrl.enc_rsp.skds[0], 8);
-		memcpy(&conn->lll.ccm_rx.iv[4],
-		       &pdu_rx->llctrl.enc_rsp.ivs[0], 4);
+		(void)memcpy(&conn->llcp.encryption.skd[8],
+				&pdu_rx->llctrl.enc_rsp.skds[0], 8);
+		(void)memcpy(&conn->lll.ccm_rx.iv[4],
+				&pdu_rx->llctrl.enc_rsp.ivs[0], 4);
 
 		/* pause rx data packets */
 		conn->llcp_enc.pause_rx = 1U;
@@ -5379,8 +5381,9 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 				break;
 			}
 
-			memcpy(&conn->llcp.chan_map.chm[0], data_chan_map,
-			       sizeof(conn->llcp.chan_map.chm));
+			(void)memcpy(&conn->llcp.chan_map.chm[0],
+					data_chan_map,
+					sizeof(conn->llcp.chan_map.chm));
 			/* conn->llcp.chan_map.instant     = 0; */
 			conn->llcp.chan_map.initiate = 1U;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -214,7 +214,7 @@ void ll_rl_id_addr_get(u8_t rl_idx, u8_t *id_addr_type, u8_t *id_addr)
 	LL_ASSERT(rl[rl_idx].taken);
 
 	*id_addr_type = rl[rl_idx].id_addr_type;
-	memcpy(id_addr, rl[rl_idx].id_addr.val, BDADDR_SIZE);
+	(void)memcpy(id_addr, rl[rl_idx].id_addr.val, BDADDR_SIZE);
 }
 
 u8_t ll_rl_size_get(void)
@@ -265,10 +265,10 @@ u8_t ll_rl_add(bt_addr_le_t *id_addr, const u8_t pirk[16], const u8_t lirk[16])
 		sys_memcpy_swap(peer_irks[peer_irk_count++], pirk, 16);
 	}
 	if (rl[i].lirk) {
-		memcpy(rl[i].local_irk, lirk, 16);
+		(void)memcpy(rl[i].local_irk, lirk, 16);
 		rl[i].local_rpa = NULL;
 	}
-	memset(rl[i].curr_rpa.val, 0x00, sizeof(rl[i].curr_rpa));
+	(void)memset(rl[i].curr_rpa.val, 0x00, sizeof(rl[i].curr_rpa));
 	rl[i].rpas_ready = 0U;
 	/* Default to Network Privacy */
 	rl[i].dev = 0U;
@@ -303,7 +303,7 @@ u8_t ll_rl_remove(bt_addr_le_t *id_addr)
 			u8_t pi = rl[i].pirk_idx, pj = peer_irk_count - 1;
 
 			if (pj && pi != pj) {
-				memcpy(peer_irks[pi], peer_irks[pj], 16);
+				(void)memcpy(peer_irks[pi], peer_irks[pj], 16);
 				for (k = 0U;
 				     k < CONFIG_BT_CTLR_RL_SIZE;
 				     k++) {
@@ -341,8 +341,8 @@ void ll_rl_crpa_set(u8_t id_addr_type, u8_t *id_addr, u8_t rl_idx, u8_t *crpa)
 		}
 
 		if (rl_idx < ARRAY_SIZE(rl) && rl[rl_idx].taken) {
-			memcpy(rl[rl_idx].curr_rpa.val, crpa,
-			       sizeof(bt_addr_t));
+			(void)memcpy(rl[rl_idx].curr_rpa.val, crpa,
+					sizeof(bt_addr_t));
 		}
 	}
 }
@@ -551,7 +551,7 @@ void ull_filter_adv_pdu_update(struct ll_adv_set *adv, u8_t idx,
 	if (idx < ARRAY_SIZE(rl) && rl[idx].lirk) {
 		LL_ASSERT(rl[idx].rpas_ready);
 		pdu->tx_addr = 1;
-		memcpy(adva, rl[idx].local_rpa->val, BDADDR_SIZE);
+		(void)memcpy(adva, rl[idx].local_rpa->val, BDADDR_SIZE);
 	} else {
 		pdu->tx_addr = adv->own_addr_type & 0x1;
 		ll_addr_get(adv->own_addr_type & 0x1, adva);
@@ -561,12 +561,12 @@ void ull_filter_adv_pdu_update(struct ll_adv_set *adv, u8_t idx,
 	if (pdu->type == PDU_ADV_TYPE_DIRECT_IND) {
 		if (idx < ARRAY_SIZE(rl) && rl[idx].pirk) {
 			pdu->rx_addr = 1;
-			memcpy(&pdu->direct_ind.tgt_addr[0],
-			       rl[idx].peer_rpa.val, BDADDR_SIZE);
+			(void)memcpy(&pdu->direct_ind.tgt_addr[0],
+					rl[idx].peer_rpa.val, BDADDR_SIZE);
 		} else {
 			pdu->rx_addr = adv->id_addr_type;
-			memcpy(&pdu->direct_ind.tgt_addr[0],
-			       adv->id_addr, BDADDR_SIZE);
+			(void)memcpy(&pdu->direct_ind.tgt_addr[0],
+					adv->id_addr, BDADDR_SIZE);
 		}
 	}
 }
@@ -890,8 +890,8 @@ static void rpa_adv_refresh(struct ll_adv_set *adv)
 
 	ull_filter_adv_pdu_update(adv, idx, pdu);
 
-	memcpy(&pdu->adv_ind.data[0], &prev->adv_ind.data[0],
-	       prev->len - BDADDR_SIZE);
+	(void)memcpy(&pdu->adv_ind.data[0], &prev->adv_ind.data[0],
+			prev->len - BDADDR_SIZE);
 	pdu->len = prev->len;
 
 	lll_adv_data_enqueue(&adv->lll, idx);
@@ -988,7 +988,7 @@ static void filter_insert(struct lll_filter *filter, int index, u8_t addr_type,
 {
 	filter->enable_bitmask |= BIT(index);
 	filter->addr_type_bitmask |= ((addr_type & 0x01) << index);
-	memcpy(&filter->bdaddr[index][0], bdaddr, BDADDR_SIZE);
+	(void)memcpy(&filter->bdaddr[index][0], bdaddr, BDADDR_SIZE);
 }
 
 static void filter_clear(struct lll_filter *filter)

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -88,15 +88,15 @@ u8_t ll_create_connection(u16_t scan_interval, u16_t scan_window,
 	ull_scan_params_set(lll, 0, scan_interval, scan_window, filter_policy);
 
 	lll->adv_addr_type = peer_addr_type;
-	memcpy(lll->adv_addr, peer_addr, BDADDR_SIZE);
+	(void)memcpy(lll->adv_addr, peer_addr, BDADDR_SIZE);
 	lll->conn_timeout = timeout;
 	lll->conn_ticks_slot = 0; /* TODO: */
 
 	conn_lll = &conn->lll;
 
 	access_addr_get(access_addr);
-	memcpy(conn_lll->access_addr, &access_addr,
-	       sizeof(conn_lll->access_addr));
+	(void)memcpy(conn_lll->access_addr, &access_addr,
+			sizeof(conn_lll->access_addr));
 	bt_rand(&conn_lll->crc_init[0], 3);
 
 	conn_lll->handle = 0xFFFF;
@@ -318,8 +318,8 @@ u8_t ll_chm_update(u8_t *chm)
 			return ret;
 		}
 
-		memcpy(conn->llcp.chan_map.chm, chm,
-		       sizeof(conn->llcp.chan_map.chm));
+		(void)memcpy(conn->llcp.chan_map.chm, chm,
+				sizeof(conn->llcp.chan_map.chm));
 		/* conn->llcp.chan_map.instant     = 0; */
 		conn->llcp.chan_map.initiate = 1U;
 
@@ -351,7 +351,8 @@ u8_t ll_enc_req_send(u16_t handle, u8_t *rand, u8_t *ediv, u8_t *ltk)
 
 		pdu_data_tx = (void *)tx->pdu;
 
-		memcpy(&conn->llcp_enc.ltk[0], ltk, sizeof(conn->llcp_enc.ltk));
+		(void)memcpy(&conn->llcp_enc.ltk[0], ltk,
+			      sizeof(conn->llcp_enc.ltk));
 
 		if ((conn->lll.enc_rx == 0) && (conn->lll.enc_tx == 0)) {
 			struct pdu_data_llctrl_enc_req *enc_req;
@@ -364,14 +365,15 @@ u8_t ll_enc_req_send(u16_t handle, u8_t *rand, u8_t *ediv, u8_t *ltk)
 				PDU_DATA_LLCTRL_TYPE_ENC_REQ;
 			enc_req = (void *)
 				&pdu_data_tx->llctrl.enc_req;
-			memcpy(enc_req->rand, rand, sizeof(enc_req->rand));
+			(void)memcpy(enc_req->rand, rand,
+				      sizeof(enc_req->rand));
 			enc_req->ediv[0] = ediv[0];
 			enc_req->ediv[1] = ediv[1];
 			bt_rand(enc_req->skdm, sizeof(enc_req->skdm));
 			bt_rand(enc_req->ivm, sizeof(enc_req->ivm));
 		} else if ((conn->lll.enc_rx != 0) && (conn->lll.enc_tx != 0)) {
-			memcpy(&conn->llcp_enc.rand[0], rand,
-			       sizeof(conn->llcp_enc.rand));
+			(void)memcpy(&conn->llcp_enc.rand[0], rand,
+					sizeof(conn->llcp_enc.rand));
 
 			conn->llcp_enc.ediv[0] = ediv[0];
 			conn->llcp_enc.ediv[1] = ediv[1];

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -417,7 +417,8 @@ u8_t ll_start_enc_req_send(u16_t handle, u8_t error_code,
 			return ret;
 		}
 
-		memcpy(&conn->llcp_enc.ltk[0], ltk, sizeof(conn->llcp_enc.ltk));
+		(void)memcpy(&conn->llcp_enc.ltk[0],
+			      ltk, sizeof(conn->llcp_enc.ltk));
 
 		conn->llcp.encryption.error_code = 0U;
 		conn->llcp.encryption.initiate = 0U;

--- a/subsys/bluetooth/controller/util/mem.c
+++ b/subsys/bluetooth/controller/util/mem.c
@@ -32,8 +32,8 @@ void mem_init(void *mem_pool, u16_t mem_size, u16_t mem_count,
 
 		next = (u32_t)((u8_t *) mem_pool +
 			       (mem_size * (mem_count + 1)));
-		memcpy(((u8_t *)mem_pool + (mem_size * mem_count)),
-		       (void *)&next, sizeof(next));
+		(void)memcpy(((u8_t *)mem_pool + (mem_size * mem_count)),
+				(void *)&next, sizeof(next));
 	}
 }
 
@@ -50,7 +50,7 @@ void *mem_acquire(void **mem_head)
 		free_count--;
 
 		mem = *mem_head;
-		memcpy(&head, mem, sizeof(head));
+		(void)memcpy(&head, mem, sizeof(head));
 
 		/* Store free mem_count after the list's next pointer */
 		if (head) {
@@ -76,7 +76,7 @@ void mem_release(void *mem, void **mem_head)
 	}
 	free_count++;
 
-	memcpy(mem, mem_head, sizeof(mem));
+	(void)memcpy(mem, mem_head, sizeof(mem));
 
 	/* Store free mem_count after the list's next pointer */
 	*((u16_t *)MROUND((u8_t *)mem + sizeof(mem))) = free_count;

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -497,8 +497,9 @@ static u8_t find_info_cb(const struct bt_gatt_attr *attr, void *user_data)
 		/* Fast forward to next item position */
 		data->info128 = net_buf_add(data->buf, sizeof(*data->info128));
 		data->info128->handle = sys_cpu_to_le16(attr->handle);
-		memcpy(data->info128->uuid, BT_UUID_128(attr->uuid)->val,
-		       sizeof(data->info128->uuid));
+		(void)memcpy(data->info128->uuid,
+				BT_UUID_128(attr->uuid)->val,
+				sizeof(data->info128->uuid));
 
 		if (att->chan.tx.mtu - data->buf->len >
 		    sizeof(*data->info128)) {
@@ -1450,7 +1451,7 @@ static u8_t att_prep_write_rsp(struct bt_att *att, u16_t handle, u16_t offset,
 	rsp->handle = sys_cpu_to_le16(handle);
 	rsp->offset = sys_cpu_to_le16(offset);
 	net_buf_add(data.buf, len);
-	memcpy(rsp->value, value, len);
+	(void)memcpy(rsp->value, value, len);
 
 	bt_l2cap_send_cb(conn, BT_L2CAP_CID_ATT, data.buf, att_rsp_sent, NULL);
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -411,7 +411,7 @@ struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
 
 	(void)memset(cp, 0, sizeof(*cp));
 
-	memcpy(&cp->bdaddr, peer, sizeof(cp->bdaddr));
+	(void)memcpy(&cp->bdaddr, peer, sizeof(cp->bdaddr));
 	cp->packet_type = sys_cpu_to_le16(0xcc18); /* DM1 DH1 DM3 DH5 DM5 DH5 */
 	cp->pscan_rep_mode = 0x02; /* R2 */
 	cp->allow_role_switch = param->allow_role_switch ? 0x01 : 0x00;
@@ -843,7 +843,7 @@ static int bt_hci_connect_br_cancel(struct bt_conn *conn)
 	}
 
 	cp = net_buf_add(buf, sizeof(*cp));
-	memcpy(&cp->bdaddr, &conn->br.dst, sizeof(cp->bdaddr));
+	(void)memcpy(&cp->bdaddr, &conn->br.dst, sizeof(cp->bdaddr));
 
 	err = bt_hci_cmd_send_sync(BT_HCI_OP_CONNECT_CANCEL, buf, &rsp);
 	if (err) {
@@ -912,10 +912,10 @@ int bt_conn_le_start_encryption(struct bt_conn *conn, u8_t rand[8],
 
 	cp = net_buf_add(buf, sizeof(*cp));
 	cp->handle = sys_cpu_to_le16(conn->handle);
-	memcpy(&cp->rand, rand, sizeof(cp->rand));
-	memcpy(&cp->ediv, ediv, sizeof(cp->ediv));
+	(void)memcpy(&cp->rand, rand, sizeof(cp->rand));
+	(void)memcpy(&cp->ediv, ediv, sizeof(cp->ediv));
 
-	memcpy(cp->ltk, ltk, len);
+	(void)memcpy(cp->ltk, ltk, len);
 	if (len < sizeof(cp->ltk)) {
 		(void)memset(cp->ltk + len, 0, sizeof(cp->ltk) - len);
 	}
@@ -2223,7 +2223,7 @@ struct bt_conn *bt_conn_create_slave_le(const bt_addr_le_t *peer,
 	struct bt_conn *conn;
 	struct bt_le_adv_param param_int;
 
-	memcpy(&param_int, param, sizeof(param_int));
+	(void)memcpy(&param_int, param, sizeof(param_int));
 	param_int.options |= (BT_LE_ADV_OPT_CONNECTABLE |
 			      BT_LE_ADV_OPT_ONE_TIME);
 

--- a/subsys/bluetooth/host/crypto.c
+++ b/subsys/bluetooth/host/crypto.c
@@ -44,7 +44,7 @@ static int prng_reseed(struct tc_hmac_prng_struct *h)
 		}
 
 		rp = (void *)rsp->data;
-		memcpy(&seed[i * 8], rp->rand, 8);
+		(void)memcpy(&seed[i * 8], rp->rand, 8);
 
 		net_buf_unref(rsp);
 	}

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -92,7 +92,7 @@ static ssize_t write_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	}
 
-	memcpy(value, buf, len);
+	(void)memcpy(value, buf, len);
 
 	bt_set_name(value);
 
@@ -235,7 +235,7 @@ static ssize_t cf_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 
 	cfg = find_cf_cfg(conn);
 	if (cfg) {
-		memcpy(data, cfg->data, sizeof(data));
+		(void)memcpy(data, cfg->data, sizeof(data));
 	}
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, data,
@@ -468,7 +468,7 @@ static ssize_t db_hash_read(struct bt_conn *conn,
 static void clear_cf_cfg(struct gatt_cf_cfg *cfg)
 {
 	bt_addr_le_copy(&cfg->peer, BT_ADDR_LE_ANY);
-	memset(cfg->data, 0, sizeof(cfg->data));
+	(void)memset(cfg->data, 0, sizeof(cfg->data));
 	atomic_set(cfg->flags, 0);
 }
 
@@ -894,7 +894,7 @@ ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 	BT_DBG("handle 0x%04x offset %u length %u", attr->handle, offset,
 	       len);
 
-	memcpy(buf, (u8_t *)value + offset, len);
+	(void)memcpy(buf, (u8_t *)value + offset, len);
 
 	return len;
 }
@@ -1034,7 +1034,7 @@ ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn,
 		pdu.uuid16 = sys_cpu_to_le16(BT_UUID_16(chrc->uuid)->val);
 		value_len += 2U;
 	} else {
-		memcpy(pdu.uuid, BT_UUID_128(chrc->uuid)->val, 16);
+		(void)memcpy(pdu.uuid, BT_UUID_128(chrc->uuid)->val, 16);
 		value_len += 16U;
 	}
 
@@ -1105,8 +1105,8 @@ void bt_gatt_foreach_attr_type(u16_t start_handle, u16_t end_handle,
 			for (i = 0; i < static_svc->attr_count; i++, handle++) {
 				struct bt_gatt_attr attr;
 
-				memcpy(&attr, &static_svc->attrs[i],
-				       sizeof(attr));
+				(void)memcpy(&attr, &static_svc->attrs[i],
+						sizeof(attr));
 
 				attr.handle = handle;
 
@@ -1169,7 +1169,7 @@ static void clear_ccc_cfg(struct bt_gatt_ccc_cfg *cfg)
 	bt_addr_le_copy(&cfg->peer, BT_ADDR_LE_ANY);
 	cfg->id = 0U;
 	cfg->value = 0U;
-	memset(cfg->data, 0, sizeof(cfg->data));
+	(void)memset(cfg->data, 0, sizeof(cfg->data));
 }
 
 static struct bt_gatt_ccc_cfg *find_ccc_cfg(const struct bt_conn *conn,
@@ -1378,7 +1378,7 @@ static int gatt_notify(struct bt_conn *conn, u16_t handle,
 	nfy->handle = sys_cpu_to_le16(handle);
 
 	net_buf_add(buf, params->len);
-	memcpy(nfy->value, params->data, params->len);
+	(void)memcpy(nfy->value, params->data, params->len);
 
 	return bt_att_send(conn, buf, params->func, params->user_data);
 }
@@ -1448,7 +1448,7 @@ static int gatt_indicate(struct bt_conn *conn, u16_t handle,
 	ind->handle = sys_cpu_to_le16(handle);
 
 	net_buf_add(buf, params->len);
-	memcpy(ind->value, params->data, params->len);
+	(void)memcpy(ind->value, params->data, params->len);
 
 	return gatt_send(conn, buf, gatt_indicate_rsp, params, NULL);
 }
@@ -1465,7 +1465,7 @@ static void sc_save(struct bt_gatt_ccc_cfg *cfg,
 	struct sc_data data;
 	struct sc_data *stored;
 
-	memcpy(&data, params->data, params->len);
+	(void)memcpy(&data, params->data, params->len);
 
 	data.start = sys_le16_to_cpu(data.start);
 	data.end = sys_le16_to_cpu(data.end);
@@ -2039,7 +2039,7 @@ static void read_included_uuid_cb(struct bt_conn *conn, u8_t err,
 	value.end_handle = params->_included.end_handle;
 	value.uuid = &u.uuid;
 	u.uuid.type = BT_UUID_TYPE_128;
-	memcpy(u.u128.val, pdu, length);
+	(void)memcpy(u.u128.val, pdu, length);
 
 	BT_DBG("handle 0x%04x uuid %s start_handle 0x%04x "
 	       "end_handle 0x%04x\n", params->_included.attr_handle,
@@ -2225,7 +2225,8 @@ static u16_t parse_characteristic(struct bt_conn *conn, const void *pdu,
 			u.u16.val = sys_le16_to_cpu(chrc->uuid16);
 			break;
 		case BT_UUID_TYPE_128:
-			memcpy(u.u128.val, chrc->uuid, sizeof(chrc->uuid));
+			(void)memcpy(u.u128.val,
+				      chrc->uuid, sizeof(chrc->uuid));
 			break;
 		}
 
@@ -2355,11 +2356,13 @@ static u16_t parse_service(struct bt_conn *conn, const void *pdu,
 
 		switch (u.uuid.type) {
 		case BT_UUID_TYPE_16:
-			memcpy(&u.u16.val, data->value, sizeof(u.u16.val));
+			(void)memcpy(&u.u16.val, data->value,
+				      sizeof(u.u16.val));
 			u.u16.val = sys_le16_to_cpu(u.u16.val);
 			break;
 		case BT_UUID_TYPE_128:
-			memcpy(u.u128.val, data->value, sizeof(u.u128.val));
+			(void)memcpy(u.u128.val, data->value,
+				      sizeof(u.u128.val));
 			break;
 		}
 
@@ -2501,7 +2504,7 @@ static void gatt_find_info_rsp(struct bt_conn *conn, u8_t err,
 			u.u16.val = sys_le16_to_cpu(info.i16->uuid);
 			break;
 		case BT_UUID_TYPE_128:
-			memcpy(u.u128.val, info.i128->uuid, 16);
+			(void)memcpy(u.u128.val, info.i128->uuid, 16);
 			break;
 		}
 
@@ -2887,7 +2890,7 @@ int bt_gatt_write_without_response_cb(struct bt_conn *conn, u16_t handle,
 
 	cmd = net_buf_add(buf, sizeof(*cmd));
 	cmd->handle = sys_cpu_to_le16(handle);
-	memcpy(cmd->value, data, length);
+	(void)memcpy(cmd->value, data, length);
 	net_buf_add(buf, length);
 
 	BT_DBG("handle 0x%04x length %u", handle, length);
@@ -2957,7 +2960,7 @@ static int gatt_prepare_write(struct bt_conn *conn,
 	req = net_buf_add(buf, sizeof(*req));
 	req->handle = sys_cpu_to_le16(params->handle);
 	req->offset = sys_cpu_to_le16(params->offset);
-	memcpy(req->value, params->data, len);
+	(void)memcpy(req->value, params->data, len);
 	net_buf_add(buf, len);
 
 	/* Update params */
@@ -2998,7 +3001,7 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params)
 
 	req = net_buf_add(buf, sizeof(*req));
 	req->handle = sys_cpu_to_le16(params->handle);
-	memcpy(req->value, params->data, params->length);
+	(void)memcpy(req->value, params->data, params->length);
 	net_buf_add(buf, params->length);
 
 	BT_DBG("handle 0x%04x length %u", params->handle, params->length);
@@ -3449,7 +3452,7 @@ static u8_t remove_peer_from_attr(const struct bt_gatt_attr *attr,
 	/* Check if there is a cfg for the peer */
 	cfg = ccc_find_cfg(ccc, addr_with_id->addr, addr_with_id->id);
 	if (cfg) {
-		memset(cfg, 0, sizeof(*cfg));
+		(void)memset(cfg, 0, sizeof(*cfg));
 	}
 
 	return BT_GATT_ITER_CONTINUE;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1301,8 +1301,8 @@ static void le_remote_feat_complete(struct net_buf *buf)
 	}
 
 	if (!evt->status) {
-		memcpy(conn->le.features, evt->features,
-		       sizeof(conn->le.features));
+		(void)memcpy(conn->le.features, evt->features,
+				sizeof(conn->le.features));
 	}
 
 	if (IS_ENABLED(CONFIG_BT_AUTO_PHY_UPDATE) &&
@@ -1960,7 +1960,7 @@ static void link_key_notify(struct net_buf *buf)
 					      BT_CONN_BR_LEGACY_SECURE)) {
 			conn->br.link_key->flags |= BT_LINK_KEY_AUTHENTICATED;
 		}
-		memcpy(conn->br.link_key->val, evt->link_key, 16);
+		(void)memcpy(conn->br.link_key->val, evt->link_key, 16);
 		break;
 	case BT_LK_AUTH_COMBINATION_P192:
 		conn->br.link_key->flags |= BT_LINK_KEY_AUTHENTICATED;
@@ -1971,7 +1971,7 @@ static void link_key_notify(struct net_buf *buf)
 			atomic_set_bit(conn->flags, BT_CONN_BR_NOBOND);
 		}
 
-		memcpy(conn->br.link_key->val, evt->link_key, 16);
+		(void)memcpy(conn->br.link_key->val, evt->link_key, 16);
 		break;
 	case BT_LK_AUTH_COMBINATION_P256:
 		conn->br.link_key->flags |= BT_LINK_KEY_AUTHENTICATED;
@@ -1984,7 +1984,7 @@ static void link_key_notify(struct net_buf *buf)
 			atomic_set_bit(conn->flags, BT_CONN_BR_NOBOND);
 		}
 
-		memcpy(conn->br.link_key->val, evt->link_key, 16);
+		(void)memcpy(conn->br.link_key->val, evt->link_key, 16);
 		break;
 	default:
 		BT_WARN("Unsupported Link Key type %u", evt->key_type);
@@ -2029,7 +2029,7 @@ static void link_key_reply(const bt_addr_t *bdaddr, const u8_t *lk)
 
 	cp = net_buf_add(buf, sizeof(*cp));
 	bt_addr_copy(&cp->bdaddr, bdaddr);
-	memcpy(cp->link_key, lk, 16);
+	(void)memcpy(cp->link_key, lk, 16);
 	bt_hci_cmd_send_sync(BT_HCI_OP_LINK_KEY_REPLY, buf, NULL);
 }
 
@@ -2436,7 +2436,7 @@ static void inquiry_result_with_rssi(struct net_buf *buf)
 		priv->pscan_rep_mode = evt->pscan_rep_mode;
 		priv->clock_offset = evt->clock_offset;
 
-		memcpy(result->cod, evt->cod, 3);
+		(void)memcpy(result->cod, evt->cod, 3);
 		result->rssi = evt->rssi;
 
 		/* we could reuse slot so make sure EIR is cleared */
@@ -2466,8 +2466,8 @@ static void extended_inquiry_result(struct net_buf *buf)
 	priv->clock_offset = evt->clock_offset;
 
 	result->rssi = evt->rssi;
-	memcpy(result->cod, evt->cod, 3);
-	memcpy(result->eir, evt->eir, sizeof(result->eir));
+	(void)memcpy(result->cod, evt->cod, 3);
+	(void)memcpy(result->eir, evt->eir, sizeof(result->eir));
 }
 
 static void remote_name_request_complete(struct net_buf *buf)
@@ -2515,7 +2515,7 @@ static void remote_name_request_complete(struct net_buf *buf)
 				eir[1] = EIR_SHORT_NAME;
 			}
 
-			memcpy(&eir[2], evt->name, eir[0] - 1);
+			(void)memcpy(&eir[2], evt->name, eir[0] - 1);
 
 			break;
 		}
@@ -2622,7 +2622,8 @@ static void read_remote_features_complete(struct net_buf *buf)
 		goto done;
 	}
 
-	memcpy(conn->br.features[0], evt->features, sizeof(evt->features));
+	(void)memcpy(conn->br.features[0],
+		      evt->features, sizeof(evt->features));
 
 	if (!BT_FEAT_EXT_FEATURES(conn->br.features)) {
 		goto done;
@@ -2660,8 +2661,8 @@ static void read_remote_ext_features_complete(struct net_buf *buf)
 	}
 
 	if (!evt->status && evt->page == 0x01) {
-		memcpy(conn->br.features[1], evt->features,
-		       sizeof(conn->br.features[1]));
+		(void)memcpy(conn->br.features[1], evt->features,
+				sizeof(conn->br.features[1]));
 	}
 
 	bt_conn_unref(conn);
@@ -2759,10 +2760,10 @@ static int hci_id_add(const bt_addr_le_t *addr, u8_t val[16])
 
 	cp = net_buf_add(buf, sizeof(*cp));
 	bt_addr_le_copy(&cp->peer_id_addr, addr);
-	memcpy(cp->peer_irk, val, 16);
+	(void)memcpy(cp->peer_irk, val, 16);
 
 #if defined(CONFIG_BT_PRIVACY)
-	memcpy(cp->local_irk, bt_dev.irk, 16);
+	(void)memcpy(cp->local_irk, bt_dev.irk, 16);
 #else
 	(void)memset(cp->local_irk, 0, 16);
 #endif
@@ -3158,7 +3159,7 @@ static void le_ltk_request(struct net_buf *buf)
 
 		cp = net_buf_add(buf, sizeof(*cp));
 		cp->handle = evt->handle;
-		memcpy(cp->ltk, tk, sizeof(cp->ltk));
+		(void)memcpy(cp->ltk, tk, sizeof(cp->ltk));
 
 		bt_hci_cmd_send(BT_HCI_OP_LE_LTK_REQ_REPLY, buf);
 		goto done;
@@ -3186,8 +3187,8 @@ static void le_ltk_request(struct net_buf *buf)
 		cp->handle = evt->handle;
 
 		/* use only enc_size bytes of key for encryption */
-		memcpy(cp->ltk, conn->le.keys->ltk.val,
-		       conn->le.keys->enc_size);
+		(void)memcpy(cp->ltk, conn->le.keys->ltk.val,
+				conn->le.keys->enc_size);
 		if (conn->le.keys->enc_size < sizeof(cp->ltk)) {
 			(void)memset(cp->ltk + conn->le.keys->enc_size, 0,
 				     sizeof(cp->ltk) - conn->le.keys->enc_size);
@@ -3212,8 +3213,8 @@ static void le_ltk_request(struct net_buf *buf)
 		cp->handle = evt->handle;
 
 		/* use only enc_size bytes of key for encryption */
-		memcpy(cp->ltk, conn->le.keys->slave_ltk.val,
-		       conn->le.keys->enc_size);
+		(void)memcpy(cp->ltk, conn->le.keys->slave_ltk.val,
+				conn->le.keys->enc_size);
 		if (conn->le.keys->enc_size < sizeof(cp->ltk)) {
 			(void)memset(cp->ltk + conn->le.keys->enc_size, 0,
 				     sizeof(cp->ltk) - conn->le.keys->enc_size);
@@ -3242,7 +3243,7 @@ static void le_pkey_complete(struct net_buf *buf)
 	atomic_clear_bit(bt_dev.flags, BT_DEV_PUB_KEY_BUSY);
 
 	if (!evt->status) {
-		memcpy(pub_key, evt->key, 64);
+		(void)memcpy(pub_key, evt->key, 64);
 		atomic_set_bit(bt_dev.flags, BT_DEV_HAS_PUB_KEY);
 	}
 
@@ -3884,7 +3885,8 @@ static void read_le_features_complete(struct net_buf *buf)
 
 	BT_DBG("status 0x%02x", rp->status);
 
-	memcpy(bt_dev.le.features, rp->features, sizeof(bt_dev.le.features));
+	(void)memcpy(bt_dev.le.features, rp->features,
+		      sizeof(bt_dev.le.features));
 }
 
 #if defined(CONFIG_BT_BREDR)
@@ -3952,8 +3954,8 @@ static void read_supported_commands_complete(struct net_buf *buf)
 
 	BT_DBG("status 0x%02x", rp->status);
 
-	memcpy(bt_dev.supported_commands, rp->commands,
-	       sizeof(bt_dev.supported_commands));
+	(void)memcpy(bt_dev.supported_commands, rp->commands,
+			sizeof(bt_dev.supported_commands));
 
 	/*
 	 * Report "LE Read Local P-256 Public Key" and "LE Generate DH Key" as
@@ -3971,7 +3973,8 @@ static void read_local_features_complete(struct net_buf *buf)
 
 	BT_DBG("status 0x%02x", rp->status);
 
-	memcpy(bt_dev.features[0], rp->features, sizeof(bt_dev.features[0]));
+	(void)memcpy(bt_dev.features[0], rp->features,
+		      sizeof(bt_dev.features[0]));
 }
 
 static void le_read_supp_states_complete(struct net_buf *buf)
@@ -4310,8 +4313,8 @@ static int read_ext_features(void)
 
 		rp = (void *)rsp->data;
 
-		memcpy(&bt_dev.features[i], rp->ext_features,
-		       sizeof(bt_dev.features[i]));
+		(void)memcpy(&bt_dev.features[i], rp->ext_features,
+				sizeof(bt_dev.features[i]));
 
 		if (rp->max_page <= i) {
 			net_buf_unref(rsp);
@@ -4726,7 +4729,8 @@ static void hci_vs_init(void)
 	}
 
 	rp.cmds = (void *)rsp->data;
-	memcpy(bt_dev.vs_commands, rp.cmds->commands, BT_DEV_VS_CMDS_MAX);
+	(void)memcpy(bt_dev.vs_commands, rp.cmds->commands,
+		      BT_DEV_VS_CMDS_MAX);
 	net_buf_unref(rsp);
 
 	err = bt_hci_cmd_send_sync(BT_HCI_OP_VS_READ_SUPPORTED_FEATURES,
@@ -4737,7 +4741,8 @@ static void hci_vs_init(void)
 	}
 
 	rp.feat = (void *)rsp->data;
-	memcpy(bt_dev.vs_features, rp.feat->features, BT_DEV_VS_FEAT_MAX);
+	(void)memcpy(bt_dev.vs_features, rp.feat->features,
+		      BT_DEV_VS_FEAT_MAX);
 	net_buf_unref(rsp);
 }
 #endif /* CONFIG_BT_HCI_VS_EXT */
@@ -5100,8 +5105,9 @@ static int set_ad(u16_t hci_op, const struct bt_ad *ad, size_t ad_len)
 			set_data->data[set_data->len++] = len + 1;
 			set_data->data[set_data->len++] = type;
 
-			memcpy(&set_data->data[set_data->len], data[i].data,
-			       len);
+			(void)memcpy(&set_data->data[set_data->len],
+					data[i].data,
+					len);
 			set_data->len += len;
 		}
 	}
@@ -5180,7 +5186,7 @@ void bt_id_get(bt_addr_le_t *addrs, size_t *count)
 {
 	size_t to_copy = MIN(*count, bt_dev.id_count);
 
-	memcpy(addrs, bt_dev.id_addr, to_copy * sizeof(bt_addr_le_t));
+	(void)memcpy(addrs, bt_dev.id_addr, to_copy * sizeof(bt_addr_le_t));
 	*count = to_copy;
 }
 
@@ -5221,11 +5227,11 @@ static void id_create(u8_t id, bt_addr_le_t *addr, u8_t *irk)
 		u8_t zero_irk[16] = { 0 };
 
 		if (irk && memcmp(irk, zero_irk, 16)) {
-			memcpy(&bt_dev.irk[id], irk, 16);
+			(void)memcpy(&bt_dev.irk[id], irk, 16);
 		} else {
 			bt_rand(&bt_dev.irk[id], 16);
 			if (irk) {
-				memcpy(irk, &bt_dev.irk[id], 16);
+				(void)memcpy(irk, &bt_dev.irk[id], 16);
 			}
 		}
 	}
@@ -5872,7 +5878,7 @@ int bt_le_set_chan_map(u8_t chan_map[5])
 
 	cp = net_buf_add(buf, sizeof(*cp));
 
-	memcpy(&cp->ch_map[0], &chan_map[0], 4);
+	(void)memcpy(&cp->ch_map[0], &chan_map[0], 4);
 	cp->ch_map[4] = chan_map[4] & BIT_MASK(5);
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_HOST_CHAN_CLASSIF,
@@ -5983,7 +5989,7 @@ static int br_start_inquiry(const struct bt_br_discovery_param *param)
 	cp->length = param->length;
 	cp->num_rsp = 0xff; /* we limit discovery only by time */
 
-	memcpy(cp->lap, iac, 3);
+	(void)memcpy(cp->lap, iac, 3);
 	if (param->limited) {
 		cp->lap[0] = 0x00;
 	}
@@ -6222,7 +6228,7 @@ int bt_dh_key_gen(const u8_t remote_pk[64], bt_dh_key_cb_t cb)
 	}
 
 	cp = net_buf_add(buf, sizeof(*cp));
-	memcpy(cp->key, remote_pk, sizeof(cp->key));
+	(void)memcpy(cp->key, remote_pk, sizeof(cp->key));
 
 	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_GENERATE_DHKEY, buf, NULL);
 	if (err) {

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -342,7 +342,7 @@ static int keys_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 		bt_keys_clear(keys);
 		return -EINVAL;
 	} else {
-		memcpy(keys->storage_start, val, len);
+		(void)memcpy(keys->storage_start, val, len);
 	}
 
 	BT_DBG("Successfully restored keys for %s", bt_addr_le_str(&addr));

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1210,8 +1210,8 @@ static int l2cap_chan_le_send_sdu(struct bt_l2cap_le_chan *ch,
 		if (ret < 0) {
 			if (ret == -EAGAIN) {
 				/* Store sent data into user_data */
-				memcpy(net_buf_user_data(frag), &sent,
-				       sizeof(sent));
+				(void)memcpy(net_buf_user_data(frag), &sent,
+						sizeof(sent));
 			}
 			*buf = frag;
 			return ret;
@@ -1230,8 +1230,8 @@ static int l2cap_chan_le_send_sdu(struct bt_l2cap_le_chan *ch,
 		if (ret < 0) {
 			if (ret == -EAGAIN) {
 				/* Store sent data into user_data */
-				memcpy(net_buf_user_data(frag), &sent,
-				       sizeof(sent));
+				(void)memcpy(net_buf_user_data(frag), &sent,
+						sizeof(sent));
 			}
 			*buf = frag;
 			return ret;
@@ -1468,7 +1468,7 @@ int bt_l2cap_chan_recv_complete(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	BT_DBG("chan %p buf %p", chan, buf);
 
 	/* Restore credits used by packet */
-	memcpy(&credits, net_buf_user_data(buf), sizeof(credits));
+	(void)memcpy(&credits, net_buf_user_data(buf), sizeof(credits));
 
 	l2cap_chan_send_credits(ch, buf, credits);
 
@@ -1522,7 +1522,7 @@ static void l2cap_chan_le_recv_seg(struct bt_l2cap_le_chan *chan,
 
 	len = net_buf_frags_len(chan->_sdu);
 	if (len) {
-		memcpy(&seg, net_buf_user_data(chan->_sdu), sizeof(seg));
+		(void)memcpy(&seg, net_buf_user_data(chan->_sdu), sizeof(seg));
 	}
 
 	if (len + buf->len > chan->_sdu_len) {
@@ -1533,7 +1533,7 @@ static void l2cap_chan_le_recv_seg(struct bt_l2cap_le_chan *chan,
 
 	seg++;
 	/* Store received segments in user_data */
-	memcpy(net_buf_user_data(chan->_sdu), &seg, sizeof(seg));
+	(void)memcpy(net_buf_user_data(chan->_sdu), &seg, sizeof(seg));
 
 	BT_DBG("chan %p seg %d len %zu", chan, seg, net_buf_frags_len(buf));
 

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -175,7 +175,7 @@ void bt_monitor_new_index(u8_t type, u8_t bus, bt_addr_t *addr,
 
 	pkt.type = type;
 	pkt.bus = bus;
-	memcpy(pkt.bdaddr, addr, 6);
+	(void)memcpy(pkt.bdaddr, addr, 6);
 	strncpy(pkt.name, name, sizeof(pkt.name) - 1);
 	pkt.name[sizeof(pkt.name) - 1] = '\0';
 

--- a/subsys/bluetooth/host/sdp.c
+++ b/subsys/bluetooth/host/sdp.c
@@ -372,7 +372,7 @@ static u32_t search_uuid(struct bt_sdp_data_elem *elem, struct bt_uuid *uuid,
 			}
 		} else if (seq_size == 16U) {
 			u.uuid.type = BT_UUID_TYPE_128;
-			memcpy(u.u128.val, cur_elem, seq_size);
+			(void)memcpy(u.u128.val, cur_elem, seq_size);
 			if (!bt_uuid_cmp(&u.uuid, uuid)) {
 				*found = true;
 			}
@@ -1813,8 +1813,8 @@ static int sdp_client_receive(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		 */
 		if (cstate->length) {
 			/* Cache original Continuation State in context */
-			memcpy(&session->cstate, cstate,
-			       sizeof(struct bt_sdp_pdu_cstate));
+			(void)memcpy(&session->cstate, cstate,
+					sizeof(struct bt_sdp_pdu_cstate));
 
 			net_buf_pull(buf, cstate->length +
 				     sizeof(cstate->length));
@@ -2341,9 +2341,9 @@ static int sdp_get_uuid_data(const struct bt_sdp_attr_item *attr,
 		/* check DTD and get stacked UUID value */
 		switch (p[0]) {
 		case BT_SDP_UUID16:
-			memcpy(&pd->uuid16,
-			       BT_UUID_DECLARE_16(sys_get_be16(++p)),
-			       sizeof(struct bt_uuid_16));
+			(void)memcpy(&pd->uuid16,
+					BT_UUID_DECLARE_16(sys_get_be16(++p)),
+					sizeof(struct bt_uuid_16));
 			p += sizeof(u16_t);
 			left -= sizeof(u16_t);
 			break;
@@ -2353,9 +2353,9 @@ static int sdp_get_uuid_data(const struct bt_sdp_attr_item *attr,
 				return -EMSGSIZE;
 			}
 
-			memcpy(&pd->uuid32,
-			       BT_UUID_DECLARE_32(sys_get_be32(++p)),
-			       sizeof(struct bt_uuid_32));
+			(void)memcpy(&pd->uuid32,
+					BT_UUID_DECLARE_32(sys_get_be32(++p)),
+					sizeof(struct bt_uuid_32));
 			p += sizeof(u32_t);
 			left -= sizeof(u32_t);
 			break;

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -492,11 +492,11 @@ static int smp_f6(const u8_t *w, const u8_t *n1, const u8_t *n2,
 	sys_memcpy_swap(m + 48, iocap, 3);
 
 	m[51] = a1->type;
-	memcpy(m + 52, a1->a.val, 6);
+	(void)memcpy(m + 52, a1->a.val, 6);
 	sys_memcpy_swap(m + 52, a1->a.val, 6);
 
 	m[58] = a2->type;
-	memcpy(m + 59, a2->a.val, 6);
+	(void)memcpy(m + 59, a2->a.val, 6);
 	sys_memcpy_swap(m + 59, a2->a.val, 6);
 
 	sys_memcpy_swap(ws, w, 16);
@@ -536,7 +536,7 @@ static int smp_g2(const u8_t u[32], const u8_t v[32],
 	}
 	BT_DBG("res %s", bt_hex(xs, 16));
 
-	memcpy(passkey, xs + 12, 4);
+	(void)memcpy(passkey, xs + 12, 4);
 	*passkey = sys_be32_to_cpu(*passkey) % 1000000;
 
 	BT_DBG("passkey %u", *passkey);
@@ -938,7 +938,7 @@ static void smp_br_distribute_keys(struct bt_smp_br *smp)
 		}
 
 		id_info = net_buf_add(buf, sizeof(*id_info));
-		memcpy(id_info->irk, bt_dev.irk[conn->id], 16);
+		(void)memcpy(id_info->irk, bt_dev.irk[conn->id], 16);
 
 		smp_br_send(smp, buf, NULL);
 
@@ -976,7 +976,7 @@ static void smp_br_distribute_keys(struct bt_smp_br *smp)
 
 		if (atomic_test_bit(smp->flags, SMP_FLAG_BOND)) {
 			bt_keys_add_type(keys, BT_KEYS_LOCAL_CSRK);
-			memcpy(keys->local_csrk.val, info->csrk, 16);
+			(void)memcpy(keys->local_csrk.val, info->csrk, 16);
 			keys->local_csrk.cnt = 0U;
 		}
 
@@ -1176,7 +1176,7 @@ static u8_t smp_br_ident_info(struct bt_smp_br *smp, struct net_buf *buf)
 		return BT_SMP_ERR_UNSPECIFIED;
 	}
 
-	memcpy(keys->irk.val, req->irk, sizeof(keys->irk.val));
+	(void)memcpy(keys->irk.val, req->irk, sizeof(keys->irk.val));
 
 	atomic_set_bit(&smp->allowed_cmds, BT_SMP_CMD_IDENT_ADDR_INFO);
 
@@ -1246,7 +1246,8 @@ static u8_t smp_br_signing_info(struct bt_smp_br *smp, struct net_buf *buf)
 		return BT_SMP_ERR_UNSPECIFIED;
 	}
 
-	memcpy(keys->remote_csrk.val, req->csrk, sizeof(keys->remote_csrk.val));
+	(void)memcpy(keys->remote_csrk.val, req->csrk,
+		      sizeof(keys->remote_csrk.val));
 
 	smp->remote_dist &= ~BT_SMP_DIST_SIGN;
 
@@ -1623,7 +1624,7 @@ static u8_t smp_send_pairing_random(struct bt_smp *smp)
 	}
 
 	req = net_buf_add(rsp_buf, sizeof(*req));
-	memcpy(req->val, smp->prnd, sizeof(req->val));
+	(void)memcpy(req->val, smp->prnd, sizeof(req->val));
 
 	smp_send(smp, rsp_buf, NULL, NULL);
 
@@ -1655,8 +1656,8 @@ static int smp_c1(const u8_t k[16], const u8_t r[16],
 	/* pres, preq, rat and iat are concatenated to generate p1 */
 	p1[0] = ia->type;
 	p1[1] = ra->type;
-	memcpy(p1 + 2, preq, 7);
-	memcpy(p1 + 9, pres, 7);
+	(void)memcpy(p1 + 2, preq, 7);
+	(void)memcpy(p1 + 9, pres, 7);
 
 	BT_DBG("p1 %s", bt_hex(p1, 16));
 
@@ -1671,8 +1672,8 @@ static int smp_c1(const u8_t k[16], const u8_t r[16],
 	}
 
 	/* ra is concatenated with ia and padding to generate p2 */
-	memcpy(p2, ra->a.val, 6);
-	memcpy(p2 + 6, ia->a.val, 6);
+	(void)memcpy(p2, ra->a.val, 6);
+	(void)memcpy(p2 + 6, ia->a.val, 6);
 	(void)memset(p2 + 12, 0, 4);
 
 	BT_DBG("p2 %s", bt_hex(p2, 16));
@@ -1763,7 +1764,7 @@ static void legacy_distribute_keys(struct bt_smp *smp)
 		info = net_buf_add(buf, sizeof(*info));
 
 		/* distributed only enc_size bytes of key */
-		memcpy(info->ltk, key, keys->enc_size);
+		(void)memcpy(info->ltk, key, keys->enc_size);
 		if (keys->enc_size < sizeof(info->ltk)) {
 			(void)memset(info->ltk + keys->enc_size, 0,
 				     sizeof(info->ltk) - keys->enc_size);
@@ -1779,19 +1780,19 @@ static void legacy_distribute_keys(struct bt_smp *smp)
 		}
 
 		ident = net_buf_add(buf, sizeof(*ident));
-		memcpy(ident->rand, rand, sizeof(ident->rand));
-		memcpy(ident->ediv, ediv, sizeof(ident->ediv));
+		(void)memcpy(ident->rand, rand, sizeof(ident->rand));
+		(void)memcpy(ident->ediv, ediv, sizeof(ident->ediv));
 
 		smp_send(smp, buf, ident_sent, NULL);
 
 		if (atomic_test_bit(smp->flags, SMP_FLAG_BOND)) {
 			bt_keys_add_type(keys, BT_KEYS_SLAVE_LTK);
 
-			memcpy(keys->slave_ltk.val, key,
-			       sizeof(keys->slave_ltk.val));
-			memcpy(keys->slave_ltk.rand, rand, sizeof(rand));
-			memcpy(keys->slave_ltk.ediv, ediv,
-			       sizeof(keys->slave_ltk.ediv));
+			(void)memcpy(keys->slave_ltk.val, key,
+					sizeof(keys->slave_ltk.val));
+			(void)memcpy(keys->slave_ltk.rand, rand, sizeof(rand));
+			(void)memcpy(keys->slave_ltk.ediv, ediv,
+					sizeof(keys->slave_ltk.ediv));
 		}
 	}
 }
@@ -1828,7 +1829,7 @@ static void bt_smp_distribute_keys(struct bt_smp *smp)
 		}
 
 		id_info = net_buf_add(buf, sizeof(*id_info));
-		memcpy(id_info->irk, bt_dev.irk[conn->id], 16);
+		(void)memcpy(id_info->irk, bt_dev.irk[conn->id], 16);
 
 		smp_send(smp, buf, NULL, NULL);
 
@@ -1864,7 +1865,7 @@ static void bt_smp_distribute_keys(struct bt_smp *smp)
 
 		if (atomic_test_bit(smp->flags, SMP_FLAG_BOND)) {
 			bt_keys_add_type(keys, BT_KEYS_LOCAL_CSRK);
-			memcpy(keys->local_csrk.val, info->csrk, 16);
+			(void)memcpy(keys->local_csrk.val, info->csrk, 16);
 			keys->local_csrk.cnt = 0U;
 		}
 
@@ -1886,7 +1887,7 @@ static u8_t send_pairing_rsp(struct bt_smp *smp)
 	}
 
 	rsp = net_buf_add(rsp_buf, sizeof(*rsp));
-	memcpy(rsp, smp->prsp + 1, sizeof(*rsp));
+	(void)memcpy(rsp, smp->prsp + 1, sizeof(*rsp));
 
 	smp_send(smp, rsp_buf, NULL, NULL);
 
@@ -1906,8 +1907,8 @@ static int smp_s1(const u8_t k[16], const u8_t r1[16],
 	 *
 	 *    r' = r1' || r2'
 	 */
-	memcpy(out, r2, 8);
-	memcpy(out + 8, r1, 8);
+	(void)memcpy(out, r2, 8);
+	(void)memcpy(out + 8, r1, 8);
 
 	/* s1(k, r1 , r2) = e(k, r') */
 	return bt_encrypt_le(k, out, out);
@@ -2105,7 +2106,7 @@ static u8_t legacy_pairing_random(struct bt_smp *smp)
 			return BT_SMP_ERR_UNSPECIFIED;
 		}
 
-		memcpy(smp->tk, tmp, sizeof(smp->tk));
+		(void)memcpy(smp->tk, tmp, sizeof(smp->tk));
 		BT_DBG("generated STK %s", bt_hex(smp->tk, 16));
 
 		atomic_set_bit(smp->flags, SMP_FLAG_ENC_PENDING);
@@ -2142,7 +2143,7 @@ static u8_t legacy_pairing_confirm(struct bt_smp *smp)
 static void legacy_passkey_entry(struct bt_smp *smp, unsigned int passkey)
 {
 	passkey = sys_cpu_to_le32(passkey);
-	memcpy(smp->tk, &passkey, sizeof(passkey));
+	(void)memcpy(smp->tk, &passkey, sizeof(passkey));
 
 	if (!atomic_test_and_clear_bit(smp->flags, SMP_FLAG_CFM_DELAYED)) {
 		return;
@@ -2181,7 +2182,7 @@ static u8_t smp_encrypt_info(struct bt_smp *smp, struct net_buf *buf)
 			return BT_SMP_ERR_UNSPECIFIED;
 		}
 
-		memcpy(keys->ltk.val, req->ltk, 16);
+		(void)memcpy(keys->ltk.val, req->ltk, 16);
 	}
 
 	atomic_set_bit(&smp->allowed_cmds, BT_SMP_CMD_MASTER_IDENT);
@@ -2206,8 +2207,9 @@ static u8_t smp_master_ident(struct bt_smp *smp, struct net_buf *buf)
 			return BT_SMP_ERR_UNSPECIFIED;
 		}
 
-		memcpy(keys->ltk.ediv, req->ediv, sizeof(keys->ltk.ediv));
-		memcpy(keys->ltk.rand, req->rand, sizeof(req->rand));
+		(void)memcpy(keys->ltk.ediv, req->ediv,
+			      sizeof(keys->ltk.ediv));
+		(void)memcpy(keys->ltk.rand, req->rand, sizeof(req->rand));
 
 		smp->remote_dist &= ~BT_SMP_DIST_ENC_KEY;
 	}
@@ -2439,7 +2441,7 @@ static u8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 
 	/* Store req for later use */
 	smp->preq[0] = BT_SMP_CMD_PAIRING_REQ;
-	memcpy(smp->preq + 1, req, sizeof(*req));
+	(void)memcpy(smp->preq + 1, req, sizeof(*req));
 
 	/* create rsp, it will be used later on */
 	smp->prsp[0] = BT_SMP_CMD_PAIRING_RSP;
@@ -2529,8 +2531,8 @@ static u8_t sc_send_public_key(struct bt_smp *smp)
 
 	req = net_buf_add(req_buf, sizeof(*req));
 
-	memcpy(req->x, sc_public_key, sizeof(req->x));
-	memcpy(req->y, &sc_public_key[32], sizeof(req->y));
+	(void)memcpy(req->x, sc_public_key, sizeof(req->x));
+	(void)memcpy(req->y, &sc_public_key[32], sizeof(req->y));
 
 	smp_send(smp, req_buf, NULL, NULL);
 
@@ -2594,7 +2596,7 @@ int bt_smp_send_pairing_req(struct bt_conn *conn)
 
 	/* Store req for later use */
 	smp->preq[0] = BT_SMP_CMD_PAIRING_REQ;
-	memcpy(smp->preq + 1, req, sizeof(*req));
+	(void)memcpy(smp->preq + 1, req, sizeof(*req));
 
 	smp_send(smp, req_buf, NULL, NULL);
 
@@ -2622,7 +2624,7 @@ static u8_t smp_pairing_rsp(struct bt_smp *smp, struct net_buf *buf)
 
 	/* Store rsp for later use */
 	smp->prsp[0] = BT_SMP_CMD_PAIRING_RSP;
-	memcpy(smp->prsp + 1, rsp, sizeof(*rsp));
+	(void)memcpy(smp->prsp + 1, rsp, sizeof(*rsp));
 
 	if ((rsp->auth_req & BT_SMP_AUTH_SC) &&
 	    (req->auth_req & BT_SMP_AUTH_SC)) {
@@ -2695,7 +2697,7 @@ static u8_t smp_pairing_confirm(struct bt_smp *smp, struct net_buf *buf)
 
 	atomic_clear_bit(smp->flags, SMP_FLAG_DISPLAY);
 
-	memcpy(smp->pcnf, req->val, sizeof(smp->pcnf));
+	(void)memcpy(smp->pcnf, req->val, sizeof(smp->pcnf));
 
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
 	    smp->chan.chan.conn->role == BT_HCI_ROLE_MASTER) {
@@ -2746,7 +2748,7 @@ static u8_t sc_smp_send_dhkey_check(struct bt_smp *smp, const u8_t *e)
 	}
 
 	req = net_buf_add(buf, sizeof(*req));
-	memcpy(req->e, e, sizeof(req->e));
+	(void)memcpy(req->e, e, sizeof(req->e));
 
 	smp_send(smp, buf, NULL, NULL);
 
@@ -2766,11 +2768,11 @@ static u8_t compute_and_send_master_dhcheck(struct bt_smp *smp)
 		break;
 	case PASSKEY_DISPLAY:
 	case PASSKEY_INPUT:
-		memcpy(r, &smp->passkey, sizeof(smp->passkey));
+		(void)memcpy(r, &smp->passkey, sizeof(smp->passkey));
 		break;
 	case LE_SC_OOB:
 		if (smp->oobd_remote) {
-			memcpy(r, smp->oobd_remote->r, sizeof(r));
+			(void)memcpy(r, smp->oobd_remote->r, sizeof(r));
 		}
 		break;
 	default:
@@ -2810,11 +2812,11 @@ static u8_t compute_and_check_and_send_slave_dhcheck(struct bt_smp *smp)
 		break;
 	case PASSKEY_DISPLAY:
 	case PASSKEY_INPUT:
-		memcpy(r, &smp->passkey, sizeof(smp->passkey));
+		(void)memcpy(r, &smp->passkey, sizeof(smp->passkey));
 		break;
 	case LE_SC_OOB:
 		if (smp->oobd_remote) {
-			memcpy(r, smp->oobd_remote->r, sizeof(r));
+			(void)memcpy(r, smp->oobd_remote->r, sizeof(r));
 		}
 		break;
 	default:
@@ -2838,9 +2840,9 @@ static u8_t compute_and_check_and_send_slave_dhcheck(struct bt_smp *smp)
 
 	if (smp->method == LE_SC_OOB) {
 		if (smp->oobd_local) {
-			memcpy(r, smp->oobd_local->r, sizeof(r));
+			(void)memcpy(r, smp->oobd_local->r, sizeof(r));
 		} else {
-			memset(r, 0, sizeof(r));
+			(void)memset(r, 0, sizeof(r));
 		}
 	}
 
@@ -2888,7 +2890,7 @@ static void bt_smp_dhkey_ready(const u8_t *dhkey)
 		return;
 	}
 
-	memcpy(smp->dhkey, dhkey, 32);
+	(void)memcpy(smp->dhkey, dhkey, 32);
 
 	/* wait for user passkey confirmation */
 	if (atomic_test_bit(smp->flags, SMP_FLAG_USER)) {
@@ -3019,7 +3021,7 @@ static u8_t smp_pairing_random(struct bt_smp *smp, struct net_buf *buf)
 
 	BT_DBG("");
 
-	memcpy(smp->rrnd, req->val, sizeof(smp->rrnd));
+	(void)memcpy(smp->rrnd, req->val, sizeof(smp->rrnd));
 
 #if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
 	if (!atomic_test_bit(smp->flags, SMP_FLAG_SC)) {
@@ -3196,7 +3198,7 @@ static u8_t smp_ident_info(struct bt_smp *smp, struct net_buf *buf)
 			return BT_SMP_ERR_UNSPECIFIED;
 		}
 
-		memcpy(keys->irk.val, req->irk, 16);
+		(void)memcpy(keys->irk.val, req->irk, 16);
 	}
 
 	atomic_set_bit(&smp->allowed_cmds, BT_SMP_CMD_IDENT_ADDR_INFO);
@@ -3299,8 +3301,8 @@ static u8_t smp_signing_info(struct bt_smp *smp, struct net_buf *buf)
 			return BT_SMP_ERR_UNSPECIFIED;
 		}
 
-		memcpy(keys->remote_csrk.val, req->csrk,
-		       sizeof(keys->remote_csrk.val));
+		(void)memcpy(keys->remote_csrk.val, req->csrk,
+				sizeof(keys->remote_csrk.val));
 	}
 
 	smp->remote_dist &= ~BT_SMP_DIST_SIGN;
@@ -3490,8 +3492,8 @@ static u8_t smp_public_key(struct bt_smp *smp, struct net_buf *buf)
 
 	BT_DBG("");
 
-	memcpy(smp->pkey, req->x, 32);
-	memcpy(&smp->pkey[32], req->y, 32);
+	(void)memcpy(smp->pkey, req->x, 32);
+	(void)memcpy(&smp->pkey[32], req->y, 32);
 
 	/* mark key as debug if remote is using it */
 	if (memcmp(smp->pkey, sc_debug_public_key, 64) == 0) {
@@ -3591,11 +3593,11 @@ static u8_t smp_dhkey_check(struct bt_smp *smp, struct net_buf *buf)
 			break;
 		case PASSKEY_DISPLAY:
 		case PASSKEY_INPUT:
-			memcpy(r, &smp->passkey, sizeof(smp->passkey));
+			(void)memcpy(r, &smp->passkey, sizeof(smp->passkey));
 			break;
 		case LE_SC_OOB:
 			if (smp->oobd_local) {
-				memcpy(r, smp->oobd_local->r, sizeof(r));
+				(void)memcpy(r, smp->oobd_local->r, sizeof(r));
 			}
 			break;
 		default:
@@ -3630,7 +3632,7 @@ static u8_t smp_dhkey_check(struct bt_smp *smp, struct net_buf *buf)
 #if defined(CONFIG_BT_PERIPHERAL)
 	if (smp->chan.chan.conn->role == BT_HCI_ROLE_SLAVE) {
 		atomic_clear_bit(smp->flags, SMP_FLAG_DHCHECK_WAIT);
-		memcpy(smp->e, req->e, sizeof(smp->e));
+		(void)memcpy(smp->e, req->e, sizeof(smp->e));
 
 		/* wait for DHKey being generated */
 		if (atomic_test_bit(smp->flags, SMP_FLAG_DHKEY_PENDING)) {
@@ -3900,12 +3902,12 @@ static int smp_sign_buf(const u8_t *key, u8_t *msg, u16_t len)
 	}
 
 	sys_mem_swap(tmp, sizeof(tmp));
-	memcpy(tmp + 4, &cnt, sizeof(cnt));
+	(void)memcpy(tmp + 4, &cnt, sizeof(cnt));
 
 	/* Swap original message back */
 	sys_mem_swap(m, len + sizeof(cnt));
 
-	memcpy(sig, tmp + 4, 12);
+	(void)memcpy(sig, tmp + 4, 12);
 
 	BT_DBG("sig %s", bt_hex(sig, 12));
 
@@ -3922,7 +3924,7 @@ int bt_smp_sign_verify(struct bt_conn *conn, struct net_buf *buf)
 	int err;
 
 	/* Store signature incl. count */
-	memcpy(sig, net_buf_tail(buf) - sizeof(sig), sizeof(sig));
+	(void)memcpy(sig, net_buf_tail(buf) - sizeof(sig), sizeof(sig));
 
 	keys = bt_keys_find(BT_KEYS_REMOTE_CSRK, conn->id, &conn->le.dst);
 	if (!keys) {
@@ -3933,7 +3935,7 @@ int bt_smp_sign_verify(struct bt_conn *conn, struct net_buf *buf)
 
 	/* Copy signing count */
 	cnt = sys_cpu_to_le32(keys->remote_csrk.cnt);
-	memcpy(net_buf_tail(buf) - sizeof(sig), &cnt, sizeof(cnt));
+	(void)memcpy(net_buf_tail(buf) - sizeof(sig), &cnt, sizeof(cnt));
 
 	BT_DBG("Sign data len %zu key %s count %u", buf->len - sizeof(sig),
 	       bt_hex(keys->remote_csrk.val, 16), keys->remote_csrk.cnt);
@@ -3975,7 +3977,7 @@ int bt_smp_sign(struct bt_conn *conn, struct net_buf *buf)
 
 	/* Copy signing count */
 	cnt = sys_cpu_to_le32(keys->local_csrk.cnt);
-	memcpy(net_buf_tail(buf) - 12, &cnt, sizeof(cnt));
+	(void)memcpy(net_buf_tail(buf) - 12, &cnt, sizeof(cnt));
 
 	BT_DBG("Sign data len %u key %s count %u", buf->len,
 	       bt_hex(keys->local_csrk.val, 16), keys->local_csrk.cnt);
@@ -4096,10 +4098,10 @@ static int sign_test(const char *prefix, const u8_t *key, const u8_t *m,
 	BT_DBG("%s: Sign message with len %u", prefix, len);
 
 	(void)memset(msg, 0, sizeof(msg));
-	memcpy(msg, m, len);
+	(void)memcpy(msg, m, len);
 	(void)memset(msg + len, 0, sizeof(u32_t));
 
-	memcpy(orig, msg, sizeof(msg));
+	(void)memcpy(orig, msg, sizeof(msg));
 
 	err = smp_sign_buf(key, msg, len);
 	if (err) {
@@ -4518,7 +4520,7 @@ int bt_smp_le_oob_generate_sc_data(struct bt_le_oob_sc_data *le_sc_oob)
 			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 		};
 
-		memcpy(le_sc_oob->r, rand_num, sizeof(le_sc_oob->r));
+		(void)memcpy(le_sc_oob->r, rand_num, sizeof(le_sc_oob->r));
 	} else {
 		err = bt_rand(le_sc_oob->r, 16);
 		if (err) {
@@ -4805,8 +4807,8 @@ void bt_smp_update_keys(struct bt_conn *conn)
 
 		if (atomic_test_bit(smp->flags, SMP_FLAG_BOND)) {
 			bt_keys_add_type(conn->le.keys, BT_KEYS_LTK_P256);
-			memcpy(conn->le.keys->ltk.val, smp->tk,
-			       sizeof(conn->le.keys->ltk.val));
+			(void)memcpy(conn->le.keys->ltk.val, smp->tk,
+					sizeof(conn->le.keys->ltk.val));
 			(void)memset(conn->le.keys->ltk.rand, 0,
 				     sizeof(conn->le.keys->ltk.rand));
 			(void)memset(conn->le.keys->ltk.ediv, 0,
@@ -4841,7 +4843,7 @@ bool bt_smp_get_tk(struct bt_conn *conn, u8_t *tk)
 	 * We keep both legacy STK and LE SC LTK in TK.
 	 * Also use only enc_size bytes of key for encryption.
 	 */
-	memcpy(tk, smp->tk, enc_size);
+	(void)memcpy(tk, smp->tk, enc_size);
 	if (enc_size < sizeof(smp->tk)) {
 		(void)memset(tk + enc_size, 0, sizeof(smp->tk) - enc_size);
 	}

--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -46,7 +46,7 @@ static void uuid_to_uuid128(const struct bt_uuid *src, struct bt_uuid_128 *dst)
 			     &dst->val[UUID_16_BASE_OFFSET]);
 		return;
 	case BT_UUID_TYPE_128:
-		memcpy(dst, src, sizeof(*dst));
+		(void)memcpy(dst, src, sizeof(*dst));
 		return;
 	}
 }
@@ -90,7 +90,7 @@ bool bt_uuid_create_le(struct bt_uuid *uuid, const u8_t *data, u8_t data_len)
 		break;
 	case 16:
 		uuid->type = BT_UUID_TYPE_128;
-		memcpy(&BT_UUID_128(uuid)->val, data, 16);
+		(void)memcpy(&BT_UUID_128(uuid)->val, data, 16);
 		break;
 	default:
 		return false;
@@ -119,7 +119,7 @@ bool bt_uuid_create(struct bt_uuid *uuid, u8_t *data, u8_t data_len)
 		break;
 	case 16:
 		uuid->type = BT_UUID_TYPE_128;
-		memcpy(&BT_UUID_128(uuid)->val, v.u128, 16);
+		(void)memcpy(&BT_UUID_128(uuid)->val, v.u128, 16);
 		break;
 	default:
 		return false;
@@ -141,12 +141,12 @@ void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len)
 		snprintk(str, len, "%04x", BT_UUID_32(uuid)->val);
 		break;
 	case BT_UUID_TYPE_128:
-		memcpy(&tmp0, &BT_UUID_128(uuid)->val[0], sizeof(tmp0));
-		memcpy(&tmp1, &BT_UUID_128(uuid)->val[2], sizeof(tmp1));
-		memcpy(&tmp2, &BT_UUID_128(uuid)->val[6], sizeof(tmp2));
-		memcpy(&tmp3, &BT_UUID_128(uuid)->val[8], sizeof(tmp3));
-		memcpy(&tmp4, &BT_UUID_128(uuid)->val[10], sizeof(tmp4));
-		memcpy(&tmp5, &BT_UUID_128(uuid)->val[12], sizeof(tmp5));
+		(void)memcpy(&tmp0, &BT_UUID_128(uuid)->val[0], sizeof(tmp0));
+		(void)memcpy(&tmp1, &BT_UUID_128(uuid)->val[2], sizeof(tmp1));
+		(void)memcpy(&tmp2, &BT_UUID_128(uuid)->val[6], sizeof(tmp2));
+		(void)memcpy(&tmp3, &BT_UUID_128(uuid)->val[8], sizeof(tmp3));
+		(void)memcpy(&tmp4, &BT_UUID_128(uuid)->val[10], sizeof(tmp4));
+		(void)memcpy(&tmp5, &BT_UUID_128(uuid)->val[12], sizeof(tmp5));
 
 		snprintk(str, len, "%08x-%04x-%04x-%04x-%08x%04x",
 			 tmp5, tmp4, tmp3, tmp2, tmp1, tmp0);

--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -62,7 +62,7 @@ static struct bt_mesh_subnet *cache_check(u8_t data[21])
 
 static void cache_add(u8_t data[21], struct bt_mesh_subnet *sub)
 {
-	memcpy(sub->beacon_cache, data, 21);
+	(void)memcpy(sub->beacon_cache, data, 21);
 }
 
 static void beacon_complete(int err, void *user_data)

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -421,7 +421,7 @@ static u8_t app_key_set(u16_t net_idx, u16_t app_idx, const u8_t val[16],
 
 	key->net_idx = net_idx;
 	key->app_idx = app_idx;
-	memcpy(keys->val, val, 16);
+	(void)memcpy(keys->val, val, 16);
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		BT_DBG("Storing AppKey persistently");
@@ -981,9 +981,9 @@ static void send_mod_pub_status(struct bt_mesh_model *cfg_mod,
 	}
 
 	if (vnd) {
-		memcpy(net_buf_simple_add(&msg, 4), mod_id, 4);
+		(void)memcpy(net_buf_simple_add(&msg, 4), mod_id, 4);
 	} else {
-		memcpy(net_buf_simple_add(&msg, 2), mod_id, 2);
+		(void)memcpy(net_buf_simple_add(&msg, 2), mod_id, 2);
 	}
 
 	if (bt_mesh_model_send(cfg_mod, ctx, &msg, NULL, NULL)) {
@@ -1129,7 +1129,7 @@ static u8_t va_add(u8_t *label_uuid, u16_t *addr)
 
 	free_slot->ref = 1U;
 	free_slot->addr = *addr;
-	memcpy(free_slot->uuid, label_uuid, 16);
+	(void)memcpy(free_slot->uuid, label_uuid, 16);
 
 	return STATUS_SUCCESS;
 }
@@ -1337,9 +1337,9 @@ static void send_mod_sub_status(struct bt_mesh_model *model,
 	net_buf_simple_add_le16(&msg, sub_addr);
 
 	if (vnd) {
-		memcpy(net_buf_simple_add(&msg, 4), mod_id, 4);
+		(void)memcpy(net_buf_simple_add(&msg, 4), mod_id, 4);
 	} else {
-		memcpy(net_buf_simple_add(&msg, 2), mod_id, 2);
+		(void)memcpy(net_buf_simple_add(&msg, 2), mod_id, 2);
 	}
 
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
@@ -2418,9 +2418,9 @@ static void create_mod_app_status(struct net_buf_simple *msg,
 	net_buf_simple_add_le16(msg, app_idx);
 
 	if (vnd) {
-		memcpy(net_buf_simple_add(msg, 4), mod_id, 4);
+		(void)memcpy(net_buf_simple_add(msg, 4), mod_id, 4);
 	} else {
-		memcpy(net_buf_simple_add(msg, 2), mod_id, 2);
+		(void)memcpy(net_buf_simple_add(msg, 2), mod_id, 2);
 	}
 }
 
@@ -2896,8 +2896,9 @@ static void hb_pub_send_status(struct bt_mesh_model *model,
 	net_buf_simple_add_u8(&msg, status);
 
 	if (orig_msg) {
-		memcpy(net_buf_simple_add(&msg, sizeof(*orig_msg)), orig_msg,
-		       sizeof(*orig_msg));
+		(void)memcpy(net_buf_simple_add(&msg, sizeof(*orig_msg)),
+				orig_msg,
+				sizeof(*orig_msg));
 		goto send;
 	}
 

--- a/subsys/bluetooth/mesh/crypto.c
+++ b/subsys/bluetooth/mesh/crypto.c
@@ -118,7 +118,7 @@ int bt_mesh_k2(const u8_t n[16], const u8_t *p, size_t p_len,
 		return err;
 	}
 
-	memcpy(enc_key, out, 16);
+	(void)memcpy(enc_key, out, 16);
 
 	pad = 0x03;
 
@@ -127,7 +127,7 @@ int bt_mesh_k2(const u8_t n[16], const u8_t *p, size_t p_len,
 		return err;
 	}
 
-	memcpy(priv_key, out, 16);
+	(void)memcpy(priv_key, out, 16);
 
 	BT_DBG("NID 0x%02x enc_key %s", net_id[0], bt_hex(enc_key, 16));
 	BT_DBG("priv_key %s", bt_hex(priv_key, 16));
@@ -157,7 +157,7 @@ int bt_mesh_k3(const u8_t n[16], u8_t out[8])
 		return err;
 	}
 
-	memcpy(out, tmp + 8, 8);
+	(void)memcpy(out, tmp + 8, 8);
 
 	return 0;
 }
@@ -219,7 +219,7 @@ static int bt_mesh_ccm_decrypt(const u8_t key[16], u8_t nonce[13],
 
 	/* C_mic = e(AppKey, 0x01 || nonce || 0x0000) */
 	pmsg[0] = 0x01;
-	memcpy(pmsg + 1, nonce, 13);
+	(void)memcpy(pmsg + 1, nonce, 13);
 	sys_put_be16(0x0000, pmsg + 14);
 
 	err = bt_encrypt_be(key, pmsg, cmic);
@@ -234,7 +234,7 @@ static int bt_mesh_ccm_decrypt(const u8_t key[16], u8_t nonce[13],
 		pmsg[0] = 0x09 | (aad_len ? 0x40 : 0x00);
 	}
 
-	memcpy(pmsg + 1, nonce, 13);
+	(void)memcpy(pmsg + 1, nonce, 13);
 	sys_put_be16(msg_len, pmsg + 14);
 
 	err = bt_encrypt_be(key, pmsg, Xn);
@@ -291,7 +291,7 @@ static int bt_mesh_ccm_decrypt(const u8_t key[16], u8_t nonce[13],
 		if (j + 1 == blk_cnt) {
 			/* C_1 = e(AppKey, 0x01 || nonce || 0x0001) */
 			pmsg[0] = 0x01;
-			memcpy(pmsg + 1, nonce, 13);
+			(void)memcpy(pmsg + 1, nonce, 13);
 			sys_put_be16(j + 1, pmsg + 14);
 
 			err = bt_encrypt_be(key, pmsg, cmsg);
@@ -304,7 +304,7 @@ static int bt_mesh_ccm_decrypt(const u8_t key[16], u8_t nonce[13],
 				msg[i] = enc_msg[(j * 16) + i] ^ cmsg[i];
 			}
 
-			memcpy(out_msg + (j * 16), msg, last_blk);
+			(void)memcpy(out_msg + (j * 16), msg, last_blk);
 
 			/* X_1 = e(AppKey, X_0 ^ Payload[0-15]) */
 			for (i = 0; i < last_blk; i++) {
@@ -327,7 +327,7 @@ static int bt_mesh_ccm_decrypt(const u8_t key[16], u8_t nonce[13],
 		} else {
 			/* C_1 = e(AppKey, 0x01 || nonce || 0x0001) */
 			pmsg[0] = 0x01;
-			memcpy(pmsg + 1, nonce, 13);
+			(void)memcpy(pmsg + 1, nonce, 13);
 			sys_put_be16(j + 1, pmsg + 14);
 
 			err = bt_encrypt_be(key, pmsg, cmsg);
@@ -340,7 +340,7 @@ static int bt_mesh_ccm_decrypt(const u8_t key[16], u8_t nonce[13],
 				msg[i] = enc_msg[(j * 16) + i] ^ cmsg[i];
 			}
 
-			memcpy(out_msg + (j * 16), msg, 16);
+			(void)memcpy(out_msg + (j * 16), msg, 16);
 
 			/* X_1 = e(AppKey, X_0 ^ Payload[0-15]) */
 			for (i = 0; i < 16; i++) {
@@ -383,7 +383,7 @@ static int bt_mesh_ccm_encrypt(const u8_t key[16], u8_t nonce[13],
 
 	/* C_mic = e(AppKey, 0x01 || nonce || 0x0000) */
 	pmsg[0] = 0x01;
-	memcpy(pmsg + 1, nonce, 13);
+	(void)memcpy(pmsg + 1, nonce, 13);
 	sys_put_be16(0x0000, pmsg + 14);
 
 	err = bt_encrypt_be(key, pmsg, cmic);
@@ -398,7 +398,7 @@ static int bt_mesh_ccm_encrypt(const u8_t key[16], u8_t nonce[13],
 		pmsg[0] = 0x09 | (aad_len ? 0x40 : 0x00);
 	}
 
-	memcpy(pmsg + 1, nonce, 13);
+	(void)memcpy(pmsg + 1, nonce, 13);
 	sys_put_be16(msg_len, pmsg + 14);
 
 	err = bt_encrypt_be(key, pmsg, Xn);
@@ -473,7 +473,7 @@ static int bt_mesh_ccm_encrypt(const u8_t key[16], u8_t nonce[13],
 
 			/* C_1 = e(AppKey, 0x01 || nonce || 0x0001) */
 			pmsg[0] = 0x01;
-			memcpy(pmsg + 1, nonce, 13);
+			(void)memcpy(pmsg + 1, nonce, 13);
 			sys_put_be16(j + 1, pmsg + 14);
 
 			err = bt_encrypt_be(key, pmsg, cmsg);
@@ -499,7 +499,7 @@ static int bt_mesh_ccm_encrypt(const u8_t key[16], u8_t nonce[13],
 
 			/* C_1 = e(AppKey, 0x01 || nonce || 0x0001) */
 			pmsg[0] = 0x01;
-			memcpy(pmsg + 1, nonce, 13);
+			(void)memcpy(pmsg + 1, nonce, 13);
 			sys_put_be16(j + 1, pmsg + 14);
 
 			err = bt_encrypt_be(key, pmsg, cmsg);
@@ -516,7 +516,7 @@ static int bt_mesh_ccm_encrypt(const u8_t key[16], u8_t nonce[13],
 		}
 	}
 
-	memcpy(out_msg + msg_len, mic, mic_size);
+	(void)memcpy(out_msg + msg_len, mic, mic_size);
 
 	return 0;
 }
@@ -585,7 +585,7 @@ int bt_mesh_net_obfuscate(u8_t *pdu, u32_t iv_index,
 	BT_DBG("IVIndex %u, PrivacyKey %s", iv_index, bt_hex(privacy_key, 16));
 
 	sys_put_be32(iv_index, &priv_rand[5]);
-	memcpy(&priv_rand[9], &pdu[7], 7);
+	(void)memcpy(&priv_rand[9], &pdu[7], 7);
 
 	BT_DBG("PrivacyRandom %s", bt_hex(priv_rand, 16));
 
@@ -862,14 +862,14 @@ int bt_mesh_beacon_auth(const u8_t beacon_key[16], u8_t flags,
 	BT_DBG("IV Index 0x%08x", iv_index);
 
 	msg[0] = flags;
-	memcpy(&msg[1], net_id, 8);
+	(void)memcpy(&msg[1], net_id, 8);
 	sys_put_be32(iv_index, &msg[9]);
 
 	BT_DBG("BeaconMsg %s", bt_hex(msg, sizeof(msg)));
 
 	err = bt_mesh_aes_cmac_one(beacon_key, msg, sizeof(msg), tmp);
 	if (!err) {
-		memcpy(auth, tmp, 8);
+		(void)memcpy(auth, tmp, 8);
 	}
 
 	return err;

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -78,7 +78,7 @@ static void health_fault_status(struct bt_mesh_model *model,
 		*param->fault_count = buf->len;
 	}
 
-	memcpy(param->faults, buf->data, *param->fault_count);
+	(void)memcpy(param->faults, buf->data, *param->fault_count);
 
 	k_sem_give(&health_cli->op_sync);
 }

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -74,7 +74,7 @@ int bt_mesh_provision(const u8_t net_key[16], u16_t net_idx,
 
 	bt_mesh_comp_provision(addr);
 
-	memcpy(bt_mesh.dev_key, dev_key, 16);
+	(void)memcpy(bt_mesh.dev_key, dev_key, 16);
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		BT_DBG("Storing network information persistently");
@@ -97,7 +97,7 @@ void bt_mesh_reset(void)
 	bt_mesh.iv_index = 0U;
 	bt_mesh.seq = 0U;
 
-	memset(bt_mesh.flags, 0, sizeof(bt_mesh.flags));
+	(void)memset(bt_mesh.flags, 0, sizeof(bt_mesh.flags));
 
 	k_delayed_work_cancel(&bt_mesh.ivu_timer);
 
@@ -149,7 +149,7 @@ int bt_mesh_prov_enable(bt_mesh_prov_bearer_t bearers)
 		const struct bt_mesh_prov *prov = bt_mesh_prov_get();
 		struct bt_uuid_128 uuid = { .uuid.type = BT_UUID_TYPE_128 };
 
-		memcpy(uuid.val, prov->uuid, 16);
+		(void)memcpy(uuid.val, prov->uuid, 16);
 		BT_INFO("Device UUID: %s", bt_uuid_str(&uuid.uuid));
 	}
 

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -119,7 +119,7 @@ static u64_t msg_hash(struct bt_mesh_net_rx *rx, struct net_buf_simple *pdu)
 	hash1 = (BT_MESH_NET_IVI_RX(rx) << 8) | pdu->data[2];
 
 	/* Two last bytes of SEQ + SRC */
-	memcpy(&hash2, &pdu->data[3], 4);
+	(void)memcpy(&hash2, &pdu->data[3], 4);
 
 	return (u64_t)hash1 << 32 | (u64_t)hash2;
 }
@@ -174,7 +174,7 @@ int bt_mesh_net_keys_create(struct bt_mesh_subnet_keys *keys,
 		return err;
 	}
 
-	memcpy(keys->net, key, 16);
+	(void)memcpy(keys->net, key, 16);
 
 	keys->nid = nid;
 
@@ -264,8 +264,8 @@ void friend_cred_refresh(u16_t net_idx)
 
 		if (cred->addr != BT_MESH_ADDR_UNASSIGNED &&
 		    cred->net_idx == net_idx) {
-			memcpy(&cred->cred[0], &cred->cred[1],
-			       sizeof(cred->cred[0]));
+			(void)memcpy(&cred->cred[0], &cred->cred[1],
+					sizeof(cred->cred[0]));
 		}
 	}
 }
@@ -499,7 +499,7 @@ void bt_mesh_net_revoke_keys(struct bt_mesh_subnet *sub)
 
 	BT_DBG("idx 0x%04x", sub->net_idx);
 
-	memcpy(&sub->keys[0], &sub->keys[1], sizeof(sub->keys[0]));
+	(void)memcpy(&sub->keys[0], &sub->keys[1], sizeof(sub->keys[0]));
 
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.app_keys); i++) {
 		struct bt_mesh_app_key *key = &bt_mesh.app_keys[i];
@@ -508,7 +508,8 @@ void bt_mesh_net_revoke_keys(struct bt_mesh_subnet *sub)
 			continue;
 		}
 
-		memcpy(&key->keys[0], &key->keys[1], sizeof(key->keys[0]));
+		(void)memcpy(&key->keys[0], &key->keys[1],
+			      sizeof(key->keys[0]));
 		key->updated = false;
 	}
 }
@@ -994,7 +995,7 @@ static int net_decrypt(struct bt_mesh_subnet *sub, const u8_t *enc,
 	rx->old_iv = (IVI(data) != (bt_mesh.iv_index & 0x01));
 
 	net_buf_simple_reset(buf);
-	memcpy(net_buf_simple_add(buf, data_len), data, data_len);
+	(void)memcpy(net_buf_simple_add(buf, data_len), data, data_len);
 
 	if (bt_mesh_net_obfuscate(buf->data, BT_MESH_NET_IVI_RX(rx), priv)) {
 		return -ENOENT;

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -567,7 +567,7 @@ static void prov_invite(const u8_t *data)
 	/* Input OOB Action */
 	net_buf_simple_add_be16(&buf, prov->input_actions);
 
-	memcpy(&link.conf_inputs[1], &buf.data[1], 11);
+	(void)memcpy(&link.conf_inputs[1], &buf.data[1], 11);
 
 	if (prov_send(&buf)) {
 		BT_ERR("Failed to send capabilities");
@@ -651,8 +651,8 @@ static int prov_auth(u8_t method, u8_t action, u8_t size)
 			return -EINVAL;
 		}
 
-		memcpy(link.auth + 16 - prov->static_val_len,
-		       prov->static_val, prov->static_val_len);
+		(void)memcpy(link.auth + 16 - prov->static_val_len,
+				prov->static_val, prov->static_val_len);
 		(void)memset(link.auth, 0,
 			     sizeof(link.auth) - prov->static_val_len);
 		return 0;
@@ -688,7 +688,7 @@ static int prov_auth(u8_t method, u8_t action, u8_t size)
 			}
 			str[size] = '\0';
 
-			memcpy(link.auth, str, size);
+			(void)memcpy(link.auth, str, size);
 			(void)memset(link.auth + size, 0,
 				     sizeof(link.auth) - size);
 
@@ -754,7 +754,7 @@ static void prov_start(const u8_t *data)
 		return;
 	}
 
-	memcpy(&link.conf_inputs[12], data, 5);
+	(void)memcpy(&link.conf_inputs[12], data, 5);
 
 	link.expect = PROV_PUB_KEY;
 
@@ -895,7 +895,7 @@ static void send_pub_key(const u8_t dhkey[32])
 	sys_memcpy_swap(net_buf_simple_add(&buf, 32), key, 32);
 	sys_memcpy_swap(net_buf_simple_add(&buf, 32), &key[32], 32);
 
-	memcpy(&link.conf_inputs[81], &buf.data[1], 64);
+	(void)memcpy(&link.conf_inputs[81], &buf.data[1], 64);
 
 	if (prov_send(&buf)) {
 		BT_ERR("Failed to send Public Key");
@@ -928,7 +928,7 @@ static void prov_pub_key(const u8_t *data)
 {
 	BT_DBG("Remote Public Key: %s", bt_hex(data, 64));
 
-	memcpy(&link.conf_inputs[17], data, 64);
+	(void)memcpy(&link.conf_inputs[17], data, 64);
 
 	if (!bt_pub_key_get()) {
 		/* Clear retransmit timer */
@@ -966,7 +966,7 @@ static void prov_confirm(const u8_t *data)
 {
 	BT_DBG("Remote Confirm: %s", bt_hex(data, 16));
 
-	memcpy(link.conf, data, 16);
+	(void)memcpy(link.conf, data, 16);
 
 	if (atomic_test_bit(link.flags, WAIT_NUMBER) ||
 	    atomic_test_bit(link.flags, WAIT_STRING)) {
@@ -1355,7 +1355,7 @@ static void gen_prov_cont(struct prov_rx *rx, struct net_buf_simple *buf)
 		return;
 	}
 
-	memcpy(XACT_SEG_DATA(seg), buf->data, buf->len);
+	(void)memcpy(XACT_SEG_DATA(seg), buf->data, buf->len);
 	XACT_SEG_RECV(seg);
 
 	if (!link.rx.seg) {
@@ -1417,7 +1417,7 @@ static void gen_prov_start(struct prov_rx *rx, struct net_buf_simple *buf)
 
 	link.rx.seg = (1 << (START_LAST_SEG(rx->gpc) + 1)) - 1;
 	link.rx.last_seg = START_LAST_SEG(rx->gpc);
-	memcpy(link.rx.buf->data, buf->data, buf->len);
+	(void)memcpy(link.rx.buf->data, buf->data, buf->len);
 	XACT_SEG_RECV(0);
 
 	if (!link.rx.seg) {

--- a/subsys/bluetooth/mesh/proxy.c
+++ b/subsys/bluetooth/mesh/proxy.c
@@ -1037,7 +1037,7 @@ static int node_id_adv(struct bt_mesh_subnet *sub)
 	}
 
 	(void)memset(tmp, 0, 6);
-	memcpy(tmp + 6, proxy_svc_data + 11, 8);
+	(void)memcpy(tmp + 6, proxy_svc_data + 11, 8);
 	sys_put_be16(bt_mesh_primary_addr(), tmp + 14);
 
 	err = bt_encrypt_be(sub->keys[sub->kr_flag].identity, tmp, tmp);
@@ -1045,7 +1045,7 @@ static int node_id_adv(struct bt_mesh_subnet *sub)
 		return err;
 	}
 
-	memcpy(proxy_svc_data + 3, tmp + 8, 8);
+	(void)memcpy(proxy_svc_data + 3, tmp + 8, 8);
 
 	err = bt_le_adv_start(&fast_adv_param, node_id_ad,
 			      ARRAY_SIZE(node_id_ad), NULL, 0);
@@ -1070,7 +1070,7 @@ static int net_id_adv(struct bt_mesh_subnet *sub)
 	BT_DBG("Advertising with NetId %s",
 	       bt_hex(sub->keys[sub->kr_flag].net_id, 8));
 
-	memcpy(proxy_svc_data + 3, sub->keys[sub->kr_flag].net_id, 8);
+	(void)memcpy(proxy_svc_data + 3, sub->keys[sub->kr_flag].net_id, 8);
 
 	err = bt_le_adv_start(&slow_adv_param, net_id_ad,
 			      ARRAY_SIZE(net_id_ad), NULL, 0);
@@ -1198,7 +1198,7 @@ static size_t gatt_prov_adv_create(struct bt_data prov_sd[2])
 	size_t prov_sd_len = 0;
 	size_t sd_space = 31;
 
-	memcpy(prov_svc_data + 2, prov->uuid, 16);
+	(void)memcpy(prov_svc_data + 2, prov->uuid, 16);
 	sys_put_be16(prov->oob_info, prov_svc_data + 18);
 
 	if (prov->uri) {

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -165,7 +165,7 @@ static int net_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 		return err;
 	}
 
-	memcpy(bt_mesh.dev_key, net.dev_key, sizeof(bt_mesh.dev_key));
+	(void)memcpy(bt_mesh.dev_key, net.dev_key, sizeof(bt_mesh.dev_key));
 	bt_mesh_comp_provision(net.primary_addr);
 
 	BT_DBG("Provisioned with primary address 0x%04x", net.primary_addr);
@@ -357,8 +357,8 @@ static int net_key_set(const char *name, size_t len_rd,
 
 		sub->kr_flag = key.kr_flag;
 		sub->kr_phase = key.kr_phase;
-		memcpy(sub->keys[0].net, &key.val[0], 16);
-		memcpy(sub->keys[1].net, &key.val[1], 16);
+		(void)memcpy(sub->keys[0].net, &key.val[0], 16);
+		(void)memcpy(sub->keys[1].net, &key.val[1], 16);
 
 		return 0;
 	}
@@ -378,8 +378,8 @@ static int net_key_set(const char *name, size_t len_rd,
 	sub->net_idx = net_idx;
 	sub->kr_flag = key.kr_flag;
 	sub->kr_phase = key.kr_phase;
-	memcpy(sub->keys[0].net, &key.val[0], 16);
-	memcpy(sub->keys[1].net, &key.val[1], 16);
+	(void)memcpy(sub->keys[0].net, &key.val[0], 16);
+	(void)memcpy(sub->keys[1].net, &key.val[1], 16);
 
 	BT_DBG("NetKeyIndex 0x%03x recovered from storage", net_idx);
 
@@ -432,8 +432,8 @@ static int app_key_set(const char *name, size_t len_rd,
 	app->net_idx = key.net_idx;
 	app->app_idx = app_idx;
 	app->updated = key.updated;
-	memcpy(app->keys[0].val, key.val[0], 16);
-	memcpy(app->keys[1].val, key.val[1], 16);
+	(void)memcpy(app->keys[0].val, key.val[0], 16);
+	(void)memcpy(app->keys[1].val, key.val[1], 16);
 
 	bt_mesh_app_id(app->keys[0].val, &app->keys[0].id);
 	bt_mesh_app_id(app->keys[1].val, &app->keys[1].id);
@@ -898,7 +898,7 @@ static void store_pending_net(void)
 	       bt_hex(bt_mesh.dev_key, 16));
 
 	net.primary_addr = bt_mesh_primary_addr();
-	memcpy(net.dev_key, bt_mesh.dev_key, 16);
+	(void)memcpy(net.dev_key, bt_mesh.dev_key, 16);
 
 	err = settings_save_one("bt/mesh/Net", &net, sizeof(net));
 	if (err) {
@@ -1139,8 +1139,8 @@ static void store_net_key(struct bt_mesh_subnet *sub)
 	BT_DBG("NetKeyIndex 0x%03x NetKey %s", sub->net_idx,
 	       bt_hex(sub->keys[0].net, 16));
 
-	memcpy(&key.val[0], sub->keys[0].net, 16);
-	memcpy(&key.val[1], sub->keys[1].net, 16);
+	(void)memcpy(&key.val[0], sub->keys[0].net, 16);
+	(void)memcpy(&key.val[1], sub->keys[1].net, 16);
 	key.kr_flag = sub->kr_flag;
 	key.kr_phase = sub->kr_phase;
 
@@ -1162,8 +1162,8 @@ static void store_app_key(struct bt_mesh_app_key *app)
 
 	key.net_idx = app->net_idx;
 	key.updated = app->updated;
-	memcpy(key.val[0], app->keys[0].val, 16);
-	memcpy(key.val[1], app->keys[1].val, 16);
+	(void)memcpy(key.val[0], app->keys[0].val, 16);
+	(void)memcpy(key.val[1], app->keys[1].val, 16);
 
 	snprintk(path, sizeof(path), "bt/mesh/AppKey/%x", app->app_idx);
 

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -398,7 +398,7 @@ static int cmd_uuid(const struct shell *shell, size_t argc, char *argv[])
 		return -EINVAL;
 	}
 
-	memcpy(dev_uuid, uuid, len);
+	(void)memcpy(dev_uuid, uuid, len);
 	(void)memset(dev_uuid + len, 0, sizeof(dev_uuid) - len);
 
 	shell_print(shell, "Device UUID set");
@@ -916,7 +916,7 @@ static int cmd_net_key_add(const struct shell *shell, size_t argc, char *argv[])
 			      key_val, sizeof(key_val));
 		(void)memset(key_val, 0, sizeof(key_val) - len);
 	} else {
-		memcpy(key_val, default_key, sizeof(key_val));
+		(void)memcpy(key_val, default_key, sizeof(key_val));
 	}
 
 	err = bt_mesh_cfg_net_key_add(net.net_idx, net.dst, key_net_idx,
@@ -958,7 +958,7 @@ static int cmd_app_key_add(const struct shell *shell, size_t argc, char *argv[])
 			      key_val, sizeof(key_val));
 		(void)memset(key_val, 0, sizeof(key_val) - len);
 	} else {
-		memcpy(key_val, default_key, sizeof(key_val));
+		(void)memcpy(key_val, default_key, sizeof(key_val));
 	}
 
 	err = bt_mesh_cfg_app_key_add(net.net_idx, net.dst, key_net_idx,

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1346,7 +1346,8 @@ found_rx:
 	}
 
 	/* Location in buffer can be calculated based on seg_o & rx->ctl */
-	memcpy(rx->buf.data + (seg_o * seg_len(rx->ctl)), buf->data, buf->len);
+	(void)memcpy(rx->buf.data + (seg_o * seg_len(rx->ctl)),
+		      buf->data, buf->len);
 
 	BT_DBG("Received %u/%u", seg_o, seg_n);
 

--- a/subsys/bluetooth/shell/bredr.c
+++ b/subsys/bluetooth/shell/bredr.c
@@ -131,9 +131,9 @@ static void br_device_found(const bt_addr_t *addr, s8_t rssi,
 		case BT_DATA_NAME_SHORTENED:
 		case BT_DATA_NAME_COMPLETE:
 			if (eir[0] > sizeof(name) - 1) {
-				memcpy(name, &eir[2], sizeof(name) - 1);
+				(void)memcpy(name, &eir[2], sizeof(name) - 1);
 			} else {
-				memcpy(name, &eir[2], eir[0] - 1);
+				(void)memcpy(name, &eir[2], eir[0] - 1);
 			}
 			break;
 		default:

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -64,7 +64,8 @@ static bool data_cb(struct bt_data *data, void *user_data)
 	switch (data->type) {
 	case BT_DATA_NAME_SHORTENED:
 	case BT_DATA_NAME_COMPLETE:
-		memcpy(name, data->data, MIN(data->data_len, NAME_LEN - 1));
+		(void)memcpy(name, data->data,
+			      MIN(data->data_len, NAME_LEN - 1));
 		return false;
 	default:
 		return true;
@@ -1002,7 +1003,7 @@ static int cmd_oob_remote(const struct shell *shell, size_t argc,
 
 static int cmd_oob_clear(const struct shell *shell, size_t argc, char *argv[])
 {
-	memset(&oob_remote, 0, sizeof(oob_remote));
+	(void)memset(&oob_remote, 0, sizeof(oob_remote));
 	bt_set_oob_data_flag(false);
 
 	return 0;

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -561,7 +561,7 @@ static int cmd_show_db(const struct shell *shell, size_t argc, char *argv[])
 	struct bt_uuid_16 uuid;
 	size_t total_len;
 
-	memset(&stats, 0, sizeof(stats));
+	(void)memset(&stats, 0, sizeof(stats));
 
 	if (argc > 1) {
 		u16_t num_matches = 0;
@@ -663,7 +663,7 @@ static ssize_t write_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	memcpy(value + offset, buf, len);
+	(void)memcpy(value + offset, buf, len);
 
 	return len;
 }
@@ -697,7 +697,7 @@ static ssize_t write_long_vnd(struct bt_conn *conn,
 	}
 
 	/* Copy to buffer */
-	memcpy(value + offset, buf, len);
+	(void)memcpy(value + offset, buf, len);
 
 	return len;
 }
@@ -783,7 +783,7 @@ static int cmd_notify(const struct shell *shell, size_t argc, char *argv[])
 		data = strtoul(argv[1], NULL, 16);
 	}
 
-	memset(&params, 0, sizeof(params));
+	(void)memset(&params, 0, sizeof(params));
 
 	params.uuid = &vnd1_echo_uuid.uuid;
 	params.attr = vnd1_attrs;
@@ -836,7 +836,7 @@ static ssize_t write_met(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	memcpy(value + offset, buf, len);
+	(void)memcpy(value + offset, buf, len);
 
 	delta = k_cycle_get_32() - cycle_stamp;
 	delta = SYS_CLOCK_HW_CYCLES_TO_NS(delta);

--- a/subsys/bluetooth/shell/hci.c
+++ b/subsys/bluetooth/shell/hci.c
@@ -43,7 +43,7 @@ int cmd_mesh_adv(const struct shell *shell, size_t argc, char *argv[])
 		cp = net_buf_add(buf, sizeof(*cp));
 		cp->adv_slot = 0U;
 		cp->own_addr_type = 0x01;
-		memset(&cp->random_addr, 0, sizeof(bt_addr_t));
+		(void)memset(&cp->random_addr, 0, sizeof(bt_addr_t));
 		cp->ch_map = 0x07;
 		cp->tx_power = 0;
 		cp->min_tx_delay = 0U;
@@ -54,7 +54,7 @@ int cmd_mesh_adv(const struct shell *shell, size_t argc, char *argv[])
 		cp->scan_duration = sys_cpu_to_le16(0x0064);
 		cp->scan_filter = 0x00;
 		cp->data_len = 0U;
-		memset(cp->data, 0, sizeof(cp->data));
+		(void)memset(cp->data, 0, sizeof(cp->data));
 	} else if (!strcmp(argv[1], "off")) {
 		struct bt_hci_cp_mesh_advertise_cancel *cp;
 

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -297,7 +297,7 @@ static int boot_write_trailer_byte(const struct flash_area *fa, u32_t off,
 	align = flash_area_align(fa);
 	assert(align <= BOOT_MAX_ALIGN);
 	erased_val = flash_area_erased_val(fa);
-	memset(buf, erased_val, BOOT_MAX_ALIGN);
+	(void)memset(buf, erased_val, BOOT_MAX_ALIGN);
 	buf[0] = val;
 
 	rc = flash_area_write(fa, off, buf, align);

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -164,8 +164,8 @@ int flash_img_buffered_write(struct flash_img_context *ctx, u8_t *data,
 
 	while ((len - processed) >=
 	       (buf_empty_bytes = CONFIG_IMG_BLOCK_BUF_SIZE - ctx->buf_bytes)) {
-		memcpy(ctx->buf + ctx->buf_bytes, data + processed,
-		       buf_empty_bytes);
+		(void)memcpy(ctx->buf + ctx->buf_bytes, data + processed,
+				buf_empty_bytes);
 
 		ctx->buf_bytes = CONFIG_IMG_BLOCK_BUF_SIZE;
 		rc = flash_sync(ctx);
@@ -179,8 +179,8 @@ int flash_img_buffered_write(struct flash_img_context *ctx, u8_t *data,
 
 	/* place rest of the data into ctx->buf */
 	if (processed < len) {
-		memcpy(ctx->buf + ctx->buf_bytes,
-		       data + processed, len - processed);
+		(void)memcpy(ctx->buf + ctx->buf_bytes,
+				data + processed, len - processed);
 		ctx->buf_bytes += len - processed;
 	}
 

--- a/subsys/disk/disk_access_flash.c
+++ b/subsys/disk/disk_access_flash.c
@@ -129,7 +129,7 @@ static int read_copy_flash_block(off_t start_addr, u32_t size,
 	}
 
 	/* overwrite with user data */
-	memcpy(dest_buff + offset, src_buff, size);
+	(void)memcpy(dest_buff + offset, src_buff, size);
 
 	return 0;
 }

--- a/subsys/disk/disk_access_ram.c
+++ b/subsys/disk/disk_access_ram.c
@@ -48,7 +48,8 @@ static int disk_ram_access_init(struct disk_info *disk)
 static int disk_ram_access_read(struct disk_info *disk, u8_t *buff,
 				u32_t sector, u32_t count)
 {
-	memcpy(buff, lba_to_address(sector), count * RAMDISK_SECTOR_SIZE);
+	(void)memcpy(buff, lba_to_address(sector),
+		      count * RAMDISK_SECTOR_SIZE);
 
 	return 0;
 }
@@ -56,7 +57,8 @@ static int disk_ram_access_read(struct disk_info *disk, u8_t *buff,
 static int disk_ram_access_write(struct disk_info *disk, const u8_t *buff,
 				 u32_t sector, u32_t count)
 {
-	memcpy(lba_to_address(sector), buff, count * RAMDISK_SECTOR_SIZE);
+	(void)memcpy(lba_to_address(sector), buff,
+		      count * RAMDISK_SECTOR_SIZE);
 
 	return 0;
 }

--- a/subsys/disk/disk_access_usdhc.c
+++ b/subsys/disk/disk_access_usdhc.c
@@ -1645,8 +1645,8 @@ static inline void usdhc_op_ctx_init(struct usdhc_priv *priv,
 
 	priv->op_context.cmd_only = cmd_only;
 
-	memset((char *)cmd, 0, sizeof(struct usdhc_cmd));
-	memset((char *)data, 0, sizeof(struct usdhc_data));
+	(void)memset((char *)cmd, 0, sizeof(struct usdhc_cmd));
+	(void)memset((char *)data, 0, sizeof(struct usdhc_data));
 
 	cmd->index = cmd_idx;
 	cmd->argument = arg;
@@ -2019,8 +2019,8 @@ static int usdhc_select_bus_timing(struct usdhc_priv *priv)
 		/* execute tuning */
 		priv->op_context.cmd_only = 0;
 
-		memset((char *)cmd, 0, sizeof(struct usdhc_cmd));
-		memset((char *)data, 0, sizeof(struct usdhc_data));
+		(void)memset((char *)cmd, 0, sizeof(struct usdhc_cmd));
+		(void)memset((char *)data, 0, sizeof(struct usdhc_data));
 
 		cmd->index = SDHC_SEND_TUNING_BLOCK;
 		cmd->rsp_type = SDHC_RSP_TYPE_R1;
@@ -2051,8 +2051,8 @@ static int usdhc_write_sector(void *bus_data, const u8_t *buf, u32_t sector,
 	struct usdhc_cmd *cmd = &priv->op_context.cmd;
 	struct usdhc_data *data = &priv->op_context.data;
 
-	memset((char *)cmd, 0, sizeof(struct usdhc_cmd));
-	memset((char *)data, 0, sizeof(struct usdhc_data));
+	(void)memset((char *)cmd, 0, sizeof(struct usdhc_cmd));
+	(void)memset((char *)data, 0, sizeof(struct usdhc_data));
 
 	priv->op_context.cmd_only = 0;
 	cmd->index = SDHC_WRITE_MULTIPLE_BLOCK;
@@ -2080,8 +2080,8 @@ static int usdhc_read_sector(void *bus_data, u8_t *buf, u32_t sector,
 	struct usdhc_cmd *cmd = &priv->op_context.cmd;
 	struct usdhc_data *data = &priv->op_context.data;
 
-	memset((char *)cmd, 0, sizeof(struct usdhc_cmd));
-	memset((char *)data, 0, sizeof(struct usdhc_data));
+	(void)memset((char *)cmd, 0, sizeof(struct usdhc_cmd));
+	(void)memset((char *)data, 0, sizeof(struct usdhc_data));
 
 	priv->op_context.cmd_only = 0;
 	cmd->index = SDHC_READ_MULTIPLE_BLOCK;
@@ -2414,8 +2414,8 @@ APP_SEND_OP_COND_AGAIN:
 
 	ret = usdhc_xfer(priv);
 	if (!ret) {
-		memcpy(priv->card_info.raw_cid, cmd->response,
-			sizeof(priv->card_info.raw_cid));
+		(void)memcpy(priv->card_info.raw_cid, cmd->response,
+				sizeof(priv->card_info.raw_cid));
 		sdhc_decode_cid(&priv->card_info.cid,
 			priv->card_info.raw_cid);
 	} else {
@@ -2439,8 +2439,8 @@ APP_SEND_OP_COND_AGAIN:
 
 	ret = usdhc_xfer(priv);
 	if (!ret) {
-		memcpy(priv->card_info.raw_csd, cmd->response,
-			sizeof(priv->card_info.raw_csd));
+		(void)memcpy(priv->card_info.raw_csd, cmd->response,
+				sizeof(priv->card_info.raw_csd));
 		sdhc_decode_csd(&priv->card_info.csd, priv->card_info.raw_csd,
 			&priv->card_info.sd_block_count,
 			&priv->card_info.sd_block_size);
@@ -2704,7 +2704,7 @@ static int usdhc_access_init(const struct device *dev)
 
 	(void)k_mutex_lock(&z_usdhc_init_lock, K_FOREVER);
 
-	memset((char *)priv, 0, sizeof(struct usdhc_priv));
+	(void)memset((char *)priv, 0, sizeof(struct usdhc_priv));
 #ifdef DT_INST_0_NXP_IMX_USDHC_LABEL
 	if (!strcmp(dev->config->name, DT_INST_0_NXP_IMX_USDHC_LABEL)) {
 		priv->host_config.base =

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -173,7 +173,7 @@ int cfb_framebuffer_clear(struct device *dev, bool clear_display)
 	desc.width = fb->x_res;
 	desc.height = fb->y_res;
 	desc.pitch = fb->x_res;
-	memset(fb->buf, 0, fb->size);
+	(void)memset(fb->buf, 0, fb->size);
 
 	return 0;
 }
@@ -316,7 +316,7 @@ int cfb_framebuffer_init(struct device *dev)
 		return -1;
 	}
 
-	memset(fb->buf, 0, fb->size);
+	(void)memset(fb->buf, 0, fb->size);
 
 	return 0;
 }

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -195,7 +195,7 @@ static int littlefs_open(struct fs_file_t *fp, const char *path)
 
 	struct lfs_file_data *fdp = fp->filep;
 
-	memset(fdp, 0, sizeof(*fdp));
+	(void)memset(fdp, 0, sizeof(*fdp));
 
 	ret = k_mem_pool_alloc(&file_cache_pool, &fdp->cache_block,
 			       lfs->cfg->cache_size, K_NO_WAIT);
@@ -368,7 +368,7 @@ static int littlefs_opendir(struct fs_dir_t *dp, const char *path)
 		return -ENOMEM;
 	}
 
-	memset(dp->dirp, 0, sizeof(struct lfs_dir));
+	(void)memset(dp->dirp, 0, sizeof(struct lfs_dir));
 
 	path = fs_impl_strip_prefix(path, dp->mp);
 

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -65,7 +65,7 @@ static int nvs_flash_al_wrt(struct nvs_fs *fs, u32_t addr, const void *data,
 		data8 += blen;
 	}
 	if (len) {
-		memcpy(buf, data8, len);
+		(void)memcpy(buf, data8, len);
 		(void)memset(buf + len, 0xff, fs->write_block_size - len);
 		rc = flash_write(fs->flash_device, offset, buf,
 				 fs->write_block_size);

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -437,7 +437,7 @@ static char *mntpt_prepare(char *mntpt)
 	cpy_mntpt = k_malloc(strlen(mntpt) + 1);
 	if (cpy_mntpt) {
 		((u8_t *)mntpt)[strlen(mntpt)] = '\0';
-		memcpy(cpy_mntpt, mntpt, strlen(mntpt));
+		(void)memcpy(cpy_mntpt, mntpt, strlen(mntpt));
 	}
 	return cpy_mntpt;
 }

--- a/subsys/jwt/jwt.c
+++ b/subsys/jwt/jwt.c
@@ -104,7 +104,7 @@ static void base64_flush(struct jwt_builder *st)
 	}
 
 	st->pending = 0;
-	memset(st->wip, 0, 3);
+	(void)memset(st->wip, 0, 3);
 }
 
 static void base64_addbyte(struct jwt_builder *st, uint8_t byte)
@@ -253,7 +253,7 @@ static int setup_prng(void)
 	for (int i = 0; i < sizeof(entropy); i += sizeof(u32_t)) {
 		u32_t rv = sys_rand32_get();
 
-		memcpy(entropy + i, &rv, sizeof(uint32_t));
+		(void)memcpy(entropy + i, &rv, sizeof(uint32_t));
 	}
 
 	int res = tc_ctr_prng_init(&prng_state,

--- a/subsys/mgmt/buf.c
+++ b/subsys/mgmt/buf.c
@@ -51,7 +51,7 @@ cbor_nb_reader_get16(struct cbor_decoder_reader *d, int offset)
 		return UINT16_MAX;
 	}
 
-	memcpy(&val, cnr->nb->data + offset, sizeof(val));
+	(void)memcpy(&val, cnr->nb->data + offset, sizeof(val));
 	return cbor_ntohs(val);
 }
 
@@ -67,7 +67,7 @@ cbor_nb_reader_get32(struct cbor_decoder_reader *d, int offset)
 		return UINT32_MAX;
 	}
 
-	memcpy(&val, cnr->nb->data + offset, sizeof(val));
+	(void)memcpy(&val, cnr->nb->data + offset, sizeof(val));
 	return cbor_ntohl(val);
 }
 
@@ -83,7 +83,7 @@ cbor_nb_reader_get64(struct cbor_decoder_reader *d, int offset)
 		return UINT64_MAX;
 	}
 
-	memcpy(&val, cnr->nb->data + offset, sizeof(val));
+	(void)memcpy(&val, cnr->nb->data + offset, sizeof(val));
 	return cbor_ntohll(val);
 }
 

--- a/subsys/mgmt/serial_util.c
+++ b/subsys/mgmt/serial_util.c
@@ -36,7 +36,7 @@ static int mcumgr_serial_parse_op(const u8_t *buf, int len)
 		return -EINVAL;
 	}
 
-	memcpy(&op, buf, sizeof(op));
+	(void)memcpy(&op, buf, sizeof(op));
 	op = sys_be16_to_cpu(op);
 
 	if (op != MCUMGR_SERIAL_HDR_PKT && op != MCUMGR_SERIAL_HDR_FRAG) {
@@ -219,7 +219,7 @@ int mcumgr_serial_tx_frame(const u8_t *data, bool first, int len,
 	/* Only the first fragment contains the packet length. */
 	if (first) {
 		u16 = sys_cpu_to_be16(len);
-		memcpy(raw, &u16, sizeof(u16));
+		(void)memcpy(raw, &u16, sizeof(u16));
 		raw[2] = data[0];
 
 		rc = mcumgr_serial_tx_small(raw, 3, cb, arg);
@@ -284,7 +284,7 @@ int mcumgr_serial_tx_frame(const u8_t *data, bool first, int len,
 		}
 
 		/* Otherwise, just encode payload data. */
-		memcpy(raw, data + src_off, 3);
+		(void)memcpy(raw, data + src_off, 3);
 		rc = mcumgr_serial_tx_small(raw, 3, cb, arg);
 		if (rc != 0) {
 			return rc;

--- a/subsys/mgmt/smp.c
+++ b/subsys/mgmt/smp.c
@@ -49,9 +49,9 @@ zephyr_smp_alloc_rsp(const void *req, void *arg)
 		zst->zst_ud_copy(rsp_nb, req_nb);
 	} else {
 		pool = net_buf_pool_get(req_nb->pool_id);
-		memcpy(net_buf_user_data(rsp_nb),
-		       net_buf_user_data((void *)req_nb),
-		       sizeof(req_nb->user_data));
+		(void)memcpy(net_buf_user_data(rsp_nb),
+				net_buf_user_data((void *)req_nb),
+				sizeof(req_nb->user_data));
 	}
 
 	return rsp_nb;
@@ -152,7 +152,7 @@ zephyr_smp_write_at(struct cbor_encoder_writer *writer, size_t offset,
 		return MGMT_ERR_EINVAL;
 	}
 
-	memcpy(nb->data + offset, data, len);
+	(void)memcpy(nb->data + offset, data, len);
 	if (nb->len < offset + len) {
 		nb->len = offset + len;
 		writer->bytes_written = nb->len;

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -110,7 +110,7 @@ static u8_t *mem_pool_data_alloc(struct net_buf *buf, size_t *size,
 	}
 
 	/* save the block descriptor info at the start of the actual block */
-	memcpy(block.data, &block.id, sizeof(block.id));
+	(void)memcpy(block.data, &block.id, sizeof(block.id));
 
 	ref_count = (u8_t *)block.data + sizeof(block.id);
 	*ref_count = 1U;
@@ -130,7 +130,7 @@ static void mem_pool_data_unref(struct net_buf *buf, u8_t *data)
 	}
 
 	/* Need to copy to local variable due to alignment */
-	memcpy(&id, ref_count - sizeof(id), sizeof(id));
+	(void)memcpy(&id, ref_count - sizeof(id), sizeof(id));
 	k_mem_pool_free_id(&id);
 }
 
@@ -695,7 +695,8 @@ size_t net_buf_linearize(void *dst, size_t dst_len, struct net_buf *src,
 	copied = 0;
 	while (frag && len > 0) {
 		to_copy = MIN(len, frag->len - offset);
-		memcpy((u8_t *)dst + copied, frag->data + offset, to_copy);
+		(void)memcpy((u8_t *)dst + copied,
+			      frag->data + offset, to_copy);
 
 		copied += to_copy;
 
@@ -797,7 +798,7 @@ void net_buf_simple_add_le16(struct net_buf_simple *buf, u16_t val)
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
 	val = sys_cpu_to_le16(val);
-	memcpy(net_buf_simple_add(buf, sizeof(val)), &val, sizeof(val));
+	(void)memcpy(net_buf_simple_add(buf, sizeof(val)), &val, sizeof(val));
 }
 
 void net_buf_simple_add_be16(struct net_buf_simple *buf, u16_t val)
@@ -805,7 +806,7 @@ void net_buf_simple_add_be16(struct net_buf_simple *buf, u16_t val)
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
 	val = sys_cpu_to_be16(val);
-	memcpy(net_buf_simple_add(buf, sizeof(val)), &val, sizeof(val));
+	(void)memcpy(net_buf_simple_add(buf, sizeof(val)), &val, sizeof(val));
 }
 
 void net_buf_simple_add_le32(struct net_buf_simple *buf, u32_t val)
@@ -813,7 +814,7 @@ void net_buf_simple_add_le32(struct net_buf_simple *buf, u32_t val)
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
 	val = sys_cpu_to_le32(val);
-	memcpy(net_buf_simple_add(buf, sizeof(val)), &val, sizeof(val));
+	(void)memcpy(net_buf_simple_add(buf, sizeof(val)), &val, sizeof(val));
 }
 
 void net_buf_simple_add_be32(struct net_buf_simple *buf, u32_t val)
@@ -821,7 +822,7 @@ void net_buf_simple_add_be32(struct net_buf_simple *buf, u32_t val)
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
 	val = sys_cpu_to_be32(val);
-	memcpy(net_buf_simple_add(buf, sizeof(val)), &val, sizeof(val));
+	(void)memcpy(net_buf_simple_add(buf, sizeof(val)), &val, sizeof(val));
 }
 
 void *net_buf_simple_push(struct net_buf_simple *buf, size_t len)
@@ -840,7 +841,7 @@ void net_buf_simple_push_le16(struct net_buf_simple *buf, u16_t val)
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
 	val = sys_cpu_to_le16(val);
-	memcpy(net_buf_simple_push(buf, sizeof(val)), &val, sizeof(val));
+	(void)memcpy(net_buf_simple_push(buf, sizeof(val)), &val, sizeof(val));
 }
 
 void net_buf_simple_push_be16(struct net_buf_simple *buf, u16_t val)
@@ -848,7 +849,7 @@ void net_buf_simple_push_be16(struct net_buf_simple *buf, u16_t val)
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
 	val = sys_cpu_to_be16(val);
-	memcpy(net_buf_simple_push(buf, sizeof(val)), &val, sizeof(val));
+	(void)memcpy(net_buf_simple_push(buf, sizeof(val)), &val, sizeof(val));
 }
 
 void net_buf_simple_push_u8(struct net_buf_simple *buf, u8_t val)

--- a/subsys/net/hostname.c
+++ b/subsys/net/hostname.c
@@ -64,7 +64,8 @@ int net_hostname_set_postfix(const u8_t *hostname_postfix,
 
 void net_hostname_init(void)
 {
-	memcpy(hostname, CONFIG_NET_HOSTNAME, sizeof(CONFIG_NET_HOSTNAME) - 1);
+	(void)memcpy(hostname, CONFIG_NET_HOSTNAME,
+		      sizeof(CONFIG_NET_HOSTNAME) - 1);
 
 	NET_DBG("Hostname set to %s", hostname);
 }

--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -1401,8 +1401,8 @@ static bool uncompress_IPHC_header(struct net_pkt *pkt)
 
 		if ((iphc & NET_6LO_IPHC_SAM_MASK) == NET_6LO_IPHC_SAM_00) {
 			NET_DBG("SAM_00 unspecified address");
-			memset(&ipv6->src.s6_addr[0], 0,
-				sizeof(ipv6->src.s6_addr));
+			(void)memset(&ipv6->src.s6_addr[0], 0,
+					sizeof(ipv6->src.s6_addr));
 		} else if (IS_ENABLED(CONFIG_NET_6LO_CONTEXT)) {
 #if defined(CONFIG_NET_6LO_CONTEXT)
 			if (!src) {

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -263,8 +263,8 @@ int net_conn_register(u16_t proto, u8_t family,
 	if (remote_addr) {
 		if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		    remote_addr->sa_family == AF_INET6) {
-			memcpy(&conn->remote_addr, remote_addr,
-			       sizeof(struct sockaddr_in6));
+			(void)memcpy(&conn->remote_addr, remote_addr,
+					sizeof(struct sockaddr_in6));
 
 			if (!net_ipv6_is_addr_unspecified(
 				    &net_sin6(remote_addr)->
@@ -273,8 +273,8 @@ int net_conn_register(u16_t proto, u8_t family,
 			}
 		} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 			   remote_addr->sa_family == AF_INET) {
-			memcpy(&conn->remote_addr, remote_addr,
-			       sizeof(struct sockaddr_in));
+			(void)memcpy(&conn->remote_addr, remote_addr,
+					sizeof(struct sockaddr_in));
 
 			if (net_sin(remote_addr)->sin_addr.s_addr) {
 				flags |= NET_CONN_REMOTE_ADDR_SPEC;
@@ -290,8 +290,8 @@ int net_conn_register(u16_t proto, u8_t family,
 	if (local_addr) {
 		if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		    local_addr->sa_family == AF_INET6) {
-			memcpy(&conn->local_addr, local_addr,
-			       sizeof(struct sockaddr_in6));
+			(void)memcpy(&conn->local_addr, local_addr,
+					sizeof(struct sockaddr_in6));
 
 			if (!net_ipv6_is_addr_unspecified(
 				    &net_sin6(local_addr)->
@@ -300,16 +300,16 @@ int net_conn_register(u16_t proto, u8_t family,
 			}
 		} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 			   local_addr->sa_family == AF_INET) {
-			memcpy(&conn->local_addr, local_addr,
-			       sizeof(struct sockaddr_in));
+			(void)memcpy(&conn->local_addr, local_addr,
+					sizeof(struct sockaddr_in));
 
 			if (net_sin(local_addr)->sin_addr.s_addr) {
 				flags |= NET_CONN_LOCAL_ADDR_SPEC;
 			}
 		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) &&
 			   local_addr->sa_family == AF_CAN) {
-			memcpy(&conn->local_addr, local_addr,
-			       sizeof(struct sockaddr_can));
+			(void)memcpy(&conn->local_addr, local_addr,
+					sizeof(struct sockaddr_can));
 		} else {
 			NET_ERR("Local address family not set");
 			goto error;

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -204,11 +204,11 @@ static struct net_pkt *dhcpv4_create_message(struct net_if *iface, u8_t type,
 		 * asked to send a ciaddr then fill it in now
 		 * otherwise leave it as all zeros.
 		 */
-		memcpy(msg->ciaddr, ciaddr, 4);
+		(void)memcpy(msg->ciaddr, ciaddr, 4);
 	}
 
-	memcpy(msg->chaddr, net_if_get_link_addr(iface)->addr,
-	       net_if_get_link_addr(iface)->len);
+	(void)memcpy(msg->chaddr, net_if_get_link_addr(iface)->addr,
+			net_if_get_link_addr(iface)->len);
 
 	if (net_pkt_set_data(pkt, &dhcp_access)) {
 		goto fail;
@@ -955,8 +955,8 @@ static enum net_verdict net_dhcpv4_input(struct net_conn *conn,
 		return NET_DROP;
 	}
 
-	memcpy(iface->config.dhcpv4.requested_ip.s4_addr,
-	       msg->yiaddr, sizeof(msg->yiaddr));
+	(void)memcpy(iface->config.dhcpv4.requested_ip.s4_addr,
+			msg->yiaddr, sizeof(msg->yiaddr));
 
 	net_pkt_acknowledge_data(pkt, &dhcp_access);
 

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1062,7 +1062,7 @@ int net_ipv6_send_na(struct net_if *iface, const struct in6_addr *src,
 	}
 
 	/* Let's make sure reserved part is full of 0 */
-	memset(na_hdr, 0, sizeof(struct net_icmpv6_na_hdr));
+	(void)memset(na_hdr, 0, sizeof(struct net_icmpv6_na_hdr));
 
 	na_hdr->flags = flags;
 	net_ipaddr_copy(&na_hdr->tgt, tgt);
@@ -2126,7 +2126,7 @@ static inline void handle_prefix_autonomous(struct net_pkt *pkt,
 	 */
 	net_ipv6_addr_create_iid(&addr,
 				 net_if_get_link_addr(net_pkt_iface(pkt)));
-	memcpy(&addr, &prefix_info->prefix, sizeof(struct in6_addr) / 2);
+	(void)memcpy(&addr, &prefix_info->prefix, sizeof(struct in6_addr) / 2);
 
 	ifaddr = net_if_ipv6_addr_lookup(&addr, NULL);
 	if (ifaddr && ifaddr->addr_type == NET_ADDR_AUTOCONF) {

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -402,8 +402,9 @@ static int bind_default(struct net_context *context)
 		}
 
 		addr6.sin6_family = AF_INET6;
-		memcpy(&addr6.sin6_addr, net_ipv6_unspecified_address(),
-		       sizeof(addr6.sin6_addr));
+		(void)memcpy(&addr6.sin6_addr,
+				net_ipv6_unspecified_address(),
+				sizeof(addr6.sin6_addr));
 		addr6.sin6_port =
 			find_available_port(context,
 					    (struct sockaddr *)&addr6);
@@ -917,8 +918,8 @@ int net_context_connect(struct net_context *context,
 			goto unlock;
 		}
 
-		memcpy(&addr6->sin6_addr, &net_sin6(addr)->sin6_addr,
-		       sizeof(struct in6_addr));
+		(void)memcpy(&addr6->sin6_addr, &net_sin6(addr)->sin6_addr,
+				sizeof(struct in6_addr));
 
 		addr6->sin6_port = net_sin6(addr)->sin6_port;
 		addr6->sin6_family = AF_INET6;
@@ -967,8 +968,8 @@ int net_context_connect(struct net_context *context,
 
 		addr4 = (struct sockaddr_in *)&context->remote;
 
-		memcpy(&addr4->sin_addr, &net_sin(addr)->sin_addr,
-		       sizeof(struct in_addr));
+		(void)memcpy(&addr4->sin_addr, &net_sin(addr)->sin_addr,
+				sizeof(struct in_addr));
 
 		addr4->sin_port = net_sin(addr)->sin_port;
 		addr4->sin_family = AF_INET;
@@ -1131,7 +1132,7 @@ static int get_context_proxy(struct net_context *context,
 
 	*len = MIN(context->options.proxy.addrlen, *len);
 
-	memcpy(addr, &context->options.proxy.addr, *len);
+	(void)memcpy(addr, &context->options.proxy.addr, *len);
 
 	return 0;
 #else
@@ -1148,7 +1149,8 @@ int net_context_get_timestamp(struct net_context *context,
 
 	get_context_timepstamp(context, &is_timestamped, NULL);
 	if (is_timestamped) {
-		memcpy(timestamp, net_pkt_timestamp(pkt), sizeof(*timestamp));
+		(void)memcpy(timestamp, net_pkt_timestamp(pkt),
+			      sizeof(*timestamp));
 		return 0;
 	}
 
@@ -2031,7 +2033,7 @@ static int set_context_proxy(struct net_context *context,
 	}
 
 	context->options.proxy.addrlen = len;
-	memcpy(&context->options.proxy.addr, addr, len);
+	(void)memcpy(&context->options.proxy.addr, addr, len);
 
 	return 0;
 #else

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -600,8 +600,8 @@ static struct net_if_router *iface_router_add(struct net_if *iface,
 		}
 
 		if (IS_ENABLED(CONFIG_NET_IPV6) && family == AF_INET6) {
-			memcpy(net_if_router_ipv6(&routers[i]), addr,
-			       sizeof(struct in6_addr));
+			(void)memcpy(net_if_router_ipv6(&routers[i]), addr,
+					sizeof(struct in6_addr));
 			net_mgmt_event_notify_with_info(
 					NET_EVENT_IPV6_ROUTER_ADD, iface,
 					&routers[i].address.in6_addr,
@@ -613,8 +613,8 @@ static struct net_if_router *iface_router_add(struct net_if *iface,
 						   (struct in6_addr *)addr)),
 				lifetime, routers[i].is_default);
 		} else if (IS_ENABLED(CONFIG_NET_IPV4) && family == AF_INET) {
-			memcpy(net_if_router_ipv4(&routers[i]), addr,
-			       sizeof(struct in_addr));
+			(void)memcpy(net_if_router_ipv4(&routers[i]), addr,
+					sizeof(struct in_addr));
 			routers[i].is_default = is_default;
 
 			net_mgmt_event_notify_with_info(
@@ -1563,7 +1563,7 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 
 		ipv6->mcast[i].is_used = true;
 		ipv6->mcast[i].address.family = AF_INET6;
-		memcpy(&ipv6->mcast[i].address.in6_addr, addr, 16);
+		(void)memcpy(&ipv6->mcast[i].address.in6_addr, addr, 16);
 
 		NET_DBG("[%d] interface %p address %s added", i, iface,
 			log_strdup(net_sprint_ipv6_addr(addr)));

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -64,7 +64,7 @@ static inline void mgmt_push_event(u32_t mgmt_event, struct net_if *iface,
 #ifdef CONFIG_NET_MGMT_EVENT_INFO
 	if (info && length) {
 		if (length <= NET_EVENT_INFO_MAX_SIZE) {
-			memcpy(events[i_idx].info, info, length);
+			(void)memcpy(events[i_idx].info, info, length);
 			events[i_idx].info_length = length;
 		} else {
 			NET_ERR("Event info length %zu > max size %zu",

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -773,7 +773,8 @@ bool net_pkt_compact(struct net_pkt *pkt)
 				copy_len = net_buf_tailroom(frag);
 			}
 
-			memcpy(net_buf_tail(frag), frag->frags->data, copy_len);
+			(void)memcpy(net_buf_tail(frag),
+				      frag->frags->data, copy_len);
 			net_buf_add(frag, copy_len);
 
 			memmove(frag->frags->data,
@@ -1178,7 +1179,7 @@ static struct net_pkt *pkt_alloc(struct k_mem_slab *slab, s32_t timeout)
 		return NULL;
 	}
 
-	memset(pkt, 0, sizeof(struct net_pkt));
+	(void)memset(pkt, 0, sizeof(struct net_pkt));
 
 	pkt->atomic_ref = ATOMIC_INIT(1);
 	pkt->slab = slab;
@@ -1523,11 +1524,11 @@ static int net_pkt_cursor_operate(struct net_pkt *pkt,
 		}
 
 		if (copy) {
-			memcpy(write ? c_op->pos : data,
-			       write ? data : c_op->pos,
-			       len);
+			(void)memcpy(write ? c_op->pos : data,
+					write ? data : c_op->pos,
+					len);
 		} else if (data) {
-			memset(c_op->pos, *(int *)data, len);
+			(void)memset(c_op->pos, *(int *)data, len);
 		}
 
 		if (write && !net_pkt_is_being_overwritten(pkt)) {
@@ -1652,7 +1653,7 @@ int net_pkt_copy(struct net_pkt *pkt_dst,
 			break;
 		}
 
-		memcpy(c_dst->pos, c_src->pos, len);
+		(void)memcpy(c_dst->pos, c_src->pos, len);
 
 		if (!net_pkt_is_being_overwritten(pkt_dst)) {
 			net_buf_add(c_dst->buf, len);
@@ -1721,10 +1722,10 @@ struct net_pkt *net_pkt_clone(struct net_pkt *pkt, s32_t timeout)
 		 * a buffer that we copied because those pointers point
 		 * to start of the fragment which we do not have right now.
 		 */
-		memcpy(&clone_pkt->lladdr_src, &pkt->lladdr_src,
-		       sizeof(clone_pkt->lladdr_src));
-		memcpy(&clone_pkt->lladdr_dst, &pkt->lladdr_dst,
-		       sizeof(clone_pkt->lladdr_dst));
+		(void)memcpy(&clone_pkt->lladdr_src, &pkt->lladdr_src,
+				sizeof(clone_pkt->lladdr_src));
+		(void)memcpy(&clone_pkt->lladdr_dst, &pkt->lladdr_dst,
+				sizeof(clone_pkt->lladdr_dst));
 	}
 
 	clone_pkt_attributes(pkt, clone_pkt);
@@ -1760,10 +1761,10 @@ struct net_pkt *net_pkt_shallow_clone(struct net_pkt *pkt, s32_t timeout)
 		 * a buffer that we copied because those pointers point
 		 * to start of the fragment which we do not have right now.
 		 */
-		memcpy(&clone_pkt->lladdr_src, &pkt->lladdr_src,
-		       sizeof(clone_pkt->lladdr_src));
-		memcpy(&clone_pkt->lladdr_dst, &pkt->lladdr_dst,
-		       sizeof(clone_pkt->lladdr_dst));
+		(void)memcpy(&clone_pkt->lladdr_src, &pkt->lladdr_src,
+				sizeof(clone_pkt->lladdr_src));
+		(void)memcpy(&clone_pkt->lladdr_dst, &pkt->lladdr_dst,
+				sizeof(clone_pkt->lladdr_dst));
 	}
 
 	clone_pkt_attributes(pkt, clone_pkt);

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3422,7 +3422,8 @@ static void get_my_ipv6_addr(struct net_if *iface,
 	my6addr = net_if_ipv6_select_src_addr(iface,
 					      &net_sin6(myaddr)->sin6_addr);
 
-	memcpy(&net_sin6(myaddr)->sin6_addr, my6addr, sizeof(struct in6_addr));
+	(void)memcpy(&net_sin6(myaddr)->sin6_addr,
+		      my6addr, sizeof(struct in6_addr));
 
 	net_sin6(myaddr)->sin6_port = 0U; /* let the IP stack to select */
 #endif
@@ -3433,9 +3434,9 @@ static void get_my_ipv4_addr(struct net_if *iface,
 {
 #if defined(CONFIG_NET_IPV4)
 	/* Just take the first IPv4 address of an interface. */
-	memcpy(&net_sin(myaddr)->sin_addr,
-	       &iface->config.ip.ipv4->unicast[0].address.in_addr,
-	       sizeof(struct in_addr));
+	(void)memcpy(&net_sin(myaddr)->sin_addr,
+			&iface->config.ip.ipv4->unicast[0].address.in_addr,
+			sizeof(struct in_addr));
 
 	net_sin(myaddr)->sin_port = 0U; /* let the IP stack to select */
 #endif
@@ -4096,7 +4097,8 @@ static void nbr_populate_addresses(void)
 static char *set_nbr_address(size_t idx)
 {
 	if (idx == 0) {
-		memset(nbr_address_buffer, 0, sizeof(nbr_address_buffer));
+		(void)memset(nbr_address_buffer, 0,
+			      sizeof(nbr_address_buffer));
 		nbr_populate_addresses();
 	}
 

--- a/subsys/net/ip/net_stats.c
+++ b/subsys/net/ip/net_stats.c
@@ -290,7 +290,7 @@ static int net_stats_get(u32_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	memcpy(data, src, len);
+	(void)memcpy(data, src, len);
 
 	return 0;
 }

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -457,7 +457,7 @@ static int prepare_segment(struct net_tcp *tcp,
 		}
 	}
 
-	memset(tcp_hdr, 0, NET_TCPH_LEN);
+	(void)memset(tcp_hdr, 0, NET_TCPH_LEN);
 
 	tcp_hdr->src_port = src_port;
 	tcp_hdr->dst_port = dst_port;
@@ -1602,8 +1602,8 @@ static int tcp_backlog_ack(struct net_pkt *pkt,
 		return -EINVAL;
 	}
 
-	memcpy(&context->remote, &tcp_backlog[r].remote,
-		sizeof(struct sockaddr));
+	(void)memcpy(&context->remote, &tcp_backlog[r].remote,
+			sizeof(struct sockaddr));
 	context->tcp->send_seq = tcp_backlog[r].send_seq + 1;
 	context->tcp->send_ack = tcp_backlog[r].send_ack;
 	context->tcp->send_mss = tcp_backlog[r].send_mss;
@@ -2397,8 +2397,8 @@ NET_CONN_CB(tcp_syn_rcvd)
 
 		new_context->flags |= NET_CONTEXT_REMOTE_ADDR_SET;
 
-		memcpy(&new_context->remote, &remote_addr,
-		       sizeof(remote_addr));
+		(void)memcpy(&new_context->remote, &remote_addr,
+				sizeof(remote_addr));
 
 		ret = net_tcp_register(net_pkt_family(pkt),
 			       &new_context->remote,

--- a/subsys/net/ip/udp.c
+++ b/subsys/net/ip/udp.c
@@ -114,7 +114,7 @@ struct net_udp_hdr *net_udp_set_hdr(struct net_pkt *pkt,
 		goto out;
 	}
 
-	memcpy(udp_hdr, hdr, sizeof(struct net_udp_hdr));
+	(void)memcpy(udp_hdr, hdr, sizeof(struct net_udp_hdr));
 
 	net_pkt_set_data(pkt, &udp_access);
 out:

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -657,10 +657,10 @@ static bool parse_ipv6(const char *str, size_t str_len,
 		}
 
 		end = MIN(len, ptr - (str + 1));
-		memcpy(ipaddr, str + 1, end);
+		(void)memcpy(ipaddr, str + 1, end);
 	} else {
 		end = len;
-		memcpy(ipaddr, str, end);
+		(void)memcpy(ipaddr, str, end);
 	}
 
 	ipaddr[end] = '\0';
@@ -682,7 +682,7 @@ static bool parse_ipv6(const char *str, size_t str_len,
 		len = str_len - end;
 
 		/* Re-use the ipaddr buf for port conversion */
-		memcpy(ipaddr, ptr + 2, len);
+		(void)memcpy(ipaddr, ptr + 2, len);
 		ipaddr[len] = '\0';
 
 		ret = convert_port(ipaddr, &port);
@@ -743,7 +743,7 @@ static bool parse_ipv4(const char *str, size_t str_len,
 		end = len;
 	}
 
-	memcpy(ipaddr, str, end);
+	(void)memcpy(ipaddr, str, end);
 	ipaddr[end] = '\0';
 
 	addr4 = &net_sin(addr)->sin_addr;
@@ -759,7 +759,7 @@ static bool parse_ipv4(const char *str, size_t str_len,
 		return true;
 	}
 
-	memcpy(ipaddr, ptr + 1, str_len - end);
+	(void)memcpy(ipaddr, ptr + 1, str_len - end);
 	ipaddr[str_len - end] = '\0';
 
 	ret = convert_port(ipaddr, &port);

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -413,7 +413,7 @@ static bool eir_found(u8_t type, const u8_t *data, u8_t data_len,
 		struct bt_uuid *uuid;
 		u16_t u16;
 
-		memcpy(&u16, &data[i], sizeof(u16));
+		(void)memcpy(&u16, &data[i], sizeof(u16));
 		uuid = BT_UUID_DECLARE_16(sys_le16_to_cpu(u16));
 		if (bt_uuid_cmp(uuid, BT_UUID_IPSS)) {
 			continue;

--- a/subsys/net/l2/canbus/6locan.c
+++ b/subsys/net/l2/canbus/6locan.c
@@ -919,16 +919,16 @@ static inline int canbus_send_ff(struct net_pkt *pkt, size_t len, bool mcast,
 
 	if (!mcast && canbus_dest_is_translator(pkt)) {
 		lladdr_inline = net_pkt_lladdr_dst(pkt);
-		memcpy(&frame.data[index], lladdr_inline->addr,
-		       lladdr_inline->len);
+		(void)memcpy(&frame.data[index], lladdr_inline->addr,
+				lladdr_inline->len);
 		index += lladdr_inline->len;
 	}
 
 	if (IS_ENABLED(CONFIG_NET_L2_CANBUS_ETH_TRANSLATOR) &&
 	    net_pkt_lladdr_src(pkt)->type == NET_LINK_ETHERNET) {
 		lladdr_inline = net_pkt_lladdr_src(pkt);
-		memcpy(&frame.data[index], lladdr_inline->addr,
-		       lladdr_inline->len);
+		(void)memcpy(&frame.data[index], lladdr_inline->addr,
+				lladdr_inline->len);
 		index += lladdr_inline->len;
 	}
 
@@ -965,7 +965,8 @@ static inline int canbus_send_single_frame(struct net_pkt *pkt, size_t len,
 
 	if (!mcast && canbus_dest_is_translator(pkt)) {
 		lladdr_dest = net_pkt_lladdr_dst(pkt);
-		memcpy(&frame.data[index], lladdr_dest->addr, lladdr_dest->len);
+		(void)memcpy(&frame.data[index],
+			      lladdr_dest->addr, lladdr_dest->len);
 		index += lladdr_dest->len;
 	}
 
@@ -1326,8 +1327,8 @@ static void extend_llao(struct net_pkt *pkt, struct net_linkaddr *mac_addr)
 		goto done;
 	}
 
-	memcpy(llao_backup, llao, sizeof(struct net_canbus_lladdr));
-	memcpy(llao, mac_addr->addr, mac_addr->len);
+	(void)memcpy(llao_backup, llao, sizeof(struct net_canbus_lladdr));
+	(void)memcpy(llao, mac_addr->addr, mac_addr->len);
 
 	llao[4] = (llao[4] & 0xC0) | llao_backup[0];
 	llao[5] = llao_backup[1];
@@ -1387,8 +1388,8 @@ static void can_to_eth_lladdr(struct net_pkt *pkt, struct net_if *eth_iface,
 
 	lladdr_src->addr = net_pkt_lladdr_src(pkt)->addr -
 			   (sizeof(struct net_eth_addr) - lladdr_src->len);
-	memcpy(lladdr_src->addr, net_if_get_link_addr(eth_iface)->addr,
-	       sizeof(struct net_eth_addr));
+	(void)memcpy(lladdr_src->addr, net_if_get_link_addr(eth_iface)->addr,
+			sizeof(struct net_eth_addr));
 	lladdr_src->addr[4] = (lladdr_src->addr[4] & 0xC0) | (src_can_addr >> 8U);
 	lladdr_src->addr[5] = src_can_addr & 0xFF;
 	lladdr_src->len = sizeof(struct net_eth_addr);

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -295,8 +295,8 @@ static inline struct net_pkt *arp_prepare(struct net_if *iface,
 
 	net_ipaddr_copy(&hdr->dst_ipaddr, next_addr);
 
-	memcpy(hdr->src_hwaddr.addr, net_pkt_lladdr_src(pkt)->addr,
-	       sizeof(struct net_eth_addr));
+	(void)memcpy(hdr->src_hwaddr.addr, net_pkt_lladdr_src(pkt)->addr,
+			sizeof(struct net_eth_addr));
 
 	if (!entry || net_pkt_ipv4_auto(pkt)) {
 		my_addr = current_ip;
@@ -412,7 +412,7 @@ static void arp_gratuitous(struct net_if *iface,
 					   (const u8_t *)hwaddr,
 					   sizeof(struct net_eth_addr))));
 
-		memcpy(&entry->eth, hwaddr, sizeof(struct net_eth_addr));
+		(void)memcpy(&entry->eth, hwaddr, sizeof(struct net_eth_addr));
 	}
 }
 
@@ -439,8 +439,8 @@ static void arp_update(struct net_if *iface,
 
 			entry = arp_entry_find(&arp_table, iface, src, &prev);
 			if (entry) {
-				memcpy(&entry->eth, hwaddr,
-				       sizeof(struct net_eth_addr));
+				(void)memcpy(&entry->eth, hwaddr,
+						sizeof(struct net_eth_addr));
 			} else {
 				/* Add new entry as it was not found and force
 				 * was set.
@@ -455,7 +455,8 @@ static void arp_update(struct net_if *iface,
 					entry->req_start = k_uptime_get_32();
 					entry->iface = iface;
 					net_ipaddr_copy(&entry->ip, src);
-					memcpy(&entry->eth, hwaddr, sizeof(entry->eth));
+					(void)memcpy(&entry->eth, hwaddr,
+						      sizeof(entry->eth));
 					sys_slist_prepend(&arp_table, &entry->node);
 				}
 			}
@@ -476,7 +477,7 @@ static void arp_update(struct net_if *iface,
 	pkt = entry->pending;
 	entry->pending = NULL;
 
-	memcpy(&entry->eth, hwaddr, sizeof(struct net_eth_addr));
+	(void)memcpy(&entry->eth, hwaddr, sizeof(struct net_eth_addr));
 
 	/* Inserting entry into the table */
 	sys_slist_prepend(&arp_table, &entry->node);
@@ -511,10 +512,11 @@ static inline struct net_pkt *arp_prepare_reply(struct net_if *iface,
 	hdr->protolen = sizeof(struct in_addr);
 	hdr->opcode = htons(NET_ARP_REPLY);
 
-	memcpy(&hdr->dst_hwaddr.addr, &dst_addr->addr,
-	       sizeof(struct net_eth_addr));
-	memcpy(&hdr->src_hwaddr.addr, net_if_get_link_addr(iface)->addr,
-	       sizeof(struct net_eth_addr));
+	(void)memcpy(&hdr->dst_hwaddr.addr, &dst_addr->addr,
+			sizeof(struct net_eth_addr));
+	(void)memcpy(&hdr->src_hwaddr.addr,
+			net_if_get_link_addr(iface)->addr,
+			sizeof(struct net_eth_addr));
 
 	net_ipaddr_copy(&hdr->dst_ipaddr, &query->src_ipaddr);
 	net_ipaddr_copy(&hdr->src_ipaddr, &query->dst_ipaddr);

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -54,7 +54,7 @@ void net_eth_ipv6_mcast_to_mac_addr(const struct in6_addr *ipv6_addr,
 	 * last four octets are the last four octets of DST."
 	 */
 	mac_addr->addr[0] = mac_addr->addr[1] = 0x33;
-	memcpy(mac_addr->addr + 2, &ipv6_addr->s6_addr[12], 4);
+	(void)memcpy(mac_addr->addr + 2, &ipv6_addr->s6_addr[12], 4);
 }
 
 #define print_ll_addrs(pkt, type, len, src, dst)			   \
@@ -377,11 +377,11 @@ static bool ethernet_fill_in_dst_on_ipv6_mcast(struct net_pkt *pkt,
 {
 	if (net_pkt_family(pkt) == AF_INET6 &&
 	    net_ipv6_is_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
-		memcpy(dst, (u8_t *)multicast_eth_addr.addr,
-		       sizeof(struct net_eth_addr) - 4);
-		memcpy((u8_t *)dst + 2,
-		       (u8_t *)(&NET_IPV6_HDR(pkt)->dst) + 12,
-		       sizeof(struct net_eth_addr) - 2);
+		(void)memcpy(dst, (u8_t *)multicast_eth_addr.addr,
+				sizeof(struct net_eth_addr) - 4);
+		(void)memcpy((u8_t *)dst + 2,
+				(u8_t *)(&NET_IPV6_HDR(pkt)->dst) + 12,
+				sizeof(struct net_eth_addr) - 2);
 
 		return true;
 	}
@@ -484,12 +484,13 @@ static struct net_buf *ethernet_fill_header(struct ethernet_context *ctx,
 
 		if (!ethernet_fill_in_dst_on_ipv4_mcast(pkt, &hdr_vlan->dst) &&
 		    !ethernet_fill_in_dst_on_ipv6_mcast(pkt, &hdr_vlan->dst)) {
-			memcpy(&hdr_vlan->dst, net_pkt_lladdr_dst(pkt)->addr,
-			       sizeof(struct net_eth_addr));
+			(void)memcpy(&hdr_vlan->dst,
+					net_pkt_lladdr_dst(pkt)->addr,
+					sizeof(struct net_eth_addr));
 		}
 
-		memcpy(&hdr_vlan->src, net_pkt_lladdr_src(pkt)->addr,
-		       sizeof(struct net_eth_addr));
+		(void)memcpy(&hdr_vlan->src, net_pkt_lladdr_src(pkt)->addr,
+				sizeof(struct net_eth_addr));
 
 		hdr_vlan->type = ptype;
 		hdr_vlan->vlan.tpid = htons(NET_ETH_PTYPE_VLAN);
@@ -505,12 +506,13 @@ static struct net_buf *ethernet_fill_header(struct ethernet_context *ctx,
 
 		if (!ethernet_fill_in_dst_on_ipv4_mcast(pkt, &hdr->dst) &&
 		    !ethernet_fill_in_dst_on_ipv6_mcast(pkt, &hdr->dst)) {
-			memcpy(&hdr->dst, net_pkt_lladdr_dst(pkt)->addr,
-			       sizeof(struct net_eth_addr));
+			(void)memcpy(&hdr->dst,
+					net_pkt_lladdr_dst(pkt)->addr,
+					sizeof(struct net_eth_addr));
 		}
 
-		memcpy(&hdr->src, net_pkt_lladdr_src(pkt)->addr,
-		       sizeof(struct net_eth_addr));
+		(void)memcpy(&hdr->src, net_pkt_lladdr_src(pkt)->addr,
+				sizeof(struct net_eth_addr));
 
 		hdr->type = ptype;
 		net_buf_add(hdr_frag, sizeof(struct net_eth_hdr));

--- a/subsys/net/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/l2/ethernet/ethernet_mgmt.c
@@ -112,8 +112,8 @@ static int ethernet_set_config(u32_t mgmt_request,
 			(void)net_if_ipv6_addr_rm(iface, &iid);
 		}
 
-		memcpy(&config.mac_address, &params->mac_address,
-		       sizeof(struct net_eth_addr));
+		(void)memcpy(&config.mac_address, &params->mac_address,
+				sizeof(struct net_eth_addr));
 		type = ETHERNET_CONFIG_TYPE_MAC_ADDRESS;
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_SET_QAV_PARAM) {
 		if (!is_hw_caps_supported(dev, ETHERNET_QAV)) {
@@ -136,8 +136,8 @@ static int ethernet_set_config(u32_t mgmt_request,
 			break;
 		}
 
-		memcpy(&config.qav_param, &params->qav_param,
-		       sizeof(struct ethernet_qav_param));
+		(void)memcpy(&config.qav_param, &params->qav_param,
+				sizeof(struct ethernet_qav_param));
 		type = ETHERNET_CONFIG_TYPE_QAV_PARAM;
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_SET_PROMISC_MODE) {
 		if (!is_hw_caps_supported(dev, ETHERNET_PROMISC_MODE)) {

--- a/subsys/net/l2/ethernet/ethernet_stats.c
+++ b/subsys/net/l2/ethernet/ethernet_stats.c
@@ -44,7 +44,7 @@ static int eth_stats_get(u32_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	memcpy(data, src, len);
+	(void)memcpy(data, src, len);
 
 	return 0;
 }

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -399,9 +399,9 @@ static void gptp_init_clock_ds(void)
 	/* Initialize parent data set. */
 
 	/* parent clock id is initialized to default_ds clock id. */
-	memcpy(parent_ds->port_id.clk_id, default_ds->clk_id,
-	       GPTP_CLOCK_ID_LEN);
-	memcpy(parent_ds->gm_id, default_ds->clk_id, GPTP_CLOCK_ID_LEN);
+	(void)memcpy(parent_ds->port_id.clk_id, default_ds->clk_id,
+			GPTP_CLOCK_ID_LEN);
+	(void)memcpy(parent_ds->gm_id, default_ds->clk_id, GPTP_CLOCK_ID_LEN);
 	parent_ds->port_id.port_number = 0U;
 
 	/* TODO: Check correct value for below field. */
@@ -450,7 +450,8 @@ static void gptp_init_port_ds(int port)
 	port_ds = GPTP_PORT_DS(port);
 
 	/* Initialize port data set. */
-	memcpy(port_ds->port_id.clk_id, default_ds->clk_id, GPTP_CLOCK_ID_LEN);
+	(void)memcpy(port_ds->port_id.clk_id,
+		      default_ds->clk_id, GPTP_CLOCK_ID_LEN);
 	port_ds->port_id.port_number = port;
 
 	port_ds->ptt_port_enabled = true;

--- a/subsys/net/l2/ethernet/gptp/gptp_md.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.c
@@ -20,8 +20,8 @@ static void gptp_md_sync_prepare(struct net_pkt *pkt,
 
 	hdr = GPTP_HDR(pkt);
 
-	memcpy(&hdr->port_id.clk_id, &sync_send->src_port_id.clk_id,
-	       GPTP_CLOCK_ID_LEN);
+	(void)memcpy(&hdr->port_id.clk_id, &sync_send->src_port_id.clk_id,
+			GPTP_CLOCK_ID_LEN);
 
 	hdr->port_id.port_number = htons(port_number);
 
@@ -53,8 +53,8 @@ static void gptp_md_follow_up_prepare(struct net_pkt *pkt,
 	hdr->correction_field += sync_send->follow_up_correction_field;
 	hdr->correction_field <<= 16;
 
-	memcpy(&hdr->port_id.clk_id, &sync_send->src_port_id.clk_id,
-	       GPTP_CLOCK_ID_LEN);
+	(void)memcpy(&hdr->port_id.clk_id, &sync_send->src_port_id.clk_id,
+			GPTP_CLOCK_ID_LEN);
 
 	hdr->port_id.port_number = htons(port_number);
 
@@ -116,8 +116,8 @@ static int gptp_set_md_sync_receive(int port,
 
 	sync_rcv->follow_up_correction_field =
 		ntohll(fup_hdr->correction_field);
-	memcpy(&sync_rcv->src_port_id, &sync_hdr->port_id,
-	       sizeof(struct gptp_port_identity));
+	(void)memcpy(&sync_rcv->src_port_id, &sync_hdr->port_id,
+			sizeof(struct gptp_port_identity));
 	sync_rcv->log_msg_interval = fup_hdr->log_msg_interval;
 	sync_rcv->precise_orig_ts._sec.high =
 		ntohs(fup->prec_orig_ts_secs_high);

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -332,8 +332,8 @@ struct net_pkt *gptp_prepare_pdelay_req(int port)
 	hdr->reserved1 = 0U;
 	hdr->reserved2 = 0U;
 
-	memcpy(hdr->port_id.clk_id,
-	       port_ds->port_id.clk_id, GPTP_CLOCK_ID_LEN);
+	(void)memcpy(hdr->port_id.clk_id,
+			port_ds->port_id.clk_id, GPTP_CLOCK_ID_LEN);
 
 	/* PTP configuration. */
 	(void)memset(&req->reserved1, 0, sizeof(req->reserved1));
@@ -392,16 +392,16 @@ struct net_pkt *gptp_prepare_pdelay_resp(int port,
 	hdr->reserved1 = 0U;
 	hdr->reserved2 = 0U;
 
-	memcpy(hdr->port_id.clk_id, port_ds->port_id.clk_id,
-	       GPTP_CLOCK_ID_LEN);
+	(void)memcpy(hdr->port_id.clk_id, port_ds->port_id.clk_id,
+			GPTP_CLOCK_ID_LEN);
 
 	/* PTP configuration. */
 	pdelay_resp->req_receipt_ts_secs_high = 0U;
 	pdelay_resp->req_receipt_ts_secs_low = 0U;
 	pdelay_resp->req_receipt_ts_nsecs = 0U;
 
-	memcpy(&pdelay_resp->requesting_port_id,
-	       &query->port_id, sizeof(struct gptp_port_identity));
+	(void)memcpy(&pdelay_resp->requesting_port_id,
+			&query->port_id, sizeof(struct gptp_port_identity));
 
 	return pkt;
 }
@@ -454,17 +454,17 @@ struct net_pkt *gptp_prepare_pdelay_follow_up(int port,
 	hdr->reserved1 = 0U;
 	hdr->reserved2 = 0U;
 
-	memcpy(hdr->port_id.clk_id, port_ds->port_id.clk_id,
-	       GPTP_CLOCK_ID_LEN);
+	(void)memcpy(hdr->port_id.clk_id, port_ds->port_id.clk_id,
+			GPTP_CLOCK_ID_LEN);
 
 	/* PTP configuration. */
 	follow_up->resp_orig_ts_secs_high = 0U;
 	follow_up->resp_orig_ts_secs_low = 0U;
 	follow_up->resp_orig_ts_nsecs = 0U;
 
-	memcpy(&follow_up->requesting_port_id,
-	       &pdelay_resp->requesting_port_id,
-	       sizeof(struct gptp_port_identity));
+	(void)memcpy(&follow_up->requesting_port_id,
+			&pdelay_resp->requesting_port_id,
+			sizeof(struct gptp_port_identity));
 
 	return pkt;
 }
@@ -512,8 +512,8 @@ struct net_pkt *gptp_prepare_announce(int port)
 	hdr->flags.octets[1] =
 		global_ds->global_flags.octets[1] | GPTP_FLAG_PTP_TIMESCALE;
 
-	memcpy(hdr->port_id.clk_id, GPTP_DEFAULT_DS()->clk_id,
-	       GPTP_CLOCK_ID_LEN);
+	(void)memcpy(hdr->port_id.clk_id, GPTP_DEFAULT_DS()->clk_id,
+			GPTP_CLOCK_ID_LEN);
 
 	hdr->port_id.port_number = htons(port);
 	hdr->control = GPTP_OTHER_CONTROL_VALUE;
@@ -532,19 +532,19 @@ struct net_pkt *gptp_prepare_announce(int port)
 		ann->root_system_id.grand_master_prio1 = default_ds->priority1;
 		ann->root_system_id.grand_master_prio2 = default_ds->priority2;
 
-		memcpy(&ann->root_system_id.clk_quality,
-		       &default_ds->clk_quality,
-		       sizeof(struct gptp_clock_quality));
+		(void)memcpy(&ann->root_system_id.clk_quality,
+				&default_ds->clk_quality,
+				sizeof(struct gptp_clock_quality));
 
-		memcpy(&ann->root_system_id.grand_master_id,
-		       default_ds->clk_id,
-		       GPTP_CLOCK_ID_LEN);
+		(void)memcpy(&ann->root_system_id.grand_master_id,
+				default_ds->clk_id,
+				GPTP_CLOCK_ID_LEN);
 		break;
 	case GPTP_INFO_IS_RECEIVED:
-		memcpy(&ann->root_system_id,
-		       &GPTP_PORT_BMCA_DATA(port)->
+		(void)memcpy(&ann->root_system_id,
+				&GPTP_PORT_BMCA_DATA(port)->
 				master_priority.root_system_id,
-		       sizeof(struct gptp_root_system_identity));
+				sizeof(struct gptp_root_system_identity));
 		break;
 	default:
 		goto fail;

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -340,7 +340,8 @@ static void gptp_mi_pss_rcv_compute(int port)
 
 	pss->local_port_number = port;
 
-	memcpy(&pss->sync_info, sync_rcv, sizeof(struct gptp_md_sync_info));
+	(void)memcpy(&pss->sync_info, sync_rcv,
+		      sizeof(struct gptp_md_sync_info));
 
 	pss->sync_receipt_timeout_time = gptp_get_current_time_nanosecond(port);
 	pss->sync_receipt_timeout_time +=
@@ -417,10 +418,12 @@ static void gptp_mi_pss_store_last_pss(int port)
 
 	state->last_rcvd_port_num = pss_ptr->local_port_number;
 
-	memcpy(&state->last_precise_orig_ts, &sync_info->precise_orig_ts,
-	       sizeof(struct net_ptp_time));
-	memcpy(&state->last_gm_phase_change, &sync_info->last_gm_phase_change,
-	       sizeof(struct gptp_scaled_ns));
+	(void)memcpy(&state->last_precise_orig_ts,
+			&sync_info->precise_orig_ts,
+			sizeof(struct net_ptp_time));
+	(void)memcpy(&state->last_gm_phase_change,
+			&sync_info->last_gm_phase_change,
+			sizeof(struct gptp_scaled_ns));
 
 	state->last_follow_up_correction_field =
 		sync_info->follow_up_correction_field;
@@ -442,8 +445,8 @@ static void gptp_mi_pss_send_md_sync_send(int port)
 	pss_ptr = state->pss_sync_ptr;
 	sync_send = &GPTP_PORT_STATE(port)->sync_send;
 
-	memcpy(&state->sync_send, &pss_ptr->sync_info,
-	       sizeof(struct gptp_md_sync_info));
+	(void)memcpy(&state->sync_send, &pss_ptr->sync_info,
+			sizeof(struct gptp_md_sync_info));
 
 	sync_send->sync_send_ptr = &state->sync_send;
 	sync_send->rcvd_md_sync = true;
@@ -564,8 +567,8 @@ static void gptp_mi_site_ss_prepare_pss_send(void)
 
 	state = &GPTP_STATE()->site_ss;
 
-	memcpy(&state->pss_send, state->pss_rcv_ptr,
-	       sizeof(struct gptp_mi_port_sync_sync));
+	(void)memcpy(&state->pss_send, state->pss_rcv_ptr,
+			sizeof(struct gptp_mi_port_sync_sync));
 }
 
 static void gptp_mi_site_ss_send_to_pss(void)
@@ -818,14 +821,14 @@ static void gptp_mi_clk_master_sync_offset_state_machine(void)
 
 		if (global_ds->selected_role[0] == GPTP_PORT_PASSIVE) {
 			/* TODO Calculate real values for proper BC support */
-			memset(&global_ds->clk_src_phase_offset, 0x0,
-			       sizeof(struct gptp_scaled_ns));
+			(void)memset(&global_ds->clk_src_phase_offset, 0x0,
+					sizeof(struct gptp_scaled_ns));
 			global_ds->clk_src_freq_offset = 0;
 		} else if (global_ds->clk_src_time_base_indicator_prev
 			   != global_ds->clk_src_time_base_indicator) {
-			memcpy(&global_ds->clk_src_phase_offset,
-			       &global_ds->last_gm_phase_change,
-			       sizeof(struct gptp_scaled_ns));
+			(void)memcpy(&global_ds->clk_src_phase_offset,
+					&global_ds->last_gm_phase_change,
+					sizeof(struct gptp_scaled_ns));
 
 			global_ds->clk_src_freq_offset =
 				global_ds->last_gm_freq_change;
@@ -887,9 +890,9 @@ static void gptp_mi_set_ps_sync_cmss(void)
 	sync_info->follow_up_correction_field = 0;
 	sync_info->rate_ratio = 0;
 
-	memcpy(&sync_info->src_port_id.clk_id,
-	       GPTP_DEFAULT_DS()->clk_id,
-	       GPTP_CLOCK_ID_LEN);
+	(void)memcpy(&sync_info->src_port_id.clk_id,
+			GPTP_DEFAULT_DS()->clk_id,
+			GPTP_CLOCK_ID_LEN);
 
 	sync_info->src_port_id.port_number = 0U;
 	sync_info->log_msg_interval = CONFIG_NET_GPTP_INIT_LOG_SYNC_ITV;
@@ -900,9 +903,9 @@ static void gptp_mi_set_ps_sync_cmss(void)
 	sync_info->gm_time_base_indicator =
 		global_ds->clk_src_time_base_indicator;
 
-	memcpy(&sync_info->last_gm_phase_change,
-	       &global_ds->clk_src_phase_offset,
-	       sizeof(struct gptp_scaled_ns));
+	(void)memcpy(&sync_info->last_gm_phase_change,
+			&global_ds->clk_src_phase_offset,
+			sizeof(struct gptp_scaled_ns));
 
 	sync_info->last_gm_freq_change = global_ds->clk_src_freq_offset;
 }
@@ -974,19 +977,19 @@ static void gptp_compute_gm_rate_ratio(void)
 	global_ds = GPTP_GLOBAL_DS();
 
 	/* Get current local and source time */
-	memcpy(&src_time_n, &state->rcvd_clk_src_req.src_time,
-	       sizeof(struct net_ptp_extended_time));
+	(void)memcpy(&src_time_n, &state->rcvd_clk_src_req.src_time,
+			sizeof(struct net_ptp_extended_time));
 
-	memcpy(&local_time_n, &global_ds->local_time,
-	       sizeof(struct gptp_uscaled_ns));
+	(void)memcpy(&local_time_n, &global_ds->local_time,
+			sizeof(struct gptp_uscaled_ns));
 
 	if ((src_time_0.second == 0U && src_time_0.fract_nsecond == 0U)
 	    || (local_time_0.high == 0U && local_time_0.low == 0U)) {
-		memcpy(&src_time_0, &src_time_n,
-		       sizeof(struct net_ptp_extended_time));
+		(void)memcpy(&src_time_0, &src_time_n,
+				sizeof(struct net_ptp_extended_time));
 
-		memcpy(&local_time_0, &local_time_n,
-		       sizeof(struct gptp_uscaled_ns));
+		(void)memcpy(&local_time_0, &local_time_n,
+				sizeof(struct gptp_uscaled_ns));
 
 		global_ds->gm_rate_ratio = 1.0;
 
@@ -1000,12 +1003,12 @@ static void gptp_compute_gm_rate_ratio(void)
 	    || (src_time_n.second == src_time_0.second
 		&& src_time_n.fract_nsecond < src_time_0.fract_nsecond)) {
 		/* Change result sign and swap src_time_n and src_time_0 */
-		memcpy(&src_time_t, &src_time_n,
-		       sizeof(struct net_ptp_extended_time));
-		memcpy(&src_time_n, &src_time_0,
-		       sizeof(struct net_ptp_extended_time));
-		memcpy(&src_time_0, &src_time_t,
-		       sizeof(struct net_ptp_extended_time));
+		(void)memcpy(&src_time_t, &src_time_n,
+				sizeof(struct net_ptp_extended_time));
+		(void)memcpy(&src_time_n, &src_time_0,
+				sizeof(struct net_ptp_extended_time));
+		(void)memcpy(&src_time_0, &src_time_t,
+				sizeof(struct net_ptp_extended_time));
 
 		new_gm_rate *= -1;
 	}
@@ -1014,12 +1017,12 @@ static void gptp_compute_gm_rate_ratio(void)
 	    || (local_time_n.high == local_time_0.high
 		&& local_time_n.low < local_time_0.low)) {
 		/* Change result sign and swap local_time_n and local_time_0 */
-		memcpy(&local_time_t, &local_time_n,
-		       sizeof(struct gptp_uscaled_ns));
-		memcpy(&local_time_n, &local_time_0,
-		       sizeof(struct gptp_uscaled_ns));
-		memcpy(&local_time_0, &local_time_t,
-		       sizeof(struct gptp_uscaled_ns));
+		(void)memcpy(&local_time_t, &local_time_n,
+				sizeof(struct gptp_uscaled_ns));
+		(void)memcpy(&local_time_n, &local_time_0,
+				sizeof(struct gptp_uscaled_ns));
+		(void)memcpy(&local_time_0, &local_time_t,
+				sizeof(struct gptp_uscaled_ns));
 
 		new_gm_rate *= -1;
 	}
@@ -1068,8 +1071,8 @@ static void gptp_mi_clk_master_sync_rcv_state_machine(void)
 
 	invoke_args.src_time.fract_nsecond = cur * GPTP_POW2_16;
 
-	memset(&invoke_args.last_gm_phase_change, 0x0,
-	       sizeof(struct gptp_scaled_ns));
+	(void)memset(&invoke_args.last_gm_phase_change, 0x0,
+			sizeof(struct gptp_scaled_ns));
 	invoke_args.last_gm_freq_change = 0;
 
 	gptp_clk_src_time_invoke(&invoke_args);
@@ -1104,9 +1107,9 @@ static void gptp_mi_clk_master_sync_rcv_state_machine(void)
 			global_ds->clk_src_time_base_indicator =
 				s->rcvd_clk_src_req.time_base_indicator;
 
-			memcpy(&global_ds->clk_src_last_gm_phase_change,
-			       &s->rcvd_clk_src_req.last_gm_phase_change,
-			       sizeof(struct gptp_scaled_ns));
+			(void)memcpy(&global_ds->clk_src_last_gm_phase_change,
+				&s->rcvd_clk_src_req.last_gm_phase_change,
+				sizeof(struct gptp_scaled_ns));
 
 			global_ds->clk_src_last_gm_freq_change =
 				s->rcvd_clk_src_req.last_gm_freq_change;
@@ -1138,12 +1141,13 @@ static void copy_path_trace(struct gptp_announce *announce)
 
 	sys_path_trace->len = htons(len + GPTP_CLOCK_ID_LEN);
 
-	memcpy(sys_path_trace->path_sequence, announce->tlv.path_sequence,
-	       len);
+	(void)memcpy(sys_path_trace->path_sequence,
+			announce->tlv.path_sequence,
+			len);
 
 	/* Append local clockIdentity. */
-	memcpy((u8_t *)sys_path_trace->path_sequence + len,
-	       GPTP_DEFAULT_DS()->clk_id, GPTP_CLOCK_ID_LEN);
+	(void)memcpy((u8_t *)sys_path_trace->path_sequence + len,
+			GPTP_DEFAULT_DS()->clk_id, GPTP_CLOCK_ID_LEN);
 }
 
 static bool gptp_mi_qualify_announce(int port, struct net_pkt *announce_msg)
@@ -1332,11 +1336,12 @@ static void copy_priority_vector(struct gptp_priority_vector *vector,
 	hdr = GPTP_HDR(pkt);
 	announce = GPTP_ANNOUNCE(pkt);
 
-	memcpy(&vector->root_system_id, &announce->root_system_id,
-	       sizeof(struct gptp_root_system_identity) + sizeof(u16_t));
+	(void)memcpy(&vector->root_system_id, &announce->root_system_id,
+		      sizeof(struct gptp_root_system_identity) +
+		      sizeof(u16_t));
 
-	memcpy(&vector->src_port_id, &hdr->port_id,
-	       sizeof(struct gptp_port_identity));
+	(void)memcpy(&vector->src_port_id, &hdr->port_id,
+			sizeof(struct gptp_port_identity));
 
 	vector->port_number = htons(port);
 }
@@ -1391,9 +1396,9 @@ static void gptp_mi_port_announce_information_state_machine(int port)
 
 	case GPTP_PA_INFO_UPDATE:
 		if (IS_SELECTED(global_ds, port) && bmca_data->updt_info) {
-			memcpy(&bmca_data->port_priority,
-			       &bmca_data->master_priority,
-			       sizeof(struct gptp_priority_vector));
+			(void)memcpy(&bmca_data->port_priority,
+					&bmca_data->master_priority,
+					sizeof(struct gptp_priority_vector));
 
 			bmca_data->port_steps_removed =
 				global_ds->master_steps_removed;
@@ -1507,8 +1512,9 @@ static void gptp_updt_role_disabled_tree(void)
 
 	/* Set pathTrace array to contain the single element thisClock. */
 	global_ds->path_trace.len = htons(GPTP_CLOCK_ID_LEN);
-	memcpy(global_ds->path_trace.path_sequence, GPTP_DEFAULT_DS()->clk_id,
-	       GPTP_CLOCK_ID_LEN);
+	(void)memcpy(global_ds->path_trace.path_sequence,
+			GPTP_DEFAULT_DS()->clk_id,
+			GPTP_CLOCK_ID_LEN);
 }
 
 static void gptp_clear_reselect_tree(void)
@@ -1543,10 +1549,11 @@ static int compute_best_vector(void)
 	gm_prio->root_system_id.clk_quality.offset_scaled_log_var =
 		htons(default_ds->clk_quality.offset_scaled_log_var);
 
-	memcpy(gm_prio->src_port_id.clk_id, default_ds->clk_id,
-	       GPTP_CLOCK_ID_LEN);
-	memcpy(gm_prio->root_system_id.grand_master_id, default_ds->clk_id,
-	       GPTP_CLOCK_ID_LEN);
+	(void)memcpy(gm_prio->src_port_id.clk_id, default_ds->clk_id,
+			GPTP_CLOCK_ID_LEN);
+	(void)memcpy(gm_prio->root_system_id.grand_master_id,
+			default_ds->clk_id,
+			GPTP_CLOCK_ID_LEN);
 
 	best_vector = gm_prio;
 
@@ -1616,16 +1623,16 @@ static int compute_best_vector(void)
 	}
 
 	if (best_port != 0) {
-		memcpy(&global_ds->gm_priority.root_system_id,
-		       &best_vector->root_system_id,
-		       sizeof(struct gptp_root_system_identity));
+		(void)memcpy(&global_ds->gm_priority.root_system_id,
+				&best_vector->root_system_id,
+				sizeof(struct gptp_root_system_identity));
 
 		global_ds->gm_priority.steps_removed =
 			htons(ntohs(best_vector->steps_removed) + 1);
 
-		memcpy(&global_ds->gm_priority.src_port_id,
-		       &best_vector->src_port_id,
-		       sizeof(struct gptp_port_identity));
+		(void)memcpy(&global_ds->gm_priority.src_port_id,
+				&best_vector->src_port_id,
+				sizeof(struct gptp_port_identity));
 
 		global_ds->gm_priority.port_number = best_vector->port_number;
 	}
@@ -1643,18 +1650,18 @@ static void update_bmca(int port,
 
 	/* Update masterPriorityVector for the port. */
 	if (best_port == 0) {
-		memcpy(&bmca_data->master_priority, gm_prio,
-		       sizeof(struct gptp_priority_vector));
+		(void)memcpy(&bmca_data->master_priority, gm_prio,
+				sizeof(struct gptp_priority_vector));
 
 		bmca_data->master_priority.port_number = htons(port);
 		bmca_data->master_priority.src_port_id.port_number =
 			htons(port);
 	} else {
-		memcpy(&bmca_data->master_priority.root_system_id,
-		       &gm_prio->root_system_id,
-		       sizeof(struct gptp_root_system_identity));
-		memcpy(bmca_data->master_priority.src_port_id.clk_id,
-		       default_ds->clk_id, GPTP_CLOCK_ID_LEN);
+		(void)memcpy(&bmca_data->master_priority.root_system_id,
+				&gm_prio->root_system_id,
+				sizeof(struct gptp_root_system_identity));
+		(void)memcpy(bmca_data->master_priority.src_port_id.clk_id,
+				default_ds->clk_id, GPTP_CLOCK_ID_LEN);
 		bmca_data->master_priority.port_number = htons(port);
 		bmca_data->master_priority.src_port_id.port_number =
 			htons(port);
@@ -1734,7 +1741,8 @@ static void gptp_updt_roles_tree(void)
 	last_gm_prio = &global_ds->last_gm_priority;
 
 	/* Save gmPriority. */
-	memcpy(last_gm_prio, gm_prio, sizeof(struct gptp_priority_vector));
+	(void)memcpy(last_gm_prio, gm_prio,
+		      sizeof(struct gptp_priority_vector));
 
 	best_port = compute_best_vector();
 
@@ -1789,8 +1797,8 @@ static void gptp_updt_roles_tree(void)
 	if (memcmp(default_ds->clk_id, gm_prio->root_system_id.grand_master_id,
 		   GPTP_CLOCK_ID_LEN) == 0) {
 		global_ds->path_trace.len = htons(GPTP_CLOCK_ID_LEN);
-		memcpy(global_ds->path_trace.path_sequence,
-		       default_ds->clk_id, GPTP_CLOCK_ID_LEN);
+		(void)memcpy(global_ds->path_trace.path_sequence,
+				default_ds->clk_id, GPTP_CLOCK_ID_LEN);
 	}
 }
 

--- a/subsys/net/l2/ethernet/gptp/gptp_user_api.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_user_api.c
@@ -87,8 +87,8 @@ void gptp_clk_src_time_invoke(struct gptp_clk_src_time_invoke_params *arg)
 
 	state = &GPTP_STATE()->clk_master_sync_receive;
 
-	memcpy(&state->rcvd_clk_src_req, arg,
-	       sizeof(struct gptp_clk_src_time_invoke_params));
+	(void)memcpy(&state->rcvd_clk_src_req, arg,
+			sizeof(struct gptp_clk_src_time_invoke_params));
 
 	state->rcvd_clock_source_req = true;
 }

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -262,8 +262,8 @@ static int ieee802154_send(struct net_if *iface, struct net_pkt *pkt)
 			ieee802154_fragment(&f_ctx, &frame_buf, true);
 			buf = f_ctx.buf;
 		} else {
-			memcpy(frame_buf.data + frame_buf.len,
-			       buf->data, buf->len);
+			(void)memcpy(frame_buf.data + frame_buf.len,
+					buf->data, buf->len);
 			net_buf_add(&frame_buf, buf->len);
 			buf = buf->frags;
 		}
@@ -345,7 +345,7 @@ void ieee802154_init(struct net_if *iface)
 #endif
 
 	sys_memcpy_swap(long_addr, mac, 8);
-	memcpy(ctx->ext_addr, long_addr, 8);
+	(void)memcpy(ctx->ext_addr, long_addr, 8);
 	ieee802154_filter_ieee_addr(iface, ctx->ext_addr);
 
 	if (!ieee802154_set_tx_power(iface, tx_power)) {

--- a/subsys/net/l2/ieee802154/ieee802154_fragment.c
+++ b/subsys/net/l2/ieee802154/ieee802154_fragment.c
@@ -134,7 +134,7 @@ static inline u8_t copy_data(struct ieee802154_fragment_ctx *ctx,
 
 	move = MIN(move, max);
 
-	memcpy(frame_buf->data + frame_buf->len, ctx->pos, move);
+	(void)memcpy(frame_buf->data + frame_buf->len, ctx->pos, move);
 
 	net_buf_add(frame_buf, move);
 

--- a/subsys/net/l2/ieee802154/ieee802154_frame.c
+++ b/subsys/net/l2/ieee802154/ieee802154_frame.c
@@ -615,8 +615,8 @@ u8_t *generate_addressing_fields(struct ieee802154_context *ctx,
 		src_addr->short_addr = sys_cpu_to_le16(params->short_addr);
 		p_buf += IEEE802154_SHORT_ADDR_LENGTH;
 	} else {
-		memcpy(src_addr->ext_addr, ctx->ext_addr,
-		       IEEE802154_EXT_ADDR_LENGTH);
+		(void)memcpy(src_addr->ext_addr, ctx->ext_addr,
+				IEEE802154_EXT_ADDR_LENGTH);
 		p_buf += IEEE802154_EXT_ADDR_LENGTH;
 	}
 

--- a/subsys/net/l2/ieee802154/ieee802154_mgmt.c
+++ b/subsys/net/l2/ieee802154/ieee802154_mgmt.c
@@ -283,8 +283,8 @@ static int ieee802154_associate(u32_t mgmt_request, struct net_if *iface,
 		if (ctx->coord_addr_len == IEEE802154_SHORT_ADDR_LENGTH) {
 			ctx->coord.short_addr = req->short_addr;
 		} else {
-			memcpy(ctx->coord.ext_addr,
-			       req->addr, IEEE802154_EXT_ADDR_LENGTH);
+			(void)memcpy(ctx->coord.ext_addr,
+					req->addr, IEEE802154_EXT_ADDR_LENGTH);
 		}
 	} else {
 		ret = -EACCES;
@@ -410,7 +410,8 @@ static int ieee802154_set_parameters(u32_t mgmt_request,
 		}
 
 		if (memcmp(ctx->ext_addr, data, IEEE802154_EXT_ADDR_LENGTH)) {
-			memcpy(ctx->ext_addr, data, IEEE802154_EXT_ADDR_LENGTH);
+			(void)memcpy(ctx->ext_addr, data,
+				      IEEE802154_EXT_ADDR_LENGTH);
 			ieee802154_filter_ieee_addr(iface, ctx->ext_addr);
 		}
 	} else if (mgmt_request == NET_REQUEST_IEEE802154_SET_SHORT_ADDR) {
@@ -468,7 +469,7 @@ static int ieee802154_get_parameters(u32_t mgmt_request,
 			return -EINVAL;
 		}
 
-		memcpy(data, ctx->ext_addr, IEEE802154_EXT_ADDR_LENGTH);
+		(void)memcpy(data, ctx->ext_addr, IEEE802154_EXT_ADDR_LENGTH);
 	} else if (mgmt_request == NET_REQUEST_IEEE802154_GET_SHORT_ADDR) {
 		*value = ctx->short_addr;
 	} else if (mgmt_request == NET_REQUEST_IEEE802154_GET_TX_POWER) {
@@ -542,7 +543,7 @@ static int ieee802154_get_security_settings(u32_t mgmt_request,
 
 	params = (struct ieee802154_security_params *)data;
 
-	memcpy(params->key, ctx->sec_ctx.key, ctx->sec_ctx.key_len);
+	(void)memcpy(params->key, ctx->sec_ctx.key, ctx->sec_ctx.key_len);
 	params->key_len = ctx->sec_ctx.key_len;
 	params->key_mode = ctx->sec_ctx.key_mode;
 	params->level = ctx->sec_ctx.level;

--- a/subsys/net/l2/ieee802154/ieee802154_security.c
+++ b/subsys/net/l2/ieee802154/ieee802154_security.c
@@ -44,7 +44,7 @@ int ieee802154_security_setup_session(struct ieee802154_security_ctx *sec_ctx,
 	sec_ctx->level = level;
 
 	if (level > IEEE802154_SECURITY_LEVEL_NONE) {
-		memcpy(sec_ctx->key, key, key_len);
+		(void)memcpy(sec_ctx->key, key, key_len);
 		sec_ctx->key_len = key_len;
 		sec_ctx->key_mode = key_mode;
 
@@ -99,7 +99,7 @@ bool ieee802154_decrypt_auth(struct ieee802154_security_ctx *sec_ctx,
 	}
 
 	/* See Section 7.3.2 */
-	memcpy(nonce, src_ext_addr, IEEE802154_EXT_ADDR_LENGTH);
+	(void)memcpy(nonce, src_ext_addr, IEEE802154_EXT_ADDR_LENGTH);
 	nonce[8] = (u8_t)(frame_counter >> 24);
 	nonce[9] = (u8_t)(frame_counter >> 16);
 	nonce[10] = (u8_t)(frame_counter >> 8);
@@ -144,7 +144,7 @@ bool ieee802154_encrypt_auth(struct ieee802154_security_ctx *sec_ctx,
 	}
 
 	/* See Section 7.3.2 */
-	memcpy(nonce, src_ext_addr, IEEE802154_EXT_ADDR_LENGTH);
+	(void)memcpy(nonce, src_ext_addr, IEEE802154_EXT_ADDR_LENGTH);
 	sys_put_be32(sec_ctx->frame_counter, &nonce[8]);
 	nonce[12] = sec_ctx->level;
 

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -84,7 +84,7 @@ void otPlatRadioGetIeeeEui64(otInstance *instance, uint8_t *ieee_eui64)
 {
 	ARG_UNUSED(instance);
 
-	memcpy(ieee_eui64, ll_addr->addr, ll_addr->len);
+	(void)memcpy(ieee_eui64, ll_addr->addr, ll_addr->len);
 }
 
 void otTaskletsSignalPending(otInstance *instance)

--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -137,9 +137,9 @@ void add_ipv6_addr_to_ot(struct openthread_context *context)
 	/* save the last added IP address for this interface */
 	for (i = NET_IF_MAX_IPV6_ADDR - 1; i >= 0; i--) {
 		if (ipv6->unicast[i].is_used) {
-			memcpy(&addr.mAddress,
-			       &ipv6->unicast[i].address.in6_addr,
-			       sizeof(addr.mAddress));
+			(void)memcpy(&addr.mAddress,
+					&ipv6->unicast[i].address.in6_addr,
+					sizeof(addr.mAddress));
 			break;
 		}
 	}
@@ -177,9 +177,9 @@ void add_ipv6_maddr_to_ot(struct openthread_context *context)
 	/* save the last added IP address for this interface */
 	for (i = NET_IF_MAX_IPV6_MADDR - 1; i >= 0; i--) {
 		if (ipv6->mcast[i].is_used) {
-			memcpy(&addr,
-			       &ipv6->mcast[i].address.in6_addr,
-			       sizeof(addr));
+			(void)memcpy(&addr,
+					&ipv6->mcast[i].address.in6_addr,
+					sizeof(addr));
 			break;
 		}
 	}

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -59,7 +59,7 @@ static struct net_buf *ipcp_config_info_add(struct ppp_fsm *fsm)
 
 	option[0] = IPCP_OPTION_IP_ADDRESS;
 	option[1] = IP_ADDRESS_OPTION_LEN;
-	memcpy(&option[2], &my_addr->s_addr, sizeof(my_addr->s_addr));
+	(void)memcpy(&option[2], &my_addr->s_addr, sizeof(my_addr->s_addr));
 
 	buf = ppp_get_net_buf(NULL, 0);
 	if (!buf) {
@@ -94,8 +94,8 @@ static int ipcp_config_info_req(struct ppp_fsm *fsm,
 	enum net_verdict verdict;
 	int i;
 
-	memset(options, 0, sizeof(options));
-	memset(nack_options, 0, sizeof(nack_options));
+	(void)memset(options, 0, sizeof(options));
+	(void)memset(nack_options, 0, sizeof(nack_options));
 
 	verdict = ppp_parse_options(fsm, pkt, length, options,
 				    ARRAY_SIZE(options));
@@ -135,9 +135,9 @@ static int ipcp_config_info_req(struct ppp_fsm *fsm,
 			nack_options[nack_idx].len = options[i].len;
 
 			if (options[i].len > 2) {
-				memcpy(&nack_options[nack_idx].value,
-				       &options[i].value,
-				       sizeof(nack_options[nack_idx].value));
+				(void)memcpy(&nack_options[nack_idx].value,
+					  &options[i].value,
+					  sizeof(nack_options[nack_idx].value));
 			}
 
 			nack_idx++;
@@ -221,7 +221,8 @@ static int ipcp_config_info_req(struct ppp_fsm *fsm,
 			return -EMSGSIZE;
 		}
 
-		memcpy(&ctx->ipcp.peer_options.address, &addr, sizeof(addr));
+		(void)memcpy(&ctx->ipcp.peer_options.address,
+			      &addr, sizeof(addr));
 
 		if (CONFIG_NET_L2_PPP_LOG_LEVEL >= LOG_LEVEL_DBG) {
 			char dst[INET_ADDRSTRLEN];
@@ -293,7 +294,7 @@ static int ipcp_config_info_rej(struct ppp_fsm *fsm,
 	int i, ret, address_option_idx = -1;
 	struct in_addr addr;
 
-	memset(nack_options, 0, sizeof(nack_options));
+	(void)memset(nack_options, 0, sizeof(nack_options));
 
 	verdict = ppp_parse_options(fsm, pkt, length, nack_options,
 				    ARRAY_SIZE(nack_options));
@@ -432,7 +433,7 @@ static void ipcp_init(struct ppp_context *ctx)
 	NET_DBG("proto %s (0x%04x) fsm %p", ppp_proto2str(PPP_IPCP), PPP_IPCP,
 		&ctx->ipcp.fsm);
 
-	memset(&ctx->ipcp.fsm, 0, sizeof(ctx->ipcp.fsm));
+	(void)memset(&ctx->ipcp.fsm, 0, sizeof(ctx->ipcp.fsm));
 
 	ppp_fsm_init(&ctx->ipcp.fsm, PPP_IPCP);
 

--- a/subsys/net/l2/ppp/ipv6cp.c
+++ b/subsys/net/l2/ppp/ipv6cp.c
@@ -55,17 +55,17 @@ static struct net_buf *ipv6cp_config_info_add(struct ppp_fsm *fsm)
 
 	linkaddr = net_if_get_link_addr(ctx->iface);
 	if (linkaddr->len == 8) {
-		memcpy(iid, linkaddr->addr, sizeof(iid));
+		(void)memcpy(iid, linkaddr->addr, sizeof(iid));
 	} else {
-		memcpy(iid, linkaddr->addr, 3);
+		(void)memcpy(iid, linkaddr->addr, 3);
 		iid[3] = 0xff;
 		iid[4] = 0xfe;
-		memcpy(iid + 5, linkaddr->addr + 3, 3);
+		(void)memcpy(iid + 5, linkaddr->addr + 3, 3);
 	}
 
 	option[0] = IPV6CP_OPTION_INTERFACE_IDENTIFIER;
 	option[1] = INTERFACE_IDENTIFIER_OPTION_LEN;
-	memcpy(&option[2], iid, sizeof(iid));
+	(void)memcpy(&option[2], iid, sizeof(iid));
 
 	buf = ppp_get_net_buf(NULL, sizeof(option));
 	if (!buf) {
@@ -100,8 +100,8 @@ static int ipv6cp_config_info_req(struct ppp_fsm *fsm,
 	enum net_verdict verdict;
 	int i;
 
-	memset(options, 0, sizeof(options));
-	memset(nack_options, 0, sizeof(nack_options));
+	(void)memset(options, 0, sizeof(options));
+	(void)memset(nack_options, 0, sizeof(nack_options));
 
 	verdict = ppp_parse_options(fsm, pkt, length, options,
 				    ARRAY_SIZE(options));
@@ -133,9 +133,9 @@ static int ipv6cp_config_info_req(struct ppp_fsm *fsm,
 			nack_options[nack_idx].len = options[i].len;
 
 			if (options[i].len > 2) {
-				memcpy(&nack_options[nack_idx].value,
-				       &options[i].value,
-				       sizeof(nack_options[nack_idx].value));
+				(void)memcpy(&nack_options[nack_idx].value,
+					  &options[i].value,
+					  sizeof(nack_options[nack_idx].value));
 			}
 
 			nack_idx++;
@@ -221,8 +221,8 @@ static int ipv6cp_config_info_req(struct ppp_fsm *fsm,
 			return -EMSGSIZE;
 		}
 
-		memcpy(ctx->ipv6cp.peer_options.iid, iface_id,
-		       sizeof(iface_id));
+		(void)memcpy(ctx->ipv6cp.peer_options.iid, iface_id,
+				sizeof(iface_id));
 
 		if (CONFIG_NET_L2_PPP_LOG_LEVEL >= LOG_LEVEL_DBG) {
 			u8_t iid_str[sizeof("xx:xx:xx:xx:xx:xx:xx:xx")];
@@ -284,7 +284,7 @@ static int config_info_ack_rej(struct ppp_context *ctx,
 	int i, ret, iface_id_option_idx = -1;
 	enum net_verdict verdict;
 
-	memset(nack_options, 0, sizeof(nack_options));
+	(void)memset(nack_options, 0, sizeof(nack_options));
 
 	verdict = ppp_parse_options(fsm, pkt, length, nack_options,
 				    ARRAY_SIZE(nack_options));
@@ -327,7 +327,8 @@ static int config_info_ack_rej(struct ppp_context *ctx,
 		return -EMSGSIZE;
 	}
 
-	memcpy(ctx->ipv6cp.peer_accepted.iid, iface_id, sizeof(iface_id));
+	(void)memcpy(ctx->ipv6cp.peer_accepted.iid,
+		      iface_id, sizeof(iface_id));
 
 	if (CONFIG_NET_L2_PPP_LOG_LEVEL >= LOG_LEVEL_DBG) {
 		u8_t iid_str[sizeof("xx:xx:xx:xx:xx:xx:xx:xx")];
@@ -389,7 +390,7 @@ static void setup_iid_address(u8_t *iid, struct in6_addr *addr)
 	addr->s6_addr[1] = 0x80;
 	UNALIGNED_PUT(0, &addr->s6_addr16[1]);
 	UNALIGNED_PUT(0, &addr->s6_addr32[1]);
-	memcpy(&addr->s6_addr[8], iid, PPP_INTERFACE_IDENTIFIER_LEN);
+	(void)memcpy(&addr->s6_addr[8], iid, PPP_INTERFACE_IDENTIFIER_LEN);
 
 	/* TODO: should we toggle local/global bit */
 	/* addr->s6_addr[8] ^= 0x02; */
@@ -547,7 +548,7 @@ static void ipv6cp_init(struct ppp_context *ctx)
 	NET_DBG("proto %s (0x%04x) fsm %p", ppp_proto2str(PPP_IPV6CP),
 		PPP_IPV6CP, &ctx->ipv6cp.fsm);
 
-	memset(&ctx->ipv6cp.fsm, 0, sizeof(ctx->ipv6cp.fsm));
+	(void)memset(&ctx->ipv6cp.fsm, 0, sizeof(ctx->ipv6cp.fsm));
 
 	ppp_fsm_init(&ctx->ipv6cp.fsm, PPP_IPV6CP);
 

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -84,8 +84,8 @@ static int lcp_config_info_req(struct ppp_fsm *fsm,
 	int i, nack_idx = 0;
 	int count_rej = 0, count_nack = 0;
 
-	memset(options, 0, sizeof(options));
-	memset(nack_options, 0, sizeof(nack_options));
+	(void)memset(options, 0, sizeof(options));
+	(void)memset(nack_options, 0, sizeof(nack_options));
 
 	verdict = ppp_parse_options(fsm, pkt, length, options,
 				    ARRAY_SIZE(options));
@@ -140,9 +140,9 @@ static int lcp_config_info_req(struct ppp_fsm *fsm,
 			nack_options[nack_idx].len = options[i].len;
 
 			if (options[i].len > 2) {
-				memcpy(&nack_options[nack_idx].value,
-				       &options[i].value,
-				       sizeof(nack_options[nack_idx].value));
+				(void)memcpy(&nack_options[nack_idx].value,
+					  &options[i].value,
+					  sizeof(nack_options[nack_idx].value));
 			}
 
 			nack_idx++;
@@ -285,7 +285,7 @@ static void lcp_init(struct ppp_context *ctx)
 	NET_DBG("proto %s (0x%04x) fsm %p", ppp_proto2str(PPP_LCP), PPP_LCP,
 		&ctx->lcp.fsm);
 
-	memset(&ctx->lcp.fsm, 0, sizeof(ctx->lcp.fsm));
+	(void)memset(&ctx->lcp.fsm, 0, sizeof(ctx->lcp.fsm));
 
 	ppp_fsm_init(&ctx->lcp.fsm, PPP_LCP);
 

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -465,7 +465,7 @@ void net_ppp_init(struct net_if *iface)
 	NET_DBG("Initializing PPP L2 %p for iface %p", ctx, iface);
 
 	if (!ctx->is_init) {
-		memset(ctx, 0, sizeof(*ctx));
+		(void)memset(ctx, 0, sizeof(*ctx));
 	}
 
 	ctx->ppp_l2_flags = NET_L2_MULTICAST | NET_L2_POINT_TO_POINT;

--- a/subsys/net/l2/ppp/ppp_stats.c
+++ b/subsys/net/l2/ppp/ppp_stats.c
@@ -43,7 +43,7 @@ static int ppp_stats_get(u32_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	memcpy(data, src, len);
+	(void)memcpy(data, src, len);
 
 	return 0;
 }

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -86,7 +86,7 @@ static inline bool append(struct coap_packet *cpkt, const u8_t *data, u16_t len)
 		return false;
 	}
 
-	memcpy(cpkt->data + cpkt->offset, data, len);
+	(void)memcpy(cpkt->data + cpkt->offset, data, len);
 	cpkt->offset += len;
 
 	return true;
@@ -103,7 +103,7 @@ int coap_packet_init(struct coap_packet *cpkt, u8_t *data,
 		return -EINVAL;
 	}
 
-	memset(cpkt, 0, sizeof(*cpkt));
+	(void)memset(cpkt, 0, sizeof(*cpkt));
 
 	cpkt->data = data;
 	cpkt->offset = 0U;
@@ -379,7 +379,7 @@ static int read(u8_t *data, u16_t offset, u16_t *pos,
 		return -EINVAL;
 	}
 
-	memcpy(value, data + offset, len);
+	(void)memcpy(value, data + offset, len);
 	offset += len;
 	*pos = offset;
 
@@ -540,7 +540,7 @@ int coap_packet_parse(struct coap_packet *cpkt, u8_t *data, u16_t len,
 	}
 
 	if (options) {
-		memset(options, 0, opt_num * sizeof(struct coap_option));
+		(void)memset(options, 0, opt_num * sizeof(struct coap_option));
 	}
 
 	cpkt->data = data;
@@ -662,7 +662,7 @@ u8_t coap_header_get_token(const struct coap_packet *cpkt, u8_t *token)
 
 	tkl = cpkt->data[0] & 0x0f;
 	if (tkl) {
-		memcpy(token, cpkt->data + BASIC_HEADER_SIZE, tkl);
+		(void)memcpy(token, cpkt->data + BASIC_HEADER_SIZE, tkl);
 	}
 
 	return tkl;
@@ -1052,11 +1052,11 @@ int coap_pending_init(struct coap_pending *pending,
 		      const struct coap_packet *request,
 		      const struct sockaddr *addr)
 {
-	memset(pending, 0, sizeof(*pending));
+	(void)memset(pending, 0, sizeof(*pending));
 
 	pending->id = coap_header_get_id(request);
 
-	memcpy(&pending->addr, addr, sizeof(*addr));
+	(void)memcpy(&pending->addr, addr, sizeof(*addr));
 
 	pending->data = request->data;
 	pending->len = request->offset;
@@ -1275,7 +1275,7 @@ void coap_reply_init(struct coap_reply *reply,
 	tkl = coap_header_get_token(request, (u8_t *)&token);
 
 	if (tkl > 0) {
-		memcpy(reply->token, token, tkl);
+		(void)memcpy(reply->token, token, tkl);
 	}
 
 	reply->tkl = tkl;

--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -62,7 +62,7 @@ static inline bool append(struct coap_packet *cpkt, const u8_t *data, u16_t len)
 		return false;
 	}
 
-	memcpy(cpkt->data + cpkt->offset, data, len);
+	(void)memcpy(cpkt->data + cpkt->offset, data, len);
 	cpkt->offset += len;
 
 	return true;

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -193,9 +193,9 @@ static void ipv6_event_handler(struct net_mgmt_event_callback *cb,
 		/* save the last added IP address for this interface */
 		for (i = NET_IF_MAX_IPV6_ADDR - 1; i >= 0; i--) {
 			if (ipv6->unicast[i].is_used) {
-				memcpy(&laddr,
-				       &ipv6->unicast[i].address.in6_addr,
-				       sizeof(laddr));
+				(void)memcpy(&laddr,
+					    &ipv6->unicast[i].address.in6_addr,
+					    sizeof(laddr));
 			}
 		}
 	}

--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -270,7 +270,7 @@ int dns_msg_pack_query(u8_t *buf, u16_t *len, u16_t size,
 	}
 
 	offset = DNS_MSG_HEADER_SIZE;
-	memcpy(buf + offset, qname, qname_len);
+	(void)memcpy(buf + offset, qname, qname_len);
 
 	offset += qname_len;
 
@@ -387,7 +387,8 @@ int dns_copy_qname(u8_t *buf, u16_t *len, u16_t size,
 		}
 
 		/* copy the lb_size value and label elements */
-		memcpy(buf + *len, msg + pos, DNS_LABEL_LEN_SIZE + lb_size);
+		(void)memcpy(buf + *len, msg + pos,
+			      DNS_LABEL_LEN_SIZE + lb_size);
 		/* update destination buffer len */
 		*len += DNS_LABEL_LEN_SIZE + lb_size;
 		/* update msg ptr position */

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -202,7 +202,8 @@ static int add_answer(struct net_buf *query, u32_t ttl,
 	const u16_t q_len = query->len + 1 + DNS_QTYPE_LEN + DNS_QCLASS_LEN;
 	u16_t offset = DNS_MSG_HEADER_SIZE + q_len;
 
-	memcpy(query->data + offset, query->data + DNS_MSG_HEADER_SIZE, q_len);
+	(void)memcpy(query->data + offset,
+		      query->data + DNS_MSG_HEADER_SIZE, q_len);
 	offset += q_len;
 
 	UNALIGNED_PUT(htonl(ttl), query->data + offset);
@@ -211,7 +212,7 @@ static int add_answer(struct net_buf *query, u32_t ttl,
 	UNALIGNED_PUT(htons(addr_len), query->data + offset);
 	offset += DNS_RDLENGTH_LEN;
 
-	memcpy(query->data + offset, addr, addr_len);
+	(void)memcpy(query->data + offset, addr, addr_len);
 
 	return offset + addr_len;
 }

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -173,7 +173,7 @@ static void add_answer(struct net_buf *query, enum dns_rr_type qtype,
 	UNALIGNED_PUT(htons(addr_len), query->data + offset);
 
 	offset += DNS_RDLENGTH_LEN;
-	memcpy(query->data + offset, addr, addr_len);
+	(void)memcpy(query->data + offset, addr, addr_len);
 }
 
 static int create_answer(struct net_context *ctx,

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -232,8 +232,9 @@ int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[],
 
 	if (servers_sa) {
 		for (i = 0; idx < SERVER_COUNT && servers_sa[i]; i++) {
-			memcpy(&ctx->servers[idx].dns_server, servers_sa[i],
-			       sizeof(ctx->servers[idx].dns_server));
+			(void)memcpy(&ctx->servers[idx].dns_server,
+					servers_sa[i],
+					sizeof(ctx->servers[idx].dns_server));
 			dns_postprocess_server(ctx, idx);
 			idx++;
 		}
@@ -448,7 +449,7 @@ static int dns_read(struct dns_resolve_context *ctx,
 
 			src = dns_msg.msg + dns_msg.response_position;
 
-			memcpy(addr, src, address_size);
+			(void)memcpy(addr, src, address_size);
 
 			ctx->queries[query_idx].cb(DNS_EAI_INPROGRESS, &info,
 					ctx->queries[query_idx].user_data);
@@ -756,15 +757,16 @@ int dns_resolve_name(struct dns_resolve_context *ctx,
 		struct dns_addrinfo info = { 0 };
 
 		if (type == DNS_QUERY_TYPE_A) {
-			memcpy(net_sin(&info.ai_addr), net_sin(&addr),
-			       sizeof(struct sockaddr_in));
+			(void)memcpy(net_sin(&info.ai_addr), net_sin(&addr),
+					sizeof(struct sockaddr_in));
 			info.ai_family = AF_INET;
 			info.ai_addr.sa_family = AF_INET;
 			info.ai_addrlen = sizeof(struct sockaddr_in);
 		} else if (type == DNS_QUERY_TYPE_AAAA) {
 #if defined(CONFIG_NET_IPV6)
-			memcpy(net_sin6(&info.ai_addr), net_sin6(&addr),
-			       sizeof(struct sockaddr_in6));
+			(void)memcpy(net_sin6(&info.ai_addr),
+					net_sin6(&addr),
+					sizeof(struct sockaddr_in6));
 			info.ai_family = AF_INET6;
 			info.ai_addr.sa_family = AF_INET6;
 			info.ai_addrlen = sizeof(struct sockaddr_in6);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -277,7 +277,7 @@ init_block_ctx(const u8_t *token, u8_t tkl, struct block_context **ctx)
 	}
 
 	(*ctx)->tkl = tkl;
-	memcpy((*ctx)->token, token, tkl);
+	(void)memcpy((*ctx)->token, token, tkl);
 	coap_block_transfer_init(&(*ctx)->ctx, lwm2m_default_block_size(), 0);
 	(*ctx)->timestamp = timestamp;
 
@@ -436,7 +436,7 @@ static int engine_add_observer(struct lwm2m_message *msg,
 		if (obs->ctx == msg->ctx &&
 		    memcmp(&obs->path, &msg->path, sizeof(msg->path)) == 0) {
 			/* quietly update the token information */
-			memcpy(obs->token, token, tkl);
+			(void)memcpy(obs->token, token, tkl);
 			obs->tkl = tkl;
 
 			LOG_DBG("OBSERVER DUPLICATE %u/%u/%u(%u) [%s]",
@@ -527,8 +527,9 @@ static int engine_add_observer(struct lwm2m_message *msg,
 
 	/* copy the values and add it to the list */
 	observe_node_data[i].ctx = msg->ctx;
-	memcpy(&observe_node_data[i].path, &msg->path, sizeof(msg->path));
-	memcpy(observe_node_data[i].token, token, tkl);
+	(void)memcpy(&observe_node_data[i].path, &msg->path,
+		      sizeof(msg->path));
+	(void)memcpy(observe_node_data[i].token, token, tkl);
 	observe_node_data[i].tkl = tkl;
 	observe_node_data[i].last_timestamp = k_uptime_get();
 	observe_node_data[i].event_timestamp =
@@ -1060,7 +1061,7 @@ u16_t lwm2m_get_rd_data(u8_t *client_data, u16_t size)
 	int len;
 
 	/* Add resource-type/content-type to the registration message */
-	memcpy(client_data, REG_PREFACE, sizeof(REG_PREFACE) - 1);
+	(void)memcpy(client_data, REG_PREFACE, sizeof(REG_PREFACE) - 1);
 	pos += sizeof(REG_PREFACE) - 1;
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&engine_obj_list, obj, node) {
@@ -1078,7 +1079,7 @@ u16_t lwm2m_get_rd_data(u8_t *client_data, u16_t size)
 				break;
 			}
 
-			memcpy(&client_data[pos], temp, len);
+			(void)memcpy(&client_data[pos], temp, len);
 			pos += len;
 			continue;
 		}
@@ -1100,7 +1101,7 @@ u16_t lwm2m_get_rd_data(u8_t *client_data, u16_t size)
 					break;
 				}
 
-				memcpy(&client_data[pos], temp, len);
+				(void)memcpy(&client_data[pos], temp, len);
 				pos += len;
 			}
 		}
@@ -1452,11 +1453,11 @@ static int lwm2m_engine_set(char *pathstr, void *value, u16_t len)
 	switch (obj_field->data_type) {
 
 	case LWM2M_RES_TYPE_OPAQUE:
-		memcpy((u8_t *)data_ptr, value, len);
+		(void)memcpy((u8_t *)data_ptr, value, len);
 		break;
 
 	case LWM2M_RES_TYPE_STRING:
-		memcpy((u8_t *)data_ptr, value, len);
+		(void)memcpy((u8_t *)data_ptr, value, len);
 		((u8_t *)data_ptr)[len] = '\0';
 		break;
 
@@ -1691,7 +1692,7 @@ static int lwm2m_engine_get(char *pathstr, void *buf, u16_t buflen)
 				return -ENOMEM;
 			}
 
-			memcpy(buf, data_ptr, data_len);
+			(void)memcpy(buf, data_ptr, data_len);
 			break;
 
 		case LWM2M_RES_TYPE_STRING:
@@ -2517,7 +2518,7 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 		}
 
 		vlen = options[i].len - plen - 1;
-		memcpy(opt_buf, options[i].value + plen + 1, vlen);
+		(void)memcpy(opt_buf, options[i].value + plen + 1, vlen);
 		opt_buf[vlen] = '\0';
 
 		/* convert value to integer or float */
@@ -2550,7 +2551,8 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 		if (type <= LWM2M_ATTR_PMAX) {
 			*(s32_t *)nattr_ptrs[type] = val.val1;
 		} else {
-			memcpy(nattr_ptrs[type], &val, sizeof(float32_value_t));
+			(void)memcpy(nattr_ptrs[type], &val,
+				      sizeof(float32_value_t));
 		}
 
 		nattrs.flags |= BIT(type);
@@ -2617,8 +2619,8 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 				continue;
 			}
 
-			memcpy(&attr->float_val, nattr_ptrs[type],
-			       sizeof(float32_value_t));
+			(void)memcpy(&attr->float_val, nattr_ptrs[type],
+					sizeof(float32_value_t));
 		}
 
 		LOG_DBG("Update %s to %d.%06d",
@@ -2651,8 +2653,8 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 			attr->int_val = *(s32_t *)nattr_ptrs[type];
 			update_observe_node = true;
 		} else {
-			memcpy(&attr->float_val, nattr_ptrs[type],
-			       sizeof(float32_value_t));
+			(void)memcpy(&attr->float_val, nattr_ptrs[type],
+					sizeof(float32_value_t));
 		}
 
 		nattrs.flags &= ~BIT(type);
@@ -2846,7 +2848,7 @@ int lwm2m_perform_read_op(struct lwm2m_message *msg, u16_t content_format)
 	}
 
 	/* store original path values so we can change them during processing */
-	memcpy(&temp_path, &msg->path, sizeof(temp_path));
+	(void)memcpy(&temp_path, &msg->path, sizeof(temp_path));
 	engine_put_begin(&msg->out, &msg->path);
 
 	while (obj_inst) {
@@ -2932,7 +2934,7 @@ move_forward:
 	engine_put_end(&msg->out, &msg->path);
 
 	/* restore original path values */
-	memcpy(&msg->path, &temp_path, sizeof(temp_path));
+	(void)memcpy(&msg->path, &temp_path, sizeof(temp_path));
 
 	/* did not read anything even if we should have - on single item */
 	if (ret == 0 && num_read == 0U && msg->path.level == 3U) {
@@ -3781,7 +3783,7 @@ static int generate_notify_message(struct observe_node *obs,
 	}
 
 	/* copy path */
-	memcpy(&msg->path, &obs->path, sizeof(struct lwm2m_obj_path));
+	(void)memcpy(&msg->path, &obs->path, sizeof(struct lwm2m_obj_path));
 	msg->operation = LWM2M_OP_READ;
 
 	LOG_DBG("[%s] NOTIFY MSG START: %u/%u/%u(%u) token:'%s' [%s] %lld",
@@ -4273,7 +4275,7 @@ int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls)
 			goto cleanup;
 		}
 
-		memcpy(addr, res->ai_addr, sizeof(*addr));
+		(void)memcpy(addr, res->ai_addr, sizeof(*addr));
 		addr->sa_family = res->ai_family;
 		free(res);
 #else

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -270,8 +270,8 @@ do_firmware_transfer_reply_cb(const struct coap_packet *response,
 	}
 
 	/* save main firmware block context */
-	memcpy(&received_block_ctx, &firmware_block_ctx,
-	       sizeof(firmware_block_ctx));
+	(void)memcpy(&received_block_ctx, &firmware_block_ctx,
+			sizeof(firmware_block_ctx));
 
 	ret = coap_update_from_block(check_response, &firmware_block_ctx);
 	if (ret < 0) {
@@ -285,8 +285,8 @@ do_firmware_transfer_reply_cb(const struct coap_packet *response,
 		LOG_WRN("Duplicate packet ignored");
 
 		/* restore main firmware block context */
-		memcpy(&firmware_block_ctx, &received_block_ctx,
-		       sizeof(firmware_block_ctx));
+		(void)memcpy(&firmware_block_ctx, &received_block_ctx,
+				sizeof(firmware_block_ctx));
 
 		/* set reply->user_data to error to avoid releasing */
 		reply->user_data = (void *)COAP_REPLY_STATUS_ERROR;

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -269,8 +269,8 @@ static int do_registration_reply_cb(const struct coap_packet *response,
 			return -EINVAL;
 		}
 
-		memcpy(client.server_ep, options[1].value,
-		       options[1].len);
+		(void)memcpy(client.server_ep, options[1].value,
+				options[1].len);
 		client.server_ep[options[1].len] = '\0';
 		set_sm_state(ENGINE_REGISTRATION_DONE);
 		LOG_INF("Registration Done (EP='%s')",

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -781,7 +781,7 @@ int do_write_op_json(struct lwm2m_message *msg)
 	engine_set_in_user_data(&msg->in, &fd);
 
 	/* store a copy of the original path */
-	memcpy(&orig_path, &msg->path, sizeof(msg->path));
+	(void)memcpy(&orig_path, &msg->path, sizeof(msg->path));
 
 	/* PARSE base name "bn" */
 	json_next_token(&msg->in, &fd);

--- a/subsys/net/lib/lwm2m/lwm2m_util.c
+++ b/subsys/net/lib/lwm2m/lwm2m_util.c
@@ -22,7 +22,7 @@ int lwm2m_f32_to_b32(float32_value_t *f32, u8_t *b32, size_t len)
 
 	/* handle zero value special case */
 	if (f32->val1 == 0 && f32->val2 == 0) {
-		memset(b32, 0, len);
+		(void)memset(b32, 0, len);
 		return 0;
 	}
 
@@ -73,7 +73,7 @@ int lwm2m_f32_to_b32(float32_value_t *f32, u8_t *b32, size_t len)
 	/* adjust exponent for bias */
 	e += 127;
 
-	memset(b32, 0, len);
+	(void)memset(b32, 0, len);
 
 	/* sign: bit 31 */
 	b32[0] = f32->val1 < 0 ? 0x80 : 0;
@@ -104,7 +104,7 @@ int lwm2m_f64_to_b64(float64_value_t *f64, u8_t *b64, size_t len)
 
 	/* handle zero value special case */
 	if (f64->val1 == 0LL && f64->val2 == 0LL) {
-		memset(b64, 0, len);
+		(void)memset(b64, 0, len);
 		return 0;
 	}
 
@@ -155,7 +155,7 @@ int lwm2m_f64_to_b64(float64_value_t *f64, u8_t *b64, size_t len)
 	/* adjust exponent for bias */
 	e += 1023;
 
-	memset(b64, 0, len);
+	(void)memset(b64, 0, len);
 
 	/* sign: bit 63 */
 	b64[0] = f64->val1 < 0 ? 0x80 : 0;

--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -30,7 +30,7 @@ static void client_reset(struct mqtt_client *client)
 /** @brief Initialize tx buffer. */
 static void tx_buf_init(struct mqtt_client *client, struct buf_ctx *buf)
 {
-	memset(client->tx_buf, 0, client->tx_buf_size);
+	(void)memset(client->tx_buf, 0, client->tx_buf_size);
 	buf->cur = client->tx_buf;
 	buf->end = client->tx_buf + client->tx_buf_size;
 }
@@ -161,7 +161,7 @@ void mqtt_client_init(struct mqtt_client *client)
 {
 	NULL_PARAM_CHECK_VOID(client);
 
-	memset(client, 0, sizeof(*client));
+	(void)memset(client, 0, sizeof(*client));
 
 	MQTT_STATE_INIT(client);
 	mqtt_mutex_init(client);
@@ -182,7 +182,8 @@ int mqtt_client_set_proxy(struct mqtt_client *client,
 		}
 
 		client->transport.proxy.addrlen = addrlen;
-		memcpy(&client->transport.proxy.addr, proxy_addr, addrlen);
+		(void)memcpy(&client->transport.proxy.addr,
+			      proxy_addr, addrlen);
 
 		return 0;
 	}

--- a/subsys/net/lib/mqtt/mqtt_encoder.c
+++ b/subsys/net/lib/mqtt/mqtt_encoder.c
@@ -118,7 +118,7 @@ static int pack_utf8_str(const struct mqtt_utf8 *str, struct buf_ctx *buf)
 	/* Pack length followed by string. */
 	(void)pack_uint16(str->size, buf);
 
-	memcpy(buf->cur, str->utf8, str->size);
+	(void)memcpy(buf->cur, str->utf8, str->size);
 	buf->cur += str->size;
 
 	return 0;
@@ -486,7 +486,7 @@ int disconnect_encode(struct buf_ctx *buf)
 		return -ENOMEM;
 	}
 
-	memcpy(buf->cur, disc_packet, sizeof(disc_packet));
+	(void)memcpy(buf->cur, disc_packet, sizeof(disc_packet));
 	buf->end = buf->cur + sizeof(disc_packet);
 
 	return 0;
@@ -562,7 +562,7 @@ int ping_request_encode(struct buf_ctx *buf)
 		return -ENOMEM;
 	}
 
-	memcpy(buf->cur, ping_packet, sizeof(ping_packet));
+	(void)memcpy(buf->cur, ping_packet, sizeof(ping_packet));
 	buf->end = buf->cur + sizeof(ping_packet);
 
 	return 0;

--- a/subsys/net/lib/openthread/platform/random.c
+++ b/subsys/net/lib/openthread/platform/random.c
@@ -27,11 +27,11 @@ otError otPlatRandomGetTrue(u8_t *aOutput, u16_t aOutputLength)
 
 	for (i = 0; i < (aOutputLength & 0xFFFC); i += 4) {
 		random = sys_rand32_get();
-		memcpy(&aOutput[i], &random, sizeof(random));
+		(void)memcpy(&aOutput[i], &random, sizeof(random));
 	}
 
 	random = sys_rand32_get();
-	memcpy(&aOutput[i], &random, aOutputLength & 0x0003);
+	(void)memcpy(&aOutput[i], &random, aOutputLength & 0x0003);
 
 	return OT_ERROR_NONE;
 }

--- a/subsys/net/lib/sntp/sntp.c
+++ b/subsys/net/lib/sntp/sntp.c
@@ -148,7 +148,7 @@ int sntp_init(struct sntp_ctx *ctx, struct sockaddr *addr, socklen_t addr_len)
 		return -EFAULT;
 	}
 
-	memset(ctx, 0, sizeof(struct sntp_ctx));
+	(void)memset(ctx, 0, sizeof(struct sntp_ctx));
 
 	ctx->sock.fd = socket(addr->sa_family, SOCK_DGRAM, IPPROTO_UDP);
 	if (ctx->sock.fd < 0) {

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -74,12 +74,12 @@ static void dns_resolve_cb(enum dns_resolve_status status,
 	}
 
 	ai = &state->ai_arr[state->idx];
-	memcpy(&ai->_ai_addr, &info->ai_addr, info->ai_addrlen);
+	(void)memcpy(&ai->_ai_addr, &info->ai_addr, info->ai_addrlen);
 	net_sin(&ai->_ai_addr)->sin_port = state->port;
 	ai->ai_addr = &ai->_ai_addr;
 	ai->ai_addrlen = info->ai_addrlen;
-	memcpy(&ai->_ai_canonname, &info->ai_canonname,
-	       sizeof(ai->_ai_canonname));
+	(void)memcpy(&ai->_ai_canonname, &info->ai_canonname,
+			sizeof(ai->_ai_canonname));
 	ai->ai_canonname = ai->_ai_canonname;
 	ai->ai_family = info->ai_family;
 

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -394,7 +394,7 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 	if (addr != NULL && addrlen != NULL) {
 		int len = MIN(*addrlen, sizeof(ctx->remote));
 
-		memcpy(addr, &ctx->remote, len);
+		(void)memcpy(addr, &ctx->remote, len);
 		/* addrlen is a value-result argument, set to actual
 		 * size of source address
 		 */
@@ -1344,22 +1344,24 @@ int zsock_getsockname_ctx(struct net_context *ctx, struct sockaddr *addr,
 
 		addr4.sin_family = AF_INET;
 		addr4.sin_port = net_sin_ptr(&ctx->local)->sin_port;
-		memcpy(&addr4.sin_addr, net_sin_ptr(&ctx->local)->sin_addr,
-		       sizeof(struct in_addr));
+		(void)memcpy(&addr4.sin_addr,
+				net_sin_ptr(&ctx->local)->sin_addr,
+				sizeof(struct in_addr));
 		newlen = sizeof(struct sockaddr_in);
 
-		memcpy(addr, &addr4, MIN(*addrlen, newlen));
+		(void)memcpy(addr, &addr4, MIN(*addrlen, newlen));
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		   ctx->local.family == AF_INET6) {
 		struct sockaddr_in6 addr6 = { 0 };
 
 		addr6.sin6_family = AF_INET6;
 		addr6.sin6_port = net_sin6_ptr(&ctx->local)->sin6_port;
-		memcpy(&addr6.sin6_addr, net_sin6_ptr(&ctx->local)->sin6_addr,
-		       sizeof(struct in6_addr));
+		(void)memcpy(&addr6.sin6_addr,
+				net_sin6_ptr(&ctx->local)->sin6_addr,
+				sizeof(struct in6_addr));
 		newlen = sizeof(struct sockaddr_in6);
 
-		memcpy(addr, &addr6, MIN(*addrlen, newlen));
+		(void)memcpy(addr, &addr6, MIN(*addrlen, newlen));
 	} else {
 		SET_ERRNO(EINVAL);
 	}

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -233,7 +233,7 @@ ssize_t zcan_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 	}
 
 	if (dest_addr == NULL) {
-		memset(&can_addr, 0, sizeof(can_addr));
+		(void)memset(&can_addr, 0, sizeof(can_addr));
 
 		can_addr.can_ifindex = -1;
 		can_addr.can_family = AF_CAN;

--- a/subsys/net/lib/sockets/sockets_net_mgmt.c
+++ b/subsys/net/lib/sockets/sockets_net_mgmt.c
@@ -213,7 +213,7 @@ again:
 	if (info) {
 		ret = info_len + sizeof(hdr);
 		ret = MIN(max_len, ret);
-		memcpy(&copy_to[sizeof(hdr)], info, ret);
+		(void)memcpy(&copy_to[sizeof(hdr)], info, ret);
 	} else {
 		ret = 0;
 	}
@@ -221,7 +221,7 @@ again:
 	hdr.nm_msg_version = NET_MGMT_SOCKET_VERSION_1;
 	hdr.nm_msg_len = ret;
 
-	memcpy(copy_to, &hdr, sizeof(hdr));
+	(void)memcpy(copy_to, &hdr, sizeof(hdr));
 
 	return ret;
 }

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -357,8 +357,8 @@ static struct tls_context *tls_clone(struct tls_context *source_tls)
 
 	target_tls->tls_version = source_tls->tls_version;
 
-	memcpy(&target_tls->options, &source_tls->options,
-	       sizeof(target_tls->options));
+	(void)memcpy(&target_tls->options, &source_tls->options,
+			sizeof(target_tls->options));
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 	if (target_tls->options.is_hostname_set) {
@@ -441,7 +441,8 @@ static void dtls_peer_address_set(struct net_context *context,
 				  socklen_t addrlen)
 {
 	if (addrlen <= sizeof(context->tls->dtls_peer_addr)) {
-		memcpy(&context->tls->dtls_peer_addr, peer_addr, addrlen);
+		(void)memcpy(&context->tls->dtls_peer_addr,
+			      peer_addr, addrlen);
 		context->tls->dtls_peer_addrlen = addrlen;
 	}
 }
@@ -452,7 +453,7 @@ static void dtls_peer_address_get(struct net_context *context,
 {
 	socklen_t len = MIN(context->tls->dtls_peer_addrlen, *addrlen);
 
-	memcpy(peer_addr, &context->tls->dtls_peer_addr, len);
+	(void)memcpy(peer_addr, &context->tls->dtls_peer_addr, len);
 	*addrlen = len;
 }
 
@@ -931,7 +932,8 @@ static int tls_opt_sec_tag_list_set(struct net_context *context,
 		return -EINVAL;
 	}
 
-	memcpy(context->tls->options.sec_tag_list.sec_tags, optval, optlen);
+	(void)memcpy(context->tls->options.sec_tag_list.sec_tags,
+		      optval, optlen);
 	context->tls->options.sec_tag_list.sec_tag_count = sec_tag_cnt;
 
 	return 0;
@@ -949,7 +951,7 @@ static int tls_opt_sec_tag_list_get(struct net_context *context,
 	len = MIN(context->tls->options.sec_tag_list.sec_tag_count *
 		  sizeof(sec_tag_t), *optlen);
 
-	memcpy(optval, context->tls->options.sec_tag_list.sec_tags, len);
+	(void)memcpy(optval, context->tls->options.sec_tag_list.sec_tags, len);
 	*optlen = len;
 
 	return 0;
@@ -993,7 +995,7 @@ static int tls_opt_ciphersuite_list_set(struct net_context *context,
 		return -EINVAL;
 	}
 
-	memcpy(context->tls->options.ciphersuites, optval, optlen);
+	(void)memcpy(context->tls->options.ciphersuites, optval, optlen);
 	context->tls->options.ciphersuites[cipher_cnt] = 0;
 
 	return 0;
@@ -1276,7 +1278,7 @@ int ztls_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 	if (addr != NULL && addrlen != NULL) {
 		int len = MIN(*addrlen, sizeof(child->remote));
 
-		memcpy(addr, &child->remote, len);
+		(void)memcpy(addr, &child->remote, len);
 		/* addrlen is a value-result argument, set to actual
 		 * size of source address
 		 */

--- a/subsys/net/lib/socks/socks.c
+++ b/subsys/net/lib/socks/socks.c
@@ -27,13 +27,15 @@ static void socks5_method_rsp_cb(struct net_context *ctx,
 			(struct socks5_method_response *)user_data;
 
 	if (!pkt || status) {
-		memset(method_rsp, 0, sizeof(struct socks5_method_response));
+		(void)memset(method_rsp, 0,
+			      sizeof(struct socks5_method_response));
 		goto end;
 	}
 
 	if (net_pkt_read(pkt, (u8_t *)method_rsp,
 			 sizeof(struct socks5_method_response))) {
-		memset(method_rsp, 0, sizeof(struct socks5_method_response));
+		(void)memset(method_rsp, 0,
+			      sizeof(struct socks5_method_response));
 	}
 
 end:
@@ -52,16 +54,16 @@ static void socks5_cmd_rsp_cb(struct net_context *ctx,
 	int size;
 
 	if (!pkt || status) {
-		memset(cmd_rsp, 0,
-		       sizeof(struct socks5_command_request_common));
+		(void)memset(cmd_rsp, 0,
+				sizeof(struct socks5_command_request_common));
 		goto end;
 	}
 
 	size = sizeof(struct socks5_command_request_common);
 
 	if (net_pkt_read(pkt, (u8_t *)cmd_rsp, size)) {
-		memset(cmd_rsp, 0,
-		       sizeof(struct socks5_command_request_common));
+		(void)memset(cmd_rsp, 0,
+				sizeof(struct socks5_command_request_common));
 	}
 
 end:
@@ -128,9 +130,9 @@ static int socks5_tcp_connect(struct net_context *ctx,
 
 		cmd_req.r.atyp = SOCKS5_ATYP_IPV4;
 
-		memcpy(&cmd_req.ipv4_addr.addr,
-		       (u8_t *)&d4->sin_addr,
-		       sizeof(cmd_req.ipv4_addr.addr));
+		(void)memcpy(&cmd_req.ipv4_addr.addr,
+				(u8_t *)&d4->sin_addr,
+				sizeof(cmd_req.ipv4_addr.addr));
 
 		cmd_req.ipv4_addr.port = d4->sin_port;
 
@@ -142,9 +144,9 @@ static int socks5_tcp_connect(struct net_context *ctx,
 
 		cmd_req.r.atyp = SOCKS5_ATYP_IPV6;
 
-		memcpy(&cmd_req.ipv6_addr.addr,
-		       (u8_t *)&d6->sin6_addr,
-		       sizeof(cmd_req.ipv6_addr.addr));
+		(void)memcpy(&cmd_req.ipv6_addr.addr,
+				(u8_t *)&d6->sin6_addr,
+				sizeof(cmd_req.ipv6_addr.addr));
 
 		cmd_req.ipv6_addr.port = d6->sin6_port;
 

--- a/subsys/net/lib/tls_credentials/tls_credentials.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials.c
@@ -135,7 +135,7 @@ int tls_credential_get(sec_tag_t tag, enum tls_credential_type type,
 	}
 
 	*credlen = credential->len;
-	memcpy(cred, credential->buf, credential->len);
+	(void)memcpy(cred, credential->buf, credential->len);
 
 exit:
 	credentials_unlock();

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -125,8 +125,8 @@ static void settings_tmpfile(char *dst, const char *src, char *pfx)
 	if (len + pfx_len >= SETTINGS_FILE_NAME_MAX) {
 		len = SETTINGS_FILE_NAME_MAX - pfx_len - 1;
 	}
-	memcpy(dst, src, len);
-	memcpy(dst + len, pfx, pfx_len);
+	(void)memcpy(dst, src, len);
+	(void)memcpy(dst + len, pfx, pfx_len);
 	dst[len + pfx_len] = '\0';
 }
 

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -53,7 +53,7 @@ int settings_line_write(const char *name, const char *value, size_t val_len,
 
 #ifdef CONFIG_SETTINGS_ENCODE_LEN
 	len_field = settings_line_len_calc(name, val_len);
-	memcpy(w_buf, &len_field, sizeof(len_field));
+	(void)memcpy(w_buf, &len_field, sizeof(len_field));
 	w_size = 0;
 
 
@@ -64,7 +64,7 @@ int settings_line_write(const char *name, const char *value, size_t val_len,
 			w_size = rem;
 		}
 
-		memcpy(w_buf + sizeof(len_field), name, w_size);
+		(void)memcpy(w_buf + sizeof(len_field), name, w_size);
 		name += w_size;
 		rem -= w_size;
 	}
@@ -88,7 +88,7 @@ int settings_line_write(const char *name, const char *value, size_t val_len,
 	w_size = rem;
 
 	if (rem) {
-		memcpy(w_buf, name, rem);
+		(void)memcpy(w_buf, name, rem);
 	}
 
 	w_buf[rem] = '=';
@@ -102,7 +102,7 @@ int settings_line_write(const char *name, const char *value, size_t val_len,
 #ifdef CONFIG_SETTINGS_USE_BASE64
 			if (enc_len) {
 				add = MIN(enc_len, sizeof(w_buf) - w_size);
-				memcpy(&w_buf[w_size], p_enc, add);
+				(void)memcpy(&w_buf[w_size], p_enc, add);
 				enc_len -= add;
 				w_size += add;
 				p_enc += add;
@@ -120,7 +120,8 @@ int settings_line_write(const char *name, const char *value, size_t val_len,
 					p_enc = enc_buf;
 #else
 					add = MIN(rem, sizeof(w_buf) - w_size);
-					memcpy(&w_buf[w_size], value, add);
+					(void)memcpy(&w_buf[w_size],
+						      value, add);
 					value += add;
 					rem -= add;
 					w_size += add;
@@ -129,8 +130,9 @@ int settings_line_write(const char *name, const char *value, size_t val_len,
 					add = (w_size) % wbs;
 					if (add) {
 						add = wbs - add;
-						memset(&w_buf[w_size], '\0',
-						       add);
+						(void)memset(&w_buf[w_size],
+								'\0',
+								add);
 						w_size += add;
 					}
 					done = true;
@@ -254,7 +256,7 @@ static int settings_line_raw_read_until(off_t seek, char *out, size_t len_req,
 			}
 		}
 
-		memcpy(out, &temp_buf[off], len);
+		(void)memcpy(out, &temp_buf[off], len);
 
 		rem_size -= len;
 
@@ -327,7 +329,7 @@ int settings_line_val_read(off_t val_off, off_t off, char *out, size_t len_req,
 
 		clen = MIN(olen + off_begin - off, rem_size);
 
-		memcpy(out, &dec_buf[off - off_begin], clen);
+		(void)memcpy(out, &dec_buf[off - off_begin], clen);
 		rem_size -= clen;
 
 		if (exp_size > read_size || olen < read_size/4*3) {

--- a/subsys/settings/src/settings_runtime.c
+++ b/subsys/settings/src/settings_runtime.c
@@ -11,7 +11,7 @@
 
 static ssize_t settings_runtime_read_cb(void *cb_arg, void *data, size_t len)
 {
-	memcpy(data, cb_arg, len);
+	(void)memcpy(data, cb_arg, len);
 	return len;
 }
 

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -229,7 +229,7 @@ static bool tab_prepare(const struct shell *shell,
 	}
 
 	/* Copy command from its beginning to cursor position. */
-	memcpy(shell->ctx->temp_buff, shell->ctx->cmd_buff,
+	(void)memcpy(shell->ctx->temp_buff, shell->ctx->cmd_buff,
 			shell->ctx->cmd_buff_pos);
 	shell->ctx->temp_buff[shell->ctx->cmd_buff_pos] = '\0';
 
@@ -551,7 +551,8 @@ static int execute(const struct shell *shell)
 		cursor_next_line_move(shell);
 	}
 
-	memset(&shell->ctx->active_cmd, 0, sizeof(shell->ctx->active_cmd));
+	(void)memset(&shell->ctx->active_cmd, 0,
+		      sizeof(shell->ctx->active_cmd));
 
 	shell_cmd_trim(shell);
 
@@ -1077,7 +1078,7 @@ static int instance_init(const struct shell *shell, const void *p_config,
 		return err;
 	}
 
-	memset(shell->ctx, 0, sizeof(*shell->ctx));
+	(void)memset(shell->ctx, 0, sizeof(*shell->ctx));
 	shell->ctx->prompt = shell->default_prompt;
 
 	history_init(shell);

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -66,7 +66,7 @@ static int cursor_position_get(const struct shell *shell, u16_t *x, u16_t *y)
 	*x = 0U;
 	*y = 0U;
 
-	memset(shell->ctx->temp_buff, 0, sizeof(shell->ctx->temp_buff));
+	(void)memset(shell->ctx->temp_buff, 0, sizeof(shell->ctx->temp_buff));
 
 	/* escape code asking terminal about its size */
 	static char const cmd_get_terminal_size[] = "\033[6n";

--- a/subsys/shell/shell_history.c
+++ b/subsys/shell/shell_history.c
@@ -78,7 +78,7 @@ bool shell_history_get(struct shell_history *history, bool up,
 	h_item = CONTAINER_OF(l_item, struct shell_history_item, dnode);
 
 	if (l_item) {
-		memcpy(dst, h_item->data, h_item->len);
+		(void)memcpy(dst, h_item->data, h_item->len);
 		*len = h_item->len;
 		dst[*len] = '\0';
 		return true;
@@ -94,7 +94,7 @@ static void add_to_head(struct shell_history *history,
 {
 	item->len = len;
 	item->padding = padding;
-	memcpy(item->data, src, len);
+	(void)memcpy(item->data, src, len);
 	sys_dlist_prepend(&history->list, &item->dnode);
 }
 

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -246,7 +246,7 @@ static void data_insert(const struct shell *shell, const char *data, u16_t len)
 	}
 
 	memmove(curr_pos + len, curr_pos, after);
-	memcpy(curr_pos, data, len);
+	(void)memcpy(curr_pos, data, len);
 	shell->ctx->cmd_buff_len += len;
 	shell->ctx->cmd_buff[shell->ctx->cmd_buff_len] = '\0';
 

--- a/subsys/shell/shell_telnet.c
+++ b/subsys/shell/shell_telnet.c
@@ -335,7 +335,7 @@ static int init(const struct shell_transport *transport,
 		return err;
 	}
 
-	memset(sh_telnet, 0, sizeof(struct shell_telnet));
+	(void)memset(sh_telnet, 0, sizeof(struct shell_telnet));
 
 	sh_telnet->shell_handler = evt_handler;
 	sh_telnet->shell_context = context;
@@ -397,7 +397,7 @@ static int write(const struct shell_transport *transport,
 			copy_len = length - *cnt;
 		}
 
-		memcpy(lb->buf + lb->len, (u8_t *)data + *cnt, copy_len);
+		(void)memcpy(lb->buf + lb->len, (u8_t *)data + *cnt, copy_len);
 		lb->len += copy_len;
 
 		/* Send the data immediately if the buffer is full or line feed

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -384,7 +384,7 @@ int shell_command_add(char *buff, u16_t *buff_len,
 
 	/* make place for new command: + 1 for space + 1 for EOS */
 	memmove(cmd_source_addr + cmd_len + 1, cmd_source_addr, shift + 1);
-	memcpy(cmd_source_addr, new_cmd, cmd_len);
+	(void)memcpy(cmd_source_addr, new_cmd, cmd_len);
 	cmd_source_addr[cmd_len] = ' ';
 
 	*buff_len += cmd_len + 1; /* + 1 for space */

--- a/subsys/shell/shell_wildcard.c
+++ b/subsys/shell/shell_wildcard.c
@@ -54,7 +54,7 @@ static enum shell_wildcard_status command_add(char *buff, u16_t *buff_len,
 
 	/* make place for new command: + 1 for space + 1 for EOS */
 	memmove(completion_addr + cmd_len + 1, completion_addr, shift + 1);
-	memcpy(completion_addr, cmd, cmd_len);
+	(void)memcpy(completion_addr, cmd, cmd_len);
 	/* adding space to not brake next command in the buffer */
 	completion_addr[cmd_len] = ' ';
 
@@ -168,8 +168,8 @@ void shell_wildcard_prepare(const struct shell *shell)
 	 *    including expanded commands, are passed as arguments.
 	 */
 
-	memset(shell->ctx->temp_buff, 0, sizeof(shell->ctx->temp_buff));
-	memcpy(shell->ctx->temp_buff,
+	(void)memset(shell->ctx->temp_buff, 0, sizeof(shell->ctx->temp_buff));
+	(void)memcpy(shell->ctx->temp_buff,
 			shell->ctx->cmd_buff,
 			shell->ctx->cmd_buff_len);
 
@@ -212,8 +212,8 @@ enum shell_wildcard_status shell_wildcard_process(const struct shell *shell,
 
 void shell_wildcard_finalize(const struct shell *shell)
 {
-	memcpy(shell->ctx->cmd_buff,
-	       shell->ctx->temp_buff,
-	       shell->ctx->cmd_tmp_buff_len);
+	(void)memcpy(shell->ctx->cmd_buff,
+			shell->ctx->temp_buff,
+			shell->ctx->cmd_tmp_buff_len);
 	shell->ctx->cmd_buff_len = shell->ctx->cmd_tmp_buff_len;
 }

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -227,8 +227,8 @@ int cdc_acm_class_handle_req(struct usb_setup_packet *pSetup,
 
 	switch (pSetup->bRequest) {
 	case SET_LINE_CODING:
-		memcpy(&dev_data->line_coding,
-		       *data, sizeof(dev_data->line_coding));
+		(void)memcpy(&dev_data->line_coding,
+				*data, sizeof(dev_data->line_coding));
 		LOG_DBG("CDC_SET_LINE_CODING %d %d %d %d",
 			sys_le32_to_cpu(dev_data->line_coding.dwDTERate),
 			dev_data->line_coding.bCharFormat,
@@ -375,7 +375,7 @@ static void cdc_acm_reset_port(struct cdc_acm_dev_data_t *dev_data)
 				CDC_ACM_DEFAULT_BAUDRATE;
 	dev_data->serial_state = 0;
 	dev_data->line_state = 0;
-	memset(&dev_data->rx_buf, 0, CDC_ACM_BUFFER_SIZE);
+	(void)memset(&dev_data->rx_buf, 0, CDC_ACM_BUFFER_SIZE);
 }
 
 static void cdc_acm_do_cb(struct cdc_acm_dev_data_t *dev_data,

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -490,7 +490,7 @@ static void CBWDecode(u8_t *buf, u16_t size)
 		return;
 	}
 
-	memcpy((u8_t *)&cbw, buf, size);
+	(void)memcpy((u8_t *)&cbw, buf, size);
 	if (cbw.Signature != CBW_Signature) {
 		LOG_ERR("CBW Signature Mismatch");
 		return;

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -125,7 +125,7 @@ static int eem_send(struct net_pkt *pkt)
 	b_idx += len - sizeof(sentinel);
 
 	/* Add crc-sentinel */
-	memcpy(&tx_buf[b_idx], sentinel, sizeof(sentinel));
+	(void)memcpy(&tx_buf[b_idx], sentinel, sizeof(sentinel));
 	b_idx += sizeof(sentinel);
 
 	/* transfer data to host */

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -620,13 +620,13 @@ static int rndis_query_handle(u8_t *data, u32_t len)
 		/* IEEE 802.3 */
 	case RNDIS_OBJECT_ID_802_3_PERMANENT_ADDRESS:
 		LOG_DBG("RNDIS_OBJECT_ID_802_3_PERMANENT_ADDRESS");
-		memcpy(net_buf_add(buf, sizeof(rndis.mac)), rndis.mac,
-		       sizeof(rndis.mac));
+		(void)memcpy(net_buf_add(buf, sizeof(rndis.mac)), rndis.mac,
+				sizeof(rndis.mac));
 		break;
 	case RNDIS_OBJECT_ID_802_3_CURR_ADDRESS:
 		LOG_DBG("RNDIS_OBJECT_ID_802_3_CURR_ADDRESS");
-		memcpy(net_buf_add(buf, sizeof(rndis.mac)), rndis.mac,
-		       sizeof(rndis.mac));
+		(void)memcpy(net_buf_add(buf, sizeof(rndis.mac)), rndis.mac,
+				sizeof(rndis.mac));
 		break;
 	case RNDIS_OBJECT_ID_802_3_MCAST_LIST:
 		LOG_DBG("RNDIS_OBJECT_ID_802_3_MCAST_LIST");
@@ -644,8 +644,9 @@ static int rndis_query_handle(u8_t *data, u32_t len)
 		break;
 	case RNDIS_OBJECT_ID_GEN_VENDOR_DESC:
 		LOG_DBG("RNDIS_OBJECT_ID_GEN_VENDOR_DESC");
-		memcpy(net_buf_add(buf, sizeof(manufacturer) - 1), manufacturer,
-		       sizeof(manufacturer) - 1);
+		(void)memcpy(net_buf_add(buf, sizeof(manufacturer) - 1),
+				manufacturer,
+				sizeof(manufacturer) - 1);
 		break;
 	case RNDIS_OBJECT_ID_GEN_VENDOR_DRV_VER:
 		LOG_DBG("RNDIS_OBJECT_ID_GEN_VENDOR_DRV_VER");
@@ -818,7 +819,7 @@ static int queue_encapsulated_cmd(u8_t *data, u32_t len)
 		return -ENOMEM;
 	}
 
-	memcpy(net_buf_add(buf, len), data, len);
+	(void)memcpy(net_buf_add(buf, len), data, len);
 
 	net_buf_put(&rndis_cmd_queue, buf);
 
@@ -882,7 +883,7 @@ static int handle_encapsulated_rsp(u8_t **data, u32_t *len)
 		net_hexdump("RSP <", buf->data, buf->len);
 	}
 
-	memcpy(*data, buf->data, buf->len);
+	(void)memcpy(*data, buf->data, buf->len);
 	*len = buf->len;
 
 	net_buf_unref(buf);

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -455,7 +455,8 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 			dfu_data.state = dfuDNBUSY;
 			dfu_data_worker.worker_state = dfuIDLE;
 			dfu_data_worker.worker_len  = pSetup->wLength;
-			memcpy(dfu_data_worker.buf, *data, pSetup->wLength);
+			(void)memcpy(dfu_data_worker.buf, *data,
+				      pSetup->wLength);
 			k_work_submit(&dfu_work);
 			break;
 		case dfuDNLOAD_IDLE:
@@ -467,7 +468,8 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 				k_poll_signal_raise(&dfu_signal, 0);
 			}
 
-			memcpy(dfu_data_worker.buf, *data, pSetup->wLength);
+			(void)memcpy(dfu_data_worker.buf, *data,
+				      pSetup->wLength);
 			k_work_submit(&dfu_work);
 			break;
 		default:

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -320,7 +320,7 @@ static void usb_fix_ascii_sn_string_descriptor(struct usb_sn_descriptor *sn)
 		return;
 	}
 
-	memcpy(sn->bString, runtime_sn, runtime_sn_len);
+	(void)memcpy(sn->bString, runtime_sn, runtime_sn_len);
 }
 
 /*


### PR DESCRIPTION
MISRA-C rule 17.7 says that the return value of a non-void must be
checked. For memcpy/memset there is no error handling or checking we
can do with the return value, so it is just casting it to void to
explicitly ignore while adhering to MISRA-C.

This patch was generated using the coccinelle script
ignore_return.cocci

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>