### PR TITLE
sanitycheck: support on windows

### DIFF
--- a/tests/kernel/fifo/fifo_timeout/src/main.c
+++ b/tests/kernel/fifo/fifo_timeout/src/main.c
@@ -158,6 +158,7 @@ static int test_multiple_threads_pending(struct timeout_order_data *test_data,
 		struct timeout_order_data *data =
 			k_fifo_get(&timeout_order_fifo, K_FOREVER);
 
+		zassert_true(data != NULL, "");
 		if (data->timeout_order == ii) {
 			TC_PRINT(" thread (q order: %d, t/o: %d, fifo %p)\n",
 				data->q_order, data->timeout, data->fifo);


### PR DESCRIPTION
We now support building on windows. Running in Qemu still does not work.

Partially addresses #2664