### PR TITLE
stm32: Fix uart_irq_tx_complete() to output correct status

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -518,7 +518,7 @@ static int uart_stm32_irq_tx_complete(struct device *dev)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
-	return LL_USART_IsActiveFlag_TXE(UartInstance);
+	return LL_USART_IsActiveFlag_TC(UartInstance);
 }
 
 static void uart_stm32_irq_rx_enable(struct device *dev)


### PR DESCRIPTION
Currently both 
`uart_stm32_irq_tx_complete()` and
`uart_stm32_irq_tx_ready()` 
return the TXE flag. 
However `uart_stm32_irq_tx_complete()` should really return the TC flag to output true
"Transmit Complete" status.

Signed-off-by: Tommy Vestermark <tovsurf@vestermark.dk>