### PR TITLE
fs/fcb: improve error handling in fcb_offset_last_n

### DIFF
--- a/subsys/fs/fcb/fcb.c
+++ b/subsys/fs/fcb/fcb.c
@@ -290,6 +290,7 @@ fcb_offset_last_n(struct fcb *fcb, u8_t entries,
 {
 	struct fcb_entry loc;
 	int i;
+	int rc;
 
 	/* assure a minimum amount of entries */
 	if (!entries) {
@@ -305,7 +306,14 @@ fcb_offset_last_n(struct fcb *fcb, u8_t entries,
 		}
 		/* Update last_n_entry after n entries and keep updating */
 		else if (i > (entries - 1)) {
-			fcb_getnext(fcb, last_n_entry);
+			rc = fcb_getnext(fcb, last_n_entry);
+
+			if (rc) {
+				/* A fcb history must have been erased,
+				 * wanted entry doesn't exist anymore.
+				 */
+				return -ENOENT;
+			}
 		}
 		i++;
 	}


### PR DESCRIPTION
Fix for not served error code in fcb_offset_last_n()
implementation.
Issue was reported by static code analyze scan.
Looks like the function might have failed silently
if aggressive access to the fcb instance
from another thread have been occurring while the function
have been processing the fcb storage.

fixes #20512

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>