### PR TITLE
Added option to disable Zephyrs C++ implementation

### DIFF
--- a/subsys/cpp/CMakeLists.txt
+++ b/subsys/cpp/CMakeLists.txt
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_sources_ifdef(CONFIG_CPLUSPLUS
-  cpp_virtual.c
-  cpp_vtable.cpp
+zephyr_sources(
   cpp_init_array.c
   cpp_ctors.c
   cpp_dtors.c
+)
+
+if (NOT CONFIG_LIB_CPLUSPLUS OR CONFIG_ZEPHYR_CPLUSPLUS)
+zephyr_sources(
+  cpp_virtual.c
+  cpp_vtable.cpp
   cpp_new.cpp
 )
+endif()

--- a/subsys/cpp/Kconfig
+++ b/subsys/cpp/Kconfig
@@ -65,4 +65,14 @@ config RTTI
 	help
 	  This option enables support of C++ RTTI.
 
+if LIB_CPLUSPLUS
+
+config ZEPHYR_CPLUSPLUS
+	bool "Use Zephyr C++ Implementation"
+	help
+	  Use Zephyr implementation for operator new, delete, pure virtual
+	  functions and vtables.
+
+endif #LIB_CPLUSPLUS
+
 endif # CPLUSPLUS

--- a/tests/application_development/libcxx/testcase.yaml
+++ b/tests/application_development/libcxx/testcase.yaml
@@ -2,11 +2,18 @@ tests:
   misc.app_dev.libcxx:
     arch_exclude: posix
     platform_exclude: qemu_x86_coverage
+    min_flash: 54
     tags: cpp
+  misc.app_dev.libcxx.zephyr_cpp:
+    arch_exclude: posix
+    platform_exclude: qemu_x86_coverage
+    tags: cpp
+    extra_configs:
+        - CONFIG_ZEPHYR_CPLUSPLUS=y
   misc.app_dev.libcxx.exceptions:
     arch_exclude: posix
-    platform_exclude: qemu_x86_coverage 96b_meerkat96
-        colibri_imx7d_m4 warp7_m4 pico_pi_m4 qemu_x86_64
+    platform_exclude: qemu_x86_coverage
+    min_flash: 54
     tags: cpp
     extra_configs:
         - CONFIG_EXCEPTIONS=y


### PR DESCRIPTION
~Blocked by: PR #19002, without this PR libcxx tests will fail~

--------

Added a Kconfig option to disable Zephyrs C++ implementation for operator
new, delete, pure virtual functions and vtables in case stdlibc++ is used.

Main reason is that Zephyr implementation of new and delete uses k_malloc/k_free instead of malloc/free and this only in case a kernel heap size is defined.