### PR TITLE
modules: hal_nxp: support offload board

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -83,7 +83,7 @@ manifest:
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs
     - name: hal_nxp
-      revision: c6ce9b7e8ddb501ca6d54e927e1602cb5f7a7183
+      revision: f5e84dc7814c33b6364211eb84394ab6763e9312
       path: modules/hal/nxp
     - name: open-amp
       revision: 9b591b289e1f37339bd038b5a1f0e6c8ad39c63a


### PR DESCRIPTION
offload mcux board to zephyr/board/arm/new_board

Signed-off-by: Frank Li <lgl88911@163.com>

Depends on zephyrproject-rtos/hal_nxp#20