### PR TITLE
doc: update release notes index to use globbing

### DIFF
--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -21,20 +21,20 @@ so with the help of west.
 The project's technical documentation is also tagged to correspond with a
 specific release and can be found at https://docs.zephyrproject.org/.
 
+.. comment We need to split the globbing of release notes to get the
+   single-digit and double-digit subversions sorted correctly.  Specify
+   names in normal order and use the :reversed: option to reverse it.
+   This will get us through 10 subversions (0-9) before we need to
+   update this list for two-digit subversions again.
+
 .. toctree::
    :maxdepth: 1
+   :glob:
+   :reversed:
 
-   release-notes-2.0
-   release-notes-1.14
-   release-notes-1.13
-   release-notes-1.12
-   release-notes-1.11
-   release-notes-1.10
-   release-notes-1.9
-   release-notes-1.8
-   release-notes-1.7
-   release-notes-1.6
-   release-notes-1.5
+   release-notes-1.?
+   release-notes-1.*
+   release-notes-*
 
 .. _`GitHub repository`: https://github.com/zephyrproject-rtos/zephyr
 .. _`GitHub tagged releases`: https://github.com/zephyrproject-rtos/zephyr/tags


### PR DESCRIPTION
Use globbing to find release notes and display them in the expected
reverse-sorted order (newest release first).  Some trickery is needed
because were not using two-digit version/subversion numbers so the list
won't sort naturally. This will eliminate the need to edit the index
page on every release, until we get to subversion 10.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>