### PR TITLE
doc: application.py: Make functions that don't use 'self' static

### DIFF
--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -285,7 +285,8 @@ class ZephyrAppCommandsDirective(Directive):
 
         return content
 
-    def _mkdir(self, mkdir, build_dir, host_os, skip_config):
+    @staticmethod
+    def _mkdir(mkdir, build_dir, host_os, skip_config):
         content = []
         if skip_config:
             content.append("# If you already made a build directory ({}) and ran cmake, just 'cd {}' instead.".format(build_dir, build_dir))  # noqa: E501
@@ -298,7 +299,8 @@ class ZephyrAppCommandsDirective(Directive):
             content.append('mkdir {} & cd {}'.format(build_dir, build_dir))
         return content
 
-    def _cmake_args(self, **kwargs):
+    @staticmethod
+    def _cmake_args(**kwargs):
         board = kwargs['board']
         shield = kwargs['shield']
         conf = kwargs['conf']


### PR DESCRIPTION
Fixes this pylint warning:

    R0201: Method could be a function (no-self-use)

Another option would be to turn them into regular functions, but that'd
be a bigger change.

Fixing pylint warnings for a CI check.