### PR TITLE
disk: sdhc: Remove logically dead code from spi sdhc driver

### DIFF
--- a/subsys/disk/disk_access_spi_sdhc.c
+++ b/subsys/disk/disk_access_spi_sdhc.c
@@ -563,11 +563,6 @@ static int sdhc_spi_detect(struct sdhc_spi_data *data)
 				break;
 			}
 		} while (sdhc_retry_ok(&retry));
-
-		if (err != 0) {
-			/* Card never finished power-up */
-			return -ETIMEDOUT;
-		}
 	}
 
 	if ((ocr & SDHC_CCS) != 0U) {


### PR DESCRIPTION
We already returned out of the function if err is nonzero, therefore it
is impossible to reach this return statement.

Coverity-CID: 205612

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #20511