### PR TITLE
tests: eliminate the compile warning for arc

### DIFF
--- a/tests/kernel/fp_sharing/generic/src/float_regs_arc_gcc.h
+++ b/tests/kernel/fp_sharing/generic/src/float_regs_arc_gcc.h
@@ -38,9 +38,9 @@
  */
 static inline void _load_all_float_registers(struct fp_register_set *regs)
 {
+#ifdef CONFIG_FP_FPU_DA
 	u32_t temp = 0;
 
-#ifdef CONFIG_FP_FPU_DA
 	__asm__ volatile (
 		"ld.ab %1, [%0, 4];\n\t"
 		"sr %1, [%2];\n\t"
@@ -72,9 +72,9 @@ static inline void _load_all_float_registers(struct fp_register_set *regs)
 
 static inline void _store_all_float_registers(struct fp_register_set *regs)
 {
+#ifdef CONFIG_FP_FPU_DA
 	u32_t temp = 0;
 
-#ifdef CONFIG_FP_FPU_DA
 	__asm__ volatile (
 		"lr %1, [%2];\n\t"
 		"st.ab %1, [%0, 4];\n\t"


### PR DESCRIPTION
the compile warning will fail the CI

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>