### PR TITLE
cmake: add --divide to GNU assembler options for x86

### DIFF
--- a/cmake/compiler/gcc/target_x86.cmake
+++ b/cmake/compiler/gcc/target_x86.cmake
@@ -9,3 +9,10 @@ else()
   string(PREPEND CMAKE_C_FLAGS   "-m32 ")
   string(PREPEND CMAKE_CXX_FLAGS "-m32 ")
 endif()
+
+# GNU Assembler, by default on non-Linux targets, treats slashes as
+# start of comments on i386.
+# (https://sourceware.org/binutils/docs-2.33.1/as/i386_002dChars.html#i386_002dChars)
+# In order to use division, `--divide` needs to be passed to
+# the assembler.
+list(APPEND TOOLCHAIN_C_FLAGS -Wa,--divide)


### PR DESCRIPTION
GNU Assembler, by default on non-Linux targets, treats slashes as
start of comments on i386.
(https://sourceware.org/binutils/docs-2.33.1/as/i386_002dChars.html#i386_002dChars)
In order to use division, `--divide` needs to be passed to
the assembler.

Fixes https://github.com/zephyrproject-rtos/sdk-ng/issues/109