### PR TITLE
west: boards: Remove accidental comma to fix pylint warning

### DIFF
--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -49,7 +49,7 @@ class Boards(WestCommand):
         # flags
         parser.add_argument('-f', '--format', default=default_fmt,
                             help='''Format string to use to list each board;
-                                    see FORMAT STRINGS below.'''),
+                                    see FORMAT STRINGS below.''')
 
         return parser
 


### PR DESCRIPTION
Remove a trailing comma that generated a single-element tuple and made
pylint warn:

    scripts/west_commands/boards.py:50:8: W0106: Expression
    "(parser.add_argument(...), )" is assigned to nothing
    (expression-not-assigned)

No functional change.

Fixing pylint warnings for a CI check.