### PR TITLE
doc: fix misspelling in API doxygen comments

### DIFF
--- a/include/bluetooth/services/hrs.h
+++ b/include/bluetooth/services/hrs.h
@@ -25,7 +25,7 @@ extern "C" {
  *
  * This will send a GATT notification to all current subscribers.
  *
- *  @param heartrate The heartrate measuremennt in beats per minute.
+ *  @param heartrate The heartrate measurement in beats per minute.
  *
  *  @return Zero in case of success and error code in case of error.
  */

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -576,7 +576,7 @@ static inline int z_impl_can_recover(struct device *dev, s32_t timeout)
  * @brief Register an ISR callback for state change interrupt
  *
  * Only one callback can be registered per controller.
- * Calling this function again, overrides the previos call.
+ * Calling this function again, overrides the previous call.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param isr Pointer to ISR

--- a/include/drivers/espi.h
+++ b/include/drivers/espi.h
@@ -90,7 +90,7 @@ enum espi_io_mode {
  * @brief eSPI channel.
  *
  * Identifies each eSPI logical channel supported by eSPI controller
- * Each channel allows idependent traffic, but the assignment of channel
+ * Each channel allows independent traffic, but the assignment of channel
  * type to channel number is fixed.
  *
  * Note that generic commands are not associated with any channel, so traffic

--- a/include/drivers/kscan.h
+++ b/include/drivers/kscan.h
@@ -9,7 +9,7 @@
  * @brief Public API for Keyboard scan matrix devices.
  * The scope of this API is simply to report which key event was triggered
  * and users can later decode keys using their desired scan code tables in
- * their application. In additon, typematic rate and delay can easily be
+ * their application. In addition, typematic rate and delay can easily be
  * implemented using a timer if desired.
  */
 
@@ -70,7 +70,7 @@ struct kscan_driver_api {
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param callback called when keyboard devices reply to to a keyboard
- * event susch as key pressed/released.
+ * event such as key pressed/released.
  *
  * @retval 0 If successful.
  * @retval Negative errno code if failure.

--- a/include/drivers/led/ht16k33.h
+++ b/include/drivers/led/ht16k33.h
@@ -20,7 +20,7 @@
  * @param child       HT16K33 keyscan child device.
  * @param keyscan_idx Index of the keyscan line handled by the keyscan
  *		      child device (0, 1, or 2).
- * @return 0 if successful, negative errne code on failure.
+ * @return 0 if successful, negative errno code on failure.
  */
 int ht16k33_register_keyscan_device(struct device *parent,
 				    struct device *child,

--- a/include/drivers/video.h
+++ b/include/drivers/video.h
@@ -56,7 +56,7 @@ struct video_format {
  *
  * Used to describe a video endpoint format capability.
  *
- * @param pixelformat is a list of suported pixel formats (0 terminated).
+ * @param pixelformat is a list of supported pixel formats (0 terminated).
  * @param width_min is the minimum supported frame width.
  * @param width_max is the maximum supported frame width.
  * @param height_min is the minimum supported frame width.

--- a/include/fatal.h
+++ b/include/fatal.h
@@ -45,7 +45,7 @@ enum k_fatal_error_reason {
  * @brief Halt the system on a fatal error
  *
  * Invokes architecture-specific code to power off or halt the system in
- * a low power state. Lacking that, lock interupts and sit in an idle loop.
+ * a low power state. Lacking that, lock interrupts and sit in an idle loop.
  *
  * @param reason Fatal exception reason code
  */

--- a/include/fs/fcb.h
+++ b/include/fs/fcb.h
@@ -191,7 +191,7 @@ typedef int (*fcb_walk_cb)(struct fcb_entry_ctx *loc_ctx, void *arg);
 /**
  * Walk over all entries in the FCB sector
  *
- * @param[in] sector     fcb sector to be wallked. If null, traverse entire
+ * @param[in] sector     fcb sector to be walked. If null, traverse entire
  *                       storage.
  * @param[in] fcb        FCB instance structure.
  * @param[in] cb         pointer to the function which gets called for every
@@ -290,7 +290,7 @@ int fcb_clear(struct fcb *fcb);
  */
 
 /**
- * @brief Flash Circular internall
+ * @brief Flash Circular internal
  * @defgroup fcb_internall fcb non-API prototypes
  * @ingroup fcb
  * @{

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1330,7 +1330,7 @@ const char *k_thread_name_get(k_tid_t thread_id);
  *
  * @param thread_id Thread to obtain name information
  * @param buf Destination buffer
- * @param size Destinatiomn buffer size
+ * @param size Destination buffer size
  * @retval -ENOSPC Destination buffer too small
  * @retval -EFAULT Memory access error
  * @retval -ENOSYS Thread name feature not enabled
@@ -3106,7 +3106,7 @@ extern void k_work_poll_init(struct k_work_poll *work,
  * Submitting a previously submitted triggered work item that is still
  * waiting for the event cancels the existing submission and reschedules it
  * the using the new event list. Note that this behavior is inherently subject
- * to race conditions with the pre-existig triggered work item and work queue,
+ * to race conditions with the pre-existing triggered work item and work queue,
  * so care must be taken to synchronize such resubmissions externally.
  *
  * @note Can be called by ISRs.
@@ -3146,7 +3146,7 @@ extern int k_work_poll_submit_to_queue(struct k_work_q *work_q,
  * Submitting a previously submitted triggered work item that is still
  * waiting for the event cancels the existing submission and reschedules it
  * the using the new event list. Note that this behavior is inherently subject
- * to race conditions with the pre-existig triggered work item and work queue,
+ * to race conditions with the pre-existing triggered work item and work queue,
  * so care must be taken to synchronize such resubmissions externally.
  *
  * @note Can be called by ISRs.
@@ -3185,7 +3185,7 @@ static inline int k_work_poll_submit(struct k_work_poll *work,
  *
  * @param work Address of delayed work item.
  *
- * @retval 0 Work tiem canceled.
+ * @retval 0 Work item canceled.
  * @retval -EINVAL Work item is being processed or has completed its work.
  */
 extern int k_work_poll_cancel(struct k_work_poll *work);

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -636,7 +636,7 @@ void __printf_like(2, 3) log_from_user(struct log_msg_ids src_level,
 /* Internal function used by log_from_user(). */
 __syscall void z_log_string_from_user(u32_t src_level_val, const char *str);
 
-/** @brief Log binary data (displayed as hexdump) from user mode conext.
+/** @brief Log binary data (displayed as hexdump) from user mode context.
  *
  * @note This function is intended to be used internally
  *	 by the logging subsystem.

--- a/include/settings/settings.h
+++ b/include/settings/settings.h
@@ -172,7 +172,7 @@ struct settings_handler_static {
  * @param _commit commit routine (can be NULL)
  * @param _export export routine (can be NULL)
  *
- * This createa a variable _hname prepended by settings_handler_.
+ * This creates a variable _hname prepended by settings_handler_.
  *
  */
 

--- a/include/shell/shell_history.h
+++ b/include/shell/shell_history.h
@@ -75,7 +75,7 @@ void shell_history_mode_exit(struct shell_history *history);
  * @param[in]     history	Shell history instance.
  * @param[in]     up		Direction.
  * @param[out]    dst		Buffer where line is copied.
- * @param[in,out] len		Buffer size (intput), amount of copied
+ * @param[in,out] len		Buffer size (input), amount of copied
  *				data (output).
  * @return True if remains in history mode.
  */

--- a/include/sys/math_extras.h
+++ b/include/sys/math_extras.h
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief Extra arithmetic and bitmanipulation functions.
+ * @brief Extra arithmetic and bit manipulation functions.
  *
  * @details This header file provides portable wrapper functions for a number of
  * arithmetic and bit-counting functions that are often provided by compiler


### PR DESCRIPTION
Fix misspellings in API doxygen comments missed during regular reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>