### PR TITLE
Test arm thread swap extend to cortex m0

### DIFF
--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.yaml
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.yaml
@@ -15,6 +15,5 @@ supported:
   - watchdog
   - counter
 testing:
-  default: true
   ignore_tags:
     - net

--- a/tests/arch/arm/arm_thread_swap/README.txt
+++ b/tests/arch/arm/arm_thread_swap/README.txt
@@ -17,12 +17,12 @@ behaves as expected. In particular, the test verifies that:
   space or FP shared registers) is saved and restored properly.
 
 Notes:
-  The test verifies the correct behavior of the thread contex-switch,
+  The test verifies the correct behavior of the thread context-switch,
   when it is triggered indirectly (by setting the PendSV interrupt
   to pending state), as well as when the thread itself triggers its
   swap-out (by calling z_arch_swap(.)).
 
-  The test is currently supported only in ARMv7-M and ARMv8-M Mainline
+  The test is currently supported in ARM Cortex-M Baseline and Mainline
   targets.
 
 

--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -215,8 +215,8 @@ static void alt_thread_entry(void)
 	zassert_true(p_ztest_thread->arch.basepri == 0,
 		"ztest thread basepri not preserved in swap-out\n");
 #else
-	/* Verify that the main test thread has an initial value of zero
-	 * for state variable thread.arch.basepri.
+	/* Verify that the main test thread has the correct value
+	 * for state variable thread.arch.basepri (set before swap).
 	 */
 	zassert_true(p_ztest_thread->arch.basepri == BASEPRI_MODIFIED_1,
 		"ztest thread basepri not preserved in swap-out\n");
@@ -359,7 +359,7 @@ void test_arm_thread_swap(void)
 	/* Verify, also, that the interrupts are unlocked. */
 #if defined(CONFIG_CPU_CORTEX_M_HAS_BASEPRI)
 	zassert_true(__get_BASEPRI() == 0,
-		"initial BASEPRI not in zero\n");
+		"initial BASEPRI not zero\n");
 #else
 	/* For Cortex-M Baseline architecture, we verify that
 	 * the interrupt lock is disabled.
@@ -429,7 +429,7 @@ void test_arm_thread_swap(void)
 	 * The container will, later, be populated by the swap
 	 * mechanism.
 	 */
-	memcpy(&_current->callee_saved, 0, sizeof(_callee_saved_t));
+	memset(&_current->callee_saved, 0, sizeof(_callee_saved_t));
 
 	/* Verify context-switch has not occurred yet. */
 	test_flag = switch_flag;

--- a/tests/arch/arm/arm_thread_swap/testcase.yaml
+++ b/tests/arch/arm/arm_thread_swap/testcase.yaml
@@ -1,11 +1,11 @@
 tests:
   arch.arm.swap.common:
     arch_whitelist: arm
-    filter: CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     tags: arm
   arch.arm.swap.common.no_optimizations:
     arch_whitelist: arm
-    filter: CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     extra_configs:
       - CONFIG_NO_OPTIMIZATIONS=y
     tags: arm


### PR DESCRIPTION
- remove nrf51_pca10028 from default boards, since we now have qemu_cortex_m0
- re-work the arm-thread-swap test so it builds and runs for Cortex-M Baseline