### PR TITLE
usb: Fix BCD() macro used to set bcdDevice

### DIFF
--- a/include/usb/usb_common.h
+++ b/include/usb/usb_common.h
@@ -45,7 +45,7 @@
 #ifndef ZEPHYR_INCLUDE_USB_USB_COMMON_H_
 #define ZEPHYR_INCLUDE_USB_USB_COMMON_H_
 
-#define BCD(x) ((((x) / 10) << 4) | ((x) / 10))
+#define BCD(x) ((((x) / 10) << 4) | ((x) % 10))
 
 /* Descriptor size in bytes */
 #define USB_DEVICE_DESC_SIZE		18


### PR DESCRIPTION
According to API documentation, the bcdDevice field of the USB descriptor is supposed to represents the Zephyr kernel major and minor versions as a binary coded decimal value. However, when using zephyr 2.0, bcdDevice is shown as 0.00 instead of 2.00.

This is due to a typo in the implementation of the BCD macro in usb_commond.h. This commit fixes the macro.

Signed-off-by: Arnaud Taffanel <arnaud@bitcraze.io>