### PR TITLE
drivers: dma: sam0: fix DMA to peripheral transfer on SAMD5x

### DIFF
--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -149,7 +149,7 @@ static int dma_sam0_config(struct device *dev, u32_t channel,
 				     DMAC_CHCTRLA_TRIGSRC(config->dma_slot);
 	} else {
 		/* One peripheral trigger per beat */
-		chcfg->CHCTRLA.reg = DMAC_CHCTRLA_TRIGACT_BURST |
+		chcfg->CHCTRLA.reg = DMAC_CHCTRLA_TRIGACT_BLOCK |
 				     DMAC_CHCTRLA_TRIGSRC(config->dma_slot);
 	}
 
@@ -160,22 +160,6 @@ static int dma_sam0_config(struct device *dev, u32_t channel,
 	}
 
 	chcfg->CHPRILVL.bit.PRILVL = config->channel_priority;
-
-	/* Set the burst length */
-	if (config->source_burst_length != config->dest_burst_length) {
-		LOG_ERR("Source and destination burst lengths must be equal");
-		goto inval;
-	}
-
-	if (config->source_burst_length > 16U) {
-		LOG_ERR("Invalid burst length");
-		goto inval;
-	}
-
-	if (config->source_burst_length > 0U) {
-		chcfg->CHCTRLA.reg |= DMAC_CHCTRLA_BURSTLEN(
-			config->source_burst_length - 1U);
-	}
 
 	/* Enable the interrupts */
 	chcfg->CHINTENSET.reg = DMAC_CHINTENSET_TCMPL;


### PR DESCRIPTION
@Sizurka already prepared the driver for this platform (the `!DMAC_CHID_ID` case), but we need to select `TRIGACT_BLOCK` for DMA to peripheral to work.
With this, we don't need to set the burst length.

split off from #14685