### PR TITLE
Bluetooth: Mesh: Add prov input_complete cb

### DIFF
--- a/include/bluetooth/mesh/main.h
+++ b/include/bluetooth/mesh/main.h
@@ -128,6 +128,14 @@ struct bt_mesh_prov {
 	 */
 	int         (*input)(bt_mesh_input_action_t act, u8_t size);
 
+	/** @brief The other device finished their OOB input.
+	 *
+	 * This callback notifies the application that it should stop
+	 * displaying its output OOB value, as the other party finished their
+	 * OOB input.
+	 */
+	void 	    (*input_complete)(void);
+
 	/** @brief Provisioning link has been opened.
 	 *
 	 *  This callback notifies the application that a provisioning

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -215,6 +215,11 @@ static void prov_complete(u16_t net_idx, u16_t addr)
 	net.dst = addr;
 }
 
+static void prov_input_complete(void)
+{
+	shell_print(ctx_shell, "Input complete");
+}
+
 static void prov_reset(void)
 {
 	shell_print(ctx_shell, "The local node has been reset and needs "
@@ -357,6 +362,7 @@ static struct bt_mesh_prov prov = {
 	.input_size = 6,
 	.input_actions = (BT_MESH_ENTER_NUMBER | BT_MESH_ENTER_STRING),
 	.input = input,
+	.input_complete = prov_input_complete,
 };
 
 static int cmd_static_oob(const struct shell *shell, size_t argc, char *argv[])


### PR DESCRIPTION
Allows the user to pass a provisioning input complete callback to the
provisioning module, letting the application stop displaying its output
OOB value when the other party finishes their OOB input.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>