### PR TITLE
kconfiglib: Expose parsing location to Python preprocessor functions

### DIFF
--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -1696,7 +1696,7 @@ def _try_save(save_fn, filename, description):
         _set_status(msg)
         print(msg)
         return True
-    except (OSError, IOError) as e:
+    except EnvironmentError as e:
         messagebox.showerror(
             "Error saving " + description,
             "Error saving {} to '{}': {} (errno: {})"
@@ -1717,7 +1717,7 @@ def _try_load(filename):
         _set_status(msg)
         print(msg)
         return True
-    except (OSError, IOError) as e:
+    except EnvironmentError as e:
         messagebox.showerror(
             "Error loading configuration",
             "Error loading '{}': {} (errno: {})"
@@ -2119,7 +2119,10 @@ def _defaults_info(sc):
     if not sc.defaults:
         return ""
 
-    s = "Defaults:\n"
+    s = "Default"
+    if len(sc.defaults) > 1:
+        s += "s"
+    s += ":\n"
 
     for val, cond in sc.orig_defaults:
         s += "  - "

--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -503,6 +503,15 @@ expected by the function (excluding the implicit 'name' argument). If
 <max.args> is None, there is no upper limit to the number of arguments. Passing
 an invalid number of arguments will generate a KconfigError exception.
 
+Functions can access the current parsing location as kconf.filename/linenr.
+Accessing other fields of the Kconfig object is not safe. See the warning
+below.
+
+Keep in mind that for a variable defined like 'foo = $(fn)', 'fn' will be
+called only when 'foo' is expanded. If 'fn' uses the parsing location and the
+intent is to use the location of the assignment, you want 'foo := $(fn)'
+instead, which calls the function immediately.
+
 Once defined, user functions can be called from Kconfig in the same way as
 other preprocessor functions:
 
@@ -523,8 +532,7 @@ User-defined preprocessor functions are called as they're encountered at parse
 time, before all Kconfig files have been processed, and before the menu tree
 has been finalized. There are no guarantees that accessing Kconfig symbols or
 the menu tree via the 'kconf' parameter will work, and it could potentially
-lead to a crash. The 'kconf' parameter is provided for future extension (and
-because the predefined functions take it anyway).
+lead to a crash.
 
 Preferably, user-defined functions should be stateless.
 
@@ -546,7 +554,7 @@ from glob import iglob
 from os.path import dirname, exists, expandvars, islink, join, realpath
 
 
-VERSION = (12, 9, 0)
+VERSION = (12, 14, 0)
 
 
 # File layout:
@@ -788,6 +796,10 @@ class Kconfig(object):
 
       Like for srctree, only the value of $CONFIG_ when the configuration is
       loaded matters.
+
+    filename/linenr:
+      The current parsing location, for use in Python preprocessor functions.
+      See the module docstring.
     """
     __slots__ = (
         "_encoding",
@@ -795,7 +807,7 @@ class Kconfig(object):
         "_set_match",
         "_srctree_prefix",
         "_unset_match",
-        "_warn_no_prompt",
+        "_warn_assign_no_prompt",
         "choices",
         "comments",
         "config_prefix",
@@ -805,7 +817,6 @@ class Kconfig(object):
         "env_vars",
         "kconfig_filenames",
         "m",
-        "mainmenu_text",
         "menus",
         "missing_syms",
         "modules",
@@ -828,8 +839,8 @@ class Kconfig(object):
         # Parsing-related
         "_parsing_kconfigs",
         "_readline",
-        "_filename",
-        "_linenr",
+        "filename",
+        "linenr",
         "_include_path",
         "_filestack",
         "_line",
@@ -853,9 +864,13 @@ class Kconfig(object):
         default warning settings (KCONFIG_WARN_UNDEF and
         KCONFIG_WARN_UNDEF_ASSIGN).
 
-        Raises KconfigError on syntax/semantic errors, and (possibly a subclass
-        of) IOError on IO errors ('errno', 'strerror', and 'filename' are
-        available). Note that IOError can be caught as OSError on Python 3.
+        Raises KconfigError on syntax/semantic errors, and OSError or (possibly
+        a subclass of) IOError on IO errors ('errno', 'strerror', and
+        'filename' are available). Note that IOError is an alias for OSError on
+        Python 3, so it's enough to catch OSError there. If you need Python 2/3
+        compatibility, it's easiest to catch EnvironmentError, which is a
+        common base class of OSError/IOError on Python 2 and an alias for
+        OSError on Python 3.
 
         filename (default: "Kconfig"):
           The Kconfig file to load. For the Linux kernel, you'll want "Kconfig"
@@ -891,8 +906,9 @@ class Kconfig(object):
           True/False.
 
         encoding (default: "utf-8"):
-          The encoding to use when reading and writing files. If None, the
-          encoding specified in the current locale will be used.
+          The encoding to use when reading and writing files, and when decoding
+          output from commands run via $(shell). If None, the encoding
+          specified in the current locale will be used.
 
           The "utf-8" default avoids exceptions on systems that are configured
           to use the C locale, which implies an ASCII encoding.
@@ -904,40 +920,35 @@ class Kconfig(object):
 
           Related PEP: https://www.python.org/dev/peps/pep-0538/
         """
+        self._encoding = encoding
+
         self.srctree = os.getenv("srctree", "")
         # A prefix we can reliably strip from glob() results to get a filename
         # relative to $srctree. relpath() can cause issues for symlinks,
         # because it assumes symlink/../foo is the same as foo/.
         self._srctree_prefix = realpath(self.srctree) + os.sep
 
-        self.config_prefix = os.getenv("CONFIG_", "CONFIG_")
-
-        # Regular expressions for parsing .config files
-        self._set_match = _re_match(self.config_prefix + r"([^=]+)=(.*)")
-        self._unset_match = \
-            _re_match(r"# {}([^ ]+) is not set".format(self.config_prefix))
-
-
-        self.warnings = []
-
         self.warn = warn
         self.warn_to_stderr = warn_to_stderr
         self.warn_assign_undef = os.getenv("KCONFIG_WARN_UNDEF_ASSIGN") == "y"
-        self.warn_assign_override = self.warn_assign_redun = True
+        self.warn_assign_override = True
+        self.warn_assign_redun = True
+        self._warn_assign_no_prompt = True
 
+        self.warnings = []
 
-        self._encoding = encoding
-
+        self.config_prefix = os.getenv("CONFIG_", "CONFIG_")
+        # Regular expressions for parsing .config files
+        self._set_match = _re_match(self.config_prefix + r"([^=]+)=(.*)")
+        self._unset_match = _re_match(r"# {}([^ ]+) is not set".format(
+            self.config_prefix))
 
         self.syms = {}
         self.const_syms = {}
         self.defined_syms = []
-
         self.missing_syms = []
-
         self.named_choices = {}
         self.choices = []
-
         self.menus = []
         self.comments = []
 
@@ -959,7 +970,6 @@ class Kconfig(object):
         for nmy in "n", "m", "y":
             sym = self.const_syms[nmy]
             sym.rev_dep = sym.weak_rev_dep = sym.direct_dep = self.n
-
 
         # Maps preprocessor variables names to Variable instances
         self.variables = {}
@@ -983,10 +993,9 @@ class Kconfig(object):
         except ImportError:
             pass
 
-
-        # This is used to determine whether previously unseen symbols should be
-        # registered. They shouldn't be if we parse expressions after parsing,
-        # as part of Kconfig.eval_string().
+        # This determines whether previously unseen symbols are registered.
+        # They shouldn't be if we parse expressions after parsing, as part of
+        # Kconfig.eval_string().
         self._parsing_kconfigs = True
 
         self.modules = self._lookup_sym("MODULES")
@@ -1010,45 +1019,43 @@ class Kconfig(object):
         self.kconfig_filenames = [filename]
         self.env_vars = set()
 
-        # Used to avoid retokenizing lines when we discover that they're not
-        # part of the construct currently being parsed. This is kinda like an
-        # unget operation.
-        self._reuse_tokens = False
-
         # Keeps track of the location in the parent Kconfig files. Kconfig
         # files usually source other Kconfig files. See _enter_file().
         self._filestack = []
         self._include_path = ()
 
         # The current parsing location
-        self._filename = filename
-        self._linenr = 0
+        self.filename = filename
+        self.linenr = 0
+
+        # Used to avoid retokenizing lines when we discover that they're not
+        # part of the construct currently being parsed. This is kinda like an
+        # unget operation.
+        self._reuse_tokens = False
 
         # Open the top-level Kconfig file. Store the readline() method directly
         # as a small optimization.
         self._readline = self._open(join(self.srctree, filename), "r").readline
 
         try:
-            # Parse everything
+            # Parse the Kconfig files
             self._parse_block(None, self.top_node, self.top_node)
+            self.top_node.list = self.top_node.next
+            self.top_node.next = None
         except UnicodeDecodeError as e:
-            _decoding_error(e, self._filename)
+            _decoding_error(e, self.filename)
 
         # Close the top-level Kconfig file. __self__ fetches the 'file' object
         # for the method.
         self._readline.__self__.close()
 
-        self.top_node.list = self.top_node.next
-        self.top_node.next = None
-
         self._parsing_kconfigs = False
+
+        # Do various menu tree post-processing
+        self._finalize_node(self.top_node, self.y)
 
         self.unique_defined_syms = _ordered_unique(self.defined_syms)
         self.unique_choices = _ordered_unique(self.choices)
-
-        # Do various post-processing on the menu tree
-        self._finalize_tree(self.top_node, self.y)
-
 
         # Do sanity checks. Some of these depend on everything being finalized.
         self._check_sym_sanity()
@@ -1060,7 +1067,6 @@ class Kconfig(object):
            os.getenv("KCONFIG_STRICT") == "y":
 
             self._check_undef_syms()
-
 
         # Build Symbol._dependents for all symbols and choices
         self._build_dep()
@@ -1074,10 +1080,12 @@ class Kconfig(object):
         # awkward during dependency loop detection
         self._add_choice_deps()
 
-
-        self._warn_no_prompt = True
-
-        self.mainmenu_text = self.top_node.prompt[0]
+    @property
+    def mainmenu_text(self):
+        """
+        See the class documentation.
+        """
+        return self.top_node.prompt[0]
 
     @property
     def defconfig_filename(self):
@@ -1090,7 +1098,7 @@ class Kconfig(object):
                     try:
                         with self._open_config(filename.str_value) as f:
                             return f.name
-                    except IOError:
+                    except EnvironmentError:
                         continue
 
         return None
@@ -1113,9 +1121,8 @@ class Kconfig(object):
         True, and appended to otherwise. See the documentation for
         Kconfig.missing_syms as well.
 
-        Raises (possibly a subclass of) IOError on IO errors ('errno',
-        'strerror', and 'filename' are available). Note that IOError can be
-        caught as OSError on Python 3.
+        See the Kconfig.__init__() docstring for raised exceptions
+        (OSError/IOError). KconfigError is never raised here.
 
         filename (default: None):
           Path to load configuration from (a string). Respects $srctree if set
@@ -1181,15 +1188,16 @@ class Kconfig(object):
 
         # Disable the warning about assigning to symbols without prompts. This
         # is normal and expected within a .config file.
-        self._warn_no_prompt = False
+        self._warn_assign_no_prompt = False
 
-        # This stub only exists to make sure _warn_no_prompt gets reenabled
+        # This stub only exists to make sure _warn_assign_no_prompt gets
+        # reenabled
         try:
             self._load_config(filename, replace)
         except UnicodeDecodeError as e:
             _decoding_error(e, filename)
         finally:
-            self._warn_no_prompt = True
+            self._warn_assign_no_prompt = True
 
         return ("Loaded" if replace else "Merged") + msg
 
@@ -1427,6 +1435,9 @@ class Kconfig(object):
         like the modification time and possibly triggering redundant work in
         build tools.
 
+        See the Kconfig.__init__() docstring for raised exceptions
+        (OSError/IOError). KconfigError is never raised here.
+
         filename (default: None):
           Filename to save configuration to (a string).
 
@@ -1548,7 +1559,7 @@ class Kconfig(object):
 
             elif expr_value(node.dep) and \
                  ((item is MENU and expr_value(node.visibility)) or
-                   item is COMMENT):
+                  item is COMMENT):
 
                 add("\n#\n# {}\n#\n".format(node.prompt[0]))
                 after_end_comment = False
@@ -1565,6 +1576,9 @@ class Kconfig(object):
         configuration files can serve as a more manageable configuration format
         compared to a "full" .config file, especially when configurations files
         are merged or edited by hand.
+
+        See the Kconfig.__init__() docstring for raised exceptions
+        (OSError/IOError). KconfigError is never raised here.
 
         filename:
           Self-explanatory.
@@ -1612,7 +1626,7 @@ class Kconfig(object):
             # to n or the symbol to m in those cases).
             if sym.choice and \
                not sym.choice.is_optional and \
-               sym.choice._get_selection_from_defaults() is sym and \
+               sym.choice._selection_from_defaults() is sym and \
                sym.orig_type is BOOL and \
                sym.tri_value == 2:
                 continue
@@ -1629,6 +1643,9 @@ class Kconfig(object):
 
         This function is intended to be called during each build, before
         compiling source files that depend on configuration symbols.
+
+        See the Kconfig.__init__() docstring for raised exceptions
+        (OSError/IOError). KconfigError is never raised here.
 
         path:
           Path to directory
@@ -1740,7 +1757,7 @@ class Kconfig(object):
 
         try:
             auto_conf = self._open(join(path, "auto.conf"), "r")
-        except IOError as e:
+        except EnvironmentError as e:
             if e.errno == errno.ENOENT:
                 # No old values
                 return
@@ -1847,12 +1864,12 @@ class Kconfig(object):
     def eval_string(self, s):
         """
         Returns the tristate value of the expression 's', represented as 0, 1,
-        and 2 for n, m, and y, respectively. Raises KconfigError if syntax
-        errors are detected in 's'. Warns if undefined symbols are referenced.
+        and 2 for n, m, and y, respectively. Raises KconfigError on syntax
+        errors. Warns if undefined symbols are referenced.
 
         As an example, if FOO and BAR are tristate symbols at least one of
-        which has the value y, then config.eval_string("y && (FOO || BAR)")
-        returns 2 (y).
+        which has the value y, then eval_string("y && (FOO || BAR)") returns
+        2 (y).
 
         To get the string value of non-bool/tristate symbols, use
         Symbol.str_value. eval_string() always returns a tristate value, and
@@ -1867,7 +1884,7 @@ class Kconfig(object):
         # an expression can never appear at the beginning of a line). We have
         # to monkey-patch things a bit here to reuse it.
 
-        self._filename = None
+        self.filename = None
 
         self._tokens = self._tokenize("if " + s)
         # Strip "if " to avoid giving confusing error messages
@@ -1881,7 +1898,7 @@ class Kconfig(object):
         Removes any user values from all symbols, as if Kconfig.load_config()
         or Symbol.set_value() had never been called.
         """
-        self._warn_no_prompt = False
+        self._warn_assign_no_prompt = False
         try:
             # set_value() already rejects undefined symbols, and they don't
             # need to be invalidated (because their value never changes), so we
@@ -1892,7 +1909,7 @@ class Kconfig(object):
             for choice in self.unique_choices:
                 choice.unset_value()
         finally:
-            self._warn_no_prompt = True
+            self._warn_assign_no_prompt = True
 
     def enable_warnings(self):
         """
@@ -2004,12 +2021,12 @@ class Kconfig(object):
 
         try:
             return self._open(filename, "r")
-        except IOError as e:
+        except EnvironmentError as e:
             # This will try opening the same file twice if $srctree is unset,
             # but it's not a big deal
             try:
                 return self._open(join(self.srctree, filename), "r")
-            except IOError as e2:
+            except EnvironmentError as e2:
                 # This is needed for Python 3, because e2 is deleted after
                 # the try block:
                 #
@@ -2030,9 +2047,9 @@ class Kconfig(object):
         # filename:
         #   Absolute path to file
 
-        # Path relative to $srctree, stored in e.g. self._filename
-        # (which makes it indirectly show up in MenuNode.filename). Equals
-        # 'filename' for absolute paths passed to 'source'.
+        # Path relative to $srctree, stored in e.g. self.filename (which makes
+        # it indirectly show up in MenuNode.filename). Equals 'filename' for
+        # absolute paths passed to 'source'.
         if filename.startswith(self._srctree_prefix):
             # Relative path (or a redundant absolute path to within $srctree,
             # but it's probably fine to reduce those too)
@@ -2061,7 +2078,7 @@ class Kconfig(object):
 
         # _include_path is a tuple, so this rebinds the variable instead of
         # doing in-place modification
-        self._include_path += ((self._filename, self._linenr),)
+        self._include_path += ((self.filename, self.linenr),)
 
         # Check for recursive 'source'
         for name, _ in self._include_path:
@@ -2070,29 +2087,29 @@ class Kconfig(object):
                     "\n{}:{}: recursive 'source' of '{}' detected. Check that "
                     "environment variables are set correctly.\n"
                     "Include path:\n{}"
-                    .format(self._filename, self._linenr, rel_filename,
+                    .format(self.filename, self.linenr, rel_filename,
                             "\n".join("{}:{}".format(name, linenr)
                                       for name, linenr in self._include_path)))
 
         try:
             self._readline = self._open(filename, "r").readline
-        except IOError as e:
+        except EnvironmentError as e:
             # We already know that the file exists
             raise _KconfigIOError(
                 e, "{}:{}: Could not open '{}' (in '{}') ({}: {})"
-                   .format(self._filename, self._linenr, filename,
+                   .format(self.filename, self.linenr, filename,
                            self._line.strip(),
                            errno.errorcode[e.errno], e.strerror))
 
-        self._filename = rel_filename
-        self._linenr = 0
+        self.filename = rel_filename
+        self.linenr = 0
 
     def _leave_file(self):
         # Returns from a Kconfig file to the file that sourced it. See
         # _enter_file().
 
         # Restore location from parent Kconfig file
-        self._filename, self._linenr = self._include_path[-1]
+        self.filename, self.linenr = self._include_path[-1]
         # Restore include path and 'file' object
         self._readline.__self__.close()  # __self__ fetches the 'file' object
         self._include_path, self._readline = self._filestack.pop()
@@ -2115,12 +2132,12 @@ class Kconfig(object):
         line = self._readline()
         if not line:
             return False
-        self._linenr += 1
+        self.linenr += 1
 
         # Handle line joining
         while line.endswith("\\\n"):
             line = line[:-2] + self._readline()
-            self._linenr += 1
+            self.linenr += 1
 
         self._tokens = self._tokenize(line)
         # Initialize to 1 instead of 0 to factor out code from _parse_block()
@@ -2141,7 +2158,7 @@ class Kconfig(object):
         # Handle line joining
         while line.endswith("\\\n"):
             line = line[:-2] + self._readline()
-            self._linenr += 1
+            self.linenr += 1
 
         self._tokens = self._tokenize(line)
         self._reuse_tokens = True
@@ -2169,7 +2186,7 @@ class Kconfig(object):
                 # Robust re. things like encoding and line endings (mmap()
                 # trickery isn't)
                 return f.read(len(contents) + 1) == contents
-        except IOError:
+        except EnvironmentError:
             # If the error here would prevent writing the file as well, we'll
             # notice it later
             return False
@@ -2290,9 +2307,8 @@ class Kconfig(object):
                     else:
                         i = match.end()
 
-                    token = self.const_syms[name] \
-                            if name in ("y", "m", "n") else \
-                            self._lookup_sym(name)
+                    token = self.const_syms[name] if name in STR_TO_TRI else \
+                        self._lookup_sym(name)
 
                 else:
                     # It's a case of missing quotes. For example, the
@@ -2310,7 +2326,7 @@ class Kconfig(object):
                     if token is not _T_CHOICE:
                         self._warn("style: quotes recommended around '{}' in '{}'"
                                    .format(name, self._line.strip()),
-                                   self._filename, self._linenr)
+                                   self.filename, self.linenr)
 
                     token = name
                     i = match.end()
@@ -2722,7 +2738,7 @@ class Kconfig(object):
 
                 raise KconfigError("{}:{}: bad number of arguments in call "
                                    "to {}, expected {}, got {}"
-                                   .format(self._filename, self._linenr, fn,
+                                   .format(self.filename, self.linenr, fn,
                                            expected_args, len(args) - 1))
 
             return py_fn(self, *args)
@@ -2810,8 +2826,8 @@ class Kconfig(object):
                 node.is_menuconfig = (t0 is _T_MENUCONFIG)
                 node.prompt = node.help = node.list = None
                 node.parent = parent
-                node.filename = self._filename
-                node.linenr = self._linenr
+                node.filename = self.filename
+                node.linenr = self.linenr
                 node.include_path = self._include_path
 
                 sym.nodes.append(node)
@@ -2839,7 +2855,7 @@ class Kconfig(object):
 
                 if t0 in _REL_SOURCE_TOKENS:
                     # Relative source
-                    pattern = join(dirname(self._filename), pattern)
+                    pattern = join(dirname(self.filename), pattern)
 
                 # - glob() doesn't support globbing relative to a directory, so
                 #   we need to prepend $srctree to 'pattern'. Use join()
@@ -2857,7 +2873,7 @@ class Kconfig(object):
                         "environment variables are set correctly (e.g. "
                         "$srctree, which is {}). Also note that unset "
                         "environment variables expand to the empty string."
-                        .format(self._filename, self._linenr, pattern,
+                        .format(self.filename, self.linenr, pattern,
                                 self._line.strip(),
                                 "set to '{}'".format(self.srctree)
                                     if self.srctree else "unset or blank"))
@@ -2896,8 +2912,8 @@ class Kconfig(object):
                 node.prompt = (self._expect_str_and_eol(), self.y)
                 node.visibility = self.y
                 node.parent = parent
-                node.filename = self._filename
-                node.linenr = self._linenr
+                node.filename = self.filename
+                node.linenr = self.linenr
                 node.include_path = self._include_path
 
                 self.menus.append(node)
@@ -2916,8 +2932,8 @@ class Kconfig(object):
                 node.prompt = (self._expect_str_and_eol(), self.y)
                 node.list = None
                 node.parent = parent
-                node.filename = self._filename
-                node.linenr = self._linenr
+                node.filename = self.filename
+                node.linenr = self.linenr
                 node.include_path = self._include_path
 
                 self.comments.append(node)
@@ -2948,8 +2964,8 @@ class Kconfig(object):
                 node.is_menuconfig = True
                 node.prompt = node.help = None
                 node.parent = parent
-                node.filename = self._filename
-                node.linenr = self._linenr
+                node.filename = self.filename
+                node.linenr = self.linenr
                 node.include_path = self._include_path
 
                 choice.nodes.append(node)
@@ -2980,7 +2996,7 @@ class Kconfig(object):
                 .format("endchoice" if end_token is _T_ENDCHOICE else
                         "endif"     if end_token is _T_ENDIF else
                         "endmenu",
-                        self._filename))
+                        self.filename))
 
         prev.next = None
         return prev
@@ -3093,7 +3109,7 @@ class Kconfig(object):
                         self._warn("{1} has 'option env=\"{0}\"', "
                                    "but the environment variable {0} is not "
                                    "set".format(node.item.name, env_var),
-                                   self._filename, self._linenr)
+                                   self.filename, self.linenr)
 
                     if env_var != node.item.name:
                         self._warn("Kconfiglib expands environment variables "
@@ -3103,7 +3119,7 @@ class Kconfig(object):
                                    "rename {} to {} (so that the symbol name "
                                    "matches the environment variable name)."
                                    .format(node.item.name, env_var),
-                                   self._filename, self._linenr)
+                                   self.filename, self.linenr)
 
                 elif self._check_token(_T_DEFCONFIG_LIST):
                     if not self.defconfig_list:
@@ -3113,7 +3129,7 @@ class Kconfig(object):
                                    "symbols ({0} and {1}). Only {0} will be "
                                    "used.".format(self.defconfig_list.name,
                                                   node.item.name),
-                                   self._filename, self._linenr)
+                                   self.filename, self.linenr)
 
                 elif self._check_token(_T_MODULES):
                     # To reduce warning spam, only warn if 'option modules' is
@@ -3130,7 +3146,7 @@ class Kconfig(object):
                                    "MODULES, like older versions of the C "
                                    "implementation did when 'option modules' "
                                    "wasn't used.",
-                                   self._filename, self._linenr)
+                                   self.filename, self.linenr)
 
                 elif self._check_token(_T_ALLNOCONFIG_Y):
                     if node.item.__class__ is not Symbol:
@@ -3200,7 +3216,7 @@ class Kconfig(object):
 
         while 1:
             line = readline()
-            self._linenr += 1
+            self.linenr += 1
             if not line:
                 self._empty_help(node, line)
                 return
@@ -3239,7 +3255,7 @@ class Kconfig(object):
                     break
                 add_line(expline[indent:])
 
-        self._linenr += len_(lines)
+        self.linenr += len_(lines)
         node.help = "".join(lines).rstrip()
         if line:
             self._line_after_help(line)
@@ -3289,9 +3305,8 @@ class Kconfig(object):
         # Return 'and_expr' directly if we have a "single-operand" OR.
         # Otherwise, parse the expression on the right and make an OR node.
         # This turns A || B || C || D into (OR, A, (OR, B, (OR, C, D))).
-        return and_expr \
-               if not self._check_token(_T_OR) else \
-               (OR, and_expr, self._parse_expr(transform_m))
+        return and_expr if not self._check_token(_T_OR) else \
+            (OR, and_expr, self._parse_expr(transform_m))
 
     def _parse_and_expr(self, transform_m):
         factor = self._parse_factor(transform_m)
@@ -3299,9 +3314,8 @@ class Kconfig(object):
         # Return 'factor' directly if we have a "single-operand" AND.
         # Otherwise, parse the right operand and make an AND node. This turns
         # A && B && C && D into (AND, A, (AND, B, (AND, C, D))).
-        return factor \
-               if not self._check_token(_T_AND) else \
-               (AND, factor, self._parse_and_expr(transform_m))
+        return factor if not self._check_token(_T_AND) else \
+            (AND, factor, self._parse_and_expr(transform_m))
 
     def _parse_factor(self, transform_m):
         token = self._tokens[self._tokens_i]
@@ -3433,56 +3447,42 @@ class Kconfig(object):
     # implicit submenu creation
     #
 
-    def _finalize_tree(self, node, visible_if):
-        # Propagates properties and dependencies, creates implicit menus (see
-        # kconfig-language.txt), removes 'if' nodes, and finalizes choices.
-        # This pretty closely mirrors menu_finalize() from the C
-        # implementation, with some minor tweaks (MenuNode holds lists of
-        # properties instead of each property having a MenuNode pointer, for
-        # example).
+    def _finalize_node(self, node, visible_if):
+        # Finalizes a menu node and its children:
+        #
+        #  - Copies properties from menu nodes up to their contained
+        #    symbols/choices
+        #
+        #  - Propagates dependencies from parent to child nodes
+        #
+        #  - Creates implicit menus (see kconfig-language.txt)
+        #
+        #  - Removes 'if' nodes
+        #
+        #  - Sets 'choice' types and registers choice symbols
+        #
+        # menu_finalize() in the C implementation is similar.
         #
         # node:
-        #   The current "parent" menu node, from which we propagate
-        #   dependencies
+        #   The menu node to finalize. This node and its children will have
+        #   been finalized when the function returns, and any implicit menus
+        #   will have been created.
         #
         # visible_if:
         #   Dependencies from 'visible if' on parent menus. These are added to
         #   the prompts of symbols and choices.
 
-        if node.list:
-            # The menu node is a choice, menu, or if. Finalize each child in
-            # it.
-
-            if node.item is MENU:
-                visible_if = self._make_and(visible_if, node.visibility)
-
-            # Propagate the menu node's dependencies to each child menu node.
-            #
-            # The recursive _finalize_tree() calls assume that the current
-            # "level" in the tree has already had dependencies propagated. This
-            # makes e.g. implicit submenu creation easier, because it needs to
-            # look ahead.
-            self._propagate_deps(node, visible_if)
-
-            # Finalize the children
-            cur = node.list
-            while cur:
-                self._finalize_tree(cur, visible_if)
-                cur = cur.next
-
-        elif node.item.__class__ is Symbol:
-            # Add the node's non-node-specific properties (defaults, ranges,
-            # etc.) to the Symbol
+        if node.item.__class__ is Symbol:
+            # Copy defaults, ranges, selects, and implies to the Symbol
             self._add_props_to_sym(node)
 
-            # See if we can create an implicit menu rooted at the Symbol and
-            # finalize each child menu node in that menu if so, like for the
-            # choice/menu/if case above
+            # Find any items that should go in an implicit menu rooted at the
+            # symbol
             cur = node
             while cur.next and _auto_menu_dep(node, cur.next):
-                # This also makes implicit submenu creation work recursively,
-                # with implicit menus inside implicit menus
-                self._finalize_tree(cur.next, visible_if)
+                # This makes implicit submenu creation work recursively, with
+                # implicit menus inside implicit menus
+                self._finalize_node(cur.next, visible_if)
                 cur = cur.next
                 cur.parent = node
 
@@ -3493,10 +3493,27 @@ class Kconfig(object):
                 node.next = cur.next
                 cur.next = None
 
+        elif node.list:
+            # The menu node is a choice, menu, or if. Finalize each child node.
+
+            if node.item is MENU:
+                visible_if = self._make_and(visible_if, node.visibility)
+
+            # Propagate the menu node's dependencies to each child menu node.
+            #
+            # This needs to go before the recursive _finalize_node() call so
+            # that implicit submenu creation can look ahead at dependencies.
+            self._propagate_deps(node, visible_if)
+
+            # Finalize the children
+            cur = node.list
+            while cur:
+                self._finalize_node(cur, visible_if)
+                cur = cur.next
 
         if node.list:
-            # We have a parent node with individually finalized child nodes. Do
-            # final steps to finalize this "level" in the menu tree.
+            # node's children have been individually finalized. Do final steps
+            # to finalize this "level" in the menu tree.
             _flatten(node.list)
             _remove_ifs(node)
 
@@ -3636,7 +3653,7 @@ class Kconfig(object):
                                            TYPE_TO_STR[target_sym.orig_type],
                                            _name_and_loc(target_sym)))
 
-            elif sym.orig_type in _STRING_INT_HEX:
+            elif sym.orig_type:  # STRING/INT/HEX
                 for default, _ in sym.defaults:
                     if default.__class__ is not Symbol:
                         raise KconfigError(
@@ -3754,8 +3771,8 @@ class Kconfig(object):
 
     def _parse_error(self, msg):
         raise KconfigError("{}couldn't parse '{}': {}".format(
-            "" if self._filename is None else
-                "{}:{}: ".format(self._filename, self._linenr),
+            "" if self.filename is None else
+                "{}:{}: ".format(self.filename, self.linenr),
             self._line.strip(), msg))
 
     def _trailing_tokens_error(self):
@@ -4047,7 +4064,7 @@ class Symbol(object):
       The direct ('depends on') dependencies for the symbol, or self.kconfig.y
       if there are no direct dependencies.
 
-      This attribute includes any dependencies from surrounding menus and if's.
+      This attribute includes any dependencies from surrounding menus and ifs.
       Those get propagated to the direct dependencies, and the resulting direct
       dependencies in turn get propagated to the conditions of all properties.
 
@@ -4058,7 +4075,7 @@ class Symbol(object):
       A set() with all symbols and choices referenced in the properties and
       property conditions of the symbol.
 
-      Also includes dependencies from surrounding menus and if's, because those
+      Also includes dependencies from surrounding menus and ifs, because those
       get propagated to the symbol (see the 'Intro to symbol values' section in
       the module docstring).
 
@@ -4144,7 +4161,7 @@ class Symbol(object):
         See the class documentation.
         """
         if self.orig_type is TRISTATE and \
-           ((self.choice and self.choice.tri_value == 2) or
+           (self.choice and self.choice.tri_value == 2 or
             not self.kconfig.modules.tri_value):
 
             return BOOL
@@ -4460,7 +4477,7 @@ class Symbol(object):
             value = STR_TO_TRI[value]
 
         # If the new user value matches the old, nothing changes, and we can
-        # save some work.
+        # avoid invalidating cached values.
         #
         # This optimization is skipped for choice symbols: Setting a choice
         # symbol's user value to y might change the state of the choice, so it
@@ -4473,11 +4490,11 @@ class Symbol(object):
         # Check if the value is valid for our type
         if not (self.orig_type is BOOL     and value in (2, 0)     or
                 self.orig_type is TRISTATE and value in TRI_TO_STR or
-                (value.__class__ is str    and
-                 (self.orig_type is STRING                         or
-                  self.orig_type is INT and _is_base_n(value, 10)  or
-                  self.orig_type is HEX and _is_base_n(value, 16)
-                                        and int(value, 16) >= 0))):
+                value.__class__ is str and
+                (self.orig_type is STRING                        or
+                 self.orig_type is INT and _is_base_n(value, 10) or
+                 self.orig_type is HEX and _is_base_n(value, 16)
+                                       and int(value, 16) >= 0)):
 
             # Display tristate values as n, m, y in the warning
             self.kconfig._warn(
@@ -4644,13 +4661,16 @@ class Symbol(object):
         #   rev_dep
         #   weak_rev_dep
 
-        self.orig_type = UNKNOWN
+        # - UNKNOWN == 0
+        # - _visited is used during tree iteration and dep. loop detection
+        self.orig_type = self._visited = 0
+
+        self.nodes = []
+
         self.defaults = []
         self.selects = []
         self.implies = []
         self.ranges = []
-
-        self.nodes = []
 
         self.user_value = \
         self.choice = \
@@ -4667,10 +4687,6 @@ class Symbol(object):
 
         # See Kconfig._build_dep()
         self._dependents = set()
-
-        # Used during dependency loop detection and (independently) in
-        # node_iter()
-        self._visited = 0
 
     def _assignable(self):
         # Worker function for the 'assignable' attribute
@@ -4722,7 +4738,7 @@ class Symbol(object):
         # Marks the symbol as needing to be recalculated
 
         self._cached_str_val = self._cached_tri_val = self._cached_vis = \
-            self._cached_assignable = None
+        self._cached_assignable = None
 
     def _rec_invalidate(self):
         # Invalidates the symbol and all items that (possibly) depend on it
@@ -4761,8 +4777,8 @@ class Symbol(object):
         # symbols, so we skip invalidation for them as an optimization.
         #
         # This also prevents constant (quoted) symbols from being invalidated
-        # if set_value() is called on them, which would cause them to lose
-        # their value and break things.
+        # if set_value() is called on them, which would make them lose their
+        # value and break things.
         #
         # Prints a warning if the symbol has no prompt. In some contexts (e.g.
         # when loading a .config files) assignments to promptless symbols are
@@ -4773,7 +4789,7 @@ class Symbol(object):
                 self._rec_invalidate()
                 return
 
-        if self.kconfig._warn_no_prompt:
+        if self.kconfig._warn_assign_no_prompt:
             self.kconfig._warn(_name_and_loc(self) + " has no prompt, meaning "
                                "user values have no effect on it")
 
@@ -4805,7 +4821,7 @@ class Symbol(object):
 
             return TRI_TO_STR[val]
 
-        if self.orig_type in _STRING_INT_HEX:
+        if self.orig_type:  # STRING/INT/HEX
             for default, cond in self.defaults:
                 if expr_value(cond):
                     return default.str_value
@@ -4983,7 +4999,7 @@ class Choice(object):
       A set() with all symbols referenced in the properties and property
       conditions of the choice.
 
-      Also includes dependencies from surrounding menus and if's, because those
+      Also includes dependencies from surrounding menus and ifs, because those
       get propagated to the choice (see the 'Intro to symbol values' section in
       the module docstring).
 
@@ -5094,28 +5110,27 @@ class Choice(object):
         Choice.assignable attribute to see what values are currently in range
         and would actually be reflected in the mode of the choice.
         """
+        if value in STR_TO_TRI:
+            value = STR_TO_TRI[value]
+
         if value == self.user_value:
             # We know the value must be valid if it was successfully set
             # previously
             self._was_set = True
             return True
 
-        if not ((self.orig_type is BOOL     and value in (2, 0, "y", "n")        ) or
-                (self.orig_type is TRISTATE and value in (2, 1, 0, "y", "m", "n"))):
+        if not (self.orig_type is BOOL     and value in (2, 0) or
+                self.orig_type is TRISTATE and value in TRI_TO_STR):
 
             # Display tristate values as n, m, y in the warning
             self.kconfig._warn(
                 "the value {} is invalid for {}, which has type {} -- "
                 "assignment ignored"
-                .format(TRI_TO_STR[value] if value in (0, 1, 2) else
+                .format(TRI_TO_STR[value] if value in TRI_TO_STR else
                             "'{}'".format(value),
-                        _name_and_loc(self),
-                        TYPE_TO_STR[self.orig_type]))
+                        _name_and_loc(self), TYPE_TO_STR[self.orig_type]))
 
             return False
-
-        if value in ("y", "m", "n"):
-            value = STR_TO_TRI[value]
 
         self.user_value = value
         self._was_set = True
@@ -5221,11 +5236,14 @@ class Choice(object):
         #   direct_dep
         #   kconfig
 
-        self.orig_type = UNKNOWN
-        self.syms = []
-        self.defaults = []
+        # - UNKNOWN == 0
+        # - _visited is used during dep. loop detection
+        self.orig_type = self._visited = 0
 
         self.nodes = []
+
+        self.syms = []
+        self.defaults = []
 
         self.name = \
         self.user_value = self.user_selection = \
@@ -5239,9 +5257,6 @@ class Choice(object):
 
         # See Kconfig._build_dep()
         self._dependents = set()
-
-        # Used during dependency loop detection
-        self._visited = 0
 
     def _assignable(self):
         # Worker function for the 'assignable' attribute
@@ -5276,9 +5291,9 @@ class Choice(object):
             return self.user_selection
 
         # Otherwise, check if we have a default
-        return self._get_selection_from_defaults()
+        return self._selection_from_defaults()
 
-    def _get_selection_from_defaults(self):
+    def _selection_from_defaults(self):
         # Check if we have a default
         for sym, cond in self.defaults:
             # The default symbol must be visible too
@@ -5396,7 +5411,7 @@ class MenuNode(object):
       The direct ('depends on') dependencies for the menu node, or
       self.kconfig.y if there are no direct dependencies.
 
-      This attribute includes any dependencies from surrounding menus and if's.
+      This attribute includes any dependencies from surrounding menus and ifs.
       Those get propagated to the direct dependencies, and the resulting direct
       dependencies in turn get propagated to the conditions of all properties.
 
@@ -5414,7 +5429,7 @@ class MenuNode(object):
       A set() with all symbols and choices referenced in the properties and
       property conditions of the menu node.
 
-      Also includes dependencies inherited from surrounding menus and if's.
+      Also includes dependencies inherited from surrounding menus and ifs.
       Choices appear in the dependencies of choice symbols.
 
     is_menuconfig:
@@ -5435,7 +5450,7 @@ class MenuNode(object):
     filename/linenr:
       The location where the menu node appears. The filename is relative to
       $srctree (or to the current directory if $srctree isn't set), except
-      absolute paths passed to 'source' and Kconfig.__init__() are preserved.
+      absolute paths are used for paths outside $srctree.
 
     include_path:
       A tuple of (filename, linenr) tuples, giving the locations of the
@@ -5891,11 +5906,10 @@ def standard_sc_expr_str(sc):
     See expr_str().
     """
     if sc.__class__ is Symbol:
-        if sc.is_constant and sc.name not in ("n", "m", "y"):
+        if sc.is_constant and sc.name not in STR_TO_TRI:
             return '"{}"'.format(escape(sc.name))
         return sc.name
 
-    # Choice
     return "<choice {}>".format(sc.name) if sc.name else "<choice>"
 
 
@@ -5947,8 +5961,9 @@ def expr_items(expr):
     """
     Returns a set() of all items (symbols and choices) that appear in the
     expression 'expr'.
-    """
 
+    Passing subexpressions of expressions to this function works as expected.
+    """
     res = set()
 
     def rec(subexpr):
@@ -6050,7 +6065,7 @@ def standard_kconfig():
     # Only show backtraces for unexpected exceptions
     try:
         return Kconfig("Kconfig" if len(sys.argv) < 2 else sys.argv[1])
-    except (IOError, KconfigError) as e:
+    except (EnvironmentError, KconfigError) as e:
         # Some long exception messages have extra newlines for better
         # formatting when reported as an unhandled exception. Strip them here.
         sys.exit(str(e).strip())
@@ -6096,6 +6111,10 @@ def load_allconfig(kconf, filename):
     def std_msg(e):
         # "Upcasts" a _KconfigIOError to an IOError, removing the custom
         # __str__() message. The standard message is better here.
+        #
+        # This might also convert an OSError to an IOError in obscure cases,
+        # but it's probably not a big deal. The distinction is shaky (see
+        # PEP-3151).
         return IOError(e.errno, e.strerror, e.filename)
 
     old_warn_assign_override = kconf.warn_assign_override
@@ -6105,17 +6124,17 @@ def load_allconfig(kconf, filename):
     if allconfig in ("", "1"):
         try:
             print(kconf.load_config(filename, False))
-        except IOError as e1:
+        except EnvironmentError as e1:
             try:
                 print(kconf.load_config("all.config", False))
-            except IOError as e2:
+            except EnvironmentError as e2:
                 sys.exit("error: KCONFIG_ALLCONFIG is set, but neither {} "
                          "nor all.config could be opened: {}, {}"
                          .format(filename, std_msg(e1), std_msg(e2)))
     else:
         try:
             print(kconf.load_config(allconfig, False))
-        except IOError as e:
+        except EnvironmentError as e:
             sys.exit("error: KCONFIG_ALLCONFIG is set to '{}', which "
                      "could not be opened: {}"
                      .format(allconfig, std_msg(e)))
@@ -6600,22 +6619,22 @@ def _warn_verbose_deprecated(fn_name):
 
 
 def _filename_fn(kconf, _):
-    return kconf._filename
+    return kconf.filename
 
 
 def _lineno_fn(kconf, _):
-    return str(kconf._linenr)
+    return str(kconf.linenr)
 
 
 def _info_fn(kconf, _, msg):
-    print("{}:{}: {}".format(kconf._filename, kconf._linenr, msg))
+    print("{}:{}: {}".format(kconf.filename, kconf.linenr, msg))
 
     return ""
 
 
 def _warning_if_fn(kconf, _, cond, msg):
     if cond == "y":
-        kconf._warn(msg, kconf._filename, kconf._linenr)
+        kconf._warn(msg, kconf.filename, kconf.linenr)
 
     return ""
 
@@ -6623,7 +6642,7 @@ def _warning_if_fn(kconf, _, cond, msg):
 def _error_if_fn(kconf, _, cond, msg):
     if cond == "y":
         raise KconfigError("{}:{}: {}".format(
-            kconf._filename, kconf._linenr, msg))
+            kconf.filename, kconf.linenr, msg))
 
     return ""
 
@@ -6641,12 +6660,12 @@ def _shell_fn(kconf, _, command):
             stdout = stdout.decode(kconf._encoding)
             stderr = stderr.decode(kconf._encoding)
         except UnicodeDecodeError as e:
-            _decoding_error(e, kconf._filename, kconf._linenr)
+            _decoding_error(e, kconf.filename, kconf.linenr)
 
     if stderr:
         kconf._warn("'{}' wrote to stderr: {}".format(
                         command, "\n".join(stderr.splitlines())),
-                    kconf._filename, kconf._linenr)
+                    kconf.filename, kconf.linenr)
 
     # Universal newlines with splitlines() (to prevent e.g. stray \r's in
     # command output on Windows), trailing newline removal, and
@@ -6871,7 +6890,7 @@ _DEF_TOKEN_TO_TYPE = {
 # Identifier-like lexemes ("missing quotes") are also treated as strings after
 # these tokens. _T_CHOICE is included to avoid symbols being registered for
 # named choices.
-_STRING_LEX = frozenset((
+_STRING_LEX = frozenset({
     _T_BOOL,
     _T_CHOICE,
     _T_COMMENT,
@@ -6886,82 +6905,76 @@ _STRING_LEX = frozenset((
     _T_SOURCE,
     _T_STRING,
     _T_TRISTATE,
-))
+})
 
 # Various sets for quick membership tests. Gives a single global lookup and
 # avoids creating temporary dicts/tuples.
 
-_TYPE_TOKENS = frozenset((
+_TYPE_TOKENS = frozenset({
     _T_BOOL,
     _T_TRISTATE,
     _T_INT,
     _T_HEX,
     _T_STRING,
-))
+})
 
-_SOURCE_TOKENS = frozenset((
+_SOURCE_TOKENS = frozenset({
     _T_SOURCE,
     _T_RSOURCE,
     _T_OSOURCE,
     _T_ORSOURCE,
-))
+})
 
-_REL_SOURCE_TOKENS = frozenset((
+_REL_SOURCE_TOKENS = frozenset({
     _T_RSOURCE,
     _T_ORSOURCE,
-))
+})
 
 # Obligatory (non-optional) sources
-_OBL_SOURCE_TOKENS = frozenset((
+_OBL_SOURCE_TOKENS = frozenset({
     _T_SOURCE,
     _T_RSOURCE,
-))
+})
 
-_BOOL_TRISTATE = frozenset((
+_BOOL_TRISTATE = frozenset({
     BOOL,
     TRISTATE,
-))
+})
 
-_BOOL_TRISTATE_UNKNOWN = frozenset((
+_BOOL_TRISTATE_UNKNOWN = frozenset({
     BOOL,
     TRISTATE,
     UNKNOWN,
-))
+})
 
-_INT_HEX = frozenset((
+_INT_HEX = frozenset({
     INT,
     HEX,
-))
+})
 
-_STRING_INT_HEX = frozenset((
-    STRING,
-    INT,
-    HEX,
-))
-
-_SYMBOL_CHOICE = frozenset((
+_SYMBOL_CHOICE = frozenset({
     Symbol,
     Choice,
-))
+})
 
-_MENU_COMMENT = frozenset((
+_MENU_COMMENT = frozenset({
     MENU,
     COMMENT,
-))
+})
 
-_EQUAL_UNEQUAL = frozenset((
+_EQUAL_UNEQUAL = frozenset({
     EQUAL,
     UNEQUAL,
-))
+})
 
-_RELATIONS = frozenset((
+_RELATIONS = frozenset({
     EQUAL,
     UNEQUAL,
     LESS,
     LESS_EQUAL,
     GREATER,
     GREATER_EQUAL,
-))
+})
 
 # Helper functions for getting compiled regular expressions, with the needed
 # matching function returned directly as a small optimization.
@@ -7010,7 +7023,7 @@ _string_special_search = _re_search(r'"|\'|\\|\$\(')
 
 # Special characters/strings while expanding a symbol name. Also includes
 # end-of-line, in case the macro is the last thing on the line.
-_name_special_search = _re_search(r'[^$A-Za-z0-9_/.-]|\$\(|$')
+_name_special_search = _re_search(r'[^A-Za-z0-9_$/.-]|\$\(|$')
 
 # A valid right-hand side for an assignment to a string symbol in a .config
 # file, including escaped characters. Extracts the contents.

--- a/scripts/kconfig/menuconfig.py
+++ b/scripts/kconfig/menuconfig.py
@@ -1829,7 +1829,7 @@ def _try_load(filename):
     try:
         _kconf.load_config(filename)
         return True
-    except OSError as e:
+    except EnvironmentError as e:
         _error("Error loading '{}'\n\n{} (errno: {})"
                .format(filename, e.strerror, errno.errorcode[e.errno]))
         return False
@@ -1881,7 +1881,7 @@ def _try_save(save_fn, filename, description):
     try:
         # save_fn() returns a message to print
         return save_fn(filename)
-    except OSError as e:
+    except EnvironmentError as e:
         _error("Error saving {} to '{}'\n\n{} (errno: {})"
                .format(description, e.filename, e.strerror,
                        errno.errorcode[e.errno]))
@@ -2639,7 +2639,10 @@ def _defaults_info(sc):
     if not sc.defaults:
         return ""
 
-    s = "Defaults:\n"
+    s = "Default"
+    if len(sc.defaults) > 1:
+        s += "s"
+    s += ":\n"
 
     for val, cond in sc.orig_defaults:
         s += "  - "


### PR DESCRIPTION
Update Kconfiglib (and menuconfig/guiconfig, just to sync) to upstream
revision f2ce282eca, to get this commit in:

    Allow preprocessor user functions to access the parsing location

    Just requires making Kconfig.filename/linenr public.

    'lineno' would be a more standard name, but be consistent with
    MenuNode.linenr.

This can be used to give friendly errors in
scripts/kconfig/kconfigfunctions.py, e.g. for
https://github.com/zephyrproject-rtos/zephyr/pull/18752.

Some minor optimizations are included too.