### PR TITLE
arch: arm: clean up inclusions in assembly files

### DIFF
--- a/arch/arm/core/cpu_idle.S
+++ b/arch/arm/core/cpu_idle.S
@@ -10,13 +10,8 @@
  *
  */
 
-#include <offsets_short.h>
 #include <toolchain.h>
 #include <linker/sections.h>
-#include <arch/cpu.h>
-#ifdef CONFIG_TICKLESS_IDLE
-#include <kernel_structs.h>
-#endif
 
 _ASM_FILE_PROLOGUE
 

--- a/arch/arm/core/cpu_idle.S
+++ b/arch/arm/core/cpu_idle.S
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief ARM Cortex-M power management
+ * @brief ARM Cortex-M and Cortex-R power management
  *
  */
 

--- a/arch/arm/core/exc_exit.S
+++ b/arch/arm/core/exc_exit.S
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief ARM Cortex-M exception/interrupt exit API
+ * @brief ARM Cortex-M and Cortex-R exception/interrupt exit API
  *
  *
  * Provides functions for performing kernel handling when exiting exceptions or

--- a/arch/arm/core/exc_exit.S
+++ b/arch/arm/core/exc_exit.S
@@ -14,9 +14,9 @@
  * wrapped around by _isr_wrapper()).
  */
 
-#include <kernel_structs.h>
-#include <offsets_short.h>
 #include <toolchain.h>
+#include <linker/sections.h>
+#include <offsets_short.h>
 #include <arch/cpu.h>
 
 _ASM_FILE_PROLOGUE

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -6,9 +6,10 @@
 
 /**
  * @file
- * @brief Kernel fatal error handler for ARM Cortex-M
+ * @brief Kernel fatal error handler for ARM Cortex-M and Cortex-R
  *
- * This module provides the z_NanoFatalErrorHandler() routine for ARM Cortex-M.
+ * This module provides the z_arm_fatal_error() routine for ARM Cortex-M
+ * and Cortex-R CPUs.
  */
 
 #include <toolchain.h>

--- a/arch/arm/core/fault_s.S
+++ b/arch/arm/core/fault_s.S
@@ -6,9 +6,9 @@
 
 /**
  * @file
- * @brief Fault handlers for ARM Cortex-M
+ * @brief Fault handlers for ARM Cortex-M and Cortex-R
  *
- * Fault handlers for ARM Cortex-M processors.
+ * Fault handlers for ARM Cortex-M and Cortex-R processors.
  */
 
 #include <toolchain.h>

--- a/arch/arm/core/irq_manage.c
+++ b/arch/arm/core/irq_manage.c
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief ARM Cortex-M interrupt management
+ * @brief ARM Cortex-M and Cortex-R interrupt management
  *
  *
  * Interrupt management: enabling/disabling and dynamic ISR

--- a/arch/arm/core/isr_wrapper.S
+++ b/arch/arm/core/isr_wrapper.S
@@ -12,12 +12,12 @@
  * a parameter.
  */
 
-#include <offsets_short.h>
 #include <toolchain.h>
 #include <linker/sections.h>
-#include <sw_isr_table.h>
-#include <kernel_structs.h>
+#include <offsets_short.h>
 #include <arch/cpu.h>
+#include <sw_isr_table.h>
+
 
 _ASM_FILE_PROLOGUE
 

--- a/arch/arm/core/isr_wrapper.S
+++ b/arch/arm/core/isr_wrapper.S
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief ARM Cortex-M wrapper for ISRs with parameter
+ * @brief ARM Cortex-M and Cortex-R wrapper for ISRs with parameter
  *
  * Wrapper installed in vector table for handling dynamic interrupts that accept
  * a parameter.

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -1,15 +1,16 @@
 /*
  * Copyright (c) 2013-2014 Wind River Systems, Inc.
+ * Copyright (c) 2017-2019 Nordic Semiconductor ASA.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 /**
  * @file
- * @brief Thread context switching for ARM Cortex-M
+ * @brief Thread context switching for ARM Cortex-M and Cortex-R
  *
  * This module implements the routines necessary for thread context switching
- * on ARM Cortex-M CPUs.
+ * on ARM Cortex-M and Cortex-R CPUs.
  */
 
 #include <toolchain.h>

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -12,9 +12,9 @@
  * on ARM Cortex-M CPUs.
  */
 
-#include <kernel_structs.h>
-#include <offsets_short.h>
 #include <toolchain.h>
+#include <linker/sections.h>
+#include <offsets_short.h>
 #include <arch/cpu.h>
 #include <syscall.h>
 

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -6,9 +6,10 @@
 
 /**
  * @file
- * @brief New thread creation for ARM Cortex-M
+ * @brief New thread creation for ARM Cortex-M and Cortex-R
  *
- * Core thread related primitives for the ARM Cortex-M processor architecture.
+ * Core thread related primitives for the ARM Cortex-M and Cortex-R
+ * processor architecture.
  */
 
 #include <kernel.h>

--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -7,11 +7,9 @@
  *
  */
 
-#include <offsets_short.h>
 #include <toolchain.h>
 #include <linker/sections.h>
-#include <kernel_structs.h>
-#include <arch/cpu.h>
+#include <offsets_short.h>
 #include <syscall.h>
 
 _ASM_FILE_PROLOGUE


### PR DESCRIPTION
A clean-up commit that removes unnecessary inclusions from
assembly files in arm/core and arm/core/cortex_m.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

No functional changes.

A second commit enhances the file descriptions under /arm/core, to stress that these are common source for -M and -R CPUs