### PR TITLE
ztest: fix ztest_1cpu_user_unit_test()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,6 +570,10 @@ if(CONFIG_APPLICATION_DEFINED_SYSCALL)
   set(SYSCALL_INCLUDE_DIRECTORY --include ${APPLICATION_SOURCE_DIR})
 endif()
 
+if(CONFIG_ZTEST)
+  set(SYSCALL_ZTEST_DIRECTORY --include ${ZEPHYR_BASE}/subsys/testsuite/ztest/include)
+endif()
+
 add_custom_command(
   OUTPUT
   ${syscalls_json}
@@ -578,6 +582,7 @@ add_custom_command(
   ${ZEPHYR_BASE}/scripts/parse_syscalls.py
    --include          ${ZEPHYR_BASE}/include        # Read files from this dir
   ${SYSCALL_INCLUDE_DIRECTORY}
+  ${SYSCALL_ZTEST_DIRECTORY}
   --json-file        ${syscalls_json}              # Write this file
   DEPENDS ${syscalls_subdirs_trigger} ${PARSE_SYSCALLS_HEADER_DEPENDS}
   )

--- a/subsys/testsuite/ztest/include/ztest_test.h
+++ b/subsys/testsuite/ztest/include/ztest_test.h
@@ -130,8 +130,8 @@ static inline void unit_test_noop(void)
 #define ztest_user_unit_test(fn) \
 	ztest_user_unit_test_setup_teardown(fn, unit_test_noop, unit_test_noop)
 
-extern void z_test_1cpu_start(void);
-extern void z_test_1cpu_stop(void);
+__syscall void z_test_1cpu_start(void);
+__syscall void z_test_1cpu_stop(void);
 
 /**
  * @brief Define a SMP-unsafe test function
@@ -206,6 +206,9 @@ extern struct k_mem_domain ztest_mem_domain;
 /**
  * @}
  */
+#ifndef ZTEST_UNITTEST
+#include <syscalls/ztest_test.h>
+#endif
 
 #ifdef __cplusplus
 }

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -98,7 +98,7 @@ static void cpu_hold(void *arg1, void *arg2, void *arg3)
 	arch_irq_unlock(key);
 }
 
-void z_test_1cpu_start(void)
+void z_impl_z_test_1cpu_start(void)
 {
 	cpuhold_active = 1;
 
@@ -116,7 +116,7 @@ void z_test_1cpu_start(void)
 	}
 }
 
-void z_test_1cpu_stop(void)
+void z_impl_z_test_1cpu_stop(void)
 {
 	cpuhold_active = 0;
 
@@ -125,6 +125,19 @@ void z_test_1cpu_stop(void)
 	}
 }
 
+#ifdef CONFIG_USERSPACE
+void z_vrfy_z_test_1cpu_start(void)
+{
+	z_impl_z_test_1cpu_start();
+}
+#include <syscalls/z_test_1cpu_start_mrsh.c>
+
+void z_vrfy_z_test_1cpu_stop(void)
+{
+	z_impl_z_test_1cpu_stop();
+}
+#include <syscalls/z_test_1cpu_stop_mrsh.c>
+#endif /* CONFIG_USERSPACE */
 #endif
 
 static void run_test_functions(struct unit_test *test)


### PR DESCRIPTION
The start/stop functions do a whole pile of supervisor-
only stuff; resolve this by making them ztest-specific
system calls.

Fixes: #20927

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>