### PR TITLE
arch: arm: minor clean-up in irq_init.c and timing_info_bench.c

### DIFF
--- a/arch/arm/core/cortex_m/irq_init.c
+++ b/arch/arm/core/cortex_m/irq_init.c
@@ -8,17 +8,8 @@
  * @file
  * @brief ARM Cortex-M interrupt initialization
  *
- * The ARM Cortex-M architecture provides its own k_thread_abort() to deal with
- * different CPU modes (handler vs thread) when a thread aborts. When its entry
- * point returns or when it aborts itself, the CPU is in thread mode and must
- * call z_swap() (which triggers a service call), but when in handler mode, the
- * CPU must exit handler mode to cause the context switch, and thus must queue
- * the PendSV exception.
  */
 
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <kernel.h>
 #include <arch/cpu.h>
 #include <arch/arm/cortex_m/cmsis.h>
 

--- a/arch/common/timing_info_bench.c
+++ b/arch/common/timing_info_bench.c
@@ -20,10 +20,8 @@ u32_t __read_swap_end_time_value;
 u64_t __common_var_swap_end_time;
 u64_t __temp_start_swap_time;
 
-#if CONFIG_ARM
-#include <arch/arm/cortex_m/cmsis.h>
-#endif
 #ifdef CONFIG_NRF_RTC_TIMER
+#include <nrfx.h>
 
 /* To get current count of timer, first 1 need to be written into
  * Capture Register and Current Count will be copied into corresponding
@@ -41,6 +39,7 @@ u64_t __temp_start_swap_time;
 #define SUBTRACT_CLOCK_CYCLES(val)     (val)
 
 #elif CONFIG_ARM
+#include <arch/arm/cortex_m/cmsis.h>
 #define TIMING_INFO_PRE_READ()
 #define TIMING_INFO_OS_GET_TIME()      (k_cycle_get_32())
 #define TIMING_INFO_GET_TIMER_VALUE()  (SysTick->VAL)


### PR DESCRIPTION
- Remove redundant inclusions in irq_init.c
- Remove comment about thread_abort function,
  which does not belong in this file (probably
  left-out during code refactoring)
- Include arm cmsis.h only under #ifdef CONFIG_ARM

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>