### PR TITLE
scripts: sanitycheck: Remove redundant ifs

### DIFF
--- a/scripts/sanity_chk/expr_parser.py
+++ b/scripts/sanity_chk/expr_parser.py
@@ -205,9 +205,9 @@ def ast_expr(ast, env):
     elif ast[0] == "in":
         return ast_sym(ast[1], env) in ast[2]
     elif ast[0] == "exists":
-        return True if ast_sym(ast[1], env) else False
+        return bool(ast_sym(ast[1], env))
     elif ast[0] == ":":
-        return True if re.compile(ast[2]).match(ast_sym(ast[1], env)) else False
+        return bool(re.match(ast[2], ast_sym(ast[1], env)))
 
 mutex = threading.Lock()
 

--- a/scripts/sanity_chk/ini2yaml.py
+++ b/scripts/sanity_chk/ini2yaml.py
@@ -22,7 +22,7 @@ for section in config.sections():
     for opt in config.options(section):
         value = config.get(section, opt)
         if value in ['false', 'true']:
-            tc[opt] = True if value == 'true' else False
+            tc[opt] = value == 'true'
         else:
             tc[opt] = value
 


### PR DESCRIPTION
Fixes these pylint warnings:

    scripts/sanity_chk/ini2yaml.py:25:22: R1719: The if expression can
    be replaced with 'test' (simplifiable-if-expression)

    scripts/sanity_chk/expr_parser.py:208:15: R1719: The if expression
    can be replaced with 'bool(test)' (simplifiable-if-expression)

    scripts/sanity_chk/expr_parser.py:210:15: R1719: The if expression
    can be replaced with 'bool(test)' (simplifiable-if-expression)

Also replace a redundant re.compile().match() with re.match(). compile()
doesn't help when re-compiling the regular expression each time through.

(compile() often doesn't help much in general, because the 're' module
caches compiled regexes.)