### PR TITLE
doc: fix misspellings in documentation

### DIFF
--- a/boards/arm/96b_avenger96/doc/index.rst
+++ b/boards/arm/96b_avenger96/doc/index.rst
@@ -100,7 +100,7 @@ The STM32MP157A SoC provides the following hardware capabilities:
   - HDMI-CEC interface
   - MDIO Slave interface
   - 3 × SDMMC up to 8-bit (SD / e•MMC™ / SDIO)
-  - 2 × CAN controllers supporting CAN FD protocol, TTCAN capiblity
+  - 2 × CAN controllers supporting CAN FD protocol, TTCAN capability
   - 2 × USB 2.0 high-speed Host+ 1 × USB 2.0 full-speed OTG simultaneously
   - 10/100M or Gigabit Ethernet GMAC (IEEE 1588v2 hardware, MII/RMII/GMII/RGMI)
   - 8- to 14-bit camera interface up to 140 Mbyte/s
@@ -232,7 +232,7 @@ Debugging
 You can debug an application using OpenOCD and GDB. The Solution proposed below
 is based on the Linux STM32MP1 SDK OpenOCD and is available only for a Linux
 environment. The firmware must first be loaded by the Cortex®-A7. Developer
-then attachs the debugger to the running Zephyr using OpenOCD.
+then attaches the debugger to the running Zephyr using OpenOCD.
 
 Prerequisite
 ------------

--- a/samples/drivers/CAN/README.rst
+++ b/samples/drivers/CAN/README.rst
@@ -18,7 +18,7 @@ In loopback mode, the board receives its own messages. This could be used for
 standalone testing.
 
 The sample can be built and executed on boards supporting CAN.
-The LED output pin is defined in the board's device tre.
+The LED output pin is defined in the board's device tree.
 
 Sample output
 =============


### PR DESCRIPTION
Fix some misspellings found in .rst files missed during regular reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>