### PR TITLE
Missing documentation for third argument of modem_iface_uart_init()

### DIFF
--- a/drivers/modem/modem_iface_uart.h
+++ b/drivers/modem/modem_iface_uart.h
@@ -40,6 +40,7 @@ struct modem_iface_uart_data {
  *
  * @param  *iface: modem interface to initialize.
  * @param  *data: modem interface data to use
+ * @param  *dev_name: name of the UART device to use
  *
  * @retval 0 if ok, < 0 if error.
  */


### PR DESCRIPTION
Document that the third argument is the UART device name.

Signed-off-by: Patrik Flykt <patrik.flykt@intel.com>