### PR TITLE
arm/riscv: Remove types from SOC_SERIES in Kconfig.defconfig files

### DIFF
--- a/soc/arm/atmel_sam/sam3x/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/sam3x/Kconfig.defconfig.series
@@ -9,7 +9,6 @@
 if SOC_SERIES_SAM3X
 
 config SOC_SERIES
-	string
 	default "sam3x"
 
 config SOC_PART_NUMBER

--- a/soc/arm/atmel_sam/sam4s/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/sam4s/Kconfig.defconfig.series
@@ -9,7 +9,6 @@
 if SOC_SERIES_SAM4S
 
 config SOC_SERIES
-	string
 	default "sam4s"
 
 config SOC_PART_NUMBER

--- a/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
@@ -7,7 +7,6 @@
 if SOC_SERIES_SAME70
 
 config SOC_SERIES
-	string
 	default "same70"
 
 config SOC_PART_NUMBER

--- a/soc/arm/atmel_sam0/samd20/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samd20/Kconfig.defconfig.series
@@ -6,7 +6,6 @@
 if SOC_SERIES_SAMD20
 
 config SOC_SERIES
-	string
 	default "samd20"
 
 config SOC_PART_NUMBER

--- a/soc/arm/atmel_sam0/samd21/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samd21/Kconfig.defconfig.series
@@ -6,7 +6,6 @@
 if SOC_SERIES_SAMD21
 
 config SOC_SERIES
-	string
 	default "samd21"
 
 config SOC_PART_NUMBER

--- a/soc/arm/atmel_sam0/samr21/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samr21/Kconfig.defconfig.series
@@ -6,7 +6,6 @@
 if SOC_SERIES_SAMR21
 
 config SOC_SERIES
-	string
 	default "samr21"
 
 config SOC_PART_NUMBER

--- a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.series
@@ -8,7 +8,6 @@
 if SOC_SERIES_MEC1501X
 
 config SOC_SERIES
-	string
 	default "mec1501"
 
 config NUM_IRQS

--- a/soc/arm/microchip_mec/mec1701/Kconfig.defconfig.series
+++ b/soc/arm/microchip_mec/mec1701/Kconfig.defconfig.series
@@ -8,7 +8,6 @@
 if SOC_SERIES_MEC1701X
 
 config SOC_SERIES
-	string
 	default "mec1701"
 
 config NUM_IRQS

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
@@ -10,7 +10,6 @@ if SOC_SERIES_CC13X2_CC26X2
 source "soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.cc*"
 
 config SOC_SERIES
-	string
 	default "cc13x2_cc26x2"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/soc/riscv/riscv-privilege/miv/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/miv/Kconfig.defconfig.series
@@ -3,7 +3,6 @@
 if SOC_SERIES_RISCV32_MIV
 
 config SOC_SERIES
-	string
 	default "miv"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/soc/riscv/riscv-privilege/sifive-freedom/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/sifive-freedom/Kconfig.defconfig.series
@@ -3,7 +3,6 @@
 if SOC_SERIES_RISCV_SIFIVE_FREEDOM
 
 config SOC_SERIES
-	string
 	default "sifive-freedom"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC


### PR DESCRIPTION
SOC_SERIES is already defined with a type in arch/Kconfig, which is
always included.

Trying to get rid of unnecessary "full" symbol definitions in
Kconfig.defconfig files, to make the organization clearer. It can also
help with finding unused symbols.