### PR TITLE
lvgl: Suppress memory leak errors detected by valgrind

### DIFF
--- a/scripts/valgrind.supp
+++ b/scripts/valgrind.supp
@@ -24,3 +24,17 @@
    fun:posix_boot_cpu
    fun:main
 }
+{
+   lvgl no cleanup
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:lv_mem_alloc
+}
+{
+   lvgl no cleanup 2
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:lvgl_allocate_rendering_buffers
+}


### PR DESCRIPTION
The lvgl library is configured in some tests to use
the libC malloc to allocate heap. In native_posix this
ends up in the underlying OS heap, which cannot be safely
freed in general when the program finnishes, and
ends up being reported by valgrind as leaked on exit. See
https://github.com/zephyrproject-rtos/zephyr/pull/18471
for a longer discussion.

Instead of trying to fix the leak, let's just accept it
but suppress the errors so it does not confuse other
developers

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>