### PR TITLE
tests: arm thread swap: increase Idle Stack size for no-opt test-case

### DIFF
--- a/tests/arch/arm/arm_thread_swap/testcase.yaml
+++ b/tests/arch/arm/arm_thread_swap/testcase.yaml
@@ -8,6 +8,7 @@ tests:
     filter: CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     extra_configs:
       - CONFIG_NO_OPTIMIZATIONS=y
+      - CONFIG_IDLE_STACK_SIZE=512
     tags: arm
     min_flash: 64
   arch.arm.swap.common.fp_sharing:
@@ -24,5 +25,6 @@ tests:
       - CONFIG_FLOAT=y
       - CONFIG_FP_SHARING=y
       - CONFIG_NO_OPTIMIZATIONS=y
+      - CONFIG_IDLE_STACK_SIZE=512
     tags: arm
     min_flash: 64


### PR DESCRIPTION
Executing the ARM thread swap test with NO_OPTIMIZATIONS
option set, leads to Idle thread stack overflow in certain
platforms. We increase the size of the Idle thread stack to
address this.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>