### PR TITLE
Bluetooth: controller: split: Fix ctrl proc rx node starvation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -147,9 +147,9 @@ static struct {
 } mem_link_done;
 
 #if defined(CONFIG_BT_CTLR_PHY) && defined(CONFIG_BT_CTLR_DATA_LENGTH)
-#define LL_PDU_RX_CNT 2
+#define LL_PDU_RX_CNT 3
 #else
-#define LL_PDU_RX_CNT 1
+#define LL_PDU_RX_CNT 2
 #endif
 
 #define PDU_RX_CNT    (CONFIG_BT_CTLR_RX_BUFFERS + 3)


### PR DESCRIPTION
Rx nodes are reserved during control procedures for
generation of HCI event on completion. Fix the allocation
and reservation in the form of a linked list per connection
context. Worst case, this list will hold one rx node for
overlapping non-instant control procedure (Data Length
Update) plus two rx node for control procedure with instant
(PHY update with Data Length Update support).

Fixes #19198.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>