### PR TITLE
linker: discard .note.GNU-stack

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -480,6 +480,8 @@ GROUP_END(DTCM)
 
 #include <linker/debug-sections.ld>
 
+    /DISCARD/ : { *(.note.GNU-stack) }
+
     SECTION_PROLOGUE(.ARM.attributes, 0,)
 	{
 	KEEP(*(.ARM.attributes))

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -212,6 +212,8 @@ SECTIONS
 
 #include <linker/debug-sections.ld>
 
+    /DISCARD/ : { *(.note.GNU-stack) }
+
     SECTION_PROLOGUE(.riscv.attributes, 0,)
 	{
 	KEEP(*(.riscv.attributes))


### PR DESCRIPTION
Similar to what was required for x86 in #12719 / PR #12752

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>

When building on Fedora with the Fedora gcc 9.x cross toolchain I get the following:
```
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `app/libapp.a(main.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(isr_tables.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(fdtable.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(mempool.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(thread_entry.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(printk.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(configs.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(soc.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(arm_mpu_regions.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(uart_console.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(exti_stm32.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(clock_stm32_ll_common.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(clock_stm32f2_f4_f7.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(pinmux_stm32.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(sys_clock_init.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(cortex_m_systick.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/arm/core/libarch__arm__core.a(swap.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/arm/core/libarch__arm__core.a(irq_manage.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/arm/core/libarch__arm__core.a(thread.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/arm/core/libarch__arm__core.a(fatal.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/arm/core/libarch__arm__core.a(nmi.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/arm/core/libarch__arm__core.a(prep_c.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/arm/core/cortex_m/libarch__arm__core__cortex_m.a(fault.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/arm/core/cortex_m/libarch__arm__core__cortex_m.a(irq_init.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/arm/core/cortex_m/libarch__arm__core__cortex_m.a(thread_abort.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/arm/core/cortex_m/mpu/libarch__arm__core__cortex_m__mpu.a(arm_core_mpu.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/arm/core/cortex_m/mpu/libarch__arm__core__cortex_m__mpu.a(arm_mpu.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/lib/libc/minimal/liblib__libc__minimal.a(string.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/lib/libc/minimal/liblib__libc__minimal.a(stdout_console.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/boards/arm/96b_carbon/libboards__arm__96b_carbon.a(pinmux.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/drivers/gpio/libdrivers__gpio.a(gpio_stm32.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/drivers/serial/libdrivers__serial.a(uart_stm32.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `modules/stm32/stm32cube/lib..__modules__hal__stm32__stm32cube.a(system_stm32f4xx.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `modules/stm32/stm32cube/lib..__modules__hal__stm32__stm32cube.a(stm32f4xx_ll_utils.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(device.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(errno.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(fatal.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(init.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(sched.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(thread.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(timeout.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(idle.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(mempool.c.obj)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `zephyr/CMakeFiles/offsets.dir/arch/arm/core/offsets/offsets.c.obj' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `/usr/lib/gcc/arm-linux-gnueabi/9/libgcc.a(_aeabi_ldivmod.o)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `/usr/lib/gcc/arm-linux-gnueabi/9/libgcc.a(_aeabi_uldivmod.o)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `/usr/lib/gcc/arm-linux-gnueabi/9/libgcc.a(_dvmd_lnx.o)' being placed in section `.note.GNU-stack'
/usr/bin/arm-linux-gnu-ld: warning: orphan section `.note.GNU-stack' from `/usr/lib/gcc/arm-linux-gnueabi/9/libgcc.a(_udivmoddi4.o)' being placed in section `.note.GNU-stack'
```