### PR TITLE
[Backport v1.14-branch] net: gptp: Do not update clock if time diff is < 0

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -737,6 +737,13 @@ static void gptp_update_local_port_clock(void)
 		key = irq_lock();
 		ptp_clock_get(clk, &tm);
 
+		if (second_diff < 0 && tm.second < -second_diff) {
+			NET_DBG("Do not set local clock because %lu < %ld",
+				(unsigned long int)tm.second,
+				(long int)-second_diff);
+			goto skip_clock_set;
+		}
+
 		tm.second += second_diff;
 
 		if (nanosecond_diff < 0 &&
@@ -754,7 +761,18 @@ static void gptp_update_local_port_clock(void)
 			tm.nanosecond -= NSEC_PER_SEC;
 		}
 
+		/* This prints too much data normally but can be enabled to see
+		 * what time we are setting to the local clock.
+		 */
+		if (0) {
+			NET_INFO("Set local clock %lu.%lu",
+				 (unsigned long int)tm.second,
+				 (unsigned long int)tm.nanosecond);
+		}
+
 		ptp_clock_set(clk, &tm);
+
+	skip_clock_set:
 		irq_unlock(key);
 	} else {
 		if (nanosecond_diff < -200) {


### PR DESCRIPTION
The time difference calculation did not check if the result
value would be < 0 which means really large value when converted
to unsigned.

Fixes #20100

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>