### PR TITLE
tests: updated names for the dns tests

### DIFF
--- a/tests/net/lib/dns_addremove/testcase.yaml
+++ b/tests/net/lib/dns_addremove/testcase.yaml
@@ -4,9 +4,9 @@ common:
   min_ram: 16
   timeout: 600
 tests:
-  net.dns:
+  net.dns.addremove:
     min_ram: 21
-  net.dns.no_ipv6:
+  net.dns.addremove.no_ipv6:
     extra_configs:
       - CONFIG_NET_IPV6=n
   net.dns.no_ipv4:

--- a/tests/net/lib/dns_resolve/testcase.yaml
+++ b/tests/net/lib/dns_resolve/testcase.yaml
@@ -2,10 +2,10 @@ common:
   tags: dns net
   depends_on: netif
 tests:
-  net.dns:
+  net.dns.resolve:
     min_ram: 21
     timeout: 600
-  net.dns.no_ipv6:
+  net.dns.resolve.no_ipv6:
     extra_args: CONF_FILE=prj-no-ipv6.conf
     min_ram: 16
     timeout: 600


### PR DESCRIPTION
After run Sanitycheck script I found out that some test cases have a same test case name in the test result .xml file. 
For boards mimxrt1050_evk, qemu_x86, sam_e70_xplained in .xml files that cases were duplicated.
Problem happened only with cases `net.dns.no_ipv6.init` and `net.dns.init`. Only that cases were duplicated.
To get rid of it, I decided to change test cases names for the dns tests. 

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>