### PR TITLE
Bluetooth: controller: split: Fix TICKER_COMPATABILITY_MODE

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -265,6 +265,7 @@ int lll_done(void *param)
 		}
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) &&
+		    IS_ENABLED(CONFIG_BT_TICKER_COMPATIBILITY_MODE) &&
 		    (CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)) {
 			mayfly_enable(TICKER_USER_ID_LLL,
 				      TICKER_USER_ID_ULL_LOW,
@@ -606,7 +607,8 @@ static void preempt(void *param)
 }
 #else /* CONFIG_BT_CTLR_LOW_LAT */
 
-#if (CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
+#if defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE) && \
+	(CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
 static void ticker_op_job_disable(u32_t status, void *op_context)
 {
 	ARG_UNUSED(status);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1522,10 +1522,13 @@ static void conn_cleanup(struct ll_conn *conn)
 		ll_rx_put(rx->hdr.link, rx);
 	}
 
+#if defined(CONFIG_BT_TICKER_COMPATIBILITY_MODE) && \
+	(CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
 	/* Enable Ticker Job, we are in a radio event which disabled it if
 	 * worker0 and job0 priority where same.
 	 */
 	mayfly_enable(TICKER_USER_ID_ULL_HIGH, TICKER_USER_ID_ULL_LOW, 1);
+#endif
 
 	/* Stop Master or Slave role ticker */
 	ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,
@@ -2020,6 +2023,7 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, u16_t lazy,
 			conn->supervision_expire = 0U;
 		}
 
+#if (CONFIG_BT_CTLR_ULL_HIGH_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
 		/* disable ticker job, in order to chain stop and start
 		 * to avoid RTC being stopped if no tickers active.
 		 */
@@ -2027,6 +2031,7 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, u16_t lazy,
 						       TICKER_USER_ID_ULL_LOW);
 		mayfly_enable(TICKER_USER_ID_ULL_HIGH, TICKER_USER_ID_ULL_LOW,
 			      0);
+#endif
 
 		/* start slave/master with new timings */
 		ticker_id_conn = TICKER_ID_CONN_BASE + ll_conn_handle_get(conn);
@@ -2059,11 +2064,13 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, u16_t lazy,
 		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 			  (ticker_status == TICKER_STATUS_BUSY));
 
+#if (CONFIG_BT_CTLR_ULL_HIGH_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
 		/* enable ticker job, if disabled in this function */
 		if (mayfly_was_enabled) {
 			mayfly_enable(TICKER_USER_ID_ULL_HIGH,
 				      TICKER_USER_ID_ULL_LOW, 1);
 		}
+#endif
 
 		return 0;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -538,10 +538,10 @@ void ull_master_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	conn_offset_us -= EVENT_OVERHEAD_START_US;
 	conn_offset_us -= ftr->us_radio_rdy;
 
+#if (CONFIG_BT_CTLR_ULL_HIGH_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
 	/* disable ticker job, in order to chain stop and start to avoid RTC
 	 * being stopped if no tickers active.
 	 */
-#if (CONFIG_BT_CTLR_ULL_HIGH_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
 	mayfly_was_enabled = mayfly_is_enabled(TICKER_USER_ID_ULL_HIGH,
 					       TICKER_USER_ID_ULL_LOW);
 	mayfly_enable(TICKER_USER_ID_ULL_HIGH, TICKER_USER_ID_ULL_LOW, 0);

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -236,10 +236,10 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	conn_offset_us -= EVENT_JITTER_US;
 	conn_offset_us -= ftr->us_radio_rdy;
 
+#if (CONFIG_BT_CTLR_ULL_HIGH_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
 	/* disable ticker job, in order to chain stop and start to avoid RTC
 	 * being stopped if no tickers active.
 	 */
-#if (CONFIG_BT_CTLR_ULL_HIGH_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
 	mayfly_was_enabled = mayfly_is_enabled(TICKER_USER_ID_ULL_HIGH,
 					       TICKER_USER_ID_ULL_LOW);
 	mayfly_enable(TICKER_USER_ID_ULL_HIGH, TICKER_USER_ID_ULL_LOW, 0);


### PR DESCRIPTION
When not using ticker compatibility mode in split controller,
ticker job should not be disabled inside radio events.

Ticker compatibility mode was introduced in
commit 3a9173afe151 ("bluetooth: controller: Revised ticker
for improved conflict resolution").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>