### PR TITLE
interrupt_controller: gic: Support PPIs

### DIFF
--- a/drivers/interrupt_controller/gic-400.c
+++ b/drivers/interrupt_controller/gic-400.c
@@ -133,7 +133,6 @@ static void gic_irq_enable(struct device *dev, unsigned int irq)
 {
 	int int_grp, int_off;
 
-	irq += GIC_SPI_INT_BASE;
 	int_grp = irq / 32;
 	int_off = irq % 32;
 
@@ -144,7 +143,6 @@ static void gic_irq_disable(struct device *dev, unsigned int irq)
 {
 	int int_grp, int_off;
 
-	irq += GIC_SPI_INT_BASE;
 	int_grp = irq / 32;
 	int_off = irq % 32;
 
@@ -162,14 +160,12 @@ static void gic_irq_set_priority(struct device *dev,
 	int int_grp, int_off;
 	u8_t val;
 
-	irq += GIC_SPI_INT_BASE;
-
 	/* Set priority */
 	sys_write8(prio & 0xff, GICD_IPRIORITYRn + irq);
 
 	/* Set interrupt type */
 	int_grp = irq / 4;
-	int_off = (irq % 4) * 2;
+	int_off = (irq % 16) * 2;
 
 	val = sys_read8(GICD_ICFGRn + int_grp);
 	val &= ~(GIC_INT_TYPE_MASK << int_off);
@@ -193,7 +189,7 @@ static void gic_isr(void *arg)
 		return;
 	}
 
-	isr_offset = cfg->isr_table_offset + irq - GIC_SPI_INT_BASE;
+	isr_offset = cfg->isr_table_offset + irq;
 
 	gic_isr_handle = _sw_isr_table[isr_offset].isr;
 	if (gic_isr_handle)

--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -26,7 +26,7 @@
 		gic: interrupt-controller@f9010000  {
 			compatible = "arm,gic";
 			reg = <0xf9010000 0x1000>,
-					<0xf9020000 0x100>;
+			      <0xf9020000 0x100>;
 			interrupt-controller;
 			#interrupt-cells = <3>;
 			label = "GIC";
@@ -47,7 +47,7 @@
 			compatible = "xlnx,xuartps";
 			reg = <0xff000000 0x4c>;
 			status = "disabled";
-			interrupts = <21 0 IRQ_TYPE_LEVEL>;
+			interrupts = <53 0 IRQ_TYPE_LEVEL>;
 			interrupt-names = "irq_0";
 			label = "UART_0";
 		};
@@ -55,9 +55,9 @@
 		ttc0: timer@ff110000 {
 			compatible = "cdns,ttc";
 			status = "disabled";
-			interrupts = <36 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<37 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<38 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>;
+			interrupts = <68 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
+				     <69 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
+				     <70 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>;
 			interrupt-names = "irq_0", "irq_1", "irq_2";
 			reg = <0xff110000 0x1000>;
 			label = "ttc0";
@@ -66,9 +66,9 @@
 		ttc1: timer@ff120000 {
 			compatible = "cdns,ttc";
 			status = "disabled";
-			interrupts = <39 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<40 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<41 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>;
+			interrupts = <71 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
+				     <72 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
+				     <73 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>;
 			interrupt-names = "irq_0", "irq_1", "irq_2";
 			reg = <0xff120000 0x1000>;
 			label = "ttc1";
@@ -77,9 +77,9 @@
 		ttc2: timer@ff130000 {
 			compatible = "cdns,ttc";
 			status = "disabled";
-			interrupts = <42 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<43 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<44 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>;
+			interrupts = <74 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
+				     <75 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
+				     <76 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>;
 			interrupt-names = "irq_0", "irq_1", "irq_2";
 			reg = <0xff130000 0x1000>;
 			label = "ttc2";
@@ -88,9 +88,9 @@
 		ttc3: timer@ff140000 {
 			compatible = "cdns,ttc";
 			status = "disabled";
-			interrupts = <45 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<46 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<47 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>;
+			interrupts = <77 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
+				     <78 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
+				     <79 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>;
 			interrupt-names = "irq_0", "irq_1", "irq_2";
 			reg = <0xff140000 0x1000>;
 			label = "ttc3";


### PR DESCRIPTION
The GIC-400 driver currently only supports SPIs because the (32) offset
for the INTIDs is hard-coded in the driver. At the driver level there is
no really difference between PPIs and SPIs so we can easily extend the
driver to support PPIs as well.

This is useful if we want to add support for the ARM Generic Timers that
use INTIDs in the PPI range.

To remove the 32 offset from the driver and support PPIs we need to
modify the DTS of the platforms using the GIC driver (currently only the
Cortex-r5) adding back the offset. This is needed because currently
it is not possible in Zephyr to define the type of interrupt directly
into the DTS as done (for example) in the Linux kernel (with GIC_SPI /
GIC_PPI).

Signed-off-by: Carlo Caione <ccaione@baylibre.com>