### PR TITLE
[TOPIC-GPIO] tests: gpio_api_1pin: Exclude mps2_an385

### DIFF
--- a/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
+++ b/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
@@ -3,4 +3,6 @@ tests:
     tags: drivers gpio
     depends_on: gpio
     min_flash: 48
+    # Fix exclude when we can exclude just sim run
+    platform_exclude: mps2_an385 mps2_an521
     filter: DT_ALIAS_LED0_GPIOS_CONTROLLER


### PR DESCRIPTION
Exclude the mps2_an385 as we try to run on qemu and that doesnt support
the GPIO/LED so the tests will fail.  For now exclude the platform
completely until we can just do a sim run exclusion.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>