### PR TITLE
west.yml: Update ci-tools to broaden pylint check and fix formatting

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -29,7 +29,7 @@ manifest:
       revision: 04ff67a0826a51041e51034faf8fc4d3eeacd846
       path: modules/hal/atmel
     - name: ci-tools
-      revision: a54a1a59457f5ea2a1fdbb21fcb3f0a5e7c8952f
+      revision: bd945cfc2f934704aa11abdf648217a7dc2f2e6b
       path: tools/ci-tools
     - name: civetweb
       revision: 99129c5efc907ea613c4b73ccff07581feb58a7a


### PR DESCRIPTION
Get these ci-tools commits into CI runs:

 - Commit 3a08069 ("check_compliance.py: pylint: Detect Python files not
   ending in .py")

 - Commit 2184bb4 ("check_compliance.py: Fix formatting mess-up for
   error messages")