### PR TITLE
dts: bindings: semtech,sx1509b: add fixed ngpios property

### DIFF
--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
@@ -90,6 +90,7 @@
 		label = "GPIO_P0";
 		gpio-controller;
 		#gpio-cells = <2>;
+		ngpios = <16>;
 	};
 
 	lps22hb_press: lps22hb_press@5c {

--- a/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
@@ -17,6 +17,10 @@ properties:
     "#gpio-cells":
       const: 2
 
+    ngpios:
+      required: true
+      const: 16
+
 gpio-cells:
   - pin
   - flags


### PR DESCRIPTION
Unlike most other GPIO controllers which support 32 pins this device only supports 16.  (There is an SX1508B that has 8 pins, but the driver doesn't support it.)