### PR TITLE
tests: Bluetooth: Bsim tests: expand README a bit

### DIFF
--- a/tests/bluetooth/bsim_bt/README.txt
+++ b/tests/bluetooth/bsim_bt/README.txt
@@ -1,2 +1,11 @@
 This folder contains tests meant to be run with BabbleSim's physical layer
 simulation, and therefore cannot be run directly from sanitycheck
+
+The compile.sh and run_parallel.sh scripts are used by the CI system to build
+the needed images and execute these tests in batch.
+
+You can also run them manually if desired, but be sure to call them setting
+the variables they expect. For example, from Zephyr's root folder, you can run:
+
+WORK_DIR=${ZEPHYR_BASE}/bsim_bt_out tests/bluetooth/bsim_bt/compile.sh
+RESULTS_FILE=${ZEPHYR_BASE}/myresults.xml SEARCH_PATH=tests/bluetooth/bsim_bt/bsim_test_app/tests_scripts tests/bluetooth/bsim_bt/run_parallel.sh


### PR DESCRIPTION
Expand a bit the README file to cover the compile.sh and
run_parallel.sh scripts, in case users would like to use
them locally, to guide them a bit.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

----------------

This is not meant to be documentation for normal users,
but for those who are digging deeper into these tests.

Anyhow, the longer term plan is to move out of using these scripts
in CI and into something a bit more reliable and user friendly.