### PR TITLE
drivers: CAN: Add bus-state API

### DIFF
--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -50,6 +50,15 @@ config CAN_RX_TIMESTAMP
 	  The value is incremented every bit time and starts when the controller
 	  is initialized.
 
+config CAN_AUTO_BUS_OFF_RECOVERY
+	bool "Enable automatic recovery from bus-off"
+	default y
+	help
+	  This option enables the automatic bus-off recovery according to
+	  ISO 11898-1 (recovery after 128 occurrences of 11 consecutive
+	  recessive bits). When this option is enabled, the recovery API is not
+	  available.
+
 config CAN_0
 	bool "Enable CAN 0"
 	help

--- a/drivers/can/Kconfig.mcp2515
+++ b/drivers/can/Kconfig.mcp2515
@@ -9,6 +9,7 @@
 config CAN_MCP2515
 	bool "MCP2515 CAN Driver"
 	depends on SPI
+	select CAN_AUTO_BUS_OFF_RECOVERY
 	help
 	  Enable MCP2515 CAN Driver
 

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -8,7 +8,8 @@
 #include <drivers/can.h>
 
 static inline int z_vrfy_can_configure(struct device *dev, enum can_mode mode,
-				       u32_t bitrate) {
+				       u32_t bitrate)
+{
 
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, configure));
 
@@ -21,8 +22,8 @@ static inline int z_vrfy_can_send(struct device *dev,
 				  const struct zcan_frame *msg,
 				  s32_t timeout,
 				  can_tx_callback_t callback_isr,
-				  void *callback_arg) {
-
+				  void *callback_arg)
+{
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, send));
 
 	Z_OOPS(Z_SYSCALL_MEMORY_READ((const struct zcan_frame *)msg,
@@ -43,7 +44,8 @@ static inline int z_vrfy_can_send(struct device *dev,
 
 static inline int z_vrfy_can_attach_msgq(struct device *dev,
 					 struct k_msgq *msgq,
-					 const struct zcan_filter *filter) {
+					 const struct zcan_filter *filter)
+{
 	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
 	Z_OOPS(Z_SYSCALL_MEMORY_READ((struct zcan_filter *)filter,
@@ -57,9 +59,37 @@ static inline int z_vrfy_can_attach_msgq(struct device *dev,
 #include <syscalls/can_attach_msgq_mrsh.c>
 
 static inline void z_vrfy_can_detach(struct device *dev, int filter_id)
+{
 
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, detach));
 
 	z_impl_can_detach((struct device *)dev, (int)filter_id);
 }
 #include <syscalls/can_detach_mrsh.c>
+
+static inline
+enum can_state z_vrfy_can_get_state(struct device *dev,
+				    struct can_bus_err_cnt *err_cnt)
+{
+
+	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+
+	if (err_cnt) {
+		Z_OOPS(Z_SYSCALL_MEMORY_WRITE(err_cnt, sizeof(err_cnt)));
+	}
+
+	return z_impl_can_get_state(dev, err_cnt);
+}
+#include <syscalls/can_get_state_mrsh.c>
+
+
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
+static inline int z_vrfy_can_recover(struct device *dev, s32_t timeout)
+{
+
+	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+
+	return z_impl_can_recover(dev, s32_t timeout);
+}
+#include <syscalls/can_recover_mrsh.c>
+#endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -36,6 +36,8 @@ static inline int check_filter_match(const struct zcan_frame *frame,
 	return ((id & mask) == (frame_id & mask));
 }
 
+
+
 int can_loopback_send(struct device *dev, const struct zcan_frame *frame,
 		      s32_t timeout, can_tx_callback_t callback,
 		      void *callback_arg)
@@ -149,11 +151,46 @@ int can_loopback_configure(struct device *dev, enum can_mode mode,
 	return 0;
 }
 
+static enum can_state can_loopback_get_state(struct device *dev,
+					     struct can_bus_err_cnt *err_cnt)
+{
+	ARG_UNUSED(dev);
+
+	if (err_cnt) {
+		err_cnt->tx_err_cnt = 0;
+		err_cnt->rx_err_cnt = 0;
+	}
+
+	return CAN_ERROR_ACTIVE;
+}
+
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
+int can_loopback_recover(struct device *dev, s32_t timeout)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(timeout);
+
+	return 0;
+}
+#endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
+
+static void can_loopback_register_state_change_isr(struct device *dev,
+						   can_state_change_isr_t isr)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(isr);
+}
+
 static const struct can_driver_api can_api_funcs = {
 	.configure = can_loopback_configure,
 	.send = can_loopback_send,
 	.attach_isr = can_loopback_attach_isr,
-	.detach = can_loopback_detach
+	.detach = can_loopback_detach,
+	.get_state = can_loopback_get_state,
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
+	.recover = can_loopback_recover,
+#endif
+	.register_state_change_isr = can_loopback_register_state_change_isr
 };
 
 

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -40,16 +40,19 @@ struct mcp2515_data {
 
 	/* tx data */
 	struct k_sem tx_sem;
-	struct k_mutex tx_mutex;
 	struct mcp2515_tx_cb tx_cb[MCP2515_TX_CNT];
 	u8_t tx_busy_map;
 
 	/* filter data */
-	struct k_mutex filter_mutex;
 	u32_t filter_usage;
 	can_rx_callback_t rx_cb[CONFIG_CAN_MCP2515_MAX_FILTER];
 	void *cb_arg[CONFIG_CAN_MCP2515_MAX_FILTER];
 	struct zcan_filter filter[CONFIG_CAN_MCP2515_MAX_FILTER];
+	can_state_change_isr_t state_change_isr;
+
+	/* general data */
+	struct k_mutex mutex;
+	enum can_state old_state;
 };
 
 struct mcp2515_config {
@@ -85,11 +88,14 @@ struct mcp2515_config {
 /* MCP2515 Registers */
 #define MCP2515_ADDR_CANSTAT            0x0E
 #define MCP2515_ADDR_CANCTRL            0x0F
+#define MCP2515_ADDR_TEC                0x1C
+#define MCP2515_ADDR_REC                0x1D
 #define MCP2515_ADDR_CNF3               0x28
 #define MCP2515_ADDR_CNF2               0x29
 #define MCP2515_ADDR_CNF1               0x2A
 #define MCP2515_ADDR_CANINTE            0x2B
 #define MCP2515_ADDR_CANINTF            0x2C
+#define MCP2515_ADDR_EFLG               0x2D
 #define MCP2515_ADDR_TXB0CTRL           0x30
 #define MCP2515_ADDR_TXB1CTRL           0x40
 #define MCP2515_ADDR_TXB2CTRL           0x50
@@ -123,6 +129,23 @@ struct mcp2515_config {
 #define MCP2515_CANINTF_WAKIF           BIT(6)
 #define MCP2515_CANINTF_MERRF           BIT(7)
 
+#define MCP2515_INTE_RX0IE              BIT(0)
+#define MCP2515_INTE_RX1IE              BIT(1)
+#define MCP2515_INTE_TX0IE              BIT(2)
+#define MCP2515_INTE_TX1IE              BIT(3)
+#define MCP2515_INTE_TX2IE              BIT(4)
+#define MCP2515_INTE_ERRIE              BIT(5)
+#define MCP2515_INTE_WAKIE              BIT(6)
+#define MCP2515_INTE_MERRE              BIT(7)
+
+#define MCP2515_EFLG_EWARN              BIT(0)
+#define MCP2515_EFLG_RXWAR              BIT(1)
+#define MCP2515_EFLG_TXWAR              BIT(2)
+#define MCP2515_EFLG_RXEP               BIT(3)
+#define MCP2515_EFLG_TXEP               BIT(4)
+#define MCP2515_EFLG_TXBO               BIT(5)
+#define MCP2515_EFLG_RX0OVR             BIT(6)
+#define MCP2515_EFLG_RX1OVR             BIT(7)
 
 #define MCP2515_TXCTRL_TXREQ			BIT(3)
 

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -86,6 +86,8 @@ struct mcux_flexcan_data {
 	ATOMIC_DEFINE(tx_allocs, MCUX_FLEXCAN_MAX_TX);
 	struct k_sem tx_allocs_sem;
 	struct mcux_flexcan_tx_callback tx_cbs[MCUX_FLEXCAN_MAX_TX];
+	enum can_state state;
+	can_state_change_isr_t state_change_isr;
 };
 
 #if (!defined(FSL_FEATURE_FLEXCAN_HAS_ERRATA_9595) || \
@@ -384,6 +386,68 @@ static int mcux_flexcan_attach_isr(struct device *dev, can_rx_callback_t isr,
 	return alloc;
 }
 
+static void mcux_flexcan_register_state_change_isr(struct device *dev,
+						   can_state_change_isr_t isr)
+{
+	struct mcux_flexcan_data *data = dev->driver_data;
+
+	data->state_change_isr = isr;
+}
+
+static enum can_state mcux_flexcan_get_state(struct device *dev,
+					     struct can_bus_err_cnt *err_cnt)
+{
+	const struct mcux_flexcan_config *config = dev->config->config_info;
+	u32_t status_flags;
+
+	if (err_cnt) {
+		FLEXCAN_GetBusErrCount(config->base, &err_cnt->tx_err_cnt,
+				       &err_cnt->rx_err_cnt);
+	}
+
+	status_flags = (FLEXCAN_GetStatusFlags(config->base) &
+			CAN_ESR1_FLTCONF_MASK) << CAN_ESR1_FLTCONF_SHIFT;
+
+	if (status_flags & 0x02) {
+		return CAN_BUS_OFF;
+	}
+
+	if (status_flags & 0x01) {
+		return CAN_ERROR_PASSIVE;
+	}
+
+	return CAN_ERROR_ACTIVE;
+}
+
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
+int mcux_flexcan_recover(struct device *dev, s32_t timeout)
+{
+	const struct mcux_flexcan_config *config = dev->config->config_info;
+	int ret = 0;
+	u64_t start_time;
+
+	if (mcux_flexcan_get_state(dev, NULL) != CAN_BUS_OFF) {
+		return 0;
+	}
+
+	start_time = k_uptime_get();
+	config->base->CTRL1 &= ~CAN_CTRL1_BOFFREC_MASK;
+
+	if (timeout != K_NO_WAIT) {
+		while (mcux_flexcan_get_state(dev, NULL) == CAN_BUS_OFF) {
+			if (timeout != K_FOREVER &&
+			    k_uptime_get() - start_time >= timeout) {
+				ret = CAN_TIMEOUT;
+			}
+		}
+	}
+
+	config->base->CTRL1 |= CAN_CTRL1_BOFFREC_MASK;
+
+	return ret;
+}
+#endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
+
 static void mcux_flexcan_detach(struct device *dev, int filter_id)
 {
 	const struct mcux_flexcan_config *config = dev->config->config_info;
@@ -421,6 +485,8 @@ static inline void mcux_flexcan_transfer_error_status(struct device *dev,
 	int status = CAN_TX_OK;
 	void *arg;
 	int alloc;
+	enum can_state state;
+	struct can_bus_err_cnt err_cnt;
 
 	if (error & CAN_ESR1_FLTCONF(2)) {
 		LOG_DBG("Tx bus off (error 0x%08x)", error);
@@ -440,6 +506,14 @@ static inline void mcux_flexcan_transfer_error_status(struct device *dev,
 		LOG_DBG("RX CRC error (error 0x%08x)", error);
 	} else {
 		LOG_DBG("Unhandled error (error 0x%08x)", error);
+	}
+
+	state = mcux_flexcan_get_state(dev, &err_cnt);
+	if (data->state != state) {
+		data->state = state;
+		if (data->state_change_isr) {
+			data->state_change_isr(state, err_cnt);
+		}
 	}
 
 	if (status == CAN_TX_OK) {
@@ -598,6 +672,11 @@ static int mcux_flexcan_init(struct device *dev)
 
 	config->irq_config_func(dev);
 
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
+	config->base->CTRL1 |= CAN_CTRL1_BOFFREC_MASK;
+#endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
+	data->state = mcux_flexcan_get_state(dev, NULL);
+
 	return 0;
 }
 
@@ -606,6 +685,11 @@ static const struct can_driver_api mcux_flexcan_driver_api = {
 	.send = mcux_flexcan_send,
 	.attach_isr = mcux_flexcan_attach_isr,
 	.detach = mcux_flexcan_detach,
+	.get_state = mcux_flexcan_get_state,
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
+	.recover = mcux_flexcan_recover,
+#endif
+	.register_state_change_isr = mcux_flexcan_register_state_change_isr
 };
 
 #ifdef CONFIG_CAN_0

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -18,7 +18,8 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(can_driver, CONFIG_CAN_LOG_LEVEL);
 
-#define INIT_TIMEOUT  (10 * sys_clock_hw_cycles_per_sec() / MSEC_PER_SEC)
+#define CAN_INIT_TIMEOUT  (10 * sys_clock_hw_cycles_per_sec() / MSEC_PER_SEC)
+#define CAN_BOFF_RECOVER_TIMEOUT  (10 * sys_clock_hw_cycles_per_sec() / MSEC_PER_SEC)
 
 /*
  * Translation tables
@@ -92,6 +93,32 @@ void can_stm32_rx_isr_handler(CAN_TypeDef *can, struct can_stm32_data *data)
 	}
 }
 
+static inline void can_stm32_bus_state_change_isr(CAN_TypeDef *can,
+						  struct can_stm32_data *data)
+{
+	struct can_bus_err_cnt err_cnt;
+	enum can_state state;
+
+	if (!(can->ESR & CAN_ESR_EPVF) && !(can->ESR & CAN_ESR_BOFF)) {
+		return;
+	}
+
+	err_cnt.tx_err_cnt = ((can->ESR & CAN_ESR_TEC) >> CAN_ESR_TEC_Pos);
+	err_cnt.rx_err_cnt = ((can->ESR & CAN_ESR_REC) >> CAN_ESR_REC_Pos);
+
+	if (can->ESR & CAN_ESR_BOFF) {
+		state = CAN_BUS_OFF;
+	} else if (can->ESR & CAN_ESR_EPVF) {
+		state = CAN_ERROR_PASSIVE;
+	} else {
+		state = CAN_ERROR_ACTIVE;
+	}
+
+	if (data->state_change_isr) {
+		data->state_change_isr(state, err_cnt);
+	}
+}
+
 static inline
 void can_stm32_tx_isr_handler(CAN_TypeDef *can, struct can_stm32_data *data)
 {
@@ -156,7 +183,10 @@ static void can_stm32_isr(void *arg)
 
 	can_stm32_tx_isr_handler(can, data);
 	can_stm32_rx_isr_handler(can, data);
-
+	if (can->MSR & CAN_MSR_ERRI) {
+		can_stm32_bus_state_change_isr(can, data);
+		can->MSR |= CAN_MSR_ERRI;
+	}
 }
 
 #else
@@ -191,6 +221,27 @@ static void can_stm32_tx_isr(void *arg)
 	can_stm32_tx_isr_handler(can, data);
 }
 
+static void can_stm32_state_change_isr(void *arg)
+{
+	struct device *dev;
+	struct can_stm32_data *data;
+	const struct can_stm32_config *cfg;
+	CAN_TypeDef *can;
+
+	dev = (struct device *)arg;
+	data = DEV_DATA(dev);
+	cfg = DEV_CFG(dev);
+	can = cfg->can;
+
+
+	/*Signal bus-off to waiting tx*/
+	if (can->MSR & CAN_MSR_ERRI) {
+		can_stm32_tx_isr_handler(can, data);
+		can_stm32_bus_state_change_isr(can, data);
+		can->MSR |= CAN_MSR_ERRI;
+	}
+}
+
 #endif
 
 static int can_enter_init_mode(CAN_TypeDef *can)
@@ -201,7 +252,8 @@ static int can_enter_init_mode(CAN_TypeDef *can)
 	start_time = k_cycle_get_32();
 
 	while ((can->MSR & CAN_MSR_INAK) == 0U) {
-		if (k_cycle_get_32() - start_time > INIT_TIMEOUT) {
+		if (k_cycle_get_32() - start_time > CAN_INIT_TIMEOUT) {
+			can->MCR &= ~CAN_MCR_INRQ;
 			return CAN_TIMEOUT;
 		}
 	}
@@ -217,7 +269,7 @@ static int can_leave_init_mode(CAN_TypeDef *can)
 	start_time = k_cycle_get_32();
 
 	while ((can->MSR & CAN_MSR_INAK) != 0U) {
-		if (k_cycle_get_32() - start_time > INIT_TIMEOUT) {
+		if (k_cycle_get_32() - start_time > CAN_INIT_TIMEOUT) {
 			return CAN_TIMEOUT;
 		}
 	}
@@ -233,7 +285,7 @@ static int can_leave_sleep_mode(CAN_TypeDef *can)
 	start_time = k_cycle_get_32();
 
 	while ((can->MSR & CAN_MSR_SLAK) != 0) {
-		if (k_cycle_get_32() - start_time > INIT_TIMEOUT) {
+		if (k_cycle_get_32() - start_time > CAN_INIT_TIMEOUT) {
 			return CAN_TIMEOUT;
 		}
 	}
@@ -247,6 +299,7 @@ int can_stm32_runtime_configure(struct device *dev, enum can_mode mode,
 	CAN_HandleTypeDef hcan;
 	const struct can_stm32_config *cfg = DEV_CFG(dev);
 	CAN_TypeDef *can = cfg->can;
+	struct can_stm32_data *data = DEV_DATA(dev);
 	struct device *clock;
 	u32_t clock_rate;
 	u32_t prescaler;
@@ -301,10 +354,11 @@ int can_stm32_runtime_configure(struct device *dev, enum can_mode mode,
 		    (mode == CAN_SILENT_MODE)   ? CAN_BTR_SILM :
 						CAN_BTR_LBKM | CAN_BTR_SILM;
 
+	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 	ret = can_enter_init_mode(can);
 	if (ret) {
 		LOG_ERR("Failed to enter init mode");
-		return ret;
+		goto done;
 	}
 
 	can->BTR = reg_mode | sjw | ts1 | ts2 | (prescaler - 1U);
@@ -312,11 +366,14 @@ int can_stm32_runtime_configure(struct device *dev, enum can_mode mode,
 	ret = can_leave_init_mode(can);
 	if (ret) {
 		LOG_ERR("Failed to leave init mode");
-		return ret;
+		goto done;
 	}
 
 	LOG_DBG("Runtime configure of %s done", dev->config->name);
-	return 0;
+	ret = 0;
+done:
+	k_mutex_unlock(&data->inst_mutex);
+	return ret;
 }
 
 static int can_stm32_init(struct device *dev)
@@ -327,8 +384,7 @@ static int can_stm32_init(struct device *dev)
 	struct device *clock;
 	int ret;
 
-	k_mutex_init(&data->tx_mutex);
-	k_mutex_init(&data->set_filter_mutex);
+	k_mutex_init(&data->inst_mutex);
 	k_sem_init(&data->tx_int_sem, 0, 1);
 	k_sem_init(&data->mb0.tx_int_sem, 0, 1);
 	k_sem_init(&data->mb1.tx_int_sem, 0, 1);
@@ -336,6 +392,7 @@ static int can_stm32_init(struct device *dev)
 	data->mb0.tx_callback = NULL;
 	data->mb1.tx_callback = NULL;
 	data->mb2.tx_callback = NULL;
+	data->state_change_isr = NULL;
 
 	data->filter_usage = (1ULL << CAN_MAX_NUMBER_OF_FILTERS) - 1ULL;
 	(void)memset(data->rx_cb, 0, sizeof(data->rx_cb));
@@ -369,6 +426,9 @@ static int can_stm32_init(struct device *dev)
 #ifdef CONFIG_CAN_RX_TIMESTAMP
 	can->MCR |= CAN_MCR_TTCM;
 #endif
+#ifdef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
+	can->MCR |= CAN_MCR_ABOM;
+#endif
 
 	ret = can_stm32_runtime_configure(dev, CAN_NORMAL_MODE, 0);
 	if (ret) {
@@ -384,6 +444,88 @@ static int can_stm32_init(struct device *dev)
 	return 0;
 }
 
+static void can_stm32_register_state_change_isr(struct device *dev,
+						can_state_change_isr_t isr)
+{
+	struct can_stm32_data *data = DEV_DATA(dev);
+	const struct can_stm32_config *cfg = DEV_CFG(dev);
+	CAN_TypeDef *can = cfg->can;
+
+	data->state_change_isr = isr;
+
+	if (isr == NULL) {
+		can->IER &= ~CAN_IER_EPVIE;
+	} else {
+		can->IER |= CAN_IER_EPVIE;
+	}
+}
+
+static enum can_state can_stm32_get_state(struct device *dev,
+					  struct can_bus_err_cnt *err_cnt)
+{
+	const struct can_stm32_config *cfg = DEV_CFG(dev);
+	CAN_TypeDef *can = cfg->can;
+
+	if (err_cnt) {
+		err_cnt->tx_err_cnt =
+			((can->ESR & CAN_ESR_TEC) >> CAN_ESR_TEC_Pos);
+		err_cnt->rx_err_cnt =
+			((can->ESR & CAN_ESR_REC) >> CAN_ESR_REC_Pos);
+	}
+
+	if (can->ESR & CAN_ESR_BOFF) {
+		return CAN_BUS_OFF;
+	}
+
+	if (can->ESR & CAN_ESR_EPVF) {
+		return CAN_ERROR_PASSIVE;
+	}
+
+	return CAN_ERROR_ACTIVE;
+
+}
+
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
+int can_stm32_recover(struct device *dev, s32_t timeout)
+{
+	const struct can_stm32_config *cfg = DEV_CFG(dev);
+	struct can_stm32_data *data = DEV_DATA(dev);
+	CAN_TypeDef *can = cfg->can;
+	int ret = CAN_TIMEOUT;
+	u32_t start_time;
+
+	if (!(can->ESR & CAN_ESR_BOFF)) {
+		return 0;
+	}
+
+	if (k_mutex_lock(&data->inst_mutex, K_FOREVER)) {
+		return CAN_TIMEOUT;
+	}
+
+	ret = can_enter_init_mode(can);
+	if (ret) {
+		goto done;
+	}
+
+	can_leave_init_mode(can);
+
+	start_time = k_cycle_get_32();
+
+	while (can->ESR & CAN_ESR_BOFF) {
+		if (k_cycle_get_32() - start_time >= CAN_BOFF_RECOVER_TIMEOUT) {
+			goto done;
+		}
+	}
+
+	ret = 0;
+
+done:
+	k_mutex_unlock(&data->inst_mutex);
+	return ret;
+}
+#endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
+
+
 int can_stm32_send(struct device *dev, const struct zcan_frame *msg,
 		   s32_t timeout, can_tx_callback_t callback, void *callback_arg)
 {
@@ -392,7 +534,6 @@ int can_stm32_send(struct device *dev, const struct zcan_frame *msg,
 	CAN_TypeDef *can = cfg->can;
 	u32_t transmit_status_register = can->TSR;
 	CAN_TxMailBox_TypeDef *mailbox = NULL;
-	struct k_mutex *tx_mutex = &data->tx_mutex;
 	struct can_mailbox *mb = NULL;
 
 	LOG_DBG("Sending %d bytes on %s. "
@@ -413,16 +554,16 @@ int can_stm32_send(struct device *dev, const struct zcan_frame *msg,
 		return CAN_TX_BUS_OFF;
 	}
 
-	k_mutex_lock(tx_mutex, K_FOREVER);
+	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 	while (!(transmit_status_register & CAN_TSR_TME)) {
-		k_mutex_unlock(tx_mutex);
+		k_mutex_unlock(&data->inst_mutex);
 		LOG_DBG("Transmit buffer full. Wait with timeout (%dms)",
 			    timeout);
 		if (k_sem_take(&data->tx_int_sem, timeout)) {
 			return CAN_TIMEOUT;
 		}
 
-		k_mutex_lock(tx_mutex, K_FOREVER);
+		k_mutex_lock(&data->inst_mutex, K_FOREVER);
 		transmit_status_register = can->TSR;
 	}
 
@@ -465,7 +606,7 @@ int can_stm32_send(struct device *dev, const struct zcan_frame *msg,
 	mailbox->TDHR = msg->data_32[1];
 
 	mailbox->TIR |= CAN_TI0R_TXRQ;
-	k_mutex_unlock(tx_mutex);
+	k_mutex_unlock(&data->inst_mutex);
 
 	if (callback == NULL) {
 		k_sem_take(&mb->tx_int_sem, K_FOREVER);
@@ -817,9 +958,9 @@ int can_stm32_attach_isr(struct device *dev, can_rx_callback_t isr,
 	struct can_stm32_data *data = DEV_DATA(dev);
 	int filter_nr;
 
-	k_mutex_lock(&data->set_filter_mutex, K_FOREVER);
+	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 	filter_nr = can_stm32_attach(dev, isr, cb_arg, filter);
-	k_mutex_unlock(&data->set_filter_mutex);
+	k_mutex_unlock(&data->inst_mutex);
 	return filter_nr;
 }
 
@@ -838,7 +979,7 @@ void can_stm32_detach(struct device *dev, int filter_nr)
 
 	__ASSERT_NO_MSG(filter_nr >= 0 && filter_nr < CAN_MAX_NUMBER_OF_FILTERS);
 
-	k_mutex_lock(&data->set_filter_mutex, K_FOREVER);
+	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 
 	bank_nr = filter_nr / 4;
 	bank_bit = (1U << bank_nr);
@@ -870,14 +1011,19 @@ void can_stm32_detach(struct device *dev, int filter_nr)
 	data->rx_cb[filter_index] = NULL;
 	data->cb_arg[filter_index] = NULL;
 
-	k_mutex_unlock(&data->set_filter_mutex);
+	k_mutex_unlock(&data->inst_mutex);
 }
 
 static const struct can_driver_api can_api_funcs = {
 	.configure = can_stm32_runtime_configure,
 	.send = can_stm32_send,
 	.attach_isr = can_stm32_attach_isr,
-	.detach = can_stm32_detach
+	.detach = can_stm32_detach,
+	.get_state = can_stm32_get_state,
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
+	.recover = can_stm32_recover,
+#endif
+	.register_state_change_isr = can_stm32_register_state_change_isr
 };
 
 #ifdef CONFIG_CAN_1
@@ -921,7 +1067,7 @@ static void config_can_1_irq(CAN_TypeDef *can)
 	irq_enable(DT_CAN_1_IRQ_TX);
 
 	IRQ_CONNECT(DT_CAN_1_IRQ_SCE, DT_CAN_1_IRQ_PRIORITY,
-		    can_stm32_tx_isr, DEVICE_GET(can_stm32_1), 0);
+		    can_stm32_state_change_isr, DEVICE_GET(can_stm32_1), 0);
 	irq_enable(DT_CAN_1_IRQ_SCE);
 #endif
 	can->IER |= CAN_IER_TMEIE | CAN_IER_ERRIE | CAN_IER_FMPIE0 |

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -56,8 +56,7 @@ enum can_filter_type {
 };
 
 struct can_stm32_data {
-	struct k_mutex tx_mutex;
-	struct k_mutex set_filter_mutex;
+	struct k_mutex inst_mutex;
 	struct k_sem tx_int_sem;
 	struct can_mailbox mb0;
 	struct can_mailbox mb1;
@@ -65,6 +64,7 @@ struct can_stm32_data {
 	u64_t filter_usage;
 	can_rx_callback_t rx_cb[CONFIG_CAN_MAX_FILTER];
 	void *cb_arg[CONFIG_CAN_MAX_FILTER];
+	can_state_change_isr_t state_change_isr;
 };
 
 struct can_stm32_config {

--- a/samples/drivers/CAN/src/main.c
+++ b/samples/drivers/CAN/src/main.c
@@ -14,6 +14,8 @@
 
 #define RX_THREAD_STACK_SIZE 512
 #define RX_THREAD_PRIORITY 2
+#define STATE_POLL_THREAD_STACK_SIZE 512
+#define STATE_POLL_THREAD_PRIORITY 2
 #define LED_MSG_ID 0x10
 #define COUNTER_MSG_ID 0x12345
 #define SET_LED 1
@@ -21,9 +23,16 @@
 #define SLEEP_TIME K_MSEC(250)
 
 K_THREAD_STACK_DEFINE(rx_thread_stack, RX_THREAD_STACK_SIZE);
+K_THREAD_STACK_DEFINE(poll_state_stack, STATE_POLL_THREAD_STACK_SIZE);
+
+struct device *can_dev;
 
 struct k_thread rx_thread_data;
+struct k_thread poll_state_thread_data;
 struct zcan_work rx_work;
+struct k_work state_change_work;
+enum can_state current_state;
+struct can_bus_err_cnt current_err_cnt;
 
 CAN_DEFINE_MSGQ(counter_msgq, 2);
 
@@ -37,10 +46,11 @@ void tx_irq_callback(u32_t error_flags, void *arg)
 	}
 }
 
-void rx_thread(void *can_dev_param, void *arg1, void *arg2)
+void rx_thread(void *arg1, void *arg2, void *arg3)
 {
 	ARG_UNUSED(arg1);
 	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
 	const struct zcan_filter filter = {
 		.id_type = CAN_EXTENDED_IDENTIFIER,
 		.rtr = CAN_DATAFRAME,
@@ -48,7 +58,6 @@ void rx_thread(void *can_dev_param, void *arg1, void *arg2)
 		.rtr_mask = 1,
 		.ext_id_mask = CAN_EXT_ID_MASK
 	};
-	struct device *can_dev = can_dev_param;
 	struct zcan_frame msg;
 	int filter_id;
 
@@ -92,6 +101,73 @@ void change_led(struct zcan_frame *msg, void *led_dev_param)
 #endif
 }
 
+char *state_to_str(enum can_state state)
+{
+	switch (state) {
+	case CAN_ERROR_ACTIVE:
+		return "error-active";
+	case CAN_ERROR_PASSIVE:
+		return "error-passive";
+	case CAN_BUS_OFF:
+		return "bus-off";
+	default:
+		return "unknown";
+	}
+}
+
+void poll_state_thread(void *unused1, void *unused2, void *unused3)
+{
+	struct can_bus_err_cnt err_cnt = {0, 0};
+	struct can_bus_err_cnt err_cnt_prev = {0, 0};
+	enum can_state state_prev = CAN_ERROR_ACTIVE;
+	enum can_state state;
+
+	while (1) {
+		state = can_get_state(can_dev, &err_cnt);
+		if (err_cnt.tx_err_cnt != err_cnt_prev.tx_err_cnt ||
+		    err_cnt.rx_err_cnt != err_cnt_prev.rx_err_cnt ||
+		    state_prev != state) {
+
+			err_cnt_prev.tx_err_cnt = err_cnt.tx_err_cnt;
+			err_cnt_prev.rx_err_cnt = err_cnt.rx_err_cnt;
+			state_prev = state;
+			printk("state: %s\n"
+			       "rx error count: %d\n"
+			       "tx error count: %d\n",
+			       state_to_str(state),
+			       err_cnt.rx_err_cnt, err_cnt.tx_err_cnt);
+		} else {
+			k_sleep(K_MSEC(100));
+		}
+	}
+}
+
+void state_change_work_handler(struct k_work *work)
+{
+	printk("State Change ISR\nstate: %s\n"
+	       "rx error count: %d\n"
+	       "tx error count: %d\n",
+		state_to_str(current_state),
+		current_err_cnt.rx_err_cnt, current_err_cnt.tx_err_cnt);
+
+#ifndef CONFIG_CAN_AUTO_BOFF_RECOVERY
+	if (current_state == CAN_BUS_OFF) {
+		printk("Recover from bus-off\n");
+
+		if (can_recover(can_dev, K_MSEC(100) != 0)) {
+			printk("Recovery timed out\n");
+		}
+	}
+#endif /* CONFIG_CAN_AUTO_BOFF_RECOVERY */
+}
+
+void state_change_isr(enum can_state state, struct can_bus_err_cnt err_cnt)
+{
+	current_state = state;
+	current_err_cnt = err_cnt;
+	k_work_submit(&state_change_work);
+}
+
 void main(void)
 {
 	const struct zcan_filter change_led_filter = {
@@ -116,8 +192,7 @@ void main(void)
 	u8_t toggle = 1;
 	u16_t counter = 0;
 	struct device *led_gpio_dev = NULL;
-	struct device *can_dev;
-	k_tid_t rx_tid;
+	k_tid_t rx_tid, get_state_tid;
 	int ret;
 
 	/* Usually the CAN device is either called CAN_0 or CAN_1, depending
@@ -151,6 +226,8 @@ void main(void)
 	}
 #endif
 
+	k_work_init(&state_change_work, state_change_work_handler);
+
 	ret = can_attach_workq(can_dev, &k_sys_work_q, &rx_work, change_led,
 			       led_gpio_dev, &change_led_filter);
 	if (ret == CAN_NO_FREE_FILTER) {
@@ -162,11 +239,24 @@ void main(void)
 
 	rx_tid = k_thread_create(&rx_thread_data, rx_thread_stack,
 				 K_THREAD_STACK_SIZEOF(rx_thread_stack),
-				 rx_thread, can_dev, NULL, NULL,
+				 rx_thread, NULL, NULL, NULL,
 				 RX_THREAD_PRIORITY, 0, K_NO_WAIT);
 	if (!rx_tid) {
 		printk("ERROR spawning rx thread\n");
 	}
+
+
+	get_state_tid = k_thread_create(&poll_state_thread_data,
+					poll_state_stack,
+					K_THREAD_STACK_SIZEOF(poll_state_stack),
+					poll_state_thread, NULL, NULL, NULL,
+					STATE_POLL_THREAD_PRIORITY, 0,
+					K_NO_WAIT);
+	if (!get_state_tid) {
+		printk("ERROR spawning poll_state_thread\n");
+	}
+
+	can_register_state_change_isr(can_dev, state_change_isr);
 
 	printk("Finished init.\n");
 


### PR DESCRIPTION
This PR adds three new functions to the actual CAN API.
 - can_get_state
 - can_register_state_change_isr
 - can_recover

`can_get_state` can be used to get the actual RX-, TX-error-count and state.
`can_register_state_change_isr` registers an ISR callback when the bus-state changes.
`can_recover` can be used to recover from the bus-off state. This function is only available when automatic recovery is turned off.