### PR TITLE
 doc: releases: Document board and driver changes in 2.0 release note

### DIFF
--- a/doc/releases/release-notes-2.0.rst
+++ b/doc/releases/release-notes-2.0.rst
@@ -38,6 +38,66 @@ Boards & SoC Support
 
 * Add native_posix_64: A 64 bit variant of native_posix
 
+* Added support for the following ARC boards:
+
+  * emdsp
+  * hsdk
+
+* Added support for the following ARM boards:
+
+  * atsamr21_xpro
+  * cc1352r1_launchxl
+  * cc26x2r1_launchxl
+  * holyiot_yj16019
+  * lpcxpresso55s69
+  * mec15xxevb_assy6853
+  * mikroe_mini_m4_for_stm32
+  * mimxrt1015_evk
+  * mps2_an521
+  * nrf51_pca10031
+  * nrf52811_pca10056
+  * nucleo_g071rb
+  * nucleo_wb55rg
+  * qemu_cortex_r5
+  * stm32h747i_disco
+  * stm32mp157c_dk2
+  * twr_ke18f
+  * v2m_musca_b1
+  * 96b_avenger96
+  * 96b_meerkat96
+  * 96b_wistrio
+
+* Added support for the following RISC-V boards:
+
+  * hifive1_revb
+  * litex_vexriscv
+  * qemu_riscv64
+
+* Added support for the following x86 boards:
+
+  * gpmrb
+
+* Added support for the following shield boards:
+
+  * frdm_cr20a
+  * link_board_can
+  * sparkfun_sara_r4
+  * wnc_m14a2a
+  * x_nucleo_iks01a3
+
+* Removed support for the following boards:
+
+  * arduino_101
+  * arduino_101_sss
+  * curie_ble
+  * galileo
+  * quark_d2000_crb
+  * quark_se_c1000_devboard
+  * quark_se_c1000_ss_devboard
+  * quark_se_c1000_ble
+  * tinytile
+  * x86_jailhouse
+
 Drivers and Sensors
 *******************
 

--- a/doc/releases/release-notes-2.0.rst
+++ b/doc/releases/release-notes-2.0.rst
@@ -101,7 +101,172 @@ Boards & SoC Support
 Drivers and Sensors
 *******************
 
-* native_posix timer driver rewrite with tickless support
+* ADC
+
+  * Added API to support calibration
+  * Enabled ADC on STM32WB
+  * Removed Quark D2000 ADC driver
+  * Added NXP ADC12 and SAM0 ADC drivers
+  * Added ADC shell
+
+* Audio
+
+  * Added support for 2 microphones (stereo) in mpxxdtyy driver
+
+* CAN
+
+  * Added support for canbus Ethernet translator
+  * Added 6LoCAN implementation
+  * Added MCP2515, NXP FlexCAN, and loopback drivers
+  * Added CAN shell
+
+* Clock Control
+
+  * Added NXP Kinetis MCG, SCG, and PCC drivers
+  * Removed Quark SE driver
+  * Added STM32H7, STM32L1X, and STM32WB support
+
+* Counter
+
+  * Added optional flags to alarm configuration structure and extended set channel alarm flags
+  * Added top_value setting configuration structure to API
+  * Enabled counter for STM32WB
+  * Added NXP GPT, "CMOS" RTC, SiLabs RTCC, and SAM0 drivers
+  * Removed Quark D2000 support from QMSI driver
+
+* Display
+
+  * Added ST7789V based LCD driver
+  * Renamed ssd1673 driver to ssd16xx
+  * Added framebuffer driver with multiboot support
+  * Added support for Seeed 2.8" TFT touch shield v2.0
+
+* DMA
+
+  * Added API to retrieve runtime status
+  * Added SAM0 DMAC driver
+  * Removed Quark SE C1000 support from QMSI driver
+
+* Entropy
+
+  * Added TI CC13xx / CC26xx driver
+
+* ESPI
+
+  * Added Microchip XEC driver
+
+* Ethernet
+
+  * Added LiteEth driver
+
+* Flash
+
+  * Removed Quark SE C1000 driver
+  * Removed support for Quark D2000 from QMSI driver
+  * Added STM32G0XX and STM32WB support to STM32 driver
+  * Added RV32M1 and native POSIX drivers
+
+* GPIO
+
+  * Added stm32f1x SWJ configuration
+  * Removed Quark SE C1000 and D2000 support from DesignWare driver
+  * Added support for STM32H7, STM32L1X, and STM32WB to STM32 driver
+  * Added Microchip XEC and TI CC13x2 / CC26x2 drivers
+  * Added HT16K33 LED driver
+  * Added interrupt support to SAM0 driver
+
+* Hardware Info
+
+  * Added ESP32 and SAM0 drivers
+
+* I2C
+
+  * Added support for STM32MP1, STM32WB, and STM32L1X to STM32 driver
+  * Added STM32F10X slave support
+  * Added power management to nrf TWI and TWIM drivers
+  * Added TI CC13xx / CC26xx, Microchip MEC, SAM0, and RV32M1 drivers
+  * Rewrote DesignWare driver for PCI(e) support
+
+* IEEE 802.15.4
+
+  * Fixed KW41z fault and dBm mapping
+
+* Interrupt Controller
+
+  * Added initial support for ARC TCC
+  * Added GIC400, LiteX, and SAM0 EIC drivers
+  * Added support for STM32G0X, STM32H7, STM32WB, and STM32MP1 to STM32 driver
+  * Removed MVIC driver
+
+* IPM
+
+  * Removed Quark SE driver
+  * Added MHU and STM32 drivers
+
+* LED
+
+  * Added Holtek HT16K33 LED driver
+
+* Modem
+
+  * Introduced socket helper layer
+  * Introduced command handler and UART interface driver layers
+  * Introduced modem context helper driver
+  * Added u-blox SARA-R4 modem driver
+
+* Pinmux
+
+  * Added SPI support to STM32MP1
+  * Enabled ADC, PWM, I2C, and SPI pins on STM32WB
+  * Added Microchip XEC and TI CC13x2 / CC26x2 drivers
+
+* PWM
+
+  * Added NXP PWM driver
+  * Added support for STM32G0XX to STM32 driver
+
+* Sensor
+
+  * Added STTS751 temperature sensor driver
+  * Added LSM6DSO and LPS22HH drivers
+  * Renamed HDC1008 driver to ti_hdc and added support for 1050 version
+  * Added LED current, proximity pulse length, ALS, and proximity gain configurations to APDS9960 driver
+  * Reworked temperature and acceleration conversions, and added interrupt handling in ADXL362 driver
+  * Added BME680 driver and AMS ENS210 drivers
+
+* Serial
+
+  * Added Xilinx ZynqMP PS, LiteUART, and TI CC12x2 / CC26x2 drivers
+  * Added support for virtual UARTS over RTT channels
+  * Added support for STM32H7 to STM32 driver
+  * Removed support for Quark D2000 from QMSI driver
+  * Enabled interrupts in LPC driver
+  * Implemented ASYNC API in SAM0 driver
+  * Added PCI(e) support to NS16550 driver
+
+* SPI
+
+  * Added support for STM32MP1X and STM32WB to STM32 driver
+  * Removed support for Quark SE C1000 from DesignWare driver
+  * Added TI CC13xx / CC26xx driver
+  * Implemented ASYNC API in SAM0 driver
+
+* Timer
+
+  * Added Xilinx ZynqMP PS ttc driver
+  * Added support for SMP to ARC V2 driver
+  * Added MEC1501 32 KHZ, local APIC timer, and LiteX drivers
+  * Replaced native POSIX system timer driver with tickless support
+  * Removed default selection of SYSTICK timer for ARM platforms
+
+* USB
+
+  * Added NXP EHCI driver
+  * Implemented missing API functions in SAM0 driver
+
+* WiFi
+
+  * Implemented TCP listen/accept and UDP support in eswifi driver
 
 Networking
 **********


### PR DESCRIPTION
- Documents all the boards added and removed across all architectures
since the 1.14.0 release.
- Documents major driver changes (additions, removals, fixes, etc.) across
all driver families since the 1.14.0 release.