### PR TITLE
boards: nucleo_l476rg: add arduino-header-r3 connector

### DIFF
--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -34,6 +34,33 @@
 		};
 	};
 
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 4 0>,	/* A2 */
+			   <3 0 &gpiob 0 0>,	/* A3 */
+			   <4 0 &gpioc 1 0>,	/* A4 */
+			   <5 0 &gpioc 0 0>,	/* A5 */
+			   <6 0 &gpioa 3 0>,	/* D0 */
+			   <7 0 &gpioa 2 0>,	/* D1 */
+			   <8 0 &gpioa 10 0>,	/* D2 */
+			   <9 0 &gpiob 3 0>,	/* D3 */
+			   <10 0 &gpiob 5 0>,	/* D4 */
+			   <11 0 &gpiob 4 0>,	/* D5 */
+			   <12 0 &gpiob 10 0>,	/* D6 */
+			   <13 0 &gpioa 8 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpioc 7 0>,	/* D9 */
+			   <16 0 &gpiob 6 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+
 	aliases {
 		led0 = &green_led_2;
 		sw0 = &user_button;


### PR DESCRIPTION
Provides GPIOs available on the Arduino Uno header.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>