### PR TITLE
driver: modem: ublox sara u2/r4 localization info

### DIFF
--- a/drivers/modem/modem_receiver.h
+++ b/drivers/modem/modem_receiver.h
@@ -21,6 +21,26 @@
 extern "C" {
 #endif
 
+/* Localisation Data */
+struct mdm_cell_locate {
+	char *date;
+	char *time;
+	char *lat;
+	char *lon;
+	int alt;
+	int uncertainty;
+	int speed;
+	int direction;
+	int vertical_acc;
+	int sensor_used;
+	int sv_used;
+	int antenna_status;
+	int jamming_status;
+	int count;
+	bool ok;
+	int size;
+};
+
 struct mdm_receiver_context {
 	struct device *uart_dev;
 
@@ -33,7 +53,10 @@ struct mdm_receiver_context {
 	char *data_model;
 	char *data_revision;
 	char *data_imei;
-	int   data_rssi;
+	int data_rssi;
+
+	/* UBLOX Cell Localization Data */
+	struct mdm_cell_locate data_locaization;
 };
 
 /**


### PR DESCRIPTION
UBlox Sara U2/R4 Localisation info commands

Uses the UBlox cellular location sensor (CellLocate®)
+ULOCCELL

May have issues with the R4 as UBlox were problems with original firmware
