### PR TITLE
devicetree: tree-wide: add nexus map properties for arduino headers

### DIFF
--- a/boards/arm/disco_l475_iot1/arduino_r3_connector.dtsi
+++ b/boards/arm/disco_l475_iot1/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioc 5 0>,	/* A0 */
 			   <1 0 &gpioc 4 0>,	/* A1 */
 			   <2 0 &gpioc 3 0>,	/* A2 */

--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -78,6 +78,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpiob 0 0>,	/* A0 */
 			   <1 0 &gpiob 1 0>,	/* A1 */
 			   <2 0 &gpioc 1 0>,	/* A2 */

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -79,6 +79,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpiob 2 0>,	/* A0 */
 			   <1 0 &gpiob 3 0>,	/* A1 */
 			   <2 0 &gpiob 10 0>,	/* A2 */

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -73,6 +73,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
 			   <1 0 &gpio0 4 0>,	/* A1 */
 			   <2 0 &gpio0 28 0>,	/* A2 */

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -74,6 +74,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
 			   <1 0 &gpio0 4 0>,	/* A1 */
 			   <2 0 &gpio0 28 0>,	/* A2 */

--- a/boards/arm/nucleo_f030r8/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f030r8/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_f070rb/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f070rb/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_f091rc/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f091rc/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_f103rb/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f103rb/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_f207zg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f207zg/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
 			   <1 0 &gpioc 0 0>,	/* A1 */
 			   <2 0 &gpioc 3 0>,	/* A2 */

--- a/boards/arm/nucleo_f302r8/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f302r8/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_f334r8/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f334r8/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_f401re/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f401re/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_f411re/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f411re/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_f412zg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f412zg/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
 			   <1 0 &gpioc 0 0>,	/* A1 */
 			   <2 0 &gpioc 3 0>,	/* A2 */

--- a/boards/arm/nucleo_f413zh/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f413zh/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
 			   <1 0 &gpioc 0 0>,	/* A1 */
 			   <2 0 &gpioc 3 0>,	/* A2 */

--- a/boards/arm/nucleo_f429zi/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f429zi/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
 			   <1 0 &gpioc 0 0>,	/* A1 */
 			   <2 0 &gpioc 3 0>,	/* A2 */

--- a/boards/arm/nucleo_f446re/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f446re/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_f746zg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f746zg/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
 			   <1 0 &gpioc 0 0>,	/* A1 */
 			   <2 0 &gpioc 3 0>,	/* A2 */

--- a/boards/arm/nucleo_f756zg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_f756zg/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
 			   <1 0 &gpioc 0 0>,	/* A1 */
 			   <2 0 &gpioc 3 0>,	/* A2 */

--- a/boards/arm/nucleo_g071rb/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_g071rb/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_g431rb/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_g431rb/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_l053r8/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_l053r8/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_l073rz/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_l073rz/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_l476rg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_l476rg/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
 			   <1 0 &gpioa 1 0>,	/* A1 */
 			   <2 0 &gpioa 4 0>,	/* A2 */

--- a/boards/arm/nucleo_l496zg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_l496zg/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
 			   <1 0 &gpioc 0 0>,	/* A1 */
 			   <2 0 &gpioc 3 0>,	/* A2 */

--- a/boards/arm/nucleo_l4r5zi/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_l4r5zi/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
 			   <1 0 &gpioc 0 0>,	/* A1 */
 			   <2 0 &gpioc 3 0>,	/* A2 */

--- a/boards/arm/nucleo_wb55rg/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_wb55rg/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioc 0 0>,	/* A0 */
 			   <1 0 &gpioc 1 0>,	/* A1 */
 			   <2 0 &gpioa 1 0>,	/* A2 */

--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -37,6 +37,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
 			   <1 0 &gpio0 4 0>,	/* A1 */
 			   <2 0 &gpio0 28 0>,	/* A2 */

--- a/boards/arm/stm32mp157c_dk2/arduino_r3_connector.dtsi
+++ b/boards/arm/stm32mp157c_dk2/arduino_r3_connector.dtsi
@@ -8,6 +8,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpiof 14 0>,	/* A0 */
 			   <1 0 &gpiof 13 0>,	/* A1 */
 			   /* ANA0 is not a GPIO   A2 */

--- a/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
@@ -58,6 +58,8 @@
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <0 0 &gpioc 11 0>,	/* A0 */
 			   <1 0 &gpioc 12 0>,	/* A1 */
 			   <2 0 &gpiob 9 0>,	/* A2 */

--- a/doc/guides/dts/index.rst
+++ b/doc/guides/dts/index.rst
@@ -712,4 +712,77 @@ generated in the same directory concatenating all board-related fixup files.
 The include file ``include/generated_dts_board.h`` includes both these generated
 files, giving Zephyr C source files access to the board's devicetree information.
 
+GPIO Nexus Nodes
+****************
+
+Each board has a set of General Purpose Input/Output (GPIO)
+peripherals that can be accessed through the :ref:`GPIO<gpio>` module.
+Many boards provide headers that allow :ref:`shields<shields>` from
+other vendors to be mounted on their boards.  Each shield identifies
+its hardware in a devicetree overlay.
+
+GPIOs accessed by the shield peripherals must be identified using the
+shield GPIO abstraction, for example from the ``arduino-r3-header``
+compatible.  Boards that provide the header must map the header pins
+to SOC-specific pins.  This is accomplished by including a `nexus
+node`_ that looks like the following into the board devicetree file:
+
+.. _nexus node:
+    https://github.com/devicetree-org/devicetree-specification/blob/4b1dac80eaca45b4babf5299452a951008a5d864/source/devicetree-basics.rst#nexus-nodes-and-specifier-mapping
+
+.. code-block:: none
+
+    arduino_header: connector {
+            compatible = "arduino-header-r3";
+            #gpio-cells = <2>;
+            gpio-map-mask = <0xffffffff 0xffffffc0>;
+            gpio-map-pass-thru = <0 0x3f>;
+            gpio-map = <0 0 &gpioa 0 0>,    /* A0 */
+                       <1 0 &gpioa 1 0>,    /* A1 */
+                       <2 0 &gpioa 4 0>,    /* A2 */
+                       <3 0 &gpiob 0 0>,    /* A3 */
+                       <4 0 &gpioc 1 0>,    /* A4 */
+                       <5 0 &gpioc 0 0>,    /* A5 */
+                       <6 0 &gpioa 3 0>,    /* D0 */
+                       <7 0 &gpioa 2 0>,    /* D1 */
+                       <8 0 &gpioa 10 0>,   /* D2 */
+                       <9 0 &gpiob 3 0>,    /* D3 */
+                       <10 0 &gpiob 5 0>,   /* D4 */
+                       <11 0 &gpiob 4 0>,   /* D5 */
+                       <12 0 &gpiob 10 0>,  /* D6 */
+                       <13 0 &gpioa 8 0>,   /* D7 */
+                       <14 0 &gpioa 9 0>,   /* D8 */
+                       <15 0 &gpioc 7 0>,   /* D9 */
+                       <16 0 &gpiob 6 0>,   /* D10 */
+                       <17 0 &gpioa 7 0>,   /* D11 */
+                       <18 0 &gpioa 6 0>,   /* D12 */
+                       <19 0 &gpioa 5 0>,   /* D13 */
+                       <20 0 &gpiob 9 0>,   /* D14 */
+                       <21 0 &gpiob 8 0>;   /* D15 */
+    };
+
+This specifies how Arduino pin references like ``<&arduino_header 11
+0>`` are converted to SOC gpio pin references like ``<&gpiob 4 0>``.
+
+In Zephyr GPIO specifiers generally have two parameters (indicated by
+``#gpio-cells = <2>``): the pin number and a set of flags.  The low 6
+bits of the flags correspond to features that can be configured in
+devicetree.  In some cases it's necessary to use a non-zero flag value
+to tell the driver how a particular pin behaves, as with:
+
+.. code-block:: none
+
+    drdy-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>;
+
+After preprocessing this becomes ``<&arduino_header 11 1>``.  Normally
+the presence of such a flag would cause the map lookup to fail,
+because there is no map entry with a non-zero flags value.  The
+``gpio-map-mask`` property specifies that, for lookup, all bits of the
+pin and all but the low 6 bits of the flags are used to identify the
+specifier.  Then the ``gpio-map-pass-thru`` specifies that the low 6
+bits of the flags are copied over, so the SOC GPIO reference becomes
+``<&gpiob 4 1>`` as intended.
+
+See `nexus node`_ for more information about this capability.
+
 .. include:: flash_partitions.inc


### PR DESCRIPTION
We need to be able to specify GPIO flags in devicetree without that preventing translation from the Arduino specifier to the host GPIO specifier.  Set up to ignore the low 6 bits of the flags field when matching the child specifier, and to copy those bits to the parent specifier.

This is a blocking capability for topic-gpio where we need to be able to specify the active level of signals from sensors connected through Arduino shields.

To preemptively answer a question: the low 6 bits are defined for devicetree in Linux although Zephyr currently does not use bit 3.  Bit 3 is used to signal suspend/resume/reset persistance, so may be needed in the future.