### PR TITLE
west.yml: point civetweb at the zephyrproject-rtos GH fork

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -21,8 +21,6 @@ manifest:
   remotes:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
-    - name: civetweb
-      url-base: https://github.com/civetweb
 
   #
   # Please add items below based on alphabetical order
@@ -34,7 +32,6 @@ manifest:
       revision: d56f2dd3510e20fa8cf4aad442495c08a658113f
       path: tools/ci-tools
     - name: civetweb
-      remote: civetweb
       revision: 99129c5efc907ea613c4b73ccff07581feb58a7a
       path: modules/lib/civetweb
     - name: esp-idf


### PR DESCRIPTION
We don't want to point anything outside of the Zephyr GitHub organization. Let's point at the recently created zephyr fork instead (https://github.com/zephyrproject-rtos/civetweb).

Details on how this will be managed going forward, according to standard project policy (for the Antmicro folks especially):

https://docs.zephyrproject.org/latest/guides/modules.html
