### PR TITLE
samples: bluetooth: hci_uart: add config for nrf5340_dk_nrf5340_cpuapp

### DIFF
--- a/samples/bluetooth/hci_uart/nrf5340_dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/hci_uart/nrf5340_dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&uart0 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <1000000>;
+	status = "okay";
+};


### PR DESCRIPTION
Sets the baud rate to 1M to align with other nrf boards.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/21138

Signed-off-by: Rubin Gerritsen <Rubin.Gerritsen@nordicsemi.no>