### PR TITLE
nrf_rtc_timer: fix for announcement starvation

### DIFF
--- a/tests/kernel/timer/starve/CMakeLists.txt
+++ b/tests/kernel/timer/starve/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(timer_starve)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/timer/starve/Kconfig
+++ b/tests/kernel/timer/starve/Kconfig
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2019 Nordic Semicondutor ASA
+
+mainmenu "Timer Starvation Test"
+
+source "Kconfig.zephyr"
+
+config APP_STOP_S
+	int "The number of seconds to run without error before pass"
+	default 3600

--- a/tests/kernel/timer/starve/README.txt
+++ b/tests/kernel/timer/starve/README.txt
@@ -1,0 +1,27 @@
+Title: Timer Starvation test
+
+The purpose of the test is to detect whether the timer implementation
+correctly handles situations where only one timeout is present, and that
+timeout is repeatedly rescheduled before it has a chance to fire.  In
+some implementations this may prevent the timer interrupt handler from
+ever being invoked, which in turn prevents an announcement of ticks.
+Lack of tick announcement propagates into a monotonic increase in the
+value returned by z_clock_elapsed().
+
+This test is not run in automatic test suites because it generally takes
+minutes, hours, or days to fail, depending on the hardware clock rate
+and the tick rate.  By default the test passes if one hour passes
+without detecting a failure.
+
+Failure will occur when some counter wraps around.  This may be a
+hardware timer counter, a timer driver internal calculation of
+unannounced cycles, or the Zephyr measurement of unannounced ticks.
+
+For example a system that uses a 32768-Hz internal timer counter with
+24-bit resolution and determines elapsed time by a 24-bit unsigned
+difference between the current and last-recorded counter value will fail
+at 512 s when the updated counter value is observed to be less than the
+last recorded counter.
+
+Systems that use a 32-bit counter of 80 MHz ticks would fail after
+53.687 s.

--- a/tests/kernel/timer/starve/prj.conf
+++ b/tests/kernel/timer/starve/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/kernel/timer/starve/src/main.c
+++ b/tests/kernel/timer/starve/src/main.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <tc_util.h>
+#include <ztest.h>
+
+#include <sys/printk.h>
+
+#define STAMP_INTERVAL_s 60
+#define TIMER_DELAY_ms 500
+#define BUSY_WAIT_ms 100
+
+static volatile u32_t na;
+
+static void handler(struct k_timer *timer)
+{
+	++na;
+}
+
+static u32_t iters;
+static u32_t now;
+
+static const char *tag(void)
+{
+	static char buf[32];
+
+	snprintf(buf, sizeof(buf), "[%6u.%03u] %u: ",
+		 now / MSEC_PER_SEC, now % MSEC_PER_SEC, iters);
+	return buf;
+}
+
+static void test_starve(void)
+{
+	static struct k_timer tmr;
+	static struct k_spinlock lock;
+	u32_t stamp = 0;
+	u32_t last_now = 0;
+	u64_t last_ticks = 0;
+	k_spinlock_key_t key;
+
+	TC_PRINT("Cycle clock runs at %u Hz\n",
+		 k_ms_to_cyc_ceil32(MSEC_PER_SEC));
+	TC_PRINT("There are %u cycles per tick (%u Hz ticks)\n",
+		 k_ticks_to_cyc_ceil32(1U),
+		 k_ms_to_ticks_ceil32(MSEC_PER_SEC));
+
+	k_timer_init(&tmr, handler, NULL);
+	while (true) {
+		now = k_uptime_get_32();
+		if ((now / MSEC_PER_SEC) > CONFIG_APP_STOP_S) {
+			break;
+		}
+
+		++iters;
+
+		if (now > stamp) {
+			TC_PRINT("%sstill running, would pass at %u s\n",
+				 tag(), CONFIG_APP_STOP_S);
+			stamp += STAMP_INTERVAL_s * MSEC_PER_SEC;
+		}
+
+		s32_t now_diff = now - last_now;
+
+		zassert_true(now_diff > 0,
+			     "%sTime went backwards by %d: was %u.%03u\n",
+			     tag(), -now_diff, last_now / MSEC_PER_SEC,
+			     last_now % MSEC_PER_SEC);
+		last_now = now;
+
+		/* Assume tick delta fits in printable 32 bits */
+		u64_t ticks = z_tick_get();
+		s64_t ticks_diff = ticks - last_ticks;
+
+		zassert_true(ticks_diff > 0,
+			     "%sTicks went backwards by %d\n",
+			     tag(), -(s32_t)ticks_diff);
+		last_ticks = ticks;
+
+		zassert_equal(na, 0,
+			      "%sTimer alarm fired: %u\n",
+			      na);
+
+		k_timer_start(&tmr, K_MSEC(TIMER_DELAY_ms), K_NO_WAIT);
+
+		/* Wait with interrupts disabled to increase chance
+		 * that overflow is detected.
+		 */
+		key = k_spin_lock(&lock);
+		k_busy_wait(BUSY_WAIT_ms * USEC_PER_MSEC);
+		k_spin_unlock(&lock, key);
+	}
+	TC_PRINT("%sCompleted %u iters without failure\n",
+		 tag(), iters);
+}
+
+void test_main(void)
+{
+	ztest_test_suite(starve_fn, ztest_unit_test(test_starve));
+	ztest_run_test_suite(starve_fn);
+}

--- a/tests/kernel/timer/starve/testcase.yaml
+++ b/tests/kernel/timer/starve/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  kernel.timer.starve:
+    build_only: true
+    tags: timer


### PR DESCRIPTION
This PR provides the Nordic fix for #20585.  It also provides a test application that can be used to verify the presence of the bug.

Sample output of the test for unpatched Nordic devices (fixed in this PR):
```
[    60.069] 599: still running, would pass at 3600 s
[   120.081] 1197: still running, would pass at 3600 s
[   180.016] 1794: still running, would pass at 3600 s
[   240.051] 2392: still running, would pass at 3600 s
[   300.080] 2990: still running, would pass at 3600 s
[   360.018] 3587: still running, would pass at 3600 s
[   420.050] 4185: still running, would pass at 3600 s
[   480.071] 4783: still running, would pass at 3600 s

    Assertion failed at ../src/main.c:69: test_starve: (now_diff > 0 is false)
[     0.094] 5102: Time went backwards by 511900: was 511.994

FAIL - test_starve
```

Sample output of the test for unpatched SysTick devices (nucleo_l476rg) (fixed in #15478):
```

Running test suite starve_fn
===================================================================
starting test - test_starve
Cycle clock runs at 80000000 kHz
There are 8000 cycles per tick (10000 Hz ticks)
[     0.023] 1: still running, would pass at 3600 s

    Assertion failed at ../src/main.c:69: test_starve: (now_diff > 0 is false)
[     0.001] 537: Time went backwards by 53587: was 53.588

FAIL - test_starve
```
