### PR TITLE
drivers: espi: mchp: Remove duplicated KConfig option

### DIFF
--- a/drivers/espi/Kconfig.xec
+++ b/drivers/espi/Kconfig.xec
@@ -7,14 +7,11 @@
 
 config ESPI_XEC
 	bool "XEC Microchip ESPI driver"
-	help
-	  Enable the Microchip XEC ESPI driver.
-
-config ESPI_XEC
-	bool "Enable ESPI IO device"
 	depends on SOC_FAMILY_MEC
 	help
-	  This tells the driver to configure the eSPI device at boot
+	  Enable the Microchip XEC ESPI driver
+
+if ESPI_XEC
 
 config ESPI_PERIPHERAL_HOST_IO
 	def_bool y
@@ -32,3 +29,5 @@ config ESPI_PERIPHERAL_UART_SOC_MAPPING
 	help
 	  This tells the driver to which SoC UART to direct the UART traffic
 	  send over eSPI from host
+
+endif # ESPI_XEC


### PR DESCRIPTION
Fix #20086 by removing duplicate kconfig option.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>