### PR TITLE
subsys/settings: Remove optional from Kconfig

### DIFF
--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -45,7 +45,6 @@ config SETTINGS_USE_BASE64
 
 choice
 	prompt "Storage back-end"
-	optional
 	default SETTINGS_FCB if FCB
 	default SETTINGS_NONE
 	depends on SETTINGS


### PR DESCRIPTION
Kconfig does not set SETTINGS_NONE as default backend (meaning no
backend) because SETTINGS_NONE is optional. There is no difference
between SETTINGS_NONE and SETTINGS_CUSTOM. By removing the optional line
SETTINGS_NONE is selected as default, to use a custom backend
SETTINGS_CUSTOM=y must be set.

Signed-off-by: Laczen JMS <laczenjms@gmail.com>