### PR TITLE
intel64: check if switched_from points to NULL

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -196,6 +196,9 @@ mxcsr:	.long X86_MXCSR_SANE
 z_x86_switch:
 	movq (%rsi), %rsi
 
+	test %rsi, %rsi
+	jz __switch_stack
+
 	andb $~X86_THREAD_FLAG_ALL, _thread_offset_to_flags(%rsi)
 
 	popq %rax
@@ -208,6 +211,7 @@ z_x86_switch:
 	movq %r14, _thread_offset_to_r14(%rsi)
 	movq %r15, _thread_offset_to_r15(%rsi)
 
+__switch_stack:
 	movq %gs:__x86_tss64_t_ist1_OFFSET, %rsp
 
 	/* fall through to __resume */


### PR DESCRIPTION
This happens on initial context switch from the dummy
thread.

Later on this implementation of z_arch_switch() should
be updated to use stack-based switch handles, which
perform optimally with the switch design and the
switched_from parameter is treated as output-only.

Fixes: #19759

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>