### PR TITLE
power: stm32l4: support of the Low Power Mode

### DIFF
--- a/soc/arm/st_stm32/stm32l4/CMakeLists.txt
+++ b/soc/arm/st_stm32/stm32l4/CMakeLists.txt
@@ -4,3 +4,7 @@ zephyr_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_sources(
   soc.c
   )
+
+zephyr_sources_ifdef(CONFIG_SYS_POWER_MANAGEMENT
+  power.c
+  )

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
@@ -13,6 +13,11 @@ source "soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4*"
 config SOC_SERIES
 	default "stm32l4"
 
+config STM32_LPTIM_TIMER
+	bool
+	default y
+	depends on SYS_POWER_MANAGEMENT
+
 config DMA_STM32_V2
 	default y
 	depends on DMA_STM32

--- a/soc/arm/st_stm32/stm32l4/Kconfig.series
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.series
@@ -14,5 +14,8 @@ config SOC_SERIES_STM32L4X
 	select HAS_STM32CUBE
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
+	select HAS_SYS_POWER_STATE_SLEEP_1
+	select HAS_SYS_POWER_STATE_SLEEP_2
+	select HAS_SYS_POWER_STATE_SLEEP_3
 	help
 	  Enable support for STM32L4 MCU series

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2019 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr.h>
+#include <power/power.h>
+#include <soc.h>
+#include <init.h>
+
+#include <stm32l4xx_ll_bus.h>
+#include <stm32l4xx_ll_cortex.h>
+#include <stm32l4xx_ll_pwr.h>
+#include <stm32l4xx_ll_rcc.h>
+
+#include <logging/log.h>
+LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+
+/* Invoke Low Power/System Off specific Tasks */
+void sys_set_power_state(enum power_states state)
+{
+	switch (state) {
+#ifdef CONFIG_SYS_POWER_SLEEP_STATES
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_1
+	case SYS_POWER_STATE_SLEEP_1:
+
+		/* this corresponds to the STOP0 mode: */
+#ifdef CONFIG_DEBUG
+		/* Enable the Debug Module during STOP mode */
+		LL_DBGMCU_EnableDBGStopMode();
+#endif /* CONFIG_DEBUG */
+		/* ensure HSI is the wake-up system clock */
+		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
+		/* enter STOP0 mode */
+		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP0);
+		LL_LPM_EnableDeepSleep();
+		/* enter SLEEP mode : WFE or WFI */
+		k_cpu_idle();
+		break;
+#endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_1 */
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_2
+	case SYS_POWER_STATE_SLEEP_2:
+		/* this corresponds to the STOP1 mode: */
+#ifdef CONFIG_DEBUG
+		/* Enable the Debug Module during STOP mode */
+		LL_DBGMCU_EnableDBGStopMode();
+#endif /* CONFIG_DEBUG */
+		/* ensure HSI is the wake-up system clock */
+		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
+		/* enter STOP1 mode */
+		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP1);
+		LL_LPM_EnableDeepSleep();
+		k_cpu_idle();
+		break;
+#endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_2 */
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_3
+	case SYS_POWER_STATE_SLEEP_3:
+		/* this corresponds to the STOP2 mode: */
+#ifdef CONFIG_DEBUG
+		/* Enable the Debug Module during STOP mode */
+		LL_DBGMCU_EnableDBGStopMode();
+#endif /* CONFIG_DEBUG */
+		/* ensure HSI is the wake-up system clock */
+		LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
+#ifdef PWR_CR1_RRSTP
+		LL_PWR_DisableSRAM3Retention();
+#endif /* PWR_CR1_RRSTP */
+		/* enter STOP2 mode */
+		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP2);
+		LL_LPM_EnableDeepSleep();
+		k_cpu_idle();
+		break;
+#endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_3 */
+#endif /* CONFIG_SYS_POWER_SLEEP_STATES */
+	default:
+		LOG_DBG("Unsupported power state %u", state);
+		break;
+	}
+}
+
+/* Handle SOC specific activity after Low Power Mode Exit */
+void _sys_pm_power_state_exit_post_ops(enum power_states state)
+{
+	switch (state) {
+#ifdef CONFIG_SYS_POWER_SLEEP_STATES
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_1
+	case SYS_POWER_STATE_SLEEP_1:
+#endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_1 */
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_2
+	case SYS_POWER_STATE_SLEEP_2:
+#endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_2 */
+#ifdef CONFIG_HAS_SYS_POWER_STATE_SLEEP_3
+	case SYS_POWER_STATE_SLEEP_3:
+#endif /* CONFIG_HAS_SYS_POWER_STATE_SLEEP_3 */
+		LL_LPM_DisableSleepOnExit();
+		break;
+#endif /* CONFIG_SYS_POWER_SLEEP_STATES */
+	default:
+		LOG_DBG("Unsupported power state %u", state);
+		break;
+	}
+
+	/*
+	 * System is now in active mode.
+	 * Reenable interrupts which were disabled
+	 * when OS started idling code.
+	 */
+	irq_unlock(0);
+}
+
+/* Initialize STM32 Power */
+static int stm32_power_init(struct device *dev)
+{
+	unsigned int ret;
+
+	ARG_UNUSED(dev);
+
+	ret = irq_lock();
+
+	/* enable Power clock */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+
+	irq_unlock(ret);
+
+	return 0;
+}
+
+SYS_INIT(stm32_power_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -45,6 +45,11 @@ static const char *const core_devices[] = {
 static const char *const core_devices[] = {
 	"",
 };
+#elif defined(CONFIG_SOC_SERIES_STM32L4X)
+#define MAX_PM_DEVICES	1
+static const char *const core_devices[] = {
+	"sys_clock",
+};
 #else
 #error "Add SoC's core devices list for PM"
 #endif


### PR DESCRIPTION
This patch enables the low power Mode for the stm32l4r5 soc. 
The SLEEP (1,2,3) Modes, corresponding to the stm32L4 STOP 0,1,2, Modes, are supported on this device.
The CONFIG_SYS_POWER_MANAGEMENT is required to activate the low power sleep modes.
This config will enable the LPTIM low power timer to preserve the kernel count  during the low power phase. The lptim is a low power timer running during stop Modes, so that the kernel ticks are preserved. Then will the kernel run in a tickless mode, going to low power sleep mode when the device policy accepts. The device PM residency policy applies. 
Due to the LPTIM clocking and timeout capacity, the maximum timeout value is 2000ms : LPTIM counter reaches the 16 bits value, when prescaler is set to 1 (DIV1). This means that when kernel request a sleep duration of more than 2 seconds, it will sleep for 2000ms then wakes Up and goes to sleep again for the next 2-second period. 
Increasing this timeout value implies that the LPTIM count unit is also increased. The LPTIM count unit gives the minimum timeout value. Based on the LSE source clock, the LPTIM count unit is 0.03 ms.
This PR also requires a definition of the PM residency policy. Then any application calling the k_sleep function will enter low power sleep mode for the given duration. Some peripherals can run during stop mode, some cannot. 
This is adjustable with CONFIG_HAS_SYS_POWER_STATE_SLEEP_X.
 
FOREVER: the system goes to sleep without a timer to wakeup, only a reset or EXTI can resume, if the EXTI line has been configured before entering the sleep mode. EXTI line can be a gpio pin or a peripheral with wakeup capability. Then is the lptim able to re-start counting.

Note that DEEP_SLEEP modes are not enabled yet, as LPTIM cannot run during stm32 standby or shutdown modes.

Signed-off-by: Francois Ramu francois.ramu@st.com