### PR TITLE
Bluetooth: controller: Fix Zero Latency Interrupt support

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -516,7 +516,7 @@ config BT_CTLR_PHY_CODED
 
 config BT_CTLR_ZLI
 	bool "Use Zero Latency IRQs"
-	depends on ZERO_LATENCY_IRQS
+	depends on ZERO_LATENCY_IRQS && BT_LL_SW_SPLIT
 	help
 	  Enable support for use of Zero Latency IRQ feature. Note, applications
 	  shall not use Zero Latency IRQ themselves when this option is selected,

--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -40,12 +40,6 @@
 #include "ll_feat.h"
 #include "ll_filter.h"
 
-#if defined(CONFIG_BT_CTLR_ZLI)
-#define IRQ_CONNECT_FLAGS IRQ_ZERO_LATENCY
-#else
-#define IRQ_CONNECT_FLAGS 0
-#endif
-
 /* Global singletons */
 
 #if defined(CONFIG_SOC_FLASH_NRF_RADIO_SYNC)
@@ -185,16 +179,11 @@ int ll_init(struct k_sem *sem_rx)
 	}
 
 	IRQ_DIRECT_CONNECT(RADIO_IRQn, CONFIG_BT_CTLR_WORKER_PRIO,
-			   radio_nrf5_isr, IRQ_CONNECT_FLAGS);
+			   radio_nrf5_isr, 0);
 	IRQ_CONNECT(RTC0_IRQn, CONFIG_BT_CTLR_WORKER_PRIO,
-		    rtc0_nrf5_isr, NULL, IRQ_CONNECT_FLAGS);
-#if (CONFIG_BT_CTLR_WORKER_PRIO == CONFIG_BT_CTLR_JOB_PRIO)
-	IRQ_CONNECT(SWI5_IRQn, CONFIG_BT_CTLR_JOB_PRIO,
-		    swi5_nrf5_isr, NULL, IRQ_CONNECT_FLAGS);
-#else
+		    rtc0_nrf5_isr, NULL, 0);
 	IRQ_CONNECT(SWI5_IRQn, CONFIG_BT_CTLR_JOB_PRIO,
 		    swi5_nrf5_isr, NULL, 0);
-#endif
 
 	irq_enable(RADIO_IRQn);
 	irq_enable(RTC0_IRQn);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -33,6 +33,12 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
+#if defined(CONFIG_BT_CTLR_ZLI)
+#define IRQ_CONNECT_FLAGS IRQ_ZERO_LATENCY
+#else
+#define IRQ_CONNECT_FLAGS 0
+#endif
+
 static struct {
 	struct {
 		void              *param;
@@ -158,11 +164,11 @@ int lll_init(void)
 
 	/* Connect ISRs */
 	IRQ_DIRECT_CONNECT(RADIO_IRQn, CONFIG_BT_CTLR_LLL_PRIO,
-			   radio_nrf5_isr, 0);
+			   radio_nrf5_isr, IRQ_CONNECT_FLAGS);
 	IRQ_CONNECT(RTC0_IRQn, CONFIG_BT_CTLR_ULL_HIGH_PRIO,
 		    rtc0_nrf5_isr, NULL, 0);
 	IRQ_CONNECT(HAL_SWI_RADIO_IRQ, CONFIG_BT_CTLR_LLL_PRIO,
-		    swi_lll_nrf5_isr, NULL, 0);
+		    swi_lll_nrf5_isr, NULL, IRQ_CONNECT_FLAGS);
 #if defined(CONFIG_BT_CTLR_LOW_LAT) || \
 	(CONFIG_BT_CTLR_ULL_HIGH_PRIO != CONFIG_BT_CTLR_ULL_LOW_PRIO)
 	IRQ_CONNECT(HAL_SWI_JOB_IRQ, CONFIG_BT_CTLR_ULL_LOW_PRIO,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -33,12 +33,6 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
-#if defined(CONFIG_BT_CTLR_ZLI)
-#define IRQ_CONNECT_FLAGS IRQ_ZERO_LATENCY
-#else
-#define IRQ_CONNECT_FLAGS 0
-#endif
-
 static struct {
 	struct {
 		void              *param;
@@ -164,16 +158,11 @@ int lll_init(void)
 
 	/* Connect ISRs */
 	IRQ_DIRECT_CONNECT(RADIO_IRQn, CONFIG_BT_CTLR_LLL_PRIO,
-			   radio_nrf5_isr, IRQ_CONNECT_FLAGS);
-#if (CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_HIGH_PRIO)
-	IRQ_CONNECT(RTC0_IRQn, CONFIG_BT_CTLR_ULL_HIGH_PRIO,
-		    rtc0_nrf5_isr, NULL, IRQ_CONNECT_FLAGS);
-#else
+			   radio_nrf5_isr, 0);
 	IRQ_CONNECT(RTC0_IRQn, CONFIG_BT_CTLR_ULL_HIGH_PRIO,
 		    rtc0_nrf5_isr, NULL, 0);
-#endif
 	IRQ_CONNECT(HAL_SWI_RADIO_IRQ, CONFIG_BT_CTLR_LLL_PRIO,
-		    swi_lll_nrf5_isr, NULL, IRQ_CONNECT_FLAGS);
+		    swi_lll_nrf5_isr, NULL, 0);
 #if defined(CONFIG_BT_CTLR_LOW_LAT) || \
 	(CONFIG_BT_CTLR_ULL_HIGH_PRIO != CONFIG_BT_CTLR_ULL_LOW_PRIO)
 	IRQ_CONNECT(HAL_SWI_JOB_IRQ, CONFIG_BT_CTLR_ULL_LOW_PRIO,


### PR DESCRIPTION
Reverted/removed ZLI implementation/support in legacy controller, as ISR uses k_sem_give which would crash the OS.

Fixed ZLI implementation in split controller, the k_sem_give call in LLL context is conditionally compiled in for builds that do not use ZLI.