### PR TITLE
Bluetooth: host: Fix command buffer corruption

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -115,9 +115,6 @@ void cmd_state_set_init(struct cmd_state_set *state, atomic_t *target, int bit,
 }
 
 struct cmd_data {
-	/** BT_BUF_CMD */
-	u8_t  type;
-
 	/** HCI status of the command completion */
 	u8_t  status;
 
@@ -142,7 +139,9 @@ struct acl_data {
 	u16_t handle;
 };
 
-#define cmd(buf) ((struct cmd_data *)net_buf_user_data(buf))
+static struct cmd_data cmd_data[CONFIG_BT_HCI_CMD_COUNT];
+
+#define cmd(buf) (&cmd_data[net_buf_id(buf)])
 #define acl(buf) ((struct acl_data *)net_buf_user_data(buf))
 
 /* HCI command buffers. Derive the needed size from BT_BUF_RX_SIZE since
@@ -288,7 +287,8 @@ struct net_buf *bt_hci_cmd_create(u16_t opcode, u8_t param_len)
 
 	net_buf_reserve(buf, BT_BUF_RESERVE);
 
-	cmd(buf)->type = BT_BUF_CMD;
+	bt_buf_set_type(buf, BT_BUF_CMD);
+
 	cmd(buf)->opcode = opcode;
 	cmd(buf)->sync = NULL;
 	cmd(buf)->state = NULL;


### PR DESCRIPTION
A recent patch increased struct cmd_data from 8 to 12 bytes, which is
more than the default user data for Bluetooth. We generally don't want
the core stack to require more than 8, so instead of increasing the
requirement, move the data out from the buffer into its own array with
the help of the net_buf_id() API.

Fixes #21004

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>