### PR TITLE
Fix shield sample build issue for x_nucleo_iks01a2

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
   - arduino_i2c
   - i2c
   - hts221

--- a/boards/arm/frdm_k64f/frdm_k64f.yaml
+++ b/boards/arm/frdm_k64f/frdm_k64f.yaml
@@ -7,6 +7,8 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
+  - arduino_i2c
   - netif:eth
   - adc
   - i2c

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.yaml
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.yaml
@@ -8,6 +8,8 @@ toolchain:
   - xtools
 supported:
   - adc
+  - arduino_gpio
+  - arduino_i2c
   - usb_device
   - usb_cdc
   - ble

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
@@ -10,6 +10,8 @@ ram: 64
 flash: 512
 supported:
   - adc
+  - arduino_gpio
+  - arduino_i2c
   - counter
   - nvs
   - i2c

--- a/boards/arm/nucleo_f401re/nucleo_f401re.yaml
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
   - arduino_i2c
   - pwm
   - rtc

--- a/boards/arm/nucleo_f411re/nucleo_f411re.yaml
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
   - arduino_i2c
   - rtc
   - counter

--- a/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.yaml
+++ b/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.yaml
@@ -7,6 +7,8 @@ toolchain:
   - gccarmemb
   - xtools
 supported:
+  - arduino_i2c
+  - arduino_gpio
   - gpio
   - shell
   - i2c

--- a/boards/riscv/rv32m1_vega/rv32m1_vega_ri5cy.yaml
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega_ri5cy.yaml
@@ -6,4 +6,6 @@ toolchain:
   - cross-compile
   - zephyr
 supported:
+  - arduino_gpio
+  - arduino_i2c
   - i2c

--- a/boards/riscv/rv32m1_vega/rv32m1_vega_zero_riscy.yaml
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega_zero_riscy.yaml
@@ -6,4 +6,6 @@ toolchain:
   - cross-compile
   - zephyr
 supported:
+  - arduino_gpio
+  - arduino_i2c
   - i2c

--- a/samples/shields/x_nucleo_iks01a2/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a2/sample.yaml
@@ -5,4 +5,4 @@ tests:
     harness: shield
     tags: shield
     depends_on: arduino_i2c arduino_gpio
-    platform_exclude: disco_l475_iot1
+    platform_exclude: disco_l475_iot1 stm32mp157c_dk2

--- a/samples/shields/x_nucleo_iks01a2/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a2/sample.yaml
@@ -2,8 +2,7 @@ sample:
   name: X-NUCLEO-IKS01A2 sensor shield
 tests:
   sample.shields.x_nucleo_iks01a2:
-    platform_exclude: disco_l475_iot1
     harness: shield
     tags: shield
-    depends_on: arduino_i2c
+    depends_on: arduino_i2c arduino_gpio
     platform_exclude: disco_l475_iot1

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/sample.yaml
@@ -2,8 +2,7 @@ sample:
   name: X-NUCLEO-IKS01A3 sensor shield
 tests:
   test:
-    platform_exclude: disco_l475_iot1
     harness: shield
     tags: shield
     depends_on: arduino_i2c arduino_gpio
-    platform_exclude: disco_l475_iot1
+    platform_exclude: disco_l475_iot1 stm32mp157c_dk2

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/sample.yaml
@@ -5,5 +5,5 @@ tests:
     platform_exclude: disco_l475_iot1
     harness: shield
     tags: shield
-    depends_on: arduino_i2c arduino_header
+    depends_on: arduino_i2c arduino_gpio
     platform_exclude: disco_l475_iot1

--- a/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
@@ -2,8 +2,7 @@ sample:
   name: X-NUCLEO-IKS01A3 sensor shield
 tests:
   test:
-    platform_exclude: disco_l475_iot1
     harness: shield
     tags: shield
     depends_on: arduino_i2c arduino_gpio
-    platform_exclude: disco_l475_iot1
+    platform_exclude: disco_l475_iot1 stm32mp157c_dk2

--- a/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
@@ -5,5 +5,5 @@ tests:
     platform_exclude: disco_l475_iot1
     harness: shield
     tags: shield
-    depends_on: arduino_i2c arduino_header
+    depends_on: arduino_i2c arduino_gpio
     platform_exclude: disco_l475_iot1


### PR DESCRIPTION
samples/shields/x_nucleo_iks01a2/sample.shields.x_nucleo_iks01a2 fails to build on a number of boards because they lack `arduino_header` in their dts.  Make the sample depend on `arduino_header` and update various boards to say they support this.