### PR TITLE
samples: net: sockets: Allow to build and test with POSIX subsys

### DIFF
--- a/samples/net/sockets/big_http_download/sample.yaml
+++ b/samples/net/sockets/big_http_download/sample.yaml
@@ -1,10 +1,18 @@
 sample:
   description: BSD Sockets big HTTP download example
   name: big_http_download
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
+  harness: net
+  min_ram: 32
+  min_flash: 128
+  tags: net socket
 tests:
   sample.net.sockets.big_http_download:
-    filter: TOOLCHAIN_HAS_NEWLIB == 1
-    harness: net
-    min_ram: 32
-    min_flash: 128
-    tags: net socket
+    extra_configs:
+      - CONFIG_NET_SOCKETS_POSIX_NAMES=y
+  sample.net.sockets.big_http_download.posix:
+    filter: and not CONFIG_NET_SOCKETS_OFFLOAD
+    extra_configs:
+      - CONFIG_NET_SOCKETS_POSIX_NAMES=n
+      - CONFIG_POSIX_API=y

--- a/samples/net/sockets/big_http_download/src/big_http_download.c
+++ b/samples/net/sockets/big_http_download/src/big_http_download.c
@@ -11,7 +11,7 @@
 
 #include "mbedtls/md.h"
 
-#ifndef __ZEPHYR__
+#if !defined(__ZEPHYR__) || defined(CONFIG_POSIX_API)
 
 #include <netinet/in.h>
 #include <sys/socket.h>

--- a/samples/net/sockets/dumb_http_server/sample.yaml
+++ b/samples/net/sockets/dumb_http_server/sample.yaml
@@ -1,10 +1,18 @@
 sample:
   description: BSD Sockets API dumb HTTP server example
   name: socket_dumb_http_server
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
+  harness: net
+  min_ram: 32
+  min_flash: 96
+  tags: net socket
 tests:
   sample.net.sockets.dumb_http_server:
-    filter: TOOLCHAIN_HAS_NEWLIB == 1
-    harness: net
-    min_ram: 32
-    min_flash: 96
-    tags: net socket
+    extra_configs:
+      - CONFIG_NET_SOCKETS_POSIX_NAMES=y
+  sample.net.sockets.dumb_http_server.posix:
+    filter: and not CONFIG_NET_SOCKETS_OFFLOAD
+    extra_configs:
+      - CONFIG_NET_SOCKETS_POSIX_NAMES=n
+      - CONFIG_POSIX_API=y

--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <errno.h>
 
-#ifndef __ZEPHYR__
+#if !defined(__ZEPHYR__) || defined(CONFIG_POSIX_API)
 
 #include <netinet/in.h>
 #include <sys/socket.h>

--- a/samples/net/sockets/echo_async/sample.yaml
+++ b/samples/net/sockets/echo_async/sample.yaml
@@ -2,8 +2,17 @@ sample:
   description: BSD Sockets API TCP echo server sample
     using non-blocking sockets
   name: socket_echo_async
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
+  harness: net
+  platform_whitelist: qemu_x86
+  tags: net socket
 tests:
   sample.net.sockets.echo_async:
-    harness: net
-    platform_whitelist: qemu_x86
-    tags: net socket
+    extra_configs:
+      - CONFIG_NET_SOCKETS_POSIX_NAMES=y
+  sample.net.sockets.echo_async.posix:
+    filter: and not CONFIG_NET_SOCKETS_OFFLOAD
+    extra_configs:
+      - CONFIG_NET_SOCKETS_POSIX_NAMES=n
+      - CONFIG_POSIX_API=y

--- a/samples/net/sockets/echo_async/src/socket_echo.c
+++ b/samples/net/sockets/echo_async/src/socket_echo.c
@@ -9,7 +9,7 @@
 #include <errno.h>
 #include <stdlib.h>
 
-#ifndef __ZEPHYR__
+#if !defined(__ZEPHYR__) || defined(CONFIG_POSIX_API)
 
 #include <netinet/in.h>
 #include <sys/socket.h>

--- a/samples/net/sockets/echo_async_select/src/socket_echo_select.c
+++ b/samples/net/sockets/echo_async_select/src/socket_echo_select.c
@@ -9,10 +9,11 @@
 #include <errno.h>
 #include <stdlib.h>
 
-#ifndef __ZEPHYR__
+#if !defined(__ZEPHYR__) || defined(CONFIG_POSIX_API)
 
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <sys/select.h>
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/samples/net/sockets/http_get/sample.yaml
+++ b/samples/net/sockets/http_get/sample.yaml
@@ -1,10 +1,21 @@
 sample:
   description: BSD Sockets API HTTP GET example
   name: socket_http_get
+common:
+  filter: TOOLCHAIN_HAS_NEWLIB == 1
+  harness: net
+  min_ram: 32
+  min_flash: 80
+  tags: net socket
 tests:
   sample.net.sockets.http_get:
-    filter: TOOLCHAIN_HAS_NEWLIB == 1
-    harness: net
-    min_ram: 32
-    min_flash: 80
-    tags: net socket
+    extra_configs:
+      - CONFIG_NET_SOCKETS_POSIX_NAMES=y
+    # Forcibly defines CONFIG_POSIX_API, which is incompatible with
+    # CONFIG_NET_SOCKETS_POSIX_NAMES.
+    platform_exclude: cc3220sf_launchxl
+  sample.net.sockets.http_get.posix:
+    filter: and not CONFIG_NET_SOCKETS_OFFLOAD
+    extra_configs:
+      - CONFIG_NET_SOCKETS_POSIX_NAMES=n
+      - CONFIG_POSIX_API=y

--- a/samples/net/sockets/http_get/src/http_get.c
+++ b/samples/net/sockets/http_get/src/http_get.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifndef __ZEPHYR__
+#if !defined(__ZEPHYR__) || defined(CONFIG_POSIX_API)
 
 #include <netinet/in.h>
 #include <sys/socket.h>


### PR DESCRIPTION
With CONFIG_POSIX_API enabled, these samples now build under Zephyr
with exactly the same source as e.g. Linux (or in general, other POSIX
systems). However, building without CONFIG_POSIX_API (i.e. with
CONFIG_NET_SOCKETS_POSIX_NAMES aux option) is retained for now.

Add testcase definitions to build these samples with CONFIG_POSIX_API
in CI.

Fixes: #17353

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>