### PR TITLE
boards: mps2_an521: kconfig: Remove unused PINMUX_MPS2 symbol

### DIFF
--- a/boards/arm/mps2_an521/Kconfig.defconfig
+++ b/boards/arm/mps2_an521/Kconfig.defconfig
@@ -39,13 +39,6 @@ config GPIO_CMSDK_AHB_PORT3
 
 endif # GPIO
 
-if PINMUX
-
-config PINMUX_MPS2
-	def_bool y
-
-endif # PINMUX
-
 if SERIAL
 
 config UART_CMSDK_APB


### PR DESCRIPTION
Unused since commit 0829ddfe9a ("kbuild: Removed KBuild").
Kconfig.defconfig leftover.