### PR TITLE
tests: remove duplicate names for the net tests

### DIFF
--- a/tests/net/socket/getaddrinfo/testcase.yaml
+++ b/tests/net/socket/getaddrinfo/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   depends_on: netif
 tests:
-  net.socket:
+  net.socket.get_addr_info:
     min_ram: 21
     tags: net socket getaddrinfo userspace

--- a/tests/net/socket/getnameinfo/testcase.yaml
+++ b/tests/net/socket/getnameinfo/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   depends_on: netif
 tests:
-  net.socket:
+  net.socket.get_name_info:
     min_ram: 21
     tags: net socket userspace

--- a/tests/net/socket/misc/testcase.yaml
+++ b/tests/net/socket/misc/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   depends_on: netif
 tests:
-  net.socket:
+  net.socket.misc:
     min_ram: 21
     tags: net socket userspace

--- a/tests/net/socket/select/testcase.yaml
+++ b/tests/net/socket/select/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   depends_on: netif
 tests:
-  net.socket:
+  net.socket.select:
     min_ram: 21
     tags: net socket userspace


### PR DESCRIPTION
According to the comment in #20008 I found out that some test cases
for different tests have same names.
To get rid of it, I decided to change test cases names.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>