### PR TITLE
samples: blink_led: Fix the behavior of the sample

### DIFF
--- a/samples/basic/blink_led/README.rst
+++ b/samples/basic/blink_led/README.rst
@@ -14,6 +14,13 @@ reaches 64 Hz, the blinking frequency will be halved every 4 seconds
 until the blinking frequency reaches 1 Hz. This completes a whole
 blinking cycle. This faster-then-slower LED blinking cycle repeats forever.
 
+Since for some PWM hardware it might be not possible to set the PWM period of
+1 second (to achieve the blinking frequency of 1 Hz), this application at its
+beginning tries to determine what is available for the used PWM hardware,
+and accordingly decreases the maximum PWM period (thus increases the initial
+blinking frequency) if needed.
+
+
 Wiring
 ******
 


### PR DESCRIPTION
Commit 16d8ce519c9fe13a2a7bfd23552eafe93b422b49 introduced changes
that caused this sample to no longer behave according to documentation
and for some hardware to no longer work at all.
On nRF51 SoCs for instance, the reported number of cycles per second
is 16M, what makes the calculated max_period and min_period to be 16
and 0 microseconds, respectively, what effectively makes it impossible
for the sample to return to the initial blinking frequency. Moreover,
with such short PWM periods, the blinking is not even noticeable.

This patch partially reverts the changes mentioned above, and instead
of calculating max_period and min_period basing on the reported clock
rate, it tries to only decrease the max_period if needed, accordingly
to what the used hardware can handle.
Documentation is also updated to mention the possible change in
observed behavior of the sample on some hardware.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>