### PR TITLE
scripts: edtlib: Rename edtlib.Device to edtlib.Node, and 'specifier' to 'data'

### DIFF
--- a/scripts/dts/dtlib.py
+++ b/scripts/dts/dtlib.py
@@ -8,7 +8,7 @@
 # pylint: disable=undefined-variable
 
 """
-A library for extracting information from .dts (Device Tree) files. See the
+A library for extracting information from .dts (devicetree) files. See the
 documentation for the DT and Node classes for more information.
 
 The top-level entry point of the library is the DT class. DT.__init__() takes a
@@ -23,14 +23,17 @@ import re
 import sys
 import textwrap
 
-# NOTE: testdtlib.py is the test suite for this library. It can be run directly.
+# NOTE: testdtlib.py is the test suite for this library. It can be run directly
+# as a script:
+#
+#   ./testdtlib.py
 
 
 class DT:
     """
-    Represents a device tree parsed from a .dts file (or from many files, if
-    the .dts file /include/s other files). Creating many instances of this
-    class is fine. The library has no global state.
+    Represents a devicetree parsed from a .dts file (or from many files, if the
+    .dts file /include/s other files). Creating many instances of this class is
+    fine. The library has no global state.
 
     These attributes are available on DT instances:
 
@@ -160,7 +163,7 @@ class DT:
 
     def node_iter(self):
         """
-        Returns a generator for iterating over all nodes in the device tree.
+        Returns a generator for iterating over all nodes in the devicetree.
 
         For example, this will print the name of each node that has a property
         called 'foo':
@@ -173,8 +176,8 @@ class DT:
 
     def __str__(self):
         """
-        Returns a DTS representation of the device tree. Called automatically
-        if the DT instance is print()ed.
+        Returns a DTS representation of the devicetree. Called automatically if
+        the DT instance is print()ed.
         """
         s = "/dts-v1/;\n\n"
 
@@ -1165,7 +1168,7 @@ class DT:
 
 class Node:
     r"""
-    Represents a node in the device tree ('node-name { ... };').
+    Represents a node in the devicetree ('node-name { ... };').
 
     These attributes are available on Node instances:
 
@@ -1721,7 +1724,7 @@ class Property:
 def to_num(data, length=None, signed=False):
     """
     Converts the 'bytes' array 'data' to a number. The value is expected to be
-    in big-endian format, which is standard in Device Tree.
+    in big-endian format, which is standard in devicetree.
 
     length (default: None):
       The expected length of the value in bytes, as a simple type check. If
@@ -1743,7 +1746,7 @@ def to_num(data, length=None, signed=False):
 def to_nums(data, length=4, signed=False):
     """
     Like Property.to_nums(), but takes an arbitrary 'bytes' array. The values
-    are assumed to be in big-endian format, which is standard in Device Tree.
+    are assumed to be in big-endian format, which is standard in devicetree.
     """
     _check_is_bytes(data)
     _check_length_positive(length)
@@ -1844,7 +1847,7 @@ _escape_table = str.maketrans({
 
 
 class DTError(Exception):
-    "Exception raised for Device Tree-related errors"
+    "Exception raised for devicetree-related errors"
 
 
 _Token = collections.namedtuple("Token", "id val")

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -428,15 +428,15 @@ def write_irqs(node):
         # Look for interrupt controller parent until we have none
         while irq_ctrl.interrupts:
             irq_num = (irq_num + 1) << 8
-            if "irq" not in irq_ctrl.interrupts[0].specifier:
+            if "irq" not in irq_ctrl.interrupts[0].data:
                 err("Expected binding for {!r} to have 'irq' "
                     "in '#cells'".format(irq_ctrl))
-            irq_num |= irq_ctrl.interrupts[0].specifier["irq"]
+            irq_num |= irq_ctrl.interrupts[0].data["irq"]
             irq_ctrl = irq_ctrl.interrupts[0].controller
         return irq_num
 
     for irq_i, irq in enumerate(node.interrupts):
-        for cell_name, cell_value in irq.specifier.items():
+        for cell_name, cell_value in irq.data.items():
             ident = "IRQ_{}".format(irq_i)
             if cell_name == "irq":
                 cell_value = encode_zephyr_multi_level_irq(irq, cell_value)
@@ -514,7 +514,7 @@ def write_phandle_val_list_entry(node, entry, i, ident):
         initializer_vals.append(quote_str(entry.controller.label))
         out_dev_s(node, ctrl_ident, entry.controller.label)
 
-    for cell, val in entry.specifier.items():
+    for cell, val in entry.data.items():
         cell_ident = ident + "S_" + str2ident(cell)  # e.g. PWMS_CHANNEL
         if entry.name:
             # From e.g. 'pwm-names = ...'
@@ -524,7 +524,7 @@ def write_phandle_val_list_entry(node, entry, i, ident):
             cell_ident += "_{}".format(i)
         out_dev(node, cell_ident, val)
 
-    initializer_vals += entry.specifier.values()
+    initializer_vals += entry.data.values()
 
     initializer_ident = ident + "S"
     if entry.name:
@@ -536,7 +536,7 @@ def write_phandle_val_list_entry(node, entry, i, ident):
 
 
 def write_clocks(node):
-    # Writes clock controller and specifier info for the clock in the node's
+    # Writes clock controller and clock data for the clock in the node's
     # 'clock' property
 
     for clock_i, clock in enumerate(node.clocks):
@@ -546,7 +546,7 @@ def write_clocks(node):
         if clock.frequency is not None:
             out_dev(node, "CLOCKS_CLOCK_FREQUENCY", clock.frequency)
 
-        for spec, val in clock.specifier.items():
+        for spec, val in clock.data.items():
             if clock_i == 0:
                 clk_name_alias = "CLOCK_" + str2ident(spec)
             else:

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -41,47 +41,47 @@ def run():
     #
 
     verify_streq(edt.get_node("/interrupt-parent-test/node").interrupts,
-                 "[<Interrupt, name: foo, target: <Node /interrupt-parent-test/controller in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 1, 'two': 2, 'three': 3}>, <Interrupt, name: bar, target: <Node /interrupt-parent-test/controller in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 4, 'two': 5, 'three': 6}>]")
+                 "[<Interrupt, name: foo, target: <Node /interrupt-parent-test/controller in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: {'one': 1, 'two': 2, 'three': 3}>, <Interrupt, name: bar, target: <Node /interrupt-parent-test/controller in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: {'one': 4, 'two': 5, 'three': 6}>]")
 
     verify_streq(edt.get_node("/interrupts-extended-test/node").interrupts,
-                 "[<Interrupt, target: <Node /interrupts-extended-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, specifier: {'one': 1}>, <Interrupt, target: <Node /interrupts-extended-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, specifier: {'one': 2, 'two': 3}>, <Interrupt, target: <Node /interrupts-extended-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 4, 'two': 5, 'three': 6}>]")
+                 "[<Interrupt, target: <Node /interrupts-extended-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, data: {'one': 1}>, <Interrupt, target: <Node /interrupts-extended-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, data: {'one': 2, 'two': 3}>, <Interrupt, target: <Node /interrupts-extended-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: {'one': 4, 'two': 5, 'three': 6}>]")
 
     verify_streq(edt.get_node("/interrupt-map-test/node@0").interrupts,
-                 "[<Interrupt, target: <Node /interrupt-map-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, specifier: {'one': 0}>, <Interrupt, target: <Node /interrupt-map-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, specifier: {'one': 0, 'two': 1}>, <Interrupt, target: <Node /interrupt-map-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 0, 'two': 0, 'three': 2}>]")
+                 "[<Interrupt, target: <Node /interrupt-map-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, data: {'one': 0}>, <Interrupt, target: <Node /interrupt-map-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, data: {'one': 0, 'two': 1}>, <Interrupt, target: <Node /interrupt-map-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: {'one': 0, 'two': 0, 'three': 2}>]")
 
     verify_streq(edt.get_node("/interrupt-map-test/node@1").interrupts,
-                 "[<Interrupt, target: <Node /interrupt-map-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, specifier: {'one': 3}>, <Interrupt, target: <Node /interrupt-map-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, specifier: {'one': 0, 'two': 4}>, <Interrupt, target: <Node /interrupt-map-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 0, 'two': 0, 'three': 5}>]")
+                 "[<Interrupt, target: <Node /interrupt-map-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, data: {'one': 3}>, <Interrupt, target: <Node /interrupt-map-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, data: {'one': 0, 'two': 4}>, <Interrupt, target: <Node /interrupt-map-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: {'one': 0, 'two': 0, 'three': 5}>]")
 
     verify_streq(edt.get_node("/interrupt-map-bitops-test/node@70000000E").interrupts,
-                 "[<Interrupt, target: <Node /interrupt-map-bitops-test/controller in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, specifier: {'one': 3, 'two': 2}>]")
+                 "[<Interrupt, target: <Node /interrupt-map-bitops-test/controller in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, data: {'one': 3, 'two': 2}>]")
 
     #
     # Test GPIOs
     #
 
     verify_streq(edt.get_node("/gpio-test/node").gpios,
-                 "{'': [<GPIO, name: , target: <Node /gpio-test/controller-0 in 'test.dts', binding test-bindings/gpio-1-cell.yaml>, specifier: {'one': 1}>, <GPIO, name: , target: <Node /gpio-test/controller-1 in 'test.dts', binding test-bindings/gpio-2-cell.yaml>, specifier: {'one': 2, 'two': 3}>], 'foo': [<GPIO, name: foo, target: <Node /gpio-test/controller-1 in 'test.dts', binding test-bindings/gpio-2-cell.yaml>, specifier: {'one': 4, 'two': 5}>], 'bar': [<GPIO, name: bar, target: <Node /gpio-test/controller-1 in 'test.dts', binding test-bindings/gpio-2-cell.yaml>, specifier: {'one': 6, 'two': 7}>]}")
+                 "{'': [<GPIO, name: , target: <Node /gpio-test/controller-0 in 'test.dts', binding test-bindings/gpio-1-cell.yaml>, data: {'one': 1}>, <GPIO, name: , target: <Node /gpio-test/controller-1 in 'test.dts', binding test-bindings/gpio-2-cell.yaml>, data: {'one': 2, 'two': 3}>], 'foo': [<GPIO, name: foo, target: <Node /gpio-test/controller-1 in 'test.dts', binding test-bindings/gpio-2-cell.yaml>, data: {'one': 4, 'two': 5}>], 'bar': [<GPIO, name: bar, target: <Node /gpio-test/controller-1 in 'test.dts', binding test-bindings/gpio-2-cell.yaml>, data: {'one': 6, 'two': 7}>]}")
 
     #
     # Test clocks
     #
 
     verify_streq(edt.get_node("/clock-test/node").clocks,
-                 "[<Clock, name: fixed, frequency: 123, target: <Node /clock-test/fixed-clock in 'test.dts', binding test-bindings/fixed-clock.yaml>, specifier: {}>, <Clock, name: one-cell, target: <Node /clock-test/clock-1 in 'test.dts', binding test-bindings/clock-1-cell.yaml>, specifier: {'one': 1}>, <Clock, name: two-cell, target: <Node /clock-test/clock-2 in 'test.dts', binding test-bindings/clock-2-cell.yaml>, specifier: {'one': 1, 'two': 2}>]")
+                 "[<Clock, name: fixed, frequency: 123, target: <Node /clock-test/fixed-clock in 'test.dts', binding test-bindings/fixed-clock.yaml>, data: {}>, <Clock, name: one-cell, target: <Node /clock-test/clock-1 in 'test.dts', binding test-bindings/clock-1-cell.yaml>, data: {'one': 1}>, <Clock, name: two-cell, target: <Node /clock-test/clock-2 in 'test.dts', binding test-bindings/clock-2-cell.yaml>, data: {'one': 1, 'two': 2}>]")
 
     #
     # Test PWMs
     #
 
     verify_streq(edt.get_node("/pwm-test/node").pwms,
-                 "[<PWM, name: zero-cell, target: <Node /pwm-test/pwm-0 in 'test.dts', binding test-bindings/pwm-0-cell.yaml>, specifier: {}>, <PWM, name: one-cell, target: <Node /pwm-test/pwm-1 in 'test.dts', binding test-bindings/pwm-1-cell.yaml>, specifier: {'one': 1}>]")
+                 "[<PWM, name: zero-cell, target: <Node /pwm-test/pwm-0 in 'test.dts', binding test-bindings/pwm-0-cell.yaml>, data: {}>, <PWM, name: one-cell, target: <Node /pwm-test/pwm-1 in 'test.dts', binding test-bindings/pwm-1-cell.yaml>, data: {'one': 1}>]")
 
     #
     # Test IO channels
     #
 
     verify_streq(edt.get_node("/io-channel-test/node").iochannels,
-                 "[<IOChannel, name: io-channel, target: <Node /io-channel-test/io-channel in 'test.dts', binding test-bindings/io-channel.yaml>, specifier: {'one': 1}>]")
+                 "[<IOChannel, name: io-channel, target: <Node /io-channel-test/io-channel in 'test.dts', binding test-bindings/io-channel.yaml>, data: {'one': 1}>]")
 
     #
     # Test 'reg'

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -40,109 +40,109 @@ def run():
     # Test interrupts
     #
 
-    verify_streq(edt.get_dev("/interrupt-parent-test/node").interrupts,
-                 "[<Interrupt, name: foo, target: <Device /interrupt-parent-test/controller in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 1, 'two': 2, 'three': 3}>, <Interrupt, name: bar, target: <Device /interrupt-parent-test/controller in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 4, 'two': 5, 'three': 6}>]")
+    verify_streq(edt.get_node("/interrupt-parent-test/node").interrupts,
+                 "[<Interrupt, name: foo, target: <Node /interrupt-parent-test/controller in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 1, 'two': 2, 'three': 3}>, <Interrupt, name: bar, target: <Node /interrupt-parent-test/controller in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 4, 'two': 5, 'three': 6}>]")
 
-    verify_streq(edt.get_dev("/interrupts-extended-test/node").interrupts,
-                 "[<Interrupt, target: <Device /interrupts-extended-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, specifier: {'one': 1}>, <Interrupt, target: <Device /interrupts-extended-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, specifier: {'one': 2, 'two': 3}>, <Interrupt, target: <Device /interrupts-extended-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 4, 'two': 5, 'three': 6}>]")
+    verify_streq(edt.get_node("/interrupts-extended-test/node").interrupts,
+                 "[<Interrupt, target: <Node /interrupts-extended-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, specifier: {'one': 1}>, <Interrupt, target: <Node /interrupts-extended-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, specifier: {'one': 2, 'two': 3}>, <Interrupt, target: <Node /interrupts-extended-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 4, 'two': 5, 'three': 6}>]")
 
-    verify_streq(edt.get_dev("/interrupt-map-test/node@0").interrupts,
-                 "[<Interrupt, target: <Device /interrupt-map-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, specifier: {'one': 0}>, <Interrupt, target: <Device /interrupt-map-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, specifier: {'one': 0, 'two': 1}>, <Interrupt, target: <Device /interrupt-map-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 0, 'two': 0, 'three': 2}>]")
+    verify_streq(edt.get_node("/interrupt-map-test/node@0").interrupts,
+                 "[<Interrupt, target: <Node /interrupt-map-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, specifier: {'one': 0}>, <Interrupt, target: <Node /interrupt-map-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, specifier: {'one': 0, 'two': 1}>, <Interrupt, target: <Node /interrupt-map-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 0, 'two': 0, 'three': 2}>]")
 
-    verify_streq(edt.get_dev("/interrupt-map-test/node@1").interrupts,
-                 "[<Interrupt, target: <Device /interrupt-map-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, specifier: {'one': 3}>, <Interrupt, target: <Device /interrupt-map-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, specifier: {'one': 0, 'two': 4}>, <Interrupt, target: <Device /interrupt-map-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 0, 'two': 0, 'three': 5}>]")
+    verify_streq(edt.get_node("/interrupt-map-test/node@1").interrupts,
+                 "[<Interrupt, target: <Node /interrupt-map-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, specifier: {'one': 3}>, <Interrupt, target: <Node /interrupt-map-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, specifier: {'one': 0, 'two': 4}>, <Interrupt, target: <Node /interrupt-map-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, specifier: {'one': 0, 'two': 0, 'three': 5}>]")
 
-    verify_streq(edt.get_dev("/interrupt-map-bitops-test/node@70000000E").interrupts,
-                 "[<Interrupt, target: <Device /interrupt-map-bitops-test/controller in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, specifier: {'one': 3, 'two': 2}>]")
+    verify_streq(edt.get_node("/interrupt-map-bitops-test/node@70000000E").interrupts,
+                 "[<Interrupt, target: <Node /interrupt-map-bitops-test/controller in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, specifier: {'one': 3, 'two': 2}>]")
 
     #
     # Test GPIOs
     #
 
-    verify_streq(edt.get_dev("/gpio-test/node").gpios,
-                 "{'': [<GPIO, name: , target: <Device /gpio-test/controller-0 in 'test.dts', binding test-bindings/gpio-1-cell.yaml>, specifier: {'one': 1}>, <GPIO, name: , target: <Device /gpio-test/controller-1 in 'test.dts', binding test-bindings/gpio-2-cell.yaml>, specifier: {'one': 2, 'two': 3}>], 'foo': [<GPIO, name: foo, target: <Device /gpio-test/controller-1 in 'test.dts', binding test-bindings/gpio-2-cell.yaml>, specifier: {'one': 4, 'two': 5}>], 'bar': [<GPIO, name: bar, target: <Device /gpio-test/controller-1 in 'test.dts', binding test-bindings/gpio-2-cell.yaml>, specifier: {'one': 6, 'two': 7}>]}")
+    verify_streq(edt.get_node("/gpio-test/node").gpios,
+                 "{'': [<GPIO, name: , target: <Node /gpio-test/controller-0 in 'test.dts', binding test-bindings/gpio-1-cell.yaml>, specifier: {'one': 1}>, <GPIO, name: , target: <Node /gpio-test/controller-1 in 'test.dts', binding test-bindings/gpio-2-cell.yaml>, specifier: {'one': 2, 'two': 3}>], 'foo': [<GPIO, name: foo, target: <Node /gpio-test/controller-1 in 'test.dts', binding test-bindings/gpio-2-cell.yaml>, specifier: {'one': 4, 'two': 5}>], 'bar': [<GPIO, name: bar, target: <Node /gpio-test/controller-1 in 'test.dts', binding test-bindings/gpio-2-cell.yaml>, specifier: {'one': 6, 'two': 7}>]}")
 
     #
     # Test clocks
     #
 
-    verify_streq(edt.get_dev("/clock-test/node").clocks,
-                 "[<Clock, name: fixed, frequency: 123, target: <Device /clock-test/fixed-clock in 'test.dts', binding test-bindings/fixed-clock.yaml>, specifier: {}>, <Clock, name: one-cell, target: <Device /clock-test/clock-1 in 'test.dts', binding test-bindings/clock-1-cell.yaml>, specifier: {'one': 1}>, <Clock, name: two-cell, target: <Device /clock-test/clock-2 in 'test.dts', binding test-bindings/clock-2-cell.yaml>, specifier: {'one': 1, 'two': 2}>]")
+    verify_streq(edt.get_node("/clock-test/node").clocks,
+                 "[<Clock, name: fixed, frequency: 123, target: <Node /clock-test/fixed-clock in 'test.dts', binding test-bindings/fixed-clock.yaml>, specifier: {}>, <Clock, name: one-cell, target: <Node /clock-test/clock-1 in 'test.dts', binding test-bindings/clock-1-cell.yaml>, specifier: {'one': 1}>, <Clock, name: two-cell, target: <Node /clock-test/clock-2 in 'test.dts', binding test-bindings/clock-2-cell.yaml>, specifier: {'one': 1, 'two': 2}>]")
 
     #
     # Test PWMs
     #
 
-    verify_streq(edt.get_dev("/pwm-test/node").pwms,
-                 "[<PWM, name: zero-cell, target: <Device /pwm-test/pwm-0 in 'test.dts', binding test-bindings/pwm-0-cell.yaml>, specifier: {}>, <PWM, name: one-cell, target: <Device /pwm-test/pwm-1 in 'test.dts', binding test-bindings/pwm-1-cell.yaml>, specifier: {'one': 1}>]")
+    verify_streq(edt.get_node("/pwm-test/node").pwms,
+                 "[<PWM, name: zero-cell, target: <Node /pwm-test/pwm-0 in 'test.dts', binding test-bindings/pwm-0-cell.yaml>, specifier: {}>, <PWM, name: one-cell, target: <Node /pwm-test/pwm-1 in 'test.dts', binding test-bindings/pwm-1-cell.yaml>, specifier: {'one': 1}>]")
 
     #
     # Test IO channels
     #
 
-    verify_streq(edt.get_dev("/io-channel-test/node").iochannels,
-                 "[<IOChannel, name: io-channel, target: <Device /io-channel-test/io-channel in 'test.dts', binding test-bindings/io-channel.yaml>, specifier: {'one': 1}>]")
+    verify_streq(edt.get_node("/io-channel-test/node").iochannels,
+                 "[<IOChannel, name: io-channel, target: <Node /io-channel-test/io-channel in 'test.dts', binding test-bindings/io-channel.yaml>, specifier: {'one': 1}>]")
 
     #
     # Test 'reg'
     #
 
-    verify_streq(edt.get_dev("/reg-zero-address-cells/node").regs,
+    verify_streq(edt.get_node("/reg-zero-address-cells/node").regs,
                  "[<Register, addr: 0x0, size: 0x1>, <Register, addr: 0x0, size: 0x2>]")
 
-    verify_streq(edt.get_dev("/reg-zero-size-cells/node").regs,
+    verify_streq(edt.get_node("/reg-zero-size-cells/node").regs,
                  "[<Register, addr: 0x1, size: 0x0>, <Register, addr: 0x2, size: 0x0>]")
 
-    verify_streq(edt.get_dev("/reg-ranges/parent/node").regs,
+    verify_streq(edt.get_node("/reg-ranges/parent/node").regs,
                  "[<Register, addr: 0x5, size: 0x1>, <Register, addr: 0xe0000000f, size: 0x1>, <Register, addr: 0xc0000000e, size: 0x1>, <Register, addr: 0xc0000000d, size: 0x1>, <Register, addr: 0xa0000000b, size: 0x1>, <Register, addr: 0x0, size: 0x1>]")
 
-    verify_streq(edt.get_dev("/reg-nested-ranges/grandparent/parent/node").regs,
+    verify_streq(edt.get_node("/reg-nested-ranges/grandparent/parent/node").regs,
                  "[<Register, addr: 0x30000000200000001, size: 0x1>]")
 
     #
     # Test Device.parent and Device.children
     #
 
-    verify_eq(edt.get_dev("/").parent, None)
+    verify_eq(edt.get_node("/").parent, None)
 
-    verify_streq(edt.get_dev("/parent/child-1").parent,
-                 "<Device /parent in 'test.dts', no binding>")
+    verify_streq(edt.get_node("/parent/child-1").parent,
+                 "<Node /parent in 'test.dts', no binding>")
 
-    verify_streq(edt.get_dev("/parent/child-2/grandchild").parent,
-                 "<Device /parent/child-2 in 'test.dts', no binding>")
+    verify_streq(edt.get_node("/parent/child-2/grandchild").parent,
+                 "<Node /parent/child-2 in 'test.dts', no binding>")
 
-    verify_streq(edt.get_dev("/parent").children,
-                 "{'child-1': <Device /parent/child-1 in 'test.dts', no binding>, 'child-2': <Device /parent/child-2 in 'test.dts', no binding>}")
+    verify_streq(edt.get_node("/parent").children,
+                 "{'child-1': <Node /parent/child-1 in 'test.dts', no binding>, 'child-2': <Node /parent/child-2 in 'test.dts', no binding>}")
 
-    verify_eq(edt.get_dev("/parent/child-1").children, {})
+    verify_eq(edt.get_node("/parent/child-1").children, {})
 
     #
     # Test 'include:' and the legacy 'inherits: !include ...'
     #
 
-    verify_streq(edt.get_dev("/binding-include").description,
+    verify_streq(edt.get_node("/binding-include").description,
                  "Parent binding")
 
-    verify_streq(edt.get_dev("/binding-include").props,
+    verify_streq(edt.get_node("/binding-include").props,
                  "{'foo': <Property, name: foo, type: int, value: 0>, 'bar': <Property, name: bar, type: int, value: 1>, 'baz': <Property, name: baz, type: int, value: 2>, 'qaz': <Property, name: qaz, type: int, value: 3>}")
 
     #
     # Test 'child/parent-bus:'
     #
 
-    verify_streq(edt.get_dev("/buses/foo-bus/node").binding_path,
+    verify_streq(edt.get_node("/buses/foo-bus/node").binding_path,
                  "test-bindings/device-on-foo-bus.yaml")
 
-    verify_streq(edt.get_dev("/buses/bar-bus/node").binding_path,
+    verify_streq(edt.get_node("/buses/bar-bus/node").binding_path,
                  "test-bindings/device-on-bar-bus.yaml")
 
     #
     # Test 'child-binding:'
     #
 
-    child1 = edt.get_dev("/child-binding/child-1")
-    child2 = edt.get_dev("/child-binding/child-2")
-    grandchild = edt.get_dev("/child-binding/child-1/grandchild")
+    child1 = edt.get_node("/child-binding/child-1")
+    child2 = edt.get_node("/child-binding/child-2")
+    grandchild = edt.get_node("/child-binding/child-1/grandchild")
 
     verify_streq(child1.binding_path, "test-bindings/child-binding.yaml")
     verify_streq(child1.description, "child node")
@@ -160,21 +160,21 @@ def run():
     # Test deprecated 'sub-node:' key (replaced with 'child-binding:')
     #
 
-    verify_streq(edt.get_dev("/deprecated/sub-node").props,
+    verify_streq(edt.get_node("/deprecated/sub-node").props,
                  "{'child-prop': <Property, name: child-prop, type: int, value: 3>}")
 
     #
     # Test Device.property (derived from DT and 'properties:' in the binding)
     #
 
-    verify_streq(edt.get_dev("/props").props,
-                 r"{'nonexistent-boolean': <Property, name: nonexistent-boolean, type: boolean, value: False>, 'existent-boolean': <Property, name: existent-boolean, type: boolean, value: True>, 'int': <Property, name: int, type: int, value: 1>, 'array': <Property, name: array, type: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, type: uint8-array, value: b'\x124'>, 'string': <Property, name: string, type: string, value: 'foo'>, 'string-array': <Property, name: string-array, type: string-array, value: ['foo', 'bar', 'baz']>, 'phandle-ref': <Property, name: phandle-ref, type: phandle, value: <Device /props/node in 'test.dts', no binding>>, 'phandle-refs': <Property, name: phandle-refs, type: phandles, value: [<Device /props/node in 'test.dts', no binding>, <Device /props/node2 in 'test.dts', no binding>]>}")
+    verify_streq(edt.get_node("/props").props,
+                 r"{'nonexistent-boolean': <Property, name: nonexistent-boolean, type: boolean, value: False>, 'existent-boolean': <Property, name: existent-boolean, type: boolean, value: True>, 'int': <Property, name: int, type: int, value: 1>, 'array': <Property, name: array, type: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, type: uint8-array, value: b'\x124'>, 'string': <Property, name: string, type: string, value: 'foo'>, 'string-array': <Property, name: string-array, type: string-array, value: ['foo', 'bar', 'baz']>, 'phandle-ref': <Property, name: phandle-ref, type: phandle, value: <Node /props/node in 'test.dts', no binding>>, 'phandle-refs': <Property, name: phandle-refs, type: phandles, value: [<Node /props/node in 'test.dts', no binding>, <Node /props/node2 in 'test.dts', no binding>]>}")
 
     #
     # Test property default values given in bindings
     #
 
-    verify_streq(edt.get_dev("/defaults").props,
+    verify_streq(edt.get_node("/defaults").props,
                  r"{'int': <Property, name: int, type: int, value: 123>, 'array': <Property, name: array, type: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, type: uint8-array, value: b'\x89\xab\xcd'>, 'string': <Property, name: string, type: string, value: 'hello'>, 'string-array': <Property, name: string-array, type: string-array, value: ['hello', 'there']>, 'default-not-used': <Property, name: default-not-used, type: int, value: 234>}")
 
     #
@@ -183,10 +183,10 @@ def run():
 
     edt = edtlib.EDT("test-multidir.dts", ["test-bindings", "test-bindings-2"])
 
-    verify_streq(edt.get_dev("/in-dir-1").binding_path,
+    verify_streq(edt.get_node("/in-dir-1").binding_path,
                  "test-bindings/multidir.yaml")
 
-    verify_streq(edt.get_dev("/in-dir-2").binding_path,
+    verify_streq(edt.get_node("/in-dir-2").binding_path,
                  "test-bindings-2/multidir.yaml")
 
 

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -121,54 +121,54 @@ def dt_str_val(kconf, _, name):
 def dt_chosen_label(kconf, _, chosen):
     """
     This function takes a 'chosen' property and treats that property as a path
-    to a EDT device.  If it finds a EDT device, it will look to see if that
-    device has a "label" property and return the value of that "label", if not
-    we return an empty string.
+    to an EDT node.  If it finds an EDT node, it will look to see if that node
+    has a "label" property and return the value of that "label", if not we
+    return an empty string.
     """
     if doc_mode or edt is None:
         return ""
 
-    dev = edt.chosen_dev(chosen)
-    if not dev:
+    node = edt.chosen_node(chosen)
+    if not node:
         return ""
 
-    if "label" not in dev.props:
+    if "label" not in node.props:
         return ""
 
-    return dev.props["label"].val
+    return node.props["label"].val
 
 
-def _dev_reg_addr(dev, index, unit):
-    if not dev:
+def _node_reg_addr(node, index, unit):
+    if not node:
         return "0x0"
 
-    if not dev.regs:
+    if not node.regs:
         return "0x0"
 
-    if int(index) >= len(dev.regs):
+    if int(index) >= len(node.regs):
         return "0x0"
 
-    return hex(dev.regs[int(index)].addr >> _dt_units_to_scale(unit))
+    return hex(node.regs[int(index)].addr >> _dt_units_to_scale(unit))
 
 
-def _dev_reg_size(dev, index, unit):
-    if not dev:
+def _node_reg_size(node, index, unit):
+    if not node:
         return "0"
 
-    if not dev.regs:
+    if not node.regs:
         return "0"
 
-    if int(index) >= len(dev.regs):
+    if int(index) >= len(node.regs):
         return "0"
 
-    return str(dev.regs[int(index)].size >> _dt_units_to_scale(unit))
+    return str(node.regs[int(index)].size >> _dt_units_to_scale(unit))
 
 
 def dt_chosen_reg_addr(kconf, _, chosen, index=0, unit=None):
     """
     This function takes a 'chosen' property and treats that property as a path
-    to a EDT device.  If it finds a EDT device, it will look to see if that
-    device has a register at the give 'index' and return the address value of
+    to an EDT node.  If it finds an EDT node, it will look to see if that
+    nodnode has a register at the given 'index' and return the address value of
     that reg, if not we return 0.
 
     The function will divide the value based on 'unit':
@@ -180,17 +180,17 @@ def dt_chosen_reg_addr(kconf, _, chosen, index=0, unit=None):
     if doc_mode or edt is None:
         return "0x0"
 
-    dev = edt.chosen_dev(chosen)
+    node = edt.chosen_node(chosen)
 
-    return _dev_reg_addr(dev, index, unit)
+    return _node_reg_addr(node, index, unit)
 
 
 def dt_chosen_reg_size(kconf, _, chosen, index=0, unit=None):
     """
     This function takes a 'chosen' property and treats that property as a path
-    to a EDT device.  If it finds a EDT device, it will look to see if that
-    device has a register at the give 'index' and return the size value of
-    that reg, if not we return 0.
+    to an EDT node.  If it finds an EDT node, it will look to see if that node
+    has a register at the given 'index' and return the size value of that reg,
+    if not we return 0.
 
     The function will divide the value based on 'unit':
         None        No division
@@ -201,17 +201,16 @@ def dt_chosen_reg_size(kconf, _, chosen, index=0, unit=None):
     if doc_mode or edt is None:
         return "0"
 
-    dev = edt.chosen_dev(chosen)
+    node = edt.chosen_node(chosen)
 
-    return _dev_reg_size(dev, index, unit)
+    return _node_reg_size(node, index, unit)
 
 
 def dt_node_reg_addr(kconf, _, path, index=0, unit=None):
     """
-    This function takes a 'path' and looks for a EDT device at that path.
-    If it finds a EDT device, it will look to see if that device has a
-    register at the give 'index' and return the address value of that reg, if
-    not we return 0.
+    This function takes a 'path' and looks for an EDT node at that path. If it
+    finds an EDT node, it will look to see if that node has a register at the
+    given 'index' and return the address value of that reg, if not we return 0.
 
     The function will divide the value based on 'unit':
         None        No division
@@ -223,19 +222,18 @@ def dt_node_reg_addr(kconf, _, path, index=0, unit=None):
         return "0"
 
     try:
-        dev = edt.get_dev(path)
+        node = edt.get_node(path)
     except edtlib.EDTError:
         return "0"
 
-    return _dev_reg_addr(dev, index, unit)
+    return _node_reg_addr(node, index, unit)
 
 
 def dt_node_reg_size(kconf, _, path, index=0, unit=None):
     """
-    This function takes a 'path' and looks for a EDT device at that path.
-    If it finds a EDT device, it will look to see if that device has a
-    register at the give 'index' and return the size value of that reg, if
-    not we return 0.
+    This function takes a 'path' and looks for an EDT node at that path. If it
+    finds an EDT node, it will look to see if that node has a register at the
+    given 'index' and return the size value of that reg, if not we return 0.
 
     The function will divide the value based on 'unit':
         None        No division
@@ -247,35 +245,35 @@ def dt_node_reg_size(kconf, _, path, index=0, unit=None):
         return "0"
 
     try:
-        dev = edt.get_dev(path)
+        node = edt.get_node(path)
     except edtlib.EDTError:
         return "0"
 
-    return _dev_reg_size(dev, index, unit)
+    return _node_reg_size(node, index, unit)
 
 
 def dt_node_has_bool_prop(kconf, _, path, prop):
     """
-    This function takes a 'path' and looks for a EDT device at that path.
-    If it finds a EDT device, it will look to see if that device has a
-    boolean property by the name of 'prop'.  If the 'prop' exists it will
-    return "y" otherwise we return "n".
+    This function takes a 'path' and looks for an EDT node at that path. If it
+    finds an EDT node, it will look to see if that node has a boolean property
+    by the name of 'prop'.  If the 'prop' exists it will return "y" otherwise
+    we return "n".
     """
     if doc_mode or edt is None:
         return "n"
 
     try:
-        dev = edt.get_dev(path)
+        node = edt.get_node(path)
     except edtlib.EDTError:
         return "n"
 
-    if prop not in dev.props:
+    if prop not in node.props:
         return "n"
 
-    if dev.props[prop].type != "boolean":
+    if node.props[prop].type != "boolean":
         return "n"
 
-    if dev.props[prop].val:
+    if node.props[prop].val:
         return "y"
 
     return "n"
@@ -284,13 +282,13 @@ def dt_node_has_bool_prop(kconf, _, path, prop):
 def dt_compat_enabled(kconf, _, compat):
     """
     This function takes a 'compat' and returns "y" if we find an "enabled"
-    compatible device in the EDT otherwise we return "n"
+    compatible node in the EDT otherwise we return "n"
     """
     if doc_mode or edt is None:
         return "n"
 
-    for dev in edt.devices:
-        if compat in dev.compats and dev.enabled:
+    for node in edt.nodes:
+        if compat in node.compats and node.enabled:
             return "y"
 
     return "n"


### PR DESCRIPTION
Two commits to reduce confusion:

```
scripts: edtlib: Call nodes "nodes" instead of "devices"

edtlib.Device is just a devicetree node augmented with binding
information and some interpretation of properties. Rename it to
edtlib.Node to make that clearer. That also avoids calling things like
flash partition nodes "devices", which is a bit confusing.

I called it edtlib.Device instead of edtlib.Node originally to avoid
confusion with dtlib.Node, but in retrospect it probably makes it more
confusing on the whole. Something like edtlib.ENode might work too, but
it's probably overkill. Clients of edtlib.py only interact with
edtlib.Node, so the only potential for confusion is within edtlib.py
itself, and it doesn't get too bad there either.

Piggyback some documentation nits, and consistently write it
"devicetree" instead of "device tree", to match the spec.
```

```
scripts: edtlib: Rename Interrupt/GPIO/etc. 'specifier' field to 'data'

'Specifier' is devicetree specalese for data associated with interrupts,
GPIOs, etc., e.g. <1 2> and <3 4> in

    pwms = <&ctrl-1 1 2 &ctrl-2 3 4>;

It's probably unnecessarily confusing to call it that. Call it 'data'
instead, which is a bit more straightforward.
```