### PR TITLE
tests: remove duplicate name for the kernel arch.interrupt test

### DIFF
--- a/tests/arch/arm/arm_interrupt/testcase.yaml
+++ b/tests/arch/arm/arm_interrupt/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  arch.interrupt:
+  arch.interrupt.arm:
     filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     tags: arm interrupt ignore_faults
     arch_whitelist: arm


### PR DESCRIPTION
After SanityCheck I found out, that test arch.interrupt still has same duplicate names.
To get rid of it, I decided to change test cases names.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>