### PR TITLE
BLE: Enable/Disable Automatic Sending of Connection Parameter update

### DIFF
--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -84,16 +84,23 @@ config BT_GATT_READ_MULTIPLE
 	  This option enables support for the GATT Read Multiple Characteristic
 	  Values procedure.
 
+config BT_GAP_AUTO_UPDATE_CONN_PARAMS
+	bool "Automatic Update of Connection Parameters"
+	default y
+	depends on BT_PERIPHERAL
+	help
+	  This option if enabled allows automatically sending request for connection
+	  parameters update after GAP recommended 5 seconds of connection as
+	  peripheral.
+
 config BT_GAP_PERIPHERAL_PREF_PARAMS
 	bool "Configure peripheral preferred connection parameters"
 	default y
 	depends on BT_PERIPHERAL
 	help
 	  This allows to configure peripheral preferred connection parameters.
-	  Enabling this option results in adding PPCP characteristic in GAP
-	  and sending request for connection parameters update after GAP
-	  recommended 5 seconds of connection as peripheral. If disabled it is
-	  up to application to set expected connection parameters.
+	  Enabling this option results in adding PPCP characteristic in GAP.
+	  If disabled it is up to application to set expected connection parameters.
 
 if BT_GAP_PERIPHERAL_PREF_PARAMS
 config BT_PERIPHERAL_PREF_MIN_INT

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -326,34 +326,38 @@ static void conn_update_timeout(struct k_work *work)
 		return;
 	}
 
-#if defined (CONFIG_BT_GAP_PERIPHERAL_PREF_PARAMS)
-	/* if application set own params use those, otherwise use defaults */
-	if (atomic_test_and_clear_bit(conn->flags, BT_CONN_SLAVE_PARAM_SET)) {
-		param = BT_LE_CONN_PARAM(conn->le.interval_min,
-					 conn->le.interval_max,
-					 conn->le.pending_latency,
-					 conn->le.pending_timeout);
-
-		send_conn_le_param_update(conn, param);
-	} else {
-		param = BT_LE_CONN_PARAM(CONFIG_BT_PERIPHERAL_PREF_MIN_INT,
-					 CONFIG_BT_PERIPHERAL_PREF_MAX_INT,
-					 CONFIG_BT_PERIPHERAL_PREF_SLAVE_LATENCY,
-					 CONFIG_BT_PERIPHERAL_PREF_TIMEOUT);
-
-		send_conn_le_param_update(conn, param);
-	}
+	if (IS_ENABLED(CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS)) {
+#if defined(CONFIG_BT_GAP_PERIPHERAL_PREF_PARAMS)
+		/* if application set own params use those, otherwise
+		 * use defaults
+		 */
+		if (atomic_test_and_clear_bit(conn->flags,
+					      BT_CONN_SLAVE_PARAM_SET)) {
+			param = BT_LE_CONN_PARAM(conn->le.interval_min,
+						conn->le.interval_max,
+						conn->le.pending_latency,
+						conn->le.pending_timeout);
+			send_conn_le_param_update(conn, param);
+		} else {
+			param = BT_LE_CONN_PARAM(
+					CONFIG_BT_PERIPHERAL_PREF_MIN_INT,
+					CONFIG_BT_PERIPHERAL_PREF_MAX_INT,
+					CONFIG_BT_PERIPHERAL_PREF_SLAVE_LATENCY,
+					CONFIG_BT_PERIPHERAL_PREF_TIMEOUT);
+			send_conn_le_param_update(conn, param);
+		}
 #else
-	/* update only if application set own params */
-	if (atomic_test_and_clear_bit(conn->flags, BT_CONN_SLAVE_PARAM_SET)) {
-		param = BT_LE_CONN_PARAM(conn->le.interval_min,
-					 conn->le.interval_max,
-					 conn->le.latency,
-					 conn->le.timeout);
-
-		send_conn_le_param_update(conn, param);
-	}
+		/* update only if application set own params */
+		if (atomic_test_and_clear_bit(conn->flags,
+					      BT_CONN_SLAVE_PARAM_SET)) {
+			param = BT_LE_CONN_PARAM(conn->le.interval_min,
+						conn->le.interval_max,
+						conn->le.latency,
+						conn->le.timeout);
+			send_conn_le_param_update(conn, param);
+		}
 #endif
+	}
 
 	atomic_set_bit(conn->flags, BT_CONN_SLAVE_PARAM_UPDATE);
 }


### PR DESCRIPTION
request on GAP recommended timeout of 5 seconds.

Added a new Kconfig flag to enable/disable this feature.

Fixes: #21058

Signed-off-by: Kiran Paramaswaran <kipm@oticon.com>