### PR TITLE
drivers: (le)u(s)art_gecko: use DT defined clock identifiers

### DIFF
--- a/drivers/serial/leuart_gecko.c
+++ b/drivers/serial/leuart_gecko.c
@@ -11,6 +11,11 @@
 #include <em_cmu.h>
 #include <soc.h>
 
+#define LEUART_PREFIX cmuClock_LEUART
+#define CLOCK_ID_PRFX2(prefix, suffix) prefix##suffix
+#define CLOCK_ID_PRFX(prefix, suffix) CLOCK_ID_PRFX2(prefix, suffix)
+#define CLOCK_LEUART(id) CLOCK_ID_PRFX(LEUART_PREFIX, id)
+
 #define DEV_CFG(dev) \
 	((const struct leuart_gecko_config * const)(dev)->config->config_info)
 #define DEV_DATA(dev) \
@@ -323,7 +328,7 @@ static void leuart_gecko_config_func_0(struct device *dev);
 
 static const struct leuart_gecko_config leuart_gecko_0_config = {
 	.base = (LEUART_TypeDef *)DT_INST_0_SILABS_GECKO_LEUART_BASE_ADDRESS,
-	.clock = cmuClock_LEUART0,
+	.clock = CLOCK_LEUART(DT_INST_0_SILABS_GECKO_LEUART_PERIPHERAL_ID),
 	.baud_rate = DT_INST_0_SILABS_GECKO_LEUART_CURRENT_SPEED,
 	.pin_rx = PIN_LEUART_0_RXD,
 	.pin_tx = PIN_LEUART_0_TXD,
@@ -376,7 +381,7 @@ static void leuart_gecko_config_func_1(struct device *dev);
 
 static const struct leuart_gecko_config leuart_gecko_1_config = {
 	.base = (LEUART_TypeDef *)DT_INST_1_SILABS_GECKO_LEUART_BASE_ADDRESS,
-	.clock = cmuClock_LEUART0,
+	.clock = CLOCK_LEUART(DT_INST_1_SILABS_GECKO_LEUART_PERIPHERAL_ID),
 	.baud_rate = DT_INST_1_SILABS_GECKO_LEUART_CURRENT_SPEED,
 	.pin_rx = PIN_LEUART_1_RXD,
 	.pin_tx = PIN_LEUART_1_TXD,

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -11,6 +11,13 @@
 #include <em_cmu.h>
 #include <soc.h>
 
+#define USART_PREFIX cmuClock_USART
+#define UART_PREFIX cmuClock_UART
+#define CLOCK_ID_PRFX2(prefix, suffix) prefix##suffix
+#define CLOCK_ID_PRFX(prefix, suffix) CLOCK_ID_PRFX2(prefix, suffix)
+#define CLOCK_USART(id) CLOCK_ID_PRFX(USART_PREFIX, id)
+#define CLOCK_UART(id) CLOCK_ID_PRFX(UART_PREFIX, id)
+
 struct uart_gecko_config {
 	USART_TypeDef *base;
 	CMU_Clock_TypeDef clock;
@@ -307,7 +314,7 @@ static void uart_gecko_config_func_0(struct device *dev);
 
 static const struct uart_gecko_config uart_gecko_0_config = {
 	.base = (USART_TypeDef *)DT_INST_0_SILABS_GECKO_UART_BASE_ADDRESS,
-	.clock = cmuClock_UART0,
+	.clock = CLOCK_UART(DT_INST_0_SILABS_GECKO_UART_PERIPHERAL_ID),
 	.baud_rate = DT_INST_0_SILABS_GECKO_UART_CURRENT_SPEED,
 	.pin_rx = PIN_UART0_RXD,
 	.pin_tx = PIN_UART0_TXD,
@@ -362,7 +369,7 @@ static void uart_gecko_config_func_1(struct device *dev);
 
 static const struct uart_gecko_config uart_gecko_1_config = {
 	.base = (USART_TypeDef *)DT_INST_1_SILABS_GECKO_UART_BASE_ADDRESS,
-	.clock = cmuClock_UART1,
+	.clock = CLOCK_UART(DT_INST_1_SILABS_GECKO_UART_PERIPHERAL_ID),
 	.baud_rate = DT_INST_1_SILABS_GECKO_UART_CURRENT_SPEED,
 	.pin_rx = PIN_UART1_RXD,
 	.pin_tx = PIN_UART1_TXD,
@@ -417,7 +424,7 @@ static void usart_gecko_config_func_0(struct device *dev);
 
 static const struct uart_gecko_config usart_gecko_0_config = {
 	.base = (USART_TypeDef *)DT_INST_0_SILABS_GECKO_USART_BASE_ADDRESS,
-	.clock = cmuClock_USART0,
+	.clock = CLOCK_USART(DT_INST_0_SILABS_GECKO_USART_PERIPHERAL_ID),
 	.baud_rate = DT_INST_0_SILABS_GECKO_USART_CURRENT_SPEED,
 	.pin_rx = PIN_USART0_RXD,
 	.pin_tx = PIN_USART0_TXD,
@@ -473,7 +480,7 @@ static void usart_gecko_config_func_1(struct device *dev);
 
 static const struct uart_gecko_config usart_gecko_1_config = {
 	.base = (USART_TypeDef *)DT_INST_1_SILABS_GECKO_USART_BASE_ADDRESS,
-	.clock = cmuClock_USART1,
+	.clock = CLOCK_USART(DT_INST_1_SILABS_GECKO_USART_PERIPHERAL_ID),
 	.baud_rate = DT_INST_1_SILABS_GECKO_USART_CURRENT_SPEED,
 	.pin_rx = PIN_USART1_RXD,
 	.pin_tx = PIN_USART1_TXD,
@@ -529,7 +536,7 @@ static void usart_gecko_config_func_2(struct device *dev);
 
 static const struct uart_gecko_config usart_gecko_2_config = {
 	.base = (USART_TypeDef *)DT_INST_2_SILABS_GECKO_USART_BASE_ADDRESS,
-	.clock = cmuClock_USART2,
+	.clock = CLOCK_USART(DT_INST_2_SILABS_GECKO_USART_PERIPHERAL_ID),
 	.baud_rate = DT_INST_2_SILABS_GECKO_USART_CURRENT_SPEED,
 	.pin_rx = PIN_USART2_RXD,
 	.pin_tx = PIN_USART2_TXD,
@@ -585,7 +592,7 @@ static void usart_gecko_config_func_3(struct device *dev);
 
 static const struct uart_gecko_config usart_gecko_3_config = {
 	.base = (USART_TypeDef *)DT_INST_3_SILABS_GECKO_USART_BASE_ADDRESS,
-	.clock = cmuClock_USART3,
+	.clock = CLOCK_USART(DT_INST_3_SILABS_GECKO_USART_PERIPHERAL_ID),
 	.baud_rate = DT_INST_3_SILABS_GECKO_USART_CURRENT_SPEED,
 	.pin_rx = PIN_USART3_RXD,
 	.pin_tx = PIN_USART3_TXD,

--- a/dts/arm/silabs/efm32hg.dtsi
+++ b/dts/arm/silabs/efm32hg.dtsi
@@ -43,6 +43,7 @@
 			reg = <0x4000c000 0x400>;
 			interrupts = <17 0>, <18 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <0>;
 			status = "disabled";
 			label = "UART_0";
 		};
@@ -52,6 +53,7 @@
 			reg = <0x4000c400 0x400>;
 			interrupts = <8 0>, <9 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <1>;
 			status = "disabled";
 			label = "UART_1";
 		};
@@ -60,6 +62,7 @@
 			compatible = "silabs,gecko-leuart";
 			reg = <0x40084000 0x400>;
 			interrupts = <10 0>;
+			peripheral-id = <0>;
 			status = "disabled";
 			label = "LEUART_0";
 		};

--- a/dts/arm/silabs/efm32pg12b.dtsi
+++ b/dts/arm/silabs/efm32pg12b.dtsi
@@ -47,6 +47,7 @@
 			reg = <0x40010000 0x400>;
 			interrupts = <12 0 13 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <0>;
 			status = "disabled";
 			label = "USART_0";
 		};
@@ -56,6 +57,7 @@
 			reg = <0x40010400 0x400>;
 			interrupts = <20 0 21 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <1>;
 			status = "disabled";
 			label = "USART_1";
 		};
@@ -65,6 +67,7 @@
 			reg = <0x40010800 0x400>;
 			interrupts = <40 0 41 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <2>;
 			status = "disabled";
 			label = "USART_2";
 		};
@@ -74,6 +77,7 @@
 			reg = <0x40010c00 0x400>;
 			interrupts = <43 0 44 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <3>;
 			status = "disabled";
 			label = "USART_3";
 		};
@@ -82,6 +86,7 @@
 			compatible = "silabs,gecko-leuart";
 			reg = <0x4004a000 0x400>;
 			interrupts = <22 0>;
+			peripheral-id = <0>;
 			status = "disabled";
 			label = "LEUART_0";
 		};

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -43,6 +43,7 @@
 			reg = <0x4000c000 0x400>;
 			interrupts = <3 0>, <4 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <0>;
 			status = "disabled";
 			label = "UART_0";
 		};
@@ -52,6 +53,7 @@
 			reg = <0x4000c400 0x400>;
 			interrupts = <15 0>, <16 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <1>;
 			status = "disabled";
 			label = "UART_1";
 		};
@@ -61,6 +63,7 @@
 			reg = <0x4000c800 0x400>;
 			interrupts = <18 0>, <19 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <2>;
 			status = "disabled";
 			label = "UART_2";
 		};
@@ -70,6 +73,7 @@
 			reg = <0x4000e000 0x400>;
 			interrupts = <20 0>, <21 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <0>;
 			status = "disabled";
 			label = "UART_3";
 		};
@@ -79,6 +83,7 @@
 			reg = <0x4000e400 0x400>;
 			interrupts = <22 0>, <23 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <1>;
 			status = "disabled";
 			label = "UART_4";
 		};
@@ -87,6 +92,7 @@
 			compatible = "silabs,gecko-leuart";
 			reg = <0x40084000 0x400>;
 			interrupts = <24 0>;
+			peripheral-id = <0>;
 			status = "disabled";
 			label = "LEUART_0";
 		};
@@ -95,6 +101,7 @@
 			compatible = "silabs,gecko-leuart";
 			reg = <0x40084400 0x400>;
 			interrupts = <25 0>;
+			peripheral-id = <1>;
 			status = "disabled";
 			label = "LEUART_1";
 		};

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -43,6 +43,7 @@
 			reg = <0x40010000 0x400>;
 			interrupts = <11 0>, <12 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <0>;
 			status = "disabled";
 			label = "USART_0";
 		};
@@ -52,6 +53,7 @@
 			reg = <0x40010400 0x400>;
 			interrupts = <19 0>, <20 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <1>;
 			status = "disabled";
 			label = "USART_1";
 		};
@@ -60,6 +62,7 @@
 			compatible = "silabs,gecko-leuart";
 			reg = <0x4004a000 0x400>;
 			interrupts = <21 0>;
+			peripheral-id = <0>;
 			status = "disabled";
 			label = "LEUART_0";
 		};

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -43,6 +43,7 @@
 			reg = <0x40010000 0x400>;
 			interrupts = <12 0>, <13 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <0>;
 			status = "disabled";
 			label = "USART_0";
 		};
@@ -52,6 +53,7 @@
 			reg = <0x40010400 0x400>;
 			interrupts = <20 0>, <21 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <1>;
 			status = "disabled";
 			label = "USART_1";
 		};
@@ -61,6 +63,7 @@
 			reg = <0x40010800 0x400>;
 			interrupts = <40 0>, <41 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <2>;
 			status = "disabled";
 			label = "USART_2";
 		};
@@ -70,6 +73,7 @@
 			reg = <0x40010c00 0x400>;
 			interrupts = <43 0>, <44 0>;
 			interrupt-names = "rx", "tx";
+			peripheral-id = <3>;
 			status = "disabled";
 			label = "USART_3";
 		};
@@ -78,6 +82,7 @@
 			compatible = "silabs,gecko-leuart";
 			reg = <0x4004a000 0x400>;
 			interrupts = <22 0>;
+			peripheral-id = <0>;
 			status = "disabled";
 			label = "LEUART_0";
 		};

--- a/dts/bindings/serial/silabs,gecko-leuart.yaml
+++ b/dts/bindings/serial/silabs,gecko-leuart.yaml
@@ -14,6 +14,11 @@ properties:
     interrupts:
       required: true
 
+    peripheral-id:
+      type: int
+      required: true
+      description: peripheral ID
+
     # Note: Not all SoC series support setting individual pin location. If this
     # is a case all location-* properties need to have identical value.
 

--- a/dts/bindings/serial/silabs,gecko-uart.yaml
+++ b/dts/bindings/serial/silabs,gecko-uart.yaml
@@ -14,6 +14,11 @@ properties:
     interrupts:
       required: true
 
+    peripheral-id:
+      type: int
+      required: true
+      description: peripheral ID
+
     # Note: Not all SoC series support setting individual pin location. If this
     # is a case all location-* properties need to have identical value.
 

--- a/dts/bindings/serial/silabs,gecko-usart.yaml
+++ b/dts/bindings/serial/silabs,gecko-usart.yaml
@@ -14,6 +14,11 @@ properties:
     interrupts:
       required: true
 
+    peripheral-id:
+      type: int
+      required: true
+      description: peripheral ID
+
     # Note: Not all SoC series support setting individual pin location. If this
     # is a case all location-* properties need to have identical value.
 


### PR DESCRIPTION
Use the device tree to assign the correct peripheral clock to each
UART/USART/LEUART. Previously, the clock identifier was determined
through the sequence number of the instantiated UART. This meant
configuring all UARTs when only one of the later UARTs was required.

Signed-off-by: Oane Kingma <o.kingma@interay.com>