### PR TITLE
MCP2515 improve performance

### DIFF
--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -139,6 +139,43 @@ static int mcp2515_cmd_read_reg(struct device *dev, u8_t reg_addr,
 			      &tx, &rx);
 }
 
+/*
+ * Read RX Buffer instruction
+ *
+ * When reading a receive buffer, reduces the overhead of a normal READ
+ * command by placing the Address Pointer at one of four locations selected by
+ * parameter nm:
+ *   0: Receive Buffer 0, Start at RXB0SIDH (0x61)
+ *   1: Receive Buffer 0, Start at RXB0D0 (0x66)
+ *   2: Receive Buffer 1, Start at RXB1SIDH (0x71)
+ *   3: Receive Buffer 1, Start at RXB1D0 (0x76)
+ */
+static int mcp2515_cmd_read_rx_buffer(struct device *dev, u8_t nm,
+				u8_t *buf_data, u8_t buf_len)
+{
+	__ASSERT(nm <= 0x03, "nm <= 0x03");
+
+	u8_t cmd_buf[] = { MCP2515_OPCODE_READ_RX_BUFFER | (nm << 1) };
+
+	struct spi_buf tx_buf[] = {
+		{ .buf = cmd_buf, .len = sizeof(cmd_buf) },
+		{ .buf = NULL, .len = buf_len }
+	};
+	const struct spi_buf_set tx = {
+		.buffers = tx_buf, .count = ARRAY_SIZE(tx_buf)
+	};
+	struct spi_buf rx_buf[] = {
+		{ .buf = NULL, .len = sizeof(cmd_buf) },
+		{ .buf = buf_data, .len = buf_len }
+	};
+	const struct spi_buf_set rx = {
+		.buffers = rx_buf, .count = ARRAY_SIZE(rx_buf)
+	};
+
+	return spi_transceive(DEV_DATA(dev)->spi, &DEV_DATA(dev)->spi_cfg,
+			      &tx, &rx);
+}
+
 static u8_t mcp2515_convert_canmode_to_mcp2515mode(enum can_mode mode)
 {
 	switch (mode) {
@@ -499,15 +536,17 @@ static void mcp2515_rx_filter(struct device *dev, struct zcan_frame *msg)
 
 static void mcp2515_rx(struct device *dev, u8_t rx_idx)
 {
+	__ASSERT(rx_idx < MCP2515_RX_CNT, "rx_idx < MCP2515_RX_CNT");
+
 	struct zcan_frame msg;
 	u8_t rx_frame[MCP2515_FRAME_LEN];
-	u8_t addr_rx_ctrl = MCP2515_ADDR_RXB0CTRL +
-			    (rx_idx * MCP2515_ADDR_OFFSET_FRAME2FRAME);
+	u8_t nm;
+
+	/* Address Pointer selection */
+	nm = 2 * rx_idx;
 
 	/* Fetch rx buffer */
-	mcp2515_cmd_read_reg(dev,
-			     addr_rx_ctrl + MCP2515_ADDR_OFFSET_CTRL2FRAME,
-			     rx_frame, sizeof(rx_frame));
+	mcp2515_cmd_read_rx_buffer(dev, nm, rx_frame, sizeof(rx_frame));
 	mcp2515_convert_mcp2515frame_to_zcanframe(rx_frame, &msg);
 	mcp2515_rx_filter(dev, &msg);
 }
@@ -611,10 +650,16 @@ static void mcp2515_handle_interrupts(struct device *dev)
 
 		if (canintf & MCP2515_CANINTF_RX0IF) {
 			mcp2515_rx(dev, 0);
+
+			/* RX0IF flag cleared automatically during read */
+			canintf &= ~MCP2515_CANINTF_RX0IF;
 		}
 
 		if (canintf & MCP2515_CANINTF_RX1IF) {
 			mcp2515_rx(dev, 1);
+
+			/* RX1IF flag cleared automatically during read */
+			canintf &= ~MCP2515_CANINTF_RX1IF;
 		}
 
 		if (canintf & MCP2515_CANINTF_TX0IF) {
@@ -633,9 +678,11 @@ static void mcp2515_handle_interrupts(struct device *dev)
 			mcp2515_handle_errors(dev);
 		}
 
-		/* clear the flags we handled */
-		mcp2515_cmd_bit_modify(dev, MCP2515_ADDR_CANINTF, canintf,
-				       ~canintf);
+		if (canintf != 0) {
+			/* Clear remaining flags */
+			mcp2515_cmd_bit_modify(dev, MCP2515_ADDR_CANINTF,
+					canintf, ~canintf);
+		}
 
 		/* Break from loop if INT pin is no longer low */
 		ret = gpio_pin_read(dev_data->int_gpio, dev_cfg->int_pin, &pin);

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -92,6 +92,29 @@ static int mcp2515_cmd_load_tx_buffer(struct device *dev, u8_t abc,
 	return spi_write(DEV_DATA(dev)->spi, &DEV_DATA(dev)->spi_cfg, &tx);
 }
 
+/*
+ * Request-to-Send Instruction
+ *
+ * Parameter nnn is the combination of bits at positions 0, 1 and 2 in the RTS
+ * opcode that respectively initiate transmission for buffers TXB0, TXB1 and
+ * TXB2.
+ */
+static int mcp2515_cmd_rts(struct device *dev, u8_t nnn)
+{
+	__ASSERT(nnn < BIT(MCP2515_TX_CNT), "nnn < BIT(MCP2515_TX_CNT)");
+
+	u8_t cmd_buf[] = { MCP2515_OPCODE_RTS | nnn };
+
+	struct spi_buf tx_buf[] = {
+		{ .buf = cmd_buf, .len = sizeof(cmd_buf) }
+	};
+	const struct spi_buf_set tx = {
+		.buffers = tx_buf, .count = ARRAY_SIZE(tx_buf)
+	};
+
+	return spi_write(DEV_DATA(dev)->spi, &DEV_DATA(dev)->spi_cfg, &tx);
+}
+
 static int mcp2515_cmd_read_reg(struct device *dev, u8_t reg_addr,
 				u8_t *buf_data, u8_t buf_len)
 {
@@ -325,7 +348,7 @@ static int mcp2515_send(struct device *dev, const struct zcan_frame *msg,
 	struct mcp2515_data *dev_data = DEV_DATA(dev);
 	u8_t tx_idx = 0U;
 	u8_t abc;
-	u8_t addr_tx_ctrl;
+	u8_t nnn;
 	u8_t tx_frame[MCP2515_FRAME_LEN];
 
 	if (k_sem_take(&dev_data->tx_sem, timeout) != 0) {
@@ -352,9 +375,6 @@ static int mcp2515_send(struct device *dev, const struct zcan_frame *msg,
 	dev_data->tx_cb[tx_idx].cb = callback;
 	dev_data->tx_cb[tx_idx].cb_arg = callback_arg;
 
-	addr_tx_ctrl = MCP2515_ADDR_TXB0CTRL +
-		       (tx_idx * MCP2515_ADDR_OFFSET_FRAME2FRAME);
-
 	mcp2515_convert_zcanframe_to_mcp2515frame(msg, tx_frame);
 
 	/* Address Pointer selection */
@@ -363,8 +383,8 @@ static int mcp2515_send(struct device *dev, const struct zcan_frame *msg,
 	mcp2515_cmd_load_tx_buffer(dev, abc, tx_frame, sizeof(tx_frame));
 
 	/* request tx slot transmission */
-	mcp2515_cmd_bit_modify(dev, addr_tx_ctrl, MCP2515_TXCTRL_TXREQ,
-			       MCP2515_TXCTRL_TXREQ);
+	nnn = BIT(tx_idx);
+	mcp2515_cmd_rts(dev, nnn);
 
 	if (callback == NULL) {
 		k_sem_take(&dev_data->tx_cb[tx_idx].sem, K_FOREVER);

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -10,6 +10,7 @@
 
 #include <drivers/can.h>
 
+#define MCP2515_RX_CNT                   2
 #define MCP2515_TX_CNT                   3
 #define MCP2515_FRAME_LEN               13
 
@@ -84,6 +85,7 @@ struct mcp2515_config {
 #define MCP2515_OPCODE_BIT_MODIFY       0x05
 #define MCP2515_OPCODE_LOAD_TX_BUFFER   0x40
 #define MCP2515_OPCODE_RTS              0x80
+#define MCP2515_OPCODE_READ_RX_BUFFER   0x90
 #define MCP2515_OPCODE_READ_STATUS      0xA0
 #define MCP2515_OPCODE_RESET            0xC0
 

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -83,6 +83,7 @@ struct mcp2515_config {
 #define MCP2515_OPCODE_READ             0x03
 #define MCP2515_OPCODE_BIT_MODIFY       0x05
 #define MCP2515_OPCODE_LOAD_TX_BUFFER   0x40
+#define MCP2515_OPCODE_RTS              0x80
 #define MCP2515_OPCODE_READ_STATUS      0xA0
 #define MCP2515_OPCODE_RESET            0xC0
 

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -82,6 +82,7 @@ struct mcp2515_config {
 #define MCP2515_OPCODE_WRITE            0x02
 #define MCP2515_OPCODE_READ             0x03
 #define MCP2515_OPCODE_BIT_MODIFY       0x05
+#define MCP2515_OPCODE_LOAD_TX_BUFFER   0x40
 #define MCP2515_OPCODE_READ_STATUS      0xA0
 #define MCP2515_OPCODE_RESET            0xC0
 


### PR DESCRIPTION
Adds and uses specialized MCP2515 SPI instructions to improve driver performance:

1. **READ RX BUFFER** - One less SPI byte required (than general read instruction) and automatically clears corresponding interrupt flag,
2. **LOAD TX BUFFER** - One less SPI byte required (than general write instruction),
3. **RTS** - Only one SPI byte required instead of 4 previously.
4. Also adds a check if the interrupt flags have been handled via a **_read of the GPIO INT pin_** which is faster than rechecking the CANINTF register via an SPI read.

**Test 1 -  CPU usage**
- loopback mode
- 125kbit/s baud
- Test data was sent (and received) as fast as possible

I recorded a throughput of 113kbits/s for all changes to the driver.  The CPU usage was observed via enabling CONFIG_TRACING_CPU_STATS.

Driver changes        |  CPU usage
-----------------------|-----------
None                  |  67.5%
Added INT pin check   |  59%
Added Load TX buffer  |  59%
Added RTS             |  57%
Added Read RX buffer  |  56%


**Test 2 - Throughput when not constrained by the above test's 125kbit/s baud rate**

- loopback mode
- 250kbit/s baud
- Test data was sent (and received) as fast as possible

CPU usage during test was 98% for all changes to the driver.

Driver changes        |  Throughput
-----------------------|----------
None                  |  165kbit/s
Added INT pin check   |  184kbit/s
Added Load TX buffer  |  187kbit/s
Added RTS             |  194kbit/s
Added Read RX buffer  |  196kbit/s


_For the above performance test this PR provides an overall **throughput increase of 18%** = (196/165 - 1)_
