### PR TITLE
drivers: console: kconfig: Remove unused IPM_CONSOLE_INIT_PRIORITY sym

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -179,15 +179,6 @@ config IPM_CONSOLE_STACK_SIZE
 	  thread to print out incoming messages from the remote CPU. Specify the
 	  stack size for these threads here.
 
-config IPM_CONSOLE_INIT_PRIORITY
-	int "IPM console init priority"
-	default 60
-	depends on IPM_CONSOLE_SENDER || IPM_CONSOLE_RECEIVER
-	help
-	  Device driver initialization priority.
-	  Console has to be initialized after the IPM subsystem
-	  it uses.
-
 config	UART_PIPE
 	bool "Enable pipe UART driver"
 	select UART_INTERRUPT_DRIVEN


### PR DESCRIPTION
Unused after commit 578ae40761 ("boards: remove quarl_se_c1000").

Found with a script.