### PR TITLE
Bluetooth: Host: Fix checking for sufficient encryption key size

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -708,6 +708,9 @@ struct bt_hci_rp_read_rssi {
 	s8_t  rssi;
 } __packed;
 
+#define BT_HCI_ENCRYPTION_KEY_SIZE_MIN          7
+#define BT_HCI_ENCRYPTION_KEY_SIZE_MAX          16
+
 #define BT_HCI_OP_READ_ENCRYPTION_KEY_SIZE      BT_OP(BT_OGF_STATUS, 0x0008)
 struct bt_hci_cp_read_encryption_key_size {
 	u16_t handle;


### PR DESCRIPTION
A security vulnerability in the Bluetooth BR/EDR Bluetooth Core
specification versions 1.0 through 5.1 has been identified as
CVE-2019-9506. The Bluetooth BR/EDR encryption key negotiation
protocol is vulnerable to packet injection that could allow an
unauthenticated user to decrease the size of the entropy of the
encryption key, potentially causing information disclosure and/or
escalation of privileges via adjacent access. There is not currently
any knowledge of this being exploited.

From Core spec erratum 11838:

A device shall enforce an encryption key with at least 128-bit
equivalent strength for all services that require Security Mode 4,
Level 4. For all other services that require encryption, a device
should enforce an encryption key with at least 56-bit equivalent
strength, irrespective of whether the remote device supports Secure
Simple Pairing.
    
After encryption has been enabled, the Host should check the
encryption key size using either the HCI_Read_Encryption_Key_Size
command (see [Vol 2] Part E, Section 7.5.7) or a vendor-specific
method.

Fixes #18658

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>