### PR TITLE
tests: kernel: Fix incorrect interrupt controller type inference.

### DIFF
--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -44,7 +44,7 @@ extern u32_t _irq_vector_table[];
 
 static volatile int trigger_check[TRIG_CHECK_SIZE];
 
-#if defined(CONFIG_ARM)
+#if defined(CONFIG_CPU_CORTEX_M)
 #include <arch/arm/cortex_m/cmsis.h>
 
 void trigger_irq(int irq)

--- a/tests/kernel/interrupt/src/interrupt.h
+++ b/tests/kernel/interrupt/src/interrupt.h
@@ -9,7 +9,7 @@
 #include <kernel_structs.h>
 
 
-#if defined(CONFIG_ARM)
+#if defined(CONFIG_CPU_CORTEX_M)
 #include <arch/arm/cortex_m/cmsis.h>
 
 static u32_t get_available_nvic_line(u32_t initial_offset)

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -23,7 +23,7 @@ struct k_timer timer;
  * in all other architectures, system timer is considered
  * to be in priority 0.
  */
-#if defined(CONFIG_ARM)
+#if defined(CONFIG_CPU_CORTEX_M)
 u32_t irq_line_0;
 u32_t irq_line_1;
 #define ISR0_PRIO 2
@@ -31,7 +31,7 @@ u32_t irq_line_1;
 #else
 #define ISR0_PRIO 1
 #define ISR1_PRIO 0
-#endif /* CONFIG_ARM */
+#endif /* CONFIG_CPU_CORTEX_M */
 
 #define MS_TO_US(ms)  (K_MSEC(ms) * USEC_PER_MSEC)
 volatile u32_t new_val;
@@ -55,13 +55,13 @@ void isr1(void *param)
 static void handler(struct k_timer *timer)
 {
 	ARG_UNUSED(timer);
-#if defined(CONFIG_ARM)
+#if defined(CONFIG_CPU_CORTEX_M)
 	irq_enable(irq_line_1);
 	trigger_irq(irq_line_1);
 #else
 	irq_enable(IRQ_LINE(ISR1_OFFSET));
 	trigger_irq(IRQ_LINE(ISR1_OFFSET));
-#endif /* CONFIG_ARM */
+#endif /* CONFIG_CPU_CORTEX_M */
 }
 #else
 void handler(void)
@@ -101,7 +101,7 @@ void isr0(void *param)
 #ifndef NO_TRIGGER_FROM_SW
 void test_nested_isr(void)
 {
-#if defined(CONFIG_ARM)
+#if defined(CONFIG_CPU_CORTEX_M)
 	irq_line_0 = get_available_nvic_line(CONFIG_NUM_IRQS);
 	irq_line_1 = get_available_nvic_line(irq_line_0);
 	z_arch_irq_connect_dynamic(irq_line_0, ISR0_PRIO, isr0, NULL, 0);
@@ -109,18 +109,18 @@ void test_nested_isr(void)
 #else
 	IRQ_CONNECT(IRQ_LINE(ISR0_OFFSET), ISR0_PRIO, isr0, NULL, 0);
 	IRQ_CONNECT(IRQ_LINE(ISR1_OFFSET), ISR1_PRIO, isr1, NULL, 0);
-#endif /* CONFIG_ARM */
+#endif /* CONFIG_CPU_CORTEX_M */
 
 	k_timer_init(&timer, handler, NULL);
 	k_timer_start(&timer, DURATION, K_NO_WAIT);
 
-#if defined(CONFIG_ARM)
+#if defined(CONFIG_CPU_CORTEX_M)
 	irq_enable(irq_line_0);
 	trigger_irq(irq_line_0);
 #else
 	irq_enable(IRQ_LINE(ISR0_OFFSET));
 	trigger_irq(IRQ_LINE(ISR0_OFFSET));
-#endif /* CONFIG_ARM */
+#endif /* CONFIG_CPU_CORTEX_M */
 
 }
 #else


### PR DESCRIPTION
tests: kernel: Fix incorrect interrupt controller type inference.

The current implementation of kernel interrupt tests incorrectly
infers NVIC, which is specific to Cortex-M, from CONFIG_ARM.

This commit fixes such incorrect NVIC inferences by using
CONFIG_CPU_CORTEX_M instead of CONFIG_ARM.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>