### PR TITLE
usb: fix ZLP handling for Variable-length Data Stage

### DIFF
--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -65,6 +65,12 @@ config USB_REQUEST_BUFFER_SIZE
 	default 1024 if USB_DEVICE_LOOPBACK
 	default 128
 
+config USB_NUMOF_EP_WRITE_RETRIES
+	int "Number of endpoint write retries"
+	default 3
+	help
+	  Number of endpoint write retries.
+
 config USB_DEVICE_SOF
 	bool "Enable Start of Frame processing in events"
 

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -1049,12 +1049,13 @@ int usb_disable(void)
 
 int usb_write(u8_t ep, const u8_t *data, u32_t data_len, u32_t *bytes_ret)
 {
-	int tries = 10;
+	int tries = CONFIG_USB_NUMOF_EP_WRITE_RETRIES;
 	int ret;
 
 	do {
 		ret = usb_dc_ep_write(ep, data, data_len, bytes_ret);
 		if (ret == -EAGAIN) {
+			LOG_WRN("Failed to write endpoint buffer 0x%02x", ep);
 			k_yield();
 		}
 


### PR DESCRIPTION
ZLP flag should only be set if less data is sent
than requested by host and the length is a multiple
of wMaxPacketSize. Current implementation does not
check it correctly.

For some platforms like nRF52, this patch will not
be enough to fix the problem. The driver must be informed
about the transfer type before sending the last packet,
without changing the API it is not possible.

081c45a picked from #16274
c0abd59 picked from #17259

references: USB 2.0 spec:  5.5.3 Control Transfer Packet Size Constraints, 8.5.3.2 Variable-length Data Stage