### PR TITLE
net: shell: ping: Figure out the output network interface

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2861,9 +2861,12 @@ static int ping_ipv6(const struct shell *shell,
 
 	net_icmpv6_register_handler(&ping6_handler);
 
-	nbr = net_ipv6_nbr_lookup(NULL, &ipv6_target);
-	if (nbr) {
-		iface = nbr->iface;
+	iface = net_if_ipv6_select_src_iface(&ipv6_target);
+	if (!iface) {
+		nbr = net_ipv6_nbr_lookup(NULL, &ipv6_target);
+		if (nbr) {
+			iface = nbr->iface;
+		}
 	}
 
 #if defined(CONFIG_NET_ROUTE)


### PR DESCRIPTION
Try to figure out where the ping reply should be sent if there
are multiple network interfaces in the system.

Fixes #19612

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>