### PR TITLE
Bluetooth: ATT: Fix ATT MTU support for larger MTUs

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -1198,7 +1198,7 @@ struct write_data {
 	struct net_buf *buf;
 	u8_t req;
 	const void *value;
-	u8_t len;
+	u16_t len;
 	u16_t offset;
 	u8_t err;
 };
@@ -1238,7 +1238,7 @@ static u8_t write_cb(const struct bt_gatt_attr *attr, void *user_data)
 
 static u8_t att_write_rsp(struct bt_conn *conn, u8_t req, u8_t rsp,
 			  u16_t handle, u16_t offset, const void *value,
-			  u8_t len)
+			  u16_t len)
 {
 	struct write_data data;
 
@@ -1305,7 +1305,7 @@ struct prep_data {
 	struct bt_conn *conn;
 	struct net_buf *buf;
 	const void *value;
-	u8_t len;
+	u16_t len;
 	u16_t offset;
 	u8_t err;
 };
@@ -1358,7 +1358,7 @@ append:
 }
 
 static u8_t att_prep_write_rsp(struct bt_att *att, u16_t handle, u16_t offset,
-			       const void *value, u8_t len)
+			       const void *value, u16_t len)
 {
 	struct bt_conn *conn = att->chan.chan.conn;
 	struct prep_data data;

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2841,7 +2841,7 @@ static void gatt_find_info_rsp(struct bt_conn *conn, u8_t err,
 	const struct bt_att_find_info_rsp *rsp = pdu;
 	struct bt_gatt_discover_params *params = user_data;
 	u16_t handle = 0U;
-	u8_t len;
+	u16_t len;
 	union {
 		const struct bt_att_info_16 *i16;
 		const struct bt_att_info_128 *i128;
@@ -3022,7 +3022,7 @@ static void parse_read_by_uuid(struct bt_conn *conn,
 	     length -= rsp->len, pdu = (const u8_t *)pdu + rsp->len) {
 		const struct bt_att_data *data = pdu;
 		u16_t handle;
-		u8_t len;
+		u16_t len;
 
 		handle = sys_le16_to_cpu(data->handle);
 


### PR DESCRIPTION
Fix ATT MTU size of length variables resulting in wrong length values
reported to the user. Communicating with an Android device using an MTU
of 517 resulted in write commands reported as length 2 instead.

Fixes: #21177