### PR TITLE
tests/ /gen_inc_file: convert 4,5,6,7 enumeration to an interval

### DIFF
--- a/tests/application_development/gen_inc_file/src/main.c
+++ b/tests/application_development/gen_inc_file/src/main.c
@@ -92,7 +92,7 @@ static void do_test_gen_gz_inc_file(const unsigned char gz_inc_file[],
 	int i;
 
 	for (i = 0; i < sizeof(inc_file); i++) {
-		if (i == 4 || i == 5 || i == 6 || i == 7) {
+		if (4 <= i && i < 8) {
 			/* Modification time field (4 bytes) in
 			 * the gzip header.
 			 */


### PR DESCRIPTION
It's shorter and may get rid of false Coverity positives 203489 and
203498 and fix #18424 and duplicate #18425.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>