### PR TITLE
net: tls: Set accepting socket to LISTENING state

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1267,6 +1267,10 @@ int ztls_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 		return -1;
 	}
 
+	if (net_context_get_ip_proto(parent) == IPPROTO_TCP) {
+		net_context_set_state(parent, NET_CONTEXT_LISTENING);
+	}
+
 	child = k_fifo_get(&parent->accept_q, K_FOREVER);
 
 	#ifdef CONFIG_USERSPACE


### PR DESCRIPTION
This is related to commit 1a6f4a636896 ("net: tcp: Accept
connections only in LISTENING state") which made the system
to only accept new connections if the application had called
accept(). Unfortunately the TLS accept was not fixed by that
commit so we were in wrong state when accepting TLS sockets.
This commit fixes that issue.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>