### PR TITLE
doc: cmake: Fix PYTHONPATH on Windows

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -184,7 +184,7 @@ add_custom_target(
 )
 
 if(WIN32)
-  set(SEP ;)
+  set(SEP $<SEMICOLON>)
 else()
   set(SEP :)
 endif()


### PR DESCRIPTION
Correctly set the separator as a semicolon on Windows when
constructing the PYTHONPATH environment variable so that CMake
doesn't intepret it and swallow it.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>