### PR TITLE
kernel: Fix gcc-9.2 warning with _StackCheckHandler

### DIFF
--- a/kernel/compiler_stack_protect.c
+++ b/kernel/compiler_stack_protect.c
@@ -32,7 +32,7 @@
  *
  * @return Does not return
  */
-void FUNC_NORETURN _StackCheckHandler(void)
+void _StackCheckHandler(void)
 {
 	/* Stack canary error is a software fatal condition; treat it as such.
 	 */


### PR DESCRIPTION
Remove FUNC_NORETURN attribute from _StackCheckHandler to address the
following warning from gcc-9.2:

kernel/compiler_stack_protect.c:62:32: error: '__stack_chk_fail'
specifies less restrictive attribute than its target
'_StackCheckHandler': 'noreturn' [-Werror=missing-attributes]

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>