### PR TITLE
scripts: dts: generate array values as initializer lists

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -190,6 +190,8 @@ def write_props(node):
         elif prop.type == "array":
             for i, val in enumerate(prop.val):
                 out_dev(node, "{}_{}".format(ident, i), val)
+            out_dev(node, ident,
+                    "{" + ", ".join(map(str, prop.val)) + "}")
         elif prop.type == "string-array":
             for i, val in enumerate(prop.val):
                 out_dev_s(node, "{}_{}".format(ident, i), val)


### PR DESCRIPTION
Simplify use of property values that have multiple elements.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>

Addresses the behavioral part of #20172