### PR TITLE
posix arch: Use zephyr_link_libraries() to set -m32

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -3,10 +3,10 @@
 if (CONFIG_64BIT)
 	# some gcc versions fail to build without -fPIC
 	zephyr_compile_options(-m64 -fPIC)
-	zephyr_ld_options(-m64)
+	zephyr_link_libraries(-m64)
 else ()
 	zephyr_compile_options(-m32)
-	zephyr_ld_options(-m32)
+	zephyr_link_libraries(-m32)
 endif ()
 
 zephyr_compile_options(


### PR DESCRIPTION
For some reason, some users have been facing a bizarre issue
in which the -m32 option was not being passed to the linker
by cmake when building for the POSIX arch as a 32bit target,
even though the option was actually supported.

Instead of using zephyr_ld_options() which checks if an
option is supported and drops it otherwise, use
zephyr_link_libraries()

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

Fixes #10243 (hopefully, some of the reasons)