### PR TITLE
stm32wb55 fix LSE configuation

### DIFF
--- a/boards/arm/nucleo_wb55rg/Kconfig.defconfig
+++ b/boards/arm/nucleo_wb55rg/Kconfig.defconfig
@@ -10,6 +10,9 @@ if BOARD_NUCLEO_WB55RG
 config BOARD
 	default "nucleo_wb55rg"
 
+config CLOCK_STM32_LSE
+	default y
+
 if UART_CONSOLE
 
 config UART_1

--- a/drivers/clock_control/clock_stm32l4_wb.c
+++ b/drivers/clock_control/clock_stm32l4_wb.c
@@ -41,8 +41,10 @@ void config_enable_default_clocks(void)
 #ifdef CONFIG_CLOCK_STM32_LSE
 	/* LSE belongs to the back-up domain, enable access.*/
 
+#ifdef LL_APB1_GRP1_PERIPH_PWR
 	/* Enable the power interface clock */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+#endif
 
 	/* Set the DBP bit in the Power control register 1 (PWR_CR1) */
 	LL_PWR_EnableBkUpAccess();


### PR DESCRIPTION
1) Remove redundant call for undefined symbol
2) Enable LSE on nucleo_wb55rg by default