### PR TITLE
gpio: stm32: support disabling and reenabling interrupts on gpio pin

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -188,7 +188,7 @@ int gpio_stm32_configure(u32_t *base_addr, int pin, int conf, int altf)
 /**
  * @brief Enable EXTI of the specific line
  */
-const int gpio_stm32_enable_int(int port, int pin)
+static int gpio_stm32_enable_int(int port, int pin)
 {
 #if defined(CONFIG_SOC_SERIES_STM32F2X) ||     \
 	defined(CONFIG_SOC_SERIES_STM32F3X) || \

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -237,6 +237,44 @@ static int gpio_stm32_set_exti_source(int port, int pin)
 }
 
 /**
+ * @brief Get enabled GPIO port for EXTI of the specific pin number
+ */
+static int gpio_stm32_get_exti_source(int pin)
+{
+	uint32_t line;
+	int port;
+
+	if (pin > 15) {
+		return -EINVAL;
+	}
+
+	line = gpio_stm32_pin_to_exti_line(pin);
+
+#if defined(CONFIG_SOC_SERIES_STM32F1X)
+	port = LL_GPIO_AF_GetEXTISource(line);
+#elif defined(CONFIG_SOC_SERIES_STM32MP1X)
+	port = LL_EXTI_GetEXTISource(line);
+#elif defined(CONFIG_SOC_SERIES_STM32G0X)
+	port = LL_EXTI_GetEXTISource(line);
+#else
+	port = LL_SYSCFG_GetEXTISource(line);
+#endif
+
+#if defined(CONFIG_SOC_SERIES_STM32L0X) && defined(LL_SYSCFG_EXTI_PORTH)
+	/*
+	 * Ports F and G are not present on some STM32L0 parts, so
+	 * for these parts port H external interrupt is enabled
+	 * by writing value 0x5 instead of 0x7.
+	 */
+	if (port == LL_SYSCFG_EXTI_PORTH) {
+		port = STM32_PORTH;
+	}
+#endif
+
+	return port;
+}
+
+/**
  * @brief Enable EXTI of the specific line
  */
 static int gpio_stm32_enable_int(int port, int pin)
@@ -305,8 +343,11 @@ static int gpio_stm32_config(struct device *dev, int access_op,
 		goto release_lock;
 	}
 
-	if (IS_ENABLED(CONFIG_EXTI_STM32) && (flags & GPIO_INT) != 0) {
+	if (!IS_ENABLED(CONFIG_EXTI_STM32)) {
+		goto release_lock;
+	}
 
+	if (flags & GPIO_INT) {
 		if (stm32_exti_set_callback(pin, cfg->port,
 					    gpio_stm32_isr, dev) != 0) {
 			err = -EBUSY;
@@ -338,7 +379,11 @@ static int gpio_stm32_config(struct device *dev, int access_op,
 			err = -EIO;
 			goto release_lock;
 		}
-
+	} else {
+		if (gpio_stm32_get_exti_source(pin) == cfg->port) {
+			stm32_exti_disable(pin);
+			stm32_exti_unset_callback(pin);
+		}
 	}
 
 release_lock:

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -185,6 +185,57 @@ int gpio_stm32_configure(u32_t *base_addr, int pin, int conf, int altf)
 	return 0;
 }
 
+static inline uint32_t gpio_stm32_pin_to_exti_line(int pin)
+{
+#if defined(CONFIG_SOC_SERIES_STM32L0X) || \
+	defined(CONFIG_SOC_SERIES_STM32F0X)
+	return ((pin % 4 * 4) << 16) | (pin / 4);
+#elif defined(CONFIG_SOC_SERIES_STM32MP1X)
+	return (((pin * 8) % 32) << 16) | (pin / 4);
+#elif defined(CONFIG_SOC_SERIES_STM32G0X)
+	return ((pin & 0x3) << (16 + 3)) | (pin >> 2);
+#else
+	return (0xF << ((pin % 4 * 4) + 16)) | (pin / 4);
+#endif
+}
+
+/**
+ * @brief Set GPIO port as EXTI source for the specific pin number
+ */
+static int gpio_stm32_set_exti_source(int port, int pin)
+{
+	uint32_t line;
+
+	if (pin > 15) {
+		return -EINVAL;
+	}
+
+	line = gpio_stm32_pin_to_exti_line(pin);
+
+#if defined(CONFIG_SOC_SERIES_STM32L0X) && defined(LL_SYSCFG_EXTI_PORTH)
+	/*
+	 * Ports F and G are not present on some STM32L0 parts, so
+	 * for these parts port H external interrupt should be enabled
+	 * by writing value 0x5 instead of 0x7.
+	 */
+	if (port == STM32_PORTH) {
+		port = LL_SYSCFG_EXTI_PORTH;
+	}
+#endif
+
+#if defined(CONFIG_SOC_SERIES_STM32F1X)
+	LL_GPIO_AF_SetEXTISource(port, line);
+#elif defined(CONFIG_SOC_SERIES_STM32MP1X)
+	LL_EXTI_SetEXTISource(port, line);
+#elif defined(CONFIG_SOC_SERIES_STM32G0X)
+	LL_EXTI_SetEXTISource(port, line);
+#else
+	LL_SYSCFG_SetEXTISource(port, line);
+#endif
+
+	return 0;
+}
+
 /**
  * @brief Enable EXTI of the specific line
  */
@@ -212,45 +263,7 @@ static int gpio_stm32_enable_int(int port, int pin)
 	clock_control_on(clk, (clock_control_subsys_t *) &pclken);
 #endif
 
-	uint32_t line;
-
-	if (pin > 15) {
-		return -EINVAL;
-	}
-
-#if defined(CONFIG_SOC_SERIES_STM32L0X) || \
-	defined(CONFIG_SOC_SERIES_STM32F0X)
-	line = ((pin % 4 * 4) << 16) | (pin / 4);
-#elif defined(CONFIG_SOC_SERIES_STM32MP1X)
-	line = (((pin * 8) % 32) << 16) | (pin / 4);
-#elif defined(CONFIG_SOC_SERIES_STM32G0X)
-	line = ((pin & 0x3) << (16 + 3)) | (pin >> 2);
-#else
-	line = (0xF << ((pin % 4 * 4) + 16)) | (pin / 4);
-#endif
-
-#if defined(CONFIG_SOC_SERIES_STM32L0X) && defined(LL_SYSCFG_EXTI_PORTH)
-	/*
-	 * Ports F and G are not present on some STM32L0 parts, so
-	 * for these parts port H external interrupt should be enabled
-	 * by writing value 0x5 instead of 0x7.
-	 */
-	if (port == STM32_PORTH) {
-		port = LL_SYSCFG_EXTI_PORTH;
-	}
-#endif
-
-#if defined(CONFIG_SOC_SERIES_STM32F1X)
-	LL_GPIO_AF_SetEXTISource(port, line);
-#elif defined(CONFIG_SOC_SERIES_STM32MP1X)
-	LL_EXTI_SetEXTISource(port, line);
-#elif defined(CONFIG_SOC_SERIES_STM32G0X)
-	LL_EXTI_SetEXTISource(port, line);
-#else
-	LL_SYSCFG_SetEXTISource(port, line);
-#endif
-
-	return 0;
+	return gpio_stm32_set_exti_source(port, pin);
 }
 
 /**

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -240,9 +240,9 @@ static int gpio_stm32_enable_int(int port, int pin)
 	}
 #endif
 
-#ifdef CONFIG_SOC_SERIES_STM32F1X
+#if defined(CONFIG_SOC_SERIES_STM32F1X)
 	LL_GPIO_AF_SetEXTISource(port, line);
-#elif CONFIG_SOC_SERIES_STM32MP1X
+#elif defined(CONFIG_SOC_SERIES_STM32MP1X)
 	LL_EXTI_SetEXTISource(port, line);
 #elif defined(CONFIG_SOC_SERIES_STM32G0X)
 	LL_EXTI_SetEXTISource(port, line);


### PR DESCRIPTION
Up to now interrupts could be only configured once, with no way to disable them in runtime.

Allow interrupts to be disabled in runtime and then properly reenabled on user request. This allows to ignore interrupts when software is not expecting them.

The improvement over previously reverted patch [1] is that we disable interrupts only when we configure port for which interrupt line was previously selected. This for example prevents to disable interrupts line 2 in case PA2 was previously configured as interrupt source, but we are currently configuring PB2 as output.

Besides we make a small improvement by declaring gpio_stm32_enable_int as static and splitting into smaller functions in order to achieve better readability.

Those patches are a result of previously noticed bug #19177.

[1] 0951ce2 ("gpio: stm32: support disabling and reenabling interrupts on pin")