### PR TITLE
west: run_common.py: Remove redundant 'if'

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -172,7 +172,7 @@ def _build_dir(args, die_if_none=True):
         return args.build_dir
 
     guess = config.get('build', 'guess-dir', fallback='never')
-    guess = True if guess == 'runners' else False
+    guess = guess == 'runners'
     dir = find_build_dir(None, guess)
 
     if dir and is_zephyr_build(dir):


### PR DESCRIPTION
Fixes this pylint warning:

    scripts/west_commands/run_common.py:175:12: R1719: The if expression
    can be replaced with 'test' (simplifiable-if-expression)

Fixing pylint warnings for a CI check.