### PR TITLE
doc/reference/kernel: Add SMP architecture documentation

### DIFF
--- a/doc/reference/kernel/index.rst
+++ b/doc/reference/kernel/index.rst
@@ -36,6 +36,7 @@ synchronization.
    other/polling.rst
    synchronization/semaphores.rst
    synchronization/mutexes.rst
+   smp/smp.rst
 
 Data Passing
 ************


### PR DESCRIPTION
First cut at an architecture-level description for SMP.

Note this is in "baby RST".  It sorta looks right in a text editor, but I'm sure I've violated all sorts of rules and conventions about how this is supposed to work.  But the content is there and we can figure out the technical details as we review.