### PR TITLE
[Backport v1.14-branch] tests: turn off watchdog for sam_e70 test kernel/critical

### DIFF
--- a/tests/kernel/critical/testcase.yaml
+++ b/tests/kernel/critical/testcase.yaml
@@ -5,7 +5,7 @@ tests:
   kernel.common:
     platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
     filter: not CONFIG_WDT_SAM
-  kernel.critical.sam:
+  kernel.common.sam:
     filter: CONFIG_WDT_SAM
     extra_configs:
       - CONFIG_WDT_DISABLE_AT_BOOT=y

--- a/tests/kernel/critical/testcase.yaml
+++ b/tests/kernel/critical/testcase.yaml
@@ -4,9 +4,13 @@ common:
 tests:
   kernel.common:
     platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
+    filter: not CONFIG_WDT_SAM
+  kernel.critical.sam:
+    filter: CONFIG_WDT_SAM
+    extra_configs:
+      - CONFIG_WDT_DISABLE_AT_BOOT=y
   kernel.common.nsim:
     platform_whitelist: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
     extra_configs:
       - CONFIG_TEST_USERSPACE=n
       - CONFIG_TEST_HW_STACK_PROTECTION=n
-


### PR DESCRIPTION
Wrong configuration of a watchdog in v1.14-branch for sam_e70_xplained_board caused
endless reboot loop. During tests I found out that if to decrease
NUM_MILLISECONDS numeric constant from 5000ms to 4000ms, then
test will complete successfully. It seems that problem caused by
a watchdog.
So to solve that issue were 2 variants. First is to make constant
NUM_MILLISECONDS less than 5000, for example 3000 or 4000.
Second variant to disable a watchdog using new config for the board
CONFIG_WDT_DISABLE_AT_BOOT=y
I decided to use second variant and created a new config file
for the sam_e70_xplained hardware board.

Signed-off-by: Maksim Masalski <maksim.masalski@intel.com>