### PR TITLE
tests: new updated names for the kernel tests

### DIFF
--- a/tests/arch/x86/boot_page_table/testcase.yaml
+++ b/tests/arch/x86/boot_page_table/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kernel.memory_protection:
+  kernel.memory_protection.x86.bootpage.validation:
     platform_whitelist: qemu_x86
     tags: mmu

--- a/tests/kernel/mbox/mbox_api/testcase.yaml
+++ b/tests/kernel/mbox/mbox_api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kernel.mailbox:
+  kernel.mailbox.api:
     tags: kernel
     min_ram: 20

--- a/tests/kernel/mbox/mbox_usage/testcase.yaml
+++ b/tests/kernel/mbox/mbox_usage/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.mailbox:
+  kernel.mailbox.usage:
     tags: kernel

--- a/tests/kernel/mem_pool/mem_pool_api/testcase.yaml
+++ b/tests/kernel/mem_pool/mem_pool_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.memory_pool:
+  kernel.memory_pool.api:
     tags: kernel mem_pool

--- a/tests/kernel/mem_pool/mem_pool_concept/testcase.yaml
+++ b/tests/kernel/mem_pool/mem_pool_concept/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.memory_pool:
+  kernel.memory_pool.concept:
     tags: kernel mem_pool

--- a/tests/kernel/mem_pool/mem_pool_threadsafe/testcase.yaml
+++ b/tests/kernel/mem_pool/mem_pool_threadsafe/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.memory_pool:
+  kernel.memory_pool.threadsafe:
     tags: kernel mem_pool

--- a/tests/kernel/mem_pool/sys_mem_pool/testcase.yaml
+++ b/tests/kernel/mem_pool/sys_mem_pool/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kernel.memory_pool:
+  kernel.memory_pool.sys:
     min_ram: 32
     tags: kernel userspace mem_pool

--- a/tests/kernel/mem_protect/stackprot/testcase.yaml
+++ b/tests/kernel/mem_protect/stackprot/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kernel.memory_protection:
+  kernel.memory_protection.stackprot:
     arch_exclude: nios2 xtensa posix x86_64
     tags: kernel ignore_faults userspace

--- a/tests/kernel/mem_slab/mslab/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kernel.memory_slabs:
+  kernel.memory_slabs.api.test:
     tags: kernel
     min_ram: 16

--- a/tests/kernel/mem_slab/mslab_api/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.memory_slabs:
+  kernel.memory_slabs.api:
     tags: kernel

--- a/tests/kernel/mem_slab/mslab_concept/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_concept/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.memory_slabs:
+  kernel.memory_slabs.concept:
     tags: kernel

--- a/tests/kernel/mem_slab/mslab_threadsafe/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_threadsafe/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.memory_slabs:
+  kernel.memory_slabs.threadsafe:
     tags: kernel

--- a/tests/kernel/pipe/pipe_api/testcase.yaml
+++ b/tests/kernel/pipe/pipe_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.pipe:
+  kernel.pipe.api:
       tags: kernel userspace

--- a/tests/kernel/semaphore/sema_api/testcase.yaml
+++ b/tests/kernel/semaphore/sema_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.semaphore:
+  kernel.semaphore.api:
     tags: kernel userspace

--- a/tests/kernel/smp/testcase.yaml
+++ b/tests/kernel/smp/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.multiprocessing:
+  kernel.multiprocessing.smp:
     filter: (CONFIG_MP_NUM_CPUS > 1)

--- a/tests/kernel/spinlock/testcase.yaml
+++ b/tests/kernel/spinlock/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.multiprocessing:
+  kernel.multiprocessing.spinlock:
     filter: CONFIG_SMP and CONFIG_MP_NUM_CPUS > 1

--- a/tests/kernel/threads/thread_apis/testcase.yaml
+++ b/tests/kernel/threads/thread_apis/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kernel.threads:
+  kernel.threads.apis:
     tags: kernel threads userspace ignore_faults
     min_flash: 34

--- a/tests/kernel/threads/thread_init/testcase.yaml
+++ b/tests/kernel/threads/thread_init/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.threads:
+  kernel.threads.init:
     tags: kernel threads userspace

--- a/tests/kernel/tickless/tickless_concept/testcase.yaml
+++ b/tests/kernel/tickless/tickless_concept/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  kernel.tickless:
+  kernel.tickless.concept:
     arch_exclude: riscv32 nios2
     # FIXME: This test fails sporadically on all QEMU platforms, but fails
     # consistently when coverage is enabled. Disable until 14173 is fixed.

--- a/tests/kernel/timer/timer_monotonic/testcase.yaml
+++ b/tests/kernel/timer/timer_monotonic/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.timer:
+  kernel.timer.monotonic:
     tags: timer

--- a/tests/kernel/workq/work_queue_api/testcase.yaml
+++ b/tests/kernel/workq/work_queue_api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kernel.workqueue:
+  kernel.workqueue.api:
     min_flash: 34
     tags: kernel userspace


### PR DESCRIPTION
After run Sanitycheck script I found out that some test cases
have the same test case name in the test result .xml file.
To get rid of it, I decided to change test cases names
for the kernel tests.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>