### PR TITLE
sanitycheck: Fix incorrect QEMUHandler status reporting.

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2003,7 +2003,7 @@ class ProjectBuilder(FilterBuilder):
                 "test": self.instance,
                 "state": "executed",
                 "status": self.instance.status,
-                "reason": self.instance.status}
+                "reason": self.instance.reason}
                 )
 
         # Report results and output progress to screen
@@ -2125,6 +2125,10 @@ class ProjectBuilder(FilterBuilder):
                 verbose("Spawning QEMUHandler Thread for %s" % instance.name)
                 proc.wait()
                 self.returncode = proc.returncode
+
+            if self.returncode != 0:
+                instance.handler.set_state("failed", 0)
+                instance.reason = "Exited with {}".format(self.returncode)
 
         sys.stdout.flush()
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -974,6 +974,19 @@ class QEMUHandler(Handler):
         self.thread.start()
         subprocess.call(["stty", "sane"])
 
+        verbose("Running %s (%s)" %(self.name, self.type_str))
+        command = [get_generator()[0]]
+        command += ["-C", self.build_dir, "run"]
+
+        with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self.build_dir) as proc:
+            verbose("Spawning QEMUHandler Thread for %s" % self.name)
+            proc.wait()
+            self.returncode = proc.returncode
+
+        if self.returncode != 0:
+            self.set_state("failed", 0)
+            self.instance.reason = "Exited with {}".format(self.returncode)
+
     def get_fifo(self):
         return self.fifo_fn
 
@@ -2115,20 +2128,6 @@ class ProjectBuilder(FilterBuilder):
             instance.handler.suite = self.suite
 
         instance.handler.handle()
-
-        if instance.handler.type_str == "qemu":
-            verbose("Running %s (%s)" %(instance.name, instance.handler.type_str))
-            command = [get_generator()[0]]
-            command += ["-C", self.build_dir, "run"]
-
-            with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self.build_dir) as proc:
-                verbose("Spawning QEMUHandler Thread for %s" % instance.name)
-                proc.wait()
-                self.returncode = proc.returncode
-
-            if self.returncode != 0:
-                instance.handler.set_state("failed", 0)
-                instance.reason = "Exited with {}".format(self.returncode)
 
         sys.stdout.flush()
 


### PR DESCRIPTION
The current QEMUHandler implementation in sanitycheck does not check
for the process exit code and reports "PASS" even when either the QEMU
executable cannot be launched or exited immediately due to an error
(e.g. unsupported machine type, missing file, ...).

This commit adds QEMU process exit code check and error reporting when
the exit code is a non-zero value.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>