### PR TITLE
x86: gen_idt.py: Simplify test with 'not in'

### DIFF
--- a/arch/x86/gen_idt.py
+++ b/arch/x86/gen_idt.py
@@ -279,7 +279,7 @@ def create_irq_vectors_allocated(vectors, spur_code, spur_nocode, filename):
     vbits = [0 for i in range(num_chars)]
     for i in range(len(vectors)):
         handler, _, _ = vectors[i]
-        if handler != spur_code and handler != spur_nocode:
+        if handler not in (spur_code, spur_nocode):
             continue
 
         vbit_index = i // 8


### PR DESCRIPTION
Getting slightly subjective, but fixes this pylint warning:

    arch/x86/gen_idt.py:281:11: R1714: Consider merging these comparisons
    with "in" to 'handler not in (spur_code, spur_nocode)'
    (consider-using-in)

Getting rid of pylint warnings for a CI check. I could disable any
controversial ones (it's already a list of warnings to enable anyway).