### PR TITLE
sample: ipsp: fix build reply function

### DIFF
--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -173,9 +173,9 @@ static int build_reply(const char *name,
 		return ret;
 	}
 
-	LOG_DBG("sending %d bytes", ret);
+	LOG_DBG("sending %d bytes", reply_len);
 
-	return ret;
+	return reply_len;
 }
 
 static inline void pkt_sent(struct net_context *context,

--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -165,7 +165,7 @@ static int build_reply(const char *name,
 	int reply_len = net_pkt_remaining_data(pkt);
 	int ret;
 
-	LOG_DBG("%s received %d bytes", name, reply_len);
+	LOG_DBG("%s received %d bytes", log_strdup(name), reply_len);
 
 	ret = net_pkt_read(pkt, buf, reply_len);
 	if (ret < 0) {


### PR DESCRIPTION
Fix build reply function. The sample uses return value
from net_pkt_read() to determine data length,
but the return value is 0 on success.