### PR TITLE
DTS: generate initializers for phandle-arrays and their elements

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -476,29 +476,43 @@ def write_phandle_val_list(dev, entries, ident):
     #
     # entries:
     #   List of entries (two for 'pwms' above). This might be a list of
-    #   edtlib.PWM instances, for example.
+    #   edtlib.PWM instances, for example.  If only one entry is given it
+    #   does not have a suffix '_0', and the '_COUNT' and group initializer
+    #   are not emitted.
     #
     # ident:
     #   Base identifier. For example, "PWM" generates output like this:
     #
     #     #define <device prefix>_PWMS_CONTROLLER_0 "PWM_0"  (name taken from 'label = ...')
     #     #define <device prefix>_PWMS_CHANNEL_0 123         (name taken from #cells in binding)
+    #     #define <device prefix>_PWMS_0 {"PWM_0", 123}
     #     #define <device prefix>_PWMS_CONTROLLER_1 "PWM_1"
     #     #define <device prefix>_PWMS_CHANNEL_1 456
+    #     #define <device prefix>_PWMS_1 {"PWM_1", 456}
+    #     #define <device prefix>_PWMS_COUNT 2
+    #     #define <device prefix>_PWMS {<device prefix>_PWMS_0, <device prefix>_PWMS_1}
     #     ...
     #
     #   Note: Do not add an "S" to 'ident'. It's added automatically, which
     #   forces consistency.
 
+    initializer_vals = []
     for i, entry in enumerate(entries):
-        write_phandle_val_list_entry(
-            dev, entry, i if len(entries) > 1 else None, ident)
+        initializer_vals.append(write_phandle_val_list_entry(
+            dev, entry, i if len(entries) > 1 else None, ident))
+    if len(entries) > 1:
+        out_dev(dev, ident + "S_COUNT", len(initializer_vals))
+        out_dev(dev, ident + "S", "{" + ", ".join(initializer_vals) + "}")
 
 
 def write_phandle_val_list_entry(dev, entry, i, ident):
     # write_phandle_val_list() helper. We could get rid of it if it wasn't for
     # write_spi_dev(). Adds 'i' as an index to identifiers unless it's None.
+    #
+    # Returns the identifier for the macro that provides the
+    # initializer for the entire entry.
 
+    initializer_vals = []
     if entry.controller.label is not None:
         ctrl_ident = ident + "S_CONTROLLER"  # e.g. PWMS_CONTROLLER
         if entry.name:
@@ -507,6 +521,7 @@ def write_phandle_val_list_entry(dev, entry, i, ident):
         # more than one entry.
         if i is not None:
             ctrl_ident += "_{}".format(i)
+        initializer_vals.append(quote_str(entry.controller.label))
         out_dev_s(dev, ctrl_ident, entry.controller.label)
 
     for cell, val in entry.specifier.items():
@@ -518,6 +533,16 @@ def write_phandle_val_list_entry(dev, entry, i, ident):
         if i is not None:
             cell_ident += "_{}".format(i)
         out_dev(dev, cell_ident, val)
+
+    initializer_vals += entry.specifier.values()
+
+    initializer_ident = ident + "S"
+    if entry.name:
+        initializer_ident += "_" + str2ident(entry.name)
+    if i is not None:
+        initializer_ident += "_{}".format(i)
+    return out_dev(dev, initializer_ident,
+                   "{" + ", ".join(map(str, initializer_vals)) + "}")
 
 
 def write_clocks(dev):

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -569,6 +569,9 @@ def out_dev(dev, ident, val, name_alias=None):
     #   <device alias>_<name alias> (for each device alias)
     #
     # 'name_alias' is used for reg-names and the like.
+    #
+    # Returns the identifier used for the macro that provides the value
+    # for 'ident' within 'dev', e.g. DT_MFG_MODEL_CTL_GPIOS_PIN.
 
     dev_prefix = dev_ident(dev)
 
@@ -577,20 +580,24 @@ def out_dev(dev, ident, val, name_alias=None):
         aliases.append(dev_prefix + "_" + name_alias)
         aliases += [alias + "_" + name_alias for alias in dev_aliases(dev)]
 
-    out(dev_prefix + "_" + ident, val, aliases)
+    return out(dev_prefix + "_" + ident, val, aliases)
 
 
 def out_dev_s(dev, ident, s):
     # Like out_dev(), but emits 's' as a string literal
+    #
+    # Returns the generated macro name for 'ident'.
 
-    out_dev(dev, ident, quote_str(s))
+    return out_dev(dev, ident, quote_str(s))
 
 
 def out_s(ident, val):
     # Like out(), but puts quotes around 'val' and escapes any double
     # quotes and backslashes within it
+    #
+    # Returns the generated macro name for 'ident'.
 
-    out(ident, quote_str(val))
+    return out(ident, quote_str(val))
 
 
 def out(ident, val, aliases=()):
@@ -600,9 +607,12 @@ def out(ident, val, aliases=()):
     # Also writes any aliases listed in 'aliases' (an iterable). For the
     # header, these look like '#define <alias> <ident>'. For the configuration
     # file, the value is just repeated as '<alias>=<val>' for each alias.
+    #
+    # Returns the generated macro name for 'ident'.
 
     print("#define DT_{:40} {}".format(ident, val), file=header_file)
-    print("DT_{}={}".format(ident, val), file=conf_file)
+    primary_ident = "DT_{}".format(ident)
+    print("{}={}".format(primary_ident, val), file=conf_file)
 
     for alias in aliases:
         if alias != ident:
@@ -611,6 +621,8 @@ def out(ident, val, aliases=()):
             # For the configuration file, the value is just repeated for all
             # the aliases
             print("DT_{}={}".format(alias, val), file=conf_file)
+
+    return primary_ident
 
 
 def out_comment(s, blank_before=True):

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -581,18 +581,16 @@ def out_dev(dev, ident, val, name_alias=None):
 
 
 def out_dev_s(dev, ident, s):
-    # Like out_dev(), but puts quotes around 's' and escapes any double quotes
-    # and backslashes within it
+    # Like out_dev(), but emits 's' as a string literal
 
-    # \ must be escaped before " to avoid double escaping
-    out_dev(dev, ident, '"{}"'.format(escape(s)))
+    out_dev(dev, ident, quote_str(s))
 
 
 def out_s(ident, val):
-    # Like out(), but puts quotes around 's' and escapes any double quotes and
-    # backslashes within it
+    # Like out(), but puts quotes around 'val' and escapes any double
+    # quotes and backslashes within it
 
-    out(ident, '"{}"'.format(escape(val)))
+    out(ident, quote_str(val))
 
 
 def out(ident, val, aliases=()):
@@ -634,6 +632,13 @@ def escape(s):
 
     # \ must be escaped before " to avoid double escaping
     return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def quote_str(s):
+    # Puts quotes around 's' and escapes any double quotes and
+    # backslashes within it
+
+    return '"{}"'.format(escape(s))
 
 
 def err(s):


### PR DESCRIPTION
The primary goal of this is to extend the generated symbols for:
```
		io-channels = <&adc 1>, <&adc 2>, <&adc 4>,
			      <&adc 5>, <&adc 6>;
```
to include the added ones below:
```
 #define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_CONTROLLER_0 DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_CONTROLLER_0
 #define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_INPUT_0 1
 #define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_INPUT_0 DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_INPUT_0
+#define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_0   {"ADC_0", 1}
+#define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_0     DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_0
 #define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_CONTROLLER_1 "ADC_0"
 #define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_CONTROLLER_1 DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_CONTROLLER_1
 #define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_INPUT_1 2
 #define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_INPUT_1 DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_INPUT_1
+#define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_1   {"ADC_0", 2}
+#define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_1     DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_1
 #define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_CONTROLLER_2 "ADC_0"
 #define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_CONTROLLER_2 DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_CONTROLLER_2
 #define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_INPUT_2 4
 #define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_INPUT_2 DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_INPUT_2
+#define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_2   {"ADC_0", 4}
+#define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_2     DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_2
 #define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_CONTROLLER_3 "ADC_0"
 #define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_CONTROLLER_3 DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_CONTROLLER_3
 #define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_INPUT_3 5
 #define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_INPUT_3 DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_INPUT_3
+#define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_3   {"ADC_0", 5}
+#define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_3     DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_3
 #define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_CONTROLLER_4 "ADC_0"
 #define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_CONTROLLER_4 DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_CONTROLLER_4
 #define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_INPUT_4 6
 #define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_INPUT_4 DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_INPUT_4
+#define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_4   {"ADC_0", 6}
+#define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_4     DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_4
+#define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_COUNT 5
+#define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_COUNT DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_COUNT
+#define DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS     {DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_0, DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_1, DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_2, DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_3, DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS_4}
+#define DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS       DT_VOLTAGE_DIVIDER_ADC_BANK_IO_CHANNELS
```

so I can do:
```
struct io_channel_config_type {
	const char *name;
	unsigned int channel;
};

static struct io_channel_config_type io_channel[] =
#ifdef DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_COUNT
	DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS
#else
{
	DT_INST_0_VOLTAGE_DIVIDER_IO_CHANNELS_0
}
#endif
	;
```

There's a little refactoring to make that possible in separate commits.