### PR TITLE
boards: arm: mps2_an521/musca: kconfig: Clean up BOARD defaults

### DIFF
--- a/boards/arm/mps2_an521/Kconfig.defconfig
+++ b/boards/arm/mps2_an521/Kconfig.defconfig
@@ -6,19 +6,9 @@
 
 if BOARD_MPS2_AN521
 
-if !TRUSTED_EXECUTION_NONSECURE
-
 config BOARD
+	default "mps2_an521_nonsecure" if TRUSTED_EXECUTION_NONSECURE
 	default "mps2_an521"
-
-endif
-
-if TRUSTED_EXECUTION_NONSECURE
-
-config BOARD
-	default "mps2_an521_nonsecure"
-
-endif # !TRUSTED_EXECUTION_NONSECURE
 
 if GPIO
 

--- a/boards/arm/v2m_musca/Kconfig.defconfig
+++ b/boards/arm/v2m_musca/Kconfig.defconfig
@@ -6,20 +6,9 @@
 
 if BOARD_MUSCA_A
 
-if TRUSTED_EXECUTION_SECURE || !TRUSTED_EXECUTION_NONSECURE
-
 config BOARD
-	default "musca_a"
-
-endif
-
-if TRUSTED_EXECUTION_NONSECURE
-
-config BOARD
+	default "musca_a" if TRUSTED_EXECUTION_SECURE || !TRUSTED_EXECUTION_NONSECURE
 	default "musca_a_nonsecure"
-
-endif
-
 
 if GPIO
 

--- a/boards/arm/v2m_musca_b1/Kconfig.defconfig
+++ b/boards/arm/v2m_musca_b1/Kconfig.defconfig
@@ -6,19 +6,9 @@
 
 if BOARD_MUSCA_B1
 
-if TRUSTED_EXECUTION_SECURE || !TRUSTED_EXECUTION_NONSECURE
-
 config BOARD
-	default "musca_b1"
-
-endif
-
-if TRUSTED_EXECUTION_NONSECURE
-
-config BOARD
+	default "musca_b1" if TRUSTED_EXECUTION_SECURE || !TRUSTED_EXECUTION_NONSECURE
 	default "musca_b1_nonsecure"
-
-endif
 
 if GPIO
 


### PR DESCRIPTION
Putting 'if's directly on the defaults is simpler here.

I'm guessing BOARD should always be "musca_{a,b1}\_nonsecure" if it isn't
"musca_{a,b1}", so I removed the condition on the
"musca_{a,b1}_nonsecure" default (turning it into an "else").

Avoiding a top-level 'if'/'depends on' also avoids adding direct
dependencies to the BOARD symbol, which looks a bit neater in the
generated docs (though direct dependencies only matter for symbols that
might be selected/implied).