### PR TITLE
boards: arm: nrf5340_dk: Enable DC/DC by default & Fix NRF_CACHE and NVMC macro defines

### DIFF
--- a/boards/arm/nrf5340_dk_nrf5340/Kconfig
+++ b/boards/arm/nrf5340_dk_nrf5340/Kconfig
@@ -5,6 +5,21 @@
 
 if BOARD_NRF5340_DK_NRF5340_CPUAPP || BOARD_NRF5340_DK_NRF5340_CPUAPPNS
 
+config BOARD_ENABLE_DCDC_APP
+	bool "Enable Application MCU DCDC converter"
+	select SOC_DCDC_NRF53X_APP
+	default y
+
+config BOARD_ENABLE_DCDC_NET
+	bool "Enable Network MCU DCDC converter"
+	select SOC_DCDC_NRF53X_NET
+	default y
+
+config BOARD_ENABLE_DCDC_HV
+	bool "Enable High Voltage DCDC converter"
+	select SOC_DCDC_NRF53X_HV
+	default y
+
 endif # BOARD_NRF5340_DK_NRF5340_CPUAPP || BOARD_NRF5340_DK_NRF5340_CPUAPPNS
 
 if BOARD_NRF5340_DK_NRF5340_CPUNET

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -89,6 +89,27 @@ config SOC_NRF5340_CPUNET_QKAA
 
 endchoice
 
+
+if SOC_NRF5340_CPUAPP
+
+config SOC_DCDC_NRF53X_APP
+	bool
+	help
+	  Enable nRF53 series System on Chip Application MCU DC/DC converter.
+
+config SOC_DCDC_NRF53X_NET
+	bool
+	help
+	  Enable nRF53 series System on Chip Network MCU DC/DC converter.
+
+config SOC_DCDC_NRF53X_HV
+	bool
+	help
+	  Enable nRF53 series System on Chip High Voltage DC/DC converter.
+
+endif # SOC_NRF5340_CPUAPP
+
+
 config NRF_ENABLE_CACHE
 	bool "Enable cache"
 	depends on (SOC_NRF5340_CPUAPP && !TRUSTED_EXECUTION_NONSECURE) \

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -47,10 +47,10 @@ static int nordicsemi_nrf53_init(struct device *arg)
 #ifdef CONFIG_NRF_ENABLE_CACHE
 #ifdef CONFIG_SOC_NRF5340_CPUAPP
 	/* Enable the instruction & data cache */
-	NRF_CACHE_S->ENABLE = CACHE_ENABLE_ENABLE_Msk;
+	NRF_CACHE->ENABLE = CACHE_ENABLE_ENABLE_Msk;
 #endif /* CONFIG_SOC_NRF5340_CPUAPP */
 #ifdef CONFIG_SOC_NRF5340_CPUNET
-	NRF_NVMC_NS->ICACHECNF |= NVMC_ICACHECNF_CACHEEN_Enabled;
+	NRF_NVMC->ICACHECNF |= NVMC_ICACHECNF_CACHEEN_Enabled;
 #endif /* CONFIG_SOC_NRF5340_CPUNET */
 #endif
 

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -59,6 +59,16 @@ static int nordicsemi_nrf53_init(struct device *arg)
 	*((u32_t *)0x500046D0) = 0x1;
 #endif
 
+#if defined(CONFIG_SOC_DCDC_NRF53X_APP)
+	NRF_REGULATORS->VREGMAIN.DCDCEN = 1;
+#endif
+#if defined(CONFIG_SOC_DCDC_NRF53X_NET)
+	NRF_REGULATORS->VREGRADIO.DCDCEN = 1;
+#endif
+#if defined(CONFIG_SOC_DCDC_NRF53X_HV)
+	NRF_REGULATORS->VREGH.DCDCEN = 1;
+#endif
+
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise
 	 */


### PR DESCRIPTION
Since the nRF5340 DK contains the required DC/DC circuitry,
enable it by default while keeping it configurable. This
reduces power consumption in application core , network
core and high voltage use.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>

Fixes #20695