### PR TITLE
dts: enable uart3 for frdm_k64f

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -109,7 +109,10 @@
 	};
 };
 
-arduino_serial: &uart3 {};
+arduino_serial: &uart3 {
+	status = "okay";
+	current-speed = <115200>;
+};
 
 &cpu0 {
 	clock-frequency = <120000000>;


### PR DESCRIPTION
Building `smp_svr` for this board results in a build error due to undefined symbols `DT_NXP_KINETIS_UART_4006D000_*` which are related to uart3 DTS symbols not being generated. This marks uart3's status as OK.