### PR TITLE
driver/sensor: lsm6dso: Fix unchecked return value

### DIFF
--- a/drivers/sensor/lsm6dso/lsm6dso_shub.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_shub.c
@@ -426,9 +426,9 @@ static inline void lsm6dso_shub_wait_completed(struct lsm6dso_data *data)
 static inline void lsm6dso_shub_embedded_en(struct lsm6dso_data *data, bool on)
 {
 	if (on) {
-		lsm6dso_mem_bank_set(data->ctx, LSM6DSO_SENSOR_HUB_BANK);
+		(void) lsm6dso_mem_bank_set(data->ctx, LSM6DSO_SENSOR_HUB_BANK);
 	} else {
-		lsm6dso_mem_bank_set(data->ctx, LSM6DSO_USER_BANK);
+		(void) lsm6dso_mem_bank_set(data->ctx, LSM6DSO_USER_BANK);
 	}
 
 	k_busy_wait(150);


### PR DESCRIPTION
Cast to (void) the lsm6dso_mem_bank_set() calls as we
are not interested to the return value.

Coverity-CID: 205625

Fix bug #20499 