### PR TITLE
sanitycheck: Fix pylint warnings

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2151,9 +2151,6 @@ class BoundedExecutor(concurrent.futures.ThreadPoolExecutor):
             future.add_done_callback(lambda x: self.semaphore.release())
             return future
 
-    def shutdown(self, wait=True):
-        super().shutdown(wait)
-
 
 class TestSuite:
     config_re = re.compile('(CONFIG_[A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1522,6 +1522,9 @@ class TestCase(object):
         with open(inf_name) as inf:
             with contextlib.closing(mmap.mmap(inf.fileno(), 0, mmap.MAP_PRIVATE,
                                               mmap.PROT_READ, 0)) as main_c:
+                # contextlib makes pylint think main_c isn't subscriptable
+                # pylint: disable=unsubscriptable-object
+
                 suite_regex_match = suite_regex.search(main_c)
                 if not suite_regex_match:
                     # can't find ztest_test_suite, maybe a client, because

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2009,20 +2009,6 @@ class ProjectBuilder(FilterBuilder):
             with report_lock:
                 self.report_out()
 
-    def log_info_file(self, instance):
-
-        build_dir = instance.build_dir
-        h_log = "{}/handler.log".format(build_dir)
-        b_log = "{}/build.log".format(build_dir)
-        v_log = "{}/valgrind.log".format(build_dir)
-
-        if os.path.exists(v_log) and "Valgrind" in instance.reason:
-            log_info("{}".format(v_log))
-        elif os.path.exists(h_log):
-            log_info("{}".format(h_log))
-        else:
-            log_info("{}".format(b_log))
-
     def report_out(self):
         total_tests_width = len(str(self.suite.total_tests))
         self.suite.total_done += 1
@@ -2041,7 +2027,7 @@ class ProjectBuilder(FilterBuilder):
                         COLOR_NORMAL,
                         instance.reason), False)
             if not VERBOSE:
-                self.log_info_file(instance)
+                log_info_file(instance)
         elif instance.status == "skipped":
             self.suite.total_skipped += 1
             status = COLOR_YELLOW + "SKIPPED" + COLOR_NORMAL
@@ -2067,7 +2053,7 @@ class ProjectBuilder(FilterBuilder):
                 instance.testcase.name, status, more_info))
 
             if instance.status in ["failed", "timeout"]:
-                self.log_info_file(instance)
+                log_info_file(instance)
         else:
             sys.stdout.write("\rtotal complete: %s%4d/%4d%s  %2d%%  skipped: %s%4d%s, failed: %s%4d%s" % (
                         COLOR_GREEN,
@@ -3394,6 +3380,21 @@ def log_info(filename):
         info("{:-^100}".format(filename))
     else:
         info("\n\tsee: " + COLOR_YELLOW + filename + COLOR_NORMAL)
+
+
+def log_info_file(instance):
+    build_dir = instance.build_dir
+    h_log = "{}/handler.log".format(build_dir)
+    b_log = "{}/build.log".format(build_dir)
+    v_log = "{}/valgrind.log".format(build_dir)
+
+    if os.path.exists(v_log) and "Valgrind" in instance.reason:
+        log_info("{}".format(v_log))
+    elif os.path.exists(h_log):
+        log_info("{}".format(h_log))
+    else:
+        log_info("{}".format(b_log))
+
 
 def size_report(sc):
     info(sc.filename)


### PR DESCRIPTION
Fix the last remaining `pylint` warnings in preparation for turning on checking of `scripts/sanitycheck` (it's currently skipped manually).

```
sanitycheck: Suppress bogus not-subscriptable pylint warning

pylint gets confused by contextlib.
```

```
sanitycheck: Make log_info_file() a regular function

Fixes this pylint warning:

    R0201: Method could be a function (no-self-use)

Could also make it a class method.
```

```
sanitycheck: Remove pointless shutdown() from BoundedExecutor

Just calls through to concurrent.futures.Executor.shutdown() in the base
class, which has the same signature. Removing it means the base class
version will get used directly.

Fixes this pylint warning:

    W0235: Useless super delegation in method 'shutdown'
    (useless-super-delegation)
```