### PR TITLE
Bluetooth: SMP: Add option to disallow unauthenticated re-pairing

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -298,6 +298,17 @@ config BT_SMP_SC_ONLY
 	  Security Mode 1 Level 4 stands for authenticated LE Secure Connections
 	  pairing with encryption. Enabling this option disables legacy pairing.
 
+config BT_SMP_ALLOW_UNAUTH_OVERWRITE
+	bool "Allow unauthenticated pairing for paired device"
+	help
+	  This option allows all unauthenticated pairing attempts made by the
+	  peer where an unauthenticated bond already exists.
+	  This would enable cases where an attacker could copy the peer device
+	  address to connect and start an unauthenticated pairing procedure
+	  to replace the existing bond. When this option is disabled in order
+	  to create a new bond the old bond has to be explicitly deleted with
+	  bt_unpair.
+
 config BT_FIXED_PASSKEY
 	bool "Use a fixed passkey for pairing"
 	help

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -684,6 +684,12 @@ static bool update_keys_check(struct bt_smp *smp)
 		return false;
 	}
 
+	if (!IS_ENABLED(CONFIG_BT_SMP_ALLOW_UNAUTH_OVERWRITE) &&
+	    (!(conn->le.keys->flags & BT_KEYS_AUTHENTICATED)
+	     && smp->method == JUST_WORKS)) {
+		return false;
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Add option to disallow all unauthenticated pairing attempts made by the
peer where an unauthenticated bond already exists.
This would prevent cases where an attacker could copy the peer device
address to connect and start an unauthenticated pairing procedure
to replace the existing bond. To recover the bond information in this
case the bond information has to be explicitly deleted with bt_unpair.

Fixes: #20422

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>