### PR TITLE
cmake: need to specify m32/mx32/m64 for x86_64 toolchain

### DIFF
--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -54,6 +54,8 @@ elseif("${ARCH}" STREQUAL "riscv")
   else()
     list(APPEND TOOLCHAIN_C_FLAGS -mabi=ilp32 -march=rv32ima)
   endif()
+elseif("${ARCH}" STREQUAL "x86")
+  include(${CMAKE_CURRENT_LIST_DIR}/target_x86.cmake)
 endif()
 
 if(NOT no_libgcc)

--- a/cmake/compiler/gcc/target_x86.cmake
+++ b/cmake/compiler/gcc/target_x86.cmake
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_X86_64)
+  string(PREPEND CMAKE_ASM_FLAGS "-m64 ")
+  string(PREPEND CMAKE_C_FLAGS   "-m64 ")
+  string(PREPEND CMAKE_CXX_FLAGS "-m64 ")
+else()
+  string(PREPEND CMAKE_ASM_FLAGS "-m32 ")
+  string(PREPEND CMAKE_C_FLAGS   "-m32 ")
+  string(PREPEND CMAKE_CXX_FLAGS "-m32 ")
+endif()

--- a/cmake/compiler/host-gcc/target.cmake
+++ b/cmake/compiler/host-gcc/target.cmake
@@ -4,18 +4,6 @@
 
 find_program(CMAKE_C_COMPILER gcc)
 
-# -march={pentium,lakemont,...} do not automagically imply -m32, so
-# adding it here.
-
-# Maybe the -m32/-miamcu FLAGS should all be next to -march= in the
-# longer term?
-if (CONFIG_X86)
-  string(PREPEND CMAKE_ASM_FLAGS             "-m32 ")
-  string(PREPEND CMAKE_C_FLAGS               "-m32 ")
-  string(PREPEND CMAKE_CXX_FLAGS             "-m32 ")
-  string(PREPEND CMAKE_SHARED_LINKER_FLAGS   "-m32 ") # unused?
-endif()
-
 if(CONFIG_CPLUSPLUS)
   set(cplusplus_compiler g++)
 else()

--- a/cmake/toolchain/xtools/target.cmake
+++ b/cmake/toolchain/xtools/target.cmake
@@ -2,17 +2,21 @@
 
 set(CROSS_COMPILE_TARGET_arm         arm-zephyr-eabi)
 set(CROSS_COMPILE_TARGET_nios2     nios2-zephyr-elf)
-set(CROSS_COMPILE_TARGET_riscv   riscv32-zephyr-elf)
+set(CROSS_COMPILE_TARGET_riscv   riscv64-zephyr-elf)
 set(CROSS_COMPILE_TARGET_mips     mipsel-zephyr-elf)
 set(CROSS_COMPILE_TARGET_xtensa   xtensa-zephyr-elf)
 set(CROSS_COMPILE_TARGET_arc         arc-zephyr-elf)
-set(CROSS_COMPILE_TARGET_x86        i586-zephyr-elf)
+
+if(CONFIG_X86_64)
+  set(CROSS_COMPILE_TARGET_x86 x86_64-zephyr-elf)
+else()
+  set(CROSS_COMPILE_TARGET_x86 i586-zephyr-elf)
+endif()
 
 set(CROSS_COMPILE_TARGET ${CROSS_COMPILE_TARGET_${ARCH}})
 set(SYSROOT_TARGET       ${CROSS_COMPILE_TARGET})
 
 set(CROSS_COMPILE ${TOOLCHAIN_HOME}/${CROSS_COMPILE_TARGET}/bin/${CROSS_COMPILE_TARGET}-)
-set(SYSROOT_DIR   ${TOOLCHAIN_HOME}/${SYSROOT_TARGET}/${SYSROOT_TARGET})
 
 if("${ARCH}" STREQUAL "xtensa")
   set(SYSROOT_DIR ${TOOLCHAIN_HOME}/${SYSROOT_TARGET})
@@ -24,3 +28,4 @@ if("${ARCH}" STREQUAL "xtensa")
   LIST(APPEND TOOLCHAIN_LIBS hal)
   LIST(APPEND LIB_INCLUDE_DIR -L${SYSROOT_DIR}/lib)
 endif()
+set(SYSROOT_DIR   ${TOOLCHAIN_HOME}/${SYSROOT_TARGET}/${SYSROOT_TARGET})

--- a/cmake/toolchain/xtools/target.cmake
+++ b/cmake/toolchain/xtools/target.cmake
@@ -29,3 +29,20 @@ if("${ARCH}" STREQUAL "xtensa")
   LIST(APPEND LIB_INCLUDE_DIR -L${SYSROOT_DIR}/lib)
 endif()
 set(SYSROOT_DIR   ${TOOLCHAIN_HOME}/${SYSROOT_TARGET}/${SYSROOT_TARGET})
+
+if("${ARCH}" STREQUAL "x86")
+  if(CONFIG_X86_64)
+    if(CONFIG_LIB_CPLUSPLUS)
+      # toolchain was built with a few missing bits in
+      # the multilib configuration so we need to specify
+      # where to find the 64-bit libstdc++.
+      LIST(APPEND LIB_INCLUDE_DIR -L${SYSROOT_DIR}/lib64)
+    endif()
+
+    list(APPEND TOOLCHAIN_C_FLAGS -m64)
+    list(APPEND TOOLCHAIN_LD_FLAGS -m64)
+  else()
+    list(APPEND TOOLCHAIN_C_FLAGS -m32)
+    list(APPEND TOOLCHAIN_LD_FLAGS -m32)
+  endif()
+endif()

--- a/cmake/toolchain/zephyr/0.10/target.cmake
+++ b/cmake/toolchain/zephyr/0.10/target.cmake
@@ -29,3 +29,20 @@ if("${ARCH}" STREQUAL "xtensa")
   LIST(APPEND LIB_INCLUDE_DIR -L${SYSROOT_DIR}/lib)
 endif()
 set(SYSROOT_DIR   ${TOOLCHAIN_HOME}/${SYSROOT_TARGET}/${SYSROOT_TARGET})
+
+if("${ARCH}" STREQUAL "x86")
+  if(CONFIG_X86_64)
+    if(CONFIG_LIB_CPLUSPLUS)
+      # toolchain was built with a few missing bits in
+      # the multilib configuration so we need to specify
+      # where to find the 64-bit libstdc++.
+      LIST(APPEND LIB_INCLUDE_DIR -L${SYSROOT_DIR}/lib64)
+    endif()
+
+    list(APPEND TOOLCHAIN_C_FLAGS -m64)
+    list(APPEND TOOLCHAIN_LD_FLAGS -m64)
+  else()
+    list(APPEND TOOLCHAIN_C_FLAGS -m32)
+    list(APPEND TOOLCHAIN_LD_FLAGS -m32)
+  endif()
+endif()


### PR DESCRIPTION
Since x86_64-zephyr-elf is a multi-lib toolchain, m32/mx32/m64
need to be specified for the compiler to return the correct
library path when queried (e.g. --print-libgcc-file-name).
This affects the compile check done by CMake. Without these
flags, the compiler returns incorrect toolchain path (e.g.
requiring 64-bit libraries but returning 32-bit library path).
This also affects compiler flag checks for "-lstdc++". Incorrect
library path results in error when checking for "-lstdc++", and
this flag will not be used for the build. This results in
undefined references when compiling C++ code.
    
This creates target_x86.cmake to add the necessary flags for
CMake to use. The target_x86_64.cmake is also created to
mirror the same change.
    
Also removing the -m32 flags for host-gcc since we are not
building x86 targets with the host-gcc compiler.
    
Signed-off-by: Daniel Leung <daniel.leung@intel.com>