### PR TITLE
drivers: gpio: add named flag set for disconnected GPIO

### DIFF
--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -44,6 +44,9 @@ extern "C" {
 /** Enables pin as output, no change to the output state. */
 #define GPIO_OUTPUT             (1U << 9)
 
+/** Disables pin for both input and output. */
+#define GPIO_DISCONNECTED	0
+
 /** @cond INTERNAL_HIDDEN */
 
 /* Initializes output to a low state. */

--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
@@ -358,7 +358,7 @@ static int check_pulls(void)
 	TC_PRINT("- %s\n", __func__);
 
 	/* Disconnect output */
-	rc = gpio_pin_configure(dev, PIN_OUT, 0);
+	rc = gpio_pin_configure(dev, PIN_OUT, GPIO_DISCONNECTED);
 	if (rc == -ENOTSUP) {
 		TC_PRINT("NOTE: cannot configure pin as disconnected; trying as input\n");
 		rc = gpio_pin_configure(dev, PIN_OUT, GPIO_INPUT);


### PR DESCRIPTION
A disconnected GPIO is one that is neither an input nor an output.
This is represented by a zero-valued all-default configuration.  Call
this configuration GPIO_DISCONNECTED so the intent is clear.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>