### PR TITLE
net: if: Fix interface initialization with socket offloading

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -444,6 +444,11 @@ struct net_if_dev {
 
 	/** The hardware MTU */
 	u16_t mtu;
+
+#if defined(CONFIG_NET_SOCKETS_OFFLOAD)
+	/** Indicate whether interface is offloaded at socket level. */
+	bool offloaded;
+#endif /* CONFIG_NET_SOCKETS_OFFLOAD */
 };
 
 /**
@@ -621,6 +626,24 @@ static inline struct net_offload *net_if_offload(struct net_if *iface)
 	return iface->if_dev->offload;
 #else
 	return NULL;
+#endif
+}
+
+/**
+ * @brief Return the socket offload status
+ *
+ * @param iface Network interface
+ *
+ * @return True if socket offloading is active, false otherwise.
+ */
+static inline bool net_if_is_socket_offloaded(struct net_if *iface)
+{
+#if defined(CONFIG_NET_SOCKETS_OFFLOAD)
+	return iface->if_dev->offloaded;
+#else
+	ARG_UNUSED(iface);
+
+	return false;
 #endif
 }
 

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3439,7 +3439,10 @@ int net_if_up(struct net_if *iface)
 		return 0;
 	}
 
-	if (IS_ENABLED(CONFIG_NET_OFFLOAD) && net_if_is_ip_offloaded(iface)) {
+	if ((IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+	     net_if_is_ip_offloaded(iface)) ||
+	    (IS_ENABLED(CONFIG_NET_SOCKETS_OFFLOAD) &&
+	     net_if_is_socket_offloaded(iface))) {
 		net_if_flag_set(iface, NET_IF_UP);
 		goto exit;
 	}


### PR DESCRIPTION
A socket-offloaded interface should bypass interface initialization in
the same way as net-offloaded interface does.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>