### PR TITLE
Bluetooth: controller: split: Fix crash on terminate

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -305,8 +305,6 @@ lll_conn_isr_rx_exit:
 	}
 
 	if (is_rx_enqueue) {
-		LL_ASSERT(lll->handle != 0xFFFF);
-
 		ull_pdu_rx_alloc();
 
 		node_rx->hdr.type = NODE_RX_TYPE_DC_PDU;


### PR DESCRIPTION
Remove incorrect LL_ASSERT check in Lower Link Layer that
checked for invalid connection handle on reception of PDU.
The assert is not needed as PDUs can be received until the
Upper Link Layer is aware of the acknowledgement of the
terminate ind PDU.

Fixes #18828.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>