### PR TITLE
cmake: app mem partion flexibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1055,11 +1055,13 @@ if(CONFIG_USERSPACE)
     -d ${OBJ_FILE_DIR}
     -o ${APP_SMEM_UNALIGNED_LD}
     ${NEWLIB_PART} ${MBEDTLS_PART}
+    $<TARGET_PROPERTY:zephyr_property_target,COMPILE_OPTIONS>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     DEPENDS
     kernel
     ${ZEPHYR_LIBS_PROPERTY}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/
+    COMMAND_EXPAND_LISTS
     COMMENT "Generating app_smem_unaligned linker section"
     )
 
@@ -1104,12 +1106,14 @@ if(CONFIG_USERSPACE)
     -e $<TARGET_FILE:app_smem_unaligned_prebuilt>
     -o ${APP_SMEM_ALIGNED_LD}
     ${NEWLIB_PART} ${MBEDTLS_PART}
+    $<TARGET_PROPERTY:zephyr_property_target,COMPILE_OPTIONS>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     DEPENDS
     kernel
     ${ZEPHYR_LIBS_PROPERTY}
     app_smem_unaligned_prebuilt
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/
+    COMMAND_EXPAND_LISTS
     COMMENT "Generating app_smem_aligned linker section"
     )
 endif()

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -525,6 +525,13 @@ if(CONFIG_QEMU_TARGET)
   endif()
 endif()
 
+# General purpose Zephyr target.
+# This target can be used for custom zephyr settings that needs to be used elsewhere in the build system
+#
+# Currently used properties:
+# - COMPILES_OPTIONS: Used by application memory partition feature
+add_custom_target(zephyr_property_target)
+
 # "app" is a CMake library containing all the application code and is
 # modified by the entry point ${APPLICATION_SOURCE_DIR}/CMakeLists.txt
 # that was specified when cmake was called.

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -484,6 +484,19 @@ function(zephyr_library_import library_name library_path)
   zephyr_append_cmake_library(${library_name})
 endfunction()
 
+# Place the current zephyr library in the application memory partition.
+#
+# The partition argument is the name of the partition where the library shall
+# be placed.
+#
+# Note: Ensure the given partition has been define using
+#       K_APPMEM_PARTITION_DEFINE in source code.
+function(zephyr_library_app_memory partition)
+  set_property(TARGET zephyr_property_target
+               APPEND PROPERTY COMPILE_OPTIONS
+               "-l" $<TARGET_FILE_NAME:${ZEPHYR_CURRENT_LIBRARY}> "${partition}")
+endfunction()
+
 # 1.2.1 zephyr_interface_library_*
 #
 # A Zephyr interface library is a thin wrapper over a CMake INTERFACE

--- a/doc/reference/usermode/memory_domain.rst
+++ b/doc/reference/usermode/memory_domain.rst
@@ -284,8 +284,13 @@ top-level ``CMakeLists.txt`` adds the following:
 
     gen_app_partitions.py ... --library libc.a z_libc_partition ..
 
-There is no support for expressing this in the project-level configuration
-or build files; the toplevel ``CMakeLists.txt`` must be edited.
+For pre-compiled libraries there is no support for expressing this in the
+project-level configuration or build files; the toplevel ``CMakeLists.txt`` must
+be edited.
+
+For Zephyr libraries created using ``zephyr_library`` or ``zephyr_library_named``
+the ``zephyr_library_app_memory`` function can be used to specify the memory
+partition where all globals in the library should be placed.
 
 Pre-defined Memory Partitions
 -----------------------------


### PR DESCRIPTION
Today, it is necessary to edit toplevel `zephyr/CMakeLists.txt` if all globals in a static library shall be placed in application memory partition, as described here:
https://docs.zephyrproject.org/latest/reference/usermode/memory_domain.html?highlight=k_appmem_partition_define#automatic-partitions-for-static-library-globals

This gives a hard dependence for projects / modules that top-level `zephyr/CMakeLists.txt` must be edited. If using Zephyr for a custom zephyr modules, this means that users must unfortunately place their own changes into top-level `CMakeLists.txt`.
The current solution where the library name is hard code, as with mbedTLS, where the library name is, doesn't look nice: `lib..__modules__crypto__mbedtls.a`
as well as it makes it harder to re-structure folders, if need be.

Therefore this PR introduces `zephyr_library_app_memory` that can be used for zephyr libraries to places them in a named partion.

Introducing this feature allow for removing this:
https://github.com/zephyrproject-rtos/zephyr/blob/d6d79933c1a991bc4456a9cadd000b2f638e2891/CMakeLists.txt#L1048
```
if(CONFIG_MBEDTLS)
    set(MBEDTLS_PART -l lib..__modules__crypto__mbedtls.a k_mbedtls_partition)
endif()
```

and instead do:
```
 zephyr_library_app_memory(k_mbedtls_partition)
```
https://github.com/tejlmand/mbedtls/blob/dfa007d45dca3098eae5c25d11555f596dbcd984/CMakeLists.txt#L26

as seen in these commits:
https://github.com/tejlmand/zephyr/commit/d2e8c85e613844fba22206b97693b9e42535c2cd
https://github.com/tejlmand/mbedtls/commit/dfa007d45dca3098eae5c25d11555f596dbcd984

------ commit message ------

This commit allows a more dynamic approach for specifying that a zephyr
library must be placed in a dedicated app memory partition.
This is still done by defining the partition in code using
K_APPMEM_PARTITION_DEFINE, but now the zephyr library can be added to
the generation of partition table using zephyr_library_app_memory
instead of modifying the overall zephyr/CMakeLists.txt file.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>