### PR TITLE
bindings/gpio: Add missing property "gpio-cells"

### DIFF
--- a/dts/bindings/gpio/espressif,esp32-gpio.yaml
+++ b/dts/bindings/gpio/espressif,esp32-gpio.yaml
@@ -15,6 +15,9 @@ properties:
     label:
         required: true
 
+    "#gpio-cells":
+        const: 2
+
 "#cells":
   - pin
   - flags


### PR DESCRIPTION
Add missing property "gpio-cells".

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>