### PR TITLE
drivers: i2c: configurable I2C timeout value for STM32 platform

### DIFF
--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -47,4 +47,12 @@ config I2C_STM32_COMBINED_INTERRUPT
 	depends on I2C_STM32_INTERRUPT
 	default y if SOC_SERIES_STM32F0X || SOC_SERIES_STM32L0X
 
+config I2C_STM32_TIMEOUT_USEC
+	int "STM32 MCU I2C transaction timeout, in microseconds"
+	depends on I2C_STM32_V1
+	default 1000
+	help
+	  I2C timeout controls how long to wait for an ACK from a slave device.
+	  Upon exceeding the timeout the error is raised by I2C driver.
+
 endif # I2C_STM32

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(i2c_ll_stm32_v1);
 
 #include "i2c-priv.h"
 
-#define STM32_I2C_TIMEOUT_USEC  1000
+#define STM32_I2C_TIMEOUT_USEC  CONFIG_I2C_STM32_TIMEOUT_USEC
 #define I2C_REQUEST_WRITE       0x00
 #define I2C_REQUEST_READ        0x01
 #define HEADER                  0xF0
@@ -619,7 +619,7 @@ error:
 	return -EIO;
 }
 
-static int stm32_i2c_wait_timeout(u16_t *timeout)
+static int stm32_i2c_wait_timeout(u32_t *timeout)
 {
 	if (*timeout == 0) {
 		return 1;
@@ -637,7 +637,7 @@ s32_t stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 	struct i2c_stm32_data *data = DEV_DATA(dev);
 	I2C_TypeDef *i2c = cfg->i2c;
 	u32_t len = msg->len;
-	u16_t timeout;
+	u32_t timeout;
 	u8_t *buf = msg->buf;
 
 	msg_init(dev, msg, next_msg_flags, saddr, I2C_REQUEST_WRITE);
@@ -729,7 +729,7 @@ s32_t stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 	struct i2c_stm32_data *data = DEV_DATA(dev);
 	I2C_TypeDef *i2c = cfg->i2c;
 	u32_t len = msg->len;
-	u16_t timeout;
+	u32_t timeout;
 	u8_t *buf = msg->buf;
 
 	msg_init(dev, msg, next_msg_flags, saddr, I2C_REQUEST_READ);


### PR DESCRIPTION
Hard-coded value of 1000 microseconds is too low for some I2C slave devices,
operating in the master hold mode (otherwise known as clock stretching).
One of such devices, Si7006 RH/T sensor requires up to 11 ms when
sampling temperature and humidity.

Idea is to control such timeout via Kconfig.

The timing diagram shows a real use-case:

![17_ms_reading_time](https://user-images.githubusercontent.com/5261821/67148750-9edb1c80-f2ab-11e9-83d6-56815da5645f.png)

That's consistent with the datasheet of Si7007:

![conversion_time_si7006](https://user-images.githubusercontent.com/5261821/67148768-d2b64200-f2ab-11e9-9c36-975c34818cd4.png)



