### PR TITLE
boards: intel_s1000_crb: remove xcc toolchain restriction

### DIFF
--- a/boards/xtensa/intel_s1000_crb/board.cmake
+++ b/boards/xtensa/intel_s1000_crb/board.cmake
@@ -9,7 +9,3 @@ board_finalize_runner_args(intel_s1000
   "--ocd-jtag-instr=dsp0_gdb.txt"
   "--gdb-flash-file=load_elf.txt"
 )
-
-if(NOT "${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "xcc")
-  message(FATAL_ERROR "ZEPHYR_TOOLCHAIN_VARIANT != xcc. This requires xcc to build!")
-endif()

--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.yaml
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.yaml
@@ -4,3 +4,10 @@ type: mcu
 arch: xtensa
 toolchain:
   - xcc
+  - xtools
+  - zephyr
+testing:
+  default: true
+  ignore_tags:
+     - net
+     - bluetooth


### PR DESCRIPTION
This allows applications targeting intel_s1000_crb to be compiled with sdk or xtools toolchain.

Also copy the testing ignore_tags from qemu_xtensa for net and bluetooth.

This requires SDK v0.11 to be the main toolchain before CI will pass.