### PR TITLE
Collect RX and TX timing statistics

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -97,10 +97,21 @@ struct net_pkt {
 	struct net_if *orig_iface; /* Original network interface */
 #endif
 
+	/* We do not support combination of TXTIME and TXTIME_STATS as the
+	 * same variable is shared in net_pkt.h
+	 */
+#if defined(CONFIG_NET_PKT_TXTIME) && defined(CONFIG_NET_PKT_TXTIME_STATS)
+#error \
+"Cannot define both CONFIG_NET_PKT_TXTIME and CONFIG_NET_PKT_TXTIME_STATS"
+#endif
+
 #if defined(CONFIG_NET_PKT_TIMESTAMP) || defined(CONFIG_NET_PKT_TXTIME) || \
-					defined(CONFIG_NET_PKT_RXTIME_STATS)
+				defined(CONFIG_NET_PKT_RXTIME_STATS) || \
+				defined(CONFIG_NET_PKT_TXTIME_STATS)
 	union {
-#if defined(CONFIG_NET_PKT_TIMESTAMP) || defined(CONFIG_NET_PKT_RXTIME_STATS)
+#if defined(CONFIG_NET_PKT_TIMESTAMP) || \
+				defined(CONFIG_NET_PKT_RXTIME_STATS) ||	\
+				defined(CONFIG_NET_PKT_TXTIME_STATS)
 		/** Timestamp if available. */
 		struct net_ptp_time timestamp;
 #endif /* CONFIG_NET_PKT_TIMESTAMP */

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -97,9 +97,10 @@ struct net_pkt {
 	struct net_if *orig_iface; /* Original network interface */
 #endif
 
-#if defined(CONFIG_NET_PKT_TIMESTAMP) || defined(CONFIG_NET_PKT_TXTIME)
+#if defined(CONFIG_NET_PKT_TIMESTAMP) || defined(CONFIG_NET_PKT_TXTIME) || \
+					defined(CONFIG_NET_PKT_RXTIME_STATS)
 	union {
-#if defined(CONFIG_NET_PKT_TIMESTAMP)
+#if defined(CONFIG_NET_PKT_TIMESTAMP) || defined(CONFIG_NET_PKT_RXTIME_STATS)
 		/** Timestamp if available. */
 		struct net_ptp_time timestamp;
 #endif /* CONFIG_NET_PKT_TIMESTAMP */

--- a/include/net/net_stats.h
+++ b/include/net/net_stats.h
@@ -203,11 +203,11 @@ struct net_stats_ipv6_mld {
 };
 
 /**
- * @brief Network packet transfer times
+ * @brief Network packet transfer times for calculating average TX time
  */
 struct net_stats_tx_time {
-	u64_t time_sum;
-	net_stats_t time_count;
+	u64_t sum;
+	net_stats_t count;
 };
 
 /**
@@ -223,10 +223,10 @@ struct net_stats_rx_time {
  */
 struct net_stats_tc {
 	struct {
+		struct net_stats_tx_time tx_time;
 		net_stats_t pkts;
 		net_stats_t bytes;
 		u8_t priority;
-		struct net_stats_tx_time tx_time;
 	} sent[NET_TC_TX_COUNT];
 
 	struct {
@@ -293,7 +293,13 @@ struct net_stats {
 	struct net_stats_tc tc;
 #endif
 
-#if defined(CONFIG_NET_CONTEXT_TIMESTAMP)
+#if defined(CONFIG_NET_CONTEXT_TIMESTAMP) && \
+	defined(CONFIG_NET_PKT_TXTIME_STATS)
+#error \
+"Cannot define both CONFIG_NET_CONTEXT_TIMESTAMP and CONFIG_NET_PKT_TXTIME_STATS"
+#endif
+#if defined(CONFIG_NET_CONTEXT_TIMESTAMP) || \
+					defined(CONFIG_NET_PKT_TXTIME_STATS)
 	/** Network packet TX time statistics */
 	struct net_stats_tx_time tx_time;
 #endif

--- a/include/net/net_stats.h
+++ b/include/net/net_stats.h
@@ -211,6 +211,14 @@ struct net_stats_tx_time {
 };
 
 /**
+ * @brief Network packet receive times for calculating average RX time
+ */
+struct net_stats_rx_time {
+	u64_t sum;
+	net_stats_t count;
+};
+
+/**
  * @brief Traffic class statistics
  */
 struct net_stats_tc {
@@ -222,6 +230,7 @@ struct net_stats_tc {
 	} sent[NET_TC_TX_COUNT];
 
 	struct {
+		struct net_stats_rx_time rx_time;
 		net_stats_t pkts;
 		net_stats_t bytes;
 		u8_t priority;
@@ -287,6 +296,11 @@ struct net_stats {
 #if defined(CONFIG_NET_CONTEXT_TIMESTAMP)
 	/** Network packet TX time statistics */
 	struct net_stats_tx_time tx_time;
+#endif
+
+#if defined(CONFIG_NET_PKT_RXTIME_STATS)
+	/** Network packet RX time statistics */
+	struct net_stats_rx_time rx_time;
 #endif
 };
 

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -189,11 +189,19 @@ config NET_TC_MAPPING_SR_CLASS_B_ONLY
 endchoice
 
 config NET_TX_DEFAULT_PRIORITY
-	int "Default network packet priority if none have been set"
+	int "Default network TX packet priority if none have been set"
 	default 1
 	range 0 7
 	help
 	  What is the default network packet priority if user has not specified
+	  one. The value 0 means lowest priority and 7 is the highest.
+
+config NET_RX_DEFAULT_PRIORITY
+	int "Default network RX packet priority if none have been set"
+	default 0
+	range 0 7
+	help
+	  What is the default network RX packet priority if user has not set
 	  one. The value 0 means lowest priority and 7 is the highest.
 
 config NET_IP_ADDR_CHECK
@@ -639,6 +647,19 @@ config NET_PKT_TXTIME
 	  Enable network packet TX time support. This is needed for
 	  when the application wants to set the exact time when the network
 	  packet should be sent.
+
+config NET_PKT_RXTIME_STATS
+	bool "Enable network packet RX time statistics"
+	select NET_PKT_TIMESTAMP
+	select NET_STATISTICS
+	depends on (NET_UDP || NET_TCP)
+	help
+	  Enable network packet RX time statistics support. This is used to
+	  calculate how long on average it takes for a packet to travel from
+	  device driver to just before it is given to application. The RX
+	  timing information can then be seen in network interface statistics
+	  in net-shell.
+	  The RX statistics are only calculated for UDP and TCP packets.
 
 config NET_PROMISCUOUS_MODE
 	bool "Enable promiscuous mode support [EXPERIMENTAL]"

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -661,6 +661,23 @@ config NET_PKT_RXTIME_STATS
 	  in net-shell.
 	  The RX statistics are only calculated for UDP and TCP packets.
 
+config NET_PKT_TXTIME_STATS
+	bool "Enable network packet TX time statistics"
+	select NET_PKT_TIMESTAMP
+	select NET_STATISTICS
+	depends on (NET_UDP || NET_TCP) && !NET_PKT_TXTIME
+	help
+	  Enable network packet TX time statistics support. This is used to
+	  calculate how long on average it takes for a packet to travel from
+	  application to just before it is sent to network. The TX timing
+	  information can then be seen in network interface statistics in
+	  net-shell.
+	  The RX calculation is done only for UDP or TCP packets, but for TX
+	  we do not know the protocol so the TX packet timing is done for all
+	  network protocol packets.
+	  Note that CONFIG_NET_PKT_TXTIME cannot be set at the same time
+	  because net_pkt shares the time variable for statistics and TX time.
+
 config NET_PROMISCUOUS_MODE
 	bool "Enable promiscuous mode support [EXPERIMENTAL]"
 	select NET_MGMT

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -269,6 +269,31 @@ void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt)
 	net_tc_submit_to_tx_queue(tc, pkt);
 }
 
+void net_if_stats_reset(struct net_if *iface)
+{
+#if defined(CONFIG_NET_STATISTICS_PER_INTERFACE)
+	struct net_if *tmp;
+
+	for (tmp = __net_if_start; tmp != __net_if_end; tmp++) {
+		if (iface == tmp) {
+			memset(&iface->stats, 0, sizeof(iface->stats));
+			return;
+		}
+	}
+#endif
+}
+
+void net_if_stats_reset_all(void)
+{
+#if defined(CONFIG_NET_STATISTICS_PER_INTERFACE)
+	struct net_if *iface;
+
+	for (iface = __net_if_start; iface != __net_if_end; iface++) {
+		memset(&iface->stats, 0, sizeof(iface->stats));
+	}
+#endif
+}
+
 static inline void init_iface(struct net_if *iface)
 {
 	const struct net_if_api *api = net_if_get_device(iface)->driver_api;

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1193,13 +1193,14 @@ static struct net_pkt *pkt_alloc(struct k_mem_slab *slab, s32_t timeout)
 		net_pkt_set_priority(pkt, CONFIG_NET_RX_DEFAULT_PRIORITY);
 	}
 
-	if (IS_ENABLED(CONFIG_NET_PKT_RXTIME_STATS)) {
+	if (IS_ENABLED(CONFIG_NET_PKT_RXTIME_STATS) ||
+	    IS_ENABLED(CONFIG_NET_PKT_TXTIME_STATS)) {
 		struct net_ptp_time tp = {
 			/* Use the nanosecond field to temporarily
 			 * store the cycle count as it is a 32-bit
 			 * variable. The net_pkt timestamp field is used
 			 * to calculate how long it takes the packet to travel
-			 * from network device driver to the application.
+			 * between network device driver and application.
 			 */
 			.nanosecond = k_cycle_get_32(),
 		};

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -41,6 +41,8 @@
 extern void net_if_init(void);
 extern void net_if_post_init(void);
 extern void net_if_carrier_down(struct net_if *iface);
+extern void net_if_stats_reset(struct net_if *iface);
+extern void net_if_stats_reset_all(void);
 
 #if defined(CONFIG_NET_NATIVE) || defined(CONFIG_NET_OFFLOAD)
 extern void net_context_init(void);

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -88,6 +88,17 @@ char *net_sprint_addr(sa_family_t af, const void *addr);
 int net_context_get_timestamp(struct net_context *context,
 			      struct net_pkt *pkt,
 			      struct net_ptp_time *timestamp);
+#else
+static inline int net_context_get_timestamp(struct net_context *context,
+					    struct net_pkt *pkt,
+					    struct net_ptp_time *timestamp)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(timestamp);
+
+	return -ENOTSUP;
+}
 #endif
 
 #if defined(CONFIG_COAP)

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3462,7 +3462,11 @@ static int cmd_net_stats(const struct shell *shell, size_t argc, char *argv[])
 		return 0;
 	}
 
-	cmd_net_stats_iface(shell, argc, argv);
+	if (strcmp(argv[1], "reset") == 0) {
+		net_stats_reset(NULL);
+	} else {
+		cmd_net_stats_iface(shell, argc, argv);
+	}
 #else
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);

--- a/subsys/net/ip/net_stats.c
+++ b/subsys/net/ip/net_stats.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(net_stats, NET_LOG_LEVEL);
 #include <net/net_core.h>
 
 #include "net_stats.h"
+#include "net_private.h"
 
 /* Global network statistics.
  *
@@ -338,3 +339,14 @@ NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_STATS_GET_TCP,
 #endif
 
 #endif /* CONFIG_NET_STATISTICS_USER_API */
+
+void net_stats_reset(struct net_if *iface)
+{
+	if (iface) {
+		net_if_stats_reset(iface);
+		return;
+	}
+
+	net_if_stats_reset_all();
+	memset(&net_stats, 0, sizeof(net_stats));
+}

--- a/subsys/net/ip/net_stats.h
+++ b/subsys/net/ip/net_stats.h
@@ -475,4 +475,5 @@ void net_print_statistics(void);
 #define net_print_statistics()
 #endif
 
+void net_stats_reset(struct net_if *iface);
 #endif /* __NET_STATS_H__ */

--- a/subsys/net/ip/net_stats.h
+++ b/subsys/net/ip/net_stats.h
@@ -318,27 +318,21 @@ static inline void net_stats_update_ipv6_mld_drop(struct net_if *iface)
 #define net_stats_update_ipv6_mld_drop(iface)
 #endif /* CONFIG_NET_STATISTICS_MLD */
 
-#if defined(CONFIG_NET_CONTEXT_TIMESTAMP) && defined(CONFIG_NET_STATISTICS)
+#if (defined(CONFIG_NET_CONTEXT_TIMESTAMP) || \
+	defined(CONFIG_NET_PKT_TXTIME_STATS)) && defined(CONFIG_NET_STATISTICS)
 static inline void net_stats_update_tx_time(struct net_if *iface,
 					    u32_t start_time,
 					    u32_t end_time)
 {
-	u32_t diff = abs(end_time - start_time);
+	u32_t diff = end_time - start_time;
 
-	UPDATE_STAT(iface, stats.tx_time.time_sum +=
-		    SYS_CLOCK_HW_CYCLES_TO_NS64(diff) / 1000);
-	UPDATE_STAT(iface, stats.tx_time.time_count += 1);
+	UPDATE_STAT(iface, stats.tx_time.sum +=
+		    SYS_CLOCK_HW_CYCLES_TO_NS64(diff) / NSEC_PER_USEC);
+	UPDATE_STAT(iface, stats.tx_time.count += 1);
 }
 #else
-static inline void net_stats_update_tx_time(struct net_if *iface,
-					    u32_t start_time,
-					    u32_t end_time)
-{
-	ARG_UNUSED(iface);
-	ARG_UNUSED(start_time);
-	ARG_UNUSED(end_time);
-}
-#endif /* CONFIG_NET_CONTEXT_TIMESTAMP && STATISTICS */
+#define net_stats_update_tx_time(iface, start_time, end_time)
+#endif /* (TIMESTAMP || NET_PKT_TXTIME_STATS) && NET_STATISTICS */
 
 #if defined(CONFIG_NET_PKT_RXTIME_STATS) && defined(CONFIG_NET_STATISTICS)
 static inline void net_stats_update_rx_time(struct net_if *iface,
@@ -353,7 +347,7 @@ static inline void net_stats_update_rx_time(struct net_if *iface,
 }
 #else
 #define net_stats_update_rx_time(iface, start_time, end_time)
-#endif /* CONFIG_NET_CONTEXT_TIMESTAMP && STATISTICS */
+#endif /* NET_CONTEXT_TIMESTAMP && STATISTICS */
 
 #if (NET_TC_COUNT > 1) && defined(CONFIG_NET_STATISTICS) \
 	&& defined(CONFIG_NET_NATIVE)
@@ -374,33 +368,25 @@ static inline void net_stats_update_tc_sent_priority(struct net_if *iface,
 	UPDATE_STAT(iface, stats.tc.sent[tc].priority = priority);
 }
 
-#if defined(CONFIG_NET_CONTEXT_TIMESTAMP) && defined(CONFIG_NET_STATISTICS) \
-	&& defined(CONFIG_NET_NATIVE)
+#if (defined(CONFIG_NET_CONTEXT_TIMESTAMP) || \
+	defined(CONFIG_NET_PKT_TXTIME_STATS)) && \
+	defined(CONFIG_NET_STATISTICS) && defined(CONFIG_NET_NATIVE)
 static inline void net_stats_update_tc_tx_time(struct net_if *iface,
 					       u8_t tc,
 					       u32_t start_time,
 					       u32_t end_time)
 {
-	u32_t diff = abs(end_time - start_time);
+	u32_t diff = end_time - start_time;
 
-	UPDATE_STAT(iface, stats.tc.sent[tc].tx_time.time_sum +=
-		    SYS_CLOCK_HW_CYCLES_TO_NS64(diff) / 1000);
-	UPDATE_STAT(iface, stats.tc.sent[tc].tx_time.time_count += 1);
+	UPDATE_STAT(iface, stats.tc.sent[tc].tx_time.sum +=
+		    SYS_CLOCK_HW_CYCLES_TO_NS64(diff) / NSEC_PER_USEC);
+	UPDATE_STAT(iface, stats.tc.sent[tc].tx_time.count += 1);
 
 	net_stats_update_tx_time(iface, start_time, end_time);
 }
 #else
-static inline void net_stats_update_tc_tx_time(struct net_if *iface,
-					       u8_t tc,
-					       u32_t start_time,
-					       u32_t end_time)
-{
-	ARG_UNUSED(iface);
-	ARG_UNUSED(tc);
-	ARG_UNUSED(start_time);
-	ARG_UNUSED(end_time);
-}
-#endif /* CONFIG_NET_CONTEXT_TIMESTAMP && CONFIG_NET_STATISTICS */
+#define net_stats_update_tc_tx_time(iface, tc, start_time, end_time)
+#endif /* (NET_CONTEXT_TIMESTAMP || NET_PKT_TXTIME_STATS) && NET_STATISTICS */
 
 #if defined(CONFIG_NET_PKT_RXTIME_STATS) && defined(CONFIG_NET_STATISTICS) \
 	&& defined(CONFIG_NET_NATIVE)
@@ -445,8 +431,9 @@ static inline void net_stats_update_tc_recv_priority(struct net_if *iface,
 #define net_stats_update_tc_recv_bytes(iface, tc, bytes)
 #define net_stats_update_tc_recv_priority(iface, tc, priority)
 
-#if defined(CONFIG_NET_CONTEXT_TIMESTAMP) && defined(CONFIG_NET_STATISTICS) \
-	&& defined(CONFIG_NET_NATIVE)
+#if (defined(CONFIG_NET_CONTEXT_TIMESTAMP) || \
+	defined(CONFIG_NET_PKT_TXTIME_STATS)) && \
+	defined(CONFIG_NET_STATISTICS) && defined(CONFIG_NET_NATIVE)
 static inline void net_stats_update_tc_tx_time(struct net_if *iface,
 					       u8_t pkt_priority,
 					       u32_t start_time,
@@ -457,17 +444,8 @@ static inline void net_stats_update_tc_tx_time(struct net_if *iface,
 	net_stats_update_tx_time(iface, start_time, end_time);
 }
 #else
-static inline void net_stats_update_tc_tx_time(struct net_if *iface,
-					       u8_t pkt_priority,
-					       u32_t start_time,
-					       u32_t end_time)
-{
-	ARG_UNUSED(iface);
-	ARG_UNUSED(pkt_priority);
-	ARG_UNUSED(start_time);
-	ARG_UNUSED(end_time);
-}
-#endif /* CONFIG_NET_CONTEXT_TIMESTAMP && CONFIG_NET_STATISTICS */
+#define net_stats_update_tc_tx_time(iface, priority, start_time, end_time)
+#endif /* (NET_CONTEXT_TIMESTAMP || NET_PKT_TXTIME_STATS) && NET_STATISTICS */
 
 #if defined(CONFIG_NET_PKT_RXTIME_STATS) && defined(CONFIG_NET_STATISTICS) \
 	&& defined(CONFIG_NET_NATIVE)

--- a/subsys/net/ip/net_stats.h
+++ b/subsys/net/ip/net_stats.h
@@ -340,6 +340,21 @@ static inline void net_stats_update_tx_time(struct net_if *iface,
 }
 #endif /* CONFIG_NET_CONTEXT_TIMESTAMP && STATISTICS */
 
+#if defined(CONFIG_NET_PKT_RXTIME_STATS) && defined(CONFIG_NET_STATISTICS)
+static inline void net_stats_update_rx_time(struct net_if *iface,
+					    u32_t start_time,
+					    u32_t end_time)
+{
+	u32_t diff = end_time - start_time;
+
+	UPDATE_STAT(iface, stats.rx_time.sum +=
+		    SYS_CLOCK_HW_CYCLES_TO_NS64(diff) / NSEC_PER_USEC);
+	UPDATE_STAT(iface, stats.rx_time.count += 1);
+}
+#else
+#define net_stats_update_rx_time(iface, start_time, end_time)
+#endif /* CONFIG_NET_CONTEXT_TIMESTAMP && STATISTICS */
+
 #if (NET_TC_COUNT > 1) && defined(CONFIG_NET_STATISTICS) \
 	&& defined(CONFIG_NET_NATIVE)
 static inline void net_stats_update_tc_sent_pkt(struct net_if *iface, u8_t tc)
@@ -386,6 +401,25 @@ static inline void net_stats_update_tc_tx_time(struct net_if *iface,
 	ARG_UNUSED(end_time);
 }
 #endif /* CONFIG_NET_CONTEXT_TIMESTAMP && CONFIG_NET_STATISTICS */
+
+#if defined(CONFIG_NET_PKT_RXTIME_STATS) && defined(CONFIG_NET_STATISTICS) \
+	&& defined(CONFIG_NET_NATIVE)
+static inline void net_stats_update_tc_rx_time(struct net_if *iface,
+					       u8_t tc,
+					       u32_t start_time,
+					       u32_t end_time)
+{
+	u32_t diff = end_time - start_time;
+
+	UPDATE_STAT(iface, stats.tc.recv[tc].rx_time.sum +=
+		    SYS_CLOCK_HW_CYCLES_TO_NS64(diff) / NSEC_PER_USEC);
+	UPDATE_STAT(iface, stats.tc.recv[tc].rx_time.count += 1);
+
+	net_stats_update_rx_time(iface, start_time, end_time);
+}
+#else
+#define net_stats_update_tc_rx_time(iface, tc, start_time, end_time)
+#endif /* NET_PKT_RXTIME_STATS && NET_STATISTICS */
 
 static inline void net_stats_update_tc_recv_pkt(struct net_if *iface, u8_t tc)
 {
@@ -434,6 +468,21 @@ static inline void net_stats_update_tc_tx_time(struct net_if *iface,
 	ARG_UNUSED(end_time);
 }
 #endif /* CONFIG_NET_CONTEXT_TIMESTAMP && CONFIG_NET_STATISTICS */
+
+#if defined(CONFIG_NET_PKT_RXTIME_STATS) && defined(CONFIG_NET_STATISTICS) \
+	&& defined(CONFIG_NET_NATIVE)
+static inline void net_stats_update_tc_rx_time(struct net_if *iface,
+					       u8_t pkt_priority,
+					       u32_t start_time,
+					       u32_t end_time)
+{
+	ARG_UNUSED(pkt_priority);
+
+	net_stats_update_rx_time(iface, start_time, end_time);
+}
+#else
+#define net_stats_update_tc_rx_time(iface, priority, start_time, end_time)
+#endif /* NET_PKT_RXTIME_STATS && NET_STATISTICS */
 #endif /* NET_TC_COUNT > 1 */
 
 #if defined(CONFIG_NET_STATISTICS_PERIODIC_OUTPUT) \

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <sys/fdtable.h>
 #include <sys/math_extras.h>
 #include <net/socks.h>
+#include "../../ip/net_stats.h"
 
 #include "sockets_internal.h"
 
@@ -765,6 +766,11 @@ static inline ssize_t zsock_recv_dgram(struct net_context *ctx,
 		return -1;
 	}
 
+	net_stats_update_tc_rx_time(net_pkt_iface(pkt),
+				    net_pkt_priority(pkt),
+				    net_pkt_timestamp(pkt)->nanosecond,
+				    k_cycle_get_32());
+
 	if (!(flags & ZSOCK_MSG_PEEK)) {
 		net_pkt_unref(pkt);
 	} else {
@@ -845,6 +851,12 @@ static inline ssize_t zsock_recv_stream(struct net_context *ctx,
 				if (net_pkt_eof(pkt)) {
 					sock_set_eof(ctx);
 				}
+
+				net_stats_update_tc_rx_time(
+					net_pkt_iface(pkt),
+					net_pkt_priority(pkt),
+					net_pkt_timestamp(pkt)->nanosecond,
+					k_cycle_get_32());
 
 				net_pkt_unref(pkt);
 			}


### PR DESCRIPTION
Calculate how long it takes for RX packet from network driver to application. Same for TX packet from application to network driver. Show this information in net-shell for `net stats` command.
Application needs to enable `CONFIG_NET_PKT_RXTIME_STATS=y` and `CONFIG_NET_PKT_TXTIME_STATS=y` to get this information.

If we go with this route, then I will probably remove `CONFIG_NET_CONTEXT_TIMESTAMP` support as it is conflicting with the `CONFIG_NET_PKT_TXTIME_STATS` (the code looks a bit ugly because of this).
