### PR TITLE
doc: include flash page layout API

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1978,6 +1978,7 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "CONFIG_BT_SMP=y" \
                          "CONFIG_USERSPACE=y" \
                          "CONFIG_BT_BREDR=y" \
+                         "CONFIG_FLASH_PAGE_LAYOUT=y" \
                          "NET_MGMT_DEFINE_REQUEST_HANDLER(x)=" \
                          "DEVICE_DEFINE()=" \
                          "DEVICE_AND_API_INIT()=" \


### PR DESCRIPTION
Flash page layout API was omitted by documentation as it
is optional.
Added tag which turn it on to doxygen setup which allows
to include missing API documentation.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>