### PR TITLE
Bluetooth: controller: split: Fix Tx FIFO, queue, and pool corruption

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -746,7 +746,10 @@ static int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 				memq_dequeue(lll->memq_tx.tail,
 					     &lll->memq_tx.head, NULL);
 
-				link->next = tx->next;
+				/* TX node UPSTREAM, i.e. Tx node ack path */
+				link->next = tx->next; /* Indicates ctrl or data
+							* pool.
+							*/
 				tx->next = link;
 
 				*tx_release = tx;

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1227,11 +1227,11 @@ static inline void *done_release(memq_link_t *link,
 {
 	u8_t idx;
 
-	done->hdr.link = link;
-
 	if (!MFIFO_ENQUEUE_IDX_GET(done, &idx)) {
 		return NULL;
 	}
+
+	done->hdr.link = link;
 
 	MFIFO_BY_IDX_ENQUEUE(done, idx, done);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1155,8 +1155,17 @@ static void disabled_cb(void *param)
 
 static inline void conn_release(struct ll_adv_set *adv)
 {
-	ll_conn_release(adv->lll.conn->hdr.parent);
+	struct lll_conn *lll = adv->lll.conn;
+	memq_link_t *link;
+
+	LL_ASSERT(!lll->link_tx_free);
+	link = memq_deinit(&lll->memq_tx.head, &lll->memq_tx.tail);
+	LL_ASSERT(link);
+	lll->link_tx_free = link;
+
+	ll_conn_release(lll->hdr.parent);
 	adv->lll.conn = NULL;
+
 	ll_rx_release(adv->node_rx_cc_free);
 	adv->node_rx_cc_free = NULL;
 	ll_rx_link_release(adv->link_cc_free);


### PR DESCRIPTION
Fix the Tx FIFO, queue and pool corruption due to missing
release of link object to Tx link pool and hence missing
reset of the per connection initially allocated Tx link
free pointer.

The bug caused Tx PDUs and associated memory to be lost
leading to missing L2CAP segment transmissions. With lost
control PDU buffers, ULL would stall processing Done events
also leading to controller asserts.

Fixes #18546.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>