### PR TITLE
cmake: Move the invocation of 'project' earlier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,6 @@ endif()
 # For Zephyr more specifically this breaks (at least)
 #     -fmacro-prefix-map=${ZEPHYR_BASE}=
 
-project(Zephyr-Kernel VERSION ${PROJECT_VERSION})
-enable_language(C CXX ASM)
 
 # Verify that the toolchain can compile a dummy file, if it is not we
 # won't be able to test for compatibility with certain C flags.

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -470,6 +470,15 @@ endif()
 
 include(${ZEPHYR_BASE}/cmake/target_toolchain.cmake)
 
+project(Zephyr-Kernel VERSION ${PROJECT_VERSION})
+enable_language(C CXX ASM)
+
+# 'project' sets PROJECT_BINARY_DIR to ${CMAKE_CURRENT_BINARY_DIR},
+# but for legacy reasons we need it to be set to
+# ${CMAKE_CURRENT_BINARY_DIR}/zephyr
+set(PROJECT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/zephyr)
+set(PROJECT_SOURCE_DIR ${ZEPHYR_BASE})
+
 set(KERNEL_NAME ${CONFIG_KERNEL_BIN_NAME})
 
 set(KERNEL_ELF_NAME   ${KERNEL_NAME}.elf)


### PR DESCRIPTION
The CMake documentation for 'project' states "Call the project()
command near the top of the top-level CMakeLists.txt". Meaning, it
should be run as early as possible.

An obscure internal error was observed when 'project' was located in
zephyr/CMakeLists.txt and was observed to be fixed after moving
'project' earlier, hence this patch that moves it earlier.

Invoking project depends on knowing information about the toolchain so
it is placed after target_toolchain.cmake.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>