### PR TITLE
drivers: pwm: Fix wrong dc calculation for pwm tests

### DIFF
--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -136,7 +136,8 @@ static u32_t xec_compute_dc(u32_t on, u32_t off)
 {
 	int dc = (on + 1) + (off + 1);
 
-	dc = (((on + 1) * XEC_PWM_DC_PF) / dc);
+	/* Make calculation in u64_t since XEC_PWM_DC_PF is large */
+	dc = (((u64_t)(on + 1) * XEC_PWM_DC_PF) / dc);
 
 	return (u32_t)dc;
 }


### PR DESCRIPTION
Values used in tests/drivers/pwm/pwm_api overflows calculation inside
xec_compute_dc(). Make calculation to be done in u64_t and then
convert to int.

Probably we need to revisit also other parts, the issue was found executing default pwm test.