### PR TITLE
usb: Remove extra logs

### DIFF
--- a/subsys/usb/bos.c
+++ b/subsys/usb/bos.c
@@ -55,9 +55,8 @@ void usb_bos_register_cap(struct usb_bos_platform_descriptor *desc)
 int usb_handle_bos(struct usb_setup_packet *setup,
 		   s32_t *len, u8_t **data)
 {
-	LOG_DBG("wValue 0x%x", setup->wValue);
-
 	if (GET_DESC_TYPE(setup->wValue) == DESCRIPTOR_TYPE_BOS) {
+		LOG_DBG("Read BOS descriptor");
 		*data = (u8_t *)usb_bos_get_header();
 		*len = usb_bos_get_length();
 

--- a/subsys/usb/os_desc.c
+++ b/subsys/usb/os_desc.c
@@ -18,8 +18,6 @@ static struct usb_os_descriptor *os_desc;
 int usb_handle_os_desc(struct usb_setup_packet *setup,
 		       s32_t *len, u8_t **data)
 {
-	LOG_DBG("wValue 0x%x", setup->wValue);
-
 	if (!os_desc) {
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
usb_handle_bos() and usb_handle_os_desc() are got invoked from
usb_handle_standard_request(), remove those unneeded logs.
