### PR TITLE
nrf52_bsim: doc: Change to fetch manifest thru http

### DIFF
--- a/boards/posix/nrf52_bsim/doc/index.rst
+++ b/boards/posix/nrf52_bsim/doc/index.rst
@@ -63,7 +63,7 @@ In short, you can do:
 
    mkdir -p ${HOME}/bsim && cd ${HOME}/bsim
    curl https://storage.googleapis.com/git-repo-downloads/repo > ./repo  && chmod a+x ./repo
-   ./repo init -u git@github.com:BabbleSim/manifest.git -m everything.xml -b master
+   ./repo init -u https://github.com/BabbleSim/manifest.git -m everything.xml -b master
    ./repo sync
    make everything -j 8
 


### PR DESCRIPTION
Some people are behind firewalls that prevent them
from doing ssh connections.
Change the default BabbleSim fetching instructions to
be over https which should work for everybody.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>