### PR TITLE
drivers: flash: Fix control flow coverity issue

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -112,6 +112,8 @@ static inline void delay_until_exit_dpd_ok(const struct device *const dev)
 		since -= T_DPDD_MS;
 #endif /* DT_INST_0_JEDEC_SPI_NOR_DPD_WAKEUP_SEQUENCE */
 
+#if defined(DT_INST_0_JEDEC_SPI_NOR_T_ENTER_DPD) ||
+	defined(DT_INST_0_JEDEC_SPI_NOR_DPD_WAKEUP_SEQUENCE)
 		/* If the adjusted time is negative we have to wait
 		 * until it reaches zero before we can proceed.
 		 */
@@ -119,6 +121,8 @@ static inline void delay_until_exit_dpd_ok(const struct device *const dev)
 			k_sleep(K_MSEC((u32_t)-since));
 		}
 	}
+#endif /* DT_INST_0_JEDEC_SPI_NOR_T_ENTER_DPD ||
+	  DT_INST_0_JEDEC_SPI_NOR_DPD_WAKEUP_SEQUENCE */
 #endif /* DT_INST_0_JEDEC_SPI_NOR_HAS_DPD */
 }
 


### PR DESCRIPTION
Coverity CID 205797 exposed a warning in spi_nor.c where if
certain conditional compile options are not set then there
is dead code. Change wraps the potential dead code with
conditional compilation.

Fixes: #20835

Signed-off-by: David Leach <david.leach@nxp.com>