### PR TITLE
Bluetooth: host: Fix ordering of TX sent callbacks

### DIFF
--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -80,11 +80,8 @@ struct bt_conn_sco {
 typedef void (*bt_conn_tx_cb_t)(struct bt_conn *conn, void *user_data);
 
 struct bt_conn_tx {
-	union {
-		sys_snode_t node;
-		struct k_work work;
-	};
-	struct bt_conn *conn;
+	sys_snode_t node;
+
 	bt_conn_tx_cb_t cb;
 	void *user_data;
 
@@ -122,6 +119,11 @@ struct bt_conn {
 	 * the next packet (if any) in tx_pending.
 	 */
 	u32_t                   pending_no_cb;
+
+	/* Completed TX for which we need to call the callback */
+	sys_slist_t		tx_complete;
+	struct k_work           tx_complete_work;
+
 
 	/* Queue for outgoing ACL data */
 	struct k_fifo		tx_queue;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -728,9 +728,10 @@ static void hci_num_completed_packets(struct net_buf *buf)
 			key = irq_lock();
 			conn->pending_no_cb = tx->pending_no_cb;
 			tx->pending_no_cb = 0U;
+			sys_slist_append(&conn->tx_complete, &tx->node);
 			irq_unlock(key);
 
-			k_work_submit(&tx->work);
+			k_work_submit(&conn->tx_complete_work);
 			k_sem_give(bt_conn_get_pkts(conn));
 		}
 


### PR DESCRIPTION
Now that the TX callbacks happen from the system workqueue but fixed
channels get processed from the RX thread there's a risk that the
ordering of these gets messed up. This is particularly bad for ATT
when it's trying to enforce flow control.
    
To fix the issue store the completed TX packet information in a
per-connection list and process this list before processing any new
packets for the same connection. We still also schedule a workqueue
callback, which will simply do nothing for this list if bt_recv()
already took care of it.

Fixes #21059