### PR TITLE
[TOPIC: DTS] dts: nordic,nrf-uarte: Declare hw-flow-control in binding

### DIFF
--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -15,6 +15,9 @@ properties:
     interrupts:
       required: true
 
+    hw-flow-control:
+      type: boolean
+
     tx-pin:
       type: int
       description: TX pin


### PR DESCRIPTION
Fixes an upcoming error:

    device tree error: 'hw-flow-control' appears in /soc/uart@40028000
    in nrf52840_pca10056.dts.pre.tmp, but is not declared in
    'properties:' in .../dts/bindings/serial/nordic,nrf-uarte.yaml