### PR TITLE
soc: arm: stm32: fix sign of timeout variable

### DIFF
--- a/soc/arm/st_stm32/stm32h7/soc_m7.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m7.c
@@ -24,7 +24,7 @@ static int stm32h7_m4_wakeup(struct device *arg)
 	LL_AHB4_GRP1_EnableClock(LL_AHB4_GRP1_PERIPH_HSEM);
 
 	if (IS_ENABLED(CONFIG_STM32H7_BOOT_CM4_CM7)) {
-		u32_t timeout;
+		int timeout;
 
 		/*
 		 * When system initialization is finished, Cortex-M7 will


### PR DESCRIPTION
'timeout' needs to be a signed variable, so that the
check for less-than-zero is able to result to true (if
the timeout actually expires). Addresses the coverity
issue [Coverity CID :203493] reported in #18379.

Fixes #18379.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>