### PR TITLE
64-bit cleanups for system calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -583,6 +583,14 @@ add_custom_command(
   )
 
 add_custom_target(${SYSCALL_LIST_H_TARGET} DEPENDS             ${syscall_list_h})
+
+# 64-bit systems do not require special handling of 64-bit system call
+# parameters or return values, indicate this to the system call boilerplate
+# generation script.
+if(CONFIG_64BIT)
+  set(SYSCALL_LONG_REGISTERS_ARG --long-registers)
+endif()
+
 add_custom_command(OUTPUT include/generated/syscall_dispatch.c ${syscall_list_h}
   # Also, some files are written to include/generated/syscalls/
   COMMAND
@@ -592,6 +600,7 @@ add_custom_command(OUTPUT include/generated/syscall_dispatch.c ${syscall_list_h}
   --base-output      include/generated/syscalls           # Write to this dir
   --syscall-dispatch include/generated/syscall_dispatch.c # Write this file
   --syscall-list     ${syscall_list_h}
+  ${SYSCALL_LONG_REGISTERS_ARG}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${syscalls_json}
   )

--- a/doc/reference/usermode/syscalls.rst
+++ b/doc/reference/usermode/syscalls.rst
@@ -149,7 +149,7 @@ Inside this header is the body of :c:func:`k_sem_init()`::
     {
     #ifdef CONFIG_USERSPACE
             if (z_syscall_trap()) {
-                    z_arch_syscall_invoke3(*(u32_t *)&sem, *(u32_t *)&initial_count, *(u32_t *)&limit, K_SYSCALL_K_SEM_INIT);
+                    z_arch_syscall_invoke3(*(uintptr_t *)&sem, *(uintptr_t *)&initial_count, *(uintptr_t *)&limit, K_SYSCALL_K_SEM_INIT);
                     return;
             }
             compiler_barrier();

--- a/include/arch/arc/syscall.h
+++ b/include/arch/arc/syscall.h
@@ -38,9 +38,10 @@ extern "C" {
  * just for enabling CONFIG_USERSPACE on arc w/o errors.
  */
 
-static inline u32_t z_arch_syscall_invoke6(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t arg4, u32_t arg5, u32_t arg6,
-					  u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke6(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3, uintptr_t arg4,
+					       uintptr_t arg5, uintptr_t arg6,
+					       uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0") = arg1;
 	register u32_t r1 __asm__("r1") = arg2;
@@ -62,8 +63,10 @@ static inline u32_t z_arch_syscall_invoke6(u32_t arg1, u32_t arg2, u32_t arg3,
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke5(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t arg4, u32_t arg5, u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke5(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3, uintptr_t arg4,
+					       uintptr_t arg5,
+					       uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0") = arg1;
 	register u32_t r1 __asm__("r1") = arg2;
@@ -84,8 +87,9 @@ static inline u32_t z_arch_syscall_invoke5(u32_t arg1, u32_t arg2, u32_t arg3,
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke4(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t arg4, u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke4(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3, uintptr_t arg4,
+					       uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0") = arg1;
 	register u32_t r1 __asm__("r1") = arg2;
@@ -105,8 +109,9 @@ static inline u32_t z_arch_syscall_invoke4(u32_t arg1, u32_t arg2, u32_t arg3,
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke3(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke3(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3,
+					       uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0") = arg1;
 	register u32_t r1 __asm__("r1") = arg2;
@@ -124,7 +129,8 @@ static inline u32_t z_arch_syscall_invoke3(u32_t arg1, u32_t arg2, u32_t arg3,
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke2(u32_t arg1, u32_t arg2, u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke2(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0") = arg1;
 	register u32_t r1 __asm__("r1") = arg2;
@@ -141,7 +147,7 @@ static inline u32_t z_arch_syscall_invoke2(u32_t arg1, u32_t arg2, u32_t call_id
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke1(u32_t arg1, u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke1(uintptr_t arg1, uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0") = arg1;
 	register u32_t r6 __asm__("r6") = call_id;
@@ -157,7 +163,7 @@ static inline u32_t z_arch_syscall_invoke1(u32_t arg1, u32_t call_id)
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke0(u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke0(uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0");
 	register u32_t r6 __asm__("r6") = call_id;

--- a/include/arch/arm/syscall.h
+++ b/include/arch/arm/syscall.h
@@ -36,9 +36,10 @@ extern "C" {
 /* Syscall invocation macros. arm-specific machine constraints used to ensure
  * args land in the proper registers.
  */
-static inline u32_t z_arch_syscall_invoke6(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t arg4, u32_t arg5, u32_t arg6,
-					  u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke6(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3, uintptr_t arg4,
+					       uintptr_t arg5, uintptr_t arg6,
+					       uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0") = arg1;
 	register u32_t r1 __asm__("r1") = arg2;
@@ -58,8 +59,10 @@ static inline u32_t z_arch_syscall_invoke6(u32_t arg1, u32_t arg2, u32_t arg3,
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke5(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t arg4, u32_t arg5, u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke5(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3, uintptr_t arg4,
+					       uintptr_t arg5,
+					       uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0") = arg1;
 	register u32_t r1 __asm__("r1") = arg2;
@@ -78,8 +81,9 @@ static inline u32_t z_arch_syscall_invoke5(u32_t arg1, u32_t arg2, u32_t arg3,
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke4(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t arg4, u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke4(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3, uintptr_t arg4,
+					       uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0") = arg1;
 	register u32_t r1 __asm__("r1") = arg2;
@@ -97,8 +101,9 @@ static inline u32_t z_arch_syscall_invoke4(u32_t arg1, u32_t arg2, u32_t arg3,
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke3(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke3(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3,
+					       uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0") = arg1;
 	register u32_t r1 __asm__("r1") = arg2;
@@ -114,7 +119,8 @@ static inline u32_t z_arch_syscall_invoke3(u32_t arg1, u32_t arg2, u32_t arg3,
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke2(u32_t arg1, u32_t arg2, u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke2(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0") = arg1;
 	register u32_t r1 __asm__("r1") = arg2;
@@ -129,7 +135,8 @@ static inline u32_t z_arch_syscall_invoke2(u32_t arg1, u32_t arg2, u32_t call_id
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke1(u32_t arg1, u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke1(uintptr_t arg1,
+					       uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0") = arg1;
 	register u32_t r6 __asm__("r6") = call_id;
@@ -142,7 +149,7 @@ static inline u32_t z_arch_syscall_invoke1(u32_t arg1, u32_t call_id)
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke0(u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke0(uintptr_t call_id)
 {
 	register u32_t ret __asm__("r0");
 	register u32_t r6 __asm__("r6") = call_id;

--- a/include/arch/x86/ia32/syscall.h
+++ b/include/arch/x86/ia32/syscall.h
@@ -34,9 +34,10 @@ extern "C" {
  * z_x86_syscall_entry_stub in userspace.S
  */
 
-static inline u32_t z_arch_syscall_invoke6(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t arg4, u32_t arg5, u32_t arg6,
-					  u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke6(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3, uintptr_t arg4,
+					       uintptr_t arg5, uintptr_t arg6,
+					       uintptr_t call_id)
 {
 	u32_t ret;
 
@@ -52,8 +53,10 @@ static inline u32_t z_arch_syscall_invoke6(u32_t arg1, u32_t arg2, u32_t arg3,
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke5(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t arg4, u32_t arg5, u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke5(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3, uintptr_t arg4,
+					       uintptr_t arg5,
+					       uintptr_t call_id)
 {
 	u32_t ret;
 
@@ -65,8 +68,9 @@ static inline u32_t z_arch_syscall_invoke5(u32_t arg1, u32_t arg2, u32_t arg3,
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke4(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t arg4, u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke4(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3, uintptr_t arg4,
+					       uintptr_t call_id)
 {
 	u32_t ret;
 
@@ -78,8 +82,9 @@ static inline u32_t z_arch_syscall_invoke4(u32_t arg1, u32_t arg2, u32_t arg3,
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke3(u32_t arg1, u32_t arg2, u32_t arg3,
-					  u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke3(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3,
+					       uintptr_t call_id)
 {
 	u32_t ret;
 
@@ -90,7 +95,8 @@ static inline u32_t z_arch_syscall_invoke3(u32_t arg1, u32_t arg2, u32_t arg3,
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke2(u32_t arg1, u32_t arg2, u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke2(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t call_id)
 {
 	u32_t ret;
 
@@ -102,7 +108,8 @@ static inline u32_t z_arch_syscall_invoke2(u32_t arg1, u32_t arg2, u32_t call_id
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke1(u32_t arg1, u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke1(uintptr_t arg1,
+					       uintptr_t call_id)
 {
 	u32_t ret;
 
@@ -114,7 +121,7 @@ static inline u32_t z_arch_syscall_invoke1(u32_t arg1, u32_t call_id)
 	return ret;
 }
 
-static inline u32_t z_arch_syscall_invoke0(u32_t call_id)
+static inline uintptr_t z_arch_syscall_invoke0(uintptr_t call_id)
 {
 	u32_t ret;
 

--- a/include/sys/arch_inlines.h
+++ b/include/sys/arch_inlines.h
@@ -350,7 +350,7 @@ void z_arch_irq_offload(irq_offload_routine_t routine, void *parameter);
  * @param call_id System call ID
  * @return Return value of the system call. Void system calls return 0 here.
  */
-static inline u32_t z_arch_syscall_invoke0(u32_t call_id);
+static inline uintptr_t z_arch_syscall_invoke0(uintptr_t call_id);
 
 /**
  * Invoke a system call with 1 argument.
@@ -362,7 +362,8 @@ static inline u32_t z_arch_syscall_invoke0(u32_t call_id);
  *	          kernel-side dispatch table
  * @return Return value of the system call. Void system calls return 0 here.
  */
-static inline u32_t z_arch_syscall_invoke1(u32_t arg1, u32_t call_id);
+static inline uintptr_t z_arch_syscall_invoke1(uintptr_t arg1,
+					       uintptr_t call_id);
 
 /**
  * Invoke a system call with 2 arguments.
@@ -375,8 +376,8 @@ static inline u32_t z_arch_syscall_invoke1(u32_t arg1, u32_t call_id);
  *	          kernel-side dispatch table
  * @return Return value of the system call. Void system calls return 0 here.
  */
-static inline u32_t z_arch_syscall_invoke2(u32_t arg1, u32_t arg2,
-					   u32_t call_id);
+static inline uintptr_t z_arch_syscall_invoke2(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t call_id);
 
 /**
  * Invoke a system call with 3 arguments.
@@ -390,8 +391,9 @@ static inline u32_t z_arch_syscall_invoke2(u32_t arg1, u32_t arg2,
  *	          kernel-side dispatch table
  * @return Return value of the system call. Void system calls return 0 here.
  */
-static inline u32_t z_arch_syscall_invoke3(u32_t arg1, u32_t arg2, u32_t arg3,
-					   u32_t call_id);
+static inline uintptr_t z_arch_syscall_invoke3(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3,
+					       uintptr_t call_id);
 
 /**
  * Invoke a system call with 4 arguments.
@@ -406,8 +408,9 @@ static inline u32_t z_arch_syscall_invoke3(u32_t arg1, u32_t arg2, u32_t arg3,
  *	          kernel-side dispatch table
  * @return Return value of the system call. Void system calls return 0 here.
  */
-static inline u32_t z_arch_syscall_invoke4(u32_t arg1, u32_t arg2, u32_t arg3,
-					   u32_t arg4, u32_t call_id);
+static inline uintptr_t z_arch_syscall_invoke4(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3, uintptr_t arg4,
+					       uintptr_t call_id);
 
 /**
  * Invoke a system call with 5 arguments.
@@ -423,9 +426,10 @@ static inline u32_t z_arch_syscall_invoke4(u32_t arg1, u32_t arg2, u32_t arg3,
  *	          kernel-side dispatch table
  * @return Return value of the system call. Void system calls return 0 here.
  */
-static inline u32_t z_arch_syscall_invoke5(u32_t arg1, u32_t arg2, u32_t arg3,
-					   u32_t arg4, u32_t arg5,
-					   u32_t call_id);
+static inline uintptr_t z_arch_syscall_invoke5(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3, uintptr_t arg4,
+					       uintptr_t arg5,
+					       uintptr_t call_id);
 
 /**
  * Invoke a system call with 6 arguments.
@@ -442,9 +446,10 @@ static inline u32_t z_arch_syscall_invoke5(u32_t arg1, u32_t arg2, u32_t arg3,
  *	          kernel-side dispatch table
  * @return Return value of the system call. Void system calls return 0 here.
  */
-static inline u32_t z_arch_syscall_invoke6(u32_t arg1, u32_t arg2, u32_t arg3,
-					   u32_t arg4, u32_t arg5, u32_t arg6,
-					   u32_t call_id);
+static inline uintptr_t z_arch_syscall_invoke6(uintptr_t arg1, uintptr_t arg2,
+					       uintptr_t arg3, uintptr_t arg4,
+					       uintptr_t arg5, uintptr_t arg6,
+					       uintptr_t call_id);
 
 /**
  * Indicate whether we are currently running in user mode

--- a/include/syscall.h
+++ b/include/syscall.h
@@ -83,9 +83,10 @@ extern "C" {
  *         return void
  *
  */
-typedef u32_t (*_k_syscall_handler_t)(u32_t arg1, u32_t arg2, u32_t arg3,
-				      u32_t arg4, u32_t arg5, u32_t arg6,
-				      void *ssf);
+typedef uintptr_t (*_k_syscall_handler_t)(uintptr_t arg1, uintptr_t arg2,
+					  uintptr_t arg3, uintptr_t arg4,
+					  uintptr_t arg5, uintptr_t arg6,
+					  void *ssf);
 
 /* True if a syscall function must trap to the kernel, usually a
  * compile-time decision.

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -20,6 +20,7 @@
 #include <app_memory/app_memdomain.h>
 #include <sys/libc-hooks.h>
 #include <sys/mutex.h>
+#include <inttypes.h>
 
 #ifdef Z_LIBC_PARTITION_EXISTS
 K_APPMEM_PARTITION_DEFINE(z_libc_partition);
@@ -753,16 +754,19 @@ void z_app_shmem_bss_zero(void)
  * Default handlers if otherwise unimplemented
  */
 
-static u32_t handler_bad_syscall(u32_t bad_id, u32_t arg2, u32_t arg3,
-				  u32_t arg4, u32_t arg5, u32_t arg6, void *ssf)
+static uintptr_t handler_bad_syscall(uintptr_t bad_id, uintptr_t arg2,
+				     uintptr_t arg3, uintptr_t arg4,
+				     uintptr_t arg5, uintptr_t arg6,
+				     void *ssf)
 {
-	LOG_ERR("Bad system call id %u invoked", bad_id);
+	LOG_ERR("Bad system call id %" PRIuPTR " invoked", bad_id);
 	z_arch_syscall_oops(_current_cpu->syscall_frame);
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }
 
-static u32_t handler_no_syscall(u32_t arg1, u32_t arg2, u32_t arg3,
-				 u32_t arg4, u32_t arg5, u32_t arg6, void *ssf)
+static uintptr_t handler_no_syscall(uintptr_t arg1, uintptr_t arg2,
+				    uintptr_t arg3, uintptr_t arg4,
+				    uintptr_t arg5, uintptr_t arg6, void *ssf)
 {
 	LOG_ERR("Unimplemented system call");
 	z_arch_syscall_oops(_current_cpu->syscall_frame);


### PR DESCRIPTION
- Low-level system call dispatch functions now use `uintptr_t` instead of `u32_t` to generically correspond to register width.
- Special handling for 64-bit return values or arguments skipped if CONFIG_64BIT