### PR TITLE
DTC warning suppression

### DIFF
--- a/boards/arm/lpcxpresso54114/pre_dt_board.cmake
+++ b/boards/arm/lpcxpresso54114/pre_dt_board.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2019, NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "simple_bus_reg" on LPC boards as all GPIO ports use the same register.
+list(APPEND EXTRA_DTC_FLAGS "-Wno-simple_bus_reg")

--- a/boards/arm/lpcxpresso55s69/pre_dt_board.cmake
+++ b/boards/arm/lpcxpresso55s69/pre_dt_board.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2019, NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "simple_bus_reg" on LPC boards as all GPIO ports use the same register.
+list(APPEND EXTRA_DTC_FLAGS "-Wno-simple_bus_reg")

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -442,6 +442,9 @@ set(CMAKE_CXX_COMPILER_FORCED 1)
 
 include(${ZEPHYR_BASE}/cmake/host-tools.cmake)
 
+# Include board specific device-tree flags before parsing.
+include(${BOARD_DIR}/pre_dt_board.cmake OPTIONAL)
+
 # DTS should be close to kconfig because CONFIG_ variables from
 # kconfig and dts should be available at the same time.
 #

--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -195,6 +195,7 @@ if(SUPPORTS_DTS)
 
   set(CMD_NEW_EXTRACT ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/dts/gen_defines.py
   --dts ${BOARD}.dts.pre.tmp
+  --dtc-flags '${EXTRA_DTC_FLAGS}'
   --bindings-dirs ${DTS_ROOT_BINDINGS}
   --conf-out ${DEVICETREE_CONF}
   --header-out ${DEVICETREE_UNFIXED_H}

--- a/doc/guides/dts/index.rst
+++ b/doc/guides/dts/index.rst
@@ -290,6 +290,14 @@ file. It includes the generated :file:`include/devicetree_unfixed.h` and
    Do not include the generated C headers from the build directory directly.
    Include :file:`devicetree.h` instead.
 
+Since some boards may need special instructions for the device tree compiler
+(e.g. warning suppression), create a file named ``pre_dt_board.cmake`` inside
+the board's folder and add the extra flags inside.
+
+.. code-block:: cmake
+
+   list(APPEND EXTRA_DTC_FLAGS "-Wno-simple_bus_reg")
+
 Generated macros
 ================
 

--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -82,6 +82,9 @@ from dtlib import DT, DTError, to_num, to_nums, TYPE_EMPTY, TYPE_NUMS, \
                   TYPE_PHANDLE, TYPE_PHANDLES_AND_NUMS
 from grutils import Graph
 
+
+dtc_flags = ""
+
 #
 # Public classes
 #
@@ -776,6 +779,8 @@ class Node:
       The flash controller for the node. Only meaningful for nodes representing
       flash partitions.
     """
+    global dtc_flags
+
     @property
     def name(self):
         "See the class docstring"
@@ -797,9 +802,12 @@ class Node:
 
         addr = _translate(addr, self._node)
 
-        if self.regs and self.regs[0].addr != addr:
-            self.edt._warn("unit-address and first reg (0x{:x}) don't match "
-                           "for {}".format(self.regs[0].addr, self.name))
+        # This code is redundant, it checks the same thing as simple_bus_reg in
+        # dtc, we disable it in python if it's suppressed in dtc.
+        if "-Wno-simple_bus_reg" not in dtc_flags:
+            if self.regs and self.regs[0].addr != addr:
+                self.edt._warn("unit-address and first reg (0x{:x}) don't match "
+                               "for {}".format(self.regs[0].addr, self.name))
 
         return addr
 

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -45,6 +45,7 @@ def main():
     conf_file = open(args.conf_out, "w", encoding="utf-8")
     header_file = open(args.header_out, "w", encoding="utf-8")
     flash_area_num = 0
+    edtlib.dtc_flags = args.dtc_flags
 
     write_top_comment(edt)
 
@@ -89,6 +90,7 @@ def parse_args():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--dts", required=True, help="DTS file")
+    parser.add_argument("--dtc-flags", help="extra device tree parameters")
     parser.add_argument("--bindings-dirs", nargs='+', required=True,
                         help="directory with bindings in YAML format, "
                         "we allow multiple")


### PR DESCRIPTION
Allows boards to have a extra.cmake that allows for custom cmake commands.
We use the extra.cmake file to set EXTRA_DTC_FLAGS to suppress warnings on LPC SoC that have a single register address for all gpio ports.

Fixes #20748