### PR TITLE
scripts: dts: Generalize '#cells' to allow multiple sources

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -126,8 +126,9 @@ parent-bus: <string describing bus type, e.g. "i2c">
 #     Taking 'pwms' as an example, the final -s is stripped from the property
 #     name, and #pwm-cells is looked up in the node for the controller
 #     (&ctrl-1/&ctrl-2) to determine the number of data values after the
-#     phandle. The binding for each controller must also have a #cells key,
-#     giving names to data values. See below for an explanation of #cells.
+#     phandle. The binding for each controller must also have a *-cells key
+#     (e.g. pwm-cells), giving names to data values. See below for an
+#     explanation of *-cells.
 #
 #     A *-names (e.g. pwm-names) property can appear on the node as well,
 #     giving a name to each entry (the 'pwms' example above has two entries,
@@ -286,28 +287,41 @@ child-binding:
 
 # If the binding describes an interrupt controller, GPIO controller, pinmux
 # device, or any other node referenced by other nodes via 'phandle-array'
-# properties, then #cells should be given.
+# properties, then *-cells should be given.
 #
-# To understand the purpose of #cells, assume that some node has
+# To understand the purpose of *-cells, assume that some node has
 #
-#     foo-gpios = <&gpio-ctrl 1 2>;
+#     pwms = <&pwm-ctrl 1 2>;
 #
-# , where &gpio-ctrl refers to a node whose binding is this file.
+# , where &pwm-ctrl refers to a node whose binding is this file.
 #
 # The <1 2> part of the property value is called a *specifier* (this
 # terminology is from the devicetree specification), and contains additional
 # data associated with the GPIO. Here, the specifier has two cells, and the
-# node pointed at by &gpio-ctrl is expected to have '#gpio-cells = <2>'.
+# node pointed at by &gpio-ctrl is expected to have '#pwm-cells = <2>'.
 #
-# #cells gives a name to each cell in the specifier. These names are used
-# when generating identifiers.
+# *-cells gives a name to each cell in the specifier. These names are used when
+# generating identifiers.
 #
 # In this example, assume that 1 refers to a pin and that 2 is a flag value.
-# This gives a #cells assignment like below.
-"#cells":
-    - pin  # name of first cell
-    - flag # name of second cell
+# This gives a *-cells assignment like below.
+pwm-cells:
+    - channel # name of first cell
+    - period  # name of second cell
 
-# If the specifier is empty (e.g. '#clock-cells = <0>'), then #cells can either
-# be omitted (recommended) or set to an empty array. Note that an empty array
-# is specified as '"#cells": []' in YAML.
+# If the specifier is empty (e.g. '#clock-cells = <0>'), then *-cells can
+# either be omitted (recommended) or set to an empty array. Note that an empty
+# array is specified as e.g. 'clock-cells: []' in YAML.
+
+# As a special case, all *-gpio properties map to the key 'gpio-cells',
+# regardless of prefix
+gpio-cells:
+    - pin
+    - flags
+
+# This older syntax is deprecated and will generate a warning when used. It
+# works as a catch-all, where the name of the referencing 'phandle-array'
+# property doesn't matter.
+"#cells":
+    - pin
+    - flags

--- a/dts/bindings/arm/nxp,kinetis-mcg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-mcg.yaml
@@ -20,5 +20,5 @@ properties:
     "#clock-cells":
       const: 1
 
-"#cells":
+clock-cells:
   - name

--- a/dts/bindings/arm/nxp,kinetis-pcc.yaml
+++ b/dts/bindings/arm/nxp,kinetis-pcc.yaml
@@ -20,5 +20,5 @@ properties:
     "#clock-cells":
       const: 1
 
-"#cells":
+clock-cells:
   - name

--- a/dts/bindings/arm/nxp,kinetis-scg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-scg.yaml
@@ -120,5 +120,5 @@ properties:
     "#clock-cells":
       const: 1
 
-"#cells":
+clock-cells:
   - name

--- a/dts/bindings/arm/nxp,kinetis-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-sim.yaml
@@ -32,7 +32,7 @@ properties:
       required: false
       const: 3
 
-"#cells":
+clock-cells:
   - name
   - offset
   - bits

--- a/dts/bindings/clock/nxp,imx-ccm.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm.yaml
@@ -20,7 +20,7 @@ properties:
     "#clock-cells":
       const: 3
 
-"#cells":
+clock-cells:
   - name
   - offset
   - bits

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -14,6 +14,6 @@ properties:
     "#clock-cells":
       const: 2
 
-"#cells":
+clock-cells:
   - bus
   - bits

--- a/dts/bindings/gpio/arm,cmsdk-gpio.yaml
+++ b/dts/bindings/gpio/arm,cmsdk-gpio.yaml
@@ -17,6 +17,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/atmel,sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam-gpio.yaml
@@ -25,6 +25,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/atmel,sam0-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam0-gpio.yaml
@@ -17,6 +17,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/espressif,esp32-gpio.yaml
+++ b/dts/bindings/gpio/espressif,esp32-gpio.yaml
@@ -18,6 +18,6 @@ properties:
     "#gpio-cells":
         const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
+++ b/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
@@ -14,6 +14,6 @@ properties:
     label:
       required: true
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/intel,apl-gpio.yaml
+++ b/dts/bindings/gpio/intel,apl-gpio.yaml
@@ -23,6 +23,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/microchip,xec-gpio.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio.yaml
@@ -23,6 +23,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -20,6 +20,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -28,6 +28,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -17,6 +17,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
+++ b/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
@@ -20,6 +20,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
@@ -17,6 +17,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/sifive,gpio0.yaml
+++ b/dts/bindings/gpio/sifive,gpio0.yaml
@@ -23,6 +23,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
@@ -17,6 +17,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
@@ -17,6 +17,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
@@ -17,6 +17,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -28,6 +28,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -23,6 +23,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
@@ -23,6 +23,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/ti,cc32xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc32xx-gpio.yaml
@@ -21,6 +21,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/ti,stellaris-gpio.yaml
+++ b/dts/bindings/gpio/ti,stellaris-gpio.yaml
@@ -21,6 +21,6 @@ properties:
     "#gpio-cells":
       const: 2
 
-"#cells":
+gpio-cells:
   - pin
   - flags

--- a/dts/bindings/iio/adc/atmel,sam-afec.yaml
+++ b/dts/bindings/iio/adc/atmel,sam-afec.yaml
@@ -22,5 +22,5 @@ properties:
     "#io-channel-cells":
       const: 1
 
-"#cells":
+io-channel-cells:
     - input

--- a/dts/bindings/iio/adc/atmel,sam0-adc.yaml
+++ b/dts/bindings/iio/adc/atmel,sam0-adc.yaml
@@ -30,5 +30,5 @@ properties:
     "#io-channel-cells":
       const: 1
 
-"#cells":
+io-channel-cells:
     - input

--- a/dts/bindings/iio/adc/microchip,xec-adc.yaml
+++ b/dts/bindings/iio/adc/microchip,xec-adc.yaml
@@ -23,5 +23,5 @@ properties:
     "#io-channel-cells":
       const: 1
 
-"#cells":
+io-channel-cells:
     - input

--- a/dts/bindings/iio/adc/nordic,nrf-adc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-adc.yaml
@@ -20,5 +20,5 @@ properties:
     "#io-channel-cells":
       const: 1
 
-"#cells":
+io-channel-cells:
     - input

--- a/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
@@ -20,5 +20,5 @@ properties:
     "#io-channel-cells":
       const: 1
 
-"#cells":
+io-channel-cells:
     - input

--- a/dts/bindings/iio/adc/nxp,kinetis-adc12.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc12.yaml
@@ -40,5 +40,5 @@ properties:
     "#io-channel-cells":
       const: 1
 
-"#cells":
+io-channel-cells:
     - input

--- a/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
@@ -20,5 +20,5 @@ properties:
     "#io-channel-cells":
       const: 1
 
-"#cells":
+io-channel-cells:
     - input

--- a/dts/bindings/iio/adc/st,stm32-adc.yaml
+++ b/dts/bindings/iio/adc/st,stm32-adc.yaml
@@ -24,5 +24,5 @@ properties:
     "#io-channel-cells":
       const: 1
 
-"#cells":
+io-channel-cells:
     - input

--- a/dts/bindings/interrupt-controller/arm,gic.yaml
+++ b/dts/bindings/interrupt-controller/arm,gic.yaml
@@ -17,7 +17,7 @@ properties:
     label:
       required: true
 
-"#cells":
+interrupt-cells:
   - irq
   - priority
   - flags

--- a/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
@@ -19,6 +19,6 @@ properties:
     "#interrupt-cells":
       const: 2
 
-"#cells":
+interrupt-cells:
   - irq
   - priority

--- a/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
@@ -19,6 +19,6 @@ properties:
     "#interrupt-cells":
       const: 2
 
-"#cells":
+interrupt-cells:
   - irq
   - priority

--- a/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
@@ -19,6 +19,6 @@ properties:
     "#interrupt-cells":
       const: 2
 
-"#cells":
+interrupt-cells:
   - irq
   - priority

--- a/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "intel,cavs-intc"
 
-include: base.yaml
+include: [interrupt-controller.yaml, base.yaml]
 
 properties:
   reg:
@@ -17,7 +17,7 @@ properties:
   "#interrupt-cells":
       const: 3
 
-"#cells":
+interrupt-cells:
   - irq
   - sense
   - priority

--- a/dts/bindings/interrupt-controller/intel,ioapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,ioapic.yaml
@@ -15,7 +15,7 @@ properties:
   "#interrupt-cells":
       const: 3
 
-"#cells":
+interrupt-cells:
   - irq
   - sense
   - priority

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
@@ -18,5 +18,5 @@ properties:
   "#interrupt-cells":
       const: 1
 
-"#cells":
+interrupt-cells:
   - irq

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux-ch.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux-ch.yaml
@@ -20,5 +20,5 @@ properties:
   interrupts:
       required: true
 
-"#cells":
+interrupt-cells:
   - irq

--- a/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
+++ b/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
@@ -14,5 +14,5 @@ properties:
   "#interrupt-cells":
       const: 1
 
-"#cells":
+interrupt-cells:
   - irq

--- a/dts/bindings/interrupt-controller/riscv,plic0.yaml
+++ b/dts/bindings/interrupt-controller/riscv,plic0.yaml
@@ -17,5 +17,5 @@ properties:
   "#interrupt-cells":
       const: 1
 
-"#cells":
+interrupt-cells:
   - irq

--- a/dts/bindings/interrupt-controller/snps,archs-idu-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,archs-idu-intc.yaml
@@ -12,6 +12,6 @@ compatible: "snps,archs-idu-intc"
 
 include: [interrupt-controller.yaml, base.yaml]
 
-"#cells":
+interrupt-cells:
   - irq
   - priority

--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -14,6 +14,6 @@ properties:
     "#interrupt-cells":
       const: 2
 
-"#cells":
+interrupt-cells:
   - irq
   - priority

--- a/dts/bindings/interrupt-controller/snps,designware-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,designware-intc.yaml
@@ -17,7 +17,7 @@ properties:
   "#interrupt-cells":
       const: 3
 
-"#cells":
+interrupt-cells:
   - irq
   - sense
   - priority

--- a/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
+++ b/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
@@ -22,6 +22,6 @@ properties:
   "#interrupt-cells":
       const: 2
 
-"#cells":
+interrupt-cells:
   - irq
   - priority

--- a/dts/bindings/interrupt-controller/xtensa,intc.yaml
+++ b/dts/bindings/interrupt-controller/xtensa,intc.yaml
@@ -14,7 +14,7 @@ properties:
   "#interrupt-cells":
       const: 3
 
-"#cells":
+interrupt-cells:
   - irq
   - sense
   - priority

--- a/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
+++ b/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
@@ -14,6 +14,6 @@ properties:
     label:
       required: true
 
-"#cells":
+pinmux-cells:
   - pin
   - function

--- a/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
+++ b/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
@@ -12,6 +12,6 @@ properties:
     reg:
       required: true
 
-"#cells":
+pinmux-cells:
   - pin
   - function

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -14,6 +14,6 @@ properties:
     clocks:
       required: true
 
-"#cells":
+pinmux-cells:
   - pin
   - function

--- a/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
+++ b/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
@@ -14,6 +14,6 @@ properties:
     clocks:
       required: true
 
-"#cells":
+pinmux-cells:
   - pin
   - function

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -11,6 +11,6 @@ properties:
     reg:
       required: true
 
-"#cells":
+pinmux-cells:
   - pin
   - function

--- a/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
@@ -12,6 +12,6 @@ properties:
     reg:
       required: true
 
-"#cells":
+pinmux-cells:
   - pin
   - function

--- a/dts/bindings/pwm/atmel,sam-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam-pwm.yaml
@@ -35,7 +35,7 @@ properties:
     "#pwm-cells":
       const: 2
 
-"#cells":
+pwm-cells:
   - channel
 # period in terms of nanoseconds
   - period

--- a/dts/bindings/pwm/fsl,imx7d-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx7d-pwm.yaml
@@ -30,7 +30,7 @@ properties:
     "#pwm-cells":
      const: 2
 
-"#cells":
+pwm-cells:
   - channel
 # period in terms of nanoseconds
   - period

--- a/dts/bindings/pwm/nxp,imx-pwm.yaml
+++ b/dts/bindings/pwm/nxp,imx-pwm.yaml
@@ -25,5 +25,5 @@ properties:
     "#pwm-cells":
       const: 1
 
-"#cells":
+pwm-cells:
   - channel

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -20,7 +20,7 @@ properties:
     "#pwm-cells":
       const: 2
 
-"#cells":
+pwm-cells:
   - channel
 # period in terms of nanoseconds
   - period

--- a/dts/bindings/pwm/sifive,pwm0.yaml
+++ b/dts/bindings/pwm/sifive,pwm0.yaml
@@ -30,7 +30,7 @@ properties:
     "#pwm-cells":
       const: 2
 
-"#cells":
+pwm-cells:
   - channel
 # period in terms of nanoseconds
   - period

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -19,7 +19,7 @@ properties:
     "#pwm-cells":
       const: 2
 
-"#cells":
+pwm-cells:
   - channel
 # period in terms of nanoseconds
   - period

--- a/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
+++ b/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
@@ -20,5 +20,5 @@ properties:
     "#clock-cells":
       const: 1
 
-"#cells":
+clock-cells:
   - name

--- a/scripts/dts/extract/clocks.py
+++ b/scripts/dts/extract/clocks.py
@@ -46,8 +46,14 @@ class DTClocks(DTDirective):
                                      '#clock-cells', 0))
                 clock_cells_string = clock_provider_bindings.get(
                     'cell_string', 'CLOCK')
-                clock_cells_names = clock_provider_bindings.get(
-                    '#cells', ['ID', 'CELL1',  "CELL2", "CELL3"])
+
+                if "clock-cells" in clock_provider_bindings:
+                    clock_cells_names = clock_provider_bindings["clock-cells"]
+                elif "#cells" in clock_provider_bindings:
+                    clock_cells_names = clock_provider_bindings["#cells"]
+                else:
+                    clock_cells_names = ["ID", "CELL1",  "CELL2", "CELL3"]
+
                 clock_cells = []
             else:
                 clock_cells.append(cell)

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -538,8 +538,8 @@ def extract_cells(node_path, prop, prop_values, names, index,
         # Get number of cells per element of current property
         for props in reduced[cell_parent]['props']:
             if props[0] == '#' and '-cells' in props:
-                if props in cell_yaml:
-                    cell_yaml_names = props
+                if props[1:] in cell_yaml:
+                    cell_yaml_names = props[1:]  # #foo-cells -> foo-cells
                 else:
                     cell_yaml_names = '#cells'
 

--- a/scripts/dts/extract/interrupts.py
+++ b/scripts/dts/extract/interrupts.py
@@ -55,7 +55,12 @@ class DTInterrupts(DTDirective):
             l_cell_prefix = ['IRQ']
 
             for i in range(reduced[irq_parent]['props']['#interrupt-cells']):
-                l_cell_name = [cell_yaml['#cells'][i].upper()]
+                if "interrupt-cells" in cell_yaml:
+                    cell_yaml_name = "interrupt-cells"
+                else:
+                    cell_yaml_name = "#cells"
+
+                l_cell_name = [cell_yaml[cell_yaml_name][i].upper()]
                 if l_cell_name == l_cell_prefix:
                     l_cell_name = []
 

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -433,8 +433,8 @@ def write_irqs(node):
         while irq_ctrl.interrupts:
             irq_num = (irq_num + 1) << 8
             if "irq" not in irq_ctrl.interrupts[0].data:
-                err("Expected binding for {!r} to have 'irq' "
-                    "in '#cells'".format(irq_ctrl))
+                err("Expected binding for {!r} to have 'irq' in *-cells"
+                    .format(irq_ctrl))
             irq_num |= irq_ctrl.interrupts[0].data["irq"]
             irq_ctrl = irq_ctrl.interrupts[0].controller
         return irq_num
@@ -476,7 +476,7 @@ def write_phandle_val_list(prop):
     # generates output like this:
     #
     #   #define <device prefix>_PWMS_CONTROLLER_0 "PWM_0"  (name taken from 'label = ...')
-    #   #define <device prefix>_PWMS_CHANNEL_0 123         (name taken from #cells in binding)
+    #   #define <device prefix>_PWMS_CHANNEL_0 123         (name taken from *-cells in binding)
     #   #define <device prefix>_PWMS_0 {"PWM_0", 123}
     #   #define <device prefix>_PWMS_CONTROLLER_1 "PWM_1"
     #   #define <device prefix>_PWMS_CHANNEL_1 456

--- a/scripts/dts/test-bindings/deprecated.yaml
+++ b/scripts/dts/test-bindings/deprecated.yaml
@@ -26,6 +26,11 @@ properties:
 # Deprecated older 'child-binding'-alike
 sub-node:
     properties:
-        child-prop:
-            type: int
+        foos:
+            type: phandle-array
             required: true
+
+# Deprecated older catch-all version of *-cells
+"#cells":
+    - foo
+    - bar

--- a/scripts/dts/test-bindings/gpio-dst.yaml
+++ b/scripts/dts/test-bindings/gpio-dst.yaml
@@ -5,5 +5,5 @@ description: GPIO destination for mapping test
 
 compatible: "gpio-dst"
 
-"#cells":
+gpio-cells:
     - val

--- a/scripts/dts/test-bindings/interrupt-1-cell.yaml
+++ b/scripts/dts/test-bindings/interrupt-1-cell.yaml
@@ -5,5 +5,5 @@ description: Interrupt controller with one cell
 
 compatible: "interrupt-one-cell"
 
-"#cells":
-  - one
+interrupt-cells:
+    - one

--- a/scripts/dts/test-bindings/interrupt-2-cell.yaml
+++ b/scripts/dts/test-bindings/interrupt-2-cell.yaml
@@ -5,6 +5,6 @@ description: Interrupt controller with two cells
 
 compatible: "interrupt-two-cell"
 
-"#cells":
-  - one
-  - two
+interrupt-cells:
+    - one
+    - two

--- a/scripts/dts/test-bindings/interrupt-3-cell.yaml
+++ b/scripts/dts/test-bindings/interrupt-3-cell.yaml
@@ -5,7 +5,7 @@ description: Interrupt controller with three cells
 
 compatible: "interrupt-three-cell"
 
-"#cells":
-  - one
-  - two
-  - three
+interrupt-cells:
+    - one
+    - two
+    - three

--- a/scripts/dts/test-bindings/phandle-array-controller-1.yaml
+++ b/scripts/dts/test-bindings/phandle-array-controller-1.yaml
@@ -5,5 +5,8 @@ description: Controller with one data value
 
 compatible: "phandle-array-controller-1"
 
-"#cells":
+phandle-array-foo-cells:
     - one
+
+gpio-cells:
+    - gpio-one

--- a/scripts/dts/test-bindings/phandle-array-controller-2.yaml
+++ b/scripts/dts/test-bindings/phandle-array-controller-2.yaml
@@ -5,6 +5,6 @@ description: Controller with two data values
 
 compatible: "phandle-array-controller-2"
 
-"#cells":
+phandle-array-foo-cells:
     - one
     - two

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -337,8 +337,9 @@
 		compatible = "deprecated";
 		required = <1>;
 		required-2 = <2>;
+		#foo-cells = <2>;
 		sub-node {
-			child-prop = <3>;
+			foos = <&{/deprecated} 1 2>;
 		};
 	};
 };

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: BSD-3-Clause
 
+import io
 import sys
 
 import edtlib
@@ -34,7 +35,18 @@ def run():
     def verify_streq(actual, expected):
         verify_eq(str(actual), expected)
 
-    edt = edtlib.EDT("test.dts", ["test-bindings"])
+    warnings = io.StringIO()
+    edt = edtlib.EDT("test.dts", ["test-bindings"], warnings)
+
+    # Deprecated features are tested too, which generate warnings. Verify them.
+    verify_streq(warnings.getvalue(), """\
+warning: The 'properties: compatible: constraint: ...' way of specifying the compatible in test-bindings/deprecated.yaml is deprecated. Put 'compatible: "deprecated"' at the top level of the binding instead.
+warning: the 'inherits:' syntax in test-bindings/deprecated.yaml is deprecated and will be removed - please use 'include: foo.yaml' or 'include: [foo.yaml, bar.yaml]' instead
+warning: please put 'required: true' instead of 'category: required' in properties: required: ...' in test-bindings/deprecated.yaml - 'category' will be removed
+warning: please put 'required: false' instead of 'category: optional' in properties: optional: ...' in test-bindings/deprecated.yaml - 'category' will be removed
+warning: 'sub-node: properties: ...' in test-bindings/deprecated.yaml is deprecated and will be removed - please give a full binding for the child node in 'child-binding:' instead (see binding-template.yaml)
+warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be removed - please put 'interrupt-cells:', 'pwm-cells:', 'gpio-cells:', etc., instead. The name should match the name of the corresponding phandle-array property (see binding-template.yaml)
+""")
 
     #
     # Test interrupts

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -129,11 +129,12 @@ def run():
     verify_streq(grandchild.props, "{'grandchild-prop': <Property, name: grandchild-prop, type: int, value: 2>}")
 
     #
-    # Test deprecated 'sub-node:' key (replaced with 'child-binding:')
+    # Test deprecated 'sub-node' key (replaced with 'child-binding') and
+    # deprecated '#cells' key (replaced with '*-cells')
     #
 
     verify_streq(edt.get_node("/deprecated/sub-node").props,
-                 "{'child-prop': <Property, name: child-prop, type: int, value: 3>}")
+                 "{'foos': <Property, name: foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /deprecated in 'test.dts', binding test-bindings/deprecated.yaml>, data: {'foo': 1, 'bar': 2}>]>}")
 
     #
     # Test Node.props (derived from DT and 'properties:' in the binding)
@@ -170,7 +171,7 @@ def run():
                  "<Property, name: phandle-array-foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-1 in 'test.dts', binding test-bindings/phandle-array-controller-1.yaml>, data: {'one': 1}>, <ControllerAndData, controller: <Node /props/ctrl-2 in 'test.dts', binding test-bindings/phandle-array-controller-2.yaml>, data: {'one': 2, 'two': 3}>]>")
 
     verify_streq(edt.get_node("/props").props["foo-gpios"],
-                 "<Property, name: foo-gpios, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-1 in 'test.dts', binding test-bindings/phandle-array-controller-1.yaml>, data: {'one': 1}>]>")
+                 "<Property, name: foo-gpios, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-1 in 'test.dts', binding test-bindings/phandle-array-controller-1.yaml>, data: {'gpio-one': 1}>]>")
 
     #
     # Test <prefix>-map, via gpio-map (the most common case)


### PR DESCRIPTION
Implement a nice generalization suggested by Bobby Noelte.

Instead of having a generic #cells key in bindings, have source-specific
*-cells keys. Some examples:

    interrupt-cells:
        - irq
        - priority
        - flags

    gpio-cells:
        - pin
        - flags

    pwm-cells:
        - channel
        - period

This makes bindings a bit easier to read, and allows a node to be a
controller for many different 'phandle-array' properties.

The prefix before *-cells is derived from the property name, meaning
there's no fixed set of *-cells keys. This is possible because of the
earlier 'phandle-array' generalization.

The older #cells key is supported for backwards compatibility, but
generates a deprecation warning.