### PR TITLE
boards: hifive1*: fix ticks per second

### DIFF
--- a/boards/riscv/hifive1/Kconfig.defconfig
+++ b/boards/riscv/hifive1/Kconfig.defconfig
@@ -5,6 +5,9 @@ if BOARD_HIFIVE1
 config BOARD
 	default "hifive1"
 
+config SYS_CLOCK_TICKS_PER_SEC
+	default 128
+
 if PWM
 
 config PWM_SIFIVE

--- a/boards/riscv/hifive1_revb/Kconfig.defconfig
+++ b/boards/riscv/hifive1_revb/Kconfig.defconfig
@@ -15,6 +15,9 @@ config FLASH_BASE_ADDRESS
 config FLASH_LOAD_OFFSET
 	default 0x0
 
+config SYS_CLOCK_TICKS_PER_SEC
+	default 128
+
 if PWM
 config PWM_SIFIVE
 	default y


### PR DESCRIPTION
The HiFive1 boards power up using a 32 KiHz low frequency kernel, so
have a cycle rate of 32768 Hz.  The board definitions have not been
revisited since the Zephyr default for ticks-per-second increased from
100 to 10000.  The timer system on the board does not operate
correctly at 4 cycles per tick, but does at 328 cycles per tick.

To support functional timers while keeping system milliseconds in sync
with clock time set ticks-per-second to 128.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>