### PR TITLE
include: drivers: can: Fix zframe to frame conversion

### DIFF
--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -616,7 +616,8 @@ static inline void can_copy_zframe_to_frame(const struct zcan_frame *zframe,
 					    struct can_frame *frame)
 {
 	frame->can_id = (zframe->id_type << 31) | (zframe->rtr << 30) |
-		zframe->ext_id;
+		(zframe->id_type == CAN_STANDARD_IDENTIFIER ? zframe->std_id :
+				    zframe->ext_id);
 	frame->can_dlc = zframe->dlc;
 	memcpy(frame->data, zframe->data, sizeof(frame->data));
 }


### PR DESCRIPTION
can_copy_zframe_to_frame did not distinguish between the standard and
extended frames. As a result, uninitialized bits were copied to the
destination frame. This commit changes the function to use the correct
bitfields.

This PR is a fix for ##20030 