### PR TITLE
west.yml: stm32: make stm32cube a zephyr_library()

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
       revision: 0ec40aed8087f26bd9ac1b70fb5a6c326a6451aa
       path: modules/hal/st
     - name: hal_stm32
-      revision: 41ae0cf14ca89fb0c934ebdb5d75e940f98af64a
+      revision: pull/23/head
       path: modules/hal/stm32
     - name: hal_ti
       revision: 7a82e93e14766ef6e42df9915ea2ab8e3b952a8b


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/hal_stm32/pull/23

Signed-off-by: Marc Herbert <marc.herbert@intel.com>