### PR TITLE
Bluetooth: Mesh: Persistent storage of Virtual Addresses

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -41,11 +41,7 @@
 
 static struct bt_mesh_cfg_srv *conf;
 
-static struct label {
-	u16_t ref;
-	u16_t addr;
-	u8_t  uuid[16];
-} labels[CONFIG_BT_MESH_LABEL_COUNT];
+static struct label labels[CONFIG_BT_MESH_LABEL_COUNT];
 
 static int comp_add_elem(struct net_buf_simple *buf, struct bt_mesh_elem *elem,
 			 bool primary)
@@ -1090,23 +1086,59 @@ send_status:
 			    status, mod_id);
 }
 
-#if CONFIG_BT_MESH_LABEL_COUNT > 0
-static u8_t va_add(u8_t *label_uuid, u16_t *addr)
+struct label *get_label(u16_t index)
 {
-	struct label *free_slot = NULL;
+	if (index >= ARRAY_SIZE(labels)) {
+		return NULL;
+	}
+
+	return &labels[index];
+}
+
+#if CONFIG_BT_MESH_LABEL_COUNT > 0
+static inline void va_store(struct label *store)
+{
+	atomic_set_bit(store->flags, BT_MESH_VA_CHANGED);
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		bt_mesh_store_label();
+	}
+}
+
+static struct label *va_find(const u8_t *label_uuid,
+				struct label **free_slot)
+{
+	struct label *match = NULL;
 	int i;
 
+	if (free_slot != NULL) {
+		*free_slot = NULL;
+	}
+
 	for (i = 0; i < ARRAY_SIZE(labels); i++) {
-		if (!labels[i].ref) {
-			free_slot = &labels[i];
+		if (labels[i].ref == 0) {
+			if (free_slot != NULL) {
+				*free_slot = &labels[i];
+			}
 			continue;
 		}
 
 		if (!memcmp(labels[i].uuid, label_uuid, 16)) {
-			*addr = labels[i].addr;
-			labels[i].ref++;
-			return STATUS_SUCCESS;
+			match = &labels[i];
 		}
+	}
+
+	return match;
+}
+
+static u8_t va_add(u8_t *label_uuid, u16_t *addr)
+{
+	struct label *update, *free_slot = NULL;
+
+	update = va_find(label_uuid, &free_slot);
+	if (update) {
+		update->ref++;
+		va_store(update);
+		return 0;
 	}
 
 	if (!free_slot) {
@@ -1120,23 +1152,24 @@ static u8_t va_add(u8_t *label_uuid, u16_t *addr)
 	free_slot->ref = 1U;
 	free_slot->addr = *addr;
 	memcpy(free_slot->uuid, label_uuid, 16);
+	va_store(free_slot);
 
 	return STATUS_SUCCESS;
 }
 
 static u8_t va_del(u8_t *label_uuid, u16_t *addr)
 {
-	int i;
+	struct label *update;
 
-	for (i = 0; i < ARRAY_SIZE(labels); i++) {
-		if (!memcmp(labels[i].uuid, label_uuid, 16)) {
-			if (addr) {
-				*addr = labels[i].addr;
-			}
+	update = va_find(label_uuid, NULL);
+	if (update) {
+		update->ref--;
 
-			labels[i].ref--;
-			return STATUS_SUCCESS;
+		if (addr) {
+			*addr = update->addr;
 		}
+
+		va_store(update);
 	}
 
 	if (addr) {

--- a/subsys/bluetooth/mesh/foundation.h
+++ b/subsys/bluetooth/mesh/foundation.h
@@ -112,11 +112,24 @@
 #define STATUS_UNSPECIFIED                 0x10
 #define STATUS_INVALID_BINDING             0x11
 
+enum {
+	BT_MESH_VA_CHANGED,	/* Label information changed */
+};
+
+struct label {
+	u16_t ref;
+	u16_t addr;
+	u8_t  uuid[16];
+	atomic_t flags[1];
+};
+
 void bt_mesh_cfg_reset(void);
 
 void bt_mesh_heartbeat(u16_t src, u16_t dst, u8_t hops, u16_t feat);
 
 void bt_mesh_attention(struct bt_mesh_model *model, u8_t time);
+
+struct label *get_label(u16_t index);
 
 u8_t *bt_mesh_label_uuid_get(u16_t addr);
 

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -215,6 +215,7 @@ enum {
 	BT_MESH_HB_PUB_PENDING,
 	BT_MESH_CFG_PENDING,
 	BT_MESH_MOD_PENDING,
+	BT_MESH_VA_PENDING,
 
 	/* Don't touch - intentionally last */
 	BT_MESH_FLAG_COUNT,

--- a/subsys/bluetooth/mesh/settings.h
+++ b/subsys/bluetooth/mesh/settings.h
@@ -15,6 +15,7 @@ void bt_mesh_store_cfg(void);
 void bt_mesh_store_mod_bind(struct bt_mesh_model *mod);
 void bt_mesh_store_mod_sub(struct bt_mesh_model *mod);
 void bt_mesh_store_mod_pub(struct bt_mesh_model *mod);
+void bt_mesh_store_label(void);
 
 void bt_mesh_clear_net(void);
 void bt_mesh_clear_subnet(struct bt_mesh_subnet *sub);


### PR DESCRIPTION
The 16-bit format group addresses will be stored,
but we don't store (or restore) the virtual label UUIDs,
i.e. after a power cycle the 16-bit group addresses
would be meaningless.

Fixes #19342

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>