### PR TITLE
scripts: dts: Make 'status = "ok"' a warning instead of an error

### DIFF
--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -6,6 +6,7 @@ properties:
         required: false
         description: indicates the operational status of a device
         enum:
+           - "ok" # Deprecated form
            - "okay"
            - "disabled"
            - "reserved"

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -2090,10 +2090,16 @@ def _check_dt(dt):
                 _err(str(e))
 
             if status_val not in ok_status:
-                _err("unknown 'status' value \"{}\" in {} in {}, expected one "
-                     "of {} (see the devicetree specification)"
-                     .format(status_val, node.path, node.dt.filename,
-                             ", ".join(ok_status)))
+                if status_val == "ok":
+                    _warn("'status = \"ok\"' in {} in {} is deprecated, "
+                          "please use 'status = \"okay\"' instead (see the "
+                          "devicetree specification)"
+                          .format(node.path, node.dt.filename))
+                else:
+                    _err("unknown 'status' value \"{}\" in {} in {}, expected "
+                         "one of {} (see the devicetree specification)"
+                         .format(status_val, node.path, node.dt.filename,
+                                 ", ".join(ok_status)))
 
         ranges_prop = node.props.get("ranges")
         if ranges_prop:


### PR DESCRIPTION
Erroring out for 'status = "ok"' broke backwards compatibility for a
downstream project. Turn it into a warning instead.

The rest of the code only checks for 'status = "disabled"' (like the old
scripts), so no other updates are needed.

(It's a bit weird that we duplicate the property check in base.yaml.
Thinking of including base.yaml implicitly. Could clean things up then.)