### PR TITLE
net: tls: Add sendmsg

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1455,6 +1455,29 @@ ssize_t ztls_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
 }
 
+ssize_t ztls_sendmsg_ctx(struct net_context *ctx, const struct msghdr *msg,
+			 int flags)
+{
+	ssize_t len;
+	ssize_t ret;
+	int i;
+
+	len = 0;
+	if (msg) {
+		for (i = 0; i < msg->msg_iovlen; i++) {
+			ret = ztls_sendto_ctx(ctx, msg->msg_iov[i].iov_base,
+					      msg->msg_iov[i].iov_len, flags,
+					      msg->msg_name, msg->msg_namelen);
+			if (ret < 0) {
+				return ret;
+			}
+			len += ret;
+		}
+	}
+
+	return len;
+}
+
 static ssize_t recv_tls(struct net_context *ctx, void *buf,
 			size_t max_len, int flags)
 {
@@ -1982,6 +2005,12 @@ static ssize_t tls_sock_sendto_vmeth(void *obj, const void *buf, size_t len,
 	return ztls_sendto_ctx(obj, buf, len, flags, dest_addr, addrlen);
 }
 
+static ssize_t tls_sock_sendmsg_vmeth(void *obj, const struct msghdr *msg,
+				      int flags)
+{
+	return ztls_sendmsg_ctx(obj, msg, flags);
+}
+
 static ssize_t tls_sock_recvfrom_vmeth(void *obj, void *buf, size_t max_len,
 				       int flags, struct sockaddr *src_addr,
 				       socklen_t *addrlen)
@@ -2014,6 +2043,7 @@ static const struct socket_op_vtable tls_sock_fd_op_vtable = {
 	.listen = tls_sock_listen_vmeth,
 	.accept = tls_sock_accept_vmeth,
 	.sendto = tls_sock_sendto_vmeth,
+	.sendmsg = tls_sock_sendmsg_vmeth,
 	.recvfrom = tls_sock_recvfrom_vmeth,
 	.getsockopt = tls_sock_getsockopt_vmeth,
 	.setsockopt = tls_sock_setsockopt_vmeth,


### PR DESCRIPTION
Add an implementation for `sendmsg`, so secure sockets can be used
together with the WebSocket module to implement secure WebSockets
("wss").

Fixes #20431

Signed-off-by: Markus Fuchs <markus.fuchs@de.sauter-bc.com>