### PR TITLE
kernel: adjust dedicated sections

### DIFF
--- a/include/debug/object_tracing_common.h
+++ b/include/debug/object_tracing_common.h
@@ -13,6 +13,7 @@
 #define ZEPHYR_INCLUDE_DEBUG_OBJECT_TRACING_COMMON_H_
 
 #include <stdbool.h>
+#include <toolchain/common.h>
 
 #ifndef CONFIG_OBJECT_TRACING
 
@@ -20,7 +21,12 @@
 #define SYS_TRACING_OBJ_INIT_DLL(name, obj) do { } while (false)
 #define SYS_TRACING_OBJ_REMOVE_DLL(name, obj) do { } while (false)
 
+#define Z_OBJECT_TRACING_ITERABLE(_struct_name, _obj_name) \
+	struct _struct_name _obj_name
 #else
+
+#define Z_OBJECT_TRACING_ITERABLE(_struct_name, _obj_name) \
+	Z_STRUCT_SECTION_ITERABLE(_struct_name, _obj_name)
 
 /**
  * @def SYS_TRACING_OBJ_INIT

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1537,7 +1537,7 @@ typedef void (*k_timer_stop_t)(struct k_timer *timer);
  * @param stop_fn   Function to invoke if the timer is stopped while running.
  */
 #define K_TIMER_DEFINE(name, expiry_fn, stop_fn) \
-	Z_STRUCT_SECTION_ITERABLE(k_timer, name) = \
+	Z_OBJECT_TRACING_ITERABLE(k_timer, name) = \
 		Z_TIMER_INITIALIZER(name, expiry_fn, stop_fn)
 
 /**
@@ -2144,7 +2144,7 @@ static inline void *z_impl_k_queue_peek_tail(struct k_queue *queue)
  * @param name Name of the queue.
  */
 #define K_QUEUE_DEFINE(name) \
-	Z_STRUCT_SECTION_ITERABLE(k_queue, name) = \
+	Z_OBJECT_TRACING_ITERABLE(k_queue, name) = \
 		_K_QUEUE_INITIALIZER(name)
 
 /** @} */
@@ -2436,7 +2436,7 @@ struct k_fifo {
  * @req K-FIFO-002
  */
 #define K_FIFO_DEFINE(name) \
-	Z_STRUCT_SECTION_ITERABLE(k_fifo, name) = \
+	Z_OBJECT_TRACING_ITERABLE(k_fifo, name) = \
 		Z_FIFO_INITIALIZER(name)
 
 /** @} */
@@ -2547,7 +2547,7 @@ struct k_lifo {
  * @req K-LIFO-002
  */
 #define K_LIFO_DEFINE(name) \
-	Z_STRUCT_SECTION_ITERABLE(k_lifo, name) = \
+	Z_OBJECT_TRACING_ITERABLE(k_lifo, name) = \
 		_K_LIFO_INITIALIZER(name)
 
 /** @} */
@@ -2687,7 +2687,7 @@ __syscall int k_stack_pop(struct k_stack *stack, stack_data_t *data,
 #define K_STACK_DEFINE(name, stack_num_entries)                \
 	stack_data_t __noinit                                  \
 		_k_stack_buf_##name[stack_num_entries];        \
-	Z_STRUCT_SECTION_ITERABLE(k_stack, name) = \
+	Z_OBJECT_TRACING_ITERABLE(k_stack, name) = \
 		_K_STACK_INITIALIZER(name, _k_stack_buf_##name, \
 				    stack_num_entries)
 
@@ -3253,7 +3253,7 @@ struct k_mutex {
  * @req K-MUTEX-001
  */
 #define K_MUTEX_DEFINE(name) \
-	Z_STRUCT_SECTION_ITERABLE(k_mutex, name) = \
+	Z_OBJECT_TRACING_ITERABLE(k_mutex, name) = \
 		_K_MUTEX_INITIALIZER(name)
 
 /**
@@ -3456,7 +3456,7 @@ static inline unsigned int z_impl_k_sem_count_get(struct k_sem *sem)
  * @req K-SEM-002
  */
 #define K_SEM_DEFINE(name, initial_count, count_limit) \
-	Z_STRUCT_SECTION_ITERABLE(k_sem, name) = \
+	Z_OBJECT_TRACING_ITERABLE(k_sem, name) = \
 		Z_SEM_INITIALIZER(name, initial_count, count_limit); \
 	BUILD_ASSERT(((count_limit) != 0) && \
 		     ((initial_count) <= (count_limit)));
@@ -3546,7 +3546,7 @@ struct k_msgq_attrs {
 #define K_MSGQ_DEFINE(q_name, q_msg_size, q_max_msgs, q_align)		\
 	static char __noinit __aligned(q_align)				\
 		_k_fifo_buf_##q_name[(q_max_msgs) * (q_msg_size)];	\
-	Z_STRUCT_SECTION_ITERABLE(k_msgq, q_name) =			\
+	Z_OBJECT_TRACING_ITERABLE(k_msgq, q_name) =			\
 	       _K_MSGQ_INITIALIZER(q_name, _k_fifo_buf_##q_name,	\
 				  q_msg_size, q_max_msgs)
 
@@ -3812,7 +3812,7 @@ struct k_mbox {
  * @req K-MBOX-001
  */
 #define K_MBOX_DEFINE(name) \
-	Z_STRUCT_SECTION_ITERABLE(k_mbox, name) = \
+	Z_OBJECT_TRACING_ITERABLE(k_mbox, name) = \
 		_K_MBOX_INITIALIZER(name) \
 
 /**
@@ -4015,7 +4015,7 @@ struct k_pipe {
 #define K_PIPE_DEFINE(name, pipe_buffer_size, pipe_align)		\
 	static unsigned char __noinit __aligned(pipe_align)	\
 		_k_pipe_buf_##name[pipe_buffer_size];			\
-	Z_STRUCT_SECTION_ITERABLE(k_pipe, name) = \
+	Z_OBJECT_TRACING_ITERABLE(k_pipe, name) = \
 		_K_PIPE_INITIALIZER(name, _k_pipe_buf_##name, pipe_buffer_size)
 
 /**

--- a/include/kernel_includes.h
+++ b/include/kernel_includes.h
@@ -37,5 +37,6 @@
 #include <spinlock.h>
 #include <fatal.h>
 #include <irq.h>
+#include <debug/object_tracing_common.h>
 
 #endif /* ZEPHYR_INCLUDE_KERNEL_INCLUDES_H_ */

--- a/include/linker/common-ram.ld
+++ b/include/linker/common-ram.ld
@@ -55,13 +55,6 @@
 	_static_kernel_objects_begin = .;
 #endif /* CONFIG_USERSPACE */
 
-	SECTION_DATA_PROLOGUE(_k_timer_area,,SUBALIGN(4))
-	{
-		_k_timer_list_start = .;
-		KEEP(*("._k_timer.static.*"))
-		_k_timer_list_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
 	SECTION_DATA_PROLOGUE(_k_mem_slab_area,,SUBALIGN(4))
 	{
 		_k_mem_slab_list_start = .;
@@ -74,6 +67,15 @@
 		_k_mem_pool_list_start = .;
 		KEEP(*("._k_mem_pool.static.*"))
 		_k_mem_pool_list_end = .;
+	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+#ifdef CONFIG_OBJECT_TRACING
+
+	SECTION_DATA_PROLOGUE(_k_timer_area,,SUBALIGN(4))
+	{
+		_k_timer_list_start = .;
+		KEEP(*("._k_timer.static.*"))
+		_k_timer_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(_k_sem_area,,SUBALIGN(4))
@@ -127,6 +129,8 @@
 		KEEP(*("._k_pipe.static.*"))
 		_k_pipe_list_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+#endif /* CONFIG_OBJECT_TRACING */
 
 	SECTION_DATA_PROLOGUE(_net_buf_pool_area,,SUBALIGN(4))
 	{

--- a/include/sys/sem.h
+++ b/include/sys/sem.h
@@ -65,7 +65,7 @@ struct sys_sem {
  * are identical and can be treated as a k_sem in the boot initialization code
  */
 #define SYS_SEM_DEFINE(_name, _initial_count, _count_limit) \
-	Z_STRUCT_SECTION_ITERABLE(sys_sem, _name) = { \
+	Z_OBJECT_TRACING_ITERABLE(sys_sem, _name) = { \
 		.kernel_sem = Z_SEM_INITIALIZER(_name.kernel_sem, \
 						_initial_count, _count_limit) \
 	}; \


### PR DESCRIPTION
Some kernel objects only need to go in dedicated sections
if CONFIG_OBJECT_TRACING is enabled. Unfortunately this
defeats gc-sections, and we are doing this unconditionally.

Fixes: #20663

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>