### PR TITLE
subsys: dfu: default progressive erase on Nordic

### DIFF
--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -128,6 +128,7 @@ config USB_DFU_CLASS
 	select MPU_ALLOW_FLASH_WRITE
 	select POLL
 	depends on IMG_MANAGER
+	select IMG_ERASE_PROGRESSIVELY if SOC_FLASH_NRF
 	help
 	  USB DFU class driver
 


### PR DESCRIPTION
The instructions for samples/usb/dfu fail on Nordic platforms if the erase is not progressive.  Default to enable that on Nordic.

This allows `samples/usb/dfu` to work as described on Nordic platforms.