### PR TITLE
Misc static analysis fixups

### DIFF
--- a/tests/kernel/common/src/sflist.c
+++ b/tests/kernel/common/src/sflist.c
@@ -404,7 +404,7 @@ void test_sflist(void)
 		sys_sfnode_flags_set(node, 3 - ii);
 		sys_sflist_append(&test_list, node);
 	}
-	for (ii = 3; ii <= 0; ii--) {
+	for (ii = 3; ii >= 0; ii--) {
 		node = sys_sflist_get(&test_list);
 		zassert_equal(sys_sfnode_flags_get(node), ii,
 			      "wrong flags value");

--- a/tests/kernel/fp_sharing/float_disable/src/k_float_disable.c
+++ b/tests/kernel/fp_sharing/float_disable/src/k_float_disable.c
@@ -139,7 +139,10 @@ void test_k_float_disable_syscall(void)
 		"usr_fp_thread FP options not clear (0x%0x)",
 		usr_fp_thread.base.user_options);
 
-	zassert_true(ret == TC_PASS, "");
+	/* ret is volatile, static analysis says we can't use in assert */
+	bool ok = ret == TC_PASS;
+
+	zassert_true(ok, "");
 #else
 	/* Check skipped for x86 without support for Lazy FP Sharing */
 #endif
@@ -237,7 +240,10 @@ void test_k_float_disable_irq(void)
 	/* Yield will swap-in sup_fp_thread */
 	k_yield();
 
-	zassert_true(ret == TC_PASS, "");
+	/* ret is volatile, static analysis says we can't use in assert */
+	bool ok = ret == TC_PASS;
+
+	zassert_true(ok, "");
 }
 #else
 void test_k_float_disable_irq(void)


### PR DESCRIPTION
One volatile-reads-are-side-effect irrelevancy, one actual bug in the sflist test.