### PR TITLE
Bluetooth: controller: split: Fix slave latency enable

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -963,7 +963,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 						       lll->memq_tx.tail,
 						       NULL)) {
 				lll->latency_event = 0;
-			} else {
+			} else if (lll->slave.latency_enabled) {
 				lll->latency_event = lll->latency;
 			}
 		} else if (reason_peer) {


### PR DESCRIPTION
Fix regression in porting slave latency, slave latency
enabled was not used, cause slave latency to be applied
before first packet being acknowledged by the master.

Regression in commit 5dff214d57eb ("Bluetooth: controller:
split: Fix missing slave latency impl.").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>