### PR TITLE
dts: Use separate compatibles for Nordic TWI/TWIM/TWIS and SPI/SPIM/SPIS peripherals

### DIFF
--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -80,6 +80,7 @@
 };
 
 &spi1 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <26>;
 	mosi-pin = <23>;

--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -73,6 +73,7 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-pin = <20>;
 	scl-pin = <22>;

--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -89,6 +89,7 @@
 };
 
 &i2c2 {
+	compatible = "nordic,nrf-twim";
 	status = "okay";
 
 	clock-frequency = <I2C_BITRATE_FAST>;

--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -105,6 +105,7 @@
 };
 
 &spi3 {
+	compatible = "nordic,nrf-spim";
 	status = "okay";
 
 	sck-pin = <20>;

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -91,19 +91,21 @@
 };
 
 &spi0 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <25>;
 	mosi-pin = <23>;
 	miso-pin = <24>;
-    cs-gpios = <&gpio0 22 0>;
+	cs-gpios = <&gpio0 22 0>;
 };
 
 &spi1 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <16>;
 	mosi-pin = <20>;
 	miso-pin = <14>;
-    cs-gpios = <&gpio0 12 0>;
+	cs-gpios = <&gpio0 12 0>;
 };
 
 &flash0 {

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -79,6 +79,7 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -103,6 +103,7 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -115,6 +115,7 @@
 };
 
 &spi0 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <41>;
 	mosi-pin = <40>;
@@ -123,6 +124,7 @@
 };
 
 &spi1 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <19>;
 	mosi-pin = <20>;

--- a/boards/arm/degu_evk/degu_evk.dts
+++ b/boards/arm/degu_evk/degu_evk.dts
@@ -93,12 +93,14 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twim";
 	status = "okay";
 	sda-pin = <20>;
 	scl-pin = <22>;
 };
 
 &i2c1 {
+	compatible = "nordic,nrf-twim";
 	status = "okay";
 	sda-pin = <41>;
 	scl-pin = <11>;

--- a/boards/arm/nrf51_ble400/nrf51_ble400.dts
+++ b/boards/arm/nrf51_ble400/nrf51_ble400.dts
@@ -91,6 +91,7 @@
 };
 
 &spi1 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <25>;
 	mosi-pin = <24>;

--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -119,6 +119,7 @@
 };
 
 &spi1 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <6>;
 	mosi-pin = <5>;

--- a/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
+++ b/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
@@ -108,6 +108,7 @@
 };
 
 &spi0 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <29>;
 	mosi-pin = <31>;

--- a/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
+++ b/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
@@ -101,6 +101,7 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;

--- a/boards/arm/nrf52811_pca10056/nrf52811_pca10056.dts
+++ b/boards/arm/nrf52811_pca10056/nrf52811_pca10056.dts
@@ -113,6 +113,7 @@
 };
 
 &spi0 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <0>;
 	mosi-pin = <1>;
@@ -120,6 +121,7 @@
 };
 
 &spi1 {
+	compatible = "nordic,nrf-spi";
 	/* cannot be used with i2c0 */
 	sck-pin = <19>;
 	mosi-pin = <20>;

--- a/boards/arm/nrf52811_pca10056/nrf52811_pca10056.dts
+++ b/boards/arm/nrf52811_pca10056/nrf52811_pca10056.dts
@@ -90,8 +90,8 @@
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
-	current-speed = <115200>;
 	status = "okay";
+	current-speed = <115200>;
 	tx-pin = <6>;
 	rx-pin = <8>;
 	rts-pin = <5>;
@@ -99,8 +99,9 @@
 };
 
 &i2c0 {
-	/* Arduino compatible PINs */
+	compatible = "nordic,nrf-twi";
 	status = "okay";
+	/* Arduino compatible PINs */
 	sda-pin = <26>;
 	scl-pin = <27>;
 };

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -80,12 +80,14 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &i2c1 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-pin = <30>;
 	scl-pin = <31>;

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -100,6 +100,7 @@
 };
 
 &spi0 {
+	compatible = "nordic,nrf-spi";
 	/* Cannot be used together with i2c0. */
 	/* status = "okay"; */
 	sck-pin = <19>;
@@ -108,6 +109,7 @@
 };
 
 &spi1 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <25>;
 	mosi-pin = <34>;
@@ -115,6 +117,7 @@
 };
 
 &spi2 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <26>;
 	mosi-pin = <23>;

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -85,12 +85,14 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-pin = <12>;
 	scl-pin = <11>;
 };
 
 &i2c1 {
+	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
 	sda-pin = <2>;

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -82,12 +82,14 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &i2c1 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-pin = <30>;
 	scl-pin = <31>;

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -87,6 +87,7 @@
 };
 
 &spi1 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <31>;
 	mosi-pin = <29>;

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -80,6 +80,7 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-pin = <5>;
 	scl-pin = <6>;

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -158,6 +158,7 @@ arduino_i2c: &i2c0 {
 };
 
 &spi0 {
+	compatible = "nordic,nrf-spi";
 	/* Cannot be used together with i2c0. */
 	/* status = "okay"; */
 	sck-pin = <27>;
@@ -166,6 +167,7 @@ arduino_i2c: &i2c0 {
 };
 
 &spi1 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <31>;
 	mosi-pin = <30>;
@@ -173,6 +175,7 @@ arduino_i2c: &i2c0 {
 };
 
 &spi2 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <19>;
 	mosi-pin = <20>;

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -121,8 +121,8 @@
 
 &uart0 {
 	compatible = "nordic,nrf-uart";
-	current-speed = <115200>;
 	status = "okay";
+	current-speed = <115200>;
 	tx-pin = <6>;
 	rx-pin = <8>;
 	rts-pin = <5>;
@@ -137,12 +137,14 @@ arduino_serial: &uart1 {
 };
 
 arduino_i2c: &i2c0 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &i2c1 {
+	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
 	sda-pin = <30>;

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -84,8 +84,8 @@
 
 &uart0 {
 	compatible = "nordic,nrf-uarte";
-	current-speed = <115200>;
 	status = "okay";
+	current-speed = <115200>;
 	tx-pin = <20>;
 	rx-pin = <24>;
 	rts-pin = <17>;
@@ -93,12 +93,14 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &i2c1 {
+	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
 	sda-pin = <30>;

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -112,6 +112,7 @@
  * limited GPIOs available on dongle board.
  */
 &spi0 {
+	compatible = "nordic,nrf-spi";
 	/* Cannot be used together with i2c0. */
 	/* status = "okay"; */
 	sck-pin = <27>;
@@ -120,6 +121,7 @@
 };
 
 &spi1 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <31>;
 	mosi-pin = <30>;

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -70,6 +70,7 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twi";
 	sda-pin = <25>;
 	scl-pin = <26>;
 };

--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
@@ -55,6 +55,7 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twim";
 	status = "okay";
 	sda-pin = <28>;
 	scl-pin = <2>;

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -127,12 +127,14 @@ arduino_serial: &uart0 {
 };
 
 arduino_i2c: &i2c0 {
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;
 };
 
 &i2c1 {
+	compatible = "nordic,nrf-twi";
 	/* Cannot be used together with spi1. */
 	/* status = "okay"; */
 	sda-pin = <30>;

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -148,6 +148,7 @@ arduino_i2c: &i2c0 {
 };
 
 &spi0 {
+	compatible = "nordic,nrf-spi";
 	/* Cannot be used together with i2c0. */
 	/* status = "okay"; */
 	sck-pin = <27>;
@@ -156,6 +157,7 @@ arduino_i2c: &i2c0 {
 };
 
 &spi1 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <31>;
 	mosi-pin = <30>;
@@ -163,6 +165,7 @@ arduino_i2c: &i2c0 {
 };
 
 arduino_spi: &spi2 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <25>;
 	mosi-pin = <23>;

--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
@@ -70,14 +70,15 @@
 };
 
 &uart0 {
-	status = "okay";
 	compatible = "nordic,nrf-uart";
+	status = "okay";
 	current-speed = <115200>;
 	tx-pin = <3>;
 	rx-pin = <2>;
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twim";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <7>;
@@ -112,6 +113,7 @@
 };
 
 &i2c1 {
+	compatible = "nordic,nrf-twim";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <14>;

--- a/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
+++ b/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
@@ -65,6 +65,7 @@
 };
 
 &i2c0 {
+	compatible = "nordic,nrf-twim";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <26>;

--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
@@ -116,6 +116,7 @@
 };
 
 &spi3 {
+	compatible = "nordic,nrf-spim";
 	status = "okay";
 	sck-pin = <19>;
 	mosi-pin = <18>;

--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
@@ -104,6 +104,7 @@
 };
 
 &i2c2 {
+	compatible = "nordic,nrf-twim";
 	status = "okay";
 	sda-pin = <30>;
 	scl-pin = <31>;

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -117,6 +117,7 @@
 };
 
 &i2c0 { /* feather I2C */
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <26>;

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -127,6 +127,7 @@
 /* TWI1 used on Boron; also see mesh_feather_spi1_spi1.dtsi */
 
 &spi2 { /* dedicated MX25L */
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <19>;
 	mosi-pin = <20>;

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -117,6 +117,7 @@
 };
 
 &i2c0 { /* feather I2C */
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <26>;

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -127,6 +127,7 @@
 /* TWI1 used on Boron; also see mesh_feather_spi1_spi1.dtsi */
 
 &spi2 { /* dedicated MX25L */
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <19>;
 	mosi-pin = <20>;

--- a/boards/arm/particle_boron/particle_boron.dts
+++ b/boards/arm/particle_boron/particle_boron.dts
@@ -25,6 +25,7 @@
 };
 
 &i2c1 { /* power monitoring */
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <24>;

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -117,6 +117,7 @@
 };
 
 &i2c0 { /* feather I2C */
+	compatible = "nordic,nrf-twi";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <26>;

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -127,6 +127,7 @@
 /* TWI1 used on Boron; also see mesh_feather_spi1_spi1.dtsi */
 
 &spi2 { /* dedicated MX25L */
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <19>;
 	mosi-pin = <20>;

--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -98,6 +98,7 @@ arduino_serial: &uart1 {
 };
 
 arduino_i2c: &i2c0 {
+	compatible = "nordic,nrf-twim";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <26>;

--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -128,6 +128,7 @@ arduino_i2c: &i2c0 {
 };
 
 arduino_spi: &spi1 {
+	compatible = "nordic,nrf-spi";
 	status = "okay";
 	sck-pin = <47>;
 	miso-pin = <46>;

--- a/boards/shields/ssd1306_128x32/boards/reel_board.overlay
+++ b/boards/shields/ssd1306_128x32/boards/reel_board.overlay
@@ -1,0 +1,3 @@
+&arduino_i2c {
+        compatible = "nordic,nrf-twi";
+};

--- a/boards/shields/ssd1306_128x64/boards/reel_board.overlay
+++ b/boards/shields/ssd1306_128x64/boards/reel_board.overlay
@@ -1,0 +1,3 @@
+&arduino_i2c {
+        compatible = "nordic,nrf-twi";
+};

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -244,13 +244,13 @@ static int twi_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 #define I2C_NRFX_TWI_DEVICE(idx)					       \
 	BUILD_ASSERT_MSG(						       \
 		I2C_NRFX_TWI_FREQUENCY(					       \
-			DT_NORDIC_NRF_I2C_I2C_##idx##_CLOCK_FREQUENCY)	       \
+			DT_NORDIC_NRF_TWI_I2C_##idx##_CLOCK_FREQUENCY)	       \
 		!= I2C_NRFX_TWI_INVALID_FREQUENCY,			       \
 		"Wrong I2C " #idx " frequency setting in dts");		       \
 	static int twi_##idx##_init(struct device *dev)			       \
 	{								       \
-		IRQ_CONNECT(DT_NORDIC_NRF_I2C_I2C_##idx##_IRQ_0,	       \
-			    DT_NORDIC_NRF_I2C_I2C_##idx##_IRQ_0_PRIORITY,      \
+		IRQ_CONNECT(DT_NORDIC_NRF_TWI_I2C_##idx##_IRQ_0,	       \
+			    DT_NORDIC_NRF_TWI_I2C_##idx##_IRQ_0_PRIORITY,      \
 			    nrfx_isr, nrfx_twi_##idx##_irq_handler, 0);	       \
 		return init_twi(dev);					       \
 	}								       \
@@ -263,14 +263,14 @@ static int twi_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 	static const struct i2c_nrfx_twi_config twi_##idx##z_config = {	       \
 		.twi = NRFX_TWI_INSTANCE(idx),				       \
 		.config = {						       \
-			.scl       = DT_NORDIC_NRF_I2C_I2C_##idx##_SCL_PIN,    \
-			.sda       = DT_NORDIC_NRF_I2C_I2C_##idx##_SDA_PIN,    \
+			.scl       = DT_NORDIC_NRF_TWI_I2C_##idx##_SCL_PIN,    \
+			.sda       = DT_NORDIC_NRF_TWI_I2C_##idx##_SDA_PIN,    \
 			.frequency = I2C_NRFX_TWI_FREQUENCY(		       \
-				DT_NORDIC_NRF_I2C_I2C_##idx##_CLOCK_FREQUENCY) \
+				DT_NORDIC_NRF_TWI_I2C_##idx##_CLOCK_FREQUENCY) \
 		}							       \
 	};								       \
 	DEVICE_DEFINE(twi_##idx,					       \
-		      DT_NORDIC_NRF_I2C_I2C_##idx##_LABEL,		       \
+		      DT_NORDIC_NRF_TWI_I2C_##idx##_LABEL,		       \
 		      twi_##idx##_init,					       \
 		      twi_nrfx_pm_control,				       \
 		      &twi_##idx##_data,				       \
@@ -286,4 +286,3 @@ I2C_NRFX_TWI_DEVICE(0);
 #ifdef CONFIG_I2C_1_NRF_TWI
 I2C_NRFX_TWI_DEVICE(1);
 #endif
-

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -218,13 +218,13 @@ static int twim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 #define I2C_NRFX_TWIM_DEVICE(idx)					       \
 	BUILD_ASSERT_MSG(						       \
 		I2C_NRFX_TWIM_FREQUENCY(				       \
-			DT_NORDIC_NRF_I2C_I2C_##idx##_CLOCK_FREQUENCY)	       \
+			DT_NORDIC_NRF_TWIM_I2C_##idx##_CLOCK_FREQUENCY)	       \
 		!= I2C_NRFX_TWIM_INVALID_FREQUENCY,			       \
 		"Wrong I2C " #idx " frequency setting in dts");		       \
 	static int twim_##idx##_init(struct device *dev)		       \
 	{								       \
-		IRQ_CONNECT(DT_NORDIC_NRF_I2C_I2C_##idx##_IRQ_0,	       \
-			    DT_NORDIC_NRF_I2C_I2C_##idx##_IRQ_0_PRIORITY,      \
+		IRQ_CONNECT(DT_NORDIC_NRF_TWIM_I2C_##idx##_IRQ_0,	       \
+			    DT_NORDIC_NRF_TWIM_I2C_##idx##_IRQ_0_PRIORITY,     \
 			    nrfx_isr, nrfx_twim_##idx##_irq_handler, 0);       \
 		return init_twim(dev);					       \
 	}								       \
@@ -237,14 +237,14 @@ static int twim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 	static const struct i2c_nrfx_twim_config twim_##idx##z_config = {      \
 		.twim = NRFX_TWIM_INSTANCE(idx),			       \
 		.config = {						       \
-			.scl       = DT_NORDIC_NRF_I2C_I2C_##idx##_SCL_PIN,    \
-			.sda       = DT_NORDIC_NRF_I2C_I2C_##idx##_SDA_PIN,    \
+			.scl       = DT_NORDIC_NRF_TWIM_I2C_##idx##_SCL_PIN,   \
+			.sda       = DT_NORDIC_NRF_TWIM_I2C_##idx##_SDA_PIN,   \
 			.frequency = I2C_NRFX_TWIM_FREQUENCY(		       \
-				DT_NORDIC_NRF_I2C_I2C_##idx##_CLOCK_FREQUENCY) \
+				DT_NORDIC_NRF_TWIM_I2C_##idx##_CLOCK_FREQUENCY)\
 		}							       \
 	};								       \
 	DEVICE_DEFINE(twim_##idx,					       \
-		      DT_NORDIC_NRF_I2C_I2C_##idx##_LABEL,		       \
+		      DT_NORDIC_NRF_TWIM_I2C_##idx##_LABEL,		       \
 		      twim_##idx##_init,				       \
 		      twim_nrfx_pm_control,				       \
 		      &twim_##idx##_data,				       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -371,7 +371,7 @@ static int spim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 	static int spi_##idx##_init(struct device *dev)			       \
 	{								       \
 		IRQ_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_SPIM##idx),		       \
-			    DT_NORDIC_NRF_SPI_SPI_##idx##_IRQ_0_PRIORITY,      \
+			    DT_NORDIC_NRF_SPIM_SPI_##idx##_IRQ_0_PRIORITY,     \
 			    nrfx_isr, nrfx_spim_##idx##_irq_handler, 0);       \
 		return init_spim(dev);					       \
 	}								       \
@@ -384,9 +384,9 @@ static int spim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 		.spim = NRFX_SPIM_INSTANCE(idx),			       \
 		.max_chunk_len = (1 << SPIM##idx##_EASYDMA_MAXCNT_SIZE) - 1,   \
 		.config = {						       \
-			.sck_pin   = DT_NORDIC_NRF_SPI_SPI_##idx##_SCK_PIN,    \
-			.mosi_pin  = DT_NORDIC_NRF_SPI_SPI_##idx##_MOSI_PIN,   \
-			.miso_pin  = DT_NORDIC_NRF_SPI_SPI_##idx##_MISO_PIN,   \
+			.sck_pin   = DT_NORDIC_NRF_SPIM_SPI_##idx##_SCK_PIN,   \
+			.mosi_pin  = DT_NORDIC_NRF_SPIM_SPI_##idx##_MOSI_PIN,  \
+			.miso_pin  = DT_NORDIC_NRF_SPIM_SPI_##idx##_MISO_PIN,  \
 			.ss_pin    = NRFX_SPIM_PIN_NOT_USED,		       \
 			.orc       = CONFIG_SPI_##idx##_NRF_ORC,	       \
 			.frequency = NRF_SPIM_FREQ_4M,			       \
@@ -396,7 +396,7 @@ static int spim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 		}							       \
 	};								       \
 	DEVICE_DEFINE(spi_##idx,					       \
-		      DT_NORDIC_NRF_SPI_SPI_##idx##_LABEL,		       \
+		      DT_NORDIC_NRF_SPIM_SPI_##idx##_LABEL,		       \
 		      spi_##idx##_init,					       \
 		      spim_nrfx_pm_control,				       \
 		      &spi_##idx##_data,				       \

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -101,7 +101,7 @@
 		};
 
 		i2c0: i2c@40003000 {
-			compatible = "nordic,nrf-i2c";
+			compatible = "nordic,nrf-twi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -112,7 +112,7 @@
 		};
 
 		i2c1: i2c@40004000 {
-			compatible = "nordic,nrf-i2c";
+			compatible = "nordic,nrf-twi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -141,7 +141,12 @@
 		};
 
 		spi1: spi@40004000 {
-			compatible = "nordic,nrf-spi";
+			/*
+			 * This spi node can be either SPI or SPIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-spi" or
+			 *              "nordic,nrf-spis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -101,7 +101,13 @@
 		};
 
 		i2c0: i2c@40003000 {
-			compatible = "nordic,nrf-i2c";
+			/*
+			 * This i2c node can be TWI, TWIM, or TWIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-twi" or
+			 *              "nordic,nrf-twim" or
+			 *              "nordic,nrf-twis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -134,7 +134,13 @@
 		};
 
 		spi0: spi@40004000 {
-			compatible = "nordic,nrf-spi";
+			/*
+			 * This spi node can be SPI, SPIM, or SPIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-spi" or
+			 *              "nordic,nrf-spim" or
+			 *              "nordic,nrf-spis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -108,7 +108,13 @@
 		};
 
 		i2c0: i2c@40003000 {
-			compatible = "nordic,nrf-i2c";
+			/*
+			 * This i2c node can be TWI, TWIM, or TWIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-twi" or
+			 *              "nordic,nrf-twim" or
+			 *              "nordic,nrf-twis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -141,7 +141,13 @@
 		};
 
 		spi0: spi@40004000 {
-			compatible = "nordic,nrf-spi";
+			/*
+			 * This spi node can be SPI, SPIM, or SPIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-spi" or
+			 *              "nordic,nrf-spim" or
+			 *              "nordic,nrf-spis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
@@ -152,7 +158,13 @@
 
 		spi1: spi@40003000 {
 		/* cannot be used with i2c0 */
-			compatible = "nordic,nrf-spi";
+			/*
+			 * This spi node can be SPI, SPIM, or SPIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-spi" or
+			 *              "nordic,nrf-spim" or
+			 *              "nordic,nrf-spis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -175,7 +175,13 @@
 		};
 
 		spi0: spi@40003000 {
-			compatible = "nordic,nrf-spi";
+			/*
+			 * This spi node can be SPI, SPIM, or SPIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-spi" or
+			 *              "nordic,nrf-spim" or
+			 *              "nordic,nrf-spis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -185,7 +191,13 @@
 		};
 
 		spi1: spi@40004000 {
-			compatible = "nordic,nrf-spi";
+			/*
+			 * This spi node can be SPI, SPIM, or SPIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-spi" or
+			 *              "nordic,nrf-spim" or
+			 *              "nordic,nrf-spis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
@@ -195,7 +207,13 @@
 		};
 
 		spi2: spi@40023000 {
-			compatible = "nordic,nrf-spi";
+			/*
+			 * This spi node can be SPI, SPIM, or SPIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-spi" or
+			 *              "nordic,nrf-spim" or
+			 *              "nordic,nrf-spis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40023000 0x1000>;

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -109,7 +109,13 @@
 		};
 
 		i2c0: i2c@40003000 {
-			compatible = "nordic,nrf-i2c";
+			/*
+			 * This i2c node can be TWI, TWIM, or TWIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-twi" or
+			 *              "nordic,nrf-twim" or
+			 *              "nordic,nrf-twis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -120,7 +126,13 @@
 		};
 
 		i2c1: i2c@40004000 {
-			compatible = "nordic,nrf-i2c";
+			/*
+			 * This i2c node can be TWI, TWIM, or TWIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-twi" or
+			 *              "nordic,nrf-twim" or
+			 *              "nordic,nrf-twis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -209,7 +209,13 @@
 		};
 
 		spi0: spi@40003000 {
-			compatible = "nordic,nrf-spi";
+			/*
+			 * This spi node can be SPI, SPIM, or SPIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-spi" or
+			 *              "nordic,nrf-spim" or
+			 *              "nordic,nrf-spis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -219,7 +225,13 @@
 		};
 
 		spi1: spi@40004000 {
-			compatible = "nordic,nrf-spi";
+			/*
+			 * This spi node can be SPI, SPIM, or SPIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-spi" or
+			 *              "nordic,nrf-spim" or
+			 *              "nordic,nrf-spis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
@@ -229,7 +241,13 @@
 		};
 
 		spi2: spi@40023000 {
-			compatible = "nordic,nrf-spi";
+			/*
+			 * This spi node can be SPI, SPIM, or SPIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-spi" or
+			 *              "nordic,nrf-spim" or
+			 *              "nordic,nrf-spis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40023000 0x1000>;
@@ -239,7 +257,7 @@
 		};
 
 		spi3: spi@4002b000 {
-			compatible = "nordic,nrf-spi";
+			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x4002b000 0x1000>;

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -135,7 +135,13 @@
 		};
 
 		i2c0: i2c@40003000 {
-			compatible = "nordic,nrf-i2c";
+			/*
+			 * This i2c node can be TWI, TWIM, or TWIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-twi" or
+			 *              "nordic,nrf-twim" or
+			 *              "nordic,nrf-twis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -146,7 +152,13 @@
 		};
 
 		i2c1: i2c@40004000 {
-			compatible = "nordic,nrf-i2c";
+			/*
+			 * This i2c node can be TWI, TWIM, or TWIS,
+			 * for the user to pick:
+			 * compatible = "nordic,nrf-twi" or
+			 *              "nordic,nrf-twim" or
+			 *              "nordic,nrf-twis".
+			 */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -149,7 +149,11 @@ uart3: uart@b000 {
 };
 
 i2c0: i2c@8000 {
-	compatible = "nordic,nrf-i2c";
+	/*
+	 * This i2c node can be either TWIM or TWIS, for the user to pick:
+	 * compatible = "nordic,nrf-twim" or
+	 *              "nordic,nrf-twis".
+	 */
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
@@ -160,7 +164,11 @@ i2c0: i2c@8000 {
 };
 
 i2c1: i2c@9000 {
-	compatible = "nordic,nrf-i2c";
+	/*
+	 * This i2c node can be either TWIM or TWIS, for the user to pick:
+	 * compatible = "nordic,nrf-twim" or
+	 *              "nordic,nrf-twis".
+	 */
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
@@ -171,7 +179,11 @@ i2c1: i2c@9000 {
 };
 
 i2c2: i2c@a000 {
-	compatible = "nordic,nrf-i2c";
+	/*
+	 * This i2c node can be either TWIM or TWIS, for the user to pick:
+	 * compatible = "nordic,nrf-twim" or
+	 *              "nordic,nrf-twis".
+	 */
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xa000 0x1000>;
@@ -182,7 +194,11 @@ i2c2: i2c@a000 {
 };
 
 i2c3: i2c@b000 {
-	compatible = "nordic,nrf-i2c";
+	/*
+	 * This i2c node can be either TWIM or TWIS, for the user to pick:
+	 * compatible = "nordic,nrf-twim" or
+	 *              "nordic,nrf-twis".
+	 */
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -209,7 +209,11 @@ i2c3: i2c@b000 {
 };
 
 spi0: spi@8000 {
-	compatible = "nordic,nrf-spi";
+	/*
+	 * This spi node can be either SPIM or SPIS, for the user to pick:
+	 * compatible = "nordic,nrf-spim" or
+	 *              "nordic,nrf-spis".
+	 */
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
@@ -219,7 +223,11 @@ spi0: spi@8000 {
 };
 
 spi1: spi@9000 {
-	compatible = "nordic,nrf-spi";
+	/*
+	 * This spi node can be either SPIM or SPIS, for the user to pick:
+	 * compatible = "nordic,nrf-spim" or
+	 *              "nordic,nrf-spis".
+	 */
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
@@ -229,7 +237,11 @@ spi1: spi@9000 {
 };
 
 spi2: spi@a000 {
-	compatible = "nordic,nrf-spi";
+	/*
+	 * This spi node can be either SPIM or SPIS, for the user to pick:
+	 * compatible = "nordic,nrf-spim" or
+	 *              "nordic,nrf-spis".
+	 */
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xa000 0x1000>;
@@ -239,7 +251,11 @@ spi2: spi@a000 {
 };
 
 spi3: spi@b000 {
-	compatible = "nordic,nrf-spi";
+	/*
+	 * This spi node can be either SPIM or SPIS, for the user to pick:
+	 * compatible = "nordic,nrf-spim" or
+	 *              "nordic,nrf-spis".
+	 */
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;

--- a/dts/bindings/i2c/nordic,nrf-twi-common.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi-common.yaml
@@ -2,12 +2,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF Family I2C Master node
-
-description: >
-    This is a representation of the Nordic nRF I2C node
-
-compatible: "nordic,nrf-i2c"
+# Common fields for Nordic nRF family TWI peripherals
 
 include: i2c-controller.yaml
 
@@ -20,10 +15,10 @@ properties:
 
     sda-pin:
       type: int
-      description: SDA pin
       required: true
+      description: SDA pin
 
     scl-pin:
       type: int
-      description: SCL pin
       required: true
+      description: SCL pin

--- a/dts/bindings/i2c/nordic,nrf-twi.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+title: Nordic nRF family TWI
+
+description: Nordic nRF family TWI (TWI master)
+
+compatible: "nordic,nrf-twi"
+
+include: nordic,nrf-twi-common.yaml

--- a/dts/bindings/i2c/nordic,nrf-twim.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twim.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+title: Nordic nRF family TWIM
+
+description: Nordic nRF family TWIM (TWI master with EasyDMA)
+
+compatible: "nordic,nrf-twim"
+
+include: nordic,nrf-twi-common.yaml

--- a/dts/bindings/i2c/nordic,nrf-twis.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twis.yaml
@@ -1,32 +1,15 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic TWIS
+title: Nordic nRF family TWIS
 
-description: >
-    Binding for the Nordic TWIS (TWI slave with EasyDMA)
+description: Nordic nRF family TWIS (TWI slave with EasyDMA)
 
 compatible: "nordic,nrf-twis"
 
-include: base.yaml
+include: nordic,nrf-twi-common.yaml
 
 properties:
-    reg:
-      required: true
-
-    interrupts:
-      required: true
-
-    sda-pin:
-      type: int
-      required: true
-      description: SDA pin
-
-    scl-pin:
-      type: int
-      required: true
-      description: SCL pin
-
     address-0:
       type: int
       required: false

--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for Nordic nRF family SPI peripherals
+
+include: spi-controller.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true
+
+    sck-pin:
+      type: int
+      required: true
+      description: SCK pin
+
+    mosi-pin:
+      type: int
+      required: true
+      description: MOSI pin
+
+    miso-pin:
+      type: int
+      required: true
+      description: MISO pin

--- a/dts/bindings/spi/nordic,nrf-spim.yaml
+++ b/dts/bindings/spi/nordic,nrf-spim.yaml
@@ -1,10 +1,10 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF family SPI
+title: Nordic nRF family SPIM
 
-description: Nordic nRF family SPI (SPI master)
+description: Nordic nRF family SPIM (SPI master with EasyDMA)
 
-compatible: "nordic,nrf-spi"
+compatible: "nordic,nrf-spim"
 
 include: nordic,nrf-spi-common.yaml

--- a/dts/bindings/spi/nordic,nrf-spis.yaml
+++ b/dts/bindings/spi/nordic,nrf-spis.yaml
@@ -1,37 +1,15 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF Family SPIS (SPI Slave)
+title: Nordic nRF family SPIS
 
-description: >
-    This is a representation of the Nordic nRF SPIS node
+description: Nordic nRF family SPIS (SPI slave with EasyDMA)
 
 compatible: "nordic,nrf-spis"
 
-include: spi-controller.yaml
+include: nordic,nrf-spi-common.yaml
 
 properties:
-    reg:
-      required: true
-
-    interrupts:
-      required: true
-
-    sck-pin:
-      type: int
-      required: true
-      description: SCK pin
-
-    mosi-pin:
-      type: int
-      required: true
-      description: MOSI pin
-
-    miso-pin:
-      type: int
-      required: true
-      description: MISO pin
-
     csn-pin:
       type: int
       required: true


### PR DESCRIPTION
**dts: Use separate compatibles for Nordic TWI/TWIM/TWIS peripherals**

This commit introduces separate "compatible" strings for dts nodes
representing different types of Nordic TWI peripherals. Previously
"nordic,nrf-i2c" was used for both TWI and TWIM, and TWIS was not
supported.

Quite a few files need to be touched by this commit but the changes can
be divided into groups of related or very similar ones, distinguishable
by the initial part of the path to the modified file:

* dts/bindings/i2c/
  new bindings for "nordic,nrf-twim" and "nordic,nrf-twis" are added
  and the one for "nordic,nrf-i2s" is renamed to "nordic,nrf-twi",
  common fields for all these bindings are extracted to a shared file

* dts/arm/nordic/
  "compatible" properties in i2cX nodes are updated (when there is no
  choice as only one type of TWI peripheral is available) or replaced
  with a comment pointing out that the proper type of peripheral needs
  to be picked at some upper layer

* drivers/i2c/
  both flavors of i2c_nrfx drivers are updated with the new names of
  macros generated from dts

* boards/
  all i2cX nodes in dts files for boards equipped with an nRF chip are
  updated with the proper "compatible" property, according to the type
  of TWI peripheral that is currently selected for the board by the
  corresponding Kconfig choice option (I2C_x_NRF_TWI*)

**dts: Use separate compatibles for Nordic SPI/SPIM/SPIS peripherals**

The set of changes done for SPI nodes is very similar. See the second commit message for details.