### PR TITLE
arch: arm: Inline arch_isr_direct_header.

### DIFF
--- a/arch/arm/core/irq_manage.c
+++ b/arch/arm/core/irq_manage.c
@@ -159,15 +159,6 @@ void z_irq_spurious(void *unused)
 	z_arm_reserved();
 }
 
-/* FIXME: IRQ direct inline functions have to be placed here and not in
- * arch/cpu.h as inline functions due to nasty circular dependency between
- * arch/cpu.h and kernel_structs.h; the inline functions typically need to
- * perform operations on _kernel.  For now, leave as regular functions, a
- * future iteration will resolve this.
- *
- * See https://github.com/zephyrproject-rtos/zephyr/issues/3056
- */
-
 #ifdef CONFIG_SYS_POWER_MANAGEMENT
 void _arch_isr_direct_pm(void)
 {
@@ -205,11 +196,6 @@ void _arch_isr_direct_pm(void)
 
 }
 #endif
-
-void arch_isr_direct_header(void)
-{
-	sys_trace_isr_enter();
-}
 
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
 /**

--- a/include/arch/arm/irq.h
+++ b/include/arch/arm/irq.h
@@ -90,7 +90,6 @@ extern void z_arm_irq_priority_set(unsigned int irq, unsigned int prio,
 	irq_p; \
 })
 
-/* FIXME prefer these inline, but see GH-3056 */
 #ifdef CONFIG_SYS_POWER_MANAGEMENT
 extern void _arch_isr_direct_pm(void);
 #define ARCH_ISR_DIRECT_PM() _arch_isr_direct_pm()
@@ -99,20 +98,25 @@ extern void _arch_isr_direct_pm(void);
 #endif
 
 #define ARCH_ISR_DIRECT_HEADER() arch_isr_direct_header()
-extern void arch_isr_direct_header(void);
-
 #define ARCH_ISR_DIRECT_FOOTER(swap) arch_isr_direct_footer(swap)
 
 /* arch/arm/core/exc_exit.S */
 extern void z_arm_int_exit(void);
 
 #ifdef CONFIG_TRACING
+extern void sys_trace_isr_enter(void);
 extern void sys_trace_isr_exit(void);
 #endif
 
+static inline void arch_isr_direct_header(void)
+{
+#ifdef CONFIG_TRACING
+	sys_trace_isr_enter();
+#endif
+}
+
 static inline void arch_isr_direct_footer(int maybe_swap)
 {
-
 #ifdef CONFIG_TRACING
 	sys_trace_isr_exit();
 #endif


### PR DESCRIPTION
This commit inlines arch_isr_direct_header function that was previously
placed in irq_manage.c for no good reason (possibly in relation to the
FIXME for #3056).

In addition, since the PR #20119 resolved the header circular
dependency issue described in the issue #3056, this commit removes the
references to it in the code.

The reason for not inlining _arch_is_direct_pm as the #3056 FIXME
suggests is that there is little to gain from doing so and there still
exists circular dependency for the headers required by this function
(#20119 only addresses kernel_structs.h, which is required for _current
and _kernel, which, in turn, is required for handling interrupt nesting
in many architectures; in fact, Cortex-A and Cortex-R port will require
it as well).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>