### PR TITLE
kconfig: Turn pointless/confusing 'menuconfig's into 'config's

### DIFF
--- a/drivers/led/Kconfig.lp5562
+++ b/drivers/led/Kconfig.lp5562
@@ -1,10 +1,7 @@
-#
 # Copyright (c) 2018 Workaround GmbH
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-menuconfig LP5562
+config LP5562
 	bool "LP5562 LED driver"
 	depends on I2C
 	help

--- a/drivers/spi/Kconfig.xec_qmspi
+++ b/drivers/spi/Kconfig.xec_qmspi
@@ -1,9 +1,9 @@
 # Kconfig - Microchip XEC QMSPI
-#
+
 # Copyright (c) 2019 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig SPI_XEC_QMSPI
+config SPI_XEC_QMSPI
 	bool "Microchip XEC QMSPI driver"
 	default y
 	depends on SOC_FAMILY_MEC

--- a/drivers/video/Kconfig.mcux_csi
+++ b/drivers/video/Kconfig.mcux_csi
@@ -1,11 +1,8 @@
 # Kconfig - NXP MCUX CSI driver configuration options
 
-#
 # Copyright (c) 2019, Linaro Limited
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-menuconfig VIDEO_MCUX_CSI
+config VIDEO_MCUX_CSI
 	bool "NXP MCUX CMOS Sensor Interface (CSI) driver"
 	depends on HAS_MCUX_CSI

--- a/drivers/video/Kconfig.mt9m114
+++ b/drivers/video/Kconfig.mt9m114
@@ -1,13 +1,10 @@
 # Kconfig - MT9m114
 
-#
 # Copyright (c) 2016 Linaro Limited
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-menuconfig VIDEO_MT9M114
-        bool "MT9M114 Aptina CMOS digital image sensor"
-        depends on I2C
-        help
-          Enable driver for MT9M114 CMOS digital image sensor device.
+config VIDEO_MT9M114
+	bool "MT9M114 Aptina CMOS digital image sensor"
+	depends on I2C
+	help
+	  Enable driver for MT9M114 CMOS digital image sensor device.

--- a/drivers/video/Kconfig.sw_generator
+++ b/drivers/video/Kconfig.sw_generator
@@ -1,12 +1,9 @@
 # Kconfig - MT9m114
 
-#
 # Copyright (c) 2016 Linaro Limited
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-menuconfig VIDEO_SW_GENERATOR
-        bool "Video Software Generator"
-        help
-          Enable video pattern generator (for testing purpose).
+config VIDEO_SW_GENERATOR
+	bool "Video Software Generator"
+	help
+	  Enable video pattern generator (for testing purposes).


### PR DESCRIPTION
Same deal as in commit 677f1e6db9 ("config: Turn pointless/confusing
'menuconfig's into 'config's"), for some newly introduced (or maybe
overlooked) stuff.

Also clean up formatting a bit, replacing spaces with tabs and
shortening the header.