### PR TITLE
net: tcp: Cleanup context if connection is not established

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1402,6 +1402,11 @@ int net_tcp_put(struct net_context *context)
 			return 0;
 		}
 
+		if (context->tcp &&
+		    net_tcp_get_state(context->tcp) == NET_TCP_SYN_SENT) {
+			net_context_unref(context);
+		}
+
 		return -ENOTCONN;
 	}
 


### PR DESCRIPTION
If we are closing connection before the connection was established,
then unref the context so that the cleanup is done properly.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>