### PR TITLE
Nios2 qspi unaligned read

### DIFF
--- a/drivers/flash/soc_flash_nios2_qspi.c
+++ b/drivers/flash/soc_flash_nios2_qspi.c
@@ -330,18 +330,40 @@ static int flash_nios2_qspi_read(struct device *dev, off_t offset,
 	u32_t word_to_read, bytes_to_copy;
 	s32_t rc = 0;
 
-	k_sem_take(&flash_cfg->sem_lock, K_FOREVER);
 	/*
-	 * check if offset is word aligned and
-	 * length is with in the range
+	 * check if offset and length are within the range
 	 */
-	if ((data == NULL) || ((offset + len) > qspi_dev->data_end) ||
-			(0 != (read_offset & (NIOS2_WRITE_BLOCK_SIZE - 1)))) {
+	if ((data == NULL) || (offset < qspi_dev->data_base) ||
+	    ((offset + len) > qspi_dev->data_end)) {
 		LOG_ERR("read failed at offset 0x%lx", (long)offset);
-		rc = -EINVAL;
-		goto qspi_read_err;
+		return -EINVAL;
 	}
 
+	if (!len) {
+		return 0;
+	}
+
+	k_sem_take(&flash_cfg->sem_lock, K_FOREVER);
+
+	/* first unaligned start */
+	read_offset &= ~(NIOS2_WRITE_BLOCK_SIZE - 1U);
+	if (offset > read_offset) {
+		/* number of bytes from source to copy */
+		bytes_to_copy = NIOS2_WRITE_BLOCK_SIZE - (offset - read_offset);
+		if (bytes_to_copy > remaining_length) {
+			bytes_to_copy = remaining_length;
+		}
+		/* read from flash 32 bits at a time */
+		word_to_read = IORD_32DIRECT(qspi_dev->data_base, read_offset);
+		memcpy((u8_t *)data, (u8_t *)&word_to_read + offset -
+		       read_offset, bytes_to_copy);
+		/* update offset and length variables */
+		read_offset += NIOS2_WRITE_BLOCK_SIZE;
+		buffer_offset += bytes_to_copy;
+		remaining_length -= bytes_to_copy;
+	}
+
+	/* aligned part, including unaligned end */
 	while (remaining_length > 0) {
 		/* number of bytes from source to copy */
 		bytes_to_copy = NIOS2_WRITE_BLOCK_SIZE;
@@ -354,14 +376,12 @@ static int flash_nios2_qspi_read(struct device *dev, off_t offset,
 		word_to_read = IORD_32DIRECT(qspi_dev->data_base, read_offset);
 		memcpy((u8_t *)data + buffer_offset, &word_to_read,
 		       bytes_to_copy);
-
 		/* update offset and length variables */
 		read_offset += bytes_to_copy;
 		buffer_offset += bytes_to_copy;
 		remaining_length -= bytes_to_copy;
 	}
 
-qspi_read_err:
 	k_sem_give(&flash_cfg->sem_lock);
 	return rc;
 }

--- a/tests/boards/altera_max10/qspi/src/qspi_flash.c
+++ b/tests/boards/altera_max10/qspi/src/qspi_flash.c
@@ -19,6 +19,8 @@ void test_qspi_flash(void)
 {
 	struct device *flash_dev;
 	u32_t i, offset, rd_val, wr_val;
+	u8_t wr_buf[4] = {0xAA, 0xBB, 0xCC, 0xDD};
+	u8_t rd_buf[2];
 
 	flash_dev = device_get_binding(CONFIG_SOC_FLASH_NIOS2_QSPI_DEV_NAME);
 	zassert_equal(!flash_dev, TC_PASS, "Flash device not found!");
@@ -53,6 +55,19 @@ void test_qspi_flash(void)
 				TC_PASS, "Flash read call failed!");
 		zassert_equal(rd_val != wr_val,	TC_PASS,
 					"Flash Write & Read Test failed!!");
+		TC_PRINT("PASS\n");
+
+
+		/* Flash Unaligned Read Test */
+		TC_PRINT("	Flash Unaligned Read Test...");
+		zassert_equal(flash_write(flash_dev, offset + sizeof(wr_val),
+				&wr_buf, sizeof(wr_buf)),
+				TC_PASS, "Flash write call failed!");
+		zassert_equal(flash_read(flash_dev, offset + sizeof(wr_val) + 1,
+				&rd_buf, sizeof(rd_buf)),
+				TC_PASS, "Flash read call failed!");
+		zassert_equal(memcmp(wr_buf + 1, rd_buf, sizeof(rd_buf)),
+				TC_PASS, "Flash Write & Read Test failed!!");
 		TC_PRINT("PASS\n");
 
 


### PR DESCRIPTION
Modify nios2 flash interface to allow unaligned flash reads.

This has not been tested as I do not have access to such a system.

This is required to meet:
[flash: unify read alignment requirements](https://github.com/zephyrproject-rtos/zephyr/issues/16439)