### PR TITLE
net: lwm2m: kconfig: Remove unused firmware pull port symbol

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -194,15 +194,6 @@ config LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
 	  block transfer and "FIRMWARE PACKAGE URI" resource.  This option
 	  adds another UDP context and packet handling.
 
-config LWM2M_FIRMWARE_UPDATE_PULL_LOCAL_PORT
-	int "LWM2M client firmware pull local port"
-	default 0
-	depends on LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
-	help
-	  This is the client port for LWM2M firmware download.  The default
-	  setting of 0 sets a random port for the client to be used for
-	  outgoing communication.
-
 config LWM2M_NUM_BLOCK1_CONTEXT
 	int "Maximum # of LWM2M block1 contexts"
 	default 3


### PR DESCRIPTION
LWM2M_FIRMWARE_UPDATE_PULL_LOCAL_PORT is unused since commit 54c10c04e5
("net: lwm2m: use security data for connections").

Found with a script.