### PR TITLE
arch: arm: cmse: re-introduce workaround for typeof

### DIFF
--- a/arch/arm/include/cortex_m/cmse.h
+++ b/arch/arm/include/cortex_m/cmse.h
@@ -135,6 +135,13 @@ int arm_cmse_addr_range_read_ok(u32_t addr, u32_t size, int force_npriv);
  */
 int arm_cmse_addr_range_readwrite_ok(u32_t addr, u32_t size, int force_npriv);
 
+/* Required for C99 compilation (required for GCC-8.x version,
+ * where typeof is used instead of __typeof__)
+ */
+#ifndef typeof
+#define typeof  __typeof__
+#endif
+
 /**
  * @brief Read accessibility of an object
  *

--- a/arch/arm/include/cortex_m/tz.h
+++ b/arch/arm/include/cortex_m/tz.h
@@ -283,6 +283,13 @@ int tz_sau_region_configure(tz_sau_conf_t *p_sau_conf);
  */
 typedef void __attribute__((cmse_nonsecure_call)) (*tz_ns_func_ptr_t) (void);
 
+/* Required for C99 compilation (required for GCC-8.x version,
+ * where typeof is used instead of __typeof__)
+ */
+#ifndef typeof
+#define typeof  __typeof__
+#endif
+
 #if defined(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
 /**
  * @brief Non-Secure entry function attribute.


### PR DESCRIPTION
The GNU ARM Embedded "8-2019-q3-update" toolchain
erroneously uses "typeof" instead of "__typeof__".
To work around this we define typeof to be able to
support it.

This reverts commit 01a71eae3d74613d920336c659371b5f3d82a79c.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>