### PR TITLE
arch: arm: Make PLATFORM_SPECIFIC_INIT available to all ARM variants.

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -95,6 +95,12 @@ config RUNTIME_NMI
 	  NMI handler installed when the CPU boots. If a custom handler is
 	  needed, enable this option and attach it via _NmiHandlerSet().
 
+config PLATFORM_SPECIFIC_INIT
+	bool "Enable platform (SOC) specific startup hook"
+	help
+	  The platform specific initialization code (z_platform_init) is executed
+	  at the beginning of the startup code (__start).
+
 config FAULT_DUMP
 	int "Fault dump level"
 	default 2

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -255,12 +255,6 @@ config SW_VECTOR_RELAY
 	  (or an Armv8-M baseline core) with no VTOR and no other hardware
 	  relocation table mechanisms.
 
-config PLATFORM_SPECIFIC_INIT
-	bool "Enable platform (SOC) specific startup hook"
-	help
-	  The platform specific initialization code (z_platform_init) is executed
-	  at the beginning of the startup code (__start).
-
 endmenu
 
 endif # CPU_CORTEX_M


### PR DESCRIPTION
Move PLATFORM_SPECIFIC_INIT declaration from Cortex-M Kconfig to the
ARM arch Kconfig in order to make it available for all ARM variants.

The rationale is that there is really no good reason why
platform-specific initialisation should be a Cortex-M-specific feature
and that Cortex-R port is expected to utilise this in a near future.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

NOTE: Separated out from #19698 for timely review and merging.