### PR TITLE
boards: add ADC to nrf52840_mdk

### DIFF
--- a/boards/arm/nrf52840_mdk/Kconfig.defconfig
+++ b/boards/arm/nrf52840_mdk/Kconfig.defconfig
@@ -8,6 +8,13 @@ if BOARD_NRF52840_MDK
 config BOARD
 	default "nrf52840_mdk"
 
+if ADC
+
+config ADC_0
+	default y
+
+endif # ADC
+
 if I2C
 
 config I2C_0

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -59,6 +59,10 @@
 	};
 };
 
+&adc {
+	status = "okay";
+};
+
 &gpiote {
 	status = "okay";
 };


### PR DESCRIPTION
ADC is supported by nRF52840, so add it to nrf52840_mdk.

edited:
remove SPI, as nrf52840_mdk doesn't define SPI pins