### PR TITLE
scripts: elf_helper.py: fix C++ template constexpr value processing

### DIFF
--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -295,9 +295,12 @@ def analyze_die_struct(die):
         for child in die.iter_children():
             if child.tag != "DW_TAG_member":
                 continue
+            data_member_location = child.attributes.get("DW_AT_data_member_location")
+            if not data_member_location:
+                continue
+
             child_type = die_get_type_offset(child)
-            member_offset = \
-                child.attributes["DW_AT_data_member_location"].value
+            member_offset = data_member_location.value
             cname = die_get_name(child) or "<anon>"
             m = AggregateTypeMember(child.offset, cname, child_type,
                                     member_offset)


### PR DESCRIPTION
Some DWARF symbols for members of template classes members such as numeric_limits<unsigned int> reference are static constexpr values that do not have a data member location.  Avoid attempting to dereference the value for that attribute when it isn't present.

This fix is required to get some C++ applications to link when usermode is enabled.

Below is the information for a DIE aggregate type (name, size, child) for an example:
```
integral_constant<bool, false> 1 DIE DW_TAG_member, size=13, has_chidren=False
    |DW_AT_name        :  AttributeValue(name='DW_AT_name', form='DW_FORM_strp', value=b'value', raw_value=23231, offset=82)
    |DW_AT_decl_file   :  AttributeValue(name='DW_AT_decl_file', form='DW_FORM_data1', value=15, raw_value=15, offset=86)
    |DW_AT_decl_line   :  AttributeValue(name='DW_AT_decl_line', form='DW_FORM_data1', value=59, raw_value=59, offset=87)
    |DW_AT_decl_column :  AttributeValue(name='DW_AT_decl_column', form='DW_FORM_data1', value=45, raw_value=45, offset=88)
    |DW_AT_type        :  AttributeValue(name='DW_AT_type', form='DW_FORM_ref4', value=35867, raw_value=35867, offset=89)
    |DW_AT_external    :  AttributeValue(name='DW_AT_external', form='DW_FORM_flag_present', value=b'', raw_value=b'', offset=93)
    |DW_AT_declaration :  AttributeValue(name='DW_AT_declaration', form='DW_FORM_flag_present', value=b'', raw_value=b'', offset=93)
    |DW_AT_const_expr  :  AttributeValue(name='DW_AT_const_expr', form='DW_FORM_flag_present', value=b'', raw_value=b'', offset=93)
    |DW_AT_inline      :  AttributeValue(name='DW_AT_inline', form='DW_FORM_data1', value=1, raw_value=1, offset=93)
```