### PR TITLE
drivers: flash: spi_nor: use non configurable page size

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -363,7 +363,7 @@ static int spi_nor_init(struct device *dev)
 #define INST_0_BYTES (DT_INST_0_JEDEC_SPI_NOR_SIZE / 8)
 
 /* instance 0 page count */
-#define LAYOUT_PAGES_COUNT (INST_0_BYTES / CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE)
+#define LAYOUT_PAGES_COUNT (INST_0_BYTES / SPI_NOR_PAGE_SIZE)
 
 BUILD_ASSERT_MSG((CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE * LAYOUT_PAGES_COUNT)
 		 == INST_0_BYTES,
@@ -371,7 +371,7 @@ BUILD_ASSERT_MSG((CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE * LAYOUT_PAGES_COUNT)
 
 static const struct flash_pages_layout dev_layout = {
 	.pages_count = LAYOUT_PAGES_COUNT,
-	.pages_size = CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE,
+	.pages_size = SPI_NOR_PAGE_SIZE,
 };
 #undef LAYOUT_PAGES_COUNT
 


### PR DESCRIPTION
This PR fixes #19438.

The driver has recently been rewritten to use a fixed page size, however, when using CONFIG_FLASH_PAGE_LAYOUT, the layout page is inconsistent with the non-configurable values.

This fix makes the driver always use the hardcoded flash page size and raises a build assert whenever an incompatible flash layout page is configured.