### PR TITLE
Refactor and fix Cortex-R device tree

### DIFF
--- a/dts/arm/armv7-r.dtsi
+++ b/dts/arm/armv7-r.dtsi
@@ -3,27 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 #include "skeleton.dtsi"
 
 / {
-	cpus {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		cpu@0 {
-			device_type = "cpu";
-			compatible = "Cortex-R";
-			reg = <0>;
-		};
-
-		core_intc: core_intc@0 {
-			compatible = "armv7-r,core-intc";
-			reg = <0x00 0x4>;
-			interrupt-controller;
-			#interrupt-cells = <2>;
-		};
-	};
-
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -31,4 +14,3 @@
 		ranges;
 	};
 };
-

--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -2,7 +2,6 @@
  * Copyright (c) 2019 Lexmark International, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
- *
  */
 
 #include <mem.h>
@@ -10,6 +9,17 @@
 #include <dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-r4";
+			reg = <0>;
+		};
+	};
+
 	soc {
 		interrupt-parent = <&gic>;
 
@@ -19,7 +29,6 @@
 					<0xf9020000 0x100>;
 			interrupt-controller;
 			#interrupt-cells = <3>;
-			interrupt-parent = <&core_intc>;
 			label = "GIC";
 			status = "okay";
 		};

--- a/dts/bindings/cpu/arm,cortex-r4.yaml
+++ b/dts/bindings/cpu/arm,cortex-r4.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
+# SPDX-License-Identifier: Apache-2.0
+
+title: ARM Cortex-R4 CPU
+
+description: >
+    This is a representation of ARM Cortex-R4 CPU.
+
+compatible: "arm,cortex-r4"
+
+include: cpu.yaml

--- a/dts/bindings/cpu/arm,cortex-r4f.yaml
+++ b/dts/bindings/cpu/arm,cortex-r4f.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
+# SPDX-License-Identifier: Apache-2.0
+
+title: ARM Cortex-R4F CPU
+
+description: >
+    This is a representation of ARM Cortex-R4F CPU.
+
+compatible: "arm,cortex-r4f"
+
+include: cpu.yaml

--- a/dts/bindings/cpu/arm,cortex-r5.yaml
+++ b/dts/bindings/cpu/arm,cortex-r5.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
+# SPDX-License-Identifier: Apache-2.0
+
+title: ARM Cortex-R5 CPU
+
+description: >
+    This is a representation of ARM Cortex-R5 CPU.
+
+compatible: "arm,cortex-r5"
+
+include: cpu.yaml

--- a/dts/bindings/cpu/arm,cortex-r5f.yaml
+++ b/dts/bindings/cpu/arm,cortex-r5f.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
+# SPDX-License-Identifier: Apache-2.0
+
+title: ARM Cortex-R5F CPU
+
+description: >
+    This is a representation of ARM Cortex-R5F CPU.
+
+compatible: "arm,cortex-r5f"
+
+include: cpu.yaml


### PR DESCRIPTION
Refactor and fix Cortex-R device tree

```
This commit adds device bindings for Cortex-R4(F) and Cortex-R5(F).

These were supposed to be added during the initial development of
Cortex-R port, but it was not due to an incorrect device tree
specification.
```

```
1. Replace the non-existent CPU device binding ("Cortex-R") specified
   by the CPU node with a proper one.

2. Relocate CPU node declaration to SoC dtsi:

  The CPU node should be declared in the SoC dtsi because the core
  type is SoC-dependent. In fact, this is exactly how it is done in
  the Cortex-M port.

3. Remove core_intc (supposedly Cortex-R VIC):

  Unlike the NVIC of Cortex-M, the VIC of Cortex-R is not a true
 interrupt controller in the conventional sense and merely acts as
 a CPU input port for aggregated interrupt request and vector index
 signals. For this reason, there is no point in declaring it in the
 device tree and specifying it as an interrupt parent. All SoCs
 incorporating Cortex-R implement a separate true interrupt
 controller (for instance, GIC for Zynq MPSoC and VIM for Hercules).
```

This PR is part of the preparations for #19644.