### PR TITLE
x86: abstract toplevel page table pointer

### DIFF
--- a/arch/x86/core/ia32/crt0.S
+++ b/arch/x86/core/ia32/crt0.S
@@ -345,7 +345,7 @@ dataWords:
 #ifdef CONFIG_X86_MMU
 z_x86_enable_paging:
 	/* load the page directory address into the registers*/
-	movl $z_x86_kernel_pdpt, %eax
+	movl $z_x86_kernel_ptables, %eax
 	movl %eax, %cr3
 
 	/* Enable PAE */

--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -287,11 +287,11 @@ static void dump_entry_flags(const char *name, x86_page_entry_data_t flags)
 		"Execute Disable" : "Execute Enabled");
 }
 
-static void dump_mmu_flags(struct x86_mmu_pdpt *pdpt, void *addr)
+static void dump_mmu_flags(struct x86_page_tables *ptables, void *addr)
 {
 	x86_page_entry_data_t pde_flags, pte_flags;
 
-	z_x86_mmu_get_flags(pdpt, addr, &pde_flags, &pte_flags);
+	z_x86_mmu_get_flags(ptables, addr, &pde_flags, &pte_flags);
 
 	dump_entry_flags("PDE", pde_flags);
 	dump_entry_flags("PTE", pte_flags);
@@ -317,11 +317,11 @@ static void dump_page_fault(z_arch_esf_t *esf)
 #ifdef CONFIG_X86_MMU
 #ifdef CONFIG_X86_KPTI
 	if (err & US) {
-		dump_mmu_flags(&z_x86_user_pdpt, (void *)cr2);
+		dump_mmu_flags(&z_x86_user_ptables, (void *)cr2);
 		return;
 	}
 #endif
-	dump_mmu_flags(&z_x86_kernel_pdpt, (void *)cr2);
+	dump_mmu_flags(&z_x86_kernel_ptables, (void *)cr2);
 #endif
 }
 #endif /* CONFIG_EXCEPTION_DEBUG */
@@ -396,7 +396,7 @@ struct task_state_segment _df_tss = {
 	.es = DATA_SEG,
 	.ss = DATA_SEG,
 	.eip = (u32_t)df_handler_top,
-	.cr3 = (u32_t)&z_x86_kernel_pdpt
+	.cr3 = (u32_t)&z_x86_kernel_ptables
 };
 
 static __used void df_handler_bottom(void)
@@ -444,7 +444,7 @@ static FUNC_NORETURN __used void df_handler_top(void)
 	_main_tss.es = DATA_SEG;
 	_main_tss.ss = DATA_SEG;
 	_main_tss.eip = (u32_t)df_handler_bottom;
-	_main_tss.cr3 = (u32_t)&z_x86_kernel_pdpt;
+	_main_tss.cr3 = (u32_t)&z_x86_kernel_ptables;
 	_main_tss.eflags = 0U;
 
 	/* NT bit is set in EFLAGS so we will task switch back to _main_tss

--- a/arch/x86/core/ia32/prep_c.c
+++ b/arch/x86/core/ia32/prep_c.c
@@ -33,8 +33,9 @@ FUNC_NORETURN void z_x86_prep_c(struct multiboot_info *info)
 #endif
 
 #if CONFIG_X86_STACK_PROTECTION
-	z_x86_mmu_set_flags(&z_x86_kernel_pdpt, _interrupt_stack, MMU_PAGE_SIZE,
-			    MMU_ENTRY_READ, MMU_PTE_RW_MASK, true);
+	z_x86_mmu_set_flags(&z_x86_kernel_ptables, _interrupt_stack,
+			    MMU_PAGE_SIZE, MMU_ENTRY_READ, MMU_PTE_RW_MASK,
+			    true);
 #endif
 
 	z_cstart();

--- a/arch/x86/core/ia32/userspace.S
+++ b/arch/x86/core/ia32/userspace.S
@@ -50,7 +50,7 @@ SECTION_FUNC(TEXT, z_x86_trampoline_to_kernel)
 	pushl	%edi
 
 	/* Switch to kernel page table */
-	movl	$z_x86_kernel_pdpt, %esi
+	movl	$z_x86_kernel_ptables, %esi
 	movl	%esi, %cr3
 
 	/* Save old trampoline stack pointer in %edi */
@@ -165,7 +165,7 @@ SECTION_FUNC(TEXT, z_x86_syscall_entry_stub)
 	pushl	%edi
 
 	/* Switch to kernel page table */
-	movl	$z_x86_kernel_pdpt, %esi
+	movl	$z_x86_kernel_ptables, %esi
 	movl	%esi, %cr3
 
 	/* Save old trampoline stack pointer in %edi */

--- a/arch/x86/include/ia32/kernel_arch_func.h
+++ b/arch/x86/include/ia32/kernel_arch_func.h
@@ -77,15 +77,16 @@ extern FUNC_NORETURN void z_x86_userspace_enter(k_thread_entry_t user_entry,
 
 void z_x86_thread_pt_init(struct k_thread *thread);
 
-void z_x86_apply_mem_domain(struct x86_mmu_pdpt *pdpt,
+void z_x86_apply_mem_domain(struct x86_page_tables *ptables,
 			    struct k_mem_domain *mem_domain);
 
-static inline struct x86_mmu_pdpt *z_x86_pdpt_get(struct k_thread *thread)
+static inline struct x86_page_tables *
+z_x86_thread_page_tables_get(struct k_thread *thread)
 {
 	struct z_x86_thread_stack_header *header =
 		(struct z_x86_thread_stack_header *)thread->stack_obj;
 
-	return &header->kernel_data.pdpt;
+	return &header->kernel_data.ptables;
 }
 #endif /* CONFIG_USERSPACE */
 

--- a/tests/kernel/boot_page_table/src/boot_page_table.c
+++ b/tests/kernel/boot_page_table/src/boot_page_table.c
@@ -45,7 +45,7 @@ static void starting_addr_range(u32_t start_addr_range)
 	for (addr_range = start_addr_range; addr_range <=
 	     (start_addr_range + STARTING_ADDR_RANGE_LMT);
 	     addr_range += 0x1000) {
-		value = X86_MMU_GET_PTE(&z_x86_kernel_pdpt, addr_range);
+		value = X86_MMU_GET_PTE(&z_x86_kernel_ptables, addr_range);
 		status &= check_param(value, REGION_PERM);
 		zassert_false((status == 0U), "error at %d permissions %d\n",
 			      addr_range, REGION_PERM);
@@ -60,7 +60,7 @@ static void before_start_addr_range(u32_t start_addr_range)
 	for (addr_range = start_addr_range - 0x7000;
 	     addr_range < (start_addr_range); addr_range += 0x1000) {
 
-		value = X86_MMU_GET_PTE(&z_x86_kernel_pdpt, addr_range);
+		value = X86_MMU_GET_PTE(&z_x86_kernel_ptables, addr_range);
 		status &= check_param_nonset_region(value, REGION_PERM);
 
 		zassert_false((status == 0U), "error at %d permissions %d\n",
@@ -76,7 +76,7 @@ static void ending_start_addr_range(u32_t start_addr_range)
 	for (addr_range = start_addr_range + ADDR_SIZE; addr_range <
 	     (start_addr_range + ADDR_SIZE + 0x10000);
 	     addr_range += 0x1000) {
-		value = X86_MMU_GET_PTE(&z_x86_kernel_pdpt, addr_range);
+		value = X86_MMU_GET_PTE(&z_x86_kernel_ptables, addr_range);
 		status &= check_param_nonset_region(value, REGION_PERM);
 		zassert_false((status == 0U), "error at %d permissions %d\n",
 			      addr_range, REGION_PERM);

--- a/tests/kernel/mem_protect/x86_mmu_api/src/userbuffer_validate.c
+++ b/tests/kernel/mem_protect/x86_mmu_api/src/userbuffer_validate.c
@@ -25,23 +25,23 @@ void reset_flag(void);
 void reset_multi_pte_page_flag(void);
 void reset_multi_pde_flag(void);
 
-#define PDPT (&z_x86_kernel_pdpt)
+#define PTABLES (&z_x86_kernel_ptables)
 
 #define ADDR_PAGE_1 ((u8_t *)__bss_start + SKIP_SIZE * MMU_PAGE_SIZE)
 #define ADDR_PAGE_2 ((u8_t *)__bss_start + (SKIP_SIZE + 1) * MMU_PAGE_SIZE)
-#define PRESET_PAGE_1_VALUE (X86_MMU_GET_PTE(PDPT, ADDR_PAGE_1)->p = 1)
-#define PRESET_PAGE_2_VALUE (X86_MMU_GET_PTE(PDPT, ADDR_PAGE_2)->p = 1)
+#define PRESET_PAGE_1_VALUE (X86_MMU_GET_PTE(PTABLES, ADDR_PAGE_1)->p = 1)
+#define PRESET_PAGE_2_VALUE (X86_MMU_GET_PTE(PTABLES, ADDR_PAGE_2)->p = 1)
 
 
 static void set_flags(void *ptr, size_t size, x86_page_entry_data_t flags,
 		      x86_page_entry_data_t mask)
 {
-	z_x86_mmu_set_flags(PDPT, ptr, size, flags, mask, true);
+	z_x86_mmu_set_flags(PTABLES, ptr, size, flags, mask, true);
 }
 
 static int buffer_validate(void *addr, size_t size, int write)
 {
-	return z_x86_mmu_validate(PDPT, addr, size, write);
+	return z_x86_mmu_validate(PTABLES, addr, size, write);
 }
 
 /* if Failure occurs


### PR DESCRIPTION
This patch is a preparatory step in enabling the MMU in
long mode; no steps are taken to implement long mode support.

We introduce struct x86_page_tables, which represents the
top-level data structure for page tables:

- For 32-bit, this will contain a four-entry page directory
  pointer table (PDPT)
- For 64-bit, this will (eventually) contain a page map level 4
  table (PML4)

In either case, this pointer value is what gets programmed into
CR3 to activate a set of page tables. There are extra bits in
CR3 to set for long mode, we'll get around to that later.

This abstraction will allow us to use the same APIs that work
with page tables in either mode, rather than hard-coding that
the top level data structure is a PDPT.

z_x86_mmu_validate() has been re-written to make it easier to
add another level of paging for long mode, to support 2MB
PDPT entries, and correctly validate regions which span PDPTE
entries.

Some MMU-related APIs moved out of 32-bit x86's arch.h into
mmustructs.h.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>