### PR TITLE
flash: Fixes on stm32f4 driver

### DIFF
--- a/drivers/flash/flash_stm32f4x.c
+++ b/drivers/flash/flash_stm32f4x.c
@@ -70,6 +70,17 @@ static int erase_sector(struct device *dev, u32_t sector)
 		return rc;
 	}
 
+#if FLASH_SECTOR_TOTAL == 24
+	/*
+	 * RM0090, §3.9.8: STM32F42xxx, STM32F43xxx
+	 * RM0386, §3.7.5: STM32F469xx, STM32F479xx
+	 */
+	if (sector >= 12) {
+		/* From sector 12, SNB is offset by 0b10000 */
+		sector += 4U;
+	}
+#endif
+
 	regs->cr &= STM32F4X_SECTOR_MASK;
 	regs->cr |= FLASH_CR_SER | (sector << 3);
 	regs->cr |= FLASH_CR_STRT;

--- a/drivers/flash/flash_stm32f4x.c
+++ b/drivers/flash/flash_stm32f4x.c
@@ -20,6 +20,17 @@ bool flash_stm32_valid_range(struct device *dev, off_t offset, u32_t len,
 {
 	ARG_UNUSED(write);
 
+#if (FLASH_SECTOR_TOTAL == 12) && defined(FLASH_OPTCR_DB1M)
+	struct stm32f4x_flash *regs = FLASH_STM32_REGS(dev);
+	/*
+	 * RM0090, table 7.1: STM32F42xxx, STM32F43xxx
+	 */
+	if (regs->optcr & FLASH_OPTCR_DB1M) {
+		/* Device configured in Dual Bank, but not supported for now */
+		return false;
+	}
+#endif
+
 	return flash_stm32_range_exists(dev, offset, len);
 }
 


### PR DESCRIPTION
commit 5200669
```
Author: Erwan Gouriou <erwan.gouriou@linaro.org>
Date:   Thu Oct 24 15:10:38 2019 +0200

    drivers/flash: stm32f4: Return error on Dual Bank configuration
    
    Some stm32f4 1MB SoCs support optional Dual Bank configuration.
    This is not yet supported by stm32f4 driver, so report an
    error when configuration is detected
    
    Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>
```

commit 543b3cc
```
Author: Erwan Gouriou <erwan.gouriou@linaro.org>
Date:   Thu Oct 24 15:15:53 2019 +0200

    drivers/flash: stm32f4: Offset SNB from sector 12 on 2MB parts
    
    On 2MB parts, on sector 12 and above SNB is offset by 4.
    
    Fixes #20016
    
    Signed-off-by: Florian Vaussard <florian.vaussard@gmail.com>
    Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>
```