### PR TITLE
native_posix: Ensure printf fed type matches format specifier

### DIFF
--- a/boards/posix/native_posix/hw_models_top.c
+++ b/boards/posix/native_posix/hw_models_top.c
@@ -102,8 +102,8 @@ static void hwm_sleep_until_next_timer(void)
 		/* LCOV_EXCL_START */
 		posix_print_warning("next_timer_time corrupted (%"PRIu64"<= %"
 				PRIu64", timer idx=%i)\n",
-				next_timer_time,
-				simu_time,
+				(uint64_t)next_timer_time,
+				(uint64_t)simu_time,
 				next_timer_index);
 		/* LCOV_EXCL_STOP */
 	}


### PR DESCRIPTION
In Zephyr we have the rule of "do not use stdint defined types",
but unfortunately that leaves us with no properly defined
format specifiers for printing values out.
So cast to stdint types in this expression to actually be able to
do so.

Fixes Coverity CID: 205798
Fixes Coverity CID: 205825
Fixes #20826
Fixes #20834

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>