### PR TITLE
doc: tweak CSS for responsive table display

### DIFF
--- a/doc/static/zephyr-custom.css
+++ b/doc/static/zephyr-custom.css
@@ -43,7 +43,7 @@ div.rst-other-versions dl {
    margin-bottom: 0;
 }
 
-/* tweak spacing after a toctree */
+/* tweak spacing after a toctree, fixing issue from sphinx-tabs */
 .toctree-wrapper ul, .section ul {
    margin-bottom: 24px !important;
 }
@@ -295,4 +295,11 @@ div.numbered-step h2::before {
 
 .tab div[class^='highlight']:last-child {
    margin-bottom: 1em;
+}
+
+/* force table content font-size in responsive tables to be 100%
+ * fixing larger font size for paragraphs in the kconfig tables */
+
+.wy-table-responsive td p {
+   font-size:100%;
 }


### PR DESCRIPTION
Noticed that ``<p>`` within a responsive table (as found in the kconfig docs
generated by the new genrest.py script in PR #20322) weren't displaying
using the same font size as table cells without ``<p>`` content. This
situation occurs when the help text in the Kconfig file is more than one
paragraph.

Also added a comment explaining why a previous CSS tweak was added.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>