### PR TITLE
samples: i2c_scanner: provide more complete output

### DIFF
--- a/samples/drivers/i2c_scanner/src/main.c
+++ b/samples/drivers/i2c_scanner/src/main.c
@@ -23,12 +23,13 @@
 void main(void)
 {
 	struct device *i2c_dev;
+	u8_t cnt = 0;
 
 	printk("Starting i2c scanner...\n");
 
 	i2c_dev = device_get_binding(I2C_DEV);
 	if (!i2c_dev) {
-		printk("I2C: Device driver not found.\n");
+		printk("I2C: Device driver %s not found.\n", I2C_DEV);
 		return;
 	}
 
@@ -43,6 +44,9 @@ void main(void)
 
 		if (i2c_transfer(i2c_dev, &msgs[0], 1, i) == 0) {
 			printk("0x%2x FOUND\n", i);
+			++cnt;
 		}
 	}
+	printk("%u devices found on %s\n", cnt, I2C_DEV);
+
 }


### PR DESCRIPTION
Update the sample to indicate which device it was using, which helps
mitigate the existing problems identifyin Arduino I2C buses.  Also
output a summary of results so cases where no devices are found
provide output after the Starting... line.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>