### PR TITLE
arch: arm: Add Cortex-R floating point configuration support.

### DIFF
--- a/cmake/compiler/gcc/target_arm.cmake
+++ b/cmake/compiler/gcc/target_arm.cmake
@@ -27,6 +27,8 @@ else()
   set(FPU_FOR_cortex-m4      fpv4-${PRECISION_TOKEN}d16)
   set(FPU_FOR_cortex-m7      fpv5-${PRECISION_TOKEN}d16)
   set(FPU_FOR_cortex-m33     fpv5-${PRECISION_TOKEN}d16)
+  set(FPU_FOR_cortex-r4      vfpv3-d16)
+  set(FPU_FOR_cortex-r5      vfpv3-d16)
 
   if(CONFIG_FLOAT)
     list(APPEND TOOLCHAIN_C_FLAGS -mfpu=${FPU_FOR_${GCC_M_CPU}})

--- a/soc/arm/Kconfig
+++ b/soc/arm/Kconfig
@@ -43,7 +43,6 @@ config CPU_HAS_NRF_IDAU
 
 config CPU_HAS_FPU_DOUBLE_PRECISION
 	bool
-	depends on CPU_CORTEX_M7
 	select CPU_HAS_FPU
 	help
 	  When enabled, indicates that the SoC has a double


### PR DESCRIPTION
1. Allow CPU_HAS_FPU_DOUBLE_PRECISION on Cortex-R4 and Cortex-R5, as
   the optional VFPv3-D16 is, by default, a double precision unit.

2. Add GCC compiler support for Cortex-R4F and Cortex-R5F floating
   point unit. The FPU type on these cores is fixed to VFPv3-D16,
   which supports double precision by default. While later revisions
   of Cortex-R5F can have single precision VFPv3-D16, GCC does not
   have a separate type for it.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

NOTE: Separated out from #19698 for timely review and merging.