### PR TITLE
x86: intel64: enable no-execute

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -112,9 +112,9 @@ go64:	movl %cr4, %eax			/* enable PAE and SSE */
 	movl $pml4, %eax		/* load page base */
 	movl %eax, %cr3
 
-	movl $X86_EFER_MSR, %ecx	/* enable long mode */
+	movl $X86_EFER_MSR, %ecx	/* enable long mode and no-execute */
 	rdmsr
-	orl $X86_EFER_MSR_LME, %eax
+	orl $(X86_EFER_MSR_LME | X86_EFER_MSR_NXE), %eax
 	wrmsr
 
 	movl %cr0, %eax			/* enable paging */

--- a/include/arch/x86/msr.h
+++ b/include/arch/x86/msr.h
@@ -26,6 +26,7 @@
 
 #define X86_EFER_MSR			0xC0000080
 #define X86_EFER_MSR_LME		BIT(8)
+#define X86_EFER_MSR_NXE		BIT(11)
 
 #ifndef _ASMLANGUAGE
 #ifdef __cplusplus


### PR DESCRIPTION
Set the NXE bit in the EFER MSR so that the NX bit can
be set in page tables. Otherwise, the NX bit is treated
as reserved and leads to a fault if set.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>