### PR TITLE
bluetooth: controller: Remove condition for header inclusion

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -11,9 +11,7 @@
 #include <soc.h>
 #include <device.h>
 #include <drivers/clock_control.h>
-#ifdef CONFIG_CLOCK_CONTROL_NRF
 #include <drivers/clock_control/nrf_clock_control.h>
-#endif
 #include <bluetooth/hci.h>
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)


### PR DESCRIPTION
Remove ifdef guard around inclusion of nrf_clock_control.h in bluetooth
controller as the defines in this header are needed anyway.

Signed-off-by: Solveig Fure <solveig.fure@nordicsemi.no>