### PR TITLE
doc/drivers: correct number of initialization levels

### DIFF
--- a/doc/reference/drivers/index.rst
+++ b/doc/reference/drivers/index.rst
@@ -262,7 +262,7 @@ Initialization Levels
 Drivers may depend on other drivers being initialized first, or
 require the use of kernel services. The DEVICE_INIT() APIs allow the user to
 specify at what time during the boot sequence the init function will be
-executed. Any driver will specify one of five initialization levels:
+executed. Any driver will specify one of four initialization levels:
 
 ``PRE_KERNEL_1``
         Used for devices that have no dependencies, such as those that rely


### PR DESCRIPTION
When init level hierarchy was reworked the documentation was switched to
describe the new levels, but the count of relevant levels was not
changed.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>