### PR TITLE
Smp pairing both sides handling

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -327,6 +327,9 @@ typedef enum __packed {
  *  to achieve due to local or remote device limitation (e.g., input output
  *  capabilities), or if the maximum number of paired devices has been reached.
  *
+ *  This function may return error if the pairing procedure has already been
+ *  initiated by the local device or the peer device.
+ *
  *  @param conn Connection object.
  *  @param sec Requested security level.
  *

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1030,28 +1030,11 @@ static int start_security(struct bt_conn *conn)
 	}
 #endif /* CONFIG_BT_BREDR */
 
-	switch (conn->role) {
-#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_SMP)
-	case BT_HCI_ROLE_MASTER:
-	{
-		if (!bt_smp_keys_check(conn)) {
-			return bt_smp_send_pairing_req(conn);
-		}
-		/* LE SC LTK and legacy master LTK are stored in same place */
-		return bt_conn_le_start_encryption(conn,
-						   conn->le.keys->ltk.rand,
-						   conn->le.keys->ltk.ediv,
-						   conn->le.keys->ltk.val,
-						   conn->le.keys->enc_size);
+	if (IS_ENABLED(CONFIG_BT_SMP)) {
+		return bt_smp_start_security(conn);
 	}
-#endif /* CONFIG_BT_CENTRAL && CONFIG_BT_SMP */
-#if defined(CONFIG_BT_PERIPHERAL) && defined(CONFIG_BT_SMP)
-	case BT_HCI_ROLE_SLAVE:
-		return bt_smp_send_security_req(conn);
-#endif /* CONFIG_BT_PERIPHERAL && CONFIG_BT_SMP */
-	default:
-		return -EINVAL;
-	}
+
+	return -EINVAL;
 }
 
 int bt_conn_set_security(struct bt_conn *conn, bt_security_t sec)

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -308,7 +308,7 @@ no_callbacks:
 static u8_t legacy_get_pair_method(struct bt_smp *smp, u8_t remote_io);
 #endif
 
-bool bt_smp_keys_check(struct bt_conn *conn)
+static bool smp_keys_check(struct bt_conn *conn)
 {
 	if (atomic_test_bit(conn->flags, BT_CONN_FORCE_PAIR)) {
 		return false;
@@ -2547,8 +2547,91 @@ static struct bt_smp *smp_chan_get(struct bt_conn *conn)
 	return CONTAINER_OF(chan, struct bt_smp, chan);
 }
 
+bool bt_smp_request_ltk(struct bt_conn *conn, u64_t rand, u16_t ediv, u8_t *ltk)
+{
+	struct bt_smp *smp;
+	u8_t enc_size;
+
+	smp = smp_chan_get(conn);
+	if (!smp) {
+		return false;
+	}
+
+	/*
+	 * Both legacy STK and LE SC LTK have rand and ediv equal to zero.
+	 * If pairing is in progress use the TK for encryption.
+	 */
+	if (ediv == 0U && rand == 0U &&
+	    atomic_test_bit(smp->flags, SMP_FLAG_PAIRING) &&
+	    atomic_test_bit(smp->flags, SMP_FLAG_ENC_PENDING)) {
+		enc_size = get_encryption_key_size(smp);
+
+		/*
+		 * We keep both legacy STK and LE SC LTK in TK.
+		 * Also use only enc_size bytes of key for encryption.
+		 */
+		memcpy(ltk, smp->tk, enc_size);
+		if (enc_size < BT_SMP_MAX_ENC_KEY_SIZE) {
+			(void)memset(ltk + enc_size, 0,
+				     BT_SMP_MAX_ENC_KEY_SIZE - enc_size);
+		}
+
+		return true;
+	}
+
+	if (!conn->le.keys) {
+		conn->le.keys = bt_keys_find(BT_KEYS_LTK_P256, conn->id,
+					     &conn->le.dst);
+		if (!conn->le.keys) {
+			conn->le.keys = bt_keys_find(BT_KEYS_SLAVE_LTK,
+						     conn->id, &conn->le.dst);
+		}
+	}
+
+	if (ediv == 0U && rand == 0U &&
+	    conn->le.keys && (conn->le.keys->keys & BT_KEYS_LTK_P256)) {
+		enc_size = conn->le.keys->enc_size;
+
+		memcpy(ltk, conn->le.keys->ltk.val, enc_size);
+		if (enc_size < BT_SMP_MAX_ENC_KEY_SIZE) {
+			(void)memset(ltk + enc_size, 0,
+				     BT_SMP_MAX_ENC_KEY_SIZE - enc_size);
+		}
+
+		return true;
+	}
+
+#if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
+	if (conn->le.keys && (conn->le.keys->keys & BT_KEYS_SLAVE_LTK) &&
+	    !memcmp(conn->le.keys->slave_ltk.rand, &rand, 8) &&
+	    !memcmp(conn->le.keys->slave_ltk.ediv, &ediv, 2)) {
+		enc_size = conn->le.keys->enc_size;
+
+		memcpy(ltk, conn->le.keys->slave_ltk.val, enc_size);
+		if (enc_size < BT_SMP_MAX_ENC_KEY_SIZE) {
+			(void)memset(ltk + enc_size, 0,
+				     BT_SMP_MAX_ENC_KEY_SIZE - enc_size);
+		}
+
+		return true;
+	}
+#endif /* !CONFIG_BT_SMP_SC_PAIR_ONLY */
+
+	if (atomic_test_bit(smp->flags, SMP_FLAG_SEC_REQ)) {
+		/* Notify higher level that security failed if security was
+		 * initiated by slave.
+		 */
+		bt_conn_security_changed(smp->chan.chan.conn,
+					 BT_SECURITY_ERR_PIN_OR_KEY_MISSING);
+
+	}
+
+	smp_reset(smp);
+	return false;
+}
+
 #if defined(CONFIG_BT_PERIPHERAL)
-int bt_smp_send_security_req(struct bt_conn *conn)
+static int smp_send_security_req(struct bt_conn *conn)
 {
 	struct bt_smp *smp;
 	struct bt_smp_security_request *req;
@@ -2571,7 +2654,7 @@ int bt_smp_send_security_req(struct bt_conn *conn)
 	}
 
 	/* early verify if required sec level if reachable */
-	if (!(sec_level_reachable(conn) || bt_smp_keys_check(conn))) {
+	if (!(sec_level_reachable(conn) || smp_keys_check(conn))) {
 		return -EINVAL;
 	}
 
@@ -2743,7 +2826,7 @@ static u8_t sc_send_public_key(struct bt_smp *smp)
 }
 
 #if defined(CONFIG_BT_CENTRAL)
-int bt_smp_send_pairing_req(struct bt_conn *conn)
+static int smp_send_pairing_req(struct bt_conn *conn)
 {
 	struct bt_smp *smp;
 	struct bt_smp_pairing *req;
@@ -3613,7 +3696,7 @@ static u8_t smp_security_request(struct bt_smp *smp, struct net_buf *buf)
 
 	return 0;
 pair:
-	if (bt_smp_send_pairing_req(conn) < 0) {
+	if (smp_send_pairing_req(conn) < 0) {
 		return BT_SMP_ERR_UNSPECIFIED;
 	}
 
@@ -4975,6 +5058,33 @@ int bt_passkey_set(unsigned int passkey)
 }
 #endif /* CONFIG_BT_FIXED_PASSKEY */
 
+int bt_smp_start_security(struct bt_conn *conn)
+{
+	switch (conn->role) {
+#if defined(CONFIG_BT_CENTRAL)
+	case BT_HCI_ROLE_MASTER:
+	{
+		if (!smp_keys_check(conn)) {
+			return smp_send_pairing_req(conn);
+		}
+
+		/* LE SC LTK and legacy master LTK are stored in same place */
+		return bt_conn_le_start_encryption(conn,
+						   conn->le.keys->ltk.rand,
+						   conn->le.keys->ltk.ediv,
+						   conn->le.keys->ltk.val,
+						   conn->le.keys->enc_size);
+	}
+#endif /* CONFIG_BT_CENTRAL && CONFIG_BT_SMP */
+#if defined(CONFIG_BT_PERIPHERAL)
+	case BT_HCI_ROLE_SLAVE:
+		return smp_send_security_req(conn);
+#endif /* CONFIG_BT_PERIPHERAL && CONFIG_BT_SMP */
+	default:
+		return -EINVAL;
+	}
+}
+
 void bt_smp_update_keys(struct bt_conn *conn)
 {
 	struct bt_smp *smp;
@@ -5050,55 +5160,6 @@ void bt_smp_update_keys(struct bt_conn *conn)
 	} else {
 		conn->le.keys->flags &= ~BT_KEYS_SC;
 	}
-}
-
-bool bt_smp_get_tk(struct bt_conn *conn, u8_t *tk)
-{
-	struct bt_smp *smp;
-	u8_t enc_size;
-
-	smp = smp_chan_get(conn);
-	if (!smp) {
-		return false;
-	}
-
-	if (!atomic_test_bit(smp->flags, SMP_FLAG_PAIRING)) {
-		return false;
-	}
-
-	if (!atomic_test_bit(smp->flags, SMP_FLAG_ENC_PENDING)) {
-		return false;
-	}
-
-	enc_size = get_encryption_key_size(smp);
-
-	/*
-	 * We keep both legacy STK and LE SC LTK in TK.
-	 * Also use only enc_size bytes of key for encryption.
-	 */
-	memcpy(tk, smp->tk, enc_size);
-	if (enc_size < sizeof(smp->tk)) {
-		(void)memset(tk + enc_size, 0, sizeof(smp->tk) - enc_size);
-	}
-
-	return true;
-}
-
-void bt_smp_keys_reject(struct bt_conn *conn)
-{
-	struct bt_smp *smp;
-
-	smp = smp_chan_get(conn);
-	if (!smp) {
-		return;
-	}
-
-	if (atomic_test_bit(smp->flags, SMP_FLAG_SEC_REQ)) {
-		bt_conn_security_changed(smp->chan.chan.conn,
-					 BT_SECURITY_ERR_PIN_OR_KEY_MISSING);
-	}
-
-	smp_reset(smp);
 }
 
 static int bt_smp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -308,6 +308,42 @@ no_callbacks:
 static u8_t legacy_get_pair_method(struct bt_smp *smp, u8_t remote_io);
 #endif
 
+bool bt_smp_keys_check(struct bt_conn *conn)
+{
+	if (atomic_test_bit(conn->flags, BT_CONN_FORCE_PAIR)) {
+		return false;
+	}
+
+	if (!conn->le.keys) {
+		conn->le.keys = bt_keys_find(BT_KEYS_LTK_P256,
+						     conn->id, &conn->le.dst);
+		if (!conn->le.keys) {
+			conn->le.keys = bt_keys_find(BT_KEYS_LTK,
+						     conn->id,
+						     &conn->le.dst);
+		}
+	}
+
+	if (!conn->le.keys ||
+	    !(conn->le.keys->keys & (BT_KEYS_LTK | BT_KEYS_LTK_P256))) {
+		return false;
+	}
+
+	if (conn->required_sec_level > BT_SECURITY_L2 &&
+	    !(conn->le.keys->flags & BT_KEYS_AUTHENTICATED)) {
+		return false;
+	}
+
+	if (conn->required_sec_level > BT_SECURITY_L3 &&
+	    !(conn->le.keys->flags & BT_KEYS_AUTHENTICATED) &&
+	    !(conn->le.keys->keys & BT_KEYS_LTK_P256) &&
+	    !(conn->le.keys->enc_size == BT_SMP_MAX_ENC_KEY_SIZE)) {
+		return false;
+	}
+
+	return true;
+}
+
 static u8_t get_pair_method(struct bt_smp *smp, u8_t remote_io)
 {
 	struct bt_smp_pairing *req, *rsp;
@@ -5043,42 +5079,6 @@ bool bt_smp_get_tk(struct bt_conn *conn, u8_t *tk)
 	memcpy(tk, smp->tk, enc_size);
 	if (enc_size < sizeof(smp->tk)) {
 		(void)memset(tk + enc_size, 0, sizeof(smp->tk) - enc_size);
-	}
-
-	return true;
-}
-
-bool bt_smp_keys_check(struct bt_conn *conn)
-{
-	if (atomic_test_bit(conn->flags, BT_CONN_FORCE_PAIR)) {
-		return false;
-	}
-
-	if (!conn->le.keys) {
-		conn->le.keys = bt_keys_find(BT_KEYS_LTK_P256,
-						     conn->id, &conn->le.dst);
-		if (!conn->le.keys) {
-			conn->le.keys = bt_keys_find(BT_KEYS_LTK,
-						     conn->id,
-						     &conn->le.dst);
-		}
-	}
-
-	if (!conn->le.keys ||
-	    !(conn->le.keys->keys & (BT_KEYS_LTK | BT_KEYS_LTK_P256))) {
-		return false;
-	}
-
-	if (conn->required_sec_level > BT_SECURITY_L2 &&
-	    !(conn->le.keys->flags & BT_KEYS_AUTHENTICATED)) {
-		return false;
-	}
-
-	if (conn->required_sec_level > BT_SECURITY_L3 &&
-	    !(conn->le.keys->flags & BT_KEYS_AUTHENTICATED) &&
-	    !(conn->le.keys->keys & BT_KEYS_LTK_P256) &&
-	    !(conn->le.keys->enc_size == BT_SMP_MAX_ENC_KEY_SIZE)) {
-		return false;
 	}
 
 	return true;

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -2576,6 +2576,7 @@ bool bt_smp_request_ltk(struct bt_conn *conn, u64_t rand, u16_t ediv, u8_t *ltk)
 				     BT_SMP_MAX_ENC_KEY_SIZE - enc_size);
 		}
 
+		atomic_set_bit(smp->flags, SMP_FLAG_ENC_PENDING);
 		return true;
 	}
 
@@ -2613,6 +2614,7 @@ bool bt_smp_request_ltk(struct bt_conn *conn, u64_t rand, u16_t ediv, u8_t *ltk)
 				     BT_SMP_MAX_ENC_KEY_SIZE - enc_size);
 		}
 
+		atomic_set_bit(smp->flags, SMP_FLAG_ENC_PENDING);
 		return true;
 	}
 #endif /* !CONFIG_BT_SMP_SC_PAIR_ONLY */
@@ -2650,6 +2652,10 @@ static int smp_send_security_req(struct bt_conn *conn)
 
 	/* pairing is in progress */
 	if (atomic_test_bit(smp->flags, SMP_FLAG_PAIRING)) {
+		return -EBUSY;
+	}
+
+	if (atomic_test_bit(smp->flags, SMP_FLAG_ENC_PENDING)) {
 		return -EBUSY;
 	}
 
@@ -2849,6 +2855,11 @@ static int smp_send_pairing_req(struct bt_conn *conn)
 		return -EBUSY;
 	}
 
+	/* Encryption is in progress */
+	if (atomic_test_bit(smp->flags, SMP_FLAG_ENC_PENDING)) {
+		return -EBUSY;
+	}
+
 	/* early verify if required sec level if reachable */
 	if (!sec_level_reachable(conn)) {
 		return -EINVAL;
@@ -2890,6 +2901,7 @@ static int smp_send_pairing_req(struct bt_conn *conn)
 	smp_send(smp, req_buf, NULL, NULL);
 
 	atomic_set_bit(&smp->allowed_cmds, BT_SMP_CMD_PAIRING_RSP);
+	atomic_set_bit(&smp->allowed_cmds, BT_SMP_CMD_SECURITY_REQUEST);
 	atomic_set_bit(smp->flags, SMP_FLAG_PAIRING);
 
 	return 0;
@@ -2973,6 +2985,8 @@ static u8_t smp_pairing_rsp(struct bt_smp *smp, struct net_buf *buf)
 	}
 
 	atomic_set_bit(&smp->allowed_cmds, BT_SMP_CMD_PUBLIC_KEY);
+	atomic_clear_bit(&smp->allowed_cmds, BT_SMP_CMD_SECURITY_REQUEST);
+
 	return sc_send_public_key(smp);
 }
 #else
@@ -3640,6 +3654,16 @@ static u8_t smp_security_request(struct bt_smp *smp, struct net_buf *buf)
 
 	BT_DBG("");
 
+	if (atomic_test_bit(smp->flags, SMP_FLAG_PAIRING)) {
+		/* We have already started pairing process */
+		return 0;
+	}
+
+	if (atomic_test_bit(smp->flags, SMP_FLAG_ENC_PENDING)) {
+		/* We have already started encryption procedure */
+		return 0;
+	}
+
 	if (sc_supported) {
 		auth = req->auth_req & BT_SMP_AUTH_MASK_SC;
 	} else {
@@ -4127,6 +4151,8 @@ static void bt_smp_encrypt_change(struct bt_l2cap_chan *chan,
 	BT_DBG("chan %p conn %p handle %u encrypt 0x%02x hci status 0x%02x",
 	       chan, conn, conn->handle, conn->encrypt, hci_status);
 
+	atomic_clear_bit(smp->flags, SMP_FLAG_ENC_PENDING);
+
 	if (hci_status) {
 		return;
 	}
@@ -4143,8 +4169,6 @@ static void bt_smp_encrypt_change(struct bt_l2cap_chan *chan,
 		smp_reset(smp);
 		return;
 	}
-
-	atomic_clear_bit(smp->flags, SMP_FLAG_ENC_PENDING);
 
 	/* derive BR/EDR LinkKey if supported by both sides */
 	if (atomic_test_bit(smp->flags, SMP_FLAG_SC)) {
@@ -5064,16 +5088,41 @@ int bt_smp_start_security(struct bt_conn *conn)
 #if defined(CONFIG_BT_CENTRAL)
 	case BT_HCI_ROLE_MASTER:
 	{
+		int err;
+		struct bt_smp *smp;
+
+		smp = smp_chan_get(conn);
+		if (!smp) {
+			return -ENOTCONN;
+		}
+
 		if (!smp_keys_check(conn)) {
 			return smp_send_pairing_req(conn);
 		}
 
+		/* pairing is in progress */
+		if (atomic_test_bit(smp->flags, SMP_FLAG_PAIRING)) {
+			return -EBUSY;
+		}
+
+		/* Encryption is in progress */
+		if (atomic_test_bit(smp->flags, SMP_FLAG_ENC_PENDING)) {
+			return -EBUSY;
+		}
+
 		/* LE SC LTK and legacy master LTK are stored in same place */
-		return bt_conn_le_start_encryption(conn,
-						   conn->le.keys->ltk.rand,
-						   conn->le.keys->ltk.ediv,
-						   conn->le.keys->ltk.val,
-						   conn->le.keys->enc_size);
+		err = bt_conn_le_start_encryption(conn,
+						  conn->le.keys->ltk.rand,
+						  conn->le.keys->ltk.ediv,
+						  conn->le.keys->ltk.val,
+						  conn->le.keys->enc_size);
+		if (err) {
+			return err;
+		}
+
+		atomic_set_bit(&smp->allowed_cmds, BT_SMP_CMD_SECURITY_REQUEST);
+		atomic_set_bit(smp->flags, SMP_FLAG_ENC_PENDING);
+		return 0;
 	}
 #endif /* CONFIG_BT_CENTRAL && CONFIG_BT_SMP */
 #if defined(CONFIG_BT_PERIPHERAL)

--- a/subsys/bluetooth/host/smp.h
+++ b/subsys/bluetooth/host/smp.h
@@ -123,12 +123,11 @@ struct bt_smp_dhkey_check {
 	u8_t e[16];
 } __packed;
 
-int bt_smp_send_pairing_req(struct bt_conn *conn);
-int bt_smp_send_security_req(struct bt_conn *conn);
+int bt_smp_start_security(struct bt_conn *conn);
+bool bt_smp_request_ltk(struct bt_conn *conn, u64_t rand, u16_t ediv,
+			u8_t *ltk);
+
 void bt_smp_update_keys(struct bt_conn *conn);
-bool bt_smp_get_tk(struct bt_conn *conn, u8_t *tk);
-bool bt_smp_keys_check(struct bt_conn *conn);
-void bt_smp_keys_reject(struct bt_conn *conn);
 
 int bt_smp_br_send_pairing_req(struct bt_conn *conn);
 


### PR DESCRIPTION
Handle both Central and Peripheral initiating security at the same time, this would result in the host starting the encryption procedure twice in the controller, one of them will then fail.
