### PR TITLE
Bluetooth: Host: Fix deadlock calling API functions from SMP callbacks

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1209,18 +1209,14 @@ int bt_conn_send_cb(struct bt_conn *conn, struct net_buf *buf,
 
 static bool conn_tx_internal(bt_conn_tx_cb_t cb)
 {
+	/* Only functions which are known to not block on anything that may
+	 * depend on the TX thread itself, thereby causing a deadlock, are
+	 * considered internal in this context.
+	 * This means that e.g. SMP callbacks cannot be considered internal,
+	 * since they may perform application callbacks and dependency on the
+	 * TX thread is then out of our control.
+	 */
 	if (cb == att_pdu_sent || cb == att_cfm_sent || cb == att_rsp_sent ||
-#if defined(CONFIG_BT_SMP)
-#if defined(CONFIG_BT_PRIVACY)
-	    cb == smp_id_sent ||
-#endif /* CONFIG_BT_PRIVACY */
-#if defined(CONFIG_BT_SIGNING)
-	    cb == smp_sign_info_sent ||
-#endif /* CONFIG_BT_SIGNING */
-#if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
-	    cb == smp_ident_sent ||
-#endif /* CONFIG_BT_SMP_SC_PAIR_ONLY */
-#endif /* CONFIG_BT_SMP */
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	    cb == l2cap_chan_sdu_sent ||
 #endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
@@ -1242,7 +1238,7 @@ void bt_conn_notify_tx(struct bt_conn *conn)
 
 		/* Only submit if there is a callback set */
 		if (tx->data.cb) {
-			/* Submit using RX thread if internal callback */
+			/* Submit using TX thread if internal callback */
 			if (conn_tx_internal(tx->data.cb)) {
 				tx_notify_cb(&tx->work);
 			} else {

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -762,14 +762,14 @@ static void smp_check_complete(struct bt_conn *conn, u8_t dist_complete)
 #endif
 
 #if defined(CONFIG_BT_PRIVACY)
-void smp_id_sent(struct bt_conn *conn, void *user_data)
+static void smp_id_sent(struct bt_conn *conn, void *user_data)
 {
 	smp_check_complete(conn, BT_SMP_DIST_ID_KEY);
 }
 #endif /* CONFIG_BT_PRIVACY */
 
 #if defined(CONFIG_BT_SIGNING)
-void smp_sign_info_sent(struct bt_conn *conn, void *user_data)
+static void smp_sign_info_sent(struct bt_conn *conn, void *user_data)
 {
 	smp_check_complete(conn, BT_SMP_DIST_SIGN);
 }
@@ -1926,7 +1926,7 @@ static u8_t smp_send_pairing_confirm(struct bt_smp *smp)
 }
 
 #if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
-void smp_ident_sent(struct bt_conn *conn, void *user_data)
+static void smp_ident_sent(struct bt_conn *conn, void *user_data)
 {
 	smp_check_complete(conn, BT_SMP_DIST_ENC_KEY);
 }

--- a/subsys/bluetooth/host/smp.h
+++ b/subsys/bluetooth/host/smp.h
@@ -146,11 +146,6 @@ int bt_smp_le_oob_get_sc_data(struct bt_conn *conn,
 			      const struct bt_le_oob_sc_data **oobd_local,
 			      const struct bt_le_oob_sc_data **oobd_remote);
 
-
-void smp_ident_sent(struct bt_conn *conn, void *user_data);
-void smp_id_sent(struct bt_conn *conn, void *user_data);
-void smp_sign_info_sent(struct bt_conn *conn, void *user_data);
-
 /** brief Verify signed message
  *
  *  @param conn Bluetooth connection


### PR DESCRIPTION
Fix deadlock in Bluetooth Host. Deadlock could happen from the SMP
callbacks when calling Bluetooth API functions. This is because the
callbacks was given directly from the HCI TX thread. If the calling
API function resulted in trying to send a new HCI command it would post
this HCI command to the HCI TX thread and then wait for command complete
event. This would result in the HCI TX thread blocked waiting for the
itself to process the command.

Example:
Calling bt_conn_le_conn_param_update from pairing_complete callback.

Fixes: #20833