### PR TITLE
[RFC] logging: Add simple float numbers support

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -276,6 +276,23 @@ int log_printk(const char *fmt, va_list ap);
  */
 char *log_strdup(const char *str);
 
+/** @brief Use as format specifier for float in a formatted string.
+ *
+ * Use this macro in a formatted string instead of the %f specifier together with
+ * @ref LOGF_ARG macro.
+ * Example: LOG_INF("My float number" LOGF "\r\n", LOGF_ARG(f)))
+ */
+#define LOGF "%s%d.%04d"
+
+/** @brief Dissect a float number into two numbers (integer and residuum).
+ *
+ * See @ref LOGF for more details.
+ */
+#define LOGF_ARG(f) \
+	(((f) < 0 && (f) > -1.0) ? "-" : ""), \
+	(s32_t)(f), \
+	(s32_t)((((f) > 0) ? (f) - (s32_t)(f) : (s32_t)(f) - (f))*10000)
+
 #ifdef __cplusplus
 }
 #define LOG_IN_CPLUSPLUS 1


### PR DESCRIPTION
Added macros which allow printing float number. It is splitting float
into 3 arguments: sign, interger and residuum.

Method requires custom macro being used instead of format specifier and
macro for converting float argument.

Partially fixes #18351.

Example of logging float numer:
```
LOG_INF("value:"LOGF" is printed as float", LOGF_ARG(-0.112));
```
will result in: `value:-0.1120 is printed as float`

I know that it's not very convenient but allows float logging. Supporting %f is (as mentioned by @pabigot ) rather complex.

FYI: this approach is taken from nRF5 SDK where similar logger exists with similar limitation.

Let me know what do you think about it. If it is accepted i'll extend sample and document it.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>