### PR TITLE
scripts: dtlib: Refactor to fix two no-self-use pylint warnings

### DIFF
--- a/scripts/dts/dtlib.py
+++ b/scripts/dts/dtlib.py
@@ -236,7 +236,7 @@ class DT:
                     _append_no_dup(node.labels, label)
 
             elif tok.id is _T_DEL_NODE:
-                self._del_node(self._next_ref2node())
+                self._next_ref2node()._del()
                 self._expect_token(";")
 
             elif tok.id is _T_OMIT_IF_NO_REF:
@@ -326,7 +326,7 @@ class DT:
                         self._parse_error(
                             "/omit-if-no-ref/ can only be used on nodes")
 
-                    prop = self._node_prop(node, tok.val)
+                    prop = node._get_prop(tok.val)
 
                     if self._check_token("="):
                         self._parse_assignment(prop)
@@ -342,7 +342,7 @@ class DT:
                 if tok2.id is not _T_PROPNODENAME:
                     self._parse_error("expected node name")
                 if tok2.val in node.nodes:
-                    self._del_node(node.nodes[tok2.val])
+                    node.nodes[tok2.val]._del()
                 self._expect_token(";")
 
             elif tok.id is _T_DEL_PROP:
@@ -537,16 +537,6 @@ class DT:
             prop._add_marker(_REF_LABEL, tok.val)
             self._next_token()
 
-    def _node_prop(self, node, name):
-        # Returns the property named 'name' on the Node 'node', creating it if
-        # it doesn't already exist
-
-        prop = node.props.get(name)
-        if not prop:
-            prop = Property(node, name)
-            node.props[name] = prop
-        return prop
-
     def _node_phandle(self, node):
         # Returns the phandle for Node 'node', creating a new phandle if the
         # node has no phandle, and fixing up the value for existing
@@ -571,11 +561,6 @@ class DT:
             node.props["phandle"] = phandle_prop
 
         return phandle_prop.value
-
-    def _del_node(self, node):
-        # Removes the Node 'node' from the tree
-
-        node.parent.nodes.pop(node.name)
 
     # Expression evaluation
 
@@ -1057,7 +1042,7 @@ class DT:
         # iteration' errors
         for node in tuple(self.node_iter()):
             if node._omit_if_no_ref and not node._is_referenced:
-                self._del_node(node)
+                node._del()
 
     def _register_labels(self):
         # Checks for duplicate labels and registers labels in label2node,
@@ -1279,6 +1264,21 @@ class Node:
         yield self
         for node in self.nodes.values():
             yield from node.node_iter()
+
+    def _get_prop(self, name):
+        # Returns the property named 'name' on the node, creating it if it
+        # doesn't already exist
+
+        prop = self.props.get(name)
+        if not prop:
+            prop = Property(self, name)
+            self.props[name] = prop
+        return prop
+
+    def _del(self):
+        # Removes the node from the tree
+
+        self.parent.nodes.pop(self.name)
 
     def __str__(self):
         """


### PR DESCRIPTION
Move some property fetching and node deletion code from the DT class
over to the Node class. Reads pretty nicely, and indirectly gets rid of
two unused 'self' arguments.