### PR TITLE
kernel/idle: Correct SMP_FALLBACK define

### DIFF
--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -20,8 +20,11 @@
 #endif
 
 /* Fallback idle spin loop for SMP platforms without a working IPI */
-#define SMP_FALLBACK \
-	(defined(CONFIG_SMP) && !defined(CONFIG_SCHED_IPI_SUPPORTED))
+#if (defined(CONFIG_SMP) && !defined(CONFIG_SCHED_IPI_SUPPORTED))
+#define SMP_FALLBACK 1
+#else
+#define SMP_FALLBACK 0
+#endif
 
 #ifdef CONFIG_SYS_POWER_MANAGEMENT
 /*


### PR DESCRIPTION
Corrected the define of SMP_FALLBACK to prevent llvm warning.

llvm issues a warning as the behaviour of using defined(x) inside a
macro expansion is undefined (https://reviews.llvm.org/D15866).

```
zephyr/code/zephyr/kernel/idle.c:63:6: error: macro expansion producing 'defined' has undefined behavior [-Werror,-Wexpansion-to-defined]
#if !SMP_FALLBACK

```