### PR TITLE
tests: cmsis_rtos_v2: Fix warning in old GCC.

### DIFF
--- a/tests/portability/cmsis_rtos_v2/src/msgq.c
+++ b/tests/portability/cmsis_rtos_v2/src/msgq.c
@@ -27,7 +27,7 @@ void send_msg_thread(void *argument)
 	int i;
 	osStatus_t status;
 	struct sample_data sample;
-	struct sample_data data[Q_LEN] = { 0 };
+	struct sample_data data[Q_LEN] = { { 0 } };
 
 	/* Wait for message_recv to complete initial checks */
 	osDelay(TIMEOUT_TICKS);


### PR DESCRIPTION
This commit modifies the struct array initialisation expression using
the "universal initialiser" to a struct single element initialisation
expression in order to prevent old GCC versions from erroneously
reporting the "missing braces around initializer" warning.

This is an infamous bug in old GCC versions; since there is no side
effect of using this alternate initialisation expression and it does
not violate the C99 standard, this problem should be addressed in the
code for the sake of portability.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>