### PR TITLE
boards: arm: nucleo_g071rb: include MPU in HW features

### DIFF
--- a/boards/arm/nucleo_g071rb/doc/index.rst
+++ b/boards/arm/nucleo_g071rb/doc/index.rst
@@ -83,6 +83,8 @@ The Zephyr nucleo_g071rb board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |
 +===========+============+=====================================+
+| MPU       | on-chip    | arm memory protection unit          |
++-----------+------------+-------------------------------------+
 | NVIC      | on-chip    | nested vector interrupt controller  |
 +-----------+------------+-------------------------------------+
 | UART      | on-chip    | serial port-polling;                |


### PR DESCRIPTION
Include ARM MPU in the list of supported features
in nucleo_g071rb platform.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>