### PR TITLE
dts: stm32: Introduce linux like pinctrl bindings

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -51,6 +51,8 @@
 
 &usart1 {
 	current-speed = <115200>;
+	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pb7>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/dts/arm/st/l4/stm32l4-pinctrl.dtsi
+++ b/dts/arm/st/l4/stm32l4-pinctrl.dtsi
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pinctrl/stm32-pinctrl.h>
+
+/ {
+	soc {
+		pinctrl: pin-controller@48000000 {
+			/* USART1_TX */
+			usart1_tx_pa9: usart1_tx_1 {
+				pinmux = <STM32_PINMUX('A', 9, AF7)>;
+				drive-push-pull;
+				bias-pull-up;
+			};
+			usart1_tx_pb6: usart1_tx_2 {
+				pinmux = <STM32_PINMUX('B', 6, AF7)>;
+				drive-push-pull;
+				bias-pull-up;
+			};
+			/* USART1_RX */
+			usart1_rx_pa10: usart1_rx_1 {
+				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-disable;
+			};
+			usart1_rx_pb7: usart1_rx_2 {
+				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-disable;
+			};
+			/* USART2_TX */
+			usart2_tx_pa2: usart2_tx_1 {
+				pinmux = <STM32_PINMUX('A', 2, AF7)>;
+				bias-disable;
+			};
+			/* USART2_RX */
+			usart2_rx_pa3: usart2_rx_1 {
+				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-disable;
+			};
+			usart2_rx_pa15: usart2_rx_2 {
+				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-disable;
+			};
+		};
+	};
+};

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -7,6 +7,7 @@
 
 
 #include <arm/armv7-m.dtsi>
+#include <st/l4/stm32l4-pinctrl.dtsi>
 #include <dt-bindings/clock/stm32_clock.h>
 #include <dt-bindings/i2c/i2c.h>
 #include <dt-bindings/gpio/gpio.h>

--- a/dts/arm/st/l4/stm32l471-pinctrl.dtsi
+++ b/dts/arm/st/l4/stm32l471-pinctrl.dtsi
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pinctrl/stm32-pinctrl.h>
+
+/ {
+	soc {
+		pinctrl: pin-controller@48000000 {
+			/* USART3_TX */
+			usart3_tx_pb10: usart3_tx_1 {
+				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				drive-push-pull;
+				bias-pull-up;
+			};
+			usart3_tx_pc4: usart3_tx_2 {
+				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				drive-push-pull;
+				bias-pull-up;
+			};
+			usart3_tx_pc11: usart3_tx_3 {
+				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				drive-push-pull;
+				bias-pull-up;
+			};
+			/* USART3_RX */
+			usart3_rx_pb10: usart3_rx_1 {
+				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
+			};
+			usart3_rx_pc4: usart3_rx_2 {
+				pinmux = <STM32_PINMUX('C', 4, AF7)>;
+				bias-pull-up;
+			};
+			usart3_rx_pc11: usart3_rx_3 {
+				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
+			};
+		};
+	};
+};

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -11,6 +11,50 @@ properties:
     reg:
       required: true
 
-pinmux-cells:
-  - pin
-  - function
+child-binding:
+    title: STM32 PIN configurations
+
+    description: |
+        This binding gives a base representation of the STM32 pins configration
+
+    properties:
+        pinmux:
+          required: false
+          type: int
+
+        bias-disable:
+          required: false
+          type: boolean
+
+        bias-pull-down:
+          required: false
+          type: boolean
+
+        bias-pull-up:
+          required: false
+          type: boolean
+
+        drive-push-pull:
+          required: false
+          type: boolean
+
+        drive-open-drain:
+          required: false
+          type: boolean
+
+        output-low:
+          required: false
+          type: boolean
+
+        output-high:
+          required: false
+          type: boolean
+
+        slew-rate:
+          type: int
+          default: 2
+          enum:
+          - 0
+          - 1
+          - 2
+          - 3

--- a/include/dt-bindings/pinctrl/stm32-pinctrl-common.h
+++ b/include/dt-bindings/pinctrl/stm32-pinctrl-common.h
@@ -7,6 +7,31 @@
 #ifndef ZEPHYR_STM32_PINCTRL_COMMON_H_
 #define ZEPHYR_STM32_PINCTRL_COMMON_H_
 
+/* Extracted from Linux: include/dt-bindings/pinctrl/stm32-pinfunc.h */
+/*  define PIN modes */
+#define GPIO	0x0
+#define AF0	0x1
+#define AF1	0x2
+#define AF2	0x3
+#define AF3	0x4
+#define AF4	0x5
+#define AF5	0x6
+#define AF6	0x7
+#define AF7	0x8
+#define AF8	0x9
+#define AF9	0xa
+#define AF10	0xb
+#define AF11	0xc
+#define AF12	0xd
+#define AF13	0xe
+#define AF14	0xf
+#define AF15	0x10
+#define ANALOG	0x11
+
+/* define Pins number*/
+#define PIN_NO(port, line)	(((port) - 'A') * 0x10 + (line))
+
+#define STM32_PINMUX(port, line, mode) (((PIN_NO(port, line)) << 8) | (mode))
 
 /**
  * @brief numerical IDs for IO ports


### PR DESCRIPTION
Introduce Linux like dts bindings for stm32 devices.
Reason for this change is described with more detail in dedicated commit.

Ultimate goal is to generate -pinctrl.dtsi files from STM23CubeMx GPIO IP database (which is available for download to all users). Scripts could then be used for generation and correctness verification.

While the number of GPIO IPs to describe is limited (54 GPIO IPs for 988 MCUs according to latest database in CubeMx 5.4), I'd like we could re-use the current inclusion/inheritance model currently in use in `dts/arm/st/*`. This means that each stm32f/l/g(/...)xxx.dtsi would include a matching stm32f/l/gxxx-pinctrl.dtsi describing the pin configuration of the peripheral described in stm32f/l/gxxx.dtsi. Aim is to minimize pinctrl file sizes (and information redundancy, potential errors, ..)
Alternative option would be to provide stm32f/l/gxxx-pinctrl.dtsi de-correlated from stm32f/l/gxxx.dtsi but describing various GPIO IPs and using its own inclusion/inheritance schema. This should further reduce the number of duplicates, but would require additional verification effort (which might be feasible with appropriate tooling)


EDIT: Aim of this draft PR is to get early feedbacks on the direction
