### PR TITLE
Kconfig option for enabling USB device.

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -33,6 +33,9 @@
 #ifdef CONFIG_UART_CONSOLE_MCUMGR
 #include "mgmt/serial.h"
 #endif
+#ifndef CONFIG_USB_DEVICE_AUTO_ENABLE
+#include <usb/usb_device.h>
+#endif
 
 static struct device *uart_console_dev;
 
@@ -596,6 +599,14 @@ static int uart_console_init(struct device *arg)
 	uart_console_dev = device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
 
 #if defined(CONFIG_USB_UART_CONSOLE) && defined(CONFIG_USB_UART_DTR_WAIT)
+#ifndef CONFIG_USB_DEVICE_AUTO_ENABLE
+	int ret;
+
+	ret = usb_enable();
+	if (ret < 0) {
+		return ret;
+	}
+#endif
 	while (1) {
 		u32_t dtr = 0U;
 

--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -19,6 +19,9 @@
 #include <zephyr.h>
 #include <sys/ring_buffer.h>
 
+#ifndef CONFIG_USB_DEVICE_AUTO_ENABLE
+#include <usb/usb_device.h>
+#endif
 #include <logging/log.h>
 LOG_MODULE_REGISTER(cdc_acm_echo, LOG_LEVEL_INF);
 
@@ -80,6 +83,14 @@ void main(void)
 		LOG_ERR("CDC ACM device not found");
 		return;
 	}
+
+#ifndef CONFIG_USB_DEVICE_AUTO_ENABLE
+	ret = usb_enable();
+	if (ret < 0) {
+		LOG_ERR("Failed to enable USB device");
+		return;
+	}
+#endif
 
 	ring_buf_init(&ringbuf, sizeof(ring_buffer), ring_buffer);
 

--- a/samples/subsys/usb/cdc_acm_composite/src/main.c
+++ b/samples/subsys/usb/cdc_acm_composite/src/main.c
@@ -19,6 +19,9 @@
 #include <zephyr.h>
 #include <sys/ring_buffer.h>
 
+#ifndef CONFIG_USB_DEVICE_AUTO_ENABLE
+#include <usb/usb_device.h>
+#endif
 #include <logging/log.h>
 LOG_MODULE_REGISTER(cdc_acm_composite, LOG_LEVEL_INF);
 
@@ -127,6 +130,16 @@ void main(void)
 		LOG_DBG("CDC_ACM_1 device not found");
 		return;
 	}
+
+#ifndef CONFIG_USB_DEVICE_AUTO_ENABLE
+	int ret;
+
+	ret = usb_enable();
+	if (ret < 0) {
+		LOG_ERR("Failed to enable USB device");
+		return;
+	}
+#endif
 
 	LOG_INF("Wait for DTR");
 

--- a/samples/subsys/usb/hid-cdc/src/main.c
+++ b/samples/subsys/usb/hid-cdc/src/main.c
@@ -620,6 +620,17 @@ void main(void)
 
 	usb_hid_register_device(hid1_dev, hid_kbd_report_desc,
 				sizeof(hid_kbd_report_desc), &ops);
+
+#ifndef CONFIG_USB_DEVICE_AUTO_ENABLE
+	int ret;
+
+	ret = usb_enable();
+	if (ret < 0) {
+		LOG_ERR("Failed to enable USB device");
+		return;
+	}
+#endif
+
 	usb_hid_init(hid0_dev);
 	usb_hid_init(hid1_dev);
 

--- a/samples/subsys/usb/hid-mouse/src/main.c
+++ b/samples/subsys/usb/hid-mouse/src/main.c
@@ -267,6 +267,17 @@ void main(void)
 	usb_hid_register_device(hid_dev,
 				hid_report_desc, sizeof(hid_report_desc),
 				&ops);
+
+#ifndef CONFIG_USB_DEVICE_AUTO_ENABLE
+	int ret;
+
+	ret = usb_enable();
+	if (ret < 0) {
+		LOG_ERR("Failed to enable USB device");
+		return;
+	}
+#endif
+
 	usb_hid_init(hid_dev);
 
 	while (true) {

--- a/samples/subsys/usb/hid/src/main.c
+++ b/samples/subsys/usb/hid/src/main.c
@@ -118,6 +118,16 @@ void main(void)
 {
 	LOG_DBG("Starting application");
 
+#ifndef CONFIG_USB_DEVICE_AUTO_ENABLE
+	int ret;
+
+	ret = usb_enable();
+	if (ret < 0) {
+		LOG_ERR("Failed to enable USB device");
+		return;
+	}
+#endif
+
 	k_delayed_work_init(&delayed_report_send, send_report);
 }
 

--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -9,6 +9,9 @@
 
 #include <zephyr.h>
 #include <logging/log.h>
+#ifndef CONFIG_USB_DEVICE_AUTO_ENABLE
+#include <usb/usb_device.h>
+#endif
 LOG_MODULE_REGISTER(main);
 
 #if CONFIG_DISK_ACCESS_FLASH && CONFIG_FAT_FILESYSTEM_ELM
@@ -27,9 +30,16 @@ static struct fs_mount_t fatfs_mnt = {
 
 void main(void)
 {
-	/* Nothing to be done other than the selecting appropriate build
-	 * config options. Everything is driven from the USB host side.
-	 */
+#ifndef CONFIG_USB_DEVICE_AUTO_ENABLE
+	int ret;
+
+	ret = usb_enable();
+	if (ret < 0) {
+		LOG_ERR("Failed to enable USB device");
+	return;
+	}
+#endif
+
 	LOG_INF("The device is put in USB mass storage mode.\n");
 
 #if CONFIG_DISK_ACCESS_FLASH && CONFIG_FAT_FILESYSTEM_ELM

--- a/samples/subsys/usb/testusb/src/main.c
+++ b/samples/subsys/usb/testusb/src/main.c
@@ -6,10 +6,22 @@
 
 #include <zephyr.h>
 #include <logging/log.h>
+#ifndef CONFIG_USB_DEVICE_AUTO_ENABLE
+#include <usb/usb_device.h>
+#endif
 LOG_MODULE_REGISTER(main);
 
 void main(void)
 {
+#ifndef CONFIG_USB_DEVICE_AUTO_ENABLE
+	int ret;
+
+	ret = usb_enable();
+	if (ret < 0) {
+		LOG_ERR("Failed to enable USB device");
+		return;
+	}
+#endif
 	LOG_INF("entered main.");
 }
 

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -283,10 +283,18 @@ static struct webusb_req_handlers req_handlers = {
 
 void main(void)
 {
+	int ret;
+
 	LOG_DBG("");
 
 	/* Set the custom and vendor request handlers */
 	webusb_register_request_handlers(&req_handlers);
+
+	ret = usb_enable();
+	if (ret < 0) {
+		LOG_ERR("Failed to enable USB device");
+	return;
+	}
 
 	usb_bos_register_cap((void *)&bos_cap_webusb);
 	usb_bos_register_cap((void *)&bos_cap_msosv2);

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -51,6 +51,13 @@ config USB_DEVICE_SN
 	help
 	  USB device SerialNumber string. MUST be configured by vendor.
 
+config USB_DEVICE_AUTO_ENABLE
+	bool "Enable USB device on system boot up"
+	default y
+	help
+	  USB device auto enable when system boots up.
+	  If selected USB device would be enabled with APPLICATION initialization level.
+
 config USB_COMPOSITE_DEVICE
 	bool "Enable composite device driver"
 	depends on USB

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -1634,7 +1634,9 @@ static int usb_device_init(struct device *dev)
 
 	usb_set_config(device_descriptor);
 
+#ifdef CONFIG_USB_DEVICE_AUTO_ENABLE
 	usb_enable();
+#endif
 
 	return 0;
 }

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -110,6 +110,8 @@ LOG_MODULE_REGISTER(usb_device);
 extern struct usb_cfg_data __usb_data_start[];
 extern struct usb_cfg_data __usb_data_end[];
 
+K_MUTEX_DEFINE(usb_enable_lock);
+
 struct usb_transfer_data {
 	/** endpoint associated to the transfer */
 	u8_t ep;
@@ -1542,10 +1544,16 @@ int usb_enable(void)
 		return 0;
 	}
 
+	/* Prevent from calling usb_enable form different contex.
+	 * This should only be called once.
+	 */
+	LOG_DBG("lock usb_enable_lock mutex");
+	k_mutex_lock(&usb_enable_lock, K_FOREVER);
+
 	/* Enable VBUS if needed */
 	ret = usb_vbus_set(true);
 	if (ret < 0) {
-		return ret;
+		goto usb_enable_error;
 	}
 
 	usb_register_status_callback(forward_status_cb);
@@ -1553,7 +1561,7 @@ int usb_enable(void)
 
 	ret = usb_dc_attach();
 	if (ret < 0) {
-		return ret;
+		goto usb_enable_error;
 	}
 
 	/* Configure control EP */
@@ -1563,32 +1571,32 @@ int usb_enable(void)
 	ep0_cfg.ep_addr = USB_CONTROL_OUT_EP0;
 	ret = usb_dc_ep_configure(&ep0_cfg);
 	if (ret < 0) {
-		return ret;
+		goto usb_enable_error;
 	}
 
 	ep0_cfg.ep_addr = USB_CONTROL_IN_EP0;
 	ret = usb_dc_ep_configure(&ep0_cfg);
 	if (ret < 0) {
-		return ret;
+		goto usb_enable_error;
 	}
 
 	/* Register endpoint 0 handlers*/
 	ret = usb_dc_ep_set_callback(USB_CONTROL_OUT_EP0,
 				     usb_handle_control_transfer);
 	if (ret < 0) {
-		return ret;
+		goto usb_enable_error;
 	}
 
 	ret = usb_dc_ep_set_callback(USB_CONTROL_IN_EP0,
 				     usb_handle_control_transfer);
 	if (ret < 0) {
-		return ret;
+		goto usb_enable_error;
 	}
 
 	/* Register endpoint handlers*/
 	ret = composite_setup_ep_cb();
 	if (ret < 0) {
-		return ret;
+		goto usb_enable_error;
 	}
 
 	/* Init transfer slots */
@@ -1600,17 +1608,20 @@ int usb_enable(void)
 	/* Enable control EP */
 	ret = usb_dc_ep_enable(USB_CONTROL_OUT_EP0);
 	if (ret < 0) {
-		return ret;
+		goto usb_enable_error;
 	}
 
 	ret = usb_dc_ep_enable(USB_CONTROL_IN_EP0);
 	if (ret < 0) {
-		return ret;
+		goto usb_enable_error;
 	}
 
 	usb_dev.enabled = true;
 
-	return 0;
+usb_enable_error:
+	LOG_DBG("unlock usb_enable_lock mutex");
+	k_mutex_unlock(&usb_enable_lock);
+	return ret;
 }
 
 /*


### PR DESCRIPTION
USB_DEVICE_AUTO_ENABLE option is useful when user wants to control when to enable USB device.
By default this option is disabled and USB is enabled on system boot up.

Having enabled USB device automatically may cause loosing power events from USB device. It can happen if USB had been enabled and some events arrived but user did not register any class specific callback yet. In such scenario this information will be dropped.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>