### PR TITLE
arch: arm: Fix incorrect Cortex-R interrupt state control logic.

### DIFF
--- a/arch/arm/include/aarch32/cortex_r/exc.h
+++ b/arch/arm/include/aarch32/cortex_r/exc.h
@@ -42,7 +42,9 @@ static ALWAYS_INLINE bool arch_is_in_isr(void)
 			: "=r" (status) : : "memory", "cc");
 	status &= MODE_MASK;
 
-	return (status == MODE_FIQ) || (status == MODE_IRQ);
+	return	(status == MODE_FIQ) ||
+		(status == MODE_IRQ) ||
+		(status == MODE_SVC);
 }
 
 /**

--- a/boards/arm/qemu_cortex_r5/qemu_cortex_r5.yaml
+++ b/boards/arm/qemu_cortex_r5/qemu_cortex_r5.yaml
@@ -13,8 +13,6 @@ testing:
   default: true
   ignore_tags:
     - benchmark
-    - cmsis_rtos
     - interrupt
-    - kernel
     - memory_protection
     - userspace

--- a/tests/kernel/sleep/src/main.c
+++ b/tests/kernel/sleep/src/main.c
@@ -24,7 +24,16 @@
 #define ONE_SECOND_ALIGNED	\
 	(u32_t)(k_ticks_to_ms_floor64(k_ms_to_ticks_ceil32(ONE_SECOND) + _TICK_ALIGN))
 
+#if defined(CONFIG_SOC_XILINX_ZYNQMP)
+/*
+ * The Xilinx QEMU, used to emulate the Xilinx ZynqMP platform, is particularly
+ * unstable in terms of timing. The tick margin of at least 5 is necessary to
+ * allow this test to pass with a reasonable repeatability.
+ */
+#define TICK_MARGIN		5
+#else
 #define TICK_MARGIN		1
+#endif
 
 static struct k_sem test_thread_sem;
 static struct k_sem helper_thread_sem;

--- a/tests/kernel/sleep/src/main.c
+++ b/tests/kernel/sleep/src/main.c
@@ -24,6 +24,8 @@
 #define ONE_SECOND_ALIGNED	\
 	(u32_t)(k_ticks_to_ms_floor64(k_ms_to_ticks_ceil32(ONE_SECOND) + _TICK_ALIGN))
 
+#define TICK_MARGIN		1
+
 static struct k_sem test_thread_sem;
 static struct k_sem helper_thread_sem;
 static struct k_sem task_sem;
@@ -88,7 +90,7 @@ static int sleep_time_valid(u32_t start, u32_t end, u32_t dur)
 {
 	u32_t dt = end - start;
 
-	return dt >= dur && dt <= (dur + 1);
+	return dt >= dur && dt <= (dur + TICK_MARGIN);
 }
 
 static void test_thread(int arg1, int arg2)
@@ -120,7 +122,7 @@ static void test_thread(int arg1, int arg2)
 	k_sleep(ONE_SECOND);
 	end_tick = k_uptime_get_32();
 
-	if (end_tick - start_tick > 1) {
+	if (end_tick - start_tick > TICK_MARGIN) {
 		TC_ERROR(" *** k_wakeup() took too long (%d ticks)\n",
 			 end_tick - start_tick);
 		return;
@@ -134,7 +136,7 @@ static void test_thread(int arg1, int arg2)
 	k_sleep(ONE_SECOND);
 	end_tick = k_uptime_get_32();
 
-	if (end_tick - start_tick > 1) {
+	if (end_tick - start_tick > TICK_MARGIN) {
 		TC_ERROR(" *** k_wakeup() took too long (%d ticks)\n",
 			 end_tick - start_tick);
 		return;
@@ -148,7 +150,7 @@ static void test_thread(int arg1, int arg2)
 	k_sleep(ONE_SECOND);	/* Task will execute */
 	end_tick = k_uptime_get_32();
 
-	if (end_tick - start_tick > 1) {
+	if (end_tick - start_tick > TICK_MARGIN) {
 		TC_ERROR(" *** k_wakeup() took too long (%d ticks) at LAST\n",
 			 end_tick - start_tick);
 		return;


### PR DESCRIPTION
This commit fixes incorrect Cortex-R interrupt lock, unlock and state
check function implementations.

The issues can be summarised as follows:

1. The current implementation of 'z_arch_irq_lock' returns the value
  of CPSR as the IRQ key and, since CPSR contains many other state
  bits, this caused 'z_arch_irq_unlocked' to return false even when
  IRQ is unlocked. This problem is fixed by isolating only the I-bit
  of CPSR and returning this value as the IRQ key, such that it
  returns a non-zero value when interrupt is disabled.

2. The current implementation of 'z_arch_irq_unlock' directly updates
  the value of CPSR control field with the IRQ key and this can cause
  other state bits in CPSR to be corrupted. This problem is fixed by
  conditionally enabling interrupt using CPSIE instruction when the
  value of IRQ key is a zero.

3. The current implementation of 'z_arch_is_in_isr' checks the value
  of CPSR MODE field and returns true if its value is IRQ or FIQ.
  While this does not normally cause an issue, the function can return
  false when IRQ offloading is used because the offload function
  executes in SVC mode. This problem is fixed by adding check for SVC
  mode.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

NOTE:
* Separated out from #19698 for timely review and merging.
* Without the changes in this PR, kernel tests will fail.
* Includes the commits from #22667 (closes #22667).