### PR TITLE
drivers: espi: kconfig: Remove unused ESPI_SLAVE symbol

### DIFF
--- a/drivers/espi/Kconfig
+++ b/drivers/espi/Kconfig
@@ -18,12 +18,6 @@ module = ESPI
 module-str = espi
 source "subsys/logging/Kconfig.template.log_config"
 
-config ESPI_SLAVE
-	bool "ESPI slave driver"
-	default y
-	help
-	  Enables eSPI driver in slave mode
-
 config ESPI_INIT_PRIORITY
 	int "IRQ Priority for ESPI Controller"
 	default 3


### PR DESCRIPTION
Added in commit a7e44ebf44 ("drivers: espi: Add Kconfig for eSPI
driver"), then never used.

Found with a script.