### PR TITLE
tests/subsys/settings/fcb: Fix ifdef in ztest_test_suite

### DIFF
--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -382,12 +382,14 @@ void test_config_save_fcb_unaligned(void);
 
 void test_main(void)
 {
-	ztest_test_suite(test_config_fcb,
 #ifdef CONFIG_SETTINGS_USE_BASE64
+	ztest_test_suite(test_config_fcb_base64,
 			 ztest_unit_test(test_settings_encode),
 			 ztest_unit_test(test_setting_raw_read),
-			 ztest_unit_test(test_setting_val_read),
+			 ztest_unit_test(test_setting_val_read));
+	ztest_run_test_suite(test_config_fcb_base64);
 #endif
+	ztest_test_suite(test_config_fcb,
 			 /* Config tests */
 			 ztest_unit_test(config_empty_lookups),
 			 ztest_unit_test(test_config_insert),


### PR DESCRIPTION
We don't allow an ifdef in ztest_test_suite because its a macro.  We
usually handle this by defining multiple blocks and ifdef around them.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>