### PR TITLE
usb: derive USB device Serial Number String from HWINFO

### DIFF
--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -6,6 +6,7 @@
 menuconfig USB_DEVICE_STACK
 	bool "USB device stack"
 	depends on USB_DEVICE_DRIVER || ARCH_POSIX
+	select HWINFO
 	help
 	  Enable USB device stack.
 
@@ -42,11 +43,12 @@ config USB_DEVICE_PRODUCT
 	  USB device Product string. MUST be configured by vendor.
 
 config USB_DEVICE_SN
-	string "USB serial number"
-	default "ABCDEF012345" if USB_MASS_STORAGE
-	default "0.01"
+	string "USB device Serial Number String"
+	default "0123456789ABCDEF"
 	help
-	  USB device SerialNumber string. MUST be configured by vendor.
+	  Placeholder for USB device Serial Number String.
+	  Serial Number String will be derived from
+	  Hardware Information Driver (HWINFO).
 
 config USB_COMPOSITE_DEVICE
 	bool "Enable composite device driver"

--- a/tests/subsys/usb/desc_sections/src/desc_sections.c
+++ b/tests/subsys/usb/desc_sections/src/desc_sections.c
@@ -37,6 +37,7 @@ struct usb_test_config {
 } __packed;
 
 #define TEST_BULK_EP_MPS		64
+#define TEST_DESCRIPTOR_TABLE_SPAN	157
 
 #define INITIALIZER_IF							\
 	{								\
@@ -233,7 +234,7 @@ static void test_desc_sections(void)
 	zassert_not_null(head, NULL);
 
 	zassert_equal(SYMBOL_SPAN(__usb_descriptor_end, __usb_descriptor_start),
-		      133, NULL);
+		      TEST_DESCRIPTOR_TABLE_SPAN, NULL);
 
 	/* Calculate number of structures */
 	zassert_equal(__usb_data_end - __usb_data_start, NUM_INSTANCES, NULL);


### PR DESCRIPTION
Derive USB device Serial Number String from HWINFO driver.