### PR TITLE
drivers: flash: nrf: Change write_block_size parameter to 32-bits

### DIFF
--- a/drivers/flash/Kconfig.nrf
+++ b/drivers/flash/Kconfig.nrf
@@ -33,4 +33,12 @@ config SOC_FLASH_NRF_UICR
 	  Enable operations on UICR. Once enabled UICR are written or read as
 	  ordinary flash memory. Erase is possible for whole UICR at once.
 
+config SOC_FLASH_NRF_EMULATE_ONE_BYTE_WRITE_ACCESS
+	bool "8-bit write block size emulation"
+	depends on SOC_FLASH_NRF
+	help
+	  When this option is enabled writing chunks less than minimal write
+	  block size parameter (imposed by manufacturer) is possible but operation
+	  is more complex and requires basic user knowledge about NVMC controller.
+
 endif #!FLASH_NRF_FORCE_ALT


### PR DESCRIPTION
According to NRF product specifications

Signed-off-by: Adam Kondraciuk <adam.kondraciuk@nordicsemi.no>