### PR TITLE
Bluetooth: HCI: Add function to get connection handle of connection

### DIFF
--- a/include/bluetooth/addr.h
+++ b/include/bluetooth/addr.h
@@ -1,0 +1,95 @@
+/** @file
+ *  @brief Bluetooth device address definitions and utilities.
+ */
+
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_ADDR_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_ADDR_H_
+
+#include <zephyr/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BT_ADDR_LE_PUBLIC       0x00
+#define BT_ADDR_LE_RANDOM       0x01
+#define BT_ADDR_LE_PUBLIC_ID    0x02
+#define BT_ADDR_LE_RANDOM_ID    0x03
+
+/** Bluetooth Device Address */
+typedef struct {
+	u8_t  val[6];
+} bt_addr_t;
+
+/** Bluetooth LE Device Address */
+typedef struct {
+	u8_t      type;
+	bt_addr_t a;
+} bt_addr_le_t;
+
+#define BT_ADDR_ANY     (&(bt_addr_t) { { 0, 0, 0, 0, 0, 0 } })
+#define BT_ADDR_NONE    (&(bt_addr_t) { \
+			 { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } })
+#define BT_ADDR_LE_ANY  (&(bt_addr_le_t) { 0, { { 0, 0, 0, 0, 0, 0 } } })
+#define BT_ADDR_LE_NONE (&(bt_addr_le_t) { 0, \
+			 { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } } })
+
+static inline int bt_addr_cmp(const bt_addr_t *a, const bt_addr_t *b)
+{
+	return memcmp(a, b, sizeof(*a));
+}
+
+static inline int bt_addr_le_cmp(const bt_addr_le_t *a, const bt_addr_le_t *b)
+{
+	return memcmp(a, b, sizeof(*a));
+}
+
+static inline void bt_addr_copy(bt_addr_t *dst, const bt_addr_t *src)
+{
+	memcpy(dst, src, sizeof(*dst));
+}
+
+static inline void bt_addr_le_copy(bt_addr_le_t *dst, const bt_addr_le_t *src)
+{
+	memcpy(dst, src, sizeof(*dst));
+}
+
+#define BT_ADDR_IS_RPA(a)     (((a)->val[5] & 0xc0) == 0x40)
+#define BT_ADDR_IS_NRPA(a)    (((a)->val[5] & 0xc0) == 0x00)
+#define BT_ADDR_IS_STATIC(a)  (((a)->val[5] & 0xc0) == 0xc0)
+
+#define BT_ADDR_SET_RPA(a)    ((a)->val[5] = (((a)->val[5] & 0x3f) | 0x40))
+#define BT_ADDR_SET_NRPA(a)   ((a)->val[5] &= 0x3f)
+#define BT_ADDR_SET_STATIC(a) ((a)->val[5] |= 0xc0)
+
+int bt_addr_le_create_nrpa(bt_addr_le_t *addr);
+int bt_addr_le_create_static(bt_addr_le_t *addr);
+
+static inline bool bt_addr_le_is_rpa(const bt_addr_le_t *addr)
+{
+	if (addr->type != BT_ADDR_LE_RANDOM) {
+		return false;
+	}
+
+	return BT_ADDR_IS_RPA(&addr->a);
+}
+
+static inline bool bt_addr_le_is_identity(const bt_addr_le_t *addr)
+{
+	if (addr->type == BT_ADDR_LE_PUBLIC) {
+		return true;
+	}
+
+	return BT_ADDR_IS_STATIC(&addr->a);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_ADDR_H_ */

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -22,6 +22,7 @@
 #include <sys/printk.h>
 #include <sys/util.h>
 #include <net/buf.h>
+#include <bluetooth/gap.h>
 #include <bluetooth/crypto.h>
 
 #ifdef __cplusplus

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -22,7 +22,6 @@
 #include <sys/printk.h>
 #include <sys/util.h>
 #include <net/buf.h>
-#include <bluetooth/hci.h>
 #include <bluetooth/crypto.h>
 
 #ifdef __cplusplus
@@ -419,9 +418,17 @@ enum {
 	BT_LE_SCAN_FILTER_EXTENDED = BIT(2),
 };
 
+enum {
+	/* Scan without requesting additional information from advertisers. */
+	BT_LE_SCAN_TYPE_PASSIVE = 0x00,
+
+	/* Scan and request additional information from advertisers. */
+	BT_LE_SCAN_TYPE_ACTIVE = 0x01,
+};
+
 /** LE scan parameters */
 struct bt_le_scan_param {
-	/** Scan type (BT_HCI_LE_SCAN_ACTIVE or BT_HCI_LE_SCAN_PASSIVE) */
+	/** Scan type (BT_LE_SCAN_TYPE_ACTIVE or BT_LE_SCAN_TYPE_PASSIVE) */
 	u8_t  type;
 
 	/** Bit-field of scanning filter options. */
@@ -436,7 +443,8 @@ struct bt_le_scan_param {
 
 /** Helper to declare scan parameters inline
   *
-  * @param _type     Scan Type (BT_HCI_LE_SCAN_ACTIVE/BT_HCI_LE_SCAN_PASSIVE)
+  * @param _type     Scan Type, BT_LE_SCAN_TYPE_ACTIVE or
+  *                  BT_LE_SCAN_TYPE_PASSIVE.
   * @param _filter   Filter options
   * @param _interval Scan Interval (N * 0.625 ms)
   * @param _window   Scan Window (N * 0.625 ms)
@@ -450,7 +458,7 @@ struct bt_le_scan_param {
 		 })
 
 /** Helper macro to enable active scanning to discover new devices. */
-#define BT_LE_SCAN_ACTIVE BT_LE_SCAN_PARAM(BT_HCI_LE_SCAN_ACTIVE, \
+#define BT_LE_SCAN_ACTIVE BT_LE_SCAN_PARAM(BT_LE_SCAN_TYPE_ACTIVE, \
 					   BT_LE_SCAN_FILTER_DUPLICATE, \
 					   BT_GAP_SCAN_FAST_INTERVAL, \
 					   BT_GAP_SCAN_FAST_WINDOW)
@@ -460,7 +468,7 @@ struct bt_le_scan_param {
  * This macro should be used if information required for device identification
  * (e.g., UUID) are known to be placed in Advertising Data.
  */
-#define BT_LE_SCAN_PASSIVE BT_LE_SCAN_PARAM(BT_HCI_LE_SCAN_PASSIVE, \
+#define BT_LE_SCAN_PASSIVE BT_LE_SCAN_PARAM(BT_LE_SCAN_TYPE_PASSIVE, \
 					    BT_LE_SCAN_FILTER_DUPLICATE, \
 					    BT_GAP_SCAN_FAST_INTERVAL, \
 					    BT_GAP_SCAN_FAST_WINDOW)

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -23,6 +23,7 @@
 #include <sys/util.h>
 #include <net/buf.h>
 #include <bluetooth/gap.h>
+#include <bluetooth/addr.h>
 #include <bluetooth/crypto.h>
 
 #ifdef __cplusplus

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -21,6 +21,7 @@
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
+#include <bluetooth/addr.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -20,7 +20,7 @@
 #include <stdbool.h>
 
 #include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
+#include <bluetooth/hci_err.h>
 #include <bluetooth/addr.h>
 
 #ifdef __cplusplus

--- a/include/bluetooth/gap.h
+++ b/include/bluetooth/gap.h
@@ -1,0 +1,76 @@
+/** @file
+ *  @brief Bluetooth Generic Access Profile defines and Assigned Numbers.
+ */
+
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_GAP_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_GAP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Company Identifiers (see Bluetooth Assigned Numbers) */
+#define BT_COMP_ID_LF           0x05f1 /* The Linux Foundation */
+
+/* EIR/AD data type definitions */
+#define BT_DATA_FLAGS                   0x01 /* AD flags */
+#define BT_DATA_UUID16_SOME             0x02 /* 16-bit UUID, more available */
+#define BT_DATA_UUID16_ALL              0x03 /* 16-bit UUID, all listed */
+#define BT_DATA_UUID32_SOME             0x04 /* 32-bit UUID, more available */
+#define BT_DATA_UUID32_ALL              0x05 /* 32-bit UUID, all listed */
+#define BT_DATA_UUID128_SOME            0x06 /* 128-bit UUID, more available */
+#define BT_DATA_UUID128_ALL             0x07 /* 128-bit UUID, all listed */
+#define BT_DATA_NAME_SHORTENED          0x08 /* Shortened name */
+#define BT_DATA_NAME_COMPLETE           0x09 /* Complete name */
+#define BT_DATA_TX_POWER                0x0a /* Tx Power */
+#define BT_DATA_SM_TK_VALUE             0x10 /* Security Manager TK Value */
+#define BT_DATA_SM_OOB_FLAGS            0x11 /* Security Manager OOB Flags */
+#define BT_DATA_SOLICIT16               0x14 /* Solicit UUIDs, 16-bit */
+#define BT_DATA_SOLICIT128              0x15 /* Solicit UUIDs, 128-bit */
+#define BT_DATA_SVC_DATA16              0x16 /* Service data, 16-bit UUID */
+#define BT_DATA_GAP_APPEARANCE          0x19 /* GAP appearance */
+#define BT_DATA_LE_BT_DEVICE_ADDRESS    0x1b /* LE Bluetooth Device Address */
+#define BT_DATA_LE_ROLE                 0x1c /* LE Role */
+#define BT_DATA_SOLICIT32               0x1f /* Solicit UUIDs, 32-bit */
+#define BT_DATA_SVC_DATA32              0x20 /* Service data, 32-bit UUID */
+#define BT_DATA_SVC_DATA128             0x21 /* Service data, 128-bit UUID */
+#define BT_DATA_LE_SC_CONFIRM_VALUE     0x22 /* LE SC Confirmation Value */
+#define BT_DATA_LE_SC_RANDOM_VALUE      0x23 /* LE SC Random Value */
+#define BT_DATA_URI                     0x24 /* URI */
+#define BT_DATA_MESH_PROV               0x29 /* Mesh Provisioning PDU */
+#define BT_DATA_MESH_MESSAGE            0x2a /* Mesh Networking PDU */
+#define BT_DATA_MESH_BEACON             0x2b /* Mesh Beacon */
+
+#define BT_DATA_MANUFACTURER_DATA       0xff /* Manufacturer Specific Data */
+
+#define BT_LE_AD_LIMITED                0x01 /* Limited Discoverable */
+#define BT_LE_AD_GENERAL                0x02 /* General Discoverable */
+#define BT_LE_AD_NO_BREDR               0x04 /* BR/EDR not supported */
+
+/* Defined GAP timers */
+#define BT_GAP_SCAN_FAST_INTERVAL               0x0060  /* 60 ms    */
+#define BT_GAP_SCAN_FAST_WINDOW                 0x0030  /* 30 ms    */
+#define BT_GAP_SCAN_SLOW_INTERVAL_1             0x0800  /* 1.28 s   */
+#define BT_GAP_SCAN_SLOW_WINDOW_1               0x0012  /* 11.25 ms */
+#define BT_GAP_SCAN_SLOW_INTERVAL_2             0x1000  /* 2.56 s   */
+#define BT_GAP_SCAN_SLOW_WINDOW_2               0x0012  /* 11.25 ms */
+#define BT_GAP_ADV_FAST_INT_MIN_1               0x0030  /* 30 ms    */
+#define BT_GAP_ADV_FAST_INT_MAX_1               0x0060  /* 60 ms    */
+#define BT_GAP_ADV_FAST_INT_MIN_2               0x00a0  /* 100 ms   */
+#define BT_GAP_ADV_FAST_INT_MAX_2               0x00f0  /* 150 ms   */
+#define BT_GAP_ADV_SLOW_INT_MIN                 0x0640  /* 1 s      */
+#define BT_GAP_ADV_SLOW_INT_MAX                 0x0780  /* 1.2 s    */
+#define BT_GAP_INIT_CONN_INT_MIN                0x0018  /* 30 ms    */
+#define BT_GAP_INIT_CONN_INT_MAX                0x0028  /* 50 ms    */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_GAP_H_ */

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -14,87 +14,16 @@
 #include <string.h>
 #include <sys/util.h>
 #include <net/buf.h>
+#include <bluetooth/addr.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define BT_ADDR_LE_PUBLIC       0x00
-#define BT_ADDR_LE_RANDOM       0x01
-#define BT_ADDR_LE_PUBLIC_ID    0x02
-#define BT_ADDR_LE_RANDOM_ID    0x03
-
 /* Special own address types for LL privacy (used in adv & scan parameters) */
 #define BT_HCI_OWN_ADDR_RPA_OR_PUBLIC  0x02
 #define BT_HCI_OWN_ADDR_RPA_OR_RANDOM  0x03
 #define BT_HCI_OWN_ADDR_RPA_MASK       0x02
-
-/** Bluetooth Device Address */
-typedef struct {
-	u8_t  val[6];
-} bt_addr_t;
-
-/** Bluetooth LE Device Address */
-typedef struct {
-	u8_t      type;
-	bt_addr_t a;
-} bt_addr_le_t;
-
-#define BT_ADDR_ANY     (&(bt_addr_t) { { 0, 0, 0, 0, 0, 0 } })
-#define BT_ADDR_NONE    (&(bt_addr_t) { \
-			 { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } })
-#define BT_ADDR_LE_ANY  (&(bt_addr_le_t) { 0, { { 0, 0, 0, 0, 0, 0 } } })
-#define BT_ADDR_LE_NONE (&(bt_addr_le_t) { 0, \
-			 { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } } })
-
-static inline int bt_addr_cmp(const bt_addr_t *a, const bt_addr_t *b)
-{
-	return memcmp(a, b, sizeof(*a));
-}
-
-static inline int bt_addr_le_cmp(const bt_addr_le_t *a, const bt_addr_le_t *b)
-{
-	return memcmp(a, b, sizeof(*a));
-}
-
-static inline void bt_addr_copy(bt_addr_t *dst, const bt_addr_t *src)
-{
-	memcpy(dst, src, sizeof(*dst));
-}
-
-static inline void bt_addr_le_copy(bt_addr_le_t *dst, const bt_addr_le_t *src)
-{
-	memcpy(dst, src, sizeof(*dst));
-}
-
-#define BT_ADDR_IS_RPA(a)     (((a)->val[5] & 0xc0) == 0x40)
-#define BT_ADDR_IS_NRPA(a)    (((a)->val[5] & 0xc0) == 0x00)
-#define BT_ADDR_IS_STATIC(a)  (((a)->val[5] & 0xc0) == 0xc0)
-
-#define BT_ADDR_SET_RPA(a)    ((a)->val[5] = (((a)->val[5] & 0x3f) | 0x40))
-#define BT_ADDR_SET_NRPA(a)   ((a)->val[5] &= 0x3f)
-#define BT_ADDR_SET_STATIC(a) ((a)->val[5] |= 0xc0)
-
-int bt_addr_le_create_nrpa(bt_addr_le_t *addr);
-int bt_addr_le_create_static(bt_addr_le_t *addr);
-
-static inline bool bt_addr_le_is_rpa(const bt_addr_le_t *addr)
-{
-	if (addr->type != BT_ADDR_LE_RANDOM) {
-		return false;
-	}
-
-	return BT_ADDR_IS_RPA(&addr->a);
-}
-
-static inline bool bt_addr_le_is_identity(const bt_addr_le_t *addr)
-{
-	if (addr->type == BT_ADDR_LE_PUBLIC) {
-		return true;
-	}
-
-	return BT_ADDR_IS_STATIC(&addr->a);
-}
 
 #define BT_ENC_KEY_SIZE_MIN                     0x07
 #define BT_ENC_KEY_SIZE_MAX                     0x10

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -16,6 +16,7 @@
 #include <net/buf.h>
 #include <bluetooth/addr.h>
 #include <bluetooth/hci_err.h>
+#include <bluetooth/conn.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -1767,6 +1768,15 @@ int bt_hci_cmd_send(u16_t opcode, struct net_buf *buf);
   */
 int bt_hci_cmd_send_sync(u16_t opcode, struct net_buf *buf,
 			 struct net_buf **rsp);
+
+/** @brief Get connection handle for a connection.
+ *
+ * @param conn Connection object.
+ * @param conn_handle Place to store the Connection handle.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int bt_hci_get_conn_handle(const struct bt_conn *conn, u16_t *conn_handle);
 
 /** @typedef bt_hci_vnd_evt_cb_t
   * @brief Callback type for vendor handling of HCI Vendor-Specific Events.

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -19,9 +19,6 @@
 extern "C" {
 #endif
 
-/* Company Identifiers (see Bluetooth Assigned Numbers) */
-#define BT_COMP_ID_LF           0x05f1
-
 #define BT_ADDR_LE_PUBLIC       0x00
 #define BT_ADDR_LE_RANDOM       0x01
 #define BT_ADDR_LE_PUBLIC_ID    0x02
@@ -143,41 +140,6 @@ static inline bool bt_addr_le_is_identity(const bt_addr_le_t *addr)
 
 #define BT_HCI_ERR_AUTHENTICATION_FAIL __DEPRECATED_MACRO BT_HCI_ERR_AUTH_FAIL
 
-/* EIR/AD data type definitions */
-#define BT_DATA_FLAGS                   0x01 /* AD flags */
-#define BT_DATA_UUID16_SOME             0x02 /* 16-bit UUID, more available */
-#define BT_DATA_UUID16_ALL              0x03 /* 16-bit UUID, all listed */
-#define BT_DATA_UUID32_SOME             0x04 /* 32-bit UUID, more available */
-#define BT_DATA_UUID32_ALL              0x05 /* 32-bit UUID, all listed */
-#define BT_DATA_UUID128_SOME            0x06 /* 128-bit UUID, more available */
-#define BT_DATA_UUID128_ALL             0x07 /* 128-bit UUID, all listed */
-#define BT_DATA_NAME_SHORTENED          0x08 /* Shortened name */
-#define BT_DATA_NAME_COMPLETE           0x09 /* Complete name */
-#define BT_DATA_TX_POWER                0x0a /* Tx Power */
-#define BT_DATA_SM_TK_VALUE             0x10 /* Security Manager TK Value */
-#define BT_DATA_SM_OOB_FLAGS            0x11 /* Security Manager OOB Flags */
-#define BT_DATA_SOLICIT16               0x14 /* Solicit UUIDs, 16-bit */
-#define BT_DATA_SOLICIT128              0x15 /* Solicit UUIDs, 128-bit */
-#define BT_DATA_SVC_DATA16              0x16 /* Service data, 16-bit UUID */
-#define BT_DATA_GAP_APPEARANCE          0x19 /* GAP appearance */
-#define BT_DATA_LE_BT_DEVICE_ADDRESS    0x1b /* LE Bluetooth Device Address */
-#define BT_DATA_LE_ROLE                 0x1c /* LE Role */
-#define BT_DATA_SOLICIT32               0x1f /* Solicit UUIDs, 32-bit */
-#define BT_DATA_SVC_DATA32              0x20 /* Service data, 32-bit UUID */
-#define BT_DATA_SVC_DATA128             0x21 /* Service data, 128-bit UUID */
-#define BT_DATA_LE_SC_CONFIRM_VALUE     0x22 /* LE SC Confirmation Value */
-#define BT_DATA_LE_SC_RANDOM_VALUE      0x23 /* LE SC Random Value */
-#define BT_DATA_URI                     0x24 /* URI */
-#define BT_DATA_MESH_PROV               0x29 /* Mesh Provisioning PDU */
-#define BT_DATA_MESH_MESSAGE            0x2a /* Mesh Networking PDU */
-#define BT_DATA_MESH_BEACON             0x2b /* Mesh Beacon */
-
-#define BT_DATA_MANUFACTURER_DATA       0xff /* Manufacturer Specific Data */
-
-#define BT_LE_AD_LIMITED                0x01 /* Limited Discoverable */
-#define BT_LE_AD_GENERAL                0x02 /* General Discoverable */
-#define BT_LE_AD_NO_BREDR               0x04 /* BR/EDR not supported */
-
 struct bt_hci_evt_hdr {
 	u8_t  evt;
 	u8_t  len;
@@ -284,22 +246,6 @@ struct bt_hci_cmd_hdr {
 #define BT_IO_DISPLAY_YESNO                     0x01
 #define BT_IO_KEYBOARD_ONLY                     0x02
 #define BT_IO_NO_INPUT_OUTPUT                   0x03
-
-/* Defined GAP timers */
-#define BT_GAP_SCAN_FAST_INTERVAL               0x0060  /* 60 ms    */
-#define BT_GAP_SCAN_FAST_WINDOW                 0x0030  /* 30 ms    */
-#define BT_GAP_SCAN_SLOW_INTERVAL_1             0x0800  /* 1.28 s   */
-#define BT_GAP_SCAN_SLOW_WINDOW_1               0x0012  /* 11.25 ms */
-#define BT_GAP_SCAN_SLOW_INTERVAL_2             0x1000  /* 2.56 s   */
-#define BT_GAP_SCAN_SLOW_WINDOW_2               0x0012  /* 11.25 ms */
-#define BT_GAP_ADV_FAST_INT_MIN_1               0x0030  /* 30 ms    */
-#define BT_GAP_ADV_FAST_INT_MAX_1               0x0060  /* 60 ms    */
-#define BT_GAP_ADV_FAST_INT_MIN_2               0x00a0  /* 100 ms   */
-#define BT_GAP_ADV_FAST_INT_MAX_2               0x00f0  /* 150 ms   */
-#define BT_GAP_ADV_SLOW_INT_MIN                 0x0640  /* 1 s      */
-#define BT_GAP_ADV_SLOW_INT_MAX                 0x0780  /* 1.2 s    */
-#define BT_GAP_INIT_CONN_INT_MIN                0x0018  /* 30 ms    */
-#define BT_GAP_INIT_CONN_INT_MAX                0x0028  /* 50 ms    */
 
 /* SCO packet types */
 #define HCI_PKT_TYPE_HV1                        0x0020

--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -15,6 +15,7 @@
 #include <sys/util.h>
 #include <net/buf.h>
 #include <bluetooth/addr.h>
+#include <bluetooth/hci_err.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,47 +28,6 @@ extern "C" {
 
 #define BT_ENC_KEY_SIZE_MIN                     0x07
 #define BT_ENC_KEY_SIZE_MAX                     0x10
-
-/* HCI Error Codes */
-#define BT_HCI_ERR_SUCCESS                      0x00
-#define BT_HCI_ERR_UNKNOWN_CMD                  0x01
-#define BT_HCI_ERR_UNKNOWN_CONN_ID              0x02
-#define BT_HCI_ERR_HW_FAILURE                   0x03
-#define BT_HCI_ERR_PAGE_TIMEOUT                 0x04
-#define BT_HCI_ERR_AUTH_FAIL                    0x05
-#define BT_HCI_ERR_PIN_OR_KEY_MISSING           0x06
-#define BT_HCI_ERR_MEM_CAPACITY_EXCEEDED        0x07
-#define BT_HCI_ERR_CONN_TIMEOUT                 0x08
-#define BT_HCI_ERR_CONN_LIMIT_EXCEEDED          0x09
-#define BT_HCI_ERR_SYNC_CONN_LIMIT_EXCEEDED     0x0a
-#define BT_HCI_ERR_CONN_ALREADY_EXISTS          0x0b
-#define BT_HCI_ERR_CMD_DISALLOWED               0x0c
-#define BT_HCI_ERR_INSUFFICIENT_RESOURCES       0x0d
-#define BT_HCI_ERR_INSUFFICIENT_SECURITY        0x0e
-#define BT_HCI_ERR_BD_ADDR_UNACCEPTABLE         0x0f
-#define BT_HCI_ERR_CONN_ACCEPT_TIMEOUT          0x10
-#define BT_HCI_ERR_UNSUPP_FEATURE_PARAM_VAL     0x11
-#define BT_HCI_ERR_INVALID_PARAM                0x12
-#define BT_HCI_ERR_REMOTE_USER_TERM_CONN        0x13
-#define BT_HCI_ERR_REMOTE_LOW_RESOURCES         0x14
-#define BT_HCI_ERR_REMOTE_POWER_OFF             0x15
-#define BT_HCI_ERR_LOCALHOST_TERM_CONN          0x16
-#define BT_HCI_ERR_PAIRING_NOT_ALLOWED          0x18
-#define BT_HCI_ERR_UNSUPP_REMOTE_FEATURE        0x1a
-#define BT_HCI_ERR_INVALID_LL_PARAM             0x1e
-#define BT_HCI_ERR_UNSPECIFIED                  0x1f
-#define BT_HCI_ERR_UNSUPP_LL_PARAM_VAL          0x20
-#define BT_HCI_ERR_LL_RESP_TIMEOUT              0x22
-#define BT_HCI_ERR_LL_PROC_COLLISION            0x23
-#define BT_HCI_ERR_INSTANT_PASSED               0x28
-#define BT_HCI_ERR_PAIRING_NOT_SUPPORTED        0x29
-#define BT_HCI_ERR_DIFF_TRANS_COLLISION         0x2a
-#define BT_HCI_ERR_UNACCEPT_CONN_PARAM          0x3b
-#define BT_HCI_ERR_ADV_TIMEOUT                  0x3c
-#define BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL         0x3d
-#define BT_HCI_ERR_CONN_FAIL_TO_ESTAB           0x3e
-
-#define BT_HCI_ERR_AUTHENTICATION_FAIL __DEPRECATED_MACRO BT_HCI_ERR_AUTH_FAIL
 
 struct bt_hci_evt_hdr {
 	u8_t  evt;

--- a/include/bluetooth/hci_err.h
+++ b/include/bluetooth/hci_err.h
@@ -1,0 +1,62 @@
+/** @file
+ *  @brief Bluetooth Host Control Interface status codes.
+ */
+
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_HCI_STATUS_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_HCI_STATUS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* HCI Error Codes, BT Core spec [Vol 2, Part D]. */
+#define BT_HCI_ERR_SUCCESS                      0x00
+#define BT_HCI_ERR_UNKNOWN_CMD                  0x01
+#define BT_HCI_ERR_UNKNOWN_CONN_ID              0x02
+#define BT_HCI_ERR_HW_FAILURE                   0x03
+#define BT_HCI_ERR_PAGE_TIMEOUT                 0x04
+#define BT_HCI_ERR_AUTH_FAIL                    0x05
+#define BT_HCI_ERR_PIN_OR_KEY_MISSING           0x06
+#define BT_HCI_ERR_MEM_CAPACITY_EXCEEDED        0x07
+#define BT_HCI_ERR_CONN_TIMEOUT                 0x08
+#define BT_HCI_ERR_CONN_LIMIT_EXCEEDED          0x09
+#define BT_HCI_ERR_SYNC_CONN_LIMIT_EXCEEDED     0x0a
+#define BT_HCI_ERR_CONN_ALREADY_EXISTS          0x0b
+#define BT_HCI_ERR_CMD_DISALLOWED               0x0c
+#define BT_HCI_ERR_INSUFFICIENT_RESOURCES       0x0d
+#define BT_HCI_ERR_INSUFFICIENT_SECURITY        0x0e
+#define BT_HCI_ERR_BD_ADDR_UNACCEPTABLE         0x0f
+#define BT_HCI_ERR_CONN_ACCEPT_TIMEOUT          0x10
+#define BT_HCI_ERR_UNSUPP_FEATURE_PARAM_VAL     0x11
+#define BT_HCI_ERR_INVALID_PARAM                0x12
+#define BT_HCI_ERR_REMOTE_USER_TERM_CONN        0x13
+#define BT_HCI_ERR_REMOTE_LOW_RESOURCES         0x14
+#define BT_HCI_ERR_REMOTE_POWER_OFF             0x15
+#define BT_HCI_ERR_LOCALHOST_TERM_CONN          0x16
+#define BT_HCI_ERR_PAIRING_NOT_ALLOWED          0x18
+#define BT_HCI_ERR_UNSUPP_REMOTE_FEATURE        0x1a
+#define BT_HCI_ERR_INVALID_LL_PARAM             0x1e
+#define BT_HCI_ERR_UNSPECIFIED                  0x1f
+#define BT_HCI_ERR_UNSUPP_LL_PARAM_VAL          0x20
+#define BT_HCI_ERR_LL_RESP_TIMEOUT              0x22
+#define BT_HCI_ERR_LL_PROC_COLLISION            0x23
+#define BT_HCI_ERR_INSTANT_PASSED               0x28
+#define BT_HCI_ERR_PAIRING_NOT_SUPPORTED        0x29
+#define BT_HCI_ERR_DIFF_TRANS_COLLISION         0x2a
+#define BT_HCI_ERR_UNACCEPT_CONN_PARAM          0x3b
+#define BT_HCI_ERR_ADV_TIMEOUT                  0x3c
+#define BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL         0x3d
+#define BT_HCI_ERR_CONN_FAIL_TO_ESTAB           0x3e
+
+#define BT_HCI_ERR_AUTHENTICATION_FAIL __DEPRECATED_MACRO BT_HCI_ERR_AUTH_FAIL
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_HCI_STATUS_H_ */

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3607,6 +3607,16 @@ static void le_adv_report(struct net_buf *buf)
 }
 #endif /* CONFIG_BT_OBSERVER */
 
+int bt_hci_get_conn_handle(const struct bt_conn *conn, u16_t *conn_handle)
+{
+	if (conn->state != BT_CONN_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	*conn_handle = conn->handle;
+	return 0;
+}
+
 #if defined(CONFIG_BT_HCI_VS_EVT_USER)
 int bt_hci_register_vnd_evt_cb(bt_hci_vnd_evt_cb_t cb)
 {


### PR DESCRIPTION
Add public API function to get the connection handle of the connection.
The connection handle is needed by applications that intend to send
vendor specific commands for a given connection.

In order to use the conn.h header file in hci.h I had to remove the dependency in conn.h on hci.h to avoid a circular dependency.
 - Extracted GAP and Device Address defines out from hci.h
 - Added non-HCI scan types to bluetooth.h (with same values)
 - Extracted hci error codes to its own header file so that conn.h can include hci_err.h instead.


