### PR TITLE
west.yml: Update ci-tools to treat all .py files as Python

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -29,7 +29,7 @@ manifest:
       revision: 04ff67a0826a51041e51034faf8fc4d3eeacd846
       path: modules/hal/atmel
     - name: ci-tools
-      revision: bd945cfc2f934704aa11abdf648217a7dc2f2e6b
+      revision: 343b5c7543a6681e8625e7d56f27e58e1006dde4
       path: tools/ci-tools
     - name: civetweb
       revision: 99129c5efc907ea613c4b73ccff07581feb58a7a


### PR DESCRIPTION
Get commit 343b5c7 ("check_compliance.py: Treat all .py files as Python
in pylint check") in.

libmagic doesn't consider the filename, and mis-detects kconfiglib.py as
HTML for example. Treat all files ending in .py as Python, and only use
libmagic for other files.