### PR TITLE
usb: allow hardware to handle ZLP for Variable-length Data Stage

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -61,6 +61,7 @@ menuconfig USB_NRF52840
 	depends on SOC_NRF52840
 	select USB_DEVICE_DRIVER
 	select NRFX_USBD
+	select USB_DEVICE_DISABLE_ZLP_EPIN_HANDLING
 	help
 	  nRF52840 USB Device Controller Driver
 

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -79,6 +79,12 @@ config USB_DEVICE_REMOTE_WAKEUP
 	help
 	  This option requires USBD peripheral driver to also support remote wakeup.
 
+config USB_DEVICE_DISABLE_ZLP_EPIN_HANDLING
+	bool
+	help
+	  Stack should not handle ZLP for Variable-length Data Stage
+	  bacause it is taken over by the hardware.
+
 config USB_DEVICE_BOS
 	bool "Enable USB Binary Device Object Store (BOS)"
 

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -245,6 +245,7 @@ static void usb_data_to_host(u16_t len)
 		usb_dev.data_buf += chunk;
 		usb_dev.data_buf_residue -= chunk;
 
+#ifndef CONFIG_USB_DEVICE_DISABLE_ZLP_EPIN_HANDLING
 		/*
 		 * Set ZLP flag when host asks for a bigger length and the
 		 * last chunk is wMaxPacketSize long, to indicate the last
@@ -259,6 +260,7 @@ static void usb_data_to_host(u16_t len)
 				usb_dev.zlp_flag = true;
 			}
 		}
+#endif
 
 	} else {
 		usb_dev.zlp_flag = false;

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -299,10 +299,7 @@ static void usb_handle_control_transfer(u8_t ep,
 		length = sys_le16_to_cpu(setup->wLength);
 		if (length > CONFIG_USB_REQUEST_BUFFER_SIZE) {
 			if (REQTYPE_GET_DIR(setup->bmRequestType)
-			    == REQTYPE_DIR_TO_HOST) {
-				/* Limit wLength */
-				length = CONFIG_USB_REQUEST_BUFFER_SIZE;
-			} else {
+			    != REQTYPE_DIR_TO_HOST) {
 				LOG_ERR("Request buffer too small");
 				usb_dc_ep_set_stall(USB_CONTROL_IN_EP0);
 				usb_dc_ep_set_stall(USB_CONTROL_OUT_EP0);


### PR DESCRIPTION
Allow hardware to handle ZLP for Variable-length Data Stage.

On nRF52840, USB hardware and driver [handle](https://github.com/zephyrproject-rtos/zephyr/blob/master/drivers/usb/device/usb_dc_nrfx.c#L1679) the status stage. When it comes to Variable-length Data Stage nRF52 hardware finishes a transmission with ZLP.

How to test:
Apply the patch below:
```diff
diff --git a/subsys/usb/class/loopback.c b/subsys/usb/class/loopback.c
index 66e2aaf0b8..49f37709f1 100644
--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -144,6 +144,9 @@ static int loopback_vendor_handler(struct usb_setup_packet *setup,
            (setup->bRequest == 0x5c)) {
                LOG_DBG("Device-to-Host, wLength %d, data %p",
                        setup->wLength, *data);
+               if (setup->wLength == 1024) {
+                       *len = 512;
+               }
                return 0;
        }

```
Perform TEST14: e.g. `testusb -v 1 -t 14 -c 1000 -D /dev/bus/usb/005/056`
on the current master nRF52840 device will not able to transmit on the control IN endpoint after first 512 bytes. With this patch, testusb reports `Broken pipe` but device remains full functional.

Alternatively, `cdc_acm_composite` sample can be used as it has a string descriptor exact 64 bytes long.

rebased on #19321