### PR TITLE
usb: check if the request buffer is not too small

### DIFF
--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -287,6 +287,12 @@ static void usb_handle_control_transfer(u8_t ep,
 		}
 
 		length = sys_le16_to_cpu(setup->wLength);
+		if (length > CONFIG_USB_REQUEST_BUFFER_SIZE) {
+			LOG_ERR("Request buffer too small");
+			usb_dc_ep_set_stall(USB_CONTROL_IN_EP0);
+			usb_dc_ep_set_stall(USB_CONTROL_OUT_EP0);
+			return;
+		}
 
 		usb_dev.data_buf = usb_dev.req_data;
 		usb_dev.data_buf_residue = length;


### PR DESCRIPTION
The size of the request buffer (USB_REQUEST_BUFFER_SIZE)
is configurable and depends on the needs of an application.
Check if the request buffer is not too small.

