### PR TITLE
doc: release notes: Add note on kconfig function deprecation

### DIFF
--- a/doc/releases/release-notes-2.1.rst
+++ b/doc/releases/release-notes-2.1.rst
@@ -46,7 +46,9 @@ Bluetooth
 Build and Infrastructure
 ************************
 
-* TBD
+* Deprecated kconfig functions dt_int_val, dt_hex_val, and dt_str_val.
+  Use new functions that utilize eDTS info such as dt_node_reg_addr.
+  See :zephyr_file:`scripts/kconfig/kconfigfunctions.py` for details.
 
 Libraries / Subsystems
 ***********************


### PR DESCRIPTION
Add some info on the deprecation of the kconfigfunctions.py that have
been deprecated.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>