### PR TITLE
Bluetooth: HCI: Add utility to extract PB and BC flags from data header

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -39,9 +39,15 @@ struct bt_hci_evt_hdr {
 #define BT_ACL_START_NO_FLUSH           0x00
 #define BT_ACL_CONT                     0x01
 #define BT_ACL_START                    0x02
+#define BT_ACL_COMPLETE                 0x03
 
-#define bt_acl_handle(h)                ((h) & 0x0fff)
+#define BT_ACL_POINT_TO_POINT           0x00
+#define BT_ACL_BROADCAST                0x01
+
+#define bt_acl_handle(h)                ((h) & BIT_MASK(12))
 #define bt_acl_flags(h)                 ((h) >> 12)
+#define bt_acl_flags_pb(f)              ((f) & BIT_MASK(2))
+#define bt_acl_flags_bc(f)              ((f) >> 2)
 #define bt_acl_handle_pack(h, f)        ((h) | ((f) << 12))
 
 struct bt_hci_acl_hdr {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1168,6 +1168,10 @@ void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, u8_t flags)
 
 		break;
 	default:
+		/* BT_ACL_START_NO_FLUSH and BT_ACL_COMPLETE are not allowed on
+		 * LE-U from Controller to Host.
+		 * Only BT_ACL_POINT_TO_POINT is supported.
+		 */
 		BT_ERR("Unexpected ACL flags (0x%02x)", flags);
 		bt_conn_reset_rx_state(conn);
 		net_buf_unref(buf);


### PR DESCRIPTION
Add utility to extract the flags Packet Boundary and Broadcast to the
hci.h together with the rest of the ACL data header definitions.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>