### PR TITLE
object tracing: Fix the issue that objects lost from trace list

### DIFF
--- a/include/debug/object_tracing_common.h
+++ b/include/debug/object_tracing_common.h
@@ -33,15 +33,18 @@
  * @param name Name of the trace list.
  * @param obj Object to be added in the trace list.
  */
-#define SYS_TRACING_OBJ_INIT(name, obj)		       \
-	do {					       \
-		unsigned int key;		       \
-						       \
-		key = irq_lock();		       \
-		(obj)->__next =  _trace_list_ ## name; \
-		_trace_list_ ## name = obj;	       \
-		irq_unlock(key);		       \
-	}					       \
+#define SYS_TRACING_OBJ_INIT(name, obj)			       \
+	do {						       \
+		unsigned int key;			       \
+							       \
+		key = irq_lock();			       \
+		if (!(obj)->__linked) {			       \
+			(obj)->__next =  _trace_list_ ## name; \
+			_trace_list_ ## name = obj;	       \
+			(obj)->__linked = 1;		       \
+		}					       \
+		irq_unlock(key);			       \
+	}						       \
 	while (false)
 
 /**

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -98,10 +98,14 @@ typedef struct {
 
 #ifdef CONFIG_OBJECT_TRACING
 #define _OBJECT_TRACING_NEXT_PTR(type) struct type *__next;
-#define _OBJECT_TRACING_INIT .__next = NULL,
+#define _OBJECT_TRACING_LINKED_FLAG u8_t __linked;
+#define _OBJECT_TRACING_INIT \
+	.__next = NULL,	     \
+	.__linked = 0,
 #else
 #define _OBJECT_TRACING_INIT
 #define _OBJECT_TRACING_NEXT_PTR(type)
+#define _OBJECT_TRACING_LINKED_FLAG
 #endif
 
 #ifdef CONFIG_POLL
@@ -1461,6 +1465,7 @@ struct k_timer {
 	void *user_data;
 
 	_OBJECT_TRACING_NEXT_PTR(k_timer)
+	_OBJECT_TRACING_LINKED_FLAG
 };
 
 #define Z_TIMER_INITIALIZER(obj, expiry, stop) \
@@ -1834,6 +1839,7 @@ struct k_queue {
 	};
 
 	_OBJECT_TRACING_NEXT_PTR(k_queue)
+	_OBJECT_TRACING_LINKED_FLAG
 };
 
 #define _K_QUEUE_INITIALIZER(obj) \
@@ -2555,6 +2561,7 @@ struct k_stack {
 	stack_data_t *base, *next, *top;
 
 	_OBJECT_TRACING_NEXT_PTR(k_stack)
+	_OBJECT_TRACING_LINKED_FLAG
 	u8_t flags;
 };
 
@@ -3206,6 +3213,7 @@ struct k_mutex {
 	int owner_orig_prio;
 
 	_OBJECT_TRACING_NEXT_PTR(k_mutex)
+	_OBJECT_TRACING_LINKED_FLAG
 };
 
 /**
@@ -3307,6 +3315,7 @@ struct k_sem {
 	_POLL_EVENT;
 
 	_OBJECT_TRACING_NEXT_PTR(k_sem)
+	_OBJECT_TRACING_LINKED_FLAG
 };
 
 #define Z_SEM_INITIALIZER(obj, initial_count, count_limit) \
@@ -3465,6 +3474,7 @@ struct k_msgq {
 	u32_t used_msgs;
 
 	_OBJECT_TRACING_NEXT_PTR(k_msgq)
+	_OBJECT_TRACING_LINKED_FLAG
 	u8_t flags;
 };
 /**
@@ -3760,6 +3770,7 @@ struct k_mbox {
 	struct k_spinlock lock;
 
 	_OBJECT_TRACING_NEXT_PTR(k_mbox)
+	_OBJECT_TRACING_LINKED_FLAG
 };
 /**
  * @cond INTERNAL_HIDDEN
@@ -3944,6 +3955,7 @@ struct k_pipe {
 	} wait_q;
 
 	_OBJECT_TRACING_NEXT_PTR(k_pipe)
+	_OBJECT_TRACING_LINKED_FLAG
 	u8_t	       flags;		/**< Flags */
 };
 
@@ -4121,6 +4133,7 @@ struct k_mem_slab {
 	u32_t num_used;
 
 	_OBJECT_TRACING_NEXT_PTR(k_mem_slab)
+	_OBJECT_TRACING_LINKED_FLAG
 };
 
 #define _K_MEM_SLAB_INITIALIZER(obj, slab_buffer, slab_block_size, \


### PR DESCRIPTION
Add a flag for identifing whether this object is on the trace
list. Ensure that link any object to the trace list only one time.
It will avoid the issue about lost object caused by adding a
object to trace list twice.

Fixes #19537

Signed-off-by: Shih-Wei Teng <swteng@andestech.com>