### PR TITLE
doc: remove modernizr.min.js from RTD theme

### DIFF
--- a/doc/static/js/modernizr.min.js
+++ b/doc/static/js/modernizr.min.js
@@ -1,0 +1,9 @@
+/* modernizr.min.js is causing unnecessary reloads of a page causing
+ * flashing of the browser window during page load.  This empty script
+ * effectively wipes out the modernizr.min.js unnecessarily loaded by
+ * the Sphinx rtd theme (see
+ * https://github.com/readthedocs/sphinx_rtd_theme/issues/724)
+ *
+ * Copyright (c) 2019 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */


### PR DESCRIPTION
modernizr.min.js is causing unnecessary reloads of a page causing
flashing of the browser window during page load (most noticiable with
firefox).  This empty script effectively wipes out the modernizr.min.js
unnecessarily loaded by the Sphinx rtd theme (see
https://github.com/readthedocs/sphinx_rtd_theme/issues/724)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>