### PR TITLE
lib: cmsis_v1: kconfig: Remove unused CMSIS_MAX_THREAD_COUNT symbol

### DIFF
--- a/lib/cmsis_rtos_v1/Kconfig
+++ b/lib/cmsis_rtos_v1/Kconfig
@@ -13,14 +13,6 @@ config CMSIS_RTOS_V1
 	  Zephyr.
 
 if CMSIS_RTOS_V1
-config CMSIS_MAX_THREAD_COUNT
-	int "Maximum thread count in CMSIS RTOS application"
-	default 10
-	range 0 255
-	help
-	  Mention max number of threads in CMSIS RTOS compliant application.
-	  There's a limitation on the number of threads due to memory
-	  related constraints.
 
 config CMSIS_THREAD_MAX_STACK_SIZE
 	int "Max stack size threads can be allocated in CMSIS RTOS application"
@@ -49,4 +41,5 @@ config CMSIS_SEMAPHORE_MAX_COUNT
 	range 0 255
 	help
 	  Mention maximum number of semaphores in CMSIS compliant application.
+
 endif


### PR DESCRIPTION
Added in commit ccd1c21824 ("lib/cmsis_rtos_v1: Implement support for
thread APIs"), then never used.

Found with a script.