### PR TITLE
[TOPIC-GPIO] drivers/wifi: eswifi: Update to new GPIO API

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -118,7 +118,7 @@
 &spi3 {
 	status = "okay";
 
-	cs-gpios = <&gpiod 13 0>, <&gpioe 0 0>;
+	cs-gpios = <&gpiod 13 0>, <&gpioe 0 GPIO_ACTIVE_HIGH>;
 
 	spbtle-rf@0 {
 		compatible = "zephyr,bt-hci-spi";
@@ -133,10 +133,10 @@
 		compatible = "inventek,eswifi";
 		spi-max-frequency = <2000000>;
 		reg = <1>;
-		resetn-gpios = <&gpioe 8 0>;
-		boot0-gpios = <&gpiob 12 0>;
-		wakeup-gpios = <&gpiob 13 0>;
-		data-gpios = <&gpioe 1 0>;
+		resetn-gpios = <&gpioe 8 GPIO_ACTIVE_HIGH>;
+		boot0-gpios = <&gpiob 12 GPIO_ACTIVE_HIGH>;
+		wakeup-gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
+		data-gpios = <&gpioe 1 GPIO_ACTIVE_HIGH>;
 		label = "ESWIFI0";
 	};
 };

--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -245,8 +245,9 @@ int eswifi_spi_init(struct eswifi_dev *eswifi)
 		return -ENODEV;
 	}
 	spi->dr.pin = DT_INVENTEK_ESWIFI_ESWIFI0_DATA_GPIOS_PIN;
-	gpio_pin_configure(spi->dr.dev, spi->dr.pin, GPIO_DIR_IN);
-
+	gpio_pin_configure(spi->dr.dev, spi->dr.pin,
+			   DT_INVENTEK_ESWIFI_ESWIFI0_DATA_GPIOS_FLAGS |
+			   GPIO_INPUT);
 
 	/* SPI CONFIG/CS */
 	spi->spi_cfg.frequency = DT_INVENTEK_ESWIFI_ESWIFI0_SPI_MAX_FREQUENCY;

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -38,10 +38,10 @@ static struct eswifi_dev eswifi0; /* static instance */
 
 static int eswifi_reset(struct eswifi_dev *eswifi)
 {
-	gpio_pin_write(eswifi->resetn.dev, eswifi->resetn.pin, 0);
+	gpio_pin_set(eswifi->resetn.dev, eswifi->resetn.pin, 0);
 	k_sleep(K_MSEC(10));
-	gpio_pin_write(eswifi->resetn.dev, eswifi->resetn.pin, 1);
-	gpio_pin_write(eswifi->wakeup.dev, eswifi->wakeup.pin, 1);
+	gpio_pin_set(eswifi->resetn.dev, eswifi->resetn.pin, 1);
+	gpio_pin_set(eswifi->wakeup.dev, eswifi->wakeup.pin, 1);
 	k_sleep(K_MSEC(500));
 
 	/* fetch the cursor */
@@ -646,7 +646,8 @@ static int eswifi_init(struct device *dev)
 	}
 	eswifi->resetn.pin = DT_INVENTEK_ESWIFI_ESWIFI0_RESETN_GPIOS_PIN;
 	gpio_pin_configure(eswifi->resetn.dev, eswifi->resetn.pin,
-			   GPIO_DIR_OUT);
+			   DT_INVENTEK_ESWIFI_ESWIFI0_RESETN_GPIOS_FLAGS |
+			   GPIO_OUTPUT_INACTIVE);
 
 	eswifi->wakeup.dev = device_get_binding(
 			DT_INVENTEK_ESWIFI_ESWIFI0_WAKEUP_GPIOS_CONTROLLER);
@@ -657,8 +658,8 @@ static int eswifi_init(struct device *dev)
 	}
 	eswifi->wakeup.pin = DT_INVENTEK_ESWIFI_ESWIFI0_WAKEUP_GPIOS_PIN;
 	gpio_pin_configure(eswifi->wakeup.dev, eswifi->wakeup.pin,
-			   GPIO_DIR_OUT);
-	gpio_pin_write(eswifi->wakeup.dev, eswifi->wakeup.pin, 1);
+			   DT_INVENTEK_ESWIFI_ESWIFI0_WAKEUP_GPIOS_FLAGS |
+			   GPIO_OUTPUT_ACTIVE);
 
 	k_work_q_start(&eswifi->work_q, eswifi_work_q_stack,
 		       K_THREAD_STACK_SIZEOF(eswifi_work_q_stack),


### PR DESCRIPTION
drivers/wifi: eswifi: Update to new GPIO API

Update to new GPIO API.
Tested on disco_l475_iot1

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>

Based on #21065 