### PR TITLE
samples: intel_s1000: Simplify code and fix pylint warning

### DIFF
--- a/samples/boards/intel_s1000_crb/audio/audio.py
+++ b/samples/boards/intel_s1000_crb/audio/audio.py
@@ -25,17 +25,14 @@ class Device:
         When the script is run using sudo permission, the
         manufacturer and product strings are printed
         """
-        config_file = os.path.dirname(__file__)
-        if len(config_file) != 0:
-            config_file += '/'
-        config_file += 'config.yml'
+        config_file = os.path.join(os.path.dirname(__file__), 'config.yml')
         with open(config_file, 'r') as ymlfile:
             config = yaml.safe_load(ymlfile)
         self.name = config['general']['name']
         self.usb_vid = config['usb']['vid']
         self.usb_pid = config['usb']['pid']
         self.hid_dev = hid.device()
-        if self.hid_dev == None:
+        if self.hid_dev is None:
             print('Device not found')
         else:
             self.hid_dev.open(self.usb_vid, self.usb_pid)


### PR DESCRIPTION
Empty sequences in Python are falsy, so

    if len(config_file) != 0:

can be simplified to

    if config_file:

pylint warning:

    C1801: Do not use `len(SEQUENCE)` to determine if a sequence is
    empty (len-as-condition)

Simplify the code a bit with os.path.join(), which indirectly gets rid
of the warning. os.path.join('', 'foo') returns 'foo', so things work
out when os.path.basename() returns '' (no directory) as well.

I'm getting rid of pylint warnings for a CI check.

Also replace a '== None' with 'is None', which is more common.