### PR TITLE
Bluetooth: controller: split: Fix to reject invalid enable command

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -14,6 +14,7 @@
 #include "hal/ticker.h"
 
 #include "util/util.h"
+#include "util/mem.h"
 #include "util/memq.h"
 #include "util/mayfly.h"
 
@@ -443,11 +444,15 @@ u8_t ll_adv_enable(u8_t enable)
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
-	/* remember addr to use and also update the addr in
-	 * both adv and scan response PDUs.
-	 */
 	lll = &adv->lll;
+
 	pdu_adv = lll_adv_data_peek(lll);
+	if (pdu_adv->tx_addr) {
+		if (!mem_nz(ll_addr_get(1, NULL), BDADDR_SIZE)) {
+			return BT_HCI_ERR_INVALID_PARAM;
+		}
+	}
+
 	pdu_scan = lll_adv_scan_rsp_peek(lll);
 
 	if (0) {

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -12,6 +12,7 @@
 #include "hal/ticker.h"
 
 #include "util/util.h"
+#include "util/mem.h"
 #include "util/memq.h"
 #include "util/mayfly.h"
 
@@ -77,6 +78,12 @@ u8_t ll_scan_enable(u8_t enable)
 	scan = ull_scan_is_disabled_get(0);
 	if (!scan) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+
+	if (scan->own_addr_type & 0x1) {
+		if (!mem_nz(ll_addr_get(1, NULL), BDADDR_SIZE)) {
+			return BT_HCI_ERR_INVALID_PARAM;
+		}
 	}
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)


### PR DESCRIPTION
Fix to reject invalid advertise and scan enable commands.

Fixes BT HCI.TS.5.1.1 tests:
HCI/DDI/BI-06-C
HCI/DDI/BI-07-C

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>