### PR TITLE
samples: add harness to exclude from device testing

### DIFF
--- a/samples/drivers/ht16k33/sample.yaml
+++ b/samples/drivers/ht16k33/sample.yaml
@@ -4,4 +4,5 @@ sample:
 tests:
   sample.driver.ht16k33:
     platform_whitelist: nrf52840_pca10056
+    harness: TBD
     tags: LED

--- a/samples/drivers/led_lp5562/sample.yaml
+++ b/samples/drivers/led_lp5562/sample.yaml
@@ -5,3 +5,4 @@ tests:
   sample.driver.led_lp5562:
     platform_whitelist: nrf52840_pca10056
     tags: led
+    harness: TBD


### PR DESCRIPTION
Set harness to led as a placeholder to avoid running samples on
platforms that do not have the needed hardware.