### PR TITLE
gpio: sam0: Add support for SAME54

### DIFF
--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -291,3 +291,21 @@ DEVICE_AND_API_INIT(gpio_sam0_2, DT_ATMEL_SAM0_GPIO_PORT_C_LABEL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &gpio_sam0_api);
 #endif
+
+/* Port D */
+#if DT_ATMEL_SAM0_GPIO_PORT_D_BASE_ADDRESS
+
+static const struct gpio_sam0_config gpio_sam0_config_3 = {
+	.regs = (PortGroup *)DT_ATMEL_SAM0_GPIO_PORT_D_BASE_ADDRESS,
+#ifdef CONFIG_SAM0_EIC
+	.id = 3,
+#endif
+};
+
+static struct gpio_sam0_data gpio_sam0_data_3;
+
+DEVICE_AND_API_INIT(gpio_sam0_3, DT_ATMEL_SAM0_GPIO_PORT_D_LABEL,
+		    gpio_sam0_init, &gpio_sam0_data_3, &gpio_sam0_config_3,
+		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    &gpio_sam0_api);
+#endif

--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -12,6 +12,10 @@
 
 #include "gpio_utils.h"
 
+#ifndef PORT_PMUX_PMUXE_A_Val
+#define PORT_PMUX_PMUXE_A_Val (0)
+#endif
+
 struct gpio_sam0_config {
 	PortGroup *regs;
 #ifdef CONFIG_SAM0_EIC

--- a/drivers/pinmux/pinmux_sam0.c
+++ b/drivers/pinmux/pinmux_sam0.c
@@ -101,3 +101,14 @@ DEVICE_AND_API_INIT(pinmux_sam0_2, DT_ATMEL_SAM0_PINMUX_PINMUX_C_LABEL,
 		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
 		    &pinmux_sam0_api);
 #endif
+
+#if DT_ATMEL_SAM0_PINMUX_PINMUX_D_BASE_ADDRESS
+static const struct pinmux_sam0_config pinmux_sam0_config_3 = {
+	.regs = (PortGroup *)DT_ATMEL_SAM0_PINMUX_PINMUX_D_BASE_ADDRESS,
+};
+
+DEVICE_AND_API_INIT(pinmux_sam0_3, DT_ATMEL_SAM0_PINMUX_PINMUX_D_LABEL,
+		    pinmux_sam0_init, NULL, &pinmux_sam0_config_3,
+		    PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY,
+		    &pinmux_sam0_api);
+#endif


### PR DESCRIPTION
The GPIO driver itself doesn't need any adjustments to work on SAME54, but the platform sports an additional port.

 The interrupt controller requires small adjustments in the clock setup.

split off from #14685