### PR TITLE
drivers/sensor: sht3xd: implement single shot mode

### DIFF
--- a/drivers/sensor/sht3xd/Kconfig
+++ b/drivers/sensor/sht3xd/Kconfig
@@ -71,6 +71,20 @@ config SHT3XD_REPEATABILITY_HIGH
 endchoice
 
 choice
+	prompt "Measurement mode"
+	default SHT3XD_PERIODIC_MODE
+
+config SHT3XD_SINGLE_SHOT_MODE
+	bool "single shot"
+
+config SHT3XD_PERIODIC_MODE
+	bool "periodic data acquisition"
+
+endchoice
+
+if SHT3XD_PERIODIC_MODE
+
+choice
 	prompt "Measurements per second"
 	default SHT3XD_MPS_1
 	help
@@ -92,5 +106,7 @@ config SHT3XD_MPS_10
 	bool "10"
 
 endchoice
+
+endif # SHT3XD_PERIODIC_MODE
 
 endif # SHT3XD


### PR DESCRIPTION
For now there is only periodic data acquisition mode implemented.
This mode is quite power consuming. Based on datasheet in idle
state in periodic data acquisition mode SHT3X consumes 45uA but
in single shot mode 0.2uA. For many applications where power
consumption has to be kept as low as possible single shot mode
is the only choice. Tester on custom board NRF52832 + SHT31-DIS.

Signed-off-by: Michał Oleszczyk <oleszczyk.m@gmail.com>