### PR TITLE
drivers: espi: espi_mchp_xec: Fix wrong size type for status var

### DIFF
--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -438,7 +438,7 @@ static void setup_espi_io_config(u16_t host_address)
 
 static void espi_pc_isr(struct device *dev)
 {
-	u8_t status = ESPI_PC_REGS->PC_STATUS;
+	u32_t status = ESPI_PC_REGS->PC_STATUS;
 
 	if (status & MCHP_ESPI_PC_STS_EN_CHG) {
 		if (status & MCHP_ESPI_PC_STS_EN) {


### PR DESCRIPTION
In status variable in espi_pc_isr should have been a 32-bit unsigned int
as ESPI_PC_REGS->PC_STATUS is 32-bits.

Fixes #18359
Coverity-CID: 203521

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>