### PR TITLE
[WIP] Drivers: CAN: Implementation of a send timeout for can_send(...)

### DIFF
--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(can_driver);
 
 #define WORK_BUF_FULL 0xFFFF
 
-void can_common_isr_callback_handler(u32_t err, void *cb_arg)
+void can_common_isr_callback_handler(int err, void *cb_arg)
 {
 	struct can_send_wait *send_wait = (struct can_send_wait *) cb_arg;
 

--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -24,6 +24,14 @@ LOG_MODULE_REGISTER(can_driver);
 
 #define WORK_BUF_FULL 0xFFFF
 
+void can_common_isr_callback_handler(u32_t err, void *cb_arg)
+{
+	struct can_send_wait *send_wait = (struct can_send_wait *) cb_arg;
+
+	send_wait->err = err;
+	k_sem_give(&send_wait->sem);
+}
+
 static void can_msgq_put(struct zcan_frame *frame, void *arg)
 {
 	struct k_msgq *msgq = (struct k_msgq *)arg;

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -20,25 +20,21 @@ static inline int z_vrfy_can_configure(struct device *dev, enum can_mode mode,
 
 static inline int z_vrfy_can_send(struct device *dev,
 				  const struct zcan_frame *msg,
-				  s32_t timeout,
+				  s32_t mb_timeout, s32_t send_timeout,
 				  can_tx_callback_t callback_isr,
 				  void *callback_arg)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, send));
 
-	Z_OOPS(Z_SYSCALL_MEMORY_READ((const struct zcan_frame *)msg,
-				      sizeof(struct zcan_frame)));
-	Z_OOPS(Z_SYSCALL_MEMORY_READ(((struct zcan_frame *)msg)->data,
-				     sizeof((struct zcan_frame *)msg)->data));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(msg, sizeof(struct zcan_frame)));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(msg->data, sizeof(msg->data)));
 	Z_OOPS(Z_SYSCALL_VERIFY_MSG(callback_isr == 0,
 				    "callbacks may not be set from user mode"));
 
-	Z_OOPS(Z_SYSCALL_MEMORY_READ((void *)callback_arg, sizeof(void *)));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(callback_arg, sizeof(void *)));
 
-	return z_impl_can_send((struct device *)dev,
-			      (const struct zcan_frame *)msg,
-			      (s32_t)timeout, (can_tx_callback_t) callback_isr,
-			      (void *)callback_arg);
+	return z_impl_can_send(dev, msg, mb_timeout, send_timeout, callback_isr,
+			       callback_arg);
 }
 #include <syscalls/can_send_mrsh.c>
 

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -389,6 +389,8 @@ static int mcp2515_send(struct device *dev, const struct zcan_frame *msg,
 	u8_t len;
 	u8_t tx_frame[MCP2515_FRAME_LEN];
 
+	__ASSERT(callback != NULL, "callback is null");
+
 	if (msg->dlc > CAN_MAX_DLC) {
 		LOG_ERR("DLC of %d exceeds maximum (%d)", msg->dlc, CAN_MAX_DLC);
 		return CAN_TX_EINVAL;
@@ -431,10 +433,6 @@ static int mcp2515_send(struct device *dev, const struct zcan_frame *msg,
 	/* request tx slot transmission */
 	nnn = BIT(tx_idx);
 	mcp2515_cmd_rts(dev, nnn);
-
-	if (callback == NULL) {
-		k_sem_take(&dev_data->tx_cb[tx_idx].sem, K_FOREVER);
-	}
 
 	return 0;
 }
@@ -564,11 +562,7 @@ static void mcp2515_tx_done(struct device *dev, u8_t tx_idx)
 {
 	struct mcp2515_data *dev_data = DEV_DATA(dev);
 
-	if (dev_data->tx_cb[tx_idx].cb == NULL) {
-		k_sem_give(&dev_data->tx_cb[tx_idx].sem);
-	} else {
-		dev_data->tx_cb[tx_idx].cb(0, dev_data->tx_cb[tx_idx].cb_arg);
-	}
+	dev_data->tx_cb[tx_idx].cb(CAN_TX_OK, dev_data->tx_cb[tx_idx].cb_arg);
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 	dev_data->tx_busy_map &= ~BIT(tx_idx);
@@ -745,9 +739,6 @@ static int mcp2515_init(struct device *dev)
 	k_sem_init(&dev_data->int_sem, 0, 1);
 	k_mutex_init(&dev_data->mutex);
 	k_sem_init(&dev_data->tx_sem, MCP2515_TX_CNT, MCP2515_TX_CNT);
-	k_sem_init(&dev_data->tx_cb[0].sem, 0, 1);
-	k_sem_init(&dev_data->tx_cb[1].sem, 0, 1);
-	k_sem_init(&dev_data->tx_cb[2].sem, 0, 1);
 
 	/* SPI config */
 	dev_data->spi_cfg.operation = SPI_WORD_SET(8);

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -19,7 +19,6 @@
 #define DEV_DATA(dev) ((struct mcp2515_data *const)(dev)->driver_data)
 
 struct mcp2515_tx_cb {
-	struct k_sem sem;
 	can_tx_callback_t cb;
 	void *cb_arg;
 };

--- a/drivers/can/can_net.c
+++ b/drivers/can/can_net.c
@@ -89,12 +89,14 @@ static inline void can_set_lladdr(struct net_pkt *pkt, struct zcan_frame *frame)
 }
 
 static int net_can_send(struct device *dev, const struct zcan_frame *frame,
-			can_tx_callback_t cb, void *cb_arg, s32_t timeout)
+			can_tx_callback_t cb, void *cb_arg,
+			s32_t mb_timeout, s32_t send_timeout)
 {
 	struct net_can_context *ctx = dev->driver_data;
 
 	NET_ASSERT(frame->id_type == CAN_EXTENDED_IDENTIFIER);
-	return can_send(ctx->can_dev, frame, timeout, cb, cb_arg);
+	return can_send(ctx->can_dev, frame, mb_timeout, send_timeout,
+			cb, cb_arg);
 }
 
 static void net_can_recv(struct zcan_frame *frame, void *arg)

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -198,7 +198,7 @@ static int cmd_send(const struct shell *shell, size_t argc, char **argv)
 		    ext ? frame.ext_id : frame.std_id,
 		    ext ? "extended" : "standard", frame.dlc);
 
-	ret = can_send(can_dev, &frame, K_FOREVER, NULL, NULL);
+	ret = can_send(can_dev, &frame, K_FOREVER, K_MSEC(100), NULL, NULL);
 	if (ret) {
 		shell_error(shell, "Failed to send frame [%d]", ret);
 		return -EIO;

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -42,6 +42,7 @@
 struct can_mailbox {
 	can_tx_callback_t tx_callback;
 	void *callback_arg;
+	struct _timeout timeout;
 };
 
 
@@ -59,6 +60,7 @@ struct can_stm32_data {
 	struct can_mailbox mb0;
 	struct can_mailbox mb1;
 	struct can_mailbox mb2;
+	struct device *dev;  /* Device ptr for the timeout function */
 	u64_t filter_usage;
 	can_rx_callback_t rx_cb[CONFIG_CAN_MAX_FILTER];
 	void *cb_arg[CONFIG_CAN_MAX_FILTER];

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -42,8 +42,6 @@
 struct can_mailbox {
 	can_tx_callback_t tx_callback;
 	void *callback_arg;
-	struct k_sem tx_int_sem;
-	u32_t error_flags;
 };
 
 

--- a/drivers/can/socket_can_generic.h
+++ b/drivers/can/socket_can_generic.h
@@ -44,12 +44,12 @@ static inline void socket_can_iface_init(struct net_if *iface)
 	LOG_DBG("Init CAN interface %p dev %p", iface, dev);
 }
 
-static inline void tx_irq_callback(u32_t error_flags, void *arg)
+static inline void tx_irq_callback(int error_number, void *arg)
 {
 	char *caller_str = (char *)arg;
-	if (error_flags) {
+	if (error_number) {
 		LOG_DBG("TX error from %s! error-code: %d",
-			caller_str, error_flags);
+			caller_str, error_number);
 	}
 }
 

--- a/drivers/can/socket_can_generic.h
+++ b/drivers/can/socket_can_generic.h
@@ -15,6 +15,7 @@
 
 #define SOCKET_CAN_NAME_1 "SOCKET_CAN_1"
 #define SEND_TIMEOUT K_MSEC(100)
+#define MB_TIMEOUT   K_MSEC(100)
 #define RX_THREAD_STACK_SIZE 512
 #define RX_THREAD_PRIORITY 2
 #define BUF_ALLOC_TIMEOUT K_MSEC(50)
@@ -63,7 +64,7 @@ static inline int socket_can_send(struct device *dev, struct net_pkt *pkt)
 	}
 
 	ret = can_send(socket_context->can_dev,
-		       (struct zcan_frame *)pkt->frags->data,
+		       (struct zcan_frame *)pkt->frags->data, MB_TIMEOUT,
 		       SEND_TIMEOUT, tx_irq_callback, "socket_can_send");
 	if (ret) {
 		LOG_DBG("Cannot send socket CAN msg (%d)", ret);

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -257,7 +257,7 @@ struct can_bus_err_cnt {
  * @param error_flags status of the performed send operation
  * @param arg argument that was passed when the message was sent
  */
-typedef void (*can_tx_callback_t)(u32_t error_flags, void *arg);
+typedef void (*can_tx_callback_t)(int error_number, void *arg);
 
 /**
  * @typedef can_rx_callback_t

--- a/include/net/can.h
+++ b/include/net/can.h
@@ -100,7 +100,8 @@ struct net_can_api {
 
 	/** Send a single CAN frame */
 	int (*send)(struct device *dev, const struct zcan_frame *frame,
-		    can_tx_callback_t cb, void *cb_arg, s32_t timeout);
+		    can_tx_callback_t cb, void *cb_arg, s32_t mb_timeout,
+		    s32_t send_timeout);
 	/** Attach a filter with it's callback */
 	int (*attach_filter)(struct device *dev, can_rx_callback_t cb,
 			     void *cb_arg, const struct zcan_filter *filter);

--- a/samples/drivers/CAN/src/main.c
+++ b/samples/drivers/CAN/src/main.c
@@ -36,13 +36,13 @@ struct can_bus_err_cnt current_err_cnt;
 
 CAN_DEFINE_MSGQ(counter_msgq, 2);
 
-void tx_irq_callback(u32_t error_flags, void *arg)
+void tx_irq_callback(int error_number, void *arg)
 {
 	char *sender = (char *)arg;
 
-	if (error_flags) {
+	if (error_number) {
 		printk("Callback! error-code: %d\nSender: %s\n",
-		       error_flags, sender);
+		       error_number, sender);
 	}
 }
 

--- a/subsys/net/l2/canbus/6locan.c
+++ b/subsys/net/l2/canbus/6locan.c
@@ -425,10 +425,10 @@ static void canbus_set_frame_addr_pkt(struct zcan_frame *frame,
 	canbus_set_frame_addr(frame, dest_addr, &src_addr, mcast);
 }
 
-static void canbus_fc_send_cb(u32_t err_flags, void *arg)
+static void canbus_fc_send_cb(int err_number, void *arg)
 {
-	if (err_flags) {
-		NET_ERR("Sending FC frame failed: %d", err_flags);
+	if (err_number) {
+		NET_ERR("Sending FC frame failed: %d", err_number);
 	}
 }
 
@@ -684,7 +684,7 @@ static enum net_verdict canbus_process_sf(struct net_pkt *pkt)
 	return canbus_finish_pkt(pkt);
 }
 
-static void canbus_tx_frame_isr(u32_t err_flags, void *arg)
+static void canbus_tx_frame_isr(int err_number, void *arg)
 {
 	struct net_pkt *pkt = (struct net_pkt *)arg;
 	struct canbus_isotp_tx_ctx *ctx = pkt->canbus_tx_ctx;
@@ -1528,14 +1528,14 @@ static inline int canbus_send_dad_request(struct device *net_can_dev,
 	return 0;
 }
 
-static void canbus_send_dad_resp_cb(u32_t err_flags, void *cb_arg)
+static void canbus_send_dad_resp_cb(int err_number, void *cb_arg)
 {
 	static u8_t fail_cnt;
 	struct k_work *work = (struct k_work *)cb_arg;
 
-	if (err_flags) {
-		NET_ERR("Failed to send dad response [%u]", err_flags);
-		if (err_flags != CAN_TX_BUS_OFF &&
+	if (err_number) {
+		NET_ERR("Failed to send dad response [%u]", err_number);
+		if (err_number != CAN_TX_BUS_OFF &&
 		    fail_cnt < NET_CAN_DAD_SEND_RETRY) {
 			k_work_submit_to_queue(&net_canbus_workq, work);
 		}

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -162,7 +162,7 @@ static inline void check_msg(struct zcan_frame *msg1, struct zcan_frame *msg2,
 	zassert_equal(cmp_res, 0, "Received data differ");
 }
 
-static void tx_timeout_isr(u32_t error_flags, void *arg)
+static void tx_timeout_isr(int error_number, void *arg)
 {
 	int expected_err = (int)arg;
 
@@ -173,7 +173,7 @@ static void tx_timeout_isr(u32_t error_flags, void *arg)
 			  expected_err, error_number);
 }
 
-static void tx_std_isr(u32_t error_flags, void *arg)
+static void tx_std_isr(int error_number, void *arg)
 {
 	struct zcan_frame *msg = (struct zcan_frame *)arg;
 
@@ -182,7 +182,7 @@ static void tx_std_isr(u32_t error_flags, void *arg)
 	zassert_equal(msg->std_id, TEST_CAN_STD_ID, "Arg does not match");
 }
 
-static void tx_std_masked_isr(u32_t error_flags, void *arg)
+static void tx_std_masked_isr(int error_number, void *arg)
 {
 	struct zcan_frame *msg = (struct zcan_frame *)arg;
 
@@ -191,7 +191,7 @@ static void tx_std_masked_isr(u32_t error_flags, void *arg)
 	zassert_equal(msg->std_id, TEST_CAN_STD_MASK_ID, "Arg does not match");
 }
 
-static void tx_ext_isr(u32_t error_flags, void *arg)
+static void tx_ext_isr(int error_number, void *arg)
 {
 	struct zcan_frame *msg = (struct zcan_frame *)arg;
 
@@ -200,7 +200,7 @@ static void tx_ext_isr(u32_t error_flags, void *arg)
 	zassert_equal(msg->ext_id, TEST_CAN_EXT_ID, "Arg does not match");
 }
 
-static void tx_ext_masked_isr(u32_t error_flags, void *arg)
+static void tx_ext_masked_isr(int error_number, void *arg)
 {
 	struct zcan_frame *msg = (struct zcan_frame *)arg;
 

--- a/tests/drivers/can/stm32/src/main.c
+++ b/tests/drivers/can/stm32/src/main.c
@@ -121,7 +121,8 @@ static void send_test_msg(struct device *can_dev, struct zcan_frame *msg)
 {
 	int ret;
 
-	ret = can_send(can_dev, msg, TEST_SEND_TIMEOUT, NULL, NULL);
+	ret = can_send(can_dev, msg, TEST_SEND_TIMEOUT, TEST_SEND_TIMEOUT,
+		       NULL, NULL);
 	zassert_not_equal(ret, CAN_TX_ARB_LOST,
 			  "Arbitration though in loopback mode");
 	zassert_equal(ret, CAN_TX_OK, "Can't send a message. Err: %d", ret);


### PR DESCRIPTION
This PR implements a timeout for outgoing CAN frames.

~~At the moment only the stm32 driver implements the new functionality. Other drivers will follow by the end of the week.~~

It fixes issue #19502