### PR TITLE
net: socket: The socket flags need to use uintptr_t

### DIFF
--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -12,18 +12,18 @@
 #define SOCK_EOF 1
 #define SOCK_NONBLOCK 2
 
-static inline void sock_set_flag(struct net_context *ctx, u32_t mask,
-				 u32_t flag)
+static inline void sock_set_flag(struct net_context *ctx, uintptr_t mask,
+				 uintptr_t flag)
 {
-	u32_t val = POINTER_TO_INT(ctx->user_data);
+	uintptr_t val = POINTER_TO_UINT(ctx->user_data);
 
 	val = (val & ~mask) | flag;
-	(ctx)->user_data = INT_TO_POINTER(val);
+	(ctx)->user_data = UINT_TO_POINTER(val);
 }
 
-static inline u32_t sock_get_flag(struct net_context *ctx, u32_t mask)
+static inline uintptr_t sock_get_flag(struct net_context *ctx, uintptr_t mask)
 {
-	return POINTER_TO_INT(ctx->user_data) & mask;
+	return POINTER_TO_UINT(ctx->user_data) & mask;
 }
 
 #define sock_is_eof(ctx) sock_get_flag(ctx, SOCK_EOF)


### PR DESCRIPTION
The socket flags are stored in void* so we need to use uintptr_t
instead of u32_t when manipulating the flag variable.

Fixes #19181

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>