### PR TITLE
net: lib: socketutils, sntp: Allow to build for CONFIG_POSIX_API

### DIFF
--- a/include/net/sntp.h
+++ b/include/net/sntp.h
@@ -8,7 +8,13 @@
 #ifndef ZEPHYR_INCLUDE_NET_SNTP_H_
 #define ZEPHYR_INCLUDE_NET_SNTP_H_
 
+#ifdef CONFIG_NET_SOCKETS_POSIX_NAMES
 #include <net/socket.h>
+#else
+#include <posix/sys/socket.h>
+#include <posix/unistd.h>
+#include <posix/poll.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/net/socketutils.h
+++ b/include/net/socketutils.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef CONFIG_NET_SOCKETS_POSIX_NAMES
+#include <net/socket.h>
+#else
+#include <posix/netdb.h>
+#endif
+
 /**
  * @brief Find port in addr:port string.
  *

--- a/samples/net/sockets/sntp_client/sample.yaml
+++ b/samples/net/sockets/sntp_client/sample.yaml
@@ -1,8 +1,15 @@
 sample:
   description: SNTP client sample
   name: sntp_client
+common:
+  harness: net
+  platform_whitelist: qemu_x86
+  tags: net
 tests:
   sample.net.sockets.sntp_client:
-    harness: net
-    platform_whitelist: qemu_x86
-    tags: net
+    extra_configs:
+      - CONFIG_NET_SOCKETS_POSIX_NAMES=y
+  sample.net.sockets.sntp_client.posix:
+    extra_configs:
+      - CONFIG_NET_SOCKETS_POSIX_NAMES=n
+      - CONFIG_POSIX_API=y

--- a/samples/net/sockets/sntp_client/src/main.c
+++ b/samples/net/sockets/sntp_client/src/main.c
@@ -9,6 +9,9 @@
 LOG_MODULE_REGISTER(net_sntp_client_sample, LOG_LEVEL_DBG);
 
 #include <net/sntp.h>
+#ifdef CONFIG_POSIX_API
+#include <arpa/inet.h>
+#endif
 
 #include "config.h"
 

--- a/subsys/net/lib/utils/addr_utils.c
+++ b/subsys/net/lib/utils/addr_utils.c
@@ -4,12 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <net/socket.h>
+#ifdef CONFIG_NET_SOCKETS
 
-/* These utility functions are intended to be on top of POSIX API, and don't
- * make sense if it's not available.
- */
-#ifdef CONFIG_NET_SOCKETS_POSIX_NAMES
+#include <net/socketutils.h>
 
 const char *net_addr_str_find_port(const char *addr_str)
 {


### PR DESCRIPTION
socketutils and SNTP APIs were previously tested only with CONFIG_NET_SOCKETS_POSIX_NAMES. Make required changes for them to work with CONFIG_POSIX_API too (mostly, including POSIX headers in this case). Add CI cases to track this.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>