### PR TITLE
subsys/fs/shell: Prevent buffer overrun when creating abs path

### DIFF
--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -85,7 +85,7 @@ static void create_abs_path(const char *name, char *path, size_t len)
 			if (plen < len) {
 				path += plen;
 				*path++ = '/';
-				len -= plen - 1U;
+				len -= plen + 1U;
 				strncpy(path, name, len);
 				path[len - 1] = '\0';
 			}


### PR DESCRIPTION
Prevent buffer overrun in function create_abs_path when a current
working directory is set.

This problem was detected by gcc stack smashing protection when  running the fs shell sample on a native_posix board (exact location was pinpointed by ASAN).

Set prio to medium as it renders the fs shell sample useless under native_posix and corrupts the stack on real boards.