### PR TITLE
bluetooth: host: fix missing bt_conn_unref

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1705,6 +1705,7 @@ static u8_t notify_cb(const struct bt_gatt_attr *attr, void *user_data)
 
 		/* Confirm match if cfg is managed by application */
 		if (ccc->cfg_match && !ccc->cfg_match(conn, attr)) {
+			bt_conn_unref(conn);
 			continue;
 		}
 


### PR DESCRIPTION
Fix missing bt_conn_unref when using the ccc match callback.

Fixes: #20229

Signed-off-by: François Delawarde <fnde@oticon.com>