### PR TITLE
logging: add minimal implementation

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -257,10 +257,8 @@ extern "C" {
  *
  * @param fmt Formatted string to output.
  * @param ap  Variable parameters.
- *
- * return Number of bytes written.
  */
-int log_printk(const char *fmt, va_list ap);
+void log_printk(const char *fmt, va_list ap);
 
 /** @brief Copy transient string to a buffer from internal, logger pool.
  *

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -28,12 +28,6 @@ extern "C" {
  * @{
  */
 
-#define LOG_LEVEL_NONE 0
-#define LOG_LEVEL_ERR  1
-#define LOG_LEVEL_WRN  2
-#define LOG_LEVEL_INF  3
-#define LOG_LEVEL_DBG  4
-
 /**
  * @brief Writes an ERROR level message to the log.
  *
@@ -247,6 +241,7 @@ extern "C" {
 #define LOG_INST_HEXDUMP_DBG(_log_inst, _data, _length, _str)	\
 	Z_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_DBG, _log_inst, _data, _length, _str)
 
+#ifndef CONFIG_LOG_MINIMAL
 /**
  * @brief Writes an formatted string to the log.
  *
@@ -266,13 +261,29 @@ void log_printk(const char *fmt, va_list ap);
  * Logger allocates a buffer and copies input string returning a pointer to the
  * copy. Logger ensures that buffer is freed when logger message is freed.
  *
+ * Depending on configuration, this function may do nothing and just pass
+ * along the supplied string pointer. Do not rely on this function to always
+ * make a copy!
+ *
  * @param str Transient string.
  *
  * @return Copy of the string or default string if buffer could not be
  *	   allocated. String may be truncated if input string does not fit in
- *	   a buffer from the pool (see CONFIG_LOG_STRDUP_MAX_STRING).
+ *	   a buffer from the pool (see CONFIG_LOG_STRDUP_MAX_STRING). In
+ *	   some configurations, the original string pointer is returned.
  */
 char *log_strdup(const char *str);
+#else
+static inline void log_printk(const char *fmt, va_list ap)
+{
+	vprintk(fmt, ap);
+}
+
+static inline char *log_strdup(const char *str)
+{
+	return (char *)str;
+}
+#endif /* CONFIG_LOG_MINIMAL */
 
 #ifdef __cplusplus
 }

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -505,15 +505,6 @@ void log_hexdump(const char *str,
 		 u32_t length,
 		 struct log_msg_ids src_level);
 
-/** @brief Format and put string into log message.
- *
- * @param fmt	String to format.
- * @param ap	Variable list of arguments.
- *
- * @return Number of bytes processed.
- */
-int log_printk(const char *fmt, va_list ap);
-
 /** @brief Process log message synchronously.
  *
  * @param src_level	Log message details.

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -13,6 +13,13 @@
 #include <stdarg.h>
 #include <syscall.h>
 #include <sys/util.h>
+#include <sys/printk.h>
+
+#define LOG_LEVEL_NONE 0
+#define LOG_LEVEL_ERR  1
+#define LOG_LEVEL_WRN  2
+#define LOG_LEVEL_INF  3
+#define LOG_LEVEL_DBG  4
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,8 +27,11 @@ extern "C" {
 
 #ifndef CONFIG_LOG
 #define CONFIG_LOG_DEFAULT_LEVEL 0
-#define CONFIG_LOG_DOMAIN_ID 0
 #define CONFIG_LOG_MAX_LEVEL 0
+#endif
+
+#if !defined(CONFIG_LOG) || defined(CONFIG_LOG_MINIMAL)
+#define CONFIG_LOG_DOMAIN_ID 0
 #endif
 
 #define LOG_FUNCTION_PREFIX_MASK \
@@ -211,34 +221,66 @@ extern "C" {
 	))
 
 /******************************************************************************/
+/****************** Defiinitions used by minimal logging **********************/
+/******************************************************************************/
+void log_minimal_hexdump_print(int level, const char *data, size_t size);
+
+#define Z_LOG_TO_PRINTK(_level, fmt, ...) do {				     \
+		printk("%c: " fmt "\n", z_log_minimal_level_to_char(_level), \
+			##__VA_ARGS__);					     \
+	} while (false)
+
+static inline char z_log_minimal_level_to_char(int level)
+{
+	switch (level) {
+	case LOG_LEVEL_ERR:
+		return 'E';
+	case LOG_LEVEL_WRN:
+		return 'W';
+	case LOG_LEVEL_INF:
+		return 'I';
+	case LOG_LEVEL_DBG:
+		return 'D';
+	default:
+		return '?';
+	}
+}
+/******************************************************************************/
 /****************** Macros for standard logging *******************************/
 /******************************************************************************/
-#define __LOG(_level, _id, _filter, ...)				    \
-	do {								    \
-		bool is_user_context = _is_user_context();		    \
-									    \
-		if (Z_LOG_CONST_LEVEL_CHECK(_level) &&			    \
-		    (is_user_context ||					    \
-		     (_level <= LOG_RUNTIME_FILTER(_filter)))) {	    \
-			struct log_msg_ids src_level = {		    \
-				.level = _level,			    \
-				.domain_id = CONFIG_LOG_DOMAIN_ID,	    \
-				.source_id = _id			    \
-			};						    \
-									    \
-			if ((BIT(_level) & LOG_FUNCTION_PREFIX_MASK) != 0U) {\
-				__LOG_INTERNAL(is_user_context, src_level,  \
-						Z_LOG_STR(__VA_ARGS__));    \
-			} else {					    \
-				__LOG_INTERNAL(is_user_context, src_level,  \
-						__VA_ARGS__);		    \
-			}						    \
-		} else if (false) {					    \
-			/* Arguments checker present but never evaluated.*/ \
-			/* Placed here to ensure that __VA_ARGS__ are*/     \
-			/* evaluated once when log is enabled.*/	    \
-			log_printf_arg_checker(__VA_ARGS__);		    \
-		}							    \
+#define __LOG(_level, _id, _filter, ...)				       \
+	do {								       \
+		bool is_user_context = _is_user_context();		       \
+									       \
+		if (Z_LOG_CONST_LEVEL_CHECK(_level)) {			       \
+			if (IS_ENABLED(CONFIG_LOG_MINIMAL)) {		       \
+				Z_LOG_TO_PRINTK(_level, __VA_ARGS__);	       \
+			} else if (is_user_context ||			       \
+				   (_level <= LOG_RUNTIME_FILTER(_filter))) {  \
+				struct log_msg_ids src_level = {	       \
+					.level = _level,		       \
+					.domain_id = CONFIG_LOG_DOMAIN_ID,     \
+					.source_id = _id		       \
+				};					       \
+									       \
+				if ((BIT(_level) &			       \
+				     LOG_FUNCTION_PREFIX_MASK) != 0U) {        \
+					__LOG_INTERNAL(is_user_context,	       \
+						       src_level,	       \
+						       Z_LOG_STR(__VA_ARGS__));\
+				} else {				       \
+					__LOG_INTERNAL(is_user_context,	       \
+						       src_level,	       \
+						       __VA_ARGS__);	       \
+				}					       \
+			}						       \
+		}							       \
+		if (false) {						       \
+			/* Arguments checker present but never evaluated.*/    \
+			/* Placed here to ensure that __VA_ARGS__ are*/        \
+			/* evaluated once when log is enabled.*/	       \
+			log_printf_arg_checker(__VA_ARGS__);		       \
+		}							       \
 	} while (false)
 
 #define Z_LOG(_level, ...)			       \
@@ -259,29 +301,35 @@ extern "C" {
 /******************************************************************************/
 /****************** Macros for hexdump logging ********************************/
 /******************************************************************************/
-#define __LOG_HEXDUMP(_level, _id, _filter, _data, _length, _str)	      \
-	do {								      \
-		bool is_user_context = _is_user_context();		      \
-									      \
-		if (Z_LOG_CONST_LEVEL_CHECK(_level) &&			      \
-		    (is_user_context ||					      \
-		     (_level <= LOG_RUNTIME_FILTER(_filter)))) {	      \
-			struct log_msg_ids src_level = {		      \
-				.level = _level,			      \
-				.source_id = _id,			      \
-				.domain_id = CONFIG_LOG_DOMAIN_ID	      \
-			};						      \
-									      \
-			if (is_user_context) {				      \
-				log_hexdump_from_user(src_level, _str,	      \
-						      _data, _length);	      \
-			} else if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) {	      \
-				log_hexdump_sync(src_level, _str,	      \
-						 _data, _length);	      \
-			} else {					      \
-				log_hexdump(_str, _data, _length, src_level); \
-			}						      \
-		}							      \
+#define __LOG_HEXDUMP(_level, _id, _filter, _data, _length, _str)	       \
+	do {								       \
+		bool is_user_context = _is_user_context();		       \
+									       \
+		if (Z_LOG_CONST_LEVEL_CHECK(_level)) {			       \
+			if (IS_ENABLED(CONFIG_LOG_MINIMAL)) {		       \
+				Z_LOG_TO_PRINTK(_level, "%s", _str);	       \
+				log_minimal_hexdump_print(_level, _data,       \
+							  _length);	       \
+			} else if (is_user_context ||			       \
+				   (_level <= LOG_RUNTIME_FILTER(_filter))) {  \
+				struct log_msg_ids src_level = {	       \
+					.level = _level,		       \
+					.source_id = _id,		       \
+					.domain_id = CONFIG_LOG_DOMAIN_ID      \
+				};					       \
+									       \
+				if (is_user_context) {			       \
+					log_hexdump_from_user(src_level, _str, \
+							      _data, _length); \
+				} else if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) { \
+					log_hexdump_sync(src_level, _str,      \
+							 _data, _length);      \
+				} else {				       \
+					log_hexdump(_str, _data, _length,      \
+						    src_level);		       \
+				}					       \
+			}						       \
+		}							       \
 	} while (false)
 
 #define Z_LOG_HEXDUMP(_level, _data, _length, _str)	       \

--- a/include/logging/log_ctrl.h
+++ b/include/logging/log_ctrl.h
@@ -169,7 +169,7 @@ void log_backend_enable(struct log_backend const *const backend,
  */
 void log_backend_disable(struct log_backend const *const backend);
 
-#if defined(CONFIG_LOG)
+#if defined(CONFIG_LOG) && !defined(CONFIG_LOG_MINIMAL)
 #define LOG_CORE_INIT() log_core_init()
 #define LOG_INIT() log_init()
 #define LOG_PANIC() log_panic()

--- a/include/logging/log_ctrl.h
+++ b/include/logging/log_ctrl.h
@@ -170,10 +170,12 @@ void log_backend_enable(struct log_backend const *const backend,
 void log_backend_disable(struct log_backend const *const backend);
 
 #if defined(CONFIG_LOG)
+#define LOG_CORE_INIT() log_core_init()
 #define LOG_INIT() log_init()
 #define LOG_PANIC() log_panic()
 #define LOG_PROCESS() log_process(false)
 #else
+#define LOG_CORE_INIT() do { } while (false)
 #define LOG_INIT() 0
 #define LOG_PANIC() /* Empty */
 #define LOG_PROCESS() false

--- a/include/shell/shell_log_backend.h
+++ b/include/shell/shell_log_backend.h
@@ -64,7 +64,7 @@ int shell_log_backend_output_func(u8_t *data, size_t length, void *ctx);
  *
  *  @param _name Shell name.
  */
-#ifdef CONFIG_LOG
+#ifdef CONFIG_SHELL_LOG_BACKEND
 #define SHELL_LOG_BACKEND_DEFINE(_name, _buf, _size, _queue_size, _timeout)  \
 	LOG_BACKEND_DEFINE(_name##_backend, log_backend_shell_api, false);   \
 	K_MSGQ_DEFINE(_name##_msgq, sizeof(struct shell_log_backend_msg),    \

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -481,9 +481,7 @@ FUNC_NORETURN void z_cstart(void)
 	/* gcov hook needed to get the coverage report.*/
 	gcov_static_init();
 
-	if (IS_ENABLED(CONFIG_LOG)) {
-		log_core_init();
-	}
+	LOG_CORE_INIT();
 
 	/* perform any architecture-specific initialization */
 	z_arch_kernel_init();

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -216,6 +216,7 @@ extern void __stdout_hook_install(int (*fn)(int));
 #define CONFIG_BT_MONITOR_ON_DEV_NAME CONFIG_UART_CONSOLE_ON_DEV_NAME
 #endif
 
+#ifndef CONFIG_LOG_MINIMAL
 struct monitor_log_ctx {
 	size_t total_len;
 	char msg[MONITOR_MSG_MAX];
@@ -319,6 +320,7 @@ static const struct log_backend_api monitor_log_api = {
 };
 
 LOG_BACKEND_DEFINE(bt_monitor, monitor_log_api, true);
+#endif /* CONFIG_LOG_MINIMAL */
 
 static int bt_monitor_init(struct device *d)
 {

--- a/subsys/logging/CMakeLists.txt
+++ b/subsys/logging/CMakeLists.txt
@@ -1,49 +1,53 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_sources_ifdef(
-  CONFIG_LOG
-  log_list.c
-  log_core.c
-  log_msg.c
-  log_output.c
+if(NOT CONFIG_LOG_MINIMAL)
+  zephyr_sources_ifdef(
+    CONFIG_LOG
+    log_list.c
+    log_core.c
+    log_msg.c
+    log_output.c
   )
 
-zephyr_sources_ifdef(
-  CONFIG_LOG_BACKEND_UART
-  log_backend_uart.c
+  zephyr_sources_ifdef(
+    CONFIG_LOG_BACKEND_UART
+    log_backend_uart.c
   )
 
-zephyr_sources_ifdef(
-  CONFIG_LOG_CMDS
-  log_cmds.c
+  zephyr_sources_ifdef(
+    CONFIG_LOG_CMDS
+    log_cmds.c
   )
 
-zephyr_sources_ifdef(
-  CONFIG_LOG_BACKEND_NATIVE_POSIX
-  log_backend_native_posix.c
+  zephyr_sources_ifdef(
+    CONFIG_LOG_BACKEND_NATIVE_POSIX
+    log_backend_native_posix.c
   )
 
-zephyr_sources_ifdef(
-  CONFIG_LOG_BACKEND_XTENSA_SIM
-  log_backend_xtensa_sim.c
+  zephyr_sources_ifdef(
+    CONFIG_LOG_BACKEND_XTENSA_SIM
+    log_backend_xtensa_sim.c
   )
 
-zephyr_sources_ifdef(
-  CONFIG_LOG_BACKEND_NET
-  log_backend_net.c
+  zephyr_sources_ifdef(
+    CONFIG_LOG_BACKEND_NET
+    log_backend_net.c
   )
 
-zephyr_sources_ifdef(
-  CONFIG_LOG_BACKEND_RTT
-  log_backend_rtt.c
-)
+  zephyr_sources_ifdef(
+    CONFIG_LOG_BACKEND_RTT
+    log_backend_rtt.c
+  )
 
-zephyr_sources_ifdef(
-  CONFIG_LOG_BACKEND_SWO
-  log_backend_swo.c
-)
+  zephyr_sources_ifdef(
+    CONFIG_LOG_BACKEND_SWO
+    log_backend_swo.c
+  )
 
-zephyr_sources_ifdef(
-  CONFIG_LOG_BACKEND_QEMU_X86_64
-  log_backend_qemu_x86_64.c
-)
+  zephyr_sources_ifdef(
+    CONFIG_LOG_BACKEND_QEMU_X86_64
+    log_backend_qemu_x86_64.c
+  )
+else()
+  zephyr_sources(log_minimal.c)
+endif()

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -13,9 +13,21 @@ menuconfig LOG
 
 if LOG
 
+config LOG_MINIMAL
+	bool "Enable minimal-footprint logging"
+	imply PRINTK
+	help
+	  Enable minimal logging implementation. This has very little footprint
+	  overhead on top of the printk() implementation for standard
+	  logging macros. Hexdump macros are also supported, with a small
+	  amount of code pulled in if used. Build time filtering is supported,
+	  but not runtime filtering. There are no timestamps, prefixes,
+	  colors, or asynchronous logging, and all messages are simply
+	  sent to printk().
+
 config LOG_RUNTIME_FILTERING
 	bool "Enable runtime reconfiguration of the logger"
-	depends on !LOG_FRONTEND
+	depends on !LOG_FRONTEND && !LOG_MINIMAL
 	help
 	  Allow runtime configuration of maximal, independent severity
 	  level for instance.
@@ -68,6 +80,8 @@ config LOG_MAX_LEVEL
 	  - 2 WARNING, maximal level set to LOG_LEVEL_WRN
 	  - 3 INFO, maximal level set to LOG_LEVEL_INFO
 	  - 4 DEBUG, maximal level set to LOG_LEVEL_DBG
+
+if !LOG_MINIMAL
 
 menu "Prepend log message with function name"
 	depends on !LOG_FRONTEND
@@ -477,4 +491,5 @@ config LOG_BACKEND_FORMAT_TIMESTAMP
 	help
 	  When enabled timestamp is formatted to hh:mm:ss:ms,us.
 
+endif # LOG_MINIMAL
 endif # LOG

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -320,10 +320,8 @@ void log_hexdump(const char *str,
 	}
 }
 
-int log_printk(const char *fmt, va_list ap)
+void log_printk(const char *fmt, va_list ap)
 {
-	int length = 0;
-
 	if (IS_ENABLED(CONFIG_LOG_PRINTK)) {
 		union {
 			struct log_msg_ids structure;
@@ -337,8 +335,7 @@ int log_printk(const char *fmt, va_list ap)
 		if (_is_user_context()) {
 			u8_t str[CONFIG_LOG_PRINTK_MAX_STRING_LENGTH + 1];
 
-			length = vsnprintk(str, sizeof(str), fmt, ap);
-			length = MIN(length, sizeof(str));
+			vsnprintk(str, sizeof(str), fmt, ap);
 
 			z_log_string_from_user(src_level_union.value, str);
 		} else if (IS_ENABLED(CONFIG_LOG_IMMEDIATE)) {
@@ -346,20 +343,19 @@ int log_printk(const char *fmt, va_list ap)
 		} else {
 			u8_t str[CONFIG_LOG_PRINTK_MAX_STRING_LENGTH + 1];
 			struct log_msg *msg;
+			int length;
 
 			length = vsnprintk(str, sizeof(str), fmt, ap);
 			length = MIN(length, sizeof(str));
 
 			msg = log_msg_hexdump_create(NULL, str, length);
 			if (msg == NULL) {
-				return 0;
+				return;
 			}
 
 			msg_finalize(msg, src_level_union.structure);
 		}
 	}
-
-	return length;
 }
 
 /** @brief Count number of arguments in formatted string.

--- a/subsys/logging/log_minimal.c
+++ b/subsys/logging/log_minimal.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sys/printk.h>
+#include <ctype.h>
+#include <logging/log.h>
+
+#define HEXDUMP_BYTES_IN_LINE 8
+
+static void minimal_hexdump_line_print(const char *data, size_t length)
+{
+	for (int i = 0; i < HEXDUMP_BYTES_IN_LINE; i++) {
+		if (i < length) {
+			printk("%02x ", data[i] & 0xFF);
+		} else {
+			printk("   ");
+		}
+	}
+
+	printk("|");
+
+	for (int i = 0; i < HEXDUMP_BYTES_IN_LINE; i++) {
+		if (i < length) {
+			char c = data[i];
+
+			printk("%c", isprint((int)c) ? c : '.');
+		} else {
+			printk(" ");
+		}
+	}
+	printk("\n");
+}
+
+void log_minimal_hexdump_print(int level, const char *data, size_t size)
+{
+	while (size > 0) {
+		printk("%c: ", z_log_minimal_level_to_char(level));
+		minimal_hexdump_line_print(data, size);
+
+		if (size < HEXDUMP_BYTES_IN_LINE) {
+			break;
+		}
+
+		size -= HEXDUMP_BYTES_IN_LINE;
+		data += HEXDUMP_BYTES_IN_LINE;
+	}
+}

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -150,8 +150,8 @@ config SHELL_CMDS_SELECT
 
 config SHELL_LOG_BACKEND
 	bool
+	depends on !LOG_MINIMAL
 	default y if LOG
-	default n if !LOG
 
 source "subsys/shell/modules/Kconfig"
 

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1120,7 +1120,7 @@ static int instance_uninit(const struct shell *shell)
 		return -EBUSY;
 	}
 
-	if (IS_ENABLED(CONFIG_LOG)) {
+	if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
 		/* todo purge log queue */
 		shell_log_backend_disable(shell->log_backend);
 	}
@@ -1174,7 +1174,7 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 		return;
 	}
 
-	if (log_backend && IS_ENABLED(CONFIG_LOG)) {
+	if (log_backend && IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
 		shell_log_backend_enable(shell->log_backend, (void *)shell,
 					 log_level);
 	}
@@ -1204,7 +1204,7 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 
 		shell_signal_handle(shell, SHELL_SIGNAL_KILL, kill_handler);
 		shell_signal_handle(shell, SHELL_SIGNAL_RXRDY, shell_process);
-		if (IS_ENABLED(CONFIG_LOG)) {
+		if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
 			shell_signal_handle(shell, SHELL_SIGNAL_LOG_MSG,
 					    shell_log_process);
 		}

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -83,11 +83,11 @@ config TEST_LOGGING_DEFAULTS
 	bool "Enable test case logging defaults"
 	depends on TEST
 	select LOG
-	select LOG_IMMEDIATE
+	select LOG_MINIMAL
 	default y
 	help
 	  Option which implements default policy of enabling logging in
-	  immediate mode for all test cases. For tests that need alternate
+	  minimal mode for all test cases. For tests that need alternate
 	  logging configuration, or no logging at all, disable this
 	  in the project-level defconfig.
 


### PR DESCRIPTION
The log mechanism, even in immediate mode, adds somewhere
between 1K-2K of footprint to applications that use it.
    
We want to standardize the logging APIs for all logging
within the kernel, but need to not let platforms with
very constrained RAM/ROM in the dust.
    
This patch introduces CONFIG_LOG_MINIMAL, which is a very
thin wrapper to printk(). It supports the APIs expressed
in logging/log.h.
    
This will be the new default for test cases.

log_printk()'s return value was removed to make it more like Zephyr printk().

Some code in shell and bluetooth monitor which assumed that the backend code existed has been adjusted.

Fixes: #19317