### PR TITLE
dts: bindings: Preserve newlines in descriptions

### DIFF
--- a/dts/bindings/arc/arc,dccm.yaml
+++ b/dts/bindings/arc/arc,dccm.yaml
@@ -3,7 +3,7 @@
 
 title: ARC DCCM
 
-description: >
+description: |
     This binding gives a base representation of the ARC DCCM
 
 compatible: "arc,dccm"

--- a/dts/bindings/arc/arc,iccm.yaml
+++ b/dts/bindings/arc/arc,iccm.yaml
@@ -3,7 +3,7 @@
 
 title: ARC ICCM
 
-description: >
+description: |
     This binding gives a base representation of the ARC ICCM
 
 compatible: "arc,iccm"

--- a/dts/bindings/arm/arm,dtcm.yaml
+++ b/dts/bindings/arm/arm,dtcm.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 title: DTCM
 
-description: >
+description: |
   This binding gives a base representation of the Cortex M7 DTCM (Data Tightly Coupled Memory)
 
 compatible: "arm,dtcm"

--- a/dts/bindings/arm/arm,scc.yaml
+++ b/dts/bindings/arm/arm,scc.yaml
@@ -3,7 +3,7 @@
 
 title: ARM Serial Configuration Control
 
-description: >
+description: |
     This binding gives a base representation of the ARM SCC
 
 compatible: "arm,scc"

--- a/dts/bindings/arm/atmel,sam0-device_id.yaml
+++ b/dts/bindings/arm/atmel,sam0-device_id.yaml
@@ -1,6 +1,6 @@
 title: Atmel Device ID (Serial Number) binding
 
-description: >
+description: |
     Binding for locating the Device ID (serial number) on Atmel SAM0 devices.
 
 compatible: "atmel,sam0-id"

--- a/dts/bindings/arm/atmel,sam0-dmac.yaml
+++ b/dts/bindings/arm/atmel,sam0-dmac.yaml
@@ -1,6 +1,6 @@
 title: Atmel DMAC binding
 
-description: >
+description: |
     Binding for the Atmel SAM0 DMA controller.
 
 compatible: "atmel,sam0-dmac"

--- a/dts/bindings/arm/atmel,sam0-sercom.yaml
+++ b/dts/bindings/arm/atmel,sam0-sercom.yaml
@@ -1,6 +1,6 @@
 title: Atmel SERCOM binding
 
-description: >
+description: |
     Binding for the Atmel SAM0 multi-protocol (UART, SPI, I2C) SERCOM unit.
 
 compatible: "atmel,sam0-sercom"

--- a/dts/bindings/arm/nordic,nrf-dppic.yaml
+++ b/dts/bindings/arm/nordic,nrf-dppic.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic DPPIC
 
-description: >
+description: |
     Binding for the Nordic DPPIC
     Distributed Programmable Peripheral Interconnect Controller
 

--- a/dts/bindings/arm/nordic,nrf-egu.yaml
+++ b/dts/bindings/arm/nordic,nrf-egu.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic EGU
 
-description: >
+description: |
     Binding for the Nordic EGU (Event Generator Unit)
 
 compatible: "nordic,nrf-egu"

--- a/dts/bindings/arm/nordic,nrf-ficr.yaml
+++ b/dts/bindings/arm/nordic,nrf-ficr.yaml
@@ -1,6 +1,6 @@
 title: Nordic FICR (Factory Information Configuration Registers)
 
-description: >
+description: |
     Binding for the Nordic FICR (Factory Information Configuration Registers)
 
 compatible: "nordic,nrf-ficr"

--- a/dts/bindings/arm/nordic,nrf-kmu.yaml
+++ b/dts/bindings/arm/nordic,nrf-kmu.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic KMU
 
-description: >
+description: |
     Binding for the Nordic KMU (Key Management Unit)
 
 compatible: "nordic,nrf-kmu"

--- a/dts/bindings/arm/nordic,nrf-spu.yaml
+++ b/dts/bindings/arm/nordic,nrf-spu.yaml
@@ -1,6 +1,6 @@
 title: Nordic SPU (System Protection Unit)
 
-description: >
+description: |
     Binding for the Nordic SPU (System Protection Unit)
 
 compatible: "nordic,nrf-spu"

--- a/dts/bindings/arm/nordic,nrf-uicr.yaml
+++ b/dts/bindings/arm/nordic,nrf-uicr.yaml
@@ -1,6 +1,6 @@
 title: Nordic UICR (User Information Configuration Registers)
 
-description: >
+description: |
     Binding for the Nordic UICR (User Information Configuration Registers)
 
 compatible: "nordic,nrf-uicr"

--- a/dts/bindings/arm/nxp,imx-dtcm.yaml
+++ b/dts/bindings/arm/nxp,imx-dtcm.yaml
@@ -3,7 +3,7 @@
 
 title: i.MX DTCM (Data Tightly Coupled Memory)
 
-description: >
+description: |
   This binding gives a base representation of the i.MX DTCM
 
 compatible: "nxp,imx-dtcm"

--- a/dts/bindings/arm/nxp,imx-epit.yaml
+++ b/dts/bindings/arm/nxp,imx-epit.yaml
@@ -3,7 +3,7 @@
 
 title: IMX EPIT COUNTER
 
-description: >
+description: |
     This binding gives a base representation of the i.MX Enhanced Periodic Interrupt Timer (EPIT)
 
 compatible: "nxp,imx-epit"

--- a/dts/bindings/arm/nxp,imx-itcm.yaml
+++ b/dts/bindings/arm/nxp,imx-itcm.yaml
@@ -3,7 +3,7 @@
 
 title: i.MX ITCM (Instruction Tightly Coupled Memory)
 
-description: >
+description: |
   This binding gives a base representation of the i.MX ITCM
 
 compatible: "nxp,imx-itcm"

--- a/dts/bindings/arm/nxp,imx-mu.yaml
+++ b/dts/bindings/arm/nxp,imx-mu.yaml
@@ -3,7 +3,7 @@
 
 title: IMX MESSAGING UNIT
 
-description: >
+description: |
     This binding gives a base representation of the i.MX Messaging Unit
 
 compatible: "nxp,imx-mu"

--- a/dts/bindings/arm/nxp,kinetis-ke1xf-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-ke1xf-sim.yaml
@@ -3,7 +3,7 @@
 
 title: Kinetis KE1xF System Integration Module (SIM)
 
-description: >
+description: |
     This is a representation of the Kinetis SIM IP node
 
 compatible: "nxp,kinetis-ke1xf-sim"

--- a/dts/bindings/arm/nxp,kinetis-mcg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-mcg.yaml
@@ -3,7 +3,7 @@
 
 title: NXP Kinetis Multipurpose Clock Generator (MCG)
 
-description: >
+description: |
     This is a representation of the NXP Kinetis MCG IP node
 
 compatible: "nxp,kinetis-mcg"

--- a/dts/bindings/arm/nxp,kinetis-pcc.yaml
+++ b/dts/bindings/arm/nxp,kinetis-pcc.yaml
@@ -3,7 +3,7 @@
 
 title: NXP Kinetis PCC (Peripheral Clock Controller)
 
-description: >
+description: |
     This is a representation of the NXP Kinetis PCC IP node
 
 compatible: "nxp,kinetis-pcc"

--- a/dts/bindings/arm/nxp,kinetis-scg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-scg.yaml
@@ -3,7 +3,7 @@
 
 title: NXP Kinetis SCG (System Clock Generator)
 
-description: >
+description: |
     This is a representation of the NXP Kinetis SCG IP node
 
 compatible: "nxp,kinetis-scg"

--- a/dts/bindings/arm/nxp,kinetis-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-sim.yaml
@@ -3,7 +3,7 @@
 
 title: Kinetis System Integration Module (SIM)
 
-description: >
+description: |
     This is a representation of the Kinetis SIM IP node
 
 compatible: "nxp,kinetis-sim"

--- a/dts/bindings/arm/nxp,lpc-mailbox.yaml
+++ b/dts/bindings/arm/nxp,lpc-mailbox.yaml
@@ -3,7 +3,7 @@
 
 title: LPC MAILBOX
 
-description: >
+description: |
     This binding gives a base representation of the LPC MAILBOX
 
 compatible: "nxp,lpc-mailbox"

--- a/dts/bindings/arm/st,stm32-ccm.yaml
+++ b/dts/bindings/arm/st,stm32-ccm.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 title: STM32 CCM
 
-description: >
+description: |
   This binding gives a base representation of the STM32 CCM (Core Coupled Memory)
 
 compatible: "st,stm32-ccm"

--- a/dts/bindings/arm/ti,cc2650-prcm.yaml
+++ b/dts/bindings/arm/ti,cc2650-prcm.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 title: TI CC2650 PRCM
 
-description: >
+description: |
     This binding gives a base representation of the TI CC2650
     Power, Reset, and Clock control Module.
 

--- a/dts/bindings/audio/nordic,nrf-pdm.yaml
+++ b/dts/bindings/audio/nordic,nrf-pdm.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic PDM
 
-description: >
+description: |
     Binding for the Nordic PDM (pulse density modulation interface)
 
 compatible: "nordic,nrf-pdm"

--- a/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
+++ b/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
@@ -3,7 +3,7 @@
 
 title: ST Microelectronics MPXXDTYY digital pdm microphone family
 
-description: >
+description: |
     This binding gives a base representation of MPXXDTYY digital microphone family
 
 compatible: "st,mpxxdtyy"

--- a/dts/bindings/audio/ti,tlv320dac.yaml
+++ b/dts/bindings/audio/ti,tlv320dac.yaml
@@ -3,7 +3,7 @@
 
 title: Texas Instruments TLV320DAC Audio DAC
 
-description: >
+description: |
     This binding gives a base representation of TLV320DAC310x Audio DAC
 
 compatible: "ti,tlv320dac"

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
@@ -3,7 +3,7 @@
 
 title: Bluetooth controller that provides Host Controller Interface over SPI
 
-description: >
+description: |
     This binding gives the base representation of a bluetooth controller node
     that provides HCI over SPI.
 

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
@@ -3,7 +3,7 @@
 
 title: Bluetooth module based on Zephyr's Bluetooth HCI SPI driver
 
-description: >
+description: |
     This binding gives the base representation of a bluetooth module which use
     Zephyr's bluetooth Host Controller Interface SPI driver (e.g. nRF51822).
 

--- a/dts/bindings/can/microchip,mcp2515.yaml
+++ b/dts/bindings/can/microchip,mcp2515.yaml
@@ -3,7 +3,7 @@
 
 title: MCP2515 CAN
 
-description: >
+description: |
     This binding gives a base representation of the MCP2515 SPI CAN controller
 
 compatible: "microchip,mcp2515"

--- a/dts/bindings/can/nxp,kinetis-flexcan.yaml
+++ b/dts/bindings/can/nxp,kinetis-flexcan.yaml
@@ -3,7 +3,7 @@
 
 title: NXP FlexCAN
 
-description: >
+description: |
     This binding gives a base representation of the NXP FlexCAN controller
 
 compatible: "nxp,kinetis-flexcan"

--- a/dts/bindings/can/st,stm32-can.yaml
+++ b/dts/bindings/can/st,stm32-can.yaml
@@ -1,6 +1,6 @@
 title: STM32 CAN
 
-description: >
+description: |
     This binding gives a base representation of the STM32 CAN controller
 
 compatible: "st,stm32-can"

--- a/dts/bindings/clock/fixed-clock.yaml
+++ b/dts/bindings/clock/fixed-clock.yaml
@@ -3,7 +3,7 @@
 
 title: Generic fixed rate clock provider
 
-description: >
+description: |
     This is a representation of a generic fixed rate clock provider.
 
 compatible: "fixed-clock"

--- a/dts/bindings/clock/nordic,nrf-clock.yaml
+++ b/dts/bindings/clock/nordic,nrf-clock.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic nRF clock control
 
-description: >
+description: |
     This is a representation of the Nordic nRF clock control node
 
 compatible: "nordic,nrf-clock"

--- a/dts/bindings/clock/nxp,imx-ccm.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm.yaml
@@ -3,7 +3,7 @@
 
 title: i.MX Clock Controller Module (CCM)
 
-description: >
+description: |
     This is a representation of the i.MX CCM IP node
 
 compatible: "nxp,imx-ccm"

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -1,6 +1,6 @@
 title: STM32 RCC
 
-description: >
+description: |
     This binding gives a base representation of the STM32 Clock control
 
 compatible: "st,stm32-rcc"

--- a/dts/bindings/cpu/arm,cortex-m0+.yaml
+++ b/dts/bindings/cpu/arm,cortex-m0+.yaml
@@ -3,7 +3,7 @@
 
 title: ARM Cortex-M0+ CPU
 
-description: >
+description: |
     This binding gives a base representation for ARM Cortex-M0+ CPU.
 
 compatible: "arm,cortex-m0+"

--- a/dts/bindings/cpu/arm,cortex-m0.yaml
+++ b/dts/bindings/cpu/arm,cortex-m0.yaml
@@ -3,7 +3,7 @@
 
 title: ARM Cortex-M0 CPU
 
-description: >
+description: |
     This binding gives a base representation for ARM Cortex-M0 CPU.
 
 compatible: "arm,cortex-m0"

--- a/dts/bindings/cpu/arm,cortex-m23.yaml
+++ b/dts/bindings/cpu/arm,cortex-m23.yaml
@@ -3,7 +3,7 @@
 
 title: ARM Cortex-M23 CPU
 
-description: >
+description: |
     This binding gives a base representation for ARM Cortex-M23 CPU.
 
 compatible: "arm,cortex-m23"

--- a/dts/bindings/cpu/arm,cortex-m3.yaml
+++ b/dts/bindings/cpu/arm,cortex-m3.yaml
@@ -3,7 +3,7 @@
 
 title: ARM Cortex-M3 CPU
 
-description: >
+description: |
     This binding gives a base representation for ARM Cortex-M3 CPU.
 
 compatible: "arm,cortex-m3"

--- a/dts/bindings/cpu/arm,cortex-m33.yaml
+++ b/dts/bindings/cpu/arm,cortex-m33.yaml
@@ -3,7 +3,7 @@
 
 title: ARM Cortex-M33 CPU
 
-description: >
+description: |
     This binding gives a base representation for ARM Cortex-M33 CPU.
 
 compatible: "arm,cortex-m33"

--- a/dts/bindings/cpu/arm,cortex-m4.yaml
+++ b/dts/bindings/cpu/arm,cortex-m4.yaml
@@ -3,7 +3,7 @@
 
 title: ARM Cortex-M4 CPU
 
-description: >
+description: |
     This binding gives a base representation for ARM Cortex-M4 CPU.
 
 compatible: "arm,cortex-m4"

--- a/dts/bindings/cpu/arm,cortex-m4f.yaml
+++ b/dts/bindings/cpu/arm,cortex-m4f.yaml
@@ -3,7 +3,7 @@
 
 title: ARM Cortex-M4F CPU
 
-description: >
+description: |
     This binding gives a base representation for ARM Cortex-M4F CPU.
 
 compatible: "arm,cortex-m4f"

--- a/dts/bindings/cpu/arm,cortex-m7.yaml
+++ b/dts/bindings/cpu/arm,cortex-m7.yaml
@@ -3,7 +3,7 @@
 
 title: ARM Cortex-M7 CPU
 
-description: >
+description: |
     This binding gives a base representation for ARM Cortex-M7 CPU.
 
 compatible: "arm,cortex-m7"

--- a/dts/bindings/cpu/arm,cortex-r4.yaml
+++ b/dts/bindings/cpu/arm,cortex-r4.yaml
@@ -3,7 +3,7 @@
 
 title: ARM Cortex-R4 CPU
 
-description: >
+description: |
     This is a representation of ARM Cortex-R4 CPU.
 
 compatible: "arm,cortex-r4"

--- a/dts/bindings/cpu/arm,cortex-r4f.yaml
+++ b/dts/bindings/cpu/arm,cortex-r4f.yaml
@@ -3,7 +3,7 @@
 
 title: ARM Cortex-R4F CPU
 
-description: >
+description: |
     This is a representation of ARM Cortex-R4F CPU.
 
 compatible: "arm,cortex-r4f"

--- a/dts/bindings/cpu/arm,cortex-r5.yaml
+++ b/dts/bindings/cpu/arm,cortex-r5.yaml
@@ -3,7 +3,7 @@
 
 title: ARM Cortex-R5 CPU
 
-description: >
+description: |
     This is a representation of ARM Cortex-R5 CPU.
 
 compatible: "arm,cortex-r5"

--- a/dts/bindings/cpu/arm,cortex-r5f.yaml
+++ b/dts/bindings/cpu/arm,cortex-r5f.yaml
@@ -3,7 +3,7 @@
 
 title: ARM Cortex-R5F CPU
 
-description: >
+description: |
     This is a representation of ARM Cortex-R5F CPU.
 
 compatible: "arm,cortex-r5f"

--- a/dts/bindings/cpu/cadence,tensilica-xtensa-lx6.yaml
+++ b/dts/bindings/cpu/cadence,tensilica-xtensa-lx6.yaml
@@ -3,7 +3,7 @@
 
 title: Cadence Tensilica Xtensa LX6 CPU
 
-description: >
+description: |
     This binding gives a base representation for Cadence Tensilica Xtensa LX6 CPU.
 
 compatible: "cadence,tensilica-xtensa-lx6"

--- a/dts/bindings/cpu/sample_controller.yaml
+++ b/dts/bindings/cpu/sample_controller.yaml
@@ -3,7 +3,7 @@
 
 title: Sample Controller CPU
 
-description: >
+description: |
     This binding gives a base representation for Sample Controller CPU.
 
 compatible: "sample_controller"

--- a/dts/bindings/cpu/snps,arcem.yaml
+++ b/dts/bindings/cpu/snps,arcem.yaml
@@ -3,7 +3,7 @@
 
 title: Synopsys ARC EM CPU
 
-description: >
+description: |
     This binding gives a base representation for Synopsys ARC EM CPU.
 
 compatible: "snps,arcem"

--- a/dts/bindings/crypto/arm,cryptocell-310.yaml
+++ b/dts/bindings/crypto/arm,cryptocell-310.yaml
@@ -3,7 +3,7 @@
 
 title: ARM TrustZone CryptoCell 310
 
-description: >
+description: |
     This is a representation of the ARM TrustZone CryptoCell 310
 
 compatible: "arm,cryptocell-310"

--- a/dts/bindings/crypto/nordic,nrf-cc310.yaml
+++ b/dts/bindings/crypto/nordic,nrf-cc310.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic Control Interface for ARM TrustZone CryptoCell 310
 
-description: >
+description: |
     This is a representation of the Nordic Control Interface for ARM TrustZone CryptoCell 310
 
 compatible: "nordic,nrf-cc310"

--- a/dts/bindings/display/fsl,imx6sx-lcdif.yaml
+++ b/dts/bindings/display/fsl,imx6sx-lcdif.yaml
@@ -3,7 +3,7 @@
 
 title: NXP Enhanced LCD Interface (eLCDIF) controller
 
-description: >
+description: |
     This binding gives a base representation of the NXP i.MX eLCDIF controller
 
 compatible: "fsl,imx6sx-lcdif"

--- a/dts/bindings/display/ilitek,ili9340.yaml
+++ b/dts/bindings/display/ilitek,ili9340.yaml
@@ -3,7 +3,7 @@
 
 title: ILI9340 320x240 Display Controller
 
-description: >
+description: |
     This is a representation of the ILI9340 320x240 Display Controller
 
 compatible: "ilitek,ili9340"

--- a/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
+++ b/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
@@ -3,7 +3,7 @@
 
 title: Rocktech LCD Module
 
-description: >
+description: |
     This binding gives a base representation of the Rocktech LCD module with
     LED backlight and capacitive touch panel.
 

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -3,7 +3,7 @@
 
 title: ST7789V 320x240 Display Controller
 
-description: >
+description: |
     This is a representation of the ST7789V 320x240 Display Controller
 
 compatible: "sitronix,st7789v"

--- a/dts/bindings/display/solomon,ssd1306fb.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb.yaml
@@ -3,7 +3,7 @@
 
 title: SSD1306 128x64 Dot Matrix Display Controller
 
-description: >
+description: |
     This is a representation of the SSD1306 128x64 Dot Matrix Display Controller
 
 compatible: "solomon,ssd1306fb"

--- a/dts/bindings/display/solomon,ssd1673fb.yaml
+++ b/dts/bindings/display/solomon,ssd1673fb.yaml
@@ -3,7 +3,7 @@
 
 title: SSD16XX 250x150 EPD Display Controller
 
-description: >
+description: |
     This is a representation of the SSD16XX 250x150 EPD Display Controller
 
 compatible: "solomon,ssd16xxfb"

--- a/dts/bindings/espi/microchip,xec-espi.yaml
+++ b/dts/bindings/espi/microchip,xec-espi.yaml
@@ -3,7 +3,7 @@
 
 title: MICROCHIP ESPI
 
-description: >
+description: |
     This binding gives a base representation of ESPI controller for Microchip
 
 compatible: "microchip,xec-espi"

--- a/dts/bindings/ethernet/intel,e1000.yaml
+++ b/dts/bindings/ethernet/intel,e1000.yaml
@@ -3,7 +3,7 @@
 
 title: Intel E1000 Ethernet controller
 
-description: >
+description: |
      This is a representation of the Intel E1000 Ethernet controller
 
 compatible: "intel,e1000"

--- a/dts/bindings/ethernet/litex,eth0.yaml
+++ b/dts/bindings/ethernet/litex,eth0.yaml
@@ -3,7 +3,7 @@
 
 title: LiteX Ethernet
 
-description: >
+description: |
     This binding gives a base representation of LiteX Ethernet
 
 compatible: "litex,eth0"

--- a/dts/bindings/ethernet/microchip,enc28j60.yaml
+++ b/dts/bindings/ethernet/microchip,enc28j60.yaml
@@ -3,7 +3,7 @@
 
 title: 10Base-T Ethernet Controller with SPI Interface
 
-description: >
+description: |
     This binding gives a base representation of the standalone ENC28J60 chip
 
 compatible: "microchip,enc28j60"

--- a/dts/bindings/ethernet/microchip,enc424j600.yaml
+++ b/dts/bindings/ethernet/microchip,enc424j600.yaml
@@ -3,7 +3,7 @@
 
 title: 100Base-T Ethernet Controller with SPI Interface
 
-description: >
+description: |
     This binding gives a base representation of the ENC424J600 Stand-Alone
     Ethernet Controller
 

--- a/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
+++ b/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
@@ -3,7 +3,7 @@
 
 title: NXP Kinetis Ethernet
 
-description: >
+description: |
     This binding gives a base representation of the NXP Kinetis Ethernet
 
 compatible: "nxp,kinetis-ethernet"

--- a/dts/bindings/ethernet/nxp,kinetis-ptp.yaml
+++ b/dts/bindings/ethernet/nxp,kinetis-ptp.yaml
@@ -3,7 +3,7 @@
 
 title: NXP Kinetis Ethernet PTP
 
-description: >
+description: |
     This binding gives a base representation of the NXP Kinetis Ethernet PTP
 
 compatible: "nxp,kinetis-ptp"

--- a/dts/bindings/ethernet/smsc,lan9220.yaml
+++ b/dts/bindings/ethernet/smsc,lan9220.yaml
@@ -3,7 +3,7 @@
 
 title: SMSC/Microchip LAN9220 Ethernet controller
 
-description: >
+description: |
      This is a representation of the formerly SMSC, now Microchip, LAN9220
      Ethernet controller.
 

--- a/dts/bindings/ethernet/ti,stellaris-ethernet.yaml
+++ b/dts/bindings/ethernet/ti,stellaris-ethernet.yaml
@@ -3,7 +3,7 @@
 
 title: TI Stellaris Ethernet
 
-description: >
+description: |
     This binding gives a base representation of the TI Stellaris Ethernet
 
 compatible: "ti,stellaris-ethernet"

--- a/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
+++ b/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel SAM Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the Atmel SAM Enhanced Embedded Flash Controller
 
 compatible: "atmel,sam-flash-controller"

--- a/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
+++ b/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
@@ -1,6 +1,6 @@
 title: Atmel SAM0 Non-Volatile Memory Controller
 
-description: >
+description: |
     This binding gives a base representation of the Atmel SAM0 NVMC
 
 compatible: "atmel,sam0-nvmctrl"

--- a/dts/bindings/flash_controller/cypress,psoc6-flash-controller.yaml
+++ b/dts/bindings/flash_controller/cypress,psoc6-flash-controller.yaml
@@ -3,7 +3,7 @@
 
 title: Cypress Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the Cypress Flash Controller
 
 compatible: "cypress,psoc6-flash-controller"

--- a/dts/bindings/flash_controller/nordic,nrf51-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf51-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: Nordic NVMC
 
-description: >
+description: |
     This binding gives a base representation of the Nordic NVMC
 
 compatible: "nordic,nrf51-flash-controller"

--- a/dts/bindings/flash_controller/nordic,nrf52-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf52-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: Nordic NVMC
 
-description: >
+description: |
     This binding gives a base representation of the Nordic NVMC
 
 compatible: "nordic,nrf52-flash-controller"

--- a/dts/bindings/flash_controller/nordic,nrf91-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf91-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: Nordic NVMC
 
-description: >
+description: |
     This binding gives a base representation of the Nordic NVMC
 
 compatible: "nordic,nrf91-flash-controller"

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfa.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfa.yaml
@@ -1,6 +1,6 @@
 title: NXP Kinetis Flash Memory Module (FTFA)
 
-description: >
+description: |
     This binding gives for the NXP Kinetis Flash Memory Module A (FTFA)
 
 compatible: "nxp,kinetis-ftfa"

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfe.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfe.yaml
@@ -1,6 +1,6 @@
 title: NXP Kinetis Flash Memory Module (FTFE)
 
-description: >
+description: |
     This binding gives for the NXP Kinetis Flash Memory Module E (FTFE)
 
 compatible: "nxp,kinetis-ftfe"

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfl.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfl.yaml
@@ -1,6 +1,6 @@
 title: NXP Kinetis Flash Memory Module (FTFL)
 
-description: >
+description: |
     This binding gives for the NXP Kinetis Flash Memory Module L (FTFL)
 
 compatible: "nxp,kinetis-ftfl"

--- a/dts/bindings/flash_controller/openisa,rv32m1-ftfe.yaml
+++ b/dts/bindings/flash_controller/openisa,rv32m1-ftfe.yaml
@@ -1,6 +1,6 @@
 title: OpenISA Flash Memory Module (FTFE)
 
-description: >
+description: |
     This binding gives for the OpenISA Flash Memory Module E (FTFE)
 
 compatible: "openisa,rv32m1-ftfe"

--- a/dts/bindings/flash_controller/silabs,gecko-flash-controller.yaml
+++ b/dts/bindings/flash_controller/silabs,gecko-flash-controller.yaml
@@ -3,7 +3,7 @@
 
 title: Silicon Labs Gecko Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the Silicon Labs Gecko Flash Controller
 
 compatible: "silabs,gecko-flash-controller"

--- a/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: STM32 F0 Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the STM32 F0 Flash Controller
 
 compatible: "st,stm32f0-flash-controller"

--- a/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: STM32 F2 Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the STM32 F2 Flash Controller
 
 compatible: "st,stm32f2-flash-controller"

--- a/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: STM32 F3 Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the STM32 F3 Flash Controller
 
 compatible: "st,stm32f3-flash-controller"

--- a/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: STM32 F4 Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the STM32 F4 Flash Controller
 
 compatible: "st,stm32f4-flash-controller"

--- a/dts/bindings/flash_controller/st,stm32f7-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f7-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: STM32 F7 Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the STM32 F7 Flash Controller
 
 compatible: "st,stm32f7-flash-controller"

--- a/dts/bindings/flash_controller/st,stm32g0-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32g0-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: STM32 G0 Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the STM32 G0 Flash Controller
 
 compatible: "st,stm32g0-flash-controller"

--- a/dts/bindings/flash_controller/st,stm32g4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32g4-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: STM32 G4 Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the STM32 G4 Flash Controller
 
 compatible: "st,stm32g4-flash-controller"

--- a/dts/bindings/flash_controller/st,stm32h7-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32h7-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: STM32 H7 Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the STM32 H7 Flash Controller
 
 compatible: "st,stm32h7-flash-controller"

--- a/dts/bindings/flash_controller/st,stm32l1-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32l1-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: STM32 L1 Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the STM32 L1 Flash Controller
 
 compatible: "st,stm32l1-flash-controller"

--- a/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: STM32 L4 Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the STM32 L4 Flash Controller
 
 compatible: "st,stm32l4-flash-controller"

--- a/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: STM32 WB Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the STM32 wb Flash Controller
 
 compatible: "st,stm32wb-flash-controller"

--- a/dts/bindings/flash_controller/zephyr,native-posix-flash-controller.yaml
+++ b/dts/bindings/flash_controller/zephyr,native-posix-flash-controller.yaml
@@ -1,6 +1,6 @@
 title: Native POSIX Flash Controller
 
-description: >
+description: |
     This binding gives a base representation of the Native POSIX flash
     controller
 

--- a/dts/bindings/flash_controller/zephyr,sim-flash.yaml
+++ b/dts/bindings/flash_controller/zephyr,sim-flash.yaml
@@ -2,7 +2,7 @@
 
 title: simulated flash
 
-description: >
+description: |
     This binding gives a base representation of a simulated flash memory
 
 compatible: "zephyr,sim-flash"

--- a/dts/bindings/gpio/arduino-header-r3.yaml
+++ b/dts/bindings/gpio/arduino-header-r3.yaml
@@ -3,7 +3,7 @@
 
 title: ARDUINO GPIO HEADER
 
-description: >
+description: |
     This is a representation of GPIO pin nodes exposed as headers on Arduino R3
 
 compatible: "arduino-header-r3"

--- a/dts/bindings/gpio/arm,cmsdk-gpio.yaml
+++ b/dts/bindings/gpio/arm,cmsdk-gpio.yaml
@@ -1,6 +1,6 @@
 title: ARM CMSDK GPIO
 
-description: >
+description: |
     This binding gives a base representation of the ARM CMSDK GPIO
 
 compatible: "arm,cmsdk-gpio"

--- a/dts/bindings/gpio/atmel,sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam-gpio.yaml
@@ -1,6 +1,6 @@
 title: Atmel SAM GPIO PORT driver
 
-description: >
+description: |
     This is a representation of the SAM GPIO PORT nodes
 
 compatible: "atmel,sam-gpio"

--- a/dts/bindings/gpio/atmel,sam0-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam0-gpio.yaml
@@ -1,6 +1,6 @@
 title: Atmel SAM0 GPIO PORT driver
 
-description: >
+description: |
     This is a representation of the SAM0 GPIO PORT nodes
 
 compatible: "atmel,sam0-gpio"

--- a/dts/bindings/gpio/intel,apl-gpio.yaml
+++ b/dts/bindings/gpio/intel,apl-gpio.yaml
@@ -3,7 +3,7 @@
 
 title: Intel Apollo Lake GPIO controller
 
-description: >
+description: |
     This is a representation of the Intel Apollo Lake GPIO node
 
 compatible: "intel,apl-gpio"

--- a/dts/bindings/gpio/microchip,xec-gpio.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio.yaml
@@ -3,7 +3,7 @@
 
 title: MICROCHIP GPIO
 
-description: >
+description: |
     This is a representation of the CEC/MEC GPIO nodes for Microchip
 
 compatible: "microchip,xec-gpio"

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -3,7 +3,7 @@
 
 title: NRF5 GPIO
 
-description: >
+description: |
     This is a representation of the NRF GPIO nodes
 
 compatible: "nordic,nrf-gpio"

--- a/dts/bindings/gpio/nordic,nrf-gpiote.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpiote.yaml
@@ -3,7 +3,7 @@
 
 title: NRF5 GPIOTE
 
-description: >
+description: |
     This is a representation of the NRF GPIOTE node
 
 compatible: "nordic,nrf-gpiote"

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -3,7 +3,7 @@
 
 title: i.MX GPIO
 
-description: >
+description: |
     This is a representation of the i.MX GPIO nodes
 
 compatible: "nxp,imx-gpio"

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -1,6 +1,6 @@
 title: Kinetis GPIO
 
-description: >
+description: |
     This is a representation of the Kinetis GPIO nodes
 
 compatible: "nxp,kinetis-gpio"

--- a/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
+++ b/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
@@ -1,6 +1,6 @@
 title: OpenISA GPIO
 
-description: >
+description: |
     This is a representation of the OpenISA GPIO nodes
 
 compatible: "openisa,rv32m1-gpio"

--- a/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
@@ -3,7 +3,7 @@
 
 title: Semtech SX1509B I2C GPIO
 
-description: >
+description: |
         This is a representation of the SX1509B GPIO node
 
 compatible: "semtech,sx1509b"

--- a/dts/bindings/gpio/sifive,gpio0.yaml
+++ b/dts/bindings/gpio/sifive,gpio0.yaml
@@ -3,7 +3,7 @@
 
 title: SiFive GPIO
 
-description: >
+description: |
     This is a representation of the SiFive GPIO nodes
 
 compatible: "sifive,gpio0"

--- a/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
@@ -1,6 +1,6 @@
 title: EFM32 GPIO
 
-description: >
+description: |
     This is a representation of the EFM32 GPIO Port nodes
 
 compatible: "silabs,efm32-gpio-port"

--- a/dts/bindings/gpio/silabs,efm32-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio.yaml
@@ -1,6 +1,6 @@
 title: EFM32 GPIO
 
-description: >
+description: |
     This is a representation of the EFM32 GPIO nodes
 
 compatible: "silabs,efm32-gpio"

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
@@ -1,6 +1,6 @@
 title: EFR32MG GPIO
 
-description: >
+description: |
     This is a representation of the EFR32MG GPIO Port nodes
 
 compatible: "silabs,efr32mg-gpio-port"

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
@@ -1,6 +1,6 @@
 title: EFR32MG GPIO
 
-description: >
+description: |
     This is a representation of the EFR32MG GPIO nodes
 
 compatible: "silabs,efr32mg-gpio"

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
@@ -1,6 +1,6 @@
 title: EFR32XG1 GPIO
 
-description: >
+description: |
     This is a representation of the EFR32XG1 GPIO Port nodes
 
 compatible: "silabs,efr32xg1-gpio-port"

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
@@ -1,6 +1,6 @@
 title: EFR32XG1 GPIO
 
-description: >
+description: |
     This is a representation of the EFR32XG1 GPIO nodes
 
 compatible: "silabs,efr32xg1-gpio"

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -3,7 +3,7 @@
 
 title: Synopsys Designware GPIO controller
 
-description: >
+description: |
     This is a representation of the Synopsys DesignWare gpio node
 
 compatible: "snps,designware-gpio"

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -3,7 +3,7 @@
 
 title: STM32 GPIO
 
-description: >
+description: |
     This is a representation of the STM32 GPIO nodes
 
 compatible: "st,stm32-gpio"

--- a/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
@@ -3,7 +3,7 @@
 
 title: TI SimpleLink CC13xx / CC26xx GPIO
 
-description: >
+description: |
     This is a representation of the TI SimpleLink CC13xx / CC26xx GPIO node
 
 compatible: "ti,cc13xx-cc26xx-gpio"

--- a/dts/bindings/gpio/ti,cc2650-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc2650-gpio.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 title: TI CC2650 GPIO
 
-description: >
+description: |
     This is a representation of the TI CC2650 GPIO node
 
 compatible: "ti,cc2650-gpio"

--- a/dts/bindings/gpio/ti,cc32xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc32xx-gpio.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 title: TI CC32XX GPIO
 
-description: >
+description: |
     This is a representation of the TI CC32XX GPIO node
 
 compatible: "ti,cc32xx-gpio"

--- a/dts/bindings/gpio/ti,stellaris-gpio.yaml
+++ b/dts/bindings/gpio/ti,stellaris-gpio.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 title: TI Stellaris GPIO
 
-description: >
+description: |
     This is a representation of the TI Stellaris GPIO node
 
 compatible: "ti,stellaris-gpio"

--- a/dts/bindings/i2c/arm,versatile-i2c.yaml
+++ b/dts/bindings/i2c/arm,versatile-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: ARM SBCon two-wire serial bus interface
 
-description: >
+description: |
     This is a representation of the ARM SBCon two-wire serial bus interface
 
 compatible: "arm,versatile-i2c"

--- a/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel SAM Family I2C (TWI) node
 
-description: >
+description: |
     This is a representation of the Atmel SAM Family I2C (TWI) node
 
 compatible: "atmel,sam-i2c-twi"

--- a/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel SAM Family I2C (TWIHS) node
 
-description: >
+description: |
     This is a representation of the Atmel SAM Family I2C (TWIHS) node
 
 compatible: "atmel,sam-i2c-twihs"

--- a/dts/bindings/i2c/atmel,sam0-i2c.yaml
+++ b/dts/bindings/i2c/atmel,sam0-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel SAM0 series SERCOM I2C controller
 
-description: >
+description: |
     This is a representation of the Atmel SAM0 series SERCOM I2C nodes
 
 compatible: "atmel,sam0-i2c"

--- a/dts/bindings/i2c/espressif,esp32-i2c.yaml
+++ b/dts/bindings/i2c/espressif,esp32-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: ESP32 I2C
 
-description: >
+description: |
     This is a representation of the ESP32 I2C
 
 compatible: "espressif,esp32-i2c"

--- a/dts/bindings/i2c/fsl,imx7d-i2c.yaml
+++ b/dts/bindings/i2c/fsl,imx7d-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: i.MX I2C Controller
 
-description: >
+description: |
     This is a representation of the i.MX I2C nodes
 
 compatible: "fsl,imx7d-i2c"

--- a/dts/bindings/i2c/microchip,xec-i2c.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: MICROCHIP I2C
 
-description: >
+description: |
     This binding gives a base representation for I2C/SMB controller for Microchip
 
 compatible: "microchip,xec-i2c"

--- a/dts/bindings/i2c/nios2,i2c.yaml
+++ b/dts/bindings/i2c/nios2,i2c.yaml
@@ -3,7 +3,7 @@
 
 title: NIOS2 i2c
 
-description: >
+description: |
     This binding gives a base representation of the NIOS2 i2c
 
 compatible: "nios2,i2c"

--- a/dts/bindings/i2c/nxp,imx-lpi2c.yaml
+++ b/dts/bindings/i2c/nxp,imx-lpi2c.yaml
@@ -3,7 +3,7 @@
 
 title: NXP LPI2C
 
-description: >
+description: |
     This binding gives a base representation of the NXP i.MX LPI2C controller
 
 compatible: "nxp,imx-lpi2c"

--- a/dts/bindings/i2c/nxp,kinetis-i2c.yaml
+++ b/dts/bindings/i2c/nxp,kinetis-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: Kinetis I2C Controller
 
-description: >
+description: |
     This is a representation of the Kinetis I2C nodes
 
 compatible: "nxp,kinetis-i2c"

--- a/dts/bindings/i2c/openisa,rv32m1-lpi2c.yaml
+++ b/dts/bindings/i2c/openisa,rv32m1-lpi2c.yaml
@@ -3,7 +3,7 @@
 
 title: OpenISA LPI2C
 
-description: >
+description: |
     This binding gives a base representation of the OpenISA LPI2C controller
 
 compatible: "openisa,rv32m1-lpi2c"

--- a/dts/bindings/i2c/sifive,i2c0.yaml
+++ b/dts/bindings/i2c/sifive,i2c0.yaml
@@ -3,7 +3,7 @@
 
 title: SiFive Freedom I2C
 
-description: >
+description: |
     This is a binding for the SiFive Freedom I2C interface
 
 compatible: "sifive,i2c0"

--- a/dts/bindings/i2c/silabs,gecko-i2c.yaml
+++ b/dts/bindings/i2c/silabs,gecko-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: Silabs Gecko I2C Controller
 
-description: >
+description: |
     This is a representation of the Silabs Gecko I2C nodes
 
 compatible: "silabs,gecko-i2c"

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: Synopys DesignWare I2C controller
 
-description: >
+description: |
     This is a representation of the Synopsys DesignWare i2c node
 
 compatible: "snps,designware-i2c"

--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -3,7 +3,7 @@
 
 title: STM32 I2C V1
 
-description: >
+description: |
     This binding gives a base representation of the STM32 I2C V1 controller
 
 compatible: "st,stm32-i2c-v1"

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -3,7 +3,7 @@
 
 title: STM32 I2C V2
 
-description: >
+description: |
     This binding gives a base representation of the STM32 I2C V2 controller
 
 compatible: "st,stm32-i2c-v2"

--- a/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: TI CC13xx / CC26xx I2C
 
-description: >
+description: |
     This is a representation of the TI CC13xx / CC26xx I2C node
 
 compatible: "ti,cc13xx-cc26xx-i2c"

--- a/dts/bindings/i2c/ti,cc32xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc32xx-i2c.yaml
@@ -1,6 +1,6 @@
 title: CC32XX I2C
 
-description: >
+description: |
     This binding gives a base representation of the TI CC32XX I2C controller
 
 compatible: "ti,cc32xx-i2c"

--- a/dts/bindings/i2s/nordic,nrf-i2s.yaml
+++ b/dts/bindings/i2s/nordic,nrf-i2s.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic I2S
 
-description: >
+description: |
     Binding for the Nordic I2S (Inter-IC sound interface)
 
 compatible: "nordic,nrf-i2s"

--- a/dts/bindings/i2s/st,stm32-i2s.yaml
+++ b/dts/bindings/i2s/st,stm32-i2s.yaml
@@ -3,7 +3,7 @@
 
 title: STM32 I2S
 
-description: >
+description: |
     This binding gives a base representation of the STM32 I2S controller
 
 compatible: "st,stm32-i2s"

--- a/dts/bindings/ieee802154/nxp,mcr20a.yaml
+++ b/dts/bindings/ieee802154/nxp,mcr20a.yaml
@@ -3,7 +3,7 @@
 
 title: NXP MCR20A 802.15.4 Wireless Transceiver
 
-description: >
+description: |
     This is a representation of the NXP MCR20A wireless transceiver.
 
 compatible: "nxp,mcr20a"

--- a/dts/bindings/ieee802154/ti,cc1200.yaml
+++ b/dts/bindings/ieee802154/ti,cc1200.yaml
@@ -3,7 +3,7 @@
 
 title: CC1200 802.15.4 Wireless Transceiver
 
-description: >
+description: |
     This is a representation of the CC1200 wireless transceiver.
 
 compatible: "ti,cc1200"

--- a/dts/bindings/ieee802154/ti,cc2520.yaml
+++ b/dts/bindings/ieee802154/ti,cc2520.yaml
@@ -3,7 +3,7 @@
 
 title: CC2520 802.15.4 Wireless Transceiver
 
-description: >
+description: |
     This is a representation of the CC2520 wireless transceiver.
 
 compatible: "ti,cc2520"

--- a/dts/bindings/iio/adc/atmel,sam-afec.yaml
+++ b/dts/bindings/iio/adc/atmel,sam-afec.yaml
@@ -1,6 +1,6 @@
 title: Atmel SAM Family AFEC
 
-description: >
+description: |
     This binding gives a base representation of the Atmel SAM AFEC
 
 compatible: "atmel,sam-afec"

--- a/dts/bindings/iio/adc/atmel,sam0-adc.yaml
+++ b/dts/bindings/iio/adc/atmel,sam0-adc.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel SAM0 Family ADC
 
-description: >
+description: |
     This binding gives a base representation of the Atmel SAM0 ADC
 
 compatible: "atmel,sam0-adc"

--- a/dts/bindings/iio/adc/microchip,xec-adc.yaml
+++ b/dts/bindings/iio/adc/microchip,xec-adc.yaml
@@ -6,7 +6,7 @@
 
 title: Microchip XEC ADC
 
-description: >
+description: |
     This binding gives a base representation of the Microchip XEC ADC
 
 compatible: "microchip,xec-adc"

--- a/dts/bindings/iio/adc/nordic,nrf-adc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-adc.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic Semiconductor nRF Family ADC
 
-description: >
+description: |
     This is a representation of the nRF ADC node
 
 compatible: "nordic,nrf-adc"

--- a/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic Semiconductor nRF Family SAADC
 
-description: >
+description: |
     This is a representation of the nRF SAADC node
 
 compatible: "nordic,nrf-saadc"

--- a/dts/bindings/iio/adc/nxp,kinetis-adc12.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc12.yaml
@@ -3,7 +3,7 @@
 
 title: NXP Kinetis ADC12
 
-description: >
+description: |
     This binding gives a base representation of the NXP Kinetis ADC12
 
 compatible: "nxp,kinetis-adc12"

--- a/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
@@ -3,7 +3,7 @@
 
 title: Kinetis ADC16
 
-description: >
+description: |
     This binding gives a base representation of the Kinetis ADC16
 
 compatible: "nxp,kinetis-adc16"

--- a/dts/bindings/iio/adc/st,stm32-adc.yaml
+++ b/dts/bindings/iio/adc/st,stm32-adc.yaml
@@ -4,7 +4,7 @@
 
 title: ST STM32 family ADC
 
-description: >
+description: |
     This binding gives a base representation of the ST STM32 ADC
 
 compatible: "st,stm32-adc"

--- a/dts/bindings/interrupt-controller/arm,gic.yaml
+++ b/dts/bindings/interrupt-controller/arm,gic.yaml
@@ -3,7 +3,7 @@
 
 title: ARMv7-R Generic Interrupt Controller
 
-description: >
+description: |
     This binding describes the ARM Generic Interrupt Controller.
 
 compatible: "arm,gic"

--- a/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
@@ -1,6 +1,6 @@
 title: ARMv6-M NVIC Interrupt Controller
 
-description: >
+description: |
     This binding describes the ARMv6-M Nested Vectored Interrupt Controller.
 
 compatible: "arm,v6m-nvic"

--- a/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
@@ -1,6 +1,6 @@
 title: ARMv7-M NVIC Interrupt Controller
 
-description: >
+description: |
     This binding describes the ARMv7-M Nested Vectored Interrupt Controller.
 
 compatible: "arm,v7m-nvic"

--- a/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
@@ -1,6 +1,6 @@
 title: ARMv8-M NVIC Interrupt Controller
 
-description: >
+description: |
     This binding describes the ARMv8-M Nested Vectored Interrupt Controller.
 
 compatible: "arm,v8m-nvic"

--- a/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
+++ b/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
@@ -1,6 +1,6 @@
 title: Atmel SAM0 External Interrupt Controller
 
-description: >
+description: |
     This binding describes the Atmel SAM0 series External Interrupt Controller
 
 compatible: "atmel,sam0-eic"

--- a/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
@@ -1,6 +1,6 @@
 title: CAVS Interrupt Controller
 
-description: >
+description: |
     This binding describes CAVS Interrupt controller
 
 compatible: "intel,cavs-intc"

--- a/dts/bindings/interrupt-controller/intel,ioapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,ioapic.yaml
@@ -1,6 +1,6 @@
 title: Intel I/O Advanced Programmable Interrupt Controller
 
-description: >
+description: |
     This binding describes the Intel I/O Advanced Programmable Interrupt
     controller
 

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
@@ -4,7 +4,7 @@
 
 title: RV32M1 Event Unit
 
-description: >
+description: |
     This binding describes the RV32M1 Event Unit
 
 compatible: "openisa,rv32m1-event-unit"

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux-ch.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux-ch.yaml
@@ -3,7 +3,7 @@
 
 title: RV32M1 INTMUX Channel
 
-description: >
+description: |
     This binding describes the RV32M1 INTMUX Channel
 
 compatible: "openisa,rv32m1-intmux-ch"

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
@@ -3,7 +3,7 @@
 
 title: RV32M1 INTMUX
 
-description: >
+description: |
     This binding describes the RV32M1 INTMUX IP
 
 compatible: "openisa,rv32m1-intmux"

--- a/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
+++ b/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
@@ -3,7 +3,7 @@
 
 title: RISC-V CPU INTC
 
-description: >
+description: |
     This binding describes the RISC-V CPU Interrupt Controller
 
 compatible: "riscv,cpu-intc"

--- a/dts/bindings/interrupt-controller/shared-irq.yaml
+++ b/dts/bindings/interrupt-controller/shared-irq.yaml
@@ -1,6 +1,6 @@
 title: Shared IRQ interrupt dispatcher
 
-description: >
+description: |
     This binding describes Shared IRQ interrupt dispatcher
 
 compatible: "shared-irq"

--- a/dts/bindings/interrupt-controller/snps,archs-idu-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,archs-idu-intc.yaml
@@ -3,7 +3,7 @@
 
 title: ARC-HS Interrupt Distribution Unit
 
-description: >
+description: |
     This binding describes the 2nd level interrupt controller can be used in
     SMP configurations for dynamic IRQ routing, load balancing of
     common/external IRQs towards core intc

--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -3,7 +3,7 @@
 
 title: ARCV2 Interrupt Controller
 
-description: >
+description: |
     This binding describes the ARCV2 IRQ controller
 
 compatible: "snps,arcv2-intc"

--- a/dts/bindings/interrupt-controller/snps,designware-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,designware-intc.yaml
@@ -1,6 +1,6 @@
 title: DesignWare Interrupt Controller
 
-description: >
+description: |
     This binding describes DesignWare Programmable Interrupt controller
 
 compatible: "snps,designware-intc"

--- a/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
+++ b/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
@@ -3,7 +3,7 @@
 
 title: LiteX VexRiscV Interrupt Controller
 
-description: >
+description: |
     This binding describes LiteX VexRiscV Interrupt Controller
 
 compatible: "vexriscv,intc0"

--- a/dts/bindings/interrupt-controller/xtensa,intc.yaml
+++ b/dts/bindings/interrupt-controller/xtensa,intc.yaml
@@ -1,6 +1,6 @@
 title: Xtensa Core Interrupt Controller
 
-description: >
+description: |
     This binding describes Xtensa Core Interrupt controller
 
 compatible: "xtensa,core-intc"

--- a/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
+++ b/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
@@ -3,7 +3,7 @@
 
 title: STM32 MAILBOX
 
-description: >
+description: |
   This binding gives a base representation of the STM32 IPCC
 
 compatible: "st,stm32-ipcc-mailbox"

--- a/dts/bindings/kscan/kscan.yaml
+++ b/dts/bindings/kscan/kscan.yaml
@@ -3,7 +3,7 @@
 
 title: Keyboard Scan Matrix  Base Structure
 
-description: >
+description: |
     This binding gives the base structures for all Keyboard Matrix devices
 
 include: base.yaml

--- a/dts/bindings/kscan/microchip,xec-kscan.yaml
+++ b/dts/bindings/kscan/microchip,xec-kscan.yaml
@@ -3,7 +3,7 @@
 
 title: Microchip XEC Keyboard Scan Matrix
 
-description: >
+description: |
     This is a representation of the Microchip XEC Keyboard Matrix controller
 
 compatible: "microchip,xec-kscan"

--- a/dts/bindings/memory-controllers/nxp,imx-semc.yaml
+++ b/dts/bindings/memory-controllers/nxp,imx-semc.yaml
@@ -3,7 +3,7 @@
 
 title: NXP SEMC
 
-description: >
+description: |
     This binding gives a base representation of the NXP smart external memory
     controller (SEMC)
 

--- a/dts/bindings/mhu/arm,mhu.yaml
+++ b/dts/bindings/mhu/arm,mhu.yaml
@@ -3,7 +3,7 @@
 
 title: ARM MHU
 
-description: >
+description: |
     This binding gives a base representation of the ARM MHU
 
 compatible: "arm,mhu"

--- a/dts/bindings/misc/skyworks,sky13351.yaml
+++ b/dts/bindings/misc/skyworks,sky13351.yaml
@@ -3,7 +3,7 @@
 
 title: Skyworks SKY13351 GaAs FET I/C switch
 
-description: >
+description: |
     This binding allows control of the output selectors of the SKY13351
     SPDT switch.
 

--- a/dts/bindings/mmc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/mmc/nxp,imx-usdhc.yaml
@@ -3,7 +3,7 @@
 
 title: NXP i.MXRT USDHC module
 
-description: >
+description: |
     This binding specifies the NXP i.MXRT USDHC module.
 
 compatible: "nxp,imx-usdhc"

--- a/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
@@ -1,6 +1,6 @@
 title: ARMv7-M Memory Protection Unit
 
-description: >
+description: |
     This binding describes the ARMv7-M Memory Protection Unit (MPU).
 
 compatible: "arm,armv7m-mpu"

--- a/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
@@ -1,6 +1,6 @@
 title: ARMv8-M Memory Protection Unit
 
-description: >
+description: |
     This binding describes the ARMv8-M Memory Protection Unit (MPU).
 
 compatible: "arm,armv8m-mpu"

--- a/dts/bindings/modem/ublox,sara-r4.yaml
+++ b/dts/bindings/modem/ublox,sara-r4.yaml
@@ -3,7 +3,7 @@
 
 title: u-blox SARA-R4 modem
 
-description: >
+description: |
     This is a representation of the u-blox SARA-R4 modem.
 
 compatible: "ublox,sara-r4"

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -3,7 +3,7 @@
 
 title: WNC-M14A2A LTE-M Modem
 
-description: >
+description: |
     This is a representation of the WNC-M14A2A LTE-M modem.
 
 compatible: "wnc,m14a2a"

--- a/dts/bindings/mtd/atmel,at24.yaml
+++ b/dts/bindings/mtd/atmel,at24.yaml
@@ -3,7 +3,7 @@
 
 title: Virtual I2C slave eeprom
 
-description: >
+description: |
     This binding gives a base representation of a generic I2C slave EEPROM
 
 compatible: "atmel,at24"

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -3,7 +3,7 @@
 
 title: SPI NOR flash devices (JEDEC CFI interface)
 
-description: >
+description: |
   Any SPI NOR flash that supports the JEDEC CFI interface.
 
 compatible: "jedec,spi-nor"

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -1,6 +1,6 @@
 title: Flash base node description
 
-description: >
+description: |
     This binding gives a base FLASH description
 
 compatible: "soc-nv-flash"

--- a/dts/bindings/mtd/winbond,w25q16.yaml
+++ b/dts/bindings/mtd/winbond,w25q16.yaml
@@ -3,7 +3,7 @@
 
 title: SPI NOR FLASH
 
-description: >
+description: |
     This binding gives a base representation of SPI slave NOR FLASH
 
 compatible: "winbond,w25q16"

--- a/dts/bindings/phy/st,stm32-usbphyc.yaml
+++ b/dts/bindings/phy/st,stm32-usbphyc.yaml
@@ -3,7 +3,7 @@
 
 title: STM32 USB HS PHY
 
-description: >
+description: |
     This binding gives a base representation of the STM32 USB HS PHY controller
 
 compatible: "st,stm32-usbphyc"

--- a/dts/bindings/phy/usb-nop-xceiv.yaml
+++ b/dts/bindings/phy/usb-nop-xceiv.yaml
@@ -3,7 +3,7 @@
 
 title: NOP USB Transceiver
 
-description: >
+description: |
     This binding is to be used by all the usb transceivers which are built-in
     with USB IP
 

--- a/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
+++ b/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
@@ -1,6 +1,6 @@
 title: Atmel SAM0 PINMUX
 
-description: >
+description: |
     This binding gives a base representation of the Atmel SAM0 PINMUX
 
 compatible: "atmel,sam0-pinmux"

--- a/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
+++ b/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 title: Intel S1000 Pinmux
 
-description: >
+description: |
     This is a representation of the Intel S1000 SoC's pinmux node
 
 compatible: "intel,s1000-pinmux"

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -1,6 +1,6 @@
 title: Kinetis Pinmux
 
-description: >
+description: |
     This is a representation of the Kinetis Pinmux node
 
 compatible: "nxp,kinetis-pinmux"

--- a/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
+++ b/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
@@ -1,6 +1,6 @@
 title: RV32M1 Pinmux
 
-description: >
+description: |
     This is a representation of the RV32M1 Pinmux node
 
 compatible: "openisa,rv32m1-pinmux"

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -1,6 +1,6 @@
 title: STM32 PINMUX
 
-description: >
+description: |
     This binding gives a base representation of the STM32 PINMUX
 
 compatible: "st,stm32-pinmux"

--- a/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
@@ -3,7 +3,7 @@
 
 title: TI SimpleLink CC13xx / CC26xx Pinmux
 
-description: >
+description: |
     This is a representation of the TI SimpleLink CC13xx / CC26xx pinmux node
 
 compatible: "ti,cc13xx-cc26xx-pinmux"

--- a/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 title: TI CC2650 Pinmux
 
-description: >
+description: |
     This is a representation of the TI CC2650 pinmux node
 
 compatible: "ti,cc2650-pinmux"

--- a/dts/bindings/power/nordic,nrf-power.yaml
+++ b/dts/bindings/power/nordic,nrf-power.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic nRF power control
 
-description: >
+description: |
     This is a representation of the Nordic nRF power control node
 
 compatible: "nordic,nrf-power"

--- a/dts/bindings/power/nordic,nrf-regulators.yaml
+++ b/dts/bindings/power/nordic,nrf-regulators.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic REGULATORS
 
-description: >
+description: |
     Binding for the Nordic REGULATORS (voltage regulators control module)
 
 compatible: "nordic,nrf-regulators"

--- a/dts/bindings/power/nordic,nrf-vmc.yaml
+++ b/dts/bindings/power/nordic,nrf-vmc.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic VMC
 
-description: >
+description: |
     Binding for the Nordic VMC (Volatile Memory Controller)
 
 compatible: "nordic,nrf-vmc"

--- a/dts/bindings/ps2/microchip,xec-ps2.yaml
+++ b/dts/bindings/ps2/microchip,xec-ps2.yaml
@@ -3,7 +3,7 @@
 
 title: Microchip XEC PS/2
 
-description: >
+description: |
     This is a representation of the Microchip XEC PS/2 controller
 
 compatible: "microchip,xec-ps2"

--- a/dts/bindings/ps2/ps2.yaml
+++ b/dts/bindings/ps2/ps2.yaml
@@ -3,7 +3,7 @@
 
 title: PS/2 Base Structure
 
-description: >
+description: |
     This binding gives the base structures for all PS/2 devices
 
 include: base.yaml

--- a/dts/bindings/pwm/atmel,sam-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam-pwm.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel SAM PWM
 
-description: >
+description: |
     This binding gives a base representation of the Atmel SAM PWM
 
 compatible: "atmel,sam-pwm"

--- a/dts/bindings/pwm/fsl,imx7d-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx7d-pwm.yaml
@@ -3,7 +3,7 @@
 
 title: i.MX7D PWM
 
-description: >
+description: |
     This binding gives a base representation of the i.MX7D PWM
 
 compatible: "fsl,imx7d-pwm"

--- a/dts/bindings/pwm/microchip,xec-pwm.yaml
+++ b/dts/bindings/pwm/microchip,xec-pwm.yaml
@@ -6,7 +6,7 @@
 
 title: Microchip XEC PWM
 
-description: >
+description: |
     This binding gives a base representation of the Microchip XEC PWM
 
 include: [pwm-controller.yaml, base.yaml]

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -1,6 +1,6 @@
 title: nRF PWM
 
-description: >
+description: |
     This binding gives a base representation of the nRF PWM
 
 compatible: "nordic,nrf-pwm"

--- a/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
@@ -1,6 +1,6 @@
 title: nRF SW PWM
 
-description: >
+description: |
     This binding gives a base representation of the nRFx S/W PWM
 
 compatible: "nordic,nrf-sw-pwm"

--- a/dts/bindings/pwm/nxp,flexpwm.yaml
+++ b/dts/bindings/pwm/nxp,flexpwm.yaml
@@ -3,7 +3,7 @@
 
 title: MCUX PWM
 
-description: >
+description: |
     This binding gives a base representation of the NXP eFLEX PWM module which
     is supposed to contain mcux-pwm submodules.
 

--- a/dts/bindings/pwm/nxp,imx-pwm.yaml
+++ b/dts/bindings/pwm/nxp,imx-pwm.yaml
@@ -3,7 +3,7 @@
 
 title: MCUX PWM
 
-description: >
+description: |
     This binding gives a base representation of the NXP MCUX PWM
 
 compatible: "nxp,imx-pwm"

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -3,7 +3,7 @@
 
 title: Kinetis FTM
 
-description: >
+description: |
     This binding gives a base representation of the Kinetis FTM
 
 compatible: "nxp,kinetis-ftm"

--- a/dts/bindings/pwm/sifive,pwm0.yaml
+++ b/dts/bindings/pwm/sifive,pwm0.yaml
@@ -3,7 +3,7 @@
 
 title: SiFive PWM
 
-description: >
+description: |
     This binding gives a base representation of the SiFive PWM
 
 compatible: "sifive,pwm0"

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -1,6 +1,6 @@
 title: STM32 PWM
 
-description: >
+description: |
     This binding gives a base representation of the STM32 PWM
 
 compatible: "st,stm32-pwm"

--- a/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
+++ b/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
@@ -3,7 +3,7 @@
 
 title: RV32M1 PCC (Peripheral Clock Control)
 
-description: >
+description: |
     This is a representation of the RV32M1 PCC IP node
 
 compatible: "openisa,rv32m1-pcc"

--- a/dts/bindings/rng/atmel,sam-trng.yaml
+++ b/dts/bindings/rng/atmel,sam-trng.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel SAM TRNG (True Random Number Generator)
 
-description: >
+description: |
     This binding gives a base representation of the Atmel SAM RNG
 
 compatible: "atmel,sam-trng"

--- a/dts/bindings/rng/espressif,esp32-trng.yaml
+++ b/dts/bindings/rng/espressif,esp32-trng.yaml
@@ -3,7 +3,7 @@
 
 title: Espressif ESP32 TRNG (True Random Number Generator)
 
-description: >
+description: |
     The TRNG use the noise in the Wi-Fi/BT RF system.
     When Wi-Fi and BT are disabled, the random number generator will give out
     pseudo-random numbers.

--- a/dts/bindings/rng/nxp,kinetis-rnga.yaml
+++ b/dts/bindings/rng/nxp,kinetis-rnga.yaml
@@ -3,7 +3,7 @@
 
 title: Kinetis RNGA (Random Number Generator Accelerator)
 
-description: >
+description: |
     This binding gives a base representation of the Kinetis RNGA
 
 compatible: "nxp,kinetis-rnga"

--- a/dts/bindings/rng/nxp,kinetis-trng.yaml
+++ b/dts/bindings/rng/nxp,kinetis-trng.yaml
@@ -3,7 +3,7 @@
 
 title: Kinetis TRNG (True Random Number Generator)
 
-description: >
+description: |
     This binding gives a base representation of the Kinetis RNGA
 
 compatible: "nxp,kinetis-trng"

--- a/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
+++ b/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
@@ -3,7 +3,7 @@
 
 title: TI SimpleLink CC13xx / CC26xx True Random Number Generator (TRNG)
 
-description: >
+description: |
     This is a representation of the TI SimpleLink CC13xx / CC26xx TRNG node
 
 compatible: "ti,cc13xx-cc26xx-trng"

--- a/dts/bindings/rtc/atmel,sam0-rtc.yaml
+++ b/dts/bindings/rtc/atmel,sam0-rtc.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel SAM0 RTC
 
-description: >
+description: |
     This binding gives a base representation of the Atmel SAM0 RTC
 
 compatible: "atmel,sam0-rtc"

--- a/dts/bindings/rtc/microchip,xec-timer.yaml
+++ b/dts/bindings/rtc/microchip,xec-timer.yaml
@@ -6,7 +6,7 @@
 
 title: Microchip XEC basic timer
 
-description: >
+description: |
     This binding gives a base representation of the Microchip XEC basic timer
 
 compatible: "microchip,xec-timer"

--- a/dts/bindings/rtc/nordic,nrf-rtc.yaml
+++ b/dts/bindings/rtc/nordic,nrf-rtc.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic nRF Real Time Counter
 
-description: >
+description: |
     This is a representation of the Nordic nRF RTC node
 
 compatible: "nordic,nrf-rtc"

--- a/dts/bindings/rtc/nxp,kinetis-rtc.yaml
+++ b/dts/bindings/rtc/nxp,kinetis-rtc.yaml
@@ -3,7 +3,7 @@
 
 title: Kinetis RTC
 
-description: >
+description: |
     This binding gives a base representation of the Kinetis RTC
 
 compatible: "nxp,kinetis-rtc"

--- a/dts/bindings/rtc/silabs,gecko-rtcc.yaml
+++ b/dts/bindings/rtc/silabs,gecko-rtcc.yaml
@@ -3,7 +3,7 @@
 
 title: Silabs Gecko Real Time Counter
 
-description: >
+description: |
     This is a representation of the Silabs Gecko RTCC node
 
 compatible: "silabs,gecko-rtcc"

--- a/dts/bindings/rtc/st,stm32-rtc.yaml
+++ b/dts/bindings/rtc/st,stm32-rtc.yaml
@@ -3,7 +3,7 @@
 
 title: STM32 RTC
 
-description: >
+description: |
     This binding gives a base representation of the STM32 RTC
 
 compatible: "st,stm32-rtc"

--- a/dts/bindings/rtc/ti,cc13xx-cc26xx-rtc.yaml
+++ b/dts/bindings/rtc/ti,cc13xx-cc26xx-rtc.yaml
@@ -6,7 +6,7 @@
 
 title: TI SimpleLink CC13xx/CC26xx RTC
 
-description: >
+description: |
     This binding gives a base representation of the TI SimpleLink CC13xx/CC26xx RTC
 
 compatible: "ti,cc13xx-cc26xx-rtc"

--- a/dts/bindings/sensor/adi,adt7420.yaml
+++ b/dts/bindings/sensor/adi,adt7420.yaml
@@ -3,7 +3,7 @@
 
 title: ADT7420 16-Bit Digital I2C Temperature Sensor
 
-description: >
+description: |
     This is a representation of the ADT7420 16-Bit Digital I2C Temperature Sensor
 
 compatible: "adi,adt7420"

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -3,7 +3,7 @@
 
 title: ADXL362 Three Axis SPI accelerometer
 
-description: >
+description: |
     This is a representation of the ADXL362 Three Axis SPI accelerometer
 
 compatible: "adi,adxl362"

--- a/dts/bindings/sensor/adi,adxl372-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl372-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: ADXL372 Three Axis High-g I2C/SPI accelerometer
 
-description: >
+description: |
     This is a representation of the ADXL372 Three Axis High-g I2C/SPI accelerometer
 
 compatible: "adi,adxl372"

--- a/dts/bindings/sensor/adi,adxl372-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl372-spi.yaml
@@ -4,7 +4,7 @@
 
 title: ADXL372 Three Axis High-g I2C/SPI accelerometer
 
-description: >
+description: |
     This is a representation of the ADXL372 Three Axis High-g accelerometer,
     accessed through SPI bus
 

--- a/dts/bindings/sensor/ams,ccs811.yaml
+++ b/dts/bindings/sensor/ams,ccs811.yaml
@@ -3,7 +3,7 @@
 
 title: AMS (Austria Mikro Systeme) Digital Air Quality Sensor CCS811
 
-description: >
+description: |
     This binding gives a base representation of CCS811 digital air quality
     sensor
 

--- a/dts/bindings/sensor/ams,ens210.yaml
+++ b/dts/bindings/sensor/ams,ens210.yaml
@@ -3,7 +3,7 @@
 
 title: AMS (Austria Mikro Systeme) Relative Humidity and Temperature Sensor
 
-description: >
+description: |
     This binding gives a base representation of ens210 Relative Humidity and
     Temperature Sensor
 

--- a/dts/bindings/sensor/ams,iaqcore.yaml
+++ b/dts/bindings/sensor/ams,iaqcore.yaml
@@ -3,7 +3,7 @@
 
 title: AMS (Austria Mikro Systeme) Indoor Air Quality Sensor iAQ-core
 
-description: >
+description: |
     This binding gives a base representation of iAQ-core indoor air quality
     sensor
 

--- a/dts/bindings/sensor/avago,apds9960.yaml
+++ b/dts/bindings/sensor/avago,apds9960.yaml
@@ -3,7 +3,7 @@
 
 title: APDS9960 Digital Proximity, Ambient Light, RGB and Gesture Sensor
 
-description: >
+description: |
     This is a representation of the APDS9960 sensor
 
 compatible: "avago,apds9960"

--- a/dts/bindings/sensor/bosch,bme280-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bme280-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: BME280 Integrated environmental sensor
 
-description: >
+description: |
     This is a representation of the BME280 Integrated environmental sensor
 
 compatible: "bosch,bme280"

--- a/dts/bindings/sensor/bosch,bme280-spi.yaml
+++ b/dts/bindings/sensor/bosch,bme280-spi.yaml
@@ -3,7 +3,7 @@
 
 title: BME280 Integrated environmental sensor
 
-description: >
+description: |
     This is a representation of the BME280 Integrated environmental sensor
 
 compatible: "bosch,bme280"

--- a/dts/bindings/sensor/bosch,bme680-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bme680-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: BME680 integrated environmental sensor
 
-description: >
+description: |
     The BME680 is an integrated environmental sensor that measures
     temperature, pressure, humidity and air quality
 

--- a/dts/bindings/sensor/bosch,bmi160.yaml
+++ b/dts/bindings/sensor/bosch,bmi160.yaml
@@ -3,7 +3,7 @@
 
 title: BMI160 Inertial measurement unit
 
-description: >
+description: |
     This is a representation of the BMI160 Inertial measurement unit
 
 compatible: "bosch,bmi160"

--- a/dts/bindings/sensor/max,max30101.yaml
+++ b/dts/bindings/sensor/max,max30101.yaml
@@ -3,7 +3,7 @@
 
 title: MAX30101 heart rate sensor
 
-description: >
+description: |
     This is a representation of the MAX30101 heart rate sensor
 
 compatible: "max,max30101"

--- a/dts/bindings/sensor/meas,ms5837.yaml
+++ b/dts/bindings/sensor/meas,ms5837.yaml
@@ -3,7 +3,7 @@
 
 title: TE Connectivity digital pressure sensor MS5837
 
-description: >
+description: |
     This binding gives a base representation of the MS5837 digital pressure
     sensor
 

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic nRF Family QDEC node
 
-description: >
+description: |
     This is a representation of the Nordic nRF QDEC node
 
 compatible: "nordic,nrf-qdec"

--- a/dts/bindings/sensor/nordic,nrf-temp.yaml
+++ b/dts/bindings/sensor/nordic,nrf-temp.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic nRF Family TEMP node
 
-description: >
+description: |
     This is a representation of the Nordic nRF TEMP node
 
 compatible: "nordic,nrf-temp"

--- a/dts/bindings/sensor/nxp,fxas21002.yaml
+++ b/dts/bindings/sensor/nxp,fxas21002.yaml
@@ -3,7 +3,7 @@
 
 title: FXAS21002 3-axis gyroscope
 
-description: >
+description: |
     This is a representation of the FXAS21002 3-axis gyroscope sensor
 
 compatible: "nxp,fxas21002"

--- a/dts/bindings/sensor/nxp,fxos8700.yaml
+++ b/dts/bindings/sensor/nxp,fxos8700.yaml
@@ -3,7 +3,7 @@
 
 title: FXOS8700 6-axis accelerometer/magnetometer
 
-description: >
+description: |
     This is a representation of the FXOS8700 6-axis accelerometer/magnetometer
     sensor
 

--- a/dts/bindings/sensor/panasonic,amg88xx.yaml
+++ b/dts/bindings/sensor/panasonic,amg88xx.yaml
@@ -3,7 +3,7 @@
 
 title: Panasonic AMG88XX 8x8 (64) pixel infrared array sensor
 
-description: >
+description: |
     This is a representation of the AMG88XX sensor
 
 compatible: "panasonic,amg88xx"

--- a/dts/bindings/sensor/sensirion,sht3xd.yaml
+++ b/dts/bindings/sensor/sensirion,sht3xd.yaml
@@ -3,7 +3,7 @@
 
 title: Sensirion Humidity Sensor SHT-3x-DIS
 
-description: >
+description: |
     This binding gives a base representation of SHT3x-DIS humidity and temperature
     sensor
 

--- a/dts/bindings/sensor/silabs,si7006.yaml
+++ b/dts/bindings/sensor/silabs,si7006.yaml
@@ -3,7 +3,7 @@
 
 title: Si7006 Temperature and Humidity sensor
 
-description: >
+description: |
     This is a representation of Si7006 Temperature and Humidity sensor
 
 compatible: "silabs,si7006"

--- a/dts/bindings/sensor/silabs,si7060.yaml
+++ b/dts/bindings/sensor/silabs,si7060.yaml
@@ -3,7 +3,7 @@
 
 title: Si7060 Temperature sensor
 
-description: >
+description: |
     This is a representation of Si7060 Temperature sensor
 
 compatible: "silabs,si7060"

--- a/dts/bindings/sensor/st,hts221.yaml
+++ b/dts/bindings/sensor/st,hts221.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors HTS221
 
-description: >
+description: |
     This binding gives a base representation of HTS221 humidity and temperature
     sensor
 

--- a/dts/bindings/sensor/st,iis3dhhc-spi.yaml
+++ b/dts/bindings/sensor/st,iis3dhhc-spi.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors IIS3DHHC SPI
 
-description: >
+description: |
     This binding gives a base representation of IIS3DHHC 3-axis accelerometer
     accessed through SPI bus
 

--- a/dts/bindings/sensor/st,lis2dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dh-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LIS2DH
 
-description: >
+description: |
     This binding gives a base representation of LIS2DH 3-axis accelerometer
 
 compatible: "st,lis2dh"

--- a/dts/bindings/sensor/st,lis2dh-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dh-spi.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LIS2DH SPI
 
-description: >
+description: |
     This binding gives a base representation of LIS2DH 3-axis accelerometer
     accessed through SPI bus
 

--- a/dts/bindings/sensor/st,lis2dh12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dh12-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LIS2DH12
 
-description: >
+description: |
     This binding gives a base representation of LIS2DH12 3-axis accelerometer
 
 compatible: "st,lis2dh12"

--- a/dts/bindings/sensor/st,lis2ds12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LIS2DS12
 
-description: >
+description: |
     This binding gives a base representation of LIS2DS12 3-axis accelerometer
 
 compatible: "st,lis2ds12"

--- a/dts/bindings/sensor/st,lis2ds12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-spi.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LIS2DS12 SPI
 
-description: >
+description: |
     This binding gives a base representation of LIS2DS12 3-axis accelerometer
     accessed through SPI bus
 

--- a/dts/bindings/sensor/st,lis2dw12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LIS2DW12
 
-description: >
+description: |
     This binding gives a base representation of LIS2DW12 3-axis accelerometer
 
 compatible: "st,lis2dw12"

--- a/dts/bindings/sensor/st,lis2dw12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-spi.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LIS2DW12 SPI
 
-description: >
+description: |
     This binding gives a base representation of LIS2DW12 3-axis accelerometer
     accessed through SPI bus
 

--- a/dts/bindings/sensor/st,lis2mdl-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LIS2MDL I2C
 
-description: >
+description: |
     This binding gives a base representation of LIS2MDL magnetometer
     accessed through I2C bus
 

--- a/dts/bindings/sensor/st,lis2mdl-spi.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-spi.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LIS2MDL SPI
 
-description: >
+description: |
     This binding gives a base representation of LIS2MDL magnetometer
     accessed through SPI bus
 

--- a/dts/bindings/sensor/st,lis3dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis3dh-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LIS3DH
 
-description: >
+description: |
     This binding gives a base representation of LIS3DH 3-axis accelerometer
 
 compatible: "st,lis3dh"

--- a/dts/bindings/sensor/st,lis3mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis3mdl-magn.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LIS3MDL
 
-description: >
+description: |
     This binding gives a base representation of LIS3MDL magnetometer
 
 compatible: "st,lis3mdl-magn"

--- a/dts/bindings/sensor/st,lps22hb-press.yaml
+++ b/dts/bindings/sensor/st,lps22hb-press.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LPS22HB
 
-description: >
+description: |
     This binding gives a base representation of LPS22HB pressure sensor
 
 compatible: "st,lps22hb-press"

--- a/dts/bindings/sensor/st,lps22hh-i2c.yaml
+++ b/dts/bindings/sensor/st,lps22hh-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LPS22HH
 
-description: >
+description: |
     This binding gives a base representation of LPS22HH pressure and
     temperature sensor connected to I2C bus
 

--- a/dts/bindings/sensor/st,lps22hh-spi.yaml
+++ b/dts/bindings/sensor/st,lps22hh-spi.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LPS22HH
 
-description: >
+description: |
     This binding gives a base representation of LPS22HH pressure and
     temperature sensor connected to SPI bus
 

--- a/dts/bindings/sensor/st,lps25hb-press.yaml
+++ b/dts/bindings/sensor/st,lps25hb-press.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LPS25HB
 
-description: >
+description: |
     This binding gives a base representation of LPS25HB pressure sensor
 
 compatible: "st,lps25hb-press"

--- a/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
+++ b/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LSM303DLHC
 
-description: >
+description: |
     This binding gives a base representation of LSM303DLHC acceleration sensor
 
 compatible: "st,lsm303dlhc-accel"

--- a/dts/bindings/sensor/st,lsm303dlhc-magn.yaml
+++ b/dts/bindings/sensor/st,lsm303dlhc-magn.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LSM303DLHC
 
-description: >
+description: |
     This binding gives a base representation of LSM303DLHC magnetometer sensor
 
 compatible: "st,lsm303dlhc-magn"

--- a/dts/bindings/sensor/st,lsm6ds0.yaml
+++ b/dts/bindings/sensor/st,lsm6ds0.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LSM6DS0
 
-description: >
+description: |
     This binding gives a base representation of LSM6DS0 6-axis accelerometer
     and gyrometer
 

--- a/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LSM6DSL
 
-description: >
+description: |
     This binding gives a base representation of LSM6DSL 6-axis accelerometer
     and gyrometer
 

--- a/dts/bindings/sensor/st,lsm6dsl-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-spi.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LSM6DSL SPI
 
-description: >
+description: |
     This binding gives a base representation of LSM6DSL 6-axis accelerometer
     and gyrometer accessed through SPI bus
 

--- a/dts/bindings/sensor/st,lsm6dso-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LSM6DSO
 
-description: >
+description: |
     This binding gives a base representation of LSM6DSO 6-axis IMU
     sensor accessed through I2C bus
 

--- a/dts/bindings/sensor/st,lsm6dso-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-spi.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LSM6DSO SPI
 
-description: >
+description: |
     This binding gives a base representation of LSM6DSO 6-axis IMU
     sensor accessed through SPI bus
 

--- a/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LSM9DS0-GYRO
 
-description: >
+description: |
     This binding gives a base representation of LSM9DS0 3-axis gyro
 
 compatible: "st,lsm9ds0-gyro"

--- a/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors LSM9DS0-MFD
 
-description: >
+description: |
     This binding gives a base representation of LSM9DS0 3-axis accelerometer + magnetometer
 
 compatible: "st,lsm9ds0-mfd"

--- a/dts/bindings/sensor/st,stts751-i2c.yaml
+++ b/dts/bindings/sensor/st,stts751-i2c.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors STTS751
 
-description: >
+description: |
     This binding gives a base representation of STTS751
     temperature sensor connected to I2C bus
 

--- a/dts/bindings/sensor/st,vl53l0x.yaml
+++ b/dts/bindings/sensor/st,vl53l0x.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics MEMS sensors VL53L0X
 
-description: >
+description: |
     This binding gives a base representation of VL53L0X Time Of Flight sensor
 
 compatible: "st,vl53l0x"

--- a/dts/bindings/sensor/ti,hdc.yaml
+++ b/dts/bindings/sensor/ti,hdc.yaml
@@ -3,7 +3,7 @@
 
 title: Texas Instruments Temperature and Humidity Sensor
 
-description: >
+description: |
     This is a representation of the TI Temperature and Humidity sensor (e.g. HDC1008)
 
 compatible: "ti,hdc"

--- a/dts/bindings/sensor/ti,opt3001.yaml
+++ b/dts/bindings/sensor/ti,opt3001.yaml
@@ -3,7 +3,7 @@
 
 title: Texas Instruments OPT3001 Ambient light sensor
 
-description: >
+description: |
     This is a representation of the Texas Instruments OPT3001 Ambient light sensor
 
 compatible: "ti,opt3001"

--- a/dts/bindings/sensor/ti,tmp116.yaml
+++ b/dts/bindings/sensor/ti,tmp116.yaml
@@ -6,7 +6,7 @@
 
 title: Texas Instruments Temperature Sensor TMP116
 
-description: >
+description: |
     This is a representation of the TI Temperature sensor TMP116
 
 compatible: "ti,tmp116"

--- a/dts/bindings/serial/altera,jtag-uart.yaml
+++ b/dts/bindings/serial/altera,jtag-uart.yaml
@@ -1,6 +1,6 @@
 title: Altera JTAG UART
 
-description: >
+description: |
     This binding gives a base representation of the Altera Jtag UART
 
 compatible: "altera,jtag-uart"

--- a/dts/bindings/serial/arm,cmsdk-uart.yaml
+++ b/dts/bindings/serial/arm,cmsdk-uart.yaml
@@ -1,6 +1,6 @@
 title: ARM CMSDK UART
 
-description: >
+description: |
     This binding gives a base representation of the ARM CMSDK UART
 
 compatible: "arm,cmsdk-uart"

--- a/dts/bindings/serial/arm,pl011.yaml
+++ b/dts/bindings/serial/arm,pl011.yaml
@@ -1,6 +1,6 @@
 title: ARM PL011 UART
 
-description: >
+description: |
     This binding gives a base representation of the ARM PL011 UART
 
 compatible: "arm,pl011"

--- a/dts/bindings/serial/atmel,sam-uart.yaml
+++ b/dts/bindings/serial/atmel,sam-uart.yaml
@@ -1,6 +1,6 @@
 title: SAM Family UART
 
-description: >
+description: |
     This binding gives a base representation of the SAM UART
 
 compatible: "atmel,sam-uart"

--- a/dts/bindings/serial/atmel,sam-usart.yaml
+++ b/dts/bindings/serial/atmel,sam-usart.yaml
@@ -1,6 +1,6 @@
 title: Atmel SAM Family USART
 
-description: >
+description: |
     This binding gives a base representation of the Atmel SAM USART
 
 compatible: "atmel,sam-usart"

--- a/dts/bindings/serial/atmel,sam0-uart.yaml
+++ b/dts/bindings/serial/atmel,sam0-uart.yaml
@@ -1,6 +1,6 @@
 title: Atmel SAM0 SERCOM UART driver
 
-description: >
+description: |
     This binding gives a base representation of the Atmel SAM0 SERCOM UART driver
 
 compatible: "atmel,sam0-uart"

--- a/dts/bindings/serial/cypress,psoc6-uart.yaml
+++ b/dts/bindings/serial/cypress,psoc6-uart.yaml
@@ -3,7 +3,7 @@
 
 title: CYPRESS UART
 
-description: >
+description: |
     This binding gives a base representation of the Cypress UART
 
 compatible: "cypress,psoc6-uart"

--- a/dts/bindings/serial/espressif,esp32-uart.yaml
+++ b/dts/bindings/serial/espressif,esp32-uart.yaml
@@ -1,6 +1,6 @@
 title: ESP32 Uart
 
-description: >
+description: |
     This binding gives a base representation of the ESP32 UART
 
 compatible: "espressif,esp32-uart"

--- a/dts/bindings/serial/litex,uart0.yaml
+++ b/dts/bindings/serial/litex,uart0.yaml
@@ -3,7 +3,7 @@
 
 title: LiteX UART
 
-description: >
+description: |
     This binding gives a base representation of the LiteX UART
 
 compatible: "litex,uart0"

--- a/dts/bindings/serial/microsemi,coreuart.yaml
+++ b/dts/bindings/serial/microsemi,coreuart.yaml
@@ -3,7 +3,7 @@
 
 title: SIFIVE UART
 
-description: >
+description: |
     This binding gives a base representation of the SIFIVE UART
 
 compatible: "microsemi,coreuart"

--- a/dts/bindings/serial/nordic,nrf-uart.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart.yaml
@@ -1,6 +1,6 @@
 title: Nordic UART
 
-description: >
+description: |
     This binding gives a base representation of the Nordic UART
 
 compatible: "nordic,nrf-uart"

--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -1,6 +1,6 @@
 title: Nordic UARTE
 
-description: >
+description: |
     This binding gives a base representation of the Nordic UARTE
 
 compatible: "nordic,nrf-uarte"

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -1,6 +1,6 @@
 title: ns16550
 
-description: >
+description: |
     This binding gives a base representation of the ns16550 UART
 
 compatible: "ns16550"

--- a/dts/bindings/serial/nxp,imx-uart.yaml
+++ b/dts/bindings/serial/nxp,imx-uart.yaml
@@ -3,7 +3,7 @@
 
 title: iMX Uart
 
-description: >
+description: |
     This binding gives a base representation of the iMX UART
 
 compatible: "nxp,imx-uart"

--- a/dts/bindings/serial/nxp,kinetis-lpsci.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpsci.yaml
@@ -1,6 +1,6 @@
 title: Kinetis LPSCI UART
 
-description: >
+description: |
     This binding gives a base representation of the LPSCI UART
 
 compatible: "nxp,kinetis-lpsci"

--- a/dts/bindings/serial/nxp,kinetis-lpuart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpuart.yaml
@@ -1,6 +1,6 @@
 title: Kinetis LPUART
 
-description: >
+description: |
     This binding gives a base representation of the Kinetis LPUART
 
 compatible: "nxp,kinetis-lpuart"

--- a/dts/bindings/serial/nxp,kinetis-uart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-uart.yaml
@@ -1,6 +1,6 @@
 title: Kinetis UART
 
-description: >
+description: |
     This binding gives a base representation of the Kinetis UART
 
 compatible: "nxp,kinetis-uart"

--- a/dts/bindings/serial/nxp,lpc-usart.yaml
+++ b/dts/bindings/serial/nxp,lpc-usart.yaml
@@ -3,7 +3,7 @@
 
 title: LPC USART
 
-description: >
+description: |
     This binding gives a base representation of the LPC USART
 
 compatible: "nxp,lpc-usart"

--- a/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
+++ b/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
@@ -1,6 +1,6 @@
 title: OpenISA LPUART
 
-description: >
+description: |
     This binding gives a base representation of the OpenISA LPUART
 
 compatible: "openisa,rv32m1-lpuart"

--- a/dts/bindings/serial/sifive,uart0.yaml
+++ b/dts/bindings/serial/sifive,uart0.yaml
@@ -3,7 +3,7 @@
 
 title: SIFIVE UART
 
-description: >
+description: |
     This binding gives a base representation of the SIFIVE UART
 
 compatible: "sifive,uart0"

--- a/dts/bindings/serial/silabs,gecko-leuart.yaml
+++ b/dts/bindings/serial/silabs,gecko-leuart.yaml
@@ -1,6 +1,6 @@
 title: GECKO LEUART
 
-description: >
+description: |
     This binding gives a base representation of the Gecko LEUART
 
 compatible: "silabs,gecko-leuart"

--- a/dts/bindings/serial/silabs,gecko-uart.yaml
+++ b/dts/bindings/serial/silabs,gecko-uart.yaml
@@ -1,6 +1,6 @@
 title: GECKO UART
 
-description: >
+description: |
     This binding gives a base representation of the GECKO UART
 
 compatible: "silabs,gecko-uart"

--- a/dts/bindings/serial/silabs,gecko-usart.yaml
+++ b/dts/bindings/serial/silabs,gecko-usart.yaml
@@ -1,6 +1,6 @@
 title: GECKO USART
 
-description: >
+description: |
     This binding gives a base representation of the Gecko USART
 
 compatible: "silabs,gecko-usart"

--- a/dts/bindings/serial/snps,nsim-uart.yaml
+++ b/dts/bindings/serial/snps,nsim-uart.yaml
@@ -3,7 +3,7 @@
 
 title: Synopsys ARC nSIM UART
 
-description: >
+description: |
     This binding gives a base representation of the Synopsys ARC nSIM UART
 
 compatible: "snps,nsim-uart"

--- a/dts/bindings/serial/st,stm32-lpuart.yaml
+++ b/dts/bindings/serial/st,stm32-lpuart.yaml
@@ -1,6 +1,6 @@
 title: STM32 LPUART
 
-description: >
+description: |
     This binding gives a base representation of the STM32 LPUART
 
 compatible: "st,stm32-lpuart"

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -1,6 +1,6 @@
 title: STM32 UART
 
-description: >
+description: |
     This binding gives a base representation of the STM32 UART
 
 compatible: "st,stm32-uart"

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -1,6 +1,6 @@
 title: STM32 USART
 
-description: >
+description: |
     This binding gives a base representation of the STM32 USART
 
 compatible: "st,stm32-usart"

--- a/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
@@ -3,7 +3,7 @@
 
 title: TI SimpleLink CC13xx / CC26xx UART
 
-description: >
+description: |
     This is a representation of the TI SimpleLink CC13xx / CC26xx UART node
 
 compatible: "ti,cc13xx-cc26xx-uart"

--- a/dts/bindings/serial/ti,cc32xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc32xx-uart.yaml
@@ -1,6 +1,6 @@
 title: TI CC32XX Uart
 
-description: >
+description: |
     This binding gives a base representation of the TI CC32XX UART
 
 compatible: "ti,cc32xx-uart"

--- a/dts/bindings/serial/ti,msp432p4xx-uart.yaml
+++ b/dts/bindings/serial/ti,msp432p4xx-uart.yaml
@@ -1,6 +1,6 @@
 title: TI MSP432P4XX UART
 
-description: >
+description: |
     This binding gives a base representation of the TI MSP432P4XX UART
 
 compatible: "ti,msp432p4xx-uart"

--- a/dts/bindings/serial/ti,stellaris-uart.yaml
+++ b/dts/bindings/serial/ti,stellaris-uart.yaml
@@ -1,6 +1,6 @@
 title: TI Stellaris UART
 
-description: >
+description: |
     This binding gives a base representation of the TI Stellaris UART
 
 compatible: "ti,stellaris-uart"

--- a/dts/bindings/serial/xlnx,uartps.yaml
+++ b/dts/bindings/serial/xlnx,uartps.yaml
@@ -1,6 +1,6 @@
 title: Xilinx PS UART
 
-description: >
+description: |
     This binding gives a base representation of the Xilinx PS UART
 
 compatible: "xlnx,xuartps"

--- a/dts/bindings/serial/zephyr,native-posix-uart.yaml
+++ b/dts/bindings/serial/zephyr,native-posix-uart.yaml
@@ -3,7 +3,7 @@
 
 title: Native POSIX UART
 
-description: >
+description: |
     This binding gives a base representation of the Native POSIX UART
 
 compatible: "zephyr,native-posix-uart"

--- a/dts/bindings/spi/atmel,sam-spi.yaml
+++ b/dts/bindings/spi/atmel,sam-spi.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel SAM SPI driver
 
-description: >
+description: |
     This binding gives a base representation of the Atmel SAM SPI controller
 
 compatible: "atmel,sam-spi"

--- a/dts/bindings/spi/atmel,sam0-spi.yaml
+++ b/dts/bindings/spi/atmel,sam0-spi.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel SAM0 SERCOM SPI driver
 
-description: >
+description: |
     This binding gives a base representation of the Atmel SAM0 SERCOM SPI controller
 
 compatible: "atmel,sam0-spi"

--- a/dts/bindings/spi/litex,spi.yaml
+++ b/dts/bindings/spi/litex,spi.yaml
@@ -6,7 +6,7 @@
 
 title: LiteX SPI
 
-description: >
+description: |
     This binding gives a base representation of the LiteX SPI
 
 compatible: "litex,spi"

--- a/dts/bindings/spi/microchip,xec-qmspi.yaml
+++ b/dts/bindings/spi/microchip,xec-qmspi.yaml
@@ -6,7 +6,7 @@
 
 title: Microchip XEC Quad Master SPI driver
 
-description: >
+description: |
     This binding gives a base representation of the Microchip XEC QMSPI controller
 
 compatible: "microchip,xec-qmspi"

--- a/dts/bindings/spi/nordic,nrf-spis.yaml
+++ b/dts/bindings/spi/nordic,nrf-spis.yaml
@@ -18,6 +18,6 @@ properties:
     def-char:
       type: int
       required: true
-      description: >
+      description: |
           Default character. Character clocked out when the slave was not
           provided with buffers and is ignoring the transaction.

--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -3,7 +3,7 @@
 
 title: NXP FlexSPI
 
-description: >
+description: |
     This binding gives a base representation of the NXP FlexSPI controller
 
 compatible: "nxp,imx-flexspi"

--- a/dts/bindings/spi/nxp,imx-lpspi.yaml
+++ b/dts/bindings/spi/nxp,imx-lpspi.yaml
@@ -3,7 +3,7 @@
 
 title: NXP LPSPI
 
-description: >
+description: |
     This binding gives a base representation of the NXP i.MX LPSPI controller
 
 compatible: "nxp,imx-lpspi"

--- a/dts/bindings/spi/nxp,kinetis-dspi.yaml
+++ b/dts/bindings/spi/nxp,kinetis-dspi.yaml
@@ -3,7 +3,7 @@
 
 title: NXP DSPI
 
-description: >
+description: |
     This binding gives a base representation of the NXP Kinetis DSPI controller
 
 compatible: "nxp,kinetis-dspi"

--- a/dts/bindings/spi/opencores,spi-simple.yaml
+++ b/dts/bindings/spi/opencores,spi-simple.yaml
@@ -3,7 +3,7 @@
 
 title: OpenCores Simple SPI driver
 
-description: >
+description: |
     This binding gives a base representation of the OpenCores Simple SPI controller
 
 compatible: "opencores,spi-simple"

--- a/dts/bindings/spi/sifive,spi0.yaml
+++ b/dts/bindings/spi/sifive,spi0.yaml
@@ -3,7 +3,7 @@
 
 title: Sifive SPI driver
 
-description: >
+description: |
     This binding gives a base representation of the Sifive SPI controller
 
 compatible: "sifive,spi0"

--- a/dts/bindings/spi/snps,designware-spi.yaml
+++ b/dts/bindings/spi/snps,designware-spi.yaml
@@ -3,7 +3,7 @@
 
 title: Synopsys Designware SPI Controller
 
-description: >
+description: |
      This is a representation of the Synopsys DesignWare spi node
 
 compatible: "snps,designware-spi"

--- a/dts/bindings/spi/st,stm32-spi-fifo.yaml
+++ b/dts/bindings/spi/st,stm32-spi-fifo.yaml
@@ -3,7 +3,7 @@
 
 title: STM32 SPI FIFO
 
-description: >
+description: |
     This binding gives a base representation of the STM32 SPI controller with
     embedded Rx and Tx FIFOs
 

--- a/dts/bindings/spi/st,stm32-spi.yaml
+++ b/dts/bindings/spi/st,stm32-spi.yaml
@@ -3,7 +3,7 @@
 
 title: STM32 SPI
 
-description: >
+description: |
     This binding gives a base representation of the STM32 SPI controller
 
 compatible: "st,stm32-spi"

--- a/dts/bindings/spi/ti,cc13xx-cc26xx-spi.yaml
+++ b/dts/bindings/spi/ti,cc13xx-cc26xx-spi.yaml
@@ -3,7 +3,7 @@
 
 title: TI SimpleLink CC13xx / CC26xx SPI
 
-description: >
+description: |
     This is a representation of the TI SimpleLink CC13xx / CC26xx SPI node
 
 compatible: "ti,cc13xx-cc26xx-spi"

--- a/dts/bindings/sram/mmio-sram.yaml
+++ b/dts/bindings/sram/mmio-sram.yaml
@@ -3,7 +3,7 @@
 
 title: Generic on-chip SRAM
 
-description: >
+description: |
     This binding gives a generic on-chip SRAM description
 
 compatible: "mmio-sram"

--- a/dts/bindings/sram/sifive,dtim0.yaml
+++ b/dts/bindings/sram/sifive,dtim0.yaml
@@ -3,7 +3,7 @@
 
 title: Data Tightly-Integrated Memory
 
-description: >
+description: |
     This bindings describes the SiFive Data Tightly-Integrated Memory
 
 compatible: "sifive,dtim0"

--- a/dts/bindings/timer/arm,cmsdk-dtimer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-dtimer.yaml
@@ -1,6 +1,6 @@
 title: ARM CMSDK DUALTIMER
 
-description: >
+description: |
     This binding gives a base representation of the ARM CMSDK DUALTIMER
 
 compatible: "arm,cmsdk-dtimer"

--- a/dts/bindings/timer/arm,cmsdk-timer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-timer.yaml
@@ -1,6 +1,6 @@
 title: ARM CMSDK TIMER
 
-description: >
+description: |
     This binding gives a base representation of the ARM CMSDK TIMER
 
 compatible: "arm,cmsdk-timer"

--- a/dts/bindings/timer/atmel,sam0-tc32.yaml
+++ b/dts/bindings/timer/atmel,sam0-tc32.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel SAM0 32-bit Basic Timer
 
-description: >
+description: |
     This binding gives a base representation of the Atmel SAM0 timer
     counter (TC) operating in 32-bit wide mode.
 

--- a/dts/bindings/timer/intel,hpet.yaml
+++ b/dts/bindings/timer/intel,hpet.yaml
@@ -3,7 +3,7 @@
 
 title: HPET
 
-description: >
+description: |
     This binding represents the High-Precision Event Timer
 
 compatible: "intel,hpet"

--- a/dts/bindings/timer/litex,timer0.yaml
+++ b/dts/bindings/timer/litex,timer0.yaml
@@ -3,7 +3,7 @@
 
 title: LiteX timer
 
-description: >
+description: |
     This binding gives a base representation of the LiteX timer
 
 compatible: "litex,timer0"

--- a/dts/bindings/timer/microchip,xec-rtos-timer.yaml
+++ b/dts/bindings/timer/microchip,xec-rtos-timer.yaml
@@ -3,7 +3,7 @@
 
 title: Microchip XEC RTOS timer
 
-description: >
+description: |
     This is a representation of the Microchip XEC RTOS timer node
 
 compatible: "microchip,xec-rtos-timer"

--- a/dts/bindings/timer/nordic,nrf-timer.yaml
+++ b/dts/bindings/timer/nordic,nrf-timer.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic nRF timer
 
-description: >
+description: |
     This is a representation of the Nordic nRF timer node
 
 compatible: "nordic,nrf-timer"

--- a/dts/bindings/timer/nxp,imx-gpt.yaml
+++ b/dts/bindings/timer/nxp,imx-gpt.yaml
@@ -3,7 +3,7 @@
 
 title: NXP MCUX General Purpose Timer
 
-description: >
+description: |
     This is a representation of the NXP MCUX General Purpose Timer (GPT)
 
 compatible: "nxp,imx-gpt"

--- a/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
+++ b/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
@@ -1,6 +1,6 @@
 title: OpenISA RV32M1 LPTMR
 
-description: >
+description: |
     This binding represents the OpenISA RV32M1 LPTMR peripheral.
 
 compatible: "openisa,rv32m1-lptmr"

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -1,6 +1,6 @@
 title: STM32 TIMERS
 
-description: >
+description: |
     This binding gives a base representation of the STM32 TIMERS
 
 compatible: "st,stm32-timers"

--- a/dts/bindings/timer/xlnx,ttcps.yaml
+++ b/dts/bindings/timer/xlnx,ttcps.yaml
@@ -1,6 +1,6 @@
 title: Xilinx ZynqMP PS TTC TIMERS
 
-description: >
+description: |
     This binding gives a base representation of the Xilinx ZynqMP PS TTC TIMERS
 
 compatible: "cdns,ttc"

--- a/dts/bindings/usb/atmel,sam-usbhs.yaml
+++ b/dts/bindings/usb/atmel,sam-usbhs.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel SAM USBHS
 
-description: >
+description: |
     Atmel SAM Family USB (USBHS) in device mode
 
 compatible: "atmel,sam-usbhs"

--- a/dts/bindings/usb/atmel,sam0-usb.yaml
+++ b/dts/bindings/usb/atmel,sam0-usb.yaml
@@ -1,6 +1,6 @@
 title: Atmel SAM0 USB device
 
-description: >
+description: |
     Atmel SAM0 USB in device mode
 
 compatible: "atmel,sam0-usb"

--- a/dts/bindings/usb/nordic,nrf-usbd.yaml
+++ b/dts/bindings/usb/nordic,nrf-usbd.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic nRF52 USBD
 
-description: >
+description: |
     This binding gives a base representation of the Nordic nRF52 USB device controller
 
 compatible: "nordic,nrf-usbd"

--- a/dts/bindings/usb/nxp,kinetis-usbd.yaml
+++ b/dts/bindings/usb/nxp,kinetis-usbd.yaml
@@ -3,7 +3,7 @@
 
 title: NXP Kinetis USBD
 
-description: >
+description: |
     NPX Kinetis USBFSOTG Controller in device mode
 
 compatible: "nxp,kinetis-usbd"

--- a/dts/bindings/usb/st,stm32-otgfs.yaml
+++ b/dts/bindings/usb/st,stm32-otgfs.yaml
@@ -3,7 +3,7 @@
 
 title: STM32 OTGFS
 
-description: >
+description: |
     This binding gives a base representation of the STM32 OTGFS controller
 
 compatible: "st,stm32-otgfs"

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -3,7 +3,7 @@
 
 title: STM32 OTGHS
 
-description: >
+description: |
     This binding gives a base representation of the STM32 OTG HS controller
 
 compatible: "st,stm32-otghs"

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -3,7 +3,7 @@
 
 title: STM32 USB
 
-description: >
+description: |
     This binding gives a base representation of the STM32 USB controller
 
 compatible: "st,stm32-usb"

--- a/dts/bindings/video/aptina,mt9m114.yaml
+++ b/dts/bindings/video/aptina,mt9m114.yaml
@@ -6,7 +6,7 @@
 
 title: MT9M114 CMOS video sensor.
 
-description: >
+description: |
     This is a representation of the MT9M114 CMOS video sensor.
 
 compatible: "aptina,mt9m114"

--- a/dts/bindings/video/nxp,imx-csi.yaml
+++ b/dts/bindings/video/nxp,imx-csi.yaml
@@ -6,7 +6,7 @@
 
 title: NXP MCUX CSI module
 
-description: >
+description: |
     This binding gives a base representation of NXP MCUX CMOS Sensor Interface
 
 compatible: "nxp,imx-csi"

--- a/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
+++ b/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
@@ -1,6 +1,6 @@
 title: ARM CMSDK WATCHDOG
 
-description: >
+description: |
     This binding gives a base representation of the ARM CMSDK WATCHDOG
 
 compatible: "arm,cmsdk-watchdog"

--- a/dts/bindings/watchdog/atmel,sam-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam-watchdog.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel SAM watchdog driver
 
-description: >
+description: |
     This is a representation of the SAM0 watchdog
 
 compatible: "atmel,sam-watchdog"

--- a/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
@@ -1,6 +1,6 @@
 title: Atmel SAM0 watchdog driver
 
-description: >
+description: |
     This is a representation of the SAM0 watchdog
 
 compatible: "atmel,sam0-watchdog"

--- a/dts/bindings/watchdog/microchip,xec-watchdog.yaml
+++ b/dts/bindings/watchdog/microchip,xec-watchdog.yaml
@@ -6,7 +6,7 @@
 
 title: Microchip XEC watchdog timer
 
-description: >
+description: |
     This binding gives a base representation of the Microchip XEC watchdog timer
 
 include: base.yaml

--- a/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
+++ b/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
@@ -3,7 +3,7 @@
 
 title: Nordic Semiconductor NRF watchdog driver
 
-description: >
+description: |
     This is a representation of the NRF watchdog
 
 compatible: "nordic,nrf-watchdog"

--- a/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
@@ -3,7 +3,7 @@
 
 title: NXP Kinetis watchdog driver
 
-description: >
+description: |
     This is a representation of the Kinetis watchdog
 
 compatible: "nxp,kinetis-wdog"

--- a/dts/bindings/watchdog/nxp,kinetis-wdog32.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog32.yaml
@@ -3,7 +3,7 @@
 
 title: NXP Kinetis watchdog (WDOG32) driver
 
-description: >
+description: |
     This is a representation of the Kinetis watchdog (WDOG32)
 
 compatible: "nxp,kinetis-wdog32"

--- a/dts/bindings/watchdog/st,stm32-watchdog.yaml
+++ b/dts/bindings/watchdog/st,stm32-watchdog.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics STM32 watchdog driver
 
-description: >
+description: |
     This is a representation of the STM32 watchdog
 
 compatible: "st,stm32-watchdog"

--- a/dts/bindings/watchdog/st,stm32-window-watchdog.yaml
+++ b/dts/bindings/watchdog/st,stm32-window-watchdog.yaml
@@ -3,7 +3,7 @@
 
 title: STMicroelectronics STM32 system window watchdog driver
 
-description: >
+description: |
     This is a representation of the STM32 system window watchdog
 
 compatible: "st,stm32-window-watchdog"

--- a/dts/bindings/wifi/atmel,winc1500.yaml
+++ b/dts/bindings/wifi/atmel,winc1500.yaml
@@ -3,7 +3,7 @@
 
 title: Atmel WINC1500 Wifi module
 
-description: >
+description: |
     This binding gives the base representation of the Atmel WINC1500 Wifi module
 
 compatible: "atmel,winc1500"

--- a/dts/bindings/wifi/inventek,eswifi.yaml
+++ b/dts/bindings/wifi/inventek,eswifi.yaml
@@ -3,7 +3,7 @@
 
 title: Inventek eS-WiFi WiFi module
 
-description: >
+description: |
     This binding gives the base representation of es-WiFi module
 
 compatible: "inventek,eswifi"


### PR DESCRIPTION
With https://github.com/zephyrproject-rtos/zephyr/pull/20185, multi-line
descriptions will be formatted nicely, but using '>' breaks it, because
it removes internal newlines (including between paragraphs).

See https://yaml-multiline.info/.

Replace 'description: >' with 'description: |' to encourage '|'. That'll
prevent '>' from getting copied around and messing up long descriptions.

This will lead to some extra newlines in the output, but it's fine.
Line-wrapping messes up any manual formatting.

The replacement was done with

    $ git ls-files 'dts/bindings/*.yaml' | \
          xargs sed -i 's/description:\s*>/description: |/'