### PR TITLE
bluetooth: host: fix missing log_strdup

### DIFF
--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -168,7 +168,7 @@ static int set(const char *name, size_t len_rd, settings_read_cb read_cb,
 		} else {
 			bt_dev.name[len] = '\0';
 
-			BT_DBG("Name set to %s", bt_dev.name);
+			BT_DBG("Name set to %s", log_strdup(bt_dev.name));
 		}
 		return 0;
 	}


### PR DESCRIPTION
Fix missing log_strdup when loading bt/name setting

Signed-off-by: François Delawarde <fnde@oticon.com>