### PR TITLE
drivers: counter: nrf_rtc: Fix top value handling

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -346,8 +346,9 @@ void test_multiple_alarms_instance(const char *dev_name)
 
 	k_busy_wait(1.2*counter_ticks_to_us(dev, ticks * 2U));
 	tmp_alarm_cnt = alarm_cnt; /* to avoid passing volatile to the macro */
-	zassert_equal(2, tmp_alarm_cnt, "%s: Counter set alarm failed",
-			dev_name);
+	zassert_equal(2, tmp_alarm_cnt,
+			"%s: Invalid number of callbacks %d (expected: %d)",
+			dev_name, tmp_alarm_cnt, 2);
 	zassert_equal(&alarm_cfg2, clbk_data[0],
 			"%s: Expected different order or callbacks",
 			dev_name);


### PR DESCRIPTION
Top value interrupt was not enabled because channel index was used instead of mask. Additionally, interrupt was enabled only when user callback was provided and not in case there was custom top value and no top callback.