### PR TITLE
Bluetooth: controller: split: Fix typo EVENT_RX_TX_TURNARROUND

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
@@ -26,5 +26,4 @@
 				  EVENT_RX_JITTER_US(phy))
 
 /* TODO - fix up numbers re. HW */
-#define EVENT_RX_TX_TURNARROUND(phy)  ((phy) == 1?100:((phy) == 2 ? 80:900))
-
+#define EVENT_RX_TX_TURNAROUND(phy)  ((phy) == 1?100:((phy) == 2 ? 80:900))

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_vendor.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_vendor.h
@@ -26,5 +26,4 @@
 				  EVENT_RX_JITTER_US(phy))
 
 /* TODO - fix up numbers re. HW */
-#define EVENT_RX_TX_TURNARROUND(phy)  ((phy) == 1?100:((phy) == 2 ? 80:900))
-
+#define EVENT_RX_TX_TURNAROUND(phy)  ((phy) == 1?100:((phy) == 2 ? 80:900))

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -715,7 +715,7 @@ u8_t ll_adv_enable(u8_t enable)
 		u32_t adv_size		= ll_hdr_size + ADVA_SIZE;
 		const u8_t ll_hdr_us	= BYTES2US(ll_hdr_size, phy);
 		const u8_t rx_to_us	= EVENT_RX_TO_US(phy);
-		const u8_t rxtx_turn_us = EVENT_RX_TX_TURNARROUND(phy);
+		const u8_t rxtx_turn_us = EVENT_RX_TX_TURNAROUND(phy);
 		const u16_t conn_ind_us = ll_hdr_us +
 					  BYTES2US(INITA_SIZE + ADVA_SIZE +
 						   LLDATA_SIZE, phy);


### PR DESCRIPTION
Fix typo in EVENT_RX_TX_TURNARROUND.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>