### PR TITLE
settings: file: Fix possible success status while failed to write

### DIFF
--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -385,9 +385,9 @@ static int settings_file_save_priv(struct settings_store *cs, const char *name,
 		rc = fs_seek(&file, 0, FS_SEEK_END);
 		if (rc == 0) {
 			entry_ctx.stor_ctx = &file;
-			rc2 = settings_line_write(name, value, val_len, 0,
+			rc = settings_line_write(name, value, val_len, 0,
 						  (void *)&entry_ctx);
-			if (rc2 == 0) {
+			if (rc == 0) {
 				cf->cf_lines++;
 			}
 		}


### PR DESCRIPTION
Assuming that fs_seek has been successful; in case when fs_write
would be unsuccessful and fs_close, that follows, would be successful,
the success code would have been returned for the entire procedure,
although it has failed.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>