### PR TITLE
cmake: Fix usb include directory organization

### DIFF
--- a/subsys/usb/CMakeLists.txt
+++ b/subsys/usb/CMakeLists.txt
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_USB_DEVICE_STACK)
+  zephyr_include_directories(${ZEPHYR_BASE}/subsys/usb)
+
   zephyr_sources(
     usb_device.c
     usb_descriptor.c

--- a/subsys/usb/class/CMakeLists.txt
+++ b/subsys/usb/class/CMakeLists.txt
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/usb)
-
 zephyr_sources_ifdef(CONFIG_USB_CDC_ACM cdc_acm.c)
 zephyr_sources_ifdef(CONFIG_USB_MASS_STORAGE mass_storage.c)
 zephyr_sources_ifdef(CONFIG_USB_DEVICE_BLUETOOTH bluetooth.c)


### PR DESCRIPTION
There are two problems with how zephyr/subsys/usb is being added to
the include path. Firstly it is using the zephyr_library_ API to
modify the zephyr library, when the zephyr_ API should have been used.

Secondly the code is located in the class directory even though it
affects the more general usb directory.

This patch fixes these issues. Using zephyr_library_ in this instance
works by accident when 'zephyr' is the current library but has not
guarantees of working in the future.

The intent of the code is not clear, it could be that it is intended for the include
directory to only be modified for the subsys/usb code, if so this patch is not correct.
It is assumed that the intention is to modify the include directory globally (which matches
most closely with the written code, albeit not exactly).