### PR TITLE
Bluetooth: Mesh: Fixes seg_tx_reset adv buf unref

### DIFF
--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -204,6 +204,7 @@ static void seg_tx_reset(struct seg_tx *tx)
 			continue;
 		}
 
+		BT_MESH_ADV(tx->seg[i])->busy = 0U;
 		net_buf_unref(tx->seg[i]);
 		tx->seg[i] = NULL;
 	}


### PR DESCRIPTION
In seg_tx_reset() in transport.c, set the busy flag to 0U
before doing adv buf unref, which will avoid sending
unnecessary adv packets in case the adv buf is already put
in the mesh adv_queue.

Fixes: #20970

Signed-off-by: llymaximus <llymaximus@gmail.com>