### PR TITLE
soc: snps_arc_hsdk: kconfig: Remove unused CPU_HS38_LINUX symbol

### DIFF
--- a/soc/arc/snps_arc_hsdk/Kconfig.defconfig
+++ b/soc/arc/snps_arc_hsdk/Kconfig.defconfig
@@ -9,9 +9,6 @@ if SOC_ARC_HSDK
 config SOC
 	default "snps_arc_hsdk"
 
-config CPU_HS38_LINUX
-	def_bool y
-
 config NUM_IRQ_PRIO_LEVELS
 	# This processor supports 2 priority levels:
 	# 0 for Fast Interrupts (FIRQs) and 1 for Regular Interrupts (IRQs).


### PR DESCRIPTION
Added in commit dbc29fe77e ("boards: hsdk: add initial support of ARC HS
Development Kit"), then never used.

Found with a script. CPU_HS38_LINUX was only defined in a
Kconfig.defconfig file.