### PR TITLE
up_squared: set the flash runner.

### DIFF
--- a/boards/x86/up_squared/board.cmake
+++ b/boards/x86/up_squared/board.cmake
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(misc-flasher)
+board_finalize_runner_args(misc-flasher)


### PR DESCRIPTION
set the flash runner of up squared board using misc-flasher according to #20273 and #20659.

Signed-off-by: peng1 chen <peng1.chen@intel.com>