### PR TITLE
drivers: flexcan: fix loopback mode

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -165,8 +165,10 @@ static int mcux_flexcan_configure(struct device *dev, enum can_mode mode,
 	if (mode == CAN_SILENT_MODE || mode == CAN_SILENT_LOOPBACK_MODE) {
 		config->base->CTRL1 |= CAN_CTRL1_LOM(1);
 	}
-	/* Disable self reception */
-	config->base->MCR |= CAN_MCR_SRXDIS(1);
+	if (mode != CAN_LOOPBACK_MODE && mode != CAN_SILENT_LOOPBACK_MODE) {
+		/* Disable self-reception unless loopback is requested */
+		config->base->MCR |= CAN_MCR_SRXDIS(1);
+	}
 	mcux_flexcan_thaw(dev);
 #endif
 


### PR DESCRIPTION
Fix CAN loopback mode in the NXP MCUX FlexCAN driver by only disabling
self-reception when loopback mode was not requested.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>