### PR TITLE
dts: Add bindings for Nordic nRF family IPC and RNG peripherals

### DIFF
--- a/dts/bindings/ipm/nordic,nrf-ipc.yaml
+++ b/dts/bindings/ipm/nordic,nrf-ipc.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+title: Nordic nRF family IPC
+
+description: Nordic nRF family IPC (Interprocessor Communication)
+
+compatible: "nordic,nrf-ipc"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true

--- a/dts/bindings/rng/nordic,nrf-rng.yaml
+++ b/dts/bindings/rng/nordic,nrf-rng.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+title: Nordic nRF family RNG
+
+description: Nordic nRF family RNG (Random Number Generator)
+
+compatible: "nordic,nrf-rng"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true


### PR DESCRIPTION
Add bindings for Nordic nRF family peripherals:
- IPC (Interprocessor Communication)
- RNG (Random Number Generator)

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>