### PR TITLE
Bluetooth: Add log_strdup() to BT_ERR string arguments

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3670,7 +3670,7 @@ static int ccc_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 
 	err = bt_settings_decode_key(name, &addr);
 	if (err) {
-		BT_ERR("Unable to decode address %s", name);
+		BT_ERR("Unable to decode address %s", log_strdup(name));
 		return -EINVAL;
 	}
 
@@ -3721,7 +3721,7 @@ static int cf_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 
 	err = bt_settings_decode_key(name, &addr);
 	if (err) {
-		BT_ERR("Unable to decode address %s", name);
+		BT_ERR("Unable to decode address %s", log_strdup(name));
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Wrap string arguments to BT_ERR in log_strdup().

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@nordicsemi.no>