### PR TITLE
net: conn_mgr: Check IPv4 events against command

### DIFF
--- a/subsys/net/lib/conn_mgr/events_handler.c
+++ b/subsys/net/lib/conn_mgr/events_handler.c
@@ -124,11 +124,11 @@ static void conn_mgr_ipv4_events_handler(struct net_mgmt_event_callback *cb,
 
 	NET_DBG("Iface index %u", idx);
 
-	switch (NET_MGMT_EVENT(mgmt_event)) {
-	case NET_EVENT_IPV4_ADDR_ADD:
+	switch (NET_MGMT_GET_COMMAND(mgmt_event)) {
+	case NET_EVENT_IPV4_CMD_ADDR_ADD:
 		iface_states[idx] |= NET_STATE_IPV4_ADDR_SET;
 		break;
-	case NET_EVENT_IPV4_ADDR_DEL:
+	case NET_EVENT_IPV4_CMD_ADDR_DEL:
 		if (net_if_ipv4_get_global_addr(iface, NET_ADDR_PREFERRED)) {
 			break;
 		}


### PR DESCRIPTION
Make sure we use the IPv4 event command when checking IPv4 address
add or delete instead of event mask.

Coverity-CID: 203483
Fixes #18400

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>