### PR TITLE
soc: gecko: Enable SWO output during SoC initialization

### DIFF
--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -283,24 +283,6 @@ DEVICE_AND_API_INIT(gpio_gecko_common, DT_GPIO_GECKO_COMMON_NAME,
 
 static int gpio_gecko_common_init(struct device *dev)
 {
-	/* Serial Wire Output (SWO) pin is controlled by GPIO module, configure
-	 * if enabled.
-	 */
-#if defined(DT_GPIO_GECKO_SWO_LOCATION)
-	struct soc_gpio_pin pin_swo = PIN_SWO;
-
-#if defined(_GPIO_ROUTEPEN_MASK)
-	/* Enable Serial wire output pin */
-	GPIO->ROUTEPEN |= GPIO_ROUTEPEN_SWVPEN;
-	/* Set SWO location */
-	GPIO->ROUTELOC0 =
-		DT_GPIO_GECKO_SWO_LOCATION << _GPIO_ROUTELOC0_SWVLOC_SHIFT;
-#else
-	GPIO->ROUTE = GPIO_ROUTE_SWOPEN | (DT_GPIO_GECKO_SWO_LOCATION << 8);
-#endif
-	soc_gpio_configure(&pin_swo);
-#endif /* defined(DT_GPIO_GECKO_SWO_LOCATION) */
-
 	gpio_gecko_common_data.count = 0;
 	IRQ_CONNECT(GPIO_EVEN_IRQn, DT_GPIO_GECKO_COMMON_EVEN_PRI,
 		    gpio_gecko_common_isr, DEVICE_GET(gpio_gecko_common), 0);

--- a/soc/arm/silabs_exx32/common/soc.c
+++ b/soc/arm/silabs_exx32/common/soc.c
@@ -70,12 +70,7 @@ static ALWAYS_INLINE void clock_init(void)
 	/* Enable the High Frequency Peripheral Clock */
 	CMU_ClockEnable(cmuClock_HFPER, true);
 
-#ifdef CONFIG_LOG_BACKEND_SWO
-	/* Select HFCLK as the debug trace clock */
-	CMU->DBGCLKSEL = CMU_DBGCLKSEL_DBG_HFCLK;
-#endif
-
-#ifdef CONFIG_GPIO_GECKO
+#if defined(CONFIG_GPIO_GECKO) || defined(CONFIG_LOG_BACKEND_SWO)
 	CMU_ClockEnable(cmuClock_GPIO, true);
 #endif
 }
@@ -98,6 +93,27 @@ static ALWAYS_INLINE void dcdc_init(void)
 #endif
 }
 #endif
+
+#ifdef CONFIG_LOG_BACKEND_SWO
+static void swo_init(void)
+{
+	struct soc_gpio_pin pin_swo = PIN_SWO;
+
+	/* Select HFCLK as the debug trace clock */
+	CMU->DBGCLKSEL = CMU_DBGCLKSEL_DBG_HFCLK;
+
+#if defined(_GPIO_ROUTEPEN_MASK)
+	/* Enable Serial wire output pin */
+	GPIO->ROUTEPEN |= GPIO_ROUTEPEN_SWVPEN;
+	/* Set SWO location */
+	GPIO->ROUTELOC0 =
+		DT_GPIO_GECKO_SWO_LOCATION << _GPIO_ROUTELOC0_SWVLOC_SHIFT;
+#else
+	GPIO->ROUTE = GPIO_ROUTE_SWOPEN | (DT_GPIO_GECKO_SWO_LOCATION << 8);
+#endif
+	soc_gpio_configure(&pin_swo);
+}
+#endif /* CONFIG_LOG_BACKEND_SWO */
 
 /**
  * @brief Perform basic hardware initialization
@@ -131,6 +147,11 @@ static int silabs_exx32_init(struct device *arg)
 	 * if configured in the kernel, NOP otherwise
 	 */
 	NMI_INIT();
+
+#ifdef CONFIG_LOG_BACKEND_SWO
+	/* Configure SWO debug output */
+	swo_init();
+#endif
 
 	/* restore interrupt state */
 	irq_unlock(oldLevel);

--- a/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.efm32pg12b
+++ b/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.efm32pg12b
@@ -3,12 +3,12 @@
 # Copyright (c) 2018 Christian Taedcke
 # SPDX-License-Identifier: Apache-2.0
 
-if GPIO || LOG_BACKEND_SWO
+if GPIO
 
 config GPIO_GECKO
 	default y
 
-endif # GPIO || LOG_BACKEND_SWO
+endif # GPIO
 
 if SERIAL
 

--- a/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
@@ -16,7 +16,6 @@
 #include <soc.h>
 #include <em_gpio.h>
 
-#ifdef CONFIG_GPIO_GECKO
 /* Serial Wire Output (SWO) */
 #if (DT_GPIO_GECKO_SWO_LOCATION == 0)
 #define PIN_SWO {gpioPortF, 2, gpioModePushPull, 1}
@@ -29,6 +28,5 @@
 #elif (DT_GPIO_GECKO_SWO_LOCATION >= 4)
 #error ("Invalid SWO pin location")
 #endif
-#endif /* CONFIG_GPIO_GECKO */
 
 #endif /* _SILABS_EFM32PG12B_SOC_PINMAP_H_ */

--- a/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.efr32fg1p
+++ b/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.efr32fg1p
@@ -3,12 +3,12 @@
 # Copyright (c) 2018 Christian Taedcke
 # SPDX-License-Identifier: Apache-2.0
 
-if GPIO || LOG_BACKEND_SWO
+if GPIO
 
 config GPIO_GECKO
 	default y
 
-endif # GPIO || LOG_BACKEND_SWO
+endif # GPIO
 
 if SERIAL
 

--- a/soc/arm/silabs_exx32/efr32fg1p/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32fg1p/soc_pinmap.h
@@ -16,7 +16,6 @@
 #include <soc.h>
 #include <em_gpio.h>
 
-#ifdef CONFIG_GPIO_GECKO
 /* Serial Wire Output (SWO) */
 #if (DT_GPIO_GECKO_SWO_LOCATION == 0)
 #define PIN_SWO {gpioPortF, 2, gpioModePushPull, 1}
@@ -29,6 +28,5 @@
 #elif (DT_GPIO_GECKO_SWO_LOCATION >= 4)
 #error ("Invalid SWO pin location")
 #endif
-#endif /* CONFIG_GPIO_GECKO */
 
 #endif /* _SILABS_EFR32FG1P_SOC_PINMAP_H_ */

--- a/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.efr32mg12p
+++ b/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.efr32mg12p
@@ -3,12 +3,12 @@
 # Copyright (c) 2018 Diego Sueiro
 # SPDX-License-Identifier: Apache-2.0
 
-if GPIO || LOG_BACKEND_SWO
+if GPIO
 
 config GPIO_GECKO
 	default y
 
-endif # GPIO || LOG_BACKEND_SWO
+endif # GPIO
 
 if SERIAL
 

--- a/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
@@ -15,7 +15,6 @@
 
 #include <em_gpio.h>
 
-#ifdef CONFIG_GPIO_GECKO
 /* Serial Wire Output (SWO) */
 #if (DT_GPIO_GECKO_SWO_LOCATION == 0)
 #define PIN_SWO {gpioPortF, 2, gpioModePushPull, 1}
@@ -28,6 +27,5 @@
 #elif (DT_GPIO_GECKO_SWO_LOCATION >= 4)
 #error ("Invalid SWO pin location")
 #endif
-#endif /* CONFIG_GPIO_GECKO */
 
 #endif /* _SOC_PINMAP_H_ */


### PR DESCRIPTION
Enable SWO debug output during system initialization and not as part of
GPIO driver initialization. After the modification the logger output
becomes available earlier during the boot process. Also, it's not
necessary anymore to build full GPIO driver only to enable SWO. This may
be critical when building small images, e.g. mcuboot.