### PR TITLE
[TOPIC-GPIO] drivers: sensor: hts221: update to new GPIO API

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -92,7 +92,7 @@
 		compatible = "st,hts221";
 		reg = <0x5f>;
 		label = "HTS221";
-		drdy-gpios = <&gpioa 2 GPIO_ACTIVE_LOW>;
+		drdy-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
 	};
 
 	lps22hb-press@5d {

--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
@@ -102,7 +102,7 @@
 		compatible = "st,hts221";
 		reg = <0x5f>;
 		label = "HTS221";
-		drdy-gpios = <&gpio0 24 0>;
+		drdy-gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
 	};
 
 	ccs811: ccs811@5a {

--- a/boards/arm/sensortile_box/sensortile_box.dts
+++ b/boards/arm/sensortile_box/sensortile_box.dts
@@ -59,7 +59,7 @@
 		compatible = "st,hts221";
 		reg = <0x5f>;
 		label = "HTS221";
-		drdy-gpios = <&gpiod 13 GPIO_ACTIVE_LOW>;
+		drdy-gpios = <&gpiod 13 GPIO_ACTIVE_HIGH>;
 	};
 
 	lps22hh@5d {

--- a/dts/bindings/sensor/st,hts221.yaml
+++ b/dts/bindings/sensor/st,hts221.yaml
@@ -16,3 +16,7 @@ properties:
       type: phandle-array
       required: false
       description: DRDY pin
+
+        This pin defaults to active high when produced by the sensor.
+        The property value should ensure the flags properly describe
+        the signal that is presented to the driver.


### PR DESCRIPTION
Correct DRDY active level to default active-high, switch to new interrupt configuration.

Tested on nrf52_pca20020 (Thingy:52) and (after much pain unrelated to this change) frdm_k64f with the x_nucleo_iks01a2 shield.

*NOTE*: This PR also contains #19862 and #19870 on which it depends.