### PR TITLE
[TOPIC-GPIO] drivers: hci: spi: update to new GPIO API

### DIFF
--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -84,8 +84,8 @@
 	bt-hci@0 {
 		compatible = "zephyr,bt-hci-spi";
 		reg = <0>;
-		reset-gpios = <&gpiob 4 0>;
-		irq-gpios = <&gpiob 1 0>;
+		reset-gpios = <&gpiob 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		irq-gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
 		spi-max-frequency = <2000000>;
 		label = "BT_HCI";
 	};

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -118,13 +118,14 @@
 &spi3 {
 	status = "okay";
 
-	cs-gpios = <&gpiod 13 0>, <&gpioe 0 GPIO_ACTIVE_HIGH>;
+	cs-gpios = <&gpiod 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>,
+		   <&gpioe 0 GPIO_ACTIVE_HIGH>;
 
 	spbtle-rf@0 {
 		compatible = "zephyr,bt-hci-spi";
 		reg = <0>;
-		reset-gpios = <&gpioa 8 0>;
-		irq-gpios = <&gpioe 6 0>;
+		reset-gpios = <&gpioa 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		irq-gpios = <&gpioe 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		spi-max-frequency = <2000000>;
 		label = "SPBTLE-RF";
 	};

--- a/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
+++ b/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
@@ -5,13 +5,13 @@
  */
 
 &arduino_spi {
-	cs-gpios = <&arduino_header 16 0>;		/* D10 */
+	cs-gpios = <&arduino_header 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;	      /* D10 */
 
 	spbtle-rf@0 {
 		compatible = "zephyr,bt-hci-spi";
 		reg = <0>;
-		reset-gpios = <&arduino_header 13 0>;	/* D7 */
-		irq-gpios = <&arduino_header 0 0>;	/* A0 */
+		reset-gpios = <&arduino_header 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>; /* D7 */
+		irq-gpios = <&arduino_header 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;  /* A0 */
 		spi-max-frequency = <2000000>;
 		label = "SPBTLE-RF";
 	};


### PR DESCRIPTION
Update bluetooth hcp spi driver to new GPIO API.

Tested on disco_l475_iot1 and 96b_carbon.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>