### PR TITLE
soc: arm: stm32: do not include kernel headers in soc.h

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -5,11 +5,11 @@
  */
 
 #include <errno.h>
+#include <soc.h>
+#include <fsl_lpuart.h>
 #include <device.h>
 #include <drivers/uart.h>
 #include <drivers/clock_control.h>
-#include <soc.h>
-#include <fsl_lpuart.h>
 
 struct mcux_lpuart_config {
 	LPUART_Type *base;

--- a/soc/arm/arm/beetle/soc.h
+++ b/soc/arm/arm/beetle/soc.h
@@ -12,6 +12,8 @@
 #ifndef _ARM_BEETLE_SOC_H_
 #define _ARM_BEETLE_SOC_H_
 
+#include <sys/util.h>
+
 #ifndef _ASMLANGUAGE
 #include "CMSDK_BEETLE.h"
 #endif
@@ -93,11 +95,8 @@
 
 #ifndef _ASMLANGUAGE
 
-/* ARM CMSIS definitions must be included before kernel_includes.h.
- * Therefore, it is essential to include kernel_includes.h after including
- * core SOC-specific headers.
- */
-#include <kernel_includes.h>
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
 
 #include "soc_pins.h"
 #include "soc_power.h"

--- a/soc/arm/atmel_sam/same70/soc.h
+++ b/soc/arm/atmel_sam/same70/soc.h
@@ -13,6 +13,8 @@
 #ifndef _ATMEL_SAME70_SOC_H_
 #define _ATMEL_SAME70_SOC_H_
 
+#include <sys/util.h>
+
 #ifndef _ASMLANGUAGE
 
 #define DONT_USE_CMSIS_INIT
@@ -64,11 +66,8 @@
 #include "../common/soc_pmc.h"
 #include "../common/soc_gpio.h"
 
-/* ARM CMSIS definitions must be included before kernel_includes.h.
- * Therefore, it is essential to include kernel_includes.h after including
- * core SOC-specific headers.
- */
-#include <kernel_includes.h>
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -18,15 +18,14 @@
 #ifndef _STM32F4_SOC_H_
 #define _STM32F4_SOC_H_
 
+#include <sys/util.h>
+
 #ifndef _ASMLANGUAGE
 
 #include <stm32f4xx.h>
 
-/* ARM CMSIS definitions must be included before kernel_includes.h.
- * Therefore, it is essential to include kernel_includes.h after including
- * core SOC-specific headers.
- */
-#include <kernel_includes.h>
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
 
 #ifdef CONFIG_EXTI_STM32
 #include <stm32f4xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -17,15 +17,14 @@
 #ifndef _STM32F7_SOC_H_
 #define _STM32F7_SOC_H_
 
+#include <sys/util.h>
+
 #ifndef _ASMLANGUAGE
 
 #include <stm32f7xx.h>
 
-/* ARM CMSIS definitions must be included before kernel_includes.h.
- * Therefore, it is essential to include kernel_includes.h after including
- * core SOC-specific headers.
- */
-#include <kernel_includes.h>
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
 
 #ifdef CONFIG_EXTI_STM32
 #include <stm32f7xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -19,16 +19,15 @@
 #ifndef _STM32L4X_SOC_H_
 #define _STM32L4X_SOC_H_
 
+#include <sys/util.h>
+
 #ifndef _ASMLANGUAGE
 
 #include <autoconf.h>
 #include <stm32l4xx.h>
 
-/* ARM CMSIS definitions must be included before kernel_includes.h.
- * Therefore, it is essential to include kernel_includes.h after including
- * core SOC-specific headers.
- */
-#include <kernel_includes.h>
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
 
 #ifdef CONFIG_EXTI_STM32
 #include <stm32l4xx_ll_exti.h>

--- a/soc/arm/st_stm32/stm32wb/soc.h
+++ b/soc/arm/st_stm32/stm32wb/soc.h
@@ -17,15 +17,14 @@
 #ifndef _STM32WBX_SOC_H_
 #define _STM32WBX_SOC_H_
 
+#include <sys/util.h>
+
 #ifndef _ASMLANGUAGE
 
 #include <stm32wbxx.h>
 
-/* ARM CMSIS definitions must be included before kernel_includes.h.
- * Therefore, it is essential to include kernel_includes.h after including
- * core SOC-specific headers.
- */
-#include <kernel_includes.h>
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
 
 #ifdef CONFIG_GPIO_STM32
 #include <stm32wbxx_ll_gpio.h>


### PR DESCRIPTION
We shall not include core kernel headers in soc.h
header of ARM SoCs. We should try to only include
the vendor headers and auto-generated board header
from DTS.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>