### PR TITLE
intel_s1000_crb: messenger.py: Simplify loops to fix pylint warnings

### DIFF
--- a/boards/xtensa/intel_s1000_crb/support/messenger.py
+++ b/boards/xtensa/intel_s1000_crb/support/messenger.py
@@ -128,9 +128,8 @@ class Message:
         bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8,
                 len(tuple))
         self.tx_index += 4
-        for index in range(len(tuple)):
-            bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8,
-                    tuple[index])
+        for elm in tuple:
+            bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8, elm)
             self.tx_index += 4
         return self.tx_data
 
@@ -152,9 +151,8 @@ class Message:
         bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8,
                 len(tuple))
         self.tx_index += 4
-        for index in range(len(tuple)):
-            bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8,
-                    tuple[index])
+        for elm in tuple:
+            bitstruct.pack_into('u32', self.tx_data, self.tx_index * 8, elm)
             self.tx_index += 4
         return self.tx_data
 


### PR DESCRIPTION
Simplify two loops in create_memread_cmd() by looping over elements
instead of indices, to fix two pylint warnings.

Fixing warnings for a CI check.