### PR TITLE
usb: bluetooth (hci_usb): do not use ZLP for HCI event transfers

### DIFF
--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -92,7 +92,7 @@ config USB_DEVICE_BLUETOOTH
 	  USB Bluetooth device class driver
 
 config BLUETOOTH_INT_EP_MPS
-	int
+	int "Bluetooth device class interrupt endpoint size"
 	depends on USB_DEVICE_BLUETOOTH
 	default 16
 	range 8 64

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -151,7 +151,7 @@ static void hci_rx_thread(void)
 			usb_transfer_sync(
 				bluetooth_ep_data[HCI_INT_EP_IDX].ep_addr,
 				buf->data, buf->len,
-				USB_TRANS_WRITE);
+				USB_TRANS_WRITE | USB_TRANS_NO_ZLP);
 			break;
 		case BT_BUF_ACL_IN:
 			usb_transfer_sync(


### PR DESCRIPTION
Do not use ZLP for HCI event transfers.
Linux btusb driver do not relies on ZLP to determine the
end of a transfer. Instead the data is transmitted
continuously and the driver obtains the length of an event
from the HCI Event Packet header.

Fixes: #20250