### PR TITLE
arch: arm: include: cortex_m: tz: Patch cmse_nsfptr_create for gcc 8

### DIFF
--- a/arch/arm/include/cortex_m/tz.h
+++ b/arch/arm/include/cortex_m/tz.h
@@ -25,6 +25,11 @@
 
 #ifdef __cplusplus
 extern "C" {
+
+/* Workaround for bug in the cmse_nsfptr_create macro in GCC version 8 */
+#if (__GNUC__ > 7) && (__GNUC__ < 9)
+#undef cmse_nsfptr_create
+#define cmse_nsfptr_create(p) ((__typeof__ ((p))) ((__INTPTR_TYPE__) (p) & ~1))
 #endif
 
 /**


### PR DESCRIPTION
arm-none-eabi-gcc 8 has a bug in the `cmse_nsfptr_create` macro. This
patch undefs the symbol and patches it with the corrected version which
is present in version 7.2 and 9.2.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>