### PR TITLE
net: Verify correctness of iface_api inside L2 driver API

### DIFF
--- a/include/net/can.h
+++ b/include/net/can.h
@@ -110,6 +110,11 @@ struct net_can_api {
 	int (*enable)(struct device *dev, bool enable);
 };
 
+/* Make sure that the network interface API is properly setup inside
+ * net_can_api struct (it is the first one).
+ */
+BUILD_ASSERT(offsetof(struct net_can_api, iface_api) == 0);
+
 /** @cond INTERNAL_HIDDEN */
 
 #define CANBUS_L2_CTX_TYPE	struct net_canbus_context *

--- a/include/net/dummy.h
+++ b/include/net/dummy.h
@@ -33,6 +33,11 @@ struct dummy_api {
 	int (*send)(struct device *dev, struct net_pkt *pkt);
 };
 
+/* Make sure that the network interface API is properly setup inside
+ * dummy API struct (it is the first one).
+ */
+BUILD_ASSERT(offsetof(struct dummy_api, iface_api) == 0);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -265,6 +265,11 @@ struct ethernet_api {
 	int (*send)(struct device *dev, struct net_pkt *pkt);
 };
 
+/* Make sure that the network interface API is properly setup inside
+ * Ethernet API struct (it is the first one).
+ */
+BUILD_ASSERT(offsetof(struct ethernet_api, iface_api) == 0);
+
 /** @cond INTERNAL_HIDDEN */
 struct net_eth_hdr {
 	struct net_eth_addr dst;

--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -154,6 +154,11 @@ struct ieee802154_radio_api {
 #endif /* CONFIG_NET_L2_OPENTHREAD */
 };
 
+/* Make sure that the network interface API is properly setup inside
+ * IEEE 802154 radio API struct (it is the first one).
+ */
+BUILD_ASSERT(offsetof(struct ieee802154_radio_api, iface_api) == 0);
+
 #define IEEE802154_AR_FLAG_SET (0x20)
 
 /**

--- a/include/net/ppp.h
+++ b/include/net/ppp.h
@@ -62,6 +62,11 @@ struct ppp_api {
 #endif
 };
 
+/* Make sure that the network interface API is properly setup inside
+ * PPP API struct (it is the first one).
+ */
+BUILD_ASSERT(offsetof(struct ppp_api, iface_api) == 0);
+
 /**
  * PPP protocol types.
  * See https://www.iana.org/assignments/ppp-numbers/ppp-numbers.xhtml

--- a/include/net/socket_can.h
+++ b/include/net/socket_can.h
@@ -77,6 +77,11 @@ struct canbus_api {
 			  const void *optval, socklen_t *optlen);
 };
 
+/* Make sure that the network interface API is properly setup inside
+ * CANBUS API struct (it is the first one).
+ */
+BUILD_ASSERT(offsetof(struct canbus_api, iface_api) == 0);
+
 /**
  * @}
  */

--- a/include/net/wifi_mgmt.h
+++ b/include/net/wifi_mgmt.h
@@ -131,6 +131,11 @@ struct net_wifi_mgmt_offload {
 	int (*ap_disable)(struct device *dev);
 };
 
+/* Make sure that the network interface API is properly setup inside
+ * Wifi mgmt offload API struct (it is the first one).
+ */
+BUILD_ASSERT(offsetof(struct net_wifi_mgmt_offload, iface_api) == 0);
+
 #ifdef CONFIG_WIFI_OFFLOAD
 
 void wifi_mgmt_raise_connect_result_event(struct net_if *iface, int status);


### PR DESCRIPTION
Add build time check that guarantees that iface_api struct is the
first entry inside L2 driver data. This makes sure we do not miss
a case when the ordering of the fields in the struct is changed.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>