### PR TITLE
tests: fcb: initialize buffers to avoid processing uninitialized values

### DIFF
--- a/tests/subsys/fs/fcb/src/fcb_test_last_of_n.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_last_of_n.c
@@ -14,7 +14,7 @@ void fcb_test_last_of_n(void)
 	int rc;
 	struct fcb_entry loc;
 	struct fcb_entry areas[ENTRIES];
-	u8_t test_data[128];
+	u8_t test_data[128] = {0};
 	u8_t i;
 
 	fcb = &test_fcb;

--- a/tests/subsys/fs/fcb/src/fcb_test_multiple_scratch.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_multiple_scratch.c
@@ -12,7 +12,7 @@ void fcb_test_multi_scratch(void)
 	struct fcb *fcb;
 	int rc;
 	struct fcb_entry loc;
-	u8_t test_data[128];
+	u8_t test_data[128] = {0};
 	int elem_cnts[4];
 	int idx;
 	int cnts[4];

--- a/tests/subsys/fs/fcb/src/fcb_test_rotate.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_rotate.c
@@ -13,7 +13,7 @@ void fcb_test_rotate(void)
 	int rc;
 	int old_id;
 	struct fcb_entry loc;
-	u8_t test_data[128];
+	u8_t test_data[128] = {0};
 	int elem_cnts[2] = {0, 0};
 	int cnts[2];
 	struct append_arg aa_arg = {


### PR DESCRIPTION
Running the test under valgrind identified three places where an
uninitialized stack buffer was used as the source of data over which a
CRC was incidently calculated, causing an uninitialized value warning
in the CRC calculation.  Zero out the source buffers before using them
as a data source.

Closes #20105