### PR TITLE
scripts: gen_relocate_app.py: Simplify test with 'in'

### DIFF
--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -225,7 +225,7 @@ def string_create_helper(region, memory_type,
         # Create a complete list of funcs/ variables that goes in for this
         # memory type
         tmp = print_linker_sections(full_list_of_sections[region])
-        if memory_type == 'SRAM' and (region == 'data' or region == 'bss'):
+        if memory_type == 'SRAM' and region in {'data', 'bss'}:
             linker_string += tmp
         else:
             if memory_type != 'SRAM' and region == 'rodata':


### PR DESCRIPTION
Getting slightly subjective, but fixes this pylint warning:

    scripts/gen_relocate_app.py:228:38: R1714: Consider merging these
    comparisons with "in" to "region in ('data', 'bss')"
    (consider-using-in)

Use a set literal instead of a tuple literal, as recent Python 3
versions optimize set literals with constant keys nicely.

Getting rid of pylint warnings for a CI check. I could disable any
controversial ones (it's already a list of warnings to enable anyway).