### PR TITLE
west: runners: Fix typo'd log.wrn() call

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -371,8 +371,8 @@ def _dump_context(command, args, runner_args, cached_runner_var):
             colorize=True)
 
     if cache is None:
-        log.warn('Missing or invalid CMake cache {}; there is no context.',
-                 'Use --build-dir to specify the build directory.')
+        log.wrn('Missing or invalid CMake cache; there is no context.',
+                'Use --build-dir to specify the build directory.')
         return
 
     log.inf('Build directory:', colorize=True)


### PR DESCRIPTION
Should be wrn() instead of warn(). Reported by pylint.

Also remove a {} from the message. It's not being formatted.