### PR TITLE
Align sensor drivers to stmemsc HAL library v1.02

### DIFF
--- a/drivers/sensor/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.c
@@ -23,7 +23,7 @@ static int iis3dhhc_sample_fetch(struct device *dev,
 				 enum sensor_channel chan)
 {
 	struct iis3dhhc_data *data = dev->driver_data;
-	axis3bit16_t raw_accel;
+	union axis3bit16_t raw_accel;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
@@ -35,16 +35,13 @@ static int iis3dhhc_sample_fetch(struct device *dev,
 	return 0;
 }
 
-#define IIS3DHHC_FROM_LSB_TO_ums2(lsb)	\
-		((IIS3DHHC_FROM_LSB_TO_mg((s64_t)lsb) * SENSOR_G) / 1000LL)
-
 static inline void iis3dhhc_convert(struct sensor_value *val,
 					s16_t raw_val)
 {
 	s64_t micro_ms2;
 
 	/* Convert to m/s^2 */
-	micro_ms2 = IIS3DHHC_FROM_LSB_TO_ums2((s64_t)raw_val);
+	micro_ms2 = ((iis3dhhc_from_lsb_to_mg(raw_val) * SENSOR_G) / 1000LL);
 	val->val1 = micro_ms2 / 1000000LL;
 	val->val2 = micro_ms2 % 1000000LL;
 }

--- a/drivers/sensor/iis3dhhc/iis3dhhc.h
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.h
@@ -19,6 +19,11 @@
 #include <sys/util.h>
 #include "iis3dhhc_reg.h"
 
+union axis3bit16_t {
+	s16_t i16bit[3];
+	u8_t u8bit[6];
+};
+
 struct iis3dhhc_config {
 	char *master_dev_name;
 	int (*bus_init)(struct device *dev);
@@ -39,10 +44,10 @@ struct iis3dhhc_data {
 	struct device *bus;
 	s16_t acc[3];
 
-	iis3dhhc_ctx_t *ctx;
+	stmdev_ctx_t *ctx;
 
 #ifdef DT_ST_IIS3DHHC_BUS_SPI
-	iis3dhhc_ctx_t ctx_spi;
+	stmdev_ctx_t ctx_spi;
 #endif
 
 #ifdef CONFIG_IIS3DHHC_TRIGGER

--- a/drivers/sensor/iis3dhhc/iis3dhhc_spi.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_spi.c
@@ -89,9 +89,9 @@ static int iis3dhhc_spi_write(struct iis3dhhc_data *ctx, u8_t reg,
 	return 0;
 }
 
-iis3dhhc_ctx_t iis3dhhc_spi_ctx = {
-	.read_reg = (iis3dhhc_read_ptr) iis3dhhc_spi_read,
-	.write_reg = (iis3dhhc_write_ptr) iis3dhhc_spi_write,
+stmdev_ctx_t iis3dhhc_spi_ctx = {
+	.read_reg = (stmdev_read_ptr) iis3dhhc_spi_read,
+	.write_reg = (stmdev_write_ptr) iis3dhhc_spi_write,
 };
 
 int iis3dhhc_spi_init(struct device *dev)

--- a/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
@@ -40,7 +40,7 @@ int iis3dhhc_trigger_set(struct device *dev,
 			 sensor_trigger_handler_t handler)
 {
 	struct iis3dhhc_data *iis3dhhc = dev->driver_data;
-	axis3bit16_t raw;
+	union axis3bit16_t raw;
 
 	if (trig->chan == SENSOR_CHAN_ACCEL_XYZ) {
 		iis3dhhc->handler_drdy = handler;

--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -178,7 +178,7 @@ static int lis2dw12_sample_fetch(struct device *dev, enum sensor_channel chan)
 	struct lis2dw12_data *lis2dw12 = dev->driver_data;
 	const struct lis2dw12_device_config *cfg = dev->config->config_info;
 	u8_t shift;
-	axis3bit16_t buf;
+	union axis3bit16_t buf;
 
 	/* fetch raw data sample */
 	if (lis2dw12_acceleration_raw_get(lis2dw12->ctx, buf.u8bit) < 0) {

--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -17,6 +17,11 @@
 #include <drivers/sensor.h>
 #include "lis2dw12_reg.h"
 
+union axis3bit16_t {
+	s16_t i16bit[3];
+	u8_t u8bit[6];
+};
+
 #if defined(CONFIG_LIS2DW12_ODR_1_6)
 	#define LIS2DW12_DEFAULT_ODR	LIS2DW12_XL_ODR_1Hz6_LP_ONLY
 #elif defined(CONFIG_LIS2DW12_ODR_12_5)
@@ -109,7 +114,7 @@ struct lis2dw12_data {
 	 /* save sensitivity */
 	u16_t gain;
 
-	lis2dw12_ctx_t *ctx;
+	stmdev_ctx_t *ctx;
 #ifdef CONFIG_LIS2DW12_TRIGGER
 	struct device *gpio;
 	u8_t gpio_pin;

--- a/drivers/sensor/lis2dw12/lis2dw12_i2c.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_i2c.c
@@ -34,9 +34,9 @@ static int lis2dw12_i2c_write(struct lis2dw12_data *data, u8_t reg_addr,
 			       reg_addr, value, len);
 }
 
-lis2dw12_ctx_t lis2dw12_i2c_ctx = {
-	.read_reg = (lis2dw12_read_ptr) lis2dw12_i2c_read,
-	.write_reg = (lis2dw12_write_ptr) lis2dw12_i2c_write,
+stmdev_ctx_t lis2dw12_i2c_ctx = {
+	.read_reg = (stmdev_read_ptr) lis2dw12_i2c_read,
+	.write_reg = (stmdev_write_ptr) lis2dw12_i2c_write,
 };
 
 int lis2dw12_i2c_init(struct device *dev)

--- a/drivers/sensor/lis2dw12/lis2dw12_spi.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_spi.c
@@ -90,9 +90,9 @@ static int lis2dw12_spi_write(struct lis2dw12_data *ctx, u8_t reg,
 	return 0;
 }
 
-lis2dw12_ctx_t lis2dw12_spi_ctx = {
-	.read_reg = (lis2dw12_read_ptr) lis2dw12_spi_read,
-	.write_reg = (lis2dw12_write_ptr) lis2dw12_spi_write,
+stmdev_ctx_t lis2dw12_spi_ctx = {
+	.read_reg = (stmdev_read_ptr) lis2dw12_spi_read,
+	.write_reg = (stmdev_write_ptr) lis2dw12_spi_write,
 };
 
 int lis2dw12_spi_init(struct device *dev)

--- a/drivers/sensor/lis2dw12/lis2dw12_trigger.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_trigger.c
@@ -78,7 +78,7 @@ int lis2dw12_trigger_set(struct device *dev,
 			  sensor_trigger_handler_t handler)
 {
 	struct lis2dw12_data *lis2dw12 = dev->driver_data;
-	axis3bit16_t raw;
+	union axis3bit16_t raw;
 	int state = (handler != NULL) ? PROPERTY_ENABLE : PROPERTY_DISABLE;
 
 	switch (trig->type) {

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -56,7 +56,7 @@ static int lis2mdl_set_hard_iron(struct device *dev, enum sensor_channel chan,
 {
 	struct lis2mdl_data *lis2mdl = dev->driver_data;
 	u8_t i;
-	axis3bit16_t offset;
+	union axis3bit16_t offset;
 
 	for (i = 0U; i < 3; i++) {
 		offset.i16bit[i] = sys_cpu_to_le16(val->val1);
@@ -172,7 +172,7 @@ static int lis2mdl_attr_set(struct device *dev,
 static int lis2mdl_sample_fetch_mag(struct device *dev)
 {
 	struct lis2mdl_data *lis2mdl = dev->driver_data;
-	axis3bit16_t raw_mag;
+	union axis3bit16_t raw_mag;
 
 	/* fetch raw data sample */
 	if (lis2mdl_magnetic_raw_get(lis2mdl->ctx, raw_mag.u8bit) < 0) {
@@ -190,7 +190,7 @@ static int lis2mdl_sample_fetch_mag(struct device *dev)
 static int lis2mdl_sample_fetch_temp(struct device *dev)
 {
 	struct lis2mdl_data *lis2mdl = dev->driver_data;
-	axis1bit16_t raw_temp;
+	union axis1bit16_t raw_temp;
 	s32_t temp;
 
 	/* fetch raw temperature sample */

--- a/drivers/sensor/lis2mdl/lis2mdl.h
+++ b/drivers/sensor/lis2mdl/lis2mdl.h
@@ -17,6 +17,16 @@
 #include <sys/util.h>
 #include "lis2mdl_reg.h"
 
+union axis3bit16_t {
+	s16_t i16bit[3];
+	u8_t u8bit[6];
+};
+
+union axis1bit16_t {
+	s16_t i16bit;
+	u8_t u8bit[2];
+};
+
 struct lis2mdl_config {
 	char *master_dev_name;
 	int (*bus_init)(struct device *dev);
@@ -42,12 +52,12 @@ struct lis2mdl_data {
 	s16_t mag[3];
 	s32_t temp_sample;
 
-	lis2mdl_ctx_t *ctx;
+	stmdev_ctx_t *ctx;
 
 #ifdef DT_ST_LIS2MDL_BUS_I2C
-	lis2mdl_ctx_t ctx_i2c;
+	stmdev_ctx_t ctx_i2c;
 #elif DT_ST_LIS2MDL_BUS_SPI
-	lis2mdl_ctx_t ctx_spi;
+	stmdev_ctx_t ctx_spi;
 #endif
 
 #ifdef CONFIG_LIS2MDL_TRIGGER

--- a/drivers/sensor/lis2mdl/lis2mdl_i2c.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_i2c.c
@@ -43,8 +43,8 @@ int lis2mdl_i2c_init(struct device *dev)
 {
 	struct lis2mdl_data *data = dev->driver_data;
 
-	data->ctx_i2c.read_reg = (lis2mdl_read_ptr) lis2mdl_i2c_read;
-	data->ctx_i2c.write_reg = (lis2mdl_write_ptr) lis2mdl_i2c_write;
+	data->ctx_i2c.read_reg = (stmdev_read_ptr) lis2mdl_i2c_read;
+	data->ctx_i2c.write_reg = (stmdev_write_ptr) lis2mdl_i2c_write;
 
 	data->ctx = &data->ctx_i2c;
 	data->ctx->handle = dev;

--- a/drivers/sensor/lis2mdl/lis2mdl_spi.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_spi.c
@@ -99,8 +99,8 @@ int lis2mdl_spi_init(struct device *dev)
 {
 	struct lis2mdl_data *data = dev->driver_data;
 
-	data->ctx_spi.read_reg = (lis2mdl_read_ptr) lis2mdl_spi_read;
-	data->ctx_spi.write_reg = (lis2mdl_write_ptr) lis2mdl_spi_write;
+	data->ctx_spi.read_reg = (stmdev_read_ptr) lis2mdl_spi_read;
+	data->ctx_spi.write_reg = (stmdev_write_ptr) lis2mdl_spi_write;
 
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = dev;

--- a/drivers/sensor/lis2mdl/lis2mdl_trigger.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_trigger.c
@@ -30,7 +30,7 @@ int lis2mdl_trigger_set(struct device *dev,
 			  sensor_trigger_handler_t handler)
 {
 	struct lis2mdl_data *lis2mdl = dev->driver_data;
-	axis3bit16_t raw;
+	union axis3bit16_t raw;
 
 	if (trig->chan == SENSOR_CHAN_MAGN_XYZ) {
 		lis2mdl->handler_drdy = handler;

--- a/drivers/sensor/lps22hh/lps22hh.c
+++ b/drivers/sensor/lps22hh/lps22hh.c
@@ -31,8 +31,8 @@ static int lps22hh_sample_fetch(struct device *dev,
 				enum sensor_channel chan)
 {
 	struct lps22hh_data *data = dev->driver_data;
-	axis1bit32_t raw_press;
-	axis1bit16_t raw_temp;
+	union axis1bit32_t raw_press;
+	union axis1bit16_t raw_temp;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 

--- a/drivers/sensor/lps22hh/lps22hh.h
+++ b/drivers/sensor/lps22hh/lps22hh.h
@@ -20,6 +20,16 @@
 #include <sys/util.h>
 #include "lps22hh_reg.h"
 
+union axis1bit32_t {
+	s32_t i32bit;
+	u8_t u8bit[4];
+};
+
+union axis1bit16_t {
+	s16_t i16bit;
+	u8_t u8bit[2];
+};
+
 struct lps22hh_config {
 	char *master_dev_name;
 	int (*bus_init)(struct device *dev);
@@ -43,12 +53,12 @@ struct lps22hh_data {
 	s32_t sample_press;
 	s16_t sample_temp;
 
-	lps22hh_ctx_t *ctx;
+	stmdev_ctx_t *ctx;
 
 #ifdef DT_ST_LPS22HH_BUS_I2C
-	lps22hh_ctx_t ctx_i2c;
+	stmdev_ctx_t ctx_i2c;
 #elif DT_ST_LPS22HH_BUS_SPI
-	lps22hh_ctx_t ctx_spi;
+	stmdev_ctx_t ctx_spi;
 #endif
 
 #ifdef CONFIG_LPS22HH_TRIGGER

--- a/drivers/sensor/lps22hh/lps22hh_i2c.c
+++ b/drivers/sensor/lps22hh/lps22hh_i2c.c
@@ -42,8 +42,8 @@ int lps22hh_i2c_init(struct device *dev)
 {
 	struct lps22hh_data *data = dev->driver_data;
 
-	data->ctx_i2c.read_reg = (lps22hh_read_ptr) lps22hh_i2c_read;
-	data->ctx_i2c.write_reg = (lps22hh_write_ptr) lps22hh_i2c_write;
+	data->ctx_i2c.read_reg = (stmdev_read_ptr) lps22hh_i2c_read;
+	data->ctx_i2c.write_reg = (stmdev_write_ptr) lps22hh_i2c_write;
 
 	data->ctx = &data->ctx_i2c;
 	data->ctx->handle = dev;

--- a/drivers/sensor/lps22hh/lps22hh_spi.c
+++ b/drivers/sensor/lps22hh/lps22hh_spi.c
@@ -99,8 +99,8 @@ int lps22hh_spi_init(struct device *dev)
 {
 	struct lps22hh_data *data = dev->driver_data;
 
-	data->ctx_spi.read_reg = (lps22hh_read_ptr) lps22hh_spi_read;
-	data->ctx_spi.write_reg = (lps22hh_write_ptr) lps22hh_spi_write;
+	data->ctx_spi.read_reg = (stmdev_read_ptr) lps22hh_spi_read;
+	data->ctx_spi.write_reg = (stmdev_write_ptr) lps22hh_spi_write;
 
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = dev;

--- a/drivers/sensor/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/lps22hh/lps22hh_trigger.c
@@ -41,7 +41,7 @@ int lps22hh_trigger_set(struct device *dev,
 			  sensor_trigger_handler_t handler)
 {
 	struct lps22hh_data *lps22hh = dev->driver_data;
-	axis1bit32_t raw_press;
+	union axis1bit32_t raw_press;
 
 	if (trig->chan == SENSOR_CHAN_ALL) {
 		lps22hh->handler_drdy = handler;

--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -296,7 +296,7 @@ static int lsm6dso_attr_set(struct device *dev, enum sensor_channel chan,
 static int lsm6dso_sample_fetch_accel(struct device *dev)
 {
 	struct lsm6dso_data *data = dev->driver_data;
-	axis3bit16_t buf;
+	union axis3bit16_t buf;
 
 	if (lsm6dso_acceleration_raw_get(data->ctx, buf.u8bit) < 0) {
 		LOG_DBG("Failed to read sample");
@@ -313,7 +313,7 @@ static int lsm6dso_sample_fetch_accel(struct device *dev)
 static int lsm6dso_sample_fetch_gyro(struct device *dev)
 {
 	struct lsm6dso_data *data = dev->driver_data;
-	axis3bit16_t buf;
+	union axis3bit16_t buf;
 
 	if (lsm6dso_angular_rate_raw_get(data->ctx, buf.u8bit) < 0) {
 		LOG_DBG("Failed to read sample");
@@ -331,7 +331,7 @@ static int lsm6dso_sample_fetch_gyro(struct device *dev)
 static int lsm6dso_sample_fetch_temp(struct device *dev)
 {
 	struct lsm6dso_data *data = dev->driver_data;
-	axis1bit16_t buf;
+	union axis1bit16_t buf;
 
 	if (lsm6dso_temperature_raw_get(data->ctx, buf.u8bit) < 0) {
 		LOG_DBG("Failed to read sample");

--- a/drivers/sensor/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/lsm6dso/lsm6dso.h
@@ -18,6 +18,16 @@
 #include <sys/util.h>
 #include "lsm6dso_reg.h"
 
+union axis3bit16_t {
+	s16_t i16bit[3];
+	u8_t u8bit[6];
+};
+
+union axis1bit16_t {
+	s16_t i16bit;
+	u8_t u8bit[2];
+};
+
 #define LSM6DSO_EN_BIT					0x01
 #define LSM6DSO_DIS_BIT					0x00
 
@@ -146,12 +156,12 @@ struct lsm6dso_data {
 	} hts221;
 #endif /* CONFIG_LSM6DSO_SENSORHUB */
 
-	lsm6dso_ctx_t *ctx;
+	stmdev_ctx_t *ctx;
 
 	#ifdef DT_ST_LSM6DSO_BUS_I2C
-	lsm6dso_ctx_t ctx_i2c;
+	stmdev_ctx_t ctx_i2c;
 	#elif DT_ST_LSM6DSO_BUS_SPI
-	lsm6dso_ctx_t ctx_spi;
+	stmdev_ctx_t ctx_spi;
 	#endif
 
 	u16_t accel_freq;

--- a/drivers/sensor/lsm6dso/lsm6dso_i2c.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_i2c.c
@@ -42,8 +42,8 @@ int lsm6dso_i2c_init(struct device *dev)
 {
 	struct lsm6dso_data *data = dev->driver_data;
 
-	data->ctx_i2c.read_reg = (lsm6dso_read_ptr) lsm6dso_i2c_read,
-	data->ctx_i2c.write_reg = (lsm6dso_write_ptr) lsm6dso_i2c_write,
+	data->ctx_i2c.read_reg = (stmdev_read_ptr) lsm6dso_i2c_read,
+	data->ctx_i2c.write_reg = (stmdev_write_ptr) lsm6dso_i2c_write,
 
 	data->ctx = &data->ctx_i2c;
 	data->ctx->handle = dev;

--- a/drivers/sensor/lsm6dso/lsm6dso_spi.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_spi.c
@@ -98,8 +98,8 @@ int lsm6dso_spi_init(struct device *dev)
 {
 	struct lsm6dso_data *data = dev->driver_data;
 
-	data->ctx_spi.read_reg = (lsm6dso_read_ptr) lsm6dso_spi_read,
-	data->ctx_spi.write_reg = (lsm6dso_write_ptr) lsm6dso_spi_write,
+	data->ctx_spi.read_reg = (stmdev_read_ptr) lsm6dso_spi_read,
+	data->ctx_spi.write_reg = (stmdev_write_ptr) lsm6dso_spi_write,
 
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = dev;

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -28,7 +28,7 @@ static int lsm6dso_enable_t_int(struct device *dev, int enable)
 	lsm6dso_pin_int2_route_t int2_route;
 
 	if (enable) {
-		axis1bit16_t buf;
+		union axis1bit16_t buf;
 
 		/* dummy read: re-trigger interrupt */
 		lsm6dso_temperature_raw_get(lsm6dso->ctx, buf.u8bit);
@@ -55,7 +55,7 @@ static int lsm6dso_enable_xl_int(struct device *dev, int enable)
 	struct lsm6dso_data *lsm6dso = dev->driver_data;
 
 	if (enable) {
-		axis3bit16_t buf;
+		union axis3bit16_t buf;
 
 		/* dummy read: re-trigger interrupt */
 		lsm6dso_acceleration_raw_get(lsm6dso->ctx, buf.u8bit);
@@ -91,7 +91,7 @@ static int lsm6dso_enable_g_int(struct device *dev, int enable)
 	struct lsm6dso_data *lsm6dso = dev->driver_data;
 
 	if (enable) {
-		axis3bit16_t buf;
+		union axis3bit16_t buf;
 
 		/* dummy read: re-trigger interrupt */
 		lsm6dso_angular_rate_raw_get(lsm6dso->ctx, buf.u8bit);

--- a/drivers/sensor/stts751/stts751.c
+++ b/drivers/sensor/stts751/stts751.c
@@ -31,7 +31,7 @@ static int stts751_sample_fetch(struct device *dev,
 				enum sensor_channel chan)
 {
 	struct stts751_data *data = dev->driver_data;
-	axis1bit16_t raw_temp;
+	union axis1bit16_t raw_temp;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 

--- a/drivers/sensor/stts751/stts751.h
+++ b/drivers/sensor/stts751/stts751.h
@@ -19,6 +19,11 @@
 #include <sys/util.h>
 #include "stts751_reg.h"
 
+union axis1bit16_t {
+	s16_t i16bit;
+	u8_t u8bit[2];
+};
+
 struct stts751_config {
 	char *master_dev_name;
 	int (*bus_init)(struct device *dev);
@@ -35,10 +40,10 @@ struct stts751_data {
 	struct device *bus;
 	s16_t sample_temp;
 
-	stts751_ctx_t *ctx;
+	stmdev_ctx_t *ctx;
 
 #ifdef DT_ST_STTS751_BUS_I2C
-	stts751_ctx_t ctx_i2c;
+	stmdev_ctx_t ctx_i2c;
 #endif
 
 #ifdef CONFIG_STTS751_TRIGGER

--- a/drivers/sensor/stts751/stts751_i2c.c
+++ b/drivers/sensor/stts751/stts751_i2c.c
@@ -42,8 +42,8 @@ int stts751_i2c_init(struct device *dev)
 {
 	struct stts751_data *data = dev->driver_data;
 
-	data->ctx_i2c.read_reg = (stts751_read_ptr) stts751_i2c_read;
-	data->ctx_i2c.write_reg = (stts751_write_ptr) stts751_i2c_write;
+	data->ctx_i2c.read_reg = (stmdev_read_ptr) stts751_i2c_read;
+	data->ctx_i2c.write_reg = (stmdev_write_ptr) stts751_i2c_write;
 
 	data->ctx = &data->ctx_i2c;
 	data->ctx->handle = dev;

--- a/modules/Kconfig.st
+++ b/modules/Kconfig.st
@@ -13,6 +13,9 @@ if HAS_STMEMSC
 config USE_STDC_A3G4250D
 	bool
 
+config USE_STDC_AIS2DW12
+	bool
+
 config USE_STDC_AIS328DQ
 	bool
 
@@ -43,13 +46,22 @@ config USE_STDC_IIS328DQ
 config USE_STDC_IIS3DHHC
 	bool
 
+config USE_STDC_IIS3DWB
+	bool
+
 config USE_STDC_ISM303DAC
+	bool
+
+config USE_STDC_ISM330DHCX
 	bool
 
 config USE_STDC_ISM330DLC
 	bool
 
 config USE_STDC_L20G20IS
+	bool
+
+config USE_STDC_L3GD20H
 	bool
 
 config USE_STDC_LIS2DE12
@@ -59,6 +71,9 @@ config USE_STDC_LIS2DH12
 	bool
 
 config USE_STDC_LIS2DS12
+	bool
+
+config USE_STDC_LIS2DTW12
 	bool
 
 config USE_STDC_LIS2DW12
@@ -94,7 +109,13 @@ config USE_STDC_LPS22HH
 config USE_STDC_LPS25HB
 	bool
 
+config USE_STDC_LPS27HHW
+	bool
+
 config USE_STDC_LPS33HW
+	bool
+
+config USE_STDC_LPS33W
 	bool
 
 config USE_STDC_LSM303AGR
@@ -104,6 +125,9 @@ config USE_STDC_LSM303AH
 	bool
 
 config USE_STDC_LSM6DS3
+	bool
+
+config USE_STDC_LSM6DS3TR
 	bool
 
 config USE_STDC_LSM6DSL
@@ -116,6 +140,9 @@ config USE_STDC_LSM6DSO
 	bool
 
 config USE_STDC_LSM6DSOX
+	bool
+
+config USE_STDC_LSM6DSR
 	bool
 
 config USE_STDC_LSM9DS1

--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
       revision: 9151e614c23997074acd1096a3e8a9e5c255d5b9
       path: modules/hal/silabs
     - name: hal_st
-      revision: 0ec40aed8087f26bd9ac1b70fb5a6c326a6451aa
+      revision: fa481784b3c49780f18d50bafe00390ccb62b2ec
       path: modules/hal/st
     - name: hal_stm32
       revision: 41ae0cf14ca89fb0c934ebdb5d75e940f98af64a


### PR DESCRIPTION
The stmemsc HAL library is going to be upgraded to version v1.02 (see https://github.com/zephyrproject-rtos/hal_st/pull/3). Hence the ST sensor drivers that are currently using it has to be updated as well to align to API changes.

Sensor drivers impacted:

- IIS3DHHC
- LIS2MDL
- LIS2DW12
- LPS22HH
- LSM6DSO
- STTS751

This PR has been market as Do Not Merge (DNM) because it depends from the https://github.com/zephyrproject-rtos/hal_st/pull/3, which should be approved and merged first.
