### PR TITLE
interrupt_controller: Remove unused IOAPIC_DEBUG symbol

### DIFF
--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -55,12 +55,6 @@ config IOAPIC
 	  This option signifies that the target has an IO-APIC device. This
 	  capability allows IO-APIC-dependent code to be included.
 
-config IOAPIC_DEBUG
-	bool "IO-APIC Debugging"
-	depends on IOAPIC
-	help
-	  Enable debugging for IO-APIC driver.
-
 config IOAPIC_NUM_RTES
 	int "Number of Redirection Table Entries available"
 	default 24


### PR DESCRIPTION
Unused since commit 876c86e1a8 ("ioapic_intr: remove dead code").

Found with a script.