### PR TITLE
Kconfig: Remove copy-pasted comments on some promptless symbols

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -433,13 +433,11 @@ config CPU_HAS_FPU
 
 config CPU_HAS_MPU
 	bool
-	# Omit prompt to signify "hidden" option
 	help
 	  This option is enabled when the CPU has a Memory Protection Unit (MPU).
 
 config MEMORY_PROTECTION
 	bool
-	# Omit prompt to signify "hidden" option
 	help
 	  This option is enabled when Memory Protection features are supported.
 	  Memory protection support is currently available on ARC, ARM, and x86
@@ -447,14 +445,12 @@ config MEMORY_PROTECTION
 
 config MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 	bool
-	# Omit prompt to signify "hidden" option
 	help
 	  This option is enabled when the MPU requires a power of two alignment
 	  and size for MPU regions.
 
 config MPU_REQUIRES_NON_OVERLAPPING_REGIONS
 	bool
-	# Omit prompt to signify "hidden" option
 	help
 	  This option is enabled when the MPU requires the active (i.e. enabled)
 	  MPU regions to be non-overlapping with each other.

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -8,13 +8,11 @@
 
 config CPU_CORTEX
 	bool
-	# Omit prompt to signify "hidden" option
 	help
 	  This option signifies the use of a CPU of the Cortex family.
 
 config CPU_CORTEX_M
 	bool
-	# Omit prompt to signify "hidden" option
 	select CPU_CORTEX
 	select ARCH_HAS_CUSTOM_SWAP_TO_MAIN
 	select HAS_CMSIS

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -15,7 +15,6 @@
 config CPU_CORTEX_M0
 	bool
 	select CPU_CORTEX_M
-	# Omit prompt to signify "hidden" option
 	select ARMV6_M_ARMV8_M_BASELINE
 	help
 	  This option signifies the use of a Cortex-M0 CPU
@@ -23,7 +22,6 @@ config CPU_CORTEX_M0
 config CPU_CORTEX_M0PLUS
 	bool
 	select CPU_CORTEX_M
-	# Omit prompt to signify "hidden" option
 	select ARMV6_M_ARMV8_M_BASELINE
 	help
 	  This option signifies the use of a Cortex-M0+ CPU
@@ -31,7 +29,6 @@ config CPU_CORTEX_M0PLUS
 config CPU_CORTEX_M3
 	bool
 	select CPU_CORTEX_M
-	# Omit prompt to signify "hidden" option
 	select ARMV7_M_ARMV8_M_MAINLINE
 	help
 	  This option signifies the use of a Cortex-M3 CPU
@@ -39,7 +36,6 @@ config CPU_CORTEX_M3
 config CPU_CORTEX_M4
 	bool
 	select CPU_CORTEX_M
-	# Omit prompt to signify "hidden" option
 	select ARMV7_M_ARMV8_M_MAINLINE
 	select ARMV7_M_ARMV8_M_FP if CPU_HAS_FPU
 	help
@@ -48,7 +44,6 @@ config CPU_CORTEX_M4
 config CPU_CORTEX_M23
 	bool
 	select CPU_CORTEX_M
-	# Omit prompt to signify "hidden" option
 	select ARMV8_M_BASELINE
 	select ARMV8_M_SE if CPU_HAS_TEE
 	help
@@ -57,7 +52,6 @@ config CPU_CORTEX_M23
 config CPU_CORTEX_M33
 	bool
 	select CPU_CORTEX_M
-	# Omit prompt to signify "hidden" option
 	select ARMV8_M_MAINLINE
 	select ARMV8_M_SE if CPU_HAS_TEE
 	select ARMV7_M_ARMV8_M_FP if CPU_HAS_FPU
@@ -67,7 +61,6 @@ config CPU_CORTEX_M33
 config CPU_CORTEX_M7
 	bool
 	select CPU_CORTEX_M
-	# Omit prompt to signify "hidden" option
 	select ARMV7_M_ARMV8_M_MAINLINE
 	select ARMV7_M_ARMV8_M_FP if CPU_HAS_FPU
 	help
@@ -77,13 +70,11 @@ if CPU_CORTEX_M
 
 config CPU_CORTEX_M_HAS_SYSTICK
 	bool
-	# Omit prompt to signify "hidden" option
 	help
 	  This option is enabled when the CPU implements the SysTick timer.
 
 config CPU_CORTEX_M_HAS_BASEPRI
 	bool
-	# Omit prompt to signify "hidden" option
 	depends on ARMV7_M_ARMV8_M_MAINLINE
 	help
 	  This option signifies the CPU has the BASEPRI register.
@@ -97,7 +88,6 @@ config CPU_CORTEX_M_HAS_BASEPRI
 
 config CPU_CORTEX_M_HAS_VTOR
 	bool
-	# Omit prompt to signify "hidden" option
 	depends on !CPU_CORTEX_M0
 	help
 	  This option signifies the CPU has the VTOR register.
@@ -110,7 +100,6 @@ config CPU_CORTEX_M_HAS_VTOR
 
 config CPU_CORTEX_M_HAS_SPLIM
 	bool
-	# Omit prompt to signify "hidden" option
 	depends on ARMV8_M_MAINLINE || (ARMV8_M_SE && !ARM_NONSECURE_FIRMWARE)
 	help
 	  This option signifies the CPU has the MSPLIM, PSPLIM registers.
@@ -127,7 +116,6 @@ config CPU_CORTEX_M_HAS_SPLIM
 
 config CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 	bool
-	# Omit prompt to signify "hidden" option
 	depends on ARMV7_M_ARMV8_M_MAINLINE
 	help
 	  This option signifies the CPU may trigger system faults
@@ -136,7 +124,6 @@ config CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 
 config CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
 	bool
-	# Omit prompt to signify "hidden" option
 	help
 	  This option signifies the Cortex-M0 has some mechanisms that can map
 	  the vector table to SRAM
@@ -149,7 +136,6 @@ config CPU_CORTEX_M_HAS_CMSE
 
 config ARMV6_M_ARMV8_M_BASELINE
 	bool
-	# Omit prompt to signify "hidden" option
 	select ATOMIC_OPERATIONS_C
 	select ISA_THUMB2
 	help
@@ -167,7 +153,6 @@ config ARMV6_M_ARMV8_M_BASELINE
 
 config ARMV8_M_BASELINE
 	bool
-	# Omit prompt to signify "hidden" option
 	select ARMV6_M_ARMV8_M_BASELINE
 	select CPU_CORTEX_M_HAS_CMSE
 	help
@@ -179,7 +164,6 @@ config ARMV8_M_BASELINE
 
 config ARMV7_M_ARMV8_M_MAINLINE
 	bool
-	# Omit prompt to signify "hidden" option
 	select ATOMIC_OPERATIONS_BUILTIN
 	select ISA_THUMB2
 	select CPU_CORTEX_M_HAS_BASEPRI
@@ -203,7 +187,6 @@ config ARMV7_M_ARMV8_M_MAINLINE
 
 config ARMV8_M_MAINLINE
 	bool
-	# Omit prompt to signify "hidden" option
 	select ARMV7_M_ARMV8_M_MAINLINE
 	select CPU_CORTEX_M_HAS_SPLIM
 	select CPU_CORTEX_M_HAS_CMSE
@@ -216,7 +199,6 @@ config ARMV8_M_MAINLINE
 
 config ARMV8_M_SE
 	bool
-	# Omit prompt to signify "hidden" option
 	depends on ARMV8_M_BASELINE || ARMV8_M_MAINLINE
 	select CPU_CORTEX_M_HAS_SPLIM if !ARM_NONSECURE_FIRMWARE
 	help
@@ -226,7 +208,6 @@ config ARMV8_M_SE
 
 config ARMV7_M_ARMV8_M_FP
 	bool
-	# Omit prompt to signify "hidden" option
 	depends on ARMV7_M_ARMV8_M_MAINLINE && !CPU_CORTEX_M3
 	help
 	  This option signifies the use of an ARMv7-M processor
@@ -235,7 +216,6 @@ config ARMV7_M_ARMV8_M_FP
 
 config ARMV8_M_DSP
 	bool
-	# Omit prompt to signify "hidden" option
 	depends on ARMV8_M_MAINLINE
 	help
 	  This option signifies the use of an ARMv8-M processor

--- a/boards/arm/efm32hg_slstk3400a/Kconfig
+++ b/boards/arm/efm32hg_slstk3400a/Kconfig
@@ -9,8 +9,6 @@ if BOARD_EFM32HG_SLSTK3400A
 
 config BOARD_INIT_PRIORITY
 	int
-
-	# omit prompt to signify a "hidden" option
 	default KERNEL_INIT_PRIORITY_DEFAULT
 	depends on GPIO
 	help

--- a/boards/arm/efm32pg_stk3402a/Kconfig
+++ b/boards/arm/efm32pg_stk3402a/Kconfig
@@ -8,8 +8,6 @@ if BOARD_EFM32PG_STK3402A
 
 config BOARD_INIT_PRIORITY
 	int
-
-	# omit prompt to signify a "hidden" option
 	default KERNEL_INIT_PRIORITY_DEFAULT
 	depends on GPIO
 	help

--- a/boards/arm/efm32wg_stk3800/Kconfig
+++ b/boards/arm/efm32wg_stk3800/Kconfig
@@ -8,8 +8,6 @@ if BOARD_EFM32WG_STK3800
 
 config BOARD_INIT_PRIORITY
 	int
-
-	# omit prompt to signify a "hidden" option
 	default KERNEL_INIT_PRIORITY_DEFAULT
 	depends on GPIO
 	help

--- a/boards/arm/efr32_slwstk6061a/Kconfig
+++ b/boards/arm/efr32_slwstk6061a/Kconfig
@@ -8,8 +8,6 @@ if BOARD_EFR32_SLWSTK6061A
 
 config BOARD_INIT_PRIORITY
 	int
-
-	# omit prompt to signify a "hidden" option
 	default KERNEL_INIT_PRIORITY_DEFAULT
 	depends on GPIO
 	help

--- a/boards/arm/efr32mg_sltb004a/Kconfig
+++ b/boards/arm/efr32mg_sltb004a/Kconfig
@@ -8,8 +8,6 @@ if BOARD_EFR32MG_SLTB004A
 
 config BOARD_INIT_PRIORITY
 	int
-
-	# omit prompt to signify a "hidden" option
 	default KERNEL_INIT_PRIORITY_DEFAULT
 	help
 	  Board initialization priority. This must be bigger than

--- a/drivers/ipm/Kconfig
+++ b/drivers/ipm/Kconfig
@@ -48,7 +48,6 @@ endchoice
 config IPM_IMX_MAX_DATA_SIZE
 	int
 	range 4 16
-	# omit prompt to signify a "hidden" option
 	default 4 if IPM_IMX_MAX_DATA_SIZE_4
 	default 8 if IPM_IMX_MAX_DATA_SIZE_8
 	default 16 if IPM_IMX_MAX_DATA_SIZE_16
@@ -57,7 +56,6 @@ config IPM_IMX_MAX_DATA_SIZE
 config IPM_IMX_MAX_ID_VAL
 	int
 	range 0 3
-	# omit prompt to signify a "hidden" option
 	default 3 if IPM_IMX_MAX_DATA_SIZE_4
 	default 1 if IPM_IMX_MAX_DATA_SIZE_8
 	default 0 if IPM_IMX_MAX_DATA_SIZE_16

--- a/soc/arm/Kconfig
+++ b/soc/arm/Kconfig
@@ -1,14 +1,10 @@
 # Kconfig - general options signifying CPU capabilities of ARM SoCs
 
-#
 # Copyright (c) 2018 Nordic Semiconductor ASA.
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 config CPU_HAS_ARM_MPU
 	bool
-	# Omit prompt to signify "hidden" option
 	select CPU_HAS_MPU
 	help
 	  This option is enabled when the CPU has a Memory Protection Unit (MPU)
@@ -16,7 +12,6 @@ config CPU_HAS_ARM_MPU
 
 config CPU_HAS_NXP_MPU
 	bool
-	# Omit prompt to signify "hidden" option
 	select CPU_HAS_MPU
 	help
 	  This option is enabled when the CPU has a Memory Protection Unit (MPU)
@@ -24,14 +19,12 @@ config CPU_HAS_NXP_MPU
 
 config CPU_HAS_ARM_SAU
 	bool
-	# Omit prompt to signify "hidden" option
 	select CPU_HAS_TEE
 	help
 	  MCU implements the ARM Security Attribution Unit (SAU).
 
 config CPU_HAS_NRF_IDAU
 	bool
-	# Omit prompt to signify "hidden" option
 	depends on SOC_SERIES_NRF91X
 	select CPU_HAS_TEE
 	help
@@ -41,7 +34,6 @@ config CPU_HAS_NRF_IDAU
 
 config CPU_HAS_FPU_DOUBLE_PRECISION
 	bool
-	# Omit prompt to signify "hidden" option
 	depends on CPU_CORTEX_M7
 	select CPU_HAS_FPU
 	help
@@ -50,6 +42,5 @@ config CPU_HAS_FPU_DOUBLE_PRECISION
 
 config HAS_SWO
 	bool
-	# Omit prompt to signify "hidden" option
 	help
 	  When enabled, indicates that SoC has an SWO output

--- a/soc/arm/arm/Kconfig
+++ b/soc/arm/arm/Kconfig
@@ -7,7 +7,6 @@
 
 config SOC_FAMILY_ARM
 	bool
-	# omit prompt to signify a "hidden" option
 
 if SOC_FAMILY_ARM
 config SOC_FAMILY

--- a/soc/arm/atmel_sam/Kconfig
+++ b/soc/arm/atmel_sam/Kconfig
@@ -5,7 +5,6 @@
 
 config SOC_FAMILY_SAM
 	bool
-	# omit prompt to signify a "hidden" option
 	select HAS_SEGGER_RTT
 
 if SOC_FAMILY_SAM

--- a/soc/arm/microchip_mec/Kconfig
+++ b/soc/arm/microchip_mec/Kconfig
@@ -1,12 +1,10 @@
 # Kconfig - Microchip MEC MCU line
-#
+
 # Copyright (c) 2018, Intel Corporation
-#
 # SPDX-License-Identifier: Apache-2.0
-#
+
 config SOC_FAMILY_MEC
 	bool
-	# omit prompt to signify a "hidden" option
 
 if SOC_FAMILY_MEC
 config SOC_FAMILY

--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -1,15 +1,12 @@
 # Kconfig - Nordic Semiconductor nRFx MCU line
-#
+
 # Copyright (c) 2016-2018 Nordic Semiconductor ASA
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 config SOC_FAMILY_NRF
 	select SOC_COMPATIBLE_NRF
 	select PLATFORM_SPECIFIC_INIT
 	bool
-	# omit prompt to signify a "hidden" option
 
 if SOC_FAMILY_NRF
 config SOC_FAMILY

--- a/soc/arm/nxp_imx/Kconfig
+++ b/soc/arm/nxp_imx/Kconfig
@@ -1,15 +1,12 @@
-#
 # Copyright (c) 2017, NXP
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 config SOC_FAMILY_IMX
 	bool
 	select HAS_SEGGER_RTT
-	# omit prompt to signify a "hidden" option
 
 if SOC_FAMILY_IMX
+
 config SOC_FAMILY
 	string
 	default "nxp_imx"

--- a/soc/arm/nxp_kinetis/Kconfig
+++ b/soc/arm/nxp_kinetis/Kconfig
@@ -8,9 +8,9 @@
 config SOC_FAMILY_KINETIS
 	bool
 	select HAS_SEGGER_RTT
-	# omit prompt to signify a "hidden" option
 
 if SOC_FAMILY_KINETIS
+
 config SOC_FAMILY
 	string
 	default "nxp_kinetis"

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.soc
@@ -73,7 +73,6 @@ config K22_FLASH_CLOCK_DIVIDER
 
 config WDOG_INIT
 	def_bool y
-	# omit prompt to signify a "hidden" option
 	help
 	  This processor enables the watchdog timer with a short timeout
 	  upon reset. Therefore, this requires that the watchdog be configured

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.soc
@@ -100,7 +100,6 @@ config K64_FLASH_CLOCK_DIVIDER
 
 config WDOG_INIT
 	def_bool y
-	# omit prompt to signify a "hidden" option
 	help
 	  This processor enables the watchdog timer with a short timeout
 	  upon reset. Therefore, this requires that the watchdog be configured

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.soc
@@ -73,7 +73,6 @@ config K8X_FLASH_CLOCK_DIVIDER
 
 config WDOG_INIT
 	def_bool y
-	# omit prompt to signify a "hidden" option
 	help
 	  This processor enables the watchdog timer with a short
 	  window for configuration upon reset. Therefore, this

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.soc
@@ -82,7 +82,6 @@ config SOC_PART_NUMBER_KINETIS_KE1XF
 
 config WDOG_INIT
 	def_bool y
-	# omit prompt to signify a "hidden" option
 	help
 	  This processor enables the watchdog timer with a short
 	  window for configuration upon reset. Therefore, this

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.soc
@@ -113,7 +113,6 @@ config KW2XD_FLASH_CLOCK_DIVIDER
 
 config WDOG_INIT
 	def_bool y
-	# omit prompt to signify a "hidden" option
 	help
 	  This processor enables the watchdog timer with a short timeout
 	  upon reset. Therefore, this requires that the watchdog be configured

--- a/soc/arm/nxp_lpc/Kconfig
+++ b/soc/arm/nxp_lpc/Kconfig
@@ -7,7 +7,6 @@
 config SOC_FAMILY_LPC
 	bool
 	select HAS_SEGGER_RTT
-	# omit prompt to signify a "hidden" option
 
 if SOC_FAMILY_LPC
 config SOC_FAMILY

--- a/soc/arm/silabs_exx32/Kconfig
+++ b/soc/arm/silabs_exx32/Kconfig
@@ -7,7 +7,6 @@
 
 config SOC_FAMILY_EXX32
 	bool
-	# omit prompt to signify a "hidden" option
 	select HAS_SEGGER_RTT
 
 if SOC_FAMILY_EXX32
@@ -172,7 +171,6 @@ endif # SOC_GECKO_CMU
 
 config SOC_GECKO_HAS_INDIVIDUAL_PIN_LOCATION
 	bool
-	# omit prompt to signify a "hidden" option
 	help
 	  If enabled, indicates that SoC allows to configure individual pin
 	  locations. This is supported by e.g. efr32fg1p, efr32mg12p series.

--- a/soc/arm/st_stm32/Kconfig
+++ b/soc/arm/st_stm32/Kconfig
@@ -7,7 +7,6 @@
 
 config SOC_FAMILY_STM32
 	bool
-	# omit prompt to signify a "hidden" option
 	select HAS_SEGGER_RTT
 	select BUILD_OUTPUT_HEX
 

--- a/soc/arm/ti_simplelink/Kconfig
+++ b/soc/arm/ti_simplelink/Kconfig
@@ -1,11 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Kconfig - Texas Instruments SimpleLink Family
-#
 
 config SOC_FAMILY_TISIMPLELINK
 	bool
-	# omit prompt to signify a "hidden" option
 
 if SOC_FAMILY_TISIMPLELINK
 config SOC_FAMILY

--- a/soc/riscv/riscv-privilege/Kconfig
+++ b/soc/riscv/riscv-privilege/Kconfig
@@ -8,7 +8,6 @@
 
 config SOC_FAMILY_RISCV_PRIVILEGE
 	bool
-	# omit prompt to signify a "hidden" option
 
 config SOC_FAMILY
 	string

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -89,7 +89,6 @@ endmenu
 source "subsys/bluetooth/services/Kconfig"
 
 config BT_CONN
-	# Virtual/hidden option
 	bool
 
 config BT_MAX_CONN

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -54,7 +54,6 @@ config BT_WAIT_NOP
 	  ready to receive commands.
 
 config BT_RPA
-	# Virtual/hidden option
 	bool
 	select TINYCRYPT
 	select TINYCRYPT_AES
@@ -85,7 +84,7 @@ config BT_ASSERT_PANIC
 endif # BT_ASSERT
 
 config BT_DEBUG
-	# Virtual/hidden option to make the conditions more intuitive
+	# Hidden option to make the conditions more intuitive
 	bool
 
 choice

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -10,7 +10,7 @@
 comment "Host Stack Configuration"
 
 config BT_HCI_HOST
-	# Virtual/hidden option to make the conditions more intuitive
+	# Hidden option to make the conditions more intuitive
 	bool
 	default y
 	depends on !BT_HCI_RAW


### PR DESCRIPTION
Remove the

    # Omit prompt to signify a "hidden" option

comments that appear on some symbols. They seem to have been copy-pasted
at random, as there are lots of promptless symbols that don't have them
(that's confusing in itself, because it might give the idea that the
ones with comments are special in some way).

I suspect those comments wouldn't have helped me much if I didn't know
Kconfig either. There's a lot more Kconfig documentation now too, e.g.
https://docs.zephyrproject.org/latest/guides/kconfig/index.html.

Keep some comments that give more information than the symbol having no
prompt.

Also do some minor drive-by cleanup.