### PR TITLE
tests: kernel: fp_sharing: fix compile warning for arc

### DIFF
--- a/tests/kernel/fp_sharing/generic/src/float_regs_arc_gcc.h
+++ b/tests/kernel/fp_sharing/generic/src/float_regs_arc_gcc.h
@@ -55,6 +55,7 @@ static inline void _load_all_float_registers(struct fp_register_set *regs)
 		"i"(_ARC_V2_FPU_DPFP2L), "i"(_ARC_V2_FPU_DPFP2H)
 		: "memory"
 		);
+	(void)temp;
 #endif
 }
 
@@ -88,6 +89,7 @@ static inline void _store_all_float_registers(struct fp_register_set *regs)
 		"i"(_ARC_V2_FPU_DPFP1L), "i"(_ARC_V2_FPU_DPFP1H),
 		"i"(_ARC_V2_FPU_DPFP2L), "i"(_ARC_V2_FPU_DPFP2H)
 		);
+	(void)temp;
 #endif
 }
 


### PR DESCRIPTION
Second attempt: the version of gcc used for ARC appears to detect that
the register is written to but not read.  Add a no-code reference to
the value after it's been set.

See: https://app.shippable.com/github/zephyrproject-rtos/ci-test/runs/3202/2/tests