### PR TITLE
samples: usb: cdc_acm*: Fix device testing

### DIFF
--- a/samples/subsys/usb/cdc_acm_composite/src/main.c
+++ b/samples/subsys/usb/cdc_acm_composite/src/main.c
@@ -20,7 +20,7 @@
 #include <sys/ring_buffer.h>
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(cdc_acm_composite, CONFIG_LOG_DEFAULT_LEVEL);
+LOG_MODULE_REGISTER(cdc_acm_composite, LOG_LEVEL_INF);
 
 #define RING_BUF_SIZE	(64 * 2)
 
@@ -128,7 +128,7 @@ void main(void)
 		return;
 	}
 
-	LOG_DBG("Wait for DTR");
+	LOG_INF("Wait for DTR");
 
 	while (1) {
 		uart_line_ctrl_get(dev0, LINE_CTRL_DTR, &dtr);
@@ -148,7 +148,7 @@ void main(void)
 		k_sleep(100);
 	}
 
-	LOG_DBG("DTR set, start test");
+	LOG_INF("DTR set, start test");
 
 	uart_line_set(dev0);
 	uart_line_set(dev1);


### PR DESCRIPTION
The device testing harness for the cdc_acm & cdc_acm_composite samples
has some expected console output to tell if the sample is running
propertly.  However that output is handled via LOG_DBG() statements in
the code.  To ensure we see those LOG_DBG() statements enable
CONFIG_LOG_IMMEDIATE.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>