### PR TITLE
samples: bbc_microbit: pong: Include hci.h, for BT_LE_ADV_IND

### DIFF
--- a/samples/boards/bbc_microbit/pong/src/ble.c
+++ b/samples/boards/bbc_microbit/pong/src/ble.c
@@ -13,6 +13,7 @@
 #include <display/mb_display.h>
 
 #include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
 #include <bluetooth/uuid.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/gatt.h>


### PR DESCRIPTION
bluetooth/hci.h #defines BT_LE_ADV_IND. Since commit e53ee2d
("Bluetooth: Host: Move HCI error codes to its own header"), it is no
longer indirectly included via bluetooth/conn.h.

Include bluetooth/hci.h explicitly. This fixes this compilation error:

    error: 'BT_LE_ADV_IND' undeclared (first use in this function); did
    you mean 'BT_LE_ADV_CONN'?

      if (type != BT_LE_ADV_IND) {
                  ^~~~~~~~~~~~~
                  BT_LE_ADV_CONN