### PR TITLE
drivers: clock_control: nrf_power_clock: Make isr function global

### DIFF
--- a/drivers/clock_control/nrf_power_clock.c
+++ b/drivers/clock_control/nrf_power_clock.c
@@ -187,7 +187,15 @@ static int clock_start(struct device *dev, clock_control_subsys_t sub_system)
 	return clock_async_start(dev, sub_system, NULL);
 }
 
-static void nrf_power_clock_isr(void *arg);
+/* Note: this function has public linkage, and MUST have this
+ * particular name.  The platform architecture itself doesn't care,
+ * but there is a test (tests/kernel/arm_irq_vector_table) that needs
+ * to find it to it can set it in a custom vector table.  Should
+ * probably better abstract that at some point (e.g. query and reset
+ * it by pointer at runtime, maybe?) so we don't have this leaky
+ * symbol.
+ */
+void nrf_power_clock_isr(void *arg);
 
 static int hfclk_init(struct device *dev)
 {
@@ -316,15 +324,6 @@ static void usb_power_isr(void)
 #endif
 }
 
-
-/* Note: this function has public linkage, and MUST have this
- * particular name.  The platform architecture itself doesn't care,
- * but there is a test (tests/kernel/arm_irq_vector_table) that needs
- * to find it to it can set it in a custom vector table.  Should
- * probably better abstract that at some point (e.g. query and reset
- * it by pointer at runtime, maybe?) so we don't have this leaky
- * symbol.
- */
 void nrf_power_clock_isr(void *arg)
 {
 	ARG_UNUSED(arg);


### PR DESCRIPTION
Some tests are failing because nrf_power_clock_isr was static.

Apparently, some tests are using irq function (https://github.com/zephyrproject-rtos/zephyr/blob/288940dbbda5b8b9f5ca1f0a335a04be4ef91194/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c#L165) which was declared static in the driver.

Fixes #19683.
Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>