### PR TITLE
logging: avoid buffer overrun extracting arguments

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -392,6 +392,7 @@ void log_generic(struct log_msg_ids src_level, const char *fmt, va_list ap)
 		log_arg_t args[LOG_MAX_NARGS];
 		u32_t nargs = count_args(fmt);
 
+		__ASSERT_NO_MSG(nargs < LOG_MAX_NARGS);
 		for (int i = 0; i < nargs; i++) {
 			args[i] = va_arg(ap, log_arg_t);
 		}


### PR DESCRIPTION
The number of arguments for a format string is approximated by the
number of conversion specifications.  This count may exceed the maximum
supported argument count.  Limit the extraction to the available space.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>

Closes #18462