### PR TITLE
modules: Kconfig.tls-generic: Add CONFIG_MBEDTLS_ECDSA_DETERMINISTIC

### DIFF
--- a/modules/Kconfig.tls-generic
+++ b/modules/Kconfig.tls-generic
@@ -81,6 +81,9 @@ config MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 config MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
 	bool "Enable the ECDH-ECDSA based ciphersuite modes"
 
+config MBEDTLS_ECDSA_DETERMINISTIC
+	bool "Enable deterministic ECDSA (RFC 6979)"
+
 config MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
 	bool "Enable the ECDH-RSA based ciphersuite modes"
 


### PR DESCRIPTION
From mbedTLS's description:

Enable deterministic ECDSA (RFC 6979).
Standard ECDSA is "fragile" in the sense that lack of entropy when signing
may result in a compromise of the long-term signing key. This is avoided by
the deterministic variant.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>