### PR TITLE
ci: do not export BSIM env vars if bsim is not available

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -24,6 +24,9 @@ SANITYCHECK_OPTIONS=" --inline-logs -N"
 SANITYCHECK_OPTIONS_RETRY="${SANITYCHECK_OPTIONS} --only-failed --outdir=out-2nd-pass"
 SANITYCHECK_OPTIONS_RETRY_2="${SANITYCHECK_OPTIONS} --only-failed --outdir=out-3nd-pass"
 export BSIM_OUT_PATH="${BSIM_OUT_PATH:-/opt/bsim/}"
+if [ ! -d "${BSIM_OUT_PATH}" ]; then
+        unset BSIM_OUT_PATH
+fi
 export BSIM_COMPONENTS_PATH="${BSIM_OUT_PATH}/components/"
 BSIM_BT_TEST_RESULTS_FILE="./bsim_bt_out/bsim_results.xml"
 WEST_COMMANDS_RESULTS_FILE="./pytest_out/west_commands.xml"


### PR DESCRIPTION
When running run_ci.sh locally with:

 ./scripts/ci/run_ci.sh -l -b master -R upstream/master..

we export BSIM_OUT_PATH unconditionally which causes sanitycheck to fail
on nrf52_bsim (it depends on BSIM_OUT_PATH variable).

Check if the path defined in BSIM_OUT_PATH is available and unset env.
variable if it is not.