### PR TITLE
Bluetooth: Mesh: Fixes Config client send publish message

### DIFF
--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -1236,7 +1236,7 @@ static int mod_pub_set(u16_t net_idx, u16_t addr, u16_t elem_addr,
 
 	net_buf_simple_add_le16(&msg, elem_addr);
 	net_buf_simple_add_le16(&msg, pub->addr);
-	net_buf_simple_add_le16(&msg, (pub->app_idx & (pub->cred_flag << 12)));
+	net_buf_simple_add_le16(&msg, (pub->app_idx | (pub->cred_flag << 12)));
 	net_buf_simple_add_u8(&msg, pub->ttl);
 	net_buf_simple_add_u8(&msg, pub->period);
 	net_buf_simple_add_u8(&msg, pub->transmit);


### PR DESCRIPTION
When Config client model send publish message, app_idx will
be need, however, currently code clear this value use `&`,
this will be generate error when app_idx not zero.

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>