### PR TITLE
kernel: restrict irq_offload() to test cases

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -316,9 +316,11 @@ config GEN_IRQ_START_VECTOR
 
 config IRQ_OFFLOAD
 	bool "Enable IRQ offload"
+	depends on TEST
 	help
 	  Enable irq_offload() API which allows functions to be synchronously
-	  run in interrupt context. Mainly useful for test cases.
+	  run in interrupt context. Only useful for test cases that need
+	  to validate the correctness of kernel objects in IRQ context.
 
 endmenu # Interrupt configuration
 


### PR DESCRIPTION
This API was only created to facilitate testing of kernel
objects in IRQ context, never for actual applications.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>