### PR TITLE
scripts: Suppress/fix undefined variable pylint warnings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,7 +56,7 @@ extensions = [
 ]
 
 # Only use SVG converter when it is really needed, e.g. LaTeX.
-if tags.has("svgconvert"):
+if tags.has("svgconvert"):  # pylint: disable=undefined-variable
     extensions.append('sphinxcontrib.rsvgconverter')
 
 # Add any paths that contain templates here, relative to this directory.
@@ -182,7 +182,7 @@ html_theme_options = {
     'prev_next_buttons_location': None
 }
 
-if tags.has('release'):
+if tags.has('release'):  # pylint: disable=undefined-variable
     is_release = True
     docs_title = 'Docs / %s' %(version)
 else:

--- a/scripts/dts/dtlib.py
+++ b/scripts/dts/dtlib.py
@@ -3,6 +3,10 @@
 
 # Tip: You can view just the documentation with 'pydoc3 dtlib'
 
+# _init_tokens() builds names dynamically.
+#
+# pylint: disable=undefined-variable
+
 """
 A library for extracting information from .dts (Device Tree) files. See the
 documentation for the DT and Node classes for more information.

--- a/scripts/dts/testdtlib.py
+++ b/scripts/dts/testdtlib.py
@@ -1272,7 +1272,7 @@ foo
                 fail("expected {} to lead to {}, lead to {}"
                      .format(path, node_name, node.name))
         except dtlib.DTError:
-            fail("no node found for path " + alias)
+            fail("no node found for path " + path)
 
     def verify_path_error(path, msg):
         prefix = "expected looking up '{}' to generate the error '{}', " \

--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -3,6 +3,12 @@
 # Copyright (c) 2019, Nordic Semiconductor ASA and Ulf Magnusson
 # SPDX-License-Identifier: ISC
 
+# _load_images() builds names dynamically to avoid having to give them twice
+# (once for the variable and once for the filename). This forces consistency
+# too.
+#
+# pylint: disable=undefined-variable
+
 """
 Overview
 ========


### PR DESCRIPTION
dtlib.py and guiconfig.py do some hackery to build token and image
variable names, which triggers spurious pylint warnings like

    scripts/dts/dtlib.py:243:28: E0602: Undefined variable '_T_LABEL'
    (undefined-variable)

Suppress the warning for those files. The generated names get used in
lots of places.

Also suppress some warnings in doc/conf.py ('tags' is from Sphinx), and
fix a legitimate issue in scripts/dts/testdtlib.py.

This pylint check is useful enough to want enabled in the upcoming CI
check.