### PR TITLE
soc: xtensa/intel_s1000_crb: fix build error on xtensa_api.h

### DIFF
--- a/soc/xtensa/intel_s1000/soc.c
+++ b/soc/xtensa/intel_s1000/soc.c
@@ -5,7 +5,7 @@
  */
 
 #include <device.h>
-#include <xtensa_api.h>
+#include <arch/xtensa/xtensa_api.h>
 #include <xtensa/xtruntime.h>
 #include <irq_nextlevel.h>
 #include <xtensa/hal.h>


### PR DESCRIPTION
Commit 2d7460482de9ee1aaaa05a48ac9f5db2fb9114a3 missed replacing
the path to xtensa_api.h in the intel_s1000_crb soc.c file.
So update it.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>