### PR TITLE
[v1.14-branch] doc: relnotes: Add QDID for Controller

### DIFF
--- a/doc/releases/release-notes-1.14.rst
+++ b/doc/releases/release-notes-1.14.rst
@@ -28,7 +28,7 @@ Bluetooth
 
   * 1.14.x Host subsystem qualified with QDID 95152
   * 1.14.x Mesh subsystem qualified with QDID 95153
-  * 1.14.x Controller subsystem qualified on Nordic nRF52 with QDID <TBD>
+  * 1.14.x Controller component qualified on Nordic nRF52 with QDID 135679
 
 Zephyr Kernel 1.14.0
 ####################

--- a/doc/releases/release-notes-1.14.rst
+++ b/doc/releases/release-notes-1.14.rst
@@ -26,8 +26,8 @@ Bluetooth
 
 * Qualification:
 
-  * 1.14.x Host subsystem qualified with QDID 95152
-  * 1.14.x Mesh subsystem qualified with QDID 95153
+  * 1.14.x Host subsystem qualified with QDID 139258
+  * 1.14.x Mesh subsystem qualified with QDID 139259
   * 1.14.x Controller component qualified on Nordic nRF52 with QDID 135679
 
 Zephyr Kernel 1.14.0


### PR DESCRIPTION
Now that the Controller has its own QDID, add it to the release notes.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>