### PR TITLE
scripts: elf_helper.py: add analyze for DW_TAG_typedef

### DIFF
--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -336,6 +336,15 @@ def analyze_die_array(die):
     type_env[die.offset] = ArrayType(die.offset, elements, type_offset)
 
 
+def analyze_typedef(die):
+    type_offset = die_get_type_offset(die)
+
+    if type_offset not in type_env.keys():
+        return
+
+    type_env[die.offset] = type_env[type_offset]
+
+
 def addr_deref(elf, addr):
     for section in elf.iter_sections():
         start = section['sh_addr']
@@ -404,6 +413,8 @@ class ElfHelper:
                     analyze_die_const(die)
                 elif die.tag == "DW_TAG_array_type":
                     analyze_die_array(die)
+                elif die.tag == "DW_TAG_typedef":
+                    analyze_typedef(die)
                 elif die.tag == "DW_TAG_variable":
                     variables.append(die)
 

--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -331,9 +331,14 @@ def analyze_die_array(die):
         elements.append(ub.value + 1)
 
     if not elements:
-        return
-
-    type_env[die.offset] = ArrayType(die.offset, elements, type_offset)
+        if type_offset in type_env.keys():
+            mt = type_env[type_offset]
+            if mt.has_kobject():
+                if isinstance(mt, KobjectType) and mt.name == STACK_TYPE:
+                    elements.append(1)
+                    type_env[die.offset] = ArrayType(die.offset, elements, type_offset)
+    else:
+        type_env[die.offset] = ArrayType(die.offset, elements, type_offset)
 
 
 def analyze_typedef(die):


### PR DESCRIPTION
1) add analyze for DW_TAG_typedef in order to catch the kernel objects with typedef 
2) If a stack is declared with K_THREAD_STACK_EXTERN first, analyze array in elf_helper.py will ignore this declaration which will be referenced by the actual instances via the tag DW_AT_specification, so that this stack can't be detected by the kernel object detection mechanism, and this will cause user-space not work.
 

Fixes: #16760.