### PR TITLE
board: reel_board: fix target name used for pyocd

### DIFF
--- a/boards/arm/reel_board/board.cmake
+++ b/boards/arm/reel_board/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
+board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Fix target name used for pyocd.