### PR TITLE
bluetooth: host: Add flag to prevent client resubscription on reconnect

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1278,6 +1278,20 @@ enum {
 	 */
 	BT_GATT_SUBSCRIBE_FLAG_VOLATILE,
 
+	/** No resubscribe flag
+	 *
+	 * By default when BT_GATT_SUBSCRIBE_FLAG_VOLATILE is unset, the
+	 * subscription will be automatically renewed when the client
+	 * reconnects, as a workaround for GATT servers that do not persist
+	 * subscriptions.
+	 *
+	 * This flag will disable the automatic resubscription. It is useful
+	 * if the application layer knows that the GATT server remembers
+	 * subscriptions from previous connections and wants to avoid renewing
+	 * the subscriptions.
+	 */
+	BT_GATT_SUBSCRIBE_FLAG_NO_RESUB,
+
 	/** Write pending flag
 	 *
 	 * If set, indicates write operation is pending waiting remote end to

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3579,11 +3579,15 @@ static void add_subscriptions(struct bt_conn *conn)
 			continue;
 		}
 
-		/* Force write to CCC to workaround devices that don't track
-		 * it properly.
-		 */
-		gatt_write_ccc(conn, params->ccc_handle, params->value,
-			       gatt_write_ccc_rsp, params);
+		if (bt_addr_le_is_bonded(conn->id, &conn->le.dst) &&
+		    !atomic_test_bit(params->flags,
+				     BT_GATT_SUBSCRIBE_FLAG_NO_RESUB)) {
+			/* Force write to CCC to workaround devices that don't
+			 * track it properly.
+			 */
+			gatt_write_ccc(conn, params->ccc_handle, params->value,
+				       gatt_write_ccc_rsp, params);
+		}
 	}
 }
 


### PR DESCRIPTION
When set, the BT_GATT_SUBSCRIBE_FLAG_NO_RESUB flag indicates that the
subscription should not be renewed when reconnecting with the server.

This is useful if the application layer knows that the GATT server
persists subscription information.

Signed-off-by: François Delawarde <fnde@oticon.com>