### PR TITLE
scripts: kconfig: fix partition size calculation

### DIFF
--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -1406,10 +1406,6 @@ class Kconfig(object):
                     .format(self.config_prefix, sym.name, escape(val)))
 
             else:  # sym.orig_type in _INT_HEX:
-                if sym.orig_type is HEX and \
-                   not val.startswith(("0x", "0X")):
-                    val = "0x" + val
-
                 add("#define {}{} {}\n"
                     .format(self.config_prefix, sym.name, val))
 


### PR DESCRIPTION
adding of 0x to decimal value breaks the logic

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/19877