### PR TITLE
drivers: CAN: MCP2515: Move oscillator frequency definition to devce-tree

### DIFF
--- a/boards/shields/link_board_can/link_board_can.overlay
+++ b/boards/shields/link_board_can/link_board_can.overlay
@@ -13,13 +13,12 @@
 
 	mcp2515@0 {
 		compatible = "microchip,mcp2515";
-		spi-port-name = "SPI_1";
 		spi-max-frequency = <1000000>;
 		int-gpios = <&gpio1 7 GPIO_INT_ACTIVE_LOW>;
 		status = "okay";
 		label = "CAN_1";
 		reg = <0>;
-		bus-speed = <250000>;
+		bus-speed = <125000>;
 		sjw = <1>;
 		prop-seg = <2>;
 		phase-seg1 = <7>;

--- a/boards/shields/link_board_can/link_board_can.overlay
+++ b/boards/shields/link_board_can/link_board_can.overlay
@@ -19,6 +19,7 @@
 		label = "CAN_1";
 		reg = <0>;
 		bus-speed = <125000>;
+		osc-freq = <24000000>;
 		sjw = <1>;
 		prop-seg = <2>;
 		phase-seg1 = <7>;

--- a/drivers/can/Kconfig.mcp2515
+++ b/drivers/can/Kconfig.mcp2515
@@ -14,12 +14,6 @@ config CAN_MCP2515
 
 if CAN_MCP2515
 
-config CAN_MCP2515_OSC_FREQ
-	int "Oscillator frequency"
-	default 8000000
-	help
-	  Specify the frequency of the oscillator connected to the MCP2515.
-
 config CAN_MCP2515_INT_THREAD_STACK_SIZE
 	int "Stack size for interrupt handler"
 	default 512

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -193,8 +193,7 @@ static int mcp2515_configure(struct device *dev, enum can_mode mode,
 				dev_cfg->tq_bs2;
 
 	/* CNF1; SJW<7:6> | BRP<5:0> */
-	u8_t brp =
-		(CONFIG_CAN_MCP2515_OSC_FREQ / (bit_length * bitrate * 2)) - 1;
+	u8_t brp = (dev_cfg->osc_freq / (bit_length * bitrate * 2)) - 1;
 	const u8_t sjw = (dev_cfg->tq_sjw - 1) << 6;
 	u8_t cnf1 = sjw | brp;
 
@@ -238,12 +237,12 @@ static int mcp2515_configure(struct device *dev, enum can_mode mode,
 		 "PROP + BS1 >= BS2");
 	__ASSERT(dev_cfg->tq_bs2 > dev_cfg->tq_sjw, "BS2 > SJW");
 
-	if (CONFIG_CAN_MCP2515_OSC_FREQ % (bit_length * bitrate * 2)) {
+	if (dev_cfg->osc_freq % (bit_length * bitrate * 2)) {
 		LOG_ERR("Prescaler is not a natural number! "
 			"prescaler = osc_rate / ((PROP + SEG1 + SEG2 + 1) "
 			"* bitrate * 2)\n"
 			"prescaler = %d / ((%d + %d + %d + 1) * %d * 2)",
-			CONFIG_CAN_MCP2515_OSC_FREQ, dev_cfg->tq_prop,
+			dev_cfg->osc_freq, dev_cfg->tq_prop,
 			dev_cfg->tq_bs1, dev_cfg->tq_bs2, bitrate);
 	}
 
@@ -623,6 +622,7 @@ static const struct mcp2515_config mcp2515_config_1 = {
 	.tq_bs1 = DT_INST_0_MICROCHIP_MCP2515_PHASE_SEG1,
 	.tq_bs2 = DT_INST_0_MICROCHIP_MCP2515_PHASE_SEG2,
 	.bus_speed = DT_INST_0_MICROCHIP_MCP2515_BUS_SPEED,
+	.osc_freq = DT_INST_0_MICROCHIP_MCP2515_OSC_FREQ
 };
 
 DEVICE_AND_API_INIT(can_mcp2515_1, DT_INST_0_MICROCHIP_MCP2515_LABEL, &mcp2515_init,

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -72,6 +72,7 @@ struct mcp2515_config {
 	u8_t tq_bs1;
 	u8_t tq_bs2;
 	u32_t bus_speed;
+	u32_t osc_freq;
 };
 
 /* MCP2515 Opcodes */

--- a/dts/bindings/can/microchip,mcp2515.yaml
+++ b/dts/bindings/can/microchip,mcp2515.yaml
@@ -11,6 +11,10 @@ compatible: "microchip,mcp2515"
 include: [spi-device.yaml, can-controller.yaml]
 
 properties:
+    osc-freq:
+      type: int
+      required: true
+      description: Frequency of the external oscillator
     int-gpios:
       type: phandle-array
       required: true

--- a/samples/drivers/CAN/mcp2515-dts.overlay
+++ b/samples/drivers/CAN/mcp2515-dts.overlay
@@ -9,13 +9,13 @@
 	cs-gpios = <&gpioa 4 0>;
 	mcp2515@0 {
 		compatible = "microchip,mcp2515";
-		spi-port-name = "SPI_1";
 		spi-max-frequency = <1000000>;
 		int-gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
 		status = "okay";
 		label = "CAN_1";
 		reg = <0>;
-		bus-speed = <250000>;
+		osc-freq = <8000000>;
+		bus-speed = <125000>;
 		sjw = <1>;
 		prop-seg = <2>;
 		phase-seg1 = <7>;


### PR DESCRIPTION
This PR moves the definition of the external oscillator frequency from Kconfig to device-tree.
It makes sense because it is a property of the board.