### PR TITLE
net: sockets: Store socket private data into its own variable

### DIFF
--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -257,6 +257,9 @@ struct net_context {
 #endif /* CONFIG_NET_CONTEXT_SYNC_RECV */
 
 #if defined(CONFIG_NET_SOCKETS)
+	/** BSD socket private data */
+	void *socket_data;
+
 	/** Per-socket packet or connection queues */
 	union {
 		struct k_fifo recv_q;

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -229,6 +229,8 @@ int net_context_get(sa_family_t family,
 			continue;
 		}
 
+		memset(&contexts[i], 0, sizeof(contexts[i]));
+
 		if (ip_proto == IPPROTO_TCP) {
 			if (net_tcp_get(&contexts[i]) < 0) {
 				break;

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -111,6 +111,9 @@ int zsock_socket_internal(int family, int type, int proto)
 	/* Initialize user_data, all other calls will preserve it */
 	ctx->user_data = NULL;
 
+	/* The socket flags are stored here */
+	ctx->socket_data = NULL;
+
 	/* recv_q and accept_q are in union */
 	k_fifo_init(&ctx->recv_q);
 

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -15,15 +15,15 @@
 static inline void sock_set_flag(struct net_context *ctx, uintptr_t mask,
 				 uintptr_t flag)
 {
-	uintptr_t val = POINTER_TO_UINT(ctx->user_data);
+	uintptr_t val = POINTER_TO_UINT(ctx->socket_data);
 
 	val = (val & ~mask) | flag;
-	(ctx)->user_data = UINT_TO_POINTER(val);
+	(ctx)->socket_data = UINT_TO_POINTER(val);
 }
 
 static inline uintptr_t sock_get_flag(struct net_context *ctx, uintptr_t mask)
 {
-	return POINTER_TO_UINT(ctx->user_data) & mask;
+	return POINTER_TO_UINT(ctx->socket_data) & mask;
 }
 
 #define sock_is_eof(ctx) sock_get_flag(ctx, SOCK_EOF)


### PR DESCRIPTION
Do not try to re-use net_context.user_data field as in many places
(like in accept) it is expected to contain pointer to net_context.
Storing the socket flags will corrupt the value. To simplify and
make things less error prone, use socket specific field in net_context
to store the socket flags.

Fixes #19191

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>