### PR TITLE
samples: fix signed overflow in blinky example

### DIFF
--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -8,15 +8,15 @@
 #include <device.h>
 #include <drivers/gpio.h>
 
-#define LED_PORT DT_ALIAS_LED0_GPIOS_CONTROLLER
-#define LED	DT_ALIAS_LED0_GPIOS_PIN
+#define LED_PORT	DT_ALIAS_LED0_GPIOS_CONTROLLER
+#define LED		DT_ALIAS_LED0_GPIOS_PIN
 
 /* 1000 msec = 1 sec */
-#define SLEEP_TIME 	1000
+#define SLEEP_TIME	1000
 
 void main(void)
 {
-	int cnt = 0;
+	u32_t cnt = 0;
 	struct device *dev;
 
 	dev = device_get_binding(LED_PORT);


### PR DESCRIPTION
Overflow for int is undefined in C, change to u32_t where it is defined.

Signed-off-by: Christoph Reiter <christoph.reiter@infineon.com>