### PR TITLE
tests: Add test to check default board configuration compliance

### DIFF
--- a/tests/misc/default_board_config/CMakeLists.txt
+++ b/tests/misc/default_board_config/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(default_config)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/misc/default_board_config/src/main.c
+++ b/tests/misc/default_board_config/src/main.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2019 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+
+#ifdef CONFIG_IEEE802154
+#error IEEE802154 should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_ADC
+#error ADC should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_AUDIO
+#error AUDIO should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_BT
+#error BT should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_CAN
+#error CAN should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_COUNTER
+#error COUNTER should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_DMA
+#error DMA should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_DISK_ACCESS
+#error DISK_ACCESS should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_CRYPTO
+#error CRYPTO should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_CRYPTO
+#error CRYPTO should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_DISPLAY
+#error  should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_DMA
+#error DMA should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_EEPROM
+#error EEPROM should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_ESPI
+#error ESPI should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_FLASH
+#error FLASH should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_I2C
+#error I2C should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_I2S
+#error I2S should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_IPM
+#error IPM should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_KSCAN
+#error KSCAN should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_LED
+#error LED should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_MODEM
+#error MODEM should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_NEURAL_NET_ACCEL
+#error NEURAL_NET_ACCEL should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_NET
+#error NET should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_PCIE
+#error PCIE should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_PS2
+#error PS2 should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_PWN
+#error PWM should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_USB
+#error USB should not be part of default board configuration
+#endif
+
+#ifdef CONFIG_VIDEO
+#error VIDEO should not be part of default board configuration
+#endif
+
+
+
+void main(void)
+{
+}

--- a/tests/misc/default_board_config/testcase.yaml
+++ b/tests/misc/default_board_config/testcase.yaml
@@ -1,0 +1,6 @@
+tests:
+  default_board_config:
+    build_only: true
+    build_on_all: true
+    tags: default_board_config
+    filter: not USING_OUT_OF_TREE_BOARD


### PR DESCRIPTION
Aim of the test is to enforce compliance to default board configuration guidelines on in tree boards (out of tree boards are filtered out).
Test is build_only and error is generated if any driver is enabled aside from basic gpio, pinmux, clock_control, serial or any subsystem other than console.

Tested Kconfig symbols are drivers and subsystems.
Each new flag will need to be added manually and I can't find a clever way to automate that, unless we add a new level of info to identify Kconfig flags role (peripheral, subsytem, ...) and level (zephyr top level, soc level, peripheral driver level, vendor peripheral driver level, ..). So this test will have to be maintained and updated manually, similarly as we do on `tests/drivers/build_all`

Fixes #19116

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>