### PR TITLE
sifive: extend hifive1_revb arduino support, fix I2C build warning

### DIFF
--- a/boards/riscv/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv/hifive1_revb/hifive1_revb.dts
@@ -36,6 +36,35 @@
 			label = "Red LED";
 		};
 	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = /* A0 not connected */
+			   <1 0 &gpio0 9 0>,	/* A1, also CS2 */
+			   <2 0 &gpio0 10 0>,	/* A2, also WF_INT */
+			   <3 0 &gpio0 11 0>,	/* A3 */
+			   <4 0 &gpio0 12 0>,	/* A4 */
+			   <5 0 &gpio0 13 0>,	/* A5 */
+			   <6 0 &gpio0 16 0>,	/* D0, also TX */
+			   <7 0 &gpio0 17 0>,	/* D1, also RX */
+			   <8 0 &gpio0 18 0>,	/* D2 */
+			   <9 0 &gpio0 19 0>,	/* D3 */
+			   <10 0 &gpio0 20 0>,	/* D4 */
+			   <11 0 &gpio0 21 0>,	/* D5 */
+			   <12 0 &gpio0 22 0>,	/* D6 */
+			   <13 0 &gpio0 23 0>,	/* D7 */
+			   <14 0 &gpio0 0 0>,	/* D8 */
+			   <15 0 &gpio0 1 0>,	/* D9 */
+			   <16 0 &gpio0 2 0>,	/* D10 */
+			   <17 0 &gpio0 3 0>,	/* D11, also MOSI */
+			   <18 0 &gpio0 4 0>,	/* D12, also MISO */
+			   <19 0 &gpio0 5 0>,	/* D13, also SCK */
+			   <20 0 &gpio0 12 0>,	/* D14, also SDA */
+			   <21 0 &gpio0 13 0>;	/* D15, also SCL */
+	};
 };
 
 &gpio0 {

--- a/boards/riscv/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv/hifive1_revb/hifive1_revb.dts
@@ -4,6 +4,7 @@
 /dts-v1/;
 
 #include <riscv32-fe310.dtsi>
+#include <dt-bindings/i2c/i2c.h>
 
 / {
 	model = "SiFive HiFive 1 Rev B";
@@ -123,8 +124,9 @@
 	clock-frequency = <16000000>;
 };
 
-&i2c0 {
+arduino_i2c: &i2c0 {
 	status = "okay";
+	label = "I2C_0";
 	input-frequency = <16000000>;
 	clock-frequency = <100000>;
 };

--- a/boards/riscv/hifive1_revb/hifive1_revb.yaml
+++ b/boards/riscv/hifive1_revb/hifive1_revb.yaml
@@ -11,4 +11,6 @@ testing:
     - bluetooth
 supported:
   - arduino_gpio
+  - arduino_i2c
   - gpio
+  - i2c

--- a/boards/riscv/hifive1_revb/hifive1_revb.yaml
+++ b/boards/riscv/hifive1_revb/hifive1_revb.yaml
@@ -9,3 +9,6 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+supported:
+  - arduino_gpio
+  - gpio

--- a/drivers/i2c/i2c_sifive.c
+++ b/drivers/i2c/i2c_sifive.c
@@ -332,12 +332,12 @@ static struct i2c_driver_api i2c_sifive_api = {
 
 #define I2C_SIFIVE_INIT(n) \
 	static struct i2c_sifive_cfg i2c_sifive_cfg_##n = { \
-		.base = DT_SIFIVE_I2C0_##n##_BASE_ADDRESS, \
-		.f_sys = DT_SIFIVE_I2C0_##n##_INPUT_FREQUENCY, \
-		.f_bus = DT_SIFIVE_I2C0_##n##_CLOCK_FREQUENCY, \
+		.base = DT_INST_##n##_SIFIVE_I2C0_BASE_ADDRESS, \
+		.f_sys = DT_INST_##n##_SIFIVE_I2C0_INPUT_FREQUENCY, \
+		.f_bus = DT_INST_##n##_SIFIVE_I2C0_CLOCK_FREQUENCY, \
 	}; \
 	DEVICE_AND_API_INIT(i2c_##n, \
-			    DT_SIFIVE_I2C0_##n##_LABEL, \
+			    DT_INST_##n##_SIFIVE_I2C0_LABEL, \
 			    i2c_sifive_init, \
 			    NULL, \
 			    &i2c_sifive_cfg_##n, \
@@ -345,7 +345,6 @@ static struct i2c_driver_api i2c_sifive_api = {
 			    CONFIG_I2C_INIT_PRIORITY, \
 			    &i2c_sifive_api)
 
-#ifdef DT_INST_0_SIFIVE_I2C0_LABEL
+#ifdef DT_INST_0_SIFIVE_I2C0
 I2C_SIFIVE_INIT(0);
 #endif
-


### PR DESCRIPTION
The original goal was to fix the deprecation warnings; the devicetree bindings got caught up in dependencies and test support.

## boards: hifive1_revb: add arduino gpio nexus map
    
Provide the mapping from FE310-G002 GPIO pins to the Arduino Uno
headers.  Note where pins have pre-assigned functions that may
interfere with use as GPIOs with the default pinmux assignments.
    
## boards: hifive1_revb: add ardunio_i2c support
   
Add node label and missing label property.

## drivers: i2c_sifive: fix deprecation warnings
    
The init macro used outdated spellings for the instance-specific
properties, resulting in build warnings when I2C was enabled.