### PR TITLE
doc: west: v0.6.2 fixes a critical v0.6.1 bug

### DIFF
--- a/doc/guides/west/release-notes.rst
+++ b/doc/guides/west/release-notes.rst
@@ -1,8 +1,20 @@
 West Release Notes
 ##################
 
+v0.6.2
+******
+
+This point release fixes an error in the behavior of ``west
+update --fetch=smart``, introduced in v0.6.1.
+
+All v0.6.1 users must upgrade.
+
 v0.6.1
 ******
+
+.. warning::
+
+   Do not use this point release. Make sure to use v0.6.2 instead.
 
 The user-visible features in this point release are:
 


### PR DESCRIPTION
All v0.6.1 users must upgrade. Add release notes blurb.

@ioannisg @dbkinder  we really should get this into 2.0. Sorry for the last minute fire drill, but the docs change is small.