### PR TITLE
drivers: sensor: bme680: Use DBG log level for non-error

### DIFF
--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -348,7 +348,7 @@ static int bme680_chip_init(struct device *dev)
 	}
 
 	if (data->chip_id == BME680_CHIP_ID) {
-		LOG_ERR("BME680 chip detected");
+		LOG_DBG("BME680 chip detected");
 	} else {
 		LOG_ERR("Bad BME680 chip id 0x%x", data->chip_id);
 		return -ENOTSUP;


### PR DESCRIPTION
Use LOG_DBG instead of LOG_ERR when BME680 chip is detected
and its ID verified successfully.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>