### PR TITLE
CODEOWNERS: Add entry for gpio drivers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -131,6 +131,7 @@
 /drivers/flash/*native_posix*             @vanwinkeljan @aescolar
 /drivers/flash/*spi_nor*                  @pabigot
 /drivers/flash/*stm32*                    @superna9999
+/drivers/gpio/                            @mnkp @pabigot
 /drivers/gpio/*ht16k33*                   @henrikbrixandersen
 /drivers/gpio/*stm32*                     @rsalveti @idlethread
 /drivers/hwinfo/                          @alexanderwachter


### PR DESCRIPTION
Adding code owners of gpio drivers.