### PR TITLE
Bluetooth: Fix missing includes for hci.h

### DIFF
--- a/samples/boards/bbc_microbit/pong/src/ble.c
+++ b/samples/boards/bbc_microbit/pong/src/ble.c
@@ -16,6 +16,7 @@
 #include <bluetooth/uuid.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/gatt.h>
+#include <bluetooth/hci.h>
 
 
 #include "pong.h"

--- a/tests/bluetooth/tester/src/gap.c
+++ b/tests/bluetooth/tester/src/gap.c
@@ -13,6 +13,7 @@
 #include <toolchain.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
+#include <bluetooth/hci.h>
 
 #include <sys/byteorder.h>
 #include <net/buf.h>


### PR DESCRIPTION
With the changes in PR #19836 applications now need to explicitly
include hci.h to use defines from it. Fix two sample/tests apps which
were missing this.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>