### PR TITLE
dts: nxp: kinetis-ke1xf-sim: make clkout properties optional

### DIFF
--- a/dts/bindings/arm/nxp,kinetis-ke1xf-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-ke1xf-sim.yaml
@@ -19,10 +19,10 @@ properties:
 
     clkout-source:
       type: int
-      required: true
+      required: false
       description: clkout clock source
 
     clkout-divider:
       type: int
-      required: true
+      required: false
       description: clkout divider


### PR DESCRIPTION
Make the clkout properties of the NXP Kinetis SIM module device tree bindings optional since not all boards rely on this clock signal for clocking external peripherals.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>