### PR TITLE
Add Low speed connector support for 96Boards IE boards

### DIFF
--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f4/stm32f401Xe.dtsi>
+#include "96b_lscon.dtsi"
 
 / {
 	model = "Seeed Studio Carbon 96boards";

--- a/boards/arm/96b_carbon/96b_lscon.dtsi
+++ b/boards/arm/96b_carbon/96b_lscon.dtsi
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019 Linaro Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	lscon_96b: connector {
+		compatible = "96b-lscon-3v3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <13 0 &gpioc 2 0>,	/* GPIO-A */
+			   <14 0 &gpioc 3 0>,	/* GPIO-B */
+			   <15 0 &gpioc 4 0>,	/* GPIO-C */
+			   <16 0 &gpioc 5 0>,	/* GPIO-D */
+			   <17 0 &gpioc 6 0>,	/* GPIO-E */
+			   <18 0 &gpioc 7 0>,	/* GPIO-F */
+			   <19 0 &gpioc 8 0>,	/* GPIO-G */
+			   <20 0 &gpioc 9 0>;	/* GPIO-H */
+	};
+};
+
+lscon_96b_i2c0: &i2c1 {};
+lscon_96b_spi0: &spi2 {};
+lscon_96b_uart0: &usart2 {};
+lscon_96b_uart1: &usart1 {};

--- a/boards/arm/96b_carbon/doc/index.rst
+++ b/boards/arm/96b_carbon/doc/index.rst
@@ -195,6 +195,9 @@ Low Speed Header
 | 30     | NC          | NC                   |
 +--------+-------------+----------------------+
 
+More detailed information about the connectors can be found in
+`96Boards IE Specification`_.
+
 External Clock Sources
 ----------------------
 
@@ -377,3 +380,6 @@ STM32F401RET using an SWD scan.
 
 .. _STM32F401 reference manual:
    http://www.st.com/resource/en/reference_manual/dm00096844.pdf
+
+.. _96Boards IE Specification:
+    https://linaro.co/ie-specification

--- a/boards/arm/96b_nitrogen/96b_lscon.dtsi
+++ b/boards/arm/96b_nitrogen/96b_lscon.dtsi
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Linaro Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	lscon_96b: connector {
+		compatible = "96b-lscon-1v8";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <23 0 &gpio0 2 0>,	/* GPIO-A */
+			   <24 0 &gpio0 3 0>,	/* GPIO-B */
+			   <25 0 &gpio0 4 0>,	/* GPIO-C */
+			   <26 0 &gpio0 5 0>,	/* GPIO-D */
+			   <27 0 &gpio0 6 0>,	/* GPIO-E */
+			   <28 0 &gpio0 7 0>,	/* GPIO-F */
+			   <29 0 &gpio0 8 0>,	/* GPIO-G */
+			   <30 0 &gpio0 11 0>,	/* GPIO-H */
+			   <31 0 &gpio0 16 0>,	/* GPIO-I */
+			   <32 0 &gpio0 17 0>,	/* GPIO-J */
+			   <33 0 &gpio0 18 0>,	/* GPIO-K */
+			   <34 0 &gpio0 19 0>;	/* GPIO-L */
+	};
+};
+
+lscon_96b_spi0: &spi1 {};
+lscon_96b_uart0: &uart0 {};

--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <nordic/nrf52832_qfaa.dtsi>
+#include "96b_lscon.dtsi"
 
 / {
 	model = "Seeed Studio Nitrogen 96board";

--- a/boards/arm/96b_nitrogen/doc/index.rst
+++ b/boards/arm/96b_nitrogen/doc/index.rst
@@ -187,6 +187,9 @@ Low Speed Header
 | 40     | GND         | GND                  |
 +--------+-------------+----------------------+
 
+More detailed information about the connectors can be found in
+`96Boards IE Specification`_.
+
 System Clock
 ============
 
@@ -341,3 +344,6 @@ You can debug an application in the usual way.  Here is an example for the
 
 .. _pyOCD issue 259:
     https://github.com/mbedmicro/pyOCD/issues/259
+
+.. _96Boards IE Specification:
+    https://linaro.co/ie-specification

--- a/boards/arm/96b_wistrio/96b_lscon.dtsi
+++ b/boards/arm/96b_wistrio/96b_lscon.dtsi
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019 Linaro Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	lscon_96b: connector {
+		compatible = "96b-lscon-3v3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <13 0 &gpioa 8 0>,	/* GPIO-A */
+			   <14 0 &gpiob 3 0>,	/* GPIO-B */
+			   /* GPIO-C not connected */
+			   <16 0 &gpiob 5 0>,	/* GPIO-D */
+			   <17 0 &gpioa 13 0>,	/* GPIO-E */
+			   <18 0 &gpioa 14 0>,	/* GPIO-F */
+			   <19 0 &gpioa 12 0>,	/* GPIO-G */
+			   <20 0 &gpiob 4 0>;	/* GPIO-H */
+	};
+};
+
+lscon_96b_i2c0: &i2c1 {};
+lscon_96b_uart0: &usart1 {};

--- a/boards/arm/96b_wistrio/96b_wistrio.dts
+++ b/boards/arm/96b_wistrio/96b_wistrio.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/l1/stm32l151Xb-a.dtsi>
+#include "96b_lscon.dtsi"
 
 / {
 	model = "RAKWireless 96boards WisTrio board";

--- a/boards/arm/96b_wistrio/doc/96b_wistrio.rst
+++ b/boards/arm/96b_wistrio/doc/96b_wistrio.rst
@@ -19,7 +19,7 @@ boards.
 
      96Boards WisTrio
 
-This board is one of the 96Boards IoT Edition platform providing LoRa
+This board is one of the `96Boards IoT Edition`_ platforms providing LoRa
 connectivity.
 
 Hardware
@@ -212,3 +212,6 @@ References
 
 .. _Getting started page:
    https://github.com/blacksphere/blackmagic/wiki/Getting-Started
+
+.. _96Boards IoT Edition:
+    https://linaro.co/ie-specification

--- a/dts/bindings/gpio/96boards-lscon-1v8.yaml
+++ b/dts/bindings/gpio/96boards-lscon-1v8.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2019 Linaro Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+title: 96BOARDS 1.8V LOW SPEED CONNECTOR
+
+description: >
+    This is a representation of GPIO pin nodes exposed on the 96Boards 1.8v low speed header
+
+compatible: "96b-lscon-1v8"
+
+include: [gpio-nexus.yaml, base.yaml]

--- a/dts/bindings/gpio/96boards-lscon-3v3.yaml
+++ b/dts/bindings/gpio/96boards-lscon-3v3.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2019 Linaro Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+title: 96BOARDS 3.3V LOW SPEED CONNECTOR
+
+description: >
+    This is a representation of GPIO pin nodes exposed on the 96Boards 3.3v low speed header
+
+compatible: "96b-lscon-3v3"
+
+include: [gpio-nexus.yaml, base.yaml]


### PR DESCRIPTION
All 96Boards complying to the IE spec exposes either 40pin or 30pin
standard low speed connectors for peripheral connectivity. These
connectors are well defined and available in the IE spec [1]. This PR
creates two different gpio bindings for these connectors:

1. 96b-lscon-1v8 - 40 pin connector with maximum of 12 GPIOs
2. 96b-lscon-3v3 - 30 pin connector with maximum of 8 GPIOs

These bindings will be utilized by the 96Boards for exposing the
GPIO pins as nexus node as per the devicetree spec. This will allow
the shields and applications to use board independent GPIO mapping.

While at it, 96Boards generic node labels for I2C, SPI and UART are also
added.

[1] https://linaro.co/ie-specification

Fixes: #15598

Signed-off-by: Manivannan Sadhasivam <mani@kernel.org>
