### PR TITLE
scripts: kconfig: dt_exists macro

### DIFF
--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -91,8 +91,22 @@ def dt_str_val(kconf, _, name):
 
     return dt_defines[name].strip('"')
 
+def dt_exists(kconf, _, name):
+    """
+    This function looks up 'name' in the DTS generated "conf" style database
+    (generated_dts_board.conf in <build_dir>/zephyr/include/generated/)
+    and if it's found it will return "y".  If it's not found we
+    return "n"
+    """
+
+    if doc_mode or name not in dt_defines:
+        return "n"
+
+    return "y"
+
 functions = {
         "dt_int_val": (dt_int_val, 1, 2),
         "dt_hex_val": (dt_hex_val, 1, 2),
         "dt_str_val": (dt_str_val, 1, 1),
+        "dt_exists":  (dt_exists, 1, 1),
 }


### PR DESCRIPTION
Implement a `dt_exists` macro that will expand to "y" or "n" depending on whether a certain DT define is found. It can be used to let Kconfig options depend on DT-generated defines, for example:
```
config XYZ
 bool "Enable XYZ"
  depends on $(dt_exists, DT_MACRO)
```

Similar macros exists for hex, str and int values.
However, they expand to the respective values of the DT-macro.