### PR TITLE
[TOPIC-GPIO] drivers: Update TI cc32xx and cc13x2/cc26x2 gpio drivers to use new gpio api

### DIFF
--- a/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
+++ b/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
@@ -8,7 +8,7 @@
 
 #include <ti/cc1352r.dtsi>
 
-#define BTN_GPIO_FLAGS (GPIO_INT_ACTIVE_LOW | GPIO_PUD_PULL_UP)
+#define BTN_GPIO_FLAGS (GPIO_ACTIVE_LOW | GPIO_PULL_UP)
 
 / {
 	model = "TI CC1352R1 LaunchXL";
@@ -31,11 +31,11 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio0 7 0>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 			label = "Green LED";
 		};
 		led1: led_1 {
-			gpios = <&gpio0 6 0>;
+			gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
 			label = "Red LED";
 		};
 	};

--- a/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
+++ b/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
@@ -8,7 +8,7 @@
 
 #include <ti/cc2652r.dtsi>
 
-#define BTN_GPIO_FLAGS (GPIO_INT_ACTIVE_LOW | GPIO_PUD_PULL_UP)
+#define BTN_GPIO_FLAGS (GPIO_ACTIVE_LOW | GPIO_PULL_UP)
 
 / {
 	model = "TI CC26x2R1 LaunchXL";
@@ -31,11 +31,11 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio0 7 0>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 			label = "Green LED";
 		};
 		led1: led_1 {
-			gpios = <&gpio0 6 0>;
+			gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
 			label = "Red LED";
 		};
 	};

--- a/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
+++ b/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
@@ -30,15 +30,15 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpioa1 3 0>;
+			gpios = <&gpioa1 3 GPIO_ACTIVE_HIGH>;
 			label = "Green LED";
 		};
 		led1: led_1 {
-			gpios = <&gpioa1 2 0>;
+			gpios = <&gpioa1 2 GPIO_ACTIVE_HIGH>;
 			label = "Yellow LED";
 		};
 		led2: led_2 {
-			gpios = <&gpioa1 1 0>;
+			gpios = <&gpioa1 1 GPIO_ACTIVE_HIGH>;
 			label = "Red LED";
 		};
 	};
@@ -47,12 +47,12 @@
 		/* Push button 2 */
 		compatible = "gpio-keys";
 		sw2: button_0 {
-			gpios = <&gpioa2 6 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa2 6 GPIO_ACTIVE_HIGH>;
 			label = "Push button switch 2";
 		};
 		/* Push button 3 */
 		sw3: button_1 {
-			gpios = <&gpioa1 5 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa1 5 GPIO_ACTIVE_HIGH>;
 			label = "Push button switch 3";
 		};
 	};

--- a/boards/arm/cc3235sf_launchxl/cc3235sf_launchxl.dts
+++ b/boards/arm/cc3235sf_launchxl/cc3235sf_launchxl.dts
@@ -34,15 +34,15 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpioa1 3 0>;
+			gpios = <&gpioa1 3 GPIO_ACTIVE_HIGH>;
 			label = "Green LED";
 		};
 		led1: led_1 {
-			gpios = <&gpioa1 2 0>;
+			gpios = <&gpioa1 2 GPIO_ACTIVE_HIGH>;
 			label = "Yellow LED";
 		};
 		led2: led_2 {
-			gpios = <&gpioa1 1 0>;
+			gpios = <&gpioa1 1 GPIO_ACTIVE_HIGH>;
 			label = "Red LED";
 		};
 	};
@@ -51,12 +51,12 @@
 		/* Push button 2 */
 		compatible = "gpio-keys";
 		sw2: button_0 {
-			gpios = <&gpioa2 6 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa2 6 GPIO_ACTIVE_HIGH>;
 			label = "Push button switch 2";
 		};
 		/* Push button 3 */
 		sw3: button_1 {
-			gpios = <&gpioa1 5 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa1 5 GPIO_ACTIVE_HIGH>;
 			label = "Push button switch 3";
 		};
 	};

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -17,6 +17,12 @@
 
 #include "gpio_utils.h"
 
+/* bits 16-18 in iocfg registers correspond to interrupt settings */
+#define IOCFG_INT_MASK    0x00070000
+
+/* the rest are for general (non-interrupt) config */
+#define IOCFG_GEN_MASK    (~IOCFG_INT_MASK)
+
 struct gpio_cc13xx_cc26xx_data {
 	/* gpio_driver_data needs to be first */
 	struct gpio_driver_data common;
@@ -26,10 +32,15 @@ struct gpio_cc13xx_cc26xx_data {
 
 static struct gpio_cc13xx_cc26xx_data gpio_cc13xx_cc26xx_data_0;
 
+static int gpio_cc13xx_cc26xx_port_set_bits_raw(struct device *port,
+	u32_t mask);
+static int gpio_cc13xx_cc26xx_port_clear_bits_raw(struct device *port,
+	u32_t mask);
+
 static int gpio_cc13xx_cc26xx_config(struct device *port, int access_op,
 				     u32_t pin, int flags)
 {
-	u32_t config;
+	u32_t config = 0;
 
 	if (access_op != GPIO_ACCESS_BY_PIN) {
 		return -ENOTSUP;
@@ -37,37 +48,26 @@ static int gpio_cc13xx_cc26xx_config(struct device *port, int access_op,
 
 	__ASSERT_NO_MSG(pin < NUM_IO_MAX);
 
-	config = IOC_CURRENT_2MA | IOC_STRENGTH_AUTO | IOC_SLEW_DISABLE |
-		 IOC_NO_WAKE_UP;
-
-	if (flags & GPIO_INT) {
-		__ASSERT_NO_MSG((flags & GPIO_DIR_MASK) == GPIO_DIR_IN);
-
-		config |= IOC_INT_ENABLE | IOC_INPUT_ENABLE;
-
-		if (flags & GPIO_INT_EDGE) {
-			if (flags & GPIO_INT_DOUBLE_EDGE) {
-				config |= IOC_BOTH_EDGES;
-			} else if (flags & GPIO_INT_ACTIVE_HIGH) {
-				config |= IOC_RISING_EDGE;
-			} else { /* GPIO_INT_ACTIVE_LOW */
-				config |= IOC_FALLING_EDGE;
-			}
-		} else {
-			return -ENOTSUP;
-		}
-
-		config |= (flags & GPIO_INT_DEBOUNCE) ? IOC_HYST_ENABLE :
-							IOC_HYST_DISABLE;
-	} else {
-		config |= IOC_INT_DISABLE | IOC_NO_EDGE | IOC_HYST_DISABLE;
-		config |= (flags & GPIO_DIR_MASK) == GPIO_DIR_IN ?
-				  IOC_INPUT_ENABLE :
-				  IOC_INPUT_DISABLE;
+	switch (flags & (GPIO_INPUT | GPIO_OUTPUT)) {
+	case GPIO_INPUT:
+		config = IOC_INPUT_ENABLE;
+		break;
+	case GPIO_OUTPUT:
+		config = IOC_INPUT_DISABLE;
+		break;
+	case 0:  /* disconnected */
+		IOCPortConfigureSet(pin, IOC_PORT_GPIO, IOC_NO_IOPULL);
+		GPIO_setOutputEnableDio(pin, GPIO_OUTPUT_DISABLE);
+		return 0;
+	default:
+		return -ENOTSUP;
 	}
 
-	config |= (flags & GPIO_POL_MASK) == GPIO_POL_INV ? IOC_IOMODE_INV :
-							    IOC_IOMODE_NORMAL;
+	config |= IOC_CURRENT_2MA | IOC_STRENGTH_AUTO | IOC_SLEW_DISABLE |
+		 IOC_NO_WAKE_UP;
+
+	config |= (flags & GPIO_INT_DEBOUNCE) ? IOC_HYST_ENABLE :
+							IOC_HYST_DISABLE;
 
 	switch (flags & GPIO_PUD_MASK) {
 	case GPIO_PUD_NORMAL:
@@ -83,12 +83,18 @@ static int gpio_cc13xx_cc26xx_config(struct device *port, int access_op,
 		return -EINVAL;
 	}
 
+	config |= IOCPortConfigureGet(pin) & IOCFG_INT_MASK;
 	IOCPortConfigureSet(pin, IOC_PORT_GPIO, config);
 
-	if ((flags & GPIO_DIR_MASK) == GPIO_DIR_IN) {
-		GPIO_setOutputEnableDio(pin, GPIO_OUTPUT_DISABLE);
-	} else {
+	if ((flags & GPIO_OUTPUT) != 0) {
+		if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0) {
+			gpio_cc13xx_cc26xx_port_set_bits_raw(port, BIT(pin));
+		} else if ((flags & GPIO_OUTPUT_INIT_LOW) != 0) {
+			gpio_cc13xx_cc26xx_port_clear_bits_raw(port, BIT(pin));
+		}
 		GPIO_setOutputEnableDio(pin, GPIO_OUTPUT_ENABLE);
+	} else {
+		GPIO_setOutputEnableDio(pin, GPIO_OUTPUT_DISABLE);
 	}
 
 	return 0;
@@ -136,6 +142,80 @@ static int gpio_cc13xx_cc26xx_read(struct device *port, int access_op,
 	default:
 		return -EINVAL;
 	}
+
+	return 0;
+}
+
+static int gpio_cc13xx_cc26xx_port_get_raw(struct device *port, u32_t *value)
+{
+	__ASSERT_NO_MSG(value != NULL);
+
+	*value = GPIO_readMultiDio(GPIO_DIO_ALL_MASK);
+
+	return 0;
+}
+
+static int gpio_cc13xx_cc26xx_port_set_masked_raw(struct device *port,
+	u32_t mask, u32_t value)
+{
+	GPIO_setMultiDio(mask & value);
+	GPIO_clearMultiDio(mask & ~value);
+
+	return 0;
+}
+
+static int gpio_cc13xx_cc26xx_port_set_bits_raw(struct device *port, u32_t mask)
+{
+	GPIO_setMultiDio(mask);
+
+	return 0;
+}
+
+static int gpio_cc13xx_cc26xx_port_clear_bits_raw(struct device *port,
+	u32_t mask)
+{
+	GPIO_clearMultiDio(mask);
+
+	return 0;
+}
+
+static int gpio_cc13xx_cc26xx_port_toggle_bits(struct device *port, u32_t mask)
+{
+	GPIO_toggleMultiDio(mask);
+
+	return 0;
+}
+
+static int gpio_cc13xx_cc26xx_pin_interrupt_configure(struct device *port,
+		unsigned int pin, enum gpio_int_mode mode,
+		enum gpio_int_trig trig)
+{
+	struct gpio_cc13xx_cc26xx_data *data = port->driver_data;
+	u32_t config = 0;
+
+	if (mode != GPIO_INT_MODE_DISABLED) {
+		if (mode == GPIO_INT_MODE_EDGE) {
+			if (trig == GPIO_INT_TRIG_BOTH) {
+				config |= IOC_BOTH_EDGES;
+			} else if (trig == GPIO_INT_TRIG_HIGH) {
+				config |= IOC_RISING_EDGE;
+			} else { /* GPIO_INT_TRIG_LOW */
+				config |= IOC_FALLING_EDGE;
+			}
+		} else {
+			return -ENOTSUP;
+		}
+
+		config |= IOC_INT_ENABLE;
+	} else {
+		config |= IOC_INT_DISABLE | IOC_NO_EDGE;
+	}
+
+	config |= IOCPortConfigureGet(pin) & IOCFG_GEN_MASK;
+	IOCPortConfigureSet(pin, IOC_PORT_GPIO, config);
+
+	WRITE_BIT(data->pin_callback_enables, pin,
+		mode != GPIO_INT_MODE_DISABLED);
 
 	return 0;
 }
@@ -247,6 +327,12 @@ static const struct gpio_driver_api gpio_cc13xx_cc26xx_driver_api = {
 	.config = gpio_cc13xx_cc26xx_config,
 	.write = gpio_cc13xx_cc26xx_write,
 	.read = gpio_cc13xx_cc26xx_read,
+	.port_get_raw = gpio_cc13xx_cc26xx_port_get_raw,
+	.port_set_masked_raw = gpio_cc13xx_cc26xx_port_set_masked_raw,
+	.port_set_bits_raw = gpio_cc13xx_cc26xx_port_set_bits_raw,
+	.port_clear_bits_raw = gpio_cc13xx_cc26xx_port_clear_bits_raw,
+	.port_toggle_bits = gpio_cc13xx_cc26xx_port_toggle_bits,
+	.pin_interrupt_configure = gpio_cc13xx_cc26xx_pin_interrupt_configure,
 	.manage_callback = gpio_cc13xx_cc26xx_manage_callback,
 	.enable_callback = gpio_cc13xx_cc26xx_enable_callback,
 	.disable_callback = gpio_cc13xx_cc26xx_disable_callback,

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -111,6 +111,8 @@ static inline int gpio_cc32xx_write(struct device *port,
 	const struct gpio_cc32xx_config *gpio_config = DEV_CFG(port);
 	unsigned long port_base = gpio_config->port_base;
 
+	__ASSERT(pin < 8, "Invalid pin number - only 8 pins per port");
+
 	if (access_op == GPIO_ACCESS_BY_PIN) {
 		value = value << pin;
 		/* Bitpack external GPIO pin number for GPIOPinWrite API: */
@@ -132,6 +134,8 @@ static inline int gpio_cc32xx_read(struct device *port,
 	unsigned long port_base = gpio_config->port_base;
 	long status;
 	unsigned char pin_packed;
+
+	__ASSERT(pin < 8, "Invalid pin number - only 8 pins per port");
 
 	if (access_op == GPIO_ACCESS_BY_PIN) {
 		/* Bitpack external GPIO pin number for GPIOPinRead API: */
@@ -210,6 +214,8 @@ static int gpio_cc32xx_pin_interrupt_configure(struct device *port,
 	unsigned long port_base = gpio_config->port_base;
 	unsigned long int_type;
 
+	__ASSERT(pin < 8, "Invalid pin number - only 8 pins per port");
+
 	if (mode != GPIO_INT_MODE_DISABLED) {
 		if (mode == GPIO_INT_MODE_EDGE) {
 			if (trig == GPIO_INT_TRIG_BOTH) {
@@ -253,6 +259,8 @@ static int gpio_cc32xx_enable_callback(struct device *dev,
 {
 	struct gpio_cc32xx_data *data = DEV_DATA(dev);
 
+	__ASSERT(pin < 8, "Invalid pin number - only 8 pins per port");
+
 	if (access_op == GPIO_ACCESS_BY_PIN) {
 		data->pin_callback_enables |= (1 << pin);
 	} else {
@@ -267,6 +275,8 @@ static int gpio_cc32xx_disable_callback(struct device *dev,
 				     int access_op, u32_t pin)
 {
 	struct gpio_cc32xx_data *data = DEV_DATA(dev);
+
+	__ASSERT(pin < 8, "Invalid pin number - only 8 pins per port");
 
 	if (access_op == GPIO_ACCESS_BY_PIN) {
 		data->pin_callback_enables &= ~(1 << pin);

--- a/tests/drivers/gpio/gpio_basic_api/boards/cc1352r1_launchxl.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/cc1352r1_launchxl.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2019 Linaro Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Connect DIO21 to DIO22 to run this test */
+
+/ {
+        resources {
+                compatible = "test,gpio_basic_api";
+                out-gpios = <&gpio0 22 0>;
+                in-gpios = <&gpio0 21 0>;
+        };
+};
+

--- a/tests/drivers/gpio/gpio_basic_api/boards/cc3220sf_launchxl.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/cc3220sf_launchxl.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2019 Linaro Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Connect P07 to P08 to run this test */
+
+/ {
+        resources {
+                compatible = "test,gpio_basic_api";
+                out-gpios = <&gpioa2 1 0>;
+                in-gpios = <&gpioa2 0 0>;
+        };
+};
+

--- a/tests/drivers/gpio/gpio_basic_api/boards/cc3235sf_launchxl.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/cc3235sf_launchxl.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2019 Linaro Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Connect P07 to P08 to run this test */
+
+/ {
+        resources {
+                compatible = "test,gpio_basic_api";
+                out-gpios = <&gpioa2 1 0>;
+                in-gpios = <&gpioa2 0 0>;
+        };
+};
+


### PR DESCRIPTION
Updates the gpio drivers and all associated boards to use
new device tree compatible gpio configuration flags. Implements new port
get/set/clear/toggle and pin_interrupt_configure functions recently
added to the gpio api.

Tested with:

samples/basic/blinky
samples/basic/button
tests/drivers/gpio/gpio_api_1pin
tests/drivers/gpio/gpio_basic_api (overlays added for the tested boards)

On board:

cc3220sf_launchxl
cc3235sf_launchxl
cc1352r1_launchxl
