### PR TITLE
[TOPIC: DTS] scripts: dts: Remove unused variable in old scripts

### DIFF
--- a/scripts/dts/extract/clocks.py
+++ b/scripts/dts/extract/clocks.py
@@ -22,7 +22,6 @@ from extract.directive import DTDirective
 #
 class DTClocks(DTDirective):
     def _extract_consumer(self, node_path, clocks, def_label):
-        clock_consumer_bindings = get_binding(node_path)
         clock_consumer_label = 'DT_' + node_label(node_path)
 
         clock_index = 0


### PR DESCRIPTION
Detected by pylint. Getting rid of pylint warnings for a CI check.