### PR TITLE
samples: lsm6dsl: Add a harness_config

### DIFF
--- a/samples/sensor/lsm6dsl/sample.yaml
+++ b/samples/sensor/lsm6dsl/sample.yaml
@@ -5,3 +5,11 @@ tests:
     harness: console
     tags: sensors
     depends_on: lsm6dsl
+    timeout: 15
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "accel x:[-.0-9]* ms/2 y:[-.0-9]* ms/2 z:[-.0-9]* ms/2"
+        - "gyro x:[-.0-9]* dps y:[-.0-9]* dps z:[-.0-9]* dps"
+        - "loop:[0-9]* trig_cnt:[0-9]*"

--- a/samples/sensor/lsm6dsl/src/main.c
+++ b/samples/sensor/lsm6dsl/src/main.c
@@ -146,33 +146,37 @@ void main(void)
 		printf("LSM6DSL sensor samples:\n\n");
 
 		/* lsm6dsl accel */
-		sprintf(out_str, "accel (%f %f %f) m/s2", out_ev(&accel_x_out),
-							out_ev(&accel_y_out),
-							out_ev(&accel_z_out));
+		sprintf(out_str, "accel x:%f ms/2 y:%f ms/2 z:%f ms/2",
+							  out_ev(&accel_x_out),
+							  out_ev(&accel_y_out),
+							  out_ev(&accel_z_out));
 		printk("%s\n", out_str);
 
 		/* lsm6dsl gyro */
-		sprintf(out_str, "gyro (%f %f %f) dps", out_ev(&gyro_x_out),
-							out_ev(&gyro_y_out),
-							out_ev(&gyro_z_out));
+		sprintf(out_str, "gyro x:%f dps y:%f dps z:%f dps",
+							   out_ev(&gyro_x_out),
+							   out_ev(&gyro_y_out),
+							   out_ev(&gyro_z_out));
 		printk("%s\n", out_str);
 
 #if defined(CONFIG_LSM6DSL_EXT0_LIS2MDL)
 		/* lsm6dsl external magn */
-		sprintf(out_str, "magn (%f %f %f) gauss", out_ev(&magn_x_out),
-							 out_ev(&magn_y_out),
-							 out_ev(&magn_z_out));
+		sprintf(out_str, "magn x:%f gauss y:%f gauss z:%f gauss",
+							   out_ev(&magn_x_out),
+							   out_ev(&magn_y_out),
+							   out_ev(&magn_z_out));
 		printk("%s\n", out_str);
 #endif
 
 #if defined(CONFIG_LSM6DSL_EXT0_LPS22HB)
 		/* lsm6dsl external press/temp */
-		sprintf(out_str, "press (%f) kPa - temp (%f) deg",
+		sprintf(out_str, "press: %f kPa - temp: %f deg",
 			out_ev(&press_out), out_ev(&temp_out));
 		printk("%s\n", out_str);
 #endif
 
-		printk("- (%d) (trig_cnt: %d)\n\n", ++cnt, lsm6dsl_trig_cnt);
+		printk("loop:%d trig_cnt:%d\n\n", ++cnt, lsm6dsl_trig_cnt);
+
 		print_samples = 1;
 		k_sleep(K_MSEC(2000));
 	}


### PR DESCRIPTION
In order to enable sample to be run and evaluated in sanitycheck,
add a harness_config to validate sample output.
Tested on disco_l475_iot1

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>