### PR TITLE
Initialize tcp6_handler_in_use for IPv6 in echo server sample

### DIFF
--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -325,7 +325,7 @@ void start_tcp(void)
 		tcp4_handler_in_use[i] = false;
 #endif
 #if defined(CONFIG_NET_IPV6)
-		tcp4_handler_in_use[i] = false;
+		tcp6_handler_in_use[i] = false;
 #endif
 	}
 


### PR DESCRIPTION
Initialize tcp6_handler_in_use instead of tcp4_handler_in_use for IPv6
in start_tcp of echo server sample.