### PR TITLE
scripts/requirements: update PyYAML to >=5.1

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,5 +1,5 @@
 Pillow
-PyYAML>=3.13
+PyYAML>=5.1
 breathe>=4.9.1
 colorama
 docutils>=0.14


### PR DESCRIPTION
sanitycheck now requires yaml.FullLoader to support generating
hardware maps.  This feature was introduced in PyYAML 5.1.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>