### PR TITLE
Set recommended thread stack size for native posix 64-bit to 40 bytes

### DIFF
--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -14,6 +14,7 @@ config ARCH
 
 config ARCH_POSIX_RECOMMENDED_STACK_SIZE
 	int
+	default 40 if 64BIT
 	default 24
 	help
 	  In bytes, stack size for Zephyr threads meant only for the POSIX

--- a/arch/posix/include/posix_core.h
+++ b/arch/posix/include/posix_core.h
@@ -29,8 +29,12 @@ typedef struct {
 
 	/*
 	 * Note: If more elements are added to this structure, remember to
-	 * update ARCH_POSIX_RECOMMENDED_STACK_SIZE in the configuration
-	 * Currently it is 24 = 4 pointers + 2 ints = 4*4 + 2*4
+	 * update ARCH_POSIX_RECOMMENDED_STACK_SIZE in the configuration.
+	 *
+	 * Currently there are 4 pointers + 2 ints, on a 32-bit native posix
+	 * implementation this will result in 24 bytes ( 4*4 + 2*4).
+	 * For a 64-bit implementation the recommended stack size will be
+	 * 40 bytes ( 4*8 + 2*4 ).
 	 */
 } posix_thread_status_t;
 


### PR DESCRIPTION
Set the recommended thread stack size for native posix 64-bit boards to 40 bytes instead of 24 bytes to prevent thread stack overrun.