### PR TITLE
cc1352r1_launchxl: configure jtag reset for openocd.cfg

### DIFF
--- a/boards/arm/cc1352r1_launchxl/support/openocd.cfg
+++ b/boards/arm/cc1352r1_launchxl/support/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/ti_cc13x2_launchpad.cfg]
+reset_config trst_only


### PR DESCRIPTION
The cc1352r requires

reset_config trst_only

Fixes #18852.