### PR TITLE
samples: philosophers: Introduce CONFIG_TEST_EXTRA_STACKSIZE

### DIFF
--- a/samples/philosophers/src/main.c
+++ b/samples/philosophers/src/main.c
@@ -83,7 +83,7 @@
 /* end - control behaviour of the demo */
 /***************************************/
 
-#define STACK_SIZE 768
+#define STACK_SIZE (768 + CONFIG_TEST_EXTRA_STACKSIZE)
 
 #include "phil_obj_abstract.h"
 


### PR DESCRIPTION
Some architectures require more space on the stack when running samples
and tests. Use the CONFIG_TEST_EXTRA_STACKSIZE also on the philosophers
sample to deal with such cases.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>