### PR TITLE
coccinelle: standardize kernel timeout arguments

### DIFF
--- a/drivers/adc/adc_context.h
+++ b/drivers/adc/adc_context.h
@@ -95,7 +95,7 @@ static inline void adc_context_enable_timer(struct adc_context *ctx)
 	u32_t interval_us = ctx->options.interval_us;
 	u32_t interval_ms = ceiling_fraction(interval_us, 1000UL);
 
-	k_timer_start(&ctx->timer, 0, interval_ms);
+	k_timer_start(&ctx->timer, K_NO_WAIT, interval_ms);
 }
 
 static inline void adc_context_disable_timer(struct adc_context *ctx)

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -635,10 +635,10 @@ static int cc1200_tx(struct device *dev,
 	}
 
 	/* Wait for SYNC to be sent */
-	k_sem_take(&cc1200->tx_sync, 100);
+	k_sem_take(&cc1200->tx_sync, K_MSEC(100));
 	if (atomic_get(&cc1200->tx_start) == 1) {
 		/* Now wait for the packet to be fully sent */
-		k_sem_take(&cc1200->tx_sync, 100);
+		k_sem_take(&cc1200->tx_sync, K_MSEC(100));
 	}
 
 out:

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -839,7 +839,7 @@ static int cc2520_tx(struct device *dev,
 			goto error;
 		}
 
-		k_sem_take(&cc2520->tx_sync, 10);
+		k_sem_take(&cc2520->tx_sync, K_MSEC(10));
 
 		retry--;
 		status = verify_tx_done(cc2520);

--- a/drivers/led/ht16k33.c
+++ b/drivers/led/ht16k33.c
@@ -442,7 +442,7 @@ static int ht16k33_init(struct device *dev)
 
 		/* Setup timer for polling key data */
 		k_timer_init(&data->timer, ht16k33_timer_callback, NULL);
-		k_timer_start(&data->timer, 0,
+		k_timer_start(&data->timer, K_NO_WAIT,
 			      CONFIG_HT16K33_KEYSCAN_POLL_MSEC);
 	}
 

--- a/drivers/sensor/hp206c/hp206c.c
+++ b/drivers/sensor/hp206c/hp206c.c
@@ -168,7 +168,7 @@ static int hp206c_wait_dev_ready(struct device *dev, u32_t timeout_ms)
 	struct hp206c_device_data *hp206c = dev->driver_data;
 	u8_t int_src;
 
-	k_timer_start(&hp206c->tmr, timeout_ms, 0);
+	k_timer_start(&hp206c->tmr, timeout_ms, K_NO_WAIT);
 	k_timer_status_sync(&hp206c->tmr);
 
 	if (hp206c_read_reg(dev, HP206C_REG_INT_SRC, &int_src) < 0) {

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -485,7 +485,8 @@ static int uarte_nrfx_tx(struct device *dev, const u8_t *buf, size_t len,
 	nrf_uarte_tx_buffer_set(uarte, buf, len);
 	nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STARTTX);
 	if (data->uart_config.flow_ctrl == UART_CFG_FLOW_CTRL_RTS_CTS) {
-		k_timer_start(&data->async->tx_timeout_timer, timeout, 0);
+		k_timer_start(&data->async->tx_timeout_timer, timeout,
+			      K_NO_WAIT);
 	}
 	return 0;
 }

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -361,7 +361,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const cfg)
 	(void)memset(&bdt[idx_even], 0, sizeof(struct buf_descriptor));
 	(void)memset(&bdt[idx_odd], 0, sizeof(struct buf_descriptor));
 
-	if (k_mem_pool_alloc(&ep_buf_pool, block, cfg->ep_mps * 2U, 10) == 0) {
+	if (k_mem_pool_alloc(&ep_buf_pool, block, cfg->ep_mps * 2U, K_MSEC(10)) == 0) {
 		(void)memset(block->data, 0, cfg->ep_mps * 2U);
 	} else {
 		LOG_ERR("Memory allocation time-out");

--- a/drivers/usb/device/usb_dc_mcux_ehci.c
+++ b/drivers/usb/device/usb_dc_mcux_ehci.c
@@ -160,7 +160,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data *const cfg)
 		block->data = NULL;
 	}
 
-	if (k_mem_pool_alloc(&ep_buf_pool, block, cfg->ep_mps, 10) == 0) {
+	if (k_mem_pool_alloc(&ep_buf_pool, block, cfg->ep_mps, K_MSEC(10)) == 0) {
 		memset(block->data, 0, cfg->ep_mps);
 	} else {
 		LOG_ERR("Memory allocation time-out");

--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -433,7 +433,7 @@ static int eswifi_off_get(sa_family_t family,
 	k_sem_init(&socket->accept_sem, 1, 1);
 
 	k_delayed_work_submit_to_queue(&eswifi->work_q, &socket->read_work,
-				       500);
+				       K_MSEC(500));
 
 unlock:
 	eswifi_unlock(eswifi);

--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -141,7 +141,7 @@ static void eswifi_off_read_work(struct k_work *work)
 done:
 	err = k_delayed_work_submit_to_queue(&eswifi->work_q,
 					     &socket->read_work,
-					     500);
+					     K_MSEC(500));
 	if (err) {
 		LOG_ERR("Rescheduling socket read error");
 	}

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -344,7 +344,7 @@ static int eswifi_socket_open(int family, int type, int proto)
 	socket->recv_data = socket;
 
 	k_delayed_work_submit_to_queue(&eswifi->work_q, &socket->read_work,
-					500);
+					K_MSEC(500));
 
 unlock:
 	eswifi_unlock(eswifi);

--- a/lib/cmsis_rtos_v1/cmsis_mutex.c
+++ b/lib/cmsis_rtos_v1/cmsis_mutex.c
@@ -25,7 +25,7 @@ osMutexId osMutexCreate(const osMutexDef_t *mutex_def)
 		return NULL;
 	}
 
-	if (k_mem_slab_alloc(&cmsis_mutex_slab, (void **)&mutex, 100) == 0) {
+	if (k_mem_slab_alloc(&cmsis_mutex_slab, (void **)&mutex, K_MSEC(100)) == 0) {
 		(void)memset(mutex, 0, sizeof(struct k_mutex));
 	} else {
 		return NULL;

--- a/lib/cmsis_rtos_v1/cmsis_semaphore.c
+++ b/lib/cmsis_rtos_v1/cmsis_semaphore.c
@@ -27,7 +27,7 @@ osSemaphoreId osSemaphoreCreate(const osSemaphoreDef_t *semaphore_def,
 	}
 
 	if (k_mem_slab_alloc(&cmsis_semaphore_slab,
-				(void **)&semaphore, 100) == 0) {
+				(void **)&semaphore, K_MSEC(100)) == 0) {
 		(void)memset(semaphore, 0, sizeof(struct k_sem));
 	} else {
 		return NULL;

--- a/lib/cmsis_rtos_v1/cmsis_timer.c
+++ b/lib/cmsis_rtos_v1/cmsis_timer.c
@@ -47,7 +47,7 @@ osTimerId osTimerCreate(const osTimerDef_t *timer_def, os_timer_type type,
 		return NULL;
 	}
 
-	if (k_mem_slab_alloc(&cmsis_timer_slab, (void **)&timer, 100) == 0) {
+	if (k_mem_slab_alloc(&cmsis_timer_slab, (void **)&timer, K_MSEC(100)) == 0) {
 		(void)memset(timer, 0, sizeof(struct timer_obj));
 	} else {
 		return NULL;
@@ -79,9 +79,9 @@ osStatus osTimerStart(osTimerId timer_id, uint32_t millisec)
 	}
 
 	if (timer->type == osTimerOnce) {
-		k_timer_start(&timer->ztimer, millisec, 0);
+		k_timer_start(&timer->ztimer, millisec, K_NO_WAIT);
 	} else if (timer->type == osTimerPeriodic) {
-		k_timer_start(&timer->ztimer, 0, millisec);
+		k_timer_start(&timer->ztimer, K_NO_WAIT, millisec);
 	}
 
 	timer->status = ACTIVE;

--- a/lib/cmsis_rtos_v2/event_flags.c
+++ b/lib/cmsis_rtos_v2/event_flags.c
@@ -35,7 +35,7 @@ osEventFlagsId_t osEventFlagsNew(const osEventFlagsAttr_t *attr)
 		attr = &init_event_flags_attrs;
 	}
 
-	if (k_mem_slab_alloc(&cv2_event_flags_slab, (void **)&events, 100)
+	if (k_mem_slab_alloc(&cv2_event_flags_slab, (void **)&events, K_MSEC(100))
 	    == 0) {
 		memset(events, 0, sizeof(struct cv2_event_flags));
 	} else {

--- a/lib/cmsis_rtos_v2/mempool.c
+++ b/lib/cmsis_rtos_v2/mempool.c
@@ -45,7 +45,7 @@ osMemoryPoolId_t osMemoryPoolNew(uint32_t block_count, uint32_t block_size,
 		attr = &init_mslab_attrs;
 	}
 
-	if (k_mem_slab_alloc(&cv2_mem_slab, (void **)&mslab, 100) == 0) {
+	if (k_mem_slab_alloc(&cv2_mem_slab, (void **)&mslab, K_MSEC(100)) == 0) {
 		(void)memset(mslab, 0, sizeof(struct cv2_mslab));
 	} else {
 		return NULL;

--- a/lib/cmsis_rtos_v2/msgq.c
+++ b/lib/cmsis_rtos_v2/msgq.c
@@ -43,7 +43,7 @@ osMessageQueueId_t osMessageQueueNew(uint32_t msg_count, uint32_t msg_size,
 		attr = &init_msgq_attrs;
 	}
 
-	if (k_mem_slab_alloc(&cv2_msgq_slab, (void **)&msgq, 100) == 0) {
+	if (k_mem_slab_alloc(&cv2_msgq_slab, (void **)&msgq, K_MSEC(100)) == 0) {
 		(void)memset(msgq, 0, sizeof(struct cv2_msgq));
 	} else {
 		return NULL;

--- a/lib/cmsis_rtos_v2/mutex.c
+++ b/lib/cmsis_rtos_v2/mutex.c
@@ -38,7 +38,7 @@ osMutexId_t osMutexNew(const osMutexAttr_t *attr)
 	__ASSERT(!(attr->attr_bits & osMutexRobust),
 		 "Zephyr does not support osMutexRobust.\n");
 
-	if (k_mem_slab_alloc(&cv2_mutex_slab, (void **)&mutex, 100) == 0) {
+	if (k_mem_slab_alloc(&cv2_mutex_slab, (void **)&mutex, K_MSEC(100)) == 0) {
 		memset(mutex, 0, sizeof(struct cv2_mutex));
 	} else {
 		return NULL;

--- a/lib/cmsis_rtos_v2/semaphore.c
+++ b/lib/cmsis_rtos_v2/semaphore.c
@@ -34,7 +34,7 @@ osSemaphoreId_t osSemaphoreNew(uint32_t max_count, uint32_t initial_count,
 	}
 
 	if (k_mem_slab_alloc(&cv2_semaphore_slab,
-			     (void **)&semaphore, 100) == 0) {
+			     (void **)&semaphore, K_MSEC(100)) == 0) {
 		(void)memset(semaphore, 0, sizeof(struct cv2_sem));
 	} else {
 		return NULL;

--- a/lib/cmsis_rtos_v2/timer.c
+++ b/lib/cmsis_rtos_v2/timer.c
@@ -50,7 +50,7 @@ osTimerId_t osTimerNew(osTimerFunc_t func, osTimerType_t type,
 		attr = &init_timer_attrs;
 	}
 
-	if (k_mem_slab_alloc(&cv2_timer_slab, (void **)&timer, 100) == 0) {
+	if (k_mem_slab_alloc(&cv2_timer_slab, (void **)&timer, K_MSEC(100)) == 0) {
 		(void)memset(timer, 0, sizeof(struct cv2_timer));
 	} else {
 		return NULL;
@@ -90,9 +90,9 @@ osStatus_t osTimerStart(osTimerId_t timer_id, uint32_t ticks)
 	}
 
 	if (timer->type == osTimerOnce) {
-		k_timer_start(&timer->z_timer, millisec, 0);
+		k_timer_start(&timer->z_timer, millisec, K_NO_WAIT);
 	} else if (timer->type == osTimerPeriodic) {
-		k_timer_start(&timer->z_timer, 0, millisec);
+		k_timer_start(&timer->z_timer, K_NO_WAIT, millisec);
 	}
 
 	timer->status = ACTIVE;

--- a/lib/posix/timer.c
+++ b/lib/posix/timer.c
@@ -58,7 +58,7 @@ int timer_create(clockid_t clockid, struct sigevent *evp, timer_t *timerid)
 		return -1;
 	}
 
-	if (k_mem_slab_alloc(&posix_timer_slab, (void **)&timer, 100) == 0) {
+	if (k_mem_slab_alloc(&posix_timer_slab, (void **)&timer, K_MSEC(100)) == 0) {
 		(void)memset(timer, 0, sizeof(struct timer_obj));
 	} else {
 		errno = ENOMEM;

--- a/samples/boards/nrf52/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff-app/src/main.c
@@ -445,7 +445,7 @@ static void button_pressed(struct device *dev, struct gpio_callback *cb,
 	}
 
 	if (button_press_cnt == 0U) {
-		k_timer_start(&sw.button_timer, K_SECONDS(1), 0);
+		k_timer_start(&sw.button_timer, K_SECONDS(1), K_NO_WAIT);
 	}
 
 	printk("button_press_cnt 0x%02x\n", button_press_cnt);

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -210,12 +210,12 @@ void main(void)
 	update_light_state();
 
 	short_time_multireset_bt_mesh_unprovisioning();
-	k_timer_start(&reset_counter_timer, K_MSEC(7000), 0);
+	k_timer_start(&reset_counter_timer, K_MSEC(7000), K_NO_WAIT);
 
 #if defined(CONFIG_MCUMGR)
 	/* Initialize the Bluetooth mcumgr transport. */
 	smp_bt_register();
 
-	k_timer_start(&smp_svr_timer, 0, K_MSEC(1000));
+	k_timer_start(&smp_svr_timer, K_NO_WAIT, K_MSEC(1000));
 #endif
 }

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/no_transition_work_handler.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/no_transition_work_handler.c
@@ -69,14 +69,15 @@ static void no_transition_work_handler(struct k_work *work)
 		update_led_gpio();
 	}
 
-	k_timer_start(&unsolicitedly_publish_states_timer, K_MSEC(5000), 0);
+	k_timer_start(&unsolicitedly_publish_states_timer, K_MSEC(5000),
+		      K_NO_WAIT);
 
 	/* If Lightness & Temperature values remains stable for
 	 * 10 Seconds then & then only get stored on SoC flash.
 	 */
 	if (gen_power_onoff_srv_user_data.onpowerup == STATE_RESTORE) {
 		k_timer_start(&save_lightness_temp_last_values_timer,
-			      K_MSEC(10000), 0);
+			      K_MSEC(10000), K_NO_WAIT);
 	}
 }
 

--- a/scripts/coccinelle/int_literal_to_timeout.cocci
+++ b/scripts/coccinelle/int_literal_to_timeout.cocci
@@ -1,0 +1,81 @@
+// Copyright (c) 2019 Nordic Semiconductor ASA
+// SPDX-License-Identifer: Apache-2.0
+
+// Replace integer constant timeouts with K_MSEC variants
+//
+// Some existing code assumes that timeout parameters are provided as
+// integer milliseconds, when they were intended to be timeout values
+// produced by specific constants and macros.  Convert the integer
+// literals to the desired equivalent.
+
+// Handle k_timer_start delay parameters
+@delay_id@
+expression T, P;
+position p;
+identifier D;
+@@
+k_timer_start@p(T, D, P)
+
+@@
+expression T, P;
+position p != delay_id.p;
+@@
+k_timer_start@p(T,
+- 0
++ K_NO_WAIT
+ , P)
+
+@@
+expression T, P;
+position p != delay_id.p;
+@@
+k_timer_start@p(T,
+- -1
++ K_FOREVER
+ , P)
+
+@@
+expression T, P;
+constant int D;
+position p != delay_id.p;
+@@
+k_timer_start@p(T,
+- D
++ K_MSEC(D)
+ , P)
+
+// Handle timeouts at the end of the argument list
+@end_id@
+identifier f =~ "^k_(timer_start|queue_get|futex_wait|stack_pop|delayed_work_submit_to_queue|mutex_lock|sem_take|(msgq|mbox|pipe)_(block_)?(put|get)|mem_(slab|pool)_alloc|poll|thread_deadline_set)$";
+position p;
+identifier D;
+@@
+f@p(..., D)
+
+@@
+identifier f =~ "^k_(timer_start|queue_get|futex_wait|stack_pop|delayed_work_submit_to_queue|mutex_lock|sem_take|(msgq|mbox|pipe)_(block_)?(put|get)|mem_(slab|pool)_alloc|poll|thread_deadline_set)$";
+position p != end_id.p;
+@@
+f@p(...,
+- 0
++ K_NO_WAIT
+ )
+
+@@
+identifier f =~ "^k_(timer_start|queue_get|futex_wait|stack_pop|delayed_work_submit_to_queue|mutex_lock|sem_take|(msgq|mbox|pipe)_(block_)?(put|get)|mem_(slab|pool)_alloc|poll|thread_deadline_set)$";
+position p != end_id.p;
+@@
+f@p(...,
+- -1
++ K_FOREVER
+ )
+
+@@
+identifier f =~ "^k_(timer_start|queue_get|futex_wait|stack_pop|delayed_work_submit_to_queue|mutex_lock|sem_take|(msgq|mbox|pipe)_(block_)?(put|get)|mem_(slab|pool)_alloc|poll|thread_deadline_set)$";
+position p != end_id.p;
+constant int D;
+@@
+f@p(...,
+- D
++ K_MSEC(D)
+ )

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -214,7 +214,7 @@ static inline void msg_finalize(struct log_msg *msg,
 		irq_unlock(key);
 	} else if (proc_tid != NULL && buffered_cnt == 1) {
 		k_timer_start(&log_process_thread_timer,
-			CONFIG_LOG_PROCESS_THREAD_SLEEP_MS, 0);
+			CONFIG_LOG_PROCESS_THREAD_SLEEP_MS, K_NO_WAIT);
 	} else if (CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD) {
 		if ((buffered_cnt == CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD) &&
 		    (proc_tid != NULL)) {

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -735,7 +735,7 @@ void gptp_update_pdelay_req_interval(int port, s8_t log_val)
 		new_itv = 1;
 	}
 
-	k_timer_start(&state_pdelay->pdelay_timer, new_itv, 0);
+	k_timer_start(&state_pdelay->pdelay_timer, new_itv, K_NO_WAIT);
 }
 
 void gptp_update_sync_interval(int port, s8_t log_val)
@@ -814,7 +814,7 @@ void gptp_update_announce_interval(int port, s8_t log_val)
 		new_itv = 1;
 	}
 
-	k_timer_start(&state_ann->ann_send_periodic_timer, new_itv, 0);
+	k_timer_start(&state_ann->ann_send_periodic_timer, new_itv, K_NO_WAIT);
 }
 
 struct port_user_data {

--- a/subsys/net/l2/ethernet/gptp/gptp_md.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.c
@@ -203,7 +203,7 @@ static void gptp_md_pdelay_check_multiple_resp(int port)
 		duration = GPTP_MULTIPLE_PDELAY_RESP_WAIT -
 			gptp_uscaled_ns_to_timer_ms(&port_ds->pdelay_req_itv);
 
-		k_timer_start(&state->pdelay_timer, duration, 0);
+		k_timer_start(&state->pdelay_timer, duration, K_NO_WAIT);
 	} else {
 		state->state = GPTP_PDELAY_REQ_SEND_REQ;
 	}
@@ -636,7 +636,7 @@ static void gptp_md_pdelay_req_state_machine(int port)
 		k_timer_start(&state->pdelay_timer,
 			      gptp_uscaled_ns_to_timer_ms(
 				      &port_ds->pdelay_req_itv),
-			      0);
+			      K_NO_WAIT);
 		/*
 		 * Transition directly to GPTP_PDELAY_REQ_WAIT_RESP.
 		 * Check for the TX timestamp will be done during

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -608,7 +608,7 @@ void gptp_handle_sync(int port, struct net_pkt *pkt)
 	duration = (upstream_sync_itv / 1000000U);
 
 	/* Start timeout timer. */
-	k_timer_start(&state->follow_up_discard_timer, duration, 0);
+	k_timer_start(&state->follow_up_discard_timer, duration, K_NO_WAIT);
 }
 
 int gptp_handle_follow_up(int port, struct net_pkt *pkt)

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -356,7 +356,8 @@ static void start_rcv_sync_timer(struct gptp_port_ds *port_ds,
 
 	duration = port_ds->sync_receipt_timeout_time_itv;
 
-	k_timer_start(&state->rcv_sync_receipt_timeout_timer, duration, 0);
+	k_timer_start(&state->rcv_sync_receipt_timeout_timer, duration,
+		      K_NO_WAIT);
 }
 
 static void gptp_mi_pss_rcv_state_machine(int port)
@@ -506,7 +507,8 @@ static void gptp_mi_pss_send_state_machine(int port)
 						&port_ds->half_sync_itv);
 
 		/* Start 0.5 * syncInterval timeout timer. */
-		k_timer_start(&state->half_sync_itv_timer, duration, 0);
+		k_timer_start(&state->half_sync_itv_timer, duration,
+			      K_NO_WAIT);
 
 		gptp_mi_pss_send_md_sync_send(port);
 
@@ -548,7 +550,7 @@ static void gptp_mi_pss_send_state_machine(int port)
 				(NSEC_PER_USEC * USEC_PER_MSEC);
 
 			k_timer_start(&state->send_sync_receipt_timeout_timer,
-				      duration, 0);
+				      duration, K_NO_WAIT);
 
 		} else if (state->send_sync_receipt_timeout_timer_expired) {
 			state->state = GPTP_PSS_SEND_SYNC_RECEIPT_TIMEOUT;
@@ -1474,7 +1476,7 @@ static void gptp_mi_port_announce_information_state_machine(int port)
 		k_timer_start(&state->ann_rcpt_expiry_timer,
 			      gptp_uscaled_ns_to_timer_ms(
 				   &bmca_data->ann_rcpt_timeout_time_interval),
-			      0);
+			      K_NO_WAIT);
 		/* Fallthrough. */
 
 	case GPTP_PA_INFO_INFERIOR_MASTER_OR_OTHER_PORT:
@@ -1872,7 +1874,7 @@ static void gptp_mi_port_announce_transmit_state_machine(int port)
 		k_timer_start(&state->ann_send_periodic_timer,
 			      gptp_uscaled_ns_to_timer_ms(
 				      &bmca_data->announce_interval),
-			      0);
+			      K_NO_WAIT);
 
 		state->state = GPTP_PA_TRANSMIT_POST_IDLE;
 		/* Fallthrough. */

--- a/subsys/net/l2/ieee802154/ieee802154_radio_utils.h
+++ b/subsys/net/l2/ieee802154/ieee802154_radio_utils.h
@@ -51,7 +51,7 @@ static inline int wait_for_ack(struct net_if *iface,
 		return 0;
 	}
 
-	if (k_sem_take(&ctx->ack_lock, 10) == 0) {
+	if (k_sem_take(&ctx->ack_lock, K_MSEC(10)) == 0) {
 		/*
 		 * We reinit the semaphore in case handle_ack
 		 * got called multiple times.

--- a/subsys/net/lib/openthread/platform/alarm.c
+++ b/subsys/net/lib/openthread/platform/alarm.c
@@ -51,7 +51,7 @@ void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t t0, uint32_t dt)
 	s64_t delta = -k_uptime_delta(&reftime);
 
 	if (delta > 0) {
-		k_timer_start(&ot_timer, K_MSEC(delta), 0);
+		k_timer_start(&ot_timer, K_MSEC(delta), K_NO_WAIT);
 	} else {
 		ot_timer_fired(NULL);
 	}

--- a/subsys/shell/shell_telnet.c
+++ b/subsys/shell/shell_telnet.c
@@ -420,7 +420,7 @@ static int write(const struct shell_transport *transport,
 		 */
 		timeout = (timeout == 0) ? TELNET_TIMEOUT : timeout;
 
-		k_timer_start(&sh_telnet->send_timer, timeout, 0);
+		k_timer_start(&sh_telnet->send_timer, timeout, K_NO_WAIT);
 	}
 
 	sh_telnet->shell_handler(SHELL_TRANSPORT_EVT_TX_RDY,

--- a/tests/benchmarks/timing_info/src/msg_passing_bench.c
+++ b/tests/benchmarks/timing_info/src/msg_passing_bench.c
@@ -131,7 +131,8 @@ void msg_passing_bench(void)
 				thread_producer_msgq_w_cxt_switch, NULL,
 				NULL, NULL, 2 /*priority*/, 0, 50);
 
-	u32_t msg_status =  k_msgq_get(&benchmark_q, &received_data, 300);
+	u32_t msg_status =  k_msgq_get(&benchmark_q, &received_data,
+				       K_MSEC(300));
 
 	producer_wo_cxt_switch_tid =
 		k_thread_create(&my_thread_0, my_stack_area_0, STACK_SIZE,
@@ -242,7 +243,8 @@ void msg_passing_bench(void)
 	TIMING_INFO_PRE_READ();
 	mbox_get_w_cxt_start_time = TIMING_INFO_OS_GET_TIME();
 
-	status = k_mbox_get(&benchmark_mbox, &rx_msg, &single_element_buffer, 300);
+	status = k_mbox_get(&benchmark_mbox, &rx_msg, &single_element_buffer,
+			    K_MSEC(300));
 	MBOX_CHECK(status);
 
 	TIMING_INFO_PRE_READ();
@@ -356,7 +358,8 @@ void thread_producer_get_msgq_w_cxt_switch(void *p1, void *p2, void *p3)
 		if (status == 0) {
 			data_to_send++;
 		}
-		status = k_msgq_put(&benchmark_q_get, &data_to_send, 20);
+		status = k_msgq_put(&benchmark_q_get, &data_to_send,
+				    K_MSEC(20));
 	}
 }
 
@@ -368,7 +371,7 @@ void thread_consumer_get_msgq_w_cxt_switch(void *p1, void *p2, void *p3)
 	__msg_q_get_w_cxt_start_time = TIMING_INFO_OS_GET_TIME();
 	received_data_get =  k_msgq_get(&benchmark_q_get,
 					&received_data_consumer,
-					300);
+					K_MSEC(300));
 	TIMING_INFO_PRE_READ();
 	time_check = TIMING_INFO_OS_GET_TIME();
 }
@@ -389,7 +392,7 @@ void thread_mbox_sync_put_send(void *p1, void *p2, void *p3)
 	mbox_sync_put_start_time = TIMING_INFO_OS_GET_TIME();
 	z_arch_timing_value_swap_end = 1U;
 
-	status = k_mbox_put(&benchmark_mbox, &tx_msg, 300);
+	status = k_mbox_put(&benchmark_mbox, &tx_msg, K_MSEC(300));
 	MBOX_CHECK(status);
 
 	TIMING_INFO_PRE_READ();
@@ -405,7 +408,8 @@ void thread_mbox_sync_put_receive(void *p1, void *p2, void *p3)
 		.tx_target_thread = K_ANY
 	};
 
-	status = k_mbox_get(&benchmark_mbox, &rx_msg, &single_element_buffer, 300);
+	status = k_mbox_get(&benchmark_mbox, &rx_msg, &single_element_buffer,
+			    K_MSEC(300));
 	MBOX_CHECK(status);
 }
 
@@ -420,7 +424,7 @@ void thread_mbox_sync_get_send(void *p1, void *p2, void *p3)
 		.tx_target_thread = K_ANY,
 	};
 
-	status = k_mbox_put(&benchmark_mbox, &tx_msg, 300);
+	status = k_mbox_put(&benchmark_mbox, &tx_msg, K_MSEC(300));
 	MBOX_CHECK(status);
 }
 
@@ -437,7 +441,8 @@ void thread_mbox_sync_get_receive(void *p1, void *p2, void *p3)
 	TIMING_INFO_PRE_READ();
 	mbox_sync_get_start_time = TIMING_INFO_OS_GET_TIME();
 
-	status = k_mbox_get(&benchmark_mbox, &rx_msg, &single_element_buffer, 300);
+	status = k_mbox_get(&benchmark_mbox, &rx_msg, &single_element_buffer,
+			    K_MSEC(300));
 	MBOX_CHECK(status);
 }
 
@@ -469,6 +474,7 @@ void thread_mbox_async_put_receive(void *p1, void *p2, void *p3)
 		.tx_target_thread = K_ANY
 	};
 
-	status = k_mbox_get(&benchmark_mbox, &rx_msg, &single_element_buffer, 300);
+	status = k_mbox_get(&benchmark_mbox, &rx_msg, &single_element_buffer,
+			    K_MSEC(300));
 	MBOX_CHECK(status);
 }

--- a/tests/benchmarks/timing_info/src/semaphore_bench.c
+++ b/tests/benchmarks/timing_info/src/semaphore_bench.c
@@ -95,7 +95,7 @@ void semaphore_bench(void)
 	TIMING_INFO_PRE_READ();
 	u32_t sem_take_wo_cxt_start = TIMING_INFO_OS_GET_TIME();
 
-	k_sem_take(&sem_bench, 10);
+	k_sem_take(&sem_bench, K_MSEC(10));
 	TIMING_INFO_PRE_READ();
 	u32_t sem_take_wo_cxt_end = TIMING_INFO_OS_GET_TIME();
 	u32_t sem_take_wo_cxt_cycles = sem_take_wo_cxt_end -
@@ -136,7 +136,7 @@ void mutex_bench(void)
 		TIMING_INFO_PRE_READ();
 		mutex_lock_start_time = TIMING_INFO_OS_GET_TIME();
 
-		k_mutex_lock(&mutex0, 100);
+		k_mutex_lock(&mutex0, K_MSEC(100));
 
 		TIMING_INFO_PRE_READ();
 		mutex_lock_end_time = TIMING_INFO_OS_GET_TIME();
@@ -180,13 +180,13 @@ void thread_sem1_test(void *p1, void *p2, void *p3)
 	z_arch_timing_value_swap_end = 1U;
 	TIMING_INFO_PRE_READ();
 	sem_start_time =  TIMING_INFO_OS_GET_TIME();
-	k_sem_take(&sem_bench, 10);
+	k_sem_take(&sem_bench, K_MSEC(10));
 }
 
 u32_t sem_count;
 void thread_sem0_test(void *p1, void *p2, void *p3)
 {
-	k_sem_take(&sem_bench, 10);/* To sync threads */
+	k_sem_take(&sem_bench, K_MSEC(10));/* To sync threads */
 
 	k_sem_give(&sem_bench);
 	sem_count++;
@@ -197,12 +197,12 @@ void thread_sem1_give_test(void *p1, void *p2, void *p3)
 {
 	k_sem_give(&sem_bench);         /* sync the 2 threads*/
 
-	k_sem_take(&sem_bench_1, 1000); /* clear the previous sem_give*/
+	k_sem_take(&sem_bench_1, K_MSEC(1000)); /* clear the previous sem_give*/
 }
 
 void thread_sem0_give_test(void *p1, void *p2, void *p3)
 {
-	k_sem_take(&sem_bench, 10);/* To sync threads */
+	k_sem_take(&sem_bench, K_MSEC(10));/* To sync threads */
 
 	/* To make sure that the sem give will cause a swap to occur */
 	k_thread_priority_set(sem1_tid, 1);

--- a/tests/benchmarks/timing_info/src/yield_bench.c
+++ b/tests/benchmarks/timing_info/src/yield_bench.c
@@ -68,7 +68,7 @@ void yield_bench(void)
 
 void thread_yield0_test(void *p1, void *p2, void *p3)
 {
-	k_sem_take(&yield_sem, 10);
+	k_sem_take(&yield_sem, K_MSEC(10));
 	TIMING_INFO_PRE_READ();
 	thread_start_time =  TIMING_INFO_OS_GET_TIME();
 	while (count != 1000U) {

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -55,19 +55,20 @@ void test_single_read(void)
 
 	uart_rx_enable(uart_dev, rx_buf, 10, 50);
 	uart_tx(uart_dev, tx_buf, sizeof(tx_buf), 100);
-	zassert_equal(k_sem_take(&tx_done, 100), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_rdy, 100), 0, "RX_RDY timeout");
+	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
 
 	zassert_equal(memcmp(tx_buf, rx_buf, 5), 0, "Buffers not equal");
 	zassert_not_equal(memcmp(tx_buf, rx_buf+5, 5), 0, "Buffers not equal");
 
 	uart_tx(uart_dev, tx_buf, sizeof(tx_buf), 100);
-	zassert_equal(k_sem_take(&tx_done, 100), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_rdy, 100), 0, "RX_RDY timeout");
-	zassert_equal(k_sem_take(&rx_buf_released, 100),
+	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
+	zassert_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
 		      0,
 		      "RX_BUF_RELEASED timeout");
-	zassert_equal(k_sem_take(&rx_disabled, 1000), 0, "RX_DISABLED timeout");
+	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(1000)), 0,
+		      "RX_DISABLED timeout");
 	zassert_equal(memcmp(tx_buf, rx_buf+5, 5), 0, "Buffers not equal");
 	zassert_equal(tx_aborted_count, 0, "TX aborted triggered");
 }
@@ -125,13 +126,15 @@ void test_chained_read(void)
 	uart_rx_enable(uart_dev, chained_read_buf0, 10, 50);
 
 	for (int i = 0; i < 6; i++) {
-		zassert_not_equal(k_sem_take(&rx_disabled, 10),
+		zassert_not_equal(k_sem_take(&rx_disabled, K_MSEC(10)),
 				  0,
 				  "RX_DISABLED occurred");
 		snprintf(tx_buf, sizeof(tx_buf), "Message %d", i);
 		uart_tx(uart_dev, tx_buf, sizeof(tx_buf), 100);
-		zassert_equal(k_sem_take(&tx_done, 100), 0, "TX_DONE timeout");
-		zassert_equal(k_sem_take(&rx_rdy, 1000), 0, "RX_RDY timeout");
+		zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0,
+			      "TX_DONE timeout");
+		zassert_equal(k_sem_take(&rx_rdy, K_MSEC(1000)), 0,
+			      "RX_RDY timeout");
 		size_t read_len_temp = read_len;
 
 		zassert_equal(read_len_temp, sizeof(tx_buf),
@@ -140,7 +143,8 @@ void test_chained_read(void)
 			      0,
 			      "Buffers not equal");
 	}
-	zassert_equal(k_sem_take(&rx_disabled, 100), 0, "RX_DISABLED timeout");
+	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
+		      "RX_DISABLED timeout");
 }
 
 u8_t double_buffer[2][12];
@@ -192,14 +196,17 @@ void test_double_buffer(void)
 	for (int i = 0; i < 100; i++) {
 		snprintf(tx_buf, sizeof(tx_buf), "%03d", i);
 		uart_tx(uart_dev, tx_buf, sizeof(tx_buf), 100);
-		zassert_equal(k_sem_take(&tx_done, 100), 0, "TX_DONE timeout");
-		zassert_equal(k_sem_take(&rx_rdy, 100), 0, "RX_RDY timeout");
+		zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0,
+			      "TX_DONE timeout");
+		zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0,
+			      "RX_RDY timeout");
 		zassert_equal(memcmp(tx_buf, read_ptr, sizeof(tx_buf)),
 			      0,
 			      "Buffers not equal");
 	}
 	uart_rx_disable(uart_dev);
-	zassert_equal(k_sem_take(&rx_disabled, 100), 0, "RX_DISABLED timeout");
+	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
+		      "RX_DISABLED timeout");
 }
 
 void test_read_abort_callback(struct uart_event *evt, void *user_data)
@@ -237,19 +244,21 @@ void test_read_abort(void)
 	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), 50);
 
 	uart_tx(uart_dev, tx_buf, 5, 100);
-	zassert_equal(k_sem_take(&tx_done, 100), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_rdy, 100), 0, "RX_RDY timeout");
+	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
 	zassert_equal(memcmp(tx_buf, rx_buf, 5), 0, "Buffers not equal");
 
 
 	uart_tx(uart_dev, tx_buf, 95, 100);
 	uart_rx_disable(uart_dev);
-	zassert_equal(k_sem_take(&tx_done, 100), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_buf_released, 100),
+	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	zassert_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
 		      0,
 		      "RX_BUF_RELEASED timeout");
-	zassert_equal(k_sem_take(&rx_disabled, 100), 0, "RX_DISABLED timeout");
-	zassert_not_equal(k_sem_take(&rx_rdy, 100), 0, "RX_RDY occurred");
+	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
+		      "RX_DISABLED timeout");
+	zassert_not_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0,
+			  "RX_RDY occurred");
 	zassert_not_equal(memcmp(tx_buf, rx_buf, 100), 0, "Buffers equal");
 }
 
@@ -296,22 +305,25 @@ void test_write_abort(void)
 	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), 50);
 
 	uart_tx(uart_dev, tx_buf, 5, 100);
-	zassert_equal(k_sem_take(&tx_done, 100), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_rdy, 100), 0, "RX_RDY timeout");
+	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
 	zassert_equal(memcmp(tx_buf, rx_buf, 5), 0, "Buffers not equal");
 
 	uart_tx(uart_dev, tx_buf, 95, 100);
 	uart_tx_abort(uart_dev);
-	zassert_equal(k_sem_take(&tx_aborted, 100), 0, "TX_ABORTED timeout");
+	zassert_equal(k_sem_take(&tx_aborted, K_MSEC(100)), 0,
+		      "TX_ABORTED timeout");
 	if (sent != 0) {
-		zassert_equal(k_sem_take(&rx_rdy, 100), 0, "RX_RDY timeout");
+		zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0,
+			      "RX_RDY timeout");
 		zassert_equal(sent, received, "Sent is not equal to received.");
 	}
 	uart_rx_disable(uart_dev);
-	zassert_equal(k_sem_take(&rx_buf_released, 100),
+	zassert_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
 		      0,
 		      "RX_BUF_RELEASED timeout");
-	zassert_equal(k_sem_take(&rx_disabled, 100), 0, "RX_DISABLED timeout");
+	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
+		      "RX_DISABLED timeout");
 }
 
 u8_t chained_write_tx_bufs[2][10] = {"Message 1", "Message 2"};
@@ -363,10 +375,10 @@ void test_chained_write(void)
 	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), 50);
 
 	uart_tx(uart_dev, chained_write_tx_bufs[0], 10, 100);
-	zassert_equal(k_sem_take(&tx_done, 100), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&tx_done, 100), 0, "TX_DONE timeout");
+	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
 	zassert_equal(chained_write_next_buf, false, "Sent no message");
-	zassert_equal(k_sem_take(&rx_rdy, 100), 0, "RX_RDY timeout");
+	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
 	zassert_equal(memcmp(chained_write_tx_bufs[0], rx_buf, 10),
 		      0,
 		      "Buffers not equal");
@@ -375,10 +387,11 @@ void test_chained_write(void)
 		      "Buffers not equal");
 
 	uart_rx_disable(uart_dev);
-	zassert_equal(k_sem_take(&rx_buf_released, 100),
+	zassert_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
 		      0,
 		      "RX_BUF_RELEASED timeout");
-	zassert_equal(k_sem_take(&rx_disabled, 100), 0, "RX_DISABLED timeout");
+	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
+		      "RX_DISABLED timeout");
 }
 
 u8_t long_rx_buf[1024];
@@ -436,8 +449,8 @@ void test_long_buffers(void)
 	uart_rx_enable(uart_dev, long_rx_buf, sizeof(long_rx_buf), 10);
 
 	uart_tx(uart_dev, long_tx_buf, 500, 200);
-	zassert_equal(k_sem_take(&tx_done, 200), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_rdy, 200), 0, "RX_RDY timeout");
+	zassert_equal(k_sem_take(&tx_done, K_MSEC(200)), 0, "TX_DONE timeout");
+	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(200)), 0, "RX_RDY timeout");
 	zassert_equal(long_received[0], 500, "Wrong number of bytes received.");
 	zassert_equal(memcmp(long_tx_buf, long_rx_buf, 500),
 		      0,
@@ -445,9 +458,9 @@ void test_long_buffers(void)
 
 	evt_num = 0;
 	uart_tx(uart_dev, long_tx_buf, 1000, 200);
-	zassert_equal(k_sem_take(&tx_done, 200), 0, "TX_DONE timeout");
-	zassert_equal(k_sem_take(&rx_rdy, 200), 0, "RX_RDY timeout");
-	zassert_equal(k_sem_take(&rx_rdy, 200), 0, "RX_RDY timeout");
+	zassert_equal(k_sem_take(&tx_done, K_MSEC(200)), 0, "TX_DONE timeout");
+	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(200)), 0, "RX_RDY timeout");
+	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(200)), 0, "RX_RDY timeout");
 	zassert_equal(long_received[0], 524, "Wrong number of bytes received.");
 	zassert_equal(long_received[1], 476, "Wrong number of bytes received.");
 	zassert_equal(memcmp(long_tx_buf, long_rx_buf + 500, long_received[0]),
@@ -458,8 +471,9 @@ void test_long_buffers(void)
 		      "Buffers not equal");
 
 	uart_rx_disable(uart_dev);
-	zassert_equal(k_sem_take(&rx_buf_released, 100),
+	zassert_equal(k_sem_take(&rx_buf_released, K_MSEC(100)),
 		      0,
 		      "RX_BUF_RELEASED timeout");
-	zassert_equal(k_sem_take(&rx_disabled, 100), 0, "RX_DISABLED timeout");
+	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(100)), 0,
+		      "RX_DISABLED timeout");
 }

--- a/tests/kernel/common/src/timeout_order.c
+++ b/tests/kernel/common/src/timeout_order.c
@@ -73,7 +73,7 @@ void test_timeout_order(void)
 	}
 
 	for (ii = 0; ii < NUM_TIMEOUTS; ii++) {
-		k_timer_start(&timer[ii], 100, 0);
+		k_timer_start(&timer[ii], K_MSEC(100), K_NO_WAIT);
 	}
 
 	struct k_poll_event poll_events[NUM_TIMEOUTS];
@@ -86,7 +86,7 @@ void test_timeout_order(void)
 	/* drop prio to get all poll events together */
 	k_thread_priority_set(k_current_get(), prio + 1);
 
-	zassert_equal(k_poll(poll_events, NUM_TIMEOUTS, 2000), 0, "");
+	zassert_equal(k_poll(poll_events, NUM_TIMEOUTS, K_MSEC(2000)), 0, "");
 
 	k_thread_priority_set(k_current_get(), prio - 1);
 

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -175,7 +175,7 @@ void stack_sentinel_timer(void)
 
 	blow_up_stack();
 	k_timer_init(&timer, NULL, NULL);
-	k_timer_start(&timer, 1, 0);
+	k_timer_start(&timer, K_MSEC(1), K_NO_WAIT);
 	while (true) {
 	}
 }

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -100,7 +100,7 @@ void test_nested_isr(void)
 #endif /* CONFIG_ARM */
 
 	k_timer_init(&timer, handler, NULL);
-	k_timer_start(&timer, DURATION, 0);
+	k_timer_start(&timer, DURATION, K_NO_WAIT);
 
 #if defined(CONFIG_ARM)
 	irq_enable(irq_line_0);
@@ -131,7 +131,7 @@ static void offload_function(void *param)
 	zassert_true(k_is_in_isr(), "Not in IRQ context!");
 	k_timer_init(&timer, timer_handler, NULL);
 	k_busy_wait(MS_TO_US(1));
-	k_timer_start(&timer, DURATION, 0);
+	k_timer_start(&timer, DURATION, K_NO_WAIT);
 	zassert_not_equal(check_lock_new, check_lock_old,
 		"Interrupt locking didn't work properly");
 }

--- a/tests/kernel/mem_pool/mem_pool/src/main.c
+++ b/tests/kernel/mem_pool/mem_pool/src/main.c
@@ -204,7 +204,7 @@ static void test_pool_block_get_timeout(void)
 		free_blocks(getwt_set, ARRAY_SIZE(getwt_set));
 	}
 
-	rv = k_mem_pool_alloc(&POOL_ID, &helper_block, 3148, 5);
+	rv = k_mem_pool_alloc(&POOL_ID, &helper_block, 3148, K_MSEC(5));
 	zassert_true(rv == 0,
 		     "Failed to get size 3148 byte block from POOL_ID");
 
@@ -213,7 +213,7 @@ static void test_pool_block_get_timeout(void)
 		     "byte block from POOL_ID");
 
 	k_sem_give(&HELPER_SEM);    /* Activate helper_task */
-	rv = k_mem_pool_alloc(&POOL_ID, &block, 3148, 20);
+	rv = k_mem_pool_alloc(&POOL_ID, &block, 3148, K_MSEC(20));
 	zassert_true(rv == 0, "Failed to get size 3148 byte block from POOL_ID");
 
 	rv = k_sem_take(&REGRESS_SEM, K_NO_WAIT);

--- a/tests/kernel/mem_slab/mslab/src/main.c
+++ b/tests/kernel/mem_slab/mslab/src/main.c
@@ -243,13 +243,13 @@ void test_mslab(void)
 	TC_PRINT("(3) - Further allocation results in  timeout "
 		 "in <%s>\n", __func__);
 
-	ret_value = k_mem_slab_alloc(&map_lgblks, &b, 20);
+	ret_value = k_mem_slab_alloc(&map_lgblks, &b, K_MSEC(20));
 	zassert_equal(-EAGAIN, ret_value,
 		      "Failed k_mem_slab_alloc, retValue %d\n", ret_value);
 
 	TC_PRINT("%s: start to wait for block\n", __func__);
 	k_sem_give(&SEM_REGRESSDONE);    /* Allow helper thread to run part 4 */
-	ret_value = k_mem_slab_alloc(&map_lgblks, &b, 50);
+	ret_value = k_mem_slab_alloc(&map_lgblks, &b, K_MSEC(50));
 	zassert_equal(0, ret_value,
 		      "Failed k_mem_slab_alloc, ret_value %d\n", ret_value);
 

--- a/tests/kernel/obj_tracing/src/main.c
+++ b/tests/kernel/obj_tracing/src/main.c
@@ -95,7 +95,7 @@ static void object_monitor(void)
 
 	void *obj_list   = NULL;
 
-	k_sem_take(&f3, 0);
+	k_sem_take(&f3, K_NO_WAIT);
 	/* ztest use one semaphore so use one count less than expected to pass
 	 * test
 	 */

--- a/tests/kernel/pending/src/main.c
+++ b/tests/kernel/pending/src/main.c
@@ -196,7 +196,7 @@ static void timer_tests(void)
 
 	timer_start_tick = k_uptime_get_32();
 
-	k_timer_start(&timer, NUM_SECONDS(1), 0);
+	k_timer_start(&timer, NUM_SECONDS(1), K_NO_WAIT);
 
 	if (k_timer_status_sync(&timer)) {
 		timer_data = timer.user_data;

--- a/tests/kernel/poll/src/test_poll.c
+++ b/tests/kernel/poll/src/test_poll.c
@@ -78,16 +78,17 @@ void test_poll_no_wait(void)
 	 * implementation
 	 */
 
-	zassert_equal(k_poll(events, 0, 0), -EINVAL, NULL);
-	zassert_equal(k_poll(events, INT_MAX, 0), -EINVAL, NULL);
-	zassert_equal(k_poll(events, 4096, 0), -ENOMEM, NULL);
+	zassert_equal(k_poll(events, 0, K_NO_WAIT), -EINVAL, NULL);
+	zassert_equal(k_poll(events, INT_MAX, K_NO_WAIT), -EINVAL, NULL);
+	zassert_equal(k_poll(events, 4096, K_NO_WAIT), -ENOMEM, NULL);
 
 	struct k_poll_event bad_events[] = {
 		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SEM_AVAILABLE,
 					 K_POLL_NUM_MODES,
 					 &no_wait_sem),
 	};
-	zassert_equal(k_poll(bad_events, ARRAY_SIZE(bad_events), 0), -EINVAL,
+	zassert_equal(k_poll(bad_events, ARRAY_SIZE(bad_events), K_NO_WAIT),
+		      -EINVAL,
 		      NULL);
 
 	struct k_poll_event bad_events2[] = {
@@ -95,7 +96,8 @@ void test_poll_no_wait(void)
 					 K_POLL_MODE_NOTIFY_ONLY,
 					 &no_wait_sem),
 	};
-	zassert_equal(k_poll(bad_events2, ARRAY_SIZE(bad_events), 0), -EINVAL,
+	zassert_equal(k_poll(bad_events2, ARRAY_SIZE(bad_events), K_NO_WAIT),
+		      -EINVAL,
 		      NULL);
 #endif /* CONFIG_USERSPACE */
 
@@ -103,10 +105,10 @@ void test_poll_no_wait(void)
 	zassert_false(k_fifo_alloc_put(&no_wait_fifo, &msg), NULL);
 	k_poll_signal_raise(&no_wait_signal, SIGNAL_RESULT);
 
-	zassert_equal(k_poll(events, ARRAY_SIZE(events), 0), 0, "");
+	zassert_equal(k_poll(events, ARRAY_SIZE(events), K_NO_WAIT), 0, "");
 
 	zassert_equal(events[0].state, K_POLL_STATE_SEM_AVAILABLE, "");
-	zassert_equal(k_sem_take(&no_wait_sem, 0), 0, "");
+	zassert_equal(k_sem_take(&no_wait_sem, K_NO_WAIT), 0, "");
 
 	zassert_equal(events[1].state, K_POLL_STATE_FIFO_DATA_AVAILABLE, "");
 	msg_ptr = k_fifo_get(&no_wait_fifo, 0);
@@ -128,13 +130,14 @@ void test_poll_no_wait(void)
 	events[3].state = K_POLL_STATE_NOT_READY;
 	k_poll_signal_reset(&no_wait_signal);
 
-	zassert_equal(k_poll(events, ARRAY_SIZE(events), 0), -EAGAIN, "");
+	zassert_equal(k_poll(events, ARRAY_SIZE(events), K_NO_WAIT), -EAGAIN,
+		      "");
 	zassert_equal(events[0].state, K_POLL_STATE_NOT_READY, "");
 	zassert_equal(events[1].state, K_POLL_STATE_NOT_READY, "");
 	zassert_equal(events[2].state, K_POLL_STATE_NOT_READY, "");
 	zassert_equal(events[3].state, K_POLL_STATE_NOT_READY, "");
 
-	zassert_not_equal(k_sem_take(&no_wait_sem, 0), 0, "");
+	zassert_not_equal(k_sem_take(&no_wait_sem, K_NO_WAIT), 0, "");
 	zassert_is_null(k_fifo_get(&no_wait_fifo, 0), "");
 }
 
@@ -216,7 +219,7 @@ void test_poll_wait(void)
 	zassert_equal(rc, 0, "");
 
 	zassert_equal(wait_events[0].state, K_POLL_STATE_SEM_AVAILABLE, "");
-	zassert_equal(k_sem_take(&wait_sem, 0), 0, "");
+	zassert_equal(k_sem_take(&wait_sem, K_NO_WAIT), 0, "");
 	zassert_equal(wait_events[0].tag, TAG_0, "");
 
 	zassert_equal(wait_events[1].state,
@@ -272,7 +275,7 @@ void test_poll_wait(void)
 	zassert_equal(rc, 0, "");
 
 	zassert_equal(wait_events[0].state, K_POLL_STATE_SEM_AVAILABLE, "");
-	zassert_equal(k_sem_take(&wait_sem, 0), 0, "");
+	zassert_equal(k_sem_take(&wait_sem, K_NO_WAIT), 0, "");
 	zassert_equal(wait_events[0].tag, TAG_0, "");
 
 	zassert_equal(wait_events[1].state, K_POLL_STATE_NOT_READY, "");
@@ -307,7 +310,7 @@ void test_poll_wait(void)
 	zassert_equal(rc, 0, "");
 
 	zassert_equal(wait_events[0].state, K_POLL_STATE_SEM_AVAILABLE, "");
-	zassert_equal(k_sem_take(&wait_sem, 0), 0, "");
+	zassert_equal(k_sem_take(&wait_sem, K_NO_WAIT), 0, "");
 	zassert_equal(wait_events[0].tag, TAG_0, "");
 
 	zassert_equal(wait_events[1].state, K_POLL_STATE_NOT_READY, "");
@@ -326,7 +329,7 @@ void test_poll_wait(void)
 	zassert_equal(rc, 0, "");
 
 	zassert_equal(wait_events[0].state, K_POLL_STATE_NOT_READY, "");
-	zassert_equal(k_sem_take(&wait_sem, 0), -EBUSY, "");
+	zassert_equal(k_sem_take(&wait_sem, K_NO_WAIT), -EBUSY, "");
 	zassert_equal(wait_events[0].tag, TAG_0, "");
 
 	zassert_equal(wait_events[1].state,
@@ -346,7 +349,7 @@ void test_poll_wait(void)
 	zassert_equal(rc, 0, "");
 
 	zassert_equal(wait_events[0].state, K_POLL_STATE_NOT_READY, "");
-	zassert_equal(k_sem_take(&wait_sem, 0), -EBUSY, "");
+	zassert_equal(k_sem_take(&wait_sem, K_NO_WAIT), -EBUSY, "");
 	zassert_equal(wait_events[0].tag, TAG_0, "");
 
 	zassert_equal(wait_events[1].state, K_POLL_STATE_NOT_READY, "");

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -80,7 +80,7 @@ static void timer_handler(struct k_timer *timer)
 static void thread_handler(void *p1, void *p2, void *p3)
 {
 	k_timer_init(&timer, timer_handler, NULL);
-	k_timer_start(&timer, DURATION, 0);
+	k_timer_start(&timer, DURATION, K_NO_WAIT);
 }
 
 /*test cases*/
@@ -188,7 +188,7 @@ void test_sleep_wakeup_preemptible(void)
 static int executed;
 static void coop_thread(void *p1, void *p2, void *p3)
 {
-	k_sem_take(&pend_sema, 100);
+	k_sem_take(&pend_sema, K_MSEC(100));
 	executed = 1;
 }
 

--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -556,7 +556,7 @@ void test_sem_measure_timeouts(void)
 	/* With 0 as the timeout */
 	start_ticks = k_uptime_get();
 
-	ret_value = k_sem_take(&simple_sem, 0);
+	ret_value = k_sem_take(&simple_sem, K_NO_WAIT);
 
 	end_ticks = k_uptime_get();
 

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -159,7 +159,7 @@ void test_timer_period_0(void)
 {
 	init_timer_data();
 	/** TESTPOINT: set period 0 */
-	k_timer_start(&period0_timer, DURATION, 0);
+	k_timer_start(&period0_timer, DURATION, K_NO_WAIT);
 	tdata.timestamp = k_uptime_get();
 	busy_wait_ms(DURATION + 1);
 
@@ -208,7 +208,7 @@ void test_timer_expirefn_null(void)
  */
 static void tick_sync(void)
 {
-	k_timer_start(&sync_timer, 0, 1);
+	k_timer_start(&sync_timer, K_NO_WAIT, K_MSEC(1));
 	k_timer_status_sync(&sync_timer);
 	k_timer_stop(&sync_timer);
 }
@@ -242,7 +242,7 @@ void test_timer_periodicity(void)
 
 	init_timer_data();
 	/** TESTPOINT: set duration 0 */
-	k_timer_start(&periodicity_timer, 0, PERIOD);
+	k_timer_start(&periodicity_timer, K_NO_WAIT, PERIOD);
 
 	/* clear the expiration that would have happened due to
 	 * whatever duration that was set. Since timer is likely
@@ -485,7 +485,7 @@ void test_timer_user_data(void)
 	}
 
 	for (ii = 0; ii < 5; ii++) {
-		k_timer_start(user_data_timer[ii], 50 + ii * 50, 0);
+		k_timer_start(user_data_timer[ii], 50 + ii * 50, K_NO_WAIT);
 	}
 
 	k_sleep(50 * ii + 50);
@@ -519,7 +519,7 @@ void test_timer_remaining_get(void)
 	u32_t remaining;
 
 	init_timer_data();
-	k_timer_start(&remain_timer, DURATION, 0);
+	k_timer_start(&remain_timer, DURATION, K_NO_WAIT);
 	busy_wait_ms(DURATION / 2);
 	remaining = k_timer_remaining_get(&remain_timer);
 	k_timer_stop(&remain_timer);

--- a/tests/kernel/workq/work_queue_api/src/main.c
+++ b/tests/kernel/workq/work_queue_api/src/main.c
@@ -91,7 +91,7 @@ static void twork_resubmit(void *data)
 	/**TESTPOINT: init via k_work_init*/
 	k_delayed_work_init(&new_work, new_work_handler);
 
-	k_delayed_work_submit_to_queue(work_q, &new_work, 0);
+	k_delayed_work_submit_to_queue(work_q, &new_work, K_NO_WAIT);
 
 	/* This is done to test a neagtive case when k_delayed_work_cancel()
 	 * fails in k_delayed_work_submit_to_queue API. Removing work from it
@@ -100,7 +100,7 @@ static void twork_resubmit(void *data)
 	 */
 	k_queue_remove(&(new_work.work_q->queue), &(new_work.work));
 
-	zassert_equal(k_delayed_work_submit_to_queue(work_q, &new_work, 0),
+	zassert_equal(k_delayed_work_submit_to_queue(work_q, &new_work, K_NO_WAIT),
 		      -EINVAL, NULL);
 
 	k_sem_give(&sync_sema);


### PR DESCRIPTION
Legacy code uses integer literal delays measured in milliseconds as arguments to kernel API that is intended to take timeout values.  Replace these integers with the corresponding defined constants and macro conversions that represent the timeout values.

This is a demonstration and prototype of using semantic patch technology to repeatably perform the conversions necessary to support #17155, done in a way that is reviewable, verifiable, and easy to re-apply when pending work is merged to master or rebases are required.