### PR TITLE
samples: CAN: kconfig: Fix ref. to CONFIG_CAN_AUTO_BUS_OFF_RECOVERY

### DIFF
--- a/samples/drivers/CAN/src/main.c
+++ b/samples/drivers/CAN/src/main.c
@@ -150,7 +150,7 @@ void state_change_work_handler(struct k_work *work)
 		state_to_str(current_state),
 		current_err_cnt.rx_err_cnt, current_err_cnt.tx_err_cnt);
 
-#ifndef CONFIG_CAN_AUTO_BOFF_RECOVERY
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 	if (current_state == CAN_BUS_OFF) {
 		printk("Recover from bus-off\n");
 
@@ -158,7 +158,7 @@ void state_change_work_handler(struct k_work *work)
 			printk("Recovery timed out\n");
 		}
 	}
-#endif /* CONFIG_CAN_AUTO_BOFF_RECOVERY */
+#endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 }
 
 void state_change_isr(enum can_state state, struct can_bus_err_cnt err_cnt)


### PR DESCRIPTION
A reference to CONFIG_CAN_AUTO_BOFF_RECOVERY was added in commit
1b88658f9f ("samples: driver: Extend CAN sample"), but it's never been
defined as a Kconfig symbol.

Should have been CONFIG_CAN_AUTO_BUS_OFF_RECOVERY according to
alexanderwachter, so change it to that.

Adding detection of unused symbols in samples and tests to CI.