### PR TITLE
Bluetooth: Mesh: Remove dependency on BT_MESH_IV_UPDATE_TEST in shell

### DIFF
--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -710,6 +710,7 @@ static int cmd_net_send(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
+#if defined(CONFIG_BT_MESH_IV_UPDATE_TEST)
 static int cmd_iv_update(const struct shell *shell, size_t argc, char *argv[])
 {
 	if (bt_mesh_iv_update()) {
@@ -744,6 +745,7 @@ static int cmd_iv_update_test(const struct shell *shell, size_t argc,
 
 	return 0;
 }
+#endif /* CONFIG_BT_MESH_IV_UPDATE_TEST */
 
 static int cmd_rpl_clear(const struct shell *shell, size_t argc, char *argv[])
 {
@@ -1936,9 +1938,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mesh_cmds,
 
 	/* Commands which access internal APIs, for testing only */
 	SHELL_CMD_ARG(net-send, NULL, "<hex string>", cmd_net_send, 2, 0),
+#if defined(CONFIG_BT_MESH_IV_UPDATE_TEST)
 	SHELL_CMD_ARG(iv-update, NULL, NULL, cmd_iv_update, 1, 0),
 	SHELL_CMD_ARG(iv-update-test, NULL, "<value: off, on>",
 		      cmd_iv_update_test, 2, 0),
+#endif
 	SHELL_CMD_ARG(rpl-clear, NULL, NULL, cmd_rpl_clear, 1, 0),
 
 	/* Configuration Client Model operations */


### PR DESCRIPTION
Fixes undefined reference to bt_mesh_iv_update when enabling BT_MESH_SHELL without BT_MESH_IV_UPDATE_TEST.