### PR TITLE
[TOPIC-GPIO] tests: gpio_basic_api: fix misplacement of debounce flag

### DIFF
--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -671,6 +671,7 @@ static inline int gpio_pin_configure(struct device *port, u32_t pin,
 		data->invert &= ~BIT(pin);
 	}
 	if (api->pin_interrupt_configure) {
+		flags &= ~GPIO_INT_DEBOUNCE;
 		ret = z_impl_gpio_pin_interrupt_configure(port, pin, flags);
 	}
 

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_manage.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_manage.c
@@ -55,7 +55,8 @@ static int init_callback(struct device *dev,
 
 	if (rc == 0) {
 		/* 2. configure PIN_IN callback, but don't enable */
-		rc = gpio_pin_configure(dev, PIN_IN, GPIO_INPUT);
+		rc = gpio_pin_configure(dev, PIN_IN,
+					GPIO_INPUT | GPIO_INT_DEBOUNCE);
 	}
 
 	if (rc == 0) {
@@ -79,9 +80,7 @@ static void trigger_callback(struct device *dev, int enable_cb)
 	cb_cnt[0] = 0;
 	cb_cnt[1] = 0;
 	if (enable_cb == 1) {
-		gpio_pin_interrupt_configure(dev, PIN_IN,
-					     GPIO_INT_EDGE_RISING
-					     | GPIO_INT_DEBOUNCE);
+		gpio_pin_interrupt_configure(dev, PIN_IN, GPIO_INT_EDGE_RISING);
 	} else {
 		gpio_pin_interrupt_configure(dev, PIN_IN, GPIO_INT_DISABLE);
 	}

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
@@ -71,7 +71,7 @@ static int test_callback(int mode)
 	}
 
 	/* 2. configure PIN_IN callback and trigger condition */
-	rc = gpio_pin_configure(dev, PIN_IN, GPIO_INPUT);
+	rc = gpio_pin_configure(dev, PIN_IN, GPIO_INPUT | GPIO_INT_DEBOUNCE);
 	if (rc != 0) {
 		TC_ERROR("config PIN_IN fail: %d\n", rc);
 		goto err_exit;
@@ -90,7 +90,7 @@ static int test_callback(int mode)
 
 	/* 3. enable callback, trigger PIN_IN interrupt by operate PIN_OUT */
 	cb_cnt = 0;
-	rc = gpio_pin_interrupt_configure(dev, PIN_IN, mode | GPIO_INT_DEBOUNCE);
+	rc = gpio_pin_interrupt_configure(dev, PIN_IN, mode);
 	if (rc == -ENOTSUP) {
 		TC_PRINT("Mode %x not supported\n", mode);
 		goto pass_exit;


### PR DESCRIPTION
The debounce flag is to be provided to the pin configuration, not the pin interrupt configuration.

This matters for SAM0.