### PR TITLE
Corrected thread stack size in thread priority test

### DIFF
--- a/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
+++ b/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
@@ -8,13 +8,10 @@
 #include <irq_offload.h>
 #include <debug/stack.h>
 
+#include "tests_thread_apis.h"
+
 #define SLEEP_MS 100
 #define TEST_STRING "TEST"
-
-#define STACKSIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
-
-K_THREAD_STACK_EXTERN(tstack);
-extern struct k_thread tdata;
 
 static int tcount;
 static bool thread_flag;
@@ -64,7 +61,7 @@ void test_k_thread_foreach(void)
 
 	/* Create new thread which should add a new entry to the thread list */
 	k_tid_t tid = k_thread_create(&tdata, tstack,
-			STACKSIZE, (k_thread_entry_t)thread_entry, NULL,
+			STACK_SIZE, (k_thread_entry_t)thread_entry, NULL,
 			NULL, NULL, K_PRIO_PREEMPT(0), 0, 0);
 	k_sleep(1);
 

--- a/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
@@ -6,10 +6,8 @@
 
 #include <ztest.h>
 
-#define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
+#include "tests_thread_apis.h"
 
-K_THREAD_STACK_EXTERN(tstack);
-extern struct k_thread tdata;
 static ZTEST_BMEM int execute_flag;
 
 K_SEM_DEFINE(sync_sema, 0, 1);

--- a/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
@@ -6,14 +6,14 @@
 #include <ztest.h>
 #include <kernel.h>
 
+#include "tests_thread_apis.h"
+
 /* Very simple (and limited) test of the SMP cpu mask API.  Runs on
  * just one CPU.  Creates a thread, sets the CPU mask, starts it,
  * checks if it ran (or didn't run) as expected.
  */
 
 struct k_thread child_thread;
-extern size_t tstack_size;
-K_THREAD_STACK_EXTERN(tstack);
 
 bool child_has_run;
 

--- a/tests/kernel/threads/thread_apis/src/test_threads_set_priority.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_set_priority.c
@@ -6,10 +6,8 @@
 
 #include <ztest.h>
 
-#define STACK_SIZE (640 + CONFIG_TEST_EXTRA_STACKSIZE)
+#include "tests_thread_apis.h"
 
-K_THREAD_STACK_EXTERN(tstack);
-extern struct k_thread tdata;
 static int thread2_data;
 
 K_SEM_DEFINE(sem_thread2, 0, 1);

--- a/tests/kernel/threads/thread_apis/src/test_threads_spawn.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_spawn.c
@@ -7,9 +7,7 @@
 
 #include <ztest.h>
 
-#define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
-K_THREAD_STACK_EXTERN(tstack);
-extern struct k_thread tdata;
+#include "tests_thread_apis.h"
 
 static ZTEST_BMEM char tp1[8];
 static ZTEST_DMEM int tp2 = 100;

--- a/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
@@ -6,10 +6,8 @@
 
 #include <ztest.h>
 
-#define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
+#include "tests_thread_apis.h"
 
-K_THREAD_STACK_EXTERN(tstack);
-extern struct k_thread tdata;
 static ZTEST_BMEM int last_prio;
 
 static void thread_entry(void *p1, void *p2, void *p3)

--- a/tests/kernel/threads/thread_apis/src/tests_thread_apis.h
+++ b/tests/kernel/threads/thread_apis/src/tests_thread_apis.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TESTS_KERNEL_THREADS_THREAD_APIS_SRC_TEST_THREAD_APIS_H_
+#define ZEPHYR_TESTS_KERNEL_THREADS_THREAD_APIS_SRC_TEST_THREAD_APIS_H_
+
+#include <kernel.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
+K_THREAD_STACK_EXTERN(tstack);
+extern size_t tstack_size;
+extern struct k_thread tdata;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_TESTS_KERNEL_THREADS_THREAD_APIS_SRC_TEST_THREAD_APIS_H_ */


### PR DESCRIPTION
Corrected thread stack size in thread set priority test to prevent buffer overrun.

This problem was detected by running sanitycheck for native_posix with clang and address sanitizer enabled