### PR TITLE
soc: same70: Fix incorrect default config value

### DIFF
--- a/soc/arm/atmel_sam/same70/Kconfig.soc
+++ b/soc/arm/atmel_sam/same70/Kconfig.soc
@@ -158,7 +158,6 @@ config SOC_ATMEL_SAME70_WAIT_MODE
 
 config SOC_ATMEL_SAME70_DISABLE_ERASE_PIN
 	bool "Disable ERASE pin"
-	default 0
 	help
 	  At reset ERASE pin is configured in System IO mode. Asserting the ERASE
 	  pin at '1' will completely erase Flash memory. Setting this option will


### PR DESCRIPTION
The type of SOC_ATMEL_SAME70_DISABLE_ERASE_PIN is bool, yet its default
is specified as an int value of 0.

This commit removes the implied `default 0`, which is equivalent to
`default n`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>