### PR TITLE
kernel/thread: Cancel timeouts on k_thread_suspend(), make schedule p…

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1140,10 +1140,13 @@ int k_thread_cpu_mask_disable(k_tid_t thread, int cpu);
 /**
  * @brief Suspend a thread.
  *
- * This routine prevents the kernel scheduler from making @a thread the
- * current thread. All other internal operations on @a thread are still
- * performed; for example, any timeout it is waiting on keeps ticking,
- * kernel objects it is waiting on are still handed to it, etc.
+ * This routine prevents the kernel scheduler from making @a thread
+ * the current thread. All other internal operations on @a thread are
+ * still performed; for example, kernel objects it is waiting on are
+ * still handed to it.  Note that any existing timeouts
+ * (e.g. k_sleep(), or a timeout argument to k_sem_take() et. al.)
+ * will be canceled.  On resume, the thread will begin running
+ * immediately and return from the blocked call.
  *
  * If @a thread is already suspended, the routine has no effect.
  *

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -658,7 +658,13 @@ void z_thread_single_suspend(struct k_thread *thread)
 		z_remove_thread_from_ready_q(thread);
 	}
 
+	(void)z_abort_thread_timeout(thread);
+
 	z_mark_thread_as_suspended(thread);
+
+	if (thread == _current) {
+		z_reschedule_unlocked();
+	}
 }
 
 void z_impl_k_thread_suspend(struct k_thread *thread)

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -35,6 +35,8 @@ extern void test_threads_priority_set(void);
 extern void test_delayed_thread_abort(void);
 extern void test_k_thread_foreach(void);
 extern void test_threads_cpu_mask(void);
+extern void test_threads_suspend_timeout(void);
+extern void test_threads_suspend(void);
 
 struct k_thread tdata;
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
@@ -303,7 +305,9 @@ void test_main(void)
 			 ztest_unit_test(test_thread_name_get_set),
 			 ztest_user_unit_test(test_thread_name_user_get_set),
 			 ztest_unit_test(test_user_mode),
-			 ztest_1cpu_unit_test(test_threads_cpu_mask)
+			 ztest_1cpu_unit_test(test_threads_cpu_mask),
+			 ztest_unit_test(test_threads_suspend_timeout),
+			 ztest_unit_test(test_threads_suspend)
 			 );
 
 	ztest_run_test_suite(threads_lifecycle);


### PR DESCRIPTION
…oint

When suspending a thread, cancel any pending timeouts which might wake
it up unexpectedly.  Also, make suspending the current thread
(specifically) a schedule point, as callers are clearly going to
expect that to be synchronous.

Also fix a documentation weirdness.  The phrasing in the earlier docs
for k_thread_suspend() was confusing: it could be interpreted as
either document the current (essentially buggy) behavior that threads
will "wake up" due to preexisting timeouts, OR to mean that thread
timeouts will continue to be tracked so that resuming a thread that
was sleeping will continue to sleep until the timeout (something that
has never been implemented: k_sleep() is implemented on top of
suspend).  Rewrite to document what we actually implement.

Fixes #20033

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>