### PR TITLE
interrupt_controller: ioapic_intr: account for QEMU magic

### DIFF
--- a/drivers/interrupt_controller/ioapic_intr.c
+++ b/drivers/interrupt_controller/ioapic_intr.c
@@ -117,7 +117,7 @@ int _ioapic_init(struct device *unused)
 		   IOAPIC_PHYSICAL | 0 /* dummy vector */;
 
 	for (ix = 0; ix < CONFIG_IOAPIC_NUM_RTES; ix++) {
-		ioApicRedSetHi(ix, 0xFF000000);
+		ioApicRedSetHi(ix, IOAPIC_DESTINATION);
 		ioApicRedSetLo(ix, rteValue);
 	}
 #endif
@@ -242,7 +242,7 @@ int ioapic_resume_from_suspend(struct device *port)
 				IOAPIC_FIXED | IOAPIC_INT_MASK |
 				IOAPIC_PHYSICAL | 0 ; /* dummy vector*/
 		}
-		ioApicRedSetHi(irq, 0xFF000000);
+		ioApicRedSetHi(irq, IOAPIC_DESTINATION);
 		ioApicRedSetLo(irq, rteValue);
 	}
 	ioapic_device_power_state = DEVICE_PM_ACTIVE_STATE;
@@ -295,7 +295,7 @@ void z_ioapic_irq_set(unsigned int irq, unsigned int vector, u32_t flags)
 
 	rteValue = IOAPIC_FIXED | IOAPIC_INT_MASK | IOAPIC_PHYSICAL |
 		   (vector & IOAPIC_VEC_MASK) | flags;
-	ioApicRedSetHi(irq, 0xFF000000);
+	ioApicRedSetHi(irq, IOAPIC_DESTINATION);
 	ioApicRedSetLo(irq, rteValue);
 }
 

--- a/drivers/interrupt_controller/ioapic_priv.h
+++ b/drivers/interrupt_controller/ioapic_priv.h
@@ -42,7 +42,14 @@
 
 /* Redirection table entry bits: upper 32 bit */
 
+#ifdef CONFIG_QEMU_TARGET
+/* QEMU has special case in its interrupt handling code
+ * for 0xFF000000 to address all processors.
+ */
 #define IOAPIC_DESTINATION 0xff000000
+#else
+#define IOAPIC_DESTINATION 0x00000000
+#endif
 
 /* Redirection table entry bits: lower 32 bit */
 


### PR DESCRIPTION
Commit 5a9a33b0cf943312dfe4de6e4525087601a741e4 changes interrupt
destination in an attempt to broadcast interrupts. However, this
change causes interrupts to stop working on the UP Squared board
in non-SMP configuration. According to QEMU source code,
physical destination address 0xFF000000 is a special case where
it broadcasts the interrupts. However, none of the IOAPIC
documentation (that I can find) describes this behavior. So,
at least for now, revert to the old behavior for non-QEMU targets.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>