### PR TITLE
drivers: flash: add omitted dependency

### DIFF
--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -33,7 +33,7 @@ source "subsys/logging/Kconfig.template.log_config"
 
 config FLASH_SHELL
 	bool "Enable Flash shell"
-	depends on FLASH_PAGE_LAYOUT
+	depends on SHELL && FLASH_PAGE_LAYOUT
 	help
 	  Enable the flash shell with flash related commands such as test,
 	  write, read and erase.


### PR DESCRIPTION
FLASH_SHELL must depend on the base SHELL.
enabling FLASH_SHELL base SHELL will lead to undefined references during linkage