### PR TITLE
doc: reference: peripherals: add EEPROM API documentation

### DIFF
--- a/doc/reference/peripherals/eeprom.rst
+++ b/doc/reference/peripherals/eeprom.rst
@@ -1,0 +1,28 @@
+.. _eeprom_interface:
+
+EEPROM
+######
+
+Overview
+********
+
+The EEPROM API provides read and write access to Electrically Erasable
+Programmable Read-Only Memory (EEPROM) devices.
+
+EEPROMs have an erase block size of 1 byte, a long lifetime, and allow
+overwriting data on byte-by-byte access.
+
+Configuration Options
+*********************
+
+Related configuration options:
+
+* :option:`CONFIG_EEPROM`
+
+.. _eeprom_api:
+
+API Reference
+*************
+
+.. doxygengroup:: eeprom_interface
+   :project: Zephyr

--- a/doc/reference/peripherals/index.rst
+++ b/doc/reference/peripherals/index.rst
@@ -9,6 +9,7 @@ Peripherals
    adc.rst
    counter.rst
    dma.rst
+   eeprom.rst
    entropy.rst
    flash.rst
    gpio.rst


### PR DESCRIPTION
Add documentation for the EEPROM API to the peripheral reference section.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>