### PR TITLE
Bluetooth: Mesh: Restructure doc

### DIFF
--- a/doc/reference/bluetooth/mesh.rst
+++ b/doc/reference/bluetooth/mesh.rst
@@ -1,59 +1,21 @@
 .. _bluetooth_mesh:
 
-
-
 Bluetooth Mesh Profile
 ######################
 
+The Bluetooth Mesh Profile adds secure wireless multi-hop communication for
+Bluetooth Low Energy. This module implements the
+`Bluetooth Mesh Profile Specification v1.0.1 <https://www.bluetooth.com/specifications/mesh-specifications/>`_.
 
+Read more about Bluetooth Mesh on the
+`Bluetooth SIG Website <https://www.bluetooth.com/bluetooth-resources/?tags=mesh>`_.
 
-API Reference
-**************
+.. toctree::
+   :maxdepth: 1
 
-Mesh Profile
-============
+   mesh/core.rst
+   mesh/access.rst
+   mesh/models.rst
+   mesh/provisioning.rst
+   mesh/proxy.rst
 
-.. doxygengroup:: bt_mesh
-   :project: Zephyr
-
-Bluetooth Mesh Access Layer
-===========================
-
-.. doxygengroup:: bt_mesh_access
-   :project: Zephyr
-
-Bluetooth Mesh Configuration Client Model
-=========================================
-
-.. doxygengroup:: bt_mesh_cfg_cli
-   :project: Zephyr
-
-Bluetooth Mesh Configuration Server Model
-=========================================
-
-.. doxygengroup:: bt_mesh_cfg_srv
-   :project: Zephyr
-
-Bluetooth Mesh Health Client Model
-==================================
-
-.. doxygengroup:: bt_mesh_health_cli
-   :project: Zephyr
-
-Bluetooth Mesh Health Server Model
-==================================
-
-.. doxygengroup:: bt_mesh_health_srv
-   :project: Zephyr
-
-Bluetooth Mesh Provisioning
-===========================
-
-.. doxygengroup:: bt_mesh_prov
-   :project: Zephyr
-
-Bluetooth Mesh Proxy
-====================
-
-.. doxygengroup:: bt_mesh_proxy
-   :project: Zephyr

--- a/doc/reference/bluetooth/mesh/access.rst
+++ b/doc/reference/bluetooth/mesh/access.rst
@@ -1,0 +1,147 @@
+.. _bluetooth_mesh_access:
+
+Access
+######
+
+The Bluetooth Mesh access layer is the application's interface to the mesh
+network. The access layer provides mechanisms for compartmentalizing the node
+behavior into elements and models, which are implemented by the application.
+
+Mesh models
+***********
+
+The functionality of a mesh node is represented by models. A model implements
+a single behavior the node supports, like being a light, a sensor or a
+thermostat. The mesh models are grouped into *elements*. Each element is
+assigned its own unicast address, and may only contain one of each type of
+model. Conventionally, each element represents a single aspect of the mesh
+node behavior. For instance, a node that contains a sensor, two lights and a
+power outlet would spread this functionality across four elements, with each
+element instantiating all the models required for a single aspect of the
+supported behavior.
+
+The node's element and model structure is specified in the node composition
+data, which is passed to :cpp:func:`bt_mesh_init()` during initialization. The
+Bluetooth SIG have defined a set of foundation models (see
+:ref:`bluetooth_mesh_models`) and a set of models for implementing common
+behavior in the `Bluetooth Mesh Model Specification
+<https://www.bluetooth.com/specifications/mesh-specifications/>`_. All models
+not specified by the Bluetooth SIG are vendor models, and must be tied to a
+Company ID.
+
+Mesh Models have several parameters that can be configured either through
+initialization of the mesh stack or with the
+:ref:`bluetooth_mesh_models_cfg_srv`:
+
+Opcode list
+===========
+
+The opcode list contains all message opcodes the model can receive, as well as
+the minimum acceptable payload length and the callback to pass them to. Models
+can support any number of opcodes, but each opcode can only be listed by one
+model in each element.
+
+The full opcode list must be passed to the model structure in the composition
+data, and cannot be changed at runtime. The end of the opcode list is
+determined by the special :c:macro:`BT_MESH_MODEL_OP_END` entry. This entry
+must always be present in the opcode list, unless the list is empty. In that
+case, :c:macro:`BT_MESH_MODEL_NO_OPS` should be used in place of a proper
+opcode list definition.
+
+AppKey list
+===========
+
+The AppKey list contains all the application keys the model can receive
+messages on. Only messages encrypted with application keys in the AppKey list
+will be passed to the model.
+
+The maximum number of supported application keys each model can hold is
+configured with the :option:`CONFIG_BT_MESH_MODEL_KEY_COUNT` configuration
+option. The contents of the AppKey list is managed by the
+:ref:`bluetooth_mesh_models_cfg_srv`.
+
+Subscription list
+=================
+
+A model will process all messages addressed to the unicast address of their
+element (given that the utilized application key is present in the AppKey
+list). Additionally, the model will process packets addressed to any group or
+virtual address in its subscription list. This allows nodes to address
+multiple nodes throughout the mesh network with a single message.
+
+The maximum number of supported addresses in the Subscription list each model
+can hold is configured with the :option:`CONFIG_BT_MESH_MODEL_GROUP_COUNT`
+configuration option. The contents of the subscription list is managed by the
+:ref:`bluetooth_mesh_models_cfg_srv`.
+
+Model publication
+=================
+
+The models may send messages in two ways:
+
+* By specifying a set of message parameters in a :cpp:type:`bt_mesh_msg_ctx`,
+  and calling :cpp:func:`bt_mesh_model_send()`.
+* By setting up a :cpp:type:`bt_mesh_model_pub` structure and calling
+  :cpp:func:`bt_mesh_model_publish()`.
+
+When publishing messages with :cpp:func:`bt_mesh_model_publish()`, the model
+will use the publication parameters configured by the
+:ref:`bluetooth_mesh_models_cfg_srv`. This is the recommended way to send
+unprompted model messages, as it passes the responsibility of selecting
+message parameters to the network administrator, which likely knows more about
+the mesh network than the individual nodes will.
+
+To support publishing with the publication parameters, the model must allocate
+a packet buffer for publishing, and pass it to
+:cpp:var:`bt_mesh_model_pub::msg`. The Config Server may also set up period
+publication for the publication message. To support this, the model must
+populate the :cpp:var:`bt_mesh_model_pub::update` callback. The
+:cpp:var:`bt_mesh_model_pub::update` callback will be called right before the
+message is published, allowing the model to change the payload to reflect its
+current state.
+
+Extended models
+===============
+
+The Bluetooth Mesh specification allows the Mesh models to extend each other.
+When a model extends another, it inherits that model's functionality, and
+extension can be used to construct complex models out of simple ones,
+leveraging the existing model functionality to avoid defining new opcodes.
+Models may extend any number of models, from any element. When one model
+extends another in the same element, the two models will share subscription
+lists. The mesh stack implements this by merging the subscription lists of the
+two models into one, combining the number of subscriptions the models can have
+in total. Models may extend models that extend others, creating an "extension
+tree". All models in an extension tree share a single subscription list per
+element it spans.
+
+Model extensions are done by calling :cpp:func:`bt_mesh_model_extend()` during
+initialization. A model can only be extended by one other model, and
+extensions cannot be circular. Note that binding of node states and other
+relationships between the models must be defined by the model implementations.
+
+The model extension concept adds some overhead in the access layer packet
+processing, and must be explicitly enabled with
+:option:`CONFIG_BT_MESH_MODEL_EXTENSIONS` to have any effect.
+
+Model data storage
+==================
+
+Mesh models may have data associated with each model instance that needs to be
+stored persistently. The access API provides a mechanism for storing this
+data, leveraging the internal model instance encoding scheme. Models can store
+one user defined data entry per instance by calling
+:cpp:func:`bt_mesh_model_data_store()`. To be able to read out the data the
+next time the device reboots, the model's
+:cpp:var:`bt_mesh_model_cb::settings_set()` callback must be populated. This
+callback gets called when model specific data is found in the persistent
+storage. The model can retrieve the data by calling the ``read_cb`` passed as
+a parameter to the callback. See the :ref:`settings` module documentation for
+details.
+
+API reference
+*************
+
+.. doxygengroup:: bt_mesh_access
+   :project: Zephyr
+   :members:

--- a/doc/reference/bluetooth/mesh/cfg_cli.rst
+++ b/doc/reference/bluetooth/mesh/cfg_cli.rst
@@ -1,0 +1,28 @@
+.. _bluetooth_mesh_models_cfg_cli:
+
+Configuration Client
+####################
+
+Configuration Client model is a foundation model defined by the Bluetooth Mesh
+specification. It provides functionality for configuring most parameters of a
+mesh node, including encryption keys, model configuration and feature
+enabling.
+
+The Configuration Client model communicates with a
+:ref:`bluetooth_mesh_models_cfg_srv` model using the device key of the target
+node. The Configuration Client model may communicate with servers on other
+nodes or self-configure through the local Configuration Server model.
+
+All configuration functions in the Configuration Client API have ``net_idx``
+and ``addr`` as their first parameters. These should be set to the network
+index and primary unicast address that the target node was provisioned with.
+
+The Configuration Client model is optional, but should be instantiated on the
+first element if it is present in the composition data.
+
+API reference
+*************
+
+.. doxygengroup:: bt_mesh_cfg_cli
+   :project: Zephyr
+   :members:

--- a/doc/reference/bluetooth/mesh/cfg_srv.rst
+++ b/doc/reference/bluetooth/mesh/cfg_srv.rst
@@ -1,0 +1,25 @@
+.. _bluetooth_mesh_models_cfg_srv:
+
+Configuration Server
+####################
+
+Configuration Server model is a foundation model defined by the Bluetooth Mesh
+specification. The Configuration Server model controls most parameters of the
+mesh node. It does not have an API of its own, but relies on a
+:ref:`bluetooth_mesh_models_cfg_cli` to control it.
+
+The application can configure the initial parameters of the Configuration
+Server model through the :cpp:type:`bt_mesh_cfg_srv` instance passed to
+:c:macro:`BT_MESH_MODEL_CFG_SRV`. Note that if the mesh node stored changes to
+this configuration in the settings subsystem, the initial values may be
+overwritten upon loading.
+
+The Configuration Server model is mandatory on all Bluetooth Mesh nodes, and
+should be instantiated in the first element.
+
+API reference
+*************
+
+.. doxygengroup:: bt_mesh_cfg_srv
+   :project: Zephyr
+   :members:

--- a/doc/reference/bluetooth/mesh/core.rst
+++ b/doc/reference/bluetooth/mesh/core.rst
@@ -1,0 +1,29 @@
+.. _bluetooth_mesh_core:
+
+Core API
+########
+
+The Bluetooth Mesh Core API provides functionality for managing the general
+Bluetooth Mesh state.
+
+Low Power Node
+**************
+
+The Low Power Node (LPN) role allows battery powered devices to participate in
+a mesh network as a leaf node. An LPN interacts with the mesh network through
+a Friend node, which is responsible for relaying any messages directed to the
+LPN. The LPN saves power by keeping its radio turned off, and only wakes up to
+either send messages or poll the Friend node for any incoming messages.
+
+The radio control and polling is managed automatically by the mesh stack, but
+the LPN API allows the application to trigger the polling at any time through
+:cpp:func:`bt_mesh_lpn_poll()`. The LPN operation parameters, including poll
+interval, poll event timing and Friend requirements is controlled through the
+:option:`CONFIG_BT_MESH_LOW_POWER` option and related configuration options.
+
+API reference
+**************
+
+.. doxygengroup:: bt_mesh
+   :project: Zephyr
+   :members:

--- a/doc/reference/bluetooth/mesh/health_cli.rst
+++ b/doc/reference/bluetooth/mesh/health_cli.rst
@@ -1,0 +1,25 @@
+.. _bluetooth_mesh_models_health_cli:
+
+Health Client
+#############
+
+The Health Client model interacts with a Health Server model to read out
+diagnostics and control the node's attention state.
+
+All message passing functions in the Health Client API have ``net_idx`` and
+``addr`` as their first parameters. These should be set to the network index
+and primary unicast address that the target node was provisioned with.
+
+The Health Client model is optional, and may be instantiated in any element.
+However, if a Health Client model is instantiated in an element other than the
+first, an instance must also be present in the first element.
+
+See :ref:`bluetooth_mesh_health_faults` for a list of specification defined
+fault values.
+
+API reference
+*************
+
+.. doxygengroup:: bt_mesh_health_cli
+   :project: Zephyr
+   :members:

--- a/doc/reference/bluetooth/mesh/health_srv.rst
+++ b/doc/reference/bluetooth/mesh/health_srv.rst
@@ -1,0 +1,65 @@
+.. _bluetooth_mesh_models_health_srv:
+
+Health Server
+#############
+
+The Health Server model provides attention callbacks and node diagnostics for
+:ref:`bluetooth_mesh_models_health_cli` models. It is primarily used to report
+faults in the mesh node and map the mesh nodes to their physical location.
+
+Faults
+******
+
+The Health Server model may report a list of faults that have occurred in the
+device's lifetime. Typically, the faults are events or conditions that may
+alter the behavior of the node, like power outages or faulty peripherals.
+Faults are split into warnings and errors. Warnings indicate conditions that
+are close to the limits of what the node is designed to withstand, but not
+necessarily damaging to the device. Errors indicate conditions that are
+outside of the node's design limits, and may have caused invalid behavior or
+permanent damage to the device.
+
+Fault values ``0x01`` to ``0x7f`` are reserved for the Bluetooth Mesh
+specification, and the full list of specification defined faults are available
+in :ref:`bluetooth_mesh_health_faults`. Fault values ``0x80`` to ``0xff`` are
+vendor specific. The list of faults are always reported with a company ID to
+help interpreting the vendor specific faults.
+
+.. _bluetooth_mesh_models_health_srv_attention:
+
+Attention state
+***************
+
+The attention state is used to make the device call attention to itself
+through some physical behavior like blinking, playing a sound or vibrating.
+The attention state may be used during provisioning to let the user know which
+device they're provisioning, as well as through the Health models at runtime.
+
+The attention state is always assigned a timeout in the range of one to 255
+seconds when enabled. The Health Server API provides two callbacks for the
+application to run their attention calling behavior:
+:cpp:var:`bt_mesh_health_srv_cb::attn_on` is called at the beginning of the
+attention period, :cpp:var:`bt_mesh_health_srv_cb::attn_off` is called at
+the end.
+
+The remaining time for the attention period may be queried through
+:cpp:var:`bt_mesh_health_srv::attn_timer`.
+
+API reference
+*************
+
+.. doxygengroup:: bt_mesh_health_srv
+   :project: Zephyr
+   :members:
+
+
+.. _bluetooth_mesh_health_faults:
+
+Bluetooth Mesh Health Faults
+============================
+
+Fault values defined by the Bluetooth Mesh specification.
+
+.. doxygengroup:: bt_mesh_health_faults
+   :project: Zephyr
+

--- a/doc/reference/bluetooth/mesh/models.rst
+++ b/doc/reference/bluetooth/mesh/models.rst
@@ -1,0 +1,15 @@
+.. _bluetooth_mesh_models:
+
+Foundation models
+#################
+
+The Bluetooth Mesh specification defines four foundation models that can be
+used by network administrators to configure and diagnose mesh nodes.
+
+.. toctree::
+   :maxdepth: 1
+
+   cfg_srv
+   cfg_cli
+   health_srv
+   health_cli

--- a/doc/reference/bluetooth/mesh/provisioning.rst
+++ b/doc/reference/bluetooth/mesh/provisioning.rst
@@ -1,0 +1,136 @@
+.. _bluetooth_mesh_provisioning:
+
+Provisioning
+############
+
+Provisioning is the process of adding devices to a mesh network. It requires
+two devices operating in the following roles:
+
+* The *provisioner* represents the network owner, and is responsible for
+  adding new nodes to the mesh network.
+* The *provisionee* is the device that gets added to the network through the
+  Provisioning process. Before the provisioning process starts, the
+  provisionee is an *unprovisioned device*.
+
+The Provisioning module in the Zephyr Bluetooth Mesh stack supports both the
+Advertising and GATT Provisioning bearers for the provisionee role, as well as
+the Advertising Provisioning bearer for the provisioner role.
+
+The Provisioning process
+************************
+
+All Bluetooth Mesh nodes must be provisioned before they can participate in a
+Bluetooth Mesh network. The Provisioning API provides all the functionality
+necessary for a device to become a provisioned mesh node.
+
+Beaconing
+=========
+
+To start the provisioning process, the unprovisioned device must first start
+broadcasting the Unprovisioned Beacon. This makes it visible to nearby
+provisioners, which can initiate the provisioning. To indicate that the device
+needs to be provisioned, call :cpp:func:`bt_mesh_prov_enable()`. The device
+starts broadcasting the Unprovisioned Beacon with the device UUID and the
+``OOB information`` field, as specified in the ``prov`` parameter passed to
+:cpp:func:`bt_mesh_init`. Additionally, a Uniform Resource Identifier (URI)
+may be specified, which can point the provisioner to the location of some Out
+Of Band information, such as the device's public key or an authentication
+value database. The URI is advertised in a separate beacon, with a URI hash
+included in the unprovisioned beacon, to tie the two together.
+
+
+Uniform Resource Identifier
+---------------------------
+
+The Uniform Resource Identifier shall follow the format specified in the
+Bluetooth Core Specification Supplement. The URI must start with a URI scheme,
+encoded as a single utf-8 data point, or the special ``none`` scheme, encoded
+as ``0x01``. The available schemes are listed on the `Bluetooth website
+<https://www.bluetooth.com/specifications/assigned-numbers/uri-scheme-name-string-mapping/>`_.
+
+Examples of encoded URIs:
+
+.. list-table:: URI encoding examples
+
+  * - URI
+    - Encoded
+  * - ``http://example.com``
+    - ``\x16//example.com``
+  * - ``https://www.zephyrproject.org/``
+    - ``\x17//www.zephyrproject.org/``
+  * - ``just a string``
+    - ``\x01just a string``
+
+Provisioning invitation
+=======================
+
+The provisioner initiates the Provisioning process by sending a Provisioning
+invitation. The invitations prompts the provisionee to call attention to
+itself using the Health Server
+:ref:`bluetooth_mesh_models_health_srv_attention`, if available.
+
+The Unprovisioned device automatically responds to the invite by presenting a
+list of its capabilities, including the supported Out of Band Authentication
+methods.
+
+Authentication
+==============
+
+After the initial exchange, the provisioner selects an Out of Band (OOB)
+Authentication method. This allows the user to confirm that the device the
+provisioner connected to is actually the device they intended, and not a
+malicious third party.
+
+The Provisioning API supports the following authentication methods for the
+provisionee:
+
+* **Static OOB:** An authentication value is assigned to the device in
+  production, which the provisioner can query in some application specific
+  way.
+* **Input OOB:** The user inputs the authentication value. The available input
+  actions are listed in :cpp:enum:`bt_mesh_input_action_t`.
+* **Output OOB:** Show the user the authentication value. The available output
+  actions are listed in :cpp:enum:`bt_mesh_output_action_t`.
+
+The application must provide callbacks for the supported authentication
+methods in :cpp:type:`bt_mesh_prov`, as well as enabling the supported actions
+in :cpp:var:`bt_mesh_prov::output_actions` and
+:cpp:var:`bt_mesh_prov::input_actions`.
+
+When an Output OOB action is selected, the authentication value should be
+presented to the user when the output callback is called, and remain until the
+:cpp:var:`bt_mesh_prov::input_complete` or :cpp:var:`bt_mesh_prov::complete`
+callback is called. If the action is ``blink``, ``beep`` or ``vibrate``, the
+sequence should be repeated after a delay of three seconds or more.
+
+When an Input OOB action is selected, the user should be prompted when the
+application receives the :cpp:var:`bt_mesh_prov::input` callback. The user
+response should be fed back to the Provisioning API through
+:cpp:func:`bt_mesh_input_string()` or :cpp:func:`bt_mesh_input_number()`. If
+no user response is recorded within 60 seconds, the Provisioning process is
+aborted.
+
+Data transfer
+=============
+
+After the device has been successfully authenticated, the provisioner
+transfers the Provisioning data:
+
+* Unicast address
+* A network key
+* IV index
+* Network flags
+
+  * Key refresh
+  * IV update
+
+Additionally, a device key is generated for the node. All this data is stored
+by the mesh stack, and the provisioning :cpp:var:`bt_mesh_prov::complete`
+callback gets called.
+
+API reference
+*************
+
+.. doxygengroup:: bt_mesh_prov
+   :project: Zephyr
+   :members:

--- a/doc/reference/bluetooth/mesh/proxy.rst
+++ b/doc/reference/bluetooth/mesh/proxy.rst
@@ -1,0 +1,16 @@
+.. _bt_mesh_proxy:
+
+Proxy
+#####
+
+The Bluetooth Mesh Proxy feature allows legacy devices like phones to access
+the Mesh network through GATT. The Proxy feature is only compiled in if the
+:option:`CONFIG_BT_MESH_GATT_PROXY` option is set. The Proxy feature state is
+controlled by the :ref:`bluetooth_mesh_models_cfg_srv`, and the initial value
+can be set with :cpp:var:`bt_mesh_cfg_srv::gatt_proxy`.
+
+API reference
+*************
+
+.. doxygengroup:: bt_mesh_proxy
+   :project: Zephyr

--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -158,6 +158,7 @@ struct bt_mesh_msg_ctx {
 	u8_t  send_ttl;
 };
 
+/** Model opcode handler. */
 struct bt_mesh_model_op {
 	/* OpCode encoded using the BT_MESH_MODEL_OP_* macros */
 	const u32_t  opcode;

--- a/include/bluetooth/mesh/health_faults.h
+++ b/include/bluetooth/mesh/health_faults.h
@@ -1,0 +1,85 @@
+/** @file
+ * @brief Bluetooth Mesh Health faults
+ */
+
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_HEALTH_FAULTS_H__
+#define ZEPHYR_INCLUDE_BLUETOOTH_MESH_HEALTH_FAULTS_H__
+
+/**
+ * @brief List of specification defined Health Fault values.
+ * @defgroup bt_mesh_health_faults Bluetooth Mesh Health Faults
+ * @ingroup bt_mesh
+ * @{
+ */
+
+/** No fault has occurred. */
+#define BT_MESH_HEALTH_FAULT_NO_FAULT                           0x00
+
+#define BT_MESH_HEALTH_FAULT_BATTERY_LOW_WARNING                0x01
+#define BT_MESH_HEALTH_FAULT_BATTERY_LOW_ERROR                  0x02
+#define BT_MESH_HEALTH_FAULT_SUPPLY_VOLTAGE_TOO_LOW_WARNING     0x03
+#define BT_MESH_HEALTH_FAULT_SUPPLY_VOLTAGE_TOO_LOW_ERROR       0x04
+#define BT_MESH_HEALTH_FAULT_SUPPLY_VOLTAGE_TOO_HIGH_WARNING    0x05
+#define BT_MESH_HEALTH_FAULT_SUPPLY_VOLTAGE_TOO_HIGH_ERROR      0x06
+#define BT_MESH_HEALTH_FAULT_POWER_SUPPLY_INTERRUPTED_WARNING   0x07
+#define BT_MESH_HEALTH_FAULT_POWER_SUPPLY_INTERRUPTED_ERROR     0x08
+#define BT_MESH_HEALTH_FAULT_NO_LOAD_WARNING                    0x09
+#define BT_MESH_HEALTH_FAULT_NO_LOAD_ERROR                      0x0A
+#define BT_MESH_HEALTH_FAULT_OVERLOAD_WARNING                   0x0B
+#define BT_MESH_HEALTH_FAULT_OVERLOAD_ERROR                     0x0C
+#define BT_MESH_HEALTH_FAULT_OVERHEAT_WARNING                   0x0D
+#define BT_MESH_HEALTH_FAULT_OVERHEAT_ERROR                     0x0E
+#define BT_MESH_HEALTH_FAULT_CONDENSATION_WARNING               0x0F
+#define BT_MESH_HEALTH_FAULT_CONDENSATION_ERROR                 0x10
+#define BT_MESH_HEALTH_FAULT_VIBRATION_WARNING                  0x11
+#define BT_MESH_HEALTH_FAULT_VIBRATION_ERROR                    0x12
+#define BT_MESH_HEALTH_FAULT_CONFIGURATION_WARNING              0x13
+#define BT_MESH_HEALTH_FAULT_CONFIGURATION_ERROR                0x14
+#define BT_MESH_HEALTH_FAULT_ELEMENT_NOT_CALIBRATED_WARNING     0x15
+#define BT_MESH_HEALTH_FAULT_ELEMENT_NOT_CALIBRATED_ERROR       0x16
+#define BT_MESH_HEALTH_FAULT_MEMORY_WARNING                     0x17
+#define BT_MESH_HEALTH_FAULT_MEMORY_ERROR                       0x18
+#define BT_MESH_HEALTH_FAULT_SELF_TEST_WARNING                  0x19
+#define BT_MESH_HEALTH_FAULT_SELF_TEST_ERROR                    0x1A
+#define BT_MESH_HEALTH_FAULT_INPUT_TOO_LOW_WARNING              0x1B
+#define BT_MESH_HEALTH_FAULT_INPUT_TOO_LOW_ERROR                0x1C
+#define BT_MESH_HEALTH_FAULT_INPUT_TOO_HIGH_WARNING             0x1D
+#define BT_MESH_HEALTH_FAULT_INPUT_TOO_HIGH_ERROR               0x1E
+#define BT_MESH_HEALTH_FAULT_INPUT_NO_CHANGE_WARNING            0x1F
+#define BT_MESH_HEALTH_FAULT_INPUT_NO_CHANGE_ERROR              0x20
+#define BT_MESH_HEALTH_FAULT_ACTUATOR_BLOCKED_WARNING           0x21
+#define BT_MESH_HEALTH_FAULT_ACTUATOR_BLOCKED_ERROR             0x22
+#define BT_MESH_HEALTH_FAULT_HOUSING_OPENED_WARNING             0x23
+#define BT_MESH_HEALTH_FAULT_HOUSING_OPENED_ERROR               0x24
+#define BT_MESH_HEALTH_FAULT_TAMPER_WARNING                     0x25
+#define BT_MESH_HEALTH_FAULT_TAMPER_ERROR                       0x26
+#define BT_MESH_HEALTH_FAULT_DEVICE_MOVED_WARNING               0x27
+#define BT_MESH_HEALTH_FAULT_DEVICE_MOVED_ERROR                 0x28
+#define BT_MESH_HEALTH_FAULT_DEVICE_DROPPED_WARNING             0x29
+#define BT_MESH_HEALTH_FAULT_DEVICE_DROPPED_ERROR               0x2A
+#define BT_MESH_HEALTH_FAULT_OVERFLOW_WARNING                   0x2B
+#define BT_MESH_HEALTH_FAULT_OVERFLOW_ERROR                     0x2C
+#define BT_MESH_HEALTH_FAULT_EMPTY_WARNING                      0x2D
+#define BT_MESH_HEALTH_FAULT_EMPTY_ERROR                        0x2E
+#define BT_MESH_HEALTH_FAULT_INTERNAL_BUS_WARNING               0x2F
+#define BT_MESH_HEALTH_FAULT_INTERNAL_BUS_ERROR                 0x30
+#define BT_MESH_HEALTH_FAULT_MECHANISM_JAMMED_WARNING           0x31
+#define BT_MESH_HEALTH_FAULT_MECHANISM_JAMMED_ERROR             0x32
+
+/**
+ * Start of the vendor specific fault values.
+ *
+ * All values below this are reserved for the Bluetooth Specification.
+ */
+#define BT_MESH_HEALTH_FAULT_VENDOR_SPECIFIC_START              0x80
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_MESH_HEALTH_FAULTS_H__ */

--- a/include/bluetooth/mesh/health_srv.h
+++ b/include/bluetooth/mesh/health_srv.h
@@ -21,6 +21,7 @@
 extern "C" {
 #endif
 
+/** Callback function for the Health Server model */
 struct bt_mesh_health_srv_cb {
 	/* Fetch current faults */
 	int (*fault_get_cur)(struct bt_mesh_model *model, u8_t *test_id,
@@ -69,8 +70,10 @@ struct bt_mesh_health_srv {
 
 int bt_mesh_fault_update(struct bt_mesh_elem *elem);
 
+/** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op bt_mesh_health_srv_op[];
 extern const struct bt_mesh_model_cb bt_mesh_health_srv_cb;
+/** @endcond */
 
 /** @def BT_MESH_MODEL_HEALTH_SRV
  *

--- a/include/bluetooth/mesh/main.h
+++ b/include/bluetooth/mesh/main.h
@@ -244,6 +244,49 @@ int bt_mesh_prov_enable(bt_mesh_prov_bearer_t bearers);
  */
 int bt_mesh_prov_disable(bt_mesh_prov_bearer_t bearers);
 
+/** @brief Provision the local Mesh Node.
+ *
+ *  This API should normally not be used directly by the application. The
+ *  only exception is for testing purposes where manual provisioning is
+ *  desired without an actual external provisioner.
+ *
+ *  @param net_key  Network Key
+ *  @param net_idx  Network Key Index
+ *  @param flags    Provisioning Flags
+ *  @param iv_index IV Index
+ *  @param addr     Primary element address
+ *  @param dev_key  Device Key
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int bt_mesh_provision(const u8_t net_key[16], u16_t net_idx,
+		      u8_t flags, u32_t iv_index, u16_t addr,
+		      const u8_t dev_key[16]);
+
+/** @brief Provision a Mesh Node using PB-ADV
+ *
+ * @param uuid    UUID
+ * @param net_idx Network Key Index
+ * @param addr    Address to assign to remote device. If addr is 0, the lowest
+ *                available address will be chosen.
+ * @param attention_duration The attention duration to be send to remote device
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int bt_mesh_provision_adv(const u8_t uuid[16], u16_t net_idx, u16_t addr,
+			  u8_t attention_duration);
+
+/** @brief Check if the local node has been provisioned.
+ *
+ *  This API can be used to check if the local node has been provisioned
+ *  or not. It can e.g. be helpful to determine if there was a stored
+ *  network in flash, i.e. if the network was restored after calling
+ *  settings_load().
+ *
+ *  @return True if the node is provisioned. False otherwise.
+ */
+bool bt_mesh_is_provisioned(void);
+
 /**
  * @}
  */
@@ -333,49 +376,6 @@ int bt_mesh_suspend(void);
  *  @return 0 on success, or (negative) error code on failure.
  */
 int bt_mesh_resume(void);
-
-/** @brief Provision the local Mesh Node.
- *
- *  This API should normally not be used directly by the application. The
- *  only exception is for testing purposes where manual provisioning is
- *  desired without an actual external provisioner.
- *
- *  @param net_key  Network Key
- *  @param net_idx  Network Key Index
- *  @param flags    Provisioning Flags
- *  @param iv_index IV Index
- *  @param addr     Primary element address
- *  @param dev_key  Device Key
- *
- *  @return Zero on success or (negative) error code otherwise.
- */
-int bt_mesh_provision(const u8_t net_key[16], u16_t net_idx,
-		      u8_t flags, u32_t iv_index, u16_t addr,
-		      const u8_t dev_key[16]);
-
-/** @brief Provision a Mesh Node using PB-ADV
- *
- * @param uuid    UUID
- * @param net_idx Network Key Index
- * @param addr    Address to assign to remote device. If addr is 0, the lowest
- *                available address will be chosen.
- * @param attention_duration The attention duration to be send to remote device
- *
- * @return Zero on success or (negative) error code otherwise.
- */
-int bt_mesh_provision_adv(const u8_t uuid[16], u16_t net_idx, u16_t addr,
-			  u8_t attention_duration);
-
-/** @brief Check if the local node has been provisioned.
- *
- *  This API can be used to check if the local node has been provisioned
- *  or not. It can e.g. be helpful to determine if there was a stored
- *  network in flash, i.e. if the network was restored after calling
- *  settings_load().
- *
- *  @return True if the node is provisioned. False otherwise.
- */
-bool bt_mesh_is_provisioned(void);
 
 /** @brief Toggle the IV Update test mode
  *


### PR DESCRIPTION
Adds a deeper hierarchy to the Bluetooth Mesh documentation by moving
the modules in separate pages with a brief description of the concepts
in each module.

Adds the full list of specification defined Health model faults.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>