### PR TITLE
boards: Clean up references to env variable PROJECT_SOURCE_DIR

### DIFF
--- a/boards/arm/cy8ckit_062_wifi_bt_m0/CMakeLists.txt
+++ b/boards/arm/cy8ckit_062_wifi_bt_m0/CMakeLists.txt
@@ -5,5 +5,5 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources_if_kconfig(pinmux.c)

--- a/boards/arm/cy8ckit_062_wifi_bt_m4/CMakeLists.txt
+++ b/boards/arm/cy8ckit_062_wifi_bt_m4/CMakeLists.txt
@@ -5,5 +5,5 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources_if_kconfig(pinmux.c)

--- a/boards/arm/efm32pg_stk3402a/CMakeLists.txt
+++ b/boards/arm/efm32pg_stk3402a/CMakeLists.txt
@@ -3,5 +3,5 @@
 if(CONFIG_UART_GECKO)
   zephyr_library()
   zephyr_library_sources(board.c)
-  zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/efr32_slwstk6061a/CMakeLists.txt
+++ b/boards/arm/efr32_slwstk6061a/CMakeLists.txt
@@ -3,5 +3,5 @@
 if(CONFIG_UART_GECKO)
   zephyr_library()
   zephyr_library_sources(board.c)
-  zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/mps2_an521/CMakeLists.txt
+++ b/boards/arm/mps2_an521/CMakeLists.txt
@@ -6,4 +6,4 @@
 
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32f769i_disco/CMakeLists.txt
+++ b/boards/arm/stm32f769i_disco/CMakeLists.txt
@@ -3,5 +3,5 @@
 if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/stm32h747i_disco/CMakeLists.txt
+++ b/boards/arm/stm32h747i_disco/CMakeLists.txt
@@ -3,5 +3,5 @@
 if(CONFIG_PINMUX)
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/udoo_neo_full_m4/CMakeLists.txt
+++ b/boards/arm/udoo_neo_full_m4/CMakeLists.txt
@@ -5,5 +5,5 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/v2m_musca/CMakeLists.txt
+++ b/boards/arm/v2m_musca/CMakeLists.txt
@@ -6,4 +6,4 @@
 
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/v2m_musca_b1/CMakeLists.txt
+++ b/boards/arm/v2m_musca_b1/CMakeLists.txt
@@ -6,4 +6,4 @@
 
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/riscv/litex_vexriscv/CMakeLists.txt
+++ b/boards/riscv/litex_vexriscv/CMakeLists.txt
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/riscv/m2gl025_miv/CMakeLists.txt
+++ b/boards/riscv/m2gl025_miv/CMakeLists.txt
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)


### PR DESCRIPTION
As recommended in cmake/app/boilerplate.cmake, ZEPHYR_BASE should
be preferred to PROJECT_SOURCE_DIR.
Do the change for all boards still referring to PROJECT_SOURCE_DIR.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>