### PR TITLE
remove qemu's systick workaround

### DIFF
--- a/boards/arm/mps2_an385/board.cmake
+++ b/boards/arm/mps2_an385/board.cmake
@@ -8,6 +8,7 @@ set(QEMU_FLAGS_${ARCH}
   -machine mps2-an385
   -nographic
   -vga none
+  -icount auto
   )
 
 board_set_debugger_ifnset(qemu)

--- a/boards/arm/mps2_an521/board.cmake
+++ b/boards/arm/mps2_an521/board.cmake
@@ -9,6 +9,7 @@ set(QEMU_FLAGS_${ARCH}
   -nographic
   -m 16
   -vga none
+  -icount auto
   )
 
 board_set_debugger_ifnset(qemu)

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -29,8 +29,7 @@ void z_arm_exc_exit(void);
  */
 #define MIN_DELAY MAX(1024, (CYC_PER_TICK/16))
 
-#define TICKLESS (IS_ENABLED(CONFIG_TICKLESS_KERNEL) &&			\
-		  !IS_ENABLED(CONFIG_QEMU_TICKLESS_WORKAROUND))
+#define TICKLESS (IS_ENABLED(CONFIG_TICKLESS_KERNEL))
 
 /* VAL value above which we assume that a subsequent COUNTFLAG
  * overflow seen in CTRL is real and not an artifact of wraparound
@@ -126,7 +125,7 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 		return;
 	}
 
-#if defined(CONFIG_TICKLESS_KERNEL) && !defined(CONFIG_QEMU_TICKLESS_WORKAROUND)
+#if defined(CONFIG_TICKLESS_KERNEL)
 	u32_t delay;
 
 	ticks = MIN(MAX_TICKS, MAX(ticks - 1, 0));

--- a/tests/kernel/sched/schedule_api/src/main.c
+++ b/tests/kernel/sched/schedule_api/src/main.c
@@ -15,14 +15,10 @@ K_THREAD_STACK_EXTERN(ustack);
 
 void spin_for_ms(int ms)
 {
-#if (defined(CONFIG_SOC_SERIES_MPS2) || defined(CONFIG_X86_64)) \
-		&& defined(CONFIG_QEMU_TARGET)
+#if defined(CONFIG_X86_64) && defined(CONFIG_QEMU_TARGET)
 	/* qemu-system-x86_64 has a known bug with the hpet device
 	 * where it will drop interrupts if you try to spin on the
 	 * counter.
-	 *
-	 * qemu-system-arm has a similar issue of dropping interrupts
-	 * on MPS2+ targets.
 	 */
 	k_busy_wait(ms * 1000);
 #else

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -19,8 +19,17 @@ BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
 #define BUSY_MS (SLICE_SIZE + 20)
 /* a half timeslice*/
 #define HALF_SLICE_SIZE (SLICE_SIZE >> 1)
-#define HALF_SLICE_SIZE_CYCLES \
-	((u64_t)(HALF_SLICE_SIZE) * sys_clock_hw_cycles_per_sec() / 1000)
+#define HALF_SLICE_SIZE_CYCLES                                                 \
+	((u64_t)(HALF_SLICE_SIZE)*sys_clock_hw_cycles_per_sec() / 1000)
+
+/* Task switch tolerance ... */
+#if CONFIG_SYS_CLOCK_TICKS_PER_SEC >= 1000
+/* ... will not take more than 1 ms. */
+#define TASK_SWITCH_TOLERANCE (1)
+#else
+/* ... 1ms is faster than a tick, loosen tolerance to 1 tick */
+#define TASK_SWITCH_TOLERANCE (1000 / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+#endif
 
 K_SEM_DEFINE(sema, 0, NUM_THREAD);
 /*elapsed_slice taken by last thread*/
@@ -45,28 +54,31 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 
 	if (thread_idx == 0) {
 		/*
-		 * Thread number 0 releases CPU after HALF_SLICE_SIZE,
-		 * and we expect that task switch will not take more than 1 ms.
+		 * Thread number 0 releases CPU after HALF_SLICE_SIZE, and
+		 * expected to switch in less than the switching tolerance.
 		 */
-		expected_slice_min = (u64_t)(HALF_SLICE_SIZE - 1) *
-				     sys_clock_hw_cycles_per_sec() / 1000;
-		expected_slice_max = (u64_t)(HALF_SLICE_SIZE + 1) *
-				     sys_clock_hw_cycles_per_sec() / 1000;
+		expected_slice_min =
+			(u64_t)(HALF_SLICE_SIZE - TASK_SWITCH_TOLERANCE) *
+			sys_clock_hw_cycles_per_sec() / 1000;
+		expected_slice_max =
+			(u64_t)(HALF_SLICE_SIZE + TASK_SWITCH_TOLERANCE) *
+			sys_clock_hw_cycles_per_sec() / 1000;
 	} else {
 		/*
-		 * Other threads are sliced with tick granulity. Here, we
-		 * also expecting task switch time below 1 ms.
+		 * Other threads are sliced with tick granularity. Here, we
+		 * also expecting task switch below the switching tolerance.
 		 */
-		expected_slice_min = (z_ms_to_ticks(SLICE_SIZE) - 1) *
-				     sys_clock_hw_cycles_per_tick();
-		expected_slice_max = (z_ms_to_ticks(SLICE_SIZE) *
-				     sys_clock_hw_cycles_per_tick()) +
-				     (sys_clock_hw_cycles_per_sec() / 1000);
+		expected_slice_min =
+			(z_ms_to_ticks(SLICE_SIZE) - TASK_SWITCH_TOLERANCE) *
+			sys_clock_hw_cycles_per_tick();
+		expected_slice_max =
+			(z_ms_to_ticks(SLICE_SIZE) + TASK_SWITCH_TOLERANCE) *
+			sys_clock_hw_cycles_per_tick();
 	}
 
 #ifdef CONFIG_DEBUG
 	TC_PRINT("thread[%d] elapsed slice: %d, expected: <%d, %d>\n",
-		thread_idx, t, expected_slice_min, expected_slice_max);
+		 thread_idx, t, expected_slice_min, expected_slice_max);
 #endif
 
 	/** TESTPOINT: timeslice should be reset for each preemptive thread*/
@@ -123,8 +135,8 @@ void test_slice_reset(void)
 		/* create delayed threads with equal preemptive priority*/
 		for (int i = 0; i < NUM_THREAD; i++) {
 			tid[i] = k_thread_create(&t[i], tstacks[i], STACK_SIZE,
-						 thread_time_slice, NULL, NULL, NULL,
-						 K_PRIO_PREEMPT(j), 0,
+						 thread_time_slice, NULL, NULL,
+						 NULL, K_PRIO_PREEMPT(j), 0,
 						 K_NO_WAIT);
 		}
 		/* enable time slice*/


### PR DESCRIPTION
Removed workarounds in systick driver as they prevent normal usage in TICKLESS systems. 
Set qemu parameter for MPS2 targets: -icount auto.
CONFIG_SOC_SERIES_MPS2 specific test workaround is removed to use systick drives as tickless.
test_sched_timeslice_reset - loosen tolerance for slow ticking systems.

Signed-off-by: Andrei Gansari <andrei.gansari@nxp.com>