### PR TITLE
tests/kernel/sched/schedule_api: Filter for MULTIQ platforms

### DIFF
--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -1,10 +1,12 @@
 tests:
   kernel.sched:
+    filter: not CONFIG_SCHED_MULTIQ
     extra_configs:
       - CONFIG_TIMESLICING=y
     min_ram: 40
     tags: kernel threads sched userspace
   kernel.sched_no_timeslicing:
+    filter: not CONFIG_SCHED_MULTIQ
     extra_configs:
       - CONFIG_TIMESLICING=n
     min_ram: 40


### PR DESCRIPTION
This test requires more than 32 static priorities by default, and
doesn't run with the multiq scheduler without a special configuration.
That used to be specified per-platform, but got moved to a separate
test case a while back.

This broke non-default platforms like qemu_cortex_m3 which use
SCHED_MULTIQ as their default backend.  Put a filter in place instead
of going back to per-platform changes.

Fixes #19437

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>