### PR TITLE
subsys/fs: nvs Coverty CID205795 & CID205803 corrections

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -553,7 +553,8 @@ static int nvs_startup(struct nvs_fs *fs)
 	 * a closed sector, this is where NVS can to write.
 	 */
 	for (i = 0; i < fs->sector_count; i++) {
-		addr = (i << ADDR_SECT_SHIFT) + fs->sector_size - ate_size;
+		addr = (i << ADDR_SECT_SHIFT) +
+		       (u16_t)(fs->sector_size - ate_size);
 		rc = nvs_flash_cmp_const(fs, addr, 0xff,
 					  sizeof(struct nvs_ate));
 		if (rc) {
@@ -671,7 +672,7 @@ end:
 int nvs_clear(struct nvs_fs *fs)
 {
 	int rc;
-	off_t addr;
+	u32_t addr;
 
 	if (!fs->ready) {
 		LOG_ERR("NVS not initialized");


### PR DESCRIPTION
In nvs writing addresses are u32_t. Coverty reports two situations
where the address could be converted (unwanted) to a signed value.
Both have been corrected.

There is however a general problem with flash API where the addresses
are defined as off_t which is a s32_t. These are converted in the flash
hal to u32_t. As a result of this only half of the possible range can
be used.

Closes #20867
Closes #20866

Signed-off-by: Laczen JMS <laczenjms@gmail.com>