### PR TITLE
kernel: Add typedef forward declaration check for portability.

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -364,7 +364,11 @@ static inline void k_obj_free(void *obj)
 struct __packed _k_thread_stack_element {
 	char data;
 };
+
+#ifndef ZEPHYR_INCLUDE_SYS_ARCH_INTERFACE_H_
+/* Forward declaration in include/sys/arch_interface.h */
 typedef struct _k_thread_stack_element k_thread_stack_t;
+#endif
 
 /**
  * @typedef k_thread_entry_t
@@ -384,7 +388,10 @@ typedef struct _k_thread_stack_element k_thread_stack_t;
  *
  * @return N/A
  */
+#ifndef ZEPHYR_INCLUDE_SYS_ARCH_INTERFACE_H_
+/* Forward declaration in include/sys/arch_interface.h */
 typedef void (*k_thread_entry_t)(void *p1, void *p2, void *p3);
+#endif
 
 #ifdef CONFIG_THREAD_MONITOR
 struct __thread_entry {


### PR DESCRIPTION
'k_thread_stack_t' and 'k_thread_entry_t' typedefs are forward-declared
in sys/arch_interface.h and, because this header is included by
arch/cpu.h, which is, in turn, included by kernel_includes.h, the
typedefs effectively get re-declared in kernel.h.

While this does not cause a compilation error when compiling with GCC
4.6 and above, GCC 4.5 and below strictly enforce the C99 standard and
do not allow redeclaration of the same typedef in the same scope.

This commit adds sys/arch_interface.h header inclusion checks in
kernel.h to skip declaration of the forward-declared typedefs.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>