### PR TITLE
boards: arm: nucleo_g431rb: Fix flash backed storage settings

### DIFF
--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -99,10 +99,10 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Set 2Kb of storage at the end of the 128Kb of flash */
-		storage_partition: partition@1f800 {
+		/* Set 4Kb of storage at the end of the 128Kb of flash */
+		storage_partition: partition@1f000 {
 			label = "storage";
-			reg = <0x0001f800 0x00000800>;
+			reg = <0x0001f000 0x00001000>;
 		};
 	};
 };


### PR DESCRIPTION
Flash storage requires at least 2 sectors in order to work correctly

Signed-off-by: Richard Osterloh <richard.osterloh@gmail.com>

Fixes  #20769