### PR TITLE
[TOPIC: DTS] scripts: edtlib: Add backwards compatibility for 'category:'

### DIFF
--- a/scripts/dts/test-bindings/child.yaml
+++ b/scripts/dts/test-bindings/child.yaml
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-include: [grandchild-1.yaml, grandchild-2.yaml]
-
-# Legacy include
-inherits:
-    !include grandchild-3.yaml
+include: [grandchild-1.yaml, grandchild-2.yaml, grandchild-3.yaml]
 
 properties:
     bar:

--- a/scripts/dts/test-bindings/deprecated-include.yaml
+++ b/scripts/dts/test-bindings/deprecated-include.yaml
@@ -1,0 +1,4 @@
+properties:
+    required-2:
+        type: int
+        required: true

--- a/scripts/dts/test-bindings/deprecated.yaml
+++ b/scripts/dts/test-bindings/deprecated.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+title: Deprecated stuff
+description: Deprecated stuff
+
+# Deprecated include syntax
+inherits:
+    !include deprecated-include.yaml
+
+properties:
+    compatible:
+        constraint: "deprecated"
+        type: string-array
+
+    # Deprecated 'category' key (replaced with 'required')
+
+    required:
+        type: int
+        category: required
+
+    optional:
+        type: int
+        category: optional

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -274,7 +274,7 @@
 	};
 
 	//
-	// For testing 'include:' and the legacy 'inherits: !include ...'
+	// For testing 'include:'
 	//
 
 	binding-include {
@@ -322,5 +322,15 @@
 			bar = <2>;
 			not-speced = <0>;
 		};
+	};
+
+	//
+	// For testing deprecated features
+	//
+
+	deprecated {
+		compatible = "deprecated";
+		required = <1>;
+		required-2 = <2>;
 	};
 };


### PR DESCRIPTION
Having backwards compatibility for !include and 'constraint:' is silly
without also having backwards compatibility for 'category:', because
that forces a binding change anyway.

Add backwards compatibility for 'category:', and just print a
deprecation warning when it's used.

Also move tests for deprecated features into a dedicated
test-bindings/deprecated.yaml binding, instead of piggybacking on other
tests.