### PR TITLE
cmake: Fix bug where -Wno- flags could not be compatbility-checked

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -754,8 +754,17 @@ function(zephyr_check_compiler_flag lang option check)
     return()
   endif()
 
-  # Test the flag
-  check_compiler_flag(${lang} "${option}" inner_check)
+  # Flags that start with -Wno-<warning> can not be tested by
+  # check_compiler_flag, they will always pass, but -W<warning> can be
+  # tested, so to test -Wno-<warning> flags we test -W<warning>
+  # instead.
+  if("${option}" MATCHES "-Wno-(.*)")
+    set(possibly_translated_option -W${CMAKE_MATCH_1})
+  else()
+    set(possibly_translated_option ${option})
+  endif()
+
+  check_compiler_flag(${lang} "${possibly_translated_option}" inner_check)
 
   set(${check} ${inner_check} PARENT_SCOPE)
 


### PR DESCRIPTION
It turns out that 'check_compiler_flag' has not been working for flags
that start with -Wno-. This has caused old compilers to accidentally
use flags that they do not support.

To fix this we check for compatibility with the appropriate -W flag
instead and infer the -Wno- compatibility from this check.

The root cause of this problem is explained well here:

https://github.com/zephyrproject-rtos/zephyr/pull/18922#discussion_r321537098

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>