### PR TITLE
samples: mesh_badge: fix font size

### DIFF
--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -23,9 +23,9 @@
 #include "board.h"
 
 enum font_size {
-	FONT_BIG = 0,
+	FONT_SMALL = 0,
 	FONT_MEDIUM = 1,
-	FONT_SMALL = 2,
+	FONT_BIG = 2,
 };
 
 enum screen_ids {


### PR DESCRIPTION
The order of the fonts in ROM has changed.
Since the sorting is not wrong, correct the
order in the application.