### PR TITLE
Bluetooth: SMP: Fix pairing using debug keys

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -616,7 +616,7 @@ static u8_t get_encryption_key_size(struct bt_smp *smp)
 /* Check that if a new pairing procedure with an existing bond will not lower
  * the established security level of the bond.
  */
-bool update_keys_check(struct bt_smp *smp)
+static bool update_keys_check(struct bt_smp *smp)
 {
 	struct bt_conn *conn = smp->chan.chan.conn;
 


### PR DESCRIPTION
Fix issue when checking if SMP pairing procedure is allowed to use the
SMP debug keys. This check did not consider the case where the keys
pointer was assigned, but did not contain a valid LTK key.
This resulted in being unable to pair with debug keys without an
existing bond.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>