### PR TITLE
sensor: bmg160: Use BMG160_THREAD_PRIORITY instead of ignoring it

### DIFF
--- a/drivers/sensor/bmg160/bmg160_trigger.c
+++ b/drivers/sensor/bmg160/bmg160_trigger.c
@@ -234,7 +234,9 @@ int bmg160_trigger_init(struct device *dev)
 	k_sem_init(&bmg160->trig_sem, 0, UINT_MAX);
 	k_thread_create(&bmg160_thread, bmg160_thread_stack,
 			CONFIG_BMG160_THREAD_STACK_SIZE, bmg160_thread_main,
-			dev, NULL, NULL, K_PRIO_COOP(10), 0, K_NO_WAIT);
+			dev, NULL, NULL,
+			K_PRIO_COOP(CONFIG_BMG160_THREAD_PRIORITY), 0,
+			K_NO_WAIT);
 
 #elif defined(CONFIG_BMG160_TRIGGER_GLOBAL_THREAD)
 	bmg160->work.handler = bmg160_work_cb;


### PR DESCRIPTION
The value of BMG160_THREAD_PRIORITY has never been used after the symbol
was added. Use it.

The value defaults to 10 in Kconfig too, so this is a no-op in itself.