### PR TITLE
doc: fix genrest turbo mode output error

### DIFF
--- a/doc/scripts/genrest.py
+++ b/doc/scripts/genrest.py
@@ -127,7 +127,8 @@ def write_dummy_index(kconf, out_dir):
     # so that they can be referenced from elsewhere in the documentation, to
     # speed up builds when we don't need the Kconfig symbol documentation
 
-    index_rst = INDEX_RST_HEADER + "\n(Dummy index page for turbo mode)\n\n"
+    index_rst = INDEX_RST_HEADER + "\n   * - dummy" + \
+       "\n     - Dummy index page for turbo mode\n\n"
 
     for sym in sorted(kconf.unique_defined_syms, key=attrgetter("name")):
         index_rst += ".. option:: CONFIG_{}\n".format(sym.name)


### PR DESCRIPTION
PR #19493 cleaned up the turbo-mode process for doc generation but
introduced an error in the generated index.rst that causes use of the
"make htmldocs-fast" (so-called turbo mode) to fail with an error -
the generated list-table directive has no content (other than
the header row).  This PR adds one dummy row.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>