### PR TITLE
doc: relnotes: document change in toolchain newlib default

### DIFF
--- a/doc/releases/release-notes-2.0.rst
+++ b/doc/releases/release-notes-2.0.rst
@@ -409,6 +409,10 @@ Bluetooth
 Build and Infrastructure
 ************************
 
+* ARM Embedded Toolchain
+
+  * Changed ARM Embedded toolchain to default to nano variant of newlib
+
 * TBD
 
 Libraries / Subsystems


### PR DESCRIPTION
Note that the ARM Embedded Toolchain no longer uses the full version of newlib by default.

I believe this should be highlighted in the release notes since it was a last-second change that invalidated any pre-2.0 testing somebody might have done using this toolchain and `CONFIG_NEWLIB_LIBC=y`.  We should at least give anybody in this group a clue.