### PR TITLE
lib/timeutil: fix const correctness and remove undefined behavior

### DIFF
--- a/include/sys/timeutil.h
+++ b/include/sys/timeutil.h
@@ -11,7 +11,11 @@
  * POSIX defines gmtime() to convert from time_t to struct tm, but all
  * inverse transformations are non-standard or require access to time
  * zone information.  timeutil_timegm() implements the functionality
- * of the GNU extension timegm() function.
+ * of the GNU extension timegm() function, but changes the error value
+ * as @c EOVERFLOW is not a standard C error identifier.
+ *
+ * timeutil_timegm64() is provided to support full precision
+ * conversion on platforms where @c time_t is limited to 32 bits.
  */
 
 #ifndef ZEPHYR_INCLUDE_SYS_TIMEUTIL_H_
@@ -29,6 +33,19 @@ extern "C" {
  * @param tm pointer to broken down time.
  *
  * @return the corresponding time in the POSIX epoch time scale.
+ *
+ * @see http://man7.org/linux/man-pages/man3/timegm.3.html
+ */
+s64_t timeutil_timegm64(const struct tm *tm);
+
+/**
+ * @brief Convert broken-down time to a POSIX epoch offset in seconds.
+ *
+ * @param tm pointer to broken down time.
+ *
+ * @return the corresponding time in the POSIX epoch time scale.  If
+ * the time cannot be represented then @c (time_t)-1 is returned and
+ * @c errno is set to @c ERANGE`.
  *
  * @see http://man7.org/linux/man-pages/man3/timegm.3.html
  */

--- a/include/sys/timeutil.h
+++ b/include/sys/timeutil.h
@@ -32,7 +32,7 @@ extern "C" {
  *
  * @see http://man7.org/linux/man-pages/man3/timegm.3.html
  */
-time_t timeutil_timegm(struct tm *tm);
+time_t timeutil_timegm(const struct tm *tm);
 
 #ifdef __cplusplus
 }

--- a/lib/os/timeutil.c
+++ b/lib/os/timeutil.c
@@ -48,7 +48,7 @@ static s64_t time_days_from_civil(s64_t y,
  * @return the signed number of seconds between 1970-01-01T00:00:00
  * and the specified time ignoring leap seconds and DST offsets.
  */
-time_t timeutil_timegm(struct tm *tm)
+time_t timeutil_timegm(const struct tm *tm)
 {
 	s64_t y = 1900 + (s64_t)tm->tm_year;
 	unsigned int m = tm->tm_mon + 1;

--- a/lib/os/timeutil.c
+++ b/lib/os/timeutil.c
@@ -11,6 +11,7 @@
  */
 
 #include <zephyr/types.h>
+#include <errno.h>
 #include <sys/timeutil.h>
 
 /** Convert a civil (proleptic Gregorian) date to days relative to
@@ -39,23 +40,31 @@ static s64_t time_days_from_civil(s64_t y,
 	return era * 146097 + (time_t)doe - 719468;
 }
 
-/** Convert civil time to UNIX time.
- *
- * @param tvp pointer to a civil time structure.  `tm_year`, `tm_mon`,
- * `tm_mday`, `tm_hour`, `tm_min`, and `tm_sec` must be valid.  All
- * other fields are ignored.
- *
- * @return the signed number of seconds between 1970-01-01T00:00:00
- * and the specified time ignoring leap seconds and DST offsets.
- */
-time_t timeutil_timegm(const struct tm *tm)
+s64_t timeutil_timegm64(const struct tm *tm)
 {
 	s64_t y = 1900 + (s64_t)tm->tm_year;
 	unsigned int m = tm->tm_mon + 1;
 	unsigned int d = tm->tm_mday - 1;
 	s64_t ndays = time_days_from_civil(y, m, d);
+	s64_t time = tm->tm_sec;
 
-	return (time_t)tm->tm_sec
-	       + 60 * (tm->tm_min + 60 * tm->tm_hour)
-	       + 86400 * ndays;
+	time += 60LL * (tm->tm_min + 60LL * tm->tm_hour);
+	time += 86400LL * ndays;
+
+	return time;
+}
+
+time_t timeutil_timegm(const struct tm *tm)
+{
+	s64_t time = timeutil_timegm64(tm);
+	time_t rv = (time_t)time;
+
+	errno = 0;
+	if ((sizeof(rv) == sizeof(s32_t))
+	    && ((time < (s64_t)INT32_MIN)
+		|| (time > (s64_t)INT32_MAX))) {
+		errno = ERANGE;
+		rv = -1;
+	}
+	return rv;
 }


### PR DESCRIPTION
The algorithm for converting broken-down civil time to seconds in the POSIX epoch time scale would produce undefined behavior on a toolchain that uses a 32-bit time_t in cases where the referenced time could not be represented exactly.

However, there are use cases in Zephyr for civil time conversions outside the 32-bit representable range of 1901-12-13T20:45:52Z through 2038-01-19T03:14:07Z inclusive.

Add new API that specifically returns a 64-bit signed seconds count, and revise the existing API to detect out-of-range values and convert them to a diagnosible error.

Closes #18465
