### PR TITLE
doc: update link from released doc to master

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -2,7 +2,7 @@
 {% block document %}
   {% if is_release %}
     <div class="wy-alert wy-alert-danger">
-      The <a href="/{{ pagename }}.html">latest development version</a>
+      The <a href="/latest/{{ pagename }}.html">latest development version</a>
       of this page may be more current than this released {{ version }} version.
     </div>
   {% endif %}


### PR DESCRIPTION
Documents generated for a tagged release have a header that mentions
that the "latest" (master branch) version of the doc may be more up to
date, but the link to the corresponding master doc is missing the
/latest/ (previously the master docs were in the root folder.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>
Fixes: #17764