### PR TITLE
disk: sdhc: reinitialize and detect always

### DIFF
--- a/subsys/disk/disk_access_spi_sdhc.c
+++ b/subsys/disk/disk_access_spi_sdhc.c
@@ -867,11 +867,6 @@ static int disk_spi_sdhc_access_init(struct disk_info *disk)
 	struct sdhc_spi_data *data = dev->driver_data;
 	int err;
 
-	if (data->status == DISK_STATUS_OK) {
-		/* Called twice, don't re-init. */
-		return 0;
-	}
-
 	err = sdhc_spi_detect(data);
 	sdhc_spi_set_cs(data, 1);
 


### PR DESCRIPTION
Do not skip sdhc/spi sdhc disk detect and interface init, on subsequent calls. This pr does not touch flash and RAM disk files as those will not need 'detection' of storage medium. It also does not touch USDHC initialization.

See https://github.com/zephyrproject-rtos/zephyr/issues/16035#issuecomment-507651886.

Fixes #16035