### PR TITLE
drivers: clock_control: Remove unused CLOCK_STM32_PLL2_* symbols

### DIFF
--- a/drivers/clock_control/Kconfig.stm32f1
+++ b/drivers/clock_control/Kconfig.stm32f1
@@ -32,20 +32,4 @@ config CLOCK_STM32_PLL_PREDIV1
 	help
 	 PREDIV1 is PLL clock signal prescaler, allowed values: 1 - 16.
 
-config CLOCK_STM32_PLL2_MULTIPLIER
-	int "PLL2 multiplier"
-	depends on SOC_STM32F10X_CONNECTIVITY_LINE_DEVICE && CLOCK_STM32_PLL_SRC_PLL2
-	default 8
-	range 8 20
-	help
-	 PLL2 multiplier, allowed values: 8 - 20. 15-17-18-19 reserved
-
-config CLOCK_STM32_PLL2_PREDIV2
-	int "PREDIV2 Prescaler"
-	depends on SOC_STM32F10X_CONNECTIVITY_LINE_DEVICE && CLOCK_STM32_PLL_SRC_PLL2
-	default 1
-	range 1 16
-	help
-	 PREDIV2 is PLL2 prescaler, allowed values: 1 - 16.
-
 endif # SOC_SERIES_STM32F1X


### PR DESCRIPTION
CLOCK_STM32_PLL2_MULTIPLIER and CLOCK_STM32_PLL2_PREDIV2 were added in
commit e1a90583d4 ("drivers: clock_control: provide LL based driver to
stm32f1xx series"). They have never been used.

Found with a script.