### PR TITLE
Merge pull request #19236 from vanti/fatal_fix

### DIFF
--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -171,7 +171,7 @@ void stack_sentinel_timer(void)
 	 * k_timer and spin until we die.  Spinning alone won't work
 	 * on a tickless kernel.
 	 */
-	struct k_timer timer;
+	static struct k_timer timer;
 
 	blow_up_stack();
 	k_timer_init(&timer, NULL, NULL);


### PR DESCRIPTION
In stack_sentinel_timer(), the timer should not be allocated on the
stack. If it gets added to the list of timeouts by k_timer_start,
then an unexpected exception may occur when the timer expires since it
may have been overwritten.

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>