### PR TITLE
usb: sam0: Add support for SAME54

### DIFF
--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -166,6 +166,14 @@ static void usb_sam0_load_padcal(void)
 	regs->PADCAL.bit.TRIM = pad_trim;
 }
 
+#define SAM0_USB_IRQ_CONNECT(n) 				\
+	do {							\
+	IRQ_CONNECT(DT_INST_0_ATMEL_SAM0_USB_IRQ_##n,		\
+		    DT_INST_0_ATMEL_SAM0_USB_IRQ_##n##_PRIORITY,\
+		    usb_sam0_isr, 0, 0);			\
+	irq_enable(DT_INST_0_ATMEL_SAM0_USB_IRQ_##n);		\
+	} while (0)
+
 /* Attach by initializing the device */
 int usb_dc_attach(void)
 {
@@ -203,10 +211,18 @@ int usb_dc_attach(void)
 	regs->INTENSET.reg = USB_DEVICE_INTENSET_EORST;
 
 	/* Connect and enable the interrupt */
-	IRQ_CONNECT(DT_INST_0_ATMEL_SAM0_USB_IRQ_0,
-		    DT_INST_0_ATMEL_SAM0_USB_IRQ_0_PRIORITY,
-		    usb_sam0_isr, 0, 0);
-	irq_enable(DT_INST_0_ATMEL_SAM0_USB_IRQ_0);
+#ifdef DT_INST_0_ATMEL_SAM0_USB_IRQ_0
+	SAM0_USB_IRQ_CONNECT(0);
+#endif
+#ifdef DT_INST_0_ATMEL_SAM0_USB_IRQ_1
+	SAM0_USB_IRQ_CONNECT(1);
+#endif
+#ifdef DT_INST_0_ATMEL_SAM0_USB_IRQ_2
+	SAM0_USB_IRQ_CONNECT(2);
+#endif
+#ifdef DT_INST_0_ATMEL_SAM0_USB_IRQ_3
+	SAM0_USB_IRQ_CONNECT(3);
+#endif
 
 	/* Enable and attach */
 	regs->CTRLA.bit.ENABLE = 1;

--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -180,6 +180,17 @@ int usb_dc_attach(void)
 	UsbDevice *regs = &REGS->DEVICE;
 	struct usb_sam0_data *data = usb_sam0_get_data();
 
+#ifdef MCLK
+	/* Enable the clock in MCLK */
+	MCLK->APBBMASK.bit.USB_ = 1;
+
+	/* Enable the GCLK - use 48 MHz source */
+	GCLK->PCHCTRL[USB_GCLK_ID].reg = GCLK_PCHCTRL_GEN(2)
+				       | GCLK_PCHCTRL_CHEN;
+
+	while (GCLK->SYNCBUSY.reg) {
+	}
+#else
 	/* Enable the clock in PM */
 	PM->APBBMASK.bit.USB_ = 1;
 
@@ -189,6 +200,7 @@ int usb_dc_attach(void)
 
 	while (GCLK->STATUS.bit.SYNCBUSY) {
 	}
+#endif /* !MCLK */
 
 	/* Configure */
 	regs->CTRLA.bit.SWRST = 1;

--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -132,6 +132,9 @@ static void usb_sam0_load_padcal(void)
 	u32_t pad_transp;
 	u32_t pad_trim;
 
+#ifdef USB_FUSES_TRANSN_ADDR
+	pad_transn = *(uint32_t *)USB_FUSES_TRANSN_ADDR;
+#else
 	pad_transn = (*((uint32_t *)(NVMCTRL_OTP4) +
 			(NVM_USB_PAD_TRANSN_POS / 32)) >>
 		      (NVM_USB_PAD_TRANSN_POS % 32)) &
@@ -140,9 +143,13 @@ static void usb_sam0_load_padcal(void)
 	if (pad_transn == 0x1F) {
 		pad_transn = 5U;
 	}
+#endif
 
 	regs->PADCAL.bit.TRANSN = pad_transn;
 
+#ifdef USB_FUSES_TRANSP_ADDR
+	pad_transp = *(uint32_t *)USB_FUSES_TRANSP_ADDR;
+#else
 	pad_transp = (*((uint32_t *)(NVMCTRL_OTP4) +
 			(NVM_USB_PAD_TRANSP_POS / 32)) >>
 		      (NVM_USB_PAD_TRANSP_POS % 32)) &
@@ -151,9 +158,13 @@ static void usb_sam0_load_padcal(void)
 	if (pad_transp == 0x1F) {
 		pad_transp = 29U;
 	}
+#endif
 
 	regs->PADCAL.bit.TRANSP = pad_transp;
 
+#ifdef USB_FUSES_TRIM_ADDR
+	pad_trim = *(uint32_t *)USB_FUSES_TRIM_ADDR;
+#else
 	pad_trim = (*((uint32_t *)(NVMCTRL_OTP4) +
 		      (NVM_USB_PAD_TRIM_POS / 32)) >>
 		    (NVM_USB_PAD_TRIM_POS % 32)) &
@@ -162,6 +173,7 @@ static void usb_sam0_load_padcal(void)
 	if (pad_trim == 0x7) {
 		pad_trim = 3U;
 	}
+#endif
 
 	regs->PADCAL.bit.TRIM = pad_trim;
 }


### PR DESCRIPTION
The USB peripheral is the same as in previous SAM0 MCUs, but the clock setup is different.

split off from #14685