### PR TITLE
doc: add how to exit from QEMU in samples

### DIFF
--- a/boards/arm/qemu_cortex_m3/doc/index.rst
+++ b/boards/arm/qemu_cortex_m3/doc/index.rst
@@ -102,6 +102,8 @@ QEMU, and display the following console output:
         threadA: Hello World from arm!
         threadB: Hello World from arm!
 
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
+
 Debugging
 =========
 

--- a/boards/nios2/qemu_nios2/doc/index.rst
+++ b/boards/nios2/qemu_nios2/doc/index.rst
@@ -107,6 +107,8 @@ QEMU, and display the following console output:
         threadA: Hello World from arm!
         threadB: Hello World from arm!
 
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
+
 Debugging
 =========
 

--- a/boards/riscv/qemu_riscv32/doc/index.rst
+++ b/boards/riscv/qemu_riscv32/doc/index.rst
@@ -52,6 +52,8 @@ QEMU, and display the following console output:
         threadA: Hello World from riscv32!
         threadB: Hello World from riscv32!
 
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
+
 Debugging
 =========
 

--- a/boards/riscv/qemu_riscv64/doc/index.rst
+++ b/boards/riscv/qemu_riscv64/doc/index.rst
@@ -62,6 +62,8 @@ QEMU, and display the following console output:
         threadA: Hello World from riscv64!
         threadB: Hello World from riscv64!
 
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
+
 Debugging
 =========
 

--- a/boards/x86/qemu_x86/doc/index.rst
+++ b/boards/x86/qemu_x86/doc/index.rst
@@ -111,6 +111,8 @@ QEMU, and display the following console output:
         threadA: Hello World from x86!
         threadB: Hello World from x86!
 
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
+
 Debugging
 =========
 

--- a/boards/xtensa/qemu_xtensa/doc/index.rst
+++ b/boards/xtensa/qemu_xtensa/doc/index.rst
@@ -45,6 +45,8 @@ QEMU, and display the following console output:
         threadA: Hello World from xtensa!
         threadB: Hello World from xtensa!
 
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
+
 Debugging
 =========
 

--- a/doc/guides/networking/qemu_eth_setup.rst
+++ b/doc/guides/networking/qemu_eth_setup.rst
@@ -81,3 +81,5 @@ In terminal #2, type:
    :gen-args: -DOVERLAY_CONFIG=overlay-e1000.conf
    :goals: run
    :compact:
+
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/doc/guides/networking/qemu_setup.rst
+++ b/doc/guides/networking/qemu_setup.rst
@@ -138,6 +138,7 @@ laptop to normal Wi-Fi use.
 To stop the daemons, press Ctrl+C in the corresponding terminal windows
 (you need to stop both ``loop-slip-tap.sh`` and ``loop-socat.sh``).
 
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
 
 .. _networking_internet:
 

--- a/samples/hello_world/README.rst
+++ b/samples/hello_world/README.rst
@@ -30,3 +30,5 @@ Sample Output
 .. code-block:: console
 
     Hello World! x86
+
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/samples/net/sockets/big_http_download/README.rst
+++ b/samples/net/sockets/big_http_download/README.rst
@@ -37,7 +37,9 @@ Build the Zephyr version of the application like this:
    :compact:
 
 ``board_to_use`` defaults to ``qemu_x86``. In this case, you can run the
-application in QEMU using ``make run``. If you used another BOARD, you
+application in QEMU using ``make run``.
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
+If you used another BOARD, you
 will need to consult its documentation for application deployment
 instructions. You can read about Zephyr support for specific boards in
 the documentation at :ref:`boards`.

--- a/samples/net/sockets/echo_client/README.rst
+++ b/samples/net/sockets/echo_client/README.rst
@@ -154,6 +154,7 @@ Run echo-client application in QEMU:
 
 Note that echo-server must be running in the Linux host terminal window
 before you start the echo-client application in QEMU.
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
 
 You can verify TLS communication with a Linux host as well. See
 https://github.com/zephyrproject-rtos/net-tools documentation for information

--- a/samples/net/sockets/http_get/README.rst
+++ b/samples/net/sockets/http_get/README.rst
@@ -44,6 +44,7 @@ After the sample starts, it issues HTTP GET request to "google.com:80"
 and dumps the response. You can edit the source code to issue a request
 to any other site on the Internet (or on the local network, in which
 case no NAT/routing setup is needed).
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
 
 Enabling TLS support
 =================================

--- a/samples/philosophers/README.rst
+++ b/samples/philosophers/README.rst
@@ -62,4 +62,4 @@ Sample Output
    Philosopher 4 [C:-1]  THINKING [ 2200 ms ]
    Philosopher 5 [C:-2]  THINKING [ 1700 ms ]
 
-
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/samples/portability/cmsis_rtos_v1/philosophers/README.rst
+++ b/samples/portability/cmsis_rtos_v1/philosophers/README.rst
@@ -54,3 +54,5 @@ Sample Output
     CMSIS RTOS V1 APIs. This particular implementation demonstrates the
     usage of multiple preemptible threads of differing
     priorities, as well as semaphores and thread sleeping.
+
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/samples/portability/cmsis_rtos_v1/timer_synchronization/README.rst
+++ b/samples/portability/cmsis_rtos_v1/timer_synchronization/README.rst
@@ -64,3 +64,4 @@ Sample Output
 
     Sample execution successful
 
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/samples/portability/cmsis_rtos_v2/philosophers/README.rst
+++ b/samples/portability/cmsis_rtos_v2/philosophers/README.rst
@@ -54,3 +54,5 @@ Sample Output
     CMSIS RTOS V2 APIs. This particular implementation demonstrates the
     usage of multiple preemptible threads of differing
     priorities, as well as semaphores and thread sleeping.
+
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/samples/portability/cmsis_rtos_v2/timer_synchronization/README.rst
+++ b/samples/portability/cmsis_rtos_v2/timer_synchronization/README.rst
@@ -63,3 +63,5 @@ Sample Output
     Read from message queue: 15
 
     Sample execution successful
+
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/samples/subsys/console/getchar/README.rst
+++ b/samples/subsys/console/getchar/README.rst
@@ -39,3 +39,4 @@ The easiest way to run this sample is using QEMU:
 Now start pressing keys on a keyboard, and they will be printed both as
 hex values and in character form. Be sure to press Enter, Up/Down, etc.
 key to check what control characters are produced for them.
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/samples/subsys/console/getline/README.rst
+++ b/samples/subsys/console/getline/README.rst
@@ -40,3 +40,4 @@ Now start pressing keys on a keyboard, followed by Enter. The input line
 will be printed back, with a hex code of the last character, to show that
 line does not include any special "end of line" characters (like LF, CR,
 etc.)
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/samples/subsys/logging/logger/README.rst
+++ b/samples/subsys/logging/logger/README.rst
@@ -67,3 +67,5 @@ Sample Output
         [00:00:03.166,006] <wrn> ext_log_system: warning level log, 2 arguments: 12
         [00:00:03.166,025] <inf> ext_log_system: notice level log, 3 arguments: 105
         [00:00:03.166,044] <inf> ext_log_system: info level log, 4 arguments : 1 24
+
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/samples/synchronization/README.rst
+++ b/samples/synchronization/README.rst
@@ -42,3 +42,5 @@ Sample Output
    threadB: Hello World!
 
    <repeats endlessly>
+
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/samples/userspace/shared_mem/README.rst
+++ b/samples/userspace/shared_mem/README.rst
@@ -38,6 +38,8 @@ message is the output of the first message, and the resulting
 output is the first message without spaces.  The two messages are
 marked as 1 and 1' respectively.
 
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
+
 Two definitions can be inserted to change the wheel settings and print
 the state information.  To enable the definitions uncomment the last
 two lines in CMakelists.txt.


### PR DESCRIPTION
While trying out the hello_world sample built for QEMU, I was expecting
the sample app to exit and I'd return to a command prompt.  Nope.  You
need to exit QEMU manually, so add that step to the sample instructions.
Looking around, there are more uses of QEMU like this that could use
this added step after running the sample app.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>