### PR TITLE
dts: nxp: remove unused pinmux

### DIFF
--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -136,9 +136,6 @@
 			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1034 10>;
 			label = "UART_0";
 
-			pinctrl-0 = <&uart0_default>;
-			pinctrl-names = "default";
-
 			status = "disabled";
 		};
 
@@ -197,26 +194,12 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004c000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
-
-			spi0_default: spi0_default {
-				miso-mosi-clk {
-					pins = <1>, <2>, <3>;
-					function = <2>;
-				};
-			};
 		};
 
 		pinmux_e: pinmux@4004d000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004d000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
-
-			uart0_default: uart0_default {
-				rx-tx {
-					pins = <0>, <1>;
-					function = <3>;
-				};
-			};
 		};
 
 		gpioa: gpio@400ff000 {
@@ -272,9 +255,6 @@
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 12>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-
-			pinctrl-0 = <&spi0_default>;
-			pinctrl-names = "default";
 		};
 
 		spi1: spi@4002d000 {

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -142,9 +142,6 @@
 			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1034 10>;
 			label = "UART_0";
 
-			pinctrl-0 = <&uart0_default>;
-			pinctrl-names = "default";
-
 			status = "disabled";
 		};
 
@@ -213,26 +210,6 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
-			uart0_default: uart0_default {
-				rx-tx {
-					pins = <16>, <17>;
-					function = <3>;
-				};
-			};
-
-			uart0_lpm: uart0_lpm {
-				rx-tx {
-					pins = <16>, <17>;
-					function = <0>;
-				};
-			};
-
-			spi0_default: spi0_default {
-				miso-mosi-clk {
-					pins = <10>, <9>;
-					function = <2>;
-				};
-			};
 		};
 
 		pinmux_c: pinmux@4004b000 {
@@ -306,9 +283,6 @@
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 12>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-
-			pinctrl-0 = <&spi0_default>;
-			pinctrl-names = "default";
 		};
 
 		spi1: spi@4002d000 {

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -108,9 +108,6 @@
 			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1034 10>;
 			label = "UART_0";
 
-			pinctrl-0 = <&uart0_default>;
-			pinctrl-names = "default";
-
 			status = "disabled";
 		};
 
@@ -133,9 +130,6 @@
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 12>;
 			label = "UART_2";
 
-			pinctrl-0 = <&uart2_default>;
-			pinctrl-names = "default";
-
 			status = "disabled";
 		};
 
@@ -143,26 +137,12 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
-
-			uart0_default: uart0_default {
-				rx-tx {
-					pins = <1>, <2>;
-					function = <2>;
-				};
-			};
 		};
 
 		pinmux_b: pinmux@4004a000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
-
-			spi1_default: spi1_default {
-				miso-mosi-clk {
-					pins = <17>, <16>, <11>;
-					function = <2>;
-				};
-			};
 		};
 
 		pinmux_c: pinmux@4004b000 {
@@ -175,13 +155,6 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004c000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
-
-			uart2_default: uart2_default {
-				rx-tx {
-					pins = <2>, <3>;
-					function = <3>;
-				};
-			};
 		};
 
 		pinmux_e: pinmux@4004d000 {
@@ -253,8 +226,6 @@
 			label = "SPI_1";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 13>;
 
-			pinctrl-0 = <&spi1_default>;
-			pinctrl-names = "default";
 			#address-cells = <1>;
 			#size-cells = <0>;
 

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -97,9 +97,6 @@
 			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1038 20>;
 			label = "UART_0";
 
-			pinctrl-0 = <&lpuart0_default>;
-			pinctrl-names = "default";
-
 			status = "disabled";
 		};
 
@@ -107,13 +104,6 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
-
-			spi1_default: spi1_default {
-				mosi-miso-sck-pcs0 {
-					pins = <16>, <17>, <18>, <19>;
-					function = <2>;
-				};
-			};
 		};
 
 		pinmux_b: pinmux@4004a000 {
@@ -126,34 +116,6 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
-
-			lpuart0_default: lpuart0_default {
-				rx-tx {
-					pins = <6>, <7>;
-					function = <4>;
-				};
-			};
-
-			lpuart0_alt1: lpuart0_alt1 {
-				rx-tx {
-					pins = <17>, <18>;
-					function = <4>;
-				};
-			};
-
-			lpuart0_alt2: lpuart0_alt2 {
-				rx-tx-cts-rts {
-					pins = <2>, <3>, <0>, <1>;
-					function = <4>;
-				};
-			};
-
-			spi0_default: spi0_default {
-				mosi-miso-clk-pcs0 {
-					pins = <18>, <17>, <16>, <19>;
-					function = <2>;
-				};
-			};
 		};
 
 		gpioa: gpio@400ff000 {
@@ -189,8 +151,6 @@
 			label = "SPI_0";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 12>;
 
-			pinctrl-0 = <&spi0_default>;
-			pinctrl-names = "default";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -100,9 +100,6 @@
 			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1038 20>;
 			label = "UART_0";
 
-			pinctrl-0 = <&lpuart0_default>;
-			pinctrl-names = "default";
-
 			status = "disabled";
 		};
 
@@ -110,13 +107,6 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
-
-			spi1_default: spi1_default {
-				mosi-miso-sck-pcs0 {
-					pins = <16>, <17>, <18>, <19>;
-					function = <2>;
-				};
-			};
 		};
 
 		pinmux_b: pinmux@4004a000 {
@@ -129,34 +119,6 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
-
-			lpuart0_default: lpuart0_default {
-				rx-tx {
-					pins = <6>, <7>;
-					function = <4>;
-				};
-			};
-
-			lpuart0_alt1: lpuart0_alt1 {
-				rx-tx {
-					pins = <17>, <18>;
-					function = <4>;
-				};
-			};
-
-			lpuart0_alt2: lpuart0_alt2 {
-				rx-tx-cts-rts {
-					pins = <2>, <3>, <0>, <1>;
-					function = <4>;
-				};
-			};
-
-			spi0_default: spi0_default {
-				mosi-miso-clk-pcs0 {
-					pins = <18>, <17>, <16>, <19>;
-					function = <2>;
-				};
-			};
 		};
 
 		gpioa: gpio@400ff000 {
@@ -192,8 +154,6 @@
 			label = "SPI_0";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 12>;
 
-			pinctrl-0 = <&spi0_default>;
-			pinctrl-names = "default";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};


### PR DESCRIPTION
We've never used the pinctrl from dts so remove it as we hopefully
replace it with something useful.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>