### PR TITLE
dts: bindings: Fix u-blox misspelling

### DIFF
--- a/dts/bindings/modem/ublox,sara-r4.yaml
+++ b/dts/bindings/modem/ublox,sara-r4.yaml
@@ -6,7 +6,7 @@ title: u-blox SARA-R4 modem
 description: >
     This is a representation of the u-blox SARA-R4 modem.
 
-compatible: "ubloc,sara-r4"
+compatible: "ublox,sara-r4"
 
 include: uart-device.yaml
 


### PR DESCRIPTION
Spell ublox correctly.

Fixes #19867.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>