### PR TITLE
boards: arm: arduino_due: add option to use jlink tool

### DIFF
--- a/boards/arm/arduino_due/board.cmake
+++ b/boards/arm/arduino_due/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)
+
+board_runner_args(jlink "--device=atsam3x8e" "--speed=4000")
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
With this commit we add the option to use jlink for
flashing and running samples & tests on Arduino Due
using jlink. Bossac remains the default option.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>