### PR TITLE
cmake: app: set zephyr_extra_modules from environment

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -408,6 +408,14 @@ the configuration settings specified in an alternate .conf file using this param
 These settings will override the settings in the application’s .config file or its default .conf file.\
 Multiple files may be listed, e.g. CONF_FILE=\"prj1.conf prj2.conf\"")
 
+if(ZEPHYR_EXTRA_MODULES)
+  # ZEPHYR_EXTRA_MODULES has either been specified on the cmake CLI or is
+  # already in the CMakeCache.txt. This has precedence over the environment
+  # variable ZEPHYR_EXTRA_MODULES
+elseif(DEFINED ENV{ZEPHYR_EXTRA_MODULES})
+  set(ZEPHYR_EXTRA_MODULES $ENV{ZEPHYR_EXTRA_MODULES})
+endif()
+
 if(DTC_OVERLAY_FILE)
   # DTC_OVERLAY_FILE has either been specified on the cmake CLI or is already
   # in the CMakeCache.txt. This has precedence over the environment

--- a/doc/guides/modules.rst
+++ b/doc/guides/modules.rst
@@ -30,8 +30,10 @@ If you have :ref:`west <west>` installed, you don't need to worry about how
 this variable is defined unless you are adding a new module. The build system
 knows how to use west to set :makevar:`ZEPHYR_MODULES`. You can add additional
 modules to this list by setting the :makevar:`ZEPHYR_EXTRA_MODULES` CMake
-variable. This can be useful if you want to keep the list of modules found with
-west and also add your own.
+variable or by adding a :makevar:`ZEPHYR_EXTRA_MODULES` line to ``.zephyrrc``
+(See the section on :ref:`env_vars` for more details). This can be
+useful if you want to keep the list of modules found with west and also add
+your own.
 
 See the section about :ref:`west-multi-repo` for more details.
 


### PR DESCRIPTION
This PR adds the possibility to specify ZEPHYR_EXTRA_MODULES from an
environmental variable. To add a custom module mymodule in
path/mymodule the variable ZEPHYR_EXTRA_MODULES can be set in `.zephyrrc`.

Signed-off-by: Laczen JMS <laczenjms@gmail.com>