### PR TITLE
[Backport v1.14-branch] Bluetooth: Mesh: Fix matching for "All Proxies" group address

### DIFF
--- a/subsys/bluetooth/host/mesh/access.c
+++ b/subsys/bluetooth/host/mesh/access.c
@@ -513,8 +513,7 @@ bool bt_mesh_fixed_group_match(u16_t addr)
 	case BT_MESH_ADDR_ALL_NODES:
 		return true;
 	case BT_MESH_ADDR_PROXIES:
-		/* TODO: Proxy not yet supported */
-		return false;
+		return (bt_mesh_gatt_proxy_get() == BT_MESH_GATT_PROXY_ENABLED);
 	case BT_MESH_ADDR_FRIENDS:
 		return (bt_mesh_friend_get() == BT_MESH_FRIEND_ENABLED);
 	case BT_MESH_ADDR_RELAYS:


### PR DESCRIPTION
Backport #19016