### PR TITLE
arch: arm: error: fix ARMv6-M assembly for Z_ARCH_EXCEPT

### DIFF
--- a/include/arch/arm/error.h
+++ b/include/arch/arm/error.h
@@ -31,13 +31,14 @@ extern "C" {
  * schedule a new thread until they are unlocked which is not what we want.
  * Force them unlocked as well.
  */
-#define Z_ARCH_EXCEPT(reason_p) do { \
+#define Z_ARCH_EXCEPT(reason_p) \
+register u32_t r0 __asm__("r0") = reason_p; \
+do { \
 	__asm__ volatile ( \
 		"cpsie i\n\t" \
-		"movs r0, %[reason]\n\t" \
 		"svc %[id]\n\t" \
 		: \
-		: [reason] "i" (reason_p), [id] "i" (_SVC_CALL_RUNTIME_EXCEPT) \
+		: "r" (r0), [id] "i" (_SVC_CALL_RUNTIME_EXCEPT) \
 		: "memory"); \
 	CODE_UNREACHABLE; \
 } while (false)

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -124,6 +124,19 @@ void alt_thread4(void)
 	rv = TC_FAIL;
 }
 
+void alt_thread5(void)
+{
+	unsigned int key;
+
+	expected_reason = INT_MAX;
+
+	key = irq_lock();
+	z_except_reason(INT_MAX);
+	TC_ERROR("SHOULD NEVER SEE THIS\n");
+	rv = TC_FAIL;
+	irq_unlock(key);
+}
+
 #ifndef CONFIG_ARCH_POSIX
 #ifdef CONFIG_STACK_SENTINEL
 void blow_up_stack(void)
@@ -297,6 +310,14 @@ void test_fatal(void)
 	k_thread_abort(&alt_thread);
 	zassert_not_equal(rv, TC_FAIL, "thread was not aborted");
 
+	TC_PRINT("test alt thread 5: initiate arbitrary SW exception\n");
+	k_thread_create(&alt_thread, alt_stack,
+			K_THREAD_STACK_SIZEOF(alt_stack),
+			(k_thread_entry_t)alt_thread5,
+			NULL, NULL, NULL, K_PRIO_COOP(PRIORITY), 0,
+			K_NO_WAIT);
+	k_thread_abort(&alt_thread);
+	zassert_not_equal(rv, TC_FAIL, "thread was not aborted");
 
 #ifndef CONFIG_ARCH_POSIX
 


### PR DESCRIPTION
As we are allowed to pass any integer value as as software
fatal exception reason, we need to fix the inline assembly
for ARMv6-M, to accept large immediate offsets. We do this
by changing MOV to LDR. We add a test case in kernel/fatal
to cover this scenario.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>