### PR TITLE
samples: olimex_stm32_e407: fix coverity warning

### DIFF
--- a/samples/boards/olimex_stm32_e407/ccm/src/main.c
+++ b/samples/boards/olimex_stm32_e407/ccm/src/main.c
@@ -101,13 +101,13 @@ void print_var_values(void)
 	printf("ccm_data_var_32 addr: %p value: 0x%08x\n",
 		&ccm_data_var_32, ccm_data_var_32);
 	printf("ccm_data_array  addr: %p size: %d value:\n\t",
-		ccm_data_array, sizeof(ccm_data_array));
+		ccm_data_array, (int)sizeof(ccm_data_array));
 	print_array(ccm_data_array, sizeof(ccm_data_array));
 	printf("\nccm_bss_array addr: %p size: %d value:\n\t",
-		ccm_bss_array, sizeof(ccm_bss_array));
+		ccm_bss_array, (int)sizeof(ccm_bss_array));
 	print_array(ccm_bss_array, sizeof(ccm_bss_array));
 	printf("\nccm_noinit_array addr: %p size: %d value:\n\t",
-		ccm_noinit_array, sizeof(ccm_noinit_array));
+		ccm_noinit_array, (int)sizeof(ccm_noinit_array));
 	print_array(ccm_noinit_array, sizeof(ccm_noinit_array));
 	printf("\n");
 }


### PR DESCRIPTION
Fix a Coverity warning when using %d to print the result
of a sizeof(...)

Since the result of the sizeof() use in the example
will always fit in a int, simply cast the result
to a int so the %d is always correct.

Fixes: #18373

Signed-off-by: Erwin Rol <erwin@erwinrol.com>