### PR TITLE
qemu_x86_long: don't munge to elf32 in-place

### DIFF
--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -236,11 +236,14 @@ endif(QEMU_PIPE_STACK)
 if(CONFIG_X86_LONGMODE)
   # QEMU doesn't like 64-bit ELF files. Since we don't use any >4GB
   # addresses, converting it to 32-bit is safe enough for emulation.
-  list(APPEND PRE_QEMU_COMMANDS
+  set(QEMU_KERNEL_FILE "${CMAKE_BINARY_DIR}/zephyr-qemu.elf")
+  add_custom_target(qemu_kernel_target
     COMMAND
     ${CMAKE_OBJCOPY}
     -O elf32-i386
     $<TARGET_FILE:${logical_target_for_zephyr_elf}>
+    ${CMAKE_BINARY_DIR}/zephyr-qemu.elf
+    DEPENDS ${logical_target_for_zephyr_elf}
     )
 endif()
 


### PR DESCRIPTION
Instead, use the QEMU_KERNEL_FILE facility to perform the
change in a new file zephyr-qemu.elf. This is what will
be sent to the emulator.

Fixes an issue where opening zephyr.elf in GDB would treat
it as a 32-bit binary instead of what it actually is,
forcing the user to override the arch setting.

Fixes: #19734

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>