### PR TITLE
soc: nxp: rt: DATA_OCRAM flag and Custom linker sections

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -141,6 +141,16 @@ config SRAM_BASE_ADDRESS
 
 endif # DATA_SEMC
 
+if DATA_OCRAM
+
+config SRAM_SIZE
+	default $(dt_node_reg_size,/memory@20200000,0,K)
+
+config SRAM_BASE_ADDRESS
+	default $(dt_node_reg_addr,/memory@20200000)
+
+endif # DATA_OCRAM
+
 if USB
 
 config USB_DC_NXP_EHCI

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -346,6 +346,9 @@ config DATA_SEMC
 	bool "Link data into external SEMC-controlled memory"
 	select DEVICE_CONFIGURATION_DATA if NXP_IMX_RT_BOOT_HEADER
 
+config DATA_OCRAM
+	bool "Link data into On-Chip RAM memory"
+
 endchoice
 
 endif # SOC_SERIES_IMX_RT

--- a/soc/arm/nxp_imx/rt/linker.ld
+++ b/soc/arm/nxp_imx/rt/linker.ld
@@ -4,4 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+ #include <autoconf.h>
+ #include <generated_dts_board.h>
+
+MEMORY
+     {
+#if (DT_MMIO_SRAM_20200000_SIZE > 0) && !defined(CONFIG_DATA_OCRAM)
+        OCRAM  (wx) : ORIGIN = DT_MMIO_SRAM_20200000_BASE_ADDRESS, LENGTH = DT_MMIO_SRAM_20200000_SIZE
+#endif
+#if (DT_MMIO_SRAM_80000000_SIZE > 0) && !defined(CONFIG_DATA_SEMC)
+        SDRAM  (wx) : ORIGIN = DT_MMIO_SRAM_80000000_BASE_ADDRESS, LENGTH = DT_MMIO_SRAM_80000000_SIZE
+#endif
+#if (DT_INST_0_NXP_IMX_DTCM_SIZE > 0) && !defined(CONFIG_DATA_DTCM)
+        DTCM    (wx) : ORIGIN = DT_INST_0_NXP_IMX_DTCM_BASE_ADDRESS, LENGTH = DT_INST_0_NXP_IMX_DTCM_SIZE
+#endif
+#if (DT_INST_0_NXP_IMX_ITCM_SIZE > 0) && !defined(CONFIG_CODE_ITCM)
+        ITCM    (wx) : ORIGIN = DT_INST_0_NXP_IMX_ITCM_BASE_ADDRESS, LENGTH = DT_INST_0_NXP_IMX_ITCM_SIZE
+#endif
+     }
+
 #include <arch/arm/cortex_m/scripts/linker.ld>


### PR DESCRIPTION
RT SOCs have several memory areas (OCRAMs, DTCM, ITCM, SDRAM, FLASH...)
but only two are selected for FLASH (code) and RAM (data).
It would be good to let the linker be aware about other regions, which
could then be used by drivers or application to create dedicated
sections and relocate memory. For example if we have code in ITCM and
data in DTCM, we still need a dma-able region/section for e.g.
video/camera buffers.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>