### PR TITLE
tests/arch/x86/info: add console harness and regex

### DIFF
--- a/tests/arch/x86/info/testcase.yaml
+++ b/tests/arch/x86/info/testcase.yaml
@@ -2,3 +2,8 @@ tests:
   arch.x86.info:
     arch_whitelist: x86
     platform_whitelist: up_squared
+    harness: console
+    harness_config:
+        type: one_line
+        regex:
+          - "info: complete"


### PR DESCRIPTION
use the console handler to handle this test, parse
the output and capture the regex to pass it.

Fixes: #20444 

Signed-off-by: peng1 chen <peng1.chen@intel.com>