### PR TITLE
boards: stm32: Set arduino gpio connector on nucleo 64 pins boards

### DIFF
--- a/boards/arm/nucleo_f030r8/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f030r8/arduino_r3_connector.dtsi
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 0 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 10 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f0/stm32f030X8.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F030R8-NUCLEO board";
@@ -54,7 +55,7 @@
 	status = "okay";
 };
 
-arduino_i2c: &i2c1 {
+&i2c1 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -64,7 +65,7 @@ arduino_i2c: &i2c1 {
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
-arduino_spi: &spi1 {
+&spi1 {
       status = "okay";
 };
 

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.yaml
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.yaml
@@ -9,7 +9,9 @@ toolchain:
 ram: 8
 flash: 64
 supported:
+  - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - i2c
   - spi
   - gpio

--- a/boards/arm/nucleo_f070rb/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f070rb/arduino_r3_connector.dtsi
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 0 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 10 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f0/stm32f070Xb.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics NUCLEO-F070RB board";
@@ -54,7 +55,7 @@
 	status = "okay";
 };
 
-arduino_i2c: &i2c1 {
+&i2c1 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -64,7 +65,7 @@ arduino_i2c: &i2c1 {
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
-arduino_spi: &spi1 {
+&spi1 {
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.yaml
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.yaml
@@ -9,7 +9,9 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - gpio
   - i2c
   - spi

--- a/boards/arm/nucleo_f091rc/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f091rc/arduino_r3_connector.dtsi
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 0 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 10 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f0/stm32f091Xc.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F091RC-NUCLEO board";
@@ -53,7 +54,7 @@
 	status = "okay";
 };
 
-arduino_i2c: &i2c1 {
+&i2c1 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -63,7 +64,7 @@ arduino_i2c: &i2c1 {
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
-arduino_spi: &spi1 {
+&spi1 {
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
@@ -9,7 +9,9 @@ toolchain:
 ram: 32
 flash: 256
 supported:
+  - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - gpio
   - i2c
   - nvs

--- a/boards/arm/nucleo_f103rb/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f103rb/arduino_r3_connector.dtsi
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 0 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 10 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -59,7 +59,7 @@
 	pinctrl-names = "default";
 };
 
-arduino_spi: &spi1 {
+&spi1 {
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.yaml
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.yaml
@@ -9,6 +9,8 @@ toolchain:
 ram: 20
 flash: 128
 supported:
+  - arduino_gpio
+  - arduino_spi
   - gpio
   - spi
   - pwm

--- a/boards/arm/nucleo_f302r8/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f302r8/arduino_r3_connector.dtsi
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 0 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 10 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpiob 15 0>,	/* D11 */
+			   <18 0 &gpiob 14 0>,	/* D12 */
+			   <19 0 &gpiob 13 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi2 {};

--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f3/stm32f302X8.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F302R8-NUCLEO board";
@@ -39,9 +40,6 @@
 		sw0 = &user_button;
 	};
 };
-
-arduino_i2c: &i2c1 {};
-arduino_spi: &spi2 {};
 
 &i2c1 {
       status = "okay";

--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.yaml
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.yaml
@@ -9,7 +9,9 @@ toolchain:
 ram: 16
 flash: 64
 supported:
+  - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - i2c
   - spi
   - gpio

--- a/boards/arm/nucleo_f334r8/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f334r8/arduino_r3_connector.dtsi
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 0 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 10 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f3/stm32f334X8.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F334R8-NUCLEO board";
@@ -60,12 +61,12 @@
 	pinctrl-names = "default";
 };
 
-arduino_i2c: &i2c1 {
+&i2c1 {
       status = "okay";
       clock-frequency = <I2C_BITRATE_FAST>;
 };
 
-arduino_spi: &spi1 {
+&spi1 {
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.yaml
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.yaml
@@ -13,7 +13,9 @@ testing:
     - bluetooth
     - net
 supported:
+  - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - gpio
   - i2c
   - spi

--- a/boards/arm/nucleo_f401re/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f401re/arduino_r3_connector.dtsi
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 0 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 10 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -7,6 +7,7 @@
 
 /dts-v1/;
 #include <st/f4/stm32f401Xe.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F401RE-NUCLEO board";
@@ -40,33 +41,6 @@
 		led0 = &green_led_2;
 		sw0 = &user_button;
 	};
-
-	arduino_header: connector {
-		compatible = "arduino-header-r3";
-		#gpio-cells = <2>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
-	};
 };
 
 &usart1 {
@@ -83,12 +57,12 @@
 	status = "okay";
 };
 
-arduino_i2c: &i2c1 {
+&i2c1 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
-arduino_spi: &spi1 {
+&spi1 {
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f401re/nucleo_f401re.yaml
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.yaml
@@ -9,6 +9,7 @@ toolchain:
 supported:
   - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - pwm
   - counter
   - gpio

--- a/boards/arm/nucleo_f411re/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f411re/arduino_r3_connector.dtsi
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 0 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 10 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f4/stm32f411Xe.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F411RE-NUCLEO board";
@@ -38,33 +39,6 @@
 		led0 = &green_led_2;
 		sw0 = &user_button;
 	};
-
-	arduino_header: connector {
-		compatible = "arduino-header-r3";
-		#gpio-cells = <2>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
-	};
 };
 
 &usart1 {
@@ -81,7 +55,7 @@
 	status = "okay";
 };
 
-arduino_i2c: &i2c1 {
+&i2c1 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -94,7 +68,7 @@ arduino_i2c: &i2c1 {
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
-arduino_spi: &spi1 {
+&spi1 {
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f411re/nucleo_f411re.yaml
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.yaml
@@ -9,6 +9,7 @@ toolchain:
 supported:
   - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - counter
   - gpio
   - spi

--- a/boards/arm/nucleo_f446re/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f446re/arduino_r3_connector.dtsi
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 0 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 10 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f4/stm32f446Xe.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F446RE-NUCLEO board";
@@ -54,7 +55,7 @@
 	status = "okay";
 };
 
-arduino_i2c: &i2c1 {
+&i2c1 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
@@ -69,7 +70,7 @@ arduino_i2c: &i2c1 {
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
-arduino_spi: &spi1 {
+&spi1 {
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f446re/nucleo_f446re.yaml
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.yaml
@@ -7,7 +7,9 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - counter
   - gpio
   - spi

--- a/boards/arm/nucleo_g071rb/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_g071rb/arduino_r3_connector.dtsi
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 1 0>,	/* A3 */
+			   <4 0 &gpiob 11 0>,	/* A4 */
+			   <5 0 &gpiob 12 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 14 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 0 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -7,6 +7,7 @@
 
 /dts-v1/;
 #include <st/g0/stm32g071Xb.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32G071RB-NUCLEO board";

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.yaml
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.yaml
@@ -9,5 +9,6 @@ toolchain:
 ram: 36
 flash: 128
 supported:
+  - arduino_gpio
   - uart
   - gpio

--- a/boards/arm/nucleo_l053r8/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_l053r8/arduino_r3_connector.dtsi
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 0 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 10 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/l0/stm32l053X8.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L053R8-NUCLEO board";
@@ -53,11 +54,11 @@
 	status = "okay";
 };
 
-arduino_i2c: &i2c1 {
+&i2c1 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
-arduino_spi: &spi1 {
+&spi1 {
 	status = "okay";
 };

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.yaml
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.yaml
@@ -7,7 +7,9 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - gpio
   - i2c
   - spi

--- a/boards/arm/nucleo_l073rz/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_l073rz/arduino_r3_connector.dtsi
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 0 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 10 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/l0/stm32l073Xz.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L073RZ-NUCLEO board";
@@ -53,12 +54,12 @@
 	status = "okay";
 };
 
-arduino_i2c: &i2c1 {
+&i2c1 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
-arduino_spi: &spi1 {
+&spi1 {
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
@@ -9,7 +9,9 @@ toolchain:
 ram: 20
 flash: 192
 supported:
+  - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - gpio
   - i2c
   - spi

--- a/boards/arm/nucleo_l476rg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_l476rg/arduino_r3_connector.dtsi
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 0 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 10 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/l4/stm32l476Xg.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L476RG-NUCLEO board";
@@ -54,7 +55,7 @@
 	status = "okay";
 };
 
-arduino_i2c: &i2c1 {
+&i2c1 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.yaml
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
   - arduino_i2c
   - pwm
   - gpio

--- a/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
@@ -1,5 +1,7 @@
 sample:
   name: X-NUCLEO-IKS01A3 sensor shield
+common:
+  min_ram: 16
 tests:
   sample.shield.x_nucleo_iks01a3:
     harness: shield


### PR DESCRIPTION
Apply same scheme for all nucleo_64 pins boards:
-provide a separate arduino connector dtsi file
-provide complete gpio map
-update board.yaml vs arduino support (i2c, spi and gpio)

Done using following reference:
http://www.st.com/resource/en/user_manual/dm00105823.pdf

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>