### PR TITLE
Coverity: posix: pthread_create: Ignore retval of pthread_mutex_init() calls

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -164,8 +164,12 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr,
 	prio = posix_to_zephyr_priority(attr->priority, attr->schedpolicy);
 
 	thread = &posix_thread_pool[pthread_num];
-	pthread_mutex_init(&thread->state_lock, NULL);
-	pthread_mutex_init(&thread->cancel_lock, NULL);
+	/*
+	 * Ignore return value, as we know that Zephyr implementation
+	 * cannot fail.
+	 */
+	(void)pthread_mutex_init(&thread->state_lock, NULL);
+	(void)pthread_mutex_init(&thread->cancel_lock, NULL);
 
 	pthread_mutex_lock(&thread->cancel_lock);
 	thread->cancel_state = (1 << _PTHREAD_CANCEL_POS) & attr->flags;


### PR DESCRIPTION
pthread_mutex_init() just redirects to Zephyr kernel primitive, for
initializing structure fields. So, use the knowledge that it can't
fail (for as long as structure pointer is initialized, and here it's
from pre-allocated array), and ignore return value of
pthread_mutex_init()

Coverity-CID: 203542
Fixes: #18371

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>