### PR TITLE
arch: arc: necessary fixes for smp

### DIFF
--- a/arch/arc/core/CMakeLists.txt
+++ b/arch/arc/core/CMakeLists.txt
@@ -26,7 +26,7 @@ zephyr_library_sources_if_kconfig(irq_offload.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.S)
 zephyr_library_sources_ifdef(CONFIG_ARC_CONNECT arc_connect.c)
-zephyr_library_sources_ifdef(CONFIG_SMP arc_smp.c)
+zephyr_library_sources_ifdef(CONFIG_ARC_CONNECT arc_smp.c)
 
 add_subdirectory_ifdef(CONFIG_ARC_CORE_MPU mpu)
 add_subdirectory_ifdef(CONFIG_ARC_SECURE_FIRMWARE secureshield)

--- a/arch/arc/core/arc_smp.c
+++ b/arch/arc/core/arc_smp.c
@@ -44,15 +44,15 @@ u64_t z_arc_smp_switch_in_isr(void)
 	u32_t new_thread;
 	u32_t old_thread;
 
-	if (!_current_cpu->swap_ok) {
-		return 0;
-	}
-
 	old_thread = (u32_t)_current;
 
 	new_thread = (u32_t)z_get_next_ready_thread();
 
 	if (new_thread != old_thread) {
+/* should check whether new_thread to relace old_thread */
+#ifdef CONFIG_TIMESLICING
+		z_reset_time_slice();
+#endif
 		_current_cpu->swap_ok = 0;
 		((struct k_thread *)new_thread)->base.cpu =
 				arch_curr_cpu()->id;
@@ -120,7 +120,7 @@ void arch_sched_ipi(void)
 {
 	u32_t i;
 
-	/* broadcast sched_ipi request to all cores
+	/* broadcast sched_ipi request to other cores
 	 * if the target is current core, hardware will ignore it
 	 */
 	for (i = 0; i < CONFIG_MP_NUM_CPUS; i++) {

--- a/arch/arc/core/arc_smp.c
+++ b/arch/arc/core/arc_smp.c
@@ -75,6 +75,7 @@ void z_arc_slave_start(int cpu_num)
 	z_icache_setup();
 	z_irq_setup();
 
+	z_arc_connect_ici_clear();
 	z_irq_priority_set(IRQ_ICI, ARCV2_ICI_IRQ_PRIORITY, 0);
 	irq_enable(IRQ_ICI);
 #endif
@@ -153,6 +154,7 @@ static int arc_smp_init(struct device *dev)
 
 	if (bcr.ipi) {
 	/* register ici interrupt, just need master core to register once */
+		z_arc_connect_ici_clear();
 		IRQ_CONNECT(IRQ_ICI, ARCV2_ICI_IRQ_PRIORITY,
 		    sched_ipi_handler, NULL, 0);
 

--- a/arch/arc/core/arc_smp.c
+++ b/arch/arc/core/arc_smp.c
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief codes required for ARC smp support
+ * @brief codes required for ARC multicore and Zephyr smp support
  *
  */
 #include <device.h>
@@ -22,6 +22,69 @@
 #endif
 
 #define ARCV2_ICI_IRQ_PRIORITY 1
+
+volatile struct {
+	void (*fn)(int, void*);
+	void *arg;
+} arc_cpu_init[CONFIG_MP_NUM_CPUS];
+
+/*
+ * arc_cpu_wake_flag is used to sync up master core and slave cores
+ * Slave core will spin for arc_cpu_wake_flag until master core sets
+ * it to the core id of slave core. Then, slave core clears it to notify
+ * master core that it's waken
+ *
+ */
+volatile u32_t arc_cpu_wake_flag;
+
+volatile char *arc_cpu_sp;
+/*
+ * _curr_cpu is used to record the struct of _cpu_t of each cpu.
+ * for efficient usage in assembly
+ */
+volatile _cpu_t *_curr_cpu[CONFIG_MP_NUM_CPUS];
+
+/* Called from Zephyr initialization */
+void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
+		    void (*fn)(int, void *), void *arg)
+{
+	_curr_cpu[cpu_num] = &(_kernel.cpus[cpu_num]);
+	arc_cpu_init[cpu_num].fn = fn;
+	arc_cpu_init[cpu_num].arg = arg;
+
+	/* set the initial sp of target sp through arc_cpu_sp
+	 * arc_cpu_wake_flag will protect arc_cpu_sp that
+	 * only one slave cpu can read it per time
+	 */
+	arc_cpu_sp = Z_THREAD_STACK_BUFFER(stack) + sz;
+
+	arc_cpu_wake_flag = cpu_num;
+
+	/* wait slave cpu to start */
+	while (arc_cpu_wake_flag != 0) {
+		;
+	}
+}
+
+/* the C entry of slave cores */
+void z_arc_slave_start(int cpu_num)
+{
+	void (*fn)(int, void*);
+
+#ifdef CONFIG_SMP
+	z_icache_setup();
+	z_irq_setup();
+
+	z_irq_priority_set(IRQ_ICI, ARCV2_ICI_IRQ_PRIORITY, 0);
+	irq_enable(IRQ_ICI);
+#endif
+	/* call the function set by arch_start_cpu */
+	fn = arc_cpu_init[cpu_num].fn;
+
+	fn(cpu_num, arc_cpu_init[cpu_num].arg);
+}
+
+#ifdef CONFIG_SMP
 
 static void sched_ipi_handler(void *unused)
 {
@@ -49,7 +112,6 @@ u64_t z_arc_smp_switch_in_isr(void)
 	new_thread = (u32_t)z_get_next_ready_thread();
 
 	if (new_thread != old_thread) {
-/* should check whether new_thread to relace old_thread */
 #ifdef CONFIG_TIMESLICING
 		z_reset_time_slice();
 #endif
@@ -61,58 +123,6 @@ u64_t z_arc_smp_switch_in_isr(void)
 	}
 
 	return ret;
-}
-
-volatile struct {
-	void (*fn)(int, void*);
-	void *arg;
-} arc_cpu_init[CONFIG_MP_NUM_CPUS];
-
-/*
- * arc_cpu_wake_flag is used to sync up master core and slave cores
- * Slave core will spin for arc_cpu_wake_flag until master core sets
- * it to the core id of slave core. Then, slave core clears it to notify
- * master core that it's waken
- *
- */
-volatile u32_t arc_cpu_wake_flag;
-/*
- * _curr_cpu is used to record the struct of _cpu_t of each cpu.
- * for efficient usage in assembly
- */
-volatile _cpu_t *_curr_cpu[CONFIG_MP_NUM_CPUS];
-
-/* Called from Zephyr initialization */
-void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
-		    void (*fn)(int, void *), void *arg)
-{
-	_curr_cpu[cpu_num] = &(_kernel.cpus[cpu_num]);
-	arc_cpu_init[cpu_num].fn = fn;
-	arc_cpu_init[cpu_num].arg = arg;
-
-	arc_cpu_wake_flag = cpu_num;
-
-	/* wait slave cpu to start */
-	while (arc_cpu_wake_flag != 0) {
-		;
-	}
-}
-
-/* the C entry of slave cores */
-void z_arc_slave_start(int cpu_num)
-{
-	void (*fn)(int, void*);
-
-	z_icache_setup();
-	z_irq_setup();
-
-	z_irq_priority_set(IRQ_ICI, ARCV2_ICI_IRQ_PRIORITY, 0);
-	irq_enable(IRQ_ICI);
-
-	/* call the function set by arch_start_cpu */
-	fn = arc_cpu_init[cpu_num].fn;
-
-	fn(cpu_num, arc_cpu_init[cpu_num].arg);
 }
 
 /* arch implementation of sched_ipi */
@@ -170,3 +180,4 @@ static int arc_smp_init(struct device *dev)
 }
 
 SYS_INIT(arc_smp_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+#endif

--- a/arch/arc/core/cpu_idle.S
+++ b/arch/arc/core/cpu_idle.S
@@ -43,7 +43,19 @@ SECTION_FUNC(TEXT, arch_cpu_idle)
 
 	ld r1, [z_arc_cpu_sleep_mode]
 	or r1, r1, (1 << 4) /* set IRQ-enabled bit */
+/*
+ * It's found that (in nsim_hs_smp), when cpu
+ * is sleeping, no response to inter-processor interrupt
+ * although it's pending and interrupts are enabled.
+ * here is a workround
+ */
+#if !defined(CONFIG_SOC_NSIM) && !defined(CONFIG_SMP)
 	sleep r1
+#else
+	seti r1
+_z_arc_idle_loop:
+	b _z_arc_idle_loop
+#endif
 	j_s [blink]
 	nop
 

--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -126,7 +126,7 @@ done_cache_invalidate:
         jl @_sys_resume_from_deep_sleep
 #endif
 
-#ifdef CONFIG_SMP
+#if CONFIG_MP_NUM_CPUS  > 1
 	_get_cpu_id r0
 	breq r0, 0, _master_core_startup
 
@@ -137,11 +137,9 @@ _slave_core_wait:
 	ld r1, [arc_cpu_wake_flag]
 	brne r0, r1, _slave_core_wait
 
+	ld sp, [arc_cpu_sp]
 	/* signal master core that slave core runs */
 	st 0, [arc_cpu_wake_flag]
-
-	/* get sp set by master core */
-	_get_curr_cpu_irq_stack sp
 
 #if defined(CONFIG_ARC_FIRQ_STACK)
 	jl z_arc_firq_stack_set

--- a/boards/arc/nsim/support/mdb_hs_smp.args
+++ b/boards/arc/nsim/support/mdb_hs_smp.args
@@ -23,6 +23,7 @@
 	-action_points=8
 	-Xstack_check
 	-interrupts=72
+	-firq
 	-interrupt_priorities=2
 	-ext_interrupts=70
 	-interrupt_base=0x0

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -235,7 +235,12 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	 * that interrupts are already disabled)
 	 */
 #ifdef CONFIG_SMP
-	if (IS_ENABLED(CONFIG_TICKLESS_IDLE) && idle && ticks == K_FOREVER) {
+	/* as 64-bits GFRC is used as wall clock, it's ok to ignore idle
+	 * systick will not be missed.
+	 * However for single core using 32-bits arc timer, idle cannot
+	 * be ignored, as 32-bits timer will overflow in a not-long time.
+	 */
+	if (IS_ENABLED(CONFIG_TICKLESS_IDLE) && ticks == K_FOREVER) {
 		timer0_control_register_set(0);
 		timer0_count_register_set(0);
 		timer0_limit_register_set(0);
@@ -246,7 +251,7 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	u32_t delay;
 	u32_t key;
 
-	ticks = MIN(MAX_TICKS, MAX(ticks - 1, 0));
+	ticks = MIN(MAX_TICKS, ticks);
 
 	/* Desired delay in the future */
 	delay = (ticks == 0) ? CYC_PER_TICK : ticks * CYC_PER_TICK;

--- a/soc/arc/snps_arc_hsdk/Kconfig.defconfig
+++ b/soc/arc/snps_arc_hsdk/Kconfig.defconfig
@@ -36,6 +36,13 @@ config ARC_CONNECT
 config MP_NUM_CPUS
 	default 4
 
+if SMP
+# When SMP is enabled, use gfrc as wall clock, so sloppy
+# idle should be y
+config SYSTEM_CLOCK_SLOPPY_IDLE
+	default y
+endif
+
 if SERIAL
 
 config UART_NS16550

--- a/soc/arc/snps_nsim/Kconfig.defconfig.hs_smp
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.hs_smp
@@ -33,4 +33,11 @@ config ARC_CONNECT
 config MP_NUM_CPUS
 	default 2
 
-endif # SOC_NSIM_HS_SMP
+if SMP
+# When SMP is enabled, use gfrc as wall clock, so sloppy
+# idle should be y
+config SYSTEM_CLOCK_SLOPPY_IDLE
+	default y
+endif
+
+endif #SOC_NSIM_HS_SMP


### PR DESCRIPTION
After  recent changes in Zephyr 's SMP high-level code and tests cases,  the arc smp doesn't work and failed in the tests related to SMP and multi-core.

This PR fixes all the failures.

Fixes #19885 
Fixes #19599 