### PR TITLE
kernel: improve C++ compatibility

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4592,8 +4592,8 @@ struct k_poll_event {
 #define K_POLL_EVENT_STATIC_INITIALIZER(event_type, event_mode, event_obj, \
 					event_tag) \
 	{ \
-	.type = event_type, \
 	.tag = event_tag, \
+	.type = event_type, \
 	.state = K_POLL_STATE_NOT_READY, \
 	.mode = event_mode, \
 	.unused = 0, \


### PR DESCRIPTION
This patch improves C++ compatibility by reordering the
K_POLL_EVENT_STATIC_INITIALIZER designated initializer macro so its
designators appear in the same order as the members they initialize.

Signed-off-by: Markus Fuchs <markus.fuchs@de.sauter-bc.com>