### PR TITLE
openamp: ensure external openamp is build when target is out-of-date

### DIFF
--- a/samples/subsys/ipc/openamp/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/CMakeLists.txt
@@ -24,6 +24,7 @@ ExternalProject_Add(
   INSTALL_COMMAND ""      # This particular build system has no install command
   BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/openamp_remote-prefix/src/openamp_remote-build/zephyr/zephyr.bin"
   # NB: Do we need to pass on more CMake variables?
+  BUILD_ALWAYS True
 )
 add_dependencies(core_m0_inc_target openamp_remote)
 


### PR DESCRIPTION
Fixes: #19918
https://cmake.org/cmake/help/latest/module/ExternalProject.html

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>