### PR TITLE
driver: watchdog: Incorrect expression in wdt_wwdg_stm32.c

### DIFF
--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -84,7 +84,7 @@ static u32_t wwdg_stm32_get_timeout(struct device *dev, u32_t prescaler,
 				    u32_t counter)
 {
 	u32_t divider = WWDG_INTERNAL_DIVIDER * (1 << (prescaler >> 7));
-	float f_wwdg = wwdg_stm32_get_pclk(dev) / divider;
+	float f_wwdg = (float)wwdg_stm32_get_pclk(dev) / divider;
 
 	return USEC_PER_SEC * (((counter & 0x3F) + 1) / f_wwdg);
 }


### PR DESCRIPTION
This patch changes wwdg_stm32_get_timeout function to calculate f_wwdg to a float variable 
It fixes the issue Incorrect expression in /drivers/watchdog/wdt_wwdg_stm32.c #20504 

[Coverity CID :205661]

Signed-off-by: Francois Ramu <francois.ramu@st.com>