### PR TITLE
kconfig: Fix up newly-introduced copy-pasted headers

### DIFF
--- a/boards/arm/decawave_dwm1001_dev/Kconfig
+++ b/boards/arm/decawave_dwm1001_dev/Kconfig
@@ -1,7 +1,6 @@
-# Kconfig - DecaWave DWM1001 DEV board configuration
-#
+# DecaWave DWM1001 DEV board configuration
+
 # Copyright (c) 2019 Stéphane D'Alu
-#
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_DECAWAVE_DWM1001_DEV

--- a/boards/arm/decawave_dwm1001_dev/Kconfig.board
+++ b/boards/arm/decawave_dwm1001_dev/Kconfig.board
@@ -1,9 +1,8 @@
-# Kconfig - DecaWave DWM1001 board configuration
-#
+# DecaWave DWM1001 board configuration
+
 # Copyright (c) 2019 Stéphane D'Alu
-#
 # SPDX-License-Identifier: Apache-2.0
 
-config  BOARD_DECAWAVE_DWM1001_DEV
+config BOARD_DECAWAVE_DWM1001_DEV
 	bool "Decawave DWM1001-DEV"
 	depends on SOC_NRF52832_QFAA

--- a/boards/arm/decawave_dwm1001_dev/Kconfig.defconfig
+++ b/boards/arm/decawave_dwm1001_dev/Kconfig.defconfig
@@ -1,7 +1,6 @@
-# Kconfig - DecaWave DWM1001 board configuration
-#
+# DecaWave DWM1001 board configuration
+
 # Copyright (c) 2019 Stéphane D'Alu
-#
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_DECAWAVE_DWM1001_DEV

--- a/boards/arm/nrf52833_pca10100/Kconfig
+++ b/boards/arm/nrf52833_pca10100/Kconfig
@@ -1,7 +1,6 @@
-# Kconfig - nRF52833 PCA10100 board configuration
-#
+# nRF52833 PCA10100 board configuration
+
 # Copyright (c) 2019 Nordic Semiconductor ASA
-#
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_NRF52833_PCA10100

--- a/boards/arm/nrf52833_pca10100/Kconfig.board
+++ b/boards/arm/nrf52833_pca10100/Kconfig.board
@@ -1,9 +1,8 @@
-# Kconfig - nRF52833 PCA10100 board configuration
-#
+# nRF52833 PCA10100 board configuration
+
 # Copyright (c) 2019 Nordic Semiconductor ASA
-#
 # SPDX-License-Identifier: Apache-2.0
 
-config  BOARD_NRF52833_PCA10100
+config BOARD_NRF52833_PCA10100
 	bool "NRF52833 PCA10100"
 	depends on SOC_NRF52833_QIAA

--- a/boards/arm/nrf52833_pca10100/Kconfig.defconfig
+++ b/boards/arm/nrf52833_pca10100/Kconfig.defconfig
@@ -1,7 +1,6 @@
-# Kconfig - nRF52833 PCA10100 board configuration
-#
+# nRF52833 PCA10100 board configuration
+
 # Copyright (c) 2019 Nordic Semiconductor ASA
-#
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_NRF52833_PCA10100

--- a/boards/arm/twr_kv58f220m/Kconfig.board
+++ b/boards/arm/twr_kv58f220m/Kconfig.board
@@ -1,7 +1,6 @@
-# Kconfig - TWR-KV58F220M board configuration
-#
+# TWR-KV58F220M board configuration
+
 # Copyright (c) 2019 SEAL AG
-#
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_TWR_KV58F220M

--- a/boards/arm/twr_kv58f220m/Kconfig.defconfig
+++ b/boards/arm/twr_kv58f220m/Kconfig.defconfig
@@ -1,9 +1,7 @@
-# Kconfig - TWR-KV58F220M board
-#
+# TWR-KV58F220M board
+
 # Copyright (c) 2019 SEAL AG
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 if BOARD_TWR_KV58F220M
 

--- a/drivers/dma/Kconfig.stm32
+++ b/drivers/dma/Kconfig.stm32
@@ -1,11 +1,8 @@
-# Kconfig - DMA configuration options
-#
-#
+# DMA configuration options
+
 # Copyright (c) 2016 Intel Corporation
 # Copyright (c) 2019 Song Qiang <songqiang1304521@gmail.com>
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 config DMA_STM32
 	bool "Enable STM32 DMA driver"

--- a/drivers/entropy/Kconfig.rv32m1
+++ b/drivers/entropy/Kconfig.rv32m1
@@ -1,7 +1,6 @@
-# Kconfig.rv32m1 - RV32M1 entropy generator driver configuration
-#
+# RV32M1 entropy generator driver configuration
+
 # Copyright 2019 NXP
-#
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig ENTROPY_RV32M1_TRNG

--- a/drivers/spi/Kconfig.rv32m1_lpspi
+++ b/drivers/spi/Kconfig.rv32m1_lpspi
@@ -1,9 +1,7 @@
-# Kconfig - RV32M1 SPI
-#
+# RV32M1 SPI
+
 # Copyright (c) 2019, Karsten Koenig <karsten.koenig.030@gmail.com>
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 config SPI_RV32M1_LPSPI
 	bool "RV32M1 LPSPI driver"

--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -1,9 +1,7 @@
-# Kconfig - STM32 LPTIM configuration options
-#
+# STM32 LPTIM configuration options
+
 # Copyright (c) 2019 STMicroelectronics
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 menuconfig STM32_LPTIM_TIMER
 	bool "STM32 Low Power Timer"

--- a/soc/arm/atmel_sam0/samd51/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/samd51/Kconfig.defconfig.series
@@ -1,5 +1,5 @@
-# Kconfig - Atmel SAMD51 MCU series configuration options
-#
+# Atmel SAMD51 MCU series configuration options
+
 # Copyright (c) 2019 ML!PA Consulting GmbH
 # SPDX-License-Identifier: Apache-2.0
 

--- a/soc/arm/atmel_sam0/samd51/Kconfig.series
+++ b/soc/arm/atmel_sam0/samd51/Kconfig.series
@@ -1,5 +1,5 @@
-# Kconfig - Atmel SAMD51 MCU series
-#
+# Atmel SAMD51 MCU series
+
 # Copyright (c) 2019 ML!PA Consulting GmbH
 # SPDX-License-Identifier: Apache-2.0
 

--- a/soc/arm/atmel_sam0/samd51/Kconfig.soc
+++ b/soc/arm/atmel_sam0/samd51/Kconfig.soc
@@ -1,11 +1,11 @@
-# Kconfig - Atmel SAMD51 MCU series
-#
+# Atmel SAMD51 MCU series
+
 # Copyright (c) 2019 ML!PA Consulting GmbH
 # SPDX-License-Identifier: Apache-2.0
 
 choice
-prompt "Atmel SAMD51 MCU Selection"
-depends on SOC_SERIES_SAMD51
+	prompt "Atmel SAMD51 MCU Selection"
+	depends on SOC_SERIES_SAMD51
 
 config SOC_PART_NUMBER_SAMD51G18A
 	bool "SAMD51G18A"

--- a/soc/arm/atmel_sam0/same51/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/same51/Kconfig.defconfig.series
@@ -1,5 +1,5 @@
-# Kconfig - Atmel SAME51 MCU series configuration options
-#
+# Atmel SAME51 MCU series configuration options
+
 # Copyright (c) 2019 ML!PA Consulting GmbH
 # SPDX-License-Identifier: Apache-2.0
 

--- a/soc/arm/atmel_sam0/same51/Kconfig.series
+++ b/soc/arm/atmel_sam0/same51/Kconfig.series
@@ -1,5 +1,5 @@
-# Kconfig - Atmel SAME51 MCU series
-#
+# Atmel SAME51 MCU series
+
 # Copyright (c) 2019 ML!PA Consulting GmbH
 # SPDX-License-Identifier: Apache-2.0
 

--- a/soc/arm/atmel_sam0/same51/Kconfig.soc
+++ b/soc/arm/atmel_sam0/same51/Kconfig.soc
@@ -1,11 +1,11 @@
-# Kconfig - Atmel SAME51 MCU series
-#
+# Atmel SAME51 MCU series
+
 # Copyright (c) 2019 ML!PA Consulting GmbH
 # SPDX-License-Identifier: Apache-2.0
 
 choice
-prompt "Atmel SAME51 MCU Selection"
-depends on SOC_SERIES_SAME51
+	prompt "Atmel SAME51 MCU Selection"
+	depends on SOC_SERIES_SAME51
 
 config SOC_PART_NUMBER_SAME51J18A
 	bool "SAME51J18A"

--- a/soc/arm/atmel_sam0/same53/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/same53/Kconfig.defconfig.series
@@ -1,5 +1,5 @@
-# Kconfig - Atmel SAME53 MCU series configuration options
-#
+# Atmel SAME53 MCU series configuration options
+
 # Copyright (c) 2019 ML!PA Consulting GmbH
 # SPDX-License-Identifier: Apache-2.0
 

--- a/soc/arm/atmel_sam0/same53/Kconfig.series
+++ b/soc/arm/atmel_sam0/same53/Kconfig.series
@@ -1,5 +1,5 @@
-# Kconfig - Atmel SAME53 MCU series
-#
+# Atmel SAME53 MCU series
+
 # Copyright (c) 2019 ML!PA Consulting GmbH
 # SPDX-License-Identifier: Apache-2.0
 

--- a/soc/arm/atmel_sam0/same53/Kconfig.soc
+++ b/soc/arm/atmel_sam0/same53/Kconfig.soc
@@ -1,11 +1,11 @@
-# Kconfig - Atmel SAME53 MCU series
-#
+# Atmel SAME53 MCU series
+
 # Copyright (c) 2019 ML!PA Consulting GmbH
 # SPDX-License-Identifier: Apache-2.0
 
 choice
-prompt "Atmel SAME53 MCU Selection"
-depends on SOC_SERIES_SAME53
+	prompt "Atmel SAME53 MCU Selection"
+	depends on SOC_SERIES_SAME53
 
 config SOC_PART_NUMBER_SAME53J18A
 	bool "SAME53J18A"

--- a/soc/arm/atmel_sam0/same54/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/same54/Kconfig.defconfig.series
@@ -1,5 +1,5 @@
-# Kconfig - Atmel SAME MCU series configuration options
-#
+# Atmel SAME MCU series configuration options
+
 # Copyright (c) 2019 ML!PA Consulting GmbH
 # SPDX-License-Identifier: Apache-2.0
 

--- a/soc/arm/atmel_sam0/same54/Kconfig.series
+++ b/soc/arm/atmel_sam0/same54/Kconfig.series
@@ -1,5 +1,5 @@
-# Kconfig - Atmel SAME54 MCU series
-#
+# Atmel SAME54 MCU series
+
 # Copyright (c) 2019 ML!PA Consulting GmbH
 # SPDX-License-Identifier: Apache-2.0
 

--- a/soc/arm/atmel_sam0/same54/Kconfig.soc
+++ b/soc/arm/atmel_sam0/same54/Kconfig.soc
@@ -1,11 +1,11 @@
-# Kconfig - Atmel SAME MCU series
-#
+# Atmel SAME MCU series
+
 # Copyright (c) 2019 ML!PA Consulting GmbH
 # SPDX-License-Identifier: Apache-2.0
 
 choice
-prompt "Atmel SAME54 MCU Selection"
-depends on SOC_SERIES_SAME54
+	prompt "Atmel SAME54 MCU Selection"
+	depends on SOC_SERIES_SAME54
 
 config SOC_PART_NUMBER_SAME54N19A
 	bool "SAME54N19A"

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52833_QIAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52833_QIAA
@@ -1,10 +1,7 @@
-# Kconfig.defconfig.nrf52833 - Nordic Semiconductor nRF52833 MCU
-#
-# Copyright (c) 2019 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: Apache-2.0
-#
+# Nordic Semiconductor nRF52833 MCU
 
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
 
 if SOC_NRF52833_QIAA
 

--- a/soc/arm/nxp_kinetis/kv5x/Kconfig.series
+++ b/soc/arm/nxp_kinetis/kv5x/Kconfig.series
@@ -1,9 +1,7 @@
-# Kconfig - Kinetis KV5x series MCU
-#
+# Kinetis KV5x series MCU
+
 # Copyright (c) 2019 SEAL AG
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 config SOC_SERIES_KINETIS_KV5X
 	bool "Kinetis KV5x Series MCU"

--- a/soc/arm/st_stm32/common/Kconfig.soc
+++ b/soc/arm/st_stm32/common/Kconfig.soc
@@ -1,4 +1,4 @@
-# Kconfig - ST Microelectronics Common Kconfig
+# ST Microelectronics Common Kconfig
 
 # Copyright (c) 2019 Linaro Ltd.
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Same deal as in https://github.com/zephyrproject-rtos/zephyr/pull/20280,
for newly-introduced stuff.

Will avoid failures with the new CI test in
https://github.com/zephyrproject-rtos/ci-tools/pull/112, though it only
checks changed files.

Also fix some un-indented properties on choices. Choice properties work
the same as symbol properties syntactically.