### PR TITLE
drivers: pwm: pwm_mchp_xec: Fix u32_t overflow for freq calculation

### DIFF
--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -124,7 +124,7 @@ static u16_t xec_select_div(u32_t freq, u32_t max_freq[16])
 static void xec_compute_on_off(u32_t freq, u32_t dc, u32_t clk,
 			       u32_t *on, u32_t *off)
 {
-	u32_t on_off;
+	u64_t on_off;
 
 	on_off = (clk * 10) / freq;
 


### PR DESCRIPTION
Fixes u32_t overflow during intermediary calculations using u64_t for
it. on_off is temporary value used for calculating on and off and it
got overflowed with simple test in tests/drivers/pwm/pwm_api
([period]: 2000, [pulse]: 2000)