### PR TITLE
arch/xtensa: Clean up fatal error handling

### DIFF
--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -9,6 +9,7 @@
 #include <inttypes.h>
 #include <kernel_arch_data.h>
 #include <xtensa/specreg.h>
+#include <xtensa-asm2-context.h>
 
 #ifdef XT_SIMULATOR
 #include <xtensa/simcall.h>
@@ -25,9 +26,9 @@
 	})
 
 
-#if defined(CONFIG_PRINTK) || defined(CONFIG_LOG)
-static char *cause_str(unsigned int cause_code)
+char *z_xtensa_exccause(unsigned int cause_code)
 {
+#if defined(CONFIG_PRINTK) || defined(CONFIG_LOG)
 	switch (cause_code) {
 	case 0:
 		return "illegal instruction";
@@ -78,49 +79,16 @@ static char *cause_str(unsigned int cause_code)
 	default:
 		return "unknown/reserved";
 	}
-}
+#else
+	ARG_UNUSED(cause_code);
+	return "na";
 #endif
-
-static inline unsigned int get_bits(int offset, int num_bits, unsigned int val)
-{
-	int mask;
-
-	mask = BIT(num_bits) - 1;
-	val = val >> offset;
-	return val & mask;
 }
 
-static void dump_exc_state(void)
+void z_xtensa_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 {
-#if defined(CONFIG_PRINTK) || defined (CONFIG_LOG)
-	unsigned int cause, ps;
-
-	cause = get_sreg(EXCCAUSE);
-	ps = get_sreg(PS);
-
-	z_fatal_print("Exception cause %d (%s):", cause, cause_str(cause));
-	z_fatal_print("  EPC1     : 0x%08x EXCSAVE1 : 0x%08x EXCVADDR : 0x%08x",
-		      get_sreg(EPC_1), get_sreg(EXCSAVE_1), get_sreg(EXCVADDR));
-
-	z_fatal_print("Program state (PS):");
-	z_fatal_print("  INTLEVEL : %02d EXCM    : %d UM  : %d RING : %d WOE : %d",
-		      get_bits(0, 4, ps), get_bits(4, 1, ps),
-		      get_bits(5, 1, ps), get_bits(6, 2, ps),
-		      get_bits(18, 1, ps));
-#ifndef __XTENSA_CALL0_ABI__
-	z_fatal_print("  OWB      : %02d CALLINC : %d",
-		      get_bits(8, 4, ps), get_bits(16, 2, ps));
-#endif
-#endif /* CONFIG_PRINTK || CONFIG_LOG */
-}
-
-XTENSA_ERR_NORET void z_xtensa_fatal_error(unsigned int reason,
-					   const z_arch_esf_t *esf)
-{
-	dump_exc_state();
-
 	if (esf) {
-		z_fatal_print("Faulting instruction address = 0x%x", esf->pc);
+		z_xtensa_dump_stack(esf);
 	}
 
 	z_fatal_error(reason, esf);

--- a/include/arch/xtensa/exc.h
+++ b/include/arch/xtensa/exc.h
@@ -32,7 +32,15 @@ struct __esf {
 	u32_t pc;
 };
 
-typedef struct __esf z_arch_esf_t;
+/* Xtensa uses a variable length stack frame depending on how many
+ * register windows are in use.  This isn't a struct type, it just
+ * matches the register/stack-unit width.
+ */
+typedef int z_arch_esf_t;
+
+void z_xtensa_dump_stack(const z_arch_esf_t *stack);
+char *z_xtensa_exccause(unsigned int cause_code);
+
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Update the xtensa backend to work better with the new fatal error
architecture.  Move the stack frame dump (xtensa uses a variable-size
frame becuase we don't spill unused register windows, so it doesn't
strictly have an ESF struct) into z_xtensa_fatal_error().  Unify the
older exception logging with the newer one (they'd been sort of glomed
together in the recent rework), mostly using the asm2 code but with
the exception cause stringification and the PS register field
extraction from the older one.

Note that one shortcoming is that the way the dispatch code works, we
don't have access to the spilled frame from within the spurious error
handler, so this can't log the interrupted CPU state.  This isn't
fixable easily without adding overhead to every interrupt entry, so it
needs to stay the way it is for now.  Longer term we could exract the
caller frame from the window state and figure it out with some
elaborate assembly, I guess.

Fixes #18140

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>