### PR TITLE
tests: arch: arm: increase main stack size for no-opt interrupt test

### DIFF
--- a/tests/arch/arm/arm_interrupt/testcase.yaml
+++ b/tests/arch/arm/arm_interrupt/testcase.yaml
@@ -10,3 +10,4 @@ tests:
     extra_configs:
       - CONFIG_NO_OPTIMIZATIONS=y
       - CONFIG_IDLE_STACK_SIZE=512
+      - CONFIG_MAIN_STACK_SIZE=1024


### PR DESCRIPTION
Tests fail with the default 512 byte main stack size.  Increase it
just as the idle stack size has been increased over default.

Tested on sam_e70_xplained and nrf52840_pca10056 which exhibited the same failure.

Closes #20202
