### PR TITLE
SI7006 sensor: combined RH/T measurements and fixed temperature conversion

### DIFF
--- a/drivers/sensor/si7006/si7006.c
+++ b/drivers/sensor/si7006/si7006.c
@@ -62,7 +62,7 @@ static int si7006_get_temperature(struct device *i2c_dev,
 	int retval;
 
 	retval = i2c_burst_read(i2c_dev, DT_INST_0_SILABS_SI7006_BASE_ADDRESS,
-		SI7006_MEAS_TEMP_MASTER_MODE, temp, sizeof(temp));
+		SI7006_READ_OLD_TEMP, temp, sizeof(temp));
 
 	if (retval == 0) {
 		si_data->temperature = (temp[0] << 8) | temp[1];
@@ -83,9 +83,9 @@ static int si7006_sample_fetch(struct device *dev, enum sensor_channel chan)
 	int retval;
 	struct si7006_data *si_data = dev->driver_data;
 
-	retval = si7006_get_temperature(si_data->i2c_dev, si_data);
+	retval = si7006_get_humidity(si_data->i2c_dev, si_data);
 	if (retval == 0) {
-		retval = si7006_get_humidity(si_data->i2c_dev, si_data);
+		retval = si7006_get_temperature(si_data->i2c_dev, si_data);
 	}
 
 	return retval;
@@ -104,7 +104,7 @@ static int si7006_channel_get(struct device *dev, enum sensor_channel chan,
 	if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 
 		s32_t temp_ucelcius = ((17572 * (s32_t)si_data->temperature)
-				       / 65536) * 10000;
+				       / 65536 - 4685) * 10000;
 
 		val->val1 = temp_ucelcius / 1000000;
 		val->val2 = temp_ucelcius % 1000000;


### PR DESCRIPTION
The driver was incorrectly converting the temperature samples. According
to Si7006-A20 rev. 1.2 datasheet, section 5.1.2. Measuring Temperature,
the offset -46.85 must be applied.

![forgotten_offset](https://user-images.githubusercontent.com/5261821/67118710-25312900-f1ee-11e9-8970-1791032b5ccc.png)

Additionally, the same section says that:

"Each time a relative humidity measurement is made a temperature
measurement is also made for the purposes of temperature compensation of
the relative humidity measurement. If the temperature value is required,
it can be read using command 0xE0; this avoids having to perform a
second temperature measurement."

![combined_rh_t_measurements](https://user-images.githubusercontent.com/5261821/67118749-34b07200-f1ee-11e9-86e5-9562f6892a1d.png)

Respective improvement is implemented.

Fixes #22907