### PR TITLE
Bluetooth: ATT: Fix responding to unknown ATT command

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -1965,6 +1965,10 @@ static att_type_t att_op_get_type(u8_t op)
 		return ATT_INDICATION;
 	}
 
+	if (op & ATT_CMD_MASK) {
+		return ATT_COMMAND;
+	}
+
 	return ATT_UNKNOWN;
 }
 


### PR DESCRIPTION
Host shall ignore the unknown ATT PDU that has Command Flag set.
Fixes regression introduced in 3b271b8455f1ef6d74ffc80f610633146b00265e.

Fixes #19039

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>