### PR TITLE
driver: watchdog: Error handling issues in wdt_wwdg_stm32.c

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -39,8 +39,12 @@ int i2c_stm32_runtime_configure(struct device *dev, u32_t config)
 	LL_RCC_GetSystemClocksFreq(&rcc_clocks);
 	clock = rcc_clocks.SYSCLK_Frequency;
 #else
-	clock_control_get_rate(device_get_binding(STM32_CLOCK_CONTROL_NAME),
-			(clock_control_subsys_t *) &cfg->pclken, &clock);
+	if (clock_control_get_rate(device_get_binding(STM32_CLOCK_CONTROL_NAME),
+			(clock_control_subsys_t *) &cfg->pclken, &clock) < 0) {
+		LOG_ERR("Failed call clock_control_get_rate");
+		return -EIO;
+	}
+
 #endif /* CONFIG_SOC_SERIES_STM32F3X) || CONFIG_SOC_SERIES_STM32F0X */
 
 	data->dev_config = config;

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -16,6 +16,9 @@
 
 #include "pwm_stm32.h"
 
+#include <logging/log.h>
+LOG_MODULE_REGISTER(pwm_stm32);
+
 /* convenience defines */
 #define DEV_CFG(dev)							\
 	((const struct pwm_stm32_config * const)(dev)->config->config_info)
@@ -160,8 +163,11 @@ static int pwm_stm32_get_cycles_per_sec(struct device *dev, u32_t pwm,
 	}
 
 	/* Timer clock depends on APB prescaler */
-	clock_control_get_rate(data->clock,
-			(clock_control_subsys_t *)&cfg->pclken, &bus_clk);
+	if (clock_control_get_rate(data->clock,
+			(clock_control_subsys_t *)&cfg->pclken, &bus_clk) < 0) {
+		LOG_ERR("Failed call clock_control_get_rate");
+		return -EIO;
+	}
 
 	tim_clk = __get_tim_clk(bus_clk,
 			(clock_control_subsys_t *)&cfg->pclken);

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -24,6 +24,9 @@
 #include <clock_control/stm32_clock_control.h>
 #include "uart_stm32.h"
 
+#include <logging/log.h>
+LOG_MODULE_REGISTER(uart_stm32);
+
 /* convenience defines */
 #define DEV_CFG(dev)							\
 	((const struct uart_stm32_config * const)(dev)->config->config_info)
@@ -43,10 +46,12 @@ static inline void uart_stm32_set_baudrate(struct device *dev, u32_t baud_rate)
 	u32_t clock_rate;
 
 	/* Get clock rate */
-	clock_control_get_rate(data->clock,
+	if (clock_control_get_rate(data->clock,
 			       (clock_control_subsys_t *)&config->pclken,
-			       &clock_rate);
-
+			       &clock_rate) < 0) {
+		LOG_ERR("Failed call clock_control_get_rate");
+		return;
+	}
 
 
 #ifdef CONFIG_LPUART_1

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -281,8 +281,11 @@ static int spi_stm32_configure(struct device *dev,
 		return -ENOTSUP;
 	}
 
-	clock_control_get_rate(device_get_binding(STM32_CLOCK_CONTROL_NAME),
-			       (clock_control_subsys_t) &cfg->pclken, &clock);
+	if (clock_control_get_rate(device_get_binding(STM32_CLOCK_CONTROL_NAME),
+			(clock_control_subsys_t) &cfg->pclken, &clock) < 0) {
+		LOG_ERR("Failed call clock_control_get_rate");
+		return -EIO;
+	}
 
 	for (br = 1 ; br <= ARRAY_SIZE(scaler) ; ++br) {
 		u32_t clk = clock >> br;

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -13,6 +13,9 @@
 
 #include "wdt_wwdg_stm32.h"
 
+#include <logging/log.h>
+LOG_MODULE_REGISTER(wdt_wwdg_stm32);
+
 #define WWDG_INTERNAL_DIVIDER   4096U
 #define WWDG_RESET_LIMIT    WWDG_COUNTER_MIN
 #define WWDG_COUNTER_MIN    0x40
@@ -66,8 +69,11 @@ static u32_t wwdg_stm32_get_pclk(struct device *dev)
 
 	__ASSERT_NO_MSG(clk);
 
-	clock_control_get_rate(clk, (clock_control_subsys_t *) &cfg->pclken,
-			       &pclk_rate);
+	if (clock_control_get_rate(clk, (clock_control_subsys_t *) &cfg->pclken,
+			       &pclk_rate) < 0) {
+		LOG_ERR("Failed call clock_control_get_rate");
+		return -EIO;
+	}
 
 	return pclk_rate;
 }


### PR DESCRIPTION
This patch changes wwdg_stm32_get_pclk function to test the return value of clock_control_get_rate
It fixes the issue Error handling issues in /drivers/watchdog/wdt_wwdg_stm32.c #20503 
[Coverity CID :205655]

Signed-off-by: Francois Ramu <francois.ramu@st.com>