### PR TITLE
subsys: shell: Uninit shell backend if shell is uninit

### DIFF
--- a/subsys/shell/shell_rtt.c
+++ b/subsys/shell/shell_rtt.c
@@ -52,6 +52,10 @@ static int init(const struct shell_transport *transport,
 
 static int uninit(const struct shell_transport *transport)
 {
+	struct shell_rtt *sh_rtt = (struct shell_rtt *)transport->ctx;
+
+	k_timer_stop(&sh_rtt->timer);
+
 	return 0;
 }
 

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -181,6 +181,16 @@ static int init(const struct shell_transport *transport,
 
 static int uninit(const struct shell_transport *transport)
 {
+	const struct shell_uart *sh_uart = (struct shell_uart *)transport->ctx;
+
+	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN)) {
+		struct device *dev = sh_uart->ctrl_blk->dev;
+
+		uart_irq_rx_disable(dev);
+	} else {
+		k_timer_stop(sh_uart->timer);
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Currently, calling `shell_uninit` leaves the shell_backend running while it should be disabled.