### PR TITLE
arc: hsdk: Set SRAM_BASE_ADDRESS in defconfig

### DIFF
--- a/dts/arc/arc_hsdk.dtsi
+++ b/dts/arc/arc_hsdk.dtsi
@@ -61,10 +61,10 @@
 		interrupt-parent = <&idu_intc>;
 		ranges;
 
-		ddr0: memory@0 {
+		ddr0: memory@90000000 {
 			device_type = "memory";
 			compatible = "mmio-sram";
-			reg = <0x0 0x80000000>;
+			reg = <0x90000000 0x50000000>;
 		};
 
 		uart0: uart@f0005000 {


### PR DESCRIPTION
On power-on boot-ROM is mapped to address 0 in HSDK board.
Normally later when U-Boot gets started by boot-ROM we change mappings
so that real DDR is mapped to entire address space including 0:
https://elixir.bootlin.com/u-boot/latest/source/board/synopsys/hsdk/hsdk.c#L474

But if U-Boot is not started (which is controlled by the BIM dip-switch
on the board) boot-ROM remains mapped to 0, and essentially any attempt
to write to that location fails, thus we cannot upload contents of our
target Elf there even with JTAG.

The next logical option is to use beginning of the non-translated
memory region 0x8000_0000 which we typically use for loading
U-Boot & Linux kernel on ARC boards. But in case of HSDK
we have DCCM (Data Closely-Coupled MEmory - fast on-chip SRAM)
mapped there and since we cannot execute code from DCCM
we need to skip that region as well which gives us the next option
being 0x9000_0000 . That's because DCCM owns entire 256 MiB "aperture"
even though it may have much smaller size up-to 8 MiB.

Signed-off-by: Evgeniy Didin <didin@synopsys.com>
Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>