### PR TITLE
cmake: -fmacro-prefix-map=${WEST_TOPDIR}=WEST_TOPDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,12 +333,14 @@ zephyr_cc_option_ifdef(CONFIG_STACK_USAGE            -fstack-usage)
 # in binaries, makes failure logs more deterministic and most
 # importantly makes builds more deterministic
 
-# If both match then the last one wins. This matters for tests/ and
-# samples/ inside *both* CMAKE_SOURCE_DIR and ZEPHYR_BASE: for them
-# let's strip the shortest prefix.
+# If several match then the last one wins. This matters for instances
+# like tests/ and samples/: they're inside all of them! Then let's
+# strip as little as possible.
 zephyr_cc_option(-fmacro-prefix-map=${CMAKE_SOURCE_DIR}=CMAKE_SOURCE_DIR)
 zephyr_cc_option(-fmacro-prefix-map=${ZEPHYR_BASE}=ZEPHYR_BASE)
-# TODO: -fmacro-prefix-map=modules/etc. "build/zephyr_modules.txt" might help.
+if(WEST_TOPDIR)
+  zephyr_cc_option(-fmacro-prefix-map=${WEST_TOPDIR}=WEST_TOPDIR)
+endif()
 
 # TODO: Archiver arguments
 # ar_option(D)

--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -43,6 +43,14 @@ else()
   # Just output information for a single version. This will still work
   # even after output is one line.
   message(STATUS "Found west: ${WEST} (found suitable version \"${west_version}\", minimum required is \"${MIN_WEST_VERSION}\")")
+
+  if (${west_version} VERSION_GREATER_EQUAL "0.7.0")
+    execute_process(
+      COMMAND ${WEST}  topdir
+      OUTPUT_VARIABLE  WEST_TOPDIR
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+  endif()
 endif()
 
 # Search for the must-have program dtc on PATH and in


### PR DESCRIPTION
Commit 28a5657f1ff6d and f67dcdbdf893a86 stopped ZEPHYR_BASE and
CMAKE_SOURCE_DIR from leaking into `__FILE__` and other macros.
WEST_TOPDIR was still missing. Add it now that the new 'west topdir'
command has been implemented in
https://github.com/zephyrproject-rtos/west/pull/311

If the west version is too old then do nothing; same as before.

Any ASSERT in a zephyr module outside ZEPHYR_BASE is enough to test
this. One example:
```
$ZEPHYR_BASE/sanitycheck -T $ZEPHYR_BASE/tests/posix/fs/ -p qemu_x86 -v

readelf --string-dump=.rodata.disk_status.str1.1 {} \
  $(find sanity-out -name zfs_diskio.c.obj | head -n 1)

String dump of section '.rodata.disk_status.str1.1':

  [     0]  WEST_TOPDIR/modules/fs/fatfs/zfs_diskio.c
  [    2a]  pdrv < ((long) (((int) sizeof(char[1 - 2 * !(!__built....
  [    de]  ASSERTION FAIL [%s] @ %s:%d^J
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>