### PR TITLE
spinlock: Ensure SPIN_VALIDATE is not defined when having only one cpu.

### DIFF
--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -17,7 +17,8 @@
  * even more poorly supported.
  */
 #if (CONFIG_FLASH_SIZE == 0) || (CONFIG_FLASH_SIZE > 32)
-#if defined(CONFIG_ASSERT) && (CONFIG_MP_NUM_CPUS < 4)
+#if defined(CONFIG_ASSERT) && \
+	(CONFIG_MP_NUM_CPUS > 1) && (CONFIG_MP_NUM_CPUS < 4)
 #include <sys/__assert.h>
 #include <stdbool.h>
 struct k_spinlock;


### PR DESCRIPTION
For small targets having only one cpu, the overhead of the
spinlock validation is undesirable and not needed.
This PR serves to ensure that spinlock validation is disabled for 
targets with only one cpu, but which still needs asserts enabled.