### PR TITLE
dts: bindings: Distinguish controller and device

### DIFF
--- a/dts/bindings/can/can.yaml
+++ b/dts/bindings/can/can.yaml
@@ -1,7 +1,7 @@
 title: CAN Base Structure
 
 description: >
-    This binding gives the base structures for all CAN devices
+    This binding gives the base structures for all CAN controllers
 
 inherits:
     !include base.yaml

--- a/dts/bindings/i2c/i2c.yaml
+++ b/dts/bindings/i2c/i2c.yaml
@@ -7,7 +7,7 @@
 title: I2C Base Structure
 
 description: >
-    This binding gives the base structures for all I2C devices
+    This binding gives the base structures for all I2C controllers
 
 inherits:
     !include base.yaml

--- a/dts/bindings/i2s/i2s.yaml
+++ b/dts/bindings/i2s/i2s.yaml
@@ -7,7 +7,7 @@
 title: I2S Base Structure
 
 description: >
-    This binding gives the base structures for all I2S devices
+    This binding gives the base structures for all I2S controllers
 
 inherits:
     !include base.yaml

--- a/dts/bindings/serial/uart.yaml
+++ b/dts/bindings/serial/uart.yaml
@@ -1,7 +1,7 @@
 title: Uart Base Structure
 
 description: >
-    This binding gives the base structures for all UART devices
+    This binding gives the base structures for all UART controllers
 
 inherits:
     !include base.yaml

--- a/dts/bindings/spi/spi.yaml
+++ b/dts/bindings/spi/spi.yaml
@@ -7,7 +7,7 @@
 title: SPI Base Structure
 
 description: >
-    This binding gives the base structures for all SPI devices
+    This binding gives the base structures for all SPI controllers
 
 inherits:
     !include base.yaml

--- a/dts/bindings/usb/usb.yaml
+++ b/dts/bindings/usb/usb.yaml
@@ -7,7 +7,7 @@
 title: USB Base Structure
 
 description: >
-    This binding gives the base structures for all USB devices
+    This binding gives the base structures for all USB controllers
 
 inherits:
     !include base.yaml


### PR DESCRIPTION
Distinguishing from controller and device was limited to [uppercase / controller](https://github.com/zephyrproject-rtos/zephyr/blob/0d766c668de052f00c04820897ca966cfd781aa4/dts/bindings/spi/spi.yaml#L10) and [lowercase / device](https://github.com/zephyrproject-rtos/zephyr/blob/0d766c668de052f00c04820897ca966cfd781aa4/dts/bindings/spi/spi-device.yaml#L10) name of the bus in question. Using controller vs device is hopefully less confusing to figure out which one to inherit.