### PR TITLE
linker: move where we define _LINKER and _ASMLANGUAGE

### DIFF
--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -41,6 +41,8 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     -x assembler-with-cpp
     ${NOSYSDEF_CFLAG}
     -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
+    -D_LINKER
+    -D_ASMLANGUAGE
     ${current_includes}
     ${current_defines}
     ${linker_pass_define}

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -8,9 +8,6 @@
  * @brief Common parts of the linker scripts for the ARCv2/EM targets.
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <linker/sections.h>
 
 #if defined(CONFIG_UART_NSIM)

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -11,9 +11,6 @@
  * Linker script for the Cortex-M platforms.
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <autoconf.h>
 #include <linker/sections.h>
 #include <generated_dts_board.h>

--- a/include/arch/arm/cortex_r/scripts/linker.ld
+++ b/include/arch/arm/cortex_r/scripts/linker.ld
@@ -11,9 +11,6 @@
  * Linker script for the Cortex-R platforms.
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <autoconf.h>
 #include <linker/sections.h>
 #include <generated_dts_board.h>

--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -11,9 +11,6 @@
  * Linker script for the Nios II platform
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <autoconf.h>
 #include <linker/sections.h>
 

--- a/include/arch/posix/linker.ld
+++ b/include/arch/posix/linker.ld
@@ -12,9 +12,6 @@
  * Linker script for the POSIX (native) platform
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <autoconf.h>
 #include <linker/sections.h>
 

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -11,9 +11,6 @@
  * Generic Linker script for the riscv platform
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <soc.h>
 
 #include <autoconf.h>

--- a/include/arch/x86/ia32/linker.ld
+++ b/include/arch/x86/ia32/linker.ld
@@ -37,9 +37,6 @@
  * order when programming the MMU.
  */
 
-#define _LINKER
-
-#define _ASMLANGUAGE
 #include <linker/linker-defs.h>
 #include <offsets.h>
 #include <sys/util.h>

--- a/include/arch/x86/intel64/linker.ld
+++ b/include/arch/x86/intel64/linker.ld
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <linker/linker-defs.h>
 #include <linker/linker-tool.h>
 

--- a/samples/application_development/code_relocation/linker_arm_sram2.ld
+++ b/samples/application_development/code_relocation/linker_arm_sram2.ld
@@ -11,9 +11,6 @@
  * Linker script for the Cortex-M platforms.
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <autoconf.h>
 #include <linker/sections.h>
 #include <generated_dts_board.h>

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -12,9 +12,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <generated_dts_board.h>
 #include <autoconf.h>
 

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -11,9 +11,6 @@
  * Linker script for the Xtensa platform.
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <generated_dts_board.h>
 #include <autoconf.h>
 #include <linker/sections.h>

--- a/soc/xtensa/intel_s1000/linker.ld
+++ b/soc/xtensa/intel_s1000/linker.ld
@@ -12,8 +12,6 @@
  */
 
 OUTPUT_ARCH(xtensa)
-#define _LINKER
-#define _ASMLANGUAGE
 
 #include <generated_dts_board.h>
 #include "memory.h"

--- a/soc/xtensa/sample_controller/linker.ld
+++ b/soc/xtensa/sample_controller/linker.ld
@@ -10,9 +10,6 @@
  * Linker script for the Xtensa platform.
  */
 
-#define _LINKER
-#define _ASMLANGUAGE
-
 #include <autoconf.h>
 #include <linker/sections.h>
 


### PR DESCRIPTION
Move _LINKER and _ASMLANGUAGE to target.cmake because of how we pick the
linker script that might be used.  This way regardless of how or where a
linker.ld gets included we will always set _LINKER & _ASMLANGUAGE (so
any header that needs check based on those defines they can,
specifically generated_dts_board.h)

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>