### PR TITLE
Bluetooth: Host: Workaround for controller advertising data bug

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -5666,15 +5666,6 @@ int bt_le_adv_start_internal(const struct bt_le_adv_param *param,
 		return -EALREADY;
 	}
 
-	if (!dir_adv) {
-		err = le_adv_update(ad, ad_len, sd, sd_len,
-				    param->options & BT_LE_ADV_OPT_CONNECTABLE,
-				    param->options & BT_LE_ADV_OPT_USE_NAME);
-		if (err) {
-			return err;
-		}
-	}
-
 	(void)memset(&set_param, 0, sizeof(set_param));
 
 	set_param.min_interval = sys_cpu_to_le16(param->interval_min);
@@ -5787,6 +5778,15 @@ int bt_le_adv_start_internal(const struct bt_le_adv_param *param,
 	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_ADV_PARAM, buf, NULL);
 	if (err) {
 		return err;
+	}
+
+	if (!dir_adv) {
+		err = le_adv_update(ad, ad_len, sd, sd_len,
+				    param->options & BT_LE_ADV_OPT_CONNECTABLE,
+				    param->options & BT_LE_ADV_OPT_USE_NAME);
+		if (err) {
+			return err;
+		}
 	}
 
 	err = set_advertise_enable(true);


### PR DESCRIPTION
Add workaround for advertising data issue in the internal bluetooth
controller. The advertising data must be set after advertising
parameters in order to successfully update the advertising data after
an directed advertiser has been active.

Workaround for: #18850

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>