### PR TITLE
gen_gcov_files.py: Replace bare 'except' with 'except Exception'

### DIFF
--- a/scripts/gen_gcov_files.py
+++ b/scripts/gen_gcov_files.py
@@ -48,10 +48,10 @@ def create_gcda_files(extracted_coverage_info):
         # if kobject_hash is given for coverage gcovr fails
         # hence skipping it problem only in gcovr v4.1
         if "kobject_hash" in filename:
-            filename = (filename[:-4]) +"gcno"
+            filename = filename[:-4] + "gcno"
             try:
                 os.remove(filename)
-            except:
+            except Exception:
                 pass
             continue
 


### PR DESCRIPTION
A bare 'except:' can do some annoying stuff like eat Ctrl-C (because it
catches KeyboardInterrupt). Better to use 'except Exception:' as a
catch-all.

Even better might be to catch some more specific exception, because even
'except Exception:' eats stuff like misspelled identifiers.

Fixes this pylint warning:

    scripts/gen_gcov_files.py:54:12: W0702: No exception type(s)
    specified (bare-except)

Piggyback a formatting nit.