### PR TITLE
kconfig: Remove redundant 'default n' and 'prompt' properties

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -117,7 +117,6 @@ config ARC_FIRQ
 config ARC_FIRQ_STACK
 	bool "Enable separate firq stack"
 	depends on ARC_FIRQ && RGF_NUM_BANKS > 1
-	default n
 	help
 	  Use separate stack for FIRQ handing. When the fast irq is also a direct
 	  irq, this will get the minimal interrupt latency.
@@ -167,7 +166,6 @@ config ARC_STACK_PROTECTION
 
 config ARC_USE_UNALIGNED_MEM_ACCESS
 	bool "Enable unaligned access in HW"
-	default n if CPU_ARCEM
 	default y if CPU_ARCHS
 	depends on (CPU_ARCEM && !ARC_HAS_SECURE) || CPU_ARCHS
 	help
@@ -235,8 +233,7 @@ config SJLI_TABLE_SIZE
 	  sjli instruction.
 
 config ARC_SECURE_FIRMWARE
-	prompt "Generate Secure Firmware"
-	bool
+	bool "Generate Secure Firmware"
 	depends on ARC_HAS_SECURE
 	default y if TRUSTED_EXECUTION_SECURE
 	help
@@ -252,8 +249,7 @@ config ARC_SECURE_FIRMWARE
 	  and normal resources of the ARC processors.
 
 config ARC_NORMAL_FIRMWARE
-	prompt "Generate Normal Firmware"
-	bool
+	bool "Generate Normal Firmware"
 	depends on !ARC_SECURE_FIRMWARE
 	depends on ARC_HAS_SECURE
 	default y if TRUSTED_EXECUTION_NONSECURE

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -41,9 +41,7 @@ config CPU_APOLLO_LAKE
 #
 
 config X86_64
-	bool
-	prompt "Run in 64-bit mode"
-	default n
+	bool "Run in 64-bit mode"
 	select 64BIT
 	select USE_SWITCH
 	select USE_SWITCH_SUPPORTED
@@ -85,7 +83,6 @@ endchoice
 
 config ACPI
 	bool "ACPI (Advanced Configuration and Power Interface) support"
-	default n
 	help
 	  Allow retrieval of platform configuration at runtime.
 
@@ -110,7 +107,6 @@ if MULTIBOOT
 
 config MULTIBOOT_INFO
 	bool "Preserve multiboot information structure"
-	default n
 	help
 	  Multiboot passes a pointer to an information structure to the
 	  kernel entry point. Some drivers (e.g., the multiboot framebuffer
@@ -119,14 +115,12 @@ config MULTIBOOT_INFO
 
 config MULTIBOOT_MEMMAP
 	bool "Use multiboot memory map if provided"
-	default n
 	select MULTIBOOT_INFO
 	help
 	  Use the multiboot memory map if the loader provides one.
 
 config MULTIBOOT_FRAMEBUF
 	bool "Multiboot framebuffer support"
-	default n
 	select DISPLAY
 	select FRAMEBUF_DISPLAY
 	select MULTIBOOT_INFO

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -27,7 +27,6 @@ source "drivers/display/Kconfig.dummy"
 config FRAMEBUF_DISPLAY
 	# Hidden, selected by client drivers.
 	bool
-	default n
 	help
 	  Enable framebuffer-based display 'helper' driver.
 

--- a/drivers/ethernet/Kconfig.liteeth
+++ b/drivers/ethernet/Kconfig.liteeth
@@ -20,7 +20,6 @@ config ETH_LITEETH_0_IRQ_PRI
 config ETH_LITEETH_0_RANDOM_MAC
 	bool "Random MAC address"
 	depends on ENTROPY_GENERATOR
-	default n
 	help
 	  Generate a random MAC address dynamically.
 

--- a/drivers/flash/Kconfig.simulator
+++ b/drivers/flash/Kconfig.simulator
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig FLASH_SIMULATOR
-	bool
-	prompt "Flash simulator"
+	bool "Flash simulator"
 	select STATS
 	select STATS_NAMES
 	select FLASH_HAS_PAGE_LAYOUT
@@ -16,8 +15,7 @@ menuconfig FLASH_SIMULATOR
 if FLASH_SIMULATOR
 
 config FLASH_SIMULATOR_UNALIGNED_READ
-	bool
-	prompt "Allow read access to be unaligned"
+	bool "Allow read access to be unaligned"
 	default y
 	help
 	 If selected, the reading operation does not check if access is aligned.
@@ -25,23 +23,19 @@ config FLASH_SIMULATOR_UNALIGNED_READ
 	 a specific FLASH interface that requires aligned read access.
 
 config FLASH_SIMULATOR_DOUBLE_WRITES
-	bool
-	prompt "Allow program units to be programmed more than once"
-	default n
+	bool "Allow program units to be programmed more than once"
 	help
 	 If selected, writing to a non-erased program unit will succeed, otherwise, it will return an error.
 	 Keep in mind that write operations can only pull bits to zero, regardless.
 
 config FLASH_SIMULATOR_ERASE_PROTECT
-	bool
-	prompt "Enable erase protection on write protection"
+	bool "Enable erase protection on write protection"
 	default y
 	help
 	 If selected, turning on write protection will also prevent erasing.
 
 config FLASH_SIMULATOR_SIMULATE_TIMING
-	bool
-	prompt "Enable hardware timing simulation"
+	bool "Enable hardware timing simulation"
 
 config FLASH_SIMULATOR_STAT_PAGE_COUNT
 	int "Pages under statistic"
@@ -59,20 +53,17 @@ config FLASH_SIMULATOR_STAT_PAGE_COUNT
 if FLASH_SIMULATOR_SIMULATE_TIMING
 
 config FLASH_SIMULATOR_MIN_READ_TIME_US
-	int
-	prompt "Minimum read time (µS)"
+	int "Minimum read time (µS)"
 	default 2
 	range 1 1000000
 
 config FLASH_SIMULATOR_MIN_WRITE_TIME_US
-	int
-	prompt "Minimum write time (µS)"
+	int "Minimum write time (µS)"
 	default 100
 	range 1 1000000
 
 config FLASH_SIMULATOR_MIN_ERASE_TIME_US
-	int
-	prompt "Minimum erase time (µS)"
+	int "Minimum erase time (µS)"
 	default 2000
 	range 1 1000000
 

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -10,7 +10,9 @@ menuconfig LOAPIC
 	depends on X86
 	help
 	  This option selects local APIC as the interrupt controller.
+
 if LOAPIC
+
 config LOAPIC_BASE_ADDRESS
 	hex "Local APIC Base Address"
 	default 0xFEE00000
@@ -19,7 +21,6 @@ config LOAPIC_BASE_ADDRESS
 
 config X2APIC
 	bool "Access local APIC in x2APIC mode"
-	default n
 	help
 	  If your local APIC supports x2APIC mode, turn this on.
 

--- a/drivers/pcie/Kconfig
+++ b/drivers/pcie/Kconfig
@@ -13,7 +13,6 @@ if PCIE
 
 config PCIE_MSI
 	bool "Enable support for PCI(e) MSI"
-	default n
 	help
 	  Use Message-Signaled Interrupts where possible. With this option
 	  enabled, PCI(e) devices which support MSI will be configured (at
@@ -22,7 +21,6 @@ config PCIE_MSI
 
 config PCIE_SHELL
 	bool "Enable PCIe/new PCI Shell"
-	default n
 	depends on SHELL
 	help
 	  Enable commands for debugging PCI(e) using the built-in shell.

--- a/drivers/serial/Kconfig.ns16550
+++ b/drivers/serial/Kconfig.ns16550
@@ -34,7 +34,6 @@ config UART_NS16750
 
 config UART_NS16550_ACCESS_WORD_ONLY
 	bool "NS16550 only allows word access"
-	default n
 	depends on UART_NS16550
 	help
 	  In some case, e.g. ARC HS Development kit, the peripheral space of ns

--- a/drivers/spi/Kconfig.dw
+++ b/drivers/spi/Kconfig.dw
@@ -34,7 +34,6 @@ config SPI_DW_FIFO_DEPTH
 
 config SPI_DW_ACCESS_WORD_ONLY
 	bool "DesignWare SPI only allows word access"
-	default n
 	depends on SPI_DW
 	help
 	  In some case, e.g. ARC HS Development kit, the peripheral space of

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -33,7 +33,6 @@ config APIC_TIMER_IRQ_PRIORITY
 
 config APIC_TIMER_TSC
 	bool "Use invariant TSC for z_timer_cycle_get_32()"
-	default n
 	help
 	  If your CPU supports invariant TSC, and you know the ratio of the
 	  TSC frequency to CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC (the local APIC

--- a/samples/drivers/espi/Kconfig
+++ b/samples/drivers/espi/Kconfig
@@ -19,7 +19,6 @@ config ESPI_VIRTUAL_WIRE_TIMEOUT
 
 config ESPI_GPIO_DEV_NEEDED
 	bool "GPIO required for minimum eSPI handshake"
-	default n
 
 if ESPI_GPIO_DEV_NEEDED
 

--- a/soc/arm/microchip_mec/mec1501/Kconfig.soc
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.soc
@@ -28,7 +28,6 @@ config SOC_MEC1501_PROC_CLK_DIV
 
 config SOC_MEC1501_EXT_32K
 	bool "Use external 32KHz clock source"
-	default n
 	help
 	  Use an external 32768 Hz clock source for PLL reference
 	  clock.
@@ -41,7 +40,6 @@ config SOC_MEC1501_EXT_32K
 config SOC_MEC1501_EXT_32K_CRYSTAL
 	bool "External 32KHz is a crystal"
 	depends on SOC_MEC1501_EXT_32K
-	default n
 	help
 	  Choose a crystal as the external 32KHz source.
 
@@ -54,7 +52,6 @@ config SOC_MEC1501_EXT_32K_CRYSTAL
 config SOC_MEC1501_EXT_32K_PARALLEL_CRYSTAL
 	bool "Use parallel connected 32KHz crystal"
 	depends on SOC_MEC1501_EXT_32K_CRYSTAL
-	default n
 	help
 	  Choose external 32KHz crystal connection.
 

--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -42,7 +42,6 @@ config BT_GATT_SERVICE_CHANGED
 
 config BT_GATT_DYNAMIC_DB
 	bool "GATT dynamic database support"
-	default n
 	depends on BT_GATT_SERVICE_CHANGED
 	help
 	  This option enables registering/unregistering services at runtime.

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -33,7 +33,6 @@ config BT_MESH_PROVISIONER
 	bool "Provisioner support"
 	select BT_ECC
 	select BT_MESH_PROV
-	default n
 	help
 	  Enable this option to have support for provisioning remote devices.
 

--- a/subsys/bluetooth/services/Kconfig.bas
+++ b/subsys/bluetooth/services/Kconfig.bas
@@ -6,7 +6,6 @@
 menuconfig BT_GATT_BAS
 	bool "Enable GATT Battery service"
 	select SENSOR
-	default n
 
 if BT_GATT_BAS
 

--- a/subsys/bluetooth/services/Kconfig.hrs
+++ b/subsys/bluetooth/services/Kconfig.hrs
@@ -5,7 +5,6 @@
 
 menuconfig BT_GATT_HRS
 	bool "Enable GATT Heart Rate service"
-	default n
 
 if BT_GATT_HRS
 

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -266,7 +266,6 @@ config LOG_CMDS
 
 config LOG_FRONTEND
 	bool "Enable frontend"
-	default n
 	select LOG_IMMEDIATE
 	help
 	  When enabled, logs are redirected to a custom frontend instead

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -293,7 +293,6 @@ config NET_TCP_BACKLOG_SIZE
 
 config NET_TCP_AUTO_ACCEPT
 	bool "Auto accept incoming TCP data"
-	default n
 	depends on NET_TCP
 	help
 	  Automatically accept incoming TCP data packet to the valid
@@ -382,7 +381,6 @@ endchoice
 
 config NET_TEST_PROTOCOL
 	bool "Enable JSON based test protocol (UDP)"
-	default n
 	help
 	  Enable JSON based test protocol (UDP).
 

--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -145,8 +145,7 @@ config USB_DFU_DETACH_TIMEOUT
 	default 1000
 
 config USB_DFU_DEFAULT_POLLTIMEOUT
-	prompt "Default value for bwPollTimeout"
-	int
+	int "Default value for bwPollTimeout"
 	depends on USB_DFU_CLASS
 	default 256
 	range 0 1000

--- a/tests/drivers/spi/spi_loopback/Kconfig
+++ b/tests/drivers/spi/spi_loopback/Kconfig
@@ -35,4 +35,3 @@ config SPI_LOOPBACK_FAST_FREQ
 
 config SPI_LOOPBACK_MODE_LOOP
 	bool "Configure the SPI in LOOP mode, so that no extra wiring is needed"
-	default n


### PR DESCRIPTION
Bool symbols implicitly default to 'n'.

A 'default n' can make sense e.g. in a Kconfig.defconfig file, if you
want to override a 'default y' on the base definition of the symbol. It
isn't used like that on any of these symbols though.

Also replace some

    config
    	prompt "foo"
    	bool/int

with the more common shorthand

    config
    	bool/int "foo"

See the 'Style recommendations and shorthands' section in
https://docs.zephyrproject.org/latest/guides/kconfig/index.html.