### PR TITLE
tests: remove duplicate names for the boards tests

### DIFF
--- a/tests/boards/altera_max10/i2c_master/testcase.yaml
+++ b/tests/boards/altera_max10/i2c_master/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  boards.altera_max10:
+  boards.altera_max10.i2c_master:
     platform_whitelist: altera_max10
     tags: i2c

--- a/tests/boards/altera_max10/msgdma/testcase.yaml
+++ b/tests/boards/altera_max10/msgdma/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  boards.altera_max10:
+  boards.altera_max10.dma:
     platform_whitelist: altera_max10
     tags: dma

--- a/tests/boards/altera_max10/qspi/testcase.yaml
+++ b/tests/boards/altera_max10/qspi/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  boards.altera_max10:
+  boards.altera_max10.qspi:
     platform_whitelist: altera_max10
     tags: qspi flash

--- a/tests/boards/altera_max10/sysid/testcase.yaml
+++ b/tests/boards/altera_max10/sysid/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  boards.altera_max10:
+  boards.altera_max10.sysid:
     platform_whitelist: altera_max10
     tags: sysid

--- a/tests/boards/native_posix/native_tasks/testcase.yaml
+++ b/tests/boards/native_posix/native_tasks/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  boards.native_posix:
+  boards.native_posix.native_tasks:
     arch_whitelist: posix
-  boards.native_posix_64:
+  boards.native_posix_64.native_tasks:
     arch_whitelist: posix

--- a/tests/boards/native_posix/rtc/testcase.yaml
+++ b/tests/boards/native_posix/rtc/testcase.yaml
@@ -1,6 +1,6 @@
 # Test of the native_posix real timenes and RTC model
 tests:
-  boards.native_posix:
+  boards.native_posix.rtc:
     platform_whitelist: native_posix native_posix_64
     build_only: true
 #Note: this test depends too much on not having a high host load to pass.


### PR DESCRIPTION
According to the comment in #20008 I found out that some test cases
for different tests have same names.
To get rid of it, I decided to change test cases names.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>