### PR TITLE
drivers: ethernet: stm32, sam, mcux: correctly set LAA bit

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -754,10 +754,11 @@ static void generate_mac(u8_t *mac_addr)
 
 	entropy = sys_rand32_get();
 
+	mac_addr[0] |= 0x02; /* force LAA bit */
+
 	mac_addr[3] = entropy >> 8;
 	mac_addr[4] = entropy >> 16;
-	/* Locally administered, unicast */
-	mac_addr[5] = ((entropy >> 0) & 0xfc) | 0x02;
+	mac_addr[5] = entropy >> 0;
 }
 #elif defined(CONFIG_ETH_MCUX_0_UNIQUE_MAC)
 static void generate_mac(u8_t *mac_addr)
@@ -770,10 +771,11 @@ static void generate_mac(u8_t *mac_addr)
 	u32_t id = SIM->UIDH ^ SIM->UIDMH ^ SIM->UIDML ^ SIM->UIDL;
 #endif
 
+	mac_addr[0] |= 0x02; /* force LAA bit */
+
 	mac_addr[3] = id >> 8;
 	mac_addr[4] = id >> 16;
-	/* Locally administered, unicast */
-	mac_addr[5] = ((id >> 0) & 0xfc) | 0x02;
+	mac_addr[5] = id >> 0;
 }
 #endif
 

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1626,15 +1626,13 @@ static void generate_random_mac(u8_t mac_addr[6])
 
 	entropy = sys_rand32_get();
 
-	/* Atmel's OUI */
-	mac_addr[0] = 0x00;
-	mac_addr[1] = 0x04;
-	mac_addr[2] = 0x25;
+	mac_addr[0] = ATMEL_OUI_B0 | 0x02; /* force LAA bit */
+	mac_addr[1] = ATMEL_OUI_B1;
+	mac_addr[2] = ATMEL_OUI_B2;
 
 	mac_addr[3] = entropy >> 8;
 	mac_addr[4] = entropy >> 16;
-	/* Locally administered, unicast */
-	mac_addr[5] = ((entropy >> 0) & 0xfc) | 0x02;
+	mac_addr[5] = entropy >> 0;
 }
 #endif
 

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -12,6 +12,10 @@
 
 #include <zephyr/types.h>
 
+#define ATMEL_OUI_B0 0x00
+#define ATMEL_OUI_B1 0x04
+#define ATMEL_OUI_B2 0x25
+
 /* This option enables support to push multiple packets to the DMA engine.
  * This currently doesn't work given the current version of net_pkt or
  * net_buf does not allowed access from multiple threads. This option is

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -359,10 +359,11 @@ static void generate_mac(u8_t *mac_addr)
 
 	entropy = sys_rand32_get();
 
-	mac_addr[3] = entropy >> 8;
-	mac_addr[4] = entropy >> 16;
-	/* Locally administered, unicast */
-	mac_addr[5] = ((entropy >> 0) & 0xfc) | 0x02;
+	mac_addr[0] |= 0x02; /* force LAA bit */
+
+	mac_addr[3] = entropy >> 16;
+	mac_addr[4] = entropy >> 8;
+	mac_addr[5] = entropy >> 0;
 }
 #endif
 
@@ -497,10 +498,9 @@ static struct eth_stm32_hal_dev_data eth0_data = {
 		},
 	},
 	.mac_addr = {
-		/* ST's OUI */
-		0x00,
-		0x80,
-		0xE1,
+		ST_OUI_B0,
+		ST_OUI_B1,
+		ST_OUI_B2,
 #if !defined(CONFIG_ETH_STM32_HAL_RANDOM_MAC)
 		CONFIG_ETH_STM32_HAL_MAC3,
 		CONFIG_ETH_STM32_HAL_MAC4,

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -9,6 +9,10 @@
 #include <kernel.h>
 #include <zephyr/types.h>
 
+#define ST_OUI_B0 0x00
+#define ST_OUI_B1 0x80
+#define ST_OUI_B2 0xE1
+
 #define ETH_STM32_HAL_MTU NET_ETH_MTU
 #define ETH_STM32_HAL_FRAME_SIZE_MAX (ETH_STM32_HAL_MTU + 18)
 
@@ -46,4 +50,3 @@ struct eth_stm32_hal_dev_data {
 	((struct eth_stm32_hal_dev_data *)(dev)->driver_data)
 
 #endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_STM32_HAL_PRIV_H_ */
-


### PR DESCRIPTION
When randomly generating MAC addresses they will always be
locally administrated addresses, so the LAA bit should be set.
The LAA bit is the 2nd bit of the 1st byte of the MAC address
not the 2nd bit of the 4th byte.

Fixes:  #16452