### PR TITLE
samples/bluetooth: peripheral: Remove nucleo_f429zi from withelist

### DIFF
--- a/samples/bluetooth/peripheral/sample.yaml
+++ b/samples/bluetooth/peripheral/sample.yaml
@@ -8,6 +8,6 @@ tests:
     tags: bluetooth
   sample.bluetooth.peripheral_hr.x_nucleo_idb05a1_shield:
     harness: bluetooth
-    platform_whitelist: nucleo_f429zi nucleo_l4r5zi
+    platform_whitelist: nucleo_l4r5zi
     depends_on: arduino_spi arduino_gpio
     extra_args: SHIELD=x_nucleo_idb05a1


### PR DESCRIPTION
samples/bluetooth/peripheral couldn't build on nucleo_f429zi
since settings dependency on flash erase bock size.
Flash erase being done by sector and sectors have varying size,
erase block size can't be used directly.
This has to be sorted, but for now nucleo_f429zi is removed from
sample withelist to unlock CI.


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>