### PR TITLE
doc: fix display of monospaced text links

### DIFF
--- a/doc/static/zephyr-custom.css
+++ b/doc/static/zephyr-custom.css
@@ -53,6 +53,13 @@ div.rst-other-versions dl {
     color: #000000;
 }
 
+/* code literal links should be blue, and purple after visiting */
+a.internal code.literal {
+   color: #2980B9;
+}
+a.internal:visited code.literal {
+   color: #9B59B9;
+}
 
 /* Make the version number more visible */
 .wy-side-nav-search>div.version {


### PR DESCRIPTION
Links to doxygen-generated API content are displayed as monospaced code
spans in the text, but have no indication that they're clickable
links.  Tweak the CSS to color the monospaced text the same as regular
links in the text (blue) and after visited (purple).  This might also
help us notice doxygen API references that aren't creating links (and
should).

Fixes: #20032
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>