### PR TITLE
scripts: use compatible release specifiers in requirements.txt

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,25 +1,25 @@
 Pillow
 PyYAML>=3.13
-breathe==4.9.1
+breathe>=4.9.1
 colorama
-docutils==0.14
+docutils>=0.14
 gcovr
-git-spindle==2.0
+git-spindle>=2.0
 gitlint
 intelhex
 junit2html
 packaging
-ply==3.10
-pyelftools==0.24
+ply>=3.10
+pyelftools>=0.24
 pykwalify
-pyocd==0.21.0
+pyocd>=0.21.0
 pyserial
 pytest
-sphinx==1.7.5
+sphinx>=1.7.5
 sphinx_rtd_theme
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter
 west>=0.6.2
-wheel==0.30.0
+wheel>=0.30.0
 # "win32" is used for 64-bit Windows as well
 windows-curses; sys_platform == "win32"


### PR DESCRIPTION
Using exact versions for our PyPI dependencies (i.e. requirements.txt
lines that look like "dependency==X.Y.Z") is rude since we're asking
users to install these dependencies outside of any virtual
environment. This causes conflicts with other packages which may
depend on the same things as us.

Use inclusive ordered comparison (>=) release specifiers instead:

https://www.python.org/dev/peps/pep-0440/#inclusive-ordered-comparison

If this causes problems for individual packages, we can refine them
using compatible release specifiers (~=):

https://www.python.org/dev/peps/pep-0440/#compatible-release

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>