### PR TITLE
kconfig: Update Kconfiglib and use new helpers in kconfig.py

### DIFF
--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -101,7 +101,7 @@ an item will jump to it. Item values can be toggled directly within the dialog.\
 
 
 def _main():
-    menuconfig(standard_kconfig())
+    menuconfig(standard_kconfig(__doc__))
 
 
 # Global variables used below:
@@ -1481,9 +1481,8 @@ def _toggle_showall(_):
 def _do_showall():
     # Updates the UI for the current show-all setting
 
-    # Don't allow turning off show-all if we're in single-menu mode and the
-    # current menu would become empty
-    if _single_menu and not _shown_menu_nodes(_cur_menu):
+    # Don't allow turning off show-all if we'd end up with no visible nodes
+    if _nothing_shown():
         _show_all_var.set(True)
         return
 
@@ -1516,6 +1515,17 @@ def _do_showall():
     _tree.yview(_item_row(stayput) - old_scroll)
 
     _tree.focus_set()
+
+
+def _nothing_shown():
+    # _do_showall() helper. Returns True if no nodes would get
+    # shown with the current show-all setting. Also handles the
+    # (obscure) case when there are no visible nodes in the entire
+    # tree, meaning guiconfig was automatically started in
+    # show-all mode, which mustn't be turned off.
+
+    return not _shown_menu_nodes(
+        _cur_menu if _single_menu else _kconf.top_node)
 
 
 def _toggle_tree_mode(_):

--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Modified from: https://github.com/ulfalizer/Kconfiglib/blob/master/examples/merge_config.py
+
 import argparse
 import os
 import sys
@@ -131,7 +131,7 @@ def verify_assigned_sym_value(sym):
     if user_value != sym.str_value:
         msg = "warning: {} was assigned the value '{}' but got the " \
               "value '{}'." \
-              .format(name_and_loc(sym), user_value, sym.str_value)
+              .format(sym.name_and_loc, user_value, sym.str_value)
 
         if promptless(sym): msg += PROMPTLESS_HINT
         msg += SYM_INFO_HINT.format(sym.name)
@@ -158,24 +158,12 @@ def verify_assigned_choice_value(choice):
     if choice.user_selection is not choice.selection:
         msg = "warning: the choice symbol {} was selected (set =y), but {} " \
               "ended up as the choice selection. {}" \
-              .format(name_and_loc(choice.user_selection),
-                      name_and_loc(choice.selection) if choice.selection
+              .format(choice.user_selection.name_and_loc,
+                      choice.selection.name_and_loc if choice.selection
                           else "no symbol",
                       SYM_INFO_HINT.format(choice.user_selection.name))
 
         print("\n" + textwrap.fill(msg, 100), file=sys.stderr)
-
-
-def name_and_loc(sym):
-    # Helper for printing the name and Kconfig file location(s) for a symbol
-
-    if not sym.nodes:
-        return sym.name + " (undefined)"
-
-    return "{} (defined at {})".format(
-        sym.name,
-        ", ".join("{}:{}".format(node.filename, node.linenr)
-                  for node in sym.nodes))
 
 
 def promptless(sym):
@@ -209,16 +197,13 @@ def write_kconfig_filenames(paths, root_path, output_file_path):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter
-    )
+    parser = argparse.ArgumentParser()
 
     parser.add_argument("kconfig_root")
     parser.add_argument("dotconfig")
     parser.add_argument("autoconf")
     parser.add_argument("sources")
-    parser.add_argument("conf_fragments", metavar='conf', type=str, nargs='+')
+    parser.add_argument("conf_fragments", nargs='+')
 
     return parser.parse_args()
 

--- a/scripts/kconfig/menuconfig.py
+++ b/scripts/kconfig/menuconfig.py
@@ -73,7 +73,7 @@ This is the current list of built-in styles:
     - default       classic Kconfiglib theme with a yellow accent
     - monochrome    colorless theme (uses only bold and standout) attributes,
                     this style is used if the terminal doesn't support colors
-    - aquatic       blue tinted style loosely resembling the lxdialog theme
+    - aquatic       blue-tinted style loosely resembling the lxdialog theme
 
 It is possible to customize the current style by changing colors of UI
 elements on the screen. This is the list of elements that can be stylized:
@@ -174,21 +174,40 @@ Other features
 Limitations
 ===========
 
-Doesn't work out of the box on Windows, but can be made to work with 'pip
-install windows-curses'. See the
-https://github.com/zephyrproject-rtos/windows-curses repository.
+Doesn't work out of the box on Windows, but can be made to work with
 
-'pip install kconfiglib' on Windows automatically installs windows-curses
-to make the menuconfig usable.
+    pip install windows-curses
+
+See the https://github.com/zephyrproject-rtos/windows-curses repository.
 """
 from __future__ import print_function
 
-import curses
+import sys
+
+try:
+    import curses
+except ImportError as e:
+    if sys.platform != "win32":
+        raise
+    sys.exit("""\
+menuconfig failed to import the standard Python 'curses' library. Try
+installing a package like windows-curses
+(https://github.com/zephyrproject-rtos/windows-curses) by running this command
+in cmd.exe:
+
+    pip install windows-curses
+
+Starting with Kconfiglib 13.0.0, windows-curses is no longer automatically
+installed when installing Kconfiglib via pip on Windows (because it breaks
+installation on MSYS2).
+
+Exception:
+{}: {}""".format(type(e).__name__, e))
+
 import errno
 import locale
 import os
 import re
-import sys
 import textwrap
 
 from kconfiglib import Symbol, Choice, MENU, COMMENT, MenuNode, \
@@ -628,7 +647,7 @@ def _style_attr(fg_color, bg_color, attribs, color_attribs={}):
 
 
 def _main():
-    menuconfig(standard_kconfig())
+    menuconfig(standard_kconfig(__doc__))
 
 
 def menuconfig(kconf):
@@ -2194,9 +2213,7 @@ def _sorted_sc_nodes(cached_nodes=[]):
                          key=lambda choice: choice.name or "")
 
         cached_nodes += sorted(
-            [node
-             for choice in choices
-                 for node in choice.nodes],
+            [node for choice in choices for node in choice.nodes],
             key=lambda node: node.prompt[0] if node.prompt else "")
 
     return cached_nodes


### PR DESCRIPTION
Update Kconfiglib, menuconfig, and guiconfig to upstream revision
faa1d21998, mostly to get this commit in:

    Add public helpers for generating "<name> (defined at ...)" strings

    Have Symbol/Choice.name_and_loc return strings like

        "MY_SYM (defined at foo:1, bar:2)"
        "<choice> (defined at foo:4)"

    I've added a function like that in at least four different scripts
    now, so that's probably a sign that it's a worthwhile helper.

    Clean up the tests/Klocation tests a bit while adding tests.

Use the new helper to simplify kconfig.py a bit. Also clean it up a bit
more by removing some unused stuff.

Some other minor improvements are included as well, e.g. to make
menuconfig/guiconfig give more helpful errors on invalid arguments.