### PR TITLE
drivers: net: kconfig: Remove unused NET_PPP_CALC_FCS symbol

### DIFF
--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -43,14 +43,6 @@ config NET_PPP_VERIFY_FCS
 	  to disable this as it takes some time to verify the received
 	  packet.
 
-config NET_PPP_CALC_FCS
-	bool "Calculate FCS for the sent packet"
-	default y
-	help
-	  If you have a reliable link, then it might make sense
-	  to disable this as it takes some time to calculate the FCS for
-	  the sent packet.
-
 config	PPP_MAC_ADDR
 	string "MAC address for the interface"
 	help


### PR DESCRIPTION
Added in commit aa46bac54c ("drivers: net: ppp: Driver for
point-to-point protocol"). Never used.

Found with a script.