### PR TITLE
Bluetooth: host: Fix potential deadlocks with the TX thread and system workqueue

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -90,9 +90,6 @@ struct bt_l2cap_chan {
 	struct k_delayed_work		rtx_work;
 	ATOMIC_DEFINE(status, BT_L2CAP_NUM_STATUS);
 
-	struct k_work			rx_work;
-	struct k_fifo			rx_queue;
-
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	bt_l2cap_chan_state_t		state;
 	/** Remote PSM to be connected */
@@ -132,6 +129,9 @@ struct bt_l2cap_le_chan {
 	/** Segment SDU packet from upper layer */
 	struct net_buf			*_sdu;
 	u16_t				_sdu_len;
+
+	struct k_work			rx_work;
+	struct k_fifo			rx_queue;
 };
 
 /** @def BT_L2CAP_LE_CHAN(_ch)

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -240,13 +240,13 @@ config BT_ACL_RX_COUNT
 endif # BT_HCI_ACL_FLOW_CONTROL
 
 config BT_CONN_TX_MAX
-	int "Maximum number of pending TX buffers"
-	default BT_CTLR_TX_BUFFERS if BT_CTLR
-	default 7
-	range 1 128
+	int "Maximum number of pending TX buffers with a callback"
+	default BT_L2CAP_TX_BUF_COUNT
+	range BT_L2CAP_TX_BUF_COUNT 255
 	help
-	  Maximum number of pending TX buffers that have not yet
-	  been acknowledged by the controller.
+	  Maximum number of pending TX buffers that have an associated
+	  callback. Normally this can be left to the default value, which
+	  is equal to the number of TX buffers in the stack-internal pool.
 
 config BT_AUTO_PHY_UPDATE
 	bool "Auto-initiate PHY Update Procedure"

--- a/subsys/bluetooth/host/Kconfig.l2cap
+++ b/subsys/bluetooth/host/Kconfig.l2cap
@@ -19,6 +19,7 @@ endif # BT_HCI_ACL_FLOW_CONTROL
 
 config BT_L2CAP_TX_BUF_COUNT
 	int "Number of L2CAP TX buffers"
+	default BT_CTLR_TX_BUFFERS if BT_CTLR
 	default 3
 	range 2 255
 	help

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1197,15 +1197,22 @@ void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, u8_t flags)
 
 static struct bt_conn_tx *conn_tx_alloc(void)
 {
+	/* The TX context always get freed in the system workqueue,
+	 * so if we're in the same workqueue but there are no immediate
+	 * contexts available, there's no chance we'll get one by waiting.
+	 */
+	if (k_current_get() == &k_sys_work_q.thread) {
+		return k_fifo_get(&free_tx, K_NO_WAIT);
+	}
+
 	if (IS_ENABLED(CONFIG_BT_DEBUG_CONN)) {
 		struct bt_conn_tx *tx = k_fifo_get(&free_tx, K_NO_WAIT);
 
-		if (!tx) {
-			BT_WARN("Unable to get a free conn_tx, yielding...");
-			tx = k_fifo_get(&free_tx, K_FOREVER);
+		if (tx) {
+			return tx;
 		}
 
-		return tx;
+		BT_WARN("Unable to get an immediate free conn_tx");
 	}
 
 	return k_fifo_get(&free_tx, K_FOREVER);
@@ -1227,6 +1234,20 @@ int bt_conn_send_cb(struct bt_conn *conn, struct net_buf *buf,
 
 	if (cb) {
 		tx = conn_tx_alloc();
+		if (!tx) {
+			BT_ERR("Unable to allocate TX context");
+			net_buf_unref(buf);
+			return -ENOBUFS;
+		}
+
+		/* Verify that we're still connected after blocking */
+		if (conn->state != BT_CONN_CONNECTED) {
+			BT_WARN("Disconnected while allocating context");
+			net_buf_unref(buf);
+			tx_free(tx);
+			return -ENOTCONN;
+		}
+
 		tx->cb = cb;
 		tx->user_data = user_data;
 		tx->conn = bt_conn_ref(conn);
@@ -2265,20 +2286,10 @@ struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
 		pool = &acl_tx_pool;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_DEBUG_CONN) ||
-	    (k_current_get() == &k_sys_work_q.thread && timeout == K_FOREVER)) {
+	if (IS_ENABLED(CONFIG_BT_DEBUG_CONN)) {
 		buf = net_buf_alloc(pool, K_NO_WAIT);
 		if (!buf) {
 			BT_WARN("Unable to allocate buffer with K_NO_WAIT");
-			/* Cannot block with K_FOREVER on k_sys_work_q as that
-			 * can cause a deadlock when trying to dispatch TX
-			 * notification.
-			 */
-			if (k_current_get() == &k_sys_work_q.thread) {
-				BT_WARN("Unable to allocate buffer: timeout %d",
-					 timeout);
-				return NULL;
-			}
 			buf = net_buf_alloc(pool, timeout);
 		}
 	} else {

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -85,9 +85,11 @@ struct bt_conn_tx_data {
 };
 
 struct bt_conn_tx {
-	sys_snode_t node;
+	union {
+		sys_snode_t node;
+		struct k_work work;
+	};
 	struct bt_conn *conn;
-	struct k_work work;
 	struct bt_conn_tx_data data;
 };
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -704,9 +704,18 @@ static void hci_num_completed_packets(struct net_buf *buf)
 		irq_unlock(key);
 
 		while (count--) {
+			struct bt_conn_tx *tx;
 			sys_snode_t *node;
 
 			key = irq_lock();
+
+			if (conn->pending_no_cb) {
+				conn->pending_no_cb--;
+				irq_unlock(key);
+				k_sem_give(bt_conn_get_pkts(conn));
+				continue;
+			}
+
 			node = sys_slist_get(&conn->tx_pending);
 			irq_unlock(key);
 
@@ -715,7 +724,14 @@ static void hci_num_completed_packets(struct net_buf *buf)
 				break;
 			}
 
-			k_fifo_put(&conn->tx_notify, node);
+			tx = CONTAINER_OF(node, struct bt_conn_tx, node);
+
+			key = irq_lock();
+			conn->pending_no_cb = tx->pending_no_cb;
+			tx->pending_no_cb = 0U;
+			irq_unlock(key);
+
+			k_work_submit(&tx->work);
 			k_sem_give(bt_conn_get_pkts(conn));
 		}
 
@@ -3878,12 +3894,7 @@ static void process_events(struct k_poll_event *ev, int count)
 			} else if (IS_ENABLED(CONFIG_BT_CONN)) {
 				struct bt_conn *conn;
 
-				if (ev->tag == BT_EVENT_CONN_TX_NOTIFY) {
-					conn = CONTAINER_OF(ev->fifo,
-							    struct bt_conn,
-							    tx_notify);
-					bt_conn_notify_tx(conn);
-				} else if (ev->tag == BT_EVENT_CONN_TX_QUEUE) {
+				if (ev->tag == BT_EVENT_CONN_TX_QUEUE) {
 					conn = CONTAINER_OF(ev->fifo,
 							    struct bt_conn,
 							    tx_queue);
@@ -3901,8 +3912,8 @@ static void process_events(struct k_poll_event *ev, int count)
 }
 
 #if defined(CONFIG_BT_CONN)
-/* command FIFO + conn_change signal + MAX_CONN * 2 (tx & tx_notify) */
-#define EV_COUNT (2 + (CONFIG_BT_MAX_CONN * 2))
+/* command FIFO + conn_change signal + MAX_CONN */
+#define EV_COUNT (2 + CONFIG_BT_MAX_CONN)
 #else
 /* command FIFO */
 #define EV_COUNT 1
@@ -4016,8 +4027,6 @@ static void read_buffer_size_complete(struct net_buf *buf)
 
 	BT_DBG("ACL BR/EDR buffers: pkts %u mtu %u", pkts, bt_dev.le.mtu);
 
-	pkts = MIN(pkts, CONFIG_BT_CONN_TX_MAX);
-
 	k_sem_init(&bt_dev.le.pkts, pkts, pkts);
 }
 #endif
@@ -4026,7 +4035,6 @@ static void read_buffer_size_complete(struct net_buf *buf)
 static void le_read_buffer_size_complete(struct net_buf *buf)
 {
 	struct bt_hci_rp_le_read_buffer_size *rp = (void *)buf->data;
-	u8_t le_max_num;
 
 	BT_DBG("status 0x%02x", rp->status);
 
@@ -4037,8 +4045,7 @@ static void le_read_buffer_size_complete(struct net_buf *buf)
 
 	BT_DBG("ACL LE buffers: pkts %u mtu %u", rp->le_max_num, bt_dev.le.mtu);
 
-	le_max_num = MIN(rp->le_max_num, CONFIG_BT_CONN_TX_MAX);
-	k_sem_init(&bt_dev.le.pkts, le_max_num, le_max_num);
+	k_sem_init(&bt_dev.le.pkts, rp->le_max_num, rp->le_max_num);
 }
 #endif
 

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -22,7 +22,6 @@
 /* k_poll event tags */
 enum {
 	BT_EVENT_CMD_TX,
-	BT_EVENT_CONN_TX_NOTIFY,
 	BT_EVENT_CONN_TX_QUEUE,
 };
 

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -27,7 +27,7 @@
 #include "l2cap_internal.h"
 
 #define LE_CHAN_RTX(_w) CONTAINER_OF(_w, struct bt_l2cap_le_chan, chan.rtx_work)
-#define CHAN_RX(_w) CONTAINER_OF(_w, struct bt_l2cap_chan, rx_work)
+#define CHAN_RX(_w) CONTAINER_OF(_w, struct bt_l2cap_le_chan, rx_work)
 
 #define L2CAP_LE_MIN_MTU		23
 
@@ -221,8 +221,6 @@ void bt_l2cap_chan_set_state(struct bt_l2cap_chan *chan,
 
 void bt_l2cap_chan_del(struct bt_l2cap_chan *chan)
 {
-	struct net_buf *buf;
-
 	BT_DBG("conn %p chan %p", chan->conn, chan);
 
 	if (!chan->conn) {
@@ -242,11 +240,6 @@ destroy:
 	chan->psm = 0U;
 #endif
 
-	/* Remove buffers on the RX queue */
-	while ((buf = net_buf_get(&chan->rx_queue, K_NO_WAIT))) {
-		net_buf_unref(buf);
-	}
-
 	if (chan->destroy) {
 		chan->destroy(chan);
 	}
@@ -262,19 +255,22 @@ static void l2cap_rtx_timeout(struct k_work *work)
 	bt_l2cap_chan_del(&chan->chan);
 }
 
-static void l2cap_chan_recv(struct bt_l2cap_chan *chan, struct net_buf *buf);
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
+static void l2cap_chan_le_recv(struct bt_l2cap_le_chan *chan,
+			       struct net_buf *buf);
 
 static void l2cap_rx_process(struct k_work *work)
 {
-	struct bt_l2cap_chan *chan = CHAN_RX(work);
+	struct bt_l2cap_le_chan *ch = CHAN_RX(work);
 	struct net_buf *buf;
 
-	while ((buf = net_buf_get(&chan->rx_queue, K_NO_WAIT))) {
-		BT_DBG("chan %p buf %p", chan, buf);
-		l2cap_chan_recv(chan, buf);
+	while ((buf = net_buf_get(&ch->rx_queue, K_NO_WAIT))) {
+		BT_DBG("ch %p buf %p", ch, buf);
+		l2cap_chan_le_recv(ch, buf);
 		net_buf_unref(buf);
 	}
 }
+#endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
 
 void bt_l2cap_chan_add(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 		       bt_l2cap_chan_destroy_t destroy)
@@ -304,15 +300,16 @@ static bool l2cap_chan_add(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 	}
 
 	k_delayed_work_init(&chan->rtx_work, l2cap_rtx_timeout);
-	k_work_init(&chan->rx_work, l2cap_rx_process);
-	k_fifo_init(&chan->rx_queue);
 
 	bt_l2cap_chan_add(conn, chan, destroy);
 
-	if (IS_ENABLED(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL) &&
-	    L2CAP_LE_CID_IS_DYN(ch->rx.cid)) {
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
+	if (L2CAP_LE_CID_IS_DYN(ch->rx.cid)) {
+		k_work_init(&ch->rx_work, l2cap_rx_process);
+		k_fifo_init(&ch->rx_queue);
 		bt_l2cap_chan_set_state(chan, BT_L2CAP_CONNECT);
 	}
+#endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
 
 	return true;
 }
@@ -756,6 +753,11 @@ static void l2cap_chan_destroy(struct bt_l2cap_chan *chan)
 
 	/* Remove buffers on the TX queue */
 	while ((buf = net_buf_get(&ch->tx_queue, K_NO_WAIT))) {
+		net_buf_unref(buf);
+	}
+
+	/* Remove buffers on the RX queue */
+	while ((buf = net_buf_get(&ch->rx_queue, K_NO_WAIT))) {
 		net_buf_unref(buf);
 	}
 
@@ -1660,7 +1662,8 @@ static void l2cap_chan_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	struct bt_l2cap_le_chan *ch = BT_L2CAP_LE_CHAN(chan);
 
 	if (L2CAP_LE_CID_IS_DYN(ch->rx.cid)) {
-		l2cap_chan_le_recv(ch, buf);
+		net_buf_put(&ch->rx_queue, net_buf_ref(buf));
+		k_work_submit(&ch->rx_work);
 		return;
 	}
 #endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
@@ -1668,13 +1671,6 @@ static void l2cap_chan_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	BT_DBG("chan %p len %u", chan, buf->len);
 
 	chan->ops->recv(chan, buf);
-}
-
-static void l2cap_chan_recv_queue(struct bt_l2cap_chan *chan,
-				  struct net_buf *buf)
-{
-	net_buf_put(&chan->rx_queue, buf);
-	k_work_submit(&chan->rx_work);
 }
 
 void bt_l2cap_recv(struct bt_conn *conn, struct net_buf *buf)
@@ -1707,7 +1703,8 @@ void bt_l2cap_recv(struct bt_conn *conn, struct net_buf *buf)
 		return;
 	}
 
-	l2cap_chan_recv_queue(chan, buf);
+	l2cap_chan_recv(chan, buf);
+	net_buf_unref(buf);
 }
 
 int bt_l2cap_update_conn_param(struct bt_conn *conn,


### PR DESCRIPTION
Three related patches, the essence is in the second one and described fairly well in its commit message:

This is a moderate redesign of the pending TX packet handling that aims to eliminate potential deadlocks between the TX thread and the system workqueue thread. The main changes are:
    
 - TX context (`bt_conn_tx`) is allocated during buffer allocation, i.e. not in the TX thread.   
 - We don't allocate a TX context unless there's an associated callback. When there's no callback simple integer counters are used for tracking.
 - The TX thread is no longer responsible for TX callbacks or scheduling of TX callbacks. Instead, the callbacks get directly scheduled (`k_work_submit`) from the RX priority thread.
 - The `CONFIG_BT_CONN_TX_MAX` defaults to `CONFIG_BT_L2CAP_TX_BUF_COUNT` and in most cases won't need changing.

Fixes #20938