### PR TITLE
various: correct arguments to k_sleep

### DIFF
--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -85,7 +85,7 @@ static void rx_thread(void *p1, void *p2, void *p3)
 		ssize_t len;
 
 		if (!uc_ready()) {
-			k_sleep(K_MSEC(20));
+			k_sleep(20);
 			continue;
 		}
 

--- a/drivers/dma/dma_stm32f4x.c
+++ b/drivers/dma/dma_stm32f4x.c
@@ -275,7 +275,7 @@ static int dma_stm32_disable_stream(struct dma_stm32_device *ddata,
 				config &= ~DMA_STM32_SCR_EN);
 
 		/* After trying for 5 seconds, give up */
-		k_sleep(K_SECONDS(5));
+		k_sleep(5 * MSEC_PER_SEC);
 		if (count++ > (5 * 1000) / 50) {
 			LOG_ERR("DMA error: Stream in use\n");
 			return -EBUSY;

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -383,7 +383,7 @@ static void eth_rx(struct eth_context *ctx)
 			}
 		}
 
-		k_sleep(K_MSEC(50));
+		k_sleep(50);
 	}
 }
 

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -448,7 +448,7 @@ int modem_cmd_handler_setup_cmds(struct modem_iface *iface,
 
 	for (i = 0; i < cmds_len; i++) {
 		if (i) {
-			k_sleep(K_MSEC(50));
+			k_sleep(50);
 		}
 
 		if (cmds[i].handle_cmd.cmd && cmds[i].handle_cmd.func) {

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -628,28 +628,28 @@ static int pin_init(void)
 
 	LOG_DBG("MDM_POWER_PIN -> ENABLE");
 	modem_pin_write(&mctx, MDM_POWER, MDM_POWER_ENABLE);
-	k_sleep(K_SECONDS(4));
+	k_sleep(4 * MSEC_PER_SEC);
 
 	LOG_DBG("MDM_POWER_PIN -> DISABLE");
 	modem_pin_write(&mctx, MDM_POWER, MDM_POWER_DISABLE);
 #if defined(CONFIG_MODEM_UBLOX_SARA_U2)
-	k_sleep(K_SECONDS(1));
+	k_sleep(MSEC_PER_SEC);
 #else
-	k_sleep(K_SECONDS(4));
+	k_sleep(4 * MSEC_PER_SEC);
 #endif
 	LOG_DBG("MDM_POWER_PIN -> ENABLE");
 	modem_pin_write(&mctx, MDM_POWER, MDM_POWER_ENABLE);
-	k_sleep(K_SECONDS(1));
+	k_sleep(MSEC_PER_SEC);
 
 	/* make sure module is powered off */
 #if defined(DT_UBLOX_SARA_R4_0_MDM_VINT_GPIOS_CONTROLLER)
 	LOG_DBG("Waiting for MDM_VINT_PIN = 0");
 
 	do {
-		k_sleep(K_MSEC(100));
+		k_sleep(100);
 	} while (modem_pin_read(&mctx, MDM_VINT) != MDM_VINT_DISABLE);
 #else
-	k_sleep(K_SECONDS(8));
+	k_sleep(8 * MSEC_PER_SEC);
 #endif
 
 	LOG_DBG("MDM_POWER_PIN -> DISABLE");
@@ -660,7 +660,7 @@ static int pin_init(void)
 #if defined(CONFIG_MODEM_UBLOX_SARA_U2)
 	k_usleep(50);		/* 50-80 microseconds */
 #else
-	k_sleep(K_SECONDS(1));
+	k_sleep(MSEC_PER_SEC);
 #endif
 	modem_pin_write(&mctx, MDM_POWER, MDM_POWER_ENABLE);
 
@@ -671,10 +671,10 @@ static int pin_init(void)
 #if defined(DT_UBLOX_SARA_R4_0_MDM_VINT_GPIOS_CONTROLLER)
 	LOG_DBG("Waiting for MDM_VINT_PIN = 1");
 	do {
-		k_sleep(K_MSEC(100));
+		k_sleep(100);
 	} while (modem_pin_read(&mctx, MDM_VINT) != MDM_VINT_ENABLE);
 #else
-	k_sleep(K_SECONDS(10));
+	k_sleep(10 * MSEC_PER_SEC);
 #endif
 
 	modem_pin_config(&mctx, MDM_POWER, GPIO_DIR_IN);
@@ -770,7 +770,7 @@ restart:
 	 */
 	ret = -1;
 	while (counter++ < 50 && ret < 0) {
-		k_sleep(K_SECONDS(2));
+		k_sleep(2 * MSEC_PER_SEC);
 		ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler,
 				     NULL, 0, "AT", &mdata.sem_response,
 				     MDM_CMD_TIMEOUT);
@@ -825,7 +825,7 @@ restart:
 	/* wait for +CREG: 1(normal) or 5(roaming) */
 	counter = 0;
 	while (counter++ < 20 && mdata.ev_creg != 1 && mdata.ev_creg != 5) {
-		k_sleep(K_SECONDS(1));
+		k_sleep(MSEC_PER_SEC);
 	}
 
 	/* query modem RSSI */

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -590,7 +590,7 @@ static void on_cmd_atcmdecho_nosock_imei(struct net_buf **buf, u16_t len)
 	if (len < MDM_IMEI_LENGTH) {
 		LOG_DBG("Waiting for data");
 		/* wait for more data */
-		k_sleep(K_MSEC(500));
+		k_sleep(500);
 		wncm14a2a_read_rx(buf);
 	}
 
@@ -1217,7 +1217,7 @@ static int modem_pin_init(void)
 	LOG_DBG("MDM_RESET_PIN -> ASSERTED");
 	gpio_pin_write(ictx.gpio_port_dev[MDM_RESET],
 		       pinconfig[MDM_RESET].pin, MDM_RESET_ASSERTED);
-	k_sleep(K_SECONDS(7));
+	k_sleep(7 * MSEC_PER_SEC);
 	LOG_DBG("MDM_RESET_PIN -> NOT_ASSERTED");
 	gpio_pin_write(ictx.gpio_port_dev[MDM_RESET],
 		       pinconfig[MDM_RESET].pin, MDM_RESET_NOT_ASSERTED);
@@ -1255,7 +1255,7 @@ static int modem_pin_init(void)
 #endif
 
 	/* wait for the WNC Module to perform its initial boot correctly */
-	k_sleep(K_SECONDS(1));
+	k_sleep(MSEC_PER_SEC);
 
 	/* Enable the level translator.
 	 * The input pins should now be the same as how the M14A module is
@@ -1278,15 +1278,15 @@ static void modem_wakeup_pin_fix(void)
 	 * UART characters.
 	 */
 	LOG_DBG("Toggling MDM_KEEP_AWAKE_PIN to avoid missed characters");
-	k_sleep(K_MSEC(20));
+	k_sleep(20);
 	LOG_DBG("MDM_KEEP_AWAKE_PIN -> DISABLED");
 	gpio_pin_write(ictx.gpio_port_dev[MDM_KEEP_AWAKE],
 		       pinconfig[MDM_KEEP_AWAKE].pin, MDM_KEEP_AWAKE_DISABLED);
-	k_sleep(K_SECONDS(2));
+	k_sleep(2 * MSEC_PER_SEC);
 	LOG_DBG("MDM_KEEP_AWAKE_PIN -> ENABLED");
 	gpio_pin_write(ictx.gpio_port_dev[MDM_KEEP_AWAKE],
 		       pinconfig[MDM_KEEP_AWAKE].pin, MDM_KEEP_AWAKE_ENABLED);
-	k_sleep(K_MSEC(20));
+	k_sleep(20);
 }
 
 static void wncm14a2a_rssi_query_work(struct k_work *work)
@@ -1325,7 +1325,7 @@ restart:
 	 */
 	ret = -1;
 	while (counter++ < 50 && ret < 0) {
-		k_sleep(K_SECONDS(2));
+		k_sleep(2 * MSEC_PER_SEC);
 		ret = send_at_cmd(NULL, "AT", MDM_CMD_TIMEOUT);
 		if (ret < 0 && ret != -ETIMEDOUT) {
 			break;
@@ -1372,7 +1372,7 @@ restart:
 
 	/* query modem RSSI */
 	wncm14a2a_rssi_query_work(NULL);
-	k_sleep(K_SECONDS(2));
+	k_sleep(2 * MSEC_PER_SEC);
 
 	counter = 0;
 	/* wait for RSSI > -1000 and != 0 */
@@ -1382,7 +1382,7 @@ restart:
 		/* stop RSSI delay work */
 		k_delayed_work_cancel(&ictx.rssi_query_work);
 		wncm14a2a_rssi_query_work(NULL);
-		k_sleep(K_SECONDS(2));
+		k_sleep(2 * MSEC_PER_SEC);
 	}
 
 	if (ictx.mdm_ctx.data_rssi <= -1000 || ictx.mdm_ctx.data_rssi == 0) {

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -86,7 +86,7 @@ static int imx_pwm_pin_set(struct device *dev, u32_t pwm,
 		if (fifoav == PWM_PWMSR_FIFOAV_4WORDS) {
 			period_ms = (get_pwm_clock_freq(base) >>
 					config->prescaler) * MSEC_PER_SEC;
-			k_sleep(K_MSEC(period_ms));
+			k_sleep(period_ms);
 
 			sr = PWM_PWMSR_REG(base);
 			if (fifoav == PWM_PWMSR_FIFOAV(sr)) {

--- a/drivers/sensor/sht3xd/sht3xd.c
+++ b/drivers/sensor/sht3xd/sht3xd.c
@@ -100,7 +100,7 @@ static int sht3xd_sample_fetch(struct device *dev, enum sensor_channel chan)
 		LOG_DBG("Failed to set single shot measurement mode!");
 		return -EIO;
 	}
-	k_sleep(K_MSEC(measure_wait[SHT3XD_REPEATABILITY_IDX] / USEC_PER_MSEC));
+	k_sleep(measure_wait[SHT3XD_REPEATABILITY_IDX] / USEC_PER_MSEC);
 
 	if (i2c_read(i2c, rx_buf, sizeof(rx_buf), address) < 0) {
 		LOG_DBG("Failed to read data sample!");

--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -220,7 +220,7 @@ static void eswifi_spi_poll_thread(void *p1)
 	struct eswifi_dev *eswifi = p1;
 
 	while (1) {
-		k_sleep(K_MSEC(1000));
+		k_sleep(1000);
 		eswifi_spi_read_msg(eswifi);
 	}
 }

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -954,7 +954,7 @@ static void winc1500_thread(void)
 		while (m2m_wifi_handle_events(NULL) != 0) {
 		}
 
-		k_sleep(K_MSEC(1));
+		k_sleep(1);
 	}
 }
 

--- a/lib/posix/sleep.c
+++ b/lib/posix/sleep.c
@@ -14,7 +14,7 @@
  */
 unsigned sleep(unsigned int seconds)
 {
-	k_sleep(K_SECONDS(seconds));
+	k_sleep(seconds * MSEC_PER_SEC);
 	return 0;
 }
 /**

--- a/lib/updatehub/updatehub.c
+++ b/lib/updatehub/updatehub.c
@@ -155,7 +155,7 @@ static bool start_coap_client(void)
 		if (ret == 0) {
 			break;
 		}
-		k_sleep(K_SECONDS(1));
+		k_sleep(MSEC_PER_SEC);
 	}
 	if (ret < 0) {
 		LOG_ERR("Could not resolve dns");

--- a/samples/bluetooth/scan_adv/src/main.c
+++ b/samples/bluetooth/scan_adv/src/main.c
@@ -54,7 +54,7 @@ void main(void)
 	}
 
 	do {
-		k_sleep(K_MSEC(400));
+		k_sleep(400);
 
 		/* Start advertising */
 		err = bt_le_adv_start(BT_LE_ADV_NCONN, ad, ARRAY_SIZE(ad),
@@ -64,7 +64,7 @@ void main(void)
 			return;
 		}
 
-		k_sleep(K_MSEC(400));
+		k_sleep(400);
 
 		err = bt_le_adv_stop();
 		if (err) {

--- a/samples/boards/bbc_microbit/display/src/main.c
+++ b/samples/boards/bbc_microbit/display/src/main.c
@@ -73,7 +73,7 @@ void main(void)
 	/* Display countdown from '9' to '0' */
 	mb_display_print(disp, MB_DISPLAY_MODE_SINGLE,
 			 K_SECONDS(1), "9876543210");
-	k_sleep(K_SECONDS(11));
+	k_sleep(11 * MSEC_PER_SEC);
 
 	/* Iterate through all pixels one-by-one */
 	for (y = 0; y < 5; y++) {
@@ -82,24 +82,24 @@ void main(void)
 			pixel.row[y] = BIT(x);
 			mb_display_image(disp, MB_DISPLAY_MODE_SINGLE,
 					 K_MSEC(250), &pixel, 1);
-			k_sleep(K_MSEC(300));
+			k_sleep(300);
 		}
 	}
 
 	/* Show a smiley-face */
 	mb_display_image(disp, MB_DISPLAY_MODE_SINGLE, K_SECONDS(2),
 			 &smiley, 1);
-	k_sleep(K_SECONDS(2));
+	k_sleep(2 * MSEC_PER_SEC);
 
 	/* Show a short scrolling animation */
 	mb_display_image(disp, MB_DISPLAY_MODE_SCROLL, K_SECONDS(1),
 			 scroll, ARRAY_SIZE(scroll));
-	k_sleep(K_SECONDS(1) * (ARRAY_SIZE(scroll) + 2));
+	k_sleep(MSEC_PER_SEC * (ARRAY_SIZE(scroll) + 2));
 
 	/* Show a sequential animation */
 	mb_display_image(disp, MB_DISPLAY_MODE_DEFAULT | MB_DISPLAY_FLAG_LOOP,
 			 K_MSEC(150), animation, ARRAY_SIZE(animation));
-	k_sleep(K_MSEC(150) * ARRAY_SIZE(animation) * 5);
+	k_sleep(150 * ARRAY_SIZE(animation) * 5);
 
 	/* Show some scrolling text ("Hello Zephyr!") */
 	mb_display_print(disp, MB_DISPLAY_MODE_DEFAULT | MB_DISPLAY_FLAG_LOOP,

--- a/samples/boards/bbc_microbit/sound/src/main.c
+++ b/samples/boards/bbc_microbit/sound/src/main.c
@@ -41,7 +41,7 @@ static void beep(struct k_work *work)
 	pwm_pin_set_usec(pwm, BUZZER_PIN, 0, 0);
 
 	/* Ensure there's a clear silent period between two tones */
-	k_sleep(K_MSEC(50));
+	k_sleep(50);
 	beep_active = false;
 }
 

--- a/samples/boards/nrf52/power_mgr/src/main.c
+++ b/samples/boards/nrf52/power_mgr/src/main.c
@@ -94,7 +94,7 @@ void main(void)
 
 		printk("\n<-- App going to sleep for %u Sec -->\n",
 							sleep_seconds);
-		k_sleep(K_SECONDS(sleep_seconds));
+		k_sleep(sleep_seconds * MSEC_PER_SEC);
 	}
 
 	/* Restore automatic power management. */
@@ -107,7 +107,7 @@ void main(void)
 	while (1) {
 		gpio_pin_read(gpio_port, BUTTON_1, &level);
 		if (level == LOW) {
-			k_sleep(K_SECONDS(DEEP_SLEEP_STATE_ENTER_TO));
+			k_sleep(DEEP_SLEEP_STATE_ENTER_TO * MSEC_PER_SEC);
 		}
 		k_busy_wait(1000);
 	}

--- a/samples/drivers/gpio/src/main.c
+++ b/samples/drivers/gpio/src/main.c
@@ -104,6 +104,6 @@ void main(void)
 			toggle = 1;
 		}
 
-		k_sleep(K_SECONDS(2));
+		k_sleep(2 * MSEC_PER_SEC);
 	}
 }

--- a/samples/net/nats/src/main.c
+++ b/samples/net/nats/src/main.c
@@ -140,7 +140,7 @@ static void initialize_network(void)
 	/* TODO: add a timeout/retry */
 	LOG_INF("Waiting for DHCP ...");
 	do {
-		k_sleep(K_SECONDS(1));
+		k_sleep(MSEC_PER_SEC);
 	} while (net_ipv4_is_addr_unspecified(&iface->dhcpv4.requested_ip));
 
 	LOG_INF("Done!");
@@ -148,7 +148,7 @@ static void initialize_network(void)
 	/* TODO: add a timeout */
 	LOG_INF("Waiting for IP assginment ...");
 	do {
-		k_sleep(K_SECONDS(1));
+		k_sleep(MSEC_PER_SEC);
 	} while (!net_ipv4_is_my_addr(&iface->dhcpv4.requested_ip));
 
 	LOG_INF("Done!");

--- a/samples/net/sockets/can/src/main.c
+++ b/samples/net/sockets/can/src/main.c
@@ -146,7 +146,7 @@ static void rx(int *can_fd, int *do_close_period,
 			if (close_period <= 0) {
 				(void)close(fd);
 
-				k_sleep(K_SECONDS(1));
+				k_sleep(MSEC_PER_SEC);
 
 				fd = create_socket(filter);
 				if (fd < 0) {
@@ -258,7 +258,7 @@ void main(void)
 	int fd;
 
 	/* Let the device start before doing anything */
-	k_sleep(K_SECONDS(2));
+	k_sleep(2 * MSEC_PER_SEC);
 
 	fd = setup_socket();
 	if (fd < 0) {

--- a/samples/net/sockets/net_mgmt/src/main.c
+++ b/samples/net/sockets/net_mgmt/src/main.c
@@ -57,7 +57,7 @@ static void trigger_events(void)
 
 		operation++;
 
-		k_sleep(K_SECONDS(1));
+		k_sleep(MSEC_PER_SEC);
 	}
 }
 

--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -563,7 +563,7 @@ static int execute_upload(const struct shell *shell,
 		net_icmpv6_send_echo_request(net_if_get_default(),
 					     &ipv6->sin6_addr, 0, 0, NULL, 0);
 
-		k_sleep(K_SECONDS(1));
+		k_sleep(MSEC_PER_SEC);
 	}
 
 	if (is_udp && IS_ENABLED(CONFIG_NET_UDP)) {

--- a/samples/sensor/ti_hdc/src/main.c
+++ b/samples/sensor/ti_hdc/src/main.c
@@ -35,6 +35,6 @@ void main(void)
 		       temp.val1, temp.val2, humidity.val1, humidity.val2);
 
 		/* wait for the next sample */
-		k_sleep(K_SECONDS(10));
+		k_sleep(10 * MSEC_PER_SEC);
 	}
 }

--- a/samples/subsys/usb/console/src/main.c
+++ b/samples/subsys/usb/console/src/main.c
@@ -22,6 +22,6 @@ void main(void)
 
 	while (1) {
 		printk("Hello World! %s\n", CONFIG_ARCH);
-		k_sleep(K_SECONDS(1));
+		k_sleep(MSEC_PER_SEC);
 	}
 }

--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -136,7 +136,7 @@ static inline void adv_send(struct net_buf *buf)
 
 	BT_DBG("Advertising started. Sleeping %u ms", duration);
 
-	k_sleep(K_MSEC(duration));
+	k_sleep(duration);
 
 	err = bt_le_adv_stop();
 	adv_send_end(err, cb, cb_data);

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1056,7 +1056,7 @@ static void shell_log_process(const struct shell *shell)
 		 * readable and can be used to enter further commands.
 		 */
 		if (shell->ctx->cmd_buff_len) {
-			k_sleep(K_MSEC(15));
+			k_sleep(15);
 		}
 
 		k_poll_signal_check(signal, &signaled, &result);

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -339,7 +339,7 @@ void main(void)
 		if (test_status == 0) {
 			PRINT("Reset board #%u to test again\n",
 				state.boots);
-			k_sleep(K_MSEC(10));
+			k_sleep(10);
 			sys_reboot(SYS_REBOOT_COLD);
 		} else {
 			PRINT("Failed after %u attempts\n", state.boots);

--- a/tests/boards/intel_s1000_crb/src/test_hid.c
+++ b/tests/boards/intel_s1000_crb/src/test_hid.c
@@ -116,7 +116,7 @@ void hid_thread(void)
 
 	while (true) {
 
-		k_sleep(K_SECONDS(1));
+		k_sleep(MSEC_PER_SEC);
 
 		report_1[1]++;
 

--- a/tests/kernel/mem_protect/futex/src/main.c
+++ b/tests/kernel/mem_protect/futex/src/main.c
@@ -189,7 +189,7 @@ void test_futex_wait_timeout(void)
 			K_NO_WAIT);
 
 	/* giving time for the futex_wait_task to execute */
-	k_sleep(K_MSEC(100));
+	k_sleep(100);
 
 	zassert_true(atomic_get(&simple_futex.val) == 0,
 			"wait timeout doesn't timeout");
@@ -209,7 +209,7 @@ void test_futex_wait_nowait(void)
 			K_NO_WAIT);
 
 	/* giving time for the futex_wait_task to execute */
-	k_sleep(K_MSEC(100));
+	k_sleep(100);
 
 	zassert_true(atomic_get(&simple_futex.val) == 0, "wait nowait fail");
 
@@ -298,7 +298,7 @@ void test_futex_wait_nowait_wake(void)
 			K_NO_WAIT);
 
 	/* giving time for the futex_wait_wake_task to execute */
-	k_sleep(K_MSEC(100));
+	k_sleep(100);
 
 	k_thread_create(&futex_wake_tid, futex_wake_stack, STACK_SIZE,
 			futex_wake_task, &woken, NULL, NULL,

--- a/tests/kernel/mem_protect/sys_sem/src/main.c
+++ b/tests/kernel/mem_protect/sys_sem/src/main.c
@@ -60,7 +60,7 @@ void sem_give_task(void *p1, void *p2, void *p3)
 
 void sem_take_timeout_forever_helper(void *p1, void *p2, void *p3)
 {
-	k_sleep(K_MSEC(100));
+	k_sleep(100);
 	sys_sem_give(&simple_sem);
 }
 

--- a/tests/kernel/mutex/sys_mutex/src/main.c
+++ b/tests/kernel/mutex/sys_mutex/src/main.c
@@ -79,7 +79,7 @@ void thread_05(void)
 {
 	int rv;
 
-	k_sleep(K_MSEC(3500));
+	k_sleep(3500);
 
 	/* Wait and boost owner priority to 5 */
 	rv = sys_mutex_lock(&mutex_4, K_SECONDS(1));
@@ -102,7 +102,7 @@ void thread_06(void)
 {
 	int rv;
 
-	k_sleep(K_MSEC(3750));
+	k_sleep(3750);
 
 	/*
 	 * Wait for the mutex.  There is a higher priority level thread waiting
@@ -134,7 +134,7 @@ void thread_07(void)
 {
 	int rv;
 
-	k_sleep(K_MSEC(2500));
+	k_sleep(2500);
 
 	/*
 	 * Wait and boost owner priority to 7.  While waiting, another thread of
@@ -164,7 +164,7 @@ void thread_08(void)
 {
 	int rv;
 
-	k_sleep(K_MSEC(1500));
+	k_sleep(1500);
 
 	/* Wait and boost owner priority to 8 */
 	rv = sys_mutex_lock(&mutex_2, K_FOREVER);
@@ -188,7 +188,7 @@ void thread_09(void)
 {
 	int rv;
 
-	k_sleep(K_MSEC(500));	/* Allow lower priority thread to run */
+	k_sleep(500);	/* Allow lower priority thread to run */
 
 	/*<mutex_1> is already locked. */
 	rv = sys_mutex_lock(&mutex_1, K_NO_WAIT);
@@ -221,7 +221,7 @@ void thread_11(void)
 {
 	int rv;
 
-	k_sleep(K_MSEC(3500));
+	k_sleep(3500);
 	rv = sys_mutex_lock(&mutex_3, K_FOREVER);
 	if (rv != 0) {
 		tc_rc = TC_FAIL;

--- a/tests/kernel/mutex/sys_mutex/src/thread_12.c
+++ b/tests/kernel/mutex/sys_mutex/src/thread_12.c
@@ -45,7 +45,7 @@ void thread_12(void)
 
 	/* Wait a bit, then release the mutex */
 
-	k_sleep(K_MSEC(500));
+	k_sleep(500);
 	sys_mutex_unlock(&private_mutex);
 
 }

--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -60,7 +60,7 @@ void sem_give_task(void *p1, void *p2, void *p3)
 
 void sem_take_timeout_forever_helper(void *p1, void *p2, void *p3)
 {
-	k_sleep(K_MSEC(100));
+	k_sleep(100);
 	k_sem_give(&simple_sem);
 }
 
@@ -363,17 +363,17 @@ void test_sem_take_multiple(void)
 
 
 	/* time for those 3 threads to complete */
-	k_sleep(K_MSEC(20));
+	k_sleep(20);
 
 	/* Let these threads proceed to take the multiple_sem */
 	k_sem_give(&high_prio_sem);
 	k_sem_give(&mid_prio_sem);
 	k_sem_give(&low_prio_sem);
-	k_sleep(K_MSEC(200));
+	k_sleep(200);
 
 	/* enable the higher priority thread to run. */
 	k_sem_give(&multiple_thread_sem);
-	k_sleep(K_MSEC(200));
+	k_sleep(200);
 	/* check which threads completed. */
 	signal_count = k_sem_count_get(&high_prio_sem);
 	zassert_true(signal_count == 1U,
@@ -389,7 +389,7 @@ void test_sem_take_multiple(void)
 
 	/* enable the Medium priority thread to run. */
 	k_sem_give(&multiple_thread_sem);
-	k_sleep(K_MSEC(200));
+	k_sleep(200);
 	/* check which threads completed. */
 	signal_count = k_sem_count_get(&high_prio_sem);
 	zassert_true(signal_count == 1U,
@@ -405,7 +405,7 @@ void test_sem_take_multiple(void)
 
 	/* enable the low priority thread to run. */
 	k_sem_give(&multiple_thread_sem);
-	k_sleep(K_MSEC(200));
+	k_sleep(200);
 	/* check which threads completed. */
 	signal_count = k_sem_count_get(&high_prio_sem);
 	zassert_true(signal_count == 1U,
@@ -492,7 +492,7 @@ void test_sem_multiple_threads_wait(void)
 		}
 
 		/* giving time for the other threads to execute  */
-		k_sleep(K_MSEC(500));
+		k_sleep(500);
 
 		/* Give the semaphores */
 		for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {
@@ -500,7 +500,7 @@ void test_sem_multiple_threads_wait(void)
 		}
 
 		/* giving time for the other threads to execute  */
-		k_sleep(K_MSEC(500));
+		k_sleep(500);
 
 		/* check if all the threads are done. */
 		for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {

--- a/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
@@ -121,7 +121,7 @@ static void uthread_entry(void)
 	block = k_malloc(BLOCK_SIZE);
 	zassert_true(block != NULL, NULL);
 	printk("Child thread is running\n");
-	k_sleep(K_MSEC(2));
+	k_sleep(2);
 }
 
 /**
@@ -139,7 +139,7 @@ void test_abort_handler(void)
 
 	tdata.fn_abort = &abort_function;
 
-	k_sleep(K_MSEC(1));
+	k_sleep(1);
 
 	abort_called = false;
 

--- a/tests/kernel/threads/thread_apis/testcase.yaml
+++ b/tests/kernel/threads/thread_apis/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.threads:
     tags: kernel threads userspace ignore_faults
+    platform_exclude: 96b_meerkat96 colibri_imx7d_m4 warp7_m4

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -756,7 +756,7 @@ static void rx_chksum_offload_disabled_test_v6(void)
 	}
 
 	/* Let the receiver to receive the packets */
-	k_sleep(K_MSEC(10));
+	k_sleep(10);
 }
 
 static void rx_chksum_offload_disabled_test_v4(void)
@@ -812,7 +812,7 @@ static void rx_chksum_offload_disabled_test_v4(void)
 	}
 
 	/* Let the receiver to receive the packets */
-	k_sleep(K_MSEC(10));
+	k_sleep(10);
 }
 
 static void rx_chksum_offload_enabled_test_v6(void)
@@ -866,7 +866,7 @@ static void rx_chksum_offload_enabled_test_v6(void)
 	}
 
 	/* Let the receiver to receive the packets */
-	k_sleep(K_MSEC(10));
+	k_sleep(10);
 }
 
 static void rx_chksum_offload_enabled_test_v4(void)
@@ -920,7 +920,7 @@ static void rx_chksum_offload_enabled_test_v4(void)
 	}
 
 	/* Let the receiver to receive the packets */
-	k_sleep(K_MSEC(10));
+	k_sleep(10);
 }
 
 void test_main(void)

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -935,7 +935,7 @@ static void test_address_lifetime(void)
 	zassert_not_null(ifaddr, "Address with lifetime cannot be added");
 
 	/* Make sure DAD gets some time to run */
-	k_sleep(K_MSEC(200));
+	k_sleep(200);
 
 	/* Then check that the timeout values in net_if_addr are set correctly.
 	 * Start first with smaller timeout values.
@@ -1050,17 +1050,17 @@ static void test_dad_timeout(void)
 	ifaddr = net_if_ipv6_addr_add(iface, &addr1, NET_ADDR_AUTOCONF, 0xffff);
 	zassert_not_null(ifaddr, "Address 1 cannot be added");
 
-	k_sleep(K_MSEC(10));
+	k_sleep(10);
 
 	ifaddr = net_if_ipv6_addr_add(iface, &addr2, NET_ADDR_AUTOCONF, 0xffff);
 	zassert_not_null(ifaddr, "Address 2 cannot be added");
 
-	k_sleep(K_MSEC(10));
+	k_sleep(10);
 
 	ifaddr = net_if_ipv6_addr_add(iface, &addr3, NET_ADDR_AUTOCONF, 0xffff);
 	zassert_not_null(ifaddr, "Address 3 cannot be added");
 
-	k_sleep(K_MSEC(200));
+	k_sleep(200);
 
 	/* We should have received three DAD queries, make sure they are in
 	 * proper order.

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -321,7 +321,7 @@ static void trigger_events(void)
 
 		operation++;
 
-		k_sleep(K_MSEC(100));
+		k_sleep(100);
 	}
 }
 

--- a/tests/net/traffic_class/src/main.c
+++ b/tests/net/traffic_class/src/main.c
@@ -506,7 +506,7 @@ static void traffic_class_send_priority(enum net_priority prio,
 		/* This sleep is needed here so that the sending side
 		 * can run properly.
 		 */
-		k_sleep(K_MSEC(1));
+		k_sleep(1);
 	}
 }
 
@@ -775,7 +775,7 @@ static void traffic_class_recv_packets_with_prio(enum net_priority prio,
 	zassert_true(ret > 0, "Send UDP pkt failed");
 
 	/* Let the receiver to receive the packets */
-	k_sleep(K_MSEC(1));
+	k_sleep(1);
 }
 
 static void traffic_class_recv_priority(enum net_priority prio,
@@ -801,7 +801,7 @@ static void traffic_class_recv_priority(enum net_priority prio,
 		/* This sleep is needed here so that the receiving side
 		 * can run properly.
 		 */
-		k_sleep(K_MSEC(1));
+		k_sleep(1);
 	}
 }
 

--- a/tests/subsys/fs/littlefs/src/test_lfs_basic.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_basic.c
@@ -508,7 +508,7 @@ void test_lfs_basic(void)
 	zassert_equal(fs_unmount(mp), 0,
 		      "unmount small failed");
 
-	k_sleep(K_MSEC(100));   /* flush log messages */
+	k_sleep(100);   /* flush log messages */
 	TC_PRINT("checking double unmount diagnoses\n");
 	zassert_equal(fs_unmount(mp), -EINVAL,
 		      "unmount unmounted failed");

--- a/tests/subsys/fs/littlefs/src/test_lfs_dirops.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_dirops.c
@@ -317,19 +317,19 @@ void test_lfs_dirops(void)
 	zassert_equal(check_mkdir(mp), TC_PASS,
 		      "check mkdir failed");
 
-	k_sleep(K_MSEC(100));   /* flush log messages */
+	k_sleep(100);   /* flush log messages */
 	zassert_equal(build_layout(mp, test_hierarchy), TC_PASS,
 		      "build test hierarchy failed");
 
-	k_sleep(K_MSEC(100));   /* flush log messages */
+	k_sleep(100);   /* flush log messages */
 	zassert_equal(check_layout(mp, test_hierarchy), TC_PASS,
 		      "check test hierarchy failed");
 
-	k_sleep(K_MSEC(100));   /* flush log messages */
+	k_sleep(100);   /* flush log messages */
 	zassert_equal(check_rename(mp), TC_PASS,
 		      "check rename failed");
 
-	k_sleep(K_MSEC(100));   /* flush log messages */
+	k_sleep(100);   /* flush log messages */
 	zassert_equal(fs_unmount(mp), 0,
 		      "unmount small failed");
 }

--- a/tests/subsys/fs/littlefs/src/test_lfs_perf.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_perf.c
@@ -224,25 +224,25 @@ static int small_8_1K_cust(void)
 
 void test_lfs_perf(void)
 {
-	k_sleep(K_MSEC(100));   /* flush log messages */
+	k_sleep(100);   /* flush log messages */
 	zassert_equal(write_read("small 8x1K dflt",
 				 &testfs_small_mnt,
 				 1024, 8),
 		      TC_PASS,
 		      "failed");
 
-	k_sleep(K_MSEC(100));   /* flush log messages */
+	k_sleep(100);   /* flush log messages */
 	zassert_equal(small_8_1K_cust(), TC_PASS,
 		      "failed");
 
-	k_sleep(K_MSEC(100));   /* flush log messages */
+	k_sleep(100);   /* flush log messages */
 	zassert_equal(write_read("medium 32x2K dflt",
 				 &testfs_medium_mnt,
 				 2048, 32),
 		      TC_PASS,
 		      "failed");
 
-	k_sleep(K_MSEC(100));   /* flush log messages */
+	k_sleep(100);   /* flush log messages */
 	zassert_equal(write_read("large 64x4K dflt",
 				 &testfs_large_mnt,
 				 4096, 64),


### PR DESCRIPTION
The `k_sleep()` kernel function is documented to take a value in milliseconds.  A significant number of in-tree calls to it first pass the value through `K_MSEC()`, which is intended to convert milliseconds to a timeout for kernel API such as `k_poll()` and `k_sem_take()`.  Currently this macro does nothing, while its companions like `K_SECONDS()` convert their values to milliseconds.

In the future `K_MSEC()` and its kin will produce an opaque timeout value that supports precision finer than 1 ms and alternative clocks. In that future `k_sleep()` will continue to take its argument as milliseconds (as `k_usleep()` will continue to use microseconds), and passing a timeout value to `k_sleep()` will result in compilation errors.

Replace the arguments to `k_sleep()` that involve `K_MSEC`-like macros with values that provide milliseconds.

(Several of these are necessary to get #17155 to pass sanity-check; others are unexercised by the test infrastructure.)