### PR TITLE
intel_s1000_crb: messenger.py: Fix 3-space indentation

### DIFF
--- a/boards/xtensa/intel_s1000_crb/support/download.py
+++ b/boards/xtensa/intel_s1000_crb/support/download.py
@@ -36,29 +36,29 @@ def calc_firmware_sha(file):
     Caculate SHA256 hash of the padded contents
     """
     with open(file, 'rb') as firmware:
-       firmware.seek(0, 2)
-       size = firmware.tell()
+        firmware.seek(0, 2)
+        size = firmware.tell()
 
-       # pad firmware to round upto 64 byte boundary
-       padding = (size % 64)
-       if padding != 0:
-           padding = (64 - padding)
-       size += padding
+        # pad firmware to round upto 64 byte boundary
+        padding = (size % 64)
+        if padding != 0:
+            padding = (64 - padding)
+        size += padding
 
-       firmware.seek(0, 0)
-       sha256 = hashlib.sha256()
-       for block in iter(lambda: firmware.read(4096), b""):
-           sha256.update(block)
-       firmware.close()
+        firmware.seek(0, 0)
+        sha256 = hashlib.sha256()
+        for block in iter(lambda: firmware.read(4096), b""):
+            sha256.update(block)
+        firmware.close()
 
-       if padding != 0:
-           sha256.update(b'\0' * padding)
-           print('Firmware (%s): %d bytes, will be padded to %d bytes.'
-                   % (os.path.basename(file), size - padding, size))
-       else:
-           print('Firmware file size: %d bytes.' % size)
-       print('SHA: ' + sha256.hexdigest())
-       return (size, padding, sha256.digest())
+        if padding != 0:
+            sha256.update(b'\0' * padding)
+            print('Firmware (%s): %d bytes, will be padded to %d bytes.'
+                    % (os.path.basename(file), size - padding, size))
+        else:
+            print('Firmware file size: %d bytes.' % size)
+        print('SHA: ' + sha256.hexdigest())
+        return (size, padding, sha256.digest())
 
 def setup_device():
     """


### PR DESCRIPTION
Accidental 3-space instead of 4-space indent.

Fixing pylint warnings for a CI check.