### PR TITLE
Add ordering to zephyr_linker_sources()

### DIFF
--- a/arch/arc/core/CMakeLists.txt
+++ b/arch/arc/core/CMakeLists.txt
@@ -30,3 +30,5 @@ zephyr_library_sources_ifdef(CONFIG_ARC_CONNECT arc_smp.c)
 
 add_subdirectory_ifdef(CONFIG_ARC_CORE_MPU mpu)
 add_subdirectory_ifdef(CONFIG_ARC_SECURE_FIRMWARE secureshield)
+
+zephyr_linker_sources(TEXT_START SORT_KEY 0x0vectors vector_table.ld)

--- a/arch/arc/core/vector_table.ld
+++ b/arch/arc/core/vector_table.ld
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* when !XIP, .text is in RAM, and vector table must be at its very start */
+
+KEEP(*(.exc_vector_table))
+KEEP(*(".exc_vector_table.*"))
+KEEP(*(IRQ_VECTOR_TABLE))

--- a/arch/arm/core/CMakeLists.txt
+++ b/arch/arm/core/CMakeLists.txt
@@ -33,3 +33,5 @@ add_subdirectory_ifdef(CONFIG_ARM_SECURE_FIRMWARE cortex_m/tz)
 add_subdirectory_ifdef(CONFIG_ARM_NONSECURE_FIRMWARE cortex_m/tz)
 
 add_subdirectory_ifdef(CONFIG_CPU_CORTEX_R cortex_r)
+
+zephyr_linker_sources(TEXT_START SORT_KEY 0x0vectors vector_table.ld)

--- a/arch/arm/core/cortex_m/CMakeLists.txt
+++ b/arch/arm/core/cortex_m/CMakeLists.txt
@@ -12,6 +12,12 @@ zephyr_library_sources(
   )
 
 zephyr_linker_sources_ifdef(CONFIG_SW_VECTOR_RELAY
+  TEXT_START
+  SORT_KEY 0x0relay_vectors
+  relay_vector_table.ld
+  )
+
+zephyr_linker_sources_ifdef(CONFIG_SW_VECTOR_RELAY
   RAM_SECTIONS
   vt_pointer_section.ld
   )

--- a/arch/arm/core/cortex_m/relay_vector_table.ld
+++ b/arch/arm/core/cortex_m/relay_vector_table.ld
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+KEEP(*(.vector_relay_table))
+KEEP(*(".vector_relay_table.*"))
+KEEP(*(.vector_relay_handler))
+KEEP(*(".vector_relay_handler.*"))

--- a/arch/arm/core/cortex_m/tz/CMakeLists.txt
+++ b/arch/arm/core/cortex_m/tz/CMakeLists.txt
@@ -25,6 +25,8 @@ if(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
     extra_post_build_byproducts
     ${CMAKE_BINARY_DIR}/${CONFIG_ARM_ENTRY_VENEERS_LIB_NAME}
     )
+
+  zephyr_linker_sources(SECTIONS SORT_KEY z_end secure_entry_functions.ld)
 endif()
 
 # Link the entry veneers library file with the Non-Secure Firmware that needs it.

--- a/arch/arm/core/cortex_m/tz/secure_entry_functions.ld
+++ b/arch/arm/core/cortex_m/tz/secure_entry_functions.ld
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if CONFIG_ARM_NSC_REGION_BASE_ADDRESS != 0
+	#define NSC_ALIGN . = ABSOLUTE(CONFIG_ARM_NSC_REGION_BASE_ADDRESS)
+#elif defined(CONFIG_CPU_HAS_NRF_IDAU)
+	/* The nRF9160 needs the NSC region to be at the end of a 32 kB region. */
+	#define NSC_ALIGN . = ALIGN(0x8000) - (1 << LOG2CEIL(__sg_size))
+#else
+	#define NSC_ALIGN . = ALIGN(4)
+#endif
+
+#ifdef CONFIG_CPU_HAS_NRF_IDAU
+	#define NSC_ALIGN_END . = ALIGN(0x8000)
+#else
+	#define NSC_ALIGN_END . = ALIGN(4)
+#endif
+
+SECTION_PROLOGUE(.gnu.sgstubs,,)
+{
+	NSC_ALIGN;
+	__sg_start = .;
+	/* No input section necessary, since the Secure Entry Veneers are
+	   automatically placed after the .gnu.sgstubs output section. */
+} GROUP_LINK_IN(ROMABLE_REGION)
+__sg_end = .;
+__sg_size = __sg_end - __sg_start;
+NSC_ALIGN_END;
+__nsc_size = . - __sg_start;
+
+#ifdef CONFIG_CPU_HAS_NRF_IDAU
+	ASSERT(1 << LOG2CEIL(0x8000 - (__sg_start % 0x8000))
+			 == (0x8000 - (__sg_start % 0x8000))
+		&& (0x8000 - (__sg_start % 0x8000)) >= 32
+		&& (0x8000 - (__sg_start % 0x8000)) <= 4096,
+		"The Non-Secure Callable region size must be a power of 2 \
+between 32 and 4096 bytes.")
+#endif

--- a/arch/arm/core/vector_table.ld
+++ b/arch/arm/core/vector_table.ld
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+_vector_start = .;
+KEEP(*(.exc_vector_table))
+KEEP(*(".exc_vector_table.*"))
+
+KEEP(*(IRQ_VECTOR_TABLE))
+
+KEEP(*(.vectors))
+
+KEEP(*(.openocd_dbg))
+KEEP(*(".openocd_dbg.*"))
+
+_vector_end = .;

--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -33,3 +33,8 @@ zephyr_linker_sources_ifdef(CONFIG_NOCACHE_MEMORY
   RAM_SECTIONS
   nocache.ld
 )
+
+# Only ARM, X86 and RISCV use TEXT_SECTION_OFFSET
+if (DEFINED CONFIG_ARM OR DEFINED CONFIG_X86 OR DEFINED CONFIG_RISCV)
+  zephyr_linker_sources(TEXT_START SORT_KEY 0x0 text_section_offset.ld)
+endif()

--- a/arch/common/text_section_offset.ld
+++ b/arch/common/text_section_offset.ld
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+. = CONFIG_TEXT_SECTION_OFFSET;
+. = ALIGN(4);

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -873,15 +873,17 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #    NOINIT       Inside the noinit output section.
 #    RWDATA       Inside the data output section.
 #    RODATA       Inside the rodata output section.
+#    TEXT_START   At the beginning of the text section, i.e. the beginning of
+#                 the image.
 #    RAM_SECTIONS Inside the RAMABLE_REGION GROUP.
 #    SECTIONS     Near the end of the file. Don't use this when linking into
 #                 RAMABLE_REGION, use RAM_SECTIONS instead.
 #
 # Use NOINIT, RWDATA, and RODATA unless they don't work for your use case.
 #
-# When placing into NOINIT, RWDATA, or RODATA, the contents of the files will be
-# placed inside an output section, so assume the section definition is already
-# present, e.g.:
+# When placing into NOINIT, RWDATA, RODATA, or TEXT_START the contents of the files
+# will be placed inside an output section, so assume the section definition is
+# already present, e.g.:
 #    _mysection_start = .;
 #    KEEP(*(.mysection));
 #    _mysection_end = .;
@@ -909,6 +911,7 @@ function(zephyr_linker_sources location)
   set(snippet_base      "${__build_dir}/include/generated")
   set(sections_path     "${snippet_base}/snippets-sections.ld")
   set(ram_sections_path "${snippet_base}/snippets-ram-sections.ld")
+  set(text_start_path   "${snippet_base}/snippets-text-start.ld")
   set(noinit_path       "${snippet_base}/snippets-noinit.ld")
   set(rwdata_path       "${snippet_base}/snippets-rwdata.ld")
   set(rodata_path       "${snippet_base}/snippets-rodata.ld")
@@ -918,6 +921,7 @@ function(zephyr_linker_sources location)
   if (NOT DEFINED cleared)
     file(WRITE ${sections_path} "")
     file(WRITE ${ram_sections_path} "")
+    file(WRITE ${text_start_path} "")
     file(WRITE ${noinit_path} "")
     file(WRITE ${rwdata_path} "")
     file(WRITE ${rodata_path} "")
@@ -929,6 +933,8 @@ function(zephyr_linker_sources location)
     set(snippet_path "${sections_path}")
   elseif("${location}" STREQUAL "RAM_SECTIONS")
     set(snippet_path "${ram_sections_path}")
+  elseif("${location}" STREQUAL "TEXT_START")
+    set(snippet_path "${text_start_path}")
   elseif("${location}" STREQUAL "NOINIT")
     set(snippet_path "${noinit_path}")
   elseif("${location}" STREQUAL "RWDATA")

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -87,6 +87,10 @@ SECTIONS {
 		_image_rom_start = .;
 		_image_text_start = .;
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-text-start.ld>
 /* when !XIP, .text is in RAM, and vector table must be at its very start */
 
 		KEEP(*(.exc_vector_table))

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -91,11 +91,6 @@ SECTIONS {
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-text-start.ld>
-/* when !XIP, .text is in RAM, and vector table must be at its very start */
-
-		KEEP(*(.exc_vector_table))
-		KEEP(*(".exc_vector_table.*"))
-		KEEP(*(IRQ_VECTOR_TABLE))
 
 		*(.text)
 		*(".text.*")

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -449,44 +449,6 @@ GROUP_END(DTCM)
 	KEEP(*(.gnu.attributes))
 	}
 
-#if defined(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
-#if CONFIG_ARM_NSC_REGION_BASE_ADDRESS != 0
-	#define NSC_ALIGN . = ABSOLUTE(CONFIG_ARM_NSC_REGION_BASE_ADDRESS)
-#elif defined(CONFIG_CPU_HAS_NRF_IDAU)
-	/* The nRF9160 needs the NSC region to be at the end of a 32 kB region. */
-	#define NSC_ALIGN . = ALIGN(0x8000) - (1 << LOG2CEIL(__sg_size))
-#else
-	#define NSC_ALIGN . = ALIGN(4)
-#endif
-
-#ifdef CONFIG_CPU_HAS_NRF_IDAU
-	#define NSC_ALIGN_END . = ALIGN(0x8000)
-#else
-	#define NSC_ALIGN_END . = ALIGN(4)
-#endif
-
-SECTION_PROLOGUE(.gnu.sgstubs,,)
-{
-	NSC_ALIGN;
-	__sg_start = .;
-	/* No input section necessary, since the Secure Entry Veneers are
-	   automatically placed after the .gnu.sgstubs output section. */
-} GROUP_LINK_IN(ROMABLE_REGION)
-__sg_end = .;
-__sg_size = __sg_end - __sg_start;
-NSC_ALIGN_END;
-__nsc_size = . - __sg_start;
-
-#ifdef CONFIG_CPU_HAS_NRF_IDAU
-	ASSERT(1 << LOG2CEIL(0x8000 - (__sg_start % 0x8000))
-			 == (0x8000 - (__sg_start % 0x8000))
-		&& (0x8000 - (__sg_start % 0x8000)) >= 32
-		&& (0x8000 - (__sg_start % 0x8000)) <= 4096,
-		"The Non-Secure Callable region size must be a power of 2 \
-between 32 and 4096 bytes.")
-#endif
-#endif /* CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS */
-
 /* Must be last in romable region */
 SECTION_PROLOGUE(.last_section,(NOLOAD),)
 {

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -144,16 +144,6 @@ SECTIONS
 	KEEP(*(".dbghdr.*"))
 #endif
 
-#ifdef CONFIG_NXP_IMX_RT_BOOT_HEADER
-	KEEP(*(.boot_hdr.conf))
-	. = CONFIG_IMAGE_VECTOR_TABLE_OFFSET;
-	KEEP(*(.boot_hdr.ivt))
-	KEEP(*(.boot_hdr.data))
-#ifdef CONFIG_DEVICE_CONFIGURATION_DATA
-	KEEP(*(.boot_hdr.dcd_data))
-#endif
-#endif
-
 	. = CONFIG_TEXT_SECTION_OFFSET;
 
 /* Located in generated directory. This file is populated by the

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -138,8 +138,6 @@ SECTIONS
     SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
 	{
 
-	. = CONFIG_TEXT_SECTION_OFFSET;
-
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -160,23 +160,6 @@ SECTIONS
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-text-start.ld>
-#if defined(CONFIG_SW_VECTOR_RELAY)
-	KEEP(*(.vector_relay_table))
-	KEEP(*(".vector_relay_table.*"))
-	KEEP(*(.vector_relay_handler))
-	KEEP(*(".vector_relay_handler.*"))
-#endif
-
-	_vector_start = .;
-	KEEP(*(.exc_vector_table))
-	KEEP(*(".exc_vector_table.*"))
-
-	KEEP(*(IRQ_VECTOR_TABLE))
-
-	KEEP(*(.vectors))
-
-	KEEP(*(.openocd_dbg))
-	KEEP(*(".openocd_dbg.*"))
 
 #ifdef CONFIG_KINETIS_FLASH_CONFIG
 	. = CONFIG_KINETIS_FLASH_CONFIG_OFFSET;
@@ -184,7 +167,6 @@ SECTIONS
 	KEEP(*(".kinetis_flash_config.*"))
 #endif
 
-	_vector_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 #ifdef CONFIG_CODE_DATA_RELOCATION

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -161,12 +161,6 @@ SECTIONS
  */
 #include <snippets-text-start.ld>
 
-#ifdef CONFIG_KINETIS_FLASH_CONFIG
-	. = CONFIG_KINETIS_FLASH_CONFIG_OFFSET;
-	KEEP(*(.kinetis_flash_config))
-	KEEP(*(".kinetis_flash_config.*"))
-#endif
-
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 #ifdef CONFIG_CODE_DATA_RELOCATION

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -137,12 +137,6 @@ SECTIONS
 
     SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
 	{
-#if defined(CONFIG_CC3220SF_DEBUG) || defined(CONFIG_CC3235SF_DEBUG)
-	/* Add CC32xx flash header to disable flash verification */
-	. = 0x0;
-	KEEP(*(.dbghdr))
-	KEEP(*(".dbghdr.*"))
-#endif
 
 	. = CONFIG_TEXT_SECTION_OFFSET;
 

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -156,6 +156,10 @@ SECTIONS
 
 	. = CONFIG_TEXT_SECTION_OFFSET;
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-text-start.ld>
 #if defined(CONFIG_SW_VECTOR_RELAY)
 	KEEP(*(.vector_relay_table))
 	KEEP(*(".vector_relay_table.*"))

--- a/include/arch/arm/cortex_r/scripts/linker.ld
+++ b/include/arch/arm/cortex_r/scripts/linker.ld
@@ -134,13 +134,6 @@ SECTIONS
 
     SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
 	{
-#ifdef CONFIG_CC3220SF_DEBUG
-	/* Add CC3220SF flash header to disable flash verification */
-	. = 0x0;
-	KEEP(*(.dbghdr))
-	KEEP(*(".dbghdr.*"))
-#endif
-
 	. = CONFIG_TEXT_SECTION_OFFSET;
 
 /* Located in generated directory. This file is populated by the

--- a/include/arch/arm/cortex_r/scripts/linker.ld
+++ b/include/arch/arm/cortex_r/scripts/linker.ld
@@ -158,11 +158,6 @@ SECTIONS
  */
 #include <snippets-text-start.ld>
 
-	/* Kinetis has to write 16 bytes at 0x400 */
-	SKIP_TO_KINETIS_FLASH_CONFIG
-	KEEP(*(.kinetis_flash_config))
-	KEEP(*(".kinetis_flash_config.*"))
-
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 #ifdef CONFIG_CODE_DATA_RELOCATION

--- a/include/arch/arm/cortex_r/scripts/linker.ld
+++ b/include/arch/arm/cortex_r/scripts/linker.ld
@@ -153,6 +153,10 @@ SECTIONS
 
 	. = CONFIG_TEXT_SECTION_OFFSET;
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-text-start.ld>
 #if defined(CONFIG_SW_VECTOR_RELAY)
 	KEEP(*(.vector_relay_table))
 	KEEP(*(".vector_relay_table.*"))

--- a/include/arch/arm/cortex_r/scripts/linker.ld
+++ b/include/arch/arm/cortex_r/scripts/linker.ld
@@ -157,30 +157,12 @@ SECTIONS
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-text-start.ld>
-#if defined(CONFIG_SW_VECTOR_RELAY)
-	KEEP(*(.vector_relay_table))
-	KEEP(*(".vector_relay_table.*"))
-	KEEP(*(.vector_relay_handler))
-	KEEP(*(".vector_relay_handler.*"))
-#endif
-
-	_vector_start = .;
-	KEEP(*(.exc_vector_table))
-	KEEP(*(".exc_vector_table.*"))
-
-	KEEP(*(IRQ_VECTOR_TABLE))
-
-	KEEP(*(.vectors))
-
-	KEEP(*(.openocd_dbg))
-	KEEP(*(".openocd_dbg.*"))
 
 	/* Kinetis has to write 16 bytes at 0x400 */
 	SKIP_TO_KINETIS_FLASH_CONFIG
 	KEEP(*(.kinetis_flash_config))
 	KEEP(*(".kinetis_flash_config.*"))
 
-	_vector_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 #ifdef CONFIG_CODE_DATA_RELOCATION

--- a/include/arch/arm/cortex_r/scripts/linker.ld
+++ b/include/arch/arm/cortex_r/scripts/linker.ld
@@ -141,16 +141,6 @@ SECTIONS
 	KEEP(*(".dbghdr.*"))
 #endif
 
-#ifdef CONFIG_NXP_IMX_RT_BOOT_HEADER
-	KEEP(*(.boot_hdr.conf))
-	. = CONFIG_IMAGE_VECTOR_TABLE_OFFSET;
-	KEEP(*(.boot_hdr.ivt))
-	KEEP(*(.boot_hdr.data))
-#ifdef CONFIG_DEVICE_CONFIGURATION_DATA
-	KEEP(*(.boot_hdr.dcd_data))
-#endif
-#endif
-
 	. = CONFIG_TEXT_SECTION_OFFSET;
 
 /* Located in generated directory. This file is populated by the

--- a/include/arch/arm/cortex_r/scripts/linker.ld
+++ b/include/arch/arm/cortex_r/scripts/linker.ld
@@ -408,44 +408,6 @@ SECTIONS
 	KEEP(*(.gnu.attributes))
 	}
 
-#if defined(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
-#if CONFIG_ARM_NSC_REGION_BASE_ADDRESS != 0
-	#define NSC_ALIGN . = ABSOLUTE(CONFIG_ARM_NSC_REGION_BASE_ADDRESS)
-#elif defined(CONFIG_CPU_HAS_NRF_IDAU)
-	/* The nRF9160 needs the NSC region to be at the end of a 32 kB region. */
-	#define NSC_ALIGN . = ALIGN(0x8000) - (1 << LOG2CEIL(__sg_size))
-#else
-	#define NSC_ALIGN . = ALIGN(4)
-#endif
-
-#ifdef CONFIG_CPU_HAS_NRF_IDAU
-	#define NSC_ALIGN_END . = ALIGN(0x8000)
-#else
-	#define NSC_ALIGN_END . = ALIGN(4)
-#endif
-
-SECTION_PROLOGUE(.gnu.sgstubs,,)
-{
-	NSC_ALIGN;
-	__sg_start = .;
-	/* No input section necessary, since the Secure Entry Veneers are
-	   automatically placed after the .gnu.sgstubs output section. */
-} GROUP_LINK_IN(ROMABLE_REGION)
-__sg_end = .;
-__sg_size = __sg_end - __sg_start;
-NSC_ALIGN_END;
-__nsc_size = . - __sg_start;
-
-#ifdef CONFIG_CPU_HAS_NRF_IDAU
-	ASSERT(1 << LOG2CEIL(0x8000 - (__sg_start % 0x8000))
-			 == (0x8000 - (__sg_start % 0x8000))
-		&& (0x8000 - (__sg_start % 0x8000)) >= 32
-		&& (0x8000 - (__sg_start % 0x8000)) <= 4096,
-		"The Non-Secure Callable region size must be a power of 2 \
-between 32 and 4096 bytes.")
-#endif
-#endif /* CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS */
-
 /* Must be last in romable region */
 SECTION_PROLOGUE(.last_section,(NOLOAD),)
 {

--- a/include/arch/arm/cortex_r/scripts/linker.ld
+++ b/include/arch/arm/cortex_r/scripts/linker.ld
@@ -134,7 +134,6 @@ SECTIONS
 
     SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
 	{
-	. = CONFIG_TEXT_SECTION_OFFSET;
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.

--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -120,6 +120,12 @@ SECTIONS
         . = ALT_CPU_RESET_ADDR;
 
         _image_text_start = .;
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-text-start.ld>
+
         *(.text)
         *(".text.*")
         *(.gnu.linkonce.t.*)

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -88,6 +88,12 @@ SECTIONS
 		KEEP(*(".openocd_debug.*"))
 
 		_image_text_start = .;
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-text-start.ld>
+
 		*(.text)
 		*(".text.*")
 		*(.gnu.linkonce.t.*)

--- a/include/arch/x86/ia32/linker.ld
+++ b/include/arch/x86/ia32/linker.ld
@@ -86,6 +86,12 @@ SECTIONS
 	SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
 	{
 	. = CONFIG_TEXT_SECTION_OFFSET;
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-text-start.ld>
+
 	*(.text_start)
 	*(".text_start.*")
 	*(.text)

--- a/include/arch/x86/ia32/linker.ld
+++ b/include/arch/x86/ia32/linker.ld
@@ -85,7 +85,6 @@ SECTIONS
 	_image_text_start = PHYS_LOAD_ADDR;
 	SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
 	{
-	. = CONFIG_TEXT_SECTION_OFFSET;
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.

--- a/soc/arm/nxp_imx/rt/CMakeLists.txt
+++ b/soc/arm/nxp_imx/rt/CMakeLists.txt
@@ -7,3 +7,6 @@
 zephyr_sources(
   soc.c
   )
+
+zephyr_linker_sources_ifdef(CONFIG_NXP_IMX_RT_BOOT_HEADER
+  TEXT_START SORT_KEY 0 boot_header.ld)

--- a/soc/arm/nxp_imx/rt/boot_header.ld
+++ b/soc/arm/nxp_imx/rt/boot_header.ld
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2019 NXP
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+KEEP(*(.boot_hdr.conf))
+. = CONFIG_IMAGE_VECTOR_TABLE_OFFSET;
+KEEP(*(.boot_hdr.ivt))
+KEEP(*(.boot_hdr.data))
+#ifdef CONFIG_DEVICE_CONFIGURATION_DATA
+	KEEP(*(.boot_hdr.dcd_data))
+#endif

--- a/soc/arm/nxp_kinetis/CMakeLists.txt
+++ b/soc/arm/nxp_kinetis/CMakeLists.txt
@@ -3,3 +3,9 @@
 zephyr_sources_ifdef(CONFIG_KINETIS_FLASH_CONFIG	flash_configuration.c)
 
 add_subdirectory(${SOC_SERIES})
+
+zephyr_linker_sources_ifdef(CONFIG_KINETIS_FLASH_CONFIG
+  TEXT_START
+  SORT_KEY ${CONFIG_KINETIS_FLASH_CONFIG_OFFSET}
+  flash_config.ld
+  )

--- a/soc/arm/nxp_kinetis/flash_config.ld
+++ b/soc/arm/nxp_kinetis/flash_config.ld
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2019 NXP
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+. = CONFIG_KINETIS_FLASH_CONFIG_OFFSET;
+KEEP(*(.kinetis_flash_config))
+KEEP(*(".kinetis_flash_config.*"))

--- a/soc/arm/ti_simplelink/cc32xx/CMakeLists.txt
+++ b/soc/arm/ti_simplelink/cc32xx/CMakeLists.txt
@@ -1,3 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_sources(soc.c)
+
+if (DEFINED CONFIG_CC3220SF_DEBUG OR DEFINED CONFIG_CC3235SF_DEBUG)
+  zephyr_linker_sources(TEXT_START SORT_KEY 0 cc32xx_debug.ld)
+endif()

--- a/soc/arm/ti_simplelink/cc32xx/cc32xx_debug.ld
+++ b/soc/arm/ti_simplelink/cc32xx/cc32xx_debug.ld
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2019 Texas Instruments Incorporated
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Add CC32xx flash header to disable flash verification */
+. = 0x0;
+KEEP(*(.dbghdr))
+KEEP(*(".dbghdr.*"))

--- a/soc/riscv/openisa_rv32m1/CMakeLists.txt
+++ b/soc/riscv/openisa_rv32m1/CMakeLists.txt
@@ -18,3 +18,5 @@ zephyr_sources(
   wdog.S
   soc.c
 )
+
+zephyr_linker_sources(TEXT_START SORT_KEY 0x0vectors vector_table.ld)

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -133,6 +133,12 @@ SECTIONS
 	KEEP(*(".openocd_debug.*"))
 
 	_image_text_start = .;
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-text-start.ld>
+
 	*(.text .text.*)
 	*(.gnu.linkonce.t.*)
 	*(.eh_frame)

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -103,9 +103,6 @@ SECTIONS
 
     SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
 	{
-	. = CONFIG_TEXT_SECTION_OFFSET;
-	. = ALIGN(4);
-
 	/*
 	 * Respect for CONFIG_TEXT_SECTION_OFFSET is mandatory
 	 * for MCUboot support, so .reset.* and .exception.*

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -103,38 +103,13 @@ SECTIONS
 
     SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
 	{
-	/*
-	 * Respect for CONFIG_TEXT_SECTION_OFFSET is mandatory
-	 * for MCUboot support, so .reset.* and .exception.*
-	 * must come after that offset from ROM_BASE.
-	 */
-
-#ifdef CONFIG_BOOTLOADER_MCUBOOT
-	/*
-	 * For CONFIG_BOOTLOADER_MCUBOOT, the vector table is located at the
-	 * end of the image header of the MCUboot. After the tagert image is
-	 * boot, the register Machine Trap-Vector Base Address (MTVEC) is
-	 * set with the value of _vector_start in the reset handler.
-	 */
-	_vector_start = .;
-	KEEP(*(.vectors.*))
-	_vector_end = .;
-	. = ALIGN(4);
-#endif
-
-	KEEP(*(.reset.*))
-	KEEP(*(".exception.entry.*")) /* contains __irq_wrapper */
-	*(".exception.other.*")
-
-	KEEP(*(.openocd_debug))
-	KEEP(*(".openocd_debug.*"))
-
-	_image_text_start = .;
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-text-start.ld>
+
+	_image_text_start = .;
 
 	*(.text .text.*)
 	*(.gnu.linkonce.t.*)

--- a/soc/riscv/openisa_rv32m1/vector_table.ld
+++ b/soc/riscv/openisa_rv32m1/vector_table.ld
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Foundries.io Ltd
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Respect for CONFIG_TEXT_SECTION_OFFSET is mandatory
+ * for MCUboot support, so .reset.* and .exception.*
+ * must come after that offset from ROM_BASE.
+ */
+
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+	/*
+	 * For CONFIG_BOOTLOADER_MCUBOOT, the vector table is located at the
+	 * end of the image header of the MCUboot. After the tagert image is
+	 * boot, the register Machine Trap-Vector Base Address (MTVEC) is
+	 * set with the value of _vector_start in the reset handler.
+	 */
+	_vector_start = .;
+	KEEP(*(.vectors.*))
+	_vector_end = .;
+	. = ALIGN(4);
+#endif
+
+KEEP(*(.reset.*))
+KEEP(*(".exception.entry.*")) /* contains __irq_wrapper */
+*(".exception.other.*")
+
+KEEP(*(.openocd_debug))
+KEEP(*(".openocd_debug.*"))


### PR DESCRIPTION
This adds two new features to zephyr_linker_sources():

- Add a new location for `zephyr_linker_sources()`: Beginning of TEXT section ("TEXT_START")
- Add a "sort key" argument to `zephyr_linker_sources()`.

In addition to giving more opportunities for out-of-tree placement of linker snippets, this allows linker snippets to be placed in a predictable order, especially useful for the start and end of the image, where order can be important, e.g. because sections are placed at a particular offset by setting the location counter ('.').

This PR ports mostly cortex_m linker sections, because in the other linker scripts there are less things in the text section. For example, the reset vector in nios2 is placed in a separate section before .text.

Some open questions:
Should TEXT_START be SECTIONS_START instead, and place snippets at the start of the SECTIONS {} block instead of the start of .text? This would allow porting more of the other linker scripts as well. Should we have both TEXT_START and SECTIONS_START?