### PR TITLE
scripts: Fix random typo'd whitespace

### DIFF
--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -105,8 +105,8 @@ def read_intlist(intlist_path, syms):
 def parse_args():
     global args
 
-    parser = argparse.ArgumentParser(description = __doc__,
-            formatter_class = argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(description=__doc__,
+            formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument("-e", "--big-endian", action="store_true",
             help="Target encodes data in big-endian format (little endian is "

--- a/boards/xtensa/intel_s1000_crb/support/device.py
+++ b/boards/xtensa/intel_s1000_crb/support/device.py
@@ -100,7 +100,7 @@ class Device:
         self.reset_pin.write(True)
         self.check_device_ready()
 
-    def send_receive(self, data, wait = True):
+    def send_receive(self, data, wait=True):
         """
         Transmit and receive full duplex data over SPI
         If requested to wait, wait for device to become ready

--- a/boards/xtensa/intel_s1000_crb/support/download.py
+++ b/boards/xtensa/intel_s1000_crb/support/download.py
@@ -65,7 +65,7 @@ def setup_device():
     Configure SPI master device
     Reset target and send initialization commands
     """
-    sue_creek.configure_device(spi_mode = 3, order = 'msb', bits = 8)
+    sue_creek.configure_device(spi_mode=3, order='msb', bits=8)
     sue_creek.reset_device()
 
     command = msg.create_memwrite_cmd((0x71d14, 0, 0x71d24, 0,
@@ -112,7 +112,7 @@ def execute_firmware():
     msg.print_response(response)
 
     command = msg.create_execfw_cmd()
-    response = sue_creek.send_receive(command, wait = False)
+    response = sue_creek.send_receive(command, wait=False)
     msg.print_response(response)
 
 def main():

--- a/boards/xtensa/intel_s1000_crb/support/messenger.py
+++ b/boards/xtensa/intel_s1000_crb/support/messenger.py
@@ -66,7 +66,7 @@ class Message:
             word = bitstruct.unpack_from('u32', self.tx_data, offset)
             print('Index: %2d Content: 0x%08x' %(index, word[0]))
 
-    def print_response(self, msg, verbose = False):
+    def print_response(self, msg, verbose=False):
         """
         Parses and prints the contents of the response message
         """

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -524,7 +524,7 @@ html_context = {
     'is_release': is_release,
     'theme_logo_only': False,
     'current_version': version,
-    'versions': ( ("latest", "/"),
+    'versions': (("latest", "/"),
                  ("2.0.0", "/2.0.0/"),
                  ("1.14.0", "/1.14.0/"),
                  ("1.13.0", "/1.13.0/"),

--- a/doc/extensions/lexer/DtsLexer.py
+++ b/doc/extensions/lexer/DtsLexer.py
@@ -62,7 +62,7 @@ class DtsLexer(RegexLexer):
         'node': [
             (r'\s+', Text),
             (r'((?:[0-9a-zA-Z,._+-]+):)?(\s*)([0-9a-zA-Z,._+-]+)(@[0-9a-zA-Z,._+-]+)?(\s*)({)', bygroups(Name.Label, Text, Name.Class, Name.Function, Text, Punctuation), ('node-content')),
-            (r'(/)(\s+)({)', bygroups(Keyword, Text, Punctuation) , ('node-content')),
+            (r'(/)(\s+)({)', bygroups(Keyword, Text, Punctuation), ('node-content')),
         ],
         'node-content': [
             include('comments'),

--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -207,7 +207,7 @@ class ZephyrAppCommandsDirective(Directive):
             if tool_comment:
                 paragraph = nodes.paragraph()
                 paragraph += nodes.Text(tool_comment.format(
-                                    'CMake and {}'.format( generator)))
+                    'CMake and {}'.format(generator)))
                 content.append(paragraph)
                 content.append(self._lit_block(c))
             else:
@@ -295,7 +295,7 @@ class ZephyrAppCommandsDirective(Directive):
         if host_os == "unix":
             content.append('{} {} && cd {}'.format(mkdir, build_dir, build_dir))
         elif host_os == "win":
-            build_dir = build_dir.replace('/','\\')
+            build_dir = build_dir.replace('/', '\\')
             content.append('mkdir {} & cd {}'.format(build_dir, build_dir))
         return content
 

--- a/scripts/gen_app_partitions.py
+++ b/scripts/gen_app_partitions.py
@@ -98,7 +98,7 @@ elf_part_size_regex = re.compile(r'z_data_smem_(.*)_part_size')
 
 def find_obj_file_partitions(filename, partitions):
     with open(filename, 'rb') as f:
-        full_lib = ELFFile( f)
+        full_lib = ELFFile(f)
         if not full_lib:
             sys.exit("Error parsing file: " + filename)
 
@@ -126,7 +126,7 @@ def parse_obj_files(partitions):
     # Iterate over all object files to find partitions
     for dirpath, _, files in os.walk(args.directory):
         for filename in files:
-            if re.match(r".*\.obj$",filename):
+            if re.match(r".*\.obj$", filename):
                 fullname = os.path.join(dirpath, filename)
                 find_obj_file_partitions(fullname, partitions)
 
@@ -191,7 +191,7 @@ def parse_args():
                         help="ELF file")
     parser.add_argument("-o", "--output", required=False,
                         help="Output ld file")
-    parser.add_argument("-v", "--verbose", action="count", default =0,
+    parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="Verbose Output")
     parser.add_argument("-l", "--library", nargs=2, action="append", default=[],
                         metavar=("LIBRARY", "PARTITION"),

--- a/scripts/gen_cfb_font_header.py
+++ b/scripts/gen_cfb_font_header.py
@@ -98,7 +98,7 @@ def generate_header():
 
     zephyr_base = os.environ.get('ZEPHYR_BASE', "")
 
-    clean_cmd = [ ]
+    clean_cmd = []
     for arg in sys.argv:
         if arg.startswith("--bindir"):
             # Drop. Assumes --bindir= was passed with '=' sign.

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -73,7 +73,7 @@ from collections import OrderedDict
 # Regular dictionaries are ordered only with Python 3.6 and
 # above. Good summary and pointers to official documents at:
 # https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6
-kobjects = OrderedDict ([
+kobjects = OrderedDict([
     ("k_mem_slab", (None, False)),
     ("k_msgq", (None, False)),
     ("k_mutex", (None, False)),

--- a/scripts/sanity_chk/expr_parser.py
+++ b/scripts/sanity_chk/expr_parser.py
@@ -101,7 +101,7 @@ precedence = (
     ('left', 'OR'),
     ('left', 'AND'),
     ('right', 'NOT'),
-    ('nonassoc' , 'EQUALS', 'NOTEQUALS', 'GT', 'LT', 'GTEQ', 'LTEQ', 'IN'),
+    ('nonassoc', 'EQUALS', 'NOTEQUALS', 'GT', 'LT', 'GTEQ', 'LTEQ', 'IN'),
 )
 
 def p_expr_or(p):

--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -31,7 +31,7 @@ class Harness:
 
         if config:
             self.type = config.get('type', None)
-            self.regex = config.get('regex', [] )
+            self.regex = config.get('regex', [])
             self.repeat = config.get('repeat', 1)
             self.ordered = config.get('ordered', True)
 

--- a/scripts/sanity_chk/ini2yaml.py
+++ b/scripts/sanity_chk/ini2yaml.py
@@ -26,12 +26,12 @@ for section in config.sections():
         else:
             tc[opt] = value
 
-    test = { section : tc}
+    test = {section : tc}
     tests.append(test)
 
 y['tests'] = tests
 if sample:
-    y['sample'] = { 'name': "TBD", 'description': "TBD" }
+    y['sample'] = {'name': "TBD", 'description': "TBD"}
 
 with open(out_file, "w") as f:
-    yaml.dump(y, f, width=50, indent=4,  default_flow_style=False)
+    yaml.dump(y, f, width=50, indent=4, default_flow_style=False)

--- a/scripts/sanity_chk/scl.py
+++ b/scripts/sanity_chk/scl.py
@@ -46,8 +46,8 @@ try:
     def _yaml_validate(data, schema):
         if not schema:
             return
-        c = pykwalify.core.Core(source_data = data, schema_data = schema)
-        c.validate(raise_exception = True)
+        c = pykwalify.core.Core(source_data=data, schema_data=schema)
+        c.validate(raise_exception=True)
 
 except ImportError as e:
     log.warning("can't import pykwalify; won't validate YAML (%s)", e)


### PR DESCRIPTION
Reported by pylint's 'bad-whitespace' warning.

Not gonna enable this warning in the CI check, because it flags stuff
like deliberately aligning assignments and gets too cultish. Just a
cleanup pass.

For whatever reason, the common convention in Python is to skip spaces
around '=' when passing keyword arguments and giving default arguments:

```python
f(x=3, y=4)
def f(x, y=8):
    ...
```