### PR TITLE
Code Coverage: Fix the issue of function code coverage in thread.c

### DIFF
--- a/tests/kernel/sched/preempt/src/main.c
+++ b/tests/kernel/sched/preempt/src/main.c
@@ -102,8 +102,8 @@ void wakeup_src_thread(int id)
 	for (int i = 0; i < NUM_THREADS; i++) {
 		k_tid_t th = &worker_threads[i];
 
-		zassert_true(th->base.thread_state & _THREAD_PENDING,
-			     "worker thread %d not pending?", i);
+		zassert_equal(strcmp(k_thread_state_str(th), "pending"),
+				0, "worker thread %d not pending?", i);
 	}
 
 	/* Wake the src worker up */


### PR DESCRIPTION
The k_thread_state_str is a new function added into
kernel/thread.c recently which was used to return
the human friendly thread state, so it hasn't been
called by other existing code.
In order to improve the function code coverage, we
just replace the "th->base.thread_state & _THREAD_PENDING"
code by using k_thread_state_str function in
tests/kernel/sched/preempt/src/main.c, because
k_thread_state_str function is realized by judging
the thread_state member to return the thread state.

Signed-off-by: chen peng <peng1.chen@intel.com>