### PR TITLE
Bluetooth: controller: Add missing BT_DEBUG_ENABLED define

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -47,7 +47,7 @@
 #include "ll_filter.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
-#define LOG_MODULE_NAME bt_ctlr_llsw_ctrl
+#define LOG_MODULE_NAME bt_ctlr_ctrl
 #include "common/log.h"
 
 #if defined(CONFIG_BT_CTLR_CONN_RSSI)

--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -15,7 +15,7 @@
 #include <bluetooth/hci.h>
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
-#define LOG_MODULE_NAME bt_ctlr_llsw_ll
+#define LOG_MODULE_NAME bt_ctlr_ll
 #include "common/log.h"
 
 #include "hal/cpu.h"

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -24,7 +24,7 @@
 #define ADDR_TYPE_ANON 0xFF
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
-#define LOG_MODULE_NAME bt_ctlr_llsw_llfilter
+#define LOG_MODULE_NAME bt_ctlr_ll_filter
 #include "common/log.h"
 
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/lll_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_chan.c
@@ -9,7 +9,8 @@
 #include "hal/ccm.h"
 #include "hal/radio.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_nordic_lll_chan
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_lll_chan
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cntr.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cntr.c
@@ -8,12 +8,14 @@
 #include <sys/dlist.h>
 #include <sys/mempool_base.h>
 
+#include <nrfx/hal/nrf_rtc.h>
+
 #include "hal/cntr.h"
 
-#define LOG_MODULE_NAME bt_ctlr_cntr
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_hal_cntr
 #include "common/log.h"
 #include "hal/debug.h"
-#include <nrfx/hal/nrf_rtc.h>
 
 #ifndef NRF_RTC
 #define NRF_RTC NRF_RTC0

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
@@ -10,14 +10,15 @@
 #include <sys/dlist.h>
 #include <sys/mempool_base.h>
 
+#include <nrfx/hal/nrf_ecb.h>
+
 #include "util/mem.h"
 #include "hal/ecb.h"
 
-#define LOG_MODULE_NAME bt_ctlr_nrf5_ecb
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_hal_ecb
 #include "common/log.h"
 #include "hal/debug.h"
-
-#include <nrfx/hal/nrf_ecb.h>
 
 struct ecb_param {
 	u8_t key[16];

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/mayfly.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/mayfly.c
@@ -13,7 +13,8 @@
 #include "util/memq.h"
 #include "util/mayfly.h"
 
-#define LOG_MODULE_NAME bt_ctlr_nrf5_mayfly
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_hal_mayfly
 #include "common/log.h"
 #include "hal/debug.h"
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.c
@@ -16,7 +16,8 @@
 
 #include "ticker/ticker.h"
 
-#define LOG_MODULE_NAME bt_ctlr_nrf5_ticker
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_hal_ticker
 #include "common/log.h"
 #include "hal/debug.h"
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -28,9 +28,9 @@
 #include "lll_vendor.h"
 #include "lll_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_nordic_lll
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_lll
 #include "common/log.h"
-
 #include "hal/debug.h"
 
 #if defined(CONFIG_BT_CTLR_ZLI)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -36,7 +36,8 @@
 #include "lll_adv_internal.h"
 #include "lll_prof_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_nordic_lll_adv
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_lll_adv
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -10,7 +10,8 @@
 #include <drivers/clock_control.h>
 #include <drivers/clock_control/nrf_clock_control.h>
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_nordic_lll_clock
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_lll_clock
 #include "common/log.h"
 #include "hal/debug.h"
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -28,7 +28,8 @@
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_nordic_lll_conn
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_lll_conn
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_master.c
@@ -27,7 +27,8 @@
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_nordic_lll_master
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_lll_master
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -32,7 +32,8 @@
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_nordic_lll_scan
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_lll_scan
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_slave.c
@@ -27,7 +27,8 @@
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_nordic_lll_slave
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_lll_slave
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -24,8 +24,10 @@
 
 #include "ll_test.h"
 
-#include "hal/debug.h"
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_lll_test
 #include "common/log.h"
+#include "hal/debug.h"
 
 #define CNTR_MIN_DELTA 3
 

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -50,7 +50,8 @@
 #include "ull_vendor.h"
 #endif /* CONFIG_BT_CTLR_USER_EXT */
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_ull
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_ull
 #include "common/log.h"
 #include "hal/debug.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -42,7 +42,8 @@
 #include "ull_conn_internal.h"
 #include "ull_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_ull_adv
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_ull_adv
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -38,7 +38,8 @@
 #include "ll_feat.h"
 #include "ll_settings.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_ull_conn
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_ull_conn
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -35,9 +35,9 @@
 
 #define ADDR_TYPE_ANON 0xFF
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_nordic_lll_filter
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_ull_filter
 #include "common/log.h"
-
 #include "hal/debug.h"
 
 /* Hardware whitelist */

--- a/subsys/bluetooth/controller/ll_sw/ull_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_master.c
@@ -40,7 +40,8 @@
 #include "ull_conn_internal.h"
 #include "ull_master_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_ull_master
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_ull_master
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -37,7 +37,8 @@
 #include "ull_scan_internal.h"
 #include "ull_sched_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_ull_scan
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_ull_scan
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -37,7 +37,8 @@
 #include "ull_conn_internal.h"
 #include "ull_slave_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_ull_slave
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME bt_ctlr_ull_slave
 #include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -14,6 +14,7 @@
 
 #include "ticker.h"
 
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ticker
 #include "common/log.h"
 #include "hal/debug.h"


### PR DESCRIPTION
Add missing BT_DEBUG_ENABLED definitions.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>