### PR TITLE
[TOPIC-GPIO] drivers: gpio: gecko: fix interrupt clear

### DIFF
--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -345,13 +345,13 @@ static void gpio_gecko_common_isr(void *arg)
 		port_dev = data->ports[i];
 		port_data = port_dev->driver_data;
 		enabled_int = int_status & port_data->pin_callback_enables;
-		int_status &= ~enabled_int;
-
-		gpio_fire_callbacks(&port_data->callbacks, port_dev,
-				     enabled_int);
+		if (enabled_int != 0) {
+			int_status &= ~enabled_int;
+			GPIO->IFC = enabled_int;
+			gpio_fire_callbacks(&port_data->callbacks, port_dev,
+					    enabled_int);
+		}
 	}
-	/* Clear the pending interrupts */
-	GPIO->IFC = 0xFFFF;
 }
 
 


### PR DESCRIPTION
In order to reliably detect interrupts the interrupt must be
acknowledged before the callback is invoked.

Fixes #20223 