### PR TITLE
Enable kbc 8042 lpc peripheral in eSPI driver

### DIFF
--- a/boards/arm/mec1501modular_assy6885/Kconfig.defconfig
+++ b/boards/arm/mec1501modular_assy6885/Kconfig.defconfig
@@ -71,12 +71,13 @@ config I2C_XEC_2
 
 endif # I2C
 
-if ESPI
+if ESPI_XEC
 
-config ESPI_XEC
+#PS/2 driver is compiled in terms of this flag.
+config ESPI_PERIPHERAL_8042_KBC
 	default y
 
-endif # ESPI
+endif #ESPI_XEC
 
 if RTOS_TIMER
 

--- a/drivers/espi/Kconfig
+++ b/drivers/espi/Kconfig
@@ -6,7 +6,7 @@
 menuconfig ESPI
 	bool "ESPI Driver"
 	help
-	  Enable ESPI Driver
+	  Enable ESPI Driver.
 
 if ESPI
 
@@ -20,69 +20,62 @@ config ESPI_SLAVE
 	bool "ESPI slave driver"
 	default y
 	help
-	  Enables eSPI driver in slave mode
+	  Enables eSPI driver in slave mode.
 
 config ESPI_INIT_PRIORITY
 	int "IRQ Priority for ESPI Controller"
 	default 3
 	help
-	  IRQ Priority for ESPI Controller
+	  IRQ Priority for ESPI Controller.
 
 config ESPI_PERIPHERAL_CHANNEL
 	bool "eSPI peripheral channel"
 	default y
 	help
-	  eSPI Controller supports peripheral channel
+	  eSPI Controller supports peripheral channel.
 
 config ESPI_VWIRE_CHANNEL
 	bool "eSPI virtual wire channel"
 	default y
 	help
-	  eSPI Controller supports virtual wires channel
+	  eSPI Controller supports virtual wires channel.
 
 config ESPI_OOB_CHANNEL
 	bool "eSPI Out-of-band channel"
-	default n
 	help
-	  eSPI Controller supports OOB channel
+	  eSPI Controller supports OOB channel.
 
 config ESPI_FLASH_CHANNEL
 	bool "ESPI flash channel"
-	default n
 	help
-	  eSPI Controller supports flash channel
+	  eSPI Controller supports flash channel.
 
 if ESPI_PERIPHERAL_CHANNEL
 
 config ESPI_PERIPHERAL_UART
 	bool "UART peripheral"
-	default n
 	help
-	  Enables UART over eSPI peripheral channel
+	  Enables UART over eSPI peripheral channel.
 
-config ESPI_PERIPHERAL_8042_KEYBOARD
-	bool "8042 keyboard peripheral"
-	default n
+config ESPI_PERIPHERAL_8042_KBC
+	bool "8042 kbc peripheral"
 	help
-	  Enables 8042 keyboard over eSPI peripheral channel
+	  Enables 8042 keyboard controller over eSPI peripheral channel.
 
 config ESPI_PERIPHERAL_HOST_IO
 	bool "Host I/O peripheral"
-	default n
 	help
-	  Enables ACPI Host I/O over eSPI peripheral channel
+	  Enables ACPI Host I/O over eSPI peripheral channel.
 
 config ESPI_PERIPHERAL_PORT_92
 	bool "Legacy Port 92 peripheral"
-	default n
 	help
-	  Enables legacy Port 92 over eSPI peripheral channel
+	  Enables legacy Port 92 over eSPI peripheral channel.
 
 config ESPI_PERIPHERAL_DEBUG_PORT_80
 	bool "Debug Port 80 peripheral"
-	default n
 	help
-	  Enables debug Port 80 over eSPI peripheral channel
+	  Enables debug Port 80 over eSPI peripheral channel.
 
 endif # ESPI_PERIPHERAL_CHANNEL
 

--- a/drivers/espi/Kconfig.xec
+++ b/drivers/espi/Kconfig.xec
@@ -7,18 +7,18 @@ config ESPI_XEC
 	bool "XEC Microchip ESPI driver"
 	depends on SOC_FAMILY_MEC
 	help
-	  Enable the Microchip XEC ESPI driver
+	  Enable the Microchip XEC ESPI driver.
 
 if ESPI_XEC
 
 config ESPI_PERIPHERAL_HOST_IO
-	def_bool y
+	default  y
 
 config ESPI_PERIPHERAL_DEBUG_PORT_80
-	def_bool y
+	default y
 
 config ESPI_PERIPHERAL_UART
-	def_bool y
+	default y
 
 config ESPI_PERIPHERAL_UART_SOC_MAPPING
 	int "SoC port exposed as logical eSPI UART"
@@ -26,6 +26,6 @@ config ESPI_PERIPHERAL_UART_SOC_MAPPING
 	depends on ESPI_PERIPHERAL_UART
 	help
 	  This tells the driver to which SoC UART to direct the UART traffic
-	  send over eSPI from host
+	  send over eSPI from host.
 
-endif # ESPI_XEC
+endif #ESPI_XEC

--- a/drivers/ps2/Kconfig.xec
+++ b/drivers/ps2/Kconfig.xec
@@ -5,9 +5,10 @@
 
 menuconfig PS2_XEC
 	bool "XEC Microchip PS2 driver"
-	depends on SOC_FAMILY_MEC
+	depends on SOC_FAMILY_MEC && ESPI_PERIPHERAL_8042_KBC
 	help
-	  Enable the Microchip XEC PS2 IO driver.
+	  Enable the Microchip XEC PS2 IO driver. The driver also
+	  depends on the KBC 8042 keyboard controller.
 
 if PS2_XEC
 

--- a/include/drivers/espi.h
+++ b/include/drivers/espi.h
@@ -135,6 +135,9 @@ enum espi_bus_event {
 
 #define ESPI_PERIPHERAL_NODATA   0ul
 
+#define E8042_START_OPCODE      0x50
+#define E8042_MAX_OPCODE        0x5F
+
 /** @endcond */
 
 /**
@@ -145,7 +148,7 @@ enum espi_bus_event {
  */
 enum espi_virtual_peripheral {
 	ESPI_PERIPHERAL_UART,
-	ESPI_PERIPHERAL_8042_KEYBOARD,
+	ESPI_PERIPHERAL_8042_KBC,
 	ESPI_PERIPHERAL_HOST_IO,
 	ESPI_PERIPHERAL_DEBUG_PORT80
 };
@@ -203,6 +206,20 @@ enum espi_vwire_signal {
 	ESPI_VWIRE_SIGNAL_SCI,
 	ESPI_VWIRE_SIGNAL_DNX_ACK,
 	ESPI_VWIRE_SIGNAL_SUS_ACK,
+};
+
+/* eSPI LPC peripherals. */
+enum lpc_peripheral_opcode {
+	/* Read transactions */
+	E8042_OBF_HAS_CHAR = 0x50,
+	E8042_IBF_HAS_CHAR,
+	/* Write transactions */
+	E8042_WRITE_KB_CHAR,
+	E8042_WRITE_MB_CHAR,
+	/* Write transactions without input parameters */
+	E8042_RESUME_IRQ,
+	E8042_PAUSE_IRQ,
+	E8042_CLEAR_OBF,
 };
 
 /**
@@ -313,6 +330,10 @@ typedef int (*espi_api_read_request)(struct device *dev,
 				     struct espi_request_packet);
 typedef int (*espi_api_write_request)(struct device *dev,
 				      struct espi_request_packet);
+typedef int (*espi_api_lpc_read_request)(struct device *dev,
+				enum lpc_peripheral_opcode op, u32_t *data);
+typedef int (*espi_api_lpc_write_request)(struct device *dev,
+				enum lpc_peripheral_opcode op, u32_t *data);
 /* Logical Channel 1 APIs */
 typedef int (*espi_api_send_vwire)(struct device *dev,
 				   enum espi_vwire_signal vw,
@@ -339,9 +360,11 @@ typedef int (*espi_api_manage_callback)(struct device *dev,
 
 struct espi_driver_api {
 	espi_api_config config;
-	espi_api_get_channel_status  get_channel_status;
+	espi_api_get_channel_status get_channel_status;
 	espi_api_read_request read_request;
 	espi_api_write_request write_request;
+	espi_api_lpc_read_request read_lpc_request;
+	espi_api_lpc_write_request write_lpc_request;
 	espi_api_send_vwire send_vwire;
 	espi_api_receive_vwire receive_vwire;
 	espi_api_send_oob send_oob;
@@ -477,7 +500,7 @@ static inline int z_impl_espi_read_request(struct device *dev,
  * @retval 0 If successful.
  * @retval -ENOTSUP if eSPI controller doesn't support raw packets and instead
  *         low memory transactions are handled by controller hardware directly.
- * @retval -EIO General input / output error, failed to send over the bus.
+ * @retval -EINVAL General input / output error, failed to send over the bus.
  */
 __syscall int espi_write_request(struct device *dev,
 				 struct espi_request_packet req);
@@ -493,6 +516,72 @@ static inline int z_impl_espi_write_request(struct device *dev,
 	}
 
 	return api->write_request(dev, req);
+}
+
+/**
+ * @brief Reads SOC data from a LPC peripheral with information
+ * updated over eSPI.
+ *
+ * This routine provides a generic interface to read a block whose
+ * information was updated by an eSPI transaction. Reading may trigger
+ * a transaction. The eSPI packet is assembled by the HW block.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param op Enum representing opcode for peripheral type and read request.
+ * @param data Parameter to be read from to the LPC peripheral.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOTSUP if eSPI peripheral is off or not supported.
+ * @retval -EINVAL for unimplemented lpc opcode, but in range.
+ */
+__syscall int espi_read_lpc_request(struct device *dev,
+				enum lpc_peripheral_opcode op, u32_t *data);
+
+static inline int z_impl_espi_read_lpc_request(struct device *dev,
+					       enum lpc_peripheral_opcode op,
+					       u32_t *data)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->driver_api;
+
+	if (!api->read_lpc_request) {
+		return -ENOTSUP;
+	}
+
+	return api->read_lpc_request(dev, op, data);
+}
+
+/**
+ * @brief Writes data to a LPC peripheral which generates an eSPI transaction.
+ *
+ * This routine provides a generic interface to write data to a block which
+ * triggers an eSPI transacion. The eSPI packet is assembled by the HW
+ * block.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param op Enum representing an opcode for peripheral type and write request.
+ * @param data Represents the parameter passed to the LPC peripheral.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOTSUP if eSPI peripheral is off or not supported.
+ * @retval -EINVAL for unimplemented lpc opcode, but in range.
+ */
+__syscall int espi_write_lpc_request(struct device *dev,
+				     enum lpc_peripheral_opcode op,
+				     u32_t *data);
+
+static inline int z_impl_espi_write_lpc_request(struct device *dev,
+						enum lpc_peripheral_opcode op,
+						u32_t *data)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->driver_api;
+
+	if (!api->write_lpc_request) {
+		return -ENOTSUP;
+	}
+
+	return api->write_lpc_request(dev, op, data);
 }
 
 /**

--- a/soc/arm/microchip_mec/common/soc_espi_channels.h
+++ b/soc/arm/microchip_mec/common/soc_espi_channels.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SOC_ESPI_CHANNELS_H_
+#define _SOC_ESPI_CHANNELS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/* Channel 0 - Peripheral Channel */
+
+/* 8042 event data */
+#define E8042_ISR_DATA_POS	8U
+#define E8042_ISR_CMD_DATA_POS	0U
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SOC_ESPI_CHANNELS_H_ */

--- a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz
@@ -46,6 +46,13 @@ config I2C_XEC
 
 endif # I2C
 
+if ESPI
+
+config ESPI_XEC
+	default y
+
+endif #ESPI
+
 if COUNTER
 
 config COUNTER_XEC

--- a/soc/arm/microchip_mec/mec1501/soc.h
+++ b/soc/arm/microchip_mec/mec1501/soc.h
@@ -16,6 +16,7 @@
 
 #include "../common/soc_gpio.h"
 #include "../common/soc_pins.h"
+#include "../common/soc_espi_channels.h"
 
 #endif
 


### PR DESCRIPTION
This change enables the emulated keyboard controller which enables bidirectional communication with the host over eSPI. Applications can receive keyboard commands,  then forward data to the PS/2 peripherals for configuration. The emulated keyboard controller peripheral is also used for sending keyboard and mouse data back to the host.