### PR TITLE
[TOPIC-GPIO] drivers: sensor: lsm6dsl: update to new GPIO API

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -62,7 +62,7 @@
 		compatible = "st,lsm6dsl";
 		reg = <1>;
 		spi-max-frequency = <1000000>;
-		irq-gpios = <&gpiob 1 0>;
+		irq-gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
 		label = "LSM6DSL_SPI";
 	};
 };

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -94,7 +94,7 @@
 	lsm6dsl@6a {
 		compatible = "st,lsm6dsl";
 		reg = <0x6a>;
-		irq-gpios = <&gpiod 11 0>;
+		irq-gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
 		label = "LSM6DSL";
 	};
 

--- a/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
+++ b/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
@@ -23,7 +23,7 @@
 		compatible = "st,lsm6dsl";
 		reg = <0x6b>;
 		label = "LSM6DSL";
-		irq-gpios = <&arduino_header 10 0>;	/* D4 */
+		irq-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;	/* D4 */
 	};
 
 	lsm303agr-magn@1e {

--- a/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
@@ -13,5 +13,6 @@ include: i2c-device.yaml
 
 properties:
     irq-gpios:
+      # This signal is active high when produced by the sensor
       type: phandle-array
       required: false

--- a/dts/bindings/sensor/st,lsm6dsl-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-spi.yaml
@@ -13,5 +13,6 @@ include: spi-device.yaml
 
 properties:
     irq-gpios:
+      # This signal is active high when produced by the sensor
       type: phandle-array
       required: false

--- a/samples/sensor/lsm6dsl/README.rst
+++ b/samples/sensor/lsm6dsl/README.rst
@@ -48,6 +48,17 @@ Building on disco_l475_iot1 board
    :goals: build
    :compact:
 
+Building on nrf52840_pca10056 board with x-nucleo-iks01a2 shield
+================================================================
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/lsm6dsl
+   :host-os: unix
+   :board: nrf52840_pca10056
+   :shield: x_nucleo_iks01a2
+   :goals: build
+   :compact:
+
 Sample Output
 =============
 


### PR DESCRIPTION
Correct IRQ active level to default active-low, switch to new interrupt configuration.

Tested with frdm_k64f and nucleo_l476rg with x-nucleo-iks01a2.

*NOTE* This is based on #19862, #19866, and #19870 on which it depends.  It's DNM solely for those inclusions.