### PR TITLE
tests: net: hostname: Set MAC address properly to all interfaces

### DIFF
--- a/tests/net/hostname/src/main.c
+++ b/tests/net/hostname/src/main.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #define NET_LOG_ENABLED 1
 #include "net_private.h"
 
-#if defined(CONFIG_NET_IF_LOG_LEVEL_DBG)
+#if defined(CONFIG_NET_HOSTNAME_LOG_LEVEL_DBG)
 #define DBG(fmt, ...) printk(fmt, ##__VA_ARGS__)
 #else
 #define DBG(fmt, ...)
@@ -142,6 +142,14 @@ static void eth_fake_iface_init(struct net_if *iface)
 	struct eth_fake_context *ctx = dev->driver_data;
 
 	ctx->iface = iface;
+
+	/* 00-00-5E-00-53-xx Documentation RFC 7042 */
+	ctx->mac_address[0] = 0x00;
+	ctx->mac_address[1] = 0x00;
+	ctx->mac_address[2] = 0x5E;
+	ctx->mac_address[3] = 0x00;
+	ctx->mac_address[4] = 0x53;
+	ctx->mac_address[5] = sys_rand32_get();
 
 	net_if_set_link_addr(iface, ctx->mac_address,
 			     sizeof(ctx->mac_address),


### PR DESCRIPTION
The test creates two network interfaces, but does not set MAC
address of one of them correctly (MAC address is all zeros).
This is not good and the issue fixed in commit 9468cb6eb1
could have been revealed earlier.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>