### PR TITLE
boards: shields: add TI BOOSTXL-SENSORS

### DIFF
--- a/boards/shields/boostxl_sensors/boostxl_sensors.overlay
+++ b/boards/shields/boostxl_sensors/boostxl_sensors.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Brett Witherspoon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&boosterpack_i2c {
+
+	tmp007@40 {
+		compatible = "ti,tmp007";
+		reg = <0x40>;
+		int-gpios = <&boosterpack_header 12 0>;
+		label = "TMP007";
+	};
+
+	opt3001@47 {
+		compatible = "ti,opt3001";
+		reg = <0x47>;
+		label = "OPT3001";
+	};
+
+	bme280@77 {
+		compatible = "bosch,bme280";
+		reg = <0x77>;
+		label = "BME280";
+	};
+
+};

--- a/boards/shields/boostxl_sensors/doc/index.rst
+++ b/boards/shields/boostxl_sensors/doc/index.rst
@@ -1,0 +1,42 @@
+.. _boostxl-sensors:
+
+BOOSTXL-SENSORS: Sensors BoosterPack Plug-in Module
+###################################################
+
+Overview
+********
+
+The Sensors BoosterPack adds digital sensors to a TI LaunchPad |trade|
+development kit. The plug-in module features gyroscope, accelerometer,
+magnetometer, pressure, temperature, humidity, and light sensors.
+
+Currently only the pressure, temperature, humidity and light sensors are
+supported.
+
+More information about the board can be found at the
+`BOOSTXL_SENSORS website`_.
+
+Requirements
+************
+
+This shield can be used with any TI LaunchPad |trade| development kit with
+BoosterPack connectors.
+
+Programming
+***********
+
+Set ``-DSHIELD=boostxl_sensors`` when you invoke ``west build``. For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/bme280
+   :board: cc1352r1_launchxl
+   :shield: boostxl_sensors
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _BOOSTXL_SENSORS website:
+   http://www.ti.com/tool/BOOSTXL-SENSORS


### PR DESCRIPTION
This shield adds digital sensors to a TI LaunchPad development kit. It
is useful for exercising the I2C interface.

This commit depends on #16392 and the relevant commit is `boards: shields: add TI BOOSTXL-SENSORS`.