### PR TITLE
scripts: sanitycheck: Multiple --west-flash arguments

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -679,14 +679,16 @@ class DeviceHandler(Handler):
             if options.west_runner is not None:
                 command.append("--runner")
                 command.append(options.west_runner)
-            # There are two ways this option is used.
+            # There are three ways this option is used.
             # 1) bare: --west-flash
             #    This results in options.west_flash == []
             # 2) with a value: --west-flash="--board-id=42"
             #    This results in options.west_flash == "--board-id=42"
+            # 3) Multiple values: --west-flash="--board-id=42,--erase"
+            #    This results in options.west_flash == "--board-id=42 --erase"
             if options.west_flash != []:
                 command.append('--')
-                command.append(options.west_flash)
+                command.extend(options.west_flash.split(','))
         else:
             if options.ninja:
                 generator_cmd = "ninja"
@@ -3051,11 +3053,11 @@ Artificially long but functional example:
     parser.add_argument(
         "--west-flash", nargs='?', const=[],
         help="""Uses west instead of ninja or make to flash when running with
-             --device-testing.
+             --device-testing. Supports comma-separated argument list.
 
         E.g "sanitycheck --device-testing --device-serial /dev/ttyACM0
-                         --west-flash="--board-id=foobar"
-        will translate to "west flash -- --board-id=foobar"
+                         --west-flash="--board-id=foobar,--erase"
+        will translate to "west flash -- --board-id=foobar --erase"
 
         NOTE: device-testing must be enabled to use this option.
         """


### PR DESCRIPTION
Make --west-flash support multiple arguments

Signed-off-by: Jorgen Kvalvaag <jorgen.kvalvaag@nordicsemi.no>