### PR TITLE
soc: arm: kconfig: Clean up SOC_PART_NUMBER definitions

### DIFF
--- a/soc/arm/Kconfig
+++ b/soc/arm/Kconfig
@@ -44,3 +44,10 @@ config HAS_SWO
 	bool
 	help
 	  When enabled, indicates that SoC has an SWO output
+
+config SOC_PART_NUMBER
+	string
+	help
+	  This string holds the full part number of the SoC. It is a hidden option
+	  that you should not set directly. The part number selection choice defines
+	  the default value for this string.

--- a/soc/arm/atmel_sam/sam3x/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/sam3x/Kconfig.defconfig.series
@@ -13,7 +13,6 @@ config SOC_SERIES
 	default "sam3x"
 
 config SOC_PART_NUMBER
-	string
 	default "sam3x4c" if SOC_PART_NUMBER_SAM3X4C
 	default "sam3x4e" if SOC_PART_NUMBER_SAM3X4E
 	default "sam3x8c" if SOC_PART_NUMBER_SAM3X8C

--- a/soc/arm/atmel_sam/sam4s/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/sam4s/Kconfig.defconfig.series
@@ -13,7 +13,6 @@ config SOC_SERIES
 	default "sam4s"
 
 config SOC_PART_NUMBER
-	string
 	default "sam4s16c" if SOC_PART_NUMBER_SAM4S16C
 	default "sam4s16b" if SOC_PART_NUMBER_SAM4S16B
 	default "sam4s8c" if SOC_PART_NUMBER_SAM4S8C

--- a/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
@@ -11,7 +11,6 @@ config SOC_SERIES
 	default "same70"
 
 config SOC_PART_NUMBER
-	string
 	default "same70q21" if SOC_PART_NUMBER_SAME70Q21
 	default "same70q20" if SOC_PART_NUMBER_SAME70Q20
 	default "same70q19" if SOC_PART_NUMBER_SAME70Q19

--- a/soc/arm/atmel_sam0/samd20/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samd20/Kconfig.defconfig.series
@@ -10,7 +10,6 @@ config SOC_SERIES
 	default "samd20"
 
 config SOC_PART_NUMBER
-	string
 	default "samd20e14" if SOC_PART_NUMBER_SAMD20E14
 	default "samd20e15" if SOC_PART_NUMBER_SAMD20E15
 	default "samd20e16" if SOC_PART_NUMBER_SAMD20E16

--- a/soc/arm/atmel_sam0/samd21/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samd21/Kconfig.defconfig.series
@@ -10,7 +10,6 @@ config SOC_SERIES
 	default "samd21"
 
 config SOC_PART_NUMBER
-	string
 	default "samd21e15a" if SOC_PART_NUMBER_SAMD21E15A
 	default "samd21e16a" if SOC_PART_NUMBER_SAMD21E16A
 	default "samd21e17a" if SOC_PART_NUMBER_SAMD21E17A

--- a/soc/arm/atmel_sam0/samr21/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samr21/Kconfig.defconfig.series
@@ -10,7 +10,6 @@ config SOC_SERIES
 	default "samr21"
 
 config SOC_PART_NUMBER
-	string
 	default "samr21e16a" if SOC_PART_NUMBER_SAMR21E16A
 	default "samr21e17a" if SOC_PART_NUMBER_SAMR21E17A
 	default "samr21e18a" if SOC_PART_NUMBER_SAMR21E18A

--- a/soc/arm/cypress/psoc6/Kconfig.defconfig.series
+++ b/soc/arm/cypress/psoc6/Kconfig.defconfig.series
@@ -12,7 +12,6 @@ config SOC_SERIES
 	default "psoc6"
 
 config SOC_PART_NUMBER
-	string
 	default "CY8C6247BZI_D54" if SOC_PART_NUMBER_CY8C6247BZI_D54
 
 config NUM_IRQS

--- a/soc/arm/nxp_imx/Kconfig
+++ b/soc/arm/nxp_imx/Kconfig
@@ -14,13 +14,8 @@ config SOC_FAMILY
 source "soc/arm/nxp_imx/*/Kconfig.soc"
 
 config SOC_PART_NUMBER
-	string
 	default SOC_PART_NUMBER_IMX_RT if SOC_SERIES_IMX_RT
 	default SOC_PART_NUMBER_IMX_6X_M4 if SOC_SERIES_IMX_6X_M4
 	default SOC_PART_NUMBER_IMX7_M4 if SOC_SERIES_IMX7_M4
-	help
-	  This string holds the full part number of the SoC. It is a hidden option
-	  that you should not set directly. The part number selection choice defines
-	  the default value for this string.
 
 endif # SOC_FAMILY_IMX

--- a/soc/arm/nxp_kinetis/Kconfig
+++ b/soc/arm/nxp_kinetis/Kconfig
@@ -18,17 +18,12 @@ config SOC_FAMILY
 source "soc/arm/nxp_kinetis/*/Kconfig.soc"
 
 config SOC_PART_NUMBER
-	string
 	default SOC_PART_NUMBER_KINETIS_K2X if SOC_SERIES_KINETIS_K2X
 	default SOC_PART_NUMBER_KINETIS_K6X if SOC_SERIES_KINETIS_K6X
 	default SOC_PART_NUMBER_KINETIS_K8X if SOC_SERIES_KINETIS_K8X
 	default SOC_PART_NUMBER_KINETIS_KWX if SOC_SERIES_KINETIS_KWX
 	default SOC_PART_NUMBER_KINETIS_KL2X if SOC_SERIES_KINETIS_KL2X
 	default SOC_PART_NUMBER_KINETIS_KE1XF if SOC_SERIES_KINETIS_KE1XF
-	help
-	  This string holds the full part number of the SoC. It is a hidden option
-	  that you should not set directly. The part number selection choice defines
-	  the default value for this string.
 
 config HAS_OSC
 	bool

--- a/soc/arm/nxp_lpc/Kconfig
+++ b/soc/arm/nxp_lpc/Kconfig
@@ -9,6 +9,7 @@ config SOC_FAMILY_LPC
 	select HAS_SEGGER_RTT
 
 if SOC_FAMILY_LPC
+
 config SOC_FAMILY
 	string
 	default "nxp_lpc"
@@ -16,12 +17,7 @@ config SOC_FAMILY
 source "soc/arm/nxp_lpc/*/Kconfig.soc"
 
 config SOC_PART_NUMBER
-	string
 	default SOC_PART_NUMBER_LPC54XXX if SOC_SERIES_LPC54XXX
 	default SOC_PART_NUMBER_LPC55XXX if SOC_SERIES_LPC55XXX
 
-	help
-	  This string holds the full part number of the SoC. It is a hidden option
-	  that you should not set directly. The part number selection choice defines
-	  the default value for this string.
 endif # SOC_FAMILY_LPC


### PR DESCRIPTION
Put a common definition of the SOC_PART_NUMBER symbol in
soc/arm/Kconfig, to make it always available for ARM SoCs. Have the
other definitions extend the base definition, without repeating the
type.

Also put the help text on just the base definition. It will show up in
the generated documentation and when looking at the symbol information
at any of the definition locations in the menuconfig (after going into
show-all mode).

Trying to get rid of unnecessary "full" symbol definitions in
Kconfig.defconfig files, to make the organization clearer. It can also
help with finding unused symbols.