### PR TITLE
Bluetooth: GATT: Fix taking address of packed member of struct sc_data.

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -191,11 +191,15 @@ struct sc_data {
 struct gatt_sc_cfg {
 	u8_t		id;
 	bt_addr_le_t	peer;
-	struct sc_data	data;
+	struct {
+		u16_t		start;
+		u16_t		end;
+	} data;
 };
 
 #define SC_CFG_MAX (CONFIG_BT_MAX_PAIRED + CONFIG_BT_MAX_CONN)
 static struct gatt_sc_cfg sc_cfg[SC_CFG_MAX];
+BUILD_ASSERT(sizeof(struct sc_data) == sizeof(sc_cfg[0].data));
 
 static struct gatt_sc_cfg *find_sc_cfg(u8_t id, bt_addr_le_t *addr)
 {


### PR DESCRIPTION
Fix GCC9 warning "warning: taking address of packed member of
'struct sc_data' may result in an unaligned pointer value"
Issue is that the on-air structure of sc_data was re-used for the gatt
service changed data.

Added build assert because data is stored in settings, so the structure
should be the same size to be compatible.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>