### PR TITLE
tests: build kernel/common on all platforms, always

### DIFF
--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   kernel.common:
     tags: kernel userspace
+    build_on_all: true
     min_flash: 33
     min_ram: 32
   kernel.common.misra:


### PR DESCRIPTION
To catch more potential issues with PRs, build common kernel tests
instead of the synchronization sample which does not run any tests.