### PR TITLE
drivers: Check errors on devices selected using dt macro

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 #include <zephyr/types.h>
+#include <sys/__assert.h>
 #include <errno.h>
 #include <ctype.h>
 
@@ -597,6 +598,8 @@ static int uart_console_init(struct device *arg)
 	ARG_UNUSED(arg);
 
 	uart_console_dev = device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
+
+	__ASSERT_NO_MSG(uart_console_dev);
 
 #if defined(CONFIG_USB_UART_CONSOLE) && defined(CONFIG_USB_UART_DTR_WAIT)
 	int ret;

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -328,6 +328,8 @@ static int bt_monitor_init(struct device *d)
 
 	monitor_dev = device_get_binding(CONFIG_BT_MONITOR_ON_DEV_NAME);
 
+	__ASSERT_NO_MSG(monitor_dev);
+
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN)
 	uart_irq_rx_disable(monitor_dev);
 	uart_irq_tx_disable(monitor_dev);

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -274,6 +274,10 @@ static int enable_shell_uart(struct device *arg)
 		(CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > LOG_LEVEL_DBG) ?
 		CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL;
 
+	if (dev == NULL) {
+		return -ENODEV;
+	}
+
 	shell_init(&shell_uart, dev, true, log_backend, level);
 
 	return 0;


### PR DESCRIPTION
Some Kconfig defined devices may be defined using dt_chosen_label
function. Since there is no way to ensure a device enabled in dts
is also defined in Kconfig, it may happen that instance is not
actually defined.
In this case device_get_binding might return 0, leading to undefined
behavior in the function that calls it.
When not already done, systematically check return of function
device_get_binding on devices defined through dt_chosen_label macro.
Trigger ASSERT when required and return error when possible.

Fixes #20068

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>