### PR TITLE
Bluetooth: controller: split: Fix check for control procedures request

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -769,7 +769,6 @@ int ull_conn_llcp(struct ll_conn *conn, u32_t ticks_at_expire, u16_t lazy)
 {
 	LL_ASSERT(conn->lll.handle != 0xFFFF);
 
-#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ) || defined(CONFIG_BT_CTLR_PHY)
 	/* Check if no other procedure with instant is requested and not in
 	 * Encryption setup.
 	 */
@@ -782,10 +781,8 @@ int ull_conn_llcp(struct ll_conn *conn, u32_t ticks_at_expire, u16_t lazy)
 
 		/* TODO: Optimize the checks below, maybe have common flag */
 
-		if (0) {
-
 		/* check if connection update procedure is requested */
-		} else if (conn->llcp_cu.ack != conn->llcp_cu.req) {
+		if (conn->llcp_cu.ack != conn->llcp_cu.req) {
 			/* switch to LLCP_CONN_UPD state machine */
 			conn->llcp_type = LLCP_CONN_UPD;
 			conn->llcp_ack -= 2U;
@@ -831,7 +828,6 @@ int ull_conn_llcp(struct ll_conn *conn, u32_t ticks_at_expire, u16_t lazy)
 #endif /* CONFIG_BT_CTLR_PHY */
 		}
 	}
-#endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ || CONFIG_BT_CTLR_PHY */
 
 	/* check if procedure is requested */
 	if (((conn->llcp_req - conn->llcp_ack) & 0x03) == 0x02) {


### PR DESCRIPTION
Remove wrong #ifdef that guarded the control procedures request check

Fixes #20781