### PR TITLE
drivers: i2c: slave: Kconfig: Remove unused LOG_I2C_SLAVE_LEVEL symbol

### DIFF
--- a/drivers/i2c/slave/Kconfig
+++ b/drivers/i2c/slave/Kconfig
@@ -22,19 +22,6 @@ config I2C_SLAVE_INIT_PRIORITY
 	help
 	  I2C Slave device driver initialization priority.
 
-config LOG_I2C_SLAVE_LEVEL
-	int "I2C Slave log level"
-	depends on LOG
-	default 0
-	help
-	  Sets log level for I2C drivers.
-	  Levels are:
-	  - 0 OFF, do not write
-	  - 1 ERROR, only write LOG_ERR
-	  - 2 WARNING, write LOG_WRN in addition to previous level
-	  - 3 INFO, write LOG_INF in addition to previous levels
-	  - 4 DEBUG, write LOG_DBG in addition to previous levels
-
 source "drivers/i2c/slave/Kconfig.eeprom"
 
 endif # I2C_SLAVE


### PR DESCRIPTION
Unused since commit f7dac85d15 ("drivers: i2c: move to new logger").

Found with a script.