### PR TITLE
arch: arm: Optimise Cortex-R exception return function.

### DIFF
--- a/arch/arm/core/aarch32/exc_exit.S
+++ b/arch/arm/core/aarch32/exc_exit.S
@@ -71,10 +71,6 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_int_exit)
  */
 
 SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_exc_exit)
-#if defined(CONFIG_CPU_CORTEX_R)
-    /* r0 contains the caller mode */
-    push {r0, lr}
-#endif
 
 #ifdef CONFIG_PREEMPT_ENABLED
     ldr r0, =_kernel
@@ -117,9 +113,6 @@ _EXIT_EXC:
 #if defined(CONFIG_CPU_CORTEX_M)
     bx lr
 #elif defined(CONFIG_CPU_CORTEX_R)
-    /* Restore the caller mode to r0 */
-    pop {r0, lr}
-
     /*
      * Restore r0-r3, r12 and lr stored into the process stack by the mode
      * entry function. These registers are saved by _isr_wrapper for IRQ mode
@@ -128,22 +121,15 @@ _EXIT_EXC:
      * r0-r3 are either the values from the thread before it was switched out
      * or they are the args to _new_thread for a new thread.
      */
-    push {r4, r5}
+    push {r4-r6}
+    mrs r6, cpsr
 
-    cmp r0, #RET_FROM_SVC
     cps #MODE_SYS
     ldmia sp!, {r0-r5}
-    beq _svc_exit
+    msr cpsr_c, r6
 
-    cps #MODE_IRQ
-    b _exc_exit
-
-_svc_exit:
-    cps #MODE_SVC
-
-_exc_exit:
     mov r12, r4
     mov lr, r5
-    pop {r4, r5}
+    pop {r4-r6}
     movs pc, lr
 #endif

--- a/arch/arm/core/aarch32/isr_wrapper.S
+++ b/arch/arm/core/aarch32/isr_wrapper.S
@@ -182,10 +182,6 @@ _idle_state_cleared:
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 
-#if defined(CONFIG_CPU_CORTEX_R)
-	mov r0, #RET_FROM_IRQ
-#endif
-
 	/* Use 'bx' instead of 'b' because 'bx' can jump further, and use
 	 * 'bx' instead of 'blx' because exception return is done in
 	 * z_arm_int_exit() */

--- a/arch/arm/core/aarch32/swap_helper.S
+++ b/arch/arm/core/aarch32/swap_helper.S
@@ -625,7 +625,6 @@ demux:
     blx z_irq_do_offload  /* call C routine which executes the offload */
 
     /* exception return is done in z_arm_int_exit() */
-    mov r0, #RET_FROM_SVC
     b z_arm_int_exit
 #endif
 
@@ -633,7 +632,6 @@ _context_switch:
     /* handler mode exit, to PendSV */
     bl z_arm_pendsv
 
-    mov r0, #RET_FROM_SVC
     b z_arm_int_exit
 
 _oops:

--- a/include/arch/arm/aarch32/cortex_r/cpu.h
+++ b/include/arch/arm/aarch32/cortex_r/cpu.h
@@ -31,9 +31,6 @@
 
 #define FPEXC_EN	(1 << 30)
 
-#define RET_FROM_SVC	0
-#define RET_FROM_IRQ	1
-
 #define __ISB()	__asm__ volatile ("isb sy" : : : "memory")
 #define __DMB()	__asm__ volatile ("dmb sy" : : : "memory")
 


### PR DESCRIPTION
z_arm_exc_exit (z_arm_int_exit) requires the current execution mode to
be specified as a parameter (through r0). This is not necessary because
this value can be directly read from CPSR.

This commit modifies the exception return function to retrieve the
current execution mode from CPSR and removes all provisions for passing
the execution mode parameter.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

NOTE:
* Separated out from #19698 for timely review and merging.
* This can be tested in qemu_cortex_r5 by following the procedure described in https://github.com/zephyrproject-rtos/zephyr/pull/19698#issuecomment-549744279.