### PR TITLE
CODEOWNERS: Add subsys/logging/log_backend_net.c

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -347,6 +347,7 @@
 /subsys/fs/littlefs_fs.c                  @pabigot
 /subsys/fs/nvs/                           @Laczen
 /subsys/logging/                          @nordic-krch
+/subsys/logging/log_backend_net.c         @nordic-krch @jukkar
 /subsys/mgmt/                             @carlescufi @nvlsianpu
 /subsys/net/buf.c                         @jukkar @jhedberg @tbursztyka @pfalcon
 /subsys/net/ip/                           @jukkar @tbursztyka @pfalcon


### PR DESCRIPTION
Add myself to owner of subsys/logging/log_backend_net.c so
that if there are changes to that file, I get notified.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>