### PR TITLE
scripts: dts: Fix misc. pylint warnings in old scripts

### DIFF
--- a/scripts/dts/extract/default.py
+++ b/scripts/dts/extract/default.py
@@ -17,14 +17,16 @@ from extract.directive import DTDirective
 # @brief Manage directives in a default way.
 #
 class DTDefault(DTDirective):
-    def _extract_enum(self, node_path, prop, prop_values, label):
+
+    @staticmethod
+    def _extract_enum(node_path, prop, prop_values, label):
         cell_yaml = get_binding(node_path)['properties'][prop]
         if 'enum' in cell_yaml:
             if prop_values in cell_yaml['enum']:
                 if isinstance(cell_yaml['enum'], list):
-                   value = cell_yaml['enum'].index(prop_values)
+                    value = cell_yaml['enum'].index(prop_values)
                 if isinstance(cell_yaml['enum'], dict):
-                   value = cell_yaml['enum'][prop_values]
+                    value = cell_yaml['enum'][prop_values]
                 label = label + "_ENUM"
                 return {label:value}
             else:
@@ -52,8 +54,9 @@ class DTDefault(DTDirective):
         else:
             prop_values = reduced[node_path]['props'][prop]
 
-        if prop_type == "string-array" or prop_type == "array" or prop_type == "uint8-array":
-            if type(prop_values) is not list: prop_values = [ prop_values, ]
+        if prop_type in {"string-array", "array", "uint8-array"}:
+            if not isinstance(prop_values, list):
+                prop_values = [prop_values]
 
         if prop_type == "uint8-array":
             prop_name = str_to_label(prop)

--- a/scripts/dts/extract/flash.py
+++ b/scripts/dts/extract/flash.py
@@ -67,7 +67,8 @@ class DTFlash(DTDirective):
 
         insert_defs("DT_FLASH_AREA", prop_def, prop_alias)
 
-    def _add_partition_label_entries(self, node_path):
+    @staticmethod
+    def _add_partition_label_entries(node_path):
         # Adds DT_FLASH_AREA_<label>_... entries, to the '# partition@...'
         # section
 
@@ -108,7 +109,8 @@ class DTFlash(DTDirective):
 
         insert_defs(node_path, prop_def, prop_alias)
 
-    def extract_flash(self):
+    @staticmethod
+    def extract_flash():
         node_path = chosen.get('zephyr,flash')
         if not node_path:
             # Add addr/size 0 for systems with no flash controller. This is
@@ -131,7 +133,8 @@ class DTFlash(DTDirective):
             nr_address_cells, nr_size_cells = get_addr_size_cells(node_path)
 
         reg = reduced[node_path]['props']['reg']
-        if type(reg) is not list: reg = [reg]
+        if not isinstance(reg, list):
+            reg = [reg]
         props = list(reg)
 
         num_reg_elem = len(props)/(nr_address_cells + nr_size_cells)
@@ -170,8 +173,8 @@ class DTFlash(DTDirective):
                 prop_alias['FLASH' + label_post] = 'DT_FLASH' + label_post
                 insert_defs(node_path, {}, prop_alias)
 
-
-    def extract_code_partition(self):
+    @staticmethod
+    def extract_code_partition():
         node_path = chosen.get('zephyr,code-partition')
         if not node_path:
             # Fall back on zephyr,flash if zephyr,code-partition isn't set.

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -152,7 +152,7 @@ def create_reduced(node, path):
     # Assign an instance ID for each compat
     compat = node['props'].get('compatible')
     if compat:
-        if type(compat) is not list:
+        if not isinstance(compat, list):
             compat = [compat]
 
         reduced[path]['instance_id'] = {}

--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -32,7 +32,8 @@ class DTReg(DTDirective):
         binding = get_binding(node_path)
 
         reg = reduced[node_path]['props']['reg']
-        if type(reg) is not list: reg = [ reg, ]
+        if not isinstance(reg, list):
+            reg = [reg]
 
         (nr_address_cells, nr_size_cells) = get_addr_size_cells(node_path)
 
@@ -93,7 +94,7 @@ class DTReg(DTDirective):
             if nr_size_cells:
                 prop_def[l_size_fqn] = int(size / div)
                 add_compat_alias(node_path, '_'.join(l_size + l_idx), l_size_fqn, prop_alias)
-            if len(name):
+            if name:
                 if nr_address_cells:
                     prop_alias['_'.join(l_base + name + l_addr)] = l_addr_fqn
                     add_compat_alias(node_path, '_'.join(name + l_addr), l_addr_fqn, prop_alias)

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -78,7 +78,7 @@ def generate_prop_defines(node_path, prop):
 
     if prop == 'reg':
         reg.extract(node_path, names, def_label, 1)
-    elif prop == 'interrupts' or prop == 'interrupts-extended':
+    elif prop in {'interrupts', 'interrupts-extended'}:
         interrupts.extract(node_path, prop, names, def_label)
     elif prop == 'compatible':
         compatible.extract(node_path, prop, def_label)


### PR DESCRIPTION
Fix pylint warnings for bad indent, redundant len()s in conditionals,
tests that could be improved with 'in', methods that don't use 'self',
and type()s where isinstance() is more common.

Preparation for adding a CI check.