### PR TITLE
native_posix: 💧 Fix realloc potential leak

### DIFF
--- a/boards/posix/native_posix/cmdline.c
+++ b/boards/posix/native_posix/cmdline.c
@@ -54,13 +54,15 @@ void native_add_command_line_opts(struct args_struct_t *args)
 			growby = ARGS_ALLOC_CHUNK_SIZE;
 		}
 
-		args_struct = realloc(args_struct,
+		struct args_struct_t *new_args_struct = realloc(args_struct,
 				      (args_aval + growby)*
 				      sizeof(struct args_struct_t));
 		args_aval += growby;
 		/* LCOV_EXCL_START */
-		if (args_struct == NULL) {
+		if (new_args_struct == NULL) {
 			posix_print_error_and_exit("Could not allocate memory");
+		} else {
+			args_struct = new_args_struct;
 		}
 		/* LCOV_EXCL_STOP */
 	}


### PR DESCRIPTION
Fix a possible leak if `realloc` fails here; check the result of the
`realloc` call before updating the pointer, so it can be freed in the
failure case.