### PR TITLE
cleanup and enhancement of JEDEC SPI NOR support

### DIFF
--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -53,6 +53,7 @@ arduino_serial: &uart4 {};
 	reg = <0x402a8000 0x4000>, <0x60000000 0x1000000>;
 	at25sf128a: at25sf128a@0 {
 		compatible = "adesto,at25sf128a", "jedec,spi-nor";
+		size = <134217728>;
 		label = "AT25SF128A";
 		reg = <0>;
 		spi-max-frequency = <133000000>;

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -61,6 +61,7 @@ arduino_serial: &uart2 {};
 	reg = <0x402a8000 0x4000>, <0x60000000 0x800000>;
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
+		size = <67108864>;
 		label = "IS25WP064";
 		reg = <0>;
 		spi-max-frequency = <133000000>;

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -12,6 +12,7 @@
 	reg = <0x402a8000 0x4000>, <0x60000000 0x800000>;
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
+		size = <67108864>;
 		label = "IS25WP064";
 		reg = <0>;
 		spi-max-frequency = <133000000>;

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -68,6 +68,7 @@ arduino_serial: &uart3 {};
 	reg = <0x402a8000 0x4000>, <0x60000000 0x800000>;
 	is25wp064: is25wp064@0 {
 		compatible = "issi,is25wp064", "jedec,spi-nor";
+		size = <67108864>;
 		label = "IS25WP064";
 		reg = <0>;
 		spi-max-frequency = <133000000>;

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -199,6 +199,9 @@ arduino_i2c: &i2c0 {
 		jedec-id = [c2 28 17];
 		size = <67108864>;
 		has-be32k;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		dpd-wakeup-sequence = <30000 20 45000>;
 		wp-gpios = <&gpio0 22 0>;
 		hold-gpios = <&gpio0 23 0>;
 	};

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -142,6 +142,9 @@
 		hold-gpios = <&gpio0 23 0>;
 		size = <0x2000000>;
 		has-be32k;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <100000>;
 		jedec-id = [c2 20 16];
 	};
 };

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -142,6 +142,9 @@
 		hold-gpios = <&gpio0 23 0>;
 		size = <0x2000000>;
 		has-be32k;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <100000>;
 		jedec-id = [c2 20 16];
 	};
 };

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -142,6 +142,9 @@
 		hold-gpios = <&gpio0 23 0>;
 		size = <0x2000000>;
 		has-be32k;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <100000>;
 		jedec-id = [c2 20 16];
 	};
 };

--- a/boards/riscv/hifive1/hifive1.dts
+++ b/boards/riscv/hifive1/hifive1.dts
@@ -63,6 +63,7 @@
 	reg = <0x10014000 0x1000 0x20400000 0xc00000>;
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";
+		size = <134217728>;
 		label = "FLASH0";
 		jedec-id = [96 60 18];
 		reg = <0>;

--- a/boards/riscv/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv/hifive1_revb/hifive1_revb.dts
@@ -61,6 +61,7 @@
 	reg = <0x10014000 0x1000 0x20010000 0x3c0900>;
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";
+		size = <134217728>;
 		label = "FLASH0";
 		jedec-id = [96 60 18];
 		reg = <0>;

--- a/boards/riscv/qemu_riscv32/qemu_riscv32.dts
+++ b/boards/riscv/qemu_riscv32/qemu_riscv32.dts
@@ -39,6 +39,7 @@
 	reg = <0x10014000 0x1000 0x20400000 0xc00000>;
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";
+		size = <134217728>;
 		label = "FLASH0";
 		jedec-id = [96 60 18];
 		reg = <0>;

--- a/boards/riscv/qemu_riscv64/qemu_riscv64.dts
+++ b/boards/riscv/qemu_riscv64/qemu_riscv64.dts
@@ -43,6 +43,7 @@
 	reg = <0x10014000 0x1000 0x20400000 0xc00000>;
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";
+		size = <134217728>;
 		label = "FLASH0";
 		jedec-id = [96 60 18];
 		reg = <0>;

--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -29,7 +29,8 @@ config SPI_NOR_FLASH_LAYOUT_PAGE_SIZE
 	  When CONFIG_FLASH_PAGE_LAYOUT is used this driver will support
 	  that API.  By default the page size corresponds to the block
 	  size (65536).  Other options include the 32K-byte erase size
-	  (32768), and the sector size (4096).
+	  (32768), the sector size (4096), or any non-zero multiple of the
+	  sector size.
 
 config SPI_NOR_IDLE_IN_DPD
 	bool "Use Deep Power-Down mode when flash is not being accessed."

--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -31,4 +31,16 @@ config SPI_NOR_FLASH_LAYOUT_PAGE_SIZE
 	  size (65536).  Other options include the 32K-byte erase size
 	  (32768), and the sector size (4096).
 
+config SPI_NOR_IDLE_IN_DPD
+	bool "Use Deep Power-Down mode when flash is not being accessed."
+	help
+	  Where supported deep power-down mode can reduce current draw
+	  to as little as 0.1% of standby current.  However it takes
+	  some milliseconds to enter and exit from this mode.
+
+	  Select this option for applications where device power
+	  management is not enabled, the flash remains inactive for
+	  long periods, and when used the impact of waiting for mode
+	  enter and exit delays is acceptable.
+
 endif # SPI_NOR

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -290,11 +290,11 @@ static int spi_nor_write_protection_set(struct device *dev, bool write_protect)
 	ret = spi_nor_cmd_write(dev, (write_protect) ?
 	      SPI_NOR_CMD_WRDI : SPI_NOR_CMD_WREN);
 
-#if DT_INST_0_JEDEC_SPI_NOR_JEDEC_ID_0 == 0xbf && DT_INST_0_JEDEC_SPI_NOR_JEDEC_ID_1 == 0x26
-	if (ret == 0 && !write_protect) {
-		ret = spi_nor_cmd_write(dev, SPI_NOR_CMD_MCHP_UNLOCK);
+	if (IS_ENABLED(DT_INST_0_JEDEC_SPI_NOR_REQUIRES_ULBPR)
+	    && (ret == 0)
+	    && !write_protect) {
+		ret = spi_nor_cmd_write(dev, SPI_NOR_CMD_ULBPR);
 	}
-#endif
 
 	SYNC_UNLOCK();
 

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -528,6 +528,9 @@ static int spi_nor_init(struct device *dev)
 /* instance 0 size in bytes */
 #define INST_0_BYTES (DT_INST_0_JEDEC_SPI_NOR_SIZE / 8)
 
+BUILD_ASSERT_MSG(SPI_NOR_IS_SECTOR_ALIGNED(CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE),
+		 "SPI_NOR_FLASH_LAYOUT_PAGE_SIZE must be multiple of 4096");
+
 /* instance 0 page count */
 #define LAYOUT_PAGES_COUNT (INST_0_BYTES / CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE)
 

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -38,7 +38,7 @@ struct spi_nor_config {
 #define SPI_NOR_CMD_BE          0xD8    /* Block erase */
 #define SPI_NOR_CMD_CE          0xC7    /* Chip erase */
 #define SPI_NOR_CMD_RDID        0x9F    /* Read JEDEC ID */
-#define SPI_NOR_CMD_MCHP_UNLOCK 0x98    /* Microchip: Global unblock */
+#define SPI_NOR_CMD_ULBPR       0x98    /* Global Block Protection Unlock */
 
 /* Page, sector, and block size are standard, not configurable. */
 #define SPI_NOR_PAGE_SIZE    0x0100U

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -39,6 +39,8 @@ struct spi_nor_config {
 #define SPI_NOR_CMD_CE          0xC7    /* Chip erase */
 #define SPI_NOR_CMD_RDID        0x9F    /* Read JEDEC ID */
 #define SPI_NOR_CMD_ULBPR       0x98    /* Global Block Protection Unlock */
+#define SPI_NOR_CMD_DPD         0xB9    /* Deep Power Down */
+#define SPI_NOR_CMD_RDPD        0xAB    /* Release from Deep Power Down */
 
 /* Page, sector, and block size are standard, not configurable. */
 #define SPI_NOR_PAGE_SIZE    0x0100U

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -11,6 +11,7 @@
 	/* WINBOND */
 	w25q32jvwj0: w25q32jvwj@0 {
 		compatible = "winbond,w25q32jvwj", "jedec,spi-nor";
+		size = <33554432>;
 		label = "W25Q32JVWJ0";
 		reg = <0>;
 		spi-max-frequency = <133000000>;

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -19,7 +19,18 @@ properties:
   has-be32k:
     type: boolean
     required: false
-    description: Indicates the device supports the BE32K command
+    description: Indicates the device supports the BE32K (0xD8) command
+
+  requires-ulbpr:
+    type: boolean
+    required: false
+    description: |
+      Indicates the device requires the ULBPR (0x98) command.
+
+      Some flash chips such as the Microchip SST26VF series have a block
+      protection register that initializes to write-protected.  Use this
+      property to indicate that the BPR must be unlocked before write
+      operations can proceed.
 
   size:
     type: int

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -32,6 +32,60 @@ properties:
       property to indicate that the BPR must be unlocked before write
       operations can proceed.
 
+  has-dpd:
+    type: boolean
+    required: false
+    description: |
+      Indicates the device supports the DPD (0xB9) command.
+
+      Use this property to indicate the flash chip supports the Deep
+      Power-Down mode that is entered by command 0xB9 to reduce power
+      consumption below normal standby levels.  Use of this property
+      implies that the RDPD (0xAB) Release from Deep Power Down command
+      is also supported.  (On some chips this command functions as Read
+      Electronic Signature; see t-enter-dpd).
+
+  dpd-wakeup-sequence:
+    type: array
+    required: false
+    description: |
+      Specifies wakeup durations for devices without RDPD.
+
+      Some devices (Macronix MX25R in particular) wake from deep power
+      down by a timed sequence of CSn toggles rather than the RDPD
+      command.  This property specifies three durations measured in
+      nanoseconds, in this order:
+      (1) tDPDD (Delay Time for Release from Deep Power-Down Mode)
+      (2) tCDRP (CSn Toggling Time before Release from Deep Power-Down Mode)
+      (3) tRDP (Recovery Time for Release from Deep Power-Down Mode)
+
+      Absence of this property indicates that the RDPD command should be
+      used to wake the chip from Deep Power-Down mode.
+
+  t-enter-dpd:
+    type: int
+    required: false
+    description: |
+      Duration required to complete the DPD command.
+
+      This provides the duration, in nanoseconds, that CSn must be
+      remain deasserted after issuing DPD before the chip will enter
+      deep power down.
+
+      If not provided the driver does not enforce a delay.
+
+  t-exit-dpd:
+    type: int
+    required: false
+    description: |
+      Duration required to complete the RDPD command.
+
+      This provides the duration, in nanoseconds, that CSn must be
+      remain deasserted after issuing RDPD before the chip will exit
+      deep power down and be ready to receive additional commands.
+
+      If not provided the driver does not enforce a delay.
+
   size:
     type: int
     required: true

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -23,7 +23,7 @@ properties:
 
   size:
     type: int
-    required: false
+    required: true
     description: flash capacity in bits
 
   wp-gpios:

--- a/samples/drivers/spi_flash/sample.yaml
+++ b/samples/drivers/spi_flash/sample.yaml
@@ -16,3 +16,10 @@ tests:
             - "Data read 55 aa"
             - "Data read matches with data written. Good!!"
     depends_on: spi
+  sample.driver.spi_flash_dpd:
+    tags: spi flash
+    filter: dt_compat_enabled("jedec,spi-nor")
+    build_only: true
+    extra_configs:
+      - CONFIG_SPI_NOR_IDLE_IN_DPD=y
+    depends_on: spi

--- a/tests/subsys/fs/littlefs/boards/native_posix.overlay
+++ b/tests/subsys/fs/littlefs/boards/native_posix.overlay
@@ -19,11 +19,11 @@
 			label = "small";
 			reg = <0x00000000 0x00010000>;
 		};
-		partition@200000 {
+		partition@10000 {
 			label = "medium";
 			reg = <0x00010000 0x000F0000>;
 		};
-		partition@220000 {
+		partition@100000 {
 			label = "large";
 			reg = <0x00100000 0x00300000>;
 		};

--- a/tests/subsys/fs/littlefs/boards/native_posix_64.overlay
+++ b/tests/subsys/fs/littlefs/boards/native_posix_64.overlay
@@ -19,11 +19,11 @@
 			label = "small";
 			reg = <0x00000000 0x00010000>;
 		};
-		partition@200000 {
+		partition@10000 {
 			label = "medium";
 			reg = <0x00010000 0x000F0000>;
 		};
-		partition@220000 {
+		partition@100000 {
 			label = "large";
 			reg = <0x00100000 0x00300000>;
 		};

--- a/tests/subsys/fs/littlefs/boards/nrf52840_pca10056.overlay
+++ b/tests/subsys/fs/littlefs/boards/nrf52840_pca10056.overlay
@@ -14,11 +14,11 @@
 			label = "small";
 			reg = <0x00000000 0x00010000>;
 		};
-		partition@200000 {
+		partition@10000 {
 			label = "medium";
 			reg = <0x00010000 0x000F0000>;
 		};
-		partition@220000 {
+		partition@100000 {
 			label = "large";
 			reg = <0x00100000 0x00300000>;
 		};


### PR DESCRIPTION
Fixes bad unit addresses in the bindings used to test littlefs.

Changes `jedec,spi-nor` binding to require the `size` property, which is in fact required for the driver to build.  Adds the property to all declared compatible nodes in-tree from which it was missing.

Extends `jedec,spi-nor` binding to identify support for deep-power-down mode, a common feature that can reduce standby mode current consumption by as much as 99.9% (MX25L32 from 10 uA to 3 uA; MX24R64 from 9 uA to 7 nA).

Updates driver to place chip into DPD when it is not active.