### PR TITLE
 [ESP32] drivers: Add PINMUX Device tree support

### DIFF
--- a/drivers/pinmux/pinmux_esp32.c
+++ b/drivers/pinmux/pinmux_esp32.c
@@ -20,6 +20,10 @@
  * this array covers only the first function of each I/O pin.
  * Items with offset `0` are not present in the documentation, and
  * trying to configure them will result in -EINVAL being returned.
+ *
+ * Note: DR_REG_IO_MUX_BASE here is used to extract GPIO_X register offset.
+ *       Don't replace it by device tree value, because PERIPHS_IO_MUX_
+ *       is "internally" depends on it.
  */
 #define PIN(id)   ((PERIPHS_IO_MUX_ ## id ## _U) - (DR_REG_IO_MUX_BASE))
 static const u8_t pin_mux_off[] = {
@@ -49,7 +53,7 @@ static u32_t *reg_for_pin(u32_t pin)
 		return NULL;
 	}
 
-	return (u32_t *)(DR_REG_IO_MUX_BASE + off);
+	return (u32_t *)(DT_INST_0_ESPRESSIF_ESP32_PINMUX_BASE_ADDRESS + off);
 }
 
 static int set_reg(u32_t pin, u32_t clr_mask, u32_t set_mask)

--- a/dts/bindings/pinctrl/espressif,esp32-pinmux.yaml
+++ b/dts/bindings/pinctrl/espressif,esp32-pinmux.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2019 Mohamed ElShahawi
+# SPDX-License-Identifier: Apache-2.0
+title: ESP32 PINMUX
+
+description: >
+    This binding gives a base representation of the ESP32 PINMUX
+
+compatible: "espressif,esp32-pinmux"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -57,6 +57,11 @@
 			status = "disabled";
 		};
 
+		pinmux: pinmux@3ff49000 {
+			compatible = "espressif,esp32-pinmux";
+			reg = <0x3ff49000 0x94>;
+		};
+
 		gpio0: gpio@3ff44000 {
 			compatible = "espressif,esp32-gpio";
 			gpio-controller;


### PR DESCRIPTION
- Add PINMUX module to esp32.dtsi

Related issues:
- #10516 


Signed-off-by: Mohamed ElShahawi <ExtremeGTX@hotmail.com>