### PR TITLE
kconfig: support multiple DTS bindings directories

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -40,7 +40,7 @@ set(ENV{CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR})
 set(ENV{ARCH_DIR}   ${ARCH_DIR})
 set(ENV{GENERATED_DTS_BOARD_CONF} ${GENERATED_DTS_BOARD_CONF})
 set(ENV{DTS_POST_CPP} ${DTS_POST_CPP})
-set(ENV{DTS_ROOT_BINDINGS} ${DTS_ROOT_BINDINGS})
+set(ENV{DTS_ROOT_BINDINGS} "${DTS_ROOT_BINDINGS}")
 
 # Allow out-of-tree users to add their own Kconfig python frontend
 # targets by appending targets to the CMake list

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -20,11 +20,11 @@ doc_mode = os.environ.get('KCONFIG_DOC_MODE') == "1"
 dt_defines = {}
 if not doc_mode:
     DTS_POST_CPP = os.environ["DTS_POST_CPP"]
-    BINDINGS_DIR = os.environ.get("DTS_ROOT_BINDINGS")
+    BINDINGS_DIRS = os.environ.get("DTS_ROOT_BINDINGS")
 
     # if a board port doesn't use DTS than these might not be set
-    if os.path.isfile(DTS_POST_CPP) and BINDINGS_DIR is not None:
-        edt = edtlib.EDT(DTS_POST_CPP, [BINDINGS_DIR])
+    if os.path.isfile(DTS_POST_CPP) and BINDINGS_DIRS is not None:
+        edt = edtlib.EDT(DTS_POST_CPP, BINDINGS_DIRS.split(";"))
     else:
         edt = None
 


### PR DESCRIPTION
Some confluence of recent changes resulted in builds with application-specific bindings being unable to find bindings present in the system directory.  Add quotes and splits as necessary to propagate multiple directories through the system.

Example output showing part of the problem (some fixes were applied for this run):

```
Device tree configuration written to /mnt/devel/zapps/hvac/build/zephyr/include/generated/generated_dts_board.conf
DTS ROOT BINDINGS: /mnt/devel/zapps/hvac/dts/bindings;/mnt/devel/external/zp/zephyr/dts/bindings
^^# added diagnostic
Parsing Kconfig tree in /mnt/devel/external/zp/zephyr/Kconfig
Bindings from:  /mnt/devel/zapps/hvac/dts/bindings
^^#added diagnostic showing value of BINDINGS_DIR after os.environ.get
Traceback (most recent call last):
  blah blah
edtlib.EDTError: interrupt controller <Node /soc/interrupt-controller@e000e100 in '/mnt/devel/zapps/hvac/build/zephyr/particle_xenon.dts.pre.tmp'> for <Node /soc/adc@40007000 in '/mnt/devel/zapps/hvac/build/zephyr/particle_xenon.dts.pre.tmp'> lacks binding
CMake Error at /mnt/devel/external/zp/zephyr/cmake/kconfig.cmake:205 (message):
  command failed with return code: 1
```
