### PR TITLE
drivers: espi: xec: Enable OOB channel by default

### DIFF
--- a/drivers/espi/Kconfig.xec
+++ b/drivers/espi/Kconfig.xec
@@ -11,6 +11,9 @@ config ESPI_XEC
 
 if ESPI_XEC
 
+config ESPI_OOB_CHANNEL
+	default y
+
 config ESPI_PERIPHERAL_HOST_IO
 	default  y
 


### PR DESCRIPTION
Enable ESPI OOB channel by default in XEC driver.
Enable OOB channel transmit interrupt and handle OOB up/down correctly.
Change interrupt clearing, clear low level interrupt bits in subhandlers
and high level interrupt at the end of aggregate handlers .

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>