### PR TITLE
cmake: check sdk_version format

### DIFF
--- a/cmake/toolchain/zephyr/host-tools.cmake
+++ b/cmake/toolchain/zephyr/host-tools.cmake
@@ -35,7 +35,17 @@ string(REGEX REPLACE "-.*" "" SDK_VERSION_PRE2 ${SDK_VERSION_PRE1})
 # Strip any trailing spaces/newlines from the version string
 string(STRIP ${SDK_VERSION_PRE2} SDK_VERSION)
 string(REGEX MATCH "([0-9]*).([0-9]*)" SDK_MAJOR_MINOR ${SDK_VERSION})
-if(${REQUIRED_SDK_VER} VERSION_GREATER ${SDK_VERSION})
+
+string(REGEX MATCH "([0-9]+)\.([0-9]+)\.([0-9]+)" SDK_MAJOR_MINOR_MICRO ${SDK_VERSION})
+
+#at least 0.0.0
+if(NOT SDK_MAJOR_MINOR_MICRO)
+  message(FATAL_ERROR "sdk version: ${SDK_MAJOR_MINOR_MICRO} improper format.
+  Expected format: x.y.z
+  Check whether the Zephyr SDK was installed correctly.
+")
+
+elseif(${REQUIRED_SDK_VER} VERSION_GREATER ${SDK_VERSION})
   message(FATAL_ERROR "The SDK version you are using is too old, please update your SDK.
 You need at least SDK version ${REQUIRED_SDK_VER}.
 You have version ${SDK_VERSION} (${ZEPHYR_SDK_INSTALL_DIR}).


### PR DESCRIPTION
I encountered situation when after zephyr-sdk had been installed `west build` was unable to work despite I had done everything properly (at the firs glance)
It takes me extended amount of time to realize that sdk_version string was empty and this must had been the result of corrupted installation (I probably must had missed a message about failure).

The version should had 0.0.0 format.
Patch add check for this and descriptive failure message.

Objective is to help the user to recognize the installation failure.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>