### PR TITLE
boards/arm: Add arduino_header support to nucleo f429zi

### DIFF
--- a/boards/arm/nucleo_f429zi/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f429zi/arduino_r3_connector.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019, Christian Taedcke
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
+			   <1 0 &gpioc 0 0>,	/* A1 */
+			   <2 0 &gpioc 3 0>,	/* A2 */
+			   <3 0 &gpiof 3 0>,	/* A3 */
+			   <4 0 &gpiof 5 0>,	/* A4 */
+			   <5 0 &gpiof 10 0>,	/* A5 */
+			   <6 0 &gpiog 9 0>,	/* D0 */
+			   <7 0 &gpiog 14 0>,	/* D1 */
+			   <8 0 &gpiof 15 0>,	/* D2 */
+			   <9 0 &gpioe 13 0>,	/* D3 */
+			   <10 0 &gpioe 14 0>,	/* D4 */
+			   <11 0 &gpioe 11 0>,	/* D5 */
+			   <12 0 &gpioe 9 0>,	/* D6 */
+			   <13 0 &gpiof 13 0>,	/* D7 */
+			   <14 0 &gpiof 12 0>,	/* D8 */
+			   <15 0 &gpiod 15 0>,	/* D9 */
+			   <16 0 &gpiod 14 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};
+arduino_serial: &usart6 {};

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f4/stm32f429Xi.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F429ZI-NUCLEO board";
@@ -51,10 +52,6 @@
 		sw0 = &user_button;
 	};
 };
-
-arduino_i2c: &i2c1 {};
-arduino_spi: &spi1 {};
-arduino_serial: &usart6 {};
 
 &i2c1 {
 	status = "okay";

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.yaml
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.yaml
@@ -9,7 +9,9 @@ toolchain:
 ram: 192
 flash: 2048
 supported:
+  - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - netif:eth
   - i2c
   - spi


### PR DESCRIPTION
Add arduino_header support to nucleo f429zi board.

Signed-off-by: Christian Taedcke <hacking@taedcke.com>