### PR TITLE
drivers/serial: stm32: fix the uart_irq_tx_ready

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -511,7 +511,8 @@ static int uart_stm32_irq_tx_ready(struct device *dev)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
-	return LL_USART_IsActiveFlag_TXE(UartInstance);
+	return LL_USART_IsActiveFlag_TXE(UartInstance) &&
+		 LL_USART_IsEnabledIT_TC(UartInstance);
 }
 
 static int uart_stm32_irq_tx_complete(struct device *dev)


### PR DESCRIPTION
The TXE flag is on even then tx irq not enabled, so add check
the tx irq enable status.

Signed-off-by: Harry Jiang <explora26@gmail.com>