### PR TITLE
CoAP: Random generate ID the first time coap_next_id() is called

### DIFF
--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -357,12 +357,7 @@ u8_t *coap_next_token(void);
  *
  * @return a new message id
  */
-static inline u16_t coap_next_id(void)
-{
-	static u16_t message_id;
-
-	return ++message_id;
-}
+u16_t coap_next_id(void);
 
 /**
  * @brief Return the values associated with the option of value @a

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -451,6 +451,8 @@ static inline int services_init(void)
 
 	dns_init_resolver();
 
+	net_coap_init();
+
 	net_shell_init();
 
 	return status;

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -90,6 +90,22 @@ int net_context_get_timestamp(struct net_context *context,
 			      struct net_ptp_time *timestamp);
 #endif
 
+#if defined(CONFIG_COAP)
+/**
+ * @brief CoAP init function declaration. It belongs here because we don't want
+ * to expose it as a public API -- it should only be called once, and only by
+ * net_core.
+ */
+extern void net_coap_init(void);
+#else
+static inline void net_coap_init(void)
+{
+	return;
+}
+#endif
+
+
+
 #if defined(CONFIG_NET_GPTP)
 /**
  * @brief Initialize Precision Time Protocol Layer.

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -12,6 +12,8 @@ LOG_MODULE_REGISTER(net_coap, CONFIG_COAP_LOG_LEVEL);
 #include <string.h>
 #include <stdbool.h>
 #include <errno.h>
+#include <random/rand32.h>
+#include <atomic.h>
 
 #include <zephyr/types.h>
 #include <sys/byteorder.h>
@@ -44,6 +46,9 @@ LOG_MODULE_REGISTER(net_coap, CONFIG_COAP_LOG_LEVEL);
 #define COAP_MARKER		0xFF
 
 #define BASIC_HEADER_SIZE	4
+
+/* The CoAP message ID that is incremented each time coap_next_id() is called. */
+static u16_t message_id;
 
 static inline bool append_u8(struct coap_packet *cpkt, u8_t data)
 {
@@ -1396,4 +1401,26 @@ struct coap_observer *coap_find_observer_by_addr(
 	}
 
 	return NULL;
+}
+
+/**
+ * @brief Internal initialization function for CoAP library.
+ *
+ * Called by the network layer init procedure. Seeds the CoAP @message_id with a
+ * random number in accordance with recommendations in CoAP specification.
+ *
+ * @note This function is not exposed in a public header, as it's for internal
+ * use and should therefore not be exposed to applications.
+ *
+ * @return N/A
+ */
+void net_coap_init(void)
+{
+	/* Initialize message_id to a random number */
+	message_id = (u16_t)sys_rand32_get();
+}
+
+u16_t coap_next_id(void)
+{
+	return message_id++;
 }


### PR DESCRIPTION
This is more in accordance with CoAP recommendations (see
https://tools.ietf.org/html/draft-ietf-core-coap-18, section 4.4)

"It is strongly recommended that the initial value of the variable (e.g.,
on startup) be randomized, in order to make successful off-path attacks
on the protocol less likely."

Signed-off-by: Benjamin Lindqvist <benjamin.lindqvist@endian.se>