### PR TITLE
Increased TX/RX buffer size in pipe test

### DIFF
--- a/tests/kernel/pipe/pipe/src/test_pipe.c
+++ b/tests/kernel/pipe/pipe/src/test_pipe.c
@@ -19,8 +19,8 @@ K_SEM_DEFINE(sync_sem, 0, 1);
 K_SEM_DEFINE(multiple_send_sem, 0, 1);
 
 
-ZTEST_BMEM u8_t tx_buffer[PIPE_SIZE];
-ZTEST_BMEM u8_t rx_buffer[PIPE_SIZE];
+ZTEST_BMEM u8_t tx_buffer[PIPE_SIZE + 1];
+ZTEST_BMEM u8_t rx_buffer[PIPE_SIZE + 1];
 
 #define TOTAL_ELEMENTS (sizeof(single_elements) / sizeof(struct pipe_sequence))
 #define TOTAL_WAIT_ELEMENTS (sizeof(wait_elements) / \


### PR DESCRIPTION
Increased TX/RX buffer size by one in pipe test to prevent buffer overrun.

This problem was detected by running saniycheck with clang and address sanitizer enabled