### PR TITLE
tests: timer_api: Fix duplicate timestamp update.

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -55,15 +55,15 @@ static void init_timer_data(void)
 static void duration_expire(struct k_timer *timer)
 {
 	/** TESTPOINT: expire function */
+	s64_t interval = k_uptime_delta(&tdata.timestamp);
+
 	tdata.expire_cnt++;
 	if (tdata.expire_cnt == 1) {
-		TIMER_ASSERT(k_uptime_delta(&tdata.timestamp) >= DURATION,
-			     timer);
+		TIMER_ASSERT(interval >= DURATION, timer);
 	} else {
-		TIMER_ASSERT(k_uptime_delta(&tdata.timestamp) >= PERIOD, timer);
+		TIMER_ASSERT(interval >= PERIOD, timer);
 	}
 
-	tdata.timestamp = k_uptime_get();
 	if (tdata.expire_cnt >= EXPIRE_TIMES) {
 		k_timer_stop(timer);
 	}


### PR DESCRIPTION
Remove duplicate "tdata.timestamp" update in duration_expire; this
value is already updated by k_uptime_delta.

Besides simply removing duplicate value update, this commit also
addresses the intermittent assertion failure that is caused by
updating "tdata.timestamp" at a later time than the actual execution
of the k_uptime_delta function.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>