### PR TITLE
soc: nxp_imx: Remove CLOCK_CONTROL_IMX_CCM config

### DIFF
--- a/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
+++ b/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
@@ -11,13 +11,6 @@ config SOC
 config FLOAT
 	default y
 
-if CLOCK_CONTROL
-
-config CLOCK_CONTROL_IMX_CCM
-	def_bool y
-
-endif # CLOCK_CONTROL
-
 if GPIO
 
 config GPIO_IMX

--- a/soc/arm/nxp_imx/mcimx7_m4/Kconfig.defconfig.mcimx7_m4
+++ b/soc/arm/nxp_imx/mcimx7_m4/Kconfig.defconfig.mcimx7_m4
@@ -11,13 +11,6 @@ config SOC
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 200000000
 
-if CLOCK_CONTROL
-
-config CLOCK_CONTROL_IMX_CCM
-	default y
-
-endif # CLOCK_CONTROL
-
 config GPIO
 	default y
 

--- a/west.yml
+++ b/west.yml
@@ -83,7 +83,7 @@ manifest:
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs
     - name: hal_nxp
-      revision: 34460db49655aed281e6f20645ee7d8a70421bdd
+      revision: c6ce9b7e8ddb501ca6d54e927e1602cb5f7a7183
       path: modules/hal/nxp
     - name: open-amp
       revision: 9b591b289e1f37339bd038b5a1f0e6c8ad39c63a


### PR DESCRIPTION
There is no imx ccm shim driver in drivers/clock_control. This config
was only used to conditionally compile nxp hal drivers, even though the
imx6/7 soc init always needs them.

Updates the nxp hal to unconditionally compile the ccm drivers and
removes the unnecessary config symbol.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Depends on zephyrproject-rtos/hal_nxp#19

Alternative to #20132