### PR TITLE
doc: fix broken file and zephyr-app refs

### DIFF
--- a/boards/arm/mec1501modular_assy6885/doc/index.rst
+++ b/boards/arm/mec1501modular_assy6885/doc/index.rst
@@ -69,7 +69,7 @@ features:
 Other hardware features are not currently supported by Zephyr (at the moment)
 
 The default configuration can be found in the
-:zephyr_file:`boards/arm/mec1501modular_assy6885/mec1501modular_assy6885`
+:zephyr_file:`boards/arm/mec1501modular_assy6885/mec1501modular_assy6885_defconfig`
 Kconfig file.
 
 Connections and IOs

--- a/boards/riscv/rv32m1_vega/doc/index.rst
+++ b/boards/riscv/rv32m1_vega/doc/index.rst
@@ -276,8 +276,8 @@ Additional Pins
 For an up-to-date description of additional pins (such as buttons,
 LEDs, etc.) supported by Zephyr, see the board DTS files in the Zephyr
 source code, i.e.
-:zephyr_file:`boards/riscv32/rv32m1_vega/rv32m1_vega_ri5cy.dts` for RI5CY and
-:zephyr_file:`boards/riscv32/rv32m1_vega/rv32m1_vega_zero_riscy.dts` for
+:zephyr_file:`boards/riscv/rv32m1_vega/rv32m1_vega_ri5cy.dts` for RI5CY and
+:zephyr_file:`boards/riscv/rv32m1_vega/rv32m1_vega_zero_riscy.dts` for
 ZERO-RISCY.
 
 See the schematic in the documentation available from the `OpenISA

--- a/doc/guides/networking/qemu_setup.rst
+++ b/doc/guides/networking/qemu_setup.rst
@@ -216,7 +216,7 @@ Terminal #2:
 ============
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/net/echo_client
+   :zephyr-app: samples/net/sockets/echo_client
    :host-os: unix
    :board: qemu_x86
    :goals: build

--- a/doc/guides/porting/arch.rst
+++ b/doc/guides/porting/arch.rst
@@ -162,7 +162,7 @@ we strongly suggest that handlers at least print some debug information. The
 information helps figuring out what went wrong when hitting an exception that
 is a fault, like divide-by-zero or invalid memory access, or an interrupt that
 is not expected (:dfn:`spurious interrupt`). See the ARM implementation in
-:zephyr_file:`arch/arm/core/fault.c` for an example.
+:zephyr_file:`arch/arm/core/cortex_m/fault.c` for an example.
 
 Thread Context Switching
 ************************

--- a/samples/boards/bbc_microbit/display/README.rst
+++ b/samples/boards/bbc_microbit/display/README.rst
@@ -15,7 +15,7 @@ This project outputs various things on the BBC micro:bit display. It can
 be built as follows:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/boards/microbit/display
+   :zephyr-app: samples/boards/bbc_microbit/display
    :board: bbc_microbit
    :goals: build
    :compact:

--- a/samples/boards/bbc_microbit/line_follower_robot/README.rst
+++ b/samples/boards/bbc_microbit/line_follower_robot/README.rst
@@ -22,7 +22,7 @@ and put it on the black line track.
 Build this sample project using these commands:
 
 .. zephyr-app-commands::
-  :zephyr-app: samples/boards/microbit/line_follower_robot
+  :zephyr-app: samples/boards/bbc_microbit/line_follower_robot
   :board: bbc_microbit
   :goals: build
   :compact:

--- a/samples/boards/bbc_microbit/pong/README.rst
+++ b/samples/boards/bbc_microbit/pong/README.rst
@@ -26,7 +26,7 @@ Building
 ********
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/boards/microbit/pong
+   :zephyr-app: samples/boards/bbc_microbit/pong
    :board: bbc_microbit
    :goals: build
    :compact:

--- a/samples/boards/bbc_microbit/sound/README.rst
+++ b/samples/boards/bbc_microbit/sound/README.rst
@@ -20,7 +20,7 @@ Building
 The sample can be built as follows:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/boards/microbit/sound
+   :zephyr-app: samples/boards/bbc_microbit/sound
    :board: bbc_microbit
    :goals: build
    :compact:

--- a/samples/display/grove_display/README.rst
+++ b/samples/display/grove_display/README.rst
@@ -41,7 +41,7 @@ shield interface. For example, it can be run on the FRDM K64F board as
 described below:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/grove/lcd
+   :zephyr-app: samples/display/grove_display
    :board: frdm_k64f
    :goals: flash
    :compact:

--- a/samples/drivers/counter/alarm/README.rst
+++ b/samples/drivers/counter/alarm/README.rst
@@ -23,7 +23,7 @@ Building and Running
 ********************
 
  .. zephyr-app-commands::
-    :zephyr-app: samples/counter/alarm
+    :zephyr-app: samples/drivers/counter/alarm
     :host-os: unix
     :board: disco_l475_iot1
     :goals: run

--- a/samples/sensor/adt7420/README.rst
+++ b/samples/sensor/adt7420/README.rst
@@ -35,7 +35,7 @@ In this example below the :ref:`nrf52_pca10040` board is used.
 
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/adt7420
+   :zephyr-app: samples/sensor/adt7420
    :board: nrf52_pca10040
    :goals: build flash
 

--- a/samples/sensor/adxl362/README.rst
+++ b/samples/sensor/adxl362/README.rst
@@ -18,7 +18,7 @@ This sample requires an ADXL362 sensor. It should work with any platform
 featuring a I2C peripheral interface. It does not work on QEMU.
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/adxl362
+   :zephyr-app: samples/sensor/adxl362
    :board: <board to use>
    :goals: build flash
    :compact:

--- a/samples/sensor/adxl372/README.rst
+++ b/samples/sensor/adxl372/README.rst
@@ -70,7 +70,7 @@ In this example below the :ref:`nrf52_pca10040` board is used.
 
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/adxl372
+   :zephyr-app: samples/sensor/adxl372
    :board: nrf52_pca10040
    :goals: build flash
 

--- a/samples/sensor/amg88xx/README.rst
+++ b/samples/sensor/amg88xx/README.rst
@@ -38,7 +38,7 @@ the sample. The default upper threshold value is 27 |deg| Celsius
 (80.6 |deg| Fahrenheit).
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/amg88xx
+   :zephyr-app: samples/sensor/amg88xx
    :board: reel_board
    :goals: build flash
 

--- a/samples/sensor/ams_iAQcore/README.rst
+++ b/samples/sensor/ams_iAQcore/README.rst
@@ -20,7 +20,7 @@ This sample can run on every board with i2c.
 For example build for a nucleo_f446re board:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/ams_iAQcore
+   :zephyr-app: samples/sensor/ams_iAQcore
    :board: nucleo_f446re
    :goals: build flash
    :compact:

--- a/samples/sensor/apds9960/README.rst
+++ b/samples/sensor/apds9960/README.rst
@@ -18,7 +18,7 @@ This sample application uses an APDS9960 sensor connected to a board
 `Sparkfun APDS9960 tutorial`_).
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/apds9960
+   :zephyr-app: samples/sensor/apds9960
    :board: reel_board
    :goals: flash
    :compact:

--- a/samples/sensor/bme280/README.rst
+++ b/samples/sensor/bme280/README.rst
@@ -20,7 +20,7 @@ at page 38.
 
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/bme280
+   :zephyr-app: samples/sensor/bme280
    :board: nrf52840_pca10056
    :goals: flash
    :compact:

--- a/samples/sensor/bme680/README.rst
+++ b/samples/sensor/bme680/README.rst
@@ -34,7 +34,7 @@ In this example below the :ref:`nrf52_pca10040` board is used.
 
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/bme680
+   :zephyr-app: samples/sensor/bme680
    :board: nrf52_pca10040
    :goals: build flash
 

--- a/samples/sensor/bmm150/README.rst
+++ b/samples/sensor/bmm150/README.rst
@@ -21,7 +21,7 @@ Sensor has multiple pins so you need to connect according to connection diagram 
 .. code-block:: console
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/bmm150
+   :zephyr-app: samples/sensor/bmm150
    :board: nrf52840_pca10056
    :goals: flash
    :compact:

--- a/samples/sensor/ens210/README.rst
+++ b/samples/sensor/ens210/README.rst
@@ -18,7 +18,7 @@ Flash the binary to a board of choice with a sensor connected.
 For example build for a nucleo_f446re board:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/ens210
+   :zephyr-app: samples/sensor/ens210
    :board: nucleo_f446re
    :goals: build flash
    :compact:

--- a/samples/sensor/fxas21002/README.rst
+++ b/samples/sensor/fxas21002/README.rst
@@ -17,7 +17,7 @@ sensor, which is present on the :ref:`hexiwear_k64` board. It does not work on
 QEMU.
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/fxas21002
+   :zephyr-app: samples/sensor/fxas21002
    :board: hexiwear_k64
    :goals: build
    :compact:

--- a/samples/sensor/hts221/README.rst
+++ b/samples/sensor/hts221/README.rst
@@ -26,7 +26,7 @@ Building and Running
  sensor, which is present on the disco_l475_iot1 board.
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/hts221
+   :zephyr-app: samples/sensor/hts221
    :board: disco_l475_iot1
    :goals: build
    :compact:

--- a/samples/sensor/lsm303dlhc/README.rst
+++ b/samples/sensor/lsm303dlhc/README.rst
@@ -29,7 +29,7 @@ This project outputs sensor data to the console. It requires a LSM303DLHC
 system-in-package, which is present on the stm32f3_disco board
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/lsm303dlhc
+   :zephyr-app: samples/sensor/lsm303dlhc
    :board: stm32f3_disco
    :goals: build
    :compact:

--- a/samples/sensor/lsm6dsl/README.rst
+++ b/samples/sensor/lsm6dsl/README.rst
@@ -32,7 +32,7 @@ Building on ArgonKey board
 ==========================
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/lsm6dsl
+   :zephyr-app: samples/sensor/lsm6dsl
    :host-os: unix
    :board: 96b_argonkey
    :goals: build
@@ -42,7 +42,7 @@ Building on disco_l475_iot1 board
 =================================
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/lsm6dsl
+   :zephyr-app: samples/sensor/lsm6dsl
    :host-os: unix
    :board: disco_l475_iot1
    :goals: build

--- a/samples/sensor/max30101/README.rst
+++ b/samples/sensor/max30101/README.rst
@@ -18,7 +18,7 @@ ADC data prints to the console. Further processing (not included in this
 sample) is required to extract a heart rate signal from the light measurement.
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/max30101
+   :zephyr-app: samples/sensor/max30101
    :board: hexiwear_k64
    :goals: build
    :compact:

--- a/samples/sensor/sht3xd/README.rst
+++ b/samples/sensor/sht3xd/README.rst
@@ -35,7 +35,7 @@ interface.  It does not work on QEMU.  In this example below the
 
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/sht3xd
+   :zephyr-app: samples/sensor/sht3xd
    :board: nrf51_ble400
    :goals: build flash
 

--- a/samples/sensor/ti_hdc/README.rst
+++ b/samples/sensor/ti_hdc/README.rst
@@ -42,7 +42,7 @@ This sample builds one application for the HDC1080 sensor.
 Build/Flash Steps:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/boards/nucleo_l496zg/sensors
+   :zephyr-app: samples/sensor/ti_hdc/
    :board: nucleo_l496zg
    :goals: build flash
    :compact:

--- a/samples/userspace/shared_mem/README.rst
+++ b/samples/userspace/shared_mem/README.rst
@@ -26,7 +26,7 @@ This example will only cover the qemu_x86 board, since the sample
 just prints text to a console.
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/basic/userspace/shared_mem
+   :zephyr-app: samples/userspace/shared_mem
    :board: qemu_x86
    :goals: build run
    :compact:


### PR DESCRIPTION
found some references to files (via :zephyr_file: and :zephyr-app:) that
were moved, so the links were broken

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>