### PR TITLE
Bluetooth: Host: Add CONFIG_BT_BONDING_REQUIRED flag

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -348,6 +348,14 @@ config BT_BONDABLE
 	  Bonding flag in AuthReq of SMP Pairing Request/Response will be set
 	  indicating the support for this mode.
 
+config BT_BONDING_REQUIRED
+	bool "Always require bonding"
+	depends on BT_BONDABLE
+	help
+	  When this option is enabled remote devices are required to always
+	  set the bondable flag in their pairing request. Any other kind of
+	  requests will be rejected.
+
 config BT_STORE_DEBUG_KEYS
 	bool "Store Debug Mode bonds"
 	help


### PR DESCRIPTION
Added configuration for accepting pairing requests only if both devices has bonding flag set in order to reject other devices at an early stage, thus leaving more chance for devices expected to bond.

With the CONFIG_BT_BONDING_REQUIRED flag the device only accept pairing requests if it has CONFIG_BT_BONMDABLE set and the device requesting pairing has Bonding_Flags field set to Bonding (0x01) in its AuthReq.
Note: When using bt_set_bondable(false) pairing requests will be
rejected when CONFIG_BT_BONDING_REQUIRED is set.

Signed-off-by: Martin Rieva <mrrv@demant.com>