### PR TITLE
ci: use v0.10.1 docker image

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -20,7 +20,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.9.1
+        image_tag: v0.10.1
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
Bump to v0.9.6 Docker Image to get access to SDK 0.11.0-alpha7 for
testing purposes.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>