### PR TITLE
avoid shippable build errors on limited platforms

### DIFF
--- a/tests/kernel/poll/testcase.yaml
+++ b/tests/kernel/poll/testcase.yaml
@@ -2,4 +2,5 @@ tests:
   kernel.poll:
     tags: kernel userspace
     min_ram: 16
+    min_flash: 34
     platform_exclude: nrf52810_pca10040

--- a/tests/kernel/threads/thread_apis/testcase.yaml
+++ b/tests/kernel/threads/thread_apis/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.threads:
     tags: kernel threads userspace ignore_faults
+    min_flash: 34

--- a/tests/lib/json/testcase.yaml
+++ b/tests/lib/json/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   libraries.encoding:
     filter: not CONFIG_NEWLIB_LIBC
+    min_flash: 34
     tags: json

--- a/tests/subsys/jwt/testcase.yaml
+++ b/tests/subsys/jwt/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.encoding:
     min_ram: 96
+    min_flash: 72
     tags: jwt
-    platform_exclude: esp32 qemu_x86_64 #no newlib
+    platform_exclude: qemu_x86_64 #no newlib


### PR DESCRIPTION
Several platforms fail to build several tests because they run out of memory.  Exclude them so we don't get false negatives from shippable on PRs that happen to trigger these tests.

Found with `sanitycheck --all`.