### PR TITLE
boards: nrf: Add pwm-led0 alias in all Nordic DKs with enabled PWM node

### DIFF
--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -43,6 +43,13 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&sw_pwm 21>;
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -69,6 +76,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		led3 = &led3;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;

--- a/boards/arm/nrf51_pca10031/nrf51_pca10031.dts
+++ b/boards/arm/nrf51_pca10031/nrf51_pca10031.dts
@@ -39,11 +39,19 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&sw_pwm 21>;
+		};
+	};
+
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0_red;
 		led1 = &led0_green;
 		led2 = &led0_blue;
+		pwm-led0 = &pwm_led0;
 	};
 };
 

--- a/boards/arm/nrf52811_pca10056/nrf52811_pca10056.dts
+++ b/boards/arm/nrf52811_pca10056/nrf52811_pca10056.dts
@@ -43,6 +43,13 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0 13>;
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -69,6 +76,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		led3 = &led3;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -43,6 +43,13 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0 13>;
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -96,6 +103,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		led3 = &led3;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -44,6 +44,13 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0 17>;
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -97,6 +104,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		led3 = &led3;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;

--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_common.dts
@@ -35,6 +35,13 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0 2>;
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -61,6 +68,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		led3 = &led3;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button2;
 		sw1 = &button3;
 		sw2 = &button0;

--- a/drivers/pwm/Kconfig.nrf5_sw
+++ b/drivers/pwm/Kconfig.nrf5_sw
@@ -14,14 +14,3 @@ menuconfig PWM_NRF5_SW
 	  Enable driver to utilize PWM on the Nordic Semiconductor nRF5x series.
 	  This implementation provides up to 3 pins using one HF timer, two PPI
 	  channels per pin and one GPIOTE config per pin.
-
-if PWM_NRF5_SW
-
-config PWM_NRF5_SW_0_DEV_NAME
-	string "Nordic Semiconductor nRF5x series S/W PWM Device Name"
-	default "PWM_0"
-	help
-	  Specify the device name for the Nordic Semiconductor nRF5x series S/W
-	  PWM driver.
-
-endif # PWM_NRF5_SW

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -255,7 +255,7 @@ static const struct pwm_config pwm_nrf5_sw_0_config = {
 static struct pwm_data pwm_nrf5_sw_0_data;
 
 DEVICE_AND_API_INIT(pwm_nrf5_sw_0,
-		    CONFIG_PWM_NRF5_SW_0_DEV_NAME,
+		    DT_INST_0_NORDIC_NRF_SW_PWM_LABEL,
 		    pwm_nrf5_sw_init,
 		    &pwm_nrf5_sw_0_data,
 		    &pwm_nrf5_sw_0_config,

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -234,4 +234,5 @@
 	ppi-base = <7>;
 	gpiote-base = <0>;
 	status = "okay";
+	#pwm-cells = <1>;
 };

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -123,6 +123,7 @@
 			interrupts = <28 1>;
 			status = "disabled";
 			label = "PWM_0";
+			#pwm-cells = <1>;
 		};
 
 		qdec: qdec@40012000 {
@@ -224,4 +225,5 @@
 	clock-prescaler = <0>;
 	ppi-base = <14>;
 	gpiote-base = <0>;
+	#pwm-cells = <1>;
 };

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -130,6 +130,7 @@
 			interrupts = <28 1>;
 			status = "disabled";
 			label = "PWM_0";
+			#pwm-cells = <1>;
 		};
 
 		qdec: qdec@40012000 {
@@ -248,4 +249,5 @@
 	clock-prescaler = <0>;
 	ppi-base = <14>;
 	gpiote-base = <0>;
+	#pwm-cells = <1>;
 };

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -148,6 +148,7 @@
 			interrupts = <28 1>;
 			status = "disabled";
 			label = "PWM_0";
+			#pwm-cells = <1>;
 		};
 
 		pwm1: pwm@40021000 {
@@ -156,6 +157,7 @@
 			interrupts = <33 1>;
 			status = "disabled";
 			label = "PWM_1";
+			#pwm-cells = <1>;
 		};
 
 		pwm2: pwm@40022000 {
@@ -164,6 +166,7 @@
 			interrupts = <34 1>;
 			status = "disabled";
 			label = "PWM_2";
+			#pwm-cells = <1>;
 		};
 
 		qdec: qdec@40012000 {
@@ -325,4 +328,5 @@
 	clock-prescaler = <0>;
 	ppi-base = <14>;
 	gpiote-base = <0>;
+	#pwm-cells = <1>;
 };

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -174,6 +174,7 @@
 			interrupts = <28 1>;
 			status = "disabled";
 			label = "PWM_0";
+			#pwm-cells = <1>;
 		};
 
 		pwm1: pwm@40021000 {
@@ -182,6 +183,7 @@
 			interrupts = <33 1>;
 			status = "disabled";
 			label = "PWM_1";
+			#pwm-cells = <1>;
 		};
 
 		pwm2: pwm@40022000 {
@@ -190,6 +192,7 @@
 			interrupts = <34 1>;
 			status = "disabled";
 			label = "PWM_2";
+			#pwm-cells = <1>;
 		};
 
 		pwm3: pwm@4002d000 {
@@ -198,6 +201,7 @@
 			interrupts = <45 1>;
 			status = "disabled";
 			label = "PWM_3";
+			#pwm-cells = <1>;
 		};
 
 		qdec: qdec@40012000 {
@@ -397,4 +401,5 @@
 	clock-prescaler = <0>;
 	ppi-base = <14>;
 	gpiote-base = <0>;
+	#pwm-cells = <1>;
 };

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -270,6 +270,7 @@ pwm0: pwm@21000 {
 	interrupts = <33 1>;
 	status = "disabled";
 	label = "PWM_0";
+	#pwm-cells = <1>;
 };
 
 pwm1: pwm@22000 {
@@ -278,6 +279,7 @@ pwm1: pwm@22000 {
 	interrupts = <34 1>;
 	status = "disabled";
 	label = "PWM_1";
+	#pwm-cells = <1>;
 };
 
 pwm2: pwm@23000 {
@@ -286,6 +288,7 @@ pwm2: pwm@23000 {
 	interrupts = <35 1>;
 	status = "disabled";
 	label = "PWM_2";
+	#pwm-cells = <1>;
 };
 
 pwm3: pwm@24000 {
@@ -294,6 +297,7 @@ pwm3: pwm@24000 {
 	interrupts = <36 1>;
 	status = "disabled";
 	label = "PWM_3";
+	#pwm-cells = <1>;
 };
 
 gpio0: gpio@842500 {

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -5,13 +5,10 @@ description: >
 
 compatible: "nordic,nrf-pwm"
 
-include: base.yaml
+include: [pwm-controller.yaml, base.yaml]
 
 properties:
     reg:
-      required: true
-
-    label:
       required: true
 
     center-aligned:
@@ -58,3 +55,9 @@ properties:
       type: boolean
       description: Channel 3 inverted
       required: false
+
+    "#pwm-cells":
+      const: 1
+
+pwm-cells:
+  - channel

--- a/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
@@ -5,12 +5,9 @@ description: >
 
 compatible: "nordic,nrf-sw-pwm"
 
-include: base.yaml
+include: [pwm-controller.yaml, base.yaml]
 
 properties:
-    label:
-      required: true
-
     timer-instance:
       type: int
       description: Timer instance to use for generating the PWM output signals
@@ -35,3 +32,9 @@ properties:
       type: int
       description: GPIOTE base used for GPIOTE index calculation used for PWM output generation
       required: true
+
+    "#pwm-cells":
+      const: 1
+
+pwm-cells:
+  - channel

--- a/samples/bluetooth/mesh_demo/src/microbit.c
+++ b/samples/bluetooth/mesh_demo/src/microbit.c
@@ -249,7 +249,7 @@ void board_init(u16_t *addr)
 	struct mb_display *disp = mb_display_get();
 
 	nvm = device_get_binding(DT_FLASH_DEV_NAME);
-	pwm = device_get_binding(CONFIG_PWM_NRF5_SW_0_DEV_NAME);
+	pwm = device_get_binding(DT_INST_0_NORDIC_NRF_SW_PWM_LABEL);
 
 	*addr = NRF_UICR->CUSTOMER[0];
 	if (!*addr || *addr == 0xffff) {

--- a/samples/boards/bbc_microbit/pong/src/main.c
+++ b/samples/boards/bbc_microbit/pong/src/main.c
@@ -510,7 +510,7 @@ void main(void)
 
 	k_delayed_work_init(&refresh, game_refresh);
 
-	pwm = device_get_binding(CONFIG_PWM_NRF5_SW_0_DEV_NAME);
+	pwm = device_get_binding(DT_INST_0_NORDIC_NRF_SW_PWM_LABEL);
 
 	ble_init();
 

--- a/samples/boards/bbc_microbit/sound/src/main.c
+++ b/samples/boards/bbc_microbit/sound/src/main.c
@@ -94,7 +94,7 @@ void main(void)
 			   BIT(DT_ALIAS_SW0_GPIOS_PIN) | BIT(DT_ALIAS_SW1_GPIOS_PIN));
 	gpio_add_callback(gpio, &button_cb);
 
-	pwm = device_get_binding(CONFIG_PWM_NRF5_SW_0_DEV_NAME);
+	pwm = device_get_binding(DT_INST_0_NORDIC_NRF_SW_PWM_LABEL);
 
 	k_work_init(&beep_work, beep);
 	/* Notify with a beep that we've started */


### PR DESCRIPTION
The `pwm-led0` alias is required for building fade_led and blink_led samples.

Relates to: #19523 and #19467.

---

**dts: nordic: Add #pwm-cells property to Nordic PWM nodes**

Add #pwm-cells property in bindings for Nordic PWMs and add this
property with a suitable value assigned to all PWM nodes in dts
files for Nordic SoCs.

**boards: nrf: Add pwm-led0 alias in all Nordic DKs with enabled PWM node**

The `pwm-led0` alias is required for building fade_led and blink_led
samples. Add a suitable `pwmleds` definition and the mentioned alias
for all Nordic Semiconductor Development Kits that have a PWM node
with "okay" status.

**drivers: pwm_nrf5_sw: Remove PWM_NRF5_SW_0_DEV_NAME Kconfig option**

This option determines the name under which the device represented by
the `sw_pwm` node is registered in the system. But when the value of
this option does not match the `label` property of the `sw_pwm` node,
a problem arises when the `sw_pwm` node is referenced by a "pwm-leds"
compatible node, since the `*_PWMS_CONTROLLER` macro that is generated
for this referencing node contains a non-existing device name (as it is
the `label` property value, not the Kconfig option value).
This commit solves the issue described above by removing the Kconfig
option and replacing all of its occurrences in sample applications
by the standard macro generated for the `sw_pwm` node, containing
the value of the `label` property of this node.
