### PR TITLE
API documentation: don't generate internal "z_impl_XX" APIS.

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -839,7 +839,7 @@ EXCLUDE_PATTERNS       =
 
 # Hide internal names (starting with an underscore, and doxygen-generated names
 # for nested unnamed unions that don't generate meaningful sphinx output anyway.
-EXCLUDE_SYMBOLS        = _*  *.__unnamed__
+EXCLUDE_SYMBOLS        = _*  *.__unnamed__ z_* Z_*
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include


### PR DESCRIPTION
For the 1.14-branch in github, internal APIs "z_impl_XX" should not be included into the API
documentaion when running doxgen commands, so we use the
EXCLUDE_SYMBOLS in doc/zephyr.doxyfile.in file to exclude those apis.

Signed-off-by: peng1 chen <peng1.chen@intel.com>