### PR TITLE
test_pipe_contexts: don't free memory blocks handed to k_pipe_block_put

### DIFF
--- a/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
@@ -62,7 +62,6 @@ static void tpipe_block_put(struct k_pipe *ppipe, struct k_sem *sema,
 		if (sema) {
 			k_sem_take(sema, K_FOREVER);
 		}
-		k_mem_pool_free(&block);
 	}
 }
 


### PR DESCRIPTION
Documentation for k_pipe_block_put() says:

  This routine writes the data contained in a memory block to pipe.
  Once all of the data in the block has been written to the pipe,
  it will free the memory block.

Therefore it is wrong to free the memory block within the test code.
When the mempool allocator is instrumented to detect double-free
instances, this case is signaled right away.