### PR TITLE
bluetooth: h5: Fix memory access error

### DIFF
--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -501,6 +501,9 @@ static void bt_uart_isr(struct device *unused)
 				h5.rx_state = END;
 				break;
 			}
+			if (!remaining) {
+				h5.rx_state = END;
+			}
 			break;
 		case PAYLOAD:
 			if (h5_unslip_byte(&byte) < 0) {

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -397,6 +397,12 @@ static void h5_process_complete_packet(u8_t *hdr)
 		net_buf_put(&h5.rx_queue, buf);
 		break;
 	case HCI_EVENT_PKT:
+		if (buf->len > sizeof(struct bt_hci_evt_hdr) &&
+			bt_hci_evt_is_prio(((struct bt_hci_evt_hdr *)buf->data)->evt)) {
+			hexdump("=> ", buf->data, buf->len);
+			bt_recv_prio(buf);
+			break;
+		}
 	case HCI_ACLDATA_PKT:
 		hexdump("=> ", buf->data, buf->len);
 		bt_recv(buf);

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -406,14 +406,7 @@ static void h5_process_complete_packet(u8_t *hdr)
 
 static inline struct net_buf *get_evt_buf(u8_t evt)
 {
-	struct net_buf *buf;
-
-	buf = bt_buf_get_evt(evt, false, K_NO_WAIT);
-	if (buf) {
-		net_buf_add_u8(h5.rx_buf, evt);
-	}
-
-	return buf;
+	return bt_buf_get_evt(evt, false, K_NO_WAIT);
 }
 
 static void bt_uart_isr(struct device *unused)


### PR DESCRIPTION
Fix memory access error, handle the case where H5_HDR_LEN
is 0 (e.g: ACK packet), high-priority events are processed
using bt_recv_prio, otherwise the assertion in
hci_core.c: hci_event function cannot be passed

Signed-off-by: ZhongYao Luo <LuoZhongYao@gmail.com>