### PR TITLE
Bluetooth: Mesh: Friend enc failure

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -154,6 +154,19 @@ static inline void net_buf_simple_reset(struct net_buf_simple *buf)
 }
 
 /**
+ * Clone buffer state, using the same data buffer.
+ *
+ * Initializes a buffer to point to the same data as an existing buffer.
+ * Allows operations on the same data without altering the length and
+ * offset of the original.
+ *
+ * @param original Buffer to clone.
+ * @param clone The new clone.
+ */
+void net_buf_simple_clone(const struct net_buf_simple *original,
+			  struct net_buf_simple *clone);
+
+/**
  * @brief Prepare data to be added at the end of the buffer
  *
  * Increments the data length of a buffer to account for more data

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -35,6 +35,8 @@
 #define FRIEND_BUF_COUNT    ((CONFIG_BT_MESH_FRIEND_QUEUE_SIZE + 1) * \
 			     CONFIG_BT_MESH_FRIEND_LPN_COUNT)
 
+#define FRIEND_ADV(buf) CONTAINER_OF(BT_MESH_ADV(buf), struct friend_adv, adv)
+
 /* PDUs from Friend to the LPN should only be transmitted once with the
  * smallest possible interval (20ms).
  */
@@ -55,11 +57,15 @@ struct friend_pdu_info {
 NET_BUF_POOL_FIXED_DEFINE(friend_buf_pool, FRIEND_BUF_COUNT,
 			  BT_MESH_ADV_DATA_SIZE, NULL);
 
-static struct bt_mesh_adv adv_pool[FRIEND_BUF_COUNT];
+static struct friend_adv {
+	struct bt_mesh_adv adv;
+	u16_t app_idx;
+} adv_pool[FRIEND_BUF_COUNT];
 
 static struct bt_mesh_adv *adv_alloc(int id)
 {
-	return &adv_pool[id];
+	adv_pool[id].app_idx = BT_MESH_KEY_UNUSED;
+	return &adv_pool[id].adv;
 }
 
 static bool is_lpn_unicast(struct bt_mesh_friend *frnd, u16_t addr)
@@ -316,13 +322,122 @@ static struct net_buf *create_friend_pdu(struct bt_mesh_friend *frnd,
 	return buf;
 }
 
-static int encrypt_friend_pdu(struct bt_mesh_friend *frnd, struct net_buf *buf, bool master_cred)
+struct unseg_app_sdu_meta {
+	struct bt_mesh_net_rx net;
+	const u8_t *key;
+	struct bt_mesh_subnet *subnet;
+	bool is_dev_key;
+	u8_t aid;
+	u8_t *ad;
+};
+
+static int unseg_app_sdu_unpack(struct bt_mesh_friend *frnd,
+				struct net_buf *buf,
+				struct unseg_app_sdu_meta *meta)
+{
+	u16_t app_idx = FRIEND_ADV(buf)->app_idx;
+	int err;
+
+	meta->subnet = bt_mesh_subnet_get(frnd->net_idx);
+	meta->is_dev_key = (app_idx == BT_MESH_KEY_DEV);
+	bt_mesh_net_header_parse(&buf->b, &meta->net);
+	err = bt_mesh_app_key_get(meta->subnet, app_idx, &meta->key,
+				  &meta->aid);
+	if (err) {
+		return err;
+	}
+
+	if (BT_MESH_ADDR_IS_VIRTUAL(meta->net.ctx.recv_dst)) {
+		meta->ad = bt_mesh_label_uuid_get(meta->net.ctx.recv_dst);
+		if (!meta->ad) {
+			return -ENOENT;
+		}
+	} else {
+		meta->ad = NULL;
+	}
+
+	return 0;
+}
+
+static int unseg_app_sdu_decrypt(struct bt_mesh_friend *frnd,
+				 struct net_buf *buf,
+				 const struct unseg_app_sdu_meta *meta)
+{
+	struct net_buf_simple sdu = {
+		.len = buf->len - 14,
+		.data = &buf->data[10],
+		.__buf = &buf->data[10],
+		.size = buf->len - 10,
+	};
+
+	return bt_mesh_app_decrypt(meta->key, meta->is_dev_key, 0, &sdu, &sdu,
+				   meta->ad, meta->net.ctx.addr,
+				   meta->net.ctx.recv_dst, meta->net.seq,
+				   BT_MESH_NET_IVI_TX);
+}
+
+static int unseg_app_sdu_encrypt(struct bt_mesh_friend *frnd,
+				 struct net_buf *buf,
+				 const struct unseg_app_sdu_meta *meta)
+{
+	struct net_buf_simple sdu = {
+		.len = buf->len - 14,
+		.data = &buf->data[10],
+		.__buf = &buf->data[10],
+		.size = buf->len - 10,
+	};
+
+	return bt_mesh_app_encrypt(meta->key, meta->is_dev_key, 0, &sdu,
+				   meta->ad, meta->net.ctx.addr,
+				   meta->net.ctx.recv_dst, bt_mesh.seq,
+				   BT_MESH_NET_IVI_TX);
+}
+
+static int unseg_app_sdu_prepare(struct bt_mesh_friend *frnd,
+				 struct net_buf *buf)
+{
+	struct unseg_app_sdu_meta meta;
+	int err;
+
+	if (FRIEND_ADV(buf)->app_idx == BT_MESH_KEY_UNUSED) {
+		return 0;
+	}
+
+	err = unseg_app_sdu_unpack(frnd, buf, &meta);
+	if (err) {
+		return err;
+	}
+
+	/* No need to reencrypt the message if the sequence number is
+	 * unchanged.
+	 */
+	if (meta.net.seq == bt_mesh.seq) {
+		return 0;
+	}
+
+	err = unseg_app_sdu_decrypt(frnd, buf, &meta);
+	if (err) {
+		BT_WARN("Decryption failed! %d", err);
+		return err;
+	}
+
+	err = unseg_app_sdu_encrypt(frnd, buf, &meta);
+	if (err) {
+		BT_WARN("Re-encryption failed! %d", err);
+	}
+
+	return err;
+}
+
+static int encrypt_friend_pdu(struct bt_mesh_friend *frnd, struct net_buf *buf,
+			      bool master_cred)
 {
 	struct bt_mesh_subnet *sub = bt_mesh_subnet_get(frnd->net_idx);
 	const u8_t *enc, *priv;
 	u32_t iv_index;
 	u16_t src;
 	u8_t nid;
+	int err;
 
 	if (master_cred) {
 		enc = sub->keys[sub->kr_flag].enc;
@@ -338,12 +453,22 @@ static int encrypt_friend_pdu(struct bt_mesh_friend *frnd, struct net_buf *buf, 
 	src = sys_get_be16(&buf->data[5]);
 
 	if (bt_mesh_elem_find(src)) {
-		/* Local messages were stored with a blank seqnum */
-		u32_t seq = bt_mesh_next_seq();
+		u32_t seq;
+
+		if (FRIEND_ADV(buf)->app_idx != BT_MESH_KEY_UNUSED) {
+			err = unseg_app_sdu_prepare(frnd, buf);
+			if (err) {
+				return err;
+			}
+		}
+
+		seq = bt_mesh_next_seq();
 		buf->data[2] = seq >> 16;
 		buf->data[3] = seq >> 8;
 		buf->data[4] = seq;
+
 		iv_index = BT_MESH_NET_IVI_TX;
+		FRIEND_ADV(buf)->app_idx = BT_MESH_KEY_UNUSED;
 	} else {
 		u8_t ivi = (buf->data[0] >> 7);
 		iv_index = (bt_mesh.iv_index - ((bt_mesh.iv_index & 1) != ivi));
@@ -1207,7 +1332,9 @@ static void friend_lpn_enqueue_tx(struct bt_mesh_friend *frnd,
 	info.ttl = tx->ctx->send_ttl;
 	info.ctl = (tx->ctx->app_idx == BT_MESH_KEY_UNUSED);
 
-	memset(info.seq, 0, sizeof(info.seq)); /* Will be allocated before encryption */
+	info.seq[0] = (bt_mesh.seq >> 16);
+	info.seq[1] = (bt_mesh.seq >> 8);
+	info.seq[2] = bt_mesh.seq;
 
 	info.iv_index = BT_MESH_NET_IVI_TX;
 
@@ -1215,6 +1342,14 @@ static void friend_lpn_enqueue_tx(struct bt_mesh_friend *frnd,
 	if (!buf) {
 		BT_ERR("Failed to encode Friend buffer");
 		return;
+	}
+
+	if (type == BT_MESH_FRIEND_PDU_SINGLE && !info.ctl) {
+		/* Unsegmented application packets may be reencrypted later,
+		 * as they depend on the the sequence number being the same
+		 * when encrypting in transport and network.
+		 */
+		FRIEND_ADV(buf)->app_idx = tx->ctx->app_idx;
 	}
 
 	enqueue_friend_pdu(frnd, type, info.src, seg_count, buf);

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -363,12 +363,11 @@ static int unseg_app_sdu_decrypt(struct bt_mesh_friend *frnd,
 				 struct net_buf *buf,
 				 const struct unseg_app_sdu_meta *meta)
 {
-	struct net_buf_simple sdu = {
-		.len = buf->len - 14,
-		.data = &buf->data[10],
-		.__buf = &buf->data[10],
-		.size = buf->len - 10,
-	};
+	struct net_buf_simple sdu;
+
+	net_buf_simple_clone(&buf->b, &sdu);
+	net_buf_simple_pull(&sdu, 10);
+	sdu.len -= 4;
 
 	return bt_mesh_app_decrypt(meta->key, meta->is_dev_key, 0, &sdu, &sdu,
 				   meta->ad, meta->net.ctx.addr,
@@ -380,12 +379,11 @@ static int unseg_app_sdu_encrypt(struct bt_mesh_friend *frnd,
 				 struct net_buf *buf,
 				 const struct unseg_app_sdu_meta *meta)
 {
-	struct net_buf_simple sdu = {
-		.len = buf->len - 14,
-		.data = &buf->data[10],
-		.__buf = &buf->data[10],
-		.size = buf->len - 10,
-	};
+	struct net_buf_simple sdu;
+
+	net_buf_simple_clone(&buf->b, &sdu);
+	net_buf_simple_pull(&sdu, 10);
+	sdu.len -= 4;
 
 	return bt_mesh_app_encrypt(meta->key, meta->is_dev_key, 0, &sdu,
 				   meta->ad, meta->net.ctx.addr,

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -1276,6 +1276,14 @@ static void friend_lpn_enqueue_rx(struct bt_mesh_friend *frnd,
 	struct friend_pdu_info info;
 	struct net_buf *buf;
 
+	/* Because of network loopback, tx packets will also be passed into
+	 * this rx function. These packets have already been added to the
+	 * queue, and should be ignored.
+	 */
+	if (bt_mesh_elem_find(rx->ctx.addr)) {
+		return;
+	}
+
 	BT_DBG("LPN 0x%04x queue_size %u", frnd->lpn, frnd->queue_size);
 
 	if (type == BT_MESH_FRIEND_PDU_SINGLE && seq_auth) {

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -1233,6 +1233,17 @@ done:
 	net_buf_unref(buf);
 }
 
+void bt_mesh_net_header_parse(struct net_buf_simple *buf,
+			      struct bt_mesh_net_rx *rx)
+{
+	rx->old_iv = (IVI(buf->data) != (bt_mesh.iv_index & 0x01));
+	rx->ctl = CTL(buf->data);
+	rx->ctx.recv_ttl = TTL(buf->data);
+	rx->seq = SEQ(buf->data);
+	rx->ctx.addr = SRC(buf->data);
+	rx->ctx.recv_dst = DST(buf->data);
+}
+
 int bt_mesh_net_decode(struct net_buf_simple *data, enum bt_mesh_net_if net_if,
 		       struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 {

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -344,6 +344,8 @@ u32_t bt_mesh_next_seq(void);
 void bt_mesh_net_start(void);
 
 void bt_mesh_net_init(void);
+void bt_mesh_net_header_parse(struct net_buf_simple *buf,
+			      struct bt_mesh_net_rx *rx);
 
 /* Friendship Credential Management */
 struct friend_cred {

--- a/subsys/bluetooth/mesh/transport.h
+++ b/subsys/bluetooth/mesh/transport.h
@@ -97,3 +97,6 @@ void bt_mesh_trans_init(void);
 void bt_mesh_rpl_clear(void);
 
 void bt_mesh_heartbeat_send(void);
+
+int bt_mesh_app_key_get(const struct bt_mesh_subnet *subnet, u16_t app_idx,
+			const u8_t **key, u8_t *aid);

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -760,6 +760,12 @@ size_t net_buf_append_bytes(struct net_buf *buf, size_t len,
 #define NET_BUF_SIMPLE_ASSERT(cond)
 #endif /* CONFIG_NET_BUF_SIMPLE_LOG */
 
+void net_buf_simple_clone(const struct net_buf_simple *original,
+			  struct net_buf_simple *clone)
+{
+	memcpy(clone, original, sizeof(struct net_buf_simple));
+}
+
 void *net_buf_simple_add(struct net_buf_simple *buf, size_t len)
 {
 	u8_t *tail = net_buf_simple_tail(buf);


### PR DESCRIPTION
Re-encrypts single-segment application messages when the network seqnum has changed, to avoid encrypting messages with different seqnums in network and transport. This operation is only required for unsegmented messages, as segmented messages don't need to use the same seqnum in network.

Fixes #19265.