### PR TITLE
drivers: uart: Properly configure pins in NRF UARTE power management

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1205,8 +1205,14 @@ static int uarte_instance_init(struct device *dev,
 static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
+	u32_t tx_pin = nrf_uarte_tx_pin_get(uarte);
+	u32_t rx_pin = nrf_uarte_rx_pin_get(uarte);
 
 	if (new_state == DEVICE_PM_ACTIVE_STATE) {
+		nrf_gpio_pin_write(tx_pin, 1);
+		nrf_gpio_cfg_output(tx_pin);
+		nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_NOPULL);
+
 		nrf_uarte_enable(uarte);
 #ifdef CONFIG_UART_ASYNC_API
 		if (get_dev_data(dev)->async) {
@@ -1225,6 +1231,8 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 #ifdef CONFIG_UART_ASYNC_API
 		if (get_dev_data(dev)->async) {
 			nrf_uarte_disable(uarte);
+			nrf_gpio_cfg_default(tx_pin);
+			nrf_gpio_cfg_default(rx_pin);
 			return;
 		}
 #endif
@@ -1234,6 +1242,8 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 		}
 		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXTO);
 		nrf_uarte_disable(uarte);
+		nrf_gpio_cfg_default(tx_pin);
+		nrf_gpio_cfg_default(rx_pin);
 	}
 }
 


### PR DESCRIPTION
Configure pins before enabling and after disabling UARTE through
power management functions.

Signed-off-by: Mieszko Mierunski <mieszko.mierunski@nordicsemi.no>

Pins without proper prior configuration could result in undefined behaviour of UARTE at start
Fixes #16861 

