### PR TITLE
samples: net: zperf: Ignore out of net_buf issue

### DIFF
--- a/samples/net/zperf/src/zperf_tcp_uploader.c
+++ b/samples/net/zperf/src/zperf_tcp_uploader.c
@@ -31,6 +31,7 @@ void zperf_tcp_upload(const struct shell *shell,
 	u32_t nb_packets = 0U, nb_errors = 0U;
 	u32_t start_time, last_print_time, end_time;
 	u8_t time_elapsed = 0U, finished = 0U;
+	u32_t alloc_errors = 0U;
 
 	if (packet_size > PACKET_SIZE_MAX) {
 		shell_fprintf(shell, SHELL_WARNING,
@@ -66,11 +67,24 @@ void zperf_tcp_upload(const struct shell *shell,
 				       packet_size, NULL,
 				       K_NO_WAIT, NULL);
 		if (ret < 0) {
-			shell_fprintf(shell, SHELL_WARNING,
+			if (nb_errors == 0 && ret != -ENOMEM) {
+				shell_fprintf(shell, SHELL_WARNING,
 				      "Failed to send the packet (%d)\n",
 				      ret);
+			}
+
 			nb_errors++;
-			break;
+
+			if (ret == -ENOMEM) {
+				/* Ignore memory errors as we just run out of
+				 * buffers which is kind of expected if the
+				 * buffer count is not optimized for the test
+				 * and device.
+				 */
+				alloc_errors++;
+			} else {
+				break;
+			}
 		} else {
 			nb_packets++;
 
@@ -99,6 +113,16 @@ void zperf_tcp_upload(const struct shell *shell,
 		HW_CYCLES_TO_USEC(time_delta(start_time, end_time));
 	results->packet_size = packet_size;
 	results->nb_packets_errors = nb_errors;
+
+	if (alloc_errors > 0) {
+		shell_fprintf(shell, SHELL_WARNING,
+			      "There was %u network buffer allocation "
+			      "errors during send.\nConsider increasing the "
+			      "value of CONFIG_NET_BUF_TX_COUNT and\n"
+			      "optionally CONFIG_NET_PKT_TX_COUNT Kconfig "
+			      "options.\n",
+			      alloc_errors);
+	}
 
 	net_context_put(ctx);
 }


### PR DESCRIPTION
If we ran out of net_buf's while sending, ignore the issue
and try to finish the test instead. Solving the "running out
of network buffers" case would require careful tuning of
number of network buffers, buffer size, upload speed etc. which
is difficult to solve with generic buffer count options.

The user should tweak mainly the CONFIG_NET_BUF_TX_COUNT option.
Optionally CONFIG_NET_PKT_TX_COUNT can be changed too. Information
about these options is printed to console after the test is finished.

Fixes #20315

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>