### PR TITLE
[TOPIC-GPIO] drivers/gpio: use more clear expression for GPIO direction mask

### DIFF
--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -247,8 +247,7 @@ extern "C" {
  */
 
 /** @cond INTERNAL_HIDDEN */
-#define GPIO_DIR_SHIFT          8
-#define GPIO_DIR_MASK		(0x3U << GPIO_DIR_SHIFT)
+#define GPIO_DIR_MASK		(GPIO_INPUT | GPIO_OUTPUT)
 /** @endcond */
 
 /** Legacy flag indicating pin is configured as input only.


### PR DESCRIPTION
Define the mask in terms of the individual non-zero fields to isolate
from future changes to the bit position.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>