### PR TITLE
scripts: dts: Change 'child/parent: bus: ...' to 'child/parent-bus:'

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -46,19 +46,19 @@ compatible: "manufacturer,device"
 # 'required: true' is always respected.
 include: other.yaml # or [other1.yaml, other2.yaml]
 
-# If the node describes a bus, then the bus type should be given, like below
-child:
-    bus: <string describing bus type, e.g. "i2c">
+# If the node describes a bus, then the bus type should be given, like below.
+# The name has "child" in it since it describes the bus children of the node
+# appear on.
+child-bus: <string describing bus type, e.g. "i2c">
 
 # If the node appears on a bus, then the bus type should be given, like below.
 #
 # When looking for a binding for a node, the code checks if the binding for the
-# parent node contains 'child: bus: <bus type>'. If it does, then only bindings
-# with a matching 'parent: bus: <bus type>' are considered. This allows the
-# same type of device to have different bindings depending on what bus it
-# appears on.
-parent:
-    bus: <string describing bus type, e.g. "i2c">
+# parent node contains 'child-bus: <bus type>'. If it does, then only bindings
+# with a matching 'parent-bus: <bus type>' are considered. This allows the same
+# type of device to have different bindings depending on what bus it appears
+# on.
+parent-bus: <string describing bus type, e.g. "i2c">
 
 # 'sub-node' is used to simplify cases where a node has children that can all
 # use the same binding. The contents of 'sub-node' becomes the binding for each

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
@@ -11,8 +11,7 @@ compatible: "zephyr,bt-hci-spi-slave"
 
 include: base.yaml
 
-parent:
-    bus: spi
+parent-bus: spi
 
 properties:
     irq-gpios:

--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -2,8 +2,7 @@
 
 include: base.yaml
 
-child:
-    bus: can
+child-bus: can
 
 properties:
     "#address-cells":

--- a/dts/bindings/can/can-device.yaml
+++ b/dts/bindings/can/can-device.yaml
@@ -5,8 +5,7 @@
 
 include: base.yaml
 
-parent:
-    bus: can
+parent-bus: can
 
 properties:
     reg:

--- a/dts/bindings/espi/espi-controller.yaml
+++ b/dts/bindings/espi/espi-controller.yaml
@@ -5,8 +5,7 @@
 
 include: base.yaml
 
-child:
-    bus: espi
+child-bus: espi
 
 properties:
     label:

--- a/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
+++ b/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
@@ -6,8 +6,7 @@ compatible: "holtek,ht16k33-keyscan"
 
 include: base.yaml
 
-parent:
-    bus: ht16k33
+parent-bus: ht16k33
 
 properties:
     reg:

--- a/dts/bindings/i2c/i2c-controller.yaml
+++ b/dts/bindings/i2c/i2c-controller.yaml
@@ -5,8 +5,7 @@
 
 include: base.yaml
 
-child:
-    bus: i2c
+child-bus: i2c
 
 properties:
     "#address-cells":

--- a/dts/bindings/i2c/i2c-device.yaml
+++ b/dts/bindings/i2c/i2c-device.yaml
@@ -5,8 +5,7 @@
 
 include: base.yaml
 
-parent:
-    bus: i2c
+parent-bus: i2c
 
 properties:
     reg:

--- a/dts/bindings/i2s/i2s-controller.yaml
+++ b/dts/bindings/i2s/i2s-controller.yaml
@@ -5,8 +5,7 @@
 
 include: base.yaml
 
-child:
-    bus: i2s
+child-bus: i2s
 
 properties:
     "#address-cells":

--- a/dts/bindings/i2s/i2s-device.yaml
+++ b/dts/bindings/i2s/i2s-device.yaml
@@ -5,8 +5,7 @@
 
 include: base.yaml
 
-parent:
-    bus: i2s
+parent-bus: i2s
 
 properties:
     reg:

--- a/dts/bindings/led/holtek,ht16k33.yaml
+++ b/dts/bindings/led/holtek,ht16k33.yaml
@@ -6,8 +6,7 @@ compatible: "holtek,ht16k33"
 
 include: i2c-device.yaml
 
-child:
-    bus: ht16k33
+child-bus: ht16k33
 
 properties:
     "#address-cells":

--- a/dts/bindings/serial/uart-controller.yaml
+++ b/dts/bindings/serial/uart-controller.yaml
@@ -2,8 +2,7 @@
 
 include: base.yaml
 
-child:
-    bus: uart
+child-bus: uart
 
 properties:
     clock-frequency:

--- a/dts/bindings/serial/uart-device.yaml
+++ b/dts/bindings/serial/uart-device.yaml
@@ -5,8 +5,7 @@
 
 include: base.yaml
 
-parent:
-    bus: uart
+parent-bus: uart
 
 properties:
     label:

--- a/dts/bindings/spi/spi-controller.yaml
+++ b/dts/bindings/spi/spi-controller.yaml
@@ -5,8 +5,7 @@
 
 include: base.yaml
 
-child:
-    bus: spi
+child-bus: spi
 
 properties:
     clock-frequency:

--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -5,8 +5,7 @@
 
 include: base.yaml
 
-parent:
-    bus: spi
+parent-bus: spi
 
 properties:
     reg:

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -317,6 +317,11 @@ def get_binding(node_path):
             return parent_binding['sub-node']
 
         # look for a bus-specific binding
+
+        if 'child-bus' in parent_binding:
+            bus = parent_binding['child-bus']
+            return bus_bindings[bus][compat]
+
         if 'child' in parent_binding and 'bus' in parent_binding['child']:
             bus = parent_binding['child']['bus']
             return bus_bindings[bus][compat]

--- a/scripts/dts/test-bindings/bar-bus.yaml
+++ b/scripts/dts/test-bindings/bar-bus.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+title: Bar bus controller
+description: Bar bus controller
+
+compatible: "bar-bus"
+
+child-bus: "bar"

--- a/scripts/dts/test-bindings/device-on-bar-bus.yaml
+++ b/scripts/dts/test-bindings/device-on-bar-bus.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+title: Device on bar bus
+description: Device on bar bus
+
+compatible: "on-bus"
+
+parent-bus: "bar"

--- a/scripts/dts/test-bindings/device-on-foo-bus.yaml
+++ b/scripts/dts/test-bindings/device-on-foo-bus.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+title: Device on foo bus
+description: Device on foo bus
+
+compatible: "on-bus"
+
+parent-bus: "foo"

--- a/scripts/dts/test-bindings/foo-bus.yaml
+++ b/scripts/dts/test-bindings/foo-bus.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+title: Foo bus controller
+description: Foo bus controller
+
+compatible: "foo-bus"
+
+child-bus: "foo"

--- a/scripts/dts/test-bindings/grandchild-3.yaml
+++ b/scripts/dts/test-bindings/grandchild-3.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+properties:
+    qaz:
+        required: true
+        type: int

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -319,6 +319,27 @@
 	};
 
 	//
+	// For testing 'child-bus:' and 'parent-bus:'
+	//
+
+	buses {
+		// The nodes below will map to different bindings since they
+		// appear on different buses
+		foo-bus {
+			compatible = "foo-bus";
+			node {
+				compatible = "on-bus";
+			};
+		};
+		bar-bus {
+			compatible = "bar-bus";
+			node {
+				compatible = "on-bus";
+			};
+		};
+	};
+
+	//
 	// Parent with 'sub-node:' in binding
 	//
 

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -106,6 +106,16 @@ def run():
                  "{'foo': <Property, name: foo, type: int, value: 0>, 'bar': <Property, name: bar, type: int, value: 1>, 'baz': <Property, name: baz, type: int, value: 2>, 'qaz': <Property, name: qaz, type: int, value: 3>}")
 
     #
+    # Test 'child/parent-bus:'
+    #
+
+    verify_streq(edt.get_dev("/buses/foo-bus/node").binding_path,
+                 "test-bindings/device-on-foo-bus.yaml")
+
+    verify_streq(edt.get_dev("/buses/bar-bus/node").binding_path,
+                 "test-bindings/device-on-bar-bus.yaml")
+
+    #
     # Test 'sub-node:' in binding
     #
 


### PR DESCRIPTION
Instead of

    child:
        bus: foo

    parent:
        bus: bar

, have

    child-bus: foo

    parent-bus: bar

'bus' is the only key that ever appears under 'child' and 'parent'.

Support the old keys for backwards compatibility, with a deprecation
warning if they're used.

Also add some 'child/parent-bus' tests to the edtlib test suite. It was
untested before.

I also considered putting more stuff under 'child' and 'parent', but
there's not much point when there's just a few keys I think. Top-level
stuff is cleaner and easier to read.

I'm planning to add a 'child-binding' key a bit later (like 'sub-node',
but more flexible), and child-* is consistent with that.

Also add an unrelated test-bindings/grandchild-3.yaml that was
accidentally left out earlier.