### PR TITLE
kernel: Make it possible to disable mempool

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -10,7 +10,6 @@ add_library(kernel
   init.c
   mailbox.c
   mem_slab.c
-  mempool.c
   msg_q.c
   mutex.c
   pipes.c
@@ -39,6 +38,7 @@ target_sources_ifdef(CONFIG_STACK_CANARIES        kernel PRIVATE compiler_stack_
 target_sources_ifdef(CONFIG_SYS_CLOCK_EXISTS      kernel PRIVATE timeout.c timer.c)
 target_sources_ifdef(CONFIG_ATOMIC_OPERATIONS_C   kernel PRIVATE atomic_c.c)
 target_sources_if_kconfig(                        kernel PRIVATE poll.c)
+target_sources_if_kconfig(                        kernel PRIVATE mempool.c)
 
 # The last 2 files inside the target_sources_ifdef should be
 # userspace_handler.c and userspace.c. If not the linker would complain.

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -479,6 +479,15 @@ config NUM_PIPE_ASYNC_MSGS
 	  Setting this option to 0 disables support for asynchronous
 	  pipe messages.
 
+config MEMPOOL
+	bool "Memory pools"
+	default y
+	help
+	  If the mempool is not used, this can be disabled to save space. The
+	  mempool is used by a number of internal modules, so keep this in mind
+	  if disabling.
+
+if MEMPOOL
 config HEAP_MEM_POOL_SIZE
 	int "Heap memory pool size (in bytes)"
 	default 0 if !POSIX_MQUEUE
@@ -497,6 +506,7 @@ config HEAP_MEM_POOL_MIN_SIZE
 	  This option specifies the size of the smallest block in the pool.
 	  Option must be a power of 2 and lower than or equal to the size
 	  of the entire pool.
+endif
 endmenu
 
 config ARCH_HAS_CUSTOM_SWAP_TO_MAIN


### PR DESCRIPTION
To save code space when making constrained applications, since
mempool automatically adds code even when not used.

In my test (pca10090, hello_world) it saves 288 bytes.