### PR TITLE
doc: kconfig: Get rid of some duplicate path separators in output

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -196,10 +196,10 @@ add_custom_target(
   PYTHONPATH="${ZEPHYR_BASE}/scripts/kconfig${SEP}$ENV{PYTHONPATH}"
   ZEPHYR_BASE=${ZEPHYR_BASE}
   srctree=${ZEPHYR_BASE}
-  BOARD_DIR=boards/*/*/
+  BOARD_DIR=boards/*/*
   ARCH=*
-  ARCH_DIR=arch/
-  SOC_DIR=soc/
+  ARCH_DIR=arch
+  SOC_DIR=soc
   CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}
   KCONFIG_WARN_UNDEF=y
   KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}


### PR DESCRIPTION
Paths like soc//arm/... showed up in the output due to the extra '/' at
the end of the SOC_DIR value. Remove the redundant '/' in SOC_DIR and
other environment variables that get referenced in the Kconfig files.

Kconfiglib never normalizes paths, because it avoids some gotchas, e.g.
with symlinks.