### PR TITLE
boards: qemu_cortex_m0: kconfig: Move NRF_TIMER_TIMER to board options

### DIFF
--- a/boards/arm/qemu_cortex_m0/Kconfig
+++ b/boards/arm/qemu_cortex_m0/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2019 Nordic Semiconductor ASA.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_QEMU_CORTEX_M0
+
+config NRF_TIMER_TIMER
+	bool "nRF Timer Counter (NRF_TIMER0) Timer"
+	depends on CLOCK_CONTROL
+	depends on SOC_COMPATIBLE_NRF
+	depends on SYS_CLOCK_EXISTS
+	select TICKLESS_CAPABLE
+	default y
+	help
+	  This module implements a kernel device driver for the nRF Timer
+	  Counter NRF_TIMER0 and provides the standard "system clock driver"
+	  interfaces.
+
+endif # BOARD_QEMU_CORTEX_M0

--- a/boards/arm/qemu_cortex_m0/Kconfig.defconfig
+++ b/boards/arm/qemu_cortex_m0/Kconfig.defconfig
@@ -11,17 +11,6 @@ config BOARD
 
 if SYS_CLOCK_EXISTS
 
-config NRF_TIMER_TIMER
-	bool "nRF Timer Counter (NRF_TIMER0) Timer"
-	depends on CLOCK_CONTROL
-	depends on SOC_COMPATIBLE_NRF
-	select TICKLESS_CAPABLE
-	default y
-	help
-	  This module implements a kernel device driver for the nRF Timer
-	  Counter NRF_TIMER0 and provides the standard "system clock driver"
-	  interfaces.
-
 config NRF_RTC_TIMER
 	default n
 


### PR DESCRIPTION
Kconfig.defconfig files are for adding board-specific defaults to
symbols. Board-specific options go in boards/<board>/Kconfig, which is
source'd from boards/Kconfig and shows up in the Board Options menu.

Found with a script. NRF_TIMER_TIMER was only defined in a
Kconfig.defconfig file.