### PR TITLE
ci: scripts: Suppress pylint warnings for the sh library

### DIFF
--- a/scripts/ci/get_modified_boards.py
+++ b/scripts/ci/get_modified_boards.py
@@ -57,7 +57,9 @@ def main():
     if not args.commits:
         exit(1)
 
-    commit = sh.git("diff","--name-only", args.commits, **sh_special_args)
+    # pylint does not like the 'sh' library
+    # pylint: disable=too-many-function-args,unexpected-keyword-arg
+    commit = sh.git("diff", "--name-only", args.commits, **sh_special_args)
     files = commit.split("\n")
 
     for f in files:

--- a/scripts/ci/get_modified_tests.py
+++ b/scripts/ci/get_modified_tests.py
@@ -52,7 +52,9 @@ def main():
     if not args.commits:
         exit(1)
 
-    commit = sh.git("diff","--name-only", args.commits, **sh_special_args)
+    # pylint does not like the 'sh' library
+    # pylint: disable=too-many-function-args,unexpected-keyword-arg
+    commit = sh.git("diff", "--name-only", args.commits, **sh_special_args)
     files = commit.split("\n")
     tests = set()
     for f in files:


### PR DESCRIPTION
pylint does not like how this library works and generates spurious
warnings like

    scripts/ci/get_modified_tests.py:55:13: E1121: Too many positional
    arguments for function call (too-many-function-args)

    scripts/ci/get_modified_tests.py:57:13: E1123: Unexpected keyword
    argument '_tty_out' in function call (unexpected-keyword-arg)

These warnings are useful enough to want to have enabled in the upcoming
pylint CI check, so suppress them here.