### PR TITLE
Backport 18820 to v1.14 branch:  nvs: Fix deletion of the last entry added

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -753,6 +753,7 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 	struct nvs_ate wlk_ate;
 	u32_t wlk_addr, rd_addr;
 	u16_t required_space = 0U; /* no space, appropriate for delete ate */
+	bool prev_found = false;
 
 	if (!fs->ready) {
 		LOG_ERR("NVS not initialized");
@@ -782,6 +783,7 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 			return rc;
 		}
 		if ((wlk_ate.id == id) && (!nvs_ate_crc8_check(&wlk_ate))) {
+			prev_found = true;
 			break;
 		}
 		if (wlk_addr == fs->ate_wra) {
@@ -789,7 +791,7 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 		}
 	}
 
-	if (wlk_addr != fs->ate_wra) {
+	if (prev_found) {
 		/* previous entry found */
 		rd_addr &= ADDR_SECT_MASK;
 		rd_addr += wlk_ate.offset;


### PR DESCRIPTION
Make sure that the last entry added is deleted correctly by storing the
fact that one was found in a local variable.

Without tests upgrades as it doesn't exist in the v1.14

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>
Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>