### PR TITLE
drivers: CAN: Limit the DLC to 8

### DIFF
--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -56,6 +56,11 @@ int can_loopback_send(struct device *dev, const struct zcan_frame *frame,
 		    "standard" : "extended"
 		    , frame->rtr == CAN_DATAFRAME ? "no" : "yes");
 
+	if (frame->dlc > CAN_MAX_DLC) {
+		LOG_ERR("DLC of %d exceeds maximum (%d)", frame->dlc, CAN_MAX_DLC);
+		return CAN_TX_EINVAL;
+	}
+
 	if (!data->loopback) {
 
 		return 0;

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -388,6 +388,11 @@ static int mcp2515_send(struct device *dev, const struct zcan_frame *msg,
 	u8_t nnn;
 	u8_t tx_frame[MCP2515_FRAME_LEN];
 
+	if (msg->dlc > CAN_MAX_DLC) {
+		LOG_ERR("DLC of %d exceeds maximum (%d)", msg->dlc, CAN_MAX_DLC);
+		return CAN_TX_EINVAL;
+	}
+
 	if (k_sem_take(&dev_data->tx_sem, timeout) != 0) {
 		return CAN_TIMEOUT;
 	}

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -296,6 +296,11 @@ static int mcux_flexcan_send(struct device *dev, const struct zcan_frame *msg,
 	status_t status;
 	int alloc;
 
+	if (msg->dlc > CAN_MAX_DLC) {
+		LOG_ERR("DLC of %d exceeds maximum (%d)", msg->dlc, CAN_MAX_DLC);
+		return CAN_TX_EINVAL;
+	}
+
 	while (true) {
 		alloc = mcux_get_tx_alloc(data);
 		if (alloc >= 0) {

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -548,7 +548,11 @@ int can_stm32_send(struct device *dev, const struct zcan_frame *msg,
 		    , msg->rtr == CAN_DATAFRAME ? "no" : "yes");
 
 	__ASSERT(msg->dlc == 0U || msg->data != NULL, "Dataptr is null");
-	__ASSERT(msg->dlc <= CAN_MAX_DLC, "DLC > 8");
+
+	if (msg->dlc > CAN_MAX_DLC) {
+		LOG_ERR("DLC of %d exceeds maximum (%d)", msg->dlc, CAN_MAX_DLC);
+		return CAN_TX_EINVAL;
+	}
 
 	if (can->ESR & CAN_ESR_BOFF) {
 		return CAN_TX_BUS_OFF;

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -47,6 +47,9 @@ extern "C" {
 /** unexpected error */
 #define CAN_TX_UNKNOWN  (-5)
 
+/** invalid parameter */
+#define CAN_TX_EINVAL   (-22)
+
 /** attach_* failed because there is no unused filter left*/
 #define CAN_NO_FREE_FILTER (-1)
 

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -593,6 +593,21 @@ static void test_send_receive_wrong_id(void)
 	can_detach(can_dev, filter_id);
 }
 
+/*
+ * Check if a call with dlc > CAN_MAX_DLC returns CAN_TX_EINVAL
+ */
+static void test_send_invalid_dlc(void)
+{
+	struct zcan_frame frame;
+	int ret;
+
+	frame.dlc = CAN_MAX_DLC + 1;
+
+	ret = can_send(can_dev, &frame, TEST_SEND_TIMEOUT, tx_std_isr, NULL);
+	zassert_equal(ret, CAN_TX_EINVAL,
+		      "ret [%d] not equal to %d", ret, CAN_TX_EINVAL);
+}
+
 void test_main(void)
 {
 	k_sem_init(&rx_isr_sem, 0, 1);
@@ -612,6 +627,7 @@ void test_main(void)
 			 ztest_unit_test(test_send_receive_std_masked),
 			 ztest_unit_test(test_send_receive_ext_masked),
 			 ztest_unit_test(test_send_receive_buffer),
-			 ztest_unit_test(test_send_receive_wrong_id));
+			 ztest_unit_test(test_send_receive_wrong_id),
+			 ztest_unit_test(test_send_invalid_dlc));
 	ztest_run_test_suite(can_driver);
 }


### PR DESCRIPTION
This commit limits the data length code to eight.
DLC > 8 returns a newly introduced CAN_TX_EINVAL error code.