### PR TITLE
Boards: Nordic: PWM: Add missing PWM LEDs to device trees

### DIFF
--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -34,6 +34,25 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+
+		red_pwm_led: led_pwm_0 {
+			pwms = <&pwm0 10>;
+			label = "Red PWM LED";
+		};
+
+		green_pwm_led: led_pwm_1 {
+			pwms = <&pwm0 11>;
+			label = "Green PWM LED";
+		};
+
+		blue_pwm_led: led_pwm_2 {
+			pwms = <&pwm0 12>;
+			label = "Blue PWM LED";
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 
@@ -47,7 +66,12 @@
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
-		rgb-pwm = &pwm0;
+		pwm-led0 = &red_pwm_led;
+		pwm-led1 = &green_pwm_led;
+		pwm-led2 = &blue_pwm_led;
+		red-pwm-led = &red_pwm_led;
+		green-pwm-led = &green_pwm_led;
+		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
 	};
 };

--- a/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
+++ b/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
@@ -43,6 +43,14 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0_red: pwm_led_0 {
+			pwms = <&pwm0 22>;
+			label = "Red PWM LED";
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -62,6 +70,7 @@
 		led1-green = &led1_green;
 		led2-red   = &led2_red;
 		led3-blue  = &led3_blue;
+		pwm-led0   = &pwm_led0_red;
 	};
 
 };
@@ -117,7 +126,6 @@
 	ch0-pin = <22>;
 	ch0-inverted;
 };
-
 
 &flash0 {
 	/*

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -40,6 +40,22 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0_green: pwm_led_0 {
+			pwms = <&pwm0 22>;
+			label = "Green PWM LED 0";
+		};
+		pwm_led1_red: pwm_led_1 {
+			pwms = <&pwm0 23>;
+			label = "Red PWM LED 1";
+		};
+		pwm_led2_blue: pwm_led_2 {
+			pwms = <&pwm0 24>;
+			label = "Blue PWM LED 1";
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -57,6 +73,12 @@
 		led0-green = &led0_green;
 		led1-red   = &led1_red;
 		led2-blue  = &led2_blue;
+		pwm-led0 = &pwm_led0_green;
+		pwm-led1 = &pwm_led1_red;
+		pwm-led2 = &pwm_led2_blue;
+		green-pwm-led = &pwm_led0_green;
+		red-pwm-led = &pwm_led1_red;
+		blue-pwm-led = &pwm_led2_blue;
 	};
 
 };
@@ -97,6 +119,10 @@
 	status = "okay";
 	ch0-pin = <22>;
 	ch0-inverted;
+	ch1-pin = <23>;
+	ch1-inverted;
+	ch2-pin = <24>;
+	ch2-inverted;
 };
 
 &flash0 {

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -39,6 +39,22 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0_green: pwm_led_0 {
+			pwms = <&pwm0 22>;
+			label = "Green PWM LED 0";
+		};
+		pwm_led1_red: pwm_led_1 {
+			pwms = <&pwm0 23>;
+			label = "Red PWM LED 1";
+		};
+		pwm_led2_blue: pwm_led_2 {
+			pwms = <&pwm0 24>;
+			label = "Blue PWM LED 2";
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -56,6 +72,12 @@
 		led0-green = &led0_green;
 		led1-red   = &led1_red;
 		led1-blue  = &led2_blue;
+		pwm-led0 = &pwm_led0_green;
+		pwm-led1 = &pwm_led1_red;
+		pwm-led2 = &pwm_led2_blue;
+		green-pwm-led = &pwm_led0_green;
+		red-pwm-led = &pwm_led1_red;
+		blue-pwm-led = &pwm_led2_blue;
 	};
 };
 
@@ -99,6 +121,10 @@
 	status = "okay";
 	ch0-pin = <22>;
 	ch0-inverted;
+	ch1-pin = <23>;
+	ch1-inverted;
+	ch2-pin = <24>;
+	ch2-inverted;
 };
 
 &flash0 {

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -38,6 +38,22 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0 13>;
+			label = "Green PWM LED 0";
+		};
+		pwm_led1: pwm_led_1 {
+			pwms = <&pwm0 15>;
+			label = "Blue PWM LED 1";
+		};
+		pwm_led2: pwm_led_2 {
+			pwms = <&pwm0 14>;
+			label = "Red PWM LED 2";
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -51,6 +67,12 @@
 		led0 = &led0;
 		led1 = &led1;
 		led2 = &led2;
+		pwm-led0 = &pwm_led0;
+		pwm-led1 = &pwm_led1;
+		pwm-led2 = &pwm_led2;
+		green-pwm-led = &pwm_led0;
+		blue-pwm-led = &pwm_led1;
+		red-pwm-led = &pwm_led2;
 		sw0 = &button0;
 	};
 };
@@ -98,6 +120,10 @@
 	status = "okay";
 	ch0-pin = <13>;
 	ch0-inverted;
+	ch1-pin = <14>;
+	ch1-inverted;
+	ch2-pin = <15>;
+	ch2-inverted;
 };
 
 &flash0 {


### PR DESCRIPTION
This series of commits adds configuration of previously unreferenced PWM channels to boards based on the Nordic nRF SoC series.

This is a general clean-up and preparation for #20657 (which moves PWM channel polarity from the PWM controller device tree entry to the PWM consumer device tree entry, which is currently lacking for these boards).