### PR TITLE
net: tls: Add SSL/TLS secure renegotiation support

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -842,6 +842,13 @@ static int tls_mbedtls_init(struct net_context *context, bool is_server)
 		return -ENOMEM;
 	}
 
+#if defined(MBEDTLS_SSL_RENEGOTIATION)
+	mbedtls_ssl_conf_legacy_renegotiation(&context->tls->config,
+					   MBEDTLS_SSL_LEGACY_BREAK_HANDSHAKE);
+	mbedtls_ssl_conf_renegotiation(&context->tls->config,
+				       MBEDTLS_SSL_RENEGOTIATION_ENABLED);
+#endif
+
 #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
 	if (type == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
 		/* DTLS requires timer callbacks to operate */


### PR DESCRIPTION
Allow enabling SSL/TLS secure renegotiation support when initiated by
peer.

This is needed when authenticating with an X.509 client certificate to
Microsoft Azure/IIS through a secure websocket.

Signed-off-by: Markus Fuchs <markus.fuchs@de.sauter-bc.com>