### PR TITLE
drivers: dma: stm32: add missing assignment for fifo threshold

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -381,7 +381,8 @@ static int dma_stm32_configure(struct device *dev, u32_t id,
 	}
 	DMA_InitStruct.Channel = table_ll_channel[config->dma_slot];
 
-	stm32_dma_get_fifo_threshold(config->head_block->fifo_mode_control);
+	DMA_InitStruct.FIFOThreshold = stm32_dma_get_fifo_threshold(
+					config->head_block->fifo_mode_control);
 
 	if (stm32_dma_check_fifo_mburst(&DMA_InitStruct)) {
 		DMA_InitStruct.FIFOMode = LL_DMA_FIFOMODE_ENABLE;


### PR DESCRIPTION
Fixes #20490.

Signed-off-by: Song Qiang <songqiang1304521@gmail.com>