### PR TITLE
menuconfig: Suppress spurious pylint tuple unpacking warning

### DIFF
--- a/scripts/kconfig/menuconfig.py
+++ b/scripts/kconfig/menuconfig.py
@@ -3181,7 +3181,7 @@ def _safe_addstr(win, *args):
         if len(args) == 2:
             attr = args[1]
     else:
-        y, x, s = args[:3]
+        y, x, s = args[:3]  # pylint: disable=unbalanced-tuple-unpacking
         if len(args) == 4:
             attr = args[3]
 


### PR DESCRIPTION
pylint might be afraid that there'd be less than three elements in
'args', but there never is. Fixes this warning:

    scripts/kconfig/menuconfig.py:3184:8: W0632: Possible unbalanced
    tuple unpacking with sequence: left side has 3 label(s), right side
    has 0 value(s) (unbalanced-tuple-unpacking)