### PR TITLE
native_posix: Check pointer before de-referencing it

### DIFF
--- a/boards/posix/native_posix/cmdline_common.c
+++ b/boards/posix/native_posix/cmdline_common.c
@@ -121,7 +121,7 @@ void cmd_read_option_value(const char *str, void *dest, const char type,
 			   const char *option)
 {
 	int error = 0;
-	char *endptr;
+	char *endptr = NULL;
 
 	switch (type) {
 	case 'b':
@@ -162,10 +162,11 @@ void cmd_read_option_value(const char *str, void *dest, const char type,
 		break;
 	default:
 		posix_print_error_and_exit(CMD_TYPE_ERROR, type);
+		/* Unreachable */
 		break;
 	}
 
-	if (!error && *endptr != 0) {
+	if (!error && endptr && *endptr != 0) {
 		error = 1;
 	}
 


### PR DESCRIPTION
To avoid a Coverity warning (203449):
https://github.com/zephyrproject-rtos/zephyr/issues/18354

Initialize a pointer to NULL, and check it later before
de-referencing it.
Coverity could not see that posix_print_error_and_exit()
never returns even that it ends with exit()

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

Fixes #18354