### PR TITLE
[TOPIC-GPIO] improve test validation diagnostic

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
@@ -81,8 +81,10 @@ static int setup(void)
 	zassert_equal(rc, 0,
 		      "get raw low failed");
 	if (raw_in() != false) {
-		printk("FATAL: output low does not read low\n");
-		k_panic();
+		TC_PRINT("FATAL output pin not wired to input pin? (out low => in high)\n");
+		while (true) {
+			k_sleep(K_FOREVER);
+		}
 	}
 
 	zassert_equal(v1 & BIT(PIN_IN), 0,
@@ -96,8 +98,10 @@ static int setup(void)
 	zassert_equal(rc, 0,
 		      "get raw high failed");
 	if (raw_in() != true) {
-		printk("FATAL: output high does not read high\n");
-		k_panic();
+		TC_PRINT("FATAL output pin not wired to input pin? (out high => in low)\n");
+		while (true) {
+			k_sleep(K_FOREVER);
+		}
 	}
 	zassert_not_equal(v1 & BIT(PIN_IN), 0,
 			  "out high does not read low");


### PR DESCRIPTION
The test verifies that the output pin appears to be shorted to the
input pin by confirming output low and high read low and high.
Failure should block progress through the test as subsequent tests
will not pass.

Replace the use of k_panic() to halt the test with an infinite loop
that doesn't splatter the console with stack traces and register
dumps.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>