### PR TITLE
[Backport v1.14-branch] drivers: spi_nor: fix writes across page boundaries

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -177,7 +177,6 @@ static int spi_nor_read(struct device *dev, off_t addr, void *dest,
 	struct spi_nor_data *const driver_data = dev->driver_data;
 	const struct spi_nor_config *params = dev->config->config_info;
 	int ret;
-	int to_read;
 
 	/* should be between 0 and flash size */
 	if ((addr < 0) || (addr + size) >  (params->sector_size
@@ -189,26 +188,10 @@ static int spi_nor_read(struct device *dev, off_t addr, void *dest,
 
 	spi_nor_wait_until_ready(dev);
 
-	while (size) {
-		to_read = size;
-		if (size > params->page_size) {
-			to_read = params->page_size;
-		}
-
-		ret = spi_nor_cmd_addr_read(dev, SPI_NOR_CMD_READ, addr,
-					    dest, to_read);
-		if (ret != 0) {
-			SYNC_UNLOCK();
-			return ret;
-		}
-
-		size -= to_read;
-		addr += to_read;
-		dest = (u8_t *)dest + to_read;
-	}
+	ret = spi_nor_cmd_addr_read(dev, SPI_NOR_CMD_READ, addr, dest, size);
 
 	SYNC_UNLOCK();
-	return 0;
+	return ret;
 }
 
 static int spi_nor_write(struct device *dev, off_t addr, const void *src,

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -21,6 +21,8 @@
 #define SZ_32K  0x8000
 #define SZ_64K  0x10000
 
+#define SPI_NOR_PAGE_SIZE 256
+
 #define MASK_256 0xFF
 #define MASK_4K  0xFFF
 #define MASK_32K 0x7FFF
@@ -125,7 +127,7 @@ static int spi_nor_access(const struct device *const dev,
 #define spi_nor_cmd_write(dev, opcode) \
 	spi_nor_access(dev, opcode, false, 0, NULL, 0, true)
 #define spi_nor_cmd_addr_write(dev, opcode, addr, src, length) \
-	spi_nor_access(dev, opcode, true, addr, src, length, true)
+	spi_nor_access(dev, opcode, true, addr, (void *)src, length, true)
 
 /**
  * @brief Retrieve the Flash JEDEC ID and compare it with the one expected
@@ -215,7 +217,6 @@ static int spi_nor_write(struct device *dev, off_t addr, const void *src,
 	struct spi_nor_data *const driver_data = dev->driver_data;
 	const struct spi_nor_config *params = dev->config->config_info;
 	int ret;
-	size_t to_write;
 
 	/* should be between 0 and flash size */
 	if ((addr < 0) || ((size + addr) > (params->sector_size *
@@ -225,25 +226,31 @@ static int spi_nor_write(struct device *dev, off_t addr, const void *src,
 
 	SYNC_LOCK();
 
-	while (size) {
-		/* write enable */
-		spi_nor_cmd_write(dev, SPI_NOR_CMD_WREN);
+	while (size > 0) {
+		size_t to_write = size;
 
-		to_write = size;
-		if (size >= params->page_size) {
-			to_write = params->page_size;
+		/* Don't write more than a page. */
+		if (to_write >= SPI_NOR_PAGE_SIZE) {
+			to_write = SPI_NOR_PAGE_SIZE;
 		}
 
+		/* Don't write across a page boundary */
+		if (((addr + to_write - 1U) / SPI_NOR_PAGE_SIZE)
+		    != (addr / SPI_NOR_PAGE_SIZE)) {
+			to_write = SPI_NOR_PAGE_SIZE - (addr % SPI_NOR_PAGE_SIZE);
+		}
+
+		spi_nor_cmd_write(dev, SPI_NOR_CMD_WREN);
 		ret = spi_nor_cmd_addr_write(dev, SPI_NOR_CMD_PP, addr,
-					     (void *)src, to_write);
+					     src, to_write);
 		if (ret != 0) {
 			SYNC_UNLOCK();
 			return ret;
 		}
 
 		size -= to_write;
+		src = (const u8_t *)src + to_write;
 		addr += to_write;
-		src = (u8_t *)src + to_write;
 
 		spi_nor_wait_until_ready(dev);
 	}


### PR DESCRIPTION
Closes #18935

### drivers/spi_nor: fix writes across page boundaries

The previous code limited the length of a write to the size of a page,
but did not check whether the starting position was far enough into the
page that the write would still cross a page boundary.

NOTE: SPI NOR page size is fixed as 256 regardless of what Kconfig says.

Backport: 2.0 660149b50073d4bfcead75153eb9082811df9391
Backport: 2.0 86dcf3c173e6a9542e7751fc2ab0850ad8d80943

### drivers/spi_nor: de-pessimize reads

SPI NOR devices require that writes be performed within only one page at
a time.  There is no such limitation on reads.  Remove the code that
forced reads to be performed in 256-byte chunks.

Backport: 2.0 d60d16d4cdf54fd5ce6e903b5e5ecb77953cb701
