### PR TITLE
mcumgr: BT SMP transport config for authenticated requirement

### DIFF
--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/prj_smp_svr.conf
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/prj_smp_svr.conf
@@ -8,8 +8,9 @@ CONFIG_BOOTLOADER_MCUBOOT=y
 CONFIG_BT_L2CAP_TX_MTU=260
 CONFIG_BT_RX_BUF_LEN=260
 
-# Enable the Bluetooth and shell mcumgr transports.
+# Enable the Bluetooth (unauthenticated) and shell mcumgr transports.
 CONFIG_MCUMGR_SMP_BT=y
+CONFIG_MCUMGR_SMP_BT_AUTHEN=n
 #CONFIG_MCUMGR_SMP_SHELL=y
 #CONFIG_MCUMGR_SMP_UART=y
 

--- a/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
@@ -11,8 +11,9 @@ CONFIG_BOOTLOADER_MCUBOOT=y
 CONFIG_BT_L2CAP_TX_MTU=260
 CONFIG_BT_RX_BUF_LEN=260
 
-# Enable the Bluetooth and shell mcumgr transports.
+# Enable the Bluetooth (unauthenticated) and shell mcumgr transports.
 CONFIG_MCUMGR_SMP_BT=y
+CONFIG_MCUMGR_SMP_BT_AUTHEN=n
 CONFIG_MCUMGR_SMP_SHELL=y
 #CONFIG_MCUMGR_SMP_UART=y
 

--- a/samples/subsys/mgmt/mcumgr/smp_svr/prj_tiny.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/prj_tiny.conf
@@ -15,8 +15,9 @@ CONFIG_BOOTLOADER_MCUBOOT=y
 CONFIG_BT_L2CAP_TX_MTU=260
 CONFIG_BT_RX_BUF_LEN=260
 
-# Enable the Bluetooth and UART mcumgr transports.
+# Enable the Bluetooth (unauthenticated) and UART mcumgr transports.
 CONFIG_MCUMGR_SMP_BT=y
+CONFIG_MCUMGR_SMP_BT_AUTHEN=n
 #CONFIG_MCUMGR_SMP_SHELL=y
 CONFIG_MCUMGR_SMP_UART=y
 

--- a/subsys/mgmt/Kconfig
+++ b/subsys/mgmt/Kconfig
@@ -14,6 +14,15 @@ config MCUMGR_SMP_BT
 	help
 	  Enables handling of SMP commands received over Bluetooth.
 
+config MCUMGR_SMP_BT_AUTHEN
+	bool "Authenticated requirement for Bluetooth mcumgr SMP transport"
+	depends on MCUMGR_SMP_BT
+	select BT_SMP
+	default y
+	help
+	  Enables encrypted and authenticated connection requirement to
+	  Bluetooth SMP transport.
+
 config MCUMGR_SMP_SHELL
 	bool "Shell mcumgr SMP transport"
 	select MCUMGR

--- a/subsys/mgmt/smp_bt.c
+++ b/subsys/mgmt/smp_bt.c
@@ -76,9 +76,19 @@ static struct bt_gatt_attr smp_bt_attrs[] = {
 	BT_GATT_CHARACTERISTIC(&smp_bt_chr_uuid.uuid,
 			       BT_GATT_CHRC_WRITE_WITHOUT_RESP |
 			       BT_GATT_CHRC_NOTIFY,
+#ifdef CONFIG_MCUMGR_SMP_BT_AUTHEN
+			       BT_GATT_PERM_WRITE_AUTHEN,
+#else
 			       BT_GATT_PERM_WRITE,
+#endif
 			       NULL, smp_bt_chr_write, NULL),
-	BT_GATT_CCC(smp_bt_ccc_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+	BT_GATT_CCC(smp_bt_ccc_changed,
+#ifdef CONFIG_MCUMGR_SMP_BT_AUTHEN
+			       BT_GATT_PERM_READ_AUTHEN |
+			       BT_GATT_PERM_WRITE_AUTHEN),
+#else
+			       BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+#endif
 };
 
 static struct bt_gatt_service smp_bt_svc = BT_GATT_SERVICE(smp_bt_attrs);


### PR DESCRIPTION
This PR introduces a new Kconfig symbol MCUMGR_SMP_BT_AUTHEN.
When selected it configures the Bluetooth mcumgr transport to require
an authenticated connection.

If the Bluetooth mcumgr transport is selected then this new symbol is
selected by default.  Bluetooth SMP is also selected to ensure Zephyr
is configured with Bluetooth security features enabled to provide
Bluetooth authentication APIs to the user's app.  Users can choose to
disable this level of security for the Bluetooth mcumgr transport if
they do not require it.

This PR takes the approach of security by default so Zephyr samples that
selected MCUMGR_SMP_BT (and previously were not using authentication)
required this new symbol to be unselected.

Fixes #16482

Signed-off-by: Nick Ward <nix.ward@gmail.com>