### PR TITLE
Bluetooth: rework to support C++20 designated initializers

### DIFF
--- a/include/bluetooth/uuid.h
+++ b/include/bluetooth/uuid.h
@@ -52,19 +52,19 @@ struct bt_uuid_128 {
 
 #define BT_UUID_INIT_16(value)		\
 {					\
-	.uuid.type = BT_UUID_TYPE_16,	\
+	.uuid = { BT_UUID_TYPE_16 },	\
 	.val = (value),			\
 }
 
 #define BT_UUID_INIT_32(value)		\
 {					\
-	.uuid.type = BT_UUID_TYPE_32,	\
+	.uuid = { BT_UUID_TYPE_32 },	\
 	.val = (value),			\
 }
 
 #define BT_UUID_INIT_128(value...)	\
 {					\
-	.uuid.type = BT_UUID_TYPE_128,	\
+	.uuid = { BT_UUID_TYPE_128 },	\
 	.val = { value },		\
 }
 

--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -23,7 +23,7 @@
  *  big endian 0x2800    : [28 00] -> swapping required
  */
 static const struct bt_uuid_128 uuid128_base = {
-	.uuid.type = BT_UUID_TYPE_128,
+	.uuid = { BT_UUID_TYPE_128 },
 	.val = { BT_UUID_128_ENCODE(
 		0x00000000, 0x0000, 0x1000, 0x8000, 0x00805F9B34FB) }
 };

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -167,7 +167,7 @@ int bt_mesh_prov_enable(bt_mesh_prov_bearer_t bearers)
 
 	if (IS_ENABLED(CONFIG_BT_DEBUG)) {
 		const struct bt_mesh_prov *prov = bt_mesh_prov_get();
-		struct bt_uuid_128 uuid = { .uuid.type = BT_UUID_TYPE_128 };
+		struct bt_uuid_128 uuid = { .uuid = { BT_UUID_TYPE_128 } };
 
 		memcpy(uuid.val, prov->uuid, 16);
 		BT_INFO("Device UUID: %s", bt_uuid_str(&uuid.uuid));


### PR DESCRIPTION
C++ [does not allow](https://en.cppreference.com/w/cpp/language/aggregate_initialization#Designated_initializers) nested designators in an initializer.  Since the generic structure has only one member remove the designator from its internal initializer.

There are much larger barriers to supporting the Zephyr Bluetooth infrastructure in C++ (see https://github.com/zephyrproject-rtos/zephyr/issues/18551#issuecomment-548853280) but this is a relatively simple step that would have to be done anyway.