### PR TITLE
Bluetooth: tester: Adapt to BTP Get Attribute Value API change

### DIFF
--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -577,6 +577,8 @@ struct gatt_attr {
 
 #define GATT_GET_ATTRIBUTE_VALUE	0x1d
 struct gatt_get_attribute_value_cmd {
+	u8_t address_type;
+	u8_t address[6];
 	u16_t handle;
 } __packed;
 struct gatt_get_attribute_value_rp {


### PR DESCRIPTION
Related autopts issue: https://github.com/intel/auto-pts/issues/342

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>