### PR TITLE
Bluetooth: Host: Fix invalid pointer in bt_smp_pkey_ready

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3271,7 +3271,7 @@ static void le_pkey_complete(struct net_buf *buf)
 	}
 
 	for (cb = pub_key_cb; cb; cb = cb->_next) {
-		cb->func(evt->status ? NULL : evt->key);
+		cb->func(evt->status ? NULL : pub_key);
 	}
 
 	pub_key_cb = NULL;


### PR DESCRIPTION
The storage for the public key is pub_key in hci_core.c.
When the public key event is generated the public key is copied into
this buffer, but the pointer to the event storage of the key is given
in the public key ready callback (bt_smp_pkey_ready).
SMP expects that it is safe to assign a global pointer to this variable.
In smp_init bt_pub_key_get is used to get the pointer to the public key.
In both cases SMP assigns the le_sc_pub_key to the pointer given.
    
This creates an issue when bt_smp_pkey_ready callback occurs after
smp_init during pairing procedure, SMP will then have a pointer to an
event buffer that has been released and contains invalid data.
    
Fixes: #18580

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>