### PR TITLE
drivers: spi_nrfx_spim: Fix handling of extended SPIM configuration

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -360,12 +360,12 @@ static int spim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 }
 #endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
 
-#if NRFX_CHECK(NRFX_SPIM_EXTENDED_ENABLED)
-#define SPI_NRFX_SPIM_EXTENDED_CONFIG(idx) \
-	.rx_delay = CONFIG_SPI_##idx##_NRF_RX_DELAY,
-#else
-#define SPI_NRFX_SPIM_EXTENDED_CONFIG(idx)
-#endif
+#define SPI_NRFX_SPIM_EXTENDED_CONFIG(idx)				\
+	COND_CODE_1(IS_ENABLED(NRFX_SPIM_EXTENDED_ENABLED),		\
+		(COND_CODE_1(SPIM##idx##_FEATURE_RXDELAY_PRESENT,	\
+			(.rx_delay = CONFIG_SPI_##idx##_NRF_RX_DELAY,),	\
+			())),						\
+		())
 
 #define SPI_NRFX_SPIM_DEVICE(idx)					       \
 	static int spi_##idx##_init(struct device *dev)			       \


### PR DESCRIPTION
Fill the `rx_delay` field in the SPIM configuration structure only when
the RXDELAY feature is present in a given SPIM instance, to prevent
compilation errors when some other SPIM instance is enabled together
with SPIM3.

Fixes #21126.