### PR TITLE
Add EDTT tests (BT controller conformance) to CI

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -26,6 +26,8 @@ if [ ! -d "${BSIM_OUT_PATH}" ]; then
         unset BSIM_OUT_PATH
 fi
 export BSIM_COMPONENTS_PATH="${BSIM_OUT_PATH}/components/"
+export EDTT_PATH="${EDTT_PATH:-../tools/edtt}"
+
 bsim_bt_test_results_file="./bsim_bt_out/bsim_results.xml"
 west_commands_results_file="./pytest_out/west_commands.xml"
 

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -126,7 +126,7 @@ function on_complete() {
 function run_bsim_bt_tests() {
 	WORK_DIR=${ZEPHYR_BASE}/bsim_bt_out tests/bluetooth/bsim_bt/compile.sh
 	RESULTS_FILE=${ZEPHYR_BASE}/${bsim_bt_test_results_file} \
-	SEARCH_PATH=tests/bluetooth/bsim_bt/bsim_test_app/tests_scripts \
+	SEARCH_PATH=tests/bluetooth/bsim_bt/ \
 	tests/bluetooth/bsim_bt/run_parallel.sh
 }
 


### PR DESCRIPTION
So far trial PR which:

* ~Adds the EDTT controller and GATT test apps~
* ~Fetches the EDTTool and tests in CI (to be fetched as a west module)~
* ~Installs a few extra packages in CI (to be part of the docker image)~
* ~Fetches the BabbleSim EDTT bridge (to be part of the docker image)~
* ~Compiles both EDTT app images, and~
* Runs all available conformance tests in CI (~1 min extra runtime in the first instance)

Note: As of now, some of the tests are known to fail

----------

Current failing tests status:

* HCI/CCO/BV-07-C [BR/EDR Commands Not Supported on LE Device]
                             No response to Inquire command 
* HCI/GEV/BV-01-C [Status return for Unsupported Commands] 
                             No response to Inquire command
* LL/CON/INI/BV-24-C [Network Privacy - Connection Establishment using resolving list with address resolution disabled]
                              (not enabled by default, needs to be investigated)