### PR TITLE
tests: remove duplicate names for the peripheral tests

### DIFF
--- a/tests/drivers/can/stm32/testcase.yaml
+++ b/tests/drivers/can/stm32/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  peripheral.can:
+  peripheral.can.stm32:
     tags: driver can
     depends_on: can


### PR DESCRIPTION
According to the comment in #20008 I found out that some test cases
for different tests have same names.
To get rid of it, I decided to change test cases names.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>