### PR TITLE
counter: mchp_xec: fix logical/bit-wise AND

### DIFF
--- a/drivers/counter/counter_mchp_xec.c
+++ b/drivers/counter/counter_mchp_xec.c
@@ -192,7 +192,7 @@ static int counter_xec_set_top_value(struct device *dev,
 		return -EINVAL;
 	}
 
-	restart = (counter->CTRL && MCHP_BTMR_CTRL_START);
+	restart = ((counter->CTRL & MCHP_BTMR_CTRL_START) != 0U);
 
 	counter->CTRL &= ~MCHP_BTMR_CTRL_START;
 


### PR DESCRIPTION
Coverity discovered that a logical AND was used in place of
a bit-wise AND. So fix it.

Fixes #20489

Signed-off-by: Daniel Leung <daniel.leung@intel.com>