### PR TITLE
Bluetooth: controller: Fix DLE event on PHY update

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -8732,8 +8732,8 @@ static inline void event_phy_upd_ind_prep(struct connection *conn,
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 		/* Update max tx and/or max rx if changed */
-		if ((eff_tx_time == conn->max_tx_time) &&
-		    (eff_rx_time == conn->max_rx_time)) {
+		if ((eff_tx_time <= conn->max_tx_time) &&
+		    (eff_rx_time <= conn->max_rx_time)) {
 			return;
 		}
 		conn->max_tx_time = eff_tx_time;


### PR DESCRIPTION
Fix HCI Data Length Update event generation on PHY update
procedure, i.e. preserve Data Length Parameters on PHY
update.

Fixes BT LL.TS.5.1.1 tests:
LL/CON/MAS/BV-126-C
LL/CON/MAS/BV-127-C
LL/CON/SLA/BV-129-C
LL/CON/SLA/BV-130-C

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>