### PR TITLE
logging: Include sys/util.h in log_backend.h

### DIFF
--- a/include/logging/log_backend.h
+++ b/include/logging/log_backend.h
@@ -9,6 +9,7 @@
 #include <logging/log_msg.h>
 #include <stdarg.h>
 #include <sys/__assert.h>
+#include <sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The UTIL_CAT macro which is used in log_backend.h is implemented in
sys/util.h.

Fixes #21045.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>