### PR TITLE
Bluetooth: controller: split: Fix directed adv event interval

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -823,7 +823,7 @@ u8_t ll_adv_enable(u8_t enable)
 				   TICKER_USER_ID_THREAD,
 				   (TICKER_ID_ADV_BASE + handle),
 				   ticks_anchor, 0,
-				   adv->evt.ticks_slot,
+				   (adv->evt.ticks_slot + ticks_slot_overhead),
 				   TICKER_NULL_REMAINDER, TICKER_NULL_LAZY,
 				   (adv->evt.ticks_slot + ticks_slot_overhead),
 				   ticker_cb, adv,


### PR DESCRIPTION
Fix the directed advertising event interval calculation.
When CONFIG_BT_CTLR_LOW_LAT is used then prepare duration
has to be included in the event slot reservation.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>