### PR TITLE
sensor: lis2dh: fix SPI burst transfers

### DIFF
--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -144,7 +144,7 @@ static int lis2dh_sample_fetch(struct device *dev, enum sensor_channel chan)
 
 	for (i = 0; i < (3 * sizeof(s16_t)); i += sizeof(s16_t)) {
 		s16_t *sample =
-			(s16_t *)&lis2dh->sample.raw[LIS2DH_DATA_OFS + 1 + i];
+			(s16_t *)&lis2dh->sample.raw[1 + i];
 
 		*sample = sys_le16_to_cpu(*sample);
 	}
@@ -316,7 +316,7 @@ int lis2dh_init(struct device *dev)
 {
 	struct lis2dh_data *lis2dh = dev->driver_data;
 	int status;
-	u8_t raw[LIS2DH_DATA_OFS + 6];
+	u8_t raw[6];
 
 	status = lis2dh_bus_configure(dev);
 	if (status < 0) {
@@ -329,7 +329,7 @@ int lis2dh_init(struct device *dev)
 	 * Default values see LIS2DH documentation page 30, chapter 6.
 	 */
 	(void)memset(raw, 0, sizeof(raw));
-	raw[LIS2DH_DATA_OFS] = LIS2DH_ACCEL_EN_BITS;
+	raw[0] = LIS2DH_ACCEL_EN_BITS;
 
 	status = lis2dh_burst_write(dev, LIS2DH_REG_CTRL1, raw,
 				    sizeof(raw));

--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -166,13 +166,7 @@
 #define LIS2DH_REG_INT2_DUR		0x37
 
 /* sample buffer size includes status register */
-#if defined(DT_ST_LIS2DH_BUS_SPI)
-#define LIS2DH_BUF_SZ			8
-#define LIS2DH_DATA_OFS			1
-#else
 #define LIS2DH_BUF_SZ			7
-#define LIS2DH_DATA_OFS			0
-#endif
 
 #if defined(DT_INST_0_ST_LIS2DH_IRQ_GPIOS_CONTROLLER_1)
 /* INT1 and INT2 are configured */
@@ -189,9 +183,6 @@
 union lis2dh_sample {
 	u8_t raw[LIS2DH_BUF_SZ];
 	struct {
-#if defined(DT_ST_LIS2DH_BUS_SPI)
-		u8_t dummy;
-#endif
 		u8_t status;
 		s16_t xyz[3];
 	} __packed;

--- a/drivers/sensor/lis2dh/lis2dh_trigger.c
+++ b/drivers/sensor/lis2dh/lis2dh_trigger.c
@@ -356,7 +356,7 @@ int lis2dh_init_interrupt(struct device *dev)
 {
 	struct lis2dh_data *lis2dh = dev->driver_data;
 	int status;
-	u8_t raw[LIS2DH_DATA_OFS + 2];
+	u8_t raw[2];
 
 	/* setup data ready gpio interrupt */
 	lis2dh->gpio_int1 = device_get_binding(DT_LIS2DH_INT1_GPIO_DEV_NAME);


### PR DESCRIPTION
After switching to new SPI API there is no need to reserve first dummy
byte in buffer and ignore that in application later on. Instead two
buffers can be specified, which is how it is done already in lis2dh
driver. The problem is that dummy byte is still part of the buffer, but
it clearly should no longer be. As an example we write 0x7 (bits to
enable XYZ axes) into CTRL2 instead of CTRL1 register. When reading
measurements on the other hand we have filled buffer starting from 0,
instead of 1 as the driver code has expected.

Fix driver in all places that use burst transfers by removing first
dummy byte from input/output buffer.

Fixes: 2f7e6b6d42af ("drivers/sensors: Switch lis2dh driver to new SPI
  API")
Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>