### PR TITLE
Added (sub-)sections .gcc_except_table to linker scripts

### DIFF
--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -132,6 +132,8 @@ SECTIONS {
 
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
+#include <linker/cplusplus-rom.ld>
+
 	_image_rodata_end = .;
 	MPU_ALIGN(_image_rodata_end - _image_rom_start);
 	_image_rom_end = .;
@@ -227,6 +229,7 @@ SECTIONS {
 
 #include <linker/common-ram.ld>
 #include <linker/kobject.ld>
+#include <linker/cplusplus-ram.ld>
 
 	__data_ram_end = .;
 

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -273,6 +273,8 @@ SECTIONS
 	. = ALIGN(4);
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
+#include <linker/cplusplus-rom.ld>
+
 	_image_rodata_end = .;
 	MPU_ALIGN(_image_rodata_end -_image_rom_start);
 	_image_rom_end = .;
@@ -411,6 +413,7 @@ SECTIONS
 #include <linker/kobject.ld>
 
 #include <linker/priv_stacks-noinit.ld>
+#include <linker/cplusplus-ram.ld>
 
     __data_ram_end = .;
 

--- a/include/arch/arm/cortex_r/scripts/linker.ld
+++ b/include/arch/arm/cortex_r/scripts/linker.ld
@@ -272,6 +272,8 @@ SECTIONS
 	. = ALIGN(4);
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
+#include <linker/cplusplus-rom.ld>
+
 	_image_rodata_end = .;
 	MPU_ALIGN(_image_rodata_end -_image_rom_start);
 	_image_rom_end = .;
@@ -411,6 +413,8 @@ SECTIONS
 #include <linker/kobject.ld>
 
 #include <linker/priv_stacks-noinit.ld>
+
+#include <linker/cplusplus-ram.ld>
 
     __data_ram_end = .;
 

--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -163,6 +163,8 @@ SECTIONS
         . = ALIGN(4);
         } GROUP_LINK_IN(ROMABLE_REGION)
 
+#include <linker/cplusplus-rom.ld>
+
     _image_rom_end = .;
     __data_rom_start = ALIGN(4);    /* XIP imaged DATA ROM start addr */
 
@@ -279,6 +281,8 @@ SECTIONS
 #include <snippets-noinit.ld>
 
         } GROUP_LINK_IN(RAMABLE_REGION)
+
+#include <linker/cplusplus-ram.ld>
 
     /* Define linker symbols */
     _image_ram_end = .;

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -120,6 +120,8 @@ SECTIONS
 
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
+#include <linker/cplusplus-rom.ld>
+
     _image_rom_end = .;
     __data_rom_start = .;
 
@@ -195,6 +197,8 @@ SECTIONS
 #endif
 
 	} GROUP_LINK_IN(RAMABLE_REGION)
+
+#include <linker/cplusplus-ram.ld>
 
      _image_ram_end = .;
      _end = .; /* end of image */

--- a/include/arch/x86/ia32/linker.ld
+++ b/include/arch/x86/ia32/linker.ld
@@ -160,6 +160,8 @@ SECTIONS
 #include <linker/kobject-rom.ld>
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
+#include <linker/cplusplus-rom.ld>
+
 	MMU_PAGE_ALIGN
 	/* ROM ends here, position counter will now be in RAM areas */
 	_image_rom_end = .;
@@ -348,6 +350,7 @@ SECTIONS
 #include <linker/common-ram.ld>
 
 #include <linker/kobject.ld>
+#include <linker/cplusplus-ram.ld>
 
 	MMU_PAGE_ALIGN
 	__data_ram_end = .;

--- a/include/arch/x86/intel64/linker.ld
+++ b/include/arch/x86/intel64/linker.ld
@@ -54,9 +54,12 @@ SECTIONS
 	#include <custom-rodata.ld>
 	#endif /* CONFIG_CUSTOM_RODATA_LD */
 
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
+#include <linker/cplusplus-rom.ld>
+
 	_image_rodata_end = .;
 	_image_rodata_size = _image_rodata_end - _image_rodata_start;
-	} GROUP_LINK_IN(ROMABLE_REGION)
 
 	SECTION_PROLOGUE(_DATA_SECTION_NAME,,ALIGN(16))
 	{
@@ -70,6 +73,7 @@ SECTIONS
 
 #include <snippets-ram-sections.ld>
 #include <linker/common-ram.ld>
+#include <linker/cplusplus-ram.ld>
 
 	SECTION_PROLOGUE(_BSS_SECTION_NAME, (NOLOAD), ALIGN(16))
 	{

--- a/include/linker/cplusplus-ram.ld
+++ b/include/linker/cplusplus-ram.ld
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2019 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if defined (CONFIG_CPLUSPLUS)
+	SECTION_PROLOGUE(.gcc_except_table,,ONLY_IF_RW)
+	{
+	*(.gcc_except_table .gcc_except_table.*)
+	} GROUP_LINK_IN(RAMABLE_REGION)
+#endif

--- a/include/linker/cplusplus-rom.ld
+++ b/include/linker/cplusplus-rom.ld
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2019 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if defined (CONFIG_CPLUSPLUS)
+	SECTION_PROLOGUE(.gcc_except_table,,ONLY_IF_RO)
+	{
+	*(.gcc_except_table .gcc_except_table.*)
+	} GROUP_LINK_IN(ROMABLE_REGION)
+#endif

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -163,6 +163,8 @@ SECTIONS
 
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
+#include <linker/cplusplus-rom.ld>
+
     _image_rodata_end = .;
     _image_rom_end = .;
 
@@ -202,6 +204,7 @@ SECTIONS
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 #include <linker/common-ram.ld>
+#include <linker/cplusplus-ram.ld>
 
     __data_ram_end = .;
     __data_rom_start = LOADADDR(_DATA_SECTION_NAME);

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -183,7 +183,7 @@ SECTIONS
     *(.rodata1)
     __XT_EXCEPTION_TABLE__ = ABSOLUTE(.);
     KEEP (*(.xt_except_table))
-    KEEP (*(.gcc_except_table))
+    KEEP (*(.gcc_except_table .gcc_except_table.*))
     *(.gnu.linkonce.e.*)
     *(.gnu.version_r)
     KEEP (*(.eh_frame))

--- a/soc/xtensa/intel_s1000/linker.ld
+++ b/soc/xtensa/intel_s1000/linker.ld
@@ -357,7 +357,7 @@ SECTIONS
     *(.rodata1)
     __XT_EXCEPTION_TABLE__ = ABSOLUTE(.);
     KEEP (*(.xt_except_table))
-    KEEP (*(.gcc_except_table))
+    KEEP (*(.gcc_except_table .gcc_except_table.*))
     *(.gnu.linkonce.e.*)
     *(.gnu.version_r)
     KEEP (*(.eh_frame))

--- a/soc/xtensa/sample_controller/linker.ld
+++ b/soc/xtensa/sample_controller/linker.ld
@@ -447,7 +447,7 @@ SECTIONS
     *(.rodata1)
     __XT_EXCEPTION_TABLE__ = ABSOLUTE(.);
     KEEP (*(.xt_except_table))
-    KEEP (*(.gcc_except_table))
+    KEEP (*(.gcc_except_table .gcc_except_table.*))
     *(.gnu.linkonce.e.*)
     *(.gnu.version_r)
     KEEP (*(.eh_frame))

--- a/tests/application_development/libcxx/testcase.yaml
+++ b/tests/application_development/libcxx/testcase.yaml
@@ -3,3 +3,10 @@ tests:
     arch_exclude: posix
     platform_exclude: qemu_x86_coverage qemu_x86_64
     tags: cpp
+  misc.app_dev.libcxx.exceptions:
+    arch_exclude: posix
+    platform_exclude: qemu_x86_coverage qemu_x86_64 96b_meerkat96
+        colibri_imx7d_m4 warp7_m4 pico_pi_m4 qemu_x86_long
+    tags: cpp
+    extra_configs:
+        - CONFIG_EXCEPTIONS=y


### PR DESCRIPTION
Include .gcc_except_table section and it sub-sections in the linker files of supported architectures to allow enabling C++ with exception support. 
If these sections are not mapped warnings will be generated for orphaned sections at link time.