### PR TITLE
bluetooth: controller: Vendor specific ticker resolution margin

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -703,7 +703,7 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 		evt = HDR_LLL2EVT(lll);
 		if (pdu_end_us > (HAL_TICKER_TICKS_TO_US(evt->ticks_slot) -
 				  502 - EVENT_OVERHEAD_START_US -
-				  (EVENT_JITTER_US << 1))) {
+				  EVENT_TICKER_RES_MARGIN_US)) {
 			return -ETIME;
 		}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
@@ -14,6 +14,12 @@
  */
 #define EVENT_OVERHEAD_END_US         40
 #define EVENT_JITTER_US               16
+/* Ticker resolution margin
+ * Needed due to the lack of fine timing resolution in ticker_start
+ * and ticker_update. Set to 32 us, which is ~1 tick with 32768 Hz
+ * clock.
+ */
+#define EVENT_TICKER_RES_MARGIN_US    32
 
 #define EVENT_RX_JITTER_US(phy) 16    /* Radio Rx timing uncertainty */
 #define EVENT_RX_TO_US(phy) ((((((phy)&0x03) + 4)<<3)/BIT((((phy)&0x3)>>1))) + \

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -232,7 +232,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	conn_offset_us = ftr->us_radio_end;
 	conn_offset_us += ((u64_t)win_offset + 1) * 1250U;
 	conn_offset_us -= EVENT_OVERHEAD_START_US;
-	conn_offset_us -= EVENT_JITTER_US << 1;
+	conn_offset_us -= EVENT_TICKER_RES_MARGIN_US;
 	conn_offset_us -= EVENT_JITTER_US;
 	conn_offset_us -= ftr->us_radio_rdy;
 
@@ -317,7 +317,7 @@ void ull_slave_done(struct node_rx_event_done *done, u32_t *ticks_drift_plus,
 		done->extra.slave.preamble_to_addr_us;
 
 	start_to_address_expected_us = EVENT_JITTER_US +
-				       (EVENT_JITTER_US << 1) +
+				       EVENT_TICKER_RES_MARGIN_US +
 				       window_widening_event_us +
 				       preamble_to_addr_us;
 
@@ -332,7 +332,7 @@ void ull_slave_done(struct node_rx_event_done *done, u32_t *ticks_drift_plus,
 			HAL_TICKER_US_TO_TICKS(start_to_address_actual_us);
 		*ticks_drift_minus =
 			HAL_TICKER_US_TO_TICKS(EVENT_JITTER_US +
-					       (EVENT_JITTER_US << 1) +
+					       EVENT_TICKER_RES_MARGIN_US +
 					       preamble_to_addr_us);
 	}
 }


### PR DESCRIPTION
With sub-microsecond resolution in ticker, it is not necessary to add a
precision margin to the conn_offset. A macro is created to allow setting
the margin to something other than the hard coded 2 * EVENT_JITTER_US.

Signed-off-by: Morten Priess <mtpr@oticon.com>