### PR TITLE
i2c_ll_stm32: Allow to send zero length message

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -119,7 +119,7 @@ static int i2c_stm32_transfer(struct device *dev, struct i2c_msg *msg,
 			next = current + 1;
 			next_msg_flags = &(next->flags);
 		}
-		while (current->len > 0) {
+		do {
 			u32_t temp_len = current->len;
 			u8_t tmp_msg_flags = current->flags & ~I2C_MSG_RESTART;
 			u8_t tmp_next_msg_flags = next_msg_flags ?
@@ -152,7 +152,7 @@ static int i2c_stm32_transfer(struct device *dev, struct i2c_msg *msg,
 			current->buf += current->len;
 			current->flags = tmp_msg_flags;
 			current->len = temp_len - current->len;
-		}
+		} while (current->len > 0);
 		current++;
 		num_msgs--;
 	}


### PR DESCRIPTION
Some applications, like i2c_scanner, require to send zero length messages.

Tested on disco_l475_iot1 with `samples/driversi2c_scanner`.
Tested also `samples/sensor/hts221` and `samples/display/cfb_shell` to 
make sure I didn't break something.

Fixes #20325 

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>