### PR TITLE
tests: updated names for the arch interrupt tests

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/testcase.yaml
+++ b/tests/arch/arm/arm_irq_vector_table/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  arch.interrupt:
+  arch.interrupt.arm.irq_vector_table:
     filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     tags: arm interrupt vector_table
     arch_whitelist: arm

--- a/tests/arch/arm/arm_runtime_nmi/testcase.yaml
+++ b/tests/arch/arm/arm_runtime_nmi/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  arch.interrupt:
+  arch.interrupt.arm.nmi:
     arch_whitelist: arm
     tags: nmi interrupt arm

--- a/tests/arch/x86/static_idt/testcase.yaml
+++ b/tests/arch/x86/static_idt/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  arch.interrupt:
+  arch.interrupt.x86:
     arch_whitelist: x86
     platform_exclude: qemu_x86_long
     tags: ignore_faults interrupt idt

--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  arch.interrupt:
+  arch.interrupt.gen_isr_table:
     platform_exclude: nucleo_f103rb olimexino_stm32 stm32_min_dev_black
         stm32_min_dev_blue usb_kw24d512 v2m_beetle
     filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV7_M_ARMV8_M_MAINLINE


### PR DESCRIPTION
Test case arch.interrupt have same test case name
for different architectures. To get rid of it,
I decided to change test cases names.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>