### PR TITLE
bluetooth: controller: Prevent unnecessary ticker "must expire"

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -791,8 +791,11 @@ void ticker_worker(void *param)
 		if (ticker->ticks_slot != 0U &&
 		   (slot_reserved || ticker_resolve_collision(node, ticker))) {
 			ticker->lazy_current++;
-			if (ticker->must_expire == 0U) {
-				/* Skip this ticker node */
+			if ((ticker->must_expire == 0U) ||
+			    (ticker->lazy_periodic >= ticker->lazy_current)) {
+				/* Not a must-expire case or this is programmed
+				 * latency. Skip this ticker node
+				 */
 				continue;
 			}
 			/* Continue but perform shallow expiry */


### PR DESCRIPTION
When running a ticker node as "must expire", the node would invoke the
ticker callback even when programmed with latency. As "must expire" is
intended for scheduled events which are skipped due to collision, and as
such expected by LLL, purposefully skipped events should not generate
"must expire" callbacks.

Signed-off-by: Morten Priess <mtpr@oticon.com>