### PR TITLE
Bluetooth: Mesh: Remove unnecessary #ifdefs

### DIFF
--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -151,7 +151,6 @@ static int secure_beacon_send(void)
 
 static int unprovisioned_beacon_send(void)
 {
-#if defined(CONFIG_BT_MESH_PB_ADV)
 	const struct bt_mesh_prov *prov;
 	u8_t uri_hash[16] = { 0 };
 	struct net_buf *buf;
@@ -203,7 +202,6 @@ static int unprovisioned_beacon_send(void)
 		net_buf_unref(buf);
 	}
 
-#endif /* CONFIG_BT_MESH_PB_ADV */
 	return 0;
 }
 
@@ -253,11 +251,10 @@ static void beacon_send(struct k_work *work)
 			k_delayed_work_submit(&beacon_timer,
 					      PROVISIONED_INTERVAL);
 		}
-	} else {
+	} else if (IS_ENABLED(CONFIG_BT_MESH_PB_ADV)) {
 		unprovisioned_beacon_send();
 		k_delayed_work_submit(&beacon_timer, UNPROVISIONED_INTERVAL);
 	}
-
 }
 
 static void secure_beacon_recv(struct net_buf_simple *buf)

--- a/subsys/bluetooth/mesh/crypto.c
+++ b/subsys/bluetooth/mesh/crypto.c
@@ -521,7 +521,6 @@ static int bt_mesh_ccm_encrypt(const u8_t key[16], u8_t nonce[13],
 	return 0;
 }
 
-#if defined(CONFIG_BT_MESH_PROXY)
 static void create_proxy_nonce(u8_t nonce[13], const u8_t *pdu,
 			       u32_t iv_index)
 {
@@ -547,7 +546,6 @@ static void create_proxy_nonce(u8_t nonce[13], const u8_t *pdu,
 	/* IV Index */
 	sys_put_be32(iv_index, &nonce[9]);
 }
-#endif /* PROXY */
 
 static void create_net_nonce(u8_t nonce[13], const u8_t *pdu,
 			     u32_t iv_index)
@@ -612,15 +610,11 @@ int bt_mesh_net_encrypt(const u8_t key[16], struct net_buf_simple *buf,
 	       mic_len);
 	BT_DBG("PDU (len %u) %s", buf->len, bt_hex(buf->data, buf->len));
 
-#if defined(CONFIG_BT_MESH_PROXY)
-	if (proxy) {
+	if (IS_ENABLED(CONFIG_BT_MESH_PROXY) && proxy) {
 		create_proxy_nonce(nonce, buf->data, iv_index);
 	} else {
 		create_net_nonce(nonce, buf->data, iv_index);
 	}
-#else
-	create_net_nonce(nonce, buf->data, iv_index);
-#endif
 
 	BT_DBG("Nonce %s", bt_hex(nonce, 13));
 
@@ -643,15 +637,11 @@ int bt_mesh_net_decrypt(const u8_t key[16], struct net_buf_simple *buf,
 	BT_DBG("iv_index %u, key %s mic_len %u", iv_index, bt_hex(key, 16),
 	       mic_len);
 
-#if defined(CONFIG_BT_MESH_PROXY)
-	if (proxy) {
+	if (IS_ENABLED(CONFIG_BT_MESH_PROXY) && proxy) {
 		create_proxy_nonce(nonce, buf->data, iv_index);
 	} else {
 		create_net_nonce(nonce, buf->data, iv_index);
 	}
-#else
-	create_net_nonce(nonce, buf->data, iv_index);
-#endif
 
 	BT_DBG("Nonce %s", bt_hex(nonce, 13));
 


### PR DESCRIPTION
Static variables and functions don't need #ifdefs if the code calling them is using `IS_ENABLED()`. If `IS_ENABLED()` evaluates to false the compiler will strip out all the static entities.