### PR TITLE
boards: arm: mimxrt1064_evk: Fix display support

### DIFF
--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -67,9 +67,6 @@ config LVGL_VDB_SIZE
 config LVGL_DPI
 	default 128
 
-config LVGL_BITS_PER_PIXEL
-	default 0
-
 choice LVGL_COLOR_DEPTH
 	default LVGL_COLOR_DEPTH_16
 endchoice

--- a/samples/gui/lvgl/sample.yaml
+++ b/samples/gui/lvgl/sample.yaml
@@ -4,7 +4,7 @@ sample:
 tests:
   sample.gui.lvgl:
     harness: display
-    platform_whitelist: reel_board mimxrt1050_evk mimxrt1060_evk
+    platform_whitelist: reel_board mimxrt1050_evk mimxrt1060_evk mimxrt1064_evk
     tags: samples display gui
   sample.display.adafruit_2_8_tft_touch_v2:
     platform_whitelist: nrf52840_pca10056


### PR DESCRIPTION
Delete wrong LVGL_BITS_PER_PIXEL config and add mimxrt1064_evk
to the lvgl sample platform whitelist.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>