### PR TITLE
boards/shields: Enable shields samples on stm32mp157c_dk2

### DIFF
--- a/boards/shields/x_nucleo_iks01a2/boards/stm32mp157c_dk2.overlay
+++ b/boards/shields/x_nucleo_iks01a2/boards/stm32mp157c_dk2.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * On stm32mp157c_dk2 pin A3 is not mapped on a GPIO pin.
+ * Delete this optional property for shield/board compatibility
+ */
+
+&arduino_i2c {
+	lsm303agr-magn@1e {
+		/delete-property/ irq-gpios;	/* A3 */
+	};
+
+	lsm303agr-accel@19 {
+		/delete-property/ irq-gpios;	/* A3 */
+	};
+};

--- a/boards/shields/x_nucleo_iks01a3/boards/x_nucleo_iks01a3/stm32mp157c_dk2.overlay
+++ b/boards/shields/x_nucleo_iks01a3/boards/x_nucleo_iks01a3/stm32mp157c_dk2.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * On stm32mp157c_dk2 pin A3 is not mapped on a GPIO pin.
+ * Delete this optional property for shield/board compatibility
+ */
+
+&arduino_i2c {
+	lis2dw12@19 {
+		/delete-property/ irq-gpios;	/* A3 */
+	};
+};

--- a/boards/shields/x_nucleo_iks01a3/boards/x_nucleo_iks01a3_shub/stm32mp157c_dk2.overlay
+++ b/boards/shields/x_nucleo_iks01a3/boards/x_nucleo_iks01a3_shub/stm32mp157c_dk2.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * On stm32mp157c_dk2 pin A3 is not mapped on a GPIO pin.
+ * Delete this optional property for shield/board compatibility
+ */
+
+&arduino_i2c {
+	lis2dw12@19 {
+		/delete-property/ irq-gpios;	/* A3 */
+	};
+};


### PR DESCRIPTION
stm32mp157c_dk2 Arduino header lack A2 and A3 pins which
are assigned to non GPIO pins.
Remove optional shields properties that are using one of these
pins by providing board overlays to the impacted shields.

Fixes #19079


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>