### PR TITLE
SYS_MEM_POOL_DEFINE(): move BUILD_ASSERT() at the end

### DIFF
--- a/include/sys/mempool.h
+++ b/include/sys/mempool.h
@@ -47,7 +47,6 @@ struct sys_mem_pool_block {
  * @param section Destination binary section for pool data
  */
 #define SYS_MEM_POOL_DEFINE(name, ignored, minsz, maxsz, nmax, align, section) \
-	BUILD_ASSERT(WB_UP(maxsz) >= _MPOOL_MINBLK);			\
 	char __aligned(WB_UP(align)) Z_GENERIC_SECTION(section)		\
 		_mpool_buf_##name[WB_UP(maxsz) * nmax			\
 				  + _MPOOL_BITS_SIZE(maxsz, minsz, nmax)]; \
@@ -62,7 +61,8 @@ struct sys_mem_pool_block {
 			.levels = _mpool_lvls_##name,			\
 			.flags = SYS_MEM_POOL_USER			\
 		}							\
-	}
+	};								\
+	BUILD_ASSERT(WB_UP(maxsz) >= _MPOOL_MINBLK)
 
 /**
  * @brief Initialize a memory pool


### PR DESCRIPTION
Similarly to commit 223a2b950fc9 ("mempool: move BUILD_ASSERT to the
end of K_MEM_POOL_DEFINE"), move BUILD_ASSERT() at the end for
consistency.