### PR TITLE
kernel: arch interface housekeeping

### DIFF
--- a/arch/arc/include/kernel_arch_func.h
+++ b/arch/arc/include/kernel_arch_func.h
@@ -66,7 +66,10 @@ static ALWAYS_INLINE int Z_INTERRUPT_CAUSE(void)
 	return irq_num;
 }
 
-#define z_arch_is_in_isr	z_arc_v2_irq_unit_is_in_isr
+static inline bool z_arch_is_in_isr(void)
+{
+	return z_arc_v2_irq_unit_is_in_isr();
+}
 
 extern void z_thread_entry_wrapper(void);
 extern void z_user_thread_entry_wrapper(void);

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -379,3 +379,95 @@ int z_arch_float_disable(struct k_thread *thread)
 	return 0;
 }
 #endif /* CONFIG_FLOAT && CONFIG_FP_SHARING */
+
+void z_arch_switch_to_main_thread(struct k_thread *main_thread,
+				  k_thread_stack_t *main_stack,
+				  size_t main_stack_size,
+				  k_thread_entry_t _main)
+{
+#if defined(CONFIG_FLOAT)
+	/* Initialize the Floating Point Status and Control Register when in
+	 * Unshared FP Registers mode (In Shared FP Registers mode, FPSCR is
+	 * initialized at thread creation for threads that make use of the FP).
+	 */
+	__set_FPSCR(0);
+#if defined(CONFIG_FP_SHARING)
+	/* In Sharing mode clearing FPSCR may set the CONTROL.FPCA flag. */
+	__set_CONTROL(__get_CONTROL() & (~(CONTROL_FPCA_Msk)));
+	__ISB();
+#endif /* CONFIG_FP_SHARING */
+#endif /* CONFIG_FLOAT */
+
+#ifdef CONFIG_ARM_MPU
+	/* Configure static memory map. This will program MPU regions,
+	 * to set up access permissions for fixed memory sections, such
+	 * as Application Memory or No-Cacheable SRAM area.
+	 *
+	 * This function is invoked once, upon system initialization.
+	 */
+	z_arm_configure_static_mpu_regions();
+#endif
+
+	/* get high address of the stack, i.e. its start (stack grows down) */
+	char *start_of_main_stack;
+
+	start_of_main_stack =
+		Z_THREAD_STACK_BUFFER(main_stack) + main_stack_size;
+
+	start_of_main_stack = (char *)STACK_ROUND_DOWN(start_of_main_stack);
+
+	_current = main_thread;
+#ifdef CONFIG_TRACING
+	sys_trace_thread_switched_in();
+#endif
+
+	/* the ready queue cache already contains the main thread */
+
+#ifdef CONFIG_ARM_MPU
+	/*
+	 * If stack protection is enabled, make sure to set it
+	 * before jumping to thread entry function
+	 */
+	z_arm_configure_dynamic_mpu_regions(main_thread);
+#endif
+
+#if defined(CONFIG_BUILTIN_STACK_GUARD)
+	/* Set PSPLIM register for built-in stack guarding of main thread. */
+#if defined(CONFIG_CPU_CORTEX_M_HAS_SPLIM)
+	__set_PSPLIM((u32_t)main_stack);
+#else
+#error "Built-in PSP limit checks not supported by HW"
+#endif
+#endif /* CONFIG_BUILTIN_STACK_GUARD */
+
+	/*
+	 * Set PSP to the highest address of the main stack
+	 * before enabling interrupts and jumping to main.
+	 */
+	__asm__ volatile (
+	"mov   r0,  %0\n\t"	/* Store _main in R0 */
+#if defined(CONFIG_CPU_CORTEX_M)
+	"msr   PSP, %1\n\t"	/* __set_PSP(start_of_main_stack) */
+#endif
+
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) \
+			|| defined(CONFIG_ARMV7_R)
+	"cpsie i\n\t"		/* __enable_irq() */
+#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	"cpsie if\n\t"		/* __enable_irq(); __enable_fault_irq() */
+	"mov   r1,  #0\n\t"
+	"msr   BASEPRI, r1\n\t"	/* __set_BASEPRI(0) */
+#else
+#error Unknown ARM architecture
+#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
+	"isb\n\t"
+	"movs r1, #0\n\t"
+	"movs r2, #0\n\t"
+	"movs r3, #0\n\t"
+	"bl z_thread_entry\n\t"	/* z_thread_entry(_main, 0, 0, 0); */
+	:
+	: "r" (_main), "r" (start_of_main_stack)
+	);
+
+	CODE_UNREACHABLE;
+}

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -44,98 +44,6 @@ static ALWAYS_INLINE void z_arch_kernel_init(void)
 }
 
 static ALWAYS_INLINE void
-z_arch_switch_to_main_thread(struct k_thread *main_thread,
-			    k_thread_stack_t *main_stack,
-			    size_t main_stack_size, k_thread_entry_t _main)
-{
-#if defined(CONFIG_FLOAT)
-	/* Initialize the Floating Point Status and Control Register when in
-	 * Unshared FP Registers mode (In Shared FP Registers mode, FPSCR is
-	 * initialized at thread creation for threads that make use of the FP).
-	 */
-	__set_FPSCR(0);
-#if defined(CONFIG_FP_SHARING)
-	/* In Sharing mode clearing FPSCR may set the CONTROL.FPCA flag. */
-	__set_CONTROL(__get_CONTROL() & (~(CONTROL_FPCA_Msk)));
-	__ISB();
-#endif /* CONFIG_FP_SHARING */
-#endif /* CONFIG_FLOAT */
-
-#ifdef CONFIG_ARM_MPU
-	/* Configure static memory map. This will program MPU regions,
-	 * to set up access permissions for fixed memory sections, such
-	 * as Application Memory or No-Cacheable SRAM area.
-	 *
-	 * This function is invoked once, upon system initialization.
-	 */
-	z_arm_configure_static_mpu_regions();
-#endif
-
-	/* get high address of the stack, i.e. its start (stack grows down) */
-	char *start_of_main_stack;
-
-	start_of_main_stack =
-		Z_THREAD_STACK_BUFFER(main_stack) + main_stack_size;
-
-	start_of_main_stack = (char *)STACK_ROUND_DOWN(start_of_main_stack);
-
-	_current = main_thread;
-#ifdef CONFIG_TRACING
-	sys_trace_thread_switched_in();
-#endif
-
-	/* the ready queue cache already contains the main thread */
-
-#ifdef CONFIG_ARM_MPU
-	/*
-	 * If stack protection is enabled, make sure to set it
-	 * before jumping to thread entry function
-	 */
-	z_arm_configure_dynamic_mpu_regions(main_thread);
-#endif
-
-#if defined(CONFIG_BUILTIN_STACK_GUARD)
-	/* Set PSPLIM register for built-in stack guarding of main thread. */
-#if defined(CONFIG_CPU_CORTEX_M_HAS_SPLIM)
-	__set_PSPLIM((u32_t)main_stack);
-#else
-#error "Built-in PSP limit checks not supported by HW"
-#endif
-#endif /* CONFIG_BUILTIN_STACK_GUARD */
-
-	/*
-	 * Set PSP to the highest address of the main stack
-	 * before enabling interrupts and jumping to main.
-	 */
-	__asm__ volatile (
-	"mov   r0,  %0     \n\t"   /* Store _main in R0 */
-#if defined(CONFIG_CPU_CORTEX_M)
-	"msr   PSP, %1     \n\t"   /* __set_PSP(start_of_main_stack) */
-#endif
-
-#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) \
-			|| defined(CONFIG_ARMV7_R)
-	"cpsie i           \n\t"   /* __enable_irq() */
-#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	"cpsie if          \n\t"   /* __enable_irq(); __enable_fault_irq() */
-	"mov   r1,  #0     \n\t"
-	"msr   BASEPRI, r1 \n\t"   /* __set_BASEPRI(0) */
-#else
-#error Unknown ARM architecture
-#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
-	"isb               \n\t"
-	"movs r1, #0       \n\t"
-	"movs r2, #0       \n\t"
-	"movs r3, #0       \n\t"
-	"bl z_thread_entry \n\t"   /* z_thread_entry(_main, 0, 0, 0); */
-	:
-	: "r" (_main), "r" (start_of_main_stack)
-	);
-
-	CODE_UNREACHABLE;
-}
-
-static ALWAYS_INLINE void
 z_arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
 {
 	thread->arch.swap_return_value = value;
@@ -149,6 +57,11 @@ extern FUNC_NORETURN void z_arm_userspace_enter(k_thread_entry_t user_entry,
 					       u32_t stack_start);
 
 extern void z_arm_fatal_error(unsigned int reason, const z_arch_esf_t *esf);
+
+extern void z_arch_switch_to_main_thread(struct k_thread *main_thread,
+					 k_thread_stack_t *main_stack,
+					 size_t main_stack_size,
+					 k_thread_entry_t _main);
 
 #endif /* _ASMLANGUAGE */
 

--- a/arch/nios2/include/kernel_arch_func.h
+++ b/arch/nios2/include/kernel_arch_func.h
@@ -41,7 +41,10 @@ z_arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
 FUNC_NORETURN void z_nios2_fatal_error(unsigned int reason,
 				       const z_arch_esf_t *esf);
 
-#define z_arch_is_in_isr() (_kernel.nested != 0U)
+static inline bool z_arch_is_in_isr(void)
+{
+	return _kernel.nested != 0U;
+}
 
 #ifdef CONFIG_IRQ_OFFLOAD
 void z_irq_do_offload(void);

--- a/arch/posix/core/CMakeLists.txt
+++ b/arch/posix/core/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_library_compile_definitions(NO_POSIX_CHEATS)
 zephyr_library_sources(
 	cpuhalt.c
 	fatal.c
+	irq.c
 	posix_core.c
 	swap.c
 	thread.c

--- a/arch/posix/core/irq.c
+++ b/arch/posix/core/irq.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "posix_soc_if.h"
+#include "board_irq.h"
+
+void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
+{
+	posix_irq_offload(routine, parameter);
+}
+
+#ifdef CONFIG_DYNAMIC_INTERRUPTS
+/**
+ * Configure a dynamic interrupt.
+ *
+ * Use this instead of IRQ_CONNECT() if arguments cannot be known at build time.
+ *
+ * @param irq IRQ line number
+ * @param priority Interrupt priority
+ * @param routine Interrupt service routine
+ * @param parameter ISR parameter
+ * @param flags Arch-specific IRQ configuration flags
+ *
+ * @return The vector assigned to this interrupt
+ */
+int z_arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
+			       void (*routine)(void *parameter),
+			       void *parameter, u32_t flags)
+{
+	posix_isr_declare(irq, (int)flags, routine, parameter);
+	posix_irq_priority_set(irq, priority, flags);
+	return irq;
+}
+#endif /* CONFIG_DYNAMIC_INTERRUPTS */

--- a/arch/posix/include/kernel_arch_func.h
+++ b/arch/posix/include/kernel_arch_func.h
@@ -53,7 +53,10 @@ z_arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
 }
 #endif
 
-#define z_arch_is_in_isr() (_kernel.nested != 0U)
+static inline bool z_arch_is_in_isr(void)
+{
+	return _kernel.nested != 0U;
+}
 
 #endif /* _ASMLANGUAGE */
 

--- a/arch/posix/include/posix_soc_if.h
+++ b/arch/posix/include/posix_soc_if.h
@@ -24,8 +24,6 @@ extern "C" {
 void posix_halt_cpu(void);
 void posix_atomic_halt_cpu(unsigned int imask);
 
-unsigned int z_arch_irq_lock(void);
-void z_arch_irq_unlock(unsigned int key);
 void z_arch_irq_enable(unsigned int irq);
 void z_arch_irq_disable(unsigned int irq);
 int  z_arch_irq_is_enabled(unsigned int irq);
@@ -34,6 +32,16 @@ void posix_irq_unlock(unsigned int key);
 void posix_irq_full_unlock(void);
 int  posix_get_current_irq(void);
 /* irq_offload() from irq_offload.h must also be defined by the SOC or board */
+
+static inline unsigned int z_arch_irq_lock(void)
+{
+	return posix_irq_lock();
+}
+
+static inline void z_arch_irq_unlock(unsigned int key)
+{
+	posix_irq_unlock(key);
+}
 
 /**
  * Returns true if interrupts were unlocked prior to the

--- a/arch/posix/include/posix_soc_if.h
+++ b/arch/posix/include/posix_soc_if.h
@@ -16,6 +16,7 @@
 
 #include "posix_trace.h"
 #include "soc_irq.h" /* Must exist and define _ARCH_IRQ/ISR_* macros */
+#include "irq_offload.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,33 +25,14 @@ extern "C" {
 void posix_halt_cpu(void);
 void posix_atomic_halt_cpu(unsigned int imask);
 
-void z_arch_irq_enable(unsigned int irq);
-void z_arch_irq_disable(unsigned int irq);
-int  z_arch_irq_is_enabled(unsigned int irq);
+void posix_irq_enable(unsigned int irq);
+void posix_irq_disable(unsigned int irq);
+int  posix_irq_is_enabled(unsigned int irq);
 unsigned int posix_irq_lock(void);
 void posix_irq_unlock(unsigned int key);
 void posix_irq_full_unlock(void);
 int  posix_get_current_irq(void);
-/* irq_offload() from irq_offload.h must also be defined by the SOC or board */
-
-static inline unsigned int z_arch_irq_lock(void)
-{
-	return posix_irq_lock();
-}
-
-static inline void z_arch_irq_unlock(unsigned int key)
-{
-	posix_irq_unlock(key);
-}
-
-/**
- * Returns true if interrupts were unlocked prior to the
- * z_arch_irq_lock() call that produced the key argument.
- */
-static inline bool z_arch_irq_unlocked(unsigned int key)
-{
-	return key == false;
-}
+void posix_irq_offload(irq_offload_routine_t routine, void *parameter);
 
 #ifdef __cplusplus
 }

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -37,7 +37,10 @@ z_arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
 FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 				       const z_arch_esf_t *esf);
 
-#define z_arch_is_in_isr() (_kernel.nested != 0U)
+static inline bool z_arch_is_in_isr(void)
+{
+	return _kernel.nested != 0U;
+}
 
 #ifdef CONFIG_IRQ_OFFLOAD
 int z_irq_do_offload(void);

--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -183,7 +183,7 @@ x86_sse_init:
 mxcsr:	.long X86_MXCSR_SANE
 
 /*
- * void z_arch_switch(void *switch_to, void **switched_from);
+ * void z_x86_switch(void *switch_to, void **switched_from);
  *
  * Note that switch_handle for us is simply a pointer to the containing
  * 'struct k_thread', thus:
@@ -192,8 +192,8 @@ mxcsr:	.long X86_MXCSR_SANE
  * RSI = (struct k_thread **) switched_from
  */
 
-.globl z_arch_switch
-z_arch_switch:
+.globl z_x86_switch
+z_x86_switch:
 	movq (%rsi), %rsi
 
 	andb $~X86_THREAD_FLAG_ALL, _thread_offset_to_flags(%rsi)

--- a/arch/x86/include/intel64/kernel_arch_func.h
+++ b/arch/x86/include/intel64/kernel_arch_func.h
@@ -6,9 +6,16 @@
 #ifndef ZEPHYR_ARCH_X86_INCLUDE_INTEL64_KERNEL_ARCH_FUNC_H_
 #define ZEPHYR_ARCH_X86_INCLUDE_INTEL64_KERNEL_ARCH_FUNC_H_
 
+#include <kernel_structs.h>
+
 #ifndef _ASMLANGUAGE
 
-extern void z_arch_switch(void *switch_to, void **switched_from);
+extern void z_x86_switch(void *switch_to, void **switched_from);
+
+static inline void z_arch_switch(void *switch_to, void **switched_from)
+{
+	z_x86_switch(switch_to, switched_from);
+}
 
 /**
  * @brief Initialize scheduler IPI vector.

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -12,13 +12,15 @@
 #include <ia32/kernel_arch_func.h>
 #endif
 
-#ifdef CONFIG_SMP
-#define z_arch_is_in_isr() (z_arch_curr_cpu()->nested != 0U)
-#else
-#define z_arch_is_in_isr() (_kernel.nested != 0U)
-#endif
-
 #ifndef _ASMLANGUAGE
+static inline bool z_arch_is_in_isr(void)
+{
+#ifdef CONFIG_SMP
+	return z_arch_curr_cpu()->nested != 0;
+#else
+	return _kernel.nested != 0U;
+#endif
+}
 
 extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
 extern K_THREAD_STACK_DEFINE(_interrupt_stack1, CONFIG_ISR_STACK_SIZE);

--- a/arch/xtensa/include/kernel_arch_data.h
+++ b/arch/xtensa/include/kernel_arch_data.h
@@ -51,9 +51,6 @@ extern "C" {
 
 typedef struct __esf __esf_t;
 
-void xtensa_switch(void *switch_to, void **switched_from);
-#define z_arch_switch xtensa_switch
-
 #ifdef __cplusplus
 }
 #endif

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -87,8 +87,10 @@ static ALWAYS_INLINE void z_arch_kernel_init(void)
 }
 #endif
 
-#define z_arch_is_in_isr() (z_arch_curr_cpu()->nested != 0U)
-
+static inline bool z_arch_is_in_isr(void)
+{
+	return z_arch_curr_cpu()->nested != 0U;
+}
 #endif /* _ASMLANGUAGE */
 
 #endif /* ZEPHYR_ARCH_XTENSA_INCLUDE_KERNEL_ARCH_FUNC_H_ */

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -83,6 +83,13 @@ static ALWAYS_INLINE void z_arch_kernel_init(void)
 #endif
 }
 
+void xtensa_switch(void *switch_to, void **switched_from);
+
+static inline void z_arch_switch(void *switch_to, void **switched_from)
+{
+	return xtensa_switch(switch_to, switched_from);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/posix/native_posix/board_irq.h
+++ b/boards/posix/native_posix/board_irq.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _BOARD_IRQ_H
-#define _BOARD_IRQ_H
+#ifndef BOARDS_POSIX_NATIVE_POSIX_BOARD_IRQ_H
+#define BOARDS_POSIX_NATIVE_POSIX_BOARD_IRQ_H
 
 #include "sw_isr_table.h"
 #include "zephyr/types.h"
@@ -15,9 +15,9 @@
 extern "C" {
 #endif
 
-void z_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
-		void *isr_param_p);
-void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
+void posix_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
+		       void *isr_param_p);
+void posix_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
 
 /**
  * Configure a static interrupt.
@@ -32,8 +32,8 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  */
 #define Z_ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 ({ \
-	z_isr_declare(irq_p, 0, isr_p, isr_param_p); \
-	z_irq_priority_set(irq_p, priority_p, flags_p); \
+	posix_isr_declare(irq_p, 0, isr_p, isr_param_p); \
+	posix_irq_priority_set(irq_p, priority_p, flags_p); \
 	irq_p; \
 })
 
@@ -45,8 +45,9 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  */
 #define Z_ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
 ({ \
-	z_isr_declare(irq_p, ISR_FLAG_DIRECT, (void (*)(void *))isr_p, NULL); \
-	z_irq_priority_set(irq_p, priority_p, flags_p); \
+	posix_isr_declare(irq_p, ISR_FLAG_DIRECT, (void (*)(void *))isr_p, \
+			  NULL); \
+	posix_irq_priority_set(irq_p, priority_p, flags_p); \
 	irq_p; \
 })
 
@@ -86,4 +87,4 @@ extern void posix_irq_check_idle_exit(void);
 }
 #endif
 
-#endif /* _BOARD_IRQ_H */
+#endif /* BOARDS_POSIX_NATIVE_POSIX_BOARD_IRQ_H */

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -194,17 +194,17 @@ void posix_irq_full_unlock(void)
 	hw_irq_ctrl_change_lock(false);
 }
 
-void z_arch_irq_enable(unsigned int irq)
+void posix_irq_enable(unsigned int irq)
 {
 	hw_irq_ctrl_enable_irq(irq);
 }
 
-void z_arch_irq_disable(unsigned int irq)
+void posix_irq_disable(unsigned int irq)
 {
 	hw_irq_ctrl_disable_irq(irq);
 }
 
-int z_arch_irq_is_enabled(unsigned int irq)
+int posix_irq_is_enabled(unsigned int irq)
 {
 	return hw_irq_ctrl_is_irq_enabled(irq);
 }
@@ -217,8 +217,8 @@ int posix_get_current_irq(void)
 /**
  * Configure a static interrupt.
  *
- * z_isr_declare will populate the interrupt table table with the interrupt's
- * parameters, the vector table and the software ISR table.
+ * posix_isr_declare will populate the interrupt table table with the
+ * interrupt's parameters, the vector table and the software ISR table.
  *
  * We additionally set the priority in the interrupt controller at
  * runtime.
@@ -229,7 +229,7 @@ int posix_get_current_irq(void)
  * @param isr_param_p ISR parameter
  * @param flags_p IRQ options
  */
-void z_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
+void posix_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
 		void *isr_param_p)
 {
 	irq_vector_table[irq_p].irq   = irq_p;
@@ -247,34 +247,10 @@ void z_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
  *
  * @return N/A
  */
-void z_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+void posix_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	hw_irq_ctrl_prio_set(irq, prio);
 }
-
-#ifdef CONFIG_DYNAMIC_INTERRUPTS
-/**
- * Configure a dynamic interrupt.
- *
- * Use this instead of IRQ_CONNECT() if arguments cannot be known at build time.
- *
- * @param irq IRQ line number
- * @param priority Interrupt priority
- * @param routine Interrupt service routine
- * @param parameter ISR parameter
- * @param flags Arch-specific IRQ configuration flags
- *
- * @return The vector assigned to this interrupt
- */
-int z_arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
-			     void (*routine)(void *parameter), void *parameter,
-			     u32_t flags)
-{
-	z_isr_declare(irq, (int)flags, routine, parameter);
-	z_irq_priority_set(irq, priority, flags);
-	return irq;
-}
-#endif /* CONFIG_DYNAMIC_INTERRUPTS */
 
 /**
  * Similar to ARM's NVIC_SetPendingIRQ
@@ -318,12 +294,12 @@ static void offload_sw_irq_handler(void *a)
  *
  * Raise the SW IRQ assigned to handled this
  */
-void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
+void posix_irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	off_routine = routine;
 	off_parameter = parameter;
-	z_isr_declare(OFFLOAD_SW_IRQ, 0, offload_sw_irq_handler, NULL);
-	z_arch_irq_enable(OFFLOAD_SW_IRQ);
+	posix_isr_declare(OFFLOAD_SW_IRQ, 0, offload_sw_irq_handler, NULL);
+	posix_irq_enable(OFFLOAD_SW_IRQ);
 	posix_sw_set_pending_IRQ(OFFLOAD_SW_IRQ);
-	z_arch_irq_disable(OFFLOAD_SW_IRQ);
+	posix_irq_disable(OFFLOAD_SW_IRQ);
 }

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -171,11 +171,6 @@ unsigned int posix_irq_lock(void)
 	return hw_irq_ctrl_change_lock(true);
 }
 
-unsigned int z_arch_irq_lock(void)
-{
-	return posix_irq_lock();
-}
-
 /**
  *
  * @brief Enable all interrupts on the CPU
@@ -193,12 +188,6 @@ void posix_irq_unlock(unsigned int key)
 {
 	hw_irq_ctrl_change_lock(key);
 }
-
-void z_arch_irq_unlock(unsigned int key)
-{
-	posix_irq_unlock(key);
-}
-
 
 void posix_irq_full_unlock(void)
 {

--- a/boards/posix/nrf52_bsim/board_irq.h
+++ b/boards/posix/nrf52_bsim/board_irq.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _BOARD_IRQ_H
-#define _BOARD_IRQ_H
+#ifndef BOARDS_POSIX_NRF52_BSIM_BOARD_IRQ_H
+#define BOARDS_POSIX_NRF52_BSIM_BOARD_IRQ_H
 
 #include "sw_isr_table.h"
 #include "zephyr/types.h"
@@ -15,9 +15,9 @@
 extern "C" {
 #endif
 
-void z_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
-		void *isr_param_p);
-void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
+void posix_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
+		       void *isr_param_p);
+void posix_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
 
 /**
  * Configure a static interrupt.
@@ -32,8 +32,8 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  */
 #define Z_ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 ({ \
-	z_isr_declare(irq_p, 0, isr_p, isr_param_p); \
-	z_irq_priority_set(irq_p, priority_p, flags_p); \
+	posix_isr_declare(irq_p, 0, isr_p, isr_param_p); \
+	posix_irq_priority_set(irq_p, priority_p, flags_p); \
 	irq_p; \
 })
 
@@ -45,8 +45,9 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  */
 #define Z_ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
 ({ \
-	z_isr_declare(irq_p, ISR_FLAG_DIRECT, (void (*)(void *))isr_p, NULL); \
-	z_irq_priority_set(irq_p, priority_p, flags_p); \
+	posix_isr_declare(irq_p, ISR_FLAG_DIRECT, (void (*)(void *))isr_p, \
+			  NULL); \
+	posix_irq_priority_set(irq_p, priority_p, flags_p); \
 	irq_p; \
 })
 
@@ -86,4 +87,4 @@ extern void posix_irq_check_idle_exit(void);
 }
 #endif
 
-#endif /* _BOARD_IRQ_H */
+#endif /* BOARDS_POSIX_NRF52_BSIM_BOARD_IRQ_H */

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -230,11 +230,6 @@ unsigned int posix_irq_lock(void)
 	return hw_irq_ctrl_change_lock(true);
 }
 
-unsigned int z_arch_irq_lock(void)
-{
-	return posix_irq_lock();
-}
-
 /**
  *
  * @brief Enable all interrupts on the CPU
@@ -252,12 +247,6 @@ void posix_irq_unlock(unsigned int key)
 {
 	hw_irq_ctrl_change_lock(key);
 }
-
-void z_arch_irq_unlock(unsigned int key)
-{
-	posix_irq_unlock(key);
-}
-
 
 void posix_irq_full_unlock(void)
 {

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -253,24 +253,19 @@ void posix_irq_full_unlock(void)
 	hw_irq_ctrl_change_lock(false);
 }
 
-void z_arch_irq_enable(unsigned int irq)
+void posix_irq_enable(unsigned int irq)
 {
 	hw_irq_ctrl_enable_irq(irq);
 }
 
-void z_arch_irq_disable(unsigned int irq)
+void posix_irq_disable(unsigned int irq)
 {
 	hw_irq_ctrl_disable_irq(irq);
 }
 
-int z_arch_irq_is_enabled(unsigned int irq)
+int posix_irq_is_enabled(unsigned int irq)
 {
 	return hw_irq_ctrl_is_irq_enabled(irq);
-}
-
-void z_arch_isr_direct_header(void)
-{
-	/* Nothing to be done */
 }
 
 int posix_get_current_irq(void)
@@ -281,8 +276,8 @@ int posix_get_current_irq(void)
 /**
  * Configure a static interrupt.
  *
- * z_isr_declare will populate the interrupt table table with the interrupt's
- * parameters, the vector table and the software ISR table.
+ * posix_isr_declare will populate the interrupt table table with the
+ * interrupt's parameters, the vector table and the software ISR table.
  *
  * We additionally set the priority in the interrupt controller at
  * runtime.
@@ -293,7 +288,7 @@ int posix_get_current_irq(void)
  * @param isr_param_p ISR parameter
  * @param flags_p IRQ options
  */
-void z_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
+void posix_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
 		void *isr_param_p)
 {
 	irq_vector_table[irq_p].irq   = irq_p;
@@ -311,34 +306,10 @@ void z_isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
  *
  * @return N/A
  */
-void z_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+void posix_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	hw_irq_ctrl_prio_set(irq, prio);
 }
-
-#ifdef CONFIG_DYNAMIC_INTERRUPTS
-/**
- * Configure a dynamic interrupt.
- *
- * Use this instead of IRQ_CONNECT() if arguments cannot be known at build time.
- *
- * @param irq IRQ line number
- * @param priority Interrupt priority
- * @param routine Interrupt service routine
- * @param parameter ISR parameter
- * @param flags Arch-specific IRQ configuration flags
- *
- * @return The vector assigned to this interrupt
- */
-int z_arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
-			     void (*routine)(void *parameter), void *parameter,
-			     u32_t flags)
-{
-	z_isr_declare(irq, (int)flags, routine, parameter);
-	z_irq_priority_set(irq, priority, flags);
-	return irq;
-}
-#endif /* CONFIG_DYNAMIC_INTERRUPTS */
 
 /**
  * Similar to ARM's NVIC_SetPendingIRQ
@@ -382,14 +353,14 @@ static void offload_sw_irq_handler(void *a)
  *
  * Raise the SW IRQ assigned to handled this
  */
-void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
+void posix_irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	off_routine = routine;
 	off_parameter = parameter;
-	z_isr_declare(OFFLOAD_SW_IRQ, 0, offload_sw_irq_handler, NULL);
-	z_arch_irq_enable(OFFLOAD_SW_IRQ);
+	posix_isr_declare(OFFLOAD_SW_IRQ, 0, offload_sw_irq_handler, NULL);
+	posix_irq_enable(OFFLOAD_SW_IRQ);
 	posix_sw_set_pending_IRQ(OFFLOAD_SW_IRQ);
-	z_arch_irq_disable(OFFLOAD_SW_IRQ);
+	posix_irq_disable(OFFLOAD_SW_IRQ);
 }
 
 /**

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -6,6 +6,7 @@
 #include <drivers/timer/system_timer.h>
 #include <sys_clock.h>
 #include <spinlock.h>
+#include <irq.h>
 
 #define HPET_REG32(off) (*(volatile u32_t *)(long)			\
 		       (DT_INST_0_INTEL_HPET_BASE_ADDRESS + (off)))

--- a/include/arch/arc/v2/misc.h
+++ b/include/arch/arc/v2/misc.h
@@ -22,7 +22,11 @@ extern "C" {
 extern unsigned int z_arc_cpu_sleep_mode;
 
 extern u32_t z_timer_cycle_get_32(void);
-#define z_arch_k_cycle_get_32()	z_timer_cycle_get_32()
+
+static inline u32_t z_arch_k_cycle_get_32(void)
+{
+	return z_timer_cycle_get_32();
+}
 #endif
 
 #ifdef __cplusplus

--- a/include/arch/arm/misc.h
+++ b/include/arch/arm/misc.h
@@ -20,7 +20,11 @@ extern "C" {
 
 #ifndef _ASMLANGUAGE
 extern u32_t z_timer_cycle_get_32(void);
-#define z_arch_k_cycle_get_32()	z_timer_cycle_get_32()
+
+static inline u32_t z_arch_k_cycle_get_32(void)
+{
+	return z_timer_cycle_get_32();
+}
 
 /**
  * @brief Explicitly nop operation.

--- a/include/arch/common/sys_io.h
+++ b/include/arch/common/sys_io.h
@@ -14,6 +14,7 @@
 
 #ifndef _ASMLANGUAGE
 
+#include <toolchain.h>
 #include <zephyr/types.h>
 #include <sys/sys_io.h>
 

--- a/include/arch/nios2/arch.h
+++ b/include/arch/nios2/arch.h
@@ -199,7 +199,11 @@ enum nios2_exception_cause {
 
 
 extern u32_t z_timer_cycle_get_32(void);
-#define z_arch_k_cycle_get_32()	z_timer_cycle_get_32()
+
+static inline u32_t z_arch_k_cycle_get_32(void)
+{
+	return z_timer_cycle_get_32();
+}
 
 /**
  * @brief Explicitly nop operation.

--- a/include/arch/posix/arch.h
+++ b/include/arch/posix/arch.h
@@ -45,7 +45,11 @@ struct __esf {
 typedef struct __esf z_arch_esf_t;
 
 extern u32_t z_timer_cycle_get_32(void);
-#define z_arch_k_cycle_get_32()  z_timer_cycle_get_32()
+
+static inline u32_t z_arch_k_cycle_get_32(void)
+{
+	return z_timer_cycle_get_32();
+}
 
 /**
  * @brief Explicitly nop operation.

--- a/include/arch/posix/arch.h
+++ b/include/arch/posix/arch.h
@@ -59,6 +59,40 @@ static ALWAYS_INLINE void z_arch_nop(void)
 	__asm__ volatile("nop");
 }
 
+static ALWAYS_INLINE unsigned int z_arch_irq_lock(void)
+{
+	return posix_irq_lock();
+}
+
+static ALWAYS_INLINE void z_arch_irq_unlock(unsigned int key)
+{
+	posix_irq_unlock(key);
+}
+
+static ALWAYS_INLINE void z_arch_irq_enable(unsigned int irq)
+{
+	posix_irq_enable(irq);
+}
+
+static ALWAYS_INLINE void z_arch_irq_disable(unsigned int irq)
+{
+	posix_irq_disable(irq);
+}
+
+static ALWAYS_INLINE int z_arch_irq_is_enabled(unsigned int irq)
+{
+	return posix_irq_is_enabled(irq);
+}
+
+/**
+ * Returns true if interrupts were unlocked prior to the
+ * z_arch_irq_lock() call that produced the key argument.
+ */
+static ALWAYS_INLINE bool z_arch_irq_unlocked(unsigned int key)
+{
+	return key == false;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/arch/riscv/arch.h
+++ b/include/arch/riscv/arch.h
@@ -156,7 +156,11 @@ static ALWAYS_INLINE void z_arch_nop(void)
 
 
 extern u32_t z_timer_cycle_get_32(void);
-#define z_arch_k_cycle_get_32()	z_timer_cycle_get_32()
+
+static inline u32_t z_arch_k_cycle_get_32(void)
+{
+	return z_timer_cycle_get_32();
+}
 
 #ifdef __cplusplus
 }

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -211,7 +211,11 @@ extern void z_arch_irq_enable(unsigned int irq);
 extern void z_arch_irq_disable(unsigned int irq);
 
 extern u32_t z_timer_cycle_get_32(void);
-#define z_arch_k_cycle_get_32() z_timer_cycle_get_32()
+
+static inline u32_t z_arch_k_cycle_get_32(void)
+{
+	return z_timer_cycle_get_32();
+}
 
 /**
  * Returns true if interrupts were unlocked prior to the

--- a/include/arch/x86_64/arch.h
+++ b/include/arch/x86_64/arch.h
@@ -6,7 +6,6 @@
 #ifndef _X86_64_ARCH_H
 #define _X86_64_ARCH_H
 
-#include <kernel_arch_func.h>
 #include <arch/common/sys_io.h>
 #include <arch/common/ffs.h>
 
@@ -17,4 +16,67 @@
 #define DT_INST_0_INTEL_HPET_IRQ_0_PRIORITY	4
 
 typedef struct z_arch_esf_t z_arch_esf_t;
+
+static inline u32_t z_arch_k_cycle_get_32(void)
+{
+#ifdef CONFIG_HPET_TIMER
+	extern u32_t z_timer_cycle_get_32(void);
+	return z_timer_cycle_get_32();
+#else
+	return (u32_t)z_arch_k_cycle_get_64();
+#endif
+}
+
+/* Not a standard Zephyr function, but probably will be */
+static inline unsigned long long z_arch_k_cycle_get_64(void)
+{
+	unsigned int hi, lo;
+
+	__asm__ volatile("rdtsc" : "=d"(hi), "=a"(lo));
+	return (((unsigned long long)hi) << 32) | lo;
+}
+
+static inline unsigned int z_arch_irq_lock(void)
+{
+	unsigned long long key;
+
+	__asm__ volatile("pushfq; cli; popq %0" : "=r"(key));
+	return (int)key;
+}
+
+static inline void z_arch_irq_unlock(unsigned int key)
+{
+	if (key & 0x200) {
+		__asm__ volatile("sti");
+	}
+}
+
+/**
+ * Returns true if interrupts were unlocked prior to the
+ * z_arch_irq_lock() call that produced the key argument.
+ */
+static inline bool z_arch_irq_unlocked(unsigned int key)
+{
+	return (key & 0x200) != 0;
+}
+
+void z_arch_irq_enable(unsigned int irq);
+
+void z_arch_irq_disable(unsigned int irq);
+
+#define Z_ARCH_IRQ_CONNECT(irq, pri, isr, arg, flags) \
+	z_arch_irq_connect_dynamic(irq, pri, isr, arg, flags)
+
+extern int x86_64_except_reason;
+
+
+/* Vector 5 is the "bounds" exception which is otherwise vestigial
+ * (BOUND is an illegal instruction in long mode)
+ */
+#define Z_ARCH_EXCEPT(reason) do {		\
+		x86_64_except_reason = reason;	\
+		__asm__ volatile("int $5");	\
+	} while (false)
+
+
 #endif /* _X86_64_ARCH_H */

--- a/include/arch/xtensa/arch.h
+++ b/include/arch/xtensa/arch.h
@@ -81,7 +81,11 @@ extern void z_irq_spurious(void *unused);
 #define XTENSA_ERR_NORET
 
 extern u32_t z_timer_cycle_get_32(void);
-#define z_arch_k_cycle_get_32()	z_timer_cycle_get_32()
+
+static inline u32_t z_arch_k_cycle_get_32(void)
+{
+	return z_timer_cycle_get_32();
+}
 
 /**
  * @brief Explicitly nop operation.

--- a/include/kernel_includes.h
+++ b/include/kernel_includes.h
@@ -36,5 +36,6 @@
 #include <sys_clock.h>
 #include <spinlock.h>
 #include <fatal.h>
+#include <irq.h>
 
 #endif /* ZEPHYR_INCLUDE_KERNEL_INCLUDES_H_ */


### PR DESCRIPTION
To prepare for the centralized arch interface in #19584 some housekeeping is in order, in that all arches must define these APIs in the same way.

APIs which are defined as inline functions, but implemented non-inline, or vice versa, are now consistent across all arches and in conformance with the arch header.

APIs which are defined as inline functions, but implemented as macros, are now implemented as inline functions.

x86_64 needed a little more work as arch/cpu.h was pulling in kernel_arch_func.h. which shouldn't be done.