### PR TITLE
Lowercase internal variables in shell scripts

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -20,17 +20,17 @@
 
 set -xe
 
-SANITYCHECK_OPTIONS=" --inline-logs -N --timestamps"
+sanitycheck_options=" --inline-logs -N --timestamps"
 export BSIM_OUT_PATH="${BSIM_OUT_PATH:-/opt/bsim/}"
 if [ ! -d "${BSIM_OUT_PATH}" ]; then
         unset BSIM_OUT_PATH
 fi
 export BSIM_COMPONENTS_PATH="${BSIM_OUT_PATH}/components/"
-BSIM_BT_TEST_RESULTS_FILE="./bsim_bt_out/bsim_results.xml"
-WEST_COMMANDS_RESULTS_FILE="./pytest_out/west_commands.xml"
+bsim_bt_test_results_file="./bsim_bt_out/bsim_results.xml"
+west_commands_results_file="./pytest_out/west_commands.xml"
 
-MATRIX_BUILDS=1
-MATRIX=1
+matrix_builds=1
+matrix=1
 
 function handle_coverage() {
 	# this is for shippable coverage reports
@@ -40,7 +40,7 @@ function handle_coverage() {
 
 	# Upload to codecov.io only on merged builds or if CODECOV_IO variable
 	# is set.
-	if [ -n "${CODECOV_IO}" -o -z "${PULL_REQUEST_NR}" ]; then
+	if [ -n "${CODECOV_IO}" -o -z "${pull_request_nr}" ]; then
 		# Capture data
 		echo "Running lcov --capture ..."
 		lcov --capture \
@@ -97,17 +97,17 @@ function on_complete() {
 		cp ./sanity-out/sanitycheck.xml shippable/testresults/;
 	fi;
 
-	if [ -e ${BSIM_BT_TEST_RESULTS_FILE} ]; then
-		echo "Copy ${BSIM_BT_TEST_RESULTS_FILE}"
-		cp ${BSIM_BT_TEST_RESULTS_FILE} shippable/testresults/;
+	if [ -e ${bsim_bt_test_results_file} ]; then
+		echo "Copy ${bsim_bt_test_results_file}"
+		cp ${bsim_bt_test_results_file} shippable/testresults/;
 	fi;
 
-	if [ -e ${WEST_COMMANDS_RESULTS_FILE} ]; then
-		echo "Copy ${WEST_COMMANDS_RESULTS_FILE}"
-		cp ${WEST_COMMANDS_RESULTS_FILE} shippable/testresults;
+	if [ -e ${west_commands_results_file} ]; then
+		echo "Copy ${west_commands_results_file}"
+		cp ${west_commands_results_file} shippable/testresults;
 	fi;
 
-	if [ "$MATRIX" = "1" ]; then
+	if [ "$matrix" = "1" ]; then
 		echo "Skip handling coverage data..."
 		#handle_coverage
 	else
@@ -117,7 +117,7 @@ function on_complete() {
 
 
 function build_btsim() {
-	NRF_HW_MODELS_VERSION=`cat boards/posix/nrf52_bsim/hw_models_version`
+	nrf_hw_models_version=`cat boards/posix/nrf52_bsim/hw_models_version`
 	pushd . ;
 	cd ${BSIM_COMPONENTS_PATH} ;
 	if [ -d ext_NRF52_hw_models ]; then
@@ -130,7 +130,7 @@ function build_btsim() {
 			exit 1;
 		)
 	else
-		git clone -b ${NRF_HW_MODELS_VERSION} \
+		git clone -b ${nrf_hw_models_version} \
 		https://github.com/BabbleSim/ext_NRF52_hw_models.git
 	fi
 	cd ${BSIM_OUT_PATH}
@@ -140,20 +140,20 @@ function build_btsim() {
 
 function run_bsim_bt_tests() {
 	WORK_DIR=${ZEPHYR_BASE}/bsim_bt_out tests/bluetooth/bsim_bt/compile.sh
-	RESULTS_FILE=${ZEPHYR_BASE}/${BSIM_BT_TEST_RESULTS_FILE} \
+	RESULTS_FILE=${ZEPHYR_BASE}/${bsim_bt_test_results_file} \
 	SEARCH_PATH=tests/bluetooth/bsim_bt/bsim_test_app/tests_scripts \
 	tests/bluetooth/bsim_bt/run_parallel.sh
 }
 
 function get_tests_to_run() {
-	./scripts/ci/get_modified_tests.py --commits ${COMMIT_RANGE} > modified_tests.args;
-	./scripts/ci/get_modified_boards.py --commits ${COMMIT_RANGE} > modified_boards.args;
+	./scripts/ci/get_modified_tests.py --commits ${commit_range} > modified_tests.args;
+	./scripts/ci/get_modified_boards.py --commits ${commit_range} > modified_boards.args;
 
 	if [ -s modified_boards.args ]; then
-		${SANITYCHECK} ${SANITYCHECK_OPTIONS} +modified_boards.args --save-tests test_file_1.txt || exit 1;
+		${sanitycheck} ${sanitycheck_options} +modified_boards.args --save-tests test_file_1.txt || exit 1;
 	fi
 	if [ -s modified_tests.args ]; then
-		${SANITYCHECK} ${SANITYCHECK_OPTIONS} +modified_tests.args --save-tests test_file_2.txt || exit 1;
+		${sanitycheck} ${sanitycheck_options} +modified_tests.args --save-tests test_file_2.txt || exit 1;
 	fi
 	rm -f modified_tests.args modified_boards.args;
 }
@@ -161,10 +161,10 @@ function get_tests_to_run() {
 
 function west_setup() {
 	# West handling
-	GIT_DIR=$(basename $PWD)
+	git_dir=$(basename $PWD)
 	pushd ..
 	if [ ! -d .west ]; then
-		west init -l ${GIT_DIR}
+		west init -l ${git_dir}
 		west update
 	fi
 	popd
@@ -175,44 +175,44 @@ while getopts ":p:m:b:r:M:cfslR:" opt; do
 	case $opt in
 		c)
 			echo "Execute CI" >&2
-			MAIN_CI=1
+			main_ci=1
 			;;
 		l)
 			echo "Executing script locally" >&2
-			LOCAL_RUN=1
-			MAIN_CI=1
+			local_run=1
+			main_ci=1
 			;;
 		s)
 			echo "Success" >&2
-			SUCCESS=1
+			success=1
 			;;
 		f)
 			echo "Failure" >&2
-			FAILURE=1
+			failure=1
 			;;
 		p)
 			echo "Testing a Pull Request: $OPTARG." >&2
-			PULL_REQUEST_NR=$OPTARG
+			pull_request_nr=$OPTARG
 			;;
 		m)
 			echo "Running on Matrix $OPTARG" >&2
-			MATRIX=$OPTARG
+			matrix=$OPTARG
 			;;
 		M)
 			echo "Running a matrix of $OPTARG slaves" >&2
-			MATRIX_BUILDS=$OPTARG
+			matrix_builds=$OPTARG
 			;;
 		b)
 			echo "Base Branch: $OPTARG" >&2
-			BRANCH=$OPTARG
+			branch=$OPTARG
 			;;
 		r)
 			echo "Remote: $OPTARG" >&2
-			REMOTE=$OPTARG
+			remote=$OPTARG
 			;;
 		R)
 			echo "Range: $OPTARG" >&2
-			RANGE=$OPTARG
+			range=$OPTARG
 			;;
 		\?)
 			echo "Invalid option: -$OPTARG" >&2
@@ -220,32 +220,32 @@ while getopts ":p:m:b:r:M:cfslR:" opt; do
 	esac
 done
 
-if [ -n "$MAIN_CI" ]; then
+if [ -n "$main_ci" ]; then
 
 	west_setup
 
-	if [ -z "$BRANCH" ]; then
+	if [ -z "$branch" ]; then
 		echo "No base branch given"
 		exit 1
 	else
-		COMMIT_RANGE=$REMOTE/${BRANCH}..HEAD
-		echo "Commit range:" ${COMMIT_RANGE}
+		commit_range=$remote/${branch}..HEAD
+		echo "Commit range:" ${commit_range}
 	fi
-	if [ -n "$RANGE" ]; then
-		COMMIT_RANGE=$RANGE
+	if [ -n "$range" ]; then
+		commit_range=$range
 	fi
 	source zephyr-env.sh
-	SANITYCHECK="${ZEPHYR_BASE}/scripts/sanitycheck"
+	sanitycheck="${ZEPHYR_BASE}/scripts/sanitycheck"
 
 	# Possibly the only record of what exact version is being tested:
 	short_git_log='git log -n 5 --oneline --decorate --abbrev=12 '
 
-	if [ -n "$PULL_REQUEST_NR" ]; then
-		$short_git_log $REMOTE/${BRANCH}
+	if [ -n "$pull_request_nr" ]; then
+		$short_git_log $remote/${branch}
 		# Now let's pray this script is being run from a
 		# different location
 # https://stackoverflow.com/questions/3398258/edit-shell-script-while-its-running
-		git rebase $REMOTE/${BRANCH};
+		git rebase $remote/${branch};
 	fi
 	$short_git_log
 
@@ -255,22 +255,22 @@ if [ -n "$MAIN_CI" ]; then
 		build_btsim
 
 		# Run BLE tests in simulator on the 1st CI instance:
-		if [ "$MATRIX" = "1" ]; then
+		if [ "$matrix" = "1" ]; then
 			run_bsim_bt_tests
 		fi
 	else
 		echo "Skipping BT simulator tests"
 	fi
 
-	if [ "$MATRIX" = "1" ]; then
+	if [ "$matrix" = "1" ]; then
 		# Run pytest-based testing for Python in matrix
 		# builder 1.  For now, this is just done for the west
 		# extension commands, but additional directories which
 		# run pytest could go here too.
-		PYTEST=$(type -p pytest-3 || echo "pytest")
-		mkdir -p $(dirname ${WEST_COMMANDS_RESULTS_FILE})
-		PYTHONPATH=./scripts/west_commands "${PYTEST}" \
-			  --junitxml=${WEST_COMMANDS_RESULTS_FILE} \
+		pytest=$(type -p pytest-3 || echo "pytest")
+		mkdir -p $(dirname ${west_commands_results_file})
+		PYTHONPATH=./scripts/west_commands "${pytest}" \
+			  --junitxml=${west_commands_results_file} \
 			  ./scripts/west_commands/tests
 	else
 		echo "Skipping west command tests"
@@ -281,24 +281,24 @@ if [ -n "$MAIN_CI" ]; then
 	touch test_file_1.txt test_file_2.txt
 
 	# In a pull-request see if we have changed any tests or board definitions
-	if [ -n "${PULL_REQUEST_NR}" -o -n "${LOCAL_RUN}"  ]; then
+	if [ -n "${pull_request_nr}" -o -n "${local_run}"  ]; then
 		get_tests_to_run
 	fi
 
 	# Save list of tests to be run
-	${SANITYCHECK} ${SANITYCHECK_OPTIONS} --save-tests test_file_3.txt || exit 1
+	${sanitycheck} ${sanitycheck_options} --save-tests test_file_3.txt || exit 1
 	cat test_file_1.txt test_file_2.txt test_file_3.txt > test_file.txt
 
 	# Run a subset of tests based on matrix size
-	${SANITYCHECK} ${SANITYCHECK_OPTIONS} --load-tests test_file.txt \
-		--subset ${MATRIX}/${MATRIX_BUILDS} --retry-failed 3
+	${sanitycheck} ${sanitycheck_options} --load-tests test_file.txt \
+		--subset ${matrix}/${matrix_builds} --retry-failed 3
 
 	# cleanup
 	rm -f test_file*
 
-elif [ -n "$FAILURE" ]; then
+elif [ -n "$failure" ]; then
 	on_complete failure
-elif [ -n "$SUCCESS" ]; then
+elif [ -n "$success" ]; then
 	on_complete
 else
 	echo "Nothing to do"

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -35,7 +35,7 @@ matrix=1
 function handle_coverage() {
 	# this is for shippable coverage reports
 	echo "Calling gcovr"
-	gcovr -r ${ZEPHYR_BASE} -x > shippable/codecoverage/coverage.xml;
+	gcovr -r ${ZEPHYR_BASE} -x > shippable/codecoverage/coverage.xml
 
 
 	# Upload to codecov.io only on merged builds or if CODECOV_IO variable
@@ -48,7 +48,7 @@ function handle_coverage() {
 			--directory sanity-out/nrf52_bsim/ \
 			--directory sanity-out/unit_testing/ \
 			--directory bsim_bt_out/ \
-			--output-file lcov.pre.info -q --rc lcov_branch_coverage=1;
+			--output-file lcov.pre.info -q --rc lcov_branch_coverage=1
 
 		# Remove noise
 		echo "Exclude data from coverage report..."
@@ -58,19 +58,19 @@ function handle_coverage() {
 			--remove lcov.pre.info samples/\* \
 			--remove lcov.pre.info ext/\* \
 			--remove lcov.pre.info *generated* \
-			-o lcov.info --rc lcov_branch_coverage=1;
+			-o lcov.info --rc lcov_branch_coverage=1
 
 		# Cleanup
-		rm lcov.pre.info;
-		rm -rf sanity-out out-2nd-pass;
+		rm lcov.pre.info
+		rm -rf sanity-out out-2nd-pass
 
 		# Upload to codecov.io
 		echo "Upload coverage reports to codecov.io"
-		bash <(curl -s https://codecov.io/bash) -f "lcov.info" -X coveragepy -X fixes;
-		rm -f lcov.info;
+		bash <(curl -s https://codecov.io/bash) -f "lcov.info" -X coveragepy -X fixes
+		rm -f lcov.info
 	fi
 
-	rm -rf sanity-out out-2nd-pass;
+	rm -rf sanity-out out-2nd-pass
 
 }
 
@@ -79,7 +79,7 @@ function handle_compiler_cache() {
 	if [ -f "$HOME/.cache/zephyr/ToolchainCapabilityDatabase.cmake" ]; then
 		echo "Dumping the capability database in case we are affected by #9992"
 		cat $HOME/.cache/zephyr/ToolchainCapabilityDatabase.cmake
-	fi;
+	fi
 }
 
 function on_complete() {
@@ -94,32 +94,32 @@ function on_complete() {
 
 	if [ -e ./sanity-out/sanitycheck.xml ]; then
 		echo "Copy ./sanity-out/sanitycheck.xml"
-		cp ./sanity-out/sanitycheck.xml shippable/testresults/;
-	fi;
+		cp ./sanity-out/sanitycheck.xml shippable/testresults/
+	fi
 
 	if [ -e ${bsim_bt_test_results_file} ]; then
 		echo "Copy ${bsim_bt_test_results_file}"
-		cp ${bsim_bt_test_results_file} shippable/testresults/;
-	fi;
+		cp ${bsim_bt_test_results_file} shippable/testresults/
+	fi
 
 	if [ -e ${west_commands_results_file} ]; then
 		echo "Copy ${west_commands_results_file}"
-		cp ${west_commands_results_file} shippable/testresults;
-	fi;
+		cp ${west_commands_results_file} shippable/testresults
+	fi
 
 	if [ "$matrix" = "1" ]; then
 		echo "Skip handling coverage data..."
 		#handle_coverage
 	else
-		rm -rf sanity-out out-2nd-pass;
-	fi;
+		rm -rf sanity-out out-2nd-pass
+	fi
 }
 
 
 function build_btsim() {
 	nrf_hw_models_version=`cat boards/posix/nrf52_bsim/hw_models_version`
-	pushd . ;
-	cd ${BSIM_COMPONENTS_PATH} ;
+	pushd .
+	cd ${BSIM_COMPONENTS_PATH}
 	if [ -d ext_NRF52_hw_models ]; then
 		cd ext_NRF52_hw_models
 		git describe --tags --abbrev=0 ${NRF52_HW_MODELS_TAG}\
@@ -127,7 +127,7 @@ function build_btsim() {
 		(
 			echo "`pwd` seems to contain the nRF52 HW\
  models but they are out of date"
-			exit 1;
+			exit 1
 		)
 	else
 		git clone -b ${nrf_hw_models_version} \
@@ -135,7 +135,7 @@ function build_btsim() {
 	fi
 	cd ${BSIM_OUT_PATH}
 	make everything -j 8 -s
-	popd ;
+	popd
 }
 
 function run_bsim_bt_tests() {
@@ -146,16 +146,16 @@ function run_bsim_bt_tests() {
 }
 
 function get_tests_to_run() {
-	./scripts/ci/get_modified_tests.py --commits ${commit_range} > modified_tests.args;
-	./scripts/ci/get_modified_boards.py --commits ${commit_range} > modified_boards.args;
+	./scripts/ci/get_modified_tests.py --commits ${commit_range} > modified_tests.args
+	./scripts/ci/get_modified_boards.py --commits ${commit_range} > modified_boards.args
 
 	if [ -s modified_boards.args ]; then
-		${sanitycheck} ${sanitycheck_options} +modified_boards.args --save-tests test_file_1.txt || exit 1;
+		${sanitycheck} ${sanitycheck_options} +modified_boards.args --save-tests test_file_1.txt || exit 1
 	fi
 	if [ -s modified_tests.args ]; then
-		${sanitycheck} ${sanitycheck_options} +modified_tests.args --save-tests test_file_2.txt || exit 1;
+		${sanitycheck} ${sanitycheck_options} +modified_tests.args --save-tests test_file_2.txt || exit 1
 	fi
-	rm -f modified_tests.args modified_boards.args;
+	rm -f modified_tests.args modified_boards.args
 }
 
 
@@ -245,7 +245,7 @@ if [ -n "$main_ci" ]; then
 		# Now let's pray this script is being run from a
 		# different location
 # https://stackoverflow.com/questions/3398258/edit-shell-script-while-its-running
-		git rebase $remote/${branch};
+		git rebase $remote/${branch}
 	fi
 	$short_git_log
 

--- a/tests/bluetooth/bsim_bt/bsim_test_app/tests_scripts/basic_conn.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/tests_scripts/basic_conn.sh
@@ -4,9 +4,9 @@
 
 # Basic connection test: a central connects to a peripheral and expects a
 # notification
-SIMULATION_ID="basic_conn"
-VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
+simulation_id="basic_conn"
+verbosity_level=2
+process_ids=""; exit_code=0
 
 function Execute(){
   if [ ! -f $1 ]; then
@@ -14,7 +14,7 @@ function Execute(){
  compile it?)\e[39m"
     exit 1
   fi
-  timeout 5 $@ & PROCESS_IDS="$PROCESS_IDS $!"
+  timeout 5 $@ & process_ids="$process_ids $!"
 }
 
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
@@ -25,17 +25,17 @@ BOARD="${BOARD:-nrf52_bsim}"
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_app_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -RealEncryption=0 \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -RealEncryption=0 \
   -testid=peripheral -rs=23
 
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_app_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -RealEncryption=0 \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -RealEncryption=0 \
   -testid=central -rs=6
 
-Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=20e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
+for process_id in $process_ids; do
+  wait $process_id || let "exit_code=$?"
 done
-exit $EXIT_CODE #the last exit code != 0
+exit $exit_code #the last exit code != 0

--- a/tests/bluetooth/bsim_bt/bsim_test_app/tests_scripts/basic_conn_encrypted.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/tests_scripts/basic_conn_encrypted.sh
@@ -4,9 +4,9 @@
 
 # Basic connection test: a central connects to a peripheral and expects a
 # notification
-SIMULATION_ID="basic_conn_encr"
-VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
+simulation_id="basic_conn_encr"
+verbosity_level=2
+process_ids=""; exit_code=0
 
 function Execute(){
   if [ ! -f $1 ]; then
@@ -14,7 +14,7 @@ function Execute(){
  compile it?)\e[39m"
     exit 1
   fi
-  timeout 5 $@ & PROCESS_IDS="$PROCESS_IDS $!"
+  timeout 5 $@ & process_ids="$process_ids $!"
 }
 
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
@@ -25,17 +25,17 @@ BOARD="${BOARD:-nrf52_bsim}"
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_app_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -RealEncryption=1 \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -RealEncryption=1 \
   -testid=peripheral -rs=23
 
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_app_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -RealEncryption=1 \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -RealEncryption=1 \
   -testid=central_encrypted -rs=6
 
-Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=20e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
+for process_id in $process_ids; do
+  wait $process_id || let "exit_code=$?"
 done
-exit $EXIT_CODE #the last exit code != 0
+exit $exit_code #the last exit code != 0

--- a/tests/bluetooth/bsim_bt/bsim_test_app/tests_scripts/basic_conn_encrypted_split.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/tests_scripts/basic_conn_encrypted_split.sh
@@ -4,9 +4,9 @@
 
 # Basic connection test: a central connects to a peripheral and expects a
 # notification
-SIMULATION_ID="basic_conn_encr_split"
-VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
+simulation_id="basic_conn_encr_split"
+verbosity_level=2
+process_ids=""; exit_code=0
 
 function Execute(){
   if [ ! -f $1 ]; then
@@ -14,7 +14,7 @@ function Execute(){
  compile it?)\e[39m"
     exit 1
   fi
-  timeout 5 $@ & PROCESS_IDS="$PROCESS_IDS $!"
+  timeout 5 $@ & process_ids="$process_ids $!"
 }
 
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
@@ -25,17 +25,17 @@ BOARD="${BOARD:-nrf52_bsim}"
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_app_prj_split_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -RealEncryption=1 \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -RealEncryption=1 \
   -testid=peripheral -rs=23
 
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_app_prj_split_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -RealEncryption=1 \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -RealEncryption=1 \
   -testid=central_encrypted -rs=6
 
-Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=20e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
+for process_id in $process_ids; do
+  wait $process_id || let "exit_code=$?"
 done
-exit $EXIT_CODE #the last exit code != 0
+exit $exit_code #the last exit code != 0

--- a/tests/bluetooth/bsim_bt/bsim_test_app/tests_scripts/basic_conn_split.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/tests_scripts/basic_conn_split.sh
@@ -4,9 +4,9 @@
 
 # Basic connection test: a central connects to a peripheral and expects a
 # notification, using the split controller (ULL LLL)
-SIMULATION_ID="basic_conn_split"
-VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
+simulation_id="basic_conn_split"
+verbosity_level=2
+process_ids=""; exit_code=0
 
 function Execute(){
   if [ ! -f $1 ]; then
@@ -14,7 +14,7 @@ function Execute(){
  compile it?)\e[39m"
     exit 1
   fi
-  timeout 5 $@ & PROCESS_IDS="$PROCESS_IDS $!"
+  timeout 5 $@ & process_ids="$process_ids $!"
 }
 
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
@@ -25,17 +25,17 @@ BOARD="${BOARD:-nrf52_bsim}"
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_app_prj_split_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -RealEncryption=0 \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -RealEncryption=0 \
   -testid=peripheral -rs=23
 
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_app_prj_split_conf\
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -RealEncryption=0 \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -RealEncryption=0 \
   -testid=central -rs=6
 
-Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=20e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
+for process_id in $process_ids; do
+  wait $process_id || let "exit_code=$?"
 done
-exit $EXIT_CODE #the last exit code != 0
+exit $exit_code #the last exit code != 0

--- a/tests/bluetooth/bsim_bt/compile.sh
+++ b/tests/bluetooth/bsim_bt/compile.sh
@@ -19,38 +19,38 @@ BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 mkdir -p ${WORK_DIR}
 
 function compile(){
-  local APP_ROOT="${APP_ROOT:-${ZEPHYR_BASE}}"
-  local CONF_FILE="${CONF_FILE:-prj.conf}"
-  local CMAKE_ARGS="${CMAKE_ARGS:-"-DCONFIG_COVERAGE=y"}"
-  local NINJA_ARGS="${NINJA_ARGS:-""}"
+  local app_root="${app_root:-${ZEPHYR_BASE}}"
+  local conf_file="${conf_file:-prj.conf}"
+  local cmake_args="${cmake_args:-"-DCONFIG_COVERAGE=y"}"
+  local ninja_args="${ninja_args:-""}"
 
-  local EXE_NAME="${EXE_NAME:-bs_${BOARD}_${APP}_${CONF_FILE}}"
-  local EXE_NAME=${EXE_NAME//\//_}
-  local EXE_NAME=${EXE_NAME//./_}
-  local EXE_NAME=${BSIM_OUT_PATH}/bin/$EXE_NAME
-  local MAP_FILE_NAME=${EXE_NAME}.Tsymbols
+  local exe_name="${exe_name:-bs_${BOARD}_${app}_${conf_file}}"
+  local exe_name=${exe_name//\//_}
+  local exe_name=${exe_name//./_}
+  local exe_name=${BSIM_OUT_PATH}/bin/$exe_name
+  local map_file_name=${exe_name}.Tsymbols
 
-  local THIS_DIR=${WORK_DIR}/${APP}/${CONF_FILE}
+  local this_dir=${WORK_DIR}/${app}/${conf_file}
 
-  echo "Building $EXE_NAME"
+  echo "Building $exe_name"
 
-  #Set INCR_BUILD when calling to only do an incremental build
-  if [ ! -v INCR_BUILD ] || [ ! -d "${THIS_DIR}" ]; then
-      [ -d "${THIS_DIR}" ] && rm ${THIS_DIR} -rf
-      mkdir -p ${THIS_DIR} && cd ${THIS_DIR}
+  # Set INCR_BUILD when calling to only do an incremental build
+  if [ ! -v INCR_BUILD ] || [ ! -d "${this_dir}" ]; then
+      [ -d "${this_dir}" ] && rm ${this_dir} -rf
+      mkdir -p ${this_dir} && cd ${this_dir}
       cmake -GNinja -DBOARD_ROOT=${BOARD_ROOT} -DBOARD=${BOARD} \
-            -DCONF_FILE=${CONF_FILE} ${CMAKE_ARGS} ${APP_ROOT}/${APP} \
+            -DCONF_FILE=${conf_file} ${cmake_args} ${app_root}/${app} \
             &> cmake.out || { cat cmake.out && return 0; }
   else
-      cd ${THIS_DIR}
+      cd ${this_dir}
   fi
-  ninja ${NINJA_ARGS} &> ninja.out || { cat ninja.out && return 0; }
-  cp ${THIS_DIR}/zephyr/zephyr.exe ${EXE_NAME}
+  ninja ${ninja_args} &> ninja.out || { cat ninja.out && return 0; }
+  cp ${this_dir}/zephyr/zephyr.exe ${exe_name}
 
-  nm ${EXE_NAME} | grep -v " [U|w] " | sort | cut -d" " -f1,3 > ${MAP_FILE_NAME}
-  sed -i "1i $(wc -l ${MAP_FILE_NAME} | cut -d" " -f1)" ${MAP_FILE_NAME}
+  nm ${exe_name} | grep -v " [U|w] " | sort | cut -d" " -f1,3 > ${map_file_name}
+  sed -i "1i $(wc -l ${map_file_name} | cut -d" " -f1)" ${map_file_name}
 }
 
-APP=tests/bluetooth/bsim_bt/bsim_test_app compile
-APP=tests/bluetooth/bsim_bt/bsim_test_app CONF_FILE=prj_split.conf \
+app=tests/bluetooth/bsim_bt/bsim_test_app compile
+app=tests/bluetooth/bsim_bt/bsim_test_app conf_file=prj_split.conf \
 	compile

--- a/tests/bluetooth/bsim_bt/run_parallel.sh
+++ b/tests/bluetooth/bsim_bt/run_parallel.sh
@@ -6,7 +6,7 @@
 
 set -u
 
-START=$SECONDS
+start=$SECONDS
 
 function display_help(){
   echo "run_parallel.sh [-help] [options]"
@@ -31,25 +31,25 @@ i=0
 SEARCH_PATH="${SEARCH_PATH:-`pwd`}"
 
 #All the testcases we want to run:
-ALL_CASES=`find ${SEARCH_PATH} -name "*.sh" | \
+all_cases=`find ${SEARCH_PATH} -name "*.sh" | \
            grep -Ev "(/_|run_parallel|compile.sh)"`
 #we dont run ourselves
 
 RESULTS_FILE="${RESULTS_FILE:-`pwd`/../RunResults.xml}"
-TMP_RES_FILE=tmp.xml
+tmp_res_file=tmp.xml
 
-ALL_CASES_A=( $ALL_CASES )
-N_CASES=$((${#ALL_CASES_A[@]}))
+all_cases_a=( $all_cases )
+n_cases=$((${#all_cases_a[@]}))
 touch ${RESULTS_FILE}
-echo "Attempting to run ${N_CASES} cases (logging to \
+echo "Attempting to run ${n_cases} cases (logging to \
  `realpath ${RESULTS_FILE}`)"
 
-chmod +x $ALL_CASES
+chmod +x $all_cases
 
 export CLEAN_XML="sed -E -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' \
                   -e 's/\"/&quot;/g'"
 
-echo -n "" > $TMP_RES_FILE
+echo -n "" > $tmp_res_file
 
 if [ `command -v parallel` ]; then
   parallel '
@@ -69,31 +69,31 @@ if [ `command -v parallel` ]; then
     rm {#}.log ;
     echo "</testcase>";
   fi;
-  ' ::: $ALL_CASES >> $TMP_RES_FILE ; err=$?
+  ' ::: $all_cases >> $tmp_res_file ; err=$?
 else #fallback in case parallel is not installed
-  for CASE in $ALL_CASES; do
-    echo "<testcase name=\"$CASE\" time=\"0\">" >> $TMP_RES_FILE
-    $CASE $@ &> $i.log
+  for case in $all_cases; do
+    echo "<testcase name=\"$case\" time=\"0\">" >> $tmp_res_file
+    $case $@ &> $i.log
     if [ $? -ne 0 ]; then
-      echo -e "\e[91m$CASE FAILED\e[39m"
+      echo -e "\e[91m$case FAILED\e[39m"
       cat $i.log
-      echo "<failure message=\"failed\" type=\"failure\">" >> $TMP_RES_FILE
-      cat $i.log | eval $CLEAN_XML >> $TMP_RES_FILE
-      echo "</failure>" >> $TMP_RES_FILE
+      echo "<failure message=\"failed\" type=\"failure\">" >> $tmp_res_file
+      cat $i.log | eval $CLEAN_XML >> $tmp_res_file
+      echo "</failure>" >> $tmp_res_file
       let "err++"
     else
-      echo -e "$CASE PASSED"
+      echo -e "$case PASSED"
     fi;
-    echo "</testcase>" >> $TMP_RES_FILE
+    echo "</testcase>" >> $tmp_res_file
     rm $i.log
     let i=i+1
   done
 fi
-echo -e "</testsuite>\n</testsuites>\n" >> $TMP_RES_FILE
-dur=$(($SECONDS - $START))
+echo -e "</testsuite>\n</testsuites>\n" >> $tmp_res_file
+dur=$(($SECONDS - $start))
 echo -e "<testsuites>\n<testsuite errors=\"0\" failures=\"$err\"\
- name=\"bsim_bt tests\" skip=\"0\" tests=\"$N_CASES\" time=\"$dur\">" \
- | cat - $TMP_RES_FILE > $RESULTS_FILE
-rm $TMP_RES_FILE
+ name=\"bsim_bt tests\" skip=\"0\" tests=\"$n_cases\" time=\"$dur\">" \
+ | cat - $tmp_res_file > $RESULTS_FILE
+rm $tmp_res_file
 
 exit $err

--- a/tests/bluetooth/bsim_bt/run_parallel.sh
+++ b/tests/bluetooth/bsim_bt/run_parallel.sh
@@ -21,7 +21,7 @@ function display_help(){
 if [ $# -ge 1 ]; then
   if grep -Eiq "(\?|-\?|-h|help|-help|--help)" <<< $1 ; then
     display_help
-    exit 0;
+    exit 0
   fi
 fi
 
@@ -53,22 +53,22 @@ echo -n "" > $tmp_res_file
 
 if [ `command -v parallel` ]; then
   parallel '
-  echo "<testcase name=\"{}\" time=\"0\">";
-  {} $@ &> {#}.log ;
+  echo "<testcase name=\"{}\" time=\"0\">"
+  {} $@ &> {#}.log
   if [ $? -ne 0 ]; then
-    (>&2 echo -e "\e[91m{} FAILED\e[39m");
-    (>&2 cat {#}.log);
-    echo "<failure message=\"failed\" type=\"failure\">";
-    cat {#}.log | eval $CLEAN_XML;
-    echo "</failure>";
-    rm {#}.log ;
-    echo "</testcase>";
-    exit 1;
+    (>&2 echo -e "\e[91m{} FAILED\e[39m")
+    (>&2 cat {#}.log)
+    echo "<failure message=\"failed\" type=\"failure\">"
+    cat {#}.log | eval $CLEAN_XML
+    echo "</failure>"
+    rm {#}.log
+    echo "</testcase>"
+    exit 1
   else
-    (>&2 echo -e "{} PASSED");
-    rm {#}.log ;
-    echo "</testcase>";
-  fi;
+    (>&2 echo -e "{} PASSED")
+    rm {#}.log
+    echo "</testcase>"
+  fi
   ' ::: $all_cases >> $tmp_res_file ; err=$?
 else #fallback in case parallel is not installed
   for case in $all_cases; do
@@ -83,7 +83,7 @@ else #fallback in case parallel is not installed
       let "err++"
     else
       echo -e "$case PASSED"
-    fi;
+    fi
     echo "</testcase>" >> $tmp_res_file
     rm $i.log
     let i=i+1

--- a/tests/net/all/check_net_options.sh
+++ b/tests/net/all/check_net_options.sh
@@ -16,23 +16,23 @@ if [ -z "$1" ]; then
     exit
 fi
 
-BUILD_DIR="$1"
+build_dir="$1"
 
-if [ ! -d $BUILD_DIR ]; then
-    echo "Directory $BUILD_DIR not found!"
+if [ ! -d $build_dir ]; then
+    echo "Directory $build_dir not found!"
     exit
 fi
 
-KCONFIG_DIR=$BUILD_DIR/rst/doc/reference/kconfig
+kconfig_dir=$build_dir/rst/doc/reference/kconfig
 
-if [ ! -d $KCONFIG_DIR ]; then
-    echo "Kconfig documentation not found at $KCONFIG_DIR"
+if [ ! -d $kconfig_dir ]; then
+    echo "Kconfig documentation not found at $kconfig_dir"
     exit
 fi
 
 get_options()
 {
-    cd $KCONFIG_DIR; ls CONFIG_DNS* CONFIG_NET* CONFIG_IEEE802154* | sed 's/\.rst//g'
+    cd $kconfig_dir; ls CONFIG_DNS* CONFIG_NET* CONFIG_IEEE802154* | sed 's/\.rst//g'
 }
 
 get_options | while read opt

--- a/zephyr-env.sh
+++ b/zephyr-env.sh
@@ -13,20 +13,20 @@
 # Note: The version of zsh need to be 5.0.6 or above. Any versions below
 # 5.0.6 maybe encoutner errors when sourcing this script.
 if [ -n "${ZSH_VERSION:-}" ]; then
-	DIR="${(%):-%N}"
+	dir="${(%):-%N}"
 	if [ $options[posixargzero] != "on" ]; then
 		setopt posixargzero
-		NAME=$(basename -- "$0")
+		name=$(basename -- "$0")
 		unsetopt posixargzero
 	else
-		NAME=$(basename -- "$0")
+		name=$(basename -- "$0")
 	fi
 else
-	DIR="${BASH_SOURCE[0]}"
-	NAME=$(basename -- "$0")
+	dir="${BASH_SOURCE[0]}"
+	name=$(basename -- "$0")
 fi
 
-if [ "X$NAME" "==" "Xzephyr-env.sh" ]; then
+if [ "X$name" "==" "Xzephyr-env.sh" ]; then
     echo "Source this file (do NOT execute it!) to set the Zephyr Kernel environment."
     exit
 fi
@@ -37,15 +37,15 @@ fi
 
 if uname | grep -q "MINGW"; then
     win_build=1
-    PWD_OPT="-W"
+    pwd_opt="-W"
 else
     win_build=0
-    PWD_OPT=""
+    pwd_opt=""
 fi
 
 # identify OS source tree root directory
-export ZEPHYR_BASE=$( builtin cd "$( dirname "$DIR" )" > /dev/null && pwd ${PWD_OPT})
-unset PWD_OPT
+export ZEPHYR_BASE=$( builtin cd "$( dirname "$dir" )" > /dev/null && pwd ${pwd_opt})
+unset pwd_opt
 
 scripts_path=${ZEPHYR_BASE}/scripts
 if [ "$win_build" -eq 1 ]; then

--- a/zephyr-env.sh
+++ b/zephyr-env.sh
@@ -60,10 +60,10 @@ unset scripts_path
 # enable custom environment settings
 zephyr_answer_file=~/zephyr-env_install.bash
 [ -f ${zephyr_answer_file} ] && {
-	echo "Warning: Please rename ~/zephyr-env_install.bash to ~/.zephyrrc";
-	. ${zephyr_answer_file};
+	echo "Warning: Please rename ~/zephyr-env_install.bash to ~/.zephyrrc"
+	. ${zephyr_answer_file}
 }
 unset zephyr_answer_file
 zephyr_answer_file=~/.zephyrrc
-[ -f ${zephyr_answer_file} ] &&  . ${zephyr_answer_file};
+[ -f ${zephyr_answer_file} ] &&  . ${zephyr_answer_file}
 unset zephyr_answer_file


### PR DESCRIPTION
This makes it possible to tell at a glance which variables are internal to the script and which ones are parameters to it (or are exported from it), which is very helpful, and would've saved me a bunch of effort.

This convention is pretty common. See e.g. [Google's shell style guide](https://google.github.io/styleguide/shell.xml#Naming_Conventions), and [this random one](https://github.com/icy/bash-coding-style#variable-names). It's older than those though. Some other scripts in Zephyr already do it.

Also remove some semicolons at ends of lines.

(Some people do uppercase for "constants" as well, and leave lowercase to variables. Having some kind of distinction helps at least. I like the super simple lowercase-for-all-internal.)