### PR TITLE
doc: dts: Fix 'child-binding' typo in legacy syntax section

### DIFF
--- a/doc/guides/dts/index.rst
+++ b/doc/guides/dts/index.rst
@@ -503,7 +503,7 @@ This should now be written like this:
            type: int
            required: false
 
-   child-node:
+   child-binding:
        title: ...
        description: ...
 


### PR DESCRIPTION
'child-node' should be 'child-binding'.