### PR TITLE
[Code coverage]: Fix the issue of function code coverage in device.c.

### DIFF
--- a/kernel/device.c
+++ b/kernel/device.c
@@ -4,10 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <errno.h>
 #include <string.h>
 #include <device.h>
-#include <sys/util.h>
 #include <sys/atomic.h>
 #include <syscall_handler.h>
 


### PR DESCRIPTION
It was reported in the code coverage report that Z_SYSCALL_HANDLER() was
not called by other code, if we run "sanitycheck -p qemu_x86 --coverage
-T tests/kernel/device/".

The root cause is that we include "errno.h", which includes
"include/generated/syscalls/device.h". It causes that the
declare of device_get_binding() in "include/generated/syscalls/device.h"
is marked as "has been called", rather than Z_SYSCALL_HANDLER() in device.c.

So I remove "#include <errno.h>", which is useless in device.c. Also,
"#include <sys/util.h>" is removed for the same reason.