### PR TITLE
west.yml: Update ci-tools to run the (e)dtlib test suites in CI

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -29,7 +29,7 @@ manifest:
       revision: 5690f5b84495c8b657ff204c5c827df1ab9e12e3
       path: modules/hal/atmel
     - name: ci-tools
-      revision: 20aa511fbd302ba8429a9ab04ee96c201b547743
+      revision: c083680dd5e281218ddb47d0ceac5c5fd5619749
       path: tools/ci-tools
     - name: civetweb
       revision: 99129c5efc907ea613c4b73ccff07581feb58a7a


### PR DESCRIPTION
Get this commit in:

    check_compliance.py: Run the dtlib/edtlib test suites on Python 3.5

    Will work once
    https://github.com/zephyrproject-rtos/zephyr/pull/20597 is in. CI
    uses Python 3.5, so they have been skipped until now.

That PR is in now.