### PR TITLE
dts: atmel_sam0: fix location of flash and sram blocks

### DIFF
--- a/dts/arm/atmel/samd5xx18.dtsi
+++ b/dts/arm/atmel/samd5xx18.dtsi
@@ -8,11 +8,13 @@
 #include <atmel/samd5x.dtsi>
 
 / {
-	flash0: flash@0 {
-		reg = <0x0 DT_SIZE_K(256)>;
-	};
+	soc {
+		flash0: flash@0 {
+			reg = <0x0 DT_SIZE_K(256)>;
+		};
 
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(128)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(128)>;
+		};
 	};
 };

--- a/dts/arm/atmel/samd5xx19.dtsi
+++ b/dts/arm/atmel/samd5xx19.dtsi
@@ -8,11 +8,13 @@
 #include <atmel/samd5x.dtsi>
 
 / {
-	flash0: flash@0 {
-		reg = <0x0 DT_SIZE_K(512)>;
-	};
+	soc {
+		flash0: flash@0 {
+			reg = <0x0 DT_SIZE_K(512)>;
+		};
 
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(192)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(192)>;
+		};
 	};
 };

--- a/dts/arm/atmel/samd5xx20.dtsi
+++ b/dts/arm/atmel/samd5xx20.dtsi
@@ -8,11 +8,13 @@
 #include <atmel/samd5x.dtsi>
 
 / {
-	flash0: flash@0 {
-		reg = <0x0 DT_SIZE_K(1024)>;
-	};
+	soc {
+		flash0: flash@0 {
+			reg = <0x0 DT_SIZE_K(1024)>;
+		};
 
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(256)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(256)>;
+		};
 	};
 };

--- a/soc/arm/atmel_sam0/common/soc_samd5x.c
+++ b/soc/arm/atmel_sam0/common/soc_samd5x.c
@@ -10,7 +10,6 @@
  */
 
 #include <arch/cpu.h>
-#include <cortex_m/exc.h>
 #include <device.h>
 #include <init.h>
 #include <kernel.h>


### PR DESCRIPTION
The blocks were moved into the soc block in samd5x.dtsi, so we also have to move
them for the the actual SoC definitions that inherit from that.

Signed-off-by: Benjamin Valentin <benjamin.valentin@ml-pa.com>