### PR TITLE
can: loopback: kconfig: Remove unused CAN_RECEIVER_WORKQ_PRIO + CAN_LOOPBACK_FRAME_BUF_SIZE symbols

### DIFF
--- a/drivers/can/Kconfig.loopback
+++ b/drivers/can/Kconfig.loopback
@@ -34,11 +34,4 @@ config CAN_LOOPBACK_FRAME_BUF_SIZE
 	help
 	  Defines the number of frames that can be buffered for each filter.
 
-config CAN_RECEIVER_WORKQ_PRIO
-	int "Priority of the receiver workq"
-	default 2
-	help
-	  Specify the priority for the receiver workq. This workq calls the
-	  receiver callbacks.
-
 endif # CAN_LOOPBACK

--- a/drivers/can/Kconfig.loopback
+++ b/drivers/can/Kconfig.loopback
@@ -27,11 +27,4 @@ config CAN_MAX_FILTER
 	  Defines the array size of the filters.
 	  Must be at least the size of concurrent reads.
 
-config CAN_LOOPBACK_FRAME_BUF_SIZE
-	int "Frame buffer count"
-	range 1 65534
-	default 4
-	help
-	  Defines the number of frames that can be buffered for each filter.
-
 endif # CAN_LOOPBACK


### PR DESCRIPTION
Added in commit 0e807c3f54 ("drivers: can: Add loopback driver"), then
never used.

Found with a script.