### PR TITLE
west: completion.py: Fix bad indentation and blank lines at end of file

### DIFF
--- a/scripts/west_commands/completion.py
+++ b/scripts/west_commands/completion.py
@@ -46,5 +46,4 @@ class Completion(WestCommand):
             with open(cf, 'r') as f:
                 print(f.read())
         except FileNotFoundError as e:
-                log.die('Unable to find completion file: {}'.format(e))
-
+            log.die('Unable to find completion file: {}'.format(e))


### PR DESCRIPTION
Fixing pylint warnings for a CI check.