### PR TITLE
tmp116: Add support for tmp117, fix calculation issues

### DIFF
--- a/drivers/sensor/tmp116/tmp116.c
+++ b/drivers/sensor/tmp116/tmp116.c
@@ -51,7 +51,7 @@ static inline int tmp116_device_id_check(struct device *dev)
 		return -EIO;
 	}
 
-	if (value != TMP116_DEVICE_ID) {
+	if ((value != TMP116_DEVICE_ID) && (value != TMP117_DEVICE_ID)) {
 		LOG_ERR("%s: Failed to match the device IDs!",
 			DT_INST_0_TI_TMP116_LABEL);
 		return -EINVAL;
@@ -100,9 +100,9 @@ static int tmp116_channel_get(struct device *dev, enum sensor_channel chan,
 	 * See datasheet "Temperature Results and Limits" section for more
 	 * details on processing sample data.
 	 */
-	tmp = (s32_t)drv_data->sample * TMP116_RESOLUTION;
-	val->val1 = tmp / 10000000; /* Tens of uCelsius */
-	val->val2 = tmp % 10000000;
+	tmp = ((s16_t)drv_data->sample * (s32_t)TMP116_RESOLUTION) / 10;
+	val->val1 = tmp / 1000000; /* uCelsius */
+	val->val2 = tmp % 1000000;
 
 	return 0;
 }

--- a/drivers/sensor/tmp116/tmp116.h
+++ b/drivers/sensor/tmp116/tmp116.h
@@ -22,6 +22,7 @@
 #define TMP116_RESOLUTION_DIV		10000000
 
 #define TMP116_DEVICE_ID		0x1116
+#define TMP117_DEVICE_ID		0x0117
 
 struct tmp116_data {
 	struct device *i2c;


### PR DESCRIPTION
- Added support for TMP117 in existing driver for TMP116
  The Texas Instruments TMP117 is a higher precision upgrade
   from TMP116. It shares most functionality, but has a
   differing device ID.
   This patch will run with the hardware IDs of both devices.

- Fixed an int promote issue in tmp116_channel_get
  Negative temperature values in drv_data->sample were not
  processed correctly.
  The error occured during integer promotion from u16_t to s32_t
  in this code line:
     tmp = (s32_t)drv_data->sample * TMP116_RESOLUTION;

  By first promoting to s16_t, the correct result is obtained:
     tmp = (s16_t)drv_data->sample * (s32_t)TMP116_RESOLUTION;

- Made temperature resolution compatible to sensor API
  The fractional part of the temperature was returned as a
  multiple of 10^-7 deg.Celsius.
  This differs from the resolution sugegsted by the sensor API,
  which is 10^-6.

  The driver is now returning temperature readings with
  a resolution of 10^-6 deg. Celsius.

- The changed driver was tested using following hardware:
  TMP117 attached to disco_l475_iot1 via i2c1

Signed-off-by: Hans Wilmers <hans@wilmers.no>
