### PR TITLE
dts: bindings: spi: nrf: Set license to Apache 2.0

### DIFF
--- a/dts/bindings/spi/nordic,nrf-spi.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi.yaml
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2018 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: BSD-5-Clause-Nordic
+# SPDX-License-Identifier: Apache-2.0
 #
 
 title: Nordic nRF Family SPI Master node


### PR DESCRIPTION
The file contained an invalid license which came from a Nordic custom
repository. Switch it to Apache 2.0.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>