### PR TITLE
boards: nucleo_wb55rg: add omitted code-partition

### DIFF
--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -18,6 +18,7 @@
 		zephyr,bt-mon-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {


### PR DESCRIPTION
Add omitted chosen entry. Required for MCUBOOT
