### PR TITLE
github: Add support for using github workflow labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,135 @@
+"area: Modem":
+  - drivers/modem/**
+
+"area: PWM":
+  - drivers/pwm/**
+
+"area: C Library":
+  - lib/libc/**
+
+"area: Device Tree":
+  - dts/**
+  - "**/*.dts"
+
+"area: Watchdog":
+  - drivers/watchdog/**
+
+"area: Sensors":
+  - drivers/sensor/**
+
+"area: ADC":
+  - drivers/adc/**
+
+"area: Counter":
+  - drivers/counter/**
+
+"area: Timer":
+  - drivers/timer/**
+
+"area: I2S":
+  - drivers/i2s/**
+
+"area: I2C":
+  - drivers/i2c/**
+
+"area: SPI":
+  - drivers/spi/**
+
+"area: Boards":
+  - boards/**
+
+"area: POSIX":
+  - lib/posix/**
+
+"area: native port":
+  - arch/posix/**
+  - soc/posix/**
+  - "**/*native_posix.*"
+
+"area: X86":
+  - arch/x86/**
+
+"area: ARM":
+  - arch/arm/**
+
+"area: NIOS2":
+  - arch/nios2/**
+
+"area: Xtensa":
+  - arch/xtensa/**
+
+"area: RISCv32":
+  - arch/riscv32/**
+
+"area: ARC":
+  - arch/arc/**
+
+"area: Networking":
+  - subsys/net/**
+  - samples/net/**
+  - tests/net/**
+
+"area: Logging":
+  - subsys/logging/**
+
+"area: Shell":
+  - subsys/shell/**
+
+"area: Console":
+  - subsys/console/**
+
+"area: Testing Suite":
+  - subsys/testsuite/**
+
+"area: Settings":
+  - subsys/settings/**
+
+"area: File System":
+  - subsys/fs/**
+
+"area: Storage":
+  - subsys/storage/**
+
+"area: Bluetooth":
+  - subsys/bluetooth/**
+  - "**/*bluetooth.*"
+
+"area: Bluetooth Mesh":
+  - subsys/bluetooth/mesh/**
+
+"area: API":
+  - include/**
+
+"area: Samples":
+  - samples/**
+
+"area: Tests":
+  - tests/**
+
+"area: Kernel":
+  - kernel/**
+  - tests/kernel/**
+
+"EXT":
+  - ext/**
+
+"area: Documentation":
+  - doc/**
+  - "**/*.rst"
+  - "**/*.txt"
+
+"area: Build System":
+  - cmake/**
+  - CMakeLists.txt
+
+"area: Kconfig":
+  - scripts/kconfig/**
+  - Kconfig
+  - Kconfig.zephyr
+
+"area: Sanitycheck":
+  - scripts/sanitycheck
+  - scripts/sanity_chk/**
+
+"area: Modules":
+  - west.yml

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+ /* SPDX-License-Identifier: Apache-2.0 */
 
 /dts-v1/;
 

--- a/west.yml
+++ b/west.yml
@@ -29,7 +29,7 @@ manifest:
       revision: 04ff67a0826a51041e51034faf8fc4d3eeacd846
       path: modules/hal/atmel
     - name: ci-tools
-      revision: 20aa511fbd302ba8429a9ab04ee96c201b547743
+      revision: pull/106/head
       path: tools/ci-tools
     - name: civetweb
       revision: 99129c5efc907ea613c4b73ccff07581feb58a7a


### PR DESCRIPTION
Converted the ci-tools/scripts/what_changed.py table into
.github/labeler.yml.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>