### PR TITLE
Bluetooth: controller: split: Make number of TX ctrl buffers configurable

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -235,6 +235,16 @@ comment "BLE Controller features"
 
 if BT_CONN
 
+config BT_CTLR_LLCP_CONN
+	int "Number of connections with worst-case overlapping procedures"
+	default 1
+	range 1 BT_MAX_CONN
+	help
+	  Set the number connections for which worst-case buffer requirements
+	  for LLCP procedures must be met. Executing LLCP procedures on
+	  more than this number of connections simultaneously may cause
+	  instabilities.
+
 config BT_CTLR_LE_ENC
 	bool "LE Encryption"
 	depends on !BT_CTLR_DATA_LENGTH_CLEAR && !BT_CTLR_PHY_2M_NRF

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -114,7 +114,12 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 				(CONFIG_BT_CTLR_TX_BUFFER_SIZE + \
 				BT_CTLR_USER_TX_BUFFER_OVERHEAD))
 
-#define CONN_TX_CTRL_BUFFERS 2
+/**
+ * One connection may take up to 4 TX buffers for procedures
+ * simultaneously, for example 2 for encryption, 1 for termination,
+ * and 1 one that is in flight and has not been returned to the pool
+ */
+#define CONN_TX_CTRL_BUFFERS (4 * CONFIG_BT_CTLR_LLCP_CONN)
 #define CONN_TX_CTRL_BUF_SIZE MROUND(offsetof(struct node_tx, pdu) + \
 				     offsetof(struct pdu_data, llctrl) + \
 				     sizeof(struct pdu_data_llctrl))


### PR DESCRIPTION
Number of required buffers depends on LLCP procedures that are allowed
to be in flight at the same time.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>