### PR TITLE
kernel: Fix _K_QUEUE_INITIALIZER portability issue.

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1839,8 +1839,11 @@ struct k_queue {
 #define _K_QUEUE_INITIALIZER(obj) \
 	{ \
 	.data_q = SYS_SLIST_STATIC_INIT(&obj.data_q), \
-	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q), \
-	_POLL_EVENT_OBJ_INIT(obj) \
+	.lock = { }, \
+	{ \
+		.wait_q = Z_WAIT_Q_INIT(&obj.wait_q), \
+		_POLL_EVENT_OBJ_INIT(obj) \
+	}, \
 	_OBJECT_TRACING_INIT \
 	}
 


### PR DESCRIPTION
_K_QUEUE_INITIALIZER macro provides initialisation for k_queue struct,
which contains an anonymous union.

Older versions of GCC (<= 4.5), even when compiling with -std=gnu99,
do not allow specifying members of an anonymous union without braces
in an initialiser, so it is necessary to add braces around anonymous
union members.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>