### PR TITLE
[TOPIC-GPIO] Update nrf52833_pca10100 and nrf5340_dk_nrf5340 to use the new GPIO API

### DIFF
--- a/boards/arm/nrf52833_pca10100/nrf52833_pca10100.dts
+++ b/boards/arm/nrf52833_pca10100/nrf52833_pca10100.dts
@@ -26,19 +26,19 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio0 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 			label = "Green LED 0";
 		};
 		led1: led_1 {
-			gpios = <&gpio0 14 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 			label = "Green LED 1";
 		};
 		led2: led_2 {
-			gpios = <&gpio0 15 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
 			label = "Green LED 2";
 		};
 		led3: led_3 {
-			gpios = <&gpio0 16 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
 			label = "Green LED 3";
 		};
 	};
@@ -53,19 +53,19 @@
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
-			gpios = <&gpio0 11 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 11 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button switch 0";
 		};
 		button1: button_1 {
-			gpios = <&gpio0 12 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 12 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button switch 1";
 		};
 		button2: button_2 {
-			gpios = <&gpio0 24 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 24 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button switch 2";
 		};
 		button3: button_3 {
-			gpios = <&gpio0 25 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 25 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button switch 3";
 		};
 	};

--- a/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp_common.dts
@@ -18,19 +18,19 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio0 28 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
 			label = "Green LED 0";
 		};
 		led1: led_1 {
-			gpios = <&gpio0 29 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
 			label = "Green LED 1";
 		};
 		led2: led_2 {
-			gpios = <&gpio0 30 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
 			label = "Green LED 2";
 		};
 		led3: led_3 {
-			gpios = <&gpio0 31 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
 			label = "Green LED 3";
 		};
 	};
@@ -38,19 +38,19 @@
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
-			gpios = <&gpio0 23 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 23 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button 1";
 		};
 		button1: button_1 {
-			gpios = <&gpio0 24 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 24 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button 2";
 		};
 		button2: button_2 {
-			gpios = <&gpio0 8 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button 3";
 		};
 		button3: button_3 {
-			gpios = <&gpio0 9 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button 4";
 		};
 	};

--- a/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpunet.dts
@@ -40,25 +40,25 @@
 			gpios = <&gpio0 31 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 3";
 		};
+	};
 
-		buttons {
-			compatible = "gpio-keys";
-			button0: button_0 {
-				gpios = <&gpio0 23 GPIO_PUD_PULL_UP>;
-				label = "Push button 1";
-			};
-			button1: button_1 {
-				gpios = <&gpio0 24 GPIO_PUD_PULL_UP>;
-				label = "Push button 2";
-			};
-			button2: button_2 {
-				gpios = <&gpio0 8 GPIO_PUD_PULL_UP>;
-				label = "Push button 3";
-			};
-			button3: button_3 {
-				gpios = <&gpio0 9 GPIO_PUD_PULL_UP>;
-				label = "Push button 4";
-			};
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio0 23 GPIO_PUD_PULL_UP>;
+			label = "Push button 1";
+		};
+		button1: button_1 {
+			gpios = <&gpio0 24 GPIO_PUD_PULL_UP>;
+			label = "Push button 2";
+		};
+		button2: button_2 {
+			gpios = <&gpio0 8 GPIO_PUD_PULL_UP>;
+			label = "Push button 3";
+		};
+		button3: button_3 {
+			gpios = <&gpio0 9 GPIO_PUD_PULL_UP>;
+			label = "Push button 4";
 		};
 	};
 

--- a/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpunet.dts
@@ -25,19 +25,19 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio0 28 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
 			label = "Green LED 0";
 		};
 		led1: led_1 {
-			gpios = <&gpio0 29 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
 			label = "Green LED 1";
 		};
 		led2: led_2 {
-			gpios = <&gpio0 30 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
 			label = "Green LED 2";
 		};
 		led3: led_3 {
-			gpios = <&gpio0 31 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
 			label = "Green LED 3";
 		};
 	};
@@ -45,19 +45,19 @@
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
-			gpios = <&gpio0 23 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 23 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button 1";
 		};
 		button1: button_1 {
-			gpios = <&gpio0 24 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 24 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button 2";
 		};
 		button2: button_2 {
-			gpios = <&gpio0 8 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button 3";
 		};
 		button3: button_3 {
-			gpios = <&gpio0 9 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button 4";
 		};
 	};


### PR DESCRIPTION
Update GPIO flags in the boards' dts files.

---

Depends on #20998.