### PR TITLE
Add explicit check for endianness preprocessor definitions

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -17,6 +17,7 @@
 #include <kernel_includes.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/net/ptp_time.h
+++ b/include/net/ptp_time.h
@@ -21,6 +21,7 @@
  */
 
 #include <net/net_core.h>
+#include <toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/sys/byteorder.h
+++ b/include/sys/byteorder.h
@@ -14,6 +14,7 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <sys/__assert.h>
+#include <toolchain.h>
 
 /* Internal helpers only used by the sys_* APIs further below */
 #define __bswap_16(x) ((u16_t) ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8)))

--- a/include/toolchain.h
+++ b/include/toolchain.h
@@ -41,4 +41,18 @@
 #include <toolchain/other.h>
 #endif
 
+/*
+ * Ensure that __BYTE_ORDER__ and related preprocessor definitions are defined,
+ * as these are often used without checking for definition and doing so can
+ * cause unexpected behaviours.
+ */
+#ifndef _LINKER
+#if !defined(__BYTE_ORDER__) || !defined(__ORDER_BIG_ENDIAN__) || \
+    !defined(__ORDER_LITTLE_ENDIAN__)
+
+#error "__BYTE_ORDER__ is not defined"
+
+#endif
+#endif /* !_LINKER */
+
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_H_ */

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <toolchain.h>
+
 #define BDADDR_SIZE 6
 
 /*

--- a/subsys/net/l2/ieee802154/ieee802154_frame.h
+++ b/subsys/net/l2/ieee802154/ieee802154_frame.h
@@ -14,8 +14,8 @@
 
 #include <kernel.h>
 #include <net/net_pkt.h>
-
 #include <net/ieee802154.h>
+#include <toolchain.h>
 
 #define IEEE802154_MTU				127
 #define IEEE802154_MIN_LENGTH			3


### PR DESCRIPTION
This pull request adds explicit check for endianness preprocessor definitions (`__BYTE_ORDER__`, `__ORDER_LITTLE_ENDIAN__`, `__ORDER_BIG_ENDIAN__`).

The endianness preprocessor definitions are used throughout the Zephyr codebase and, in order to prevent data corruption and unexpected system behaviours, it is absolutely critical that they are properly defined before being used.

**Background**
These preprocessor definitions are often used like this:
```
#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
...
#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
...
#endif
```

The example above, if the referenced definitions are not defined, will silently fall into the first statement, and this may or may not be the correct endianness of the system. This can easily go unnoticed by a developer and can cause insane behaviours in the system. Here is a good example of such: https://github.com/zephyrproject-rtos/zephyr/pull/18922#issuecomment-528238789.

This PR adds a definition check for the endianness preprocessor definitions in `include/toolchain.h` and explicitly adds inclusion of this header file from every source file that uses these definitions.

In conjunction with PR #18922, this allows older GCC versions that do not define these preprocessor definitions by default to produce correct code.

In the future, all new files using these preprocessor definitions should include `include/toolchain.h` at the top.

Please see PR #18922 for an in-depth discussion on this matter.