### PR TITLE
Bluetooth: Host: Add SMP bt_smp_get_pairing_peer_info

### DIFF
--- a/include/bluetooth/smp.h
+++ b/include/bluetooth/smp.h
@@ -1,0 +1,111 @@
+/**
+ * @file bluetooth/smp.h
+ * Security Manager Protocol implementation header
+ */
+
+/*
+ * Copyright (c) 2015-2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief Security management
+ * @defgroup bt_smp Security management
+ * @ingroup bluetooth
+ * @{
+ */
+
+#include <bluetooth/bluetooth.h>
+
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_SMP_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_SMP_H_
+
+#define BT_SMP_IO_DISPLAY_ONLY			0x00
+#define BT_SMP_IO_DISPLAY_YESNO			0x01
+#define BT_SMP_IO_KEYBOARD_ONLY			0x02
+#define BT_SMP_IO_NO_INPUT_OUTPUT		0x03
+#define BT_SMP_IO_KEYBOARD_DISPLAY		0x04
+
+#define BT_SMP_OOB_DATA_MASK			0x01
+#define BT_SMP_OOB_NOT_PRESENT			0x00
+#define BT_SMP_OOB_PRESENT			0x01
+
+#define BT_SMP_MIN_ENC_KEY_SIZE			7
+#define BT_SMP_MAX_ENC_KEY_SIZE			16
+
+#define BT_SMP_DIST_ENC_KEY			0x01
+#define BT_SMP_DIST_ID_KEY			0x02
+#define BT_SMP_DIST_SIGN			0x04
+#define BT_SMP_DIST_LINK_KEY			0x08
+
+#define BT_SMP_DIST_MASK			0x0f
+
+#define BT_SMP_AUTH_NONE			0x00
+#define BT_SMP_AUTH_BONDING			0x01
+#define BT_SMP_AUTH_MITM			0x04
+#define BT_SMP_AUTH_SC				0x08
+#define BT_SMP_AUTH_KEYPRESS			0x10
+#define BT_SMP_AUTH_CT2				0x20
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Pairing request parameters, Core Spec 5.1 Vol 3 Part H 3.5.1
+ *
+ * @param io_capability IO Capability, octet 1, valid range 0x00-0x04
+ * @param oob_flag OOB data flag, octet 2, valid range 0x00-0x01
+ * @param auth_req AuthReq, octet 3, bits:
+ *   MSB  LSB
+ *   ------0x  Bonding_Flags, range 0x00-0x01
+ *   -----x--  MITM
+ *   ----x---  SC
+ *   ---x----  Keypress
+ *   --x-----  CT2
+ *   xx------  Reserved for future use
+ * @param max_key_size Max Encryption Key Size, octet 4, valid range 0x07-0x10
+ * @param init_key_dist Initiator Key Distribution/Generation, octet 5, bits:
+ *   MSB  LSB
+ *   -------x  EncKey
+ *   ------x-  IdKey
+ *   -----x--  SignKey
+ *   ----x---  LinkKey
+ *   xxxx----  Reserved for future use
+ * @param resp_key_dist Responder Key Dist/Generation, octet 6, see above.
+ *
+ */
+struct bt_smp_pairing {
+	u8_t  io_capability;
+	u8_t  oob_flag;
+	u8_t  auth_req;
+	u8_t  max_key_size;
+	u8_t  init_key_dist;
+	u8_t  resp_key_dist;
+} __packed;
+
+/**
+ * @brief Return pairing req/rsp parameters for peer.
+ *
+ * @details Return pairing req parameters, except Code, for peer associated
+ * with conn object. Can only be called during pairing while waiting for user
+ * input.
+ *
+ * @param conn Connection object.
+ * @param info Pairing info object.
+ *
+ * @return Zero on success or (negative) error code on failure.
+ */
+int bt_smp_get_pairing_peer_info(const struct bt_conn *conn,
+				 struct bt_smp_pairing *info);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_SMP_H_ */

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -27,7 +27,7 @@
 #include "hci_core.h"
 #include "conn_internal.h"
 #include "l2cap_internal.h"
-#include "smp.h"
+#include "smp_internal.h"
 #include "att_internal.h"
 #include "gatt_internal.h"
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -31,7 +31,7 @@
 #include "conn_internal.h"
 #include "l2cap_internal.h"
 #include "keys.h"
-#include "smp.h"
+#include "smp_internal.h"
 #include "att_internal.h"
 #include "gatt_internal.h"
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -41,7 +41,7 @@
 #include "keys.h"
 #include "l2cap_internal.h"
 #include "att_internal.h"
-#include "smp.h"
+#include "smp_internal.h"
 #include "settings.h"
 #include "gatt_internal.h"
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -23,6 +23,7 @@
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
+#include <bluetooth/smp.h>
 #include <bluetooth/l2cap.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_vs.h>
@@ -42,7 +43,7 @@
 #include "conn_internal.h"
 #include "l2cap_internal.h"
 #include "gatt_internal.h"
-#include "smp.h"
+#include "smp_internal.h"
 #include "crypto.h"
 #include "settings.h"
 

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -25,7 +25,7 @@
 #include "common/rpa.h"
 #include "gatt_internal.h"
 #include "hci_core.h"
-#include "smp.h"
+#include "smp_internal.h"
 #include "settings.h"
 #include "keys.h"
 

--- a/subsys/bluetooth/host/smp_internal.h
+++ b/subsys/bluetooth/host/smp_internal.h
@@ -1,5 +1,5 @@
 /**
- * @file smp.h
+ * @file smp_internal.h
  * Security Manager Protocol implementation header
  */
 
@@ -28,43 +28,8 @@ struct bt_smp_hdr {
 #define BT_SMP_ERR_BREDR_PAIRING_IN_PROGRESS	0x0d
 #define BT_SMP_ERR_CROSS_TRANSP_NOT_ALLOWED	0x0e
 
-#define BT_SMP_IO_DISPLAY_ONLY			0x00
-#define BT_SMP_IO_DISPLAY_YESNO			0x01
-#define BT_SMP_IO_KEYBOARD_ONLY			0x02
-#define BT_SMP_IO_NO_INPUT_OUTPUT		0x03
-#define BT_SMP_IO_KEYBOARD_DISPLAY		0x04
-
-#define BT_SMP_OOB_DATA_MASK			0x01
-#define BT_SMP_OOB_NOT_PRESENT			0x00
-#define BT_SMP_OOB_PRESENT			0x01
-
-#define BT_SMP_MIN_ENC_KEY_SIZE			7
-#define BT_SMP_MAX_ENC_KEY_SIZE			16
-
-#define BT_SMP_DIST_ENC_KEY			0x01
-#define BT_SMP_DIST_ID_KEY			0x02
-#define BT_SMP_DIST_SIGN			0x04
-#define BT_SMP_DIST_LINK_KEY			0x08
-
-#define BT_SMP_DIST_MASK			0x0f
-
-#define BT_SMP_AUTH_NONE			0x00
-#define BT_SMP_AUTH_BONDING			0x01
-#define BT_SMP_AUTH_MITM			0x04
-#define BT_SMP_AUTH_SC				0x08
-#define BT_SMP_AUTH_KEYPRESS			0x10
-#define BT_SMP_AUTH_CT2				0x20
-
 #define BT_SMP_CMD_PAIRING_REQ			0x01
 #define BT_SMP_CMD_PAIRING_RSP			0x02
-struct bt_smp_pairing {
-	u8_t  io_capability;
-	u8_t  oob_flag;
-	u8_t  auth_req;
-	u8_t  max_key_size;
-	u8_t  init_key_dist;
-	u8_t  resp_key_dist;
-} __packed;
 
 #define BT_SMP_CMD_PAIRING_CONFIRM		0x03
 struct bt_smp_pairing_confirm {

--- a/subsys/bluetooth/host/smp_null.c
+++ b/subsys/bluetooth/host/smp_null.c
@@ -25,7 +25,7 @@
 #include "hci_core.h"
 #include "conn_internal.h"
 #include "l2cap_internal.h"
-#include "smp.h"
+#include "smp_internal.h"
 
 static struct bt_l2cap_le_chan bt_smp_pool[CONFIG_BT_MAX_CONN];
 

--- a/subsys/mgmt/smp.c
+++ b/subsys/mgmt/smp.c
@@ -8,7 +8,7 @@
 #include "net/buf.h"
 #include "mgmt/mgmt.h"
 #include "mgmt/buf.h"
-#include "smp/smp.h"
+#include "smp/smp_internal.h"
 #include "mgmt/smp.h"
 
 static mgmt_alloc_rsp_fn zephyr_smp_alloc_rsp;


### PR DESCRIPTION
Used to obtain pairing flags from peer before pairing.
Returns bt_smp_pairing for a given bt_conn during smp_pairing_req or
smp_pairing_rsp, which contains IO caps, OOB, AuthReq and keys config.

This function is available through a public SMP API.

Fixes: #21036

Signed-off-by: Martin Rieva <mrrv@demant.com>