### PR TITLE
modules: Kconfig.simplelink: Remove POSIX_API from being selected

### DIFF
--- a/modules/Kconfig.simplelink
+++ b/modules/Kconfig.simplelink
@@ -13,7 +13,6 @@ config SIMPLELINK_HOST_DRIVER
 	depends on MULTITHREADING
 	select NEWLIB_LIBC
 	select ERRNO
-        select POSIX_API
         select PTHREAD_IPC
 	help
 	  Build the SimpleLink host driver


### PR DESCRIPTION
PR #18780 introduces a way to decouple pthread support from the general
CONFIG_POSIX_API global switch. This commit modifies the build of
SimpleLink components to take advantage of it, since SimpleLink
libraries only require pthread (and sem) support, not entire POSIX.

This fixes the build errors in the http_get sample introduced
by the merge of #18736.

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>