### PR TITLE
Bluetooth: controller: split: Fix incorrect MD bit value

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -606,7 +606,7 @@ void lll_conn_pdu_tx_prep(struct lll_conn *lll, struct pdu_data **pdu_data_tx)
 			p->md = 1;
 		}
 
-		if (link->next) {
+		if (link->next != lll->memq_tx.tail) {
 			p->md = 1;
 		}
 	}


### PR DESCRIPTION
MD bit was set based on whether a memq link's next pointer
being NULL, instead the check should be that the  memq has
more elements.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>