### PR TITLE
drivers: flash: Rework soc_flash_nrf to aligned write

### DIFF
--- a/drivers/flash/Kconfig.nrf
+++ b/drivers/flash/Kconfig.nrf
@@ -33,4 +33,12 @@ config SOC_FLASH_NRF_UICR
 	  Enable operations on UICR. Once enabled UICR are written or read as
 	  ordinary flash memory. Erase is possible for whole UICR at once.
 
+config SOC_FLASH_NRF_OVERRIDE_WBS
+	bool "Override Write Block Size"
+	default n
+	help
+	  Override the standard write block size on nRF flash driver, sets the
+	  write block size to 1 byte. Using this option might reduce the number
+	  of writes that can be performed. If unsure, leave disabled.
+
 endif #!FLASH_NRF_FORCE_ALT


### PR DESCRIPTION
Standard flash write changed to word aligned write,
Use relative addresses instead of absolute,
Simplified writing in time slice setup,
Added Kconfig option `CONFIG_SOC_FLASH_NRF_OVERRIDE_WBS` that overrides the standard word size and sets it back to 1 byte alignment

Fixes: #20423,
Fixes: #20425 
Fixes: #20472 
Alternative to: #19720, #20471

Signed-off-by: Laczen JMS <laczenjms@gmail.com> 

