### PR TITLE
samples/96b_argonkey: microphone: (FIX) stop dmic trigger

### DIFF
--- a/samples/boards/96b_argonkey/microphone/src/main.c
+++ b/samples/boards/96b_argonkey/microphone/src/main.c
@@ -154,6 +154,12 @@ void main(void)
 
 	signal_sampling_stopped();
 
+	ret = dmic_trigger(mic_dev, DMIC_TRIGGER_STOP);
+	if (ret < 0) {
+		printk("microphone stop trigger error\n");
+		return;
+	}
+
 	/* print PCM stream */
 #ifdef PCM_OUTPUT_IN_ASCII
 	printk("-- start\n");


### PR DESCRIPTION
Stop the trigger (DMIC_TRIGGER_STOP) after acquiring microphone data

For some reason the current sample is working correctly with the current stm32 dma driver, but it is not with new one (see PR #19712). In any case it seems more than reasonable to invoke the DMIC_TRIGGER_STOP after a DMIC_TRIGGER_START operation plus mic data acquisition.