### PR TITLE
Fix CoAP coverity issues

### DIFF
--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -726,8 +726,7 @@ static int test_block1_request(struct coap_block_context *req_ctx, u8_t iter)
 		}
 	} else {
 		if (req_ctx->current !=
-		    coap_block_size_to_bytes(COAP_BLOCK_32) *
-		    (iter - 1)) {
+		    coap_block_size_to_bytes(COAP_BLOCK_32) * (iter - 1U)) {
 			TC_PRINT("req:%d,Couldn't get the current block "
 				 "position\n", iter);
 			goto done;
@@ -755,7 +754,7 @@ static int test_block1_response(struct coap_block_context *rsp_ctx, u8_t iter)
 	}
 
 	if (rsp_ctx->current !=
-	    coap_block_size_to_bytes(COAP_BLOCK_32) * (iter - 1)) {
+	    coap_block_size_to_bytes(COAP_BLOCK_32) * (iter - 1U)) {
 		TC_PRINT("rsp:%d, Couldn't get the current block position\n",
 			 iter);
 		goto done;
@@ -954,7 +953,7 @@ static int test_block2_request(struct coap_block_context *req_ctx, u8_t iter)
 	}
 
 	if (req_ctx->current !=
-	    coap_block_size_to_bytes(COAP_BLOCK_64) * (iter - 1)) {
+	    coap_block_size_to_bytes(COAP_BLOCK_64) * (iter - 1U)) {
 		TC_PRINT("req:%d, Couldn't get the current block position\n",
 			 iter);
 		goto done;
@@ -990,8 +989,7 @@ static int test_block2_response(struct coap_block_context *rsp_ctx, u8_t iter)
 		}
 	} else {
 		if (rsp_ctx->current !=
-		    coap_block_size_to_bytes(COAP_BLOCK_64) *
-		    (iter - 1)) {
+		    coap_block_size_to_bytes(COAP_BLOCK_64) * (iter - 1U)) {
 			TC_PRINT("req:%d,Couldn't get the current block "
 				 "position\n", iter);
 			goto done;


### PR DESCRIPTION
Fix unintended sign extension (SIGN_EXTENSION).

The result of "coap_block_size_to_bytes() * iter"
extending the sign type.

current variable from struct coap_block_context is size_t.
So store the result in current_block which is size_t
defined and compare it.

Fixes #20880
Fixes #20881
Fixes #20882
Fixes #20883

Coverity CID :205780
Coverity CID :205786
Coverity CID :205806
Coverity CID :205808