### PR TITLE
arch: posix: kconfig: Remove unused ARCH_POSIX_STOP_ON_FATAL_ERROR sym

### DIFF
--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -23,14 +23,4 @@ config ARCH_POSIX_RECOMMENDED_STACK_SIZE
 	  thread stack, the real stack is the native underlying pthread stack.
 	  Therefore the allocated stack can be limited to this size)
 
-config ARCH_POSIX_STOP_ON_FATAL_ERROR
-	bool "Terminate execution on fatal errors"
-	depends on ARCH_POSIX
-	help
-	  If set, when a fatal error occurs, the execution will stop immediately with
-	  an error. If not set, the default Zephyr behavior will be followed:
-	  terminate only if the fault was triggered in an ISR or essential thread,
-	  otherwise abort the current thread and attempt to continue.
-	  Enabling this option may simplify locating and debugging faults
-
 endmenu


### PR DESCRIPTION
Unused after commit 71ce8ceb18 ("kernel: consolidate error handling
code").

Found with a script.