### PR TITLE
tests: benchmarks: parse output on passing benchmark

### DIFF
--- a/tests/benchmarks/timing_info/testcase.yaml
+++ b/tests/benchmarks/timing_info/testcase.yaml
@@ -4,8 +4,11 @@ tests:
     tags: benchmark
     harness: console
     harness_config:
+      type: one_line
       record:
         regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"
   benchmark.timing.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_args: CONF_FILE=prj_userspace.conf
@@ -13,5 +16,8 @@ tests:
     tags: benchmark userspace
     harness: console
     harness_config:
+      type: one_line
       record:
         regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"


### PR DESCRIPTION
Parse output of test to verify success, this was previously treated as a
test and now it is using the console handler, so we need to verify
success using regex.

Fixes: #20177