### PR TITLE
west: runners: Fix two pylint warnings

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -511,10 +511,7 @@ class ZephyrBinaryRunner(abc.ABC):
         self._log_cmd(cmd)
         if _DRY_RUN:
             return
-        try:
-            subprocess.check_call(cmd)
-        except subprocess.CalledProcessError:
-            raise
+        subprocess.check_call(cmd)
 
     def check_output(self, cmd):
         '''Subclass subprocess.check_output() wrapper.
@@ -526,10 +523,7 @@ class ZephyrBinaryRunner(abc.ABC):
         self._log_cmd(cmd)
         if _DRY_RUN:
             return b''
-        try:
-            return subprocess.check_output(cmd)
-        except subprocess.CalledProcessError:
-            raise
+        return subprocess.check_output(cmd)
 
     def popen_ignore_int(self, cmd):
         '''Spawn a child command, ensuring it ignores SIGINT.

--- a/scripts/west_commands/runners/qemu.py
+++ b/scripts/west_commands/runners/qemu.py
@@ -10,9 +10,6 @@ from runners.core import ZephyrBinaryRunner, RunnerCaps
 class QemuBinaryRunner(ZephyrBinaryRunner):
     '''Place-holder for QEMU runner customizations.'''
 
-    def __init__(self, cfg):
-        super(QemuBinaryRunner, self).__init__(cfg)
-
     @classmethod
     def name(cls):
         return 'qemu'

--- a/scripts/west_commands/runners/xtensa.py
+++ b/scripts/west_commands/runners/xtensa.py
@@ -12,9 +12,6 @@ from runners.core import ZephyrBinaryRunner, RunnerCaps
 class XtensaBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for xt-gdb.'''
 
-    def __init__(self, cfg):
-        super(XtensaBinaryRunner, self).__init__(cfg)
-
     @classmethod
     def name(cls):
         return 'xtensa'


### PR DESCRIPTION
Two unrelated pylint warning fixes:

```
west: runners: Remove unnecessary constructors

These just pass their arguments through to the base class constructor.
Removing them means the base class constructor gets called directly
instead.

Fixes this pylint warning:

    W0235: Useless super delegation in method '__init__'
    (useless-super-delegation)
```

```
west: runners: core.py: Remove no-op try-excepts

Removing these doesn't change behavior, since the
subprocess.CalledProcessError is just immediately re-raised when caught.

Fixes this pylint warning:

    W0706: The except handler raises immediately (try-except-raise)
```