### PR TITLE
Bluetooth: controller: Fix Enc setup reset on rejection

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -2254,6 +2254,7 @@ isr_rx_conn_pkt_ctrl_rej(struct radio_pdu_node_rx *node_rx, u8_t *rx_enqueue)
 			_radio.conn_curr->pause_tx = 0U;
 
 			/* Procedure complete */
+			_radio.conn_curr->llcp_ack = _radio.conn_curr->llcp_req;
 			_radio.conn_curr->procedure_expire = 0U;
 
 			/* enqueue as if it were a reject ind */
@@ -2863,6 +2864,7 @@ isr_rx_conn_pkt_ctrl(struct radio_pdu_node_rx *node_rx,
 		_radio.conn_curr->pause_tx = 0U;
 
 		/* Procedure complete */
+		_radio.conn_curr->llcp_ack = _radio.conn_curr->llcp_req;
 		_radio.conn_curr->procedure_expire = 0U;
 
 		/* enqueue the reject ind */


### PR DESCRIPTION
Fix reset of Encryption Procedure state on reception of
REJECT_IND and REJECT_EXT_IND.

This is a regression in commit 79cb61577045 ("Bluetooth:
controller: split: Port Enc setup to be queueable")

Relates to #18578.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>