### PR TITLE
Bluetooth: Mesh: Model message macros

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -176,6 +176,55 @@ struct bt_mesh_model_op {
 /** Helper to define an empty model array */
 #define BT_MESH_MODEL_NONE ((struct bt_mesh_model []){})
 
+/** Length of a short Mesh MIC. */
+#define BT_MESH_MIC_SHORT 4
+/** Length of a long Mesh MIC. */
+#define BT_MESH_MIC_LONG 8
+
+/** @def BT_MESH_MODEL_OP_LEN
+ *
+ * @brief Helper to determine the length of an opcode.
+ *
+ * @param _op Opcode.
+ */
+#define BT_MESH_MODEL_OP_LEN(_op) ((_op) <= 0xff ? 1 : (_op) <= 0xffff ? 2 : 3)
+
+/** @def BT_MESH_MODEL_BUF_LEN
+ *
+ * @brief Helper for model message buffer length.
+ *
+ * Returns the length of a Mesh model message buffer, including the opcode
+ * length and a short MIC.
+ *
+ * @param _op Opcode of the message.
+ * @param _payload_len Length of the model payload.
+ */
+#define BT_MESH_MODEL_BUF_LEN(_op, _payload_len)                               \
+	(BT_MESH_MODEL_OP_LEN(_op) + (_payload_len) + BT_MESH_MIC_SHORT)
+
+/** @def BT_MESH_MODEL_BUF_LEN_LONG_MIC
+ *
+ * @brief Helper for model message buffer length.
+ *
+ * Returns the length of a Mesh model message buffer, including the opcode
+ * length and a long MIC.
+ *
+ * @param _op Opcode of the message.
+ * @param _payload_len Length of the model payload.
+ */
+#define BT_MESH_MODEL_BUF_LEN_LONG_MIC(_op, _payload_len)                      \
+	(BT_MESH_MODEL_OP_LEN(_op) + (_payload_len) + BT_MESH_MIC_LONG)
+
+/** @def BT_MESH_MODEL_BUF_DEFINE
+ *
+ * @brief Define a Mesh model message buffer using @ref NET_BUF_SIMPLE_DEFINE.
+ *
+ * @param _buf Buffer name.
+ * @param _op Opcode of the message.
+ * @param _payload_len Length of the model message payload.
+ */
+#define BT_MESH_MODEL_BUF_DEFINE(_buf, _op, _payload_len)                      \
+	NET_BUF_SIMPLE_DEFINE(_buf, BT_MESH_MODEL_BUF_LEN(_op, (_payload_len)))
 
 /** @def BT_MESH_MODEL_CB
  *

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -582,21 +582,21 @@ void bt_mesh_model_msg_init(struct net_buf_simple *msg, u32_t opcode)
 {
 	net_buf_simple_init(msg, 0);
 
-	if (opcode < 0x100) {
-		/* 1-byte OpCode */
+	switch (BT_MESH_MODEL_OP_LEN(opcode)) {
+	case 1:
 		net_buf_simple_add_u8(msg, opcode);
-		return;
-	}
-
-	if (opcode < 0x10000) {
-		/* 2-byte OpCode */
+		break;
+	case 2:
 		net_buf_simple_add_be16(msg, opcode);
-		return;
+		break;
+	case 3:
+		net_buf_simple_add_u8(msg, ((opcode >> 16) & 0xff));
+		net_buf_simple_add_le16(msg, opcode & 0xffff);
+		break;
+	default:
+		BT_WARN("Unknown opcode format");
+		break;
 	}
-
-	/* 3-byte OpCode */
-	net_buf_simple_add_u8(msg, ((opcode >> 16) & 0xff));
-	net_buf_simple_add_le16(msg, opcode & 0xffff);
 }
 
 static int model_send(struct bt_mesh_model *model,

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -27,6 +27,9 @@
 
 #define CID_NVAL 0xffff
 
+/* 2 byte dummy opcode for getting compile time buffer sizes. */
+#define DUMMY_2_BYTE_OP	BT_MESH_MODEL_OP_2(0xff, 0xff)
+
 struct comp_data {
 	u8_t *status;
 	struct net_buf_simple *comp;
@@ -552,7 +555,7 @@ static int cli_wait(void)
 int bt_mesh_cfg_comp_data_get(u16_t net_idx, u16_t addr, u8_t page,
 			      u8_t *status, struct net_buf_simple *comp)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_DEV_COMP_DATA_GET, 1);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -586,7 +589,7 @@ int bt_mesh_cfg_comp_data_get(u16_t net_idx, u16_t addr, u8_t page,
 static int get_state_u8(u16_t net_idx, u16_t addr, u32_t op, u32_t rsp,
 			u8_t *val)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, DUMMY_2_BYTE_OP, 0);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -615,7 +618,7 @@ static int get_state_u8(u16_t net_idx, u16_t addr, u32_t op, u32_t rsp,
 static int set_state_u8(u16_t net_idx, u16_t addr, u32_t op, u32_t rsp,
 			u8_t new_val, u8_t *val)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, DUMMY_2_BYTE_OP, 1);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -694,7 +697,7 @@ int bt_mesh_cfg_gatt_proxy_set(u16_t net_idx, u16_t addr, u8_t val,
 int bt_mesh_cfg_relay_get(u16_t net_idx, u16_t addr, u8_t *status,
 			  u8_t *transmit)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_RELAY_GET, 0);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -727,7 +730,7 @@ int bt_mesh_cfg_relay_get(u16_t net_idx, u16_t addr, u8_t *status,
 int bt_mesh_cfg_relay_set(u16_t net_idx, u16_t addr, u8_t new_relay,
 			  u8_t new_transmit, u8_t *status, u8_t *transmit)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 2 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_RELAY_SET, 2);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -762,7 +765,7 @@ int bt_mesh_cfg_relay_set(u16_t net_idx, u16_t addr, u8_t new_relay,
 int bt_mesh_cfg_net_key_add(u16_t net_idx, u16_t addr, u16_t key_net_idx,
 			    const u8_t net_key[16], u8_t *status)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 18 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_ADD, 18);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -803,7 +806,7 @@ int bt_mesh_cfg_app_key_add(u16_t net_idx, u16_t addr, u16_t key_net_idx,
 			    u16_t key_app_idx, const u8_t app_key[16],
 			    u8_t *status)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 1 + 19 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_ADD, 19);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -845,7 +848,7 @@ static int mod_app_bind(u16_t net_idx, u16_t addr, u16_t elem_addr,
 			u16_t mod_app_idx, u16_t mod_id, u16_t cid,
 			u8_t *status)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 8 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_BIND, 8);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -913,7 +916,7 @@ int bt_mesh_cfg_mod_app_bind_vnd(u16_t net_idx, u16_t addr, u16_t elem_addr,
 static int mod_sub(u32_t op, u16_t net_idx, u16_t addr, u16_t elem_addr,
 		   u16_t sub_addr, u16_t mod_id, u16_t cid, u8_t *status)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 8 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, DUMMY_2_BYTE_OP, 8);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -1020,7 +1023,7 @@ static int mod_sub_va(u32_t op, u16_t net_idx, u16_t addr, u16_t elem_addr,
 		      const u8_t label[16], u16_t mod_id, u16_t cid,
 		      u16_t *virt_addr, u8_t *status)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 22 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, DUMMY_2_BYTE_OP, 22);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -1136,7 +1139,7 @@ static int mod_pub_get(u16_t net_idx, u16_t addr, u16_t elem_addr,
 		       u16_t mod_id, u16_t cid,
 		       struct bt_mesh_cfg_mod_pub *pub, u8_t *status)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 6 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_PUB_GET, 6);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -1205,7 +1208,7 @@ static int mod_pub_set(u16_t net_idx, u16_t addr, u16_t elem_addr,
 		       u16_t mod_id, u16_t cid,
 		       struct bt_mesh_cfg_mod_pub *pub, u8_t *status)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 13 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_PUB_SET, 13);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -1278,7 +1281,7 @@ int bt_mesh_cfg_mod_pub_set_vnd(u16_t net_idx, u16_t addr, u16_t elem_addr,
 int bt_mesh_cfg_hb_sub_set(u16_t net_idx, u16_t addr,
 			   struct bt_mesh_cfg_hb_sub *sub, u8_t *status)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 5 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_SUB_SET, 5);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -1319,7 +1322,7 @@ int bt_mesh_cfg_hb_sub_set(u16_t net_idx, u16_t addr,
 int bt_mesh_cfg_hb_sub_get(u16_t net_idx, u16_t addr,
 			   struct bt_mesh_cfg_hb_sub *sub, u8_t *status)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_SUB_GET, 0);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -1357,7 +1360,7 @@ int bt_mesh_cfg_hb_sub_get(u16_t net_idx, u16_t addr,
 int bt_mesh_cfg_hb_pub_set(u16_t net_idx, u16_t addr,
 			   const struct bt_mesh_cfg_hb_pub *pub, u8_t *status)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 9 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_PUB_SET, 9);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -1400,7 +1403,7 @@ int bt_mesh_cfg_hb_pub_set(u16_t net_idx, u16_t addr,
 int bt_mesh_cfg_hb_pub_get(u16_t net_idx, u16_t addr,
 			   struct bt_mesh_cfg_hb_pub *pub, u8_t *status)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_PUB_GET, 0);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -435,7 +435,7 @@ static void app_key_add(struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 4 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_STATUS, 4);
 	u16_t key_net_idx, key_app_idx;
 	u8_t status;
 
@@ -460,7 +460,7 @@ static void app_key_update(struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 4 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_STATUS, 4);
 	u16_t key_net_idx, key_app_idx;
 	u8_t status;
 
@@ -514,7 +514,7 @@ static void app_key_del(struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 4 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_STATUS, 4);
 	u16_t key_net_idx, key_app_idx;
 	struct bt_mesh_app_key *key;
 	u8_t status;
@@ -564,8 +564,8 @@ static void app_key_get(struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 3 + 4 +
-			      IDX_LEN(CONFIG_BT_MESH_APP_KEY_COUNT));
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_LIST,
+				 3 + IDX_LEN(CONFIG_BT_MESH_APP_KEY_COUNT));
 	u16_t get_idx, i, prev;
 	u8_t status;
 
@@ -623,8 +623,7 @@ static void beacon_get(struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_BEACON_STATUS, 1);
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
@@ -642,8 +641,7 @@ static void beacon_set(struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_BEACON_STATUS, 1);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
@@ -683,8 +681,7 @@ static void default_ttl_get(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_DEFAULT_TTL_STATUS, 1);
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
@@ -702,8 +699,7 @@ static void default_ttl_set(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_DEFAULT_TTL_STATUS, 1);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
@@ -736,8 +732,7 @@ static void default_ttl_set(struct bt_mesh_model *model,
 static void send_gatt_proxy_status(struct bt_mesh_model *model,
 				   struct bt_mesh_msg_ctx *ctx)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_GATT_PROXY_STATUS, 1);
 
 	bt_mesh_model_msg_init(&msg, OP_GATT_PROXY_STATUS);
 	net_buf_simple_add_u8(&msg, bt_mesh_gatt_proxy_get());
@@ -831,8 +826,7 @@ static void net_transmit_get(struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_TRANSMIT_STATUS, 1);
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
@@ -850,8 +844,7 @@ static void net_transmit_set(struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_TRANSMIT_STATUS, 1);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
@@ -884,8 +877,7 @@ static void relay_get(struct bt_mesh_model *model,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 2 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_RELAY_STATUS, 2);
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
@@ -904,8 +896,7 @@ static void relay_set(struct bt_mesh_model *model,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 2 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_RELAY_STATUS, 2);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
@@ -958,8 +949,7 @@ static void send_mod_pub_status(struct bt_mesh_model *cfg_mod,
 				bool vnd, struct bt_mesh_model *mod,
 				u8_t status, u8_t *mod_id)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 14 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_PUB_STATUS, 14);
 
 	bt_mesh_model_msg_init(&msg, OP_MOD_PUB_STATUS);
 
@@ -1324,8 +1314,7 @@ static void send_mod_sub_status(struct bt_mesh_model *model,
 				u16_t elem_addr, u16_t sub_addr, u8_t *mod_id,
 				bool vnd)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 9 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_SUB_STATUS, 9);
 
 	BT_DBG("status 0x%02x elem_addr 0x%04x sub_addr 0x%04x", status,
 	       elem_addr, sub_addr);
@@ -1614,8 +1603,8 @@ static void mod_sub_get(struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 5 + 4 +
-			      CONFIG_BT_MESH_MODEL_GROUP_COUNT * 2);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_SUB_LIST,
+				 5 + CONFIG_BT_MESH_MODEL_GROUP_COUNT * 2);
 	struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	u16_t addr, id;
@@ -1670,8 +1659,8 @@ static void mod_sub_get_vnd(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 7 + 4 +
-			      CONFIG_BT_MESH_MODEL_GROUP_COUNT * 2);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_SUB_LIST_VND,
+				 7 + CONFIG_BT_MESH_MODEL_GROUP_COUNT * 2);
 	struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	u16_t company, addr, id;
@@ -2063,8 +2052,7 @@ static void send_net_key_status(struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				u16_t idx, u8_t status)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 3 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_STATUS, 3);
 
 	bt_mesh_model_msg_init(&msg, OP_NET_KEY_STATUS);
 
@@ -2276,8 +2264,8 @@ static void net_key_get(struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	NET_BUF_SIMPLE_DEFINE(msg,
-			      2 + 4 + IDX_LEN(CONFIG_BT_MESH_SUBNET_COUNT));
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_LIST,
+				 IDX_LEN(CONFIG_BT_MESH_SUBNET_COUNT));
 	u16_t prev, i;
 
 	bt_mesh_model_msg_init(&msg, OP_NET_KEY_LIST);
@@ -2312,8 +2300,7 @@ static void node_identity_get(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 4 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NODE_IDENTITY_STATUS, 4);
 	struct bt_mesh_subnet *sub;
 	u8_t node_id;
 	u16_t idx;
@@ -2351,8 +2338,7 @@ static void node_identity_set(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 4 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NODE_IDENTITY_STATUS, 4);
 	struct bt_mesh_subnet *sub;
 	u8_t node_id;
 	u16_t idx;
@@ -2428,7 +2414,7 @@ static void mod_app_bind(struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 9 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_STATUS, 9);
 	u16_t elem_addr, key_app_idx;
 	struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
@@ -2485,7 +2471,7 @@ static void mod_app_unbind(struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 9 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_STATUS, 9);
 	u16_t elem_addr, key_app_idx;
 	struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
@@ -2537,7 +2523,11 @@ static void mod_app_get(struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 9 + KEY_LIST_LEN + 4);
+	NET_BUF_SIMPLE_DEFINE(msg,
+			      MAX(BT_MESH_MODEL_BUF_LEN(OP_VND_MOD_APP_LIST,
+							9 + KEY_LIST_LEN),
+				  BT_MESH_MODEL_BUF_LEN(OP_SIG_MOD_APP_LIST,
+							9 + KEY_LIST_LEN)));
 	struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	u8_t *mod_id, status;
@@ -2605,8 +2595,7 @@ static void node_reset(struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NODE_RESET_STATUS, 0);
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
@@ -2628,8 +2617,7 @@ static void node_reset(struct bt_mesh_model *model,
 static void send_friend_status(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_FRIEND_STATUS, 1);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 
 	bt_mesh_model_msg_init(&msg, OP_FRIEND_STATUS);
@@ -2701,8 +2689,7 @@ static void lpn_timeout_get(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 5 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_LPN_TIMEOUT_STATUS, 5);
 	struct bt_mesh_friend *frnd;
 	u16_t lpn_addr;
 	s32_t timeout;
@@ -2747,8 +2734,7 @@ static void send_krp_status(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    u16_t idx, u8_t phase, u8_t status)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 4 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_KRP_STATUS, 4);
 
 	bt_mesh_model_msg_init(&msg, OP_KRP_STATUS);
 
@@ -2885,8 +2871,7 @@ static void hb_pub_send_status(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx, u8_t status,
 			       struct hb_pub_param *orig_msg)
 {
-	/* Needed size: opcode (1 byte) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 1 + 10 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_PUB_STATUS, 10);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 
 	BT_DBG("src 0x%04x status 0x%02x", ctx->addr, status);
@@ -3009,8 +2994,7 @@ failed:
 static void hb_sub_send_status(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx, u8_t status)
 {
-	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 9 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_SUB_STATUS, 9);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 	u16_t period;
 	s64_t uptime;

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -209,7 +209,7 @@ static int cli_wait(void)
 int bt_mesh_health_attention_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 				 u8_t *attention)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_ATTENTION_GET, 0);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -241,7 +241,7 @@ int bt_mesh_health_attention_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 int bt_mesh_health_attention_set(u16_t net_idx, u16_t addr, u16_t app_idx,
 				 u8_t attention, u8_t *updated_attention)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_ATTENTION_SET, 1);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -284,7 +284,7 @@ int bt_mesh_health_attention_set(u16_t net_idx, u16_t addr, u16_t app_idx,
 int bt_mesh_health_period_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 			      u8_t *divisor)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEALTH_PERIOD_GET, 0);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -316,7 +316,7 @@ int bt_mesh_health_period_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 int bt_mesh_health_period_set(u16_t net_idx, u16_t addr, u16_t app_idx,
 			      u8_t divisor, u8_t *updated_divisor)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEALTH_PERIOD_SET, 1);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -360,7 +360,7 @@ int bt_mesh_health_fault_test(u16_t net_idx, u16_t addr, u16_t app_idx,
 			      u16_t cid, u8_t test_id, u8_t *faults,
 			      size_t *fault_count)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 3 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEALTH_FAULT_TEST, 3);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -408,7 +408,7 @@ int bt_mesh_health_fault_clear(u16_t net_idx, u16_t addr, u16_t app_idx,
 			       u16_t cid, u8_t *test_id, u8_t *faults,
 			       size_t *fault_count)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 2 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEALTH_FAULT_CLEAR, 2);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -455,7 +455,7 @@ int bt_mesh_health_fault_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 			     u16_t cid, u8_t *test_id, u8_t *faults,
 			     size_t *fault_count)
 {
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 2 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEALTH_FAULT_GET, 2);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,

--- a/subsys/bluetooth/mesh/health_srv.c
+++ b/subsys/bluetooth/mesh/health_srv.c
@@ -218,7 +218,7 @@ static void send_attention_status(struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_ATTENTION_STATUS, 1);
 	struct bt_mesh_health_srv *srv = model->user_data;
 	u8_t time;
 
@@ -271,7 +271,7 @@ static void send_health_period_status(struct bt_mesh_model *model,
 				      struct bt_mesh_msg_ctx *ctx)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
+	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEALTH_PERIOD_STATUS, 1);
 
 	bt_mesh_model_msg_init(&msg, OP_HEALTH_PERIOD_STATUS);
 


### PR DESCRIPTION
Creates macros for determining model message lengths based on opcode,
payload length and MIC size. Also adds macro wrapping
NET_BUF_SIMPLE_DEFINE to serve the most common use case.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>