### PR TITLE
kconfig: Remove long-unused LINK_WHOLE_ARCHIVE symbol

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -179,12 +179,6 @@ config CUSTOM_SECTIONS_LD
 	  Include a customized linker script fragment for inserting additional
 	  arbitrary sections.
 
-config LINK_WHOLE_ARCHIVE
-	bool "Allow linking with --whole-archive"
-	help
-	  This options allows linking external libraries with the
-	  --whole-archive option to keep all symbols.
-
 config KERNEL_ENTRY
 	string "Kernel entry symbol"
 	default "__start"


### PR DESCRIPTION
Seems to have been unused since commit 06e78de681 ("build: do not use
link-zephyr"), committed in 2015.

Discovered with a script.