### PR TITLE
bluetooth: controller: nrf5: use nrfx function to get CCM IRQ line

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1060,7 +1060,7 @@ u32_t radio_ccm_is_done(void)
 		__WFE();
 	}
 	nrf_ccm_int_disable(NRF_CCM, CCM_INTENCLR_ENDCRYPT_Msk);
-	NVIC_ClearPendingIRQ(CCM_AAR_IRQn);
+	NVIC_ClearPendingIRQ(nrfx_get_irq_number(NRF_CCM));
 
 	return (NRF_CCM->EVENTS_ERROR == 0);
 }


### PR DESCRIPTION
We use the nRFx API nrf_get_irq_line(.) to retrieve the IRQ
line of the CCM peripheral, instead of the hard coded enum
value from MDK. We do this for portability, since these
enums may be different for different nRF SoC series.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>