### PR TITLE
cmake: don't link interface libraries with zephyr_interface

### DIFF
--- a/lib/cmsis_rtos_v1/CMakeLists.txt
+++ b/lib/cmsis_rtos_v1/CMakeLists.txt
@@ -21,4 +21,3 @@ zephyr_library_sources_ifdef(
 )
 
 zephyr_library_link_libraries(CMSIS)
-target_link_libraries(CMSIS INTERFACE zephyr_interface)

--- a/lib/cmsis_rtos_v2/CMakeLists.txt
+++ b/lib/cmsis_rtos_v2/CMakeLists.txt
@@ -20,4 +20,3 @@ zephyr_library_sources_ifdef(
 )
 
 zephyr_library_link_libraries(CMSIS)
-target_link_libraries(CMSIS INTERFACE zephyr_interface)

--- a/lib/gui/lvgl/CMakeLists.txt
+++ b/lib/gui/lvgl/CMakeLists.txt
@@ -23,5 +23,3 @@ zephyr_library_sources_ifdef( CONFIG_LVGL_MEM_POOL_USER lvgl_mem_user.c)
 zephyr_library_sources_ifdef( CONFIG_LVGL_MEM_POOL_KERNEL lvgl_mem_kernel.c)
 
 zephyr_library_link_libraries(lvgl)
-
-target_link_libraries(lvgl INTERFACE zephyr_interface)

--- a/lib/posix/CMakeLists.txt
+++ b/lib/posix/CMakeLists.txt
@@ -22,4 +22,3 @@ zephyr_library_sources_ifdef(CONFIG_POSIX_MQUEUE mqueue.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_FS fs.c)
 
 zephyr_library_link_libraries(posix_subsys)
-target_link_libraries(posix_subsys INTERFACE zephyr_interface)

--- a/subsys/bluetooth/CMakeLists.txt
+++ b/subsys/bluetooth/CMakeLists.txt
@@ -15,5 +15,3 @@ if(CONFIG_BT_CTLR)
     add_subdirectory(controller)
   endif()
 endif()
-
-target_link_libraries(subsys__bluetooth INTERFACE zephyr_interface)


### PR DESCRIPTION
Stop linking interface libraries against zephyr_interface. This is
cargo cult code that in practice does nothing.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>