### PR TITLE
runners: pyocd: add --telnet-port parameter

### DIFF
--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -10,6 +10,7 @@ from runners.core import ZephyrBinaryRunner, RunnerCaps, \
     BuildConfiguration
 
 DEFAULT_PYOCD_GDB_PORT = 3333
+DEFAULT_PYOCD_TELNET_PORT = 4444
 
 
 class PyOcdBinaryRunner(ZephyrBinaryRunner):
@@ -18,7 +19,8 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
     def __init__(self, cfg, target,
                  pyocd='pyocd',
                  flash_addr=0x0, flash_opts=None,
-                 gdb_port=DEFAULT_PYOCD_GDB_PORT, tui=False,
+                 gdb_port=DEFAULT_PYOCD_GDB_PORT,
+                 telnet_port=DEFAULT_PYOCD_TELNET_PORT, tui=False,
                  board_id=None, daparg=None, frequency=None):
         super(PyOcdBinaryRunner, self).__init__(cfg)
 
@@ -27,6 +29,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
         self.flash_addr_args = ['-a', hex(flash_addr)] if flash_addr else []
         self.gdb_cmd = [cfg.gdb] if cfg.gdb is not None else None
         self.gdb_port = gdb_port
+        self.telnet_port = telnet_port
         self.tui_args = ['-tui'] if tui else []
         self.hex_name = cfg.hex_file
         self.bin_name = cfg.bin_file
@@ -75,6 +78,9 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--gdb-port', default=DEFAULT_PYOCD_GDB_PORT,
                             help='pyocd gdb port, defaults to {}'.format(
                                 DEFAULT_PYOCD_GDB_PORT))
+        parser.add_argument('--telnet-port', default=DEFAULT_PYOCD_TELNET_PORT,
+                            help='pyocd telnet port, defaults to {}'.format(
+                                DEFAULT_PYOCD_TELNET_PORT))
         parser.add_argument('--tui', default=False, action='store_true',
                             help='if given, GDB uses -tui')
         parser.add_argument('--board-id',
@@ -89,7 +95,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
             cfg, args.target,
             pyocd=args.pyocd,
             flash_addr=flash_addr, flash_opts=args.flash_opt,
-            gdb_port=args.gdb_port, tui=args.tui,
+            gdb_port=args.gdb_port, telnet_port=args.telnet_port, tui=args.tui,
             board_id=args.board_id, daparg=args.daparg,
             frequency=args.frequency)
 
@@ -102,7 +108,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
         return ret
 
     def port_args(self):
-        return ['-p', str(self.gdb_port)]
+        return ['-p', str(self.gdb_port), '-T', str(self.telnet_port)]
 
     def do_run(self, command, **kwargs):
         self.require(self.pyocd)

--- a/scripts/west_commands/tests/test_pyocd.py
+++ b/scripts/west_commands/tests/test_pyocd.py
@@ -23,13 +23,15 @@ TEST_FREQUENCY = 'test-frequency'
 TEST_DAPARG = 'test-daparg'
 TEST_TARGET = 'test-target'
 TEST_FLASH_OPTS = ['--test-flash', 'args']
-TEST_PORT = 1
+TEST_GDB_PORT = 1
+TEST_TELNET_PORT = 2
 
 TEST_ALL_KWARGS = {
     'pyocd': TEST_PYOCD,
     'flash_addr': TEST_ADDR,
     'flash_opts': TEST_FLASH_OPTS,
-    'gdb_port': TEST_PORT,
+    'gdb_port': TEST_GDB_PORT,
+    'telnet_port': TEST_TELNET_PORT,
     'tui': False,
     'board_id': TEST_BOARD_ID,
     'frequency': TEST_FREQUENCY,
@@ -43,7 +45,8 @@ TEST_ALL_PARAMS = (['--target', TEST_TARGET,
                     '--pyocd', TEST_PYOCD] +
                    ['--flash-opt={}'.format(o) for o in
                     TEST_FLASH_OPTS] +
-                   ['--gdb-port', str(TEST_PORT),
+                   ['--gdb-port', str(TEST_GDB_PORT),
+                    '--telnet-port', str(TEST_TELNET_PORT),
                     '--board-id', TEST_BOARD_ID,
                     '--frequency', str(TEST_FREQUENCY)])
 
@@ -76,18 +79,20 @@ FLASH_DEF_EXPECTED_CALL = ['pyocd', 'flash', '-e', 'sector',
 DEBUG_ALL_EXPECTED_SERVER = [TEST_PYOCD,
                              'gdbserver',
                              '-da', TEST_DAPARG,
-                             '-p', str(TEST_PORT),
+                             '-p', str(TEST_GDB_PORT),
+                             '-T', str(TEST_TELNET_PORT),
                              '-t', TEST_TARGET,
                              '-u', TEST_BOARD_ID,
                              '-f', TEST_FREQUENCY]
 DEBUG_ALL_EXPECTED_CLIENT = [RC_GDB, RC_KERNEL_ELF,
-                             '-ex', 'target remote :{}'.format(TEST_PORT),
+                             '-ex', 'target remote :{}'.format(TEST_GDB_PORT),
                              '-ex', 'monitor halt',
                              '-ex', 'monitor reset',
                              '-ex', 'load']
 DEBUG_DEF_EXPECTED_SERVER = ['pyocd',
                              'gdbserver',
                              '-p', '3333',
+                             '-T', '4444',
                              '-t', TEST_TARGET]
 DEBUG_DEF_EXPECTED_CLIENT = [RC_GDB, RC_KERNEL_ELF,
                              '-ex', 'target remote :3333',
@@ -99,13 +104,15 @@ DEBUG_DEF_EXPECTED_CLIENT = [RC_GDB, RC_KERNEL_ELF,
 DEBUGSERVER_ALL_EXPECTED_CALL = [TEST_PYOCD,
                                  'gdbserver',
                                  '-da', TEST_DAPARG,
-                                 '-p', str(TEST_PORT),
+                                 '-p', str(TEST_GDB_PORT),
+                                 '-T', str(TEST_TELNET_PORT),
                                  '-t', TEST_TARGET,
                                  '-u', TEST_BOARD_ID,
                                  '-f', TEST_FREQUENCY]
 DEBUGSERVER_DEF_EXPECTED_CALL = ['pyocd',
                                  'gdbserver',
                                  '-p', '3333',
+                                 '-T', '4444',
                                  '-t', TEST_TARGET]
 
 


### PR DESCRIPTION
With multiple debug probes attached, attempting to launch multiple debug
servers resulted in `OSError: [Errno 98] Address already in use` despite
explicitly setting `--gdb-port` to unique values.

The issue was caused by the default telnet port: 4444. Adding
`--telnet-port` parameter allows to explicitly define the address to a
unique value and avoid the socket exception.