### PR TITLE
cmake: compiler: clang: target.cmake: Add arm target

### DIFF
--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -18,6 +18,7 @@ endif()
 find_program(CMAKE_C_COMPILER   clang   ${find_program_clang_args})
 find_program(CMAKE_CXX_COMPILER clang++ ${find_program_clang_args})
 
+
 if(NOT "${ARCH}" STREQUAL "posix")
 
   foreach(file_name include/stddef.h include-fixed/limits.h)
@@ -54,6 +55,37 @@ if(NOT "${ARCH}" STREQUAL "posix")
   set(CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags} -Wl,--unresolved-symbols=ignore-in-object-files)
   string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 
+endif()
+
+include(${ZEPHYR_BASE}/cmake/gcc-m-cpu.cmake)
+
+if("${ARCH}" STREQUAL "arm")
+  list(APPEND TOOLCHAIN_C_FLAGS
+    -mthumb
+    -mcpu=${GCC_M_CPU}
+    )
+  list(APPEND TOOLCHAIN_LD_FLAGS
+    -mthumb
+    -mcpu=${GCC_M_CPU}
+    )
+
+  include(${ZEPHYR_BASE}/cmake/fpu-for-gcc-m-cpu.cmake)
+
+  if(CONFIG_FLOAT)
+    list(APPEND TOOLCHAIN_C_FLAGS -mfpu=${FPU_FOR_${GCC_M_CPU}})
+    list(APPEND TOOLCHAIN_LD_FLAGS -mfpu=${FPU_FOR_${GCC_M_CPU}})
+    if    (CONFIG_FP_SOFTABI)
+      list(APPEND TOOLCHAIN_C_FLAGS -mfloat-abi=softfp)
+      list(APPEND TOOLCHAIN_LD_FLAGS -mfloat-abi=softfp)
+    elseif(CONFIG_FP_HARDABI)
+      list(APPEND TOOLCHAIN_C_FLAGS -mfloat-abi=hard)
+      list(APPEND TOOLCHAIN_LD_FLAGS -mfloat-abi=hard)
+    endif()
+  endif()
+elseif("${ARCH}" STREQUAL "arc")
+  list(APPEND TOOLCHAIN_C_FLAGS
+    -mcpu=${GCC_M_CPU}
+    )
 endif()
 
 # Load toolchain_cc-family macros


### PR DESCRIPTION
Adds `-mcpu and -mfloat-abi` to compiler flags if you try to compile for
the ARM architecture using llvm.

Signed-off-by: Sigvart Hovland <sigvart.m@gmail.com>