### PR TITLE
drivers: i2c_bitbang: read SDA on high clock

### DIFF
--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -101,6 +101,9 @@ static void i2c_start(struct i2c_bitbang *context)
 	}
 	i2c_set_sda(context, 0);
 	i2c_delay(context->delays[T_HD_STA]);
+
+	i2c_set_scl(context, 0);
+	i2c_delay(context->delays[T_LOW]);
 }
 
 static void i2c_repeated_start(struct i2c_bitbang *context)
@@ -111,6 +114,9 @@ static void i2c_repeated_start(struct i2c_bitbang *context)
 
 static void i2c_stop(struct i2c_bitbang *context)
 {
+	i2c_set_scl(context, 1);
+	i2c_delay(context->delays[T_HIGH]);
+
 	if (i2c_get_sda(context)) {
 		/*
 		 * SDA is already high, so we need to make it low so that
@@ -128,25 +134,28 @@ static void i2c_stop(struct i2c_bitbang *context)
 
 static void i2c_write_bit(struct i2c_bitbang *context, int bit)
 {
-	i2c_set_scl(context, 0);
 	/* SDA hold time is zero, so no need for a delay here */
 	i2c_set_sda(context, bit);
-	i2c_delay(context->delays[T_LOW]);
 	i2c_set_scl(context, 1);
 	i2c_delay(context->delays[T_HIGH]);
+	i2c_set_scl(context, 0);
+	i2c_delay(context->delays[T_LOW]);
 }
 
 static bool i2c_read_bit(struct i2c_bitbang *context)
 {
 	bool bit;
 
-	i2c_set_scl(context, 0);
 	/* SDA hold time is zero, so no need for a delay here */
 	i2c_set_sda(context, 1); /* Stop driving low, so slave has control */
-	i2c_delay(context->delays[T_LOW]);
-	bit = i2c_get_sda(context);
+
 	i2c_set_scl(context, 1);
 	i2c_delay(context->delays[T_HIGH]);
+
+	bit = i2c_get_sda(context);
+
+	i2c_set_scl(context, 0);
+	i2c_delay(context->delays[T_LOW]);
 	return bit;
 }
 


### PR DESCRIPTION
According to the I2C spec, the SDA signal must be
stable as long as the SCL signal is high (which
means it can change only when clock is low).

This commit reworks clock signal handling
in such a way that all reads are done
when SCL is high and SDA is stable.

Signed-off-by: Mateusz Holenko <mholenko@antmicro.com>