### PR TITLE
Bluetooth: controller: Fix ticker previous slot value

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -1109,8 +1109,15 @@ static inline void ticker_job_node_manage(struct ticker_instance *instance,
 		ticker->req = ticker->ack;
 
 		if (instance->ticker_id_slot_previous == user_op->id) {
+			u32_t ticks_now = cntr_cnt_get();
+			u32_t ticks_used;
+
 			instance->ticker_id_slot_previous = TICKER_NULL;
-			instance->ticks_slot_previous = 0U;
+			ticks_used = ticks_elapsed +
+				ticker_ticks_diff_get(ticks_now,
+						      instance->ticks_current);
+			instance->ticks_slot_previous =	MIN(ticker->ticks_slot,
+							    ticks_used);
 		}
 	}
 


### PR DESCRIPTION
Fix ticker previous slot value with elapsed ticks value from
the time stopped ticker has expired. When a ticker is
stopped, if it was in its reserved time space, then the
currently occupied slot (was set to 0) should be the amount
of time that has elapsed in the expired and stopped ticker's
reserved time space and beyond until the stop.
This is required to ensure that any other new ticker does
not get scheduled over the stopped ticker's reserved time
space.

Fixes #19515.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>