### PR TITLE
west: flash: Fix exception on build folder guessing

### DIFF
--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -64,6 +64,8 @@ def _resolve_build_dir(fmt, guess, cwd, **kwargs):
         except KeyError:
             # Missing key, check sub-folders and match if a single one exists
             while True:
+                if not curr.exists():
+                    return None
                 dirs = [f for f in curr.iterdir() if f.is_dir()]
                 if len(dirs) != 1:
                     return None


### PR DESCRIPTION
When guessing the build folder, the current path might not exist at all,
leading to an uncaught exception when trying to list its folders. Fix
this by making sure the path exists at all first.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>