### PR TITLE
dts/watchdog: microchip,xec: fix cmake warnings

### DIFF
--- a/dts/bindings/watchdog/microchip,xec-watchdog.yaml
+++ b/dts/bindings/watchdog/microchip,xec-watchdog.yaml
@@ -9,19 +9,16 @@ title: Microchip XEC watchdog timer
 description: >
     This binding gives a base representation of the Microchip XEC watchdog timer
 
-inherits:
-    !include base.yaml
+include: base.yaml
+
+compatible: "microchip,xec-watchdog"
 
 properties:
-    compatible:
-      constraint: "microchip,xec-watchdog"
-
     reg:
-      category: required
+      required: true
 
     label:
-      category: required
+      required: true
 
     interrupts:
-      category: required
-...
+      required: true


### PR DESCRIPTION
With the change to "compatible", and deprecation of "inherit"
and "category: required", there are multiple warnings when
running cmake. So fix those by updating the DTS YAML file.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>