### PR TITLE
usb: cdc_acm: fix suspend handling in CDC ACM class

### DIFF
--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -20,7 +20,7 @@
 #include <sys/ring_buffer.h>
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(cdc_acm_echo, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(cdc_acm_echo, LOG_LEVEL_INF);
 
 #define RING_BUF_SIZE 1024
 u8_t ring_buffer[RING_BUF_SIZE];
@@ -83,16 +83,19 @@ void main(void)
 
 	ring_buf_init(&ringbuf, sizeof(ring_buffer), ring_buffer);
 
-	LOG_DBG("Wait for DTR");
+	LOG_INF("Wait for DTR");
 
 	while (true) {
 		uart_line_ctrl_get(dev, LINE_CTRL_DTR, &dtr);
 		if (dtr) {
 			break;
+		} else {
+			/* Give CPU resources to low priority threads. */
+			k_sleep(100);
 		}
 	}
 
-	LOG_DBG("DTR set");
+	LOG_INF("DTR set");
 
 	/* They are optional, we use them to test the interrupt endpoint */
 	ret = uart_line_ctrl_set(dev, LINE_CTRL_DCD, 1);

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -408,17 +408,18 @@ static void cdc_acm_do_cb(struct cdc_acm_dev_data_t *dev_data,
 		dev_data->tx_ready = true;
 		dev_data->tx_irq_ena = true;
 		dev_data->rx_irq_ena = true;
-		LOG_DBG("USB device configured");
+		LOG_INF("USB device configured");
 		break;
 	case USB_DC_DISCONNECTED:
-		LOG_DBG("USB device disconnected");
+		LOG_INF("USB device disconnected");
 		cdc_acm_reset_port(dev_data);
 		break;
 	case USB_DC_SUSPEND:
-		LOG_DBG("USB device suspended");
+		LOG_INF("USB device suspended");
 		break;
 	case USB_DC_RESUME:
-		LOG_DBG("USB device resumed");
+		dev_data->usb_status = USB_DC_CONFIGURED;
+		LOG_INF("USB device resumed");
 		break;
 	case USB_DC_SOF:
 		break;
@@ -548,6 +549,7 @@ static int cdc_acm_fifo_fill(struct device *dev,
 		dev_data, len, ring_buf_space_get(dev_data->tx_ringbuf));
 
 	if (dev_data->usb_status != USB_DC_CONFIGURED) {
+		LOG_WRN("Device not configured, drop %d bytes", len);
 		return 0;
 	}
 


### PR DESCRIPTION
usb: cdc_acm: update state after RESUME event 
Update state after RESUME event.
Use LOG_INF for important events and log a
warning if the data is discarded.
Fixes #17488

samples: cdc_acm: rework sample logging 
Use  LOG_LEVEL_INF as defautl log level and use LOG_INF
for important messages. Relax while loop and
give CPU resources to low priority threads like logging.