### PR TITLE
settings: Set a default value to name_key before processing

### DIFF
--- a/subsys/settings/src/settings.c
+++ b/subsys/settings/src/settings.c
@@ -197,7 +197,7 @@ int settings_call_set_handler(const char *name,
 			      const struct settings_load_arg *load_arg)
 {
 	int rc;
-	const char *name_key;
+	const char *name_key = name;
 
 	if (load_arg && load_arg->subtree &&
 	    !settings_name_steq(name, load_arg->subtree, &name_key)) {


### PR DESCRIPTION
This commit fixes the settings_call_set_handler function
in a situation where the user calls settings_load_subtree_direct
with NULL as a subtree parameter.

Fixes: #20514

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>