### PR TITLE
coccinelle: cleanups related to timeout

### DIFF
--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -222,7 +222,7 @@ static int mt9m114_set_state(struct device *dev, u8_t state)
 			break;
 		}
 
-		k_sleep(1);
+		k_sleep(K_MSEC(1));
 	}
 
 	/* Issue the Set State command. */
@@ -240,7 +240,7 @@ static int mt9m114_set_state(struct device *dev, u8_t state)
 			break;
 		}
 
-		k_sleep(1);
+		k_sleep(K_MSEC(1));
 	}
 
 	/* Check the 'OK' bit to see if the command was successful. */
@@ -349,7 +349,7 @@ static int mt9m114_init(struct device *dev)
 	int ret;
 
 	/* no power control, wait for camera ready */
-	k_sleep(100);
+	k_sleep(K_MSEC(100));
 
 	ret = mt9m114_read_reg(dev, MT9M114_CHIP_ID, sizeof(val), &val);
 	if (ret) {

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -209,7 +209,7 @@ static int video_mcux_csi_flush(struct device *dev, enum video_endpoint_id ep,
 	if (!cancel) {
 		/* wait for all buffer to be processed */
 		do {
-			k_sleep(1);
+			k_sleep(K_MSEC(1));
 		} while (!k_fifo_is_empty(&data->fifo_in));
 	} else {
 		/* Flush driver ouput queue */

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -56,7 +56,7 @@ static int video_sw_generator_stream_start(struct device *dev)
 {
 	struct video_sw_generator_data *data = dev->driver_data;
 
-	return k_delayed_work_submit(&data->buf_work, 33);
+	return k_delayed_work_submit(&data->buf_work, K_MSEC(33));
 }
 
 static int video_sw_generator_stream_stop(struct device *dev)
@@ -166,7 +166,7 @@ static int video_sw_generator_flush(struct device *dev,
 	if (!cancel) {
 		/* wait for all buffer to be processed */
 		do {
-			k_sleep(1);
+			k_sleep(K_MSEC(1));
 		} while (!k_fifo_is_empty(&data->fifo_in));
 	} else {
 		while ((vbuf = k_fifo_get(&data->fifo_in, K_NO_WAIT))) {

--- a/samples/smp/pi/src/main.c
+++ b/samples/smp/pi/src/main.c
@@ -96,7 +96,7 @@ void main(void)
 
 	/* Wait for all workers to finish their calculations */
 	while (counter)
-		k_sleep(1);
+		k_sleep(K_MSEC(1));
 
 	/* Capture final time stamp */
 	stop_time = k_cycle_get_32();

--- a/samples/userspace/prod_consumer/src/app_b.c
+++ b/samples/userspace/prod_consumer/src/app_b.c
@@ -50,7 +50,7 @@ static void processor_thread(void *p1, void *p2, void *p3)
 	 * meanwhile data coming in from the driver will be buffered in the
 	 * incoming queue/
 	 */
-	k_sleep(4000);
+	k_sleep(K_MSEC(4000));
 
 	/* Consume data blobs from shared_queue_incoming.
 	 * Do some processing, and the put the processed data

--- a/samples/userspace/prod_consumer/src/main.c
+++ b/samples/userspace/prod_consumer/src/main.c
@@ -62,7 +62,7 @@ void main(void *p1, void *p2, void *p3)
 	/* Spawn supervisor entry for application A */
 	k_thread_create(&app_a_thread, app_a_stack, APP_A_STACKSIZE,
 			app_a_entry, NULL, NULL, NULL,
-			-1, K_INHERIT_PERMS, 0);
+			-1, K_INHERIT_PERMS, K_NO_WAIT);
 
 	/* Re-use main for app B supervisor mode setup */
 	app_b_entry(NULL, NULL, NULL);

--- a/samples/userspace/prod_consumer/src/sample_driver_foo.c
+++ b/samples/userspace/prod_consumer/src/sample_driver_foo.c
@@ -59,7 +59,7 @@ static int sample_driver_foo_state_set(struct device *dev, bool active)
 
 	data->timer.user_data = dev;
 	if (active) {
-		k_timer_start(&data->timer, 1000, 1000);
+		k_timer_start(&data->timer, K_MSEC(1000), K_MSEC(1000));
 	} else {
 		k_timer_stop(&data->timer);
 	}

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -381,7 +381,7 @@ static void tcp_send_process(struct k_timer *timer)
 	}
 
 	if (conn && conn->in_retransmission) {
-		k_timer_start(&conn->send_timer, K_MSEC(tcp_rto), 0);
+		k_timer_start(&conn->send_timer, K_MSEC(tcp_rto), K_NO_WAIT);
 	}
 }
 
@@ -403,7 +403,7 @@ static void tcp_send_timer_cancel(struct tcp *conn)
 		conn->in_retransmission = false;
 	} else {
 		conn->send_retries = tcp_retries;
-		k_timer_start(&conn->send_timer, K_MSEC(tcp_rto), 0);
+		k_timer_start(&conn->send_timer, K_MSEC(tcp_rto), K_NO_WAIT);
 	}
 }
 

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/src/test_counter_fixed_top.c
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/src/test_counter_fixed_top.c
@@ -51,7 +51,7 @@ static void test_all_instances(counter_test_func_t func)
 		func(devices[i]);
 		counter_tear_down_instance(devices[i]);
 		/* Allow logs to be printed. */
-		k_sleep(100);
+		k_sleep(K_MSEC(100));
 	}
 }
 


### PR DESCRIPTION
Re-run the script that replaces literal integer timeouts with the standard `K_MSEC()`-style wrappers.