### PR TITLE
sanitycheck: fix --board-root parser to enable multiple path args

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3243,7 +3243,7 @@ Artificially long but functional example:
                        "%s/scripts/sanity_chk/boards" % ZEPHYR_BASE]
 
     parser.add_argument(
-        "-A", "--board-root", default=board_root_list,
+        "-A", "--board-root", action="append", default=board_root_list,
         help="""Directory to search for board configuration files. All .yaml
 files in the directory will be processed. The directory should have the same
 structure in the main Zephyr tree: boards/<arch>/<board_name>/""")


### PR DESCRIPTION
accidently? removed during sanitycheck refactor

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>