### PR TITLE
doc: fix broken doc links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Here's a quick summary of resources to help you find your way around:
 * **Zephyr Project Website**: https://zephyrproject.org
 
 .. _Slack Invite: https://tinyurl.com/y5glwylp
-.. _supported boards: http://docs.zephyrproject.org/latest/boards
+.. _supported boards: http://docs.zephyrproject.org/latest/boards/index.html
 .. _Zephyr Documentation: http://docs.zephyrproject.org
 .. _Introduction to Zephyr: http://docs.zephyrproject.org/latest/introduction/index.html
 .. _Getting Started Guide: http://docs.zephyrproject.org/latest/getting_started/index.html

--- a/boards/riscv/qemu_riscv64/doc/index.rst
+++ b/boards/riscv/qemu_riscv64/doc/index.rst
@@ -21,8 +21,7 @@ Get the Toolchain and QEMU
 The minimum version of the `Zephyr SDK tools
 <https://www.zephyrproject.org/developers/#downloads>`_
 with toolchain and QEMU support for the RISV64 architecture is v0.10.2.
-Please see the `installation instructions
-<https://docs.zephyrproject.org/latest/getting_started/index.html#install-the-required-tools>`_
+Please see the :ref:`installation instructions <install-required-tools>`
 for more details.
 
 Programming and Debugging

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -44,6 +44,8 @@ package is already installed locally but a more recent version is available. It
 is good practice to use this flag if the latest version of a package is
 required.
 
+.. _install-required-tools:
+
 Install the required tools
 ===========================
 

--- a/doc/releases/release-notes-1.10.rst
+++ b/doc/releases/release-notes-1.10.rst
@@ -138,7 +138,7 @@ Build and Infrastructure
   either simple one-to-one translations of KBuild features or introduce
   new concepts that replace KBuild concepts. Please re-read the Getting
   Started guide
-  (https://docs.zephyrproject.org/getting_started/getting_started.html)
+  (https://docs.zephyrproject.org/1.10.0/getting_started/getting_started.html)
   with updated instructions for setting up and developing on your host-OS.
   You *will* need to port your own out-of-tree scripts and Makefiles to
   CMake.


### PR DESCRIPTION
The project's README.rst references the support board docs with an URL
that's not working these days (see
https://github.com/zephyrproject-rtos/infrastructure/issues/134) so fix
that URL reference.  While looking for other similar linking cases, I
found a hard URL references that should be using
:ref: role, and a release notes reference to a (now) broken link (fixing that
in the /latest/ version of the 1.10 release notes).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>