### PR TITLE
tests: smp: do not whitelist, use filter

### DIFF
--- a/tests/kernel/smp/testcase.yaml
+++ b/tests/kernel/smp/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.multiprocessing:
-    platform_whitelist: esp32 qemu_x86_64 hsdk nsim_hs_smp
+    filter: (CONFIG_MP_NUM_CPUS > 1)


### PR DESCRIPTION
Whitelisting is bad, new platforms with this capability would be
missed..