### PR TITLE
tests/posix/common: Fix miscalibrated timing test

### DIFF
--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -112,7 +112,7 @@ void test_posix_realtime(void)
 		 * downward
 		 */
 		zassert_true(error >= 90, "Clock inaccurate %d", error);
-		zassert_true(error < 110, "Clock inaccurate %d", error);
+		zassert_true(error <= 110, "Clock inaccurate %d", error);
 
 		last_delta = delta;
 	}


### PR DESCRIPTION
This test seems a little confused.
Adjust the calibration to allow 110ms sleeps to avoid error
during automated testing.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>