### PR TITLE
net: mdns: Fix unused variable warnings

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -33,8 +33,12 @@ LOG_MODULE_REGISTER(net_mdns_responder, CONFIG_MDNS_RESPONDER_LOG_LEVEL);
 
 #define MDNS_TTL CONFIG_MDNS_RESPONDER_TTL /* In seconds */
 
+#if defined(CONFIG_NET_IPV4)
 static struct net_context *ipv4;
+#endif
+#if defined(CONFIG_NET_IPV6)
 static struct net_context *ipv6;
+#endif
 
 #define BUF_ALLOC_TIMEOUT K_MSEC(100)
 


### PR DESCRIPTION
Fix GCC "warning: 'ipv4' defined but not used [-Wunused-variable]" and
"warning: 'ipv6' defined but not used [-Wunused-variable]" when either
IPv4 or IPv6 support is not enabled.

Signed-off-by: Markus Fuchs <markus.fuchs@de.sauter-bc.com>