### PR TITLE
tests: remove duplicate names for the bluetooth tests

### DIFF
--- a/tests/bluetooth/tester/testcase.yaml
+++ b/tests/bluetooth/tester/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  bluetooth.general:
+  bluetooth.general.tester:
     platform_whitelist: qemu_x86
     tags: bluetooth
     harness: bluetooth


### PR DESCRIPTION
According to the comment in #20008 I found out that some test cases
for different tests have same names.
To get rid of it, I decided to change test cases names.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>