### PR TITLE
arch: arc/arm: kconfig: Remove unused DATA_ENDIANNESS_LITTLE symbol

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -74,14 +74,6 @@ config	CPU_ARCV2
 	help
 	  This option signifies the use of a CPU of the ARCv2 family.
 
-config	DATA_ENDIANNESS_LITTLE
-	bool
-	default y
-	help
-	  This is driven by the processor implementation, since it is fixed in
-	  hardware. The BSP should set this value to 'n' if the data is
-	  implemented as big endian.
-
 config	NUM_IRQ_PRIO_LEVELS
 	int "Number of supported interrupt priority levels"
 	range 1 16

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -79,14 +79,6 @@ config ISA_ARM
 config NUM_IRQS
 	int
 
-config DATA_ENDIANNESS_LITTLE
-	bool
-	default y if CPU_CORTEX
-	help
-	  This is driven by the processor implementation, since it is fixed in
-	  hardware. The board should set this value to 'n' if the data is
-	  implemented as big endian.
-
 config STACK_ALIGN_DOUBLE_WORD
 	bool "Align stacks on double-words (8 octets)"
 	default y


### PR DESCRIPTION
Existed already in commit 8ddf82cf70 ("First commit"). Has never been
used.

Found with a script.