### PR TITLE
can-stm32: add support for autmatic bus-off recovery

### DIFF
--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -21,3 +21,11 @@ config CAN_MAX_FILTER
 	help
 	  Defines the array size of the callback/msgq pointers.
 	  Must be at least the size of concurrent reads.
+
+config CAN_AUTOMATIC_BUS_OFF_RECOVERY
+	bool "Automatic bus-off recovery (ABOM)"
+	depends on CAN_STM32
+	help
+		Enable STM32 CAN Automatic bus off recovery.
+		Bus-Off state is left automatically by hardware once 128 occurrences of 11 recessive bits have been monitored.
+		Otherwise the software must initiate the recovering sequence by requesting bxCAN to enter and to leave initialization mode.

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -390,6 +390,10 @@ static int can_stm32_init(struct device *dev)
 	can->MCR |= CAN_MCR_TTCM;
 #endif
 
+#ifdef CONFIG_CAN_AUTOMATIC_BUS_OFF_RECOVERY
+	can->MCR |= CAN_MCR_ABOM;
+#endif
+
 	ret = can_stm32_runtime_configure(dev, CAN_NORMAL_MODE, 0);
 	if (ret) {
 		return ret;


### PR DESCRIPTION
The internal can driver has support for recovering from bus-off situtation. This PR adds support for automatic bus recovery. Bus can only be used with #19994, due to the need of clearing the errors