### PR TITLE
setting: fix NVS error handling on write

### DIFF
--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -173,12 +173,25 @@ static int settings_nvs_save(struct settings_store *cs, const char *name,
 			cf->last_name_id--;
 			rc = nvs_write(&cf->cf_nvs, NVS_NAMECNT_ID,
 				       &cf->last_name_id, sizeof(u16_t));
+			if (rc < 0) {
+				/* Error: can't to store
+				 * the largest name ID in use.
+				 */
+				return rc;
+			}
 		}
 
 		if (delete) {
 			rc = nvs_delete(&cf->cf_nvs, name_id);
-			rc = nvs_delete(&cf->cf_nvs, name_id +
+
+			if (rc >= 0) {
+				rc = nvs_delete(&cf->cf_nvs, name_id +
 					NVS_NAME_ID_OFFSET);
+			}
+
+			if (rc < 0) {
+				return rc;
+			}
 
 			return 0;
 		}
@@ -203,6 +216,9 @@ static int settings_nvs_save(struct settings_store *cs, const char *name,
 	/* write the name if required */
 	if (write_name) {
 		rc = nvs_write(&cf->cf_nvs, write_name_id, name, strlen(name));
+		if (rc < 0) {
+			return rc;
+		}
 	}
 
 	/* update the last_name_id and write to flash if required*/


### PR DESCRIPTION
In settings write NVS errors were not handled
in a few places.
This patch improve that.

fixes #20515

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>