### PR TITLE
net: lwm2m: firmware_pull: fix multiple last_block notifications

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -336,7 +336,9 @@ do_firmware_transfer_reply_cb(const struct coap_packet *response,
 				}
 
 				ret = write_cb(0, 0, 0,
-					       write_buf, len, last_block,
+					       write_buf, len,
+					       last_block &&
+							(payload_len == 0U),
 					       firmware_block_ctx.total_size);
 				if (ret < 0) {
 					goto error;


### PR DESCRIPTION
When the firmware_pull mechansim sends the callback to notify the
sample of a new firmware block, the user supplied buffer can be
smaller than the CoAP BLOCK_SIZE setting.  To handle this case,
we loop through the payload and fill the user supplied buffer with
smaller chunks.

Unfortunately, the last_block calculation is done outside this loop
which causes several callbacks (while in this loop) to have
last_block true.   Let's fix this by adding a small check to make
sure we're at the end of the current payload block before notifying
the user of a last_block.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/16158

Signed-off-by: Michael Scott <mike@foundries.io>