### PR TITLE
arch_interface: Remove duplicate irq_offload_routine_t typedef.

### DIFF
--- a/include/sys/arch_interface.h
+++ b/include/sys/arch_interface.h
@@ -301,8 +301,6 @@ int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
  */
 
 #ifdef CONFIG_IRQ_OFFLOAD
-typedef void (*irq_offload_routine_t)(void *parameter);
-
 /**
  * Run a function in interrupt context.
  *


### PR DESCRIPTION
This commit removes duplicate 'irq_offload_routine_t' typedef
declaration in sys/arch_interface.h.

This typedef is provided by irq_offload.h and, since this header file
is included at the top of sys/arch_interface.h, it is guaranteed to be
defined for arch_irq_offload definition.

While this does not cause a compilation error when compiling with GCC
4.6 and above, GCC 4.5 and below strictly enforce the C99 standard and
do not allow redeclaration of the same typedef in the same scope.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>