### PR TITLE
STM32 wdg: Remove use of float

### DIFF
--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -46,7 +46,7 @@ static void iwdg_stm32_convert_timeout(u32_t timeout,
 	u8_t shift = 0U;
 
 	/* Convert timeout to seconds. */
-	float m_timeout = (float)timeout / 1000000 * LSI_VALUE;
+	u32_t m_timeout = (u64_t)timeout * LSI_VALUE / 1000000;
 
 	do {
 		divider = 4 << shift;


### PR DESCRIPTION
Using int avoids pulling in several kilobytes of float math code, which can be a big deal on small targets.

I have verified on an STM32L0 that this int code produces the same result as the float code for the full range of input values.