### PR TITLE
scripts: dts: Fix wrong filename in 'include:' code in old scripts

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -218,12 +218,12 @@ def merge_included_bindings(fname, node):
     res = node
 
     if "include" in node:
-        fnames = node.pop("include")
-        if isinstance(fnames, str):
-            fnames = [fnames]
+        included = node.pop("include")
+        if isinstance(included, str):
+            included = [included]
 
-        for fname in fnames:
-            binding = load_binding_file(fname)
+        for included_fname in included:
+            binding = load_binding_file(included_fname)
             inherited = merge_included_bindings(fname, binding)
             merge_properties(None, fname, inherited, res)
             res = inherited


### PR DESCRIPTION
The 'fname' parameter to merge_included_bindings(), giving the path to
the top-level binding file, was accidentally shadowed in the
'for fname in fnames:' loop. This could lead to the wrong filename being
used in error messages.

Discovered via this pylint warning:

    scripts/dts/extract_dts_includes.py:225:12: R1704: Redefining
    argument with the local name 'fname' (redefined-argument-from-local)

Improve naming a bit to fix it.