### PR TITLE
Fix Coverity issue

### DIFF
--- a/samples/net/sockets/dumb_http_server_mt/src/main.c
+++ b/samples/net/sockets/dumb_http_server_mt/src/main.c
@@ -165,7 +165,7 @@ static void client_conn_handler(void *ptr1, void *ptr2, void *ptr3)
 		 * We are assuming here that the full HTTP request is received
 		 * in one TCP segment which in real life might not.
 		 */
-		if (strstr(buf, "\r\n\r\n")) {
+		if (strstr(buf, "\r\n\r\n\0")) {
 			break;
 		}
 	} while (true);


### PR DESCRIPTION
strstr() expects null-terminated string. But the terminating
null bytes ('\0') are not compared.

Fixes #20507
Coverity CID :205662
