### PR TITLE
Bluetooth: controller: split: Dont use continuous directed adv in nRF51

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -479,7 +479,8 @@ static void isr_done(void *param)
 #endif /* CONFIG_BT_HCI_MESH_EXT */
 
 #if defined(CONFIG_BT_PERIPHERAL)
-	if (!lll->chan_map_curr && lll->is_hdcd) {
+	if (!IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) && lll->is_hdcd &&
+	    !lll->chan_map_curr) {
 		lll->chan_map_curr = lll->chan_map;
 	}
 #endif /* CONFIG_BT_PERIPHERAL */


### PR DESCRIPTION
In nRF51 which uses CONFIG_BT_CTLR_LOW_LAT, the advertising
PDU tend to get aborted in directed advertising at event slot
durations.

Dont not use continuous directed advertising event in nRF51
where CONFIG_BT_CTLR_LOW_LAT scheduling design alternative
is used. Instead close the event after each triplet of PDU
has been tx-ed.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>