### PR TITLE
miscellaneous enhancements to sanitycheck device testing

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3863,6 +3863,12 @@ def main():
     info("%d test configurations selected, %d configurations discarded due to filters." %
         (len(suite.instances), len(discards)))
 
+    if options.device_testing:
+        print("\nDevice testing on:")
+        for p in suite.connected_hardware:
+            if p['connected']:
+                print("%s (%s) on %s" %(p['platform'], p.get('id', None), p['serial']))
+
     if options.dry_run:
         duration = time.time() - start_time
         info("Completed in %d seconds" % (duration))

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -736,7 +736,7 @@ class DeviceHandler(Handler):
 
         runner = hardware.get('runner', None)
         if runner:
-            board_id = hardware.get("id", None)
+            board_id = hardware.get("probe_id", hardware.get("id", None))
             product = hardware.get("product", None)
             command = ["west", "flash", "--skip-rebuild", "-d", self.build_dir]
             command.append("--runner")

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3615,7 +3615,8 @@ def main():
         filtered = []
         for d in serial_devices:
             if d.manufacturer in ['ARM', 'SEGGER', 'MBED', 'STMicroelectronics',
-                                  'Atmel Corp.', 'Texas Instruments']:
+                                  'Atmel Corp.', 'Texas Instruments',
+                                  'Silicon Labs', 'NXP Semiconductors']:
                 # TI XDS110 can have multiple serial devices for a single board
                 # assume endpoint 0 is the serial, skip all others
                 if d.manufacturer == 'Texas Instruments' and not d.location.endswith('0'):
@@ -3627,7 +3628,7 @@ def main():
                 s_dev['product'] = d.product
                 if s_dev['product'] in ['DAPLink CMSIS-DAP', 'MBED CMSIS-DAP']:
                     s_dev['runner'] = "pyocd"
-                elif s_dev['product'] in ['J-Link']:
+                elif s_dev['product'] in ['J-Link', 'J-Link OB']:
                     s_dev['runner'] = "jlink"
                 elif s_dev['product'] in ['STM32 STLink']:
                     s_dev['runner'] = "openocd"

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3650,6 +3650,7 @@ def main():
                 # disconnect everything
                 for h in hwm:
                     h['connected'] = False
+                    h['serial'] = None
 
                 for d in filtered:
                     for h in hwm:


### PR DESCRIPTION
Support boards from more vendors, as well as boards that use external programmers, and clean up the properties of disconnected devices.