### PR TITLE
scripts: dts: Accept 'status = "ok"'

### DIFF
--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -6,6 +6,7 @@ properties:
         required: false
         description: indicates the operational status of a device
         enum:
+           - "ok" # Deprecated form
            - "okay"
            - "disabled"
            - "reserved"

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -2076,7 +2076,8 @@ def _check_dt(dt):
 
     # Check that 'status' has one of the values given in the devicetree spec.
 
-    ok_status = {"okay", "disabled", "reserved", "fail", "fail-sss"}
+    # Accept "ok" for backwards compatibility
+    ok_status = {"ok", "okay", "disabled", "reserved", "fail", "fail-sss"}
 
     for node in dt.node_iter():
         if "status" in node.props:


### PR DESCRIPTION
Erroring out for 'status = "ok"' broke backwards compatibility for a
downstream project. Accept it instead.

Maybe the error could be selectively re-enabled later.

The rest of the code only checks for 'status = "disabled"' (like the old
scripts), so no other updates are needed.

(It's a bit weird that we duplicate the property check in base.yaml.
Thinking of including base.yaml implicitly. Could clean things up then.)