### PR TITLE
soc: same70: Disable watchdog when watchdog driver is disabled

### DIFF
--- a/soc/arm/atmel_sam/same70/Kconfig.soc
+++ b/soc/arm/atmel_sam/same70/Kconfig.soc
@@ -165,4 +165,19 @@ config SOC_ATMEL_SAME70_DISABLE_ERASE_PIN
 	  switch the pin to general IO mode giving control of the pin to the GPIO
 	  module.
 
+config SOC_ATMEL_SAME70_DISABLE_WDT
+	bool "Disable watchdog"
+	depends on !WDT_SAM
+	default y
+	help
+	  Watchdog is enabled by default on the SAME70 SoC. When the watchdog
+	  driver is not used, setting this option will disable the watchdog
+	  and prevent unintentional processor reset; otherwise, watchdog state
+	  is governed by the watchdog driver.
+
+	  If the application configures watchdog on its own and does not rely
+	  on the Zephyr-provided watchdog driver, this option must be disabled
+	  to leave watchdog enabled, as SAME70 watchdog cannot be re-enabled
+	  until reset, once disabled.
+
 endif # SOC_SERIES_SAME70

--- a/soc/arm/atmel_sam/same70/soc_config.c
+++ b/soc/arm/atmel_sam/same70/soc_config.c
@@ -51,6 +51,17 @@ static int atmel_same70_config(struct device *dev)
 	}
 #endif
 
+#ifdef CONFIG_SOC_ATMEL_SAME70_DISABLE_WDT
+	/*
+	 * Disable the watchdog to prevent unintentional processor reset when
+	 * the watchdog driver is not enabled and the application does not
+	 * configure the watchdog on its own.
+	 */
+	 Wdt *wdt = (Wdt *)DT_WDT_SAM_BASE_ADDRESS;
+
+	 wdt->WDT_MR |= WDT_MR_WDDIS;
+#endif
+
 	return 0;
 }
 


### PR DESCRIPTION
This commit adds a new SAME70 SoC configuration option for disabling
the watchdog when the watchdog driver is not enabled.

The CONFIG_SOC_ATMEL_SAME70_DISABLE_WDT configuration option serves
two purposes:

1. If enabled, disables the watchdog by default when the watchdog
  driver is not enabled in order to prevent unintentional processor
  reset.

2. If disabled, allows the application to configure the watchdog on
  its own. Note that the SAM watchdog timer cannot be re-enabled until
  reset, once disabled.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>