### PR TITLE
[TOPIC-GPIO] Convert actinius_icarus and degu_evk boards to new GPIO API

### DIFF
--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -19,17 +19,17 @@
 		compatible = "gpio-leds";
 
 		red_led: led_0 {
-			gpios = <&gpio0 10 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			label = "Red LED";
 		};
 
 		green_led: led_1 {
-			gpios = <&gpio0 11 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 			label = "Green LED";
 		};
 
 		blue_led: led_2 {
-			gpios = <&gpio0 12 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 			label = "Blue LED";
 		};
 	};
@@ -38,7 +38,7 @@
 		compatible = "gpio-keys";
 
 		button0: button_0 {
-			gpios = <&gpio0 5 (GPIO_PUD_PULL_UP | GPIO_INT_ACTIVE_LOW)>;
+			gpios = <&gpio0 5 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push Button 1";
 		};
 	};

--- a/boards/arm/actinius_icarus/board.c
+++ b/boards/arm/actinius_icarus/board.c
@@ -22,12 +22,11 @@ static void select_sim(void)
 		return;
 	}
 
-	gpio_pin_configure(port, SIM_SELECT_PIN, GPIO_DIR_OUT);
 	#ifdef CONFIG_BOARD_SELECT_SIM_EXTERNAL
-		gpio_pin_write(port, SIM_SELECT_PIN, 0);
+		gpio_pin_configure(port, SIM_SELECT_PIN, GPIO_OUTPUT_LOW);
 		LOG_INF("External SIM is selected");
 	#else
-		gpio_pin_write(port, SIM_SELECT_PIN, 1);
+		gpio_pin_configure(port, SIM_SELECT_PIN, GPIO_OUTPUT_HIGH);
 		LOG_INF("eSIM is selected");
 	#endif
 }

--- a/boards/arm/degu_evk/board.c
+++ b/boards/arm/degu_evk/board.c
@@ -18,20 +18,17 @@ static int board_degu_evk_init(struct device *dev)
 	 * Degu Evaluation Kit has a TPS22916C power switch.
 	 * It is connected to GPIO0_26 so we must enable it.
 	 */
-	gpio_pin_configure(gpio0, 26, GPIO_DIR_OUT);
-	gpio_pin_write(gpio0, 26, 1);
+	gpio_pin_configure(gpio0, 26, GPIO_OUTPUT_HIGH);
 
 	/*
 	 * We must enable GPIO1_2 to use Secure Element.
 	 */
-	gpio_pin_configure(gpio1, 2, GPIO_DIR_OUT);
-	gpio_pin_write(gpio1, 2, 1);
+	gpio_pin_configure(gpio1, 2, GPIO_OUTPUT_HIGH);
 
 	/*
 	 * We must enable GPIO1_6 to read Vin voltage.
 	 */
-	gpio_pin_configure(gpio1, 6, GPIO_DIR_OUT);
-	gpio_pin_write(gpio1, 6, 1);
+	gpio_pin_configure(gpio1, 6, GPIO_OUTPUT_HIGH);
 
 	return 0;
 }

--- a/boards/arm/degu_evk/degu_evk.dts
+++ b/boards/arm/degu_evk/degu_evk.dts
@@ -21,19 +21,19 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio1 7 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 			label = "LED1";
 		};
 		led1: led_1 {
-			gpios = <&gpio1 5 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
 			label = "LED2";
 		};
 		led2: led_2 {
-			gpios = <&gpio1 3 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
 			label = "LED3";
 		};
 		led3: led_3 {
-			gpios = <&gpio1 4 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
 			label = "LED4";
 		};
 	};
@@ -41,15 +41,15 @@
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
-			gpios = <&gpio1 0 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio1 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "SW2";
 		};
 		button1: button_1 {
-			gpios = <&gpio1 1 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio1 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "SW3";
 		};
 		button2: button_2 {
-			gpios = <&gpio1 14 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio1 14 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "SW4";
 		};
 	};


### PR DESCRIPTION
Pairs of gpio_pin_configure/gpio_pin_write are replaced with calls to
gpio_pin_configure that configure a given pin as output with the proper
initial state.