### PR TITLE
net: LwM2M support to put Opaque type data into CoAP message

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -2091,8 +2091,10 @@ static int lwm2m_read_handler(struct lwm2m_engine_obj_inst *obj_inst,
 
 		switch (obj_field->data_type) {
 
-		/* do nothing for OPAQUE (probably has a callback) */
 		case LWM2M_RES_TYPE_OPAQUE:
+			engine_put_opaque(&msg->out, &msg->path,
+					(u8_t *)data_ptr,
+					data_len);
 			break;
 
 		case LWM2M_RES_TYPE_STRING:

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -497,6 +497,25 @@ static size_t put_string(struct lwm2m_output_context *out,
 	return len;
 }
 
+static size_t put_opaque(struct lwm2m_output_context *out,
+			 struct lwm2m_obj_path *path,
+			 char *buf, size_t buflen)
+{
+	struct tlv_out_formatter_data *fd;
+	size_t len;
+	struct oma_tlv tlv;
+
+	fd = engine_get_out_user_data(out);
+	if (!fd) {
+		return 0;
+	}
+
+	tlv_setup(&tlv, tlv_calc_type(fd->writer_flags),
+		  tlv_calc_id(fd->writer_flags, path), (u32_t)buflen);
+	len = oma_tlv_put(&tlv, out, (u8_t *)buf, false);
+	return len;
+}
+
 static size_t put_float32fix(struct lwm2m_output_context *out,
 			     struct lwm2m_obj_path *path,
 			     float32_value_t *value)
@@ -761,6 +780,7 @@ const struct lwm2m_writer oma_tlv_writer = {
 	.put_s32 = put_s32,
 	.put_s64 = put_s64,
 	.put_string = put_string,
+	.put_opaque = put_opaque,
 	.put_float32fix = put_float32fix,
 	.put_float64fix = put_float64fix,
 	.put_bool = put_bool,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -183,6 +183,17 @@ static size_t put_string(struct lwm2m_output_context *out,
 	return buflen;
 }
 
+static size_t put_opaque(struct lwm2m_output_context *out,
+			 struct lwm2m_obj_path *path,
+			 char *buf, size_t buflen)
+{
+	if (buf_append(CPKT_BUF_WRITE(out->out_cpkt), buf, buflen) < 0) {
+		return 0;
+	}
+
+	return buflen;
+}
+
 static size_t put_bool(struct lwm2m_output_context *out,
 		       struct lwm2m_obj_path *path,
 		       bool value)
@@ -336,6 +347,7 @@ const struct lwm2m_writer plain_text_writer = {
 	.put_s32 = put_s32,
 	.put_s64 = put_s64,
 	.put_string = put_string,
+	.put_opaque = put_opaque,
 	.put_float32fix = plain_text_put_float32fix,
 	.put_float64fix = plain_text_put_float64fix,
 	.put_bool = put_bool,


### PR DESCRIPTION
Support put_opaque in Plain Text and OMA TLV formats
Support in Json format is to be implemented

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>