### PR TITLE
tests/subsys/settings/functional: make common code a zephyr_library()

### DIFF
--- a/tests/subsys/settings/functional/fcb/CMakeLists.txt
+++ b/tests/subsys/settings/functional/fcb/CMakeLists.txt
@@ -4,12 +4,17 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-FILE(GLOB app_sources ../src/*.c)
-target_sources(app PRIVATE ${app_sources})
+
 zephyr_include_directories(
 	$ENV{ZEPHYR_BASE}/subsys/settings/include
 	$ENV{ZEPHYR_BASE}/subsys/settings/src
 	)
+
+# The code is in the library common to several tests.
+target_sources(app PRIVATE placeholder.c)
+
+add_subdirectory(../src func_test_bindir)
+target_link_libraries(app PRIVATE settings_func_test)
 
 if(TEST)
 	target_compile_definitions(app PRIVATE

--- a/tests/subsys/settings/functional/fcb/placeholder.c
+++ b/tests/subsys/settings/functional/fcb/placeholder.c
@@ -1,0 +1,2 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2019 Intel Corporation */

--- a/tests/subsys/settings/functional/nvs/CMakeLists.txt
+++ b/tests/subsys/settings/functional/nvs/CMakeLists.txt
@@ -4,12 +4,16 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-FILE(GLOB app_sources ../src/*.c)
-target_sources(app PRIVATE ${app_sources})
 zephyr_include_directories(
 	$ENV{ZEPHYR_BASE}/subsys/settings/include
 	$ENV{ZEPHYR_BASE}/subsys/settings/src
 	)
+
+# The code is in the library common to several tests.
+target_sources(app PRIVATE placeholder.c)
+
+add_subdirectory(../src func_test_bindir)
+target_link_libraries(app PRIVATE settings_func_test)
 
 if(TEST)
 	target_compile_definitions(app PRIVATE

--- a/tests/subsys/settings/functional/nvs/placeholder.c
+++ b/tests/subsys/settings/functional/nvs/placeholder.c
@@ -1,0 +1,2 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2019 Intel Corporation */

--- a/tests/subsys/settings/functional/src/CMakeLists.txt
+++ b/tests/subsys/settings/functional/src/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_named(  settings_func_test)
+zephyr_library_sources(settings_basic_test.c)
+
+# zephyr_library() is here in "app-mode", see
+# https://github.com/zephyrproject-rtos/zephyr/issues/19582
+# Random build failures without this, depends on the number of threads.
+add_dependencies(      settings_func_test offsets_h)


### PR DESCRIPTION
Stops leaking very long source paths in build directories; makes them
deterministic.

Besides satisfying a CMake requirement, the new empty_file.c provide a
clue that the actual test code is not in the directory of the test case.

See https://github.com/zephyrproject-rtos/hal_nordic/pull/6 and
https://gitlab.kitware.com/cmake/cmake/issues/19475 for more details.

- Test with a simple:

 sanitycheck -T $ZEPHYR_BASE/tests/subsys/settings/functional/

- Before:
```
CMakeFiles
├── app.dir
│   ├── HOME
│   │   └── JOHN
│   │       └── zephyrproject
│   │           └── zephyr
│   │               └── tests
│   │                   └── subsys
│   │                       └── settings
│   │                           └── functional
│   │                               └── src
│   │                                   └── settings_basic_test.c.obj
```
- After:
```
func_test_bindir/
├── CMakeFiles
│   └── settings_func_test.dir
│       └── settings_basic_test.c.obj
│
├── libsettings_func_test.a
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>