### PR TITLE
[ESP32] drivers: Add I2C Device tree support

### DIFF
--- a/boards/xtensa/esp32/esp32.dts
+++ b/boards/xtensa/esp32/esp32.dts
@@ -13,6 +13,7 @@
 
 	aliases {
 		uart-0 = &uart0;
+		i2c-0 = &i2c0;
 	};
 
 	chosen {
@@ -55,4 +56,17 @@
 	rts-pin = <7>;
 	cts-pin = <8>;
 	hw-flow-control;
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	sda-pin = <21>;
+	scl-pin = <22>;
+};
+
+&i2c1 {
+	clock-frequency = <I2C_BITRATE_FAST>;
+	sda-pin = <18>;
+	scl-pin = <5>;
 };

--- a/boards/xtensa/esp32/esp32_defconfig
+++ b/boards/xtensa/esp32/esp32_defconfig
@@ -37,9 +37,6 @@ CONFIG_I2C_1=y
 CONFIG_I2C_2=n
 CONFIG_I2C_3=n
 
-# FIXME: ESP32 port should support DTS.
-CONFIG_HAS_DTS_I2C=n
-
 # IRQ priorities are fixed on Xtensa, but Kconfig will ask for these
 # if not set.
 CONFIG_I2C_0_IRQ_PRI=1

--- a/drivers/i2c/Kconfig.esp32
+++ b/drivers/i2c/Kconfig.esp32
@@ -10,6 +10,7 @@ menuconfig I2C_ESP32
 	bool "ESP32 I2C"
 	depends on SOC_ESP32
 	select GPIO_ESP32
+	select HAS_DTS_I2C
 	help
 	  Enables the ESP32 I2C driver
 
@@ -21,10 +22,6 @@ config I2C_ESP32_TIMEOUT
 
 if I2C_0
 
-config I2C_0_DEFAULT_CFG
-	# Standard speed, master
-	default 0x12
-
 config I2C_ESP32_0_TX_LSB_FIRST
 	bool "Port 0 Transmit LSB first"
 
@@ -35,21 +32,9 @@ config I2C_ESP32_0_IRQ
 	int "Port 0 IRQ line"
 	default 8
 
-config I2C_ESP32_0_SCL_PIN
-	int "Port 0 SCL pin"
-	default 2
-
-config I2C_ESP32_0_SDA_PIN
-	int "Port 0 SDA pin"
-	default 4
-
 endif # I2C_0
 
 if I2C_1
-
-config I2C_1_DEFAULT_CFG
-	# Standard speed, master
-	default 0x12
 
 config I2C_ESP32_1_TX_LSB_FIRST
 	bool "Port 1 Transmit LSB first"
@@ -60,14 +45,6 @@ config I2C_ESP32_1_RX_LSB_FIRST
 config I2C_ESP32_1_IRQ
 	int "Port 1 IRQ line"
 	default 9
-
-config I2C_ESP32_1_SCL_PIN
-	int "Port 1 SCL pin"
-	default 5
-
-config I2C_ESP32_1_SDA_PIN
-	int "Port 1 SDA pin"
-	default 18
 
 endif # I2C_1
 

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -18,6 +18,12 @@
 #include <sys/util.h>
 #include <string.h>
 
+#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(i2c_esp32);
+
+#include "i2c-priv.h"
+
 /* Number of entries in hardware command queue */
 #define I2C_ESP32_NUM_CMDS 16
 /* Number of bytes in hardware FIFO */
@@ -87,6 +93,7 @@ struct i2c_esp32_config {
 	} irq;
 
 	const u32_t default_config;
+	const u32_t bitrate;
 };
 
 static int i2c_esp32_configure_pins(int pin, int matrix_out, int matrix_in)
@@ -562,7 +569,7 @@ static const struct i2c_driver_api i2c_esp32_driver_api = {
 	.transfer = i2c_esp32_transfer,
 };
 
-#ifdef CONFIG_I2C_0
+#ifdef DT_INST_0_ESPRESSIF_ESP32_I2C
 DEVICE_DECLARE(i2c_esp32_0);
 
 static void i2c_esp32_connect_irq_0(void)
@@ -581,8 +588,8 @@ static const struct i2c_esp32_config i2c_esp32_config_0 = {
 		.scl_in = I2CEXT0_SCL_IN_IDX,
 	},
 	.pins = {
-		.scl = CONFIG_I2C_ESP32_0_SCL_PIN,
-		.sda = CONFIG_I2C_ESP32_0_SDA_PIN,
+		.scl = DT_INST_0_ESPRESSIF_ESP32_I2C_SCL_PIN,
+		.sda = DT_INST_0_ESPRESSIF_ESP32_I2C_SDA_PIN,
 	},
 	.peripheral = {
 		.clk = DPORT_I2C_EXT0_CLK_EN,
@@ -598,18 +605,19 @@ static const struct i2c_esp32_config i2c_esp32_config_0 = {
 		.source = ETS_I2C_EXT0_INTR_SOURCE,
 		.line = CONFIG_I2C_ESP32_0_IRQ,
 	},
-	.default_config = CONFIG_I2C_0_DEFAULT_CFG,
+	.default_config = I2C_MODE_MASTER, /* FIXME: Zephyr don't support I2C_SLAVE_MODE */
+	.bitrate = DT_INST_0_ESPRESSIF_ESP32_I2C_CLOCK_FREQUENCY,
 };
 
 static struct i2c_esp32_data i2c_esp32_data_0;
 
-DEVICE_AND_API_INIT(i2c_esp32_0, CONFIG_I2C_0_NAME, &i2c_esp32_init,
+DEVICE_AND_API_INIT(i2c_esp32_0, DT_INST_0_ESPRESSIF_ESP32_I2C_LABEL, &i2c_esp32_init,
 		    &i2c_esp32_data_0, &i2c_esp32_config_0,
 		    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		    &i2c_esp32_driver_api);
-#endif /* CONFIG_I2C_0 */
+#endif /* DT_INST_0_ESPRESSIF_ESP32_I2C */
 
-#ifdef CONFIG_I2C_1
+#ifdef DT_INST_1_ESPRESSIF_ESP32_I2C
 DEVICE_DECLARE(i2c_esp32_1);
 
 static void i2c_esp32_connect_irq_1(void)
@@ -628,8 +636,8 @@ static const struct i2c_esp32_config i2c_esp32_config_1 = {
 		.scl_in = I2CEXT1_SCL_IN_IDX,
 	},
 	.pins = {
-		.scl = CONFIG_I2C_ESP32_1_SCL_PIN,
-		.sda = CONFIG_I2C_ESP32_1_SDA_PIN,
+		.scl = DT_INST_1_ESPRESSIF_ESP32_I2C_SCL_PIN,
+		.sda = DT_INST_1_ESPRESSIF_ESP32_I2C_SDA_PIN,
 	},
 	.peripheral = {
 		.clk = DPORT_I2C_EXT1_CLK_EN,
@@ -645,21 +653,23 @@ static const struct i2c_esp32_config i2c_esp32_config_1 = {
 		.source = ETS_I2C_EXT1_INTR_SOURCE,
 		.line = CONFIG_I2C_ESP32_1_IRQ,
 	},
-	.default_config = CONFIG_I2C_1_DEFAULT_CFG,
+	.default_config = I2C_MODE_MASTER, /* FIXME: Zephyr don't support I2C_SLAVE_MODE */
+	.bitrate = DT_INST_1_ESPRESSIF_ESP32_I2C_CLOCK_FREQUENCY,
 };
 
 static struct i2c_esp32_data i2c_esp32_data_1;
 
-DEVICE_AND_API_INIT(i2c_esp32_1, CONFIG_I2C_1_NAME, &i2c_esp32_init,
+DEVICE_AND_API_INIT(i2c_esp32_1, DT_INST_1_ESPRESSIF_ESP32_I2C_LABEL, &i2c_esp32_init,
 		    &i2c_esp32_data_1, &i2c_esp32_config_1,
 		    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		    &i2c_esp32_driver_api);
-#endif /* CONFIG_I2C_1 */
+#endif /* DT_INST_1_ESPRESSIF_ESP32_I2C */
 
 static int i2c_esp32_init(struct device *dev)
 {
 	const struct i2c_esp32_config *config = dev->config->config_info;
 	struct i2c_esp32_data *data = dev->driver_data;
+	u32_t bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 	unsigned int key = irq_lock();
 
 	k_sem_init(&data->fifo_sem, 1, 1);
@@ -676,5 +686,5 @@ static int i2c_esp32_init(struct device *dev)
 	config->connect_irq();
 	irq_unlock(key);
 
-	return i2c_esp32_configure(dev, config->default_config);
+	return i2c_esp32_configure(dev, config->default_config | bitrate_cfg);
 }

--- a/dts/bindings/i2c/espressif,esp32-i2c.yaml
+++ b/dts/bindings/i2c/espressif,esp32-i2c.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2019 Mohamed ElShahawi (ExtremeGTX@hotmail.com)
+# SPDX-License-Identifier: Apache-2.0
+
+title: ESP32 I2C
+
+description: >
+    This is a representation of the ESP32 I2C
+
+compatible: "espressif,esp32-i2c"
+
+include: i2c-controller.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: false
+
+    sda-pin:
+      type: int
+      description: SDA pin
+      required: true
+
+    scl-pin:
+      type: int
+      description: SCL pin
+      required: true

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -5,6 +5,7 @@
  */
 #include <xtensa/xtensa.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {
@@ -70,6 +71,26 @@
 			#gpio-cells = <2>;
 			reg = <0x3ff44800 0x800>;
 			label = "GPIO_1";
+		};
+
+		i2c0: i2c@3ff53000 {
+			compatible = "espressif,esp32-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x3ff53000 0x1000>;
+			/* interrupts = <8>; - FIXME: Enable interrupts when interrupt-controller got supported in device tree */
+			label = "I2C_0";
+			status = "disabled";
+		};
+
+		i2c1: i2c@3ff67000 {
+			compatible = "espressif,esp32-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x3ff67000 0x1000>;
+			/* interrupts = <9>; - FIXME: Enable interrupts when interrupt-controller got supported in device tree */
+			label = "I2C_1";
+			status = "disabled";
 		};
 	};
 };


### PR DESCRIPTION
- Add I2C modules to esp32.dtsi
- I2C Pins and bitrate config moved to esp32.dts

Related issues:
- #10516 



Signed-off-by: Mohamed ElShahawi <ExtremeGTX@hotmail.com>