### PR TITLE
Bluetooth: UUID: Expose bt_uuid_to_str to application

### DIFF
--- a/include/bluetooth/uuid.h
+++ b/include/bluetooth/uuid.h
@@ -79,7 +79,6 @@ struct bt_uuid_128 {
 #define BT_UUID_32(__u) CONTAINER_OF(__u, struct bt_uuid_32, uuid)
 #define BT_UUID_128(__u) CONTAINER_OF(__u, struct bt_uuid_128, uuid)
 
-
 /**
  * @brief Encode 128 bit UUID into an array values
  *
@@ -123,6 +122,16 @@ struct bt_uuid_128 {
 	(((w32) >>  8) & 0xFF), \
 	(((w32) >> 16) & 0xFF), \
 	(((w32) >> 24) & 0xFF)
+
+/** @def BT_UUID_STR_LEN
+ *
+ *  @brief Recommended length of user string buffer for Bluetooth UUID.
+ *
+ *  @details The recommended length guarantee the output of UUID
+ *  conversion will not lose valuable information about the UUID being
+ *  processed. If the length of the UUID is known the string can be shorter.
+ */
+#define BT_UUID_STR_LEN 37
 
 /** @def BT_UUID_GAP
  *  @brief Generic Access
@@ -524,11 +533,10 @@ int bt_uuid_cmp(const struct bt_uuid *u1, const struct bt_uuid *u2);
  */
 bool bt_uuid_create(struct bt_uuid *uuid, const u8_t *data, u8_t data_len);
 
-#if defined(CONFIG_BT_DEBUG)
 /** @brief Convert Bluetooth UUID to string.
  *
- *  Converts Bluetooth UUID to string. UUID has to be in 16 bits or 128 bits
- *  format.
+ *  Converts Bluetooth UUID to string.
+ *  UUID can be in any format, 16-bit, 32-bit or 128-bit.
  *
  *  @param uuid Bluetooth UUID
  *  @param str pointer where to put converted string
@@ -537,34 +545,6 @@ bool bt_uuid_create(struct bt_uuid *uuid, const u8_t *data, u8_t data_len);
  *  @return N/A
  */
 void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len);
-
-const char *bt_uuid_str_real(const struct bt_uuid *uuid);
-
-/** @def bt_uuid_str
- *  @brief Convert Bluetooth UUID to string in place.
- *
- *  Converts Bluetooth UUID to string in place. UUID has to be in 16 bits or
- *  128 bits format.
- *
- *  @param uuid Bluetooth UUID
- *
- *  @return String representation of the UUID given
- */
-#define bt_uuid_str(_uuid) log_strdup(bt_uuid_str_real(_uuid))
-#else
-static inline void bt_uuid_to_str(const struct bt_uuid *uuid, char *str,
-				  size_t len)
-{
-	if (len > 0) {
-		str[0] = '\0';
-	}
-}
-
-static inline const char *bt_uuid_str(const struct bt_uuid *uuid)
-{
-	return "";
-}
-#endif /* CONFIG_BT_DEBUG */
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/common/log.c
+++ b/subsys/bluetooth/common/log.c
@@ -17,6 +17,7 @@
 #include <zephyr.h>
 #include <sys/util.h>
 #include <bluetooth/bluetooth.h>
+#include <bluetooth/uuid.h>
 #include <bluetooth/hci.h>
 
 const char *bt_hex_real(const void *buf, size_t len)
@@ -52,6 +53,15 @@ const char *bt_addr_le_str_real(const bt_addr_le_t *addr)
 	static char str[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(addr, str, sizeof(str));
+
+	return str;
+}
+
+const char *bt_uuid_str_real(const struct bt_uuid *uuid)
+{
+	static char str[BT_UUID_STR_LEN];
+
+	bt_uuid_to_str(uuid, str, sizeof(str));
 
 	return str;
 }

--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -17,6 +17,7 @@
 #include <logging/log.h>
 
 #include <bluetooth/bluetooth.h>
+#include <bluetooth/uuid.h>
 #include <bluetooth/hci.h>
 
 #ifdef __cplusplus
@@ -68,10 +69,13 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 /* NOTE: These helper functions always encodes into the same buffer storage.
  * It is the responsibility of the user of this function to copy the information
  * in this string if needed.
+ *
+ * NOTE: These functions are not thread-safe!
  */
 const char *bt_hex_real(const void *buf, size_t len);
 const char *bt_addr_str_real(const bt_addr_t *addr);
 const char *bt_addr_le_str_real(const bt_addr_le_t *addr);
+const char *bt_uuid_str_real(const struct bt_uuid *uuid);
 
 /* NOTE: log_strdup does not guarantee a duplication of the string.
  * It is therefore still the responsibility of the user to handle the
@@ -80,6 +84,7 @@ const char *bt_addr_le_str_real(const bt_addr_le_t *addr);
 #define bt_hex(buf, len) log_strdup(bt_hex_real(buf, len))
 #define bt_addr_str(addr) log_strdup(bt_addr_str_real(addr))
 #define bt_addr_le_str(addr) log_strdup(bt_addr_le_str_real(addr))
+#define bt_uuid_str(uuid) log_strdup(bt_uuid_str_real(uuid))
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -98,7 +98,6 @@ bool bt_uuid_create(struct bt_uuid *uuid, const u8_t *data, u8_t data_len)
 	return true;
 }
 
-#if defined(CONFIG_BT_DEBUG)
 void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len)
 {
 	u32_t tmp1, tmp5;
@@ -109,7 +108,7 @@ void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len)
 		snprintk(str, len, "%04x", BT_UUID_16(uuid)->val);
 		break;
 	case BT_UUID_TYPE_32:
-		snprintk(str, len, "%04x", BT_UUID_32(uuid)->val);
+		snprintk(str, len, "%08x", BT_UUID_32(uuid)->val);
 		break;
 	case BT_UUID_TYPE_128:
 		memcpy(&tmp0, &BT_UUID_128(uuid)->val[0], sizeof(tmp0));
@@ -127,13 +126,3 @@ void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len)
 		return;
 	}
 }
-
-const char *bt_uuid_str_real(const struct bt_uuid *uuid)
-{
-	static char str[37];
-
-	bt_uuid_to_str(uuid, str, sizeof(str));
-
-	return str;
-}
-#endif /* CONFIG_BT_DEBUG */

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -115,7 +115,7 @@ static u8_t discover_func(struct bt_conn *conn,
 	struct bt_gatt_service_val *gatt_service;
 	struct bt_gatt_chrc *gatt_chrc;
 	struct bt_gatt_include *gatt_include;
-	char str[37];
+	char str[BT_UUID_STR_LEN];
 
 	if (!attr) {
 		shell_print(ctx_shell, "Discover complete");
@@ -555,6 +555,7 @@ static struct db_stats {
 static u8_t print_attr(const struct bt_gatt_attr *attr, void *user_data)
 {
 	const struct shell *shell = user_data;
+	char str[BT_UUID_STR_LEN];
 
 	stats.attr_count++;
 
@@ -572,8 +573,9 @@ static u8_t print_attr(const struct bt_gatt_attr *attr, void *user_data)
 		stats.ccc_count++;
 	}
 
+	bt_uuid_to_str(attr->uuid, str, sizeof(str));
 	shell_print(shell, "attr %p handle 0x%04x uuid %s perm 0x%02x",
-		    attr, attr->handle, bt_uuid_str(attr->uuid), attr->perm);
+		    attr, attr->handle, str, attr->perm);
 
 	return BT_GATT_ITER_CONTINUE;
 }
@@ -926,9 +928,11 @@ static u8_t get_cb(const struct bt_gatt_attr *attr, void *user_data)
 	struct shell *shell = user_data;
 	u8_t buf[256];
 	ssize_t ret;
+	char str[BT_UUID_STR_LEN];
 
-	shell_print(shell, "attr %p uuid %s perm 0x%02x", attr,
-		    bt_uuid_str(attr->uuid), attr->perm);
+	bt_uuid_to_str(attr->uuid, str, sizeof(str));
+	shell_print(shell, "attr %p uuid %s perm 0x%02x", attr, str,
+		    attr->perm);
 
 	if (!attr->read) {
 		return BT_GATT_ITER_CONTINUE;

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -1850,12 +1850,15 @@ static void get_attrs(u8_t *data, u16_t len)
 	end_handle = sys_le16_to_cpu(cmd->end_handle);
 
 	if (cmd->type_length) {
+		char uuid_str[BT_UUID_STR_LEN];
+
 		if (btp2bt_uuid(cmd->type, cmd->type_length, &uuid.uuid)) {
 			goto fail;
 		}
 
+		bt_uuid_to_str(&uuid.uuid, uuid_str, sizeof(uuid_str));
 		LOG_DBG("start 0x%04x end 0x%04x, uuid %s", start_handle,
-			end_handle, bt_uuid_str(&uuid.uuid));
+			end_handle, uuid_str);
 
 		foreach.uuid = &uuid.uuid;
 	} else {


### PR DESCRIPTION
Expose the bt_uuid_to_str function as an API to the application.
This aligns this function with the bt_addr_to_str function call. This
allows the application to use this function without having to enable
the BT_DEBUG option.

Move the in-place bt_uuid_str to internal logging, this is mainly done
due to the limitation in the log_strdup that shouldn't be exposed to the
application.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>