### PR TITLE
sanitycheck: Fix --enable-coverage option

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3686,8 +3686,9 @@ def main():
     if options.coverage:
         options.enable_coverage = True
         options.enable_slow = True
-        if not options.coverage_platform:
-            options.coverage_platform = options.platform
+
+    if not options.coverage_platform:
+        options.coverage_platform = options.platform
 
     if options.size:
         for fn in options.size:


### PR DESCRIPTION
This commit fixes the issue, that --enable-coverage alone did not create
coverage information. It also required to give --coverage-platform.
Now the fallback for coverage-platform to platform works as documented
also for enable-coverage, not only for coverage option.

Signed-off-by: Christian Taedcke <hacking@taedcke.com>