### PR TITLE
syscalls: small fixes

### DIFF
--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -13,6 +13,7 @@
 #include <kernel_internal.h>
 #include <drivers/interrupt_controller/sysapic.h>
 #include <arch/x86/ia32/segmentation.h>
+#include <arch/syscall.h>
 #include <ia32/exception.h>
 #include <inttypes.h>
 #include <exc_handle.h>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -516,7 +516,7 @@ breathe_default_project = "Zephyr"
 # Error when parsing function declaration and more.  This is a list
 # of strings that the parser additionally should accept as
 # attributes.
-cpp_id_attributes = ['__syscall', '__syscall_inline', '__deprecated',
+cpp_id_attributes = ['__syscall', '__deprecated',
     '__may_alias', '__used', '__unused', '__weak',
     '__DEPRECATED_MACRO', 'FUNC_NORETURN']
 

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1998,8 +1998,7 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "__aligned(x)=" \
                          "__printf_like(x, y)=" \
                          "__attribute__(x)=" \
-                         "__syscall=" \
-                         "__syscall_inline="
+                         "__syscall="
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -384,8 +384,7 @@ our $Attribute	= qr{
 			____cacheline_aligned_in_smp|
 			____cacheline_internodealigned_in_smp|
 			__weak|
-			__syscall|
-			__syscall_inline
+			__syscall
 		  }x;
 our $Modifier;
 our $Inline	= qr{inline|__always_inline|noinline|__inline|__inline__};


### PR DESCRIPTION
- Remove invalid keyword from from doxygen and checkpatch
- Include explicit used header