### PR TITLE
west.yml: update nxp_hal SHA to latest commit

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -89,7 +89,7 @@ manifest:
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs
     - name: hal_nxp
-      revision: f55f52e57de4280e38f20b8182b752ea27241645
+      revision: 5852d8f66e454f66f0a8484a9f2309f392a78026
       path: modules/hal/nxp
     - name: open-amp
       revision: 9b591b289e1f37339bd038b5a1f0e6c8ad39c63a


### PR DESCRIPTION
Commit 5852d8f from https://github.com/zephyrproject-rtos/hal_nxp
fixed the import script, but there's no corresponding update for the
west.yml configuration file. As such, if one attempts to add support
for new drivers, they'll be copied in the wrong places
(under $ZEPHYR_BASE). As such, modify the west.yml file to point to
the HEAD of the master branch of the hal_nxp repo.

Fixes: 5852d8f mcux: adjust paths in import script after moving HAL to module

Signed-off-by: Alex Porosanu <alexandru.porosanu@nxp.com>