### PR TITLE
intel_s1000_crb: kconfig: Remove unused I2C_0_DEFAULT_CFG symbol

### DIFF
--- a/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
@@ -46,8 +46,6 @@ config CAVS_ISR_TBL_OFFSET
 config DW_ISR_TBL_OFFSET
 	default 3RD_LVL_ISR_TBL_OFFSET
 
-config I2C_0_DEFAULT_CFG
-	default 0x12
 if DMA_CAVS
 
 config HEAP_MEM_POOL_SIZE


### PR DESCRIPTION
Unused since commit 7e96ca5d80 ("i2c: Remove non DTS Kconfig params").

intel_s1000_crb probably isn't getting tested in CI, because Kconfiglib
generated a warning for the symbol no longer being given a type, which
would be turned into an error.