### PR TITLE
dts/bindings: Add gpio-generic binding

### DIFF
--- a/dts/bindings/gpio/gpio-generic.yaml
+++ b/dts/bindings/gpio/gpio-generic.yaml
@@ -1,0 +1,20 @@
+title: GPIO GENERIC
+
+description: >
+    This is a representation of the GPIO GENERIC nodes
+
+inherits:
+    !include [base.yaml]
+
+properties:
+    compatible:
+        constraint: "gpio-generic"
+
+sub-node:
+    properties:
+        gpios:
+            type: compound
+            category: required
+        label:
+            type: string
+            category: required


### PR DESCRIPTION
This binding is meant to specify gpios in the device-tree that are not leds
or buttons.

Signed-off-by: Tobias Svehagen <tobias.svehagen@gmail.com>