### PR TITLE
kernel: ignore z_fatal_halt() from code coverage

### DIFF
--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -86,10 +86,13 @@ void z_fatal_print(const char *fmt, ...)
 }
 #endif /* CONFIG_LOG || CONFIG_PRINTK */
 
+/* LCOV_EXCL_START */
 FUNC_NORETURN void k_fatal_halt(unsigned int reason)
 {
 	z_arch_system_halt(reason);
 }
+/* LCOV_EXCL_STOP */
+
 
 void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 {


### PR DESCRIPTION
The reason we decide to ignore it in code coverage:
1.No test case can cover the function for code coverage.
2.Even if we added a test for testing, it would be marked as
  "never be called by other code" because the function cause
  CPU halted and it can't return.

Signed-off-by: Peng Su <peng.su@intel.com>