### PR TITLE
samples: logger: Fix test on stack hungry platforms

### DIFF
--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -30,7 +30,7 @@ static struct k_mem_partition *app_parts[] = {
 #endif /* CONFIG_USERSPACE */
 
 /* size of stack area used by each thread */
-#define STACKSIZE 1024
+#define STACKSIZE (1024 + CONFIG_TEST_EXTRA_STACKSIZE)
 
 extern void sample_module_func(void);
 


### PR DESCRIPTION
One more CONFIG_TEST_EXTRA_STACKSIZE missing.