### PR TITLE
net: l2: arp: Drop ARP packet that has the interface's source address

### DIFF
--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -565,10 +565,14 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 
 	switch (ntohs(arp_hdr->opcode)) {
 	case NET_ARP_REQUEST:
-		/* If ARP request sender hw address is our address,
+		/* If ARP request sender hw address is our address or
+		 * ethernet header source hw address is our address
 		 * we must drop the packet.
 		 */
 		if (memcmp(&arp_hdr->src_hwaddr,
+			   net_if_get_link_addr(net_pkt_iface(pkt))->addr,
+			   sizeof(struct net_eth_addr)) == 0 ||
+		    memcmp(&eth_hdr->src,
 			   net_if_get_link_addr(net_pkt_iface(pkt))->addr,
 			   sizeof(struct net_eth_addr)) == 0) {
 			return NET_DROP;


### PR DESCRIPTION
If an ARP packet has the interface's MAC hw address in either the ARP
source hw address field or the ethernet hw source addres field, the
packet is either malformed or originated by the receiving host and
shall be dropped. See RFC 826, "Packet format".

Signed-off-by: Patrik Flykt <patrik.flykt@intel.com>