### PR TITLE
logging: Fix lack of logging after startup

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -828,6 +828,14 @@ void log_backend_enable(struct log_backend const *const backend,
 	log_backend_id_set(backend, id);
 	backend_filter_set(backend, level);
 	log_backend_activate(backend, ctx);
+
+	/* Wakeup logger thread after attaching first backend. It might be
+	 * blocked with log messages pending.
+	 */
+	if (!backend_attached) {
+		k_sem_give(&log_process_thread_sem);
+	}
+
 	backend_attached = true;
 }
 


### PR DESCRIPTION
Commit ad28c2d6 introduced semaphore on which logger thread
pends. It is possible that log messages are created before
any backend is attached. In that case, logger thread pends
on semaphore with pending log messages and is not waken up
unless new log messages comes.

Fixed by setting semaphore when first backend is attached.
This wakes up logger thread and log messages can be processed.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>