### PR TITLE
nrf52_bsim: Fix: shell return code should be != 0 on ASSERT

### DIFF
--- a/boards/posix/nrf52_bsim/trace_hook.c
+++ b/boards/posix/nrf52_bsim/trace_hook.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <init.h>
 #include "bs_tracing.h"
+#include "posix_board_if.h"
 
 #define _STDOUT_BUF_SIZE 256
 static char stdout_buff[_STDOUT_BUF_SIZE];
@@ -75,9 +76,10 @@ void posix_print_error_and_exit(const char *format, ...)
 	va_list variable_argsp;
 
 	va_start(variable_argsp, format);
-	bs_trace_vprint(BS_TRACE_ERROR, NULL, 0, 0, BS_TRACE_AUTOTIME, 0,
+	bs_trace_vprint(BS_TRACE_WARNING, NULL, 0, 0, BS_TRACE_AUTOTIME, 0,
 			format, variable_argsp);
 	va_end(variable_argsp);
+	posix_exit(1);
 }
 
 void posix_print_warning(const char *format, ...)


### PR DESCRIPTION
When calling posix_print_error_and_exit() a return != 0 was not provided to the shell

This was due to the way the tracing functions call back into the main app exit function, assuming that callback will return.
But in the SOC_INF boards, that function does not return when called from a SW thread,
and the tracing functions never have the chance to exit(!=0)
Fix it by calling posix_exit() in the wrap function instead.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>