### PR TITLE
Fixed generating single value properties from DTS in legacy

### DIFF
--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -333,6 +333,11 @@ def build_cell_array(prop_array):
     index = 0
     ret_array = []
 
+    if isinstance(prop_array, int):
+        # Work around old code generating an integer for e.g.
+        # 'pwms = <&foo>'
+        prop_array = [prop_array]
+
     while index < len(prop_array):
         handle = prop_array[index]
 


### PR DESCRIPTION
After slack discussion with @ulfalizer we believe the legacy DTS include generation has a bug where single value properties in the device tree are not generated properly, resulting in an internal python error. 

Something puts the single value as a scalar where it needs to be an array. This fix simply checks for that case and puts the scalar into an array if needed.

Example of non-working property in dts:

```
pwmleds {
	compatible = "pwm-leds";
	pwmled0: pwmled0 {
		pwms = <&pwm0>;
		label = "pwm-led-1";
		channel= <11>;
	};
};
```

This makes DTS generation throw this python error: 
```
Traceback (most recent call last):

  File "C:/Users/Olle/Documents/ncs/ncs/zephyr/scripts/dts/extract_dts_includes.py", line 546, in <module>
    main()
  File "C:/Users/Olle/Documents/ncs/ncs/zephyr/scripts/dts/extract_dts_includes.py", line 532, in main
    generate_defines()
  File "C:/Users/Olle/Documents/ncs/ncs/zephyr/scripts/dts/extract_dts_includes.py", line 455, in generate_defines
    generate_node_defines(node_path)
  File "C:/Users/Olle/Documents/ncs/ncs/zephyr/scripts/dts/extract_dts_includes.py", line 138, in generate_node_defines
    generate_prop_defines(node_path, prop)
  File "C:/Users/Olle/Documents/ncs/ncs/zephyr/scripts/dts/extract_dts_includes.py", line 93, in generate_prop_defines
    def_label, generic, deprecate=True)
  File "C:\Users\Olle\Documents\ncs\ncs\zephyr\scripts\dts\extract\globals.py", line 411, in extract_controller
    prop_array = build_cell_array(prop_values)
  File "C:\Users\Olle\Documents\ncs\ncs\zephyr\scripts\dts\extract\globals.py", line 336, in build_cell_array
    while index < len(prop_array):
TypeError: object of type 'int' has no len()
CMake Error at C:/Users/Olle/Documents/ncs/ncs/zephyr/cmake/dts.cmake:203 (message):
  command failed with return code: 1
Call Stack (most recent call first):
  C:/Users/Olle/Documents/ncs/ncs/zephyr/cmake/app/boilerplate.cmake:532 (include)

  CMakeLists.txt:8 (include)
```