### PR TITLE
Bluetooth: ATT: Fix disconnected ATT not releasing buffers

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2054,18 +2054,18 @@ static void att_reset(struct bt_att *att)
 {
 	struct bt_att_req *req, *tmp;
 	int i;
-#if CONFIG_BT_ATT_PREPARE_COUNT > 0
 	struct net_buf *buf;
 
+#if CONFIG_BT_ATT_PREPARE_COUNT > 0
 	/* Discard queued buffers */
 	while ((buf = k_fifo_get(&att->prep_queue, K_NO_WAIT))) {
 		net_buf_unref(buf);
 	}
+#endif /* CONFIG_BT_ATT_PREPARE_COUNT > 0 */
 
 	while ((buf = k_fifo_get(&att->tx_queue, K_NO_WAIT))) {
 		net_buf_unref(buf);
 	}
-#endif
 
 	atomic_set_bit(att->flags, ATT_DISCONNECTED);
 


### PR DESCRIPTION
Fix bug in ATT reset handling, not releasing queued notification
buffers when the connection is terminated.

Fixes: #19604

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>