### PR TITLE
[TOPIC-GPIO] Handle logical interrupt setting in common layer

### DIFF
--- a/drivers/gpio/gpio_altera_nios2.c
+++ b/drivers/gpio/gpio_altera_nios2.c
@@ -27,6 +27,12 @@ struct gpio_nios2_config {
 	config_func_t config_func;
 };
 
+/* Driver data */
+struct gpio_nios2_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
+};
+
 static int gpio_nios2_config_oput_port(struct device *dev, int access_op,
 				       u32_t pin, int flags)
 {
@@ -143,6 +149,8 @@ static const struct gpio_nios2_config gpio_nios2_oput_cfg = {
 	.config_func = gpio_nios2_config_oput_port,
 };
 
+static struct gpio_nios2_data gpio_nios2_oput_data;
+
 /**
  * @brief Initialization function of PIO
  *
@@ -155,7 +163,8 @@ static int gpio_nios2_oput_init(struct device *dev)
 }
 
 DEVICE_AND_API_INIT(gpio_nios2_oput, CONFIG_GPIO_ALTERA_NIOS2_OUTPUT_DEV_NAME,
-		    gpio_nios2_oput_init, NULL, &gpio_nios2_oput_cfg,
+		    gpio_nios2_oput_init, &gpio_nios2_oput_data,
+		    &gpio_nios2_oput_cfg,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_nios2_drv_api_funcs);
 

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -18,6 +18,8 @@
 #include "gpio_utils.h"
 
 struct gpio_cc13xx_cc26xx_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	sys_slist_t callbacks;
 	u32_t pin_callback_enables;
 };

--- a/drivers/gpio/gpio_cc2650.c
+++ b/drivers/gpio/gpio_cc2650.c
@@ -15,6 +15,8 @@
 
 
 struct gpio_cc2650_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	u32_t pin_callback_enables;
 	sys_slist_t callbacks;
 };

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -33,6 +33,8 @@ struct gpio_cc32xx_config {
 };
 
 struct gpio_cc32xx_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	/* list of registered callbacks */
 	sys_slist_t callbacks;
 	/* callback enable pin bitmask */

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -34,6 +34,8 @@ struct gpio_cmsdk_ahb_cfg {
 };
 
 struct gpio_cmsdk_ahb_dev_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	/* list of callbacks */
 	sys_slist_t gpio_cb;
 };

--- a/drivers/gpio/gpio_dw.h
+++ b/drivers/gpio/gpio_dw.h
@@ -32,6 +32,8 @@ struct gpio_dw_config {
 };
 
 struct gpio_dw_runtime {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	u32_t base_addr;
 #ifdef CONFIG_GPIO_DW_CLOCK_GATE
 	struct device *clock;

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -21,6 +21,8 @@
 #include "gpio_utils.h"
 
 struct gpio_esp32_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	struct device *pinmux;
 
 	struct {

--- a/drivers/gpio/gpio_ht16k33.c
+++ b/drivers/gpio/gpio_ht16k33.c
@@ -29,6 +29,8 @@ struct gpio_ht16k33_cfg {
 };
 
 struct gpio_ht16k33_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	struct device *parent;
 	sys_slist_t callbacks;
 };

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -17,6 +17,8 @@ struct imx_gpio_config {
 };
 
 struct imx_gpio_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	/* port ISR callback routine address */
 	sys_slist_t callbacks;
 	/* pin callback routine enable flags, by pin number */

--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -103,6 +103,8 @@ struct gpio_intel_apl_config {
 };
 
 struct gpio_intel_apl_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	/* Pad base address */
 	u32_t		pad_base;
 

--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -22,6 +22,8 @@ static const u32_t valid_ctrl_masks[NUM_MCHP_GPIO_PORTS] = {
 };
 
 struct gpio_xec_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	/* port ISR callback routine address */
 	sys_slist_t callbacks;
 	/* pin callback routine enable flags, by pin number */

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -32,6 +32,8 @@ struct gpio_mcux_lpc_config {
 };
 
 struct gpio_mcux_lpc_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	/* port ISR callback routine address */
 	sys_slist_t callbacks;
 	/* pin callback routine enable flags, by pin number */

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -11,7 +11,8 @@
 #include "gpio_utils.h"
 
 struct gpio_nrfx_data {
-	struct gpio_driver_data general;
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	sys_slist_t callbacks;
 
 	/* Mask holding information about which pins have been configured to
@@ -33,9 +34,6 @@ struct gpio_nrfx_cfg {
 	NRF_GPIO_Type *port;
 	u8_t port_num;
 };
-
-static int gpio_nrfx_pin_interrupt_configure(struct device *port, u32_t pin,
-					     unsigned int flags);
 
 static inline struct gpio_nrfx_data *get_port_data(struct device *port)
 {
@@ -129,7 +127,6 @@ static int gpio_nrfx_config(struct device *port, int access_op,
 			    u32_t pin, int flags)
 {
 	NRF_GPIO_Type *reg = get_port_cfg(port)->port;
-	struct gpio_nrfx_data *data = get_port_data(port);
 	nrf_gpio_pin_pull_t pull;
 	nrf_gpio_pin_drive_t drive;
 	nrf_gpio_pin_dir_t dir;
@@ -195,8 +192,6 @@ static int gpio_nrfx_config(struct device *port, int access_op,
 	}
 
 	for (u8_t curr_pin = from_pin; curr_pin <= to_pin; ++curr_pin) {
-		int res;
-
 		if ((flags & GPIO_OUTPUT) != 0) {
 			if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0) {
 				nrf_gpio_port_out_set(reg, BIT(curr_pin));
@@ -208,14 +203,6 @@ static int gpio_nrfx_config(struct device *port, int access_op,
 		nrf_gpio_cfg(NRF_GPIO_PIN_MAP(get_port_cfg(port)->port_num,
 					      curr_pin),
 			     dir, input, pull, drive, NRF_GPIO_PIN_NOSENSE);
-
-		WRITE_BIT(data->general.invert, curr_pin,
-			  flags & GPIO_ACTIVE_LOW);
-
-		res = gpio_nrfx_pin_interrupt_configure(port, curr_pin, flags);
-		if (res != 0) {
-			return res;
-		}
 	}
 
 	return 0;
@@ -228,9 +215,9 @@ static int gpio_nrfx_write(struct device *port, int access_op,
 	struct gpio_nrfx_data *data = get_port_data(port);
 
 	if (access_op == GPIO_ACCESS_BY_PORT) {
-		nrf_gpio_port_out_write(reg, value ^ data->general.invert);
+		nrf_gpio_port_out_write(reg, value ^ data->common.invert);
 	} else {
-		if ((value > 0) ^ ((BIT(pin) & data->general.invert) != 0)) {
+		if ((value > 0) ^ ((BIT(pin) & data->common.invert) != 0)) {
 			nrf_gpio_port_out_set(reg, BIT(pin));
 		} else {
 			nrf_gpio_port_out_clear(reg, BIT(pin));
@@ -249,7 +236,7 @@ static int gpio_nrfx_read(struct device *port, int access_op,
 	u32_t dir = nrf_gpio_port_dir_read(reg);
 	u32_t port_in = nrf_gpio_port_in_read(reg) & ~dir;
 	u32_t port_out = nrf_gpio_port_out_read(reg) & dir;
-	u32_t port_val = (port_in | port_out) ^ data->general.invert;
+	u32_t port_val = (port_in | port_out) ^ data->common.invert;
 
 	if (access_op == GPIO_ACCESS_BY_PORT) {
 		*value = port_val;
@@ -311,13 +298,13 @@ static int gpio_nrfx_port_toggle_bits(struct device *port, u32_t mask)
 }
 
 static int gpio_nrfx_pin_interrupt_configure(struct device *port,
-		unsigned int pin, unsigned int flags)
+		unsigned int pin, enum gpio_int_mode mode,
+		enum gpio_int_trig trig)
 {
 	struct gpio_nrfx_data *data = get_port_data(port);
 	u32_t abs_pin = NRF_GPIO_PIN_MAP(get_port_cfg(port)->port_num, pin);
 
-	if (((flags & GPIO_INT_ENABLE) != 0) &&
-	    ((flags & GPIO_INT_EDGE) != 0) &&
+	if ((mode == GPIO_INT_MODE_EDGE) &&
 	    (nrf_gpio_pin_dir_get(abs_pin) == NRF_GPIO_PIN_DIR_OUTPUT)) {
 		/*
 		 * The pin's output value as specified in the GPIO will be
@@ -328,19 +315,11 @@ static int gpio_nrfx_pin_interrupt_configure(struct device *port,
 		return -ENOTSUP;
 	}
 
-	WRITE_BIT(data->pin_int_en, pin, flags & GPIO_INT_ENABLE);
-	WRITE_BIT(data->int_en, pin, true);
-	WRITE_BIT(data->trig_edge, pin, flags & GPIO_INT_EDGE);
-	WRITE_BIT(data->double_edge, pin, (flags & GPIO_INT_LOW_0) &&
-					  (flags & GPIO_INT_HIGH_1));
-
-	bool active_high = ((flags & GPIO_INT_HIGH_1) != 0);
-
-	if (((flags & GPIO_INT_LEVELS_LOGICAL) != 0) &&
-	    ((data->general.invert & BIT(pin)) != 0)) {
-		active_high = !active_high;
-	}
-	WRITE_BIT(data->int_active_level, pin, active_high);
+	WRITE_BIT(data->pin_int_en, pin, mode != GPIO_INT_MODE_DISABLED);
+	WRITE_BIT(data->int_en, pin, mode != GPIO_INT_MODE_DISABLED);
+	WRITE_BIT(data->trig_edge, pin, mode == GPIO_INT_MODE_EDGE);
+	WRITE_BIT(data->double_edge, pin, trig == GPIO_INT_TRIG_BOTH);
+	WRITE_BIT(data->int_active_level, pin, trig == GPIO_INT_TRIG_HIGH);
 
 	return gpiote_pin_int_cfg(port, pin);
 }

--- a/drivers/gpio/gpio_pcal9535a.h
+++ b/drivers/gpio/gpio_pcal9535a.h
@@ -40,6 +40,9 @@ union gpio_pcal9535a_port_data {
 
 /** Runtime driver data */
 struct gpio_pcal9535a_drv_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
+
 	/** Master I2C device */
 	struct device *i2c_master;
 

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -26,6 +26,8 @@ struct gpio_rv32m1_config {
 };
 
 struct gpio_rv32m1_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	/* port ISR callback routine address */
 	sys_slist_t callbacks;
 	/* pin callback routine enable flags, by pin number */

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -22,7 +22,8 @@ struct gpio_sam_config {
 };
 
 struct gpio_sam_runtime {
-	struct gpio_driver_data general;
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	sys_slist_t cb;
 };
 
@@ -33,13 +34,9 @@ struct gpio_sam_runtime {
 
 #define GPIO_SAM_ALL_PINS    0xFFFFFFFF
 
-static int gpio_sam_port_interrupt_configure(struct device *dev, u32_t mask,
-					     unsigned int flags);
-
 static int gpio_sam_port_configure(struct device *dev, u32_t mask, int flags)
 {
 	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
-	struct gpio_sam_runtime * const dev_data = DEV_DATA(dev);
 	Pio * const pio = cfg->regs;
 
 	if (flags & GPIO_SINGLE_ENDED) {
@@ -87,12 +84,6 @@ static int gpio_sam_port_configure(struct device *dev, u32_t mask, int flags)
 
 	/* Note: Input is always enabled. */
 
-	if (flags & GPIO_ACTIVE_LOW) {
-		dev_data->general.invert |= mask;
-	} else {
-		dev_data->general.invert &= ~mask;
-	}
-
 	/* Setup Pull-up resistor. */
 	if (flags & GPIO_PULL_UP) {
 		/* Enable pull-up. */
@@ -129,9 +120,7 @@ static int gpio_sam_port_configure(struct device *dev, u32_t mask, int flags)
 	/* Enable the PIO to control the pin (instead of a peripheral). */
 	pio->PIO_PER = mask;
 
-	int ret = gpio_sam_port_interrupt_configure(dev, mask, flags);
-
-	return ret;
+	return 0;
 }
 
 static int gpio_sam_config(struct device *dev, int access_op, u32_t pin,
@@ -256,10 +245,10 @@ static int gpio_sam_port_toggle_bits(struct device *dev, u32_t mask)
 }
 
 static int gpio_sam_port_interrupt_configure(struct device *dev, u32_t mask,
-					     unsigned int flags)
+					     enum gpio_int_mode mode,
+					     enum gpio_int_trig trig)
 {
 	const struct gpio_sam_config * const cfg = DEV_CFG(dev);
-	struct gpio_sam_runtime * const dev_data = DEV_DATA(dev);
 	Pio * const pio = cfg->regs;
 
 	/* Disable the interrupt. */
@@ -267,13 +256,13 @@ static int gpio_sam_port_interrupt_configure(struct device *dev, u32_t mask,
 	/* Disable additional interrupt modes. */
 	pio->PIO_AIMDR = mask;
 
-	if (!((flags & GPIO_INT_LOW_0) && (flags & GPIO_INT_HIGH_1))) {
+	if (trig != GPIO_INT_TRIG_BOTH) {
 		/* Enable additional interrupt modes to support single
 		 * edge/level detection.
 		 */
 		pio->PIO_AIMER = mask;
 
-		if (flags & GPIO_INT_EDGE) {
+		if (mode == GPIO_INT_MODE_EDGE) {
 			pio->PIO_ESR = mask;
 		} else {
 			pio->PIO_LSR = mask;
@@ -281,14 +270,10 @@ static int gpio_sam_port_interrupt_configure(struct device *dev, u32_t mask,
 
 		u32_t rising_edge;
 
-		if (flags & GPIO_INT_HIGH_1) {
+		if (trig == GPIO_INT_TRIG_HIGH) {
 			rising_edge = mask;
 		} else {
 			rising_edge = ~mask;
-		}
-
-		if (flags & GPIO_INT_LEVELS_LOGICAL) {
-			rising_edge ^= dev_data->general.invert & mask;
 		}
 
 		/* Set to high-level or rising edge. */
@@ -297,7 +282,7 @@ static int gpio_sam_port_interrupt_configure(struct device *dev, u32_t mask,
 		pio->PIO_FELLSR = ~rising_edge & mask;
 	}
 
-	if (flags & GPIO_INT_ENABLE) {
+	if (mode != GPIO_INT_MODE_DISABLED) {
 		/* Clear any pending interrupts */
 		(void)pio->PIO_ISR;
 		/* Enable the interrupt. */
@@ -308,9 +293,10 @@ static int gpio_sam_port_interrupt_configure(struct device *dev, u32_t mask,
 }
 
 static int gpio_sam_pin_interrupt_configure(struct device *dev,
-		unsigned int pin, unsigned int flags)
+		unsigned int pin, enum gpio_int_mode mode,
+		enum gpio_int_trig trig)
 {
-	return gpio_sam_port_interrupt_configure(dev, BIT(pin), flags);
+	return gpio_sam_port_interrupt_configure(dev, BIT(pin), mode, trig);
 }
 
 static void gpio_sam_isr(void *arg)

--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -20,6 +20,8 @@ struct gpio_sam0_config {
 };
 
 struct gpio_sam0_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 #ifdef CONFIG_SAM0_EIC
 	sys_slist_t callbacks;
 #endif

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -47,6 +47,8 @@ struct gpio_sifive_config {
 };
 
 struct gpio_sifive_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	/* list of callbacks */
 	sys_slist_t cb;
 };

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -20,6 +20,8 @@ struct gpio_stellaris_config {
 };
 
 struct gpio_stellaris_runtime {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	sys_slist_t cb;
 };
 

--- a/drivers/gpio/gpio_stm32.h
+++ b/drivers/gpio/gpio_stm32.h
@@ -188,6 +188,8 @@ struct gpio_stm32_config {
  * @brief driver data
  */
 struct gpio_stm32_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	/* Enabled INT pins generating a cb */
 	u32_t cb_pins;
 	/* user ISR cb */

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -33,6 +33,8 @@ struct gpio_sx1509b_pin_state {
 
 /** Runtime driver data */
 struct gpio_sx1509b_drv_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	struct device *i2c_master;
 	struct gpio_sx1509b_pin_state pin_state;
 	struct k_sem lock;

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -543,6 +543,41 @@ static inline int z_impl_gpio_disable_callback(struct device *port,
  */
 
 /**
+ * @brief Configure pin interrupt.
+ *
+ * @note This function can also be used to configure interrupts on pins
+ *       not controlled directly by the GPIO module. That is, pins which are
+ *       routed to other modules such as I2C, SPI, UART.
+ *
+ * @param port Pointer to device structure for the driver instance.
+ * @param pin Pin number.
+ * @param flags Interrupt configuration flags as defined by GPIO_INT_*.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOTSUP If any of the configuration options is not supported.
+ * @retval -EINVAL  Invalid argument.
+ * @retval -EBUSY   Interrupt line required to configure pin interrupt is
+ *                  already in use.
+ */
+__syscall int gpio_pin_interrupt_configure(struct device *port,
+		unsigned int pin, unsigned int flags);
+
+static inline int z_impl_gpio_pin_interrupt_configure(struct device *port,
+		unsigned int pin, unsigned int flags)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->driver_api;
+
+	__ASSERT(pin < GPIO_MAX_PINS_PER_PORT, "Invalid pin number");
+
+	__ASSERT(((flags & GPIO_INT_ENABLE) == 0) ||
+		 ((flags & (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1)) != 0),
+		 "At least one of GPIO_INT_LOW_0, GPIO_INT_HIGH_1 has to be "
+		 "enabled.");
+	return api->pin_interrupt_configure(port, pin, flags);
+}
+
+/**
  * @brief Configure a single pin.
  *
  * @param port Pointer to device structure for the driver instance.
@@ -981,41 +1016,6 @@ static inline int gpio_pin_read(struct device *port, u32_t pin,
 				u32_t *value)
 {
 	return gpio_read(port, GPIO_ACCESS_BY_PIN, pin, value);
-}
-
-/**
- * @brief Configure pin interrupt.
- *
- * @note This function can also be used to configure interrupts on pins
- *       not controlled directly by the GPIO module. That is, pins which are
- *       routed to other modules such as I2C, SPI, UART.
- *
- * @param port Pointer to device structure for the driver instance.
- * @param pin Pin number.
- * @param flags Interrupt configuration flags as defined by GPIO_INT_*.
- *
- * @retval 0 If successful.
- * @retval -ENOTSUP If any of the configuration options is not supported.
- * @retval -EINVAL  Invalid argument.
- * @retval -EBUSY   Interrupt line required to configure pin interrupt is
- *                  already in use.
- */
-__syscall int gpio_pin_interrupt_configure(struct device *port,
-		unsigned int pin, unsigned int flags);
-
-static inline int z_impl_gpio_pin_interrupt_configure(struct device *port,
-		unsigned int pin, unsigned int flags)
-{
-	const struct gpio_driver_api *api =
-		(const struct gpio_driver_api *)port->driver_api;
-
-	__ASSERT(pin < GPIO_MAX_PINS_PER_PORT, "Invalid pin number");
-
-	__ASSERT(((flags & GPIO_INT_ENABLE) == 0) ||
-		 ((flags & (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1)) != 0),
-		 "At least one of GPIO_INT_LOW_0, GPIO_INT_HIGH_1 has to be "
-		 "enabled.");
-	return api->pin_interrupt_configure(port, pin, flags);
 }
 
 /**

--- a/include/drivers/gpio/gpio_mmio32.h
+++ b/include/drivers/gpio/gpio_mmio32.h
@@ -17,6 +17,8 @@ struct gpio_mmio32_config {
 };
 
 struct gpio_mmio32_context {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
 	const struct gpio_mmio32_config *config;
 	u32_t invert; /* Mask of 'reg' bits that should be inverted */
 };


### PR DESCRIPTION
Move handling of inverting of flags for gpio_pin_interrupt_configure to common code so drivers don't have to do it.