### PR TITLE
kernel/sched: Fix edge case in MetaIRQ preemption of cooperative threads

### DIFF
--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -112,6 +112,11 @@ struct _cpu {
 	void *syscall_frame;
 #endif
 
+#if (CONFIG_NUM_METAIRQ_PRIORITIES > 0) && (CONFIG_NUM_COOP_PRIORITIES > 0)
+	/* Coop thread preempted by current metairq, or NULL */
+	struct k_thread *metairq_preempted;
+#endif
+
 #ifdef CONFIG_TIMESLICING
 	/* number of ticks remaining in current time slice */
 	int slice_ticks;


### PR DESCRIPTION
When a MetaIRQ preempts a cooperative thread, that thread would be
added back to the generic run queue.  When the MetaIRQ is done, the
highest priority thread will be selected to run, which may obviously
be a cooperative thread of a higher priority than the one that was
preempted.

But that's wrong, because the original thread was promised that it
would NOT be preempted until it reached a scheduling point on its own
(that's the whole point of a cooperative thread, of course).

We need to track the thread that got preempted (one per CPU) and
return to it instead of whatever else the scheduler might have found.

Fixes #20255

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>