### PR TITLE
k_mem_pool_alloc(): remove dead code

### DIFF
--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -61,26 +61,9 @@ int k_mem_pool_alloc(struct k_mem_pool *p, struct k_mem_block *block,
 	while (true) {
 		u32_t level_num, block_num;
 
-		/* There is a "managed race" in alloc that can fail
-		 * (albeit in a well-defined way, see comments there)
-		 * with -EAGAIN when simultaneous allocations happen.
-		 * Retry exactly once before sleeping to resolve it.
-		 * If we're so contended that it fails twice, then we
-		 * clearly want to block.
-		 */
-		for (int i = 0; i < 2; i++) {
-			ret = z_sys_mem_pool_block_alloc(&p->base, size,
-							&level_num, &block_num,
-							&block->data);
-			if (ret != -EAGAIN) {
-				break;
-			}
-		}
-
-		if (ret == -EAGAIN) {
-			ret = -ENOMEM;
-		}
-
+		ret = z_sys_mem_pool_block_alloc(&p->base, size,
+						 &level_num, &block_num,
+						 &block->data);
 		block->id.pool = pool_id(p);
 		block->id.level = level_num;
 		block->id.block = block_num;


### PR DESCRIPTION
A loop in k_mem_pool_alloc() around z_sys_mem_pool_block_alloc() assumes
the later may return -EAGAIN with an elaborate comment about it. But
-EAGAIN is no longer returned by that function since commit 7845e1b01e90
("lib/mempool: Fix spurious -ENOMEM due to agressive latency control").