### PR TITLE
Bluetooth: GATT: Fix bug in bt_gatt_attr_next unable for static handles

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1164,9 +1164,9 @@ static u8_t find_next(const struct bt_gatt_attr *attr, void *user_data)
 struct bt_gatt_attr *bt_gatt_attr_next(const struct bt_gatt_attr *attr)
 {
 	struct bt_gatt_attr *next = NULL;
+	u16_t handle = attr->handle ? : find_static_attr(attr);
 
-	bt_gatt_foreach_attr(attr->handle + 1, attr->handle + 1, find_next,
-			     &next);
+	bt_gatt_foreach_attr(handle + 1, handle + 1, find_next, &next);
 
 	return next;
 }


### PR DESCRIPTION
Fix bug in bt_gatt_attr_next when given an attribute that has static
allocation. The handle is then 0 and the function would always return
the attribute with handle 1.

Fixes: #19795
Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>