### PR TITLE
[TOPIC-GPIO]: Introduce helper functions for irq flags

### DIFF
--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -272,9 +272,9 @@ static int gpio_gecko_pin_interrupt_configure(struct device *dev,
 	bool rising_edge;
 	bool falling_edge;
 
-	if ((flags & GPIO_INT_ENABLE) != 0) {
+	if (gpio_flags_int_enabled(flags)) {
 		/* Interrupt on static level is not supported by the hardware */
-		if ((flags & GPIO_INT_EDGE) == 0) {
+		if (gpio_flags_int_edge(flags)) {
 			return -ENOTSUP;
 		}
 

--- a/drivers/gpio/gpio_utils.h
+++ b/drivers/gpio/gpio_utils.h
@@ -11,6 +11,7 @@
 #ifndef ZEPHYR_DRIVERS_GPIO_GPIO_UTILS_H_
 #define ZEPHYR_DRIVERS_GPIO_GPIO_UTILS_H_
 
+#include <drivers/gpio.h>
 
 /**
  * @brief Generic function to insert or remove a callback from a callback list
@@ -62,6 +63,53 @@ static inline void gpio_fire_callbacks(sys_slist_t *list,
 			cb->handler(port, cb, pins);
 		}
 	}
+}
+
+static inline bool gpio_flags_int_enabled(int flags)
+{
+	return (flags & GPIO_INT_ENABLE) == GPIO_INT_ENABLE;
+}
+
+static inline bool gpio_flags_int_disabled(int flags)
+{
+	return (flags & GPIO_INT_ENABLE) == 0;
+}
+
+static inline bool gpio_flags_int_edge(int flags)
+{
+	return (flags & GPIO_INT_EDGE) == GPIO_INT_EDGE;
+}
+
+static inline bool gpio_flags_int_edge_both(int flags)
+{
+	return (flags & GPIO_INT_EDGE_BOTH) == GPIO_INT_EDGE_BOTH;
+}
+
+static inline bool gpio_flags_int_edge_rising(int flags)
+{
+	return (flags & GPIO_INT_EDGE_BOTH) == GPIO_INT_EDGE_RISING;
+}
+
+static inline bool gpio_flags_int_edge_falling(int flags)
+{
+	return (flags & GPIO_INT_EDGE_BOTH) == GPIO_INT_EDGE_FALLING;
+}
+
+static inline bool gpio_flags_int_level(int flags)
+{
+	return (flags & GPIO_INT_EDGE) == 0;
+}
+
+static inline bool gpio_flags_int_level_low(int flags)
+{
+	return (flags & (GPIO_INT_LEVEL_LOW|GPIO_INT_LEVEL_HIGH))
+		== GPIO_INT_LEVEL_LOW;
+}
+
+static inline bool gpio_flags_int_level_high(int flags)
+{
+	return (flags & (GPIO_INT_LEVEL_LOW|GPIO_INT_LEVEL_HIGH))
+		== GPIO_INT_LEVEL_HIGH;
 }
 
 #endif /* ZEPHYR_DRIVERS_GPIO_GPIO_UTILS_H_ */

--- a/tests/unit/gpio/CMakeLists.txt
+++ b/tests/unit/gpio/CMakeLists.txt
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+
+project(gpio)
+set(SOURCES main.c)
+list(APPEND INCLUDE tests/unit/gpio drivers/gpio)
+include($ENV{ZEPHYR_BASE}/subsys/testsuite/unittest.cmake)

--- a/tests/unit/gpio/main.c
+++ b/tests/unit/gpio/main.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019 Linaro Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+
+#include <drivers/gpio.h>
+
+#include "gpio_utils.h"
+
+static void gpio_test(void)
+{
+	int flags;
+
+	flags = GPIO_INT_ENABLE;
+	zassert_true(gpio_flags_int_enabled(flags), NULL);
+	zassert_false(gpio_flags_int_disabled(flags), NULL);
+
+	flags = GPIO_INT_DISABLE;
+	zassert_true(gpio_flags_int_disabled(flags), NULL);
+	zassert_false(gpio_flags_int_enabled(flags), NULL);
+
+	flags = GPIO_INT_LEVEL;
+	zassert_true(gpio_flags_int_level(flags), NULL);
+	zassert_false(gpio_flags_int_edge(flags), NULL);
+
+	flags = GPIO_INT_LEVEL_LOW;
+	zassert_true(gpio_flags_int_level_low(flags), NULL);
+	zassert_true(gpio_flags_int_level(flags), NULL);
+	zassert_false(gpio_flags_int_level_high(flags), NULL);
+
+	flags = GPIO_INT_LEVEL_HIGH;
+	zassert_true(gpio_flags_int_level_high(flags), NULL);
+	zassert_true(gpio_flags_int_level(flags), NULL);
+	zassert_false(gpio_flags_int_level_low(flags), NULL);
+
+	flags = GPIO_INT_EDGE;
+	zassert_true(gpio_flags_int_edge(flags), NULL);
+	zassert_false(gpio_flags_int_level(flags), NULL);
+
+	flags = GPIO_INT_EDGE_RISING;
+	zassert_true(gpio_flags_int_edge_rising(flags), NULL);
+	zassert_true(gpio_flags_int_edge(flags), NULL);
+	zassert_false(gpio_flags_int_edge_falling(flags), NULL);
+	zassert_false(gpio_flags_int_edge_both(flags), NULL);
+
+	flags = GPIO_INT_EDGE_FALLING;
+	zassert_true(gpio_flags_int_edge_falling(flags), NULL);
+	zassert_true(gpio_flags_int_edge(flags), NULL);
+	zassert_false(gpio_flags_int_edge_rising(flags), NULL);
+	zassert_false(gpio_flags_int_edge_both(flags), NULL);
+
+	flags = GPIO_INT_EDGE_BOTH;
+	zassert_true(gpio_flags_int_edge_both(flags), NULL);
+	zassert_true(gpio_flags_int_edge(flags), NULL);
+	zassert_false(gpio_flags_int_edge_rising(flags), NULL);
+	zassert_false(gpio_flags_int_edge_falling(flags), NULL);
+}
+
+void test_main(void)
+{
+	ztest_test_suite(gpio_tests,
+		ztest_unit_test(gpio_test)
+	);
+
+	ztest_run_test_suite(gpio_tests);
+}

--- a/tests/unit/gpio/syscalls/device.h
+++ b/tests/unit/gpio/syscalls/device.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2019 Linaro Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Dummy header so we build */

--- a/tests/unit/gpio/syscalls/gpio.h
+++ b/tests/unit/gpio/syscalls/gpio.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2019 Linaro Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Dummy header so we build */

--- a/tests/unit/gpio/testcase.yaml
+++ b/tests/unit/gpio/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  gpio:
+    timeout: 1
+    type: unit


### PR DESCRIPTION
Add some helper functions to make things a bit more readable and less error prone.