### PR TITLE
tests: arm_zero_latency_irqs: Allow for platform specified IRQ

### DIFF
--- a/tests/arch/arm/arm_zero_latency_irqs/Kconfig
+++ b/tests/arch/arm/arm_zero_latency_irqs/Kconfig
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+config TEST_IRQ_NUM_SPECIFIED
+	bool
+	default y if SOC_SERIES_CC32XX
+
+config TEST_IRQ_NUM
+	int
+	depends on TEST_IRQ_NUM_SPECIFIED
+	default 163 if SOC_SERIES_CC32XX # Pick the Camera IRQ
+	help
+	  Allow for a board/SoC specific IRQ to be selected if the logic
+	  in the code to auto determine and IRQ doesn't work
+
+source "Kconfig.zephyr"

--- a/tests/arch/arm/arm_zero_latency_irqs/src/arm_zero_latency_irqs.c
+++ b/tests/arch/arm/arm_zero_latency_irqs/src/arm_zero_latency_irqs.c
@@ -27,6 +27,9 @@ void test_arm_zero_latency_irqs(void)
 
 	zassert_false(init_flag, "Test flag not initialized to zero\n");
 
+#ifdef CONFIG_TEST_IRQ_NUM_SPECIFIED
+	i = CONFIG_TEST_IRQ_NUM;
+#else
 	for (i = CONFIG_NUM_IRQS - 1; i >= 0; i--) {
 		if (NVIC_GetEnableIRQ(i) == 0) {
 			/*
@@ -38,6 +41,7 @@ void test_arm_zero_latency_irqs(void)
 			break;
 		}
 	}
+#endif
 
 	zassert_true(i >= 0,
 		"No available IRQ line to configure as zero-latency\n");


### PR DESCRIPTION
On the CC3220SF platform the assumption that all IRQ numbers are valid
from 0..CONFIG_NUM_IRQS isn't true.  As such when the code that tries to
find a free IRQ grabs one, it will get an IRQ number that is associated
with a non-existent IRQ.  And thus the test fails since the IRQ handler
will never got called.

To workaround this, allow platforms to specify the IRQ number to test on
if the logic for finding an IRQ isn't valid for that platform.

Fixes #18593

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>