### PR TITLE
Bluetooth: controller: Fix the slow Enc Setup alternative

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl_internal.h
@@ -159,7 +159,11 @@ struct connection {
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 		struct {
-			u8_t  initiate:1;
+			enum {
+				LLCP_ENC_STATE_INPROG,
+				LLCP_ENC_STATE_INIT,
+				LLCP_ENC_STATE_LTK_WAIT,
+			} state:2 __packed;
 			u8_t  error_code;
 			u8_t  skd[16];
 		} encryption;


### PR DESCRIPTION
Fix the implementation of slow encryption setup design
alternative to send ENC_RSP PDU before sending REJECT_IND
or REJECT_EXT_IND PDU.

Fixes #19917.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>