### PR TITLE
sanitycheck: export compile commands on --cmake-only

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1827,6 +1827,9 @@ class CMake():
                 '-G{}'.format(get_generator()[1])
                 ]
 
+        if options.cmake_only:
+            cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=1")
+
         args = ["-D{}".format(a.replace('"', '')) for a in args]
         cmake_args.extend(args)
 


### PR DESCRIPTION
export compile commands when running with --cmake-only, this can be used
for analysis and coverage statistics.