### PR TITLE
Conn not connected

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1586,6 +1586,10 @@ int bt_gatt_notify_cb(struct bt_conn *conn,
 
 	attr = params->attr;
 
+	if (conn && conn->state != BT_CONN_CONNECTED) {
+		return -ENOTCONN;
+	}
+
 	handle = attr->handle ? : find_static_attr(attr);
 	if (!handle) {
 		return -ENOENT;
@@ -1643,6 +1647,10 @@ int bt_gatt_indicate(struct bt_conn *conn,
 	__ASSERT(params->attr, "invalid parameters\n");
 
 	attr = params->attr;
+
+	if (conn && conn->state != BT_CONN_CONNECTED) {
+		return -ENOTCONN;
+	}
 
 	handle = attr->handle ? : find_static_attr(attr);
 	if (!handle) {


### PR DESCRIPTION
Add API for application to check if connection is alive.
Return proper error code for notification or indication on a disconnected link.