### PR TITLE
Bluetooth: host: Refactor checks in update_ccc for efficiency

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2012,8 +2012,9 @@ static u8_t update_ccc(const struct bt_gatt_attr *attr, void *user_data)
 	ccc = attr->user_data;
 
 	for (i = 0; i < ARRAY_SIZE(ccc->cfg); i++) {
-		/* Ignore configuration for different peer */
-		if (bt_conn_addr_le_cmp(conn, &ccc->cfg[i].peer)) {
+		/* Ignore configuration for different peer or not active */
+		if (!ccc->cfg[i].value ||
+		    bt_conn_addr_le_cmp(conn, &ccc->cfg[i].peer)) {
 			continue;
 		}
 
@@ -2043,14 +2044,14 @@ static u8_t update_ccc(const struct bt_gatt_attr *attr, void *user_data)
 			}
 		}
 
-		if (ccc->cfg[i].value) {
-			gatt_ccc_changed(attr, ccc);
-			if (IS_ENABLED(CONFIG_BT_GATT_SERVICE_CHANGED) &&
-			    ccc == &sc_ccc) {
-				sc_restore(conn);
-			}
-			return BT_GATT_ITER_CONTINUE;
+		gatt_ccc_changed(attr, ccc);
+
+		if (IS_ENABLED(CONFIG_BT_GATT_SERVICE_CHANGED) &&
+		    ccc == &sc_ccc) {
+			sc_restore(conn);
 		}
+
+		return BT_GATT_ITER_CONTINUE;
 	}
 
 	return BT_GATT_ITER_CONTINUE;


### PR DESCRIPTION
Host checks whether an update is needed out of loop to look for
peer. This enables skipping looking for the peer if no update is
needed in the first place. No functional change intended.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>