### PR TITLE
coccinelle: improve integer timeout script and fix missed cases

### DIFF
--- a/lib/updatehub/updatehub.c
+++ b/lib/updatehub/updatehub.c
@@ -802,6 +802,6 @@ void updatehub_autohandler(void)
 	static struct k_delayed_work work;
 
 	k_delayed_work_init(&work, autohandler);
-	k_delayed_work_submit(&work, 0);
+	k_delayed_work_submit(&work, K_NO_WAIT);
 }
 

--- a/samples/bluetooth/eddystone/src/main.c
+++ b/samples/bluetooth/eddystone/src/main.c
@@ -663,7 +663,7 @@ static void disconnected(struct bt_conn *conn, u8_t reason)
 	printk("Disconnected (reason 0x%02x)\n", reason);
 
 	if (!slot->connectable) {
-		k_delayed_work_submit(&idle_work, 0);
+		k_delayed_work_submit(&idle_work, K_NO_WAIT);
 	}
 }
 

--- a/samples/net/dns_resolve/src/main.c
+++ b/samples/net/dns_resolve/src/main.c
@@ -193,11 +193,11 @@ static void ipv4_addr_add_handler(struct net_mgmt_event_callback *cb,
 	 * So run it from work queue instead.
 	 */
 	k_delayed_work_init(&ipv4_timer, do_ipv4_lookup);
-	k_delayed_work_submit(&ipv4_timer, 0);
+	k_delayed_work_submit(&ipv4_timer, K_NO_WAIT);
 
 #if defined(CONFIG_MDNS_RESOLVER)
 	k_delayed_work_init(&mdns_ipv4_timer, do_mdns_ipv4_lookup);
-	k_delayed_work_submit(&mdns_ipv4_timer, 0);
+	k_delayed_work_submit(&mdns_ipv4_timer, K_NO_WAIT);
 #endif
 }
 
@@ -281,7 +281,7 @@ static void setup_ipv4(struct net_if *iface)
 
 #if defined(CONFIG_MDNS_RESOLVER) && defined(CONFIG_NET_IPV4)
 	k_delayed_work_init(&mdns_ipv4_timer, do_mdns_ipv4_lookup);
-	k_delayed_work_submit(&mdns_ipv4_timer, 0);
+	k_delayed_work_submit(&mdns_ipv4_timer, K_NO_WAIT);
 #endif
 }
 
@@ -321,7 +321,7 @@ static void setup_ipv6(struct net_if *iface)
 
 #if defined(CONFIG_MDNS_RESOLVER) && defined(CONFIG_NET_IPV6)
 	k_delayed_work_init(&mdns_ipv6_timer, do_mdns_ipv6_lookup);
-	k_delayed_work_submit(&mdns_ipv6_timer, 0);
+	k_delayed_work_submit(&mdns_ipv6_timer, K_NO_WAIT);
 #endif
 }
 

--- a/scripts/coccinelle/int_literal_to_timeout.cocci
+++ b/scripts/coccinelle/int_literal_to_timeout.cocci
@@ -7,75 +7,132 @@
 // integer milliseconds, when they were intended to be timeout values
 // produced by specific constants and macros.  Convert the integer
 // literals to the desired equivalent.
+//
+// Options: --include-headers
 
-// Handle k_timer_start delay parameters
-@delay_id@
-expression T, P;
-position p;
+virtual patch
+virtual report
+
+// ** Handle timeouts at the last position of kernel API arguments
+
+// Base rule provides the complex identifier regular expression
+@r_last_timeout@
+identifier last_timeout =~ "(?x)^k_
+( timer_start
+| queue_get
+| futex_wait
+| stack_pop
+| delayed_work_submit(|_to_queue)
+| work_poll_submit(|_to_queue)
+| mutex_lock
+| sem_take
+| (msgq|mbox|pipe)_(block_)?(put|get)
+| mem_(slab|pool)_alloc
+| poll
+| thread_deadline_set
+)$";
+@@
+last_timeout(...)
+
+// Identify call sites where an identifier is used for the timeout
+@r_last_timeout_id
+ extends r_last_timeout
+@
 identifier D;
+position p;
 @@
-k_timer_start@p(T, D, P)
+last_timeout@p(..., D)
 
+// Select call sites where a constant literal (not identifier) is used
+// for the timeout and replace the constant with the appropriate macro
+
+@r_last_timeout_const_patch
+ extends r_last_timeout
+ depends on patch
+@
+constant C;
+position p != r_last_timeout_id.p;
 @@
-expression T, P;
-position p != delay_id.p;
-@@
-k_timer_start@p(T,
+last_timeout@p(...,
+(
 - 0
 + K_NO_WAIT
- , P)
-
-@@
-expression T, P;
-position p != delay_id.p;
-@@
-k_timer_start@p(T,
+|
 - -1
 + K_FOREVER
- , P)
+|
+- C
++ K_MSEC(C)
+)
+ )
 
+@r_last_timeout_const_report
+ extends r_last_timeout
+ depends on report
+@
+constant C;
+position p != r_last_timeout_id.p;
 @@
-expression T, P;
-constant int D;
-position p != delay_id.p;
+last_timeout@p(..., C)
+
+@script:python
+ depends on report
+@
+fn << r_last_timeout.last_timeout;
+p << r_last_timeout_const_report.p;
+C << r_last_timeout_const_report.C;
+@@
+msg = "WARNING: replace constant {} with timeout in {}".format(C, fn)
+coccilib.report.print_report(p[0], msg);
+
+// ** Handle k_timer_start where the second (not last) argument is a
+// ** constant literal.
+
+// Select call sites where an identifier is used for the duration timeout
+@r_timer_duration@
+expression T;
+identifier D;
+expression I;
+position p;
+@@
+k_timer_start@p(T, D, I)
+
+// Select call sites where a constant literal (not identifier) is used
+// for the timeout and replace the constant with the appropriate macro
+@depends on patch@
+expression T;
+constant C;
+expression I;
+position p != r_timer_duration.p;
 @@
 k_timer_start@p(T,
-- D
-+ K_MSEC(D)
- , P)
-
-// Handle timeouts at the end of the argument list
-@end_id@
-identifier f =~ "^k_(timer_start|queue_get|futex_wait|stack_pop|delayed_work_submit_to_queue|mutex_lock|sem_take|(msgq|mbox|pipe)_(block_)?(put|get)|mem_(slab|pool)_alloc|poll|thread_deadline_set)$";
-position p;
-identifier D;
-@@
-f@p(..., D)
-
-@@
-identifier f =~ "^k_(timer_start|queue_get|futex_wait|stack_pop|delayed_work_submit_to_queue|mutex_lock|sem_take|(msgq|mbox|pipe)_(block_)?(put|get)|mem_(slab|pool)_alloc|poll|thread_deadline_set)$";
-position p != end_id.p;
-@@
-f@p(...,
+(
 - 0
 + K_NO_WAIT
- )
-
-@@
-identifier f =~ "^k_(timer_start|queue_get|futex_wait|stack_pop|delayed_work_submit_to_queue|mutex_lock|sem_take|(msgq|mbox|pipe)_(block_)?(put|get)|mem_(slab|pool)_alloc|poll|thread_deadline_set)$";
-position p != end_id.p;
-@@
-f@p(...,
+|
 - -1
 + K_FOREVER
- )
+|
+- C
++ K_MSEC(C)
+)
+, I)
 
+@r_timer_duration_report
+ depends on report
+@
+expression T;
+constant C;
+expression I;
+position p != r_timer_duration.p;
 @@
-identifier f =~ "^k_(timer_start|queue_get|futex_wait|stack_pop|delayed_work_submit_to_queue|mutex_lock|sem_take|(msgq|mbox|pipe)_(block_)?(put|get)|mem_(slab|pool)_alloc|poll|thread_deadline_set)$";
-position p != end_id.p;
-constant int D;
+k_timer_start@p(T, C, I)
+
+@script:python
+ depends on report
+@
+p << r_timer_duration_report.p;
+C << r_timer_duration_report.C;
 @@
-f@p(...,
-- D
-+ K_MSEC(D)
- )
+msg = "WARNING: replace constant {} with duration timeout in k_timer_start".format(C)
+coccilib.report.print_report(p[0], msg);

--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -289,7 +289,7 @@ static void coop_delayed_work_cancel_main(int arg1, int arg2)
 
 #if defined(CONFIG_POLL)
 	k_delayed_work_submit(&delayed_tests[2].work,
-			      0 /* Submit immediately */);
+			      K_NO_WAIT /* Submit immediately */);
 
 	TC_PRINT(" - Cancel pending delayed work from coop thread\n");
 	k_delayed_work_cancel(&delayed_tests[2].work);
@@ -370,7 +370,7 @@ static void coop_delayed_work_resubmit(void)
 
 	for (i = 0; i < NUM_TEST_ITEMS; i++) {
 		TC_PRINT(" - Resubmitting delayed work with 1 ms\n");
-		k_delayed_work_submit(&delayed_tests[0].work, 1);
+		k_delayed_work_submit(&delayed_tests[0].work, K_MSEC(1));
 
 		/* Busy wait 1 ms to force a clash with workqueue */
 #if defined(CONFIG_ARCH_POSIX)


### PR DESCRIPTION
My original naive and unmaintainable SmPL script has been significantly updated:
* Add support for the report and patch modes so this can be invoked by coccicheck.
* Use PCRE options to make the kernel timeout API identifier rule more  readable.
* Extend the pattern to new API.
* Use rule `extends` and `depends on` clauses, and pattern disjunction, to avoid replicating metavariable content

Also I missed the default-queue version of `k_delayed_work_submit`, and have added the new `k_work_poll*` functions.