### PR TITLE
modules: hal_nordic: Enable extended SPIM features only when needed

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -44,7 +44,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: db6277a1266cbcbd5588959bbacc1cd5670aed0e
+      revision: 1b14177ff2176a1d17f3dd5e7e217f44337255db
       path: modules/hal/nordic
     - name: hal_openisa
       revision: be5c01f86c96500def5079bcc58d2baefdffb6c8


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/hal_nordic/pull/9

---

These features are available only for SPIM3 and when they are enabled
but this instance is not, the compilation fails. So they cannot be
enabled by default (as currently), but only when it is actually needed
(and possible).

Update the module revision to fix the issue in nrfx_config_nrf52840.h.
