### PR TITLE
boards: nucleo_wb55rg: fix partition size

### DIFF
--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -123,19 +123,19 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x5b800>;
+			reg = <0x0000C000 0x5c000>;
 		};
-		slot1_partition: partition@67800 {
+		slot1_partition: partition@68000 {
 			label = "image-1";
-			reg = <0x00067800 0x5b800>;
+			reg = <0x00068000 0x5c000>;
 		};
-		scratch_partition: partition@c3000 {
+		scratch_partition: partition@c4000 {
 			label = "image-scratch";
-			reg = <0x000c3000 0x4000>;
+			reg = <0x000c4000 0x4000>;
 		};
-		storage_partition: partition@c7000 {
+		storage_partition: partition@c8000 {
 			label = "storage";
-			reg = <0x000c7000 0x4000>;
+			reg = <0x000c8000 0x4000>;
 		};
 
 	};


### PR DESCRIPTION
This will fix issues with using mcuboot on the nucleo_wb55rg since mcuboot requires the partitions to line up with the sector size.  The sector size for STMWB is 4096.