### PR TITLE
tests: kernel: fix unhandled return values.

### DIFF
--- a/tests/kernel/mem_protect/sys_sem/src/main.c
+++ b/tests/kernel/mem_protect/sys_sem/src/main.c
@@ -116,8 +116,12 @@ void sem_take_multiple_high_prio_helper(void *p1, void *p2, void *p3)
 
 void sem_multiple_threads_wait_helper(void *p1, void *p2, void *p3)
 {
+	int ret_value;
+
 	/* get blocked until the test thread gives the semaphore */
-	sys_sem_take(&multiple_thread_sem, K_FOREVER);
+	ret_value = sys_sem_take(&multiple_thread_sem, K_FOREVER);
+	zassert_true(ret_value == 0,
+		     "sys_sem_take failed when its shouldn't have\n");
 
 	/* Inform the test thread that this thread has got multiple_thread_sem*/
 	sys_sem_give(&simple_sem);

--- a/tests/kernel/mutex/sys_mutex/src/main.c
+++ b/tests/kernel/mutex/sys_mutex/src/main.c
@@ -418,6 +418,8 @@ K_THREAD_DEFINE(THREAD_11, STACKSIZE, thread_11, NULL, NULL, NULL,
 /*test case main entry*/
 void test_main(void)
 {
+	int rv;
+
 #ifdef CONFIG_USERSPACE
 	k_thread_access_grant(k_current_get(),
 			      &thread_12_thread_data, &thread_12_stack_area);
@@ -429,7 +431,10 @@ void test_main(void)
 	k_mem_domain_add_thread(&ztest_mem_domain, THREAD_09);
 	k_mem_domain_add_thread(&ztest_mem_domain, THREAD_11);
 #endif
-	sys_mutex_lock(&not_my_mutex, K_NO_WAIT);
+	rv = sys_mutex_lock(&not_my_mutex, K_NO_WAIT);
+	if (rv != 0) {
+		TC_ERROR("Failed to take mutex %p\n", &not_my_mutex);
+	}
 
 	/* We deliberately disable userspace, even on platforms that
 	 * support it, so that the alternate implementation of sys_mutex


### PR DESCRIPTION
Fix coverity issue 203454 and 203507. Fix unhandled return values as most other places of the same function handled in this file.

Fixes: #18443 and #18445.