### PR TITLE
scripts: footprint: Fix pylint warnings

### DIFF
--- a/scripts/footprint/compare_footprint
+++ b/scripts/footprint/compare_footprint
@@ -25,7 +25,6 @@ BASE_COMMIT is the commit used as base to compare results.
 
 import argparse
 import os
-import sys
 import csv
 import subprocess
 import logging
@@ -166,8 +165,6 @@ def read_sanity_report(filename):
     return data
 
 def get_footprint_results(commit=None):
-    results = {}
-
     sanity_file = sanity_results_filename(commit)
     if (not os.path.exists(sanity_file) or not commit) and commit != RELEASE_DATA:
         run_footprint_build(commit)
@@ -265,9 +262,10 @@ def compare_results(base_results, current_results):
                     'current': test_data[metric],
                 }
 
-            if len(tmp) != 0:
+            if tmp:
                 tests[platform] = tmp
-        if len(tests) != 0:
+
+        if tests:
             results[test] = tests
 
     return results

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -39,7 +39,7 @@ def load_symbols_and_paths(bin_nm, elf_file, path_to_strip=""):
             p_path_to_strip = Path(path_to_strip)
             try:
                 processed_path = p_path.relative_to(p_path_to_strip)
-            except ValueError as e:
+            except ValueError:
                 # path is valid, but is not prefixed by path_to_strip
                 processed_path = p_path
         else:
@@ -152,9 +152,8 @@ def get_footprint_from_bin_and_statfile(
 
 def generate_target_memory_section(
         bin_objdump, bin_nm, out, kernel_name, source_dir, features_json):
-    features_path_data = None
     try:
-        features_path_data = json.loads(open(features_json, 'r').read())
+        json.loads(open(features_json, 'r').read())
     except BaseException:
         pass
 
@@ -267,7 +266,7 @@ def generate_target_memory_section(
         out = ""
         sorted_nodes = sorted(symbols_struct.items(),
                               key=operator.itemgetter(0))
-        named_symbol_filter = re.compile('.*\.[a-zA-Z]+/.*')
+        named_symbol_filter = re.compile(r'.*\.[a-zA-Z]+/.*')
         out_symbols_filter = re.compile('^:/')
         for symbpath in sorted_nodes:
             matched = 0
@@ -283,7 +282,7 @@ def generate_target_memory_section(
                 matched = matched + \
                     _does_symbol_matches_feature(
                         symbpath[0], symbpath[1], feature)
-            if matched is 0:
+            if matched == 0:
                 out += "UNCATEGORIZED: %s %d<br/>" % (symbpath[0], symbpath[1])
         return out
 
@@ -329,7 +328,7 @@ def generate_target_memory_section(
     # Keep only final nodes
     tmp2 = {}
     for e in tmp:
-        if len(_childs_for_node(tmp, e)) == 0:
+        if not _childs_for_node(tmp, e):
             tmp2[e] = tmp[e]
 
     # Group nodes too small in an "other" section


### PR DESCRIPTION
 - Remove unused variables and an unused 'sys' import

 - Simplify 'if len(foo) != 0' to 'if foo'. Non-empty lists/dicts/etc.
   are truthy in Python.

 - Use a raw string to fix this warning:

       scripts/footprint/size_report:270:0: W1401: Anomalous backslash
       in string: '\.'. String constant might be missing an r prefix.
       (anomalous-backslash-in-string)

   The issue is that '\\.' just happens to work due to not being
   recognized as an escape sequence.

   Escape sequences are not interpreted in raw strings, so they're safer
   for regexes.

 - Replace 'is 0' with '== 0'. 'is' is for testing object identity, and
   0 isn't guaranteed to be a unique object (but always is in practice).