### PR TITLE
bindings: nordic,nrf-rtc.yaml: Do not require 'ppi-wrap' property

### DIFF
--- a/drivers/counter/Kconfig.nrfx
+++ b/drivers/counter/Kconfig.nrfx
@@ -71,4 +71,5 @@ config COUNTER_RTC_WITH_PPI_WRAP
 	default y
 	select NRFX_PPI if HAS_HW_NRF_PPI
 	select NRFX_DPPI if HAS_HW_NRF_DPPIC
+
 endif

--- a/dts/bindings/rtc/nordic,nrf-rtc.yaml
+++ b/dts/bindings/rtc/nordic,nrf-rtc.yaml
@@ -21,4 +21,4 @@ properties:
     ppi-wrap:
       type: boolean
       description: Enable wrapping with PPI
-      required: true
+      required: false


### PR DESCRIPTION
Looking at the code, this flag was probably made 'required: true' by
mistake. Combining 'type: boolean' with 'required: true' for 'ppi-wrap'
means that all nodes that use this binding are required to have a
'ppi-wrap;' property.

The mistake was hidden by a bug in edtlib (failing to flag missing
'required: true' booleans).