### PR TITLE
cmake: Cleanup ethernet include directory handling

### DIFF
--- a/drivers/ethernet/CMakeLists.txt
+++ b/drivers/ethernet/CMakeLists.txt
@@ -1,27 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/l2)
+zephyr_include_directories(${ZEPHYR_BASE}/subsys/net/l2)
 
 zephyr_sources_ifdef(CONFIG_ETH_SAM_GMAC
 	eth_sam_gmac.c
 	phy_sam_gmac.c
 	)
 
-zephyr_sources_ifdef(CONFIG_ETH_STELLARIS	eth_stellaris.c)
-zephyr_sources_ifdef(CONFIG_ETH_E1000		eth_e1000.c)
-zephyr_sources_ifdef(CONFIG_ETH_ENC28J60	eth_enc28j60.c)
-zephyr_sources_ifdef(CONFIG_ETH_ENC424J600	eth_enc424j600.c)
-zephyr_sources_ifdef(CONFIG_ETH_MCUX		eth_mcux.c)
-zephyr_sources_ifdef(CONFIG_ETH_SMSC911X	eth_smsc911x.c)
-zephyr_sources_ifdef(CONFIG_ETH_STM32_HAL	eth_stm32_hal.c)
-zephyr_sources_ifdef(CONFIG_ETH_LITEETH		eth_liteeth.c)
+zephyr_sources_ifdef(CONFIG_ETH_STELLARIS	 eth_stellaris.c)
+zephyr_sources_ifdef(CONFIG_ETH_E1000		   eth_e1000.c)
+zephyr_sources_ifdef(CONFIG_ETH_ENC28J60	 eth_enc28j60.c)
+zephyr_sources_ifdef(CONFIG_ETH_ENC424J600 eth_enc424j600.c)
+zephyr_sources_ifdef(CONFIG_ETH_MCUX		   eth_mcux.c)
+zephyr_sources_ifdef(CONFIG_ETH_SMSC911X	 eth_smsc911x.c)
+zephyr_sources_ifdef(CONFIG_ETH_STM32_HAL	 eth_stm32_hal.c)
+zephyr_sources_ifdef(CONFIG_ETH_LITEETH		 eth_liteeth.c)
 
 if(CONFIG_ETH_NATIVE_POSIX)
 	zephyr_library()
-	zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/l2)
-	zephyr_library_compile_definitions(NO_POSIX_CHEATS)
-	zephyr_library_compile_definitions(_BSD_SOURCE)
-	zephyr_library_compile_definitions(_DEFAULT_SOURCE)
+	zephyr_library_compile_definitions(
+    NO_POSIX_CHEATS
+    _BSD_SOURCE
+    _DEFAULT_SOURCE
+    )
 	zephyr_library_sources(
 		eth_native_posix.c
 		eth_native_posix_adapt.c


### PR DESCRIPTION
The zephyr/subsys/net/l2 include directory has been added through the
'zephyr_library_' API to modify the 'zephyr' library, when the
'zephyr_' API should have been used.

This patch fixes this problem. Using 'zephyr_library_' in this context
works by accident when 'zephyr' is the current library but has no
guarantees of working in the future.

Also clean up some whitespace issues.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>