### PR TITLE
spinlock: Make sure C and C++ have the same sizeof(k_spinlock) value

### DIFF
--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -61,6 +61,23 @@ struct k_spinlock {
 	 */
 	uintptr_t thread_cpu;
 #endif
+
+#if defined(CONFIG_CPLUSPLUS) && !defined(CONFIG_SMP) && !defined(SPIN_VALIDATE)
+	/* If CONFIG_SMP and SPIN_VALIDATE are both not defined
+	 * the k_spinlock struct will have no members. The result
+	 * is that in C sizeof(k_spinlock) is 0 and in C++ it is 1.
+	 *
+	 * This size difference causes problems when the k_spinlock
+	 * is embedded into another struct like k_msgq, because C and
+	 * C++ will have different ideas on the offsets of the members
+	 * that come after the k_spinlock member.
+	 *
+	 * To prevent this we add a 1 byte dummy member to k_spinlock
+	 * when the user selects C++ support and k_spinlock would
+	 * otherwise be empty.
+	 */
+	char dummy;
+#endif
 };
 
 static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)


### PR DESCRIPTION
If CONFIG_SMP and SPIN_VALIDATE are both not defined the k_spinlock struct
will have no members. The result is that in C sizeof(k_spinlock) is 0 and
in C++ it is 1.

If the user enabled CONFIG_CPLUSPLUS add a dummy member to the struct if
it otherwize would be empty, so that in both C and C++ the size is 1.

Signed-off-by: Erwin Rol <erwin@erwinrol.com>