### PR TITLE
boards: reel_board: add all LEDs to device tree

### DIFF
--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -24,8 +24,14 @@
 
 	pwmleds {
 		compatible = "pwm-leds";
-		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 13>;
+		red_pwm_led: pwm_led_0 {
+			pwms = <&pwm0 11>;
+		};
+		green_pwm_led: pwm_led_1 {
+			pwms = <&pwm0 12>;
+		};
+		blue_pwm_led: pwm_led_2 {
+			pwms = <&pwm0 41>;
 		};
 	};
 
@@ -70,7 +76,12 @@
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
-		pwm-led0 = &pwm_led0;
+		pwm-led0 = &red_pwm_led;
+		pwm-led1 = &green_pwm_led;
+		pwm-led2 = &blue_pwm_led;
+		red-pwm-led = &red_pwm_led;
+		green-pwm-led = &green_pwm_led;
+		blue-pwm-led = &blue_pwm_led;
 		sw0 = &user_button;
 	};
 };
@@ -135,7 +146,12 @@ arduino_i2c: &i2c0 {
 &pwm0 {
 	status = "okay";
 	ch0-pin = <13>;
-	ch0-inverted;
+	ch1-pin = <11>;
+	ch1-inverted;
+	ch2-pin = <12>;
+	ch2-inverted;
+	ch3-pin = <41>;
+	ch3-inverted;
 };
 
 arduino_spi: &spi3 {

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -24,6 +24,30 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 	};
+
+	leds {
+		compatible = "gpio-leds";
+		back_led: led_3 {
+			gpios = <&gpio0 13 0>;
+			label = "User D13 green";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		back_pwm_led: pwm_led_3 {
+			pwms = <&pwm0 13>;
+		};
+	};
+
+	aliases {
+		led3 = &back_led;
+		pwm-led3 = &back_pwm_led;
+	};
+};
+
+&pwm0 {
+	ch0-inverted;
 };
 
 &spi1 {


### PR DESCRIPTION
Add the green LED on the back of the reel_board to the device tree and
add PWM support for the front RGB LED.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>