### PR TITLE
tests: remove duplicate names for the libraries tests

### DIFF
--- a/tests/lib/mem_alloc/testcase.yaml
+++ b/tests/lib/mem_alloc/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  libraries.libc.minimal:
+  libraries.libc.minimal.mem_alloc:
     extra_args: CONF_FILE=prj.conf
     arch_exclude: posix
     platform_exclude: twr_ke18f

--- a/tests/lib/sprintf/testcase.yaml
+++ b/tests/lib/sprintf/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  libraries.libc:
+  libraries.libc.sprintf:
     filter: not CONFIG_SOC_MCIMX7_M4
     tags: libc


### PR DESCRIPTION
According to the comment in #20008 I found out that some test cases
for different tests have same names.
To get rid of it, I decided to change test cases names.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>