### PR TITLE
tests/subsys/settings: build common code as zephyr_libraries

### DIFF
--- a/tests/subsys/settings/fcb/base64/CMakeLists.txt
+++ b/tests/subsys/settings/fcb/base64/CMakeLists.txt
@@ -4,13 +4,11 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(settings_fcb)
 
-FILE(GLOB app_sources ../src/*.c ../../src/*c)
-target_sources(app PRIVATE ${app_sources})
-zephyr_include_directories(
-	$ENV{ZEPHYR_BASE}/subsys/settings/include
-	$ENV{ZEPHYR_BASE}/subsys/settings/src
-	$ENV{ZEPHYR_BASE}/tests/subsys/settings/fcb/src
-	)
+add_subdirectory(../src fcb_test_bindir)
+target_link_libraries(app PRIVATE settings_fcb_test)
+
+# The code is in the library common to several tests.
+target_sources(app PRIVATE placeholder.c)
 
 if(TEST)
 	target_compile_definitions(app PRIVATE

--- a/tests/subsys/settings/fcb/base64/placeholder.c
+++ b/tests/subsys/settings/fcb/base64/placeholder.c
@@ -1,0 +1,2 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2019 Intel Corporation */

--- a/tests/subsys/settings/fcb/raw/CMakeLists.txt
+++ b/tests/subsys/settings/fcb/raw/CMakeLists.txt
@@ -4,13 +4,11 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-FILE(GLOB app_sources ../src/*.c ../../src/*c)
-target_sources(app PRIVATE ${app_sources})
-zephyr_include_directories(
-	$ENV{ZEPHYR_BASE}/subsys/settings/include
-	$ENV{ZEPHYR_BASE}/subsys/settings/src
-	$ENV{ZEPHYR_BASE}/tests/subsys/settings/fcb/src
-	)
+add_subdirectory(../src fcb_test_bindir)
+target_link_libraries(app PRIVATE settings_fcb_test)
+
+# The code is in the library common to several tests.
+target_sources(app PRIVATE placeholder.c)
 
 if(TEST)
 	target_compile_definitions(app PRIVATE

--- a/tests/subsys/settings/fcb/raw/placeholder.c
+++ b/tests/subsys/settings/fcb/raw/placeholder.c
@@ -1,0 +1,2 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2019 Intel Corporation */

--- a/tests/subsys/settings/fcb/src/CMakeLists.txt
+++ b/tests/subsys/settings/fcb/src/CMakeLists.txt
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2019 Intel Corporation
+
+zephyr_library_named(settings_fcb_test)
+
+add_subdirectory(../../src settings_test_bindir)
+target_link_libraries(settings_fcb_test PRIVATE settings_test)
+
+zephyr_include_directories(
+	$ENV{ZEPHYR_BASE}/subsys/settings/include
+	$ENV{ZEPHYR_BASE}/subsys/settings/src
+	$ENV{ZEPHYR_BASE}/tests/subsys/settings/fcb/src
+	)
+
+FILE(GLOB mysources *.c)
+zephyr_library_sources(${mysources})

--- a/tests/subsys/settings/functional/fcb/CMakeLists.txt
+++ b/tests/subsys/settings/functional/fcb/CMakeLists.txt
@@ -4,12 +4,6 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-
-zephyr_include_directories(
-	$ENV{ZEPHYR_BASE}/subsys/settings/include
-	$ENV{ZEPHYR_BASE}/subsys/settings/src
-	)
-
 # The code is in the library common to several tests.
 target_sources(app PRIVATE placeholder.c)
 

--- a/tests/subsys/settings/functional/nvs/CMakeLists.txt
+++ b/tests/subsys/settings/functional/nvs/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-zephyr_include_directories(
-	$ENV{ZEPHYR_BASE}/subsys/settings/include
-	$ENV{ZEPHYR_BASE}/subsys/settings/src
-	)
-
 # The code is in the library common to several tests.
 target_sources(app PRIVATE placeholder.c)
 

--- a/tests/subsys/settings/functional/src/CMakeLists.txt
+++ b/tests/subsys/settings/functional/src/CMakeLists.txt
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library_named(  settings_func_test)
+
+zephyr_include_directories(
+	$ENV{ZEPHYR_BASE}/subsys/settings/include
+	$ENV{ZEPHYR_BASE}/subsys/settings/src
+	)
+
 zephyr_library_sources(settings_basic_test.c)
 
 # zephyr_library() is here in "app-mode", see

--- a/tests/subsys/settings/nffs/base64/CMakeLists.txt
+++ b/tests/subsys/settings/nffs/base64/CMakeLists.txt
@@ -4,13 +4,11 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(nffs)
 
-FILE(GLOB app_sources ../src/*.c ../../src/*c)
-target_sources(app PRIVATE ${app_sources})
-zephyr_include_directories(
-	$ENV{ZEPHYR_BASE}/subsys/settings/include
-	$ENV{ZEPHYR_BASE}/subsys/settings/src
-	$ENV{ZEPHYR_BASE}/tests/subsys/settings/nffs/src
-	)
+add_subdirectory(../src nffs_test_bindir)
+target_link_libraries(app PRIVATE settings_nffs_test)
+
+# The code is in the library common to several tests.
+target_sources(app PRIVATE placeholder.c)
 
 if(TEST)
 	target_compile_definitions(app PRIVATE

--- a/tests/subsys/settings/nffs/base64/placeholder.c
+++ b/tests/subsys/settings/nffs/base64/placeholder.c
@@ -1,0 +1,2 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2019 Intel Corporation */

--- a/tests/subsys/settings/nffs/raw/CMakeLists.txt
+++ b/tests/subsys/settings/nffs/raw/CMakeLists.txt
@@ -4,13 +4,11 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-FILE(GLOB app_sources ../src/*.c ../../src/*c)
-target_sources(app PRIVATE ${app_sources})
-zephyr_include_directories(
-	$ENV{ZEPHYR_BASE}/subsys/settings/include
-	$ENV{ZEPHYR_BASE}/subsys/settings/src
-	$ENV{ZEPHYR_BASE}/tests/subsys/settings/nffs/src
-	)
+add_subdirectory(../src nffs_test_bindir)
+target_link_libraries(app PRIVATE settings_nffs_test)
+
+# The code is in the library common to several tests.
+target_sources(app PRIVATE placeholder.c)
 
 if(TEST)
 	target_compile_definitions(app PRIVATE

--- a/tests/subsys/settings/nffs/raw/placeholder.c
+++ b/tests/subsys/settings/nffs/raw/placeholder.c
@@ -1,0 +1,2 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2019 Intel Corporation */

--- a/tests/subsys/settings/nffs/src/CMakeLists.txt
+++ b/tests/subsys/settings/nffs/src/CMakeLists.txt
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2019 Intel Corporation
+
+zephyr_library_named(settings_nffs_test)
+
+add_subdirectory(../../src settings_test_bindir)
+target_link_libraries(settings_nffs_test PRIVATE settings_test)
+
+target_link_libraries(settings_nffs_test PRIVATE NFFS)
+
+zephyr_include_directories(
+	$ENV{ZEPHYR_BASE}/subsys/settings/include
+	$ENV{ZEPHYR_BASE}/subsys/settings/src
+	$ENV{ZEPHYR_BASE}/tests/subsys/settings/nffs/src
+	)
+
+FILE(GLOB mysources *.c)
+zephyr_library_sources(${mysources})

--- a/tests/subsys/settings/nvs/raw/CMakeLists.txt
+++ b/tests/subsys/settings/nvs/raw/CMakeLists.txt
@@ -4,13 +4,11 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(test_settings_nvs_raw)
 
-FILE(GLOB app_sources ../src/*.c ../../src/*c)
-target_sources(app PRIVATE ${app_sources})
-zephyr_include_directories(
-	$ENV{ZEPHYR_BASE}/subsys/settings/include
-	$ENV{ZEPHYR_BASE}/subsys/settings/src
-	$ENV{ZEPHYR_BASE}/tests/subsys/settings/nvs/src
-	)
+add_subdirectory(../src nvs_test_bindir)
+target_link_libraries(app PRIVATE settings_nvs_test)
+
+# The code is in the library common to several tests.
+target_sources(app PRIVATE placeholder.c)
 
 if(TEST)
 	target_compile_definitions(app PRIVATE

--- a/tests/subsys/settings/nvs/raw/placeholder.c
+++ b/tests/subsys/settings/nvs/raw/placeholder.c
@@ -1,0 +1,2 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2019 Intel Corporation */

--- a/tests/subsys/settings/nvs/src/CMakeLists.txt
+++ b/tests/subsys/settings/nvs/src/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2019 Intel Corporation
+
+zephyr_library_named(settings_nvs_test)
+
+zephyr_include_directories(
+	$ENV{ZEPHYR_BASE}/subsys/settings/include
+	$ENV{ZEPHYR_BASE}/subsys/settings/src
+	$ENV{ZEPHYR_BASE}/tests/subsys/settings/nvs/src
+	)
+
+zephyr_library_sources(settings_test_nvs.c)
+
+add_subdirectory(../../src settings_test_bindir)
+target_link_libraries(settings_nvs_test PRIVATE settings_test)

--- a/tests/subsys/settings/src/CMakeLists.txt
+++ b/tests/subsys/settings/src/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2019 Intel Corporation
+
+zephyr_library_named(settings_test)
+
+# zephyr_library() is here in "app-mode", see
+# https://github.com/zephyrproject-rtos/zephyr/issues/19582
+# Random build failures without this, depends on the number of threads.
+add_dependencies(    settings_test offsets_h)
+
+FILE(GLOB mysources *.c )
+zephyr_library_sources(${mysources})


### PR DESCRIPTION
Stops leaking very long source paths in build directories; makes them
deterministic. Finishes what was started in commit b4282bf72db8, see
rationale and code reviews there.

See also CMake issue https://gitlab.kitware.com/cmake/cmake/issues/19475
for more details.

Use the opportunity to remove the most obvious duplication.

Test with: sanitycheck -T $ZEPHYR_BASE/tests/subsys/settings/


tests/subsys/settings/functional: de-duplicate zephyr_include_ and move it next to zephyr_library_sources()
