### PR TITLE
scripts: gen_kobject_list.py: Simplify test with chained comparison

### DIFF
--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -195,7 +195,7 @@ def write_gperf_table(fp, eh, objs, static_begin, static_end):
         # pre-initialized objects fall within this memory range, they are
         # either completely initialized at build time, or done automatically
         # at boot during some PRE_KERNEL_* phase
-        initialized = obj_addr >= static_begin and obj_addr < static_end
+        initialized = static_begin <= obj_addr < static_end
         is_driver = obj_type.startswith("K_OBJ_DRIVER_")
 
         byte_str = struct.pack("<I" if eh.little_endian else ">I", obj_addr)


### PR DESCRIPTION
'a < b and b < c' can be simplified to 'a < b < c' in Python.

Fixes this pylint warning:

    scripts/gen_kobject_list.py:198:22: R1716: Simplify chained
    comparison between the operands (chained-comparison)

Fixing pylint warnings for a CI check.