### PR TITLE
boards: mec: mec15modular: Update documentation with power management setup

### DIFF
--- a/boards/arm/mec1501modular_assy6885/doc/index.rst
+++ b/boards/arm/mec1501modular_assy6885/doc/index.rst
@@ -22,23 +22,31 @@ Hardware
 - 256 KB RAM and 64 KB boot ROM
 - GPIO headers
 - UART1 using microUSB
-- UART0 and UART2 exposed in headers
-- FAN0, FAN1, FAN2 headers
-- FAN PWM interface
-- JTAG/SWD, ETM and MCHP Trace ports
 - PECI interface 3.0
-- I2C voltage translator
-- 10 SMBUS headers
-- 4 SGPIO headers
+- 10 SMBUS instances
+- FAN, PMW and TACHO pins
 - VCI interface
-- 5 independent Hardware Driven PS/2 Ports
-- eSPI header
-- 3 Breathing/Blinking LEDs
-- 2 Sockets for SPI NOR chips
-- One reset and VCC_PWRDGD pushbuttons
-- One external PCA9555 I/O port with jumper selectable I2C address.
-- One external LTC2489 delta-sigma ADC with jumper selectable I2C address.
-- Board power jumper selectable from +5V 2.1mm/5.5mm barrel connector or USB Micro A connector.
+- Independent Hardware Driven PS/2 Ports
+
+At difference from MEC15xx evaluation board, modular MEC1501 exposes the pins
+in 2 different ways:
+
+1) Standalone mode via headers
+
+   - GPIOs
+   - PWM5
+   - JTAG/SWD, ETM and MCHP Trace ports
+   - eSPI bus
+   - SMB0
+
+2) Mated mode with another platform that has a high density MECC connector.
+
+   - FAN0, PWM0, SMB0, SMB1, SMB4 and SMB5
+   - eSPI bus
+   - Breathing/Blinking LEDs
+
+The board is powered through the +5V USB Micro A connector or from the MECC connector.
+
 
 For more information about the SOC please see the `MEC1501 Reference Manual`_
 
@@ -64,6 +72,18 @@ features:
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
 | PINMUX    | on-chip    | pinmux                              |
++-----------+------------+-------------------------------------+
+| RTOS      | on-chip    | timer                               |
++-----------+------------+-------------------------------------+
+| TIMER     | on-chip    | counter                             |
++-----------+------------+-------------------------------------+
+| PWM       | on-chip    | pwm                                 |
++-----------+------------+-------------------------------------+
+| ADC       | on-chip    | adc                                 |
++-----------+------------+-------------------------------------+
+| WATCHDOG  | on-chip    | watchdog                            |
++-----------+------------+-------------------------------------+
+| PS2       | on-chip    | ps2                                 |
 +-----------+------------+-------------------------------------+
 
 Other hardware features are not currently supported by Zephyr (at the moment)
@@ -110,29 +130,32 @@ set the jumper to ``JP35 3-4``.
 
 .. note:: A single jumper is required in JP35.
 
-+------+------+------+------+------+------+------+
-| JP30 | JP31 | JP32 | JP33 | JP34 | JP40 | JP21 |
-+======+======+======+======+======+======+======+
-| 1-2  | 1-2  | 1-2  | 1-2  |  1-2 | 1-2  | 1-2  |
-+------+------+------+------+------+------+------+
++------+---------+---------+------+------+------+----------+
+| JP30 | JP31    | JP32    | JP33 | JP34 | JP40 | JP21     |
+| VTR3 | VTR_PLL | VTR_REG | VTR1 | VTR2 | 3.3V | VREF_ADC |
++======+=========+=========+======+======+======+==========+
+| 1-2  |   1-2   |   1-2   | 1-2  |  1-2 | 1-2  |   1-2    |
++------+---------+---------+------+------+------+----------+
 
-+------+------+------+------+------+
-| JP6  | JP21 | JP36 | JP27 | JP4  |
-+======+======+======+======+======+
-| 2-3  | 1-2  | 1-2  | 2-3  | open |
-+------+------+------+------+------+
+
++------+------------+------+----------+
+| JP6  | JP36       | JP27 | JP4      |
+| VBAT | VTR_ANALOG | PECI | VREF_VTT |
++======+============+======+==========+
+| 2-3  |    1-2     | 2-3  |   open   |
++------+------------+------+----------+
 
 These jumpers configure nRESETI and JTAG_STRAP respectively.
 
-+-----------+--------------+
-| JP22      | JP29         |
-| (nRESETI) | (JTAG_STRAP) |
-+===========+==============+
-| 11-12     | 1-2          |
-+-----------+--------------+
++-----------+---------------+
+| JP22      | JP29          |
+| (nRESETI) | (JTAG_STRAP)  |
++===========+===============+
+| 11-12     | 1-2           |
++-----------+---------------+
 
-Boot-ROM Straps.
-----------------
+Boot-ROM Straps
+---------------
 
 These jumpers configure MEC1501 Boot-ROM straps.
 
@@ -158,9 +181,22 @@ This is the recommended setup.
 |             |     1      |  Use 3.3V Shared channel(R)|
 +-------------+------------+----------------------------+
 
+Power management
+----------------
+``JP20 2-3`` is required so all GPIOs powered by VTR3 rail worked at 1.8V.
 
-Jumper location map.
---------------------
+.. note:: External 1.8V needs to be connected to JP13.1
+
++-------------------+-----------------+
+| JP20              | JP13            |
+| (VTR3 selection)  | (1.8V source)   |
++===================+=================+
+|   2-3             | 1.8V to pin 1   |
++-------------------+-----------------+
+
+
+Jumper location map
+-------------------
 
 .. code-block:: none
 
@@ -186,9 +222,9 @@ Jumper location map.
    |    J45+---------------+  JP33 TP57      JP25            +-------------+ J4       J49 |
    |                                                                                      |
    | ++                                           TP4   +----------+   ++                 |
-   | ++     +    +      +    +    +     +  TP61         +----------+   ++                 |
-   | JP28   +    +      +    +    +     +  TP60            J51        JP35                |
-   |      TP58 JP16   JP11 JP13 JP15  JP10                                                |
+   | ++     +    +      +    +    +       +  TP61         +----------+   ++               |
+   | JP28   +    +      +    +    +  TP65 +  TP60            J51        JP35              |
+   |      TP58 JP16   JP11 JP13 JP15     JP10                                             |
    | TP5                                                                                  |
    | TP6                                        TP1                                       |
    +--------------------------------------------------------------------------------------+
@@ -196,6 +232,30 @@ Jumper location map.
 
 Programming and Debugging
 *************************
+
+Setup
+=====
+
+#. Clone the `SPI Image Gen`_ repository or download the files within
+   that directory.
+
+#. Make the image generation available for Zephyr, by making the tool
+   searchable by path, or by setting an environment variable
+   ``EVERGLADES_SPI_GEN``, for example:
+
+   .. code-block:: console
+
+      export EVERGLADES_SPI_GEN=<path to tool>/everglades_spi_gen_lin64
+
+   Note that the tools for Linux and Windows have different file names.
+
+#. If needed, a custom SPI image configuration file can be specified
+   to override the default one.
+
+   .. code-block:: console
+
+      export EVERGLADES_SPI_CFG=custom_spi_cfg.txt
+
 
 Building
 ==========

--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885_defconfig
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885_defconfig
@@ -7,6 +7,7 @@
 CONFIG_ARM=y
 CONFIG_SOC_MEC1501_HSZ=y
 CONFIG_SOC_SERIES_MEC1501X=y
+# Make sure external power management setup is as indicated in documentation
 CONFIG_SOC_MEC1501_VTR3_1_8V=y
 CONFIG_BOARD_MEC1501MODULAR_ASSY6885=y
 CONFIG_RTOS_TIMER=y


### PR DESCRIPTION
Add details for features exposed via headers.
Add power management recommended setup.
Add setup information to generate binary that can be flashed into SPI chip.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>