### PR TITLE
include: net: socketutils: Make sure they work with CONFIG_POSIX_API

### DIFF
--- a/include/net/socketutils.h
+++ b/include/net/socketutils.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef CONFIG_NET_SOCKETS_POSIX_NAMES
+#include <net/socket.h>
+#else
+#include <posix/netdb.h>
+#endif
+
 /**
  * @brief Find port in addr:port string.
  *

--- a/subsys/net/lib/utils/addr_utils.c
+++ b/subsys/net/lib/utils/addr_utils.c
@@ -4,12 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <net/socket.h>
+#ifdef CONFIG_NET_SOCKETS
 
-/* These utility functions are intended to be on top of POSIX API, and don't
- * make sense if it's not available.
- */
-#ifdef CONFIG_NET_SOCKETS_POSIX_NAMES
+#include <net/socketutils.h>
 
 const char *net_addr_str_find_port(const char *addr_str)
 {


### PR DESCRIPTION
Previously, they were tested only with CONFIG_NET_SOCKETS_POSIX_NAMES,
but should also work with POSIX subsys.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>