### PR TITLE
sanitycheck: fix error handling with host binaries

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -608,7 +608,7 @@ class BinaryHandler(Handler):
         if not self.terminated and self.returncode != 0:
             #When a process is killed, the default handler returns 128 + SIGTERM
             #so in that case the return code itself is not meaningful
-            self.set_state("error", handler_time)
+            self.set_state("failed", handler_time)
             self.instance.reason = "Handler error"
         elif harness.state:
             self.set_state(harness.state, handler_time)


### PR DESCRIPTION
Failed unit tests were setting wrong fail string (error instead of
failed) which made unit tests always pass.