### PR TITLE
sys_sem: straighten build time definition macros

### DIFF
--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -80,6 +80,7 @@
 	{
 		_k_sem_list_start = .;
 		KEEP(*("._k_sem.static.*"))
+		KEEP(*("._sys_sem.static.*"))
 		_k_sem_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 

--- a/include/sys/sem.h
+++ b/include/sys/sem.h
@@ -65,8 +65,7 @@ struct sys_sem {
  * are identical and can be treated as a k_sem in the boot initialization code
  */
 #define SYS_SEM_DEFINE(_name, _initial_count, _count_limit) \
-	Z_DECL_ALIGN(struct sys_sem) _name \
-		__in_section(_k_sem, static, _name) = { \
+	Z_STRUCT_SECTION_ITERABLE(sys_sem, _name) = { \
 		.kernel_sem = Z_SEM_INITIALIZER(_name.kernel_sem, \
 						_initial_count, _count_limit) \
 	}; \


### PR DESCRIPTION
Commit db48d3e22a80 ("sys_sem: add build time definition macros")
recently introduced SYS_SEM_DEFINE() and defined it in terms of
Z_DECL_ALIGN() and __in_section() to force the _k_sem linker section.

It is however cleaner and less obscur to use Z_STRUCT_SECTION_ITERABLE()
and list the _sys_sem linker section alongside the _k_sem one.