### PR TITLE
Revisit TCP connection establishment

### DIFF
--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -58,6 +58,12 @@ enum net_context_state {
 /** Remote address set */
 #define NET_CONTEXT_REMOTE_ADDR_SET  BIT(8)
 
+/** Is the socket accepting connections */
+#define NET_CONTEXT_ACCEPTING_SOCK  BIT(9)
+
+/** Is the socket closing / closed */
+#define NET_CONTEXT_CLOSING_SOCK  BIT(10)
+
 struct net_context;
 
 /**
@@ -327,6 +333,70 @@ static inline bool net_context_is_used(struct net_context *context)
 	NET_ASSERT(context);
 
 	return context->flags & NET_CONTEXT_IN_USE;
+}
+
+/**
+ * @brief Is this context is accepting data now.
+ *
+ * @param context Network context.
+ *
+ * @return True if the context is accepting connections, False otherwise.
+ */
+static inline bool net_context_is_accepting(struct net_context *context)
+{
+	NET_ASSERT(context);
+
+	return context->flags & NET_CONTEXT_ACCEPTING_SOCK;
+}
+
+/**
+ * @brief Set this context to accept data now.
+ *
+ * @param context Network context.
+ * @param accepting True if accepting, False if not
+ */
+static inline void net_context_set_accepting(struct net_context *context,
+					     bool accepting)
+{
+	NET_ASSERT(context);
+
+	if (accepting) {
+		context->flags |= NET_CONTEXT_ACCEPTING_SOCK;
+	} else {
+		context->flags &= ~NET_CONTEXT_ACCEPTING_SOCK;
+	}
+}
+
+/**
+ * @brief Is this context closing.
+ *
+ * @param context Network context.
+ *
+ * @return True if the context is closing, False otherwise.
+ */
+static inline bool net_context_is_closing(struct net_context *context)
+{
+	NET_ASSERT(context);
+
+	return context->flags & NET_CONTEXT_CLOSING_SOCK;
+}
+
+/**
+ * @brief Set this context to closing.
+ *
+ * @param context Network context.
+ * @param closing True if closing, False if not
+ */
+static inline void net_context_set_closing(struct net_context *context,
+					   bool closing)
+{
+	NET_ASSERT(context);
+
+	if (closing) {
+		context->flags |= NET_CONTEXT_CLOSING_SOCK;
+	} else {
+		context->flags &= ~NET_CONTEXT_CLOSING_SOCK;
+	}
 }
 
 #define NET_CONTEXT_STATE_SHIFT 1

--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -216,8 +216,7 @@ static int process_tcp(struct data *data)
 	client = accept(data->tcp.sock, (struct sockaddr *)&client_addr,
 			&client_addr_len);
 	if (client < 0) {
-		LOG_ERR("Error in accept (%s): %d - stopping server",
-			data->proto, -errno);
+		LOG_ERR("%s accept error (%d)", data->proto, -errno);
 		return -errno;
 	}
 
@@ -284,9 +283,11 @@ static void process_tcp4(void)
 	while (ret == 0) {
 		ret = process_tcp(&conf.ipv4);
 		if (ret < 0) {
-			quit();
+			break;
 		}
 	}
+
+	quit();
 }
 
 static void process_tcp6(void)
@@ -308,9 +309,11 @@ static void process_tcp6(void)
 	while (ret == 0) {
 		ret = process_tcp(&conf.ipv6);
 		if (ret != 0) {
-			quit();
+			break;
 		}
 	}
+
+	quit();
 }
 
 void start_tcp(void)

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -294,6 +294,18 @@ config NET_TCP_BACKLOG_SIZE
 	  The number of simultaneous TCP connection attempts, i.e. outstanding
 	  TCP connections waiting for initial ACK.
 
+config NET_TCP_AUTO_ACCEPT
+	bool "Auto accept incoming TCP data"
+	default n
+	depends on NET_TCP
+	help
+	  Automatically accept incoming TCP data packet to the valid
+	  connection even if the application has not yet called accept().
+	  This speeds up incoming data processing and is done like in Linux.
+	  Drawback is that we allocate data for the incoming packets even if
+	  the application has not yet accepted the connection. If the peer
+	  sends lot of packets, we might run out of memory in this case.
+
 config NET_TCP_TIME_WAIT_DELAY
 	int "How long to wait in TIME_WAIT state (in milliseconds)"
 	depends on NET_TCP

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2285,11 +2285,6 @@ NET_CONN_CB(tcp_syn_rcvd)
 
 	switch (net_tcp_get_state(tcp)) {
 	case NET_TCP_LISTEN:
-		if (net_context_get_state(context) != NET_CONTEXT_LISTENING) {
-			NET_DBG("Context %p is not listening", context);
-			return NET_DROP;
-		}
-
 		net_context_set_iface(context, net_pkt_iface(pkt));
 		break;
 	case NET_TCP_SYN_RCVD:
@@ -2476,14 +2471,6 @@ NET_CONN_CB(tcp_syn_rcvd)
 					0,
 					context->user_data);
 		net_pkt_unref(pkt);
-
-		/* Set the context in CONNECTED state, so that it can not
-		 * accept any new connections. If application is ready to
-		 * accept the connection, zsock_accept_ctx() will set
-		 * the state back to LISTENING.
-		 */
-		net_context_set_state(context, NET_CONTEXT_CONNECTED);
-
 		return NET_OK;
 	}
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -241,7 +241,9 @@ static void tcp_retry_expired(struct k_work *work)
 		if (net_tcp_send_pkt(pkt) < 0 && !is_6lo_technology(pkt)) {
 			NET_DBG("retry %u: [%p] pkt %p send failed",
 				tcp->retry_timeout_shift, tcp, pkt);
-			net_pkt_unref(pkt);
+			if (net_pkt_sent(pkt)) {
+				net_pkt_unref(pkt);
+			}
 		} else {
 			NET_DBG("retry %u: [%p] sent pkt %p",
 				tcp->retry_timeout_shift, tcp, pkt);

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1159,7 +1159,11 @@ static void validate_state_transition(enum net_tcp_state current,
 {
 	static const u16_t valid_transitions[] = {
 		[NET_TCP_CLOSED] = 1 << NET_TCP_LISTEN |
-			1 << NET_TCP_SYN_SENT,
+			1 << NET_TCP_SYN_SENT |
+			/* Initial transition from closed->established when
+			 * socket is accepted.
+			 */
+			1 << NET_TCP_ESTABLISHED,
 		[NET_TCP_LISTEN] = 1 << NET_TCP_SYN_RCVD |
 			1 << NET_TCP_SYN_SENT,
 		[NET_TCP_SYN_RCVD] = 1 << NET_TCP_FIN_WAIT_1 |
@@ -2459,10 +2463,7 @@ NET_CONN_CB(tcp_syn_rcvd)
 
 		net_tcp_change_state(tcp, NET_TCP_LISTEN);
 
-		/* We cannot use net_tcp_change_state() here as that will
-		 * check the state transitions. So set the state directly.
-		 */
-		new_context->tcp->state = NET_TCP_ESTABLISHED;
+		net_tcp_change_state(new_context->tcp, NET_TCP_ESTABLISHED);
 
 		/* Mark the new context to be still accepting so that we
 		 * can do proper cleanup if connection is closed before

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1165,7 +1165,8 @@ static void validate_state_transition(enum net_tcp_state current,
 			 */
 			1 << NET_TCP_ESTABLISHED,
 		[NET_TCP_LISTEN] = 1 << NET_TCP_SYN_RCVD |
-			1 << NET_TCP_SYN_SENT,
+			1 << NET_TCP_SYN_SENT |
+			1 << NET_TCP_CLOSED,
 		[NET_TCP_SYN_RCVD] = 1 << NET_TCP_FIN_WAIT_1 |
 			1 << NET_TCP_ESTABLISHED |
 			1 << NET_TCP_LISTEN |

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -402,6 +402,7 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 {
 	s32_t timeout = K_FOREVER;
 	struct net_context *ctx;
+	struct net_pkt *last_pkt;
 	int fd;
 
 	fd = z_reserve_fd();
@@ -418,6 +419,23 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 		errno = EAGAIN;
 		return -1;
 	}
+
+	/* Check if the connection is already disconnected */
+	last_pkt = k_fifo_peek_tail(&ctx->recv_q);
+	if (last_pkt) {
+		if (net_pkt_eof(last_pkt)) {
+			sock_set_eof(ctx);
+			errno = ECONNABORTED;
+			return -1;
+		}
+	}
+
+	if (net_context_is_closing(ctx)) {
+		errno = ECONNABORTED;
+		return -1;
+	}
+
+	net_context_set_accepting(ctx, false);
 
 #ifdef CONFIG_USERSPACE
 	z_object_recycle(ctx);

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -409,10 +409,6 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 		return -1;
 	}
 
-	if (net_context_get_ip_proto(parent) == IPPROTO_TCP) {
-		net_context_set_state(parent, NET_CONTEXT_LISTENING);
-	}
-
 	if (sock_is_nonblock(parent)) {
 		timeout = K_NO_WAIT;
 	}

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1267,10 +1267,6 @@ int ztls_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 		return -1;
 	}
 
-	if (net_context_get_ip_proto(parent) == IPPROTO_TCP) {
-		net_context_set_state(parent, NET_CONTEXT_LISTENING);
-	}
-
 	child = k_fifo_get(&parent->accept_q, K_FOREVER);
 
 	#ifdef CONFIG_USERSPACE

--- a/subsys/shell/shell_telnet.c
+++ b/subsys/shell/shell_telnet.c
@@ -238,6 +238,8 @@ static void telnet_accept(struct net_context *client,
 		goto error;
 	}
 
+	net_context_set_accepting(client, false);
+
 	LOG_DBG("Telnet client connected (family AF_INET%s)",
 		net_context_get_family(client) == AF_INET ? "" : "6");
 


### PR DESCRIPTION
This will revert #18965 and #19826, and obsoletes #19854 as those patches caused unintended side effects with connection establishment.
This PR will introduce new `CONFIG_NET_TCP_AUTO_ACCEPT` option that can be used to select whether the connections are automatically accepted or not. The default value is not to accept. The motivation for this is that we can easily run out of memory if we accept packets automatically and application is not accepting the connection fast enough. If we run out of net_buf's, the networking becomes non-responsive (seen in testing). In many cases there are enough buffers available and the option can be enabled which might speed up data transfer startup in some use cases.
