### PR TITLE
sanitycheck: Use os.makedirs to create --report-dir.

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2324,7 +2324,7 @@ class TestSuite:
             report_name = options.report_name
 
         if options.report_dir:
-            os.mkdir(options.report_dir)
+            os.makedirs(options.report_dir, exist_ok=True)
             filename = os.path.join(options.report_dir, report_name)
             outdir = options.report_dir
         else:


### PR DESCRIPTION
os.mkdir() is not suitable to create arbitrary directory path (can
create only a subdir of an existing dir, will error out if already
exists), os.makedirs() should be always used in such cases.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>