### PR TITLE
sensors: lis2dh: Fix scale computation

### DIFF
--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -113,7 +113,6 @@
 
 #define LIS2DH_FS_SELECT(fs)		((fs) << LIS2DH_FS_SHIFT)
 #define LIS2DH_FS_BITS			(LIS2DH_FS_SELECT(LIS2DH_FS_IDX))
-#define LIS2DH_ACCEL_SCALE(range_g)	((SENSOR_G * 2 * (range_g)) / 65636LL)
 #if defined(CONFIG_LIS2DH_OPER_MODE_HIGH_RES)
 	#define LIS2DH_HR_BIT		BIT(3)
 #else


### PR DESCRIPTION
The accelerometer values were sometimes wrong when setting the
various scales.

Fix bug #19872.
