### PR TITLE
interrupt_controller: shared_irq: DT_<COMPAT> is deprecated

### DIFF
--- a/drivers/interrupt_controller/shared_irq.c
+++ b/drivers/interrupt_controller/shared_irq.c
@@ -125,24 +125,24 @@ int shared_irq_initialize(struct device *dev)
 void shared_irq_config_0_irq(void);
 
 const struct shared_irq_config shared_irq_config_0 = {
-	.irq_num = DT_SHARED_IRQ_SHAREDIRQ0_IRQ_0,
+	.irq_num = DT_INST_0_SHARED_IRQ_IRQ_0,
 	.client_count = CONFIG_SHARED_IRQ_NUM_CLIENTS,
 	.config = shared_irq_config_0_irq
 };
 
 struct shared_irq_runtime shared_irq_0_runtime;
 
-DEVICE_AND_API_INIT(shared_irq_0, DT_SHARED_IRQ_SHAREDIRQ0_LABEL,
+DEVICE_AND_API_INIT(shared_irq_0, DT_INST_0_SHARED_IRQ_LABEL,
 		shared_irq_initialize, &shared_irq_0_runtime,
 		&shared_irq_config_0, POST_KERNEL,
 		CONFIG_SHARED_IRQ_INIT_PRIORITY, &api_funcs);
 
 void shared_irq_config_0_irq(void)
 {
-	IRQ_CONNECT(DT_SHARED_IRQ_SHAREDIRQ0_IRQ_0,
-		    DT_SHARED_IRQ_SHAREDIRQ0_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_0_SHARED_IRQ_IRQ_0,
+		    DT_INST_0_SHARED_IRQ_IRQ_0_PRIORITY,
 		    shared_irq_isr, DEVICE_GET(shared_irq_0),
-		    DT_SHARED_IRQ_SHAREDIRQ0_IRQ_0_SENSE);
+		    DT_INST_0_SHARED_IRQ_IRQ_0_SENSE);
 }
 
 #endif /* CONFIG_SHARED_IRQ_0 */
@@ -151,24 +151,24 @@ void shared_irq_config_0_irq(void)
 void shared_irq_config_1_irq(void);
 
 const struct shared_irq_config shared_irq_config_1 = {
-	.irq_num = DT_SHARED_IRQ_SHAREDIRQ1_IRQ_0,
+	.irq_num = DT_INST_1_SHARED_IRQ_IRQ_0,
 	.client_count = CONFIG_SHARED_IRQ_NUM_CLIENTS,
 	.config = shared_irq_config_1_irq
 };
 
 struct shared_irq_runtime shared_irq_1_runtime;
 
-DEVICE_AND_API_INIT(shared_irq_1, DT_SHARED_IRQ_SHAREDIRQ1_LABEL,
+DEVICE_AND_API_INIT(shared_irq_1, DT_INST_1_SHARED_IRQ_LABEL,
 		shared_irq_initialize, &shared_irq_1_runtime,
 		&shared_irq_config_1, POST_KERNEL,
 		CONFIG_SHARED_IRQ_INIT_PRIORITY, &api_funcs);
 
 void shared_irq_config_1_irq(void)
 {
-	IRQ_CONNECT(DT_SHARED_IRQ_SHAREDIRQ1_IRQ_0,
-		    DT_SHARED_IRQ_SHAREDIRQ1_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_INST_1_SHARED_IRQ_IRQ_0,
+		    DT_INST_1_SHARED_IRQ_IRQ_0_PRIORITY,
 		    shared_irq_isr, DEVICE_GET(shared_irq_1),
-		    DT_SHARED_IRQ_SHAREDIRQ1_IRQ_0_SENSE);
+		    DT_INST_1_SHARED_IRQ_IRQ_0_SENSE);
 }
 
 #endif /* CONFIG_SHARED_IRQ_1 */


### PR DESCRIPTION
`DT_<COMPAT>` is deprecated in favor of `DT_INST`. Fix that for the `shared_irq` driver. This is also needed if we want to manipulate the defines in the `dts_fixup.h` (for example if we want to offset the IRQ number in case of `MULTI_LEVEL_INTERRUPTS`).