### PR TITLE
Fix build intel_s1000_crb samples with XCC

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -368,7 +368,13 @@ static inline void k_obj_free(void *obj)
 struct __packed _k_thread_stack_element {
 	char data;
 };
-typedef struct _k_thread_stack_element k_thread_stack_t;
+
+/**
+ * @typedef k_thread_stack_t
+ * @brief Typedef of struct _k_thread_stack_element
+ *
+ * @see _k_thread_stack_element
+ */
 
 /**
  * @typedef k_thread_entry_t
@@ -388,7 +394,6 @@ typedef struct _k_thread_stack_element k_thread_stack_t;
  *
  * @return N/A
  */
-typedef void (*k_thread_entry_t)(void *p1, void *p2, void *p3);
 
 #ifdef CONFIG_THREAD_MONITOR
 struct __thread_entry {

--- a/include/toolchain/xcc.h
+++ b/include/toolchain/xcc.h
@@ -7,7 +7,15 @@
 #ifndef ZEPHYR_INCLUDE_TOOLCHAIN_XCC_H_
 #define ZEPHYR_INCLUDE_TOOLCHAIN_XCC_H_
 
+/* toolchain/gcc.h errors out if __BYTE_ORDER__ cannot be determined
+ * there. However, __BYTE_ORDER__ is actually being defined later in
+ * this file. So define __BYTE_ORDER__ to skip the check in gcc.h
+ * and undefine after including gcc.h.
+ */
+#define __BYTE_ORDER__
 #include <toolchain/gcc.h>
+#undef __BYTE_ORDER__
+
 #include <stdbool.h>
 
 /* XCC doesn't support __COUNTER__ but this should be good enough */
@@ -25,14 +33,12 @@
  * HAL defines similar ones. Thus we include it and define the missing macros
  * ourselves.
  */
-#ifndef __BYTE_ORDER__
-#define __BYTE_ORDER__ XCHAL_MEMORY_ORDER
-#endif
-#ifndef __ORDER_BIG_ENDIAN__
-#define __ORDER_BIG_ENDIAN__ XTHAL_BIGENDIAN
-#endif
-#ifndef __ORDER_LITTLE_ENDIAN__
-#define __ORDER_LITTLE_ENDIAN__ XTHAL_LITTLEENDIAN
+#if XCHAL_MEMORY_ORDER == XTHAL_BIGENDIAN
+#define __BYTE_ORDER__		__ORDER_BIG_ENDIAN__
+#elif XCHAL_MEMORY_ORDER == XTHAL_LITTLEENDIAN
+#define __BYTE_ORDER__		__ORDER_LITTLE_ENDIAN__
+#else
+#error "Cannot determine __BYTE_ORDER__"
 #endif
 
 #endif /* __GCC_LINKER_CMD__ */

--- a/soc/xtensa/intel_s1000/CMakeLists.txt
+++ b/soc/xtensa/intel_s1000/CMakeLists.txt
@@ -3,3 +3,9 @@
 zephyr_library()
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(soc.c)
+
+if("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "xcc")
+if(CONFIG_NEWLIB_LIBC)
+  zephyr_library_sources(xcc_newlib_fix.c)
+endif()
+endif()

--- a/soc/xtensa/intel_s1000/Kconfig.soc
+++ b/soc/xtensa/intel_s1000/Kconfig.soc
@@ -3,5 +3,5 @@
 
 config SOC_INTEL_S1000
 	bool "intel_s1000"
-	select HAS_I2C_DW
-	select HAS_SPI_DW
+	select HAS_I2C_DW if I2C
+	select HAS_SPI_DW if SPI

--- a/soc/xtensa/intel_s1000/xcc_newlib_fix.c
+++ b/soc/xtensa/intel_s1000/xcc_newlib_fix.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2019, Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <toolchain.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include <reent.h>
+
+/* these externs are from lib/libc/newlib/libc-hooks.c */
+extern int _read(int fd, char *buf, int nbytes);
+extern int _write(int fd, const void *buf, int nbytes);
+extern int _open(const char *name, int mode);
+extern int _close(int file);
+extern int _lseek(int file, int ptr, int dir);
+extern int _isatty(int file);
+extern int _kill(int i, int j);
+extern int _getpid(void);
+extern int _fstat(int file, struct stat *st);
+extern void _exit(int status);
+extern void *_sbrk(int count);
+
+_ssize_t _read_r(struct _reent *r, int fd, void *buf, size_t nbytes)
+{
+	ARG_UNUSED(r);
+
+	return _read(fd, (char *)buf, nbytes);
+}
+
+_ssize_t _write_r(struct _reent *r, int fd, const void *buf, size_t nbytes)
+{
+	ARG_UNUSED(r);
+
+	return _write(fd, buf, nbytes);
+}
+
+int _open_r(struct _reent *r, const char *name, int flags, int mode)
+{
+	ARG_UNUSED(r);
+	ARG_UNUSED(flags);
+
+	return _open(name, mode);
+}
+
+int _close_r(struct _reent *r, int file)
+{
+	ARG_UNUSED(r);
+
+	return _close(file);
+}
+
+_off_t _lseek_r(struct _reent *r, int file, _off_t ptr, int dir)
+{
+	ARG_UNUSED(r);
+
+	return _lseek(file, ptr, dir);
+}
+
+int _isatty_r(struct _reent *r, int file)
+{
+	ARG_UNUSED(r);
+
+	return _isatty(file);
+}
+
+int _kill_r(struct _reent *r, int i, int j)
+{
+	ARG_UNUSED(r);
+
+	return _kill(i, j);
+}
+
+int _getpid_r(struct _reent *r)
+{
+	ARG_UNUSED(r);
+
+	return _getpid();
+}
+
+int _fstat_r(struct _reent *r, int file, struct stat *st)
+{
+	ARG_UNUSED(r);
+
+	return _fstat(file, st);
+}
+
+void _exit_r(struct _reent *r, int status)
+{
+	ARG_UNUSED(r);
+
+	_exit(status);
+}
+
+void *_sbrk_r(struct _reent *r, int count)
+{
+	ARG_UNUSED(r);
+
+	return _sbrk(count);
+}


### PR DESCRIPTION
This fixes manually building the samples under `samples/boards/intel_s1000_crb/` with XCC.

Note that XCC is based on GCC 4.2.0 and with prebuilt libraries.

Fixes #20931 