### PR TITLE
tests/subsys/settings/nffs: fix not initialized variables issues

### DIFF
--- a/tests/subsys/settings/nffs/src/settings_test_save_in_file.c
+++ b/tests/subsys/settings/nffs/src/settings_test_save_in_file.c
@@ -29,6 +29,8 @@ void test_config_save_in_file(void)
 	zassert_true(rc == 0 || rc == -EEXIST, "can't create directory");
 
 	cf.cf_name = TEST_CONFIG_DIR "/blah";
+	cf.cf_maxlines = 1000;
+	cf.cf_lines = 0; /* normally fetched while loading, but this is test */
 	rc = settings_file_src(&cf);
 	zassert_true(rc == 0, "can't register FS as configuration source");
 

--- a/tests/subsys/settings/nffs/src/settings_test_save_one_file.c
+++ b/tests/subsys/settings/nffs/src/settings_test_save_one_file.c
@@ -24,6 +24,8 @@ void test_config_save_one_file(void)
 	zassert_true(rc == 0 || rc == -EEXIST, "can't create directory");
 
 	cf.cf_name = TEST_CONFIG_DIR "/blah";
+	cf.cf_maxlines = 1000;
+	cf.cf_lines = 0; /* normally fetched while loading, but this is test */
 	rc = settings_file_src(&cf);
 	zassert_true(rc == 0, "can't register FS as configuration source");
 


### PR DESCRIPTION
A few settings module variables were not initialized before used.
Normally these variable are initialized in the back-end
initialization call which couldn't be done in affected unit tests.

This path initialize these variable via assignments in test code.

fixes #19722

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>