### PR TITLE
augment libc++ test for smart pointers

### DIFF
--- a/subsys/testsuite/ztest/include/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/ztest_assert.h
@@ -18,6 +18,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,9 +27,9 @@ extern "C" {
 void ztest_test_fail(void);
 #if CONFIG_ZTEST_ASSERT_VERBOSE == 0
 
-static inline void z_zassert_(int cond, const char *file, int line)
+static inline void z_zassert_(bool cond, const char *file, int line)
 {
-	if (!(cond)) {
+	if (cond == false) {
 		PRINT("\n    Assertion failed at %s:%d\n",
 		      file, line);
 		ztest_test_fail();
@@ -40,13 +41,13 @@ static inline void z_zassert_(int cond, const char *file, int line)
 
 #else /* CONFIG_ZTEST_ASSERT_VERBOSE != 0 */
 
-static inline void z_zassert(int cond,
+static inline void z_zassert(bool cond,
 			    const char *default_msg,
 			    const char *file,
 			    int line, const char *func,
 			    const char *msg, ...)
 {
-	if (!(cond)) {
+	if (cond == false) {
 		va_list vargs;
 
 		va_start(vargs, msg);

--- a/tests/application_development/libcxx/src/main.cpp
+++ b/tests/application_development/libcxx/src/main.cpp
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <vector>
 #include <array>
 #include <functional>
+#include <memory>
+#include <vector>
 #include <ztest.h>
 
 BUILD_ASSERT(__cplusplus == 201703);
@@ -35,12 +36,44 @@ static void test_vector(void)
 	zassert_equal(vector.size(), array.size(), "vector store failed");
 }
 
+struct make_unique_data {
+	static int ctors;
+	static int dtors;
+	int inst;
+
+	make_unique_data () :
+	inst{++ctors}
+	{ }
+
+	~make_unique_data ()
+	{
+		++dtors;
+	}
+};
+int make_unique_data::ctors;
+int make_unique_data::dtors;
+
+static void test_make_unique(void)
+{
+	zassert_equal(make_unique_data::ctors, 0, "ctor count not initialized");
+	zassert_equal(make_unique_data::dtors, 0, "dtor count not initialized");
+	auto d = std::make_unique<make_unique_data>();
+	zassert_true(static_cast<bool>(d), "allocation failed");
+	zassert_equal(make_unique_data::ctors, 1, "ctr update failed");
+	zassert_equal(d->inst, 1, "instance init failed");
+	zassert_equal(make_unique_data::dtors, 0, "dtor count not zero");
+	d.reset();
+	zassert_false(d, "release failed");
+	zassert_equal(make_unique_data::dtors, 1, "dtor count not incremented");
+}
+
 void test_main(void)
 {
 	TC_PRINT("version %u\n", (u32_t)__cplusplus);
 	ztest_test_suite(libcxx_tests,
 			 ztest_unit_test(test_array),
-			 ztest_unit_test(test_vector)
+			 ztest_unit_test(test_vector),
+			 ztest_unit_test(test_make_unique)
 		);
 
 	ztest_run_test_suite(libcxx_tests);


### PR DESCRIPTION
Confirms behavior of new and delete using best-practices API.

This also requires a change to the testsuite to use the correct type for the condition argument.