### PR TITLE
Bluetooth: hci_raw: Fix buffer init after allocation

### DIFF
--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -54,6 +54,7 @@ struct net_buf *bt_buf_get_rx(enum bt_buf_type type, s32_t timeout)
 	buf = net_buf_alloc(&hci_rx_pool, timeout);
 
 	if (buf) {
+		net_buf_reserve(buf, CONFIG_BT_HCI_RESERVE);
 		bt_buf_set_type(buf, type);
 	}
 
@@ -62,26 +63,12 @@ struct net_buf *bt_buf_get_rx(enum bt_buf_type type, s32_t timeout)
 
 struct net_buf *bt_buf_get_cmd_complete(s32_t timeout)
 {
-	struct net_buf *buf;
-
-	buf = net_buf_alloc(&hci_rx_pool, timeout);
-	if (buf) {
-		bt_buf_set_type(buf, BT_BUF_EVT);
-	}
-
-	return buf;
+	return bt_buf_get_rx(BT_BUF_EVT, timeout);
 }
 
 struct net_buf *bt_buf_get_evt(u8_t evt, bool discardable, s32_t timeout)
 {
-	struct net_buf *buf;
-
-	buf = net_buf_alloc(&hci_rx_pool, timeout);
-	if (buf) {
-		bt_buf_set_type(buf, BT_BUF_EVT);
-	}
-
-	return buf;
+	return bt_buf_get_rx(BT_BUF_EVT, timeout);
 }
 
 int bt_recv(struct net_buf *buf)


### PR DESCRIPTION
The code was not properly taking into account CONFIG_BT_HCI_RESERVE,
which would cause buffer underruns for any HCI driver where this value
defaults to non-zero. Also, all the allocation functions use the same
pool, so we can map them simply to bt_buf_get_rx() instead of
repeating the same code.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>