### PR TITLE
[TOPIC-GPIO] drivers: gpio_dw: update to use new GPIO API

### DIFF
--- a/boards/arc/em_starterkit/board.dtsi
+++ b/boards/arc/em_starterkit/board.dtsi
@@ -61,37 +61,37 @@
 		compatible = "gpio-keys";
 		button0: button_0 {
 			/* gpio flags need validation */
-			gpios = <&gpio0 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			label = "Push button switch 0";
 		};
 		button1: button_1 {
 			/* gpio flags need validation */
-			gpios = <&gpio0 1 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 			label = "Push button switch 1";
 		};
 		button2: button_2 {
 			/* gpio flags need validation */
-			gpios = <&gpio0 2 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
 			label = "Push button switch 2";
 		};
 		switch0: switch_0 {
 			/* gpio flags need validation */
-			gpios = <&gpio2 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
 			label = "DIP SW1 - Switch 1";
 		};
 		switch1: switch_1 {
 			/* gpio flags need validation */
-			gpios = <&gpio2 1 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
 			label = "DIP SW1 - Switch 2";
 		};
 		switch2: switch_2 {
 			/* gpio flags need validation */
-			gpios = <&gpio2 2 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
 			label = "DIP SW1 - Switch 3";
 		};
 		switch3: switch_3 {
 			/* gpio flags need validation */
-			gpios = <&gpio2 3 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
 			label = "DIP SW1 - Switch 4";
 		};
 	};

--- a/boards/arc/emsdp/board.dtsi
+++ b/boards/arc/emsdp/board.dtsi
@@ -56,22 +56,22 @@
 		compatible = "gpio-keys";
 		switch0: switch_0 {
 			/* gpio flags need validation */
-			gpios = <&gpio0 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			label = "DIP SW1 - Switch 1";
 		};
 		switch1: switch_1 {
 			/* gpio flags need validation */
-			gpios = <&gpio0 1 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 			label = "DIP SW1 - Switch 2";
 		};
 		switch2: switch_2 {
 			/* gpio flags need validation */
-			gpios = <&gpio0 2 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
 			label = "DIP SW1 - Switch 3";
 		};
 		switch3: switch_3 {
 			/* gpio flags need validation */
-			gpios = <&gpio0 3 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
 			label = "DIP SW1 - Switch 4";
 		};
 	};

--- a/drivers/gpio/gpio_dw_registers.h
+++ b/drivers/gpio/gpio_dw_registers.h
@@ -37,7 +37,6 @@
 #define EXT_PORTC      0x58
 #define EXT_PORTD      0x5c
 #define INT_CLOCK_SYNC 0x60 /* alias LS_SYNC */
-#define INT_BOTHEDGE   0x68
 #define VER_ID_CODE    0x6c
 #define CONFIG_REG2    0x70
 #define CONFIG_REG1    0x74

--- a/tests/drivers/gpio/gpio_basic_api/boards/em_starterkit.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/em_starterkit.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test,gpio_basic_api";
+		out-gpios = <&gpio0 18 0>; /* Pmod3 pin 9  */
+		in-gpios = <&gpio0 19 0>;  /* Pmod3 pin 10 */
+	};
+};


### PR DESCRIPTION
This updates the gpio_dw driver to the new GPIO API. It also adds an overlay to the gpio_basic_api test, and updates the DTS files for board emsdp/em_starterkit.

This has been tested with gpio_basic_api.