### PR TITLE
Bluetooth: L2CAP: Queue packets when a segment could not be allocated

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -126,6 +126,8 @@ struct bt_l2cap_le_chan {
 	struct k_fifo                   tx_queue;
 	/** Channel Pending Transmission buffer  */
 	struct net_buf                  *tx_buf;
+	/** Channel Transmission work  */
+	struct k_work			tx_work;
 	/** Segment SDU packet from upper layer */
 	struct net_buf			*_sdu;
 	u16_t				_sdu_len;

--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -74,6 +74,13 @@ typedef enum bt_l2cap_chan_status {
 	/** Channel output status */
 	BT_L2CAP_STATUS_OUT,
 
+	/** Channel shutdown status
+	 *
+	 * Once this status is notified it means the channel will no longer be
+	 * able to transmit or receive data.
+	 */
+	BT_L2CAP_STATUS_SHUTDOWN,
+
 	/* Total number of status - must be at the end of the enum */
 	BT_L2CAP_NUM_STATUS,
 } __packed bt_l2cap_chan_status_t;

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -22,6 +22,7 @@ config BT_HCI_CMD_COUNT
 
 config BT_RX_BUF_COUNT
 	int "Number of HCI RX buffers"
+	default NET_BUF_RX_COUNT if NET_L2_BT
 	default 3 if BT_RECV_IS_RX_THREAD
 	default 20 if (BT_MESH && !(BT_DISCARDABLE_BUF_COUNT > 0))
 	default 10
@@ -233,6 +234,7 @@ if BT_HCI_ACL_FLOW_CONTROL
 config BT_ACL_RX_COUNT
 	int "Number of incoming ACL data buffers"
 	default BT_CTLR_RX_BUFFERS if BT_CTLR
+	default NET_BUF_RX_COUNT if NET_L2_BT
 	default 6
 	range 1 64
 	help

--- a/subsys/bluetooth/host/Kconfig.l2cap
+++ b/subsys/bluetooth/host/Kconfig.l2cap
@@ -19,6 +19,7 @@ endif # BT_HCI_ACL_FLOW_CONTROL
 
 config BT_L2CAP_TX_BUF_COUNT
 	int "Number of L2CAP TX buffers"
+	default NET_BUF_TX_COUNT if NET_L2_BT
 	default BT_CTLR_TX_BUFFERS if BT_CTLR
 	default 3
 	range 2 255
@@ -27,6 +28,7 @@ config BT_L2CAP_TX_BUF_COUNT
 
 config BT_L2CAP_TX_FRAG_COUNT
 	int "Number of L2CAP TX fragment buffers"
+	default NET_BUF_TX_COUNT if NET_L2_BT
 	default 2
 	range 0 255
 	help

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -228,11 +228,43 @@ void bt_conn_security_changed(struct bt_conn *conn, enum bt_security_err err);
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR */
 
 /* Prepare a PDU to be sent over a connection */
+#if defined(CONFIG_NET_BUF_LOG)
+struct net_buf *bt_conn_create_pdu_timeout_debug(struct net_buf_pool *pool,
+						 size_t reserve, s32_t timeout,
+						 const char *func, int line);
+#define bt_conn_create_pdu_timeout(_pool, _reserve, _timeout) \
+	bt_conn_create_pdu_timeout_debug(_pool, _reserve, _timeout, \
+					 __func__, __LINE__)
+
+#define bt_conn_create_pdu(_pool, _reserve) \
+	bt_conn_create_pdu_timeout_debug(_pool, _reserve, K_FOREVER, \
+					 __func__, __line__)
+#else
 struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
 					   size_t reserve, s32_t timeout);
 
 #define bt_conn_create_pdu(_pool, _reserve) \
 	bt_conn_create_pdu_timeout(_pool, _reserve, K_FOREVER)
+#endif
+
+/* Prepare a PDU to be sent over a connection */
+#if defined(CONFIG_NET_BUF_LOG)
+struct net_buf *bt_conn_create_frag_timeout_debug(size_t reserve, s32_t timeout,
+						  const char *func, int line);
+
+#define bt_conn_create_frag_timeout(_reserve, _timeout) \
+	bt_conn_create_frag_timeout_debug(_reserve, _timeout, \
+					  __func__, __LINE__)
+
+#define bt_conn_create_frag(_reserve) \
+	bt_conn_create_frag_timeout_debug(_reserve, K_FOREVER, \
+					  __func__, __LINE__)
+#else
+struct net_buf *bt_conn_create_frag_timeout(size_t reserve, s32_t timeout);
+
+#define bt_conn_create_frag(_reserve) \
+	bt_conn_create_frag_timeout(_reserve, K_FOREVER)
+#endif
 
 /* Initialize connection management */
 int bt_conn_init(void);

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1255,6 +1255,16 @@ static void l2cap_chan_seg_sent(struct bt_conn *conn, void *user_data)
 	l2cap_chan_tx_resume(BT_L2CAP_LE_CHAN(chan));
 }
 
+/* This returns -EAGAIN whenever a segment cannot be send immediately which can
+ * happen under the following circuntances:
+ *
+ * 1. There are no credits
+ * 2. There are no buffers
+ * 3. There are no TX contexts
+ *
+ * In all cases the original buffer is unaffected so it can be pushed back to
+ * be sent later.
+ */
 static int l2cap_chan_le_send(struct bt_l2cap_le_chan *ch,
 			      struct net_buf *buf, u16_t sdu_hdr_len)
 {

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -49,6 +49,7 @@
 
 #define L2CAP_CONN_TIMEOUT	K_SECONDS(40)
 #define L2CAP_DISC_TIMEOUT	K_SECONDS(2)
+#define L2CAP_RTX_TIMEOUT	K_SECONDS(2)
 
 /* Dedicated pool for disconnect buffers so they are guaranteed to be send
  * even in case of data congestion due to flooding.
@@ -391,7 +392,7 @@ static struct net_buf *l2cap_create_le_sig_pdu(struct net_buf *buf,
 	}
 
 	/* Don't wait more than the minimum RTX timeout of 2 seconds */
-	buf = bt_l2cap_create_pdu_timeout(pool, 0, K_SECONDS(2));
+	buf = bt_l2cap_create_pdu_timeout(pool, 0, L2CAP_RTX_TIMEOUT);
 	if (!buf) {
 		/* If it was not possible to allocate a buffer within the
 		 * timeout return NULL.

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -222,8 +222,6 @@ struct bt_l2cap_br_fixed_chan {
 				.accept = _accept,		\
 			}
 
-void l2cap_chan_sdu_sent(struct bt_conn *conn, void *user_data);
-
 /* Notify L2CAP channels of a new connection */
 void bt_l2cap_connected(struct bt_conn *conn);
 

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -252,7 +252,7 @@ static struct net_buf *ipsp_alloc_buf(struct bt_l2cap_chan *chan)
 {
 	NET_DBG("Channel %p requires buffer", chan);
 
-	return net_pkt_get_reserve_rx_data(K_FOREVER);
+	return net_pkt_get_reserve_rx_data(BUF_TIMEOUT);
 }
 
 static struct bt_l2cap_chan_ops ipsp_ops = {

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -114,6 +114,8 @@ static int net_bt_send(struct net_if *iface, struct net_pkt *pkt)
 
 	ret = bt_l2cap_chan_send(&conn->ipsp_chan.chan, buffer);
 	if (ret < 0) {
+		NET_ERR("Unable to send packet: %d", ret);
+		bt_l2cap_chan_disconnect(&conn->ipsp_chan.chan);
 		return ret;
 	}
 


### PR DESCRIPTION
When a segment could not be allocated it should be possible to resume
sending it later once previous segments complete, the only exception is
when there is no previous activity and we are unable to alocate even the
very first segment which should indicate to the caller that it would
block since that only happens on syswq the caller might need to defer to
another thread or resubmit the work.

Fixes #20640

Patch grow a little bit big but the overall impact in memory is quite small:

IPSP sample board=qemu_x86

Before:

make ram_report

    l2                                                                                   392     0.35%
      bluetooth                                                                          392     0.35%
        bluetooth.c                                                                      392     0.35%
          __config_net_bt                                                                 12     0.01%
          __device_net_bt                                                                 12     0.01%
          __net_if_dev_net_bt_0                                                           28     0.02%
          __net_if_net_bt_0                                                               32     0.03%
          __net_l2_data_net_bt0                                                            4     0.00%
          bt_context_data                                                                228     0.20%
          bt_if_api                                                                        4     0.00%
          conn_callbacks                                                                  28     0.02%
          default_conn                                                                     4     0.00%
          ipsp_ops                                                                        28     0.02%
          server                                                                          12     0.01%

make rom_report

    l2                                                                                  1419     0.47%
      bluetooth                                                                         1419     0.47%
        bluetooth.c                                                                     1419     0.47%
          __config_net_bt                                                                 12     0.00%
          __device_net_bt                                                                 12     0.00%
          __net_if_dev_net_bt_0                                                           28     0.01%
          __net_if_net_bt_0                                                               32     0.01%
          __net_l2_data_net_bt0                                                            4     0.00%
          ad                                                                              16     0.01%
          bt_advertise                                                                   106     0.04%
          bt_context_data                                                                228     0.08%
          bt_if_api                                                                        4     0.00%
          bt_iface_init                                                                   27     0.01%
          conn_callbacks                                                                  28     0.01%
          connected                                                                       46     0.02%
          disconnected                                                                    32     0.01%
          ipsp_accept                                                                     40     0.01%
          ipsp_alloc_buf                                                                  16     0.01%
          ipsp_connected                                                                 247     0.08%
          ipsp_disconnected                                                               47     0.02%
          ipsp_ops                                                                        28     0.01%
          ipsp_recv                                                                      115     0.04%
          net_bt_enable                                                                   35     0.01%
          net_bt_flags                                                                     3     0.00%
          net_bt_get_conn                                                                 17     0.01%
          net_bt_init                                                                     30     0.01%
          net_bt_recv                                                                     23     0.01%
          net_bt_send                                                                    117     0.04%
          net_mgmt_NET_REQUEST_BT_ADVERTISE                                              106     0.04%
          sd                                                                               8     0.00%
          server                                                                          12     0.00%
          
After:

make ram_report

    l2                                                                                   404     0.36%
      bluetooth                                                                          404     0.36%
        bluetooth.c                                                                      404     0.36%
          __config_net_bt                                                                 12     0.01%
          __device_net_bt                                                                 12     0.01%
          __net_if_dev_net_bt_0                                                           28     0.02%
          __net_if_net_bt_0                                                               32     0.03%
          __net_l2_data_net_bt0                                                            4     0.00%
          bt_context_data                                                                240     0.21%
          bt_if_api                                                                        4     0.00%
          conn_callbacks                                                                  28     0.02%
          default_conn                                                                     4     0.00%
          ipsp_ops                                                                        28     0.02%
          server                                                                          12     0.01%

make rom_report

    l2                                                                                  1446     0.48%
      bluetooth                                                                         1446     0.48%
        bluetooth.c                                                                     1446     0.48%
          __config_net_bt                                                                 12     0.00%
          __device_net_bt                                                                 12     0.00%
          __net_if_dev_net_bt_0                                                           28     0.01%
          __net_if_net_bt_0                                                               32     0.01%
          __net_l2_data_net_bt0                                                            4     0.00%
          ad                                                                              16     0.01%
          bt_advertise                                                                   106     0.04%
          bt_context_data                                                                240     0.08%
          bt_if_api                                                                        4     0.00%
          bt_iface_init                                                                   27     0.01%
          conn_callbacks                                                                  28     0.01%
          connected                                                                       46     0.02%
          disconnected                                                                    32     0.01%
          ipsp_accept                                                                     40     0.01%
          ipsp_alloc_buf                                                                  16     0.01%
          ipsp_connected                                                                 247     0.08%
          ipsp_disconnected                                                               47     0.02%
          ipsp_ops                                                                        28     0.01%
          ipsp_recv                                                                      115     0.04%
          net_bt_enable                                                                   35     0.01%
          net_bt_flags                                                                     3     0.00%
          net_bt_get_conn                                                                 17     0.01%
          net_bt_init                                                                     30     0.01%
          net_bt_recv                                                                     23     0.01%
          net_bt_send                                                                    132     0.04%
          net_mgmt_NET_REQUEST_BT_ADVERTISE                                              106     0.04%
          sd                                                                               8     0.00%
          server                                                                          12     0.00%

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>