### PR TITLE
libc: Make libc-nano default for ARM toolchain if newlib

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -19,6 +19,7 @@ if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "gnuarmemb"
 config NEWLIB_LIBC_NANO
 	bool "Build with newlib-nano c library"
 	depends on NEWLIB_LIBC
+	default y
 	help
 	  Build with newlib-nano library, for small embedded apps.
 	  The newlib-nano library for ARM embedded processors is a part of the


### PR DESCRIPTION
The ARM embedded toolchain has 2 newlib based libc build variants, one
that utilizes the "nano" configuration which is more in line with the
Zephyr SDK.  Make the "nano" cfg the default if newlib is enabled to
match closer how the Zephyr SDK behaves.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>