### PR TITLE
cmake: make the BT_HCI_TX_STACK_SIZE's prompt conditional

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -62,7 +62,8 @@ config BT_DISCARDABLE_BUF_COUNT
 config BT_HCI_TX_STACK_SIZE
 	# NOTE: This value is derived from other symbols and should only be
 	# changed if required by architecture
-	int "HCI Tx thread stack size"
+	int
+	prompt "HCI Tx thread stack size" if BT_HCI_TX_STACK_SIZE_WITH_PROMPT
 	default 512 if BT_H4
 	default 512 if BT_H5
 	default 416 if BT_SPI
@@ -79,6 +80,9 @@ config BT_HCI_TX_STACK_SIZE
 	  Stack size needed for executing bt_send with specified driver.
 	  NOTE: This is an advanced setting and should not be changed unless
 	  absolutely necessary
+
+config BT_HCI_TX_STACK_SIZE_WITH_PROMPT
+	bool "Override HCI Tx thread stack size"
 
 config BT_HCI_ECC_STACK_SIZE
 	# NOTE: This value is derived from other symbols and should only be


### PR DESCRIPTION
The BT_HCI_TX_STACK_SIZE is carefully calculated from other
options. When those options change, e.g. from a menuconfig update, it
is important that the stack size is re-calculated, but it is not when
there is a prompt.

Therefore, make the prompt conditional such that the previously set
value is only used when it has been explicitly configured to be so.

Now users can still change the value through menuconfig and prj.conf,
by also enabling <option>_WITH_PROMPT, but when the value is
calculated by the defaults, it will continue to be calculated by
defaults instead of inheriting the intial value.

This is AFAIK a novel approach, but testing has shown that it gives
the users the behaviour they want, at the cost of some boilerplate of
course. This pattern can be re-used for other options if it proves to
work as intended.

Alternatively one could remove the prompt, but then it would no longer
be possible to override the value through menuconfig.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>