### PR TITLE
boards: arm: nrf: change board docs to link to Nordic Infocenter

### DIFF
--- a/boards/arm/holyiot_yj16019/doc/index.rst
+++ b/boards/arm/holyiot_yj16019/doc/index.rst
@@ -28,7 +28,7 @@ Semiconductor nRF52832 ARM Cortex-M4 CPU and the following devices:
      Holyiot YJ-16019 (Credit: Holyiot)
 
 The board is equipped with one LED, one push button, and is powered by
-a CR2032 coin cell. The `Nordic Semiconductor Documentation library`_
+a CR2032 coin cell. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -146,4 +146,4 @@ References
 .. target-notes::
 
 .. _Holyiot: http://www.holyiot.com
-.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
+.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com

--- a/boards/arm/nrf51_ble400/doc/index.rst
+++ b/boards/arm/nrf51_ble400/doc/index.rst
@@ -210,7 +210,7 @@ References
 .. target-notes::
 
 .. _nRF51 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF51-DK
-.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
+.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
 .. _Waveshare Wiki BLE400: https://www.waveshare.com/wiki/BLE400
 .. _User manual: https://www.waveshare.com/w/upload/b/b7/NRF51822-Eval-Kit-UserManual-EN.pdf
 .. _Schematic: https://www.waveshare.com/w/upload/1/1b/BLE400-Schematic.pdf

--- a/boards/arm/nrf51_pca10028/doc/index.rst
+++ b/boards/arm/nrf51_pca10028/doc/index.rst
@@ -27,10 +27,10 @@ Semiconductor nRF51822 ARM Cortex-M0 CPU and the following devices:
      :align: center
      :alt: nRF51 PCA10028 DK
 
-     nRF51 PCA10028 DK (Credit: Nordic Semi)
+     nRF51 PCA10028 DK (Credit: Nordic Semiconductor)
 
 More information about the board can be found at the
-`nRF51 DK website`_. The `Nordic Semiconductor Documentation library`_
+`nRF51 DK website`_. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -75,7 +75,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
-See `nRF51 DK website`_ and `Nordic Semiconductor Documentation library`_
+See `nRF51 DK website`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF51 Development Kit board hardware features.
 
 Connections and IOs
@@ -156,5 +156,4 @@ References
 .. target-notes::
 
 .. _nRF51 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF51-DK
-.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
-
+.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com

--- a/boards/arm/nrf51_pca10031/doc/index.rst
+++ b/boards/arm/nrf51_pca10031/doc/index.rst
@@ -27,7 +27,7 @@ Semiconductor nRF51822 ARM Cortex-M0 CPU and the following devices:
      :align: center
      :alt: nRF51 PCA10031 Dongle
 
-     nRF51 PCA10031 Dongle (Credit: Nordic Semi)
+     nRF51 PCA10031 Dongle (Credit: Nordic Semiconductor)
 
 More information about the board can be found at the
 `nRF51 Dongle website`_. The `Nordic Semiconductor Infocenter`_

--- a/boards/arm/nrf52833_pca10100/doc/index.rst
+++ b/boards/arm/nrf52833_pca10100/doc/index.rst
@@ -27,7 +27,7 @@ the following devices:
 * :abbr:`WDT (Watchdog Timer)`
 
 More information about the board can be found at the
-`nRF52833 PDK website`_. The `Nordic Semiconductor Documentation library`_
+`nRF52833 PDK website`_. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -79,7 +79,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
-See `nRF52833 PDK website`_ and `Nordic Semiconductor Documentation library`_
+See `nRF52833 PDK website`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF52833 Development Kit board hardware features.
 
 Connections and IOs
@@ -216,6 +216,6 @@ References
 .. target-notes::
 
 .. _nRF52833 PDK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52833-DK
-.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
+.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
 .. _J-Link Software and documentation pack: https://www.segger.com/jlink-software.html
 .. _nRF52833 Product Specification: https://infocenter.nordicsemi.com/pdf/nRF52833_OPS_v0.7.pdf

--- a/boards/arm/nrf52840_pca10056/doc/index.rst
+++ b/boards/arm/nrf52840_pca10056/doc/index.rst
@@ -31,10 +31,10 @@ the following devices:
      :align: center
      :alt: nRF52840 PCA10056 Preview DK
 
-     nRF52840 PCA10056 Preview DK (Credit: Nordic Semi)
+     nRF52840 PCA10056 Preview DK (Credit: Nordic Semiconductor)
 
 More information about the board can be found at the
-`nRF52840 PDK website`_. The `Nordic Semiconductor Documentation library`_
+`nRF52840 PDK website`_. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -86,7 +86,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
-See `nRF52840 PDK website`_ and `Nordic Semiconductor Documentation library`_
+See `nRF52840 PDK website`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF52840 Development Kit board hardware features.
 
 Connections and IOs
@@ -225,6 +225,6 @@ References
 .. target-notes::
 
 .. _nRF52840 PDK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK
-.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
+.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
 .. _J-Link Software and documentation pack: https://www.segger.com/jlink-software.html
 .. _nRF52840 Product Specification: http://infocenter.nordicsemi.com/pdf/nRF52840_PS_v1.0.pdf

--- a/boards/arm/nrf52840_pca10059/doc/index.rst
+++ b/boards/arm/nrf52840_pca10059/doc/index.rst
@@ -32,7 +32,7 @@ Semiconductor nRF52840 ARM Cortex-M4F CPU and the following devices:
      nRF52840 PCA10059
 
 More information about the board can be found at the
-`nRF52840 Dongle website`_. The `Nordic Semiconductor Documentation library`_
+`nRF52840 Dongle website`_. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -82,7 +82,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
-See `nRF52840 Dongle website`_ and `Nordic Semiconductor Documentation library`_
+See `nRF52840 Dongle website`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF52840 PCA10059 Development Kit board hardware features.
 
 Connections and IOs
@@ -330,8 +330,8 @@ References
 
 .. _nRF52840 Dongle website:
    https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-Dongle
-.. _Nordic Semiconductor Documentation library:
-   https://www.nordicsemi.com/DocLib
+.. _Nordic Semiconductor Infocenter:
+   https://infocenter.nordicsemi.com
 .. _J-Link Software and documentation pack:
    https://www.segger.com/jlink-software.html
 .. _Nordic Semiconductor USB DFU:

--- a/boards/arm/nrf52840_pca10090/doc/index.rst
+++ b/boards/arm/nrf52840_pca10090/doc/index.rst
@@ -28,7 +28,7 @@ SiP.
 
 More information about the board can be found at
 the `Nordic Low power cellular IoT`_ website.
-The `Nordic Semiconductor documentation library`_
+The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -159,6 +159,5 @@ References
 
 .. target-notes::
 .. _Nordic Low power cellular IoT: https://www.nordicsemi.com/Products/Low-power-cellular-IoT
-.. _Nordic Semiconductor documentation library: https://www.nordicsemi.com/DocLib
+.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
 .. _J-Link Software and documentation pack: https://www.segger.com/jlink-software.html
-

--- a/boards/arm/nrf52_adafruit_feather/doc/index.rst
+++ b/boards/arm/nrf52_adafruit_feather/doc/index.rst
@@ -26,7 +26,7 @@ the following devices:
      nRF52 Adafruit Feather Board (Credit: Adafruit)
 
 More information about the board and its features can be found at the
-`Adafruit Feather nRF52 Bluefruit Learning Guide`_. The `Nordic Semiconductor Documentation library`_
+`Adafruit Feather nRF52 Bluefruit Learning Guide`_. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -187,9 +187,8 @@ References
 .. _Adafruit Feather nRF52 Bluefruit Learning Guide: https://learn.adafruit.com/bluefruit-nrf52-feather-learning-guide/introduction
 .. _schematic: https://learn.adafruit.com/assets/39913
 .. _pinouts: https://cdn-learn.adafruit.com/assets/assets/000/046/210/original/Feather_NRF52_Pinout_v1.2.pdf?1504807075
-.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
+.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
 .. _J-Link Software and documentation pack: https://www.segger.com/jlink-software.html
 .. _Adafruit Feather nRF52 Bluefruit LE: https://www.adafruit.com/product/3406
 .. _Adafruit Feather nRF52 Pro with myNewt Bootloader: https://www.adafruit.com/product/3574
 .. _Adafruit SWD connector: https://www.adafruit.com/product/752
-

--- a/boards/arm/nrf52_pca10040/doc/index.rst
+++ b/boards/arm/nrf52_pca10040/doc/index.rst
@@ -30,10 +30,10 @@ the following devices:
      :align: center
      :alt: nRF52 PCA10040 DK
 
-     nRF52 PCA10040 DK (Credit: Nordic Semi)
+     nRF52 PCA10040 DK (Credit: Nordic Semiconductor)
 
 More information about the board can be found at the
-`nRF52 DK website`_. The `Nordic Semiconductor Documentation library`_
+`nRF52 DK website`_. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -82,7 +82,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
-See `nRF52 DK website`_ and `Nordic Semiconductor Documentation library`_
+See `nRF52 DK website`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF52 Development Kit board hardware features.
 
 Connections and IOs
@@ -403,5 +403,4 @@ References
 .. target-notes::
 
 .. _nRF52 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52-DK
-.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
-
+.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com

--- a/boards/arm/nrf52_pca20020/doc/index.rst
+++ b/boards/arm/nrf52_pca20020/doc/index.rst
@@ -34,7 +34,7 @@ a set of environmental sensors, a pushbutton, and two RGB LEDs.
      :align: center
      :alt: nRF52 Thingy:52
 
-     nRF52 Thingy:52 (Credit: Nordic Semi)
+     nRF52 Thingy:52 (Credit: Nordic Semiconductor)
 
 More information about the board can be found at the `nRF52 DK website`_. The
 `Nordic Semiconductor Infocenter`_ contains the processor's information and the

--- a/boards/arm/nrf5340_dk_nrf5340/doc/index.rst
+++ b/boards/arm/nrf5340_dk_nrf5340/doc/index.rst
@@ -49,7 +49,7 @@ nRF5340 SoC provides support for the following devices:
 
 More information about the board can be found at the
 `nRF5340 DK website`_.
-The `Nordic Semiconductor Documentation library`_
+The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -136,7 +136,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
-See `Nordic Semiconductor Documentation library`_
+See `Nordic Semiconductor Infocenter`_
 for a complete list of nRF5340 Development Kit board hardware features.
 
 Connections and IOs
@@ -268,4 +268,4 @@ References
    https://developer.arm.com/products/architecture/cpu-architecture/m-profile/docs/100690/latest/attribution-units-sau-and-idau
 .. _nRF5340 DK website:
    https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF5340-PDK
-.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
+.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com

--- a/boards/arm/nrf9160_pca10090/doc/index.rst
+++ b/boards/arm/nrf9160_pca10090/doc/index.rst
@@ -32,10 +32,10 @@ following devices:
      :align: center
      :alt: nRF9160 PCA10090 DK
 
-     nRF9160 PCA10090 DK (Credit: Nordic Semi)
+     nRF9160 PCA10090 DK (Credit: Nordic Semiconductor)
 
 More information about the board can be found at the
-`nRF91 DK website`_. The `Nordic Semiconductor Documentation library`_
+`nRF91 DK website`_. The `Nordic Semiconductor Infocenter`_
 contains the processor's information and the datasheet.
 
 Hardware
@@ -84,7 +84,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
-See `nRF91 DK website`_ and `Nordic Semiconductor Documentation library`_
+See `nRF91 DK website`_ and `Nordic Semiconductor Infocenter`_
 for a complete list of nRF9160 Development Kit board hardware features.
 
 Connections and IOs
@@ -200,4 +200,4 @@ References
 .. _IDAU:
    https://developer.arm.com/products/architecture/cpu-architecture/m-profile/docs/100690/latest/attribution-units-sau-and-idau
 .. _nRF91 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF9160-DK
-.. _Nordic Semiconductor Documentation library: https://www.nordicsemi.com/DocLib
+.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com


### PR DESCRIPTION
Link to Nordic Semiconductor Infocenter, instead of
DocLib in the documentation for nRF Development Kits.

Fixes: #20332

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>