### PR TITLE
boards: bbc_microbit: reference board variations

### DIFF
--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -63,12 +63,33 @@
 	sda-pin = <30>;
 	scl-pin = <0>;
 
+	/* See https://tech.microbit.org/hardware/i2c/ for board variants */
+
+	/* v1.3 MMA8653FC (= FXOS8700) + MAG3110 */
 	mma8653fc@1d {
-		compatible = "nxp,fxos8700","nxp,mma8653fc";
+		compatible = "nxp,fxos8700", "nxp,mma8653fc";
+		status = "okay";
 		reg = <0x1d>;
 		label = "MMA8653FC";
 		int1-gpios = <&gpio0 28 0>;
 		int2-gpios = <&gpio0 27 0>;
+	};
+
+	/* v1.5 variant 1 LSM303AGR */
+	lsm303agr-magn@1e {
+		compatible = "st,lis2mdl", "st,lsm303agr-magn";
+		status = "disabled";
+		reg = <0x1e>;
+		label = "LSM303AGR-MAGN";
+		irq-gpios = <&gpio0 27 0>;	/* A3 */
+	};
+
+	lsm303agr-accel@19 {
+		compatible = "st,lis2dh", "st,lsm303agr-accel";
+		status = "disabled";
+		reg = <0x19>;
+		label = "LSM303AGR-ACCEL";
+		irq-gpios = <&gpio0 28 0>;
 	};
 };
 


### PR DESCRIPTION
The original v1.3 had MMA8653+MAG3110, but v1.5 has verified LSM303AGR and theoretical FXOS8700.  Add the v1.5 variant 1 nodes in disabled form; they can be enabled through overlays.

(Analysis while working on #20416 found these variations.  I've verified that the lis2dh interface of LSM303AGR works on my v1.5 variant 1 device, but there's no standalone sample for the lis2mdl at this time so I haven't been able to check that.)