### PR TITLE
bluetooth: host: Bug fix in bt_uuid_create

### DIFF
--- a/include/bluetooth/uuid.h
+++ b/include/bluetooth/uuid.h
@@ -465,37 +465,23 @@ struct bt_uuid_128 {
  */
 int bt_uuid_cmp(const struct bt_uuid *u1, const struct bt_uuid *u2);
 
-/** @brief Copy UUID from packet data (LE) to internal bt_uuid.
- *
- *  Copy UUID from packet data in little endian format to internal bt_uuid
- *  format. The data_len parameter is used to determine whether the received
- *  UUID is of 16 or 128 bit format (length 2 or 16). 32 bit format is not
- *  allowed over the air.
- *
- *  @param uuid Pointer to where to write the Bluetooth UUID
- *  @param data pointer to location of the UUID in the packet
- *  @param data_len length of the UUID in the packet
- *
- *  @return true if the data was valid and the UUID was successfully created.
- */
-bool bt_uuid_create_le(struct bt_uuid *uuid, const u8_t *data, u8_t data_len);
-
 /** @brief Copy UUID from internal variable to internal bt_uuid.
  *
- *  Copy UUID from internal variable pointer to internal bt_uuid format.
- *  The data parameter points to a variable (originally stored in bt_uuid_128,
- *  bt_uuid_32 or bt_uuid_16 format) and therefore take into account of
- *  alignment of the val member.
+ *  Copy little endian format UUID from packet data or internal variable
+ *  pointer to internal bt_uuid format.The data parameter points to a variable
+ *  (originally stored in bt_uuid_128, bt_uuid_32 or bt_uuid_16 format)
+ *  and therefore take into account of alignment of the val member.
  *  The data_len parameter is used to determine whether to copy the UUID from
  *  16, 32 or 128 bit format (length 2, 4 or 16).
+ *  32 bit format is not allowed over the air.
  *
  *  @param uuid Pointer to where to write the Bluetooth UUID
- *  @param data pointer to location of the UUID variable
- *  @param data_len length of the UUID in the packet
+ *  @param data pointer to location of the UUID variable/in the packet
+ *  @param data_len length of the UUID variable/in the packet
  *
  *  @return true if the data was valid and the UUID was successfully created.
  */
-bool bt_uuid_create(struct bt_uuid *uuid, u8_t *data, u8_t data_len);
+bool bt_uuid_create(struct bt_uuid *uuid, const u8_t *data, u8_t data_len);
 
 #if defined(CONFIG_BT_DEBUG)
 /** @brief Convert Bluetooth UUID to string.

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -615,8 +615,7 @@ static u8_t find_type_cb(const struct bt_gatt_attr *attr, void *user_data)
 		struct bt_uuid_128 ref_uuid;
 		struct bt_uuid_128 recvd_uuid;
 
-		if (!bt_uuid_create_le(&recvd_uuid.uuid, data->value,
-				       data->value_len)) {
+		if (!bt_uuid_create(&recvd_uuid.uuid, data->value, data->value_len)) {
 			BT_WARN("Unable to create UUID: size %u", data->value_len);
 			goto skip;
 		}
@@ -904,7 +903,7 @@ static u8_t att_read_type_req(struct bt_att *att, struct net_buf *buf)
 
 	start_handle = sys_le16_to_cpu(req->start_handle);
 	end_handle = sys_le16_to_cpu(req->end_handle);
-	if (!bt_uuid_create_le(&u.uuid, req->uuid, uuid_len)) {
+	if (!bt_uuid_create(&u.uuid, req->uuid, uuid_len)) {
 		return BT_ATT_ERR_UNLIKELY;
 	}
 
@@ -1211,7 +1210,7 @@ static u8_t att_read_group_req(struct bt_att *att, struct net_buf *buf)
 	start_handle = sys_le16_to_cpu(req->start_handle);
 	end_handle = sys_le16_to_cpu(req->end_handle);
 
-	if (!bt_uuid_create_le(&u.uuid, req->uuid, uuid_len)) {
+	if (!bt_uuid_create(&u.uuid, req->uuid, uuid_len)) {
 		return BT_ATT_ERR_UNLIKELY;
 	}
 

--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -80,46 +80,21 @@ int bt_uuid_cmp(const struct bt_uuid *u1, const struct bt_uuid *u2)
 	return -EINVAL;
 }
 
-bool bt_uuid_create_le(struct bt_uuid *uuid, const u8_t *data, u8_t data_len)
+bool bt_uuid_create(struct bt_uuid *uuid, const u8_t *data, u8_t data_len)
 {
-	/* Copy UUID from packet data to internal bt_uuid */
+	/* Copy UUID from packet data/internal variable to internal bt_uuid */
 	switch (data_len) {
 	case 2:
 		uuid->type = BT_UUID_TYPE_16;
 		BT_UUID_16(uuid)->val = sys_get_le16(data);
 		break;
+	case 4:
+		uuid->type = BT_UUID_TYPE_32;
+		BT_UUID_32(uuid)->val = sys_get_le32(data);
+		break;
 	case 16:
 		uuid->type = BT_UUID_TYPE_128;
 		memcpy(&BT_UUID_128(uuid)->val, data, 16);
-		break;
-	default:
-		return false;
-	}
-	return true;
-}
-
-bool bt_uuid_create(struct bt_uuid *uuid, u8_t *data, u8_t data_len)
-{
-	/* Copy UUID from internal variable to internal bt_uuid */
-	union {
-		u16_t *u16;
-		u32_t *u32;
-		u8_t *u128;
-	} v;
-
-	v.u128 = data;
-	switch (data_len) {
-	case 2:
-		uuid->type = BT_UUID_TYPE_16;
-		BT_UUID_16(uuid)->val = *v.u16;
-		break;
-	case 4:
-		uuid->type = BT_UUID_TYPE_32;
-		BT_UUID_32(uuid)->val = *v.u32;
-		break;
-	case 16:
-		uuid->type = BT_UUID_TYPE_128;
-		memcpy(&BT_UUID_128(uuid)->val, v.u128, 16);
 		break;
 	default:
 		return false;


### PR DESCRIPTION
Endianness bug fix in bt_uuid_create function.
Replaced bt_uuid_create_le with bt_uuid_create which
handles both UUID from air and internal varaiable.
Fixed bug with endianess in case of big endian targets.

Fixes #18799

Signed-off-by: Akshatha.H <akhr@oticon.com>