### PR TITLE
Bluetooth: controller: split: Add hook for flushing in LLL

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -160,5 +160,6 @@ void lll_conn_isr_abort(void *param);
 void lll_conn_rx_pkt_set(struct lll_conn *lll);
 void lll_conn_tx_pkt_set(struct lll_conn *lll, struct pdu_data *pdu_data_tx);
 void lll_conn_pdu_tx_prep(struct lll_conn *lll, struct pdu_data **pdu_data_tx);
+void lll_conn_flush(struct lll_conn *lll);
 
 extern void ull_conn_lll_ack_enqueue(u16_t handle, struct node_tx *tx);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -854,3 +854,8 @@ static struct pdu_data *empty_tx_enqueue(struct lll_conn *lll)
 
 	return p;
 }
+
+void lll_conn_flush(struct lll_conn *lll)
+{
+	/* Nothing to be flushed */
+}

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1578,6 +1578,8 @@ static void tx_lll_flush(void *param)
 	struct node_tx *tx;
 	memq_link_t *link;
 
+	lll_conn_flush(lll);
+
 	link = memq_dequeue(lll->memq_tx.tail, &lll->memq_tx.head,
 			    (void **)&tx);
 	while (link) {


### PR DESCRIPTION
Add hook for flushing in LLL to allow clean-up of LLL-specific
resources.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>