### PR TITLE
samples: drivers: espi: Fix #20505 and #20506 coverity issues

### DIFF
--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -226,19 +226,22 @@ void main(void)
 
 #ifdef CONFIG_ESPI_GPIO_DEV_NEEDED
 	gpio_dev0 = device_get_binding(CONFIG_ESPI_GPIO_DEV0);
-	if (gpio_dev0) {
-		printk("%s FOUND!\n", CONFIG_ESPI_GPIO_DEV0);
+	if (!gpio_dev0) {
+		printk("Fail to find: %s!\n", CONFIG_ESPI_GPIO_DEV0);
+		return;
 	}
 
 	gpio_dev1 = device_get_binding(CONFIG_ESPI_GPIO_DEV1);
-	if (gpio_dev1) {
-		printk("%s FOUND!\n", CONFIG_ESPI_GPIO_DEV1);
+	if (!gpio_dev1) {
+		printk("Fail to find: %s!\n", CONFIG_ESPI_GPIO_DEV1);
+		return;
 	}
 
 #endif
 	espi_dev = device_get_binding(CONFIG_ESPI_DEV);
-	if (espi_dev) {
-		printk("%s FOUND!\n", CONFIG_ESPI_DEV);
+	if (!espi_dev) {
+		printk("Fail to find %s!\n", CONFIG_ESPI_DEV);
+		return;
 	}
 
 	printk("Hello eSPI test! %s\n", CONFIG_BOARD);


### PR DESCRIPTION
Abort execution if any null pointer found during espi/gpio binding.
Fix https://github.com/zephyrproject-rtos/zephyr/issues/20505
Fix https://github.com/zephyrproject-rtos/zephyr/issues/20506

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>