### PR TITLE
[RFC] drivers/flash: Introduce flash absolute offset processing

### DIFF
--- a/drivers/flash/flash_page_layout.c
+++ b/drivers/flash/flash_page_layout.c
@@ -19,6 +19,10 @@ static int flash_get_page_info(struct device *dev, off_t offs,
 
 	api->page_layout(dev, &layout, &layout_size);
 
+	if (use_addr) {
+		offs -= api->base_address;
+	}
+
 	while (layout_size--) {
 		if (use_addr) {
 			end += layout->pages_count * layout->pages_size;
@@ -36,7 +40,7 @@ static int flash_get_page_info(struct device *dev, off_t offs,
 				num_in_group = offs - page_count;
 			}
 
-			info->start_offset = group_offs +
+			info->start_offset = group_offs + api->base_address +
 					     num_in_group * layout->pages_size;
 			info->index = page_count + num_in_group;
 
@@ -87,7 +91,7 @@ void flash_page_foreach(struct device *dev, flash_page_cb cb, void *data)
 	const struct flash_pages_layout *layout;
 	struct flash_pages_info page_info;
 	size_t block, num_blocks, page = 0, i;
-	off_t off = 0;
+	off_t off = api->base_address;
 
 	api->page_layout(dev, &layout, &num_blocks);
 

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -253,6 +253,7 @@ static const struct flash_driver_api flash_nrf_api = {
 	.page_layout = flash_nrf_pages_layout,
 #endif
 	.write_block_size = 1,
+	.base_address = DT_FLASH_BASE_ADDRESS,
 };
 
 static int nrf_flash_init(struct device *dev)

--- a/include/drivers/flash.h
+++ b/include/drivers/flash.h
@@ -79,6 +79,7 @@ struct flash_driver_api {
 	flash_api_pages_layout page_layout;
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 	const size_t write_block_size;
+	const off_t base_address;
 };
 
 /**
@@ -187,8 +188,15 @@ static inline int z_impl_flash_write_protection_set(struct device *dev,
 	return api->write_protection(dev, enable);
 }
 
+/**
+ * @brief Flash page description
+ *
+ * @param start_offset  absolute offset of the flash page
+ * @param size          page size in byte unit
+ * @param index         index of the page within the flash memory
+ */
 struct flash_pages_info {
-	off_t start_offset; /* offset from the base of flash address */
+	off_t start_offset;
 	size_t size;
 	u32_t index;
 };


### PR DESCRIPTION
Potential fix to: https://github.com/zephyrproject-rtos/zephyr/issues/20425 & https://github.com/zephyrproject-rtos/zephyr/issues/20423

It was not possible to get know base address of the flash memory form the
flash API. It becomes problem on memories with non-zero base address as
flash_map description is absolute which makes usage of flash_map erroneous.

Patch introduces flash shim API for fetch flash memory base address
and uses it in order to make flash_page_layout API absolute offset
oriented.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>