### PR TITLE
manifest: Update the revision of tinycbor

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -96,7 +96,7 @@ manifest:
       path: modules/debug/segger
     - name: tinycbor
       path: modules/lib/tinycbor
-      revision: 31ae89e4b768612722620cb6cb173a0de4a19cc9
+      revision: 6966f6140cb870b792330a5186020eb1f4151f3e
     - name: littlefs
       path: modules/fs/littlefs
       revision: fe9572dd5a9fcf93a249daa4233012692bd2881d


### PR DESCRIPTION
Point to the current revision at the tip of the tinycbor repo after
merging https://github.com/zephyrproject-rtos/tinycbor/pull/7.

Fixes #19629.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>