### PR TITLE
[Backport v1.14-branch] xtensa: fix CONFIG_NUM_IRQS if !CONFIG_*_LEVEL_INTERRUPTS

### DIFF
--- a/include/arch/xtensa/xtensa_irq.h
+++ b/include/arch/xtensa/xtensa_irq.h
@@ -16,10 +16,20 @@
 /* for _soc_irq_*() */
 #include <soc.h>
 
+#ifdef CONFIG_2ND_LEVEL_INTERRUPTS
+#ifdef CONFIG_3RD_LEVEL_INTERRUPTS
 #define CONFIG_NUM_IRQS (XCHAL_NUM_INTERRUPTS +\
 			(CONFIG_NUM_2ND_LEVEL_AGGREGATORS +\
 			CONFIG_NUM_3RD_LEVEL_AGGREGATORS) *\
 			CONFIG_MAX_IRQ_PER_AGGREGATOR)
+#else
+#define CONFIG_NUM_IRQS (XCHAL_NUM_INTERRUPTS +\
+			CONFIG_NUM_2ND_LEVEL_AGGREGATORS *\
+			CONFIG_MAX_IRQ_PER_AGGREGATOR)
+#endif
+#else
+#define CONFIG_NUM_IRQS XCHAL_NUM_INTERRUPTS
+#endif
 
 #define z_arch_irq_enable(irq)	z_soc_irq_enable(irq)
 #define z_arch_irq_disable(irq)	z_soc_irq_disable(irq)


### PR DESCRIPTION
CONFIG_NUM_IRQS blindly assumes CONFIG_2ND_LEVEL_INTERRUPTS
and CONFIG_3RD_LEVEL_INTERRUPTS are always enabled together,
which is not always the case. So fix the #define.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>