### PR TITLE
Tests arch arm irq vector table fix for armv6

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/README.txt
+++ b/tests/arch/arm/arm_irq_vector_table/README.txt
@@ -3,7 +3,7 @@ Title: Installation of ISRs Directly in the Vector Table (ARM Only)
 Description:
 
 Verify a project can install ISRs directly in the vector table. Only for
-ARM Cortex-M3/4/7/33 targets.
+ARM Cortex-M targets.
 
 ---------------------------------------------------------------------------
 

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -134,7 +134,8 @@ void test_arm_irq_vector_table(void)
 		      k_sem_take(&sem[2], K_NO_WAIT)), NULL);
 
 	for (int ii = 0; ii < 3; ii++) {
-#if defined(CONFIG_SOC_TI_LM3S6965_QEMU)
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || \
+	defined(CONFIG_SOC_TI_LM3S6965_QEMU)
 		/* the QEMU does not simulate the
 		 * STIR register: this is a workaround
 		 */

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -164,14 +164,14 @@ typedef void (*vth)(void); /* Vector Table Handler */
 void rtc1_nrf_isr(void);
 void nrf_power_clock_isr(void);
 #if defined(CONFIG_SOC_SERIES_NRF52X)
-vth __irq_vector_table _irq_vector_table[RTC1_IRQn + 1] = {
+vth __irq_vector_table _irq_vector_table[] = {
 	nrf_power_clock_isr,
 	isr0, isr1, isr2,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	rtc1_nrf_isr
 };
 #elif defined(CONFIG_SOC_SERIES_NRF91X)
-vth __irq_vector_table _irq_vector_table[RTC1_IRQn + 1] = {
+vth __irq_vector_table _irq_vector_table[] = {
 	0, 0, 0, 0, 0, nrf_power_clock_isr, 0, 0,
 	isr0, isr1, isr2,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -185,12 +185,12 @@ vth __irq_vector_table _irq_vector_table[RTC1_IRQn + 1] = {
  * the custom vector table to handle the timer "tick" interrupts.
  */
 extern void rtc_isr(void);
-vth __irq_vector_table _irq_vector_table[CONFIG_NUM_IRQS + 2] = {
+vth __irq_vector_table _irq_vector_table[] = {
 	isr0, isr1, isr2, 0,
 	rtc_isr
 };
 #else
-vth __irq_vector_table _irq_vector_table[CONFIG_NUM_IRQS] = {
+vth __irq_vector_table _irq_vector_table[] = {
 	isr0, isr1, isr2
 };
 #endif /* CONFIG_SOC_SERIES_NRF52X || CONFIG_SOC_SERIES_NRF91X */

--- a/tests/arch/arm/arm_irq_vector_table/testcase.yaml
+++ b/tests/arch/arm/arm_irq_vector_table/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   arch.interrupt:
-    filter: CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     tags: arm interrupt vector_table
     arch_whitelist: arm


### PR DESCRIPTION
Increasing coverage for ARMv6 - adding the IRQ Vector Table test for Cortex-M Baseline, too.