### PR TITLE
native_posix: kconfig: Fix misplaced USB_NATIVE_POSIX default

### DIFF
--- a/boards/posix/native_posix/Kconfig.defconfig
+++ b/boards/posix/native_posix/Kconfig.defconfig
@@ -95,11 +95,11 @@ config FLASH_NATIVE_POSIX
 
 endif # FLASH
 
-endif # BOARD_NATIVE_POSIX
-
 if USB
 
 config USB_NATIVE_POSIX
 	default y
 
 endif # USB
+
+endif # BOARD_NATIVE_POSIX


### PR DESCRIPTION
Should be within the 'if BOARD_NATIVE_POSIX`, or USB_NATIVE_POSIX will
get enabled whenever USB is (unless a user value overrides it).

Probably didn't cause any problems, since
boards/posix/native_posix/Kconfig.defconfig is only included for this
board.