### PR TITLE
drivers: nrf: Add 2 stop bits option to nrf UARTE driver

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -266,8 +266,19 @@ static int uart_nrfx_configure(struct device *dev,
 {
 	nrf_uart_parity_t parity;
 	nrf_uart_hwfc_t hwfc;
+#ifdef UART_CONFIG_STOP_Two
+	bool two_stop_bits = false;
+#endif
 
-	if (cfg->stop_bits != UART_CFG_STOP_BITS_1) {
+	switch (cfg->stop_bits) {
+	case UART_CFG_STOP_BITS_1:
+		break;
+#ifdef UART_CONFIG_STOP_Two
+	case UART_CFG_STOP_BITS_2:
+		two_stop_bits = true;
+		break;
+#endif
+	default:
 		return -ENOTSUP;
 	}
 
@@ -307,6 +318,13 @@ static int uart_nrfx_configure(struct device *dev,
 
 	nrf_uart_configure(uart0_addr, parity, hwfc);
 
+#ifdef UART_CONFIG_STOP_Two
+	if (two_stop_bits) {
+		/* TODO Change this to nrfx HAL function when available */
+		uart0_addr->CONFIG |=
+			UART_CONFIG_STOP_Two << UART_CONFIG_STOP_Pos;
+	}
+#endif
 	get_dev_data(dev)->uart_config = *cfg;
 
 	return 0;

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -274,8 +274,19 @@ static int uarte_nrfx_configure(struct device *dev,
 {
 	nrf_uarte_parity_t parity;
 	nrf_uarte_hwfc_t hwfc;
+#ifdef UARTE_CONFIG_STOP_Two
+	bool two_stop_bits = false;
+#endif
 
-	if (cfg->stop_bits != UART_CFG_STOP_BITS_1) {
+	switch (cfg->stop_bits) {
+	case UART_CFG_STOP_BITS_1:
+		break;
+#ifdef UARTE_CONFIG_STOP_Two
+	case UART_CFG_STOP_BITS_2:
+		two_stop_bits = true;
+		break;
+#endif
+	default:
 		return -ENOTSUP;
 	}
 
@@ -315,6 +326,13 @@ static int uarte_nrfx_configure(struct device *dev,
 
 	nrf_uarte_configure(get_uarte_instance(dev), parity, hwfc);
 
+#ifdef UARTE_CONFIG_STOP_Two
+	if (two_stop_bits) {
+		/* TODO Change this to nrfx HAL function when available */
+		get_uarte_instance(dev)->CONFIG |=
+			UARTE_CONFIG_STOP_Two << UARTE_CONFIG_STOP_Pos;
+	}
+#endif
 	get_dev_data(dev)->uart_config = *cfg;
 
 	return 0;


### PR DESCRIPTION
nrf52840 and nrf9160 have possible configuration of two stop bits
for UARTE, this commit adds handling of it to driver.

Signed-off-by: Mieszko Mierunski <mieszko.mierunski@nordicsemi.no>