### PR TITLE
RFC: API Change: PWM: add support for inverted PWM signals

### DIFF
--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -8,6 +8,7 @@
 
 #include <mem.h>
 #include <nxp/nxp_k82fn256vxx15.dtsi>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	model = "NXP Kinetis K82 Freedom Board";
@@ -53,13 +54,13 @@
 		compatible = "pwm-leds";
 
 		red_pwm_led: red_pwm_led {
-			pwms = <&pwm3 4 15625000>;
+			pwms = <&pwm3 4 15625000 PWM_POLARITY_INVERTED>;
 		};
 		green_pwm_led: green_pwm_led {
-			pwms = <&pwm3 5 15625000>;
+			pwms = <&pwm3 5 15625000 PWM_POLARITY_INVERTED>;
 		};
 		blue_pwm_led: blue_pwm_led {
-			pwms = <&pwm3 6 15625000>;
+			pwms = <&pwm3 6 15625000 PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -3,6 +3,7 @@
 /dts-v1/;
 
 #include <nxp/nxp_k6x.dtsi>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	model = "Hexiwear K64 board";
@@ -68,13 +69,13 @@
 		compatible = "pwm-leds";
 
 		red_pwm_led: red_pwm_led {
-			pwms = <&pwm3 4 15625000>;
+			pwms = <&pwm3 4 15625000 PWM_POLARITY_INVERTED>;
 		};
 		green_pwm_led: green_pwm_led {
-			pwms = <&pwm3 0 15625000>;
+			pwms = <&pwm3 0 15625000 PWM_POLARITY_INVERTED>;
 		};
 		blue_pwm_led: blue_pwm_led {
-			pwms = <&pwm3 5 15625000>;
+			pwms = <&pwm3 5 15625000 PWM_POLARITY_INVERTED>;
 		};
 	};
 };

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_ke18f512vlx16.dtsi>
 #include <dt-bindings/clock/kinetis_scg.h>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	model = "NXP Kinetis KE18 MCU Tower System Module";
@@ -77,32 +78,32 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		orange_pwm_led: led_pwm_0 {
-			pwms = <&pwm3 7 60000>;
+			pwms = <&pwm3 7 60000 PWM_POLARITY_INVERTED>;
 			label = "User PWM LED D9";
 		};
 		yellow_pwm_led: led_pwm_1 {
-			pwms = <&pwm3 6 60000>;
+			pwms = <&pwm3 6 60000 PWM_POLARITY_INVERTED>;
 			label = "User PWM LED D8";
 		};
 		green_pwm_led: led_pwm_2 {
-			pwms = <&pwm3 5 60000>;
+			pwms = <&pwm3 5 60000 PWM_POLARITY_INVERTED>;
 			label = "User PWM LED D7";
 		};
 		red_pwm_led: led_pwm_3 {
-			pwms = <&pwm3 4 60000>;
+			pwms = <&pwm3 4 60000 PWM_POLARITY_INVERTED>;
 			label = "User PWM LED D6";
 		};
 
 		tri_red_pwm_led: led_pwm_4 {
-			pwms = <&pwm0 1 60000>;
+			pwms = <&pwm0 1 60000 PWM_POLARITY_INVERTED>;
 			label = "User Tricolor PWM LED D5 (Red)";
 		};
 		tri_green_pwm_led: led_pwm_5 {
-			pwms = <&pwm0 0 60000>;
+			pwms = <&pwm0 0 60000 PWM_POLARITY_INVERTED>;
 			label = "User Tricolor PWM LED D5 (Green)";
 		};
 		tri_blue_pwm_led: led_pwm_6 {
-			pwms = <&pwm0 5 60000>;
+			pwms = <&pwm0 5 60000 PWM_POLARITY_INVERTED>;
 			label = "User Tricolor PWM LED D5 (Blue)";
 		};
 	};

--- a/doc/releases/release-notes-2.2.rst
+++ b/doc/releases/release-notes-2.2.rst
@@ -27,6 +27,19 @@ Deprecated in this release
 Stable API changes in this release
 ==================================
 
+* PWM
+
+  * The pwm_pin_set_cycles(), pwm_pin_set_usec(), and
+    pwm_pin_set_nsec() functions now take a flags parameter. The newly
+    introduced flags are PWM_POLARITY_NORMAL and PWM_POLARITY_INVERTED
+    for specifying the polarity of the PWM signal. The flags parameter
+    can be set to 0 if no flags are required (the default is
+    PWM_POLARITY_NORMAL).
+  * Similarly, the pwm_pin_set_t PWM driver API function function now
+    takes a flags parameter. The PWM controller driver must check the
+    value of the flags parameter and return -ENOTSUP if any
+    unsupported flag is set.
+
 * USB
 
   * The usb_enable() function, which was previously invoked automatically

--- a/drivers/pwm/pwm_dw.c
+++ b/drivers/pwm/pwm_dw.c
@@ -135,11 +135,13 @@ static int __set_one_port(struct device *dev, u32_t pwm,
  * @param pwm Which PWM pin to set
  * @param period_cycles Period in clock cycles of the pwm.
  * @param pulse_cycles PWM width in clock cycles
+ * @param flags Flags for pin configuration (polarity).
  *
  * @return 0
  */
 static int pwm_dw_pin_set_cycles(struct device *dev,
-			     u32_t pwm, u32_t period_cycles, u32_t pulse_cycles)
+				 u32_t pwm, u32_t period_cycles,
+				 u32_t pulse_cycles, pwm_flags_t flags)
 {
 	const struct pwm_dw_config * const cfg =
 	    (struct pwm_dw_config *)dev->config->config_info;
@@ -149,6 +151,11 @@ static int pwm_dw_pin_set_cycles(struct device *dev,
 	/* make sure the PWM port exists */
 	if (pwm >= cfg->num_ports) {
 		return -EIO;
+	}
+
+	if (flags) {
+		/* PWM polarity not supported (yet?) */
+		return -ENOTSUP;
 	}
 
 	if (period_cycles == 0U || pulse_cycles > period_cycles) {

--- a/drivers/pwm/pwm_handlers.c
+++ b/drivers/pwm/pwm_handlers.c
@@ -8,11 +8,12 @@
 #include <drivers/pwm.h>
 
 static inline int z_vrfy_pwm_pin_set_cycles(struct device *dev, u32_t pwm,
-					   u32_t period, u32_t pulse)
+					    u32_t period, u32_t pulse,
+					    pwm_flags_t flags)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, pin_set));
 	return z_impl_pwm_pin_set_cycles((struct device *)dev, pwm, period,
-					pulse);
+					 pulse, flags);
 }
 #include <syscalls/pwm_pin_set_cycles_mrsh.c>
 

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -52,7 +52,8 @@ static int imx_pwm_get_cycles_per_sec(struct device *dev, u32_t pwm,
 }
 
 static int imx_pwm_pin_set(struct device *dev, u32_t pwm,
-			    u32_t period_cycles, u32_t pulse_cycles)
+			   u32_t period_cycles, u32_t pulse_cycles,
+			   pwm_flags_t flags)
 {
 	PWM_Type *base = DEV_BASE(dev);
 	const struct imx_pwm_config *config = DEV_CFG(dev);
@@ -67,6 +68,11 @@ static int imx_pwm_pin_set(struct device *dev, u32_t pwm,
 		LOG_ERR("Invalid combination: period_cycles=%d, "
 			    "pulse_cycles=%d", period_cycles, pulse_cycles);
 		return -EINVAL;
+	}
+
+	if (flags) {
+		/* PWM polarity not supported (yet?) */
+		return -ENOTSUP;
 	}
 
 	LOG_DBG("enabled=%d, pulse_cycles=%d, period_cycles=%d,"

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -311,7 +311,7 @@ static int pwm_led_esp32_timer_set(int speed_mode, int timer,
 /* period_cycles is not used, set frequency on menuconfig instead. */
 static int pwm_led_esp32_pin_set_cycles(struct device *dev,
 					u32_t pwm, u32_t period_cycles,
-					u32_t pulse_cycles)
+					u32_t pulse_cycles, pwm_flags_t flags)
 {
 	int speed_mode;
 	int channel;
@@ -321,6 +321,11 @@ static int pwm_led_esp32_pin_set_cycles(struct device *dev,
 		(struct pwm_led_esp32_config *) dev->config->config_info;
 
 	ARG_UNUSED(period_cycles);
+
+	if (flags) {
+		/* PWM polarity not supported (yet?) */
+		return -ENOTSUP;
+	}
 
 	channel = pwm_led_esp32_get_gpio_config(pwm, config->ch_cfg);
 	if (channel < 0) {

--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -305,7 +305,8 @@ done:
 }
 
 static int pwm_xec_pin_set(struct device *dev, u32_t pwm,
-			   u32_t period_cycles, u32_t pulse_cycles)
+			   u32_t period_cycles, u32_t pulse_cycles,
+			   pwm_flags_t flags)
 {
 	PWM_Type *pwm_regs = PWM_XEC_REG_BASE(dev);
 	u32_t target_freq;
@@ -317,6 +318,11 @@ static int pwm_xec_pin_set(struct device *dev, u32_t pwm,
 
 	if (pulse_cycles > period_cycles) {
 		return -EINVAL;
+	}
+
+	if (flags) {
+		/* PWM polarity not supported (yet?) */
+		return -ENOTSUP;
 	}
 
 	on = pulse_cycles;

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -30,7 +30,8 @@ struct pwm_mcux_data {
 };
 
 static int mcux_pwm_pin_set(struct device *dev, u32_t pwm,
-			    u32_t period_cycles, u32_t pulse_cycles)
+			    u32_t period_cycles, u32_t pulse_cycles,
+			    pwm_flags_t flags)
 {
 	const struct pwm_mcux_config *config = dev->config->config_info;
 	struct pwm_mcux_data *data = dev->driver_data;
@@ -39,6 +40,11 @@ static int mcux_pwm_pin_set(struct device *dev, u32_t pwm,
 	if (pwm >= CHANNEL_COUNT) {
 		LOG_ERR("Invalid channel");
 		return -EINVAL;
+	}
+
+	if (flags) {
+		/* PWM polarity not supported (yet?) */
+		return -ENOTSUP;
 	}
 
 	if ((period_cycles == 0) || (pulse_cycles > period_cycles)) {

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -34,7 +34,8 @@ struct mcux_ftm_data {
 };
 
 static int mcux_ftm_pin_set(struct device *dev, u32_t pwm,
-			    u32_t period_cycles, u32_t pulse_cycles)
+			    u32_t period_cycles, u32_t pulse_cycles,
+			    pwm_flags_t flags)
 {
 	const struct mcux_ftm_config *config = dev->config->config_info;
 	struct mcux_ftm_data *data = dev->driver_data;
@@ -48,6 +49,11 @@ static int mcux_ftm_pin_set(struct device *dev, u32_t pwm,
 
 	if (pwm >= config->channel_count) {
 		LOG_ERR("Invalid channel");
+		return -ENOTSUP;
+	}
+
+	if (flags) {
+		/* PWM polarity not supported (yet?) */
 		return -ENOTSUP;
 	}
 

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -87,7 +87,8 @@ static u8_t pwm_channel_map(struct pwm_data *data, u8_t map_size,
 }
 
 static int pwm_nrf5_sw_pin_set(struct device *dev, u32_t pwm,
-			       u32_t period_cycles, u32_t pulse_cycles)
+			       u32_t period_cycles, u32_t pulse_cycles,
+			       pwm_flags_t flags)
 {
 	struct pwm_config *config;
 	NRF_TIMER_Type *timer;
@@ -100,6 +101,11 @@ static int pwm_nrf5_sw_pin_set(struct device *dev, u32_t pwm,
 	config = (struct pwm_config *)dev->config->config_info;
 	timer = config->timer;
 	data = dev->driver_data;
+
+	if (flags) {
+		/* PWM polarity not supported (yet?) */
+		return -ENOTSUP;
+	}
 
 	/* check if requested period is allowed while other channels are
 	 * active.

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -123,7 +123,8 @@ static bool any_other_channel_is_active(u8_t channel,
 }
 
 static int pwm_nrfx_pin_set(struct device *dev, u32_t pwm,
-			    u32_t period_cycles, u32_t pulse_cycles)
+			    u32_t period_cycles, u32_t pulse_cycles,
+			    pwm_flags_t flags)
 {
 	/* We assume here that period_cycles will always be 16MHz
 	 * peripheral clock. Since pwm_nrfx_get_cycles_per_sec() function might
@@ -133,6 +134,11 @@ static int pwm_nrfx_pin_set(struct device *dev, u32_t pwm,
 	const struct pwm_nrfx_config *config = dev->config->config_info;
 	struct pwm_nrfx_data *data = dev->driver_data;
 	u8_t channel;
+
+	if (flags) {
+		/* PWM polarity not supported (yet?) */
+		return -ENOTSUP;
+	}
 
 	/* Check if PWM pin is one of the predefiend DTS config pins.
 	 * Return its array index (channel number),

--- a/drivers/pwm/pwm_pca9685.c
+++ b/drivers/pwm/pwm_pca9685.c
@@ -61,7 +61,8 @@ static inline int has_i2c_master(struct device *dev)
  * value to pulse_count
  */
 static int pwm_pca9685_pin_set_cycles(struct device *dev, u32_t pwm,
-				      u32_t period_count, u32_t pulse_count)
+				      u32_t period_count, u32_t pulse_count,
+				      pwm_flags_t flags)
 {
 	const struct pwm_pca9685_config * const config =
 		dev->config->config_info;
@@ -74,6 +75,11 @@ static int pwm_pca9685_pin_set_cycles(struct device *dev, u32_t pwm,
 	ARG_UNUSED(period_count);
 	if (!has_i2c_master(dev)) {
 		return -EINVAL;
+	}
+
+	if (flags) {
+		/* PWM polarity not supported (yet?) */
+		return -ENOTSUP;
 	}
 
 	if (pwm > MAX_PWM_OUT) {

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -36,12 +36,18 @@ static int sam_pwm_get_cycles_per_sec(struct device *dev, u32_t pwm,
 }
 
 static int sam_pwm_pin_set(struct device *dev, u32_t ch,
-			   u32_t period_cycles, u32_t pulse_cycles)
+			   u32_t period_cycles, u32_t pulse_cycles,
+			   pwm_flags_t flags)
 {
 	Pwm *const pwm = DEV_CFG(dev)->regs;
 
 	if (ch >= PWMCHNUM_NUMBER) {
 		return -EINVAL;
+	}
+
+	if (flags) {
+		/* PWM polarity not supported (yet?) */
+		return -ENOTSUP;
 	}
 
 	if (period_cycles == 0U || pulse_cycles > period_cycles) {

--- a/drivers/pwm/pwm_shell.c
+++ b/drivers/pwm/pwm_shell.c
@@ -45,7 +45,7 @@ static int cmd_cycles(const struct shell *shell, size_t argc, char **argv)
 	period = strtoul(argv[args_indx.period], NULL, 0);
 	pulse = strtoul(argv[args_indx.pulse], NULL, 0);
 
-	err = pwm_pin_set_cycles(dev, pwm, period, pulse);
+	err = pwm_pin_set_cycles(dev, pwm, period, pulse, 0);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)",
 			    err);
@@ -73,7 +73,7 @@ static int cmd_usec(const struct shell *shell, size_t argc, char **argv)
 	period = strtoul(argv[args_indx.period], NULL, 0);
 	pulse = strtoul(argv[args_indx.pulse], NULL, 0);
 
-	err = pwm_pin_set_usec(dev, pwm, period, pulse);
+	err = pwm_pin_set_usec(dev, pwm, period, pulse, 0);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)", err);
 		return err;
@@ -100,7 +100,7 @@ static int cmd_nsec(const struct shell *shell, size_t argc, char **argv)
 	period = strtoul(argv[args_indx.period], NULL, 0);
 	pulse = strtoul(argv[args_indx.pulse], NULL, 0);
 
-	err = pwm_pin_set_nsec(dev, pwm, period, pulse);
+	err = pwm_pin_set_nsec(dev, pwm, period, pulse, 0);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)", err);
 		return err;

--- a/drivers/pwm/pwm_shell.c
+++ b/drivers/pwm/pwm_shell.c
@@ -18,6 +18,7 @@ struct args_index {
 	u8_t pwm;
 	u8_t period;
 	u8_t pulse;
+	u8_t flags;
 };
 
 static const struct args_index args_indx = {
@@ -25,10 +26,12 @@ static const struct args_index args_indx = {
 	.pwm = 2,
 	.period = 3,
 	.pulse = 4,
+	.flags = 5,
 };
 
 static int cmd_cycles(const struct shell *shell, size_t argc, char **argv)
 {
+	pwm_flags_t flags = 0;
 	struct device *dev;
 	u32_t period;
 	u32_t pulse;
@@ -45,7 +48,11 @@ static int cmd_cycles(const struct shell *shell, size_t argc, char **argv)
 	period = strtoul(argv[args_indx.period], NULL, 0);
 	pulse = strtoul(argv[args_indx.pulse], NULL, 0);
 
-	err = pwm_pin_set_cycles(dev, pwm, period, pulse, 0);
+	if (argc == (args_indx.flags + 1)) {
+		flags = strtoul(argv[args_indx.flags], NULL, 0);
+	}
+
+	err = pwm_pin_set_cycles(dev, pwm, period, pulse, flags);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)",
 			    err);
@@ -57,6 +64,7 @@ static int cmd_cycles(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_usec(const struct shell *shell, size_t argc, char **argv)
 {
+	pwm_flags_t flags = 0;
 	struct device *dev;
 	u32_t period;
 	u32_t pulse;
@@ -73,7 +81,11 @@ static int cmd_usec(const struct shell *shell, size_t argc, char **argv)
 	period = strtoul(argv[args_indx.period], NULL, 0);
 	pulse = strtoul(argv[args_indx.pulse], NULL, 0);
 
-	err = pwm_pin_set_usec(dev, pwm, period, pulse, 0);
+	if (argc == (args_indx.flags + 1)) {
+		flags = strtoul(argv[args_indx.flags], NULL, 0);
+	}
+
+	err = pwm_pin_set_usec(dev, pwm, period, pulse, flags);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)", err);
 		return err;
@@ -84,6 +96,7 @@ static int cmd_usec(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_nsec(const struct shell *shell, size_t argc, char **argv)
 {
+	pwm_flags_t flags = 0;
 	struct device *dev;
 	u32_t period;
 	u32_t pulse;
@@ -100,7 +113,11 @@ static int cmd_nsec(const struct shell *shell, size_t argc, char **argv)
 	period = strtoul(argv[args_indx.period], NULL, 0);
 	pulse = strtoul(argv[args_indx.pulse], NULL, 0);
 
-	err = pwm_pin_set_nsec(dev, pwm, period, pulse, 0);
+	if (argc == (args_indx.flags + 1)) {
+		flags = strtoul(argv[args_indx.flags], NULL, 0);
+	}
+
+	err = pwm_pin_set_nsec(dev, pwm, period, pulse, flags);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)", err);
 		return err;
@@ -111,11 +128,11 @@ static int cmd_nsec(const struct shell *shell, size_t argc, char **argv)
 
 SHELL_STATIC_SUBCMD_SET_CREATE(pwm_cmds,
 	SHELL_CMD_ARG(cycles, NULL, "<device> <pwm> <period in cycles> "
-		      "<pulse width in cycles>", cmd_cycles, 5, 0),
+		      "<pulse width in cycles> [flags]", cmd_cycles, 5, 1),
 	SHELL_CMD_ARG(usec, NULL, "<device> <pwm> <period in usec> "
-		      "<pulse width in usec>", cmd_usec, 5, 0),
+		      "<pulse width in usec> [flags]", cmd_usec, 5, 1),
 	SHELL_CMD_ARG(nsec, NULL, "<device> <pwm> <period in nsec> "
-		      "<pulse width in nsec>", cmd_nsec, 5, 0),
+		      "<pulse width in nsec> [flags]", cmd_nsec, 5, 1),
 	SHELL_SUBCMD_SET_END
 );
 

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -96,7 +96,8 @@ static int pwm_sifive_init(struct device *dev)
 static int pwm_sifive_pin_set(struct device *dev,
 			      u32_t pwm,
 			      u32_t period_cycles,
-			      u32_t pulse_cycles)
+			      u32_t pulse_cycles,
+			      pwm_flags_t flags)
 {
 	const struct pwm_sifive_cfg *config = NULL;
 	u32_t count_max = 0U;
@@ -110,6 +111,11 @@ static int pwm_sifive_pin_set(struct device *dev,
 	if (dev->config == NULL) {
 		LOG_ERR("The device config pointer was NULL\n");
 		return -EFAULT;
+	}
+
+	if (flags) {
+		/* PWM polarity not supported (yet?) */
+		return -ENOTSUP;
 	}
 
 	config = dev->config->config_info;

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -71,7 +71,8 @@ static u32_t __get_tim_clk(u32_t bus_clk,
  * return 0, or negative errno code
  */
 static int pwm_stm32_pin_set(struct device *dev, u32_t pwm,
-			     u32_t period_cycles, u32_t pulse_cycles)
+			     u32_t period_cycles, u32_t pulse_cycles,
+			     pwm_flags_t flags)
 {
 	struct pwm_stm32_data *data = DEV_DATA(dev);
 	TIM_HandleTypeDef *TimerHandle = &data->hpwm;
@@ -81,6 +82,11 @@ static int pwm_stm32_pin_set(struct device *dev, u32_t pwm,
 
 	if (period_cycles == 0U || pulse_cycles > period_cycles) {
 		return -EINVAL;
+	}
+
+	if (flags) {
+		/* PWM polarity not supported (yet?) */
+		return -ENOTSUP;
 	}
 
 	/* configure channel */

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -282,7 +282,7 @@
 			interrupts = <42 0>;
 			label = "PWM_0";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm1: pwm@40039000{
@@ -291,7 +291,7 @@
 			interrupts = <43 0>;
 			label = "PWM_1";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm2: pwm@4003a000{
@@ -300,7 +300,7 @@
 			interrupts = <44 0>;
 			label = "PWM_2";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm3: pwm@400b9000{
@@ -309,7 +309,7 @@
 			interrupts = <71 0>;
 			label = "PWM_3";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		adc0: adc@4003b000{

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -322,7 +322,7 @@
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
 			label = "PWM_0";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm1: pwm@40039000{
@@ -332,7 +332,7 @@
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
 			label = "PWM_1";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm2: pwm@4003a000{
@@ -342,7 +342,7 @@
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
 			label = "PWM_2";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm3: pwm@400b9000{
@@ -352,7 +352,7 @@
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
 			label = "PWM_3";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		adc0: adc@4003b000{

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -276,7 +276,7 @@
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
 			label = "PWM_0";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm1: pwm@40039000 {
@@ -286,7 +286,7 @@
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
 			label = "PWM_1";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm2: pwm@4003a000 {
@@ -296,7 +296,7 @@
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
 			label = "PWM_2";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm3: pwm@400b9000 {
@@ -306,7 +306,7 @@
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
 			label = "PWM_3";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		rtc: rtc@4003d000 {

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -350,7 +350,7 @@
 			interrupts = <42 0>;
 			clocks = <&pcc 0xe0 KINETIS_PCC_SRC_FIRC_ASYNC>;
 			label = "PWM_0";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 			status = "disabled";
 		};
 
@@ -360,7 +360,7 @@
 			interrupts = <43 0>;
 			clocks = <&pcc 0xe4 KINETIS_PCC_SRC_FIRC_ASYNC>;
 			label = "PWM_1";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 			status = "disabled";
 		};
 
@@ -370,7 +370,7 @@
 			interrupts = <44 0>;
 			clocks = <&pcc 0xe8 KINETIS_PCC_SRC_FIRC_ASYNC>;
 			label = "PWM_2";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 			status = "disabled";
 		};
 
@@ -380,7 +380,7 @@
 			interrupts = <71 0>;
 			clocks = <&pcc 0x98 KINETIS_PCC_SRC_FIRC_ASYNC>;
 			label = "PWM_3";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/nxp_kv5x.dtsi
@@ -200,7 +200,7 @@
 			interrupts = <42 0>;
 			label = "FTM_0";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm2: pwm@40039000 {
@@ -209,7 +209,7 @@
 			interrupts = <43 0>;
 			label = "FTM_1";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm3: pwm@4003a000 {
@@ -218,7 +218,7 @@
 			interrupts = <53 0>;
 			label = "FTM_2";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm4: pwm@40026000 {
@@ -227,7 +227,7 @@
 			interrupts = <71 0>;
 			label = "FTM_3";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		spi0: spi@4002c000 {

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -255,7 +255,7 @@
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
 			label = "PWM_0";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm1: pwm@40039000{
@@ -265,7 +265,7 @@
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
 			label = "PWM_1";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		pwm2: pwm@4003a000{
@@ -275,7 +275,7 @@
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>;
 			label = "PWM_2";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		adc0: adc@4003b000{

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -15,9 +15,10 @@ properties:
       required: true
 
     "#pwm-cells":
-      const: 2
+      const: 3
 
 pwm-cells:
   - channel
 # period in terms of nanoseconds
   - period
+  - flags

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -23,10 +23,16 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <device.h>
+#include <dt-bindings/pwm/pwm.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief Provides a type to hold PWM configuration flags.
+ */
+typedef u8_t pwm_flags_t;
 
 /**
  * @typedef pwm_pin_set_t
@@ -34,7 +40,8 @@ extern "C" {
  * See @a pwm_pin_set_cycles() for argument description
  */
 typedef int (*pwm_pin_set_t)(struct device *dev, u32_t pwm,
-			     u32_t period_cycles, u32_t pulse_cycles);
+			     u32_t period_cycles, u32_t pulse_cycles,
+			     pwm_flags_t flags);
 
 /**
  * @typedef pwm_get_cycles_per_sec_t
@@ -57,20 +64,22 @@ struct pwm_driver_api {
  * @param pwm PWM pin.
  * @param period Period (in clock cycle) set to the PWM. HW specific.
  * @param pulse Pulse width (in clock cycle) set to the PWM. HW specific.
+ * @param flags Flags for pin configuration (polarity).
  *
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
 __syscall int pwm_pin_set_cycles(struct device *dev, u32_t pwm,
-				 u32_t period, u32_t pulse);
+				 u32_t period, u32_t pulse, pwm_flags_t flags);
 
 static inline int z_impl_pwm_pin_set_cycles(struct device *dev, u32_t pwm,
-					   u32_t period, u32_t pulse)
+					    u32_t period, u32_t pulse,
+					    pwm_flags_t flags)
 {
 	struct pwm_driver_api *api;
 
 	api = (struct pwm_driver_api *)dev->driver_api;
-	return api->pin_set(dev, pwm, period, pulse);
+	return api->pin_set(dev, pwm, period, pulse, flags);
 }
 
 /**
@@ -104,12 +113,14 @@ static inline int z_impl_pwm_get_cycles_per_sec(struct device *dev, u32_t pwm,
  * @param pwm PWM pin.
  * @param period Period (in microseconds) set to the PWM.
  * @param pulse Pulse width (in microseconds) set to the PWM.
+ * @param flags Flags for pin configuration (polarity).
  *
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
 static inline int pwm_pin_set_usec(struct device *dev, u32_t pwm,
-				   u32_t period, u32_t pulse)
+				   u32_t period, u32_t pulse,
+				   pwm_flags_t flags)
 {
 	u64_t period_cycles, pulse_cycles, cycles_per_sec;
 
@@ -128,7 +139,7 @@ static inline int pwm_pin_set_usec(struct device *dev, u32_t pwm,
 	}
 
 	return pwm_pin_set_cycles(dev, pwm, (u32_t)period_cycles,
-				  (u32_t)pulse_cycles);
+				  (u32_t)pulse_cycles, flags);
 }
 
 /**
@@ -138,12 +149,14 @@ static inline int pwm_pin_set_usec(struct device *dev, u32_t pwm,
  * @param pwm PWM pin.
  * @param period Period (in nanoseconds) set to the PWM.
  * @param pulse Pulse width (in nanoseconds) set to the PWM.
+ * @param flags Flags for pin configuration (polarity).
  *
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
 static inline int pwm_pin_set_nsec(struct device *dev, u32_t pwm,
-				   u32_t period, u32_t pulse)
+				   u32_t period, u32_t pulse,
+				   pwm_flags_t flags)
 {
 	u64_t period_cycles, pulse_cycles, cycles_per_sec;
 
@@ -162,7 +175,7 @@ static inline int pwm_pin_set_nsec(struct device *dev, u32_t pwm,
 	}
 
 	return pwm_pin_set_cycles(dev, pwm, (u32_t)period_cycles,
-				  (u32_t)pulse_cycles);
+				  (u32_t)pulse_cycles, flags);
 }
 
 #ifdef __cplusplus

--- a/include/dt-bindings/pwm/pwm.h
+++ b/include/dt-bindings/pwm/pwm.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PWM_PWM_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_PWM_PWM_H_
+
+/**
+ * @name PWM polarity flags
+ * The `PWM_POLARITY_*` flags are used with pwm_pin_set_cycles(),
+ * pwm_pin_set_usec(), or pwm_pin_set_nsec() to specify the polarity
+ * of a PWM pin.
+ * @{
+ */
+/** PWM pin normal polarity (active-high pulse). */
+#define PWM_POLARITY_NORMAL	(0 << 0)
+
+/** PWM pin inverted polarity (active-low pulse). */
+#define PWM_POLARITY_INVERTED	(1 << 0)
+
+/** @cond INTERNAL_HIDDEN */
+#define PWM_POLARITY_MASK	0x1
+/** @endcond */
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PWM_PWM_H_ */

--- a/samples/basic/blink_led/src/main.c
+++ b/samples/basic/blink_led/src/main.c
@@ -19,6 +19,11 @@
 /* get the defines from dt (based on alias 'pwm-led0') */
 #define PWM_DRIVER	DT_ALIAS_PWM_LED0_PWMS_CONTROLLER
 #define PWM_CHANNEL	DT_ALIAS_PWM_LED0_PWMS_CHANNEL
+#ifdef DT_ALIAS_PWM_LED0_PWMS_FLAGS
+#define PWM_FLAGS	DT_ALIAS_PWM_LED0_PWMS_FLAGS
+#else
+#define PWM_FLAGS	0
+#endif
 #else
 #error "Choose supported PWM driver"
 #endif
@@ -51,7 +56,7 @@ void main(void)
 	 */
 	max_period = MAX_PERIOD;
 	while (pwm_pin_set_usec(pwm_dev, PWM_CHANNEL,
-				max_period, max_period / 2U, 0)) {
+				max_period, max_period / 2U, PWM_FLAGS)) {
 		max_period /= 2U;
 		if (max_period < (4U * MIN_PERIOD)) {
 			printk("This sample needs to set a period that is "
@@ -63,7 +68,7 @@ void main(void)
 	period = max_period;
 	while (1) {
 		if (pwm_pin_set_usec(pwm_dev, PWM_CHANNEL,
-				     period, period / 2U, 0)) {
+				     period, period / 2U, PWM_FLAGS)) {
 			printk("pwm pin set fails\n");
 			return;
 		}

--- a/samples/basic/blink_led/src/main.c
+++ b/samples/basic/blink_led/src/main.c
@@ -51,7 +51,7 @@ void main(void)
 	 */
 	max_period = MAX_PERIOD;
 	while (pwm_pin_set_usec(pwm_dev, PWM_CHANNEL,
-				max_period, max_period / 2U)) {
+				max_period, max_period / 2U, 0)) {
 		max_period /= 2U;
 		if (max_period < (4U * MIN_PERIOD)) {
 			printk("This sample needs to set a period that is "
@@ -63,7 +63,7 @@ void main(void)
 	period = max_period;
 	while (1) {
 		if (pwm_pin_set_usec(pwm_dev, PWM_CHANNEL,
-				     period, period / 2U)) {
+				     period, period / 2U, 0)) {
 			printk("pwm pin set fails\n");
 			return;
 		}

--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -48,7 +48,7 @@ void main(void)
 
 	while (1) {
 		if (pwm_pin_set_usec(pwm_dev, PWM_CHANNEL,
-					PERIOD, pulse_width)) {
+					PERIOD, pulse_width, 0)) {
 			printk("pwm pin set fails\n");
 			return;
 		}

--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -19,6 +19,11 @@
 /* get the defines from dt (based on alias 'pwm-led0') */
 #define PWM_DRIVER	DT_ALIAS_PWM_LED0_PWMS_CONTROLLER
 #define PWM_CHANNEL	DT_ALIAS_PWM_LED0_PWMS_CHANNEL
+#ifdef DT_ALIAS_PWM_LED0_PWMS_CHANNEL
+#define PWM_FLAGS	DT_ALIAS_PWM_LED0_PWMS_CHANNEL
+#else
+#define PWM_FLAGS	0
+#endif
 #else
 #error "Choose supported PWM driver"
 #endif
@@ -48,7 +53,7 @@ void main(void)
 
 	while (1) {
 		if (pwm_pin_set_usec(pwm_dev, PWM_CHANNEL,
-					PERIOD, pulse_width, 0)) {
+					PERIOD, pulse_width, PWM_FLAGS)) {
 			printk("pwm pin set fails\n");
 			return;
 		}

--- a/samples/basic/rgb_led/src/main.c
+++ b/samples/basic/rgb_led/src/main.c
@@ -26,10 +26,25 @@
  */
 #define PWM_DEV0	DT_ALIAS_RED_PWM_LED_PWMS_CONTROLLER
 #define PWM_CH0		DT_ALIAS_RED_PWM_LED_PWMS_CHANNEL
+#ifdef DT_ALIAS_RED_PWM_LED_PWMS_FLAGS
+#define PWM_FLAGS0	DT_ALIAS_RED_PWM_LED_PWMS_FLAGS
+#else
+#define PWM_FLAGS0	0
+#endif
 #define PWM_DEV1	DT_ALIAS_GREEN_PWM_LED_PWMS_CONTROLLER
 #define PWM_CH1		DT_ALIAS_GREEN_PWM_LED_PWMS_CHANNEL
+#ifdef DT_ALIAS_GREEN_PWM_LED_PWMS_FLAGS
+#define PWM_FLAGS1	DT_ALIAS_GREEN_PWM_LED_PWMS_FLAGS
+#else
+#define PWM_FLAGS1	0
+#endif
 #define PWM_DEV2	DT_ALIAS_BLUE_PWM_LED_PWMS_CONTROLLER
 #define PWM_CH2		DT_ALIAS_BLUE_PWM_LED_PWMS_CHANNEL
+#ifdef DT_ALIAS_BLUE_PWM_LED_PWMS_FLAGS
+#define PWM_FLAGS2	DT_ALIAS_BLUE_PWM_LED_PWMS_FLAGS
+#else
+#define PWM_FLAGS2	0
+#endif
 #else
 #error "Choose supported board or add new board for the application"
 #endif
@@ -44,9 +59,9 @@
 #define STEPSIZE	2000
 
 static int write_pin(struct device *pwm_dev, u32_t pwm_pin,
-		     u32_t pulse_width)
+		     u32_t pulse_width, pwm_flags_t flags)
 {
-	return pwm_pin_set_usec(pwm_dev, pwm_pin, PERIOD, pulse_width, 0);
+	return pwm_pin_set_usec(pwm_dev, pwm_pin, PERIOD, pulse_width, flags);
 }
 
 void main(void)
@@ -68,7 +83,7 @@ void main(void)
 		for (pulse_width0 = 0U; pulse_width0 <= PERIOD;
 		     pulse_width0 += STEPSIZE) {
 			if (write_pin(pwm_dev[0], PWM_CH0,
-				      pulse_width0) != 0) {
+				      pulse_width0, PWM_FLAGS0) != 0) {
 				printk("pin 0 write fails!\n");
 				return;
 			}
@@ -76,7 +91,7 @@ void main(void)
 			for (pulse_width1 = 0U; pulse_width1 <= PERIOD;
 			     pulse_width1 += STEPSIZE) {
 				if (write_pin(pwm_dev[1], PWM_CH1,
-					      pulse_width1) != 0) {
+					      pulse_width1, PWM_FLAGS1) != 0) {
 					printk("pin 1 write fails!\n");
 					return;
 				}
@@ -84,7 +99,8 @@ void main(void)
 				for (pulse_width2 = 0U; pulse_width2 <= PERIOD;
 				     pulse_width2 += STEPSIZE) {
 					if (write_pin(pwm_dev[2], PWM_CH2,
-						      pulse_width2) != 0) {
+						      pulse_width2,
+						      PWM_FLAGS2) != 0) {
 						printk("pin 2 write fails!\n");
 						return;
 					}

--- a/samples/basic/rgb_led/src/main.c
+++ b/samples/basic/rgb_led/src/main.c
@@ -46,7 +46,7 @@
 static int write_pin(struct device *pwm_dev, u32_t pwm_pin,
 		     u32_t pulse_width)
 {
-	return pwm_pin_set_usec(pwm_dev, pwm_pin, PERIOD, pulse_width);
+	return pwm_pin_set_usec(pwm_dev, pwm_pin, PERIOD, pulse_width, 0);
 }
 
 void main(void)

--- a/samples/basic/servo_motor/src/main.c
+++ b/samples/basic/servo_motor/src/main.c
@@ -45,7 +45,7 @@ void main(void)
 	}
 
 	while (1) {
-		if (pwm_pin_set_usec(pwm_dev, 0, PERIOD, pulse_width)) {
+		if (pwm_pin_set_usec(pwm_dev, 0, PERIOD, pulse_width, 0)) {
 			printk("pwm pin set fails\n");
 			return;
 		}

--- a/samples/bluetooth/mesh_demo/src/microbit.c
+++ b/samples/bluetooth/mesh_demo/src/microbit.c
@@ -126,13 +126,14 @@ void board_play_tune(const char *str)
 		}
 
 		if (period) {
-			pwm_pin_set_usec(pwm, BUZZER_PIN, period, period / 2U);
+			pwm_pin_set_usec(pwm, BUZZER_PIN, period, period / 2U,
+					 0);
 		}
 
 		k_sleep(duration);
 
 		/* Disable the PWM */
-		pwm_pin_set_usec(pwm, BUZZER_PIN, 0, 0);
+		pwm_pin_set_usec(pwm, BUZZER_PIN, 0, 0, 0);
 	}
 }
 

--- a/samples/boards/bbc_microbit/pong/src/main.c
+++ b/samples/boards/bbc_microbit/pong/src/main.c
@@ -119,7 +119,7 @@ static enum sound_state {
 
 static inline void beep(int period)
 {
-	pwm_pin_set_usec(pwm, SOUND_PIN, period, period / 2);
+	pwm_pin_set_usec(pwm, SOUND_PIN, period, period / 2, 0);
 }
 
 static void sound_set(enum sound_state state)

--- a/samples/boards/bbc_microbit/sound/src/main.c
+++ b/samples/boards/bbc_microbit/sound/src/main.c
@@ -34,11 +34,11 @@ static void beep(struct k_work *work)
 	/* The "period / 2" pulse duration gives 50% duty cycle, which
 	 * should result in the maximum sound volume.
 	 */
-	pwm_pin_set_usec(pwm, BUZZER_PIN, period, period / 2U);
+	pwm_pin_set_usec(pwm, BUZZER_PIN, period, period / 2U, 0);
 	k_sleep(BEEP_DURATION);
 
 	/* Disable the PWM */
-	pwm_pin_set_usec(pwm, BUZZER_PIN, 0, 0);
+	pwm_pin_set_usec(pwm, BUZZER_PIN, 0, 0, 0);
 
 	/* Ensure there's a clear silent period between two tones */
 	k_sleep(K_MSEC(50));

--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -86,19 +86,19 @@ static int test_task(u32_t port, u32_t period, u32_t pulse, u8_t unit)
 
 	if (unit == UNIT_CYCLES) {
 		/* Verify pwm_pin_set_cycles() */
-		if (pwm_pin_set_cycles(pwm_dev, port, period, pulse)) {
+		if (pwm_pin_set_cycles(pwm_dev, port, period, pulse, 0)) {
 			TC_PRINT("Fail to set the period and pulse width\n");
 			return TC_FAIL;
 		}
 	} else if (unit == UNIT_USECS) {
 		/* Verify pwm_pin_set_usec() */
-		if (pwm_pin_set_usec(pwm_dev, port, period, pulse)) {
+		if (pwm_pin_set_usec(pwm_dev, port, period, pulse, 0)) {
 			TC_PRINT("Fail to set the period and pulse width\n");
 			return TC_FAIL;
 		}
 	} else { /* unit == UNIT_NSECS */
 		/* Verify pwm_pin_set_nsec() */
-		if (pwm_pin_set_nsec(pwm_dev, port, period, pulse)) {
+		if (pwm_pin_set_nsec(pwm_dev, port, period, pulse, 0)) {
 			TC_PRINT("Fail to set the period and pulse width\n");
 			return TC_FAIL;
 		}


### PR DESCRIPTION
Add support for requesting an inverted PWM pulse (active-low) when setting up the period and pulse width of a PWM pin. This is useful when driving external, active-low circuitry with a PWM signal.

You can do a "poor man" inverted PWM pulse just by "inverting" the pulse width, but without proper API support for inverted PWM signals it is not possible to do edge-aligned PWM with either a mix of active-low/active-high or any number of active-low PWM signals (which is often needed for motor control).

This PR updates all in-tree PWM controller drivers to match the new API signature. The NXP Kinetis FlexTimer (FTM) PWM controller driver has furthermore been updated to support PWM flags set through the device tree (as an example implementation).

The following in-tree samples have been updated to support PWM flags:
- samples/basic/blink_led
- samples/basic/fade_led
- samples/basic/rgb_led

Also, the PWM shell commands has been updated to allow specifying PWM flags. All other in-tree PWM consumers are updated to pass a flags value of 0.

The goal is to enable specification of PWM signal polarity through the device tree for supporting PWM controllers (e.g. using `pwms = <&pwm0 1 PWM_POLARITY_INVERTED>;` for PWM controller 0 channel/pin 1). Please see the included changes for the FTM PWM driver for examples.

Closes #21384