### PR TITLE
CODEOWNERS: Add entry for JEDEC SPI-NOR flash driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -126,6 +126,7 @@
 /drivers/ethernet/                        @jukkar @tbursztyka @pfalcon
 /drivers/flash/                           @nashif
 /drivers/flash/*native_posix*             @vanwinkeljan @aescolar
+/drivers/flash/*spi_nor*                  @pabigot
 /drivers/flash/*stm32*                    @superna9999
 /drivers/gpio/*ht16k33*                   @henrikbrixandersen
 /drivers/gpio/*stm32*                     @rsalveti @idlethread


### PR DESCRIPTION
Adding myself as owner.

https://github.com/zephyrproject-rtos/zephyr/pull/17383#issuecomment-535453901 details the motivation.