### PR TITLE
modules: Facilitate the use of nrfx drivers

### DIFF
--- a/drivers/i2c/Kconfig.nrfx
+++ b/drivers/i2c/Kconfig.nrfx
@@ -31,14 +31,14 @@ choice I2C_0_NRF_TYPE
 config I2C_0_NRF_TWI
 	bool "nRF TWI 0"
 	depends on HAS_HW_NRF_TWI0
-	select NRFX_TWI
+	select NRFX_TWI0
 	help
 	  Enable nRF TWI Master without EasyDMA on port 0.
 
 config I2C_0_NRF_TWIM
 	bool "nRF TWIM 0"
 	depends on HAS_HW_NRF_TWIM0
-	select NRFX_TWIM
+	select NRFX_TWIM0
 	help
 	  Enable nRF TWI Master with EasyDMA on port 0.
 	  This peripheral accepts transfers from RAM only,
@@ -59,14 +59,14 @@ choice I2C_1_NRF_TYPE
 config I2C_1_NRF_TWI
 	bool "nRF TWI 1"
 	depends on HAS_HW_NRF_TWI1
-	select NRFX_TWI
+	select NRFX_TWI1
 	help
 	  Enable nRF TWI Master without EasyDMA on port 1.
 
 config I2C_1_NRF_TWIM
 	bool "nRF TWIM 1"
 	depends on HAS_HW_NRF_TWIM1
-	select NRFX_TWIM
+	select NRFX_TWIM1
 	help
 	  Enable nRF TWI Master with EasyDMA on port 1.
 	  This peripheral accepts transfers from RAM only,
@@ -87,7 +87,7 @@ choice I2C_2_NRF_TYPE
 config I2C_2_NRF_TWIM
 	bool "nRF TWIM 2"
 	depends on HAS_HW_NRF_TWIM2
-	select NRFX_TWIM
+	select NRFX_TWIM2
 	help
 	  Enable nRF TWI Master with EasyDMA on port 2.
 	  This peripheral accepts transfers from RAM only,
@@ -108,7 +108,7 @@ choice I2C_3_NRF_TYPE
 config I2C_3_NRF_TWIM
 	bool "nRF TWIM 3"
 	depends on HAS_HW_NRF_TWIM3
-	select NRFX_TWIM
+	select NRFX_TWIM3
 	help
 	  Enable nRF TWI Master with EasyDMA on port 3.
 	  This peripheral accepts transfers from RAM only,

--- a/drivers/pwm/Kconfig.nrfx
+++ b/drivers/pwm/Kconfig.nrfx
@@ -8,6 +8,9 @@ menuconfig PWM_NRFX
 	default y
 	depends on HAS_HW_NRF_PWM0 || HAS_HW_NRF_PWM1 || \
 		   HAS_HW_NRF_PWM2 || HAS_HW_NRF_PWM3
-	select NRFX_PWM
+	select NRFX_PWM0 if PWM_0
+	select NRFX_PWM1 if PWM_1
+	select NRFX_PWM2 if PWM_2
+	select NRFX_PWM3 if PWM_3
 	help
 	  Enable support for nrfx Hardware PWM driver for nRF52 MCU series.

--- a/drivers/spi/Kconfig.nrfx
+++ b/drivers/spi/Kconfig.nrfx
@@ -41,7 +41,7 @@ choice
 config SPI_0_NRF_SPI
 	bool "nRF SPI 0"
 	depends on HAS_HW_NRF_SPI0
-	select NRFX_SPI
+	select NRFX_SPI0
 	help
 	  Enable nRF SPI Master without EasyDMA on port 0.
 
@@ -51,7 +51,7 @@ config SPI_0_NRF_SPIM
 	# (SPIM: An additional byte is clocked out when RXD.MAXCNT == 1 and TXD.MAXCNT <= 1)
 	# Allow the 'EasyDMA' driver only if this automatic safety-disable is overridden
 	depends on HAS_HW_NRF_SPIM0 && (!SOC_NRF52832 || SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58)
-	select NRFX_SPIM
+	select NRFX_SPIM0
 	help
 	  Enable nRF SPI Master with EasyDMA on port 0.
 
@@ -59,7 +59,7 @@ config SPI_0_NRF_SPIS
 	bool "nRF SPIS 0"
 	depends on HAS_HW_NRF_SPIS0
 	depends on SPI_SLAVE
-	select NRFX_SPIS
+	select NRFX_SPIS0
 	help
 	  Enable nRF SPI Slave with EasyDMA on port 0.
 	  Due to hardware limitations the implementation supports only simple
@@ -92,7 +92,7 @@ choice
 config SPI_1_NRF_SPI
 	bool "nRF SPI 1"
 	depends on HAS_HW_NRF_SPI1
-	select NRFX_SPI
+	select NRFX_SPI1
 	help
 	  Enable nRF SPI Master without EasyDMA on port 1.
 
@@ -102,7 +102,7 @@ config SPI_1_NRF_SPIM
 	# (SPIM: An additional byte is clocked out when RXD.MAXCNT == 1 and TXD.MAXCNT <= 1)
 	# Allow the 'EasyDMA' driver only if this automatic safety-disable is overridden
 	depends on HAS_HW_NRF_SPIM1 && (!SOC_NRF52832 || SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58)
-	select NRFX_SPIM
+	select NRFX_SPIM1
 	help
 	  Enable nRF SPI Master with EasyDMA on port 1.
 
@@ -110,7 +110,7 @@ config SPI_1_NRF_SPIS
 	bool "nRF SPIS 1"
 	depends on HAS_HW_NRF_SPIS1
 	depends on SPI_SLAVE
-	select NRFX_SPIS
+	select NRFX_SPIS1
 	help
 	  Enable nRF SPI Slave with EasyDMA on port 1.
 	  Due to hardware limitations the implementation supports only simple
@@ -143,7 +143,7 @@ choice
 config SPI_2_NRF_SPI
 	bool "nRF SPI 2"
 	depends on HAS_HW_NRF_SPI2
-	select NRFX_SPI
+	select NRFX_SPI2
 	help
 	  Enable nRF SPI Master without EasyDMA on port 2.
 
@@ -153,7 +153,7 @@ config SPI_2_NRF_SPIM
 	# (SPIM: An additional byte is clocked out when RXD.MAXCNT == 1 and TXD.MAXCNT <= 1)
 	# Allow the 'EasyDMA' driver only if this automatic safety-disable is overridden
 	depends on HAS_HW_NRF_SPIM2 && (!SOC_NRF52832 || SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58)
-	select NRFX_SPIM
+	select NRFX_SPIM2
 	help
 	  Enable nRF SPI Master with EasyDMA on port 2.
 
@@ -161,7 +161,7 @@ config SPI_2_NRF_SPIS
 	bool "nRF SPIS 2"
 	depends on HAS_HW_NRF_SPIS2
 	depends on SPI_SLAVE
-	select NRFX_SPIS
+	select NRFX_SPIS2
 	help
 	  Enable nRF SPI Slave with EasyDMA on port 2.
 	  Due to hardware limitations the implementation supports only simple
@@ -194,7 +194,7 @@ choice
 config SPI_3_NRF_SPIM
 	bool "nRF SPIM 3"
 	depends on HAS_HW_NRF_SPIM3
-	select NRFX_SPIM
+	select NRFX_SPIM3
 	help
 	  Enable nRF SPI Master with EasyDMA on port 3.
 
@@ -202,7 +202,7 @@ config SPI_3_NRF_SPIS
 	bool "nRF SPIS 3"
 	depends on HAS_HW_NRF_SPIS3
 	depends on SPI_SLAVE
-	select NRFX_SPIS
+	select NRFX_SPIS3
 	help
 	  Enable nRF SPI Slave with EasyDMA on port 3.
 	  Due to hardware limitations the implementation supports only simple

--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -13,6 +13,26 @@ config HAS_NRFX
 config NRFX_PRS
 	bool
 
+config NRFX_PRS_BOX_0
+	bool
+	select NRFX_PRS
+
+config NRFX_PRS_BOX_1
+	bool
+	select NRFX_PRS
+
+config NRFX_PRS_BOX_2
+	bool
+	select NRFX_PRS
+
+config NRFX_PRS_BOX_3
+	bool
+	select NRFX_PRS
+
+config NRFX_PRS_BOX_4
+	bool
+	select NRFX_PRS
+
 config NRFX_ADC
 	bool
 
@@ -38,13 +58,23 @@ config NRFX_PPI
 config NRFX_PWM
 	bool
 
+config NRFX_PWM0
+	bool
+	select NRFX_PWM
+
+config NRFX_PWM1
+	bool
+	select NRFX_PWM
+
+config NRFX_PWM2
+	bool
+	select NRFX_PWM
+
+config NRFX_PWM3
+	bool
+	select NRFX_PWM
+
 config NRFX_QDEC
-	bool
-
-config NRFX_RTC
-	bool
-
-config NRFX_SAADC
 	bool
 
 config NRFX_RTC
@@ -52,21 +82,71 @@ config NRFX_RTC
 
 config NRFX_RTC0
 	bool
+	select NRFX_RTC
 
 config NRFX_RTC1
 	bool
+	select NRFX_RTC
 
 config NRFX_RTC2
+	bool
+	select NRFX_RTC
+
+config NRFX_SAADC
 	bool
 
 config NRFX_SPI
 	bool
 
+config NRFX_SPI0
+	bool
+	select NRFX_SPI
+
+config NRFX_SPI1
+	bool
+	select NRFX_SPI
+
+config NRFX_SPI2
+	bool
+	select NRFX_SPI
+
 config NRFX_SPIM
 	bool
 
+config NRFX_SPIM0
+	bool
+	select NRFX_SPIM
+
+config NRFX_SPIM1
+	bool
+	select NRFX_SPIM
+
+config NRFX_SPIM2
+	bool
+	select NRFX_SPIM
+
+config NRFX_SPIM3
+	bool
+	select NRFX_SPIM
+
 config NRFX_SPIS
 	bool
+
+config NRFX_SPIS0
+	bool
+	select NRFX_SPIS
+
+config NRFX_SPIS1
+	bool
+	select NRFX_SPIS
+
+config NRFX_SPIS2
+	bool
+	select NRFX_SPIS
+
+config NRFX_SPIS3
+	bool
+	select NRFX_SPIS
 
 config NRFX_SYSTICK
 	bool
@@ -97,11 +177,39 @@ config NRFX_TIMER4
 config NRFX_TWI
 	bool
 
+config NRFX_TWI0
+	bool
+	select NRFX_TWI
+
+config NRFX_TWI1
+	bool
+	select NRFX_TWI
+
 config NRFX_TWIM
 	bool
 
+config NRFX_TWIM0
+	bool
+	select NRFX_TWIM
+
+config NRFX_TWIM1
+	bool
+	select NRFX_TWIM
+
+config NRFX_TWIM2
+	bool
+	select NRFX_TWIM
+
+config NRFX_TWIM3
+	bool
+	select NRFX_TWIM
+
 config NRFX_UART
 	bool
+
+config NRFX_UART0
+	bool
+	select NRFX_UART
 
 config NRFX_UARTE
 	bool

--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -10,229 +10,296 @@ config HAS_NORDIC_DRIVERS
 config HAS_NRFX
 	bool
 
-config NRFX_PRS
-	bool
-
-config NRFX_PRS_BOX_0
-	bool
-	select NRFX_PRS
-
-config NRFX_PRS_BOX_1
-	bool
-	select NRFX_PRS
-
-config NRFX_PRS_BOX_2
-	bool
-	select NRFX_PRS
-
-config NRFX_PRS_BOX_3
-	bool
-	select NRFX_PRS
-
-config NRFX_PRS_BOX_4
-	bool
-	select NRFX_PRS
+menu "nrfx drivers"
+	depends on HAS_NRFX
 
 config NRFX_ADC
-	bool
+	bool "Enable ADC driver"
+	depends on HAS_HW_NRF_ADC
 
 config NRFX_CLOCK
-	bool
+	bool "Enable CLOCK driver"
+	depends on HAS_HW_NRF_CLOCK
 
 config NRFX_DPPI
-	bool
+	bool "Enable DPPI allocator"
+	depends on HAS_HW_NRF_DPPIC
 
 config NRFX_GPIOTE
-	bool
+	bool "Enable GPIOTE driver"
+	depends on HAS_HW_NRF_GPIOTE
 
 config NRFX_NFCT
-	bool
+	bool "Enable NFCT driver"
+	depends on HAS_HW_NRF_NFCT
 	select NRFX_TIMER4
 
 config NRFX_NVMC
-	bool
+	bool "Enable NVMC driver"
 
 config NRFX_PPI
-	bool
+	bool "Enable PPI allocator"
+	depends on HAS_HW_NRF_PPI
 
 config NRFX_PWM
-	bool
+	bool "Enable PWM driver"
+	depends on HAS_HW_NRF_PWM0 || HAS_HW_NRF_PWM1 || \
+		   HAS_HW_NRF_PWM2 || HAS_HW_NRF_PWM3
 
 config NRFX_PWM0
-	bool
+	bool "Enable PWM0 instance"
+	depends on HAS_HW_NRF_PWM0
 	select NRFX_PWM
 
 config NRFX_PWM1
-	bool
+	bool "Enable PWM1 instance"
+	depends on HAS_HW_NRF_PWM1
 	select NRFX_PWM
 
 config NRFX_PWM2
-	bool
+	bool "Enable PWM2 instance"
+	depends on HAS_HW_NRF_PWM2
 	select NRFX_PWM
 
 config NRFX_PWM3
-	bool
+	bool "Enable PWM3 instance"
+	depends on HAS_HW_NRF_PWM3
 	select NRFX_PWM
 
 config NRFX_QDEC
-	bool
+	bool "Enable QDEC driver"
+	depends on HAS_HW_NRF_QDEC
 
 config NRFX_RTC
-	bool
+	bool "Enable RTC driver"
+	depends on HAS_HW_NRF_RTC0 || HAS_HW_NRF_RTC1 || HAS_HW_NRF_RTC2
 
 config NRFX_RTC0
-	bool
+	bool "Enable RTC0 instance"
+	depends on HAS_HW_NRF_RTC0
 	select NRFX_RTC
 
 config NRFX_RTC1
-	bool
+	bool "Enable RTC1 instance"
+	depends on HAS_HW_NRF_RTC1
 	select NRFX_RTC
 
 config NRFX_RTC2
-	bool
+	bool "Enable RTC2 instance"
+	depends on HAS_HW_NRF_RTC2
 	select NRFX_RTC
 
 config NRFX_SAADC
-	bool
+	bool "Enable SAADC driver"
+	depends on HAS_HW_NRF_SAADC
 
 config NRFX_SPI
-	bool
+	bool "Enable SPI driver"
+	depends on HAS_HW_NRF_SPI0 || HAS_HW_NRF_SPI1 || HAS_HW_NRF_SPI2
 
 config NRFX_SPI0
-	bool
+	bool "Enable SPI0 instance"
+	depends on HAS_HW_NRF_SPI0
 	select NRFX_SPI
 
 config NRFX_SPI1
-	bool
+	bool "Enable SPI1 instance"
+	depends on HAS_HW_NRF_SPI1
 	select NRFX_SPI
 
 config NRFX_SPI2
-	bool
+	bool "Enable SPI2 instance"
+	depends on HAS_HW_NRF_SPI2
 	select NRFX_SPI
 
 config NRFX_SPIM
-	bool
+	bool "Enable SPIM driver"
+	depends on HAS_HW_NRF_SPIM0 || HAS_HW_NRF_SPIM1 || \
+		   HAS_HW_NRF_SPIM2 || HAS_HW_NRF_SPIM3
 
 config NRFX_SPIM0
-	bool
+	bool "Enable SPIM0 instance"
+	depends on HAS_HW_NRF_SPIM0
 	select NRFX_SPIM
 
 config NRFX_SPIM1
-	bool
+	bool "Enable SPIM1 instance"
+	depends on HAS_HW_NRF_SPIM1
 	select NRFX_SPIM
 
 config NRFX_SPIM2
-	bool
+	bool "Enable SPIM2 instance"
+	depends on HAS_HW_NRF_SPIM2
 	select NRFX_SPIM
 
 config NRFX_SPIM3
-	bool
+	bool "Enable SPIM3 instance"
+	depends on HAS_HW_NRF_SPIM3
 	select NRFX_SPIM
 
 config NRFX_SPIS
-	bool
+	bool "Enable SPIS driver"
+	depends on HAS_HW_NRF_SPIS0 || HAS_HW_NRF_SPIS1 || \
+		   HAS_HW_NRF_SPIS2 || HAS_HW_NRF_SPIS3
 
 config NRFX_SPIS0
-	bool
+	bool "Enable SPIS0 instance"
+	depends on HAS_HW_NRF_SPIS0
 	select NRFX_SPIS
 
 config NRFX_SPIS1
-	bool
+	bool "Enable SPIS1 instance"
+	depends on HAS_HW_NRF_SPIS1
 	select NRFX_SPIS
 
 config NRFX_SPIS2
-	bool
+	bool "Enable SPIS2 instance"
+	depends on HAS_HW_NRF_SPIS2
 	select NRFX_SPIS
 
 config NRFX_SPIS3
-	bool
+	bool "Enable SPIS3 instance"
+	depends on HAS_HW_NRF_SPIS3
 	select NRFX_SPIS
 
 config NRFX_SYSTICK
-	bool
+	bool "Enable SYSTICK driver"
+	depends on CPU_CORTEX_M_HAS_SYSTICK
 
 config NRFX_TIMER
-	bool
+	bool "Enable TIMER driver"
+	depends on HAS_HW_NRF_TIMER0 || HAS_HW_NRF_TIMER1 || \
+		   HAS_HW_NRF_TIMER2 || HAS_HW_NRF_TIMER3 || \
+		   HAS_HW_NRF_TIMER4
 
 config NRFX_TIMER0
-	bool
+	bool "Enable TIMER0 instance"
+	depends on HAS_HW_NRF_TIMER0
 	select NRFX_TIMER
 
 config NRFX_TIMER1
-	bool
+	bool "Enable TIMER1 instance"
+	depends on HAS_HW_NRF_TIMER1
 	select NRFX_TIMER
 
 config NRFX_TIMER2
-	bool
+	bool "Enable TIMER2 instance"
+	depends on HAS_HW_NRF_TIMER2
 	select NRFX_TIMER
 
 config NRFX_TIMER3
-	bool
+	bool "Enable TIMER3 instance"
+	depends on HAS_HW_NRF_TIMER3
 	select NRFX_TIMER
 
 config NRFX_TIMER4
-	bool
+	bool "Enable TIMER4 instance"
+	depends on HAS_HW_NRF_TIMER4
 	select NRFX_TIMER
 
 config NRFX_TWI
-	bool
+	bool "Enable TWI driver"
+	depends on HAS_HW_NRF_TWI0 || HAS_HW_NRF_TWI1
 
 config NRFX_TWI0
-	bool
+	bool "Enable TWI0 instance"
+	depends on HAS_HW_NRF_TWI0
 	select NRFX_TWI
 
 config NRFX_TWI1
-	bool
+	bool "Enable TWI1 instance"
+	depends on HAS_HW_NRF_TWI1
 	select NRFX_TWI
 
 config NRFX_TWIM
-	bool
+	bool "Enable TWIM driver"
+	depends on HAS_HW_NRF_TWIM0 || HAS_HW_NRF_TWIM1 || \
+		   HAS_HW_NRF_TWIM2 || HAS_HW_NRF_TWIM3
 
 config NRFX_TWIM0
-	bool
+	bool "Enable TWIM0 instance"
+	depends on HAS_HW_NRF_TWIM0
 	select NRFX_TWIM
 
 config NRFX_TWIM1
-	bool
+	bool "Enable TWIM1 instance"
+	depends on HAS_HW_NRF_TWIM1
 	select NRFX_TWIM
 
 config NRFX_TWIM2
-	bool
+	bool "Enable TWIM2 instance"
+	depends on HAS_HW_NRF_TWIM2
 	select NRFX_TWIM
 
 config NRFX_TWIM3
-	bool
+	bool "Enable TWIM3 instance"
+	depends on HAS_HW_NRF_TWIM3
 	select NRFX_TWIM
 
 config NRFX_UART
-	bool
+	bool "Enable UART driver"
+	depends on HAS_HW_NRF_UART0
 
 config NRFX_UART0
-	bool
+	bool "Enable UART0 instance"
+	depends on HAS_HW_NRF_UART0
 	select NRFX_UART
 
 config NRFX_UARTE
-	bool
+	bool "Enable UARTE driver"
+	depends on HAS_HW_NRF_UARTE0 || HAS_HW_NRF_UARTE1 || \
+		   HAS_HW_NRF_UARTE2 || HAS_HW_NRF_UARTE3
 
 config NRFX_UARTE0
-	bool
+	bool "Enable UARTE0 instance"
+	depends on HAS_HW_NRF_UARTE0
 	select NRFX_UARTE
 
 config NRFX_UARTE1
-	bool
+	bool "Enable UARTE1 instance"
+	depends on HAS_HW_NRF_UARTE1
 	select NRFX_UARTE
 
 config NRFX_UARTE2
-	bool
+	bool "Enable UARTE2 instance"
+	depends on HAS_HW_NRF_UARTE2
 	select NRFX_UARTE
 
 config NRFX_UARTE3
-	bool
+	bool "Enable UARTE3 instance"
+	depends on HAS_HW_NRF_UARTE3
 	select NRFX_UARTE
 
 config NRFX_USBD
-	bool
+	bool "Enable USBD driver"
+	depends on HAS_HW_NRF_USBD
 	select NRFX_SYSTICK
 
 config NRFX_WDT
-	bool
+	bool "Enable WDT driver"
+	depends on HAS_HW_NRF_WDT
+
+config NRFX_PRS
+	bool "Enable Peripheral Resource Sharing module"
+
+config NRFX_PRS_BOX_0
+	bool "Enable PRS box 0"
+	select NRFX_PRS
+
+config NRFX_PRS_BOX_1
+	bool "Enable PRS box 1"
+	select NRFX_PRS
+
+config NRFX_PRS_BOX_2
+	bool "Enable PRS box 2"
+	select NRFX_PRS
+
+config NRFX_PRS_BOX_3
+	bool "Enable PRS box 3"
+	select NRFX_PRS
+
+config NRFX_PRS_BOX_4
+	bool "Enable PRS box 4"
+	select NRFX_PRS
+
+endmenu

--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -21,6 +21,10 @@ config NRFX_CLOCK
 	bool "Enable CLOCK driver"
 	depends on HAS_HW_NRF_CLOCK
 
+config NRFX_COMP
+	bool "Enable COMP driver"
+	depends on HAS_HW_NRF_COMP
+
 config NRFX_DPPI
 	bool "Enable DPPI allocator"
 	depends on HAS_HW_NRF_DPPIC
@@ -29,6 +33,14 @@ config NRFX_GPIOTE
 	bool "Enable GPIOTE driver"
 	depends on HAS_HW_NRF_GPIOTE
 
+config NRFX_I2S
+	bool "Enable I2S driver"
+	depends on HAS_HW_NRF_I2S
+
+config NRFX_LPCOMP
+	bool "Enable LPCOMP driver"
+	depends on HAS_HW_NRF_LPCOMP
+
 config NRFX_NFCT
 	bool "Enable NFCT driver"
 	depends on HAS_HW_NRF_NFCT
@@ -36,6 +48,14 @@ config NRFX_NFCT
 
 config NRFX_NVMC
 	bool "Enable NVMC driver"
+
+config NRFX_PDM
+	bool "Enable PDM driver"
+	depends on HAS_HW_NRF_PDM
+
+config NRFX_POWER
+	bool "Enable POWER driver"
+	depends on HAS_HW_NRF_POWER
 
 config NRFX_PPI
 	bool "Enable PPI allocator"
@@ -69,6 +89,14 @@ config NRFX_PWM3
 config NRFX_QDEC
 	bool "Enable QDEC driver"
 	depends on HAS_HW_NRF_QDEC
+
+config NRFX_QSPI
+	bool "Enable QSPI driver"
+	depends on HAS_HW_NRF_QSPI
+
+config NRFX_RNG
+	bool "Enable RNG driver"
+	depends on HAS_HW_NRF_RNG
 
 config NRFX_RTC
 	bool "Enable RTC driver"
@@ -162,9 +190,20 @@ config NRFX_SPIS3
 	depends on HAS_HW_NRF_SPIS3
 	select NRFX_SPIS
 
+config NRFX_SWI
+	bool "Enable SWI/EGU allocator"
+	depends on HAS_HW_NRF_EGU0 || HAS_HW_NRF_EGU1 || HAS_HW_NRF_EGU2 || \
+		   HAS_HW_NRF_EGU3 || HAS_HW_NRF_EGU4 || HAS_HW_NRF_EGU5 || \
+		   HAS_HW_NRF_SWI0 || HAS_HW_NRF_SWI1 || HAS_HW_NRF_SWI2 || \
+		   HAS_HW_NRF_SWI3 || HAS_HW_NRF_SWI4 || HAS_HW_NRF_SWI5
+
 config NRFX_SYSTICK
 	bool "Enable SYSTICK driver"
 	depends on CPU_CORTEX_M_HAS_SYSTICK
+
+config NRFX_TEMP
+	bool "Enable TEMP driver"
+	depends on HAS_HW_NRF_TEMP
 
 config NRFX_TIMER
 	bool "Enable TIMER driver"
@@ -235,6 +274,31 @@ config NRFX_TWIM3
 	bool "Enable TWIM3 instance"
 	depends on HAS_HW_NRF_TWIM3
 	select NRFX_TWIM
+
+config NRFX_TWIS
+	bool "Enable TWIS driver"
+	depends on HAS_HW_NRF_TWIS0 || HAS_HW_NRF_TWIS1 || \
+		   HAS_HW_NRF_TWIS2 || HAS_HW_NRF_TWIS3
+
+config NRFX_TWIS0
+	bool "Enable TWIS0 instance"
+	depends on HAS_HW_NRF_TWIS0
+	select NRFX_TWIS
+
+config NRFX_TWIS1
+	bool "Enable TWIS1 instance"
+	depends on HAS_HW_NRF_TWIS1
+	select NRFX_TWIS
+
+config NRFX_TWIS2
+	bool "Enable TWIS2 instance"
+	depends on HAS_HW_NRF_TWIS2
+	select NRFX_TWIS
+
+config NRFX_TWIS3
+	bool "Enable TWIS3 instance"
+	depends on HAS_HW_NRF_TWIS3
+	select NRFX_TWIS
 
 config NRFX_UART
 	bool "Enable UART driver"

--- a/soc/arm/nordic_nrf/nrf91/soc.h
+++ b/soc/arm/nordic_nrf/nrf91/soc.h
@@ -19,7 +19,7 @@
 #include <generated_dts_board.h>
 
 /* Add include for peripheral base address mappings */
-#include <nrfx_config_nrf9160.h>
+#include <nrfx_config.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: 7bf2d404d0bf7f36d77d5090b5207f8b4676776c
+      revision: ff3265342f2ef97b5abf4ba7d38b8011a45360f3
       path: modules/hal/nordic
     - name: hal_openisa
       revision: be5c01f86c96500def5079bcc58d2baefdffb6c8


### PR DESCRIPTION
This set of commits is intended to facilitate the use of nrfx drivers, and hence nRF peripherals, in Zephyr applications, especially in cases when there are no corresponding Zephyr driver shims.

---

Requires https://github.com/zephyrproject-rtos/hal_nordic/pull/2 to go in first.