### PR TITLE
bindings: Remove 'title:', put all information into 'description:', and remove boilerplate

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -1,7 +1,5 @@
-title: Short description of the node
-
 description: |
-    Longer free-form description of the node. Can have multiple
+    Free-form description of the device/node. Can have multiple
     lines/paragraphs.
 
     See https://yaml-multiline.info/ for formatting help.

--- a/dts/bindings/arc/arc,dccm.yaml
+++ b/dts/bindings/arc/arc,dccm.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, synopsy
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARC DCCM
-
-description: |
-    This binding gives a base representation of the ARC DCCM
+description: ARC DCCM
 
 compatible: "arc,dccm"
 

--- a/dts/bindings/arc/arc,iccm.yaml
+++ b/dts/bindings/arc/arc,iccm.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, synopsys
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARC ICCM
-
-description: |
-    This binding gives a base representation of the ARC ICCM
+description: ARC ICCM
 
 compatible: "arc,iccm"
 

--- a/dts/bindings/arm/arm,dtcm.yaml
+++ b/dts/bindings/arm/arm,dtcm.yaml
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-title: DTCM
 
-description: |
-  This binding gives a base representation of the Cortex M7 DTCM (Data Tightly Coupled Memory)
+description: Cortex M7 DTCM (Data Tightly Coupled Memory)
 
 compatible: "arm,dtcm"
 

--- a/dts/bindings/arm/arm,scc.yaml
+++ b/dts/bindings/arm/arm,scc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM Serial Configuration Control
-
-description: |
-    This binding gives a base representation of the ARM SCC
+description: ARM Serial Configuration Control (SCC)
 
 compatible: "arm,scc"
 

--- a/dts/bindings/arm/atmel,sam0-device_id.yaml
+++ b/dts/bindings/arm/atmel,sam0-device_id.yaml
@@ -1,7 +1,5 @@
-title: Atmel Device ID (Serial Number) binding
-
 description: |
-    Binding for locating the Device ID (serial number) on Atmel SAM0 devices.
+    For locating the Device ID (serial number) on Atmel SAM0 devices
 
 compatible: "atmel,sam0-id"
 

--- a/dts/bindings/arm/atmel,sam0-dmac.yaml
+++ b/dts/bindings/arm/atmel,sam0-dmac.yaml
@@ -1,7 +1,4 @@
-title: Atmel DMAC binding
-
-description: |
-    Binding for the Atmel SAM0 DMA controller.
+description: Atmel SAM0 DMA controller
 
 compatible: "atmel,sam0-dmac"
 

--- a/dts/bindings/arm/atmel,sam0-sercom.yaml
+++ b/dts/bindings/arm/atmel,sam0-sercom.yaml
@@ -1,7 +1,4 @@
-title: Atmel SERCOM binding
-
-description: |
-    Binding for the Atmel SAM0 multi-protocol (UART, SPI, I2C) SERCOM unit.
+description: Atmel SAM0 multi-protocol (UART, SPI, I2C) SERCOM unit
 
 compatible: "atmel,sam0-sercom"
 

--- a/dts/bindings/arm/nordic,nrf-dppic.yaml
+++ b/dts/bindings/arm/nordic,nrf-dppic.yaml
@@ -1,11 +1,8 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic DPPIC
-
 description: |
-    Binding for the Nordic DPPIC
-    Distributed Programmable Peripheral Interconnect Controller
+    Nordic DPPIC (Distributed Programmable Peripheral Interconnect Controller)
 
 compatible: "nordic,nrf-dppic"
 

--- a/dts/bindings/arm/nordic,nrf-egu.yaml
+++ b/dts/bindings/arm/nordic,nrf-egu.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic EGU
-
-description: |
-    Binding for the Nordic EGU (Event Generator Unit)
+description: Nordic EGU (Event Generator Unit)
 
 compatible: "nordic,nrf-egu"
 

--- a/dts/bindings/arm/nordic,nrf-ficr.yaml
+++ b/dts/bindings/arm/nordic,nrf-ficr.yaml
@@ -1,7 +1,4 @@
-title: Nordic FICR (Factory Information Configuration Registers)
-
-description: |
-    Binding for the Nordic FICR (Factory Information Configuration Registers)
+description: Nordic FICR (Factory Information Configuration Registers)
 
 compatible: "nordic,nrf-ficr"
 

--- a/dts/bindings/arm/nordic,nrf-kmu.yaml
+++ b/dts/bindings/arm/nordic,nrf-kmu.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic KMU
-
-description: |
-    Binding for the Nordic KMU (Key Management Unit)
+description: Nordic KMU (Key Management Unit)
 
 compatible: "nordic,nrf-kmu"
 

--- a/dts/bindings/arm/nordic,nrf-spu.yaml
+++ b/dts/bindings/arm/nordic,nrf-spu.yaml
@@ -1,7 +1,4 @@
-title: Nordic SPU (System Protection Unit)
-
-description: |
-    Binding for the Nordic SPU (System Protection Unit)
+description: Nordic SPU (System Protection Unit)
 
 compatible: "nordic,nrf-spu"
 

--- a/dts/bindings/arm/nordic,nrf-uicr.yaml
+++ b/dts/bindings/arm/nordic,nrf-uicr.yaml
@@ -1,7 +1,4 @@
-title: Nordic UICR (User Information Configuration Registers)
-
-description: |
-    Binding for the Nordic UICR (User Information Configuration Registers)
+description: Nordic UICR (User Information Configuration Registers)
 
 compatible: "nordic,nrf-uicr"
 

--- a/dts/bindings/arm/nxp,imx-dtcm.yaml
+++ b/dts/bindings/arm/nxp,imx-dtcm.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: i.MX DTCM (Data Tightly Coupled Memory)
-
-description: |
-  This binding gives a base representation of the i.MX DTCM
+description: i.MX DTCM (Data Tightly Coupled Memory)
 
 compatible: "nxp,imx-dtcm"
 

--- a/dts/bindings/arm/nxp,imx-epit.yaml
+++ b/dts/bindings/arm/nxp,imx-epit.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: IMX EPIT COUNTER
-
-description: |
-    This binding gives a base representation of the i.MX Enhanced Periodic Interrupt Timer (EPIT)
+description: i.MX Enhanced Periodic Interrupt Timer (EPIT)
 
 compatible: "nxp,imx-epit"
 

--- a/dts/bindings/arm/nxp,imx-itcm.yaml
+++ b/dts/bindings/arm/nxp,imx-itcm.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: i.MX ITCM (Instruction Tightly Coupled Memory)
-
-description: |
-  This binding gives a base representation of the i.MX ITCM
+description: i.MX ITCM (Instruction Tightly Coupled Memory)
 
 compatible: "nxp,imx-itcm"
 

--- a/dts/bindings/arm/nxp,imx-mu.yaml
+++ b/dts/bindings/arm/nxp,imx-mu.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: IMX MESSAGING UNIT
-
-description: |
-    This binding gives a base representation of the i.MX Messaging Unit
+description: i.MX Messaging Unit
 
 compatible: "nxp,imx-mu"
 

--- a/dts/bindings/arm/nxp,kinetis-ke1xf-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-ke1xf-sim.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: Kinetis KE1xF System Integration Module (SIM)
-
-description: |
-    This is a representation of the Kinetis SIM IP node
+description: Kinetis KE1xF System Integration Module (SIM) IP node
 
 compatible: "nxp,kinetis-ke1xf-sim"
 

--- a/dts/bindings/arm/nxp,kinetis-mcg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-mcg.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP Kinetis Multipurpose Clock Generator (MCG)
-
-description: |
-    This is a representation of the NXP Kinetis MCG IP node
+description: NXP Kinetis Multipurpose Clock generator (MCG) IP node
 
 compatible: "nxp,kinetis-mcg"
 

--- a/dts/bindings/arm/nxp,kinetis-pcc.yaml
+++ b/dts/bindings/arm/nxp,kinetis-pcc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP Kinetis PCC (Peripheral Clock Controller)
-
-description: |
-    This is a representation of the NXP Kinetis PCC IP node
+description: NXP Kinetis PCC (Peripheral Clock Controller) IP node
 
 compatible: "nxp,kinetis-pcc"
 

--- a/dts/bindings/arm/nxp,kinetis-scg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-scg.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP Kinetis SCG (System Clock Generator)
-
-description: |
-    This is a representation of the NXP Kinetis SCG IP node
+description: NXP Kinetis SCG (System Clock Generator) IP node
 
 compatible: "nxp,kinetis-scg"
 

--- a/dts/bindings/arm/nxp,kinetis-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-sim.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: Kinetis System Integration Module (SIM)
-
-description: |
-    This is a representation of the Kinetis SIM IP node
+description: Kinetis System Integration Module (SIM) IP node
 
 compatible: "nxp,kinetis-sim"
 

--- a/dts/bindings/arm/nxp,lpc-mailbox.yaml
+++ b/dts/bindings/arm/nxp,lpc-mailbox.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: LPC MAILBOX
-
-description: |
-    This binding gives a base representation of the LPC MAILBOX
+description: LPC MAILBOX
 
 compatible: "nxp,lpc-mailbox"
 

--- a/dts/bindings/arm/st,stm32-ccm.yaml
+++ b/dts/bindings/arm/st,stm32-ccm.yaml
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-title: STM32 CCM
 
-description: |
-  This binding gives a base representation of the STM32 CCM (Core Coupled Memory)
+description: STM32 CCM (Core Coupled Memory)
 
 compatible: "st,stm32-ccm"
 

--- a/dts/bindings/arm/ti,cc2650-prcm.yaml
+++ b/dts/bindings/arm/ti,cc2650-prcm.yaml
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-title: TI CC2650 PRCM
 
-description: |
-    This binding gives a base representation of the TI CC2650
-    Power, Reset, and Clock control Module.
+description: TI CC2650 PRCM (Power, Reset, and Clock control Module)
 
 compatible: "ti,cc2650-prcm"
 

--- a/dts/bindings/audio/nordic,nrf-pdm.yaml
+++ b/dts/bindings/audio/nordic,nrf-pdm.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic PDM
-
-description: |
-    Binding for the Nordic PDM (pulse density modulation interface)
+description: Nordic PDM (Pulse Density Modulation interface)
 
 compatible: "nordic,nrf-pdm"
 

--- a/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
+++ b/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: ST Microelectronics MPXXDTYY digital pdm microphone family
-
-description: |
-    This binding gives a base representation of MPXXDTYY digital microphone family
+description: STMicroelectronics MPXXDTYY digital PDM microphone family
 
 compatible: "st,mpxxdtyy"
 

--- a/dts/bindings/audio/ti,tlv320dac.yaml
+++ b/dts/bindings/audio/ti,tlv320dac.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-title: Texas Instruments TLV320DAC Audio DAC
-
-description: |
-    This binding gives a base representation of TLV320DAC310x Audio DAC
+description: Texas Instruments TLV320DAC310x Audio DAC
 
 compatible: "ti,tlv320dac"
 

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
@@ -1,11 +1,9 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Bluetooth controller that provides Host Controller Interface over SPI
-
 description: |
-    This binding gives the base representation of a bluetooth controller node
-    that provides HCI over SPI.
+    Bluetooth controller node that provides Host Controller Interface (HCI)
+    over SPI
 
 compatible: "zephyr,bt-hci-spi-slave"
 

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
@@ -1,11 +1,9 @@
 # Copyright (c) 2018, I-SENSE group of ICCS
 # SPDX-License-Identifier: Apache-2.0
 
-title: Bluetooth module based on Zephyr's Bluetooth HCI SPI driver
-
 description: |
-    This binding gives the base representation of a bluetooth module which use
-    Zephyr's bluetooth Host Controller Interface SPI driver (e.g. nRF51822).
+    Bluetooth module that uses Zephyr's Bluetooth Host Controller Interface SPI
+    driver (e.g. nRF51822)
 
 compatible: "zephyr,bt-hci-spi"
 

--- a/dts/bindings/can/microchip,mcp2515.yaml
+++ b/dts/bindings/can/microchip,mcp2515.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Karsten Koenig
 # SPDX-License-Identifier: Apache-2.0
 
-title: MCP2515 CAN
-
-description: |
-    This binding gives a base representation of the MCP2515 SPI CAN controller
+description: MCP2515 SPI CAN controller
 
 compatible: "microchip,mcp2515"
 

--- a/dts/bindings/can/nxp,kinetis-flexcan.yaml
+++ b/dts/bindings/can/nxp,kinetis-flexcan.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP FlexCAN
-
-description: |
-    This binding gives a base representation of the NXP FlexCAN controller
+description: NXP FlexCAN controller
 
 compatible: "nxp,kinetis-flexcan"
 

--- a/dts/bindings/can/st,stm32-can.yaml
+++ b/dts/bindings/can/st,stm32-can.yaml
@@ -1,7 +1,4 @@
-title: STM32 CAN
-
-description: |
-    This binding gives a base representation of the STM32 CAN controller
+description: STM32 CAN controller
 
 compatible: "st,stm32-can"
 

--- a/dts/bindings/clock/fixed-clock.yaml
+++ b/dts/bindings/clock/fixed-clock.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Derek Hageman <hageman@inthat.cloud>
 # SPDX-License-Identifier: Apache-2.0
 
-title: Generic fixed rate clock provider
-
-description: |
-    This is a representation of a generic fixed rate clock provider.
+description: Generic fixed-rate clock provider
 
 compatible: "fixed-clock"
 

--- a/dts/bindings/clock/nordic,nrf-clock.yaml
+++ b/dts/bindings/clock/nordic,nrf-clock.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF clock control
-
-description: |
-    This is a representation of the Nordic nRF clock control node
+description: Nordic nRF clock control node
 
 compatible: "nordic,nrf-clock"
 

--- a/dts/bindings/clock/nxp,imx-ccm.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: i.MX Clock Controller Module (CCM)
-
-description: |
-    This is a representation of the i.MX CCM IP node
+description: i.MX CCM (Clock Controller Module) IP node
 
 compatible: "nxp,imx-ccm"
 

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -1,7 +1,4 @@
-title: STM32 RCC
-
-description: |
-    This binding gives a base representation of the STM32 Clock control
+description: STM32 RCC (Reset and Clock Controller)
 
 compatible: "st,stm32-rcc"
 

--- a/dts/bindings/cpu/arm,cortex-m0+.yaml
+++ b/dts/bindings/cpu/arm,cortex-m0+.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM Cortex-M0+ CPU
-
-description: |
-    This binding gives a base representation for ARM Cortex-M0+ CPU.
+description: ARM Cortex-M0+ CPU
 
 compatible: "arm,cortex-m0+"
 

--- a/dts/bindings/cpu/arm,cortex-m0.yaml
+++ b/dts/bindings/cpu/arm,cortex-m0.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM Cortex-M0 CPU
-
-description: |
-    This binding gives a base representation for ARM Cortex-M0 CPU.
+description: ARM Cortex-M0 CPU
 
 compatible: "arm,cortex-m0"
 

--- a/dts/bindings/cpu/arm,cortex-m23.yaml
+++ b/dts/bindings/cpu/arm,cortex-m23.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM Cortex-M23 CPU
-
-description: |
-    This binding gives a base representation for ARM Cortex-M23 CPU.
+description: ARM Cortex-M23 CPU
 
 compatible: "arm,cortex-m23"
 

--- a/dts/bindings/cpu/arm,cortex-m3.yaml
+++ b/dts/bindings/cpu/arm,cortex-m3.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM Cortex-M3 CPU
-
-description: |
-    This binding gives a base representation for ARM Cortex-M3 CPU.
+description: ARM Cortex-M3 CPU
 
 compatible: "arm,cortex-m3"
 

--- a/dts/bindings/cpu/arm,cortex-m33.yaml
+++ b/dts/bindings/cpu/arm,cortex-m33.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM Cortex-M33 CPU
-
-description: |
-    This binding gives a base representation for ARM Cortex-M33 CPU.
+description: ARM Cortex-M33 CPU
 
 compatible: "arm,cortex-m33"
 

--- a/dts/bindings/cpu/arm,cortex-m4.yaml
+++ b/dts/bindings/cpu/arm,cortex-m4.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM Cortex-M4 CPU
-
-description: |
-    This binding gives a base representation for ARM Cortex-M4 CPU.
+description: ARM Cortex-M4 CPU
 
 compatible: "arm,cortex-m4"
 

--- a/dts/bindings/cpu/arm,cortex-m4f.yaml
+++ b/dts/bindings/cpu/arm,cortex-m4f.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM Cortex-M4F CPU
-
-description: |
-    This binding gives a base representation for ARM Cortex-M4F CPU.
+description: ARM Cortex-M4F CPU
 
 compatible: "arm,cortex-m4f"
 

--- a/dts/bindings/cpu/arm,cortex-m7.yaml
+++ b/dts/bindings/cpu/arm,cortex-m7.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM Cortex-M7 CPU
-
-description: |
-    This binding gives a base representation for ARM Cortex-M7 CPU.
+description: ARM Cortex-M7 CPU
 
 compatible: "arm,cortex-m7"
 

--- a/dts/bindings/cpu/arm,cortex-r4.yaml
+++ b/dts/bindings/cpu/arm,cortex-r4.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM Cortex-R4 CPU
-
-description: |
-    This is a representation of ARM Cortex-R4 CPU.
+description: ARM Cortex-R4 CPU
 
 compatible: "arm,cortex-r4"
 

--- a/dts/bindings/cpu/arm,cortex-r4f.yaml
+++ b/dts/bindings/cpu/arm,cortex-r4f.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM Cortex-R4F CPU
-
-description: |
-    This is a representation of ARM Cortex-R4F CPU.
+description: ARM Cortex-R4F CPU
 
 compatible: "arm,cortex-r4f"
 

--- a/dts/bindings/cpu/arm,cortex-r5.yaml
+++ b/dts/bindings/cpu/arm,cortex-r5.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM Cortex-R5 CPU
-
-description: |
-    This is a representation of ARM Cortex-R5 CPU.
+description: ARM Cortex-R5 CPU
 
 compatible: "arm,cortex-r5"
 

--- a/dts/bindings/cpu/arm,cortex-r5f.yaml
+++ b/dts/bindings/cpu/arm,cortex-r5f.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM Cortex-R5F CPU
-
-description: |
-    This is a representation of ARM Cortex-R5F CPU.
+description: ARM Cortex-R5F CPU
 
 compatible: "arm,cortex-r5f"
 

--- a/dts/bindings/cpu/cadence,tensilica-xtensa-lx6.yaml
+++ b/dts/bindings/cpu/cadence,tensilica-xtensa-lx6.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Cadence Tensilica Xtensa LX6 CPU
-
-description: |
-    This binding gives a base representation for Cadence Tensilica Xtensa LX6 CPU.
+description: Cadence Tensilica Xtensa LX6 CPU
 
 compatible: "cadence,tensilica-xtensa-lx6"
 

--- a/dts/bindings/cpu/sample_controller.yaml
+++ b/dts/bindings/cpu/sample_controller.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Sample Controller CPU
-
-description: |
-    This binding gives a base representation for Sample Controller CPU.
+description: Sample controller CPU
 
 compatible: "sample_controller"
 

--- a/dts/bindings/cpu/snps,arcem.yaml
+++ b/dts/bindings/cpu/snps,arcem.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Synopsys ARC EM CPU
-
-description: |
-    This binding gives a base representation for Synopsys ARC EM CPU.
+description: Synopsys ARC EM CPU
 
 compatible: "snps,arcem"
 

--- a/dts/bindings/crypto/arm,cryptocell-310.yaml
+++ b/dts/bindings/crypto/arm,cryptocell-310.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM TrustZone CryptoCell 310
-
-description: |
-    This is a representation of the ARM TrustZone CryptoCell 310
+description: ARM TrustZone CryptoCell 310
 
 compatible: "arm,cryptocell-310"
 

--- a/dts/bindings/crypto/nordic,nrf-cc310.yaml
+++ b/dts/bindings/crypto/nordic,nrf-cc310.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic Control Interface for ARM TrustZone CryptoCell 310
-
-description: |
-    This is a representation of the Nordic Control Interface for ARM TrustZone CryptoCell 310
+description: Nordic Control Interface for ARM TrustZone CryptoCell 310
 
 compatible: "nordic,nrf-cc310"
 

--- a/dts/bindings/display/fsl,imx6sx-lcdif.yaml
+++ b/dts/bindings/display/fsl,imx6sx-lcdif.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP Enhanced LCD Interface (eLCDIF) controller
-
-description: |
-    This binding gives a base representation of the NXP i.MX eLCDIF controller
+description: NXP i.MX eLCDIF (Enhanced LCD Interface) controller
 
 compatible: "fsl,imx6sx-lcdif"
 

--- a/dts/bindings/display/ilitek,ili9340.yaml
+++ b/dts/bindings/display/ilitek,ili9340.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Jan Van Winkel <jan.van_winkel@dxplore.eu>
 # SPDX-License-Identifier: Apache-2.0
 
-title: ILI9340 320x240 Display Controller
-
-description: |
-    This is a representation of the ILI9340 320x240 Display Controller
+description: ILI9340 320x240 display controller
 
 compatible: "ilitek,ili9340"
 

--- a/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
+++ b/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2019, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: Rocktech LCD Module
-
-description: |
-    This binding gives a base representation of the Rocktech LCD module with
-    LED backlight and capacitive touch panel.
+description: Rocktech LCD module with LED backlight and capacitive touch panel
 
 compatible: "rocktech,rk043fn02h-ct"
 

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Marc Reilly <marc@cpdesign.com.au>
 # SPDX-License-Identifier: Apache-2.0
 
-title: ST7789V 320x240 Display Controller
-
-description: |
-    This is a representation of the ST7789V 320x240 Display Controller
+description: ST7789V 320x240 display controller
 
 compatible: "sitronix,st7789v"
 

--- a/dts/bindings/display/solomon,ssd1306fb.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Phytec Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-title: SSD1306 128x64 Dot Matrix Display Controller
-
-description: |
-    This is a representation of the SSD1306 128x64 Dot Matrix Display Controller
+description: SSD1306 128x64 dot-matrix display controller
 
 compatible: "solomon,ssd1306fb"
 

--- a/dts/bindings/display/solomon,ssd1673fb.yaml
+++ b/dts/bindings/display/solomon,ssd1673fb.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Phytec Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-title: SSD16XX 250x150 EPD Display Controller
-
-description: |
-    This is a representation of the SSD16XX 250x150 EPD Display Controller
+description: SSD16XX 250x150 EPD display controller
 
 compatible: "solomon,ssd16xxfb"
 

--- a/dts/bindings/dma/st,stm32-dma.yaml
+++ b/dts/bindings/dma/st,stm32-dma.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019, Song Qiang <songqiang1304521@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-title: STM32 DMA
-
 description: STM32 DMA controller
 
 compatible: "st,stm32-dma"

--- a/dts/bindings/espi/microchip,xec-espi.yaml
+++ b/dts/bindings/espi/microchip,xec-espi.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-title: MICROCHIP ESPI
-
-description: |
-    This binding gives a base representation of ESPI controller for Microchip
+description: Microchip ESPI controller
 
 compatible: "microchip,xec-espi"
 

--- a/dts/bindings/ethernet/intel,e1000.yaml
+++ b/dts/bindings/ethernet/intel,e1000.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-title: Intel E1000 Ethernet controller
-
-description: |
-     This is a representation of the Intel E1000 Ethernet controller
+description: Intel E1000 Ethernet controller
 
 compatible: "intel,e1000"
 

--- a/dts/bindings/ethernet/litex,eth0.yaml
+++ b/dts/bindings/ethernet/litex,eth0.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-title: LiteX Ethernet
-
-description: |
-    This binding gives a base representation of LiteX Ethernet
+description: LiteX Ethernet
 
 compatible: "litex,eth0"
 

--- a/dts/bindings/ethernet/microchip,enc28j60.yaml
+++ b/dts/bindings/ethernet/microchip,enc28j60.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: 10Base-T Ethernet Controller with SPI Interface
-
-description: |
-    This binding gives a base representation of the standalone ENC28J60 chip
+description: ENC28J60 standalone 10BASE-T Ethernet controller with SPI interface
 
 compatible: "microchip,enc28j60"
 

--- a/dts/bindings/ethernet/microchip,enc424j600.yaml
+++ b/dts/bindings/ethernet/microchip,enc424j600.yaml
@@ -1,11 +1,8 @@
 # Copyright (c) 2019, Phytec Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-title: 100Base-T Ethernet Controller with SPI Interface
-
 description: |
-    This binding gives a base representation of the ENC424J600 Stand-Alone
-    Ethernet Controller
+    ENC424J600 standalone 100BASE-T Ethernet controller with SPI interface
 
 compatible: "microchip,enc424j600"
 

--- a/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
+++ b/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP Kinetis Ethernet
-
-description: |
-    This binding gives a base representation of the NXP Kinetis Ethernet
+description: NXP Kinetis Ethernet
 
 compatible: "nxp,kinetis-ethernet"
 

--- a/dts/bindings/ethernet/nxp,kinetis-ptp.yaml
+++ b/dts/bindings/ethernet/nxp,kinetis-ptp.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP Kinetis Ethernet PTP
-
-description: |
-    This binding gives a base representation of the NXP Kinetis Ethernet PTP
+description: NXP Kinetis Ethernet PTP (Precision Time Protocol)
 
 compatible: "nxp,kinetis-ptp"
 

--- a/dts/bindings/ethernet/smsc,lan9220.yaml
+++ b/dts/bindings/ethernet/smsc,lan9220.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2018 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: SMSC/Microchip LAN9220 Ethernet controller
-
-description: |
-     This is a representation of the formerly SMSC, now Microchip, LAN9220
-     Ethernet controller.
+description: SMSC (now Microchip) LAN9220 Ethernet controller
 
 compatible: "smsc,lan9220"
 

--- a/dts/bindings/ethernet/ti,stellaris-ethernet.yaml
+++ b/dts/bindings/ethernet/ti,stellaris-ethernet.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Zilogic Systems
 # SPDX-License-Identifier: Apache-2.0
 
-title: TI Stellaris Ethernet
-
-description: |
-    This binding gives a base representation of the TI Stellaris Ethernet
+description: TI Stellaris Ethernet
 
 compatible: "ti,stellaris-ethernet"
 

--- a/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
+++ b/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Aurelien Jarno
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel SAM Flash Controller
-
-description: |
-    This binding gives a base representation of the Atmel SAM Enhanced Embedded Flash Controller
+description: Atmel SAM Enhanced Embedded Flash Controller (EEFC)
 
 compatible: "atmel,sam-flash-controller"
 

--- a/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
+++ b/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
@@ -1,7 +1,4 @@
-title: Atmel SAM0 Non-Volatile Memory Controller
-
-description: |
-    This binding gives a base representation of the Atmel SAM0 NVMC
+description: Atmel SAM0 NVMC (Non-Volatile Memory Controller)
 
 compatible: "atmel,sam0-nvmctrl"
 

--- a/dts/bindings/flash_controller/cypress,psoc6-flash-controller.yaml
+++ b/dts/bindings/flash_controller/cypress,psoc6-flash-controller.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Cypress
 # SPDX-License-Identifier: Apache-2.0
 
-title: Cypress Flash Controller
-
-description: |
-    This binding gives a base representation of the Cypress Flash Controller
+description: Cypress flash controller
 
 compatible: "cypress,psoc6-flash-controller"
 

--- a/dts/bindings/flash_controller/nordic,nrf51-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf51-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: Nordic NVMC
-
-description: |
-    This binding gives a base representation of the Nordic NVMC
+description: Nordic NVMC (Non-Volatile Memory Controller)
 
 compatible: "nordic,nrf51-flash-controller"
 

--- a/dts/bindings/flash_controller/nordic,nrf52-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf52-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: Nordic NVMC
-
-description: |
-    This binding gives a base representation of the Nordic NVMC
+description: Nordic NVMC (Non-Volatile Memory Controller)
 
 compatible: "nordic,nrf52-flash-controller"
 

--- a/dts/bindings/flash_controller/nordic,nrf53-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf53-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: Nordic NVMC
-
-description: |
-    This binding gives a base representation of the Nordic NVMC
+description: Nordic NVMC (Non-Volatile Memory Controller)
 
 compatible: "nordic,nrf53-flash-controller"
 

--- a/dts/bindings/flash_controller/nordic,nrf91-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf91-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: Nordic NVMC
-
-description: |
-    This binding gives a base representation of the Nordic NVMC
+description: Nordic NVMC (Non-Volatile Memory Controller)
 
 compatible: "nordic,nrf91-flash-controller"
 

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfa.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfa.yaml
@@ -1,7 +1,4 @@
-title: NXP Kinetis Flash Memory Module (FTFA)
-
-description: |
-    This binding gives for the NXP Kinetis Flash Memory Module A (FTFA)
+description: NXP Kinetis Flash Memory Module A (FTFA)
 
 compatible: "nxp,kinetis-ftfa"
 

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfe.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfe.yaml
@@ -1,7 +1,4 @@
-title: NXP Kinetis Flash Memory Module (FTFE)
-
-description: |
-    This binding gives for the NXP Kinetis Flash Memory Module E (FTFE)
+description: NXP Kinetis Flash Memory Module E (FTFE)
 
 compatible: "nxp,kinetis-ftfe"
 

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfl.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfl.yaml
@@ -1,7 +1,4 @@
-title: NXP Kinetis Flash Memory Module (FTFL)
-
-description: |
-    This binding gives for the NXP Kinetis Flash Memory Module L (FTFL)
+description: NXP Kinetis Flash Memory Module L (FTFL)
 
 compatible: "nxp,kinetis-ftfl"
 

--- a/dts/bindings/flash_controller/openisa,rv32m1-ftfe.yaml
+++ b/dts/bindings/flash_controller/openisa,rv32m1-ftfe.yaml
@@ -1,7 +1,4 @@
-title: OpenISA Flash Memory Module (FTFE)
-
-description: |
-    This binding gives for the OpenISA Flash Memory Module E (FTFE)
+description: OpenISA Flash Memory Module E (FTFE)
 
 compatible: "openisa,rv32m1-ftfe"
 

--- a/dts/bindings/flash_controller/silabs,gecko-flash-controller.yaml
+++ b/dts/bindings/flash_controller/silabs,gecko-flash-controller.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Piotr Mienkowski
 # SPDX-License-Identifier: Apache-2.0
 
-title: Silicon Labs Gecko Flash Controller
-
-description: |
-    This binding gives a base representation of the Silicon Labs Gecko Flash Controller
+description: Silicon Labs Gecko flash controller
 
 compatible: "silabs,gecko-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: STM32 F0 Flash Controller
-
-description: |
-    This binding gives a base representation of the STM32 F0 Flash Controller
+description: STM32 F0 flash controller
 
 compatible: "st,stm32f0-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32f1-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f1-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: STM32 F1 Flash Controller
-
-description: |
-    This binding gives a base representation of the STM32 F1 Flash Controller
+description: STM32 F1 flash controller
 
 compatible: "st,stm32f1-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: STM32 F2 Flash Controller
-
-description: |
-    This binding gives a base representation of the STM32 F2 Flash Controller
+description: STM32 F2 flash controller
 
 compatible: "st,stm32f2-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: STM32 F3 Flash Controller
-
-description: |
-    This binding gives a base representation of the STM32 F3 Flash Controller
+description: STM32 F3 flash controller
 
 compatible: "st,stm32f3-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: STM32 F4 Flash Controller
-
-description: |
-    This binding gives a base representation of the STM32 F4 Flash Controller
+description: STM32 F4 flash controller
 
 compatible: "st,stm32f4-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32f7-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f7-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: STM32 F7 Flash Controller
-
-description: |
-    This binding gives a base representation of the STM32 F7 Flash Controller
+description: STM32 F7 flash controller
 
 compatible: "st,stm32f7-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32g0-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32g0-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: STM32 G0 Flash Controller
-
-description: |
-    This binding gives a base representation of the STM32 G0 Flash Controller
+description: STM32 G0 flash controller
 
 compatible: "st,stm32g0-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32g4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32g4-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: STM32 G4 Flash Controller
-
-description: |
-    This binding gives a base representation of the STM32 G4 Flash Controller
+description: STM32 G4 flash controller
 
 compatible: "st,stm32g4-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32h7-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32h7-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: STM32 H7 Flash Controller
-
-description: |
-    This binding gives a base representation of the STM32 H7 Flash Controller
+description: STM32 H7 flash controller
 
 compatible: "st,stm32h7-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32l1-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32l1-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: STM32 L1 Flash Controller
-
-description: |
-    This binding gives a base representation of the STM32 L1 Flash Controller
+description: STM32 L1 flash controller
 
 compatible: "st,stm32l1-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: STM32 L4 Flash Controller
-
-description: |
-    This binding gives a base representation of the STM32 L4 Flash Controller
+description: STM32 L4 flash controller
 
 compatible: "st,stm32l4-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
@@ -1,7 +1,4 @@
-title: STM32 WB Flash Controller
-
-description: |
-    This binding gives a base representation of the STM32 wb Flash Controller
+description: STM32 WB flash controller
 
 compatible: "st,stm32wb-flash-controller"
 

--- a/dts/bindings/flash_controller/zephyr,native-posix-flash-controller.yaml
+++ b/dts/bindings/flash_controller/zephyr,native-posix-flash-controller.yaml
@@ -1,8 +1,4 @@
-title: Native POSIX Flash Controller
-
-description: |
-    This binding gives a base representation of the Native POSIX flash
-    controller
+description: Native POSIX flash controller
 
 compatible: "zephyr,native-posix-flash-controller"
 

--- a/dts/bindings/flash_controller/zephyr,sim-flash.yaml
+++ b/dts/bindings/flash_controller/zephyr,sim-flash.yaml
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-title: simulated flash
-
-description: |
-    This binding gives a base representation of a simulated flash memory
+description: Simulated flash memory
 
 compatible: "zephyr,sim-flash"
 

--- a/dts/bindings/gpio/96boards-lscon-1v8.yaml
+++ b/dts/bindings/gpio/96boards-lscon-1v8.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Linaro Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-title: 96BOARDS 1.8V LOW SPEED CONNECTOR
-
-description: >
-    This is a representation of GPIO pin nodes exposed on the 96Boards 1.8v low speed header
+description: Represents GPIO pin nodes exposed on the 96Boards 1.8v low-speed header
 
 compatible: "96b-lscon-1v8"
 

--- a/dts/bindings/gpio/96boards-lscon-3v3.yaml
+++ b/dts/bindings/gpio/96boards-lscon-3v3.yaml
@@ -1,10 +1,8 @@
 # Copyright (c) 2019 Linaro Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-title: 96BOARDS 3.3V LOW SPEED CONNECTOR
-
-description: >
-    This is a representation of GPIO pin nodes exposed on the 96Boards 3.3v low speed header
+description: |
+    Represents GPIO pin nodes exposed on the 96Boards 3.3v low-speed header
 
 compatible: "96b-lscon-3v3"
 

--- a/dts/bindings/gpio/arduino-header-r3.yaml
+++ b/dts/bindings/gpio/arduino-header-r3.yaml
@@ -2,8 +2,6 @@
 # Copyright (C) 2019 Peter Bigot Consulting, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-title: Arduino Uno (R3) GPIO Header
-
 description: |
     GPIO pins exposed on Arduino Uno (R3) headers.
 

--- a/dts/bindings/gpio/arm,cmsdk-gpio.yaml
+++ b/dts/bindings/gpio/arm,cmsdk-gpio.yaml
@@ -1,7 +1,4 @@
-title: ARM CMSDK GPIO
-
-description: |
-    This binding gives a base representation of the ARM CMSDK GPIO
+description: ARM CMSDK GPIO
 
 compatible: "arm,cmsdk-gpio"
 

--- a/dts/bindings/gpio/arm,mps2-fpgaio-gpio.yaml
+++ b/dts/bindings/gpio/arm,mps2-fpgaio-gpio.yaml
@@ -1,5 +1,3 @@
-title: ARM MPS2 FPGA GPIO
-
 description: GPIO controller on ARM MPS2 FPGA
 
 compatible: "arm,mps2-fpgaio-gpio"

--- a/dts/bindings/gpio/atmel,sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam-gpio.yaml
@@ -1,7 +1,4 @@
-title: Atmel SAM GPIO PORT driver
-
-description: |
-    This is a representation of the SAM GPIO PORT nodes
+description: SAM GPIO PORT node
 
 compatible: "atmel,sam-gpio"
 

--- a/dts/bindings/gpio/atmel,sam0-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam0-gpio.yaml
@@ -1,7 +1,4 @@
-title: Atmel SAM0 GPIO PORT driver
-
-description: |
-    This is a representation of the SAM0 GPIO PORT nodes
+description: SAM0 GPIO PORT node
 
 compatible: "atmel,sam0-gpio"
 

--- a/dts/bindings/gpio/espressif,esp32-gpio.yaml
+++ b/dts/bindings/gpio/espressif,esp32-gpio.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2019, Yannis Damigos
 # SPDX-License-Identifier: Apache-2.0
 
-title: ESP32 GPIO controller
 description: ESP32 GPIO controller
 
 compatible: "espressif,esp32-gpio"

--- a/dts/bindings/gpio/gpio-keys.yaml
+++ b/dts/bindings/gpio/gpio-keys.yaml
@@ -1,14 +1,11 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: GPIO KEYS parent
-
 description: GPIO KEYS parent node
 
 compatible: "gpio-keys"
 
 child-binding:
-    title: GPIO KEYS node
     description: GPIO KEYS child node
     properties:
        gpios:

--- a/dts/bindings/gpio/gpio-leds.yaml
+++ b/dts/bindings/gpio/gpio-leds.yaml
@@ -1,14 +1,11 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: GPIO LEDs
-
 description: GPIO LEDs parent node
 
 compatible: "gpio-leds"
 
 child-binding:
-    title: GPIO LED node
     description: GPIO LED child node
     properties:
        gpios:

--- a/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
+++ b/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
@@ -1,6 +1,4 @@
-title: Holtek HT16K33 LED Driver With Keyscan
-
-description: Holtek HT16K33 Keyscan binding
+description: Holtek HT16K33 LED driver with keyscan
 
 compatible: "holtek,ht16k33-keyscan"
 

--- a/dts/bindings/gpio/intel,apl-gpio.yaml
+++ b/dts/bindings/gpio/intel,apl-gpio.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018-2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-title: Intel Apollo Lake GPIO controller
-
-description: |
-    This is a representation of the Intel Apollo Lake GPIO node
+description: Intel Apollo Lake GPIO node
 
 compatible: "intel,apl-gpio"
 

--- a/dts/bindings/gpio/microchip,xec-gpio.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-title: MICROCHIP GPIO
-
-description: |
-    This is a representation of the CEC/MEC GPIO nodes for Microchip
+description: Microchip CEC/MEC GPIO node
 
 compatible: "microchip,xec-gpio"
 

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, marc-cpdesign
 # SPDX-License-Identifier: Apache-2.0
 
-title: NRF5 GPIO
-
-description: |
-    This is a representation of the NRF GPIO nodes
+description: NRF5 GPIO node
 
 compatible: "nordic,nrf-gpio"
 

--- a/dts/bindings/gpio/nordic,nrf-gpiote.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpiote.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, marc-cpdesign
 # SPDX-License-Identifier: Apache-2.0
 
-title: NRF5 GPIOTE
-
-description: |
-    This is a representation of the NRF GPIOTE node
+description: NRF5 GPIOTE node
 
 compatible: "nordic,nrf-gpiote"
 

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: i.MX GPIO
-
-description: |
-    This is a representation of the i.MX GPIO nodes
+description: i.MX GPIO node
 
 compatible: "nxp,imx-gpio"
 

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -1,7 +1,4 @@
-title: Kinetis GPIO
-
-description: |
-    This is a representation of the Kinetis GPIO nodes
+description: Kinetis GPIO node
 
 compatible: "nxp,kinetis-gpio"
 

--- a/dts/bindings/gpio/nxp,lpc-gpio.yaml
+++ b/dts/bindings/gpio/nxp,lpc-gpio.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: LPC GPIO
-
-description: |
-    This is a representation of the LPC GPIO nodes
+description: LPC GPIO node
 
 compatible: "nxp,lpc-gpio"
 

--- a/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
+++ b/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
@@ -1,7 +1,4 @@
-title: OpenISA GPIO
-
-description: |
-    This is a representation of the OpenISA GPIO nodes
+description: OpenISA GPIO node
 
 compatible: "openisa,rv32m1-gpio"
 

--- a/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Aapo Vienamo
 # SPDX-License-Identifier: Apache-2.0
 
-title: Semtech SX1509B I2C GPIO
-
-description: |
-        This is a representation of the SX1509B GPIO node
+description: SX1509B GPIO node
 
 compatible: "semtech,sx1509b"
 

--- a/dts/bindings/gpio/sifive,gpio0.yaml
+++ b/dts/bindings/gpio/sifive,gpio0.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-title: SiFive GPIO
-
-description: |
-    This is a representation of the SiFive GPIO nodes
+description: SiFive GPIO node
 
 compatible: "sifive,gpio0"
 

--- a/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
@@ -1,7 +1,4 @@
-title: EFM32 GPIO
-
-description: |
-    This is a representation of the EFM32 GPIO Port nodes
+description: EFM32 GPIO port node
 
 compatible: "silabs,efm32-gpio-port"
 

--- a/dts/bindings/gpio/silabs,efm32-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio.yaml
@@ -1,7 +1,4 @@
-title: EFM32 GPIO
-
-description: |
-    This is a representation of the EFM32 GPIO nodes
+description: EFM32 GPIO node
 
 compatible: "silabs,efm32-gpio"
 

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio-port.yaml
@@ -1,7 +1,4 @@
-title: EFR32MG GPIO
-
-description: |
-    This is a representation of the EFR32MG GPIO Port nodes
+description: EFR32MG GPIO port node
 
 compatible: "silabs,efr32mg-gpio-port"
 

--- a/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32mg12-gpio.yaml
@@ -1,7 +1,4 @@
-title: EFR32MG GPIO
-
-description: |
-    This is a representation of the EFR32MG GPIO nodes
+description: EFR32MG GPIO node
 
 compatible: "silabs,efr32mg-gpio"
 

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
@@ -1,7 +1,4 @@
-title: EFR32XG1 GPIO
-
-description: |
-    This is a representation of the EFR32XG1 GPIO Port nodes
+description: EFR32XG1 GPIO port node
 
 compatible: "silabs,efr32xg1-gpio-port"
 

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
@@ -1,7 +1,4 @@
-title: EFR32XG1 GPIO
-
-description: |
-    This is a representation of the EFR32XG1 GPIO nodes
+description: EFR32XG1 GPIO node
 
 compatible: "silabs,efr32xg1-gpio"
 

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Synopsys, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-title: Synopsys Designware GPIO controller
-
-description: |
-    This is a representation of the Synopsys DesignWare gpio node
+description: Synopsys DesignWare GPIO node
 
 compatible: "snps,designware-gpio"
 

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: STM32 GPIO
-
-description: |
-    This is a representation of the STM32 GPIO nodes
+description: STM32 GPIO node
 
 compatible: "st,stm32-gpio"
 

--- a/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Brett Witherspoon
 # SPDX-License-Identifier: Apache-2.0
 
-title: TI SimpleLink CC13xx / CC26xx GPIO
-
-description: |
-    This is a representation of the TI SimpleLink CC13xx / CC26xx GPIO node
+description: TI SimpleLink CC13xx / CC26xx GPIO node
 
 compatible: "ti,cc13xx-cc26xx-gpio"
 

--- a/dts/bindings/gpio/ti,cc2650-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc2650-gpio.yaml
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-title: TI CC2650 GPIO
-
-description: |
-    This is a representation of the TI CC2650 GPIO node
+description: TI CC2650 GPIO node
 
 compatible: "ti,cc2650-gpio"
 

--- a/dts/bindings/gpio/ti,cc32xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc32xx-gpio.yaml
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-title: TI CC32XX GPIO
-
-description: |
-    This is a representation of the TI CC32XX GPIO node
+description: TI CC32XX GPIO node
 
 compatible: "ti,cc32xx-gpio"
 

--- a/dts/bindings/gpio/ti,stellaris-gpio.yaml
+++ b/dts/bindings/gpio/ti,stellaris-gpio.yaml
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-title: TI Stellaris GPIO
 
-description: |
-    This is a representation of the TI Stellaris GPIO node
+description: TI Stellaris GPIO node
 
 compatible: "ti,stellaris-gpio"
 

--- a/dts/bindings/hwinfo/litex,dna0.yaml
+++ b/dts/bindings/hwinfo/litex,dna0.yaml
@@ -1,7 +1,6 @@
 # Copyright (c)  2019 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-title: LiteX DNA
 description: LiteX DNA ID reader
 
 compatible: "litex,dna0"

--- a/dts/bindings/i2c/arm,versatile-i2c.yaml
+++ b/dts/bindings/i2c/arm,versatile-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM SBCon two-wire serial bus interface
-
-description: |
-    This is a representation of the ARM SBCon two-wire serial bus interface
+description: ARM SBCon two-wire serial bus interface
 
 compatible: "arm,versatile-i2c"
 

--- a/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017 Piotr Mienkowski
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel SAM Family I2C (TWI) node
-
-description: |
-    This is a representation of the Atmel SAM Family I2C (TWI) node
+description: Atmel SAM Family I2C (TWI) node
 
 compatible: "atmel,sam-i2c-twi"
 

--- a/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017 Piotr Mienkowski
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel SAM Family I2C (TWIHS) node
-
-description: |
-    This is a representation of the Atmel SAM Family I2C (TWIHS) node
+description: Atmel SAM Family I2C (TWIHS) node
 
 compatible: "atmel,sam-i2c-twihs"
 

--- a/dts/bindings/i2c/atmel,sam0-i2c.yaml
+++ b/dts/bindings/i2c/atmel,sam0-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Derek Hageman <hageman@inthat.cloud>
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel SAM0 series SERCOM I2C controller
-
-description: |
-    This is a representation of the Atmel SAM0 series SERCOM I2C nodes
+description: Atmel SAM0 series SERCOM I2C node
 
 compatible: "atmel,sam0-i2c"
 

--- a/dts/bindings/i2c/espressif,esp32-i2c.yaml
+++ b/dts/bindings/i2c/espressif,esp32-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Mohamed ElShahawi (ExtremeGTX@hotmail.com)
 # SPDX-License-Identifier: Apache-2.0
 
-title: ESP32 I2C
-
-description: |
-    This is a representation of the ESP32 I2C
+description: ESP32 I2C
 
 compatible: "espressif,esp32-i2c"
 

--- a/dts/bindings/i2c/fsl,imx7d-i2c.yaml
+++ b/dts/bindings/i2c/fsl,imx7d-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: i.MX I2C Controller
-
-description: |
-    This is a representation of the i.MX I2C nodes
+description: i.MX I2C node
 
 compatible: "fsl,imx7d-i2c"
 

--- a/dts/bindings/i2c/microchip,xec-i2c.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-title: MICROCHIP I2C
-
-description: |
-    This binding gives a base representation for I2C/SMB controller for Microchip
+description: Microchip I2C/SMB controller
 
 compatible: "microchip,xec-i2c"
 

--- a/dts/bindings/i2c/nios2,i2c.yaml
+++ b/dts/bindings/i2c/nios2,i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-title: NIOS2 i2c
-
-description: |
-    This binding gives a base representation of the NIOS2 i2c
+description: NIOS2 I2C
 
 compatible: "nios2,i2c"
 

--- a/dts/bindings/i2c/nordic,nrf-twi.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF family TWI
-
 description: Nordic nRF family TWI (TWI master)
 
 compatible: "nordic,nrf-twi"

--- a/dts/bindings/i2c/nordic,nrf-twim.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twim.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF family TWIM
-
 description: Nordic nRF family TWIM (TWI master with EasyDMA)
 
 compatible: "nordic,nrf-twim"

--- a/dts/bindings/i2c/nordic,nrf-twis.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twis.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF family TWIS
-
 description: Nordic nRF family TWIS (TWI slave with EasyDMA)
 
 compatible: "nordic,nrf-twis"

--- a/dts/bindings/i2c/nxp,imx-lpi2c.yaml
+++ b/dts/bindings/i2c/nxp,imx-lpi2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP LPI2C
-
-description: |
-    This binding gives a base representation of the NXP i.MX LPI2C controller
+description: NXP i.MX LPI2C controller
 
 compatible: "nxp,imx-lpi2c"
 

--- a/dts/bindings/i2c/nxp,kinetis-i2c.yaml
+++ b/dts/bindings/i2c/nxp,kinetis-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Kinetis I2C Controller
-
-description: |
-    This is a representation of the Kinetis I2C nodes
+description: Kinetis I2C node
 
 compatible: "nxp,kinetis-i2c"
 

--- a/dts/bindings/i2c/openisa,rv32m1-lpi2c.yaml
+++ b/dts/bindings/i2c/openisa,rv32m1-lpi2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
-title: OpenISA LPI2C
-
-description: |
-    This binding gives a base representation of the OpenISA LPI2C controller
+description: OpenISA LPI2C controller
 
 compatible: "openisa,rv32m1-lpi2c"
 

--- a/dts/bindings/i2c/sifive,i2c0.yaml
+++ b/dts/bindings/i2c/sifive,i2c0.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-title: SiFive Freedom I2C
-
-description: |
-    This is a binding for the SiFive Freedom I2C interface
+description: SiFive Freedom I2C interface
 
 compatible: "sifive,i2c0"
 

--- a/dts/bindings/i2c/silabs,gecko-i2c.yaml
+++ b/dts/bindings/i2c/silabs,gecko-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Diego Sueiro <diego.sueiro@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-title: Silabs Gecko I2C Controller
-
-description: |
-    This is a representation of the Silabs Gecko I2C nodes
+description: Silabs Gecko I2C node
 
 compatible: "silabs,gecko-i2c"
 

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-title: Synopys DesignWare I2C controller
-
-description: |
-    This is a representation of the Synopsys DesignWare i2c node
+description: Synopsys DesignWare I2C node
 
 compatible: "snps,designware-i2c"
 

--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017 I-SENSE group of ICCS
 # SPDX-License-Identifier: Apache-2.0
 
-title: STM32 I2C V1
-
-description: |
-    This binding gives a base representation of the STM32 I2C V1 controller
+description: STM32 I2C V1 controller
 
 compatible: "st,stm32-i2c-v1"
 

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017 I-SENSE group of ICCS
 # SPDX-License-Identifier: Apache-2.0
 
-title: STM32 I2C V2
-
-description: |
-    This binding gives a base representation of the STM32 I2C V2 controller
+description: STM32 I2C V2 controller
 
 compatible: "st,stm32-i2c-v2"
 

--- a/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Brett Witherspoon
 # SPDX-License-Identifier: Apache-2.0
 
-title: TI CC13xx / CC26xx I2C
-
-description: |
-    This is a representation of the TI CC13xx / CC26xx I2C node
+description: TI CC13xx / CC26xx I2C node
 
 compatible: "ti,cc13xx-cc26xx-i2c"
 

--- a/dts/bindings/i2c/ti,cc32xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc32xx-i2c.yaml
@@ -1,7 +1,4 @@
-title: CC32XX I2C
-
-description: |
-    This binding gives a base representation of the TI CC32XX I2C controller
+description: TI CC32XX I2C controller
 
 compatible: "ti,cc32xx-i2c"
 

--- a/dts/bindings/i2s/nordic,nrf-i2s.yaml
+++ b/dts/bindings/i2s/nordic,nrf-i2s.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic I2S
-
-description: |
-    Binding for the Nordic I2S (Inter-IC sound interface)
+description: Nordic I2S (Inter-IC sound interface)
 
 compatible: "nordic,nrf-i2s"
 

--- a/dts/bindings/i2s/st,stm32-i2s.yaml
+++ b/dts/bindings/i2s/st,stm32-i2s.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STM32 I2S
-
-description: |
-    This binding gives a base representation of the STM32 I2S controller
+description: STM32 I2S controller
 
 compatible: "st,stm32-i2s"
 

--- a/dts/bindings/ieee802154/atmel,rf2xx.yaml
+++ b/dts/bindings/ieee802154/atmel,rf2xx.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Gerson Fernando Budke
 # SPDX-License-Identifier: Apache-2.0
 
-title: ATMEL AT86RF2xx 802.15.4 Wireless Transceiver
-
-description: |
-    This is a representation of the ATMEL AT86RF2xx wireless transceiver.
+description: ATMEL AT86RF2xx 802.15.4 wireless transceiver
 
 compatible: "atmel,rf2xx"
 

--- a/dts/bindings/ieee802154/nxp,mcr20a.yaml
+++ b/dts/bindings/ieee802154/nxp,mcr20a.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP MCR20A 802.15.4 Wireless Transceiver
-
-description: |
-    This is a representation of the NXP MCR20A wireless transceiver.
+description: NXP MCR20A 802.15.4 wireless transceiver
 
 compatible: "nxp,mcr20a"
 

--- a/dts/bindings/ieee802154/ti,cc1200.yaml
+++ b/dts/bindings/ieee802154/ti,cc1200.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: CC1200 802.15.4 Wireless Transceiver
-
-description: |
-    This is a representation of the CC1200 wireless transceiver.
+description: Texas Instruments CC1200 802.15.4 wireless transceiver
 
 compatible: "ti,cc1200"
 

--- a/dts/bindings/ieee802154/ti,cc2520.yaml
+++ b/dts/bindings/ieee802154/ti,cc2520.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-title: CC2520 802.15.4 Wireless Transceiver
-
-description: |
-    This is a representation of the CC2520 wireless transceiver.
+description: Texas Instruments CC2520 802.15.4 wireless transceiver
 
 compatible: "ti,cc2520"
 

--- a/dts/bindings/iio/adc/atmel,sam-afec.yaml
+++ b/dts/bindings/iio/adc/atmel,sam-afec.yaml
@@ -1,7 +1,4 @@
-title: Atmel SAM Family AFEC
-
-description: |
-    This binding gives a base representation of the Atmel SAM AFEC
+description: Atmel SAM family AFEC
 
 compatible: "atmel,sam-afec"
 

--- a/dts/bindings/iio/adc/atmel,sam0-adc.yaml
+++ b/dts/bindings/iio/adc/atmel,sam0-adc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Derek Hageman <hageman@inthat.cloud>
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel SAM0 Family ADC
-
-description: |
-    This binding gives a base representation of the Atmel SAM0 ADC
+description: Atmel SAM0 family ADC
 
 compatible: "atmel,sam0-adc"
 

--- a/dts/bindings/iio/adc/microchip,xec-adc.yaml
+++ b/dts/bindings/iio/adc/microchip,xec-adc.yaml
@@ -1,13 +1,7 @@
-#
 # Copyright (c) 2019, Intel Corporation
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-title: Microchip XEC ADC
-
-description: |
-    This binding gives a base representation of the Microchip XEC ADC
+description: Microchip XEC ADC
 
 compatible: "microchip,xec-adc"
 

--- a/dts/bindings/iio/adc/nordic,nrf-adc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-adc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic Semiconductor nRF Family ADC
-
-description: |
-    This is a representation of the nRF ADC node
+description: nRF ADC node
 
 compatible: "nordic,nrf-adc"
 

--- a/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic Semiconductor nRF Family SAADC
-
-description: |
-    This is a representation of the nRF SAADC node
+description: Nordic Semiconductor nRF family SAADC node
 
 compatible: "nordic,nrf-saadc"
 

--- a/dts/bindings/iio/adc/nxp,kinetis-adc12.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc12.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP Kinetis ADC12
-
-description: |
-    This binding gives a base representation of the NXP Kinetis ADC12
+description: NXP Kinetis ADC12
 
 compatible: "nxp,kinetis-adc12"
 

--- a/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: Kinetis ADC16
-
-description: |
-    This binding gives a base representation of the Kinetis ADC16
+description: Kinetis ADC16
 
 compatible: "nxp,kinetis-adc16"
 

--- a/dts/bindings/iio/adc/st,stm32-adc.yaml
+++ b/dts/bindings/iio/adc/st,stm32-adc.yaml
@@ -2,10 +2,7 @@
 # Copyright (c) 2018, Song Qiang <songqiang1304521@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-title: ST STM32 family ADC
-
-description: |
-    This binding gives a base representation of the ST STM32 ADC
+description: ST STM32 family ADC
 
 compatible: "st,stm32-adc"
 

--- a/dts/bindings/interrupt-controller/arm,gic.yaml
+++ b/dts/bindings/interrupt-controller/arm,gic.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Marvell
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARMv7-R Generic Interrupt Controller
-
-description: |
-    This binding describes the ARM Generic Interrupt Controller.
+description: ARMv7-R Generic Interrupt Controller
 
 compatible: "arm,gic"
 

--- a/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
@@ -1,7 +1,4 @@
-title: ARMv6-M NVIC Interrupt Controller
-
-description: |
-    This binding describes the ARMv6-M Nested Vectored Interrupt Controller.
+description: ARMv6-M NVIC (Nested Vectored Interrupt Controller) controller
 
 compatible: "arm,v6m-nvic"
 

--- a/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
@@ -1,7 +1,4 @@
-title: ARMv7-M NVIC Interrupt Controller
-
-description: |
-    This binding describes the ARMv7-M Nested Vectored Interrupt Controller.
+description: ARMv7-M NVIC (Nested Vectored Interrupt Controller)
 
 compatible: "arm,v7m-nvic"
 

--- a/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
@@ -1,7 +1,4 @@
-title: ARMv8-M NVIC Interrupt Controller
-
-description: |
-    This binding describes the ARMv8-M Nested Vectored Interrupt Controller.
+description: ARMv8-M NVIC (Nested Vectored Interrupt Controller)
 
 compatible: "arm,v8m-nvic"
 

--- a/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
+++ b/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
@@ -1,7 +1,4 @@
-title: Atmel SAM0 External Interrupt Controller
-
-description: |
-    This binding describes the Atmel SAM0 series External Interrupt Controller
+description: Atmel SAM0 series External Interrupt Controller
 
 compatible: "atmel,sam0-eic"
 

--- a/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
@@ -1,7 +1,4 @@
-title: CAVS Interrupt Controller
-
-description: |
-    This binding describes CAVS Interrupt controller
+description: CAVS interrupt controller
 
 compatible: "intel,cavs-intc"
 

--- a/dts/bindings/interrupt-controller/intel,ioapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,ioapic.yaml
@@ -1,8 +1,4 @@
-title: Intel I/O Advanced Programmable Interrupt Controller
-
-description: |
-    This binding describes the Intel I/O Advanced Programmable Interrupt
-    controller
+description: Intel I/O Advanced Programmable Interrupt Controller (APIC)
 
 compatible: "intel,ioapic"
 

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-event-unit.yaml
@@ -2,10 +2,7 @@
 # Copyright (c) 2018, Foundries.io
 # SPDX-License-Identifier: Apache-2.0
 
-title: RV32M1 Event Unit
-
-description: |
-    This binding describes the RV32M1 Event Unit
+description: RV32M1 Event Unit
 
 compatible: "openisa,rv32m1-event-unit"
 

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux-ch.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux-ch.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: RV32M1 INTMUX Channel
-
-description: |
-    This binding describes the RV32M1 INTMUX Channel
+description: RV32M1 INTMUX channel
 
 compatible: "openisa,rv32m1-intmux-ch"
 

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Foundries.io
 # SPDX-License-Identifier: Apache-2.0
 
-title: RV32M1 INTMUX
-
-description: |
-    This binding describes the RV32M1 INTMUX IP
+description: RV32M1 INTMUX IP
 
 compatible: "openisa,rv32m1-intmux"
 

--- a/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
+++ b/dts/bindings/interrupt-controller/riscv,cpu-intc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: RISC-V CPU INTC
-
-description: |
-    This binding describes the RISC-V CPU Interrupt Controller
+description: RISC-V CPU interrupt controller
 
 compatible: "riscv,cpu-intc"
 

--- a/dts/bindings/interrupt-controller/shared-irq.yaml
+++ b/dts/bindings/interrupt-controller/shared-irq.yaml
@@ -1,7 +1,4 @@
-title: Shared IRQ interrupt dispatcher
-
-description: |
-    This binding describes Shared IRQ interrupt dispatcher
+description: Shared IRQ interrupt dispatcher
 
 compatible: "shared-irq"
 

--- a/dts/bindings/interrupt-controller/sifive,plic-1.0.0.yaml
+++ b/dts/bindings/interrupt-controller/sifive,plic-1.0.0.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2018, SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-title: SiFive PLIC
 description: SiFive RISCV-V platform-local interrupt controller
 
 compatible: "sifive,plic-1.0.0"

--- a/dts/bindings/interrupt-controller/snps,archs-idu-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,archs-idu-intc.yaml
@@ -1,12 +1,10 @@
 # Copyright (c) 2019, synopsys
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARC-HS Interrupt Distribution Unit
-
 description: |
-    This binding describes the 2nd level interrupt controller can be used in
-    SMP configurations for dynamic IRQ routing, load balancing of
-    common/external IRQs towards core intc
+    ARC-HS Interrupt Distribution Unit 2nd-level interrupt controller. Can be
+    used in SMP configurations for dynamic IRQ routing and load balancing of
+    common/external IRQs towards the core interrupt controller.
 
 compatible: "snps,archs-idu-intc"
 

--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, synopsys
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARCV2 Interrupt Controller
-
-description: |
-    This binding describes the ARCV2 IRQ controller
+description: ARCV2 interrupt controller
 
 compatible: "snps,arcv2-intc"
 

--- a/dts/bindings/interrupt-controller/snps,designware-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,designware-intc.yaml
@@ -1,7 +1,4 @@
-title: DesignWare Interrupt Controller
-
-description: |
-    This binding describes DesignWare Programmable Interrupt controller
+description: DesignWare programmable interrupt controller
 
 compatible: "snps,designware-intc"
 

--- a/dts/bindings/interrupt-controller/swerv,pic.yaml
+++ b/dts/bindings/interrupt-controller/swerv,pic.yaml
@@ -1,13 +1,6 @@
-#
-# Copyright (c) 2019
-#
 # SPDX-License-Identifier: Apache-2.0
-#
----
-title: SweRV EH1 PIC
 
-description: >
-    This binding describes the SweRV EH1 Programmable Interrupt Controller
+description: SweRV EH1 PIC (Programmable Interrupt Controller)
 
 compatible: "swerv,pic"
 

--- a/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
+++ b/dts/bindings/interrupt-controller/vexriscv,intc0.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 - 2019 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-title: LiteX VexRiscV Interrupt Controller
-
-description: |
-    This binding describes LiteX VexRiscV Interrupt Controller
+description: LiteX VexRiscV interrupt controller
 
 compatible: "vexriscv,intc0"
 

--- a/dts/bindings/interrupt-controller/xtensa,intc.yaml
+++ b/dts/bindings/interrupt-controller/xtensa,intc.yaml
@@ -1,7 +1,4 @@
-title: Xtensa Core Interrupt Controller
-
-description: |
-    This binding describes Xtensa Core Interrupt controller
+description: Xtensa Core interrupt controller
 
 compatible: "xtensa,core-intc"
 

--- a/dts/bindings/ipm/nordic,nrf-ipc.yaml
+++ b/dts/bindings/ipm/nordic,nrf-ipc.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF family IPC
-
 description: Nordic nRF family IPC (Interprocessor Communication)
 
 compatible: "nordic,nrf-ipc"

--- a/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
+++ b/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STM32 MAILBOX
-
-description: |
-  This binding gives a base representation of the STM32 IPCC
+description: STM32 IPCC MAILBOX
 
 compatible: "st,stm32-ipcc-mailbox"
 

--- a/dts/bindings/kscan/kscan.yaml
+++ b/dts/bindings/kscan/kscan.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-title: Keyboard Scan Matrix  Base Structure
-
-description: |
-    This binding gives the base structures for all Keyboard Matrix devices
+# Common properties for keyboard matrix devices
 
 include: base.yaml
 

--- a/dts/bindings/kscan/microchip,xec-kscan.yaml
+++ b/dts/bindings/kscan/microchip,xec-kscan.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-title: Microchip XEC Keyboard Scan Matrix
-
-description: |
-    This is a representation of the Microchip XEC Keyboard Matrix controller
+description: Microchip XEC keyboard matrix controller
 
 compatible: "microchip,xec-kscan"
 
@@ -16,4 +13,3 @@ properties:
 
     interrupts:
       required: true
-...

--- a/dts/bindings/led/holtek,ht16k33.yaml
+++ b/dts/bindings/led/holtek,ht16k33.yaml
@@ -1,6 +1,4 @@
-title: Holtek HT16K33 LED Driver
-
-description: Holtek HT16K33 LEDs binding
+description: Holtek HT16K33 LEDs
 
 compatible: "holtek,ht16k33"
 

--- a/dts/bindings/led/nxp,pca9633.yaml
+++ b/dts/bindings/led/nxp,pca9633.yaml
@@ -1,6 +1,4 @@
-title: NXP PCA9633 LED Driver
-
-description: NXP PCA9633 LED binding
+description: NXP PCA9633 LED
 
 compatible: "nxp,pca9633"
 

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -1,14 +1,11 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: PWM LEDs
-
 description: PWM LEDs parent node
 
 compatible: "pwm-leds"
 
 child-binding:
-    title: PWM LED node
     description: PWM LED child node
     properties:
         pwms:

--- a/dts/bindings/led/ti,lp3943.yaml
+++ b/dts/bindings/led/ti,lp3943.yaml
@@ -1,6 +1,4 @@
-title: TI LP3943 LED Driver
-
-description: TI LP3943 LED binding
+description: TI LP3943 LED
 
 compatible: "ti,lp3943"
 

--- a/dts/bindings/led/ti,lp5562.yaml
+++ b/dts/bindings/led/ti,lp5562.yaml
@@ -1,6 +1,4 @@
-title: TI LP5562 LED Driver
-
-description: TI LP5562 LED binding
+description: TI LP5562 LED
 
 compatible: "ti,lp5562"
 

--- a/dts/bindings/led_strip/apa,apa-102.yaml
+++ b/dts/bindings/led_strip/apa,apa-102.yaml
@@ -1,6 +1,4 @@
-title: APA102 SPI LED strip
-
-description: APA102 SPI LED strip binding
+description: APA102 SPI LED strip
 
 compatible: "apa,apa102"
 

--- a/dts/bindings/led_strip/colorway,lpd8803.yaml
+++ b/dts/bindings/led_strip/colorway,lpd8803.yaml
@@ -1,9 +1,7 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Colorway LPD8803 SPI LED strip
-
-description: Colorway LPD8803 SPI LED strip binding
+description: Colorway LPD8803 SPI LED strip
 
 compatible: "colorway,lpd8803"
 

--- a/dts/bindings/led_strip/colorway,lpd8806.yaml
+++ b/dts/bindings/led_strip/colorway,lpd8806.yaml
@@ -1,9 +1,7 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Colorway LPD8806 SPI LED strip
-
-description: Colorway LPD8806 SPI LED strip binding
+description: Colorway LPD8806 SPI LED strip
 
 compatible: "colorway,lpd8806"
 

--- a/dts/bindings/led_strip/worldsemi,ws2812.yaml
+++ b/dts/bindings/led_strip/worldsemi,ws2812.yaml
@@ -1,9 +1,7 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Worldsemi WS2812 SPI LED strip
-
-description: Worldsemi WS2812 SPI LED strip binding
+description: Worldsemi WS2812 SPI LED strip
 
 compatible: "worldsemi,ws2812"
 

--- a/dts/bindings/memory-controllers/nxp,imx-semc.yaml
+++ b/dts/bindings/memory-controllers/nxp,imx-semc.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP SEMC
-
-description: |
-    This binding gives a base representation of the NXP smart external memory
-    controller (SEMC)
+description: NXP Smart External Memory Controller (SEMC)
 
 compatible: "nxp,imx-semc"
 

--- a/dts/bindings/mhu/arm,mhu.yaml
+++ b/dts/bindings/mhu/arm,mhu.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: ARM MHU
-
-description: |
-    This binding gives a base representation of the ARM MHU
+description: ARM MHU (Message Handling Unit)
 
 compatible: "arm,mhu"
 

--- a/dts/bindings/misc/skyworks,sky13351.yaml
+++ b/dts/bindings/misc/skyworks,sky13351.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2019, Peter Bigot Consulting, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-title: Skyworks SKY13351 GaAs FET I/C switch
-
-description: |
-    This binding allows control of the output selectors of the SKY13351
-    SPDT switch.
+description: Output selectors on the SKY13351 GaAs SPDT FET I/C switch
 
 compatible: "skyworks,sky13351"
 

--- a/dts/bindings/mmc/mmc-spi-slot.yaml
+++ b/dts/bindings/mmc/mmc-spi-slot.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2018 Google LLC.
 # SPDX-License-Identifier: Apache-2.0
 
-title: MMC/SD/SDIO slot connected via SPI
-
 description: MMC/SD/SDIO slot connected via SPI
 
 compatible: "zephyr,mmc-spi-slot"

--- a/dts/bindings/mmc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/mmc/nxp,imx-usdhc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP i.MXRT USDHC module
-
-description: |
-    This binding specifies the NXP i.MXRT USDHC module.
+description: NXP i.MXRT USDHC module
 
 compatible: "nxp,imx-usdhc"
 

--- a/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
@@ -1,7 +1,4 @@
-title: ARMv7-M Memory Protection Unit
-
-description: |
-    This binding describes the ARMv7-M Memory Protection Unit (MPU).
+description: ARMv7-M Memory Protection Unit (MPU)
 
 compatible: "arm,armv7m-mpu"
 

--- a/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
@@ -1,7 +1,4 @@
-title: ARMv8-M Memory Protection Unit
-
-description: |
-    This binding describes the ARMv8-M Memory Protection Unit (MPU).
+description: ARMv8-M MPU (Memory Protection Unit)
 
 compatible: "arm,armv8m-mpu"
 

--- a/dts/bindings/modem/openisa,rv32m1-genfsk.yaml
+++ b/dts/bindings/modem/openisa,rv32m1-genfsk.yaml
@@ -1,11 +1,7 @@
 # Copyright 2019, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: Generic FSK
-
-description: >
-    This binding gives a base representation of the RV32M1 Generic FSK programmable
-    modem node
+description: RV32M1 Generic FSK programmable modem node
 
 compatible: "openisa,rv32m1-genfsk"
 

--- a/dts/bindings/modem/ublox,sara-r4.yaml
+++ b/dts/bindings/modem/ublox,sara-r4.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Foundries.io
 # SPDX-License-Identifier: Apache-2.0
 
-title: u-blox SARA-R4 modem
-
-description: |
-    This is a representation of the u-blox SARA-R4 modem.
+description: u-blox SARA-R4 modem
 
 compatible: "ublox,sara-r4"
 

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Foundries.io
 # SPDX-License-Identifier: Apache-2.0
 
-title: WNC-M14A2A LTE-M Modem
-
-description: |
-    This is a representation of the WNC-M14A2A LTE-M modem.
+description: WNC-M14A2A LTE-M modem
 
 compatible: "wnc,m14a2a"
 

--- a/dts/bindings/mtd/atmel,at24.yaml
+++ b/dts/bindings/mtd/atmel,at24.yaml
@@ -2,10 +2,7 @@
 # Copyright (c) 2018, Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel AT24 (and compatible) I2C EEPROM devices
-
-description: |
-    Any Atmel AT24 compatible I2C EEPROM
+description: Atmel AT24 (or compatible) I2C EEPROM
 
 compatible: "atmel,at24"
 

--- a/dts/bindings/mtd/atmel,at25.yaml
+++ b/dts/bindings/mtd/atmel,at25.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel AT25 (and compatible) SPI EEPROM devices
-
-description: >
-    Any Atmel AT25 compatible SPI EEPROM
+description: Atmel AT25 (or compatible) SPI EEPROM
 
 compatible: "atmel,at25"
 

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Peter Bigot Consulting, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-title: SPI NOR flash devices (JEDEC CFI interface)
-
-description: |
-  Any SPI NOR flash that supports the JEDEC CFI interface.
+description: SPI NOR flash that supports the JEDEC CFI interface
 
 compatible: "jedec,spi-nor"
 

--- a/dts/bindings/mtd/partition.yaml
+++ b/dts/bindings/mtd/partition.yaml
@@ -1,5 +1,3 @@
-title: Flash partitions parent
-
 description: Flash partitions parent node
 
 compatible: "fixed-partitions"
@@ -16,7 +14,6 @@ properties:
         description: number of size cells in reg property
 
 child-binding:
-    title: Flash partition
     description: Flash partition child node
     properties:
        label:

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -1,7 +1,4 @@
-title: Flash base node description
-
-description: |
-    This binding gives a base FLASH description
+description: Flash node
 
 compatible: "soc-nv-flash"
 

--- a/dts/bindings/mtd/st,stm32-eeprom.yaml
+++ b/dts/bindings/mtd/st,stm32-eeprom.yaml
@@ -1,13 +1,11 @@
 # Copyright (c) 2019 Kwon Tae-young <tykwon@m2i.co.kr>
 # SPDX-License-Identifier: Apache-2.0
 
-include: eeprom-base.yaml
-
-title: STM32 EEPROM devices
-
 description: STM32 on-chip EEPROM
 
 compatible: "st,stm32-eeprom"
+
+include: eeprom-base.yaml
 
 properties:
     reg:

--- a/dts/bindings/mtd/winbond,w25q16.yaml
+++ b/dts/bindings/mtd/winbond,w25q16.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: SPI NOR FLASH
-
-description: |
-    This binding gives a base representation of SPI slave NOR FLASH
+description: SPI slave NOR FLASH
 
 compatible: "winbond,w25q16"
 

--- a/dts/bindings/mtd/zephyr,native-posix-eeprom.yaml
+++ b/dts/bindings/mtd/zephyr,native-posix-eeprom.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-title: Zephyr Native POSIX EEPROM device
-
-description: >
-    Zephyr Native POSIX EEPROM device
+description: Zephyr Native POSIX EEPROM device
 
 compatible: "zephyr,native-posix-eeprom"
 

--- a/dts/bindings/phy/st,stm32-usbphyc.yaml
+++ b/dts/bindings/phy/st,stm32-usbphyc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Yannis Damigos
 # SPDX-License-Identifier: Apache-2.0
 
-title: STM32 USB HS PHY
-
-description: |
-    This binding gives a base representation of the STM32 USB HS PHY controller
+description: STM32 USB HS PHY controller
 
 compatible: "st,stm32-usbphyc"
 

--- a/dts/bindings/phy/usb-nop-xceiv.yaml
+++ b/dts/bindings/phy/usb-nop-xceiv.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2018, Yannis Damigos
 # SPDX-License-Identifier: Apache-2.0
 
-title: NOP USB Transceiver
-
 description: |
     This binding is to be used by all the usb transceivers which are built-in
     with USB IP

--- a/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
+++ b/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
@@ -1,7 +1,4 @@
-title: Atmel SAM0 PINMUX
-
-description: |
-    This binding gives a base representation of the Atmel SAM0 PINMUX
+description: Atmel SAM0 PINMUX
 
 compatible: "atmel,sam0-pinmux"
 

--- a/dts/bindings/pinctrl/espressif,esp32-pinmux.yaml
+++ b/dts/bindings/pinctrl/espressif,esp32-pinmux.yaml
@@ -1,9 +1,7 @@
 # Copyright (c) 2019 Mohamed ElShahawi
 # SPDX-License-Identifier: Apache-2.0
-title: ESP32 PINMUX
 
-description: >
-    This binding gives a base representation of the ESP32 PINMUX
+description: ESP32 PINMUX
 
 compatible: "espressif,esp32-pinmux"
 

--- a/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
+++ b/dts/bindings/pinctrl/intel,s1000-pinmux.yaml
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-title: Intel S1000 Pinmux
-
-description: |
-    This is a representation of the Intel S1000 SoC's pinmux node
+description: Intel S1000 pinmux
 
 compatible: "intel,s1000-pinmux"
 

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -1,7 +1,4 @@
-title: Kinetis Pinmux
-
-description: |
-    This is a representation of the Kinetis Pinmux node
+description: Kinetis pinmux node
 
 compatible: "nxp,kinetis-pinmux"
 

--- a/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
+++ b/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
@@ -1,7 +1,4 @@
-title: RV32M1 Pinmux
-
-description: |
-    This is a representation of the RV32M1 Pinmux node
+description: RV32M1 pinmux node
 
 compatible: "openisa,rv32m1-pinmux"
 

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -1,7 +1,4 @@
-title: STM32 PINMUX
-
-description: |
-    This binding gives a base representation of the STM32 PINMUX
+description: STM32 PINMUX
 
 compatible: "st,stm32-pinmux"
 

--- a/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinmux.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Brett Witherspoon
 # SPDX-License-Identifier: Apache-2.0
 
-title: TI SimpleLink CC13xx / CC26xx Pinmux
-
-description: |
-    This is a representation of the TI SimpleLink CC13xx / CC26xx pinmux node
+description: TI SimpleLink CC13xx / CC26xx pinmux node
 
 compatible: "ti,cc13xx-cc26xx-pinmux"
 

--- a/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-title: TI CC2650 Pinmux
-
-description: |
-    This is a representation of the TI CC2650 pinmux node
+description: TI CC2650 pinmux node
 
 compatible: "ti,cc2650-pinmux"
 

--- a/dts/bindings/power/nordic,nrf-power.yaml
+++ b/dts/bindings/power/nordic,nrf-power.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF power control
-
-description: |
-    This is a representation of the Nordic nRF power control node
+description: Nordic nRF power control node
 
 compatible: "nordic,nrf-power"
 

--- a/dts/bindings/power/nordic,nrf-regulators.yaml
+++ b/dts/bindings/power/nordic,nrf-regulators.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic REGULATORS
-
-description: |
-    Binding for the Nordic REGULATORS (voltage regulators control module)
+description: Nordic REGULATORS (voltage regulators control module)
 
 compatible: "nordic,nrf-regulators"
 

--- a/dts/bindings/power/nordic,nrf-vmc.yaml
+++ b/dts/bindings/power/nordic,nrf-vmc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic VMC
-
-description: |
-    Binding for the Nordic VMC (Volatile Memory Controller)
+description: Nordic VMC (Volatile Memory Controller)
 
 compatible: "nordic,nrf-vmc"
 

--- a/dts/bindings/ps2/microchip,xec-ps2.yaml
+++ b/dts/bindings/ps2/microchip,xec-ps2.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-title: Microchip XEC PS/2
-
-description: |
-    This is a representation of the Microchip XEC PS/2 controller
+description: Microchip XEC PS/2 controller
 
 compatible: "microchip,xec-ps2"
 

--- a/dts/bindings/ps2/ps2.yaml
+++ b/dts/bindings/ps2/ps2.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-title: PS/2 Base Structure
-
-description: |
-    This binding gives the base structures for all PS/2 devices
+# Common properties for PS/2 devices
 
 include: base.yaml
 

--- a/dts/bindings/pwm/atmel,sam-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam-pwm.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Aurelien Jarno
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel SAM PWM
-
-description: |
-    This binding gives a base representation of the Atmel SAM PWM
+description: Atmel SAM PWM
 
 compatible: "atmel,sam-pwm"
 

--- a/dts/bindings/pwm/fsl,imx7d-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx7d-pwm.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Diego Sueiro <diego.sueiro@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-title: i.MX7D PWM
-
-description: |
-    This binding gives a base representation of the i.MX7D PWM
+description: i.MX7D PWM
 
 compatible: "fsl,imx7d-pwm"
 

--- a/dts/bindings/pwm/microchip,xec-pwm.yaml
+++ b/dts/bindings/pwm/microchip,xec-pwm.yaml
@@ -1,13 +1,7 @@
-#
 # Copyright (c) 2019, Intel Corporation
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-title: Microchip XEC PWM
-
-description: |
-    This binding gives a base representation of the Microchip XEC PWM
+description: Microchip XEC PWM
 
 include: [pwm-controller.yaml, base.yaml]
 

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -1,7 +1,4 @@
-title: nRF PWM
-
-description: |
-    This binding gives a base representation of the nRF PWM
+description: nRF PWM
 
 compatible: "nordic,nrf-pwm"
 

--- a/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
@@ -1,7 +1,4 @@
-title: nRF SW PWM
-
-description: |
-    This binding gives a base representation of the nRFx S/W PWM
+description: nRFx S/W PWM
 
 compatible: "nordic,nrf-sw-pwm"
 

--- a/dts/bindings/pwm/nxp,flexpwm.yaml
+++ b/dts/bindings/pwm/nxp,flexpwm.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: MCUX PWM
-
-description: |
-    This binding gives a base representation of the NXP eFLEX PWM module which
-    is supposed to contain mcux-pwm submodules.
+description: NXP eFLEX PWM module with mcux-pwm submodules
 
 compatible: "nxp,flexpwm"
 

--- a/dts/bindings/pwm/nxp,imx-pwm.yaml
+++ b/dts/bindings/pwm/nxp,imx-pwm.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: MCUX PWM
-
-description: |
-    This binding gives a base representation of the NXP MCUX PWM
+description: NXP MCUX PWM
 
 compatible: "nxp,imx-pwm"
 

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: Kinetis FTM
-
-description: |
-    This binding gives a base representation of the Kinetis FTM
+description: Kinetis FTM
 
 compatible: "nxp,kinetis-ftm"
 

--- a/dts/bindings/pwm/sifive,pwm0.yaml
+++ b/dts/bindings/pwm/sifive,pwm0.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-title: SiFive PWM
-
-description: |
-    This binding gives a base representation of the SiFive PWM
+description: SiFive PWM
 
 compatible: "sifive,pwm0"
 

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -1,7 +1,4 @@
-title: STM32 PWM
-
-description: |
-    This binding gives a base representation of the STM32 PWM
+description: STM32 PWM
 
 compatible: "st,stm32-pwm"
 

--- a/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
+++ b/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Foundries.io
 # SPDX-License-Identifier: Apache-2.0
 
-title: RV32M1 PCC (Peripheral Clock Control)
-
-description: |
-    This is a representation of the RV32M1 PCC IP node
+description: RV32M1 PCC (Peripheral Clock Control) IP node
 
 compatible: "openisa,rv32m1-pcc"
 

--- a/dts/bindings/rng/atmel,sam-trng.yaml
+++ b/dts/bindings/rng/atmel,sam-trng.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2018, Aurelien Jarno
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel SAM TRNG (True Random Number Generator)
-
 description: |
     This binding gives a base representation of the Atmel SAM RNG
 

--- a/dts/bindings/rng/espressif,esp32-trng.yaml
+++ b/dts/bindings/rng/espressif,esp32-trng.yaml
@@ -1,12 +1,11 @@
 # Copyright (c) 2019, Mohamed ElShahawi <ExtremeGTX@hotmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-title: Espressif ESP32 TRNG (True Random Number Generator)
-
 description: |
-    The TRNG use the noise in the Wi-Fi/BT RF system.
-    When Wi-Fi and BT are disabled, the random number generator will give out
-    pseudo-random numbers.
+    Espressif ESP32 TRNG (True Random Number Generator).
+
+    The TRNG uses the noise in the Wi-Fi/BT RF system. When Wi-Fi and BT are
+    disabled, the random number generator will give out pseudo-random numbers.
 
 compatible: "espressif,esp32-trng"
 

--- a/dts/bindings/rng/nordic,nrf-rng.yaml
+++ b/dts/bindings/rng/nordic,nrf-rng.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF family RNG
-
 description: Nordic nRF family RNG (Random Number Generator)
 
 compatible: "nordic,nrf-rng"

--- a/dts/bindings/rng/nxp,kinetis-rnga.yaml
+++ b/dts/bindings/rng/nxp,kinetis-rnga.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Kinetis RNGA (Random Number Generator Accelerator)
-
-description: |
-    This binding gives a base representation of the Kinetis RNGA
+description: Kinetis RNGA (Random Number Generator Accelerator)
 
 compatible: "nxp,kinetis-rnga"
 

--- a/dts/bindings/rng/nxp,kinetis-trng.yaml
+++ b/dts/bindings/rng/nxp,kinetis-trng.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Kinetis TRNG (True Random Number Generator)
-
-description: |
-    This binding gives a base representation of the Kinetis RNGA
+description: Kinetis TRNG (True Random Number Generator)
 
 compatible: "nxp,kinetis-trng"
 

--- a/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
+++ b/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Brett Witherspoon
 # SPDX-License-Identifier: Apache-2.0
 
-title: TI SimpleLink CC13xx / CC26xx True Random Number Generator (TRNG)
-
-description: |
-    This is a representation of the TI SimpleLink CC13xx / CC26xx TRNG node
+description: TI SimpleLink CC13xx / CC26xx TRNG (True Random Number Generator)
 
 compatible: "ti,cc13xx-cc26xx-trng"
 

--- a/dts/bindings/rtc/atmel,sam0-rtc.yaml
+++ b/dts/bindings/rtc/atmel,sam0-rtc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 omSquare s.r.o.
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel SAM0 RTC
-
-description: |
-    This binding gives a base representation of the Atmel SAM0 RTC
+description: Atmel SAM0 RTC
 
 compatible: "atmel,sam0-rtc"
 

--- a/dts/bindings/rtc/microchip,xec-timer.yaml
+++ b/dts/bindings/rtc/microchip,xec-timer.yaml
@@ -1,13 +1,7 @@
-#
 # Copyright (c) 2019, Intel Corporation
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-title: Microchip XEC basic timer
-
-description: |
-    This binding gives a base representation of the Microchip XEC basic timer
+description: Microchip XEC basic timer
 
 compatible: "microchip,xec-timer"
 

--- a/dts/bindings/rtc/nordic,nrf-rtc.yaml
+++ b/dts/bindings/rtc/nordic,nrf-rtc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF Real Time Counter
-
-description: |
-    This is a representation of the Nordic nRF RTC node
+description: Nordic nRF RTC (Real-Time Counter)
 
 compatible: "nordic,nrf-rtc"
 

--- a/dts/bindings/rtc/nxp,kinetis-rtc.yaml
+++ b/dts/bindings/rtc/nxp,kinetis-rtc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, blik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-title: Kinetis RTC
-
-description: |
-    This binding gives a base representation of the Kinetis RTC
+description: Kinetis RTC
 
 compatible: "nxp,kinetis-rtc"
 

--- a/dts/bindings/rtc/silabs,gecko-rtcc.yaml
+++ b/dts/bindings/rtc/silabs,gecko-rtcc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Piotr Mienkowski
 # SPDX-License-Identifier: Apache-2.0
 
-title: Silabs Gecko Real Time Counter
-
-description: |
-    This is a representation of the Silabs Gecko RTCC node
+description: Silabs Gecko RTCC (Real-Time Counter)
 
 compatible: "silabs,gecko-rtcc"
 

--- a/dts/bindings/rtc/st,stm32-rtc.yaml
+++ b/dts/bindings/rtc/st,stm32-rtc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Workaround GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-title: STM32 RTC
-
-description: |
-    This binding gives a base representation of the STM32 RTC
+description: STM32 RTC
 
 compatible: "st,stm32-rtc"
 

--- a/dts/bindings/rtc/ti,cc13xx-cc26xx-rtc.yaml
+++ b/dts/bindings/rtc/ti,cc13xx-cc26xx-rtc.yaml
@@ -4,10 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-title: TI SimpleLink CC13xx/CC26xx RTC
-
-description: |
-    This binding gives a base representation of the TI SimpleLink CC13xx/CC26xx RTC
+description: TI SimpleLink CC13xx/CC26xx RTC
 
 compatible: "ti,cc13xx-cc26xx-rtc"
 

--- a/dts/bindings/sensor/adi,adt7420.yaml
+++ b/dts/bindings/sensor/adi,adt7420.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Analog Devices Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-title: ADT7420 16-Bit Digital I2C Temperature Sensor
-
-description: |
-    This is a representation of the ADT7420 16-Bit Digital I2C Temperature Sensor
+description: ADT7420 16-Bit digital I2C temperature sensor
 
 compatible: "adi,adt7420"
 

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: ADXL362 Three Axis SPI accelerometer
-
-description: |
-    This is a representation of the ADXL362 Three Axis SPI accelerometer
+description: ADXL362 3-axis SPI accelerometer
 
 compatible: "adi,adxl362"
 

--- a/dts/bindings/sensor/adi,adxl372-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl372-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Analog Devices Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-title: ADXL372 Three Axis High-g I2C/SPI accelerometer
-
-description: |
-    This is a representation of the ADXL372 Three Axis High-g I2C/SPI accelerometer
+description: ADXL372 3-axis high-g I2C/SPI accelerometer
 
 compatible: "adi,adxl372"
 

--- a/dts/bindings/sensor/adi,adxl372-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl372-spi.yaml
@@ -2,11 +2,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: ADXL372 Three Axis High-g I2C/SPI accelerometer
-
-description: |
-    This is a representation of the ADXL372 Three Axis High-g accelerometer,
-    accessed through SPI bus
+description: ADXL372 3-axis high-g accelerometer, accessed through SPI bus
 
 compatible: "adi,adxl372"
 

--- a/dts/bindings/sensor/ams,ccs811.yaml
+++ b/dts/bindings/sensor/ams,ccs811.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: AMS (Austria Mikro Systeme) Digital Air Quality Sensor CCS811
-
-description: |
-    This binding gives a base representation of CCS811 digital air quality
-    sensor
+description: CCS811 digital air quality sensor
 
 compatible: "ams,ccs811"
 

--- a/dts/bindings/sensor/ams,ens210.yaml
+++ b/dts/bindings/sensor/ams,ens210.yaml
@@ -1,11 +1,8 @@
 # Copyright (c) 2018, Alexander Wachter
 # SPDX-License-Identifier: Apache-2.0
 
-title: AMS (Austria Mikro Systeme) Relative Humidity and Temperature Sensor
-
 description: |
-    This binding gives a base representation of ens210 Relative Humidity and
-    Temperature Sensor
+    AMS (Austria Mikro Systeme) ens210 Relative Humidity and Temperature Sensor
 
 compatible: "ams,ens210"
 

--- a/dts/bindings/sensor/ams,iaqcore.yaml
+++ b/dts/bindings/sensor/ams,iaqcore.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2018, Alexander Wachter
 # SPDX-License-Identifier: Apache-2.0
 
-title: AMS (Austria Mikro Systeme) Indoor Air Quality Sensor iAQ-core
-
-description: |
-    This binding gives a base representation of iAQ-core indoor air quality
-    sensor
+description: iAQ-core indoor air quality sensor
 
 compatible: "ams,iaqcore"
 

--- a/dts/bindings/sensor/avago,apds9960.yaml
+++ b/dts/bindings/sensor/avago,apds9960.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Phytec Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-title: APDS9960 Digital Proximity, Ambient Light, RGB and Gesture Sensor
-
-description: |
-    This is a representation of the APDS9960 sensor
+description: APDS9960 digital proximity, ambient light, RGB, and gesture sensor
 
 compatible: "avago,apds9960"
 

--- a/dts/bindings/sensor/bosch,bmc150_magn.yaml
+++ b/dts/bindings/sensor/bosch,bmc150_magn.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Bosch BMC150 Magnetometer
-
 description: |
     Bosch BMC150 Magnetometer.  See more info at:
     https://www.bosch-sensortec.com/bst/products/all_products/bmc150

--- a/dts/bindings/sensor/bosch,bme280-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bme280-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: BME280 Integrated environmental sensor
-
-description: |
-    This is a representation of the BME280 Integrated environmental sensor
+description: BME280 integrated environmental sensor
 
 compatible: "bosch,bme280"
 

--- a/dts/bindings/sensor/bosch,bme280-spi.yaml
+++ b/dts/bindings/sensor/bosch,bme280-spi.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: BME280 Integrated environmental sensor
-
-description: |
-    This is a representation of the BME280 Integrated environmental sensor
+description: BME280 integrated environmental sensor
 
 compatible: "bosch,bme280"
 

--- a/dts/bindings/sensor/bosch,bme680-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bme680-i2c.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2018, Bosch Sensortec GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-title: BME680 integrated environmental sensor
-
 description: |
     The BME680 is an integrated environmental sensor that measures
     temperature, pressure, humidity and air quality

--- a/dts/bindings/sensor/bosch,bmg160.yaml
+++ b/dts/bindings/sensor/bosch,bmg160.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Bosch BMG160 gyroscope
-
 description: |
     Bosch BMG160 gyroscope.  See more info at:
     https://www.bosch-sensortec.com/bst/products/all_products/bmg160

--- a/dts/bindings/sensor/bosch,bmi160.yaml
+++ b/dts/bindings/sensor/bosch,bmi160.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: BMI160 Inertial measurement unit
-
-description: |
-    This is a representation of the BMI160 Inertial measurement unit
+description: BMI160 inertial measurement unit
 
 compatible: "bosch,bmi160"
 

--- a/dts/bindings/sensor/bosch,bmm150.yaml
+++ b/dts/bindings/sensor/bosch,bmm150.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Bosch BMM150 Geomagnetic sensor
-
 description: |
     Bosch BMM150 Geomagnetic sensor.  See more info at:
     https://www.bosch-sensortec.com/bst/products/all_products/bmm150

--- a/dts/bindings/sensor/honeywell,hmc5883l.yaml
+++ b/dts/bindings/sensor/honeywell,hmc5883l.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2019 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Honeywell MEMS sensors HMC5883L
-
-description: |
-    This binding gives a base representation of the HMC5883L 3-axis
-    magnetometer sensor
+description: Honeywell HMC5883L 3-axis magnetometer sensor
 
 compatible: "honeywell,hmc5883l"
 

--- a/dts/bindings/sensor/hoperf,hp206c.yaml
+++ b/dts/bindings/sensor/hoperf,hp206c.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: HopeRF Electronic HP206C precision barometer and altimeter
-
 description: |
     HopeRF Electronic HP206C precision barometer and altimeter.
     See more info at:

--- a/dts/bindings/sensor/hoperf,th02.yaml
+++ b/dts/bindings/sensor/hoperf,th02.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: TH02 Temperature and Humidity sensor
-
 description: |
     TH02 Temperature and Humidity sensor. See datasheet at
     http://www.datasheetspdf.com/mobile/748107/TH02.html

--- a/dts/bindings/sensor/isil,isl29035.yaml
+++ b/dts/bindings/sensor/isil,isl29035.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Intersil ISL29035 Light Sensor
-
 description: |
     Intersil ISL29035 Light Sensor. See datasheet at
     https://www.renesas.com/us/en/www/doc/datasheet/isl29035.pdf

--- a/dts/bindings/sensor/max,max30101.yaml
+++ b/dts/bindings/sensor/max,max30101.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: MAX30101 heart rate sensor
-
-description: |
-    This is a representation of the MAX30101 heart rate sensor
+description: MAX30101 heart rate sensor
 
 compatible: "max,max30101"
 

--- a/dts/bindings/sensor/maxim,max44009.yaml
+++ b/dts/bindings/sensor/maxim,max44009.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Maxim MAX44009 Ambient Light Sensor
-
 description: |
     Maxim MAX44009 Ambient Light Sensor. See datasheet at
     https://datasheets.maximintegrated.com/en/ds/MAX44009.pdf

--- a/dts/bindings/sensor/meas,ms5607-spi.yaml
+++ b/dts/bindings/sensor/meas,ms5607-spi.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019, Thomas Schmid <tom@lfence.de>
 # SPDX-License-Identifier: Apache-2.0
 
-title: TE Connectivity digital pressure sensor MS5607
-
 description: |
     TE Connectivity MS5607 digital pressure and temperature sensor.
     The Datasheet is at https://www.te.com/usa-en/product-CAT-BLPS0035.html

--- a/dts/bindings/sensor/meas,ms5837.yaml
+++ b/dts/bindings/sensor/meas,ms5837.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2018, Jan Van Winkel <jan.van_winkel@dxplore.eu>
 # SPDX-License-Identifier: Apache-2.0
 
-title: TE Connectivity digital pressure sensor MS5837
-
-description: |
-    This binding gives a base representation of the MS5837 digital pressure
-    sensor
+description: TE Connectivity MS5837 digital pressure sensor
 
 compatible: "meas,ms5837"
 

--- a/dts/bindings/sensor/microchip,mcp9808.yaml
+++ b/dts/bindings/sensor/microchip,mcp9808.yaml
@@ -1,11 +1,9 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Microchip MCP9808 Digital Temperature Sensor
-
 description: |
-    Microchip MCP9808 Digital Temperature Sensor
-    http://ww1.microchip.com/downloads/en/DeviceDoc/25095A.pdf
+    Microchip MCP9808 Digital Temperature Sensor. See
+    http://ww1.microchip.com/downloads/en/DeviceDoc/25095A.pdf.
 
 compatible: "microchip,mcp9808"
 

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF Family QDEC node
-
-description: |
-    This is a representation of the Nordic nRF QDEC node
+description: Nordic nRF QDEC node
 
 compatible: "nordic,nrf-qdec"
 

--- a/dts/bindings/sensor/nordic,nrf-temp.yaml
+++ b/dts/bindings/sensor/nordic,nrf-temp.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF Family TEMP node
-
-description: |
-    This is a representation of the Nordic nRF TEMP node
+description: Nordic nRF family TEMP node
 
 compatible: "nordic,nrf-temp"
 

--- a/dts/bindings/sensor/nxp,fxas21002.yaml
+++ b/dts/bindings/sensor/nxp,fxas21002.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: FXAS21002 3-axis gyroscope
-
-description: |
-    This is a representation of the FXAS21002 3-axis gyroscope sensor
+description: FXAS21002 3-axis gyroscope sensor
 
 compatible: "nxp,fxas21002"
 

--- a/dts/bindings/sensor/nxp,fxos8700.yaml
+++ b/dts/bindings/sensor/nxp,fxos8700.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: FXOS8700 6-axis accelerometer/magnetometer
-
-description: |
-    This is a representation of the FXOS8700 6-axis accelerometer/magnetometer
-    sensor
+description: FXOS8700 6-axis accelerometer/magnetometer sensor
 
 compatible: "nxp,fxos8700"
 

--- a/dts/bindings/sensor/panasonic,amg88xx.yaml
+++ b/dts/bindings/sensor/panasonic,amg88xx.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Phytec Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-title: Panasonic AMG88XX 8x8 (64) pixel infrared array sensor
-
-description: |
-    This is a representation of the AMG88XX sensor
+description: Panasonic AMG88XX 8x8 (64) pixel infrared array sensor
 
 compatible: "panasonic,amg88xx"
 

--- a/dts/bindings/sensor/semtech,sx9500.yaml
+++ b/dts/bindings/sensor/semtech,sx9500.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Semtech SX9500 capacitive proximity/button
-
 description: |
     Semtech SX9500 capacitive proximity/button. See more info at
     https://www.semtech.com/products/smart-sensing/touch-proximity-devices/sx9500

--- a/dts/bindings/sensor/sensirion,sht3xd.yaml
+++ b/dts/bindings/sensor/sensirion,sht3xd.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2018, Peter Bigot Consulting, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-title: Sensirion Humidity Sensor SHT-3x-DIS
-
-description: |
-    This binding gives a base representation of SHT3x-DIS humidity and temperature
-    sensor
+description: Sensirion Humidity SHT3x-DIS humidity and temperature sensor
 
 compatible: "sensirion,sht3xd"
 

--- a/dts/bindings/sensor/silabs,si7006.yaml
+++ b/dts/bindings/sensor/silabs,si7006.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Electronut Labs
 # SPDX-License-Identifier: Apache-2.0
 
-title: Si7006 Temperature and Humidity sensor
-
-description: |
-    This is a representation of Si7006 Temperature and Humidity sensor
+description: Si7006 temperature and humidity sensor
 
 compatible: "silabs,si7006"
 

--- a/dts/bindings/sensor/silabs,si7060.yaml
+++ b/dts/bindings/sensor/silabs,si7060.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Actinius
 # SPDX-License-Identifier: Apache-2.0
 
-title: Si7060 Temperature sensor
-
-description: |
-    This is a representation of Si7060 Temperature sensor
+description: Si7060 temperature sensor
 
 compatible: "silabs,si7060"
 

--- a/dts/bindings/sensor/st,hts221.yaml
+++ b/dts/bindings/sensor/st,hts221.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2017, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors HTS221
-
-description: |
-    This binding gives a base representation of HTS221 humidity and temperature
-    sensor
+description: STMicroelectronics HTS221 humidity and temperature sensor
 
 compatible: "st,hts221"
 

--- a/dts/bindings/sensor/st,iis3dhhc-spi.yaml
+++ b/dts/bindings/sensor/st,iis3dhhc-spi.yaml
@@ -1,11 +1,8 @@
 # Copyright (c) 2019 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors IIS3DHHC SPI
-
 description: |
-    This binding gives a base representation of IIS3DHHC 3-axis accelerometer
-    accessed through SPI bus
+    STMicroelectronics IIS3DHHC 3-axis accelerometer accessed through SPI bus
 
 compatible: "st,iis3dhhc"
 

--- a/dts/bindings/sensor/st,lis2dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dh-i2c.yaml
@@ -1,11 +1,8 @@
 # Copyright (c) 2018 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LIS2DH I2C
-
 description: |
-    This binding gives a base representation of LIS2DH 3-axis accelerometer
-    accessed through I2C bus
+    STMicroelectronics LIS2DH 3-axis accelerometer accessed through I2C bus
 
 compatible: "st,lis2dh"
 

--- a/dts/bindings/sensor/st,lis2dh-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dh-spi.yaml
@@ -1,11 +1,8 @@
 # Copyright (c) 2018 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LIS2DH SPI
-
 description: |
-    This binding gives a base representation of LIS2DH 3-axis accelerometer
-    accessed through SPI bus
+    STMicroelectronics LIS2DH 3-axis accelerometer accessed through SPI bus
 
 compatible: "st,lis2dh"
 

--- a/dts/bindings/sensor/st,lis2dh12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dh12-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LIS2DH12
-
-description: |
-    This binding gives a base representation of LIS2DH12 3-axis accelerometer
+description: STMicroelectronics LIS2DH12 3-axis accelerometer
 
 compatible: "st,lis2dh12"
 

--- a/dts/bindings/sensor/st,lis2ds12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LIS2DS12
-
-description: |
-    This binding gives a base representation of LIS2DS12 3-axis accelerometer
+description: STMicroelectronics LIS2DS12 3-axis accelerometer
 
 compatible: "st,lis2ds12"
 

--- a/dts/bindings/sensor/st,lis2ds12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-spi.yaml
@@ -1,11 +1,8 @@
 # Copyright (c) 2019 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LIS2DS12 SPI
-
 description: |
-    This binding gives a base representation of LIS2DS12 3-axis accelerometer
-    accessed through SPI bus
+    STMicroelectronics LIS2DS12 3-axis accelerometer accessed through SPI bus
 
 compatible: "st,lis2ds12"
 

--- a/dts/bindings/sensor/st,lis2dw12-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LIS2DW12
-
-description: |
-    This binding gives a base representation of LIS2DW12 3-axis accelerometer
+description: STMicroelectronics LIS2DW12 3-axis accelerometer
 
 compatible: "st,lis2dw12"
 

--- a/dts/bindings/sensor/st,lis2dw12-spi.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-spi.yaml
@@ -1,11 +1,8 @@
 # Copyright (c) 2019 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LIS2DW12 SPI
-
 description: |
-    This binding gives a base representation of LIS2DW12 3-axis accelerometer
-    accessed through SPI bus
+    STMicroelectronics LIS2DW12 3-axis accelerometer accessed through SPI bus
 
 compatible: "st,lis2dw12"
 

--- a/dts/bindings/sensor/st,lis2mdl-i2c.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-i2c.yaml
@@ -1,11 +1,8 @@
 # Copyright (c) 2018 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LIS2MDL I2C
-
 description: |
-    This binding gives a base representation of LIS2MDL magnetometer
-    accessed through I2C bus
+    STMicroelectronics LIS2MDL magnetometer accessed through I2C bus
 
 compatible: "st,lis2mdl"
 

--- a/dts/bindings/sensor/st,lis2mdl-spi.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-spi.yaml
@@ -1,11 +1,8 @@
 # Copyright (c) 2019 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LIS2MDL SPI
-
 description: |
-    This binding gives a base representation of LIS2MDL magnetometer
-    accessed through SPI bus
+    STMicroelectronics LIS2MDL magnetometer accessed through SPI bus
 
 compatible: "st,lis2mdl"
 

--- a/dts/bindings/sensor/st,lis3dh-i2c.yaml
+++ b/dts/bindings/sensor/st,lis3dh-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LIS3DH
-
-description: |
-    This binding gives a base representation of LIS3DH 3-axis accelerometer
+description: STMicroelectronics LIS3DH 3-axis accelerometer
 
 compatible: "st,lis3dh"
 

--- a/dts/bindings/sensor/st,lis3mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis3mdl-magn.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LIS3MDL
-
-description: |
-    This binding gives a base representation of LIS3MDL magnetometer
+description: STMicroelectronics LIS3MDL magnetometer
 
 compatible: "st,lis3mdl-magn"
 

--- a/dts/bindings/sensor/st,lps22hb-press.yaml
+++ b/dts/bindings/sensor/st,lps22hb-press.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LPS22HB
-
-description: |
-    This binding gives a base representation of LPS22HB pressure sensor
+description: STMicroelectronics LPS22HB pressure sensor
 
 compatible: "st,lps22hb-press"
 

--- a/dts/bindings/sensor/st,lps22hh-i2c.yaml
+++ b/dts/bindings/sensor/st,lps22hh-i2c.yaml
@@ -1,11 +1,9 @@
 # Copyright (c) 2019 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LPS22HH
-
 description: |
-    This binding gives a base representation of LPS22HH pressure and
-    temperature sensor connected to I2C bus
+    STMicroelectronics LPS22HH pressure and temperature sensor connected to I2C
+    bus
 
 compatible: "st,lps22hh"
 

--- a/dts/bindings/sensor/st,lps22hh-spi.yaml
+++ b/dts/bindings/sensor/st,lps22hh-spi.yaml
@@ -1,11 +1,9 @@
 # Copyright (c) 2019 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LPS22HH
-
 description: |
-    This binding gives a base representation of LPS22HH pressure and
-    temperature sensor connected to SPI bus
+    STMicroelectronics LPS22HH pressure and temperature sensor connected to SPI
+    bus
 
 compatible: "st,lps22hh"
 

--- a/dts/bindings/sensor/st,lps25hb-press.yaml
+++ b/dts/bindings/sensor/st,lps25hb-press.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LPS25HB
-
-description: |
-    This binding gives a base representation of LPS25HB pressure sensor
+description: STMicroelectronics LPS25HB pressure sensor
 
 compatible: "st,lps25hb-press"
 

--- a/dts/bindings/sensor/st,lsm303agr-accel-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm303agr-accel-i2c.yaml
@@ -1,11 +1,8 @@
 # Copyright (c) 2019 Grinn
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LSM303AGR I2C
-
-description: >
-    This binding gives a base representation of LSM303AGR 3-axis accelerometer
-    accessed through I2C bus
+description: |
+    STMicroelectronics LSM303AGR 3-axis accelerometer accessed through I2C bus
 
 compatible: "st,lsm303agr-accel"
 

--- a/dts/bindings/sensor/st,lsm303agr-accel-spi.yaml
+++ b/dts/bindings/sensor/st,lsm303agr-accel-spi.yaml
@@ -1,11 +1,8 @@
 # Copyright (c) 2019 Grinn
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LSM303AGR SPI
-
-description: >
-    This binding gives a base representation of LSM303AGR 3-axis accelerometer
-    accessed through SPI bus
+description: |
+    STMicroelectronics LSM303AGR 3-axis accelerometer accessed through SPI bus
 
 compatible: "st,lsm303agr-accel"
 

--- a/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
+++ b/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2018 Philémon Jaermann
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LSM303DLHC
-
 description: |
     This binding gives a base representation of LSM303DLHC acceleration sensor
 

--- a/dts/bindings/sensor/st,lsm303dlhc-magn.yaml
+++ b/dts/bindings/sensor/st,lsm303dlhc-magn.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Philémon Jaermann
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LSM303DLHC
-
-description: |
-    This binding gives a base representation of LSM303DLHC magnetometer sensor
+description: STMicroelectronics LSM303DLHC magnetometer sensor
 
 compatible: "st,lsm303dlhc-magn"
 

--- a/dts/bindings/sensor/st,lsm6ds0.yaml
+++ b/dts/bindings/sensor/st,lsm6ds0.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LSM6DS0
-
-description: |
-    This binding gives a base representation of LSM6DS0 6-axis accelerometer
-    and gyrometer
+description: STMicroelectronics LSM6DS0 6-axis accelerometer and gyrometer
 
 compatible: "st,lsm6ds0"
 

--- a/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2017, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LSM6DSL
-
-description: |
-    This binding gives a base representation of LSM6DSL 6-axis accelerometer
-    and gyrometer
+description: STMicroelectronics LSM6DSL 6-axis accelerometer and gyrometer
 
 compatible: "st,lsm6dsl"
 

--- a/dts/bindings/sensor/st,lsm6dsl-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-spi.yaml
@@ -1,11 +1,9 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LSM6DSL SPI
-
 description: |
-    This binding gives a base representation of LSM6DSL 6-axis accelerometer
-    and gyrometer accessed through SPI bus
+    STMicroelectronics LSM6DSL 6-axis accelerometer and gyrometer accessed
+    through SPI bus
 
 compatible: "st,lsm6dsl"
 

--- a/dts/bindings/sensor/st,lsm6dso-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-i2c.yaml
@@ -1,11 +1,9 @@
 # Copyright (c) 2019 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LSM6DSO
-
 description: |
-    This binding gives a base representation of LSM6DSO 6-axis IMU
-    sensor accessed through I2C bus
+    STMicroelectronics LSM6DSO 6-axis IMU (Inertial Measurement Unit) sensor
+    accessed through I2C bus
 
 compatible: "st,lsm6dso"
 

--- a/dts/bindings/sensor/st,lsm6dso-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-spi.yaml
@@ -1,11 +1,9 @@
 # Copyright (c) 2019 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LSM6DSO SPI
-
 description: |
-    This binding gives a base representation of LSM6DSO 6-axis IMU
-    sensor accessed through SPI bus
+    STMicroelectronics LSM6DSO 6-axis IMU (Inertial Measurement Unit) sensor
+    accessed through SPI bus
 
 compatible: "st,lsm6dso"
 

--- a/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LSM9DS0-GYRO
-
-description: |
-    This binding gives a base representation of LSM9DS0 3-axis gyro
+description: STMicroelectronics LSM9DS0-GYRO 3-axis gyro
 
 compatible: "st,lsm9ds0-gyro"
 

--- a/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors LSM9DS0-MFD
-
-description: |
-    This binding gives a base representation of LSM9DS0 3-axis accelerometer + magnetometer
+description: STMicroelectronics LSM9DS0 3-axis accelerometer + magnetometer
 
 compatible: "st,lsm9ds0-mfd"
 

--- a/dts/bindings/sensor/st,stts751-i2c.yaml
+++ b/dts/bindings/sensor/st,stts751-i2c.yaml
@@ -1,11 +1,8 @@
 # Copyright (c) 2019 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors STTS751
-
 description: |
-    This binding gives a base representation of STTS751
-    temperature sensor connected to I2C bus
+    STMicroelectronics STTS751 temperature sensor connected to I2C bus
 
 compatible: "st,stts751"
 

--- a/dts/bindings/sensor/st,vl53l0x.yaml
+++ b/dts/bindings/sensor/st,vl53l0x.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics MEMS sensors VL53L0X
-
-description: |
-    This binding gives a base representation of VL53L0X Time Of Flight sensor
+description: STMicroelectronics VL53L0X Time of Flight sensor
 
 compatible: "st,vl53l0x"
 

--- a/dts/bindings/sensor/ti,hdc.yaml
+++ b/dts/bindings/sensor/ti,hdc.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Phytec Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-title: Texas Instruments Temperature and Humidity Sensor
-
-description: |
-    This is a representation of the TI Temperature and Humidity sensor (e.g. HDC1008)
+description: Texas Instruments temperature and humidity sensor (e.g. HDC1008)
 
 compatible: "ti,hdc"
 

--- a/dts/bindings/sensor/ti,opt3001.yaml
+++ b/dts/bindings/sensor/ti,opt3001.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Actinius
 # SPDX-License-Identifier: Apache-2.0
 
-title: Texas Instruments OPT3001 Ambient light sensor
-
-description: |
-    This is a representation of the Texas Instruments OPT3001 Ambient light sensor
+description: Texas Instruments OPT3001 ambient light sensor
 
 compatible: "ti,opt3001"
 

--- a/dts/bindings/sensor/ti,tmp007.yaml
+++ b/dts/bindings/sensor/ti,tmp007.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: TI TMP007 Digital Temperature Sensor
-
 description: |
     TMP007 Digital Temperature Sensor.  See datasheet at
     https://cdn-shop.adafruit.com/datasheets/tmp007.pdf

--- a/dts/bindings/sensor/ti,tmp112.yaml
+++ b/dts/bindings/sensor/ti,tmp112.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: TI TMP112 Digital Temperature Sensor
-
 description: |
     TMP112 Digital Temperature Sensor.  See more info at
     https://www.ti.com/product/TMP112

--- a/dts/bindings/sensor/ti,tmp116.yaml
+++ b/dts/bindings/sensor/ti,tmp116.yaml
@@ -1,13 +1,7 @@
-#
 # Copyright (c) 2019 Centaur Analytics, Inc
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-title: Texas Instruments Temperature Sensor TMP116
-
-description: |
-    This is a representation of the TI Temperature sensor TMP116
+description: Texas Instruments TMP116 temperature sensor
 
 compatible: "ti,tmp116"
 

--- a/dts/bindings/serial/altera,jtag-uart.yaml
+++ b/dts/bindings/serial/altera,jtag-uart.yaml
@@ -1,7 +1,4 @@
-title: Altera JTAG UART
-
-description: |
-    This binding gives a base representation of the Altera Jtag UART
+description: Altera JTAG UART
 
 compatible: "altera,jtag-uart"
 

--- a/dts/bindings/serial/arm,cmsdk-uart.yaml
+++ b/dts/bindings/serial/arm,cmsdk-uart.yaml
@@ -1,7 +1,4 @@
-title: ARM CMSDK UART
-
-description: |
-    This binding gives a base representation of the ARM CMSDK UART
+description: ARM CMSDK UART
 
 compatible: "arm,cmsdk-uart"
 

--- a/dts/bindings/serial/arm,pl011.yaml
+++ b/dts/bindings/serial/arm,pl011.yaml
@@ -1,7 +1,4 @@
-title: ARM PL011 UART
-
-description: |
-    This binding gives a base representation of the ARM PL011 UART
+description: ARM PL011 UART
 
 compatible: "arm,pl011"
 

--- a/dts/bindings/serial/atmel,sam-uart.yaml
+++ b/dts/bindings/serial/atmel,sam-uart.yaml
@@ -1,7 +1,4 @@
-title: SAM Family UART
-
-description: |
-    This binding gives a base representation of the SAM UART
+description: SAM family UART
 
 compatible: "atmel,sam-uart"
 

--- a/dts/bindings/serial/atmel,sam-usart.yaml
+++ b/dts/bindings/serial/atmel,sam-usart.yaml
@@ -1,7 +1,4 @@
-title: Atmel SAM Family USART
-
-description: |
-    This binding gives a base representation of the Atmel SAM USART
+description: Atmel SAM family USART
 
 compatible: "atmel,sam-usart"
 

--- a/dts/bindings/serial/atmel,sam0-uart.yaml
+++ b/dts/bindings/serial/atmel,sam0-uart.yaml
@@ -1,7 +1,4 @@
-title: Atmel SAM0 SERCOM UART driver
-
-description: |
-    This binding gives a base representation of the Atmel SAM0 SERCOM UART driver
+description: Atmel SAM0 SERCOM UART driver
 
 compatible: "atmel,sam0-uart"
 

--- a/dts/bindings/serial/cypress,psoc6-uart.yaml
+++ b/dts/bindings/serial/cypress,psoc6-uart.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Cypress
 # SPDX-License-Identifier: Apache-2.0
 
-title: CYPRESS UART
-
-description: |
-    This binding gives a base representation of the Cypress UART
+description: Cypress UART
 
 compatible: "cypress,psoc6-uart"
 

--- a/dts/bindings/serial/espressif,esp32-uart.yaml
+++ b/dts/bindings/serial/espressif,esp32-uart.yaml
@@ -1,7 +1,4 @@
-title: ESP32 Uart
-
-description: |
-    This binding gives a base representation of the ESP32 UART
+description: ESP32 UART
 
 compatible: "espressif,esp32-uart"
 

--- a/dts/bindings/serial/litex,uart0.yaml
+++ b/dts/bindings/serial/litex,uart0.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 - 2019 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-title: LiteX UART
-
-description: |
-    This binding gives a base representation of the LiteX UART
+description: LiteX UART
 
 compatible: "litex,uart0"
 

--- a/dts/bindings/serial/microsemi,coreuart.yaml
+++ b/dts/bindings/serial/microsemi,coreuart.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: SIFIVE UART
-
-description: |
-    This binding gives a base representation of the SIFIVE UART
+description: SiFive UART
 
 compatible: "microsemi,coreuart"
 

--- a/dts/bindings/serial/nordic,nrf-uart.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart.yaml
@@ -1,7 +1,4 @@
-title: Nordic UART
-
-description: |
-    This binding gives a base representation of the Nordic UART
+description: Nordic UART
 
 compatible: "nordic,nrf-uart"
 

--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -1,7 +1,4 @@
-title: Nordic UARTE
-
-description: |
-    This binding gives a base representation of the Nordic UARTE
+description: Nordic UARTE
 
 compatible: "nordic,nrf-uarte"
 

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -1,7 +1,4 @@
-title: ns16550
-
-description: |
-    This binding gives a base representation of the ns16550 UART
+description: ns16550 UART
 
 compatible: "ns16550"
 

--- a/dts/bindings/serial/nxp,imx-uart.yaml
+++ b/dts/bindings/serial/nxp,imx-uart.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: iMX Uart
-
-description: |
-    This binding gives a base representation of the iMX UART
+description: iMX UART
 
 compatible: "nxp,imx-uart"
 

--- a/dts/bindings/serial/nxp,kinetis-lpsci.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpsci.yaml
@@ -1,7 +1,4 @@
-title: Kinetis LPSCI UART
-
-description: |
-    This binding gives a base representation of the LPSCI UART
+description: Kinetis LPSCI UART
 
 compatible: "nxp,kinetis-lpsci"
 

--- a/dts/bindings/serial/nxp,kinetis-lpuart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpuart.yaml
@@ -1,7 +1,4 @@
-title: Kinetis LPUART
-
-description: |
-    This binding gives a base representation of the Kinetis LPUART
+description: Kinetis LPUART
 
 compatible: "nxp,kinetis-lpuart"
 

--- a/dts/bindings/serial/nxp,kinetis-uart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-uart.yaml
@@ -1,7 +1,4 @@
-title: Kinetis UART
-
-description: |
-    This binding gives a base representation of the Kinetis UART
+description: Kinetis UART
 
 compatible: "nxp,kinetis-uart"
 

--- a/dts/bindings/serial/nxp,lpc-usart.yaml
+++ b/dts/bindings/serial/nxp,lpc-usart.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: LPC USART
-
-description: |
-    This binding gives a base representation of the LPC USART
+description: LPC USART
 
 compatible: "nxp,lpc-usart"
 

--- a/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
+++ b/dts/bindings/serial/openisa,rv32m1-lpuart.yaml
@@ -1,7 +1,4 @@
-title: OpenISA LPUART
-
-description: |
-    This binding gives a base representation of the OpenISA LPUART
+description: OpenISA LPUART
 
 compatible: "openisa,rv32m1-lpuart"
 

--- a/dts/bindings/serial/sifive,uart0.yaml
+++ b/dts/bindings/serial/sifive,uart0.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-title: SIFIVE UART
-
-description: |
-    This binding gives a base representation of the SIFIVE UART
+description: SiFive UART
 
 compatible: "sifive,uart0"
 

--- a/dts/bindings/serial/silabs,gecko-leuart.yaml
+++ b/dts/bindings/serial/silabs,gecko-leuart.yaml
@@ -1,7 +1,4 @@
-title: GECKO LEUART
-
-description: |
-    This binding gives a base representation of the Gecko LEUART
+description: Gecko LEUART
 
 compatible: "silabs,gecko-leuart"
 

--- a/dts/bindings/serial/silabs,gecko-uart.yaml
+++ b/dts/bindings/serial/silabs,gecko-uart.yaml
@@ -1,7 +1,4 @@
-title: GECKO UART
-
-description: |
-    This binding gives a base representation of the GECKO UART
+description: Gecko UART
 
 compatible: "silabs,gecko-uart"
 

--- a/dts/bindings/serial/silabs,gecko-usart.yaml
+++ b/dts/bindings/serial/silabs,gecko-usart.yaml
@@ -1,7 +1,4 @@
-title: GECKO USART
-
-description: |
-    This binding gives a base representation of the Gecko USART
+description: Gecko USART
 
 compatible: "silabs,gecko-usart"
 

--- a/dts/bindings/serial/snps,nsim-uart.yaml
+++ b/dts/bindings/serial/snps,nsim-uart.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Synopsys ARC nSIM UART
-
-description: |
-    This binding gives a base representation of the Synopsys ARC nSIM UART
+description: Synopsys ARC nSIM UART
 
 compatible: "snps,nsim-uart"
 

--- a/dts/bindings/serial/st,stm32-lpuart.yaml
+++ b/dts/bindings/serial/st,stm32-lpuart.yaml
@@ -1,7 +1,4 @@
-title: STM32 LPUART
-
-description: |
-    This binding gives a base representation of the STM32 LPUART
+description: STM32 LPUART
 
 compatible: "st,stm32-lpuart"
 

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -1,7 +1,4 @@
-title: STM32 UART
-
-description: |
-    This binding gives a base representation of the STM32 UART
+description: STM32 UART
 
 compatible: "st,stm32-uart"
 

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -1,7 +1,4 @@
-title: STM32 USART
-
-description: |
-    This binding gives a base representation of the STM32 USART
+description: STM32 USART
 
 compatible: "st,stm32-usart"
 

--- a/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc13xx-cc26xx-uart.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Brett Witherspoon
 # SPDX-License-Identifier: Apache-2.0
 
-title: TI SimpleLink CC13xx / CC26xx UART
-
-description: |
-    This is a representation of the TI SimpleLink CC13xx / CC26xx UART node
+description: TI SimpleLink CC13xx / CC26xx UART node
 
 compatible: "ti,cc13xx-cc26xx-uart"
 

--- a/dts/bindings/serial/ti,cc32xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc32xx-uart.yaml
@@ -1,7 +1,4 @@
-title: TI CC32XX Uart
-
-description: |
-    This binding gives a base representation of the TI CC32XX UART
+description: TI CC32XX UART
 
 compatible: "ti,cc32xx-uart"
 

--- a/dts/bindings/serial/ti,msp432p4xx-uart.yaml
+++ b/dts/bindings/serial/ti,msp432p4xx-uart.yaml
@@ -1,7 +1,4 @@
-title: TI MSP432P4XX UART
-
-description: |
-    This binding gives a base representation of the TI MSP432P4XX UART
+description: TI MSP432P4XX UART
 
 compatible: "ti,msp432p4xx-uart"
 

--- a/dts/bindings/serial/ti,stellaris-uart.yaml
+++ b/dts/bindings/serial/ti,stellaris-uart.yaml
@@ -1,7 +1,4 @@
-title: TI Stellaris UART
-
-description: |
-    This binding gives a base representation of the TI Stellaris UART
+description: TI Stellaris UART
 
 compatible: "ti,stellaris-uart"
 

--- a/dts/bindings/serial/xlnx,uartps.yaml
+++ b/dts/bindings/serial/xlnx,uartps.yaml
@@ -1,7 +1,4 @@
-title: Xilinx PS UART
-
-description: |
-    This binding gives a base representation of the Xilinx PS UART
+description: Xilinx PS UART
 
 compatible: "xlnx,xuartps"
 

--- a/dts/bindings/serial/zephyr,native-posix-uart.yaml
+++ b/dts/bindings/serial/zephyr,native-posix-uart.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Jan Van Winkel (jan.van_winkel@dxplore.eu)
 # SPDX-License-Identifier: Apache-2.0
 
-title: Native POSIX UART
-
-description: |
-    This binding gives a base representation of the Native POSIX UART
+description: Native POSIX UART
 
 compatible: "zephyr,native-posix-uart"
 

--- a/dts/bindings/spi/atmel,sam-spi.yaml
+++ b/dts/bindings/spi/atmel,sam-spi.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, qianfan Zhao
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel SAM SPI driver
-
-description: |
-    This binding gives a base representation of the Atmel SAM SPI controller
+description: Atmel SAM SPI controller
 
 compatible: "atmel,sam-spi"
 

--- a/dts/bindings/spi/atmel,sam0-spi.yaml
+++ b/dts/bindings/spi/atmel,sam0-spi.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Google LLC.
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel SAM0 SERCOM SPI driver
-
-description: |
-    This binding gives a base representation of the Atmel SAM0 SERCOM SPI controller
+description: Atmel SAM0 SERCOM SPI controller
 
 compatible: "atmel,sam0-spi"
 

--- a/dts/bindings/spi/litex,spi.yaml
+++ b/dts/bindings/spi/litex,spi.yaml
@@ -1,13 +1,7 @@
-#
 # Copyright (c) 2019 Antmicro <www.antmicro.com>
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-title: LiteX SPI
-
-description: |
-    This binding gives a base representation of the LiteX SPI
+description: LiteX SPI
 
 compatible: "litex,spi"
 

--- a/dts/bindings/spi/microchip,xec-qmspi.yaml
+++ b/dts/bindings/spi/microchip,xec-qmspi.yaml
@@ -1,13 +1,7 @@
-#
 # Copyright (c) 2018, Google LLC.
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-title: Microchip XEC Quad Master SPI driver
-
-description: |
-    This binding gives a base representation of the Microchip XEC QMSPI controller
+description: Microchip XEC QMSPI controller
 
 compatible: "microchip,xec-qmspi"
 

--- a/dts/bindings/spi/nordic,nrf-spi.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF family SPI
-
 description: Nordic nRF family SPI (SPI master)
 
 compatible: "nordic,nrf-spi"

--- a/dts/bindings/spi/nordic,nrf-spim.yaml
+++ b/dts/bindings/spi/nordic,nrf-spim.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF family SPIM
-
 description: Nordic nRF family SPIM (SPI master with EasyDMA)
 
 compatible: "nordic,nrf-spim"

--- a/dts/bindings/spi/nordic,nrf-spis.yaml
+++ b/dts/bindings/spi/nordic,nrf-spis.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF family SPIS
-
 description: Nordic nRF family SPIS (SPI slave with EasyDMA)
 
 compatible: "nordic,nrf-spis"

--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP FlexSPI
-
-description: |
-    This binding gives a base representation of the NXP FlexSPI controller
+description: NXP FlexSPI controller
 
 compatible: "nxp,imx-flexspi"
 

--- a/dts/bindings/spi/nxp,imx-lpspi.yaml
+++ b/dts/bindings/spi/nxp,imx-lpspi.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP LPSPI
-
-description: |
-    This binding gives a base representation of the NXP i.MX LPSPI controller
+description: NXP i.MX LPSPI controller
 
 compatible: "nxp,imx-lpspi"
 

--- a/dts/bindings/spi/nxp,kinetis-dspi.yaml
+++ b/dts/bindings/spi/nxp,kinetis-dspi.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP DSPI
-
-description: |
-    This binding gives a base representation of the NXP Kinetis DSPI controller
+description: NXP Kinetis DSPI controller
 
 compatible: "nxp,kinetis-dspi"
 

--- a/dts/bindings/spi/nxp,lpc-spi.yaml
+++ b/dts/bindings/spi/nxp,lpc-spi.yaml
@@ -1,13 +1,7 @@
-#
 # Copyright (c) 2019, NXP
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-title: NXP LPC SPI
-
-description: >
-    This binding gives a base representation of the NXP LPC SPI controller
+description: NXP LPC SPI controller
 
 compatible: "nxp,lpc-spi"
 

--- a/dts/bindings/spi/opencores,spi-simple.yaml
+++ b/dts/bindings/spi/opencores,spi-simple.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Western Digital Corporation or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
-title: OpenCores Simple SPI driver
-
-description: |
-    This binding gives a base representation of the OpenCores Simple SPI controller
+description: OpenCores Simple SPI controller
 
 compatible: "opencores,spi-simple"
 

--- a/dts/bindings/spi/openisa,rv32m1-lpspi.yaml
+++ b/dts/bindings/spi/openisa,rv32m1-lpspi.yaml
@@ -1,13 +1,7 @@
-#
 # Copyright (c) 2019, Karsten Koenig <karsten.koenig.030@gmail.com>
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-title: OpenISA LPSPI
-
-description: >
-    This binding gives a base representation of the OpenISA LPSPI controller
+description: OpenISA LPSPI controller
 
 compatible: "openisa,rv32m1-lpspi"
 

--- a/dts/bindings/spi/sifive,spi0.yaml
+++ b/dts/bindings/spi/sifive,spi0.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-title: Sifive SPI driver
-
-description: |
-    This binding gives a base representation of the Sifive SPI controller
+description: Sifive SPI controller
 
 compatible: "sifive,spi0"
 

--- a/dts/bindings/spi/snps,designware-spi.yaml
+++ b/dts/bindings/spi/snps,designware-spi.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Synopsys, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-title: Synopsys Designware SPI Controller
-
-description: |
-     This is a representation of the Synopsys DesignWare spi node
+description: Synopsys DesignWare SPI node
 
 compatible: "snps,designware-spi"
 

--- a/dts/bindings/spi/st,stm32-spi-fifo.yaml
+++ b/dts/bindings/spi/st,stm32-spi-fifo.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2018, I-SENSE group of ICCS
 # SPDX-License-Identifier: Apache-2.0
 
-title: STM32 SPI FIFO
-
-description: |
-    This binding gives a base representation of the STM32 SPI controller with
-    embedded Rx and Tx FIFOs
+description: STM32 SPI controller with embedded Rx and Tx FIFOs
 
 compatible: "st,stm32-spi-fifo"
 

--- a/dts/bindings/spi/st,stm32-spi.yaml
+++ b/dts/bindings/spi/st,stm32-spi.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, I-SENSE group of ICCS
 # SPDX-License-Identifier: Apache-2.0
 
-title: STM32 SPI
-
-description: |
-    This binding gives a base representation of the STM32 SPI controller
+description: STM32 SPI controller
 
 compatible: "st,stm32-spi"
 

--- a/dts/bindings/spi/ti,cc13xx-cc26xx-spi.yaml
+++ b/dts/bindings/spi/ti,cc13xx-cc26xx-spi.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Brett Witherspoon
 # SPDX-License-Identifier: Apache-2.0
 
-title: TI SimpleLink CC13xx / CC26xx SPI
-
-description: |
-    This is a representation of the TI SimpleLink CC13xx / CC26xx SPI node
+description: TI SimpleLink CC13xx / CC26xx SPI node
 
 compatible: "ti,cc13xx-cc26xx-spi"
 

--- a/dts/bindings/sram/mmio-sram.yaml
+++ b/dts/bindings/sram/mmio-sram.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Generic on-chip SRAM
-
-description: |
-    This binding gives a generic on-chip SRAM description
+description: Generic on-chip SRAM description
 
 compatible: "mmio-sram"
 

--- a/dts/bindings/sram/sifive,dtim0.yaml
+++ b/dts/bindings/sram/sifive,dtim0.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-title: Data Tightly-Integrated Memory
-
-description: |
-    This bindings describes the SiFive Data Tightly-Integrated Memory
+description: SiFive Data Tightly-Integrated Memory
 
 compatible: "sifive,dtim0"
 

--- a/dts/bindings/timer/arm,cmsdk-dtimer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-dtimer.yaml
@@ -1,7 +1,4 @@
-title: ARM CMSDK DUALTIMER
-
-description: |
-    This binding gives a base representation of the ARM CMSDK DUALTIMER
+description: ARM CMSDK dual timer
 
 compatible: "arm,cmsdk-dtimer"
 

--- a/dts/bindings/timer/arm,cmsdk-timer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-timer.yaml
@@ -1,7 +1,4 @@
-title: ARM CMSDK TIMER
-
-description: |
-    This binding gives a base representation of the ARM CMSDK TIMER
+description: ARM CMSDK timer
 
 compatible: "arm,cmsdk-timer"
 

--- a/dts/bindings/timer/atmel,sam0-tc32.yaml
+++ b/dts/bindings/timer/atmel,sam0-tc32.yaml
@@ -1,11 +1,7 @@
 # Copyright (c) 2019 Derek Hageman <hageman@inthat.cloud>
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel SAM0 32-bit Basic Timer
-
-description: |
-    This binding gives a base representation of the Atmel SAM0 timer
-    counter (TC) operating in 32-bit wide mode.
+description: Atmel SAM0 basic timer counter (TC) operating in 32-bit wide mode
 
 compatible: "atmel,sam0-tc32"
 

--- a/dts/bindings/timer/intel,hpet.yaml
+++ b/dts/bindings/timer/intel,hpet.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Intel Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-title: HPET
-
-description: |
-    This binding represents the High-Precision Event Timer
+description: HPET (High-Precision Event Timer)
 
 compatible: "intel,hpet"
 

--- a/dts/bindings/timer/litex,timer0.yaml
+++ b/dts/bindings/timer/litex,timer0.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 - 2019 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-title: LiteX timer
-
-description: |
-    This binding gives a base representation of the LiteX timer
+description: LiteX timer
 
 compatible: "litex,timer0"
 

--- a/dts/bindings/timer/microchip,xec-rtos-timer.yaml
+++ b/dts/bindings/timer/microchip,xec-rtos-timer.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-title: Microchip XEC RTOS timer
-
-description: |
-    This is a representation of the Microchip XEC RTOS timer node
+description: Microchip XEC RTOS timer
 
 compatible: "microchip,xec-rtos-timer"
 

--- a/dts/bindings/timer/nordic,nrf-timer.yaml
+++ b/dts/bindings/timer/nordic,nrf-timer.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF timer
-
-description: |
-    This is a representation of the Nordic nRF timer node
+description: Nordic nRF timer node
 
 compatible: "nordic,nrf-timer"
 

--- a/dts/bindings/timer/nxp,imx-gpt.yaml
+++ b/dts/bindings/timer/nxp,imx-gpt.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP MCUX General Purpose Timer
-
-description: |
-    This is a representation of the NXP MCUX General Purpose Timer (GPT)
+description: NXP MCUX General-Purpose Timer (GPT)
 
 compatible: "nxp,imx-gpt"
 

--- a/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
+++ b/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
@@ -1,7 +1,4 @@
-title: OpenISA RV32M1 LPTMR
-
-description: |
-    This binding represents the OpenISA RV32M1 LPTMR peripheral.
+description: OpenISA RV32M1 LPTMR peripheral
 
 compatible: "openisa,rv32m1-lptmr"
 

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -1,7 +1,4 @@
-title: STM32 TIMERS
-
-description: |
-    This binding gives a base representation of the STM32 TIMERS
+description: STM32 timers
 
 compatible: "st,stm32-timers"
 

--- a/dts/bindings/timer/xlnx,ttcps.yaml
+++ b/dts/bindings/timer/xlnx,ttcps.yaml
@@ -1,7 +1,4 @@
-title: Xilinx ZynqMP PS TTC TIMERS
-
-description: |
-    This binding gives a base representation of the Xilinx ZynqMP PS TTC TIMERS
+description: Xilinx ZynqMP PS TTC timer
 
 compatible: "cdns,ttc"
 

--- a/dts/bindings/usb/atmel,sam-usbhs.yaml
+++ b/dts/bindings/usb/atmel,sam-usbhs.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2018 Aurelien Jarno
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel SAM USBHS
-
 description: |
     Atmel SAM Family USB (USBHS) in device mode
 

--- a/dts/bindings/usb/atmel,sam0-usb.yaml
+++ b/dts/bindings/usb/atmel,sam0-usb.yaml
@@ -1,5 +1,3 @@
-title: Atmel SAM0 USB device
-
 description: |
     Atmel SAM0 USB in device mode
 

--- a/dts/bindings/usb/nordic,nrf-usbd.yaml
+++ b/dts/bindings/usb/nordic,nrf-usbd.yaml
@@ -1,10 +1,8 @@
 # Copyright (c) 2018, Sundar Subramaniyan <sundar.subramaniyan@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic nRF52 USBD
-
 description: |
-    This binding gives a base representation of the Nordic nRF52 USB device controller
+    Nordic nRF52 USB device controller
 
 compatible: "nordic,nrf-usbd"
 

--- a/dts/bindings/usb/nxp,kinetis-usbd.yaml
+++ b/dts/bindings/usb/nxp,kinetis-usbd.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2018 PHYTEC Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP Kinetis USBD
-
 description: |
     NPX Kinetis USBFSOTG Controller in device mode
 

--- a/dts/bindings/usb/st,stm32-otgfs.yaml
+++ b/dts/bindings/usb/st,stm32-otgfs.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, I-SENSE group of ICCS
 # SPDX-License-Identifier: Apache-2.0
 
-title: STM32 OTGFS
-
-description: |
-    This binding gives a base representation of the STM32 OTGFS controller
+description: STM32 OTGFS controller
 
 compatible: "st,stm32-otgfs"
 

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, I-SENSE group of ICCS
 # SPDX-License-Identifier: Apache-2.0
 
-title: STM32 OTGHS
-
-description: |
-    This binding gives a base representation of the STM32 OTG HS controller
+description: STM32 OTGHS controller
 
 compatible: "st,stm32-otghs"
 

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2017, I-SENSE group of ICCS
 # SPDX-License-Identifier: Apache-2.0
 
-title: STM32 USB
-
-description: |
-    This binding gives a base representation of the STM32 USB controller
+description: STM32 USB controller
 
 compatible: "st,stm32-usb"
 

--- a/dts/bindings/video/aptina,mt9m114.yaml
+++ b/dts/bindings/video/aptina,mt9m114.yaml
@@ -1,13 +1,7 @@
-#
 # Copyright (c) 2019, Linaro Limited
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-title: MT9M114 CMOS video sensor.
-
-description: |
-    This is a representation of the MT9M114 CMOS video sensor.
+description: MT9M114 CMOS video sensor
 
 compatible: "aptina,mt9m114"
 

--- a/dts/bindings/video/nxp,imx-csi.yaml
+++ b/dts/bindings/video/nxp,imx-csi.yaml
@@ -4,10 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-title: NXP MCUX CSI module
-
-description: |
-    This binding gives a base representation of NXP MCUX CMOS Sensor Interface
+description: NXP MCUX CMOS sensor interface
 
 compatible: "nxp,imx-csi"
 

--- a/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
+++ b/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
@@ -1,7 +1,4 @@
-title: ARM CMSDK WATCHDOG
-
-description: |
-    This binding gives a base representation of the ARM CMSDK WATCHDOG
+description: ARM CMSDK watchdog
 
 compatible: "arm,cmsdk-watchdog"
 

--- a/dts/bindings/watchdog/atmel,sam-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam-watchdog.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Atmel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel SAM watchdog driver
-
-description: |
-    This is a representation of the SAM0 watchdog
+description: ATMEL SAM0 watchdog
 
 compatible: "atmel,sam-watchdog"
 

--- a/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
@@ -1,7 +1,4 @@
-title: Atmel SAM0 watchdog driver
-
-description: |
-    This is a representation of the SAM0 watchdog
+description: Atmel SAM0 watchdog
 
 compatible: "atmel,sam0-watchdog"
 

--- a/dts/bindings/watchdog/espressif,esp32-watchdog.yaml
+++ b/dts/bindings/watchdog/espressif,esp32-watchdog.yaml
@@ -1,12 +1,9 @@
 # Copyright (c) 2019, Mohamed ElShahawi
 # SPDX-License-Identifier: Apache-2.0
 
-title: Espressif ESP32 watchdog driver
-
 description: |
-    This is a representation of the ESP32 watchdog, ESP32 contains 3x Watchdog
-    timers 2x Main System Watchdog Timer (MWDT), 1x RTC Watchdog Timer (RWDT).
-    RWDT is not supported yet.
+    ESP32 watchdog. ESP32 contains 3x Watchdog timers, 2x Main System Watchdog
+    Timer (MWDT), 1x RTC Watchdog Timer (RWDT). RWDT is not supported yet.
 
 compatible: "espressif,esp32-watchdog"
 

--- a/dts/bindings/watchdog/microchip,xec-watchdog.yaml
+++ b/dts/bindings/watchdog/microchip,xec-watchdog.yaml
@@ -1,13 +1,7 @@
-#
 # Copyright (c) 2019, Intel Corporation
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
-title: Microchip XEC watchdog timer
-
-description: |
-    This binding gives a base representation of the Microchip XEC watchdog timer
+description: Microchip XEC watchdog timer
 
 include: base.yaml
 

--- a/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
+++ b/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Nordic Semiconductor NRF watchdog driver
-
-description: |
-    This is a representation of the NRF watchdog
+description: Nordic Semiconductor nRF watchdog
 
 compatible: "nordic,nrf-watchdog"
 

--- a/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP Kinetis watchdog driver
-
-description: |
-    This is a representation of the Kinetis watchdog
+description: Kinetis watchdog
 
 compatible: "nxp,kinetis-wdog"
 

--- a/dts/bindings/watchdog/nxp,kinetis-wdog32.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog32.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP Kinetis watchdog (WDOG32) driver
-
-description: |
-    This is a representation of the Kinetis watchdog (WDOG32)
+description: Kinetis watchdog (WDOG32)
 
 compatible: "nxp,kinetis-wdog32"
 

--- a/dts/bindings/watchdog/st,stm32-watchdog.yaml
+++ b/dts/bindings/watchdog/st,stm32-watchdog.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics STM32 watchdog driver
-
-description: |
-    This is a representation of the STM32 watchdog
+description: STM32 watchdog
 
 compatible: "st,stm32-watchdog"
 

--- a/dts/bindings/watchdog/st,stm32-window-watchdog.yaml
+++ b/dts/bindings/watchdog/st,stm32-window-watchdog.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2019 Centaur Analytics, Inc
 # SPDX-License-Identifier: Apache-2.0
 
-title: STMicroelectronics STM32 system window watchdog driver
-
-description: |
-    This is a representation of the STM32 system window watchdog
+description: STM32 system window watchdog
 
 compatible: "st,stm32-window-watchdog"
 

--- a/dts/bindings/wifi/atmel,winc1500.yaml
+++ b/dts/bindings/wifi/atmel,winc1500.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Atmel WINC1500 Wifi module
-
-description: |
-    This binding gives the base representation of the Atmel WINC1500 Wifi module
+description: Atmel WINC1500 WiFi module
 
 compatible: "atmel,winc1500"
 

--- a/dts/bindings/wifi/inventek,eswifi.yaml
+++ b/dts/bindings/wifi/inventek,eswifi.yaml
@@ -1,8 +1,6 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-title: Inventek eS-WiFi WiFi module
-
 description: |
     This binding gives the base representation of es-WiFi module
 

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -459,12 +459,28 @@ class EDT:
         # Does sanity checking on 'binding'. Only takes 'self' for the sake of
         # self._warn().
 
-        for prop in "title", "description":
-            if prop not in binding:
-                _err("missing '{}' property in {}".format(prop, binding_path))
+        if "title" in binding:
+            # This message is the message that people copy-pasting the old
+            # format will see in practice
+            self._warn("'title:' in {} is deprecated and will be removed (and "
+                       "was never used). Just put a 'description:' that "
+                       "describes the device instead. Use other bindings as "
+                       "a reference, and note that all bindings were updated "
+                       "recently. Think about what information would be "
+                       "useful to other people (e.g. explanations of "
+                       "acronyms, or datasheet links), and put that in as "
+                       "well. The description text shows up as a comment "
+                       "in the generated header. See yaml-multiline.info for "
+                       "how to deal with multiple lines. You probably want "
+                       "'description: |'.".format(binding_path))
 
-            if not isinstance(binding[prop], str) or not binding[prop]:
-                _err("missing, malformed, or empty '{}' in {}"
+        if "description" not in binding:
+            _err("missing 'description' property in " + binding_path)
+
+        for prop in "title", "description":
+            if prop in binding and (not isinstance(binding[prop], str) or
+                                    not binding[prop]):
+                _err("malformed or empty '{}' in {}"
                      .format(prop, binding_path))
 
         ok_top = {"title", "description", "compatible", "properties", "#cells",
@@ -481,8 +497,8 @@ class EDT:
             bus_key = pc + "-bus"
             if bus_key in binding and \
                not isinstance(binding[bus_key], str):
-                self._warn("malformed '{}:' value in {}, expected string"
-                           .format(bus_key, binding_path))
+                _err("malformed '{}:' value in {}, expected string"
+                     .format(bus_key, binding_path))
 
             # Legacy 'child/parent: bus: ...' keys
             if pc in binding:

--- a/scripts/dts/test-bindings-2/multidir.yaml
+++ b/scripts/dts/test-bindings-2/multidir.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Binding in test-bindings-2/
 description: Binding in test-bindings-2/
 
 compatible: "in-dir-2"

--- a/scripts/dts/test-bindings/bar-bus.yaml
+++ b/scripts/dts/test-bindings/bar-bus.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Bar bus controller
 description: Bar bus controller
 
 compatible: "bar-bus"

--- a/scripts/dts/test-bindings/child-binding.yaml
+++ b/scripts/dts/test-bindings/child-binding.yaml
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: child-binding test
 description: child-binding test
 
 compatible: "child-binding"
 
 child-binding:
-    title: child node
     description: child node
     properties:
         child-prop:
@@ -14,7 +12,6 @@ child-binding:
             required: true
 
     child-binding:
-        title: grandchild node
         description: grandchild node
         properties:
             grandchild-prop:

--- a/scripts/dts/test-bindings/defaults.yaml
+++ b/scripts/dts/test-bindings/defaults.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Property default value test
 description: Property default value test
 
 compatible: "defaults"

--- a/scripts/dts/test-bindings/device-on-bar-bus.yaml
+++ b/scripts/dts/test-bindings/device-on-bar-bus.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Device on bar bus
 description: Device on bar bus
 
 compatible: "on-bus"

--- a/scripts/dts/test-bindings/device-on-foo-bus.yaml
+++ b/scripts/dts/test-bindings/device-on-foo-bus.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Device on foo bus
 description: Device on foo bus
 
 compatible: "on-bus"

--- a/scripts/dts/test-bindings/foo-bus.yaml
+++ b/scripts/dts/test-bindings/foo-bus.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Foo bus controller
 description: Foo bus controller
 
 compatible: "foo-bus"

--- a/scripts/dts/test-bindings/gpio-dst.yaml
+++ b/scripts/dts/test-bindings/gpio-dst.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: GPIO destination for mapping test
 description: GPIO destination for mapping test
 
 compatible: "gpio-dst"

--- a/scripts/dts/test-bindings/gpio-src.yaml
+++ b/scripts/dts/test-bindings/gpio-src.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: GPIO source for mapping test
 description: GPIO source for mapping test
 
 compatible: "gpio-src"

--- a/scripts/dts/test-bindings/interrupt-1-cell.yaml
+++ b/scripts/dts/test-bindings/interrupt-1-cell.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Interrupt controller with one cell
 description: Interrupt controller with one cell
 
 compatible: "interrupt-one-cell"

--- a/scripts/dts/test-bindings/interrupt-2-cell.yaml
+++ b/scripts/dts/test-bindings/interrupt-2-cell.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Interrupt controller with two cells
 description: Interrupt controller with two cells
 
 compatible: "interrupt-two-cell"

--- a/scripts/dts/test-bindings/interrupt-3-cell.yaml
+++ b/scripts/dts/test-bindings/interrupt-3-cell.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Interrupt controller with three cells
 description: Interrupt controller with three cells
 
 compatible: "interrupt-three-cell"

--- a/scripts/dts/test-bindings/multidir.yaml
+++ b/scripts/dts/test-bindings/multidir.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Binding in test-bindings/
 description: Binding in test-bindings/
 
 compatible: "in-dir-1"

--- a/scripts/dts/test-bindings/order-1.yaml
+++ b/scripts/dts/test-bindings/order-1.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Include ordering test
 description: Include ordering test
 
 compatible: "order-1"

--- a/scripts/dts/test-bindings/order-2.yaml
+++ b/scripts/dts/test-bindings/order-2.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Include ordering test
 description: Include ordering test
 
 compatible: "order-2"

--- a/scripts/dts/test-bindings/parent.yaml
+++ b/scripts/dts/test-bindings/parent.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Parent binding
 description: Parent binding
 
 compatible: "binding-include-test"

--- a/scripts/dts/test-bindings/phandle-array-controller-1.yaml
+++ b/scripts/dts/test-bindings/phandle-array-controller-1.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Controller with one data value
 description: Controller with one data value
 
 compatible: "phandle-array-controller-1"

--- a/scripts/dts/test-bindings/phandle-array-controller-2.yaml
+++ b/scripts/dts/test-bindings/phandle-array-controller-2.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Controller with two data values
 description: Controller with two data values
 
 compatible: "phandle-array-controller-2"

--- a/scripts/dts/test-bindings/props.yaml
+++ b/scripts/dts/test-bindings/props.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-title: Device.props test
 description: Device.props test
 
 compatible: "props"

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -42,6 +42,7 @@ def run():
     verify_eq(warnings.getvalue(), """\
 warning: The 'properties: compatible: constraint: ...' way of specifying the compatible in test-bindings/deprecated.yaml is deprecated. Put 'compatible: "deprecated"' at the top level of the binding instead.
 warning: the 'inherits:' syntax in test-bindings/deprecated.yaml is deprecated and will be removed - please use 'include: foo.yaml' or 'include: [foo.yaml, bar.yaml]' instead
+warning: 'title:' in test-bindings/deprecated.yaml is deprecated and will be removed (and was never used). Just put a 'description:' that describes the device instead. Use other bindings as a reference, and note that all bindings were updated recently. Think about what information would be useful to other people (e.g. explanations of acronyms, or datasheet links), and put that in as well. The description text shows up as a comment in the generated header. See yaml-multiline.info for how to deal with multiple lines. You probably want 'description: |'.
 warning: please put 'required: true' instead of 'category: required' in properties: required: ...' in test-bindings/deprecated.yaml - 'category' will be removed
 warning: please put 'required: false' instead of 'category: optional' in properties: optional: ...' in test-bindings/deprecated.yaml - 'category' will be removed
 warning: 'sub-node: properties: ...' in test-bindings/deprecated.yaml is deprecated and will be removed - please give a full binding for the child node in 'child-binding:' instead (see binding-template.yaml)


### PR DESCRIPTION
Most bindings look something like this:

    title: Foo

    description: This binding provides a base representation of Foo

That kind of description doesn't add any useful information, as it's just the title along with some copy-pasted text. I'm not sure what "base representation" was supposed to mean originally either.

Many bindings also put something that's closer to a description in the title, because it's not clear what's expected or how the title is used. In reality, the title isn't used anywhere. `description:` on the other hand shows up as a comment in the generated header.

Move all information into `description:` and deprecate and remove `title:`. A long informative warning is printed if `title:` shows up in a binding.

Some other things could probably be cleaned up (replacing 'GPIO node' with 'GPIO controller' on controllers for consistency, for example), but I kept things close to the original to avoid accidentally messing up.