### PR TITLE
cmake: Drop old deprecation warning

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -709,13 +709,6 @@ function(zephyr_check_compiler_flag lang option check)
     ZEPHYR_TOOLCHAIN_CAPABILITY_CACHE_DIR
     ${USER_CACHE_DIR}/ToolchainCapabilityDatabase
     )
-  if(DEFINED ZEPHYR_TOOLCHAIN_CAPABILITY_CACHE)
-    assert(0
-      "The deprecated ZEPHYR_TOOLCHAIN_CAPABILITY_CACHE is now a directory"
-      "and is named ZEPHYR_TOOLCHAIN_CAPABILITY_CACHE_DIR"
-      )
-    # Remove this deprecation warning in version 1.14.
-  endif()
 
   # The toolchain capability database/cache is maintained as a
   # directory of files. The filenames in the directory are keys, and


### PR DESCRIPTION
Drop the old deprecation warning about
ZEPHYR_TOOLCHAIN_CAPABILITY_CACHE. Sufficient time has passed to allow
users to migrate.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>