### PR TITLE
logging: Print hexdumps with 16 bytes in one line

### DIFF
--- a/samples/subsys/logging/logger/src/sample_instance.c
+++ b/samples/subsys/logging/logger/src/sample_instance.c
@@ -15,7 +15,11 @@ LOG_LEVEL_SET(LOG_LEVEL_INF);
 
 void sample_instance_call(struct sample_instance *inst)
 {
-	u8_t data[4] = { 1, 2, 3, 4 };
+	u8_t data[] = { 1, 2, 3, 4, 5, 6, 7, 8,
+			9, 10, 11, 12, 13, 14, 15, 16,
+			17, 18, 19, 20, 21, 22, 23, 24,
+			25, 26, 27, 28, 29, 30, 31, 32,
+			33, 34, };
 
 	LOG_INST_INF(inst->log, "counter_value: %d", inst->cnt++);
 	LOG_INST_HEXDUMP_WRN(inst->log, data, sizeof(data),

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -17,7 +17,7 @@
 #define LOG_COLOR_CODE_RED     "\x1B[1;31m"
 #define LOG_COLOR_CODE_YELLOW  "\x1B[1;33m"
 
-#define HEXDUMP_BYTES_IN_LINE 8
+#define HEXDUMP_BYTES_IN_LINE 16
 
 #define  DROPPED_COLOR_PREFIX \
 	Z_LOG_EVAL(CONFIG_LOG_BACKEND_SHOW_COLOR, (LOG_COLOR_CODE_RED), ())
@@ -366,6 +366,10 @@ static void hexdump_line_print(const struct log_output *log_output,
 	}
 
 	for (int i = 0; i < HEXDUMP_BYTES_IN_LINE; i++) {
+		if (i > 0 && !(i % 8)) {
+			print_formatted(log_output, " ");
+		}
+
 		if (i < length) {
 			print_formatted(log_output, "%02x ", data[i]);
 		} else {
@@ -376,6 +380,10 @@ static void hexdump_line_print(const struct log_output *log_output,
 	print_formatted(log_output, "|");
 
 	for (int i = 0; i < HEXDUMP_BYTES_IN_LINE; i++) {
+		if (i > 0 && !(i % 8)) {
+			print_formatted(log_output, " ");
+		}
+
 		if (i < length) {
 			char c = (char)data[i];
 


### PR DESCRIPTION
The hexdump was earlier printed using 8 bytes in one line like this
```
[00:00:00.131,143] <wrn> sample_instance.inst2: Example of hexdump:
01 02 03 04 05 06 07 08 |........
09 0a 0b 0c 0d 0e 0f 10 |........
11 12 13 14 15 16 17 18 |........
19 1a 1b 1c 1d 1e 1f 20 |.......
21 22                   |!"
```
This is not utilizing the width of the output best way possible.

Better utilization of the output is to print 16 bytes in one line
like this:
```
[00:00:00.131,136] <wrn> sample_instance.inst2: Example of hexdump:
01 02 03 04 05 06 07 08  09 0a 0b 0c 0d 0e 0f 10 |........ ........
11 12 13 14 15 16 17 18  19 1a 1b 1c 1d 1e 1f 20 |........ .......
21 22                                            |!"
```
In order to make it easier to find / calculate the bytes in the
output, print the output bytes in 8 byte groups.

This has the benefit that it is easier to map the Zephyr hex output
to Wireshark output which prints the bytes like this.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>