### PR TITLE
settings: Direct loading functionality

### DIFF
--- a/include/settings/settings.h
+++ b/include/settings/settings.h
@@ -342,7 +342,6 @@ int settings_commit_subtree(const char *subtree);
 struct settings_store_itf;
 
 /**
- * @struct settings_store
  * Backend handler node for storage handling.
  */
 struct settings_store {
@@ -354,23 +353,43 @@ struct settings_store {
 };
 
 /**
- * @struct settings_store_itf
+ * Arguments for data loading.
+ * Holds all parameters that changes the way data should be loaded from backend.
+ */
+struct settings_load_arg {
+	/**
+	 * @brief Name of the subtree to be loaded
+	 *
+	 * If NULL, all values would be loaded.
+	 */
+	const char *subtree;
+	/**
+	 * @brief Pointer to the callback function.
+	 *
+	 * If NULL then matching registered function would be used.
+	 */
+	settings_load_direct_cb cb;
+	/**
+	 * @brief Parameter for callback function
+	 *
+	 * Parameter to be passed to the callback function.
+	 */
+	void *param;
+};
+
+/**
  * Backend handler functions.
  * Sources are registered using a call to @ref settings_src_register.
  * Destinations are registered using a call to @ref settings_dst_register.
  */
 struct settings_store_itf {
-	int (*csi_load)(struct settings_store *cs, const char *subtree,
-			settings_load_direct_cb cb, void *param);
+	int (*csi_load)(struct settings_store *cs,
+			const struct settings_load_arg *arg);
 	/**< Loads values from storage limited to subtree defined by subtree.
 	 *
 	 * Parameters:
-	 *  - cs - Corresponding backend handler node
-	 *  - subtree - subtree name of the subtree to be loaded,
-	 *              if NULL loads all values.
-	 *  - cb - pointer to the callback function,
-	 *         if NULL then matching registered function would be used.
-	 *  - param - parameter to be passed when callback function is called.
+	 *  - cs - Corresponding backend handler node,
+	 *  - arg - Structure that holds additional data for data loading.
 	 */
 
 	int (*csi_save_start)(struct settings_store *cs);
@@ -429,9 +448,26 @@ void settings_dst_register(struct settings_store *cs);
  * @return settings_handler_static on success, NULL on failure.
  */
 struct settings_handler_static *settings_parse_and_lookup(const char *name,
-							const char **next);
+							  const char **next);
 
-
+/**
+ * Calls settings handler.
+ *
+ * @param[in]     name        The name of the data found in the backend.
+ * @param[in]     len         The size of the data found in the backend.
+ * @param[in]     read_cb     Function provided to read the data from
+ *                            the backend.
+ * @param[in,out] read_cb_arg Arguments for the read function provided by
+ *                            the backend.
+ * @param[in,out] load_arg    Arguments for data loading.
+ *
+ * @return 0 or negative error code
+ */
+int settings_call_set_handler(const char *name,
+			      size_t len,
+			      settings_read_cb read_cb,
+			      void *read_cb_arg,
+			      const struct settings_load_arg *load_arg);
 /*
  * API for const name processing
  */

--- a/include/settings/settings.h
+++ b/include/settings/settings.h
@@ -227,6 +227,59 @@ int settings_load(void);
 int settings_load_subtree(const char *subtree);
 
 /**
+ * Callback function used for direct loading.
+ * Used by @ref settings_load_subtree_direct function.
+ *
+ * @param[in]     key     the name with skipped part that was used as name in
+ *                        handler registration
+ * @param[in]     len     the size of the data found in the backend.
+ * @param[in]     read_cb function provided to read the data from the backend.
+ * @param[in,out] cb_arg  arguments for the read function provided by the
+ *                        backend.
+ * @param[in,out] param   parameter given to the
+ *                        @ref settings_load_subtree_direct function.
+ *
+ *  - key[in] the name with skipped part that was used as name in
+ *    handler registration
+ *  - len[in] the size of the data found in the backend.
+ *  - read_cb[in] function provided to read the data from the backend.
+ *  - cb_arg[in] arguments for the read function provided by the
+ *    backend.
+ *
+ * @return When nonzero value is returned, further subtree searching is stopped.
+ *         Use with care as some settings backends would iterate through old
+ *         values, and the current value is returned last.
+ */
+typedef int (*settings_load_direct_cb)(
+	const char      *key,
+	size_t           len,
+	settings_read_cb read_cb,
+	void            *cb_arg,
+	void            *param);
+
+/**
+ * Load limited set of serialized items using given callback.
+ *
+ * This function bypasses the normal data workflow in settings module.
+ * All the settings values that are found are passed to the given callback.
+ *
+ * @note
+ * This function does not call commit function.
+ * It works as a blocking function, so it is up to the user to call
+ * any kind of commit function when this operation ends.
+ *
+ * @param[in]     subtree subtree name of the subtree to be loaded.
+ * @param[in]     cb      pointer to the callback function.
+ * @param[in,out] param   parameter to be passed when callback
+ *                        function is called.
+ * @return 0 on success, non-zero on failure.
+ */
+int settings_load_subtree_direct(
+	const char             *subtree,
+	settings_load_direct_cb cb,
+	void                   *param);
+
+/**
  * Save currently running serialized items. All serialized items which are
  * different from currently persisted values will be saved.
  *
@@ -307,12 +360,17 @@ struct settings_store {
  * Destinations are registered using a call to @ref settings_dst_register.
  */
 struct settings_store_itf {
-	int (*csi_load)(struct settings_store *cs, const char *subtree);
-	/**< Loads values from storage limited to subtree defined by subtree. If
-	 * subtree = NULL loads all values.
+	int (*csi_load)(struct settings_store *cs, const char *subtree,
+			settings_load_direct_cb cb, void *param);
+	/**< Loads values from storage limited to subtree defined by subtree.
 	 *
 	 * Parameters:
 	 *  - cs - Corresponding backend handler node
+	 *  - subtree - subtree name of the subtree to be loaded,
+	 *              if NULL loads all values.
+	 *  - cb - pointer to the callback function,
+	 *         if NULL then matching registered function would be used.
+	 *  - param - parameter to be passed when callback function is called.
 	 */
 
 	int (*csi_save_start)(struct settings_store *cs);

--- a/samples/bluetooth/peripheral_dis/src/main.c
+++ b/samples/bluetooth/peripheral_dis/src/main.c
@@ -46,7 +46,9 @@ static struct bt_conn_cb conn_callbacks = {
 };
 
 static int zephyr_settings_fw_load(struct settings_store *cs,
-				   const char *subtree);
+				   const char *subtree,
+				   settings_load_direct_cb cb,
+				   void *param);
 
 static const struct settings_store_itf zephyr_settings_fw_itf = {
 	.csi_load = zephyr_settings_fw_load,
@@ -57,9 +59,13 @@ static struct settings_store zephyr_settings_fw_store = {
 };
 
 static int zephyr_settings_fw_load(struct settings_store *cs,
-				   const char *subtree)
+				   const char *subtree,
+				   settings_load_direct_cb cb,
+				   void *param)
 {
-
+	/* Ignore subtree and direct loading */
+	if (subtree || cb)
+		return 0;
 #if defined(CONFIG_BT_GATT_DIS_SETTINGS)
 	settings_runtime_set("bt/dis/model",
 			     "Zephyr Model",

--- a/samples/bluetooth/peripheral_dis/src/main.c
+++ b/samples/bluetooth/peripheral_dis/src/main.c
@@ -46,9 +46,7 @@ static struct bt_conn_cb conn_callbacks = {
 };
 
 static int zephyr_settings_fw_load(struct settings_store *cs,
-				   const char *subtree,
-				   settings_load_direct_cb cb,
-				   void *param);
+				   const struct settings_load_arg *arg);
 
 static const struct settings_store_itf zephyr_settings_fw_itf = {
 	.csi_load = zephyr_settings_fw_load,
@@ -59,12 +57,10 @@ static struct settings_store zephyr_settings_fw_store = {
 };
 
 static int zephyr_settings_fw_load(struct settings_store *cs,
-				   const char *subtree,
-				   settings_load_direct_cb cb,
-				   void *param)
+				   const struct settings_load_arg *arg)
 {
 	/* Ignore subtree and direct loading */
-	if (subtree || cb)
+	if (arg && (arg->subtree || arg->cb))
 		return 0;
 #if defined(CONFIG_BT_GATT_DIS_SETTINGS)
 	settings_runtime_set("bt/dis/model",

--- a/subsys/settings/src/settings.c
+++ b/subsys/settings/src/settings.c
@@ -190,6 +190,46 @@ struct settings_handler_static *settings_parse_and_lookup(const char *name,
 	return bestmatch;
 }
 
+int settings_call_set_handler(const char *name,
+			      size_t len,
+			      settings_read_cb read_cb,
+			      void *read_cb_arg,
+			      const struct settings_load_arg *load_arg)
+{
+	int rc;
+	const char *name_key;
+
+	if (load_arg && load_arg->subtree &&
+	    !settings_name_steq(name, load_arg->subtree, &name_key)) {
+		return 0;
+	}
+
+	if (load_arg && load_arg->cb) {
+		rc = load_arg->cb(name_key, len, read_cb, read_cb_arg,
+				  load_arg->param);
+	} else {
+		struct settings_handler_static *ch;
+
+		ch = settings_parse_and_lookup(name, &name_key);
+		if (!ch) {
+			return 0;
+		}
+
+		rc = ch->h_set(name_key, len, read_cb, read_cb_arg);
+
+		if (rc != 0) {
+			LOG_ERR("set-value failure. key: %s error(%d)",
+				log_strdup(name), rc);
+			/* Ignoring the error */
+			rc = 0;
+		} else {
+			LOG_DBG("set-value OK. key: %s",
+				log_strdup(name));
+		}
+	}
+	return rc;
+}
+
 int settings_commit(void)
 {
 	return settings_commit_subtree(NULL);

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -23,7 +23,8 @@ struct settings_fcb_load_cb_arg {
 	void *cb_arg;
 };
 
-static int settings_fcb_load(struct settings_store *cs, const char *subtree);
+static int settings_fcb_load(struct settings_store *cs, const char *subtree,
+			     settings_load_direct_cb cb, void *param);
 static int settings_fcb_save(struct settings_store *cs, const char *name,
 			     const char *value, size_t val_len);
 
@@ -117,10 +118,15 @@ static int settings_fcb_load_priv(struct settings_store *cs, line_load_cb cb,
 	return 0;
 }
 
-static int settings_fcb_load(struct settings_store *cs, const char *subtree)
+static int settings_fcb_load(struct settings_store *cs, const char *subtree,
+			     settings_load_direct_cb cb, void *param)
 {
-	return settings_fcb_load_priv(cs, settings_line_load_cb,
-				      (void *)subtree);
+	struct settings_line_load_arg arg = {
+		.subtree   = subtree,
+		.direct_cb = cb,
+		.param     = param
+	};
+	return settings_fcb_load_priv(cs, settings_line_load_cb, &arg);
 }
 
 

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -23,8 +23,8 @@ struct settings_fcb_load_cb_arg {
 	void *cb_arg;
 };
 
-static int settings_fcb_load(struct settings_store *cs, const char *subtree,
-			     settings_load_direct_cb cb, void *param);
+static int settings_fcb_load(struct settings_store *cs,
+			     const struct settings_load_arg *arg);
 static int settings_fcb_save(struct settings_store *cs, const char *name,
 			     const char *value, size_t val_len);
 
@@ -118,15 +118,10 @@ static int settings_fcb_load_priv(struct settings_store *cs, line_load_cb cb,
 	return 0;
 }
 
-static int settings_fcb_load(struct settings_store *cs, const char *subtree,
-			     settings_load_direct_cb cb, void *param)
+static int settings_fcb_load(struct settings_store *cs,
+			     const struct settings_load_arg *arg)
 {
-	struct settings_line_load_arg arg = {
-		.subtree   = subtree,
-		.direct_cb = cb,
-		.param     = param
-	};
-	return settings_fcb_load_priv(cs, settings_line_load_cb, &arg);
+	return settings_fcb_load_priv(cs, settings_line_load_cb, (void *)arg);
 }
 
 

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -14,7 +14,8 @@
 #include "settings/settings_file.h"
 #include "settings_priv.h"
 
-static int settings_file_load(struct settings_store *cs, const char *subtree);
+static int settings_file_load(struct settings_store *cs, const char *subtree,
+			      settings_load_direct_cb cb, void *param);
 static int settings_file_save(struct settings_store *cs, const char *name,
 			      const char *value, size_t val_len);
 
@@ -109,10 +110,15 @@ static int settings_file_load_priv(struct settings_store *cs, line_load_cb cb,
 /*
  * Called to load configuration items.
  */
-static int settings_file_load(struct settings_store *cs, const char *subtree)
+static int settings_file_load(struct settings_store *cs, const char *subtree,
+			      settings_load_direct_cb cb, void *param)
 {
-	return settings_file_load_priv(cs, settings_line_load_cb,
-				       (void *)subtree);
+	struct settings_line_load_arg arg = {
+		.subtree   = subtree,
+		.direct_cb = cb,
+		.param     = param
+	};
+	return settings_file_load_priv(cs, settings_line_load_cb, &arg);
 }
 
 static void settings_tmpfile(char *dst, const char *src, char *pfx)

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -14,8 +14,8 @@
 #include "settings/settings_file.h"
 #include "settings_priv.h"
 
-static int settings_file_load(struct settings_store *cs, const char *subtree,
-			      settings_load_direct_cb cb, void *param);
+static int settings_file_load(struct settings_store *cs,
+			      const struct settings_load_arg *arg);
 static int settings_file_save(struct settings_store *cs, const char *name,
 			      const char *value, size_t val_len);
 
@@ -110,15 +110,10 @@ static int settings_file_load_priv(struct settings_store *cs, line_load_cb cb,
 /*
  * Called to load configuration items.
  */
-static int settings_file_load(struct settings_store *cs, const char *subtree,
-			      settings_load_direct_cb cb, void *param)
+static int settings_file_load(struct settings_store *cs,
+			      const struct settings_load_arg *arg)
 {
-	struct settings_line_load_arg arg = {
-		.subtree   = subtree,
-		.direct_cb = cb,
-		.param     = param
-	};
-	return settings_file_load_priv(cs, settings_line_load_cb, &arg);
+	return settings_file_load_priv(cs, settings_line_load_cb, (void *)arg);
 }
 
 static void settings_tmpfile(char *dst, const char *src, char *pfx)

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -497,7 +497,7 @@ static int settings_line_cmp(char const *val, size_t val_len,
 	return rc;
 }
 
-void settings_line_dup_check_cb(const char *name, void *val_read_cb_ctx,
+int settings_line_dup_check_cb(const char *name, void *val_read_cb_ctx,
 				off_t off, void *cb_arg)
 {
 	struct settings_line_dup_check_arg *cdca;
@@ -505,7 +505,7 @@ void settings_line_dup_check_cb(const char *name, void *val_read_cb_ctx,
 
 	cdca = (struct settings_line_dup_check_arg *)cb_arg;
 	if (strcmp(name, cdca->name)) {
-		return;
+		return 0;
 	}
 
 	len_read = settings_line_val_get_len(off, val_read_cb_ctx);
@@ -521,6 +521,7 @@ void settings_line_dup_check_cb(const char *name, void *val_read_cb_ctx,
 			cdca->is_dup = 0;
 		}
 	}
+	return 0;
 }
 
 static ssize_t settings_line_read_cb(void *cb_arg, void *data, size_t len)
@@ -540,38 +541,44 @@ static ssize_t settings_line_read_cb(void *cb_arg, void *data, size_t len)
 	return -1;
 }
 
-void settings_line_load_cb(const char *name, void *val_read_cb_ctx, off_t off,
+int settings_line_load_cb(const char *name, void *val_read_cb_ctx, off_t off,
 			   void *cb_arg)
 {
 	const char *name_key;
 	struct settings_handler_static *ch;
 	struct settings_line_read_value_cb_ctx value_ctx;
+	struct settings_line_load_arg *arg = cb_arg;
 	int rc;
 	size_t len;
 
-	if (cb_arg && !settings_name_steq(name, cb_arg, NULL)) {
-		return;
-	}
-
-	ch = settings_parse_and_lookup(name, &name_key);
-	if (!ch) {
-		return;
+	if (arg && arg->subtree &&
+	    !settings_name_steq(name, arg->subtree, &name_key)) {
+		return 0;
 	}
 
 	value_ctx.read_cb_ctx = val_read_cb_ctx;
 	value_ctx.off = off;
-
 	len = settings_line_val_get_len(off, val_read_cb_ctx);
 
-	rc = ch->h_set(name_key, len, settings_line_read_cb,
-		       (void *)&value_ctx);
-
-	if (rc != 0) {
-		LOG_ERR("set-value failure. key: %s error(%d)",
-			log_strdup(name), rc);
+	if (arg && arg->direct_cb) {
+		rc = arg->direct_cb(name_key, len, settings_line_read_cb,
+				    (void *)&value_ctx, arg->param);
 	} else {
-		LOG_DBG("set-value OK. key: %s",
-			log_strdup(name));
+		ch = settings_parse_and_lookup(name, &name_key);
+		if (!ch) {
+			return 0;
+		}
+
+		rc = ch->h_set(name_key, len, settings_line_read_cb,
+			       (void *)&value_ctx);
+
+		if (rc != 0) {
+			LOG_ERR("set-value failure. key: %s error(%d)",
+				log_strdup(name), rc);
+		} else {
+			LOG_DBG("set-value OK. key: %s",
+				log_strdup(name));
+		}
 	}
-	(void)rc;
+	return rc;
 }

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -20,7 +20,8 @@ struct settings_nvs_read_fn_arg {
 	u16_t id;
 };
 
-static int settings_nvs_load(struct settings_store *cs, const char *subtree);
+static int settings_nvs_load(struct settings_store *cs, const char *subtree,
+			     settings_load_direct_cb cb, void *param);
 static int settings_nvs_save(struct settings_store *cs, const char *name,
 			     const char *value, size_t val_len);
 
@@ -62,7 +63,8 @@ int settings_nvs_dst(struct settings_nvs *cf)
 	return 0;
 }
 
-static int settings_nvs_load(struct settings_store *cs, const char *subtree)
+static int settings_nvs_load(struct settings_store *cs, const char *subtree,
+			     settings_load_direct_cb cb, void *param)
 {
 	struct settings_nvs *cf = (struct settings_nvs *)cs;
 	struct settings_nvs_read_fn_arg read_fn_arg;
@@ -113,19 +115,28 @@ static int settings_nvs_load(struct settings_store *cs, const char *subtree)
 		/* Found a name, this might not include a trailing \0 */
 		name[rc1] = '\0';
 
-		if (subtree && !settings_name_steq(name, subtree, NULL)) {
-			continue;
-		}
-
-		ch = settings_parse_and_lookup(name, &name_argv);
-		if (!ch) {
+		if (subtree && !settings_name_steq(name, subtree, &name_argv)) {
 			continue;
 		}
 
 		read_fn_arg.fs = &cf->cf_nvs;
 		read_fn_arg.id = name_id + NVS_NAME_ID_OFFSET;
-		ch->h_set(name_argv, rc2, settings_nvs_read_fn,
-			  (void *) &read_fn_arg);
+		if (cb) {
+			int ret;
+
+			ret = cb(name_argv, rc2, settings_nvs_read_fn,
+				 (void *) &read_fn_arg, param);
+			if (ret)
+				return ret;
+		} else {
+			ch = settings_parse_and_lookup(name, &name_argv);
+			if (!ch) {
+				continue;
+			}
+
+			ch->h_set(name_argv, rc2, settings_nvs_read_fn,
+				  (void *) &read_fn_arg);
+		}
 	}
 	return 0;
 }

--- a/subsys/settings/src/settings_priv.h
+++ b/subsys/settings/src/settings_priv.h
@@ -46,12 +46,6 @@ int settings_line_load_cb(const char *name, void *val_read_cb_ctx,
 typedef int (*line_load_cb)(const char *name, void *val_read_cb_ctx,
 			     off_t off, void *cb_arg);
 
-struct settings_line_load_arg {
-	const char             *subtree;
-	settings_load_direct_cb direct_cb;
-	void                   *param;
-};
-
 struct settings_line_read_value_cb_ctx {
 	void *read_cb_ctx;
 	off_t off;

--- a/subsys/settings/src/settings_priv.h
+++ b/subsys/settings/src/settings_priv.h
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <sys/slist.h>
 #include <errno.h>
+#include <settings/settings.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,14 +37,20 @@ int settings_line_write(const char *name, const char *value, size_t val_len,
 /* Get len of record without alignment to write-block-size */
 int settings_line_len_calc(const char *name, size_t val_len);
 
-void settings_line_dup_check_cb(const char *name, void *val_read_cb_ctx,
+int settings_line_dup_check_cb(const char *name, void *val_read_cb_ctx,
 				off_t off, void *cb_arg);
 
-void settings_line_load_cb(const char *name, void *val_read_cb_ctx,
+int settings_line_load_cb(const char *name, void *val_read_cb_ctx,
 			   off_t off, void *cb_arg);
 
-typedef void (*line_load_cb)(const char *name, void *val_read_cb_ctx,
+typedef int (*line_load_cb)(const char *name, void *val_read_cb_ctx,
 			     off_t off, void *cb_arg);
+
+struct settings_line_load_arg {
+	const char             *subtree;
+	settings_load_direct_cb direct_cb;
+	void                   *param;
+};
 
 struct settings_line_read_value_cb_ctx {
 	void *read_cb_ctx;

--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -51,6 +51,9 @@ int settings_load_subtree(const char *subtree)
 {
 	struct settings_store *cs;
 	int rc;
+	const struct settings_load_arg arg = {
+		.subtree = subtree
+	};
 
 	/*
 	 * for every config store
@@ -60,7 +63,7 @@ int settings_load_subtree(const char *subtree)
 	 */
 	k_mutex_lock(&settings_lock, K_FOREVER);
 	SYS_SLIST_FOR_EACH_CONTAINER(&settings_load_srcs, cs, cs_next) {
-		cs->cs_itf->csi_load(cs, subtree, NULL, NULL);
+		cs->cs_itf->csi_load(cs, &arg);
 	}
 	rc = settings_commit_subtree(subtree);
 	k_mutex_unlock(&settings_lock);
@@ -74,6 +77,11 @@ int settings_load_subtree_direct(
 {
 	struct settings_store *cs;
 
+	const struct settings_load_arg arg = {
+		.subtree = subtree,
+		.cb = cb,
+		.param = param
+	};
 	/*
 	 * for every config store
 	 *    load config
@@ -82,7 +90,7 @@ int settings_load_subtree_direct(
 	 */
 	k_mutex_lock(&settings_lock, K_FOREVER);
 	SYS_SLIST_FOR_EACH_CONTAINER(&settings_load_srcs, cs, cs_next) {
-		cs->cs_itf->csi_load(cs, subtree, cb, param);
+		cs->cs_itf->csi_load(cs, &arg);
 	}
 	k_mutex_unlock(&settings_lock);
 	return 0;

--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -60,11 +60,32 @@ int settings_load_subtree(const char *subtree)
 	 */
 	k_mutex_lock(&settings_lock, K_FOREVER);
 	SYS_SLIST_FOR_EACH_CONTAINER(&settings_load_srcs, cs, cs_next) {
-		cs->cs_itf->csi_load(cs, subtree);
+		cs->cs_itf->csi_load(cs, subtree, NULL, NULL);
 	}
 	rc = settings_commit_subtree(subtree);
 	k_mutex_unlock(&settings_lock);
 	return rc;
+}
+
+int settings_load_subtree_direct(
+	const char             *subtree,
+	settings_load_direct_cb cb,
+	void                   *param)
+{
+	struct settings_store *cs;
+
+	/*
+	 * for every config store
+	 *    load config
+	 *    apply config
+	 *    commit all
+	 */
+	k_mutex_lock(&settings_lock, K_FOREVER);
+	SYS_SLIST_FOR_EACH_CONTAINER(&settings_load_srcs, cs, cs_next) {
+		cs->cs_itf->csi_load(cs, subtree, cb, param);
+	}
+	k_mutex_unlock(&settings_lock);
+	return 0;
 }
 
 /*


### PR DESCRIPTION
This commit allows loading data from settings permanent storage
directly to the given callback function.

Note that this commit expands settings API and it is still compatible with the previous version.
New function: settings_load_subtree_direct implemented and proven by unit testing.

The API to the backends is changed and it is not compatible with the old one (additional arguments to the load function). All currently available backends are updated.