### PR TITLE
cmake: Check if match between CMAKE_BUILD_TYPE and OPTIMIZATION_FLAG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1497,6 +1497,23 @@ if(CONFIG_BOARD_DEPRECATED)
   )
 endif()
 
+# In CMake projects, 'CMAKE_BUILD_TYPE' usually determines the
+# optimization flag, but in Zephyr it is determined through
+# Kconfig. Here we give a warning when there is a mismatch between the
+# two in case the user is not aware of this.
+set(build_types None Debug Release RelWithDebInfo MinSizeRel)
+
+if((CMAKE_BUILD_TYPE IN_LIST build_types) AND (NOT NO_BUILD_TYPE_WARNING))
+  string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_uppercase)
+
+  if(NOT (${OPTIMIZATION_FLAG} IN_LIST ${CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_uppercase}}))
+    message(WARNING "
+      The CMake build type was set to '${CMAKE_BUILD_TYPE}', but the optimization flag was set to '${OPTIMIZATION_FLAG}'.
+      This may be intentional and the warning can be turned off by setting the CMake variable 'NO_BUILD_TYPE_WARNING'"
+      )
+  endif()
+endif()
+
 # @Intent: Set compiler specific flags for standard C includes
 # Done at the very end, so any other system includes which may
 # be added by Zephyr components were first in list.


### PR DESCRIPTION
In CMake projects, 'CMAKE_BUILD_TYPE' usually determines the
optimization flag, but in Zephyr it is determined through Kconfig.

To avoid confusing users we now give a warning if there is a mismatch
between the CMAKE_BUILD_TYPE and the optimization flag.

This fixes #18652