### PR TITLE
tests: remove duplicate names for the filesystem tests

### DIFF
--- a/tests/subsys/fs/fat_fs_api/testcase.yaml
+++ b/tests/subsys/fs/fat_fs_api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  filesystem.fat:
+  filesystem.fat.api:
     platform_whitelist: native_posix native_posix_64
     tags: filesystem

--- a/tests/subsys/fs/fat_fs_dual_drive/testcase.yaml
+++ b/tests/subsys/fs/fat_fs_dual_drive/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  filesystem.fat:
+  filesystem.fat.dual_drive:
     platform_whitelist: qemu_x86
     tags: filesystem


### PR DESCRIPTION
According to the comment in #20008 I found out that some test cases
for different tests have same names.
To get rid of it, I decided to change test cases names.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>