### PR TITLE
Disable LSAN "at exit" leak checking when building for 64-bit targets with GCC

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -337,6 +337,7 @@
 /subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @joerchan @Vudentz
 /subsys/cpp/                              @pabigot @vanwinkeljan
 /subsys/debug/                            @nashif
+/subsys/debug/asan.c                      @vanwinkeljan @aescolar
 /subsys/disk/disk_access_spi_sdhc.c       @JunYangNXP
 /subsys/disk/disk_access_sdhc.h           @JunYangNXP
 /subsys/disk/disk_access_usdhc.c          @JunYangNXP

--- a/subsys/debug/CMakeLists.txt
+++ b/subsys/debug/CMakeLists.txt
@@ -5,4 +5,9 @@ zephyr_sources_ifdef(
   openocd.c
   )
 
+zephyr_sources_ifdef(
+  CONFIG_ASAN
+  asan.c
+  )
+
 add_subdirectory(tracing)

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -55,6 +55,11 @@ config ASAN
 	  recent-ish compiler with the ``-fsanitize=address`` command line option,
 	  and the libasan library.
 
+	  Note that at exit leak detection is disabled for 64-bit boards when
+	  GCC is used due to potential risk of a deadlock in libasan.
+	  This behavior can be changes by adding leak_check_at_exit=1 to the
+	  environment variable ASAN_OPTIONS.
+
 config UBSAN
 	bool "Build with undefined behavior sanitizer"
 	depends on ARCH_POSIX

--- a/subsys/debug/asan.c
+++ b/subsys/debug/asan.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const char *__asan_default_options(void)
+{
+	return
+#if defined(CONFIG_64BIT) && defined(__GNUC__) && !defined(__clang__)
+		/* Running leak detection at exit could lead to a deadlock on
+		 * 64-bit boards if GCC is used.
+		 * https://github.com/zephyrproject-rtos/zephyr/issues/20122
+		 */
+		"leak_check_at_exit=0:"
+#endif
+		"";
+}


### PR DESCRIPTION
Disable "at exit" memory leak check by LSAN if building for a 64-bit target with GCC.
This is need to fix a potential deadlock in GCCs libasan implementation.

Fixes #20122

These commits where separated from PR #19093