### PR TITLE
arm/riscv: kconfig: Remove type from NUM_IRQS in defconfig files

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -76,6 +76,9 @@ config ISA_ARM
 	  processor start-up. Much of its functionality was subsumed into T32 with
 	  the introduction of Thumb-2 technology.
 
+config NUM_IRQS
+	int
+
 config DATA_ENDIANNESS_LITTLE
 	bool
 	default y if CPU_CORTEX

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -92,6 +92,9 @@ config GEN_ISR_TABLES
 config GEN_IRQ_VECTOR_TABLE
 	default n
 
+config NUM_IRQS
+	int
+
 endmenu
 
 endmenu

--- a/soc/arm/arm/beetle/Kconfig.defconfig.series
+++ b/soc/arm/arm/beetle/Kconfig.defconfig.series
@@ -14,7 +14,6 @@ config SOC_SERIES
 	default "beetle"
 
 config NUM_IRQS
-	int
 	default 45
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/soc/arm/arm/mps2/Kconfig.defconfig.mps2_an385
+++ b/soc/arm/arm/mps2/Kconfig.defconfig.mps2_an385
@@ -10,7 +10,6 @@ config SOC
 	default "mps2_an385"
 
 config NUM_IRQS
-	int
 	default 32
 
 endif

--- a/soc/arm/arm/mps2/Kconfig.defconfig.mps2_an521
+++ b/soc/arm/arm/mps2/Kconfig.defconfig.mps2_an521
@@ -10,7 +10,6 @@ config SOC
 	default "mps2_an521"
 
 config NUM_IRQS
-	int
 	default 96
 
 endif

--- a/soc/arm/arm/musca_a/Kconfig.defconfig.musca_a
+++ b/soc/arm/arm/musca_a/Kconfig.defconfig.musca_a
@@ -10,7 +10,6 @@ config SOC
 	default "musca_a"
 
 config NUM_IRQS
-	int
 	default 96
 
 endif

--- a/soc/arm/arm/musca_b1/Kconfig.defconfig.musca_b1
+++ b/soc/arm/arm/musca_b1/Kconfig.defconfig.musca_b1
@@ -10,7 +10,6 @@ config SOC
 	default "musca_b1"
 
 config NUM_IRQS
-	int
 	default 96
 
 endif

--- a/soc/arm/atmel_sam/sam3x/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/sam3x/Kconfig.defconfig.series
@@ -25,7 +25,6 @@ config SOC_PART_NUMBER
 # generating interrupts.
 #
 config NUM_IRQS
-	int
 	default 45
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/soc/arm/atmel_sam/sam4s/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/sam4s/Kconfig.defconfig.series
@@ -30,7 +30,6 @@ config SOC_PART_NUMBER
 # generating interrupts.
 #
 config NUM_IRQS
-	int
 	default 35
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
@@ -37,7 +37,6 @@ config SOC_PART_NUMBER
 # are used).
 #
 config NUM_IRQS
-	int
 	default 74 if SOC_ATMEL_SAME70_REVB
 	default 71
 

--- a/soc/arm/atmel_sam0/samd20/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samd20/Kconfig.defconfig.series
@@ -30,7 +30,6 @@ config SOC_PART_NUMBER
 	default "samd20j18" if SOC_PART_NUMBER_SAMD20J18
 
 config NUM_IRQS
-	int
 	default 25
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/soc/arm/atmel_sam0/samd21/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samd21/Kconfig.defconfig.series
@@ -27,7 +27,6 @@ config SOC_PART_NUMBER
 	default "samd21j18a" if SOC_PART_NUMBER_SAMD21J18A
 
 config NUM_IRQS
-	int
 	default 29
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/soc/arm/atmel_sam0/samr21/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samr21/Kconfig.defconfig.series
@@ -20,7 +20,6 @@ config SOC_PART_NUMBER
 	default "samr21g18a" if SOC_PART_NUMBER_SAMR21G18A
 
 config NUM_IRQS
-	int
 	default 28
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/soc/arm/cypress/psoc6/Kconfig.defconfig.series
+++ b/soc/arm/cypress/psoc6/Kconfig.defconfig.series
@@ -16,8 +16,7 @@ config SOC_PART_NUMBER
 	default "CY8C6247BZI_D54" if SOC_PART_NUMBER_CY8C6247BZI_D54
 
 config NUM_IRQS
-	int
-# must be >= the highest interrupt number used
+	# must be >= the highest interrupt number used
 	default 40
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
@@ -12,7 +12,6 @@ config SOC_SERIES
 	default "mec1501"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	# - include the UART interrupts
 	# All NVIC external sources.

--- a/soc/arm/microchip_mec/mec1701/Kconfig.defconfig.series
+++ b/soc/arm/microchip_mec/mec1701/Kconfig.defconfig.series
@@ -12,7 +12,6 @@ config SOC_SERIES
 	default "mec1701"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	# - include the UART interrupts
 	#for the moment 42 needs to be corrected in terms of devices added

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
@@ -14,7 +14,6 @@ config SOC_SERIES
 	default "nrf51"
 
 config NUM_IRQS
-	int
 	default 26
 
 config TEMP_NRF5

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52810_QFAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52810_QFAA
@@ -12,7 +12,6 @@ config SOC
 	default "nRF52810_QFAA"
 
 config NUM_IRQS
-	int
 	default 30
 
 endif # SOC_NRF52810_QFAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52811_QFAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52811_QFAA
@@ -12,7 +12,6 @@ config SOC
 	default "nRF52811_QFAA"
 
 config NUM_IRQS
-	int
 	default 30
 
 endif # SOC_NRF52811_QFAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_CIAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_CIAA
@@ -12,7 +12,6 @@ config SOC
 	default "nRF52832_CIAA"
 
 config NUM_IRQS
-	int
 	default 39
 
 endif # SOC_NRF52832_CIAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAA
@@ -12,7 +12,6 @@ config SOC
 	default "nRF52832_QFAA"
 
 config NUM_IRQS
-	int
 	default 39
 
 endif # SOC_NRF52832_QFAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAB
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAB
@@ -12,7 +12,6 @@ config SOC
 	default "nRF52832_QFAB"
 
 config NUM_IRQS
-	int
 	default 39
 
 endif # SOC_NRF52832_QFAB

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52840_QIAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52840_QIAA
@@ -12,7 +12,6 @@ config SOC
 	default "nRF52840_QIAA"
 
 config NUM_IRQS
-	int
 	default 48
 
 config NET_CONFIG_IEEE802154_DEV_NAME

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9160_SICA
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9160_SICA
@@ -12,7 +12,6 @@ config SOC
 	default "nRF9160_SICA"
 
 config NUM_IRQS
-	int
 	default 65
 
 endif # SOC_NRF9160_SICA

--- a/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.series
@@ -11,7 +11,6 @@ config SOC_SERIES
 	default "mcimx6x_m4"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 128
 

--- a/soc/arm/nxp_imx/mcimx7_m4/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/mcimx7_m4/Kconfig.defconfig.series
@@ -11,7 +11,6 @@ config SOC_SERIES
 	default "mcimx7_m4"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 127
 

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.series
@@ -13,7 +13,6 @@ config SOC_SERIES
 	default "k2x"
 
 config NUM_IRQS
-	int
 	default 74
 
 source "soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk*"

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.series
@@ -12,7 +12,6 @@ config SOC_SERIES
 	default "k6x"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 86
 

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.series
@@ -11,7 +11,6 @@ config SOC_SERIES
 	default "k8x"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 106
 

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.series
@@ -11,7 +11,6 @@ config SOC_SERIES
 	default "ke1xf"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 91
 

--- a/soc/arm/nxp_kinetis/kl2x/Kconfig.defconfig.mkl25z4
+++ b/soc/arm/nxp_kinetis/kl2x/Kconfig.defconfig.mkl25z4
@@ -11,7 +11,6 @@ config SOC
 	default "mkl25z4"
 
 config NUM_IRQS
-	int
 	default 32
 
 if ADC

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw2xd512
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw2xd512
@@ -22,7 +22,6 @@ config SOC
 endif # SOC_MKW24D5
 
 config NUM_IRQS
-	int
 	default 65
 
 if ADC

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw40z4
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw40z4
@@ -11,7 +11,6 @@ config SOC
 	default "mkw40z4"
 
 config NUM_IRQS
-	int
 	default 32
 
 if ADC

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
@@ -11,7 +11,6 @@ config SOC
 	default "mkw41z4"
 
 config NUM_IRQS
-	int
 	default 32
 
 if ADC

--- a/soc/arm/nxp_lpc/lpc54xxx/Kconfig.defconfig.series
+++ b/soc/arm/nxp_lpc/lpc54xxx/Kconfig.defconfig.series
@@ -11,7 +11,6 @@ config SOC_SERIES
 	default "lpc54xxx"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 40
 

--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.series
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.series
@@ -11,7 +11,6 @@ config SOC_SERIES
 	default "lpc55xxx"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 60
 

--- a/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.series
+++ b/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.series
@@ -15,7 +15,6 @@ config SOC_PART_NUMBER
 	default "EFM32HG322F64" if SOC_PART_NUMBER_EFM32HG322F64
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 20
 

--- a/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.series
+++ b/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.series
@@ -15,7 +15,6 @@ config SOC_PART_NUMBER
 	default "EFM32PG12B500F1024GL125" if SOC_PART_NUMBER_EFM32PG12B500F1024GL125
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 50
 

--- a/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.series
+++ b/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.series
@@ -15,7 +15,6 @@ config SOC_PART_NUMBER
 	default "EFM32WG990F256" if SOC_PART_NUMBER_EFM32WG990F256
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 39
 

--- a/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.series
+++ b/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.series
@@ -15,7 +15,6 @@ config SOC_PART_NUMBER
 	default "EFR32FG1P133F256GM48" if SOC_PART_NUMBER_EFR32FG1P133F256GM48
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 33
 

--- a/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.series
+++ b/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.series
@@ -15,7 +15,6 @@ config SOC_PART_NUMBER
 	default "EFR32MG12P332F1024GL125" if SOC_PART_NUMBER_EFR32MG12P332F1024GL125
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 49
 

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f030x4
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f030x4
@@ -12,7 +12,6 @@ config SOC
 	default "stm32f030x6"
 
 config NUM_IRQS
-	int
 	default 29
 
 endif # SOC_STM32F030X4

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f030x8
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f030x8
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f030x8"
 
 config NUM_IRQS
-	int
 	default 29
 
 endif # SOC_STM32F030X8

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f051x8
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f051x8
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f051x8"
 
 config NUM_IRQS
-	int
 	default 31
 
 endif # SOC_STM32F051X8

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f070xb
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f070xb
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f070xb"
 
 config NUM_IRQS
-	int
 	default 32
 
 endif # SOC_STM32F070XB

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f072xb
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f072xb
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f072xb"
 
 config NUM_IRQS
-	int
 	default 32
 
 endif # SOC_STM32F072XB

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f091xc
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f091xc
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f091xc"
 
 config NUM_IRQS
-	int
 	default 31
 
 endif # SOC_STM32F091XC

--- a/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f103xx
+++ b/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f103xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f103xb"
 
 config NUM_IRQS
-	int
 	default 43
 
 if GPIO_STM32
@@ -29,7 +28,6 @@ config SOC
 	default "stm32f103xe"
 
 config NUM_IRQS
-	int
 	default 60
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f107xc
+++ b/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f107xc
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f107xc"
 
 config NUM_IRQS
-	int
 	default 68
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f2/Kconfig.defconfig.stm32f207xx
+++ b/soc/arm/st_stm32/stm32f2/Kconfig.defconfig.stm32f207xx
@@ -11,7 +11,6 @@ config SOC
 	default "STM32F207xx"
 
 config NUM_IRQS
-	int
 	default 81
 
 endif

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f302x8
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f302x8
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f302x8"
 
 config NUM_IRQS
-	int
 	default 82
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f303xc
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f303xc
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f303xc"
 
 config NUM_IRQS
-	int
 	default 82
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f334x8
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f334x8
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f334x8"
 
 config NUM_IRQS
-	int
 	default 82
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f373xc
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f373xc
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f373xc"
 
 config NUM_IRQS
-	int
 	default 82
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xc
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xc
@@ -11,7 +11,6 @@ config SOC
 	default	"stm32f401xc"
 
 config NUM_IRQS
-	int
 	default 85
 
 endif # SOC_STM32F401XC

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xe
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xe
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f401xe"
 
 config NUM_IRQS
-	int
 	default 85
 
 endif # SOC_STM32F401XE

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f405xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f405xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f405xx"
 
 config NUM_IRQS
-	int
 	default 82
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f407xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f407xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f407xx"
 
 config NUM_IRQS
-	int
 	default 82
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f411xe"
 
 config NUM_IRQS
-	int
 	default 86
 
 endif # SOC_STM32F411XE

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412cg
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412cg
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f412cx"
 
 config NUM_IRQS
-	int
 	default 97
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412zg
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f412zg
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f412zx"
 
 config NUM_IRQS
-	int
 	default 97
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f413xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f413xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f413xx"
 
 config NUM_IRQS
-	int
 	default 102
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f415xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f415xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f415xx"
 
 config NUM_IRQS
-	int
 	default 82
 
 endif # SOC_STM32F415XX

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f417xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f417xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f417xx"
 
 config NUM_IRQS
-	int
 	default 82
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f429xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f429xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f429xx"
 
 config NUM_IRQS
-	int
 	default 91
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f437xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f437xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f437xx"
 
 config NUM_IRQS
-	int
 	default 91
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f446xx"
 
 config NUM_IRQS
-	int
 	default 97
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f469xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f469xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f469xx"
 
 config NUM_IRQS
-	int
 	default 93
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f723xx
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f723xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32f723xx"
 
 config NUM_IRQS
-	int
 	default 104
 
 endif # SOC_STM32F723XX

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f746xx
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f746xx
@@ -21,7 +21,6 @@ config GPIO_STM32_PORTK
 endif # GPIO_STM32
 
 config NUM_IRQS
-	int
 	default 98
 
 endif # SOC_STM32F746XX

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f756xx
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f756xx
@@ -21,7 +21,6 @@ config GPIO_STM32_PORTK
 endif # GPIO_STM32
 
 config NUM_IRQS
-	int
 	default 98
 
 endif # SOC_STM32F756XX

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f769xx
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f769xx
@@ -21,7 +21,6 @@ config GPIO_STM32_PORTK
 endif # GPIO_STM32
 
 config NUM_IRQS
-	int
 	default 110
 
 endif # SOC_STM32F769XX

--- a/soc/arm/st_stm32/stm32g0/Kconfig.defconfig.stm32g071rb
+++ b/soc/arm/st_stm32/stm32g0/Kconfig.defconfig.stm32g071rb
@@ -12,7 +12,6 @@ config SOC
 	default "stm32g071xx"
 
 config NUM_IRQS
-	int
 	default 32
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32g4/Kconfig.defconfig.stm32g431rb
+++ b/soc/arm/st_stm32/stm32g4/Kconfig.defconfig.stm32g431rb
@@ -11,7 +11,6 @@ config SOC
 	default "stm32g431xx"
 
 config NUM_IRQS
-	int
 	default 102
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h747xx
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.stm32h747xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32h747xx"
 
 config NUM_IRQS
-	int
 	default 150
 
 endif # SOC_STM32H747XX

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l053xx
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l053xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32l053xx"
 
 config NUM_IRQS
-	int
 	default 32
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l072xx
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l072xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32l072xx"
 
 config NUM_IRQS
-	int
 	default 32
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l073xx
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l073xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32l073xx"
 
 config NUM_IRQS
-	int
 	default 32
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l151x8a
+++ b/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l151x8a
@@ -11,7 +11,6 @@ config SOC
 	default "stm32l151x8a"
 
 config NUM_IRQS
-	int
 	default 45
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l151xb
+++ b/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l151xb
@@ -11,7 +11,6 @@ config SOC
 	default "stm32l151xb"
 
 config NUM_IRQS
-	int
 	default 45
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l151xba
+++ b/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l151xba
@@ -11,7 +11,6 @@ config SOC
 	default "stm32l151xba"
 
 config NUM_IRQS
-	int
 	default 45
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l432xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l432xx
@@ -12,7 +12,6 @@ config SOC
 	default "stm32l432xx"
 
 config NUM_IRQS
-	int
 	default 83
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l433xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l433xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32l433xx"
 
 config NUM_IRQS
-	int
 	default 83
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l452xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l452xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32l452xx"
 
 config NUM_IRQS
-	int
 	default 85
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l471xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l471xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32l471xx"
 
 config NUM_IRQS
-	int
 	default 82
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l475xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l475xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32l475xx"
 
 config NUM_IRQS
-	int
 	default 82
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l476xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l476xx
@@ -12,7 +12,6 @@ config SOC
 	default "stm32l476xx"
 
 config NUM_IRQS
-	int
 	default 82
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l496xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l496xx
@@ -13,7 +13,6 @@ config SOC
 	default "stm32l496xx"
 
 config NUM_IRQS
-	int
 	default 91
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4r5xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4r5xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32l4r5xx"
 
 config NUM_IRQS
-	int
 	default 95
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4r9xx
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4r9xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32l4r9xx"
 
 config NUM_IRQS
-	int
 	default 95
 
 if GPIO_STM32

--- a/soc/arm/st_stm32/stm32mp1/Kconfig.defconfig.stm32mp15_m4
+++ b/soc/arm/st_stm32/stm32mp1/Kconfig.defconfig.stm32mp15_m4
@@ -11,6 +11,6 @@ config SOC
 	default "stm32mp157cxx"
 
 config NUM_IRQS
-	int
 	default 150
+
 endif # SOC_STM32MP15_M4

--- a/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.stm32wb55xx
+++ b/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.stm32wb55xx
@@ -11,7 +11,6 @@ config SOC
 	default "stm32wb55xx"
 
 config NUM_IRQS
-	int
 	default 63
 
 endif # SOC_STM32WB55XX

--- a/soc/arm/ti_lm3s6965/Kconfig.defconfig
+++ b/soc/arm/ti_lm3s6965/Kconfig.defconfig
@@ -12,7 +12,6 @@ config SOC
 	default "ti_lm3s6965"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	# - include the UART interrupts and ethernet interrupts
 	default 43

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
@@ -23,7 +23,6 @@ config SYS_CLOCK_TICKS_PER_SEC
 	default 32768
 
 config NUM_IRQS
-	int
 	default 38
 
 config TI_CCFG_PRESENT

--- a/soc/arm/ti_simplelink/cc32xx/Kconfig.defconfig.cc3220sf
+++ b/soc/arm/ti_simplelink/cc32xx/Kconfig.defconfig.cc3220sf
@@ -9,7 +9,6 @@ config SOC
 	default "cc3220sf"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	# This includes the NWP interrupt
 	default 178

--- a/soc/arm/ti_simplelink/cc32xx/Kconfig.defconfig.cc3235sf
+++ b/soc/arm/ti_simplelink/cc32xx/Kconfig.defconfig.cc3235sf
@@ -11,7 +11,6 @@ config SOC
 	default "cc3235sf"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	# This includes the NWP interrupt
 	default 179

--- a/soc/arm/ti_simplelink/msp432p4xx/Kconfig.defconfig.msp432p401r
+++ b/soc/arm/ti_simplelink/msp432p4xx/Kconfig.defconfig.msp432p401r
@@ -14,7 +14,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 48000000
 
 config NUM_IRQS
-	int
 	default 64
 
 endif # SOC_MSP432P401R

--- a/soc/arm/xilinx_zynqmp/Kconfig.defconfig
+++ b/soc/arm/xilinx_zynqmp/Kconfig.defconfig
@@ -8,7 +8,6 @@ config SOC
 	default "xilinx_zynqmp"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	# - include the UART interrupts
 	default 220

--- a/soc/riscv/litex-vexriscv/Kconfig.defconfig
+++ b/soc/riscv/litex-vexriscv/Kconfig.defconfig
@@ -19,7 +19,6 @@ config RISCV_HAS_PLIC
 	bool
 
 config NUM_IRQS
-	int
 	default 12
 
 endif # SOC_RISCV32_LITEX_VEXRISCV

--- a/soc/riscv/openisa_rv32m1/Kconfig.defconfig
+++ b/soc/riscv/openisa_rv32m1/Kconfig.defconfig
@@ -11,7 +11,6 @@ config SOC
 
 # 32 from event unit + 32 * (1 + max enabled INTMUX channel)
 config NUM_IRQS
-	int
 	default 288 if RV32M1_INTMUX_CHANNEL_7
 	default 256 if RV32M1_INTMUX_CHANNEL_6
 	default 224 if RV32M1_INTMUX_CHANNEL_5

--- a/soc/riscv/riscv-privilege/miv/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/miv/Kconfig.defconfig.series
@@ -28,7 +28,6 @@ config MAX_IRQ_PER_AGGREGATOR
 	default 30
 
 config NUM_IRQS
-	int
 	default 42
 
 config XIP

--- a/soc/riscv/riscv-privilege/sifive-freedom/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/sifive-freedom/Kconfig.defconfig.series
@@ -28,7 +28,6 @@ config MAX_IRQ_PER_AGGREGATOR
 	default 52
 
 config NUM_IRQS
-	int
 	default 64
 
 config XIP


### PR DESCRIPTION
Add a common definition for NUM_IRQS in arch/arm/core/Kconfig and
arch/riscv/Kconfig. That way, the type doesn't have to be given for
NUM_IRQS in all the Kconfig.defconfig files.

Trying to get rid of unnecessary "full" symbol definitions in
Kconfig.defconfig files, to make the organization clearer. It can also
help with finding unused symbols.