### PR TITLE
west: prepend -c to openocd commands

### DIFF
--- a/boards/common/openocd-nrf5.board.cmake
+++ b/boards/common/openocd-nrf5.board.cmake
@@ -27,7 +27,7 @@ set(pre_init_cmds
 )
 
 foreach(cmd ${pre_init_cmds})
-  board_runner_args(openocd --cmd-pre-init "-c ${cmd}")
+  board_runner_args(openocd --cmd-pre-init "${cmd}")
 endforeach()
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -118,14 +118,30 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             raise ValueError('Cannot flash; verify command is missing')
 
         self.logger.info('Flashing file: {}'.format(self.hex_name))
+
+        pre_init_cmd = []
+        pre_load_cmd = []
+        post_verify_cmd = []
+        for i in self.pre_init:
+            pre_init_cmd.append("-c")
+            pre_init_cmd.append(i)
+
+        for i in self.pre_load:
+            pre_load_cmd.append("-c")
+            pre_load_cmd.append(i)
+
+        for i in self.post_verify:
+            post_verify_cmd.append("-c")
+            post_verify_cmd.append(i)
+
         cmd = (self.openocd_cmd + self.cfg_cmd +
-               self.pre_init + ['-c', 'init',
+               pre_init_cmd + ['-c', 'init',
                                 '-c', 'targets'] +
-               self.pre_load + ['-c', 'reset halt',
+               pre_load_cmd + ['-c', 'reset halt',
                                 '-c', self.load_cmd + ' ' + self.hex_name,
                                 '-c', 'reset halt'] +
                ['-c', self.verify_cmd + ' ' + self.hex_name] +
-               self.post_verify +
+               post_verify_cmd +
                ['-c', 'reset run',
                 '-c', 'shutdown'])
         self.check_call(cmd)
@@ -136,11 +152,16 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         if self.elf_name is None:
             raise ValueError('Cannot debug; no .elf specified')
 
+        pre_init_cmd = []
+        for i in self.pre_init:
+            pre_init_cmd.append("-c")
+            pre_init_cmd.append(i)
+
         server_cmd = (self.openocd_cmd + self.cfg_cmd +
                       ['-c', 'tcl_port {}'.format(self.tcl_port),
                        '-c', 'telnet_port {}'.format(self.telnet_port),
                        '-c', 'gdb_port {}'.format(self.gdb_port)] +
-                      self.pre_init + ['-c', 'init',
+                      pre_init_cmd + ['-c', 'init',
                                        '-c', 'targets',
                                        '-c', 'halt'])
         gdb_cmd = (self.gdb_cmd + self.tui_arg +
@@ -150,11 +171,16 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         self.run_server_and_client(server_cmd, gdb_cmd)
 
     def do_debugserver(self, **kwargs):
+        pre_init_cmd = []
+        for i in self.pre_init:
+            pre_init_cmd.append("-c")
+            pre_init_cmd.append(i)
+
         cmd = (self.openocd_cmd + self.cfg_cmd +
                ['-c', 'tcl_port {}'.format(self.tcl_port),
                 '-c', 'telnet_port {}'.format(self.telnet_port),
                 '-c', 'gdb_port {}'.format(self.gdb_port)] +
-               self.pre_init + ['-c', 'init',
+               pre_init_cmd + ['-c', 'init',
                                 '-c', 'targets',
                                 '-c', 'reset halt'])
         self.check_call(cmd)


### PR DESCRIPTION
commit 0df4a53107817b080d694ca8a18810d91d498799 changed the behavior of
how openocd commands are passed to openocd. We used to add -c to each
command, now the commands are being added without -c causing an error.

This adds "-c" to all commands instead of just passing a list.

Fixes #20449