### PR TITLE
drivers: hci: stm32_ipm: Add possibility to work on LSI

### DIFF
--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -338,7 +338,7 @@ static void start_ble_rf(void)
 	LL_RCC_SetRTCClockSource(LL_RCC_RTC_CLKSOURCE_LSE);
 
 	/* Switch OFF LSI */
-	LL_RCC_LSI1_Disable();
+	LL_RCC_LSI2_Disable();
 #else
 	LL_RCC_LSI2_Enable();
 	while (!LL_RCC_LSI2_IsReady()) {

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -327,6 +327,7 @@ static void start_ble_rf(void)
 		LL_RCC_ReleaseBackupDomainReset();
 	}
 
+#ifdef CONFIG_CLOCK_STM32_LSE
 	/* Select LSE clock */
 	LL_RCC_LSE_Enable();
 	while (!LL_RCC_LSE_IsReady()) {
@@ -338,6 +339,16 @@ static void start_ble_rf(void)
 
 	/* Switch OFF LSI */
 	LL_RCC_LSI1_Disable();
+#else
+	LL_RCC_LSI2_Enable();
+	while (!LL_RCC_LSI2_IsReady()) {
+	}
+
+	/* Select wakeup source of BLE RF */
+	LL_RCC_SetRFWKPClockSource(LL_RCC_RFWKP_CLKSOURCE_LSI);
+	LL_RCC_SetRTCClockSource(LL_RCC_RTC_CLKSOURCE_LSI);
+#endif
+
 	/* Set RNG on HSI48 */
 	LL_RCC_HSI48_Enable();
 	while (!LL_RCC_HSI48_IsReady()) {


### PR DESCRIPTION
Allow to work on LSI of LSE failed to start (or absent)

Also adding compile time switch for LSE, this nucleo_wb55 board will be extended with 
`
select CLOCK_STM32_LSE
`