### PR TITLE
x86: fix EXCEPTION_DEBUG dependency

### DIFF
--- a/arch/x86/core/Kconfig.ia32
+++ b/arch/x86/core/Kconfig.ia32
@@ -14,7 +14,7 @@ config NESTED_INTERRUPTS
 config EXCEPTION_DEBUG
 	bool "Unhandled exception debugging"
 	default y
-	depends on PRINTK
+	depends on LOG
 	help
 	  Install handlers for various CPU exception/trap vectors to
 	  make debugging them easier, at a small expense in code size.


### PR DESCRIPTION
This requires logging, not printk.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>