### PR TITLE
doc: conf.py: Replace bare 'except' with 'except Exception'

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -97,7 +97,7 @@ try:
             extraversion = val
         if version_major and version_minor and patchlevel and extraversion:
             break
-except:
+except Exception:
     pass
 finally:
     if version_major and version_minor and patchlevel and extraversion is not None:


### PR DESCRIPTION
A bare 'except:' can do some annoying stuff like eat Ctrl-C (because it
catches KeyboardInterrupt). Better to use 'except Exception:' as a
catch-all.

Even better might be to catch some more specific exception, because even
'except Exception:' eats stuff like misspelled identifiers.

Fixes this pylint warning:

    doc/conf.py:99:0: W0702: No exception type(s) specified
    (bare-except)