### PR TITLE
Bluetooth: Reduce severity of unavoidable warnings

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4993,7 +4993,7 @@ static int bt_init(void)
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		if (!bt_dev.id_count) {
-			BT_WARN("No ID address. App must call settings_load()");
+			BT_INFO("No ID address. App must call settings_load()");
 			return 0;
 		}
 

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -129,7 +129,7 @@ static void dev_comp_data_get(struct bt_mesh_model *model,
 
 	page = net_buf_simple_pull_u8(buf);
 	if (page != 0U) {
-		BT_WARN("Composition page %u not available", page);
+		BT_DBG("Composition page %u not available", page);
 		page = 0U;
 	}
 

--- a/subsys/bluetooth/mesh/proxy.c
+++ b/subsys/bluetooth/mesh/proxy.c
@@ -1138,7 +1138,7 @@ static s32_t gatt_proxy_advertise(struct bt_mesh_subnet *sub)
 	BT_DBG("");
 
 	if (conn_count == CONFIG_BT_MAX_CONN) {
-		BT_WARN("Connectable advertising deferred (max connections)");
+		BT_DBG("Connectable advertising deferred (max connections)");
 		return remaining;
 	}
 


### PR DESCRIPTION
Reduces the severity of warnings that happen from normal behavior, or
can't be prevented by the user:
- "No ID address" in hci_core.c: Reduced to an informational warning, as
  this will always output with the expected usage. This isn't useful
  information for 99.9% of users, and pollutes the output of all samples
  using the module.
- "Composition page %u not available" in cfg_srv.c: According to the
  Mesh Profile Specification section 4.4.2.2.2, the client is expected
  to send page=0xff. Reduced to a debug message.
- "Connectable advertising deferred" in proxy.c: Gets logged every 10
  seconds when in a Mesh Proxy connection. This is not useful
  information unless the user is debugging the proxy module. Reduced to
  a debug message.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>