### PR TITLE
doc: update DOXY_SOURCES

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -135,6 +135,7 @@ add_custom_target(
 # a superset of INPUT= and FILE_PATTERNS= in zephyr.doxyfile.in
 file(GLOB_RECURSE  DOXY_SOURCES
   ${ZEPHYR_BASE}/include/*.[c,h,S]
+  ${ZEPHYR_BASE}/kernel/include/kernel_arch_interface.h
   ${ZEPHYR_BASE}/lib/libc/*.[c,h,S]
   ${ZEPHYR_BASE}/subsys/testsuite/ztest/include/*.[h,c,S]
   ${ZEPHYR_BASE}/tests/*.[h,c,S]


### PR DESCRIPTION
Need to add the kernel_arch_interface.h header here
to match zephyr.doxyfile.in.

This is the header which contains the formal kernel-to-
architecture interface and we want docs generated for it.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>