### PR TITLE
drivers: nrf: Fix UART and UARTE hanging on RX errors

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -251,14 +251,8 @@ static void uart_nrfx_poll_out(struct device *dev,
 /** Console I/O function */
 static int uart_nrfx_err_check(struct device *dev)
 {
-	u32_t error = 0U;
-
-	if (nrf_uart_event_check(uart0_addr, NRF_UART_EVENT_ERROR)) {
-		/* register bitfields maps to the defines in uart.h */
-		error = nrf_uart_errorsrc_get_and_clear(uart0_addr);
-	}
-
-	return error;
+	/* register bitfields maps to the defines in uart.h */
+	return nrf_uart_errorsrc_get_and_clear(uart0_addr);
 }
 
 static int uart_nrfx_configure(struct device *dev,
@@ -842,6 +836,10 @@ static void uart_nrfx_irq_callback_set(struct device *dev,
 static void uart_nrfx_isr(void *arg)
 {
 	ARG_UNUSED(arg);
+
+	if (nrf_uart_event_check(uart0_addr, NRF_UART_EVENT_ERROR)) {
+		nrf_uart_event_clear(uart0_addr, NRF_UART_EVENT_ERROR);
+	}
 
 	if (irq_callback) {
 		irq_callback(irq_cb_data);

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -177,6 +177,10 @@ static void uarte_nrfx_isr_int(void *arg)
 		return;
 	}
 
+	if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ERROR)) {
+		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ERROR);
+	}
+
 	if (data->int_driven->cb) {
 		data->int_driven->cb(data->int_driven->cb_data);
 	}
@@ -351,15 +355,9 @@ static int uarte_nrfx_config_get(struct device *dev, struct uart_config *cfg)
 
 static int uarte_nrfx_err_check(struct device *dev)
 {
-	u32_t error = 0U;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
-
-	if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ERROR)) {
-		/* register bitfields maps to the defines in uart.h */
-		error = nrf_uarte_errorsrc_get_and_clear(uarte);
-	}
-
-	return error;
+	/* register bitfields maps to the defines in uart.h */
+	return nrf_uarte_errorsrc_get_and_clear(uarte);
 }
 
 #ifdef CONFIG_UART_ASYNC_API


### PR DESCRIPTION
Add clearing error event to UART and UARTE drivers.
Without it driver goes into infinite interrupt loop.

Fixes #19700 

Signed-off-by: Mieszko Mierunski <mieszko.mierunski@nordicsemi.no>

Solution proposed by @jimparis 