### PR TITLE
samples: usb: webusb: Mark harness as TBD

### DIFF
--- a/samples/subsys/usb/webusb/sample.yaml
+++ b/samples/subsys/usb/webusb/sample.yaml
@@ -5,3 +5,4 @@ tests:
     depends_on: usb_device
     tags: usb
     platform_exclude: native_posix native_posix_64
+    harness: TBD


### PR DESCRIPTION
Mark harness as TBD as we haven't defined how to test/validate this
sample on real hardware.  As such marking it 'harness: TBD' will get it
skipped from being attempted to run on hardware via --device-testing

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>