### PR TITLE
net: net_if: avoid deref of NULL L2

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -431,7 +431,7 @@ static enum net_l2_flags l2_flags_get(struct net_if *iface)
 {
 	enum net_l2_flags flags = 0;
 
-	if (net_if_l2(iface)->get_flags) {
+	if (net_if_l2(iface) && net_if_l2(iface)->get_flags) {
 		flags = net_if_l2(iface)->get_flags(iface);
 	}
 
@@ -794,10 +794,7 @@ static void join_mcast_nodes(struct net_if *iface, struct in6_addr *addr)
 {
 	enum net_l2_flags flags = 0;
 
-	if (net_if_l2(iface)->get_flags) {
-		flags = net_if_l2(iface)->get_flags(iface);
-	}
-
+	flags = l2_flags_get(iface);
 	if (flags & NET_L2_MULTICAST) {
 		join_mcast_allnodes(iface);
 
@@ -3345,7 +3342,7 @@ int net_if_up(struct net_if *iface)
 	}
 
 	/* If the L2 does not support enable just set the flag */
-	if (!net_if_l2(iface)->enable) {
+	if (!net_if_l2(iface) || !net_if_l2(iface)->enable) {
 		goto done;
 	}
 
@@ -3402,7 +3399,7 @@ int net_if_down(struct net_if *iface)
 	}
 
 	/* If the L2 does not support enable just clear the flag */
-	if (!net_if_l2(iface)->enable) {
+	if (!net_if_l2(iface) || !net_if_l2(iface)->enable) {
 		goto done;
 	}
 
@@ -3426,10 +3423,7 @@ static int promisc_mode_set(struct net_if *iface, bool enable)
 
 	NET_ASSERT(iface);
 
-	if (net_if_l2(iface)->get_flags) {
-		l2_flags = net_if_l2(iface)->get_flags(iface);
-	}
-
+	l2_flags = l2_flags_get(iface);
 	if (!(l2_flags & NET_L2_PROMISC_MODE)) {
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
When using offloaded network, an L2 is never assigned to the net_if.
Only certain portions of the net_if code are referenced such as:
net_if_up()
net_if_down()

And these functions make use of several L2 references:
get_flags()
enable()

Let's add checks to make sure we don't deref a NULL when using these
functions.

Fixes the following exception on K64F and other HW which can make
use of offloaded network HW:
FATAL: ***** Reserved Exception ( -16) *****
FATAL: r0/a1:  0x00000010  r1/a2:  0x0000644f  r2/a3:  0x00000000
FATAL: r3/a4:  0x00000000 r12/ip:  0x2000474c r14/lr:  0x0001475b
FATAL:  xpsr:  0x00000000
FATAL: Faulting instruction address (r15/pc): 0x0001b1cd
FATAL: >>> ZEPHYR FATAL ERROR 0: CPU exception
FATAL: Current thread: 0x20004c4c (unknown)

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/18957

Signed-off-by: Michael Scott <mike@foundries.io>