### PR TITLE
modules: hal: nordic: Remove dependency on DT from NRF_* mappings

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -44,7 +44,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: ff3265342f2ef97b5abf4ba7d38b8011a45360f3
+      revision: 6a4181a794e71fbf6e9a7c857aaff8e2e7a9602f
       path: modules/hal/nordic
     - name: hal_openisa
       revision: be5c01f86c96500def5079bcc58d2baefdffb6c8


### PR DESCRIPTION
Update the module revision so that the following commit becomes
effective:

* nrfx_config_nrf9160: Remove dependency on DT from NRF_* mappings

---

Requires https://github.com/zephyrproject-rtos/hal_nordic/pull/4 to go in first.