### PR TITLE
[Backport 16093 to v1.14 branch]shell: Move signals initialization from thread to init

### DIFF
--- a/drivers/spi/spi_handlers.c
+++ b/drivers/spi/spi_handlers.c
@@ -27,7 +27,7 @@ static struct spi_buf_set *copy_and_check(struct spi_buf_set *bufs,
 					   bufs->count,
 					   sizeof(struct spi_buf)));
 
-	/* Not worried abuot overflow here: _SYSCALL_MEMORY_ARRAY_READ()
+	/* Not worried about overflow here: _SYSCALL_MEMORY_ARRAY_READ()
 	 * takes care of it.
 	 */
 	bufs->buffers = memcpy(buf_copy,

--- a/drivers/spi/spi_handlers.c
+++ b/drivers/spi/spi_handlers.c
@@ -11,15 +11,15 @@
 /* This assumes that bufs and buf_copy are copies from the values passed
  * as syscall arguments.
  */
-static void copy_and_check(struct spi_buf_set *bufs,
-			   struct spi_buf *buf_copy,
-			   int writable, void *ssf)
+static struct spi_buf_set *copy_and_check(struct spi_buf_set *bufs,
+					  struct spi_buf *buf_copy,
+					  int writable, void *ssf)
 {
 	size_t i;
 
 	if (bufs->count == 0) {
 		bufs->buffers = NULL;
-		return;
+		return NULL;
 	}
 
 	/* Validate the array of struct spi_buf instances */
@@ -42,6 +42,8 @@ static void copy_and_check(struct spi_buf_set *bufs,
 
 		Z_OOPS(Z_SYSCALL_MEMORY(buf->buf, buf->len, writable));
 	}
+
+	return bufs;
 }
 
 /* This function is only here so tx_buf_copy and rx_buf_copy can be allocated
@@ -59,8 +61,8 @@ static u32_t copy_bufs_and_transceive(struct device *dev,
 	struct spi_buf tx_buf_copy[tx_bufs->count ? tx_bufs->count : 1];
 	struct spi_buf rx_buf_copy[rx_bufs->count ? rx_bufs->count : 1];
 
-	copy_and_check(tx_bufs, tx_buf_copy, 0, ssf);
-	copy_and_check(rx_bufs, rx_buf_copy, 1, ssf);
+	tx_bufs = copy_and_check(tx_bufs, tx_buf_copy, 0, ssf);
+	rx_bufs = copy_and_check(rx_bufs, rx_buf_copy, 1, ssf);
 
 	return z_impl_spi_transceive((struct device *)dev, config,
 				    tx_bufs, rx_bufs);

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1086,6 +1086,14 @@ static int instance_init(const struct shell *shell, const void *p_config,
 
 	k_mutex_init(&shell->ctx->wr_mtx);
 
+	for (int i = 0; i < SHELL_SIGNALS; i++) {
+		k_poll_signal_init(&shell->ctx->signals[i]);
+		k_poll_event_init(&shell->ctx->events[i],
+				  K_POLL_TYPE_SIGNAL,
+				  K_POLL_MODE_NOTIFY_ONLY,
+				  &shell->ctx->signals[i]);
+	}
+
 	if (IS_ENABLED(CONFIG_SHELL_STATS)) {
 		shell->stats->log_lost_cnt = 0;
 	}
@@ -1162,14 +1170,6 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 	bool log_backend = (bool)arg_log_backend;
 	u32_t log_level = (u32_t)arg_log_level;
 	int err;
-
-	for (int i = 0; i < SHELL_SIGNALS; i++) {
-		k_poll_signal_init(&shell->ctx->signals[i]);
-		k_poll_event_init(&shell->ctx->events[i],
-				  K_POLL_TYPE_SIGNAL,
-				  K_POLL_MODE_NOTIFY_ONLY,
-				  &shell->ctx->signals[i]);
-	}
 
 	err = shell->iface->api->enable(shell->iface, false);
 	if (err != 0) {


### PR DESCRIPTION
By moving signals initialization to shell instance init function,
shell instance is ready to receive RX signals from backend before
thread is ready to handle them.

Fixes #16080.

Signed-off-by: Krzysztof Chruscinski krzysztof.chruscinski@nordicsemi.no 