### PR TITLE
sensor: ccs811: Convert GPIOs to device tree

### DIFF
--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
@@ -110,6 +110,9 @@
 		compatible = "ams,ccs811";
 		reg = <0x5a>;
 		label = "CCS811";
+		irq-gpios = <&gpio0 22 0>;
+		reset-gpios = <&sx1509b 11 0>;
+		wake-gpios = <&sx1509b 12 0>;
 	};
 };
 

--- a/drivers/sensor/ccs811/Kconfig
+++ b/drivers/sensor/ccs811/Kconfig
@@ -3,45 +3,8 @@
 # Copyright (c) 2018 Linaro Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig CCS811
+config CCS811
 	bool "CCS811 Digital Gas Sensor"
 	depends on I2C && HAS_DTS_I2C
 	help
 	  Enable driver for CCS811 Gas sensors.
-
-if CCS811
-
-config CCS811_GPIO_DEV_NAME
-	string "GPIO device"
-	default "GPIOC"
-	help
-	  The device name of the GPIO device to which the CCS811 WAKE
-	  pin is connected.
-
-config CCS811_GPIO_WAKEUP
-	bool "Enable GPIO Wakeup for CCS811"
-	help
-	  Enable GPIO Wakeup support for CCS811
-
-config CCS811_GPIO_WAKEUP_PIN_NUM
-	int "GPIO Wakeup pin number"
-	default 0
-	depends on CCS811_GPIO_WAKEUP
-	help
-	  The number of the GPIO pin on which the WAKE pin of CCS811
-	  is connected
-
-config CCS811_GPIO_RESET
-	bool "Enable GPIO Reset for CCS811"
-	help
-	  Enable GPIO Reset support for CCS811
-
-config CCS811_GPIO_RESET_PIN_NUM
-	int "GPIO Reset pin number"
-	default 0
-	depends on CCS811_GPIO_RESET
-	help
-	  The number of the GPIO pin on which the RESET pin of CCS811
-	  is connected
-
-endif # CCS811

--- a/drivers/sensor/ccs811/ccs811.c
+++ b/drivers/sensor/ccs811/ccs811.c
@@ -165,19 +165,31 @@ int ccs811_init(struct device *dev)
 		return -EINVAL;
 	}
 
-#if defined(CONFIG_CCS811_GPIO_WAKEUP) || defined(CONFIG_CCS811_GPIO_RESET)
-	drv_data->gpio = device_get_binding(CONFIG_CCS811_GPIO_DEV_NAME);
-	if (drv_data->gpio == NULL) {
+#ifdef DT_INST_0_AMS_CCS811_WAKE_GPIOS_CONTROLLER
+	drv_data->gpio_wakeup =
+		device_get_binding(DT_INST_0_AMS_CCS811_WAKE_GPIOS_CONTROLLER);
+	if (drv_data->gpio_wakeup == NULL) {
 		LOG_ERR("Failed to get pointer to %s device!",
-			    CONFIG_CCS811_GPIO_DEV_NAME);
+			DT_INST_0_AMS_CCS811_WAKE_GPIOS_CONTROLLER);
 		return -EINVAL;
 	}
 #endif
 
-#ifdef CONFIG_CCS811_GPIO_RESET
-	gpio_pin_configure(drv_data->gpio, CONFIG_CCS811_GPIO_RESET_PIN_NUM,
+#ifdef DT_INST_0_AMS_CCS811_RESET_GPIOS_CONTROLLER
+	drv_data->gpio_reset =
+		device_get_binding(DT_INST_0_AMS_CCS811_RESET_GPIOS_CONTROLLER);
+	if (drv_data->gpio_reset == NULL) {
+		LOG_ERR("Failed to get pointer to %s device!",
+			DT_INST_0_AMS_CCS811_RESET_GPIOS_CONTROLLER);
+		return -EINVAL;
+	}
+#endif
+#ifdef DT_INST_0_AMS_CCS811_RESET_GPIOS_CONTROLLER
+	gpio_pin_configure(drv_data->gpio_reset,
+			   DT_INST_0_AMS_CCS811_RESET_GPIOS_PIN,
 			   GPIO_DIR_OUT);
-	gpio_pin_write(drv_data->gpio, CONFIG_CCS811_GPIO_RESET_PIN_NUM, 1);
+	gpio_pin_write(drv_data->gpio_reset,
+		       DT_INST_0_AMS_CCS811_RESET_GPIOS_PIN, 1);
 
 	k_sleep(K_MSEC(1));
 #endif
@@ -186,10 +198,12 @@ int ccs811_init(struct device *dev)
 	 * Wakeup pin should be pulled low before initiating any I2C transfer.
 	 * If it has been tied to GND by default, skip this part.
 	 */
-#ifdef CONFIG_CCS811_GPIO_WAKEUP
-	gpio_pin_configure(drv_data->gpio, CONFIG_CCS811_GPIO_WAKEUP_PIN_NUM,
+#ifdef DT_INST_0_AMS_CCS811_WAKE_GPIOS_CONTROLLER
+	gpio_pin_configure(drv_data->gpio_wakeup,
+			   DT_INST_0_AMS_CCS811_WAKE_GPIOS_PIN,
 			   GPIO_DIR_OUT);
-	gpio_pin_write(drv_data->gpio, CONFIG_CCS811_GPIO_WAKEUP_PIN_NUM, 0);
+	gpio_pin_write(drv_data->gpio_wakeup,
+		       DT_INST_0_AMS_CCS811_WAKE_GPIOS_PIN, 0);
 
 	k_sleep(K_MSEC(1));
 #endif

--- a/drivers/sensor/ccs811/ccs811.h
+++ b/drivers/sensor/ccs811/ccs811.h
@@ -44,8 +44,11 @@
 
 struct ccs811_data {
 	struct device *i2c;
-#ifdef CONFIG_CCS811_GPIO_WAKEUP
-	struct device *gpio;
+#ifdef DT_INST_0_AMS_CCS811_WAKE_GPIOS_CONTROLLER
+	struct device *gpio_wakeup;
+#endif
+#ifdef DT_INST_0_AMS_CCS811_RESET_GPIOS_CONTROLLER
+	struct device *gpio_reset;
 #endif
 	u16_t co2;
 	u16_t voc;

--- a/dts/bindings/sensor/ams,ccs811.yaml
+++ b/dts/bindings/sensor/ams,ccs811.yaml
@@ -10,3 +10,16 @@ description: |
 compatible: "ams,ccs811"
 
 include: i2c-device.yaml
+
+properties:
+    wake-gpios:
+      type: phandle-array
+      required: false
+
+    reset-gpios:
+      type: phandle-array
+      required: false
+
+    irq-gpios:
+      type: phandle-array
+      required: false


### PR DESCRIPTION
Update ccs811 dts binding to include GPIO pins for wakeup, reset, and
interrupt and change driver code to get the GPIO pin and controller
info from DT instead of Kconfig.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>