### PR TITLE
bindings: hwinfo: Remove deprecated syntax in LiteX DNA binding

### DIFF
--- a/dts/bindings/hwinfo/litex,dna0.yaml
+++ b/dts/bindings/hwinfo/litex,dna0.yaml
@@ -1,20 +1,13 @@
-#
 # Copyright (c)  2019 Antmicro <www.antmicro.com>
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 title: LiteX DNA
-description: >
-    This binding gives a base representation of the LiteX DNA
-inherits:
-        !include base.yaml
+description: LiteX DNA ID reader
+
+compatible: "litex,dna0"
+
+include: base.yaml
 
 properties:
-    compatible:
-      constraint: "litex,dna0"
-
     reg:
-      category: required
-
-
+        required: true


### PR DESCRIPTION
Use the new 'compatible:' and 'include:' syntaxes, and clean it up like
for other bindings.

Shorten the description, because it appears in the output as a comment
above the generated macros, and it looks neater. I asked Mateusz what
kind of device it is.