### PR TITLE
libc/minimal/assert: conditionalize static_assert macro

### DIFF
--- a/lib/libc/minimal/include/assert.h
+++ b/lib/libc/minimal/include/assert.h
@@ -13,8 +13,10 @@
 #ifdef __cplusplus
 extern "C" {
 #else
+#if __STDC_VERSION__ >= 201112L
 #define static_assert _Static_assert
-#endif
+#endif /* __STDC_VERSION__ */
+#endif /* __cplusplus */
 
 #ifndef NDEBUG
 #ifndef assert


### PR DESCRIPTION
static_assert was not added to C until C11.  Zephyr builds default to
C99.  To preserve compatibility with newlib avoid defining the
macro at standard levels where it did not exist.

Relates to #17738 and #11754.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>