### PR TITLE
Bluetooth: SMP: Add option to disable SMP security request from slave

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -383,6 +383,12 @@ config BT_KEYS_SAVE_AGING_COUNTER_ON_PAIRING
 	  time a successful pairing occurs. This increases flash wear out but offers
 	  a more correct finding of the oldest unused pairing info.
 
+config BT_SMP_NO_SECURITY_REQ
+	bool "Disable slave initated security request"
+	depends on BT_PERIPHERAL
+	  With this option security request from slave is disabled. This means
+	  that the slave has to wait for the central to initiate it if required.
+
 endif # BT_SMP
 
 source "subsys/bluetooth/host/Kconfig.l2cap"

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -2648,6 +2648,12 @@ bool bt_smp_request_ltk(struct bt_conn *conn, u64_t rand, u16_t ediv, u8_t *ltk)
 }
 
 #if defined(CONFIG_BT_PERIPHERAL)
+#if defined(CONFIG_BT_SMP_NO_SECURITY_REQ))
+static int smp_send_security_req(struct bt_conn *conn)
+{
+	return -ENOTSUP;
+}
+#else
 static int smp_send_security_req(struct bt_conn *conn)
 {
 	struct bt_smp *smp;
@@ -2707,6 +2713,7 @@ static int smp_send_security_req(struct bt_conn *conn)
 
 	return 0;
 }
+#endif /* defined(CONFIG_BT_SMP_NO_SECURITY_REQ) */
 
 static u8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 {


### PR DESCRIPTION
Add option to disable security request from slave. This means that the
slave has to wait for the central to initiate it if required.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>