### PR TITLE
doc: release: Remove net sample testing feature

### DIFF
--- a/doc/releases/release-notes-2.1.rst
+++ b/doc/releases/release-notes-2.1.rst
@@ -289,7 +289,6 @@ Networking
   and is turned off by default. Users wanting to experiment with it can set
   :option:`CONFIG_NET_TCP2` Kconfig option.
 * Added support for running MQTT protocol on top of a Websocket connection.
-* Added infrastructure for testing network samples in automatic way.
 * Added support for enabling DNS in LWM2M.
 * Added support for resetting network statistics in net-shell.
 * Added support for getting statistics about the time it took to receive or send


### PR DESCRIPTION
The network sample automatic testing feature in PR #19677 is moved
to 2.2 so removing it from 2.1 release note.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>