### PR TITLE
boards: arm: Add missing supported features to nxp imx rt boards

### DIFF
--- a/boards/arm/frdm_k22f/frdm_k22f.yaml
+++ b/boards/arm/frdm_k22f/frdm_k22f.yaml
@@ -8,9 +8,9 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - gpio
   - i2c
   - nvs
   - spi
-  - gpio
   - usb_device
   - watchdog

--- a/boards/arm/frdm_k64f/frdm_k64f.yaml
+++ b/boards/arm/frdm_k64f/frdm_k64f.yaml
@@ -7,18 +7,18 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - adc
   - arduino_gpio
   - arduino_i2c
-  - netif:eth
-  - adc
-  - i2c
-  - nvs
-  - spi
+  - can
   - gpio
+  - hwinfo
+  - i2c
+  - netif:eth
+  - nvs
+  - pwm
+  - spi
   - usb_device
   - watchdog
-  - hwinfo
-  - can
-  - pwm
 testing:
   default: true

--- a/boards/arm/frdm_kl25z/frdm_kl25z.yaml
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.yaml
@@ -14,7 +14,7 @@ testing:
     - bluetooth
 supported:
   - adc
+  - gpio
   - hwinfo
   - i2c
-  - gpio
   - usb_device

--- a/boards/arm/frdm_kw41z/frdm_kw41z.yaml
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.yaml
@@ -7,10 +7,10 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
-  - ieee802154
   - adc
   - counter
+  - gpio
   - hwinfo
   - i2c
+  - ieee802154
   - spi
-  - gpio

--- a/boards/arm/hexiwear_k64/hexiwear_k64.yaml
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.yaml
@@ -7,11 +7,11 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
-  - ble
   - adc
+  - ble
   - gpio
   - hwinfo
   - i2c
-  - spi
   - pwm
+  - spi
   - watchdog

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.yaml
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.yaml
@@ -16,5 +16,6 @@ ram: 32
 flash: 16384
 supported:
   - counter
+  - gpio
   - hwinfo
   - i2c

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.yaml
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.yaml
@@ -15,6 +15,6 @@ toolchain:
 ram: 32
 flash: 16384
 supported:
-  - i2c
-  - hwinfo
   - counter
+  - hwinfo
+  - i2c

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
@@ -15,6 +15,6 @@ toolchain:
 ram: 32768
 flash: 8192
 supported:
-  - i2c
-  - hwinfo
   - counter
+  - hwinfo
+  - i2c

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
@@ -16,5 +16,7 @@ ram: 32768
 flash: 8192
 supported:
   - counter
+  - gpio
   - hwinfo
   - i2c
+  - netif:eth

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
@@ -15,11 +15,11 @@ toolchain:
 ram: 32768
 flash: 65536
 supported:
-  - display
-  - i2c
-  - spi
-  - netif:eth
-  - hwinfo
-  - usb_device
   - counter
+  - display
+  - hwinfo
+  - i2c
+  - netif:eth
   - sdhc
+  - spi
+  - usb_device

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
@@ -17,6 +17,7 @@ flash: 65536
 supported:
   - counter
   - display
+  - gpio
   - hwinfo
   - i2c
   - netif:eth

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
@@ -16,6 +16,11 @@ ram: 32768
 flash: 8192
 supported:
   - counter
+  - display
+  - gpio
   - hwinfo
+  - i2c
   - netif:eth
+  - sdhc
   - spi
+  - usb_device

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
@@ -15,7 +15,7 @@ toolchain:
 ram: 32768
 flash: 8192
 supported:
-  - spi
-  - netif:eth
-  - hwinfo
   - counter
+  - hwinfo
+  - netif:eth
+  - spi

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
@@ -15,9 +15,9 @@ toolchain:
 ram: 32768
 flash: 8192
 supported:
+  - counter
   - display
   - gpio
   - hwinfo
   - i2c
   - netif:eth
-  - counter

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
@@ -14,3 +14,10 @@ toolchain:
   - xtools
 ram: 32768
 flash: 65536
+supported:
+  - counter
+  - display
+  - gpio
+  - hwinfo
+  - i2c
+  - netif:eth

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -15,11 +15,11 @@ toolchain:
 ram: 32768
 flash: 4096
 supported:
+  - counter
   - display
   - hwinfo
-  - netif:eth
   - i2c
+  - netif:eth
   - pwm
   - usb_device
-  - counter
   - video

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -17,6 +17,7 @@ flash: 4096
 supported:
   - counter
   - display
+  - gpio
   - hwinfo
   - i2c
   - netif:eth

--- a/boards/arm/twr_ke18f/twr_ke18f.yaml
+++ b/boards/arm/twr_ke18f/twr_ke18f.yaml
@@ -9,11 +9,11 @@ toolchain:
 ram: 32
 flash: 512
 supported:
-  - counter
-  - i2c
-  - hwinfo
-  - spi
   - adc
   - can
-  - watchdog
+  - counter
+  - hwinfo
+  - i2c
   - pwm
+  - spi
+  - watchdog

--- a/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.yaml
+++ b/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.yaml
@@ -15,6 +15,6 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
-  - uart
-  - gpio
   - counter
+  - gpio
+  - uart

--- a/boards/arm/warp7_m4/warp7_m4.yaml
+++ b/boards/arm/warp7_m4/warp7_m4.yaml
@@ -19,5 +19,5 @@ testing:
     - net
     - bluetooth
 supported:
-  - i2c
   - gpio
+  - i2c


### PR DESCRIPTION
Adds missing items to the list of supported features for all nxp imx rt
boards. These features were already supported, just missing from the
list.

This change increases the number of samples and tests that sanitycheck
selects for these boards.