### PR TITLE
logging: Add log_output flushing to synchronous processing

### DIFF
--- a/subsys/logging/log_backend_std.h
+++ b/subsys/logging/log_backend_std.h
@@ -88,6 +88,13 @@ log_backend_std_sync_string(const struct log_output *const log_output,
 	}
 
 	key = irq_lock();
+	/* Even though interrupts are locked here there are still cases when
+	 * it may lead to failure. Log output is not re-entrant and irq_lock
+	 * does not prevent NMI or ZLI (Zero latency interrupts). If context
+	 * is interrupted by NMI it usually means fault scenario and best that
+	 * can be done is to flush the output and process new data.
+	 */
+	log_output_flush(log_output);
 	log_output_string(log_output, src_level, timestamp, fmt, ap, flags);
 	irq_unlock(key);
 }
@@ -120,6 +127,13 @@ log_backend_std_sync_hexdump(const struct log_output *const log_output,
 	}
 
 	key = irq_lock();
+	/* Even though interrupts are locked here there are still cases when
+	 * it may lead to failure. Log output is not re-entrant and irq_lock
+	 * does not prevent NMI or ZLI (Zero latency interrupts). If context
+	 * is interrupted by NMI it usually means fault scenario and best that
+	 * can be done is to flush the output and process new data.
+	 */
+	log_output_flush(log_output);
 	log_output_hexdump(log_output, src_level, timestamp,
 			metadata, data, length, flags);
 	irq_unlock(key);


### PR DESCRIPTION
Even though interrupts are locked before processing in synchronous
call, it is still possible that they will be interrupted by NMI.
In that case log_output module may assert because of buffer
overwriting.

Added flushing of log_output buffer before starting the process to
ensure that output buffer is always in reset state at the beginning.

It is related to #19238 but it does not fix it. The actual root cause in #19238 ( and #19245 probably) is stack guard fault. When all tests started to use `LOG_IMMEDIATE` by default (https://github.com/zephyrproject-rtos/zephyr/commit/2192499fe0e8951c721e73bb58239da364fd6770) stack usage in tasks increased (because strings are formatted in the context of log call).

This PR fixes logger so it prints correctly when NMI happens while log message
is processed. After this fix usb test mentioned in #19238 fails with:
```
[00:00:00.004,852] <dbg> usb_descriptor.usb_get_device_descriptor: __usb_descriptor_start 0x20003380
[00:00:00.014,373] <dbg> usb_descriptor.usb_get_device_descriptor: __usb_descriptor_end 0x200033d9
[[00:00:00.023,742] <err> os: ***** MPU FAULT *****
[00:00:00.029,296] <err> os:   Stacking error (context area might be not valid)
[00:00:00.037,261] <err> os:   Data Access Violation
[00:00:00.042,907] <err> os:   MMFAR Address: 0x20002218
[00:00:00.048,919] <err> os: r0/a1:  0x0014a220  r1/a2:  0x519d5540  r2/a3:  0x045e28e8
[00:00:00.057,586] <err> os: r3/a4:  0xd0f94fce r12/ip:  0x0000ac38 r14/lr:  0x00000ec1
[00:00:00.066,284] <err> os:  xpsr:  0x61000000
[00:00:00.071,502] <err> os: Faulting instruction address (r15/pc): 0x0000a192
[00:00:00.079,406] <err> os: >>> ZEPHYR FATAL ERROR 2: Stack overflow
[00:00:00.086,517] <err> os: Current thread: 0x20001820 (main)
[00:00:00.093,017] <err> os: Halting system
```
