### PR TITLE
toolchain: Fix for off-tree toolchains

### DIFF
--- a/include/toolchain.h
+++ b/include/toolchain.h
@@ -37,6 +37,11 @@
 #include <toolchain/xcc.h>
 #elif defined(__GNUC__) || (defined(_LINKER) && defined(__GCC_LINKER_CMD__))
 #include <toolchain/gcc.h>
+#else
+/* This include line exists for off-tree definitions of compilers,
+ * and therefore this header is not meant to exist in-tree
+ */
+#include <toolchain/other.h>
 #endif
 
 /*


### PR DESCRIPTION
Revert 1b5e6072ca8324432aa920f47d8f7931232fb8bc which
broke things for off-tree toolchains,
and add a note about the reason for that line so it is not
removed again.

That include line is, logically, not there for the compilers which
are supported in the tree, but for other compilers which would
be supported thru off-tree headers and cmake files.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>