### PR TITLE
tests: drivers: flash_simulator: fix project name

### DIFF
--- a/tests/drivers/flash_simulator/CMakeLists.txt
+++ b/tests/drivers/flash_simulator/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(entropy_api)
+project(flash_simulator)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
Fix the project name of the flash_simulator driver test suite.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>