### PR TITLE
interrupt_controller: gic: Support PPIs

### DIFF
--- a/drivers/interrupt_controller/gic-400.c
+++ b/drivers/interrupt_controller/gic-400.c
@@ -133,7 +133,6 @@ static void gic_irq_enable(struct device *dev, unsigned int irq)
 {
 	int int_grp, int_off;
 
-	irq += GIC_SPI_INT_BASE;
 	int_grp = irq / 32;
 	int_off = irq % 32;
 
@@ -144,7 +143,6 @@ static void gic_irq_disable(struct device *dev, unsigned int irq)
 {
 	int int_grp, int_off;
 
-	irq += GIC_SPI_INT_BASE;
 	int_grp = irq / 32;
 	int_off = irq % 32;
 
@@ -162,14 +160,12 @@ static void gic_irq_set_priority(struct device *dev,
 	int int_grp, int_off;
 	u8_t val;
 
-	irq += GIC_SPI_INT_BASE;
-
 	/* Set priority */
 	sys_write8(prio & 0xff, GICD_IPRIORITYRn + irq);
 
 	/* Set interrupt type */
 	int_grp = irq / 4;
-	int_off = (irq % 4) * 2;
+	int_off = (irq % 16) * 2;
 
 	val = sys_read8(GICD_ICFGRn + int_grp);
 	val &= ~(GIC_INT_TYPE_MASK << int_off);
@@ -193,7 +189,7 @@ static void gic_isr(void *arg)
 		return;
 	}
 
-	isr_offset = cfg->isr_table_offset + irq - GIC_SPI_INT_BASE;
+	isr_offset = cfg->isr_table_offset + irq;
 
 	gic_isr_handle = _sw_isr_table[isr_offset].isr;
 	if (gic_isr_handle)

--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -28,7 +28,7 @@
 			reg = <0xf9010000 0x1000>,
 					<0xf9020000 0x100>;
 			interrupt-controller;
-			#interrupt-cells = <3>;
+			#interrupt-cells = <4>;
 			label = "GIC";
 			status = "okay";
 		};
@@ -47,7 +47,8 @@
 			compatible = "xlnx,xuartps";
 			reg = <0xff000000 0x4c>;
 			status = "disabled";
-			interrupts = <21 0 IRQ_TYPE_LEVEL>;
+			interrupts = <GIC_SPI 21 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0";
 			label = "UART_0";
 		};
@@ -55,9 +56,12 @@
 		ttc0: timer@ff110000 {
 			compatible = "cdns,ttc";
 			status = "disabled";
-			interrupts = <36 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<37 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<38 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>;
+			interrupts = <GIC_SPI 36 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 37 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 38 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1", "irq_2";
 			reg = <0xff110000 0x1000>;
 			label = "ttc0";
@@ -66,9 +70,12 @@
 		ttc1: timer@ff120000 {
 			compatible = "cdns,ttc";
 			status = "disabled";
-			interrupts = <39 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<40 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<41 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>;
+			interrupts = <GIC_SPI 39 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 40 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 41 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1", "irq_2";
 			reg = <0xff120000 0x1000>;
 			label = "ttc1";
@@ -77,9 +84,12 @@
 		ttc2: timer@ff130000 {
 			compatible = "cdns,ttc";
 			status = "disabled";
-			interrupts = <42 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<43 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<44 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>;
+			interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 43 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 44 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1", "irq_2";
 			reg = <0xff130000 0x1000>;
 			label = "ttc2";
@@ -88,9 +98,12 @@
 		ttc3: timer@ff140000 {
 			compatible = "cdns,ttc";
 			status = "disabled";
-			interrupts = <45 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<46 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>,
-						<47 IRQ_DEFAULT_PRIORITY IRQ_TYPE_LEVEL>;
+			interrupts = <GIC_SPI 45 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 46 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 47 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1", "irq_2";
 			reg = <0xff140000 0x1000>;
 			label = "ttc3";

--- a/dts/bindings/interrupt-controller/arm,gic.yaml
+++ b/dts/bindings/interrupt-controller/arm,gic.yaml
@@ -18,6 +18,7 @@ properties:
       required: true
 
 interrupt-cells:
+  - type
   - irq
-  - priority
   - flags
+  - priority

--- a/include/dt-bindings/interrupt-controller/arm-gic.h
+++ b/include/dt-bindings/interrupt-controller/arm-gic.h
@@ -18,6 +18,9 @@
 #define	IRQ_TYPE_LEVEL		0x0
 #define	IRQ_TYPE_EDGE		0x1
 
+#define	GIC_SPI			0x0
+#define	GIC_PPI			0x1
+
 #define IRQ_DEFAULT_PRIORITY	0xa
 
 #endif

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -484,6 +484,20 @@ def write_irqs(node):
             alias += "_" + str2ident(cell_name)
         return alias
 
+    def map_arm_gic_irq_type(irq, irq_num):
+        # Maps ARM GIC IRQ (type)+(index) combo to linear IRQ number
+        if "type" not in irq.data:
+            err("Expected binding for {!r} to have 'type' in interrupt-cells"
+                .format(irq.controller))
+        irq_type = irq.data["type"]
+
+        if irq_type == 0:  # GIC_SPI
+            return irq_num + 32
+        if irq_type == 1:  # GIC_PPI
+            return irq_num + 16
+        err("Invalid interrupt type specified for {!r}"
+            .format(irq))
+
     def encode_zephyr_multi_level_irq(irq, irq_num):
         # See doc/reference/kernel/other/interrupts.rst for details
         # on how this encoding works
@@ -493,7 +507,7 @@ def write_irqs(node):
         while irq_ctrl.interrupts:
             irq_num = (irq_num + 1) << 8
             if "irq" not in irq_ctrl.interrupts[0].data:
-                err("Expected binding for {!r} to have 'irq' in *-cells"
+                err("Expected binding for {!r} to have 'irq' in interrupt-cells"
                     .format(irq_ctrl))
             irq_num |= irq_ctrl.interrupts[0].data["irq"]
             irq_ctrl = irq_ctrl.interrupts[0].controller
@@ -503,6 +517,8 @@ def write_irqs(node):
         for cell_name, cell_value in irq.data.items():
             ident = "IRQ_{}".format(irq_i)
             if cell_name == "irq":
+                if "arm,gic" in irq.controller.compats:
+                    cell_value = map_arm_gic_irq_type(irq, cell_value)
                 cell_value = encode_zephyr_multi_level_irq(irq, cell_value)
             else:
                 ident += "_" + str2ident(cell_name)


### PR DESCRIPTION
The GIC-400 driver currently only supports SPIs because the (32) offset
for the INTIDs is hard-coded in the driver. At the driver level there is
no really difference between PPIs and SPIs so we can easily extend the
driver to support PPIs as well.

This is useful if we want to add support for the ARM Generic Timers that
use INTIDs in the PPI range.

SPI interrupts are in the range [0-987]. PPI interrupts are in the
range [0-15].

This patches introduces a new interrupt type (GIC_SPI | GIC_PPI) to be
defined in the DTS to mark the IRQ as SPI or PPI, following what's done
in the Linux kernel. When the IRQ is marked as SPI its INTID is
offsetted by 32, otherwise by 16 when marked as PPI. The fix is done
introducing a new macro to be used in the DTS fixup file.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>