### PR TITLE
Add a new attribute wrapper __no_sanitize_address and use where needed

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_DEVICE_H_
 #define ZEPHYR_INCLUDE_DEVICE_H_
 
+#include <toolchain.h>
+
 /**
  * @brief Device Driver APIs
  * @defgroup io_interfaces Device Driver APIs
@@ -127,7 +129,8 @@ extern "C" {
 	Z_DEVICE_DEFINE_PM(dev_name)					\
 	static Z_DECL_ALIGN(struct device)				\
 		DEVICE_NAME_GET(dev_name) __used			\
-	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) = { \
+	__attribute__((__section__(".device_" #level STRINGIFY(prio)))) \
+	__no_sanitize_address = {                                       \
 		.name = drv_name,					\
 		.config_info = (cfg_info),				\
 		.driver_api = (api),					\

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -9,6 +9,7 @@
 
 #include <logging/log_instance.h>
 #include <logging/log_core.h>
+#include <toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -309,7 +310,8 @@ static inline char *log_strdup(const char *str)
 	IF_ENABLED(LOG_IN_CPLUSPLUS, (extern))				     \
 	const struct log_source_const_data LOG_ITEM_CONST_DATA(_name)	     \
 	__attribute__ ((section("." STRINGIFY(LOG_ITEM_CONST_DATA(_name))))) \
-	__attribute__((used)) = {					     \
+	__attribute__((used))						     \
+	__no_sanitize_address = {					     \
 		.name = STRINGIFY(_name),				     \
 		.level = _level						     \
 	}
@@ -319,7 +321,8 @@ static inline char *log_strdup(const char *str)
 	__attribute__ ((section("." STRINGIFY(				\
 				     LOG_ITEM_DYNAMIC_DATA(_name))))	\
 				     )					\
-	__attribute__((used))
+	__attribute__((used))						\
+	__no_sanitize_address
 
 #define _LOG_MODULE_DYNAMIC_DATA_COND_CREATE(_name)		\
 	IF_ENABLED(CONFIG_LOG_RUNTIME_FILTERING,		\

--- a/include/logging/log_instance.h
+++ b/include/logging/log_instance.h
@@ -7,6 +7,7 @@
 #define ZEPHYR_INCLUDE_LOGGING_LOG_INSTANCE_H_
 
 #include <zephyr/types.h>
+#include <toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,7 +47,8 @@ struct log_source_dynamic_data {
 #define Z_LOG_CONST_ITEM_REGISTER(_name, _str_name, _level)		     \
 	const struct log_source_const_data LOG_ITEM_CONST_DATA(_name)	     \
 	__attribute__ ((section("." STRINGIFY(LOG_ITEM_CONST_DATA(_name))))) \
-	__attribute__((used)) = {					     \
+	__attribute__((used))						     \
+	__no_sanitize_address = {					     \
 		.name = _str_name,					     \
 		.level  = (_level),					     \
 	}
@@ -86,7 +88,8 @@ struct log_source_dynamic_data {
 				LOG_INSTANCE_DYNAMIC_DATA(_module_name,	   \
 						       _inst_name)	   \
 				)					   \
-		))) __attribute__((used))
+		))) __attribute__((used))				   \
+		__no_sanitize_address
 
 #define LOG_INSTANCE_PTR_INIT(_name, _module_name, _inst_name)	   \
 	._name = &LOG_ITEM_DYNAMIC_DATA(			   \

--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -14,6 +14,7 @@
 #include <zephyr/types.h>
 #include <sys/util.h>
 #include <zephyr.h>
+#include <toolchain.h>
 
 #ifndef CONFIG_NET_BUF_USER_DATA_SIZE
 #define CONFIG_NET_BUF_USER_DATA_SIZE 0
@@ -893,6 +894,7 @@ extern const struct net_buf_data_alloc net_buf_heap_alloc;
 #define NET_BUF_POOL_HEAP_DEFINE(_name, _count, _destroy)                     \
 	static struct net_buf net_buf_##_name[_count] __noinit;               \
 	static struct net_buf_pool _name __net_buf_align                      \
+			__no_sanitize_address				      \
 			__in_section(_net_buf_pool, static, _name) =          \
 		NET_BUF_POOL_INITIALIZER(_name, &net_buf_heap_alloc,          \
 					 net_buf_##_name, _count, _destroy)
@@ -945,6 +947,7 @@ extern const struct net_buf_data_cb net_buf_fixed_cb;
 		.alloc_data = (void *)&net_buf_fixed_##_name,                 \
 	};                                                                    \
 	static struct net_buf_pool _name __net_buf_align                      \
+			__no_sanitize_address				      \
 			__in_section(_net_buf_pool, static, _name) =          \
 		NET_BUF_POOL_INITIALIZER(_name, &net_buf_fixed_alloc_##_name, \
 					 net_buf_##_name, _count, _destroy)
@@ -984,6 +987,7 @@ extern const struct net_buf_data_cb net_buf_var_cb;
 		.alloc_data = &net_buf_mem_pool_##_name,                      \
 	};                                                                    \
 	static struct net_buf_pool _name __net_buf_align                      \
+			__no_sanitize_address				      \
 			__in_section(_net_buf_pool, static, _name) =          \
 		NET_BUF_POOL_INITIALIZER(_name, &net_buf_data_alloc_##_name,  \
 					 _net_buf_##_name, _count, _destroy)

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -21,6 +21,7 @@
 
 #include <device.h>
 #include <sys/slist.h>
+#include <toolchain.h>
 
 #include <net/net_core.h>
 #include <net/hostname.h>
@@ -2187,7 +2188,8 @@ struct net_if_api {
 
 #define NET_IF_INIT(dev_name, sfx, _l2, _mtu, _num_configs)		\
 	static struct net_if_dev (NET_IF_DEV_GET_NAME(dev_name, sfx))	\
-	__used __attribute__((__section__(".net_if_dev.data"))) = {	\
+	__used __attribute__((__section__(".net_if_dev.data")))		\
+	__no_sanitize_address = {					\
 		.dev = &(DEVICE_NAME_GET(dev_name)),			\
 		.l2 = &(NET_L2_GET_NAME(_l2)),				\
 		.l2_data = &(NET_L2_GET_DATA(dev_name, sfx)),		\
@@ -2195,7 +2197,8 @@ struct net_if_api {
 	};								\
 	static struct net_if						\
 	(NET_IF_GET_NAME(dev_name, sfx))[_num_configs] __used		\
-	__attribute__((__section__(".net_if.data"))) = {		\
+	__attribute__((__section__(".net_if.data")))			\
+	__no_sanitize_address = {					\
 		[0 ... (_num_configs - 1)] = {				\
 			.if_dev = &(NET_IF_DEV_GET_NAME(dev_name, sfx)), \
 			NET_IF_CONFIG_INIT				\
@@ -2204,13 +2207,15 @@ struct net_if_api {
 
 #define NET_IF_OFFLOAD_INIT(dev_name, sfx, _mtu)			\
 	static struct net_if_dev (NET_IF_DEV_GET_NAME(dev_name, sfx)) __used \
-	__attribute__((__section__(".net_if_dev.data"))) = {		\
+	__attribute__((__section__(".net_if_dev.data")))		\
+	__no_sanitize_address = {					\
 		.dev = &(__device_##dev_name),				\
 		.mtu = _mtu,						\
 	};								\
 	static struct net_if						\
 	(NET_IF_GET_NAME(dev_name, sfx))[NET_IF_MAX_CONFIGS] __used	\
-	__attribute__((__section__(".net_if.data"))) = {		\
+	__attribute__((__section__(".net_if.data")))			\
+	__no_sanitize_address = {					\
 		[0 ... (NET_IF_MAX_CONFIGS - 1)] = {			\
 			.if_dev = &(NET_IF_DEV_GET_NAME(dev_name, sfx)), \
 			NET_IF_CONFIG_INIT				\

--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -13,6 +13,7 @@
 #define ZEPHYR_INCLUDE_NET_NET_L2_H_
 
 #include <net/buf.h>
+#include <toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -127,7 +128,8 @@ NET_L2_DECLARE_PUBLIC(CANBUS_L2);
 
 #define NET_L2_INIT(_name, _recv_fn, _send_fn, _enable_fn, _get_flags_fn) \
 	const struct net_l2 (NET_L2_GET_NAME(_name)) __used		\
-	__attribute__((__section__(".net_l2.init"))) = {		\
+	__attribute__((__section__(".net_l2.init")))			\
+	__no_sanitize_address = {					\
 		.recv = (_recv_fn),					\
 		.send = (_send_fn),					\
 		.enable = (_enable_fn),					\
@@ -138,6 +140,7 @@ NET_L2_DECLARE_PUBLIC(CANBUS_L2);
 
 #define NET_L2_DATA_INIT(name, sfx, ctx_type)				\
 	static ctx_type NET_L2_GET_DATA(name, sfx) __used		\
+	__no_sanitize_address						\
 	__attribute__((__section__(".net_l2.data")));
 
 /** @endcond */

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -15,6 +15,7 @@
 #include <logging/log_instance.h>
 #include <logging/log.h>
 #include <sys/util.h>
+#include <toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -172,7 +173,8 @@ struct shell_static_entry {
 	static const struct shell_cmd_entry UTIL_CAT(shell_cmd_, syntax)   \
 	__attribute__ ((section("."					   \
 			STRINGIFY(UTIL_CAT(shell_root_cmd_, syntax)))))	   \
-	__attribute__((used)) = {					   \
+	__attribute__((used))						   \
+	__no_sanitize_address = {					   \
 		.is_dynamic = false,					   \
 		.u = {.entry = &UTIL_CAT(_shell_, syntax)}		   \
 	}

--- a/include/toolchain.h
+++ b/include/toolchain.h
@@ -37,6 +37,11 @@
 #include <toolchain/xcc.h>
 #elif defined(__GNUC__) || (defined(_LINKER) && defined(__GCC_LINKER_CMD__))
 #include <toolchain/gcc.h>
+#if defined(__llvm__)
+#include <toolchain/llvm.h>
+#endif
+#elif defined(__llvm__)
+#include <toolchain/llvm.h>
 #else
 /* This include line exists for off-tree definitions of compilers,
  * and therefore this header is not meant to exist in-tree

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -192,7 +192,8 @@
  */
 #define Z_STRUCT_SECTION_ITERABLE(struct_type, name) \
 	Z_DECL_ALIGN(struct struct_type) name \
-	__in_section(_##struct_type, static, name) __used
+	__in_section(_##struct_type, static, name) __used \
+	__no_sanitize_address
 
 /* Special variant of Z_STRUCT_SECTION_ITERABLE, for placing alternate
  * data types within the iterable section of a specific data type. The

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -158,6 +158,12 @@
 #endif
 
 /*
+ * Tell AddressSanitizer that it should not instrument the code.
+ * This attribute can be set on a function or global variable.
+ */
+#define __no_sanitize_address
+
+/*
  * This is meant to be used in conjunction with __in_section() and similar
  * where scattered structure instances are concatened together by the linker
  * and walked by the code at run time just like a contiguous array of such

--- a/include/toolchain/llvm.h
+++ b/include/toolchain/llvm.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_TOOLCHAIN_LLVM_H_
+#define ZEPHYR_INCLUDE_TOOLCHAIN_LLVM_H_
+
+#include <toolchain/gcc.h>
+
+#ifdef __clang__
+
+#ifdef CONFIG_ARCH_POSIX
+
+#if __has_feature(address_sanitizer)
+#undef __no_sanitize_address
+/*
+ * Tell AddressSanitizer that it should not instrument the code.
+ * This attribute can be set on a function or global variable.
+ */
+#define __no_sanitize_address __attribute__((no_sanitize("address")))
+#endif /* __has_feature(address_sanitizer) */
+
+#endif /* CONFIG_ARCH_POSIX */
+
+#endif /* __clang__ */
+
+#endif /* ZEPHYR_INCLUDE_TOOLCHAIN_LLVM_H_ */

--- a/include/usb/bos.h
+++ b/include/usb/bos.h
@@ -7,11 +7,15 @@
 #ifndef ZEPHYR_INCLUDE_USB_BOS_H_
 #define ZEPHYR_INCLUDE_USB_BOS_H_
 
+#include <toolchain.h>
+
 #if defined(CONFIG_USB_DEVICE_BOS)
 #define USB_DEVICE_BOS_DESC_DEFINE_HDR \
-	static __in_section(usb, bos_desc_area, 0) __aligned(1) __used
+	static __in_section(usb, bos_desc_area, 0) __aligned(1) __used \
+	__no_sanitize_address
 #define USB_DEVICE_BOS_DESC_DEFINE_CAP \
-	static __in_section(usb, bos_desc_area, 1) __aligned(1) __used
+	static __in_section(usb, bos_desc_area, 1) __aligned(1) __used \
+	__no_sanitize_address
 
 /* BOS descriptor type */
 #define DESCRIPTOR_TYPE_BOS		0x0F

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -39,6 +39,7 @@
 #include <drivers/usb/usb_dc.h>
 #include <usb/usbstruct.h>
 #include <logging/log.h>
+#include <toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,24 +50,30 @@ extern "C" {
  * in predetermined order in the RAM.
  */
 #define USBD_DEVICE_DESCR_DEFINE(p) \
-	static __in_section(usb, descriptor_##p, 0) __used __aligned(1)
+	static __in_section(usb, descriptor_##p, 0) __used __aligned(1) \
+	__no_sanitize_address
 #define USBD_CLASS_DESCR_DEFINE(p, instance) \
-	static __in_section(usb, descriptor_##p.1, instance) __used __aligned(1)
+	static __in_section(usb, descriptor_##p.1, instance) __used \
+	__aligned(1) __no_sanitize_address
 #define USBD_MISC_DESCR_DEFINE(p) \
-	static __in_section(usb, descriptor_##p, 2) __used __aligned(1)
+	static __in_section(usb, descriptor_##p, 2) __used __aligned(1) \
+	__no_sanitize_address
 #define USBD_USER_DESCR_DEFINE(p) \
-	static __in_section(usb, descriptor_##p, 3) __used __aligned(1)
+	static __in_section(usb, descriptor_##p, 3) __used __aligned(1) \
+	__no_sanitize_address
 #define USBD_STRING_DESCR_DEFINE(p) \
-	static __in_section(usb, descriptor_##p, 4) __used __aligned(1)
+	static __in_section(usb, descriptor_##p, 4) __used __aligned(1) \
+	__no_sanitize_address
 #define USBD_TERM_DESCR_DEFINE(p) \
-	static __in_section(usb, descriptor_##p, 5) __used __aligned(1)
+	static __in_section(usb, descriptor_##p, 5) __used __aligned(1) \
+	__no_sanitize_address
 
 /*
  * This macro should be used to place the struct usb_cfg_data
  * inside usb data section in the RAM.
  */
 #define USBD_CFG_DATA_DEFINE(p, name) \
-	static __in_section(usb, data_##p, name) __used
+	static __in_section(usb, data_##p, name) __used __no_sanitize_address
 
 /*************************************************************************
  *  USB configuration

--- a/soc/posix/inf_clock/soc.h
+++ b/soc/posix/inf_clock/soc.h
@@ -44,6 +44,7 @@ void posix_soc_clean_up(void);
 #define NATIVE_TASK(fn, level, prio)	\
 	static void (*_CONCAT(__native_task_, fn)) __used	\
 	__attribute__((__section__(".native_" #level STRINGIFY(prio) "_task")))\
+	__no_sanitize_address \
 	= fn
 
 


### PR DESCRIPTION
This PR addes a new attribute wrapper, __no_sanitize_address, to tell address sanitizer (ASAN) that it should not instrument some code; this attribute warper can be applied to functions and global variables.

Further this PR adds __no_sanitize_address to variables placed in a section to prevent instrumentation of the variables by the clang address sanitizer. If the variables would be instrumented with red zones and the code assumes that the variables are back-to-back this would break the code.

For more info see: google/sanitizers#1028