### PR TITLE
doc: Add skeleton for 1.14.1 release notes

### DIFF
--- a/doc/releases/release-notes-1.14.rst
+++ b/doc/releases/release-notes-1.14.rst
@@ -2,6 +2,32 @@
 
 .. _zephyr_1.14:
 
+Zephyr Kernel 1.14.1
+####################
+
+This is an LTS maintenance release with fixes.
+
+Kernel
+######
+
+Architectures
+#############
+
+Boards
+######
+
+Drivers and Sensors
+###################
+
+Bluetooth
+#########
+
+ * Qualification ready host (including Mesh)
+ * Qualification ready controller
+
+Networking
+##########
+
 Zephyr Kernel 1.14.0
 ####################
 


### PR DESCRIPTION
Add a basic skeleton for the 1.14.1 release notes. Currently only
concrete items are for Bluetooth qualification.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>