### PR TITLE
rand32: cmake: Fix invalid build scripts

### DIFF
--- a/tests/crypto/rand32/CMakeLists.txt
+++ b/tests/crypto/rand32/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(rand32)
 
-zephyr_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/kernel/include/)
+zephyr_library_include_directories(${ZEPHYR_BASE}/kernel/include/)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
The build scripts for the tests/crypto/rand32 test has been invoking
'zephyr_include_directories' in an invalid way. They have presumably
been trying to modify the 'app' library, but have in effect being
modifying the global environment, in an invalid way nonetheless.

This patch fixes the build script to modify the 'app' library only.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>