### PR TITLE
kconfig: doc: Split up symbol reference by path

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -205,7 +205,15 @@ add_custom_target(
   KCONFIG_WARN_UNDEF=y
   KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
   KCONFIG_DOC_MODE=1
-  ${PYTHON_EXECUTABLE} scripts/genrest.py ${RST_OUT}/doc/reference/kconfig/
+    ${PYTHON_EXECUTABLE} scripts/genrest.py ${RST_OUT}/doc/reference/kconfig/
+      --keep-module-paths
+      --modules Architecture:arch:${ZEPHYR_BASE}/arch
+                Driver:drivers:${ZEPHYR_BASE}/drivers
+                Kernel:kernel:${ZEPHYR_BASE}/kernel
+                Library:lib:${ZEPHYR_BASE}/lib
+                Subsystem:subsys:${ZEPHYR_BASE}/subsys
+                'External Module':modules:${ZEPHYR_BASE}/modules
+
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   COMMENT "Running genrest.py Kconfig ${RST_OUT}/doc/reference/kconfig/"
 )

--- a/doc/scripts/genrest.py
+++ b/doc/scripts/genrest.py
@@ -1,7 +1,6 @@
 """
-Generates a Kconfig symbol reference in RST format, with a separate
-CONFIG_FOO.rst file for each symbol, and an alphabetical index with links in
-index.rst.
+Generates an alphabetical index of Kconfig symbols with links in index.rst, and
+a separate CONFIG_FOO.rst file for each Kconfig symbol.
 
 The generated symbol pages can be referenced in RST as :option:`foo`, and the
 generated index page as `configuration options`_.
@@ -59,18 +58,10 @@ def expr_str(expr):
 
 
 def main():
-    # Writes index.rst and the symbol RST files
-
     init()
 
-    # Writes index page(s)
-    if modules:
-        write_module_index_pages()
-    else:
-        write_index_page(kconf.unique_defined_syms, None, None,
-                         desc_from_file(top_index_desc))
+    write_index_pages()  # Plural since there's more than one in --modules mode
 
-    # Write symbol pages
     if os.getenv("KCONFIG_TURBO_MODE") == "1":
         write_dummy_syms_page()
     else:
@@ -86,17 +77,13 @@ def init():
     # out_dir:
     #   Output directory
     #
-    # non_module_title:
-    #   Title for index of non-module symbols, as passed via
-    #   --non-module-title
-    #
-    # top_index_desc/non_module_index_desc/all_index_desc:
+    # index_desc:
     #   Set to the corresponding command-line arguments (or None if
     #   missing)
     #
     # modules:
-    #   A list of (<title>, <suffix>, <path>, <index description>) tuples. See
-    #   the --modules argument. Empty if --modules wasn't passed.
+    #   A list of (<title>, <suffix>, <path>, <desc. path>) tuples. See the
+    #   --modules flag. Empty if --modules wasn't passed.
     #
     #   <path> is an absolute pathlib.Path instance, which is handy for robust
     #   path comparisons.
@@ -106,10 +93,7 @@ def init():
 
     global kconf
     global out_dir
-    global non_module_title
-    global top_index_desc
-    global non_module_index_desc
-    global all_index_desc
+    global index_desc
     global modules
     global strip_module_paths
 
@@ -117,32 +101,28 @@ def init():
 
     kconf = kconfiglib.Kconfig(args.kconfig)
     out_dir = args.out_dir
-    non_module_title = args.non_module_title
-    top_index_desc = args.top_index_desc
-    non_module_index_desc = args.non_module_index_desc
-    all_index_desc = args.all_index_desc
+    index_desc = args.index_desc
     strip_module_paths = args.strip_module_paths
 
     modules = []
     for module_spec in args.modules:
         if module_spec.count(":") == 2:
             title, suffix, path_s = module_spec.split(":")
-            index_text = DEFAULT_INDEX_DESCRIPTION
+            desc_path = None
         elif module_spec.count(":") == 3:
-            title, suffix, path_s, index_text_fname = module_spec.split(":")
-            index_text = desc_from_file(index_text_fname)
+            title, suffix, path_s, desc_path = module_spec.split(":")
         else:
             sys.exit("error: --modules argument '{}' should have the format "
                      "<title>:<suffix>:<path> or the format "
                      "<title>:<suffix>:<path>:<index description filename>"
                      .format(module_spec))
 
-        path = pathlib.Path(path_s).resolve()
-        if not path.exists():
+        abspath = pathlib.Path(path_s).resolve()
+        if not abspath.exists():
             sys.exit("error: path '{}' in --modules argument does not exist"
-                     .format(path))
+                     .format(abspath))
 
-        modules.append((title, suffix, path, index_text))
+        modules.append((title, suffix, abspath, desc_path))
 
 
 def parse_args():
@@ -159,38 +139,15 @@ def parse_args():
         help="Top-level Kconfig file (default: Kconfig)")
 
     parser.add_argument(
-        "--non-module-title",
-        metavar="NON_MODULE_TITLE",
-        default="Zephyr",
-        help="""\
-The title used for the index page that lists the symbols
-that do not appear in any module (index-main.rst). Only
-meaningful in --modules mode.""")
-
-    parser.add_argument(
-        "--top-index-desc",
-        metavar="FILE",
+        "--index-desc",
+        metavar="RST_FILE",
         help="""\
 Path to an RST file with description text for the top-level
 index.rst index page. If missing, a generic description will
 be used. Used both in --modules and non-modules mode.
 
-See <index description filename> in the --modules
-description as well.""")
-
-    parser.add_argument(
-        "--non-module-index-desc",
-        metavar="FILE",
-        help="""\
-Like --top-index-desc, but for the index page that lists the
-non-module symbols in --modules mode (index-main.rst).""")
-
-    parser.add_argument(
-        "--all-index-desc",
-        metavar="FILE",
-        help="""\
-Like --top-index-desc, but for the index page that lists all
-symbols in --modules mode (index-all.rst).""")
+See <index description path> in the --modules description as
+well.""")
 
     parser.add_argument(
         "--modules",
@@ -198,40 +155,40 @@ symbols in --modules mode (index-all.rst).""")
         nargs="+",
         default=[],
         help="""\
-Used to split the documentation into several index pages,
-based on where symbols are defined.
+Specifies that the documentation should be split into
+several index pages, based on where symbols are defined.
 
-MODULE_SPECIFICATION is either a <title>:<suffix>:<path>
-tuple or a
-<title>:<suffix>:<path>:<index description filename> tuple.
-If the second form is used, <index description filename>
-should be the path to an RST file, the contents of which
-will appear on the index page that lists the symbols for the
-module (under an automatically-inserted Overview heading).
-If the first form is used, a generic description will be
-used instead.
+Each MODULE_SPECIFICATION has the form
 
-A separate index-<suffix>.rst index page is generated for
-each tuple, with the title "<title> Configuration Options",
-a 'configuration_options_<suffix>' RST link target, and
-links to all symbols that appear under the tuple's <path>
-(possibly more than one level deep). Symbols that do not
-appear in any module are added to index-main.rst.
+    <title>:<suffix>:<path>[:<index description path>]
 
-A separate index-all.rst page is generated that lists all
-symbols, regardless of whether they're from a module or not.
+, where <index description path> is optional.
 
-The generated index.rst contains a TOC tree that links to
-the other index-*.rst pages.
+A separate index-<suffix>.rst symbol index page is generated
+for each MODULE_SPECIFICATION, with links to all symbols
+that are defined inside <path> (possibly more than one level
+deep). The title of the index is "<title> Configuration
+Options", and a 'configuration_options_<suffix>' RST link
+target is inserted at the top of the index page.
 
-If a symbol is defined in more than one module (or both
-inside and outside a module), it will be listed on several
-index pages.
+If <index description path> is given, it should be the
+path to an RST file. The contents of this file will appear
+under the Overview heading on the symbol index page for the
+module. If no <index description path> is given, a generic
+description is used instead.
+
+The top-level index.rst index page contains a TOC tree that
+links to the index-*.rst pages for any modules. It also
+includes a list of all symbols, including symbols that do
+not appear in any module.
+
+If a symbol is defined in more than one module, it will be
+listed on several index pages.
 
 Passing --modules also tweaks how paths are displayed on
 symbol information pages, showing
 '<title>/path/within/module/Kconfig' for paths that fall
-within modules. This path rewriting can be disabled with
+within modules. This behavior can be disabled by passing
 --keep-module-paths.""")
 
     parser.add_argument(
@@ -248,128 +205,124 @@ within modules. This path rewriting can be disabled with
     return parser.parse_args()
 
 
-def write_module_index_pages():
-    # Generate all index pages. Passing --modules will generate more than one.
+def write_index_pages():
+    # Writes all index pages. --modules will give more than one.
 
-    write_toplevel_index()
+    # Implementation note: Functions used here add any newlines they want
+    # before their output themselves. Try to keep this consistent if you change
+    # things.
+
+    write_main_index_page()
+    write_module_index_pages()
+
+
+def write_main_index_page():
+    # Writes the main index page, which lists all symbols. In --modules mode,
+    # links to the module index pages are included.
+
+    rst = index_header(title="Configuration Options",
+                       link="configuration_options",
+                       desc_path=index_desc)
+
+    if modules:
+        rst += """
+
+Subsystems
+**********
+
+These index pages list symbols defined within a particular subsystem, while the
+list below includes all configuration symbols.
+
+.. toctree::
+   :maxdepth: 1
+
+""" + "\n".join("   index-" + suffix for _, suffix, _, _, in modules)
+
+    rst += sym_table_rst("All configuration options",
+                         kconf.unique_defined_syms)
+
+    write_if_updated("index.rst", rst)
+
+
+def write_module_index_pages():
+    # Writes index index-<suffix>.rst index pages for all modules
 
     # Maps each module title to a set of Symbols in the module
     module2syms = collections.defaultdict(set)
-    # Symbols that do not appear in any module
-    non_module_syms = set()
 
     for sym in kconf.unique_defined_syms:
         # Loop over all definition locations
         for node in sym.nodes:
             mod_title = path2module(node.filename)
-
-            if mod_title is None:
-                non_module_syms.add(node.item)
-            else:
+            if mod_title is not None:
                 module2syms[mod_title].add(node.item)
 
-    # Write the index-main.rst index page, which lists the symbols that aren't
-    # from a module
-    write_index_page(non_module_syms, non_module_title, "main",
-                     desc_from_file(non_module_index_desc))
+    # Iterate 'modules' instead of 'module2syms' so that an index page gets
+    # written even if the module has no symbols
+    for title, suffix, _, desc_path in modules:
+        rst = index_header(title=title + " Configuration Options",
+                           link="configuration_options_" + suffix,
+                           desc_path=desc_path)
 
-    # Write the index-<suffix>.rst index pages, which list symbols from
-    # modules. Iterate 'modules' instead of 'module2syms' so that an index page
-    # gets written even if a module has no symbols, for consistency.
-    for title, suffix, _, text in modules:
-        write_index_page(module2syms[title], title, suffix, text)
+        rst += sym_table_rst("Configuration Options",
+                             module2syms[title])
 
-    # Write the index-all.rst index page, which lists all symbols, including
-    # both module and non-module symbols
-    write_index_page(kconf.unique_defined_syms, "All", "all",
-                     desc_from_file(all_index_desc))
+        write_if_updated("index-{}.rst".format(suffix), rst)
 
 
-def write_toplevel_index():
-    # Used in --modules mode. Writes an index.rst with a TOC tree that links to
-    # index-main.rst and the index-<suffix>.rst pages.
+def sym_table_rst(title, syms):
+    # Returns RST for the list of symbols on index pages. 'title' is the
+    # heading to use.
 
-    rst = index_page_header(None, None, desc_from_file(top_index_desc)) + """
-Subsystems
-**********
+    rst = """
 
-.. toctree::
-   :maxdepth: 1
+{}
+{}
 
-"""
-
-    rst += "   index-main\n"
-    for _, suffix, _, _ in modules:
-        rst += "   index-{}\n".format(suffix)
-    rst += "   index-all\n"
-
-    write_if_updated("index.rst", rst)
-
-
-def write_index_page(syms, title, suffix, text):
-    # Writes an index page for the Symbols in 'syms' to 'index-<suffix>.rst'
-    # (or index.rst if 'suffix' is None). 'title', 'suffix', and 'text' are
-    # also used for to generate the index page header. See index_page_header().
-
-    rst = index_page_header(title, suffix, text)
-
-    rst += """
-Configuration symbols
-*********************
-
-.. list-table:: Alphabetized Index of Configuration Options
+.. list-table::
    :header-rows: 1
 
-   * - Kconfig Symbol
-     - Description
-"""
+   * - Symbol name
+     - Prompt
+""".format(title, len(title)*"*")
 
     for sym in sorted(syms, key=attrgetter("name")):
-        # Add an index entry for the symbol that links to its page. Also list
-        # its prompt(s), if any. (A symbol can have multiple prompts if it has
-        # multiple definitions.)
-        rst += "   * - :option:`CONFIG_{}`\n     - {}\n".format(
-            sym.name, " / ".join(node.prompt[0] for node in sym.nodes
-                                 if node.prompt))
+        rst += """\
+   * - :option:`CONFIG_{}`
+     - {}
+""".format(sym.name,
+           " / ".join(node.prompt[0] for node in sym.nodes if node.prompt))
 
-    if suffix is None:
-        fname = "index.rst"
-    else:
-        fname = "index-{}.rst".format(suffix)
-
-    write_if_updated(fname, rst)
+    return rst
 
 
-def index_page_header(title, link, description):
-    # write_index_page() helper. Returns the RST for the beginning of a symbol
-    # index page.
+def index_header(title, link, desc_path):
+    # Returns the RST for the beginning of a symbol index page.
     #
     # title:
-    #   String used for the page title, as '<title> Configuration Options'. If
-    #   None, just 'Configuration Options' is used as the title.
+    #   Page title
     #
     # link:
-    #   String used for link target, as 'configuration_options_<link>'. If
-    #   None, the link will be 'configuration_options'.
+    #   Link target string
     #
-    # description:
-    #   RST put into an Overview section at the beginning of the page
+    # desc_path:
+    #   Path to file with RST file put into the Overview section at the
+    #   beginning of the page. If None, a generic description is used.
 
-    if title is None:
-        title = "Configuration Options"
+    if desc_path is None:
+        desc = DEFAULT_INDEX_DESC
     else:
-        title = title + " Configuration Options"
-
-    if link is None:
-        link = "configuration_options"
-    else:
-        link = "configuration_options_" + link
-
-    title += "\n" + len(title)*"="
+        try:
+            with open(desc_path, encoding="utf-8") as f:
+                desc = f.read()
+        except OSError as e:
+            sys.exit("error: failed to open index description file '{}': {}"
+                     .format(desc_path, e))
 
     return """\
 .. _{}:
 
+{}
 {}
 
 Overview
@@ -378,38 +331,25 @@ Overview
 {}
 
 This documentation is generated automatically from the :file:`Kconfig` files by
-the :file:`{}` script. Click on symbols for more information.
-""".format(link, title, description, os.path.basename(__file__))
+the :file:`{}` script. Click on symbols for more information.""".format(
+    link,
+    title, len(title)*"=",
+    desc,
+    os.path.basename(__file__))
 
 
-DEFAULT_INDEX_DESCRIPTION = """\
+DEFAULT_INDEX_DESC = """\
 :file:`Kconfig` files describe build-time configuration options (called symbols
 in Kconfig-speak), how they're grouped into menus and sub-menus, and
 dependencies between them that determine what configurations are valid.
 
 :file:`Kconfig` files appear throughout the directory tree. For example,
-:file:`subsys/power/Kconfig` defines power-related options.
+:file:`subsys/power/Kconfig` defines power-related options.\
 """
 
 
-def desc_from_file(fname):
-    # Helper for loading files with descriptions for index pages. Returns
-    # DEFAULT_INDEX_DESCRIPTION if 'fname' is None, and the contents of the
-    # file otherwise.
-
-    if fname is None:
-        return DEFAULT_INDEX_DESCRIPTION
-
-    try:
-        with open(fname, "r", encoding="utf-8") as f:
-            return f.read()
-    except OSError as e:
-        sys.exit("error: failed to open index description file '{}': {}"
-                 .format(fname, e))
-
-
 def write_sym_pages():
-    # Generates all symbol and choice pages
+    # Writes all symbol and choice pages
 
     for sym in kconf.unique_defined_syms:
         write_sym_page(sym)
@@ -420,8 +360,8 @@ def write_sym_pages():
 
 def write_dummy_syms_page():
     # Writes a dummy page that just has targets for all symbol links so that
-    # they can be referenced from elsewhere in the documentation, to speed up
-    # builds when we don't need the Kconfig symbol documentation
+    # they can be referenced from elsewhere in the documentation. This speeds
+    # up builds when we don't need the Kconfig symbol documentation.
 
     rst = ":orphan:\n\nDummy symbols page for turbo mode.\n\n"
     for sym in kconf.unique_defined_syms:

--- a/doc/scripts/genrest.py
+++ b/doc/scripts/genrest.py
@@ -281,19 +281,36 @@ def sym_table_rst(title, syms):
 
 .. list-table::
    :header-rows: 1
+   :widths: auto
 
    * - Symbol name
-     - Prompt
+     - Help/prompt
 """.format(title, len(title)*"*")
 
     for sym in sorted(syms, key=attrgetter("name")):
         rst += """\
    * - :option:`CONFIG_{}`
      - {}
-""".format(sym.name,
-           " / ".join(node.prompt[0] for node in sym.nodes if node.prompt))
+""".format(sym.name, sym_index_desc(sym))
 
     return rst
+
+
+def sym_index_desc(sym):
+    # Returns the description used for 'sym' on the index page
+
+    # Use the first help text, if available
+    for node in sym.nodes:
+        if node.help is not None:
+            return node.help.replace("\n", "\n       ")
+
+    # If there's no help, use the first prompt string
+    for node in sym.nodes:
+        if node.prompt:
+            return node.prompt[0]
+
+    # No help text or prompt
+    return ""
 
 
 def index_header(title, link, desc_path):


### PR DESCRIPTION
Main commit:

```
kconfig: doc: Split up symbol reference by path

Use --modules to split the Kconfig reference up by where symbols are
defined. See the argparse docstring for --modules in
doc/scripts/genrest.py.

Not sure what the best way to split things up is, so feedback would be
appreciated. I just pulled out some top-level directories. It could
always be tweaked later.

If a symbol is defined in more than one module (by being defined in
multiple locations), it appears on multiple index pages.

To build the documentation, do

    $ mkdir doc/b && cd doc/b
    $ cmake -GNinja ..
    $ ninja htmldocs
    (output in html/reference/kconfig/index.html)
```

Depends on this script change, which is also included in this PR:

```
genrest: List all symbols on main index page and refactor

Instead of having index.rst just link to other index pages in --modules
mode, list all symbols on it, and have links to the module index pages
at the top.

Get rid of index-all.rst and index-main.rst (and all related options).
index-main.rst is no longer needed, and index-other.rst (symbols outside
--modules) might not be that useful to people reading the documentation
(and could be added back if needed).

Also refactor and streamline the code a bunch. For the main index page,
the only difference between modules and non-modules mode is now whether
there's links to other index pages at the top.

Suggested by David B. Kinder.
```

Also includes this tweak to show help texts on the index page:

```
genrest: Show symbol help texts on index page

Instead of showing the prompt for symbols on the index page, show their
help texts. This makes searching easier.

Fall back on the prompt if no help text is available.

Also change the code to only show one of the prompts if several are
available (happens if a symbol is defined in multiple locations and adds
a prompt in more than one of them). It's probably overkill to show them
all, and it doesn't come up that often.

Suggested by David B. Kinder.
```