### PR TITLE
Bluetooth: Mesh: Fixed Provision Random buffer size

### DIFF
--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -983,7 +983,7 @@ static void prov_confirm(const u8_t *data)
 
 static void prov_random(const u8_t *data)
 {
-	PROV_BUF(rnd, 16);
+	PROV_BUF(rnd, 17);
 	u8_t conf_verify[16];
 
 	BT_DBG("Remote Random: %s", bt_hex(data, 16));


### PR DESCRIPTION
Fixed some minor issues, missing a byte for opcode.

Fix: #19767

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>