### PR TITLE
doc: dts: Include #cells in legacy syntax section + testedtlib.py nit

### DIFF
--- a/doc/guides/dts/index.rst
+++ b/doc/guides/dts/index.rst
@@ -485,6 +485,12 @@ The binding below shows various legacy syntax.
                type: int
                category: required
 
+   # Assume this is a binding for an interrupt controller
+   "#cells":
+       - irq
+       - priority
+       - flags
+
 This should now be written like this:
 
 .. code-block:: yaml
@@ -511,6 +517,11 @@ This should now be written like this:
            child-prop:
                type: int
                required: true
+
+   interrupt-cells:
+       - irq
+       - priority
+       - cells
 
 The legacy syntax is still supported for backwards compatibility, but generates
 deprecation warnings. Support will be dropped in the Zephyr 2.3 release.

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -961,7 +961,6 @@ class Node:
         # to have a 'type: ...'. No Property object is created for it.
         return None
 
-
     def _check_undeclared_props(self):
         # Checks that all properties are declared in the binding
 

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -39,7 +39,7 @@ def run():
     edt = edtlib.EDT("test.dts", ["test-bindings"], warnings)
 
     # Deprecated features are tested too, which generate warnings. Verify them.
-    verify_streq(warnings.getvalue(), """\
+    verify_eq(warnings.getvalue(), """\
 warning: The 'properties: compatible: constraint: ...' way of specifying the compatible in test-bindings/deprecated.yaml is deprecated. Put 'compatible: "deprecated"' at the top level of the binding instead.
 warning: the 'inherits:' syntax in test-bindings/deprecated.yaml is deprecated and will be removed - please use 'include: foo.yaml' or 'include: [foo.yaml, bar.yaml]' instead
 warning: please put 'required: true' instead of 'category: required' in properties: required: ...' in test-bindings/deprecated.yaml - 'category' will be removed


### PR DESCRIPTION
Give an example for an interrupt controller, where 'interrupt-cells'
should be used instead.