### PR TITLE
tests: Cleanup of test identifiers and sanitycheck enhancements

### DIFF
--- a/doc/guides/test/sanitycheck.rst
+++ b/doc/guides/test/sanitycheck.rst
@@ -162,9 +162,36 @@ Test Cases
 
 Test cases are detected by the presence of a 'testcase.yaml' or a 'sample.yaml'
 files in the application's project directory. This file may contain one or more
-entries in the test section each identifying a test scenario. The name of
-the test case only needs to be unique for the test cases specified in
-that testcase meta-data.
+entries in the test section each identifying a test scenario.
+
+The name of each testcase needs to be unique in the context of the overall
+testsuite and has to follow basic rules:
+
+#. The format of the test identifier shall be a string without any spaces or
+   special characters (allowed characters: alphanumric and [\_=]) consisting of
+   multiple sections delimited with a dot (.).
+
+#. Each test identifier shall start with a section followed by a subsection
+   separated by a dot. For example, a test that covers semaphores in the kernel
+   shall start with ``kernel.sempahore``.
+
+#. All test identifiers within a testcase.yaml file need to be unique. For
+   example a testcase.yaml file covering semaphores in the kernel can have:
+
+   * ``kernel.semaphore``: For general semaphore tests
+   * ``kernel.semaphore.stress``: Stress testng semaphores in the kernel.
+
+#. Depending on the nature of the test, an identifier can consist of at least
+   two sections:
+
+   * Ztest tests: The individual testcases in the ztest testsuite will be
+     concatenated to identifier in the testcase.yaml file generating unique
+     identifiers for every testcase in the suite.
+
+   * Standalone tests and samples: This type of test should at least have 3
+     sections in the test identifier in the testcase.yaml (or sample.yaml) file.
+     The last section of the name shall signify the test itself.
+
 
 Test cases are written using the YAML syntax and share the same structure as
 samples. The following is an example test with a few options that are
@@ -174,11 +201,11 @@ explained in this document.
 ::
 
         tests:
-          test:
+          bluetooth.gatt:
             build_only: true
             platform_whitelist: qemu_cortex_m3 qemu_x86
             tags: bluetooth
-          test_br:
+          bluetooth.gatt.br:
             build_only: true
             extra_args: CONF_FILE="prj_br.conf"
             filter: not CONFIG_DEBUG
@@ -196,11 +223,11 @@ related to the sample and what is being demonstrated:
           name: hello world
           description: Hello World sample, the simplest Zephyr application
         tests:
-          test:
+          sample.basic.hello_world:
             build_only: true
             tags: tests
             min_ram: 16
-          singlethread:
+          sample.basic.hello_world.singlethread:
             build_only: true
             extra_args: CONF_FILE=prj_single.conf
             filter: not CONFIG_BT
@@ -289,8 +316,9 @@ extra_sections: <list of extra binary sections>
     here. They will not be included in the size calculation.
 
 harness: <string>
-    A harness string needed to run the tests successfully. This can be as simple as
-    a loopback wiring or a complete hardware test setup for sensor and IO testing.
+    A harness string needed to run the tests successfully. This can be as
+    simple as a loopback wiring or a complete hardware test setup for
+    sensor and IO testing.
     Usually pertains to external dependency domains but can be anything such as
     console, sensor, net, keyboard, or Bluetooth.
 

--- a/samples/application_development/code_relocation/sample.yaml
+++ b/samples/application_development/code_relocation/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: Code data relocation Sample
   name: code relocation
 tests:
-  sample.app_dev.code_relocation:
+  sample.application_development.code_relocation:
     harness: console
     harness_config:
       type: one_line

--- a/samples/basic/blink_led/sample.yaml
+++ b/samples/basic/blink_led/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Blink LED (PWM based)
 tests:
-  sample.blink_led:
+  sample.basic.blink_led:
     # FIXME: We should remove those and just rely on depends_on
     filter: dt_alias_exists("pwm-led0")
     tags: drivers pwm

--- a/samples/basic/blinky/sample.yaml
+++ b/samples/basic/blinky/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Blinky Sample
 tests:
-  sample.blinky:
+  sample.basic.blinky:
     tags: LED gpio
     filter: dt_compat_enabled_with_alias("gpio-leds", "led0")
     depends_on: gpio

--- a/samples/basic/button/sample.yaml
+++ b/samples/basic/button/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Button Sample
 tests:
-  sample.button:
+  sample.basic.button:
     tags: button gpio
     filter: dt_compat_enabled_with_alias("gpio-keys", "sw0")
     depends_on: gpio

--- a/samples/basic/fade_led/sample.yaml
+++ b/samples/basic/fade_led/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Fade LED
 tests:
-  sample.fade_led:
+  sample.basic.fade_led:
     tags: drivers pwm
     depends_on: pwm
     harness: led

--- a/samples/basic/rgb_led/sample.yaml
+++ b/samples/basic/rgb_led/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: RGB LED
 tests:
-  sample.rgb_led:
+  sample.basic.rgb_led:
     filter: dt_alias_exists("red-pwm-led") and
             dt_alias_exists("green-pwm-led") and
             dt_alias_exists("blue-pwm-led")

--- a/samples/basic/servo_motor/sample.yaml
+++ b/samples/basic/servo_motor/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Servo Motor using PWM
 tests:
-  sample.servo_motor:
+  sample.basic.servo_motor:
     tags: drivers pwm
     depends_on: pwm
     harness: motor

--- a/samples/basic/threads/sample.yaml
+++ b/samples/basic/threads/sample.yaml
@@ -3,7 +3,7 @@ sample:
     using K_THREAD_DEFINE
   name: Basic Thread Demo
 tests:
-  sample.threads:
+  sample.basic.threads:
     tags: kernel threads gpio
     filter: dt_compat_enabled_with_alias("gpio-leds", "led0") and
             dt_compat_enabled_with_alias("gpio-leds", "led1")

--- a/samples/boards/arc_secure_services/sample.yaml
+++ b/samples/boards/arc_secure_services/sample.yaml
@@ -3,7 +3,7 @@ sample:
      Designware ARC SecureShiled.
   name: Designware ARC Secure monitor
 tests:
-  sample.arc_secure_services:
+  sample.board.arc_secure_services:
     platform_whitelist: nsim_sem em_starterkit_em7d_secure
     tags: secure
     harness: console

--- a/samples/cpp_synchronization/sample.yaml
+++ b/samples/cpp_synchronization/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Syncronisation (C++)
 tests:
-  sample.cpp_syncronisation:
+  sample.cpp.synchronization:
     tags: cpp
     toolchain_exclude: issm
     arch_exclude: posix

--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Counter RTC Driver Sample
 tests:
-  sample.driver.counter.alarm:
+  sample.drivers.counter.alarm:
     tags: drivers
     harness: console
     platform_whitelist: nucleo_f746zg nrf51_pca10028 nrf52_pca10040

--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -8,7 +8,7 @@ common:
   min_ram: 20
   arch_exclude: xtensa
 tests:
-  sample.driver.crypto.mbedtls:
+  sample.drivers.crypto.mbedtls:
     min_flash: 34
     extra_args: CONF_FILE=prj_mtls_shim.conf
     harness_config:
@@ -18,7 +18,7 @@ tests:
         - ".*main: CBC Mode"
         - ".*main: CTR Mode"
         - ".*main: CCM Mode"
-  sample.driver.crypto.mbedtls.micro:
+  sample.drivers.crypto.mbedtls.micro:
     tags: crypto
     harness_config:
       type: multi_line

--- a/samples/drivers/current_sensing/sample.yaml
+++ b/samples/drivers/current_sensing/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: TI INA219 power monitor
 tests:
-  sample.driver.current_sensing:
+  sample.drivers.current_sensing:
     tags: sensors
     depends_on: i2c
     harness: sensor

--- a/samples/drivers/entropy/sample.yaml
+++ b/samples/drivers/entropy/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Sample for the entropy gathering driver
 tests:
-  sample.driver.entropy:
+  sample.drivers.entropy:
     tags: crypto
     filter: CONFIG_ENTROPY_HAS_DRIVER
     harness: console

--- a/samples/drivers/espi/sample.yaml
+++ b/samples/drivers/espi/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: eSPI driver sample
 tests:
-  sample.driver.espi:
+  sample.drivers.espi:
     tags: drivers
     harness: console
     harness_config:

--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -3,7 +3,7 @@ sample:
     behavior
   name: Flash shell
 tests:
-  sample.driver.flash_shell:
+  sample.drivers.flash.shell:
     platform_whitelist: 96b_carbon frdm_k64f frdm_kw41z frdm_kl25z nucleo_f746zg
     tags: flash shell
     harness: keyboard

--- a/samples/drivers/ht16k33/sample.yaml
+++ b/samples/drivers/ht16k33/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: Demonstration of the HT16K33 LED driver with keyscan
   name: HT16K33 sample
 tests:
-  sample.driver.ht16k33:
+  sample.drivers.ht16k33:
     platform_whitelist: nrf52840_pca10056
     harness: TBD
     tags: LED

--- a/samples/drivers/i2c_fujitsu_fram/sample.yaml
+++ b/samples/drivers/i2c_fujitsu_fram/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Demo for Fujitsu MB85RC256V FRAM (I2C)
 tests:
-  sample.driver.i2c_fujitsu_fram:
+  sample.drivers.i2c.fujitsu_fram:
     tags: drivers
     depends_on: i2c
     filter: dt_alias_exists("i2c-0")

--- a/samples/drivers/i2c_scanner/sample.yaml
+++ b/samples/drivers/i2c_scanner/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: I2C scanner
 tests:
-  sample.driver.i2c_scanner:
+  sample.drivers.i2c_scanner:
     platform_whitelist: nrf52840_blip nrf51_ble400
     tags: drivers
     depends_on: i2c

--- a/samples/drivers/kscan/sample.yaml
+++ b/samples/drivers/kscan/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: KSCAN driver sample
 tests:
-  sample.driver.kscan:
+  sample.drivers.kscan:
     tags: drivers
     harness: console
     harness_config:

--- a/samples/drivers/lcd_hd44780/sample.yaml
+++ b/samples/drivers/lcd_hd44780/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Display text strings on HD44780 based 20x4 LCD controller
 tests:
-  sample.driver.lcd_hd44780:
+  sample.drivers.lcd.hd44780:
     platform_whitelist: arduino_due
     tags: display
     harness: display

--- a/samples/drivers/led_apa102/sample.yaml
+++ b/samples/drivers/led_apa102/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: Demonstration of the APA102 LED strip driver
   name: APA102 sample
 tests:
-  sample.driver.led_apa102:
+  sample.drivers.led.apa102:
     platform_whitelist: nucleo_l432kc
     tags: LED
     depends_on: spi

--- a/samples/drivers/led_apa102c_bitbang/sample.yaml
+++ b/samples/drivers/led_apa102c_bitbang/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Utilize APA102C LED
 tests:
-  sample.driver.led_apa102c_bitbang:
+  sample.drivers.led.apa102c_bitbang:
     tags: LED
     filter: dt_alias_exists("gpio-0")
     depends_on: gpio

--- a/samples/drivers/led_lp3943/sample.yaml
+++ b/samples/drivers/led_lp3943/sample.yaml
@@ -2,6 +2,6 @@ sample:
   description: Demonstration of the LP3943 LED driver
   name: LP3943 sample
 tests:
-  sample.driver.led_lp3943:
+  sample.drivers.led.lp3943:
     platform_whitelist: 96b_neonkey 96b_argonkey
     tags: LED

--- a/samples/drivers/led_lp5562/sample.yaml
+++ b/samples/drivers/led_lp5562/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: Demonstration of the LP5562 LED driver
   name: LP5562 sample
 tests:
-  sample.driver.led_lp5562:
+  sample.drivers.led.lp5562:
     platform_whitelist: nrf52840_pca10056
     tags: led
     harness: TBD

--- a/samples/drivers/led_lpd8806/sample.yaml
+++ b/samples/drivers/led_lpd8806/sample.yaml
@@ -2,6 +2,6 @@ sample:
   description: Demonstration of the lpd880x LED driver
   name: LPD880x sample
 tests:
-  sample.driver.led_lpd8806:
+  sample.drivers.led.lpd8806:
     platform_whitelist: 96b_carbon
     tags: LED

--- a/samples/drivers/led_pca9633/sample.yaml
+++ b/samples/drivers/led_pca9633/sample.yaml
@@ -2,6 +2,6 @@ sample:
   description: Demonstration of the PCA9633 LED driver
   name: PCA9633 sample
 tests:
-  sample.driver.led_pca9633:
+  sample.drivers.led.pca9633:
     platform_whitelist: stm32373c_eval
     tags: LED

--- a/samples/drivers/led_ws2812/sample.yaml
+++ b/samples/drivers/led_ws2812/sample.yaml
@@ -2,6 +2,6 @@ sample:
   description: Demonstration of the WS2812 LED driver
   name: WS2812 sample
 tests:
-  sample.driver.led_ws2812:
+  sample.drivers.led.ws2812:
     platform_whitelist: 96b_carbon bbc_microbit
     tags: LED

--- a/samples/drivers/ps2/sample.yaml
+++ b/samples/drivers/ps2/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: PS2 driver  sample
 tests:
-  sample.driver.espi:
+  sample.drivers.espi.ps2:
     tags: drivers
     harness: console
     harness_config:

--- a/samples/drivers/soc_flash_nrf/sample.yaml
+++ b/samples/drivers/soc_flash_nrf/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   name: SoC Flash on NRF52
 tests:
-  sample.driver.soc_flash_nrf:
+  sample.drivers.flash.soc_flash_nrf::
     platform_whitelist: nrf52_pca10040 nrf9160_pca10090 nrf9160_pca10090ns
     tags: flash nrf52

--- a/samples/drivers/spi_flash/sample.yaml
+++ b/samples/drivers/spi_flash/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: SPI Flash Sample
 tests:
-  sample.driver.spi_flash:
+  sample.drivers.spi.flash:
     tags: spi flash
     filter: dt_compat_enabled("jedec,spi-nor")
     harness: console
@@ -16,7 +16,7 @@ tests:
             - "Data read 55 aa"
             - "Data read matches with data written. Good!!"
     depends_on: spi
-  sample.driver.spi_flash_dpd:
+  sample.drivers.spi.flash_dpd:
     tags: spi flash
     filter: dt_compat_enabled("jedec,spi-nor")
     build_only: true

--- a/samples/drivers/spi_fujitsu_fram/sample.yaml
+++ b/samples/drivers/spi_fujitsu_fram/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: SPI FRAM Module Sample
 tests:
-  sample.driver.spi_fujitsu_fram:
+  sample.drivers.spi.fujitsu_fram:
     tags: drivers fram
     harness: fram
     depends_on: gpio spi

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Watchdog Driver Sample
 tests:
-  sample.driver.watchdog:
+  sample.drivers.watchdog:
     tags: drivers
     harness: console
     harness_config:
@@ -14,7 +14,7 @@ tests:
             - "Watchdog sample application"
     depends_on: watchdog
     platform_exclude: nucleo_l496zg nucleo_f401re
-  sample.driver.window_watchdog_nucleo_l496zg:
+  sample.drivers.watchdog.nucleo_l496zg:
     tags: drivers
     harness: console
     harness_config:

--- a/samples/hello_world/sample.yaml
+++ b/samples/hello_world/sample.yaml
@@ -10,5 +10,5 @@ common:
       regex:
         - "Hello World! (.*)"
 tests:
-  sample.helloworld:
+  sample.basic.helloworld:
     tags: introduction

--- a/samples/philosophers/sample.yaml
+++ b/samples/philosophers/sample.yaml
@@ -13,30 +13,30 @@ common:
       - ".*THINKING.*"
       - ".*EATING.*"
 tests:
-  sample.philosopher:
+  sample.kernel.philosopher:
     tags: introduction
-  sample.philosopher.tracing:
+  sample.kernel.philosopher.tracing:
     min_ram: 32
     extra_configs:
       - CONFIG_SEGGER_SYSTEMVIEW=y
-  sample.philosopher.same_prio:
+  sample.kernel.philosopher.same_prio:
     extra_args: "-DSAME_PRIO=1"
-  sample.philosopher.static:
+  sample.kernel.philosopher.static:
     extra_args: "-DSTATIC_OBJS=1"
-  sample.philosopher.semaphores:
+  sample.kernel.philosopher.semaphores:
     extra_args: "-DFORKS=SEMAPHORES"
-  sample.philosopher.stacks:
+  sample.kernel.philosopher.stacks:
     extra_args: "-DFORKS=STACKS"
-  sample.philosopher.fifos:
+  sample.kernel.philosopher.fifos:
     extra_args: "-DFORKS=FIFOS"
-  sample.philosopher.lifos:
+  sample.kernel.philosopher.lifos:
     extra_args: "-DFORKS=LIFOS"
-  sample.philosopher.preempt_only:
+  sample.kernel.philosopher.preempt_only:
     extra_configs:
       - CONFIG_NUM_PREEMPT_PRIORITIES=6
       - CONFIG_NUM_COOP_PRIORITIES=0
       - CONFIG_BT=n
-  sample.philosopher.coop_only:
+  sample.kernel.philosopher.coop_only:
     extra_configs:
       - CONFIG_NUM_PREEMPT_PRIORITIES=0
       - CONFIG_NUM_COOP_PRIORITIES=6

--- a/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
+++ b/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: CMSIS_RTOS_V1 Dining Philosophers
 common:
   extra_args: "-DDEBUG_PRINTF=1"
-  tags: cmsis_rtos_v1_philosopher
+  tags: cmsis_rtos
   min_ram: 32
   min_flash: 34
   platform_exclude: qemu_xtensa qemu_x86_64
@@ -16,9 +16,9 @@ common:
       - ".*THINKING.*"
       - ".*EATING.*"
 tests:
-  sample.philosopher:
-    tags: cmsis_rtos_v1_philosopher
-  sample.philosopher.same_prio:
+  sample.portability.cmsis_rtos_v1.philosopher:
+    tags: cmsis_rtos
+  sample.portability.cmsis_rtos_v1.philosopher.same_prio:
     extra_args: "-DSAME_PRIO=1"
-  sample.philosopher.semaphores:
+  sample.portability.cmsis_rtos_v1.philosopher.semaphores:
     extra_args: "-DFORKS=SEMAPHORES"

--- a/samples/portability/cmsis_rtos_v1/timer_synchronization/sample.yaml
+++ b/samples/portability/cmsis_rtos_v1/timer_synchronization/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: CMSIS_RTOS_V1 Synchronization
 tests:
   sample.portability.cmsis_rtos_v1.timer_synchronization:
-    tags: cmsis_rtos_v1_synchronization
+    tags: cmsis_rtos
     min_ram: 32
     min_flash: 34
     harness: console

--- a/samples/portability/cmsis_rtos_v2/philosophers/sample.yaml
+++ b/samples/portability/cmsis_rtos_v2/philosophers/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: CMSIS_RTOS_V2 Dining Philosophers
 common:
   extra_args: "-DDEBUG_PRINTF=1"
-  tags: cmsis_rtos_v2_philosopher
+  tags: cmsis_rtos
   min_ram: 32
   min_flash: 34
   platform_exclude: qemu_xtensa qemu_x86_64
@@ -16,9 +16,9 @@ common:
       - ".*THINKING.*"
       - ".*EATING.*"
 tests:
-  sample.philosopher:
-    tags: cmsis_rtos_v2_philosopher
-  sample.philosopher.same_prio:
+  sample.portability.cmsis_rtos_v2.philosopher:
+    tags: cmsis_rtos
+  sample.portability.cmsis_rtos_v2.philosopher.same_prio:
     extra_args: "-DSAME_PRIO=1"
-  sample.philosopher.semaphores:
+  sample.portability.cmsis_rtos_v2.philosopher.semaphores:
     extra_args: "-DFORKS=SEMAPHORES"

--- a/samples/portability/cmsis_rtos_v2/timer_synchronization/sample.yaml
+++ b/samples/portability/cmsis_rtos_v2/timer_synchronization/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: CMSIS_RTOS_V2 Synchronization
 tests:
   sample.portability.cmsis_rtos_v2.timer_synchronization:
-    tags: cmsis_rtos_v2_synchronization
+    tags: cmsis_rtos
     min_ram: 32
     min_flash: 34
     harness: console

--- a/samples/sensor/ams_iAQcore/sample.yaml
+++ b/samples/sensor/ams_iAQcore/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: Demonstration of the AMS iAQ-core Digital VOC Sensor driver
   name: iAQcore sample
 tests:
-  sample.iAQcore:
+  sample.sensor.iaqcore:
     harness: sensor
     tags: samples
     depends_on: i2c arduino_i2c

--- a/samples/sensor/bme680/sample.yaml
+++ b/samples/sensor/bme680/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: BME680 Sensor sample
 tests:
-  sample.bme680:
+  sample.sensor.bme680:
     harness: sensor
     tags: samples sensor
     depends_on: i2c bme680

--- a/samples/sensor/ens210/sample.yaml
+++ b/samples/sensor/ens210/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: Demonstration of the AMS Temperature and Humidity Sensor driver
   name: ENS210 sample
 tests:
-  sample.ens210:
+  sample.sensor.ens210:
     harness: sensor
     tags: samples
     depends_on: i2c arduino_i2c

--- a/samples/sensor/fxos8700-hid/sample.yaml
+++ b/samples/sensor/fxos8700-hid/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: USB HID accelerometer mouse sample
 tests:
-  sample.usb.hid-mouse:
+  sample.sensor.usb.fxos8700-hid:
     depends_on: usb_device
     platform_whitelist: frdm_k64f
     harness: usb

--- a/samples/sensor/ti_hdc/sample.yaml
+++ b/samples/sensor/ti_hdc/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: TI HDC Humidity/Temperature Sensor
 tests:
-  test_build:
+  sample.sensor.ti_hdc:
     harness: sensor
     platform_whitelist: reel_board nucleo_l496zg
     tags: sensors

--- a/samples/sensor/tmp116/sample.yaml
+++ b/samples/sensor/tmp116/sample.yaml
@@ -1,11 +1,6 @@
 sample:
   name: TI TMP116 Sensor Sample
 tests:
-  test_build:
-    harness: sensor
-    platform_whitelist: nucleo_f401re
-    tags: sensors
-    depends_on: i2c
   sample.sensor.tmp116:
     harness: console
     platform_whitelist: nucleo_f401re

--- a/samples/shields/x_nucleo_iks01a2/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a2/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: X-NUCLEO-IKS01A2 sensor shield
 tests:
-  sample.shields.x_nucleo_iks01a2:
+  sample.shields..x_nucleo_iks01a2:
     harness: shield
     tags: shield
     depends_on: arduino_i2c arduino_gpio

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: X-NUCLEO-IKS01A3 sensor shield
 tests:
-  sample.shield.x_nucleo_iks01a3:
+  sample.shields.x_nucleo_iks01a3:
     harness: shield
     tags: shield
     depends_on: arduino_i2c arduino_gpio

--- a/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
@@ -3,7 +3,7 @@ sample:
 common:
   min_ram: 16
 tests:
-  sample.shield.x_nucleo_iks01a3:
+  sample.shields.x_nucleo_iks01a3:
     harness: shield
     tags: shield
     depends_on: arduino_i2c arduino_gpio

--- a/samples/smp/pi/sample.yaml
+++ b/samples/smp/pi/sample.yaml
@@ -13,6 +13,6 @@ common:
         - "Pi value calculated by thread #[0-9]+: [0-9]+(.*)"
         - "All [0-9]+ threads executed by [0-9]+ cores in [0-9]+ msec(.*)"
 tests:
-  sample.smp_pi:
+  sample.smp.pi:
     tags: introduction
     platform_whitelist: nsim_hs_smp qemu_x86_64

--- a/samples/subsys/console/echo/sample.yaml
+++ b/samples/subsys/console/echo/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: echo Sample
 tests:
-  sample.subsys.console.echo:
+  sample.console.echo:
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
     tags: console
     harness: keyboard

--- a/samples/subsys/console/getchar/sample.yaml
+++ b/samples/subsys/console/getchar/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: getchar sample
 tests:
-  sample.subsys.console.getchar:
+  sample.console.getchar:
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
     tags: console
     harness: keyboard

--- a/samples/subsys/console/getline/sample.yaml
+++ b/samples/subsys/console/getline/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: getline Sample
 tests:
-  sample.subsys.console.getline:
+  sample.console.getline:
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
     tags: console
     harness: keyboard

--- a/samples/subsys/fs/fat_fs/sample.yaml
+++ b/samples/subsys/fs/fat_fs/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Fat filesystem sample
 tests:
-  sample.subsys.fs.fat_fs:
+  sample.filesystem.fat_fs:
     build_only: true
     platform_whitelist: nrf52840_blip olimexino_stm32 mimxrt1050_evk
     tags: filesystem

--- a/samples/subsys/fs/littlefs/sample.yaml
+++ b/samples/subsys/fs/littlefs/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: littlefs filesystem sample
 tests:
-  sample.subsys.fs.littlefs:
+  sample.filesystem.littlefs:
     build_only: true
     platform_whitelist: nrf52840_pca10056 particle_xenon
     tags: filesystem

--- a/samples/subsys/ipc/ipm_imx/sample.yaml
+++ b/samples/subsys/ipc/ipm_imx/sample.yaml
@@ -3,7 +3,7 @@ sample:
         using the IPM and transmits it back unchanged
     name: i.MX IPM sample
 tests:
-    sample.subsys.ipc.ipm_imx:
+    sample.ipc.ipm.ipm_imx:
         build_only: true
         filter: CONFIG_SOC_FAMILY_IMX
         platform_whitelist: udoo_neo_full_m4 colibri_imx7d_m4 warp7_m4

--- a/samples/subsys/ipc/ipm_mcux/sample.yaml
+++ b/samples/subsys/ipc/ipm_mcux/sample.yaml
@@ -3,7 +3,7 @@ sample:
         the lpcxpresso54114 using a mailbox.
     name: IPM MCUX Mailbox Sample
 tests:
-    sample.subsys.ipc.ipm_mcux:
+    sample.ipc.ipm.ipm_mcux:
         platform_whitelist: lpcxpresso54114_m4
         tags: ipm
         harness: console

--- a/samples/subsys/ipc/ipm_mhu_dual_core/sample.yaml
+++ b/samples/subsys/ipc/ipm_mhu_dual_core/sample.yaml
@@ -3,6 +3,6 @@ sample:
     application
   name: ipm_mhu_dual_core
 tests:
-  sample.ipm:
+  sample.ipc.ipm.ipm_mhu_dual_core:
     tags: ipm
     platform_whitelist: v2m_musca v2m_musca_nonsecure v2m_musca_b1 v2m_musca_b1_nonsecure

--- a/samples/subsys/ipc/openamp/sample.yaml
+++ b/samples/subsys/ipc/openamp/sample.yaml
@@ -3,7 +3,7 @@ sample:
         with Zephyr.
     name: OpenAMP example integration
 tests:
-    sample.subsys.ipc.openamp:
+    sample.ipc.openamp:
         platform_whitelist: lpcxpresso54114_m4
         tags: ipm
         harness: console

--- a/samples/subsys/logging/logger/sample.yaml
+++ b/samples/subsys/logging/logger/sample.yaml
@@ -3,7 +3,7 @@ sample:
     use of logging feature.
   name: logger sample
 tests:
-  samples.logger:
+  sample.logger:
     tags: logging
     harness: console
     harness_config:
@@ -16,7 +16,7 @@ tests:
         - Logging performance showcase
         - Logs from external logging system showcase
 
-  samples.logger.rtt:
+  sample.logger.rtt:
     tags: logging
     filter: CONFIG_HAS_SEGGER_RTT
     harness: keyboard
@@ -24,7 +24,7 @@ tests:
       - CONFIG_LOG_BACKEND_RTT=y
       - CONFIG_USE_SEGGER_RTT=y
 
-  samples.logger.usermode:
+  sample.logger.usermode:
     tags: logging usermode
     filter: CONFIG_ARCH_HAS_USERSPACE
     harness: keyboard

--- a/samples/subsys/logging/syst/sample.yaml
+++ b/samples/subsys/logging/syst/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: syst sample
 tests:
-  sample.subsys.logging.syst:
+  sample.logger.syst:
     platform_whitelist: mps2_an385 sam_e70_xplained
     tags: logging
     harness: console

--- a/samples/subsys/nvs/sample.yaml
+++ b/samples/subsys/nvs/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: NVS Sample
 
 tests:
-  sample.subsys.nvs:
+  sample.nvs:
     tags: settings
     depends_on: nvs
     platform_exclude: qemu_x86

--- a/samples/subsys/shell/fs/sample.yaml
+++ b/samples/subsys/shell/fs/sample.yaml
@@ -2,5 +2,5 @@ sample:
   description: FS shell sample
   name: FS shell
 tests:
-  test_fs_shell:
+  sample.filesystem.shell:
     platform_whitelist: reel_board

--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -1,17 +1,17 @@
 sample:
   name: Shell Sample
 tests:
-  sample.subsys.shell.shell_module:
+  sample.shell.shell_module:
     filter: ( CONFIG_SERIAL and CONFIG_UART_SHELL_ON_DEV_NAME )
     tags: shell
     harness: keyboard
     min_ram: 40
-  sample.subsys.shell.shell_module.minimal:
+  sample.shell.shell_module.minimal:
     filter: ( CONFIG_SERIAL and CONFIG_UART_SHELL_ON_DEV_NAME )
     tags: shell
     harness: keyboard
     extra_args: CONF_FILE="prj_minimal.conf"
-  sample.subsys.shell.shell_module.minimal_rtt:
+  sample.shell.shell_module.minimal_rtt:
     filter: CONFIG_HAS_SEGGER_RTT
     tags: shell
     harness: keyboard

--- a/samples/subsys/usb/console/sample.yaml
+++ b/samples/subsys/usb/console/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   name: Console over USB
 tests:
-  sample.subsys.usb.console:
+  sample.usb.console:
     depends_on: usb_device usb_cdc
     tags: usb

--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: USB DFU sample
 tests:
-  sample.subsys.usb.dfu:
+  sample.usb.dfu:
     build_only: True
     platform_whitelist: nrf52840_pca10056 intel_s1000_crb
     depends_on: usb_device

--- a/samples/synchronization/sample.yaml
+++ b/samples/synchronization/sample.yaml
@@ -3,7 +3,7 @@ sample:
     basic sanity of the kernel.
   name: Synchronization Sample
 tests:
-  sample.synchronization:
+  sample.kernel.synchronization:
     build_on_all: true
     tags: kernel synchronization
     harness: console

--- a/samples/testing/integration/testcase.yaml
+++ b/samples/testing/integration/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
-  section.subsection:
+  # section.subsection
+  testing.ztest:
     build_only: true
-    tags: my_tags
+    platform_whitelist: native_posix
+    tags: testing

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -3821,7 +3821,7 @@ def main():
                 return
 
         elif options.list_tests:
-            for test in all_tests:
+            for test in sorted(all_tests):
                 cnt = cnt + 1
                 print(" - {}".format(test))
             print("{} total.".format(cnt))

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -193,6 +193,11 @@ from collections import OrderedDict
 from itertools import islice
 from pathlib import Path
 from distutils.spawn import find_executable
+try:
+    from anytree import Node, RenderTree, find
+except ImportError:
+    print("Install the anytree module to use the --test-tree option")
+
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 if not ZEPHYR_BASE:
@@ -1572,6 +1577,15 @@ class TestCase(object):
     def scan_path(self, path):
         subcases = []
         for filename in glob.glob(os.path.join(path, "src", "*.c")):
+            try:
+                _subcases, warnings = self.scan_file(filename)
+                if warnings:
+                    error("%s: %s" % (filename, warnings))
+                if _subcases:
+                    subcases += _subcases
+            except ValueError as e:
+                error("%s: can't find: %s" % (filename, e))
+        for filename in glob.glob(os.path.join(path, "*.c")):
             try:
                 _subcases, warnings = self.scan_file(filename)
                 if warnings:
@@ -3166,6 +3180,9 @@ Artificially long but functional example:
         and net.socket.fd_set belong to different directories.
         """)
 
+    case_select.add_argument("--test-tree", action="store_true",
+        help="""Output the testsuite in a tree form""")
+
     case_select.add_argument("--list-test-duplicates", action="store_true",
         help="""List tests with duplicate identifiers.
         """)
@@ -3789,7 +3806,7 @@ def main():
     if options.test:
         run_individual_tests = options.test
 
-    if options.list_tests or options.list_test_duplicates or options.sub_test:
+    if options.list_tests or options.test_tree or options.list_test_duplicates or options.sub_test:
         cnt = 0
         all_tests = suite.get_all_tests()
 
@@ -3820,11 +3837,46 @@ def main():
                 info("Tests not found")
                 return
 
-        elif options.list_tests:
+        elif options.list_tests or options.test_tree:
+            if options.test_tree:
+                testsuite = Node("Testsuite")
+                samples = Node("Samples", parent=testsuite)
+                tests = Node("Tests", parent=testsuite)
+
             for test in sorted(all_tests):
                 cnt = cnt + 1
-                print(" - {}".format(test))
-            print("{} total.".format(cnt))
+                if options.list_tests:
+                    print(" - {}".format(test))
+
+                if options.test_tree:
+                    if test.startswith("sample."):
+                        sec = test.split(".")
+                        area = find(samples, lambda node: node.name == sec[1] and node.parent == samples)
+                        if not area:
+                            area = Node(sec[1], parent=samples)
+
+                        t = Node(test, parent=area)
+                    else:
+                        sec = test.split(".")
+                        area = find(tests, lambda node: node.name == sec[0] and node.parent == tests)
+                        if not area:
+                            area = Node(sec[0], parent=tests)
+
+                        if area and len(sec) > 2:
+                            subarea = find(area, lambda node: node.name == sec[1] and node.parent == area)
+                            if not subarea:
+                                subarea = Node(sec[1], parent=area)
+
+                            t = Node(test, parent=subarea)
+
+            if options.list_tests:
+                print("{} total.".format(cnt))
+
+            if options.test_tree:
+                for pre, _, node in RenderTree(testsuite):
+                    print("%s%s" % (pre, node.name))
+
+
             return
 
     discards = []

--- a/tests/application_development/cpp/testcase.yaml
+++ b/tests/application_development/cpp/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  misc.app_dev.cpp:
+  application_development.cpp.main:
     arch_exclude: posix
     platform_exclude: qemu_x86_coverage
     tags: cpp

--- a/tests/application_development/libcxx/testcase.yaml
+++ b/tests/application_development/libcxx/testcase.yaml
@@ -1,10 +1,10 @@
 tests:
-  misc.app_dev.libcxx:
+  application_development.cpp.libcxx:
     arch_exclude: posix
     platform_exclude: qemu_x86_coverage
     min_flash: 54
     tags: cpp
-  misc.app_dev.libcxx.exceptions:
+  application_development.cpp.libcxx.exceptions:
     arch_exclude: posix
     platform_exclude: qemu_x86_coverage
     min_flash: 54

--- a/tests/arch/arm/arm_ramfunc/testcase.yaml
+++ b/tests/arch/arm/arm_ramfunc/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  arch.ramfunc:
+  arch.arm.ramfunc:
     filter: CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
     tags: arm userspace
     arch_whitelist: arm

--- a/tests/arch/arm/arm_zero_latency_irqs/testcase.yaml
+++ b/tests/arch/arm/arm_zero_latency_irqs/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  arch.zero_latency_interrupts:
+  arch.arm.zero_latency_interrupts:
     filter: CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     tags: arm interrupt
     arch_whitelist: arm

--- a/tests/benchmarks/app_kernel/testcase.yaml
+++ b/tests/benchmarks/app_kernel/testcase.yaml
@@ -1,12 +1,12 @@
 tests:
-  benchmark.application:
+  benchmark.kernel.application:
     arch_whitelist: x86 arm
     min_flash: 34
     min_ram: 32
     tags: benchmark
     slow: true
     timeout: 300
-  benchmark.application.posix:
+  benchmark.kernel.application.posix:
     arch_whitelist: posix
     min_ram: 32
     tags: benchmark

--- a/tests/benchmarks/boot_time/testcase.yaml
+++ b/tests/benchmarks/boot_time/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  benchmark.boot_time:
+  benchmark.kernel.boot_time:
     arch_whitelist: x86 arm posix
     platform_exclude: qemu_x86 qemu_x86_coverage qemu_x86_64 qemu_x86_nommu
       minnowboard acrn

--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  benchmark.latency:
+  benchmark.kernel.latency:
     arch_whitelist: x86 arm posix
     platform_exclude: qemu_x86_64
     filter: CONFIG_PRINTK

--- a/tests/benchmarks/mbedtls/testcase.yaml
+++ b/tests/benchmarks/mbedtls/testcase.yaml
@@ -2,5 +2,5 @@ common:
   harness: crypto
   tags: crypto
 tests:
-  benchmark.mbedtls:
+  benchmark.crypto.mbedtls:
     platform_whitelist: qemu_x86 frdm_k64f sam_e70_xplained nrf52840_pca10056

--- a/tests/benchmarks/sched/testcase.yaml
+++ b/tests/benchmarks/sched/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  benchmark.scheduler:
+  benchmark.kernel.scheduler:
     tags: benchmark
     slow: true
     harness: console

--- a/tests/benchmarks/sys_kernel/testcase.yaml
+++ b/tests/benchmarks/sys_kernel/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  benchmark.kernel:
+  benchmark.kernel.core:
     arch_exclude: nios2 riscv32 xtensa
     platform_exclude: qemu_x86_64
     min_ram: 32

--- a/tests/benchmarks/timing_info/testcase.yaml
+++ b/tests/benchmarks/timing_info/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  benchmark.timing.default_kernel:
+  benchmark.kernel.timing.default:
     arch_exclude: posix
     tags: benchmark
     harness: console
@@ -9,7 +9,7 @@ tests:
         regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
-  benchmark.timing.userspace:
+  benchmark.kernel.timing.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_args: CONF_FILE=prj_userspace.conf
     arch_whitelist: x86 arm arc

--- a/tests/bluetooth/mesh/testcase.yaml
+++ b/tests/bluetooth/mesh/testcase.yaml
@@ -1,39 +1,39 @@
 tests:
-  mesh:
+  bluetooth.mesh.main:
     build_only: true
     platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
     tags: bluetooth mesh
-  mesh.dbg:
+  bluetooth.mesh.dbg:
     build_only: true
     extra_args: CONF_FILE=dbg.conf
     platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
     tags: bluetooth mesh
-  mesh.friend:
+  bluetooth.mesh.friend:
     build_only: true
     extra_args: CONF_FILE=friend.conf
     platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
     tags: bluetooth mesh
-  mesh.gatt:
+  bluetooth.mesh.gatt:
     build_only: true
     extra_args: CONF_FILE=gatt.conf
     platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
     tags: bluetooth mesh
-  mesh.lpn:
+  bluetooth.mesh.lpn:
     build_only: true
     extra_args: CONF_FILE=lpn.conf
     platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
     tags: bluetooth mesh
-  mesh.microbit:
+  bluetooth.mesh.main.microbit:
     build_only: true
     extra_args: CONF_FILE=microbit.conf
     platform_whitelist: bbc_microbit
     tags: bluetooth mesh
-  mesh.pb_gatt:
+  bluetooth.mesh.pb_gatt:
     build_only: true
     extra_args: CONF_FILE=pb_gatt.conf
     platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
     tags: bluetooth mesh
-  mesh.proxy:
+  bluetooth.mesh.proxy:
     build_only: true
     extra_args: CONF_FILE=proxy.conf
     platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056

--- a/tests/bluetooth/mesh_shell/testcase.yaml
+++ b/tests/bluetooth/mesh_shell/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  bluetooth.mesh_shell:
+  bluetooth.mesh.mesh_shell:
     platform_whitelist: qemu_cortex_m3 qemu_x86 nrf51_pca10028
     platform_exclude: nrf52810_pca10040
     tags: bluetooth

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  bluetooth.shell:
+  bluetooth.shell.main:
     extra_configs:
       - CONFIG_NATIVE_UART_0_ON_STDINOUT=y
     platform_whitelist: qemu_cortex_m3 qemu_x86 native_posix native_posix_64 nrf52840_pca10056
@@ -7,7 +7,7 @@ tests:
     tags: bluetooth
     harness: keyboard
     min_flash: 145
-  bluetooth.shell_br:
+  bluetooth.shell.shell_br:
     extra_configs:
       - CONFIG_NATIVE_UART_0_ON_STDINOUT=y
     extra_args: CONF_FILE="prj_br.conf"

--- a/tests/boards/board_shell/testcase.yaml
+++ b/tests/boards/board_shell/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  board.shell:
+  boards.shell.shell:
     tags: shell
     harness: keyboard
     platform_whitelist: nrf52840_pca10056 frdm_k64f

--- a/tests/boards/intel_s1000_crb/testcase.yaml
+++ b/tests/boards/intel_s1000_crb/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  boards.s1000_crb:
+  boards.s1000_crb.main:
     platform_whitelist: intel_s1000_crb
     tags: boards

--- a/tests/drivers/adc/adc_api/testcase.yaml
+++ b/tests/drivers/adc/adc_api/testcase.yaml
@@ -1,5 +1,5 @@
 common:
   tags: adc drivers userspace
 tests:
-  peripheral.adc:
+  drivers.adc:
     depends_on: adc

--- a/tests/drivers/build_all/testcase.yaml
+++ b/tests/drivers/build_all/testcase.yaml
@@ -1,72 +1,72 @@
 common:
   depends_on: gpio spi i2c
 tests:
-  test_build_drivers:
+  drivers.build.build:
     build_only: true
     min_ram: 16
-    tags: drivers footprint
+    tags: drivers
     depends_on: adc i2c
-  test_build_ethernet:
+  net.ethernet.build:
     build_only: true
     extra_args: CONF_FILE=ethernet.conf
     min_flash: 42
     min_ram: 32
     platform_exclude:  frdm_kw41z
-    tags: drivers footprint
+    tags: drivers
     depends_on: spi netif
-  test_build_sensors_trigger_a_h:
+  sensors.build.trigger_a_h:
     build_only: true
     extra_args: CONF_FILE=sensors_trigger_a_h.conf
     min_ram: 32
     platform_exclude:  frdm_kw41z
-    tags: drivers footprint
+    tags: drivers
     depends_on: adc spi
-  test_build_sensors_trigger_i_z:
+  sensors.build.trigger_i_z:
     build_only: true
     extra_args: CONF_FILE=sensors_trigger_i_z.conf
     min_ram: 32
     platform_exclude:  frdm_kw41z
-    tags: drivers footprint
+    tags: drivers
     depends_on: adc spi
-  test_build_sensors_a_h:
+  sensors.build.a_h:
     build_only: true
     extra_args: CONF_FILE=sensors_a_h.conf
     min_flash: 44
     min_ram: 32
     platform_exclude:  frdm_kw41z
-    tags: drivers footprint
+    tags: drivers
     depends_on: adc spi
-  test_build_sensors_i_z:
+  sensors.build.i_z:
     build_only: true
     extra_args: CONF_FILE=sensors_i_z.conf
     min_ram: 32
     platform_exclude:  frdm_kw41z
-    tags: drivers footprint
+    tags: drivers
     depends_on: adc spi
-  test_build_sensors_stmemsc:
+  sensors.build.stmemsc:
     build_only: true
     extra_args: CONF_FILE=sensors_stmemsc.conf
     min_ram: 32
     platform_exclude:  frdm_kw41z
-    tags: drivers footprint
+    tags: drivers
     depends_on: adc spi
-  test_build_sensors_stmemsc_trigger:
+  sensors.build.stmemsc_trigger:
     build_only: true
     extra_args: CONF_FILE=sensors_stmemsc_trigger.conf
     min_ram: 32
     platform_exclude:  frdm_kw41z
-    tags: drivers footprint
+    tags: drivers
     depends_on: adc spi
-  test_clock:
+  drivers.clock.build:
     build_only: true
     extra_configs:
       - CONFIG_CLOCK_CONTROL=y
-  test_build_gpio:
+  drivers.gpio.build:
     build_only: true
     extra_args: CONF_FILE=gpio.conf
     min_ram: 32
     depends_on: gpio
-  test_build_eeprom:
+  drivers.eeprom.build:
     build_only: true
     extra_args: CONF_FILE=eeprom.conf
     min_ram: 32

--- a/tests/drivers/can/api/testcase.yaml
+++ b/tests/drivers/can/api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  peripheral.can:
+  drivers.can:
     tags: driver can
     depends_on: can

--- a/tests/drivers/can/stm32/testcase.yaml
+++ b/tests/drivers/can/stm32/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  peripheral.can.stm32:
+  drivers.can.stm32:
     tags: driver can
     depends_on: can

--- a/tests/drivers/clock_control/clock_control_api/testcase.yaml
+++ b/tests/drivers/clock_control/clock_control_api/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
-  peripheral.clock_control_nrf5:
+  drivers.clock.clock_control_nrf5:
     tags: drivers
     platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
                         nrf9160_pca10090
-  peripheral.clock_control_nrf5_lfclk_rc:
+  drivers.clock.clock_control_nrf5_lfclk_rc:
     tags: drivers
     platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
     extra_args: CONF_FILE="nrf_lfclk_rc.conf"

--- a/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  peripheral.nrf5_clock_calibration:
+  drivers.clock.nrf5_clock_calibration:
     tags: drivers
     platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
 

--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  peripheral.counter:
+  drivers.counter:
     tags: drivers
     depends_on: counter
     min_ram: 16

--- a/tests/drivers/counter/counter_cmos/testcase.yaml
+++ b/tests/drivers/counter/counter_cmos/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  counter.cmos:
+  drivers.counter.cmos:
     tags: drivers
     arch_whitelist: x86

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  peripheral.counter:
+  drivers.counter:
     tags: drivers
     depends_on: counter
     platform_whitelist: nrf52840_pca0056

--- a/tests/drivers/dma/chan_blen_transfer/testcase.yaml
+++ b/tests/drivers/dma/chan_blen_transfer/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
-  peripheral.dma:
+  drivers.dma:
     min_ram: 16
     depends_on: dma
     tags: drivers dma
-  peripheral.dma.interactive:
+  drivers.dma.interactive:
     depends_on: dma
     extra_args: CONF_FILE=prj_shell.conf
     min_ram: 16

--- a/tests/drivers/dma/loop_transfer/testcase.yaml
+++ b/tests/drivers/dma/loop_transfer/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  driver.dma.loop_transfer:
+  drivers.dma.loop_transfer:
     depends_on: dma
     tags: drivers dma
     harness: console

--- a/tests/drivers/eeprom/testcase.yaml
+++ b/tests/drivers/eeprom/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  peripheral.eeprom:
+  drivers.eeprom:
     platform_whitelist: native_posix native_posix_64
     tags: drivers userspace

--- a/tests/drivers/entropy/api/testcase.yaml
+++ b/tests/drivers/entropy/api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  peripheral.entropy:
+  drivers.entropy:
     filter: CONFIG_ENTROPY_HAS_DRIVER
     tags: driver

--- a/tests/drivers/flash_simulator/testcase.yaml
+++ b/tests/drivers/flash_simulator/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  peripheral.flash_simulator:
+  drivers.flash.flash_simulator:
     platform_whitelist: qemu_x86
     tags: driver

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  peripheral.gpio:
+  drivers.gpio:
     tags: drivers gpio
     depends_on: gpio
     harness: loopback # see documentation

--- a/tests/drivers/hwinfo/api/testcase.yaml
+++ b/tests/drivers/hwinfo/api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  peripheral.device_id:
+  drivers.device_id:
     tags: driver
     depends_on: hwinfo

--- a/tests/drivers/i2c/i2c_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  peripheral.i2c:
+  drivers.i2c:
     depends_on: i2c
     tags: drivers i2c
     harness: sensor

--- a/tests/drivers/i2c/i2c_slave_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_slave_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  peripheral.i2c_slave:
+  drivers.i2c_slave:
     depends_on: i2c
     tags: drivers i2c
     platform_whitelist: nucleo_f091rc stm32f072b_disco

--- a/tests/drivers/i2s/i2s_api/testcase.yaml
+++ b/tests/drivers/i2s/i2s_api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  peripheral.i2s:
+  drivers.i2s:
     depends_on: i2s
     tags: drivers userspace

--- a/tests/drivers/i2s/i2s_speed/testcase.yaml
+++ b/tests/drivers/i2s/i2s_speed/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  peripheral.i2s.speed:
+  drivers.i2s.speed:
     depends_on: i2s
     tags: drivers i2s

--- a/tests/drivers/ipm/testcase.yaml
+++ b/tests/drivers/ipm/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  peripheral.mailbox:
+  drivers.ipc.mailbox:
     arch_exclude: posix xtensa
     tags: drivers ipc

--- a/tests/drivers/kscan/kscan_api/testcase.yaml
+++ b/tests/drivers/kscan/kscan_api/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
-  peripheral.kscan:
+  drivers.kscan:
     tags: drivers kscan userspace
     depends_on: kscan
     platform_exclude: mec15xxevb_assy6853
-  peripheral.kscan.mec15xxevb_assy6853:
+  drivers.kscan.mec15xxevb_assy6853:
     depends_on: kscan
     tags: drivers kscan
     extra_args: CONF_FILE="mec15xxevb_assy6853.conf"

--- a/tests/drivers/pinmux/pinmux_basic_api/testcase.yaml
+++ b/tests/drivers/pinmux/pinmux_basic_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  peripheral.pinmux:
+  drivers.pinmux:
     tags: drivers
     harness: loopback
     filter: dt_alias_exists("gpio-0") or dt_alias_exists("gpio-1")

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  peripheral.pwm:
+  drivers.pwm:
     tags: drivers pwm
     filter: dt_alias_exists("pwm-0") or
             dt_alias_exists("pwm-1") or

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -427,7 +427,7 @@ static int spi_resource_lock_test(struct device *lock_dev,
 	return 0;
 }
 
-void testing_spi(void)
+void test_spi_loopback(void)
 {
 #if (CONFIG_SPI_ASYNC)
 	struct k_thread async_thread;
@@ -500,6 +500,6 @@ end:
 /*test case main entry*/
 void test_main(void)
 {
-	ztest_test_suite(test_spi, ztest_unit_test(testing_spi));
+	ztest_test_suite(test_spi, ztest_unit_test(test_spi_loopback));
 	ztest_run_test_suite(test_spi);
 }

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  peripheral.spi:
+  drivers.spi:
     depends_on: spi
     tags: drivers spi
     harness: loopback

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  peripheral.uart_async_api:
+  drivers.uart.uart_async_api:
     tags: drivers
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC
     harness: keyboard

--- a/tests/drivers/uart/uart_basic_api/testcase.yaml
+++ b/tests/drivers/uart/uart_basic_api/testcase.yaml
@@ -1,14 +1,14 @@
 tests:
-  peripheral.uart:
+  drivers.uart:
     tags: drivers
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
-  peripheral.uart.poll:
+  drivers.uart.poll:
     extra_args: CONF_FILE=prj_poll.conf
     tags: drivers
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
-  peripheral.uart.shell:
+  drivers.uart.shell:
     extra_args: CONF_FILE=prj_shell.conf
     min_flash: 64
     tags: drivers

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -1,10 +1,10 @@
 tests:
-  peripheral.watchdog:
+  drivers.watchdog:
     depends_on: watchdog
     tags: drivers watchdog
     filter: not CONFIG_WDT_SAM
     platform_exclude: nucleo_l496zg nucleo_f401re
-  peripheral.window_watchdog_nucleo_l496zg:
+  drivers.watchdog.nucleo_l496zg:
     depends_on: watchdog
     tags: drivers watchdog
     extra_args: CONF_FILE="prj.conf;nucleo_l496zg.conf"

--- a/tests/kernel/context/testcase.yaml
+++ b/tests/kernel/context/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kernel.context:
+  kernel.common:
     tags: kernel
     min_ram: 20

--- a/tests/kernel/critical/testcase.yaml
+++ b/tests/kernel/critical/testcase.yaml
@@ -2,14 +2,14 @@ common:
   tags: kernel
 
 tests:
-  kernel.critical:
+  kernel.common.critical:
     platform_exclude: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
     filter: not CONFIG_WDT_SAM
-  kernel.critical.sam:
+  kernel.common.critical.sam:
     filter: CONFIG_WDT_SAM
     extra_configs:
      - CONFIG_WDT_DISABLE_AT_BOOT=y
-  kernel.critical.nsim:
+  kernel.common.critical.nsim:
     platform_whitelist: nsim_sem_mpu_stack_guard nsim_em_mpu_stack_guard
     extra_configs:
       - CONFIG_TEST_HW_STACK_PROTECTION=n

--- a/tests/kernel/early_sleep/testcase.yaml
+++ b/tests/kernel/early_sleep/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.sleep:
+  kernel.common.sleep:
     tags: kernel sleep

--- a/tests/kernel/fp_sharing/generic/testcase.yaml
+++ b/tests/kernel/fp_sharing/generic/testcase.yaml
@@ -1,18 +1,18 @@
 tests:
-  kernel.fp_sharing:
+  kernel.float.fp_sharing:
     extra_args: PI_NUM_ITERATIONS=70000
     filter: CONFIG_ARMV7_M_ARMV8_M_FP
     slow: true
     tags: kernel
     timeout: 600
     min_ram: 16
-  kernel.fp_sharing.x86:
+  kernel.float.fp_sharing.x86:
     extra_args: CONF_FILE=prj_x86.conf
     platform_whitelist: qemu_x86
     slow: true
     tags: kernel
     timeout: 600
-  kernel.fp_sharing.arc:
+  kernel.float.fp_sharing.arc:
     extra_args: PI_NUM_ITERATIONS=500
     filter: CONFIG_CPU_ARCV2 and CONFIG_CPU_HAS_FPU
     slow: true

--- a/tests/kernel/mem_slab/mslab/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kernel.memory_slabs.api.test:
+  kernel.memory_slabs.api:
     tags: kernel
     min_ram: 16

--- a/tests/kernel/mutex/sys_mutex/testcase.yaml
+++ b/tests/kernel/mutex/sys_mutex/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
-  sys.mutex:
+  system.mutex:
     min_ram: 32
     filter: CONFIG_ARCH_HAS_USERSPACE
     tags: kernel userspace
-  sys.mutex.nouser:
+  system.mutex.nouser:
     tags: kernel
     extra_configs:
       - CONFIG_TEST_USERSPACE=n

--- a/tests/kernel/obj_tracing/testcase.yaml
+++ b/tests/kernel/obj_tracing/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kernel.object_tracing:
+  kernel.objects.tracing:
     min_ram: 32
     tags: kernel

--- a/tests/kernel/pending/src/main.c
+++ b/tests/kernel/pending/src/main.c
@@ -287,7 +287,7 @@ void task_low(void)
  *
  * @see k_sleep(), K_THREAD_DEFINE()
  */
-void test_pending(void)
+void test_pending_fifo(void)
 {
 	/*
 	 * Main thread(test_main) priority was 9 but ztest thread runs at
@@ -297,7 +297,6 @@ void test_pending(void)
 	k_thread_priority_set(k_current_get(), 9);
 
 	struct offload_work offload1 = {0};
-	struct offload_work offload2 = {0};
 
 	k_work_init(&offload1.work_item, sync_threads);
 	offload1.sem = &start_test_sem;
@@ -352,6 +351,20 @@ void test_pending(void)
 		      (task_high_state != FIFO_TEST_END + 3) ||
 		      (task_low_state != FIFO_TEST_END + 4),
 		      "**** Unexpected delivery order");
+}
+
+
+void test_pending_lifo(void)
+{
+	/*
+	 * Main thread(test_main) priority was 9 but ztest thread runs at
+	 * priority -1. To run the test smoothly make both main and ztest
+	 * threads run at same priority level.
+	 */
+	k_thread_priority_set(k_current_get(), 9);
+
+	struct offload_work offload1 = {0};
+	struct offload_work offload2 = {0};
 
 	k_work_init(&offload1.work_item, sync_threads);
 	offload1.sem = &end_test_sem;
@@ -406,6 +419,19 @@ void test_pending(void)
 		      (task_low_state != LIFO_TEST_END + 4),
 		      "**** Unexpected timeout order");
 
+}
+
+void test_pending_timer(void)
+{
+	/*
+	 * Main thread(test_main) priority was 9 but ztest thread runs at
+	 * priority -1. To run the test smoothly make both main and ztest
+	 * threads run at same priority level.
+	 */
+	k_thread_priority_set(k_current_get(), 9);
+
+	struct offload_work offload2 = {0};
+
 	k_work_init(&offload2.work_item, sync_threads);
 	offload2.sem = &end_test_sem;
 	k_work_submit_to_queue(&offload_work_q, &offload2.work_item);
@@ -440,7 +466,10 @@ void test_pending(void)
 void test_main(void)
 {
 	ztest_test_suite(pend,
-			ztest_1cpu_unit_test(test_pending));
+			ztest_1cpu_unit_test(test_pending_fifo),
+			ztest_1cpu_unit_test(test_pending_lifo),
+			ztest_1cpu_unit_test(test_pending_timer)
+			);
 	ztest_run_test_suite(pend);
 }
 

--- a/tests/kernel/pending/testcase.yaml
+++ b/tests/kernel/pending/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kernel.pending:
+  kernel.objects:
     min_ram: 16
     tags: kernel

--- a/tests/kernel/profiling/profiling_api/testcase.yaml
+++ b/tests/kernel/profiling/profiling_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  kernel.profiling:
+  kernel.common.profiling:
     arch_exclude: nios2 riscv32
     platform_exclude: em_starterkit
     tags: kernel

--- a/tests/kernel/sched/deadline/testcase.yaml
+++ b/tests/kernel/sched/deadline/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.sched.deadline:
+  kernel.scheduler.deadline:
     tags: kernel

--- a/tests/kernel/sched/metairq/testcase.yaml
+++ b/tests/kernel/sched/metairq/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  kernel.sched.metairq:
+  kernel.scheduler.metairq:
     tags: kernel
     filter: not CONFIG_SMP
     platform_exclude: nrf52810_pca10040

--- a/tests/kernel/sched/preempt/testcase.yaml
+++ b/tests/kernel/sched/preempt/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  kernel.sched.preempt:
+  kernel.scheduler.preempt:
     tags: kernel
     filter: not CONFIG_SMP
     platform_exclude: nrf52810_pca10040

--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -1,23 +1,23 @@
 tests:
-  kernel.sched:
+  kernel.scheduler:
     filter: not CONFIG_SCHED_MULTIQ
     extra_configs:
       - CONFIG_TIMESLICING=y
     min_ram: 40
     tags: kernel threads sched userspace
-  kernel.sched_no_timeslicing:
+  kernel.scheduler.no_timeslicing:
     filter: not CONFIG_SCHED_MULTIQ
     extra_configs:
       - CONFIG_TIMESLICING=n
     min_ram: 40
     tags: kernel threads sched userspace
-  kernel.sched.multiq:
+  kernel.scheduler.multiq:
     extra_args: CONF_FILE=prj_multiq.conf
     extra_configs:
       - CONFIG_TIMESLICING=y
     min_ram: 40
     tags: kernel threads sched userspace
-  kernel.sched.multiq_no_timeslicing:
+  kernel.scheduler.multiq_no_timeslicing:
     extra_args: CONF_FILE=prj_multiq.conf
     extra_configs:
       - CONFIG_TIMESLICING=n

--- a/tests/kernel/sleep/testcase.yaml
+++ b/tests/kernel/sleep/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  kernel.timing:
+  kernel.common.timing:
     tags: kernel sleep

--- a/tests/misc/test_build/testcase.yaml
+++ b/tests/misc/test_build/testcase.yaml
@@ -1,17 +1,17 @@
 tests:
-  test_debug:
+  buildsystem.debug.build:
     build_only: true
     extra_args: CONF_FILE=debug.conf
-    tags: build_test
-  test_mcuboot_bootloader:
-    tags: build_test
+    tags: debug
+  bootloader.mcuboot.build:
+    tags: mcuboot
     build_only: true
     platform_whitelist: nrf51_pca10028 nrf52_pca10040
     extra_configs:
       - CONFIG_BOOTLOADER_MCUBOOT=y
-  test_utf8_in_kconfig_values:
+  buildsystem.kconfig.utf8_in_values:
     build_only: true
-    tags: build_test
+    tags: kconfig
     platform_whitelist: native_posix
     extra_configs:
       - CONFIG_KERNEL_BIN_NAME="A_kconfig_value_with_a_utf8_char_in_it_Bøe_"

--- a/tests/net/lib/coap/testcase.yaml
+++ b/tests/net/lib/coap/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  net.coap:
+  net.coap.simple:
     min_ram: 16
     tags: net
     depends_on: netif

--- a/tests/net/tcp/testcase.yaml
+++ b/tests/net/tcp/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  net.tcp:
+  net.tcp.simple:
     depends_on: netif
     tags: net tcp

--- a/tests/portability/cmsis_rtos_v1/testcase.yaml
+++ b/tests/portability/cmsis_rtos_v1/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   portability.cmsis_rtos_v1:
-    tags: cmsis_rtos_v1
+    tags: cmsis_rtos
     min_ram: 32
     min_flash: 34

--- a/tests/portability/cmsis_rtos_v2/testcase.yaml
+++ b/tests/portability/cmsis_rtos_v2/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   portability.cmsis_rtos_v2:
     platform_exclude: qemu_x86_64 m2gl025_miv
-    tags: cmsis_rtos_v2
+    tags: cmsis_rtos
     min_ram: 32
     min_flash: 34

--- a/tests/shell/testcase.yaml
+++ b/tests/shell/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  shell:
+  shell.core:
     min_flash: 64
     min_ram: 32
     filter: ( CONFIG_SHELL )

--- a/tests/subsys/debug/tracing/testcase.yaml
+++ b/tests/subsys/debug/tracing/testcase.yaml
@@ -7,20 +7,20 @@ common:
         - "thread_a: Hello World from (.*)!"
         - "thread_b: Hello World from (.*)!"
 tests:
-  tracing.sysview:
+  tracing.backends.sysview:
     platform_whitelist: nrf52840_pca10056
     extra_configs:
       - CONFIG_SEGGER_SYSTEMVIEW=y
       - CONFIG_USE_SEGGER_RTT=y
-  tracing.ctf:
+  tracing.backends.ctf:
     platform_whitelist: native_posix
     extra_configs:
       - CONFIG_TRACING_CTF=y
-  tracing.cpu_stats:
+  tracing.backends.cpu_stats:
     platform_whitelist: nrf52840_pca10056
     extra_configs:
       - CONFIG_TRACING_CPU_STATS=y
-  tracing.openocd:
+  tracing.backends.openocd:
     extra_configs:
       - CONFIG_OPENOCD_SUPPORT=y
     arch_exclude: posix xtensa

--- a/tests/subsys/storage/flash_map/testcase.yaml
+++ b/tests/subsys/storage/flash_map/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   storage.flash_map:
     platform_whitelist: nrf51_pca10028 qemu_x86 native_posix native_posix_64
     tags: flash_map
-  storage.flash_map_mpu:
+  storage.flash_map.mpu:
     extra_args: OVERLAY_CONFIG=overlay-mpu.conf
     platform_whitelist: nrf52840_pca10056 nrf52_pca10040 frdm_k64f hexiwear_k64
                         twr_ke18f

--- a/tests/unit/base64/testcase.yaml
+++ b/tests/unit/base64/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  libraries.encoding.base64:
+  utilities.base64:
     tags: base64
     type: unit

--- a/tests/unit/crc/testcase.yaml
+++ b/tests/unit/crc/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  misc.crc:
+  utilities.crc:
     tags: net crc
     type: unit

--- a/tests/unit/math_extras/testcase.yaml
+++ b/tests/unit/math_extras/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  misc.math_extras:
+  utilities.math:
     timeout: 5
     type: unit

--- a/tests/unit/rbtree/testcase.yaml
+++ b/tests/unit/rbtree/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  libraries.data_structures.rbtree:
+  utilities.red_black_tree:
     tags: rbtree
     type: unit

--- a/tests/unit/timeutil/testcase.yaml
+++ b/tests/unit/timeutil/testcase.yaml
@@ -3,8 +3,8 @@ common:
   type: unit
 
 tests:
-  lib.os.timeutil:
+  utilities.time:
     extra_args: M64_MODE=0
 
-  lib.os.timeutil_64bit:
+  utilities.time.64bit:
     extra_args: M64_MODE=1

--- a/tests/unit/util/testcase.yaml
+++ b/tests/unit/util/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  libraries.sys.util.dec:
+  utilities.dec:
     tags: lib_sys_util_tests
     type: unit


### PR DESCRIPTION
Use sanitycheck to show tests in a tree structure that can be synced with testrail in the future.

This now can be done using sanitycheck --test-tree  -T tests/kernel/ for example, which will spit out something like that:

```
Testsuite
├── Samples
└── Tests
    ├── arch
    │   ├── common
    │   │   ├── arch.common.xip.globals
    │   │   └── arch.common.xip.nondefault.globals
    │   └── interrupt
    │       ├── arch.interrupt.arc
    │       ├── arch.interrupt.gen_isr_table
    │       ├── arch.interrupt.isr_dynamic
    │       ├── arch.interrupt.nested_isr
    │       ├── arch.interrupt.nodyn.isr_dynamic
    │       ├── arch.interrupt.nodyn.nested_isr
    │       ├── arch.interrupt.nodyn.prevent_interruption
    │       └── arch.interrupt.prevent_interruption
    ├── kernel
    │   ├── common
    │   │   ├── kernel.common.atomic
    │   │   ├── kernel.common.bitfield
    │   │   ├── kernel.common.bounds_check_mitigation
    │   │   ├── kernel.common.busy_wait
    │   │   ├── kernel.common.byteorder_mem_swap
    │   │   ├── kernel.common.byteorder_memcpy_swap
    │   │   ├── kernel.common.clock_cycle
    │   │   ├── kernel.common.clock_uptime
    │   │   ├── kernel.common.critical.critical
    │   │   ├── kernel.common.critical.nsim.critical
    │   │   ├── kernel.common.critical.sam.critical
    │   │   ├── kernel.common.irq_offload
    │   │   ├── kernel.common.k_sleep
    │   │   ├── kernel.common.k_yield
    │   │   ├── kernel.common.kernel_cpu_idle
    │   │   ├── kernel.common.kernel_cpu_idle_atomic
    │   │   ├── kernel.common.kernel_ctx_thread
    │   │   ├── kernel.common.kernel_interrupts
    │   │   ├── kernel.common.kernel_thread
    │   │   ├── kernel.common.kernel_timer_interrupts
    │   │   ├── kernel.common.misra.atomic
    │   │   ├── kernel.common.misra.bitfield
    │   │   ├── kernel.common.misra.bounds_check_mitigation
    │   │   ├── kernel.common.misra.byteorder_mem_swap
    │   │   ├── kernel.common.misra.byteorder_memcpy_swap
    │   │   ├── kernel.common.misra.clock_cycle
    │   │   ├── kernel.common.misra.clock_uptime
    │   │   ├── kernel.common.misra.irq_offload
    │   │   ├── kernel.common.misra.multilib
    │   │   ├── kernel.common.misra.printk
    │   │   ├── kernel.common.misra.sys_get_be16
    │   │   ├── kernel.common.misra.sys_get_be32
    │   │   ├── kernel.common.misra.sys_get_be64
    │   │   ├── kernel.common.misra.sys_get_le16
    │   │   ├── kernel.common.misra.sys_get_le32
    │   │   ├── kernel.common.misra.sys_get_le64
    │   │   ├── kernel.common.misra.sys_put_be16
    │   │   ├── kernel.common.misra.sys_put_be32
    │   │   ├── kernel.common.misra.sys_put_be64
    │   │   ├── kernel.common.misra.sys_put_le16
    │   │   ├── kernel.common.misra.sys_put_le32
    │   │   ├── kernel.common.misra.sys_put_le64
    │   │   ├── kernel.common.misra.thread_context
    │   │   ├── kernel.common.misra.timeout_order
    │   │   ├── kernel.common.misra.verify_bootdelay
    │   │   ├── kernel.common.misra.version
    │   │   ├── kernel.common.multilib
    │   │   ├── kernel.common.printk
    │   │   ├── kernel.common.profiling.call_stacks_analyze_idle
    │   │   ├── kernel.common.profiling.call_stacks_analyze_main
    │   │   ├── kernel.common.profiling.call_stacks_analyze_workq
    │   │   ├── kernel.common.sleep.early_sleep
    │   │   ├── kernel.common.stack_protection.fatal
    │   │   ├── kernel.common.stack_protection_arm_fp_sharing.fatal
    │   │   ├── kernel.common.stack_protection_armv8m_mpu_stack_guard.fatal
    │   │   ├── kernel.common.stack_protection_no_userspace.fatal
    │   │   ├── kernel.common.stack_sentinel.fatal
    │   │   ├── kernel.common.sys_get_be16
    │   │   ├── kernel.common.sys_get_be32
    │   │   ├── kernel.common.sys_get_be64
    │   │   ├── kernel.common.sys_get_le16
    │   │   ├── kernel.common.sys_get_le32
    │   │   ├── kernel.common.sys_get_le64
    │   │   ├── kernel.common.sys_put_be16
    │   │   ├── kernel.common.sys_put_be32
    │   │   ├── kernel.common.sys_put_be64
    │   │   ├── kernel.common.sys_put_le16
    │   │   ├── kernel.common.sys_put_le32
    │   │   ├── kernel.common.sys_put_le64
    │   │   ├── kernel.common.thread_context
    │   │   ├── kernel.common.timeout_order
    │   │   ├── kernel.common.timing.sleep
    │   │   ├── kernel.common.timing.sleep_forever
    │   │   ├── kernel.common.timing.usleep
    │   │   ├── kernel.common.verify_bootdelay
    │   │   └── kernel.common.version
    │   ├── device
    │   │   ├── kernel.device.bogus_dynamic_name
    │   │   ├── kernel.device.build_suspend_device_list
    │   │   ├── kernel.device.dummy_device
    │   │   ├── kernel.device.dummy_device_pm
    │   │   ├── kernel.device.dynamic_name
    │   │   ├── kernel.device.pm.bogus_dynamic_name
    │   │   ├── kernel.device.pm.build_suspend_device_list
    │   │   ├── kernel.device.pm.dummy_device
    │   │   ├── kernel.device.pm.dummy_device_pm
    │   │   └── kernel.device.pm.dynamic_name
    │   ├── fifo
    │   │   ├── kernel.fifo.fifo_cancel_wait
    │   │   ├── kernel.fifo.fifo_get_fail
    │   │   ├── kernel.fifo.fifo_is_empty_isr
    │   │   ├── kernel.fifo.fifo_is_empty_thread
    │   │   ├── kernel.fifo.fifo_isr2thread
    │   │   ├── kernel.fifo.fifo_loop
    │   │   ├── kernel.fifo.fifo_thread2isr
    │   │   ├── kernel.fifo.fifo_thread2thread
    │   │   ├── kernel.fifo.poll.fifo_cancel_wait
    │   │   ├── kernel.fifo.poll.fifo_get_fail
    │   │   ├── kernel.fifo.poll.fifo_is_empty_isr
    │   │   ├── kernel.fifo.poll.fifo_is_empty_thread
    │   │   ├── kernel.fifo.poll.fifo_isr2thread
    │   │   ├── kernel.fifo.poll.fifo_loop
    │   │   ├── kernel.fifo.poll.fifo_thread2isr
    │   │   ├── kernel.fifo.poll.fifo_thread2thread
    │   │   ├── kernel.fifo.timeout.poll.timeout_empty_fifo
    │   │   ├── kernel.fifo.timeout.poll.timeout_fifo_thread
    │   │   ├── kernel.fifo.timeout.poll.timeout_non_empty_fifo
    │   │   ├── kernel.fifo.timeout.poll.timeout_threads_pend_fail_on_fifo
    │   │   ├── kernel.fifo.timeout.poll.timeout_threads_pend_on_dual_fifos
    │   │   ├── kernel.fifo.timeout.poll.timeout_threads_pend_on_fifo
    │   │   ├── kernel.fifo.timeout.timeout_empty_fifo
    │   │   ├── kernel.fifo.timeout.timeout_fifo_thread
    │   │   ├── kernel.fifo.timeout.timeout_non_empty_fifo
    │   │   ├── kernel.fifo.timeout.timeout_threads_pend_fail_on_fifo
    │   │   ├── kernel.fifo.timeout.timeout_threads_pend_on_dual_fifos
    │   │   ├── kernel.fifo.timeout.timeout_threads_pend_on_fifo
    │   │   ├── kernel.fifo.usage.dual_fifo_play
    │   │   ├── kernel.fifo.usage.isr_fifo_play
    │   │   ├── kernel.fifo.usage.poll.dual_fifo_play
    │   │   ├── kernel.fifo.usage.poll.isr_fifo_play
    │   │   ├── kernel.fifo.usage.poll.single_fifo_play
    │   │   └── kernel.fifo.usage.single_fifo_play
    │   ├── fp_sharing
    │   │   ├── kernel.fp_sharing.arc
    │   │   ├── kernel.fp_sharing.float_disable.arm.k_float_disable_common
    │   │   ├── kernel.fp_sharing.float_disable.arm.k_float_disable_irq
    │   │   ├── kernel.fp_sharing.float_disable.arm.k_float_disable_syscall
    │   │   ├── kernel.fp_sharing.float_disable.x86.k_float_disable_common
    │   │   ├── kernel.fp_sharing.float_disable.x86.k_float_disable_irq
    │   │   ├── kernel.fp_sharing.float_disable.x86.k_float_disable_syscall
    │   │   ├── kernel.fp_sharing.fp_sharing
    │   │   └── kernel.fp_sharing.x86
    │   ├── futex
    │   │   ├── kernel.futex.futex_multiple_threads_wait_wake
    │   │   ├── kernel.futex.futex_wait_forever
    │   │   ├── kernel.futex.futex_wait_forever_wake
    │   │   ├── kernel.futex.futex_wait_forever_wake_from_isr
    │   │   ├── kernel.futex.futex_wait_nowait
    │   │   ├── kernel.futex.futex_wait_nowait_wake
    │   │   ├── kernel.futex.futex_wait_timeout
    │   │   ├── kernel.futex.futex_wait_timeout_wake
    │   │   ├── kernel.futex.multiple_futex_wait_wake
    │   │   └── kernel.futex.user_futex_bad
    │   ├── lifo
    │   │   ├── kernel.lifo.lifo_get_fail
    │   │   ├── kernel.lifo.lifo_isr2thread
    │   │   ├── kernel.lifo.lifo_loop
    │   │   ├── kernel.lifo.lifo_thread2isr
    │   │   ├── kernel.lifo.lifo_thread2thread
    │   │   ├── kernel.lifo.usage.lifo_nowait
    │   │   ├── kernel.lifo.usage.lifo_wait
    │   │   ├── kernel.lifo.usage.timeout_empty_lifo
    │   │   ├── kernel.lifo.usage.timeout_lifo_thread
    │   │   ├── kernel.lifo.usage.timeout_non_empty_lifo
    │   │   └── kernel.lifo.usage.timeout_threads_pend_on_lifo
    │   ├── mailbox
    │   │   ├── kernel.mailbox.api.mbox_async_multiple_put
    │   │   ├── kernel.mailbox.api.mbox_async_put_get_block
    │   │   ├── kernel.mailbox.api.mbox_async_put_get_buffer
    │   │   ├── kernel.mailbox.api.mbox_async_put_to_waiting_get
    │   │   ├── kernel.mailbox.api.mbox_block_get_buff_to_pool
    │   │   ├── kernel.mailbox.api.mbox_block_get_buff_to_smaller_pool
    │   │   ├── kernel.mailbox.api.mbox_block_get_invalid_pool
    │   │   ├── kernel.mailbox.api.mbox_clean_up_tx_pool
    │   │   ├── kernel.mailbox.api.mbox_dispose_size_0_msg
    │   │   ├── kernel.mailbox.api.mbox_get_waiting_put_incorrect_tid
    │   │   ├── kernel.mailbox.api.mbox_incorrect_receiver_tid
    │   │   ├── kernel.mailbox.api.mbox_incorrect_transmit_tid
    │   │   ├── kernel.mailbox.api.mbox_kdefine
    │   │   ├── kernel.mailbox.api.mbox_kinit
    │   │   ├── kernel.mailbox.api.mbox_msg_tid_mismatch
    │   │   ├── kernel.mailbox.api.mbox_multiple_waiting_get
    │   │   ├── kernel.mailbox.api.mbox_put_get_buffer
    │   │   ├── kernel.mailbox.api.mbox_put_get_null
    │   │   ├── kernel.mailbox.api.mbox_target_source_thread_block
    │   │   ├── kernel.mailbox.api.mbox_target_source_thread_buffer
    │   │   ├── kernel.mailbox.api.mbox_timed_out_mbox_get
    │   │   ├── kernel.mailbox.usage.msg_receiver
    │   │   └── kernel.mailbox.usage.msg_receiver_unlimited
    │   ├── memory_heap
    │   │   ├── kernel.memory_heap.mheap_block_desc
    │   │   ├── kernel.memory_heap.mheap_calloc
    │   │   ├── kernel.memory_heap.mheap_malloc_align4
    │   │   ├── kernel.memory_heap.mheap_malloc_free
    │   │   └── kernel.memory_heap.mheap_min_block_size
    │   ├── memory_pool
    │   │   ├── kernel.memory_pool.api.mpool_alloc_free_isr
    │   │   ├── kernel.memory_pool.api.mpool_alloc_free_thread
    │   │   ├── kernel.memory_pool.api.mpool_alloc_size
    │   │   ├── kernel.memory_pool.api.mpool_alloc_timeout
    │   │   ├── kernel.memory_pool.api.mpool_kdefine_extern
    │   │   ├── kernel.memory_pool.api.sys_heap_mem_pool_assign
    │   │   ├── kernel.memory_pool.concept.mpool_alloc_merge_failed_diff_parent
    │   │   ├── kernel.memory_pool.concept.mpool_alloc_merge_failed_diff_size
    │   │   ├── kernel.memory_pool.concept.mpool_alloc_size_roundup
    │   │   ├── kernel.memory_pool.concept.mpool_alloc_wait_prio
    │   │   ├── kernel.memory_pool.pool_block_get
    │   │   ├── kernel.memory_pool.pool_block_get_timeout
    │   │   ├── kernel.memory_pool.pool_block_get_wait
    │   │   ├── kernel.memory_pool.pool_malloc
    │   │   ├── kernel.memory_pool.sys.sys_mem_pool_alloc_align4
    │   │   ├── kernel.memory_pool.sys.sys_mem_pool_alloc_free
    │   │   ├── kernel.memory_pool.sys.sys_mem_pool_min_block_size
    │   │   └── kernel.memory_pool.threadsafe.mpool_threadsafe
    │   ├── memory_protection
    │   │   ├── kernel.memory_protection.access_kobject_without_init_access
    │   │   ├── kernel.memory_protection.access_kobject_without_init_with_access
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.access_kobject_without_init_access
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.access_kobject_without_init_with_access
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.create_new_essential_thread_from_user
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.create_new_higher_prio_thread_from_user
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.create_new_invalid_prio_thread_from_user
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.create_new_supervisor_thread_from_user
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.create_new_thread_from_user
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.create_new_thread_from_user_huge_stacksize
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.create_new_thread_from_user_invalid_stacksize
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.create_new_thread_from_user_no_access_stack
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.kobject_access_all_grant
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.kobject_access_grant
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.kobject_access_grant_to_invalid_thread
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.kobject_access_invalid_kobject
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.kobject_grant_access_kobj
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.kobject_grant_access_kobj_invalid
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.kobject_reinitialize_thread_kobj
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.kobject_release_from_user
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.kobject_revoke_access
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.mem_domain_add_partitions_invalid
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.mem_domain_add_partitions_simple
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.mem_domain_destroy
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.mem_domain_invalid_access
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.mem_domain_partitions_supervisor_rw
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.mem_domain_partitions_user_ro
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.mem_domain_partitions_user_rw
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.mem_domain_remove_partitions
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.mem_domain_remove_partitions_simple
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.mem_domain_remove_thread
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.mem_domain_valid_access
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.permission_inheritance
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.syscall_invalid_kobject
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.thread_has_residual_permissions
    │   │   ├── kernel.memory_protection.armv8m_gap_filling.thread_without_kobject_permission
    │   │   ├── kernel.memory_protection.create_new_essential_thread_from_user
    │   │   ├── kernel.memory_protection.create_new_higher_prio_thread_from_user
    │   │   ├── kernel.memory_protection.create_new_invalid_prio_thread_from_user
    │   │   ├── kernel.memory_protection.create_new_supervisor_thread_from_user
    │   │   ├── kernel.memory_protection.create_new_thread_from_user
    │   │   ├── kernel.memory_protection.create_new_thread_from_user_huge_stacksize
    │   │   ├── kernel.memory_protection.create_new_thread_from_user_invalid_stacksize
    │   │   ├── kernel.memory_protection.create_new_thread_from_user_no_access_stack
    │   │   ├── kernel.memory_protection.kobject_access_all_grant
    │   │   ├── kernel.memory_protection.kobject_access_grant
    │   │   ├── kernel.memory_protection.kobject_access_grant_to_invalid_thread
    │   │   ├── kernel.memory_protection.kobject_access_invalid_kobject
    │   │   ├── kernel.memory_protection.kobject_grant_access_kobj
    │   │   ├── kernel.memory_protection.kobject_grant_access_kobj_invalid
    │   │   ├── kernel.memory_protection.kobject_reinitialize_thread_kobj
    │   │   ├── kernel.memory_protection.kobject_release_from_user
    │   │   ├── kernel.memory_protection.kobject_revoke_access
    │   │   ├── kernel.memory_protection.mem_domain_add_partitions_invalid
    │   │   ├── kernel.memory_protection.mem_domain_add_partitions_simple
    │   │   ├── kernel.memory_protection.mem_domain_destroy
    │   │   ├── kernel.memory_protection.mem_domain_invalid_access
    │   │   ├── kernel.memory_protection.mem_domain_partitions_supervisor_rw
    │   │   ├── kernel.memory_protection.mem_domain_partitions_user_ro
    │   │   ├── kernel.memory_protection.mem_domain_partitions_user_rw
    │   │   ├── kernel.memory_protection.mem_domain_remove_partitions
    │   │   ├── kernel.memory_protection.mem_domain_remove_partitions_simple
    │   │   ├── kernel.memory_protection.mem_domain_remove_thread
    │   │   ├── kernel.memory_protection.mem_domain_valid_access
    │   │   ├── kernel.memory_protection.obj_validation.generic_object
    │   │   ├── kernel.memory_protection.permission_inheritance
    │   │   ├── kernel.memory_protection.protection.exec_data
    │   │   ├── kernel.memory_protection.protection.exec_heap
    │   │   ├── kernel.memory_protection.protection.exec_stack
    │   │   ├── kernel.memory_protection.protection.write_ro
    │   │   ├── kernel.memory_protection.protection.write_text
    │   │   ├── kernel.memory_protection.stack_random.stack_pt_randomization
    │   │   ├── kernel.memory_protection.stackprot.create_alt_thread
    │   │   ├── kernel.memory_protection.stackprot.stackprot
    │   │   ├── kernel.memory_protection.sys_sem.basic_sem_test
    │   │   ├── kernel.memory_protection.sys_sem.nouser.basic_sem_test
    │   │   ├── kernel.memory_protection.sys_sem.nouser.sem_give_limit
    │   │   ├── kernel.memory_protection.sys_sem.nouser.sem_give_take_from_isr
    │   │   ├── kernel.memory_protection.sys_sem.nouser.sem_multiple_threads_wait
    │   │   ├── kernel.memory_protection.sys_sem.nouser.sem_take_multiple
    │   │   ├── kernel.memory_protection.sys_sem.nouser.sem_take_no_wait
    │   │   ├── kernel.memory_protection.sys_sem.nouser.sem_take_no_wait_fails
    │   │   ├── kernel.memory_protection.sys_sem.nouser.sem_take_timeout
    │   │   ├── kernel.memory_protection.sys_sem.nouser.sem_take_timeout_fails
    │   │   ├── kernel.memory_protection.sys_sem.nouser.sem_take_timeout_forever
    │   │   ├── kernel.memory_protection.sys_sem.nouser.sem_take_timeout_isr
    │   │   ├── kernel.memory_protection.sys_sem.nouser.simple_sem_from_isr
    │   │   ├── kernel.memory_protection.sys_sem.nouser.simple_sem_from_task
    │   │   ├── kernel.memory_protection.sys_sem.sem_give_limit
    │   │   ├── kernel.memory_protection.sys_sem.sem_give_take_from_isr
    │   │   ├── kernel.memory_protection.sys_sem.sem_multiple_threads_wait
    │   │   ├── kernel.memory_protection.sys_sem.sem_take_multiple
    │   │   ├── kernel.memory_protection.sys_sem.sem_take_no_wait
    │   │   ├── kernel.memory_protection.sys_sem.sem_take_no_wait_fails
    │   │   ├── kernel.memory_protection.sys_sem.sem_take_timeout
    │   │   ├── kernel.memory_protection.sys_sem.sem_take_timeout_fails
    │   │   ├── kernel.memory_protection.sys_sem.sem_take_timeout_forever
    │   │   ├── kernel.memory_protection.sys_sem.sem_take_timeout_isr
    │   │   ├── kernel.memory_protection.sys_sem.simple_sem_from_isr
    │   │   ├── kernel.memory_protection.sys_sem.simple_sem_from_task
    │   │   ├── kernel.memory_protection.syscall_invalid_kobject
    │   │   ├── kernel.memory_protection.syscalls.arg64
    │   │   ├── kernel.memory_protection.syscalls.string_nlen
    │   │   ├── kernel.memory_protection.syscalls.string_nlen
    │   │   ├── kernel.memory_protection.syscalls.to_copy
    │   │   ├── kernel.memory_protection.syscalls.user_string_alloc_copy
    │   │   ├── kernel.memory_protection.syscalls.user_string_copy
    │   │   ├── kernel.memory_protection.thread_has_residual_permissions
    │   │   ├── kernel.memory_protection.thread_without_kobject_permission
    │   │   ├── kernel.memory_protection.userspace.access_after_revoke
    │   │   ├── kernel.memory_protection.userspace.access_other_memdomain
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.access_after_revoke
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.access_other_memdomain
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.bad_syscall
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.disable_mmu_mpu
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.domain_add_part_context_switch
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.domain_add_part_drop_to_user
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.domain_add_thread_context_switch
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.domain_add_thread_drop_to_user
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.domain_remove_part_context_switch
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.domain_remove_part_drop_to_user
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.domain_remove_thread_context_switch
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.domain_remove_thread_drop_to_user
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.is_usermode
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.object_recycle
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.oops_exception
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.oops_maxint
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.oops_oops
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.oops_panic
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.oops_stackcheck
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.pass_noperms_object
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.pass_user_object
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.read_kernel_data
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.read_kernram
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.read_kobject_user_pipe
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.read_other_stack
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.read_priv_stack
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.revoke_noperms_object
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.stack_buffer
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.start_kernel_thread
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.unimplemented_syscall
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.user_mode_enter
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.write_control
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.write_kernel_data
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.write_kernram
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.write_kernro
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.write_kerntext
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.write_kobject_user_pipe
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.write_other_stack
    │   │   ├── kernel.memory_protection.userspace.armv8m_gap_filling.write_priv_stack
    │   │   ├── kernel.memory_protection.userspace.bad_syscall
    │   │   ├── kernel.memory_protection.userspace.disable_mmu_mpu
    │   │   ├── kernel.memory_protection.userspace.domain_add_part_context_switch
    │   │   ├── kernel.memory_protection.userspace.domain_add_part_drop_to_user
    │   │   ├── kernel.memory_protection.userspace.domain_add_thread_context_switch
    │   │   ├── kernel.memory_protection.userspace.domain_add_thread_drop_to_user
    │   │   ├── kernel.memory_protection.userspace.domain_remove_part_context_switch
    │   │   ├── kernel.memory_protection.userspace.domain_remove_part_drop_to_user
    │   │   ├── kernel.memory_protection.userspace.domain_remove_thread_context_switch
    │   │   ├── kernel.memory_protection.userspace.domain_remove_thread_drop_to_user
    │   │   ├── kernel.memory_protection.userspace.is_usermode
    │   │   ├── kernel.memory_protection.userspace.object_recycle
    │   │   ├── kernel.memory_protection.userspace.oops_exception
    │   │   ├── kernel.memory_protection.userspace.oops_maxint
    │   │   ├── kernel.memory_protection.userspace.oops_oops
    │   │   ├── kernel.memory_protection.userspace.oops_panic
    │   │   ├── kernel.memory_protection.userspace.oops_stackcheck
    │   │   ├── kernel.memory_protection.userspace.pass_noperms_object
    │   │   ├── kernel.memory_protection.userspace.pass_user_object
    │   │   ├── kernel.memory_protection.userspace.read_kernel_data
    │   │   ├── kernel.memory_protection.userspace.read_kernram
    │   │   ├── kernel.memory_protection.userspace.read_kobject_user_pipe
    │   │   ├── kernel.memory_protection.userspace.read_other_stack
    │   │   ├── kernel.memory_protection.userspace.read_priv_stack
    │   │   ├── kernel.memory_protection.userspace.revoke_noperms_object
    │   │   ├── kernel.memory_protection.userspace.stack_buffer
    │   │   ├── kernel.memory_protection.userspace.start_kernel_thread
    │   │   ├── kernel.memory_protection.userspace.unimplemented_syscall
    │   │   ├── kernel.memory_protection.userspace.user_mode_enter
    │   │   ├── kernel.memory_protection.userspace.write_control
    │   │   ├── kernel.memory_protection.userspace.write_kernel_data
    │   │   ├── kernel.memory_protection.userspace.write_kernram
    │   │   ├── kernel.memory_protection.userspace.write_kernro
    │   │   ├── kernel.memory_protection.userspace.write_kerntext
    │   │   ├── kernel.memory_protection.userspace.write_kobject_user_pipe
    │   │   ├── kernel.memory_protection.userspace.write_other_stack
    │   │   └── kernel.memory_protection.userspace.write_priv_stack
    │   ├── memory_slabs
    │   │   ├── kernel.memory_slabs.api.mslab
    │   │   ├── kernel.memory_slabs.api.mslab_alloc_align
    │   │   ├── kernel.memory_slabs.api.mslab_alloc_free_thread
    │   │   ├── kernel.memory_slabs.api.mslab_alloc_timeout
    │   │   ├── kernel.memory_slabs.api.mslab_kdefine
    │   │   ├── kernel.memory_slabs.api.mslab_kdefine_extern
    │   │   ├── kernel.memory_slabs.api.mslab_kinit
    │   │   ├── kernel.memory_slabs.api.mslab_used_get
    │   │   ├── kernel.memory_slabs.concept.mslab_alloc_wait_prio
    │   │   └── kernel.memory_slabs.threadsafe.mslab_threadsafe
    │   ├── message_queue
    │   │   ├── kernel.message_queue.msgq_alloc
    │   │   ├── kernel.message_queue.msgq_attrs_get
    │   │   ├── kernel.message_queue.msgq_get_fail
    │   │   ├── kernel.message_queue.msgq_isr
    │   │   ├── kernel.message_queue.msgq_pend_thread
    │   │   ├── kernel.message_queue.msgq_purge_when_put
    │   │   ├── kernel.message_queue.msgq_put_fail
    │   │   ├── kernel.message_queue.msgq_thread
    │   │   ├── kernel.message_queue.msgq_thread_overflow
    │   │   ├── kernel.message_queue.msgq_user_attrs_get
    │   │   ├── kernel.message_queue.msgq_user_get_fail
    │   │   ├── kernel.message_queue.msgq_user_purge_when_put
    │   │   ├── kernel.message_queue.msgq_user_put_fail
    │   │   ├── kernel.message_queue.msgq_user_thread
    │   │   └── kernel.message_queue.msgq_user_thread_overflow
    │   ├── multiprocessing
    │   │   ├── kernel.multiprocessing.mp_start
    │   │   ├── kernel.multiprocessing.smp.coop_resched_threads
    │   │   ├── kernel.multiprocessing.smp.cpu_id_threads
    │   │   ├── kernel.multiprocessing.smp.preempt_resched_threads
    │   │   ├── kernel.multiprocessing.smp.sleep_threads
    │   │   ├── kernel.multiprocessing.smp.smp_coop_threads
    │   │   ├── kernel.multiprocessing.smp.wakeup_threads
    │   │   ├── kernel.multiprocessing.smp.yield_threads
    │   │   ├── kernel.multiprocessing.spinlock.spinlock_basic
    │   │   └── kernel.multiprocessing.spinlock.spinlock_bounce
    │   ├── mutex
    │   │   ├── kernel.mutex.mutex_lock_unlock
    │   │   ├── kernel.mutex.mutex_reent_lock_forever
    │   │   ├── kernel.mutex.mutex_reent_lock_no_wait
    │   │   ├── kernel.mutex.mutex_reent_lock_timeout_fail
    │   │   └── kernel.mutex.mutex_reent_lock_timeout_pass
    │   ├── objects
    │   │   ├── kernel.objects.pending_fifo
    │   │   ├── kernel.objects.pending_lifo
    │   │   ├── kernel.objects.pending_timer
    │   │   ├── kernel.objects.tracing.obj_tracing
    │   │   └── kernel.objects.tracing.philosophers_tracing
    │   ├── pipe
    │   │   ├── kernel.pipe.api.half_pipe_block_put_sema
    │   │   ├── kernel.pipe.api.half_pipe_get_put
    │   │   ├── kernel.pipe.api.pipe_alloc
    │   │   ├── kernel.pipe.api.pipe_block_put
    │   │   ├── kernel.pipe.api.pipe_block_put_sema
    │   │   ├── kernel.pipe.api.pipe_block_writer_wait
    │   │   ├── kernel.pipe.api.pipe_get_fail
    │   │   ├── kernel.pipe.api.pipe_get_put
    │   │   ├── kernel.pipe.api.pipe_put_fail
    │   │   ├── kernel.pipe.api.pipe_reader_wait
    │   │   ├── kernel.pipe.api.pipe_thread2thread
    │   │   ├── kernel.pipe.api.pipe_user_get_fail
    │   │   ├── kernel.pipe.api.pipe_user_put_fail
    │   │   ├── kernel.pipe.api.pipe_user_thread2thread
    │   │   ├── kernel.pipe.api.resource_pool_auto_free
    │   │   ├── kernel.pipe.pipe_forever_timeout
    │   │   ├── kernel.pipe.pipe_forever_wait
    │   │   ├── kernel.pipe.pipe_get_invalid_size
    │   │   ├── kernel.pipe.pipe_get_on_empty_pipe
    │   │   ├── kernel.pipe.pipe_get_timeout
    │   │   ├── kernel.pipe.pipe_on_multiple_elements
    │   │   ├── kernel.pipe.pipe_on_single_elements
    │   │   └── kernel.pipe.pipe_timeout
    │   ├── poll
    │   │   ├── kernel.poll.poll_cancel_main_high_prio
    │   │   ├── kernel.poll.poll_cancel_main_low_prio
    │   │   ├── kernel.poll.poll_multi
    │   │   ├── kernel.poll.poll_no_wait
    │   │   ├── kernel.poll.poll_threadstate
    │   │   └── kernel.poll.poll_wait
    │   ├── queue
    │   │   ├── kernel.queue.auto_free
    │   │   ├── kernel.queue.poll.auto_free
    │   │   ├── kernel.queue.poll.queue_alloc
    │   │   ├── kernel.queue.poll.queue_alloc_append_user
    │   │   ├── kernel.queue.poll.queue_alloc_prepend_user
    │   │   ├── kernel.queue.poll.queue_get_2threads
    │   │   ├── kernel.queue.poll.queue_get_fail
    │   │   ├── kernel.queue.poll.queue_isr2thread
    │   │   ├── kernel.queue.poll.queue_loop
    │   │   ├── kernel.queue.poll.queue_supv_to_user
    │   │   ├── kernel.queue.poll.queue_thread2isr
    │   │   ├── kernel.queue.poll.queue_thread2thread
    │   │   ├── kernel.queue.queue_alloc
    │   │   ├── kernel.queue.queue_alloc_append_user
    │   │   ├── kernel.queue.queue_alloc_prepend_user
    │   │   ├── kernel.queue.queue_get_2threads
    │   │   ├── kernel.queue.queue_get_fail
    │   │   ├── kernel.queue.queue_isr2thread
    │   │   ├── kernel.queue.queue_loop
    │   │   ├── kernel.queue.queue_supv_to_user
    │   │   ├── kernel.queue.queue_thread2isr
    │   │   └── kernel.queue.queue_thread2thread
    │   ├── scheduler
    │   │   ├── kernel.scheduler.bad_priorities
    │   │   ├── kernel.scheduler.deadline.deadline
    │   │   ├── kernel.scheduler.lock_preemptible
    │   │   ├── kernel.scheduler.metairq.preempt
    │   │   ├── kernel.scheduler.multiq.bad_priorities
    │   │   ├── kernel.scheduler.multiq.lock_preemptible
    │   │   ├── kernel.scheduler.multiq.pending_thread_wakeup
    │   │   ├── kernel.scheduler.multiq.priority_cooperative
    │   │   ├── kernel.scheduler.multiq.priority_preemptible
    │   │   ├── kernel.scheduler.multiq.priority_scheduling
    │   │   ├── kernel.scheduler.multiq.sched_is_preempt_thread
    │   │   ├── kernel.scheduler.multiq.sleep_cooperative
    │   │   ├── kernel.scheduler.multiq.sleep_wakeup_preemptible
    │   │   ├── kernel.scheduler.multiq.slice_reset
    │   │   ├── kernel.scheduler.multiq.slice_scheduling
    │   │   ├── kernel.scheduler.multiq.time_slicing_disable_preemptible
    │   │   ├── kernel.scheduler.multiq.time_slicing_preemptible
    │   │   ├── kernel.scheduler.multiq.unlock_nested_sched_lock
    │   │   ├── kernel.scheduler.multiq.unlock_preemptible
    │   │   ├── kernel.scheduler.multiq.user_k_is_preempt
    │   │   ├── kernel.scheduler.multiq.user_k_wakeup
    │   │   ├── kernel.scheduler.multiq.wakeup_expired_timer_thread
    │   │   ├── kernel.scheduler.multiq.yield_cooperative
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.bad_priorities
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.lock_preemptible
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.pending_thread_wakeup
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.priority_cooperative
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.priority_preemptible
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.priority_scheduling
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.sched_is_preempt_thread
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.sleep_cooperative
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.sleep_wakeup_preemptible
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.slice_reset
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.slice_scheduling
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.time_slicing_disable_preemptible
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.time_slicing_preemptible
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.unlock_nested_sched_lock
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.unlock_preemptible
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.user_k_is_preempt
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.user_k_wakeup
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.wakeup_expired_timer_thread
    │   │   ├── kernel.scheduler.multiq_no_timeslicing.yield_cooperative
    │   │   ├── kernel.scheduler.no_timeslicing.bad_priorities
    │   │   ├── kernel.scheduler.no_timeslicing.lock_preemptible
    │   │   ├── kernel.scheduler.no_timeslicing.pending_thread_wakeup
    │   │   ├── kernel.scheduler.no_timeslicing.priority_cooperative
    │   │   ├── kernel.scheduler.no_timeslicing.priority_preemptible
    │   │   ├── kernel.scheduler.no_timeslicing.priority_scheduling
    │   │   ├── kernel.scheduler.no_timeslicing.sched_is_preempt_thread
    │   │   ├── kernel.scheduler.no_timeslicing.sleep_cooperative
    │   │   ├── kernel.scheduler.no_timeslicing.sleep_wakeup_preemptible
    │   │   ├── kernel.scheduler.no_timeslicing.slice_reset
    │   │   ├── kernel.scheduler.no_timeslicing.slice_scheduling
    │   │   ├── kernel.scheduler.no_timeslicing.time_slicing_disable_preemptible
    │   │   ├── kernel.scheduler.no_timeslicing.time_slicing_preemptible
    │   │   ├── kernel.scheduler.no_timeslicing.unlock_nested_sched_lock
    │   │   ├── kernel.scheduler.no_timeslicing.unlock_preemptible
    │   │   ├── kernel.scheduler.no_timeslicing.user_k_is_preempt
    │   │   ├── kernel.scheduler.no_timeslicing.user_k_wakeup
    │   │   ├── kernel.scheduler.no_timeslicing.wakeup_expired_timer_thread
    │   │   ├── kernel.scheduler.no_timeslicing.yield_cooperative
    │   │   ├── kernel.scheduler.pending_thread_wakeup
    │   │   ├── kernel.scheduler.preempt.preempt
    │   │   ├── kernel.scheduler.priority_cooperative
    │   │   ├── kernel.scheduler.priority_preemptible
    │   │   ├── kernel.scheduler.priority_scheduling
    │   │   ├── kernel.scheduler.sched_is_preempt_thread
    │   │   ├── kernel.scheduler.sleep_cooperative
    │   │   ├── kernel.scheduler.sleep_wakeup_preemptible
    │   │   ├── kernel.scheduler.slice_reset
    │   │   ├── kernel.scheduler.slice_scheduling
    │   │   ├── kernel.scheduler.time_slicing_disable_preemptible
    │   │   ├── kernel.scheduler.time_slicing_preemptible
    │   │   ├── kernel.scheduler.unlock_nested_sched_lock
    │   │   ├── kernel.scheduler.unlock_preemptible
    │   │   ├── kernel.scheduler.user_k_is_preempt
    │   │   ├── kernel.scheduler.user_k_wakeup
    │   │   ├── kernel.scheduler.wakeup_expired_timer_thread
    │   │   └── kernel.scheduler.yield_cooperative
    │   ├── semaphore
    │   │   ├── kernel.semaphore.sem_give_take_from_isr
    │   │   ├── kernel.semaphore.sem_measure_timeout_from_thread
    │   │   ├── kernel.semaphore.sem_measure_timeouts
    │   │   ├── kernel.semaphore.sem_multi_take_timeout_diff_sem
    │   │   ├── kernel.semaphore.sem_multiple_take_and_timeouts
    │   │   ├── kernel.semaphore.sem_multiple_threads_wait
    │   │   ├── kernel.semaphore.sem_take_multiple
    │   │   ├── kernel.semaphore.sem_take_no_wait
    │   │   ├── kernel.semaphore.sem_take_no_wait_fails
    │   │   ├── kernel.semaphore.sem_take_timeout
    │   │   ├── kernel.semaphore.sem_take_timeout_fails
    │   │   ├── kernel.semaphore.sem_take_timeout_forever
    │   │   ├── kernel.semaphore.sem_take_timeout_isr
    │   │   ├── kernel.semaphore.sema_count_get
    │   │   ├── kernel.semaphore.sema_reset
    │   │   ├── kernel.semaphore.sema_thread2isr
    │   │   ├── kernel.semaphore.sema_thread2thread
    │   │   ├── kernel.semaphore.simple_sem_from_isr
    │   │   └── kernel.semaphore.simple_sem_from_task
    │   ├── stack
    │   │   ├── kernel.stack.usage.dual_stack_play
    │   │   ├── kernel.stack.usage.isr_stack_play
    │   │   ├── kernel.stack.usage.single_stack_play
    │   │   ├── kernel.stack.usage.stack_alloc_thread2thread
    │   │   ├── kernel.stack.usage.stack_pop_fail
    │   │   ├── kernel.stack.usage.stack_thread2isr
    │   │   ├── kernel.stack.usage.stack_thread2thread
    │   │   ├── kernel.stack.usage.stack_user_pop_fail
    │   │   └── kernel.stack.usage.stack_user_thread2thread
    │   ├── threads
    │   │   ├── kernel.threads.apis.abort_handler
    │   │   ├── kernel.threads.apis.customdata_get_set_coop
    │   │   ├── kernel.threads.apis.customdata_get_set_preempt
    │   │   ├── kernel.threads.apis.delayed_thread_abort
    │   │   ├── kernel.threads.apis.essential_thread_operation
    │   │   ├── kernel.threads.apis.k_thread_foreach
    │   │   ├── kernel.threads.apis.systhreads_idle
    │   │   ├── kernel.threads.apis.systhreads_main
    │   │   ├── kernel.threads.apis.thread_name_get_set
    │   │   ├── kernel.threads.apis.thread_name_user_get_set
    │   │   ├── kernel.threads.apis.thread_start
    │   │   ├── kernel.threads.apis.threads_abort_others
    │   │   ├── kernel.threads.apis.threads_abort_repeat
    │   │   ├── kernel.threads.apis.threads_abort_self
    │   │   ├── kernel.threads.apis.threads_cpu_mask
    │   │   ├── kernel.threads.apis.threads_priority_set
    │   │   ├── kernel.threads.apis.threads_spawn_delay
    │   │   ├── kernel.threads.apis.threads_spawn_forever
    │   │   ├── kernel.threads.apis.threads_spawn_params
    │   │   ├── kernel.threads.apis.threads_spawn_priority
    │   │   ├── kernel.threads.apis.threads_suspend
    │   │   ├── kernel.threads.apis.threads_suspend_resume_cooperative
    │   │   ├── kernel.threads.apis.threads_suspend_resume_preemptible
    │   │   ├── kernel.threads.apis.threads_suspend_timeout
    │   │   ├── kernel.threads.apis.user_mode
    │   │   ├── kernel.threads.dynamic.dyn_thread_perms
    │   │   ├── kernel.threads.dynamic.kernel_create_dyn_user_thread
    │   │   ├── kernel.threads.dynamic.thread_index_management
    │   │   ├── kernel.threads.dynamic.user_create_dyn_user_thread
    │   │   ├── kernel.threads.init.kdefine_coop_thread
    │   │   ├── kernel.threads.init.kdefine_preempt_thread
    │   │   ├── kernel.threads.init.kinit_coop_thread
    │   │   ├── kernel.threads.init.kinit_preempt_thread
    │   │   └── kernel.threads.no-multithreading
    │   ├── tickless
    │   │   ├── kernel.tickless.concept.tickless_slice
    │   │   ├── kernel.tickless.concept.tickless_sysclock
    │   │   └── kernel.tickless.tickless
    │   ├── timer
    │   │   ├── kernel.timer.monotonic.timer
    │   │   ├── kernel.timer.tickless.time_conversions
    │   │   ├── kernel.timer.tickless.timer_duration_period
    │   │   ├── kernel.timer.tickless.timer_expirefn_null
    │   │   ├── kernel.timer.tickless.timer_k_define
    │   │   ├── kernel.timer.tickless.timer_period_0
    │   │   ├── kernel.timer.tickless.timer_periodicity
    │   │   ├── kernel.timer.tickless.timer_remaining_get
    │   │   ├── kernel.timer.tickless.timer_status_get
    │   │   ├── kernel.timer.tickless.timer_status_get_anytime
    │   │   ├── kernel.timer.tickless.timer_status_sync
    │   │   ├── kernel.timer.tickless.timer_user_data
    │   │   ├── kernel.timer.time_conversions
    │   │   ├── kernel.timer.timer_duration_period
    │   │   ├── kernel.timer.timer_expirefn_null
    │   │   ├── kernel.timer.timer_k_define
    │   │   ├── kernel.timer.timer_period_0
    │   │   ├── kernel.timer.timer_periodicity
    │   │   ├── kernel.timer.timer_remaining_get
    │   │   ├── kernel.timer.timer_status_get
    │   │   ├── kernel.timer.timer_status_get_anytime
    │   │   ├── kernel.timer.timer_status_sync
    │   │   └── kernel.timer.timer_user_data
    │   └── workqueue
    │       ├── kernel.workqueue.already_triggered
    │       ├── kernel.workqueue.api.delayed_work_cancel_from_queue_isr
    │       ├── kernel.workqueue.api.delayed_work_cancel_from_queue_thread
    │       ├── kernel.workqueue.api.delayed_work_cancel_isr
    │       ├── kernel.workqueue.api.delayed_work_cancel_thread
    │       ├── kernel.workqueue.api.delayed_work_submit_isr
    │       ├── kernel.workqueue.api.delayed_work_submit_thread
    │       ├── kernel.workqueue.api.delayed_work_submit_to_queue_isr
    │       ├── kernel.workqueue.api.delayed_work_submit_to_queue_thread
    │       ├── kernel.workqueue.api.triggered_work_cancel_from_queue_isr
    │       ├── kernel.workqueue.api.triggered_work_cancel_from_queue_thread
    │       ├── kernel.workqueue.api.triggered_work_cancel_isr
    │       ├── kernel.workqueue.api.triggered_work_cancel_thread
    │       ├── kernel.workqueue.api.triggered_work_submit_isr
    │       ├── kernel.workqueue.api.triggered_work_submit_thread
    │       ├── kernel.workqueue.api.triggered_work_submit_to_queue_isr
    │       ├── kernel.workqueue.api.triggered_work_submit_to_queue_thread
    │       ├── kernel.workqueue.api.user_work_submit_to_queue_thread
    │       ├── kernel.workqueue.api.user_workq_granted_access
    │       ├── kernel.workqueue.api.user_workq_granted_access_setup
    │       ├── kernel.workqueue.api.user_workq_start_before_submit
    │       ├── kernel.workqueue.api.work_resubmit_to_queue
    │       ├── kernel.workqueue.api.work_submit_isr
    │       ├── kernel.workqueue.api.work_submit_thread
    │       ├── kernel.workqueue.api.work_submit_to_multipleq
    │       ├── kernel.workqueue.api.work_submit_to_queue_isr
    │       ├── kernel.workqueue.api.work_submit_to_queue_thread
    │       ├── kernel.workqueue.api.workq_start_before_submit
    │       ├── kernel.workqueue.delayed
    │       ├── kernel.workqueue.delayed_cancel
    │       ├── kernel.workqueue.delayed_resubmit
    │       ├── kernel.workqueue.delayed_resubmit_thread
    │       ├── kernel.workqueue.resubmit
    │       ├── kernel.workqueue.sequence
    │       ├── kernel.workqueue.triggered
    │       ├── kernel.workqueue.triggered_no_wait
    │       ├── kernel.workqueue.triggered_no_wait_expired
    │       ├── kernel.workqueue.triggered_resubmit
    │       ├── kernel.workqueue.triggered_wait
    │       └── kernel.workqueue.triggered_wait_expired
    └── system
        └── mutex
            ├── system.mutex.mutex
            ├── system.mutex.nouser.mutex
            ├── system.mutex.nouser.supervisor_access
            ├── system.mutex.nouser.user_access
            ├── system.mutex.supervisor_access
            └── system.mutex.user_access


```