### PR TITLE
scripts: edtlib/extract_dts_includes.py: Speed up 2x+ with yaml.CLoader

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -16,9 +16,16 @@
 
 import os, fnmatch
 import re
-import yaml
 import argparse
 from collections import defaultdict
+
+import yaml
+try:
+    # Use the C LibYAML parser if available, rather than the Python parser.
+    # It's much faster.
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
 
 from devicetree import parse_file
 from extract.globals import *
@@ -336,7 +343,7 @@ def load_bindings(root, binding_dirs):
     compats = []
 
     # Add '!include foo.yaml' handling
-    yaml.Loader.add_constructor('!include', yaml_include)
+    Loader.add_constructor('!include', yaml_include)
 
     # Code below is adapated from edtlib.py
 
@@ -353,7 +360,7 @@ def load_bindings(root, binding_dirs):
         if not dt_compats_search(contents):
             continue
 
-        binding = yaml.load(contents, Loader=yaml.Loader)
+        binding = yaml.load(contents, Loader=Loader)
 
         binding_compats = _binding_compats(binding)
         if not binding_compats:
@@ -361,7 +368,7 @@ def load_bindings(root, binding_dirs):
 
         with open(file, 'r', encoding='utf-8') as yf:
             binding = merge_included_bindings(file,
-                                              yaml.load(yf, Loader=yaml.Loader))
+                                              yaml.load(yf, Loader=Loader))
 
         for compat in binding_compats:
             if compat not in compats:
@@ -456,7 +463,7 @@ def load_binding_file(fname):
                        "!include statement: {}".format(fname, filepaths))
 
     with open(filepaths[0], 'r', encoding='utf-8') as f:
-        return yaml.load(f, Loader=yaml.Loader)
+        return yaml.load(f, Loader=Loader)
 
 
 def yaml_inc_error(msg):


### PR DESCRIPTION
Use the LibYAML-based yaml.CLoader if available instead of yaml.Loader,
which is written in Python and slow. See
https://pyyaml.org/wiki/PyYAMLDocumentation.

This speeds up gen_defines.py from 0.2s to 0.07s on my system, for
-DBOARD=hifive1. It should also make scripts/kconfig/kconfig.py faster,
because it indirectly uses edtlib via
scripts/kconfig/kconfigfunctions.py.

yaml.CLoader seems to be available out of the box when installing with
pip on Ubuntu at least.

Helps with https://github.com/zephyrproject-rtos/zephyr/issues/20104.