### PR TITLE
sanitycheck: Merge common vs per-test "filter" field values semantically

### DIFF
--- a/samples/net/sockets/big_http_download/sample.yaml
+++ b/samples/net/sockets/big_http_download/sample.yaml
@@ -12,7 +12,7 @@ tests:
     extra_configs:
       - CONFIG_NET_SOCKETS_POSIX_NAMES=y
   sample.net.sockets.big_http_download.posix:
-    filter: and not CONFIG_NET_SOCKETS_OFFLOAD
+    filter: not CONFIG_NET_SOCKETS_OFFLOAD
     extra_configs:
       - CONFIG_NET_SOCKETS_POSIX_NAMES=n
       - CONFIG_POSIX_API=y

--- a/samples/net/sockets/dumb_http_server/sample.yaml
+++ b/samples/net/sockets/dumb_http_server/sample.yaml
@@ -12,7 +12,7 @@ tests:
     extra_configs:
       - CONFIG_NET_SOCKETS_POSIX_NAMES=y
   sample.net.sockets.dumb_http_server.posix:
-    filter: and not CONFIG_NET_SOCKETS_OFFLOAD
+    filter: not CONFIG_NET_SOCKETS_OFFLOAD
     extra_configs:
       - CONFIG_NET_SOCKETS_POSIX_NAMES=n
       - CONFIG_POSIX_API=y

--- a/samples/net/sockets/echo_async/sample.yaml
+++ b/samples/net/sockets/echo_async/sample.yaml
@@ -12,7 +12,7 @@ tests:
     extra_configs:
       - CONFIG_NET_SOCKETS_POSIX_NAMES=y
   sample.net.sockets.echo_async.posix:
-    filter: and not CONFIG_NET_SOCKETS_OFFLOAD
+    filter: not CONFIG_NET_SOCKETS_OFFLOAD
     extra_configs:
       - CONFIG_NET_SOCKETS_POSIX_NAMES=n
       - CONFIG_POSIX_API=y

--- a/samples/net/sockets/http_get/sample.yaml
+++ b/samples/net/sockets/http_get/sample.yaml
@@ -15,7 +15,7 @@ tests:
     # CONFIG_NET_SOCKETS_POSIX_NAMES.
     platform_exclude: cc3220sf_launchxl cc3235sf_launchxl
   sample.net.sockets.http_get.posix:
-    filter: and not CONFIG_NET_SOCKETS_OFFLOAD
+    filter: not CONFIG_NET_SOCKETS_OFFLOAD
     extra_configs:
       - CONFIG_NET_SOCKETS_POSIX_NAMES=n
       - CONFIG_POSIX_API=y

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1614,7 +1614,14 @@ class SanityConfigParser:
 
             if k in d:
                 if isinstance(d[k], str):
-                    d[k] += " " + v
+                    # By default, we just concatenate string values of keys
+                    # which appear both in "common" and per-test sections,
+                    # but some keys are handled in adhoc way based on their
+                    # semantics.
+                    if k == "filter":
+                        d[k] = "(%s) and (%s)" % (d[k], v)
+                    else:
+                        d[k] += " " + v
             else:
                 d[k] = v
 


### PR DESCRIPTION
Currently, string values comming from "common" test definition section
and from test-specific section are just concatenated. Suppose, we want
to define some common filter condition, and also per-test additional
criteria. Currently, that leads to following syntax:

common:
  filter: TOOLCHAIN_FOO == 1
tests:
  sample.net.sockets.http_get.posix:
    filter: and not CONFIG_BAR

That's arguable quite adhoc, and the only way to figure it out for
most people will be to add debug logging.

This patch proposes to use the expected syntax (i.e.
"filter: not CONFIG_BAR"), and combine conditions properly based on
their semantic meaning (which also includes parans for proper
evaluation order).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>