### PR TITLE
drivers: lsm6dsl: kconfig: Remove unused internal pull-up symbol

### DIFF
--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -65,10 +65,6 @@ config LSM6DSL_SENSORHUB
 
 if LSM6DSL_SENSORHUB
 
-config LSM6DSL_ENABLE_INTERNAL_PULLUP
-	bool "Enabled internals pull-up resistors"
-	default y
-
 choice LSM6DSL_EXTERNAL_SENSOR_0
 	prompt "External sensor 0"
 	help


### PR DESCRIPTION
Added in commit 180b139786 ("drivers: sensor: lsm6dsl: Adding sensorhub
support"), then never used.

Found with a script.