### PR TITLE
dts: ps2: Fix yaml warning for PS/2

### DIFF
--- a/dts/bindings/ps2/ps2.yaml
+++ b/dts/bindings/ps2/ps2.yaml
@@ -8,8 +8,7 @@ description: >
 
 include: base.yaml
 
-child:
-    bus: ps2
+child-bus: ps2
 
 properties:
     "#address-cells":


### PR DESCRIPTION
Use the new child-bus: bus field in order to remove warning during board configuration 