### PR TITLE
doc: contribution guidelines: Specify roles and responsibilies

### DIFF
--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -761,3 +761,22 @@ Code component README template
 ==============================
 
 .. literalinclude:: code_component_README
+
+
+Contribution Roles and Responsibilities
+***************************************
+
+The Zephyr project defines a development process workflow using GitHub
+**Issues** to track feature, enhancement, and bug reports together with GitHub
+**Pull Requests** (PRs) for submitting and reviewing changes.  Zephyr
+community members work together to review these Issues and PRs, managing
+feature enhancements and quality improvements of Zephyr through its regular
+releases, as outlined in the
+`program management overview <https://wiki.zephyrproject.org/Program-Management>`_.
+
+We can only manage the volume of Issues and PRs, by requiring timely reviews,
+feedback, and responses from the community and contributors, both for initial
+submissions and for followup questions and clarifications.  Read about the
+project's :ref:`development processes and tools <dev-environment-and-tools>`
+and specifics about :ref:`review timelines <review_time>` to learn about the
+project's goals and guidelines for our active developer community.

--- a/doc/development_process/dev_env_and_tools.rst
+++ b/doc/development_process/dev_env_and_tools.rst
@@ -171,7 +171,7 @@ dismissed by the assignee or an owner of the repository. Reviews will be
 dismissed following the criteria below:
 
 - The feedback or concerns were visibly addressed by the author
-- The reviewer did not revisit the pull request after 1 week and multiple pings
+- The reviewer did not revisit the pull request after 2 week and multiple pings
   by the author
 - The review is unrelated to the code change or asking for unjustified
   structural changes such as:
@@ -190,8 +190,10 @@ Closing Stale Issues and Pull Requests
   Use the mailing lists for discussions.
 - In case of both issues and pull-requests the original poster needs to respond
   to questions and provide clarifications regarding the issue or the change.
-  Failing to do so, an issue or a pull request will be closed automatically
-  after 6 months.
+  After one week without a response to a request, a second attempt to elicit
+  a response from the contributor will be made. After one more week without a
+  response the item may be closed (draft and DNM tagged pull requests are
+  excluded).
 
 Continuous Integration
 ***********************


### PR DESCRIPTION
Clarify the roles and responsibilities of the Zephyr community
and contributors with respect to PRs, Bugs, and Features.

Signed-off-by: David Leach <david.leach@nxp.com>

As usual, the "live" output of this change is here: https://builds.zephyrproject.org/zephyrproject-rtos/zephyr/19498/docs/contribute/index.html (scroll to the bottom)