### PR TITLE
shell: kconfig: Fix wrong UART_SHELL_ON_DEV_NAME value due to typo

### DIFF
--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -35,7 +35,7 @@ DT_CHOSEN_Z_SHELL_UART := zephyr,shell-uart
 
 config UART_SHELL_ON_DEV_NAME
 	string "Device Name of UART Device for SHELL_BACKEND_SERIAL"
-	default "$(dt_chosen_label,$(UART_SHELL_ON_DEV_NAME))" if HAS_DTS
+	default "$(dt_chosen_label,$(DT_CHOSEN_Z_SHELL_UART))" if HAS_DTS
 	default "UART_0"
 	help
 	  This option specifies the name of UART device to be used for the


### PR DESCRIPTION
The $(dt_chosen_label) preprocessor function should be passed
$(DT_CHOSEN_Z_SHELL_UART), not $(UART_SHELL_ON_DEV_NAME).

DT_CHOSEN_Z_SHELL_UART is set right before the Kconfig symbol
definition, to work around the comma in 'zephyr,shell-uart'.

The Kconfig preprocessor functions are defined in
scripts/kconfig/kconfigfunctions.py.

Fixes: #19178