### PR TITLE
tests: updated names for the kernel tests

### DIFF
--- a/tests/kernel/context/testcase.yaml
+++ b/tests/kernel/context/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kernel.common:
+  kernel.context:
     tags: kernel
     min_ram: 20

--- a/tests/kernel/critical/testcase.yaml
+++ b/tests/kernel/critical/testcase.yaml
@@ -2,14 +2,14 @@ common:
   tags: kernel
 
 tests:
-  kernel.common:
+  kernel.critical:
     platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
     filter: not CONFIG_WDT_SAM
-  kernel.common.sam:
+  kernel.critical.sam:
     filter: CONFIG_WDT_SAM
     extra_configs:
      - CONFIG_WDT_DISABLE_AT_BOOT=y
-  kernel.common.nsim:
+  kernel.critical.nsim:
     platform_whitelist: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
     extra_configs:
       - CONFIG_TEST_HW_STACK_PROTECTION=n

--- a/tests/kernel/early_sleep/testcase.yaml
+++ b/tests/kernel/early_sleep/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.common:
+  kernel.sleep:
     tags: sleep

--- a/tests/kernel/pending/testcase.yaml
+++ b/tests/kernel/pending/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kernel.common.timing:
+  kernel.pending:
     min_ram: 16
     tags: kernel

--- a/tests/kernel/sleep/testcase.yaml
+++ b/tests/kernel/sleep/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.common.timing:
+  kernel.timing:
     tags: kernel


### PR DESCRIPTION
After run Sanitycheck script I found out that test cases
had the same test case name in the test result .xml file.
For board itodk in .xml file was duplicated kernel.common test.
To get rid of it, I decided to change test cases names
for the kernel tests, contained name kernel.common.
Now only one test has kernel.common test name,
and will be no duplicated test cases names in the future.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>