### PR TITLE
xtensa: xtensa_intgen.py: Change 'not lvl in ...' to 'lvl not in ...'

### DIFF
--- a/arch/xtensa/core/xtensa_intgen.py
+++ b/arch/xtensa/core/xtensa_intgen.py
@@ -74,7 +74,7 @@ for match in re.finditer(r'__xtensa_int_level_magic__\s+(\d+)\s+(\d+)', blob):
     irq = int(match.group(1))
     lvl = int(match.group(2))
 
-    if not lvl in ints_by_lvl:
+    if lvl not in ints_by_lvl:
         ints_by_lvl[lvl] = []
 
     ints_by_lvl[lvl].append(irq)


### PR DESCRIPTION
Use the 'not in' operator. Fixes this pylint warning:

    arch/xtensa/core/xtensa_intgen.py:77:7: C0113: Consider changing
    "not lvl in ints_by_lvl" to "lvl not in ints_by_lvl" (unneeded-not)

Not exactly the end of the world. Just fixing pylint warnings for a CI check.