### PR TITLE
K_MEM_POOL_DEFINE(): remove extra semicolon

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4194,7 +4194,7 @@ struct k_mem_pool {
 			.flags = SYS_MEM_POOL_KERNEL			\
 		} \
 	}; \
-	BUILD_ASSERT(WB_UP(maxsz) >= _MPOOL_MINBLK);
+	BUILD_ASSERT(WB_UP(maxsz) >= _MPOOL_MINBLK)
 
 /**
  * @brief Allocate memory from a memory pool.


### PR DESCRIPTION
Commit 223a2b950fc9 ("mempool: move BUILD_ASSERT to the end of
K_MEM_POOL_DEFINE") left a redundant semicolon at the end.