### PR TITLE
kernel: timeout: remove unused callback parameter from init function

### DIFF
--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -22,7 +22,7 @@ extern "C" {
 
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 
-static inline void z_init_timeout(struct _timeout *t, _timeout_func_t fn)
+static inline void z_init_timeout(struct _timeout *t)
 {
 	sys_dnode_init(&t->node);
 }
@@ -38,7 +38,7 @@ static inline bool z_is_inactive_timeout(struct _timeout *t)
 
 static inline void z_init_thread_timeout(struct _thread_base *thread_base)
 {
-	z_init_timeout(&thread_base->timeout, NULL);
+	z_init_timeout(&thread_base->timeout);
 }
 
 extern void z_thread_timeout(struct _timeout *to);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -95,7 +95,7 @@ void k_timer_init(struct k_timer *timer,
 	timer->status = 0U;
 
 	z_waitq_init(&timer->wait_q);
-	z_init_timeout(&timer->timeout, z_timer_expiration_handler);
+	z_init_timeout(&timer->timeout);
 	SYS_TRACING_OBJ_INIT(k_timer, timer);
 
 	timer->user_data = NULL;

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -48,7 +48,7 @@ static void work_timeout(struct _timeout *t)
 void k_delayed_work_init(struct k_delayed_work *work, k_work_handler_t handler)
 {
 	k_work_init(&work->work, handler);
-	z_init_timeout(&work->timeout, work_timeout);
+	z_init_timeout(&work->timeout);
 	work->work_q = NULL;
 }
 

--- a/subsys/net/l2/canbus/6locan.c
+++ b/subsys/net/l2/canbus/6locan.c
@@ -279,7 +279,7 @@ static struct canbus_isotp_rx_ctx *canbus_get_rx_ctx(u8_t state,
 		if (ctx->state == state) {
 			if (state == NET_CAN_RX_STATE_UNUSED) {
 				ctx->state = NET_CAN_RX_STATE_RESET;
-				z_init_timeout(&ctx->timeout, canbus_rx_timeout);
+				z_init_timeout(&ctx->timeout);
 				ret = ctx;
 				break;
 			}
@@ -308,7 +308,7 @@ static struct canbus_isotp_tx_ctx *canbus_get_tx_ctx(u8_t state,
 		if (ctx->state == state) {
 			if (state == NET_CAN_TX_STATE_UNUSED) {
 				ctx->state = NET_CAN_TX_STATE_RESET;
-				z_init_timeout(&ctx->timeout, canbus_tx_timeout);
+				z_init_timeout(&ctx->timeout);
 				ret = ctx;
 				break;
 			}


### PR DESCRIPTION
The callback function has been ignored in z_timeout_init() since the
timer rework in fall 2018.  Passing real handlers to it in code is
distracting when they will be overridden by whatever callback is
provided in z_add_timeout().

As this function is an internal API deprecation is not necessary.
Remove the parameter and change all call sites to drop the argument.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>