### PR TITLE
drivers: gpio_mcux: Fix interrupt handling

### DIFF
--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -348,10 +348,10 @@ static void gpio_mcux_port_isr(void *arg)
 	int_status = config->port_base->ISFR;
 	enabled_int = int_status & data->pin_callback_enables;
 
-	gpio_fire_callbacks(&data->callbacks, dev, enabled_int);
-
 	/* Clear the port interrupts */
-	config->port_base->ISFR = 0xFFFFFFFF;
+	config->port_base->ISFR = enabled_int;
+
+	gpio_fire_callbacks(&data->callbacks, dev, enabled_int);
 }
 
 


### PR DESCRIPTION
Change when we clear interrupt status to happen before we handle the
callbacks.  As the callbacks might manipluate the GPIO state and cause
a GPIO interrupt.  If we clear interrupt status after than we might
miss an interrupt.

Also only clear interrupts for interrupts that are we have enabled and
that were reported when we read from the interrupt status.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>