### PR TITLE
doc: use multi-column display for long lists

### DIFF
--- a/boards/arm/nucleo_g431rb/doc/index.rst
+++ b/boards/arm/nucleo_g431rb/doc/index.rst
@@ -133,6 +133,8 @@ For mode details please refer to `STM32G4 Nucleo-64 board User Manual`_.
 Default Zephyr Peripheral Mapping:
 ----------------------------------
 
+.. rst-class:: rst-columns
+
 - UART_1_TX : PC4
 - UART_1_RX : PC5
 - UART_2_TX : PA2

--- a/boards/arm/nucleo_l476rg/doc/index.rst
+++ b/boards/arm/nucleo_l476rg/doc/index.rst
@@ -156,6 +156,8 @@ For mode details please refer to `STM32 Nucleo-64 board User Manual`_.
 Default Zephyr Peripheral Mapping:
 ----------------------------------
 
+.. rst-class:: rst-columns
+
 - UART_1_TX : PA9
 - UART_1_RX : PA10
 - UART_2_TX : PA2

--- a/boards/arm/nucleo_l4r5zi/doc/index.rst
+++ b/boards/arm/nucleo_l4r5zi/doc/index.rst
@@ -167,6 +167,8 @@ For mode details please refer to `STM32 Nucleo-144 board User Manual`_.
 Default Zephyr Peripheral Mapping:
 ----------------------------------
 
+.. rst-class:: rst-columns
+
 - UART_1_TX : PA9
 - UART_1_RX : PA10
 - UART_2_TX : PA2

--- a/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
+++ b/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
@@ -187,6 +187,8 @@ input/output, pull-up, etc.
 Default Zephyr Peripheral Mapping:
 ----------------------------------
 
+.. rst-class:: rst-columns
+
 - UART_1 TX/RX : PB7/PB6
 - LPUART_1 TX/RX : PA3/PA2 (arduino_serial)
 - I2C_1_SCL : PB8

--- a/boards/arm/stm32f3_disco/doc/index.rst
+++ b/boards/arm/stm32f3_disco/doc/index.rst
@@ -112,6 +112,9 @@ For mode details please refer to `STM32F3DISCOVERY board User Manual`_.
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
+
+.. rst-class:: rst-columns
+
 - UART_1_TX : PC4
 - UART_1_RX : PC5
 - UART_2_TX : PA2

--- a/boards/arm/stm32f4_disco/doc/index.rst
+++ b/boards/arm/stm32f4_disco/doc/index.rst
@@ -114,6 +114,9 @@ For mode details please refer to `STM32F4DISCOVERY board User Manual`_.
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
+
+.. rst-class:: rst-columns
+
 - UART_1_TX : PB6
 - UART_1_RX : PB7
 - UART_2_TX : PA2


### PR DESCRIPTION
A style was recently added that will allow long narrow lists to display
as three columns across the page (with a responsive design that
self-adjusts based on screen width).  This looks much better than a long
list that runs down the page.

Adding this directive before a block (or nested under the directive)
will allow the content to be multi-column:

   .. rst-class:: rst-columns

as explained in
https://docs.zephyrproject.org/latest/guides/documentation/index.html
in the Multi-column lists section.

This PR tweaks a few remaining documents that have such long narrow
lists.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>