### PR TITLE
Bluetooth: controller: split: Fix conditional compile error

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -592,10 +592,11 @@ static void isr_done(void *param)
 	e->mic_state = mic_state;
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
+#if defined(CONFIG_BT_PERIPHERAL)
 	if (trx_cnt) {
 		struct lll_conn *lll = param;
 
-		if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && lll->role) {
+		if (lll->role) {
 			u32_t preamble_to_addr_us;
 
 #if defined(CONFIG_BT_CTLR_PHY)
@@ -617,6 +618,7 @@ static void isr_done(void *param)
 			lll->slave.window_size_event_us = 0;
 		}
 	}
+#endif /* CONFIG_BT_PERIPHERAL */
 
 	isr_cleanup(param);
 }
@@ -655,12 +657,14 @@ static int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 		/* Increment serial number */
 		lll->sn++;
 
+#if defined(CONFIG_BT_PERIPHERAL)
 		/* First ack (and redundantly any other ack) enable use of
 		 * slave latency.
 		 */
-		if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && lll->role) {
+		if (lll->role) {
 			lll->slave.latency_enabled = 1;
 		}
+#endif /* CONFIG_BT_PERIPHERAL */
 
 		if (!lll->empty) {
 			struct pdu_data *pdu_data_tx;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -35,6 +35,7 @@ struct ll_conn {
 			u8_t fex_valid:1;
 		} common;
 
+#if defined(CONFIG_BT_PERIPHERAL)
 		struct {
 			u8_t  fex_valid:1;
 			u8_t  latency_cancel:1;
@@ -42,11 +43,14 @@ struct ll_conn {
 			u32_t force;
 			u32_t ticks_to_offset;
 		} slave;
+#endif /* CONFIG_BT_PERIPHERAL */
 
+#if defined(CONFIG_BT_CENTRAL)
 		struct {
 			u8_t fex_valid:1;
 			u8_t terminate_ack:1;
 		} master;
+#endif /* CONFIG_BT_CENTRAL */
 	};
 
 	u8_t llcp_req;


### PR DESCRIPTION
Fix conditional compilation error in building the central
only samples as all peripheral structure member accesses in
the controller where not correctly compiled out.

Regression introduced in commit 6d8b12468e95 ("Bluetooth:
controller: split: Refactor LLL conn structure").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>