### PR TITLE
drivers: console: kconfig: Remove unused NATIVE_STDIN_PRIO symbol

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -282,13 +282,6 @@ config NATIVE_STDIN_POLL_PERIOD
 	help
 	  In ms, polling period for stdin
 
-config NATIVE_STDIN_PRIO
-	int "Priority of the stdin polling thread"
-	depends on NATIVE_POSIX_STDIN_CONSOLE
-	default 4
-	help
-	  Priority of the native stdin polling thread
-
 config NATIVE_POSIX_STDOUT_CONSOLE
 	bool "Print to the host terminal stdout"
 	depends on NATIVE_POSIX_CONSOLE


### PR DESCRIPTION
Unused since commit 140a8d0c8a ("console: Remove deprecated function
console_register_line_input").

Found with a script.