### PR TITLE
arch: Add Dual-redundant Core Lock-step (DCLS) configuration.

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -421,6 +421,12 @@ config CPU_HAS_TEE
 	  Execution Environment (e.g. when it has a security attribution
 	  unit).
 
+config CPU_HAS_DCLS
+	bool
+	help
+	  This option is enabled when the processor hardware is configured in
+	  Dual-redundant Core Lock-step (DCLS) topology.
+
 config CPU_HAS_FPU
 	bool
 	help


### PR DESCRIPTION
Add a new Kconfig configuration for specifying Dual-redundant Core
Lock-step (DCLS) processor topology.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

NOTE:
* Separated out from #19698 for timely review and merging.
* For more details on why this config should go into `arch/Kconfig` rather than `arch/arm/Kconfig` or `arch/arm/cortex_r/Kconfig`, refer to https://github.com/zephyrproject-rtos/zephyr/pull/19698#discussion_r336487724.