### PR TITLE
Bluetooth: Mesh: Access model callback struct

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -10,6 +10,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_ACCESS_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_ACCESS_H_
 
+#include <settings/settings.h>
+
 /**
  * @brief Bluetooth Mesh Access Layer
  * @defgroup bt_mesh_access Bluetooth Mesh Access Layer
@@ -382,6 +384,35 @@ struct bt_mesh_model_pub {
 
 /** Model callback functions. */
 struct bt_mesh_model_cb {
+	/** @brief Set value handler of user data tied to the model.
+	 *
+	 * @sa settings_handler::h_set
+	 *
+	 * @param model Model to set the persistent data of.
+	 * @param len_rd The size of the data found in the backend.
+	 * @param read_cb Function provided to read the data from the backend.
+	 * @param cb_arg Arguments for the read function provided by the
+	 * backend.
+	 *
+	 * @return 0 on success, error otherwise.
+	 */
+	int (*const settings_set)(struct bt_mesh_model *model,
+				  size_t len_rd, settings_read_cb read_cb,
+				  void *cb_arg);
+
+	/** @brief Callback called when all settings have been loaded.
+	 *
+	 * This handler gets called after the settings have been loaded in
+	 * full.
+	 *
+	 * @sa settings_handler::h_commit
+	 *
+	 * @param model Model this callback belongs to.
+	 *
+	 * @return 0 on success, error otherwise.
+	 */
+	int (*const settings_commit)(struct bt_mesh_model *model);
+
 	/** @brief Model init callback.
 	 *
 	 * Called on every model instance during mesh initialization.
@@ -514,6 +545,18 @@ static inline bool bt_mesh_model_in_primary(const struct bt_mesh_model *mod)
 {
 	return (mod->elem_idx == 0);
 }
+
+/** @brief Immediately store the model's user data in persistent storage.
+ *
+ * @param mod Mesh model.
+ * @param vnd This is a vendor model.
+ * @param data Model data to store, or NULL to delete any model data.
+ * @param data_len Length of the model data.
+ *
+ * @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_model_data_store(struct bt_mesh_model *mod, bool vnd,
+			     const void *data, size_t data_len);
 
 /** Node Composition */
 struct bt_mesh_comp {

--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -422,6 +422,15 @@ struct bt_mesh_model_cb {
 	 * @return 0 on success, error otherwise.
 	 */
 	int (*const init)(struct bt_mesh_model *model);
+
+	/** @brief Model reset callback.
+	 *
+	 * Called when the mesh node is reset. All model data is deleted on
+	 * reset, and the model should clear its state.
+	 *
+	 * @param model Model this callback belongs to.
+	 */
+	void (*const reset)(struct bt_mesh_model *model);
 };
 
 /** Abstraction that describes a Mesh Model instance */

--- a/include/bluetooth/mesh/cfg_cli.h
+++ b/include/bluetooth/mesh/cfg_cli.h
@@ -31,10 +31,11 @@ struct bt_mesh_cfg_cli {
 };
 
 extern const struct bt_mesh_model_op bt_mesh_cfg_cli_op[];
+extern const struct bt_mesh_model_cb bt_mesh_cfg_cli_cb;
 
-#define BT_MESH_MODEL_CFG_CLI(cli_data)                                      \
-		BT_MESH_MODEL(BT_MESH_MODEL_ID_CFG_CLI,                      \
-			      bt_mesh_cfg_cli_op, NULL, cli_data)
+#define BT_MESH_MODEL_CFG_CLI(cli_data)                                        \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_CFG_CLI, bt_mesh_cfg_cli_op, NULL,   \
+			 cli_data, &bt_mesh_cfg_cli_cb)
 
 int bt_mesh_cfg_comp_data_get(u16_t net_idx, u16_t addr, u8_t page,
 			      u8_t *status, struct net_buf_simple *comp);

--- a/include/bluetooth/mesh/cfg_srv.h
+++ b/include/bluetooth/mesh/cfg_srv.h
@@ -61,10 +61,11 @@ struct bt_mesh_cfg_srv {
 };
 
 extern const struct bt_mesh_model_op bt_mesh_cfg_srv_op[];
+extern const struct bt_mesh_model_cb bt_mesh_cfg_srv_cb;
 
-#define BT_MESH_MODEL_CFG_SRV(srv_data)                                      \
-		BT_MESH_MODEL(BT_MESH_MODEL_ID_CFG_SRV,                      \
-			      bt_mesh_cfg_srv_op, NULL, srv_data)
+#define BT_MESH_MODEL_CFG_SRV(srv_data)                                        \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_CFG_SRV, bt_mesh_cfg_srv_op, NULL,   \
+			 srv_data, &bt_mesh_cfg_srv_cb)
 
 #ifdef __cplusplus
 }

--- a/include/bluetooth/mesh/health_cli.h
+++ b/include/bluetooth/mesh/health_cli.h
@@ -35,10 +35,11 @@ struct bt_mesh_health_cli {
 };
 
 extern const struct bt_mesh_model_op bt_mesh_health_cli_op[];
+extern const struct bt_mesh_model_cb bt_mesh_health_cli_cb;
 
-#define BT_MESH_MODEL_HEALTH_CLI(cli_data)                                   \
-		BT_MESH_MODEL(BT_MESH_MODEL_ID_HEALTH_CLI,                   \
-			      bt_mesh_health_cli_op, NULL, cli_data)
+#define BT_MESH_MODEL_HEALTH_CLI(cli_data)                                     \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_HEALTH_CLI, bt_mesh_health_cli_op,   \
+			 NULL, cli_data, &bt_mesh_health_cli_cb)
 
 int bt_mesh_health_cli_set(struct bt_mesh_model *model);
 

--- a/include/bluetooth/mesh/health_srv.h
+++ b/include/bluetooth/mesh/health_srv.h
@@ -70,6 +70,7 @@ struct bt_mesh_health_srv {
 int bt_mesh_fault_update(struct bt_mesh_elem *elem);
 
 extern const struct bt_mesh_model_op bt_mesh_health_srv_op[];
+extern const struct bt_mesh_model_cb bt_mesh_health_srv_cb;
 
 /** @def BT_MESH_MODEL_HEALTH_SRV
  *
@@ -83,9 +84,9 @@ extern const struct bt_mesh_model_op bt_mesh_health_srv_op[];
  *
  *  @return New mesh model instance.
  */
-#define BT_MESH_MODEL_HEALTH_SRV(srv, pub)                                   \
-		BT_MESH_MODEL(BT_MESH_MODEL_ID_HEALTH_SRV,                   \
-			      bt_mesh_health_srv_op, pub, srv)
+#define BT_MESH_MODEL_HEALTH_SRV(srv, pub)                                     \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_HEALTH_SRV, bt_mesh_health_srv_op,   \
+			 pub, srv, &bt_mesh_health_srv_cb)
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -30,20 +30,6 @@
 static const struct bt_mesh_comp *dev_comp;
 static u16_t dev_primary_addr;
 
-static const struct {
-	const u16_t id;
-	int (*const init)(struct bt_mesh_model *model, bool primary);
-} model_init[] = {
-	{ BT_MESH_MODEL_ID_CFG_SRV, bt_mesh_cfg_srv_init },
-	{ BT_MESH_MODEL_ID_HEALTH_SRV, bt_mesh_health_srv_init },
-#if defined(CONFIG_BT_MESH_CFG_CLI)
-	{ BT_MESH_MODEL_ID_CFG_CLI, bt_mesh_cfg_cli_init },
-#endif
-#if defined(CONFIG_BT_MESH_HEALTH_CLI)
-	{ BT_MESH_MODEL_ID_HEALTH_CLI, bt_mesh_health_cli_init },
-#endif
-};
-
 void bt_mesh_model_foreach(void (*func)(struct bt_mesh_model *mod,
 					struct bt_mesh_elem *elem,
 					bool vnd, bool primary,
@@ -302,14 +288,8 @@ static void mod_init(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 		mod->mod_idx = mod - elem->models;
 	}
 
-	if (vnd) {
-		return;
-	}
-
-	for (i = 0; i < ARRAY_SIZE(model_init); i++) {
-		if (model_init[i].id == mod->id) {
-			model_init[i].init(mod, primary);
-		}
+	if (mod->cb && mod->cb->init) {
+		mod->cb->init(mod);
 	}
 }
 

--- a/subsys/bluetooth/mesh/access.h
+++ b/subsys/bluetooth/mesh/access.h
@@ -11,6 +11,7 @@ enum {
 	BT_MESH_MOD_BIND_PENDING = BIT(0),
 	BT_MESH_MOD_SUB_PENDING = BIT(1),
 	BT_MESH_MOD_PUB_PENDING = BIT(2),
+	BT_MESH_MOD_DATA_PRESENT = BIT(3),
 };
 
 void bt_mesh_elem_register(struct bt_mesh_elem *elem, u8_t count);

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -3289,14 +3289,22 @@ static void mod_reset(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 
 	/* Clear model state that isn't otherwise cleared. E.g. AppKey
 	 * binding and model publication is cleared as a consequence
-	 * of removing all app keys, however model subscription clearing
-	 * must be taken care of here.
+	 * of removing all app keys, however model subscription and user data
+	 * clearing must be taken care of here.
 	 */
 
 	clear_count = mod_sub_list_clear(mod);
 
-	if (IS_ENABLED(CONFIG_BT_SETTINGS) && clear_count) {
-		bt_mesh_store_mod_sub(mod);
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		if (clear_count) {
+			bt_mesh_store_mod_sub(mod);
+		}
+
+		bt_mesh_model_data_store(mod, vnd, NULL, 0);
+	}
+
+	if (mod->cb && mod->cb->reset) {
+		mod->cb->reset(mod);
 	}
 }
 

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -3233,9 +3233,14 @@ static bool conf_is_valid(struct bt_mesh_cfg_srv *cfg)
 	return true;
 }
 
-int bt_mesh_cfg_srv_init(struct bt_mesh_model *model, bool primary)
+static int cfg_srv_init(struct bt_mesh_model *model)
 {
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
+
+	if (!bt_mesh_model_in_primary(model)) {
+		BT_ERR("Configuration Server only allowed in primary element");
+		return -EINVAL;
+	}
 
 	if (!cfg) {
 		BT_ERR("No Configuration Server context provided");
@@ -3272,6 +3277,10 @@ int bt_mesh_cfg_srv_init(struct bt_mesh_model *model, bool primary)
 
 	return 0;
 }
+
+const struct bt_mesh_model_cb bt_mesh_cfg_srv_cb = {
+	.init = cfg_srv_init,
+};
 
 static void mod_reset(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 		      bool vnd, bool primary, void *user_data)

--- a/subsys/bluetooth/mesh/foundation.h
+++ b/subsys/bluetooth/mesh/foundation.h
@@ -112,12 +112,6 @@
 #define STATUS_UNSPECIFIED                 0x10
 #define STATUS_INVALID_BINDING             0x11
 
-int bt_mesh_cfg_srv_init(struct bt_mesh_model *model, bool primary);
-int bt_mesh_health_srv_init(struct bt_mesh_model *model, bool primary);
-
-int bt_mesh_cfg_cli_init(struct bt_mesh_model *model, bool primary);
-int bt_mesh_health_cli_init(struct bt_mesh_model *model, bool primary);
-
 void bt_mesh_cfg_reset(void);
 
 void bt_mesh_heartbeat(u16_t src, u16_t dst, u8_t hops, u16_t feat);

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -510,11 +510,11 @@ int bt_mesh_health_cli_set(struct bt_mesh_model *model)
 	return 0;
 }
 
-int bt_mesh_health_cli_init(struct bt_mesh_model *model, bool primary)
+static int health_cli_init(struct bt_mesh_model *model)
 {
 	struct bt_mesh_health_cli *cli = model->user_data;
 
-	BT_DBG("primary %u", primary);
+	BT_DBG("primary %u", bt_mesh_model_in_primary(model));
 
 	if (!cli) {
 		BT_ERR("No Health Client context provided");
@@ -533,3 +533,7 @@ int bt_mesh_health_cli_init(struct bt_mesh_model *model, bool primary)
 
 	return 0;
 }
+
+const struct bt_mesh_model_cb bt_mesh_health_cli_cb = {
+	.init = health_cli_init,
+};

--- a/subsys/bluetooth/mesh/health_srv.c
+++ b/subsys/bluetooth/mesh/health_srv.c
@@ -384,12 +384,12 @@ static void attention_off(struct k_work *work)
 	}
 }
 
-int bt_mesh_health_srv_init(struct bt_mesh_model *model, bool primary)
+static int health_srv_init(struct bt_mesh_model *model)
 {
 	struct bt_mesh_health_srv *srv = model->user_data;
 
 	if (!srv) {
-		if (!primary) {
+		if (!bt_mesh_model_in_primary(model)) {
 			return 0;
 		}
 
@@ -408,12 +408,16 @@ int bt_mesh_health_srv_init(struct bt_mesh_model *model, bool primary)
 
 	srv->model = model;
 
-	if (primary) {
+	if (bt_mesh_model_in_primary(model)) {
 		health_srv = srv;
 	}
 
 	return 0;
 }
+
+const struct bt_mesh_model_cb bt_mesh_health_srv_cb = {
+	.init = health_srv_init,
+};
 
 void bt_mesh_attention(struct bt_mesh_model *model, u8_t time)
 {


### PR DESCRIPTION
Adds a structure of callbacks for each model instance. This allows for more flexible model implementations, that can interact with the Mesh stack without going through the application.

The motivation for this change is to improve the user experience when adding modular, reusable model implementations. The intention is to make it as easy to mix and match models as it is with drivers, where the user only has to list their models in the composition data to enable them. 

Added callbacks for init and model user data persistent storage. The init callback replaces the internal lookup for foundation models. Also adds variation of the `BT_MESH_MODEL` macro with a callback parameter, without breaking the backward compatibility of the old macro.

Looking for some input, particularly in these areas:
Any other callbacks we should add right away? 
Are there better ways to enable model instance settings storage? 
Should the model persistent storage be scheduled like the other mesh settings?