### PR TITLE
Drivers: Wifi: Eswifi: Fix the use of net_pkt_write() in eswifi driver

### DIFF
--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -123,7 +123,7 @@ static void eswifi_off_read_work(struct k_work *work)
 		goto done;
 	}
 
-	if (!net_pkt_write(pkt, data, len)) {
+	if (net_pkt_write(pkt, data, len) < 0) {
 		LOG_WRN("Incomplete buffer copy");
 	}
 


### PR DESCRIPTION
net_pkt_write() function returns 0 on success. But in this driver a warning is thrown
when zero is returned. Hence fix the driver to throw the warning only when the negative
value is returned

Signed-off-by: NavinSankar Velliangiri <navin@linumiz.com>