### PR TITLE
arch: arm: userspace: add ip and sp to clobber

### DIFF
--- a/include/arch/arm/syscall.h
+++ b/include/arch/arm/syscall.h
@@ -53,7 +53,7 @@ static inline u32_t z_arch_syscall_invoke6(u32_t arg1, u32_t arg2, u32_t arg3,
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r1), "r" (r2), "r" (r3),
 			   "r" (r4), "r" (r5), "r" (r6)
-			 : "r8", "memory");
+			 : "r8", "ip", "sp", "memory");
 
 	return ret;
 }


### PR DESCRIPTION
We should be adding a compiler barrier for IP and SP
registers when we are doing syscall generation on
ARMv6-M architecture. The syscall generation itself
only does an SVC trigger; the execution returns to
thread mode and ARM does not guarantee that IP
register is preserved, when we finally get back to
the point where the syscall was invoked. The SP
also needs to be preserved for syscalls returning
64-bit results. In that case the r0 may hold a
pointer to the stack where the 64-bit result was
pushed, That is, the stack pointer may have been
changed due to the syscall, and C code needs to
know that.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>