### PR TITLE
drivers: eth: initialize ethernet stack in enc424j600 and enc28j60

### DIFF
--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -647,6 +647,7 @@ static void eth_enc28j60_iface_init(struct net_if *iface)
 			     sizeof(context->mac_address),
 			     NET_LINK_ETHERNET);
 	context->iface = iface;
+	ethernet_init(iface);
 }
 
 static const struct ethernet_api api_funcs = {

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -497,6 +497,7 @@ static void enc424j600_iface_init(struct net_if *iface)
 			     sizeof(context->mac_address),
 			     NET_LINK_ETHERNET);
 	context->iface = iface;
+	ethernet_init(iface);
 }
 
 static int enc424j600_start_device(struct device *dev)


### PR DESCRIPTION
Initialize ethernet stack in drivers enc424j600 and enc28j60.

Fixes: #19398

@ngiriprasad FYI