### PR TITLE
scripts: get_maintainer.py RFC + provisional MAINTAINERS.yml

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -483,3 +483,6 @@
 # Get all docs reviewed
 *.rst                                     @nashif
 *posix*.rst                               @aescolar @daor-oti
+# Temporary until we switch over
+MAINTAINERS.yml                           @nashif
+get_maintainer.py                         @nashif

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -484,5 +484,5 @@
 *.rst                                     @nashif
 *posix*.rst                               @aescolar @daor-oti
 # Temporary until we switch over
-MAINTAINERS.yml                           @nashif
-get_maintainer.py                         @nashif
+MAINTAINERS.yml                           @aescolar @ulfalizer
+get_maintainer.py                         @ulfalizer

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -960,6 +960,25 @@ Shell:
     labels:
         - "area: Shell"
 
+STM32:
+    status: maintained
+    maintainers:
+        - erwango
+    files:
+        - boards/arm/nucleo_*/
+        - boards/arm/stm32*_disco/
+        - boards/arm/stm32*_eval/
+        - drivers/*/*stm32*/
+        - drivers/*/*/*stm32*
+        - dts/arm/st/
+        - dts/bindings/*/*stm32*
+        - soc/arm/st_stm32/
+    labels:
+        - "platform: STM32"
+    description: >-
+        STM32 SOCs, dts files and related drivers. ST nucleo, disco and eval
+        boards.
+
 "ZTest and unit test infrastructure":
     # TODO @nashif is this what line 59 of the spreadsheet refers to?
     # Provisional entry, to be corrected

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -707,7 +707,7 @@ Documentation:
     description: >-
         Inventek es-WiFi
 
-"File Systems":
+Filesystems:
     # Provisional entry, to be corrected
     status: orphaned
     collaborators:
@@ -991,19 +991,6 @@ STM32:
         STM32 SOCs, dts files and related drivers. ST nucleo, disco and eval
         boards.
 
-"ZTest and unit test infrastructure":
-    # TODO @nashif is this what line 59 of the spreadsheet refers to?
-    # Provisional entry, to be corrected
-    status: maintained
-    maintainers:
-        - nashif
-    files:
-        - subsys/testsuite/
-        - tests/ztest/
-        - tests/unit/util/
-    labels:
-        - "area: Debugging"
-
 USB:
     # Provisional entry, to be corrected
     status: maintained
@@ -1074,3 +1061,16 @@ West:
         - tests/arch/x86/
     labels:
         - "area: X86"
+
+"ZTest and unit test infrastructure":
+    # TODO @nashif is this what line 59 of the spreadsheet refers to?
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - nashif
+    files:
+        - subsys/testsuite/
+        - tests/ztest/
+        - tests/unit/util/
+    labels:
+        - "area: Debugging"

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -460,8 +460,8 @@ Documentation:
         - "area: GPIO"
 
 "Drivers: HW Info":
-    status: orphaned
-    collaborators:
+    status: maintained
+    maintainers:
         - alexanderwachter
     files:
         - drivers/hwinfo/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1,0 +1,372 @@
+# This file contains information on who maintains what. It is parsed by
+# get_maintainer.py.
+#
+# File format
+# ###########
+#
+# "Area title" (the quotes are needed if the title has more than one word):
+#     status:
+#         One of the following:
+#
+#         * maintained:
+#             The area has a Maintainer (approved by the TSC) who
+#             looks after the area.
+#
+#         * orphaned:
+#             No current maintainer (but maybe you could take the role as you
+#             write your new code).
+#
+#         * obsolete:
+#             Old code. Something being marked obsolete generally means it has
+#             been replaced by something better that you should be using
+#             instead.
+#
+#     maintainers:
+#         List of GitHub handles for the people who maintain the area. Usually,
+#         there's only one maintainer.
+#
+#     collaborators (not to be confused with the GitHub collaborator role):
+#         Very involved contributors, who know the area well and contribute
+#         significantly to it.
+#
+#     labels:
+#         List of GitHub labels to add to pull requests that modify the area.
+#
+#     files:
+#         List of paths and/or glob patterns giving the files in the area,
+#         relative to the root directory.
+#
+#         If a path or glob pattern ends in a '/', it matches all files within
+#         the given directory or directories. Otherwise, an exact match is
+#         required.
+#
+#         Paths to directories should always have a trailing '/'.
+#
+#     files-regex:
+#         List of regular expressions applied to paths to determine if they
+#         belong to the area. The regular expression may match anywhere within
+#         the path, but can be anchored with ^ and $ as usual.
+#
+#         Can be combined with a 'files' key.
+#
+#         Note: Prefer plain 'files' patterns where possible. get_maintainer.py
+#         will check that they match some file, but won't check regexes
+#         (because it might be slow).
+#
+#     files-exclude:
+#         Like 'files', but any matching files will be excluded from the area.
+#
+#     files-regex-exclude:
+#         Like 'files-regex', but any matching files will be excluded from the
+#         area.
+#
+#     description: >-
+#         Plain-English description. Describe what the system is about, from an
+#         outsider's perspective.
+#
+#
+# All areas must have a 'status' key and a 'files' and/or 'files-regex' key.
+# The other keys are optional.
+#
+#
+# Workflow
+# ########
+#
+# Ideally, any file in the tree will be covered by some area.
+#
+# When a GitHub pull request is sent, this happens:
+#
+#     * A user mentioned in 'maintainers' is added as Assignee to
+#       the pull request
+#
+#     * Users mentioned in 'maintainers' and 'collaborators' are added as
+#       reviewers to the pull request
+#
+#     * The labels listed in 'labels' are automatically added to the pull
+#       request
+#
+#     * The bot posts this comment:
+#
+#         This PR affects the following areas:
+#         <area name>:
+#           Status: ...
+#           Maintainers: <list of maintainers>
+#           Collaborators: <list of sub-maintainers>
+#
+#         <area name>:
+#           ...
+#
+#
+# Changes to MAINTAINERS.yml need to be approved as follows:
+#
+#     * Changing the 'maintainers' for an area needs approval from the
+#       Technical Steering Committee
+#
+#     * Changing the 'collaborators' lines requires the maintainer and
+#       collaborators of that area to agree (or vote on it)
+
+# Areas are sorted by name
+
+"ARC arch":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - ruuddw
+    collaborators:
+        - vonhust
+    files:
+        - arch/arc/
+    labels:
+        - "area: ARC"
+
+"ARM arch":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - ioannisg
+    collaborators:
+        - MaureenHelm
+        - galak
+        - ioannisg
+    files:
+        - arch/arm/
+    labels:
+        - "area: ARM"
+
+Bluetooth:
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - jhedberg
+    collaborators:
+        - joerchan
+        - Vudentz
+    files:
+        - doc/reference/bluetooth/
+        - doc/guides/bluetooth/
+        - drivers/bluetooth/
+        - include/bluetooth/
+        - include/drivers/bluetooth/
+        - samples/bluetooth/
+        - subsys/bluetooth/
+        - tests/bluetooth/
+    labels:
+        - "area: Bluetooth"
+
+"Bluetooth controller":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - cvinayak
+    collaborators:
+        - carlescufi
+        - thoh-ot
+    files:
+        - subsys/bluetooth/controller/
+
+"Bluetooth Mesh":
+    # Provisional entry, to be corrected
+    status: maintained
+    collaborators:
+        - trond-snekvik
+    files:
+        - subsys/bluetooth/mesh/
+    labels:
+        - "area: Bluetooth Mesh"
+
+"Build system":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - SebastianBoe
+    files:
+        - cmake/
+    files-regex:
+        - CMakeLists.txt$
+        - \.cmake$
+    labels:
+        - "area: Build System"
+
+"Display drivers":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - drivers/display/
+        - dts/bindings/display/
+        - include/display.h
+        - include/display/
+        - include/drivers/display.h
+    labels:
+        - "area: Display"
+
+Documentation:
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - dbkinder
+    files:
+        - doc/
+    files-regex:
+        - \.rst$
+        - /doc/
+    labels:
+        - "area: Documentation"
+
+Flash:
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - nvlsianpu
+    files:
+        - drivers/flash/
+        - dts/bindings/flash_controller/
+        - include/drivers/flash.h
+        - include/flash.h
+        - samples/drivers/flash_shell/
+    labels:
+        - "area: Flash"
+
+Kconfig:
+    status: maintained
+    maintainers:
+        - ulfalizer
+    files:
+        - scripts/kconfig/
+    files-regex:
+        - Kconfig[\w._-]*$
+    labels:
+        - "area: Kconfig"
+    description: >-
+        See https://docs.zephyrproject.org/latest/guides/kconfig/index.html and
+        https://docs.zephyrproject.org/latest/guides/porting/board_porting.html#default-board-configuration
+
+Logging:
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - nordic-krch
+    files:
+        - include/logging/
+        - samples/subsys/logging/
+        - subsys/logging/
+        - tests/subsys/logging/
+    labels:
+        - "area: Logging"
+
+"Native POSIX and POSIX arch":
+    status: maintained
+    maintainers:
+        - aescolar
+    files:
+        - arch/posix/
+        - boards/posix/native_posix/
+        - drivers/*/*native_posix*
+        - drivers/*/*/*native_posix*
+        - dts/posix/
+        - include/arch/posix/
+        - scripts/valgrind.supp
+        - soc/posix/
+        - tests/boards/native_posix/
+    labels:
+        - "area: native port"
+    description: >-
+        POSIX architecture and SOC, native_posix board, and related drivers
+
+"nRF52 BSIM":
+    status: maintained
+    maintainers:
+        - aescolar
+    files:
+        - boards/posix/nrf52_bsim/
+    labels:
+        - "platform: nrf52_bsim"
+
+"RISCV arch":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - nategraff-sifive
+    collaborators:
+        - mgielda
+    files:
+        - arch/riscv/
+    labels:
+        - "area: RISCV"
+
+Sanitycheck:
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - nashif
+    files:
+        - scripts/sanitycheck
+        - scripts/sanity_chk/
+    labels:
+        - "area: Sanitycheck"
+
+Settings:
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - nvlsianpu
+    files:
+        - include/settings/
+        - subsys/settings/
+        - tests/subsys/settings/
+    labels:
+        - "area: Settings"
+
+Shell:
+    # Provisional entry, to be corrected
+    status: orphaned
+    collaborators:
+        - carlescufi
+    files:
+        - include/shell/
+        - samples/subsys/shell/
+        - subsys/shell/
+        - tests/shell/
+        - tests/subsys/shell/
+    labels:
+        - "area: Shell"
+
+USB:
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - finikorg
+    collaborators:
+        - jfischer-phytec-iot
+    files:
+        - drivers/usb/
+        - dts/bindings/usb/
+        - include/*/usb/
+        - include/usb/
+        - samples/subsys/usb/
+        - subsys/usb/
+        - tests/subsys/usb/
+    labels:
+        - "area: USB"
+
+West:
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - mbolivar
+    files:
+        - scripts/west-commands.yml
+        - scripts/west_commands/
+    labels:
+        - "area: West"
+
+"x86 arch":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - andrewboie
+    collaborators:
+        - andyross
+    files:
+        - arch/x86/
+    labels:
+        - "area: X86"

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -506,11 +506,7 @@ Documentation:
         Inter-processor mailboxes
 
 "Drivers: I2C":
-    # Provisional entry, to be corrected
-    # TODO: spreadsheet not matching CODEOWNERS
-    status: maintained
-    maintainers:
-        - mbolivar
+    status: orphaned
     files:
         - drivers/i2c/
         - dts/bindings/i2c/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4,7 +4,8 @@
 # File format
 # ###########
 #
-# "Area title" (the quotes are needed if the title has more than one word):
+# "Area title" (the quotes are only needed for titles with special characters,
+#  like colons):
 #     status:
 #         One of the following:
 #
@@ -111,7 +112,7 @@
 
 # Areas are sorted by name
 
-"ARC arch":
+ARC arch:
     # Provisional entry, to be corrected
     status: maintained
     maintainers:
@@ -124,7 +125,7 @@
     labels:
         - "area: ARC"
 
-"ARM arch":
+ARM arch:
     status: maintained
     maintainers:
         - ioannisg
@@ -157,7 +158,7 @@ Bluetooth:
     labels:
         - "area: Bluetooth"
 
-"Bluetooth controller":
+Bluetooth controller:
     # Provisional entry, to be corrected
     status: maintained
     maintainers:
@@ -168,7 +169,7 @@ Bluetooth:
     files:
         - subsys/bluetooth/controller/
 
-"Bluetooth Mesh":
+Bluetooth Mesh:
     # Provisional entry, to be corrected
     status: maintained
     collaborators:
@@ -178,7 +179,7 @@ Bluetooth:
     labels:
         - "area: Bluetooth Mesh"
 
-"Build system":
+Build system:
     status: maintained
     maintainers:
         - SebastianBoe
@@ -192,7 +193,7 @@ Bluetooth:
     labels:
         - "area: Build System"
 
-"C library":
+C library:
     # Provisional entry, to be corrected
     status: orphaned
     collaborators:
@@ -204,7 +205,7 @@ Bluetooth:
     labels:
          - "area: C Library"
 
-"CMSIS API layer":
+CMSIS API layer:
     # Provisional entry, to be corrected
     status: orphaned
     collaborators:
@@ -247,7 +248,7 @@ Devicetree:
     labels:
         - "area: Device Tree"
 
-"Display drivers":
+Display drivers:
     status: maintained
     maintainers:
         - vanwinkeljan
@@ -767,7 +768,7 @@ Logging:
     labels:
         - "area: Logging"
 
-"Native POSIX and POSIX arch":
+Native POSIX and POSIX arch:
     status: maintained
     maintainers:
         - aescolar
@@ -864,7 +865,7 @@ Networking:
         - tests/net/lib/mqtt_packet/
         - samples/net/mqtt_publisher/
 
-"NIOS-2 arch":
+NIOS-2 arch:
     # Provisional entry, to be corrected
     status: maintained
     maintainers:
@@ -875,7 +876,7 @@ Networking:
     labels:
         - "area: NIOS2"
 
-"nRF52 BSIM":
+nRF52 BSIM:
     status: maintained
     maintainers:
         - aescolar
@@ -884,7 +885,7 @@ Networking:
     labels:
         - "platform: nrf52_bsim"
 
-"POSIX API layer":
+POSIX API layer:
     # Provisional entry, to be corrected
     status: maintained
     maintainers:
@@ -896,7 +897,7 @@ Networking:
     labels:
         - "area: POSIX"
 
-"Power management":
+Power management:
     # TSC : Note this entry differs from the spreadsheet:
     # pizi-nordic is not anymore working in Zephyr, therefore he cannot be a
     # maintainer, and the are is orphaned until a new maintainer is appointed
@@ -910,7 +911,7 @@ Networking:
     labels:
         - "area: Power Management"
 
-"RISCV arch":
+RISCV arch:
     # Provisional entry, to be corrected
     status: maintained
     maintainers:
@@ -1033,7 +1034,7 @@ West:
     labels:
         - "area: West"
 
-"Xtensa arch":
+Xtensa arch:
     status: maintained
     maintainers:
         - dcpleung
@@ -1048,7 +1049,7 @@ West:
     labels:
         - "area: Xtensa"
 
-"x86 arch":
+x86 arch:
     # Provisional entry, to be corrected
     status: maintained
     maintainers:
@@ -1062,7 +1063,7 @@ West:
     labels:
         - "area: X86"
 
-"ZTest and unit test infrastructure":
+ZTest and unit test infrastructure:
     # TODO @nashif is this what line 59 of the spreadsheet refers to?
     # Provisional entry, to be corrected
     status: maintained

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -247,9 +247,11 @@ Devicetree:
         - "area: Device Tree"
 
 "Display drivers":
-    status: orphaned
-    collaborators:
+    status: maintained
+    maintainers:
         - vanwinkeljan
+    collaborators:
+        - jfischer-phytec-iot
     files:
         - drivers/display/
         - dts/bindings/display/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -65,8 +65,11 @@
 #         outsider's perspective.
 #
 #
-# All areas must have a 'status' key and a 'files' and/or 'files-regex' key.
+# All areas must have a 'files' and/or 'files-regex' key.
 # The other keys are optional.
+# It is very advisable to have a `status` key in all entries. Exceptions to this
+# would be sub-areas which add extra fields (for ex. more `collaborators` who
+# work only in that sub-area) to other areas.
 #
 #
 # Workflow

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -130,11 +130,14 @@ ARM arch:
     maintainers:
         - ioannisg
     collaborators:
+        - carlocaione
         - MaureenHelm
         - galak
+        - stephanosio
     files:
         - arch/arm/
         - include/arch/arm/
+        - tests/arch/arm/
     labels:
         - "area: ARM"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -960,6 +960,18 @@ Shell:
     labels:
         - "area: Shell"
 
+Shields:
+    status: maintained
+    maintainers:
+        - erwango
+    collaborators:
+        - avisconti
+        - jfischer-phytec-iot
+    files:
+        - boards/shields/
+    labels:
+        - "area: Shields"
+
 STM32:
     status: maintained
     maintainers:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -261,6 +261,15 @@ Devicetree:
     labels:
         - "area: Device Tree"
 
+Disk:
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - subsys/disk/
+        - include/disk/
+    labels:
+        - "area: Disk Access"
+
 Display drivers:
     status: maintained
     maintainers:
@@ -608,6 +617,14 @@ Documentation:
     labels:
         - "area: PCI"
 
+"Drivers: peci":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - drivers/peci/
+        - include/drivers/peci.h
+        - samples/drivers/peci/
+
 "Drivers: Pinmux":
     # Provisional entry, to be corrected
     status: maintained
@@ -676,6 +693,16 @@ Documentation:
     labels:
         - "area: Timer"
 
+"Drivers: video":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - drivers/video/
+        - include/drivers/video.h
+        - include/drivers/video-controls.h
+    labels:
+        - "area: Video"
+
 "Drivers: Watchdog":
     # Provisional entry, to be corrected
     status: orphaned
@@ -728,6 +755,11 @@ Filesystems:
     labels:
         - "area: File System"
 
+JSON Web Token:
+    status: orphaned
+    files:
+        - subsys/jwt/
+
 Kconfig:
     status: maintained
     maintainers:
@@ -779,6 +811,15 @@ MAINTAINERS file:
         - "area: Process"
     description:
         Zephyr Maintainers File
+
+MCU Manager:
+    status: oprhaned
+    files:
+        - subsys/mgmt/
+        - include/mgmt/
+        - samples/subsys/mgmt/
+    labels:
+        - "area: mcumgr"
 
 Native POSIX and POSIX arch:
     status: maintained
@@ -1001,6 +1042,22 @@ STM32:
     description: >-
         STM32 SOCs, dts files and related drivers. ST nucleo, disco and eval
         boards.
+
+Storage:
+    status: orphaned
+    files:
+        - subsys/storage/
+        - include/storage/
+    labels:
+        - "area: Storage"
+
+Tracing:
+    status: orphaned
+    files:
+        - subsys/tracing/
+        - include/tracing/
+    labels:
+        - "area: tracing"
 
 USB:
     # Provisional entry, to be corrected

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -232,7 +232,7 @@ DFU:
         - subsys/dfu/
         - tests/subsys/dfu/
 
-"Device Tree":
+Devicetree:
     # Provisional entry, to be corrected
     status: maintained
     maintainers:
@@ -448,7 +448,7 @@ Documentation:
     maintainers:
         - mnkp
     files:
-        - doc/reference/peripherals/gpio.rst 
+        - doc/reference/peripherals/gpio.rst
         - drivers/gpio/
         - include/drivers/gpio/
         - include/drivers/gpio.h
@@ -607,7 +607,7 @@ Documentation:
     maintainers:
         - mnkp
     files:
-        - doc/reference/peripherals/pinmux.rst 
+        - doc/reference/peripherals/pinmux.rst
         - drivers/pinmux/
         - include/drivers/pinmux.h
         - include/pinmux.h
@@ -661,7 +661,7 @@ Documentation:
     labels:
         - "area: SPI"
 
-"Drivers: System Timer":
+"Drivers: System timer":
     # Provisional entry, to be corrected
     # TODO: maintainers spreadsheet not matching CODEOWNERS
     status: maintained
@@ -787,7 +787,7 @@ Logging:
     description: >-
         POSIX architecture and SOC, native_posix board, and related drivers
 
-"Networking":
+Networking:
     # Provisional entry, to be corrected
     status: maintained
     maintainers:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -119,20 +119,20 @@
         - vonhust
     files:
         - arch/arc/
+        - include/arch/arc/
     labels:
         - "area: ARC"
 
 "ARM arch":
-    # Provisional entry, to be corrected
     status: maintained
     maintainers:
         - ioannisg
     collaborators:
         - MaureenHelm
         - galak
-        - ioannisg
     files:
         - arch/arm/
+        - include/arch/arm/
     labels:
         - "area: ARM"
 
@@ -178,10 +178,11 @@ Bluetooth:
         - "area: Bluetooth Mesh"
 
 "Build system":
-    # Provisional entry, to be corrected
     status: maintained
     maintainers:
         - SebastianBoe
+    collaborators:
+        - nashif
     files:
         - cmake/
     files-regex:
@@ -190,9 +191,65 @@ Bluetooth:
     labels:
         - "area: Build System"
 
-"Display drivers":
+"C library":
     # Provisional entry, to be corrected
     status: orphaned
+    collaborators:
+         - nashif
+         - andrewboie
+    files:
+         - lib/libc/
+         - tests/lib/c_lib/
+    labels:
+         - "area: C Library"
+
+"CMSIS API layer":
+    # Provisional entry, to be corrected
+    status: orphaned
+    collaborators:
+         - nashif
+    files:
+         - lib/cmsis_rtos_v*/
+
+Debug:
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - nashif
+    files:
+        - include/debug/
+        - subsys/debug/
+        - tests/subsys/debug/
+    labels:
+        - "area: Debugging"
+
+DFU:
+    status: maintained
+    maintainers:
+        - nvlsianpu
+    files:
+        - include/dfu/
+        - subsys/dfu/
+        - tests/subsys/dfu/
+
+"Device Tree":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - galak
+    collaborators:
+        - ulfalizer
+    files:
+        - scripts/dts/
+        - dts/bindings/
+        - dts/common/
+    labels:
+        - "area: Device Tree"
+
+"Display drivers":
+    status: orphaned
+    collaborators:
+        - vanwinkeljan
     files:
         - drivers/display/
         - dts/bindings/display/
@@ -215,8 +272,164 @@ Documentation:
     labels:
         - "area: Documentation"
 
-Flash:
+"Drivers: ADC":
     # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - anangl
+    files:
+        - drivers/adc/
+        - include/drivers/adc.h
+        - tests/drivers/adc/
+    labels:
+        - "area: ADC"
+
+"Drivers: ADC stm32":
+    # Provisional entry, to be corrected
+    collaborators:
+        - cybertale
+    files:
+        - drivers/adc/adc_stm32.c
+        - dts/bindings/iio/adc/st*stm32-adc.yaml
+
+"Drivers: Audio":
+    # Provisional entry, to be corrected
+    # TODO: spreadsheet not matching CODEOWNERS
+    status: maintained
+    maintainers:
+        - Vudentz
+    files:
+        - drivers/audio/
+        - include/audio/
+
+"Drivers: CAN":
+    status: maintained
+    maintainers:
+        - alexanderwachter
+    collaborators:
+        - henrikbrixandersen
+        - karstenkoenig
+    files:
+        - drivers/can/
+        - dts/bindings/can/
+        - include/drivers/can.h
+        - samples/drivers/CAN/
+        - tests/drivers/can/
+    labels:
+        - "area: CAN"
+
+"Drivers: Clock control":
+    status: orphaned
+    files:
+        - drivers/clock_control/
+        - dts/bindings/clock/
+        - include/clock_control.h
+        - include/dt-bindings/clock/
+        - tests/drivers/clock_control/
+    labels:
+        - "area: Clock control"
+
+"Drivers: Clock control: Nordic nRFx":
+    collaborators:
+        - nordic-krch
+    files:
+        - drivers/clock_control/*nrf*
+
+"Drivers: Console":
+    # Provisional entry, to be corrected
+    # TODO: spreadsheet not properly matching CODEOWNERS
+    status: maintained
+    maintainers:
+        - pfalcon
+    files:
+        - drivers/console/
+    labels:
+        - "area: Console"
+
+"Drivers: Counter":
+    # Provisional entry, to be corrected
+    # TODO: spreadsheet not properly matching CODEOWNERS
+    status: maintained
+    maintainers:
+        - nordic-krch
+    files:
+        - drivers/counter/
+        - include/drivers/counter.h
+        - tests/drivers/counter/
+    labels:
+        - "area: Counter"
+
+"Drivers: Crypto":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - drivers/crypto/
+        - dts/bindings/crypto/
+        - include/crypto/
+        - samples/drivers/crypto/
+    labels:
+        - "area: Crypto / RNG"
+
+"Drivers: DMA":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - drivers/dma/
+        - include/dt-bindings/dma/
+    labels:
+        - "area: DMA"
+
+"Drivers: Entropy":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - drivers/entropy/
+        - samples/drivers/entropy/
+        - tests/drivers/entropy/
+
+"Drivers: Entropy: OpenISA RV32M1":
+    # Provisional entry, to be corrected
+    collaborators:
+        - MaureenHelm
+    files:
+        - drivers/entropy/*rv32m1*
+
+"Drivers: EEPROM":
+    status: maintained
+    maintainers:
+        - henrikbrixandersen
+    files:
+        - drivers/eeprom/
+        - dts/bindings/mtd/*eeprom*
+        - include/drivers/eeprom.h
+        - tests/drivers/eeprom/
+    labels:
+        - "area: EEPROM"
+
+"Drivers: ESPI":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - drivers/espi/
+        - include/drivers/espi.h
+        - samples/drivers/espi/
+    labels:
+        - "eSPI"
+
+"Drivers: Ethernet":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - tbursztyka
+    collaborators:
+        - jukkar
+        - pfalcon
+    files:
+        - drivers/ethernet/
+    labels:
+        - "area: Ethernet"
+
+"Drivers: Flash":
     status: maintained
     maintainers:
         - nvlsianpu
@@ -228,6 +441,290 @@ Flash:
         - samples/drivers/flash_shell/
     labels:
         - "area: Flash"
+
+"Drivers: GPIO":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - mnkp
+    files:
+        - doc/reference/peripherals/gpio.rst 
+        - drivers/gpio/
+        - include/drivers/gpio/
+        - include/drivers/gpio.h
+        - include/gpio.h
+        - include/dt-bindings/gpio/
+        - tests/drivers/gpio/
+        - samples/drivers/gpio/
+    labels:
+        - "area: GPIO"
+
+"Drivers: HW Info":
+    status: orphaned
+    collaborators:
+        - alexanderwachter
+    files:
+        - drivers/hwinfo/
+        - dts/bindings/hwinfo/
+        - include/drivers/hwinfo.h
+        - include/hwinfo.h
+        - tests/drivers/hwinfo/
+    labels:
+        - "area: HWINFO"
+
+"Drivers: IEEE 802.15.4":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - tbursztyka
+    collaborators:
+        - jukkar
+    files:
+        - drivers/ieee802154/
+
+"Drivers: Interrupt controllers":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - drivers/interrupt_controller/
+        - dts/bindings/interrupt-controller/
+        - include/drivers/interrupt_controller/
+        - include/dt-bindings/interrupt-controller/
+
+"Drivers: IPM":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - andrewboie
+    files:
+        - drivers/ipm/
+    description: >-
+        Inter-processor mailboxes
+
+"Drivers: I2C":
+    # Provisional entry, to be corrected
+    # TODO: spreadsheet not matching CODEOWNERS
+    status: maintained
+    maintainers:
+        - mbolivar
+    files:
+        - drivers/i2c/
+        - dts/bindings/i2c/
+        - include/i2c.h
+        - include/drivers/i2c.h
+        - include/drivers/i2c/
+    labels:
+        - "area: I2C"
+
+"Drivers: I2S":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - doc/reference/peripherals/i2s.rst
+        - drivers/i2s/
+        - dts/bindings/i2s/
+        - include/i2s.h
+        - include/drivers/i2s.h
+        - tests/drivers/i2s/
+    labels:
+        - "area: I2S"
+
+"Drivers: kscan":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - drivers/kscan/
+        - include/drivers/kscan.h
+        - samples/drivers/espi/
+        - tests/drivers/kscan/
+
+"Drivers: lora":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - drivers/lora/
+        - include/drivers/lora.h
+        - samples/drivers/lora/
+
+"Drivers: LED":
+    # Provisional entry, to be corrected
+    status: orphaned
+    collaborators:
+        - Mani-Sadhasivam
+    files:
+        - drivers/led/
+        - include/led.h
+        - include/drivers/led/
+        - include/drivers/led.h
+        - samples/drivers/led_*/
+    labels:
+        - "area: LED"
+
+"Drivers: LED Strip":
+    # Provisional entry, to be corrected
+    status: orphaned
+    collaborators:
+        - mbolivar
+    files:
+        - drivers/led_strip/
+        - dts/bindings/led_strip/
+        - include/led_strip.h
+        - include/drivers/led_strip.h
+
+"Drivers: Modem":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - mike-scott
+    files:
+        - drivers/modem/
+    labels:
+        - "area: Modem"
+
+"Drivers: Neural networking":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - drivers/neural_net/
+
+"Drivers: PCI":
+    # Provisional entry, to be corrected
+    # TODO: spreadsheet not matching CODEOWNERS
+    status: maintained
+    maintainers:
+        - dcpleung
+    collaborators:
+        - andrewboie
+    files:
+        - drivers/pcie/
+        - include/drivers/pcie/
+    labels:
+        - "area: PCI"
+
+"Drivers: Pinmux":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - mnkp
+    files:
+        - doc/reference/peripherals/pinmux.rst 
+        - drivers/pinmux/
+        - include/drivers/pinmux.h
+        - include/pinmux.h
+        - tests/drivers/pinmux/
+    labels:
+        - "area: Pinmux"
+
+"Drivers: PWM":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - drivers/pwm/
+        - dts/bindings/pwm/
+        - include/drivers/pwm.h
+        - include/pwm.h
+        - tests/drivers/pwm/
+    labels:
+        - "area: PWM"
+
+"Drivers: Serial/UART":
+    status: maintained
+    maintainers:
+        - dcpleung
+    files:
+        - drivers/serial/
+        - dts/bindings/serial/
+    labels:
+        - "area: UART"
+
+"Drivers: Sensors":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - MaureenHelm
+    files:
+        - drivers/sensor/
+        - include/drivers/sensor.h
+        - samples/sensor/
+    labels:
+        - "area: Sensors"
+
+"Drivers: SPI":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - tbursztyka
+    files:
+        - drivers/spi/
+        - include/drivers/spi.h
+        - tests/drivers/spi/
+    labels:
+        - "area: SPI"
+
+"Drivers: System Timer":
+    # Provisional entry, to be corrected
+    # TODO: maintainers spreadsheet not matching CODEOWNERS
+    status: maintained
+    maintainers:
+        - andyross
+    files:
+        - drivers/timer/
+    labels:
+        - "area: Timer"
+
+"Drivers: Watchdog":
+    # Provisional entry, to be corrected
+    status: orphaned
+    files:
+        - doc/reference/peripherals/watchdog.rst
+        - drivers/watchdog/
+        - dts/bindings/watchdog/
+        - include/watchdog.h
+        - include/drivers/watchdog.h
+        - samples/drivers/watchdog/
+        - tests/drivers/watchdog/
+    labels:
+        - "area: Watchdog"
+
+"Drivers: WiFi":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - tbursztyka
+    collaborators:
+        - jukkar
+    files:
+        - drivers/wifi/
+    labels:
+        - "area: Wifi"
+
+"Drivers: WiFi es-WiFi":
+    # Provisional entry, to be corrected
+    collaborators:
+        - loicpoulain
+    files:
+        - drivers/wifi/eswifi/
+    description: >-
+        Inventek es-WiFi
+
+"File Systems":
+    # Provisional entry, to be corrected
+    status: orphaned
+    collaborators:
+        - nashif
+        - nvlsianpu
+        - pabigot
+        - vanwinkeljan
+        - Laczen
+        - wentongwu
+    files:
+        - include/fs/
+        - include/fs.h
+        - samples/subsys/fs/
+        - subsys/fs/
+        - tests/subsys/fs/
+    labels:
+        - "area: File System"
 
 Kconfig:
     status: maintained
@@ -242,6 +739,20 @@ Kconfig:
     description: >-
         See https://docs.zephyrproject.org/latest/guides/kconfig/index.html and
         https://docs.zephyrproject.org/latest/guides/porting/board_porting.html#default-board-configuration
+
+Kernel:
+    status: maintained
+    maintainers:
+        - andyross
+    collaborators:
+        - andrewboie
+    files:
+        - doc/reference/kernel/
+        - include/kernel*.h
+        - kernel/
+        - tests/kernel/
+    labels:
+        - "area: Kernel"
 
 Logging:
     # Provisional entry, to be corrected
@@ -269,11 +780,100 @@ Logging:
         - include/arch/posix/
         - scripts/valgrind.supp
         - soc/posix/
+        - subsys/debug/asan.c
         - tests/boards/native_posix/
     labels:
         - "area: native port"
     description: >-
         POSIX architecture and SOC, native_posix board, and related drivers
+
+"Networking":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - jukkar
+    collaborators:
+        - tbursztyka
+        - pfalcon
+    files:
+        - drivers/net/
+        - include/net/
+        - samples/net/
+        - subsys/net/
+    files-exclude:
+        - samples/net/sockets/coap_*/
+        - samples/net/lwm2m_client/
+        - subsys/net/lib/coap/
+        - subsys/net/lib/lwm2m/
+        - subsys/net/lib/openthread/
+        - subsys/net/lib/tls_credentials/
+    labels:
+        - "area: Networking"
+
+"Networking: BSD sockets":
+    # Provisional entry, to be corrected
+    maintainers:
+        - pfalcon
+    files:
+        - samples/net/sockets/
+        - subsys/net/lib/sockets/
+        - tests/net/socket/
+    labels:
+        - "area: Sockets"
+
+"Networking: Buffers":
+    # Provisional entry, to be corrected
+    maintainers:
+        - tbursztyka
+    collaborators:
+        - jhedberg
+    files:
+        - include/net/buf.h
+        - subsys/net/buf.c
+        - tests/net/buf/
+
+"Networking: CoAP":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - rveerama1
+    files:
+        - subsys/net/lib/coap/
+        - samples/net/sockets/coap_*/
+        - tests/net/lib/coap/
+
+"Networking: LWM2M":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - mike-scott
+    files:
+        - samples/net/lwm2m_client/
+        - subsys/net/lib/lwm2m/
+    labels:
+        - "area: LWM2M"
+
+"Networking: MQTT":
+    # Provisional entry, to be corrected
+    maintainers:
+        - rlubos
+    collaborators:
+        - jukkar
+    files:
+        - subsys/net/lib/mqtt/
+        - tests/net/lib/mqtt_packet/
+        - samples/net/mqtt_publisher/
+
+"NIOS-2 arch":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - nashif
+    files:
+        - arch/nios2/
+        - include/arch/nios2/
+    labels:
+        - "area: NIOS2"
 
 "nRF52 BSIM":
     status: maintained
@@ -284,6 +884,32 @@ Logging:
     labels:
         - "platform: nrf52_bsim"
 
+"POSIX API layer":
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - pfalcon
+    files:
+        - include/posix/
+        - lib/posix/
+        - tests/posix/
+    labels:
+        - "area: POSIX"
+
+"Power management":
+    # TSC : Note this entry differs from the spreadsheet:
+    # pizi-nordic is not anymore working in Zephyr, therefore he cannot be a
+    # maintainer, and the are is orphaned until a new maintainer is appointed
+    status: orphaned
+    collaborators:
+        - wentongwu
+    files:
+        - include/power/power.h
+        - samples/subsys/power/
+        - subsys/power/
+    labels:
+        - "area: Power Management"
+
 "RISCV arch":
     # Provisional entry, to be corrected
     status: maintained
@@ -293,6 +919,7 @@ Logging:
         - mgielda
     files:
         - arch/riscv/
+        - include/arch/riscv/
     labels:
         - "area: RISCV"
 
@@ -308,7 +935,6 @@ Sanitycheck:
         - "area: Sanitycheck"
 
 Settings:
-    # Provisional entry, to be corrected
     status: maintained
     maintainers:
         - nvlsianpu
@@ -316,6 +942,7 @@ Settings:
         - include/settings/
         - subsys/settings/
         - tests/subsys/settings/
+        - doc/reference/runtime_conf/
     labels:
         - "area: Settings"
 
@@ -332,6 +959,19 @@ Shell:
         - tests/subsys/shell/
     labels:
         - "area: Shell"
+
+"ZTest and unit test infrastructure":
+    # TODO @nashif is this what line 59 of the spreadsheet refers to?
+    # Provisional entry, to be corrected
+    status: maintained
+    maintainers:
+        - nashif
+    files:
+        - subsys/testsuite/
+        - tests/ztest/
+        - tests/unit/util/
+    labels:
+        - "area: Debugging"
 
 USB:
     # Provisional entry, to be corrected
@@ -351,16 +991,44 @@ USB:
     labels:
         - "area: USB"
 
-West:
+Userspace:
     # Provisional entry, to be corrected
     status: maintained
     maintainers:
-        - mbolivar
+        - andrewboie
+    files:
+        - doc/reference/usermode/kernelobjects.rst
+        - include/app_memory/
+        - include/linker/app_smem*.ld
+    labels:
+        - "area: Userspace"
+
+West:
+    status: maintained
+    maintainers:
+        - mbolivar-nordic
+    collaborators:
+        - carlescufi
     files:
         - scripts/west-commands.yml
         - scripts/west_commands/
     labels:
         - "area: West"
+
+"Xtensa arch":
+    status: maintained
+    maintainers:
+        - dcpleung
+    collaborators:
+        - andyross
+        - andrewboie
+    files:
+        - arch/xtensa/
+        - include/arch/xtensa/
+        - dts/xtensa/
+        - tests/arch/xtensa_asm2/
+    labels:
+        - "area: Xtensa"
 
 "x86 arch":
     # Provisional entry, to be corrected
@@ -371,5 +1039,7 @@ West:
         - andyross
     files:
         - arch/x86/
+        - include/arch/x86/
+        - tests/arch/x86/
     labels:
         - "area: X86"

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -183,7 +183,7 @@ Bluetooth Mesh:
 Build system:
     status: maintained
     maintainers:
-        - SebastianBoe
+        - tejlmand
     collaborators:
         - nashif
     files:
@@ -267,9 +267,9 @@ Display drivers:
 
 Documentation:
     # Provisional entry, to be corrected
-    status: maintained
-    maintainers:
-        - dbkinder
+    status: orphaned
+    collaborators:
+        - nashif
     files:
         - doc/
     files-regex:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -217,6 +217,16 @@ CMSIS API layer:
     files:
          - lib/cmsis_rtos_v*/
 
+Common arch:
+    status: maintained
+    maintainers:
+        - andrewboie
+    files:
+        - arch/common/
+        - include/arch/common/
+    labels:
+        - "area: Architectures"
+
 Debug:
     # Provisional entry, to be corrected
     status: maintained

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -258,6 +258,8 @@ Devicetree:
         - include/display.h
         - include/display/
         - include/drivers/display.h
+        - lib/gui/
+        - subsys/fb/
     labels:
         - "area: Display"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -759,6 +759,17 @@ Logging:
     labels:
         - "area: Logging"
 
+MAINTAINERS file:
+    status: maintained
+    maintainers:
+        - MaureenHelm
+    files:
+        - MAINTAINERS.yml
+    labels:
+        - "area: Process"
+    description:
+        Zephyr Maintainers File
+
 Native POSIX and POSIX arch:
     status: maintained
     maintainers:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -222,7 +222,6 @@ Debug:
     files:
         - include/debug/
         - subsys/debug/
-        - tests/subsys/debug/
     labels:
         - "area: Debugging"
 
@@ -258,7 +257,7 @@ Display drivers:
     files:
         - drivers/display/
         - dts/bindings/display/
-        - include/display.h
+        - include/drivers/display.h
         - include/display/
         - include/drivers/display.h
         - lib/gui/
@@ -330,7 +329,7 @@ Documentation:
     files:
         - drivers/clock_control/
         - dts/bindings/clock/
-        - include/clock_control.h
+        - include/drivers/clock_control.h
         - include/dt-bindings/clock/
         - tests/drivers/clock_control/
     labels:
@@ -444,7 +443,6 @@ Documentation:
         - drivers/flash/
         - dts/bindings/flash_controller/
         - include/drivers/flash.h
-        - include/flash.h
         - samples/drivers/flash_shell/
     labels:
         - "area: Flash"
@@ -459,7 +457,6 @@ Documentation:
         - drivers/gpio/
         - include/drivers/gpio/
         - include/drivers/gpio.h
-        - include/gpio.h
         - include/dt-bindings/gpio/
         - tests/drivers/gpio/
         - samples/drivers/gpio/
@@ -474,7 +471,6 @@ Documentation:
         - drivers/hwinfo/
         - dts/bindings/hwinfo/
         - include/drivers/hwinfo.h
-        - include/hwinfo.h
         - tests/drivers/hwinfo/
     labels:
         - "area: HWINFO"
@@ -513,7 +509,6 @@ Documentation:
     files:
         - drivers/i2c/
         - dts/bindings/i2c/
-        - include/i2c.h
         - include/drivers/i2c.h
         - include/drivers/i2c/
     labels:
@@ -526,7 +521,6 @@ Documentation:
         - doc/reference/peripherals/i2s.rst
         - drivers/i2s/
         - dts/bindings/i2s/
-        - include/i2s.h
         - include/drivers/i2s.h
         - tests/drivers/i2s/
     labels:
@@ -556,7 +550,6 @@ Documentation:
         - Mani-Sadhasivam
     files:
         - drivers/led/
-        - include/led.h
         - include/drivers/led/
         - include/drivers/led.h
         - samples/drivers/led_*/
@@ -570,7 +563,6 @@ Documentation:
     files:
         - drivers/led_strip/
         - dts/bindings/led_strip/
-        - include/led_strip.h
         - include/drivers/led_strip.h
 
 "Drivers: Modem":
@@ -612,8 +604,6 @@ Documentation:
         - doc/reference/peripherals/pinmux.rst
         - drivers/pinmux/
         - include/drivers/pinmux.h
-        - include/pinmux.h
-        - tests/drivers/pinmux/
     labels:
         - "area: Pinmux"
 
@@ -624,7 +614,6 @@ Documentation:
         - drivers/pwm/
         - dts/bindings/pwm/
         - include/drivers/pwm.h
-        - include/pwm.h
         - tests/drivers/pwm/
     labels:
         - "area: PWM"
@@ -681,7 +670,6 @@ Documentation:
         - doc/reference/peripherals/watchdog.rst
         - drivers/watchdog/
         - dts/bindings/watchdog/
-        - include/watchdog.h
         - include/drivers/watchdog.h
         - samples/drivers/watchdog/
         - tests/drivers/watchdog/
@@ -721,7 +709,6 @@ Filesystems:
         - wentongwu
     files:
         - include/fs/
-        - include/fs.h
         - samples/subsys/fs/
         - subsys/fs/
         - tests/subsys/fs/
@@ -782,7 +769,6 @@ Native POSIX and POSIX arch:
         - include/arch/posix/
         - scripts/valgrind.supp
         - soc/posix/
-        - subsys/debug/asan.c
         - tests/boards/native_posix/
     labels:
         - "area: native port"
@@ -944,7 +930,6 @@ Settings:
         - include/settings/
         - subsys/settings/
         - tests/subsys/settings/
-        - doc/reference/runtime_conf/
     labels:
         - "area: Settings"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -176,6 +176,7 @@ Bluetooth Mesh:
         - trond-snekvik
     files:
         - subsys/bluetooth/mesh/
+        - include/bluetooth/mesh/
     labels:
         - "area: Bluetooth Mesh"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -65,11 +65,12 @@
 #         outsider's perspective.
 #
 #
-# All areas must have a 'files' and/or 'files-regex' key.
-# The other keys are optional.
-# It is very advisable to have a `status` key in all entries. Exceptions to this
-# would be sub-areas which add extra fields (for ex. more `collaborators` who
-# work only in that sub-area) to other areas.
+# All areas must have a 'files' and/or 'files-regex' key. The other keys are
+# optional.
+#
+# It is very advisable to have a `status` key in all entries. Exceptions to
+# this would be sub-areas which add extra fields (for ex. more `collaborators`
+# who work only in that sub-area) to other areas.
 #
 #
 # Workflow

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -561,10 +561,9 @@ Documentation:
         - "area: LED"
 
 "Drivers: LED Strip":
-    # Provisional entry, to be corrected
-    status: orphaned
-    collaborators:
-        - mbolivar
+    status: maintained
+    maintainers:
+        - mbolivar-nordic
     files:
         - drivers/led_strip/
         - dts/bindings/led_strip/

--- a/get_maintainer.py
+++ b/get_maintainer.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Lists maintainers for files or commits. Similar in function to
+scripts/get_maintainer.pl from Linux, but geared towards GitHub. The mapping is
+in MAINTAINERS.yml.
+
+The comment at the top of MAINTAINERS.yml in Zephyr documents the file format.
+
+See the help texts for the various subcommands for more information. They can
+be viewed with e.g.
+
+    ./get_maintainer.py path --help
+
+This executable doubles as a Python library. Identifiers not prefixed with '_'
+are part of the library API. The library documentation can be viewed with this
+command:
+
+    $ pydoc get_maintainer
+"""
+
+import argparse
+import operator
+import os
+import pathlib
+import re
+import shlex
+import subprocess
+import sys
+
+from yaml import load, YAMLError
+try:
+    # Use the speedier C LibYAML parser if available
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
+
+def _main():
+    # Entry point when run as an executable
+
+    args = _parse_args()
+    try:
+        args.cmd_fn(Maintainers(args.maintainers), args)
+    except (MaintainersError, GitError) as e:
+        _serr(e)
+
+
+def _parse_args():
+    # Parses arguments when run as an executable
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__)
+
+    parser.add_argument(
+        "-m", "--maintainers",
+        metavar="MAINTAINERS_FILE",
+        help="Maintainers file to load. If not specified, MAINTAINERS.yml in "
+             "the top-level repository directory is used, and must exist. "
+             "Paths in the maintainers file will always be taken as relative "
+             "to the top-level directory.")
+
+    subparsers = parser.add_subparsers(
+        help="Available commands (each has a separate --help text)")
+
+    id_parser = subparsers.add_parser(
+        "path",
+        help="List area(s) for paths")
+    id_parser.add_argument(
+        "paths",
+        metavar="PATH",
+        nargs="*",
+        help="Path to list areas for")
+    id_parser.set_defaults(cmd_fn=Maintainers._path_cmd)
+
+    commits_parser = subparsers.add_parser(
+        "commits",
+        help="List area(s) for commit range")
+    commits_parser.add_argument(
+        "commits",
+        metavar="COMMIT_RANGE",
+        nargs="*",
+        help="Commit range to list areas for (default: HEAD~..)")
+    commits_parser.set_defaults(cmd_fn=Maintainers._commits_cmd)
+
+    list_parser = subparsers.add_parser(
+        "list",
+        help="List files in areas")
+    list_parser.add_argument(
+        "area",
+        metavar="AREA",
+        nargs="?",
+        help="Name of area to list files in. If not specified, all "
+             "non-orphaned files are listed (all files that do not appear in "
+             "any area).")
+    list_parser.set_defaults(cmd_fn=Maintainers._list_cmd)
+
+    orphaned_parser = subparsers.add_parser(
+        "orphaned",
+        help="List orphaned files (files that do not appear in any area)")
+    orphaned_parser.add_argument(
+        "path",
+        metavar="PATH",
+        nargs="?",
+        help="Limit to files under PATH")
+    orphaned_parser.set_defaults(cmd_fn=Maintainers._orphaned_cmd)
+
+    args = parser.parse_args()
+    if not hasattr(args, "cmd_fn"):
+        # Called without a subcommand
+        sys.exit(parser.format_usage().rstrip())
+
+    return args
+
+
+class Maintainers:
+    """
+    Represents the contents of a maintainers YAML file.
+
+    These attributes are available:
+
+    areas:
+        A dictionary that maps area names to Area instances, for all areas
+        defined in the maintainers file
+
+    filename:
+        The path to the maintainers file
+    """
+    def __init__(self, filename=None):
+        """
+        Creates a Maintainers instance.
+
+        filename (default: None):
+            Path to the maintainers file to parse. If None, MAINTAINERS.yml in
+            the top-level directory of the Git repository is used, and must
+            exist.
+        """
+        self._toplevel = pathlib.Path(_git("rev-parse", "--show-toplevel"))
+
+        if filename is None:
+            self.filename = self._toplevel / "MAINTAINERS.yml"
+        else:
+            self.filename = pathlib.Path(filename)
+
+        self.areas = {}
+        for area_name, area_dict in _load_maintainers(self.filename).items():
+            area = Area()
+            area.name = area_name
+            area.status = area_dict["status"]
+            area.maintainers = area_dict.get("maintainers", [])
+            area.collaborators = area_dict.get("collaborators", [])
+            area.inform = area_dict.get("inform", [])
+            area.labels = area_dict.get("labels", [])
+            area.description = area_dict.get("description")
+            area._files = area_dict.get("files")
+            area._files_exclude = area_dict.get("files-exclude")
+            area._files_regex = area_dict.get("files-regex")
+            area._files_regex_exclude = area_dict.get("files-regex-exclude")
+            self.areas[area_name] = area
+
+    def path2areas(self, path):
+        """
+        Returns a list of Area instances for the areas that contain 'path',
+        taken as relative to the current directory
+        """
+        # Make directory paths end in '/' so that foo/bar matches foo/bar/.
+        # Skip this check in _contains() itself, because the isdir() makes it
+        # twice as slow in cases where it's not needed.
+        is_dir = os.path.isdir(path)
+
+        # Make 'path' relative to the repository root and normalize it.
+        # normpath() would remove a trailing '/', so we add it afterwards.
+        path = os.path.normpath(os.path.join(
+            os.path.relpath(os.getcwd(), self._toplevel),
+            path))
+
+        if is_dir:
+            path += "/"
+
+        return [area for area in self.areas.values()
+                if area._contains(path)]
+
+    def commits2areas(self, commits):
+        """
+        Returns a set() of Area instances for the areas that contain files that
+        are modified by the commit range in 'commits'. 'commits' could be e.g.
+        "HEAD~..", to inspect the tip commit
+        """
+        res = set()
+        # Final '--' is to disallow a path for 'commits', so that
+        # './get_maintainers.py some/file' errors out instead of doing nothing.
+        # That makes forgetting -f easier to notice.
+        for path in _git("diff", "--name-only", commits, "--").splitlines():
+            res.update(self.path2areas(path))
+        return res
+
+    def __repr__(self):
+        return "<Maintainers for '{}'>".format(self.filename)
+
+    #
+    # Command-line subcommands
+    #
+
+    def _path_cmd(self, args):
+        # 'path' subcommand implementation
+
+        for path in args.paths:
+            if not os.path.exists(path):
+                _serr("'{}': no such file or directory".format(path))
+
+        res = set()
+        orphaned = []
+        for path in args.paths:
+            areas = self.path2areas(path)
+            res.update(areas)
+            if not areas:
+                orphaned.append(path)
+
+        _print_areas(res)
+        if orphaned:
+            if res:
+                print()
+            print("Orphaned paths (not in any area):\n" + "\n".join(orphaned))
+
+    def _commits_cmd(self, args):
+        # 'commits' subcommand implementation
+
+        commits = args.commits or ("HEAD~..",)
+        _print_areas({area for commit_range in commits
+                           for area in self.commits2areas(commit_range)})
+
+    def _list_cmd(self, args):
+        # 'list' subcommand implementation
+
+        if args.area is None:
+            # List all files that appear in some area
+            for path in _ls_files():
+                for area in self.areas.values():
+                    if area._contains(path):
+                        print(path)
+                        break
+        else:
+            # List all files that appear in the given area
+            area = self.areas.get(args.area)
+            if area is None:
+                _serr("'{}': no such area defined in '{}'"
+                      .format(args.area, self.filename))
+
+            for path in _ls_files():
+                if area._contains(path):
+                    print(path)
+
+    def _orphaned_cmd(self, args):
+        # 'orphaned' subcommand implementation
+
+        if args.path is not None and not os.path.exists(args.path):
+            _serr("'{}': no such file or directory".format(args.path))
+
+        for path in _ls_files(args.path):
+            for area in self.areas.values():
+                if area._contains(path):
+                    break
+            else:
+                print(path)  # We get here if we never hit the 'break'
+
+
+class Area:
+    """
+    Represents an entry for an area in MAINTAINERS.yml.
+
+    These attributes are available:
+
+    status:
+        The status of the area, as a string. See MAINTAINERS.yml.
+
+    maintainers:
+        List of maintainers. Empty if the area has no 'maintainers' key.
+
+    collaborators:
+        List of collaborators. Empty if the area has no 'collaborators' key.
+
+    inform:
+        List of people to inform on pull requests. Empty if the area has no
+        'inform' key.
+
+    labels:
+        List of GitHub labels for the area. Empty if the area has no 'labels'
+        key.
+
+    description:
+        Text from 'description' key, or None if the area has no 'description'
+        key
+    """
+    def _contains(self, path):
+        # Returns True if the area contains 'path', and False otherwise
+
+        # Test exclusions first
+
+        if self._files_exclude is not None:
+            for glob in self._files_exclude:
+                if _glob_match(glob, path):
+                    return False
+
+        if self._files_regex_exclude is not None:
+            for regex in self._files_regex_exclude:
+                if re.search(regex, path):
+                    return False
+
+        if self._files is not None:
+            for glob in self._files:
+                if _glob_match(glob, path):
+                    return True
+
+        if self._files_regex is not None:
+            for regex in self._files_regex:
+                if re.search(regex, path):
+                    return True
+
+        return False
+
+    def __repr__(self):
+        return "<Area {}>".format(self.name)
+
+
+def _print_areas(areas):
+    first = True
+    for area in sorted(areas, key=operator.attrgetter("name")):
+        if not first:
+            print()
+        first = False
+
+        print("""\
+{}
+\tstatus: {}
+\tmaintainers: {}
+\tcollaborators: {}
+\tinform: {}
+\tlabels: {}
+\tdescription: {}""".format(area.name,
+                            area.status,
+                            ", ".join(area.maintainers),
+                            ", ".join(area.collaborators),
+                            ", ".join(area.inform),
+                            ", ".join(area.labels),
+                            area.description or ""))
+
+
+def _glob_match(glob, path):
+    # Returns True if 'path' matches the pattern 'glob' from a
+    # 'files(-exclude)' entry in MAINTAINERS.yml
+
+    match_fn = re.match if glob.endswith("/") else re.fullmatch
+    regex = glob.replace(".", "\\.").replace("*", "[^/]*").replace("?", "[^/]")
+    return match_fn(regex, path)
+
+
+def _load_maintainers(path):
+    # Returns the parsed contents of the maintainers file 'filename', also
+    # running checks on the contents. The returned format is plain Python
+    # dicts/lists/etc., mirroring the structure of the file.
+
+    with open(path, encoding="utf-8") as f:
+        try:
+            yaml = load(f, Loader=Loader)
+        except YAMLError as e:
+            raise MaintainersError("{}: YAML error: {}".format(path, e))
+
+        _check_maintainers(path, yaml)
+        return yaml
+
+
+def _check_maintainers(maints_path, yaml):
+    # Checks the maintainers data in 'yaml', which comes from the maintainers
+    # file at maints_path, which is a pathlib.Path instance
+
+    root = maints_path.parent
+
+    def ferr(msg):
+        _err("{}: {}".format(maints_path, msg))  # Prepend the filename
+
+    if not isinstance(yaml, dict):
+        ferr("empty or malformed YAML (not a dict)")
+
+    ok_keys = {"status", "maintainers", "collaborators", "inform", "files",
+               "files-exclude", "files-regex", "files-regex-exclude",
+               "labels", "description"}
+
+    ok_status = {"maintained", "odd fixes", "orphaned", "obsolete"}
+    ok_status_s = ", ".join('"' + s + '"' for s in ok_status)  # For messages
+
+    for area_name, area_dict in yaml.items():
+        if not isinstance(area_dict, dict):
+            ferr("malformed entry for area '{}' (not a dict)"
+                 .format(area_name))
+
+        for key in area_dict:
+            if key not in ok_keys:
+                ferr("unknown key '{}' in area '{}'"
+                     .format(key, area_name))
+
+        if "status" not in area_dict:
+            ferr("missing 'status' key on area '{}', should be one of {}"
+                 .format(area_name, ok_status_s))
+
+        if area_dict["status"] not in ok_status:
+            ferr("bad 'status' key on area '{}', should be one of {}"
+                 .format(area_name, ok_status_s))
+
+        if not area_dict.keys() & {"files", "files-regex"}:
+            ferr("either 'files' or 'files-regex' (or both) must be specified "
+                 "for area '{}'".format(area_name))
+
+        for list_name in "maintainers", "collaborators", "inform", "files", \
+                         "files-regex", "labels":
+            if list_name in area_dict:
+                lst = area_dict[list_name]
+                if not (isinstance(lst, list) and
+                        all(isinstance(elm, str) for elm in lst)):
+                    ferr("malformed '{}' value for area '{}' -- should "
+                         "be a list of strings".format(list_name, area_name))
+
+        for files_key in "files", "files-exclude":
+            if files_key in area_dict:
+                for glob_pattern in area_dict[files_key]:
+                    # This could be changed if it turns out to be too slow,
+                    # e.g. to only check non-globbing filenames. The tuple() is
+                    # needed due to pathlib's glob() returning a generator.
+                    paths = tuple(root.glob(glob_pattern))
+                    if not paths:
+                        ferr("glob pattern '{}' in '{}' in area '{}' does not "
+                             "match any files".format(glob_pattern, files_key,
+                                                      area_name))
+                    if not glob_pattern.endswith("/"):
+                        for path in paths:
+                            if path.is_dir():
+                                ferr("glob pattern '{}' in '{}' in area '{}' "
+                                     "matches a directory, but has no "
+                                     "trailing '/'"
+                                     .format(glob_pattern, files_key,
+                                             area_name))
+
+        for files_regex_key in "files-regex", "files-regex-exclude":
+            if files_regex_key in area_dict:
+                for regex in area_dict[files_regex_key]:
+                    try:
+                        # This also caches the regex in the 're' module, so we
+                        # don't need to worry
+                        re.compile(regex)
+                    except re.error as e:
+                        ferr("bad regular expression '{}' in '{}' in "
+                             "'{}': {}".format(regex, files_regex_key,
+                                               area_name, e.msg))
+
+        if "description" in area_dict and \
+           not isinstance(area_dict["description"], str):
+            ferr("malformed 'description' value for area '{}' -- should be a "
+                 "string".format(area_name))
+
+
+def _git(*args):
+    # Helper for running a Git command. Returns the rstrip()ed stdout output.
+    # Called like git("diff"). Exits with SystemError (raised by sys.exit()) on
+    # errors.
+
+    git_cmd = ("git",) + args
+    git_cmd_s = " ".join(shlex.quote(word) for word in git_cmd)  # For errors
+
+    try:
+        git_process = subprocess.Popen(
+            git_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except FileNotFoundError:
+        _giterr("git executable not found (when running '{}'). Check that "
+                "it's in listed in the PATH environment variable"
+                .format(git_cmd_s))
+    except OSError as e:
+        _giterr("error running '{}': {}".format(git_cmd_s, e))
+
+    stdout, stderr = git_process.communicate()
+    if git_process.returncode:
+        _giterr("error running '{}'\n\nstdout:\n{}\nstderr:\n{}".format(
+            git_cmd_s, stdout.decode("utf-8"), stderr.decode("utf-8")))
+
+    return stdout.decode("utf-8").rstrip()
+
+
+def _ls_files(path=None):
+    cmd = ["ls-files"]
+    if path is not None:
+        cmd.append(path)
+    return _git(*cmd).splitlines()
+
+
+def _err(msg):
+    raise MaintainersError(msg)
+
+
+def _giterr(msg):
+    raise GitError(msg)
+
+
+def _serr(msg):
+    # For reporting errors when get_maintainer.py is run as a script.
+    # sys.exit() shouldn't be used otherwise.
+    sys.exit("{}: error: {}".format(sys.argv[0], msg))
+
+
+class MaintainersError(Exception):
+    "Exception raised for MAINTAINERS.yml-related errors"
+
+
+class GitError(Exception):
+    "Exception raised for Git-related errors"
+
+
+if __name__ == "__main__":
+    _main()

--- a/get_maintainer.py
+++ b/get_maintainer.py
@@ -150,7 +150,7 @@ class Maintainers:
         for area_name, area_dict in _load_maintainers(self.filename).items():
             area = Area()
             area.name = area_name
-            area.status = area_dict["status"]
+            area.status = area_dict.get("status")
             area.maintainers = area_dict.get("maintainers", [])
             area.collaborators = area_dict.get("collaborators", [])
             area.inform = area_dict.get("inform", [])
@@ -275,7 +275,8 @@ class Area:
     These attributes are available:
 
     status:
-        The status of the area, as a string. See MAINTAINERS.yml.
+        The status of the area, as a string. None if the area has no 'status'
+        key. See MAINTAINERS.yml.
 
     maintainers:
         List of maintainers. Empty if the area has no 'maintainers' key.
@@ -402,11 +403,8 @@ def _check_maintainers(maints_path, yaml):
                 ferr("unknown key '{}' in area '{}'"
                      .format(key, area_name))
 
-        if "status" not in area_dict:
-            ferr("missing 'status' key on area '{}', should be one of {}"
-                 .format(area_name, ok_status_s))
-
-        if area_dict["status"] not in ok_status:
+        if "status" in area_dict and \
+           area_dict["status"] not in ok_status:
             ferr("bad 'status' key on area '{}', should be one of {}"
                  .format(area_name, ok_status_s))
 

--- a/get_maintainer.py
+++ b/get_maintainer.py
@@ -156,10 +156,10 @@ class Maintainers:
             area.inform = area_dict.get("inform", [])
             area.labels = area_dict.get("labels", [])
             area.description = area_dict.get("description")
-            area._files = area_dict.get("files")
-            area._files_exclude = area_dict.get("files-exclude")
-            area._files_regex = area_dict.get("files-regex")
-            area._files_regex_exclude = area_dict.get("files-regex-exclude")
+            area._files = area_dict.get("files", [])
+            area._files_exclude = area_dict.get("files-exclude", [])
+            area._files_regex = area_dict.get("files-regex", [])
+            area._files_regex_exclude = area_dict.get("files-regex-exclude", [])
             self.areas[area_name] = area
 
     def path2areas(self, path):
@@ -301,25 +301,21 @@ class Area:
 
         # Test exclusions first
 
-        if self._files_exclude is not None:
-            for glob in self._files_exclude:
-                if _glob_match(glob, path):
-                    return False
+        for glob in self._files_exclude:
+            if _glob_match(glob, path):
+                return False
 
-        if self._files_regex_exclude is not None:
-            for regex in self._files_regex_exclude:
-                if re.search(regex, path):
-                    return False
+        for regex in self._files_regex_exclude:
+            if re.search(regex, path):
+                return False
 
-        if self._files is not None:
-            for glob in self._files:
-                if _glob_match(glob, path):
-                    return True
+        for glob in self._files:
+            if _glob_match(glob, path):
+                return True
 
-        if self._files_regex is not None:
-            for regex in self._files_regex:
-                if re.search(regex, path):
-                    return True
+        for regex in self._files_regex:
+            if re.search(regex, path):
+                return True
 
         return False
 

--- a/get_maintainer.py
+++ b/get_maintainer.py
@@ -191,9 +191,8 @@ class Maintainers:
         "HEAD~..", to inspect the tip commit
         """
         res = set()
-        # Final '--' is to disallow a path for 'commits', so that
-        # './get_maintainers.py some/file' errors out instead of doing nothing.
-        # That makes forgetting -f easier to notice.
+        # Final '--' is to make sure 'commits' is interpreted as a commit range
+        # rather than a path. That might give better error messages.
         for path in _git("diff", "--name-only", commits, "--").splitlines():
             res.update(self.path2areas(path))
         return res


### PR DESCRIPTION
A script/library I've been working on with input from aescolar (who also
wrote most of the MAINTAINERS.yml file).

Please try it out and give feedback. There's a detailed --help text, and
the top of MAINTAINERS.yml explains the file format.

MAINTAINERS.yml needs to be fleshed out. To be done in future PRs after this one (skeleton) is merged

This probably won't be the final location of the script, but making a PR
against the Zephyr repo makes it easier to try out and update.

Some examples:

* Identify the subsystem(s) for a path:

      $ ./get_maintainer.py path arch/arc/Kconfig
      ARC arch
              status: maintained
              maintainers: ruuddw
              collaborators: vonhust
              inform:
              labels: area: ARC
              description:

      Kconfig
              status: maintained
              maintainers: ulfalizer
              collaborators:
              inform:
              labels: area: Kconfig

* Identify the subsystem(s) for a commit range:

      $ ./get_maintainer.py commits HEAD~5..
      Flash
              status: maintained
              maintainers: nvlsianpu
              collaborators:
              inform:
              labels: area: Flash
              description:

      Kconfig
              status: maintained
              maintainers: ulfalizer
              collaborators:
              inform:
              labels: area: Kconfig

* List all files in a subsystem:

      $ ./get_maintainer.py list "ARC arch"
      arch/arc/CMakeLists.txt
      arch/arc/Kconfig
      arch/arc/core/CMakeLists.txt
      arch/arc/core/arc_connect.c
      arch/arc/core/arc_smp.c
      arch/arc/core/cache.c
      ...

* List all orphaned files (files not in any subsystem):

      $ ./get_maintained.py orphaned
      .checkpatch.conf
      .clang-format
      .codecov.yml
      .editorconfig
      .gitattributes
      .github/ISSUE_TEMPLATE/bug_report.md
      .github/ISSUE_TEMPLATE/enhancement.md
      ...

Older versions of the script had flags instead of sub-commands, like
get_maintainer.pl, but it gets a bit messy with subcommand-specific
flags.