### PR TITLE
x86: gen_idt.py: Fix broken error() call in update_irq_vec_map()

### DIFF
--- a/arch/x86/gen_idt.py
+++ b/arch/x86/gen_idt.py
@@ -127,7 +127,7 @@ def update_irq_vec_map(irq_vec_map, irq, vector, max_irq):
     # This table will never have values less than 32 since those are for
     # exceptions; 0 means unconfigured
     if irq_vec_map[irq] != 0:
-        error("multiple vector assignments for interrupt line %d", irq)
+        error("multiple vector assignments for interrupt line %d" % irq)
 
     debug("assign IRQ %d to vector %d" % (irq, vector))
     irq_vec_map[irq] = vector


### PR DESCRIPTION
Accidentally passed two arguments instead of one. Fixes this pylint
error:

    arch/x86/gen_idt.py:132:8: E1121: Too many positional arguments for
    function call (too-many-function-args)

Fixing pylint warnings for a CI check.