### PR TITLE
doc: fix misspellings in rst docs

### DIFF
--- a/boards/shields/dfrobot_can_bus_v2_0/doc/index.rst
+++ b/boards/shields/dfrobot_can_bus_v2_0/doc/index.rst
@@ -7,7 +7,7 @@ Overview
 ********
 
 The DFRobot CAN BUS shield supports the Microship MCP2515 stand-alone CAN
-controller and JTA1050 high speed CAN tranceiver.
+controller and JTA1050 high speed CAN transceiver.
 The shield has an Arduino Uno R3 compatible hardware interface.
 
 

--- a/doc/guides/kconfig/index.rst
+++ b/doc/guides/kconfig/index.rst
@@ -817,7 +817,7 @@ Devicetree Related Functions
 
 See the Python docstrings in ``scripts/kconfig/kconfigfunctions.py`` for more
 details on the functions.  The ``*_int`` version of each function returns the
-value as a decimal integer, while the ``*_hex`` version returns a hexidecimal
+value as a decimal integer, while the ``*_hex`` version returns a hexadecimal
 value starting with ``0x``.
 
 .. code-block:: none

--- a/samples/sensor/tmp116/README.rst
+++ b/samples/sensor/tmp116/README.rst
@@ -44,7 +44,7 @@ following commands:
 
 Sample Output
 *************
-The output can be seen via a terminal emultator (e.g. minicom). Connect the board with a USB cable
+The output can be seen via a terminal emulator (e.g. minicom). Connect the board with a USB cable
 to the computer and open /dev/ttyACM0 with the below serial settings:
 
 * Baudrate: 115200


### PR DESCRIPTION
Fix some misspellings missed during regular reviews

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>