### PR TITLE
scripts: runners: add misc-flash runner

### DIFF
--- a/boards/common/misc.board.cmake
+++ b/boards/common/misc.board.cmake
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Please use this sparingly and only when if your setup is exotic and
+# you're willing to handle requests for help. E.g. your "board" is a
+# core on a special-purpose SoC which requires a complicated script to
+# network boot.
+
+board_finalize_runner_args(misc-flasher)

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -10,24 +10,25 @@ from runners.core import ZephyrBinaryRunner, MissingProgram
 
 # Explicitly silence the unused import warning.
 # flake8: noqa: F401
+# Keep this list sorted by runner name.
 from runners import arc
+from runners import blackmagicprobe
 from runners import bossac
 from runners import dediprog
 from runners import dfu
 from runners import esp32
 from runners import hifive1
+from runners import intel_s1000
 from runners import jlink
+from runners import misc
 from runners import nios2
 from runners import nrfjprog
 from runners import nsim
 from runners import openocd
 from runners import pyocd
 from runners import qemu
-from runners import xtensa
-from runners import intel_s1000
-from runners import blackmagicprobe
 from runners import stm32flash
-from runners import misc
+from runners import xtensa
 
 def get_runner_cls(runner):
     '''Get a runner's class object, given its name.'''

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -27,6 +27,7 @@ from runners import xtensa
 from runners import intel_s1000
 from runners import blackmagicprobe
 from runners import stm32flash
+from runners import misc
 
 def get_runner_cls(runner):
     '''Get a runner's class object, given its name.'''

--- a/scripts/west_commands/runners/misc.py
+++ b/scripts/west_commands/runners/misc.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2019, Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Catch-all module for miscellaneous devices which can't use a
+generic or widely used tool like J-Link, OpenOCD, etc.
+
+Please use this sparingly and only when your setup is exotic and
+you're willing to handle requests for help. E.g. if your "board" is a
+core on a special-purpose SoC which requires a complicated script to
+network boot.'''
+
+from runners.core import ZephyrBinaryRunner, RunnerCaps
+
+class MiscFlasher(ZephyrBinaryRunner):
+    '''Runner for handling special purpose flashing commands.'''
+
+    def __init__(self, cfg, args):
+        super().__init__(cfg)
+        if not args:
+            # This is a board definition error, not a user error,
+            # so we can do it now and not in do_run().
+            raise ValueError('no command was given')
+        self.args = args
+
+    @classmethod
+    def name(cls):
+        return 'misc-flasher'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash'})
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument('args', nargs='+',
+                            help='command to run (and any extra arguments)')
+
+    @classmethod
+    def create(cls, cfg, args):
+        return MiscFlasher(cfg, args.args)
+
+    def do_run(self, command, **kwargs):
+        self.require(self.args[0])
+        self.check_call(self.args)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -12,8 +12,24 @@ def test_runner_imports():
     # tree-wide refactorings for runners that don't have their own
     # test suites.
     runner_names = set(r.name() for r in ZephyrBinaryRunner.get_runners())
-    expected = set(('arc-nsim', 'bossac', 'dfu-util', 'em-starterkit', 'esp32',
-                    'hifive1', 'jlink', 'nios2', 'nrfjprog', 'openocd', 'pyocd',
-                    'qemu', 'xtensa', 'intel_s1000', 'blackmagicprobe',
-                    'dediprog', 'stm32flash', 'misc-flasher'))
+
+    # Please keep this sorted alphabetically.
+    expected = set(('arc-nsim',
+                    'blackmagicprobe',
+                    'bossac',
+                    'dediprog',
+                    'dfu-util',
+                    'em-starterkit',
+                    'esp32',
+                    'hifive1',
+                    'intel_s1000',
+                    'jlink',
+                    'misc-flasher',
+                    'nios2',
+                    'nrfjprog',
+                    'openocd',
+                    'pyocd',
+                    'qemu',
+                    'stm32flash',
+                    'xtensa'))
     assert runner_names == expected

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -15,5 +15,5 @@ def test_runner_imports():
     expected = set(('arc-nsim', 'bossac', 'dfu-util', 'em-starterkit', 'esp32',
                     'hifive1', 'jlink', 'nios2', 'nrfjprog', 'openocd', 'pyocd',
                     'qemu', 'xtensa', 'intel_s1000', 'blackmagicprobe',
-                    'dediprog', 'stm32flash'))
+                    'dediprog', 'stm32flash', 'misc-flasher'))
     assert runner_names == expected


### PR DESCRIPTION
Some boards require specific sequences of commands to run which aren't
generally useful for other boards. Add a catch-all runner to handle
these cases.