### PR TITLE
Bluetooth: GATT: Persist Service Changed data

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -563,7 +563,6 @@ struct bt_gatt_ccc_cfg {
 	u8_t                    id;
 	bt_addr_le_t		peer;
 	u16_t			value;
-	u8_t			data[4] __aligned(4);
 };
 
 /* Internal representation of CCC value */

--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -37,16 +37,23 @@ config BT_ATT_TX_MAX
 	  amount the calls will block until an existing queued PDU gets
 	  sent.
 
+config BT_GATT_SERVICE_CHANGED
+	bool "GATT Service Changed support"
+	default y
+	help
+	  This option enables support for the service changed characteristic.
+
 config BT_GATT_DYNAMIC_DB
 	bool "GATT dynamic database support"
 	default n
+	depends on BT_GATT_SERVICE_CHANGED
 	help
 	  This option enables registering/unregistering services at runtime.
 
 config BT_GATT_CACHING
 	bool "GATT Caching support"
 	default y
-	depends on BT_GATT_DYNAMIC_DB
+	depends on BT_GATT_SERVICE_CHANGED
 	select TINYCRYPT
 	select TINYCRYPT_AES
 	select TINYCRYPT_AES_CMAC


### PR DESCRIPTION
Fixes #19284.

Add support for persisted Service Changed data, to fix the case of a
paired device not reconnecting before a reboot and thus not receiving
SC indication. It also enables support for GATT database being changed
during a firmware update.

- Add a BT_GATT_SERVICE_CHANGED config option to enable SC support. Both
BT_GATT_CACHING and BT_GATT_DYNAMIC_DB depend on this new parameter.

- Move Service Changed data outside of the CCC struct and make it
persistent by adding support for a "bt/sc/..." setting.

Signed-off-by: François Delawarde <fnde@oticon.com>