### PR TITLE
Revert "cmake: Error-out when 'project' is invoked too early"

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -28,14 +28,6 @@ cmake_policy(SET CMP0002 NEW)
 # CMP0079: "target_link_libraries() allows use with targets in other directories"
 cmake_policy(SET CMP0079 OLD)
 
-# Error-out if 'project' has been invoked to avoid obscure user
-# errors.
-if(DEFINED CMAKE_PROJECT_NAME)
-  message(FATAL_ERROR
-    "'project()' was called before boilerplate.cmake was included, this is not supported."
-    )
-endif()
-
 define_property(GLOBAL PROPERTY ZEPHYR_LIBS
     BRIEF_DOCS "Global list of all Zephyr CMake libs that should be linked in"
     FULL_DOCS  "Global list of all Zephyr CMake libs that should be linked in.


### PR DESCRIPTION
This reverts commit 48f97ecf463d642297f61ac8b2ce3748469b98b4 which was #18945.

For unexplained reasons the presence of this commit in the tree causes
failures in tests/arch.  Reverting it allows them to pass.

```
tirzah[95]$ git describe
zephyr-v2.0.0-137-g6e46a64a48
tirzah[96]$ git describe r.upstream/master 
zephyr-v2.0.0-137-g6e46a64a48
tirzah[97]$ rm -rf sanity-out/
tirzah[98]$ sanitycheck -s tests/arch/arm/arm_thread_swap/arch.arm.swap.common
JOBS: 32
Selecting default platforms per test case
Building testcase defconfigs...
Filtering test cases...
2 tests selected, 127989 tests discarded due to filters
total complete:    0/   2   0%  failed:    0

mps2_an385                tests/arch/arm/arm_thread_swap/arch.arm.swap.common FAILED: build_error
	see: sanity-out/mps2_an385/tests/arch/arm/arm_thread_swap/arch.arm.swap.common/build.log

total complete:    1/   2  50%  failed:    1

frdm_k64f                 tests/arch/arm/arm_thread_swap/arch.arm.swap.common FAILED: build_error
	see: sanity-out/frdm_k64f/tests/arch/arm/arm_thread_swap/arch.arm.swap.common/build.log

total complete:    2/   2  100%  failed:    2
0 of 2 tests passed with 0 warnings in 4 seconds
tirzah[99]$ west --version
West version: v0.6.2
tirzah[100]$ git fetch r.nordic 
remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 5 (delta 3), reused 1 (delta 0)
Unpacking objects: 100% (5/5), done.
From /mnt/nordic/zp/zephyr
   6e46a64a48..39d1f1276b  nordic/20190907b -> r.nordic/nordic/20190907b
tirzah[101]$ git checkout nordic/20190907b
Branch 'nordic/20190907b' set up to track remote branch 'nordic/20190907b' from 'r.nordic'.
Switched to a new branch 'nordic/20190907b'
tirzah[102]$ rm -rf sanity-out/
tirzah[103]$ sanitycheck -s tests/arch/arm/arm_thread_swap/arch.arm.swap.common
JOBS: 32
Selecting default platforms per test case
Building testcase defconfigs...
Filtering test cases...
2 tests selected, 127989 tests discarded due to filters
total complete:    2/   2  100%  failed:    0
2 of 2 tests passed with 0 warnings in 14 seconds
tirzah[104]$ git one | head
* 39d1f1276b (HEAD -> nordic/20190907b, r.nordic/nordic/20190907b) [Sat Sep 7 14:05:22 2019 -0500] Revert "cmake: Error-out when 'project' is invoked too early"
* 6e46a64a48 (r.upstream/topic-dts, r.upstream/master, r.nordic/upstream/master, r.nordic/HEAD, upstream/master) [Thu Aug 29 02:30:25 2019 +0200] dts: bindings: Shorten license headers
* a0fceff1a2 [Mon Aug 19 20:32:25 2019 +0200] scripts: dts: Simplify and improve 'compatible' matching
```