### PR TITLE
mailmap: add entry for Sean Nyekjaer

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -28,3 +28,5 @@ Jun Li <jun.r.li@intel.com>
 Xiaorui Hu <xiaorui.hu@linaro.org>
 Yannis Damigos <giannis.damigos@gmail.com> <ydamigos@iccs.gr>
 Vinayak Kariappa Chettimada <vinayak.kariappa.chettimada@nordicsemi.no> <vinayak.kariappa.chettimada@nordicsemi.no> <vich@nordicsemi.no> <vinayak.kariappa@gmail.com>
+Sean Nyekjaer <sean@geanix.com> <sean.nyekjaer@prevas.dk>
+Sean Nyekjaer <sean@geanix.com> <sean@nyekjaer.dk>


### PR DESCRIPTION
As I no longer is working for Prevas, add a mailmap entry
so any mail directed towards me reaches the appropriate mailbox.

Secondly. point to my work mail instead of my private one.

Signed-off-by: Sean Nyekjaer <sean@geanix.com>