### PR TITLE
[WIP] ICMP: Option to disable checking checksum

### DIFF
--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -67,6 +67,14 @@ config NET_IPV4_AUTO
 	help
 	  Enables IPv4 auto IP address configuration (see RFC 3927)
 
+config NET_ICMPV4_CHECKSUM
+	bool "Check ICMPv4 checksum"
+	default y
+	help
+	  Enables ICMPv4 handler to check ICMPv4 checksum. If the checksum is
+	  invalid, then the packet is discarded.
+
+
 module = NET_IPV4
 module-dep = NET_LOG
 module-str = Log level for core IPv4

--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -119,6 +119,13 @@ config NET_IPV6_RA_RDNSS
 	  Support Router Advertisement Recursive DNS Server option.
 	  See RFC 6106 for details. The value depends on your network needs.
 
+config NET_ICMPV6_CHECKSUM
+	bool "Check ICMPv6 checksum"
+	default y
+	help
+	  Enables ICMPv6 handler to check ICMPv6 checksum. If the checksum is
+	  invalid, then the packet is discarded.
+
 config NET_6LO
 	bool "Enable 6lowpan IPv6 Compression library"
 	default y if NET_L2_IEEE802154

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -310,7 +310,7 @@ enum net_verdict net_icmpv4_input(struct net_pkt *pkt,
 		return NET_DROP;
 	}
 
-	if (net_calc_chksum_icmpv4(pkt) != 0U) {
+	if (IS_ENABLED(CONFIG_NET_ICMPV4_CHECKSUM) && net_calc_chksum_icmpv4(pkt) != 0U) {
 		NET_DBG("DROP: Invalid checksum");
 		goto drop;
 	}

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -373,7 +373,7 @@ enum net_verdict net_icmpv6_input(struct net_pkt *pkt,
 		return NET_DROP;
 	}
 
-	if (net_calc_chksum_icmpv6(pkt) != 0U) {
+	if (IS_ENABLED(CONFIG_NET_ICMPV6_CHECKSUM) && net_calc_chksum_icmpv6(pkt) != 0U) {
 		NET_DBG("DROP: invalid checksum");
 		goto drop;
 	}


### PR DESCRIPTION
Previously, the samples/bluetooth/ipsp example did not work.

The following appeared after enabling network debug logging.

[00:05:42.240,753] <dbg> net_ipv6.net_ipv6_input: (0x20001e48): IPv6 packet len 72 received from fe80::5ef3:70ff:fe92:5c06 to ff02::1:ffe9:6fd0
[00:05:42.240,814] <dbg> net_icmpv6.net_icmpv6_input: (0x20001e48): DROP: invalid checksum

As @tbursztyka theorized in Slack, Linux was producing a correct ICMPv6 checksum, as shown by Wireshark (this was taken after my change was applied).
![wireshark-zephyr-icmpv6-checksum](https://user-images.githubusercontent.com/983494/66492868-18d8fd80-ea83-11e9-9f41-2965bbd77ac7.png)

After inspecting the code, indeed it seems to be the case that if net_calc_chksum_icmpv6(pkt) != 0U, then the packet is dropped.

It's possible that 6LowPan code (either in Linux or Zephyr) is not handling the IPv6 checksum properly, but I have not investigated any further.

Ideally, there would be an easy way to enable ICMPv6 checksum in Linux via /proc/sys/net/ipv6/icmp but the only node that exists there (at least on my desk) is ratelimit. If there were an easy way to enable it, then the Zephyr documentation could simply be modified.

It is a bit of a blocker to simply run a demo application. However, as @jukkar pointed out in Slack, it would be desirable to keep the checksum by default but allow it to be disabled (independently) for ICMPv6 and ICMPv4.

Therefore, I'm proposing to add a Kconfig variable to disable ICMP checksum verification and to explicitly set it to n for samples/bluetooth/ipsp.

That would also ensure that both the example and documentation remains consistent as well as the current behaviour of the ICMPv4 and ICMPv6 code.