### PR TITLE
sensor: vl53l0x: Convert GPIO XSHUT to device tree

### DIFF
--- a/boards/arm/disco_l475_iot1/Kconfig.defconfig
+++ b/boards/arm/disco_l475_iot1/Kconfig.defconfig
@@ -64,19 +64,6 @@ choice HTS221_TRIGGER_MODE
 endchoice
 
 
-if VL53L0X
-
-config VL53L0X_XSHUT_CONTROL_ENABLE
-	default y
-
-config VL53L0X_XSHUT_GPIO_DEV_NAME
-	default "GPIOC"
-
-config VL53L0X_XSHUT_GPIO_PIN_NUM
-	default 6
-
-endif # VL53L0X
-
 if LSM6DSL
 
 choice LSM6DSL_TRIGGER_MODE

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -108,6 +108,7 @@
 		compatible = "st,vl53l0x";
 		reg = <0x29>;
 		label = "VL53L0X";
+		xshut-gpios = <&gpioc 6 0>;
 	};
 };
 

--- a/drivers/sensor/vl53l0x/Kconfig
+++ b/drivers/sensor/vl53l0x/Kconfig
@@ -12,27 +12,6 @@ menuconfig VL53L0X
 
 if VL53L0X
 
-config VL53L0X_XSHUT_CONTROL_ENABLE
-	bool "Enable XSHUT pin control"
-	help
-	    Enable it if XSHUT pin is controlled by host.
-
-config VL53L0X_XSHUT_GPIO_DEV_NAME
-	string "GPIO device"
-	default "GPIO_6"
-	depends on VL53L0X_XSHUT_CONTROL_ENABLE
-	help
-	  The device name of the GPIO device to which the VL53L0X xshut pin
-	  is connected.
-
-config VL53L0X_XSHUT_GPIO_PIN_NUM
-	int "Interrupt GPIO pin number"
-	default 6
-	depends on VL53L0X_XSHUT_CONTROL_ENABLE
-	help
-	  The number of the GPIO on which the xshut signal from the VL53L0X
-	  is connected.
-
 config VL53L0X_PROXIMITY_THRESHOLD
 	int "Proximity threshold in millimeters"
 	default 100

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -202,27 +202,27 @@ static int vl53l0x_init(struct device *dev)
 
 	LOG_DBG("enter in %s", __func__);
 
-#ifdef CONFIG_VL53L0X_XSHUT_CONTROL_ENABLE
+#ifdef DT_INST_0_ST_VL53L0X_XSHUT_GPIOS_CONTROLLER
 	struct device *gpio;
 
 	/* configure and set VL53L0X_XSHUT_Pin */
-	gpio = device_get_binding(CONFIG_VL53L0X_XSHUT_GPIO_DEV_NAME);
+	gpio = device_get_binding(DT_INST_0_ST_VL53L0X_XSHUT_GPIOS_CONTROLLER);
 	if (gpio == NULL) {
 		LOG_ERR("Could not get pointer to %s device.",
-		CONFIG_VL53L0X_XSHUT_GPIO_DEV_NAME);
+		DT_INST_0_ST_VL53L0X_XSHUT_GPIOS_CONTROLLER);
 		return -EINVAL;
 	}
 
 	if (gpio_pin_configure(gpio,
-			      CONFIG_VL53L0X_XSHUT_GPIO_PIN_NUM,
+			      DT_INST_0_ST_VL53L0X_XSHUT_GPIOS_PIN,
 			      GPIO_DIR_OUT | GPIO_PUD_PULL_UP) < 0) {
 		LOG_ERR("Could not configure GPIO %s %d).",
-			CONFIG_VL53L0X_XSHUT_GPIO_DEV_NAME,
-			CONFIG_VL53L0X_XSHUT_GPIO_PIN_NUM);
+			DT_INST_0_ST_VL53L0X_XSHUT_GPIOS_CONTROLLER,
+			DT_INST_0_ST_VL53L0X_XSHUT_GPIOS_PIN);
 		return -EINVAL;
 	}
 
-	gpio_pin_write(gpio, CONFIG_VL53L0X_XSHUT_GPIO_PIN_NUM, 1);
+	gpio_pin_write(gpio, DT_INST_0_ST_VL53L0X_XSHUT_GPIOS_PIN, 1);
 	k_sleep(K_MSEC(100));
 #endif
 

--- a/dts/bindings/sensor/st,vl53l0x.yaml
+++ b/dts/bindings/sensor/st,vl53l0x.yaml
@@ -9,3 +9,8 @@ description: |
 compatible: "st,vl53l0x"
 
 include: i2c-device.yaml
+
+properties:
+    xshut-gpios:
+      type: phandle-array
+      required: false


### PR DESCRIPTION
Update vl53l0x dts binding to include GPIO XSHUT pin and change
driver code to get the GPIO pin and controller info from DT instead of
Kconfig.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>