### PR TITLE
net: lwm2m: Small DNS cleanup

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -26,6 +26,10 @@ config LWM2M_DTLS_SUPPORT
 	select NET_SOCKETS_SOCKOPT_TLS
 	select NET_SOCKETS_ENABLE_DTLS
 
+config LWM2M_DNS_SUPPORT
+	bool "Enable DNS support in the LWM2M client"
+	default y if DNS_RESOLVER
+
 config LWM2M_ENGINE_STACK_SIZE
 	int "LWM2M engine stack size"
 	default 2560 if NET_LOG

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -4203,7 +4203,7 @@ int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls)
 {
 	struct http_parser_url parser;
 #if defined(CONFIG_LWM2M_DNS_SUPPORT)
-	struct addrinfo hints, *res;
+	struct addrinfo *res, hints = { 0 };
 #endif
 	int ret;
 	u16_t off, len;
@@ -4269,9 +4269,6 @@ int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls)
 #elif defined(CONFIG_NET_IPV6)
 		hints.ai_family = AF_INET6;
 #elif defined(CONFIG_NET_IPV4)
-		hints.ai_family = AF_INET;
-#elif defined(CONFIG_NET_SOCKETS_OFFLOAD)
-		memset(&hints, 0, sizeof(hints));
 		hints.ai_family = AF_INET;
 #else
 		hints.ai_family = AF_UNSPEC;

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -4202,7 +4202,7 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls)
 {
 	struct http_parser_url parser;
-#if defined(CONFIG_DNS_RESOLVER)
+#if defined(CONFIG_LWM2M_DNS_SUPPORT)
 	struct addrinfo hints, *res;
 #endif
 	int ret;
@@ -4263,7 +4263,7 @@ int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls)
 	}
 
 	if (ret < 0) {
-#if defined(CONFIG_DNS_RESOLVER)
+#if defined(CONFIG_LWM2M_DNS_SUPPORT)
 #if defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_IPV4)
 		hints.ai_family = AF_UNSPEC;
 #elif defined(CONFIG_NET_IPV6)
@@ -4290,7 +4290,7 @@ int lwm2m_parse_peerinfo(char *url, struct sockaddr *addr, bool *use_dtls)
 		freeaddrinfo(res);
 #else
 		goto cleanup;
-#endif /* CONFIG_DNS_RESOLVER */
+#endif /* CONFIG_LWM2M_DNS_SUPPORT */
 	}
 
 	/* set port */


### PR DESCRIPTION
A small cleanup in how LWM2M library handles DNS:
1. Introduce `LWM2M_DNS_SUPPORT` config to control the DNS support in the library. This removes the dependency to `DNS_RESOLVER` from the library.
2. Remove special handling for `NET_SOCKETS_OFFLOAD`. With `CONFIG_NET_NATIVE=n` option, offloaded engines can specify IPv4/6 capabilities with `NET_IPV4`/`NET_IPV6` configs. 