### PR TITLE
net: buf: Add support for reading/writing 24, 48 and 64 bit values

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -292,6 +292,30 @@ void net_buf_simple_add_le32(struct net_buf_simple *buf, u32_t val);
 void net_buf_simple_add_be32(struct net_buf_simple *buf, u32_t val);
 
 /**
+ * @brief Add 48-bit value at the end of the buffer
+ *
+ * Adds 48-bit value in little endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 48-bit value to be added.
+ */
+void net_buf_simple_add_le48(struct net_buf_simple *buf, u64_t val);
+
+/**
+ * @brief Add 48-bit value at the end of the buffer
+ *
+ * Adds 48-bit value in big endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 48-bit value to be added.
+ */
+void net_buf_simple_add_be48(struct net_buf_simple *buf, u64_t val);
+
+/**
  * @brief Push data to the beginning of the buffer.
  *
  * Modifies the data pointer and buffer length to account for more data
@@ -445,6 +469,30 @@ u32_t net_buf_simple_pull_le32(struct net_buf_simple *buf);
  * @return 32-bit value converted from big endian to host endian.
  */
 u32_t net_buf_simple_pull_be32(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 48 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_simple_pull(), but a helper for operating
+ * on 48-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 48-bit value converted from little endian to host endian.
+ */
+u64_t net_buf_simple_pull_le48(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 48 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_simple_pull(), but a helper for operating
+ * on 48-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 48-bit value converted from big endian to host endian.
+ */
+u64_t net_buf_simple_pull_be48(struct net_buf_simple *buf);
 
 /**
  * @brief Get the tail pointer for a buffer.
@@ -1213,6 +1261,32 @@ static inline void *net_buf_user_data(const struct net_buf *buf)
 #define net_buf_add_be32(buf, val) net_buf_simple_add_be32(&(buf)->b, val)
 
 /**
+ * @def net_buf_add_le48
+ * @brief Add 48-bit value at the end of the buffer
+ *
+ * Adds 48-bit value in little endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 48-bit value to be added.
+ */
+#define net_buf_add_le48(buf, val) net_buf_simple_add_le48(&(buf)->b, val)
+
+/**
+ * @def net_buf_add_be48
+ * @brief Add 48-bit value at the end of the buffer
+ *
+ * Adds 48-bit value in big endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 48-bit value to be added.
+ */
+#define net_buf_add_be48(buf, val) net_buf_simple_add_be48(&(buf)->b, val)
+
+/**
  * @def net_buf_push
  * @brief Push data to the beginning of the buffer.
  *
@@ -1379,6 +1453,32 @@ static inline void *net_buf_user_data(const struct net_buf *buf)
  * @return 32-bit value converted from big endian to host endian.
  */
 #define net_buf_pull_be32(buf) net_buf_simple_pull_be32(&(buf)->b)
+
+/**
+ * @def net_buf_pull_le48
+ * @brief Remove and convert 48 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_pull(), but a helper for operating on
+ * 48-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 48-bit value converted from little endian to host endian.
+ */
+#define net_buf_pull_le48(buf) net_buf_simple_pull_le48(&(buf)->b)
+
+/**
+ * @def net_buf_pull_be48
+ * @brief Remove and convert 48 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_pull(), but a helper for operating on
+ * 48-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer
+ *
+ * @return 48-bit value converted from big endian to host endian.
+ */
+#define net_buf_pull_be48(buf) net_buf_simple_pull_be48(&(buf)->b)
 
 /**
  * @def net_buf_tailroom

--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -244,6 +244,30 @@ void net_buf_simple_add_le16(struct net_buf_simple *buf, u16_t val);
 void net_buf_simple_add_be16(struct net_buf_simple *buf, u16_t val);
 
 /**
+ * @brief Add 24-bit value at the end of the buffer
+ *
+ * Adds 24-bit value in little endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 24-bit value to be added.
+ */
+void net_buf_simple_add_le24(struct net_buf_simple *buf, u32_t val);
+
+/**
+ * @brief Add 24-bit value at the end of the buffer
+ *
+ * Adds 24-bit value in big endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 24-bit value to be added.
+ */
+void net_buf_simple_add_be24(struct net_buf_simple *buf, u32_t val);
+
+/**
  * @brief Add 32-bit value at the end of the buffer
  *
  * Adds 32-bit value in little endian format at the end of buffer.
@@ -373,6 +397,30 @@ u16_t net_buf_simple_pull_le16(struct net_buf_simple *buf);
  * @return 16-bit value converted from big endian to host endian.
  */
 u16_t net_buf_simple_pull_be16(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 24 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_simple_pull(), but a helper for operating
+ * on 24-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 24-bit value converted from little endian to host endian.
+ */
+u32_t net_buf_simple_pull_le24(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 24 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_simple_pull(), but a helper for operating
+ * on 24-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 24-bit value converted from big endian to host endian.
+ */
+u32_t net_buf_simple_pull_be24(struct net_buf_simple *buf);
 
 /**
  * @brief Remove and convert 32 bits from the beginning of the buffer.
@@ -1113,6 +1161,32 @@ static inline void *net_buf_user_data(const struct net_buf *buf)
 #define net_buf_add_be16(buf, val) net_buf_simple_add_be16(&(buf)->b, val)
 
 /**
+ * @def net_buf_add_le24
+ * @brief Add 24-bit value at the end of the buffer
+ *
+ * Adds 24-bit value in little endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 24-bit value to be added.
+ */
+#define net_buf_add_le24(buf, val) net_buf_simple_add_le24(&(buf)->b, val)
+
+/**
+ * @def net_buf_add_be24
+ * @brief Add 24-bit value at the end of the buffer
+ *
+ * Adds 24-bit value in big endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 24-bit value to be added.
+ */
+#define net_buf_add_be24(buf, val) net_buf_simple_add_be24(&(buf)->b, val)
+
+/**
  * @def net_buf_add_le32
  * @brief Add 32-bit value at the end of the buffer
  *
@@ -1253,6 +1327,32 @@ static inline void *net_buf_user_data(const struct net_buf *buf)
  * @return 16-bit value converted from big endian to host endian.
  */
 #define net_buf_pull_be16(buf) net_buf_simple_pull_be16(&(buf)->b)
+
+/**
+ * @def net_buf_pull_le24
+ * @brief Remove and convert 24 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_pull(), but a helper for operating on
+ * 24-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 24-bit value converted from little endian to host endian.
+ */
+#define net_buf_pull_le24(buf) net_buf_simple_pull_le24(&(buf)->b)
+
+/**
+ * @def net_buf_pull_be24
+ * @brief Remove and convert 24 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_pull(), but a helper for operating on
+ * 24-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 24-bit value converted from big endian to host endian.
+ */
+#define net_buf_pull_be24(buf) net_buf_simple_pull_be24(&(buf)->b)
 
 /**
  * @def net_buf_pull_le32

--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -316,6 +316,30 @@ void net_buf_simple_add_le48(struct net_buf_simple *buf, u64_t val);
 void net_buf_simple_add_be48(struct net_buf_simple *buf, u64_t val);
 
 /**
+ * @brief Add 64-bit value at the end of the buffer
+ *
+ * Adds 64-bit value in little endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 64-bit value to be added.
+ */
+void net_buf_simple_add_le64(struct net_buf_simple *buf, u64_t val);
+
+/**
+ * @brief Add 64-bit value at the end of the buffer
+ *
+ * Adds 64-bit value in big endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 64-bit value to be added.
+ */
+void net_buf_simple_add_be64(struct net_buf_simple *buf, u64_t val);
+
+/**
  * @brief Push data to the beginning of the buffer.
  *
  * Modifies the data pointer and buffer length to account for more data
@@ -493,6 +517,30 @@ u64_t net_buf_simple_pull_le48(struct net_buf_simple *buf);
  * @return 48-bit value converted from big endian to host endian.
  */
 u64_t net_buf_simple_pull_be48(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 64 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_simple_pull(), but a helper for operating
+ * on 64-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 64-bit value converted from little endian to host endian.
+ */
+u64_t net_buf_simple_pull_le64(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 64 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_simple_pull(), but a helper for operating
+ * on 64-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 64-bit value converted from big endian to host endian.
+ */
+u64_t net_buf_simple_pull_be64(struct net_buf_simple *buf);
 
 /**
  * @brief Get the tail pointer for a buffer.
@@ -1287,6 +1335,32 @@ static inline void *net_buf_user_data(const struct net_buf *buf)
 #define net_buf_add_be48(buf, val) net_buf_simple_add_be48(&(buf)->b, val)
 
 /**
+ * @def net_buf_add_le64
+ * @brief Add 64-bit value at the end of the buffer
+ *
+ * Adds 64-bit value in little endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 64-bit value to be added.
+ */
+#define net_buf_add_le64(buf, val) net_buf_simple_add_le64(&(buf)->b, val)
+
+/**
+ * @def net_buf_add_be64
+ * @brief Add 64-bit value at the end of the buffer
+ *
+ * Adds 64-bit value in big endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 64-bit value to be added.
+ */
+#define net_buf_add_be64(buf, val) net_buf_simple_add_be64(&(buf)->b, val)
+
+/**
  * @def net_buf_push
  * @brief Push data to the beginning of the buffer.
  *
@@ -1479,6 +1553,32 @@ static inline void *net_buf_user_data(const struct net_buf *buf)
  * @return 48-bit value converted from big endian to host endian.
  */
 #define net_buf_pull_be48(buf) net_buf_simple_pull_be48(&(buf)->b)
+
+/**
+ * @def net_buf_pull_le64
+ * @brief Remove and convert 64 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_pull(), but a helper for operating on
+ * 64-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 64-bit value converted from little endian to host endian.
+ */
+#define net_buf_pull_le64(buf) net_buf_simple_pull_le64(&(buf)->b)
+
+/**
+ * @def net_buf_pull_be64
+ * @brief Remove and convert 64 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_pull(), but a helper for operating on
+ * 64-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer
+ *
+ * @return 64-bit value converted from big endian to host endian.
+ */
+#define net_buf_pull_be64(buf) net_buf_simple_pull_be64(&(buf)->b)
 
 /**
  * @def net_buf_tailroom

--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -141,6 +141,18 @@ static inline void net_buf_simple_init(struct net_buf_simple *buf,
 }
 
 /**
+ * @brief Initialize a net_buf_simple object with data.
+ *
+ * Initialized buffer object with external data.
+ *
+ * @param buf Buffer to initialize.
+ * @param data External data pointer
+ * @param size Amount of data the pointed data buffer if able to fit.
+ */
+void net_buf_simple_init_with_data(struct net_buf_simple *buf,
+				   void *data, size_t size);
+
+/**
  * @brief Reset buffer
  *
  * Reset buffer data so it can be reused for other purposes.

--- a/include/sys/byteorder.h
+++ b/include/sys/byteorder.h
@@ -18,6 +18,9 @@
 
 /* Internal helpers only used by the sys_* APIs further below */
 #define __bswap_16(x) ((u16_t) ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8)))
+#define __bswap_24(x) ((u32_t) ((((x) >> 16) & 0xff) | \
+				   (((x)) & 0xff00) | \
+				   (((x) & 0xff) << 16)))
 #define __bswap_32(x) ((u32_t) ((((x) >> 24) & 0xff) | \
 				   (((x) >> 8) & 0xff00) | \
 				   (((x) & 0xff00) << 8) | \
@@ -47,20 +50,20 @@
  *  @return 16-bit integer in little-endian format.
  */
 
-/** @def sys_be16_to_cpu
- *  @brief Convert 16-bit integer from big-endian to host endianness.
+/** @def sys_le24_to_cpu
+ *  @brief Convert 24-bit integer from little-endian to host endianness.
  *
- *  @param val 16-bit integer in big-endian format.
+ *  @param val 24-bit integer in little-endian format.
  *
- *  @return 16-bit integer in host endianness.
+ *  @return 24-bit integer in host endianness.
  */
 
-/** @def sys_cpu_to_be16
- *  @brief Convert 16-bit integer from host endianness to big-endian.
+/** @def sys_cpu_to_le24
+ *  @brief Convert 24-bit integer from host endianness to little-endian.
  *
- *  @param val 16-bit integer in host endianness.
+ *  @param val 24-bit integer in host endianness.
  *
- *  @return 16-bit integer in big-endian format.
+ *  @return 24-bit integer in little-endian format.
  */
 
 /** @def sys_le32_to_cpu
@@ -77,6 +80,38 @@
  *  @param val 32-bit integer in host endianness.
  *
  *  @return 32-bit integer in little-endian format.
+ */
+
+/** @def sys_be16_to_cpu
+ *  @brief Convert 16-bit integer from big-endian to host endianness.
+ *
+ *  @param val 16-bit integer in big-endian format.
+ *
+ *  @return 16-bit integer in host endianness.
+ */
+
+/** @def sys_cpu_to_be16
+ *  @brief Convert 16-bit integer from host endianness to big-endian.
+ *
+ *  @param val 16-bit integer in host endianness.
+ *
+ *  @return 16-bit integer in big-endian format.
+ */
+
+/** @def sys_be24_to_cpu
+ *  @brief Convert 24-bit integer from big-endian to host endianness.
+ *
+ *  @param val 24-bit integer in big-endian format.
+ *
+ *  @return 24-bit integer in host endianness.
+ */
+
+/** @def sys_cpu_to_be24
+ *  @brief Convert 24-bit integer from host endianness to big-endian.
+ *
+ *  @param val 24-bit integer in host endianness.
+ *
+ *  @return 24-bit integer in big-endian format.
  */
 
 /** @def sys_be32_to_cpu
@@ -98,12 +133,16 @@
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define sys_le16_to_cpu(val) (val)
 #define sys_cpu_to_le16(val) (val)
-#define sys_be16_to_cpu(val) __bswap_16(val)
-#define sys_cpu_to_be16(val) __bswap_16(val)
+#define sys_le24_to_cpu(val) (val)
+#define sys_cpu_to_le24(val) (val)
 #define sys_le32_to_cpu(val) (val)
 #define sys_cpu_to_le32(val) (val)
 #define sys_le64_to_cpu(val) (val)
 #define sys_cpu_to_le64(val) (val)
+#define sys_be16_to_cpu(val) __bswap_16(val)
+#define sys_cpu_to_be16(val) __bswap_16(val)
+#define sys_be24_to_cpu(val) __bswap_24(val)
+#define sys_cpu_to_be24(val) __bswap_24(val)
 #define sys_be32_to_cpu(val) __bswap_32(val)
 #define sys_cpu_to_be32(val) __bswap_32(val)
 #define sys_be64_to_cpu(val) __bswap_64(val)
@@ -111,12 +150,16 @@
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define sys_le16_to_cpu(val) __bswap_16(val)
 #define sys_cpu_to_le16(val) __bswap_16(val)
-#define sys_be16_to_cpu(val) (val)
-#define sys_cpu_to_be16(val) (val)
+#define sys_le24_to_cpu(val) __bswap_24(val)
+#define sys_cpu_to_le24(val) __bswap_24(val)
 #define sys_le32_to_cpu(val) __bswap_32(val)
 #define sys_cpu_to_le32(val) __bswap_32(val)
 #define sys_le64_to_cpu(val) __bswap_64(val)
 #define sys_cpu_to_le64(val) __bswap_64(val)
+#define sys_be16_to_cpu(val) (val)
+#define sys_cpu_to_be16(val) (val)
+#define sys_be24_to_cpu(val) (val)
+#define sys_cpu_to_be24(val) (val)
 #define sys_be32_to_cpu(val) (val)
 #define sys_cpu_to_be32(val) (val)
 #define sys_be64_to_cpu(val) (val)
@@ -138,6 +181,21 @@ static inline void sys_put_be16(u16_t val, u8_t dst[2])
 {
 	dst[0] = val >> 8;
 	dst[1] = val;
+}
+
+/**
+ *  @brief Put a 24-bit integer as big-endian to arbitrary location.
+ *
+ *  Put a 24-bit integer, originally in host endianness, to a
+ *  potentially unaligned memory location in big-endian format.
+ *
+ *  @param val 24-bit integer in host endianness.
+ *  @param dst Destination memory address to store the result.
+ */
+static inline void sys_put_be24(u32_t val, u8_t dst[3])
+{
+	dst[0] = val >> 16;
+	sys_put_be16(val, &dst[1]);
 }
 
 /**
@@ -186,6 +244,21 @@ static inline void sys_put_le16(u16_t val, u8_t dst[2])
 }
 
 /**
+ *  @brief Put a 24-bit integer as little-endian to arbitrary location.
+ *
+ *  Put a 24-bit integer, originally in host endianness, to a
+ *  potentially unaligned memory location in littel-endian format.
+ *
+ *  @param val 24-bit integer in host endianness.
+ *  @param dst Destination memory address to store the result.
+ */
+static inline void sys_put_le24(u32_t val, u8_t dst[3])
+{
+	sys_put_le16(val, dst);
+	dst[2] = val >> 16;
+}
+
+/**
  *  @brief Put a 32-bit integer as little-endian to arbitrary location.
  *
  *  Put a 32-bit integer, originally in host endianness, to a
@@ -231,6 +304,21 @@ static inline u16_t sys_get_be16(const u8_t src[2])
 }
 
 /**
+ *  @brief Get a 24-bit integer stored in big-endian format.
+ *
+ *  Get a 24-bit integer, stored in big-endian format in a potentially
+ *  unaligned memory location, and convert it to the host endianness.
+ *
+ *  @param src Location of the big-endian 24-bit integer to get.
+ *
+ *  @return 24-bit integer in host endianness.
+ */
+static inline u32_t sys_get_be24(const u8_t src[3])
+{
+	return ((u32_t)src[0] << 16) | sys_get_be16(&src[1]);
+}
+
+/**
  *  @brief Get a 32-bit integer stored in big-endian format.
  *
  *  Get a 32-bit integer, stored in big-endian format in a potentially
@@ -273,6 +361,21 @@ static inline u64_t sys_get_be64(const u8_t src[8])
 static inline u16_t sys_get_le16(const u8_t src[2])
 {
 	return ((u16_t)src[1] << 8) | src[0];
+}
+
+/**
+ *  @brief Get a 24-bit integer stored in big-endian format.
+ *
+ *  Get a 24-bit integer, stored in big-endian format in a potentially
+ *  unaligned memory location, and convert it to the host endianness.
+ *
+ *  @param src Location of the big-endian 24-bit integer to get.
+ *
+ *  @return 24-bit integer in host endianness.
+ */
+static inline u32_t sys_get_le24(const u8_t src[3])
+{
+	return ((u32_t)src[2] << 16) | sys_get_le16(&src[0]);
 }
 
 /**

--- a/include/sys/byteorder.h
+++ b/include/sys/byteorder.h
@@ -25,6 +25,12 @@
 				   (((x) >> 8) & 0xff00) | \
 				   (((x) & 0xff00) << 8) | \
 				   (((x) & 0xff) << 24)))
+#define __bswap_48(x) ((u64_t) ((((x) >> 40) & 0xff) | \
+				   (((x) >> 24) & 0xff00) | \
+				   (((x) >> 8) & 0xff0000) | \
+				   (((x) & 0xff0000) << 8) | \
+				   (((x) & 0xff00) << 24) | \
+				   (((x) & 0xff) << 40)))
 #define __bswap_64(x) ((u64_t) ((((x) >> 56) & 0xff) | \
 				   (((x) >> 40) & 0xff00) | \
 				   (((x) >> 24) & 0xff0000) | \
@@ -82,6 +88,22 @@
  *  @return 32-bit integer in little-endian format.
  */
 
+/** @def sys_le48_to_cpu
+ *  @brief Convert 48-bit integer from little-endian to host endianness.
+ *
+ *  @param val 48-bit integer in little-endian format.
+ *
+ *  @return 48-bit integer in host endianness.
+ */
+
+/** @def sys_cpu_to_le48
+ *  @brief Convert 48-bit integer from host endianness to little-endian.
+ *
+ *  @param val 48-bit integer in host endianness.
+ *
+ *  @return 48-bit integer in little-endian format.
+ */
+
 /** @def sys_be16_to_cpu
  *  @brief Convert 16-bit integer from big-endian to host endianness.
  *
@@ -130,6 +152,22 @@
  *  @return 32-bit integer in big-endian format.
  */
 
+/** @def sys_be48_to_cpu
+ *  @brief Convert 48-bit integer from big-endian to host endianness.
+ *
+ *  @param val 48-bit integer in big-endian format.
+ *
+ *  @return 48-bit integer in host endianness.
+ */
+
+/** @def sys_cpu_to_be48
+ *  @brief Convert 48-bit integer from host endianness to big-endian.
+ *
+ *  @param val 48-bit integer in host endianness.
+ *
+ *  @return 48-bit integer in big-endian format.
+ */
+
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define sys_le16_to_cpu(val) (val)
 #define sys_cpu_to_le16(val) (val)
@@ -137,6 +175,8 @@
 #define sys_cpu_to_le24(val) (val)
 #define sys_le32_to_cpu(val) (val)
 #define sys_cpu_to_le32(val) (val)
+#define sys_le48_to_cpu(val) (val)
+#define sys_cpu_to_le48(val) (val)
 #define sys_le64_to_cpu(val) (val)
 #define sys_cpu_to_le64(val) (val)
 #define sys_be16_to_cpu(val) __bswap_16(val)
@@ -145,6 +185,8 @@
 #define sys_cpu_to_be24(val) __bswap_24(val)
 #define sys_be32_to_cpu(val) __bswap_32(val)
 #define sys_cpu_to_be32(val) __bswap_32(val)
+#define sys_be48_to_cpu(val) __bswap_48(val)
+#define sys_cpu_to_be48(val) __bswap_48(val)
 #define sys_be64_to_cpu(val) __bswap_64(val)
 #define sys_cpu_to_be64(val) __bswap_64(val)
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
@@ -154,6 +196,8 @@
 #define sys_cpu_to_le24(val) __bswap_24(val)
 #define sys_le32_to_cpu(val) __bswap_32(val)
 #define sys_cpu_to_le32(val) __bswap_32(val)
+#define sys_le48_to_cpu(val) __bswap_48(val)
+#define sys_cpu_to_le48(val) __bswap_48(val)
 #define sys_le64_to_cpu(val) __bswap_64(val)
 #define sys_cpu_to_le64(val) __bswap_64(val)
 #define sys_be16_to_cpu(val) (val)
@@ -162,6 +206,8 @@
 #define sys_cpu_to_be24(val) (val)
 #define sys_be32_to_cpu(val) (val)
 #define sys_cpu_to_be32(val) (val)
+#define sys_be48_to_cpu(val) (val)
+#define sys_cpu_to_be48(val) (val)
 #define sys_be64_to_cpu(val) (val)
 #define sys_cpu_to_be64(val) (val)
 #else
@@ -211,6 +257,21 @@ static inline void sys_put_be32(u32_t val, u8_t dst[4])
 {
 	sys_put_be16(val >> 16, dst);
 	sys_put_be16(val, &dst[2]);
+}
+
+/**
+ *  @brief Put a 48-bit integer as big-endian to arbitrary location.
+ *
+ *  Put a 48-bit integer, originally in host endianness, to a
+ *  potentially unaligned memory location in big-endian format.
+ *
+ *  @param val 48-bit integer in host endianness.
+ *  @param dst Destination memory address to store the result.
+ */
+static inline void sys_put_be48(u64_t val, u8_t dst[6])
+{
+	sys_put_be16(val >> 32, dst);
+	sys_put_be32(val, &dst[2]);
 }
 
 /**
@@ -274,6 +335,21 @@ static inline void sys_put_le32(u32_t val, u8_t dst[4])
 }
 
 /**
+ *  @brief Put a 48-bit integer as little-endian to arbitrary location.
+ *
+ *  Put a 48-bit integer, originally in host endianness, to a
+ *  potentially unaligned memory location in little-endian format.
+ *
+ *  @param val 48-bit integer in host endianness.
+ *  @param dst Destination memory address to store the result.
+ */
+static inline void sys_put_le48(u64_t val, u8_t dst[6])
+{
+	sys_put_le32(val, dst);
+	sys_put_le16(val >> 32, &dst[4]);
+}
+
+/**
  *  @brief Put a 64-bit integer as little-endian to arbitrary location.
  *
  *  Put a 64-bit integer, originally in host endianness, to a
@@ -334,6 +410,21 @@ static inline u32_t sys_get_be32(const u8_t src[4])
 }
 
 /**
+ *  @brief Get a 48-bit integer stored in big-endian format.
+ *
+ *  Get a 48-bit integer, stored in big-endian format in a potentially
+ *  unaligned memory location, and convert it to the host endianness.
+ *
+ *  @param src Location of the big-endian 48-bit integer to get.
+ *
+ *  @return 48-bit integer in host endianness.
+ */
+static inline u64_t sys_get_be48(const u8_t src[6])
+{
+	return ((u64_t)sys_get_be32(&src[0]) << 32) | sys_get_be16(&src[4]);
+}
+
+/**
  *  @brief Get a 64-bit integer stored in big-endian format.
  *
  *  Get a 64-bit integer, stored in big-endian format in a potentially
@@ -391,6 +482,21 @@ static inline u32_t sys_get_le24(const u8_t src[3])
 static inline u32_t sys_get_le32(const u8_t src[4])
 {
 	return ((u32_t)sys_get_le16(&src[2]) << 16) | sys_get_le16(&src[0]);
+}
+
+/**
+ *  @brief Get a 48-bit integer stored in little-endian format.
+ *
+ *  Get a 48-bit integer, stored in little-endian format in a potentially
+ *  unaligned memory location, and convert it to the host endianness.
+ *
+ *  @param src Location of the little-endian 48-bit integer to get.
+ *
+ *  @return 48-bit integer in host endianness.
+ */
+static inline u64_t sys_get_le48(const u8_t src[6])
+{
+	return ((u64_t)sys_get_le32(&src[2]) << 32) | sys_get_le16(&src[0]);
 }
 
 /**

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -818,6 +818,20 @@ void net_buf_simple_add_be16(struct net_buf_simple *buf, u16_t val)
 	sys_put_be16(val, net_buf_simple_add(buf, sizeof(val)));
 }
 
+void net_buf_simple_add_le24(struct net_buf_simple *buf, u32_t val)
+{
+	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
+
+	sys_put_le24(val, net_buf_simple_add(buf, 3));
+}
+
+void net_buf_simple_add_be24(struct net_buf_simple *buf, u32_t val)
+{
+	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
+
+	sys_put_be24(val, net_buf_simple_add(buf, 3));
+}
+
 void net_buf_simple_add_le32(struct net_buf_simple *buf, u32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
@@ -916,6 +930,30 @@ u16_t net_buf_simple_pull_be16(struct net_buf_simple *buf)
 	net_buf_simple_pull(buf, sizeof(val));
 
 	return sys_be16_to_cpu(val);
+}
+
+u32_t net_buf_simple_pull_le24(struct net_buf_simple *buf)
+{
+	struct uint24 {
+		u32_t u24:24;
+	} __packed val;
+
+	val = UNALIGNED_GET((struct uint24 *)buf->data);
+	net_buf_simple_pull(buf, sizeof(val));
+
+	return sys_le24_to_cpu(val.u24);
+}
+
+u32_t net_buf_simple_pull_be24(struct net_buf_simple *buf)
+{
+	struct uint24 {
+		u32_t u24:24;
+	} __packed val;
+
+	val = UNALIGNED_GET((struct uint24 *)buf->data);
+	net_buf_simple_pull(buf, sizeof(val));
+
+	return sys_be24_to_cpu(val.u24);
 }
 
 u32_t net_buf_simple_pull_le32(struct net_buf_simple *buf)

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -846,6 +846,20 @@ void net_buf_simple_add_be32(struct net_buf_simple *buf, u32_t val)
 	sys_put_be32(val, net_buf_simple_add(buf, sizeof(val)));
 }
 
+void net_buf_simple_add_le48(struct net_buf_simple *buf, u64_t val)
+{
+	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
+
+	sys_put_le48(val, net_buf_simple_add(buf, 6));
+}
+
+void net_buf_simple_add_be48(struct net_buf_simple *buf, u64_t val)
+{
+	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
+
+	sys_put_be48(val, net_buf_simple_add(buf, 6));
+}
+
 void *net_buf_simple_push(struct net_buf_simple *buf, size_t len)
 {
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
@@ -974,6 +988,30 @@ u32_t net_buf_simple_pull_be32(struct net_buf_simple *buf)
 	net_buf_simple_pull(buf, sizeof(val));
 
 	return sys_be32_to_cpu(val);
+}
+
+u64_t net_buf_simple_pull_le48(struct net_buf_simple *buf)
+{
+	struct uint48 {
+		u64_t u48:48;
+	} __packed val;
+
+	val = UNALIGNED_GET((struct uint48 *)buf->data);
+	net_buf_simple_pull(buf, sizeof(val));
+
+	return sys_le48_to_cpu(val.u48);
+}
+
+u64_t net_buf_simple_pull_be48(struct net_buf_simple *buf)
+{
+	struct uint48 {
+		u64_t u48:48;
+	} __packed val;
+
+	val = UNALIGNED_GET((struct uint48 *)buf->data);
+	net_buf_simple_pull(buf, sizeof(val));
+
+	return sys_be48_to_cpu(val.u48);
 }
 
 size_t net_buf_simple_headroom(struct net_buf_simple *buf)

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -385,10 +385,7 @@ struct net_buf *net_buf_alloc_with_data(struct net_buf_pool *pool,
 		return NULL;
 	}
 
-	buf->__buf = data;
-	buf->data  = data;
-	buf->size  = size;
-	buf->len   = size;
+	net_buf_simple_init_with_data(&buf->b, data, size);
 	buf->flags = NET_BUF_EXTERNAL_DATA;
 
 	return buf;
@@ -425,6 +422,15 @@ struct net_buf *net_buf_get(struct k_fifo *fifo, s32_t timeout)
 	frag->frags = NULL;
 
 	return buf;
+}
+
+void net_buf_simple_init_with_data(struct net_buf_simple *buf,
+				   void *data, size_t size)
+{
+	buf->__buf = data;
+	buf->data  = data;
+	buf->size  = size;
+	buf->len   = size;
 }
 
 void net_buf_simple_reserve(struct net_buf_simple *buf, size_t reserve)

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -860,6 +860,20 @@ void net_buf_simple_add_be48(struct net_buf_simple *buf, u64_t val)
 	sys_put_be48(val, net_buf_simple_add(buf, 6));
 }
 
+void net_buf_simple_add_le64(struct net_buf_simple *buf, u64_t val)
+{
+	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
+
+	sys_put_le64(val, net_buf_simple_add(buf, sizeof(val)));
+}
+
+void net_buf_simple_add_be64(struct net_buf_simple *buf, u64_t val)
+{
+	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
+
+	sys_put_be64(val, net_buf_simple_add(buf, sizeof(val)));
+}
+
 void *net_buf_simple_push(struct net_buf_simple *buf, size_t len)
 {
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
@@ -1012,6 +1026,26 @@ u64_t net_buf_simple_pull_be48(struct net_buf_simple *buf)
 	net_buf_simple_pull(buf, sizeof(val));
 
 	return sys_be48_to_cpu(val.u48);
+}
+
+u64_t net_buf_simple_pull_le64(struct net_buf_simple *buf)
+{
+	u64_t val;
+
+	val = UNALIGNED_GET((u64_t *)buf->data);
+	net_buf_simple_pull(buf, sizeof(val));
+
+	return sys_le64_to_cpu(val);
+}
+
+u64_t net_buf_simple_pull_be64(struct net_buf_simple *buf)
+{
+	u64_t val;
+
+	val = UNALIGNED_GET((u64_t *)buf->data);
+	net_buf_simple_pull(buf, sizeof(val));
+
+	return sys_be64_to_cpu(val);
 }
 
 size_t net_buf_simple_headroom(struct net_buf_simple *buf)

--- a/tests/net/buf/src/main.c
+++ b/tests/net/buf/src/main.c
@@ -457,6 +457,104 @@ static void net_buf_test_var_pool(void)
 	zassert_equal(destroy_called, 3, "Incorrect destroy callback count");
 }
 
+static void net_buf_test_byte_order(void)
+{
+	struct net_buf *buf;
+	u8_t le16[2] = { 0x02, 0x01 };
+	u8_t be16[2] = { 0x01, 0x02 };
+	u8_t le24[3] = { 0x03, 0x02, 0x01 };
+	u8_t be24[3] = { 0x01, 0x02, 0x03 };
+	u8_t le32[4] = { 0x04, 0x03, 0x02, 0x01 };
+	u8_t be32[4] = { 0x01, 0x02, 0x03, 0x04 };
+	u8_t le48[6] = { 0x06, 0x05, 0x04, 0x03, 0x02, 0x01 };
+	u8_t be48[6] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
+	u8_t le64[8] = { 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01 };
+	u8_t be64[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+	u16_t u16;
+	u32_t u32;
+	u64_t u64;
+
+	buf = net_buf_alloc_len(&fixed_pool, 16, K_FOREVER);
+	zassert_not_null(buf, "Failed to get buffer");
+
+	net_buf_add_mem(buf, &le16, sizeof(le16));
+	net_buf_add_mem(buf, &be16, sizeof(be16));
+
+	u16 = net_buf_pull_le16(buf);
+	zassert_equal(u16, net_buf_pull_be16(buf),
+		      "Invalid 16 bits byte order");
+
+	net_buf_add_le16(buf, u16);
+	net_buf_add_be16(buf, u16);
+
+	zassert_mem_equal(le16, net_buf_pull_mem(buf, sizeof(le16)),
+			  sizeof(le16), "Invalid 16 bits byte order");
+	zassert_mem_equal(be16, net_buf_pull_mem(buf, sizeof(be16)),
+			  sizeof(be16), "Invalid 16 bits byte order");
+
+	net_buf_add_mem(buf, &le24, sizeof(le24));
+	net_buf_add_mem(buf, &be24, sizeof(be24));
+
+	u32 = net_buf_pull_le24(buf);
+	zassert_equal(u32, net_buf_pull_be24(buf),
+		      "Invalid 24 bits byte order");
+
+	net_buf_add_le24(buf, u32);
+	net_buf_add_be24(buf, u32);
+
+	zassert_mem_equal(le24, net_buf_pull_mem(buf, sizeof(le24)),
+			  sizeof(le24), "Invalid 24 bits byte order");
+	zassert_mem_equal(be24, net_buf_pull_mem(buf, sizeof(be24)),
+			  sizeof(be24), "Invalid 24 bits byte order");
+
+	net_buf_add_mem(buf, &le32, sizeof(le32));
+	net_buf_add_mem(buf, &be32, sizeof(be32));
+
+	u32 = net_buf_pull_le32(buf);
+	zassert_equal(u32, net_buf_pull_be32(buf),
+		      "Invalid 32 bits byte order");
+
+	net_buf_add_le32(buf, u32);
+	net_buf_add_be32(buf, u32);
+
+	zassert_mem_equal(le32, net_buf_pull_mem(buf, sizeof(le32)),
+			  sizeof(le32), "Invalid 32 bits byte order");
+	zassert_mem_equal(be32, net_buf_pull_mem(buf, sizeof(be32)),
+			  sizeof(be32), "Invalid 32 bits byte order");
+
+	net_buf_add_mem(buf, &le48, sizeof(le48));
+	net_buf_add_mem(buf, &be48, sizeof(be48));
+
+	u64 = net_buf_pull_le48(buf);
+	zassert_equal(u64, net_buf_pull_be48(buf),
+		      "Invalid 48 bits byte order");
+
+	net_buf_add_le48(buf, u64);
+	net_buf_add_be48(buf, u64);
+
+	zassert_mem_equal(le48, net_buf_pull_mem(buf, sizeof(le48)),
+			  sizeof(le48), "Invalid 48 bits byte order");
+	zassert_mem_equal(be48, net_buf_pull_mem(buf, sizeof(be48)),
+			  sizeof(be48), "Invalid 48 bits byte order");
+
+	net_buf_add_mem(buf, &le64, sizeof(le64));
+	net_buf_add_mem(buf, &be64, sizeof(be64));
+
+	u64 = net_buf_pull_le64(buf);
+	zassert_equal(u64, net_buf_pull_be64(buf),
+		      "Invalid 64 bits byte order");
+
+	net_buf_add_le64(buf, u64);
+	net_buf_add_be64(buf, u64);
+
+	zassert_mem_equal(le64, net_buf_pull_mem(buf, sizeof(le64)),
+			  sizeof(le64), "Invalid 64 bits byte order");
+	zassert_mem_equal(be64, net_buf_pull_mem(buf, sizeof(be64)),
+			  sizeof(be48), "Invalid 64 bits byte order");
+
+	net_buf_unref(buf);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(net_buf_test,
@@ -468,7 +566,8 @@ void test_main(void)
 			 ztest_unit_test(net_buf_test_multi_frags),
 			 ztest_unit_test(net_buf_test_clone),
 			 ztest_unit_test(net_buf_test_fixed_pool),
-			 ztest_unit_test(net_buf_test_var_pool)
+			 ztest_unit_test(net_buf_test_var_pool),
+			 ztest_unit_test(net_buf_test_byte_order)
 			 );
 
 	ztest_run_test_suite(net_buf_test);


### PR DESCRIPTION
This add support for other sizes that can be found on protocols, 24 bits specially is becoming more used by Bluetooth nowadays to express intervals in usec.