### PR TITLE
samples: shell: fs: README: Typo in "pkgconfig" name.

### DIFF
--- a/samples/subsys/shell/fs/README.rst
+++ b/samples/subsys/shell/fs/README.rst
@@ -19,7 +19,7 @@ Building
 Native Posix
 ============
 
-Before starting a build, make sure that the i386 pkconfig directory is in your
+Before starting a build, make sure that the i386 pkgconfig directory is in your
 search path and that a 32-bit version of libfuse is installed. For more
 background information on this requirement see :ref:`native_posix`.
 


### PR DESCRIPTION
Was "pkconfig", which may confuse users whether some different tool
than the standard pkgconfig is meant.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>