### PR TITLE
[RFC][WIP] Make DEVICE init and device_get dt aware

### DIFF
--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -41,6 +41,8 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     -x assembler-with-cpp
     ${NOSYSDEF_CFLAG}
     -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
+    -D_LINKER
+    -D_ASMLANGUAGE
     ${current_includes}
     ${current_defines}
     ${linker_pass_define}

--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -320,7 +320,7 @@ static const struct counter_driver_api counter_gecko_driver_api = {
 
 /* RTCC0 */
 
-static struct device DEVICE_NAME_GET(counter_gecko_0);
+struct device DEVICE_NAME_GET(counter_gecko_0);
 
 ISR_DIRECT_DECLARE(counter_gecko_isr_0)
 {

--- a/drivers/dma/dma_cavs.c
+++ b/drivers/dma/dma_cavs.c
@@ -362,7 +362,7 @@ static const struct dma_driver_api dw_dma_driver_api = {
 
 /* DMA0 */
 
-static struct device DEVICE_NAME_GET(dw_dma0);
+struct device DEVICE_NAME_GET(dw_dma0);
 
 static void dw_dma0_irq_config(void)
 {

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -204,7 +204,7 @@ static const struct dma_driver_api nios2_msgdma_driver_api = {
 };
 
 /* DMA0 */
-static struct device DEVICE_NAME_GET(dma0_nios2);
+struct device DEVICE_NAME_GET(dma0_nios2);
 
 static int nios2_msgdma0_initialize(struct device *dev)
 {

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -346,7 +346,7 @@ static const struct dma_driver_api sam_xdmac_driver_api = {
 
 /* DMA0 */
 
-static struct device DEVICE_NAME_GET(dma0_sam);
+struct device DEVICE_NAME_GET(dma0_sam);
 
 static void dma0_sam_irq_config(void)
 {

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -152,7 +152,7 @@ int e1000_probe(struct device *device)
 	return retval;
 }
 
-static struct device DEVICE_NAME_GET(eth_e1000);
+struct device DEVICE_NAME_GET(eth_e1000);
 
 static void e1000_init(struct net_if *iface)
 {

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1930,7 +1930,7 @@ static const struct ethernet_api eth_api = {
 #endif
 };
 
-static struct device DEVICE_NAME_GET(eth0_sam_gmac);
+struct device DEVICE_NAME_GET(eth0_sam_gmac);
 
 static void eth0_irq_config(void)
 {

--- a/drivers/ethernet/eth_smsc911x.c
+++ b/drivers/ethernet/eth_smsc911x.c
@@ -655,7 +655,7 @@ done:
 
 /* Bindings to the platform */
 
-static struct device DEVICE_NAME_GET(eth_smsc911x_0);
+struct device DEVICE_NAME_GET(eth_smsc911x_0);
 
 int eth_init(struct device *dev)
 {

--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -318,7 +318,7 @@ static int eth_stellaris_dev_init(struct device *dev)
 	return 0;
 }
 
-static struct device DEVICE_NAME_GET(eth_stellaris);
+struct device DEVICE_NAME_GET(eth_stellaris);
 
 static void eth_stellaris_irq_config(struct device *dev)
 {

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -489,7 +489,7 @@ static const struct ethernet_api eth_api = {
 	.send = eth_tx,
 };
 
-static struct device DEVICE_NAME_GET(eth0_stm32_hal);
+struct device DEVICE_NAME_GET(eth0_stm32_hal);
 
 static void eth0_irq_config(void)
 {

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -202,7 +202,7 @@ static const struct gpio_cc32xx_config gpio_cc32xx_a0_config = {
 	.irq_num = DT_GPIO_CC32XX_A0_IRQ+16,
 };
 
-static struct device DEVICE_NAME_GET(gpio_cc32xx_a0);
+struct device DEVICE_NAME_GET(gpio_cc32xx_a0);
 static struct gpio_cc32xx_data gpio_cc32xx_a0_data;
 
 static int gpio_cc32xx_a0_init(struct device *dev)
@@ -232,7 +232,7 @@ static const struct gpio_cc32xx_config gpio_cc32xx_a1_config = {
 	.irq_num = DT_GPIO_CC32XX_A1_IRQ+16,
 };
 
-static struct device DEVICE_NAME_GET(gpio_cc32xx_a1);
+struct device DEVICE_NAME_GET(gpio_cc32xx_a1);
 static struct gpio_cc32xx_data gpio_cc32xx_a1_data;
 
 static int gpio_cc32xx_a1_init(struct device *dev)
@@ -262,7 +262,7 @@ static const struct gpio_cc32xx_config gpio_cc32xx_a2_config = {
 	.irq_num = DT_GPIO_CC32XX_A2_IRQ+16,
 };
 
-static struct device DEVICE_NAME_GET(gpio_cc32xx_a2);
+struct device DEVICE_NAME_GET(gpio_cc32xx_a2);
 static struct gpio_cc32xx_data gpio_cc32xx_a2_data;
 
 static int gpio_cc32xx_a2_init(struct device *dev)
@@ -292,7 +292,7 @@ static const struct gpio_cc32xx_config gpio_cc32xx_a3_config = {
 	.irq_num = DT_GPIO_CC32XX_A3_IRQ+16,
 };
 
-static struct device DEVICE_NAME_GET(gpio_cc32xx_a3);
+struct device DEVICE_NAME_GET(gpio_cc32xx_a3);
 static struct gpio_cc32xx_data gpio_cc32xx_a3_data;
 
 static int gpio_cc32xx_a3_init(struct device *dev)

--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -211,7 +211,7 @@ static struct i2c_gecko_config i2c_gecko_config_0 = {
 
 static struct i2c_gecko_data i2c_gecko_data_0;
 
-DEVICE_AND_API_INIT(i2c_gecko_0, DT_INST_0_SILABS_GECKO_I2C_LABEL,
+DEVICE_AND_API_INIT_DT(SILABS_GECKO_I2C, 0,
 		    &i2c_gecko_init, &i2c_gecko_data_0, &i2c_gecko_config_0,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &i2c_gecko_driver_api);
@@ -245,7 +245,7 @@ static struct i2c_gecko_config i2c_gecko_config_1 = {
 
 static struct i2c_gecko_data i2c_gecko_data_1;
 
-DEVICE_AND_API_INIT(i2c_gecko_1, DT_INST_1_SILABS_GECKO_I2C_LABEL,
+DEVICE_AND_API_INIT_DT(SILABS_GECKO_I2C, 1,
 		    &i2c_gecko_init, &i2c_gecko_data_1, &i2c_gecko_config_1,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &i2c_gecko_driver_api);

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -339,7 +339,7 @@ static const struct i2c_driver_api i2c_sam_twi_driver_api = {
 /* I2C0 */
 
 #ifdef CONFIG_I2C_0
-static struct device DEVICE_NAME_GET(i2c0_sam);
+struct device DEVICE_NAME_GET(i2c0_sam);
 
 static void i2c0_sam_irq_config(void)
 {
@@ -369,7 +369,7 @@ DEVICE_AND_API_INIT(i2c0_sam, DT_I2C_0_NAME, &i2c_sam_twi_initialize,
 /* I2C1 */
 
 #ifdef CONFIG_I2C_1
-static struct device DEVICE_NAME_GET(i2c1_sam);
+struct device DEVICE_NAME_GET(i2c1_sam);
 
 static void i2c1_sam_irq_config(void)
 {

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -326,7 +326,7 @@ static const struct i2c_driver_api i2c_sam_twihs_driver_api = {
 /* I2C0 */
 
 #ifdef CONFIG_I2C_0
-static struct device DEVICE_NAME_GET(i2c0_sam);
+struct device DEVICE_NAME_GET(i2c0_sam);
 
 static void i2c0_sam_irq_config(void)
 {
@@ -356,7 +356,7 @@ DEVICE_AND_API_INIT(i2c0_sam, DT_I2C_0_NAME, &i2c_sam_twihs_initialize,
 /* I2C1 */
 
 #ifdef CONFIG_I2C_1
-static struct device DEVICE_NAME_GET(i2c1_sam);
+struct device DEVICE_NAME_GET(i2c1_sam);
 
 static void i2c1_sam_irq_config(void)
 {
@@ -386,7 +386,7 @@ DEVICE_AND_API_INIT(i2c1_sam, DT_I2C_1_NAME, &i2c_sam_twihs_initialize,
 /* I2C2 */
 
 #ifdef CONFIG_I2C_2
-static struct device DEVICE_NAME_GET(i2c2_sam);
+struct device DEVICE_NAME_GET(i2c2_sam);
 
 static void i2c2_sam_irq_config(void)
 {

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -819,7 +819,7 @@ static struct device *get_dev_from_tx_dma_channel(u32_t dma_channel)
 }
 
 #ifdef CONFIG_I2S_1
-static struct device DEVICE_NAME_GET(i2s_stm32_1);
+struct device DEVICE_NAME_GET(i2s_stm32_1);
 
 static void i2s_stm32_irq_config_func_1(struct device *dev);
 
@@ -889,7 +889,7 @@ static void i2s_stm32_irq_config_func_1(struct device *dev)
 #endif /* CONFIG_I2S_1 */
 
 #ifdef CONFIG_I2S_2
-static struct device DEVICE_NAME_GET(i2s_stm32_2);
+struct device DEVICE_NAME_GET(i2s_stm32_2);
 
 static void i2s_stm32_irq_config_func_2(struct device *dev);
 
@@ -959,7 +959,7 @@ static void i2s_stm32_irq_config_func_2(struct device *dev)
 #endif /* CONFIG_I2S_2 */
 
 #ifdef CONFIG_I2S_3
-static struct device DEVICE_NAME_GET(i2s_stm32_3);
+struct device DEVICE_NAME_GET(i2s_stm32_3);
 
 static void i2s_stm32_irq_config_func_3(struct device *dev);
 
@@ -1029,7 +1029,7 @@ static void i2s_stm32_irq_config_func_3(struct device *dev)
 #endif /* CONFIG_I2S_3 */
 
 #ifdef CONFIG_I2S_4
-static struct device DEVICE_NAME_GET(i2s_stm32_4);
+struct device DEVICE_NAME_GET(i2s_stm32_4);
 
 static void i2s_stm32_irq_config_func_4(struct device *dev);
 
@@ -1099,7 +1099,7 @@ static void i2s_stm32_irq_config_func_4(struct device *dev)
 #endif /* CONFIG_I2S_4 */
 
 #ifdef CONFIG_I2S_5
-static struct device DEVICE_NAME_GET(i2s_stm32_5);
+struct device DEVICE_NAME_GET(i2s_stm32_5);
 
 static void i2s_stm32_irq_config_func_5(struct device *dev);
 

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -951,7 +951,7 @@ static const struct i2s_driver_api i2s_sam_driver_api = {
 
 /* I2S0 */
 
-static struct device DEVICE_NAME_GET(i2s0_sam);
+struct device DEVICE_NAME_GET(i2s0_sam);
 
 static struct device *get_dev_from_dma_channel(u32_t dma_channel)
 {

--- a/drivers/neural_net/intel_gna.c
+++ b/drivers/neural_net/intel_gna.c
@@ -42,7 +42,7 @@ static void intel_gna_config_desc_dump(struct device *dev);
 
 #define GNA_MODEL_VIRT_BASE_DEFAULT	0
 
-static struct device DEVICE_NAME_GET(gna);
+struct device DEVICE_NAME_GET(gna);
 static struct intel_gna_config_desc __aligned(GNA_PG_SIZE_IN_BYTES)
 	gna_config_desc;
 static struct intel_gna_page_table __aligned(GNA_PG_SIZE_IN_BYTES)

--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -30,7 +30,7 @@ struct uart_cc32xx_dev_data_t {
 #define PRIME_CHAR '\r'
 
 /* Forward decls: */
-static struct device DEVICE_NAME_GET(uart_cc32xx_0);
+struct device DEVICE_NAME_GET(uart_cc32xx_0);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_cc32xx_isr(void *arg);

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -31,7 +31,7 @@ struct uart_msp432p4xx_dev_data_t {
 #define DEV_DATA(dev) \
 	((struct uart_msp432p4xx_dev_data_t * const)(dev)->driver_data)
 
-static struct device DEVICE_NAME_GET(uart_msp432p4xx_0);
+struct device DEVICE_NAME_GET(uart_msp432p4xx_0);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void uart_msp432p4xx_isr(void *arg);

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -32,7 +32,7 @@ struct wdt_sam_dev_cfg {
 	Wdt *regs;
 };
 
-static struct device DEVICE_NAME_GET(wdt_sam);
+struct device DEVICE_NAME_GET(wdt_sam);
 
 struct wdt_sam_dev_data {
 	wdt_callback_t cb;

--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -19,7 +19,7 @@ struct wdt_sam0_dev_data {
 	bool timeout_valid;
 };
 
-static struct device DEVICE_NAME_GET(wdt_sam0);
+struct device DEVICE_NAME_GET(wdt_sam0);
 
 static struct wdt_sam0_dev_data wdt_sam0_data = { 0 };
 

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -8,9 +8,6 @@
  * @brief Common parts of the linker scripts for the ARCv2/EM targets.
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <linker/sections.h>
 
 #if defined(CONFIG_UART_NSIM)

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -11,9 +11,6 @@
  * Linker script for the Cortex-M platforms.
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <autoconf.h>
 #include <linker/sections.h>
 #include <generated_dts_board.h>

--- a/include/arch/arm/cortex_r/scripts/linker.ld
+++ b/include/arch/arm/cortex_r/scripts/linker.ld
@@ -11,9 +11,6 @@
  * Linker script for the Cortex-R platforms.
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <autoconf.h>
 #include <linker/sections.h>
 #include <generated_dts_board.h>

--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -11,9 +11,6 @@
  * Linker script for the Nios II platform
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <autoconf.h>
 #include <linker/sections.h>
 

--- a/include/arch/posix/linker.ld
+++ b/include/arch/posix/linker.ld
@@ -12,9 +12,6 @@
  * Linker script for the POSIX (native) platform
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <autoconf.h>
 #include <linker/sections.h>
 

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -11,9 +11,6 @@
  * Generic Linker script for the riscv platform
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <soc.h>
 
 #include <autoconf.h>

--- a/include/arch/x86/ia32/linker.ld
+++ b/include/arch/x86/ia32/linker.ld
@@ -37,9 +37,6 @@
  * order when programming the MMU.
  */
 
-#define _LINKER
-
-#define _ASMLANGUAGE
 #include <linker/linker-defs.h>
 #include <offsets.h>
 #include <sys/util.h>

--- a/include/arch/x86/intel64/linker.ld
+++ b/include/arch/x86/intel64/linker.ld
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <linker/linker-defs.h>
 #include <linker/linker-tool.h>
 

--- a/include/device.h
+++ b/include/device.h
@@ -107,7 +107,7 @@ extern "C" {
 		.name = drv_name, .init = (init_fn),			  \
 		.config_info = (cfg_info)				  \
 	};								  \
-	static Z_DECL_ALIGN(struct device) _CONCAT(__device_, dev_name) __used \
+	Z_DECL_ALIGN(struct device) _CONCAT(__device_, dev_name) __used \
 	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
 		.config = &_CONCAT(__config_, dev_name),		  \
 		.driver_api = api,					  \
@@ -164,7 +164,7 @@ extern "C" {
 		.pm  = &_CONCAT(__pm_, dev_name),                         \
 		.config_info = (cfg_info)				  \
 	};								  \
-	static Z_DECL_ALIGN(struct device) _CONCAT(__device_, dev_name) __used \
+	Z_DECL_ALIGN(struct device) _CONCAT(__device_, dev_name) __used \
 	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
 		.config = &_CONCAT(__config_, dev_name),		  \
 		.driver_api = api,					  \
@@ -218,7 +218,7 @@ extern "C" {
  *
  * @param name Device name
  */
-#define DEVICE_DECLARE(name) static struct device DEVICE_NAME_GET(name)
+#define DEVICE_DECLARE(name) struct device DEVICE_NAME_GET(name)
 
 struct device;
 

--- a/include/device.h
+++ b/include/device.h
@@ -9,6 +9,7 @@
 #define ZEPHYR_INCLUDE_DEVICE_H_
 
 #include <kernel.h>
+#include <generated_dts_board.h>
 
 /**
  * @brief Device Driver APIs
@@ -125,6 +126,12 @@ extern "C" {
 		      device_pm_control_nop, data, cfg_info, level,	 \
 		      prio, api)
 #endif
+
+#define DEVICE_AND_API_INIT_DT(dev_name, inst, init_fn, data, cfg_info, \
+			    level, prio, api)				 \
+	DEVICE_AND_API_INIT(DT_ZDID_INST_##inst##_##dev_name,\
+			    DT_INST_##inst##_##dev_name##_LABEL,\
+			    init_fn, data, cfg_info, level, prio, api)
 
 /**
  * @def DEVICE_DEFINE

--- a/samples/application_development/code_relocation/linker_arm_sram2.ld
+++ b/samples/application_development/code_relocation/linker_arm_sram2.ld
@@ -11,9 +11,6 @@
  * Linker script for the Cortex-M platforms.
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <autoconf.h>
 #include <linker/sections.h>
 #include <generated_dts_board.h>

--- a/samples/drivers/i2c_scanner/src/main.c
+++ b/samples/drivers/i2c_scanner/src/main.c
@@ -9,12 +9,18 @@
 #include <sys/printk.h>
 #include <device.h>
 #include <drivers/i2c.h>
+#include <generated_dts_board.h>
 
 #ifdef ARDUINO_I2C_LABEL
 #define I2C_DEV ARDUINO_I2C_LABEL
 #else
 #define I2C_DEV "I2C_0"
 #endif
+
+#define device_get_dt_binding_zdid(zdid) _CONCAT(&__device_, zdid)
+
+#define device_get_dt_binding(name, inst) \
+device_get_dt_binding_zdid(DT_ZDID_INST_##inst##_##name) \
 
 /**
  * @file This app scans I2C bus for any devices present
@@ -26,7 +32,7 @@ void main(void)
 
 	printk("Starting i2c scanner...\n");
 
-	i2c_dev = device_get_binding(I2C_DEV);
+	i2c_dev = device_get_dt_binding(SILABS_GECKO_I2C, 0);
 	if (!i2c_dev) {
 		printk("I2C: Device driver not found.\n");
 		return;

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -12,9 +12,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <generated_dts_board.h>
 #include <autoconf.h>
 

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -11,9 +11,6 @@
  * Linker script for the Xtensa platform.
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <generated_dts_board.h>
 #include <autoconf.h>
 #include <linker/sections.h>

--- a/soc/xtensa/intel_s1000/linker.ld
+++ b/soc/xtensa/intel_s1000/linker.ld
@@ -12,8 +12,6 @@
  */
 
 OUTPUT_ARCH(xtensa)
-#define _LINKER
-#define _ASMLANGUAGE
 
 #include <generated_dts_board.h>
 #include "memory.h"

--- a/soc/xtensa/sample_controller/linker.ld
+++ b/soc/xtensa/sample_controller/linker.ld
@@ -10,9 +10,6 @@
  * Linker script for the Xtensa platform.
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <autoconf.h>
 #include <linker/sections.h>
 


### PR DESCRIPTION
This is prototype based on conversations at ELC-E 2019 on how we can make the device api be dt aware.  

The idea here is that we'd use a unique identifier (Zephyr Device ID/ZDID) for each device tree node that would correspond to how we name the `struct device` for that device.  We can then generate various DT defines like `DT_INST_0_SILABS_GECKO_I2C_ZDID`.  These defines allow us to construct direct access to the `struct device`.  This PR show changes to the silabs i2c gecko driver and a hacked up change to the i2c_scanner to show but the changes on the driver side (how a `DEVICE_AND_API_INIT_DT` would look like, and how `device_get_dt_binding` would work.

There's at least one issue that needs to be figured out on how / where to do an `extern struct device __device_<ZDID>`.