### PR TITLE
cmake: Change the DTS preprocessing work directory

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -126,10 +126,10 @@ if(SUPPORTS_DTS)
     -P
     -E   # Stop after preprocessing
     -MD  # Generate a dependency file as a side-effect
-    -MF ${BOARD}.dts.pre.d
-    -o ${BOARD}.dts.pre.tmp
+    -MF ${PROJECT_BINARY_DIR}/${BOARD}.dts.pre.d
+    -o  ${PROJECT_BINARY_DIR}/${BOARD}.dts.pre.tmp
     ${ZEPHYR_BASE}/misc/empty_file.c
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    WORKING_DIRECTORY ${APPLICATION_SOURCE_DIR}
     RESULT_VARIABLE ret
     )
   if(NOT "${ret}" STREQUAL "0")


### PR DESCRIPTION
Change the DTS preprocessor working directory from the binary
directory to the application directory.

This is done so that the user can specify
-DDTC_OVERLAY_FILE=overlay.dts with a relative path from the
application directory as is possible for CONF_FILE, and as is
reasonably expected to be possible by users.

This fixes #20576 