### PR TITLE
dts: edtlib: Support nested nodes on buses + improve naming

### DIFF
--- a/doc/guides/dts/index.rst
+++ b/doc/guides/dts/index.rst
@@ -618,6 +618,8 @@ The binding below shows various legacy syntax.
    parent:
        bus: spi
 
+   parent-bus: spi
+
    properties:
        compatible:
            constraint: "company,device"
@@ -650,7 +652,7 @@ This should now be written like this:
 
    include: foo.yaml
 
-   parent-bus: spi
+   bus: spi
 
    properties:
        frequency:

--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -62,19 +62,16 @@ compatible: "manufacturer,device"
 # 'required: true' is always respected.
 include: other.yaml # or [other1.yaml, other2.yaml]
 
-# If the node describes a bus, then the bus type should be given, like below.
-# The name has "child" in it since it describes the bus children of the node
-# appear on.
-child-bus: <string describing bus type, e.g. "i2c">
+# If the node describes a bus, then the bus type should be given, like below
+bus: <string describing bus type, e.g. "i2c">
 
 # If the node appears on a bus, then the bus type should be given, like below.
 #
 # When looking for a binding for a node, the code checks if the binding for the
-# parent node contains 'child-bus: <bus type>'. If it does, then only bindings
-# with a matching 'parent-bus: <bus type>' are considered. This allows the same
-# type of device to have different bindings depending on what bus it appears
-# on.
-parent-bus: <string describing bus type, e.g. "i2c">
+# parent node contains 'bus: <bus type>'. If it does, then only bindings with a
+# matching 'on-bus: <bus type>' are considered. This allows the same type of
+# device to have different bindings depending on what bus it appears on.
+on-bus: <string describing bus type, e.g. "i2c">
 
 # 'properties' describes properties on the node, e.g.
 #

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi-slave.yaml
@@ -9,7 +9,7 @@ compatible: "zephyr,bt-hci-spi-slave"
 
 include: base.yaml
 
-parent-bus: spi
+on-bus: spi
 
 properties:
     irq-gpios:

--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -2,7 +2,7 @@
 
 include: base.yaml
 
-child-bus: can
+bus: can
 
 properties:
     "#address-cells":

--- a/dts/bindings/can/can-device.yaml
+++ b/dts/bindings/can/can-device.yaml
@@ -5,7 +5,7 @@
 
 include: base.yaml
 
-parent-bus: can
+on-bus: can
 
 properties:
     reg:

--- a/dts/bindings/dma/dma-controller.yaml
+++ b/dts/bindings/dma/dma-controller.yaml
@@ -5,7 +5,7 @@
 
 include: base.yaml
 
-child-bus: dma
+bus: dma
 
 properties:
     label:

--- a/dts/bindings/espi/espi-controller.yaml
+++ b/dts/bindings/espi/espi-controller.yaml
@@ -5,7 +5,7 @@
 
 include: base.yaml
 
-child-bus: espi
+bus: espi
 
 properties:
     label:

--- a/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
+++ b/dts/bindings/gpio/holtek,ht16k33-keyscan.yaml
@@ -4,7 +4,7 @@ compatible: "holtek,ht16k33-keyscan"
 
 include: base.yaml
 
-parent-bus: ht16k33
+on-bus: ht16k33
 
 properties:
     reg:

--- a/dts/bindings/i2c/i2c-controller.yaml
+++ b/dts/bindings/i2c/i2c-controller.yaml
@@ -5,7 +5,7 @@
 
 include: base.yaml
 
-child-bus: i2c
+bus: i2c
 
 properties:
     "#address-cells":

--- a/dts/bindings/i2c/i2c-device.yaml
+++ b/dts/bindings/i2c/i2c-device.yaml
@@ -5,7 +5,7 @@
 
 include: base.yaml
 
-parent-bus: i2c
+on-bus: i2c
 
 properties:
     reg:

--- a/dts/bindings/i2s/i2s-controller.yaml
+++ b/dts/bindings/i2s/i2s-controller.yaml
@@ -5,7 +5,7 @@
 
 include: base.yaml
 
-child-bus: i2s
+bus: i2s
 
 properties:
     "#address-cells":

--- a/dts/bindings/i2s/i2s-device.yaml
+++ b/dts/bindings/i2s/i2s-device.yaml
@@ -5,7 +5,7 @@
 
 include: base.yaml
 
-parent-bus: i2s
+on-bus: i2s
 
 properties:
     reg:

--- a/dts/bindings/kscan/kscan.yaml
+++ b/dts/bindings/kscan/kscan.yaml
@@ -5,7 +5,7 @@
 
 include: base.yaml
 
-child-bus: kscan
+bus: kscan
 
 properties:
     "#address-cells":

--- a/dts/bindings/led/holtek,ht16k33.yaml
+++ b/dts/bindings/led/holtek,ht16k33.yaml
@@ -4,7 +4,7 @@ compatible: "holtek,ht16k33"
 
 include: i2c-device.yaml
 
-child-bus: ht16k33
+bus: ht16k33
 
 properties:
     "#address-cells":

--- a/dts/bindings/ps2/ps2.yaml
+++ b/dts/bindings/ps2/ps2.yaml
@@ -5,7 +5,7 @@
 
 include: base.yaml
 
-child-bus: ps2
+bus: ps2
 
 properties:
     "#address-cells":

--- a/dts/bindings/serial/uart-controller.yaml
+++ b/dts/bindings/serial/uart-controller.yaml
@@ -2,7 +2,7 @@
 
 include: base.yaml
 
-child-bus: uart
+bus: uart
 
 properties:
     clock-frequency:

--- a/dts/bindings/serial/uart-device.yaml
+++ b/dts/bindings/serial/uart-device.yaml
@@ -5,7 +5,7 @@
 
 include: base.yaml
 
-parent-bus: uart
+on-bus: uart
 
 properties:
     label:

--- a/dts/bindings/spi/spi-controller.yaml
+++ b/dts/bindings/spi/spi-controller.yaml
@@ -5,7 +5,7 @@
 
 include: base.yaml
 
-child-bus: spi
+bus: spi
 
 properties:
     clock-frequency:

--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -5,7 +5,7 @@
 
 include: base.yaml
 
-parent-bus: spi
+on-bus: spi
 
 properties:
     reg:

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -244,18 +244,18 @@ def write_props(node):
 def write_bus(node):
     # Generate bus-related #defines
 
-    if not node.bus:
+    if not node.bus_node:
         return
 
-    if node.parent.label is None:
-        err("missing 'label' property on {!r}".format(node.parent))
+    if node.bus_node.label is None:
+        err("missing 'label' property on bus node {!r}".format(node.bus_node))
 
     # #define DT_<DEV-IDENT>_BUS_NAME <BUS-LABEL>
-    out_dev_s(node, "BUS_NAME", str2ident(node.parent.label))
+    out_dev_s(node, "BUS_NAME", str2ident(node.bus_node.label))
 
     for compat in node.compats:
         # #define DT_<COMPAT>_BUS_<BUS-TYPE> 1
-        out("{}_BUS_{}".format(str2ident(compat), str2ident(node.bus)), 1)
+        out("{}_BUS_{}".format(str2ident(compat), str2ident(node.on_bus)), 1)
 
 
 def write_existence_flags(node):
@@ -307,9 +307,9 @@ def dev_ident(node):
 
     ident = ""
 
-    if node.bus:
+    if node.bus_node:
         ident += "{}_{:X}_".format(
-            str2ident(node.parent.matching_compat), node.parent.unit_addr)
+            str2ident(node.bus_node.matching_compat), node.bus_node.unit_addr)
 
     ident += "{}_".format(str2ident(node.matching_compat))
 
@@ -415,8 +415,8 @@ def write_flash_node(edt):
         err("expected zephyr,flash to have a single register, has {}"
             .format(len(node.regs)))
 
-    if node.bus == "spi" and len(node.parent.regs) == 2:
-        reg = node.parent.regs[1]  # QSPI flash
+    if node.on_bus == "spi" and len(node.bus_node.regs) == 2:
+        reg = node.bus_node.regs[1]  # QSPI flash
     else:
         reg = node.regs[0]
 

--- a/scripts/dts/test-bindings/bar-bus.yaml
+++ b/scripts/dts/test-bindings/bar-bus.yaml
@@ -4,4 +4,4 @@ description: Bar bus controller
 
 compatible: "bar-bus"
 
-child-bus: "bar"
+bus: "bar"

--- a/scripts/dts/test-bindings/device-on-bar-bus.yaml
+++ b/scripts/dts/test-bindings/device-on-bar-bus.yaml
@@ -4,4 +4,4 @@ description: Device on bar bus
 
 compatible: "on-bus"
 
-parent-bus: "bar"
+on-bus: "bar"

--- a/scripts/dts/test-bindings/device-on-foo-bus.yaml
+++ b/scripts/dts/test-bindings/device-on-foo-bus.yaml
@@ -4,4 +4,4 @@ description: Device on foo bus
 
 compatible: "on-bus"
 
-parent-bus: "foo"
+on-bus: "foo"

--- a/scripts/dts/test-bindings/foo-bus.yaml
+++ b/scripts/dts/test-bindings/foo-bus.yaml
@@ -4,4 +4,4 @@ description: Foo bus controller
 
 compatible: "foo-bus"
 
-child-bus: "foo"
+bus: "foo"

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -294,7 +294,7 @@
 	};
 
 	//
-	// For testing 'child-bus:' and 'parent-bus:'
+	// For testing 'bus:' and 'on-bus:'
 	//
 
 	buses {

--- a/scripts/dts/test.dts
+++ b/scripts/dts/test.dts
@@ -298,12 +298,15 @@
 	//
 
 	buses {
-		// The nodes below will map to different bindings since they
-		// appear on different buses
+		// The 'node' nodes below will map to different bindings since
+		// they appear on different buses
 		foo-bus {
 			compatible = "foo-bus";
 			node {
 				compatible = "on-bus";
+				nested {
+					compatible = "on-bus";
+				};
 			};
 		};
 		bar-bus {

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -119,7 +119,7 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
                  "OrderedDict([('foo', <Property, name: foo, type: int, value: 0>), ('bar', <Property, name: bar, type: int, value: 1>), ('baz', <Property, name: baz, type: int, value: 2>), ('qaz', <Property, name: qaz, type: int, value: 3>)])")
 
     #
-    # Test 'child/parent-bus:'
+    # Test 'bus:' and 'on-bus:'
     #
 
     verify_streq(edt.get_node("/buses/foo-bus/node").binding_path,

--- a/scripts/dts/testedtlib.py
+++ b/scripts/dts/testedtlib.py
@@ -122,11 +122,29 @@ warning: "#cells:" in test-bindings/deprecated.yaml is deprecated and will be re
     # Test 'bus:' and 'on-bus:'
     #
 
+    verify_eq(edt.get_node("/buses/foo-bus").bus, "foo")
+    # foo-bus does not itself appear on a bus
+    verify_eq(edt.get_node("/buses/foo-bus").on_bus, None)
+    verify_eq(edt.get_node("/buses/foo-bus").bus_node, None)
+
+    # foo-bus/node is not a bus node...
+    verify_eq(edt.get_node("/buses/foo-bus/node").bus, None)
+    # ...but is on a bus
+    verify_eq(edt.get_node("/buses/foo-bus/node").on_bus, "foo")
+    verify_eq(edt.get_node("/buses/foo-bus/node").bus_node.path,
+                           "/buses/foo-bus")
+
+    # Same compatible string, but different bindings from being on different
+    # buses
     verify_streq(edt.get_node("/buses/foo-bus/node").binding_path,
                  "test-bindings/device-on-foo-bus.yaml")
-
     verify_streq(edt.get_node("/buses/bar-bus/node").binding_path,
                  "test-bindings/device-on-bar-bus.yaml")
+
+    # foo-bus/node/nested also appears on the foo-bus bus
+    verify_eq(edt.get_node("/buses/foo-bus/node/nested").on_bus, "foo")
+    verify_streq(edt.get_node("/buses/foo-bus/node/nested").binding_path,
+                 "test-bindings/device-on-foo-bus.yaml")
 
     #
     # Test 'child-binding:'


### PR DESCRIPTION
This PR first renames `child-bus:`/`parent-bus:` to `bus:`/`on-bus:`, and then adds support for devicetrees like the following, where `nested` should be viewed as being on the bus:

```
some-bus {
    compatible = "foo,bus-controller";
    node {
            nested {
                    compatible = "foo,device-on-bus";
            };
    };
};
```

Previously, nodes on buses had to be direct children of the bus node.

The edtlib bus-related APIs are tweaked/extended a bit. There's now these attributes:

- `Node.bus`: The bus type, for bus controllers
- `Node.on_bus`: The bus type, if the node appears on a bus
- `Node.bus_node`: The `Node` for the bus controller, if the node appears on a bus

Both `Node.bus` and `Node.on_bus` can be set at the same time if a bus controller appears on a bus.

Renaming commits:

```
scripts: edtlib: Rename 'child-bus:'/'parent-bus:' to 'bus:'/'on-bus:'

I keep mixing these up, so that's probably a sign that the names are
bad. The root of the problem is that "parent-bus" can be read as both
"this is the parent bus" and as "the parent bus is this".

Use 'bus:' for the bus "provider" and 'on-bus:' for nodes on the bus
instead, which is less confusing.

Support the old keys for backwards compatibility, along with a
deprecation warning.
```

```
dts: bindings: Replace 'child-bus:'/'parent-bus:' with 'bus:'/'on-bus:'

'child-bus:'/'parent-bus:' have been deprecated.
```

Commit for new functionality:

```
For the following devicetree, view 'nested' as being on the bus.
Previously, only 'node' was considered to be on the bus.

    some-bus {
    	compatible = "foo,bus-controller";
    	node {
    		nested {
    			compatible = "foo,device-on-bus";
    		};
    	};
    };

In practice, this means that a 'bus:' key in the binding for
'foo,bus-controller' will now get matched up to an 'on-bus:' key in the
binding for 'foo,device-on-bus'.

Change the meaning of Node.bus and add two new attributes Node.on_bus
and Node.bus_node, with these meanings:

    Node.bus:
      The bus type (as a string) if the node is a bus controller, and
      None otherwise

    Node.on_bus:
      The bus type (as a string) if the node appears on a bus, and None
      otherwise. The bus type is determined from the closest parent
      that's a bus controller.

    Node.bus_node:
      The node for the bus controller if the node appears on a bus, and
      None otherwise

It's a bit redundant to have both Node.bus_node and Node.on_bus, since
Node.on_bus is the same as Node.bus_node.bus, but Node.on_bus is pretty
handy to save some None checks.

Also update gen_defines.py to use Node.on_bus and Node.bus_node instead
of Node.parent wherever the code deals with buses.
```