### PR TITLE
[TOPIC-GPIO] update CAN

### DIFF
--- a/boards/shields/dfrobot_can_bus_v2_0/dfrobot_can_bus_v2_0.overlay
+++ b/boards/shields/dfrobot_can_bus_v2_0/dfrobot_can_bus_v2_0.overlay
@@ -11,7 +11,7 @@
 	mcp2515@0 {
 		compatible = "microchip,mcp2515";
 		spi-max-frequency = <1000000>;
-		int-gpios = <&arduino_header 8 0>; /* D2 */
+		int-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>; /* D2 */
 		status = "okay";
 		label = "CAN_1";
 		reg = <0x0>;

--- a/boards/shields/link_board_can/link_board_can.overlay
+++ b/boards/shields/link_board_can/link_board_can.overlay
@@ -14,7 +14,7 @@
 	mcp2515@0 {
 		compatible = "microchip,mcp2515";
 		spi-max-frequency = <1000000>;
-		int-gpios = <&gpio1 7 GPIO_INT_ACTIVE_LOW>;
+		int-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 		status = "okay";
 		label = "CAN_1";
 		reg = <0>;

--- a/dts/bindings/can/microchip,mcp2515.yaml
+++ b/dts/bindings/can/microchip,mcp2515.yaml
@@ -18,6 +18,12 @@ properties:
     int-gpios:
       type: phandle-array
       required: true
+      description: ￼>
+        Interrupt pin.
+
+        This pin signals active low when produced by the controller. The
+        property value should ensure the flags properly describe the signal
+        that is presented to the driver.
     reg:
       type: array
       required: true

--- a/samples/drivers/CAN/src/main.c
+++ b/samples/drivers/CAN/src/main.c
@@ -90,10 +90,10 @@ void change_led(struct zcan_frame *msg, void *led_dev_param)
 
 	switch (msg->data[0]) {
 	case SET_LED:
-		gpio_pin_write(led_dev, DT_ALIAS_LED0_GPIOS_PIN, 1);
+		gpio_pin_set(led_dev, DT_ALIAS_LED0_GPIOS_PIN, 1);
 		break;
 	case RESET_LED:
-		gpio_pin_write(led_dev, DT_ALIAS_LED0_GPIOS_PIN, 0);
+		gpio_pin_set(led_dev, DT_ALIAS_LED0_GPIOS_PIN, 0);
 		break;
 	}
 #else
@@ -220,7 +220,7 @@ void main(void)
 	}
 
 	ret = gpio_pin_configure(led_gpio_dev, DT_ALIAS_LED0_GPIOS_PIN,
-				 GPIO_DIR_OUT);
+				 GPIO_OUTPUT_HIGH | DT_ALIAS_LED0_GPIOS_FLAGS);
 	if (ret < 0) {
 		printk("Error setting LED pin to output mode [%d]", ret);
 	}


### PR DESCRIPTION
Switch both the CAN sample with it's LED blink pattern as well as the MCP2515 driver to the new GPIO API - https://github.com/zephyrproject-rtos/zephyr/issues/20017

