### PR TITLE
i2c_ll_stm32_v2: Send STOP manually after NACK

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -286,7 +286,12 @@ static void stm32_i2c_event(struct device *dev)
 	if (LL_I2C_IsActiveFlag_NACK(i2c)) {
 		LL_I2C_ClearFlag_NACK(i2c);
 		data->current.is_nack = 1U;
-		goto end;
+		/*
+		 * AutoEndMode is always disabled in master mode,
+		 * so send a stop condition manually
+		 */
+		LL_I2C_GenerateStopCondition(i2c);
+		return;
 	}
 
 	/* STOP received */


### PR DESCRIPTION
In master trasmitter mode AutoEndMode is
always disabled, so we need to send STOP
manually if NACK is received.

Fixes #19059

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>