### PR TITLE
dts: bindings: Remove deprecated syntax for ESP32 GPIO and NRF PWM 

### DIFF
--- a/dts/bindings/gpio/espressif,esp32-gpio.yaml
+++ b/dts/bindings/gpio/espressif,esp32-gpio.yaml
@@ -1,26 +1,19 @@
-#
 # Copyright (c) 2019, Yannis Damigos
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-title: ESP32 GPIO
+title: ESP32 GPIO controller
+description: ESP32 GPIO controller
 
-description: >
-    This is a representation of the ESP32 GPIO nodes
+compatible: "espressif,esp32-gpio"
 
-inherits:
-    !include base.yaml
+include: [gpio-controller.yaml, base.yaml]
 
 properties:
-    compatible:
-      constraint: "espressif,esp32-gpio"
-
     reg:
-      category: required
+        required: true
 
     label:
-      category: required
+        required: true
 
 "#cells":
   - pin

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -17,7 +17,7 @@ properties:
     center-aligned:
       type: boolean
       description: Use center-aligned (up and down) counter mode
-      category: optional
+      required: false
 
     ch0-pin:
       type: int


### PR DESCRIPTION
Use the new 'compatible:', 'include:', and 'required:' keys, and clean
it up like other bindings.

Shorten the 'description:' text, because it appears in the output as a
comment above the generated macros, and it looks neater.

Fixes: #19385