### PR TITLE
test/kernel: timer_api: Remove 'build_only' on tickless variant

### DIFF
--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -3,7 +3,7 @@ tests:
     tags: kernel userspace
     platform_exclude: qemu_x86_coverage qemu_cortex_m0
   kernel.timer.tickless:
-    build_only: true
     extra_args: CONF_FILE="prj_tickless.conf"
     arch_exclude: riscv32 nios2 posix
+    platform_exclude: qemu_x86_coverage qemu_cortex_m0
     tags: kernel userspace


### PR DESCRIPTION
Based on #20905

Checking if #20905 if fixing the CI issue that the 'build_only' directive was meant to bypass