### PR TITLE
zephyr_commit_rules.py: Fix pylint warning by simplifying conditional

### DIFF
--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -112,7 +112,7 @@ class MaxLineLengthExceptions(LineRule):
         if line.startswith('Signed-off-by'):
             return
 
-        if len(urls) > 0:
+        if urls:
             return
 
         if len(line) > max_length:


### PR DESCRIPTION
Non-empty sequences are truthy in Python, so len() can be skipped in
tests.

Fixes this pylint warning:

    scripts/gitlint/zephyr_commit_rules.py:115:11: C1801: Do not use
    `len(SEQUENCE)` to determine if a sequence is empty
    (len-as-condition)