### PR TITLE
drivers: usb: stm32: Fix broken DT_USB_ENABLE_PIN_REMAP test

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -404,7 +404,7 @@ int usb_dc_attach(void)
 	 * For STM32F0 series SoCs on QFN28 and TSSOP20 packages enable PIN
 	 * pair PA11/12 mapped instead of PA9/10 (e.g. stm32f070x6)
 	 */
-#if defined(DT_USB_ENABLE_PIN_REMAP)
+#if DT_USB_ENABLE_PIN_REMAP == 1
 	if (LL_APB1_GRP2_IsEnabledClock(LL_APB1_GRP2_PERIPH_SYSCFG)) {
 		LL_SYSCFG_EnablePinRemap();
 	} else {


### PR DESCRIPTION
'enable-pin-remap' is defined as 'type: boolean' in
dts/bindings/usb/st,stm32-usb.yaml, so it generates either

    #define DT_USB_ENABLE_PIN_REMAP 1

or

    #define DT_USB_ENABLE_PIN_REMAP 0

depending on if 'enable-pin-remap;' appears on the node or not.

Since a macro is always generated, #ifdef won't work. The test needs to
be this instead:

    #if DT_USB_ENABLE_PIN_REMAP == 1

(Should be careful with '#if HMZ == 0' though, because it's true even if
HMZ is undefined.)

This behavior was inherited from the old scripts, and some things depend
on it, e.g. by expanding macros in initializers.