### PR TITLE
drivers: nrf: Add CTS and RTS pins to UART and UARTE PM

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -94,7 +94,7 @@ config UART_0_NRF_HW_ASYNC_TIMER
 
 config UART_0_GPIO_MANAGEMENT
 	bool "Enable GPIO management on port 0"
-	depends on UART_0_NRF_UARTE && DEVICE_POWER_MANAGEMENT
+	depends on DEVICE_POWER_MANAGEMENT
 	default y
 	help
 	  If enabled, the driver will configure the GPIOs used by the uart to

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -972,9 +972,43 @@ static const struct uart_driver_api uart_nrfx_uart_driver_api = {
 };
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-static void uart_nrfx_set_power_state(u32_t new_state)
+
+static void uart_nrfx_pins_enable(struct device *dev, bool enable)
+{
+	if (!IS_ENABLED(CONFIG_UART_0_GPIO_MANAGEMENT)) {
+		return;
+	}
+
+	u32_t tx_pin = nrf_uart_tx_pin_get(uart0_addr);
+	u32_t rx_pin = nrf_uart_rx_pin_get(uart0_addr);
+	u32_t cts_pin = nrf_uart_cts_pin_get(uart0_addr);
+	u32_t rts_pin = nrf_uart_rts_pin_get(uart0_addr);
+
+	if (enable) {
+		nrf_gpio_pin_write(tx_pin, 1);
+		nrf_gpio_cfg_output(tx_pin);
+		nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_NOPULL);
+
+		if (get_dev_config(dev)->rts_cts_pins_set) {
+			nrf_gpio_pin_write(rts_pin, 1);
+			nrf_gpio_cfg_output(rts_pin);
+			nrf_gpio_cfg_input(cts_pin,
+					   NRF_GPIO_PIN_NOPULL);
+		}
+	} else {
+		nrf_gpio_cfg_default(tx_pin);
+		nrf_gpio_cfg_default(rx_pin);
+		if (get_dev_config(dev)->rts_cts_pins_set) {
+			nrf_gpio_cfg_default(cts_pin);
+			nrf_gpio_cfg_default(rts_pin);
+		}
+	}
+}
+
+static void uart_nrfx_set_power_state(struct device *dev, u32_t new_state)
 {
 	if (new_state == DEVICE_PM_ACTIVE_STATE) {
+		uart_nrfx_pins_enable(dev, true);
 		nrf_uart_enable(uart0_addr);
 		nrf_uart_task_trigger(uart0_addr, NRF_UART_TASK_STARTRX);
 	} else {
@@ -982,6 +1016,7 @@ static void uart_nrfx_set_power_state(u32_t new_state)
 		       new_state == DEVICE_PM_SUSPEND_STATE ||
 		       new_state == DEVICE_PM_OFF_STATE);
 		nrf_uart_disable(uart0_addr);
+		uart_nrfx_pins_enable(dev, false);
 	}
 }
 
@@ -994,7 +1029,7 @@ static int uart_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 		u32_t new_state = *((const u32_t *)context);
 
 		if (new_state != current_state) {
-			uart_nrfx_set_power_state(new_state);
+			uart_nrfx_set_power_state(dev, new_state);
 			current_state = new_state;
 		}
 	} else {

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1225,19 +1225,46 @@ static int uarte_instance_init(struct device *dev,
 }
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
-static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
+
+static void uarte_nrfx_pins_enable(struct device *dev, bool enable)
 {
+	if (!get_dev_config(dev)->gpio_mgmt) {
+		return;
+	}
+
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	u32_t tx_pin = nrf_uarte_tx_pin_get(uarte);
 	u32_t rx_pin = nrf_uarte_rx_pin_get(uarte);
+	u32_t cts_pin = nrf_uarte_cts_pin_get(uarte);
+	u32_t rts_pin = nrf_uarte_rts_pin_get(uarte);
+
+	if (enable) {
+		nrf_gpio_pin_write(tx_pin, 1);
+		nrf_gpio_cfg_output(tx_pin);
+		nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_NOPULL);
+
+		if (get_dev_config(dev)->rts_cts_pins_set) {
+			nrf_gpio_pin_write(rts_pin, 1);
+			nrf_gpio_cfg_output(rts_pin);
+			nrf_gpio_cfg_input(cts_pin,
+					   NRF_GPIO_PIN_NOPULL);
+		}
+	} else {
+		nrf_gpio_cfg_default(tx_pin);
+		nrf_gpio_cfg_default(rx_pin);
+		if (get_dev_config(dev)->rts_cts_pins_set) {
+			nrf_gpio_cfg_default(cts_pin);
+			nrf_gpio_cfg_default(rts_pin);
+		}
+	}
+}
+
+static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
+{
+	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
 	if (new_state == DEVICE_PM_ACTIVE_STATE) {
-		if (get_dev_config(dev)->gpio_mgmt) {
-			nrf_gpio_pin_write(tx_pin, 1);
-			nrf_gpio_cfg_output(tx_pin);
-			nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_NOPULL);
-		}
-
+		uarte_nrfx_pins_enable(dev, true);
 		nrf_uarte_enable(uarte);
 #ifdef CONFIG_UART_ASYNC_API
 		if (get_dev_data(dev)->async) {
@@ -1256,10 +1283,7 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 #ifdef CONFIG_UART_ASYNC_API
 		if (get_dev_data(dev)->async) {
 			nrf_uarte_disable(uarte);
-			if (get_dev_config(dev)->gpio_mgmt) {
-				nrf_gpio_cfg_default(tx_pin);
-				nrf_gpio_cfg_default(rx_pin);
-			}
+			uarte_nrfx_pins_enable(dev, false);
 			return;
 		}
 #endif
@@ -1269,10 +1293,7 @@ static void uarte_nrfx_set_power_state(struct device *dev, u32_t new_state)
 		}
 		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXTO);
 		nrf_uarte_disable(uarte);
-		if (get_dev_config(dev)->gpio_mgmt) {
-			nrf_gpio_cfg_default(tx_pin);
-			nrf_gpio_cfg_default(rx_pin);
-		}
+		uarte_nrfx_pins_enable(dev, false);
 	}
 }
 


### PR DESCRIPTION
Add gpio management for CTS and RTS pins in UART and UARTE drivers

Signed-off-by: Mieszko Mierunski <mieszko.mierunski@nordicsemi.no>

Fixes #16723