### PR TITLE
arch: arm: Remove unnecessary register preservation in Cortex-R port.

### DIFF
--- a/arch/arm/core/exc_exit.S
+++ b/arch/arm/core/exc_exit.S
@@ -72,6 +72,7 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_int_exit)
 
 SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_exc_exit)
 #if defined(CONFIG_CPU_CORTEX_R)
+    /* r0 contains the caller mode */
     push {r0, lr}
 #endif
 
@@ -116,11 +117,17 @@ _EXIT_EXC:
 #if defined(CONFIG_CPU_CORTEX_M)
     bx lr
 #elif defined(CONFIG_CPU_CORTEX_R)
-    /*
-     * r0-r3 are either the values from the thread before it was switched out
-     * or they are the args to _new_thread for a new thread
-     */
+    /* Restore the caller mode to r0 */
     pop {r0, lr}
+
+    /*
+     * Restore r0-r3, r12 and lr stored into the process stack by the mode
+     * entry function. These registers are saved by _isr_wrapper for IRQ mode
+     * and z_arm_svc for SVC mode.
+     *
+     * r0-r3 are either the values from the thread before it was switched out
+     * or they are the args to _new_thread for a new thread.
+     */
     push {r4, r5}
 
     cmp r0, #RET_FROM_SVC

--- a/arch/arm/core/exc_exit.S
+++ b/arch/arm/core/exc_exit.S
@@ -90,9 +90,7 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_exc_exit)
     ldr r2, =_SCS_ICSR_PENDSV
     str r2, [r1]
 #elif defined(CONFIG_CPU_CORTEX_R)
-    push {r0, lr}
     bl z_arm_pendsv
-    pop {r0, lr}
 #endif
 
 _ExcExitWithGdbStub:
@@ -101,6 +99,7 @@ _EXIT_EXC:
 #endif /* CONFIG_PREEMPT_ENABLED */
 
 #ifdef CONFIG_STACK_SENTINEL
+#if defined(CONFIG_CPU_CORTEX_M)
     push {r0, lr}
     bl z_check_stack_sentinel
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
@@ -109,6 +108,9 @@ _EXIT_EXC:
 #else
     pop {r0, lr}
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
+#else
+    bl z_check_stack_sentinel
+#endif /* CONFIG_CPU_CORTEX_M */
 #endif /* CONFIG_STACK_SENTINEL */
 
 #if defined(CONFIG_CPU_CORTEX_M)

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -39,6 +39,10 @@ GDATA(_kernel)
  * When PendSV is pended, the decision that a context switch must happen has
  * already been taken. In other words, when z_arm_pendsv() runs, we *know* we
  * have to swap *something*.
+ *
+ * For Cortex-R, PendSV exception is not supported by the architecture and this
+ * function is directly called either by _IntExit in case of preemption, or
+ * z_arm_svc in case of cooperative switching.
  */
 
 SECTION_FUNC(TEXT, z_arm_pendsv)
@@ -328,7 +332,10 @@ _thread_irq_disabled:
 #endif
 #endif /* CONFIG_TRACING */
 
-    /* exc return */
+    /*
+     * Cortex-M: return from PendSV exception
+     * Cortex-R: return to the caller (_IntExit or z_arm_svc)
+     */
     bx lr
 
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
@@ -514,13 +521,25 @@ valid_syscall_id:
 
     /* return from SVC to the modified LR - z_arm_do_syscall */
     bx lr
-#endif
+#endif /* CONFIG_USERSPACE */
 
 #elif defined(CONFIG_ARMV7_R)
+
+/**
+ *
+ * @brief Service call handler
+ *
+ * The service call (svc) is used in the following occasions:
+ * - Cooperative context switching
+ * - IRQ offloading
+ * - Kernel run-time exceptions
+ *
+ * @return N/A
+ */
 SECTION_FUNC(TEXT, z_arm_svc)
     /*
      * Switch to system mode to store r0-r3 to the process stack pointer.
-     * Save r12 and the lr as we will be swapping in another process and
+     * Save r12 and the lr as we could be swapping in another process and
      * returning to a different location.
      */
     push {r4, r5}

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -560,9 +560,7 @@ demux:
     beq _oops
 
 #if CONFIG_IRQ_OFFLOAD
-    push {r0, lr}
     blx z_irq_do_offload  /* call C routine which executes the offload */
-    pop {r0, lr}
 
     /* exception return is done in z_arm_int_exit() */
     mov r0, #RET_FROM_SVC
@@ -571,9 +569,7 @@ demux:
 
 _context_switch:
     /* handler mode exit, to PendSV */
-    push {r0, lr}
     bl z_arm_pendsv
-    pop {r0, lr}
 
     mov r0, #RET_FROM_SVC
     b z_arm_int_exit


### PR DESCRIPTION
The interrupt exit and swap service routines for Cortex-R unnecessarily
preserve r0 and lr registers when making function calls using bl instruction.

In case of _IntExit in exc_exit.S, the r0 register containing the caller
mode is preserved at the top, and the lr register can safely be assumed to
have been saved into the system mode stack by the interrupt service routine.

In case of __svc in swap_helper.S, since the function saves lr to the system
mode stack at the top and exits through _IntExit, it is not necessary to
preserve lr register when executing bl instructions.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>