### PR TITLE
drivers/flash: stm32l4: Fix Coverity CID 203515.

### DIFF
--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -115,7 +115,7 @@ static int erase_page(struct device *dev, unsigned int page)
 {
 	struct stm32l4x_flash *regs = FLASH_STM32_REGS(dev);
 	u32_t tmp;
-	u16_t pages_per_bank;
+	u16_t pages_per_bank = DT_FLASH_SIZE >> 1;
 	int rc;
 
 #if !defined(FLASH_OPTR_DUALBANK) && !defined(FLASH_OPTR_DBANK)


### PR DESCRIPTION
It is complained in the coverity report that "pages_per_bank" is not be initialized.
So, we set it with a default value(DT_FLASH_SIZE >> 1).

Fix for #18361.

Signed-off-by: Steven Wang <steven.l.wang@linux.intel.com>