### PR TITLE
boards: nucleo_f446re flash layout

### DIFF
--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -76,3 +76,45 @@ arduino_spi: &spi1 {
 &rtc {
 	status = "okay";
 };
+
+&flash0 {
+	/*
+	 * For more information, see:
+	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x00010000>;
+			read-only;
+		};
+
+		/*
+		 * The flash starting at 0x00010000 and ending at
+		 * 0x0001ffff (sectors 16-31) is reserved for use
+		 * by the application.
+		 */
+		storage_partition: partition@10000 {
+			label = "storage";
+			reg = <0x00010000 0x00010000>;
+		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 0x00020000>;
+		};
+		slot1_partition: partition@40000 {
+			label = "image-1";
+			reg = <0x00040000 0x00020000>;
+		};
+		scratch_partition: partition@60000 {
+			label = "image-scratch";
+			reg = <0x00060000 0x00020000>;
+		};
+	};
+};
+


### PR DESCRIPTION
Adds the missing flash partition layout to the board dts

Signed-off-by: Tom Burdick <tom.burdick@electromatic.us>