### PR TITLE
scripts: gen_kobject_list.py: Simplify test with 'in'

### DIFF
--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -305,7 +305,7 @@ def write_kobj_size_output(fp):
         dep, _ = obj_info
         # device handled by default case. Stacks are not currently handled,
         # if they eventually are it will be a special case.
-        if kobj == "device" or kobj == "_k_thread_stack_element":
+        if kobj in {"device", "_k_thread_stack_element"}:
             continue
 
         if dep:


### PR DESCRIPTION
Getting slightly subjective, but fixes this pylint warning:

    scripts/gen_kobject_list.py:308:11: R1714: Consider merging these
    comparisons with "in" to "kobj in ('device', '_k_thread_stack_element')"
    (consider-using-in)

Use a set literal instead of a tuple literal, as recent Python 3
versions optimize set literals with constant keys nicely.

Getting rid of pylint warnings for a CI check. I could disable any
controversial ones (it's already a list of warnings to enable anyway).