### PR TITLE
kconfig: modules: Trivial cleanup

### DIFF
--- a/modules/Kconfig.imx
+++ b/modules/Kconfig.imx
@@ -1,15 +1,12 @@
 # Kconfig - IMX M4 Core SDK
 #
 # Copyright (c) 2018, NXP
-#
 # SPDX-License-Identifier: Apache-2.0
-#
-
 
 config HAS_IMX_HAL
 	bool
 	select HAS_CMSIS
-	depends on  SOC_FAMILY_IMX
+	depends on SOC_FAMILY_IMX
 
 if HAS_IMX_HAL
 

--- a/modules/Kconfig.libmetal
+++ b/modules/Kconfig.libmetal
@@ -1,8 +1,5 @@
-#
 # Copyright (c) 2018 Linaro Limited
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 menuconfig LIBMETAL
 	bool "libmetal Support"

--- a/modules/Kconfig.mbedtls
+++ b/modules/Kconfig.mbedtls
@@ -1,6 +1,5 @@
 # Kconfig - Cryptography primitive options for mbed TLS
 
-#
 # Copyright (c) 2016 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-
 
 menuconfig MBEDTLS
 	bool "mbedTLS Support"

--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -1,9 +1,7 @@
 # Kconfig - MCUXpresso SDK
 #
 # Copyright (c) 2016, Freescale Semiconductor, Inc.
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 config HAS_MCUX
 	bool

--- a/modules/Kconfig.microchip
+++ b/modules/Kconfig.microchip
@@ -2,5 +2,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig HAS_MEC_HAL
+config HAS_MEC_HAL
 	bool "Microchip MEC HAL drivers support"

--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -1,8 +1,5 @@
-#
 # Copyright (c) 2016 Nordic Semiconductor ASA
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 config HAS_NORDIC_DRIVERS
 	bool

--- a/modules/Kconfig.open-amp
+++ b/modules/Kconfig.open-amp
@@ -1,8 +1,5 @@
-#
 # Copyright (c) 2018 Linaro Limited
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 config OPENAMP
 	bool "OpenAMP Support"

--- a/modules/Kconfig.qmsi
+++ b/modules/Kconfig.qmsi
@@ -1,12 +1,7 @@
 # Kconfig - QMSI drivers configuration options
 
-#
 # Copyright (c) 2015 Intel Corporation
-#
 # SPDX-License-Identifier: Apache-2.0
-#
-
-menu "QMSI"
 
 config HAS_QMSI
 	bool
@@ -16,5 +11,3 @@ config QMSI
 	depends on HAS_QMSI
 	help
 	  Enable QMSI driver support.
-
-endmenu

--- a/modules/Kconfig.silabs
+++ b/modules/Kconfig.silabs
@@ -1,9 +1,7 @@
 # Kconfig - Gecko SDK
 #
 # Copyright (c) 2017, Christian Taedcke
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 config HAS_SILABS_GECKO
 	bool

--- a/modules/Kconfig.simplelink
+++ b/modules/Kconfig.simplelink
@@ -13,16 +13,16 @@ config SIMPLELINK_HOST_DRIVER
 	depends on MULTITHREADING
 	select NEWLIB_LIBC
 	select ERRNO
-        select POSIX_API
-        select PTHREAD_IPC
+	select POSIX_API
+	select PTHREAD_IPC
 	help
 	  Build the SimpleLink host driver
 
 # Kconfig - MSP432 SDK HAL configuration
 
 config HAS_MSP432P4XXSDK
-        bool
-        select HAS_CMSIS
+	bool
+	select HAS_CMSIS
 
 # Kconfig - CC13X2 / CC26X2 SDK HAL configuration
 

--- a/modules/Kconfig.st
+++ b/modules/Kconfig.st
@@ -126,4 +126,4 @@ config USE_STDC_LSM9DS1
 config USE_STDC_STTS751
 	bool
 
-endif #HAS_STMEMSC
+endif # HAS_STMEMSC

--- a/modules/Kconfig.stm32
+++ b/modules/Kconfig.stm32
@@ -1,7 +1,6 @@
 # Kconfig - STM32CUBE HAL config
 
 # Copyright (c) 2016 Linaro Limited.
-#
 # SPDX-License-Identifier: Apache-2.0
 
 config HAS_STM32CUBE
@@ -380,4 +379,4 @@ config USE_STM32_LL_USB
 config USE_STM32_LL_UTILS
 	bool
 
-endif
+endif # HAS_STM32CUBE

--- a/modules/Kconfig.tinycbor
+++ b/modules/Kconfig.tinycbor
@@ -1,5 +1,4 @@
 # Copyright (c) 2018 Intel Corporation
-#
 # SPDX-License-Identifier: Apache-2.0
 
 config TINYCBOR
@@ -58,4 +57,4 @@ config CBOR_PRETTY_PRINTING
 	help
 	  This option enables cbor_value_to_pretty_stream function.
 
-endif #TINYCBOR
+endif # TINYCBOR

--- a/modules/Kconfig.tls-generic
+++ b/modules/Kconfig.tls-generic
@@ -1,11 +1,8 @@
 # Kconfig.tls - TLS/DTLS related options
 
-#
 # Copyright (c) 2018 Intel Corporation
 # Copyright (c) 2018 Nordic Semiconductor ASA
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 menu "TLS configuration"
 

--- a/modules/Kconfig.vega
+++ b/modules/Kconfig.vega
@@ -1,5 +1,4 @@
 # Copyright (c) 2018 Foundries.io
-#
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig VEGA_SDK_HAL
@@ -21,4 +20,3 @@ config HAS_RV32M1_FTFX
 	help
 	  Set if the flash memory (FTFA, FTFE, or FTFL) module is present in
 	  the SoC.
-


### PR DESCRIPTION
A lot of the Kconfig stuff gets copied around, so encourage a clean
compact style:

 - Reduce license header spam

 - Fix some broken indentation

 - Turn a meaningless 'menuconfig' into a 'config'

 - Remove a redundant QMSI menu

 - Unscrunch comments: #Foo -> # Foo