### PR TITLE
boards: actinius_icarus: add RGB LED to dts

### DIFF
--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -34,6 +34,25 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+
+		red_pwm_led: led_pwm_0 {
+			pwms = <&pwm0 10>;
+			label = "Red PWM LED";
+		};
+
+		green_pwm_led: led_pwm_1 {
+			pwms = <&pwm0 11>;
+			label = "Green PWM LED";
+		};
+
+		blue_pwm_led: led_pwm_2 {
+			pwms = <&pwm0 12>;
+			label = "Blue PWM LED";
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 
@@ -47,7 +66,9 @@
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
-		rgb-pwm = &pwm0;
+		red-pwm-led = &red_pwm_led;
+		green-pwm-led = &green_pwm_led;
+		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
 	};
 };


### PR DESCRIPTION
Add the RGB LED present on the Actinius Icarus board to the device tree.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>