### PR TITLE
x86: intel64: don't drop debug sections

### DIFF
--- a/include/arch/x86/intel64/linker.ld
+++ b/include/arch/x86/intel64/linker.ld
@@ -109,10 +109,10 @@ SECTIONS
 	_image_ram_end = .;
 	_end = .;
 
+#include <linker/debug-sections.ld>
+
 	/DISCARD/ :
 	{
-	*(.comment*)
-	*(.debug*)
 	*(.got)
 	*(.got.plt)
 	*(.igot)


### PR DESCRIPTION
Pull in a header specifically for suppressing orphan section
messages instead of dropping the debug sections.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>