### PR TITLE
soc: nxp_imx: Define CLOCK_CONTROL_IMX_CCM outside Kconfig.defconfig

### DIFF
--- a/soc/arm/nxp_imx/Kconfig
+++ b/soc/arm/nxp_imx/Kconfig
@@ -18,4 +18,10 @@ config SOC_PART_NUMBER
 	default SOC_PART_NUMBER_IMX_6X_M4 if SOC_SERIES_IMX_6X_M4
 	default SOC_PART_NUMBER_IMX7_M4 if SOC_SERIES_IMX7_M4
 
+config CLOCK_CONTROL_IMX_CCM
+	bool
+	depends on CLOCK_CONTROL
+	help
+	  If selected, support for the IMX CCM (Clock Controller Module) is enabled
+
 endif # SOC_FAMILY_IMX

--- a/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
+++ b/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
@@ -11,12 +11,9 @@ config SOC
 config FLOAT
 	default y
 
-if CLOCK_CONTROL
-
 config CLOCK_CONTROL_IMX_CCM
-	def_bool y
-
-endif # CLOCK_CONTROL
+	default y
+	depends on CLOCK_CONTROL
 
 if GPIO
 

--- a/soc/arm/nxp_imx/mcimx7_m4/Kconfig.defconfig.mcimx7_m4
+++ b/soc/arm/nxp_imx/mcimx7_m4/Kconfig.defconfig.mcimx7_m4
@@ -11,12 +11,9 @@ config SOC
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 200000000
 
-if CLOCK_CONTROL
-
 config CLOCK_CONTROL_IMX_CCM
 	default y
-
-endif # CLOCK_CONTROL
+	depends on CLOCK_CONTROL
 
 config GPIO
 	default y


### PR DESCRIPTION
Define CLOCK_CONTROL_IMX_CCM in soc/arm/nxp_imx/Kconfig to make it
always available. That way, the Kconfig.defconfig definitions can skip
the type, making them incomplete if the base definition of the symbol
disappears. That makes the organization easier to understand and errors
easier to spot.

The help text is based on googling. Help texts for invisible symbols
appear in the generated documentation and can be checked in the
menuconfig too if you go into show-all mode, so they're better than
adding a comment.