### PR TITLE
cmake: zephyr_library_amend feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,8 +470,11 @@ if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
     # this binary_dir is created but stays empty. Object files land in
     # the main binary dir instead.
     # https://cmake.org/pipermail/cmake/2019-June/069547.html
+    set(ZEPHYR_CURRENT_MODULE_DIR ${module_path})
     add_subdirectory(${module_path} ${CMAKE_BINARY_DIR}/modules/${module_name})
   endforeach()
+  # Done processing modules, clear ZEPHYR_CURRENT_MODULE_DIR.
+  set(ZEPHYR_CURRENT_MODULE_DIR)
 endif()
 
 set(syscall_macros_h ${ZEPHYR_BINARY_DIR}/include/generated/syscall_macros.h)


### PR DESCRIPTION
# Summary

With module support in Zephyr: https://docs.zephyrproject.org/latest/guides/modules.html?highlight=modules#modules-external-projects

more code will be located out of tree.
This means that in some cases, Kconfig settings may be set to `yes` and thus create a zephyr_library, but no file is place in the lib.

As example, high level settings for a driver might result in a zephyr_library is selected for creation, but the code for the specific driver is located out-of-tree.

This can result in an empty CMake library with the following error:
```
CMake Error at /projects/github/ncs/zephyr/cmake/extensions.cmake:411 (add_library):                       
  No SOURCES given to target: drivers__entropy
Call Stack (most recent call first):
  /projects/github/ncs/zephyr/cmake/extensions.cmake:388 (zephyr_library_named)
  /projects/github/ncs/zephyr/drivers/entropy/CMakeLists.txt:3 (zephyr_library)
```

This commit introduces the cmake extension `zephyr_library_amend` which offers
a generic way to add files from out-of-tree into a Zephyr library and still use the existing zephyr cmake extension functions.

This function allows for adding files in an out-of-tree Zephyr module
to a zephyr library created in zephyr repo CMake files.

As example:
`drivers/entropy/CMakeLists.txt` creates an zephyr library as:
```
zephyr_library()
```
only available to zephyr itself.

The amend function allows to amend to such a lib, by creating a
CMakeLists.txt file following identical folder structure in a Zephyr
Module: `<zephyr_module_oot>/drivers/entropy/CMakeLists.txt`
```
zephyr_library_amend()
zephyr_library_sources_if_kconfig(entropy_oot_driver.c) # Sources are amended to the original library
```

Requirement when using `zephyr_library_amend`.
1) If original zephyr `CMakeList.txt` is located in:
`${ZEPHYR_BASE}/drivers/entropy`
then the amending `CMakeLists.txt` must be located in
`<ZEPHYR_MODULE_DIR>/drivers/entropy`

This PR is related to: #14527


Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>