### PR TITLE
tests: drivers: watchdog: exclude platforms with SAM WDT from testing

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -2,6 +2,7 @@ tests:
   peripheral.watchdog:
     depends_on: watchdog
     tags: drivers watchdog
+    filter: not CONFIG_WDT_SAM
     platform_exclude: nucleo_l496zg nucleo_f401re
   peripheral.window_watchdog_nucleo_l496zg:
     depends_on: watchdog


### PR DESCRIPTION
On watchdog-triggered reboot, the SAM platforms
reset RAM, so the wdt_basic_api cannot be completed
successfully, as it relies on RAM retention (relies
on variables stored in RAM retaining their values
across different boot cycles). Exclude the platforms
with the SAM Watchdog from this test.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Fixes #13417 