### PR TITLE
[TOPIC-GPIO] miscellaneous patches 

### DIFF
--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.yaml
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.yaml
@@ -10,3 +10,5 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - gpio

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
@@ -16,6 +16,7 @@ ram: 32768
 flash: 8192
 supported:
   - display
+  - gpio
   - hwinfo
   - i2c
   - netif:eth

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -286,10 +286,6 @@ static int port_set_masked(struct device *dev,
 		return -EWOULDBLOCK;
 	}
 
-	if (mask & ~(gpio_port_pins_t)ALL_PINS) {
-		return -EINVAL;
-	}
-
 	return port_write(dev, mask, value);
 }
 
@@ -313,10 +309,6 @@ static int port_toggle_bits(struct device *dev,
 	/* Can't do I2C bus operations from an ISR */
 	if (k_is_in_isr()) {
 		return -EWOULDBLOCK;
-	}
-
-	if (pins & ~(gpio_port_pins_t)ALL_PINS) {
-		return -EINVAL;
 	}
 
 	return port_write(dev, pins,

--- a/drivers/gpio/gpio_utils.h
+++ b/drivers/gpio/gpio_utils.h
@@ -59,7 +59,7 @@ static inline void gpio_fire_callbacks(sys_slist_t *list,
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(list, cb, tmp, node) {
 		if (cb->pin_mask & pins) {
 			__ASSERT(cb->handler, "No callback handler!");
-			cb->handler(port, cb, pins);
+			cb->handler(port, cb, cb->pin_mask & pins);
 		}
 	}
 }

--- a/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
+++ b/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  peripheral.gpio:
+  peripheral.gpio.1pin:
     tags: drivers gpio
     depends_on: gpio
     min_flash: 48

--- a/tests/drivers/gpio/gpio_basic_api/boards/mimxrt1060_evk.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/mimxrt1060_evk.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test,gpio_basic_api";
+		out-gpios = <&gpio1 23 0>; /* Arduino D0 */
+		in-gpios = <&gpio1 22 0>;  /* Arduino D1 */
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_l476rg.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test,gpio_basic_api";
+		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
+		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
@@ -18,16 +18,6 @@
 static struct drv_data data;
 static int cb_cnt;
 
-static int pin_num(u32_t pins)
-{
-	int ret = 0;
-
-	while (pins >>= 1) {
-		ret++;
-	}
-	return ret;
-}
-
 static void callback(struct device *dev,
 		     struct gpio_callback *gpio_cb, u32_t pins)
 {
@@ -35,7 +25,8 @@ static void callback(struct device *dev,
 						 struct drv_data, gpio_cb);
 
 	/*= checkpoint: pins should be marked with correct pin number bit =*/
-	zassert_true(pin_num(pins) == PIN_IN, NULL);
+	zassert_equal(pins, BIT(PIN_IN),
+		      "unexpected pins %x", pins);
 	++cb_cnt;
 	TC_PRINT("callback triggered: %d\n", cb_cnt);
 	if ((cb_cnt == 1)

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
-  peripheral.gpio:
+  peripheral.gpio.2pin:
     tags: drivers gpio
     depends_on: gpio
-    harness: loopback # see documentation
+    harness: console
     min_flash: 34
     filter: DT_INST_0_TEST_GPIO_BASIC_API
       or DT_ALIAS_GPIO_0_LABEL or DT_ALIAS_GPIO_1_LABEL


### PR DESCRIPTION
This branch has updates for issues discovered while checking the current topic-gpio against a variety of boards listed below. 

The two below are a partial attempt to support hardware device testing with sanitycheck.  That was generally unsuccessful, but the changes are still useful so I've left them in:
* tests: drivers: gpio: clean up testcase descriptions
* boards: mark gpio as supported capability where known missing

This next one adds overlays so I can test with the boards I have:
* tests: gpio_basic_api: add more board support

These next two fix a problem with drivers that pass all signalling pins to callbacks, rather than just the ones that the callback is interested in.  See commit messages for justification.  The alternative is to do this in every driver---some (mcux) already do, some (sam) do not---or to confuse callbacks with pins that aren't relevant to them:
* tests: gpio_basic_api: simplify handling of callback pin check
* drivers: gpio: utils: filter pin notifications based on callback

This one bypasses a problem with the 1-pin test expecting to be able to use 32 pins per GPIO.  See discussion at `nrf52_pca20020` below:
* drivers: gpio: sx1509b: relax conditions on pin specification

Issues have been opened for the failures.  All issues have a PR resolving them.

#### Available Boards
* atsamd21_xpro: Both tests pass
* efr32mg_sltb004a: 1pin pass; 2pin fails double-edge detection, issue #20223 pr #20235
* esp32: 1pin not tested (no LED); 2pin passes
* frdm_k64f: Both tests pass
* nrf52840_pca10056: Both tests pass
* nrf52_pca20020 (sx1509b): Both tests pass.  Initially 1pin failed because the test assumes that devices supports more than 16 pins.  The failure has been eliminated by removing the check for invalid pins from the sx1509b driver, in expectation that eventually PR #20115 will be merged to do this at a higher level, and the test assumptions recalibrated.
* rv32m1_vega_ri5cy: 1pin passes, 2pin fails double-edge detection, issue #20224 pr #20238
* sam_e70_xplained: 1pin passes, 2pin fails issue #20225 pr #20234

#### Substituted Boards

* mimxrt1060_evk: Both tests pass
* nucleo_l476rg: Both tests pass`
