### PR TITLE
Added dummy member to struct _thread_arch of native posix board to fix warning

### DIFF
--- a/arch/posix/include/kernel_arch_thread.h
+++ b/arch/posix/include/kernel_arch_thread.h
@@ -41,6 +41,7 @@ struct _callee_saved {
 
 struct _thread_arch {
 	/* nothing for now */
+	int dummy;
 };
 
 typedef struct _thread_arch _thread_arch_t;


### PR DESCRIPTION
Added dummy member to struct _thread_arch to suppress clang compiler
warning.

In case a build is made for the native posix board with `clang` the following warning is generated:
```
In file included from .../zephyr/include/device.h:11:
In file included from .../zephyr/include/kernel.h:17:
In file included from .../zephyr/include/kernel_includes.h:31:
.../zephyr/arch/posix/include/kernel_arch_thread.h:42:1: warning: empty struct has size 0 in C, size 1 in C++ [-Wextern-c-compat]
struct _thread_arch {
^
1 warning generated.
```

Further note that according to the C standard a struct can not be empty and the behaviour is undefined.

