### PR TITLE
kconfig: Fix wrong partition size by changing type of FLASH_LOAD_SIZE

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -111,7 +111,7 @@ config FLASH_LOAD_OFFSET
 	  If unsure, leave at the default value 0.
 
 config FLASH_LOAD_SIZE
-	hex "Kernel load size"
+	int "Kernel load size"
 	default $(dt_chosen_reg_size,$(DT_CHOSEN_Z_CODE_PARTITION)) if USE_CODE_PARTITION
 	default 0
 	depends on HAS_FLASH_LOAD_OFFSET


### PR DESCRIPTION
`FLASH_LOAD_SIZE` gets its default from the `$(dt_chosen_reg_size)`
function, which is defined in `scripts/kconfig/kconfigfunctions.py`.
`$(dt_chosen_reg_size)` returns a decimal value rather than a hex value.

Previously, `FLASH_LOAD_SIZE` was declared as `hex`, which made Kconfiglib
automatically prepend 0x to its value (the same logic is in the C
Kconfig tools). This gave an incorrect size in `.config`, e.g.
`CONFIG_FLASH_LOAD_SIZE=0x374784` where
`CONFIG_FLASH_LOAD_SIZE=374784` was
intended.

Fix it by changing the type of `FLASH_LOAD_SIZE` to `int`. All other symbols
that use `$(dt_node_reg_size)` and `$(dt_chosen_reg_size)` are `int` too
(`FLASH_SIZE` and `SRAM_SIZE`, plus `BOOTLOADER_SRAM_SIZE`  is
also `int`).

This has some subtle breakage potential in that `FLASH_LOAD_SIZE` has a
prompt (is user-configurable in the menuconfig or by changing `.config`
files). Nothing seems to directly assign in Zephyr at least.

Fixes: #19877