### PR TITLE
gui: lvgl: Fix broken CONFIG_LVGL_OBJ_WINDOW check

### DIFF
--- a/lib/gui/lvgl/lv_conf.h
+++ b/lib/gui/lvgl/lv_conf.h
@@ -614,7 +614,7 @@ typedef void *lv_obj_user_data_t;
 #define LV_TILEVIEW_DEF_ANIM_TIME CONFIG_LVGL_OBJ_TILE_VIEW_ANIMATION_TIME
 #endif
 
-#ifdef CONFIGLVGL_OBJ_WINDOW
+#ifdef CONFIG_LVGL_OBJ_WINDOW
 #define LV_USE_WIN 1
 #else
 #define LV_USE_WIN 0


### PR DESCRIPTION
Was impossible to enable due to a typo. Fix it.

Found with a script (LVGL_OBJ_WINDOW was unused besides
being enabled in tests/lib/gui/lvgl/prj.conf).