### PR TITLE
tests/arch: arm_thread_swap: Increase no_optim case flash requirement

### DIFF
--- a/tests/arch/arm/arm_thread_swap/testcase.yaml
+++ b/tests/arch/arm/arm_thread_swap/testcase.yaml
@@ -9,7 +9,7 @@ tests:
     extra_configs:
       - CONFIG_NO_OPTIMIZATIONS=y
     tags: arm
-    min_flash: 64
+    min_flash: 192
   arch.arm.swap.common.fp_sharing:
     arch_whitelist: arm
     filter: CONFIG_ARMV7_M_ARMV8_M_FP
@@ -25,4 +25,4 @@ tests:
       - CONFIG_FP_SHARING=y
       - CONFIG_NO_OPTIMIZATIONS=y
     tags: arm
-    min_flash: 64
+    min_flash: 192


### PR DESCRIPTION
On most targets, application flash size for no_optimization test
configuration is slightly higher than 128 Kbytes.
Updating requirement to the next upper flash size.

This fixes issue reported by shippable in https://github.com/zephyrproject-rtos/zephyr/pull/18806