### PR TITLE
Add support of arduino connector on nucleo_wb55rg board

### DIFF
--- a/boards/arm/nucleo_wb55rg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_wb55rg/arduino_r3_connector.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioc 0 0>,	/* A0 */
+			   <1 0 &gpioc 1 0>,	/* A1 */
+			   <2 0 &gpioa 1 0>,	/* A2 */
+			   <3 0 &gpioa 0 0>,	/* A3 */
+			   <4 0 &gpioc 3 0>,	/* A4 */
+			   <5 0 &gpioc 2 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioc 6 0>,	/* D2 */
+			   <9 0 &gpioa 10 0>,	/* D3 */
+			   <10 0 &gpioc 10 0>,	/* D4 */
+			   <11 0 &gpioa 15 0>,	/* D5 */
+			   <12 0 &gpioa 8 0>,	/* D6 */
+			   <13 0 &gpioc 13 0>,	/* D7 */
+			   <14 0 &gpioc 12 0>,	/* D8 */
+			   <15 0 &gpioa 9 0>,	/* D9 */
+			   <16 0 &gpioa 4 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};
+arduino_serial: &lpuart1 {};

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/wb/stm32wb55Xg.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32WB55RG-NUCLEO board";
@@ -63,7 +64,7 @@
 	status = "okay";
 };
 
-arduino_i2c: &i2c1 {
+&i2c1 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -77,7 +78,7 @@ arduino_i2c: &i2c1 {
 	status = "okay";
 };
 
-arduino_spi: &spi1 {
+&spi1 {
 	status = "okay";
 };
 
@@ -88,7 +89,7 @@ arduino_spi: &spi1 {
 	};
 };
 
-arduino_serial: &lpuart1 {
+&lpuart1 {
 	current-speed = <115200>;
 	status = "okay";
 };

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.yaml
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.yaml
@@ -10,10 +10,12 @@ ram: 96
 flash: 1024
 supported:
   - gpio
-  - arduino_i2c
   - i2c
   - counter
   - spi
   - pwm
   - adc
   - watchdog
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_spi


### PR DESCRIPTION
Support of Arduino connector added on nucleo_wb55rg board.  Thanks in advance for you review and comments.