### PR TITLE
Bluetooth: UUID: Add tests and fix documentation for bt_uuid_create

### DIFF
--- a/include/bluetooth/uuid.h
+++ b/include/bluetooth/uuid.h
@@ -465,19 +465,15 @@ struct bt_uuid_128 {
  */
 int bt_uuid_cmp(const struct bt_uuid *u1, const struct bt_uuid *u2);
 
-/** @brief Copy UUID from internal variable to internal bt_uuid.
+/** @brief Create a bt_uuid from a little-endian data buffer.
  *
- *  Copy little endian format UUID from packet data or internal variable
- *  pointer to internal bt_uuid format.The data parameter points to a variable
- *  (originally stored in bt_uuid_128, bt_uuid_32 or bt_uuid_16 format)
- *  and therefore take into account of alignment of the val member.
- *  The data_len parameter is used to determine whether to copy the UUID from
- *  16, 32 or 128 bit format (length 2, 4 or 16).
- *  32 bit format is not allowed over the air.
+ *  Create a bt_uuid from a little-endian data buffer. The data_len parameter
+ *  is used to determine whether the UUID is in 16, 32 or 128 bit format
+ *  (length 2, 4 or 16). Note: 32 bit format is not allowed over the air.
  *
- *  @param uuid Pointer to where to write the Bluetooth UUID
- *  @param data pointer to location of the UUID variable/in the packet
- *  @param data_len length of the UUID variable/in the packet
+ *  @param uuid Pointer to the bt_uuid variable
+ *  @param data pointer to UUID stored in little-endian data buffer
+ *  @param data_len length of the UUID in the data buffer
  *
  *  @return true if the data was valid and the UUID was successfully created.
  */

--- a/tests/bluetooth/uuid/src/main.c
+++ b/tests/bluetooth/uuid/src/main.c
@@ -18,6 +18,10 @@ static struct bt_uuid_128 uuid_128 = BT_UUID_INIT_128(
 	0xfb, 0x34, 0x9b, 0x5f, 0x80, 0x00, 0x00, 0x80,
 	0x00, 0x10, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00);
 
+static struct bt_uuid_128 le_128 = BT_UUID_INIT_128(
+	0xfb, 0x34, 0x9b, 0x5f, 0x80, 0x00, 0x00, 0x80,
+	0x00, 0x10, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00);
+
 static void test_uuid_cmp(void)
 {
 	/* Compare UUID 16 bits */
@@ -41,10 +45,54 @@ static void test_uuid_cmp(void)
 		     "Test UUIDs match");
 }
 
+static void test_uuid_create(void)
+{
+	u8_t le16[] = { 0x01, 0x00 };
+	u8_t be16[] = { 0x00, 0x01 };
+	union {
+		struct bt_uuid uuid;
+		struct bt_uuid_16 u16;
+		struct bt_uuid_128 u128;
+	} u;
+
+	/* Create UUID from LE 16 bit byte array */
+	zassert_true(bt_uuid_create(&u.uuid, le16, sizeof(le16)),
+		     "Unable create UUID");
+
+	/* Compare UUID 16 bits */
+	zassert_true(bt_uuid_cmp(&u.uuid, BT_UUID_DECLARE_16(0x0001)) == 0,
+		     "Test UUIDs don't match");
+
+	/* Compare UUID 128 bits */
+	zassert_true(bt_uuid_cmp(&u.uuid, &le_128.uuid) == 0,
+		     "Test UUIDs don't match");
+
+	/* Compare swapped UUID 16 bits */
+	zassert_false(bt_uuid_cmp(&u.uuid, BT_UUID_DECLARE_16(0x0100)) == 0,
+		     "Test UUIDs match");
+
+	/* Create UUID from BE 16 bit byte array */
+	zassert_true(bt_uuid_create(&u.uuid, be16, sizeof(be16)),
+		     "Unable create UUID");
+
+	/* Compare UUID 16 bits */
+	zassert_false(bt_uuid_cmp(&u.uuid, BT_UUID_DECLARE_16(0x0001)) == 0,
+		     "Test UUIDs match");
+
+	/* Compare UUID 128 bits */
+	zassert_false(bt_uuid_cmp(&u.uuid, &le_128.uuid) == 0,
+		     "Test UUIDs match");
+
+	/* Compare swapped UUID 16 bits */
+	zassert_true(bt_uuid_cmp(&u.uuid, BT_UUID_DECLARE_16(0x0100)) == 0,
+		     "Test UUIDs don't match");
+}
+
 /*test case main entry*/
 void test_main(void)
 {
 	ztest_test_suite(test_uuid,
-			 ztest_unit_test(test_uuid_cmp));
+			 ztest_unit_test(test_uuid_cmp),
+			 ztest_unit_test(test_uuid_create));
 	ztest_run_test_suite(test_uuid);
 }


### PR DESCRIPTION
Two patches to fix issues with `bt_uuid_create()`. One adds unit tests. The other fixes the documentation not to be so misleading.

Fixes #18802