### PR TITLE
drivers: entropy: rv32m1: Turn pointless 'menuconfig' into 'config'

### DIFF
--- a/drivers/entropy/Kconfig.rv32m1
+++ b/drivers/entropy/Kconfig.rv32m1
@@ -1,10 +1,9 @@
-# Kconfig.rv32m1 - RV32M1 entropy generator driver configuration
-#
+# RV32M1 entropy generator driver configuration
+
 # Copyright 2019 NXP
-#
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig ENTROPY_RV32M1_TRNG
+config ENTROPY_RV32M1_TRNG
 	bool "RV32M1 TRNG driver"
 	depends on ENTROPY_GENERATOR && SOC_OPENISA_RV32M1_RISCV32
 	select ENTROPY_HAS_DRIVER


### PR DESCRIPTION
Same deal as in commit 677f1e6 ("config: Turn pointless/confusing
'menuconfig's into 'config's"), for a newly introduced symbol.

Also clean up a header to be consistent with recent cleanups.