### PR TITLE
arch: arc: kconfig: Define CPU_EM* + FP_FPU_DA outside Kconfig.defconfig files

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -32,6 +32,33 @@ config	CPU_ARCHS
 
 endchoice
 
+config CPU_EM4
+	bool
+	help
+	  If y, the SoC uses an ARC EM4 CPU
+
+config CPU_EM4_DMIPS
+	bool
+	help
+	  If y, the SoC uses an ARC EM4 DMIPS CPU
+
+config CPU_EM4_FPUS
+	bool
+	help
+	  If y, the SoC uses an ARC EM4 DMIPS CPU with the single-precision
+	  floating-point extension
+
+config CPU_EM4_FPUDA
+	bool
+	help
+	  If y, the SoC uses an ARC EM4 DMIPS CPU with single-precision
+	  floating-point and double assist instructions
+
+config CPU_EM6
+	bool
+	help
+	  If y, the SoC uses an ARC EM6 CPU
+
 menu "ARCv2 Family Options"
 
 config	CPU_ARCV2

--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -59,6 +59,9 @@ config CPU_EM6
 	help
 	  If y, the SoC uses an ARC EM6 CPU
 
+config FP_FPU_DA
+	bool
+
 menu "ARCv2 Family Options"
 
 config	CPU_ARCV2

--- a/soc/arc/snps_arc_iot/Kconfig.defconfig
+++ b/soc/arc/snps_arc_iot/Kconfig.defconfig
@@ -11,7 +11,7 @@ config SOC
 	default "snps_arc_iot"
 
 config CPU_EM4_FPUS
-	def_bool y
+	default y
 
 config NUM_IRQ_PRIO_LEVELS
 	# This processor supports 4 priority levels:

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em11d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em11d
@@ -10,7 +10,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 40000000
 
 config CPU_EM4_FPUDA
-	def_bool y
+	default y
 
 config ARC_MPU_VER
 	default 2

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em11d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em11d
@@ -28,7 +28,7 @@ config CACHE_FLUSHING
 	default y
 
 config FP_FPU_DA
-	def_bool y
+	default y
 
 config MAIN_STACK_SIZE
 	default 2048

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em4
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em4
@@ -28,7 +28,7 @@ config CACHE_FLUSHING
 	default n
 
 config FP_FPU_DA
-	def_bool n
+	default n
 
 config MAIN_STACK_SIZE
 	default 2048

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em4
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em4
@@ -10,7 +10,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 50000000
 
 config CPU_EM4
-	def_bool y
+	default y
 
 config ARC_MPU_VER
 	default 2

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em5d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em5d
@@ -28,7 +28,7 @@ config CACHE_FLUSHING
 	default n
 
 config FP_FPU_DA
-	def_bool y
+	default y
 
 config MAIN_STACK_SIZE
 	default 2048

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em5d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em5d
@@ -10,7 +10,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 40000000
 
 config CPU_EM4_FPUDA
-	def_bool y
+	default y
 
 config ARC_MPU_VER
 	default 2

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em6
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em6
@@ -10,7 +10,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 50000000
 
 config CPU_EM6
-	def_bool y
+	default y
 
 config ARC_MPU_VER
 	default 2

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em6
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em6
@@ -28,7 +28,7 @@ config CACHE_FLUSHING
 	default y
 
 config FP_FPU_DA
-	def_bool n
+	default n
 
 config MAIN_STACK_SIZE
 	default 2048

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em7d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em7d
@@ -10,7 +10,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 40000000
 
 config CPU_EM4_FPUDA
-	def_bool y
+	default y
 
 config ARC_MPU_VER
 	default 2

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em7d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em7d
@@ -28,7 +28,7 @@ config CACHE_FLUSHING
 	default y
 
 config FP_FPU_DA
-	def_bool y
+	default y
 
 config MAIN_STACK_SIZE
 	default 2048

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em7d_esp
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em7d_esp
@@ -10,7 +10,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 50000000
 
 config CPU_EM4_FPUDA
-	def_bool y
+	default y
 
 config ARC_MPU_VER
 	default 3

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em7d_esp
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em7d_esp
@@ -28,6 +28,6 @@ config CACHE_FLUSHING
 	default y
 
 config FP_FPU_DA
-	def_bool y
+	default y
 
 endif #SOC_EMSDP_EM7D_ESP

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em9d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em9d
@@ -28,7 +28,7 @@ config CACHE_FLUSHING
 	default n
 
 config FP_FPU_DA
-	def_bool y
+	default y
 
 config MAIN_STACK_SIZE
 	default 2048

--- a/soc/arc/snps_emsdp/Kconfig.defconfig.em9d
+++ b/soc/arc/snps_emsdp/Kconfig.defconfig.em9d
@@ -10,7 +10,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 40000000
 
 config CPU_EM4_FPUDA
-	def_bool y
+	default y
 
 config ARC_MPU_VER
 	default 2

--- a/soc/arc/snps_emsk/Kconfig.defconfig.em11d
+++ b/soc/arc/snps_emsk/Kconfig.defconfig.em11d
@@ -8,7 +8,7 @@
 if SOC_EMSK_EM11D
 
 config CPU_EM4_FPUDA
-	def_bool y
+	default y
 
 config NUM_IRQ_PRIO_LEVELS
 	# This processor supports 4 priority levels:

--- a/soc/arc/snps_emsk/Kconfig.defconfig.em11d
+++ b/soc/arc/snps_emsk/Kconfig.defconfig.em11d
@@ -33,6 +33,6 @@ config CACHE_FLUSHING
 	default y
 
 config FP_FPU_DA
-	def_bool y
+	default y
 
 endif #SOC_EMSK_EM11D

--- a/soc/arc/snps_emsk/Kconfig.defconfig.em7d
+++ b/soc/arc/snps_emsk/Kconfig.defconfig.em7d
@@ -8,7 +8,7 @@
 if SOC_EMSK_EM7D
 
 config CPU_EM4_DMIPS
-	def_bool y
+	default y
 
 config NUM_IRQ_PRIO_LEVELS
 	# This processor supports 4 priority levels:

--- a/soc/arc/snps_emsk/Kconfig.defconfig.em9d
+++ b/soc/arc/snps_emsk/Kconfig.defconfig.em9d
@@ -8,7 +8,7 @@
 if SOC_EMSK_EM9D
 
 config CPU_EM4_FPUS
-	def_bool y
+	default y
 
 config NUM_IRQ_PRIO_LEVELS
 	# This processor supports 4 priority levels:

--- a/soc/arc/snps_nsim/Kconfig.defconfig.em
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.em
@@ -7,7 +7,7 @@
 if SOC_NSIM_EM
 
 config CPU_EM4_FPUDA
-	def_bool y
+	default y
 
 config NUM_IRQ_PRIO_LEVELS
 	# This processor supports 4 priority levels:

--- a/soc/arc/snps_nsim/Kconfig.defconfig.em
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.em
@@ -37,7 +37,7 @@ config CACHE_FLUSHING
 	default y
 
 config FP_FPU_DA
-	def_bool y
+	default y
 
 if (ARC_MPU_VER = 2)
 

--- a/soc/arc/snps_nsim/Kconfig.defconfig.sem
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.sem
@@ -7,7 +7,7 @@
 if SOC_NSIM_SEM
 
 config CPU_EM4_FPUDA
-	def_bool y
+	default y
 
 config NUM_IRQ_PRIO_LEVELS
 	# This processor supports 4 priority levels:


### PR DESCRIPTION
Define CPU_EM4* and CPU_EM6 in arch/arc/Kconfig to make them always
available. That way, the Kconfig.defconfig definitions can skip the
type, making them incomplete if the base definition of the symbol
disappears. That makes the organization easier to understand and errors
easier to spot.

The help texts were taken from
https://gcc.gnu.org/onlinedocs/gcc/ARC-Options.html. Help texts for
invisible symbols can be checked in the menuconfig too if you go into
show-all mode, so they're better than adding a comment.