### PR TITLE
west: build.py: Remove len() from conditional to fix pylint warning

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -198,7 +198,7 @@ class Build(Forceable):
             # passed on to CMake
             if remainder[0] == _ARG_SEPARATOR:
                 remainder = remainder[1:]
-            if len(remainder):
+            if remainder:
                 self.args.cmake_opts = remainder
         except IndexError:
             return


### PR DESCRIPTION
Non-empty sequences are truthy in Python, so len() can be skipped.

Fixing pylint warnings for a CI check.