### PR TITLE
Zephyr 2.0.0 rc1 coverity fixes for tests/arch/arm

### DIFF
--- a/arch/arm/core/cortex_m/fault.c
+++ b/arch/arm/core/cortex_m/fault.c
@@ -692,7 +692,7 @@ static u32_t FaultHandle(z_arch_esf_t *esf, int fault, bool *recoverable)
 		break;
 	}
 
-	if (!recoverable) {
+	if ((*recoverable) == false) {
 		/* Dump generic information about the fault. */
 		FaultShow(esf, fault);
 	}

--- a/tests/arch/arm/arm_ramfunc/src/arm_ramfunc.c
+++ b/tests/arch/arm/arm_ramfunc/src/arm_ramfunc.c
@@ -17,7 +17,10 @@ __ramfunc static void arm_ram_function(void)
 
 void test_arm_ramfunc(void)
 {
-	zassert_true(test_flag == 0, "Test flag not initialized to zero");
+	int init_flag, post_flag;
+
+	init_flag = test_flag;
+	zassert_true(init_flag == 0, "Test flag not initialized to zero");
 
 	/* Verify that the .ramfunc section is not empty, it is located
 	 * inside SRAM, and that arm_ram_function(.) is located inside
@@ -46,7 +49,8 @@ void test_arm_ramfunc(void)
 	arm_ram_function();
 
 	/* Verify that the function is executed successfully. */
-	zassert_true(test_flag = 1,
+	post_flag = test_flag;
+	zassert_true(post_flag == 1,
 		"arm_ram_function() execution failed.");
 }
 /**

--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -231,7 +231,7 @@ static void alt_thread_entry(void)
 	 * later, that it is populated properly.
 	 */
 	memset(&ztest_thread_fp_callee_saved_regs,
-		0, sizeof(_callee_saved_t));
+		0, sizeof(ztest_thread_fp_callee_saved_regs));
 
 #endif /* CONFIG_FLOAT && CONFIG_FP_SHARING */
 

--- a/tests/arch/arm/arm_zero_latency_irqs/src/arm_zero_latency_irqs.c
+++ b/tests/arch/arm/arm_zero_latency_irqs/src/arm_zero_latency_irqs.c
@@ -21,8 +21,11 @@ void test_arm_zero_latency_irqs(void)
 {
 	/* Determine an NVIC IRQ line that is not currently in use. */
 	int i, key;
+	int init_flag, post_flag;
 
-	zassert_false(test_flag, "Test flag not initialized to zero\n");
+	init_flag = test_flag;
+
+	zassert_false(init_flag, "Test flag not initialized to zero\n");
 
 	for (i = CONFIG_NUM_IRQS - 1; i >= 0; i--) {
 		if (NVIC_GetEnableIRQ(i) == 0) {
@@ -65,7 +68,8 @@ void test_arm_zero_latency_irqs(void)
 	__ISB();
 
 	/* Confirm test flag is set by the zero-latency ISR handler. */
-	zassert_true(test_flag == 1, "Test flag not set by ISR\n");
+	post_flag = test_flag;
+	zassert_true(post_flag == 1, "Test flag not set by ISR\n");
 
 	irq_unlock(key);
 }


### PR DESCRIPTION
Coverity fixes for tests/arch/arm (minor) and one relatively important fix on arch/arm/core/cortex_m/fault.c

Fixes #18426
Fixes #18430
Fixes #18429 
Fixes #18427 
Fixes #18428 
Fixes #18353 
