### PR TITLE
Bluetooth: controller: Fix Kconfig conditional optionals

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -324,21 +324,22 @@ config BT_CTLR_PHY
 	select BT_CTLR_EXT_REJ_IND
 	default y if SOC_COMPATIBLE_NRF52X || BT_CTLR_PHY_2M_NRF
 
-endif # BT_CONN
-
-config BT_CTLR_CHAN_SEL_2
-	bool "Channel Selection Algorithm #2"
-	default y
-	help
-	  Enable support for Bluetooth 5.0 LE Channel Selection Algorithm #2 in
-	  the Controller.
-
 config BT_CTLR_MIN_USED_CHAN
 	bool "Minimum Number of Used Channels"
 	default y
 	help
 	  Enable support for Bluetooth 5.0 Minimum Number of Used Channels
 	  Procedure in the Controller.
+
+endif # BT_CONN
+
+config BT_CTLR_CHAN_SEL_2
+	bool "Channel Selection Algorithm #2"
+	depends on BT_CONN || BT_CTLR_ADV_EXT
+	default y
+	help
+	  Enable support for Bluetooth 5.0 LE Channel Selection Algorithm #2 in
+	  the Controller.
 
 config BT_CTLR_ADV_EXT
 	bool "LE Advertising Extensions"


### PR DESCRIPTION
Fix Kconfig conditional include of Minimum Channels Used
and Channel Selection Algorithm #2.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>