### PR TITLE
TCP2: Add support for arbitrary data payloads

### DIFF
--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -47,8 +47,7 @@ extern "C" {
 #define NET_WARN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
 #define NET_INFO(fmt, ...) LOG_INF(fmt,  ##__VA_ARGS__)
 
-#define NET_ASSERT(cond) __ASSERT_NO_MSG(cond)
-#define NET_ASSERT_INFO(cond, fmt, ...) __ASSERT(cond, fmt, ##__VA_ARGS__)
+#define NET_ASSERT(cond, ...) __ASSERT(cond, "" __VA_ARGS__)
 
 /** @endcond */
 

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -1,7 +1,7 @@
 /* buf.c - Buffer management */
 
 /*
- * Copyright (c) 2015 Intel Corporation
+ * Copyright (c) 2015-2019 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -26,17 +26,15 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define NET_BUF_ERR(fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)
 #define NET_BUF_WARN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
 #define NET_BUF_INFO(fmt, ...) LOG_INF(fmt, ##__VA_ARGS__)
-#define NET_BUF_ASSERT(cond) do { if (!(cond)) {			  \
-			NET_BUF_ERR("assert: '" #cond "' failed"); \
-		} } while (0)
 #else
 
 #define NET_BUF_DBG(fmt, ...)
 #define NET_BUF_ERR(fmt, ...)
 #define NET_BUF_WARN(fmt, ...)
 #define NET_BUF_INFO(fmt, ...)
-#define NET_BUF_ASSERT(cond)
 #endif /* CONFIG_NET_BUF_LOG */
+
+#define NET_BUF_ASSERT(cond, ...) __ASSERT(cond, "" __VA_ARGS__)
 
 #if CONFIG_NET_BUF_WARN_ALLOC_INTERVAL > 0
 #define WARN_ALLOC_INTERVAL K_SECONDS(CONFIG_NET_BUF_WARN_ALLOC_INTERVAL)

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -311,6 +311,9 @@ success:
 	NET_BUF_DBG("allocated buf %p", buf);
 
 	if (size) {
+#if __ASSERT_ON
+		size_t req_size = size;
+#endif
 		if (timeout != K_NO_WAIT && timeout != K_FOREVER) {
 			u32_t diff = k_uptime_get_32() - alloc_start;
 
@@ -324,6 +327,8 @@ success:
 			net_buf_destroy(buf);
 			return NULL;
 		}
+
+		NET_BUF_ASSERT(req_size <= size);
 	} else {
 		buf->__buf = NULL;
 	}
@@ -338,7 +343,6 @@ success:
 	pool->avail_count--;
 	NET_BUF_ASSERT(pool->avail_count >= 0);
 #endif
-
 	return buf;
 }
 

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -268,8 +268,8 @@ static u32_t dhcpv4_send_request(struct net_if *iface)
 	case NET_DHCPV4_SELECTING:
 	case NET_DHCPV4_BOUND:
 		/* Not possible */
-		NET_ASSERT_INFO(0, "Invalid state %s",
-			net_dhcpv4_state_name(iface->config.dhcpv4.state));
+		NET_ASSERT(0, "Invalid state %s",
+			   net_dhcpv4_state_name(iface->config.dhcpv4.state));
 		break;
 	case NET_DHCPV4_REQUESTING:
 		with_server_id = true;

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1410,7 +1410,7 @@ static void ipv6_nd_reachable_timeout(struct k_work *work)
 
 		switch (data->state) {
 		case NET_IPV6_NBR_STATE_STATIC:
-			NET_ASSERT_INFO(false, "Static entry shall never timeout");
+			NET_ASSERT(false, "Static entry shall never timeout");
 			break;
 
 		case NET_IPV6_NBR_STATE_INCOMPLETE:
@@ -1489,7 +1489,7 @@ void net_ipv6_nbr_set_reachable_timer(struct net_if *iface,
 
 	time = net_if_ipv6_get_reachable_time(iface);
 
-	NET_ASSERT_INFO(time, "Zero reachable timeout!");
+	NET_ASSERT(time, "Zero reachable timeout!");
 
 	NET_DBG("Starting reachable timer nbr %p data %p time %d ms",
 		nbr, net_ipv6_nbr_data(nbr), time);

--- a/subsys/net/ip/nbr.c
+++ b/subsys/net/ip/nbr.c
@@ -179,9 +179,9 @@ struct net_nbr *net_nbr_lookup(struct net_nbr_table *table,
 
 struct net_linkaddr_storage *net_nbr_get_lladdr(u8_t idx)
 {
-	NET_ASSERT_INFO(idx < CONFIG_NET_IPV6_MAX_NEIGHBORS,
-			"idx %d >= max %d", idx,
-			CONFIG_NET_IPV6_MAX_NEIGHBORS);
+	NET_ASSERT(idx < CONFIG_NET_IPV6_MAX_NEIGHBORS,
+		   "idx %d >= max %d", idx,
+		   CONFIG_NET_IPV6_MAX_NEIGHBORS);
 
 	return &net_neighbor_lladdr[idx].lladdr;
 }

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -891,11 +891,10 @@ int net_context_connect(struct net_context *context,
 	}
 
 	if (addr->sa_family != net_context_get_family(context)) {
-		NET_ASSERT_INFO(addr->sa_family == \
-				net_context_get_family(context),
-				"Family mismatch %d should be %d",
-				addr->sa_family,
-				net_context_get_family(context));
+		NET_ASSERT(addr->sa_family == net_context_get_family(context),
+			   "Family mismatch %d should be %d",
+			   addr->sa_family,
+			   net_context_get_family(context));
 		ret = -EINVAL;
 		goto unlock;
 	}

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -59,8 +59,8 @@ static inline struct net_route_nexthop *net_nexthop_data(struct net_nbr *nbr)
 
 static inline struct net_nbr *get_nexthop_nbr(struct net_nbr *start, int idx)
 {
-	NET_ASSERT_INFO(idx < CONFIG_NET_MAX_NEXTHOPS, "idx %d >= max %d",
-			idx, CONFIG_NET_MAX_NEXTHOPS);
+	NET_ASSERT(idx < CONFIG_NET_MAX_NEXTHOPS, "idx %d >= max %d",
+		   idx, CONFIG_NET_MAX_NEXTHOPS);
 
 	return (struct net_nbr *)((u8_t *)start +
 			((sizeof(struct net_nbr) + start->size) * idx));
@@ -212,9 +212,9 @@ static struct net_nbr *nbr_nexthop_get(struct net_if *iface,
 		return NULL;
 	}
 
-	NET_ASSERT_INFO(nbr->idx != NET_NBR_LLADDR_UNKNOWN,
-			"Nexthop %s not in neighbor cache!",
-			log_strdup(net_sprint_ipv6_addr(addr)));
+	NET_ASSERT(nbr->idx != NET_NBR_LLADDR_UNKNOWN,
+		   "Nexthop %s not in neighbor cache!",
+		   log_strdup(net_sprint_ipv6_addr(addr)));
 
 	net_nbr_ref(nbr);
 
@@ -242,7 +242,7 @@ static int nbr_nexthop_put(struct net_nbr *nbr)
 	if (CONFIG_NET_ROUTE_LOG_LEVEL >= LOG_LEVEL_DBG) {		\
 		struct in6_addr *naddr = net_route_get_nexthop(route);	\
 									\
-		NET_ASSERT_INFO(naddr, "Unknown nexthop address");	\
+		NET_ASSERT(naddr, "Unknown nexthop address");	\
 									\
 		NET_DBG("%s route to %s via %s (iface %p)", str,	\
 			log_strdup(net_sprint_ipv6_addr(dst)),		\
@@ -695,9 +695,9 @@ bool net_route_mcast_del(struct net_route_entry_mcast *route)
 		return false;
 	}
 
-	NET_ASSERT_INFO(route->is_used,
-			"Multicast route %p to %s was already removed", route,
-			log_strdup(net_sprint_ipv6_addr(&route->group)));
+	NET_ASSERT(route->is_used,
+		   "Multicast route %p to %s was already removed", route,
+		   log_strdup(net_sprint_ipv6_addr(&route->group)));
 
 	route->is_used = false;
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1725,7 +1725,7 @@ int net_tcp_get(struct net_context *context)
 {
 	context->tcp = net_tcp_alloc(context);
 	if (!context->tcp) {
-		NET_ASSERT_INFO(context->tcp, "Cannot allocate TCP context");
+		NET_ASSERT(context->tcp, "Cannot allocate TCP context");
 		return -ENOBUFS;
 	}
 
@@ -2481,8 +2481,8 @@ NET_CONN_CB(tcp_syn_rcvd)
 		} else if (new_context->remote.sa_family == AF_INET6) {
 			addrlen = sizeof(struct sockaddr_in6);
 		} else {
-			NET_ASSERT_INFO(false, "Invalid protocol family %d",
-					new_context->remote.sa_family);
+			NET_ASSERT(false, "Invalid protocol family %d",
+				   new_context->remote.sa_family);
 			net_context_unref(new_context);
 			return NET_DROP;
 		}

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -228,7 +228,7 @@ static const char *tcp_th(struct net_pkt *pkt)
 	}
 
 	if (data_len) {
-		s += snprintf(s, buf_size, ", len=%zd", data_len);
+		s += snprintf(s, buf_size, ", len=%ld", (long int)data_len);
 		buf_size -= s - buf;
 	}
 

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -166,11 +166,11 @@ static char *tcp_endpoint_to_string(union tcp_endpoint *ep)
 
 	switch (af) {
 	case 0:
-		snprintf(s, BUF_SIZE, ":%hu", ntohs(ep->sin.sin_port));
+		snprintk(s, BUF_SIZE, ":%hu", ntohs(ep->sin.sin_port));
 		break;
 	case AF_INET: case AF_INET6:
 		net_addr_ntop(af, &ep->sin.sin_addr, addr, sizeof(addr));
-		snprintf(s, BUF_SIZE, "%s:%hu", addr, ntohs(ep->sin.sin_port));
+		snprintk(s, BUF_SIZE, "%s:%hu", addr, ntohs(ep->sin.sin_port));
 		break;
 	default:
 		s = NULL;
@@ -191,27 +191,27 @@ static const char *tcp_flags(u8_t fl)
 
 	if (fl) {
 		if (fl & SYN) {
-			s += snprintf(s, buf_size, "SYN,");
+			s += snprintk(s, buf_size, "SYN,");
 			buf_size -= s - buf;
 		}
 		if (fl & FIN) {
-			s += snprintf(s, buf_size, "FIN,");
+			s += snprintk(s, buf_size, "FIN,");
 			buf_size -= s - buf;
 		}
 		if (fl & ACK) {
-			s += snprintf(s, buf_size, "ACK,");
+			s += snprintk(s, buf_size, "ACK,");
 			buf_size -= s - buf;
 		}
 		if (fl & PSH) {
-			s += snprintf(s, buf_size, "PSH,");
+			s += snprintk(s, buf_size, "PSH,");
 			buf_size -= s - buf;
 		}
 		if (fl & RST) {
-			s += snprintf(s, buf_size, "RST,");
+			s += snprintk(s, buf_size, "RST,");
 			buf_size -= s - buf;
 		}
 		if (fl & URG) {
-			s += snprintf(s, buf_size, "URG,");
+			s += snprintk(s, buf_size, "URG,");
 			buf_size -= s - buf;
 		}
 		s[strlen(s) - 1] = '\0';
@@ -235,7 +235,7 @@ static const char *tcp_th(struct net_pkt *pkt)
 	*s = '\0';
 
 	if (th->th_off < 5) {
-		s += snprintf(s, buf_size, "Bogus th_off: %hu",
+		s += snprintk(s, buf_size, "Bogus th_off: %hu",
 				(u16_t)th->th_off);
 		buf_size -= s - buf;
 		goto end;
@@ -243,27 +243,27 @@ static const char *tcp_th(struct net_pkt *pkt)
 
 	if (fl) {
 		if (fl & SYN) {
-			s += snprintf(s, buf_size, "SYN=%u,", th_seq(th));
+			s += snprintk(s, buf_size, "SYN=%u,", th_seq(th));
 			buf_size -= s - buf;
 		}
 		if (fl & FIN) {
-			s += snprintf(s, buf_size, "FIN=%u,", th_seq(th));
+			s += snprintk(s, buf_size, "FIN=%u,", th_seq(th));
 			buf_size -= s - buf;
 		}
 		if (fl & ACK) {
-			s += snprintf(s, buf_size, "ACK=%u,", th_ack(th));
+			s += snprintk(s, buf_size, "ACK=%u,", th_ack(th));
 			buf_size -= s - buf;
 		}
 		if (fl & PSH) {
-			s += snprintf(s, buf_size, "PSH,");
+			s += snprintk(s, buf_size, "PSH,");
 			buf_size -= s - buf;
 		}
 		if (fl & RST) {
-			s += snprintf(s, buf_size, "RST,");
+			s += snprintk(s, buf_size, "RST,");
 			buf_size -= s - buf;
 		}
 		if (fl & URG) {
-			s += snprintf(s, buf_size, "URG,");
+			s += snprintk(s, buf_size, "URG,");
 			buf_size -= s - buf;
 		}
 		s[strlen(s) - 1] = '\0';
@@ -271,7 +271,7 @@ static const char *tcp_th(struct net_pkt *pkt)
 	}
 
 	if (data_len) {
-		s += snprintf(s, buf_size, ", len=%ld", (long int)data_len);
+		s += snprintk(s, buf_size, ", len=%ld", (long int)data_len);
 		buf_size -= s - buf;
 	}
 
@@ -545,7 +545,7 @@ static const char *tcp_conn_state(struct tcp *conn, struct net_pkt *pkt)
 #define BUF_SIZE 64
 	static char buf[BUF_SIZE];
 
-	snprintf(buf, BUF_SIZE, "%s %s %u/%u", pkt ? tcp_th(pkt) : "",
+	snprintk(buf, BUF_SIZE, "%s %s %u/%u", pkt ? tcp_th(pkt) : "",
 			tcp_state_to_str(conn->state, false),
 			conn->seq, conn->ack);
 #undef BUF_SIZE

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -387,8 +387,7 @@ static void tcp_send_process(struct k_timer *timer)
 
 static void tcp_send_timer_cancel(struct tcp *conn)
 {
-	NET_ASSERT_INFO(conn->in_retransmission == true,
-			"Not in retransmission");
+	NET_ASSERT(conn->in_retransmission == true, "Not in retransmission");
 
 	k_timer_stop(&conn->send_timer);
 
@@ -434,7 +433,7 @@ static const char *tcp_state_to_str(enum tcp_state state, bool prefix)
 	_(TCP_CLOSED);
 	}
 #undef _
-	NET_ASSERT_INFO(s, "Invalid TCP state: %u", state);
+	NET_ASSERT(s, "Invalid TCP state: %u", state);
 out:
 	return prefix ? s : (s + 4);
 }
@@ -445,7 +444,7 @@ static void tcp_win_append(struct tcp_win *w, const char *name,
 	struct net_buf *buf = tcp_nbuf_alloc(&tcp_nbufs, len);
 	size_t prev_len = w->len;
 
-	NET_ASSERT_INFO(len, "Zero length data");
+	NET_ASSERT(len, "Zero length data");
 
 	memcpy(net_buf_add(buf, len), data, len);
 
@@ -476,7 +475,7 @@ static struct net_buf *tcp_win_peek(struct tcp_win *w, const char *name,
 				struct net_buf, user_data);
 	}
 
-	NET_ASSERT_INFO(len == 0, "Unfulfilled request, len: %zu", len);
+	NET_ASSERT(len == 0, "Unfulfilled request, len: %zu", len);
 
 	NET_DBG("%s len=%zu", name, net_buf_frags_len(out));
 
@@ -1104,8 +1103,8 @@ next_state:
 	case TCP_FIN_WAIT1:
 	case TCP_FIN_WAIT2:
 	default:
-		NET_ASSERT_INFO(false, "%s is unimplemented",
-				tcp_state_to_str(conn->state, true));
+		NET_ASSERT(false, "%s is unimplemented",
+			   tcp_state_to_str(conn->state, true));
 	}
 
 	if (fl) {
@@ -1412,10 +1411,10 @@ static struct net_buf *tcp_win_pop(struct tcp_win *w, const char *name,
 {
 	struct net_buf *buf, *out = NULL;
 
-	NET_ASSERT_INFO(len, "Invalid request, len: %zu", len);
+	NET_ASSERT(len, "Invalid request, len: %zu", len);
 
-	NET_ASSERT_INFO(len <= w->len, "Insufficient window length, "
-			"len: %zu, req: %zu", w->len, len);
+	NET_ASSERT(len <= w->len, "Insufficient window length, "
+		   "len: %zu, req: %zu", w->len, len);
 	while (len) {
 
 		buf = tcp_slist(&w->bufs, get, struct net_buf, user_data);
@@ -1427,7 +1426,7 @@ static struct net_buf *tcp_win_pop(struct tcp_win *w, const char *name,
 		len -= buf->len;
 	}
 
-	NET_ASSERT_INFO(len == 0, "Unfulfilled request, len: %zu", len);
+	NET_ASSERT(len == 0, "Unfulfilled request, len: %zu", len);
 
 	NET_DBG("%s len=%zu", name, net_buf_frags_len(out));
 
@@ -1440,7 +1439,7 @@ static ssize_t tcp_recv(int fd, void *buf, size_t len, int flags)
 	ssize_t bytes_received = conn->rcv->len;
 	struct net_buf *data = tcp_win_pop(conn->rcv, "RCV", bytes_received);
 
-	NET_ASSERT_INFO(bytes_received <= len, "Unimplemented");
+	NET_ASSERT(bytes_received <= len, "Unimplemented");
 
 	net_buf_linearize(buf, len, data, 0, net_buf_frags_len(data));
 
@@ -1620,7 +1619,7 @@ bool tp_input(struct net_pkt *pkt)
 		tcp_step();
 		break;
 	default:
-		NET_ASSERT_INFO(false, "Unimplemented tp command: %s", tp->msg);
+		NET_ASSERT(false, "Unimplemented tp command: %s", tp->msg);
 	}
 
 	if (json_len) {

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -748,24 +748,6 @@ static void tcp_csum(struct net_pkt *pkt)
 	th->th_sum = cs(s);
 }
 
-static struct net_pkt *tcp_pkt_linearize(struct net_pkt *pkt)
-{
-	struct net_pkt *new = tcp_pkt_alloc(0);
-	struct net_buf *tmp, *buf = net_pkt_get_frag(new, K_NO_WAIT);
-
-	for (tmp = pkt->frags; tmp; tmp = tmp->frags) {
-		memcpy(net_buf_add(buf, tmp->len), tmp->data, tmp->len);
-	}
-
-	net_pkt_frag_add(new, buf);
-
-	new->iface = pkt->iface;
-
-	tcp_pkt_unref(pkt);
-
-	return new;
-}
-
 static void tcp_chain_free(struct net_buf *head)
 {
 	struct net_buf *next;
@@ -812,8 +794,6 @@ static void tcp_out(struct tcp *conn, u8_t flags, ...)
 
 		tcp_adj(pkt, len);
 	}
-
-	pkt = tcp_pkt_linearize(pkt);
 
 	tcp_csum(pkt);
 

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -28,7 +28,7 @@ static sys_slist_t tcp_conns = SYS_SLIST_STATIC_INIT(&tcp_conns);
 static K_MEM_SLAB_DEFINE(tcp_conns_slab, sizeof(struct tcp),
 				CONFIG_NET_MAX_CONTEXTS, 4);
 
-NET_BUF_POOL_DEFINE(tcp_nbufs, 64/*count*/, 128/*size*/, 0, NULL);
+NET_BUF_POOL_DEFINE(tcp_nbufs, 64/*count*/, CONFIG_NET_BUF_DATA_SIZE, 0, NULL);
 
 static void tcp_in(struct tcp *conn, struct net_pkt *pkt);
 
@@ -43,7 +43,7 @@ static bool tcp_nbufs_reserve(struct tcp *conn, size_t len)
 
 	while (rsv_bytes < len) {
 
-		buf = tcp_nbuf_alloc(conn, 128);
+		buf = tcp_nbuf_alloc(conn, CONFIG_NET_BUF_DATA_SIZE);
 
 		NET_ASSERT(buf);
 
@@ -494,7 +494,8 @@ static void tcp_win_append(struct tcp *conn, struct tcp_win *w,
 	NET_ASSERT(data_len, "Zero length data");
 
 	while (total) {
-		len = (total <= 128) ? total : 128;
+		len = (total <= CONFIG_NET_BUF_DATA_SIZE) ?
+			total : CONFIG_NET_BUF_DATA_SIZE;
 
 		buf = tcp_nbuf_alloc(conn, len);
 
@@ -1590,7 +1591,7 @@ bool tp_input(struct net_pkt *pkt)
 	switch (type) {
 	case TP_COMMAND:
 		if (is("CONNECT", tp->op)) {
-			u8_t data_to_send[128];
+			u8_t data_to_send[CONFIG_NET_BUF_DATA_SIZE];
 			size_t len = tp_str_to_hex(data_to_send,
 						sizeof(data_to_send), tp->data);
 			tp_output(pkt->iface, buf, 1);

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(net_tcp, CONFIG_NET_TCP_LOG_LEVEL);
 #include "net_private.h"
 #include "tcp2_priv.h"
 
-static int tcp_rto = 500; /* Retransmission timeout, msec */
+static int tcp_rto = CONFIG_NET_TCP_INIT_RETRANSMISSION_TIMEOUT;
 static int tcp_retries = 3;
 static int tcp_window = NET_IPV6_MTU;
 static bool tcp_echo;

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -192,7 +192,8 @@ static const char *tcp_th(struct net_pkt *pkt)
 	*s = '\0';
 
 	if (th->th_off < 5) {
-		s += snprintf(s, buf_size, "Bogus th_off: %hu", th->th_off);
+		s += snprintf(s, buf_size, "Bogus th_off: %hu",
+				(u16_t)th->th_off);
 		buf_size -= s - buf;
 		goto end;
 	}
@@ -505,7 +506,7 @@ static bool tcp_options_check(void *buf, ssize_t len)
 		opt = options[0];
 		opt_len = options[1];
 
-		NET_DBG("opt: %hu, opt_len: %hu", opt, opt_len);
+		NET_DBG("opt: %hu, opt_len: %hu", (u16_t)opt, (u16_t)opt_len);
 
 		if (opt == TCPOPT_PAD) {
 			break;
@@ -900,7 +901,8 @@ static enum net_verdict tcp_pkt_received(struct net_conn *net_conn,
 	ARG_UNUSED(proto);
 
 	if (vhl != 0x45) {
-		NET_ERR("conn: %p, Unsupported IP version: 0x%hx", conn, vhl);
+		NET_ERR("conn: %p, Unsupported IP version: 0x%hx", conn,
+			(u16_t)vhl);
 		goto out;
 	}
 

--- a/subsys/net/ip/tcp2.c
+++ b/subsys/net/ip/tcp2.c
@@ -522,7 +522,7 @@ static struct net_buf *tcp_win_peek(struct tcp *conn, struct tcp_win *w,
 
 	while (in && total > 0) {
 
-		out = net_buf_clone(in, K_NO_WAIT);
+		out = tcp_nbuf_clone(in);
 
 		sys_slist_append(&list, (void *)out);
 

--- a/subsys/net/ip/tcp2_priv.h
+++ b/subsys/net/ip/tcp2_priv.h
@@ -192,6 +192,9 @@ extern struct net_buf_pool tcp_nbufs;
 	tp_nbuf_alloc(&tcp_nbufs, _len, tp_basename(__FILE__), \
 			__LINE__, __func__)
 
+#define tcp_nbuf_clone(_buf) \
+	tp_nbuf_clone((_buf), tp_basename(__FILE__), __LINE__, __func__)
+
 #define tcp_nbuf_unref(_nbuf) \
 	tp_nbuf_unref(_nbuf, tp_basename(__FILE__), __LINE__, __func__)
 #else
@@ -213,5 +216,6 @@ static struct net_buf *tcp_nbuf_alloc(struct tcp *conn, size_t len)
 	return buf;
 }
 
+#define tcp_nbuf_clone(_buf) net_buf_clone(_buf, K_NO_WAIT)
 #define tcp_nbuf_unref(_nbuf) net_buf_unref(_nbuf)
 #endif

--- a/subsys/net/ip/tp.c
+++ b/subsys/net/ip/tp.c
@@ -165,6 +165,24 @@ struct net_buf *tp_nbuf_alloc(struct net_buf_pool *pool, size_t len,
 	return nbuf;
 }
 
+struct net_buf *tp_nbuf_clone(struct net_buf *buf, const char *file, int line,
+				const char *func)
+{
+	struct net_buf *clone = net_buf_clone(buf, K_NO_WAIT);
+	struct tp_nbuf *tb = k_malloc(sizeof(struct tp_nbuf));
+
+	tp_dbg("size=%d %p %s:%d %s()", clone->size, clone, file, line, func);
+
+	tb->nbuf = clone;
+	tb->file = file;
+	tb->line = line;
+
+	sys_slist_append(&tp_nbufs, &tb->next);
+
+	return clone;
+
+}
+
 void tp_nbuf_unref(struct net_buf *nbuf, const char *file, int line,
 			const char *func)
 {

--- a/subsys/net/ip/tp.h
+++ b/subsys/net/ip/tp.h
@@ -128,6 +128,8 @@ void tp_mem_stat(void);
 
 struct net_buf *tp_nbuf_alloc(struct net_buf_pool *pool, size_t len,
 				const char *file, int line, const char *func);
+struct net_buf *tp_nbuf_clone(struct net_buf *buf, const char *file, int line,
+				const char *func);
 void tp_nbuf_unref(struct net_buf *nbuf, const char *file, int line,
 			const char *func);
 void tp_nbuf_stat(void);

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -488,7 +488,7 @@ static void test_send_ns_extra_options(void)
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(icmpv6_ns_invalid),
 					AF_UNSPEC, 0, K_FOREVER);
 
-	NET_ASSERT_INFO(pkt, "Out of TX packets");
+	NET_ASSERT(pkt, "Out of TX packets");
 
 	net_pkt_write(pkt, icmpv6_ns_invalid, sizeof(icmpv6_ns_invalid));
 	net_pkt_lladdr_clear(pkt);
@@ -511,7 +511,7 @@ static void test_send_ns_no_options(void)
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(icmpv6_ns_no_sllao),
 					AF_UNSPEC, 0, K_FOREVER);
 
-	NET_ASSERT_INFO(pkt, "Out of TX packets");
+	NET_ASSERT(pkt, "Out of TX packets");
 
 	net_pkt_write(pkt, icmpv6_ns_no_sllao, sizeof(icmpv6_ns_no_sllao));
 	net_pkt_lladdr_clear(pkt);
@@ -627,7 +627,7 @@ static void test_hbho_message(void)
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(ipv6_hbho),
 					AF_UNSPEC, 0, K_FOREVER);
 
-	NET_ASSERT_INFO(pkt, "Out of TX packets");
+	NET_ASSERT(pkt, "Out of TX packets");
 
 	net_pkt_write(pkt, ipv6_hbho, sizeof(ipv6_hbho));
 	net_pkt_lladdr_clear(pkt);
@@ -678,7 +678,7 @@ static void test_hbho_message_1(void)
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(ipv6_hbho_1),
 					AF_UNSPEC, 0, K_FOREVER);
 
-	NET_ASSERT_INFO(pkt, "Out of TX packets");
+	NET_ASSERT(pkt, "Out of TX packets");
 
 	net_pkt_write(pkt, ipv6_hbho_1, sizeof(ipv6_hbho_1));
 
@@ -738,7 +738,7 @@ static void test_hbho_message_2(void)
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(ipv6_hbho_2),
 					AF_UNSPEC, 0, K_FOREVER);
 
-	NET_ASSERT_INFO(pkt, "Out of TX packets");
+	NET_ASSERT(pkt, "Out of TX packets");
 
 
 	net_pkt_write(pkt, ipv6_hbho_2, sizeof(ipv6_hbho_2));
@@ -901,7 +901,7 @@ static void test_hbho_message_3(void)
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(ipv6_hbho_3),
 					AF_UNSPEC, 0, K_FOREVER);
 
-	NET_ASSERT_INFO(pkt, "Out of TX packets");
+	NET_ASSERT(pkt, "Out of TX packets");
 
 	net_pkt_write(pkt, ipv6_hbho_3, sizeof(ipv6_hbho_3));
 	net_pkt_lladdr_clear(pkt);


### PR DESCRIPTION
At present, TCP2 can’t correctly handle payloads greater than 128 bytes.

So, add support for arbitrary data payloads.

As a result, eliminate net_pkt_linearize().