### PR TITLE
drivers: flash: nrfx: Modify flash address validation

### DIFF
--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -92,13 +92,12 @@ static inline bool is_regular_addr_valid(off_t addr, size_t len)
 {
 	size_t flash_size = nrfx_nvmc_flash_size_get();
 
-	if (addr >= flash_size ||
-	    addr < 0 ||
+	if (addr >= DT_FLASH_BASE_ADDRESS + flash_size ||
+	    addr < DT_FLASH_BASE_ADDRESS ||
 	    len > flash_size ||
-	    addr + len > flash_size) {
+	    (addr - DT_FLASH_BASE_ADDRESS) + len > flash_size) {
 		return false;
 	}
-
 	return true;
 }
 


### PR DESCRIPTION
Modifications in 'is_regular_addr_valid()' function which didn't work properly
when flash base address was different than 0x00000000.
Added calculating address bounds with respect to flash base address.

Signed-off-by: Adam Kondraciuk <adam.kondraciuk@nordicsemi.no>