### PR TITLE
arch: arm: Fix non-existent include file directive

### DIFF
--- a/include/arch/arm/asm_inline.h
+++ b/include/arch/arm/asm_inline.h
@@ -17,7 +17,7 @@
 #if defined(__GNUC__)
 #include <arch/arm/asm_inline_gcc.h>
 #else
-#include <arch/arm/asm_inline_other.h>
+#error Unknown compiler.
 #endif
 
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM_ASM_INLINE_H_ */


### PR DESCRIPTION
asm_inline_other.h doesn't exist. Just print an error message if we are
not using GCC.