### PR TITLE
net: dhcpv4: Cancel pending DNS queries on DNS server update

### DIFF
--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -656,6 +656,8 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 		}
 #if defined(CONFIG_DNS_RESOLVER)
 		case DHCPV4_OPTIONS_DNS_SERVER: {
+			int i;
+			struct dns_resolve_context *ctx;
 			struct sockaddr_in dns;
 			const struct sockaddr *dns_servers[] = {
 				(struct sockaddr *)&dns, NULL
@@ -681,11 +683,18 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 				return false;
 			}
 
-			dns.sin_family = AF_INET;
-			dns_resolve_close(dns_resolve_get_default());
+			ctx = dns_resolve_get_default();
+			for (i = 0; i < CONFIG_DNS_NUM_CONCUR_QUERIES; i++) {
+				if (!ctx->queries[i].cb) {
+					continue;
+				}
 
-			status = dns_resolve_init(dns_resolve_get_default(),
-						  NULL, dns_servers);
+				dns_resolve_cancel(ctx, ctx->queries[i].id);
+			}
+			dns_resolve_close(ctx);
+
+			dns.sin_family = AF_INET;
+			status = dns_resolve_init(ctx, NULL, dns_servers);
 			if (status < 0) {
 				NET_DBG("options_dns, failed to set "
 					"resolve address: %d", status);


### PR DESCRIPTION
On processing a DNS server option, which re-initializes the DNS resolve
context, also cancel all pending DNS queries before closing the old DNS
resolve context. Otherwise, `z_clock_announce()` will later work on the
re-initialized context once the queries expire and crash because the
reference to the timeout function `query_timeout()` has been cleared.

Signed-off-by: Markus Fuchs <markus.fuchs@de.sauter-bc.com>