### PR TITLE
boards: native_posix: Disable default testing on native_posix_64

### DIFF
--- a/boards/posix/native_posix/native_posix_64.yaml
+++ b/boards/posix/native_posix/native_posix_64.yaml
@@ -8,5 +8,3 @@ toolchain:
 supported:
   - netif:eth
   - usb_device
-testing:
-  default: true


### PR DESCRIPTION
Enabling of testing/default impacts all PR CIs.  There isn't that much
extra value for all PRs to have both native_posix and native_posix_64.
Go with native_posix, since most targets are 32-bit on Zephyr.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>