### PR TITLE
cmake: Don't test whether the installed west is the bootstrapper

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -82,17 +82,6 @@ endif()
 
 # Generate the flash, debug, debugserver, attach targets within the build
 # system itself.
-if(WEST)
-  # Verify that the west version found can be used for flashing, e.g. is not the bootstrapper.
-  execute_process(COMMAND ${WEST} flash -h
-                  RESULT_VARIABLE return_code
-                  OUTPUT_QUIET
-                  ERROR_QUIET)
-  if(NOT ${return_code})
-    set(WEST_FLASH True)
-  endif(NOT ${return_code})
-endif(WEST)
-
 foreach(target flash debug debugserver attach)
   if(target STREQUAL flash)
     set(comment "Flashing ${BOARD}")
@@ -113,7 +102,7 @@ foreach(target flash debug debugserver attach)
 
   # We pass --skip-rebuild here because the DEPENDS value ensures the
   # build is already up to date before west is run.
-  if(WEST_FLASH)
+  if(WEST)
     set(cmd
       ${CMAKE_COMMAND} -E env
       ${WEST}
@@ -131,13 +120,6 @@ foreach(target flash debug debugserver attach)
       ${comment}
       USES_TERMINAL
       )
-  elseif(WEST)
-    add_custom_target(${target}
-      COMMAND ${CMAKE_COMMAND} -E echo \"West version found in path does not support
-          '${CMAKE_MAKE_PROGRAM} ${target}', ensure west is installed and not only
-          the bootstrapper. run 'west init' to fetch west.\"
-      USES_TERMINAL
-      )
   else()
     add_custom_target(${target}
       COMMAND ${CMAKE_COMMAND} -E echo \"West was not found in path. To support
@@ -145,5 +127,5 @@ foreach(target flash debug debugserver attach)
           'pip install west --user', and thereafter 'west init'.\"
       USES_TERMINAL
       )
-  endif(WEST_FLASH)
+  endif(WEST)
 endforeach()


### PR DESCRIPTION
Of the 1.7s or so that CMake spends in Configure-time there is 0.1s
spent to determine whether west can flash or not. This is significant
compared to the usefulness of flash-check.

AFAICT when installing west there is no longer a two-step procedure
where first a bootstrapper that can't flash is installed, and then a
proper west is installed, so the risk of having installed the
bootstrapper is no longer something we should spend 100ms testing for.

This patch removes the check, thereby speeding up CMake by 100ms.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>