### PR TITLE
[Backport 20815 to v1.14 branch]spi: pass correct buffer to spi driver given NULL to spi_transceive

### DIFF
--- a/drivers/spi/spi_handlers.c
+++ b/drivers/spi/spi_handlers.c
@@ -27,7 +27,7 @@ static struct spi_buf_set *copy_and_check(struct spi_buf_set *bufs,
 					   bufs->count,
 					   sizeof(struct spi_buf)));
 
-	/* Not worried abuot overflow here: _SYSCALL_MEMORY_ARRAY_READ()
+	/* Not worried about overflow here: _SYSCALL_MEMORY_ARRAY_READ()
 	 * takes care of it.
 	 */
 	bufs->buffers = memcpy(buf_copy,

--- a/drivers/spi/spi_handlers.c
+++ b/drivers/spi/spi_handlers.c
@@ -11,15 +11,15 @@
 /* This assumes that bufs and buf_copy are copies from the values passed
  * as syscall arguments.
  */
-static void copy_and_check(struct spi_buf_set *bufs,
-			   struct spi_buf *buf_copy,
-			   int writable, void *ssf)
+static struct spi_buf_set *copy_and_check(struct spi_buf_set *bufs,
+					  struct spi_buf *buf_copy,
+					  int writable, void *ssf)
 {
 	size_t i;
 
 	if (bufs->count == 0) {
 		bufs->buffers = NULL;
-		return;
+		return NULL;
 	}
 
 	/* Validate the array of struct spi_buf instances */
@@ -42,6 +42,8 @@ static void copy_and_check(struct spi_buf_set *bufs,
 
 		Z_OOPS(Z_SYSCALL_MEMORY(buf->buf, buf->len, writable));
 	}
+
+	return bufs;
 }
 
 /* This function is only here so tx_buf_copy and rx_buf_copy can be allocated
@@ -59,8 +61,8 @@ static u32_t copy_bufs_and_transceive(struct device *dev,
 	struct spi_buf tx_buf_copy[tx_bufs->count ? tx_bufs->count : 1];
 	struct spi_buf rx_buf_copy[rx_bufs->count ? rx_bufs->count : 1];
 
-	copy_and_check(tx_bufs, tx_buf_copy, 0, ssf);
-	copy_and_check(rx_bufs, rx_buf_copy, 1, ssf);
+	tx_bufs = copy_and_check(tx_bufs, tx_buf_copy, 0, ssf);
+	rx_bufs = copy_and_check(rx_bufs, rx_buf_copy, 1, ssf);
 
 	return z_impl_spi_transceive((struct device *)dev, config,
 				    tx_bufs, rx_bufs);


### PR DESCRIPTION
When pass NULL to spi_transceive with user space enabled, stack buffer
is still passed to spi driver and it will cause kinds of problems like
MPU fault, so change it to pass relevant NULL pointers in the actual
transceive call.

Also fixes a spell typo.

Fixes: #20811.