### PR TITLE
Bluetooth: controller: split: Fix missing terminate_ack initialization

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -61,11 +61,10 @@ struct lll_conn {
 	u16_t interval;
 	u16_t latency;
 
-	/* FIXME: BEGIN: Move to ULL? */
 	u16_t latency_prepare;
 	u16_t latency_event;
-
 	u16_t event_counter;
+
 	u8_t data_chan_map[5];
 	u8_t data_chan_count:6;
 	u8_t data_chan_sel:1;
@@ -80,24 +79,17 @@ struct lll_conn {
 		u16_t data_chan_id;
 	};
 
-	union {
-		struct {
-			u8_t terminate_ack:1;
-		} master;
-
-		struct {
-			u8_t  latency_enabled:1;
-			u8_t  latency_cancel:1;
-			u8_t  sca:3;
-			u32_t window_widening_periodic_us;
-			u32_t window_widening_max_us;
-			u32_t window_widening_prepare_us;
-			u32_t window_widening_event_us;
-			u32_t window_size_prepare_us;
-			u32_t window_size_event_us;
-		} slave;
-	};
-	/* FIXME: END: Move to ULL? */
+#if defined(CONFIG_BT_PERIPHERAL)
+	struct {
+		u8_t  latency_enabled:1;
+		u32_t window_widening_periodic_us;
+		u32_t window_widening_max_us;
+		u32_t window_widening_prepare_us;
+		u32_t window_widening_event_us;
+		u32_t window_size_prepare_us;
+		u32_t window_size_event_us;
+	} slave;
+#endif /* CONFIG_BT_PERIPHERAL */
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	u16_t max_tx_octets;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -605,7 +605,6 @@ u8_t ll_adv_enable(u8_t enable)
 		conn_lll->latency_prepare = 0;
 		conn_lll->latency_event = 0;
 		conn_lll->slave.latency_enabled = 0;
-		conn_lll->slave.latency_cancel = 0;
 		conn_lll->slave.window_widening_prepare_us = 0;
 		conn_lll->slave.window_widening_event_us = 0;
 		conn_lll->slave.window_size_prepare_us = 0;
@@ -619,6 +618,7 @@ u8_t ll_adv_enable(u8_t enable)
 		conn->procedure_expire = 0;
 
 		conn->common.fex_valid = 0;
+		conn->slave.latency_cancel = 0;
 
 		conn->llcp_req = conn->llcp_ack = conn->llcp_type = 0;
 		conn->llcp_rx = NULL;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -939,7 +939,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 	 * Slave received terminate ind or MIC failure
 	 */
 	reason_peer = conn->llcp_terminate.reason_peer;
-	if (reason_peer && (lll->role || lll->master.terminate_ack)) {
+	if (reason_peer && (lll->role || conn->master.terminate_ack)) {
 		conn_cleanup(conn, reason_peer);
 
 		return;
@@ -967,7 +967,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 				lll->latency_event = lll->latency;
 			}
 		} else if (reason_peer) {
-			lll->master.terminate_ack = 1;
+			conn->master.terminate_ack = 1;
 		}
 
 		/* Reset connection failed to establish countdown */
@@ -2045,7 +2045,7 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, u16_t lazy,
 
 			lll->slave.window_widening_periodic_us =
 				(((lll_conn_ppm_local_get() +
-				   lll_conn_ppm_get(lll->slave.sca)) *
+				   lll_conn_ppm_get(conn->slave.sca)) *
 				  conn_interval_us) + (1000000 - 1)) / 1000000U;
 			lll->slave.window_widening_max_us =
 				(conn_interval_us >> 1) - EVENT_IFS_US;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -36,13 +36,16 @@ struct ll_conn {
 		} common;
 
 		struct {
-			u8_t fex_valid:1;
+			u8_t  fex_valid:1;
+			u8_t  latency_cancel:1;
+			u8_t  sca:3;
 			u32_t force;
 			u32_t ticks_to_offset;
 		} slave;
 
 		struct {
 			u8_t fex_valid:1;
+			u8_t terminate_ack:1;
 		} master;
 	};
 

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -183,6 +183,7 @@ u8_t ll_create_connection(u16_t scan_interval, u16_t scan_window,
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
 	conn->common.fex_valid = 0U;
+	conn->master.terminate_ack = 0U;
 
 	conn->llcp_req = conn->llcp_ack = conn->llcp_type = 0U;
 	conn->llcp_rx = NULL;

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -87,10 +87,10 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	conn_interval_us = interval * 1250U;
 
 	/* calculate the window widening */
-	lll->slave.sca = pdu_adv->connect_ind.sca;
+	conn->slave.sca = pdu_adv->connect_ind.sca;
 	lll->slave.window_widening_periodic_us =
 		(((lll_conn_ppm_local_get() +
-		   lll_conn_ppm_get(lll->slave.sca)) *
+		   lll_conn_ppm_get(conn->slave.sca)) *
 		  conn_interval_us) + (1000000 - 1)) / 1000000U;
 	lll->slave.window_widening_max_us = (conn_interval_us >> 1) -
 					    EVENT_IFS_US;
@@ -162,7 +162,7 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 	cc->interval = lll->interval;
 	cc->latency = lll->latency;
 	cc->timeout = timeout;
-	cc->sca = lll->slave.sca;
+	cc->sca = conn->slave.sca;
 
 	lll->handle = ll_conn_handle_get(conn);
 	rx->handle = lll->handle;


### PR DESCRIPTION
Add the missing initialization of master role terminate_ack
flag. This caused slave initiated remote termination as
procedure timeout.

Fixes #20135.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>