### PR TITLE
drivers: can: flexcan: limit number of concurrent rx filters on k6x soc

### DIFF
--- a/drivers/can/Kconfig.mcux
+++ b/drivers/can/Kconfig.mcux
@@ -16,6 +16,6 @@ config CAN_MAX_FILTER
 	int "Maximum number of concurrent active RX filters"
 	depends on CAN_MCUX_FLEXCAN
 	default 5
-	range 1 15 if SOC_SERIES_KINETIS_KE1XF
+	range 1 15 if SOC_SERIES_KINETIS_KE1XF || SOC_SERIES_KINETIS_K6X
 	help
 	  Defines maximum number of concurrent active RX filters


### PR DESCRIPTION
Limit the number of concurrent FlexCAN RX filters in Kconfig on the
NXP Kinetis K6x SoC.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>