### PR TITLE
Subsys: Settings: Fixed repeated initialization return value

### DIFF
--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -199,7 +199,7 @@ int settings_subsys_init(void)
 	int err = 0;
 
 	if (settings_subsys_initialized) {
-		return 0;
+		return -EALREADY;
 	}
 
 	settings_init();


### PR DESCRIPTION
Fixed repeated call initialization should return `-EALREADY`

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>