### PR TITLE
net: ip: 6lo: Add NULL ptr check for dst context

### DIFF
--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -1434,6 +1434,11 @@ static bool uncompress_IPHC_header(struct net_pkt *pkt)
 	} else {
 		if (iphc & NET_6LO_IPHC_DAC_1) {
 #if defined(CONFIG_NET_6LO_CONTEXT)
+			if (!dst) {
+				NET_ERR("Dst context doesn't exists");
+				goto fail;
+			}
+
 			cursor = uncompress_da_ctx(iphc, cursor, ipv6, dst, pkt);
 #else
 			NET_ERR("Context based uncompression not enabled");


### PR DESCRIPTION
This commit adds a NULL pointer check for the destination
context pointer. The pointer is NULL in case the context
does not exist.

This PR is a fix for the Coverty CID 205814

Fixes #20868