### PR TITLE
bluetooth: controller: RX PDU meta data support in LLL

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -542,6 +542,10 @@ config BT_CTLR_CONN_META
 	  Enables vendor specific per-connection meta data as part of the
 	  LLL connection object.
 
+config BT_CTLR_RX_PDU_META
+	prompt "Enable RX pdu meta data"
+	bool
+
 endif # BT_LL_SW_SPLIT
 
 config BT_CTLR_RADIO_ENABLE_FAST

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -3,6 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#if defined(CONFIG_BT_CTLR_RX_PDU_META)
+#include "lll_meta.h"
+#endif /* CONFIG_BT_CTLR_RX_PDU_META */
 
 #define TICKER_INSTANCE_ID_CTLR 0
 #define TICKER_USER_ID_LLL      MAYFLY_CALL_ID_0
@@ -210,7 +213,12 @@ struct node_rx_hdr {
 	enum node_rx_type   type;
 	u16_t               handle;
 
-	struct node_rx_ftr  rx_ftr;
+	union {
+#if defined(CONFIG_BT_CTLR_RX_PDU_META)
+		lll_rx_pdu_meta_t  rx_pdu_meta;
+#endif /* CONFIG_BT_CTLR_RX_PDU_META */
+		struct node_rx_ftr rx_ftr;
+	};
 };
 
 struct node_rx_pdu {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_meta.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_meta.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if defined(CONFIG_BT_CTLR_RX_PDU_META)
+/*
+ * typedef struct { } lll_rx_pdu_meta_t;
+ */
+#error Please define typedef struct lll_rx_pdu_meta_t when enabling \
+	CONFIG_BT_CTLR_RX_PDU_META
+#endif /* CONFIG_BT_CTLR_RX_PDU_META */


### PR DESCRIPTION
Added support for vendor specific meta data in LLL node_rx_hdr. This
enables vendors to add "footer" data to the RX PDU, for supporting
specialized BLE features.

Signed-off-by: Morten Priess <mtpr@oticon.com>