### PR TITLE
dts: tell compiler the name of dependency file for output

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -126,6 +126,7 @@ if(SUPPORTS_DTS)
     -P
     -E   # Stop after preprocessing
     -MD  # Generate a dependency file as a side-effect
+    -MF ${BOARD}.dts.pre.d
     -o ${BOARD}.dts.pre.tmp
     ${ZEPHYR_BASE}/misc/empty_file.c
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}


### PR DESCRIPTION
When generating the dependency file for DTS (${BOARD}.dts.pre.d),
some toolchains would use the source file for the file name stem.
So, the resulting dependency file is empty_file.d instead of one
with the board name. Fix this by passing -MF to explicitly tell
the compiler the name of the dependency file.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>

Partially fixes #20931