### PR TITLE
tests: timer_api: exclude qemu_x86_coverage

### DIFF
--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   kernel.timer:
     tags: kernel userspace
+    platform_exclude: qemu_x86_coverage
   kernel.timer.tickless:
     build_only: true
     extra_args: CONF_FILE="prj_tickless.conf"


### PR DESCRIPTION
Test keeps failing when coverage is enabled.