### PR TITLE
boards: arm: nordic: nrf5340_dk_nrf5340_cpuapp dts UART config for BLE

### DIFF
--- a/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpuapp_common.dts
@@ -13,6 +13,8 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
+		zephyr,bt-mon-uart = &uart0;
+		zephyr,bt-c2h-uart = &uart0;
 	};
 
 	leds {

--- a/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340_dk_nrf5340/nrf5340_dk_nrf5340_cpunet.dts
@@ -16,6 +16,8 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
+		zephyr,bt-mon-uart = &uart0;
+		zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
 		zephyr,code-partition = &slot0_partition;


### PR DESCRIPTION
Add dts configs for bt-c2h-uart and bt-mon-uart. These are used by
the hci_uart sample and BT_DEBUG_MONITOR.

Signed-off-by: Rubin Gerritsen <Rubin.Gerritsen@nordicsemi.no>