### PR TITLE
Bluetooth: controller: split: Call LLL reset functions from ll_reset

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -292,6 +292,7 @@ static inline int lll_is_stop(void *lll)
 }
 
 int lll_init(void);
+int lll_reset(void);
 int lll_prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 		lll_prepare_cb_t prepare_cb, int prio,
 		struct lll_prepare_param *prepare_param);

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -218,6 +218,7 @@ static void *mark_update;
 static void *mark_disable;
 
 static inline int init_reset(void);
+static void perform_lll_reset(void *param);
 static inline void *mark_set(void **m, void *param);
 static inline void *mark_unset(void **m, void *param);
 static inline void *mark_get(void *m);
@@ -396,6 +397,19 @@ void ll_reset(void)
 	/* Re-initialize the free ll rx mfifo */
 	MFIFO_INIT(ll_pdu_rx_free);
 #endif /* CONFIG_BT_CONN */
+
+	/* Reset LLL via mayfly */
+	{
+		u32_t retval;
+		static memq_link_t link;
+		static struct mayfly mfy = {0, 0, &link, NULL,
+					    perform_lll_reset};
+
+		mfy.param = NULL;
+		retval = mayfly_enqueue(TICKER_USER_ID_THREAD,
+					TICKER_USER_ID_LLL, 0, &mfy);
+		LL_ASSERT(!retval);
+	}
 
 	/* Common to init and reset */
 	err = init_reset();
@@ -1156,6 +1170,33 @@ static inline int init_reset(void)
 	rx_alloc(UINT8_MAX);
 
 	return 0;
+}
+
+static void perform_lll_reset(void *param)
+{
+	int err;
+
+	/* Reset LLL */
+	err = lll_reset();
+	LL_ASSERT(!err);
+
+#if defined(CONFIG_BT_BROADCASTER)
+	/* Reset adv state */
+	err = lll_adv_reset();
+	LL_ASSERT(!err);
+#endif /* CONFIG_BT_BROADCASTER */
+
+#if defined(CONFIG_BT_OBSERVER)
+	/* Reset scan state */
+	err = lll_scan_reset();
+	LL_ASSERT(!err);
+#endif /* CONFIG_BT_OBSERVER */
+
+#if defined(CONFIG_BT_CONN)
+	/* Reset conn role */
+	err = lll_conn_reset();
+	LL_ASSERT(!err);
+#endif /* CONFIG_BT_CONN */
 }
 
 static inline void *mark_set(void **m, void *param)


### PR DESCRIPTION
Call LLL reset functions when calling ll_reset to avoid carrying LLL
state across HCI resets. Respective functions already exist in LLL but
had not been called from anywhere.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>