### PR TITLE
doc: relnotes: add littlefs file system support

### DIFF
--- a/doc/releases/release-notes-2.0.rst
+++ b/doc/releases/release-notes-2.0.rst
@@ -414,6 +414,10 @@ Build and Infrastructure
 Libraries / Subsystems
 ***********************
 
+* File Systems
+
+  * Added support for littlefs
+
 * TBD
 
 HALs


### PR DESCRIPTION
Trivial change to note support for littlefs added to the File System
subsystem.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>