### PR TITLE
[TOPIC: DTS] scripts: dts: Replace bare 'except's in old scripts

### DIFF
--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -186,7 +186,7 @@ def node_label(node_path):
             unit_addr += translate_addr(unit_addr, node_path,
                          nr_addr_cells, nr_size_cells)
             unit_addr = "%x" % unit_addr
-        except:
+        except Exception:
             unit_addr = node_path.split('@')[-1]
         def_label += '_' + str_to_label(unit_addr)
     else:
@@ -500,7 +500,7 @@ def extract_cells(node_path, prop, prop_values, names, index,
 
         try:
             name = names.pop(0).upper()
-        except:
+        except Exception:
             name = ''
 
         # Get number of cells per element of current property

--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -44,7 +44,7 @@ class DTReg(DTDirective):
 
                 try:
                     cs_gpios = deepcopy(find_parent_prop(node_path, 'cs-gpios'))
-                except:
+                except Exception:
                     pass
 
                 if cs_gpios:
@@ -75,7 +75,7 @@ class DTReg(DTDirective):
 
             try:
                 name = [names.pop(0).upper()]
-            except:
+            except Exception:
                 name = []
 
             for x in range(nr_address_cells):


### PR DESCRIPTION
A bare 'except:' can do some annoying stuff like eat Ctrl-C (because it
catches KeyboardInterrupt). Better to use 'except Exception:' as a
catch-all.

Even better might be to catch some more specific exception, because even
'except Exception:' eats stuff like misspelled identifiers.

Fixes this pylint warning:

    W0702: No exception type(s) specified (bare-except)

Fixing pylint warnings for a CI check.