### PR TITLE
doc: fix zephyr-app-commands for west

### DIFF
--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -251,27 +251,38 @@ class ZephyrAppCommandsDirective(Directive):
         if cd_into and app:
             content.append('cd {}'.format(app))
 
-        if 'build' in goals:
-            build_args = ' -b {}{}{}{}'.format(board, dst, src, cmake_args)
-            content.append('west build{}'.format(build_args))
+        # We always have to run west build.
+        #
+        # FIXME: doing this unconditionally essentially ignores the
+        # maybe-skip-config option if set.
+        #
+        # This whole script and its users from within the
+        # documentation needs to be overhauled now that we're
+        # defaulting to west.
+        #
+        # For now, this keeps the resulting commands working.
+        content.append('west build -b {}{}{}{}'.
+                       format(board, dst, src, cmake_args))
 
-        goal_args = '{}'.format(dst)
+        # If we're signing, we want to do that next, so that flashing
+        # etc. commands can use the signed file which must be created
+        # in this step.
         if 'sign' in goals:
-            content.append('west sign{}'.format(goal_args))
+            content.append('west sign{}'.format(dst))
 
         for goal in goals:
             if goal == 'build' or goal == 'sign':
                 continue
             elif goal == 'flash':
-                content.append('west flash{}'.format(goal_args))
+                content.append('west flash{}'.format(dst))
             elif goal == 'debug':
-                content.append('west debug{}'.format(goal_args))
+                content.append('west debug{}'.format(dst))
             elif goal == 'debugserver':
-                content.append('west debugserver{}'.format(goal_args))
+                content.append('west debugserver{}'.format(dst))
             elif goal == 'attach':
-                content.append('west attach{}'.format(goal_args))
+                content.append('west attach{}'.format(dst))
             else:
-                content.append('west build -t {}{}'.format(goal, goal_args))
+                content.append('west build -t {}{}'.format(goal, dst))
 
         return content
 


### PR DESCRIPTION
Always add the west build step.

Fixes: #18760

I think this script has outlived its usefulness and should probably be removed entirely now that user studies have shown people don't want to have to choose whether or not to use west in most situations.

This hotfix changes the behavior of the directive to ignore the `:maybe-skip-config:` option, changing from this:

![before](https://user-images.githubusercontent.com/35088/63895228-c0a2dc00-c9ab-11e9-8aec-bf43ab2061ae.png)

to this:

![after](https://user-images.githubusercontent.com/35088/63895246-c993ad80-c9ab-11e9-96aa-45cd29e9f638.png)

I think that's probably OK and it does fix the issue with hello world and other situations where the only goal is "run" or "flash" or whatever. But there are 450 instances of `zephyr-app-commands` in our documentation and I can't check them all today.