### PR TITLE
kconfig: Detect all assignments to promptless syms + kconfig.py cleanup

### DIFF
--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -53,20 +53,20 @@ def main():
         # This won't work if zephyr/.config already exists (which means it's
         # being loaded), because zephyr/.config is a full configuration file
         # that includes values for promptless symbols.
-        verify_no_promptless_assign(kconf)
+        check_no_promptless_assign(kconf)
 
     # Print warnings for symbols whose actual value doesn't match the assigned
     # value
     for sym in kconf.unique_defined_syms:
         # Was the symbol assigned to? Choice symbols are checked separately.
         if sym.user_value is not None and not sym.choice:
-            verify_assigned_sym_value(sym)
+            check_assigned_sym_value(sym)
 
     # Print warnings for choices whose actual selection doesn't match the user
     # selection
     for choice in kconf.unique_choices:
         if choice.user_selection:
-            verify_assigned_choice_value(choice)
+            check_assigned_choice_value(choice)
 
     # Hack: Force all symbols to be evaluated, to catch warnings generated
     # during evaluation. Wait till the end to write the actual output files, so
@@ -107,7 +107,7 @@ def main():
     write_kconfig_filenames(kconf.kconfig_filenames, kconf.srctree, args.sources)
 
 
-def verify_no_promptless_assign(kconf):
+def check_no_promptless_assign(kconf):
     # Checks that no promptless symbols are assigned
 
     for sym in kconf.unique_defined_syms:
@@ -119,7 +119,7 @@ other symbols. \
 """ + SYM_INFO_HINT).format(sym))
 
 
-def verify_assigned_sym_value(sym):
+def check_assigned_sym_value(sym):
     # Verifies that the value assigned to 'sym' "took" (matches the value the
     # symbol actually got), printing a warning otherwise
 
@@ -137,7 +137,7 @@ def verify_assigned_sym_value(sym):
 """ + SYM_INFO_HINT).format(sym, user_value))
 
 
-def verify_assigned_choice_value(choice):
+def check_assigned_choice_value(choice):
     # Verifies that the choice symbol that was selected (by setting it to y)
     # ended up as the selection, printing a warning otherwise.
     #

--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -91,13 +91,10 @@ def main():
     # now as well.
     for warning in kconf.warnings:
         if fatal(warning):
-            sys.exit("\n" + textwrap.fill(
-                "Error: Aborting due to non-whitelisted Kconfig "
-                "warning '{}'.\nNote: If this warning doesn't point "
-                "to an actual problem, you can add it to the "
-                "whitelist at the top of {}."
-                .format(warning, sys.argv[0]),
-                100) + "\n")
+            err("""\
+Aborting due to non-whitelisted Kconfig warning '{}'. If this warning doesn't
+point to an actual problem, you can add it to the whitelist at the top of {}.\
+""".format(warning, sys.argv[0]))
 
     # Write the merged configuration and the C header
     print(kconf.write_config(args.dotconfig))

--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -185,16 +185,10 @@ def write_kconfig_filenames(paths, root_path, output_file_path):
     # to ensure that different representations of the same path does not end
     # up with two entries, as that could cause the build system to fail.
 
-    paths_uniq = sorted({os.path.realpath(os.path.join(root_path, path))
-                         for path in paths})
-
     with open(output_file_path, 'w') as out:
-        for path in paths_uniq:
-            # Assert that the file exists, since it was sourced, it
-            # must surely also exist.
-            assert os.path.isfile(path), "Internal error: '{}' does not exist".format(path)
-
-            out.write("{}\n".format(path))
+        for path in sorted({os.path.realpath(os.path.join(root_path, path))
+                            for path in paths}):
+            print(path, file=out)
 
 
 def parse_args():


### PR DESCRIPTION
Main commit:

```
scripts: kconfig.py: Detect all assignments to promptless symbols

Assigning to promptless symbols has no effect.

Previously, the only check was for whether the value assigned to a
symbol matched its final value. This misses cases where a promptless
symbol is assigned to and just happens to get the assigned-to value as
its final value.

Instead, detect whether configuration files are being merged (by
checking if zephyr/.config already exists), and explicitly check for
assignments to promptless symbols in that case. We can't do it when
zephyr/.config already exists (and is being loaded), because it includes
values for promptless symbols as well.

With the no-prompt check moved out, also use a more specific message for
it, and remove stuff related to prompts elsewhere. Shorten messages a
bit at the same time, and add two warn() and err() helpers.
```

Cleanups:

```
scripts: kconfig.py: Rename verify_*() functions to check_*()

Bit shorter, matches the devicetree code.
```

```
scripts: kconfig.py: Use err() helper for warnings-turned-errors

De-spams the code a bit.
```

```
scripts: kconfig.py: Simplify write_kconfig_filenames()

The assert has never hit and probably won't be useful. Shorten the code
a bit.
```