### PR TITLE
Bluetooth: controller: split: Fix flash driver co-operation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -218,7 +218,8 @@ void lll_resume(void *param)
 
 void lll_disable(void *param)
 {
-	if (!param || param == event.curr.param) {
+	/* LLL disable of current event, done is generated */
+	if (!param || (param == event.curr.param)) {
 		if (event.curr.abort_cb && event.curr.param) {
 			event.curr.abort_cb(NULL, event.curr.param);
 		} else {
@@ -232,7 +233,7 @@ void lll_disable(void *param)
 		next = ull_prepare_dequeue_iter(&idx);
 		while (next) {
 			if (!next->is_aborted &&
-			    param == next->prepare_param.param) {
+			    (!param || (param == next->prepare_param.param))) {
 				next->is_aborted = 1;
 				next->abort_cb(&next->prepare_param,
 					       next->prepare_param.param);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -544,6 +544,18 @@ static void isr_done(void *param)
 
 static void isr_abort(void *param)
 {
+	/* Clear radio status and events */
+	radio_status_reset();
+	radio_tmr_status_reset();
+	radio_filter_status_reset();
+	radio_ar_status_reset();
+	radio_rssi_status_reset();
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_GPIO_PA_PIN) ||
+	    IS_ENABLED(CONFIG_BT_CTLR_GPIO_LNA_PIN)) {
+		radio_gpio_pa_lna_disable();
+	}
+
 	radio_filter_disable();
 
 	isr_cleanup(param);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -417,6 +417,18 @@ void lll_conn_isr_tx(void *param)
 
 void lll_conn_isr_abort(void *param)
 {
+	/* Clear radio status and events */
+	radio_status_reset();
+	radio_tmr_status_reset();
+	radio_filter_status_reset();
+	radio_ar_status_reset();
+	radio_rssi_status_reset();
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_GPIO_PA_PIN) ||
+	    IS_ENABLED(CONFIG_BT_CTLR_GPIO_LNA_PIN)) {
+		radio_gpio_pa_lna_disable();
+	}
+
 	isr_cleanup(param);
 }
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -557,6 +557,18 @@ static void isr_window(void *param)
 
 static void isr_abort(void *param)
 {
+	/* Clear radio status and events */
+	radio_status_reset();
+	radio_tmr_status_reset();
+	radio_filter_status_reset();
+	radio_ar_status_reset();
+	radio_rssi_status_reset();
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_GPIO_PA_PIN) ||
+	    IS_ENABLED(CONFIG_BT_CTLR_GPIO_LNA_PIN)) {
+		radio_gpio_pa_lna_disable();
+	}
+
 	/* Scanner stop can expire while here in this ISR.
 	 * Deferred attempt to stop can fail as it would have
 	 * expired, hence ignore failure.

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -576,6 +576,9 @@ static void isr_abort(void *param)
 	ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_LLL,
 		    TICKER_ID_SCAN_STOP, NULL, NULL);
 
+	/* Under race conditions, radio could get started while entering ISR */
+	radio_disable();
+
 	isr_cleanup(param);
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -932,7 +932,7 @@ void ll_radio_state_abort(void)
 	static struct mayfly mfy = {0, 0, &link, NULL, lll_disable};
 	u32_t ret;
 
-	ret = mayfly_enqueue(TICKER_USER_ID_THREAD, TICKER_USER_ID_LLL, 0,
+	ret = mayfly_enqueue(TICKER_USER_ID_ULL_HIGH, TICKER_USER_ID_LLL, 0,
 			     &mfy);
 	LL_ASSERT(!ret);
 }


### PR DESCRIPTION
When flash driver requests abort of radio event in unreserved
time space, resume radio events in the pipeline where not
flushed. These resumed events caused flash driver to assert
on the check whether radio was in use.

Fixed by flushing the pipeline of all radio events, resume
and also those events in pipeline with pre-empt timeout
being setup.

Fixes: #19484.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>