### PR TITLE
doc: net: Update LwM2M block of overview document

### DIFF
--- a/doc/guides/networking/overview.rst
+++ b/doc/guides/networking/overview.rst
@@ -78,10 +78,10 @@ can be disabled if not needed.
   applications are implemented.
 
 * **LWM2M** OMA Lightweight Machine-to-Machine Protocol
-  (`LwM2M specification 1.0.2`_) is
-  supported via the "Register Device" API (Register, De-Register and Update)
-  and has template implementations for Security, Server, Device Management and
-  Firmware objects. Bootstrap support is currently not supported.
+  (`LwM2M specification 1.0.2`_) is supported via the "Bootstrap", "Client
+  Registration", "Device Management & Service Enablement" and "Information
+  Reporting" interfaces.  The required core LwM2M objects are implemented as
+  well as several IPSO Smart Objects.
   :ref:`lwm2m-client-sample` implements the library as an example.
 
 * **DNS** Domain Name Service


### PR DESCRIPTION
Re-word the support block for LwM2M:
- the supported interfaces
- change wording of supported LwM2M objects to include the "required"
  keyword instead of explicitly listing them
- mention several IPSO Smart Objects

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/16327

Signed-off-by: Michael Scott <mike@foundries.io>