### PR TITLE
include/tc_util.h: Rename __str to fix C++ compile error

### DIFF
--- a/subsys/testsuite/include/tc_util.h
+++ b/subsys/testsuite/include/tc_util.h
@@ -42,10 +42,10 @@
  *
  * TC_RUNID is any string, that will be converted to a string literal.
  */
-#define __str(x) #x
-#define _str(x) __str(x)
+#define TC_STR_HELPER(x) #x
+#define TC_STR(x) TC_STR_HELPER(x)
 #ifdef TC_RUNID
-#define TC_PRINT_RUNID PRINT_DATA("RunID: " _str(TC_RUNID) "\n")
+#define TC_PRINT_RUNID PRINT_DATA("RunID: " TC_STR(TC_RUNID) "\n")
 #else
 #define TC_PRINT_RUNID do {} while (0)
 #endif


### PR DESCRIPTION
Several C++ std library headers use __str as internal
variable names. If those headers are included after
tc_util.h is included those headers fail to compile
because tc_util.h defined __str to be a macro.

Fixed by renaming the __str macro to TC_STR.

Signed-off-by: Erwin Rol <erwin@erwinrol.com>