### PR TITLE
Make it explicit in getting started that environment variables are needed

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -337,13 +337,20 @@ including: compiler, assembler, linker, and their dependencies.
 
    .. group-tab:: macOS
 
-      The Zephyr SDK is not supported on macOS.  See instructions for
+      #. The Zephyr SDK is not supported on macOS.  See instructions for
       :ref:`installing 3rd-party toolchains<gs_toolchain>`.
+
+      #. Do not forget to set environment variables (ZEPHYR_TOOLCHAIN_VARIANT and toolchain specific ones)
+         to let the build system know where to find the toolchain programs.
 
    .. group-tab:: Windows
 
-      The Zephyr SDK is not supported on Windows.  See instructions for
+      #. The Zephyr SDK is not supported on Windows.  See instructions for
       :ref:`installing 3rd-party toolchains<gs_toolchain>`.
+
+      #. Do not forget to set environment variables (ZEPHYR_TOOLCHAIN_VARIANT and toolchain specific ones)
+         to let the build system know where to find the toolchain programs.
+
 
 .. _getting_started_run_sample:
 


### PR DESCRIPTION
In getting started, in case of macOS and Windows, the need to set
zephyr specific environment variables is only specified several links
away from the getting started, which can be easily missed for someone
who already has the toolchain installed. So just remind the user.

I forgot to do it as I already have GCC installed and didn't follow the links down to 
https://builds.zephyrproject.org/zephyrproject-rtos/zephyr/19123/docs/getting_started/toolchain_3rd_party_x_compilers.html#gnu-arm-embedded

Maybe this can save others some time. 

