### PR TITLE
drivers: clock_control: nrf: assert if caller asks for blocking

### DIFF
--- a/drivers/clock_control/nrf_power_clock.c
+++ b/drivers/clock_control/nrf_power_clock.c
@@ -185,6 +185,14 @@ static int clock_async_start(struct device *dev,
 
 static int clock_start(struct device *dev, clock_control_subsys_t sub_system)
 {
+	/*
+	 * Previous versions of this API used to ask for blocking
+	 * behavior by providing a non-null sub_system pointer. This
+	 * is no longer supported, and this assert was added as a
+	 * warning to any users who expect the old behavior.
+	 */
+	__ASSERT_NO_MSG(sub_system == NULL);
+
 	return clock_async_start(dev, sub_system, NULL);
 }
 


### PR DESCRIPTION
We used to support a hack that blocking enable would be requested if
the sub_system was non-null. This doesn't work that way anymore, so
make sure the sub_system is null to try to catch errors.

Partially helps with #20708 for this driver.