### PR TITLE
Bluetooth: Shell: Fix shell build dependencies

### DIFF
--- a/subsys/bluetooth/shell/CMakeLists.txt
+++ b/subsys/bluetooth/shell/CMakeLists.txt
@@ -21,12 +21,15 @@ zephyr_library_sources_ifdef(
   CONFIG_BT_RFCOMM
   rfcomm.c
   )
-zephyr_library_sources_ifdef(
-  CONFIG_BT_CTLR
-  ll.c
-  ticker.c
-  )
-zephyr_include_directories_ifdef(
-	CONFIG_BT_CTLR
-	${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
-	)
+
+if(CONFIG_BT_CTLR)
+  if(CONFIG_BT_LL_SW_LEGACY OR CONFIG_BT_LL_SW_SPLIT)
+    zephyr_library_sources(
+      ll.c
+      ticker.c
+      )
+    zephyr_include_directories(
+      ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
+      )
+  endif()
+endif()

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1667,6 +1667,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 	SHELL_CMD(mesh_adv, NULL, "<on, off>", cmd_mesh_adv),
 #endif /* CONFIG_BT_HCI_MESH_EXT */
+#if defined(CONFIG_BT_LL_SW_LEGACY) || defined(CONFIG_BT_LL_SW_SPLIT)
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_BROADCASTER)
 	SHELL_CMD_ARG(advx, NULL, "<on off> [coded] [anon] [txp]", cmd_advx,
@@ -1687,6 +1688,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 		      4, 0),
 	SHELL_CMD_ARG(test_end, NULL, HELP_NONE, cmd_test_end, 1, 0),
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
+#endif /* defined(CONFIG_BT_LL_SW_LEGACY) || defined(CONFIG_BT_LL_SW_SPLIT) */
 #if defined(CONFIG_BT_LL_SW_SPLIT)
 	SHELL_CMD(ull_reset, NULL, HELP_NONE, cmd_ull_reset),
 #endif /* CONFIG_BT_LL_SW_SPLIT */


### PR DESCRIPTION
Fix shell build dependencies, subsys/bluetooth/controller is only added
for CONFIG_BT_LL_SW_SPLIT or CONFIG_BT_LL_SW_LEGACY.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>