### PR TITLE
boards: actinius_icarus: change defaults to use new kconfig functions

### DIFF
--- a/boards/arm/actinius_icarus/Kconfig.defconfig
+++ b/boards/arm/actinius_icarus/Kconfig.defconfig
@@ -47,20 +47,23 @@ endif # SPI
 # Apply this configuration below by setting the Kconfig symbols used by
 # the linker according to the information extracted from DT partitions.
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+
 if BOARD_ACTINIUS_ICARUS && TRUSTED_EXECUTION_SECURE
 
 config FLASH_LOAD_SIZE
-	default $(dt_hex_val,DT_CODE_PARTITION_SIZE)
+	default $(dt_chosen_reg_size,$(DT_CHOSEN_Z_CODE_PARTITION))
 
 endif # BOARD_ACTINIUS_ICARUS && TRUSTED_EXECUTION_SECURE
 
 if BOARD_ACTINIUS_ICARUS_NS
 
 config FLASH_LOAD_OFFSET
-	default $(dt_hex_val,DT_CODE_PARTITION_OFFSET)
+	default $(dt_chosen_reg_addr,$(DT_CHOSEN_Z_CODE_PARTITION))
 
 config FLASH_LOAD_SIZE
-	default $(dt_hex_val,DT_CODE_PARTITION_SIZE)
+	default $(dt_chosen_reg_size,$(DT_CHOSEN_Z_CODE_PARTITION))
 
 endif # BOARD_ACTINIUS_ICARUS_NS
 


### PR DESCRIPTION
This changes the default flash size and offset in the defconfig of the actinius icarus board to use the new kconfig function dt_chosen_reg_addr instead of deprecated dt_hex_val
