### PR TITLE
disk: kconfig: Remove unused DISK_ACCESS_MAX_VOLUMES symbol

### DIFF
--- a/subsys/disk/Kconfig
+++ b/subsys/disk/Kconfig
@@ -11,12 +11,6 @@ menuconfig DISK_ACCESS
 
 if DISK_ACCESS
 
-config DISK_ACCESS_MAX_VOLUMES
-	int "Maximum Disk Interfaces"
-	default 8
-	help
-	  Maximum number of disk access interfaces supported
-
 module = DISK
 module-str = disk
 source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
Added in commit 2b5b7da9f3 ("subsys: disk: Add support for multiple disk
interfaces"), then never used.

Found with a script.