### PR TITLE
LwM2M Bootstrap support fixes

### DIFF
--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -282,6 +282,17 @@ static int lwm2m_setup(void)
 				(void *)client_psk, sizeof(client_psk));
 #endif /* CONFIG_LWM2M_DTLS_SUPPORT */
 
+#if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
+	/* Mark 1st instance of security object as a bootstrap server */
+	lwm2m_engine_set_u8("0/0/1", 1);
+
+	/* Create 2nd instance of server and security objects needed for
+	 * bootstrap process
+	 */
+	lwm2m_engine_create_obj_inst("0/1");
+	lwm2m_engine_create_obj_inst("1/1");
+#endif
+
 	/* setup SERVER object */
 
 	/* setup DEVICE object */

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -111,8 +111,8 @@ config LWM2M_PEER_PORT
 
 config LWM2M_SECURITY_INSTANCE_COUNT
 	int "Maximum # of LWM2M Security object instances"
-	default 1
 	default 2 if LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP
+	default 1
 	range 1 10
 	help
 	  This setting establishes the total count of LWM2M Security instances
@@ -145,6 +145,7 @@ config LWM2M_SERVER_DEFAULT_PMAX
 
 config LWM2M_SERVER_INSTANCE_COUNT
 	int "Maximum # of LWM2M Server object instances"
+	default 2 if LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP
 	default 1
 	range 1 10
 	help

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -90,6 +90,25 @@ config LWM2M_LOCAL_PORT
 	  setting of 0 sets a random port for the client to be used for
 	  outgoing communication.
 
+config LWM2M_RD_CLIENT_SUPPORT
+	bool "support for LWM2M client bootstrap/registration state machine"
+	default y
+	help
+	  Client will use registration state machine to locate and connect to
+	  LWM2M servers (including bootstrap server support)
+
+config LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP
+	bool "Enable bootstrap support"
+	help
+	  Enabling this setting allows the RD client to support bootstrap mode.
+
+config LWM2M_PEER_PORT
+	int "LWM2M server port"
+	depends on LWM2M_RD_CLIENT_SUPPORT
+	default 5683
+	help
+	  This is the default server port to connect to for LWM2M communication
+
 config LWM2M_SECURITY_INSTANCE_COUNT
 	int "Maximum # of LWM2M Security object instances"
 	default 1
@@ -131,25 +150,6 @@ config LWM2M_SERVER_INSTANCE_COUNT
 	help
 	  This setting establishes the total count of LWM2M Server instances
 	  available to the client (including: bootstrap and regular servers).
-
-config LWM2M_RD_CLIENT_SUPPORT
-	bool "support for LWM2M client bootstrap/registration state machine"
-	default y
-	help
-	  Client will use registration state machine to locate and connect to
-	  LWM2M servers (including bootstrap server support)
-
-config LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP
-	bool "Enable bootstrap support"
-	help
-	  Enabling this setting allows the RD client to support bootstrap mode.
-
-config LWM2M_PEER_PORT
-	int "LWM2M server port"
-	depends on LWM2M_RD_CLIENT_SUPPORT
-	default 5683
-	help
-	  This is the default server port to connect to for LWM2M communication
 
 config LWM2M_CONN_MON_OBJ_SUPPORT
 	bool "Connectivity Monitoring object support"

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3312,6 +3312,13 @@ static int handle_request(struct coap_packet *request,
 		}
 
 		well_known = true;
+#if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
+	/* check for bootstrap-finish */
+	} else if ((code & COAP_REQUEST_MASK) == COAP_METHOD_POST && r == 1 && \
+		   strncmp(options[0].value, "bs", options[0].len) == 0) {
+		engine_bootstrap_finish();
+		return 0;
+#endif
 	} else {
 		r = coap_options_to_path(options, r, &msg->path);
 		if (r < 0) {


### PR DESCRIPTION
When bootstrap support is enabled:
- add second instances for server and security objects
- support bootstrap-finish notification from server (POST to /bs)
- mark first server as a bootstrap server in the sample

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/18080