### PR TITLE
doc: fix flash_area_get_sectors doc

### DIFF
--- a/include/storage/flash_map.h
+++ b/include/storage/flash_map.h
@@ -157,7 +157,7 @@ int flash_area_erase(const struct flash_area *fa, off_t off, size_t len);
  */
 u8_t flash_area_align(const struct flash_area *fa);
 
-/*
+/**
  * Retrieve info about sectors within the area.
  *
  * @param[in]  fa_id    Given flash area ID


### PR DESCRIPTION
Fix missing doxygen comment before function
which resulted in excluding it from doxygen
output.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>