### PR TITLE
scripts: Add "runsan" sanitycheck auxilliary runner

### DIFF
--- a/scripts/runsan/README.txt
+++ b/scripts/runsan/README.txt
@@ -1,0 +1,65 @@
+
+runsan
+======
+
+This is a highly simplified rig to run Zephyr ztest tests in a
+constrained environment where they will not have to compete with
+builds, other tests, or sanitycheck itself for host CPU resources, but
+still using maximum parallelism.  It's useful for determining if
+spurious test failures are the result of coarse host scheduling or not
+(micro-timing races will/should still be present in a setup like this,
+of course).
+
+Because it doesn't build the tests for every iteration, it's also
+useful when run in a loop for exercising as many tests as possible in
+a given amount of time.
+
+Unlike sanitycheck, it doesn't run a thread in parallel with each
+test, it simply loops watching the output to see if the test has
+finished.
+
+Usage:
+
+0. Apply the included patch to your zephyr tree.  This modifies the
+   build and test environment to produce metadata (just the list of
+   test directories and the qemu commands run).
+
+1. Run sanitycheck with the desired options to populate a
+   $ZEPHYR_BASE/sanity-out tree with built images.
+
+2. Make a temporary run directory somewhere.
+
+3. In that directory, run setup-runsan.pl.  It will populate the local
+   directory from the trees it finds in $ZEPHYR_BASE by copying the
+   relevant data (sanitycheck cleans its output every time it is run,
+   making managing big test environments like this annoying).  Note
+   that it produces a "dirlist" file with a list of local test
+   directories.  Note that this copy can be quite large currently:
+   about 18G for a full sanitycheck tree (really it should just be
+   copying out the zephyr.elf and qemu cmd files, but it grabs the
+   whole directory right now)
+
+4. Run runsan.pl with that dirlist file as input.  It will enumerate
+   at least once through each test, running N-1 tests at a time on a
+   machine with N physical cores.  Standard output contains the only
+   output of the script, and should be self-explanatory.  In each test
+   directory you will find various *.log files capturing the output
+   streams (stdout, stderr, monitor and serial) from the simulator.
+
+Limitations:
+
++ Only supports qemu targets
+
++ Only supports ztest syntax for detecting test success.  Testcases
+  defined with YAML regexes are ignored and will be reported as a
+  "timeout" failure.
+
++ Similarly doesn't support tests with "build_only: true".  If it
+  qfinds a runnable zephyr.elf, it's going to try to run it and will
+  hang if the output doesn't include ztest results.
+
++ Likewise, no support for spawning external tools required by many
+  network tests.
+
++ (Effectively: keep to tests/{kernel,posix,cmsis*}, or else be
+   prepared to hand-prune the sanity-out tree)

--- a/scripts/runsan/patch.diff
+++ b/scripts/runsan/patch.diff
@@ -1,0 +1,54 @@
+diff --git a/cmake/emu/qemu.cmake b/cmake/emu/qemu.cmake
+index 441f7f334c..763ec49355 100644
+--- a/cmake/emu/qemu.cmake
++++ b/cmake/emu/qemu.cmake
+@@ -291,4 +291,16 @@ foreach(target ${qemu_targets})
+   if(DEFINED QEMU_KERNEL_FILE)
+     add_dependencies(${target} qemu_kernel_target)
+   endif()
++
++  # Write out the qemu command to a file for later tools.  Note this
++  # doesn't bother with QEMU_KERNEL_OPTION or PRE_QEMU_COMMANDS, which
++  # are $<> variables that expand only in the generated makefiles,
++  # sigh.  That's OK, I know what's what.  There are a few other
++  # unexpanded variables (AFAICT cmake does that automatically,
++  # leaving the ${} in place if it doesn't find the variable and then
++  # translating the logic to makish or ninjese later) in there too,
++  # but we'll just deal...
++  string(REPLACE ";" " " qemu_cmd
++    "${QEMU} ${QEMU_FLAGS_${ARCH}} ${QEMU_FLAGS} ${QEMU_EXTRA_FLAGS} ${QEMU_SMP_FLAGS} ${MORE_FLAGS_FOR_${target}}")
++  file(WRITE ${CMAKE_BINARY_DIR}/qemu-cmd-${target} ${qemu_cmd})
+ endforeach()
+diff --git a/scripts/sanitycheck b/scripts/sanitycheck
+index c4c2ae7456..418a24e0fc 100755
+--- a/scripts/sanitycheck
++++ b/scripts/sanitycheck
+@@ -1351,6 +1351,11 @@ class MakeGenerator:
+         do_run = not do_build_only and not options.cmake_only
+         skip_slow = ti.test.slow and not options.enable_slow
+ 
++        if ti.platform.qemu_support:
++            global qemu_dirs
++            qemu_dirs.write(ti.outdir + "\n");
++            qemu_dirs.flush()
++
+         # FIXME: Need refactoring and cleanup
+         type = None
+         if ti.platform.qemu_support and do_run:
+@@ -3304,6 +3309,7 @@ def main():
+     global VERBOSE, INLINE_LOGS, JOBS, log_file
+     global options
+     global run_individual_tests
++    global qemu_dirs
+ 
+     # XXX: Workaround for #17239
+     resource.setrlimit(resource.RLIMIT_NOFILE, (4096, 4096))
+@@ -3363,6 +3369,8 @@ def main():
+         info("Cleaning output directory " + options.outdir)
+         shutil.rmtree(options.outdir)
+ 
++    qemu_dirs = open("qemu_dirs.txt", "w")
++        
+     if not options.testcase_root:
+         options.testcase_root = [os.path.join(ZEPHYR_BASE, "tests"),
+                               os.path.join(ZEPHYR_BASE, "samples")]

--- a/scripts/runsan/runsan.pl
+++ b/scripts/runsan/runsan.pl
@@ -1,0 +1,149 @@
+#!/usr/bin/perl
+use warnings;
+use strict;
+use List::Util;
+
+########################################################################
+# Heavily simplified test runner for Zephyr qemu tests.
+# + Only understands ztest tests (no yaml regexes)
+# + Relies on a pre-built sanitycheck directory with pre-cooked qemu
+#   commands
+# + Guarantees that no process underneath this script should contend
+#   with a qemu instance for CPU cycles.
+# + Uses minimal CPU internally (mostly polling on filesystem stat
+#   operations between 1-second sleeps) at the expense of a little
+#   latency
+
+my $TIMEOUT = 60;
+
+########################################################################
+# Pass a file containing a list of pre-built sanitycheck directories
+# on the command line.
+
+my @DIRS;
+my $dirlist = shift or die;
+open my $f, $dirlist or die;
+while(<$f>) {
+    chomp;
+    push @DIRS, $_;
+}
+close $f;
+
+########################################################################
+# Compute runnable job count.  Use one fewer than the true number (not
+# hyperthreaded count) of cores.  Should do this better so it supports
+# non-HT CPUs without cutting performance in half.
+
+my $JOBS = (`grep ^processor /proc/cpuinfo  | wc -l` / 2) - 1;
+print "JOBS $JOBS\n";
+
+########################################################################
+# Generate a qemu command line for each test
+
+my %cmds = ();
+my @tests;
+foreach my $d (@DIRS) {
+    my $cmd = `cat $d/qemu-cmd-run` or next;
+
+    # Need to clean up the command.  First unify whitespace
+    $cmd =~ s/\s+/ /gs;
+
+    # Scrub any (arbitrarily nested) unexpanded cmake variables that
+    # we find, replacing them with a "."
+    while($cmd =~ /\$\{[^{}]*\}/s) {
+	$cmd =~ s/\$\{[^{}]*\}/./gs;
+    }
+
+    # Now replace "-pidfile xx" and "-serial yy" arguments.  Also
+    # redirect the monitor to a file.
+    $cmd =~ s/ -pidfile [^ ]+//;
+    $cmd =~ s/ -serial [^ ]+//;
+    $cmd .= " -pidfile $d/qemu-pid";
+    $cmd .= " -serial file:$d/qemu-serial.out";
+    $cmd .= " -monitor file:$d/qemu-monitor.out";
+
+    # x86_64 uses a different qemu image for runtime than the linker
+    # output.  Also sanitycheck partially populates directories for
+    # skipped tests; don't include them if they didn't actually build
+    # a qemu kernel image.
+    if(-e "$d/zephyr-qemu.elf") {
+        $cmd .= " -kernel $d/zephyr-qemu.elf";
+    } elsif(-e "$d/zephyr/zephyr.elf") {
+        $cmd .= " -kernel $d/zephyr/zephyr.elf";
+    } else {
+        print "WARNING: no ELF image found for $d, skipping\n";
+        next;
+    }
+
+    push @tests, $d;
+    $cmds{$d} = $cmd;
+}
+
+########################################################################
+# Now run
+
+# Randomize order to prevent clustering on platform
+@tests = List::Util::shuffle(@tests);
+
+my %started;
+my $nrunning = 0;
+
+while(@tests > 0 || $nrunning) {
+    for my $t (keys %started) {
+	if(time() - $started{$t} > $TIMEOUT) {
+	    end_test("FAIL (timeout)", $t);
+	} else {
+	    # Check mtime on the output file, it it looks
+	    # stable/unchanging, parse it.
+	    next if ! -e "$t/qemu-serial.out";
+	    my $since_output = time() - (stat("$t/qemu-serial.out"))[9];
+	    if($since_output > 2) {
+		my $out = `cat $t/qemu-serial.out`;
+		if($out =~ /PROJECT EXECUTION (SUCCESSFUL|FAILED)/s) {
+		    end_test($1 eq "FAILED" ? "FAIL (test)" : "PASS", $t);
+		}
+	    }
+	}
+    }
+    
+    while($nrunning < $JOBS && @tests > 0) {
+	# Spawn one
+	my $t = shift @tests;
+	$started{$t} = time();
+
+        $nrunning++;
+
+        # x86_64 is SMP, which needs an extra job to handle the load.
+        # Note that this isn't 100% correct, if there's only one slot
+        # available we'll still spawn the process
+        $nrunning++ if $t =~ /qemu_x86_64/;
+
+	print "! $t\n";
+
+	for my $f (qw(serial monitor stdout stderr)) {
+	    unlink "$t/qemu-$f.out";
+	}
+	unlink "$t/qemu-pid";
+
+	# Note that we capture stdout/err separately from -serial and
+	# -monitor, becuase I still see stuff on the console that
+	# isn't part of those streams...
+	system("$cmds{$t} > $t/qemu-stdout.out 2> $t/qemu-stderr.out &");
+    }
+
+    sleep 1;
+}
+
+sub end_test {
+    my ($msg, $t) = @_;
+    if(-e "$t/qemu-pid") {
+	kill 9, (`cat $t/qemu-pid` + 0);
+    }
+    delete $started{$t};
+    $nrunning--;
+    $nrunning-- if $t =~ /qemu_x86_64/; # These take an extra job!
+
+    # FIXME: parse $t to remove directory path and split out
+    # platform/test/case
+    print "$msg $t\n";
+}

--- a/scripts/runsan/setup-runsan.pl
+++ b/scripts/runsan/setup-runsan.pl
@@ -1,0 +1,49 @@
+#!/usr/bin/perl
+use warnings;
+use strict;
+
+#
+# Copy built sanitycheck trees from $ZEPHYR_BASE to the current
+# directory and emit a directory list for use by runsan.pl
+#
+
+my $BASE = $ENV{ZEPHYR_BASE} or die "No ZEPHYR_BASE set\n";
+
+my $tlist = `find $BASE -name qemu-cmd-run`;
+
+my @tests = split /\n/, $tlist;
+
+die "Couldn't find instrumented tests in $BASE\n" if !@tests;
+
+foreach my $t (@tests) {
+    $t =~ s/\/qemu-cmd-run$//;
+}
+
+# Add multiples (i.e. duplicate test runs if needed) to saturate the
+# CPUs.  Leave one physical CPU free to ensure that routine host tasks
+# don't interfere.
+my $JOBS = (`grep ^processor /proc/cpuinfo  | wc -l` / 2) - 1;
+
+my $ntests = 0 + @tests;
+my $multiples = 1;
+while(1) {
+    my $tot = $multiples * $ntests;
+    my $waste = $tot - $JOBS * int($tot / $JOBS);
+    last if $waste / $tot < 0.05;
+    $multiples++;
+}
+
+$tlist = "";
+for my $t (@tests) {
+    my $tmp = $t;
+    $tmp =~ s/^$BASE\/sanity-out\///;
+    $tlist .= " $tmp";
+}
+
+for(my $i=1; $i<=$multiples; $i++) {
+    mkdir "$i" or die;
+    system("(cd $BASE/sanity-out; tar cf - $tlist)"
+	   . "| (cd $i; tar xf -)") == 0 or die;
+}
+
+system("find . -name qemu-cmd-run | xargs dirname > dirlist") == 0 or die;


### PR DESCRIPTION
This commit adds a proof of concept tool that runs qemu-based
sanitycheck output in a modified context where CPU load is firmly
constrained, so as to avoid qemu timing warps from host CPU load.

It's intended as a significant performance boost for "try these tests
on an unloaded system" workloads, which still exploits as much
parallelism as possible, keeps run logs in a saner way than "ninja
run", and produces easily interpreted log output on stdout.  You can
put this script in a loop overnight and come back to tens of thousands
of individiual test run results.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>