### PR TITLE
dts: nordic: Use lowest IRQ priority level as defaults

### DIFF
--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -61,7 +61,7 @@
 		adc: adc@40007000 {
 			compatible = "nordic,nrf-adc";
 			reg = <0x40007000 0x1000>;
-			interrupts = <7 1>;
+			interrupts = <7 2>;
 			status = "disabled";
 			label = "ADC_0";
 			#io-channel-cells = <1>;
@@ -70,7 +70,7 @@
 		clock: clock@40000000 {
 			compatible = "nordic,nrf-clock";
 			reg = <0x40000000 0x1000>;
-			interrupts = <0 1>;
+			interrupts = <0 2>;
 			status = "okay";
 			label = "CLOCK";
 		};
@@ -78,7 +78,7 @@
 		uart0: uart@40002000 {
 			compatible = "nordic,nrf-uart";
 			reg = <0x40002000 0x1000>;
-			interrupts = <2 1>;
+			interrupts = <2 2>;
 			status = "disabled";
 			label = "UART_0";
 		};
@@ -86,7 +86,7 @@
 		gpiote: gpiote@40006000 {
 			compatible = "nordic,nrf-gpiote";
 			reg = <0x40006000 0x1000>;
-			interrupts = <6 1>;
+			interrupts = <6 2>;
 			status = "disabled";
 			label = "GPIOTE_0";
 		};
@@ -106,7 +106,7 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			interrupts = <3 1>;
+			interrupts = <3 2>;
 			status = "disabled";
 			label = "I2C_0";
 		};
@@ -117,7 +117,7 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			interrupts = <4 1>;
+			interrupts = <4 2>;
 			status = "disabled";
 			label = "I2C_1";
 		};
@@ -125,7 +125,7 @@
 		qdec: qdec@40012000 {
 			compatible = "nordic,nrf-qdec";
 			reg = <0x40012000 0x1000>;
-			interrupts = <18 1>;
+			interrupts = <18 2>;
 			status = "disabled";
 			label = "QDEC";
 		};
@@ -135,7 +135,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			interrupts = <3 1>;
+			interrupts = <3 2>;
 			status = "disabled";
 			label = "SPI_0";
 		};
@@ -150,7 +150,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			interrupts = <4 1>;
+			interrupts = <4 2>;
 			status = "disabled";
 			label = "SPI_1";
 		};
@@ -158,7 +158,7 @@
 		rtc0: rtc@4000b000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
-			interrupts = <11 1>;
+			interrupts = <11 2>;
 			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -168,7 +168,7 @@
 		rtc1: rtc@40011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
-			interrupts = <17 1>;
+			interrupts = <17 2>;
 			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -179,7 +179,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40008000 0x1000>;
-			interrupts = <8 1>;
+			interrupts = <8 2>;
 			prescaler = <0>;
 			label = "TIMER_0";
 		};
@@ -188,7 +188,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40009000 0x1000>;
-			interrupts = <9 1>;
+			interrupts = <9 2>;
 			prescaler = <0>;
 			label = "TIMER_1";
 		};
@@ -197,7 +197,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4000a000 0x1000>;
-			interrupts = <10 1>;
+			interrupts = <10 2>;
 			prescaler = <0>;
 			label = "TIMER_2";
 		};
@@ -205,7 +205,7 @@
 		temp: temp@4000c000 {
 			compatible = "nordic,nrf-temp";
 			reg = <0x4000c000 0x1000>;
-			interrupts = <12 1>;
+			interrupts = <12 2>;
 			status = "okay";
 			label = "TEMP_0";
 		};
@@ -213,7 +213,7 @@
 		wdt: watchdog@40010000 {
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
-			interrupts = <16 1>;
+			interrupts = <16 2>;
 			status = "okay";
 			label = "WDT";
 		};

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -60,7 +60,7 @@
 		adc: adc@40007000 {
 			compatible = "nordic,nrf-saadc";
 			reg = <0x40007000 0x1000>;
-			interrupts = <7 1>;
+			interrupts = <7 5>;
 			status = "disabled";
 			label = "ADC_0";
 			#io-channel-cells = <1>;
@@ -69,7 +69,7 @@
 		clock: clock@40000000 {
 			compatible = "nordic,nrf-clock";
 			reg = <0x40000000 0x1000>;
-			interrupts = <0 1>;
+			interrupts = <0 5>;
 			status = "okay";
 			label = "CLOCK";
 		};
@@ -78,7 +78,7 @@
 			/* uart can be either UART or UARTE, for the user to pick */
 			/* compatible = "nordic,nrf-uarte" or "nordic,nrf-uart"; */
 			reg = <0x40002000 0x1000>;
-			interrupts = <2 1>;
+			interrupts = <2 5>;
 			status = "disabled";
 			label = "UART_0";
 		};
@@ -112,7 +112,7 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			interrupts = <3 1>;
+			interrupts = <3 5>;
 			status = "disabled";
 			label = "I2C_0";
 		};
@@ -120,7 +120,7 @@
 		pwm0: pwm@4001c000 {
 			compatible = "nordic,nrf-pwm";
 			reg = <0x4001c000 0x1000>;
-			interrupts = <28 1>;
+			interrupts = <28 5>;
 			status = "disabled";
 			label = "PWM_0";
 			#pwm-cells = <1>;
@@ -129,7 +129,7 @@
 		qdec: qdec@40012000 {
 			compatible = "nordic,nrf-qdec";
 			reg = <0x40012000 0x1000>;
-			interrupts = <18 1>;
+			interrupts = <18 5>;
 			status = "disabled";
 			label = "QDEC";
 		};
@@ -145,7 +145,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			interrupts = <4 1>;
+			interrupts = <4 5>;
 			status = "disabled";
 			label = "SPI_0";
 		};
@@ -153,7 +153,7 @@
 		rtc0: rtc@4000b000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
-			interrupts = <11 1>;
+			interrupts = <11 5>;
 			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -163,7 +163,7 @@
 		rtc1: rtc@40011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
-			interrupts = <17 1>;
+			interrupts = <17 5>;
 			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -174,7 +174,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40008000 0x1000>;
-			interrupts = <8 1>;
+			interrupts = <8 5>;
 			prescaler = <0>;
 			label = "TIMER_0";
 		};
@@ -183,7 +183,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40009000 0x1000>;
-			interrupts = <9 1>;
+			interrupts = <9 5>;
 			prescaler = <0>;
 			label = "TIMER_1";
 		};
@@ -192,7 +192,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4000a000 0x1000>;
-			interrupts = <10 1>;
+			interrupts = <10 5>;
 			prescaler = <0>;
 			label = "TIMER_2";
 		};
@@ -200,7 +200,7 @@
 		temp: temp@4000c000 {
 			compatible = "nordic,nrf-temp";
 			reg = <0x4000c000 0x1000>;
-			interrupts = <12 1>;
+			interrupts = <12 5>;
 			status = "okay";
 			label = "TEMP_0";
 		};
@@ -208,7 +208,7 @@
 		wdt: watchdog@40010000 {
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
-			interrupts = <16 1>;
+			interrupts = <16 5>;
 			status = "okay";
 			label = "WDT";
 		};

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -64,7 +64,7 @@
 		adc: adc@40007000 {
 			compatible = "nordic,nrf-saadc";
 			reg = <0x40007000 0x1000>;
-			interrupts = <7 1>;
+			interrupts = <7 5>;
 			status = "disabled";
 			label = "ADC_0";
 			#io-channel-cells = <1>;
@@ -73,7 +73,7 @@
 		clock: clock@40000000 {
 			compatible = "nordic,nrf-clock";
 			reg = <0x40000000 0x1000>;
-			interrupts = <0 1>;
+			interrupts = <0 5>;
 			status = "okay";
 			label = "CLOCK";
 		};
@@ -82,7 +82,7 @@
 			/* uart can be either UART or UARTE, for the user to pick */
 			/* compatible = "nordic,nrf-uarte" or "nordic,nrf-uart"; */
 			reg = <0x40002000 0x1000>;
-			interrupts = <2 1>;
+			interrupts = <2 5>;
 			status = "disabled";
 			label = "UART_0";
 		};
@@ -119,7 +119,7 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			interrupts = <3 1>;
+			interrupts = <3 5>;
 			status = "disabled";
 			label = "I2C_0";
 		};
@@ -127,7 +127,7 @@
 		pwm0: pwm@4001c000 {
 			compatible = "nordic,nrf-pwm";
 			reg = <0x4001c000 0x1000>;
-			interrupts = <28 1>;
+			interrupts = <28 5>;
 			status = "disabled";
 			label = "PWM_0";
 			#pwm-cells = <1>;
@@ -136,7 +136,7 @@
 		qdec: qdec@40012000 {
 			compatible = "nordic,nrf-qdec";
 			reg = <0x40012000 0x1000>;
-			interrupts = <18 1>;
+			interrupts = <18 5>;
 			status = "disabled";
 			label = "QDEC";
 		};
@@ -152,7 +152,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			interrupts = <4 1>;
+			interrupts = <4 5>;
 			status = "disabled";
 			label = "SPI_0";
 		};
@@ -169,7 +169,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			interrupts = <3 1>;
+			interrupts = <3 5>;
 			status = "disabled";
 			label = "SPI_1";
 		};
@@ -177,7 +177,7 @@
 		rtc0: rtc@4000b000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
-			interrupts = <11 1>;
+			interrupts = <11 5>;
 			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -187,7 +187,7 @@
 		rtc1: rtc@40011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
-			interrupts = <17 1>;
+			interrupts = <17 5>;
 			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -198,7 +198,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40008000 0x1000>;
-			interrupts = <8 1>;
+			interrupts = <8 5>;
 			prescaler = <0>;
 			label = "TIMER_0";
 		};
@@ -207,7 +207,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40009000 0x1000>;
-			interrupts = <9 1>;
+			interrupts = <9 5>;
 			prescaler = <0>;
 			label = "TIMER_1";
 		};
@@ -216,7 +216,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4000a000 0x1000>;
-			interrupts = <10 1>;
+			interrupts = <10 5>;
 			prescaler = <0>;
 			label = "TIMER_2";
 		};
@@ -224,7 +224,7 @@
 		temp: temp@4000c000 {
 			compatible = "nordic,nrf-temp";
 			reg = <0x4000c000 0x1000>;
-			interrupts = <12 1>;
+			interrupts = <12 5>;
 			status = "okay";
 			label = "TEMP_0";
 		};
@@ -232,7 +232,7 @@
 		wdt: watchdog@40010000 {
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
-			interrupts = <16 1>;
+			interrupts = <16 5>;
 			status = "okay";
 			label = "WDT";
 		};

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -68,7 +68,7 @@
 		adc: adc@40007000 {
 			compatible = "nordic,nrf-saadc";
 			reg = <0x40007000 0x1000>;
-			interrupts = <7 1>;
+			interrupts = <7 5>;
 			status = "disabled";
 			label = "ADC_0";
 			#io-channel-cells = <1>;
@@ -77,7 +77,7 @@
 		clock: clock@40000000 {
 			compatible = "nordic,nrf-clock";
 			reg = <0x40000000 0x1000>;
-			interrupts = <0 1>;
+			interrupts = <0 5>;
 			status = "okay";
 			label = "CLOCK";
 		};
@@ -86,7 +86,7 @@
 			/* uart can be either UART or UARTE, for the user to pick */
 			/* compatible = "nordic,nrf-uarte" or "nordic,nrf-uart"; */
 			reg = <0x40002000 0x1000>;
-			interrupts = <2 1>;
+			interrupts = <2 5>;
 			status = "disabled";
 			label = "UART_0";
 		};
@@ -120,7 +120,7 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			interrupts = <3 1>;
+			interrupts = <3 5>;
 			status = "disabled";
 			label = "I2C_0";
 		};
@@ -137,7 +137,7 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			interrupts = <4 1>;
+			interrupts = <4 5>;
 			status = "disabled";
 			label = "I2C_1";
 		};
@@ -145,7 +145,7 @@
 		pwm0: pwm@4001c000 {
 			compatible = "nordic,nrf-pwm";
 			reg = <0x4001c000 0x1000>;
-			interrupts = <28 1>;
+			interrupts = <28 5>;
 			status = "disabled";
 			label = "PWM_0";
 			#pwm-cells = <1>;
@@ -154,7 +154,7 @@
 		pwm1: pwm@40021000 {
 			compatible = "nordic,nrf-pwm";
 			reg = <0x40021000 0x1000>;
-			interrupts = <33 1>;
+			interrupts = <33 5>;
 			status = "disabled";
 			label = "PWM_1";
 			#pwm-cells = <1>;
@@ -163,7 +163,7 @@
 		pwm2: pwm@40022000 {
 			compatible = "nordic,nrf-pwm";
 			reg = <0x40022000 0x1000>;
-			interrupts = <34 1>;
+			interrupts = <34 5>;
 			status = "disabled";
 			label = "PWM_2";
 			#pwm-cells = <1>;
@@ -172,7 +172,7 @@
 		qdec: qdec@40012000 {
 			compatible = "nordic,nrf-qdec";
 			reg = <0x40012000 0x1000>;
-			interrupts = <18 1>;
+			interrupts = <18 5>;
 			status = "disabled";
 			label = "QDEC";
 		};
@@ -188,7 +188,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			interrupts = <3 1>;
+			interrupts = <3 5>;
 			status = "disabled";
 			label = "SPI_0";
 		};
@@ -204,7 +204,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			interrupts = <4 1>;
+			interrupts = <4 5>;
 			status = "disabled";
 			label = "SPI_1";
 		};
@@ -220,7 +220,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40023000 0x1000>;
-			interrupts = <35 1>;
+			interrupts = <35 5>;
 			status = "disabled";
 			label = "SPI_2";
 		};
@@ -228,7 +228,7 @@
 		rtc0: rtc@4000b000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
-			interrupts = <11 1>;
+			interrupts = <11 5>;
 			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -238,7 +238,7 @@
 		rtc1: rtc@40011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
-			interrupts = <17 1>;
+			interrupts = <17 5>;
 			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -248,7 +248,7 @@
 		rtc2: rtc@40024000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40024000 0x1000>;
-			interrupts = <36 1>;
+			interrupts = <36 5>;
 			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -259,7 +259,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40008000 0x1000>;
-			interrupts = <8 1>;
+			interrupts = <8 5>;
 			prescaler = <0>;
 			label = "TIMER_0";
 		};
@@ -268,7 +268,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40009000 0x1000>;
-			interrupts = <9 1>;
+			interrupts = <9 5>;
 			prescaler = <0>;
 			label = "TIMER_1";
 		};
@@ -277,7 +277,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4000a000 0x1000>;
-			interrupts = <10 1>;
+			interrupts = <10 5>;
 			prescaler = <0>;
 			label = "TIMER_2";
 		};
@@ -286,7 +286,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4001a000 0x1000>;
-			interrupts = <26 1>;
+			interrupts = <26 5>;
 			prescaler = <0>;
 			label = "TIMER_3";
 		};
@@ -295,7 +295,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4001b000 0x1000>;
-			interrupts = <27 1>;
+			interrupts = <27 5>;
 			prescaler = <0>;
 			label = "TIMER_4";
 		};
@@ -303,7 +303,7 @@
 		temp: temp@4000c000 {
 			compatible = "nordic,nrf-temp";
 			reg = <0x4000c000 0x1000>;
-			interrupts = <12 1>;
+			interrupts = <12 5>;
 			status = "okay";
 			label = "TEMP_0";
 		};
@@ -311,7 +311,7 @@
 		wdt: watchdog@40010000 {
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
-			interrupts = <16 1>;
+			interrupts = <16 5>;
 			status = "okay";
 			label = "WDT";
 		};

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -75,7 +75,7 @@
 		adc: adc@40007000 {
 			compatible = "nordic,nrf-saadc";
 			reg = <0x40007000 0x1000>;
-			interrupts = <7 1>;
+			interrupts = <7 5>;
 			status = "disabled";
 			label = "ADC_0";
 			#io-channel-cells = <1>;
@@ -84,7 +84,7 @@
 		clock: clock@40000000 {
 			compatible = "nordic,nrf-clock";
 			reg = <0x40000000 0x1000>;
-			interrupts = <0 1>;
+			interrupts = <0 5>;
 			status = "okay";
 			label = "CLOCK";
 		};
@@ -93,7 +93,7 @@
 			/* uart can be either UART or UARTE, for the user to pick */
 			/* compatible = "nordic,nrf-uarte" or "nordic,nrf-uart"; */
 			reg = <0x40002000 0x1000>;
-			interrupts = <2 1>;
+			interrupts = <2 5>;
 			status = "disabled";
 			label = "UART_0";
 		};
@@ -101,7 +101,7 @@
 		uart1: uart@40028000 {
 			compatible = "nordic,nrf-uarte";
 			reg = <0x40028000 0x1000>;
-			interrupts = <40 1>;
+			interrupts = <40 5>;
 			status = "disabled";
 			label = "UART_1";
 		};
@@ -146,7 +146,7 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			interrupts = <3 1>;
+			interrupts = <3 5>;
 			status = "disabled";
 			label = "I2C_0";
 		};
@@ -163,7 +163,7 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			interrupts = <4 1>;
+			interrupts = <4 5>;
 			status = "disabled";
 			label = "I2C_1";
 		};
@@ -171,7 +171,7 @@
 		pwm0: pwm@4001c000 {
 			compatible = "nordic,nrf-pwm";
 			reg = <0x4001c000 0x1000>;
-			interrupts = <28 1>;
+			interrupts = <28 5>;
 			status = "disabled";
 			label = "PWM_0";
 			#pwm-cells = <1>;
@@ -180,7 +180,7 @@
 		pwm1: pwm@40021000 {
 			compatible = "nordic,nrf-pwm";
 			reg = <0x40021000 0x1000>;
-			interrupts = <33 1>;
+			interrupts = <33 5>;
 			status = "disabled";
 			label = "PWM_1";
 			#pwm-cells = <1>;
@@ -189,7 +189,7 @@
 		pwm2: pwm@40022000 {
 			compatible = "nordic,nrf-pwm";
 			reg = <0x40022000 0x1000>;
-			interrupts = <34 1>;
+			interrupts = <34 5>;
 			status = "disabled";
 			label = "PWM_2";
 			#pwm-cells = <1>;
@@ -198,7 +198,7 @@
 		pwm3: pwm@4002d000 {
 			compatible = "nordic,nrf-pwm";
 			reg = <0x4002d000 0x1000>;
-			interrupts = <45 1>;
+			interrupts = <45 5>;
 			status = "disabled";
 			label = "PWM_3";
 			#pwm-cells = <1>;
@@ -207,7 +207,7 @@
 		qdec: qdec@40012000 {
 			compatible = "nordic,nrf-qdec";
 			reg = <0x40012000 0x1000>;
-			interrupts = <18 1>;
+			interrupts = <18 5>;
 			status = "disabled";
 			label = "QDEC";
 		};
@@ -223,7 +223,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			interrupts = <3 1>;
+			interrupts = <3 5>;
 			status = "disabled";
 			label = "SPI_0";
 		};
@@ -239,7 +239,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			interrupts = <4 1>;
+			interrupts = <4 5>;
 			status = "disabled";
 			label = "SPI_1";
 		};
@@ -255,7 +255,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40023000 0x1000>;
-			interrupts = <35 1>;
+			interrupts = <35 5>;
 			status = "disabled";
 			label = "SPI_2";
 		};
@@ -265,7 +265,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x4002f000 0x1000>;
-			interrupts = <47 1>;
+			interrupts = <47 5>;
 			status = "disabled";
 			label = "SPI_3";
 		};
@@ -273,7 +273,7 @@
 		rtc0: rtc@4000b000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x4000b000 0x1000>;
-			interrupts = <11 1>;
+			interrupts = <11 5>;
 			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -283,7 +283,7 @@
 		rtc1: rtc@40011000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40011000 0x1000>;
-			interrupts = <17 1>;
+			interrupts = <17 5>;
 			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -293,7 +293,7 @@
 		rtc2: rtc@40024000 {
 			compatible = "nordic,nrf-rtc";
 			reg = <0x40024000 0x1000>;
-			interrupts = <36 1>;
+			interrupts = <36 5>;
 			status = "okay";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -304,7 +304,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40008000 0x1000>;
-			interrupts = <8 1>;
+			interrupts = <8 5>;
 			prescaler = <0>;
 			label = "TIMER_0";
 		};
@@ -313,7 +313,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x40009000 0x1000>;
-			interrupts = <9 1>;
+			interrupts = <9 5>;
 			prescaler = <0>;
 			label = "TIMER_1";
 		};
@@ -322,7 +322,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4000a000 0x1000>;
-			interrupts = <10 1>;
+			interrupts = <10 5>;
 			prescaler = <0>;
 			label = "TIMER_2";
 		};
@@ -331,7 +331,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4001a000 0x1000>;
-			interrupts = <26 1>;
+			interrupts = <26 5>;
 			prescaler = <0>;
 			label = "TIMER_3";
 		};
@@ -340,7 +340,7 @@
 			compatible = "nordic,nrf-timer";
 			status = "okay";
 			reg = <0x4001b000 0x1000>;
-			interrupts = <27 1>;
+			interrupts = <27 5>;
 			prescaler = <0>;
 			label = "TIMER_4";
 		};
@@ -348,7 +348,7 @@
 		temp: temp@4000c000 {
 			compatible = "nordic,nrf-temp";
 			reg = <0x4000c000 0x1000>;
-			interrupts = <12 1>;
+			interrupts = <12 5>;
 			status = "okay";
 			label = "TEMP_0";
 		};
@@ -356,7 +356,7 @@
 		usbd: usbd@40027000 {
 			compatible = "nordic,nrf-usbd";
 			reg = <0x40027000 0x1000>;
-			interrupts = <39 1>;
+			interrupts = <39 5>;
 			num-bidir-endpoints = <1>;
 			num-in-endpoints = <7>;
 			num-out-endpoints = <7>;
@@ -369,7 +369,7 @@
 		wdt: watchdog@40010000 {
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;
-			interrupts = <16 1>;
+			interrupts = <16 5>;
 			status = "okay";
 			label = "WDT";
 		};
@@ -384,7 +384,7 @@
 			cryptocell310: crypto@5002b000 {
 				compatible = "arm,cryptocell-310";
 				reg = <0x5002B000 0x1000>;
-				interrupts = <42 1>;
+				interrupts = <42 5>;
 				label = "CRYPTOCELL310";
 			};
 		};

--- a/dts/arm/nordic/nrf9160.dtsi
+++ b/dts/arm/nordic/nrf9160.dtsi
@@ -91,7 +91,7 @@
 		spu: spu@50003000 {
 			compatible = "nordic,nrf-spu";
 			reg = <0x50003000 0x1000>;
-			interrupts = <3 1>;
+			interrupts = <3 5>;
 			status = "okay";
 		};
 

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -24,7 +24,7 @@ flash_controller: flash-controller@39000 {
 adc: adc@e000 {
 	compatible = "nordic,nrf-saadc";
 	reg = <0xe000 0x1000>;
-	interrupts = <14 1>;
+	interrupts = <14 5>;
 	status = "disabled";
 	label = "ADC_0";
 	#io-channel-cells = <1>;
@@ -40,42 +40,42 @@ dppic: dppic@17000 {
 egu0: egu@1b000 {
 	compatible = "nordic,nrf-egu";
 	reg = <0x1b000 0x1000>;
-	interrupts = <27 1>;
+	interrupts = <27 5>;
 	status = "okay";
 };
 
 egu1: egu@1c000 {
 	compatible = "nordic,nrf-egu";
 	reg = <0x1c000 0x1000>;
-	interrupts = <28 1>;
+	interrupts = <28 5>;
 	status = "okay";
 };
 
 egu2: egu@1d000 {
 	compatible = "nordic,nrf-egu";
 	reg = <0x1d000 0x1000>;
-	interrupts = <29 1>;
+	interrupts = <29 5>;
 	status = "okay";
 };
 
 egu3: egu@1e000 {
 	compatible = "nordic,nrf-egu";
 	reg = <0x1e000 0x1000>;
-	interrupts = <30 1>;
+	interrupts = <30 5>;
 	status = "okay";
 };
 
 egu4: egu@1f000 {
 	compatible = "nordic,nrf-egu";
 	reg = <0x1f000 0x1000>;
-	interrupts = <31 1>;
+	interrupts = <31 5>;
 	status = "okay";
 };
 
 egu5: egu@20000 {
 	compatible = "nordic,nrf-egu";
 	reg = <0x20000 0x1000>;
-	interrupts = <32 1>;
+	interrupts = <32 5>;
 	status = "okay";
 };
 
@@ -84,7 +84,7 @@ i2s0: i2s@28000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x28000 0x1000>;
-	interrupts = <40 1>;
+	interrupts = <40 5>;
 	status = "disabled";
 	label = "I2S_0";
 };
@@ -92,14 +92,14 @@ i2s0: i2s@28000 {
 kmu: kmu@39000 {
 	compatible = "nordic,nrf-kmu";
 	reg = <0x39000 0x1000>;
-	interrupts = <57 1>;
+	interrupts = <57 5>;
 	status = "okay";
 };
 
 pdm0: pdm@26000 {
 	compatible = "nordic,nrf-pdm";
 	reg = <0x26000 0x1000>;
-	interrupts = <38 1>;
+	interrupts = <38 5>;
 	status = "disabled";
 	label = "PDM_0";
 };
@@ -119,7 +119,7 @@ vmc: vmc@3a000 {
 uart0: uart@8000 {
 	compatible = "nordic,nrf-uarte";
 	reg = <0x8000 0x1000>;
-	interrupts = <8 1>;
+	interrupts = <8 5>;
 	status = "disabled";
 	label = "UART_0";
 };
@@ -127,7 +127,7 @@ uart0: uart@8000 {
 uart1: uart@9000 {
 	compatible = "nordic,nrf-uarte";
 	reg = <0x9000 0x1000>;
-	interrupts = <9 1>;
+	interrupts = <9 5>;
 	status = "disabled";
 	label = "UART_1";
 };
@@ -135,7 +135,7 @@ uart1: uart@9000 {
 uart2: uart@a000 {
 	compatible = "nordic,nrf-uarte";
 	reg = <0xa000 0x1000>;
-	interrupts = <10 1>;
+	interrupts = <10 5>;
 	status = "disabled";
 	label = "UART_2";
 };
@@ -143,7 +143,7 @@ uart2: uart@a000 {
 uart3: uart@b000 {
 	compatible = "nordic,nrf-uarte";
 	reg = <0xb000 0x1000>;
-	interrupts = <11 1>;
+	interrupts = <11 5>;
 	status = "disabled";
 	label = "UART_3";
 };
@@ -158,7 +158,7 @@ i2c0: i2c@8000 {
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	interrupts = <8 1>;
+	interrupts = <8 5>;
 	status = "disabled";
 	label = "I2C_0";
 };
@@ -173,7 +173,7 @@ i2c1: i2c@9000 {
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	interrupts = <9 1>;
+	interrupts = <9 5>;
 	status = "disabled";
 	label = "I2C_1";
 };
@@ -188,7 +188,7 @@ i2c2: i2c@a000 {
 	#size-cells = <0>;
 	reg = <0xa000 0x1000>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	interrupts = <10 1>;
+	interrupts = <10 5>;
 	status = "disabled";
 	label = "I2C_2";
 };
@@ -203,7 +203,7 @@ i2c3: i2c@b000 {
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	interrupts = <11 1>;
+	interrupts = <11 5>;
 	status = "disabled";
 	label = "I2C_3";
 };
@@ -217,7 +217,7 @@ spi0: spi@8000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
-	interrupts = <8 1>;
+	interrupts = <8 5>;
 	status = "disabled";
 	label = "SPI_0";
 };
@@ -231,7 +231,7 @@ spi1: spi@9000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
-	interrupts = <9 1>;
+	interrupts = <9 5>;
 	status = "disabled";
 	label = "SPI_1";
 };
@@ -245,7 +245,7 @@ spi2: spi@a000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xa000 0x1000>;
-	interrupts = <10 1>;
+	interrupts = <10 5>;
 	status = "disabled";
 	label = "SPI_2";
 };
@@ -259,7 +259,7 @@ spi3: spi@b000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;
-	interrupts = <11 1>;
+	interrupts = <11 5>;
 	status = "disabled";
 	label = "SPI_3";
 };
@@ -267,7 +267,7 @@ spi3: spi@b000 {
 pwm0: pwm@21000 {
 	compatible = "nordic,nrf-pwm";
 	reg = <0x21000 0x1000>;
-	interrupts = <33 1>;
+	interrupts = <33 5>;
 	status = "disabled";
 	label = "PWM_0";
 	#pwm-cells = <1>;
@@ -276,7 +276,7 @@ pwm0: pwm@21000 {
 pwm1: pwm@22000 {
 	compatible = "nordic,nrf-pwm";
 	reg = <0x22000 0x1000>;
-	interrupts = <34 1>;
+	interrupts = <34 5>;
 	status = "disabled";
 	label = "PWM_1";
 	#pwm-cells = <1>;
@@ -285,7 +285,7 @@ pwm1: pwm@22000 {
 pwm2: pwm@23000 {
 	compatible = "nordic,nrf-pwm";
 	reg = <0x23000 0x1000>;
-	interrupts = <35 1>;
+	interrupts = <35 5>;
 	status = "disabled";
 	label = "PWM_2";
 	#pwm-cells = <1>;
@@ -294,7 +294,7 @@ pwm2: pwm@23000 {
 pwm3: pwm@24000 {
 	compatible = "nordic,nrf-pwm";
 	reg = <0x24000 0x1000>;
-	interrupts = <36 1>;
+	interrupts = <36 5>;
 	status = "disabled";
 	label = "PWM_3";
 	#pwm-cells = <1>;
@@ -312,7 +312,7 @@ gpio0: gpio@842500 {
 rtc0: rtc@14000 {
 	compatible = "nordic,nrf-rtc";
 	reg = <0x14000 0x1000>;
-	interrupts = <20 1>;
+	interrupts = <20 5>;
 	status = "okay";
 	clock-frequency = <32768>;
 	prescaler = <1>;
@@ -322,7 +322,7 @@ rtc0: rtc@14000 {
 rtc1: rtc@15000 {
 	compatible = "nordic,nrf-rtc";
 	reg = <0x15000 0x1000>;
-	interrupts = <21 1>;
+	interrupts = <21 5>;
 	status = "okay";
 	clock-frequency = <32768>;
 	prescaler = <1>;
@@ -332,7 +332,7 @@ rtc1: rtc@15000 {
 clock: clock@5000 {
 	compatible = "nordic,nrf-clock";
 	reg = <0x5000 0x1000>;
-	interrupts = <5 1>;
+	interrupts = <5 5>;
 	status = "okay";
 	label = "CLOCK";
 };
@@ -340,14 +340,14 @@ clock: clock@5000 {
 power: power@5000 {
 	compatible = "nordic,nrf-power";
 	reg = <0x5000 0x1000>;
-	interrupts = <5 1>;
+	interrupts = <5 5>;
 	status = "okay";
 };
 
 wdt: watchdog@18000 {
 	compatible = "nordic,nrf-watchdog";
 	reg = <0x18000 0x1000>;
-	interrupts = <24 1>;
+	interrupts = <24 5>;
 	status = "okay";
 	label = "WDT";
 };
@@ -356,7 +356,7 @@ timer0: timer@f000 {
 	compatible = "nordic,nrf-timer";
 	status = "disabled";
 	reg = <0xf000 0x1000>;
-	interrupts = <15 1>;
+	interrupts = <15 5>;
 	prescaler = <0>;
 	label = "TIMER_0";
 };
@@ -365,7 +365,7 @@ timer1: timer@10000 {
 	compatible = "nordic,nrf-timer";
 	status = "disabled";
 	reg = <0x10000 0x1000>;
-	interrupts = <16 1>;
+	interrupts = <16 5>;
 	prescaler = <0>;
 	label = "TIMER_1";
 };
@@ -374,7 +374,7 @@ timer2: timer@11000 {
 	compatible = "nordic,nrf-timer";
 	status = "disabled";
 	reg = <0x11000 0x1000>;
-	interrupts = <17 1>;
+	interrupts = <17 5>;
 	prescaler = <0>;
 	label = "TIMER_2";
 };


### PR DESCRIPTION
Updated dts supplied default peripheral IRQ priority level
values to be the lowest supported by the platform.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>