### PR TITLE
kernel: Clarify k_sleep and k_usleep parameter range 

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -806,7 +806,7 @@ void k_thread_system_pool_assign(struct k_thread *thread);
  *
  * This routine puts the current thread to sleep for @a duration milliseconds.
  *
- * @param ms Number of milliseconds to sleep.
+ * @param ms Non-negative number of milliseconds to sleep or K_FOREVER.
  *
  * @return Zero if the requested time has elapsed or the number of milliseconds
  * left to sleep, if thread was woken up by \ref k_wakeup call.
@@ -822,7 +822,7 @@ __syscall s32_t k_sleep(s32_t ms);
  * to achieve the resolution desired. The implications of doing this must
  * be understood before attempting to use k_usleep(). Use with caution.
  *
- * @param us Number of microseconds to sleep.
+ * @param us Non-negative number of microseconds to sleep.
  *
  * @return Zero if the requested time has elapsed or the number of microseconds
  * left to sleep, if thread was woken up by \ref k_wakeup call.

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1020,6 +1020,9 @@ s32_t z_impl_k_sleep(int ms)
 {
 	s32_t ticks;
 
+	__ASSERT((ms >= 0) || (ms == K_FOREVER),
+		 "Only non-negative values are accepted.");
+
 	if (ms == K_FOREVER) {
 		k_thread_suspend(_current);
 		return K_FOREVER;
@@ -1041,6 +1044,8 @@ static inline s32_t z_vrfy_k_sleep(int ms)
 s32_t z_impl_k_usleep(int us)
 {
 	s32_t ticks;
+
+	__ASSERT(us >= 0, "Only non-negative values are accepted.");
 
 	ticks = k_us_to_ticks_ceil64(us);
 	ticks = z_tick_sleep(ticks);


### PR DESCRIPTION
Clarify k_sleep parameter range (non-negative or K_FOREVER).
Clarify k_usleep parameter range (non-negative).
Added assert to k_(u)sleep to fail on negative numbers (except
K_FOREVER in k_sleep).

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>
