### PR TITLE
doc: getting_started: Fix clang toolchain use

### DIFF
--- a/doc/getting_started/toolchain_host.rst
+++ b/doc/getting_started/toolchain_host.rst
@@ -9,4 +9,4 @@ by your operating system.
 
 To use your host gcc, set the :envvar:`ZEPHYR_TOOLCHAIN_VARIANT`
 :ref:`environment variable <env_vars>` to ``host``. To use clang, set
-:envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``clang``.
+:envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``llvm``.


### PR DESCRIPTION
In order to use clang it is necessary to set the variable
ZEPHYR_TOOLCHAIN_VARIANT to llvm instead of clang.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>