### PR TITLE
samples: counter: Add err check on set_alarm call

### DIFF
--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -23,6 +23,7 @@ static void test_counter_interrupt_fn(struct device *counter_dev,
 	u64_t now_usec = counter_ticks_to_us(counter_dev, now_ticks);
 	int now_sec = (int)(now_usec / USEC_PER_SEC);
 	struct counter_alarm_cfg *config = user_data;
+	int err;
 
 	printk("!!! Alarm !!!\n");
 	printk("Now: %u\n", now_sec);
@@ -34,13 +35,18 @@ static void test_counter_interrupt_fn(struct device *counter_dev,
 	       (u32_t)(counter_ticks_to_us(counter_dev,
 					   config->ticks) / USEC_PER_SEC),
 	       config->ticks);
-	counter_set_channel_alarm(counter_dev, ALARM_CHANNEL_ID, user_data);
+
+	err = counter_set_channel_alarm(counter_dev, ALARM_CHANNEL_ID,
+					user_data);
+	if (err != 0) {
+		printk("Alarm could not be set\n");
+	}
 }
 
 void main(void)
 {
 	struct device *counter_dev;
-	int err = 0;
+	int err;
 
 	printk("Counter alarm sample\n\n");
 	counter_dev = device_get_binding(DT_RTC_0_NAME);


### PR DESCRIPTION
Error checking was missing following call to
counter_set_channel_alarm.
This was reported in coverity report 203523.

Fixes #18374

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>