### PR TITLE
kernel: Define application entry point prototype

### DIFF
--- a/include/zephyr.h
+++ b/include/zephyr.h
@@ -17,4 +17,23 @@
 
 #include <kernel.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Optional application main entry point
+ *
+ * A Zephyr application may optionally define a main() function which will
+ * be called by the kernel after it completes the initialization.
+ * Such a function must take no arguments and return no value.
+ *
+ * This function may return but does not have to.
+ */
+void main(void);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* ZEPHYR_INCLUDE_ZEPHYR_H_ */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -274,8 +274,6 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	z_timestamp_main = k_cycle_get_32();
 #endif
 
-	extern void main(void);
-
 	main();
 
 	/* Mark nonessenrial since main() has no more work to do */

--- a/subsys/testsuite/unittest.cmake
+++ b/subsys/testsuite/unittest.cmake
@@ -73,6 +73,7 @@ endif()
 
 target_sources(testbinary PRIVATE
   $ENV{ZEPHYR_BASE}/subsys/testsuite/ztest/src/ztest.c
+  $ENV{ZEPHYR_BASE}/subsys/testsuite/ztest/src/ztest_unit_main.c
   $ENV{ZEPHYR_BASE}/subsys/testsuite/ztest/src/ztest_mock.c
   )
 

--- a/subsys/testsuite/ztest/include/ztest.h
+++ b/subsys/testsuite/ztest/include/ztest.h
@@ -59,16 +59,7 @@ typedef struct esf z_arch_esf_t;
 #include <ztest_assert.h>
 #include <ztest_mock.h>
 #include <ztest_test.h>
+#include <ztest_main_if.h>
 #include <tc_util.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-void test_main(void);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* __ZTEST_H__ */

--- a/subsys/testsuite/ztest/include/ztest_main_if.h
+++ b/subsys/testsuite/ztest/include/ztest_main_if.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SUBSYS_TESTSUITE_ZTEST_INCLUDE_ZTEST_MAIN_IF_H
+#define SUBSYS_TESTSUITE_ZTEST_INCLUDE_ZTEST_MAIN_IF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void test_main(void);
+void end_report(void);
+extern int test_status;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SUBSYS_TESTSUITE_ZTEST_INCLUDE_ZTEST_MAIN_IF_H */

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -25,7 +25,7 @@ ZTEST_DMEM enum {
 	TEST_PHASE_FRAMEWORK
 } phase = TEST_PHASE_FRAMEWORK;
 
-static ZTEST_BMEM int test_status;
+ZTEST_BMEM int test_status;
 
 static int cleanup_test(struct unit_test *test)
 {
@@ -374,16 +374,7 @@ struct k_mem_domain ztest_mem_domain;
 K_APPMEM_PARTITION_DEFINE(ztest_mem_partition);
 #endif
 
-#ifndef KERNEL
-int main(void)
-{
-	z_init_mock();
-	test_main();
-	end_report();
-
-	return test_status;
-}
-#else
+#ifdef KERNEL
 void main(void)
 {
 #ifdef CONFIG_USERSPACE
@@ -433,4 +424,6 @@ void main(void)
 		}
 	}
 }
+#else
+ /* To avoid inclusion conflicts the unit tests main is in ztests_unit_main.c */
 #endif

--- a/subsys/testsuite/ztest/src/ztest_unit_main.c
+++ b/subsys/testsuite/ztest/src/ztest_unit_main.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest_mock.h>
+#include <ztest_main_if.h>
+
+#ifndef KERNEL
+int main(void)
+{
+	z_init_mock();
+	test_main();
+	end_report();
+
+	return test_status;
+}
+#endif /* KERNEL */


### PR DESCRIPTION
kernel: Define application entry point prototype
    
Define in a public header the prototype of the (optional) application `main()`.
    
Until now, this was hidden inside the init code, which lead to some tests and samples defining it with the wrong signature.
    
Also this fixes issues when defining this function in C++ code.

~Note that this PR includes #21100, as that fix is necessary for it~
~But I would not merge this PR until after freeze (as it may break apps which have the same issue as fixed in #21100)~

~Fixes #21094~(already fixed)