### PR TITLE
boards: nrf52833_pca10100: fix arduino SPI configuration

### DIFF
--- a/boards/arm/nrf52833_pca10100/Kconfig.defconfig
+++ b/boards/arm/nrf52833_pca10100/Kconfig.defconfig
@@ -34,7 +34,7 @@ if SPI
 config SPI_1
 	default y
 
-config SPI_2
+config SPI_3
 	default y
 
 endif # SPI

--- a/boards/arm/nrf52833_pca10100/nrf52833_pca10100.dts
+++ b/boards/arm/nrf52833_pca10100/nrf52833_pca10100.dts
@@ -184,19 +184,11 @@ arduino_i2c: &i2c0 {
 	miso-pin = <40>;
 };
 
-&spi2 {
-	compatible = "nordic,nrf-spi";
-	status = "okay";
-	sck-pin = <19>;
-	mosi-pin = <20>;
-	miso-pin = <21>;
-};
-
 arduino_spi: &spi3 {
 	status = "okay";
-	sck-pin = <41>;
-	miso-pin = <43>;
-	mosi-pin = <42>;
+	sck-pin = <23>;
+	miso-pin = <22>;
+	mosi-pin = <21>;
 };
 
 &flash0 {


### PR DESCRIPTION
Fix and enable arduino SPI configuration.

The pin properties in arduino_spi node are not the pins connected to the D13, D12, D11.
Also I think spi1 node should be removed because of the conflict with the analog inputs, and spi2 does not make sense at all.

