### PR TITLE
modules: hal: nxp: update for LPC55S69 SDK update

### DIFF
--- a/drivers/serial/usart_mcux_lpc.c
+++ b/drivers/serial/usart_mcux_lpc.c
@@ -22,7 +22,7 @@
 
 struct usart_mcux_lpc_config {
 	USART_Type *base;
-	clock_name_t clock_source;
+	u32_t clock_source;
 	u32_t baud_rate;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	void (*irq_config_func)(struct device *dev);
@@ -246,7 +246,7 @@ static int usart_mcux_lpc_init(struct device *dev)
 	usart_config_t usart_config;
 	u32_t clock_freq;
 
-	clock_freq = CLOCK_GetFreq(config->clock_source);
+	clock_freq = CLOCK_GetFlexCommClkFreq(config->clock_source);
 
 	USART_GetDefaultConfig(&usart_config);
 	usart_config.enableTx = true;
@@ -291,7 +291,7 @@ static void usart_mcux_lpc_config_func_0(struct device *dev);
 
 static const struct usart_mcux_lpc_config usart_mcux_lpc_0_config = {
 	.base = (USART_Type *)DT_USART_MCUX_LPC_0_BASE_ADDRESS,
-	.clock_source = kCLOCK_Flexcomm0,
+	.clock_source = 0,
 	.baud_rate = DT_USART_MCUX_LPC_0_BAUD_RATE,
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_config_func = usart_mcux_lpc_config_func_0,

--- a/west.yml
+++ b/west.yml
@@ -83,7 +83,7 @@ manifest:
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs
     - name: hal_nxp
-      revision: 48a59fb436931d44d7595ec6deb42be41ff2f22b
+      revision: 97265a5396edc6a9de5f2fb643d505f37064e606
       path: modules/hal/nxp
     - name: open-amp
       revision: 9b591b289e1f37339bd038b5a1f0e6c8ad39c63a


### PR DESCRIPTION
Update to for LPC55S69 SDK 2.6.3 release.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>