### PR TITLE
shell: kconfig: Remove unused SHELL_MAX_LOG_MSG_BUFFERED symbol

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -114,13 +114,6 @@ config SHELL_HISTORY_BUFFER
 
 endif #SHELL_HISTORY
 
-config SHELL_MAX_LOG_MSG_BUFFERED
-	int "Maximal number of  log messages in FIFO"
-	default 8
-	help
-	  When amount of buffered log messages exceeds this threshold oldest
-	  messages are discarded.
-
 config SHELL_STATS
 	bool "Enable shell statistics"
 	default y


### PR DESCRIPTION
Unused since commit 08f0d93cbb ("shell: Improve handling of log
messages").

Discovered with a script.