### PR TITLE
Corrected memcmp in mqtt pubsub tests

### DIFF
--- a/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
+++ b/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
@@ -120,7 +120,8 @@ void publish_handler(struct mqtt_client *const client,
 		goto error;
 	}
 
-	if (memcmp(payload, buf, evt->param.publish.message.payload.len != 0)) {
+	if (memcmp(payload, buf, evt->param.publish.message.payload.len)
+			!=  0) {
 		TC_PRINT("Invalid payload content\n");
 		goto error;
 	}


### PR DESCRIPTION
Corrected payload memcmp in function publish_handler of mqtt pusub
tests.