### PR TITLE
soc: nxp_kinetis: kconfig: Remove unused PRESERVE_JTAG_IO_PINS symbol

### DIFF
--- a/soc/arm/nxp_kinetis/k6x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.soc
@@ -105,14 +105,4 @@ config WDOG_INIT
 	  upon reset. Therefore, this requires that the watchdog be configured
 	  during reset handling.
 
-config PRESERVE_JTAG_IO_PINS
-	bool "Kinetis K6x JTAG pin usage"
-	depends on PINMUX
-	default y
-	help
-	  The FRDM-K64F board routes the PTA0/1/2 pins as JTAG/SWD signals that
-	  are used for the OpenSDAv2 debug interface.  These pins are also routed to
-	  the Arduino header as D8, D3 and D5, respectively.
-	  Enable this option to preserve these pins for the debug interface.
-
 endif # SOC_SERIES_KINETIS_K6X


### PR DESCRIPTION
Unused after commit 4973787c10 ("pinmux: Remove the k64 pinmux driver").

Found with a script.