### PR TITLE
subsystem: kernel_shell: Fix pointer cast to u32_t

### DIFF
--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -106,8 +106,8 @@ static void shell_stack_dump(const struct k_thread *thread, void *user_data)
 	pcnt = ((size - unused) * 100U) / size;
 
 	shell_print((const struct shell *)user_data,
-		"0x%08X %-10s (real size %u):\tunused %u\tusage %u / %u (%u %%)",
-		      (u32_t)thread,
+		"%p %-10s (real size %u):\tunused %u\tusage %u / %u (%u %%)",
+		      thread,
 		      tname ? tname : "NA",
 		      size, unused, size - unused, size, pcnt);
 }


### PR DESCRIPTION
The current code is assuming that the pointer to the thread structure is
32bit, casting it to u32_t before printing its address. This is wrong on
64bit architectures (CONFIG_64BIT) and the compiler complains.

Fix the problem by using '%p' to print the address.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>