### PR TITLE
sanitycheck: get environment regardless of option specified

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -583,8 +583,8 @@ class BinaryHandler(Handler):
 
         start_time = time.time()
 
+        env = os.environ.copy()
         if options.enable_asan:
-            env = os.environ.copy()
             env["ASAN_OPTIONS"] = "log_path=stdout:" + \
                     env.get("ASAN_OPTIONS", "")
             if not options.enable_lsan:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2760,7 +2760,8 @@ class TestSuite:
                     try:
                         data = future.result()
                     except Exception as exc:
-                        print('%r generated an exception: %s' % (test, exc))
+                        sys.exit('%r generated an exception: %s' % (test, exc))
+
                     else:
                         if data:
                             verbose(data)


### PR DESCRIPTION
environment is passed to execution thread and should be available
regardless of SAN being enabled or not.