### PR TITLE
Misc. timing test fixes

### DIFF
--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -307,7 +307,7 @@ static void *k_queue_poll(struct k_queue *queue, s32_t timeout)
 
 		if ((val == NULL) && (timeout != K_FOREVER)) {
 			elapsed = k_uptime_get_32() - start;
-			done = elapsed > timeout;
+			done = elapsed >= timeout;
 		}
 	} while (!val && !done);
 

--- a/tests/kernel/fifo/fifo_timeout/src/main.c
+++ b/tests/kernel/fifo/fifo_timeout/src/main.c
@@ -367,7 +367,8 @@ static void test_timeout_fifo_thread(void)
 				&timeout, NULL,
 				FIFO_THREAD_PRIO, K_INHERIT_PERMS, 0);
 
-	packet = k_fifo_get(&fifo_timeout[0], timeout + 10);
+	packet = k_fifo_get(&fifo_timeout[0], timeout
+			    + k_ticks_to_ms_ceil32(2));
 	zassert_true(packet != NULL, NULL);
 	zassert_true(is_timeout_in_range(start_time, timeout), NULL);
 	put_scratch_packet(packet);
@@ -382,7 +383,6 @@ static void test_timeout_fifo_thread(void)
 				test_thread_timeout_reply_values,
 				&reply_packet, NULL, NULL,
 				FIFO_THREAD_PRIO, K_INHERIT_PERMS, 0);
-
 	k_yield();
 	packet = k_fifo_get(&timeout_order_fifo, K_NO_WAIT);
 	zassert_true(packet != NULL, NULL);

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -5,7 +5,7 @@
  */
 #include "interrupt.h"
 
-#define DURATION 5
+#define DURATION 10
 struct k_timer timer;
 
 /* This tests uses two IRQ lines, selected within the range of IRQ lines
@@ -85,7 +85,7 @@ void isr0(void *param)
 	 */
 	k_busy_wait(MS_TO_US(1000));
 #else
-	k_busy_wait(MS_TO_US(10));
+	k_busy_wait(DURATION * 1000 + (int)k_ticks_to_us_ceil64(1));
 #endif
 	printk("%s execution completed !!\n", __func__);
 	zassert_equal(new_val, old_val, "Nested interrupt is not working\n");

--- a/tests/kernel/lifo/lifo_usage/src/main.c
+++ b/tests/kernel/lifo/lifo_usage/src/main.c
@@ -324,7 +324,8 @@ static void test_timeout_lifo_thread(void)
 				&timeout, NULL,
 				LIFO_THREAD_PRIO, K_INHERIT_PERMS, 0);
 
-	packet = k_lifo_get(&lifo_timeout[0], timeout + 10);
+	packet = k_lifo_get(&lifo_timeout[0], timeout
+			    + k_ticks_to_ms_ceil32(2));
 	zassert_true(packet != NULL, NULL);
 	zassert_true(is_timeout_in_range(start_time, timeout), NULL);
 	put_scratch_packet(packet);


### PR DESCRIPTION
More evacuees from #17155 that can stand on their own.  These aren't related to the timeout work per se, except insofar as the bugs are sensitivities to timing.  See commit notes for details.

Note that two of the patches were written above the new conversion API, so they require #19591 to be merged before they will build in CI. 