### PR TITLE
arc: core: Fix possible overrun

### DIFF
--- a/arch/arc/core/mpu/arc_mpu_v3_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v3_internal.h
@@ -711,9 +711,9 @@ static int arc_mpu_init(struct device *arg)
 
 		/* record the static region which can be split */
 		if (mpu_config.mpu_regions[i].attr & REGION_DYNAMIC) {
-			if (dynamic_regions_num >
+			if (dynamic_regions_num >=
 			MPU_DYNAMIC_REGION_AREAS_NUM) {
-				LOG_ERR("no enough dynamic regions %d",
+				LOG_ERR("not enough dynamic regions %d",
 				 dynamic_regions_num);
 				return -EINVAL;
 			}


### PR DESCRIPTION
dyn_reg_info has MPU_DYNAMIC_REGION_AREAS_NUM elements, just changing
the if check to be greater equal to this number to avoid access
MPU_DYNAMIC_REGION_AREAS_NUM element causing an out-of-bounds write.

CID: 205648

Fixes #20487

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>