### PR TITLE
kconfig: Remove symbol types from Kconfig.defconfig files

### DIFF
--- a/arch/nios2/Kconfig
+++ b/arch/nios2/Kconfig
@@ -25,7 +25,6 @@ endmenu
 menu "Nios II Family Options"
 
 config XIP
-	bool
 	default y
 
 config GEN_ISR_TABLES

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -27,7 +27,7 @@ config SIMULATOR_XTENSA
 	  Specify if the board configuration should be treated as a simulator.
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int "Hardware clock cycles per second, 2000000 for ISS"
+	prompt "Hardware clock cycles per second, 2000000 for ISS"
 	default 2000000
 	range 1000000 1000000000
 	help

--- a/boards/arm/mec1501modular_assy6885/Kconfig.defconfig
+++ b/boards/arm/mec1501modular_assy6885/Kconfig.defconfig
@@ -11,7 +11,7 @@ config BOARD
 if UART_NS16550
 
 config UART_NS16550_PORT_1
-	def_bool y if UART_CONSOLE
+	default y if UART_CONSOLE
 
 endif
 

--- a/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
+++ b/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
@@ -11,7 +11,7 @@ config BOARD
 if UART_NS16550
 
 config UART_NS16550_PORT_2
-	def_bool y if UART_CONSOLE
+	default y if UART_CONSOLE
 
 endif
 

--- a/boards/arm/mps2_an521/Kconfig.defconfig
+++ b/boards/arm/mps2_an521/Kconfig.defconfig
@@ -23,19 +23,19 @@ endif # !TRUSTED_EXECUTION_NONSECURE
 if GPIO
 
 config GPIO_CMSDK_AHB
-	def_bool y
+	default y
 
 config GPIO_CMSDK_AHB_PORT0
-	def_bool y
+	default y
 
 config GPIO_CMSDK_AHB_PORT1
-	def_bool y
+	default y
 
 config GPIO_CMSDK_AHB_PORT2
-	def_bool y
+	default y
 
 config GPIO_CMSDK_AHB_PORT3
-	def_bool y
+	default y
 
 endif # GPIO
 
@@ -49,17 +49,17 @@ endif # PINMUX
 if SERIAL
 
 config UART_CMSDK_APB
-	def_bool y
+	default y
 
 config UART_INTERRUPT_DRIVEN
-	def_bool y
+	default y
 
 endif # SERIAL
 
 if WATCHDOG
 
 config WDOG_CMSDK_APB
-	def_bool y
+	default y
 
 endif # WATCHDOG
 
@@ -88,7 +88,7 @@ endif # COUNTER
 if I2C
 
 config I2C_SBCON
-	def_bool y
+	default y
 
 endif # I2C
 

--- a/boards/arm/qemu_cortex_m0/Kconfig.defconfig
+++ b/boards/arm/qemu_cortex_m0/Kconfig.defconfig
@@ -28,15 +28,12 @@ config NRF_RTC_TIMER
 endif # SYS_CLOCK_EXISTS
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 1000000
 
 config SYS_CLOCK_TICKS_PER_SEC
-	int
 	default 100
 
 config ENTROPY_NRF_FORCE_ALT
-	bool
 	default y
 
 endif # BOARD_QEMU_CORTEX_M0

--- a/boards/arm/sam4s_xplained/Kconfig.defconfig
+++ b/boards/arm/sam4s_xplained/Kconfig.defconfig
@@ -7,7 +7,6 @@
 if BOARD_SAM4S_XPLAINED
 
 config BOARD
-	string
 	default "sam4s_xplained"
 
 if I2C

--- a/boards/arm/sam_e70_xplained/Kconfig.defconfig
+++ b/boards/arm/sam_e70_xplained/Kconfig.defconfig
@@ -7,7 +7,6 @@
 if BOARD_SAM_E70_XPLAINED
 
 config BOARD
-	string
 	default "sam_e70_xplained"
 
 if I2S
@@ -28,23 +27,18 @@ choice ETH_SAM_GMAC_MAC_SELECT
 endchoice
 
 config ETH_SAM_GMAC_MAC_I2C_SLAVE_ADDRESS
-	hex
 	default 0x5F
 
 config ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS
-	hex
 	default 0x9A
 
 config ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS_SIZE
-	int
 	default 1
 
 config ETH_SAM_GMAC_MAC_I2C_DEV_NAME
-	string
 	default "I2C_0"
 
 config ETH_SAM_GMAC_MAC_I2C_EEPROM
-	bool
 	select I2C
 
 endif # ETH_SAM_GMAC

--- a/boards/arm/stm32h747i_disco/Kconfig.defconfig
+++ b/boards/arm/stm32h747i_disco/Kconfig.defconfig
@@ -38,7 +38,7 @@ config CLOCK_STM32_D3PPRE
 	default 2
 
 config STM32H7_DUAL_CORE
-	def_bool y
+	default y
 
 # Dual core boot configuration
 if STM32H7_DUAL_CORE

--- a/boards/arm/v2m_musca_b1/Kconfig.defconfig
+++ b/boards/arm/v2m_musca_b1/Kconfig.defconfig
@@ -33,16 +33,16 @@ endif
 if SERIAL
 
 config UART_PL011
-	def_bool y
+	default y
 
 config UART_INTERRUPT_DRIVEN
-	def_bool y
+	default y
 
 config UART_PL011_PORT0
-	def_bool y
+	default y
 
 config UART_PL011_PORT1
-	def_bool y
+	default y
 
 endif # SERIAL
 

--- a/boards/riscv/rv32m1_vega/Kconfig.defconfig
+++ b/boards/riscv/rv32m1_vega/Kconfig.defconfig
@@ -61,10 +61,10 @@ endif # SERIAL
 if I2C
 
 config I2C_0
-	def_bool y
+	default y
 
 config I2C_3
-	def_bool y if RV32M1_INTMUX
+	default y if RV32M1_INTMUX
 
 endif # I2C
 

--- a/drivers/adc/Kconfig.stm32
+++ b/drivers/adc/Kconfig.stm32
@@ -17,7 +17,7 @@ menuconfig ADC_STM32
 if ADC_STM32
 
 config ADC_1
-	bool "ADC1"
+	prompt "ADC1"
 	default y
 	help
 	  Enable ADC1

--- a/soc/arc/snps_arc_hsdk/Kconfig.defconfig
+++ b/soc/arc/snps_arc_hsdk/Kconfig.defconfig
@@ -7,7 +7,6 @@
 if SOC_ARC_HSDK
 
 config SOC
-	string
 	default "snps_arc_hsdk"
 
 config CPU_HS38_LINUX

--- a/soc/arc/snps_arc_iot/Kconfig.defconfig
+++ b/soc/arc/snps_arc_iot/Kconfig.defconfig
@@ -8,7 +8,6 @@
 if SOC_ARC_IOT
 
 config SOC
-	string
 	default "snps_arc_iot"
 
 config CPU_EM4_FPUS

--- a/soc/arc/snps_emsdp/Kconfig.defconfig
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig
@@ -7,7 +7,6 @@
 if SOC_ARC_EMSDP
 
 config SOC
-	string
 	default "snps_emsdp"
 
 config NUM_IRQ_PRIO_LEVELS

--- a/soc/arc/snps_emsk/Kconfig.defconfig
+++ b/soc/arc/snps_emsk/Kconfig.defconfig
@@ -8,7 +8,6 @@
 if SOC_EMSK
 
 config SOC
-	string
 	default "snps_emsk"
 
 source "soc/arc/snps_emsk/Kconfig.defconfig.em7d"

--- a/soc/arc/snps_nsim/Kconfig.defconfig
+++ b/soc/arc/snps_nsim/Kconfig.defconfig
@@ -7,11 +7,9 @@
 if SOC_NSIM
 
 config SOC
-	string
 	default "snps_nsim"
 
 config UART_CONSOLE_ON_DEV_NAME
-	string
 	default "UART_0"
 
 source "soc/arc/snps_nsim/Kconfig.defconfig.em"

--- a/soc/arm/arm/beetle/Kconfig.defconfig.series
+++ b/soc/arm/arm/beetle/Kconfig.defconfig.series
@@ -18,7 +18,6 @@ config NUM_IRQS
 	default 45
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 24000000
 
 endif # SOC_SERIES_BEETLE

--- a/soc/arm/arm/mps2/Kconfig.defconfig.series
+++ b/soc/arm/arm/mps2/Kconfig.defconfig.series
@@ -10,7 +10,6 @@ config SOC_SERIES
 	default "mps2"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 25000000
 
 source "soc/arm/arm/mps2/Kconfig.defconfig.mps2*"

--- a/soc/arm/arm/musca_a/Kconfig.defconfig.series
+++ b/soc/arm/arm/musca_a/Kconfig.defconfig.series
@@ -10,7 +10,6 @@ config SOC_SERIES
 	default "musca_a"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 50000000
 
 source "soc/arm/arm/musca_a/Kconfig.defconfig.musca_a"

--- a/soc/arm/arm/musca_b1/Kconfig.defconfig.series
+++ b/soc/arm/arm/musca_b1/Kconfig.defconfig.series
@@ -10,7 +10,6 @@ config SOC_SERIES
 	default "musca_b1"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 40000000
 
 source "soc/arm/arm/musca_b1/Kconfig.defconfig.musca_b1"

--- a/soc/arm/atmel_sam/sam3x/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/sam3x/Kconfig.defconfig.series
@@ -29,7 +29,6 @@ config NUM_IRQS
 	default 45
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 84000000
 
 endif # SOC_SERIES_SAM3X

--- a/soc/arm/atmel_sam/sam4s/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/sam4s/Kconfig.defconfig.series
@@ -34,7 +34,6 @@ config NUM_IRQS
 	default 35
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 120000000
 
 endif # SOC_SERIES_SAM4S

--- a/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
@@ -42,7 +42,6 @@ config NUM_IRQS
 	default 71
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 300000000
 
 # Configure default device drivers. If a feature is supported by more than one

--- a/soc/arm/atmel_sam0/samd20/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samd20/Kconfig.defconfig.series
@@ -34,7 +34,6 @@ config NUM_IRQS
 	default 25
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 48000000
 
 endif # SOC_SERIES_SAMD20

--- a/soc/arm/atmel_sam0/samd21/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samd21/Kconfig.defconfig.series
@@ -31,7 +31,6 @@ config NUM_IRQS
 	default 29
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 48000000
 
 endif # SOC_SERIES_SAMD21

--- a/soc/arm/atmel_sam0/samr21/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samr21/Kconfig.defconfig.series
@@ -24,7 +24,6 @@ config NUM_IRQS
 	default 28
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 48000000
 
 endif # SOC_SERIES_SAMR21

--- a/soc/arm/cypress/psoc6/Kconfig.defconfig.psoc6_m0
+++ b/soc/arm/cypress/psoc6/Kconfig.defconfig.psoc6_m0
@@ -8,7 +8,6 @@
 if SOC_PSOC6_M0
 
 config SOC
-	string
 	default "psoc6_m0"
 
 if SERIAL

--- a/soc/arm/cypress/psoc6/Kconfig.defconfig.psoc6_m4
+++ b/soc/arm/cypress/psoc6/Kconfig.defconfig.psoc6_m4
@@ -8,7 +8,6 @@
 if SOC_PSOC6_M4
 
 config SOC
-	string
 	default "psoc6_m4"
 
 if SERIAL

--- a/soc/arm/cypress/psoc6/Kconfig.defconfig.series
+++ b/soc/arm/cypress/psoc6/Kconfig.defconfig.series
@@ -21,7 +21,6 @@ config NUM_IRQS
 	default 40
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 50000000
 
 source "soc/arm/cypress/psoc6/Kconfig.defconfig.psoc*"

--- a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz
@@ -8,13 +8,12 @@
 if SOC_MEC1501_HSZ
 
 config SOC
-	string
 	default "mec1501hsz"
 
 if SERIAL
 
 config UART_NS16550
-	def_bool y
+	default y
 
 endif # SERIAL
 
@@ -45,14 +44,14 @@ endif # GPIO
 if I2C
 
 config I2C_XEC
-	def_bool y
+	default y
 
 endif # I2C
 
 if COUNTER
 
 config COUNTER_XEC
-	def_bool y
+	default y
 
 endif # COUNTER
 
@@ -66,7 +65,7 @@ endif # PS2
 if PWM
 
 config PWM_XEC
-	def_bool y
+	default y
 
 endif # PWM
 
@@ -80,7 +79,7 @@ endif # KSCAN
 if SPI
 
 config SPI_XEC_QMSPI
-	def_bool y
+	default y
 
 endif # SPI
 

--- a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
@@ -23,7 +23,6 @@ source "soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501*"
 if RTOS_TIMER
 
 config MCHP_XEC_RTOS_TIMER
-	bool
 	default y
 
 config ARCH_HAS_CUSTOM_BUSY_WAIT

--- a/soc/arm/microchip_mec/mec1701/Kconfig.defconfig.mec1701qsz
+++ b/soc/arm/microchip_mec/mec1701/Kconfig.defconfig.mec1701qsz
@@ -8,11 +8,9 @@
 if SOC_MEC1701_QSZ
 
 config SOC
-	string
 	default "mec1701qsz"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 48000000
 
 if SERIAL

--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -19,11 +19,9 @@ config NRF_RTC_TIMER
 endif # SYS_CLOCK_EXISTS
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 32768
 
 config SYS_CLOCK_TICKS_PER_SEC
-	int
 	default 32768
 
 config ARCH_HAS_CUSTOM_BUSY_WAIT

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAA
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAA
@@ -9,7 +9,6 @@
 if SOC_NRF51822_QFAA
 
 config SOC
-	string
 	default "nRF51822_QFAA"
 
 config ISR_STACK_SIZE

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAB
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAB
@@ -9,7 +9,6 @@
 if SOC_NRF51822_QFAB
 
 config SOC
-	string
 	default "nRF51822_QFAB"
 
 config ISR_STACK_SIZE

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAC
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAC
@@ -9,7 +9,6 @@
 if SOC_NRF51822_QFAC
 
 config SOC
-	string
 	default "nRF51822_QFAC"
 
 endif # SOC_NRF51822_QFAC

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52810_QFAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52810_QFAA
@@ -9,7 +9,6 @@
 if SOC_NRF52810_QFAA
 
 config SOC
-	string
 	default "nRF52810_QFAA"
 
 config NUM_IRQS

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52811_QFAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52811_QFAA
@@ -9,7 +9,6 @@
 if SOC_NRF52811_QFAA
 
 config SOC
-	string
 	default "nRF52811_QFAA"
 
 config NUM_IRQS

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_CIAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_CIAA
@@ -9,7 +9,6 @@
 if SOC_NRF52832_CIAA
 
 config SOC
-	string
 	default "nRF52832_CIAA"
 
 config NUM_IRQS

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAA
@@ -9,7 +9,6 @@
 if SOC_NRF52832_QFAA
 
 config SOC
-	string
 	default "nRF52832_QFAA"
 
 config NUM_IRQS

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAB
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAB
@@ -9,7 +9,6 @@
 if SOC_NRF52832_QFAB
 
 config SOC
-	string
 	default "nRF52832_QFAB"
 
 config NUM_IRQS

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52840_QIAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52840_QIAA
@@ -9,7 +9,6 @@
 if SOC_NRF52840_QIAA
 
 config SOC
-	string
 	default "nRF52840_QIAA"
 
 config NUM_IRQS

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9160_SICA
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9160_SICA
@@ -9,7 +9,6 @@
 if SOC_NRF9160_SICA
 
 config SOC
-	string
 	default "nRF9160_SICA"
 
 config NUM_IRQS

--- a/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
+++ b/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
@@ -8,7 +8,6 @@
 if SOC_MCIMX6X_M4
 
 config SOC
-	string
 	default "mcimx6x"
 
 config FLOAT

--- a/soc/arm/nxp_imx/mcimx7_m4/Kconfig.defconfig.mcimx7_m4
+++ b/soc/arm/nxp_imx/mcimx7_m4/Kconfig.defconfig.mcimx7_m4
@@ -8,11 +8,9 @@
 if SOC_MCIMX7_M4
 
 config SOC
-	string
 	default "mcimx7d"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 200000000
 
 if CLOCK_CONTROL

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1015
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1015
@@ -8,7 +8,6 @@
 if SOC_MIMXRT1015
 
 config SOC
-	string
 	default "mimxrt1015"
 
 config NUM_IRQS

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1021
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1021
@@ -8,7 +8,6 @@
 if SOC_MIMXRT1021
 
 config SOC
-	string
 	default "mimxrt1021"
 
 config NUM_IRQS

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
@@ -8,7 +8,6 @@
 if SOC_MIMXRT1052
 
 config SOC
-	string
 	default "mimxrt1052"
 
 config NUM_IRQS

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1062
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1062
@@ -8,7 +8,6 @@
 if SOC_MIMXRT1062
 
 config SOC
-	string
 	default "mimxrt1062"
 
 config NUM_IRQS

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
@@ -8,7 +8,6 @@
 if SOC_MIMXRT1064
 
 config SOC
-	string
 	default "mimxrt1064"
 
 config NUM_IRQS

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22f12
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22f12
@@ -8,7 +8,6 @@
 if SOC_MK22F51212
 
 config SOC
-	string
 	default "mk22f51212"
 
 if ADC

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
@@ -9,7 +9,6 @@
 if SOC_MK64F12
 
 config SOC
-	string
 	default "mk64f12"
 
 if ADC

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.mk80f25615
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.mk80f25615
@@ -8,7 +8,6 @@
 if SOC_MK80F25615
 
 config SOC
-	string
 	default "mk80f25615"
 
 endif # SOC_MK80F25615

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.mk82f25615
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.mk82f25615
@@ -8,7 +8,6 @@
 if SOC_MK82F25615
 
 config SOC
-	string
 	default "mk82f25615"
 
 endif # SOC_MK82F25615

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke14f16
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke14f16
@@ -8,7 +8,6 @@
 if SOC_MKE14F16
 
 config SOC
-	string
 	default "mke14f16"
 
 endif # SOC_MKE14F16

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke16f16
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke16f16
@@ -8,7 +8,6 @@
 if SOC_MKE16F16
 
 config SOC
-	string
 	default "mke16f16"
 
 if CAN

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke18f16
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke18f16
@@ -8,7 +8,6 @@
 if SOC_MKE18F16
 
 config SOC
-	string
 	default "mke18f16"
 
 if CAN

--- a/soc/arm/nxp_kinetis/kl2x/Kconfig.defconfig.mkl25z4
+++ b/soc/arm/nxp_kinetis/kl2x/Kconfig.defconfig.mkl25z4
@@ -8,7 +8,6 @@
 if SOC_MKL25Z4
 
 config SOC
-	string
 	default "mkl25z4"
 
 config NUM_IRQS

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw2xd512
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw2xd512
@@ -10,7 +10,6 @@ if SOC_MKW22D5 || SOC_MKW24D5
 if SOC_MKW22D5
 
 config SOC
-	string
 	default "mkw22d5"
 
 endif # SOC_MKW22D5
@@ -18,7 +17,6 @@ endif # SOC_MKW22D5
 if SOC_MKW24D5
 
 config SOC
-	string
 	default "mkw24d5"
 
 endif # SOC_MKW24D5

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw40z4
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw40z4
@@ -8,7 +8,6 @@
 if SOC_MKW40Z4
 
 config SOC
-	string
 	default "mkw40z4"
 
 config NUM_IRQS

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
@@ -8,7 +8,6 @@
 if SOC_MKW41Z4
 
 config SOC
-	string
 	default "mkw41z4"
 
 config NUM_IRQS

--- a/soc/arm/nxp_lpc/lpc54xxx/Kconfig.defconfig.lpc54114_m0
+++ b/soc/arm/nxp_lpc/lpc54xxx/Kconfig.defconfig.lpc54114_m0
@@ -9,7 +9,6 @@
 if SOC_LPC54114_M0
 
 config SOC
-	string
 	default "lpc54114_m0"
 
 if PINMUX

--- a/soc/arm/nxp_lpc/lpc54xxx/Kconfig.defconfig.lpc54114_m4
+++ b/soc/arm/nxp_lpc/lpc54xxx/Kconfig.defconfig.lpc54114_m4
@@ -8,7 +8,6 @@
 if SOC_LPC54114_M4
 
 config SOC
-	string
 	default "lpc54114"
 
 if PINMUX

--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S69_cpu0
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S69_cpu0
@@ -8,7 +8,6 @@
 if SOC_LPC55S69_CPU0
 
 config SOC
-	string
 	default "lpc55S69_cpu0"
 
 if PINMUX

--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S69_cpu1
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S69_cpu1
@@ -8,7 +8,6 @@
 if SOC_LPC55S69_CPU1
 
 config SOC
-	string
 	default "lpc55S69_cpu1"
 
 if PINMUX

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f030x4
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f030x4
@@ -9,7 +9,6 @@ if SOC_STM32F030X4
 # STM32F0 Cube package advises to use 'stm32f030x6' code
 # for both STM32F030x4 and STM32F030x6 SoC variants.
 config SOC
-	string
 	default "stm32f030x6"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f030x8
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f030x8
@@ -8,7 +8,6 @@
 if SOC_STM32F030X8
 
 config SOC
-	string
 	default "stm32f030x8"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f051x8
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f051x8
@@ -8,7 +8,6 @@
 if SOC_STM32F051X8
 
 config SOC
-	string
 	default "stm32f051x8"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f070xb
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f070xb
@@ -8,7 +8,6 @@
 if SOC_STM32F070XB
 
 config SOC
-	string
 	default "stm32f070xb"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f072xb
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f072xb
@@ -8,7 +8,6 @@
 if SOC_STM32F072XB
 
 config SOC
-	string
 	default "stm32f072xb"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f091xc
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f091xc
@@ -8,7 +8,6 @@
 if SOC_STM32F091XC
 
 config SOC
-	string
 	default "stm32f091xc"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f103xx
+++ b/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f103xx
@@ -8,7 +8,6 @@
 if SOC_STM32F103XB || SOC_STM32F103X8
 
 config SOC
-	string
 	default "stm32f103xb"
 
 config NUM_IRQS
@@ -27,7 +26,6 @@ endif # SOC_STM32F103XB || SOC_STM32F103X8
 if SOC_STM32F103XE
 
 config SOC
-	string
 	default "stm32f103xe"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f107xc
+++ b/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f107xc
@@ -8,7 +8,6 @@
 if SOC_STM32F107XC
 
 config SOC
-	string
 	default "stm32f107xc"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f2/Kconfig.defconfig.stm32f207xx
+++ b/soc/arm/st_stm32/stm32f2/Kconfig.defconfig.stm32f207xx
@@ -8,7 +8,6 @@
 if SOC_STM32F207XX
 
 config SOC
-	string
 	default "STM32F207xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f302x8
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f302x8
@@ -8,7 +8,6 @@
 if SOC_STM32F302X8
 
 config SOC
-	string
 	default "stm32f302x8"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f303xc
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f303xc
@@ -8,7 +8,6 @@
 if SOC_STM32F303XC
 
 config SOC
-	string
 	default "stm32f303xc"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f334x8
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f334x8
@@ -8,7 +8,6 @@
 if SOC_STM32F334X8
 
 config SOC
-	string
 	default "stm32f334x8"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f373xc
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f373xc
@@ -8,7 +8,6 @@
 if SOC_STM32F373XC
 
 config SOC
-	string
 	default "stm32f373xc"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xc
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xc
@@ -8,7 +8,6 @@
 if SOC_STM32F401XC
 
 config SOC
-	string
 	default	"stm32f401xc"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xe
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xe
@@ -8,7 +8,6 @@
 if SOC_STM32F401XE
 
 config SOC
-	string
 	default "stm32f401xe"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f405xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f405xx
@@ -8,7 +8,6 @@
 if SOC_STM32F405XG
 
 config SOC
-	string
 	default "stm32f405xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f407xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f407xx
@@ -8,7 +8,6 @@
 if SOC_STM32F407XG
 
 config SOC
-	string
 	default "stm32f407xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
@@ -8,7 +8,6 @@
 if SOC_STM32F411XE
 
 config SOC
-	string
 	default "stm32f411xe"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412cg
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412cg
@@ -8,7 +8,6 @@
 if SOC_STM32F412CG
 
 config SOC
-	string
 	default "stm32f412cx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412zg
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412zg
@@ -8,7 +8,6 @@
 if SOC_STM32F412ZG
 
 config SOC
-	string
 	default "stm32f412zx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f413xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f413xx
@@ -8,7 +8,6 @@
 if SOC_STM32F413XX
 
 config SOC
-	string
 	default "stm32f413xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f415xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f415xx
@@ -8,7 +8,6 @@
 if SOC_STM32F415XX
 
 config SOC
-	string
 	default "stm32f415xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f417xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f417xx
@@ -8,7 +8,6 @@
 if SOC_STM32F417XX
 
 config SOC
-	string
 	default "stm32f417xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f429xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f429xx
@@ -8,7 +8,6 @@
 if SOC_STM32F429XX
 
 config SOC
-	string
 	default "stm32f429xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f437xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f437xx
@@ -8,7 +8,6 @@
 if SOC_STM32F437XX
 
 config SOC
-	string
 	default "stm32f437xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xx
@@ -8,7 +8,6 @@
 if SOC_STM32F446XX
 
 config SOC
-	string
 	default "stm32f446xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f469xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f469xx
@@ -8,7 +8,6 @@
 if SOC_STM32F469XX
 
 config SOC
-	string
 	default "stm32f469xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f723xx
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f723xx
@@ -8,7 +8,6 @@
 if SOC_STM32F723XX
 
 config SOC
-	string
 	default "stm32f723xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f746xx
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f746xx
@@ -8,7 +8,6 @@
 if SOC_STM32F746XX
 
 config SOC
-	string
 	default "stm32f746xx"
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f756xx
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f756xx
@@ -8,7 +8,6 @@
 if SOC_STM32F756XX
 
 config SOC
-	string
 	default "stm32f756xx"
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f769xx
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f769xx
@@ -8,7 +8,6 @@
 if SOC_STM32F769XX
 
 config SOC
-	string
 	default "stm32f769xx"
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32g0/Kconfig.defconfig.stm32g071rb
+++ b/soc/arm/st_stm32/stm32g0/Kconfig.defconfig.stm32g071rb
@@ -9,7 +9,6 @@
 if SOC_STM32G071XX
 
 config SOC
-	string
 	default "stm32g071xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32g4/Kconfig.defconfig.stm32g431rb
+++ b/soc/arm/st_stm32/stm32g4/Kconfig.defconfig.stm32g431rb
@@ -8,7 +8,6 @@
 if SOC_STM32G431XX
 
 config SOC
-	string
 	default "stm32g431xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h747xx
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h747xx
@@ -8,7 +8,6 @@
 if SOC_STM32H747XX
 
 config SOC
-	string
 	default "stm32h747xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l053xx
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l053xx
@@ -8,7 +8,6 @@
 if SOC_STM32L053XX
 
 config SOC
-	string
 	default "stm32l053xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l072xx
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l072xx
@@ -8,7 +8,6 @@
 if SOC_STM32L072XX
 
 config SOC
-	string
 	default "stm32l072xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l073xx
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l073xx
@@ -8,7 +8,6 @@
 if SOC_STM32L073XX
 
 config SOC
-	string
 	default "stm32l073xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l151x8a
+++ b/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l151x8a
@@ -8,7 +8,6 @@
 if SOC_STM32L151X8A
 
 config SOC
-	string
 	default "stm32l151x8a"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l151xb
+++ b/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l151xb
@@ -8,7 +8,6 @@
 if SOC_STM32L151XB
 
 config SOC
-	string
 	default "stm32l151xb"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l151xba
+++ b/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l151xba
@@ -8,7 +8,6 @@
 if SOC_STM32L151XBA
 
 config SOC
-	string
 	default "stm32l151xba"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l432xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l432xx
@@ -9,7 +9,6 @@
 if SOC_STM32L432XX
 
 config SOC
-	string
 	default "stm32l432xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l433xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l433xx
@@ -8,7 +8,6 @@
 if SOC_STM32L433XX
 
 config SOC
-	string
 	default "stm32l433xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l452xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l452xx
@@ -8,7 +8,6 @@
 if SOC_STM32L452XX
 
 config SOC
-	string
 	default "stm32l452xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l471xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l471xx
@@ -8,7 +8,6 @@
 if SOC_STM32L471XX
 
 config SOC
-	string
 	default "stm32l471xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l475xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l475xx
@@ -8,7 +8,6 @@
 if SOC_STM32L475XX
 
 config SOC
-	string
 	default "stm32l475xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l476xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l476xx
@@ -9,7 +9,6 @@
 if SOC_STM32L476XX
 
 config SOC
-	string
 	default "stm32l476xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l496xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l496xx
@@ -10,7 +10,6 @@
 if SOC_STM32L496XX
 
 config SOC
-	string
 	default "stm32l496xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4r5xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4r5xx
@@ -8,7 +8,6 @@
 if SOC_STM32L4R5XX
 
 config SOC
-	string
 	default "stm32l4r5xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4r9xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4r9xx
@@ -8,7 +8,6 @@
 if SOC_STM32L4R9XX
 
 config SOC
-	string
 	default "stm32l4r9xx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32mp1/Kconfig.defconfig.stm32mp15_m4
+++ b/soc/arm/st_stm32/stm32mp1/Kconfig.defconfig.stm32mp15_m4
@@ -8,7 +8,6 @@
 if SOC_STM32MP15_M4
 
 config SOC
-	string
 	default "stm32mp157cxx"
 
 config NUM_IRQS

--- a/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.stm32wb55xx
+++ b/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.stm32wb55xx
@@ -8,7 +8,6 @@
 if SOC_STM32WB55XX
 
 config SOC
-	string
 	default "stm32wb55xx"
 
 config NUM_IRQS

--- a/soc/arm/ti_lm3s6965/Kconfig.defconfig
+++ b/soc/arm/ti_lm3s6965/Kconfig.defconfig
@@ -18,7 +18,6 @@ config NUM_IRQS
 	default 43
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 12000000
 
 if UART_STELLARIS

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.cc1352r
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.cc1352r
@@ -8,7 +8,6 @@
 if SOC_CC1352R
 
 config SOC
-	string
 	default "cc1352r"
 
 endif # SOC_CC1352R

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.cc2652r
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.cc2652r
@@ -8,7 +8,6 @@
 if SOC_CC2652R
 
 config SOC
-	string
 	default "cc2652r"
 
 endif # SOC_CC2652R

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
@@ -14,14 +14,12 @@ config SOC_SERIES
 	default "cc13x2_cc26x2"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 32768
 
 # Note that when using the RTC as system clock, this needs to be 32768
 # to reduce truncation errors from accumulating due to conversion to/from
 # time, ticks, and HW cycles
 config SYS_CLOCK_TICKS_PER_SEC
-	int
 	default 32768
 
 config NUM_IRQS

--- a/soc/arm/ti_simplelink/cc32xx/Kconfig.defconfig.cc3220sf
+++ b/soc/arm/ti_simplelink/cc32xx/Kconfig.defconfig.cc3220sf
@@ -6,7 +6,6 @@
 if SOC_CC3220SF
 
 config SOC
-	string
 	default "cc3220sf"
 
 config NUM_IRQS
@@ -16,7 +15,6 @@ config NUM_IRQS
 	default 178
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 80000000
 
 config TEXT_SECTION_OFFSET

--- a/soc/arm/ti_simplelink/cc32xx/Kconfig.defconfig.cc3235sf
+++ b/soc/arm/ti_simplelink/cc32xx/Kconfig.defconfig.cc3235sf
@@ -8,7 +8,6 @@
 if SOC_CC3235SF
 
 config SOC
-	string
 	default "cc3235sf"
 
 config NUM_IRQS
@@ -18,7 +17,6 @@ config NUM_IRQS
 	default 179
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 80000000
 
 config TEXT_SECTION_OFFSET

--- a/soc/arm/ti_simplelink/msp432p4xx/Kconfig.defconfig.msp432p401r
+++ b/soc/arm/ti_simplelink/msp432p4xx/Kconfig.defconfig.msp432p401r
@@ -8,11 +8,9 @@
 if SOC_MSP432P401R
 
 config SOC
-	string
 	default "msp432p401r"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 48000000
 
 config NUM_IRQS

--- a/soc/arm/xilinx_zynqmp/Kconfig.defconfig
+++ b/soc/arm/xilinx_zynqmp/Kconfig.defconfig
@@ -23,7 +23,6 @@ config NUM_2ND_LEVEL_AGGREGATORS
 	default 1
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 12000000
 
 # Workaround for not being able to have commas in macro arguments

--- a/soc/nios2/nios2-qemu/Kconfig.defconfig
+++ b/soc/nios2/nios2-qemu/Kconfig.defconfig
@@ -3,11 +3,9 @@
 if SOC_NIOS2_QEMU
 
 config SOC
-	string
 	default "nios2-qemu"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 50000000
 
 endif

--- a/soc/nios2/nios2f-zephyr/Kconfig.defconfig
+++ b/soc/nios2/nios2f-zephyr/Kconfig.defconfig
@@ -3,11 +3,9 @@
 if SOC_NIOS2F_ZEPHYR
 
 config SOC
-	string
 	default "nios2f-zephyr"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 50000000
 
 config ALTERA_AVALON_SYSID

--- a/soc/riscv/litex-vexriscv/Kconfig.defconfig
+++ b/soc/riscv/litex-vexriscv/Kconfig.defconfig
@@ -7,11 +7,9 @@
 if SOC_RISCV32_LITEX_VEXRISCV
 
 config SOC
-	string
 	default "litex-vexriscv"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 100000000
 
 config RISCV_HAS_CPU_IDLE

--- a/soc/riscv/openisa_rv32m1/Kconfig.defconfig
+++ b/soc/riscv/openisa_rv32m1/Kconfig.defconfig
@@ -7,7 +7,6 @@
 if SOC_OPENISA_RV32M1_RISCV32
 
 config SOC
-	string
 	default "openisa_rv32m1"
 
 # 32 from event unit + 32 * (1 + max enabled INTMUX channel)
@@ -24,24 +23,19 @@ config NUM_IRQS
 	default 32
 
 config XIP
-	bool
 	default y
 
 config RISCV_GENERIC_TOOLCHAIN
-	bool
 	default y if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr"
 	default n
 
 config RISCV_SOC_CONTEXT_SAVE
-	bool
 	default y if SOC_OPENISA_RV32M1_RI5CY
 
 config RISCV_SOC_OFFSETS
-	bool
 	default y
 
 config RISCV_SOC_INTERRUPT_INIT
-	bool
 	default y
 
 # We need to disable the watchdog out of reset, as it's enabled by
@@ -61,24 +55,20 @@ config RISCV_RV32M1_VECTOR_SIZE
 	default 0x100
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 8000000
 
 if MULTI_LEVEL_INTERRUPTS
 
 config MAX_IRQ_PER_AGGREGATOR
-	int
 	default 32
 
 config 2ND_LEVEL_INTERRUPTS
 	default y
 
 config 2ND_LVL_ISR_TBL_OFFSET
-	int
 	default 32
 
 config NUM_2ND_LEVEL_AGGREGATORS
-	int
 	default 8 if RV32M1_INTMUX_CHANNEL_7
 	default 7 if RV32M1_INTMUX_CHANNEL_6
 	default 6 if RV32M1_INTMUX_CHANNEL_5
@@ -89,7 +79,6 @@ config NUM_2ND_LEVEL_AGGREGATORS
 	default 1		# just channel 0
 
 config 2ND_LVL_INTR_00_OFFSET
-	int
 	default 24
 
 config 2ND_LVL_INTR_01_OFFSET
@@ -162,14 +151,14 @@ endif # GPIO
 if SERIAL
 
 config UART_RV32M1_LPUART
-	def_bool y
+	default y
 
 endif # SERIAL
 
 if I2C
 
 config I2C_RV32M1_LPI2C
-	def_bool y
+	default y
 
 endif # I2C
 

--- a/soc/riscv/riscv-privilege/miv/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/miv/Kconfig.defconfig.series
@@ -7,31 +7,24 @@ config SOC_SERIES
 	default "miv"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 660000
 
 config RISCV_SOC_INTERRUPT_INIT
-	bool
 	default y
 
 config RISCV_HAS_CPU_IDLE
-	bool
 	default y
 
 config RISCV_HAS_PLIC
-	bool
 	default y
 
 config 2ND_LVL_ISR_TBL_OFFSET
-	int
 	default 12
 
 config 2ND_LVL_INTR_00_OFFSET
-	int
 	default 11
 
 config MAX_IRQ_PER_AGGREGATOR
-	int
 	default 30
 
 config NUM_IRQS
@@ -39,7 +32,6 @@ config NUM_IRQS
 	default 42
 
 config XIP
-	bool
 	default y
 
 endif # SOC_SERIES_RISCV32_MIV

--- a/soc/riscv/riscv-privilege/sifive-freedom/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/sifive-freedom/Kconfig.defconfig.series
@@ -7,31 +7,24 @@ config SOC_SERIES
 	default "sifive-freedom"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 32768
 
 config RISCV_SOC_INTERRUPT_INIT
-	bool
 	default y
 
 config RISCV_HAS_CPU_IDLE
-	bool
 	default y
 
 config RISCV_HAS_PLIC
-	bool
 	default y
 
 config 2ND_LVL_ISR_TBL_OFFSET
-	int
 	default 12
 
 config 2ND_LVL_INTR_00_OFFSET
-	int
 	default 11
 
 config MAX_IRQ_PER_AGGREGATOR
-	int
 	default 52
 
 config NUM_IRQS
@@ -39,7 +32,6 @@ config NUM_IRQS
 	default 64
 
 config XIP
-	bool
 	default y
 
 endif # SOC_SERIES_RISCV_SIFIVE_FREEDOM

--- a/soc/xtensa/esp32/Kconfig.defconfig
+++ b/soc/xtensa/esp32/Kconfig.defconfig
@@ -6,7 +6,6 @@
 if SOC_ESP32
 
 config SOC
-	string
 	default "esp32"
 
 config IRQ_OFFLOAD_INTNUM

--- a/soc/xtensa/intel_s1000/Kconfig.defconfig
+++ b/soc/xtensa/intel_s1000/Kconfig.defconfig
@@ -6,7 +6,6 @@
 if SOC_INTEL_S1000
 
 config SOC
-	string
 	default "intel_s1000"
 
 config IRQ_OFFLOAD_INTNUM

--- a/soc/xtensa/sample_controller/Kconfig.defconfig
+++ b/soc/xtensa/sample_controller/Kconfig.defconfig
@@ -7,7 +7,6 @@
 if SOC_XTENSA_SAMPLE_CONTROLLER
 
 config SOC
-	string
 	default "sample_controller"
 
 config IRQ_OFFLOAD_INTNUM


### PR DESCRIPTION
Same deal as in commit 7fdb5257547 ("kconfig: Use 'default' instead of
'def_bool' in Kconfig.defconfig files"), but I hacked Kconfiglib to also
find cases where the type is given separately as e.g.

    config FOO
            int
            default 3

Motivation (from a note in
https://docs.zephyrproject.org/latest/guides/kconfig/index.html):

    For a symbol defined in multiple locations (e.g., in a
    Kconfig.defconfig file in Zephyr), it is best to only give the
    symbol type for the "base" definition of the symbol, and to use
    'default' (instead of 'def_<type>' value) for the remaining
    definitions. That way, if the base definition of the symbol is
    removed, the symbol ends up without a type, which generates a
    warning that points to the other definitions. That makes the extra
    definitions easier to discover and remove.

It's also nice if 'def_bool' and the like turn into a semi-reliable flag
that the symbol is only defined in Kconfig.defconfig files. That might
be a sign that things could be cleaned up.

Will do a separate pass later to remove some symbols only defined in
Kconfig.defconfig files.