### PR TITLE
arch/x86: Fix gcc-9.2 warning with z_arch_syscall_invoke6

### DIFF
--- a/include/arch/x86/ia32/syscall.h
+++ b/include/arch/x86/ia32/syscall.h
@@ -48,7 +48,7 @@ static inline u32_t z_arch_syscall_invoke6(u32_t arg1, u32_t arg2, u32_t arg3,
 			 : "S" (call_id), "a" (arg1), "d" (arg2),
 			   "c" (arg3), "b" (arg4), "D" (arg5),
 			   [arg6] "m" (arg6)
-			 : "memory", "esp");
+			 : "memory");
 	return ret;
 }
 


### PR DESCRIPTION
Fix the following warning from gcc-9.2:

x86/ia32/syscall.h: In function 'test_kinit_preempt_thread':
x86/ia32/syscall.h:43:2: error: listing the stack pointer register
 'esp' in a clobber list is deprecated [-Werror=deprecated]
   43 |  __asm__ volatile("push %%ebp\n\t"
      |  ^~~~~~~
x86/ia32/syscall.h:43:2: note: the value of the stack pointer after
an 'asm' statement must be the same as it was before the statement

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>