### PR TITLE
Bluetooth: hci: Fix Create Connection Cancel assert

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -427,16 +427,17 @@ static void recv_thread(void *p1, void *p2, void *p3)
 
 static int cmd_handle(struct net_buf *buf)
 {
-	void *node_rx = NULL;
+	struct node_rx_pdu *node_rx = NULL;
 	struct net_buf *evt;
 
-	evt = hci_cmd_handle(buf, &node_rx);
+	evt = hci_cmd_handle(buf, (void **) &node_rx);
 	if (evt) {
 		BT_DBG("Replying with event of %u bytes", evt->len);
 		bt_recv_prio(evt);
 
 		if (node_rx) {
 			BT_DBG("RX node enqueue");
+			node_rx->hdr.user_meta = hci_get_class(node_rx);
 			k_fifo_put(&recv_fifo, node_rx);
 		}
 	}


### PR DESCRIPTION
Since the LE (Enhanced) Connection Complete that comes as part of
cancelling a connection does not come through the priority rx thread in
hci_driver.c, the event class was not being calculated and cached.
Hence, calculate and cache the class whenever an event is received as
part of invoking a command.

Fixes #20110.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>