### PR TITLE
subsys/fs/littlefs: fix Coverity issues

### DIFF
--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -595,6 +595,11 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 	if (block_size == 0) {
 		block_size = get_block_size(fs->area);
 	}
+	if (block_size == 0) {
+		__ASSERT_NO_MSG(block_size != 0);
+		ret = -EINVAL;
+		goto out;
+	}
 
 	s32_t block_cycles = lcp->block_cycles;
 

--- a/tests/subsys/fs/littlefs/src/testfs_util.c
+++ b/tests/subsys/fs/littlefs/src/testfs_util.c
@@ -61,7 +61,7 @@ const char *testfs_path_init(struct testfs_path *pp,
 		if ((len + 1) >= sizeof(pp->path)) {
 			len = sizeof(pp->path) - 1;
 		}
-		strncpy(pp->path, mp->mnt_point, sizeof(pp->path));
+		strncpy(pp->path, mp->mnt_point, len);
 		pp->eos = pp->path + len;
 	}
 	*pp->eos = '\0';


### PR DESCRIPTION
Closes #18392 by asserting if the block size is not positive.

Closes #18458.  The diagnosis here was not relevant as an in-range EOS
is written before the buffer is used, but using the non-terminated
length is slightly more clear about intent and may avoid a read overrun
of the mount point.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>