### PR TITLE
samples: net: echo-server: Generate coverage report

### DIFF
--- a/samples/net/sockets/echo_server/prj.conf
+++ b/samples/net/sockets/echo_server/prj.conf
@@ -34,6 +34,7 @@ CONFIG_NET_MAX_CONTEXTS=10
 
 # Network shell
 CONFIG_NET_SHELL=y
+CONFIG_SHELL=y
 
 # Network application options and configuration
 CONFIG_NET_CONFIG_SETTINGS=y

--- a/samples/net/sockets/echo_server/src/echo-server.c
+++ b/samples/net/sockets/echo_server/src/echo-server.c
@@ -13,6 +13,7 @@ LOG_MODULE_REGISTER(net_echo_server_sample, LOG_LEVEL_DBG);
 #include <zephyr.h>
 #include <linker/sections.h>
 #include <errno.h>
+#include <shell/shell.h>
 
 #include <net/net_core.h>
 #include <net/tls_credentials.h>
@@ -81,6 +82,24 @@ static void init_app(void)
 
 	init_vlan();
 }
+
+static int cmd_sample_quit(const struct shell *shell,
+			  size_t argc, char *argv[])
+{
+	quit();
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sample_commands,
+	SHELL_CMD(quit, NULL,
+		  "Quit the sample application\n",
+		  cmd_sample_quit),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(sample, &sample_commands,
+		   "Sample application commands", NULL);
 
 void main(void)
 {


### PR DESCRIPTION
Add "sample quit" shell command which can be used to stop the
sample application and allows the generation of coverage report.

Fixes #21099

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>