### PR TITLE
Bluetooth: controller: split: Revert bit hacks in CSA2 calc

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_chan.c
@@ -129,15 +129,19 @@ void lll_chan_sel_2_ut(void)
 }
 #endif /* RADIO_UNIT_TEST */
 
-/* Attribution:
- * http://graphics.stanford.edu/%7Eseander/bithacks.html#ReverseByteWith32Bits
- */
 static u8_t chan_rev_8(u8_t b)
 {
-	b = (((u32_t)b * 0x0802LU & 0x22110LU) |
-	     ((u32_t)b * 0x8020LU & 0x88440LU)) * 0x10101LU >> 16;
+	u8_t iterate;
+	u8_t o;
 
-	return b;
+	o = 0U;
+	for (iterate = 0U; iterate < 8; iterate++) {
+		o <<= 1;
+		o |= (b & 1);
+		b >>= 1;
+	}
+
+	return o;
 }
 
 static u16_t chan_perm(u16_t i)


### PR DESCRIPTION
Revert to using iteration to reverse 8-bit value, instead of
using 32-bit hacksthat use multiplications, to reduce CPU
cycles.

Fixes failing conformance test for nRF51:
LL/CON/MAS/BV-07-C [Requesting Parameter Update]

The test failed due to connection events being skip due
prepare cb not meeting the hard start anchor point deadline.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>