### PR TITLE
net: tcp: do not drop data if the context is accepting connection

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2073,7 +2073,7 @@ resend_ack:
 	}
 
 	if (!IS_ENABLED(CONFIG_NET_TCP_AUTO_ACCEPT) &&
-	    net_context_is_accepting(context)) {
+	    !net_context_is_accepting(context)) {
 		data_len = 0;
 		do_not_send_ack = true;
 	} else {


### PR DESCRIPTION
Do not drop data if the context is accepting connection and
auto accept is disabled .

Testing IPSP sample I discovered that TCP implementation drops all incoming data. I am nor sure if it is correct fix, but together with #20581 I have got the IPSP sample working.