### PR TITLE
sanitycheck: Fix --log-file option

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3830,7 +3830,6 @@ def main():
 
     suite.misc_reports(options.compare_report, options.show_footprint,
                 options.all_deltas, options.footprint_threshold, options.last_metrics)
-    suite.save_reports()
 
     if options.coverage:
         if options.gcov_tool is None:
@@ -3859,6 +3858,7 @@ def main():
             if p['connected']:
                 print("%s (%s): %d" %(p['platform'], p.get('id', None), p['counter']))
 
+    suite.save_reports()
     if suite.total_failed or (suite.warnings and options.warnings_as_errors):
         sys.exit(1)
 


### PR DESCRIPTION
save_reports should be one of the last tasks executed because it
closes the log file. Withouth it, other functions that use debug
functions like info and error will try to write into a close file.

This fixes the following problem:

sanitycheck -x=USE_CCACHE=0 -p native_posix -T samples/hello_world/ -b
-N --log-file sanity.log
JOBS: 8
Building initial testcase list...
1 test configurations selected, 0 configurations discarded due to filters.
Adding tasks to the queue...
total complete:    1/   1  100%  skipped:    0, failed:    0
1 of 1 tests passed (100.00%), 0 failed, 0 skipped with 0 warnings in
2.91 seconds
Traceback (most recent call last):
  File "./zephyr/scripts/sanitycheck", line 3866, in <module>
    main()
  File "./zephyr/scripts/sanitycheck", line 3854, in main
    suite.summary(options.disable_unrecognized_section_test)
  File "./zephyr/scripts/sanitycheck", line 2306, in summary
    self.duration))
  File "./zephyr/scripts/sanitycheck", line 432, in info
    log_file.write(what + "\n")
ValueError: I/O operation on closed file.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>