### PR TITLE
posix arch: Untangle headers

### DIFF
--- a/arch/posix/core/irq.c
+++ b/arch/posix/core/irq.c
@@ -8,6 +8,8 @@
 #include "board_irq.h"
 
 #ifdef CONFIG_IRQ_OFFLOAD
+#include "irq_offload.h"
+
 void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter)
 {
 	posix_irq_offload(routine, parameter);

--- a/arch/posix/include/posix_soc_if.h
+++ b/arch/posix/include/posix_soc_if.h
@@ -16,7 +16,6 @@
 
 #include "posix_trace.h"
 #include "soc_irq.h" /* Must exist and define _ARCH_IRQ/ISR_* macros */
-#include "irq_offload.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,19 +32,8 @@ void posix_irq_unlock(unsigned int key);
 void posix_irq_full_unlock(void);
 int  posix_get_current_irq(void);
 #ifdef CONFIG_IRQ_OFFLOAD
-void posix_irq_offload(irq_offload_routine_t routine, void *parameter);
+void posix_irq_offload(void (*routine)(void *), void *parameter);
 #endif
-
-static ALWAYS_INLINE unsigned int z_arch_irq_lock(void)
-{
-	return posix_irq_lock();
-}
-
-
-static ALWAYS_INLINE void z_arch_irq_unlock(unsigned int key)
-{
-	posix_irq_unlock(key);
-}
 
 #ifdef __cplusplus
 }

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -278,7 +278,7 @@ void posix_sw_clear_pending_IRQ(unsigned int IRQn)
 /**
  * Storage for functions offloaded to IRQ
  */
-static irq_offload_routine_t off_routine;
+static void (*off_routine)(void *);
 static void *off_parameter;
 
 /**
@@ -295,7 +295,7 @@ static void offload_sw_irq_handler(void *a)
  *
  * Raise the SW IRQ assigned to handled this
  */
-void posix_irq_offload(irq_offload_routine_t routine, void *parameter)
+void posix_irq_offload(void (*routine)(void *), void *parameter)
 {
 	off_routine = routine;
 	off_parameter = parameter;

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -337,7 +337,7 @@ void posix_sw_clear_pending_IRQ(unsigned int IRQn)
 /**
  * Storage for functions offloaded to IRQ
  */
-static irq_offload_routine_t off_routine;
+static void (*off_routine)(void *);
 static void *off_parameter;
 
 /**
@@ -354,7 +354,7 @@ static void offload_sw_irq_handler(void *a)
  *
  * Raise the SW IRQ assigned to handled this
  */
-void posix_irq_offload(irq_offload_routine_t routine, void *parameter)
+void posix_irq_offload(void (*routine)(void *), void *parameter)
 {
 	off_routine = routine;
 	off_parameter = parameter;

--- a/include/arch/posix/arch.h
+++ b/include/arch/posix/arch.h
@@ -25,6 +25,7 @@
 #include <arch/posix/asm_inline.h>
 #include <board_irq.h> /* Each board must define this */
 #include <sw_isr_table.h>
+#include <posix_soc_if.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,6 +60,17 @@ static ALWAYS_INLINE void z_arch_nop(void)
 static ALWAYS_INLINE bool z_arch_irq_unlocked(unsigned int key)
 {
 	return key == false;
+}
+
+static ALWAYS_INLINE unsigned int z_arch_irq_lock(void)
+{
+	return posix_irq_lock();
+}
+
+
+static ALWAYS_INLINE void z_arch_irq_unlock(unsigned int key)
+{
+	posix_irq_unlock(key);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
posix_soc_if.h is meant to be a private header between
the POSIX ARCH, SOC, and maybe boards,
it should not contain definitions meant to be used directly
by the kernel or app.

Some definitions were placed here due to a dependency moebius
loop.
Unravel that by removing all header dependencies in posix_soc_if.h,
move those definitions out to a more logical place,
and while we are here reduce the amount of users of
irq_offload.h in POSIX arch related code

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>