### PR TITLE
arch: cortex_m/r: kconfig: Remove unused LDREX_STREX_AVAILABLE symbol

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -221,16 +221,8 @@ config ARMV8_M_DSP
 	  This option signifies the use of an ARMv8-M processor
 	  implementation supporting the DSP Extension.
 
-menu "ARM Cortex-M options"
-
-config LDREX_STREX_AVAILABLE
-	bool
-	default y
-
 config XIP
 	default y
-
-endmenu
 
 menu "ARM Cortex-M0/M0+/M3/M4/M7/M23/M33 options"
     depends on ARMV6_M_ARMV8_M_BASELINE || ARMV7_M_ARMV8_M_MAINLINE

--- a/arch/arm/core/cortex_r/Kconfig
+++ b/arch/arm/core/cortex_r/Kconfig
@@ -78,13 +78,9 @@ config ARMV7_SYS_STACK_SIZE
 	help
 	  This option specifies the size of the stack used by the system mode.
 
-menu "ARM Cortex-R options"
-	depends on CPU_CORTEX_R
+if CPU_CORTEX_R
 
 config RUNTIME_NMI
-	default y
-
-config LDREX_STREX_AVAILABLE
 	default y
 
 config GEN_ISR_TABLES
@@ -93,6 +89,6 @@ config GEN_ISR_TABLES
 config GEN_IRQ_VECTOR_TABLE
 	default n
 
-endmenu
+endif # CPU_CORTEX_R
 
 endif # CPU_CORTEX_R


### PR DESCRIPTION
Existed already in commit 8ddf82c ("First commit"). Has never been
used.

Found with a script.

Also remove some pointless menus that have no visible symbols in them.