### PR TITLE
drivers: dma: kconfig: Remove unused DMA_1/2_IRQ_PRI symbols

### DIFF
--- a/drivers/dma/Kconfig
+++ b/drivers/dma/Kconfig
@@ -31,23 +31,11 @@ config DMA_1_NAME
 	help
 	  Device name for DMA Controller 1.
 
-config DMA_1_IRQ_PRI
-	int "IRQ Priority for DMA Controller 1"
-	default 3
-	help
-	  IRQ Priority for DMA Controller 1.
-
 config DMA_2_NAME
 	string "Device name for DMA Controller 2"
 	default "DMA_2"
 	help
 	  Device name for DMA Controller 2.
-
-config DMA_2_IRQ_PRI
-	int "IRQ Priority for DMA Controller 2"
-	default 3
-	help
-	  IRQ Priority for DMA Controller 2.
 
 module = DMA
 module-str = dma


### PR DESCRIPTION
Added in commit bb36c0af86 ("dma: Add possibility for up to 3 DMA
Controllers") in February 2017, then never used.

Found with a script.