### PR TITLE
dts: scripts: Require properties to be declared in bindings

### DIFF
--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -300,9 +300,6 @@
 		phandle-ref = < &{/props/node} >;
 		phandle-refs = < &{/props/node} &{/props/node2} >;
 		phandle-refs-and-vals = < &{/props/node} 1 &{/props/node2} 2 >;
-		// Does not appear in the binding, so won't create an entry in
-		// Device.props
-		not-speced = <0>;
 
 		node {
 		};
@@ -330,7 +327,6 @@
 		node {
 			foo = <1>;
 			bar = <2>;
-			not-speced = <0>;
 		};
 	};
 


### PR DESCRIPTION
Except for a few special properties like 'interrupts' and '#size-cells',
require all devicetree properties on nodes with bindings to be declared
in the binding.

This will help catch misspellings, and makes refactoring and cleanups
safer.

Suggested by Peter A. Bigot.