### PR TITLE
cmake: dts: Remove duplicates from DTS_ROOT

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -33,6 +33,8 @@ list(APPEND
   ${ZEPHYR_BASE}
   )
 
+list(REMOVE_DUPLICATES DTS_ROOT)
+
 set(dts_files
   ${DTS_SOURCE}
   ${shield_dts_files}


### PR DESCRIPTION
If duplicates gets passed to scripts/dts/gen_defines.py, the bindings in
those directories will be loaded twice and actually get in conflict with
itself.

Signed-off-by: Tobias Svehagen <tobias.svehagen@gmail.com>