### PR TITLE
Fix coverity issue in coap_client sample

### DIFF
--- a/samples/net/sockets/coap_client/src/coap-client.c
+++ b/samples/net/sockets/coap_client/src/coap-client.c
@@ -627,14 +627,14 @@ void main(void)
 	}
 
 	/* Close the socket */
-	close(sock);
+	(void)close(sock);
 
 	LOG_DBG("Done");
 
 	return;
 
 quit:
-	close(sock);
+	(void)close(sock);
 
 	LOG_ERR("quit");
 }


### PR DESCRIPTION
Ignore socket close() return value in this sample.

Fixes #18961