### PR TITLE
Bluetooth: controller: split: Fix Tx pool corruption

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1227,11 +1227,11 @@ static inline void *done_release(memq_link_t *link,
 {
 	u8_t idx;
 
-	done->hdr.link = link;
-
 	if (!MFIFO_ENQUEUE_IDX_GET(done, &idx)) {
 		return NULL;
 	}
+
+	done->hdr.link = link;
 
 	MFIFO_BY_IDX_ENQUEUE(done, idx, done);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1147,25 +1147,26 @@ void ull_conn_done(struct node_rx_event_done *done)
 void ull_conn_tx_demux(u8_t count)
 {
 	do {
-		struct ll_conn *conn;
 		struct lll_tx *lll_tx;
+		struct ll_conn *conn;
+		struct node_tx *tx;
 
 		lll_tx = MFIFO_DEQUEUE_GET(conn_tx);
 		if (!lll_tx) {
 			break;
 		}
 
+		tx = lll_tx->node;
+		tx->next = NULL;
+
 		conn = ll_connected_get(lll_tx->handle);
 		if (conn) {
-			struct node_tx *tx = lll_tx->node;
-
 #if defined(CONFIG_BT_CTLR_LLID_DATA_START_EMPTY)
 			if (empty_data_start_release(conn, tx)) {
 				goto ull_conn_tx_demux_release;
 			}
 #endif /* CONFIG_BT_CTLR_LLID_DATA_START_EMPTY */
 
-			tx->next = NULL;
 			if (!conn->tx_data) {
 				conn->tx_data = tx;
 				if (!conn->tx_head) {
@@ -1180,7 +1181,6 @@ void ull_conn_tx_demux(u8_t count)
 
 			conn->tx_data_last = tx;
 		} else {
-			struct node_tx *tx = lll_tx->node;
 			struct pdu_data *p = (void *)tx->pdu;
 
 			p->ll_id = PDU_DATA_LLID_RESV;


### PR DESCRIPTION
Fix an issue where in Control PDU buffers and Data PDU
could inter changeably be released back into wrong pools.

The next field in the Tx node is used to indicate whether
the node is to be released to Control Pool, i.e. if the next
field points back to the said Tx node itself, or into the
Data Pool, i.e. if next field has the value NULL.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>