### PR TITLE
subsys: settings: adding missing header

### DIFF
--- a/subsys/settings/src/settings_priv.h
+++ b/subsys/settings/src/settings_priv.h
@@ -9,6 +9,7 @@
 #define __SETTINGS_PRIV_H_
 
 #include <sys/types.h>
+#include <sys/slist.h>
 #include <errno.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Trivial compilation issue when trying to integrate the next batch of Settings tests with the NVS backend 