### PR TITLE
drivers: flash_handlers fixes stray semicolon

### DIFF
--- a/drivers/flash/flash_handlers.c
+++ b/drivers/flash/flash_handlers.c
@@ -65,7 +65,7 @@ static inline int z_vrfy_flash_get_page_info_by_idx(struct device *dev,
 }
 #include <syscalls/flash_get_page_info_by_idx_mrsh.c>
 
-static inline size_t z_vrfy_flash_get_page_count(struct device *dev);
+static inline size_t z_vrfy_flash_get_page_count(struct device *dev)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_FLASH(dev, page_layout));
 	return z_impl_flash_get_page_count((struct device *)dev);


### PR DESCRIPTION
z_vrfy_flash_get_page_count defined as a function prototype in place of
a real function due to a stray semicolon.

Signed-off-by: Andrei Gansari <andrei.gansari@nxp.com>