### PR TITLE
mps2_an521: kconfig: Remove unused TIMER_(D)TMR_CMSDK_APB_(0/1) symbols

### DIFF
--- a/boards/arm/mps2_an521/Kconfig.defconfig
+++ b/boards/arm/mps2_an521/Kconfig.defconfig
@@ -63,28 +63,6 @@ config WDOG_CMSDK_APB
 
 endif # WATCHDOG
 
-if COUNTER
-
-if TIMER_TMR_CMSDK_APB
-
-config TIMER_TMR_CMSDK_APB_0
-	def_bool y
-
-config TIMER_TMR_CMSDK_APB_1
-	def_bool y
-
-endif # TIMER_TMR_CMSDK_APB
-
-
-if TIMER_DTMR_CMSDK_APB
-
-config TIMER_DTMR_CMSDK_APB_0
-	def_bool y
-
-endif # TIMER_DTMR_CMSDK_APB
-
-endif # COUNTER
-
 if I2C
 
 config I2C_SBCON


### PR DESCRIPTION
Unused since commit 7809970c8a ("drivers: counter: cmsdk: Convert to new
DT_<COMPAT>_<INSTANCE> defines"). Kconfig.defconfig leftover.

Found with a script.