### PR TITLE
drivers/pwm: Fix abs() usage in xec driver

### DIFF
--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -216,7 +216,8 @@ static struct xec_params *xec_compare_params(u32_t target_freq,
 				lc_params->off);
 	}
 
-	if (abs(target_freq - freq_h) < abs(target_freq - freq_l)) {
+	if (abs((int)target_freq - (int)freq_h) <
+	    abs((int)target_freq - (int)freq_l)) {
 		params = hc_params;
 	} else {
 		params = lc_params;


### PR DESCRIPTION
Seems to be fine to temporarly cast to int there as frequencies are in
Mhz and not Ghz.

Fixes #20497
Coverity CID: 205638