### PR TITLE
Fix warnings when building with Clang

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -10,8 +10,6 @@ else ()
 endif ()
 
 zephyr_compile_options(
-  -MMD
-  -MP
   ${ARCH_FLAG}
   -include ${ZEPHYR_BASE}/arch/posix/include/posix_cheats.h
   )

--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -45,6 +45,11 @@ static bool auto_attach;
 static const char default_cmd[] = CONFIG_NATIVE_UART_AUTOATTACH_DEFAULT_CMD;
 static char *auto_attach_cmd;
 
+struct native_uart_status {
+	int out_fd; /* File descriptor used for output */
+	int in_fd; /* File descriptor used for input */
+};
+
 static struct native_uart_status native_uart_status_0;
 
 static struct uart_driver_api np_uart_driver_api_0 = {
@@ -60,11 +65,6 @@ static struct uart_driver_api np_uart_driver_api_1 = {
 	.poll_in = np_uart_tty_poll_in,
 };
 #endif /* CONFIG_UART_NATIVE_POSIX_PORT_1_ENABLE */
-
-struct native_uart_status {
-	int out_fd; /* File descriptor used for output */
-	int in_fd; /* File descriptor used for input */
-};
 
 #define ERROR posix_print_error_and_exit
 #define WARN posix_print_warning

--- a/samples/application_development/external_lib/mylib/Makefile
+++ b/samples/application_development/external_lib/mylib/Makefile
@@ -10,7 +10,7 @@ LIB_DIR ?= $(PREFIX)/lib
 
 all:
 	mkdir -p $(OBJ_DIR) $(LIB_DIR)
-	$(CC) -c $(CFLAGS) -Iinclude src/mylib.c -o $(OBJ_DIR)/mylib.o
+	$(CC) -c $(CFLAGS) -MD -Iinclude src/mylib.c -o $(OBJ_DIR)/mylib.o
 	$(AR) -rcs $(LIB_DIR)/libmylib.a $(OBJ_DIR)/mylib.o
 
 clean:

--- a/samples/net/sockets/packet/src/packet.c
+++ b/samples/net/sockets/packet/src/packet.c
@@ -19,8 +19,6 @@ LOG_MODULE_REGISTER(net_pkt_sock_sample, LOG_LEVEL_DBG);
 #define RECV_BUFFER_SIZE 1280
 #define RAW_WAIT K_SECONDS(5)
 
-static struct packet_data packet;
-
 static struct k_sem quit_lock;
 
 struct packet_data {
@@ -28,6 +26,8 @@ struct packet_data {
 	char recv_buffer[RECV_BUFFER_SIZE];
 	struct k_delayed_work send;
 };
+
+static struct packet_data packet;
 
 static void process_packet(void);
 static void send_packet(void);

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -238,6 +238,7 @@ static int nbr_nexthop_put(struct net_nbr *nbr)
 
 
 #define net_route_info(str, route, dst)					\
+	do {								\
 	if (CONFIG_NET_ROUTE_LOG_LEVEL >= LOG_LEVEL_DBG) {		\
 		struct in6_addr *naddr = net_route_get_nexthop(route);	\
 									\
@@ -247,7 +248,7 @@ static int nbr_nexthop_put(struct net_nbr *nbr)
 			log_strdup(net_sprint_ipv6_addr(dst)),		\
 			log_strdup(net_sprint_ipv6_addr(naddr)),	\
 			route->iface);					\
-	} while (0)
+	} } while (0)
 
 /* Route was accessed, so place it in front of the routes list */
 static inline void update_route_access(struct net_route_entry *route)

--- a/tests/kernel/common/src/intmath.c
+++ b/tests/kernel/common/src/intmath.c
@@ -26,6 +26,11 @@
 /* Checks that MAX+1==MIN in the given type */
 #define ROLLOVER_CHECK(T, MAX, MIN) BUILD_ASSERT((T)((T)1 + (T)MAX) == (T)MIN)
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winteger-overflow"
+#endif
+
 ROLLOVER_CHECK(unsigned int, 0xffffffff, 0);
 ROLLOVER_CHECK(unsigned short, 0xffff, 0);
 ROLLOVER_CHECK(unsigned char, 0xff, 0);
@@ -50,6 +55,11 @@ NEG_CHECK(int, -1);
 NEG_CHECK(int, 0x80000000);
 NEG_CHECK(int, 0x7fffffff);
 ROLLOVER_CHECK(int, 2147483647, -2147483648);
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
 /**
  * @addtogroup kernel_common_tests
  * @{


### PR DESCRIPTION
This PR contains a number of fixes for warnings when running sanitycheck for native_posix with clang v8.0.