### PR TITLE
tests: fcb: Fix deletion test case

### DIFF
--- a/tests/subsys/settings/fcb/src/settings_test_delete_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_delete_fcb.c
@@ -37,8 +37,9 @@ void test_config_delete_fcb(void)
 	zassert_true(rc == 0, "fcb redout error");
 	zassert_true(val8 == 153U, "bad value read");
 
+	test_set_called = 0;
 	settings_delete("myfoo/mybar");
 	rc = settings_load();
 	zassert_true(rc == 0, "fcb redout error");
-	zassert_true(val8 == VAL8_DELETED, "bad value read");
+	zassert_true(test_set_called == 0, "callback called with deleted val");
 }


### PR DESCRIPTION
Since 0b0f375190c061dedfe7c454a0d4d89bc43b99fd, duplicates or deletes
are not processed anymore, so fix the test accordingly.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>