### PR TITLE
net: lwm2m: support NET_SOCKETS_OFFLOAD in peer parsing

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -4209,6 +4209,8 @@ int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls)
 	u16_t off, len;
 	u8_t tmp;
 
+	LOG_DBG("Parse url: %s", log_strdup(url));
+
 	http_parser_url_init(&parser);
 	ret = http_parser_parse_url(url, strlen(url), 0, &parser);
 	if (ret < 0) {
@@ -4268,6 +4270,9 @@ int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls)
 		hints.ai_family = AF_INET6;
 #elif defined(CONFIG_NET_IPV4)
 		hints.ai_family = AF_INET;
+#elif defined(CONFIG_NET_SOCKETS_OFFLOAD)
+		memset(&hints, 0, sizeof(hints));
+		hints.ai_family = AF_INET;
 #else
 		hints.ai_family = AF_UNSPEC;
 #endif /* defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_IPV4) */
@@ -4282,7 +4287,7 @@ int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls)
 
 		memcpy(addr, res->ai_addr, sizeof(*addr));
 		addr->sa_family = res->ai_family;
-		free(res);
+		freeaddrinfo(res);
 #else
 		goto cleanup;
 #endif /* CONFIG_DNS_RESOLVER */


### PR DESCRIPTION
Required when offloaded socket is used
Otherwise getaddrinfo() retuns DNS_EAI_ADDRFAMILY
Desired address family is set to AF_INET

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/18765