### PR TITLE
boards: nrf52_pca20020: default select ADC instance

### DIFF
--- a/boards/arm/nrf52_pca20020/Kconfig.defconfig
+++ b/boards/arm/nrf52_pca20020/Kconfig.defconfig
@@ -9,6 +9,13 @@ if BOARD_NRF52_PCA20020
 config BOARD
 	default "nrf52_pca20020"
 
+if ADC
+
+config ADC_0
+	default y
+
+endif # ADC
+
 config I2C
 	default y
 


### PR DESCRIPTION
Automatically select the ADC_0 instance when ADC is required.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>