### PR TITLE
scripts: dts: improve error message on compatible type error

### DIFF
--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -314,8 +314,10 @@ class EDT:
 
             compatible = binding["compatible"]
             if not isinstance(compatible, str):
-                _err("malformed 'compatible:' field in {} - should be a string"
-                     .format(binding_path))
+                _err("malformed 'compatible: {}' field in {} - "
+                     "should be a string, not {}"
+                     .format(compatible, binding_path,
+                             type(compatible).__name__))
 
             return compatible
 


### PR DESCRIPTION
Print the offending value and its type.
