### PR TITLE
[RFC] drivers: watchdog: Make WDT_DISABLE_AT_BOOT default to y

### DIFF
--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -14,8 +14,13 @@ if WATCHDOG
 
 config WDT_DISABLE_AT_BOOT
 	bool "Disable at boot"
+	default y
 	help
-	  Disable watchdog at Zephyr system startup.
+	  Disable watchdog at Zephyr system startup for the SoCs that enable
+	  the watchdog by default after reset.
+
+	  Note that disabling this configuration option does not enable the
+	  watchdog for the SoCs that boot with the watchdog disabled.
 
 module = WDT
 module-str = watchdog


### PR DESCRIPTION
This commit consolidates the meaning of WDT_DISABLE_AT_BOOT option as
"disabling watchdog at Zephyr system startup for the SoCs that enable
the watchdog by default after reset", and makes this default to y in
order to prevent unintentional processor reset by the watchdog when
not explicitly configured and fed by the application.

Related discussion at https://github.com/zephyrproject-rtos/zephyr/pull/20607#issuecomment-560992779, refer to the second approach.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>