### PR TITLE
cmake: use zephyr_library_app_memory for mem partition placement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1060,9 +1060,6 @@ if(CONFIG_USERSPACE)
   if(CONFIG_NEWLIB_LIBC_NANO)
     set(NEWLIB_PART -l libc_nano.a z_libc_partition)
   endif()
-  if(CONFIG_MBEDTLS)
-    set(MBEDTLS_PART -l lib..__modules__crypto__mbedtls.a k_mbedtls_partition)
-  endif()
 
   add_custom_command(
     OUTPUT ${APP_SMEM_UNALIGNED_LD}
@@ -1070,7 +1067,7 @@ if(CONFIG_USERSPACE)
     ${ZEPHYR_BASE}/scripts/gen_app_partitions.py
     -d ${OBJ_FILE_DIR}
     -o ${APP_SMEM_UNALIGNED_LD}
-    ${NEWLIB_PART} ${MBEDTLS_PART}
+    ${NEWLIB_PART}
     $<TARGET_PROPERTY:zephyr_property_target,COMPILE_OPTIONS>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     DEPENDS
@@ -1121,7 +1118,7 @@ if(CONFIG_USERSPACE)
     ${ZEPHYR_BASE}/scripts/gen_app_partitions.py
     -e $<TARGET_FILE:app_smem_unaligned_prebuilt>
     -o ${APP_SMEM_ALIGNED_LD}
-    ${NEWLIB_PART} ${MBEDTLS_PART}
+    ${NEWLIB_PART}
     $<TARGET_PROPERTY:zephyr_property_target,COMPILE_OPTIONS>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     DEPENDS

--- a/west.yml
+++ b/west.yml
@@ -71,7 +71,7 @@ manifest:
       revision: d4708d0a432e95f51bdc712591ba5295b751140c
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 4f1e8f5a78dc08aa42a47cc1ad059cce558c26c3
+      revision: 3776c158fe138a72c97c187e4d31c81c37884be9
       path: modules/crypto/mbedtls
     - name: mcumgr
       revision: 84934959d2d1722a23b7e7e200191ae4a6f96168


### PR DESCRIPTION
This commit follows the change introduced with this PR: zephyrproject-rtos/zephyr#20333

~Note: DNM until https://github.com/zephyrproject-rtos/mbedtls/pull/7 has been merged, as the SHA in `west.yml` must be updated to correct SHA.~
`west.yml` updated to correct SHA.

This commit removes the hard coded mbed TLS library name
`lib..__modules__crypto__mbedtls.a` in top-level CMakeLists.txt file and
instead uses zephyr_library_app_memory function.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>