### PR TITLE
kernel: sched: do not abort a thread that's already dead.

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1052,6 +1052,13 @@ void z_sched_abort(struct k_thread *thread)
 		return;
 	}
 
+	/* if the thread is already terminated in other
+	 * cores, e.g. in thread exit, just return
+	 */
+	if (thread->base.thread_state & _THREAD_DEAD) {
+		return;
+	}
+
 	/* First broadcast an IPI to the other CPUs so they can stop
 	 * it locally.  Not all architectures support that, alas.  If
 	 * we don't have it, we need to wait for some other interrupt.


### PR DESCRIPTION
For SMP case, if a thread is already dead/terminated, because
e.g. thread exits, and other cores want to terminate this thread,
z_sched_abort just returns and no need to do further work, e.g.
raise an ipi interrupt as the target thread is already dead.

It's an optimization, especially for SMP case.

What's more, have we ever considered the cases of multi k_thread_abort/k_thread_create on the same
thread?

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>