### PR TITLE
boards: stm32_min_dev.dtsi enable use of UART_2 and UART_3

### DIFF
--- a/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
@@ -42,12 +42,14 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_pins_a>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &usart3 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_a>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &i2c1 {


### PR DESCRIPTION
For some reason UART_2 and UART_3 was not marked "okay" in the device
tree, making use difficult.
I have tested both UARTs on a "blue pill" board (stm32_min_dev_blue)
with both polling and RX/TX interrupts and found them to work as
expected.

Signed-off-by: Tommy Vestermark <tovsurf@vestermark.dk>