### PR TITLE
Update min flash

### DIFF
--- a/samples/mpu/mpu_test/sample.yaml
+++ b/samples/mpu/mpu_test/sample.yaml
@@ -6,3 +6,4 @@ tests:
     filter: CONFIG_CPU_HAS_MPU
     tags: mpu
     harness: keyboard
+    min_flash: 64

--- a/samples/net/sockets/http_client/sample.yaml
+++ b/samples/net/sockets/http_client/sample.yaml
@@ -9,3 +9,4 @@ sample:
 tests:
   sample.net.sockets.http_client:
     harness: net
+    min_flash: 128

--- a/samples/subsys/logging/logger/sample.yaml
+++ b/samples/subsys/logging/logger/sample.yaml
@@ -29,5 +29,6 @@ tests:
     tags: logging usermode
     filter: CONFIG_ARCH_HAS_USERSPACE
     harness: keyboard
+    min_flash: 64
     extra_configs:
       - CONFIG_USERSPACE=y

--- a/samples/userspace/shared_mem/sample.yaml
+++ b/samples/userspace/shared_mem/sample.yaml
@@ -13,3 +13,4 @@ tests:
   sample.kernel.memory_protection.shared_mem:
     filter: CONFIG_ARCH_HAS_USERSPACE
     platform_exclude: twr_ke18f
+    min_flash: 36

--- a/tests/application_development/libcxx/testcase.yaml
+++ b/tests/application_development/libcxx/testcase.yaml
@@ -3,6 +3,7 @@ tests:
     arch_exclude: posix
     platform_exclude: qemu_x86_coverage qemu_x86_64
     tags: cpp
+    min_flash: 72
   misc.app_dev.libcxx.exceptions:
     arch_exclude: posix
     platform_exclude: qemu_x86_coverage qemu_x86_64 96b_meerkat96

--- a/tests/arch/arm/arm_ramfunc/testcase.yaml
+++ b/tests/arch/arm/arm_ramfunc/testcase.yaml
@@ -3,3 +3,4 @@ tests:
     filter: CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
     tags: arm userspace
     arch_whitelist: arm
+    min_flash: 64

--- a/tests/arch/arm/arm_thread_swap/testcase.yaml
+++ b/tests/arch/arm/arm_thread_swap/testcase.yaml
@@ -3,6 +3,7 @@ tests:
     arch_whitelist: arm
     filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     tags: arm
+    min_flash: 64
   arch.arm.swap.common.no_optimizations:
     arch_whitelist: arm
     filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE

--- a/tests/benchmarks/timing_info/testcase.yaml
+++ b/tests/benchmarks/timing_info/testcase.yaml
@@ -11,6 +11,7 @@ tests:
     extra_args: CONF_FILE=prj_userspace.conf
     arch_whitelist: x86 arm arc
     tags: benchmark userspace
+    min_flash: 64
     harness: console
     harness_config:
       record:

--- a/tests/kernel/fatal/testcase.yaml
+++ b/tests/kernel/fatal/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     platform_exclude: twr_ke18f
     filter: CONFIG_ARCH_HAS_STACK_PROTECTION
     tags: kernel ignore_faults userspace
+    min_flash: 48
   kernel.common.stack_protection_no_userspace:
     extra_args: CONF_FILE=protection_no_userspace.conf
     filter: CONFIG_ARCH_HAS_STACK_PROTECTION

--- a/tests/kernel/mem_pool/sys_mem_pool/testcase.yaml
+++ b/tests/kernel/mem_pool/sys_mem_pool/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   kernel.memory_pool:
     min_ram: 32
     tags: kernel userspace mem_pool
+    min_flash: 72

--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -4,3 +4,4 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     platform_exclude: twr_ke18f
     tags: kernel security userspace ignore_faults
+    min_flash: 72

--- a/tests/kernel/mem_protect/obj_validation/testcase.yaml
+++ b/tests/kernel/mem_protect/obj_validation/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   kernel.memory_protection.obj_validation:
     filter: CONFIG_ARCH_HAS_USERSPACE
     tags: kernel security userspace
+    min_flash: 64

--- a/tests/kernel/mem_protect/stackprot/testcase.yaml
+++ b/tests/kernel/mem_protect/stackprot/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   kernel.memory_protection:
     arch_exclude: nios2 xtensa posix x86_64
     tags: kernel ignore_faults userspace
+    min_flash: 64

--- a/tests/kernel/mem_protect/syscalls/testcase.yaml
+++ b/tests/kernel/mem_protect/syscalls/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   kernel.memory_protection.syscalls:
     filter: CONFIG_ARCH_HAS_USERSPACE
     tags: kernel security userspace ignore_faults
+    min_flash: 64

--- a/tests/kernel/msgq/msgq_api/testcase.yaml
+++ b/tests/kernel/msgq/msgq_api/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.message_queue:
     tags: kernel userspace
+    min_flash: 72

--- a/tests/kernel/mutex/mutex_api/testcase.yaml
+++ b/tests/kernel/mutex/mutex_api/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.mutex:
     tags: kernel userspace
+    min_flash: 64

--- a/tests/kernel/mutex/sys_mutex/testcase.yaml
+++ b/tests/kernel/mutex/sys_mutex/testcase.yaml
@@ -3,6 +3,7 @@ tests:
     min_ram: 32
     filter: CONFIG_ARCH_HAS_USERSPACE
     tags: kernel userspace
+    min_flash: 64
   sys.mutex.nouser:
     tags: kernel
     extra_configs:

--- a/tests/kernel/pipe/pipe/testcase.yaml
+++ b/tests/kernel/pipe/pipe/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.pipe:
       tags: kernel userspace ignore_faults
+      min_flash: 72

--- a/tests/kernel/pipe/pipe_api/testcase.yaml
+++ b/tests/kernel/pipe/pipe_api/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.pipe:
       tags: kernel userspace
+      min_flash: 64

--- a/tests/kernel/queue/testcase.yaml
+++ b/tests/kernel/queue/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   kernel.queue:
     tags: kernel userspace
+    min_flash: 64
   kernel.queue.poll:
     extra_args: CONF_FILE="prj_poll.conf"
     tags: kernel userspace
+    min_flash: 64

--- a/tests/kernel/semaphore/sema_api/testcase.yaml
+++ b/tests/kernel/semaphore/sema_api/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.semaphore:
     tags: kernel userspace
+    min_flash: 48

--- a/tests/kernel/semaphore/semaphore/testcase.yaml
+++ b/tests/kernel/semaphore/semaphore/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   kernel.semaphore:
     min_ram: 32
     tags: kernel userspace
+    min_flash: 72

--- a/tests/kernel/sleep/testcase.yaml
+++ b/tests/kernel/sleep/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.common.timing:
     tags: kernel
+    min_flash: 64

--- a/tests/kernel/stack/stack_api/testcase.yaml
+++ b/tests/kernel/stack/stack_api/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.stack:
     tags: kernel userspace
+    min_flash: 64

--- a/tests/kernel/stack/stack_usage/testcase.yaml
+++ b/tests/kernel/stack/stack_usage/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.stack.usage:
     tags: kernel userspace
+    min_flash: 64

--- a/tests/kernel/threads/dynamic_thread/testcase.yaml
+++ b/tests/kernel/threads/dynamic_thread/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   kernel.threads.dynamic:
     tags: kernel threads userspace ignore_faults
     filter: CONFIG_ARCH_HAS_USERSPACE
+    min_flash: 64

--- a/tests/kernel/threads/thread_init/testcase.yaml
+++ b/tests/kernel/threads/thread_init/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.threads:
     tags: kernel threads userspace
+    min_flash: 64

--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -2,6 +2,7 @@ tests:
   kernel.timer:
     tags: kernel userspace
     platform_exclude: qemu_x86_coverage qemu_cortex_m0
+    min_flash: 64
   kernel.timer.tickless:
     build_only: true
     extra_args: CONF_FILE="prj_tickless.conf"

--- a/tests/lib/mem_alloc/testcase.yaml
+++ b/tests/lib/mem_alloc/testcase.yaml
@@ -4,12 +4,14 @@ tests:
     arch_exclude: posix
     platform_exclude: twr_ke18f
     tags: clib minimal_libc userspace
+    min_flash: 64
   libraries.libc.newlib:
     extra_args: CONF_FILE=prj_newlib.conf
     arch_exclude: posix
     platform_exclude: twr_ke18f
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     tags: clib newlib userspace
+    min_flash: 64
   libraries.libc.newlibnano:
     extra_args: CONF_FILE=prj_newlibnano.conf
     toolchain_whitelist: gnuarmemb

--- a/tests/subsys/logging/log_msg/testcase.yaml
+++ b/tests/subsys/logging/log_msg/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   logging.log_msg:
     tags: log_msg logging
+    min_flash: 34


### PR DESCRIPTION
Update min_flash for samples and tests, so that devices with small flash size won't have build error due to code size overflow.