### PR TITLE
Kconfig: Correct COVERAGE help msg

### DIFF
--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -45,7 +45,8 @@ config COVERAGE
 	help
 	  This option will build your application with the -coverage option
 	  which will generate data that can be used to create coverage reports.
-	  Currently this is fully supported only on the native POSIX port.
+	  For more information see
+	  https://docs.zephyrproject.org/latest/guides/coverage.html
 
 if COVERAGE
 config COVERAGE_GCOV


### PR DESCRIPTION
CONFIG_COVERAGE is also supported in some real targets now
as described in the doc
https://docs.zephyrproject.org/latest/guides/coverage.html

So let's remove that missleading sentence

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>