### PR TITLE
Add support for STM32F098xx SOC and Google Kukui reference board

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -62,6 +62,7 @@
 /boards/arm/disco_l475_iot1/              @erwango
 /boards/arm/frdm*/                        @MaureenHelm
 /boards/arm/frdm*/doc/                    @MaureenHelm @MeganHansen
+/boards/arm/google_*/                     @jackrosenthal
 /boards/arm/hexiwear*/                    @MaureenHelm
 /boards/arm/hexiwear*/doc/                @MaureenHelm @MeganHansen
 /boards/arm/lpcxpresso*/                  @MaureenHelm

--- a/boards/arm/google_kukui/CMakeLists.txt
+++ b/boards/arm/google_kukui/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_PINMUX)
+zephyr_library()
+zephyr_library_sources(pinmux.c)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+endif()

--- a/boards/arm/google_kukui/Kconfig.board
+++ b/boards/arm/google_kukui/Kconfig.board
@@ -1,0 +1,8 @@
+# Google Kukui EC
+
+# Copyright 2019 The Chromium OS Authors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_GOOGLE_KUKUI
+	bool "Google Kukui EC"
+	depends on SOC_STM32F098XX

--- a/boards/arm/google_kukui/Kconfig.defconfig
+++ b/boards/arm/google_kukui/Kconfig.defconfig
@@ -1,0 +1,18 @@
+# Google Kukui EC
+
+# Copyright 2019 The Chromium OS Authors
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_GOOGLE_KUKUI
+
+config BOARD
+	default "google_kukui"
+
+if UART_CONSOLE
+
+config UART_1
+	default y
+
+endif # UART_CONSOLE
+
+endif # BOARD_GOOGLE_KUKUI

--- a/boards/arm/google_kukui/board.cmake
+++ b/boards/arm/google_kukui/board.cmake
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/boards/arm/google_kukui/doc/index.rst
+++ b/boards/arm/google_kukui/doc/index.rst
@@ -1,0 +1,81 @@
+.. _google_kukui_board:
+
+Google Kukui EC
+###############
+
+Overview
+********
+
+Kukui is a reference board for Chromium OS-based devices Krane and
+Kodama. Zephyr has support for the STM32-based embedded controller
+(EC) on-board.
+
+Hardware
+********
+
+- STM32F098RCH6
+- MT6370 battery charger
+- BMM150 compass
+- BMM160 gyroscope
+- Connections to the MediaTek AP
+
+Supported Features
+==================
+
+The following features are supported:
+
++-----------+------------+-------------------------------------+
+| Interface | Controller | Driver/Component                    |
++===========+============+=====================================+
+| NVIC      | on-chip    | nested vector interrupt controller  |
++-----------+------------+-------------------------------------+
+| UART      | on-chip    | serial port-polling;                |
+|           |            | serial port-interrupt               |
++-----------+------------+-------------------------------------+
+| PINMUX    | on-chip    | pinmux                              |
++-----------+------------+-------------------------------------+
+| GPIO      | on-chip    | gpio                                |
++-----------+------------+-------------------------------------+
+| CLOCK     | on-chip    | reset and clock control             |
++-----------+------------+-------------------------------------+
+| FLASH     | on-chip    | flash memory                        |
++-----------+------------+-------------------------------------+
+| WATCHDOG  | on-chip    | independent watchdog                |
++-----------+------------+-------------------------------------+
+
+Other features (such as I2C) are not available in Zephyr.
+
+The default configuration can be found in the defconfig file:
+``boards/arm/google_kukui/google_kukui_defconfig``
+
+Connections and IOs
+===================
+
+Each of the GPIO pins can be configured by software as output
+(push-pull or open-drain), as input (with or without pull-up or
+pull-down), or as peripheral alternate function.
+
+Default Zephyr Peripheral Mapping:
+----------------------------------
+
+- UART_1 TX/RX : PA10/PA9
+
+Programming and Debugging
+*************************
+
+Build application as usual for the ``google_kukui`` board, and flash
+using Servo V2, μServo, or Servo V4 (CCD). See the
+`Chromium EC Flashing Documentation`_ for more information.
+
+Debugging
+=========
+
+Use SWD with a J-Link or ST-Link.
+
+References
+**********
+
+.. target-notes::
+
+.. _Chromium EC Flashing Documentation:
+   https://chromium.googlesource.com/chromiumos/platform/ec#Flashing-via-the-servo-debug-board

--- a/boards/arm/google_kukui/google_kukui.dts
+++ b/boards/arm/google_kukui/google_kukui.dts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 The Chromium OS Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <st/f0/stm32f098Xc.dtsi>
+
+/ {
+	model = "Google Kukui EC";
+	compatible = "st,stm32f098rc", "st,stm32f098";
+
+	chosen {
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+	};
+};
+
+&usart1 {
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 6Kb of storage at the end of the 256Kb of flash */
+		storage_partition: partition@3e800 {
+			label = "storage";
+			reg = <0x0003e800 0x00001800>;
+		};
+	};
+};
+

--- a/boards/arm/google_kukui/google_kukui.yaml
+++ b/boards/arm/google_kukui/google_kukui.yaml
@@ -1,0 +1,14 @@
+identifier: google_kukui
+name: Google Kukui EC
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+ram: 32
+flash: 256
+testing:
+  ignore_tags:
+    - net
+    - bluetooth

--- a/boards/arm/google_kukui/google_kukui_defconfig
+++ b/boards/arm/google_kukui/google_kukui_defconfig
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Zephyr Kernel Configuration
+CONFIG_ARM=y
+CONFIG_SOC_SERIES_STM32F0X=y
+
+# Platform Configuration
+CONFIG_SOC_STM32F098XX=y
+CONFIG_BOARD_GOOGLE_KUKUI=y
+
+# Serial Drivers
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Pinmux Driver
+CONFIG_PINMUX=y
+
+# GPIO Controller
+CONFIG_GPIO=y
+
+# Clock configuration
+CONFIG_CLOCK_CONTROL=y
+
+# Ideally, we would use HSI48, but this is not supported in
+# Zephyr. Use "basic" HSI (8 MHz).
+CONFIG_CORTEX_M_SYSTICK=y
+CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=8000000
+
+# SYSCLK selection
+CONFIG_CLOCK_STM32_SYSCLK_SRC_HSI=y

--- a/boards/arm/google_kukui/pinmux.c
+++ b/boards/arm/google_kukui/pinmux.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 The Chromium OS Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <device.h>
+#include <init.h>
+#include <drivers/pinmux.h>
+#include <sys/sys_io.h>
+
+#include <pinmux/stm32/pinmux_stm32.h>
+
+static const struct pin_config pinconf[] = {
+#ifdef CONFIG_UART_1
+	{STM32_PIN_PA9, STM32F0_PINMUX_FUNC_PA9_USART1_TX},
+	{STM32_PIN_PA10, STM32F0_PINMUX_FUNC_PA10_USART1_RX},
+#endif	/* CONFIG_UART_1 */
+};
+
+static int pinmux_stm32_init(struct device *port)
+{
+	ARG_UNUSED(port);
+
+	stm32_setup_pins(pinconf, ARRAY_SIZE(pinconf));
+
+	return 0;
+}
+
+SYS_INIT(pinmux_stm32_init, PRE_KERNEL_1,
+	 CONFIG_PINMUX_STM32_DEVICE_INITIALIZATION_PRIORITY);

--- a/dts/arm/st/f0/stm32f098Xc.dtsi
+++ b/dts/arm/st/f0/stm32f098Xc.dtsi
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019 The Chromium OS Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <mem.h>
+#include <st/f0/stm32f091.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(32)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(256)>;
+			};
+		};
+	};
+};

--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f098xx
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.stm32f098xx
@@ -1,0 +1,14 @@
+# ST Microelectronics STM32F098XX MCU
+
+# Copyright (c) 2019 The Chromium OS Authors
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32F098XX
+
+config SOC
+	default "stm32f098xx"
+
+config NUM_IRQS
+	default 31
+
+endif # SOC_STM32F098xx

--- a/soc/arm/st_stm32/stm32f0/Kconfig.soc
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.soc
@@ -25,4 +25,7 @@ config SOC_STM32F072XB
 config SOC_STM32F091XC
 	bool "STM32F091XC"
 
+config SOC_STM32F098XX
+	bool "STM32F098XX"
+
 endchoice


### PR DESCRIPTION
This adds support for the EC (embedded controller) on a Google reference board with codename "kukui". This board uses the STM32F098RC chip. We built an application for the board and verified UART functionality on the board.
