### PR TITLE
doc: fix doc, boards, and samples misspellings

### DIFF
--- a/boards/arm/mec1501modular_assy6885/doc/index.rst
+++ b/boards/arm/mec1501modular_assy6885/doc/index.rst
@@ -146,7 +146,7 @@ These jumpers configure MEC1501 Boot-ROM straps.
 
 ``JP23 3-4`` pulls SHD SPI CS0# up to VTR2. MEC1501 Boot-ROM samples
 SHD SPI CS0# and if high, it loads code from SHD SPI.
-This is the recomended setup.
+This is the recommended setup.
 
 +-------------+------------+----------------------------+
 |  CR_STRAP   | BSS_STRAP  |         SOURCE             |

--- a/boards/arm/reel_board/doc/index.rst
+++ b/boards/arm/reel_board/doc/index.rst
@@ -420,7 +420,7 @@ third party shields in two ways:
         NOTM.2 adapter is removed from the reel board and
         connected to NOTM.2 connector on the link board BASE.
         The wiring to the shield connector is identical to the
-        configuraiton above and no software modifications for the shield
+        configuration above and no software modifications for the shield
         are necessary.
         Stand-alone configuration is more suitable for applications where
         peripherals on the reel board are not used or in conflict,

--- a/boards/arm/sensortile_box/doc/index.rst
+++ b/boards/arm/sensortile_box/doc/index.rst
@@ -61,7 +61,7 @@ SensorTile.box provides the following hardware components:
   - Microphone / audio sensor (MP23ABS1)
   - Humidity sensor (HTS221)
 
-- HCP602535ZC LI-ion rechargable battery (3.7V 500mAh)
+- HCP602535ZC LI-ion rechargeable battery (3.7V 500mAh)
 - FTSH107 connector for SWD debugging and UART Tx/Rx
 
 Supported Features

--- a/boards/posix/nrf52_bsim/doc/index.rst
+++ b/boards/posix/nrf52_bsim/doc/index.rst
@@ -53,7 +53,7 @@ Building and running
    does not support native 32-bit binaries.
 
 To target this board you need to have `BabbleSim`_ compiled in your system.
-If you do not have it yet, in `its webpage <https://BabbleSim.github.io>`_
+If you do not have it yet, in `its web page <https://BabbleSim.github.io>`_
 you can find instructions on how to
 `fetch <https://babblesim.github.io/fetching.html>`_ and
 `build <https://babblesim.github.io/building.html>`_ it.

--- a/boards/xtensa/odroid_go/doc/index.rst
+++ b/boards/xtensa/odroid_go/doc/index.rst
@@ -7,7 +7,7 @@ Overview
 ********
 
 ODROID-GO Game Kit is a "Do it yourself" ("DIY") portable game console by
-HardKernel. It fetaures a custom ESP32-WROVER with 16 MB flash and it operates
+HardKernel. It features a custom ESP32-WROVER with 16 MB flash and it operates
 from 80 MHz - 240 MHz [1]_.
 
 The features include the following:

--- a/doc/guides/portability/posix.rst
+++ b/doc/guides/portability/posix.rst
@@ -353,7 +353,7 @@ POSIX_SIGNALS
 +++++++++++++
 
 Signal services are a basic mechanism within POSIX-based systems and are
-required for error and eventhandling.
+required for error and event handling.
 
 .. csv-table:: POSIX_SIGNALS
    :header: API, Supported

--- a/samples/userspace/shared_mem/README.rst
+++ b/samples/userspace/shared_mem/README.rst
@@ -42,7 +42,7 @@ Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
 
 Two definitions can be inserted to change the wheel settings and print
 the state information.  To enable the definitions uncomment the last
-two lines in CMakelists.txt.
+two lines in CMakeLists.txt.
 
 Functionality
 *************


### PR DESCRIPTION
Regular scan for misspellings in documentation missed during regular
reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>