### PR TITLE
drivers: usb_dc_sam: validate pointer in usb_dc_ep_is_stalled

### DIFF
--- a/drivers/usb/device/usb_dc_sam.c
+++ b/drivers/usb/device/usb_dc_sam.c
@@ -568,6 +568,10 @@ int usb_dc_ep_is_stalled(u8_t ep, u8_t *stalled)
 		return -EINVAL;
 	}
 
+	if (!stalled) {
+		return -EINVAL;
+	}
+
 	*stalled = (USBHS->USBHS_DEVEPTIMR[ep_idx] &
 		    USBHS_DEVEPTIMR_STALLRQ) != 0;
 


### PR DESCRIPTION
Validate pointer argument in usb_dc_ep_is_stalled.

Fixes: #18824