### PR TITLE
drivers: ethernet: stm32: Add carrier state detection

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -88,4 +88,12 @@ config ETH_STM32_HAL_MII
 	help
 	  Use the MII physical interface instead of RMII.
 
+config ETH_STM32_CARRIER_CHECK_RX_IDLE_TIMEOUT_MS
+	int "Carrier check timeout period (ms)"
+ 	default 500
+ 	range 100 30000
+ 	help
+ 	  Set the RX idle timeout period in milliseconds after which the
+	  PHY's carrier status is re-evaluated.
+
 endif # ETH_STM32_HAL

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -37,6 +37,7 @@ struct eth_stm32_hal_dev_data {
 	K_THREAD_STACK_MEMBER(rx_thread_stack,
 		CONFIG_ETH_STM32_HAL_RX_THREAD_STACK_SIZE);
 	struct k_thread rx_thread;
+	bool link_up;
 };
 
 #define DEV_CFG(dev) \


### PR DESCRIPTION
This patch adds carrier state detection to the STM32 Ethernet driver.

Signed-off-by: Markus Fuchs <markus.fuchs@de.sauter-bc.com>