### PR TITLE
doc: application.py: Simplify test with 'in'

### DIFF
--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -271,7 +271,7 @@ class ZephyrAppCommandsDirective(Directive):
             content.append('west sign{}'.format(dst))
 
         for goal in goals:
-            if goal == 'build' or goal == 'sign':
+            if goal in {'build', 'sign'}:
                 continue
             elif goal == 'flash':
                 content.append('west flash{}'.format(dst))


### PR DESCRIPTION
Getting slightly subjective, but fixes this pylint warning:

    doc/extensions/zephyr/application.py:274:15: R1714: Consider merging
    these comparisons with "in" to "goal in ('build', 'sign')"
    (consider-using-in)

Use a set literal instead of a tuple literal, as recent Python 3
versions optimize set literals with constant keys nicely.

Getting rid of pylint warnings for a CI check. I could disable any
controversial ones (it's already a list of warnings to enable anyway).