### PR TITLE
doc: add doc changes to release notes

### DIFF
--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -24,6 +24,7 @@ specific release and can be found at https://docs.zephyrproject.org/.
 .. toctree::
    :maxdepth: 1
 
+   release-notes-2.0
    release-notes-1.14
    release-notes-1.13
    release-notes-1.12

--- a/doc/releases/release-notes-2.0.rst
+++ b/doc/releases/release-notes-2.0.rst
@@ -389,7 +389,7 @@ Bluetooth
   * Added support for out-of-tree user-defined commands and events
   * Added support for Zephyr Vendor Specific Commands
   * Added support for user-defined protocols
-  * Converted several control procedures to be queuable
+  * Converted several control procedures to be queueable
   * Nordic: Added support for Controller-based privacy
   * Nordic: Decorrelated address generation from resolution
   * Nordic: Added support for fast encryption setup
@@ -428,7 +428,10 @@ HALs
 Documentation
 *************
 
-* TBD
+* We've made many updates to component, subsystem, and process
+  documentation bringing our documentation up-to-date with code changes,
+  additions, and improvements, as well as new supported boards and
+  samples.
 
 Tests and Samples
 *****************


### PR DESCRIPTION
Add a summary of 2.0 doc changes, and fix a misspelling.
Also, add the 2.0 release notes to the index page.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>