### PR TITLE
dts: edtlib: Support giving missing properties a default value

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -89,6 +89,12 @@ sub-node:
 #     const: <string | int>
 #     default: <default>
 #
+# 'type: boolean' is for properties used as flags that don't take a value, e.g.
+# 'hw-flow-control;'. The macro generated for the property gets set to 1 if the
+# property exists on the node, and to 0 otherwise. When combined with
+# 'required: true', this type just forces the flag to appear on the node,
+# though the output will always be the same in that case (1).
+#
 # 'type: uint8-array' is for what the device tree specification calls
 # 'bytestring'. Properties of type 'uint8-array' should be set like this:
 #

--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -87,6 +87,7 @@ sub-node:
 #       ...
 #       - <itemN>
 #     const: <string | int>
+#     default: <default>
 #
 # 'type: uint8-array' is for what the device tree specification calls
 # 'bytestring'. Properties of type 'uint8-array' should be set like this:
@@ -121,6 +122,18 @@ sub-node:
 #   foo = <&label1 &label2>, <&label3 &label4>; // Okay for 'type: phandles'
 #   foo = <&label1 1 2>, <&label2 3 4>;         // Okay for 'type: phandle-array'
 #   etc.
+#
+# The optional 'default:' setting gives a value that will be used if the
+# property is missing from the device tree node. If 'default: <default>' is
+# given for a property <prop> and <prop> is missing, then the output will be as
+# if '<prop> = <default>' had appeared (except YAML data types are used for the
+# default value).
+#
+# Note that it only makes sense to combine 'default:' with 'required: false'.
+# Combining it with 'required: true' will raise an error.
+#
+# See below for examples of 'default:'. Putting 'default:' on any property type
+# besides those used in the examples will raise an error.
 properties:
     # Describes a property like 'current-speed = <115200>;'. We pretend that
     # it's obligatory for the example node and set 'required: true'.
@@ -153,6 +166,31 @@ properties:
         type: int
         required: true
         const: 1
+
+    int-with-default:
+        type: int
+        required: false
+        default: 123
+
+    array-with-default:
+        type: array
+        required: false
+        default: [1, 2, 3] # Same as 'array-with-default = <1 2 3>'
+
+    string-with-default:
+        type: string
+        required: false
+        default: "foo"
+
+    string-array-with-default:
+        type: string-array
+        required: false
+        default: ["foo", "bar"] # Same as 'string-array-with-default = "foo", "bar"'
+
+    uint8-array-with-default:
+        type: uint8-array
+        required: false
+        default: [0x12, 0x34] # Same as 'uint8-array-with-default = [12 34]'
 
 # If the binding describes an interrupt controller, GPIO controller, pinmux
 # device, or any other node referenced by other nodes, then #cells should be

--- a/scripts/dts/test-bindings/defaults.yaml
+++ b/scripts/dts/test-bindings/defaults.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+title: Property default value test
+description: Property default value test
+
+compatible: "defaults"
+
+properties:
+    int:
+        type: int
+        required: false
+        default: 123
+
+    array:
+        type: array
+        required: false
+        default: [1, 2, 3]
+
+    uint8-array:
+        type: uint8-array
+        required: false
+        default: [0x89, 0xAB, 0xCD]
+
+    string:
+        type: string
+        required: false
+        default: "hello"
+
+    string-array:
+        type: string-array
+        required: false
+        default: ["hello", "there"]
+
+    default-not-used:
+        type: int
+        required: false
+        default: 123

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -312,6 +312,16 @@
 	};
 
 	//
+	// For testing Device.props with 'default:' values in binding
+	//
+
+	defaults {
+		compatible = "defaults";
+		// Should override the 'default:' in the binding
+		default-not-used = <234>;
+	};
+
+	//
 	// Parent with 'sub-node:' in binding
 	//
 

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -123,6 +123,13 @@ def run():
                  r"{'nonexistent-boolean': <Property, name: nonexistent-boolean, type: boolean, value: False>, 'existent-boolean': <Property, name: existent-boolean, type: boolean, value: True>, 'int': <Property, name: int, type: int, value: 1>, 'array': <Property, name: array, type: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, type: uint8-array, value: b'\x124'>, 'string': <Property, name: string, type: string, value: 'foo'>, 'string-array': <Property, name: string-array, type: string-array, value: ['foo', 'bar', 'baz']>, 'phandle-ref': <Property, name: phandle-ref, type: phandle, value: <Device /props/node in 'test.dts', no binding>>, 'phandle-refs': <Property, name: phandle-refs, type: phandles, value: [<Device /props/node in 'test.dts', no binding>, <Device /props/node2 in 'test.dts', no binding>]>}")
 
     #
+    # Test property default values given in bindings
+    #
+
+    verify_streq(edt.get_dev("/defaults").props,
+                 r"{'int': <Property, name: int, type: int, value: 123>, 'array': <Property, name: array, type: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, type: uint8-array, value: b'\x89\xab\xcd'>, 'string': <Property, name: string, type: string, value: 'hello'>, 'string-array': <Property, name: string-array, type: string-array, value: ['hello', 'there']>, 'default-not-used': <Property, name: default-not-used, type: int, value: 234>}")
+
+    #
     # Test having multiple directories with bindings, with a different .dts file
     #
 


### PR DESCRIPTION
For missing optional properties, it can be handy to generate a default
value instead of no value, to cut down on #ifdefs.

Allow a default value to be specified in the binding, via a new
'default: <default value>' setting for properties in bindings.
Defaults are supported for both scalar and array types. YAML arrays are
used to specify the value for array types.

'default:' also appears in json-schema, with the same meaning.

Include misc. sanity checks, like the 'default' value matching 'type'.

The documentation changes in binding-template.yaml explain the syntax.

Suggested by Peter A. Bigot in
https://github.com/zephyrproject-rtos/zephyr/issues/17829.

Fixes: #17829