### PR TITLE
soc: nxp_kinetis: Rework flash configuration field

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -36,10 +36,6 @@
   #define _DATA_IN_ROM
 #endif
 
-#if !defined(SKIP_TO_KINETIS_FLASH_CONFIG)
-  #define SKIP_TO_KINETIS_FLASH_CONFIG
-#endif
-
 #if !defined(CONFIG_XIP) && (CONFIG_FLASH_SIZE == 0)
 #define ROM_ADDR RAM_ADDR
 #else
@@ -177,10 +173,11 @@ SECTIONS
 	KEEP(*(.openocd_dbg))
 	KEEP(*(".openocd_dbg.*"))
 
-	/* Kinetis has to write 16 bytes at 0x400 */
-	SKIP_TO_KINETIS_FLASH_CONFIG
+#ifdef CONFIG_KINETIS_FLASH_CONFIG
+	. = CONFIG_KINETIS_FLASH_CONFIG_OFFSET;
 	KEEP(*(.kinetis_flash_config))
 	KEEP(*(".kinetis_flash_config.*"))
+#endif
 
 	_vector_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)

--- a/soc/arm/nxp_kinetis/CMakeLists.txt
+++ b/soc/arm/nxp_kinetis/CMakeLists.txt
@@ -1,3 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_sources_ifdef(CONFIG_KINETIS_FLASH_CONFIG	flash_configuration.c)
+
 add_subdirectory(${SOC_SERIES})

--- a/soc/arm/nxp_kinetis/Kconfig
+++ b/soc/arm/nxp_kinetis/Kconfig
@@ -122,6 +122,39 @@ config KINETIS_FLASH_CONFIG_OFFSET
 	hex "Kinetis flash configuration field offset"
 	default 0x400
 
+config KINETIS_FLASH_CONFIG_FSEC
+	hex "Flash security byte (FSEC)"
+	range 0 0xff
+	default 0xfe
+	help
+	  Configures the reset value of the FSEC register, which includes
+	  backdoor key access, mass erase, factory access, and flash security
+	  options.
+
+config KINETIS_FLASH_CONFIG_FOPT
+	hex "Flash nonvolatile option byte (FOPT)"
+	range 0 0xff
+	default 0xff
+	help
+	  Configures the reset value of the FOPT register, which includes boot,
+	  NMI, and EzPort options.
+
+config KINETIS_FLASH_CONFIG_FEPROT
+	hex "EEPROM protection byte (FEPROT)"
+	range 0 0xff
+	default 0xff
+	help
+	  Configures the reset value of the FEPROT register for FlexNVM
+	  devices. For program flash only devices, this byte is reserved.
+
+config KINETIS_FLASH_CONFIG_FDPROT
+	hex "Data flash protection byte (FDPROT)"
+	range 0 0xff
+	default 0xff
+	help
+	  Configures the reset value of the FDPROT register for FlexNVM
+	  devices. For program flash only devices, this byte is reserved.
+
 endif # KINETIS_FLASH_CONFIG
 
 endif # SOC_FAMILY_KINETIS

--- a/soc/arm/nxp_kinetis/Kconfig
+++ b/soc/arm/nxp_kinetis/Kconfig
@@ -107,4 +107,21 @@ config MCG_FRDIV
 	  kHz.
 
 endif # HAS_MCG
+
+config KINETIS_FLASH_CONFIG
+	bool "Kinetis flash configuration field"
+	default y if XIP && !BOOTLOADER_MCUBOOT
+	help
+	  Include the 16-byte flash configuration field that stores default
+	  protection settings (loaded on reset) and security information that
+	  allows the MCU to restrict access to the FTFx module.
+
+if KINETIS_FLASH_CONFIG
+
+config KINETIS_FLASH_CONFIG_OFFSET
+	hex "Kinetis flash configuration field offset"
+	default 0x400
+
+endif # KINETIS_FLASH_CONFIG
+
 endif # SOC_FAMILY_KINETIS

--- a/soc/arm/nxp_kinetis/flash_configuration.c
+++ b/soc/arm/nxp_kinetis/flash_configuration.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <linker/sections.h>
+
+u8_t __kinetis_flash_config_section __kinetis_flash_config[] = {
+	/* Backdoor Comparison Key (unused) */
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+
+	/* Program flash protection; 1 bit/region - 0=protected, 1=unprotected
+	 */
+	0xFF, 0xFF, 0xFF, 0xFF,
+
+	/* Flash security register (FSEC) enables/disables backdoor key access,
+	 * mass erase, factory access, and flash security
+	 */
+	CONFIG_KINETIS_FLASH_CONFIG_FSEC,
+
+	/* Flash nonvolatile option register (FOPT) enables/disables NMI,
+	 * EzPort, and boot options
+	 */
+	CONFIG_KINETIS_FLASH_CONFIG_FOPT,
+
+	/* EEPROM protection register (FEPROT) for FlexNVM devices */
+	CONFIG_KINETIS_FLASH_CONFIG_FEPROT,
+
+	/* Data flash protection register (FDPROT) for FlexNVM devices */
+	CONFIG_KINETIS_FLASH_CONFIG_FDPROT,
+};

--- a/soc/arm/nxp_kinetis/k6x/linker.ld
+++ b/soc/arm/nxp_kinetis/k6x/linker.ld
@@ -11,21 +11,4 @@
  * This is the linker script for both standard images and XIP images.
  */
 
-#include <autoconf.h>
-
-/*
- * K64F Flash configuration fields
- * These are 16 bytes, which must be loaded to address 0x400, and include
- * default protection and security settings.
- * They are loaded at reset to various Flash Memory module (FTFE) registers.
- */
-
-/*
- * No need to account for this when running a RAM-only image since that
- * security feature resides in ROM.
- */
-#if defined(CONFIG_XIP)
-	#define SKIP_TO_KINETIS_FLASH_CONFIG . = 0x400;
-#endif
-
 #include <arch/arm/cortex_m/scripts/linker.ld>

--- a/soc/arm/nxp_kinetis/k6x/soc.c
+++ b/soc/arm/nxp_kinetis/k6x/soc.c
@@ -18,7 +18,6 @@
 #include <init.h>
 #include <soc.h>
 #include <drivers/uart.h>
-#include <linker/sections.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
 #include <arch/cpu.h>
@@ -33,37 +32,6 @@
 #define ER32KSEL_LPO1KHZ	(3)
 
 #define TIMESRC_OSCERCLK        (2)
-
-/*
- * K64F Flash configuration fields
- * These 16 bytes, which must be loaded to address 0x400, include default
- * protection and security settings.
- * They are loaded at reset to various Flash Memory module (FTFE) registers.
- *
- * The structure is:
- * -Backdoor Comparison Key for unsecuring the MCU - 8 bytes
- * -Program flash protection bytes, 4 bytes, written to FPROT0-3
- * -Flash security byte, 1 byte, written to FSEC
- * -Flash nonvolatile option byte, 1 byte, written to FOPT
- * -Reserved, 1 byte, (Data flash protection byte for FlexNVM)
- * -Reserved, 1 byte, (EEPROM protection byte for FlexNVM)
- *
- */
-u8_t __kinetis_flash_config_section __kinetis_flash_config[] = {
-	/* Backdoor Comparison Key (unused) */
-	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-	/* Program flash protection; 1 bit/region - 0=protected, 1=unprotected
-	 */
-	0xFF, 0xFF, 0xFF, 0xFF,
-	/*
-	 * Flash security: Backdoor key disabled, Mass erase enabled,
-	 *                 Factory access enabled, MCU is unsecure
-	 */
-	0xFE,
-	/* Flash nonvolatile option: NMI enabled, EzPort enabled, Normal boot */
-	0xFF,
-	/* Reserved for FlexNVM feature (unsupported by this MCU) */
-	0xFF, 0xFF};
 
 static const osc_config_t oscConfig = {
 	.freq = CONFIG_OSC_XTAL0_FREQ,

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.series
@@ -15,6 +15,13 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 106
 
+if KINETIS_FLASH_CONFIG
+
+config KINETIS_FLASH_CONFIG_FOPT
+	default 0x3f
+
+endif # KINETIS_FLASH_CONFIG
+
 if ADC
 
 config ADC_MCUX_ADC16

--- a/soc/arm/nxp_kinetis/k8x/linker.ld
+++ b/soc/arm/nxp_kinetis/k8x/linker.ld
@@ -11,22 +11,4 @@
  * This is the linker script for both standard images and XIP images.
  */
 
-#include <autoconf.h>
-
-/*
- * K8x Flash configuration fields
- * These are 16 bytes, which must be loaded to flash at offset 0x400, and
- * include default protection and security settings.
- * They are loaded at reset to various Flash Memory module (FTFA) registers.
- */
-
-/*
- * No need to account for this when running a RAM-only image since that
- * security feature resides in ROM. There is also no need to account for this
- * when building an image to be chainloaded by MCUboot.
- */
-#if defined(CONFIG_XIP) && !defined(CONFIG_BOOTLOADER_MCUBOOT)
-	#define SKIP_TO_KINETIS_FLASH_CONFIG . = 0x400;
-#endif
-
 #include <arch/arm/cortex_m/scripts/linker.ld>

--- a/soc/arm/nxp_kinetis/k8x/soc.c
+++ b/soc/arm/nxp_kinetis/k8x/soc.c
@@ -29,28 +29,6 @@
 #define RUNM_VLPR		(2)
 #define RUNM_HSRUN		(3)
 
-/*
- * K8x flash configuration fields
- * These 16 bytes, which must be loaded into flash memory at offset 0x400,
- * include default protection and security settings.
- * They are loaded at reset to various Flash Memory module (FTFA) registers.
- */
-u8_t __kinetis_flash_config_section __kinetis_flash_config[] = {
-	/* Backdoor Comparison Key (unused) */
-	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-	/* Program flash protection */
-	0xFF, 0xFF, 0xFF, 0xFF,
-	/*
-	 * Flash security: Backdoor key disabled, Mass erase enabled,
-	 *                 Factory access enabled, MCU is unsecure
-	 */
-	0xFE,
-	/* Flash nonvolatile option: NMI enabled, EzPort enabled, Normal boot */
-	0x3F,
-	/* Reserved for FlexNVM feature (unsupported by this MCU) */
-	0xFF, 0xFF
-};
-
 static const osc_config_t osc_config = {
 	.freq = CONFIG_OSC_XTAL0_FREQ,
 	.capLoad = 0,

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.series
@@ -15,6 +15,13 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 91
 
+if KINETIS_FLASH_CONFIG
+
+config KINETIS_FLASH_CONFIG_FOPT
+	default 0x7d
+
+endif # KINETIS_FLASH_CONFIG
+
 if CLOCK_CONTROL
 
 config CLOCK_CONTROL_MCUX_SCG

--- a/soc/arm/nxp_kinetis/ke1xf/linker.ld
+++ b/soc/arm/nxp_kinetis/ke1xf/linker.ld
@@ -11,21 +11,4 @@
  * This is the linker script for both standard images and XIP images.
  */
 
-#include <autoconf.h>
-
-/*
- * KE1xF Flash configuration fields
- * These are 16 bytes, which must be loaded to address 0x400, and include
- * default protection and security settings.
- * They are loaded at reset to various Flash Memory module (FTFE) registers.
- */
-
-/*
- * No need to account for this when running a RAM-only image since that
- * security feature resides in ROM.
- */
-#if defined(CONFIG_XIP)
-	#define SKIP_TO_KINETIS_FLASH_CONFIG . = 0x400;
-#endif
-
 #include <arch/arm/cortex_m/scripts/linker.ld>

--- a/soc/arm/nxp_kinetis/ke1xf/soc.c
+++ b/soc/arm/nxp_kinetis/ke1xf/soc.c
@@ -15,36 +15,6 @@
 #include <fsl_cache.h>
 #include <cortex_m/exc.h>
 
-/*
- * KE1xF flash configuration fields
- * These 16 bytes, which must be loaded to address 0x400, include default
- * protection, boot options and security settings.
- * They are loaded at reset to various Flash Memory module (FTFE) registers.
- */
-u8_t __kinetis_flash_config_section __kinetis_flash_config[] = {
-	/* Backdoor Comparison Key (unused) */
-	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-	/* Program flash protection */
-	0xFF, 0xFF, 0xFF, 0xFF,
-	/*
-	 * Flash security: Backdoor key disabled, Mass erase enabled,
-	 *                 Factory access enabled, MCU is unsecure
-	 */
-	0xFE,
-	/*
-	 * Flash nonvolatile option: Boot from ROM with BOOTCFG0/NMI
-	 *                           pin low, boot from flash with
-	 *                           BOOTCFG0/NMI pin high, RESET_b
-	 *                           pin dedicated, NMI enabled,
-	 *                           normal boot
-	 */
-	0x7d,
-	/* EEPROM protection */
-	0xFF,
-	/* Data flash protection */
-	0xFF,
-};
-
 #define ASSERT_WITHIN_RANGE(val, min, max, str) \
 	BUILD_ASSERT_MSG(val >= min && val <= max, str)
 

--- a/soc/arm/nxp_kinetis/kl2x/linker.ld
+++ b/soc/arm/nxp_kinetis/kl2x/linker.ld
@@ -11,21 +11,4 @@
  * This is the linker script for both standard images and XIP images.
  */
 
-#include <autoconf.h>
-
-/*
- * KL25Z Flash configuration fields
- * These are 16 bytes, which must be loaded to address 0x400, and include
- * default protection and security settings.
- * They are loaded at reset to various Flash Memory module (FTFE) registers.
- */
-
-/*
- * No need to account for this when running a RAM-only image since that
- * security feature resides in ROM.
- */
-#if defined(CONFIG_XIP)
-	#define SKIP_TO_KINETIS_FLASH_CONFIG . = 0x400;
-#endif
-
 #include <arch/arm/cortex_m/scripts/linker.ld>

--- a/soc/arm/nxp_kinetis/kl2x/soc.c
+++ b/soc/arm/nxp_kinetis/kl2x/soc.c
@@ -8,7 +8,6 @@
 #include <device.h>
 #include <init.h>
 #include <soc.h>
-#include <linker/sections.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
 #include <arch/cpu.h>
@@ -18,37 +17,6 @@
 /*******************************************************************************
  * Variables
  ******************************************************************************/
-
-/*
- * KL25Z Flash configuration fields
- * These 16 bytes, which must be loaded to address 0x400, include default
- * protection and security settings.
- * They are loaded at reset to various Flash Memory module (FTFE) registers.
- *
- * The structure is:
- * -Backdoor Comparison Key for unsecuring the MCU - 8 bytes
- * -Program flash protection bytes, 4 bytes, written to FPROT0-3
- * -Flash security byte, 1 byte, written to FSEC
- * -Flash nonvolatile option byte, 1 byte, written to FOPT
- * -Reserved, 1 byte, (Data flash protection byte for FlexNVM)
- * -Reserved, 1 byte, (EEPROM protection byte for FlexNVM)
- *
- */
-u8_t __kinetis_flash_config_section __kinetis_flash_config[] = {
-	/* Backdoor Comparison Key (unused) */
-	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-	/* Program flash protection; 1 bit/region - 0=protected, 1=unprotected
-	 */
-	0xFF, 0xFF, 0xFF, 0xFF,
-	/*
-	 * Flash security: Backdoor key disabled, Mass erase enabled,
-	 *                 Factory access enabled, MCU is unsecure
-	 */
-	0xFE,
-	/* Flash nonvolatile option: NMI enabled, EzPort enabled, Normal boot */
-	0xFF,
-	/* Reserved for FlexNVM feature (unsupported by this MCU) */
-	0xFF, 0xFF};
 
 static ALWAYS_INLINE void clkInit(void)
 {

--- a/soc/arm/nxp_kinetis/kwx/linker.ld
+++ b/soc/arm/nxp_kinetis/kwx/linker.ld
@@ -11,21 +11,4 @@
  * This is the linker script for both standard images and XIP images.
  */
 
-#include <autoconf.h>
-
-/*
- * KW41Z Flash configuration fields
- * These are 16 bytes, which must be loaded to address 0x400, and include
- * default protection and security settings.
- * They are loaded at reset to various Flash Memory module (FTFE) registers.
- */
-
-/*
- * No need to account for this when running a RAM-only image since that
- * security feature resides in ROM.
- */
-#if defined(CONFIG_XIP)
-	#define SKIP_TO_KINETIS_FLASH_CONFIG . = 0x400;
-#endif
-
 #include <arch/arm/cortex_m/scripts/linker.ld>

--- a/soc/arm/nxp_kinetis/kwx/soc_kw2xd.c
+++ b/soc/arm/nxp_kinetis/kwx/soc_kw2xd.c
@@ -11,7 +11,6 @@
 #include <init.h>
 #include <soc.h>
 #include <drivers/uart.h>
-#include <linker/sections.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
 #include <arch/cpu.h>
@@ -26,37 +25,6 @@
 #define ER32KSEL_LPO1KHZ	(3)
 
 #define TIMESRC_OSCERCLK        (2)
-
-/*
- * KW2xD Flash configuration fields
- * These 16 bytes, which must be loaded to address 0x400, include default
- * protection and security settings.
- * They are loaded at reset to various Flash Memory module (FTFE) registers.
- *
- * The structure is:
- * -Backdoor Comparison Key for unsecuring the MCU - 8 bytes
- * -Program flash protection bytes, 4 bytes, written to FPROT0-3
- * -Flash security byte, 1 byte, written to FSEC
- * -Flash nonvolatile option byte, 1 byte, written to FOPT
- * -Reserved, 1 byte, (Data flash protection byte for FlexNVM)
- * -Reserved, 1 byte, (EEPROM protection byte for FlexNVM)
- *
- */
-uint8_t __kinetis_flash_config_section __kinetis_flash_config[] = {
-	/* Backdoor Comparison Key (unused) */
-	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-	/* Program flash protection; 1 bit/region - 0=protected, 1=unprotected
-	 */
-	0xFF, 0xFF, 0xFF, 0xFF,
-	/*
-	 * Flash security: Backdoor key disabled, Mass erase enabled,
-	 *                 Factory access enabled, MCU is unsecure
-	 */
-	0xFE,
-	/* Flash nonvolatile option: NMI enabled, EzPort enabled, Normal boot */
-	0xFF,
-	/* Reserved for FlexNVM feature (unsupported by this MCU) */
-	0xFF, 0xFF};
 
 static const osc_config_t oscConfig = {
 	.freq = CONFIG_OSC_XTAL0_FREQ,

--- a/soc/arm/nxp_kinetis/kwx/soc_kw4xz.c
+++ b/soc/arm/nxp_kinetis/kwx/soc_kw4xz.c
@@ -9,7 +9,6 @@
 #include <init.h>
 #include <soc.h>
 #include <drivers/uart.h>
-#include <linker/sections.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
 #include <arch/cpu.h>
@@ -21,37 +20,6 @@
 #define LPUART0SRC_OSCERCLK	(1)
 
 #define CLKDIV1_DIVBY2		(1)
-
-/*
- * KW41Z Flash configuration fields
- * These 16 bytes, which must be loaded to address 0x400, include default
- * protection and security settings.
- * They are loaded at reset to various Flash Memory module (FTFE) registers.
- *
- * The structure is:
- * -Backdoor Comparison Key for unsecuring the MCU - 8 bytes
- * -Program flash protection bytes, 4 bytes, written to FPROT0-3
- * -Flash security byte, 1 byte, written to FSEC
- * -Flash nonvolatile option byte, 1 byte, written to FOPT
- * -Reserved, 1 byte, (Data flash protection byte for FlexNVM)
- * -Reserved, 1 byte, (EEPROM protection byte for FlexNVM)
- *
- */
-u8_t __kinetis_flash_config_section __kinetis_flash_config[] = {
-	/* Backdoor Comparison Key (unused) */
-	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-	/* Program flash protection; 1 bit/region - 0=protected, 1=unprotected
-	 */
-	0xFF, 0xFF, 0xFF, 0xFF,
-	/*
-	 * Flash security: Backdoor key disabled, Mass erase enabled,
-	 *                 Factory access enabled, MCU is unsecure
-	 */
-	0xFE,
-	/* Flash nonvolatile option: NMI enabled, EzPort enabled, Normal boot */
-	0xFF,
-	/* Reserved for FlexNVM feature (unsupported by this MCU) */
-	0xFF, 0xFF};
 
 static const osc_config_t oscConfig = {
 	.freq = CONFIG_OSC_XTAL0_FREQ,


### PR DESCRIPTION
Extends a flash size optimization found by @fbrozovic in https://github.com/zephyrproject-rtos/zephyr/pull/17118#discussion_r298723026 to all Kinetis SoCs. While we're here, refactor the Kinetis flash configuration field to reduce repetitive code.