### PR TITLE
dts/bindings: st: sensors: Mark 'irq-gpios' as optional

### DIFF
--- a/dts/bindings/sensor/st,lis2ds12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-i2c.yaml
@@ -13,4 +13,4 @@ include: i2c-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: true
+      required: false

--- a/dts/bindings/sensor/st,lis2ds12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-spi.yaml
@@ -14,4 +14,4 @@ include: spi-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: true
+      required: false

--- a/dts/bindings/sensor/st,lis2dw12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-i2c.yaml
@@ -13,4 +13,4 @@ include: i2c-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: true
+      required: false

--- a/dts/bindings/sensor/st,lis2dw12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-spi.yaml
@@ -14,4 +14,4 @@ include: spi-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: true
+      required: false

--- a/dts/bindings/sensor/st,lis2mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-magn.yaml
@@ -13,4 +13,4 @@ include: i2c-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: true
+      required: false

--- a/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
@@ -14,4 +14,4 @@ include: i2c-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: true
+      required: false

--- a/dts/bindings/sensor/st,lsm6dsl-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-spi.yaml
@@ -14,4 +14,4 @@ include: spi-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: true
+      required: false

--- a/dts/bindings/sensor/st,lsm6dso-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-i2c.yaml
@@ -14,4 +14,4 @@ include: i2c-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: true
+      required: false

--- a/dts/bindings/sensor/st,lsm6dso-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-spi.yaml
@@ -14,4 +14,4 @@ include: spi-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: true
+      required: false

--- a/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
@@ -13,4 +13,4 @@ include: i2c-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: true
+      required: false

--- a/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
@@ -13,4 +13,4 @@ include: i2c-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: true
+      required: false


### PR DESCRIPTION
The 'irq-gpios' property is optional as the drivers work fine if this
property isn't set.  The property is only required if "TRIGGER" mode is
enabled in the drivers.

As such mark 'irq-gpios' as 'required:false`.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>