### PR TITLE
boards: arm: stm32: fix out of bounds access

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -246,10 +246,14 @@ static int start_read(struct device *dev, const struct adc_sequence *sequence)
 	case 10:
 		resolution = table_resolution[2];
 		break;
-#endif
 	case 12:
 		resolution = table_resolution[3];
 		break;
+#else
+	case 12:
+		resolution = table_resolution[0];
+		break;
+#endif
 	default:
 		LOG_ERR("Invalid resolution");
 		return -EINVAL;


### PR DESCRIPTION
Fix an out of bounds access when `CONFIG_SOC_SERIES_STM32F1X` is
enabled.

Signed-off-by: Noah Pendleton <noah.pendleton@gmail.com>