### PR TITLE
cmake: xtools: use SoC name in path to xtensa toolchain

### DIFF
--- a/cmake/toolchain/xtools/generic.cmake
+++ b/cmake/toolchain/xtools/generic.cmake
@@ -15,15 +15,24 @@ set(BINTOOLS gnu)
 # should use. Note that we can't use ARCH to distinguish between
 # toolchains because choosing between iamcu and non-iamcu is dependent
 # on Kconfig, not ARCH.
-file(GLOB toolchain_paths ${TOOLCHAIN_HOME}/*)
+if("${ARCH}" STREQUAL "xtensa")
+  file(GLOB toolchain_paths ${TOOLCHAIN_HOME}/xtensa/*/*)
+else()
+  file(GLOB toolchain_paths ${TOOLCHAIN_HOME}/*)
+endif()
 list(REMOVE_ITEM toolchain_paths ${TOOLCHAIN_HOME}/sources)
 list(GET  toolchain_paths 0 some_toolchain_path)
+
+get_filename_component(some_toolchain_root "${some_toolchain_path}" DIRECTORY)
 get_filename_component(some_toolchain "${some_toolchain_path}" NAME)
 
 set(CROSS_COMPILE_TARGET ${some_toolchain})
 
 set(SYSROOT_TARGET ${CROSS_COMPILE_TARGET})
 
-set(CROSS_COMPILE ${TOOLCHAIN_HOME}/${CROSS_COMPILE_TARGET}/bin/${CROSS_COMPILE_TARGET}-)
-set(SYSROOT_DIR   ${TOOLCHAIN_HOME}/${SYSROOT_TARGET}/${SYSROOT_TARGET})
+set(CROSS_COMPILE ${some_toolchain_root}/${CROSS_COMPILE_TARGET}/bin/${CROSS_COMPILE_TARGET}-)
+set(SYSROOT_DIR   ${some_toolchain_root}/${SYSROOT_TARGET}/${SYSROOT_TARGET})
 set(TOOLCHAIN_HAS_NEWLIB ON CACHE BOOL "True if toolchain supports newlib")
+
+unset(some_toolchain_root)
+unset(some_toolchain)

--- a/cmake/toolchain/xtools/target.cmake
+++ b/cmake/toolchain/xtools/target.cmake
@@ -6,29 +6,21 @@ set(CROSS_COMPILE_TARGET_riscv   riscv64-zephyr-elf)
 set(CROSS_COMPILE_TARGET_mips     mipsel-zephyr-elf)
 set(CROSS_COMPILE_TARGET_xtensa   xtensa-zephyr-elf)
 set(CROSS_COMPILE_TARGET_arc         arc-zephyr-elf)
-
-if(CONFIG_X86_64)
-  set(CROSS_COMPILE_TARGET_x86 x86_64-zephyr-elf)
-else()
-  set(CROSS_COMPILE_TARGET_x86 i586-zephyr-elf)
-endif()
+set(CROSS_COMPILE_TARGET_x86      x86_64-zephyr-elf)
 
 set(CROSS_COMPILE_TARGET ${CROSS_COMPILE_TARGET_${ARCH}})
 set(SYSROOT_TARGET       ${CROSS_COMPILE_TARGET})
 
-set(CROSS_COMPILE ${TOOLCHAIN_HOME}/${CROSS_COMPILE_TARGET}/bin/${CROSS_COMPILE_TARGET}-)
-
-set(SYSROOT_DIR   ${TOOLCHAIN_HOME}/${SYSROOT_TARGET}/${SYSROOT_TARGET})
+if("${ARCH}" STREQUAL "xtensa")
+  set(SYSROOT_DIR ${TOOLCHAIN_HOME}/xtensa/${SOC_NAME}/${SYSROOT_TARGET})
+  set(CROSS_COMPILE ${TOOLCHAIN_HOME}/xtensa/${SOC_NAME}/${CROSS_COMPILE_TARGET}/bin/${CROSS_COMPILE_TARGET}-)
+else()
+  set(SYSROOT_DIR   ${TOOLCHAIN_HOME}/${SYSROOT_TARGET}/${SYSROOT_TARGET})
+  set(CROSS_COMPILE ${TOOLCHAIN_HOME}/${CROSS_COMPILE_TARGET}/bin/${CROSS_COMPILE_TARGET}-)
+endif()
 
 if("${ARCH}" STREQUAL "x86")
   if(CONFIG_X86_64)
-    if(CONFIG_LIB_CPLUSPLUS)
-      # toolchain was built with a few missing bits in
-      # the multilib configuration so we need to specify
-      # where to find the 64-bit libstdc++.
-      LIST(APPEND LIB_INCLUDE_DIR -L${SYSROOT_DIR}/lib64)
-    endif()
-
     list(APPEND TOOLCHAIN_C_FLAGS -m64)
     list(APPEND TOOLCHAIN_LD_FLAGS -m64)
   else()


### PR DESCRIPTION
Xtensa requires building a new toolchain for a specific SoC.
By default xtools built Xtensa toolchains all have prefix of
xtensa-zephyr-elf. In order to distinguish different toolchains,
they are now placed in their own directories under their SoC
name. This allows us to have multiple Xtensa toolchains
targeting multiple SoCs.

The additional level in path name is introduced in SDK v0.11
and sdk-ng master.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>