### PR TITLE
boards: stm32: Set arduino gpio connector on nucleo 144 pins boards

### DIFF
--- a/boards/arm/nucleo_f207zg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f207zg/arduino_r3_connector.dtsi
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
+			   <1 0 &gpioc 0 0>,	/* A1 */
+			   <2 0 &gpioc 3 0>,	/* A2 */
+			   <3 0 &gpiof 3 0>,	/* A3 */
+			   <4 0 &gpiof 5 0>,	/* A4 */
+			   <5 0 &gpiof 10 0>,	/* A5 */
+			   <6 0 &gpiog 9 0>,	/* D0 */
+			   <7 0 &gpiog 14 0>,	/* D1 */
+			   <8 0 &gpiof 15 0>,	/* D2 */
+			   <9 0 &gpioe 13 0>,	/* D3 */
+			   <10 0 &gpiof 14 0>,	/* D4 */
+			   <11 0 &gpioe 11 0>,	/* D5 */
+			   <12 0 &gpioe 9 0>,	/* D6 */
+			   <13 0 &gpiof 13 0>,	/* D7 */
+			   <14 0 &gpiof 12 0>,	/* D8 */
+			   <15 0 &gpiod 15 0>,	/* D9 */
+			   <16 0 &gpiod 14 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_serial: &usart6 {};

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f2/stm32f207Xg.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F207ZG-NUCLEO board";
@@ -49,8 +50,6 @@
 		sw0 = &user_button;
 	};
 };
-
-arduino_serial: &usart6 {};
 
 &usart3 {
 	current-speed = <115200>;

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
@@ -9,6 +9,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
   - gpio
   - usb_device
   - watchdog

--- a/boards/arm/nucleo_f412zg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f412zg/arduino_r3_connector.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
+			   <1 0 &gpioc 0 0>,	/* A1 */
+			   <2 0 &gpioc 3 0>,	/* A2 */
+			   <3 0 &gpioc 1 0>,	/* A3 */
+			   <4 0 &gpioc 4 0>,	/* A4 */
+			   <5 0 &gpioc 5 0>,	/* A5 */
+			   <6 0 &gpiog 9 0>,	/* D0 */
+			   <7 0 &gpiog 14 0>,	/* D1 */
+			   <8 0 &gpiof 15 0>,	/* D2 */
+			   <9 0 &gpioe 13 0>,	/* D3 */
+			   <10 0 &gpiof 14 0>,	/* D4 */
+			   <11 0 &gpioe 11 0>,	/* D5 */
+			   <12 0 &gpioe 9 0>,	/* D6 */
+			   <13 0 &gpiof 13 0>,	/* D7 */
+			   <14 0 &gpiof 12 0>,	/* D8 */
+			   <15 0 &gpiod 15 0>,	/* D9 */
+			   <16 0 &gpiod 14 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};
+arduino_serial: &usart6 {};

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f4/stm32f412Xg.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F412ZG-NUCLEO board";
@@ -49,10 +50,6 @@
 		sw0 = &user_button;
 	};
 };
-
-arduino_i2c: &i2c1 {};
-arduino_spi: &spi1 {};
-arduino_serial: &usart6 {};
 
 &usart3 {
 	current-speed = <115200>;

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.yaml
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.yaml
@@ -10,6 +10,8 @@ ram: 256
 flash: 1024
 supported:
   - arduino_i2c
+  - arduino_gpio
+  - arduino_spi
   - pwm
   - i2c
   - spi

--- a/boards/arm/nucleo_f413zh/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f413zh/arduino_r3_connector.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
+			   <1 0 &gpioc 0 0>,	/* A1 */
+			   <2 0 &gpioc 3 0>,	/* A2 */
+			   <3 0 &gpioc 1 0>,	/* A3 */
+			   <4 0 &gpioc 4 0>,	/* A4 */
+			   <5 0 &gpioc 5 0>,	/* A5 */
+			   <6 0 &gpiog 9 0>,	/* D0 */
+			   <7 0 &gpiog 14 0>,	/* D1 */
+			   <8 0 &gpiof 15 0>,	/* D2 */
+			   <9 0 &gpioe 13 0>,	/* D3 */
+			   <10 0 &gpiof 14 0>,	/* D4 */
+			   <11 0 &gpioe 11 0>,	/* D5 */
+			   <12 0 &gpioe 9 0>,	/* D6 */
+			   <13 0 &gpiof 13 0>,	/* D7 */
+			   <14 0 &gpiof 12 0>,	/* D8 */
+			   <15 0 &gpiod 15 0>,	/* D9 */
+			   <16 0 &gpiod 14 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};
+arduino_serial: &usart6 {};

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f4/stm32f413Xh.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F413ZH-NUCLEO board";
@@ -49,10 +50,6 @@
 		sw0 = &user_button;
 	};
 };
-
-arduino_i2c: &i2c1 {};
-arduino_spi: &spi1 {};
-arduino_serial: &usart6 {};
 
 &usart3 {
 	current-speed = <115200>;

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.yaml
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.yaml
@@ -10,6 +10,8 @@ ram: 320
 flash: 1536
 supported:
   - arduino_i2c
+  - arduino_gpio
+  - arduino_spi
   - pwm
   - i2c
   - spi

--- a/boards/arm/nucleo_f746zg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f746zg/arduino_r3_connector.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
+			   <1 0 &gpioc 0 0>,	/* A1 */
+			   <2 0 &gpioc 3 0>,	/* A2 */
+			   <3 0 &gpiof 3 0>,	/* A3 */
+			   <4 0 &gpiof 5 0>,	/* A4 */
+			   <5 0 &gpiof 10 0>,	/* A5 */
+			   <6 0 &gpiog 9 0>,	/* D0 */
+			   <7 0 &gpiog 14 0>,	/* D1 */
+			   <8 0 &gpiof 15 0>,	/* D2 */
+			   <9 0 &gpioe 13 0>,	/* D3 */
+			   <10 0 &gpiof 14 0>,	/* D4 */
+			   <11 0 &gpioe 11 0>,	/* D5 */
+			   <12 0 &gpioe 9 0>,	/* D6 */
+			   <13 0 &gpiof 13 0>,	/* D7 */
+			   <14 0 &gpiof 12 0>,	/* D8 */
+			   <15 0 &gpiod 15 0>,	/* D9 */
+			   <16 0 &gpiod 14 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_serial: &usart6 {};
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f7/stm32f746Xg.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F746ZG-NUCLEO board";
@@ -50,10 +51,6 @@
 		sw0 = &user_button;
 	};
 };
-
-arduino_serial: &usart6 {};
-arduino_i2c: &i2c1 {};
-arduino_spi: &spi1 {};
 
 &usart3 {
 	current-speed = <115200>;

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.yaml
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.yaml
@@ -10,6 +10,8 @@ ram: 256
 flash: 1024
 supported:
   - arduino_i2c
+  - arduino_gpio
+  - arduino_spi
   - uart
   - gpio
   - netif:eth

--- a/boards/arm/nucleo_f756zg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f756zg/arduino_r3_connector.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
+			   <1 0 &gpioc 0 0>,	/* A1 */
+			   <2 0 &gpioc 3 0>,	/* A2 */
+			   <3 0 &gpiof 3 0>,	/* A3 */
+			   <4 0 &gpiof 5 0>,	/* A4 */
+			   <5 0 &gpiof 10 0>,	/* A5 */
+			   <6 0 &gpiog 9 0>,	/* D0 */
+			   <7 0 &gpiog 14 0>,	/* D1 */
+			   <8 0 &gpiof 15 0>,	/* D2 */
+			   <9 0 &gpioe 13 0>,	/* D3 */
+			   <10 0 &gpiof 14 0>,	/* D4 */
+			   <11 0 &gpioe 11 0>,	/* D5 */
+			   <12 0 &gpioe 9 0>,	/* D6 */
+			   <13 0 &gpiof 13 0>,	/* D7 */
+			   <14 0 &gpiof 12 0>,	/* D8 */
+			   <15 0 &gpiod 15 0>,	/* D9 */
+			   <16 0 &gpiod 14 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_serial: &usart6 {};
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f7/stm32f756Xg.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F756ZG-NUCLEO board";
@@ -50,10 +51,6 @@
 		sw0 = &user_button;
 	};
 };
-
-arduino_serial: &usart6 {};
-arduino_i2c: &i2c1 {};
-arduino_spi: &spi1 {};
 
 &usart2 {
 	current-speed = <115200>;

--- a/boards/arm/nucleo_f756zg/nucleo_f756zg.yaml
+++ b/boards/arm/nucleo_f756zg/nucleo_f756zg.yaml
@@ -10,6 +10,8 @@ ram: 256
 flash: 1024
 supported:
   - arduino_i2c
+  - arduino_gpio
+  - arduino_spi
   - uart
   - gpio
   - netif:eth

--- a/boards/arm/nucleo_l496zg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_l496zg/arduino_r3_connector.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
+			   <1 0 &gpioc 0 0>,	/* A1 */
+			   <2 0 &gpioc 3 0>,	/* A2 */
+			   <3 0 &gpioc 1 0>,	/* A3 */
+			   <4 0 &gpioc 4 0>,	/* A4 */
+			   <5 0 &gpioc 5 0>,	/* A5 */
+			   <6 0 &gpiod 9 0>,	/* D0 */
+			   <7 0 &gpiod 8 0>,	/* D1 */
+			   <8 0 &gpiof 15 0>,	/* D2 */
+			   <9 0 &gpioe 13 0>,	/* D3 */
+			   <10 0 &gpioe 14 0>,	/* D4 */
+			   <11 0 &gpioe 11 0>,	/* D5 */
+			   <12 0 &gpioe 9 0>,	/* D6 */
+			   <13 0 &gpiof 13 0>,	/* D7 */
+			   <14 0 &gpiof 12 0>,	/* D8 */
+			   <15 0 &gpiod 15 0>,	/* D9 */
+			   <16 0 &gpiod 14 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};
+arduino_serial: &lpuart1 {};

--- a/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
+++ b/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/l4/stm32l496Xg.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L496ZG-NUCLEO board";
@@ -58,10 +59,6 @@
 		sw0 = &user_button;
 	};
 };
-
-arduino_i2c: &i2c1 {};
-arduino_spi: &spi1 {};
-arduino_serial: &lpuart1 {};
 
 &usart2 {
 	current-speed = <115200>;

--- a/boards/arm/nucleo_l496zg/nucleo_l496zg.yaml
+++ b/boards/arm/nucleo_l496zg/nucleo_l496zg.yaml
@@ -8,6 +8,9 @@ toolchain:
 ram: 320
 flash: 1024
 supported:
+  - arduino_i2c
+  - arduino_gpio
+  - arduino_spi
   - gpio
   - i2c
   - spi

--- a/boards/arm/nucleo_l4r5zi/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_l4r5zi/arduino_r3_connector.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
+			   <1 0 &gpioc 0 0>,	/* A1 */
+			   <2 0 &gpioc 3 0>,	/* A2 */
+			   <3 0 &gpioc 1 0>,	/* A3 */
+			   <4 0 &gpioc 4 0>,	/* A4 */
+			   <5 0 &gpioc 5 0>,	/* A5 */
+			   <6 0 &gpiod 9 0>,	/* D0 */
+			   <7 0 &gpiod 8 0>,	/* D1 */
+			   <8 0 &gpiof 15 0>,	/* D2 */
+			   <9 0 &gpioe 13 0>,	/* D3 */
+			   <10 0 &gpioe 14 0>,	/* D4 */
+			   <11 0 &gpioe 11 0>,	/* D5 */
+			   <12 0 &gpioe 9 0>,	/* D6 */
+			   <13 0 &gpiof 13 0>,	/* D7 */
+			   <14 0 &gpiof 12 0>,	/* D8 */
+			   <15 0 &gpiod 15 0>,	/* D9 */
+			   <16 0 &gpiod 14 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpioa 6 0>,	/* D12 */
+			   <19 0 &gpioa 5 0>,	/* D13 */
+			   <20 0 &gpiob 9 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};
+arduino_serial: &usart3 {};

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/l4/stm32l4r5Xi.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L4R5ZI-NUCLEO board";
@@ -51,10 +52,6 @@
 		sw0 = &user_button;
 	};
 };
-
-arduino_i2c: &i2c1 {};
-arduino_spi: &spi1 {};
-arduino_serial: &usart3 {};
 
 &usart1 {
 	current-speed = <115200>;

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.yaml
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.yaml
@@ -8,6 +8,8 @@ toolchain:
   - xtools
 supported:
   - arduino_i2c
+  - arduino_gpio
+  - arduino_spi
   - pwm
   - spi
   - i2c


### PR DESCRIPTION
Apply same scheme for all nucleo 144 pins boards:
-provide a separate arduino connector dtsi file
-provide complete gpio map
-update board.yaml vs arduino support (i2c, spi and gpio)

Done using following reference:
http://www.st.com/resource/en/user_manual/dm00105823.pdf

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>