### PR TITLE
Bluetooth: controller: legacy: Ensure that a `case` statement is present

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -12712,7 +12712,7 @@ void ll_rx_mem_release(void **node_rx)
 					break;
 				}
 			}
-			/* passthrough */
+			/* fall through */
 		case NODE_RX_TYPE_DC_PDU:
 #endif /* CONFIG_BT_CONN */
 
@@ -12761,6 +12761,13 @@ void ll_rx_mem_release(void **node_rx)
 		case NODE_RX_TYPE_MESH_REPORT:
 #endif /* CONFIG_BT_HCI_MESH_EXT */
 
+		/* fall through */
+
+		/* Ensure that at least one 'case' statement is present for this
+		 * code block.
+		 */
+		case NODE_RX_TYPE_NONE:
+			LL_ASSERT(_node_rx_free->hdr.type != NODE_RX_TYPE_NONE);
 			mem_release(_node_rx_free,
 				    &_radio.pkt_rx_data_free);
 			break;


### PR DESCRIPTION
When compiling a sample like a beacon, none of the `if defined()`
statements in the switch case are actually compiled in, so the compiler
complains of an orphan mem_release();break; sequence.
Add a type that we know will always be compiled in in order to avoid
this issue.

Relates to commit 76bfea7cf90d ("Bluetooth: controller: Ensure that a
`case` statement is present").

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>
Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>