### PR TITLE
cmake: Use zephyr_link_libraries in toolchain_ld_cpp

### DIFF
--- a/cmake/linker/ld/target_cpp.cmake
+++ b/cmake/linker/ld/target_cpp.cmake
@@ -4,7 +4,7 @@
 
 macro(toolchain_ld_cpp)
 
-  zephyr_ld_options(
+  zephyr_link_libraries(
     -lstdc++
   )
 


### PR DESCRIPTION
The toolchain_ld_cpp macro currently uses zephyr_ld_options function
to link libstdc++, instead of zephyr_link_libraries which is actually
intended for this purpose.

This commit replaces the usage of zephyr_ld_options with
zephyr_link_libraries as the former may erroneously filter out
-lstdc++ and the latter ensures that this linker flag is
unconditionally forwarded to the linker.

For more details, refer to the issue #20406.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>