### PR TITLE
kernel: add arch abstraction for irq_offload()

### DIFF
--- a/arch/arc/core/irq_offload.c
+++ b/arch/arc/core/irq_offload.c
@@ -20,7 +20,7 @@ void z_irq_do_offload(void)
 	offload_routine(offload_param);
 }
 
-void irq_offload(irq_offload_routine_t routine, void *parameter)
+void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	unsigned int key;
 

--- a/arch/arm/core/irq_offload.c
+++ b/arch/arm/core/irq_offload.c
@@ -20,7 +20,7 @@ void z_irq_do_offload(void)
 	offload_routine(offload_param);
 }
 
-void irq_offload(irq_offload_routine_t routine, void *parameter)
+void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) && defined(CONFIG_ASSERT)
 	/* ARMv6-M/ARMv8-M Baseline HardFault if you make a SVC call with

--- a/arch/nios2/core/irq_offload.c
+++ b/arch/nios2/core/irq_offload.c
@@ -29,7 +29,7 @@ void z_irq_do_offload(void)
 	tmp((void *)offload_param);
 }
 
-void irq_offload(irq_offload_routine_t routine, void *parameter)
+void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	unsigned int key;
 

--- a/arch/riscv/core/irq_offload.c
+++ b/arch/riscv/core/irq_offload.c
@@ -31,7 +31,7 @@ void z_irq_do_offload(void)
 	tmp((void *)offload_param);
 }
 
-void irq_offload(irq_offload_routine_t routine, void *parameter)
+void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	unsigned int key;
 

--- a/arch/x86/core/ia32/irq_offload.c
+++ b/arch/x86/core/ia32/irq_offload.c
@@ -25,7 +25,7 @@ void z_irq_do_offload(void)
 	offload_routine(offload_param);
 }
 
-void irq_offload(irq_offload_routine_t routine, void *parameter)
+void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	unsigned int key;
 

--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -89,7 +89,7 @@ int z_arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 #ifdef CONFIG_IRQ_OFFLOAD
 #include <irq_offload.h>
 
-void irq_offload(irq_offload_routine_t routine, void *parameter)
+void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	u32_t key;
 

--- a/arch/x86_64/core/x86_64.c
+++ b/arch/x86_64/core/x86_64.c
@@ -107,7 +107,7 @@ static void irq_offload_handler(void *arg, int err)
 	offload_fn(offload_arg);
 }
 
-void irq_offload(irq_offload_routine_t fn, void *arg)
+void z_arch_irq_offload(irq_offload_routine_t fn, void *arg)
 {
 	offload_fn = fn;
 	offload_arg = arg;

--- a/arch/xtensa/core/irq_offload.c
+++ b/arch/xtensa/core/irq_offload.c
@@ -23,7 +23,7 @@ void z_irq_do_offload(void *unused)
 	offload_routine(offload_param);
 }
 
-void irq_offload(irq_offload_routine_t routine, void *parameter)
+void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	IRQ_CONNECT(CONFIG_IRQ_OFFLOAD_INTNUM, XCHAL_EXCM_LEVEL,
 		z_irq_do_offload, NULL, 0);

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -329,7 +329,7 @@ static void offload_sw_irq_handler(void *a)
  *
  * Raise the SW IRQ assigned to handled this
  */
-void irq_offload(irq_offload_routine_t routine, void *parameter)
+void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	off_routine = routine;
 	off_parameter = parameter;

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -393,7 +393,7 @@ static void offload_sw_irq_handler(void *a)
  *
  * Raise the SW IRQ assigned to handled this
  */
-void irq_offload(irq_offload_routine_t routine, void *parameter)
+void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	off_routine = routine;
 	off_parameter = parameter;

--- a/include/irq_offload.h
+++ b/include/irq_offload.h
@@ -17,6 +17,8 @@ extern "C" {
 
 typedef void (*irq_offload_routine_t)(void *parameter);
 
+void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter);
+
 /**
  * @brief Run a function in interrupt context
  *
@@ -29,7 +31,10 @@ typedef void (*irq_offload_routine_t)(void *parameter);
  * @param parameter Argument to pass to the function when it is run as an
  * interrupt
  */
-void irq_offload(irq_offload_routine_t routine, void *parameter);
+static inline void irq_offload(irq_offload_routine_t routine, void *parameter)
+{
+	z_arch_irq_offload(routine, parameter);
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This makes it clearer that this is an API that is expected
to be implemented at the architecture level.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>