### PR TITLE
drivers: CAN: MCP2515: Optimise TX SPI data length

### DIFF
--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -216,7 +216,7 @@ static void mcp2515_convert_zcanframe_to_mcp2515frame(const struct zcan_frame
 
 	target[MCP2515_FRAME_OFFSET_DLC] = rtr | dlc;
 
-	for (; data_idx < 8; data_idx++) {
+	for (; data_idx < CAN_MAX_DLC; data_idx++) {
 		target[MCP2515_FRAME_OFFSET_D0 + data_idx] =
 			source->data[data_idx];
 	}
@@ -245,7 +245,7 @@ static void mcp2515_convert_mcp2515frame_to_zcanframe(const u8_t *source,
 	target->rtr = source[MCP2515_FRAME_OFFSET_DLC] & BIT(6) ?
 		      CAN_REMOTEREQUEST : CAN_DATAFRAME;
 
-	for (; data_idx < 8; data_idx++) {
+	for (; data_idx < CAN_MAX_DLC; data_idx++) {
 		target->data[data_idx] = source[MCP2515_FRAME_OFFSET_D0 +
 						data_idx];
 	}
@@ -386,6 +386,7 @@ static int mcp2515_send(struct device *dev, const struct zcan_frame *msg,
 	u8_t tx_idx = 0U;
 	u8_t abc;
 	u8_t nnn;
+	u8_t len;
 	u8_t tx_frame[MCP2515_FRAME_LEN];
 
 	if (k_sem_take(&dev_data->tx_sem, timeout) != 0) {
@@ -417,7 +418,10 @@ static int mcp2515_send(struct device *dev, const struct zcan_frame *msg,
 	/* Address Pointer selection */
 	abc = 2 * tx_idx;
 
-	mcp2515_cmd_load_tx_buffer(dev, abc, tx_frame, sizeof(tx_frame));
+	/* Calculate minimum length to transfer */
+	len = sizeof(tx_frame) - CAN_MAX_DLC + msg->dlc;
+
+	mcp2515_cmd_load_tx_buffer(dev, abc, tx_frame, len);
 
 	/* request tx slot transmission */
 	nnn = BIT(tx_idx);


### PR DESCRIPTION
When loading the TX buffer via SPI only transfer the data bytes of the CAN message that will be used as defined by the DLC bits.

Performance test below was performed with CAN driver configured in loopback mode running at 125kbit/s.

When DLC=8 the CPU usage performance is roughly the same.  As DLC reduces the CPU usage shows improvement on tests made before the PR.  For DLC <= 1 the CPU usage starts to saturate and the CAN messages per second is improved by up to 9% (1646/1505 - 1).

**Before this PR**

DLC | msg/s | kbit/s | CPU usage %
-----|-------|-------|--------------
0 | 1505 |  96 | 99
1 | 1495 | 107 | 97
2 | 1439 | 115 | 83
3 | 1296 | 114 | 77
4 | 1191 | 114 | 72
5 | 1105 | 114 | 66
6 | 1030 | 115 | 61
7 |  955 | 114 | 57
8 |  889 | 113 | 53


**After this PR**

DLC | msg/s | kbit/s | CPU usage %
-----|-------|-------|--------------
0 | 1646 | 105 | 98
1 | 1589 | 114 | 86
2 | 1439 | 115 | 78
3 | 1296 | 114 | 72
4 | 1191 | 114 | 67
5 | 1105 | 114 | 63
6 | 1030 | 115 | 60
7 |  955 | 114 | 56
8 |  889 | 113 | 53

Depends on #20367 