### PR TITLE
drivers: adc: kconfig: Remove unused ADC_INIT_PRIORITY symbol

### DIFF
--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -39,12 +39,6 @@ module = ADC
 module-str = ADC
 source "subsys/logging/Kconfig.template.log_config"
 
-config ADC_INIT_PRIORITY
-	int "Init priority"
-	default 80
-	help
-	  ADC Device driver initialization priority.
-
 config ADC_0
 	bool "Enable ADC 0"
 


### PR DESCRIPTION
Unused after commit a8d0e5af07 ("adc: ti_adc108s102: Remove driver as
its bit-rotted").

Found with a script.