### PR TITLE
drivers/sensor: lis2dw12: fix for wrong gpio_callback handling

### DIFF
--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -112,6 +112,7 @@ struct lis2dw12_data {
 	lis2dw12_ctx_t *ctx;
 #ifdef CONFIG_LIS2DW12_TRIGGER
 	struct device *gpio;
+	u8_t gpio_pin;
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t drdy_handler;
 #ifdef CONFIG_LIS2DW12_PULSE

--- a/drivers/sensor/lis2dw12/lis2dw12_trigger.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_trigger.c
@@ -192,11 +192,12 @@ static void lis2dw12_gpio_callback(struct device *dev,
 {
 	struct lis2dw12_data *lis2dw12 =
 		CONTAINER_OF(cb, struct lis2dw12_data, gpio_cb);
-	const struct lis2dw12_device_config *cfg = dev->config->config_info;
 
-	ARG_UNUSED(pins);
+	if ((pins & BIT(lis2dw12->gpio_pin)) == 0U) {
+		return;
+	}
 
-	gpio_pin_disable_callback(dev, cfg->int_gpio_pin);
+	gpio_pin_disable_callback(dev, lis2dw12->gpio_pin);
 
 #if defined(CONFIG_LIS2DW12_TRIGGER_OWN_THREAD)
 	k_sem_give(&lis2dw12->gpio_sem);
@@ -256,6 +257,8 @@ int lis2dw12_init_interrupt(struct device *dev)
 	lis2dw12->work.handler = lis2dw12_work_cb;
 	lis2dw12->dev = dev;
 #endif /* CONFIG_LIS2DW12_TRIGGER_OWN_THREAD */
+
+	lis2dw12->gpio_pin = cfg->int_gpio_pin;
 
 	ret = gpio_pin_configure(lis2dw12->gpio, cfg->int_gpio_pin,
 			   GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |


### PR DESCRIPTION
It seems that gpio_pin_disable_callback() has never been working
for that sensor as it was expected. We used there argument 'dev'
as its own (lis2dw12) device pointer. While this argument is a
gpio_port device pointer not lis2dw12 sensor device pointer. So
cfg->int_gpio_pin always tries to disable callback for some random
pin read from accidental data sector. It was working only because
current implementation triggers interrupt on rising edge not on static
level (high/low) so there is always only 1 edge during accelerometer
event and not working interrupt callback disabling was not visible.

Signed-off-by: Michał Oleszczyk <oleszczyk.m@gmail.com>