### PR TITLE
crypto: Add support for non-IV-prefixed CBC ciphers in mbedTLS shim

### DIFF
--- a/include/crypto/cipher_structs.h
+++ b/include/crypto/cipher_structs.h
@@ -172,6 +172,9 @@ struct cipher_ctx {
 /* Whether the hardware/driver supports autononce feature */
 #define CAP_AUTONONCE			BIT(7)
 
+/* Don't prefix IV to cipher blocks */
+#define CAP_NO_IV_PREFIX		BIT(8)
+
 /* More flags to be added as necessary */
 
 


### PR DESCRIPTION
This patch adds a new capability flag `CAP_NO_IV_PREFIX` that allows CBC operation without prefixing the IV to the output ciphertext.

When `CAP_NO_IV_PREFIX` is active, the IV passed to cipher_cbc_op() is not modified. So the length of the ciphertext block is equal to the plaintext block, allowing in-place encryption/decryption.

This flag is useful when the IV is derived from other sources (for instance a chained MAC serving as IV) and not directly transmitted to the other end.

**Notes:**
* Fixes: #20561
* Required for: #19483