### PR TITLE
drivers: sensor: lis2mdl: kconfig: Remove unused fixed ODR symbols

### DIFF
--- a/drivers/sensor/lis2mdl/Kconfig
+++ b/drivers/sensor/lis2mdl/Kconfig
@@ -51,25 +51,8 @@ config LIS2MDL_THREAD_STACK_SIZE
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
-choice
-	prompt "Magnetometer sampling frequency (ODR)"
-	default LIS2MDL_MAG_ODR_RUNTIME
-
 config LIS2MDL_MAG_ODR_RUNTIME
-	bool "Set ODR at runtime (default 10 Hz)"
-
-config LIS2MDL_MAG_ODR_10
-	bool "10 Hz"
-
-config LIS2MDL_MAG_ODR_20
-	bool "20 Hz"
-
-config LIS2MDL_MAG_ODR_50
-	bool "50 Hz"
-
-config LIS2MDL_MAG_ODR_100
-	bool "100 Hz"
-
-endchoice
+	bool "Set magnetometer sampling frequency (ODR) at runtime (default: 10 Hz)"
+	default y
 
 endif # LIS2MDL


### PR DESCRIPTION
After commit 44f373e806 ("driver/sensor: lis2mdl: make use of STdC
definitions"), the code only looks at LIS2MDL_MAG_ODR_RUNTIME, and not
at the LIS2MDL_MAG_ODR_\<frequency> symbols.

LIS2MDL_MAG_ODR_RUNTIME is now a yes/no thing in practice, so remove the
choice and turn it into a regular bool symbol.

Found with a script.