### PR TITLE
logging: increase log_strdup_buf size for ~\0 terminator in log_strdup()

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -45,7 +45,7 @@ LOG_MODULE_REGISTER(log);
 
 struct log_strdup_buf {
 	atomic_t refcount;
-	char buf[CONFIG_LOG_STRDUP_MAX_STRING + 1]; /* for termination */
+	char buf[CONFIG_LOG_STRDUP_MAX_STRING + 2]; /* for ~\0 terminator string */
 };
 
 #define LOG_STRDUP_POOL_BUFFER_SIZE \


### PR DESCRIPTION
In `log_strdup` a 2-character terminator `~\0` is added to the `buf` in `log_strdup_buf`, but the size of buf is 1 (`CONFIG_LOG_STRDUP_MAX_STRING+1`, where `CONFIG_LOG_STRDUP_MAX_STRING==0`).  This increases the termination padding to 2 so that  `sizeof(dup->buf) - 2` ([as calculated in `log_strdup()`](https://github.com/zephyrproject-rtos/zephyr/blob/ee57741c8c4060724eae3f4963a05cfed5b79d8f/subsys/logging/log_core.c#L872)) is never negative.

Signed-off-by: Terri Oda <terri.oda@intel.com>