### PR TITLE
Bluetooth: Mesh: Persistent storage of Virtual Addresses

### DIFF
--- a/include/bluetooth/mesh/cfg_srv.h
+++ b/include/bluetooth/mesh/cfg_srv.h
@@ -60,17 +60,6 @@ struct bt_mesh_cfg_srv {
 	} hb_sub;
 };
 
-enum{
-	BT_MESH_VA_CHANGED	/* Label information changed */
-}
-
-static struct label {
-	u16_t ref;
-	u16_t addr;
-	u8_t  uuid[16];
-	atomic_t flag[1];
-};
-
 extern const struct bt_mesh_model_op bt_mesh_cfg_srv_op[];
 extern const struct bt_mesh_model_cb bt_mesh_cfg_srv_cb;
 

--- a/include/bluetooth/mesh/cfg_srv.h
+++ b/include/bluetooth/mesh/cfg_srv.h
@@ -60,6 +60,17 @@ struct bt_mesh_cfg_srv {
 	} hb_sub;
 };
 
+enum{
+	BT_MESH_VA_CHANGED	/* Label information changed */
+}
+
+static struct label {
+	u16_t ref;
+	u16_t addr;
+	u8_t  uuid[16];
+	atomic_t flag[1];
+};
+
 extern const struct bt_mesh_model_op bt_mesh_cfg_srv_op[];
 extern const struct bt_mesh_model_cb bt_mesh_cfg_srv_cb;
 

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -1108,7 +1108,7 @@ void va_get_loop(void (*func)(u16_t index, struct label *l))
 struct label *va_alloc(u16_t index)
 {
 	if(index < ARRAY_SIZE(labels)) {
-		return labels[index];
+		return &labels[index];
 	}
 	
 	return NULL;

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -1096,26 +1096,21 @@ send_status:
 			    status, mod_id);
 }
 
-void va_get_loop(void (*func)(struct label *l))
+void va_get_loop(void (*func)(u16_t index, struct label *l))
 {
-	int i;
+	u16_t i;
 
 	for (i = 0; i < ARRAY_SIZE(labels); i++) {
-		func(&labels[i]);
+		func(i, &labels[i]);
 	}
 }
 
-struct label *va_alloc(void)
+struct label *va_alloc(u16_t index)
 {
-#if CONFIG_BT_MESH_LABEL_COUNT > 0
-	int i;
-
-	for (i = 0; i < ARRAY_SIZE(labels); i++) {
-		if (!labels[i].ref) {
-			return &labels[i];
-		}
+	if(index < ARRAY_SIZE(labels)) {
+		return labels[index];
 	}
-#endif
+	
 	return NULL;
 }
 

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -1098,13 +1098,11 @@ send_status:
 
 void va_get_loop(void (*func)(struct label *l))
 {
-#if CONFIG_BT_MESH_LABEL_COUNT > 0
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(labels); i++) {
 		func(&labels[i]);
 	}
-#endif
 }
 
 struct label *va_alloc(void)
@@ -1129,12 +1127,6 @@ static u8_t va_add(u8_t *label_uuid, u16_t *addr)
 
 	for (i = 0; i < ARRAY_SIZE(labels); i++) {
 		if (!labels[i].ref) {
-
-			if (IS_ENABLED(CONFIG_BT_SETTINGS) &&
-			    atomic_test_and_clear_bit(free_slot->flag, BT_MESH_VA_CHANGED)) {
-				bt_mesh_clear_va(&labels[i]);
-			}
-
 			free_slot = &labels[i];
 			continue;
 		}
@@ -1142,7 +1134,7 @@ static u8_t va_add(u8_t *label_uuid, u16_t *addr)
 		if (!memcmp(labels[i].uuid, label_uuid, 16)) {
 			*addr = labels[i].addr;
 			labels[i].ref++;
-			atomic_set_bit(free_slot->flag, BT_MESH_VA_CHANGED);
+			atomic_set_bit(labels[i]->flag, BT_MESH_VA_CHANGED);
 
 			if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 				bt_mesh_store_va();
@@ -1182,7 +1174,7 @@ static u8_t va_del(u8_t *label_uuid, u16_t *addr)
 			}
 
 			labels[i].ref--;
-			atomic_set_bit(free_slot->flag, BT_MESH_VA_CHANGED);
+			atomic_set_bit(labels[i]->flag, BT_MESH_VA_CHANGED);
 
 			if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 				bt_mesh_store_va();

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -41,11 +41,7 @@
 
 static struct bt_mesh_cfg_srv *conf;
 
-static struct label {
-	u16_t ref;
-	u16_t addr;
-	u8_t  uuid[16];
-} labels[CONFIG_BT_MESH_LABEL_COUNT];
+static struct label labels[CONFIG_BT_MESH_LABEL_COUNT];
 
 static int comp_add_elem(struct net_buf_simple *buf, struct bt_mesh_elem *elem,
 			 bool primary)
@@ -1100,6 +1096,31 @@ send_status:
 			    status, mod_id);
 }
 
+void va_get_loop(void (*func)(struct label *l))
+{
+#if CONFIG_BT_MESH_LABEL_COUNT > 0
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(labels); i++) {
+		func(&labels[i]);
+	}
+#endif
+}
+
+struct label *va_alloc(void)
+{
+#if CONFIG_BT_MESH_LABEL_COUNT > 0
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(labels); i++) {
+		if (!labels[i].ref) {
+			return &labels[i];
+		}
+	}
+#endif
+	return NULL;
+}
+
 #if CONFIG_BT_MESH_LABEL_COUNT > 0
 static u8_t va_add(u8_t *label_uuid, u16_t *addr)
 {
@@ -1108,6 +1129,12 @@ static u8_t va_add(u8_t *label_uuid, u16_t *addr)
 
 	for (i = 0; i < ARRAY_SIZE(labels); i++) {
 		if (!labels[i].ref) {
+
+			if (IS_ENABLED(CONFIG_BT_SETTINGS) &&
+			    atomic_test_and_clear_bit(free_slot->flag, BT_MESH_VA_CHANGED)) {
+				bt_mesh_clear_va(&labels[i]);
+			}
+
 			free_slot = &labels[i];
 			continue;
 		}
@@ -1115,6 +1142,11 @@ static u8_t va_add(u8_t *label_uuid, u16_t *addr)
 		if (!memcmp(labels[i].uuid, label_uuid, 16)) {
 			*addr = labels[i].addr;
 			labels[i].ref++;
+			atomic_set_bit(free_slot->flag, BT_MESH_VA_CHANGED);
+
+			if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+				bt_mesh_store_va();
+			}
 			return STATUS_SUCCESS;
 		}
 	}
@@ -1130,6 +1162,11 @@ static u8_t va_add(u8_t *label_uuid, u16_t *addr)
 	free_slot->ref = 1U;
 	free_slot->addr = *addr;
 	memcpy(free_slot->uuid, label_uuid, 16);
+	atomic_set_bit(free_slot->flag, BT_MESH_VA_CHANGED);
+
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		bt_mesh_store_va();
+	}
 
 	return STATUS_SUCCESS;
 }
@@ -1145,6 +1182,11 @@ static u8_t va_del(u8_t *label_uuid, u16_t *addr)
 			}
 
 			labels[i].ref--;
+			atomic_set_bit(free_slot->flag, BT_MESH_VA_CHANGED);
+
+			if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+				bt_mesh_store_va();
+			}
 			return STATUS_SUCCESS;
 		}
 	}

--- a/subsys/bluetooth/mesh/foundation.h
+++ b/subsys/bluetooth/mesh/foundation.h
@@ -143,8 +143,8 @@ u8_t bt_mesh_beacon_get(void);
 u8_t bt_mesh_gatt_proxy_get(void);
 u8_t bt_mesh_default_ttl_get(void);
 
-void va_get_loop(void (*func)(struct label *l));
-struct label *va_alloc(void);
+void va_get_loop(void (*func)(u16_t index, struct label *l));
+struct label *va_alloc(u16_t index);
 
 void bt_mesh_subnet_del(struct bt_mesh_subnet *sub, bool store);
 

--- a/subsys/bluetooth/mesh/foundation.h
+++ b/subsys/bluetooth/mesh/foundation.h
@@ -132,6 +132,9 @@ u8_t bt_mesh_beacon_get(void);
 u8_t bt_mesh_gatt_proxy_get(void);
 u8_t bt_mesh_default_ttl_get(void);
 
+void va_get_loop(void (*func)(struct label *l));
+struct label *va_alloc(void);
+
 void bt_mesh_subnet_del(struct bt_mesh_subnet *sub, bool store);
 
 struct bt_mesh_app_key *bt_mesh_app_key_alloc(u16_t app_idx);

--- a/subsys/bluetooth/mesh/foundation.h
+++ b/subsys/bluetooth/mesh/foundation.h
@@ -112,6 +112,17 @@
 #define STATUS_UNSPECIFIED                 0x10
 #define STATUS_INVALID_BINDING             0x11
 
+enum label_flag{
+	BT_MESH_VA_CHANGED,	/* Label information changed */
+};
+
+struct label {
+	u16_t ref;
+	u16_t addr;
+	u8_t  uuid[16];
+	atomic_t flag[1];
+};
+
 void bt_mesh_cfg_reset(void);
 
 void bt_mesh_heartbeat(u16_t src, u16_t dst, u8_t hops, u16_t feat);

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -216,6 +216,9 @@ enum {
 	BT_MESH_CFG_PENDING,
 	BT_MESH_MOD_PENDING,
 
+#if CONFIG_BT_MESH_LABEL_COUNT > 0
+	BLE_MESH_VA_PENDING,
+#endif
 	/* Don't touch - intentionally last */
 	BT_MESH_FLAG_COUNT,
 };

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -697,10 +697,18 @@ static int va_set(const char *name, size_t len_rd,
 {
 	struct va_val labels;
 	struct label *l;
+	u16_t index;
 	int err;
-
+	
+	if (!name) {
+		BT_ERR("Insufficient number of arguments");
+		return -ENOENT;
+	}
+	
+	index = strtol(name, NULL, 16);
+	
 	if (len_rd == 0) {
-		BT_WARN("Mesh Vritual Address length = 0");
+		BT_WARN("Mesh Virtual Address length = 0");
 		return 0;
 	}
 
@@ -715,7 +723,7 @@ static int va_set(const char *name, size_t len_rd,
 		return 0;
 	}
 
-	l = va_alloc();
+	l = va_alloc(index);
 	if (l != NULL) {
 		memcpy(&l->uuid, &labels.uuid, 16);
 		l->addr = labels.addr;
@@ -1401,13 +1409,13 @@ static void store_pending_mod(struct bt_mesh_model *mod,
 	}
 }
 
-void bt_mesh_clear_va(struct label *l)
+void bt_mesh_clear_va(u16_t index, struct label *l)
 {
 #if CONFIG_BT_MESH_LABEL_COUNT > 0
 	char path[20];
 	int err;
 
-	snprintk(path, sizeof(path), "bt/mesh/Va/%x", l->addr);
+	snprintk(path, sizeof(path), "bt/mesh/Va/%x", index);
 	err = settings_delete(path);
 
 	if (err) {
@@ -1419,7 +1427,7 @@ void bt_mesh_clear_va(struct label *l)
 }
 
 #if CONFIG_BT_MESH_LABEL_COUNT > 0
-static void store_pending_va(struct label *l)
+static void store_pending_va(u16_t index, struct label *l)
 {
 	struct va_val label;
 	char path[20];
@@ -1429,12 +1437,12 @@ static void store_pending_va(struct label *l)
 		return;
 	}
 
-	if (lab->ref == 0) {
-		bt_mesh_clear_va(lab);
+	if (l->ref == 0) {
+		bt_mesh_clear_va(index, l);
 		return;
 	}
 
-	snprintk(path, sizeof(path), "bt/mesh/Va/%x", l->addr);
+	snprintk(path, sizeof(path), "bt/mesh/Va/%x", index);
 
 	label.ref = l->ref;
 	label.addr = l->addr;

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -730,7 +730,7 @@ static int va_set(const char *name, size_t len_rd,
 		l->ref = labels.ref;
 	} else {
 		BT_WARN("Insufficient numbers of lables");
-		return;
+		return -ENOENT;
 	}
 
 	BT_DBG("Restored Virtual Address, addr 0x%04x ref 0x%03x",

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -728,6 +728,9 @@ static int va_set(const char *name, size_t len_rd,
 		memcpy(&l->uuid, &labels.uuid, 16);
 		l->addr = labels.addr;
 		l->ref = labels.ref;
+	} else {
+		BT_WARN("Insufficient numbers of lables");
+		return;
 	}
 
 	BT_DBG("Restored Virtual Address, addr 0x%04x ref 0x%03x",

--- a/subsys/bluetooth/mesh/settings.h
+++ b/subsys/bluetooth/mesh/settings.h
@@ -22,6 +22,6 @@ void bt_mesh_clear_app_key(struct bt_mesh_app_key *key);
 void bt_mesh_clear_rpl(void);
 
 void bt_mesh_store_va(void);
-void bt_mesh_clear_va(struct label *l);
+void bt_mesh_clear_va(u16_t index, struct label *l);
 
 void bt_mesh_settings_init(void);

--- a/subsys/bluetooth/mesh/settings.h
+++ b/subsys/bluetooth/mesh/settings.h
@@ -21,4 +21,7 @@ void bt_mesh_clear_subnet(struct bt_mesh_subnet *sub);
 void bt_mesh_clear_app_key(struct bt_mesh_app_key *key);
 void bt_mesh_clear_rpl(void);
 
+void bt_mesh_store_va(void);
+void bt_mesh_clear_va(struct label *l);
+
 void bt_mesh_settings_init(void);


### PR DESCRIPTION
The 16-bit format group addresses will be stored,
but we don't store (or restore) the virtual label UUIDs,
i.e. after a power cycle the 16-bit group addresses
would be meaningless.

Fixed zephyrproject-rtos#19342

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>