### PR TITLE
soc : arm : microchip_mec Move custom busy wait config to MEC1501 SoC

### DIFF
--- a/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
+++ b/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
@@ -81,10 +81,6 @@ endif # ESPI
 
 if RTOS_TIMER
 
-config MCHP_XEC_RTOS_TIMER
-	bool
-	default y
-
 # XEC RTOS timer HW frequency is fixed at 32768
 # The driver requires tickless mode and ticks per
 # second to be 32768 for accurate operation.
@@ -95,15 +91,14 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 32768
 
-config ARCH_HAS_CUSTOM_BUSY_WAIT
-	default y
-
 endif # RTOS_TIMER
 
 if !RTOS_TIMER
 
-config CORTEX_M_SYSTICK
-	default y
+# If RTOS timer is not enabled we use ARM Cortex-M
+# SYSTICK. SYSTICK frequency is 48MHz divided by
+# SOC_MEC1501_PROC_CLK_DIV.
+#
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 48000000

--- a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
@@ -19,4 +19,23 @@ config NUM_IRQS
 	default 174
 
 source "soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501*"
+
+if RTOS_TIMER
+
+config MCHP_XEC_RTOS_TIMER
+	bool
+	default y
+
+config ARCH_HAS_CUSTOM_BUSY_WAIT
+	default y
+
+endif # RTOS_TIMER
+
+if !RTOS_TIMER
+
+config CORTEX_M_SYSTICK
+	default y
+
+endif # RTOS_TIMER
+
 endif # SOC_SERIES_MEC1501X


### PR DESCRIPTION
Configuration item custom busy wait is required for all MEC1501 series
if its RTOS timer driver is enabled. We moved the configuration logic
from board level to MEC1501 SoC level.

Signed-off-by: Scott Worley <scott.worley@microchip.com>

Closes #18880 