### PR TITLE
Bluetooth: controller: openisa: do not use instances for  openisa IRQs

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ll_irqs.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ll_irqs.h
@@ -13,15 +13,15 @@
  * LPTMR1 -> INTMUX_CH2. We expect it to be the only IRQ source for this channel
  * We'll use the INTMUX ISR for channel 2 instead of LPTMR1 ISR
  */
-#define LL_RTC0_IRQn_1st_lvl DT_INST_2_OPENISA_RV32M1_INTMUX_CH_IRQ_0
-#define LL_RTC0_IRQn_2nd_lvl DT_INST_1_OPENISA_RV32M1_LPTMR_IRQ_0
+#define LL_RTC0_IRQn_1st_lvl DT_OPENISA_RV32M1_INTMUX_CH_4004F080_IRQ_0
+#define LL_RTC0_IRQn_2nd_lvl DT_OPENISA_RV32M1_LPTMR_40033000_IRQ_0
 
 /*
  * radio -> INTMUX_CH3. We expect it to be the only IRQ source for this channel
  * We'll use the INTMUX ISR for channel 3 instead of radio ISR
  */
-#define LL_RADIO_IRQn_1st_lvl DT_INST_3_OPENISA_RV32M1_INTMUX_CH_IRQ_0
-#define LL_RADIO_IRQn_2nd_lvl DT_INST_0_OPENISA_RV32M1_GENFSK_IRQ_0
+#define LL_RADIO_IRQn_1st_lvl DT_OPENISA_RV32M1_INTMUX_CH_4004F0C0_IRQ_0
+#define LL_RADIO_IRQn_2nd_lvl DT_OPENISA_RV32M1_GENFSK_41033000_IRQ_0
 
 #define LL_RTC0_IRQn LL_RTC0_IRQn_1st_lvl
 #define LL_RADIO_IRQn LL_RADIO_IRQn_1st_lvl


### PR DESCRIPTION
An issue with DT generation where instance defines are not determinstic
generating values that collide with existing IRQs.

Fixes #20558