### PR TITLE
riscv: properly pull in irq_offload logic

### DIFF
--- a/arch/riscv/core/CMakeLists.txt
+++ b/arch/riscv/core/CMakeLists.txt
@@ -4,10 +4,11 @@ zephyr_sources(
   cpu_idle.c
   fatal.c
   irq_manage.c
-  irq_offload.c
   isr.S
   prep_c.c
   reset.S
   swap.S
   thread.c
 )
+
+zephyr_sources_if_kconfig(irq_offload.c)

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -211,6 +211,7 @@ on_irq_stack:
 	addi t3, t3, 1
 	sw t3, _kernel_offset_to_nested(t2)
 
+#ifdef CONFIG_IRQ_OFFLOAD
 	/*
 	 * If we are here due to a system call, t1 register should != 0.
 	 * In this case, perform IRQ offloading, otherwise jump to call_irq
@@ -226,6 +227,7 @@ on_irq_stack:
 	tail z_irq_do_offload
 
 call_irq:
+#endif /* CONFIG_IRQ_OFFLOAD */
 #ifdef CONFIG_TRACING
 	call sys_trace_isr_enter
 #endif


### PR DESCRIPTION
This is an optional feature and no logic for it should
be present unless CONFIG_IRQ_OFFLOAD is enabled.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>