### PR TITLE
Bluetooth: controller: openisa: Fix radio ISR signature

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.c
@@ -167,8 +167,10 @@ static void pkt_rx(void)
 #define IRQ_MASK ~(GENFSK_IRQ_CTRL_T2_IRQ_MASK | \
 		   GENFSK_IRQ_CTRL_RX_WATERMARK_IRQ_MASK | \
 		   GENFSK_IRQ_CTRL_TX_IRQ_MASK)
-void isr_radio(void)
+void isr_radio(void *arg)
 {
+	ARG_UNUSED(arg);
+
 	u32_t tmr = GENFSK->EVENT_TMR & GENFSK_EVENT_TMR_EVENT_TMR_MASK;
 	u32_t irq = GENFSK->IRQ_CTRL;
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.h
@@ -10,7 +10,7 @@
 
 typedef void (*radio_isr_cb_t) (void *param);
 
-void isr_radio(void);
+void isr_radio(void *arg);
 void radio_isr_set(radio_isr_cb_t cb, void *param);
 
 void radio_setup(void);


### PR DESCRIPTION
Non-direct ISRs are supposed to take a void pointer as an argument,
unliike direct ones, which take no arguments. Since the radio ISR is not
declared as direct, the void pointer argument was missing, likely due to
a copy-paste mistake from the nordic LLL, which indeed uses a direct ISR
for the radio ISR.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>