### PR TITLE
POSIX: pthread_cond_timedwait, pthread_mutex_timedlock should use absolute deadline param

### DIFF
--- a/include/posix/pthread.h
+++ b/include/posix/pthread.h
@@ -124,7 +124,7 @@ int pthread_cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut);
  * See IEEE 1003.1
  */
 int pthread_cond_timedwait(pthread_cond_t *cv, pthread_mutex_t *mut,
-			   const struct timespec *to);
+			   const struct timespec *abstime);
 
 /**
  * @brief POSIX threading compatibility API

--- a/include/posix/pthread.h
+++ b/include/posix/pthread.h
@@ -224,7 +224,7 @@ int pthread_mutex_unlock(pthread_mutex_t *m);
  */
 
 int pthread_mutex_timedlock(pthread_mutex_t *m,
-			    const struct timespec *to);
+			    const struct timespec *abstime);
 
 /**
  * @brief POSIX threading compatibility API

--- a/lib/posix/pthread_cond.c
+++ b/lib/posix/pthread_cond.c
@@ -9,6 +9,8 @@
 #include <wait_q.h>
 #include <posix/pthread.h>
 
+s64_t timespec_to_timeoutms(const struct timespec *abstime);
+
 static int cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut, int timeout)
 {
 	__ASSERT(mut->lock_count == 1U, "");
@@ -73,8 +75,9 @@ int pthread_cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut)
 }
 
 int pthread_cond_timedwait(pthread_cond_t *cv, pthread_mutex_t *mut,
-			   const struct timespec *to)
+			   const struct timespec *abstime)
 {
-	return cond_wait(cv, mut, _ts_to_ms(to));
+	s32_t timeout = (s32_t)timespec_to_timeoutms(abstime);
+	return cond_wait(cv, mut, timeout);
 }
 

--- a/lib/posix/pthread_mutex.c
+++ b/lib/posix/pthread_mutex.c
@@ -9,6 +9,8 @@
 #include <wait_q.h>
 #include <posix/pthread.h>
 
+s64_t timespec_to_timeoutms(const struct timespec *abstime);
+
 #define MUTEX_MAX_REC_LOCK 32767
 
 /*
@@ -73,9 +75,10 @@ int pthread_mutex_trylock(pthread_mutex_t *m)
  * See IEEE 1003.1
  */
 int pthread_mutex_timedlock(pthread_mutex_t *m,
-			    const struct timespec *to)
+			    const struct timespec *abstime)
 {
-	return acquire_mutex(m, _ts_to_ms(to));
+	s32_t timeout = (s32_t)timespec_to_timeoutms(abstime);
+	return acquire_mutex(m, timeout);
 }
 
 /**


### PR DESCRIPTION
This fixes 2 POSIX Pthreads functions incorrectly treating their param as a relative timeout, instead of absolute deadline, as spotted by @jimparis in #17812, #17813.

Fixes: #17812
