### PR TITLE
dts: Fix testedtlib dep_ordinal test and tweak dependencies interface slightly

### DIFF
--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -161,18 +161,6 @@ class EDT:
         return "<EDT for '{}', binding directories '{}'>".format(
             self.dts_path, self.bindings_dirs)
 
-    def required_by(self, node):
-        """
-        Returns a list of Nodes that have direct dependencies on 'node'.
-        """
-        return self._graph.required_by(node)
-
-    def depends_on(self, node):
-        """
-        Returns a list of Nodes on which 'node' directly depends.
-        """
-        return self._graph.depends_on(node)
-
     def scc_order(self):
         """
         Returns a list of lists of Nodes where all elements of each list
@@ -655,6 +643,12 @@ class Node:
       The ordinal is defined for all Nodes including those that are not
       'enabled', and is unique among nodes in its EDT 'nodes' list.
 
+    required_by:
+      A list with the nodes that directly depend on the node
+
+    depends_on:
+      A list with the nodes that the node directly depends on
+
     enabled:
       True unless the node has 'status = "disabled"'
 
@@ -770,6 +764,16 @@ class Node:
         # would need to be kept in mind.
         return {name: self.edt._node2enode[node]
                 for name, node in self._node.nodes.items()}
+
+    @property
+    def required_by(self):
+        "See the class docstring"
+        return self.edt._graph.required_by(self)
+
+    @property
+    def depends_on(self):
+        "See the class docstring"
+        return self.edt._graph.depends_on(self)
 
     @property
     def enabled(self):

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -70,16 +70,16 @@ Directories with bindings:
                 continue
 
             requires_text = ""
-            if edt.depends_on(node):
+            if node.depends_on:
                 requires_text = "Requires:\n"
-                for depends in edt.depends_on(node):
+                for depends in node.depends_on:
                     requires_text += "  {} {}\n".format(depends.dep_ordinal, depends.path)
                 requires_text += "\n"
 
             supports_text = ""
-            if edt.required_by(node):
+            if node.required_by:
                 supports_text = "Supports:\n"
-                for required in edt.required_by(node):
+                for required in node.required_by:
                     supports_text += "  {} {}\n".format(required.dep_ordinal, required.path)
                 supports_text += "\n"
 

--- a/scripts/dts/grutils.py
+++ b/scripts/dts/grutils.py
@@ -20,7 +20,7 @@ class Graph:
     already be available.
     """
 
-    def __init__ (self, root=None):
+    def __init__(self, root=None):
         self.__roots = None
         if root is not None:
             self.__roots = {root}
@@ -28,7 +28,7 @@ class Graph:
         self.__reverse_map = collections.defaultdict(set)
         self.__nodes = set()
 
-    def add_edge (self, source, target):
+    def add_edge(self, source, target):
         """
         Add a directed edge from the C{source} to the C{target}.
 
@@ -40,7 +40,7 @@ class Graph:
         self.__nodes.add(source)
         self.__nodes.add(target)
 
-    def roots (self):
+    def roots(self):
         """
         Return the set of nodes calculated to be roots (i.e., those
         that have no incoming edges).
@@ -56,7 +56,7 @@ class Graph:
                     self.__roots.add(n)
         return self.__roots
 
-    def _tarjan (self):
+    def _tarjan(self):
         # Execute Tarjan's algorithm on the graph.
         #
         # Tarjan's algorithm
@@ -93,7 +93,7 @@ class Graph:
                 scc[0].dep_ordinal = ordinal
                 ordinal += 1
 
-    def _tarjan_root (self, v):
+    def _tarjan_root(self, v):
         # Do the work of Tarjan's algorithm for a given root node.
 
         if self.__tarjan_index.get(v) is not None:
@@ -118,7 +118,7 @@ class Graph:
                     break
             self.__scc_order.append(scc)
 
-    def scc_order (self):
+    def scc_order(self):
         """Return the strongly-connected components in order.
 
         The data structure is a list, in dependency order, of strongly
@@ -133,10 +133,10 @@ class Graph:
         return self.__scc_order
     __scc_order = None
 
-    def depends_on (self, node):
+    def depends_on(self, node):
         """Get the nodes that 'node' directly depends on."""
         return sorted(self.__edge_map[node], key=attrgetter('path'))
 
-    def required_by (self, node):
+    def required_by(self, node):
         """Get the nodes that directly depend on 'node'."""
         return sorted(self.__reverse_map[node], key=attrgetter('path'))

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -225,10 +225,10 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
 
     verify_eq(edt.get_node("/").dep_ordinal, 0)
     verify_eq(edt.get_node("/in-dir-1").dep_ordinal, 1)
-    if edt.get_node("/") not in edt.depends_on(edt.get_node("/in-dir-1")):
-        fail("/ depends-on /in-dir-1")
-    if edt.get_node("/in-dir-1") not in edt.required_by(edt.get_node("/")):
-        fail("/in-dir-1 required-by /")
+    if edt.get_node("/") not in edt.get_node("/in-dir-1").depends_on:
+        fail("/ should be a direct dependency of /in-dir-1")
+    if edt.get_node("/in-dir-1") not in edt.get_node("/").required_by:
+        fail("/in-dir-1 should directly depend on /")
 
     print("all tests passed")
 

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -223,15 +223,8 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
     # Test dependency relations
     #
 
-    #for node in edt.nodes:
-    #    print("{}: {}".format(node.path, node.ordinal))
-    #    for before in edt.depends_on(node):
-    #        print("  Requires: {} {}".format(before.ordinal, before.path))
-    #    for after in edt.required_by(node):
-    #        print("  Supports: {} {}".format(after.ordinal, after.path))
-
-    verify_eq(edt.get_node("/").ordinal, 0)
-    verify_eq(edt.get_node("/in-dir-1").ordinal, 1)
+    verify_eq(edt.get_node("/").dep_ordinal, 0)
+    verify_eq(edt.get_node("/in-dir-1").dep_ordinal, 1)
     if edt.get_node("/") not in edt.depends_on(edt.get_node("/in-dir-1")):
         fail("/ depends-on /in-dir-1")
     if edt.get_node("/in-dir-1") not in edt.required_by(edt.get_node("/")):


### PR DESCRIPTION
Three commits:

```
dts: testedtlib: Fix broken Node.dep_ordinal test

Updating the test was overlooked when Node.ordinal was renamed to
Node.dep_ordinal.
```

```
dts: grutils: Remove spaces before '(' in function definitions

Just to make it a bit more consistent with the rest of the code.
```

```
dts: edtlib: Turn edt.required_by()/depends_on() into Node attributes

Turns

    edt.required_by(node)
    edt.depends_on(node)

into

    node.required_by
    node.depends_on

which might be a bit more readable.

One drawback is that @Property hides that there's some slight overhead
in accessing them, but I suspect it won't be meaningful. Caching could
be added if it ever turns out to be.
```

`testdtlib.py` and `testedtlib.py` currently require Python 3.6+ (because they rely on dictionary insertion order being preserved), while CI uses Python 3.5, which is why this wasn't caught automatically.

Could use `collections.OrderedDict` to work around it, but haven't gotten around to it.