### PR TITLE
scripts: testedtlib.py: Generate SystemExit on test failures

### DIFF
--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: BSD-3-Clause
 
+import sys
+
 import edtlib
 
 # Test suite for edtlib.py. Mostly uses string comparisons via the various
@@ -21,7 +23,7 @@ def run():
     """
 
     def fail(msg):
-        raise Exception("test failed: " + msg)
+        sys.exit("test failed: " + msg)
 
     def verify_streq(actual, expected):
         actual = str(actual)


### PR DESCRIPTION
The devicetree check in check_compliance.py in ci-tools expects the
dtlib/edtlib test suites to exit with sys.exit() (which raises
SystemExit) on test failures, and interprets Exception as an internal
error in the test suite.

testedtlib.py accidentally raised Exception on test failures, making
check_compliance.py error out and skipping the rest of the tests when
there were failures. Fix it.