### PR TITLE
scripts: edtlib: Skip fully loading bindings in more cases

### DIFF
--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -187,13 +187,22 @@ class EDT:
             # compatibles. Might get false positives above due to comments and
             # stuff.
 
-            # Parsed PyYAML output (Python lists/dictionaries/strings/etc.,
-            # representing the file)
-            binding = yaml.load(contents, Loader=yaml.Loader)
+            try:
+                # Parsed PyYAML output (Python lists/dictionaries/strings/etc.,
+                # representing the file)
+                binding = yaml.load(contents, Loader=yaml.Loader)
+            except yaml.YAMLError as e:
+                _warn("'{}' appears in binding directories but isn't valid "
+                      "YAML: {}".format(binding_path, e))
+                continue
 
             binding_compat = _binding_compat(binding, binding_path)
-            if binding_compat is None:
-                # Not a binding. Might be a fragment or spurious file.
+            if binding_compat not in dt_compats:
+                # Either not a binding (binding_compat is None -- might be a
+                # binding fragment or a spurious file), or a binding whose
+                # compatible does not appear in the devicetree (picked up via
+                # some unrelated text in the binding file that happened to
+                # match a compatible)
                 continue
 
             # It's a match. Merge in the included bindings, do sanity checks,


### PR DESCRIPTION
As a slightly hairy but important optimization inherited from the old
scripts, the binding loading code only looks at binding files whose raw
text contains one of the compatible strings from the devicetree. For
such files, a second pass parses the file as YAML and tries to extract a
compatible string, and skips the file if it fails (e.g. due to spurious
text matches in 'include'd binding fragments).

Until now, the binding would always get fully loaded (have 'include'd
files merged in, checks run, etc.) if the second pass managed to extract
a compatible.

Do slightly better by only fully loading the binding if the extracted
compatible from the second pass appears in the devicetree. This gets rid
of unnecessary binding loading in rare cases.

Discovered by test-bindings/deprecated.yaml getting loaded even when
everything that referenced it in test.dts was commented out, because it
happened to mention 'child-binding' in a comment.

Also add a check for YAML errors in the second pass, to be slightly more
robust. Print a warning if a file that isn't valid YAML is found.