### PR TITLE
libc: Use select REQUIRES_FULL_LIBC instead of select NEWLIB_LIBC

### DIFF
--- a/modules/Kconfig.syst
+++ b/modules/Kconfig.syst
@@ -3,6 +3,6 @@
 
 config MIPI_SYST_LIB
 	bool "MIPI SyS-T Library Support"
-	select NEWLIB_LIBC
+	select REQUIRES_FULL_LIBC
 	help
 	  This option enables the MIPI SyS-T Library


### PR DESCRIPTION
Changed select NEWLIB_LIBC to select REQUIRES_FULL_LIBC.

This fixes #20274

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>