### PR TITLE
drivers: bluetooth: hci: rpmsg: fix handling of hci events

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -50,7 +50,7 @@ config BT_DISCARDABLE_BUF_COUNT
 	range 1 255
 	default 20 if BT_MESH
 	default 3
-	depends on BT_H4 || BT_CTLR
+	depends on BT_H4 || BT_RPMSG || BT_CTLR
 	help
 	  Number of buffers in a separate buffer pool for events which
 	  the HCI driver considers discardable. Examples of such events


### PR DESCRIPTION
Fixed handling of HCI events in the HCI driver over RPMsg. Now,
the driver makes use of discardable buffer pool when allocating
memory for certain HCI event types (e.g. Advertising Report Event).
Applications that are flooded with Advertising Reports will run
much better after this change (e.g. Mesh applications).

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>