### PR TITLE
scripts: Simplify code with sys.exit(<string>)

### DIFF
--- a/arch/x86/gen_gdt.py
+++ b/arch/x86/gen_gdt.py
@@ -36,8 +36,7 @@ from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 
 if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
-    sys.stderr.write("pyelftools is out of date, need version 0.24 or later\n")
-    sys.exit(1)
+    sys.exit("pyelftools is out of date, need version 0.24 or later")
 
 
 def debug(text):
@@ -47,8 +46,7 @@ def debug(text):
 
 
 def error(text):
-    sys.stderr.write(os.path.basename(sys.argv[0]) + ": " + text + "\n")
-    sys.exit(1)
+    sys.exit(os.path.basename(sys.argv[0]) + ": " + text)
 
 
 gdt_pd_fmt = "<HIH"

--- a/arch/x86/gen_idt.py
+++ b/arch/x86/gen_idt.py
@@ -38,8 +38,7 @@ from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 
 if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
-    sys.stderr.write("pyelftools is out of date, need version 0.24 or later\n")
-    sys.exit(1)
+    sys.exit("pyelftools is out of date, need version 0.24 or later")
 
 # This will never change, first selector in the GDT after the null selector
 KERNEL_CODE_SEG = 0x08
@@ -55,8 +54,7 @@ def debug(text):
 
 
 def error(text):
-    sys.stderr.write(os.path.basename(sys.argv[0]) + ": " + text + "\n")
-    sys.exit(1)
+    sys.exit(os.path.basename(sys.argv[0]) + ": " + text)
 
 
 # See Section 6.11 of the Intel Architecture Software Developer's Manual

--- a/boards/xtensa/intel_s1000_crb/support/create_board_img.py
+++ b/boards/xtensa/intel_s1000_crb/support/create_board_img.py
@@ -54,8 +54,7 @@ def debug(text):
     sys.stdout.write(os.path.basename(sys.argv[0]) + ": " + text + "\n")
 
 def error(text):
-    sys.stderr.write(os.path.basename(sys.argv[0]) + ": " + text + "\n")
-    sys.exit(1)
+    sys.exit(os.path.basename(sys.argv[0]) + ": " + text)
 
 def set_magic_number(value):
     flash_content.append(value)

--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -16,8 +16,7 @@ from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 
 if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
-    sys.stderr.write("pyelftools is out of date, need version 0.24 or later\n")
-    sys.exit(1)
+    sys.exit("pyelftools is out of date, need version 0.24 or later")
 
 
 def subsystem_to_enum(subsys):
@@ -396,8 +395,7 @@ class ElfHelper:
 
     def find_kobjects(self, syms):
         if not self.elf.has_dwarf_info():
-            sys.stderr.write("ELF file has no DWARF information\n")
-            sys.exit(1)
+            sys.exit("ELF file has no DWARF information")
 
         app_smem_start = syms["_app_smem_start"]
         app_smem_end = syms["_app_smem_end"]
@@ -569,8 +567,7 @@ class ElfHelper:
         sys.stdout.write(scr + ": " + text + "\n")
 
     def error(self, text):
-        sys.stderr.write("%s ERROR: %s\n" % (scr, text))
-        sys.exit(1)
+        sys.exit("%s ERROR: %s\n" % (scr, text))
 
     def debug_die(self, die, text):
         fn, ln = get_filename_lineno(die)

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -363,10 +363,9 @@ def main():
 
         thread_counter = eh.get_thread_counter()
         if thread_counter > max_threads:
-            sys.stderr.write("Too many thread objects (%d)\n" % thread_counter)
-            sys.stderr.write("Increase CONFIG_MAX_THREAD_BYTES to %d\n" %
-                             -(-thread_counter // 8))
-            sys.exit(1)
+            sys.exit("Too many thread objects ({})\n"
+                     "Increase CONFIG_MAX_THREAD_BYTES to {}"
+                     .format(thread_counter, -(-thread_counter // 8)))
 
         with open(args.gperf_output, "w") as fp:
             write_gperf_table(fp, eh, objs,

--- a/scripts/gen_priv_stacks.py
+++ b/scripts/gen_priv_stacks.py
@@ -128,10 +128,9 @@ def main():
 
     thread_counter = eh.get_thread_counter()
     if thread_counter > max_threads:
-        sys.stderr.write("Too many thread objects (%d)\n" % thread_counter)
-        sys.stderr.write("Increase CONFIG_MAX_THREAD_BYTES to %d\n",
-                         -(-thread_counter // 8))
-        sys.exit(1)
+        sys.exit("Too many thread objects ({})\n"
+                 "Increase CONFIG_MAX_THREAD_BYTES to {}"
+                 .format(thread_counter, -(-thread_counter // 8)))
 
     with open(args.output, "w") as fp:
         write_gperf_table(fp, eh, objs)

--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -133,8 +133,7 @@ def find_sections(filename, full_list_of_sections):
     with open(filename, 'rb') as obj_file_desc:
         full_lib = ELFFile(obj_file_desc)
         if not full_lib:
-            print("Error parsing file: ", filename)
-            sys.exit(1)
+            sys.exit("Error parsing file: " + filename)
 
         sections = [x for x in full_lib.iter_sections()]
 
@@ -380,8 +379,7 @@ def create_dict_wrt_mem():
 #need to support wild card *
     rel_dict = dict()
     if args.input_rel_dict == '':
-        print("Disable CONFIG_CODE_DATA_RELOCATION if no file needs relocation")
-        sys.exit(1)
+        sys.exit("Disable CONFIG_CODE_DATA_RELOCATION if no file needs relocation")
     for line in args.input_rel_dict.split(';'):
         mem_region, file_name = line.split(':')
 

--- a/scripts/process_gperf.py
+++ b/scripts/process_gperf.py
@@ -32,8 +32,7 @@ def debug(text):
 
 
 def error(text):
-    sys.stderr.write(os.path.basename(sys.argv[0]) + " ERROR: " + text + "\n")
-    sys.exit(1)
+    sys.exit(os.path.basename(sys.argv[0]) + " ERROR: " + text)
 
 
 def warn(text):

--- a/scripts/sanity_chk/expr_parser.py
+++ b/scripts/sanity_chk/expr_parser.py
@@ -14,10 +14,9 @@ try:
     import ply.lex as lex
     import ply.yacc as yacc
 except ImportError:
-    print("PLY library for Python 3 not installed.")
-    print("Please install the ply package using your workstation's")
-    print("package manager or the 'pip' tool.")
-    sys.exit(1)
+    sys.exit("PLY library for Python 3 not installed.\n"
+             "Please install the ply package using your workstation's\n"
+             "package manager or the 'pip' tool.")
 
 reserved = {
     'and' : 'AND',

--- a/scripts/support/quartus-flash.py
+++ b/scripts/support/quartus-flash.py
@@ -94,9 +94,8 @@ def create_pof(input_sof, kernel_hex):
         try:
             subprocess.check_output(cmd)
         except subprocess.CalledProcessError as cpe:
-            print(cpe.output.decode("UTF-8"))
-            print("Failed to create POF file")
-            sys.exit(1)
+            sys.exit(cpe.output.decode("utf-8") +
+                     "\nFailed to create POF file")
 
     return output_pof
 
@@ -114,9 +113,8 @@ def flash_kernel(device_id, input_sof, kernel_hex):
         try:
             subprocess.check_output(cmd)
         except subprocess.CalledProcessError as cpe:
-            print(cpe.output.decode("UTF-8"))
-            print("Failed to flash image")
-            sys.exit(1)
+            sys.exit(cpe.output.decode("utf-8") +
+                     "\nFailed to flash image")
     pof_file.close()
 
 def main():

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -68,24 +68,21 @@ def process_module(module, cmake_out=None, kconfig_out=None):
             pykwalify.core.Core(source_data=meta, schema_data=schema)\
                 .validate()
         except pykwalify.errors.SchemaError as e:
-            print('ERROR: Malformed "build" section in file: {}\n{}'
-                  .format(module_yml, e), file=sys.stderr)
-            sys.exit(1)
+            sys.exit('ERROR: Malformed "build" section in file: {}\n{}'
+                     .format(module_yml, e))
 
         section = meta.get('build', dict())
         cmake_setting = section.get('cmake', None)
         if not validate_setting(cmake_setting, module, 'CMakeLists.txt'):
-            print('ERROR: "cmake" key in {} has folder value "{}" which '
-                  'does not contain a CMakeLists.txt file.'
-                  .format(module_yml, cmake_setting), file=sys.stderr)
-            sys.exit(1)
+            sys.exit('ERROR: "cmake" key in {} has folder value "{}" which '
+                     'does not contain a CMakeLists.txt file.'
+                     .format(module_yml, cmake_setting))
 
         kconfig_setting = section.get('kconfig', None)
         if not validate_setting(kconfig_setting, module):
-            print('ERROR: "kconfig" key in {} has value "{}" which does not '
-                  'point to a valid Kconfig file.'
-                  .format(module_yml, kconfig_setting), file=sys.stderr)
-            sys.exit(1)
+            sys.exit('ERROR: "kconfig" key in {} has value "{}" which does '
+                     'not point to a valid Kconfig file.'
+                     .format(module.yml, kconfig_setting))
 
     cmake_path = os.path.join(module, cmake_setting or 'zephyr')
     cmake_file = os.path.join(cmake_path, 'CMakeLists.txt')


### PR DESCRIPTION
Promote a handy and often-overlooked sys.exit() feature: Passing it a
string (or any other non-int object) prints it to stderr and exits with
status 1.

See the documentation at
https://docs.python.org/3/library/sys.html#sys.exit.

This indirectly prints some errors to stderr that previously went to
stdout.