### PR TITLE
subsys/fs: fix readdir misuse in FatFs and Zephyr wrapper

### DIFF
--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -270,10 +270,12 @@ static int fatfs_readdir(struct fs_dir_t *zdp, struct fs_dirent *entry)
 
 	res = f_readdir(zdp->dirp, &fno);
 	if (res == FR_OK) {
-		entry->type = ((fno.fattrib & AM_DIR) ?
-			       FS_DIR_ENTRY_DIR : FS_DIR_ENTRY_FILE);
 		strcpy(entry->name, fno.fname);
-		entry->size = fno.fsize;
+		if (entry->name[0] != 0) {
+			entry->type = ((fno.fattrib & AM_DIR) ?
+			       FS_DIR_ENTRY_DIR : FS_DIR_ENTRY_FILE);
+			entry->size = fno.fsize;
+		}
 	}
 
 	return translate_error(res);

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -261,6 +261,9 @@ int fs_readdir(struct fs_dir_t *zdp, struct fs_dirent *entry)
 				if (rc < 0) {
 					break;
 				}
+				if (entry->name[0] == 0) {
+					break;
+				}
 				if (entry->type != FS_DIR_ENTRY_DIR) {
 					break;
 				}


### PR DESCRIPTION
Two locations failed to properly handle detection of the end of available directory entries.

Fixes #19697.