### PR TITLE
modules: Update ci-tools to disable pylint testing

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -29,7 +29,7 @@ manifest:
       revision: 04ff67a0826a51041e51034faf8fc4d3eeacd846
       path: modules/hal/atmel
     - name: ci-tools
-      revision: e6adea69826302ffc44a5aca33dd5122829e01c3
+      revision: 89e0ac76ad759ef79249339c5eadd4cecc1f287d
       path: tools/ci-tools
     - name: civetweb
       revision: 99129c5efc907ea613c4b73ccff07581feb58a7a


### PR DESCRIPTION
pylint isn't installed in the CI docker image, disable it for now.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>