### PR TITLE
drivers: wifi: simplelink: fix 'log_strdup missing' error messages 

### DIFF
--- a/drivers/wifi/simplelink/simplelink_support.c
+++ b/drivers/wifi/simplelink/simplelink_support.c
@@ -273,7 +273,7 @@ void SimpleLinkWlanEventHandler(SlWlanEvent_t *wlan_event)
 
 		LOG_INF("[WLAN EVENT] STA Connected to the AP: %s, "
 			"BSSID: %x:%x:%x:%x:%x:%x",
-			sl_conn.ssid, sl_conn.bssid[0],
+			log_strdup(sl_conn.ssid), sl_conn.bssid[0],
 			sl_conn.bssid[1], sl_conn.bssid[2],
 			sl_conn.bssid[3], sl_conn.bssid[4],
 			sl_conn.bssid[5]);
@@ -297,7 +297,7 @@ void SimpleLinkWlanEventHandler(SlWlanEvent_t *wlan_event)
 		    event_data->ReasonCode) {
 			LOG_INF("[WLAN EVENT] "
 				"Device disconnected from the AP: %s",
-				event_data->SsidName);
+				log_strdup(event_data->SsidName));
 			LOG_INF("BSSID: %x:%x:%x:%x:%x:%x on application's"
 				" request", event_data->Bssid[0],
 				event_data->Bssid[1], event_data->Bssid[2],
@@ -307,7 +307,7 @@ void SimpleLinkWlanEventHandler(SlWlanEvent_t *wlan_event)
 		} else {
 			LOG_ERR("[WLAN ERROR] "
 				"Device disconnected from the AP: %s",
-				event_data->SsidName);
+				log_strdup(event_data->SsidName));
 			LOG_ERR("BSSID: %x:%x:%x:%x:%x:%x on error: %d",
 				event_data->Bssid[0],
 				event_data->Bssid[1], event_data->Bssid[2],


### PR DESCRIPTION
Due to commit a211afb0412e29f5ffa09a8a93b7b4ca4bd1b6e4, an error on
missing log_strdup() call is seen when running samples for CC32xx
devices that use the Wi-Fi driver. Adding log_strdup() calls to fix
this.

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>