### PR TITLE
kernel: remove vestigal printk references

### DIFF
--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -6,7 +6,6 @@
 
 #include <kernel.h>
 #include <kernel_internal.h>
-#include <sys/printk.h>
 #include <sys/__assert.h>
 #include <arch/cpu.h>
 #include <logging/log_ctrl.h>
@@ -96,7 +95,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	 * See #17656
 	 *
 	 * if (k_is_in_isr()) {
-	 *     printk("Fault during interrupt handling\n");
+	 *     LOG_ERR("Fault during interrupt handling\n");
 	 * }
 	 */
 

--- a/kernel/include/syscall_handler.h
+++ b/kernel/include/syscall_handler.h
@@ -12,7 +12,6 @@
 
 #ifndef _ASMLANGUAGE
 #include <kernel.h>
-#include <sys/printk.h>
 #include <sys/math_extras.h>
 #include <kernel_internal.h>
 #include <kernel_structs.h>
@@ -404,7 +403,7 @@ static inline int z_obj_validation_check(struct _k_object *ko,
 
 	ret = z_object_validate(ko, otype, init);
 
-#ifdef CONFIG_PRINTK
+#ifdef CONFIG_LOG
 	if (ret != 0) {
 		z_dump_object_error(ret, obj, ko, otype);
 	}

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -18,7 +18,6 @@
 
 #include <spinlock.h>
 #include <kernel_structs.h>
-#include <sys/printk.h>
 #include <sys/math_extras.h>
 #include <sys_clock.h>
 #include <drivers/timer/system_timer.h>

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -66,7 +66,7 @@ const char *otype_to_str(enum k_objects otype)
 	 * GCC and these literal strings would appear in the binary even if
 	 * otype_to_str was omitted by the linker
 	 */
-#ifdef CONFIG_PRINTK
+#ifdef CONFIG_LOG
 	switch (otype) {
 	/* otype-to-str.h is generated automatically during build by
 	 * gen_kobject_list.py

--- a/kernel/userspace_handler.c
+++ b/kernel/userspace_handler.c
@@ -20,7 +20,7 @@ static struct _k_object *validate_any_object(void *obj)
 	 */
 	ret = z_object_validate(ko, K_OBJ_ANY, _OBJ_INIT_ANY);
 	if (ret != 0) {
-#ifdef CONFIG_PRINTK
+#ifdef CONFIG_LOG
 		z_dump_object_error(ret, obj, ko, K_OBJ_ANY);
 #endif
 		return NULL;


### PR DESCRIPTION
Logging is now used for these situations.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>