### PR TITLE
Bluetooth: Mesh: Fix matching for "All Proxies" group address

### DIFF
--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -517,8 +517,7 @@ bool bt_mesh_fixed_group_match(u16_t addr)
 	case BT_MESH_ADDR_ALL_NODES:
 		return true;
 	case BT_MESH_ADDR_PROXIES:
-		/* TODO: Proxy not yet supported */
-		return false;
+		return (bt_mesh_gatt_proxy_get() == BT_MESH_GATT_PROXY_ENABLED);
 	case BT_MESH_ADDR_FRIENDS:
 		return (bt_mesh_friend_get() == BT_MESH_FRIEND_ENABLED);
 	case BT_MESH_ADDR_RELAYS:


### PR DESCRIPTION
The bt_mesh_fixed_group_match() function is intended to match the
various well-known group addresses, however it was never updated when
Proxy support was added.

Fixes #19015

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>