### PR TITLE
arm: mps: docs: note on qemu usage of boards

### DIFF
--- a/boards/arm/mps2_an385/doc/index.rst
+++ b/boards/arm/mps2_an385/doc/index.rst
@@ -20,9 +20,18 @@ the following devices:
      :height: 335px
      :alt: ARM V2M MPS2
 
+In addition to enabling actual hardware usage, this board configuration can
+also use QEMU to emulate the AN385 platform running on the MPS2+.
+
 More information about the board can be found at the `V2M MPS2 Website`_.
 
 The Application Note AN385 can be found at `Application Note AN385`_.
+
+.. note::
+   This board configuration makes no claims about its suitability for use
+   with actual MPS2 hardware systems using AN385, or any other hardware
+   system. It has been tested on actual hardware, but it's primary purpose is
+   for use with qemu and unit tests.
 
 Hardware
 ********

--- a/boards/arm/mps2_an385/doc/index.rst
+++ b/boards/arm/mps2_an385/doc/index.rst
@@ -30,8 +30,8 @@ The Application Note AN385 can be found at `Application Note AN385`_.
 .. note::
    This board configuration makes no claims about its suitability for use
    with actual MPS2 hardware systems using AN385, or any other hardware
-   system. It has been tested on actual hardware, but it's primary purpose is
-   for use with qemu and unit tests.
+   system. It has been tested on actual hardware, but its primary purpose is
+   for use with QEMU and unit tests.
 
 Hardware
 ********

--- a/boards/arm/mps2_an521/doc/index.rst
+++ b/boards/arm/mps2_an521/doc/index.rst
@@ -21,7 +21,16 @@ CPU and the following devices:
      :height: 546px
      :alt: ARM MPS2+ AN521
 
+In addition to enabling actual hardware usage, this board configuration can
+also use QEMU to emulate the AN521 platform running on the MPS2+.
+
 More information about the board can be found at the `MPS2 FPGA Website`_.
+
+.. note::
+   This board configuration makes no claims about its suitability for use
+   with actual MPS2 hardware systems using AN521, or any other hardware
+   system. It has been tested on actual hardware, but it's primary purpose is
+   for use with qemu and unit tests.
 
 Hardware
 ********

--- a/boards/arm/mps2_an521/doc/index.rst
+++ b/boards/arm/mps2_an521/doc/index.rst
@@ -29,8 +29,8 @@ More information about the board can be found at the `MPS2 FPGA Website`_.
 .. note::
    This board configuration makes no claims about its suitability for use
    with actual MPS2 hardware systems using AN521, or any other hardware
-   system. It has been tested on actual hardware, but it's primary purpose is
-   for use with qemu and unit tests.
+   system. It has been tested on actual hardware, but its primary purpose is
+   for use with QEMU and unit tests.
 
 Hardware
 ********


### PR DESCRIPTION
This commit adds a note alluding to the fact that these two boards are
primarily included for use with QEMU, but have been tested on actual
hardware as well where appropriate.

Resolves #18154 .

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>