### PR TITLE
libc: kconfig: Have MINIMAL_LIBC depend on !REQUIRES_FULL_LIBC

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -23,6 +23,7 @@ choice LIBC_IMPLEMENTATION
 config MINIMAL_LIBC
 	bool "Minimal C library"
 	depends on !NATIVE_APPLICATION
+	depends on !REQUIRES_FULL_LIBC
 	help
 	  Build with minimal C library.
 


### PR DESCRIPTION
This prevents MINIMAL_LIBC from being selected by the user (in the
menuconfig or in a configuration file) when REQUIRES_FULL_LIBC is y.
'default' on a choice only determines the default selection, not what
symbols can be selected.

It's helpful to think of Kconfig in terms of someone going into the
menuconfig and making changes.