### PR TITLE
doc: shields: frdm_kw41z: Add shield to header

### DIFF
--- a/boards/shields/frdm_kw41z/doc/index.rst
+++ b/boards/shields/frdm_kw41z/doc/index.rst
@@ -1,7 +1,7 @@
 .. _frdm_kw41z_shield:
 
-NXP FRDM-KW41Z
-##############
+NXP FRDM-KW41Z Shield
+#####################
 
 Overview
 ********


### PR DESCRIPTION
Add 'Shield' to the header to help distinguish the FRDM-KW41Z general
board docs from the shield docs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>