### PR TITLE
net: lwm2m: kconfig: Remove unused LWM2M_LOCAL_PORT symbol

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -86,14 +86,6 @@ config LWM2M_ENGINE_DEFAULT_LIFETIME
 	help
 	  Set the default lifetime (in seconds) for the LWM2M library engine
 
-config LWM2M_LOCAL_PORT
-	int "LWM2M client port"
-	default 0
-	help
-	  This is the client port for LWM2M communication.  The default
-	  setting of 0 sets a random port for the client to be used for
-	  outgoing communication.
-
 config LWM2M_RD_CLIENT_SUPPORT
 	bool "support for LWM2M client bootstrap/registration state machine"
 	default y


### PR DESCRIPTION
Unused since commit d1cb39e7ce ("net: lwm2m: migrate LwM2M library to
BSD-sockets API").

Found with a script.