### PR TITLE
CODEOWNERS: Fix sensor samples

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -310,9 +310,8 @@
 /samples/net/mqtt_publisher/              @jukkar @tbursztyka
 /samples/net/sockets/coap_*/              @rveerama1
 /samples/net/sockets/                     @jukkar @tbursztyka @pfalcon
-/samples/sensor/                          @MaureenHelm
 /samples/net/updatehub/                   @chtavares592 @otavio
-/samples/sensor/                          @bogdan-davidoaia
+/samples/sensor/                          @MaureenHelm
 /samples/shields/                         @avisconti
 /samples/subsys/logging/                  @nordic-krch @jakub-uC
 /samples/subsys/shell/                    @jakub-uC @nordic-krch


### PR DESCRIPTION
There were two conflicting entries for sensor samples, which resulted in
the wrong person getting assigned as a reviewer.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>