### PR TITLE
boards: nucleo_f103rb: Fix missing include in dts file

### DIFF
--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f1/stm32f103Xb.dtsi>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F103RB-NUCLEO board";


### PR DESCRIPTION
Inclusion to arduino gpio connector is missing.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>