### PR TITLE
CODEOWNERS: remove duplicate entry

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -284,7 +284,6 @@
 /include/zephyr.h                         @andrewboie @andyross
 /kernel/                                  @andrewboie @andyross
 /lib/gui/                                 @vanwinkeljan
-/lib/libc/                                @nashif
 /lib/os/                                  @andrewboie @andyross
 /lib/posix/                               @pfalcon
 /lib/cmsis_rtos_v2/                       @nashif
@@ -296,9 +295,8 @@
 /samples/                                 @nashif
 /samples/basic/minimal/                   @carlescufi
 /samples/basic/servo_motor/*microbit*     @jhe
-/samples/bluetooth/                       @joerchan @jhedberg @Vudentz
 /lib/updatehub/                           @chtavares592 @otavio
-/samples/bluetooth/                       @sjanc @jhedberg @Vudentz
+/samples/bluetooth/                       @sjanc @jhedberg @Vudentz @joerchan
 /samples/boards/intel_s1000_crb/          @sathishkuttan @dcpleung @nashif
 /samples/display/                         @vanwinkeljan
 /samples/drivers/CAN/                     @alexanderwachter


### PR DESCRIPTION
/lib/libc/ was listed twice in the file
The first entry was overriden by the 2nd

And so was the case for
/samples/bluetooth/
In this second case, the override lost a user, so add it

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>