### PR TITLE
include/drivers: Removing legacy leftovers in PWM header

### DIFF
--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -19,9 +19,6 @@
  * @{
  */
 
-#define PWM_ACCESS_BY_PIN	0
-#define PWM_ACCESS_ALL		1
-
 #include <errno.h>
 #include <zephyr/types.h>
 #include <stddef.h>


### PR DESCRIPTION
These 2 macros are not used anymore anywhere.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>