### PR TITLE
kernel: Kconfig: Define dependencies for STACK_CANARIES

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -620,6 +620,7 @@ menu "Security Options"
 
 config STACK_CANARIES
 	bool "Compiler stack canaries"
+	depends on ENTROPY_GENERATOR || TEST_RANDOM_GENERATOR
 	help
 	  This option enables compiler stack canaries.
 


### PR DESCRIPTION
STACK_CANARIES relies on random value for the canarie so ENTROPY_GENERATOR or TEST_RANDOM_GENERATOR needs to be selected to get sys_rand32_get included in the build.
    
Fixes: #20587
    
Signed-off-by: David Leach <david.leach@nxp.com>
