### PR TITLE
[TOPIC-GPIO] tests: gpio_api_1pin: fix port related testcases

### DIFF
--- a/tests/drivers/gpio/gpio_api_1pin/src/test_pin_interrupt.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_pin_interrupt.c
@@ -21,19 +21,19 @@ struct gpio_callback gpio_cb;
 static int cb_count;
 
 static void callback_edge(struct device *port, struct gpio_callback *cb,
-			  u32_t pins)
+			  gpio_port_pins_t pins)
 {
-	zassert_equal(pins, 1 << TEST_PIN,
+	zassert_equal(pins, BIT(TEST_PIN),
 		     "Detected interrupt on an invalid pin");
 	cb_count++;
 }
 
 static void callback_level(struct device *port, struct gpio_callback *cb,
-			   u32_t pins)
+			   gpio_port_pins_t pins)
 {
 	int ret;
 
-	zassert_equal(pins, 1 << TEST_PIN,
+	zassert_equal(pins, BIT(TEST_PIN),
 		     "Detected interrupt on an invalid pin");
 
 	ret = gpio_pin_interrupt_configure(port, TEST_PIN, GPIO_INT_DISABLE);

--- a/tests/drivers/gpio/gpio_api_1pin/src/test_port.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_port.c
@@ -19,25 +19,25 @@
 
 #define TEST_GPIO_PORT_VALUE_MAX         ((1LLU << GPIO_MAX_PINS_PER_PORT) - 1)
 
-static void port_get_raw_and_verify(struct device *port,
+static void port_get_raw_and_verify(struct device *port, gpio_port_pins_t mask,
 				    gpio_port_value_t val_expected, int idx)
 {
 	gpio_port_value_t val_actual;
 
 	zassert_equal(gpio_port_get_raw(port, &val_actual), 0,
 		     "Test point %d: failed to get physical port value", idx);
-	zassert_equal(val_expected, val_actual,
+	zassert_equal(val_expected & mask, val_actual & mask,
 		      "Test point %d: invalid physical port get value", idx);
 }
 
-static void port_get_and_verify(struct device *port,
+static void port_get_and_verify(struct device *port, gpio_port_pins_t mask,
 				gpio_port_value_t val_expected, int idx)
 {
 	gpio_port_value_t val_actual;
 
 	zassert_equal(gpio_port_get(port, &val_actual), 0,
 		     "Test point %d: failed to get logical port value", idx);
-	zassert_equal(val_expected, val_actual,
+	zassert_equal(val_expected & mask, val_actual & mask,
 		      "Test point %d: invalid logical port get value", idx);
 }
 
@@ -129,26 +129,24 @@ void test_gpio_port_toggle(void)
 	}
 	zassert_equal(ret, 0, "Failed to configure the pin");
 
-	port_set_bits_raw_and_verify(port, 1 << TEST_PIN, 0);
+	port_set_bits_raw_and_verify(port, BIT(TEST_PIN), 0);
 
-	zassert_equal(gpio_port_get(port, &val_expected), 0,
-		      "Failed to get logical port value");
+	val_expected = BIT(TEST_PIN);
 
 	for (int i = 0; i < 5; i++) {
-		ret = gpio_port_toggle_bits(port, 1 << TEST_PIN);
+		ret = gpio_port_toggle_bits(port, BIT(TEST_PIN));
 		zassert_equal(ret, 0, "Failed to toggle pin value");
 		k_busy_wait(TEST_GPIO_MAX_RISE_FALL_TIME_US);
 
-		val_expected ^= 1 << TEST_PIN;
+		val_expected ^= BIT(TEST_PIN);
 
-		port_get_raw_and_verify(port, val_expected, i);
+		port_get_raw_and_verify(port, BIT(TEST_PIN), val_expected, i);
 	}
 }
 
 void test_gpio_port_set_masked_get_raw(void)
 {
 	struct device *port;
-	gpio_port_value_t val_expected;
 	int ret;
 
 	const gpio_port_value_t test_vector[] = {
@@ -180,23 +178,15 @@ void test_gpio_port_set_masked_get_raw(void)
 	}
 	zassert_equal(ret, 0, "Failed to configure the pin");
 
-	ret = gpio_port_get_raw(port, &val_expected);
-	zassert_equal(ret, 0, "Failed to get physical port value");
-
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
-		port_set_masked_raw_and_verify(port, 1 << TEST_PIN, test_vector[i], i);
-
-		val_expected &= ~(1 << TEST_PIN);
-		val_expected |= test_vector[i] & (1 << TEST_PIN);
-
-		port_get_raw_and_verify(port, val_expected, i);
+		port_set_masked_raw_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
+		port_get_raw_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
 	}
 }
 
 void test_gpio_port_set_masked_get(void)
 {
 	struct device *port;
-	gpio_port_value_t val_expected;
 	int ret;
 
 	const gpio_port_value_t test_vector[] = {
@@ -228,23 +218,15 @@ void test_gpio_port_set_masked_get(void)
 	}
 	zassert_equal(ret, 0, "Failed to configure the pin");
 
-	ret = gpio_port_get(port, &val_expected);
-	zassert_equal(ret, 0, "Failed to get logical port value");
-
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
-		port_set_masked_and_verify(port, 1 << TEST_PIN, test_vector[i], i);
-
-		val_expected &= ~(1 << TEST_PIN);
-		val_expected |= test_vector[i] & (1 << TEST_PIN);
-
-		port_get_and_verify(port, val_expected, i);
+		port_set_masked_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
+		port_get_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
 	}
 }
 
 void test_gpio_port_set_masked_get_active_high(void)
 {
 	struct device *port;
-	gpio_port_value_t val_expected;
 	int ret;
 
 	const gpio_port_value_t test_vector[] = {
@@ -278,36 +260,24 @@ void test_gpio_port_set_masked_get_active_high(void)
 	}
 	zassert_equal(ret, 0, "Failed to configure the pin");
 
-	ret = gpio_port_get(port, &val_expected);
-	zassert_equal(ret, 0, "Failed to get logical port value");
-
 	TC_PRINT("Step 1: Set logical, get logical and physical port value\n");
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
-		port_set_masked_and_verify(port, 1 << TEST_PIN, test_vector[i], i);
-
-		val_expected &= ~(1 << TEST_PIN);
-		val_expected |= test_vector[i] & (1 << TEST_PIN);
-
-		port_get_and_verify(port, val_expected, i);
-		port_get_raw_and_verify(port, val_expected, i);
+		port_set_masked_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
+		port_get_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
+		port_get_raw_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
 	}
 
 	TC_PRINT("Step 2: Set physical, get logical and physical port value\n");
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
-		port_set_masked_raw_and_verify(port, 1 << TEST_PIN, test_vector[i], i);
-
-		val_expected &= ~(1 << TEST_PIN);
-		val_expected |= test_vector[i] & (1 << TEST_PIN);
-
-		port_get_and_verify(port, val_expected, i);
-		port_get_raw_and_verify(port, val_expected, i);
+		port_set_masked_raw_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
+		port_get_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
+		port_get_raw_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
 	}
 }
 
 void test_gpio_port_set_masked_get_active_low(void)
 {
 	struct device *port;
-	gpio_port_value_t val_expected, val_raw_expected;
 	int ret;
 
 	const gpio_port_value_t test_vector[] = {
@@ -341,42 +311,25 @@ void test_gpio_port_set_masked_get_active_low(void)
 	}
 	zassert_equal(ret, 0, "Failed to configure the pin");
 
-	ret = gpio_port_get_raw(port, &val_raw_expected);
-	zassert_equal(ret, 0, "Failed to get physical port value");
-	ret = gpio_port_get(port, &val_expected);
-	zassert_equal(ret, 0, "Failed to get logical port value");
-
 	TC_PRINT("Step 1: Set logical, get logical and physical port value\n");
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
-		port_set_masked_and_verify(port, 1 << TEST_PIN, test_vector[i], i);
-
-		val_raw_expected &= ~(1 << TEST_PIN);
-		val_raw_expected |= (test_vector[i] & (1 << TEST_PIN)) ^ (1 << TEST_PIN);
-		val_expected &= ~(1 << TEST_PIN);
-		val_expected |= test_vector[i] & (1 << TEST_PIN);
-
-		port_get_and_verify(port, val_expected, i);
-		port_get_raw_and_verify(port, val_raw_expected, i);
+		port_set_masked_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
+		port_get_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
+		port_get_raw_and_verify(port, BIT(TEST_PIN), ~test_vector[i], i);
 	}
 
 	TC_PRINT("Step 2: Set physical, get logical and physical port value\n");
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
-		port_set_masked_raw_and_verify(port, 1 << TEST_PIN, test_vector[i], i);
-
-		val_raw_expected &= ~(1 << TEST_PIN);
-		val_raw_expected |= test_vector[i] & (1 << TEST_PIN);
-		val_expected &= ~(1 << TEST_PIN);
-		val_expected |= (test_vector[i] & (1 << TEST_PIN)) ^ (1 << TEST_PIN);
-
-		port_get_and_verify(port, val_expected, i);
-		port_get_raw_and_verify(port, val_raw_expected, i);
+		port_set_masked_raw_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
+		port_get_and_verify(port, BIT(TEST_PIN), ~test_vector[i], i);
+		port_get_raw_and_verify(port, BIT(TEST_PIN), test_vector[i], i);
 	}
 }
 
 void test_gpio_port_set_bits_clear_bits_raw(void)
 {
 	struct device *port;
-	gpio_port_value_t val_expected;
+	gpio_port_value_t val_expected = 0;
 	int ret;
 
 	const gpio_port_value_t test_vector[][2] = {
@@ -401,24 +354,21 @@ void test_gpio_port_set_bits_clear_bits_raw(void)
 	}
 	zassert_equal(ret, 0, "Failed to configure the pin");
 
-	ret = gpio_port_get_raw(port, &val_expected);
-	zassert_equal(ret, 0, "Failed to get logical port value");
-
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		port_set_bits_raw_and_verify(port, test_vector[i][0], i);
-		val_expected |= test_vector[i][0] & (1 << TEST_PIN);
-		port_get_raw_and_verify(port, val_expected, i);
+		val_expected |= test_vector[i][0] & (BIT(TEST_PIN));
+		port_get_raw_and_verify(port, BIT(TEST_PIN), val_expected, i);
 
 		port_clear_bits_raw_and_verify(port, test_vector[i][1], i);
-		val_expected &= ~(test_vector[i][1] & (1 << TEST_PIN));
-		port_get_raw_and_verify(port, val_expected, i);
+		val_expected &= ~(test_vector[i][1] & (BIT(TEST_PIN)));
+		port_get_raw_and_verify(port, BIT(TEST_PIN), val_expected, i);
 	}
 }
 
 void test_gpio_port_set_bits_clear_bits(void)
 {
 	struct device *port;
-	gpio_port_value_t val_expected;
+	gpio_port_value_t val_expected = 0;
 	int ret;
 
 	const gpio_port_value_t test_vector[][2] = {
@@ -443,24 +393,21 @@ void test_gpio_port_set_bits_clear_bits(void)
 	}
 	zassert_equal(ret, 0, "Failed to configure the pin");
 
-	ret = gpio_port_get(port, &val_expected);
-	zassert_equal(ret, 0, "Failed to get logical port value");
-
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		port_set_bits_and_verify(port, test_vector[i][0], i);
-		val_expected |= test_vector[i][0] & (1 << TEST_PIN);
-		port_get_and_verify(port, val_expected, i);
+		val_expected |= test_vector[i][0] & (BIT(TEST_PIN));
+		port_get_and_verify(port, BIT(TEST_PIN), val_expected, i);
 
 		port_clear_bits_and_verify(port, test_vector[i][1], i);
-		val_expected &= ~(test_vector[i][1] & (1 << TEST_PIN));
-		port_get_and_verify(port, val_expected, i);
+		val_expected &= ~(test_vector[i][1] & (BIT(TEST_PIN)));
+		port_get_and_verify(port, BIT(TEST_PIN), val_expected, i);
 	}
 }
 
 void test_gpio_port_set_clr_bits_raw(void)
 {
 	struct device *port;
-	gpio_port_value_t val_expected;
+	gpio_port_value_t val_expected = 0;
 	int ret;
 
 	const gpio_port_value_t test_vector[][2] = {
@@ -469,6 +416,7 @@ void test_gpio_port_set_clr_bits_raw(void)
 		{0x00000000, TEST_GPIO_PORT_VALUE_MAX},
 		{0x55555555, 0x00000000},
 		{TEST_GPIO_PORT_VALUE_MAX, 0x00000000},
+		{0x00000000, 0x00000000},
 		{0xAAAAAAAA, 0x00000000},
 		{0x00000000, TEST_GPIO_PORT_VALUE_MAX},
 	};
@@ -486,21 +434,18 @@ void test_gpio_port_set_clr_bits_raw(void)
 	}
 	zassert_equal(ret, 0, "Failed to configure the pin");
 
-	ret = gpio_port_get_raw(port, &val_expected);
-	zassert_equal(ret, 0, "Failed to get logical port value");
-
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		port_set_clr_bits_raw(port, test_vector[i][0], test_vector[i][1], i);
-		val_expected |= test_vector[i][0] & (1 << TEST_PIN);
-		val_expected &= ~(test_vector[i][1] & (1 << TEST_PIN));
-		port_get_raw_and_verify(port, val_expected, i);
+		val_expected |= test_vector[i][0] & (BIT(TEST_PIN));
+		val_expected &= ~(test_vector[i][1] & (BIT(TEST_PIN)));
+		port_get_raw_and_verify(port, BIT(TEST_PIN), val_expected, i);
 	}
 }
 
 void test_gpio_port_set_clr_bits(void)
 {
 	struct device *port;
-	gpio_port_value_t val_expected;
+	gpio_port_value_t val_expected = 0;
 	int ret;
 
 	const gpio_port_value_t test_vector[][2] = {
@@ -526,13 +471,10 @@ void test_gpio_port_set_clr_bits(void)
 	}
 	zassert_equal(ret, 0, "Failed to configure the pin");
 
-	ret = gpio_port_get(port, &val_expected);
-	zassert_equal(ret, 0, "Failed to get logical port value");
-
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		port_set_clr_bits(port, test_vector[i][0], test_vector[i][1], i);
-		val_expected |= test_vector[i][0] & (1 << TEST_PIN);
-		val_expected &= ~(test_vector[i][1] & (1 << TEST_PIN));
-		port_get_and_verify(port, val_expected, i);
+		val_expected |= test_vector[i][0] & (BIT(TEST_PIN));
+		val_expected &= ~(test_vector[i][1] & (BIT(TEST_PIN)));
+		port_get_and_verify(port, BIT(TEST_PIN), val_expected, i);
 	}
 }


### PR DESCRIPTION
Keep promise of testing 1 pin only, don't attempt to test other pins when verifying gpio_port_* API functions.

Fixes: #19692
