### PR TITLE
net: pkt: Make sure iface is not null when accessing L2

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -550,6 +550,10 @@ enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt);
  */
 static inline const struct net_l2 * const net_if_l2(struct net_if *iface)
 {
+	if (!iface) {
+		return NULL;
+	}
+
 	return iface->if_dev->l2;
 }
 


### PR DESCRIPTION
It is possible that the network interface is not set when we
check the interface in net_pkt.c:pkt_buffer_length(). For example
in icmpv6 unit test the interface is left as NULL as the test does
not care about what network interface is used. For real hw like
mimxrt1050_evk, which supports Ethernet, we need to add additional
checks for the interface being non-null.

Fixes #20088

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>