### PR TITLE
docs: Add -jauto to sphinx flags to improve doc build times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 
 BUILDDIR ?= doc/_build
 DOC_TAG ?= development
-SPHINXOPTS ?= -q
+SPHINXOPTS ?= "-q -jauto"
 
 # Documentation targets
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Reduce the amount of time it takes docs to build by utilizing -jauto

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>