### PR TITLE
drivers: net: kconfig: Remove unused SLIP_MTU symbol

### DIFF
--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -86,16 +86,6 @@ config	SLIP_DRV_NAME
 	help
 	  This option sets the driver name
 
-config	SLIP_MTU
-	int "SLIP MTU"
-	default 1500
-	range 80 1500
-	help
-	  This option sets the MTU for the SLIP connection.
-	  The value is only used when fragmenting the network
-	  data into net_buf's. The actual SLIP connection
-	  does not use this value.
-
 module = SLIP
 module-dep = LOG
 module-str = Log level for slip driver


### PR DESCRIPTION
Added in commit 184e251fdb ("slip: Add driver for host to qemu
connectivity"), then moved to drivers/net/Kconfig in commit 0612651deb
("drivers: slip: Consolidate under drivers/net/"). Never used.

Found with a script.