### PR TITLE
scripts: dts: devicetree.py: Fix pylint warning for iffy \w escape

### DIFF
--- a/scripts/dts/devicetree.py
+++ b/scripts/dts/devicetree.py
@@ -131,7 +131,7 @@ def parse_value(value):
         if value[0] == '0':
             return int(value, 8)
         # Match alpha numeric values
-        if re.match("\w", value):
+        if re.match(r"\w", value):
             return value
         return int(value, 10)
 


### PR DESCRIPTION
"\w" gives a two-character string, but is iffy, because it relies on \w
not being defined as an escape sequence. r"\w" is better.

Fixes this pylint warning:

    scripts/dts/devicetree.py:134:0: W1401: Anomalous backslash in
    string: '\w'. String constant might be missing an r prefix.
    (anomalous-backslash-in-string)

Wondering if I should exclude the old DTS scripts from the pylint CI
check, but doesn't hurt to fix it at least.