### PR TITLE
cmake: Suppress west module logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,7 +467,6 @@ if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
     # lazy regexes (it supports greedy only).
     string(REGEX REPLACE "\"(.*)\":\".*\"" "\\1" module_name ${module})
     string(REGEX REPLACE "\".*\":\"(.*)\"" "\\1" module_path ${module})
-    message("Including module: ${module_name} in path: ${module_path}")
     # Note the second, binary_dir parameter requires the added
     # subdirectory to have its own, local cmake target(s). If not then
     # this binary_dir is created but stays empty. Object files land in


### PR DESCRIPTION
The log from CMake invocation's are now dominated by west
modules. This noise can hide important warnings.

To fix this we drop the logging.

An example of a CMake invocation:

```
Zephyr version: 2.0.0
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.6.8", minimum required is "3.4") 
-- Selected BOARD qemu_x86
-- Found west: /home/sebo/.local/bin/west (found suitable version "0.6.0", minimum required is "0.6.0")
-- Loading /home/sebo/ncs/zephyr/boards/x86/qemu_x86/qemu_x86.dts as base
-- Overlaying /home/sebo/ncs/zephyr/dts/common/common.dts
Device tree configuration written to /home/sebo/ncs/zephyr/samples/hello_world/b/zephyr/include/generated/generated_dts_board.conf
Parsing Kconfig tree in /home/sebo/ncs/zephyr/Kconfig
Loaded configuration '/home/sebo/ncs/zephyr/boards/x86/qemu_x86/qemu_x86_defconfig'
Merged configuration '/home/sebo/ncs/zephyr/samples/hello_world/prj.conf'
Configuration saved to '/home/sebo/ncs/zephyr/samples/hello_world/b/zephyr/.config'
-- Cache files will be written to: /home/sebo/.cache/zephyr
-- The C compiler identification is GNU 8.3.0
-- The CXX compiler identification is GNU 8.3.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/sebo/zephyr-sdk-0.10.3/i586-zephyr-elf/bin/i586-zephyr-elf-gcc
Including module: atmel in path: /home/sebo/ncs/modules/hal/atmel
Including module: civetweb in path: /home/sebo/ncs/modules/lib/civetweb
Including module: esp-idf in path: /home/sebo/ncs/modules/hal/esp-idf/zephyr
Including module: fatfs in path: /home/sebo/ncs/modules/fs/fatfs
Including module: qmsi in path: /home/sebo/ncs/modules/hal/qmsi
Including module: cypress in path: /home/sebo/ncs/modules/hal/cypress
Including module: nordic in path: /home/sebo/ncs/modules/hal/nordic
Including module: openisa in path: /home/sebo/ncs/modules/hal/openisa
Including module: microchip in path: /home/sebo/ncs/modules/hal/microchip
Including module: silabs in path: /home/sebo/ncs/modules/hal/silabs
Including module: st in path: /home/sebo/ncs/modules/hal/st
Including module: stm32 in path: /home/sebo/ncs/modules/hal/stm32
Including module: ti in path: /home/sebo/ncs/modules/hal/ti
Including module: libmetal in path: /home/sebo/ncs/modules/hal/libmetal
Including module: lvgl in path: /home/sebo/ncs/modules/lib/gui/lvgl
Including module: mbedtls in path: /home/sebo/ncs/modules/crypto/mbedtls
Including module: mcumgr in path: /home/sebo/ncs/modules/lib/mcumgr
Including module: nffs in path: /home/sebo/ncs/modules/fs/nffs
Including module: nxp in path: /home/sebo/ncs/modules/hal/nxp
Including module: open-amp in path: /home/sebo/ncs/modules/lib/open-amp
Including module: openthread in path: /home/sebo/ncs/modules/lib/openthread
Including module: segger in path: /home/sebo/ncs/modules/debug/segger
Including module: tinycbor in path: /home/sebo/ncs/modules/lib/tinycbor
Including module: littlefs in path: /home/sebo/ncs/modules/fs/littlefs
-- Configuring done
-- Generating done
-- Build files have been written to: /home/sebo/ncs/zephyr/samples/hello_world/b

```