### PR TITLE
Bluetooth: host: Configurable time to run slave conn param update

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -355,9 +355,20 @@ config BT_MAX_PAIRED
 	  default) number is 1.
 
 config BT_CREATE_CONN_TIMEOUT
-        int "Timeout for pending LE Create Connection command in seconds"
-        default 3
-        range 1 65535
+	int "Timeout for pending LE Create Connection command in seconds"
+	default 3
+	range 1 65535
+
+config BT_CONN_PARAM_UPDATE_TIMEOUT
+	int "Peripheral connection parameter update timeout in milliseconds"
+	default 5000
+	range 1 65535
+
+	help
+	  The value is a timeout used by peripheral device to wait until it
+	  starts the connection parameters update procedure to change default
+	  connection parameters. The default value is set to 5s, to comply
+	  with BT protocol specification: Core 4.2 Vol 3, Part C, 9.3.12.2
 
 endif # BT_CONN
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -47,7 +47,7 @@
 #include "settings.h"
 
 /* Peripheral timeout to initialize Connection Parameter Update procedure */
-#define CONN_UPDATE_TIMEOUT  K_SECONDS(5)
+#define CONN_UPDATE_TIMEOUT  K_MSEC(CONFIG_BT_CONN_PARAM_UPDATE_TIMEOUT)
 #define RPA_TIMEOUT          K_SECONDS(CONFIG_BT_RPA_TIMEOUT)
 
 #define HCI_CMD_TIMEOUT      K_SECONDS(10)


### PR DESCRIPTION
Enable possibility to configure time a slave will wait until
start of connection parameters update procedure after BT connection
is established.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>