### PR TITLE
drivers: nrf_clock_calibration: wait for sensor initialization

### DIFF
--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -39,6 +39,10 @@ static int temp_nrf5_sample_fetch(struct device *dev, enum sensor_channel chan)
 
 	int r;
 
+	/* Error if before sensor initialized */
+	if (data->hfclk_dev == NULL) {
+		return -EAGAIN;
+	}
 
 	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_DIE_TEMP) {
 		return -ENOTSUP;
@@ -102,6 +106,7 @@ static int temp_nrf5_init(struct device *dev)
 
 	LOG_DBG("");
 
+	/* A null hfclk_dev indicates sensor has not been initialized */
 	data->hfclk_dev =
 		device_get_binding(DT_INST_0_NORDIC_NRF_CLOCK_LABEL "_16M");
 	__ASSERT_NO_MSG(data->hfclk_dev);


### PR DESCRIPTION
When using the RC clock source a periodic calibration is invoked that
involves reading from the die temperature sensor.  The code did not
protect against execution order that caused the periodic calibration
to be invoked before the temperature sensor was initialized.

Update the temperature sensor to detect that it has not been
initialized and so should reject attempts to fetch a reading.

Update the calibration code to do nothing when temperature reading
fails.

Fixes #20416