### PR TITLE
sanitycheck: fix filtering for boards without DTS

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1897,9 +1897,12 @@ class FilterBuilder(CMake):
         filter_data.update(self.cmake_cache)
 
         dts_path = os.path.join(self.build_dir, "zephyr", self.platform.name + ".dts.pre.tmp")
-        if self.testcase and self.testcase.tc_filter and os.path.exists(dts_path):
+        if self.testcase and self.testcase.tc_filter:
             try:
-                edt = edtlib.EDT(dts_path, [os.path.join(ZEPHYR_BASE, "dts", "bindings")])
+                if os.path.exists(dts_path):
+                    edt = edtlib.EDT(dts_path, [os.path.join(ZEPHYR_BASE, "dts", "bindings")])
+                else:
+                    edt = None
                 res = expr_parser.parse(self.testcase.tc_filter, filter_data, edt)
 
             except (ValueError, SyntaxError) as se:


### PR DESCRIPTION
If we don't have a DTS (like nrf52_bsim) we shouldn't try and create an
EDT, but we still need to call expr_parser.parse to filter testcases.
So move the os.path.exists(dts_path) around the creation of the EDT.

Fixes: #20371

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>