### PR TITLE
DNS: Revamp and make RFC-compliant parsing of responses

### DIFF
--- a/subsys/net/lib/dns/dns_pack.h
+++ b/subsys/net/lib/dns/dns_pack.h
@@ -234,20 +234,14 @@ static inline int dns_unpack_query_qclass(const u8_t *question)
 
 static inline int dns_answer_type(u16_t dname_size, u8_t *answer)
 {
-	/** Future versions must consider byte 0
-	 * 4.1.3. Resource record format
-	 * *(answer + dname_size + 0);
-	 */
-	return *(answer + dname_size + 1);
+	/* 4.1.3. Resource record format */
+	return ntohs(UNALIGNED_GET((u16_t *)(answer + dname_size + 0)));
 }
 
 static inline int dns_answer_class(u16_t dname_size, u8_t *answer)
 {
-	/** Future versions must consider byte 2
-	 * 4.1.3. Resource record format
-	 * *(answer + dname_size + 2);
-	 */
-	return *(answer + dname_size + 3);
+	/* 4.1.3. Resource record format */
+	return ntohs(UNALIGNED_GET((u16_t *)(answer + dname_size + 2)));
 }
 
 static inline int dns_answer_ttl(u16_t dname_size, u8_t *answer)


### PR DESCRIPTION
Simplify algorithm to skip (aka calculate length) of encoded domain
name in a DNS answer. Now it's fully compliant to RFC 1035 regarding
handling of compressed FQDNs. Additionally, bounds checking is now
performed by the parsing code.

Fixes: #18334

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>
