### PR TITLE
nvs: fix overwriting with truncated data

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -804,7 +804,8 @@ ssize_t nvs_write(struct nvs_fs *fs, u16_t id, const void *data, size_t len)
 				 */
 				return 0;
 			}
-		} else {
+		} else if (len == wlk_ate.len) {
+			/* do not try to compare if lengths are not equal */
 			/* compare the data and if equal return 0 */
 			rc = nvs_flash_block_cmp(fs, rd_addr, data, len);
 			if (rc <= 0) {


### PR DESCRIPTION
When overwriting an NVS item with data that was a truncated version of
the existing data, the "is this already saved" logic was ignoring the
differing lengths and not saving the new item because the data matched.

Fixes #19250

Signed-off-by: Justin Brzozoski <justin.brzozoski@signal-fire.com>