### PR TITLE
Bluetooth: Mesh: Fixes Delete On Node

### DIFF
--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -1904,6 +1904,7 @@ void bt_mesh_clear_node(struct bt_mesh_node *node)
 		return;
 	}
 
+	free_slot->clear = true;
 	free_slot->addr = node->addr;
 
 	schedule_store(BT_MESH_NODES_PENDING);


### PR DESCRIPTION
Fixes a issure where nodes could not be deleted.

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>