### PR TITLE
stdint.h: make redefinition of stdint types optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,9 @@ zephyr_compile_options(
 
 # @Intent: Enforce standard integer type correspondance to match Zephyr usage.
 # (must be after compiler specific flags)
+if(CONFIG_ZEPHYR_STDINT)
 toolchain_cc_imacros(${ZEPHYR_BASE}/include/toolchain/zephyr_stdint.h)
+endif()
 
 # Common toolchain-agnostic assembly flags
 zephyr_compile_options(

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -83,4 +83,12 @@ config MINIMAL_LIBC_LL_PRINTF
 	  Build with long long printf enabled. This will increase the size of
 	  the image.
 
+config ZEPHYR_STDINT
+	bool "Enforce standard integer types to match Zephyr usage"
+	default y
+	help
+	  This option enforces standard integer types such as uint32_t, int16_t
+	  to match Zephyr usage. When disabled default definitions provided by
+	  the compiler are used.
+
 endmenu


### PR DESCRIPTION
PR #16645 streamlined stdint.h type definitions. This has an unfortunate side effect that any legacy code which assumed default, compiler provided types will now generate warnings any time type mismatch is detected during the compilation process. Redefining stdint types also significantly increases porting effort when building an existing bare metal application with Zephyr.

This PR makes redefinition of stdint types optional.

I wasn't sure if the Kconfig option should go into "C library" or "Compiler Options" sub menu. For now it's in the "C library".