### PR TITLE
cmake: Cache the 'toolchain-is-ok' test as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ enable_language(C CXX ASM)
 
 # Verify that the toolchain can compile a dummy file, if it is not we
 # won't be able to test for compatibility with certain C flags.
-check_c_compiler_flag("" toolchain_is_ok)
+zephyr_check_compiler_flag(C "" toolchain_is_ok)
 assert(toolchain_is_ok "The toolchain is unable to build a dummy C file. See CMakeError.log.")
 
 # In some cases the "final" things are not used at all and "_prebuilt"


### PR DESCRIPTION
All compiler flag checks are cached for build-time performance reasons
except for the test that tests the toolchain itself.

It is believed that this test was left uncached because at the time,
there was not enough trust in the caching mechanism. But time has
shown that the caching mechanism is safe. So cache this test as well.

This improves build-time performance and also reduces noise in the
logs.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>