### PR TITLE
Bluetooth: Move Company ID config out of ctlr

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -155,6 +155,19 @@ source "subsys/bluetooth/shell/Kconfig"
 
 endif # BT_HCI
 
+config BT_COMPANY_ID
+	hex "Company Id"
+	default 0x05F1
+	range 0x0000 0xFFFF
+	help
+	  Set the Bluetooth Company Identifier for this device. The Linux
+	  Foundation's Company Identifier (0x05F1) is the default value for
+	  this option although silicon vendors and hardware manufacturers
+	  can set their own. Note that the controller's Company Identifier is
+	  controlled by BT_CTLR_COMPANY_ID. The full list of Bluetooth
+	  Company Identifiers can be found here:
+	  https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers
+
 source "subsys/bluetooth/mesh/Kconfig"
 
 endif # BT

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -209,19 +209,19 @@ config BT_CTLR_VERSION_SETTINGS
 	bool "Version Settings"
 	depends on BT_CTLR_SETTINGS
 	help
-	  Make Company Id and Subversion Number configurable through
-	  settings system.
+	  Make the controller's Company Id and Subversion Number configurable
+	  through settings system.
 
 config BT_CTLR_COMPANY_ID
-	hex "Company Id"
-	default 0x05F1
+	hex "Controller Company Id"
+	default BT_COMPANY_ID
 	range 0x0000 0xFFFF
 	help
 	  Set the Bluetooth Company Identifier that will be used in
-	  the VERSION_IND PDU. The Linux Foundation's Company Identifier
-	  (0x05F1) is the default value for this option although silicon vendors
-	  and hardware manufacturers can set their own. The full list of
-	  Bluetooth Company Identifiers can be found here:
+	  the VERSION_IND PDU. Uses BT_COMPANY_ID by default, although
+	  silicon vendors and hardware manufacturers can set their own
+	  Company Identifier for the controller. The full list of Bluetooth
+	  Company Identifiers can be found here:
 	  https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers
 
 config BT_CTLR_SUBVERSION_NUMBER


### PR DESCRIPTION
The Company ID concept is not restricted to the controller, and should
be part of the wider Bluetooth scope, so it can be used on a
controller-less device. It's used in multiple host level modules, most
notably the Bluetooth Mesh and Device Information Service.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>