### PR TITLE
boards: shields: link_board_can: status ok->okay

### DIFF
--- a/boards/shields/link_board_can/link_board_can.overlay
+++ b/boards/shields/link_board_can/link_board_can.overlay
@@ -5,7 +5,7 @@
  */
 
 &spi1 {
-	status = "ok";
+	status = "okay";
 	cs-gpios = <&gpio1 3 0>;
 	sck-pin = <36>;
 	mosi-pin = <37>;


### PR DESCRIPTION
This file was added after the mass status 'ok'->'okay' rename. This
rectifies the situation, in particular as 'ok' is not ok anymore.

Signed-off-by: Karsten Koenig <karsten.koenig.030@gmail.com>