### PR TITLE
samples: syslog_net: Remove ref. to CONFIG_SYS_LOG_BACKEND_NET_SERVER

### DIFF
--- a/samples/net/syslog_net/prj.conf
+++ b/samples/net/syslog_net/prj.conf
@@ -31,7 +31,6 @@ CONFIG_NET_CONFIG_PEER_IPV4_ADDR="192.0.2.2"
 # logging net backend config
 CONFIG_LOG_BACKEND_NET=y
 CONFIG_LOG_BACKEND_NET_SERVER="[2001:db8::2]:514"
-#CONFIG_SYS_LOG_BACKEND_NET_SERVER="192.0.2.2:514"
 
 # Get newlib by default as it has proper time function support
 CONFIG_NEWLIB_LIBC=y


### PR DESCRIPTION
The definition was removed in commit 7ccc7889fa ("logging: Remove
SYS_LOG implementation").

Adding detection of unused symbols in samples and tests to CI.