### PR TITLE
samples: net: echo-server: Increase the stack size for the coverage

### DIFF
--- a/samples/net/sockets/echo_server/src/common.h
+++ b/samples/net/sockets/echo_server/src/common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Intel Corporation.
+ * Copyright (c) 2017-2019 Intel Corporation.
  * Copyright (c) 2018 Nordic Semiconductor ASA.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -7,7 +7,8 @@
 
 
 #define MY_PORT 4242
-#if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS) || defined(CONFIG_NET_TCP2)
+#if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS) || defined(CONFIG_NET_TCP2) || \
+	defined(CONFIG_COVERAGE)
 #define STACK_SIZE 4096
 #else
 #define STACK_SIZE 1024


### PR DESCRIPTION
echo_server crashes if the coverage is enabled due to the insufficient
stack size.

Use bigger stack size when the coverage is enabled.

Fixes #20797

Signed-off-by: Oleg Zhurakivskyy <oleg.zhurakivskyy@intel.com>