### PR TITLE
samples: net: civetweb: Ignore return values

### DIFF
--- a/samples/net/sockets/civetweb/src/main.c
+++ b/samples/net/sockets/civetweb/src/main.c
@@ -171,11 +171,12 @@ int main(void)
 	pthread_attr_t civetweb_attr;
 	pthread_t civetweb_thread;
 
-	pthread_attr_init(&civetweb_attr);
-	pthread_attr_setstack(&civetweb_attr, &civetweb_stack,
-			      CIVETWEB_MAIN_THREAD_STACK_SIZE);
+	(void)pthread_attr_init(&civetweb_attr);
+	(void)pthread_attr_setstack(&civetweb_attr, &civetweb_stack,
+				    CIVETWEB_MAIN_THREAD_STACK_SIZE);
 
-	pthread_create(&civetweb_thread, &civetweb_attr, &main_pthread, 0);
+	(void)pthread_create(&civetweb_thread, &civetweb_attr,
+			     &main_pthread, 0);
 
 	return 0;
 }


### PR DESCRIPTION
We do not need the return values from various calls to pthread_*()
functions.

Coverity-CID: 203462
Coverity-CID: 203535

Fixes #18376
Fixes #18377

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>