### PR TITLE
x86: gen_idt.py: Use enumerate() to fix pylint warning

### DIFF
--- a/arch/x86/gen_idt.py
+++ b/arch/x86/gen_idt.py
@@ -274,9 +274,8 @@ def create_irq_vectors_allocated(vectors, spur_code, spur_nocode, filename):
     # interrupt handlers installed, they are free for runtime installation
     # of interrupts
     num_chars = (len(vectors) + 7) // 8
-    vbits = [0 for i in range(num_chars)]
-    for i in range(len(vectors)):
-        handler, _, _ = vectors[i]
+    vbits = num_chars*[0]
+    for i, (handler, _, _) in enumerate(vectors):
         if handler not in (spur_code, spur_nocode):
             continue
 


### PR DESCRIPTION
Use enumerate() to fix this pylint warning:

    C0200: Consider using enumerate instead of iterating with range and
    len (consider-using-enumerate)

enumerate() is handy when the loop body needs both the element and its
index. It returns (index, element) tuples.

Also use a tuple unpacking to extract 'handler' from the elements in
'vector'.

Piggyback a slightly simpler way to build a list of num_chars 0s.

Getting rid of warnings for a CI check.