### PR TITLE
xtensa: asm2: add code for double exception vector

### DIFF
--- a/arch/xtensa/core/xtensa-asm2-util.S
+++ b/arch/xtensa/core/xtensa-asm2-util.S
@@ -307,4 +307,18 @@ _KernelExceptionVector:
 	j _Level1Vector
 .popsection
 
+#ifdef XCHAL_DOUBLEEXC_VECTOR_VADDR
+.pushsection .DoubleExceptionVector.text, "ax"
+.global _DoubleExceptionVector
+_DoubleExceptionVector:
+#if XCHAL_HAVE_DEBUG
+/* Signals an unhandled double exception */
+1:	break	1, 4
+#else
+1:
+#endif
+	j	1b
+.popsection
+#endif
+
 #endif /* CONFIG_XTENSA_ASM2 */


### PR DESCRIPTION
This adds a simple infinite loop when double exception is raised.
Without this, if double exception occurs, it would execute
arbitrary code.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>