### PR TITLE
intel_s1000_crb: messenger.py: Make endian_swap() static

### DIFF
--- a/boards/xtensa/intel_s1000_crb/support/messenger.py
+++ b/boards/xtensa/intel_s1000_crb/support/messenger.py
@@ -47,7 +47,8 @@ class Message:
             self.tx_data[index] = 0
         self.tx_index = 0
 
-    def endian_swap(self, dst, dst_offset, src):
+    @staticmethod
+    def endian_swap(dst, dst_offset, src):
         """
         Performs a byte swap of a 32-bit word to change it's endianness
         """


### PR DESCRIPTION
Doesn't use 'self'. Fixes this pylint warning:

    boards/xtensa/intel_s1000_crb/support/messenger.py:50:4: R0201:
    Method could be a function (no-self-use)

If this function is meant to be internal to messenger.py, then a better
option than @staticmethod might be to turn it into a regular function.

Fixing pylint warnings for a CI check.