### PR TITLE
doc: Add native_posix information to 2.1 release note

### DIFF
--- a/doc/releases/release-notes-2.1.rst
+++ b/doc/releases/release-notes-2.1.rst
@@ -21,7 +21,8 @@ Kernel
 Architectures
 *************
 
-* TBD
+* POSIX arch: native_posix & nrf52_bsim: Added support for
+  CONFIG_DYNAMIC_INTERRUPTS
 
 Boards & SoC Support
 ********************


### PR DESCRIPTION
Contains major POSIX arch and native_posix changes between
2.0 and 2.1 releases

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>