### PR TITLE
ci: updates to fix pylint commit test

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -20,7 +20,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.9
+        image_tag: v0.9.1
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 

--- a/west.yml
+++ b/west.yml
@@ -29,7 +29,7 @@ manifest:
       revision: 04ff67a0826a51041e51034faf8fc4d3eeacd846
       path: modules/hal/atmel
     - name: ci-tools
-      revision: e6adea69826302ffc44a5aca33dd5122829e01c3
+      revision: 1c3ff2dc25c1233d88bab5d3c7dedb226c0c6eef
       path: tools/ci-tools
     - name: civetweb
       revision: 99129c5efc907ea613c4b73ccff07581feb58a7a


### PR DESCRIPTION
Update to CI image 0.9.1 to have pylint installed.  Bump ci-tools sha
that re-enables running the pylint test.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>