### PR TITLE
gen_isr_tables: Fix pylint warning by using isinstance()

### DIFF
--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -164,7 +164,7 @@ def write_source_file(fp, vt, swt, intlist, syms):
 
     for i in range(nv):
         param, func = swt[i]
-        if type(func) is int:
+        if isinstance(func, int):
             func_as_string = "{0:#x}".format(func)
         else:
             func_as_string = func


### PR DESCRIPTION
Fix this warning, as a preparation for a CI check:

    arch/common/gen_isr_tables.py:167:11: C0123: Using type() instead of
    isinstance() for a typecheck. (unidiomatic-typecheck)

isinstance() has the advantage that it also handles inheritance, though
it doesn't really matter here. It's more common at least.