### PR TITLE
west.yml: Update ci-tools to run pylint on scripts/sanitycheck

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -29,7 +29,7 @@ manifest:
       revision: 04ff67a0826a51041e51034faf8fc4d3eeacd846
       path: modules/hal/atmel
     - name: ci-tools
-      revision: e01f3bce2a94847253369efb9a081f5c0e9ec882
+      revision: 20aa511fbd302ba8429a9ab04ee96c201b547743
       path: tools/ci-tools
     - name: civetweb
       revision: 99129c5efc907ea613c4b73ccff07581feb58a7a


### PR DESCRIPTION
Get this commit in:

    check_compliance.py: Run pylint on scripts/sanitycheck

    https://github.com/zephyrproject-rtos/zephyr/pull/20212 fixes the
    last pylint warnings in the script. Once that one is in, this can be
    merged.