### PR TITLE
cmake: Fixup shield overlay and conf file search locations

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -320,6 +320,15 @@ foreach(root ${BOARD_ROOT})
           )
         endif()
 
+        # search for shield/boards/shield/board.overlay file
+        if(EXISTS ${shield_dir}/${s_dir}/boards/${s}/${BOARD}.overlay)
+          # add shield/board overlay to the shield overlays list
+          list(APPEND
+            shield_dts_files
+            ${shield_dir}/${s_dir}/boards/${s}/${BOARD}.overlay
+          )
+        endif()
+
         # search for shield/shield.conf file
         if(EXISTS ${shield_dir}/${s_dir}/${s}.conf)
           # add shield.conf to the shield config list
@@ -335,6 +344,15 @@ foreach(root ${BOARD_ROOT})
           list(APPEND
             shield_conf_files
             ${shield_dir}/${s_dir}/boards/${BOARD}.conf
+          )
+        endif()
+
+        # search for shield/boards/shield/board.conf file
+        if(EXISTS ${shield_dir}/${s_dir}/boards/${s}/${BOARD}.conf)
+          # add HW specific board.conf to the shield config list
+          list(APPEND
+            shield_conf_files
+            ${shield_dir}/${s_dir}/boards/${s}/${BOARD}.conf
           )
         endif()
       else()

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -309,35 +309,35 @@ foreach(root ${BOARD_ROOT})
           shield_dts_fixups
           ${shield_dir}/${s}/dts_fixup.h
         )
+
+        # search for shield/boards/board.overlay file
+        if(EXISTS ${shield_dir}/${s}/boards/${BOARD}.overlay)
+          # add shield/board overlay to the shield overlays list
+          list(APPEND
+            shield_dts_files
+            ${shield_dir}/${s}/boards/${BOARD}.overlay
+          )
+        endif()
+
+        # search for shield/shield.conf file
+        if(EXISTS ${shield_dir}/${s}/${s}.conf)
+          # add shield.conf to the shield config list
+          list(APPEND
+            shield_conf_files
+            ${shield_dir}/${s}/${s}.conf
+          )
+        endif()
+
+        # search for shield/boards/board.conf file
+        if(EXISTS ${shield_dir}/${s}/boards/${BOARD}.conf)
+          # add HW specific board.conf to the shield config list
+          list(APPEND
+            shield_conf_files
+            ${shield_dir}/${s}/boards/${BOARD}.conf
+          )
+        endif()
       else()
         list(APPEND NOT_FOUND_SHIELD_LIST ${s})
-      endif()
-
-      # search for shield/boards/board.overlay file
-      if(EXISTS ${shield_dir}/${s}/boards/${BOARD}.overlay)
-        # add shield/board overlay to the shield overlays list
-        list(APPEND
-          shield_dts_files
-          ${shield_dir}/${s}/boards/${BOARD}.overlay
-        )
-      endif()
-
-      # search for shield/shield.conf file
-      if(EXISTS ${shield_dir}/${s}/${s}.conf)
-        # add shield.conf to the shield config list
-        list(APPEND
-          shield_conf_files
-          ${shield_dir}/${s}/${s}.conf
-        )
-      endif()
-
-      # search for shield/boards/board.conf file
-      if(EXISTS ${shield_dir}/${s}/boards/${BOARD}.conf)
-        # add HW specific board.conf to the shield config list
-        list(APPEND
-          shield_conf_files
-          ${shield_dir}/${s}/boards/${BOARD}.conf
-        )
       endif()
     endforeach()
   endif()

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -298,6 +298,7 @@ foreach(root ${BOARD_ROOT})
       list(FIND SHIELD_LIST ${s} _idx)
       if (NOT _idx EQUAL -1)
         list(GET shields_refs_list ${_idx} s_path)
+        get_filename_component(s_dir ${s_path} DIRECTORY)
 
         # if shield config flag is on, add shield overlay to the shield overlays
         # list and dts_fixup file to the shield fixup file
@@ -307,33 +308,33 @@ foreach(root ${BOARD_ROOT})
         )
         list(APPEND
           shield_dts_fixups
-          ${shield_dir}/${s}/dts_fixup.h
+          ${shield_dir}/${s_dir}/dts_fixup.h
         )
 
         # search for shield/boards/board.overlay file
-        if(EXISTS ${shield_dir}/${s}/boards/${BOARD}.overlay)
+        if(EXISTS ${shield_dir}/${s_dir}/boards/${BOARD}.overlay)
           # add shield/board overlay to the shield overlays list
           list(APPEND
             shield_dts_files
-            ${shield_dir}/${s}/boards/${BOARD}.overlay
+            ${shield_dir}/${s_dir}/boards/${BOARD}.overlay
           )
         endif()
 
         # search for shield/shield.conf file
-        if(EXISTS ${shield_dir}/${s}/${s}.conf)
+        if(EXISTS ${shield_dir}/${s_dir}/${s}.conf)
           # add shield.conf to the shield config list
           list(APPEND
             shield_conf_files
-            ${shield_dir}/${s}/${s}.conf
+            ${shield_dir}/${s_dir}/${s}.conf
           )
         endif()
 
         # search for shield/boards/board.conf file
-        if(EXISTS ${shield_dir}/${s}/boards/${BOARD}.conf)
+        if(EXISTS ${shield_dir}/${s_dir}/boards/${BOARD}.conf)
           # add HW specific board.conf to the shield config list
           list(APPEND
             shield_conf_files
-            ${shield_dir}/${s}/boards/${BOARD}.conf
+            ${shield_dir}/${s_dir}/boards/${BOARD}.conf
           )
         endif()
       else()


### PR DESCRIPTION
* Fix dir name when shield name doesn't match the dir name.  So for
  shield 'x_nucleo_iks01a3_shub' we will look in now for
  x_nucleo_iks01a3/boards/<BOARD>.{overlay,conf} instead of
  x_nucleo_iks01a3_shub/boards/<BOARD>.{overlay,conf}

* Add support to search for a board specific shield in
  <SHIELD DIR>/boards/<SHIELD>/<BOARD>.{overlay,conf}.  So we can
  support something like:

  x_nucleo_iks01a3/boards/x_nucleo_iks01a3_shub/stm32mp157c_dk2.overlay
  x_nucleo_iks01a3/boards/x_nucleo_iks01a3_shub/stm32mp157c_dk2.conf

Fixes #19078

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>