### PR TITLE
cmake: Explicitly set the entry point when testing toolchain flags

### DIFF
--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -126,7 +126,13 @@ endforeach()
 #
 # Appending onto any existing values lets users specify
 # toolchain-specific flags at generation time.
-list(APPEND CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags} -Wl,--unresolved-symbols=ignore-in-object-files)
+list(APPEND CMAKE_REQUIRED_FLAGS
+  -nostartfiles
+  -nostdlib
+  ${isystem_include_flags}
+  -Wl,--unresolved-symbols=ignore-in-object-files
+  -Wl,--entry=0 # Set an entry point to avoid a warning
+  )
 string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 
 # Load toolchain_cc-family macros


### PR DESCRIPTION
We are observing warnings when test-compiling toolchain flags that
look like:

cannot find entry symbol _start; defaulting to 00000000000010d4

To fix this warning we explicitly set an entry point to an arbitrary
address. The files are only compiled, not run, so the entry point does
not need to be correct.

This fixes #16880