### PR TITLE
drivers: clock_control: Clarify allowed calling context of API functions

### DIFF
--- a/include/drivers/clock_control.h
+++ b/include/drivers/clock_control.h
@@ -134,9 +134,6 @@ static inline int clock_control_off(struct device *dev,
 /**
  * @brief Request clock to start with notification when clock has been started.
  *
- * User can request delayed start by providing exact information when clock
- * should be ready. Driver ensures that clock is ready before requested time.
- * It is the driver responsibility to take into account clock startup time.
  * When clock is already running user callback will be called from the context
  * of the function call else it is called from other context (e.g. clock
  * interrupt).

--- a/include/drivers/clock_control.h
+++ b/include/drivers/clock_control.h
@@ -117,7 +117,10 @@ static inline int clock_control_on(struct device *dev,
 }
 
 /**
- * @brief Disable the clock of a sub-system controlled by the device
+ * @brief Disable the clock of a sub-system controlled by the device.
+ *
+ * Function is non-blocking and can be called from any context.
+ *
  * @param dev Pointer to the device structure for the clock controller driver
  * 	instance
  * @param sys A pointer to an opaque data representing the sub-system
@@ -134,6 +137,7 @@ static inline int clock_control_off(struct device *dev,
 /**
  * @brief Request clock to start with notification when clock has been started.
  *
+ * Function is non-blocking and can be called from any context.
  * When clock is already running user callback will be called from the context
  * of the function call else it is called from other context (e.g. clock
  * interrupt).


### PR DESCRIPTION
Clarified that clock_control_off and clock_control_async_on can be called from any context since they are non-blocking.

Additionally, fixed:
drivers: clock_control: Remove false description of clock_control_async_on
Description of clock_control_async_on contained information about
delayed start which is not supported by this function call.

Given that https://github.com/zephyrproject-rtos/zephyr/pull/20710#discussion_r348153385, I've updated function descriptions to explicitly state that they can be called from any context.
