### PR TITLE
Bluetooth: Mesh: Fix secure beacon forward to other nodes

### DIFF
--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -333,7 +333,7 @@ static void secure_beacon_recv(struct net_buf_simple *buf)
              BT_MESH_IV_UPDATE(flags))) {
                 bt_mesh_beacon_ivu_initiator(false);
         } else if (iv_change || kr_change) {
-		/* Forwared changed secure beacon to other nodes(not in single hop)*/
+		/* Forward changed secure beacon to other nodes(not in single hop)*/
 		bt_mesh_beacon_ivu_initiator(true);
 	}
 


### PR DESCRIPTION
if none of the entire Mesh nodes enable beacon 
`BLE_MESH_BEACON_ENABLE`, that is, there is usually
no node to send the beacon. In fact, when a node performs
an IVI update, only nearby nodes(single hop) can hear
this information. Unfortunately, nodes farther away will
not receive this very critical information because the
information cannot be effectively forwarded.
#19186

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>