### PR TITLE
Bluetooth: host: Rethink bt unpair all

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1836,20 +1836,6 @@ void bt_conn_foreach(int type, void (*func)(struct bt_conn *conn, void *data),
 #endif /* defined(CONFIG_BT_BREDR) */
 }
 
-static void disconnect_all(struct bt_conn *conn, void *data)
-{
-	u8_t *id = (u8_t *)data;
-
-	if (conn->id == *id && conn->state == BT_CONN_CONNECTED) {
-		bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-	}
-}
-
-void bt_conn_disconnect_all(u8_t id)
-{
-	bt_conn_foreach(BT_CONN_TYPE_ALL, disconnect_all, &id);
-}
-
 struct bt_conn *bt_conn_ref(struct bt_conn *conn)
 {
 	atomic_inc(&conn->ref);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1668,35 +1668,10 @@ static int set_flow_control(void)
 }
 #endif /* CONFIG_BT_HCI_ACL_FLOW_CONTROL */
 
-static int bt_clear_all_pairings(u8_t id)
-{
-	bt_conn_disconnect_all(id);
-
-	if (IS_ENABLED(CONFIG_BT_SMP)) {
-		bt_keys_clear_all(id);
-	}
-
-	if (IS_ENABLED(CONFIG_BT_BREDR)) {
-		bt_keys_link_key_clear_addr(NULL);
-	}
-
-	return 0;
-}
-
-int bt_unpair(u8_t id, const bt_addr_le_t *addr)
+static void unpair(u8_t id, const bt_addr_le_t *addr)
 {
 	struct bt_keys *keys = NULL;
-	struct bt_conn *conn;
-
-	if (id >= CONFIG_BT_ID_MAX) {
-		return -EINVAL;
-	}
-
-	if (!addr || !bt_addr_le_cmp(addr, BT_ADDR_LE_ANY)) {
-		return bt_clear_all_pairings(id);
-	}
-
-	conn = bt_conn_lookup_addr_le(id, addr);
+	struct bt_conn *conn = bt_conn_lookup_addr_le(id, addr);
 	if (conn) {
 		/* Clear the conn->le.keys pointer since we'll invalidate it,
 		 * and don't want any subsequent code (like disconnected
@@ -1731,7 +1706,27 @@ int bt_unpair(u8_t id, const bt_addr_le_t *addr)
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		bt_gatt_clear(id, addr);
 	}
+}
 
+static void unpair_remote(const struct bt_bond_info *info, void *data)
+{
+	u8_t *id = (u8_t *) data;
+
+	unpair(*id, &info->addr);
+}
+
+int bt_unpair(u8_t id, const bt_addr_le_t *addr)
+{
+	if (id >= CONFIG_BT_ID_MAX) {
+		return -EINVAL;
+	}
+
+	if (!addr || !bt_addr_le_cmp(addr, BT_ADDR_LE_ANY)) {
+		bt_foreach_bond(id, unpair_remote, &id);
+		return 0;
+	}
+
+	unpair(id, addr);
 	return 0;
 }
 

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -263,24 +263,6 @@ void bt_keys_clear(struct bt_keys *keys)
 	(void)memset(keys, 0, sizeof(*keys));
 }
 
-static void keys_clear_id(struct bt_keys *keys, void *data)
-{
-	u8_t *id = data;
-
-	if (*id == keys->id) {
-		if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-			bt_gatt_clear(*id, &keys->addr);
-		}
-
-		bt_keys_clear(keys);
-	}
-}
-
-void bt_keys_clear_all(u8_t id)
-{
-	bt_keys_foreach(BT_KEYS_ALL, keys_clear_id, &id);
-}
-
 #if defined(CONFIG_BT_SETTINGS)
 int bt_keys_store(struct bt_keys *keys)
 {

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -78,7 +78,6 @@ struct bt_keys *bt_keys_find_addr(u8_t id, const bt_addr_le_t *addr);
 
 void bt_keys_add_type(struct bt_keys *keys, int type);
 void bt_keys_clear(struct bt_keys *keys);
-void bt_keys_clear_all(u8_t id);
 
 #if defined(CONFIG_BT_SETTINGS)
 int bt_keys_store(struct bt_keys *keys);


### PR DESCRIPTION
Instead of having all (=addr NULL or BT_ADDR_LE_ANY to bt_unpair) as a
special case, iterate over all connected peers and unpair them the
regular way. This means bt_gatt_clear is called too. Doing this way
allows us to remove a lot of (now) unused code as well.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>

Related: https://github.com/zephyrproject-rtos/zephyr/pull/21132