### PR TITLE
sys: dlist: remove deprecated sys_dlist_insert_{before,after}

### DIFF
--- a/include/sys/dlist.h
+++ b/include/sys/dlist.h
@@ -445,32 +445,6 @@ static inline void sys_dlist_insert(sys_dnode_t *successor, sys_dnode_t *node)
 	successor->prev = node;
 }
 
-static inline void __deprecated sys_dlist_insert_after(sys_dlist_t *list,
-	sys_dnode_t *insert_point, sys_dnode_t *node)
-{
-	if (insert_point == NULL) {
-		sys_dlist_prepend(list, node);
-	} else {
-		node->next = insert_point->next;
-		node->prev = insert_point;
-		insert_point->next->prev = node;
-		insert_point->next = node;
-	}
-}
-
-static inline void __deprecated sys_dlist_insert_before(sys_dlist_t *list,
-	sys_dnode_t *insert_point, sys_dnode_t *node)
-{
-	if (insert_point == NULL) {
-		sys_dlist_append(list, node);
-	} else {
-		node->prev = insert_point->prev;
-		node->next = insert_point;
-		insert_point->prev->next = node;
-		insert_point->prev = node;
-	}
-}
-
 /**
  * @brief insert node at position
  *


### PR DESCRIPTION
sys_dlist_insert_before and sys_dlist_insert_after have been deprecated
for at least 2 releases.  We can now remove them.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>