### PR TITLE
Bluetooth: shell: Fix missing return statement for name command

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -318,6 +318,7 @@ static int cmd_name(const struct shell *shell, size_t argc, char *argv[])
 
 	if (argc < 2) {
 		shell_print(shell, "Bluetooth Local Name: %s", bt_get_name());
+		return 0;
 	}
 
 	err = bt_set_name(argv[1]);


### PR DESCRIPTION
Return once bt name has been displayed

Signed-off-by: Stephane D'Alu <sdalu@sdalu.com>