### PR TITLE
kernel internal naming cleanup

### DIFF
--- a/arch/arc/core/cpu_idle.S
+++ b/arch/arc/core/cpu_idle.S
@@ -17,8 +17,8 @@
 #include <linker/sections.h>
 #include <arch/cpu.h>
 
-GTEXT(k_cpu_idle)
-GTEXT(k_cpu_atomic_idle)
+GTEXT(z_arch_cpu_idle)
+GTEXT(z_arch_cpu_atomic_idle)
 GDATA(k_cpu_sleep_mode)
 
 SECTION_VAR(BSS, k_cpu_sleep_mode)
@@ -33,7 +33,7 @@ SECTION_VAR(BSS, k_cpu_sleep_mode)
  * void nanCpuIdle(void)
  */
 
-SECTION_FUNC(TEXT, k_cpu_idle)
+SECTION_FUNC(TEXT, z_arch_cpu_idle)
 
 #ifdef CONFIG_TRACING
 	push_s blink
@@ -52,9 +52,9 @@ SECTION_FUNC(TEXT, k_cpu_idle)
  *
  * This function exits with interrupts restored to <key>.
  *
- * void k_cpu_atomic_idle(unsigned int key)
+ * void z_arch_cpu_atomic_idle(unsigned int key)
  */
-SECTION_FUNC(TEXT, k_cpu_atomic_idle)
+SECTION_FUNC(TEXT, z_arch_cpu_atomic_idle)
 
 #ifdef CONFIG_TRACING
 	push_s blink

--- a/arch/arc/core/cpu_idle.S
+++ b/arch/arc/core/cpu_idle.S
@@ -19,9 +19,9 @@
 
 GTEXT(z_arch_cpu_idle)
 GTEXT(z_arch_cpu_atomic_idle)
-GDATA(k_cpu_sleep_mode)
+GDATA(z_arc_cpu_sleep_mode)
 
-SECTION_VAR(BSS, k_cpu_sleep_mode)
+SECTION_VAR(BSS, z_arc_cpu_sleep_mode)
 	.balign 4
 	.word 0
 
@@ -41,7 +41,7 @@ SECTION_FUNC(TEXT, z_arch_cpu_idle)
 	pop_s blink
 #endif
 
-	ld r1, [k_cpu_sleep_mode]
+	ld r1, [z_arc_cpu_sleep_mode]
 	or r1, r1, (1 << 4) /* set IRQ-enabled bit */
 	sleep r1
 	j_s [blink]
@@ -62,7 +62,7 @@ SECTION_FUNC(TEXT, z_arch_cpu_atomic_idle)
 	pop_s blink
 #endif
 
-	ld r1, [k_cpu_sleep_mode]
+	ld r1, [z_arc_cpu_sleep_mode]
 	or r1, r1, (1 << 4) /* set IRQ-enabled bit */
 	sleep r1
 	j_s.d [blink]

--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -17,7 +17,7 @@
 #include <swap_macros.h>
 
 GDATA(_interrupt_stack)
-GDATA(_main_stack)
+GDATA(z_main_stack)
 GDATA(_VectorTable)
 
 /* use one of the available interrupt stacks during init */
@@ -154,7 +154,7 @@ _master_core_startup:
 	 * FIRQ stack when CONFIG_INIT_STACKS is enabled before switching to
 	 * one of them for the rest of the early boot
 	 */
-	mov_s sp, _main_stack
+	mov_s sp, z_main_stack
 	add sp, sp, CONFIG_MAIN_STACK_SIZE
 
 	mov_s r0, _interrupt_stack

--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -59,10 +59,10 @@ struct init_stack_frame {
  *
  * @return N/A
  */
-void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
-		 size_t stackSize, k_thread_entry_t pEntry,
-		 void *parameter1, void *parameter2, void *parameter3,
-		 int priority, unsigned int options)
+void z_arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
+		       size_t stackSize, k_thread_entry_t pEntry,
+		       void *parameter1, void *parameter2, void *parameter3,
+		       int priority, unsigned int options)
 {
 	char *pStackMem = Z_THREAD_STACK_BUFFER(stack);
 	Z_ASSERT_VALID_PRIO(priority, pEntry);

--- a/arch/arc/core/thread_entry_wrapper.S
+++ b/arch/arc/core/thread_entry_wrapper.S
@@ -22,7 +22,7 @@ GTEXT(z_thread_entry_wrapper1)
  * @brief Wrapper for z_thread_entry
  *
  * The routine pops parameters for the z_thread_entry from stack frame, prepared
- * by the z_new_thread() routine.
+ * by the z_arch_new_thread() routine.
  *
  * @return N/A
  */

--- a/arch/arc/include/kernel_arch_func.h
+++ b/arch/arc/include/kernel_arch_func.h
@@ -66,7 +66,7 @@ static ALWAYS_INLINE int Z_INTERRUPT_CAUSE(void)
 	return irq_num;
 }
 
-#define z_is_in_isr	z_arc_v2_irq_unit_is_in_isr
+#define z_arch_is_in_isr	z_arc_v2_irq_unit_is_in_isr
 
 extern void z_thread_entry_wrapper(void);
 extern void z_user_thread_entry_wrapper(void);

--- a/arch/arc/include/kernel_arch_func.h
+++ b/arch/arc/include/kernel_arch_func.h
@@ -44,7 +44,7 @@ static ALWAYS_INLINE _cpu_t *z_arch_curr_cpu(void)
 #endif
 }
 
-static ALWAYS_INLINE void kernel_arch_init(void)
+static ALWAYS_INLINE void z_arch_kernel_init(void)
 {
 	z_irq_setup();
 	_current_cpu->irq_stack =

--- a/arch/arc/include/v2/irq.h
+++ b/arch/arc/include/v2/irq.h
@@ -65,7 +65,7 @@ static ALWAYS_INLINE void z_irq_setup(void)
 		_ARC_V2_AUX_IRQ_CTRL_14_REGS     /* save r0 -> r13 (caller-saved) */
 	);
 
-	k_cpu_sleep_mode = _ARC_V2_WAKE_IRQ_LEVEL;
+	z_arc_cpu_sleep_mode = _ARC_V2_WAKE_IRQ_LEVEL;
 
 #ifdef CONFIG_ARC_NORMAL_FIRMWARE
 	/* normal mode cannot write irq_ctrl, ignore it */

--- a/arch/arm/core/cortex_m/vector_table.S
+++ b/arch/arm/core/cortex_m/vector_table.S
@@ -22,7 +22,7 @@
 
 _ASM_FILE_PROLOGUE
 
-GDATA(_main_stack)
+GDATA(z_main_stack)
 
 SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 
@@ -31,7 +31,7 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
      * on the interrupt stack when CONFIG_INIT_STACKS is enabled before
      * switching to the interrupt stack for the rest of the early boot
      */
-    .word _main_stack + CONFIG_MAIN_STACK_SIZE
+    .word z_main_stack + CONFIG_MAIN_STACK_SIZE
 
     .word __reset
     .word __nmi

--- a/arch/arm/core/cpu_idle.S
+++ b/arch/arm/core/cpu_idle.S
@@ -21,8 +21,8 @@
 _ASM_FILE_PROLOGUE
 
 GTEXT(z_CpuIdleInit)
-GTEXT(k_cpu_idle)
-GTEXT(k_cpu_atomic_idle)
+GTEXT(z_arch_cpu_idle)
+GTEXT(z_arch_cpu_atomic_idle)
 
 #if defined(CONFIG_CPU_CORTEX_M)
 #define _SCB_SCR 0xE000ED10
@@ -68,10 +68,10 @@ SECTION_FUNC(TEXT, z_CpuIdleInit)
  *
  * C function prototype:
  *
- * void k_cpu_idle (void);
+ * void z_arch_cpu_idle (void);
  */
 
-SECTION_FUNC(TEXT, k_cpu_idle)
+SECTION_FUNC(TEXT, z_arch_cpu_idle)
 #ifdef CONFIG_TRACING
 	push {r0, lr}
 	bl    sys_trace_idle
@@ -103,7 +103,7 @@ SECTION_FUNC(TEXT, k_cpu_idle)
  * @brief Atomically re-enable interrupts and enter low power mode
  *
  * INTERNAL
- * The requirements for k_cpu_atomic_idle() are as follows:
+ * The requirements for z_arch_cpu_atomic_idle() are as follows:
  * 1) The enablement of interrupts and entering a low-power mode needs to be
  *    atomic, i.e. there should be no period of time where interrupts are
  *    enabled before the processor enters a low-power mode.  See the comments
@@ -117,10 +117,10 @@ SECTION_FUNC(TEXT, k_cpu_idle)
  *
  * C function prototype:
  *
- * void k_cpu_atomic_idle (unsigned int key);
+ * void z_arch_cpu_atomic_idle (unsigned int key);
  */
 
-SECTION_FUNC(TEXT, k_cpu_atomic_idle)
+SECTION_FUNC(TEXT, z_arch_cpu_atomic_idle)
 #ifdef CONFIG_TRACING
 	push {r0, lr}
 	bl    sys_trace_idle

--- a/arch/arm/core/cpu_idle.S
+++ b/arch/arm/core/cpu_idle.S
@@ -37,7 +37,7 @@ GTEXT(z_arch_cpu_atomic_idle)
  *
  * @brief Initialization of CPU idle
  *
- * Only called by kernel_arch_init(). Sets SEVONPEND bit once for the system's
+ * Only called by z_arch_kernel_init(). Sets SEVONPEND bit once for the system's
  * duration.
  *
  * @return N/A

--- a/arch/arm/core/irq_relay.S
+++ b/arch/arm/core/irq_relay.S
@@ -29,7 +29,7 @@ _ASM_FILE_PROLOGUE
 #if defined(CONFIG_SW_VECTOR_RELAY)
 
 GDATA(_vector_table_pointer)
-GDATA(_main_stack)
+GDATA(z_main_stack)
 
 SECTION_FUNC(vector_relay_handler, __vector_relay_handler)
 	mrs	r0, ipsr;
@@ -52,7 +52,7 @@ SECTION_FUNC(vector_relay_handler, __vector_relay_handler)
 GTEXT(__vector_relay_handler)
 
 SECTION_FUNC(vector_relay_table, __vector_relay_table)
-	.word _main_stack + CONFIG_MAIN_STACK_SIZE
+	.word z_main_stack + CONFIG_MAIN_STACK_SIZE
 
 	.word __reset
 

--- a/arch/arm/core/swap.c
+++ b/arch/arm/core/swap.c
@@ -17,13 +17,13 @@ extern const int _k_neg_eagain;
  *
  * @brief Initiate a cooperative context switch
  *
- * The __swap() routine is invoked by various kernel services to effect
- * a cooperative context context switch.  Prior to invoking __swap(), the caller
+ * The z_arch_swap() routine is invoked by various kernel services to effect
+ * a cooperative context context switch.  Prior to invoking z_arch_swap(), the caller
  * disables interrupts via irq_lock() and the return 'key' is passed as a
- * parameter to __swap().  The 'key' actually represents the BASEPRI register
+ * parameter to z_arch_swap().  The 'key' actually represents the BASEPRI register
  * prior to disabling interrupts via the BASEPRI mechanism.
  *
- * __swap() itself does not do much.
+ * z_arch_swap() itself does not do much.
  *
  * It simply stores the intlock key (the BASEPRI value) parameter into
  * current->basepri, and then triggers a PendSV exception, which does
@@ -33,7 +33,7 @@ extern const int _k_neg_eagain;
  * __pendsv all come from handling an interrupt, which means we know the
  * interrupts were not locked: in that case the BASEPRI value is 0.
  *
- * Given that __swap() is called to effect a cooperative context switch,
+ * Given that z_arch_swap() is called to effect a cooperative context switch,
  * only the caller-saved integer registers need to be saved in the thread of the
  * outgoing thread. This is all performed by the hardware, which stores it in
  * its exception stack frame, created when handling the __pendsv exception.
@@ -45,7 +45,7 @@ extern const int _k_neg_eagain;
  * z_arch_thread_return_value_set()
  *
  */
-int __swap(int key)
+int z_arch_swap(unsigned int key)
 {
 #ifdef CONFIG_EXECUTION_BENCHMARKING
 	read_timer_start_of_swap();

--- a/arch/arm/core/swap.c
+++ b/arch/arm/core/swap.c
@@ -42,7 +42,7 @@ extern const int _k_neg_eagain;
  * as BASEPRI is not available.
  *
  * @return -EAGAIN, or a return value set by a call to
- * z_set_thread_return_value()
+ * z_arch_thread_return_value_set()
  *
  */
 int __swap(int key)

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -118,7 +118,7 @@ out_fp_endif:
     isb /* Make the effect of disabling interrupts be realized immediately */
 #elif defined(CONFIG_ARMV7_R)
     /*
-     * Interrupts are still disabled from __swap so empty clause
+     * Interrupts are still disabled from z_arch_swap so empty clause
      * here to avoid the preprocessor error below
      */
 #else

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -50,10 +50,10 @@ extern u8_t *z_priv_stack_find(void *obj);
  * @return N/A
  */
 
-void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
-		 size_t stackSize, k_thread_entry_t pEntry,
-		 void *parameter1, void *parameter2, void *parameter3,
-		 int priority, unsigned int options)
+void z_arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
+		       size_t stackSize, k_thread_entry_t pEntry,
+		       void *parameter1, void *parameter2, void *parameter3,
+		       int priority, unsigned int options)
 {
 	char *pStackMem = Z_THREAD_STACK_BUFFER(stack);
 	char *stackEnd;

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -352,7 +352,7 @@ int z_arch_float_disable(struct k_thread *thread)
 		return -EINVAL;
 	}
 
-	if (z_is_in_isr()) {
+	if (z_arch_is_in_isr()) {
 		return -EINVAL;
 	}
 

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -34,7 +34,7 @@ extern void z_arch_configure_static_mpu_regions(void);
 extern void z_arch_configure_dynamic_mpu_regions(struct k_thread *thread);
 #endif /* CONFIG_ARM_MPU */
 
-static ALWAYS_INLINE void kernel_arch_init(void)
+static ALWAYS_INLINE void z_arch_kernel_init(void)
 {
 	z_InterruptStackSetup();
 	z_ExcSetup();

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -141,7 +141,7 @@ z_set_thread_return_value(struct k_thread *thread, unsigned int value)
 	thread->arch.swap_return_value = value;
 }
 
-extern void k_cpu_atomic_idle(unsigned int key);
+extern void z_arch_cpu_atomic_idle(unsigned int key);
 
 #define z_arch_is_in_isr() z_IsInIsr()
 

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -143,7 +143,7 @@ z_set_thread_return_value(struct k_thread *thread, unsigned int value)
 
 extern void k_cpu_atomic_idle(unsigned int key);
 
-#define z_is_in_isr() z_IsInIsr()
+#define z_arch_is_in_isr() z_IsInIsr()
 
 extern FUNC_NORETURN void z_arm_userspace_enter(k_thread_entry_t user_entry,
 					       void *p1, void *p2, void *p3,

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -136,7 +136,7 @@ z_arch_switch_to_main_thread(struct k_thread *main_thread,
 }
 
 static ALWAYS_INLINE void
-z_set_thread_return_value(struct k_thread *thread, unsigned int value)
+z_arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
 {
 	thread->arch.swap_return_value = value;
 }

--- a/arch/common/timing_info_bench.c
+++ b/arch/common/timing_info_bench.c
@@ -4,21 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <kernel.h>
+#include <kernel_internal.h>
 
-/* #include <kernel_structs.h> */
-
-u64_t  __start_swap_time;
-u64_t  __end_swap_time;
-u64_t  __start_intr_time;
-u64_t  __end_intr_time;
-u64_t  __start_tick_time;
-u64_t  __end_tick_time;
-u64_t  __end_drop_to_usermode_time;
+u64_t  z_arch_timing_swap_start;
+u64_t  z_arch_timing_swap_end;
+u64_t  z_arch_timing_irq_start;
+u64_t  z_arch_timing_irq_end;
+u64_t  z_arch_timing_tick_start;
+u64_t  z_arch_timing_tick_end;
+u64_t  z_arch_timing_enter_user_mode_end;
 
 /* location of the time stamps*/
-u32_t __read_swap_end_time_value;
-u64_t __common_var_swap_end_time;
-u64_t __temp_start_swap_time;
+u32_t z_arch_timing_value_swap_end;
+u64_t z_arch_timing_value_swap_common;
+u64_t z_arch_timing_value_swap_temp;
 
 #ifdef CONFIG_NRF_RTC_TIMER
 #include <nrfx.h>
@@ -80,18 +79,18 @@ u64_t __temp_start_swap_time;
 
 void read_timer_start_of_swap(void)
 {
-	if (__read_swap_end_time_value == 1U) {
+	if (z_arch_timing_value_swap_end == 1U) {
 		TIMING_INFO_PRE_READ();
-		__start_swap_time = (u32_t) TIMING_INFO_OS_GET_TIME();
+		z_arch_timing_swap_start = (u32_t) TIMING_INFO_OS_GET_TIME();
 	}
 }
 
 void read_timer_end_of_swap(void)
 {
-	if (__read_swap_end_time_value == 1U) {
+	if (z_arch_timing_value_swap_end == 1U) {
 		TIMING_INFO_PRE_READ();
-		__read_swap_end_time_value = 2U;
-		__common_var_swap_end_time = (u64_t)TIMING_INFO_OS_GET_TIME();
+		z_arch_timing_value_swap_end = 2U;
+		z_arch_timing_value_swap_common = (u64_t)TIMING_INFO_OS_GET_TIME();
 	}
 }
 
@@ -101,29 +100,29 @@ void read_timer_end_of_swap(void)
 void read_timer_start_of_isr(void)
 {
 	TIMING_INFO_PRE_READ();
-	__start_intr_time  = (u32_t) TIMING_INFO_GET_TIMER_VALUE();
+	z_arch_timing_irq_start  = (u32_t) TIMING_INFO_GET_TIMER_VALUE();
 }
 
 void read_timer_end_of_isr(void)
 {
 	TIMING_INFO_PRE_READ();
-	__end_intr_time  = (u32_t) TIMING_INFO_GET_TIMER_VALUE();
+	z_arch_timing_irq_end  = (u32_t) TIMING_INFO_GET_TIMER_VALUE();
 }
 
 void read_timer_start_of_tick_handler(void)
 {
 	TIMING_INFO_PRE_READ();
-	__start_tick_time  = (u32_t)TIMING_INFO_GET_TIMER_VALUE();
+	z_arch_timing_tick_start  = (u32_t)TIMING_INFO_GET_TIMER_VALUE();
 }
 
 void read_timer_end_of_tick_handler(void)
 {
 	TIMING_INFO_PRE_READ();
-	 __end_tick_time  = (u32_t) TIMING_INFO_GET_TIMER_VALUE();
+	 z_arch_timing_tick_end  = (u32_t) TIMING_INFO_GET_TIMER_VALUE();
 }
 
 void read_timer_end_of_userspace_enter(void)
 {
 	TIMING_INFO_PRE_READ();
-	__end_drop_to_usermode_time  = (u32_t) TIMING_INFO_GET_TIMER_VALUE();
+	z_arch_timing_enter_user_mode_end  = (u32_t) TIMING_INFO_GET_TIMER_VALUE();
 }

--- a/arch/nios2/core/cpu_idle.c
+++ b/arch/nios2/core/cpu_idle.c
@@ -17,7 +17,7 @@
  *
  * @return N/A
  */
-void k_cpu_idle(void)
+void z_arch_cpu_idle(void)
 {
 	/* Do nothing but unconditionally unlock interrupts and return to the
 	 * caller. This CPU does not have any kind of power saving instruction.
@@ -30,7 +30,7 @@ void k_cpu_idle(void)
  * @brief Atomically re-enable interrupts and enter low power mode
  *
  * INTERNAL
- * The requirements for k_cpu_atomic_idle() are as follows:
+ * The requirements for z_arch_cpu_atomic_idle() are as follows:
  * 1) The enablement of interrupts and entering a low-power mode needs to be
  *    atomic, i.e. there should be no period of time where interrupts are
  *    enabled before the processor enters a low-power mode.  See the comments
@@ -42,7 +42,7 @@ void k_cpu_idle(void)
  *
  * @return N/A
  */
-void k_cpu_atomic_idle(unsigned int key)
+void z_arch_cpu_atomic_idle(unsigned int key)
 {
 	/* Do nothing but restore IRQ state. This CPU does not have any
 	 * kind of power saving instruction.

--- a/arch/nios2/core/exception.S
+++ b/arch/nios2/core/exception.S
@@ -12,7 +12,7 @@ GTEXT(_exception)
 
 /* import */
 GTEXT(_Fault)
-GTEXT(__swap)
+GTEXT(z_arch_swap)
 #ifdef CONFIG_IRQ_OFFLOAD
 GTEXT(z_irq_do_offload)
 GTEXT(_offload_routine)
@@ -126,7 +126,7 @@ on_irq_stack:
 	/*
 	 * A context reschedule is required: keep the volatile registers of
 	 * the interrupted thread on the context's stack.  Utilize
-	 * the existing __swap() primitive to save the remaining
+	 * the existing z_arch_swap() primitive to save the remaining
 	 * thread's registers (including floating point) and perform
 	 * a switch to the new thread.
 	 */
@@ -143,7 +143,7 @@ on_irq_stack:
 	 */
 	mov r4, et
 
-	call __swap
+	call z_arch_swap
 	jmpi _exception_exit
 #else
 	jmpi no_reschedule

--- a/arch/nios2/core/swap.S
+++ b/arch/nios2/core/swap.S
@@ -120,7 +120,7 @@ SECTION_FUNC(exception.other, __swap)
 
 	/*
 	 * Load return value into r2 (return value register). -EAGAIN unless
-	 * someone previously called z_set_thread_return_value(). Do this before
+	 * someone previously called z_arch_thread_return_value_set(). Do this before
 	 * we potentially unlock interrupts.
 	 */
 	ldw r2, _thread_offset_to_retval(r2)

--- a/arch/nios2/core/swap.S
+++ b/arch/nios2/core/swap.S
@@ -8,18 +8,18 @@
 #include <offsets_short.h>
 
 /* exports */
-GTEXT(__swap)
+GTEXT(z_arch_swap)
 GTEXT(z_thread_entry_wrapper)
 
 /* imports */
 GTEXT(sys_trace_thread_switched_in)
 GTEXT(_k_neg_eagain)
 
-/* unsigned int __swap(unsigned int key)
+/* unsigned int z_arch_swap(unsigned int key)
  *
  * Always called with interrupts locked
  */
-SECTION_FUNC(exception.other, __swap)
+SECTION_FUNC(exception.other, z_arch_swap)
 
 #ifdef CONFIG_EXECUTION_BENCHMARKING
 	/* Get a reference to _kernel in r10 */
@@ -56,7 +56,7 @@ SECTION_FUNC(exception.other, __swap)
 	ldw  r11, _kernel_offset_to_current(r10)
 
 	/* Store all the callee saved registers. We either got here via
-	 * an exception or from a cooperative invocation of __swap() from C
+	 * an exception or from a cooperative invocation of z_arch_swap() from C
 	 * domain, so all the caller-saved registers have already been
 	 * saved by the exception asm or the calling C code already.
 	 */
@@ -114,7 +114,7 @@ SECTION_FUNC(exception.other, __swap)
 	ldw sp,  _thread_offset_to_sp(r2)
 
 	/* We need to irq_unlock(current->coopReg.key);
-	 * key was supplied as argument to __swap(). Fetch it.
+	 * key was supplied as argument to z_arch_swap(). Fetch it.
 	 */
 	ldw r3, _thread_offset_to_key(r2)
 

--- a/arch/nios2/core/thread.c
+++ b/arch/nios2/core/thread.c
@@ -31,10 +31,10 @@ struct init_stack_frame {
 };
 
 
-void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
-		 size_t stack_size, k_thread_entry_t thread_func,
-		 void *arg1, void *arg2, void *arg3,
-		 int priority, unsigned int options)
+void z_arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
+		       size_t stack_size, k_thread_entry_t thread_func,
+		       void *arg1, void *arg2, void *arg3,
+		       int priority, unsigned int options)
 {
 	char *stack_memory = Z_THREAD_STACK_BUFFER(stack);
 	Z_ASSERT_VALID_PRIO(priority, thread_func);

--- a/arch/nios2/include/kernel_arch_func.h
+++ b/arch/nios2/include/kernel_arch_func.h
@@ -26,7 +26,7 @@ extern "C" {
 
 #ifndef _ASMLANGUAGE
 
-static ALWAYS_INLINE void kernel_arch_init(void)
+static ALWAYS_INLINE void z_arch_kernel_init(void)
 {
 	_kernel.irq_stack =
 		Z_THREAD_STACK_BUFFER(_interrupt_stack) + CONFIG_ISR_STACK_SIZE;

--- a/arch/nios2/include/kernel_arch_func.h
+++ b/arch/nios2/include/kernel_arch_func.h
@@ -33,7 +33,7 @@ static ALWAYS_INLINE void kernel_arch_init(void)
 }
 
 static ALWAYS_INLINE void
-z_set_thread_return_value(struct k_thread *thread, unsigned int value)
+z_arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
 {
 	thread->callee_saved.retval = value;
 }

--- a/arch/nios2/include/kernel_arch_func.h
+++ b/arch/nios2/include/kernel_arch_func.h
@@ -44,7 +44,7 @@ z_set_thread_return_value(struct k_thread *thread, unsigned int value)
 FUNC_NORETURN void z_nios2_fatal_error(unsigned int reason,
 				       const z_arch_esf_t *esf);
 
-#define z_is_in_isr() (_kernel.nested != 0U)
+#define z_arch_is_in_isr() (_kernel.nested != 0U)
 
 #ifdef CONFIG_IRQ_OFFLOAD
 void z_irq_do_offload(void);

--- a/arch/nios2/include/kernel_arch_func.h
+++ b/arch/nios2/include/kernel_arch_func.h
@@ -26,9 +26,6 @@ extern "C" {
 
 #ifndef _ASMLANGUAGE
 
-void k_cpu_idle(void);
-void k_cpu_atomic_idle(unsigned int key);
-
 static ALWAYS_INLINE void kernel_arch_init(void)
 {
 	_kernel.irq_stack =

--- a/arch/posix/core/cpuhalt.c
+++ b/arch/posix/core/cpuhalt.c
@@ -10,11 +10,11 @@
  * This module provides:
  *
  * An implementation of the architecture-specific
- * k_cpu_idle() primitive required by the kernel idle loop component.
+ * z_arch_cpu_idle() primitive required by the kernel idle loop component.
  * It can be called within an implementation of _sys_power_save_idle(),
  * which is provided for the kernel by the platform.
  *
- * An implementation of k_cpu_atomic_idle(), which
+ * An implementation of z_arch_cpu_atomic_idle(), which
  * atomically re-enables interrupts and enters low power mode.
  *
  * A weak stub for sys_arch_reboot(), which does nothing
@@ -36,7 +36,7 @@
  *
  * @return N/A
  */
-void k_cpu_idle(void)
+void z_arch_cpu_idle(void)
 {
 	sys_trace_idle();
 	posix_irq_full_unlock();
@@ -48,7 +48,7 @@ void k_cpu_idle(void)
  * @brief Atomically re-enable interrupts and enter low power mode
  *
  * INTERNAL
- * The requirements for k_cpu_atomic_idle() are as follows:
+ * The requirements for z_arch_cpu_atomic_idle() are as follows:
  * 1) The enablement of interrupts and entering a low-power mode needs to be
  *    atomic, i.e. there should be no period of time where interrupts are
  *    enabled before the processor enters a low-power mode.  See the comments
@@ -62,7 +62,7 @@ void k_cpu_idle(void)
  *
  * @return N/A
  */
-void k_cpu_atomic_idle(unsigned int key)
+void z_arch_cpu_atomic_idle(unsigned int key)
 {
 	sys_trace_idle();
 	posix_atomic_halt_cpu(key);

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -361,10 +361,10 @@ static int ttable_get_empty_slot(void)
 }
 
 /**
- * Called from z_new_thread(),
+ * Called from z_arch_new_thread(),
  * Create a new POSIX thread for the new Zephyr thread.
- * z_new_thread() picks from the kernel structures what it is that we need to
- * call with what parameters
+ * z_arch_new_thread() picks from the kernel structures what it is that we need
+ * to call with what parameters
  */
 void posix_new_thread(posix_thread_status_t *ptr)
 {

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -187,7 +187,7 @@ static void posix_preexit_cleanup(void)
 /**
  * Let the ready thread run and block this thread until it is allowed again
  *
- * called from __swap() which does the picking from the kernel structures
+ * called from z_arch_swap() which does the picking from the kernel structures
  */
 void posix_swap(int next_allowed_thread_nbr, int this_th_nbr)
 {
@@ -256,7 +256,7 @@ static void posix_cleanup_handler(void *arg)
 
 /**
  * Helper function to start a Zephyr thread as a POSIX thread:
- *  It will block the thread until a __swap() is called for it
+ *  It will block the thread until a z_arch_swap() is called for it
  *
  * Spawned from posix_new_thread() below
  */

--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -9,7 +9,7 @@
  * @file
  * @brief Kernel swapper code for POSIX
  *
- * This module implements the __swap() routine for the POSIX architecture.
+ * This module implements the z_arch_swap() routine for the POSIX architecture.
  *
  */
 
@@ -23,10 +23,10 @@
  *
  * @brief Initiate a cooperative context switch
  *
- * The __swap() routine is invoked by various kernel services to effect
- * a cooperative context switch.  Prior to invoking __swap(), the
+ * The z_arch_swap() routine is invoked by various kernel services to effect
+ * a cooperative context switch.  Prior to invoking z_arch_swap(), the
  * caller disables interrupts (via irq_lock) and the return 'key'
- * is passed as a parameter to __swap().
+ * is passed as a parameter to z_arch_swap().
  *
  *
  * @return -EAGAIN, or a return value set by a call to
@@ -34,7 +34,7 @@
  *
  */
 
-int __swap(unsigned int key)
+int z_arch_swap(unsigned int key)
 {
 /*
  * struct k_thread * _kernel.current is the currently runnig thread
@@ -80,7 +80,7 @@ int __swap(unsigned int key)
 
 #ifdef CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN
 /**
- * This is just a version of __swap() in which we do not save anything about the
+ * This is just a version of z_arch_swap() in which we do not save anything about the
  * current thread.
  *
  * Note that we will never come back to this thread:

--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -30,7 +30,7 @@
  *
  *
  * @return -EAGAIN, or a return value set by a call to
- * z_set_thread_return_value()
+ * z_arch_thread_return_value_set()
  *
  */
 
@@ -48,7 +48,7 @@ int __swap(unsigned int key)
  */
 	_kernel.current->callee_saved.key = key;
 	_kernel.current->callee_saved.retval = -EAGAIN;
-	/* retval may be modified with a call to z_set_thread_return_value() */
+	/* retval may be modified with a call to z_arch_thread_return_value_set() */
 
 	posix_thread_status_t *ready_thread_ptr =
 		(posix_thread_status_t *)

--- a/arch/posix/core/thread.c
+++ b/arch/posix/core/thread.c
@@ -41,10 +41,10 @@
  * pthreads stack and therefore we ignore the stack size
  *
  */
-void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
-		size_t stack_size, k_thread_entry_t thread_func,
-		void *arg1, void *arg2, void *arg3,
-		int priority, unsigned int options)
+void z_arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
+		       size_t stack_size, k_thread_entry_t thread_func,
+		       void *arg1, void *arg2, void *arg3,
+		       int priority, unsigned int options)
 {
 
 	char *stack_memory = Z_THREAD_STACK_BUFFER(stack);

--- a/arch/posix/include/kernel_arch_func.h
+++ b/arch/posix/include/kernel_arch_func.h
@@ -53,7 +53,7 @@ z_set_thread_return_value(struct k_thread *thread, unsigned int value)
 }
 #endif
 
-#define z_is_in_isr() (_kernel.nested != 0U)
+#define z_arch_is_in_isr() (_kernel.nested != 0U)
 
 #endif /* _ASMLANGUAGE */
 

--- a/arch/posix/include/kernel_arch_func.h
+++ b/arch/posix/include/kernel_arch_func.h
@@ -36,7 +36,7 @@ void z_arch_switch_to_main_thread(struct k_thread *main_thread,
  *
  * @return N/A
  */
-static inline void kernel_arch_init(void)
+static inline void z_arch_kernel_init(void)
 {
 	/* Nothing to be done */
 }

--- a/arch/posix/include/kernel_arch_func.h
+++ b/arch/posix/include/kernel_arch_func.h
@@ -44,7 +44,7 @@ static inline void kernel_arch_init(void)
 
 
 static ALWAYS_INLINE void
-z_set_thread_return_value(struct k_thread *thread, unsigned int value)
+z_arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
 {
 	thread->callee_saved.retval = value;
 }

--- a/arch/riscv/core/cpu_idle.c
+++ b/arch/riscv/core/cpu_idle.c
@@ -9,11 +9,11 @@
 /*
  * In RISC-V there is no conventional way to handle CPU power save.
  * Each RISC-V SOC handles it in its own way.
- * Hence, by default, k_cpu_idle and k_cpu_atomic_idle functions just
+ * Hence, by default, z_arch_cpu_idle and z_arch_cpu_atomic_idle functions just
  * unlock interrupts and return to the caller, without issuing any CPU power
  * saving instruction.
  *
- * Nonetheless, define the default k_cpu_idle and k_cpu_atomic_idle
+ * Nonetheless, define the default z_arch_cpu_idle and z_arch_cpu_atomic_idle
  * functions as weak functions, so that they can be replaced at the SOC-level.
  */
 
@@ -27,7 +27,7 @@
  *
  * @return N/A
  */
-void __weak k_cpu_idle(void)
+void __weak z_arch_cpu_idle(void)
 {
 	irq_unlock(SOC_MSTATUS_IEN);
 }
@@ -37,7 +37,7 @@ void __weak k_cpu_idle(void)
  * @brief Atomically re-enable interrupts and enter low power mode
  *
  * INTERNAL
- * The requirements for k_cpu_atomic_idle() are as follows:
+ * The requirements for z_arch_cpu_atomic_idle() are as follows:
  * 1) The enablement of interrupts and entering a low-power mode needs to be
  *    atomic, i.e. there should be no period of time where interrupts are
  *    enabled before the processor enters a low-power mode.  See the comments
@@ -49,7 +49,7 @@ void __weak k_cpu_idle(void)
  *
  * @return N/A
  */
-void __weak k_cpu_atomic_idle(unsigned int key)
+void __weak z_arch_cpu_atomic_idle(unsigned int key)
 {
 	irq_unlock(key);
 }

--- a/arch/riscv/core/swap.S
+++ b/arch/riscv/core/swap.S
@@ -78,7 +78,7 @@ SECTION_FUNC(exception.other, __swap)
 	 * Prior to unlocking irq, load return value of
 	 * __swap to temp register t2 (from
 	 * _thread_offset_to_swap_return_value). Normally, it should be -EAGAIN,
-	 * unless someone has previously called z_set_thread_return_value(..).
+	 * unless someone has previously called z_arch_thread_return_value_set(..).
 	 */
 	la t0, _kernel
 

--- a/arch/riscv/core/swap.S
+++ b/arch/riscv/core/swap.S
@@ -9,18 +9,18 @@
 #include <offsets_short.h>
 
 /* exports */
-GTEXT(__swap)
+GTEXT(z_arch_swap)
 GTEXT(z_thread_entry_wrapper)
 
 /* Use ABI name of registers for the sake of simplicity */
 
 /*
- * unsigned int __swap(unsigned int key)
+ * unsigned int z_arch_swap(unsigned int key)
  *
  * Always called with interrupts locked
  * key is stored in a0 register
  */
-SECTION_FUNC(exception.other, __swap)
+SECTION_FUNC(exception.other, z_arch_swap)
 
 	/* Make a system call to perform context switch */
 #ifdef CONFIG_EXECUTION_BENCHMARKING
@@ -76,7 +76,7 @@ SECTION_FUNC(exception.other, __swap)
 	 * Restored register a0 contains IRQ lock state of thread.
 	 *
 	 * Prior to unlocking irq, load return value of
-	 * __swap to temp register t2 (from
+	 * z_arch_swap to temp register t2 (from
 	 * _thread_offset_to_swap_return_value). Normally, it should be -EAGAIN,
 	 * unless someone has previously called z_arch_thread_return_value_set(..).
 	 */
@@ -85,7 +85,7 @@ SECTION_FUNC(exception.other, __swap)
 	/* Get pointer to _kernel.current */
 	RV_OP_LOADREG t1, _kernel_offset_to_current(t0)
 
-	/* Load return value of __swap function in temp register t2 */
+	/* Load return value of z_arch_swap function in temp register t2 */
 	lw t2, _thread_offset_to_swap_return_value(t1)
 
 	/*
@@ -108,7 +108,7 @@ SECTION_FUNC(exception.other, __swap)
 SECTION_FUNC(TEXT, z_thread_entry_wrapper)
 	/*
 	 * z_thread_entry_wrapper is called for every new thread upon the return
-	 * of __swap or ISR. Its address, as well as its input function
+	 * of z_arch_swap or ISR. Its address, as well as its input function
 	 * arguments thread_entry_t, void *, void *, void * are restored from
 	 * the thread stack (initialized via function _thread).
 	 * In this case, thread_entry_t, * void *, void * and void * are stored

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -15,10 +15,10 @@ void z_thread_entry_wrapper(k_thread_entry_t thread,
 			   void *arg2,
 			   void *arg3);
 
-void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
-		 size_t stack_size, k_thread_entry_t thread_func,
-		 void *arg1, void *arg2, void *arg3,
-		 int priority, unsigned int options)
+void z_arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
+		       size_t stack_size, k_thread_entry_t thread_func,
+		       void *arg1, void *arg2, void *arg3,
+		       int priority, unsigned int options)
 {
 	char *stack_memory = Z_THREAD_STACK_BUFFER(stack);
 	Z_ASSERT_VALID_PRIO(priority, thread_func);

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -22,9 +22,6 @@ extern "C" {
 #endif
 
 #ifndef _ASMLANGUAGE
-void k_cpu_idle(void);
-void k_cpu_atomic_idle(unsigned int key);
-
 static ALWAYS_INLINE void kernel_arch_init(void)
 {
 	_kernel.irq_stack =

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -22,7 +22,7 @@ extern "C" {
 #endif
 
 #ifndef _ASMLANGUAGE
-static ALWAYS_INLINE void kernel_arch_init(void)
+static ALWAYS_INLINE void z_arch_kernel_init(void)
 {
 	_kernel.irq_stack =
 		Z_THREAD_STACK_BUFFER(_interrupt_stack) + CONFIG_ISR_STACK_SIZE;

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -40,7 +40,7 @@ z_set_thread_return_value(struct k_thread *thread, unsigned int value)
 FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 				       const z_arch_esf_t *esf);
 
-#define z_is_in_isr() (_kernel.nested != 0U)
+#define z_arch_is_in_isr() (_kernel.nested != 0U)
 
 #ifdef CONFIG_IRQ_OFFLOAD
 int z_irq_do_offload(void);

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -29,7 +29,7 @@ static ALWAYS_INLINE void kernel_arch_init(void)
 }
 
 static ALWAYS_INLINE void
-z_set_thread_return_value(struct k_thread *thread, unsigned int value)
+z_arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
 {
 	thread->arch.swap_return_value = value;
 }

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -151,7 +151,7 @@ config X86_VERY_EARLY_CONSOLE
 	  Non-emulated X86 devices often require special hardware to attach
 	  a debugger, which may not be easily available. This option adds a
 	  very minimal serial driver which gets initialized at the very
-	  beginning of z_cstart(), via kernel_arch_init(). This driver enables
+	  beginning of z_cstart(), via z_arch_kernel_init(). This driver enables
 	  printk to emit messages to the 16550 UART port 0 instance in device
 	  tree. This mini-driver assumes I/O to the UART is done via ports.
 

--- a/arch/x86/core/cpuhalt.c
+++ b/arch/x86/core/cpuhalt.c
@@ -18,7 +18,7 @@
  *
  * @return N/A
  */
-void k_cpu_idle(void)
+void z_arch_cpu_idle(void)
 {
 	sys_trace_idle();
 #if defined(CONFIG_BOOT_TIME_MEASUREMENT)
@@ -35,7 +35,7 @@ void k_cpu_idle(void)
  * @brief Atomically re-enable interrupts and enter low power mode
  *
  * INTERNAL
- * The requirements for k_cpu_atomic_idle() are as follows:
+ * The requirements for z_arch_cpu_atomic_idle() are as follows:
  * 1) The enablement of interrupts and entering a low-power mode needs to be
  *    atomic, i.e. there should be no period of time where interrupts are
  *    enabled before the processor enters a low-power mode.  See the comments
@@ -48,7 +48,7 @@ void k_cpu_idle(void)
  * @return N/A
  */
 
-void k_cpu_atomic_idle(unsigned int key)
+void z_arch_cpu_atomic_idle(unsigned int key)
 {
 	sys_trace_idle();
 
@@ -63,7 +63,7 @@ void k_cpu_atomic_idle(unsigned int key)
 	     *    external, maskable interrupts after the next instruction is
 	     *    executed."
 	     *
-	     * Thus the IA-32 implementation of k_cpu_atomic_idle() will
+	     * Thus the IA-32 implementation of z_arch_cpu_atomic_idle() will
 	     * atomically re-enable interrupts and enter a low-power mode.
 	     */
 	    "hlt\n\t");

--- a/arch/x86/core/cpuhalt.c
+++ b/arch/x86/core/cpuhalt.c
@@ -21,10 +21,6 @@
 void z_arch_cpu_idle(void)
 {
 	sys_trace_idle();
-#if defined(CONFIG_BOOT_TIME_MEASUREMENT)
-	__idle_time_stamp = k_cycle_get_32();
-#endif
-
 	__asm__ volatile (
 	    "sti\n\t"
 	    "hlt\n\t");

--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -41,7 +41,7 @@ static bool check_stack_bounds(u32_t addr, size_t size, u16_t cs)
 {
 	u32_t start, end;
 
-	if (z_is_in_isr()) {
+	if (z_arch_is_in_isr()) {
 		/* We were servicing an interrupt */
 		start = (u32_t)Z_ARCH_THREAD_STACK_BUFFER(_interrupt_stack);
 		end = start + CONFIG_ISR_STACK_SIZE;

--- a/arch/x86/core/ia32/intstub.S
+++ b/arch/x86/core/ia32/intstub.S
@@ -30,7 +30,7 @@
 
 	/* externs */
 
-	GTEXT(__swap)
+	GTEXT(z_arch_swap)
 
 #ifdef CONFIG_SYS_POWER_MANAGEMENT
 	GTEXT(z_sys_power_save_idle_exit)
@@ -126,7 +126,7 @@ SECTION_FUNC(TEXT, _interrupt_enter)
 
 	/* Push EDI as we will use it for scratch space.
 	 * Rest of the callee-saved regs get saved by invocation of C
-	 * functions (isr handler, __swap(), etc)
+	 * functions (isr handler, z_arch_swap(), etc)
 	 */
 	pushl	%edi
 
@@ -228,7 +228,7 @@ alreadyOnIntStack:
 
 	/*
 	 * Set X86_THREAD_FLAG_INT bit in k_thread to allow the upcoming call
-	 * to __swap() to determine whether non-floating registers need to be
+	 * to z_arch_swap() to determine whether non-floating registers need to be
 	 * preserved using the lazy save/restore algorithm, or to indicate to
 	 * debug tools that a preemptive context switch has occurred.
 	 */
@@ -240,7 +240,7 @@ alreadyOnIntStack:
 	/*
 	 * A context reschedule is required: keep the volatile registers of
 	 * the interrupted thread on the context's stack.  Utilize
-	 * the existing __swap() primitive to save the remaining
+	 * the existing z_arch_swap() primitive to save the remaining
 	 * thread's registers (including floating point) and perform
 	 * a switch to the new thread.
 	 */
@@ -251,12 +251,12 @@ alreadyOnIntStack:
 	call	z_check_stack_sentinel
 #endif
 	pushfl			/* push KERNEL_LOCK_KEY argument */
-	call	__swap
+	call	z_arch_swap
 	addl 	$4, %esp	/* pop KERNEL_LOCK_KEY argument */
 
 	/*
 	 * The interrupted thread has now been scheduled,
-	 * as the result of a _later_ invocation of __swap().
+	 * as the result of a _later_ invocation of z_arch_swap().
 	 *
 	 * Now need to restore the interrupted thread's environment before
 	 * returning control to it at the point where it was interrupted ...
@@ -264,7 +264,7 @@ alreadyOnIntStack:
 
 #if defined(CONFIG_LAZY_FP_SHARING)
 	/*
-	 * __swap() has restored the floating point registers, if needed.
+	 * z_arch_swap() has restored the floating point registers, if needed.
 	 * Clear X86_THREAD_FLAG_INT in the interrupted thread's state
 	 * since it has served its purpose.
 	 */

--- a/arch/x86/core/ia32/intstub.S
+++ b/arch/x86/core/ia32/intstub.S
@@ -84,8 +84,8 @@ SECTION_FUNC(TEXT, _interrupt_enter)
 	pushl %eax
 	pushl %edx
 	rdtsc
-	mov %eax, __start_intr_time
-	mov %edx, __start_intr_time+4
+	mov %eax, z_arch_timing_irq_start
+	mov %edx, z_arch_timing_irq_start+4
 	pop %edx
 	pop %eax
 #endif
@@ -187,8 +187,8 @@ alreadyOnIntStack:
 	pushl %eax
 	pushl %edx
 	rdtsc
-	mov %eax,__end_intr_time
-	mov %edx,__end_intr_time+4
+	mov %eax,z_arch_timing_irq_end
+	mov %edx,z_arch_timing_irq_end+4
 	pop %edx
 	pop %eax
 #endif

--- a/arch/x86/core/ia32/irq_manage.c
+++ b/arch/x86/core/ia32/irq_manage.c
@@ -64,7 +64,7 @@ void z_arch_isr_direct_header(void)
 	sys_trace_isr_enter();
 
 	/* We're not going to unlock IRQs, but we still need to increment this
-	 * so that z_is_in_isr() works
+	 * so that z_arch_is_in_isr() works
 	 */
 	++_kernel.nested;
 }

--- a/arch/x86/core/ia32/swap.S
+++ b/arch/x86/core/ia32/swap.S
@@ -382,19 +382,19 @@ time_read_not_needed:
  *
  * @brief Adjust stack/parameters before invoking thread entry function
  *
- * This function adjusts the initial stack frame created by z_new_thread() such
- * that the GDB stack frame unwinders recognize it as the outermost frame in
- * the thread's stack.
+ * This function adjusts the initial stack frame created by z_arch_new_thread()
+ * such that the GDB stack frame unwinders recognize it as the outermost frame
+ * in the thread's stack.
  *
  * GDB normally stops unwinding a stack when it detects that it has
  * reached a function called main().  Kernel threads, however, do not have
  * a main() function, and there does not appear to be a simple way of stopping
  * the unwinding of the stack.
  *
- * Given the initial thread created by z_new_thread(), GDB expects to find a
- * return address on the stack immediately above the thread entry routine
- * z_thread_entry, in the location occupied by the initial EFLAGS.
- * GDB attempts to examine the memory at this return address, which typically
+ * Given the initial thread created by z_arch_new_thread(), GDB expects to find
+ * a return address on the stack immediately above the thread entry routine
+ * z_thread_entry, in the location occupied by the initial EFLAGS.  GDB
+ * attempts to examine the memory at this return address, which typically
  * results in an invalid access to page 0 of memory.
  *
  * This function overwrites the initial EFLAGS with zero.  When GDB subsequently

--- a/arch/x86/core/ia32/swap.S
+++ b/arch/x86/core/ia32/swap.S
@@ -8,7 +8,7 @@
  * @file
  * @brief Kernel swapper code for IA-32
  *
- * This module implements the __swap() routine for the IA-32 architecture.
+ * This module implements the z_arch_swap() routine for the IA-32 architecture.
  */
 
 #include <kernel_structs.h>
@@ -17,7 +17,7 @@
 
 	/* exports (internal APIs) */
 
-	GTEXT(__swap)
+	GTEXT(z_arch_swap)
 	GTEXT(z_x86_thread_entry_wrapper)
 	GTEXT(_x86_user_thread_entry_wrapper)
 
@@ -31,13 +31,13 @@
  *
  * @brief Initiate a cooperative context switch
  *
- * The __swap() routine is invoked by various kernel services to effect
- * a cooperative context switch.  Prior to invoking __swap(), the
+ * The z_arch_swap() routine is invoked by various kernel services to effect
+ * a cooperative context switch.  Prior to invoking z_arch_swap(), the
  * caller disables interrupts (via irq_lock) and the return 'key'
- * is passed as a parameter to __swap().  The 'key' actually represents
+ * is passed as a parameter to z_arch_swap().  The 'key' actually represents
  * the EFLAGS register prior to disabling interrupts via a 'cli' instruction.
  *
- * Given that __swap() is called to effect a cooperative context switch, only
+ * Given that z_arch_swap() is called to effect a cooperative context switch, only
  * the non-volatile integer registers need to be saved in the TCS of the
  * outgoing thread.  The restoration of the integer registers of the incoming
  * thread depends on whether that thread was preemptively context switched out.
@@ -72,7 +72,7 @@
  *
  * C function prototype:
  *
- * unsigned int __swap (unsigned int eflags);
+ * unsigned int z_arch_swap (unsigned int eflags);
  *
  */
 
@@ -85,7 +85,7 @@
 	pop %edx
 	pop %eax
 .endm
-SECTION_FUNC(TEXT, __swap)
+SECTION_FUNC(TEXT, z_arch_swap)
 #ifdef CONFIG_EXECUTION_BENCHMARKING
 	/* Save the eax and edx registers before reading the time stamp
 	* once done pop the values.
@@ -356,12 +356,12 @@ CROHandlingDone:
 	/*
 	 * %eax may contain one of these values:
 	 *
-	 * - the return value for __swap() that was set up by a call to
+	 * - the return value for z_arch_swap() that was set up by a call to
 	 * z_arch_thread_return_value_set()
 	 * - -EINVAL
 	 */
 
-	/* Utilize the 'eflags' parameter to __swap() */
+	/* Utilize the 'eflags' parameter to z_arch_swap() */
 
 	pushl	4(%esp)
 	popfl

--- a/arch/x86/core/ia32/swap.S
+++ b/arch/x86/core/ia32/swap.S
@@ -68,7 +68,7 @@
  * potential security leaks.
  *
  * @return -EAGAIN, or a return value set by a call to
- * z_set_thread_return_value()
+ * z_arch_thread_return_value_set()
  *
  * C function prototype:
  *
@@ -117,7 +117,7 @@ SECTION_FUNC(TEXT, __swap)
 	 * Carve space for the return value. Setting it to a default of
 	 * -EAGAIN eliminates the need for the timeout code to set it.
 	 * If another value is ever needed, it can be modified with
-	 * z_set_thread_return_value().
+	 * z_arch_thread_return_value_set().
 	 */
 
 	pushl   _k_neg_eagain
@@ -342,7 +342,7 @@ CROHandlingDone:
 	movl	_thread_offset_to_esp(%eax), %esp
 
 
-	/* load return value from a possible z_set_thread_return_value() */
+	/* load return value from a possible z_arch_thread_return_value_set() */
 
 	popl	%eax
 
@@ -357,7 +357,7 @@ CROHandlingDone:
 	 * %eax may contain one of these values:
 	 *
 	 * - the return value for __swap() that was set up by a call to
-	 * z_set_thread_return_value()
+	 * z_arch_thread_return_value_set()
 	 * - -EINVAL
 	 */
 

--- a/arch/x86/core/ia32/swap.S
+++ b/arch/x86/core/ia32/swap.S
@@ -93,8 +93,8 @@ SECTION_FUNC(TEXT, __swap)
 	push %eax
 	push %edx
 	rdtsc
-	mov %eax,__start_swap_time
-	mov %edx,__start_swap_time+4
+	mov %eax,z_arch_timing_swap_start
+	mov %edx,z_arch_timing_swap_start+4
 	pop %edx
 	pop %eax
 #endif
@@ -367,15 +367,12 @@ CROHandlingDone:
 	popfl
 
 #ifdef CONFIG_EXECUTION_BENCHMARKING
-	/* Save the eax and edx registers before reading the time stamp
-	* once done pop the values.
-	*/
-	cmp $0x1,__read_swap_end_time_value
+	cmp $0x1,z_arch_timing_value_swap_end
 	jne time_read_not_needed
-	movw $0x2,__read_swap_end_time_value
-	read_tsc __common_var_swap_end_time
-	pushl __start_swap_time
-	popl __temp_start_swap_time
+	movw $0x2,z_arch_timing_value_swap_end
+	read_tsc z_arch_timing_value_swap_common
+	pushl z_arch_timing_swap_start
+	popl z_arch_timing_value_swap_temp
 time_read_not_needed:
 #endif
 	ret

--- a/arch/x86/core/ia32/thread.c
+++ b/arch/x86/core/ia32/thread.c
@@ -190,10 +190,10 @@ int z_arch_float_disable(struct k_thread *thread)
  * @param priority thread priority
  * @param options thread options: K_ESSENTIAL, K_FP_REGS, K_SSE_REGS
  */
-void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
-		 size_t stack_size, k_thread_entry_t entry,
-		 void *parameter1, void *parameter2, void *parameter3,
-		 int priority, unsigned int options)
+void z_arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
+		       size_t stack_size, k_thread_entry_t entry,
+		       void *parameter1, void *parameter2, void *parameter3,
+		       int priority, unsigned int options)
 {
 	char *stack_buf;
 	char *stack_high;

--- a/arch/x86/core/ia32/userspace.S
+++ b/arch/x86/core/ia32/userspace.S
@@ -394,8 +394,8 @@ SECTION_FUNC(TEXT, z_x86_userspace_enter)
 	push %eax
 	push %edx
 	rdtsc
-	mov %eax,__end_drop_to_usermode_time
-	mov %edx,__end_drop_to_usermode_time+4
+	mov %eax,z_arch_timing_enter_user_mode_end
+	mov %edx,z_arch_timing_enter_user_mode_end+4
 	pop %edx
 	pop %eax
 #endif

--- a/arch/x86/core/ia32/x86_mmu.c
+++ b/arch/x86/core/ia32/x86_mmu.c
@@ -506,7 +506,7 @@ static void add_mmu_region(struct x86_mmu_pdpt *pdpt, struct mmu_region *rgn,
 extern struct mmu_region z_x86_mmulist_start[];
 extern struct mmu_region z_x86_mmulist_end[];
 
-/* Called from x86's kernel_arch_init() */
+/* Called from x86's z_arch_kernel_init() */
 void z_x86_paging_init(void)
 {
 	size_t pages_free;

--- a/arch/x86/core/intel64/thread.c
+++ b/arch/x86/core/intel64/thread.c
@@ -10,10 +10,10 @@
 
 extern void x86_sse_init(struct k_thread *); /* in locore.S */
 
-void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
-			size_t stack_size, k_thread_entry_t entry,
-			void *parameter1, void *parameter2, void *parameter3,
-			int priority, unsigned int options)
+void z_arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
+		       size_t stack_size, k_thread_entry_t entry,
+		       void *parameter1, void *parameter2, void *parameter3,
+		       int priority, unsigned int options)
 {
 	Z_ASSERT_VALID_PRIO(priority, entry);
 	z_new_thread_init(thread, Z_THREAD_STACK_BUFFER(stack),

--- a/arch/x86/include/ia32/kernel_arch_func.h
+++ b/arch/x86/include/ia32/kernel_arch_func.h
@@ -60,7 +60,7 @@ static inline void kernel_arch_init(void)
  * @return N/A
  */
 static ALWAYS_INLINE void
-z_set_thread_return_value(struct k_thread *thread, unsigned int value)
+z_arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
 {
 	/* write into 'eax' slot created in z_swap() entry */
 

--- a/arch/x86/include/ia32/kernel_arch_func.h
+++ b/arch/x86/include/ia32/kernel_arch_func.h
@@ -67,7 +67,7 @@ z_set_thread_return_value(struct k_thread *thread, unsigned int value)
 	*(unsigned int *)(thread->callee_saved.esp) = value;
 }
 
-extern void k_cpu_atomic_idle(unsigned int key);
+extern void z_arch_cpu_atomic_idle(unsigned int key);
 
 #ifdef CONFIG_USERSPACE
 extern FUNC_NORETURN void z_x86_userspace_enter(k_thread_entry_t user_entry,

--- a/arch/x86/include/ia32/kernel_arch_func.h
+++ b/arch/x86/include/ia32/kernel_arch_func.h
@@ -41,7 +41,7 @@ void z_x86_paging_init(void);
  *
  * @return N/A
  */
-static inline void kernel_arch_init(void)
+static inline void z_arch_kernel_init(void)
 {
 	/* No-op on this arch */
 }

--- a/arch/x86/include/ia32/kernel_arch_thread.h
+++ b/arch/x86/include/ia32/kernel_arch_thread.h
@@ -202,7 +202,7 @@ typedef struct s_preempFloatReg {
  * The thread control structure definition.  It contains the
  * various fields to manage a _single_ thread. The TCS will be aligned
  * to the appropriate architecture specific boundary via the
- * z_new_thread() call.
+ * z_arch_new_thread() call.
  */
 
 struct _thread_arch {

--- a/arch/x86/include/intel64/kernel_arch_func.h
+++ b/arch/x86/include/intel64/kernel_arch_func.h
@@ -10,7 +10,7 @@
 
 extern void z_arch_switch(void *switch_to, void **switched_from);
 
-static inline void kernel_arch_init(void)
+static inline void z_arch_kernel_init(void)
 {
 	/* nothing */;
 }

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -12,7 +12,7 @@
 #include <ia32/kernel_arch_func.h>
 #endif
 
-#define z_is_in_isr() (_kernel.nested != 0U)
+#define z_arch_is_in_isr() (_kernel.nested != 0U)
 
 #ifndef _ASMLANGUAGE
 

--- a/arch/x86_64/core/x86_64.c
+++ b/arch/x86_64/core/x86_64.c
@@ -43,7 +43,7 @@ void z_arch_new_thread(struct k_thread *t, k_thread_stack_t *stack,
 						   nargs);
 }
 
-void k_cpu_idle(void)
+void z_arch_cpu_idle(void)
 {
 	sys_trace_idle();
 	__asm__ volatile("sti; hlt");

--- a/arch/x86_64/core/x86_64.c
+++ b/arch/x86_64/core/x86_64.c
@@ -24,10 +24,10 @@ struct device;
 struct z_arch_esf_t {
 };
 
-void z_new_thread(struct k_thread *t, k_thread_stack_t *stack,
-		 size_t sz, k_thread_entry_t entry,
-		 void *p1, void *p2, void *p3,
-		 int prio, unsigned int opts)
+void z_arch_new_thread(struct k_thread *t, k_thread_stack_t *stack,
+		       size_t sz, k_thread_entry_t entry,
+		       void *p1, void *p2, void *p3,
+		       int prio, unsigned int opts)
 {
 	void *args[] = { entry, p1, p2, p3 };
 	int nargs = 4;

--- a/arch/x86_64/include/kernel_arch_func.h
+++ b/arch/x86_64/include/kernel_arch_func.h
@@ -78,7 +78,7 @@ static inline unsigned int z_arch_k_cycle_get_32(void)
 #endif
 }
 
-#define z_is_in_isr() (z_arch_curr_cpu()->nested != 0)
+#define z_arch_is_in_isr() (z_arch_curr_cpu()->nested != 0)
 
 static inline void z_arch_switch(void *switch_to, void **switched_from)
 {

--- a/arch/x86_64/include/kernel_arch_func.h
+++ b/arch/x86_64/include/kernel_arch_func.h
@@ -9,7 +9,7 @@
 #include <irq.h>
 #include <xuk-switch.h>
 
-static inline void kernel_arch_init(void)
+static inline void z_arch_kernel_init(void)
 {
 	/* This is a noop, we already took care of things before
 	 * z_cstart() is entered

--- a/arch/x86_64/include/kernel_arch_func.h
+++ b/arch/x86_64/include/kernel_arch_func.h
@@ -51,7 +51,7 @@ static inline bool z_arch_irq_unlocked(unsigned int key)
 	return (key & 0x200) != 0;
 }
 
-static inline void arch_nop(void)
+static inline void z_arch_nop(void)
 {
 	__asm__ volatile("nop");
 }

--- a/arch/xtensa/core/cpu_idle.c
+++ b/arch/xtensa/core/cpu_idle.c
@@ -10,9 +10,9 @@
  *
  * This function always exits with interrupts unlocked.
  *
- * void k_cpu_idle(void)
+ * void z_arch_cpu_idle(void)
  */
-void k_cpu_idle(void)
+void z_arch_cpu_idle(void)
 {
 	sys_trace_idle();
 	__asm__ volatile ("waiti 0");
@@ -22,9 +22,9 @@ void k_cpu_idle(void)
  *
  * This function exits with interrupts restored to <key>.
  *
- * void k_cpu_atomic_idle(unsigned int key)
+ * void z_arch_cpu_atomic_idle(unsigned int key)
  */
-void k_cpu_atomic_idle(unsigned int key)
+void z_arch_cpu_atomic_idle(unsigned int key)
 {
 	sys_trace_idle();
 	__asm__ volatile ("waiti 0\n\t"

--- a/arch/xtensa/core/xtensa-asm2.c
+++ b/arch/xtensa/core/xtensa-asm2.c
@@ -56,9 +56,10 @@ void *xtensa_init_stack(int *stack_top,
 	return &bsa[-9];
 }
 
-void z_new_thread(struct k_thread *thread, k_thread_stack_t *stack, size_t sz,
-		 k_thread_entry_t entry, void *p1, void *p2, void *p3,
-		 int prio, unsigned int opts)
+void z_arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
+		       size_t sz, k_thread_entry_t entry,
+		       void *p1, void *p2, void *p3,
+		       int prio, unsigned int opts)
 {
 	char *base = Z_THREAD_STACK_BUFFER(stack);
 	char *top = base + sz;

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -61,7 +61,7 @@ static ALWAYS_INLINE _cpu_t *z_arch_curr_cpu(void)
  *
  * @return N/A
  */
-static ALWAYS_INLINE void kernel_arch_init(void)
+static ALWAYS_INLINE void z_arch_kernel_init(void)
 {
 	_cpu_t *cpu0 = &_kernel.cpus[0];
 

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -83,8 +83,6 @@ static ALWAYS_INLINE void kernel_arch_init(void)
 #endif
 }
 
-extern void k_cpu_atomic_idle(unsigned int key);
-
 #ifdef __cplusplus
 }
 #endif

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -89,7 +89,7 @@ extern void k_cpu_atomic_idle(unsigned int key);
 }
 #endif
 
-#define z_is_in_isr() (z_arch_curr_cpu()->nested != 0U)
+#define z_arch_is_in_isr() (z_arch_curr_cpu()->nested != 0U)
 
 #endif /* _ASMLANGUAGE */
 

--- a/doc/guides/porting/arch.rst
+++ b/doc/guides/porting/arch.rst
@@ -407,14 +407,14 @@ CPU Idling/Power Management
 ***************************
 
 The kernel provides support for CPU power management with two functions:
-:c:func:`k_cpu_idle` and :c:func:`k_cpu_atomic_idle`.
+:c:func:`z_arch_cpu_idle` and :c:func:`z_arch_cpu_atomic_idle`.
 
-:c:func:`k_cpu_idle` can be as simple as calling the power saving instruction
-for the architecture with interrupts unlocked, for example :code:`hlt` on x86,
-:code:`wfi` or :code:`wfe` on ARM, :code:`sleep` on ARC. This function can be
-called in a loop within a context that does not care if it get interrupted or
-not by an interrupt before going to sleep. There are basically two scenarios
-when it is correct to use this function:
+:c:func:`z_arch_cpu_idle` can be as simple as calling the power saving
+instruction for the architecture with interrupts unlocked, for example
+:code:`hlt` on x86, :code:`wfi` or :code:`wfe` on ARM, :code:`sleep` on ARC.
+This function can be called in a loop within a context that does not care if it
+get interrupted or not by an interrupt before going to sleep. There are
+basically two scenarios when it is correct to use this function:
 
 * In a single-threaded system, in the only thread when the thread is not used
   for doing real work after initialization, i.e. it is sitting in a loop doing
@@ -422,7 +422,7 @@ when it is correct to use this function:
 
 * In the idle thread.
 
-:c:func:`k_cpu_atomic_idle`, on the other hand, must be able to atomically
+:c:func:`z_arch_cpu_atomic_idle`, on the other hand, must be able to atomically
 re-enable interrupts and invoke the power saving instruction. It can thus be
 used in real application code, again in single-threaded systems.
 

--- a/drivers/timer/loapic_timer.c
+++ b/drivers/timer/loapic_timer.c
@@ -206,8 +206,8 @@ void timer_int_handler(void *unused /* parameter is not used */
 		"pushl %eax\n\t"
 		"pushl %edx\n\t"
 		"rdtsc\n\t"
-		"mov %eax, __start_tick_time\n\t"
-		"mov %edx, __start_tick_time+4\n\t"
+		"mov %eax, z_arch_timing_tick_start\n\t"
+		"mov %edx, z_arch_timing_tick_start+4\n\t"
 		"pop %edx\n\t"
 		"pop %eax\n\t");
 #endif
@@ -293,8 +293,8 @@ void timer_int_handler(void *unused /* parameter is not used */
 		"pushl %eax\n\t"
 		"pushl %edx\n\t"
 		"rdtsc\n\t"
-		"mov %eax, __end_tick_time\n\t"
-		"mov %edx, __end_tick_time+4\n\t"
+		"mov %eax, z_arch_timing_tick_end\n\t"
+		"mov %edx, z_arch_timing_tick_end+4\n\t"
 		"pop %edx\n\t"
 		"pop %eax\n\t");
 #endif /* CONFIG_EXECUTION_BENCHMARKING */

--- a/include/arch/arc/arch.h
+++ b/include/arch/arc/arch.h
@@ -229,7 +229,7 @@ typedef u32_t k_mem_partition_attr_t;
 /**
  * @brief Explicitly nop operation.
  */
-static ALWAYS_INLINE void arch_nop(void)
+static ALWAYS_INLINE void z_arch_nop(void)
 {
 	__asm__ volatile("nop");
 }

--- a/include/arch/arc/v2/misc.h
+++ b/include/arch/arc/v2/misc.h
@@ -20,8 +20,6 @@ extern "C" {
 
 #ifndef _ASMLANGUAGE
 extern unsigned int k_cpu_sleep_mode;
-extern void k_cpu_idle(void);
-extern void k_cpu_atomic_idle(unsigned int key);
 
 extern u32_t z_timer_cycle_get_32(void);
 #define z_arch_k_cycle_get_32()	z_timer_cycle_get_32()

--- a/include/arch/arc/v2/misc.h
+++ b/include/arch/arc/v2/misc.h
@@ -19,7 +19,7 @@ extern "C" {
 #endif
 
 #ifndef _ASMLANGUAGE
-extern unsigned int k_cpu_sleep_mode;
+extern unsigned int z_arc_cpu_sleep_mode;
 
 extern u32_t z_timer_cycle_get_32(void);
 #define z_arch_k_cycle_get_32()	z_timer_cycle_get_32()

--- a/include/arch/arm/misc.h
+++ b/include/arch/arm/misc.h
@@ -27,7 +27,7 @@ extern u32_t z_timer_cycle_get_32(void);
 /**
  * @brief Explicitly nop operation.
  */
-static ALWAYS_INLINE void arch_nop(void)
+static ALWAYS_INLINE void z_arch_nop(void)
 {
 	__asm__ volatile("nop");
 }

--- a/include/arch/arm/misc.h
+++ b/include/arch/arm/misc.h
@@ -19,8 +19,6 @@ extern "C" {
 #endif
 
 #ifndef _ASMLANGUAGE
-extern void k_cpu_idle(void);
-
 extern u32_t z_timer_cycle_get_32(void);
 #define z_arch_k_cycle_get_32()	z_timer_cycle_get_32()
 

--- a/include/arch/nios2/arch.h
+++ b/include/arch/nios2/arch.h
@@ -204,7 +204,7 @@ extern u32_t z_timer_cycle_get_32(void);
 /**
  * @brief Explicitly nop operation.
  */
-static ALWAYS_INLINE void arch_nop(void)
+static ALWAYS_INLINE void z_arch_nop(void)
 {
 	__asm__ volatile("nop");
 }

--- a/include/arch/posix/arch.h
+++ b/include/arch/posix/arch.h
@@ -45,7 +45,7 @@ extern u32_t z_timer_cycle_get_32(void);
 /**
  * @brief Explicitly nop operation.
  */
-static ALWAYS_INLINE void arch_nop(void)
+static ALWAYS_INLINE void z_arch_nop(void)
 {
 	__asm__ volatile("nop");
 }

--- a/include/arch/riscv/arch.h
+++ b/include/arch/riscv/arch.h
@@ -149,7 +149,7 @@ static ALWAYS_INLINE bool z_arch_irq_unlocked(unsigned int key)
 /**
  * @brief Explicitly nop operation.
  */
-static ALWAYS_INLINE void arch_nop(void)
+static ALWAYS_INLINE void z_arch_nop(void)
 {
 	__asm__ volatile("nop");
 }

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -266,7 +266,7 @@ static inline u64_t z_tsc_read(void)
 	return rv.value;
 }
 
-static ALWAYS_INLINE void arch_nop(void)
+static ALWAYS_INLINE void z_arch_nop(void)
 {
 	__asm__ volatile("nop");
 }

--- a/include/arch/x86/ia32/arch.h
+++ b/include/arch/x86/ia32/arch.h
@@ -399,8 +399,6 @@ extern void k_float_enable(struct k_thread *thread, unsigned int options);
  * @}
  */
 
-extern void	k_cpu_idle(void);
-
 #ifdef CONFIG_X86_ENABLE_TSS
 extern struct task_state_segment _main_tss;
 #endif

--- a/include/arch/xtensa/arch.h
+++ b/include/arch/xtensa/arch.h
@@ -86,7 +86,7 @@ extern u32_t z_timer_cycle_get_32(void);
 /**
  * @brief Explicitly nop operation.
  */
-static ALWAYS_INLINE void arch_nop(void)
+static ALWAYS_INLINE void z_arch_nop(void)
 {
 	__asm__ volatile("nop");
 }

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -23,11 +23,6 @@
 extern "C" {
 #endif
 
-#ifdef CONFIG_BOOT_TIME_MEASUREMENT
-extern u32_t __main_time_stamp; /* timestamp when main task starts */
-extern u32_t __idle_time_stamp; /* timestamp when CPU goes idle */
-#endif
-
 /**
  * @brief Kernel APIs
  * @defgroup kernel_apis Kernel APIs

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4630,6 +4630,9 @@ extern void z_handle_obj_poll_events(sys_dlist_t *events, u32_t state);
  * @{
  */
 
+extern void z_arch_cpu_idle(void);
+extern void z_arch_cpu_atomic_idle(unsigned int key);
+
 /**
  * @brief Make the CPU idle.
  *
@@ -4643,7 +4646,10 @@ extern void z_handle_obj_poll_events(sys_dlist_t *events, u32_t state);
  * @return N/A
  * @req K-CPU-IDLE-001
  */
-extern void k_cpu_idle(void);
+static inline void k_cpu_idle(void)
+{
+	z_arch_cpu_idle();
+}
 
 /**
  * @brief Make the CPU idle in an atomic fashion.
@@ -4656,7 +4662,10 @@ extern void k_cpu_idle(void);
  * @return N/A
  * @req K-CPU-IDLE-002
  */
-extern void k_cpu_atomic_idle(unsigned int key);
+static inline void k_cpu_atomic_idle(unsigned int key)
+{
+	z_arch_cpu_atomic_idle(key);
+}
 
 /**
  * @}

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -695,13 +695,13 @@ config MAX_DOMAIN_PARTITIONS
 menu "SMP Options"
 
 config USE_SWITCH
-	bool "Use new-style _arch_switch instead of __swap"
+	bool "Use new-style _arch_switch instead of z_arch_swap"
 	depends on USE_SWITCH_SUPPORTED
 	help
 	  The _arch_switch() API is a lower level context switching
-	  primitive than the original __swap mechanism.  It is required
+	  primitive than the original z_arch_swap mechanism.  It is required
 	  for an SMP-aware scheduler, or if the architecture does not
-	  provide __swap.  In uniprocess situations where the
+	  provide z_arch_swap.  In uniprocess situations where the
 	  architecture provides both, _arch_switch incurs more somewhat
 	  overhead and may be slower.
 

--- a/kernel/futex.c
+++ b/kernel/futex.c
@@ -42,7 +42,7 @@ int z_impl_k_futex_wake(struct k_futex *futex, bool wake_all)
 		thread = z_unpend_first_thread(&futex_data->wait_q);
 		if (thread) {
 			z_ready_thread(thread);
-			z_set_thread_return_value(thread, 0);
+			z_arch_thread_return_value_set(thread, 0);
 			woken++;
 		}
 	} while (thread && wake_all);

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -147,9 +147,9 @@ void idle(void *unused1, void *unused2, void *unused3)
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
 	/* record timestamp when idling begins */
 
-	extern u32_t __idle_time_stamp;
+	extern u32_t z_timestamp_idle;
 
-	__idle_time_stamp = k_cycle_get_32();
+	z_timestamp_idle = k_cycle_get_32();
 #endif
 
 	while (true) {

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -275,6 +275,8 @@ extern int z_stack_adjust_initialized;
 extern void z_arch_busy_wait(u32_t usec_to_wait);
 #endif
 
+int z_arch_swap(unsigned int key);
+
 /**
  * TODO: document
  */

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -295,6 +295,11 @@ extern u64_t z_arch_timing_value_swap_common;
 extern u64_t z_arch_timing_value_swap_temp;
 #endif /* CONFIG_EXECUTION_BENCHMARKING */
 
+#ifdef CONFIG_BOOT_TIME_MEASUREMENT
+extern u32_t z_timestamp_main; /* timestamp when main task starts */
+extern u32_t z_timestamp_idle; /* timestamp when CPU goes idle */
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -300,6 +300,11 @@ extern u32_t z_timestamp_main; /* timestamp when main task starts */
 extern u32_t z_timestamp_idle; /* timestamp when CPU goes idle */
 #endif
 
+extern struct k_thread z_main_thread;
+extern struct k_thread z_idle_thread;
+extern K_THREAD_STACK_DEFINE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
+extern K_THREAD_STACK_DEFINE(z_idle_stack, CONFIG_IDLE_STACK_SIZE);
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -280,6 +280,21 @@ extern void z_arch_busy_wait(u32_t usec_to_wait);
  */
 extern FUNC_NORETURN void z_arch_system_halt(unsigned int reason);
 
+#ifdef CONFIG_EXECUTION_BENCHMARKING
+extern u64_t z_arch_timing_swap_start;
+extern u64_t z_arch_timing_swap_end;
+extern u64_t z_arch_timing_irq_start;
+extern u64_t z_arch_timing_irq_end;
+extern u64_t z_arch_timing_tick_start;
+extern u64_t z_arch_timing_tick_end;
+extern u64_t z_arch_timing_user_mode_end;
+
+/* FIXME: Document. Temporary storage, seems x86 specific? */
+extern u32_t z_arch_timing_value_swap_end;
+extern u64_t z_arch_timing_value_swap_common;
+extern u64_t z_arch_timing_value_swap_temp;
+#endif /* CONFIG_EXECUTION_BENCHMARKING */
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -40,10 +40,10 @@ extern FUNC_NORETURN void z_thread_entry(k_thread_entry_t entry,
 			  void *p1, void *p2, void *p3);
 
 /* Implemented by architectures. Only called from z_setup_new_thread. */
-extern void z_new_thread(struct k_thread *thread, k_thread_stack_t *pStack,
-			size_t stackSize, k_thread_entry_t entry,
-			void *p1, void *p2, void *p3,
-			int prio, unsigned int options);
+extern void z_arch_new_thread(struct k_thread *thread, k_thread_stack_t *pStack,
+			      size_t stackSize, k_thread_entry_t entry,
+			      void *p1, void *p2, void *p3,
+			      int prio, unsigned int options);
 
 extern void z_setup_new_thread(struct k_thread *new_thread,
 			      k_thread_stack_t *stack, size_t stack_size,
@@ -181,7 +181,7 @@ extern int z_arch_buffer_validate(void *addr, size_t size, int write);
  * - Set up any kernel stack region for the CPU to use during privilege
  *   elevation
  * - Put the CPU in whatever its equivalent of user mode is
- * - Transfer execution to z_new_thread() passing along all the supplied
+ * - Transfer execution to z_arch_new_thread() passing along all the supplied
  *   arguments, in user mode.
  *
  * @param Entry point to start executing as a user thread

--- a/kernel/include/kernel_structs.h
+++ b/kernel/include/kernel_structs.h
@@ -195,18 +195,18 @@ extern struct z_kernel _kernel;
  * z_swap() is in use it's a simple inline provided by the kernel.
  */
 static ALWAYS_INLINE void
-z_set_thread_return_value(struct k_thread *thread, unsigned int value)
+z_arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
 {
 	thread->swap_retval = value;
 }
 #endif
 
 static ALWAYS_INLINE void
-z_set_thread_return_value_with_data(struct k_thread *thread,
+z_thread_return_value_set_with_data(struct k_thread *thread,
 				   unsigned int value,
 				   void *data)
 {
-	z_set_thread_return_value(thread, value);
+	z_arch_thread_return_value_set(thread, value);
 	thread->base.swap_data = data;
 }
 

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_KERNEL_INCLUDE_KSCHED_H_
 
 #include <kernel_structs.h>
+#include <kernel_internal.h>
 #include <timeout_q.h>
 #include <debug/tracing.h>
 #include <stdbool.h>
@@ -85,6 +86,15 @@ static ALWAYS_INLINE struct k_thread *z_get_next_ready_thread(void)
 static inline bool z_is_idle_thread_entry(void *entry_point)
 {
 	return entry_point == idle;
+}
+
+static inline bool z_is_idle_thread_object(struct k_thread *thread)
+{
+#ifdef CONFIG_SMP
+	return thread->base.is_idle;
+#else
+	return thread == &z_idle_thread;
+#endif
 }
 
 static inline bool z_is_thread_pending(struct k_thread *thread)

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -17,7 +17,7 @@ BUILD_ASSERT(K_LOWEST_APPLICATION_THREAD_PRIO
 
 #ifdef CONFIG_MULTITHREADING
 #define Z_VALID_PRIO(prio, entry_point)				     \
-	(((prio) == K_IDLE_PRIO && z_is_idle_thread(entry_point)) || \
+	(((prio) == K_IDLE_PRIO && z_is_idle_thread_entry(entry_point)) || \
 	 ((K_LOWEST_APPLICATION_THREAD_PRIO			     \
 	   >= K_HIGHEST_APPLICATION_THREAD_PRIO)		     \
 	  && (prio) >= K_HIGHEST_APPLICATION_THREAD_PRIO	     \
@@ -82,7 +82,7 @@ static ALWAYS_INLINE struct k_thread *z_get_next_ready_thread(void)
 }
 #endif
 
-static inline bool z_is_idle_thread(void *entry_point)
+static inline bool z_is_idle_thread_entry(void *entry_point)
 {
 	return entry_point == idle;
 }
@@ -217,7 +217,7 @@ bool z_is_t1_higher_prio_than_t2(struct k_thread *t1, struct k_thread *t2);
 
 static inline bool _is_valid_prio(int prio, void *entry_point)
 {
-	if (prio == K_IDLE_PRIO && z_is_idle_thread(entry_point)) {
+	if (prio == K_IDLE_PRIO && z_is_idle_thread_entry(entry_point)) {
 		return true;
 	}
 

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -255,7 +255,7 @@ static inline void _ready_one_thread(_wait_q_t *wq)
 static inline void z_sched_lock(void)
 {
 #ifdef CONFIG_PREEMPT_ENABLED
-	__ASSERT(!z_is_in_isr(), "");
+	__ASSERT(!z_arch_is_in_isr(), "");
 	__ASSERT(_current->base.sched_locked != 1, "");
 
 	--_current->base.sched_locked;
@@ -270,7 +270,7 @@ static inline void z_sched_lock(void)
 static ALWAYS_INLINE void z_sched_unlock_no_reschedule(void)
 {
 #ifdef CONFIG_PREEMPT_ENABLED
-	__ASSERT(!z_is_in_isr(), "");
+	__ASSERT(!z_arch_is_in_isr(), "");
 	__ASSERT(_current->base.sched_locked != 0, "");
 
 	compiler_barrier();

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -113,7 +113,7 @@ static inline void z_swap_unlocked(void)
 
 #else /* !CONFIG_USE_SWITCH */
 
-extern int __swap(unsigned int key);
+extern int z_arch_swap(unsigned int key);
 
 static inline int z_swap_irqlock(unsigned int key)
 {
@@ -123,7 +123,7 @@ static inline int z_swap_irqlock(unsigned int key)
 #ifndef CONFIG_ARM
 	sys_trace_thread_switched_out();
 #endif
-	ret = __swap(key);
+	ret = z_arch_swap(key);
 #ifndef CONFIG_ARM
 	sys_trace_thread_switched_in();
 #endif

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -493,7 +493,7 @@ FUNC_NORETURN void z_cstart(void)
 	}
 
 	/* perform any architecture-specific initialization */
-	kernel_arch_init();
+	z_arch_kernel_init();
 
 #ifdef CONFIG_MULTITHREADING
 	struct k_thread dummy_thread = {

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -302,7 +302,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 void __weak main(void)
 {
 	/* NOP default main() if the application does not provide one. */
-	arch_nop();
+	z_arch_nop();
 }
 
 /* LCOV_EXCL_STOP */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -66,8 +66,8 @@ LOG_MODULE_REGISTER(os);
 /* boot time measurement items */
 
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
-u32_t __noinit __main_time_stamp;  /* timestamp when main task starts */
-u32_t __noinit __idle_time_stamp;  /* timestamp when CPU goes idle */
+u32_t __noinit z_timestamp_main;  /* timestamp when main task starts */
+u32_t __noinit z_timestamp_idle;  /* timestamp when CPU goes idle */
 #endif
 
 /* init/main and idle threads */
@@ -283,7 +283,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #endif
 
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
-	__main_time_stamp = k_cycle_get_32();
+	z_timestamp_main = k_cycle_get_32();
 #endif
 
 	extern void main(void);

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -211,7 +211,7 @@ static void mbox_message_dispose(struct k_mbox_msg *rx_msg)
 #endif
 
 	/* synchronous send: wake up sending thread */
-	z_set_thread_return_value(sending_thread, 0);
+	z_arch_thread_return_value_set(sending_thread, 0);
 	z_mark_thread_as_not_pending(sending_thread);
 	z_ready_thread(sending_thread);
 	z_reschedule_unlocked();
@@ -257,7 +257,7 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 			z_unpend_thread(receiving_thread);
 
 			/* ready receiver for execution */
-			z_set_thread_return_value(receiving_thread, 0);
+			z_arch_thread_return_value_set(receiving_thread, 0);
 			z_ready_thread(receiving_thread);
 
 #if (CONFIG_NUM_MBOX_ASYNC_MSGS > 0)

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -119,7 +119,7 @@ void k_mem_slab_free(struct k_mem_slab *slab, void **mem)
 	struct k_thread *pending_thread = z_unpend_first_thread(&slab->wait_q);
 
 	if (pending_thread != NULL) {
-		z_set_thread_return_value_with_data(pending_thread, 0, *mem);
+		z_thread_return_value_set_with_data(pending_thread, 0, *mem);
 		z_ready_thread(pending_thread);
 		z_reschedule(&lock, key);
 	} else {

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -52,7 +52,7 @@ int k_mem_pool_alloc(struct k_mem_pool *p, struct k_mem_block *block,
 	int ret;
 	s64_t end = 0;
 
-	__ASSERT(!(z_is_in_isr() && timeout != K_NO_WAIT), "");
+	__ASSERT(!(z_arch_is_in_isr() && timeout != K_NO_WAIT), "");
 
 	if (timeout > 0) {
 		end = k_uptime_get() + timeout;

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -110,7 +110,7 @@ void k_msgq_cleanup(struct k_msgq *msgq)
 
 int z_impl_k_msgq_put(struct k_msgq *msgq, void *data, s32_t timeout)
 {
-	__ASSERT(!z_is_in_isr() || timeout == K_NO_WAIT, "");
+	__ASSERT(!z_arch_is_in_isr() || timeout == K_NO_WAIT, "");
 
 	struct k_thread *pending_thread;
 	k_spinlock_key_t key;
@@ -185,7 +185,7 @@ static inline void z_vrfy_k_msgq_get_attrs(struct k_msgq *q,
 
 int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, s32_t timeout)
 {
-	__ASSERT(!z_is_in_isr() || timeout == K_NO_WAIT, "");
+	__ASSERT(!z_arch_is_in_isr() || timeout == K_NO_WAIT, "");
 
 	k_spinlock_key_t key;
 	struct k_thread *pending_thread;

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -126,7 +126,7 @@ int z_impl_k_msgq_put(struct k_msgq *msgq, void *data, s32_t timeout)
 			(void)memcpy(pending_thread->base.swap_data, data,
 			       msgq->msg_size);
 			/* wake up waiting thread */
-			z_set_thread_return_value(pending_thread, 0);
+			z_arch_thread_return_value_set(pending_thread, 0);
 			z_ready_thread(pending_thread);
 			z_reschedule(&msgq->lock, key);
 			return 0;
@@ -215,7 +215,7 @@ int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, s32_t timeout)
 			msgq->used_msgs++;
 
 			/* wake up waiting thread */
-			z_set_thread_return_value(pending_thread, 0);
+			z_arch_thread_return_value_set(pending_thread, 0);
 			z_ready_thread(pending_thread);
 			z_reschedule(&msgq->lock, key);
 			return 0;
@@ -287,7 +287,7 @@ void z_impl_k_msgq_purge(struct k_msgq *msgq)
 
 	/* wake up any threads that are waiting to write */
 	while ((pending_thread = z_unpend_first_thread(&msgq->wait_q)) != NULL) {
-		z_set_thread_return_value(pending_thread, -ENOMSG);
+		z_arch_thread_return_value_set(pending_thread, -ENOMSG);
 		z_ready_thread(pending_thread);
 	}
 

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -236,7 +236,7 @@ void z_impl_k_mutex_unlock(struct k_mutex *mutex)
 
 		k_spin_unlock(&lock, key);
 
-		z_set_thread_return_value(new_owner, 0);
+		z_arch_thread_return_value_set(new_owner, 0);
 
 		/*
 		 * new owner is already of higher or equal prio than first

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -358,7 +358,7 @@ static int signal_poll_event(struct k_poll_event *event, u32_t state)
 	}
 
 	z_unpend_thread(thread);
-	z_set_thread_return_value(thread,
+	z_arch_thread_return_value_set(thread,
 				 state == K_POLL_STATE_CANCELLED ? -EINTR : 0);
 
 	if (!z_is_thread_ready(thread)) {

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -190,7 +190,7 @@ static inline void set_event_ready(struct k_poll_event *event, u32_t state)
 
 int z_impl_k_poll(struct k_poll_event *events, int num_events, s32_t timeout)
 {
-	__ASSERT(!z_is_in_isr(), "");
+	__ASSERT(!z_arch_is_in_isr(), "");
 	__ASSERT(events != NULL, "NULL events\n");
 	__ASSERT(num_events > 0, "zero events\n");
 

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -103,7 +103,7 @@ static inline void z_vrfy_k_queue_init(struct k_queue *queue)
 static void prepare_thread_to_run(struct k_thread *thread, void *data)
 {
 	z_ready_thread(thread);
-	z_set_thread_return_value_with_data(thread, 0, data);
+	z_thread_return_value_set_with_data(thread, 0, data);
 }
 #endif /* CONFIG_POLL */
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -13,6 +13,7 @@
 #include <syscall_handler.h>
 #include <drivers/timer/system_timer.h>
 #include <stdbool.h>
+#include <kernel_internal.h>
 
 #if defined(CONFIG_SCHED_DUMB)
 #define _priq_run_add		z_priq_dumb_add
@@ -84,9 +85,7 @@ static inline bool is_idle(struct k_thread *thread)
 #ifdef CONFIG_SMP
 	return thread->base.is_idle;
 #else
-	extern k_tid_t const _idle_thread;
-
-	return thread == _idle_thread;
+	return thread == &z_idle_thread;
 #endif
 }
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -531,7 +531,7 @@ static inline int resched(u32_t key)
 	_current_cpu->swap_ok = 0;
 #endif
 
-	return z_arch_irq_unlocked(key) && !z_is_in_isr();
+	return z_arch_irq_unlocked(key) && !z_arch_is_in_isr();
 }
 
 void z_reschedule(struct k_spinlock *lock, k_spinlock_key_t key)
@@ -563,7 +563,7 @@ void k_sched_unlock(void)
 {
 #ifdef CONFIG_PREEMPT_ENABLED
 	__ASSERT(_current->base.sched_locked != 0, "");
-	__ASSERT(!z_is_in_isr(), "");
+	__ASSERT(!z_arch_is_in_isr(), "");
 
 	LOCKED(&sched_spinlock) {
 		++_current->base.sched_locked;
@@ -855,7 +855,7 @@ void z_impl_k_thread_priority_set(k_tid_t tid, int prio)
 	 * keep track of it) and idle cannot change its priority.
 	 */
 	Z_ASSERT_VALID_PRIO(prio, NULL);
-	__ASSERT(!z_is_in_isr(), "");
+	__ASSERT(!z_arch_is_in_isr(), "");
 
 	struct k_thread *thread = (struct k_thread *)tid;
 
@@ -909,7 +909,7 @@ static inline void z_vrfy_k_thread_deadline_set(k_tid_t tid, int deadline)
 
 void z_impl_k_yield(void)
 {
-	__ASSERT(!z_is_in_isr(), "");
+	__ASSERT(!z_arch_is_in_isr(), "");
 
 	if (!is_idle(_current)) {
 		LOCKED(&sched_spinlock) {
@@ -939,7 +939,7 @@ static s32_t z_tick_sleep(s32_t ticks)
 #ifdef CONFIG_MULTITHREADING
 	u32_t expected_wakeup_time;
 
-	__ASSERT(!z_is_in_isr(), "");
+	__ASSERT(!z_arch_is_in_isr(), "");
 
 	K_DEBUG("thread %p for %d ticks\n", _current, ticks);
 
@@ -1026,7 +1026,7 @@ void z_impl_k_wakeup(k_tid_t thread)
 	z_mark_thread_as_not_suspended(thread);
 	z_ready_thread(thread);
 
-	if (!z_is_in_isr()) {
+	if (!z_arch_is_in_isr()) {
 		z_reschedule_unlocked();
 	}
 
@@ -1113,7 +1113,7 @@ static inline k_tid_t z_vrfy_k_current_get(void)
 
 int z_impl_k_is_preempt_thread(void)
 {
-	return !z_is_in_isr() && is_preempt(_current);
+	return !z_arch_is_in_isr() && is_preempt(_current);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -110,7 +110,7 @@ static void do_sem_give(struct k_sem *sem)
 
 	if (thread != NULL) {
 		z_ready_thread(thread);
-		z_set_thread_return_value(thread, 0);
+		z_arch_thread_return_value_set(thread, 0);
 	} else {
 		increment_count_up_to_limit(sem);
 		handle_poll_events(sem);

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -138,7 +138,7 @@ static inline void z_vrfy_k_sem_give(struct k_sem *sem)
 
 int z_impl_k_sem_take(struct k_sem *sem, s32_t timeout)
 {
-	__ASSERT(((z_is_in_isr() == false) || (timeout == K_NO_WAIT)), "");
+	__ASSERT(((z_arch_is_in_isr() == false) || (timeout == K_NO_WAIT)), "");
 
 	sys_trace_void(SYS_TRACE_ID_SEMA_TAKE);
 	k_spinlock_key_t key = k_spin_lock(&lock);

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -106,7 +106,7 @@ void z_impl_k_stack_push(struct k_stack *stack, stack_data_t data)
 	if (first_pending_thread != NULL) {
 		z_ready_thread(first_pending_thread);
 
-		z_set_thread_return_value_with_data(first_pending_thread,
+		z_thread_return_value_set_with_data(first_pending_thread,
 						   0, (void *)data);
 		z_reschedule(&stack->lock, key);
 		return;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -61,7 +61,7 @@ void k_thread_foreach(k_thread_user_cb_t user_cb, void *user_data)
 
 bool k_is_in_isr(void)
 {
-	return z_is_in_isr();
+	return z_arch_is_in_isr();
 }
 
 /*
@@ -531,7 +531,7 @@ k_tid_t z_impl_k_thread_create(struct k_thread *new_thread,
 			      void *p1, void *p2, void *p3,
 			      int prio, u32_t options, s32_t delay)
 {
-	__ASSERT(!z_is_in_isr(), "Threads may not be created in ISRs");
+	__ASSERT(!z_arch_is_in_isr(), "Threads may not be created in ISRs");
 
 	/* Special case, only for unit tests */
 #if defined(CONFIG_TEST) && defined(CONFIG_ARCH_HAS_USERSPACE) && !defined(CONFIG_USERSPACE)

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -412,8 +412,8 @@ static inline size_t adjust_stack_size(size_t stack_size)
 		random_val = sys_rand32_get();
 	}
 
-	/* Don't need to worry about alignment of the size here, z_new_thread()
-	 * is required to do it
+	/* Don't need to worry about alignment of the size here,
+	 * z_arch_new_thread() is required to do it.
 	 *
 	 * FIXME: Not the best way to get a random number in a range.
 	 * See #6493
@@ -462,12 +462,12 @@ void z_setup_new_thread(struct k_thread *new_thread,
 #endif
 #endif
 
-	z_new_thread(new_thread, stack, stack_size, entry, p1, p2, p3,
-		    prio, options);
+	z_arch_new_thread(new_thread, stack, stack_size, entry, p1, p2, p3,
+			  prio, options);
 
 #ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
 #ifndef CONFIG_THREAD_USERSPACE_LOCAL_DATA_ARCH_DEFER_SETUP
-	/* don't set again if the arch's own code in z_new_thread() has
+	/* don't set again if the arch's own code in z_arch_new_thread() has
 	 * already set the pointer.
 	 */
 	new_thread->userspace_local_data =

--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -43,7 +43,7 @@ void z_impl_k_thread_abort(k_tid_t thread)
 	z_thread_single_abort(thread);
 	z_thread_monitor_exit(thread);
 
-	if (thread == _current && !z_is_in_isr()) {
+	if (thread == _current && !z_arch_is_in_isr()) {
 		z_swap(&lock, key);
 	} else {
 		/* Really, there's no good reason for this to be a

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -82,7 +82,7 @@ void z_timer_expiration_handler(struct _timeout *t)
 
 	z_ready_thread(thread);
 
-	z_set_thread_return_value(thread, 0);
+	z_arch_thread_return_value_set(thread, 0);
 }
 
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -184,7 +184,7 @@ static inline u32_t z_vrfy_k_timer_status_get(struct k_timer *timer)
 
 u32_t z_impl_k_timer_status_sync(struct k_timer *timer)
 {
-	__ASSERT(!z_is_in_isr(), "");
+	__ASSERT(!z_arch_is_in_isr(), "");
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	u32_t result = timer->status;

--- a/lib/cmsis_rtos_v1/cmsis_kernel.c
+++ b/lib/cmsis_rtos_v1/cmsis_kernel.c
@@ -7,8 +7,7 @@
 #include <kernel_structs.h>
 #include <cmsis_os.h>
 #include <ksched.h>
-
-extern const k_tid_t _main_thread;
+#include <kernel_internal.h>
 
 /**
  * @brief Get the RTOS kernel system timer counter
@@ -42,5 +41,5 @@ osStatus osKernelStart(void)
  */
 int32_t osKernelRunning(void)
 {
-	return z_has_thread_started(_main_thread);
+	return z_has_thread_started(&z_main_thread);
 }

--- a/lib/posix/pthread_mutex.c
+++ b/lib/posix/pthread_mutex.c
@@ -143,7 +143,7 @@ int pthread_mutex_unlock(pthread_mutex_t *m)
 			m->owner = (pthread_t)thread;
 			m->lock_count++;
 			z_ready_thread(thread);
-			z_set_thread_return_value(thread, 0);
+			z_arch_thread_return_value_set(thread, 0);
 			z_reschedule_irqlock(key);
 			return 0;
 		}

--- a/soc/posix/inf_clock/soc.c
+++ b/soc/posix/inf_clock/soc.c
@@ -14,7 +14,7 @@
  *
  * The HW models raising an interrupt will "awake the cpu" by calling
  * poisix_interrupt_raised() which will transfer control to the irq handler,
- * which will run inside SW/Zephyr contenxt. After which a __swap() to whatever
+ * which will run inside SW/Zephyr contenxt. After which a z_arch_swap() to whatever
  * Zephyr thread may follow.
  * Again, once Zephyr is done, control is given back to the HW models.
  *
@@ -143,7 +143,7 @@ void posix_halt_cpu(void)
 	 * => let the "irq handler" check if/what interrupt was raised
 	 * and call the appropriate irq handler.
 	 *
-	 * Note that, the interrupt handling may trigger a __swap() to another
+	 * Note that, the interrupt handling may trigger a z_arch_swap() to another
 	 * Zephyr thread. When posix_irq_handler() returns, the Zephyr
 	 * kernel has swapped back to this thread again
 	 */

--- a/soc/posix/inf_clock/soc.c
+++ b/soc/posix/inf_clock/soc.c
@@ -9,7 +9,7 @@
  * clock.
  *
  * Therefore, the code will always run until completion after each interrupt,
- * after which k_cpu_idle() will be called releasing the execution back to the
+ * after which z_arch_cpu_idle() will be called releasing the execution back to the
  * HW models.
  *
  * The HW models raising an interrupt will "awake the cpu" by calling
@@ -125,7 +125,7 @@ void posix_interrupt_raised(void)
 
 
 /**
- * Normally called from k_cpu_idle():
+ * Normally called from z_arch_cpu_idle():
  *   the idle loop will call this function to set the CPU to "sleep".
  * Others may also call this function with care. The CPU will be set to sleep
  * until some interrupt awakes it.
@@ -156,7 +156,7 @@ void posix_halt_cpu(void)
 
 
 /**
- * Implementation of k_cpu_atomic_idle() for this SOC
+ * Implementation of z_arch_cpu_atomic_idle() for this SOC
  */
 void posix_atomic_halt_cpu(unsigned int imask)
 {

--- a/soc/riscv/riscv-privilege/common/idle.c
+++ b/soc/riscv/riscv-privilege/common/idle.c
@@ -31,7 +31,7 @@ static ALWAYS_INLINE void riscv_idle(unsigned int key)
  *
  * @return N/A
  */
-void k_cpu_idle(void)
+void z_arch_cpu_idle(void)
 {
 	riscv_idle(SOC_MSTATUS_IEN);
 }
@@ -41,7 +41,7 @@ void k_cpu_idle(void)
  * @brief Atomically re-enable interrupts and enter low power mode
  *
  * INTERNAL
- * The requirements for k_cpu_atomic_idle() are as follows:
+ * The requirements for z_arch_cpu_atomic_idle() are as follows:
  * 1) The enablement of interrupts and entering a low-power mode needs to be
  *    atomic, i.e. there should be no period of time where interrupts are
  *    enabled before the processor enters a low-power mode.  See the comments
@@ -53,7 +53,7 @@ void k_cpu_idle(void)
  *
  * @return N/A
  */
-void k_cpu_atomic_idle(unsigned int key)
+void z_arch_cpu_atomic_idle(unsigned int key)
 {
 	riscv_idle(key);
 }

--- a/soc/xtensa/esp32/soc.c
+++ b/soc/xtensa/esp32/soc.c
@@ -64,7 +64,7 @@ void __attribute__((section(".iram1"))) __start(void)
 
 	/* Initialize the architecture CPU pointer.  Some of the
 	 * initialization code wants a valid _current before
-	 * kernel_arch_init() is invoked.
+	 * z_arch_kernel_init() is invoked.
 	 */
 	__asm__ volatile("wsr.MISC0 %0; rsync" : : "r"(&_kernel.cpus[0]));
 

--- a/subsys/debug/tracing/cpu_stats.c
+++ b/subsys/debug/tracing/cpu_stats.c
@@ -7,6 +7,7 @@
 #include <tracing_cpu_stats.h>
 #include <sys/printk.h>
 #include <kernel_internal.h>
+#include <ksched.h>
 
 enum cpu_state {
 	CPU_STATE_IDLE,
@@ -21,15 +22,6 @@ static u32_t last_time;
 static struct cpu_stats stats_hw_tick;
 static int nested_interrupts;
 static struct k_thread *current_thread;
-
-static int is_idle_thread(struct k_thread *thread)
-{
-#ifdef CONFIG_SMP
-	return thread->base.is_idle;
-#else
-	return thread == &z_idle_thread;
-#endif
-}
 
 void update_counter(volatile u64_t *cnt)
 {
@@ -107,7 +99,7 @@ void sys_trace_thread_switched_in(void)
 
 	cpu_stats_update_counters();
 	current_thread = k_current_get();
-	if (is_idle_thread(current_thread)) {
+	if (z_is_idle_thread_object(current_thread)) {
 		last_cpu_state = CPU_STATE_IDLE;
 	} else {
 		last_cpu_state = CPU_STATE_NON_IDLE;

--- a/subsys/debug/tracing/cpu_stats.c
+++ b/subsys/debug/tracing/cpu_stats.c
@@ -6,6 +6,7 @@
 
 #include <tracing_cpu_stats.h>
 #include <sys/printk.h>
+#include <kernel_internal.h>
 
 enum cpu_state {
 	CPU_STATE_IDLE,
@@ -21,16 +22,12 @@ static struct cpu_stats stats_hw_tick;
 static int nested_interrupts;
 static struct k_thread *current_thread;
 
-#ifndef CONFIG_SMP
-extern k_tid_t const _idle_thread;
-#endif
-
 static int is_idle_thread(struct k_thread *thread)
 {
 #ifdef CONFIG_SMP
 	return thread->base.is_idle;
 #else
-	return thread == _idle_thread;
+	return thread == &z_idle_thread;
 #endif
 }
 

--- a/subsys/debug/tracing/ctf/ctf_top.c
+++ b/subsys/debug/tracing/ctf/ctf_top.c
@@ -7,19 +7,15 @@
 #include <zephyr.h>
 #include <kernel_structs.h>
 #include <init.h>
+#include <kernel_internal.h>
 #include "ctf_top.h"
-
-
-#ifndef CONFIG_SMP
-extern k_tid_t const _idle_thread;
-#endif
 
 static inline int is_idle_thread(struct k_thread *thread)
 {
 #ifdef CONFIG_SMP
 	return thread->base.is_idle;
 #else
-	return thread == _idle_thread;
+	return thread == &z_idle_thread;
 #endif
 }
 

--- a/subsys/debug/tracing/ctf/ctf_top.c
+++ b/subsys/debug/tracing/ctf/ctf_top.c
@@ -10,15 +10,6 @@
 #include <kernel_internal.h>
 #include "ctf_top.h"
 
-static inline int is_idle_thread(struct k_thread *thread)
-{
-#ifdef CONFIG_SMP
-	return thread->base.is_idle;
-#else
-	return thread == &z_idle_thread;
-#endif
-}
-
 void sys_trace_thread_switched_out(void)
 {
 	struct k_thread *thread = k_current_get();

--- a/subsys/debug/tracing/include/tracing_sysview.h
+++ b/subsys/debug/tracing/include/tracing_sysview.h
@@ -7,21 +7,18 @@
 #define _TRACE_SYSVIEW_H
 #include <kernel.h>
 #include <init.h>
+#include <kernel_internal.h>
 
 #include <SEGGER_SYSVIEW.h>
 #include <Global.h>
 #include "SEGGER_SYSVIEW_Zephyr.h"
-
-#ifndef CONFIG_SMP
-extern k_tid_t const _idle_thread;
-#endif
 
 static inline int is_idle_thread(struct k_thread *thread)
 {
 #ifdef CONFIG_SMP
 	return thread->base.is_idle;
 #else
-	return thread == _idle_thread;
+	return thread == &z_idle_thread;
 #endif
 }
 

--- a/subsys/debug/tracing/include/tracing_sysview.h
+++ b/subsys/debug/tracing/include/tracing_sysview.h
@@ -13,15 +13,6 @@
 #include <Global.h>
 #include "SEGGER_SYSVIEW_Zephyr.h"
 
-static inline int is_idle_thread(struct k_thread *thread)
-{
-#ifdef CONFIG_SMP
-	return thread->base.is_idle;
-#else
-	return thread == &z_idle_thread;
-#endif
-}
-
 void sys_trace_thread_switched_in(void);
 void sys_trace_thread_switched_out(void);
 void sys_trace_isr_enter(void);

--- a/subsys/debug/tracing/sysview.c
+++ b/subsys/debug/tracing/sysview.c
@@ -6,6 +6,7 @@
 #include <zephyr.h>
 #include <kernel_structs.h>
 #include <init.h>
+#include <ksched.h>
 
 #include <SEGGER_SYSVIEW.h>
 #include <Global.h>
@@ -29,7 +30,7 @@ void sys_trace_thread_switched_in(void)
 
 	thread = k_current_get();
 
-	if (is_idle_thread(thread)) {
+	if (z_is_idle_thread_object(thread)) {
 		SEGGER_SYSVIEW_OnIdle();
 	} else {
 		SEGGER_SYSVIEW_OnTaskStartExec((u32_t)(uintptr_t)thread);
@@ -69,7 +70,7 @@ static void send_task_list_cb(void)
 		char name[20];
 		const char *tname = k_thread_name_get(thread);
 
-		if (is_idle_thread(thread)) {
+		if (z_is_idle_thread_object(thread)) {
 			continue;
 		}
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -14,6 +14,7 @@
 LOG_MODULE_REGISTER(net_shell, LOG_LEVEL_DBG);
 
 #include <zephyr.h>
+#include <kernel_internal.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <shell/shell.h>
@@ -3248,7 +3249,6 @@ static int cmd_net_route(const struct shell *shell, size_t argc, char *argv[])
 }
 
 #if defined(CONFIG_INIT_STACKS)
-extern K_THREAD_STACK_DEFINE(_main_stack, CONFIG_MAIN_STACK_SIZE);
 extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
 extern K_THREAD_STACK_DEFINE(sys_work_q_stack,
 			     CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE);
@@ -3294,11 +3294,11 @@ static int cmd_net_stacks(const struct shell *shell, size_t argc,
 	}
 
 #if defined(CONFIG_INIT_STACKS)
-	net_analyze_stack_get_values(Z_THREAD_STACK_BUFFER(_main_stack),
-				     K_THREAD_STACK_SIZEOF(_main_stack),
+	net_analyze_stack_get_values(Z_THREAD_STACK_BUFFER(z_main_stack),
+				     K_THREAD_STACK_SIZEOF(z_main_stack),
 				     &pcnt, &unused);
 	PR("%s [%s] stack size %d/%d bytes unused %u usage %d/%d (%u %%)\n",
-	   "main", "_main_stack", CONFIG_MAIN_STACK_SIZE,
+	   "main", "z_main_stack", CONFIG_MAIN_STACK_SIZE,
 	   CONFIG_MAIN_STACK_SIZE, unused,
 	   CONFIG_MAIN_STACK_SIZE - unused, CONFIG_MAIN_STACK_SIZE, pcnt);
 

--- a/tests/arch/arm/arm_thread_swap/README.txt
+++ b/tests/arch/arm/arm_thread_swap/README.txt
@@ -20,7 +20,7 @@ Notes:
   The test verifies the correct behavior of the thread contex-switch,
   when it is triggered indirectly (by setting the PendSV interrupt
   to pending state), as well as when the thread itself triggers its
-  swap-out (by calling __swap(.)).
+  swap-out (by calling z_arch_swap(.)).
 
   The test is currently supported only in ARMv7-M and ARMv8-M Mainline
   targets.

--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -9,7 +9,7 @@
 #include <arch/arm/cortex_m/cmsis.h>
 #include <kernel_structs.h>
 #include <offsets_short_arch.h>
-
+#include <ksched.h>
 
 #if !defined(__GNUC__)
 #error __FILE__ goes only with Cortex-M GCC
@@ -20,7 +20,6 @@
 #define BASEPRI_MODIFIED_2 0x40
 #define SWAP_RETVAL        0x1234
 
-extern int __swap(unsigned int key);
 extern void z_move_thread_to_end_of_prio_q(struct k_thread *thread);
 
 static struct k_thread alt_thread;
@@ -200,7 +199,7 @@ static void alt_thread_entry(void)
 	zassert_true(p_ztest_thread->arch.basepri == BASEPRI_MODIFIED_1,
 		"ztest thread basepri not preserved in swap-out\n");
 
-	/* Verify original swap return value (set by __swap() */
+	/* Verify original swap return value (set by z_arch_swap() */
 	zassert_true(p_ztest_thread->arch.swap_return_value == -EAGAIN,
 		"ztest thread swap-return-value not preserved in swap-out\n");
 #endif
@@ -420,7 +419,7 @@ void test_arm_thread_swap(void)
 	 * This will be verified by the alternative test thread.
 	 */
 	register int swap_return_val __asm__("r0") =
-		__swap(BASEPRI_MODIFIED_1);
+		z_arch_swap(BASEPRI_MODIFIED_1);
 
 #endif /* CONFIG_NO_OPTIMIZATIONS */
 

--- a/tests/benchmarks/boot_time/src/main.c
+++ b/tests/benchmarks/boot_time/src/main.c
@@ -17,6 +17,7 @@
 
 #include <zephyr.h>
 #include <tc_util.h>
+#include <kernel_internal.h>
 
 void main(void)
 {
@@ -34,17 +35,17 @@ void main(void)
 
 	int freq = sys_clock_hw_cycles_per_sec() / 1000000;
 
-	main_us = __main_time_stamp / freq;
+	main_us = z_timestamp_main / freq;
 	task_us = task_time_stamp / freq;
-	idle_us = __idle_time_stamp / freq;
+	idle_us = z_timestamp_idle / freq;
 
 	TC_START("Boot Time Measurement");
 	TC_PRINT("Boot Result: Clock Frequency: %d MHz\n", freq);
-	TC_PRINT("_start->main(): %u cycles, %u us\n", __main_time_stamp,
+	TC_PRINT("_start->main(): %u cycles, %u us\n", z_timestamp_main,
 						       main_us);
 	TC_PRINT("_start->task  : %u cycles, %u us\n", task_time_stamp,
 						       task_us);
-	TC_PRINT("_start->idle  : %u cycles, %u us\n", __idle_time_stamp,
+	TC_PRINT("_start->idle  : %u cycles, %u us\n", z_timestamp_idle,
 						       idle_us);
 	TC_PRINT("Boot Time Measurement finished\n");
 

--- a/tests/benchmarks/timing_info/src/msg_passing_bench.c
+++ b/tests/benchmarks/timing_info/src/msg_passing_bench.c
@@ -23,8 +23,8 @@ K_MBOX_DEFINE(benchmark_mbox);
 K_SEM_DEFINE(mbox_sem, 1, 1);
 
 /* common location for the swap to write the tsc data*/
-extern u32_t __read_swap_end_time_value;
-extern u64_t __common_var_swap_end_time;
+extern u32_t z_arch_timing_value_swap_end;
+extern u64_t z_arch_timing_value_swap_common;
 
 /* location of the time stamps*/
 u64_t __msg_q_put_state;
@@ -140,7 +140,7 @@ void msg_passing_bench(void)
 
 	k_thread_abort(producer_w_cxt_switch_tid);
 	k_thread_abort(producer_wo_cxt_switch_tid);
-	__msg_q_put_w_cxt_end_time = ((u32_t)__common_var_swap_end_time);
+	__msg_q_put_w_cxt_end_time = ((u32_t)z_arch_timing_value_swap_common);
 	ARG_UNUSED(msg_status);
 
 	/*******************************************************************/
@@ -160,7 +160,7 @@ void msg_passing_bench(void)
 				2 /*priority*/, 0, 50);
 	k_sleep(2000);  /* make the main thread sleep */
 	k_thread_abort(producer_get_w_cxt_switch_tid);
-	__msg_q_get_w_cxt_end_time = (__common_var_swap_end_time);
+	__msg_q_get_w_cxt_end_time = (z_arch_timing_value_swap_common);
 
 	/*******************************************************************/
 
@@ -194,7 +194,7 @@ void msg_passing_bench(void)
 				NULL, NULL, NULL,
 				1 /*priority*/, 0, 0);
 	k_sleep(1000);  /* make the main thread sleep */
-	mbox_sync_put_end_time = (__common_var_swap_end_time);
+	mbox_sync_put_end_time = (z_arch_timing_value_swap_common);
 
 	/*******************************************************************/
 
@@ -212,7 +212,7 @@ void msg_passing_bench(void)
 				thread_mbox_sync_get_receive, NULL,
 				NULL, NULL, 2 /*priority*/, 0, 0);
 	k_sleep(1000); /* make the main thread sleep */
-	mbox_sync_get_end_time = (__common_var_swap_end_time);
+	mbox_sync_get_end_time = (z_arch_timing_value_swap_common);
 
 	/*******************************************************************/
 
@@ -327,7 +327,7 @@ void thread_producer_msgq_w_cxt_switch(void *p1, void *p2, void *p3)
 {
 	int data_to_send = 5050;
 
-	__read_swap_end_time_value = 1U;
+	z_arch_timing_value_swap_end = 1U;
 	TIMING_INFO_PRE_READ();
 	__msg_q_put_w_cxt_start_time = (u32_t) TIMING_INFO_OS_GET_TIME();
 	k_msgq_put(&benchmark_q, &data_to_send, K_NO_WAIT);
@@ -363,7 +363,7 @@ void thread_producer_get_msgq_w_cxt_switch(void *p1, void *p2, void *p3)
 void thread_consumer_get_msgq_w_cxt_switch(void *p1, void *p2, void *p3)
 {
 	producer_get_w_cxt_switch_tid->base.timeout.dticks = _EXPIRED;
-	__read_swap_end_time_value = 1U;
+	z_arch_timing_value_swap_end = 1U;
 	TIMING_INFO_PRE_READ();
 	__msg_q_get_w_cxt_start_time = TIMING_INFO_OS_GET_TIME();
 	received_data_get =  k_msgq_get(&benchmark_q_get,
@@ -387,7 +387,7 @@ void thread_mbox_sync_put_send(void *p1, void *p2, void *p3)
 
 	TIMING_INFO_PRE_READ();
 	mbox_sync_put_start_time = TIMING_INFO_OS_GET_TIME();
-	__read_swap_end_time_value = 1U;
+	z_arch_timing_value_swap_end = 1U;
 
 	status = k_mbox_put(&benchmark_mbox, &tx_msg, 300);
 	MBOX_CHECK(status);
@@ -433,7 +433,7 @@ void thread_mbox_sync_get_receive(void *p1, void *p2, void *p3)
 		.tx_target_thread = K_ANY
 	};
 
-	__read_swap_end_time_value = 1U;
+	z_arch_timing_value_swap_end = 1U;
 	TIMING_INFO_PRE_READ();
 	mbox_sync_get_start_time = TIMING_INFO_OS_GET_TIME();
 

--- a/tests/benchmarks/timing_info/src/semaphore_bench.c
+++ b/tests/benchmarks/timing_info/src/semaphore_bench.c
@@ -43,8 +43,8 @@ void thread_sem1_give_test(void *p1, void *p2, void *p3);
 k_tid_t sem0_tid;
 k_tid_t sem1_tid;
 
-extern u64_t __common_var_swap_end_time;
-extern u32_t __read_swap_end_time_value;
+extern u64_t z_arch_timing_value_swap_common;
+extern u32_t z_arch_timing_value_swap_end;
 
 void semaphore_bench(void)
 {
@@ -64,7 +64,7 @@ void semaphore_bench(void)
 
 
 	/* u64_t test_time1 = z_tsc_read(); */
-	sem_end_time = (__common_var_swap_end_time);
+	sem_end_time = (z_arch_timing_value_swap_common);
 	u32_t sem_cycles = sem_end_time - sem_start_time;
 
 	sem0_tid = k_thread_create(&my_thread, my_stack_area,
@@ -77,7 +77,7 @@ void semaphore_bench(void)
 				   2 /*priority*/, 0, 0);
 
 	k_sleep(1000);
-	sem_give_end_time = (__common_var_swap_end_time);
+	sem_give_end_time = (z_arch_timing_value_swap_common);
 	u32_t sem_give_cycles = sem_give_end_time - sem_give_start_time;
 
 
@@ -177,7 +177,7 @@ void thread_sem1_test(void *p1, void *p2, void *p3)
 
 	k_sem_give(&sem_bench); /* sync the 2 threads*/
 
-	__read_swap_end_time_value = 1U;
+	z_arch_timing_value_swap_end = 1U;
 	TIMING_INFO_PRE_READ();
 	sem_start_time =  TIMING_INFO_OS_GET_TIME();
 	k_sem_take(&sem_bench, 10);
@@ -207,7 +207,7 @@ void thread_sem0_give_test(void *p1, void *p2, void *p3)
 	/* To make sure that the sem give will cause a swap to occur */
 	k_thread_priority_set(sem1_tid, 1);
 
-	__read_swap_end_time_value = 1U;
+	z_arch_timing_value_swap_end = 1U;
 	TIMING_INFO_PRE_READ();
 	sem_give_start_time =  TIMING_INFO_OS_GET_TIME();
 	k_sem_give(&sem_bench_1);

--- a/tests/benchmarks/timing_info/src/thread_bench.c
+++ b/tests/benchmarks/timing_info/src/thread_bench.c
@@ -19,9 +19,9 @@ char sline[256];
 /* FILE *output_file = stdout; */
 
 /* location of the time stamps*/
-extern u32_t __read_swap_end_time_value;
-extern u64_t __temp_start_swap_time;
-extern u64_t __common_var_swap_end_time;
+extern u32_t z_arch_timing_value_swap_end;
+extern u64_t z_arch_timing_value_swap_temp;
+extern u64_t z_arch_timing_value_swap_common;
 
 volatile u64_t thread_abort_end_time;
 volatile u64_t thread_abort_start_time;
@@ -48,7 +48,7 @@ K_THREAD_STACK_DEFINE(my_stack_area_0, STACK_SIZE);
 struct k_thread my_thread;
 struct k_thread my_thread_0;
 
-u32_t __read_swap_end_time_value_test = 1U;
+u32_t z_arch_timing_value_swap_end_test = 1U;
 u64_t dummy_time;
 u64_t start_time;
 u64_t test_end_time;
@@ -68,9 +68,9 @@ u32_t benchmarking_overhead_swap(void)
 		"rdtsc\n\t"
 		"mov %eax,start_time\n\t"
 		"mov %edx,start_time+4\n\t"
-		"cmp $0x1,__read_swap_end_time_value_test\n\t"
+		"cmp $0x1,z_arch_timing_value_swap_end_test\n\t"
 		"jne time_read_not_needed_test\n\t"
-		"movw $0x2,__read_swap_end_time_value\n\t"
+		"movw $0x2,z_arch_timing_value_swap_end\n\t"
 		"pushl %eax\n\t"
 		"pushl %edx\n\t"
 		"rdtsc\n\t"
@@ -99,7 +99,7 @@ void test_thread_entry(void *p, void *p1, void *p2)
 
 void thread_swap_test(void *p1, void *p2, void *p3)
 {
-	__read_swap_end_time_value = 1U;
+	z_arch_timing_value_swap_end = 1U;
 	TIMING_INFO_PRE_READ();
 	thread_abort_start_time = TIMING_INFO_OS_GET_TIME();
 	k_thread_abort(_current);
@@ -142,20 +142,20 @@ void system_thread_bench(void)
 			-1 /*priority*/, 0, 0);
 
 	k_sleep(1);
-	thread_abort_end_time = (__common_var_swap_end_time);
-	__end_swap_time = __common_var_swap_end_time;
+	thread_abort_end_time = (z_arch_timing_value_swap_common);
+	z_arch_timing_swap_end = z_arch_timing_value_swap_common;
 #if defined(CONFIG_X86) || defined(CONFIG_X86_64)
-	__start_swap_time = __temp_start_swap_time;
+	z_arch_timing_swap_start = z_arch_timing_value_swap_temp;
 	/* In the rest of ARCHes read_timer_start_of_swap() has already
 	 * registered the time-stamp of the start of context-switch in
-	 * __start_swap_time.
+	 * z_arch_timing_swap_start.
 	 */
 #endif
-	u32_t total_swap_cycles = __end_swap_time - __start_swap_time;
+	u32_t total_swap_cycles = z_arch_timing_swap_end - z_arch_timing_swap_start;
 
 	/* Interrupt latency*/
-	u64_t local_end_intr_time = __end_intr_time;
-	u64_t local_start_intr_time = __start_intr_time;
+	u64_t local_end_intr_time = z_arch_timing_irq_end;
+	u64_t local_start_intr_time = z_arch_timing_irq_start;
 
 	/*******************************************************************/
 	/* thread create*/
@@ -224,8 +224,8 @@ void system_thread_bench(void)
 		(u32_t) (CYCLES_TO_NS(intr_latency_cycles)));
 
 	/*tick overhead*/
-	u32_t tick_overhead_cycles =  SUBTRACT_CLOCK_CYCLES(__end_tick_time) -
-				SUBTRACT_CLOCK_CYCLES(__start_tick_time);
+	u32_t tick_overhead_cycles =  SUBTRACT_CLOCK_CYCLES(z_arch_timing_tick_end) -
+				SUBTRACT_CLOCK_CYCLES(z_arch_timing_tick_start);
 	PRINT_STATS("Tick overhead",
 		(u32_t)(tick_overhead_cycles),
 		(u32_t) (CYCLES_TO_NS(tick_overhead_cycles)));

--- a/tests/benchmarks/timing_info/src/timing_info.h
+++ b/tests/benchmarks/timing_info/src/timing_info.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <timestamp.h>
-
+#include <kernel_internal.h>
 
 #define CALCULATE_TIME(special_char, profile, name)			     \
 	{								     \
@@ -201,15 +201,6 @@ void mutex_bench(void);
 void msg_passing_bench(void);
 void userspace_bench(void);
 
-/******************************************************************************/
-/* External variables */
-extern u64_t __start_swap_time;
-extern u64_t __end_swap_time;
-extern u64_t __start_intr_time;
-extern u64_t __end_intr_time;
-extern u64_t __start_tick_time;
-extern u64_t __end_tick_time;
-/******************************************************************************/
 #ifdef CONFIG_USERSPACE
 #include <syscall_handler.h>
 __syscall int k_dummy_syscall(void);

--- a/tests/benchmarks/timing_info/src/userspace_bench.c
+++ b/tests/benchmarks/timing_info/src/userspace_bench.c
@@ -20,7 +20,7 @@ K_APPMEM_PARTITION_DEFINE(bench_ptn);
 struct k_mem_domain bench_domain;
 
 extern char sline[256];
-extern u64_t __end_drop_to_usermode_time;
+extern u64_t z_arch_timing_enter_user_mode_end;
 
 u32_t drop_to_user_mode_end_time, drop_to_user_mode_start_time;
 u32_t user_thread_creation_end_time, user_thread_creation_start_time;
@@ -105,7 +105,7 @@ void drop_to_user_mode(void)
 	k_yield();
 
 	drop_to_user_mode_end_time = (u32_t)
-		SUBTRACT_CLOCK_CYCLES(__end_drop_to_usermode_time);
+		SUBTRACT_CLOCK_CYCLES(z_arch_timing_enter_user_mode_end);
 
 	u32_t tmp_start_time =
 		SUBTRACT_CLOCK_CYCLES(drop_to_user_mode_start_time);

--- a/tests/benchmarks/timing_info/src/yield_bench.c
+++ b/tests/benchmarks/timing_info/src/yield_bench.c
@@ -18,11 +18,6 @@ extern K_THREAD_STACK_DEFINE(my_stack_area_0, STACK_SIZE);
 extern struct k_thread my_thread;
 extern struct k_thread my_thread_0;
 
-/* u64_t thread_yield_start_time[1000]; */
-/* u64_t thread_yield_end_time[1000]; */
-/* location of the time stamps*/
-extern u32_t __read_swap_end_time_value;
-extern u64_t __common_var_swap_end_time;
 extern char sline[];
 
 extern u64_t thread_sleep_start_time;
@@ -53,12 +48,12 @@ void yield_bench(void)
 				     0 /*priority*/, 0, 0);
 
 	/*read the time of start of the sleep till the swap happens */
-	__read_swap_end_time_value = 1U;
+	z_arch_timing_value_swap_end = 1U;
 
 	TIMING_INFO_PRE_READ();
 	thread_sleep_start_time =   TIMING_INFO_OS_GET_TIME();
 	k_sleep(1000);
-	thread_sleep_end_time =   ((u32_t)__common_var_swap_end_time);
+	thread_sleep_end_time =   ((u32_t)z_arch_timing_value_swap_common);
 
 	u32_t yield_cycles = (thread_end_time - thread_start_time) / 2000U;
 	u32_t sleep_cycles = thread_sleep_end_time - thread_sleep_start_time;

--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -25,7 +25,7 @@ static void offload_function(void *param)
 	u32_t x = POINTER_TO_INT(param);
 
 	/* Make sure we're in IRQ context */
-	zassert_true(z_is_in_isr(), "Not in IRQ context!");
+	zassert_true(k_is_in_isr(), "Not in IRQ context!");
 
 	sentinel = x;
 }

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -128,7 +128,7 @@ static void offload_function(void *param)
 {
 	ARG_UNUSED(param);
 
-	zassert_true(z_is_in_isr(), "Not in IRQ context!");
+	zassert_true(k_is_in_isr(), "Not in IRQ context!");
 	k_timer_init(&timer, timer_handler, NULL);
 	k_busy_wait(MS_TO_US(1));
 	k_timer_start(&timer, DURATION, 0);

--- a/tests/kernel/mem_protect/obj_validation/src/main.c
+++ b/tests/kernel/mem_protect/obj_validation/src/main.c
@@ -7,6 +7,7 @@
 #include <zephyr.h>
 #include <syscall_handler.h>
 #include <ztest.h>
+#include <kernel_internal.h>
 
 #define SEM_ARRAY_SIZE	16
 
@@ -65,8 +66,6 @@ void object_permission_checks(struct k_sem *sem, bool skip_init)
 		      "object should have had sufficient permissions");
 }
 
-extern const k_tid_t _main_thread;
-
 /**
  * @brief Tests to verify object permission
  *
@@ -93,7 +92,7 @@ void test_generic_object(void)
 		/* Give an extra reference to another thread so the object
 		 * doesn't disappear if we revoke our own
 		 */
-		k_object_access_grant(dyn_sem[i], _main_thread);
+		k_object_access_grant(dyn_sem[i], &z_main_thread);
 	}
 
 	/* dynamic object table well-populated with semaphores at this point */

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -146,7 +146,6 @@ void test_thread_name_get_set(void)
 #ifdef CONFIG_USERSPACE
 static char unreadable_string[64];
 static char not_my_buffer[CONFIG_THREAD_MAX_NAME_LEN];
-ZTEST_BMEM struct k_thread *main_thread_ptr;
 struct k_sem sem;
 #endif /* CONFIG_USERSPACE */
 
@@ -169,7 +168,7 @@ void test_thread_name_user_get_set(void)
 	zassert_equal(ret, -EFAULT, "accepted unreadable string");
 	ret = k_thread_name_set((struct k_thread *)&sem, "some name");
 	zassert_equal(ret, -EINVAL, "accepted non-thread object");
-	ret = k_thread_name_set(main_thread_ptr, "some name");
+	ret = k_thread_name_set(&z_main_thread, "some name");
 	zassert_equal(ret, -EINVAL, "no permission on thread object");
 
 	/* Set and get current thread's name */
@@ -191,7 +190,7 @@ void test_thread_name_user_get_set(void)
 	ret = k_thread_name_copy((struct k_thread *)&sem, thread_name,
 				     sizeof(thread_name));
 	zassert_equal(ret, -EINVAL, "not a thread object");
-	ret = k_thread_name_copy(main_thread_ptr, thread_name,
+	ret = k_thread_name_copy(&z_main_thread, thread_name,
 				     sizeof(thread_name));
 	zassert_equal(ret, 0, "couldn't get main thread name");
 	printk("Main thread name is '%s'\n", thread_name);
@@ -270,8 +269,6 @@ void test_user_mode(void)
 }
 #endif
 
-extern const k_tid_t _main_thread;
-
 void test_main(void)
 {
 	k_thread_access_grant(k_current_get(), &tdata, tstack);
@@ -281,8 +278,6 @@ void test_main(void)
 #ifdef CONFIG_USERSPACE
 	strncpy(unreadable_string, "unreadable string",
 		sizeof(unreadable_string));
-	/* Copy so user mode can get at it */
-	main_thread_ptr = _main_thread;
 #endif
 
 	ztest_test_suite(threads_lifecycle,


### PR DESCRIPTION
This patch attempts to clean up the naming of some private kernel variables and functions, especially if these variables are part of the kernel to architecture code interface. For the architecture interface variables and functions, they are now all prefixed with z_arch. Some symbols have been renamed to conform to zephyr coding standard, which has symbol name elements in reverse order of specificity with the verb last.

- various globals related to CONFIG_EXECUTION_BENCHMARKING renamed
- z_new_thread() renamed to z_arch_new_thread()
- z_is_in_isr() renamed to z_arch_is_in_isr()
- arch_nop() renamed to z_arch_nop()
- k_cpu_idle() and k_cpu_atomic_idle() are now wrapper functions defined in kernel.h, which call the arch-specific idle functions, now named z_arch_cpu_idle() and z_arch_cpu_atomic_idle()
- z_set_thread_return_value() renamed to z_arch_thread_return_value_set(), and z_set_thread_return_value() renamed to z_thread_return_value_set()
- kernel_arch_init() renamed to z_arch_kernel_init()
- redundant setting of x86 boot idle timestamp removed, it's already set in common code
- __idle_time_stamp renamed to z_timestamp_idle, __main_time_stamp renamed to z_timestamp_main. Definitions moved to kernel_internal.h
- _idle_thread and _main_thread, which were pointers to the actual thread objects, have been removed (they waste a bit of memory and can't be read by user mode.) They have been replaced by renaming the actual objects to z_main_thread and z_idle_thread, and exposed in kernel_internal.h. Their associated stack objects have been renamed to z_main_stack and z_idle_stack.
- __swap() renamed to z_arch_swap()
- ARC's k_cpu_sleep_mode renamed to a more suitable z_arc_cpu_sleep_mode, it's not an application facing symbol and is only used by the ARC arch code.
- Several duplicated function definitions to detect whether a provided thread object is the idle thread have been removed, with z_is_idle_thread_object() replacing them in ksched.h
- z_is_idle_thread() renamed to z_is_idle_thread_entry() to clarify what it is checking.

There's more to do, but this PR should certainly provide some value. In particular:

- I'm punting an overhaul on how _interrupt_stack is expressed to another PR, need to make sure I get this right wrt SMP and the new intel64 port.
- In most cases, only the names have been changed, not the location of definitions. Architecture-specific symbols are still defined across a variety of different header files. I aim to consolidate all of them to one or two common headers in another PR.
- Abstraction/renaming of sys_io, sys_bit, etc. functions will be done in another PR.
- There are still some symbols with leading underscores not addressed by this PR, although they all should be unrelated to arch <--> kernel interface.
- This PR does not address naming of linker symbols
- This PR does not add documentation for APIs which were previously undocumented