### PR TITLE
doc: add sphinx-tabs extension

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -16,6 +16,7 @@ pyserial
 pytest
 sphinx==1.7.5
 sphinx_rtd_theme
+sphinx-tabs
 sphinxcontrib-svg2pdfconverter
 west>=0.6.0
 wheel==0.30.0


### PR DESCRIPTION
The sphinx-tabs extension provides a tabbed interface within documents
that will let us dynamically display information based on a user
selection, for example, for instruction variations based on the user's
development OS (Linux, macOS, Windows).

I'm adding this early so it can get integrated into the CI doc build
before subsequent PRs using this extension are submitted.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>