### PR TITLE
scripts: dtlib/edtlib: Make output consistent on Python 3.5-

### DIFF
--- a/scripts/dts/dtlib.py
+++ b/scripts/dts/dtlib.py
@@ -1183,9 +1183,9 @@ class Node:
       integer.
 
     props:
-      A dictionary that maps the properties defined on the node to their
-      values. 'props' is indexed by property name (a string), and values are
-      represented as 'bytes' arrays.
+      A collections.OrderedDict that maps the properties defined on the node to
+      their values. 'props' is indexed by property name (a string), and values
+      are represented as 'bytes' arrays.
 
       To convert property values to Python numbers or strings, use
       dtlib.to_num(), dtlib.to_nums(), or dtlib.to_string().
@@ -1199,7 +1199,8 @@ class Node:
       stored in big-endian format.
 
     nodes:
-      A dictionary containing the subnodes of the node, indexed by name.
+      A collections.OrderedDict containing the subnodes of the node, indexed by
+      name.
 
     labels:
       A list with all labels pointing to the node, in the same order as the
@@ -1230,8 +1231,8 @@ class Node:
         self.parent = parent
         self.dt = dt
 
-        self.props = {}
-        self.nodes = {}
+        self.props = collections.OrderedDict()
+        self.nodes = collections.OrderedDict()
         self.labels = []
         self._omit_if_no_ref = False
         self._is_referenced = False

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -22,23 +22,6 @@ The top-level entry point of the library is the EDT class. EDT.__init__() takes
 a .dts file to parse and a list of paths to directories containing bindings.
 """
 
-from collections import OrderedDict
-import os
-import re
-import sys
-
-import yaml
-try:
-    # Use the C LibYAML parser if available, rather than the Python parser.
-    # This makes e.g. gen_defines.py more than twice as fast.
-    from yaml import CLoader as Loader
-except ImportError:
-    from yaml import Loader
-
-from dtlib import DT, DTError, to_num, to_nums, TYPE_EMPTY, TYPE_NUMS, \
-                  TYPE_PHANDLE, TYPE_PHANDLES_AND_NUMS
-from grutils import Graph
-
 # NOTE: testedtlib.py is the test suite for this library. It can be run
 # directly as a script:
 #
@@ -81,6 +64,23 @@ from grutils import Graph
 #
 # - Please use ""-quoted strings instead of ''-quoted strings, just to make
 #   things consistent (''-quoting is more common otherwise in Python)
+
+from collections import OrderedDict
+import os
+import re
+import sys
+
+import yaml
+try:
+    # Use the C LibYAML parser if available, rather than the Python parser.
+    # This makes e.g. gen_defines.py more than twice as fast.
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
+from dtlib import DT, DTError, to_num, to_nums, TYPE_EMPTY, TYPE_NUMS, \
+                  TYPE_PHANDLE, TYPE_PHANDLES_AND_NUMS
+from grutils import Graph
 
 #
 # Public classes

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -53,19 +53,19 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
     #
 
     verify_streq(edt.get_node("/interrupt-parent-test/node").interrupts,
-                 "[<ControllerAndData, name: foo, controller: <Node /interrupt-parent-test/controller in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: {'one': 1, 'two': 2, 'three': 3}>, <ControllerAndData, name: bar, controller: <Node /interrupt-parent-test/controller in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: {'one': 4, 'two': 5, 'three': 6}>]")
+                 "[<ControllerAndData, name: foo, controller: <Node /interrupt-parent-test/controller in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: OrderedDict([('one', 1), ('two', 2), ('three', 3)])>, <ControllerAndData, name: bar, controller: <Node /interrupt-parent-test/controller in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: OrderedDict([('one', 4), ('two', 5), ('three', 6)])>]")
 
     verify_streq(edt.get_node("/interrupts-extended-test/node").interrupts,
-                 "[<ControllerAndData, controller: <Node /interrupts-extended-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, data: {'one': 1}>, <ControllerAndData, controller: <Node /interrupts-extended-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, data: {'one': 2, 'two': 3}>, <ControllerAndData, controller: <Node /interrupts-extended-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: {'one': 4, 'two': 5, 'three': 6}>]")
+                 "[<ControllerAndData, controller: <Node /interrupts-extended-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, data: OrderedDict([('one', 1)])>, <ControllerAndData, controller: <Node /interrupts-extended-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, data: OrderedDict([('one', 2), ('two', 3)])>, <ControllerAndData, controller: <Node /interrupts-extended-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: OrderedDict([('one', 4), ('two', 5), ('three', 6)])>]")
 
     verify_streq(edt.get_node("/interrupt-map-test/node@0").interrupts,
-                 "[<ControllerAndData, controller: <Node /interrupt-map-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, data: {'one': 0}>, <ControllerAndData, controller: <Node /interrupt-map-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, data: {'one': 0, 'two': 1}>, <ControllerAndData, controller: <Node /interrupt-map-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: {'one': 0, 'two': 0, 'three': 2}>]")
+                 "[<ControllerAndData, controller: <Node /interrupt-map-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, data: OrderedDict([('one', 0)])>, <ControllerAndData, controller: <Node /interrupt-map-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, data: OrderedDict([('one', 0), ('two', 1)])>, <ControllerAndData, controller: <Node /interrupt-map-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: OrderedDict([('one', 0), ('two', 0), ('three', 2)])>]")
 
     verify_streq(edt.get_node("/interrupt-map-test/node@1").interrupts,
-                 "[<ControllerAndData, controller: <Node /interrupt-map-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, data: {'one': 3}>, <ControllerAndData, controller: <Node /interrupt-map-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, data: {'one': 0, 'two': 4}>, <ControllerAndData, controller: <Node /interrupt-map-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: {'one': 0, 'two': 0, 'three': 5}>]")
+                 "[<ControllerAndData, controller: <Node /interrupt-map-test/controller-0 in 'test.dts', binding test-bindings/interrupt-1-cell.yaml>, data: OrderedDict([('one', 3)])>, <ControllerAndData, controller: <Node /interrupt-map-test/controller-1 in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, data: OrderedDict([('one', 0), ('two', 4)])>, <ControllerAndData, controller: <Node /interrupt-map-test/controller-2 in 'test.dts', binding test-bindings/interrupt-3-cell.yaml>, data: OrderedDict([('one', 0), ('two', 0), ('three', 5)])>]")
 
     verify_streq(edt.get_node("/interrupt-map-bitops-test/node@70000000E").interrupts,
-                 "[<ControllerAndData, controller: <Node /interrupt-map-bitops-test/controller in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, data: {'one': 3, 'two': 2}>]")
+                 "[<ControllerAndData, controller: <Node /interrupt-map-bitops-test/controller in 'test.dts', binding test-bindings/interrupt-2-cell.yaml>, data: OrderedDict([('one', 3), ('two', 2)])>]")
 
     #
     # Test 'reg'
@@ -103,7 +103,7 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
                  "<Node /parent/child-2 in 'test.dts', no binding>")
 
     verify_streq(edt.get_node("/parent").children,
-                 "{'child-1': <Node /parent/child-1 in 'test.dts', no binding>, 'child-2': <Node /parent/child-2 in 'test.dts', no binding>}")
+                 "OrderedDict([('child-1', <Node /parent/child-1 in 'test.dts', no binding>), ('child-2', <Node /parent/child-2 in 'test.dts', no binding>)])")
 
     verify_eq(edt.get_node("/parent/child-1").children, {})
 
@@ -115,7 +115,7 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
                  "Parent binding")
 
     verify_streq(edt.get_node("/binding-include").props,
-                 "{'foo': <Property, name: foo, type: int, value: 0>, 'bar': <Property, name: bar, type: int, value: 1>, 'baz': <Property, name: baz, type: int, value: 2>, 'qaz': <Property, name: qaz, type: int, value: 3>}")
+                 "OrderedDict([('foo', <Property, name: foo, type: int, value: 0>), ('bar', <Property, name: bar, type: int, value: 1>), ('baz', <Property, name: baz, type: int, value: 2>), ('qaz', <Property, name: qaz, type: int, value: 3>)])")
 
     #
     # Test 'child/parent-bus:'
@@ -137,15 +137,15 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
 
     verify_streq(child1.binding_path, "test-bindings/child-binding.yaml")
     verify_streq(child1.description, "child node")
-    verify_streq(child1.props, "{'child-prop': <Property, name: child-prop, type: int, value: 1>}")
+    verify_streq(child1.props, "OrderedDict([('child-prop', <Property, name: child-prop, type: int, value: 1>)])")
 
     verify_streq(child2.binding_path, "test-bindings/child-binding.yaml")
     verify_streq(child2.description, "child node")
-    verify_streq(child2.props, "{'child-prop': <Property, name: child-prop, type: int, value: 3>}")
+    verify_streq(child2.props, "OrderedDict([('child-prop', <Property, name: child-prop, type: int, value: 3>)])")
 
     verify_streq(grandchild.binding_path, "test-bindings/child-binding.yaml")
     verify_streq(grandchild.description, "grandchild node")
-    verify_streq(grandchild.props, "{'grandchild-prop': <Property, name: grandchild-prop, type: int, value: 2>}")
+    verify_streq(grandchild.props, "OrderedDict([('grandchild-prop', <Property, name: grandchild-prop, type: int, value: 2>)])")
 
     #
     # Test deprecated 'sub-node' key (replaced with 'child-binding') and
@@ -153,7 +153,7 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
     #
 
     verify_streq(edt.get_node("/deprecated/sub-node").props,
-                 "{'foos': <Property, name: foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /deprecated in 'test.dts', binding test-bindings/deprecated.yaml>, data: {'foo': 1, 'bar': 2}>]>}")
+                 "OrderedDict([('foos', <Property, name: foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /deprecated in 'test.dts', binding test-bindings/deprecated.yaml>, data: OrderedDict([('foo', 1), ('bar', 2)])>]>)])")
 
     #
     # Test Node.props (derived from DT and 'properties:' in the binding)
@@ -187,24 +187,24 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
                  "<Property, name: phandle-refs, type: phandles, value: [<Node /props/ctrl-1 in 'test.dts', binding test-bindings/phandle-array-controller-1.yaml>, <Node /props/ctrl-2 in 'test.dts', binding test-bindings/phandle-array-controller-2.yaml>]>")
 
     verify_streq(edt.get_node("/props").props["phandle-array-foos"],
-                 "<Property, name: phandle-array-foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-1 in 'test.dts', binding test-bindings/phandle-array-controller-1.yaml>, data: {'one': 1}>, <ControllerAndData, controller: <Node /props/ctrl-2 in 'test.dts', binding test-bindings/phandle-array-controller-2.yaml>, data: {'one': 2, 'two': 3}>]>")
+                 "<Property, name: phandle-array-foos, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-1 in 'test.dts', binding test-bindings/phandle-array-controller-1.yaml>, data: OrderedDict([('one', 1)])>, <ControllerAndData, controller: <Node /props/ctrl-2 in 'test.dts', binding test-bindings/phandle-array-controller-2.yaml>, data: OrderedDict([('one', 2), ('two', 3)])>]>")
 
     verify_streq(edt.get_node("/props").props["foo-gpios"],
-                 "<Property, name: foo-gpios, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-1 in 'test.dts', binding test-bindings/phandle-array-controller-1.yaml>, data: {'gpio-one': 1}>]>")
+                 "<Property, name: foo-gpios, type: phandle-array, value: [<ControllerAndData, controller: <Node /props/ctrl-1 in 'test.dts', binding test-bindings/phandle-array-controller-1.yaml>, data: OrderedDict([('gpio-one', 1)])>]>")
 
     #
     # Test <prefix>-map, via gpio-map (the most common case)
     #
 
     verify_streq(edt.get_node("/gpio-map/source").props["foo-gpios"],
-                 "<Property, name: foo-gpios, type: phandle-array, value: [<ControllerAndData, controller: <Node /gpio-map/destination in 'test.dts', binding test-bindings/gpio-dst.yaml>, data: {'val': 6}>, <ControllerAndData, controller: <Node /gpio-map/destination in 'test.dts', binding test-bindings/gpio-dst.yaml>, data: {'val': 5}>]>")
+                 "<Property, name: foo-gpios, type: phandle-array, value: [<ControllerAndData, controller: <Node /gpio-map/destination in 'test.dts', binding test-bindings/gpio-dst.yaml>, data: OrderedDict([('val', 6)])>, <ControllerAndData, controller: <Node /gpio-map/destination in 'test.dts', binding test-bindings/gpio-dst.yaml>, data: OrderedDict([('val', 5)])>]>")
 
     #
     # Test property default values given in bindings
     #
 
     verify_streq(edt.get_node("/defaults").props,
-                 r"{'int': <Property, name: int, type: int, value: 123>, 'array': <Property, name: array, type: array, value: [1, 2, 3]>, 'uint8-array': <Property, name: uint8-array, type: uint8-array, value: b'\x89\xab\xcd'>, 'string': <Property, name: string, type: string, value: 'hello'>, 'string-array': <Property, name: string-array, type: string-array, value: ['hello', 'there']>, 'default-not-used': <Property, name: default-not-used, type: int, value: 234>}")
+                 r"OrderedDict([('int', <Property, name: int, type: int, value: 123>), ('array', <Property, name: array, type: array, value: [1, 2, 3]>), ('uint8-array', <Property, name: uint8-array, type: uint8-array, value: b'\x89\xab\xcd'>), ('string', <Property, name: string, type: string, value: 'hello'>), ('string-array', <Property, name: string-array, type: string-array, value: ['hello', 'there']>), ('default-not-used', <Property, name: default-not-used, type: int, value: 234>)])")
 
     #
     # Test having multiple directories with bindings, with a different .dts file


### PR DESCRIPTION
Change:

```
scripts: dtlib/edtlib: Make output consistent on Python 3.5-

Python 3.5 and earlier do not preserve dictionary insertion order when
iterating over dictionaries, and do not give the same order between
runs. This broke the dtlib and edtlib test suites and made the output
jump around randomly between runs. It also made device INST_<n> numbers
non-deterministic, which broke some code on Python 3.5 (though
hardcoding device instance numbers in the code might be a bit shaky).

Fix it by using collections.OrderedDict instead of plain dict wherever
order matters. This makes the output identical on all supported Python
versions. It also allows testdtlib.py and testedtlib.py to run in CI,
which uses Python 3.5.

Fixes: #20571
```

Semi-related cleanup:

```
scripts: edtlib: Avoid modifying the global yaml.(C)Loader

edtlib is a library, and modifying yaml.(C)Loader directly interferes
with any binding loading in edtlib clients. To avoid that, add a custom
loader for bindings.

Internally, PyYAML does this, which is why defining a separate class
works:

    @classmethod
    def add_constructor(cls, tag, constructor):
        if not 'yaml_constructors' in cls.__dict__:
            cls.yaml_constructors = cls.yaml_constructors.copy()
        cls.yaml_constructors[tag] = constructor
```

Small cleanup:

```
scripts: edtlib: Move imports after overview comment

Might make the comment easier to spot.
```