### PR TITLE
drivers: i2c: use CPU clock frequency in configuration on CC13XX/CC26XX

### DIFF
--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -248,7 +248,7 @@ static int i2c_cc13xx_cc26xx_configure(struct device *dev, u32_t dev_config)
 
 	/* Enables and configures I2C master */
 	I2CMasterInitExpClk(get_dev_config(dev)->base,
-			    sys_clock_hw_cycles_per_sec(), fast);
+		DT_CPU_CLOCK_FREQUENCY, fast);
 
 	return 0;
 }


### PR DESCRIPTION
The I2C peripheral should be configured using the CPU clock frequency
and not the system clock frequency. This used to be fine because they
were the same before #19232, but now that the system clock is
RTC-based (which has a different frequency), we can no longer make
that assumption.

Fixes #20480

Signed-off-by: Vincent Wan <vincent.wan@linaro.org>