### PR TITLE
posix: fs: ZFD_IOCTL_CLOSE: Be sure to call posix_fs_free_obj()

### DIFF
--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -102,6 +102,7 @@ static int fs_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 	switch (request) {
 	case ZFD_IOCTL_CLOSE:
 		rc = fs_close(&ptr->file);
+		posix_fs_free_obj(ptr);
 		break;
 
 	case ZFD_IOCTL_LSEEK: {

--- a/tests/posix/fs/src/main.c
+++ b/tests/posix/fs/src/main.c
@@ -14,6 +14,7 @@ void test_main(void)
 		ztest_unit_test(test_fs_write),
 		ztest_unit_test(test_fs_read),
 		ztest_unit_test(test_fs_close),
+		ztest_unit_test(test_fs_fd_leak),
 		ztest_unit_test(test_fs_unlink),
 		ztest_unit_test(test_fs_mkdir),
 		ztest_unit_test(test_fs_readdir));

--- a/tests/posix/fs/src/test_fs.h
+++ b/tests/posix/fs/src/test_fs.h
@@ -18,6 +18,7 @@ void test_fs_open(void);
 void test_fs_write(void);
 void test_fs_read(void);
 void test_fs_close(void);
+void test_fs_fd_leak(void);
 void test_fs_unlink(void);
 void test_fs_mkdir(void);
 void test_fs_readdir(void);

--- a/tests/posix/fs/src/test_fs_file.c
+++ b/tests/posix/fs/src/test_fs_file.c
@@ -16,17 +16,10 @@ static int test_file_open(void)
 {
 	int res;
 
-	TC_PRINT("\nOpen tests:\n");
-
 	res = open(TEST_FILE, O_RDWR);
-	if (res < 0) {
-		TC_PRINT("Failed opening file [%d]\n", res);
-		return res;
-	}
+	zassert_true(res >= 0, "Failed opening file: %d, errno=%d\n", res, errno);
 
 	file = res;
-
-	TC_PRINT("Opened file %s\n", TEST_FILE);
 
 	return 0;
 }
@@ -36,16 +29,12 @@ int test_file_write(void)
 	ssize_t brw;
 	off_t res;
 
-	TC_PRINT("\nWrite tests:\n");
-
 	res = lseek(file, 0, SEEK_SET);
 	if (res != 0) {
 		TC_PRINT("lseek failed [%d]\n", (int)res);
 		close(file);
 		return TC_FAIL;
 	}
-
-	TC_PRINT("Data written:\"%s\"\n\n", test_str);
 
 	brw = write(file, (char *)test_str, strlen(test_str));
 	if (brw < 0) {
@@ -61,8 +50,6 @@ int test_file_write(void)
 		return TC_FAIL;
 	}
 
-	TC_PRINT("Data successfully written!\n");
-
 	return res;
 }
 
@@ -72,8 +59,6 @@ static int test_file_read(void)
 	off_t res;
 	char read_buff[80];
 	size_t sz = strlen(test_str);
-
-	TC_PRINT("\nRead tests:\n");
 
 	res = lseek(file, 0, SEEK_SET);
 	if (res != 0) {
@@ -90,8 +75,6 @@ static int test_file_read(void)
 	}
 
 	read_buff[brw] = 0;
-
-	TC_PRINT("Data read:\"%s\"\n", read_buff);
 
 	if (strcmp(test_str, read_buff)) {
 		TC_PRINT("Error - Data read does not match data written\n");
@@ -120,15 +103,11 @@ static int test_file_read(void)
 
 	read_buff[brw] = 0;
 
-	TC_PRINT("Data read:\"%s\"\n", read_buff);
-
 	if (strcmp(test_str + 2, read_buff)) {
 		TC_PRINT("Error - Data read does not match data written\n");
 		TC_PRINT("Data read:\"%s\"\n\n", read_buff);
 		return TC_FAIL;
 	}
-
-	TC_PRINT("\nData read matches data written\n");
 
 	return res;
 }
@@ -137,15 +116,8 @@ static int test_file_close(void)
 {
 	int res;
 
-	TC_PRINT("\nClose tests:\n");
-
 	res = close(file);
-	if (res) {
-		TC_PRINT("Error closing file [%d]\n", res);
-		return res;
-	}
-
-	TC_PRINT("Closed file %s\n", TEST_FILE);
+	zassert_true(res == 0, "Failed closing file: %d, errno=%d\n", res, errno);
 
 	return res;
 }
@@ -154,15 +126,11 @@ static int test_file_delete(void)
 {
 	int res;
 
-	TC_PRINT("\nDelete tests:\n");
-
 	res = unlink(TEST_FILE);
 	if (res) {
 		TC_PRINT("Error deleting file [%d]\n", res);
 		return res;
 	}
-
-	TC_PRINT("File (%s) deleted successfully!\n", TEST_FILE);
 
 	return res;
 }

--- a/tests/posix/fs/src/test_fs_file.c
+++ b/tests/posix/fs/src/test_fs_file.c
@@ -184,3 +184,14 @@ void test_fs_unlink(void)
 {
 	zassert_true(test_file_delete() == TC_PASS, NULL);
 }
+
+void test_fs_fd_leak(void)
+{
+	const int reps =
+	    MAX(CONFIG_POSIX_MAX_OPEN_FILES, CONFIG_POSIX_MAX_FDS) + 5;
+
+	for (int i = 0; i < reps; i++) {
+		test_fs_open();
+		test_fs_close();
+	}
+}


### PR DESCRIPTION
To make sure that entry in fs.c:desc_array[] is freed. Note that
freeing an entry in fdtable is handled by generic implementation
of close().

Fixes: #17231

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>