### PR TITLE
drivers: espi: kconfig: Remove unused ESPI_VWIRE_CHANNEL symbol

### DIFF
--- a/drivers/espi/Kconfig
+++ b/drivers/espi/Kconfig
@@ -36,12 +36,6 @@ config ESPI_PERIPHERAL_CHANNEL
 	help
 	  eSPI Controller supports peripheral channel
 
-config ESPI_VWIRE_CHANNEL
-	bool "eSPI virtual wire channel"
-	default y
-	help
-	  eSPI Controller supports virtual wires channel
-
 config ESPI_OOB_CHANNEL
 	bool "eSPI Out-of-band channel"
 	default n


### PR DESCRIPTION
Added in commit a7e44ebf44 ("drivers: espi: Add Kconfig for eSPI
driver"), then never used.

Found with a script.