### PR TITLE
Bluetooth: controller: Tune tIFS switching

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -455,8 +455,7 @@ static void sw_switch(u8_t dir, u8_t phy_curr, u8_t flags_curr, u8_t phy_next,
 		/* RX */
 		delay = HAL_RADIO_NS2US_CEIL(
 			hal_radio_rx_ready_delay_ns_get(phy_next, flags_next) -
-			hal_radio_tx_chain_delay_ns_get(phy_curr, flags_curr)) +
-			4; /* 4us as +/- active jitter */
+			hal_radio_tx_chain_delay_ns_get(phy_curr, flags_curr));
 
 		hal_radio_rxen_on_sw_switch(ppi);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -315,7 +315,6 @@ static void isr_tx(void *param)
 	u32_t hcto;
 
 	/* TODO: MOVE to a common interface, isr_lll_radio_status? */
-
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		lll_prof_latency_capture();
 	}
@@ -330,17 +329,19 @@ static void isr_tx(void *param)
 	}
 	/* TODO: MOVE ^^ */
 
-	radio_isr_set(isr_rx, param);
+	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
 	radio_switch_complete_and_tx(0, 0, 0, 0);
-	radio_pkt_rx_set(radio_pkt_scratch_get());
 
+	radio_pkt_rx_set(radio_pkt_scratch_get());
 	/* assert if radio packet ptr is not set and radio started rx */
 	LL_ASSERT(!radio_is_ready());
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		lll_prof_cputime_capture();
 	}
+
+	radio_isr_set(isr_rx, param);
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	if (ull_filter_lll_rl_enabled()) {
@@ -591,6 +592,7 @@ static void chan_prepare(struct lll_adv *lll)
 
 	pdu = lll_adv_data_latest_get(lll, &upd);
 	scan_pdu = lll_adv_scan_rsp_latest_get(lll, &upd);
+
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	if (upd) {
 		/* Copy the address from the adv packet we will send into the

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -241,7 +241,6 @@ void lll_conn_isr_rx(void *param)
 #endif /* CONFIG_BT_PERIPHERAL */
 		}
 	} else {
-		radio_isr_set(lll_conn_isr_tx, param);
 		radio_tmr_tifs_set(EVENT_IFS_US);
 
 #if defined(CONFIG_BT_CTLR_PHY)
@@ -249,6 +248,8 @@ void lll_conn_isr_rx(void *param)
 #else /* !CONFIG_BT_CTLR_PHY */
 		radio_switch_complete_and_rx(0);
 #endif /* !CONFIG_BT_CTLR_PHY */
+
+		radio_isr_set(lll_conn_isr_tx, param);
 
 		/* capture end of Tx-ed PDU, used to calculate HCTO. */
 		radio_tmr_end_capture();
@@ -359,7 +360,7 @@ void lll_conn_isr_tx(void *param)
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN || CONFIG_BT_CTLR_GPIO_LNA_PIN */
 	/* TODO: MOVE ^^ */
 
-	radio_isr_set(lll_conn_isr_rx, param);
+	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
 #if defined(CONFIG_BT_CTLR_PHY)
 	radio_switch_complete_and_tx(lll->phy_rx, 0,
@@ -413,6 +414,8 @@ void lll_conn_isr_tx(void *param)
 				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
 #endif /* !CONFIG_BT_CTLR_PHY */
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
+
+	radio_isr_set(lll_conn_isr_rx, param);
 }
 
 void lll_conn_isr_abort(void *param)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -141,9 +141,6 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 		return 0;
 	}
 
-	node_rx = ull_pdu_rx_alloc_peek(1);
-	LL_ASSERT(node_rx);
-
 	radio_reset();
 	/* TODO: other Tx Power settings */
 	radio_tx_power_set(RADIO_TXP_DEFAULT);
@@ -157,6 +154,8 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 	radio_pkt_configure(8, PDU_AC_PAYLOAD_SIZE_MAX, 0);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 
+	node_rx = ull_pdu_rx_alloc_peek(1);
+	LL_ASSERT(node_rx);
 	radio_pkt_rx_set(node_rx->pdu);
 
 	radio_aa_set((u8_t *)&aa);
@@ -167,6 +166,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 	radio_isr_set(isr_rx, lll);
 
+	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
 	radio_switch_complete_and_tx(0, 0, 0, 0);
 
@@ -431,12 +431,12 @@ static void isr_tx(void *param)
 	}
 	/* TODO: MOVE ^^ */
 
-	node_rx = ull_pdu_rx_alloc_peek(1);
-	LL_ASSERT(node_rx);
-
-	radio_isr_set(isr_rx, param);
+	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
 	radio_switch_complete_and_tx(0, 0, 0, 0);
+
+	node_rx = ull_pdu_rx_alloc_peek(1);
+	LL_ASSERT(node_rx);
 	radio_pkt_rx_set(node_rx->pdu);
 
 	/* assert if radio packet ptr is not set and radio started rx */
@@ -466,6 +466,8 @@ static void isr_tx(void *param)
 				 radio_tx_chain_delay_get(0, 0) -
 				 CONFIG_BT_CTLR_GPIO_LNA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_LNA_PIN */
+
+	radio_isr_set(isr_rx, param);
 }
 
 static void isr_common_done(void *param)
@@ -486,13 +488,13 @@ static void isr_common_done(void *param)
 	}
 	/* TODO: MOVE ^^ */
 
-	node_rx = ull_pdu_rx_alloc_peek(1);
-	LL_ASSERT(node_rx);
-
+	/* setup tIFS switching */
 	radio_tmr_tifs_set(EVENT_IFS_US);
 	radio_switch_complete_and_tx(0, 0, 0, 0);
+
+	node_rx = ull_pdu_rx_alloc_peek(1);
+	LL_ASSERT(node_rx);
 	radio_pkt_rx_set(node_rx->pdu);
-	radio_rssi_measure();
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	if (ull_filter_lll_rl_enabled()) {
@@ -501,6 +503,8 @@ static void isr_common_done(void *param)
 		radio_ar_configure(count, irks);
 	}
 #endif /* CONFIG_BT_CTLR_PRIVACY */
+
+	radio_rssi_measure();
 
 	radio_isr_set(isr_rx, param);
 }
@@ -702,12 +706,11 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 		}
 		evt = HDR_LLL2EVT(lll);
 		if (pdu_end_us > (HAL_TICKER_TICKS_TO_US(evt->ticks_slot) -
-				  502 - EVENT_OVERHEAD_START_US -
+				  EVENT_IFS_US - 352 - EVENT_OVERHEAD_START_US -
 				  EVENT_TICKER_RES_MARGIN_US)) {
 			return -ETIME;
 		}
 
-		radio_isr_set(isr_cleanup, lll);
 		radio_switch_complete_and_disable();
 
 		/* Acquire the connection context */
@@ -787,6 +790,7 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 			lll_prof_cputime_capture();
 		}
 
+		radio_isr_set(isr_cleanup, lll);
 
 #if defined(CONFIG_BT_CTLR_GPIO_PA_PIN)
 		if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
@@ -872,6 +876,10 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 		u32_t err;
 
+		/* setup tIFS switching */
+		radio_tmr_tifs_set(EVENT_IFS_US);
+		radio_switch_complete_and_rx(0);
+
 		/* save the adv packet */
 		err = isr_rx_scan_report(lll, rssi_ready,
 					 irkmatch_ok ? rl_idx : FILTER_IDX_NONE,
@@ -902,12 +910,6 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 		memcpy(&pdu_tx->scan_req.adv_addr[0],
 		       &pdu_adv_rx->adv_ind.addr[0], BDADDR_SIZE);
 
-		/* switch scanner state to active */
-		lll->state = 1U;
-		radio_isr_set(isr_tx, lll);
-
-		radio_tmr_tifs_set(EVENT_IFS_US);
-		radio_switch_complete_and_rx(0);
 		radio_pkt_tx_set(pdu_tx);
 
 		/* assert if radio packet ptr is not set and radio started tx */
@@ -936,6 +938,10 @@ static inline u32_t isr_rx_pdu(struct lll_scan *lll, u8_t devmatch_ok,
 					 radio_rx_chain_delay_get(0, 0) -
 					 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN */
+
+		/* switch scanner state to active */
+		lll->state = 1U;
+		radio_isr_set(isr_tx, lll);
 
 		return 0;
 	}


### PR DESCRIPTION
Remove the 4us advanced radio reception, the implementation
passes all timing conformance tests without this.
This change should reduce some radio power consumption by
avoiding redundant reception duration.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>