### PR TITLE
Revert "kconfig: Fix wrong partition size by changing type of FLASH_L…

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -111,7 +111,7 @@ config FLASH_LOAD_OFFSET
 	  If unsure, leave at the default value 0.
 
 config FLASH_LOAD_SIZE
-	int "Kernel load size"
+	hex "Kernel load size"
 	default $(dt_chosen_reg_size,$(DT_CHOSEN_Z_CODE_PARTITION)) if USE_CODE_PARTITION
 	default 0
 	depends on HAS_FLASH_LOAD_OFFSET


### PR DESCRIPTION
…OAD_SIZE"

This reverts commit f065eb4271ae4ff5658aa0a996c4ad3935657d20.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>