### PR TITLE
drivers: fix k_thread_create timeout argument

### DIFF
--- a/drivers/console/ipm_console_receiver.c
+++ b/drivers/console/ipm_console_receiver.c
@@ -146,7 +146,7 @@ int ipm_console_receiver_init(struct device *d)
 
 	k_thread_create(&driver_data->rx_thread, config_info->thread_stack,
 			CONFIG_IPM_CONSOLE_STACK_SIZE, ipm_console_thread, d,
-			NULL, NULL, K_PRIO_COOP(IPM_CONSOLE_PRI), 0, 0);
+			NULL, NULL, K_PRIO_COOP(IPM_CONSOLE_PRI), 0, K_NO_WAIT);
 	ipm_set_enabled(ipm, 1);
 
 	return 0;

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -798,7 +798,7 @@ static int cc1200_init(struct device *dev)
 	k_thread_create(&cc1200->rx_thread, cc1200->rx_stack,
 			CONFIG_IEEE802154_CC1200_RX_STACK_SIZE,
 			(k_thread_entry_t)cc1200_rx,
-			dev, NULL, NULL, K_PRIO_COOP(2), 0, 0);
+			dev, NULL, NULL, K_PRIO_COOP(2), 0, K_NO_WAIT);
 
 	LOG_INF("CC1200 initialized");
 

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -1040,7 +1040,7 @@ static int cc2520_init(struct device *dev)
 	k_thread_create(&cc2520->cc2520_rx_thread, cc2520->cc2520_rx_stack,
 			CONFIG_IEEE802154_CC2520_RX_STACK_SIZE,
 			(k_thread_entry_t)cc2520_rx,
-			dev, NULL, NULL, K_PRIO_COOP(2), 0, 0);
+			dev, NULL, NULL, K_PRIO_COOP(2), 0, K_NO_WAIT);
 
 	LOG_INF("CC2520 initialized");
 

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1436,7 +1436,7 @@ static int mcr20a_init(struct device *dev)
 	k_thread_create(&mcr20a->mcr20a_rx_thread, mcr20a->mcr20a_rx_stack,
 			CONFIG_IEEE802154_MCR20A_RX_STACK_SIZE,
 			(k_thread_entry_t)mcr20a_thread_main,
-			dev, NULL, NULL, K_PRIO_COOP(2), 0, 0);
+			dev, NULL, NULL, K_PRIO_COOP(2), 0, K_NO_WAIT);
 
 	return 0;
 }

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -368,7 +368,7 @@ static int nrf5_init(struct device *dev)
 	k_thread_create(&nrf5_radio->rx_thread, nrf5_radio->rx_stack,
 			CONFIG_IEEE802154_NRF5_RX_STACK_SIZE,
 			nrf5_rx_thread, dev, NULL, NULL,
-			K_PRIO_COOP(2), 0, 0);
+			K_PRIO_COOP(2), 0, K_NO_WAIT);
 
 	k_thread_name_set(&nrf5_radio->rx_thread, "802154 RX");
 

--- a/drivers/sensor/bmc150_magn/bmc150_magn_trigger.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn_trigger.c
@@ -143,7 +143,7 @@ int bmc150_magn_init_interrupt(struct device *dev)
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_BMC150_MAGN_TRIGGER_THREAD_STACK,
 			bmc150_magn_thread_main, dev, NULL, NULL,
-			K_PRIO_COOP(10), 0, 0);
+			K_PRIO_COOP(10), 0, K_NO_WAIT);
 
 	data->gpio_drdy = device_get_binding(config->gpio_drdy_dev_name);
 	if (!data->gpio_drdy) {

--- a/drivers/sensor/bmg160/bmg160_trigger.c
+++ b/drivers/sensor/bmg160/bmg160_trigger.c
@@ -235,7 +235,7 @@ int bmg160_trigger_init(struct device *dev)
 	k_sem_init(&bmg160->trig_sem, 0, UINT_MAX);
 	k_thread_create(&bmg160_thread, bmg160_thread_stack,
 			CONFIG_BMG160_THREAD_STACK_SIZE, bmg160_thread_main,
-			dev, NULL, NULL, K_PRIO_COOP(10), 0, 0);
+			dev, NULL, NULL, K_PRIO_COOP(10), 0, K_NO_WAIT);
 
 #elif defined(CONFIG_BMG160_TRIGGER_GLOBAL_THREAD)
 	bmg160->work.handler = bmg160_work_cb;

--- a/drivers/sensor/bmi160/bmi160_trigger.c
+++ b/drivers/sensor/bmi160/bmi160_trigger.c
@@ -289,7 +289,7 @@ int bmi160_trigger_mode_init(struct device *dev)
 	k_thread_create(&bmi160_thread, bmi160_thread_stack,
 			CONFIG_BMI160_THREAD_STACK_SIZE,
 			bmi160_thread_main, dev, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BMI160_THREAD_PRIORITY), 0, 0);
+			K_PRIO_COOP(CONFIG_BMI160_THREAD_PRIORITY), 0, K_NO_WAIT);
 #elif defined(CONFIG_BMI160_TRIGGER_GLOBAL_THREAD)
 	bmi160->work.handler = bmi160_work_handler;
 	bmi160->dev = dev;

--- a/drivers/sensor/fxas21002/fxas21002_trigger.c
+++ b/drivers/sensor/fxas21002/fxas21002_trigger.c
@@ -180,7 +180,7 @@ int fxas21002_trigger_init(struct device *dev)
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_FXAS21002_THREAD_STACK_SIZE,
 			fxas21002_thread_main, dev, 0, NULL,
-			K_PRIO_COOP(CONFIG_FXAS21002_THREAD_PRIORITY), 0, 0);
+			K_PRIO_COOP(CONFIG_FXAS21002_THREAD_PRIORITY), 0, K_NO_WAIT);
 #elif defined(CONFIG_FXAS21002_TRIGGER_GLOBAL_THREAD)
 	data->work.handler = fxas21002_work_handler;
 	data->dev = dev;

--- a/drivers/sensor/fxos8700/fxos8700_trigger.c
+++ b/drivers/sensor/fxos8700/fxos8700_trigger.c
@@ -341,7 +341,7 @@ int fxos8700_trigger_init(struct device *dev)
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_FXOS8700_THREAD_STACK_SIZE,
 			fxos8700_thread_main, dev, 0, NULL,
-			K_PRIO_COOP(CONFIG_FXOS8700_THREAD_PRIORITY), 0, 0);
+			K_PRIO_COOP(CONFIG_FXOS8700_THREAD_PRIORITY), 0, K_NO_WAIT);
 #elif defined(CONFIG_FXOS8700_TRIGGER_GLOBAL_THREAD)
 	data->work.handler = fxos8700_work_handler;
 	data->dev = dev;

--- a/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
@@ -140,7 +140,7 @@ int iis3dhhc_init_interrupt(struct device *dev)
 		       CONFIG_IIS3DHHC_THREAD_STACK_SIZE,
 		       (k_thread_entry_t)iis3dhhc_thread, dev,
 		       0, NULL, K_PRIO_COOP(CONFIG_IIS3DHHC_THREAD_PRIORITY),
-		       0, 0);
+		       0, K_NO_WAIT);
 #elif defined(CONFIG_IIS3DHHC_TRIGGER_GLOBAL_THREAD)
 	iis3dhhc->work.handler = iis3dhhc_work_cb;
 	iis3dhhc->dev = dev;

--- a/drivers/sensor/lis2dh/lis2dh_trigger.c
+++ b/drivers/sensor/lis2dh/lis2dh_trigger.c
@@ -427,7 +427,7 @@ int lis2dh_init_interrupt(struct device *dev)
 	k_thread_create(&lis2dh->thread, lis2dh->thread_stack,
 			CONFIG_LIS2DH_THREAD_STACK_SIZE,
 			(k_thread_entry_t)lis2dh_thread, dev, NULL, NULL,
-			K_PRIO_COOP(CONFIG_LIS2DH_THREAD_PRIORITY), 0, 0);
+			K_PRIO_COOP(CONFIG_LIS2DH_THREAD_PRIORITY), 0, K_NO_WAIT);
 #elif defined(CONFIG_LIS2DH_TRIGGER_GLOBAL_THREAD)
 	lis2dh->work.handler = lis2dh_work_cb;
 	lis2dh->dev = dev;

--- a/drivers/sensor/lis2dw12/lis2dw12_trigger.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_trigger.c
@@ -251,7 +251,7 @@ int lis2dw12_init_interrupt(struct device *dev)
 		       CONFIG_LIS2DW12_THREAD_STACK_SIZE,
 		       (k_thread_entry_t)lis2dw12_thread, dev,
 		       0, NULL, K_PRIO_COOP(CONFIG_LIS2DW12_THREAD_PRIORITY),
-		       0, 0);
+		       0, K_NO_WAIT);
 #elif defined(CONFIG_LIS2DW12_TRIGGER_GLOBAL_THREAD)
 	lis2dw12->work.handler = lis2dw12_work_cb;
 	lis2dw12->dev = dev;

--- a/drivers/sensor/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/lps22hh/lps22hh_trigger.c
@@ -145,7 +145,7 @@ int lps22hh_init_interrupt(struct device *dev)
 		       CONFIG_LPS22HH_THREAD_STACK_SIZE,
 		       (k_thread_entry_t)lps22hh_thread, dev,
 		       0, NULL, K_PRIO_COOP(CONFIG_LPS22HH_THREAD_PRIORITY),
-		       0, 0);
+		       0, K_NO_WAIT);
 #elif defined(CONFIG_LPS22HH_TRIGGER_GLOBAL_THREAD)
 	lps22hh->work.handler = lps22hh_work_cb;
 	lps22hh->dev = dev;

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -266,7 +266,7 @@ int lsm6dso_init_interrupt(struct device *dev)
 			CONFIG_LSM6DSO_THREAD_STACK_SIZE,
 			(k_thread_entry_t)lsm6dso_thread, dev,
 			0, NULL, K_PRIO_COOP(CONFIG_LSM6DSO_THREAD_PRIORITY),
-			0, 0);
+			0, K_NO_WAIT);
 #elif defined(CONFIG_LSM6DSO_TRIGGER_GLOBAL_THREAD)
 	lsm6dso->work.handler = lsm6dso_work_cb;
 	lsm6dso->dev = dev;

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
@@ -104,7 +104,7 @@ int lsm9ds0_gyro_init_interrupt(struct device *dev)
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_LSM9DS0_GYRO_THREAD_STACK_SIZE,
 			lsm9ds0_gyro_thread_main, dev, NULL, NULL,
-			K_PRIO_COOP(10), 0, 0);
+			K_PRIO_COOP(10), 0, K_NO_WAIT);
 
 	data->gpio_drdy = device_get_binding(config->gpio_drdy_dev_name);
 	if (!data->gpio_drdy) {

--- a/drivers/sensor/mcp9808/mcp9808_trigger.c
+++ b/drivers/sensor/mcp9808/mcp9808_trigger.c
@@ -175,7 +175,7 @@ void mcp9808_setup_interrupt(struct device *dev)
 	k_thread_create(&mcp9808_thread, mcp9808_thread_stack,
 			CONFIG_MCP9808_THREAD_STACK_SIZE,
 			(k_thread_entry_t)mcp9808_thread_main, dev, 0, NULL,
-			K_PRIO_COOP(CONFIG_MCP9808_THREAD_PRIORITY), 0, 0);
+			K_PRIO_COOP(CONFIG_MCP9808_THREAD_PRIORITY), 0, K_NO_WAIT);
 #else /* CONFIG_MCP9808_TRIGGER_GLOBAL_THREAD */
 	data->work.handler = mcp9808_gpio_thread_cb;
 	data->dev = dev;

--- a/drivers/sensor/stts751/stts751_trigger.c
+++ b/drivers/sensor/stts751/stts751_trigger.c
@@ -137,7 +137,7 @@ int stts751_init_interrupt(struct device *dev)
 		       CONFIG_STTS751_THREAD_STACK_SIZE,
 		       (k_thread_entry_t)stts751_thread, dev,
 		       0, NULL, K_PRIO_COOP(CONFIG_STTS751_THREAD_PRIORITY),
-		       0, 0);
+		       0, K_NO_WAIT);
 #elif defined(CONFIG_STTS751_TRIGGER_GLOBAL_THREAD)
 	stts751->work.handler = stts751_work_cb;
 	stts751->dev = dev;

--- a/drivers/sensor/sx9500/sx9500_trigger.c
+++ b/drivers/sensor/sx9500/sx9500_trigger.c
@@ -180,7 +180,7 @@ int sx9500_setup_interrupt(struct device *dev)
 	k_thread_create(&sx9500_thread, sx9500_thread_stack,
 			CONFIG_SX9500_THREAD_STACK_SIZE,
 			(k_thread_entry_t)sx9500_thread_main, dev, 0, NULL,
-			K_PRIO_COOP(CONFIG_SX9500_THREAD_PRIORITY), 0, 0);
+			K_PRIO_COOP(CONFIG_SX9500_THREAD_PRIORITY), 0, K_NO_WAIT);
 #endif
 
 	return 0;


### PR DESCRIPTION
Use the named representation for no-wait to future-proof against a
change to the representation of timeout values.

(Two of these are necessary for #17155 to pass sanitycheck; the rest are unexercised by the test infrastructure.)