### PR TITLE
drivers: spi: nrfx: Move MISO lines pull configuration to DT

### DIFF
--- a/drivers/spi/Kconfig.nrfx
+++ b/drivers/spi/Kconfig.nrfx
@@ -247,52 +247,6 @@ config SPI_NRFX_RAM_BUFFER_SIZE
 	  supplying buffers located in flash to the driver, otherwise such
 	  transfers will fail.
 
-choice
-	prompt "nRF SPIM MISO pin pull configuration"
-	default SPI_NRFX_SPIM_MISO_PULL_DOWN
-
-config SPI_NRFX_SPIM_MISO_NO_PULL
-	bool "no pull"
-	help
-	  Disable MISO pin pull.
-
-config SPI_NRFX_SPIM_MISO_PULL_DOWN
-	bool "pull down"
-	help
-	  Enable MISO pin pull down.
-
-config SPI_NRFX_SPIM_MISO_PULL_UP
-	bool "pull up"
-	help
-	  Enable MISO pin pull up.
-
-endchoice
-
 endif # NRFX_SPIM
-
-if NRFX_SPI
-
-choice
-	prompt "nRF SPI MISO pin pull configuration"
-	default SPI_NRFX_SPI_MISO_PULL_DOWN
-
-config SPI_NRFX_SPI_MISO_NO_PULL
-	bool "no pull"
-	help
-	  Disable MISO pin pull.
-
-config SPI_NRFX_SPI_MISO_PULL_DOWN
-	bool "pull down"
-	help
-	  Enable MISO pin pull down.
-
-config SPI_NRFX_SPI_MISO_PULL_UP
-	bool "pull up"
-	help
-	  Enable MISO pin pull up.
-
-endchoice
-
-endif # NRFX_SPI
 
 endif # SPI_NRFX

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -360,6 +360,21 @@ static int spim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 }
 #endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
 
+#define SPIM_NRFX_MISO_PULL_DOWN(idx) \
+	IS_ENABLED(DT_NORDIC_NRF_SPIM_SPI_##idx##_MISO_PULL_DOWN)
+
+#define SPIM_NRFX_MISO_PULL_UP(idx) \
+	IS_ENABLED(DT_NORDIC_NRF_SPIM_SPI_##idx##_MISO_PULL_UP)
+
+#define SPIM_NRFX_MISO_PULL(idx)			\
+	(SPIM_NRFX_MISO_PULL_UP(idx)			\
+		? SPIM_NRFX_MISO_PULL_DOWN(idx)		\
+			? -1 /* invalid configuration */\
+			: NRF_GPIO_PIN_PULLUP		\
+		: SPIM_NRFX_MISO_PULL_DOWN(idx)		\
+			? NRF_GPIO_PIN_PULLDOWN		\
+			: NRF_GPIO_PIN_NOPULL)
+
 #define SPI_NRFX_SPIM_EXTENDED_CONFIG(idx)				\
 	COND_CODE_1(IS_ENABLED(NRFX_SPIM_EXTENDED_ENABLED),		\
 		(COND_CODE_1(SPIM##idx##_FEATURE_RXDELAY_PRESENT,	\
@@ -368,6 +383,10 @@ static int spim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 		())
 
 #define SPI_NRFX_SPIM_DEVICE(idx)					       \
+	BUILD_ASSERT_MSG(						       \
+		!SPIM_NRFX_MISO_PULL_UP(idx) || !SPIM_NRFX_MISO_PULL_DOWN(idx),\
+		"SPIM"#idx						       \
+		": cannot enable both pull-up and pull-down on MISO line");    \
 	static int spi_##idx##_init(struct device *dev)			       \
 	{								       \
 		IRQ_CONNECT(NRFX_IRQ_NUMBER_GET(NRF_SPIM##idx),		       \
@@ -392,6 +411,7 @@ static int spim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 			.frequency = NRF_SPIM_FREQ_4M,			       \
 			.mode      = NRF_SPIM_MODE_0,			       \
 			.bit_order = NRF_SPIM_BIT_ORDER_MSB_FIRST,	       \
+			.miso_pull = SPIM_NRFX_MISO_PULL(idx),		       \
 			SPI_NRFX_SPIM_EXTENDED_CONFIG(idx)		       \
 		}							       \
 	};								       \

--- a/dts/bindings/spi/nordic,nrf-spi.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi.yaml
@@ -8,3 +8,14 @@ description: Nordic nRF family SPI (SPI master)
 compatible: "nordic,nrf-spi"
 
 include: nordic,nrf-spi-common.yaml
+
+properties:
+    miso-pull-up:
+      type: boolean
+      required: false
+      description: Enable pull-up on MISO line
+
+    miso-pull-down:
+      type: boolean
+      required: false
+      description: Enable pull-down on MISO line

--- a/dts/bindings/spi/nordic,nrf-spim.yaml
+++ b/dts/bindings/spi/nordic,nrf-spim.yaml
@@ -8,3 +8,14 @@ description: Nordic nRF family SPIM (SPI master with EasyDMA)
 compatible: "nordic,nrf-spim"
 
 include: nordic,nrf-spi-common.yaml
+
+properties:
+    miso-pull-up:
+      type: boolean
+      required: false
+      description: Enable pull-up on MISO line
+
+    miso-pull-down:
+      type: boolean
+      required: false
+      description: Enable pull-down on MISO line


### PR DESCRIPTION
After switching to nrfx 2.0.0, the Kconfig choice options that allowed
enabling of pull-up or pull-down for MISO lines in SPIs and SPIMs are
not properly supported, they are simply ignored. This commit restores
the possibility of applying pull configuration for MISO lines.

In earlier nrfx versions, the MISO pull configuration could be only
set globally, in nrfx_config files, for all SPI and SPIM instances
together. Since nrfx 2.0.0, this configuration can be applied per
instance. This commit takes advantage of this possibility and instead
of using a common Kconfig option as a global setting for all instances,
allows applying individual instance settings via devicetree.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>