### PR TITLE
[RFC] SPI: Add API support for DDR, Dual, Quad and Octal modes

### DIFF
--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -25,6 +25,15 @@ config SPI_SLAVE
 	  Enables Driver SPI slave operations. Slave support depends
 	  on the driver and the hardware it runs on.
 
+config SPI_ENHANCED_MODES
+	bool "Enable enhanced modes (ddr/dual/quad/octal) [EXPERIMENTAL]"
+	help
+	  If the controller supports such modes and if some slave connected
+	  requires it, these will be made available via this option.
+	  Such modes are about dual, quad and octal MOSI lines but also about
+	  using double data rate, command/address/data based transactions as
+	  well as SPI flash hardware optimizations.
+
 config SPI_INIT_PRIORITY
 	int "Init priority"
 	default 70

--- a/include/drivers/spi.h
+++ b/include/drivers/spi.h
@@ -166,16 +166,119 @@ struct spi_config {
 };
 
 /**
+ * SPI Enhanced Mode flags: Double Data Rate, Dual/Quand/Octal modes
+ * (Respectively DDR and DQO)
+ */
+
+/**
+ * SPI Command phase is send via standard mode (single line)
+ * spi_config lines bit field will be superseded by this flag only
+ * for the command.
+ */
+#define SPI_EM_CMD_STD		BIT(0)
+
+/**
+ * SPI Command phase is send via enhanced modes (double/quad/octal)
+ * The mode will depend on the spi_config's lines bit field.
+ */
+#define SPI_EM_CMD_DQO		BIT(1)
+/**
+ * SPI Command phase will take advantage of Double Data Rate
+ * This flag is independent of SPI_EM_CMD_STD or SPI_EM_CMD_DQO.
+ */
+#define SPI_EM_CMD_DDR		BIT(2)
+/**
+ * SPI Addressing phase is send via standard mode (single line)
+ * spi_config's lines bit field will be superceded by this flag only
+ * for the address.
+ */
+#define SPI_EM_ADR_STD		BIT(3)
+/**
+ * SPI Addressing phase is send via enhanced modes (double/quad/octal)
+ * The mode will depend on the spi_config's lines bit field.
+ */
+#define SPI_EM_ADR_DQO		BIT(4)
+/**
+ * SPI Addressing phase will take advantage of Double Data Rate
+ * This flag is independent of SPI_EM_ADR_STD or SPI_EM_ADR_DQO.
+ */
+#define SPI_EM_ADR_DDR		BIT(5)
+/**
+ * SPI Data phase will take advantage of Double Data Rate
+ */
+#define SPI_EM_DATA_DDR		BIT(6)
+/**
+ * JEDEC standard is part of the transaction. This flag lets the SPI
+ * controller to know about it and take advantage of some hardware
+ * optimizations it may provide.
+ */
+#define SPI_EM_FLASH_JEDEC	BIT(7)
+
+enum spi_em_cmd_length {
+	SPI_EM_CMD_NONE		= 0,
+	SPI_EM_CMD_LEN_4_BITS,
+	SPI_EM_CMD_LEN_8_BITS,
+	SPI_EM_CMD_LEN_16_BITS
+};
+
+#define SPI_EM_CMD_LENGTH_SHIFT	(9)
+#define SPI_EM_CMD_LENGTH_MASK	(0x03 << SPI_EM_CMD_LENGTH_SHIFT)
+#define SPI_EM_CMD_LENGTH(_cfg_)		\
+	(((_cfg_) & SPI_EM_CMD_LENGTH_MASK) >> SPI_EM_CMD_LENGTH_SHIFT)
+
+#define SPI_EM_CMD_LENGTH_SET(_len_)		\
+	((_len_) << SPI_EM_CMD_LENGTH_SHIFT)
+
+enum spi_em_adr_length {
+	SPI_EM_ADR_NONE		= 0,
+	SPI_EM_ADR_LEN_4_BITS,
+	SPI_EM_ADR_LEN_8_BITS,
+	SPI_EM_ADR_LEN_12_BITS,
+	SPI_EM_ADR_LEN_16_BITS,
+	SPI_EM_ADR_LEN_20_BITS,
+	SPI_EM_ADR_LEN_24_BITS,
+	SPI_EM_ADR_LEN_28_BITS,
+	SPI_EM_ADR_LEN_32_BITS,
+	SPI_EM_ADR_LEN_36_BITS,
+	SPI_EM_ADR_LEN_40_BITS,
+	SPI_EM_ADR_LEN_44_BITS,
+	SPI_EM_ADR_LEN_48_BITS,
+	SPI_EM_ADR_LEN_52_BITS,
+	SPI_EM_ADR_LEN_56_BITS,
+	SPI_EM_ADR_LEN_60_BITS,
+	SPI_EM_ADR_LEN_64_BITS
+};
+
+#define SPI_EM_ADR_LENGTH_SHIFT	(11)
+#define SPI_EM_ADR_LENGTH_MASK	(0x1F << SPI_EM_ADR_LENGTH_SHIFT)
+#define SPI_EM_ADR_LENGTH(_cfg_)		\
+	(((_cfg_) & SPI_EM_ADR_LENGTH_MASK) >> SPI_EM_ADR_LENGTH_SHIFT)
+
+#define SPI_EM_ADR_LENGTH_SET(_len_)		\
+	((_len_) & SPI_EM_ADR_LENGTH_MASK)
+
+
+/**
  * @brief SPI buffer structure
  *
  * @param buf is a valid pointer on a data buffer, or NULL otherwise.
  * @param len is the length of the buffer or, if buf is NULL, will be the
  *    length which as to be sent as dummy bytes (as TX buffer) or
  *    the length of bytes that should be skipped (as RX buffer).
+ * @param flags is an optional attribute available if CONFIG_SPI_ENHANCED_MODES
+ *    has been enabled, and relates to ddr/dual/quad and octal modes.
+ *    This attribute is a bit field with following parts:
+ *     config          [0:8]  - See SPI enhanced mode flags above
+ *                              bits 8 and 9 are reserved for future use.
+ *     command length [9:10]  - 4 bits factor command length or 0 if none
+ *     address length [11:15] - 4 bits factor address length or 0 if none
  */
 struct spi_buf {
 	void *buf;
 	size_t len;
+#ifdef CONFIG_SPI_ENHANCED_MODES
+	u16_t flags;
+#endif
 };
 
 /**


### PR DESCRIPTION
SPI enhanced modes
=================

DDR: Double Data Rate
Dual: Dual MOSI lines
Quad: Quad MOSI lines
Octal: Octal MOSI lines
DQO: Dual Quand Octal

These modes comprise: DDR, Dual, Quad, Octal and the
specific command/address/data format


Uses cases
---------------

- single MOSI line: cmd / addr / data ddr
- single MOSI line: cmd / addr ddr / data ddr
- single MOSI line: cmd ddr / addr ddr / data ddr
- single MOSI line: cmd ddr
- single MOSI line: data ddr
- DQO MOSI lines: cmd single/addr single/data
- DQO MOSI lines: cmd single/addr/data
- DQO MOSI lines: cmd/addr/data
- DQO MOSI lines: cmd
- DQO MOSI lines: data
- DBO uses cases with DDR


Design
---------

Besides the operation attribute of struct spi_config, all goes through
a newly added u16_t attribute in struct spi_buf: flags.

Firts 9 bits are containing config flags, next 2 bits are the command
length (set to 0 if the cmd/addr format is not in use) and the last 5 bits
are the address length (set to 0 if the addr is not present or if the cmd/addr
format is not in use). Command length is a multiple of 4 (4, 8, 12, 16, ...)
and address length is a multiple of 2 factor 4 (4, 8, 16 ...)

**The good side of this approach:** it does not require changes on any existing SPI controller
drivers nor SPI device drivers.

**The drawback:** if only one SPI controller can support these modes, it adds up
16bits to each and every struct spi_buf in the system. Hopefully this is still
a relatively small amount of data (looks like uncommon for a driver to use more
than 2 struct spi_buf, and if does it will usually be due to a lack of factorization).

SPI configuration
----------------------

```
spi_config {
	   ...
	   .operation = SPI_LINES_<SINGLE/DUAL/QUAD/OCTAL>
	   ...
}
```

Basic cmd/addr format transaction usage
----------------------------------------------------

Note: 8bits length cmd/addr are used for these examples, but it's trivial to
use other size.

**TX only:**

```
u8_t tx_buf[] = { CMD, ADDR };

struct spi_buf buf[2] =  {
	{
		.buf = tx_buf,
       		.len = 2,
		.flags = SPI_EM_CMD_<mode> | SPI_EM_ADDR_<mode> |
       	      	       SPI_EM_CMD_LENGTH_SET(SPI_EM_CMD_LEN_8_BITS) |
		       SPI_EM_ADR_LENGTH_SET(SPI_EM_ADR_LEN_8_BITS)
	},
	{
		.buf = data,
 		.len = data_length
	}
};

struct spi_buf_set tx {
       .buffers = buf,
       .count = 2
};

spi_transceive(spi_dev, spi_cfg, &tx, NULL)
```

**RX added**

```
u8_t tx_buf[] = { CMD, ADDR };

struct spi_buf buf_tx[1] =  {
	{
		.buf = tx_buf,
       		.len = 2,
		.flags = SPI_EM_CMD_<mode> | SPI_EM_ADDR_<mode> |
       	      	       SPI_EM_CMD_LENGTH_SET(SPI_EM_CMD_LEN_8_BITS) |
		       SPI_EM_ADR_LENGTH_SET(SPI_EM_ADR_LEN_8_BITS)
	}
};

struct spi_buf_set tx {
       .buffers = buf_tx,
       .count = 1
};

struct spi_buf buf_rx[1] =  {
	{
		.buf = data,
 		.len = data_length
	}
};

struct spi_buf_set rx {
       .buffers = buf_rx,
       .count = 1
};

spi_transceive(spi_dev, spi_cfg, &tx, &rx)
```

**In case no address is given**

```
u8_t tx_buf[] = { CMD };

struct spi_buf buf_tx[1] =  {
	{
		.buf = tx_buf,
       		.len = 2,
		.flags = SPI_EM_CMD_<mode> | SPI_EM_ADDR_<mode> |
       	      	       SPI_EM_CMD_LENGTH_SET(SPI_EM_CMD_LEN_8_BITS) |
		       SPI_EM_ADR_LENGTH_SET(SPI_EM_ADR_NONE)
	}
};
```

etc ...



About JEDEC
------------------

spi_nor.c could be improved in order to be able to use DQO modes if configured
as well as enabling hardware optimizations.

Configuring is trivial, as seen above, and does not need any particular explanation.
It would be just Kconfig/DTS based.

Enabling hardware optimizations would be done by adding SPI_EM_FLASH_JEDEC flag to
the buf's flags attribute. If the controller has no optimizations, it will silently
ignore it and make the transaction as usual.
If it does, here is what will be possible to do in the controller driver on a write
order for instance where the controller can handle WREN by itself:
(here it's assumed the controller can do generic spi transaction as well as
 providing optimizations for flash)

spi_nor: generate a WREN transaction
ctlr   : look at first spi buf flags. If flash/jedec, it will take a look at the
       	 content of the spi buf and if it's WREN. do nothing.
spi_nor: generate a PP transaction
ctlr   : look at first spi buf flags. If flash/jedec, it will take a look at the
       	 content of the spi buf and if it's PP: setup the address found in the buf
	 generate an internal PP instruction etc...

The idea is basically looking at the preliminary buffer of the transaction where
the driver could grab the necessary info in order to use hw optimizations.
Or to summarize:
- non hw jedec optimized SPI controller:
      would feed the buffer(s) directly to the wires
- hw jewed optimized SPI controller:
      would interpret the first buffer and feed any subsequent buffer as data to
      the wires

**Good side of this approach**: It can reuse spi_nor already, no need for a new API and its related drivers (and thus to need of 2 drivers in case a generic SPI controller also provides jedec hw optimizations)

**Drawback of this approach**: might add a really tiny bit of overhead (which can be neglected imo)  for jedec hw optimized drivers compared to a dedicated API/drivers.