### PR TITLE
kernel: activate arch interface headers

### DIFF
--- a/arch/arm/core/cortex_m/fault.c
+++ b/arch/arm/core/cortex_m/fault.c
@@ -164,10 +164,10 @@ static void fault_show(const z_arch_esf_t *esf, int fault)
 #endif /* FAULT_DUMP == 1 */
 
 #ifdef CONFIG_USERSPACE
-Z_EXC_DECLARE(z_arch_user_string_nlen);
+Z_EXC_DECLARE(z_arm_user_string_nlen);
 
 static const struct z_exc_handle exceptions[] = {
-	Z_EXC_HANDLE(z_arch_user_string_nlen)
+	Z_EXC_HANDLE(z_arm_user_string_nlen)
 };
 #endif
 

--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -17,9 +17,9 @@ _ASM_FILE_PROLOGUE
 GTEXT(z_arm_userspace_enter)
 GTEXT(z_arm_do_syscall)
 GTEXT(z_arch_user_string_nlen)
-GTEXT(z_arch_user_string_nlen_fault_start)
-GTEXT(z_arch_user_string_nlen_fault_end)
-GTEXT(z_arch_user_string_nlen_fixup)
+GTEXT(z_arm_user_string_nlen_fault_start)
+GTEXT(z_arm_user_string_nlen_fault_end)
+GTEXT(z_arm_user_string_nlen_fixup)
 GDATA(_kernel)
 
 /* Imports */
@@ -514,11 +514,11 @@ SECTION_FUNC(TEXT, z_arch_user_string_nlen)
     movs r3, #0		/* r3 is the counter */
 
 strlen_loop:
-z_arch_user_string_nlen_fault_start:
+z_arm_user_string_nlen_fault_start:
     /* r0 contains the string. r5 = *(r0 + r3]). This could fault. */
     ldrb r5, [r0, r3]
 
-z_arch_user_string_nlen_fault_end:
+z_arm_user_string_nlen_fault_end:
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
     cmp r5, #0
     beq strlen_done
@@ -539,7 +539,7 @@ strlen_done:
     movs r1, #0
     str	r1, [sp, #4]
 
-z_arch_user_string_nlen_fixup:
+z_arm_user_string_nlen_fixup:
     /* Write error value to err pointer parameter */
     ldr	r1, [sp, #4]
     str	r1, [r2, #0]

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -49,19 +49,12 @@ z_arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
 	thread->arch.swap_return_value = value;
 }
 
-extern void z_arch_cpu_atomic_idle(unsigned int key);
-
 extern FUNC_NORETURN void z_arm_userspace_enter(k_thread_entry_t user_entry,
 					       void *p1, void *p2, void *p3,
 					       u32_t stack_end,
 					       u32_t stack_start);
 
 extern void z_arm_fatal_error(unsigned int reason, const z_arch_esf_t *esf);
-
-extern void z_arch_switch_to_main_thread(struct k_thread *main_thread,
-					 k_thread_stack_t *main_stack,
-					 size_t main_stack_size,
-					 k_thread_entry_t _main);
 
 #endif /* _ASMLANGUAGE */
 

--- a/arch/posix/core/irq.c
+++ b/arch/posix/core/irq.c
@@ -7,9 +7,26 @@
 #include "posix_soc_if.h"
 #include "board_irq.h"
 
+#ifdef CONFIG_IRQ_OFFLOAD
 void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	posix_irq_offload(routine, parameter);
+}
+#endif
+
+void z_arch_irq_enable(unsigned int irq)
+{
+	posix_irq_enable(irq);
+}
+
+void z_arch_irq_disable(unsigned int irq)
+{
+	posix_irq_disable(irq);
+}
+
+int z_arch_irq_is_enabled(unsigned int irq)
+{
+	return posix_irq_is_enabled(irq);
 }
 
 #ifdef CONFIG_DYNAMIC_INTERRUPTS

--- a/arch/posix/include/posix_soc_if.h
+++ b/arch/posix/include/posix_soc_if.h
@@ -32,7 +32,20 @@ unsigned int posix_irq_lock(void);
 void posix_irq_unlock(unsigned int key);
 void posix_irq_full_unlock(void);
 int  posix_get_current_irq(void);
+#ifdef CONFIG_IRQ_OFFLOAD
 void posix_irq_offload(irq_offload_routine_t routine, void *parameter);
+#endif
+
+static ALWAYS_INLINE unsigned int z_arch_irq_lock(void)
+{
+	return posix_irq_lock();
+}
+
+
+static ALWAYS_INLINE void z_arch_irq_unlock(unsigned int key)
+{
+	posix_irq_unlock(key);
+}
 
 #ifdef __cplusplus
 }

--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -327,10 +327,10 @@ static void dump_page_fault(z_arch_esf_t *esf)
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
 #ifdef CONFIG_USERSPACE
-Z_EXC_DECLARE(z_arch_user_string_nlen);
+Z_EXC_DECLARE(z_x86_user_string_nlen);
 
 static const struct z_exc_handle exceptions[] = {
-	Z_EXC_HANDLE(z_arch_user_string_nlen)
+	Z_EXC_HANDLE(z_x86_user_string_nlen)
 };
 #endif
 

--- a/arch/x86/core/ia32/userspace.S
+++ b/arch/x86/core/ia32/userspace.S
@@ -14,9 +14,9 @@
 GTEXT(z_x86_syscall_entry_stub)
 GTEXT(z_x86_userspace_enter)
 GTEXT(z_arch_user_string_nlen)
-GTEXT(z_arch_user_string_nlen_fault_start)
-GTEXT(z_arch_user_string_nlen_fault_end)
-GTEXT(z_arch_user_string_nlen_fixup)
+GTEXT(z_x86_user_string_nlen_fault_start)
+GTEXT(z_x86_user_string_nlen_fault_end)
+GTEXT(z_x86_user_string_nlen_fixup)
 
 /* Imports */
 GDATA(_k_syscall_table)
@@ -270,10 +270,10 @@ SECTION_FUNC(TEXT, z_arch_user_string_nlen)
 
 	/* This code might page fault */
 strlen_loop:
-z_arch_user_string_nlen_fault_start:
+z_x86_user_string_nlen_fault_start:
 	cmpb	$0x0, (%edx, %eax, 1)	/* *(EDX + EAX) == 0? Could fault. */
 
-z_arch_user_string_nlen_fault_end:
+z_x86_user_string_nlen_fault_end:
 	je	strlen_done
 	cmp	0xc(%ebp), %eax		/* Max length reached? */
 	je	strlen_done
@@ -284,7 +284,7 @@ strlen_done:
 	/* Set error value to 0 since we succeeded */
 	movl	$0, -4(%ebp)
 
-z_arch_user_string_nlen_fixup:
+z_x86_user_string_nlen_fixup:
 	/* Write error value to err pointer parameter */
 	movl	0x10(%ebp), %ecx
 	pop	%edx

--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -8,6 +8,7 @@
 #include <arch/cpu.h>
 #include <kernel_arch_data.h>
 #include <drivers/interrupt_controller/sysapic.h>
+#include <drivers/interrupt_controller/loapic.h>
 #include <irq.h>
 
 unsigned char _irq_to_interrupt_vector[CONFIG_MAX_IRQ_LINES];
@@ -114,4 +115,12 @@ void z_x86_ipi_setup(void)
 		(void *) z_sched_ipi;
 }
 
+/*
+ * it is not clear exactly how/where/why to abstract this, as it
+ * assumes the use of a local APIC (but there's no other mechanism).
+ */
+void z_arch_sched_ipi(void)
+{
+	z_loapic_ipi(0, LOAPIC_ICR_IPI_OTHERS, CONFIG_SCHED_IPI_VECTOR);
+}
 #endif

--- a/arch/x86/include/intel64/kernel_arch_func.h
+++ b/arch/x86/include/intel64/kernel_arch_func.h
@@ -40,24 +40,6 @@ static inline struct _cpu *z_arch_curr_cpu(void)
 
 	return cpu;
 }
-
-#if defined(CONFIG_SMP)
-
-#include <drivers/interrupt_controller/loapic.h>
-
-/*
- * it is not clear exactly how/where/why to abstract this, as it
- * assumes the use of a local APIC (but there's no other mechanism).
- */
-
-static inline void z_arch_sched_ipi(void)
-{
-	z_loapic_ipi(0, LOAPIC_ICR_IPI_OTHERS, CONFIG_SCHED_IPI_VECTOR);
-}
-
-#endif
-
-
 #endif /* _ASMLANGUAGE */
 
 #endif /* ZEPHYR_ARCH_X86_INCLUDE_INTEL64_KERNEL_ARCH_FUNC_H_ */

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -274,6 +274,7 @@ void posix_sw_clear_pending_IRQ(unsigned int IRQn)
 	hw_irq_ctrl_clear_irq(IRQn);
 }
 
+#ifdef CONFIG_IRQ_OFFLOAD
 /**
  * Storage for functions offloaded to IRQ
  */
@@ -303,3 +304,4 @@ void posix_irq_offload(irq_offload_routine_t routine, void *parameter)
 	posix_sw_set_pending_IRQ(OFFLOAD_SW_IRQ);
 	posix_irq_disable(OFFLOAD_SW_IRQ);
 }
+#endif /* CONFIG_IRQ_OFFLOAD */

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -333,6 +333,7 @@ void posix_sw_clear_pending_IRQ(unsigned int IRQn)
 	hw_irq_ctrl_clear_irq(IRQn);
 }
 
+#ifdef CONFIG_IRQ_OFFLOAD
 /**
  * Storage for functions offloaded to IRQ
  */
@@ -362,6 +363,7 @@ void posix_irq_offload(irq_offload_routine_t routine, void *parameter)
 	posix_sw_set_pending_IRQ(OFFLOAD_SW_IRQ);
 	posix_irq_disable(OFFLOAD_SW_IRQ);
 }
+#endif
 
 /**
  * Replacement for ARMs NVIC_SetPendingIRQ()

--- a/include/arch/cpu.h
+++ b/include/arch/cpu.h
@@ -9,6 +9,8 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_CPU_H_
 #define ZEPHYR_INCLUDE_ARCH_CPU_H_
 
+#include <sys/arch_inlines.h>
+
 #if defined(CONFIG_X86)
 #include <arch/x86/arch.h>
 #elif defined(CONFIG_X86_64)

--- a/include/arch/posix/arch.h
+++ b/include/arch/posix/arch.h
@@ -56,35 +56,6 @@ static ALWAYS_INLINE void z_arch_nop(void)
 	__asm__ volatile("nop");
 }
 
-static ALWAYS_INLINE unsigned int z_arch_irq_lock(void)
-{
-	return posix_irq_lock();
-}
-
-static ALWAYS_INLINE void z_arch_irq_unlock(unsigned int key)
-{
-	posix_irq_unlock(key);
-}
-
-static ALWAYS_INLINE void z_arch_irq_enable(unsigned int irq)
-{
-	posix_irq_enable(irq);
-}
-
-static ALWAYS_INLINE void z_arch_irq_disable(unsigned int irq)
-{
-	posix_irq_disable(irq);
-}
-
-static ALWAYS_INLINE int z_arch_irq_is_enabled(unsigned int irq)
-{
-	return posix_irq_is_enabled(irq);
-}
-
-/**
- * Returns true if interrupts were unlocked prior to the
- * z_arch_irq_lock() call that produced the key argument.
- */
 static ALWAYS_INLINE bool z_arch_irq_unlocked(unsigned int key)
 {
 	return key == false;

--- a/include/arch/x86/ia32/arch.h
+++ b/include/arch/x86/ia32/arch.h
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 #include <arch/common/ffs.h>
 #include <misc/util.h>
+#include <arch/x86/ia32/syscall.h>
 
 #ifndef _ASMLANGUAGE
 #include <stddef.h>	/* for size_t */

--- a/include/irq.h
+++ b/include/irq.h
@@ -50,10 +50,6 @@ extern "C" {
 #define IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 	Z_ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p)
 
-extern int z_arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
-			     void (*routine)(void *parameter), void *parameter,
-			     u32_t flags);
-
 /**
  * Configure a dynamic interrupt.
  *

--- a/include/irq_offload.h
+++ b/include/irq_offload.h
@@ -15,10 +15,9 @@
 extern "C" {
 #endif
 
-typedef void (*irq_offload_routine_t)(void *parameter);
+#include <arch/cpu.h>
 
-void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter);
-
+#ifdef CONFIG_IRQ_OFFLOAD
 /**
  * @brief Run a function in interrupt context
  *
@@ -35,6 +34,7 @@ static inline void irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	z_arch_irq_offload(routine, parameter);
 }
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1814,7 +1814,10 @@ static inline u32_t k_uptime_delta_32(s64_t *reftime)
  *
  * @return Current hardware clock up-counter (in cycles).
  */
-#define k_cycle_get_32()	z_arch_k_cycle_get_32()
+static inline u32_t k_cycle_get_32(void)
+{
+	return z_arch_k_cycle_get_32();
+}
 
 /**
  * @}
@@ -4747,10 +4750,6 @@ extern void z_handle_obj_poll_events(sys_dlist_t *events, u32_t state);
  * @ingroup kernel_apis
  * @{
  */
-
-extern void z_arch_cpu_idle(void);
-extern void z_arch_cpu_atomic_idle(unsigned int key);
-
 /**
  * @brief Make the CPU idle.
  *
@@ -5161,10 +5160,6 @@ extern void k_mem_domain_remove_thread(k_tid_t thread);
  * @req K-MISC-006
  */
 __syscall void k_str_out(char *c, size_t n);
-
-extern void z_arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
-			    void (*fn)(int key, void *data), void *arg);
-
 
 /**
  * @brief Disable preservation of floating point context information.

--- a/include/syscall.h
+++ b/include/syscall.h
@@ -86,45 +86,6 @@ extern "C" {
 typedef u32_t (*_k_syscall_handler_t)(u32_t arg1, u32_t arg2, u32_t arg3,
 				      u32_t arg4, u32_t arg5, u32_t arg6,
 				      void *ssf);
-#ifdef CONFIG_USERSPACE
-
-/*
- * Interfaces for invoking system calls
- */
-
-static inline u32_t z_arch_syscall_invoke0(u32_t call_id);
-
-static inline u32_t z_arch_syscall_invoke1(u32_t arg1, u32_t call_id);
-
-static inline u32_t z_arch_syscall_invoke2(u32_t arg1, u32_t arg2,
-					  u32_t call_id);
-
-static inline u32_t z_arch_syscall_invoke3(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t call_id);
-
-static inline u32_t z_arch_syscall_invoke4(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t arg4, u32_t call_id);
-
-static inline u32_t z_arch_syscall_invoke5(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t arg4, u32_t arg5,
-					  u32_t call_id);
-
-static inline u32_t z_arch_syscall_invoke6(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t arg4, u32_t arg5, u32_t arg6,
-					  u32_t call_id);
-
-#endif /* CONFIG_USERSPACE */
-
-/**
- * Indicate whether we are currently running in user mode
- *
- * @return true if the CPU is currently running with user permissions
- */
-#ifdef CONFIG_USERSPACE
-static inline bool z_arch_is_user_context(void);
-#else
-#define z_arch_is_user_context() (true)
-#endif
 
 /* True if a syscall function must trap to the kernel, usually a
  * compile-time decision.

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -47,7 +47,6 @@
 #endif
 #endif
 
-#endif /* !_LINKER */
 
 /* C++11 has static_assert built in */
 #ifdef __cplusplus
@@ -72,6 +71,8 @@
 	return_type new_alias() ALIAS_OF(real_func)
 
 #if defined(CONFIG_ARCH_POSIX)
+#include <posix_trace.h>
+
 /*let's not segfault if this were to happen for some reason*/
 #define CODE_UNREACHABLE \
 {\
@@ -212,7 +213,7 @@ do {                                                                    \
 
 /* These macros allow having ARM asm functions callable from thumb */
 
-#if defined(_ASMLANGUAGE) && !defined(_LINKER)
+#if defined(_ASMLANGUAGE)
 
 #ifdef CONFIG_ARM
 
@@ -239,7 +240,7 @@ do {                                                                    \
 
 #endif /* !CONFIG_ARM */
 
-#endif /* _ASMLANGUAGE && !_LINKER */
+#endif /* _ASMLANGUAGE */
 
 /*
  * These macros are used to declare assembly language symbols that need
@@ -248,7 +249,7 @@ do {                                                                    \
  * correctly.  This is an elfism. Use #if 0 for a.out.
  */
 
-#if defined(_ASMLANGUAGE) && !defined(_LINKER)
+#if defined(_ASMLANGUAGE)
 
 #if defined(CONFIG_ARM) || defined(CONFIG_NIOS2) || defined(CONFIG_RISCV) \
 	|| defined(CONFIG_XTENSA)
@@ -341,7 +342,7 @@ do {                                                                    \
 
 #endif /* CONFIG_ARC */
 
-#endif /* _ASMLANGUAGE && !_LINKER */
+#endif /* _ASMLANGUAGE */
 
 #if defined(CONFIG_ARM) && defined(_ASMLANGUAGE)
 #if defined(CONFIG_ISA_THUMB2)
@@ -445,4 +446,5 @@ do {                                                                    \
 		_value_a_ < _value_b_ ? _value_a_ : _value_b_; \
 	})
 
+#endif /* !_LINKER */
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_GCC_H_ */

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -39,48 +39,13 @@ FUNC_NORETURN void z_cstart(void);
 extern FUNC_NORETURN void z_thread_entry(k_thread_entry_t entry,
 			  void *p1, void *p2, void *p3);
 
-/* Implemented by architectures. Only called from z_setup_new_thread. */
-extern void z_arch_new_thread(struct k_thread *thread, k_thread_stack_t *pStack,
-			      size_t stackSize, k_thread_entry_t entry,
-			      void *p1, void *p2, void *p3,
-			      int prio, unsigned int options);
-
 extern void z_setup_new_thread(struct k_thread *new_thread,
 			      k_thread_stack_t *stack, size_t stack_size,
 			      k_thread_entry_t entry,
 			      void *p1, void *p2, void *p3,
 			      int prio, u32_t options, const char *name);
 
-#if defined(CONFIG_FLOAT) && defined(CONFIG_FP_SHARING)
-extern int z_arch_float_disable(struct k_thread *thread);
-#endif /* CONFIG_FLOAT && CONFIG_FP_SHARING */
-
 #ifdef CONFIG_USERSPACE
-extern int z_arch_mem_domain_max_partitions_get(void);
-
-extern void z_arch_mem_domain_thread_add(struct k_thread *thread);
-
-extern void z_arch_mem_domain_thread_remove(struct k_thread *thread);
-
-extern void z_arch_mem_domain_partition_remove(struct k_mem_domain *domain,
-					       u32_t partition_id);
-
-extern void z_arch_mem_domain_partition_add(struct k_mem_domain *domain,
-					    u32_t partition_id);
-
-extern void z_arch_mem_domain_destroy(struct k_mem_domain *domain);
-
-extern int z_arch_buffer_validate(void *addr, size_t size, int write);
-
-extern FUNC_NORETURN
-void z_arch_user_mode_enter(k_thread_entry_t user_entry, void *p1, void *p2,
-			   void *p3);
-
-
-extern FUNC_NORETURN void z_arch_syscall_oops(void *ssf);
-
-extern size_t z_arch_user_string_nlen(const char *s, size_t maxsize, int *err);
-
 /**
  * @brief Zero out BSS sections for application shared memory
  *
@@ -127,27 +92,6 @@ extern u32_t z_early_boot_rand32_get(void);
 #if CONFIG_STACK_POINTER_RANDOM
 extern int z_stack_adjust_initialized;
 #endif
-
-#if defined(CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT)
-extern void z_arch_busy_wait(u32_t usec_to_wait);
-#endif
-
-int z_arch_swap(unsigned int key);
-
-extern FUNC_NORETURN void z_arch_system_halt(unsigned int reason);
-
-#ifdef CONFIG_EXECUTION_BENCHMARKING
-extern u64_t z_arch_timing_swap_start;
-extern u64_t z_arch_timing_swap_end;
-extern u64_t z_arch_timing_irq_start;
-extern u64_t z_arch_timing_irq_end;
-extern u64_t z_arch_timing_tick_start;
-extern u64_t z_arch_timing_tick_end;
-extern u64_t z_arch_timing_user_mode_end;
-extern u32_t z_arch_timing_value_swap_end;
-extern u64_t z_arch_timing_value_swap_common;
-extern u64_t z_arch_timing_value_swap_temp;
-#endif /* CONFIG_EXECUTION_BENCHMARKING */
 
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
 extern u32_t z_timestamp_main; /* timestamp when main task starts */

--- a/kernel/include/kernel_structs.h
+++ b/kernel/include/kernel_structs.h
@@ -15,6 +15,7 @@
 #include <sys/rb.h>
 #include <sys/util.h>
 #include <string.h>
+#include <sys/arch_interface.h>
 #endif
 
 #define K_NUM_PRIORITIES \


### PR DESCRIPTION
These new headers are now pulled into the appropriate #include spaces.