### PR TITLE
Bluetooth: l2cap: fix null pointer dereference

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1136,6 +1136,9 @@ static struct net_buf *l2cap_chan_create_seg(struct bt_l2cap_le_chan *ch,
 
 segment:
 	seg = l2cap_alloc_seg(buf);
+	if (!seg) {
+		return NULL;
+	}
 
 	if (sdu_hdr_len) {
 		net_buf_add_le16(seg, net_buf_frags_len(buf));
@@ -1177,6 +1180,9 @@ static int l2cap_chan_le_send(struct bt_l2cap_le_chan *ch, struct net_buf *buf,
 	}
 
 	seg = l2cap_chan_create_seg(ch, buf, sdu_hdr_len);
+	if (!seg) {
+		return -ENOMEM;
+	}
 
 	/* Channel may have been disconnected while waiting for a buffer */
 	if (!ch->chan.conn) {


### PR DESCRIPTION
bt_conn_create_pdu_timeout() may return NULL if no buffer
is available, l2cap_chan_create_seg() does not check the
subsequent return value.
Fix possible null pointer dereference in l2cap_chan_create_seg()
and l2cap_chan_le_send().

Bluetooth can die when faced with long packets `ping -i 0,3 -s 512 2001:db8::1` or `ping -i 1 -s 1212 2001:db8::1`. Discovered while testing hci_usb with IPSP sample. This patch fixes null pointer dereference, the IPSP device itself remains unresponsive (does not recover / not respond anymore), what is not acceptable.