### PR TITLE
drivers: eth: enc424j600: Set carrier status according to link up/down

### DIFF
--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -467,8 +467,13 @@ static void enc424j600_rx_thread(struct device *dev)
 			if (estat & ENC424J600_ESTAT_PHYLNK) {
 				LOG_INF("Link up");
 				enc424j600_setup_mac(dev);
+				net_eth_carrier_on(context->iface);
 			} else {
 				LOG_INF("Link down");
+
+				if (context->iface_initialized) {
+					net_eth_carrier_off(context->iface);
+				}
 			}
 			goto done;
 		}
@@ -498,6 +503,9 @@ static void enc424j600_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 	context->iface = iface;
 	ethernet_init(iface);
+
+	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	context->iface_initialized = true;
 }
 
 static int enc424j600_start_device(struct device *dev)

--- a/drivers/ethernet/eth_enc424j600_priv.h
+++ b/drivers/ethernet/eth_enc424j600_priv.h
@@ -300,7 +300,8 @@ struct enc424j600_runtime {
 	struct k_sem tx_rx_sem;
 	struct k_sem int_sem;
 	u16_t next_pkt_ptr;
-	bool suspended;
+	bool suspended : 1;
+	bool iface_initialized : 1;
 };
 
 #endif /*_ENC424J600_*/


### PR DESCRIPTION
Set the network interface up / down according to link status.
This means that we call Ethernet carrier on/off function in
proper places.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>