### PR TITLE
test_pipe_contexts: fix mempool size issue and async pipe coverage

### DIFF
--- a/tests/kernel/pipe/pipe_api/src/main.c
+++ b/tests/kernel/pipe/pipe_api/src/main.c
@@ -20,6 +20,7 @@ extern void test_pipe_block_put(void);
 extern void test_pipe_block_put_sema(void);
 extern void test_pipe_get_put(void);
 extern void test_half_pipe_get_put(void);
+extern void test_half_pipe_saturating_block_put(void);
 extern void test_half_pipe_block_put_sema(void);
 extern void test_pipe_alloc(void);
 extern void test_pipe_reader_wait(void);
@@ -73,6 +74,7 @@ void test_main(void)
 			 ztest_1cpu_unit_test(test_pipe_get_put),
 			 ztest_unit_test(test_half_pipe_block_put_sema),
 			 ztest_unit_test(test_half_pipe_get_put),
+			 ztest_unit_test(test_half_pipe_saturating_block_put),
 			 ztest_1cpu_unit_test(test_pipe_alloc),
 			 ztest_unit_test(test_pipe_reader_wait),
 			 ztest_1cpu_unit_test(test_pipe_block_writer_wait));

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
@@ -7,12 +7,15 @@
 #include <ztest.h>
 
 #define STACK_SIZE	(1024 + CONFIG_TEST_EXTRA_STACKSIZE)
-#define PIPE_LEN	16
-#define BYTES_TO_WRITE	4
+#define PIPE_LEN	(4 * _MPOOL_MINBLK)
+#define BYTES_TO_WRITE	_MPOOL_MINBLK
 #define BYTES_TO_READ BYTES_TO_WRITE
-K_MEM_POOL_DEFINE(mpool, BYTES_TO_WRITE, PIPE_LEN, 1, BYTES_TO_WRITE);
+K_MEM_POOL_DEFINE(mpool, BYTES_TO_WRITE, PIPE_LEN, 1, 4);
 
-static ZTEST_DMEM unsigned char __aligned(4) data[] = "abcd1234$%^&PIPE";
+static ZTEST_DMEM unsigned char __aligned(4) data[] =
+"abcd1234$%^&PIPEefgh5678!/?*EPIPijkl9012[]<>PEPImnop3456{}()IPEP";
+BUILD_ASSERT(sizeof(data) >= PIPE_LEN);
+
 /**TESTPOINT: init via K_PIPE_DEFINE*/
 K_PIPE_DEFINE(kpipe, PIPE_LEN, 4);
 K_PIPE_DEFINE(khalfpipe, (PIPE_LEN / 2), 4);
@@ -291,6 +294,36 @@ void test_half_pipe_get_put(void)
 				      tThread_half_pipe_put, &khalfpipe,
 				      NULL, NULL, K_PRIO_PREEMPT(0),
 				      K_INHERIT_PERMS | K_USER, K_NO_WAIT);
+
+	tpipe_get(&khalfpipe, K_FOREVER);
+
+	/* clear the spawned thread avoid side effect */
+	k_thread_abort(tid);
+}
+
+/**
+ * @brief Test get/put with saturating smaller pipe buffer
+ * @see k_pipe_put(), k_pipe_get()
+ */
+void test_half_pipe_saturating_block_put(void)
+{
+	int r[3];
+	struct k_mem_block blocks[3];
+
+	/**TESTPOINT: thread-thread data passing via pipe*/
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      tThread_half_pipe_block_put, &khalfpipe,
+				      NULL, NULL, K_PRIO_PREEMPT(0), 0, 0);
+
+	k_sleep(10);
+
+	/* Ensure half the mempool is still queued in the pipe */
+	r[0] = k_mem_pool_alloc(&mpool, &blocks[0], BYTES_TO_WRITE, K_NO_WAIT);
+	r[1] = k_mem_pool_alloc(&mpool, &blocks[1], BYTES_TO_WRITE, K_NO_WAIT);
+	r[2] = k_mem_pool_alloc(&mpool, &blocks[2], BYTES_TO_WRITE, K_NO_WAIT);
+	zassert_true(r[0] == 0 && r[1] == 0 && r[2] == -ENOMEM, NULL);
+	k_mem_pool_free(&blocks[0]);
+	k_mem_pool_free(&blocks[1]);
 
 	tpipe_get(&khalfpipe, K_FOREVER);
 


### PR DESCRIPTION
The minimum possible mempool block size is either 8 or 16 for 32-bit or
64-bit targets respectively. Defining BYTES_TO_WRITE to 4 and using that
with K_MEM_POOL_DEFINE() won't produce the expected result i.e. only 1
block at any time could be allocated instead of 4.

Yet, the test does run successfully regardless of the block allocation
loop in tpipe_block_put().

It turns out that the pipe buffer is large enough to consume all the
block data synchronously, meaning that the mempool block is freed right
away and available for the next loop iteration. This also means that the
asynchronous delivery mechanism is never exercized.

Fix both issues by defining PIPE_LEN and BYTES_TO_WRITE in terms of
_MPOOL_MINBLK with the expected factor of 4, and adding a new test
using the half-sized pipe where the pipe buffer gets saturated and
mempool memory blocks are actually queued for asynchronous consumption.

The source data string has to be extended to accommodate larger pipe
sizes too.