### PR TITLE
tests: remove duplicate names for the shell tests

### DIFF
--- a/tests/subsys/shell/shell_history/testcase.yaml
+++ b/tests/subsys/shell/shell_history/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  shell:
+  shell.history:
     min_flash: 64
     min_ram: 32
     filter: ( CONFIG_SHELL )


### PR DESCRIPTION
According to the comment in #20008 I found out that some test cases
for different tests have same names.
To get rid of it, I decided to change test cases names.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>