### PR TITLE
usb: mitigate the check of request buffer length and enable CONFIG_CDC_ACM_IAD by default 

### DIFF
--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -63,7 +63,7 @@ config USB_REQUEST_BUFFER_SIZE
 	range 8 65536
 	default 256 if USB_DEVICE_NETWORK_RNDIS
 	default 1024 if USB_DEVICE_LOOPBACK
-	default 64
+	default 128
 
 config USB_DEVICE_SOF
 	bool "Enable Start of Frame processing in events"

--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -48,7 +48,7 @@ config CDC_ACM_BULK_EP_MPS
 
 config CDC_ACM_IAD
 	bool "Force using Interface Association Descriptor"
-	default n
+	default y
 	help
 	  IAD should not be required for non-composite CDC ACM device,
 	  but Windows 7 fails to properly enumerate without it.

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -288,10 +288,16 @@ static void usb_handle_control_transfer(u8_t ep,
 
 		length = sys_le16_to_cpu(setup->wLength);
 		if (length > CONFIG_USB_REQUEST_BUFFER_SIZE) {
-			LOG_ERR("Request buffer too small");
-			usb_dc_ep_set_stall(USB_CONTROL_IN_EP0);
-			usb_dc_ep_set_stall(USB_CONTROL_OUT_EP0);
-			return;
+			if (REQTYPE_GET_DIR(setup->bmRequestType)
+			    == REQTYPE_DIR_TO_HOST) {
+				/* Limit wLength */
+				length = CONFIG_USB_REQUEST_BUFFER_SIZE;
+			} else {
+				LOG_ERR("Request buffer too small");
+				usb_dc_ep_set_stall(USB_CONTROL_IN_EP0);
+				usb_dc_ep_set_stall(USB_CONTROL_OUT_EP0);
+				return;
+			}
 		}
 
 		usb_dev.data_buf = usb_dev.req_data;


### PR DESCRIPTION
9ba269f580bb754ef566129eab262106c3afacac  has caused a few surprises, so a few more urgent fixes:

Mitigate the check of the request buffer length because
the host may not know the real length for some responds.

Increase the length of the request buffer.
Current value is not enough for an average
device descriptor.

Enable CONFIG_CDC_ACM_IAD by default so that
CDC ACM class works out of the box on Windows OS.

Fixes #17266