### PR TITLE
cmake: Fix bug where DTS_BINDINGS_DIRS could only have one entry

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -26,6 +26,12 @@ if(OVERLAY_CONFIG)
   string(REPLACE " " ";" OVERLAY_CONFIG_AS_LIST "${OVERLAY_CONFIG}")
 endif()
 
+# DTS_ROOT_BINDINGS is a semicolon separated list, this causes
+# problems when invoking kconfig_target since semicolon is a special
+# character in the C shell, so we make it into a question-mark
+# separated list instead.
+string(REPLACE ";" "?" DTS_ROOT_BINDINGS "${DTS_ROOT_BINDINGS}")
+
 set(ENV{srctree}            ${ZEPHYR_BASE})
 set(ENV{KERNELVERSION}      ${KERNELVERSION})
 set(ENV{KCONFIG_CONFIG}     ${DOTCONFIG})

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -24,7 +24,7 @@ if not doc_mode:
 
     # if a board port doesn't use DTS than these might not be set
     if os.path.isfile(DTS_POST_CPP) and BINDINGS_DIRS is not None:
-        edt = edtlib.EDT(DTS_POST_CPP, BINDINGS_DIRS.split(";"))
+        edt = edtlib.EDT(DTS_POST_CPP, BINDINGS_DIRS.split("?"))
     else:
         edt = None
 


### PR DESCRIPTION
Fix a bug where DTS_BINDINGS_DIRS could only have one entry. When
there were more than one entry the command for invoking menuconfig
became corrupted.

This changes the separator of DTS_BINDINGS_DIR from a space to ? so
that the shell does not interpret the space as an argument separator.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>