### PR TITLE
west: zcmake.py: Simplify test with 'in'

### DIFF
--- a/scripts/west_commands/zcmake.py
+++ b/scripts/west_commands/zcmake.py
@@ -183,7 +183,7 @@ class CMakeCacheEntry:
             except ValueError as exc:
                 args = exc.args + ('on line {}: {}'.format(line_no, line),)
                 raise ValueError(args) from exc
-        elif type_ == 'STRING' or type_ == 'INTERNAL':
+        elif type_ in {'STRING', 'INTERNAL'}:
             # If the value is a CMake list (i.e. is a string which
             # contains a ';'), convert to a Python list.
             if ';' in value:


### PR DESCRIPTION
Getting slightly subjective, but fixes this pylint warning:

    scripts/west_commands/zcmake.py:186:13: R1714: Consider merging
    these comparisons with "in" to "type_ in ('STRING', 'INTERNAL')"
    (consider-using-in)

Use a set literal instead of a tuple literal, as recent Python 3
versions optimize set literals with constant keys nicely.

Getting rid of pylint warnings for a CI check. I could disable any
controversial ones (it's already a list of warnings to enable anyway).