### PR TITLE
sanitycheck: harness.py: Fix bad indentation

### DIFF
--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -62,7 +62,7 @@ class Console(Harness):
                 if pattern.search(line) and not r in self.matches:
                     self.matches[r] = line
             if len(self.matches) == len(self.regex):
-                    self.state = "passed"
+                self.state = "passed"
 
         if self.fail_on_fault:
             if self.FAULT in line:


### PR DESCRIPTION
Getting rid of pylint warnings for a CI check. No functional change.