### PR TITLE
Bluetooth: Fix BT log level config won't take effect

### DIFF
--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -33,7 +33,7 @@ extern "C" {
 #define LOG_LEVEL CONFIG_BT_LOG_LEVEL
 #endif
 
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 
 #define BT_DBG(fmt, ...) LOG_DBG(fmt, ##__VA_ARGS__)
 #define BT_ERR(fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)


### PR DESCRIPTION
BT log module should be registered as user configured level instead of always using default log level.

Fixes #20297
