### PR TITLE
[TOPIC-GPIO] update flags to support output initialization to a logic level

### DIFF
--- a/include/dt-bindings/gpio/gpio.h
+++ b/include/dt-bindings/gpio/gpio.h
@@ -84,8 +84,8 @@
 #define GPIO_DIR_OUT            (1 << 9) /* GPIO_OUTPUT */
 #define GPIO_PUD_PULL_UP	GPIO_PULL_UP
 #define GPIO_PUD_PULL_DOWN	GPIO_PULL_DOWN
-#define GPIO_INT_ACTIVE_LOW     (1 << 16) /* GPIO_INT_LOW_0 */
-#define GPIO_INT_ACTIVE_HIGH    (1 << 17) /* GPIO_INT_HIGH_1 */
+#define GPIO_INT_ACTIVE_LOW     (1 << 17) /* GPIO_INT_LOW_0 */
+#define GPIO_INT_ACTIVE_HIGH    (1 << 18) /* GPIO_INT_HIGH_1 */
 /** @endcond */
 
 /**

--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -18,7 +18,7 @@
 void main(void)
 {
 	struct device *dev;
-	bool led_is_on = false;
+	bool led_is_on = true;
 	int ret;
 
 	dev = device_get_binding(DT_ALIAS_LED0_GPIOS_CONTROLLER);
@@ -26,8 +26,9 @@ void main(void)
 		return;
 	}
 
-	ret = gpio_pin_configure(dev, DT_ALIAS_LED0_GPIOS_PIN, GPIO_OUTPUT |
-				 DT_ALIAS_LED0_GPIOS_FLAGS);
+	ret = gpio_pin_configure(dev, DT_ALIAS_LED0_GPIOS_PIN,
+				 GPIO_OUTPUT_ACTIVE
+				 | DT_ALIAS_LED0_GPIOS_FLAGS);
 	if (ret < 0) {
 		return;
 	}


### PR DESCRIPTION
Extend the physical level `GPIO_OUTPUT_{HIGH,LOW}` configuration with `GPIO_OUTPUT_{ACTIVE,INACTIVE}` for logic level initialization.  This enables use of device-tree configuration flags in calls to `gpio_pin_configure()` to set the logic level without having to determine the corresponding physical level.

Update the blinky to use this feature.