### PR TITLE
[TOPIC-GPIO] tests/drivers/gpio_basic_api: improve support for pull test

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
@@ -359,6 +359,10 @@ static int check_pulls(void)
 
 	/* Disconnect output */
 	rc = gpio_pin_configure(dev, PIN_OUT, 0);
+	if (rc == -ENOTSUP) {
+		TC_PRINT("NOTE: cannot configure pin as disconnected; trying as input\n");
+		rc = gpio_pin_configure(dev, PIN_OUT, GPIO_INPUT);
+	}
 	zassert_equal(rc, 0,
 		      "output disconnect failed");
 


### PR DESCRIPTION
The pull test assumed it was possible to configure the GPIO to be
disconnected.  Some peripherals don't support a disconnected GPIO pin,
so if disconnected is not supported emit a note and attempt to
configure the output pin as an input.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>