### PR TITLE
sensor: bme280: add forced mode measurements configuration

### DIFF
--- a/drivers/sensor/bme280/Kconfig
+++ b/drivers/sensor/bme280/Kconfig
@@ -112,6 +112,19 @@ config BME280_FILTER_16
 	bool "16"
 endchoice
 
+choice
+	prompt "BME280 forced mode"
+	default BME280_FORCED_MODE_OFF
+	help
+	  Select whether measurements must be triggered upon request. In forced mode,
+	  after the measurement is finished, the sensor returns to sleep mode. Turning this
+	  on leads to less power consumption and less self-heating.
+config BME280_FORCED_MODE_OFF
+	bool "forced mode off"
+config BME280_FORCED_MODE_ON
+	bool "forced mode on"
+endchoice
+
 endmenu
 
 endif # BME280

--- a/drivers/sensor/bme280/Kconfig
+++ b/drivers/sensor/bme280/Kconfig
@@ -112,18 +112,12 @@ config BME280_FILTER_16
 	bool "16"
 endchoice
 
-choice
-	prompt "BME280 forced mode"
-	default BME280_FORCED_MODE_OFF
+config BME280_FORCED_MODE
+	bool "Only measure on request (forced mode)"
 	help
-	  Select whether measurements must be triggered upon request. In forced mode,
+	  If enabled, measurements will be triggered upon request.  In forced mode,
 	  after the measurement is finished, the sensor returns to sleep mode. Turning this
 	  on leads to less power consumption and less self-heating.
-config BME280_FORCED_MODE_OFF
-	bool "forced mode off"
-config BME280_FORCED_MODE_ON
-	bool "forced mode on"
-endchoice
 
 endmenu
 

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -174,7 +174,7 @@ static int bme280_sample_fetch(struct device *dev, enum sensor_channel chan)
 		size = 8;
 	}
 
-#if defined CONFIG_BME280_FORCED_MODE_ON
+#ifdef CONFIG_BME280_FORCED_MODE
 
 	/*
 	 * According to datasheet, mode bits (in force mode) must be set

--- a/drivers/sensor/bme280/bme280.h
+++ b/drivers/sensor/bme280/bme280.h
@@ -19,13 +19,18 @@
 #define BME280_REG_CONFIG               0xF5
 #define BME280_REG_CTRL_MEAS            0xF4
 #define BME280_REG_CTRL_HUM             0xF2
+#define BME280_REG_STATUS               0xF3
 
 #define BMP280_CHIP_ID_SAMPLE_1         0x56
 #define BMP280_CHIP_ID_SAMPLE_2         0x57
 #define BMP280_CHIP_ID_MP               0x58
 #define BME280_CHIP_ID                  0x60
+#define BME280_MODE_SLEEP               0x00
+#define BME280_MODE_FORCED              0x01
 #define BME280_MODE_NORMAL              0x03
+#define BME280_MODE_MASK                0x03
 #define BME280_SPI_3W_DISABLE           0x00
+#define BME280_STATUS_MEASURING         0x08
 
 #if defined CONFIG_BME280_TEMP_OVER_1X
 #define BME280_TEMP_OVER                (1 << 5)
@@ -93,9 +98,19 @@
 #define BME280_FILTER                   (4 << 2)
 #endif
 
+#if defined CONFIG_BME280_FORCED_MODE_OFF
+#define BME280_MODE                     BME280_MODE_NORMAL
+#elif defined CONFIG_BME280_FORCED_MODE_ON
+/*
+ * During configuration stage and prior to actual reading the sensor
+ * can be placed into sleep mode.
+ */
+#define BME280_MODE                     BME280_MODE_SLEEP
+#endif
+
 #define BME280_CTRL_MEAS_VAL            (BME280_PRESS_OVER | \
 					 BME280_TEMP_OVER |  \
-					 BME280_MODE_NORMAL)
+					 BME280_MODE)
 #define BME280_CONFIG_VAL               (BME280_STANDBY | \
 					 BME280_FILTER |  \
 					 BME280_SPI_3W_DISABLE)

--- a/drivers/sensor/bme280/bme280.h
+++ b/drivers/sensor/bme280/bme280.h
@@ -98,9 +98,9 @@
 #define BME280_FILTER                   (4 << 2)
 #endif
 
-#if defined CONFIG_BME280_FORCED_MODE_OFF
+#ifndef CONFIG_BME280_FORCED_MODE
 #define BME280_MODE                     BME280_MODE_NORMAL
-#elif defined CONFIG_BME280_FORCED_MODE_ON
+#else
 /*
  * During configuration stage and prior to actual reading the sensor
  * can be placed into sleep mode.


### PR DESCRIPTION
BME280 sensor is known for over-heating when in normal mode, since
measurements are performed continuously.

Forced mode allows to start a measurements only when required.
Downside is that now the status register must be checked before reading
data values.

Signed-off-by: Max Payne <forgge@gmail.com>