### PR TITLE
Add support for bus state propagation through socketcan

### DIFF
--- a/drivers/can/socket_can_generic.h
+++ b/drivers/can/socket_can_generic.h
@@ -20,7 +20,7 @@
 #define BUF_ALLOC_TIMEOUT K_MSEC(50)
 
 /* TODO: make msgq size configurable */
-CAN_DEFINE_MSGQ(socket_can_msgq, 5);
+K_MSGQ_DEFINE(socket_can_msgq, sizeof(struct can_frame), 106, 4);
 K_THREAD_STACK_DEFINE(rx_thread_stack, RX_THREAD_STACK_SIZE);
 
 struct socket_can_context {
@@ -43,28 +43,79 @@ static inline void socket_can_iface_init(struct net_if *iface)
 	LOG_DBG("Init CAN interface %p dev %p", iface, dev);
 }
 
-static inline void tx_irq_callback(u32_t error_flags, void *arg)
+static inline int socket_can_tx_state_to_frame(enum can_state state)
 {
-	char *caller_str = (char *)arg;
-	if (error_flags) {
-		LOG_DBG("TX error from %s! error-code: %d",
-			caller_str, error_flags);
+	int err = 0;
+
+	switch (state) {
+	case CAN_ERROR_ACTIVE:
+		err = CAN_ERR_CRTL_ACTIVE;
+		break;
+	case CAN_ERROR_PASSIVE:
+		err = CAN_ERR_CRTL_TX_PASSIVE;
+		break;
+	default:
+		err = 0;
 	}
+	return err;
 }
+
+static inline int socket_can_rx_state_to_frame(enum can_state state)
+{
+	int err = 0;
+
+	switch (state) {
+	case CAN_ERROR_ACTIVE:
+		err = CAN_ERR_CRTL_ACTIVE;
+		break;
+	case CAN_ERROR_PASSIVE:
+		err = CAN_ERR_CRTL_RX_PASSIVE;
+		break;
+	default:
+		err = 0;
+	}
+	return err;
+}
+
+static inline void socket_can_change_state(struct socket_can_context *ctx,
+						enum can_state tx_state,
+						enum can_state rx_state)
+{
+	enum can_state new_state = MAX(tx_state, rx_state);
+	struct can_frame msg = {.can_id = CAN_ERR_FLAG, .can_dlc = CAN_ERR_DLC};
+
+	LOG_DBG("New error state: %d", new_state);
+
+	if (new_state == CAN_BUS_OFF) {
+		msg.can_id |= CAN_ERR_BUSOFF;
+	} else {
+		msg.can_id |= CAN_ERR_CRTL;
+		msg.data[1] |= tx_state >= rx_state ?
+				socket_can_tx_state_to_frame(tx_state) : 0;
+		msg.data[1] |= tx_state <= rx_state ?
+				socket_can_rx_state_to_frame(rx_state) : 0;
+	}
+
+	k_msgq_put(ctx->msgq, &msg, K_NO_WAIT);
+}
+
 
 /* This is called by net_if.c when packet is about to be sent */
 static inline int socket_can_send(struct device *dev, struct net_pkt *pkt)
 {
 	struct socket_can_context *socket_context = dev->driver_data;
+	struct zcan_frame zframe;
 	int ret;
 
 	if (net_pkt_family(pkt) != AF_CAN) {
 		return -EPFNOSUPPORT;
 	}
 
-	ret = can_send(socket_context->can_dev,
-		       (struct zcan_frame *)pkt->frags->data,
-		       SEND_TIMEOUT, tx_irq_callback, "socket_can_send");
+	can_copy_frame_to_zframe((const struct can_frame *)pkt->frags->data,
+								&zframe);
+
+	ret = can_send(socket_context->can_dev, (struct zcan_frame *)&zframe,
+		       SEND_TIMEOUT, NULL, NULL);
 	if (ret) {
 		LOG_DBG("Cannot send socket CAN msg (%d)", ret);
 	}
@@ -72,7 +123,17 @@ static inline int socket_can_send(struct device *dev, struct net_pkt *pkt)
 	/* If something went wrong, then we need to return negative value to
 	 * net_if.c:net_if_tx() so that the net_pkt will get released.
 	 */
-	return -ret;
+	return ret;
+}
+
+static inline void socket_can_rx_callback(struct zcan_frame *msg, void *arg)
+{
+	struct socket_can_context *socket_context = arg;
+	struct can_frame frame;
+
+	can_copy_zframe_to_frame(msg, &frame);
+
+	k_msgq_put(socket_context->msgq, &frame, K_NO_WAIT);
 }
 
 static inline int socket_can_setsockopt(struct device *dev, void *obj,
@@ -88,16 +149,23 @@ static inline int socket_can_setsockopt(struct device *dev, void *obj,
 		return -1;
 	}
 
-	__ASSERT_NO_MSG(optlen == sizeof(struct zcan_filter));
+	if (optname == CAN_RAW_FILTER) {
+		struct zcan_filter zfilter;
 
-	ret = can_attach_msgq(socket_context->can_dev, socket_context->msgq,
-			      optval);
-	if (ret == CAN_NO_FREE_FILTER) {
-		errno = ENOSPC;
-		return -1;
+		__ASSERT_NO_MSG(optlen == sizeof(struct can_filter));
+
+		can_copy_filter_to_zfilter(optval, &zfilter);
+
+		ret = can_attach_isr(socket_context->can_dev,
+					socket_can_rx_callback,
+					socket_context, &zfilter);
+		if (ret == CAN_NO_FREE_FILTER) {
+			errno = ENOSPC;
+			return -1;
+		}
+
+		net_context_set_filter_id(ctx, ret);
 	}
-
-	net_context_set_filter_id(ctx, ret);
 
 	return 0;
 }
@@ -118,38 +186,52 @@ static struct canbus_api socket_can_api = {
 
 static struct socket_can_context socket_can_context_1;
 
+static void state_changed(enum can_state state, struct can_bus_err_cnt err_cnt)
+{
+	enum can_state rx_state, tx_state;
+
+	rx_state = err_cnt.rx_err_cnt >= err_cnt.tx_err_cnt ? state : 0;
+	tx_state = err_cnt.rx_err_cnt <= err_cnt.tx_err_cnt ? state : 0;
+
+	socket_can_change_state(&socket_can_context_1, tx_state, rx_state);
+}
+
 static inline void rx_thread(void *ctx, void *unused1, void *unused2)
 {
 	struct socket_can_context *socket_context = ctx;
 	struct net_pkt *pkt;
-	struct zcan_frame msg;
+	struct can_frame frame;
 	int ret;
 
 	ARG_UNUSED(unused1);
 	ARG_UNUSED(unused2);
 
-	while (1) {
-		k_msgq_get((struct k_msgq *)socket_context->msgq, &msg,
-			   K_FOREVER);
+	can_register_state_change_isr(socket_context->can_dev, state_changed);
 
-		pkt = net_pkt_rx_alloc_with_buffer(socket_context->iface,
-						   sizeof(msg),
-						   AF_CAN, 0,
-						   BUF_ALLOC_TIMEOUT);
-		if (!pkt) {
-			LOG_ERR("Failed to obtain RX buffer");
-			continue;
-		}
+	while (true) {
+		ret = k_msgq_get((struct k_msgq *)socket_context->msgq, &frame,
+							K_FOREVER);
+		if (ret >= 0) {
+			pkt = net_pkt_rx_alloc_with_buffer(
+					socket_context->iface,
+					sizeof(frame),
+					AF_CAN, 0,
+					BUF_ALLOC_TIMEOUT);
+			if (!pkt) {
+				LOG_ERR("Failed to obtain RX buffer");
+				continue;
+			}
 
-		if (net_pkt_write(pkt, (void *)&msg, sizeof(msg))) {
-			LOG_ERR("Failed to append RX data");
-			net_pkt_unref(pkt);
-			continue;
-		}
+			if (net_pkt_write(pkt, (void *)&frame, sizeof(frame))) {
+				LOG_ERR("Failed to append RX data");
+				net_pkt_unref(pkt);
+				continue;
+			}
 
-		ret = net_recv_data(socket_context->iface, pkt);
-		if (ret < 0) {
-			net_pkt_unref(pkt);
+			ret = net_recv_data(socket_context->iface, pkt);
+			if (ret < 0) {
+				net_pkt_unref(pkt);
+			}
 		}
 	}
 }

--- a/drivers/can/socket_can_generic.h
+++ b/drivers/can/socket_can_generic.h
@@ -110,7 +110,7 @@ static inline void socket_can_change_state(struct socket_can_context *ctx,
 	}
 }
 
-static inline void tx_irq_callback (u32_t error_flags, void *arg)
+static inline void tx_irq_callback(u32_t error_flags, void *arg)
 {
 	ARG_UNUSED(error_flags);
 	ARG_UNUSED(arg);

--- a/drivers/can/socket_can_generic.h
+++ b/drivers/can/socket_can_generic.h
@@ -110,6 +110,13 @@ static inline void socket_can_change_state(struct socket_can_context *ctx,
 	}
 }
 
+static inline void tx_irq_callback (u32_t error_flags, void *arg)
+{
+	ARG_UNUSED(error_flags);
+	ARG_UNUSED(arg);
+
+	/* This is needed to make can_send non-blocking */
+}
 
 /* This is called by net_if.c when packet is about to be sent */
 static inline int socket_can_send(struct device *dev, struct net_pkt *pkt)
@@ -126,7 +133,7 @@ static inline int socket_can_send(struct device *dev, struct net_pkt *pkt)
 								&zframe);
 
 	ret = can_send(socket_context->can_dev, (struct zcan_frame *)&zframe,
-		       SEND_TIMEOUT, NULL, NULL);
+		       SEND_TIMEOUT, tx_irq_callback, NULL);
 	if (ret) {
 		LOG_DBG("Cannot send socket CAN msg (%d)", ret);
 	}

--- a/include/net/socket_can.h
+++ b/include/net/socket_can.h
@@ -38,10 +38,63 @@ extern "C" {
 
 enum {
 	CAN_RAW_FILTER = 1,
+	CAN_RAW_ERR_FILTER,
 };
 
 /* Socket CAN MTU size */
 #define CAN_MTU		CAN_MAX_DLEN
+
+/* special address description flags for the CAN_ID */
+#define CAN_EFF_FLAG 0x80000000U /* EFF/SFF is set in the MSB */
+#define CAN_RTR_FLAG 0x40000000U /* remote transmission request */
+#define CAN_ERR_FLAG 0x20000000U /* error message frame */
+
+/* valid bits in CAN ID for frame formats */
+#define CAN_SFF_MASK 0x000007FFU /* standard frame format (SFF) */
+#define CAN_EFF_MASK 0x1FFFFFFFU /* extended frame format (EFF) */
+#define CAN_ERR_MASK 0x1FFFFFFFU /* omit EFF, RTR, ERR flags */
+
+#define CAN_ERR_DLC 8 /* dlc for error message frames */
+
+/** error class (mask) in can_id */
+
+/** TX timeout (by netdevice driver) */
+#define CAN_ERR_TX_TIMEOUT   (0x00000001U)
+/** lost arbitration - data[0] */
+#define CAN_ERR_LOSTARB      (0x00000002U)
+/** controller problems - data[1] */
+#define CAN_ERR_CRTL         (0x00000004U)
+/** protocol violations - data[2..3] */
+#define CAN_ERR_PROT         (0x00000008U)
+/** transceiver status -data[4] */
+#define CAN_ERR_TRX          (0x00000010U)
+/** received no ACK on transmission */
+#define CAN_ERR_ACK          (0x00000020U)
+/** bus off */
+#define CAN_ERR_BUSOFF       (0x00000040U)
+/** bus error (may flood!) */
+#define CAN_ERR_BUSERROR     (0x00000080U)
+/** controller restarted */
+#define CAN_ERR_RESTARTED    (0x00000100U)
+
+/** error status of can controller data[1] */
+
+/** unspecified */
+#define CAN_ERR_CRTL_UNSPEC      (0 << 0)
+/** RX buffer overflow */
+#define CAN_ERR_CRTL_RX_OVERFLOW (1 << 0)
+/** TX buffer overflow */
+#define CAN_ERR_CRTL_TX_OVERFLOW (1 << 2)
+/** reached warning level for RX errors */
+#define CAN_ERR_CRTL_RX_WARNING  (1 << 3)
+/** reached warning level for TX errors */
+#define CAN_ERR_CRTL_TX_WARNING  (1 << 4)
+/** reached error passive status RX */
+#define CAN_ERR_CRTL_RX_PASSIVE  (1 << 5)
+/** reached error passive status TX */
+#define CAN_ERR_CRTL_TX_PASSIVE  (1 << 6)
+/** recovered to error active state */
+#define CAN_ERR_CRTL_ACTIVE      (1 << 7)
 
 /**
  * struct sockaddr_can - The sockaddr structure for CAN sockets

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -106,7 +106,8 @@ static void zcan_received_cb(struct net_context *ctx, struct net_pkt *pkt,
 		}
 
 		if ((receivers[i].can_mask & CAN_ERR_FLAG) == CAN_ERR_FLAG) {
-			if ((frame.can_id & receivers[i].can_mask) == 0) {
+			u32_t id = frame.can_id & receivers[i].can_mask;
+			if ((id & CAN_ERR_MASK) == 0) {
 				continue;
 			}
 		} else if ((frame.can_id & receivers[i].can_mask) !=

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -167,7 +167,9 @@ static void zcan_received_cb(struct net_context *ctx, struct net_pkt *pkt,
 		}
 	}
 
-	net_pkt_unref(pkt);
+	if (!clone || clone != pkt) {
+		net_pkt_unref(pkt);
+	}
 }
 
 static int zcan_bind_ctx(struct net_context *ctx, const struct sockaddr *addr,


### PR DESCRIPTION
In #19679, the can bus state can be monitored. So this PR is based on #19679 .
This is an update for the socketcan driver, to send error frames to userspace.
And enabling support for filtering on error frames.
