### PR TITLE
device: Make device variables global

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -107,7 +107,7 @@ extern "C" {
 		.name = drv_name, .init = (init_fn),			  \
 		.config_info = (cfg_info)				  \
 	};								  \
-	static Z_DECL_ALIGN(struct device) _CONCAT(__device_, dev_name) __used \
+	Z_DECL_ALIGN(struct device) _CONCAT(__device_, dev_name) __used \
 	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
 		.config = &_CONCAT(__config_, dev_name),		  \
 		.driver_api = api,					  \
@@ -164,7 +164,7 @@ extern "C" {
 		.pm  = &_CONCAT(__pm_, dev_name),                         \
 		.config_info = (cfg_info)				  \
 	};								  \
-	static Z_DECL_ALIGN(struct device) _CONCAT(__device_, dev_name) __used \
+	Z_DECL_ALIGN(struct device) _CONCAT(__device_, dev_name) __used \
 	__attribute__((__section__(".init_" #level STRINGIFY(prio)))) = { \
 		.config = &_CONCAT(__config_, dev_name),		  \
 		.driver_api = api,					  \
@@ -218,7 +218,7 @@ extern "C" {
  *
  * @param name Device name
  */
-#define DEVICE_DECLARE(name) static struct device DEVICE_NAME_GET(name)
+#define DEVICE_DECLARE(name) struct device DEVICE_NAME_GET(name)
 
 struct device;
 


### PR DESCRIPTION
Allow to access to device structures from the code.

With this change is it possible to statically initialize
pointer to the device.

Removing `static` allows to get access to the device pointer and initialize it statically during compilation when device that will be used is known. Sample:
```
extern struct device DEVICE_NAME_GET(temp_nrf5);
const struct my_struct foo = {
  .dev = DEVICE_GET(temp_nrf5)
}
```

It might be against standard approach but has following advantages:
- less code
- significantly reduces startup time and it is critical in certain applications. After enabling few drivers on nrf52840 `device_get_binding` takes 20 ms. Just few calls will take 100ms.

There is of course risk of name collision but drivers are unique and any collision can be easily avoided.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>