### PR TITLE
Bluetooth: Host: Fix create connection fails to stop scanner

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2054,13 +2054,13 @@ int bt_conn_create_auto_le(const struct bt_le_conn_param *param)
 		return err;
 	}
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_AUTO_CONN);
-
 	return 0;
 }
 
 int bt_conn_create_auto_stop(void)
 {
+	int err;
+
 	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
 		return -EINVAL;
 	}
@@ -2069,11 +2069,7 @@ int bt_conn_create_auto_stop(void)
 		return -EINVAL;
 	}
 
-	int err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_CREATE_CONN_CANCEL, NULL,
-				       NULL);
-
-	atomic_clear_bit(bt_dev.flags, BT_DEV_AUTO_CONN);
-
+	err = bt_le_auto_conn_cancel();
 	if (err) {
 		BT_ERR("Failed to stop initiator");
 		return err;

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -195,6 +195,7 @@ bool bt_le_conn_params_valid(const struct bt_le_conn_param *param);
 int bt_le_scan_update(bool fast_scan);
 
 int bt_le_auto_conn(const struct bt_le_conn_param *conn_param);
+int bt_le_auto_conn_cancel(void);
 
 bool bt_addr_le_is_bonded(u8_t id, const bt_addr_le_t *addr);
 const bt_addr_le_t *bt_lookup_id_addr(u8_t id, const bt_addr_le_t *addr);


### PR DESCRIPTION
Fix race condition in bt_conn_create_le for the state of the scanner in
the Host. This leads to the host issuing a create connection command
without stopping the scanner first. This leads to command disallowed and
failing to establish connection. As well as inconsistent state in the
host which does not allow to stop the running scanner.

The race condition exists because the processing of le_adv_report
handler is done before the thread that called bt_conn_create_le was
woken up to continue after the command_complete event.

Fixes: #20660 