### PR TITLE
tests: kernel: timer_api fails with CONFIG_STM32_LPTIM_TIMER

### DIFF
--- a/boards/arm/nucleo_l4r5zi/Kconfig.defconfig
+++ b/boards/arm/nucleo_l4r5zi/Kconfig.defconfig
@@ -8,11 +8,6 @@ if BOARD_NUCLEO_L4R5ZI
 config BOARD
 	default "nucleo_l4r5zi"
 
-choice STM32_LPTIM_CLOCK
-	default STM32_LPTIM_CLOCK_LSI
-	depends on STM32_LPTIM_TIMER
-endchoice
-
 config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI

--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig STM32_LPTIM_TIMER
-	bool "STM32 Low Power Timer"
+	bool "STM32 Low Power Timer [EXPERIMENTAL]"
 	depends on (SOC_SERIES_STM32L4X || SOC_SERIES_STM32WBX)
-	depends on CLOCK_CONTROL
+	depends on CLOCK_CONTROL && DEVICE_POWER_MANAGEMENT
 	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the LowPower Timer
@@ -17,26 +17,26 @@ if STM32_LPTIM_TIMER
 choice STM32_LPTIM_CLOCK
 	prompt "LPTIM clock value configuration"
 
-config STM32_LPTIM_CLOCK_LSI
-	bool "LSI"
-	help
-	  Use LSI as LPTIM clock
-
 config STM32_LPTIM_CLOCK_LSE
 	bool "LSE"
 	help
 	  Use LSE as LPTIM clock
 
+config STM32_LPTIM_CLOCK_LSI
+	bool "LSI"
+	help
+	  Use LSI as LPTIM clock
+
 endchoice
 
 config STM32_LPTIM_CLOCK
 	int "LPTIM clock value"
-	default 32000 if STM32_LPTIM_CLOCK_LSI
 	default 32768 if STM32_LPTIM_CLOCK_LSE
+	default 32000 if STM32_LPTIM_CLOCK_LSI
 
 config STM32_LPTIM_TIMEBASE
 	hex "LPTIM AutoReload value"
-	default 0xF9FF if STM32_LPTIM_CLOCK_LSI
 	default 0xFFFF if STM32_LPTIM_CLOCK_LSE
+	default 0xF9FF if STM32_LPTIM_CLOCK_LSI
 
 endif # STM32_LPTIM_TIMER

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -74,7 +74,7 @@ static void lptim_irq_handler(struct device *unused)
 				/ LPTIM_CLOCK;
 
 		z_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL)
-				? dticks : 1);
+				? dticks : (dticks > 0));
 	}
 }
 

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -178,11 +178,14 @@ int z_clock_driver_init(struct device *device)
 
 void z_clock_set_timeout(s32_t ticks, bool idle)
 {
-#ifdef CONFIG_TICKLESS_KERNEL
 	/* new LPTIM1 AutoReload value to set (aligned on Kernel ticks) */
 	u32_t next_arr = 0;
 
 	ARG_UNUSED(idle);
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
 
 	/* ARROK bit validates previous write operation to ARR register */
 	while (LL_LPTIM_IsActiveFlag_ARROK(LPTIM1) == 0) {
@@ -247,8 +250,6 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	LL_LPTIM_SetAutoReload(LPTIM1, next_arr);
 
 	k_spin_unlock(&lock, key);
-
-#endif /* CONFIG_TICKLESS_KERNEL */
 }
 
 u32_t z_clock_elapsed(void)

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -163,7 +163,7 @@ int z_clock_driver_init(struct device *device)
 
 	} else {
 		/* LPTIM1 is triggered on a Tick period */
-		LL_LPTIM_SetAutoReload(LPTIM1, COUNT_PER_TICK);
+		LL_LPTIM_SetAutoReload(LPTIM1, COUNT_PER_TICK - 1);
 	}
 
 	/* Start the LPTIM counter in continuous mode */
@@ -237,7 +237,7 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 			/ (CONFIG_SYS_CLOCK_TICKS_PER_SEC);
 	/* add count unit from the expected nb of Ticks */
 	next_arr = next_arr + ((u32_t)(ticks) * LPTIM_CLOCK)
-			/ CONFIG_SYS_CLOCK_TICKS_PER_SEC + 1;
+			/ CONFIG_SYS_CLOCK_TICKS_PER_SEC - 1;
 
 	/* maximise to TIMEBASE */
 	if (next_arr > LPTIM_TIMEBASE) {

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -193,17 +193,7 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	 * treated identically: it simply indicates the kernel would like the
 	 * next tick announcement as soon as possible.
 	 */
-	if (ticks <= (s32_t)1) {
-		ticks = 1;
-	} else {
-		ticks = (ticks - 1);
-	}
-	/* maximise Tick to keep next_arr on 32bit values,
-	 * in anycase the ARR cannot exceed LPTIM_TIMEBASE
-	 */
-	if (ticks > (s32_t)0xFFFF) {
-		ticks = 0xFFFF;
-	}
+	ticks = MAX(MIN(ticks - 1, (s32_t)LPTIM_TIMEBASE), 1);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -178,6 +178,7 @@ int z_clock_driver_init(struct device *device)
 
 void z_clock_set_timeout(s32_t ticks, bool idle)
 {
+#ifdef CONFIG_TICKLESS_KERNEL
 	/* new LPTIM1 AutoReload value to set (aligned on Kernel ticks) */
 	u32_t next_arr = 0;
 
@@ -188,7 +189,6 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	}
 	LL_LPTIM_ClearFlag_ARROK(LPTIM1);
 
-#ifdef CONFIG_TICKLESS_KERNEL
 	if (ticks == K_TICKS_FOREVER) {
 		/* disable LPTIM */
 		LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_LPTIM1);

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -340,7 +340,7 @@
 		};
 
 		lptim1: timers@40007c00 {
-			compatible = "st,stm32-timers";
+			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -283,7 +283,7 @@
 		};
 
 		lptim1: timers@40007c00 {
-			compatible = "st,stm32-timers";
+			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/bindings/timer/st,stm32-lptim.yaml
+++ b/dts/bindings/timer/st,stm32-lptim.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2020, STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32 lptim
+
+compatible: "st,stm32-lptim"
+
+include: st,stm32-timers.yaml

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2020, STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
 description: STM32 timers
 
 compatible: "st,stm32-timers"

--- a/soc/arm/st_stm32/common/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/common/Kconfig.defconfig.series
@@ -9,8 +9,13 @@ if SOC_FAMILY_STM32
 
 config CORTEX_M_SYSTICK
 	bool
-	default n if STM32_LPTIM_TIMER
-	default y if !STM32_LPTIM_TIMER
+	default y
+	depends on !STM32_LPTIM_TIMER
+
+# set the tick per sec as a divider of the LPTIM clock source
+config SYS_CLOCK_TICKS_PER_SEC
+	default 4096 if STM32_LPTIM_TIMER && STM32_LPTIM_CLOCK_LSE
+	default 4000 if STM32_LPTIM_TIMER && STM32_LPTIM_CLOCK_LSI
 
 config CLOCK_CONTROL_STM32_CUBE
 	default y


### PR DESCRIPTION
Testing kernel/timer/timer_API with LPTIM on stm32L4R5
the test_timer_duration_period fails w"
test_timer_duration_period: tdata.expire_cnt == 4 is false"

- changed z_timer_cycle_get_32() function to have better value returned in nb of HW cycles
- changed the calculation for next timeout in case of short delay
- source LPTIM with LSE or LSI clock for better accuracy
- reduce tick freq per sec and adjust for a better divided value of
 LPTIM_CLOCK % CONFIG_SYS_CLOCK_TICKS_PER_SEC

Activation of the LPTIM remains an experimental feature to generate kernel timings.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/20991