### PR TITLE
cmake: Support renode 1.8.2.

### DIFF
--- a/cmake/emu/renode.cmake
+++ b/cmake/emu/renode.cmake
@@ -7,6 +7,7 @@ find_program(
 
 set(RENODE_FLAGS
   --disable-xwt
+  --port -2
   --pid-file renode.pid
   )
 


### PR DESCRIPTION
Renode 1.8 introduced a behaviour change in which it automatically
launches the telnet monitor on the TCP port 1234 by default.

In order to prevent sanitycheck failures from multiple renode instances
attempting to listen on the TCP port 1234 simultaneously, this commit
disables renode telnet monitor by specifying '--port -2' (a negative
number lower than -1 is required to disable telnet monitor because of
the way renode command line parser is implemented).