### PR TITLE
settings: cleanup deletion test

### DIFF
--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -38,7 +38,7 @@ static ssize_t settings_nvs_read_fn(void *back_end, void *data, size_t len)
 	rd_fn_arg = (struct settings_nvs_read_fn_arg *)back_end;
 
 	rc = nvs_read(rd_fn_arg->fs, rd_fn_arg->id, data, len);
-	if (rc > len) {
+	if (rc > (ssize_t)len) {
 		/* nvs_read signals that not all bytes were read
 		 * align read len to what was requested
 		 */

--- a/tests/subsys/settings/fcb/src/settings_test.h
+++ b/tests/subsys/settings/fcb/src/settings_test.h
@@ -22,7 +22,6 @@
 #define SETTINGS_TEST_FCB_VAL_STR_CNT   64
 #define SETTINGS_TEST_FCB_FLASH_CNT   4
 
-#define VAL8_DELETED 255U
 
 extern u8_t val8;
 extern u8_t val8_un;

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -101,9 +101,6 @@ int c1_handle_set(const char *name, size_t len, settings_read_cb read_cb,
 	if (settings_name_steq(name, "mybar", &next) && !next) {
 		rc = read_cb(cb_arg, &val8, sizeof(val8));
 		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
-		if (rc == 0) {
-			val8 = VAL8_DELETED;
-		}
 		return 0;
 	}
 

--- a/tests/subsys/settings/nvs/src/settings_test.h
+++ b/tests/subsys/settings/nvs/src/settings_test.h
@@ -20,7 +20,6 @@
 #define SETTINGS_TEST_NVS_VAL_STR_CNT   64
 #define SETTINGS_TEST_NVS_FLASH_CNT   4
 
-#define VAL8_DELETED 255U
 
 extern u8_t val8;
 extern u8_t val8_un;

--- a/tests/subsys/settings/nvs/src/settings_test_nvs.c
+++ b/tests/subsys/settings/nvs/src/settings_test_nvs.c
@@ -99,9 +99,6 @@ int c1_handle_set(const char *name, size_t len, settings_read_cb read_cb,
 	if (settings_name_steq(name, "mybar", &next) && !next) {
 		rc = read_cb(cb_arg, &val8, sizeof(val8));
 		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
-		if (rc == 0) {
-			val8 = VAL8_DELETED;
-		}
 		return 0;
 	}
 


### PR DESCRIPTION
- cleanup deletion test
- fix integer vs unsigned compassion in nvs back-end
