### PR TITLE
boards: mec15xxevb_assy6853: allow custom SPI config file

### DIFF
--- a/boards/arm/mec15xxevb_assy6853/CMakeLists.txt
+++ b/boards/arm/mec15xxevb_assy6853/CMakeLists.txt
@@ -36,11 +36,18 @@ else()
 endif()
 
 if(DEFINED EVERGLADES_SPI_GEN)
+  if(DEFINED ENV{EVERGLADES_SPI_CFG})
+    set(EVERGLADES_SPI_CFG $ENV{EVERGLADES_SPI_CFG})
+  else()
+    set(EVERGLADES_SPI_CFG ${BOARD_DIR}/support/spi_cfg.txt)
+  endif()
+
   set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
     COMMAND ${EVERGLADES_SPI_GEN}
-    -i ${BOARD_DIR}/support/spi_cfg.txt
+    -i ${EVERGLADES_SPI_CFG}
     -o ${PROJECT_BINARY_DIR}/spi_image.bin
   )
 
   unset(EVERGLADES_SPI_GEN)
+  unset(EVERGLADES_SPI_CFG)
 endif()

--- a/boards/arm/mec15xxevb_assy6853/doc/index.rst
+++ b/boards/arm/mec15xxevb_assy6853/doc/index.rst
@@ -237,6 +237,13 @@ Setup
 
    Note that the tools for Linux and Windows have different file names.
 
+#. If needed, a custom SPI image configuration file can be specified
+   to override the default one.
+
+   .. code-block:: console
+
+      export EVERGLADES_SPI_CFG=custom_spi_cfg.txt
+
 Building
 ========
 


### PR DESCRIPTION
This adds a way to specify a custom SPI configuration file to be
used with the image generation tool. For example, this can be
used to reduce the SPI image size to allow faster flashing
(e.g. 512KB instead of 16MB).

Signed-off-by: Daniel Leung <daniel.leung@intel.com>