### PR TITLE
nvs: Fix deletion of the last entry added

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -753,6 +753,7 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 	struct nvs_ate wlk_ate;
 	u32_t wlk_addr, rd_addr;
 	u16_t required_space = 0U; /* no space, appropriate for delete ate */
+	bool prev_found = false;
 
 	if (!fs->ready) {
 		LOG_ERR("NVS not initialized");
@@ -782,6 +783,7 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 			return rc;
 		}
 		if ((wlk_ate.id == id) && (!nvs_ate_crc8_check(&wlk_ate))) {
+			prev_found = true;
 			break;
 		}
 		if (wlk_addr == fs->ate_wra) {
@@ -789,7 +791,7 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 		}
 	}
 
-	if (wlk_addr != fs->ate_wra) {
+	if (prev_found) {
 		/* previous entry found */
 		rd_addr &= ADDR_SECT_MASK;
 		rd_addr += wlk_ate.offset;

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -503,7 +503,6 @@ void test_nvs_full_sector(void)
 		len = nvs_write(&fs, filling_id, &filling_id,
 				sizeof(filling_id));
 		if (len == -ENOSPC) {
-			filling_id--;
 			break;
 		}
 		zassert_true(len == sizeof(filling_id), "nvs_write failed: %d",

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -556,6 +556,18 @@ void test_delete(void)
 
 		zassert_true(len == sizeof(filling_id), "nvs_write failed: %d",
 			     len);
+
+		if (filling_id != 0) {
+			continue;
+		}
+
+		/* delete the first entry while it is the most recent one */
+		err = nvs_delete(&fs, filling_id);
+		zassert_true(err == 0,  "nvs_delete call failure: %d", err);
+
+		len = nvs_read(&fs, filling_id, &data_read, sizeof(data_read));
+		zassert_true(len == -ENOENT,
+			     "nvs_read shouldn't found the entry: %d", len);
 	}
 
 	/* delete existing entry */


### PR DESCRIPTION
Make sure that the last entry added is deleted correctly by storing the
fact that one was found in a local variable.

Fix by Laczen JMS <laczenjms@gmail.com>

Fixes #18813.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>