### PR TITLE
net: ip: ipv6_nbr: Fix uninitialized variable in ipv6_nbr

### DIFF
--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -499,7 +499,7 @@ static void ipv6_nd_remove_old_stale_nbr(void)
 	struct net_nbr *nbr = NULL;
 	struct net_ipv6_nbr_data *data = NULL;
 	int nbr_idx = -1;
-	u32_t oldest;
+	u32_t oldest = UINT32_MAX;
 	int i;
 
 	k_sem_take(&nbr_lock, K_FOREVER);


### PR DESCRIPTION
Setting it to `UINT32_MAX`, as it is subsequently overwritten with
`MIN(oldest, something_else)`.

This change fixes the failure I observed in https://app.shippable.com/github/zephyrproject-rtos/zephyr/runs/55205/2/console

Tested with `./scripts/sanitycheck -p litex_vexriscv -T tests/subsys/jwt/` with `-Werror=maybe-uninitialized` added manually via CMake flags.