### PR TITLE
Bluetooth: controller: split: Fix PDU handling on terminate

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -667,8 +667,13 @@ int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx)
 	struct pdu_data *pdu_rx;
 	struct ll_conn *conn;
 
-	conn = ll_conn_get((*rx)->hdr.handle);
-	LL_ASSERT(conn);
+	conn = ll_connected_get((*rx)->hdr.handle);
+	if (!conn) {
+		/* Mark for buffer for release */
+		(*rx)->hdr.type = NODE_RX_TYPE_DC_PDU_RELEASE;
+
+		return 0;
+	}
 
 	pdu_rx = (void *)(*rx)->pdu;
 


### PR DESCRIPTION
Fix handling of Rx-ed PDU on termination, do not process
Rx-ed control PDUs and release the PDU buffer back to the
free pool.

Without this fix, Rx-ed control PDU was responded with a
Tx PDU, which did not get acknowledged or released.

Fixes #18819.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>