### PR TITLE
sensors: lis2dh: fix runtime and 16g range compile-time selectable range conversion

### DIFF
--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -21,10 +21,17 @@ LOG_MODULE_REGISTER(lis2dh, CONFIG_SENSOR_LOG_LEVEL);
  * multiplied by 100.
  */
 static const u32_t lis2dh_reg_val_to_scale[] = {
+#if defined(DT_INST_0_ST_LSM303AGR_ACCEL)
+	ACCEL_SCALE(1563),
+	ACCEL_SCALE(3126),
+	ACCEL_SCALE(6252),
+	ACCEL_SCALE(18758),
+#else
 	ACCEL_SCALE(1600),
 	ACCEL_SCALE(3200),
 	ACCEL_SCALE(6400),
 	ACCEL_SCALE(19200),
+#endif
 };
 
 #if defined(DT_ST_LIS2DH_BUS_SPI)

--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -77,12 +77,6 @@ static void lis2dh_convert(s16_t raw_val, u16_t scale,
 	converted_val = raw_val * scale;
 	val->val1 = converted_val / 1000000;
 	val->val2 = converted_val % 1000000;
-
-	/* normalize val to make sure val->val2 is positive */
-	if (val->val2 < 0) {
-		val->val1 -= 1;
-		val->val2 += 1000000;
-	}
 }
 
 static int lis2dh_channel_get(struct device *dev,

--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -117,7 +117,6 @@
 
 #define LIS2DH_FS_SELECT(fs)		((fs) << LIS2DH_FS_SHIFT)
 #define LIS2DH_FS_BITS			(LIS2DH_FS_SELECT(LIS2DH_FS_IDX))
-#define LIS2DH_ACCEL_SCALE(range_g)	((SENSOR_G * 2 * (range_g)) / 65636LL)
 #if defined(CONFIG_LIS2DH_OPER_MODE_HIGH_RES)
 	#define LIS2DH_HR_BIT		BIT(3)
 #else
@@ -201,7 +200,7 @@ struct lis2dh_data {
 #endif
 	union lis2dh_sample sample;
 	/* current scaling factor, in micro m/s^2 / lsb */
-	u16_t scale;
+	u32_t scale;
 
 #ifdef CONFIG_LIS2DH_TRIGGER
 	struct device *gpio_int1;

--- a/dts/bindings/sensor/st,lsm303agr-accel-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm303agr-accel-i2c.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2019 Grinn
+# SPDX-License-Identifier: Apache-2.0
+
+title: STMicroelectronics MEMS sensors LSM303AGR I2C
+
+description: >
+    This binding gives a base representation of LSM303AGR 3-axis accelerometer
+    accessed through I2C bus
+
+compatible: "st,lsm303agr-accel"
+
+include: ["i2c-device.yaml", "st,lis2dh-common.yaml"]

--- a/dts/bindings/sensor/st,lsm303agr-accel-spi.yaml
+++ b/dts/bindings/sensor/st,lsm303agr-accel-spi.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2019 Grinn
+# SPDX-License-Identifier: Apache-2.0
+
+title: STMicroelectronics MEMS sensors LSM303AGR SPI
+
+description: >
+    This binding gives a base representation of LSM303AGR 3-axis accelerometer
+    accessed through SPI bus
+
+compatible: "st,lsm303agr-accel"
+
+include: ["spi-device.yaml", "st,lis2dh-common.yaml"]


### PR DESCRIPTION
This is an alternative implementation of PR #19983