### PR TITLE
kernel: allow threads to sleep forever

### DIFF
--- a/tests/kernel/sleep/src/main.c
+++ b/tests/kernel/sleep/src/main.c
@@ -235,11 +235,41 @@ void test_sleep(void)
 
 extern void test_usleep(void);
 
+static void forever_thread_entry(void *p1, void *p2, void *p3)
+{
+	s32_t ret;
+
+	ret = k_sleep(K_FOREVER);
+	zassert_equal(ret, K_FOREVER, "unexpected return value");
+	k_sem_give(&test_thread_sem);
+}
+
+void test_sleep_forever(void)
+{
+	test_objects_init();
+
+	test_thread_id = k_thread_create(&test_thread_data,
+					 test_thread_stack,
+					 THREAD_STACK,
+					 forever_thread_entry,
+					 0, 0, NULL, TEST_THREAD_PRIORITY,
+					 K_USER | K_INHERIT_PERMS, K_NO_WAIT);
+
+	/* Allow forever thread to run */
+	k_yield();
+
+	k_wakeup(test_thread_id);
+	k_sem_take(&test_thread_sem, K_FOREVER);
+}
+
 /*test case main entry*/
 void test_main(void)
 {
+	k_thread_access_grant(k_current_get(), &test_thread_sem);
+
 	ztest_test_suite(sleep,
 			 ztest_1cpu_unit_test(test_sleep),
-			 ztest_1cpu_user_unit_test(test_usleep));
+			 ztest_1cpu_user_unit_test(test_usleep),
+			 ztest_1cpu_unit_test(test_sleep_forever));
 	ztest_run_test_suite(sleep);
 }


### PR DESCRIPTION
Previously, passing K_FOREVER to k_sleep()/k_usleep()
would return immediately.

Forever is a long time. Even if woken up at some point,
we still had forever to sleep, so return K_FOREVER in this
case.

Fixes: #19748

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>