### PR TITLE
doc: extract_content.py: Suppress spurious pylint warning

### DIFF
--- a/doc/scripts/extract_content.py
+++ b/doc/scripts/extract_content.py
@@ -61,6 +61,7 @@ def src_deps(zephyr_base, src_file, dest, src_root):
         with open(src_file, encoding="utf-8") as f:
             content = [x.strip() for x in f.readlines()]
     except UnicodeDecodeError as e:
+        # pylint: disable=unsubscriptable-object
         sys.stderr.write(
             "Malformed {} in {}\n"
             "  Context: {}\n"


### PR DESCRIPTION
UnicodeDecodeError.object supports indexing, but pylint gets confused
for some reason.

    doc/scripts/extract_content.py:70:16: E1136: Value 'e.object' is
    unsubscriptable (unsubscriptable-object)

This warning is useful enough to want to have enabled in the upcoming
pylint CI check, so suppress it.