### PR TITLE
soc: arm: ti_simplelink: Fix number of interrupt lines on CC3220SF

### DIFF
--- a/soc/arm/ti_simplelink/cc32xx/Kconfig.defconfig.cc3220sf
+++ b/soc/arm/ti_simplelink/cc32xx/Kconfig.defconfig.cc3220sf
@@ -13,7 +13,7 @@ config NUM_IRQS
 	int
 	# must be >= the highest interrupt number used
 	# This includes the NWP interrupt
-	default 179
+	default 178
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int


### PR DESCRIPTION
There are only 178 interrupt lines on CC3220SF. Hence we should not set
NUM_IRQS to a value exceeding that value. We are changing it to 178.

Fixes #18593

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>