### PR TITLE
disk: Fix usdhc driver out-of-bounds array access

### DIFF
--- a/subsys/disk/disk_access_usdhc.c
+++ b/subsys/disk/disk_access_usdhc.c
@@ -1101,7 +1101,8 @@ static int usdhc_cmd_rsp(struct usdhc_priv *priv)
 						((cmd->response[i - 2U] &
 						0xFF000000U) >> 24U);
 				}
-			} while (i--);
+				i--;
+			} while (i);
 		}
 	}
 	/* check response error flag */


### PR DESCRIPTION
The usdhc driver was incorrectly post-decrementing a do/while loop
iterator, causing an extra iteration of the loop and an out-of-bounds
array access. Change the iterator to pre-decrement instead.

Tested samples/subsys/fs/fat_fs on the mimxrt1050_evk board.

Coverity-CID: 203403

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #18391

@JunYangNXP please review