### PR TITLE
samples & tests: Correct main() type

### DIFF
--- a/samples/cpp_synchronization/src/main.cpp
+++ b/samples/cpp_synchronization/src/main.cpp
@@ -133,7 +133,7 @@ void coop_thread_entry(void)
 	}
 }
 
-int main(void)
+void main(void)
 {
 	struct k_timer timer;
 
@@ -154,6 +154,4 @@ int main(void)
 		/* Wait for coop thread to let us have a turn */
 		sem_main.wait();
 	}
-
-	return 0;
 }

--- a/samples/net/sockets/big_http_download/src/big_http_download.c
+++ b/samples/net/sockets/big_http_download/src/big_http_download.c
@@ -214,7 +214,7 @@ error:
 	(void)close(sock);
 }
 
-int main(void)
+void main(void)
 {
 	static struct addrinfo hints;
 	struct addrinfo *res;
@@ -314,6 +314,4 @@ int main(void)
 	}
 
 	mbedtls_md_free(&hash_ctx);
-
-	return 0;
 }

--- a/samples/net/sockets/civetweb/src/main.c
+++ b/samples/net/sockets/civetweb/src/main.c
@@ -166,7 +166,7 @@ void *main_pthread(void *arg)
 	return 0;
 }
 
-int main(void)
+void main(void)
 {
 	pthread_attr_t civetweb_attr;
 	pthread_t civetweb_thread;
@@ -177,6 +177,4 @@ int main(void)
 
 	(void)pthread_create(&civetweb_thread, &civetweb_attr,
 			     &main_pthread, 0);
-
-	return 0;
 }

--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -40,7 +40,7 @@ static const char content[] = {
 #endif
 };
 
-int main(void)
+void main(void)
 {
 	int serv;
 	struct sockaddr_in bind_addr;

--- a/samples/net/sockets/echo/src/socket_echo.c
+++ b/samples/net/sockets/echo/src/socket_echo.c
@@ -23,7 +23,7 @@
 
 #define PORT 4242
 
-int main(void)
+void main(void)
 {
 	int serv;
 	struct sockaddr_in bind_addr;

--- a/samples/net/sockets/echo_async/src/socket_echo.c
+++ b/samples/net/sockets/echo_async/src/socket_echo.c
@@ -104,7 +104,7 @@ void pollfds_del(int fd)
 	}
 }
 
-int main(void)
+void main(void)
 {
 	int res;
 	static int counter;

--- a/samples/net/sockets/echo_async_select/src/socket_echo_select.c
+++ b/samples/net/sockets/echo_async_select/src/socket_echo_select.c
@@ -83,7 +83,7 @@ void pollfds_del(int fd)
 	FD_CLR(fd, &readfds);
 }
 
-int main(void)
+void main(void)
 {
 	int res;
 	static int counter;

--- a/samples/net/sockets/http_get/src/http_get.c
+++ b/samples/net/sockets/http_get/src/http_get.c
@@ -55,7 +55,7 @@ void dump_addrinfo(const struct addrinfo *ai)
 	       ((struct sockaddr_in *)ai->ai_addr)->sin_port);
 }
 
-int main(void)
+void main(void)
 {
 	static struct addrinfo hints;
 	struct addrinfo *res;
@@ -76,7 +76,7 @@ int main(void)
 
 	if (st != 0) {
 		printf("Unable to resolve address, quitting\n");
-		return 1;
+		return;
 	}
 
 #if 0
@@ -116,7 +116,7 @@ int main(void)
 
 		if (len < 0) {
 			printf("Error reading response\n");
-			return 1;
+			return;
 		}
 
 		if (len == 0) {
@@ -130,6 +130,4 @@ int main(void)
 	printf("\n");
 
 	(void)close(sock);
-
-	return 0;
 }

--- a/samples/net/updatehub/src/main.c
+++ b/samples/net/updatehub/src/main.c
@@ -17,7 +17,7 @@
 
 LOG_MODULE_REGISTER(main);
 
-int main(void)
+void main(void)
 {
 	int ret = -1;
 
@@ -29,7 +29,7 @@ int main(void)
 			       server_certificate,
 			       sizeof(server_certificate)) < 0) {
 		LOG_ERR("Failed to register server certificate");
-		return -1;
+		return;
 	}
 
 	if (tls_credential_add(CA_CERTIFICATE_TAG,
@@ -37,7 +37,7 @@ int main(void)
 			       private_key,
 			       sizeof(private_key)) < 0) {
 		LOG_ERR("Failed to register private key");
-		return -1;
+		return;
 	}
 #endif
 
@@ -81,6 +81,4 @@ int main(void)
 		break;
 	}
 #endif
-
-	return ret;
 }

--- a/samples/posix/gettimeofday/src/main.c
+++ b/samples/posix/gettimeofday/src/main.c
@@ -10,7 +10,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 
-int main(void)
+void main(void)
 {
 	struct timeval tv;
 

--- a/samples/userspace/prod_consumer/src/main.c
+++ b/samples/userspace/prod_consumer/src/main.c
@@ -47,7 +47,7 @@ K_QUEUE_DEFINE(shared_queue_outgoing);
 struct k_thread app_a_thread;
 K_THREAD_STACK_DEFINE(app_a_stack, APP_A_STACKSIZE);
 
-void main(void *p1, void *p2, void *p3)
+void main(void)
 {
 	LOG_INF("APP A partition: %p %zu", (void *)app_a_partition.start,
 		(size_t)app_a_partition.size);

--- a/tests/benchmarks/mbedtls/src/benchmark.c
+++ b/tests/benchmarks/mbedtls/src/benchmark.c
@@ -288,7 +288,7 @@ typedef struct {
 	     havege, ctr_drbg, hmac_drbg, rsa, dhm, ecdsa, ecdh;
 } todo_list;
 
-int main(int argc, char *argv[])
+void main(void)
 {
 	mbedtls_ssl_config conf;
 	unsigned char tmp[200];
@@ -1062,6 +1062,4 @@ int main(int argc, char *argv[])
 	}
 #endif
 	mbedtls_printf("\n       Done\n");
-
-	return 0;
 }

--- a/tests/kernel/fp_sharing/generic/src/main.c
+++ b/tests/kernel/fp_sharing/generic/src/main.c
@@ -373,7 +373,7 @@ K_THREAD_DEFINE(pi_low, STACKSIZE, calculate_pi_low, NULL, NULL, NULL,
 K_THREAD_DEFINE(pi_high, STACKSIZE, calculate_pi_high, NULL, NULL, NULL,
 		HI_PRI, THREAD_FP_FLAGS, K_NO_WAIT);
 
-void main(void *p1, void *p2, void *p3)
+void main(void)
 {
 	/* This very old test didn't have a main() function, and would
 	 * dump gcov data immediately. Sleep forever, we'll invoke

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -1478,7 +1478,7 @@ static const struct {
 	{ "Test observer client", test_observer_client, },
 };
 
-int main(int argc, char *argv[])
+void main(void)
 {
 	int count, pass, result;
 
@@ -1495,6 +1495,4 @@ int main(int argc, char *argv[])
 	result = pass == count ? TC_PASS : TC_FAIL;
 
 	TC_END_REPORT(result);
-
-	return 0;
 }


### PR DESCRIPTION
The application main() in Zephyr is defined as having a prototype:
`void main(void)`, as expected by the kernel init (`bg_thread_main`).

So, correct the different samples and tests that were defined
otherwise.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

@andrewboie Regarding the userspace sample, due to my lack of knowledge in this area, I do not know if a different `main()` is expected so I kept that fix in a separate commit. Please tell if it should be done otherwise.