### PR TITLE
drivers: CAN: Abstract blocking send call

### DIFF
--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -24,6 +24,14 @@ LOG_MODULE_REGISTER(can_driver);
 
 #define WORK_BUF_FULL 0xFFFF
 
+void can_common_isr_callback_handler(u32_t err, void *cb_arg)
+{
+	struct can_send_wait *send_wait = (struct can_send_wait *) cb_arg;
+
+	send_wait->err = err;
+	k_sem_give(&send_wait->sem);
+}
+
 static void can_msgq_put(struct zcan_frame *frame, void *arg)
 {
 	struct k_msgq *msgq = (struct k_msgq *)arg;

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -389,6 +389,8 @@ static int mcp2515_send(struct device *dev, const struct zcan_frame *msg,
 	u8_t len;
 	u8_t tx_frame[MCP2515_FRAME_LEN];
 
+	__ASSERT(callback != NULL, "callback is null");
+
 	if (msg->dlc > CAN_MAX_DLC) {
 		LOG_ERR("DLC of %d exceeds maximum (%d)", msg->dlc, CAN_MAX_DLC);
 		return CAN_TX_EINVAL;
@@ -431,10 +433,6 @@ static int mcp2515_send(struct device *dev, const struct zcan_frame *msg,
 	/* request tx slot transmission */
 	nnn = BIT(tx_idx);
 	mcp2515_cmd_rts(dev, nnn);
-
-	if (callback == NULL) {
-		k_sem_take(&dev_data->tx_cb[tx_idx].sem, K_FOREVER);
-	}
 
 	return 0;
 }
@@ -564,11 +562,7 @@ static void mcp2515_tx_done(struct device *dev, u8_t tx_idx)
 {
 	struct mcp2515_data *dev_data = DEV_DATA(dev);
 
-	if (dev_data->tx_cb[tx_idx].cb == NULL) {
-		k_sem_give(&dev_data->tx_cb[tx_idx].sem);
-	} else {
-		dev_data->tx_cb[tx_idx].cb(0, dev_data->tx_cb[tx_idx].cb_arg);
-	}
+	dev_data->tx_cb[tx_idx].cb(CAN_TX_OK, dev_data->tx_cb[tx_idx].cb_arg);
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 	dev_data->tx_busy_map &= ~BIT(tx_idx);
@@ -745,9 +739,6 @@ static int mcp2515_init(struct device *dev)
 	k_sem_init(&dev_data->int_sem, 0, 1);
 	k_mutex_init(&dev_data->mutex);
 	k_sem_init(&dev_data->tx_sem, MCP2515_TX_CNT, MCP2515_TX_CNT);
-	k_sem_init(&dev_data->tx_cb[0].sem, 0, 1);
-	k_sem_init(&dev_data->tx_cb[1].sem, 0, 1);
-	k_sem_init(&dev_data->tx_cb[2].sem, 0, 1);
 
 	/* SPI config */
 	dev_data->spi_cfg.operation = SPI_WORD_SET(8);

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -19,7 +19,6 @@
 #define DEV_DATA(dev) ((struct mcp2515_data *const)(dev)->driver_data)
 
 struct mcp2515_tx_cb {
-	struct k_sem sem;
 	can_tx_callback_t cb;
 	void *cb_arg;
 };

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -42,8 +42,6 @@
 struct can_mailbox {
 	can_tx_callback_t tx_callback;
 	void *callback_arg;
-	struct k_sem tx_int_sem;
-	u32_t error_flags;
 };
 
 


### PR DESCRIPTION
This commit moves the semaphore for a blocking call from
the driver implementation to the stack of the caller.
It reduces the complexity of the drivers and saves some RAM.

Fixes #22379