### PR TITLE
ext: lib: tinycrypt: do not select entropy_generator

### DIFF
--- a/ext/lib/crypto/tinycrypt/Kconfig
+++ b/ext/lib/crypto/tinycrypt/Kconfig
@@ -42,7 +42,6 @@ config TINYCRYPT_SHA256_HMAC_PRNG
 config TINYCRYPT_ECC_DH
 	bool "ECC_DH anonymous key agreement protocol"
 	depends on TINYCRYPT
-	select ENTROPY_GENERATOR
 	help
 	  This option enables support for the Elliptic curve
 	  Diffie-Hellman anonymous key agreement protocol.
@@ -53,7 +52,6 @@ config TINYCRYPT_ECC_DH
 config TINYCRYPT_ECC_DSA
 	bool "ECC_DSA digital signature algorithm"
 	depends on TINYCRYPT
-	select ENTROPY_GENERATOR
 	help
 	  This option enables support for the Elliptic Curve Digital
 	  Signature Algorithm (ECDSA).


### PR DESCRIPTION
Tinycrypt ECC_DH and ECC_DSA are selecting the entropy generator, this
is not required. ECC_DH and ECC_DSA require a default_CSPRNG definition
that could be based on the entropy generator, but the entropy generator
does not provide this function.

Removing the entropy generator results in smaller code in case only
validation needs to be done (which does not need default_CSPRNG). The
modules that are providing the default_CSPRNG (e.g. subsys/jwt/jwt.c or
subsys/bluetooth/host/hci_ecc.c) are deciding themselves to use the
entropy generator or not.

Signed-off-by: Laczen JMS <laczenjms@gmail.com>