### PR TITLE
Bluetooth: Mesh: Fix Clear Procedure start timestamp initialization

### DIFF
--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -666,7 +666,7 @@ static void clear_procedure_start(struct bt_mesh_friend *frnd)
 {
 	BT_DBG("LPN 0x%04x (old) Friend 0x%04x", frnd->lpn, frnd->clear.frnd);
 
-	frnd->clear.start = k_uptime_get_32() + (2 * frnd->poll_to);
+	frnd->clear.start = k_uptime_get_32();
 	frnd->clear.repeat_sec = 1U;
 
 	send_friend_clear(frnd);


### PR DESCRIPTION
The start timestamp was supposed to signify the starting point of the
clear procedure. The code was incorrectly initializing it to the *end*
point of the procedure.

Fixes #19263

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>