### PR TITLE
kernel: fix default z_arch_cpu_halt()

### DIFF
--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -26,7 +26,7 @@ FUNC_NORETURN __weak void z_arch_system_halt(unsigned int reason)
 
 	(void)z_arch_irq_lock();
 	for (;;) {
-		k_cpu_idle();
+		/* Spin endlessly */
 	}
 }
 /* LCOV_EXCL_STOP */


### PR DESCRIPTION
k_cpu_idle() re-enables interrupts. Just spin
instead.

Fixes: #18973

Signed-off-by: Andrew Boie <andrewboie@gmail.com>