### PR TITLE
Bluetooth: GATT: Add initializer for GATT CCC

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -617,24 +617,36 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, const void *buf,
 			       u16_t len, u16_t offset, u8_t flags);
 
-/** @def BT_GATT_CCC_MANAGED
- *  @brief Managed Client Characteristic Configuration Declaration Macro.
+
+/** @def BT_GATT_CCC_INITIALIZER
+ *  @brief Initialize Client Characteristic Configuration Declaration Macro.
  *
- *  Helper macro to declare a Managed CCC attribute.
+ *  Helper macro to initialize a Managed CCC attribute value.
  *
  *  @param _changed Configuration changed callback.
  *  @param _write Configuration write callback.
  *  @param _match Configuration match callback.
  */
-#define BT_GATT_CCC_MANAGED(_changed, _write, _match)			\
-	BT_GATT_ATTRIBUTE(BT_UUID_GATT_CCC,				\
-			BT_GATT_PERM_READ | BT_GATT_PERM_WRITE,		\
-			bt_gatt_attr_read_ccc, bt_gatt_attr_write_ccc,	\
-			(&(struct _bt_gatt_ccc) {			\
-				.cfg = {},				\
-				.cfg_changed = _changed,		\
-				.cfg_write = _write,			\
-				.cfg_match = _match }))
+#define BT_GATT_CCC_INITIALIZER(_changed, _write, _match) \
+	{                                            \
+		.cfg = {},                           \
+		.cfg_changed = _changed,             \
+		.cfg_write = _write,                 \
+		.cfg_match = _match,                 \
+	}
+
+/** @def BT_GATT_CCC_MANAGED
+ *  @brief Managed Client Characteristic Configuration Declaration Macro.
+ *
+ *  Helper macro to declare a Managed CCC attribute.
+ *
+ *  @param _ccc CCC attribute user data, shall point to a _bt_gatt_ccc.
+ */
+#define BT_GATT_CCC_MANAGED(_ccc)                                       \
+	BT_GATT_ATTRIBUTE(BT_UUID_GATT_CCC,                             \
+			BT_GATT_PERM_READ | BT_GATT_PERM_WRITE,         \
+			bt_gatt_attr_read_ccc, bt_gatt_attr_write_ccc,  \
+			_ccc)
 
 /** @def BT_GATT_CCC
  *  @brief Client Characteristic Configuration Declaration Macro.
@@ -643,8 +655,9 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
  *
  *  @param _cfg_changed Configuration changed callback.
  */
-#define BT_GATT_CCC(_cfg_changed)					\
-	BT_GATT_CCC_MANAGED(_cfg_changed, NULL, NULL)
+#define BT_GATT_CCC(_cfg_changed)                                      \
+	BT_GATT_CCC_MANAGED((&(struct _bt_gatt_ccc)                    \
+		BT_GATT_CCC_INITIALIZER(_cfg_changed, NULL, NULL)))
 
 /** @brief Read Characteristic Extended Properties Attribute helper
  *

--- a/subsys/bluetooth/mesh/proxy.c
+++ b/subsys/bluetooth/mesh/proxy.c
@@ -637,6 +637,9 @@ static bool prov_ccc_write(struct bt_conn *conn,
 }
 
 /* Mesh Provisioning Service Declaration */
+static struct _bt_gatt_ccc prov_ccc =
+	BT_GATT_CCC_INITIALIZER(prov_ccc_changed, prov_ccc_write, NULL);
+
 static struct bt_gatt_attr prov_attrs[] = {
 	BT_GATT_PRIMARY_SERVICE(BT_UUID_MESH_PROV),
 
@@ -648,7 +651,7 @@ static struct bt_gatt_attr prov_attrs[] = {
 	BT_GATT_CHARACTERISTIC(BT_UUID_MESH_PROV_DATA_OUT,
 			       BT_GATT_CHRC_NOTIFY, BT_GATT_PERM_NONE,
 			       NULL, NULL, NULL),
-	BT_GATT_CCC_MANAGED(prov_ccc_changed, prov_ccc_write, NULL),
+	BT_GATT_CCC_MANAGED(&prov_ccc),
 };
 
 static struct bt_gatt_service prov_svc = BT_GATT_SERVICE(prov_attrs);
@@ -752,6 +755,9 @@ static bool proxy_ccc_write(struct bt_conn *conn,
 }
 
 /* Mesh Proxy Service Declaration */
+static struct _bt_gatt_ccc proxy_ccc =
+	BT_GATT_CCC_INITIALIZER(proxy_ccc_changed, proxy_ccc_write, NULL);
+
 static struct bt_gatt_attr proxy_attrs[] = {
 	BT_GATT_PRIMARY_SERVICE(BT_UUID_MESH_PROXY),
 
@@ -764,7 +770,7 @@ static struct bt_gatt_attr proxy_attrs[] = {
 			       BT_GATT_CHRC_NOTIFY,
 			       BT_GATT_PERM_NONE,
 			       NULL, NULL, NULL),
-	BT_GATT_CCC_MANAGED(proxy_ccc_changed, proxy_ccc_write, NULL),
+	BT_GATT_CCC_MANAGED(&proxy_ccc),
 };
 
 static struct bt_gatt_service proxy_svc = BT_GATT_SERVICE(proxy_attrs);


### PR DESCRIPTION
Add GATT initializer macro for GATT CCC and allow the
BT_GATT_CCC_MANAGED to accept an already initialized CCC user data.
This allows the application to specify the storage location of the CCC
user data.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>