### PR TITLE
boards: provide default SWO freq for efr32_slwstk6061a

### DIFF
--- a/boards/arm/efr32_slwstk6061a/Kconfig.defconfig
+++ b/boards/arm/efr32_slwstk6061a/Kconfig.defconfig
@@ -16,6 +16,13 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
+if LOG_BACKEND_SWO
+
+config LOG_BACKEND_SWO_FREQ_HZ
+	default 875000
+
+endif # LOG_BACKEND_SWO
+
 if GPIO_GECKO
 
 config GPIO_GECKO_PORTA


### PR DESCRIPTION
The commit provides default SWO frequency value for efr32_slwstk6061a board. The SWO frequency is limited by board hardware to 875 kHz.