### PR TITLE
LwM2M float32/64 formatting fixes

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -497,7 +497,7 @@ static size_t put_float32fix(struct lwm2m_output_context *out,
 	size_t len;
 
 	len = put_json_prefix(out, path, "\"v\"");
-	len += plain_text_put_format(out, "%d.%d", value->val1, value->val2);
+	len += plain_text_put_float32fix(out, path, value);
 	len += put_json_postfix(out);
 	return len;
 }
@@ -509,8 +509,7 @@ static size_t put_float64fix(struct lwm2m_output_context *out,
 	size_t len;
 
 	len = put_json_prefix(out, path, "\"v\"");
-	len += plain_text_put_format(out, "%lld.%lld",
-				     value->val1, value->val2);
+	len += plain_text_put_float64fix(out, path, value);
 	len += put_json_postfix(out);
 	return len;
 }

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -121,9 +121,9 @@ static size_t put_s64(struct lwm2m_output_context *out,
 	return plain_text_put_format(out, "%lld", value);
 }
 
-static size_t put_float32fix(struct lwm2m_output_context *out,
-			     struct lwm2m_obj_path *path,
-			     float32_value_t *value)
+size_t plain_text_put_float32fix(struct lwm2m_output_context *out,
+				 struct lwm2m_obj_path *path,
+				 float32_value_t *value)
 {
 	size_t len;
 	char buf[sizeof("000000")];
@@ -146,9 +146,9 @@ static size_t put_float32fix(struct lwm2m_output_context *out,
 				     value->val1, buf);
 }
 
-static size_t put_float64fix(struct lwm2m_output_context *out,
-			     struct lwm2m_obj_path *path,
-			     float64_value_t *value)
+size_t plain_text_put_float64fix(struct lwm2m_output_context *out,
+				 struct lwm2m_obj_path *path,
+				 float64_value_t *value)
 {
 	size_t len;
 	char buf[sizeof("000000000")];
@@ -335,8 +335,8 @@ const struct lwm2m_writer plain_text_writer = {
 	.put_s32 = put_s32,
 	.put_s64 = put_s64,
 	.put_string = put_string,
-	.put_float32fix = put_float32fix,
-	.put_float64fix = put_float64fix,
+	.put_float32fix = plain_text_put_float32fix,
+	.put_float64fix = plain_text_put_float64fix,
 	.put_bool = put_bool,
 };
 

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -125,16 +125,50 @@ static size_t put_float32fix(struct lwm2m_output_context *out,
 			     struct lwm2m_obj_path *path,
 			     float32_value_t *value)
 {
-	return plain_text_put_format(out, "%d.%d",
-				     value->val1, value->val2);
+	size_t len;
+	char buf[sizeof("000000")];
+
+	/* value of 123 -> "000123" -- ignore sign */
+	len = snprintf(buf, sizeof(buf), "%06d", abs(value->val2));
+	if (len != 6U) {
+		strcpy(buf, "0");
+	} else {
+		/* clear ending zeroes, but leave 1 if needed */
+		while (len > 1U && buf[len - 1] == '0') {
+			buf[--len] = '\0';
+		}
+	}
+
+	return plain_text_put_format(out, "%s%d.%s",
+				     /* handle negative val2 when val1 is 0 */
+				     (value->val1 == 0 && value->val2 < 0) ?
+						"-" : "",
+				     value->val1, buf);
 }
 
 static size_t put_float64fix(struct lwm2m_output_context *out,
 			     struct lwm2m_obj_path *path,
 			     float64_value_t *value)
 {
-	return plain_text_put_format(out, "%lld.%lld",
-				     value->val1, value->val2);
+	size_t len;
+	char buf[sizeof("000000000")];
+
+	/* value of 123 -> "000000123" -- ignore sign */
+	len = snprintf(buf, sizeof(buf), "%09lld", abs(value->val2));
+	if (len != 9U) {
+		strcpy(buf, "0");
+	} else {
+		/* clear ending zeroes, but leave 1 if needed */
+		while (len > 1U && buf[len - 1] == '0') {
+			buf[--len] = '\0';
+		}
+	}
+
+	return plain_text_put_format(out, "%s%lld.%s",
+				     /* handle negative val2 when val1 is 0 */
+				     (value->val1 == 0 && value->val2 < 0) ?
+						"-" : "",
+				     value->val1, buf);
 }
 
 static size_t put_string(struct lwm2m_output_context *out,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.h
@@ -52,6 +52,14 @@ extern const struct lwm2m_reader plain_text_reader;
 size_t plain_text_put_format(struct lwm2m_output_context *out,
 			     const char *format, ...);
 
+size_t plain_text_put_float32fix(struct lwm2m_output_context *out,
+				 struct lwm2m_obj_path *path,
+				 float32_value_t *value);
+size_t plain_text_put_float64fix(struct lwm2m_output_context *out,
+				 struct lwm2m_obj_path *path,
+				 float64_value_t *value);
+
+
 int do_read_op_plain_text(struct lwm2m_message *msg, int content_format);
 int do_write_op_plain_text(struct lwm2m_message *msg);
 

--- a/subsys/net/lib/lwm2m/lwm2m_util.c
+++ b/subsys/net/lib/lwm2m/lwm2m_util.c
@@ -5,6 +5,7 @@
  */
 
 #include <kernel.h>
+#include <stdlib.h>
 #include "lwm2m_util.h"
 
 #define SHIFT_LEFT(v, o, m) (((v) << (o)) & (m))
@@ -26,11 +27,8 @@ int lwm2m_f32_to_b32(float32_value_t *f32, u8_t *b32, size_t len)
 		return 0;
 	}
 
-	v = f32->val1;
 	/* sign handled later */
-	if (v < 0) {
-		v = -v;
-	}
+	v = abs(f32->val1);
 
 	/* add whole value to fraction */
 	while (v > 0) {
@@ -44,11 +42,8 @@ int lwm2m_f32_to_b32(float32_value_t *f32, u8_t *b32, size_t len)
 		e++;
 	}
 
-	v = f32->val2;
 	/* sign handled later */
-	if (v < 0) {
-		v = -v;
-	}
+	v = abs(f32->val2);
 
 	/* add decimal to fraction */
 	i = e;
@@ -76,7 +71,11 @@ int lwm2m_f32_to_b32(float32_value_t *f32, u8_t *b32, size_t len)
 	memset(b32, 0, len);
 
 	/* sign: bit 31 */
-	b32[0] = f32->val1 < 0 ? 0x80 : 0;
+	if (f32->val1 == 0) {
+		b32[0] = f32->val2 < 0 ? 0x80 : 0;
+	} else {
+		b32[0] = f32->val1 < 0 ? 0x80 : 0;
+	}
 
 	/* exponent: bits 30-23 */
 	b32[0] |= e >> 1;
@@ -108,11 +107,8 @@ int lwm2m_f64_to_b64(float64_value_t *f64, u8_t *b64, size_t len)
 		return 0;
 	}
 
-	v = f64->val1;
 	/* sign handled later */
-	if (v < 0) {
-		v = -v;
-	}
+	v = abs(f64->val1);
 
 	/* add whole value to fraction */
 	while (v > 0) {
@@ -126,11 +122,8 @@ int lwm2m_f64_to_b64(float64_value_t *f64, u8_t *b64, size_t len)
 		e++;
 	}
 
-	v = f64->val2;
 	/* sign handled later */
-	if (v < 0) {
-		v = -v;
-	}
+	v = abs(f64->val2);
 
 	/* add decimal to fraction */
 	i = e;
@@ -158,7 +151,11 @@ int lwm2m_f64_to_b64(float64_value_t *f64, u8_t *b64, size_t len)
 	memset(b64, 0, len);
 
 	/* sign: bit 63 */
-	b64[0] = f64->val1 < 0 ? 0x80 : 0;
+	if (f64->val1 == 0) {
+		b64[0] = f64->val2 < 0 ? 0x80 : 0;
+	} else {
+		b64[0] = f64->val1 < 0 ? 0x80 : 0;
+	}
 
 	/* exponent: bits 62-52 */
 	b64[0] |= (e >> 4);


### PR DESCRIPTION
- Fix plain text formatting of float32/64 to handle decimal portion and val2 negative sign correctly.
- JSON now uses the same float32/64 handling as plain text
- Fix TLV float32/64 to handle negative val2 when val1 is 0.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/16154