### PR TITLE
Bluetooth: controller: Fix legacy for TICKER_COMPATABILITY_MODE

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -652,7 +652,7 @@ config BT_MAYFLY_YIELD_AFTER_CALL
 
 config BT_TICKER_COMPATIBILITY_MODE
 	bool "Ticker compatibility mode"
-	default y if SOC_SERIES_NRF51X
+	default y if SOC_SERIES_NRF51X || BT_LL_SW_LEGACY
 	help
 	  This option enables legacy ticker scheduling which defers overlapping
 	  ticker node timeouts and thereby prevents ticker interrupts during


### PR DESCRIPTION
When not using ticker compatibility mode in legacy
controller, ticker job should not be disabled inside radio
events.

Ticker compatibility mode was introduced in
commit 3a9173afe151 ("bluetooth: controller: Revised ticker
for improved conflict resolution").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>