### PR TITLE
Bluetooth: controller: split: Support Zero Latency IRQs

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -412,6 +412,14 @@ config BT_CTLR_PHY_CODED
 	  Enable support for Bluetooth 5.0 Coded PHY in the Controller.
 endif # BT_PHY_UPDATE
 
+config BT_CTLR_ZLI
+	bool "Use Zero Latency IRQs"
+	depends on ZERO_LATENCY_IRQS
+	help
+	  Enable support for use of Zero Latency IRQ feature. Note, applications
+	  shall not use Zero Latency IRQ themselves when this option is selected,
+	  else will impact controller stability.
+
 if BT_LL_SW_LEGACY
 
 config BT_CTLR_WORKER_PRIO

--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -42,6 +42,12 @@
 #include "ll_feat.h"
 #include "ll_filter.h"
 
+#if defined(CONFIG_BT_CTLR_ZLI)
+#define IRQ_CONNECT_FLAGS IRQ_ZERO_LATENCY
+#else
+#define IRQ_CONNECT_FLAGS 0
+#endif
+
 /* Global singletons */
 
 #if defined(CONFIG_SOC_FLASH_NRF_RADIO_SYNC)
@@ -181,11 +187,16 @@ int ll_init(struct k_sem *sem_rx)
 	}
 
 	IRQ_DIRECT_CONNECT(RADIO_IRQn, CONFIG_BT_CTLR_WORKER_PRIO,
-			   radio_nrf5_isr, 0);
+			   radio_nrf5_isr, IRQ_CONNECT_FLAGS);
 	IRQ_CONNECT(RTC0_IRQn, CONFIG_BT_CTLR_WORKER_PRIO,
-		    rtc0_nrf5_isr, NULL, 0);
+		    rtc0_nrf5_isr, NULL, IRQ_CONNECT_FLAGS);
+#if (CONFIG_BT_CTLR_WORKER_PRIO == CONFIG_BT_CTLR_JOB_PRIO)
+	IRQ_CONNECT(SWI5_IRQn, CONFIG_BT_CTLR_JOB_PRIO,
+		    swi5_nrf5_isr, NULL, IRQ_CONNECT_FLAGS);
+#else
 	IRQ_CONNECT(SWI5_IRQn, CONFIG_BT_CTLR_JOB_PRIO,
 		    swi5_nrf5_isr, NULL, 0);
+#endif
 
 	irq_enable(RADIO_IRQn);
 	irq_enable(RTC0_IRQn);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -33,6 +33,12 @@
 
 #include "hal/debug.h"
 
+#if defined(CONFIG_BT_CTLR_ZLI)
+#define IRQ_CONNECT_FLAGS IRQ_ZERO_LATENCY
+#else
+#define IRQ_CONNECT_FLAGS 0
+#endif
+
 static struct {
 	struct {
 		void              *param;
@@ -158,11 +164,16 @@ int lll_init(void)
 
 	/* Connect ISRs */
 	IRQ_DIRECT_CONNECT(RADIO_IRQn, CONFIG_BT_CTLR_LLL_PRIO,
-			   radio_nrf5_isr, 0);
+			   radio_nrf5_isr, IRQ_CONNECT_FLAGS);
+#if (CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_HIGH_PRIO)
+	IRQ_CONNECT(RTC0_IRQn, CONFIG_BT_CTLR_ULL_HIGH_PRIO,
+		    rtc0_nrf5_isr, NULL, IRQ_CONNECT_FLAGS);
+#else
 	IRQ_CONNECT(RTC0_IRQn, CONFIG_BT_CTLR_ULL_HIGH_PRIO,
 		    rtc0_nrf5_isr, NULL, 0);
+#endif
 	IRQ_CONNECT(HAL_SWI_RADIO_IRQ, CONFIG_BT_CTLR_LLL_PRIO,
-		    swi_lll_nrf5_isr, NULL, 0);
+		    swi_lll_nrf5_isr, NULL, IRQ_CONNECT_FLAGS);
 #if defined(CONFIG_BT_CTLR_LOW_LAT) || \
 	(CONFIG_BT_CTLR_ULL_HIGH_PRIO != CONFIG_BT_CTLR_ULL_LOW_PRIO)
 	IRQ_CONNECT(HAL_SWI_JOB_IRQ, CONFIG_BT_CTLR_ULL_LOW_PRIO,


### PR DESCRIPTION
Add support for Zero Latency IRQs, which avoids any Zephyr
OS or application influenced ISR latencies on the
controller's ISRs.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>