### PR TITLE
tests: gui: lvgl: Pass image pointer to fs_write

### DIFF
--- a/tests/lib/gui/lvgl/src/main.c
+++ b/tests/lib/gui/lvgl/src/main.c
@@ -112,7 +112,7 @@ void setup_fs(void)
 		return;
 	}
 
-	ret = fs_write(&img, &c_img->data, c_img->data_size);
+	ret = fs_write(&img, c_img->data, c_img->data_size);
 	if (ret < 0) {
 		TC_PRINT("Failed to write image file data: %d\n", ret);
 		ztest_test_fail();


### PR DESCRIPTION
Pass image pointer to fs_write in function setup_fs of lvgl tests instead of pointer to
struct member.
