### PR TITLE
doc: fix refs to non-supported board

### DIFF
--- a/boards/arm/stm32h747i_disco/doc/index.rst
+++ b/boards/arm/stm32h747i_disco/doc/index.rst
@@ -190,7 +190,7 @@ You can debug an application in the usual way.  Here is an example for the
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: stm32h747i_disco
+   :board: stm32h747i_disco_m7
    :goals: debug
 
 

--- a/boards/arm/stm32mp157c_dk2/doc/stm32mp157_dk2.rst
+++ b/boards/arm/stm32mp157c_dk2/doc/stm32mp157_dk2.rst
@@ -270,7 +270,7 @@ install `stm32mp1 developer package`_.
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world
-      :board: stm32mp157_dk2
+      :board: stm32mp157c_dk2
       :goals: debug
 
 .. _STM32P157C Discovery website:


### PR DESCRIPTION
Comparing the output of "west boards" with mentions of boards in build
instructions (:board: boardname) found a couple of incorrect board
references.  (See PR #20242 for another board ref fix) 

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>