### PR TITLE
intel_s1000_crb: scripts: Remove '== False/True' tests

### DIFF
--- a/boards/xtensa/intel_s1000_crb/support/device.py
+++ b/boards/xtensa/intel_s1000_crb/support/device.py
@@ -82,10 +82,10 @@ class Device:
         max_wait = 0.1 	 # 100 ms
         time.sleep(min_wait)
         ready = self.irq_pin.read()
-        if ready == False:
+        if not ready:
             time.sleep(max_wait)
             ready = self.irq_pin.read()
-            if ready == False:
+            if not ready:
                 print('Error: Device not ready', file=sys.stderr)
         return ready
 
@@ -107,7 +107,7 @@ class Device:
         before return.
         """
         rx_data = self.spi.transfer(data)
-        if wait == True:
+        if wait:
             self.check_device_ready()
         return rx_data
 

--- a/boards/xtensa/intel_s1000_crb/support/messenger.py
+++ b/boards/xtensa/intel_s1000_crb/support/messenger.py
@@ -78,7 +78,7 @@ class Message:
             print('RSP <<< NULL.')
         else:
             print('RSP <<< %s.' % self.cmd_rsp[rsp])
-            if verbose == True:
+            if verbose:
                 count = bitstruct.unpack_from('u32', msg, 4 * 8)[0]
                 count &= 0x1ff
                 for index in range(0, 8 + (count * 4), 4):


### PR DESCRIPTION
Fix pylint warnings like these:

    Comparison to True should be just 'expr' (singleton-comparison)
    Comparison to False should be 'not expr' (singleton-comparison)

I checked that GPIO.read() only returns True/False in the
python-periphery docs.

Getting rid of pylint warnings for a CI check.