### PR TITLE
kernel: thread: Fix randomness problem with stack pointer random

### DIFF
--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -112,7 +112,7 @@ extern void z_smp_init(void);
 
 extern void smp_timer_init(void);
 
-extern u32_t z_early_boot_rand32_get(void);
+extern void z_early_boot_rand_get(u8_t *buf, size_t length);
 
 #if CONFIG_STACK_POINTER_RANDOM
 extern int z_stack_adjust_initialized;

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -426,7 +426,7 @@ static FUNC_NORETURN void switch_to_main_thread(void)
 }
 #endif /* CONFIG_MULTITHREADING */
 
-static void z_early_boot_rand_get(u8_t *buf, size_t length)
+void z_early_boot_rand_get(u8_t *buf, size_t length)
 {
 	int n = sizeof(u32_t);
 #ifdef CONFIG_ENTROPY_HAS_DRIVER
@@ -480,15 +480,6 @@ sys_rand_fallback:
 
 		length -= n;
 	}
-}
-
-u32_t z_early_boot_rand32_get(void)
-{
-	u32_t retval;
-
-	z_early_boot_rand_get((u8_t *)&retval, sizeof(retval));
-
-	return retval;
 }
 
 /**

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -403,9 +403,9 @@ static inline size_t adjust_stack_size(size_t stack_size)
 	size_t random_val;
 
 	if (!z_stack_adjust_initialized) {
-		random_val = z_early_boot_rand32_get();
+		z_early_boot_rand_get((u8_t *)&random_val, sizeof(random_val));
 	} else {
-		random_val = sys_rand32_get();
+		sys_rand_get((u8_t *)&random_val, sizeof(random_val));
 	}
 
 	/* Don't need to worry about alignment of the size here,

--- a/tests/crypto/rand32/src/main.c
+++ b/tests/crypto/rand32/src/main.c
@@ -8,7 +8,7 @@
 
 /*
  * This tests the following random number routines:
- * u32_t z_early_boot_rand32_get(void);
+ * void z_early_boot_rand_get(u8_t *buf, size_t length)
  * u32_t sys_rand32_get(void);
  */
 
@@ -35,9 +35,10 @@ void test_rand32(void)
 	u32_t buf[N_VALUES];
 
 	/* Test early boot random number generation function */
-	last_gen = z_early_boot_rand32_get();
-	zassert_true(last_gen != z_early_boot_rand32_get(),
-			"z_early_boot_rand32_get failed");
+	z_early_boot_rand_get((u8_t *)&last_gen, sizeof(last_gen));
+	z_early_boot_rand_get((u8_t *)&gen, sizeof(gen));
+	zassert_true(last_gen != gen,
+			"z_early_boot_rand_get failed");
 
 	/*
 	 * Test subsequently calls sys_rand32_get(), checking


### PR DESCRIPTION
In some platforms the size of size_t can be different of 4 bytes. Use
sys_rand_get to proper fill this variable.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>