### PR TITLE
doc: fix ordered lists in doxygen comments

### DIFF
--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -154,9 +154,10 @@ extern "C" {
  * @brief Define alignment of a stack buffer
  *
  * This is used for two different things:
- * 1) Used in checks for stack size to be a multiple of the stack buffer
+ *
+ * -# Used in checks for stack size to be a multiple of the stack buffer
  *    alignment
- * 2) Used to determine the alignment of a stack buffer
+ * -# Used to determine the alignment of a stack buffer
  *
  */
 #define STACK_ALIGN MAX(Z_THREAD_MIN_STACK_ALIGN, Z_MPU_GUARD_ALIGN)

--- a/include/arch/x86/ia32/arch.h
+++ b/include/arch/x86/ia32/arch.h
@@ -379,8 +379,8 @@ struct k_thread;
  * The @a options parameter indicates which floating point register sets
  * will be used by the specified thread:
  *
- *  a) K_FP_REGS  indicates x87 FPU and MMX registers only
- *  b) K_SSE_REGS indicates SSE registers (and also x87 FPU and MMX registers)
+ * - K_FP_REGS  indicates x87 FPU and MMX registers only
+ * - K_SSE_REGS indicates SSE registers (and also x87 FPU and MMX registers)
  *
  * Invoking this routine initializes the thread's floating point context info
  * to that of an FPU that has been reset. The next time the thread is scheduled

--- a/include/sys/arch_interface.h
+++ b/include/sys/arch_interface.h
@@ -136,13 +136,13 @@ void arch_cpu_idle(void);
  *
  * The requirements for arch_cpu_atomic_idle() are as follows:
  *
- * 1) Enabling interrupts and entering a low-power mode needs to be
+ * -# Enabling interrupts and entering a low-power mode needs to be
  *    atomic, i.e. there should be no period of time where interrupts are
  *    enabled before the processor enters a low-power mode.  See the comments
  *    in k_lifo_get(), for example, of the race condition that
  *    occurs if this requirement is not met.
  *
- * 2) After waking up from the low-power mode, the interrupt lockout state
+ * -# After waking up from the low-power mode, the interrupt lockout state
  *    must be restored as indicated in the 'key' input parameter.
  *
  * @see k_cpu_atomic_idle()


### PR DESCRIPTION
doxygen does not support ordered (numbered) lists using reST syntax
``1)`` or ``a)`` unless the doxygen comments are bounded by ``@rst`` and
``@endrst`` markers.  The "doxygen" way to do ordered lists is to use
``-#``.  This PR cleans this up for our API documentation.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>