### PR TITLE
kernel: irq: Add support for dynamic direct IRQs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -719,6 +719,7 @@ if(CONFIG_GEN_ISR_TABLES)
     $<$<BOOL:${CONFIG_BIG_ENDIAN}>:--big-endian>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--debug>
     ${GEN_ISR_TABLE_EXTRA_ARG}
+    DEPENDS ${ZEPHYR_BASE}/arch/common/gen_isr_tables.py
     DEPENDS ${ZEPHYR_PREBUILT_EXECUTABLE}
     )
   set_property(GLOBAL APPEND PROPERTY GENERATED_KERNEL_SOURCE_FILES isr_tables.c)

--- a/arch/arc/core/irq_manage.c
+++ b/arch/arc/core/irq_manage.c
@@ -129,6 +129,11 @@ int z_arch_irq_is_enabled(unsigned int irq)
 	return z_arc_v2_irq_unit_int_enabled(irq);
 }
 
+unsigned int z_arch_irq_line_get(void)
+{
+	return Z_INTERRUPT_CAUSE() - 16;
+}
+
 /*
  * @internal
  *

--- a/arch/arm/core/irq_manage.c
+++ b/arch/arm/core/irq_manage.c
@@ -52,6 +52,16 @@ int z_arch_irq_is_enabled(unsigned int irq)
 	return NVIC->ISER[REG_FROM_IRQ(irq)] & BIT(BIT_FROM_IRQ(irq));
 }
 
+unsigned int z_arch_irq_line_get(void)
+{
+	unsigned int irqn;
+
+	__asm__ volatile("mrs %0, IPSR\n\t" : "=r"(irqn));
+
+	/* Adjust from ARM exception to interrupt number. */
+	return irqn - 16;
+}
+
 /**
  * @internal
  *
@@ -117,6 +127,15 @@ int z_arch_irq_is_enabled(unsigned int irq)
 	struct device *dev = _sw_isr_table[0].arg;
 
 	return irq_is_enabled_next_level(dev);
+}
+
+unsigned int z_arch_irq_line_get(void)
+{
+	/*
+	 * Cortex-R only has one IRQ line so the main handler will be at
+	 * offset 0 of the table.
+	 */
+	return 0U;
 }
 
 /**

--- a/arch/common/sw_isr_common.c
+++ b/arch/common/sw_isr_common.c
@@ -25,6 +25,17 @@ void z_isr_install(unsigned int irq, void (*routine)(void *), void *param)
 	_sw_isr_table[table_idx].isr = routine;
 }
 
+void z_sw_isr_direct(void)
+{
+	unsigned int irqn = irq_line_get();
+
+	if (irqn < IRQ_TABLE_SIZE) {
+		struct _isr_table_entry *irq = &_sw_isr_table[irqn];
+
+		irq->isr(irq->arg);
+	}
+}
+
 /* Some architectures don't/can't interpret flags or priority and have
  * no more processing to do than this.  Provide a generic fallback.
  */

--- a/boards/posix/native_posix/board_irq.h
+++ b/boards/posix/native_posix/board_irq.h
@@ -51,6 +51,9 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
 	irq_p; \
 })
 
+#define Z_ARCH_IRQ_DIRECT_DYNAMIC(irq_p, priority_p, flags_p) \
+	Z_ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, NULL, flags_p)
+
 /**
  * POSIX Architecture (board) specific ISR_DIRECT_DECLARE(),
  * See include/irq.h for more information.
@@ -64,14 +67,15 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  * posix_irq_handler() both for direct and normal interrupts together
  */
 #define Z_ARCH_ISR_DIRECT_DECLARE(name) \
-	static inline int name##_body(void); \
+	static inline int name##_body(void *unused); \
 	int name(void) \
 	{ \
+		ARG_UNUSED(unused);\
 		int check_reschedule; \
-		check_reschedule = name##_body(); \
+		check_reschedule = name##_body(NULL); \
 		return check_reschedule; \
 	} \
-	static inline int name##_body(void)
+	static inline int name##_body(void *unused)
 
 #define Z_ARCH_ISR_DIRECT_HEADER()   do { } while (0)
 #define Z_ARCH_ISR_DIRECT_FOOTER(a)  do { } while (0)

--- a/boards/posix/nrf52_bsim/board_irq.h
+++ b/boards/posix/nrf52_bsim/board_irq.h
@@ -51,6 +51,9 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
 	irq_p; \
 })
 
+#define Z_ARCH_IRQ_DIRECT_DYNAMIC(irq_p, priority_p, flags_p) \
+	Z_ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, NULL, flags_p)
+
 /**
  * POSIX Architecture (board) specific ISR_DIRECT_DECLARE(),
  * See include/irq.h for more information.
@@ -64,14 +67,15 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
  * posix_irq_handler() both for direct and normal interrupts together
  */
 #define Z_ARCH_ISR_DIRECT_DECLARE(name) \
-	static inline int name##_body(void); \
+	static inline int name##_body(void *unused); \
 	int name(void) \
 	{ \
+		ARG_UNUSED(unused); \
 		int check_reschedule; \
-		check_reschedule = name##_body(); \
+		check_reschedule = name##_body(NULL); \
 		return check_reschedule; \
 	} \
-	static inline int name##_body(void)
+	static inline int name##_body(void *unused)
 
 #define Z_ARCH_ISR_DIRECT_HEADER()   do { } while (0)
 #define Z_ARCH_ISR_DIRECT_FOOTER(a)  do { } while (0)

--- a/include/arch/arc/v2/irq.h
+++ b/include/arch/arc/v2/irq.h
@@ -35,11 +35,13 @@ extern void z_arc_firq_stack_set(void);
 extern void z_arch_irq_enable(unsigned int irq);
 extern void z_arch_irq_disable(unsigned int irq);
 extern int z_arch_irq_is_enabled(unsigned int irq);
+extern int z_arch_irq_line_get(void);
 
 extern void _irq_exit(void);
 extern void z_irq_priority_set(unsigned int irq, unsigned int prio,
 			      u32_t flags);
 extern void _isr_wrapper(void);
+extern void z_sw_isr_direct(void);
 extern void z_irq_spurious(void *unused);
 
 /* Z_ISR_DECLARE will populate the .intList section with the interrupt's
@@ -91,6 +93,8 @@ extern void z_irq_spurious(void *unused);
 	irq_p; \
 })
 
+#define Z_ARCH_IRQ_DIRECT_DYNAMIC(irq_p, priority_p, flags_p) \
+	Z_ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, z_sw_isr_direct, flags_p) \
 
 static inline void z_arch_isr_direct_header(void)
 {
@@ -121,14 +125,15 @@ extern void z_arch_isr_direct_header(void);
  * aware interrupt handling
  */
 #define Z_ARCH_ISR_DIRECT_DECLARE(name) \
-	static inline int name##_body(void); \
+	static inline int name##_body(void *unused); \
 	__attribute__ ((interrupt("ilink")))void name(void) \
 	{ \
+		ARG_UNUSED(unused); \
 		ISR_DIRECT_HEADER(); \
-		name##_body(); \
+		name##_body(NULL); \
 		ISR_DIRECT_FOOTER(0); \
 	} \
-	static inline int name##_body(void)
+	static inline int name##_body(void *unused)
 
 
 /**

--- a/include/arch/x86/ia32/arch.h
+++ b/include/arch/x86/ia32/arch.h
@@ -223,6 +223,8 @@ typedef struct s_isrList {
 	Z_IRQ_TO_INTERRUPT_VECTOR(irq_p); \
 })
 
+#define Z_ARCH_IRQ_DIRECT_DYNAMIC(irq_p, priority_p, flags_p) \
+	Z_ARCH_IRQ_CONNECT(irq_p, priority_p, NULL, flags_p)
 
 #ifdef CONFIG_SYS_POWER_MANAGEMENT
 extern void z_arch_irq_direct_pm(void);

--- a/include/irq.h
+++ b/include/irq.h
@@ -115,6 +115,48 @@ irq_connect_dynamic(unsigned int irq, unsigned int priority,
 	Z_ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p)
 
 /**
+ * @brief Initialize a dynamic 'direct' interrupt handler.
+ *
+ * This routine initializes an dynamic interrupt handler for an IRQ. The IRQ
+ * must be connected with irq_connect_dynamic and enabled via irq_enable()
+ * before the interrupt handler begins servicing interrupts.
+ *
+ * These ISRs are designed for performance-critical interrupt handling and do
+ * not go through common interrupt handling code. They must be implemented in
+ * such a way that it is safe to put them directly in the software vector table.
+ * For ISRs written in C, The ISR_DIRECT_DECLARE() macro will do this
+ * automatically. For ISRs written in assembly it is entirely up to the
+ * developer to ensure that the right steps are taken.
+ *
+ * This type of interrupt currently has a few limitations compared to normal
+ * Zephyr interrupts:
+ * - No parameters are passed to the ISR.
+ * - No stack switch is done, the ISR will run on the interrupted context's
+ *   stack, unless the architecture automatically does the stack switch in HW.
+ * - Interrupt locking state is unchanged from how the HW sets it when the ISR
+ *   runs. On arches that enter ISRs with interrupts locked, they will remain
+ *   locked.
+ * - Scheduling decisions are now optional, controlled by the return value of
+ *   ISRs implemented with the ISR_DIRECT_DECLARE() macro
+ * - The call into the OS to exit power management idle state is now optional.
+ *   Normal interrupts always do this before the ISR is run, but when it runs
+ *   is now controlled by the placement of a ISR_DIRECT_PM() macro, or omitted
+ *   entirely.
+ *
+ * @warning
+ * Although this routine is invoked at run-time, all of its arguments must be
+ * computable by the compiler at build time.
+ *
+ * @param irq_p IRQ line number.
+ * @param priority_p Interrupt priority.
+ * @param flags_p Architecture-specific IRQ configuration flags.
+ *
+ * @return Interrupt vector assigned to this interrupt.
+ */
+#define IRQ_DIRECT_DYNAMIC(irq_p, priority_p, flags_p) \
+	Z_ARCH_IRQ_DIRECT_DYNAMIC(irq_p, priority_p, flags_p)
+
+/**
  * @brief Common tasks before executing the body of an ISR
  *
  * This macro must be at the beginning of all direct interrupts and performs
@@ -275,6 +317,18 @@ void z_smp_global_unlock(unsigned int key);
  * @return interrupt enable state, true or false
  */
 #define irq_is_enabled(irq) z_arch_irq_is_enabled(irq)
+
+/**
+ * @brief Get IRQ line number.
+ *
+ * This routine returns the IRQ line number of the currently executing
+ * interrupt.
+ *
+ * @warning This function should only be called during interrupt execution.
+ *
+ * @return IRQ line
+ */
+#define irq_line_get() z_arch_irq_line_get()
 
 /**
  * @}


### PR DESCRIPTION
The kernel has support for installing ISRs dynamically at runtime with irq_connect_dynamic.
Installation of dynamic direct interrupts is currently unsupported.

Add support to declare direct IRQs as dynamic.
This would allow direct interrupts to be installed dynamically at runtime.
For example two radio protocols can use the RADIO peripheral as long
as the protocols are correctly initialized and uninitialized.

These interrupts would have the same restrictions as normal direct
interrupts except:
 - Small overhead compared to non-dynamic.
 - Can be given an argument.

Example:
```
IRQ_DIRECT_DYNAMIC(RADIO_IRQn, CONFIG_BT_CTLR_WORKER_PRIO,
		   IRQ_CONNECT_FLAGS);

irq_connect_dynamic(RADIO_IRQn, CONFIG_BT_CTLR_WORKER_PRIO,
                    radio_nrf5_isr, NULL, 0);

irq_enable(RADIO_IRQn);
```
Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>