### PR TITLE
tests: arm: zero latency irqs: fix the derivation of free NVIC line

### DIFF
--- a/tests/arch/arm/arm_zero_latency_irqs/src/arm_zero_latency_irqs.c
+++ b/tests/arch/arm/arm_zero_latency_irqs/src/arm_zero_latency_irqs.c
@@ -33,9 +33,19 @@ void test_arm_zero_latency_irqs(void)
 			 * Interrupts configured statically with IRQ_CONNECT(.)
 			 * are automatically enabled. NVIC_GetEnableIRQ()
 			 * returning false, here, implies that the IRQ line is
-			 * not enabled, thus, currently not in use by Zephyr.
+			 * either not implemented or it is not enabled, thus,
+			 * currently not in use by Zephyr.
 			 */
-			break;
+
+			/* Set the NVIC line to pending. */
+			NVIC_SetPendingIRQ(i);
+
+			if (NVIC_GetPendingIRQ(i)) {
+				/* If the NVIC line is pending, it is
+				 * guaranteed that it is implemented.
+				 */
+				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
The commit fixes the way we determine an available
NVIC IRQ line to perform the zero-latency IRQ test.
The test can now run properly on SOCs that do not
have a continous set of implemented NVIC IRQ lines.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Fixes #18593