### PR TITLE
libc: newlib: Remove gnuarmemb restriction on newlib nano variant

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -40,7 +40,6 @@ endchoice # LIBC_IMPLEMENTATION
 
 if NEWLIB_LIBC
 
-if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "gnuarmemb"
 config NEWLIB_LIBC_NANO
 	bool "Build with newlib-nano C library"
 	default y
@@ -48,7 +47,6 @@ config NEWLIB_LIBC_NANO
 	  Build with newlib-nano library, for small embedded apps.
 	  The newlib-nano library for ARM embedded processors is a part of the
 	  GNU Tools for ARM Embedded Processors.
-endif
 
 config NEWLIB_LIBC_ALIGNED_HEAP_SIZE
 	int "Newlib aligned heap size"


### PR DESCRIPTION
NEWLIB_LIBC_NANO was defined only for gnuarmemb toolchain because
Zephyr SDK did not support the newlib nano variant (as defined by
nano.specs) due to the inherent limitations of crosstool-ng, which is
used to build the toolchains.

Since crosstool-ng/crosstool-ng#1279 added support for the nano C/C++
runtime library variant and this change was introduced to the Zephyr
SDK through zephyrproject-rtos#153, it is no longer necessary to
restrict the newlib nano variant to gnuarmemb toolchain only.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

_NOTE: This PR should be merged after zephyrproject-rtos/sdk-ng#153 is merged and available in a Zephyr SDK release._