### PR TITLE
drivers: serial: Configurable GPIO management in NRFX UARTE

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -94,6 +94,15 @@ config UART_0_NRF_HW_ASYNC_TIMER
 	int "Timer instance"
 	depends on UART_0_NRF_HW_ASYNC
 
+config UART_0_GPIO_MANAGEMENT
+	bool "Enable GPIO management on port 0"
+	depends on UART_0_NRF_UARTE && DEVICE_POWER_MANAGEMENT
+	default y
+	help
+	  If enabled, the driver will configure the GPIOs used by the uart to
+	  their default configuration when device is powered down. The GPIOs
+	  will be configured back to correct state when UART is powered up.
+
 endif # UART_0_NRF_UART || UART_0_NRF_UARTE
 
 # ----------------- port 1 -----------------
@@ -157,6 +166,15 @@ config UART_1_NRF_HW_ASYNC_TIMER
 	int "Timer instance"
 	depends on UART_1_NRF_HW_ASYNC
 
+config UART_1_GPIO_MANAGEMENT
+	bool "Enable GPIO management on port 1"
+	depends on DEVICE_POWER_MANAGEMENT
+	default y
+	help
+	  If enabled, the driver will configure the GPIOs used by the uart to
+	  their default configuration when device is powered down. The GPIOs
+	  will be configured back to correct state when UART is powered up.
+
 endif # UART_1_NRF_UARTE
 
 # ----------------- port 2 -----------------
@@ -219,6 +237,15 @@ config UART_2_NRF_HW_ASYNC_TIMER
 	int "Timer instance"
 	depends on UART_2_NRF_HW_ASYNC
 
+config UART_2_GPIO_MANAGEMENT
+	bool "Enable GPIO management on port 2"
+	depends on DEVICE_POWER_MANAGEMENT
+	default y
+	help
+	  If enabled, the driver will configure the GPIOs used by the uart to
+	  their default configuration when device is powered down. The GPIOs
+	  will be configured back to correct state when UART is powered up.
+
 endif # UART_2_NRF_UARTE
 
 # ----------------- port 3 -----------------
@@ -280,6 +307,15 @@ config UART_3_NRF_HW_ASYNC
 config UART_3_NRF_HW_ASYNC_TIMER
 	int "Timer instance"
 	depends on UART_3_NRF_HW_ASYNC
+
+config UART_3_GPIO_MANAGEMENT
+	bool "Enable GPIO management on port 3"
+	depends on DEVICE_POWER_MANAGEMENT
+	default y
+	help
+	  If enabled, the driver will configure the GPIOs used by the uart to
+	  their default configuration when device is powered down. The GPIOs
+	  will be configured back to correct state when UART is powered up.
 
 endif # UART_3_NRF_UARTE
 

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -117,6 +117,7 @@ struct uarte_nrfx_data {
 struct uarte_nrfx_config {
 	NRF_UARTE_Type *uarte_regs; /* Instance address */
 	bool rts_cts_pins_set;
+	bool gpio_mgmt;
 #ifdef CONFIG_UART_ASYNC_API
 	nrfx_timer_t timer;
 #endif
@@ -1228,9 +1229,11 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 	u32_t rx_pin = nrf_uarte_rx_pin_get(uarte);
 
 	if (new_state == DEVICE_PM_ACTIVE_STATE) {
-		nrf_gpio_pin_write(tx_pin, 1);
-		nrf_gpio_cfg_output(tx_pin);
-		nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_NOPULL);
+		if (get_dev_config(dev)->gpio_mgmt) {
+			nrf_gpio_pin_write(tx_pin, 1);
+			nrf_gpio_cfg_output(tx_pin);
+			nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_NOPULL);
+		}
 
 		nrf_uarte_enable(uarte);
 #ifdef CONFIG_UART_ASYNC_API
@@ -1250,8 +1253,10 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 #ifdef CONFIG_UART_ASYNC_API
 		if (get_dev_data(dev)->async) {
 			nrf_uarte_disable(uarte);
-			nrf_gpio_cfg_default(tx_pin);
-			nrf_gpio_cfg_default(rx_pin);
+			if (get_dev_config(dev)->gpio_mgmt) {
+				nrf_gpio_cfg_default(tx_pin);
+				nrf_gpio_cfg_default(rx_pin);
+			}
 			return;
 		}
 #endif
@@ -1261,8 +1266,10 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 		}
 		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXTO);
 		nrf_uarte_disable(uarte);
-		nrf_gpio_cfg_default(tx_pin);
-		nrf_gpio_cfg_default(rx_pin);
+		if (get_dev_config(dev)->gpio_mgmt) {
+			nrf_gpio_cfg_default(tx_pin);
+			nrf_gpio_cfg_default(rx_pin);
+		}
 	}
 }
 
@@ -1308,6 +1315,7 @@ static int uarte_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 		.uarte_regs = (NRF_UARTE_Type *)			       \
 			DT_NORDIC_NRF_UARTE_UART_##idx##_BASE_ADDRESS,	       \
 		.rts_cts_pins_set = IS_ENABLED(UARTE_##idx##_CONFIG_RTS_CTS),  \
+		.gpio_mgmt = IS_ENABLED(CONFIG_UART_##idx##_GPIO_MANAGEMENT),  \
 		COND_CODE_1(IS_ENABLED(CONFIG_UART_##idx##_NRF_HW_ASYNC),      \
 			(.timer = NRFX_TIMER_INSTANCE(			       \
 				CONFIG_UART_##idx##_NRF_HW_ASYNC_TIMER),),     \


### PR DESCRIPTION
In some applications where power management is used, it is not expected
that the GPIO pins of the UARTE is reconfigured upon power state change.
Added a Kconfig option to disable the UARTE driver management of GPIOs.
It defaults to y in order to not affect current behavior unless the user
configures it specifically.

Signed-off-by: Dennis Wildmark <dennis.wildmark@assaabloy.com>