### PR TITLE
west: commands: Make functions that don't use 'self' static

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -94,18 +94,21 @@ class NetworkPortHelper:
         cmd = ['netstat', '-a', '-n', '-p', 'tcp']
         return self._parser_darwin(cmd)
 
-    def _parser_windows(self, cmd):
+    @staticmethod
+    def _parser_windows(cmd):
         out = subprocess.check_output(cmd).split(b'\r\n')
         used_bytes = [x.split()[1].rsplit(b':', 1)[1] for x in out
                       if x.startswith(b'  TCP')]
         return {int(b) for b in used_bytes}
 
-    def _parser_linux(self, cmd):
+    @staticmethod
+    def _parser_linux(cmd):
         out = subprocess.check_output(cmd).splitlines()[1:]
         used_bytes = [s.split()[3].rsplit(b':', 1)[1] for s in out]
         return {int(b) for b in used_bytes}
 
-    def _parser_darwin(self, cmd):
+    @staticmethod
+    def _parser_darwin(cmd):
         out = subprocess.check_output(cmd).split(b'\n')
         used_bytes = [x.split()[3].rsplit(b':', 1)[1] for x in out
                       if x.startswith(b'tcp')]
@@ -152,7 +155,8 @@ class BuildConfiguration:
                 option, value = line.split('=', 1)
                 self.options[option] = self._parse_value(value)
 
-    def _parse_value(self, value):
+    @staticmethod
+    def _parse_value(value):
         if value.startswith('"') or value.startswith("'"):
             return value.split()
         try:
@@ -448,7 +452,8 @@ class ZephyrBinaryRunner(abc.ABC):
 
         In case of an unsupported command, raise a ValueError.'''
 
-    def require(self, program):
+    @staticmethod
+    def require(program):
         '''Require that a program is installed before proceeding.
 
         :param program: name of the program that is required,

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -264,7 +264,8 @@ class ImgtoolSigner(Signer):
             log.dbg(quote_sh_list(sign_hex))
             subprocess.check_call(sign_hex)
 
-    def get_cfg(self, command, bcfg, item):
+    @staticmethod
+    def get_cfg(command, bcfg, item):
         try:
             return bcfg[item]
         except KeyError:

--- a/scripts/west_commands/zephyr_ext_common.py
+++ b/scripts/west_commands/zephyr_ext_common.py
@@ -17,7 +17,8 @@ from runners.core import RunnerConfig
 class Forceable(WestCommand):
     '''WestCommand subclass for commands with a --force option.'''
 
-    def add_force_arg(self, parser):
+    @staticmethod
+    def add_force_arg(parser):
         '''Add a -f / --force option to the parser.'''
         parser.add_argument('-f', '--force', action='store_true',
                             help='Ignore any errors and try to proceed')


### PR DESCRIPTION
Fixes this pylint warning:

    R0201: Method could be a function (no-self-use)

Another option would be to turn them into regular functions, but that'd
be a bigger change.