### PR TITLE
dts: improve documentation for arduino-header-r3

### DIFF
--- a/dts/bindings/gpio/arduino-header-r3.yaml
+++ b/dts/bindings/gpio/arduino-header-r3.yaml
@@ -1,10 +1,51 @@
 # Copyright (c) 2019 Foundries.io
+# Copyright (C) 2019 Peter Bigot Consulting, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARDUINO GPIO HEADER
+title: Arduino Uno (R3) GPIO Header
 
 description: |
-    This is a representation of GPIO pin nodes exposed as headers on Arduino R3
+    GPIO pins exposed on Arduino Uno (R3) headers.
+
+    The Arduino Uno layout provides four headers, two each along
+    opposite edges of the board.
+
+    Proceeding counter-clockwise:
+    * An 8-pin Power Supply header.  No pins on this header are exposed
+      by this binding.
+    * A 6-pin Analog Input header.  This has analog input signals
+      labeled from A0 at the top through A5 at the bottom.
+    * An 8-pin header (opposite Analog Input).  This has digital input
+      signals labeled from D0 at the bottom D7 at the top;
+    * A 10-pin header (opposite Power Supply).  This has six additional
+      digital input signals labelled from D8 at the bottom through D13
+      towards the top, skipping two pins, then finishing with D14 and
+      D15 at the top.
+
+    This binding provides a nexus mapping for 20 pins where parent pins 0
+    through 5 correspond to A0 through A5, and parent pins 6 through 21
+    correspond to D0 through D15, as depicted below:
+
+                                 D15  21
+                                 D14  20
+                                 AREF -
+                                 GND  -
+        - N/C                    D13  19
+        - IOREF                  D12  18
+        - RESET                  D11  17
+        - 3V3                    D10  16
+        - 5V                     D9   15
+        - GND                    D8   14
+        - GND
+        - VIN                    D7   13
+                                 D6   12
+        0 A0                     D5   11
+        1 A1                     D4   10
+        2 A2                     D3    9
+        3 A3                     D2    8
+        4 A4                     D1    7
+        5 A5                     D0    6
+
 
 compatible: "arduino-header-r3"
 


### PR DESCRIPTION
Provide a clear description of the how the binding maps nexus parent
pin indexes to header pin locations.  Also use the standard name "Uno"
when identifying the header physical layout, contrasted with Mega/Due
which is a different physical layout.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>