### PR TITLE
CODEOWNERS: Add owner for valgrind suppression file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -340,6 +340,7 @@
 /scripts/west_commands/                   @mbolivar
 /scripts/west-commands.yml                @mbolivar
 /scripts/zephyr_module.py                 @tejlmand
+/scripts/valgrind.supp                    @aescolar
 /subsys/bluetooth/                        @joerchan @jhedberg @Vudentz
 /subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot
 /subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @joerchan @Vudentz


### PR DESCRIPTION
The valgrind suppression file did not have an owner
That file is only usefull for POSIX arch based boards

=> Adding myself as owner of the file

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>