### PR TITLE
net: lib: config: kconfig: Remove unused NET_CONFIG_SNTP_INIT_PRIO sym

### DIFF
--- a/subsys/net/lib/config/Kconfig
+++ b/subsys/net/lib/config/Kconfig
@@ -208,12 +208,6 @@ config NET_CONFIG_CLOCK_SNTP_INIT
 
 if NET_CONFIG_CLOCK_SNTP_INIT
 
-config NET_CONFIG_SNTP_INIT_PRIO
-	int "Startup priority to init clock using SNTP"
-	default 97
-	help
-	  Should be higher than CONFIG_NET_CONFIG_INIT_PRIO.
-
 config NET_CONFIG_SNTP_INIT_SERVER
 	string "SNTP server to use for system clock init"
 	default ""


### PR DESCRIPTION
Added in commit 106a0f7306 ("net: lib: config: Add SYS_INIT handler to
set clock from SNTP"), never used.

Found with a script.