### PR TITLE
kconfig: assert: Introduce kconfig option ASSERT_NO_FILE_INFO

### DIFF
--- a/include/sys/__assert.h
+++ b/include/sys/__assert.h
@@ -20,6 +20,12 @@
 #define __ASSERT_ON 0
 #endif
 
+#ifdef CONFIG_ASSERT_NO_FILE_INFO
+#define __ASSERT_FILE_INFO ""
+#else  /* CONFIG_ASSERT_NO_FILE_INFO */
+#define __ASSERT_FILE_INFO __FILE__
+#endif /* CONFIG_ASSERT_NO_FILE_INFO */
+
 #ifdef __ASSERT_ON
 #if (__ASSERT_ON < 0) || (__ASSERT_ON > 2)
 #error "Invalid __ASSERT() level: must be between 0 and 2"
@@ -40,26 +46,26 @@ void assert_post_action(const char *file, unsigned int line);
 #endif
 
 #define __ASSERT_LOC(test)                               \
-	printk("ASSERTION FAIL [%s] @ %s:%d\n",    \
-	       Z_STRINGIFY(test),                         \
-	       __FILE__,                                 \
+	printk("ASSERTION FAIL [%s] @ %s:%d\n",          \
+	       Z_STRINGIFY(test),                        \
+	       __ASSERT_FILE_INFO,                       \
 	       __LINE__)                                 \
 
-#define __ASSERT_NO_MSG(test)                                            \
-	do {                                                             \
-		if (!(test)) {                                           \
-			__ASSERT_LOC(test);                              \
-			assert_post_action(__FILE__, __LINE__);          \
-		}                                                        \
+#define __ASSERT_NO_MSG(test)                                             \
+	do {                                                              \
+		if (!(test)) {                                            \
+			__ASSERT_LOC(test);                               \
+			assert_post_action(__ASSERT_FILE_INFO, __LINE__); \
+		}                                                         \
 	} while (false)
 
-#define __ASSERT(test, fmt, ...)                                         \
-	do {                                                             \
-		if (!(test)) {                                           \
-			__ASSERT_LOC(test);                              \
-			printk("\t" fmt "\n", ##__VA_ARGS__);            \
-			assert_post_action(__FILE__, __LINE__);          \
-		}                                                        \
+#define __ASSERT(test, fmt, ...)                                          \
+	do {                                                              \
+		if (!(test)) {                                            \
+			__ASSERT_LOC(test);                               \
+			printk("\t" fmt "\n", ##__VA_ARGS__);             \
+			assert_post_action(__ASSERT_FILE_INFO, __LINE__); \
+		}                                                         \
 	} while (false)
 
 #define __ASSERT_EVAL(expr1, expr2, test, fmt, ...)                \

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -155,6 +155,13 @@ config FORCE_NO_ASSERT
 	  CFLAGS and not Kconfig.  Added solely to be able to work
 	  around compiler bugs for specific tests.
 
+config ASSERT_NO_FILE_INFO
+	bool "Disable file info for asserts"
+	help
+	  This option removes the name and the path of the source file
+	  in which the assertion occurred. Enabling this will save
+	  target code space, and thus may be necessary for tiny targets.
+
 config OBJECT_TRACING
 	bool "Kernel object tracing"
 	help


### PR DESCRIPTION
Default behavior is to include __FILE__ info with all of the Zephyr
assert macros, __ASSERT, __ASSERT_NO_MSG and __ASSERT_LOC. Setting the
ASSERT_NO_FILE_INFO kconfig option, replaces the __FILE__ with an
empty string, thus removing the file information from the asserts.

The intention here is to allow for code space limited devices to run
with asserts enabled.