### PR TITLE
drivers: audio: tlv320dac310x: Explicitly set GPIO_DIR_OUT

### DIFF
--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
@@ -41,7 +41,7 @@
 		compatible = "ti,tlv320dac";
 		reg = <0x18>;
 		label = "TLV320DAC";
-		reset-gpios = <&gpio0 4 GPIO_DIR_OUT>;
+		reset-gpios = <&gpio0 4 0>;
 	};
 };
 

--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -110,7 +110,7 @@ static int codec_configure(struct device *dev,
 
 	/* configure reset GPIO */
 	gpio_pin_configure(dev_cfg->gpio_device, dev_cfg->gpio_pin,
-				     dev_cfg->gpio_flags);
+				     dev_cfg->gpio_flags | GPIO_DIR_OUT);
 	/* de-assert reset */
 	gpio_pin_write(dev_cfg->gpio_device, dev_cfg->gpio_pin,
 				 CODEC_RESET_PIN_DEASSERT);


### PR DESCRIPTION
As a precursor to the new GPIO API in which GPIO_DIR_OUT isn't a dts
flag move setting of GPIO_DIR_OUT from the dts to explicitly in the
code.  We remove setting the flag in intel_s1000_crb.dts as part of this
cleanup.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>