### PR TITLE
fixes for mcp9808 driver and tests

### DIFF
--- a/drivers/sensor/mcp9808/mcp9808.c
+++ b/drivers/sensor/mcp9808/mcp9808.c
@@ -21,27 +21,15 @@ LOG_MODULE_REGISTER(MCP9808, CONFIG_SENSOR_LOG_LEVEL);
 
 int mcp9808_reg_read(struct mcp9808_data *data, u8_t reg, u16_t *val)
 {
-	struct i2c_msg msgs[2] = {
-		{
-			.buf = &reg,
-			.len = 1,
-			.flags = I2C_MSG_WRITE | I2C_MSG_RESTART,
-		},
-		{
-			.buf = (u8_t *)val,
-			.len = 2,
-			.flags = I2C_MSG_READ | I2C_MSG_STOP,
-		},
-	};
+	int rc = i2c_write_read(data->i2c_master, data->i2c_slave_addr,
+				&reg, sizeof(reg),
+				val, sizeof(*val));
 
-	if (i2c_transfer(data->i2c_master, msgs, 2, data->i2c_slave_addr)
-			 < 0) {
-		return -EIO;
+	if (rc == 0) {
+		*val = sys_be16_to_cpu(*val);
 	}
 
-	*val = sys_be16_to_cpu(*val);
-
-	return 0;
+	return rc;
 }
 
 static int mcp9808_sample_fetch(struct device *dev, enum sensor_channel chan)

--- a/drivers/sensor/mcp9808/mcp9808_trigger.c
+++ b/drivers/sensor/mcp9808/mcp9808_trigger.c
@@ -18,22 +18,13 @@ LOG_MODULE_DECLARE(MCP9808, CONFIG_SENSOR_LOG_LEVEL);
 
 static int mcp9808_reg_write(struct mcp9808_data *data, u8_t reg, u16_t val)
 {
-	u16_t be_val = sys_cpu_to_be16(val);
-
-	struct i2c_msg msgs[2] = {
-		{
-			.buf = &reg,
-			.len = 1,
-			.flags = I2C_MSG_WRITE | I2C_MSG_RESTART,
-		},
-		{
-			.buf = (u8_t *) &be_val,
-			.len = 2,
-			.flags = I2C_MSG_WRITE | I2C_MSG_STOP,
-		},
+	u8_t buf[3] = {
+		reg,
+		val >> 8,	/* big-endian register storage */
+		val & 0xFF,
 	};
 
-	return i2c_transfer(data->i2c_master, msgs, 2, data->i2c_slave_addr);
+	return i2c_write(data->i2c_master, buf, sizeof(buf), data->i2c_slave_addr);
 }
 
 static int mcp9808_reg_update(struct mcp9808_data *data, u8_t reg,

--- a/samples/sensor/mcp9808/boards/frdm_k64f.overlay
+++ b/samples/sensor/mcp9808/boards/frdm_k64f.overlay
@@ -5,10 +5,10 @@
  */
 
 &i2c0 {
-	mcp9808@68 {
+	mcp9808@18 {
 		compatible = "microchip,mcp9808";
-		reg = <0x68>;
-		int-gpios = <&gpioc 6 0>;
+		reg = <0x18>;
+		int-gpios = <&gpioc 16 0>;
 		label = "MCP9808";
 	};
 };

--- a/samples/sensor/mcp9808/boards/particle_xenon.overlay
+++ b/samples/sensor/mcp9808/boards/particle_xenon.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2019, Linaro Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c0 {
+	mcp9808@18 {
+		compatible = "microchip,mcp9808";
+		reg = <0x18>;
+		int-gpios = <&gpio1 1 0>;
+		label = "MCP9808";
+	};
+};


### PR DESCRIPTION
Use I2C transactions that work on Nordic.  Add an overlay for a Nordic platform, and fix issues with the frdm_k64f overlay.

Tested in particle_xenon and frdm_k64f.