### PR TITLE
doc: bluetooth: Add 1.14 qualification listings

### DIFF
--- a/doc/guides/bluetooth/bluetooth-qual.rst
+++ b/doc/guides/bluetooth/bluetooth-qual.rst
@@ -20,9 +20,27 @@ Host qualifications
      - Link
      - Qualifying Company
 
+   * - 1.14.x
+     - `QDID 139258 <https://launchstudio.bluetooth.com/ListingDetails/95152>`__
+     - The Linux Foundation
+
    * - 1.13
      - `QDID 119517 <https://launchstudio.bluetooth.com/ListingDetails/70189>`__
      - Nordic
+
+Mesh qualifications
+===================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Zephyr version
+     - Link
+     - Qualifying Company
+
+   * - 1.14.x
+     - `QDID 139259 <https://launchstudio.bluetooth.com/ListingDetails/95153>`__
+     - The Linux Foundation
 
 Controller qualifications
 =========================
@@ -34,6 +52,11 @@ Controller qualifications
      - Link
      - Qualifying Company
      - Compatible Hardware
+
+   * - 1.14.x
+     - `QDID 135679 <https://launchstudio.bluetooth.com/ListingDetails/90777>`__
+     - Nordic
+     - nRF52x
 
    * - 1.9 to 1.13
      - `QDID 101395 <https://launchstudio.bluetooth.com/ListingDetails/25166>`__


### PR DESCRIPTION
Add the 3 new listings obtained in the 1.14.x LTS release.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>