### PR TITLE
samples: CAN: Tweak GPIO flags in dts for mcp2515

### DIFF
--- a/samples/drivers/CAN/mcp2515-dts.overlay
+++ b/samples/drivers/CAN/mcp2515-dts.overlay
@@ -6,7 +6,7 @@
 
 &spi1 {
 	status = "okay";
-	cs-gpios = <&gpioa 4 GPIO_DIR_OUT>;
+	cs-gpios = <&gpioa 4 0>;
 	mcp2515@0 {
 		compatible = "microchip,mcp2515";
 		spi-port-name = "SPI_1";


### PR DESCRIPTION
Remove setting GPIO_DIR_OUT in the dts overlay for mcp2515 as a
precursor to new GPIO API work.  The flag isn't used for cs-gpio,
as we hard code GPIO_DIR_OUT in the spi controller code.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>