### PR TITLE
Set stack align to 8 bytes for 64-bit posix targets

### DIFF
--- a/include/arch/posix/arch.h
+++ b/include/arch/posix/arch.h
@@ -30,8 +30,13 @@
 extern "C" {
 #endif
 
+#ifdef CONFIG_64BIT
+#define STACK_ALIGN 8
+#define STACK_ALIGN_SIZE 8
+#else
 #define STACK_ALIGN 4
 #define STACK_ALIGN_SIZE 4
+#endif
 
 struct __esf {
 	u32_t dummy; /*maybe we will want to add something someday*/


### PR DESCRIPTION
Set STACK_ALIGN and STACK_ALIGN_SIZE to 8 bytes instead of 4 bytes in case a 64-bit posix board is used to prevent misaligned access.

This problem was detected by running UBSAN:
```
arch/posix/core/thread.c:66:29: runtime error: member access within misaligned address 0x55555577f8bc for type 'struct posix_thread_status_t', which requires 8 byte alignment
0x55555577f8bc: note: pointer points here
  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
              ^
```