### PR TITLE
modules: hal_nordic: Update nrfx to version 1.8.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -44,7 +44,7 @@ manifest:
       revision: a12d92816a53a521d79cefcf5c38b9dc8a4fed6e
       path: modules/hal/cypress
     - name: hal_nordic
-      revision: 1b14177ff2176a1d17f3dd5e7e217f44337255db
+      revision: e0bfd6f253ca6a5e87b6f53a8bb317bd6f483511
       path: modules/hal/nordic
     - name: hal_openisa
       revision: be5c01f86c96500def5079bcc58d2baefdffb6c8


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/hal_nordic/pull/10

---

Update nrfx to the recently released version. See
https://github.com/NordicSemiconductor/nrfx/blob/v1.8.1/CHANGELOG.md
for a list of changes that this version introduces.

Origin: nrfx
License: BSD 3-Clause
URL: https://github.com/NordicSemiconductor/nrfx/tree/v1.8.1
commit: ecc3616b8ea766ba0c921681258463696ad47930
Purpose: Provide peripheral drivers for Nordic SoCs
Maintained-by: External

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>