### PR TITLE
Bluetooth: log: Rework Bluetooth ASSERTs

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -59,6 +59,31 @@ config BT_RPA
 	select TINYCRYPT
 	select TINYCRYPT_AES
 
+config BT_ASSERT
+	bool "Custom Bluetooth assert implementation"
+	default y
+	help
+	  Use a custom Bluetooth assert implementation instead of the
+	  kernel-wide __ASSERT(), which is enabled by CONFIG_ASSERT and is
+	  disabled by default.
+
+if BT_ASSERT
+
+config BT_ASSERT_VERBOSE
+	bool "Print out an assert string when using BT_ASSERT"
+	default y
+	help
+	  When CONFIG_BT_ASSERT is enabled, this option turns on printing the
+	  cause of the assert to the console using printk().
+
+config BT_ASSERT_PANIC
+	bool "Use k_panic() instead of k_oops()"
+	help
+	  When CONFIG_BT_ASSERT is enabled, this option makes the code call
+	  k_panic() instead of k_oops() when an assertion is triggered.
+
+endif # BT_ASSERT
+
 config BT_DEBUG
 	# Virtual/hidden option to make the conditions more intuitive
 	bool

--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -40,10 +40,27 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define BT_WARN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
 #define BT_INFO(fmt, ...) LOG_INF(fmt, ##__VA_ARGS__)
 
+#if defined(CONFIG_BT_ASSERT_VERBOSE)
+#define BT_ASSERT_PRINT(fmt, ...) printk(fmt, ##__VA_ARGS__)
+#else
+#define BT_ASSERT_PRINT(fmt, ...)
+#endif /* CONFIG_BT_ASSERT_VERBOSE */
+
+#if defined(CONFIG_BT_ASSERT_PANIC)
+#define BT_ASSERT_DIE k_panic
+#else
+#define BT_ASSERT_DIE k_oops
+#endif /* CONFIG_BT_ASSERT_PANIC */
+
+#if defined(CONFIG_BT_ASSERT)
 #define BT_ASSERT(cond) if (!(cond)) { \
-				BT_ERR("assert: '" #cond "' failed"); \
-				k_oops(); \
+				BT_ASSERT_PRINT("assert: '" #cond \
+						"' failed\n"); \
+				BT_ASSERT_DIE(); \
 			}
+#else
+#define BT_ASSERT(cond) __ASSERT_NO_MSG(cond)
+#endif/* CONFIG_BT_ASSERT*/
 
 #define BT_HEXDUMP_DBG(_data, _length, _str) \
 		LOG_HEXDUMP_DBG((const u8_t *)_data, _length, _str)


### PR DESCRIPTION
Rework the BT_ASSERT infrastructure with the following changes:

- Transition from LOG() macros to printk()
- Allow the BT_ASSERT() macro to map directly to stancard __ASSERT()
- Allow printing of the assert reason to be disabled
- Switch from k_oops() to k_panic() configurable

There are 2 reasons for using printk() instead of LOG():

- BT_ERR uses deferred logging by default, which is problematic with
ASSERTs
- The __ASSERT() macro in Zephyr uses printk()

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>