### PR TITLE
[PRELIMINARY] headers: Refactor kernel_structs.h and introduce kernel_arch.h.

### DIFF
--- a/arch/arm/core/cortex_m/fault.c
+++ b/arch/arm/core/cortex_m/fault.c
@@ -11,11 +11,8 @@
  * Common fault handler for ARM Cortex-M processors.
  */
 
-#include <toolchain.h>
-#include <linker/sections.h>
-
 #include <kernel.h>
-#include <kernel_structs.h>
+#include <kernel_arch.h>
 #include <inttypes.h>
 #include <exc_handle.h>
 #include <logging/log.h>

--- a/arch/arm/core/cortex_r/fault.c
+++ b/arch/arm/core/cortex_r/fault.c
@@ -5,7 +5,7 @@
  */
 
 #include <kernel.h>
-#include <kernel_structs.h>
+#include <kernel_arch.h>
 
 /**
  *

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -17,7 +17,7 @@
 #include <inttypes.h>
 
 #include <kernel.h>
-#include <kernel_structs.h>
+#include <kernel_arch.h>
 #include <logging/log.h>
 LOG_MODULE_DECLARE(os);
 

--- a/arch/arm/core/offsets/offsets.c
+++ b/arch/arm/core/offsets/offsets.c
@@ -23,6 +23,8 @@
  */
 
 #include <gen_offset.h>
+#include <kernel.h>
+#include <kernel_arch_data.h>
 #include <kernel_structs.h>
 #include <kernel_offsets.h>
 

--- a/arch/arm/core/swap.c
+++ b/arch/arm/core/swap.c
@@ -6,7 +6,7 @@
 
 #include <kernel.h>
 #include <toolchain.h>
-#include <kernel_structs.h>
+#include <kernel_arch.h>
 
 #ifdef CONFIG_EXECUTION_BENCHMARKING
 extern void read_timer_start_of_swap(void);

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -14,7 +14,7 @@
 
 #include <kernel.h>
 #include <toolchain.h>
-#include <kernel_structs.h>
+#include <kernel_arch.h>
 #include <wait_q.h>
 
 #ifdef CONFIG_USERSPACE

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -22,6 +22,8 @@
 #ifndef ZEPHYR_ARCH_ARM_INCLUDE_KERNEL_ARCH_FUNC_H_
 #define ZEPHYR_ARCH_ARM_INCLUDE_KERNEL_ARCH_FUNC_H_
 
+#include <kernel_arch_data.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/arch/nios2/core/crt0.S
+++ b/arch/nios2/core/crt0.S
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel_structs.h>
+#include <toolchain.h>
+#include <linker/sections.h>
 
 /* exports */
 GTEXT(__start)

--- a/arch/nios2/core/exception.S
+++ b/arch/nios2/core/exception.S
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel_structs.h>
+#include <toolchain.h>
+#include <linker/sections.h>
 #include <offsets_short.h>
 
 /* exports */

--- a/arch/nios2/core/prep_c.c
+++ b/arch/nios2/core/prep_c.c
@@ -16,11 +16,7 @@
  * initialization is performed.
  */
 
-#include <zephyr/types.h>
-#include <toolchain.h>
-#include <linker/linker-defs.h>
-#include <kernel_structs.h>
-#include <kernel_internal.h>
+#include <kernel_arch.h>
 
 /**
  *

--- a/arch/nios2/core/reset.S
+++ b/arch/nios2/core/reset.S
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/cpu.h>
-#include <kernel_structs.h>
+#include <toolchain.h>
 #include <offsets_short.h>
+#include <arch/cpu.h>
 
 GTEXT(__start)
 

--- a/arch/nios2/core/swap.S
+++ b/arch/nios2/core/swap.S
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel_structs.h>
+#include <toolchain.h>
+#include <linker/sections.h>
 #include <offsets_short.h>
 
 /* exports */

--- a/arch/nios2/include/kernel_arch_func.h
+++ b/arch/nios2/include/kernel_arch_func.h
@@ -20,6 +20,8 @@
 #ifndef ZEPHYR_ARCH_NIOS2_INCLUDE_KERNEL_ARCH_FUNC_H_
 #define ZEPHYR_ARCH_NIOS2_INCLUDE_KERNEL_ARCH_FUNC_H_
 
+#include <kernel_arch_data.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/arch/riscv/core/irq_manage.c
+++ b/arch/riscv/core/irq_manage.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <toolchain.h>
-#include <kernel_structs.h>
+#include <kernel.h>
+#include <kernel_arch.h>
 #include <logging/log.h>
 LOG_MODULE_DECLARE(os);
 

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -7,8 +7,8 @@
 
 #include <toolchain.h>
 #include <linker/sections.h>
-#include <kernel_structs.h>
 #include <offsets_short.h>
+#include <arch/cpu.h>
 
 /* imports */
 GDATA(_sw_isr_table)

--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -5,7 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel_structs.h>
+#include <toolchain.h>
+#include <linker/sections.h>
 
 /* exports */
 GTEXT(__initialize)

--- a/arch/riscv/core/swap.S
+++ b/arch/riscv/core/swap.S
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <irq.h>
-#include <kernel_structs.h>
+#include <toolchain.h>
+#include <linker/sections.h>
 #include <offsets_short.h>
+#include <arch/cpu.h>
 
 /* exports */
 GTEXT(z_arch_swap)

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -15,7 +15,7 @@
 #ifndef ZEPHYR_ARCH_RISCV_INCLUDE_KERNEL_ARCH_FUNC_H_
 #define ZEPHYR_ARCH_RISCV_INCLUDE_KERNEL_ARCH_FUNC_H_
 
-#include <soc.h>
+#include <kernel_arch_data.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/x86/core/ia32/cache_s.S
+++ b/arch/x86/core/ia32/cache_s.S
@@ -10,6 +10,8 @@
  * This module contains functions for manipulating caches.
  */
 
+#include <toolchain.h>
+#include <linker/sections.h>
 #include <arch/x86/ia32/asm.h>
 
 #ifndef CONFIG_CLFLUSH_INSTRUCTION_SUPPORTED

--- a/arch/x86/core/ia32/crt0.S
+++ b/arch/x86/core/ia32/crt0.S
@@ -11,6 +11,8 @@
  * after having been loaded into RAM.
  */
 
+#include <toolchain.h>
+#include <linker/sections.h>
 #include <arch/x86/ia32/asm.h>
 #include <arch/x86/msr.h>
 #include <kernel_arch_data.h>

--- a/arch/x86/core/ia32/excstub.S
+++ b/arch/x86/core/ia32/excstub.S
@@ -14,10 +14,11 @@
  * and exiting a C exception handler.
  */
 
-#include <kernel_structs.h>
+#include <toolchain.h>
+#include <linker/sections.h>
+#include <offsets_short.h>
 #include <arch/x86/ia32/asm.h>
 #include <arch/x86/ia32/arch.h> /* For MK_ISR_NAME */
-#include <offsets_short.h>
 
 
 	/* exports (internal APIs) */

--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -13,7 +13,7 @@
 #include <linker/sections.h>
 
 #include <kernel.h>
-#include <kernel_structs.h>
+#include <kernel_arch.h>
 #include <drivers/interrupt_controller/sysapic.h>
 #include <arch/x86/ia32/segmentation.h>
 #include <ia32/exception.h>

--- a/arch/x86/core/ia32/float.c
+++ b/arch/x86/core/ia32/float.c
@@ -43,8 +43,7 @@
  * to enable FP register sharing on its behalf.
  */
 
-#include <kernel_structs.h>
-#include <toolchain.h>
+#include <kernel_arch.h>
 
 /* SSE control/status register default value (used by assembler code) */
 extern u32_t _sse_mxcsr_default_value;

--- a/arch/x86/core/ia32/intstub.S
+++ b/arch/x86/core/ia32/intstub.S
@@ -14,9 +14,10 @@
  * entering and exiting a C interrupt handler.
  */
 
-#include <kernel_structs.h>
-#include <arch/x86/ia32/asm.h>
+#include <toolchain.h>
+#include <linker/sections.h>
 #include <offsets_short.h>
+#include <arch/x86/ia32/asm.h>
 #include <arch/cpu.h>
 #include <drivers/interrupt_controller/sysapic.h>
 

--- a/arch/x86/core/ia32/swap.S
+++ b/arch/x86/core/ia32/swap.S
@@ -11,9 +11,12 @@
  * This module implements the z_arch_swap() routine for the IA-32 architecture.
  */
 
-#include <kernel_structs.h>
-#include <arch/x86/ia32/asm.h>
+#include <toolchain.h>
+#include <linker/sections.h>
 #include <offsets_short.h>
+#include <kernel.h>
+#include <kernel_arch_data.h>
+#include <arch/x86/ia32/asm.h>
 
 	/* exports (internal APIs) */
 

--- a/arch/x86/core/ia32/userspace.S
+++ b/arch/x86/core/ia32/userspace.S
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel_structs.h>
+#include <toolchain.h>
+#include <linker/sections.h>
+#include <offsets_short.h>
 #include <arch/x86/ia32/asm.h>
 #include <arch/cpu.h>
-#include <offsets_short.h>
 #include <syscall.h>
 
 /* Exports */

--- a/arch/x86/core/ia32/x86_mmu.c
+++ b/arch/x86/core/ia32/x86_mmu.c
@@ -8,7 +8,7 @@
 #include <arch/x86/mmustructs.h>
 #include <linker/linker-defs.h>
 #include <kernel_internal.h>
-#include <kernel_structs.h>
+#include <kernel_arch.h>
 #include <init.h>
 #include <ctype.h>
 #include <string.h>

--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel_structs.h>
+#include <kernel_arch.h>
 #include <arch/x86/acpi.h>
 #include <arch/x86/multiboot.h>
 

--- a/arch/x86/include/ia32/kernel_arch_func.h
+++ b/arch/x86/include/ia32/kernel_arch_func.h
@@ -12,7 +12,7 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <stddef.h> /* For size_t */
+#include <kernel_arch_data.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/x86/include/intel64/kernel_arch_func.h
+++ b/arch/x86/include/intel64/kernel_arch_func.h
@@ -6,7 +6,7 @@
 #ifndef ZEPHYR_ARCH_X86_INCLUDE_INTEL64_KERNEL_ARCH_FUNC_H_
 #define ZEPHYR_ARCH_X86_INCLUDE_INTEL64_KERNEL_ARCH_FUNC_H_
 
-#include <kernel_structs.h>
+#include <kernel_arch_data.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/arch/xtensa/core/offsets/offsets.c
+++ b/arch/xtensa/core/offsets/offsets.c
@@ -27,8 +27,8 @@
 
 /* list of headers that define whose structure offsets will be generated */
 
+#include <kernel_arch_data.h>
 #include <kernel_structs.h>
-
 #include <kernel_offsets.h>
 
 /* Xtensa-specific k_thread structure member offsets */

--- a/include/arch/arm/irq.h
+++ b/include/arch/arm/irq.h
@@ -14,6 +14,7 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_IRQ_H_
 #define ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_IRQ_H_
 
+#include <kernel_structs.h>
 #include <irq.h>
 #include <sw_isr_table.h>
 #include <stdbool.h>

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -110,7 +110,7 @@ static inline int sys_mutex_unlock(struct sys_mutex *mutex)
 
 #else
 #include <kernel.h>
-#include <kernel_structs.h>
+#include <kernel_arch.h>
 
 struct sys_mutex {
 	struct k_mutex kernel_mutex;

--- a/kernel/errno.c
+++ b/kernel/errno.c
@@ -12,8 +12,8 @@
  * context switching.
  */
 
-#include <kernel_structs.h>
-#include <syscall_handler.h>
+#include <kernel.h>
+#include <kernel_arch.h>
 
 /*
  * Define _k_neg_eagain for use in assembly files as errno.h is

--- a/kernel/include/kernel_arch.h
+++ b/kernel/include/kernel_arch.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2016 Wind River Systems, Inc.
+ * Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_KERNEL_INCLUDE_KERNEL_ARCH_H_
+#define ZEPHYR_KERNEL_INCLUDE_KERNEL_ARCH_H_
+
+#if !defined(_ASMLANGUAGE)
+
+#include <string.h>
+#include <sys/arch_interface.h>
+
+#include <kernel_structs.h>
+#include <kernel_arch_func.h>
+
+#ifdef CONFIG_USE_SWITCH
+/* This is a arch function traditionally, but when the switch-based
+ * z_swap() is in use it's a simple inline provided by the kernel.
+ */
+static ALWAYS_INLINE void
+z_arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
+{
+	thread->swap_retval = value;
+}
+#endif
+
+static ALWAYS_INLINE void
+z_thread_return_value_set_with_data(struct k_thread *thread,
+				   unsigned int value,
+				   void *data)
+{
+	z_arch_thread_return_value_set(thread, value);
+	thread->base.swap_data = data;
+}
+
+extern void z_init_thread_base(struct _thread_base *thread_base,
+			      int priority, u32_t initial_state,
+			      unsigned int options);
+
+static ALWAYS_INLINE void z_new_thread_init(struct k_thread *thread,
+					    char *pStack, size_t stackSize,
+					    int prio, unsigned int options)
+{
+#if !defined(CONFIG_INIT_STACKS) && !defined(CONFIG_THREAD_STACK_INFO)
+	ARG_UNUSED(pStack);
+	ARG_UNUSED(stackSize);
+#endif
+
+#ifdef CONFIG_INIT_STACKS
+	memset(pStack, 0xaa, stackSize);
+#endif
+#ifdef CONFIG_STACK_SENTINEL
+	/* Put the stack sentinel at the lowest 4 bytes of the stack area.
+	 * We periodically check that it's still present and kill the thread
+	 * if it isn't.
+	 */
+	*((u32_t *)pStack) = STACK_SENTINEL;
+#endif /* CONFIG_STACK_SENTINEL */
+	/* Initialize various struct k_thread members */
+	z_init_thread_base(&thread->base, prio, _THREAD_PRESTART, options);
+
+	/* static threads overwrite it afterwards with real value */
+	thread->init_data = NULL;
+	thread->fn_abort = NULL;
+
+#ifdef CONFIG_THREAD_CUSTOM_DATA
+	/* Initialize custom data field (value is opaque to kernel) */
+	thread->custom_data = NULL;
+#endif
+
+#ifdef CONFIG_THREAD_NAME
+	thread->name[0] = '\0';
+#endif
+
+#if defined(CONFIG_USERSPACE)
+	thread->mem_domain_info.mem_domain = NULL;
+#endif /* CONFIG_USERSPACE */
+
+#if defined(CONFIG_THREAD_STACK_INFO)
+	thread->stack_info.start = (uintptr_t)pStack;
+	thread->stack_info.size = (u32_t)stackSize;
+#endif /* CONFIG_THREAD_STACK_INFO */
+}
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_KERNEL_INCLUDE_KERNEL_ARCH_H_ */

--- a/kernel/include/kernel_structs.h
+++ b/kernel/include/kernel_structs.h
@@ -7,15 +7,12 @@
 #ifndef ZEPHYR_KERNEL_INCLUDE_KERNEL_STRUCTS_H_
 #define ZEPHYR_KERNEL_INCLUDE_KERNEL_STRUCTS_H_
 
-#include <kernel.h>
-
 #if !defined(_ASMLANGUAGE)
-#include <sys/atomic.h>
+#include <zephyr/types.h>
+#include <sched_priq.h>
 #include <sys/dlist.h>
-#include <sys/rb.h>
+#include <sys/slist.h>
 #include <sys/util.h>
-#include <string.h>
-#include <sys/arch_interface.h>
 #endif
 
 #define K_NUM_PRIORITIES \
@@ -66,9 +63,9 @@
 /* highest value of _thread_base.preempt at which a thread is preemptible */
 #define _PREEMPT_THRESHOLD (_NON_PREEMPT_THRESHOLD - 1)
 
-#include <kernel_arch_data.h>
-
 #if !defined(_ASMLANGUAGE)
+
+struct k_thread;
 
 struct _ready_q {
 #ifndef CONFIG_SMP
@@ -180,6 +177,8 @@ typedef struct z_kernel _kernel_t;
 extern struct z_kernel _kernel;
 
 #ifdef CONFIG_SMP
+static inline struct _cpu *z_arch_curr_cpu(void);
+
 #define _current_cpu (z_arch_curr_cpu())
 #define _current (z_arch_curr_cpu()->current)
 #else
@@ -189,77 +188,6 @@ extern struct z_kernel _kernel;
 
 #define _timeout_q _kernel.timeout_q
 
-#include <kernel_arch_func.h>
-
-#ifdef CONFIG_USE_SWITCH
-/* This is a arch function traditionally, but when the switch-based
- * z_swap() is in use it's a simple inline provided by the kernel.
- */
-static ALWAYS_INLINE void
-z_arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
-{
-	thread->swap_retval = value;
-}
-#endif
-
-static ALWAYS_INLINE void
-z_thread_return_value_set_with_data(struct k_thread *thread,
-				   unsigned int value,
-				   void *data)
-{
-	z_arch_thread_return_value_set(thread, value);
-	thread->base.swap_data = data;
-}
-
-extern void z_init_thread_base(struct _thread_base *thread_base,
-			      int priority, u32_t initial_state,
-			      unsigned int options);
-
-static ALWAYS_INLINE void z_new_thread_init(struct k_thread *thread,
-					    char *pStack, size_t stackSize,
-					    int prio, unsigned int options)
-{
-#if !defined(CONFIG_INIT_STACKS) && !defined(CONFIG_THREAD_STACK_INFO)
-	ARG_UNUSED(pStack);
-	ARG_UNUSED(stackSize);
-#endif
-
-#ifdef CONFIG_INIT_STACKS
-	memset(pStack, 0xaa, stackSize);
-#endif
-#ifdef CONFIG_STACK_SENTINEL
-	/* Put the stack sentinel at the lowest 4 bytes of the stack area.
-	 * We periodically check that it's still present and kill the thread
-	 * if it isn't.
-	 */
-	*((u32_t *)pStack) = STACK_SENTINEL;
-#endif /* CONFIG_STACK_SENTINEL */
-	/* Initialize various struct k_thread members */
-	z_init_thread_base(&thread->base, prio, _THREAD_PRESTART, options);
-
-	/* static threads overwrite it afterwards with real value */
-	thread->init_data = NULL;
-	thread->fn_abort = NULL;
-
-#ifdef CONFIG_THREAD_CUSTOM_DATA
-	/* Initialize custom data field (value is opaque to kernel) */
-	thread->custom_data = NULL;
-#endif
-
-#ifdef CONFIG_THREAD_NAME
-	thread->name[0] = '\0';
-#endif
-
-#if defined(CONFIG_USERSPACE)
-	thread->mem_domain_info.mem_domain = NULL;
-#endif /* CONFIG_USERSPACE */
-
-#if defined(CONFIG_THREAD_STACK_INFO)
-	thread->stack_info.start = (uintptr_t)pStack;
-	thread->stack_info.size = (u32_t)stackSize;
-#endif /* CONFIG_THREAD_STACK_INFO */
-}
-
-#endif /* _ASMLANGUAGE */
+#endif /* !_ASMLANGUAGE */
 
 #endif /* ZEPHYR_KERNEL_INCLUDE_KERNEL_STRUCTS_H_ */

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_KERNEL_INCLUDE_KSCHED_H_
 #define ZEPHYR_KERNEL_INCLUDE_KSCHED_H_
 
-#include <kernel_structs.h>
+#include <kernel_arch.h>
 #include <kernel_internal.h>
 #include <timeout_q.h>
 #include <debug/tracing.h>

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -17,7 +17,7 @@
 #include <linker/sections.h>
 
 #include <spinlock.h>
-#include <kernel_structs.h>
+#include <sys/arch_interface.h>
 #include <sys/math_extras.h>
 #include <sys_clock.h>
 #include <drivers/timer/system_timer.h>
@@ -29,6 +29,7 @@
 #include <kswap.h>
 #include <init.h>
 #include <debug/tracing.h>
+#include <string.h>
 #include <stdbool.h>
 
 static struct k_spinlock lock;

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -11,6 +11,7 @@
  * Workqueue support functions
  */
 
+#include <kernel.h>
 #include <kernel_structs.h>
 #include <wait_q.h>
 #include <spinlock.h>

--- a/subsys/debug/openocd.c
+++ b/subsys/debug/openocd.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel_structs.h>
+#include <kernel_arch.h>
 
 #define OPENOCD_UNIMPLEMENTED	0xffffffff
 

--- a/tests/arch/x86/static_idt/src/main.c
+++ b/tests/arch/x86/static_idt/src/main.c
@@ -14,6 +14,7 @@
 #include <zephyr.h>
 #include <ztest.h>
 #include <tc_util.h>
+#include <kernel_arch.h>
 #include <arch/x86/ia32/segmentation.h>
 
 #include <kernel_structs.h>

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -21,7 +21,7 @@
  */
 
 #include <ztest.h>
-#include <kernel_structs.h>
+#include <kernel_arch.h>
 #include <arch/cpu.h>
 #include <irq_offload.h>
 #include <sys_clock.h>


### PR DESCRIPTION
This commit refactors kernel_structs.h to be more truthful to its name
(i.e. define kernel structures only), and introduces kernel_arch.h to
provide the definitions that are not kernel structure related and were
previously provided by kernel_structs.h.

In addition, this commit updates all required inclusions of
kernel_structs.h to use kernel_arch.h instead and makes the necessary
adjustments to resolve header dependencies.

**The primary reason for refactoring kernel_structs.h is to remove its
dependency on kernel.h so that the kernel structure definitions
provided by it can be used in arch headers (for instance, in
include/arch/arm/irq.h). This was not possible until now due to a
circular dependency of these headers as described in the issue #3056.**

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

This fixes #3056.