### PR TITLE
arch: riscv: Add simple workaround to boot multicore system

### DIFF
--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -31,6 +31,16 @@ SECTION_FUNC(reset, __reset)
  * the C domain
  */
 SECTION_FUNC(TEXT, __initialize)
+	/*
+	 * This will boot master core, just halt other cores.
+	 * Note: need to be updated for complete SMP support
+	 */
+	csrr a0, mhartid
+	beqz a0, boot_master_core
+	wfi
+
+boot_master_core:
+
 #ifdef CONFIG_INIT_STACKS
 	/* Pre-populate all bytes in _interrupt_stack with 0xAA */
 	la t0, _interrupt_stack

--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -37,7 +37,10 @@ SECTION_FUNC(TEXT, __initialize)
 	 */
 	csrr a0, mhartid
 	beqz a0, boot_master_core
+
+loop_slave_core:
 	wfi
+	j loop_slave_core
 
 boot_master_core:
 


### PR DESCRIPTION
Just boot master core, halt others

I'm trying to port zephyr to a dual core rv64gc chip, Kendryte K210.
I think these code may useful to others before complete SMP support available 

Signed-off-by: Huang Qi <757509347@qq.com>