### PR TITLE
scripts: gen_kobject_list.py: Remove redundant parentheses

### DIFF
--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -173,11 +173,11 @@ def write_gperf_table(fp, eh, objs, static_begin, static_end):
         fp.write("};\n")
 
     num_futex = eh.get_futex_counter()
-    if (num_futex != 0):
+    if num_futex != 0:
         fp.write("static struct z_futex_data futex_data[%d] = {\n" % num_futex)
         for i in range(num_futex):
             fp.write("Z_FUTEX_DATA_INITIALIZER(futex_data[%d])" % i)
-            if (i != num_futex - 1):
+            if i != num_futex - 1:
                 fp.write(", ")
         fp.write("};\n")
 
@@ -205,9 +205,9 @@ def write_gperf_table(fp, eh, objs, static_begin, static_end):
             fp.write(val)
 
         flags = "0"
-        if (initialized):
+        if initialized:
             flags += " | K_OBJ_FLAG_INITIALIZED"
-        if (is_driver):
+        if is_driver:
             flags += " | K_OBJ_FLAG_DRIVER"
 
         fp.write("\", {}, %s, %s, %s\n" % (obj_type, flags, str(ko.data)))


### PR DESCRIPTION
No need to put () around 'if' conditions in Python.

Fixing pylint warnings for a CI check.