### PR TITLE
DTS: Remove parsing of DT generated Kconfig symbols

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -214,8 +214,6 @@ if(SUPPORTS_DTS)
     message(FATAL_ERROR "command failed with return code: ${ret}")
   endif()
 
-  import_kconfig(DT_     ${GENERATED_DTS_BOARD_CONF})
-
 else()
   file(WRITE ${GENERATED_DTS_BOARD_UNFIXED_H} "/* WARNING. THIS FILE IS AUTO-GENERATED. DO NOT MODIFY! */")
   file(WRITE ${GENERATED_DTS_BOARD_UNFIXED_H}.deprecated "/* WARNING. THIS FILE IS AUTO-GENERATED. DO NOT MODIFY! */")

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -121,8 +121,7 @@ class BuildConfiguration:
     Configuration options can be read as if the object were a dict,
     either object['CONFIG_FOO'] or object.get('CONFIG_FOO').
 
-    Configuration values in .config and generated_dts_board.conf are
-    available.'''
+    Kconfig configuration values are available (parsed from .config).'''
 
     def __init__(self, build_dir):
         self.build_dir = build_dir
@@ -139,12 +138,7 @@ class BuildConfiguration:
         return self.options.get(option, *args)
 
     def _init(self):
-        build_z = os.path.join(self.build_dir, 'zephyr')
-        generated = os.path.join(build_z, 'include', 'generated')
-        files = [os.path.join(build_z, '.config'),
-                 os.path.join(generated, 'generated_dts_board.conf')]
-        for f in files:
-            self._parse(f)
+        self._parse(os.path.join(self.build_dir, 'zephyr', '.config'))
 
     def _parse(self, filename):
         with open(filename, 'r') as f:


### PR DESCRIPTION
The desire is to have one means to reference DT data in various places it might be used. This might be Kconfig, sanitycheck or some other place. Having a set of functions that we provide to these utilities based on eDTS ensures that. Additionally exposing all the defines we generate as Kconfig symbols isn't terribly viable as we start to produce more C constructs like array initializers. We should utilize Kconfig as the only means to generate Kconfig symbols and not have some psuedo symbol generation from DT anymore that might not be consistent.