### PR TITLE
drivers: net: kconfig: Remove unused NET_PPP_MTU symbol

### DIFF
--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -26,15 +26,6 @@ config NET_PPP_UART_PIPE_BUF_LEN
 	  This options sets the size of the UART pipe buffer where data
 	  is being read to.
 
-config NET_PPP_MTU
-	int "PPP MTU"
-	default 1500
-	range 80 1500
-	help
-	  This option sets the MTU for the PPP connection.
-	  The value is only used when fragmenting the network
-	  data into net_buf's.
-
 config NET_PPP_VERIFY_FCS
 	bool "Verify that received FCS is valid"
 	default y


### PR DESCRIPTION
Added in commit aa46bac54c ("drivers: net: ppp: Driver for
point-to-point protocol"). Never used.

Found with a script.