### PR TITLE
[TOPIC-GPIO] drivers: ht16k33: update to use new GPIO API

### DIFF
--- a/drivers/gpio/gpio_ht16k33.c
+++ b/drivers/gpio/gpio_ht16k33.c
@@ -36,15 +36,16 @@ struct gpio_ht16k33_data {
 };
 
 static int gpio_ht16k33_cfg(struct device *dev, int access_op,
-			       u32_t pin, int flags)
+			    u32_t pin, int flags)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(access_op);
 	ARG_UNUSED(pin);
 
 	/* Keyscan is input-only */
-	if ((flags & GPIO_DIR_MASK) != GPIO_DIR_IN) {
-		return -EINVAL;
+	if (((flags & (GPIO_INPUT | GPIO_OUTPUT)) == GPIO_DISCONNECTED)
+	    || ((flags & GPIO_OUTPUT) != 0)) {
+		return -ENOTSUP;
 	}
 
 	return 0;
@@ -72,6 +73,72 @@ static int gpio_ht16k33_read(struct device *dev, int access_op,
 
 	/* Keyscan only supports interrupt mode */
 	return -ENOTSUP;
+}
+
+static int gpio_ht16k33_port_get_raw(struct device *port,
+				     gpio_port_value_t *value)
+{
+	ARG_UNUSED(port);
+	ARG_UNUSED(value);
+
+	/* Keyscan only supports interrupt mode */
+	return -ENOTSUP;
+}
+
+static int gpio_ht16k33_port_set_masked_raw(struct device *port,
+					    gpio_port_pins_t mask,
+					    gpio_port_value_t value)
+{
+	ARG_UNUSED(port);
+	ARG_UNUSED(mask);
+	ARG_UNUSED(value);
+
+	/* Keyscan is input-only */
+	return -ENOTSUP;
+}
+
+static int gpio_ht16k33_port_set_bits_raw(struct device *port,
+					  gpio_port_pins_t pins)
+{
+	ARG_UNUSED(port);
+	ARG_UNUSED(pins);
+
+	/* Keyscan is input-only */
+	return -ENOTSUP;
+}
+
+static int gpio_ht16k33_port_clear_bits_raw(struct device *port,
+					    gpio_port_pins_t pins)
+{
+	ARG_UNUSED(port);
+	ARG_UNUSED(pins);
+
+	/* Keyscan is input-only */
+	return -ENOTSUP;
+}
+
+static int gpio_ht16k33_port_toggle_bits(struct device *port,
+					 gpio_port_pins_t pins)
+{
+	ARG_UNUSED(port);
+	ARG_UNUSED(pins);
+
+	/* Keyscan is input-only */
+	return -ENOTSUP;
+}
+
+static int gpio_ht16k33_pin_interrupt_configure(struct device *port,
+						unsigned int pin,
+						enum gpio_int_mode int_mode,
+						enum gpio_int_trig int_trig)
+{
+	ARG_UNUSED(port);
+	ARG_UNUSED(pin);
+	ARG_UNUSED(int_mode);
+	ARG_UNUSED(int_trig);
+
+	/* Interrupts are always enabled */
+	return 0;
 }
 
 void ht16k33_process_keyscan_row_data(struct device *dev,
@@ -141,6 +208,12 @@ static const struct gpio_driver_api gpio_ht16k33_api = {
 	.config = gpio_ht16k33_cfg,
 	.write = gpio_ht16k33_write,
 	.read = gpio_ht16k33_read,
+	.port_get_raw = gpio_ht16k33_port_get_raw,
+	.port_set_masked_raw = gpio_ht16k33_port_set_masked_raw,
+	.port_set_bits_raw = gpio_ht16k33_port_set_bits_raw,
+	.port_clear_bits_raw = gpio_ht16k33_port_clear_bits_raw,
+	.port_toggle_bits = gpio_ht16k33_port_toggle_bits,
+	.pin_interrupt_configure = gpio_ht16k33_pin_interrupt_configure,
 	.manage_callback = gpio_ht16k33_manage_callback,
 	.enable_callback = gpio_ht16k33_enable_callback,
 	.disable_callback = gpio_ht16k33_disable_callback,

--- a/drivers/led/ht16k33.c
+++ b/drivers/led/ht16k33.c
@@ -391,10 +391,17 @@ static int ht16k33_init(struct device *dev)
 		}
 
 		err = gpio_pin_configure(irq_dev, config->irq_pin,
-					 GPIO_DIR_IN | GPIO_INT |
-					 GPIO_INT_EDGE | config->irq_flags);
+					 GPIO_INPUT | config->irq_flags);
 		if (err) {
 			LOG_ERR("Failed to configure IRQ pin (err %d)", err);
+			return -EINVAL;
+		}
+
+		err = gpio_pin_interrupt_configure(irq_dev, config->irq_pin,
+						   GPIO_INT_EDGE_FALLING);
+		if (err) {
+			LOG_ERR("Failed to configure IRQ pin flags (err %d)",
+				err);
 			return -EINVAL;
 		}
 
@@ -408,12 +415,7 @@ static int ht16k33_init(struct device *dev)
 		}
 
 		/* Enable interrupt pin */
-		cmd[0] = HT16K33_CMD_ROW_INT_SET;
-		if (config->irq_flags & GPIO_INT_ACTIVE_HIGH) {
-			cmd[0] |= HT16K33_OPT_INT_HIGH;
-		} else {
-			cmd[0] |= HT16K33_OPT_INT_LOW;
-		}
+		cmd[0] = HT16K33_CMD_ROW_INT_SET | HT16K33_OPT_INT_LOW;
 		if (i2c_write(data->i2c, cmd, 1, config->i2c_addr)) {
 			LOG_ERR("Enabling HT16K33 IRQ output failed");
 			return -EIO;

--- a/samples/drivers/ht16k33/nrf52840_pca10056.overlay
+++ b/samples/drivers/ht16k33/nrf52840_pca10056.overlay
@@ -12,7 +12,7 @@
 		reg = <0x70>;
 		label = "HT16K33";
                 /* Uncomment to use IRQ instead of polling: */
-		/* irq-gpios = <&gpio1 8 (GPIO_PUD_PULL_UP | GPIO_INT_ACTIVE_LOW)>; */
+		/* irq-gpios = <&gpio1 8 (GPIO_PUD_PULL_UP | GPIO_ACTIVE_LOW)>; */
 		#address-cells = <1>;
 		#size-cells = <0>;
 


### PR DESCRIPTION
Update the HT16K33 LED driver, key-scan driver, and sample application to use the new GPIO API.