### PR TITLE
scripts: edtlib: Automatically include base.yaml in all bindings

### DIFF
--- a/doc/guides/dts/index.rst
+++ b/doc/guides/dts/index.rst
@@ -615,6 +615,10 @@ The binding below shows various legacy syntax.
    inherits:
        !include foo.yaml
 
+   # Redundant - base.yaml is now included automatically in all bindings, and
+   # is located at scripts/dts/base.yaml
+   include: base.yaml
+
    parent:
        bus: spi
 

--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -27,18 +27,37 @@ compatible: "manufacturer,device"
 #
 # If more than one binding for a compatible is found, an error is raised.
 
-# Many bindings have common fields. These are stored in files given in
-# 'include', which are merged into the binding (with a recursive dictionary
-# merge).
+# Bindings can include other files, which can be used to share common
+# definitions between bindings.
 #
-# If a key appears both in the binding and in a file it includes, then the
-# value in the binding takes precedence. This can be used to change a
-# 'required: false' from an inherited file to a 'required: true' (see the
-# 'properties' description below).
+# The file scripts/dts/base.yaml is automatically included in all bindings. It
+# defines generic properties that appear on many devicetree nodes. It is a good
+# idea to look at it to get an idea of what definitions are already available.
+#
+# Included files are merged into bindings with a simple recursive dictionary
+# merge. It is up to the binding author to make sure that the resulting binding
+# is well-formed, though the final merged binding is sanity-checked by the code
+# as well.
+#
+# It is an error for a key to appear with a different value in a binding and in
+# a file it includes, with one exception: A binding can have 'required: true'
+# for some property for which the included file has 'required: false' (see the
+# description of 'properties' below). The 'required: true' from the binding
+# takes precedence, allowing bindings to strengthen requirements from included
+# files.
+#
+# As an example, the 'reg' property can be made mandatory like this:
+#
+#     reg:
+#         required: true
+#
+# This overrides the 'required: false' given for 'reg' in the
+# implicitly-included scripts/dts/base.yaml. Note that base.yaml already gives
+# the type for 'reg', so we do not need to repeat it here.
 #
 # An error is raised if this binding has 'required: false' for some property
-# for which the included file(s) have 'required: true'. Bindings can only
-# "strengthen" requirements from files they include. This is meant to keep the
+# for which the included file has 'required: true' instead. Bindings can't
+# weaken requirements from files they include. This is meant to keep the
 # organization clean.
 #
 # When including multiple files, any overlapping 'required' keys on properties

--- a/dts/bindings/arc/arc,dccm.yaml
+++ b/dts/bindings/arc/arc,dccm.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "arc,dccm"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arc/arc,iccm.yaml
+++ b/dts/bindings/arc/arc,iccm.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "arc,iccm"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/arm,dtcm.yaml
+++ b/dts/bindings/arm/arm,dtcm.yaml
@@ -6,8 +6,6 @@ description: >
 
 compatible: "arm,dtcm"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/arm,scc.yaml
+++ b/dts/bindings/arm/arm,scc.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "arm,scc"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/atmel,sam0-device_id.yaml
+++ b/dts/bindings/arm/atmel,sam0-device_id.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "atmel,sam0-id"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/atmel,sam0-dmac.yaml
+++ b/dts/bindings/arm/atmel,sam0-dmac.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "atmel,sam0-dmac"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/atmel,sam0-sercom.yaml
+++ b/dts/bindings/arm/atmel,sam0-sercom.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "atmel,sam0-sercom"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/nordic,nrf-dppic.yaml
+++ b/dts/bindings/arm/nordic,nrf-dppic.yaml
@@ -9,8 +9,6 @@ description: >
 
 compatible: "nordic,nrf-dppic"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/nordic,nrf-egu.yaml
+++ b/dts/bindings/arm/nordic,nrf-egu.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nordic,nrf-egu"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/nordic,nrf-ficr.yaml
+++ b/dts/bindings/arm/nordic,nrf-ficr.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "nordic,nrf-ficr"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/nordic,nrf-kmu.yaml
+++ b/dts/bindings/arm/nordic,nrf-kmu.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nordic,nrf-kmu"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/nordic,nrf-spu.yaml
+++ b/dts/bindings/arm/nordic,nrf-spu.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "nordic,nrf-spu"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/nordic,nrf-uicr.yaml
+++ b/dts/bindings/arm/nordic,nrf-uicr.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "nordic,nrf-uicr"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/nxp,imx-dtcm.yaml
+++ b/dts/bindings/arm/nxp,imx-dtcm.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nxp,imx-dtcm"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/nxp,imx-epit.yaml
+++ b/dts/bindings/arm/nxp,imx-epit.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nxp,imx-epit"
 
-include: base.yaml
-
 properties:
   reg:
       required: true

--- a/dts/bindings/arm/nxp,imx-itcm.yaml
+++ b/dts/bindings/arm/nxp,imx-itcm.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nxp,imx-itcm"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/nxp,imx-mu.yaml
+++ b/dts/bindings/arm/nxp,imx-mu.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nxp,imx-mu"
 
-include: base.yaml
-
 properties:
   reg:
       required: true

--- a/dts/bindings/arm/nxp,kinetis-ke1xf-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-ke1xf-sim.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nxp,kinetis-ke1xf-sim"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/nxp,kinetis-mcg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-mcg.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "nxp,kinetis-mcg"
 
-include: [clock-controller.yaml, base.yaml]
+include: clock-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/arm/nxp,kinetis-pcc.yaml
+++ b/dts/bindings/arm/nxp,kinetis-pcc.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "nxp,kinetis-pcc"
 
-include: [clock-controller.yaml, base.yaml]
+include: clock-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/arm/nxp,kinetis-scg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-scg.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "nxp,kinetis-scg"
 
-include: [clock-controller.yaml, base.yaml]
+include: clock-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/arm/nxp,kinetis-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-sim.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nxp,kinetis-sim"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/nxp,lpc-mailbox.yaml
+++ b/dts/bindings/arm/nxp,lpc-mailbox.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nxp,lpc-mailbox"
 
-include: base.yaml
-
 properties:
   reg:
       required: true

--- a/dts/bindings/arm/st,stm32-ccm.yaml
+++ b/dts/bindings/arm/st,stm32-ccm.yaml
@@ -6,8 +6,6 @@ description: >
 
 compatible: "st,stm32-ccm"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/arm/ti,cc2650-prcm.yaml
+++ b/dts/bindings/arm/ti,cc2650-prcm.yaml
@@ -7,8 +7,6 @@ description: >
 
 compatible: "ti,cc2650-prcm"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/audio/nordic,nrf-pdm.yaml
+++ b/dts/bindings/audio/nordic,nrf-pdm.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nordic,nrf-pdm"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
@@ -9,8 +9,6 @@ description: >
 
 compatible: "zephyr,bt-hci-spi-slave"
 
-include: base.yaml
-
 parent-bus: spi
 
 properties:

--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -1,7 +1,5 @@
 # Common fields for CAN controllers
 
-include: base.yaml
-
 child-bus: can
 
 properties:

--- a/dts/bindings/can/can-device.yaml
+++ b/dts/bindings/can/can-device.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for CAN devices
 
-include: base.yaml
-
 parent-bus: can
 
 properties:

--- a/dts/bindings/clock/fixed-clock.yaml
+++ b/dts/bindings/clock/fixed-clock.yaml
@@ -21,10 +21,5 @@ properties:
       description: output clock frequency (Hz)
       required: true
 
-    clocks:
-      type: array
-      required: false
-      description: input clock source
-
     "#clock-cells":
       const: 0

--- a/dts/bindings/clock/nordic,nrf-clock.yaml
+++ b/dts/bindings/clock/nordic,nrf-clock.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nordic,nrf-clock"
 
-include: base.yaml
-
 properties:
     label:
       required: true

--- a/dts/bindings/clock/nxp,imx-ccm.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "nxp,imx-ccm"
 
-include: [clock-controller.yaml, base.yaml]
+include: clock-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "st,stm32-rcc"
 
-include: [clock-controller.yaml, base.yaml]
+include: clock-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/cpu/cpu.yaml
+++ b/dts/bindings/cpu/cpu.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for CPUs
 
-include: base.yaml
-
 properties:
     clock-frequency:
       type: int

--- a/dts/bindings/crypto/arm,cryptocell-310.yaml
+++ b/dts/bindings/crypto/arm,cryptocell-310.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "arm,cryptocell-310"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/crypto/nordic,nrf-cc310.yaml
+++ b/dts/bindings/crypto/nordic,nrf-cc310.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nordic,nrf-cc310"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/display/fsl,imx6sx-lcdif.yaml
+++ b/dts/bindings/display/fsl,imx6sx-lcdif.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "fsl,imx6sx-lcdif"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
+++ b/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
@@ -8,5 +8,3 @@ description: >
     LED backlight and capacitive touch panel.
 
 compatible: "rocktech,rk043fn02h-ct"
-
-include: base.yaml

--- a/dts/bindings/espi/espi-controller.yaml
+++ b/dts/bindings/espi/espi-controller.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for ESPI devices
 
-include: base.yaml
-
 child-bus: espi
 
 properties:

--- a/dts/bindings/ethernet/ethernet.yaml
+++ b/dts/bindings/ethernet/ethernet.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for Ethernet devices
 
-include: base.yaml
-
 properties:
     local-mac-address:
       type: uint8-array

--- a/dts/bindings/ethernet/intel,e1000.yaml
+++ b/dts/bindings/ethernet/intel,e1000.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "intel,e1000"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/ethernet/nxp.kinetis-ptp.yaml
+++ b/dts/bindings/ethernet/nxp.kinetis-ptp.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nxp,kinetis-ptp"
 
-include: base.yaml
-
 properties:
     interrupts:
       required: true

--- a/dts/bindings/ethernet/smsc,lan9220.yaml
+++ b/dts/bindings/ethernet/smsc,lan9220.yaml
@@ -9,8 +9,6 @@ description: >
 
 compatible: "smsc,lan9220"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/flash_controller/flash-controller.yaml
+++ b/dts/bindings/flash_controller/flash-controller.yaml
@@ -1,7 +1,5 @@
 # Common fields for flash controllers
 
-include: base.yaml
-
 properties:
     label:
       required: true

--- a/dts/bindings/flash_controller/zephyr,sim-flash.yaml
+++ b/dts/bindings/flash_controller/zephyr,sim-flash.yaml
@@ -7,8 +7,6 @@ description: >
 
 compatible: "zephyr,sim-flash"
 
-include: base.yaml
-
 properties:
     label:
       required: true

--- a/dts/bindings/gpio/arduino-header-r3.yaml
+++ b/dts/bindings/gpio/arduino-header-r3.yaml
@@ -8,4 +8,4 @@ description: >
 
 compatible: "arduino-header-r3"
 
-include: [gpio-nexus.yaml, base.yaml]
+include: gpio-nexus.yaml

--- a/dts/bindings/gpio/arm,cmsdk-gpio.yaml
+++ b/dts/bindings/gpio/arm,cmsdk-gpio.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "arm,cmsdk-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/atmel,sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam-gpio.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "atmel,sam-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/atmel,sam0-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam0-gpio.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "atmel,sam0-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/espressif,esp32-gpio.yaml
+++ b/dts/bindings/gpio/espressif,esp32-gpio.yaml
@@ -6,7 +6,7 @@ description: ESP32 GPIO controller
 
 compatible: "espressif,esp32-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
+++ b/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
@@ -4,8 +4,6 @@ description: Holtek HT16K33 Keyscan binding
 
 compatible: "holtek,ht16k33-keyscan"
 
-include: base.yaml
-
 parent-bus: ht16k33
 
 properties:

--- a/dts/bindings/gpio/intel,apl-gpio.yaml
+++ b/dts/bindings/gpio/intel,apl-gpio.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "intel,apl-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/microchip,xec-gpio.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "microchip,xec-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "nordic,nrf-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/nordic,nrf-gpiote.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpiote.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nordic,nrf-gpiote"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "nxp,imx-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "nxp,kinetis-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
+++ b/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "openisa,rv32m1-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/sifive,gpio0.yaml
+++ b/dts/bindings/gpio/sifive,gpio0.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "sifive,gpio0"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "silabs,efm32-gpio-port"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/silabs,efm32-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "silabs,efm32-gpio"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "silabs,efr32mg-gpio-port"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "silabs,efr32mg-gpio"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "silabs,efr32xg1-gpio-port"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "silabs,efr32xg1-gpio"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "snps,designware-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "st,stm32-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "ti,cc13xx-cc26xx-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/ti,cc2650-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc2650-gpio.yaml
@@ -6,7 +6,7 @@ description: >
 
 compatible: "ti,cc2650-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/ti,cc32xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc32xx-gpio.yaml
@@ -6,7 +6,7 @@ description: >
 
 compatible: "ti,cc32xx-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/gpio/ti,stellaris-gpio.yaml
+++ b/dts/bindings/gpio/ti,stellaris-gpio.yaml
@@ -6,7 +6,7 @@ description: >
 
 compatible: "ti,stellaris-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: gpio-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/hwinfo/litex,dna0.yaml
+++ b/dts/bindings/hwinfo/litex,dna0.yaml
@@ -6,8 +6,6 @@ description: LiteX DNA ID reader
 
 compatible: "litex,dna0"
 
-include: base.yaml
-
 properties:
     reg:
         required: true

--- a/dts/bindings/i2c/i2c-controller.yaml
+++ b/dts/bindings/i2c/i2c-controller.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for I2C controllers
 
-include: base.yaml
-
 child-bus: i2c
 
 properties:

--- a/dts/bindings/i2c/i2c-device.yaml
+++ b/dts/bindings/i2c/i2c-device.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for I2C devices
 
-include: base.yaml
-
 parent-bus: i2c
 
 properties:

--- a/dts/bindings/i2s/i2s-controller.yaml
+++ b/dts/bindings/i2s/i2s-controller.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for I2S controllers
 
-include: base.yaml
-
 child-bus: i2s
 
 properties:

--- a/dts/bindings/i2s/i2s-device.yaml
+++ b/dts/bindings/i2s/i2s-device.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for I2S devices
 
-include: base.yaml
-
 parent-bus: i2s
 
 properties:

--- a/dts/bindings/iio/adc/adc-controller.yaml
+++ b/dts/bindings/iio/adc/adc-controller.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for ADC controllers
 
-include: base.yaml
-
 properties:
     label:
       required: true

--- a/dts/bindings/interrupt-controller/arm,gic.yaml
+++ b/dts/bindings/interrupt-controller/arm,gic.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "arm,gic"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "arm,v6m-nvic"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "arm,v7m-nvic"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "arm,v8m-nvic"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
+++ b/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "atmel,sam0-eic"
 
-include: base.yaml
-
 properties:
   reg:
     required: true

--- a/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "intel,cavs-intc"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
   reg:

--- a/dts/bindings/interrupt-controller/intel,ioapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,ioapic.yaml
@@ -6,7 +6,7 @@ description: >
 
 compatible: "intel,ioapic"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
   reg:

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
@@ -9,7 +9,7 @@ description: >
 
 compatible: "openisa,rv32m1-event-unit"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
   reg:

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux-ch.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux-ch.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "openisa,rv32m1-intmux-ch"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
   reg:

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "openisa,rv32m1-intmux"
 
-include: base.yaml
-
 properties:
   reg:
       required: true

--- a/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
+++ b/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "riscv,cpu-intc"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
   "#interrupt-cells":

--- a/dts/bindings/interrupt-controller/riscv,plic0.yaml
+++ b/dts/bindings/interrupt-controller/riscv,plic0.yaml
@@ -3,7 +3,7 @@
 
 # Common fields for the RISC-V platform-local interrupt controller
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
   reg:

--- a/dts/bindings/interrupt-controller/shared-irq.yaml
+++ b/dts/bindings/interrupt-controller/shared-irq.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "shared-irq"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
   interrupts:

--- a/dts/bindings/interrupt-controller/snps,archs-idu-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,archs-idu-intc.yaml
@@ -10,7 +10,7 @@ description: >
 
 compatible: "snps,archs-idu-intc"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 interrupt-cells:
   - irq

--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "snps,arcv2-intc"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
     "#interrupt-cells":

--- a/dts/bindings/interrupt-controller/snps,designware-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,designware-intc.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "snps,designware-intc"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
   reg:

--- a/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
+++ b/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "vexriscv,intc0"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
   reg:

--- a/dts/bindings/interrupt-controller/xtensa,intc.yaml
+++ b/dts/bindings/interrupt-controller/xtensa,intc.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "xtensa,core-intc"
 
-include: [interrupt-controller.yaml, base.yaml]
+include: interrupt-controller.yaml
 
 properties:
   reg:

--- a/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
+++ b/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "st,stm32-ipcc-mailbox"
 
-include: base.yaml
-
 properties:
   clocks:
     required: true

--- a/dts/bindings/memory-controllers/nxp,imx-semc.yaml
+++ b/dts/bindings/memory-controllers/nxp,imx-semc.yaml
@@ -9,8 +9,6 @@ description: >
 
 compatible: "nxp,imx-semc"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/mhu/arm,mhu.yaml
+++ b/dts/bindings/mhu/arm,mhu.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "arm,mhu"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/misc/skyworks,sky13351.yaml
+++ b/dts/bindings/misc/skyworks,sky13351.yaml
@@ -9,8 +9,6 @@ description: >
 
 compatible: "skyworks,sky13351"
 
-include: base.yaml
-
 properties:
     vctl1-gpios:
         type: phandle-array

--- a/dts/bindings/mmc/mmc.yaml
+++ b/dts/bindings/mmc/mmc.yaml
@@ -2,5 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Specifies the MMC/SDHC module
-
-include: base.yaml

--- a/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "arm,armv7m-mpu"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "arm,armv8m-mpu"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "soc-nv-flash"
 
-include: base.yaml
-
 properties:
     label:
       required: false

--- a/dts/bindings/phy/phy-controller.yaml
+++ b/dts/bindings/phy/phy-controller.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for PHY providers
 
-include: base.yaml
-
 properties:
     "#phy-cells":
         type: int

--- a/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
+++ b/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "atmel,sam0-pinmux"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
+++ b/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
@@ -6,8 +6,6 @@ description: >
 
 compatible: "intel,s1000-pinmux"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "nxp,kinetis-pinmux"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
+++ b/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "openisa,rv32m1-pinmux"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "st,stm32-pinmux"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "ti,cc13xx-cc26xx-pinmux"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
@@ -6,8 +6,6 @@ description: >
 
 compatible: "ti,cc2650-pinmux"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/power/nordic,nrf-power.yaml
+++ b/dts/bindings/power/nordic,nrf-power.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nordic,nrf-power"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/power/nordic,nrf-regulators.yaml
+++ b/dts/bindings/power/nordic,nrf-regulators.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nordic,nrf-regulators"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/power/nordic,nrf-vmc.yaml
+++ b/dts/bindings/power/nordic,nrf-vmc.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nordic,nrf-vmc"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/ps2/ps2.yaml
+++ b/dts/bindings/ps2/ps2.yaml
@@ -6,8 +6,6 @@ title: PS/2 Base Structure
 description: >
     This binding gives the base structures for all PS/2 devices
 
-include: base.yaml
-
 child-bus: ps2
 
 properties:
@@ -21,4 +19,3 @@ properties:
       description: should be 0.
     label:
       required: true
-

--- a/dts/bindings/pwm/atmel,sam-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam-pwm.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "atmel,sam-pwm"
 
-include: [pwm-controller.yaml, base.yaml]
+include: pwm-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/pwm/fsl,imx7d-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx7d-pwm.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "fsl,imx7d-pwm"
 
-include: [pwm-controller.yaml, base.yaml]
+include: pwm-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/pwm/microchip,xec-pwm.yaml
+++ b/dts/bindings/pwm/microchip,xec-pwm.yaml
@@ -1,15 +1,12 @@
-#
 # Copyright (c) 2019, Intel Corporation
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 title: Microchip XEC PWM
 
 description: >
     This binding gives a base representation of the Microchip XEC PWM
 
-include: [pwm-controller.yaml, base.yaml]
+include: pwm-controller.yaml
 
 compatible: "microchip,xec-pwm"
 
@@ -19,5 +16,3 @@ properties:
 
     label:
       required: true
-
-...

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "nordic,nrf-pwm"
 
-include: [pwm-controller.yaml, base.yaml]
+include: pwm-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "nordic,nrf-sw-pwm"
 
-include: [pwm-controller.yaml, base.yaml]
+include: pwm-controller.yaml
 
 properties:
     timer-instance:

--- a/dts/bindings/pwm/nxp,flexpwm.yaml
+++ b/dts/bindings/pwm/nxp,flexpwm.yaml
@@ -9,8 +9,6 @@ description: >
 
 compatible: "nxp,flexpwm"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/pwm/nxp,imx-pwm.yaml
+++ b/dts/bindings/pwm/nxp,imx-pwm.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "nxp,imx-pwm"
 
-include: [pwm-controller.yaml, base.yaml]
+include: pwm-controller.yaml
 
 properties:
     index:

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "nxp,kinetis-ftm"
 
-include: [pwm-controller.yaml, base.yaml]
+include: pwm-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/pwm/sifive,pwm0.yaml
+++ b/dts/bindings/pwm/sifive,pwm0.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "sifive,pwm0"
 
-include: [pwm-controller.yaml, base.yaml]
+include: pwm-controller.yaml
 
 properties:
     clock-frequency:

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -5,7 +5,7 @@ description: >
 
 compatible: "st,stm32-pwm"
 
-include: [pwm-controller.yaml, base.yaml]
+include: pwm-controller.yaml
 
 properties:
     label:

--- a/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
+++ b/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
@@ -8,7 +8,7 @@ description: >
 
 compatible: "openisa,rv32m1-pcc"
 
-include: [clock-controller.yaml, base.yaml]
+include: clock-controller.yaml
 
 properties:
     reg:

--- a/dts/bindings/rng/atmel,sam-trng.yaml
+++ b/dts/bindings/rng/atmel,sam-trng.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "atmel,sam-trng"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/rng/nxp,kinetis-rnga.yaml
+++ b/dts/bindings/rng/nxp,kinetis-rnga.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nxp,kinetis-rnga"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/rng/nxp,kinetis-trng.yaml
+++ b/dts/bindings/rng/nxp,kinetis-trng.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nxp,kinetis-trng"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
+++ b/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "ti,cc13xx-cc26xx-trng"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/rtc/nordic,nrf-rtc.yaml
+++ b/dts/bindings/rtc/nordic,nrf-rtc.yaml
@@ -30,4 +30,3 @@ properties:
       type: boolean
       description: Enable fixed top value
       required: false
-

--- a/dts/bindings/rtc/rtc.yaml
+++ b/dts/bindings/rtc/rtc.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for RTC devices
 
-include: base.yaml
-
 properties:
     clock-frequency:
       type: int

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nordic,nrf-qdec"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/sensor/nordic,nrf-temp.yaml
+++ b/dts/bindings/sensor/nordic,nrf-temp.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nordic,nrf-temp"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
+++ b/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
@@ -13,4 +13,3 @@ properties:
 
     interrupts:
       required: true
-

--- a/dts/bindings/serial/st,stm32-lpuart.yaml
+++ b/dts/bindings/serial/st,stm32-lpuart.yaml
@@ -16,4 +16,3 @@ properties:
 
     clocks:
       required: true
-

--- a/dts/bindings/serial/uart-controller.yaml
+++ b/dts/bindings/serial/uart-controller.yaml
@@ -1,7 +1,5 @@
 # Common fields for UART controllers
 
-include: base.yaml
-
 child-bus: uart
 
 properties:

--- a/dts/bindings/serial/uart-device.yaml
+++ b/dts/bindings/serial/uart-device.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for UART devices
 
-include: base.yaml
-
 parent-bus: uart
 
 properties:

--- a/dts/bindings/spi/spi-controller.yaml
+++ b/dts/bindings/spi/spi-controller.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for SPI controllers
 
-include: base.yaml
-
 child-bus: spi
 
 properties:

--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for SPI devices
 
-include: base.yaml
-
 parent-bus: spi
 
 properties:

--- a/dts/bindings/sram/mmio-sram.yaml
+++ b/dts/bindings/sram/mmio-sram.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "mmio-sram"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/sram/sifive,dtim0.yaml
+++ b/dts/bindings/sram/sifive,dtim0.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "sifive,dtim0"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/timer/arm,cmsdk-dtimer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-dtimer.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "arm,cmsdk-dtimer"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/timer/arm,cmsdk-timer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-timer.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "arm,cmsdk-timer"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/timer/atmel,sam0-tc32.yaml
+++ b/dts/bindings/timer/atmel,sam0-tc32.yaml
@@ -9,8 +9,6 @@ description: >
 
 compatible: "atmel,sam0-tc32"
 
-include: base.yaml
-
 properties:
   reg:
     required: true

--- a/dts/bindings/timer/intel,hpet.yaml
+++ b/dts/bindings/timer/intel,hpet.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "intel,hpet"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/timer/litex,timer0.yaml
+++ b/dts/bindings/timer/litex,timer0.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "litex,timer0"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/timer/microchip,xec-rtos-timer.yaml
+++ b/dts/bindings/timer/microchip,xec-rtos-timer.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "microchip,xec-rtos-timer"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/timer/nordic,nrf-timer.yaml
+++ b/dts/bindings/timer/nordic,nrf-timer.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nordic,nrf-timer"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/timer/nxp,imx-gpt.yaml
+++ b/dts/bindings/timer/nxp,imx-gpt.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nxp,imx-gpt"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
+++ b/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "openisa,rv32m1-lptmr"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "st,stm32-timers"
 
-include: base.yaml
-
 properties:
     label:
       required: true

--- a/dts/bindings/timer/xlnx,ttcps.yaml
+++ b/dts/bindings/timer/xlnx,ttcps.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "cdns,ttc"
 
-include: base.yaml
-
 properties:
     label:
       required: true

--- a/dts/bindings/usb/usb-controller.yaml
+++ b/dts/bindings/usb/usb-controller.yaml
@@ -3,8 +3,6 @@
 
 # Common fields for USB controllers
 
-include: base.yaml
-
 properties:
     maximum-speed:
       type: string

--- a/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
+++ b/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "arm,cmsdk-watchdog"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/watchdog/atmel,sam-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam-watchdog.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "atmel,sam-watchdog"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
@@ -5,8 +5,6 @@ description: >
 
 compatible: "atmel,sam0-watchdog"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/watchdog/microchip,xec-watchdog.yaml
+++ b/dts/bindings/watchdog/microchip,xec-watchdog.yaml
@@ -9,8 +9,6 @@ title: Microchip XEC watchdog timer
 description: >
     This binding gives a base representation of the Microchip XEC watchdog timer
 
-include: base.yaml
-
 compatible: "microchip,xec-watchdog"
 
 properties:

--- a/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
+++ b/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nordic,nrf-watchdog"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nxp,kinetis-wdog"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/watchdog/nxp,kinetis-wdog32.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog32.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "nxp,kinetis-wdog32"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/watchdog/st,stm32-watchdog.yaml
+++ b/dts/bindings/watchdog/st,stm32-watchdog.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "st,stm32-watchdog"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/dts/bindings/watchdog/st,stm32-window-watchdog.yaml
+++ b/dts/bindings/watchdog/st,stm32-window-watchdog.yaml
@@ -8,8 +8,6 @@ description: >
 
 compatible: "st,stm32-window-watchdog"
 
-include: base.yaml
-
 properties:
     reg:
       required: true

--- a/scripts/dts/base.yaml
+++ b/scripts/dts/base.yaml
@@ -1,4 +1,5 @@
-# Common fields for all devices
+# This file is automatically included in all bindings, and defines common
+# properties that appear on many nodes
 
 properties:
     status:
@@ -19,13 +20,13 @@ properties:
 
     reg:
         type: array
-        description: register space
         required: false
+        description: register space
 
     reg-names:
         type: string-array
-        description: name of each register space
         required: false
+        description: name of each register space
 
     interrupts:
         type: array

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -1738,8 +1738,8 @@ def _map(prefix, child, parent, child_spec, spec_len_fn, require_controller):
 
 
 def _mask(prefix, child, parent, child_spec):
-    # Common code for handling <prefix>-mask properties, e.g. interrupt-mask.
-    # See _map() for the parameters.
+    # Common code for handling <prefix>-map-mask properties, e.g.
+    # interrupt-map-mask. See _map() for the parameters.
 
     mask_prop = parent.props.get(prefix + "-map-mask")
     if not mask_prop:
@@ -1755,8 +1755,8 @@ def _mask(prefix, child, parent, child_spec):
 
 
 def _pass_thru(prefix, child, parent, child_spec, parent_spec):
-    # Common code for handling <prefix>-map-thru properties, e.g.
-    # interrupt-pass-thru.
+    # Common code for handling <prefix>-map-pass-thru properties, e.g.
+    # interrupt-map-pass-thru.
     #
     # parent_spec:
     #   The parent data from the matched entry in the <prefix>-map property

--- a/scripts/dts/test-bindings/deprecated.yaml
+++ b/scripts/dts/test-bindings/deprecated.yaml
@@ -7,6 +7,9 @@ description: Deprecated stuff
 inherits:
     !include deprecated-include.yaml
 
+# Deprecated base.yaml include
+include: base.yaml
+
 properties:
     # Deprecated way of specifying the 'compatible' string
     compatible:

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -42,6 +42,7 @@ def run():
     verify_eq(warnings.getvalue(), """\
 warning: The 'properties: compatible: constraint: ...' way of specifying the compatible in test-bindings/deprecated.yaml is deprecated. Put 'compatible: "deprecated"' at the top level of the binding instead.
 warning: the 'inherits:' syntax in test-bindings/deprecated.yaml is deprecated and will be removed - please use 'include: foo.yaml' or 'include: [foo.yaml, bar.yaml]' instead
+warning: 'include: base.yaml' in test-bindings/deprecated.yaml is deprecated and redundant. base.yaml is now automatically included in all bindings, and can be found at scripts/dts/base.yaml.
 warning: please put 'required: true' instead of 'category: required' in properties: required: ...' in test-bindings/deprecated.yaml - 'category' will be removed
 warning: please put 'required: false' instead of 'category: optional' in properties: optional: ...' in test-bindings/deprecated.yaml - 'category' will be removed
 warning: 'sub-node: properties: ...' in test-bindings/deprecated.yaml is deprecated and will be removed - please give a full binding for the child node in 'child-binding:' instead (see binding-template.yaml)
@@ -108,7 +109,7 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
                  "Parent binding")
 
     verify_streq(edt.get_node("/binding-include").props,
-                 "{'foo': <Property, name: foo, type: int, value: 0>, 'bar': <Property, name: bar, type: int, value: 1>, 'baz': <Property, name: baz, type: int, value: 2>, 'qaz': <Property, name: qaz, type: int, value: 3>}")
+                 "{'foo': <Property, name: foo, type: int, value: 0>, 'compatible': <Property, name: compatible, type: string-array, value: ['binding-include-test']>, 'bar': <Property, name: bar, type: int, value: 1>, 'baz': <Property, name: baz, type: int, value: 2>, 'qaz': <Property, name: qaz, type: int, value: 3>}")
 
     #
     # Test 'child/parent-bus:'
@@ -197,7 +198,7 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
     #
 
     verify_streq(edt.get_node("/defaults").props,
-                 r"{'int': <Property, name: int, type: int, value: 123>, 'array': <Property, name: array, type: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, type: uint8-array, value: b'\x89\xab\xcd'>, 'string': <Property, name: string, type: string, value: 'hello'>, 'string-array': <Property, name: string-array, type: string-array, value: ['hello', 'there']>, 'default-not-used': <Property, name: default-not-used, type: int, value: 234>}")
+                 r"{'int': <Property, name: int, type: int, value: 123>, 'array': <Property, name: array, type: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, type: uint8-array, value: b'\x89\xab\xcd'>, 'string': <Property, name: string, type: string, value: 'hello'>, 'string-array': <Property, name: string-array, type: string-array, value: ['hello', 'there']>, 'default-not-used': <Property, name: default-not-used, type: int, value: 234>, 'compatible': <Property, name: compatible, type: string-array, value: ['defaults']>}")
 
     #
     # Test having multiple directories with bindings, with a different .dts file


### PR DESCRIPTION
Main commits:

```
scripts: edtlib: Automatically include base.yaml in all bindings

This removes some boilerplate from bindings and makes things more
consistent. One downside is that all properties declared in base.yaml
can now appear on all nodes, including on nodes where they don't make
sense, but it's probably worth it.

base.yaml is moved to scripts/dts/base.yaml, and is considered part of
edtlib internals.

The automatic base.yaml inclusion is documented in
dts/binding-template.yaml and in the legacy syntax section of
doc/guides/dts/index.rst.

'include: base.yaml' is still accepted, but is ignored, and makes edtlib
print a deprecation warning. The warning mentions the new location of
base.yaml.

Remove a 'clocks' declaration from dts/bindings/clock/fixed-clock.yaml,
which declares it as 'type: array'. It clashes with the declaration for
'clocks' in base.yaml, which has it as 'type: phandle-array'. No 'clocks
= <(number) (number) ...>' assignments exist anywhere, which is the form
of assignment expected for 'type: array'.

Piggyback some binding consistency nits and a small bugfix that allows
empty files to be included (the crux is that PyYAML returns None instead
of an empty dict for them).

The empty file fix is needed because of dts/bindings/mmc/mmc.yaml, which
turns empty besides some comments if the 'include: base.yaml' is
removed. Maybe it should be removed instead.
```

```
dts: bindings: Remove base.yaml includes

base.yaml is now included automatically, so it doesn't need to be
included explicitly.
```

Piggybacked nit:

```
scripts: edtlib: Fix some *-map-mask/*-map-pass-thru typos in comments

The "map" part got lost.
```