### PR TITLE
tests: kernel: interrupt: make test work with any available NVIC IRQ

### DIFF
--- a/tests/kernel/interrupt/src/interrupt.h
+++ b/tests/kernel/interrupt/src/interrupt.h
@@ -11,6 +11,39 @@
 
 #if defined(CONFIG_ARM)
 #include <arch/arm/cortex_m/cmsis.h>
+
+static u32_t get_available_nvic_line(u32_t initial_offset)
+{
+	int i;
+
+	for (i = initial_offset - 1; i >= 0; i--) {
+
+		if (NVIC_GetEnableIRQ(i) == 0) {
+			/*
+			 * Interrupts configured statically with IRQ_CONNECT(.)
+			 * are automatically enabled. NVIC_GetEnableIRQ()
+			 * returning false, here, implies that the IRQ line is
+			 * either not implemented or it is not enabled, thus,
+			 * currently not in use by Zephyr.
+			 */
+
+			/* Set the NVIC line to pending. */
+			NVIC_SetPendingIRQ(i);
+
+			if (NVIC_GetPendingIRQ(i)) {
+				/* If the NVIC line is pending, it is
+				 * guaranteed that it is implemented.
+				 */
+				break;
+			}
+		}
+	}
+
+	zassert_true(i >= 0, "No available IRQ line\n");
+
+	return i;
+}
+
 static void trigger_irq(int irq)
 {
 	printk("Triggering irq : %d\n", irq);

--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -1,9 +1,7 @@
 tests:
   arch.interrupt:
-    arch_exclude: nios2 riscv32 arc qemu_x86 qemu_x86_coverage qemu_x86_64
-    platform_exclude: hexiwear_kw40z frdm_kw41z frdm_kl25z nucleo_f103rb
-        nucleo_f091rc olimexino_stm32 usb_kw24d512 stm32_min_dev_blue
-        stm32_min_dev_black v2m_beetle
+    arch_exclude: nios2 riscv32 arc
+    platform_exclude: qemu_x86 qemu_x86_coverage qemu_x86_64
     tags: interrupt
 
   # Platforms without relevant (gen isr) dynamic interrupt support:


### PR DESCRIPTION
This commit re-works the test for the ARM architecture,
so that it can work with any available NVIC IRQ, not
bound to use the last 2 NVIC lines. It makes use of
the dynamic IRQ feature.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Fixes #18654