### PR TITLE
dtc: Remove support for common.dts

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -17,7 +17,11 @@ set(GENERATED_DTS_BOARD_CONF      ${PROJECT_BINARY_DIR}/include/generated/genera
 set(DTS_POST_CPP                  ${PROJECT_BINARY_DIR}/${BOARD}.dts.pre.tmp)
 
 set_ifndef(DTS_SOURCE ${BOARD_DIR}/${BOARD}.dts)
-set_ifndef(DTS_COMMON_OVERLAYS ${ZEPHYR_BASE}/dts/common/common.dts)
+
+if(DEFINED DTS_COMMON_OVERLAYS)
+  # TODO: remove this warning in version 1.16
+  message(FATAL_ERROR "DTS_COMMON_OVERLAYS is no longer supported. Use DTC_OVERLAY_FILE instead.")
+endif()
 
 # 'DTS_ROOT' is a list of directories where a directory tree with DT
 # files may be found. It always includes the application directory,
@@ -31,7 +35,6 @@ list(APPEND
 
 set(dts_files
   ${DTS_SOURCE}
-  ${DTS_COMMON_OVERLAYS}
   ${shield_dts_files}
   )
 

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -1517,17 +1517,6 @@ the C preprocessor on a file which includes the following:
    can be overridden by setting the :makevar:`DTS_SOURCE` CMake
    variable.)
 
-#. Any "common" overlays provided by the build system. Currently, this
-   is just the file :file:`dts/common/common.dts`. (The common
-   overlays can be overridden by setting the
-   :makevar:`DTS_COMMON_OVERLAYS` CMake variable.)
-
-   The file :file:`common.dts` conditionally includes devicetree
-   fragments based on Kconfig settings. For example, it includes a
-   fragment for MCUboot chain-loading, located at
-   :file:`dts/common/mcuboot.overlay`, if
-   :option:`CONFIG_BOOTLOADER_MCUBOOT` is set.
-
 #. Any file or files given by the :makevar:`DTC_OVERLAY_FILE` CMake
    variable.
 

--- a/doc/application/index.rst
+++ b/doc/application/index.rst
@@ -1510,8 +1510,6 @@ to a whitespace-separated list of your overlay files.
 The Zephyr build system begins creation of a devicetree by running
 the C preprocessor on a file which includes the following:
 
-#. Configuration options from :ref:`Kconfig <configuration_options>`.
-
 #. The board's devicetree source file, which by default is the Zephyr
    file :file:`boards/<ARCHITECTURE>/<BOARD>/<BOARD>.dts`. (This location
    can be overridden by setting the :makevar:`DTS_SOURCE` CMake

--- a/dts/common/common.dts
+++ b/dts/common/common.dts
@@ -1,6 +1,0 @@
-/* SPDX-License-Identifier: Apache-2.0 */
-
-/*
- * Common Device Tree source, used for pulling in features and
- * additions by the build system.
- */


### PR DESCRIPTION
Remove the common.dts file which has been unused for a year.

common.dts at one point allowed us to do this:

> #ifdef CONFIG_BOOTLOADER_MCUBOOT	
> #include "mcuboot.overlay"	
> #endif

but since DT lost access to Kconfig options it has been unused.

The overridable variable DTS_COMMON_OVERLAYS, which by default points
to common.dts, is also unused in-tree, and any out-of-tree usage can
be ported over to use DTC_OVERLAY_FILE instead, so we remove the
variable as well.

This simplifies the configuration system.

Also, remove a nearby sentence in the docs that was saying DT uses Kconfig symbols.

fixes #15359