### PR TITLE
Revert "arch: arm: userspace: minor refactor in z_arch_is_user_context"

### DIFF
--- a/include/arch/arm/syscall.h
+++ b/include/arch/arm/syscall.h
@@ -6,9 +6,9 @@
 
 /**
  * @file
- * @brief ARM specific syscall header
+ * @brief ARM specific sycall header
  *
- * This header contains the ARM specific syscall interface.  It is
+ * This header contains the ARM specific sycall interface.  It is
  * included by the syscall interface architecture-abstraction header
  * (include/arch/syscall.h)
  */
@@ -26,7 +26,6 @@
 
 #include <zephyr/types.h>
 #include <stdbool.h>
-#include <arch/arm/cortex_m/cmsis.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -168,7 +167,7 @@ static inline bool z_arch_is_user_context(void)
 
 	/* if not handler mode, return mode information */
 	__asm__ volatile("mrs %0, CONTROL\n\t" : "=r"(value));
-	return (value & CONTROL_nPRIV_Msk) ? true : false;
+	return (value & 0x1) ? true : false;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
This reverts commit 48fa076a56fdde42adcd572215f9fc85fb076c48.

That commit pulls in a header that causes the following failure on
many platforms/tests:

sanitycheck -p stm32f469i_disco -T tests/kernel/workq/work_queue_api

Building C object zephyr/CMakeFiles/offsets.dir/arch/arm/core/offsets/offsets.c.obj
In file included from /scratch/zephyr/zp1/zephyr/include/arch/arm/syscall.h:29,
                 from /scratch/zephyr/zp1/zephyr/include/arch/syscall.h:15,
                 from /scratch/zephyr/zp1/zephyr/include/syscall.h:12,
                 from /scratch/zephyr/zp1/zephyr/include/kernel_includes.h:32,
                 from /scratch/zephyr/zp1/zephyr/include/kernel.h:17,
                 from /scratch/zephyr/zp1/zephyr/kernel/include/kernel_structs.h:10,
                 from /scratch/zephyr/zp1/zephyr/arch/arm/core/offsets/offsets.c:26:
/scratch/zephyr/zp1/zephyr/include/arch/arm/cortex_m/cmsis.h:92:2: error: #error "DT_NUM_IRQ_PRIO_BITS and __NVIC_PRIO_BITS are not set to the same value"
 #error "DT_NUM_IRQ_PRIO_BITS and __NVIC_PRIO_BITS are not set to the same value"
  ^~~~~

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>